### PR TITLE
Handle objects supporting PEP 519 in I/O functions

### DIFF
--- a/scipy/_lib/tests/test_paths.py
+++ b/scipy/_lib/tests/test_paths.py
@@ -16,6 +16,7 @@ from numpy.testing import assert_, assert_raises
 
 import scipy.io
 from scipy._lib._tmpdirs import tempdir
+import scipy.sparse
 
 # Bit of a hack to keep the test runner from exploding in Python 2.7.
 # FileNotFoundError was added in Python 3.3.
@@ -60,3 +61,20 @@ class TestPaths(unittest.TestCase):
         with self.assertRaises(FileNotFoundError):
             path = Path('nonexistent.sav')
             scipy.io.readsav(path)
+
+    def test_hb_read(self):
+        # Save data with string path, load with pathlib.Path
+        with tempdir() as temp_dir:
+            data = scipy.sparse.csr_matrix(scipy.sparse.eye(3))
+            path = Path(temp_dir) / 'data.hb'
+            scipy.io.harwell_boeing.hb_write(str(path), data)
+
+            data_new = scipy.io.harwell_boeing.hb_read(path)
+            assert_((data_new != data).nnz == 0)
+
+    def test_hb_write(self):
+        with tempdir() as temp_dir:
+            data = scipy.sparse.csr_matrix(scipy.sparse.eye(3))
+            path = Path(temp_dir) / 'data.hb'
+            scipy.io.harwell_boeing.hb_write(path, data)
+            assert_(path.is_file())

--- a/scipy/_lib/tests/test_paths.py
+++ b/scipy/_lib/tests/test_paths.py
@@ -1,0 +1,61 @@
+"""
+Ensure that we can use pathlib.Path objects in all relevant IO functions.
+"""
+import sys
+import unittest
+
+try:
+    from pathlib import Path
+except ImportError:
+    # Not available. No fallback import, since we'll skip the entire
+    # test suite for Python < 3.6.
+    pass
+
+import numpy as np
+from numpy.testing import assert_, assert_raises
+
+import scipy.io
+from scipy._lib._tmpdirs import tempdir
+
+@unittest.skipIf(sys.version_info < (3, 6),
+                 'Passing path-like objects to IO functions requires Python >= 3.6')
+class TestPaths(unittest.TestCase):
+    data = np.arange(5)
+
+    def test_savemat(self):
+        with tempdir() as temp_dir:
+            path = Path(temp_dir) / 'data.mat'
+            scipy.io.savemat(path, {'data': self.data})
+            assert_(path.is_file())
+
+    def test_loadmat(self):
+        # Save data with string path, load with pathlib.Path
+        with tempdir() as temp_dir:
+            path = Path(temp_dir) / 'data.mat'
+            scipy.io.savemat(str(path), {'data': self.data})
+
+            data = scipy.io.loadmat(path)
+            assert_((data == self.data).all())
+
+    def test_whosmat(self):
+        # Save data with string path, load with pathlib.Path
+        with tempdir() as temp_dir:
+            path = Path(temp_dir) / 'data.mat'
+            scipy.io.savemat(str(path), {'data': self.data})
+
+            contents = scipy.io.whosmat(path)
+            assert_(contents[0] == ('data', (1, 5), 'int64'))
+
+    def test_readsav(self):
+        # I have no idea how to create a valid .sav file from IDL, so let's
+        # just try to open something that doesn't exist, and ensure that we get
+        # a FileNotFoundError (as opposed to a TypeError, if `open` can't
+        # understand the argument, or another type of exception if `readsav` is
+        # unnecessarily strict in which type it accepts.
+
+        # FileNotFoundError was added in Python 3.3, and this would throw an
+        # IOError in older Python, but this entire test class is skipped in
+        # Python < 3.6 so it's safe to use the newer exception class here.
+        with self.assertRaises(FileNotFoundError):
+            path = Path('nonexistent.sav')
+            scipy.io.readsav(path)

--- a/scipy/_lib/tests/test_paths.py
+++ b/scipy/_lib/tests/test_paths.py
@@ -40,8 +40,8 @@ class TestPaths(unittest.TestCase):
             path = Path(temp_dir) / 'data.mat'
             scipy.io.savemat(str(path), {'data': self.data})
 
-            data = scipy.io.loadmat(path)
-            assert_((data == self.data).all())
+            mat_contents = scipy.io.loadmat(path)
+            assert_((mat_contents['data'] == self.data).all())
 
     def test_whosmat(self):
         # Save data with string path, load with pathlib.Path

--- a/scipy/_lib/tests/test_paths.py
+++ b/scipy/_lib/tests/test_paths.py
@@ -17,6 +17,11 @@ from numpy.testing import assert_, assert_raises
 import scipy.io
 from scipy._lib._tmpdirs import tempdir
 
+# Bit of a hack to keep the test runner from exploding in Python 2.7.
+# FileNotFoundError was added in Python 3.3.
+if sys.version_info < (3, 3):
+    FileNotFoundError = IOError
+
 @unittest.skipIf(sys.version_info < (3, 6),
                  'Passing path-like objects to IO functions requires Python >= 3.6')
 class TestPaths(unittest.TestCase):
@@ -47,15 +52,11 @@ class TestPaths(unittest.TestCase):
             assert_(contents[0] == ('data', (1, 5), 'int64'))
 
     def test_readsav(self):
-        # I have no idea how to create a valid .sav file from IDL, so let's
+        # I have no idea how to create a valid IDL .sav file, so let's
         # just try to open something that doesn't exist, and ensure that we get
         # a FileNotFoundError (as opposed to a TypeError, if `open` can't
         # understand the argument, or another type of exception if `readsav` is
         # unnecessarily strict in which type it accepts.
-
-        # FileNotFoundError was added in Python 3.3, and this would throw an
-        # IOError in older Python, but this entire test class is skipped in
-        # Python < 3.6 so it's safe to use the newer exception class here.
         with self.assertRaises(FileNotFoundError):
             path = Path('nonexistent.sav')
             scipy.io.readsav(path)

--- a/scipy/io/harwell_boeing/hb.py
+++ b/scipy/io/harwell_boeing/hb.py
@@ -467,14 +467,14 @@ class HBFile(object):
         return _write_data(m, self._fid, self._hb_info)
 
 
-def hb_read(file):
+def hb_read(path_or_open_file):
     """Read HB-format file.
 
     Parameters
     ----------
-    file : str-like or file-like
-        If a string-like object, file is the name of the file to read. If a
-        file-like object, the data are read from it.
+    path_or_open_file : path-like or file-like
+        If a file-like object, it is used as-is. Otherwise it is opened
+        before reading.
 
     Returns
     -------
@@ -495,24 +495,21 @@ def hb_read(file):
         hb = HBFile(fid)
         return hb.read_matrix()
 
-    if isinstance(file, string_types):
-        fid = open(file)
-        try:
-            return _get_matrix(fid)
-        finally:
-            fid.close()
+    if hasattr(path_or_open_file, 'read'):
+        return _get_matrix(path_or_open_file)
     else:
-        return _get_matrix(file)
+        with open(path_or_open_file) as f:
+            return _get_matrix(f)
 
 
-def hb_write(file, m, hb_info=None):
+def hb_write(path_or_open_file, m, hb_info=None):
     """Write HB-format file.
 
     Parameters
     ----------
-    file : str-like or file-like
-        if a string-like object, file is the name of the file to read. If a
-        file-like object, the data are read from it.
+    path_or_open_file : path-like or file-like
+        If a file-like object, it is used as-is. Otherwise it is opened
+        before writing.
     m : sparse-matrix
         the sparse matrix to write
     hb_info : HBInfo
@@ -539,11 +536,8 @@ def hb_write(file, m, hb_info=None):
         hb = HBFile(fid, hb_info)
         return hb.write_matrix(m)
 
-    if isinstance(file, string_types):
-        fid = open(file, "w")
-        try:
-            return _set_matrix(fid)
-        finally:
-            fid.close()
+    if hasattr(path_or_open_file, 'write'):
+        return _set_matrix(path_or_open_file)
     else:
-        return _set_matrix(file)
+        with open(path_or_open_file, 'w') as f:
+            return _set_matrix(f)

--- a/scipy/io/matlab/mio.py
+++ b/scipy/io/matlab/mio.py
@@ -20,7 +20,8 @@ def _open_file(file_like, appendmat):
     """
     Open `file_like` and return as file-like object. First, check if object is
     already file-like; if so, return it as-is. Otherwise, try to pass it
-    to open().
+    to open(). If that fails, and `file_like` is a string, and `appendmat` is true,
+    append '.mat' and try again.
     """
     try:
         file_like.read(0)

--- a/scipy/io/matlab/mio.py
+++ b/scipy/io/matlab/mio.py
@@ -17,25 +17,30 @@ __all__ = ['mat_reader_factory', 'loadmat', 'savemat', 'whosmat']
 
 
 def _open_file(file_like, appendmat):
-    ''' Open `file_like` and return as file-like object '''
-    if isinstance(file_like, string_types):
-        try:
-            return open(file_like, 'rb')
-        except IOError as e:
+    """
+    Open `file_like` and return as file-like object. First, check if object is
+    already file-like; if so, return it as-is. Otherwise, try to pass it
+    to open().
+    """
+    try:
+        file_like.read(0)
+        return file_like
+    except AttributeError:
+        pass
+
+    try:
+        return open(file_like, 'rb')
+    except IOError as e:
+        # Probably "not found"
+        if isinstance(file_like, string_types):
             if appendmat and not file_like.endswith('.mat'):
                 file_like += '.mat'
                 try:
                     return open(file_like, 'rb')
                 except IOError:
-                    pass  # Rethrow the original exception.
-            raise
-    # not a string - maybe file-like object
-    try:
-        file_like.read(0)
-    except AttributeError:
-        raise IOError('Reader needs file name or open file-like object')
-    return file_like
-
+                    raise
+        else:
+            raise IOError('Reader needs file name or open file-like object')
 
 @docfiller
 def mat_reader_factory(file_name, appendmat=True, **kwargs):

--- a/scipy/io/matlab/mio.py
+++ b/scipy/io/matlab/mio.py
@@ -192,16 +192,18 @@ def savemat(file_name, mdict,
     mio4.MatFile4Writer
     mio5.MatFile5Writer
     """
-    file_is_string = isinstance(file_name, string_types)
-    if file_is_string:
-        if appendmat and file_name[-4:] != ".mat":
-            file_name = file_name + ".mat"
-        file_stream = open(file_name, 'wb')
-    else:
-        if not hasattr(file_name, 'write'):
-            raise IOError('Writer needs file name or writeable '
-                           'file-like object')
+    file_opened = False
+    if hasattr(file_name, 'write'):
+        # File-like object already; use as-is
         file_stream = file_name
+    else:
+        if isinstance(file_name, string_types):
+            if appendmat and not file_name.endswith('.mat'):
+                file_name = file_name + ".mat"
+
+        file_stream = open(file_name, 'wb')
+        file_opened = True
+
     if format == '4':
         if long_field_names:
             raise ValueError("Long field names are not available for version 4 files")
@@ -215,7 +217,7 @@ def savemat(file_name, mdict,
     else:
         raise ValueError("Format should be '4' or '5'")
     MW.put_variables(mdict)
-    if file_is_string:
+    if file_opened:
         file_stream.close()
 
 


### PR DESCRIPTION
We don't need to specifically check for a `__fspath__` attribute here, since
part of PEP 519 is enhancing `__builtins__.open` to support path-like objects.

The logic changes are quite small: first, try to read from whatever is given to
this function. If that succeeds, it's already a file-like object, and it's
returned as-is. If it's not readable, try passing it to `open`. If that
succeeds, return the new file-like object. If it fails with an `IOError`, check
for object type, append '.mat' if appropriate, and try calling `open` again.

If the user passes something nonsensical to `_open_file`, `open` will throw a
`TypeError`, which is a perfectly sane thing to do:

"""
Python 3.6.0rc1 (default, Dec  8 2016, 17:06:38)
[GCC 5.4.0 20160609] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> open(object())
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: expected str, bytes or os.PathLike object, not object
"""

(related issue: #6854)