### PR TITLE
Do not allow negative powers

### DIFF
--- a/scipy/sparse/linalg/interface.py
+++ b/scipy/sparse/linalg/interface.py
@@ -573,8 +573,8 @@ class _PowerLinearOperator(LinearOperator):
             raise ValueError('LinearOperator expected as A')
         if A.shape[0] != A.shape[1]:
             raise ValueError('square LinearOperator expected, got %r' % A)
-        if not isintlike(p):
-            raise ValueError('integer expected as p')
+        if not isintlike(p) or p < 0:
+            raise ValueError('non-negative integer expected as p')
 
         super(_PowerLinearOperator, self).__init__(_get_dtype([A]), A.shape)
         self.args = (A, p)


### PR DESCRIPTION
Negative powers `p<0`of `LinearOperator` silently acts like `p=0`. It should drop a error instead.

Here is an example:

```
import numpy as np
from scipy.sparse.linalg import aslinearoperator

a = aslinearoperator(np.array([[1, 2], [3, 4]]))
u = np.array([1, 2])

(a**2).dot(u) - a.dot(a.dot(u))
# array([0, 0]) # OK

(a**-1).dot(u)
array([1, 2]) # The correct answer is array([ 0. ,  0.5])
```

Up to now power of a linear operator is implemented as a simple iteration:
```
    def _power(self, fun, x):
        res = np.array(x, copy=True)
        for i in range(self.args[1]):
            res = fun(res)
        return res
```
So it should filter out negative powers (`self.args[1] < 0`). 