### PR TITLE
MAINT: regularize matrix_balance argument type

### DIFF
--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -1164,7 +1164,8 @@ def matrix_balance(A, permute=True, scale=True, separate=False,
         will not be scaled.
     separate : bool, optional
         This switches from returning a full matrix of the transformation
-        to a tuple of two separate 1D permutation and scaling arrays.
+        to a (2,n) array where the first row holds the scaling and the
+        second row holds the permutation arrays.
     overwrite_a : bool, optional
         This is passed to xGEBAL directly. Essentially, overwrites the result
         to the data. It might increase the space efficiency. See LAPACK manual
@@ -1177,10 +1178,11 @@ def matrix_balance(A, permute=True, scale=True, separate=False,
     T : (n, n) ndarray
         A possibly permuted diagonal matrix whose nonzero entries are
         integer powers of 2 to avoid numerical truncation errors.
-    scale, perm : (n,) ndarray
-        If ``separate`` keyword is set to True then instead of the array
-        ``T`` above, the scaling and the permutation vector is given
-        separately without allocating the full array ``T``.
+    sp : (2,n) ndarray
+        If ``separate`` keyword is set to True then the scaling and the
+        permutation vector is given as rows of a 2xn array instead of
+        allocating the full array ``T`` described above. ``T`` can be
+        reconstructed by ``T = np.diag(sp[0])[sp[1], :]`` if needed.
 
     .. versionadded:: 0.19.0
 
@@ -1202,14 +1204,14 @@ def matrix_balance(A, permute=True, scale=True, separate=False,
     >>> from scipy import linalg
     >>> x = np.array([[1,2,0], [9,1,0.01], [1,2,10*np.pi]])
 
-    >>> y, permscale = linalg.matrix_balance(x)
+    >>> y, scaleperm = linalg.matrix_balance(x)
     >>> np.abs(x).sum(axis=0) / np.abs(x).sum(axis=1)
     array([ 3.66666667,  0.4995005 ,  0.91312162])
 
     >>> np.abs(y).sum(axis=0) / np.abs(y).sum(axis=1) # 1-norms approx. equal
     array([ 1.10625   ,  0.90547703,  1.00011878])
 
-    >>> permscale  # only powers of 2 (0.5 == 2^(-1))
+    >>> scaleperm  # only powers of 2 (0.5 == 2^(-1))
     array([[  0.5,   0. ,   0. ],
            [  0. ,   1. ,   0. ],
            [  0. ,   0. ,  16. ]])
@@ -1230,7 +1232,10 @@ def matrix_balance(A, permute=True, scale=True, separate=False,
     """
 
     A = np.atleast_2d(_asarray_validated(A, check_finite=True))
-
+    if A.size == 0:
+        if separate:
+            return A, np.array([[], []])
+        return A, np.array([])
     if not np.equal(*A.shape):
         raise ValueError('The data matrix for balancing should be square.')
 
@@ -1239,10 +1244,9 @@ def matrix_balance(A, permute=True, scale=True, separate=False,
                                 overwrite_a=overwrite_a)
 
     if info < 0:
-        raise ValueError('xGEBAL exited with the internal error '
+        raise ValueError('?GEBAL exited with the internal error '
                          '"illegal value in argument number {}.". See '
-                         'LAPACK documentation for the xGEBAL error codes.'
-                         ''.format(-info))
+                         'LAPACK documentation.'.format(-info))
 
     # Separate the permutations from the scalings and then convert to int
     scaling = np.ones_like(ps, dtype=float)
@@ -1267,6 +1271,6 @@ def matrix_balance(A, permute=True, scale=True, separate=False,
             perm[[x, ind]] = perm[[ind, x]]
 
     if separate:
-        return B, (scaling, perm)
+        return B, np.vstack((scaling, perm))
 
     return B, np.diag(scaling)[perm, :]

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -1364,6 +1364,13 @@ class TestMatrix_Balance(TestCase):
         assert_raises(ValueError, matrix_balance,
                       np.array([[1, 2], [3, np.nan]]))
 
+    def test_empty_data(self):
+        A = np.array([[], []])
+        x, (y, z) = matrix_balance(A, separate=1)
+        assert_equal(x.shape, (2, 0))
+        assert_equal(y.shape, (0,))
+        assert_equal(z.shape, (0,))
+
     def test_scaling(self):
         _, y = matrix_balance(np.array([[1000, 1], [1000, 0]]))
         # Pre/post LAPACK 3.5.0 gives the same result up to an offset


### PR DESCRIPTION
In the previous first version, a keyword `separate` was causing the second output argument `T` (nxn array) type change to a tuple ((n,) and (n,) arrays). Instead now, the tuple arrays are returned as the rows of a (2,n) array.

Also empty matrices were not handled properly. It was causing a size mismatch error although the problem was that there was no element in the matrix. Now returns back the empty arrays and the safety net is added. Also relevant test is added. 

The previous syntax can still be used to unpack the tuple to get the rows 
    
    A = np.array([[1, 0, 2**-5], [0, 1, 0], [31, 0, 0]])
    x, (y, z) = matrix_balance(A, separate=True)

Here, `y` and `z` picks up the rows of the returning (2xn) array. 