### PR TITLE
DOC: dx should be float, not int

### DIFF
--- a/scipy/integrate/quadrature.py
+++ b/scipy/integrate/quadrature.py
@@ -215,7 +215,7 @@ def cumtrapz(y, x=None, dx=1.0, axis=-1, initial=None):
     x : array_like, optional
         The coordinate to integrate along.  If None (default), use spacing `dx`
         between consecutive elements in `y`.
-    dx : int, optional
+    dx : float, optional
         Spacing between elements of `y`.  Only used if `x` is None.
     axis : int, optional
         Specifies the axis to cumulate.  Default is -1 (last axis).


### PR DESCRIPTION
In the function header
    def cumtrapz(y, x=None, dx=1.0, axis=-1, initial=None):
dx is given as float, but this is not reflected in the documentation, where it said int.