### PR TITLE
BUG: Make stats.mode return a ModeResult namedtuple on empty dataset input.

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -418,7 +418,7 @@ def mode(a, axis=0, nan_policy='propagate'):
     """
     a, axis = _chk_asarray(a, axis)
     if a.size == 0:
-        return np.array([]), np.array([])
+        return ModeResult(np.array([]), np.array([]))
 
     contains_nan, nan_policy = _contains_nan(a, nan_policy)
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1308,9 +1308,12 @@ class TestMode(TestCase):
 
     def test_mode_result_attributes(self):
         data1 = [3, 5, 1, 10, 23, 3, 2, 6, 8, 6, 10, 6]
+        data2 = []
         actual = stats.mode(data1)
         attributes = ('mode', 'count')
         check_named_results(actual, attributes)
+        actual2 = stats.mode(data2)
+        check_named_results(actual2, attributes)
 
     def test_mode_nan(self):
         data1 = [3, np.nan, 5, 1, 10, 23, 3, 2, 6, 8, 6, 10, 6]


### PR DESCRIPTION
Changes the result of stats.mode on an empty dataset into a ModeResult namedtuple to match the return type on non-empty datasets. I couldn't find a PR or issue for this already (searching for 'namedtuple' and 'stats.mode').

I ran into this when I found a bug in my code that accidentally sent empty data to the mode function and I started getting attribute errors which was a bit confusing.

I've added the test for this to the test for the full case - not sure if this is preferred practice but I wasn't sure if it needed a completely new test.

Before:
```
>>> mode([])
(array([], dtype=float64), array([], dtype=float64))
```

After:
```
>>> mode([])
ModeResult(mode=array([], dtype=float64), count=array([], dtype=float64))
```