### PR TITLE
Corrected documentation.

### DIFF
--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -713,7 +713,7 @@ class TransferFunction(LinearTimeInvariant):
     dt: None
     )
 
-    Contruct the transfer function with a sampling time of 0.5 seconds:
+    Contruct the transfer function with a sampling time of 0.1 seconds:
 
     .. math:: H(z) = \frac{z^2 + 3z + 3}{z^2 + 2z + 1}
 


### PR DESCRIPTION
TransferFunction's documentation referenced a sampling rate of 0.5s but the example used 0.1s. Changed the documentation to match the example code.