### PR TITLE
In fixed_quad, the correct axis to sum w*f over is the last one

### DIFF
--- a/scipy/integrate/quadrature.py
+++ b/scipy/integrate/quadrature.py
@@ -80,7 +80,7 @@ def fixed_quad(func, a, b, args=(), n=5):
         raise ValueError("Gaussian quadrature is only available for "
                          "finite limits.")
     y = (b-a)*(x+1)/2.0 + a
-    return (b-a)/2.0 * np.sum(w*func(y, *args), axis=0), None
+    return (b-a)/2.0 * np.sum(w*func(y, *args), axis=-1), None
 
 
 def vectorize1(func, args=(), vec_func=False):


### PR DESCRIPTION
Since w has shape (n,), the result of multiplication w*func(y, *args) will have the _last_ dimension equal to n, and this is the dimension we want to sum over. There may be other dimensions if func is vector-valued; summing over axis=0 is incorrect in this case. The change enables using fixed_quad for integrating vector-valued functions, and has no effect on integration of scalar-valued functions.

Test example: simultaneous integration of `x**0`, `x**1`, ... `x**9` on the interval [0,1]. 

```
from scipy.integrate import fixed_quad
import numpy as np
def func(x):
    p = np.arange(0, 10).reshape(-1, 1)
    return x.reshape(1, -1)**p
result = fixed_quad(func, 0, 1)
```

With the current version of SciPy, the result is `(array([ 0.12429409,  0.31110693,  0.56833333,  0.96181703,  0.96341687]), None)` which makes no sense. The different _functions_ got added, and the output has 5 values because there was no summation over the 5 points of quadrature. 

With the commit, the result will be  `(array([ 1. ,  0.5,  0.33333333,  0.25,  0.2, 0.16666667,  0.14285714,  0.125,  0.11111111,  0.1]), None)` which are the correct integrals of the 10 components of func. 