### PR TITLE
BUG: ndimage: guard against footprints of all zeros

### DIFF
--- a/scipy/ndimage/filters.py
+++ b/scipy/ndimage/filters.py
@@ -1002,6 +1002,8 @@ def _min_or_max_filter(input, size, footprint, structure, output, mode,
         else:
             footprint = numpy.asarray(footprint)
             footprint = footprint.astype(bool)
+            if not footprint.any():
+                raise ValueError("All-zero footprint is not supported.")
             if numpy.alltrue(numpy.ravel(footprint), axis=0):
                 size = footprint.shape
                 footprint = None

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -212,5 +212,13 @@ def test_minmaximum_filter1d():
     assert_equal([9, 9, 4, 5, 6, 7, 8, 9, 9, 9], out)
 
 
+def test_footprint_all_zeros():
+    # regression test for gh-6876: footprint of all zeros segfaults
+    arr = np.random.randint(0, 100, (100, 100))
+    kernel = np.zeros((3, 3), bool)
+    with assert_raises(ValueError):
+        sndi.maximum_filter(arr, footprint=kernel)
+
+
 if __name__ == "__main__":
     run_module_suite(argv=sys.argv)


### PR DESCRIPTION
Otherwise minimum/maximum_filter segfaults.

closes gh-6876