### PR TITLE
python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ matrix:
         - TESTMODE=full
         - COVERAGE=--coverage
         - NUMPYSPEC=numpy
-    - python: 3.6-dev
+    - python: 3.6
       env:
         - TESTMODE=fast
         - COVERAGE=

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ Programming Language :: Python :: 3.2
 Programming Language :: Python :: 3.3
 Programming Language :: Python :: 3.4
 Programming Language :: Python :: 3.5
+Programming Language :: Python :: 3.6
 Topic :: Software Development
 Topic :: Scientific/Engineering
 Operating System :: Microsoft :: Windows


### PR DESCRIPTION
In the spirit of the holiday season,
* Use the released py3.6 in testing. 
* Also update the trove classifiers.