### PR TITLE
Vectorized integrate.fixed_quad

### DIFF
--- a/doc/release/0.19.0-notes.rst
+++ b/doc/release/0.19.0-notes.rst
@@ -141,6 +141,11 @@ spline given data points and boundary conditions.
 New function `scipy.interpolate.make_lsq_spline` constructs a least-squares
 spline approximation given data points.
 
+`scipy.integrate` improvements
+------------------------------
+
+Now `scipy.integrate.fixed_quad` supports vector-valued functions.
+
 
 Deprecated features
 ===================

--- a/scipy/integrate/quadrature.py
+++ b/scipy/integrate/quadrature.py
@@ -80,7 +80,7 @@ def fixed_quad(func, a, b, args=(), n=5):
         raise ValueError("Gaussian quadrature is only available for "
                          "finite limits.")
     y = (b-a)*(x+1)/2.0 + a
-    return (b-a)/2.0 * np.sum(w*func(y, *args), axis=0), None
+    return (b-a)/2.0 * np.sum(w*func(y, *args), axis=-1), None
 
 
 def vectorize1(func, args=(), vec_func=False):

--- a/scipy/integrate/quadrature.py
+++ b/scipy/integrate/quadrature.py
@@ -43,6 +43,8 @@ def fixed_quad(func, a, b, args=(), n=5):
     ----------
     func : callable
         A Python function or method to integrate (must accept vector inputs).
+        If integrating a vector-valued function, the returned array must have
+        shape ``(..., len(x))``.
     a : float
         Lower limit of integration.
     b : float

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -7,8 +7,26 @@ from numpy.testing import TestCase, run_module_suite, assert_equal, \
     assert_almost_equal, assert_allclose, assert_
 
 from scipy.integrate import (quadrature, romberg, romb, newton_cotes,
-                             cumtrapz, quad, simps)
+                             cumtrapz, quad, simps, fixed_quad)
 from scipy.integrate.quadrature import AccuracyWarning
+
+
+class TestFixedQuad(object):
+    def test_scalar(self):
+        n = 4
+        func = lambda x: x**(2*n - 1)
+        expected = 1/(2*n)
+        got, _ = fixed_quad(func, 0, 1, n=n)
+        # quadrature exact for this input
+        assert_allclose(got, expected, rtol=1e-12)
+
+    def test_vector(self):
+        n = 4
+        p = np.arange(1, 2*n)
+        func = lambda x: x**p[:,None]
+        expected = 1/(p + 1)
+        got, _ = fixed_quad(func, 0, 1, n=n)
+        assert_allclose(got, expected, rtol=1e-12)
 
 
 class TestQuadrature(TestCase):


### PR DESCRIPTION
Continuation of gh-6872. Straightforward --- previously it failed by returning bogus results.