### PR TITLE
ENH: initial vector in minres

### DIFF
--- a/scipy/sparse/linalg/isolve/minres.py
+++ b/scipy/sparse/linalg/isolve/minres.py
@@ -85,8 +85,6 @@ def minres(A, b, x0=None, shift=0.0, tol=1e-5, maxiter=None, xtype=None,
 
     eps = finfo(xtype).eps
 
-    x = zeros(n, dtype=xtype)
-
     # Set up y and v for the first Lanczos vector v1.
     # y  =  beta1 P' v1,  where  P = C**(-1).
     # v is really P' v1.

--- a/scipy/sparse/linalg/isolve/tests/test_minres.py
+++ b/scipy/sparse/linalg/isolve/tests/test_minres.py
@@ -1,0 +1,19 @@
+from __future__ import division, print_function, absolute_import
+
+import numpy as np
+from numpy.testing import assert_almost_equal, run_module_suite
+
+from scipy.sparse.linalg import minres
+
+
+def test_minres():
+    a = np.random.randn(25).reshape(5,5)
+    b = np.random.randn(5)
+    c = np.random.randn(5)
+    x1 = minres(a, b)[0] + c
+    x2 = minres(a, b, x0=c)[0]
+    assert_almost_equal(x1, x2)
+
+if __name__ == "__main__":
+    # Comment out the next line to run unit tests only
+    run_module_suite()


### PR DESCRIPTION
Fix #6843 
[`make_system`](https://github.com/scipy/scipy/blob/2526df72e5d4ca8bad6e2f4b3cbdfbc33e805865/scipy/sparse/linalg/isolve/minres.py#L46) checks `x0` for `None`  [(here)](https://github.com/scipy/scipy/blob/2526df72e5d4ca8bad6e2f4b3cbdfbc33e805865/scipy/sparse/linalg/isolve/utils.py#L107) and return `zeros` array (`x0 is None`) or given array(`x0 is not None`)
But i'm not sure that test is correct