### PR TITLE
TST: fix failures for linalg.dare/care due to tightened test precision.

### DIFF
--- a/scipy/linalg/tests/test_solvers.py
+++ b/scipy/linalg/tests/test_solvers.py
@@ -277,7 +277,7 @@ def test_solve_continuous_are():
     #
     # If the test is failing use "None" for that entry.
     #
-    min_decimal = (14, 12, 14, 14, 11, 7, None, 5, 7, 14, 14,
+    min_decimal = (14, 12, 14, 14, 11, 6, None, 5, 7, 14, 14,
                    None, 10, 14, 13, 14, None, 12, None, None)
 
     def _test_factory(case, dec):
@@ -497,7 +497,7 @@ def test_solve_discrete_are():
     #
     # If the test is failing use "None" for that entry.
     #
-    min_decimal = (12, 14, 14, 14, 13, 16, 18, 15, 15, 13,
+    min_decimal = (12, 14, 13, 14, 13, 16, 18, 14, 15, 13,
                    14, 13, 13, 14, 12, 2, 5, 6, 10)
 
     def _test_factory(case, dec):


### PR DESCRIPTION
Failures occur with Python 3.5 on OS X 10.12 with Accelerate.