### PR TITLE
TST: Added asv benchmarks for scipy.spatial.Voronoi

### DIFF
--- a/benchmarks/benchmarks/spatial.py
+++ b/benchmarks/benchmarks/spatial.py
@@ -4,7 +4,7 @@ import numpy as np
 
 try:
     from scipy.spatial import (cKDTree, KDTree, SphericalVoronoi, distance,
-    ConvexHull)
+    ConvexHull, Voronoi)
 except ImportError:
     pass
 
@@ -243,3 +243,15 @@ class ConvexHullBench(Benchmark):
         and settings.
         """
         ConvexHull(self.points, incremental)
+
+class VoronoiBench(Benchmark):
+    params = ([10, 100, 1000, 5000, 10000], [False, True])
+    param_names = ['num_points', 'furthest_site']
+
+    def setup(self, num_points, furthest_site):
+        np.random.seed(123)
+        self.points = np.random.random_sample((num_points, 3))
+
+    def time_voronoi_calculation(self, num_points, furthest_site):
+        """Time conventional Voronoi diagram calculation."""
+        Voronoi(self.points, furthest_site=furthest_site)


### PR DESCRIPTION
I've added `asv` benchmark code for `scipy.spatial.Voronoi` (I did the same for `SphericalVoronoi` a few weeks ago). Both standard and farthest site diagrams are benchmarked.

Running the benchmarks against the tip of master with: `asv continuous --bench VoronoiBench c48dfa4 1a6de1c -e` produces:

```
· Creating environments....
· Discovering benchmarks
·· Uninstalling from virtualenv-py2.7-Cython0.23.4-Tempita0.5.2-numpy1.8.2-six...
·· Building for virtualenv-py2.7-Cython0.23.4-Tempita0.5.2-numpy1.8.2-six...........................................................................................................................................................................
·· Installing into virtualenv-py2.7-Cython0.23.4-Tempita0.5.2-numpy1.8.2-six..
· Running 2 total benchmarks (2 commits * 1 environments * 1 benchmarks)
[  0.00%] · For scipy commit hash 1a6de1c5:
[  0.00%] ·· Building for virtualenv-py2.7-Cython0.23.4-Tempita0.5.2-numpy1.8.2-six.......................................................................................................................................................................
[  0.00%] ·· Benchmarking virtualenv-py2.7-Cython0.23.4-Tempita0.5.2-numpy1.8.2-six
[ 50.00%] ··· Running spatial.VoronoiBench.time_voronoi_calculation                                                                                                                                      ok
[ 50.00%] ···· 
               ============ ========== ==========
               --               furthest_site    
               ------------ ---------------------
                num_points    False       True   
               ============ ========== ==========
                    10       358.46μs   342.47μs 
                   100        2.03ms     1.47ms  
                   1000      26.15ms    15.63ms  
                   5000      165.94ms   115.20ms 
                  10000      406.57ms   266.25ms 
               ============ ========== ==========

[ 50.00%] · For scipy commit hash c48dfa43:
[ 50.00%] ·· Building for virtualenv-py2.7-Cython0.23.4-Tempita0.5.2-numpy1.8.2-six...
[ 50.00%] ·· Benchmarking virtualenv-py2.7-Cython0.23.4-Tempita0.5.2-numpy1.8.2-six
[100.00%] ··· Running spatial.VoronoiBench.time_voronoi_calculation                                                                                                                                      ok
[100.00%] ···· 
               ============ ========== ==========
               --               furthest_site    
               ------------ ---------------------
                num_points    False       True   
               ============ ========== ==========
                    10       377.18μs   363.55μs 
                   100        2.16ms     1.52ms  
                   1000      26.60ms    19.68ms  
                   5000      174.44ms   119.12ms 
                  10000      400.15ms   267.40ms 
               ============ ========== ==========
    before     after       ratio
  [c48dfa43] [1a6de1c5]
-   19.68ms    15.63ms      0.79  spatial.VoronoiBench.time_voronoi_calculation(1000, True)

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
```

I suspect the minor discrepancy for a relatively small data set is within the bounds of normal behaviour.
