### PR TITLE
Deprecate calling get_window() with strings

### DIFF
--- a/doc/source/tutorial/signal.rst
+++ b/doc/source/tutorial/signal.rst
@@ -213,7 +213,7 @@ Thus, the full discrete convolution of two finite sequences of lengths
 One dimensional convolution is implemented in SciPy with the function
 :func:`convolve`. This function takes as inputs the signals :math:`x,`
 :math:`h` , and two optional flags 'mode' and 'method' and returns the signal
-:math:`y.` 
+:math:`y.`
 
 The first optional flag 'mode' allows for specification of which part of the
 output signal to return. The default value of 'full' returns the entire signal.
@@ -927,7 +927,7 @@ Gaussian noise.
    >>> x = amp*np.sin(2*np.pi*freq*time)
    >>> x += np.random.normal(scale=np.sqrt(noise_power), size=time.shape)
 
-   >>> f, Pper_spec = signal.periodogram(x, fs, 'flattop', scaling='spectrum')
+   >>> f, Pper_spec = signal.periodogram(x, fs, signal.windows.flattop, scaling='spectrum')
 
    >>> plt.semilogy(f, Pper_spec)
    >>> plt.xlabel('frequency [Hz]')

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -307,7 +307,8 @@ def freqz(b, a=1, worN=None, whole=False, plot=None):
     Examples
     --------
     >>> from scipy import signal
-    >>> b = signal.firwin(80, 0.5, window=('kaiser', 8))
+    >>> import functools
+    >>> b = signal.firwin(80, 0.5, window=functools.partial(windows.kaiser, beta=8))
     >>> w, h = signal.freqz(b)
 
     >>> import matplotlib.pyplot as plt
@@ -4108,4 +4109,3 @@ bessel_norms = {'bessel': 'phase',
                 'bessel_phase': 'phase',
                 'bessel_delay': 'delay',
                 'bessel_mag': 'mag'}
-

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -308,7 +308,7 @@ def freqz(b, a=1, worN=None, whole=False, plot=None):
     --------
     >>> from scipy import signal
     >>> import functools
-    >>> b = signal.firwin(80, 0.5, window=functools.partial(windows.kaiser, beta=8))
+    >>> b = signal.firwin(80, 0.5, window=functools.partial(signal.windows.kaiser, beta=8))
     >>> w, h = signal.freqz(b)
 
     >>> import matplotlib.pyplot as plt

--- a/scipy/signal/fir_filter_design.py
+++ b/scipy/signal/fir_filter_design.py
@@ -217,7 +217,7 @@ def firwin(numtaps, cutoff, width=None, window=None, pass_zero=True,
     --------
     Low-pass from 0 to f:
 
-    >>> from scipy import signal, windows
+    >>> from scipy import signal
     >>> numtaps = 3
     >>> f = 0.1
     >>> signal.firwin(numtaps, f)

--- a/scipy/signal/fir_filter_design.py
+++ b/scipy/signal/fir_filter_design.py
@@ -4,6 +4,7 @@ from __future__ import division, print_function, absolute_import
 
 from math import ceil, log
 import warnings
+import functools
 
 import numpy as np
 from numpy.fft import irfft, fft, ifft
@@ -11,7 +12,7 @@ from scipy.special import sinc
 from scipy.linalg import toeplitz, hankel, pinv
 from scipy._lib.six import string_types
 
-from . import sigtools
+from . import sigtools, windows
 
 __all__ = ['kaiser_beta', 'kaiser_atten', 'kaiserord',
            'firwin', 'firwin2', 'remez', 'firls', 'minimum_phase']
@@ -116,9 +117,9 @@ def kaiserord(ripple, width):
     -----
     There are several ways to obtain the Kaiser window:
 
-    - ``signal.kaiser(numtaps, beta, sym=True)``
+    - ``signal.windows.kaiser(numtaps, beta, sym=True)``
     - ``signal.get_window(beta, numtaps)``
-    - ``signal.get_window(('kaiser', beta), numtaps)``
+    - ``signal.get_window(functools.partial(signal.windows.kaiser, beta=beta), numtaps)``
 
     The empirical equations discovered by Kaiser are used.
 
@@ -141,7 +142,7 @@ def kaiserord(ripple, width):
     return int(ceil(numtaps)), beta
 
 
-def firwin(numtaps, cutoff, width=None, window='hamming', pass_zero=True,
+def firwin(numtaps, cutoff, width=None, window=None, pass_zero=True,
            scale=True, nyq=1.0):
     """
     FIR filter design using the window method.
@@ -171,9 +172,9 @@ def firwin(numtaps, cutoff, width=None, window='hamming', pass_zero=True,
         of the transition region (expressed in the same units as `nyq`)
         for use in Kaiser FIR filter design.  In this case, the `window`
         argument is ignored.
-    window : string or tuple of string and parameter values, optional
-        Desired window to use. See `scipy.signal.get_window` for a list
-        of windows and required parameters.
+    window : callable window function, optional
+        Desired window to use. See `scipy.signal.windows` for a list
+        of windows and parameters.
     pass_zero : bool, optional
         If True, the gain at the frequency 0 (i.e. the "DC gain") is 1.
         Otherwise the DC gain is 0.
@@ -216,7 +217,7 @@ def firwin(numtaps, cutoff, width=None, window='hamming', pass_zero=True,
     --------
     Low-pass from 0 to f:
 
-    >>> from scipy import signal
+    >>> from scipy import signal, windows
     >>> numtaps = 3
     >>> f = 0.1
     >>> signal.firwin(numtaps, f)
@@ -224,7 +225,7 @@ def firwin(numtaps, cutoff, width=None, window='hamming', pass_zero=True,
 
     Use a specific window function:
 
-    >>> signal.firwin(numtaps, f, window='nuttall')
+    >>> signal.firwin(numtaps, f, window=signal.windows.nuttall)
     array([  3.56607041e-04,   9.99286786e-01,   3.56607041e-04])
 
     High-pass ('stop' from 0 to f):
@@ -261,6 +262,9 @@ def firwin(numtaps, cutoff, width=None, window='hamming', pass_zero=True,
 
     cutoff = np.atleast_1d(cutoff) / float(nyq)
 
+    if window is None:
+        window = windows.hamming
+
     # Check for invalid input.
     if cutoff.ndim > 1:
         raise ValueError("The cutoff argument must be at most "
@@ -279,7 +283,7 @@ def firwin(numtaps, cutoff, width=None, window='hamming', pass_zero=True,
         # and set `window`.  This overrides the value of `window` passed in.
         atten = kaiser_atten(numtaps, float(width) / nyq)
         beta = kaiser_beta(atten)
-        window = ('kaiser', beta)
+        window = functools.partial(windows.kaiser, beta=beta)
 
     pass_nyquist = bool(cutoff.size & 1) ^ pass_zero
     if pass_nyquist and numtaps % 2 == 0:
@@ -328,7 +332,7 @@ def firwin(numtaps, cutoff, width=None, window='hamming', pass_zero=True,
 #
 # Rewritten by Warren Weckesser, 2010.
 
-def firwin2(numtaps, freq, gain, nfreqs=None, window='hamming', nyq=1.0,
+def firwin2(numtaps, freq, gain, nfreqs=None, window='default', nyq=1.0,
             antisymmetric=False):
     """
     FIR filter design using the window method.
@@ -359,10 +363,9 @@ def firwin2(numtaps, freq, gain, nfreqs=None, window='hamming', nyq=1.0,
         (e.g, 129, 257, etc).  The default is one more than the smallest
         power of 2 that is not less than `numtaps`.  `nfreqs` must be greater
         than `numtaps`.
-    window : string or (string, float) or float, or None, optional
-        Window function to use. Default is "hamming".  See
+    window : callable, optional
+        Window function to use. Default is `scipy.windows.hamming`.  See
         `scipy.signal.get_window` for the complete list of possible values.
-        If None, no window function is applied.
     nyq : float, optional
         Nyquist frequency.  Each frequency in `freq` must be between 0 and
         `nyq` (inclusive).
@@ -429,6 +432,20 @@ def firwin2(numtaps, freq, gain, nfreqs=None, window='hamming', nyq=1.0,
     [-0.02286961 -0.06362756  0.57310236  0.57310236 -0.06362756 -0.02286961]
 
     """
+
+    # We must use this awkward default argument value as `None` was abused as
+    # an alias for windows.rect in previous versions.
+    # Hsnce, passing `None` will be deprecated, too. Once phased out, the
+    # default argument will be switched to `None`.
+    if window == 'default':
+        window = windows.hamming
+
+    if window is None:
+        mesg = ("Calling firwin2 with argument window=None is deprecated. "
+                "Use window=signal.windows.rect instead.")
+        warnings.warn(mesg, DeprecationWarning)
+
+        window = windows.rect
 
     if len(freq) != len(gain):
         raise ValueError('freq and gain must be of same length.')

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -7,6 +7,7 @@ import numpy as np
 from scipy import fftpack
 from . import signaltools
 from .windows import get_window
+from . import windows
 from ._spectral import lombscargle
 import warnings
 
@@ -30,7 +31,7 @@ def periodogram(x, fs=1.0, window=None, nfft=None, detrend='constant',
     window : str or tuple or array_like, optional
         Desired window to use. See `get_window` for a list of windows and
         required parameters. If `window` is an array it will be used
-        directly as the window. Defaults to None; equivalent to 'boxcar'.
+        directly as the window. Defaults to None; equivalent to `scipy.windows.boxcar`.
     nfft : int, optional
         Length of the FFT used. If None the length of `x` will be used.
     detrend : str or function or False, optional
@@ -102,7 +103,7 @@ def periodogram(x, fs=1.0, window=None, nfft=None, detrend='constant',
 
     Now compute and plot the power spectrum.
 
-    >>> f, Pxx_spec = signal.periodogram(x, fs, 'flattop', scaling='spectrum')
+    >>> f, Pxx_spec = signal.periodogram(x, fs, signal.windows.flattop, scaling='spectrum')
     >>> plt.figure()
     >>> plt.semilogy(f, np.sqrt(Pxx_spec))
     >>> plt.ylim([1e-4, 1e1])
@@ -122,7 +123,7 @@ def periodogram(x, fs=1.0, window=None, nfft=None, detrend='constant',
         return np.empty(x.shape), np.empty(x.shape)
 
     if window is None:
-        window = 'boxcar'
+        window = windows.boxcar
 
     if nfft is None:
         nperseg = x.shape[axis]
@@ -141,7 +142,7 @@ def periodogram(x, fs=1.0, window=None, nfft=None, detrend='constant',
                  scaling, axis)
 
 
-def welch(x, fs=1.0, window='hann', nperseg=256, noverlap=None, nfft=None,
+def welch(x, fs=1.0, window=None, nperseg=256, noverlap=None, nfft=None,
           detrend='constant', return_onesided=True, scaling='density', axis=-1):
     """
     Estimate power spectral density using Welch's method.
@@ -160,7 +161,7 @@ def welch(x, fs=1.0, window='hann', nperseg=256, noverlap=None, nfft=None,
         Desired window to use. See `get_window` for a list of windows and
         required parameters. If `window` is array_like it will be used
         directly as the window and its length will be used for nperseg.
-        Defaults to 'hann'.
+        Defaults to `signal.windows.hann`.
     nperseg : int, optional
         Length of each segment.  Defaults to 256.
     noverlap : int, optional
@@ -202,7 +203,7 @@ def welch(x, fs=1.0, window='hann', nperseg=256, noverlap=None, nfft=None,
     Notes
     -----
     An appropriate amount of overlap will depend on the choice of window
-    and on your requirements.  For the default 'hann' window an
+    and on your requirements.  For the default `scipy.windows.hann` window an
     overlap of 50% is a reasonable trade off between accurately estimating
     the signal power, while not over counting any of the data.  Narrower
     windows may require a larger overlap.
@@ -255,7 +256,7 @@ def welch(x, fs=1.0, window='hann', nperseg=256, noverlap=None, nfft=None,
 
     Now compute and plot the power spectrum.
 
-    >>> f, Pxx_spec = signal.welch(x, fs, 'flattop', 1024, scaling='spectrum')
+    >>> f, Pxx_spec = signal.welch(x, fs, signal.windows.flattop, 1024, scaling='spectrum')
     >>> plt.figure()
     >>> plt.semilogy(f, np.sqrt(Pxx_spec))
     >>> plt.xlabel('frequency [Hz]')
@@ -268,6 +269,8 @@ def welch(x, fs=1.0, window='hann', nperseg=256, noverlap=None, nfft=None,
     2.0077340678640727
 
     """
+    if window is None:
+        window = windows.hann
 
     freqs, Pxx = csd(x, x, fs, window, nperseg, noverlap, nfft, detrend,
                      return_onesided, scaling, axis)
@@ -275,7 +278,7 @@ def welch(x, fs=1.0, window='hann', nperseg=256, noverlap=None, nfft=None,
     return freqs, Pxx.real
 
 
-def csd(x, y, fs=1.0, window='hann', nperseg=256, noverlap=None, nfft=None,
+def csd(x, y, fs=1.0, window=None, nperseg=256, noverlap=None, nfft=None,
         detrend='constant', return_onesided=True, scaling='density', axis=-1):
     """
     Estimate the cross power spectral density, Pxy, using Welch's method.
@@ -288,11 +291,11 @@ def csd(x, y, fs=1.0, window='hann', nperseg=256, noverlap=None, nfft=None,
         Time series of measurement values
     fs : float, optional
         Sampling frequency of the `x` and `y` time series. Defaults to 1.0.
-    window : str or tuple or array_like, optional
+    window : callable or array_like, optional
         Desired window to use. See `get_window` for a list of windows and
         required parameters. If `window` is array_like it will be used
         directly as the window and its length will be used for nperseg.
-        Defaults to 'hann'.
+        Defaults to `signal.windows.hann`.
     nperseg : int, optional
         Length of each segment.  Defaults to 256.
     noverlap: int, optional
@@ -342,7 +345,7 @@ def csd(x, y, fs=1.0, window='hann', nperseg=256, noverlap=None, nfft=None,
     zero-padded to match.
 
     An appropriate amount of overlap will depend on the choice of window
-    and on your requirements.  For the default 'hann' window an
+    and on your requirements.  For the default `signal.windows.hann` window an
     overlap of 50\\% is a reasonable trade off between accurately estimating
     the signal power, while not over counting any of the data.  Narrower
     windows may require a larger overlap.
@@ -385,6 +388,8 @@ def csd(x, y, fs=1.0, window='hann', nperseg=256, noverlap=None, nfft=None,
     >>> plt.ylabel('CSD [V**2/Hz]')
     >>> plt.show()
     """
+    if window is None:
+        window = windows.hann
 
     freqs, _, Pxy = _spectral_helper(x, y, fs, window, nperseg, noverlap, nfft,
                                      detrend, return_onesided, scaling, axis,
@@ -400,7 +405,7 @@ def csd(x, y, fs=1.0, window='hann', nperseg=256, noverlap=None, nfft=None,
     return freqs, Pxy
 
 
-def spectrogram(x, fs=1.0, window=('tukey',.25), nperseg=256, noverlap=None,
+def spectrogram(x, fs=1.0, window=None, nperseg=256, noverlap=None,
                 nfft=None, detrend='constant', return_onesided=True,
                 scaling='density', axis=-1, mode='psd'):
     """
@@ -415,7 +420,7 @@ def spectrogram(x, fs=1.0, window=('tukey',.25), nperseg=256, noverlap=None,
         Time series of measurement values
     fs : float, optional
         Sampling frequency of the `x` time series. Defaults to 1.0.
-    window : str or tuple or array_like, optional
+    window : callable or array_like, optional
         Desired window to use. See `get_window` for a list of windows and
         required parameters. If `window` is array_like it will be used
         directly as the window and its length will be used for nperseg.
@@ -511,6 +516,9 @@ def spectrogram(x, fs=1.0, window=('tukey',.25), nperseg=256, noverlap=None,
     if noverlap is None:
         noverlap = nperseg // 8
 
+    if window is None:
+        window = functools.partial(windows.tukey, alpha=.25)
+
     freqs, time, Pxy = _spectral_helper(x, x, fs, window, nperseg, noverlap,
                                         nfft, detrend, return_onesided, scaling,
                                         axis, mode=mode)
@@ -518,7 +526,7 @@ def spectrogram(x, fs=1.0, window=('tukey',.25), nperseg=256, noverlap=None,
     return freqs, time, Pxy
 
 
-def coherence(x, y, fs=1.0, window='hann', nperseg=256, noverlap=None,
+def coherence(x, y, fs=1.0, window=None, nperseg=256, noverlap=None,
               nfft=None, detrend='constant', axis=-1):
     """
     Estimate the magnitude squared coherence estimate, Cxy, of discrete-time
@@ -536,11 +544,11 @@ def coherence(x, y, fs=1.0, window='hann', nperseg=256, noverlap=None,
         Time series of measurement values
     fs : float, optional
         Sampling frequency of the `x` and `y` time series. Defaults to 1.0.
-    window : str or tuple or array_like, optional
+    window : callable or array_like, optional
         Desired window to use. See `get_window` for a list of windows and
         required parameters. If `window` is array_like it will be used
         directly as the window and its length will be used for nperseg.
-        Defaults to 'hann'.
+        Defaults to `signal.windows.hann`.
     nperseg : int, optional
         Length of each segment.  Defaults to 256.
     noverlap: int, optional
@@ -575,7 +583,7 @@ def coherence(x, y, fs=1.0, window='hann', nperseg=256, noverlap=None,
     Notes
     --------
     An appropriate amount of overlap will depend on the choice of window
-    and on your requirements.  For the default 'hann' window an
+    and on your requirements.  For the default `signal.windows.hann` window an
     overlap of 50\\% is a reasonable trade off between accurately estimating
     the signal power, while not over counting any of the data.  Narrower
     windows may require a larger overlap.
@@ -618,6 +626,8 @@ def coherence(x, y, fs=1.0, window='hann', nperseg=256, noverlap=None,
     >>> plt.ylabel('Coherence')
     >>> plt.show()
     """
+    if window is None:
+        window = windows.hann
 
     freqs, Pxx = welch(x, fs, window, nperseg, noverlap, nfft, detrend,
                        axis=axis)
@@ -629,7 +639,7 @@ def coherence(x, y, fs=1.0, window='hann', nperseg=256, noverlap=None,
     return freqs, Cxy
 
 
-def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=256,
+def _spectral_helper(x, y, fs=1.0, window=None, nperseg=256,
                     noverlap=None, nfft=None, detrend='constant',
                     return_onesided=True, scaling='spectrum', axis=-1,
                     mode='psd'):
@@ -651,11 +661,11 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=256,
         the extra computations are spared.
     fs : float, optional
         Sampling frequency of the time series. Defaults to 1.0.
-    window : str or tuple or array_like, optional
+    window : callable or array_like, optional
         Desired window to use. See `get_window` for a list of windows and
         required parameters. If `window` is array_like it will be used
         directly as the window and its length will be used for nperseg.
-        Defaults to 'hann'.
+        Defaults to `signal.windows.hann`.
     nperseg : int, optional
         Length of each segment.  Defaults to 256.
     noverlap : int, optional
@@ -707,6 +717,9 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=256,
 
     .. versionadded:: 0.16.0
     """
+    if window is None:
+        window = windows.hann
+
     if mode not in ['psd', 'complex', 'magnitude', 'angle', 'phase']:
         raise ValueError("Unknown value for mode %s, must be one of: "
                          "'default', 'psd', 'complex', "
@@ -807,7 +820,7 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=256,
     else:
         detrend_func = detrend
 
-    if isinstance(window, string_types) or type(window) is tuple:
+    if isinstance(window, string_types) or type(window) is tuple or callable(window):
         win = get_window(window, nperseg)
     else:
         win = np.asarray(window)

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -10,6 +10,7 @@ from .windows import get_window
 from . import windows
 from ._spectral import lombscargle
 import warnings
+import functools
 
 from scipy._lib.six import string_types
 

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -1,5 +1,6 @@
 from __future__ import division, print_function, absolute_import
 
+import functools
 import warnings
 import numpy as np
 from numpy.testing import assert_raises, assert_approx_equal, \
@@ -117,8 +118,8 @@ class TestPeriodogram(TestCase):
     def test_window_external(self):
         x = np.zeros(16)
         x[0] = 1
-        f, p = periodogram(x, 10, 'hann')
-        win = signal.get_window('hann', 16)
+        f, p = periodogram(x, 10, signal.windows.hann)
+        win = signal.get_window(signal.windows.hann, 16)
         fe, pe = periodogram(x, 10, win)
         assert_array_almost_equal_nulp(p, pe)
         assert_array_almost_equal_nulp(f, fe)
@@ -353,8 +354,8 @@ class TestWelch(TestCase):
         x = np.zeros(16)
         x[0] = 1
         x[8] = 1
-        f, p = welch(x, 10, 'hann', 8)
-        win = signal.get_window('hann', 8)
+        f, p = welch(x, 10, signal.windows.hann, 8)
+        win = signal.get_window(signal.windows.hann, 8)
         fe, pe = welch(x, 10, win, 8)
         assert_array_almost_equal_nulp(p, pe)
         assert_array_almost_equal_nulp(f, fe)
@@ -402,7 +403,7 @@ class TestWelch(TestCase):
         assert_allclose(p, q, atol=1e-12)
 
     def test_bad_noverlap(self):
-        assert_raises(ValueError, welch, np.zeros(4), 1, 'hann', 2, 7)
+        assert_raises(ValueError, welch, np.zeros(4), 1, signal.windows.hann, 2, 7)
 
     def test_nfft_too_short(self):
         assert_raises(ValueError, welch, np.ones(12), nfft=3, nperseg=4)
@@ -481,7 +482,12 @@ class TestWelch(TestCase):
         tt = np.arange(fs)/fs
         x = A*np.sin(2*np.pi*fsig*tt)
 
-        for window in ['hann', 'bartlett', ('tukey', 0.1), 'flattop']:
+        for window in [
+            signal.windows.hann,
+            signal.windows.bartlett,
+            functools.partial(signal.windows.tukey, alpha=0.1),
+            signal.windows.flattop
+        ]:
             _, p_spec = welch(x, fs=fs, nperseg=nperseg, window=window,
                               scaling='spectrum')
             freq, p_dens = welch(x, fs=fs, nperseg=nperseg, window=window,
@@ -655,8 +661,8 @@ class TestCSD:
         x = np.zeros(16)
         x[0] = 1
         x[8] = 1
-        f, p = csd(x, x, 10, 'hann', 8)
-        win = signal.get_window('hann', 8)
+        f, p = csd(x, x, 10, signal.windows.hann, 8)
+        win = signal.get_window(signal.windows.hann, 8)
         fe, pe = csd(x, x, 10, win, 8)
         assert_array_almost_equal_nulp(p, pe)
         assert_array_almost_equal_nulp(f, fe)
@@ -725,8 +731,8 @@ class TestCSD:
         assert_allclose(p, q, atol=1e-12)
 
     def test_bad_noverlap(self):
-        assert_raises(ValueError, csd, np.zeros(4), np.ones(4), 1, 'hann',
-                      2, 7)
+        assert_raises(ValueError, csd, np.zeros(4), np.ones(4), 1,
+                      signal.windows.hann, 2, 7)
 
     def test_nfft_too_short(self):
         assert_raises(ValueError, csd, np.ones(12), np.zeros(12), nfft=3,
@@ -826,7 +832,7 @@ class TestSpectrogram:
         x = np.random.randn(1024)
 
         fs = 1.0
-        window = ('tukey', 0.25)
+        window = functools.partial(signal.windows.tukey, alpha=0.25)
         nperseg = 16
         noverlap = 2
 

--- a/scipy/signal/tests/test_upfirdn.py
+++ b/scipy/signal/tests/test_upfirdn.py
@@ -37,7 +37,7 @@ from itertools import product
 from numpy.testing import (TestCase, run_module_suite, assert_equal,
                            assert_raises, assert_allclose)
 
-from scipy.signal import upfirdn, firwin, lfilter
+from scipy.signal import upfirdn, firwin, lfilter, windows
 from scipy.signal._upfirdn import _output_len
 
 
@@ -123,7 +123,7 @@ class test_upfirdn(TestCase):
                 x += 1j * random_state.randn(size)
 
             for down in down_factors:
-                h = firwin(31, 1. / down, window='hamming')
+                h = firwin(31, 1. / down, window=windows.hamming)
                 yl = lfilter(h, 1.0, x)[::down]
                 y = upfirdn(h, x, up=1, down=down)
                 assert_allclose(yl, y[:yl.size], atol=1e-7, rtol=1e-7)

--- a/scipy/signal/windows.py
+++ b/scipy/signal/windows.py
@@ -1678,14 +1678,36 @@ for k, v in _win_equiv_raw.items():
         _needs_param.update(k)
 
 
+brthan = bth = barthann
+bart = brt = bartlett
+black = blk = blackman
+blackharr = bkh = blackmanharris
+bman = bmn = bohman
+box = ones = rect = rectangular = boxcar
+cheb = chebwin
+halfcosine = cosine
+poisson = exponential
+flat = flt = flattop
+gauss = gss = gaussian
+general_gauss = ggs = general_gaussian
+hamm = ham = hamming
+hann = han = hann
+ksr = kaiser
+nutl = nut = nuttall
+parz = par = parzen
+slep = optimal = dpss = dss = slepian
+triang = tri = triang
+tuk = tukey
+
+
 def get_window(window, Nx, fftbins=True):
     """
     Return a window.
 
     Parameters
     ----------
-    window : string, float, or tuple
-        The type of window to create. See below for more details.
+    window : callable
+        The window window function. See below for more details.
     Nx : int
         The number of samples in the window.
     fftbins : bool, optional
@@ -1710,14 +1732,11 @@ def get_window(window, Nx, fftbins=True):
         (needs width), `chebwin` (needs attenuation), `exponential`
         (needs decay scale), `tukey` (needs taper fraction)
 
-    If the window requires no parameters, then `window` can be a string.
+    If the window requires no parameters, then `window` can be a callable
+    from this module.
 
-    If the window requires parameters, then `window` must be a tuple
-    with the first argument the string name of the window, and the next
-    arguments the needed parameters.
-
-    If `window` is a floating point number, it is interpreted as the beta
-    parameter of the `kaiser` window.
+    If the window requires parameters, then these parameters must be bound
+    to `window` using `functools.partial`.
 
     Each of the window types listed above is also the name of
     a function that can be called directly to create a window of
@@ -1725,18 +1744,25 @@ def get_window(window, Nx, fftbins=True):
 
     Examples
     --------
+    >>> import functools
     >>> from scipy import signal
-    >>> signal.get_window('triang', 7)
+    >>> signal.get_window(signal.windows.triang, 7)
     array([ 0.25,  0.5 ,  0.75,  1.  ,  0.75,  0.5 ,  0.25])
-    >>> signal.get_window(('kaiser', 4.0), 9)
-    array([ 0.08848053,  0.32578323,  0.63343178,  0.89640418,  1.        ,
-            0.89640418,  0.63343178,  0.32578323,  0.08848053])
-    >>> signal.get_window(4.0, 9)
+    >>> signal.get_window(functools.partial(signal.windows.kaiser, beta=4.0), 9)
     array([ 0.08848053,  0.32578323,  0.63343178,  0.89640418,  1.        ,
             0.89640418,  0.63343178,  0.32578323,  0.08848053])
 
     """
+    if not callable(window):
+        mesg = ("calling get_window with anything but a callable function "
+                "is deprecated and will be removed in the future.")
+        warnings.warn(mesg, DeprecationWarning)
+
     sym = not fftbins
+
+    if callable(window):
+        return window(Nx, sym=sym)
+
     try:
         beta = float(window)
     except (TypeError, ValueError):


### PR DESCRIPTION
The current implementation of [`get_window()`](https://github.com/scipy/scipy/blob/a62a60f0081c475f418c23e966792947563929c9/scipy/signal/windows.py#L1681) is very messy and has many conceptional problems:

## Pointless for user calls

In cases where the user calls the function it serves **no real purpose** besides reshuffling the function call: These two are equivalent, so why use `get_window` in the first place?

``` python
scipy.signal.windows.cosine(16)
scipy.signal.windows.get_window('cosine', 16)
```

And **obfuscates the window function API** with some weird tuple-syntax. The first one is readable with no scipy knowledge, the second one is weird:

``` python
scipy.signal.windows.kaiser(16, beta=1.0)
scipy.signal.windows.get_window(('kaiser', 1.0), 16)
```

## Parameter binding

I understand the reasoning that you may want to **parameterize the window function from outside another function**, so you can have interchangeable window functions in some other code. But using `functools` you can achieve the same and result in much more descriptive and transparent code:

- making it clear what is being used (`scipy.signal.windows.kaiser`)
- making it clear what parameter being partialled out (`beta`)
- can be mocked easily (both input and output are calleable)

``` python
winfunc = functools.partial(kaiser, beta=1.0)
# ...
winfunc(16)
```

`get_window` uses a very opaque API (a tuple with some special meaning) that needs people to
- Go dive deep in the code to find out where `winfunc` is later being used, discover it is a call to `get_window`
- Then read the `get_window` docs to understand what is going on
- needs monkeypatching of scipy to be mocked

``` python
winfunc = ('kaiser', 1.0)
# ...
get_window(winfunc, 16)
```

## Functions as strings

Another argument for using it may be that you can parameterize the **window function as a string**. If you really need to, however this can also be done using `getattr`, too.

``` python
getattr(scipy.signal.windows, 'boxcar')(16)
scipy.signal.windows.get_window('boxcar', 16)
```

## Tight coupling

Because of the very different additional parameters of all functions, `get_window` is [quite closely coupled with each window's interface](https://github.com/scipy/scipy/blob/a62a60f0081c475f418c23e966792947563929c9/scipy/signal/windows.py#L1749), doing parameter resolution and checking that should really be

- done by the window-function
- defined and documented by the window-function interface

`get_window` replaces that "nice Python function API with keyword arguments and default values" with a few lines of code that is superfluous, really hard to understand and hard to test.

## Current use in SciPy

I understand `get_window` is mainly used in in `firwin`, `firwin2`, `peridogram` etc:

``` python
from scipy.signal import window

firwin(100, 0.1, 'nuttall')
periodogram(x, fs, ('kaiser', 0.1))
```

However, this is more opaque and less testable than

``` python
from scipy.signal import window
from functools import partial

firwin(100, 0.1, window.nuttall)
periodogram(x, fs, partial(window.kaiser, beta=0.1))
```

The latter would in some cases produce nicer error messages, too. Imagine

``` python
from scipy.signal import window

firwin(100, 0.1, 'nonsense')
firwin(100, 0.1, window.nonsense)
```

the first line will show some obscure error in `scipy/signal/windows.py` whereas the second line will point to the mistake _in your script_.

Therefore this PR aims to deprecate `get_window` and ask people to use the window functions (or partialled out parameters) directly:

 1. It adds functionality to pass a `callable` to `get_window()` 
 2. Replaces all occurrences in `scipy.signal` where a `string`/`tuple` based call was used
 2. Raises a `DeprecationWarning` (although it is not visible?) if no `callable` was passed
 3. Raises a `DeprecationWarning` if [`window=None` is passed to `firwin`](https://github.com/scipy/scipy/pull/6895/files#diff-e3cb9a440373ea91c1efcd3937304d85R436). `None` was used as an alias for `windows.rect`.


## Future steps

Once this is merged, the following steps must be done to finalize the deprecation:

 1. Remove most of the [`get_window()` logic](https://github.com/scipy/scipy/blob/a62a60f0081c475f418c23e966792947563929c9/scipy/signal/windows.py#L1739-L1768)
 2. Remove most of the related [parameter tracking code](https://github.com/scipy/scipy/blob/a62a60f0081c475f418c23e966792947563929c9/scipy/signal/windows.py#L1643-L1678)
 3. Change the unusual [`window` argument in `firwin`](https://github.com/scipy/scipy/pull/6895/files#diff-e3cb9a440373ea91c1efcd3937304d85R436), using the default value `None` as an alias for `window=signal.windows.hamming` and asking the user to use `window=windows.windows.rect` if they wish to do so.
 4. Some completely unrelated functions [additionally check for `string`/`tuple` windows](https://github.com/scipy/scipy/blob/4fbca70cb4829134cfe1b986ff2b77d8f41e0ee3/scipy/signal/spectral.py#L810). This logic should be dealt with.

It closes #5744 (from which most of this text is taken, too).