### PR TITLE
Gitignore .eggs directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ setup.cfg
 .coverage
 .deps
 .libs
+.eggs
 
 # Paver generated files #
 #########################


### PR DESCRIPTION
After installation and tests there is a stray directory

    .eggs/

in my repo. This PR ignores that directory.