### PR TITLE
DOC: Added reciprocal "See Also" links between shape analyses

### DIFF
--- a/scipy/spatial/_procrustes.py
+++ b/scipy/spatial/_procrustes.py
@@ -65,6 +65,8 @@ def procrustes(data1, data2):
     See Also
     --------
     scipy.linalg.orthogonal_procrustes
+    scipy.spatial.distance.directed_hausdorff : Another similarity test
+      for two data sets
 
     Notes
     -----

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -194,6 +194,10 @@ def directed_hausdorff(u, v, seed=0):
            Pattern Analysis And Machine Intelligence, vol. 37 pp. 2153-63,
            2015.
 
+    See Also
+    --------
+    scipy.spatial.procrustes : Another similarity test for two data sets
+
     Examples
     --------
     Find the directed Hausdorff distance between two 2-D arrays of


### PR DESCRIPTION
This is a small PR to add reciprocal `See Also` docstring links between `scipy.spatial.procrustes` and (the new) `scipy.spatial.distance.directed_hausdorff`, both of which compare the similarity of two data sets (shapes, trajectories, etc.).

The html build on my machine for scipy docs seems a bit bare bone (the theme doesn't display super well), so definitely a good idea to `make html` if it works well for you (I'm probably missing some dependencies or something) to look it over.