### PR TITLE
ENH: fftpack: use float32 routines for float16 inputs.

### DIFF
--- a/scipy/fftpack/basic.py
+++ b/scipy/fftpack/basic.py
@@ -128,12 +128,17 @@ def _asfarray(x):
         # 'dtype' attribute does not ensure that the
         # object is an ndarray (e.g. Series class
         # from the pandas library)
+        if x.dtype == numpy.half:
+            # no half-precision routines, so convert to single precision
+            return numpy.asarray(x, dtype=numpy.float32)
         return numpy.asarray(x, dtype=x.dtype)
     else:
         # We cannot use asfarray directly because it converts sequences of
         # complex to sequence of real
         ret = numpy.asarray(x)
-        if ret.dtype.char not in numpy.typecodes["AllFloat"]:
+        if ret.dtype == numpy.half:
+            return numpy.asarray(ret, dtype=numpy.float32)
+        elif ret.dtype.char not in numpy.typecodes["AllFloat"]:
             return numpy.asfarray(x)
         return ret
 

--- a/scipy/fftpack/basic.py
+++ b/scipy/fftpack/basic.py
@@ -236,6 +236,11 @@ def fft(x, n=None, axis=-1, overwrite_x=False):
     negative-frequency terms.  For `n` even and `x` real, ``A[n/2]`` will
     always be real.
 
+    Both single and double precision routines are implemented.  Half precision
+    inputs will be converted to single precision.  Non floating-point inputs
+    will be converted to double precision.  Long-double precision inputs are
+    not supported.
+
     This function is most efficient when `n` is a power of two, and least
     efficient when `n` is prime.
 
@@ -317,6 +322,11 @@ def ifft(x, n=None, axis=-1, overwrite_x=False):
 
     Notes
     -----
+    Both single and double precision routines are implemented.  Half precision
+    inputs will be converted to single precision.  Non floating-point inputs
+    will be converted to double precision.  Long-double precision inputs are
+    not supported.
+
     This function is most efficient when `n` is a power of two, and least
     efficient when `n` is prime.
 
@@ -395,6 +405,11 @@ def rfft(x, n=None, axis=-1, overwrite_x=False):
     Notes
     -----
     Within numerical accuracy, ``y == rfft(irfft(y))``.
+
+    Both single and double precision routines are implemented.  Half precision
+    inputs will be converted to single precision.  Non floating-point inputs
+    will be converted to double precision.  Long-double precision inputs are
+    not supported.
 
     Examples
     --------
@@ -589,6 +604,13 @@ def fftn(x, shape=None, axes=None, overwrite_x=False):
     See Also
     --------
     ifftn
+
+    Notes
+    -----
+    Both single and double precision routines are implemented.  Half precision
+    inputs will be converted to single precision.  Non floating-point inputs
+    will be converted to double precision.  Long-double precision inputs are
+    not supported.
 
     Examples
     --------

--- a/scipy/fftpack/tests/test_basic.py
+++ b/scipy/fftpack/tests/test_basic.py
@@ -199,6 +199,25 @@ class TestSingleFFT(_TestFFTBase):
         pass
 
 
+class TestFloat16FFT(TestCase):
+
+    def test_1_argument_real(self):
+        x1 = np.array([1, 2, 3, 4], dtype=np.float16)
+        y = fft(x1, n=4)
+        assert_equal(y.dtype, np.complex64)
+        assert_equal(y.shape, (4, ))
+        assert_array_almost_equal(y, direct_dft(x1.astype(np.float32)))
+
+    def test_n_argument_real(self):
+        x1 = np.array([1, 2, 3, 4], dtype=np.float16)
+        x2 = np.array([1, 2, 3, 4], dtype=np.float16)
+        y = fft([x1, x2], n=4)
+        assert_equal(y.dtype, np.complex64)
+        assert_equal(y.shape, (2, 4))
+        assert_array_almost_equal(y[0], direct_dft(x1.astype(np.float32)))
+        assert_array_almost_equal(y[1], direct_dft(x2.astype(np.float32)))
+
+
 class _TestIFFTBase(TestCase):
     def setUp(self):
         np.random.seed(1234)
@@ -493,6 +512,32 @@ class TestFftnSingle(TestCase):
 
             assert_equal(y1.dtype, np.complex64)
             assert_array_almost_equal_nulp(y1, y2, 2000)
+
+    def test_definition_float16(self):
+        x = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+        y = fftn(np.array(x, np.float16))
+        assert_equal(y.dtype, np.complex64)
+        y_r = np.array(fftn(x), np.complex64)
+        assert_array_almost_equal_nulp(y, y_r)
+
+    def test_float16_input(self):
+        for size in SMALL_COMPOSITE_SIZES + SMALL_PRIME_SIZES:
+            np.random.seed(1234)
+            x = np.random.rand(size, size) + 1j*np.random.rand(size, size)
+            y1 = fftn(x.real.astype(np.float16))
+            y2 = fftn(x.real.astype(np.float64)).astype(np.complex64)
+
+            assert_equal(y1.dtype, np.complex64)
+            assert_array_almost_equal_nulp(y1, y2, 5e5)
+
+        for size in LARGE_COMPOSITE_SIZES + LARGE_PRIME_SIZES:
+            np.random.seed(1234)
+            x = np.random.rand(size, 3) + 1j*np.random.rand(size, 3)
+            y1 = fftn(x.real.astype(np.float16))
+            y2 = fftn(x.real.astype(np.float64)).astype(np.complex64)
+
+            assert_equal(y1.dtype, np.complex64)
+            assert_array_almost_equal_nulp(y1, y2, 2e6)
 
 
 class TestFftn(TestCase):


### PR DESCRIPTION
prior to this commit an error was raised for float16 input


```python
import numpy as np
import scipy.fftpack

scipy.fftpack.fft(np.ones(8).astype(np.float16))
Traceback (most recent call last):

  File "<ipython-input-5-3b66b4d7b5f7>", line 1, in <module>
    scipy.fftpack.fft(np.ones(8).astype(np.float16))

  File "/Users/lee8rx/anaconda/lib/python3.5/site-packages/scipy/fftpack/basic.py", line 257, in fft
    raise ValueError("type %s is not supported" % tmp.dtype)

ValueError: type float16 is not supported
```