### PR TITLE
Fix 6875: SLSQP raise ValueError for all invalid bounds.

### DIFF
--- a/scipy/optimize/slsqp.py
+++ b/scipy/optimize/slsqp.py
@@ -338,7 +338,7 @@ def _minimize_slsqp(func, x0, args=(), jac=None, bounds=None,
             raise IndexError('SLSQP Error: the length of bounds is not '
                              'compatible with that of x0.')
 
-        bnderr = where(bnds[:, 0] > bnds[:, 1])[0]
+        bnderr = bnds[:, 0] > bnds[:, 1]
         if bnderr.any():
             raise ValueError('SLSQP Error: lb > ub in bounds %s.' %
                              ', '.join(str(b) for b in bnderr))

--- a/scipy/optimize/tests/test_slsqp.py
+++ b/scipy/optimize/tests/test_slsqp.py
@@ -374,6 +374,20 @@ class TestSLSQP(TestCase):
         sol = minimize(func, [0, 0, 0], method='SLSQP')
         assert_(sol.jac.shape == (3,))
 
+    def test_invalid_bounds(self):
+        # Raise correct error when lower bound is greater than upper bound.
+        # See Github issue 6875.
+        bounds_list = [
+            ((1, 2), (2, 1)),
+            ((2, 1), (1, 2)),
+            ((2, 1), (2, 1)),
+            ((np.inf, 0), (np.inf, 0)),
+            ((1, -np.inf), (0, 1)),
+        ]
+        for bounds in bounds_list:
+            with assert_raises(ValueError):
+                minimize(self.fun, [-1.0, 1.0], bounds=bounds, method='SLSQP')
+
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Previously, SLSQP would not raise the error if the first set of bounds were
invalid, but would if any other bounds were invalid.  This now handles all
invalid bounds in the same way by raising a ValueError.

Fixes #6875.