### PR TITLE
MAINT: fix some issues for 32-bit Python

### DIFF
--- a/scipy/io/matlab/tests/test_pathological.py
+++ b/scipy/io/matlab/tests/test_pathological.py
@@ -30,4 +30,5 @@ def test_malformed1():
     #
     # Should raise an exception, not segfault
     fname = pjoin(TEST_DATA_PATH, 'malformed1.mat')
-    assert_raises(ValueError, loadmat, fname)
+    with open(fname, 'rb') as f:
+        assert_raises(ValueError, loadmat, f)

--- a/scipy/misc/tests/test_pilutil.py
+++ b/scipy/misc/tests/test_pilutil.py
@@ -183,7 +183,8 @@ def test_imread_indexed_png():
                       [0, 31, 255, 255]]], dtype=np.uint8)
 
     filename = os.path.join(datapath, 'data', 'foo3x5x4indexed.png')
-    im = misc.imread(filename)
+    with open(filename, 'rb') as f:
+        im = misc.imread(f)
     assert_array_equal(im, data)
 
 

--- a/scipy/spatial/_hausdorff.pyx
+++ b/scipy/spatial/_hausdorff.pyx
@@ -26,7 +26,7 @@ def directed_hausdorff(double[:,::1] ar1, double[:,::1] ar2, seed=0):
     cdef int N2 = ar2.shape[0]
     cdef int data_dims = ar1.shape[1]
     cdef unsigned int i, j, k
-    cdef unsigned int i_store, j_store, i_ret, j_ret = 0
+    cdef unsigned int i_store = 0, j_store = 0, i_ret = 0, j_ret = 0
     cdef long[:] resort1, resort2
 
     # shuffling the points in each array generally increases the likelihood of

--- a/scipy/spatial/_voronoi.pyx
+++ b/scipy/spatial/_voronoi.pyx
@@ -36,7 +36,7 @@ def sort_vertices_of_regions(int[:,::1] simplices, regions):
     cdef np.npy_intp[:] remaining
     cdef np.npy_intp[:] sorted_vertices = np.zeros(max([len(region) for region
                                                    in regions]),
-                                                   dtype=np.int64)
+                                                   dtype=np.intp)
 
     for n in range(num_regions):
         remaining_count = 0


### PR DESCRIPTION
Most importantly, fixes 2 test errors and a segfault in ``spatial``.