### PR TITLE
ENH: add weight-awareness to many functions in scipy.stats and scipy.…

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -179,6 +179,7 @@ def directed_hausdorff(u, v, seed=0):
     """
     Computes the directed Hausdorff distance between two N-D arrays.
     Distances between pairs are calculated using a Euclidean metric.
+
     Parameters
     ----------
     u : (M,N) ndarray
@@ -188,6 +189,7 @@ def directed_hausdorff(u, v, seed=0):
     seed : int or None
         Local `np.random.RandomState` seed. Default is 0, a random shuffling of
         u and v that guarantees reproducibility.
+
     Returns
     -------
     d : double
@@ -196,6 +198,7 @@ def directed_hausdorff(u, v, seed=0):
         index of point contributing to Hausdorff pair in `u`
     index_2 : int
         index of point contributing to Hausdorff pair in `v`
+
     Notes
     -----
     Uses the early break technique and the random sampling approach
@@ -208,15 +211,18 @@ def directed_hausdorff(u, v, seed=0):
     cmax and leads to an early break as often as possible. The authors
     have formally shown that the average runtime is closer to O(m).
     .. versionadded:: 0.19.0
+
     References
     ----------
     .. [1] A. A. Taha and A. Hanbury, "An efficient algorithm for
            calculating the exact Hausdorff distance." IEEE Transactions On
            Pattern Analysis And Machine Intelligence, vol. 37 pp. 2153-63,
            2015.
+
     See Also
     --------
     scipy.spatial.procrustes : Another similarity test for two data sets
+
     Examples
     --------
     Find the directed Hausdorff distance between two 2-D arrays of
@@ -1205,6 +1211,7 @@ def pdist(X, metric='euclidean', p=2, w=None, V=None, VI=None):
     """
     Pairwise distances between observations in n-dimensional space.
     See Notes for common calling conventions.
+
     Parameters
     ----------
     X : ndarray
@@ -1266,6 +1273,7 @@ def pdist(X, metric='euclidean', p=2, w=None, V=None, VI=None):
 
        Computes the standardized Euclidean distance. The standardized
        Euclidean distance between two n-vectors ``u`` and ``v`` is
+
        .. math::
           \\sqrt{\\sum {(u_i-v_i)^2 / V[x_i]}}
        V is the variance vector; V[i] is the variance computed over all
@@ -1289,6 +1297,7 @@ def pdist(X, metric='euclidean', p=2, w=None, V=None, VI=None):
     7. ``Y = pdist(X, 'correlation')``
 
        Computes the correlation distance between vectors u and v. This is
+
        .. math::
           1 - \\frac{(u - \\bar{u}) \\cdot (v - \\bar{v})}
                    {{||(u - \\bar{u})||}_2 {||(v - \\bar{v})||}_2}
@@ -1315,6 +1324,7 @@ def pdist(X, metric='euclidean', p=2, w=None, V=None, VI=None):
        Chebyshev distance between two n-vectors ``u`` and ``v`` is the
        maximum norm-1 distance between their respective elements. More
        precisely, the distance is given by
+
        .. math::
           d(u,v) = \\max_i {|u_i-v_i|}
 
@@ -1322,6 +1332,7 @@ def pdist(X, metric='euclidean', p=2, w=None, V=None, VI=None):
 
        Computes the Canberra distance between the points. The
        Canberra distance between two points ``u`` and ``v`` is
+
        .. math::
          d(u,v) = \\sum_i \\frac{|u_i-v_i|}
                               {|u_i|+|v_i|}
@@ -1330,6 +1341,7 @@ def pdist(X, metric='euclidean', p=2, w=None, V=None, VI=None):
 
        Computes the Bray-Curtis distance between the points. The
        Bray-Curtis distance between two points ``u`` and ``v`` is
+
        .. math::
             d(u,v) = \\frac{\\sum_i {|u_i-v_i|}}
                            {\\sum_i {|u_i+v_i|}}
@@ -1392,15 +1404,20 @@ def pdist(X, metric='euclidean', p=2, w=None, V=None, VI=None):
        using the user supplied 2-arity function f. For example,
        Euclidean distance between the vectors could be computed
        as follows::
+
          dm = pdist(X, lambda u, v: np.sqrt(((u-v)**2).sum()))
+
        Note that you should avoid passing a reference to one of
        the distance functions defined in this library. For example,::
+
          dm = pdist(X, sokalsneath)
+
        would calculate the pair-wise distances between the vectors in
        X using the Python function sokalsneath. This would result in
        sokalsneath being called :math:`{n \\choose 2}` times, which
        is inefficient. Instead, the optimized C version is more
        efficient, and we call it using the following syntax.::
+
          dm = pdist(X, 'sokalsneath')
     """
     # You can also call this as:
@@ -1881,6 +1898,7 @@ def cdist(XA, XB, metric='euclidean', p=2, V=None, VI=None, w=None):
     """
     Computes distance between each pair of the two collections of inputs.
     See Notes for common calling conventions.
+
     Parameters
     ----------
     XA : ndarray
@@ -1906,6 +1924,7 @@ def cdist(XA, XB, metric='euclidean', p=2, V=None, VI=None, w=None):
         The variance vector (for standardized Euclidean).
     VI : ndarray, optional
         The inverse of the covariance matrix (for Mahalanobis).
+
     Returns
     -------
     Y : ndarray
@@ -1913,126 +1932,187 @@ def cdist(XA, XB, metric='euclidean', p=2, V=None, VI=None, w=None):
         For each :math:`i` and :math:`j`, the metric
         ``dist(u=XA[i], v=XB[j])`` is computed and stored in the
         :math:`ij` th entry.
+
     Raises
     ------
     ValueError
         An exception is thrown if `XA` and `XB` do not have
         the same number of columns.
+
     Notes
     -----
     The following are common calling conventions:
     1. ``Y = cdist(XA, XB, 'euclidean')``
+
        Computes the distance between :math:`m` points using
        Euclidean distance (2-norm) as the distance metric between the
        points. The points are arranged as :math:`m`
        :math:`n`-dimensional row vectors in the matrix X.
+
     2. ``Y = cdist(XA, XB, 'minkowski', p)``
+
        Computes the distances using the Minkowski distance
        :math:`||u-v||_p` (:math:`p`-norm) where :math:`p \\geq 1`.
+
     3. ``Y = cdist(XA, XB, 'cityblock')``
+
        Computes the city block or Manhattan distance between the
        points.
+
     4. ``Y = cdist(XA, XB, 'seuclidean', V=None)``
+
        Computes the standardized Euclidean distance. The standardized
        Euclidean distance between two n-vectors ``u`` and ``v`` is
+
        .. math::
           \\sqrt{\\sum {(u_i-v_i)^2 / V[x_i]}}.
+
        V is the variance vector; V[i] is the variance computed over all
        the i'th components of the points. If not passed, it is
        automatically computed.
+
     5. ``Y = cdist(XA, XB, 'sqeuclidean')``
+
        Computes the squared Euclidean distance :math:`||u-v||_2^2` between
        the vectors.
+
     6. ``Y = cdist(XA, XB, 'cosine')``
+
        Computes the cosine distance between vectors u and v,
+
        .. math::
           1 - \\frac{u \\cdot v}
                    {{||u||}_2 {||v||}_2}
+
        where :math:`||*||_2` is the 2-norm of its argument ``*``, and
        :math:`u \\cdot v` is the dot product of :math:`u` and :math:`v`.
+
     7. ``Y = cdist(XA, XB, 'correlation')``
+
        Computes the correlation distance between vectors u and v. This is
+
        .. math::
           1 - \\frac{(u - \\bar{u}) \\cdot (v - \\bar{v})}
                    {{||(u - \\bar{u})||}_2 {||(v - \\bar{v})||}_2}
+
        where :math:`\\bar{v}` is the mean of the elements of vector v,
        and :math:`x \\cdot y` is the dot product of :math:`x` and :math:`y`.
+
     8. ``Y = cdist(XA, XB, 'hamming')``
+
        Computes the normalized Hamming distance, or the proportion of
        those vector elements between two n-vectors ``u`` and ``v``
        which disagree. To save memory, the matrix ``X`` can be of type
        boolean.
+
     9. ``Y = cdist(XA, XB, 'jaccard')``
+
        Computes the Jaccard distance between the points. Given two
        vectors, ``u`` and ``v``, the Jaccard distance is the
        proportion of those elements ``u[i]`` and ``v[i]`` that
        disagree where at least one of them is non-zero.
+
     10. ``Y = cdist(XA, XB, 'chebyshev')``
        Computes the Chebyshev distance between the points. The
        Chebyshev distance between two n-vectors ``u`` and ``v`` is the
        maximum norm-1 distance between their respective elements. More
        precisely, the distance is given by
+
        .. math::
           d(u,v) = \\max_i {|u_i-v_i|}.
+
     11. ``Y = cdist(XA, XB, 'canberra')``
+
        Computes the Canberra distance between the points. The
        Canberra distance between two points ``u`` and ``v`` is
+
        .. math::
          d(u,v) = \\sum_i \\frac{|u_i-v_i|}
                               {|u_i|+|v_i|}.
+
     12. ``Y = cdist(XA, XB, 'braycurtis')``
+
        Computes the Bray-Curtis distance between the points. The
        Bray-Curtis distance between two points ``u`` and ``v`` is
+
        .. math::
             d(u,v) = \\frac{\\sum_i (|u_i-v_i|)}
                           {\\sum_i (|u_i+v_i|)}
+
     13. ``Y = cdist(XA, XB, 'mahalanobis', VI=None)``
+
        Computes the Mahalanobis distance between the points. The
        Mahalanobis distance between two points ``u`` and ``v`` is
        :math:`\\sqrt{(u-v)(1/V)(u-v)^T}` where :math:`(1/V)` (the ``VI``
        variable) is the inverse covariance. If ``VI`` is not None,
        ``VI`` will be used as the inverse covariance matrix.
+
     14. ``Y = cdist(XA, XB, 'yule')``
+
        Computes the Yule distance between the boolean
        vectors. (see `yule` function documentation)
+
     15. ``Y = cdist(XA, XB, 'matching')``
+
        Synonym for 'hamming'.
+
     16. ``Y = cdist(XA, XB, 'dice')``
+
        Computes the Dice distance between the boolean vectors. (see
        `dice` function documentation)
+
     17. ``Y = cdist(XA, XB, 'kulsinski')``
+
        Computes the Kulsinski distance between the boolean
        vectors. (see `kulsinski` function documentation)
+
     18. ``Y = cdist(XA, XB, 'rogerstanimoto')``
+
        Computes the Rogers-Tanimoto distance between the boolean
        vectors. (see `rogerstanimoto` function documentation)
+
     19. ``Y = cdist(XA, XB, 'russellrao')``
+
        Computes the Russell-Rao distance between the boolean
        vectors. (see `russellrao` function documentation)
+
     20. ``Y = cdist(XA, XB, 'sokalmichener')``
+
        Computes the Sokal-Michener distance between the boolean
        vectors. (see `sokalmichener` function documentation)
+
     21. ``Y = cdist(XA, XB, 'sokalsneath')``
+
        Computes the Sokal-Sneath distance between the vectors. (see
        `sokalsneath` function documentation)
+
     22. ``Y = cdist(XA, XB, 'wminkowski')``
+
        Computes the weighted Minkowski distance between the
        vectors. (see `wminkowski` function documentation)
+
     23. ``Y = cdist(XA, XB, f)``
+
        Computes the distance between all pairs of vectors in X
        using the user supplied 2-arity function f. For example,
        Euclidean distance between the vectors could be computed
        as follows::
+
          dm = cdist(XA, XB, lambda u, v: np.sqrt(((u-v)**2).sum()))
+
        Note that you should avoid passing a reference to one of
        the distance functions defined in this library. For example,::
+
          dm = cdist(XA, XB, sokalsneath)
+
        would calculate the pair-wise distances between the vectors in
        X using the Python function `sokalsneath`. This would result in
        sokalsneath being called :math:`{n \\choose 2}` times, which
        is inefficient. Instead, the optimized C version is more
        efficient, and we call it using the following syntax::
+
          dm = cdist(XA, XB, 'sokalsneath')
+
     Examples
     --------
     Find the Euclidean distances between four 2-D coordinates:
@@ -2046,6 +2126,7 @@ def cdist(XA, XB, metric='euclidean', p=2, V=None, VI=None, w=None):
            [ 4.7044,  0.    ,  6.0893,  3.3561],
            [ 1.6172,  6.0893,  0.    ,  2.8477],
            [ 1.8856,  3.3561,  2.8477,  0.    ]])
+
     Find the Manhattan distance from a 3-D point to the corners of the unit
     cube:
     >>> a = np.array([[0, 0, 0],

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -208,10 +208,12 @@ def directed_hausdorff(u, v, seed=0):
     2.23606797749979
     >>> directed_hausdorff(v, u)[0]
     3.0
+
     Find the general (symmetric) Hausdorff distance between two 2-D
     arrays of coordinates:
     >>> max(directed_hausdorff(u, v)[0], directed_hausdorff(v, u)[0])
     3.0
+
     Find the indices of the points that generate the Hausdorff distance
     (the Hausdorff pair):
     >>> directed_hausdorff(v, u)[1:]
@@ -346,7 +348,7 @@ def sqeuclidean(u, v, w=None):
     u = _validate_vector(u, dtype=utype)
     v = _validate_vector(v, dtype=vtype)
     u_v = u - v
-    u_v_w = u_v # only want weights applied once
+    u_v_w = u_v  # only want weights applied once
     if w is not None:
         w = _validate_vector(w)
         u_v_w = w * u_v
@@ -564,7 +566,7 @@ def kulsinski(u, v, w=None):
     return (ntf + nft - ntt + n) / (ntf + nft + n)
 
 
-def seuclidean(u, v, V): # replace with euclidian -- w = 1/V?
+def seuclidean(u, v, V):
     """
     Returns the standardized Euclidean distance between two 1-D arrays.
 
@@ -1397,7 +1399,7 @@ def pdist(X, metric='euclidean', p=2, w=None, V=None, VI=None):
 
     if callable(metric):
         dfun = metric
-        if p != 2: # if not default
+        if p != 2:  # if not default
             dfun = partial(dfun, p=p)
         if w is not None:
             dfun = partial(dfun, w=w)
@@ -1522,10 +1524,10 @@ def pdist(X, metric='euclidean', p=2, w=None, V=None, VI=None):
                             'test_russellrao': russellrao,
                             'test_sokalsneath': sokalsneath,
                             'test_sokalmichener': sokalmichener,
-                           }
+                            }
             if mstr in test_metrics:
                 dfun = test_metrics[mstr]
-                if p != 2: # if not default
+                if p != 2:  # if not default
                     dfun = partial(dfun, p=p)
                 if w is not None:
                     dfun = partial(dfun, w=w)
@@ -2200,7 +2202,6 @@ def cdist(XA, XB, metric='euclidean', p=2, V=None, VI=None, w=None):
                 raise ValueError("metric %s incompatible with weights" % mstr)
             mstr = "test_%s" % mstr
 
-
         try:
             validate, cdist_fn = _SIMPLE_CDIST[mstr]
             XA = validate(XA)
@@ -2310,10 +2311,10 @@ def cdist(XA, XB, metric='euclidean', p=2, V=None, VI=None, w=None):
                             'test_sokalsneath': sokalsneath,
                             'test_sokalmichener': sokalmichener,
                             'test_sqeuclidean': sqeuclidean,
-                           }
+                            }
             if mstr in test_metrics:
                 dfun = test_metrics[mstr]
-                if p != 2: # non-default
+                if p != 2:  # non-default
                     dfun = partial(dfun, p=p)
                 if w is not None:
                     dfun = partial(dfun, w=w)

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -1145,7 +1145,7 @@ def sokalsneath(u, v, w=None):
     denom = ntt + 2.0 * (ntf + nft)
     if denom == 0:
         raise ValueError('Sokal-Sneath dissimilarity is not defined for '
-                            'vectors that are entirely false.')
+                         'vectors that are entirely false.')
     return float(2.0 * (ntf + nft)) / denom
 
 
@@ -2202,8 +2202,8 @@ def cdist(XA, XB, metric='euclidean', p=2, V=None, VI=None, w=None):
     XB = np.asarray(XB, order='c')
 
     # The C code doesn't do striding.
-    XA = _copy_array_if_base_present(_convert_to_double(XA))
-    XB = _copy_array_if_base_present(_convert_to_double(XB))
+    XA = _copy_array_if_base_present(XA)
+    XB = _copy_array_if_base_present(XB)
 
     s = XA.shape
     sB = XB.shape

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -49,7 +49,6 @@ functions. Use ``pdist`` for this purpose.
    minkowski        -- the Minkowski distance.
    seuclidean       -- the normalized Euclidean distance.
    sqeuclidean      -- the squared Euclidean distance.
-   wminkowski       -- the weighted Minkowski distance.
 
 Distance functions between two boolean vectors (representing sets) ``u`` and
 ``v``.  As in the case of numerical vectors, ``pdist`` is more efficient for
@@ -62,7 +61,6 @@ computing the distances between all pairs.
    hamming          -- the Hamming distance.
    jaccard          -- the Jaccard distance.
    kulsinski        -- the Kulsinski distance.
-   matching         -- the matching dissimilarity.
    rogerstanimoto   -- the Rogers-Tanimoto dissimilarity.
    russellrao       -- the Russell-Rao dissimilarity.
    sokalmichener    -- the Sokal-Michener dissimilarity.

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -222,7 +222,7 @@ def directed_hausdorff(u, v, seed=0):
     Find the directed Hausdorff distance between two 2-D arrays of
     coordinates:
     >>> from scipy.spatial.distance import directed_hausdorff
-    >>> u = np.array([(1.0, 0.0),
+    >>> u = np.array([( 0, 0.0),
     ...               (0.0, 1.0),
     ...               (-1.0, 0.0),
     ...               (0.0, -1.0)])
@@ -1225,6 +1225,7 @@ def pdist(X, metric='euclidean', p=2, w=None, V=None, VI=None):
         The variance vector (for standardized Euclidean).
     VI : ndarray, optional
         The inverse of the covariance matrix (for Mahalanobis).
+
     Returns
     -------
     Y : ndarray
@@ -1232,27 +1233,37 @@ def pdist(X, metric='euclidean', p=2, w=None, V=None, VI=None):
         each :math:`i` and :math:`j` (where :math:`i<j<m`),where m is the number
         of original observations. The metric ``dist(u=X[i], v=X[j])``
         is computed and stored in entry ``ij``.
+
     See Also
     --------
     squareform : converts between condensed distance matrices and
                  square distance matrices.
+
     Notes
     -----
     See ``squareform`` for information on how to calculate the index of
     this entry or to convert the condensed distance matrix to a
     redundant square matrix.
     The following are common calling conventions.
+
     1. ``Y = pdist(X, 'euclidean')``
+
        Computes the distance between m points using Euclidean distance
        (2-norm) as the distance metric between the points. The points
        are arranged as m n-dimensional row vectors in the matrix X.
+
     2. ``Y = pdist(X, 'minkowski', p)``
+
        Computes the distances using the Minkowski distance
        :math:`||u-v||_p` (p-norm) where :math:`p \\geq 1`.
+
     3. ``Y = pdist(X, 'cityblock')``
+
        Computes the city block or Manhattan distance between the
        points.
+
     4. ``Y = pdist(X, 'seuclidean', V=None)``
+
        Computes the standardized Euclidean distance. The standardized
        Euclidean distance between two n-vectors ``u`` and ``v`` is
        .. math::
@@ -1260,85 +1271,123 @@ def pdist(X, metric='euclidean', p=2, w=None, V=None, VI=None):
        V is the variance vector; V[i] is the variance computed over all
        the i'th components of the points.  If not passed, it is
        automatically computed.
+
     5. ``Y = pdist(X, 'sqeuclidean')``
+
        Computes the squared Euclidean distance :math:`||u-v||_2^2` between
        the vectors.
+
     6. ``Y = pdist(X, 'cosine')``
+
        Computes the cosine distance between vectors u and v,
        .. math::
           1 - \\frac{u \\cdot v}
                    {{||u||}_2 {||v||}_2}
        where :math:`||*||_2` is the 2-norm of its argument ``*``, and
        :math:`u \\cdot v` is the dot product of ``u`` and ``v``.
+
     7. ``Y = pdist(X, 'correlation')``
+
        Computes the correlation distance between vectors u and v. This is
        .. math::
           1 - \\frac{(u - \\bar{u}) \\cdot (v - \\bar{v})}
                    {{||(u - \\bar{u})||}_2 {||(v - \\bar{v})||}_2}
        where :math:`\\bar{v}` is the mean of the elements of vector v,
        and :math:`x \\cdot y` is the dot product of :math:`x` and :math:`y`.
+
     8. ``Y = pdist(X, 'hamming')``
+
        Computes the normalized Hamming distance, or the proportion of
        those vector elements between two n-vectors ``u`` and ``v``
        which disagree. To save memory, the matrix ``X`` can be of type
        boolean.
+
     9. ``Y = pdist(X, 'jaccard')``
+
        Computes the Jaccard distance between the points. Given two
        vectors, ``u`` and ``v``, the Jaccard distance is the
        proportion of those elements ``u[i]`` and ``v[i]`` that
        disagree.
+
     10. ``Y = pdist(X, 'chebyshev')``
+
        Computes the Chebyshev distance between the points. The
        Chebyshev distance between two n-vectors ``u`` and ``v`` is the
        maximum norm-1 distance between their respective elements. More
        precisely, the distance is given by
        .. math::
           d(u,v) = \\max_i {|u_i-v_i|}
+
     11. ``Y = pdist(X, 'canberra')``
+
        Computes the Canberra distance between the points. The
        Canberra distance between two points ``u`` and ``v`` is
        .. math::
          d(u,v) = \\sum_i \\frac{|u_i-v_i|}
                               {|u_i|+|v_i|}
+
     12. ``Y = pdist(X, 'braycurtis')``
+
        Computes the Bray-Curtis distance between the points. The
        Bray-Curtis distance between two points ``u`` and ``v`` is
        .. math::
             d(u,v) = \\frac{\\sum_i {|u_i-v_i|}}
                            {\\sum_i {|u_i+v_i|}}
+
     13. ``Y = pdist(X, 'mahalanobis', VI=None)``
+
        Computes the Mahalanobis distance between the points. The
        Mahalanobis distance between two points ``u`` and ``v`` is
        :math:`\\sqrt{(u-v)(1/V)(u-v)^T}` where :math:`(1/V)` (the ``VI``
        variable) is the inverse covariance. If ``VI`` is not None,
        ``VI`` will be used as the inverse covariance matrix.
+
     14. ``Y = pdist(X, 'yule')``
+
        Computes the Yule distance between each pair of boolean
        vectors. (see yule function documentation)
+
     15. ``Y = pdist(X, 'matching')``
+
        Synonym for 'hamming'.
+
     16. ``Y = pdist(X, 'dice')``
+
        Computes the Dice distance between each pair of boolean
        vectors. (see dice function documentation)
+
     17. ``Y = pdist(X, 'kulsinski')``
+
        Computes the Kulsinski distance between each pair of
        boolean vectors. (see kulsinski function documentation)
+
     18. ``Y = pdist(X, 'rogerstanimoto')``
+
        Computes the Rogers-Tanimoto distance between each pair of
        boolean vectors. (see rogerstanimoto function documentation)
+
     19. ``Y = pdist(X, 'russellrao')``
+
        Computes the Russell-Rao distance between each pair of
        boolean vectors. (see russellrao function documentation)
+
     20. ``Y = pdist(X, 'sokalmichener')``
+
        Computes the Sokal-Michener distance between each pair of
        boolean vectors. (see sokalmichener function documentation)
+
     21. ``Y = pdist(X, 'sokalsneath')``
+
        Computes the Sokal-Sneath distance between each pair of
        boolean vectors. (see sokalsneath function documentation)
+
     22. ``Y = pdist(X, 'wminkowski')``
+
        Computes the weighted Minkowski distance between each pair of
        vectors. (see wminkowski function documentation)
+
     23. ``Y = pdist(X, f)``
+    
        Computes the distance between all pairs of vectors in X
        using the user supplied 2-arity function f. For example,
        Euclidean distance between the vectors could be computed

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -1176,193 +1176,35 @@ for wrap_name, names, typ in [
         _SIMPLE_CDIST[name] = converter, cdist_fn
         _SIMPLE_PDIST[name] = converter, pdist_fn
 
+_TEST_METRICS = {'test_euclidean': euclidean,
+                 'test_braycurtis': braycurtis,
+                 'test_canberra': canberra,
+                 'test_cityblock': cityblock,
+                 'test_minkowski': minkowski,
+                 'test_wminkowski': wminkowski,
+                 'test_cosine': cosine,
+                 'test_correlation': correlation,
+                 'test_hamming': hamming,
+                 'test_jaccard': jaccard,
+                 'test_chebyshev': chebyshev,
+                 'test_chebychev': chebyshev,
+                 'test_yule': yule,
+                 'test_matching': hamming,
+                 'test_dice': dice,
+                 'test_kulsinski': kulsinski,
+                 'test_rogerstanimoto': rogerstanimoto,
+                 'test_russellrao': russellrao,
+                 'test_sokalsneath': sokalsneath,
+                 'test_sokalmichener': sokalmichener,
+                 'test_sqeuclidean': sqeuclidean,
+                 'test_seuclidean': seuclidean,
+                 'test_mahalanobis': mahalanobis,
+                 }
 
 def pdist(X, metric='euclidean', p=2, w=None, V=None, VI=None):
     """
     Pairwise distances between observations in n-dimensional space.
-
-    The following are common calling conventions.
-
-    1. ``Y = pdist(X, 'euclidean')``
-
-       Computes the distance between m points using Euclidean distance
-       (2-norm) as the distance metric between the points. The points
-       are arranged as m n-dimensional row vectors in the matrix X.
-
-    2. ``Y = pdist(X, 'minkowski', p)``
-
-       Computes the distances using the Minkowski distance
-       :math:`||u-v||_p` (p-norm) where :math:`p \\geq 1`.
-
-    3. ``Y = pdist(X, 'cityblock')``
-
-       Computes the city block or Manhattan distance between the
-       points.
-
-    4. ``Y = pdist(X, 'seuclidean', V=None)``
-
-       Computes the standardized Euclidean distance. The standardized
-       Euclidean distance between two n-vectors ``u`` and ``v`` is
-
-       .. math::
-
-          \\sqrt{\\sum {(u_i-v_i)^2 / V[x_i]}}
-
-
-       V is the variance vector; V[i] is the variance computed over all
-       the i'th components of the points.  If not passed, it is
-       automatically computed.
-
-    5. ``Y = pdist(X, 'sqeuclidean')``
-
-       Computes the squared Euclidean distance :math:`||u-v||_2^2` between
-       the vectors.
-
-    6. ``Y = pdist(X, 'cosine')``
-
-       Computes the cosine distance between vectors u and v,
-
-       .. math::
-
-          1 - \\frac{u \\cdot v}
-                   {{||u||}_2 {||v||}_2}
-
-       where :math:`||*||_2` is the 2-norm of its argument ``*``, and
-       :math:`u \\cdot v` is the dot product of ``u`` and ``v``.
-
-    7. ``Y = pdist(X, 'correlation')``
-
-       Computes the correlation distance between vectors u and v. This is
-
-       .. math::
-
-          1 - \\frac{(u - \\bar{u}) \\cdot (v - \\bar{v})}
-                   {{||(u - \\bar{u})||}_2 {||(v - \\bar{v})||}_2}
-
-       where :math:`\\bar{v}` is the mean of the elements of vector v,
-       and :math:`x \\cdot y` is the dot product of :math:`x` and :math:`y`.
-
-    8. ``Y = pdist(X, 'hamming')``
-
-       Computes the normalized Hamming distance, or the proportion of
-       those vector elements between two n-vectors ``u`` and ``v``
-       which disagree. To save memory, the matrix ``X`` can be of type
-       boolean.
-
-    9. ``Y = pdist(X, 'jaccard')``
-
-       Computes the Jaccard distance between the points. Given two
-       vectors, ``u`` and ``v``, the Jaccard distance is the
-       proportion of those elements ``u[i]`` and ``v[i]`` that
-       disagree.
-
-    10. ``Y = pdist(X, 'chebyshev')``
-
-       Computes the Chebyshev distance between the points. The
-       Chebyshev distance between two n-vectors ``u`` and ``v`` is the
-       maximum norm-1 distance between their respective elements. More
-       precisely, the distance is given by
-
-       .. math::
-
-          d(u,v) = \\max_i {|u_i-v_i|}
-
-    11. ``Y = pdist(X, 'canberra')``
-
-       Computes the Canberra distance between the points. The
-       Canberra distance between two points ``u`` and ``v`` is
-
-       .. math::
-
-         d(u,v) = \\sum_i \\frac{|u_i-v_i|}
-                              {|u_i|+|v_i|}
-
-
-    12. ``Y = pdist(X, 'braycurtis')``
-
-       Computes the Bray-Curtis distance between the points. The
-       Bray-Curtis distance between two points ``u`` and ``v`` is
-
-
-       .. math::
-
-            d(u,v) = \\frac{\\sum_i {|u_i-v_i|}}
-                           {\\sum_i {|u_i+v_i|}}
-
-    13. ``Y = pdist(X, 'mahalanobis', VI=None)``
-
-       Computes the Mahalanobis distance between the points. The
-       Mahalanobis distance between two points ``u`` and ``v`` is
-       :math:`\\sqrt{(u-v)(1/V)(u-v)^T}` where :math:`(1/V)` (the ``VI``
-       variable) is the inverse covariance. If ``VI`` is not None,
-       ``VI`` will be used as the inverse covariance matrix.
-
-    14. ``Y = pdist(X, 'yule')``
-
-       Computes the Yule distance between each pair of boolean
-       vectors. (see yule function documentation)
-
-    15. ``Y = pdist(X, 'matching')``
-
-       Synonym for 'hamming'.
-
-    16. ``Y = pdist(X, 'dice')``
-
-       Computes the Dice distance between each pair of boolean
-       vectors. (see dice function documentation)
-
-    17. ``Y = pdist(X, 'kulsinski')``
-
-       Computes the Kulsinski distance between each pair of
-       boolean vectors. (see kulsinski function documentation)
-
-    18. ``Y = pdist(X, 'rogerstanimoto')``
-
-       Computes the Rogers-Tanimoto distance between each pair of
-       boolean vectors. (see rogerstanimoto function documentation)
-
-    19. ``Y = pdist(X, 'russellrao')``
-
-       Computes the Russell-Rao distance between each pair of
-       boolean vectors. (see russellrao function documentation)
-
-    20. ``Y = pdist(X, 'sokalmichener')``
-
-       Computes the Sokal-Michener distance between each pair of
-       boolean vectors. (see sokalmichener function documentation)
-
-    21. ``Y = pdist(X, 'sokalsneath')``
-
-       Computes the Sokal-Sneath distance between each pair of
-       boolean vectors. (see sokalsneath function documentation)
-
-    22. ``Y = pdist(X, 'wminkowski')``
-
-       Computes the weighted Minkowski distance between each pair of
-       vectors. (see wminkowski function documentation)
-
-    23. ``Y = pdist(X, f)``
-
-       Computes the distance between all pairs of vectors in X
-       using the user supplied 2-arity function f. For example,
-       Euclidean distance between the vectors could be computed
-       as follows::
-
-         dm = pdist(X, lambda u, v: np.sqrt(((u-v)**2).sum()))
-
-       Note that you should avoid passing a reference to one of
-       the distance functions defined in this library. For example,::
-
-         dm = pdist(X, sokalsneath)
-
-       would calculate the pair-wise distances between the vectors in
-       X using the Python function sokalsneath. This would result in
-       sokalsneath being called :math:`{n \\choose 2}` times, which
-       is inefficient. Instead, the optimized C version is more
-       efficient, and we call it using the following syntax.::
-
-         dm = pdist(X, 'sokalsneath')
-
+    See Notes for common calling conventions.
     Parameters
     ----------
     X : ndarray
@@ -1383,25 +1225,134 @@ def pdist(X, metric='euclidean', p=2, w=None, V=None, VI=None):
         The variance vector (for standardized Euclidean).
     VI : ndarray, optional
         The inverse of the covariance matrix (for Mahalanobis).
-
     Returns
     -------
     Y : ndarray
         Returns a condensed distance matrix Y.  For
-        each :math:`i` and :math:`j` (where :math:`i<j<n`), the
-        metric ``dist(u=X[i], v=X[j])`` is computed and stored in entry ``ij``.
-
+        each :math:`i` and :math:`j` (where :math:`i<j<m`),where m is the number
+        of original observations. The metric ``dist(u=X[i], v=X[j])``
+        is computed and stored in entry ``ij``.
     See Also
     --------
     squareform : converts between condensed distance matrices and
                  square distance matrices.
-
     Notes
     -----
     See ``squareform`` for information on how to calculate the index of
     this entry or to convert the condensed distance matrix to a
     redundant square matrix.
-
+    The following are common calling conventions.
+    1. ``Y = pdist(X, 'euclidean')``
+       Computes the distance between m points using Euclidean distance
+       (2-norm) as the distance metric between the points. The points
+       are arranged as m n-dimensional row vectors in the matrix X.
+    2. ``Y = pdist(X, 'minkowski', p)``
+       Computes the distances using the Minkowski distance
+       :math:`||u-v||_p` (p-norm) where :math:`p \\geq 1`.
+    3. ``Y = pdist(X, 'cityblock')``
+       Computes the city block or Manhattan distance between the
+       points.
+    4. ``Y = pdist(X, 'seuclidean', V=None)``
+       Computes the standardized Euclidean distance. The standardized
+       Euclidean distance between two n-vectors ``u`` and ``v`` is
+       .. math::
+          \\sqrt{\\sum {(u_i-v_i)^2 / V[x_i]}}
+       V is the variance vector; V[i] is the variance computed over all
+       the i'th components of the points.  If not passed, it is
+       automatically computed.
+    5. ``Y = pdist(X, 'sqeuclidean')``
+       Computes the squared Euclidean distance :math:`||u-v||_2^2` between
+       the vectors.
+    6. ``Y = pdist(X, 'cosine')``
+       Computes the cosine distance between vectors u and v,
+       .. math::
+          1 - \\frac{u \\cdot v}
+                   {{||u||}_2 {||v||}_2}
+       where :math:`||*||_2` is the 2-norm of its argument ``*``, and
+       :math:`u \\cdot v` is the dot product of ``u`` and ``v``.
+    7. ``Y = pdist(X, 'correlation')``
+       Computes the correlation distance between vectors u and v. This is
+       .. math::
+          1 - \\frac{(u - \\bar{u}) \\cdot (v - \\bar{v})}
+                   {{||(u - \\bar{u})||}_2 {||(v - \\bar{v})||}_2}
+       where :math:`\\bar{v}` is the mean of the elements of vector v,
+       and :math:`x \\cdot y` is the dot product of :math:`x` and :math:`y`.
+    8. ``Y = pdist(X, 'hamming')``
+       Computes the normalized Hamming distance, or the proportion of
+       those vector elements between two n-vectors ``u`` and ``v``
+       which disagree. To save memory, the matrix ``X`` can be of type
+       boolean.
+    9. ``Y = pdist(X, 'jaccard')``
+       Computes the Jaccard distance between the points. Given two
+       vectors, ``u`` and ``v``, the Jaccard distance is the
+       proportion of those elements ``u[i]`` and ``v[i]`` that
+       disagree.
+    10. ``Y = pdist(X, 'chebyshev')``
+       Computes the Chebyshev distance between the points. The
+       Chebyshev distance between two n-vectors ``u`` and ``v`` is the
+       maximum norm-1 distance between their respective elements. More
+       precisely, the distance is given by
+       .. math::
+          d(u,v) = \\max_i {|u_i-v_i|}
+    11. ``Y = pdist(X, 'canberra')``
+       Computes the Canberra distance between the points. The
+       Canberra distance between two points ``u`` and ``v`` is
+       .. math::
+         d(u,v) = \\sum_i \\frac{|u_i-v_i|}
+                              {|u_i|+|v_i|}
+    12. ``Y = pdist(X, 'braycurtis')``
+       Computes the Bray-Curtis distance between the points. The
+       Bray-Curtis distance between two points ``u`` and ``v`` is
+       .. math::
+            d(u,v) = \\frac{\\sum_i {|u_i-v_i|}}
+                           {\\sum_i {|u_i+v_i|}}
+    13. ``Y = pdist(X, 'mahalanobis', VI=None)``
+       Computes the Mahalanobis distance between the points. The
+       Mahalanobis distance between two points ``u`` and ``v`` is
+       :math:`\\sqrt{(u-v)(1/V)(u-v)^T}` where :math:`(1/V)` (the ``VI``
+       variable) is the inverse covariance. If ``VI`` is not None,
+       ``VI`` will be used as the inverse covariance matrix.
+    14. ``Y = pdist(X, 'yule')``
+       Computes the Yule distance between each pair of boolean
+       vectors. (see yule function documentation)
+    15. ``Y = pdist(X, 'matching')``
+       Synonym for 'hamming'.
+    16. ``Y = pdist(X, 'dice')``
+       Computes the Dice distance between each pair of boolean
+       vectors. (see dice function documentation)
+    17. ``Y = pdist(X, 'kulsinski')``
+       Computes the Kulsinski distance between each pair of
+       boolean vectors. (see kulsinski function documentation)
+    18. ``Y = pdist(X, 'rogerstanimoto')``
+       Computes the Rogers-Tanimoto distance between each pair of
+       boolean vectors. (see rogerstanimoto function documentation)
+    19. ``Y = pdist(X, 'russellrao')``
+       Computes the Russell-Rao distance between each pair of
+       boolean vectors. (see russellrao function documentation)
+    20. ``Y = pdist(X, 'sokalmichener')``
+       Computes the Sokal-Michener distance between each pair of
+       boolean vectors. (see sokalmichener function documentation)
+    21. ``Y = pdist(X, 'sokalsneath')``
+       Computes the Sokal-Sneath distance between each pair of
+       boolean vectors. (see sokalsneath function documentation)
+    22. ``Y = pdist(X, 'wminkowski')``
+       Computes the weighted Minkowski distance between each pair of
+       vectors. (see wminkowski function documentation)
+    23. ``Y = pdist(X, f)``
+       Computes the distance between all pairs of vectors in X
+       using the user supplied 2-arity function f. For example,
+       Euclidean distance between the vectors could be computed
+       as follows::
+         dm = pdist(X, lambda u, v: np.sqrt(((u-v)**2).sum()))
+       Note that you should avoid passing a reference to one of
+       the distance functions defined in this library. For example,::
+         dm = pdist(X, sokalsneath)
+       would calculate the pair-wise distances between the vectors in
+       X using the Python function sokalsneath. This would result in
+       sokalsneath being called :math:`{n \\choose 2}` times, which
+       is inefficient. Instead, the optimized C version is more
+       efficient, and we call it using the following syntax.::
+         dm = pdist(X, 'sokalsneath')
     """
     # You can also call this as:
     #     Y = pdist(X, 'test_abc')
@@ -1468,6 +1419,7 @@ def pdist(X, metric='euclidean', p=2, w=None, V=None, VI=None):
         if w is not None and not mstr.startswith("test_"):
             if mstr in ['seuclidean', 'se', 's', 'mahalanobis']:
                 raise ValueError("metric %s incompatible with weights" % mstr)
+            # need to use python version for weighting
             mstr = "test_%s" % mstr
 
         try:
@@ -1523,31 +1475,7 @@ def pdist(X, metric='euclidean', p=2, w=None, V=None, VI=None):
             X = _convert_to_double(X)
             _distance_wrap.pdist_mahalanobis_wrap(X, VI, dm)
         elif mstr.startswith("test_"):
-            test_metrics = {'test_euclidean': euclidean,
-                            'test_braycurtis': braycurtis,
-                            'test_canberra': canberra,
-                            'test_cityblock': cityblock,
-                            'test_minkowski': minkowski,
-                            'test_wminkowski': wminkowski,
-                            'test_cosine': cosine,
-                            'test_correlation': correlation,
-                            'test_hamming': hamming,
-                            'test_jaccard': jaccard,
-                            'test_chebyshev': chebyshev,
-                            'test_chebychev': chebyshev,
-                            'test_yule': yule,
-                            'test_matching': hamming,
-                            'test_dice': dice,
-                            'test_kulsinski': kulsinski,
-                            'test_rogerstanimoto': rogerstanimoto,
-                            'test_russellrao': russellrao,
-                            'test_sokalsneath': sokalsneath,
-                            'test_sokalmichener': sokalmichener,
-                            'test_sqeuclidean': sqeuclidean,
-                            'test_seuclidean': seuclidean,
-                            'test_mahalanobis': mahalanobis,
-                            }
-            if mstr in test_metrics:
+            if mstr in _TEST_METRICS:
                 pfun = pdist
                 if p != 2:  # if not default
                     pfun = partial(pfun, p=p)
@@ -1557,7 +1485,7 @@ def pdist(X, metric='euclidean', p=2, w=None, V=None, VI=None):
                     pfun = partial(pfun, V=V)
                 elif VI is not None:
                     pfun = partial(pfun, VI=VI)
-                dm = pfun(X, test_metrics[mstr])
+                dm = pfun(X, _TEST_METRICS[mstr])
             else:
                 raise ValueError('Unknown Distance Metric: %s' % mstr)
         else:
@@ -1903,190 +1831,7 @@ def _cosine_cdist(XA, XB, dm):
 def cdist(XA, XB, metric='euclidean', p=2, V=None, VI=None, w=None):
     """
     Computes distance between each pair of the two collections of inputs.
-
-    The following are common calling conventions:
-
-    1. ``Y = cdist(XA, XB, 'euclidean')``
-
-       Computes the distance between :math:`m` points using
-       Euclidean distance (2-norm) as the distance metric between the
-       points. The points are arranged as :math:`m`
-       :math:`n`-dimensional row vectors in the matrix X.
-
-    2. ``Y = cdist(XA, XB, 'minkowski', p)``
-
-       Computes the distances using the Minkowski distance
-       :math:`||u-v||_p` (:math:`p`-norm) where :math:`p \\geq 1`.
-
-    3. ``Y = cdist(XA, XB, 'cityblock')``
-
-       Computes the city block or Manhattan distance between the
-       points.
-
-    4. ``Y = cdist(XA, XB, 'seuclidean', V=None)``
-
-       Computes the standardized Euclidean distance. The standardized
-       Euclidean distance between two n-vectors ``u`` and ``v`` is
-
-       .. math::
-
-          \\sqrt{\\sum {(u_i-v_i)^2 / V[x_i]}}.
-
-       V is the variance vector; V[i] is the variance computed over all
-       the i'th components of the points. If not passed, it is
-       automatically computed.
-
-    5. ``Y = cdist(XA, XB, 'sqeuclidean')``
-
-       Computes the squared Euclidean distance :math:`||u-v||_2^2` between
-       the vectors.
-
-    6. ``Y = cdist(XA, XB, 'cosine')``
-
-       Computes the cosine distance between vectors u and v,
-
-       .. math::
-
-          1 - \\frac{u \\cdot v}
-                   {{||u||}_2 {||v||}_2}
-
-       where :math:`||*||_2` is the 2-norm of its argument ``*``, and
-       :math:`u \\cdot v` is the dot product of :math:`u` and :math:`v`.
-
-    7. ``Y = cdist(XA, XB, 'correlation')``
-
-       Computes the correlation distance between vectors u and v. This is
-
-       .. math::
-
-          1 - \\frac{(u - \\bar{u}) \\cdot (v - \\bar{v})}
-                   {{||(u - \\bar{u})||}_2 {||(v - \\bar{v})||}_2}
-
-       where :math:`\\bar{v}` is the mean of the elements of vector v,
-       and :math:`x \\cdot y` is the dot product of :math:`x` and :math:`y`.
-
-
-    8. ``Y = cdist(XA, XB, 'hamming')``
-
-       Computes the normalized Hamming distance, or the proportion of
-       those vector elements between two n-vectors ``u`` and ``v``
-       which disagree. To save memory, the matrix ``X`` can be of type
-       boolean.
-
-    9. ``Y = cdist(XA, XB, 'jaccard')``
-
-       Computes the Jaccard distance between the points. Given two
-       vectors, ``u`` and ``v``, the Jaccard distance is the
-       proportion of those elements ``u[i]`` and ``v[i]`` that
-       disagree where at least one of them is non-zero.
-
-    10. ``Y = cdist(XA, XB, 'chebyshev')``
-
-       Computes the Chebyshev distance between the points. The
-       Chebyshev distance between two n-vectors ``u`` and ``v`` is the
-       maximum norm-1 distance between their respective elements. More
-       precisely, the distance is given by
-
-       .. math::
-
-          d(u,v) = \\max_i {|u_i-v_i|}.
-
-    11. ``Y = cdist(XA, XB, 'canberra')``
-
-       Computes the Canberra distance between the points. The
-       Canberra distance between two points ``u`` and ``v`` is
-
-       .. math::
-
-         d(u,v) = \\sum_i \\frac{|u_i-v_i|}
-                              {|u_i|+|v_i|}.
-
-    12. ``Y = cdist(XA, XB, 'braycurtis')``
-
-       Computes the Bray-Curtis distance between the points. The
-       Bray-Curtis distance between two points ``u`` and ``v`` is
-
-
-       .. math::
-
-            d(u,v) = \\frac{\\sum_i (|u_i-v_i|)}
-                          {\\sum_i (|u_i+v_i|)}
-
-    13. ``Y = cdist(XA, XB, 'mahalanobis', VI=None)``
-
-       Computes the Mahalanobis distance between the points. The
-       Mahalanobis distance between two points ``u`` and ``v`` is
-       :math:`\\sqrt{(u-v)(1/V)(u-v)^T}` where :math:`(1/V)` (the ``VI``
-       variable) is the inverse covariance. If ``VI`` is not None,
-       ``VI`` will be used as the inverse covariance matrix.
-
-    14. ``Y = cdist(XA, XB, 'yule')``
-
-       Computes the Yule distance between the boolean
-       vectors. (see `yule` function documentation)
-
-    15. ``Y = cdist(XA, XB, 'matching')``
-
-       Synonym for 'hamming'.
-
-    16. ``Y = cdist(XA, XB, 'dice')``
-
-       Computes the Dice distance between the boolean vectors. (see
-       `dice` function documentation)
-
-    17. ``Y = cdist(XA, XB, 'kulsinski')``
-
-       Computes the Kulsinski distance between the boolean
-       vectors. (see `kulsinski` function documentation)
-
-    18. ``Y = cdist(XA, XB, 'rogerstanimoto')``
-
-       Computes the Rogers-Tanimoto distance between the boolean
-       vectors. (see `rogerstanimoto` function documentation)
-
-    19. ``Y = cdist(XA, XB, 'russellrao')``
-
-       Computes the Russell-Rao distance between the boolean
-       vectors. (see `russellrao` function documentation)
-
-    20. ``Y = cdist(XA, XB, 'sokalmichener')``
-
-       Computes the Sokal-Michener distance between the boolean
-       vectors. (see `sokalmichener` function documentation)
-
-    21. ``Y = cdist(XA, XB, 'sokalsneath')``
-
-       Computes the Sokal-Sneath distance between the vectors. (see
-       `sokalsneath` function documentation)
-
-
-    22. ``Y = cdist(XA, XB, 'wminkowski')``
-
-       Computes the weighted Minkowski distance between the
-       vectors. (see `wminkowski` function documentation)
-
-    23. ``Y = cdist(XA, XB, f)``
-
-       Computes the distance between all pairs of vectors in X
-       using the user supplied 2-arity function f. For example,
-       Euclidean distance between the vectors could be computed
-       as follows::
-
-         dm = cdist(XA, XB, lambda u, v: np.sqrt(((u-v)**2).sum()))
-
-       Note that you should avoid passing a reference to one of
-       the distance functions defined in this library. For example,::
-
-         dm = cdist(XA, XB, sokalsneath)
-
-       would calculate the pair-wise distances between the vectors in
-       X using the Python function `sokalsneath`. This would result in
-       sokalsneath being called :math:`{n \\choose 2}` times, which
-       is inefficient. Instead, the optimized C version is more
-       efficient, and we call it using the following syntax::
-
-         dm = cdist(XA, XB, 'sokalsneath')
-
+    See Notes for common calling conventions.
     Parameters
     ----------
     XA : ndarray
@@ -2112,7 +1857,6 @@ def cdist(XA, XB, metric='euclidean', p=2, V=None, VI=None, w=None):
         The variance vector (for standardized Euclidean).
     VI : ndarray, optional
         The inverse of the covariance matrix (for Mahalanobis).
-
     Returns
     -------
     Y : ndarray
@@ -2120,17 +1864,129 @@ def cdist(XA, XB, metric='euclidean', p=2, V=None, VI=None, w=None):
         For each :math:`i` and :math:`j`, the metric
         ``dist(u=XA[i], v=XB[j])`` is computed and stored in the
         :math:`ij` th entry.
-
     Raises
     ------
     ValueError
         An exception is thrown if `XA` and `XB` do not have
         the same number of columns.
-
+    Notes
+    -----
+    The following are common calling conventions:
+    1. ``Y = cdist(XA, XB, 'euclidean')``
+       Computes the distance between :math:`m` points using
+       Euclidean distance (2-norm) as the distance metric between the
+       points. The points are arranged as :math:`m`
+       :math:`n`-dimensional row vectors in the matrix X.
+    2. ``Y = cdist(XA, XB, 'minkowski', p)``
+       Computes the distances using the Minkowski distance
+       :math:`||u-v||_p` (:math:`p`-norm) where :math:`p \\geq 1`.
+    3. ``Y = cdist(XA, XB, 'cityblock')``
+       Computes the city block or Manhattan distance between the
+       points.
+    4. ``Y = cdist(XA, XB, 'seuclidean', V=None)``
+       Computes the standardized Euclidean distance. The standardized
+       Euclidean distance between two n-vectors ``u`` and ``v`` is
+       .. math::
+          \\sqrt{\\sum {(u_i-v_i)^2 / V[x_i]}}.
+       V is the variance vector; V[i] is the variance computed over all
+       the i'th components of the points. If not passed, it is
+       automatically computed.
+    5. ``Y = cdist(XA, XB, 'sqeuclidean')``
+       Computes the squared Euclidean distance :math:`||u-v||_2^2` between
+       the vectors.
+    6. ``Y = cdist(XA, XB, 'cosine')``
+       Computes the cosine distance between vectors u and v,
+       .. math::
+          1 - \\frac{u \\cdot v}
+                   {{||u||}_2 {||v||}_2}
+       where :math:`||*||_2` is the 2-norm of its argument ``*``, and
+       :math:`u \\cdot v` is the dot product of :math:`u` and :math:`v`.
+    7. ``Y = cdist(XA, XB, 'correlation')``
+       Computes the correlation distance between vectors u and v. This is
+       .. math::
+          1 - \\frac{(u - \\bar{u}) \\cdot (v - \\bar{v})}
+                   {{||(u - \\bar{u})||}_2 {||(v - \\bar{v})||}_2}
+       where :math:`\\bar{v}` is the mean of the elements of vector v,
+       and :math:`x \\cdot y` is the dot product of :math:`x` and :math:`y`.
+    8. ``Y = cdist(XA, XB, 'hamming')``
+       Computes the normalized Hamming distance, or the proportion of
+       those vector elements between two n-vectors ``u`` and ``v``
+       which disagree. To save memory, the matrix ``X`` can be of type
+       boolean.
+    9. ``Y = cdist(XA, XB, 'jaccard')``
+       Computes the Jaccard distance between the points. Given two
+       vectors, ``u`` and ``v``, the Jaccard distance is the
+       proportion of those elements ``u[i]`` and ``v[i]`` that
+       disagree where at least one of them is non-zero.
+    10. ``Y = cdist(XA, XB, 'chebyshev')``
+       Computes the Chebyshev distance between the points. The
+       Chebyshev distance between two n-vectors ``u`` and ``v`` is the
+       maximum norm-1 distance between their respective elements. More
+       precisely, the distance is given by
+       .. math::
+          d(u,v) = \\max_i {|u_i-v_i|}.
+    11. ``Y = cdist(XA, XB, 'canberra')``
+       Computes the Canberra distance between the points. The
+       Canberra distance between two points ``u`` and ``v`` is
+       .. math::
+         d(u,v) = \\sum_i \\frac{|u_i-v_i|}
+                              {|u_i|+|v_i|}.
+    12. ``Y = cdist(XA, XB, 'braycurtis')``
+       Computes the Bray-Curtis distance between the points. The
+       Bray-Curtis distance between two points ``u`` and ``v`` is
+       .. math::
+            d(u,v) = \\frac{\\sum_i (|u_i-v_i|)}
+                          {\\sum_i (|u_i+v_i|)}
+    13. ``Y = cdist(XA, XB, 'mahalanobis', VI=None)``
+       Computes the Mahalanobis distance between the points. The
+       Mahalanobis distance between two points ``u`` and ``v`` is
+       :math:`\\sqrt{(u-v)(1/V)(u-v)^T}` where :math:`(1/V)` (the ``VI``
+       variable) is the inverse covariance. If ``VI`` is not None,
+       ``VI`` will be used as the inverse covariance matrix.
+    14. ``Y = cdist(XA, XB, 'yule')``
+       Computes the Yule distance between the boolean
+       vectors. (see `yule` function documentation)
+    15. ``Y = cdist(XA, XB, 'matching')``
+       Synonym for 'hamming'.
+    16. ``Y = cdist(XA, XB, 'dice')``
+       Computes the Dice distance between the boolean vectors. (see
+       `dice` function documentation)
+    17. ``Y = cdist(XA, XB, 'kulsinski')``
+       Computes the Kulsinski distance between the boolean
+       vectors. (see `kulsinski` function documentation)
+    18. ``Y = cdist(XA, XB, 'rogerstanimoto')``
+       Computes the Rogers-Tanimoto distance between the boolean
+       vectors. (see `rogerstanimoto` function documentation)
+    19. ``Y = cdist(XA, XB, 'russellrao')``
+       Computes the Russell-Rao distance between the boolean
+       vectors. (see `russellrao` function documentation)
+    20. ``Y = cdist(XA, XB, 'sokalmichener')``
+       Computes the Sokal-Michener distance between the boolean
+       vectors. (see `sokalmichener` function documentation)
+    21. ``Y = cdist(XA, XB, 'sokalsneath')``
+       Computes the Sokal-Sneath distance between the vectors. (see
+       `sokalsneath` function documentation)
+    22. ``Y = cdist(XA, XB, 'wminkowski')``
+       Computes the weighted Minkowski distance between the
+       vectors. (see `wminkowski` function documentation)
+    23. ``Y = cdist(XA, XB, f)``
+       Computes the distance between all pairs of vectors in X
+       using the user supplied 2-arity function f. For example,
+       Euclidean distance between the vectors could be computed
+       as follows::
+         dm = cdist(XA, XB, lambda u, v: np.sqrt(((u-v)**2).sum()))
+       Note that you should avoid passing a reference to one of
+       the distance functions defined in this library. For example,::
+         dm = cdist(XA, XB, sokalsneath)
+       would calculate the pair-wise distances between the vectors in
+       X using the Python function `sokalsneath`. This would result in
+       sokalsneath being called :math:`{n \\choose 2}` times, which
+       is inefficient. Instead, the optimized C version is more
+       efficient, and we call it using the following syntax::
+         dm = cdist(XA, XB, 'sokalsneath')
     Examples
     --------
     Find the Euclidean distances between four 2-D coordinates:
-
     >>> from scipy.spatial import distance
     >>> coords = [(35.0456, -85.2672),
     ...           (35.1174, -89.9711),
@@ -2141,11 +1997,8 @@ def cdist(XA, XB, metric='euclidean', p=2, V=None, VI=None, w=None):
            [ 4.7044,  0.    ,  6.0893,  3.3561],
            [ 1.6172,  6.0893,  0.    ,  2.8477],
            [ 1.8856,  3.3561,  2.8477,  0.    ]])
-
-
     Find the Manhattan distance from a 3-D point to the corners of the unit
     cube:
-
     >>> a = np.array([[0, 0, 0],
     ...               [0, 0, 1],
     ...               [0, 1, 0],
@@ -2164,7 +2017,6 @@ def cdist(XA, XB, metric='euclidean', p=2, V=None, VI=None, w=None):
            [ 1.7],
            [ 2.1],
            [ 2.3]])
-
     """
     # You can also call this as:
     #     Y = cdist(XA, XB, 'test_abc')
@@ -2242,6 +2094,7 @@ def cdist(XA, XB, metric='euclidean', p=2, V=None, VI=None, w=None):
         if w is not None and not mstr.startswith("test_"):
             if mstr in ['seuclidean', 'se', 's', 'mahalanobis']:
                 raise ValueError("metric %s incompatible with weights" % mstr)
+            # need to use python version for weighting
             mstr = "test_%s" % mstr
 
         try:
@@ -2299,31 +2152,7 @@ def cdist(XA, XB, metric='euclidean', p=2, V=None, VI=None, w=None):
             XB = _convert_to_double(XB)
             _distance_wrap.cdist_mahalanobis_wrap(XA, XB, VI, dm)
         elif mstr.startswith("test_"):
-            test_metrics = {'test_euclidean': euclidean,
-                            'test_braycurtis': braycurtis,
-                            'test_canberra': canberra,
-                            'test_cityblock': cityblock,
-                            'test_minkowski': minkowski,
-                            'test_wminkowski': wminkowski,
-                            'test_cosine': cosine,
-                            'test_correlation': correlation,
-                            'test_hamming': hamming,
-                            'test_jaccard': jaccard,
-                            'test_chebyshev': chebyshev,
-                            'test_chebychev': chebyshev,
-                            'test_yule': yule,
-                            'test_matching': hamming,
-                            'test_dice': dice,
-                            'test_kulsinski': kulsinski,
-                            'test_rogerstanimoto': rogerstanimoto,
-                            'test_russellrao': russellrao,
-                            'test_sokalsneath': sokalsneath,
-                            'test_sokalmichener': sokalmichener,
-                            'test_sqeuclidean': sqeuclidean,
-                            'test_seuclidean': seuclidean,
-                            'test_mahalanobis': mahalanobis,
-                            }
-            if mstr in test_metrics:
+            if mstr in _TEST_METRICS:
                 cfun = cdist
                 if p != 2:  # non-default
                     cfun = partial(cfun, p=p)
@@ -2333,7 +2162,7 @@ def cdist(XA, XB, metric='euclidean', p=2, V=None, VI=None, w=None):
                     cfun = partial(cfun, V=V)
                 elif VI is not None:
                     cfun = partial(cfun, VI=VI)
-                dm = cfun(XA, XB, test_metrics[mstr])
+                dm = cfun(XA, XB, _TEST_METRICS[mstr])
             else:
                 raise ValueError('Unknown Distance Metric: %s' % mstr)
         else:

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -1274,6 +1274,7 @@ def pdist(X, metric='euclidean', p=2, w=None, V=None, VI=None):
 
        .. math::
           \\sqrt{\\sum {(u_i-v_i)^2 / V[x_i]}}
+
        V is the variance vector; V[i] is the variance computed over all
        the i'th components of the points.  If not passed, it is
        automatically computed.
@@ -1286,9 +1287,11 @@ def pdist(X, metric='euclidean', p=2, w=None, V=None, VI=None):
     6. ``Y = pdist(X, 'cosine')``
 
        Computes the cosine distance between vectors u and v,
+
        .. math::
           1 - \\frac{u \\cdot v}
                    {{||u||}_2 {||v||}_2}
+
        where :math:`||*||_2` is the 2-norm of its argument ``*``, and
        :math:`u \\cdot v` is the dot product of ``u`` and ``v``.
 
@@ -1299,6 +1302,7 @@ def pdist(X, metric='euclidean', p=2, w=None, V=None, VI=None):
        .. math::
           1 - \\frac{(u - \\bar{u}) \\cdot (v - \\bar{v})}
                    {{||(u - \\bar{u})||}_2 {||(v - \\bar{v})||}_2}
+
        where :math:`\\bar{v}` is the mean of the elements of vector v,
        and :math:`x \\cdot y` is the dot product of :math:`x` and :math:`y`.
 
@@ -2011,6 +2015,7 @@ def cdist(XA, XB, metric='euclidean', p=2, V=None, VI=None, w=None):
        disagree where at least one of them is non-zero.
 
     10. ``Y = cdist(XA, XB, 'chebyshev')``
+
        Computes the Chebyshev distance between the points. The
        Chebyshev distance between two n-vectors ``u`` and ``v`` is the
        maximum norm-1 distance between their respective elements. More
@@ -2114,6 +2119,7 @@ def cdist(XA, XB, metric='euclidean', p=2, V=None, VI=None, w=None):
     Examples
     --------
     Find the Euclidean distances between four 2-D coordinates:
+
     >>> from scipy.spatial import distance
     >>> coords = [(35.0456, -85.2672),
     ...           (35.1174, -89.9711),
@@ -2127,6 +2133,7 @@ def cdist(XA, XB, metric='euclidean', p=2, V=None, VI=None, w=None):
 
     Find the Manhattan distance from a 3-D point to the corners of the unit
     cube:
+
     >>> a = np.array([[0, 0, 0],
     ...               [0, 0, 1],
     ...               [0, 1, 0],

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -102,7 +102,6 @@ _metrics = ['braycurtis', 'canberra', 'chebyshev', 'cityblock',
             'jaccard', 'kulsinski', 'mahalanobis', 'matching',
             'minkowski', 'rogerstanimoto', 'russellrao', 'seuclidean',
             'sokalmichener', 'sokalsneath', 'sqeuclidean', 'yule']
-_wmetrics = set(_metrics) - {'mahalanobis', 'seuclidean', 'sqeuclidean'}
 
 # A hashmap of expected output arrays for the tests. These arrays
 # come from a list of text files, which are read prior to testing.
@@ -552,19 +551,18 @@ class TestCdist(TestCase):
 
     def _check_calling_conventions(self, X1, X2, metric, eps=1e-04, **kwargs):
         # helper function for test_cdist_calling_conventions
-        cfun = wcdist if metric in _wmetrics else cdist
         try:
-            y1 = cfun(X1, X2, metric=metric, **kwargs)
-            y2 = cfun(X1, X2, metric=eval(metric), **kwargs)
-            y3 = cfun(X1, X2, metric="test_" + metric, **kwargs)
+            y1 = cdist(X1, X2, metric=metric, **kwargs)
+            y2 = cdist(X1, X2, metric=eval(metric), **kwargs)
+            y3 = cdist(X1, X2, metric="test_" + metric, **kwargs)
         except Exception as e:
             e_cls = e.__class__
             if verbose > 2:
                 print(e_cls.__name__)
                 print(e)
-            assert_raises(Exception, cfun, X1, X2, metric=metric, **kwargs)
-            assert_raises(Exception, cfun, X1, X2, metric=eval(metric), **kwargs)
-            assert_raises(Exception, cfun, X1, X2, metric="test_" + metric, **kwargs)
+            assert_raises(Exception, cdist, X1, X2, metric=metric, **kwargs)
+            assert_raises(Exception, cdist, X1, X2, metric=eval(metric), **kwargs)
+            assert_raises(Exception, cdist, X1, X2, metric="test_" + metric, **kwargs)
         else:
             _assert_within_tol(y1, y2, rtol=eps, verbose_=verbose > 2)
             _assert_within_tol(y2, y3, rtol=eps, verbose_=verbose > 2)
@@ -1370,19 +1368,18 @@ class TestPdist(TestCase):
 
     def _check_calling_conventions(self, X, metric, eps=1e-07, **kwargs):
         # helper function for test_pdist_calling_conventions
-        pfun = wpdist if metric in _wmetrics else pdist
         try:
-            y1 = pfun(X, metric=metric, **kwargs)
-            y2 = pfun(X, metric=eval(metric), **kwargs)
-            y3 = pfun(X, metric="test_" + metric, **kwargs)
+            y1 = pdist(X, metric=metric, **kwargs)
+            y2 = pdist(X, metric=eval(metric), **kwargs)
+            y3 = pdist(X, metric="test_" + metric, **kwargs)
         except Exception as e:
             e_cls = e.__class__
             if verbose > 2:
                 print(e_cls.__name__)
                 print(e)
-            assert_raises(Exception, pfun, X, metric=metric, **kwargs)
-            assert_raises(Exception, pfun, X, metric=eval(metric), **kwargs)
-            assert_raises(Exception, pfun, X, metric="test_" + metric, **kwargs)
+            assert_raises(Exception, pdist, X, metric=metric, **kwargs)
+            assert_raises(Exception, pdist, X, metric=eval(metric), **kwargs)
+            assert_raises(Exception, pdist, X, metric="test_" + metric, **kwargs)
         else:
             _assert_within_tol(y1, y2, rtol=eps, verbose_=verbose > 2)
             _assert_within_tol(y2, y3, rtol=eps, verbose_=verbose > 2)

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -1398,7 +1398,7 @@ class TestPdist(TestCase):
 
                 # Testing built-in metrics with extra args
                 if metric == "seuclidean":
-                    V = np.var(X.astype(np.double), axis=0, ddof=1).astype(np.double)
+                    V = np.var(X.astype(np.double), axis=0, ddof=1)
                     self._check_calling_conventions(X, metric, V=V)
                 elif metric == "mahalanobis":
                     V = np.atleast_2d(np.cov(X.astype(np.double).T))

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -580,10 +580,7 @@ class TestCdist(TestCase):
                 self._check_calling_conventions(X1, X2, metric)
 
                 # Testing built-in metrics with extra args
-                if metric == "wminkowski":
-                    w = 1.0 / X1.std(axis=0)
-                    self._check_calling_conventions(X1, X2, metric, w=w)
-                elif metric == "seuclidean":
+                if metric == "seuclidean":
                     X12 = np.vstack([X1, X2]).astype(np.double)
                     V = np.var(X12, axis=0, ddof=1)
                     self._check_calling_conventions(X1, X2, metric, V=V)
@@ -1386,10 +1383,7 @@ class TestPdist(TestCase):
                 self._check_calling_conventions(X, metric)
 
                 # Testing built-in metrics with extra args
-                if metric == "wminkowski":
-                    w = 1.0 / X.std(axis=0)
-                    self._check_calling_conventions(X, metric, w=w)
-                elif metric == "seuclidean":
+                if metric == "seuclidean":
                     V = np.var(X.astype(np.double), axis=0, ddof=1)
                     self._check_calling_conventions(X, metric, V=V)
                 elif metric == "mahalanobis":

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -614,7 +614,7 @@ class TestCdist(TestCase):
                         print(e_cls.__name__)
                         print(e)
                     for new_type in test[1]:
-                      X1new = new_type(X1)
+                        X1new = new_type(X1)
                         X2new = new_type(X2)
                         assert_raises(e_cls, cdist, X1new, X2new, metric=metric)
                 else:

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -35,56 +35,49 @@
 
 from __future__ import division, print_function, absolute_import
 
+import warnings
 import os.path
+from functools import wraps, partial
 from scipy._lib.six import xrange, u
+from scipy.stats.stats import _chk_weights
 
 import numpy as np
 from numpy.linalg import norm
 from numpy.testing import (verbose, TestCase, run_module_suite, assert_,
-                           assert_raises, assert_array_equal, assert_equal,
-                           assert_almost_equal, assert_allclose)
+        assert_raises, assert_array_equal, assert_equal, assert_almost_equal,
+        assert_allclose)
 
-from scipy.spatial.distance import (squareform, pdist, cdist, num_obs_y,
-                                    num_obs_dm, is_valid_dm, is_valid_y,
-                                    _validate_vector)
+from scipy.spatial.distance import (squareform, pdist, cdist,
+        jaccard, dice, sokalsneath, rogerstanimoto, russellrao, yule,
+        num_obs_y, num_obs_dm, is_valid_dm, is_valid_y, minkowski,
+        euclidean, sqeuclidean, cosine, correlation, hamming, mahalanobis,
+        canberra, braycurtis, sokalmichener, _validate_vector)
+matching = hamming # suppresses warning messages in testing
 
-# these were missing: chebyshev cityblock kulsinski
-from scipy.spatial.distance import (braycurtis, canberra, chebyshev, cityblock,
-                                    correlation, cosine, dice, euclidean,
-                                    hamming, jaccard, kulsinski, mahalanobis,
-                                    matching, minkowski, rogerstanimoto,
-                                    russellrao, seuclidean, sokalmichener,
-                                    sokalsneath, sqeuclidean, yule, wminkowski)
-
-_filenames = [
+_filenames = ["iris.txt",
               "cdist-X1.txt",
               "cdist-X2.txt",
-              "iris.txt",
+              "pdist-hamming-ml.txt",
               "pdist-boolean-inp.txt",
-              "pdist-chebychev-ml-iris.txt",
-              "pdist-chebychev-ml.txt",
+              "pdist-jaccard-ml.txt",
               "pdist-cityblock-ml-iris.txt",
+              "pdist-minkowski-3.2-ml-iris.txt",
               "pdist-cityblock-ml.txt",
               "pdist-correlation-ml-iris.txt",
-              "pdist-correlation-ml.txt",
-              "pdist-cosine-ml-iris.txt",
-              "pdist-cosine-ml.txt",
-              "pdist-double-inp.txt",
-              "pdist-euclidean-ml-iris.txt",
-              "pdist-euclidean-ml.txt",
-              "pdist-hamming-ml.txt",
-              "pdist-jaccard-ml.txt",
-              "pdist-minkowski-3.2-ml-iris.txt",
-              "pdist-minkowski-3.2-ml.txt",
               "pdist-minkowski-5.8-ml-iris.txt",
+              "pdist-correlation-ml.txt",
+              "pdist-minkowski-3.2-ml.txt",
+              "pdist-cosine-ml-iris.txt",
               "pdist-seuclidean-ml-iris.txt",
+              "pdist-cosine-ml.txt",
               "pdist-seuclidean-ml.txt",
+              "pdist-double-inp.txt",
               "pdist-spearman-ml.txt",
-              "random-bool-data.txt",
-              "random-double-data.txt",
-              "random-int-data.txt",
-              "random-uint-data.txt",
-              ]
+              "pdist-euclidean-ml.txt",
+              "pdist-euclidean-ml-iris.txt",
+              "pdist-chebychev-ml.txt",
+              "pdist-chebychev-ml-iris.txt",
+              "random-bool-data.txt"]
 
 _tdist = np.array([[0, 662, 877, 255, 412, 996],
                       [662, 0, 295, 468, 268, 400],
@@ -95,11 +88,6 @@ _tdist = np.array([[0, 662, 877, 255, 412, 996],
 
 _ytdist = squareform(_tdist)
 
-_metrics = ['braycurtis', 'canberra', 'chebyshev', 'cityblock',
-            'correlation', 'cosine', 'dice', 'euclidean', 'hamming',
-            'jaccard', 'kulsinski', 'mahalanobis', 'matching',
-            'minkowski', 'rogerstanimoto', 'russellrao', 'seuclidean',
-            'sokalmichener', 'sokalsneath', 'sqeuclidean', 'yule','wminkowski']
 # A hashmap of expected output arrays for the tests. These arrays
 # come from a list of text files, which are read prior to testing.
 # Each test loads inputs and outputs from this dictionary.
@@ -114,99 +102,285 @@ def load_testing_files():
         eo[name] = np.loadtxt(fp)
         fp.close()
     eo['pdist-boolean-inp'] = np.bool_(eo['pdist-boolean-inp'])
-    eo['random-bool-data'] = np.bool_(eo['random-bool-data'])
-    eo['random-float32-data'] = np.float32(eo['random-double-data'])
-    eo['random-int-data'] = np.int_(eo['random-int-data'])
-    eo['random-uint-data'] = np.uint(eo['random-uint-data'])
 
 load_testing_files()
 
 
+def within_tol(a, b, tol):
+    return np.abs(a - b).max() < tol
+
+
+def _assert_within_tol(a, b, atol, verbose_=False):
+    if verbose_:
+        print(np.abs(a-b).max())
+    assert_allclose(a, b, rtol=0, atol=atol)
+
+
+def _rand_split(arrays, weights, axis, split_per, seed=None):
+    # inverse operation for stats.collapse_weights
+    weights = np.array(weights) # modified inplace; need a copy
+    seeded_rand = np.random.RandomState(seed)
+    def mytake(a, ix, axis):
+        record = np.asanyarray(np.take(a, ix, axis=axis))
+        return record.reshape([a.shape[i] if i != axis else 1
+                               for i in range(a.ndim)])
+    n_obs = arrays[0].shape[axis]
+    assert all(a.shape[axis] == n_obs for a in arrays), "data must be aligned on sample axis"
+    for i in range(int(split_per) * n_obs):
+        split_ix = seeded_rand.randint(n_obs + i)
+        prev_w = weights[split_ix]
+        q = seeded_rand.rand()
+        weights[split_ix] = q * prev_w
+        weights = np.append(weights, (1-q) * prev_w)
+        arrays = [np.append(a, mytake(a, split_ix, axis=axis),
+                            axis=axis) for a in arrays]
+    return arrays, weights
+
+def _rough_check(a, b, compare_assert=partial(assert_allclose, atol=1e-5),
+                  key=lambda x: x, w=None):
+    check_a = key(a)
+    check_b = key(b)
+    try:
+        if np.array(check_a != check_b).any(): # try strict equality for string types
+            compare_assert(check_a, check_b)
+    except AttributeError: # masked array
+        compare_assert(check_a, check_b)
+    except (TypeError, ValueError): # nested data structure
+        for a_i, b_i in zip(check_a, check_b):
+            _rough_check(a_i, b_i, compare_assert=compare_assert)
+    #except Exception as e:
+    #    raise type(e)((e, check_a, check_b))
+
+# diff from test_stats:
+#  n_args=2, weight_arg='w', default_axis=None
+#  ma_safe = False, nan_safe = False
+def _weight_checked(fn, n_args=2, default_axis=None, key=lambda x: x, weight_arg='w',
+                    squeeze=True, silent=False,
+                    ones_test=True, const_test=True, dup_test=True,
+                    split_test=True, dud_test=True, ma_safe=False, ma_very_safe=False, nan_safe=False,
+                    split_per=1.0, seed=0, compare_assert=partial(assert_allclose, atol=1e-5)):
+    """runs fn on its arguments 2 or 3 ways, checks that the results are the same,
+       then returns the same thing it would have returned before"""
+    @wraps(fn)
+    def wrapped(*args, **kwargs):
+        result = fn(*args, **kwargs)
+
+        arrays = args[:n_args]
+        rest = args[n_args:]
+        weights = kwargs.get(weight_arg, None)
+        axis = kwargs.get('axis', default_axis)
+
+        chked = _chk_weights(arrays, weights=weights, axis=axis, force_weights=True, mask_screen=True)
+        arrays, weights, axis = chked[:-2], chked[-2], chked[-1]
+        if squeeze:
+            arrays = [np.atleast_1d(a.squeeze()) for a in arrays]
+
+        try:
+            # WEIGHTS CHECK 1: EQUAL WEIGHTED OBESERVATIONS
+            args = tuple(arrays) + rest
+            if ones_test:
+                kwargs[weight_arg] = weights
+                _rough_check(result, fn(*args, **kwargs), key=key)
+            if const_test:
+                kwargs[weight_arg] = weights * 101.0
+                _rough_check(result, fn(*args, **kwargs), key=key)
+                kwargs[weight_arg] = weights * 0.101
+                try:
+                    _rough_check(result, fn(*args, **kwargs), key=key)
+                except Exception as e:
+                    raise type(e)((e, arrays, weights))
+
+            # WEIGHTS CHECK 2: ADDL 0-WEIGHTED OBS
+            if dud_test:
+                # add randomly resampled rows, weighted at 0
+                dud_arrays, dud_weights = _rand_split(arrays, weights, axis, split_per=split_per, seed=seed)
+                dud_weights[:weights.size] = weights # not exactly 1 because of masked arrays
+                dud_weights[weights.size:] = 0
+                dud_args = tuple(dud_arrays) + rest
+                kwargs[weight_arg] = dud_weights
+                _rough_check(result, fn(*dud_args, **kwargs), key=key)
+                # increase the value of those 0-weighted rows
+                for a in dud_arrays:
+                    indexer = [slice(None)] * a.ndim
+                    indexer[axis] = slice(weights.size, None)
+                    a[indexer] = a[indexer] * 101 # ??? structured arrays?
+                dud_args = tuple(dud_arrays) + rest
+                _rough_check(result, fn(*dud_args, **kwargs), key=key)
+                # set those 0-weighted rows to NaNs
+                for a in dud_arrays:
+                    indexer = [slice(None)] * a.ndim
+                    indexer[axis] = slice(weights.size, None)
+                    a[indexer] = a[indexer] * np.nan
+                if kwargs.get("nan_policy", None) == "omit" and nan_safe:
+                    dud_args = tuple(dud_arrays) + rest
+                    _rough_check(result, fn(*dud_args, **kwargs), key=key)
+                # mask out those nan values
+                if ma_safe:
+                    dud_arrays = [np.ma.masked_invalid(a) for a in dud_arrays]
+                    dud_args = tuple(dud_arrays) + rest
+                    _rough_check(result, fn(*dud_args, **kwargs), key=key)
+                    if ma_very_safe:
+                        kwargs[weight_arg] = None
+                        _rough_check(result, fn(*dud_args, **kwargs), key=key)
+                del dud_arrays, dud_args, dud_weights
+
+            # WEIGHTS CHECK 3: DUPLICATE DATA (DUMB SPLITTING)
+            if dup_test:
+                dup_arrays = [np.append(a, a, axis=axis) for a in arrays]
+                dup_weights = np.append(weights, weights) / 2.0
+                dup_args = tuple(dup_arrays) + rest
+                kwargs[weight_arg] = dup_weights
+                _rough_check(result, fn(*dup_args, **kwargs), key=key)
+                del dup_args, dup_arrays, dup_weights
+
+            # WEIGHT CHECK 3: RANDOM SPLITTING
+            if split_test and split_per > 0:
+                split_arrays, split_weights = _rand_split(arrays, weights, axis, split_per=split_per, seed=seed) 
+                split_args = tuple(split_arrays) + rest
+                kwargs[weight_arg] = split_weights
+                _rough_check(result, fn(*split_args, **kwargs), key=key)
+        except NotImplementedError as e:
+            # when some combination of arguments makes weighting impossible,
+            #  this is the desired response
+            if not silent:
+                warnings.warn("%s NotImplemented weights: %s" % (fn.__name__, e))
+        return result
+    return wrapped
+
+
+wcdist = _weight_checked(cdist, default_axis=1, squeeze=False)
+wcdist_no_const = _weight_checked(cdist, default_axis=1, squeeze=False, const_test=False)
+wpdist = _weight_checked(pdist, default_axis=1, squeeze=False, n_args=1)
+wpdist_no_const = _weight_checked(pdist, default_axis=1, squeeze=False, const_test=False, n_args=1)
+wrogerstanimoto = _weight_checked(rogerstanimoto)
+wmatching = whamming = _weight_checked(hamming, dud_test=False)
+wyule = _weight_checked(yule)
+wdice = _weight_checked(dice)
+wcosine = _weight_checked(cosine)
+wcorrelation = _weight_checked(correlation)
+wminkowski = _weight_checked(minkowski, const_test=False)
+wjaccard = _weight_checked(jaccard)
+weuclidean = _weight_checked(euclidean, const_test=False)
+wsqeuclidean = _weight_checked(sqeuclidean, const_test=False)
+wbraycurtis = _weight_checked(braycurtis)
+wcanberra = _weight_checked(canberra, const_test=False)
+wsokalsneath = _weight_checked(sokalsneath)
+wsokalmichener = _weight_checked(sokalmichener)
+wrussellrao = _weight_checked(russellrao)
+
+
 class TestCdist(TestCase):
 
-    def setUp(self):
-        self.rnd_eo_names = ['random-float32-data', 'random-int-data',
-                             'random-uint-data', 'random-double-data',
-                             'random-bool-data']
-        self.valid_upcasts = {'bool': [np.uint, np.int_, np.float32, np.double],
-                              'uint': [np.int_, np.float32, np.double],
-                              'int': [np.float32, np.double],
-                              'float32': [np.double]}
+    def test_cdist_euclidean_random(self):
+        eps = 1e-07
+        # Get the data: the input matrix and the right output.
+        X1 = eo['cdist-X1']
+        X2 = eo['cdist-X2']
+        Y1 = wcdist_no_const(X1, X2, 'euclidean')
+        Y2 = wcdist_no_const(X1, X2, 'test_euclidean')
+        _assert_within_tol(Y1, Y2, eps, verbose > 2)
 
     def test_cdist_euclidean_random_unicode(self):
         eps = 1e-07
         X1 = eo['cdist-X1']
         X2 = eo['cdist-X2']
-        Y1 = cdist(X1, X2, u('euclidean'))
-        Y2 = cdist(X1, X2, u('test_euclidean'))
+        Y1 = wcdist_no_const(X1, X2, u('euclidean'))
+        Y2 = wcdist_no_const(X1, X2, u('test_euclidean'))
+        _assert_within_tol(Y1, Y2, eps, verbose > 2)
+
+    def test_cdist_sqeuclidean_random(self):
+        eps = 1e-07
+        X1 = eo['cdist-X1']
+        X2 = eo['cdist-X2']
+        Y1 = wcdist_no_const(X1, X2, 'sqeuclidean')
+        Y2 = wcdist_no_const(X1, X2, 'test_sqeuclidean')
+        _assert_within_tol(Y1, Y2, eps, verbose > 2)
+
+    def test_cdist_cityblock_random(self):
+        eps = 1e-07
+        X1 = eo['cdist-X1']
+        X2 = eo['cdist-X2']
+        Y1 = wcdist_no_const(X1, X2, 'cityblock')
+        Y2 = wcdist_no_const(X1, X2, 'test_cityblock')
+        _assert_within_tol(Y1, Y2, eps, verbose > 2)
+
+    def test_cdist_hamming_double_random(self):
+        eps = 1e-07
+        X1 = eo['cdist-X1']
+        X2 = eo['cdist-X2']
+        Y1 = wcdist(X1, X2, 'hamming')
+        Y2 = cdist(X1, X2, 'test_hamming')
+        _assert_within_tol(Y1, Y2, eps, verbose > 2)
+
+    def test_cdist_hamming_bool_random(self):
+        eps = 1e-07
+        X1 = eo['cdist-X1'] < 0.5
+        X2 = eo['cdist-X2'] < 0.5
+        Y1 = wcdist(X1, X2, 'hamming')
+        Y2 = cdist(X1, X2, 'test_hamming')
+        _assert_within_tol(Y1, Y2, eps, verbose > 2)
+
+    def test_cdist_jaccard_double_random(self):
+        eps = 1e-07
+        X1 = eo['cdist-X1']
+        X2 = eo['cdist-X2']
+        Y1 = wcdist(X1, X2, 'jaccard')
+        Y2 = wcdist(X1, X2, 'test_jaccard')
+        _assert_within_tol(Y1, Y2, eps, verbose > 2)
+
+    def test_cdist_jaccard_bool_random(self):
+        eps = 1e-07
+        X1 = eo['cdist-X1'] < 0.5
+        X2 = eo['cdist-X2'] < 0.5
+        Y1 = wcdist(X1, X2, 'jaccard')
+        Y2 = wcdist(X1, X2, 'test_jaccard')
+        _assert_within_tol(Y1, Y2, eps, verbose > 2)
+
+    def test_cdist_chebychev_random(self):
+        eps = 1e-07
+        X1 = eo['cdist-X1']
+        X2 = eo['cdist-X2']
+        Y1 = wcdist(X1, X2, 'chebychev')
+        Y2 = wcdist(X1, X2, 'test_chebychev')
         _assert_within_tol(Y1, Y2, eps, verbose > 2)
 
     def test_cdist_minkowski_random_p3d8(self):
         eps = 1e-07
         X1 = eo['cdist-X1']
         X2 = eo['cdist-X2']
-        Y1 = cdist(X1, X2, 'minkowski', p=3.8)
-        Y2 = cdist(X1, X2, 'test_minkowski', p=3.8)
+        Y1 = wcdist_no_const(X1, X2, 'minkowski', p=3.8)
+        Y2 = wcdist_no_const(X1, X2, 'test_minkowski', p=3.8)
         _assert_within_tol(Y1, Y2, eps, verbose > 2)
 
     def test_cdist_minkowski_random_p4d6(self):
         eps = 1e-07
         X1 = eo['cdist-X1']
         X2 = eo['cdist-X2']
-        Y1 = cdist(X1, X2, 'minkowski', p=4.6)
-        Y2 = cdist(X1, X2, 'test_minkowski', p=4.6)
+        Y1 = wcdist_no_const(X1, X2, 'minkowski', p=4.6)
+        Y2 = wcdist_no_const(X1, X2, 'test_minkowski', p=4.6)
         _assert_within_tol(Y1, Y2, eps, verbose > 2)
 
     def test_cdist_minkowski_random_p1d23(self):
         eps = 1e-07
         X1 = eo['cdist-X1']
         X2 = eo['cdist-X2']
-        Y1 = cdist(X1, X2, 'minkowski', p=1.23)
-        Y2 = cdist(X1, X2, 'test_minkowski', p=1.23)
+        Y1 = wcdist_no_const(X1, X2, 'minkowski', p=1.23)
+        Y2 = wcdist_no_const(X1, X2, 'test_minkowski', p=1.23)
         _assert_within_tol(Y1, Y2, eps, verbose > 2)
 
-    def test_cdist_wminkowski_random_p3d8(self):
+    def test_cdist_seuclidean_random(self):
         eps = 1e-07
         X1 = eo['cdist-X1']
         X2 = eo['cdist-X2']
-        w = 1.0 / X1.std(axis=0)
-        Y1 = cdist(X1, X2, 'wminkowski', p=3.8, w=w)
-        Y2 = cdist(X1, X2, 'test_wminkowski', p=3.8, w=w)
-        _assert_within_tol(Y1, Y2, eps, verbose > 2)
-
-    def test_cdist_wminkowski_int_weights(self):
-        # regression test when using integer weights
-        eps = 1e-07
-        X1 = eo['cdist-X1']
-        X2 = eo['cdist-X2']
-        w = np.arange(X1.shape[1])
-        Y1 = cdist(X1, X2, 'wminkowski', p=3.8, w=w)
-        Y2 = cdist(X1, X2, 'test_wminkowski', p=3.8, w=w)
-        _assert_within_tol(Y1, Y2, eps, verbose > 2)
-
-    def test_cdist_wminkowski_random_p4d6(self):
-        eps = 1e-07
-        X1 = eo['cdist-X1']
-        X2 = eo['cdist-X2']
-        w = 1.0 / X1.std(axis=0)
-        Y1 = cdist(X1, X2, 'wminkowski', p=4.6, w=w)
-        Y2 = cdist(X1, X2, 'test_wminkowski', p=4.6, w=w)
-        _assert_within_tol(Y1, Y2, eps, verbose > 2)
-
-    def test_cdist_wminkowski_random_p1d23(self):
-        eps = 1e-07
-        X1 = eo['cdist-X1']
-        X2 = eo['cdist-X2']
-        w = 1.0 / X1.std(axis=0)
-        Y1 = cdist(X1, X2, 'wminkowski', p=1.23, w=w)
-        Y2 = cdist(X1, X2, 'test_wminkowski', p=1.23, w=w)
+        Y1 = cdist(X1, X2, 'seuclidean')
+        Y2 = cdist(X1, X2, 'test_seuclidean')
         _assert_within_tol(Y1, Y2, eps, verbose > 2)
 
     def test_cdist_cosine_random(self):
         eps = 1e-07
         X1 = eo['cdist-X1']
         X2 = eo['cdist-X2']
-        Y1 = cdist(X1, X2, 'cosine')
+        Y1 = wcdist(X1, X2, 'cosine')
 
         # Naive implementation
         def norms(X):
@@ -214,6 +388,22 @@ class TestCdist(TestCase):
 
         Y2 = 1 - np.dot((X1 / norms(X1)), (X2 / norms(X2)).T)
 
+        _assert_within_tol(Y1, Y2, eps, verbose > 2)
+
+    def test_cdist_correlation_random(self):
+        eps = 1e-07
+        X1 = eo['cdist-X1']
+        X2 = eo['cdist-X2']
+        Y1 = wcdist(X1, X2, 'correlation')
+        Y2 = cdist(X1, X2, 'test_correlation')
+        _assert_within_tol(Y1, Y2, eps, verbose > 2)
+
+    def test_cdist_mahalanobis_random(self):
+        eps = 1e-07
+        X1 = eo['cdist-X1']
+        X2 = eo['cdist-X2']
+        Y1 = cdist(X1, X2, 'mahalanobis')
+        Y2 = cdist(X1, X2, 'test_mahalanobis')
         _assert_within_tol(Y1, Y2, eps, verbose > 2)
 
     def test_cdist_mahalanobis(self):
@@ -234,143 +424,134 @@ class TestCdist(TestCase):
         assert_raises(ValueError,
                       cdist, [[0, 1]], [[2, 3]], metric='mahalanobis')
 
-    def test_cdist_custom_notdouble(self):
-        class myclass(object):
-            pass
-
-        def dummy_metric(x, y):
-            if not isinstance(x[0], myclass) or not isinstance(y[0], myclass):
-                raise ValueError("Type has been changed")
-            return 1.123
-        data = np.array([[myclass()]], dtype=object)
-        cdist_y = cdist(data, data, metric=dummy_metric)
-        right_y = 1.123
-        assert_equal(cdist_y, right_y, verbose=verbose > 2)
-
-    def _check_calling_conventions(self, X1, X2, metric, eps=1e-07, **kwargs):
-        # helper function for test_cdist_calling_conventions
-        try:
-            y1 = cdist(X1, X2, metric=metric, **kwargs)
-            y2 = cdist(X1, X2, metric=eval(metric), **kwargs)
-            y3 = cdist(X1, X2, metric="test_" + metric, **kwargs)
-        except Exception as e:
-            e_cls = e.__class__
-            if verbose > 2:
-                print(e_cls.__name__)
-                print(e)
-            assert_raises(e_cls, cdist, X1, X2, metric=metric, **kwargs)
-            assert_raises(e_cls, cdist, X1, X2, metric=eval(metric), **kwargs)
-            assert_raises(e_cls, cdist, X1, X2, metric="test_" + metric, **kwargs)
-        else:
-            _assert_within_tol(y1, y2, eps, verbose > 2)
-            _assert_within_tol(y1, y3, eps, verbose > 2)
-
-    def test_cdist_calling_conventions(self):
-        # Ensures that specifying the metric with a str or scipy function
-        # gives the same behaviour (i.e. same result or same exception).
-        # NOTE: The correctness should be checked within each metric tests.
-        for eo_name in self.rnd_eo_names:
-            X1 = eo[eo_name][:, ::-1]
-            X2 = eo[eo_name][:-3:2]
-            for metric in _metrics:
-                if verbose > 2:
-                    print("testing: ", metric, " with: ", eo_name)
-                if metric == 'yule' and 'bool' not in eo_name:
-                    # python raises a ZeroDivisionError while the C doesn't
-                    continue
-                self._check_calling_conventions(X1, X2, metric)
-
-                # Testing built-in metrics with extra args
-                if metric == "wminkowski":
-                    w = 1.0 / X1.std(axis=0)
-                    self._check_calling_conventions(X1, X2, metric, w=w)
-                elif metric == "seuclidean":
-                    X12 = np.vstack([X1, X2]).astype(np.double)
-                    V = np.var(X12, axis=0, ddof=1)
-                    self._check_calling_conventions(X1, X2, metric, V=V)
-                elif metric == "mahalanobis":
-                    X12 = np.vstack([X1, X2]).astype(np.double)
-                    V = np.atleast_2d(np.cov(X12.T))
-                    VI = np.array(np.linalg.inv(V).T)
-                    self._check_calling_conventions(X1, X2, metric, VI=VI)
-
-    def test_cdist_dtype_equivalence(self):
-        # Tests that the result is not affected by type up-casting
+    def test_cdist_canberra_random(self):
         eps = 1e-07
-        tests = [(eo['random-bool-data'], self.valid_upcasts['bool']),
-                 (eo['random-uint-data'], self.valid_upcasts['uint']),
-                 (eo['random-int-data'], self.valid_upcasts['int']),
-                 (eo['random-float32-data'], self.valid_upcasts['float32'])]
-        for metric in _metrics:
-            for test in tests:
-                X1 = test[0]
-                try:
-                    y1 = pdist(X1, metric=metric)
-                except Exception as e:
-                    e_cls = e.__class__
-                    if verbose > 2:
-                        print(e_cls.__name__)
-                        print(e)
-                    for new_type in test[1]:
-                        X2 = new_type(test[0])
-                        assert_raises(e_cls, pdist, X2, metric=metric)
-                else:
-                    for new_type in test[1]:
-                        y2 = pdist(new_type(X1), metric=metric)
-                        _assert_within_tol(y1, y2, eps, verbose > 2)
+        X1 = eo['cdist-X1'] < 0.5
+        X2 = eo['cdist-X2'] < 0.5
+        Y1 = wcdist_no_const(X1, X2, 'canberra')
+        Y2 = wcdist_no_const(X1, X2, 'test_canberra')
+        _assert_within_tol(Y1, Y2, eps, verbose > 2)
+
+    def test_cdist_braycurtis_random(self):
+        eps = 1e-07
+        X1 = eo['cdist-X1'] < 0.5
+        X2 = eo['cdist-X2'] < 0.5
+        Y1 = wcdist(X1, X2, 'braycurtis')
+        Y2 = cdist(X1, X2, 'test_braycurtis')
+        if verbose > 2:
+            print(Y1, Y2)
+            print((Y1-Y2).max())
+        _assert_within_tol(Y1, Y2, eps)
+
+    def test_cdist_yule_random(self):
+        eps = 1e-07
+        X1 = eo['cdist-X1'] < 0.5
+        X2 = eo['cdist-X2'] < 0.5
+        Y1 = wcdist(X1, X2, 'yule')
+        Y2 = cdist(X1, X2, 'test_yule')
+        _assert_within_tol(Y1, Y2, eps, verbose > 2)
+
+    def test_cdist_matching_random(self):
+        eps = 1e-07
+        X1 = eo['cdist-X1'] < 0.5
+        X2 = eo['cdist-X2'] < 0.5
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            Y1 = wcdist(X1, X2, 'matching')
+            Y2 = cdist(X1, X2, 'test_matching')
+        _assert_within_tol(Y1, Y2, eps, verbose > 2)
+
+    def test_cdist_kulsinski_random(self):
+        eps = 1e-07
+        X1 = eo['cdist-X1'] < 0.5
+        X2 = eo['cdist-X2'] < 0.5
+        Y1 = wcdist(X1, X2, 'kulsinski')
+        Y2 = cdist(X1, X2, 'test_kulsinski')
+        _assert_within_tol(Y1, Y2, eps, verbose > 2)
+
+    def test_cdist_dice_random(self):
+        eps = 1e-07
+        X1 = eo['cdist-X1'] < 0.5
+        X2 = eo['cdist-X2'] < 0.5
+        Y1 = wcdist(X1, X2, 'dice')
+        Y2 = cdist(X1, X2, 'test_dice')
+        _assert_within_tol(Y1, Y2, eps, verbose > 2)
+
+    def test_cdist_rogerstanimoto_random(self):
+        eps = 1e-07
+        X1 = eo['cdist-X1'] < 0.5
+        X2 = eo['cdist-X2'] < 0.5
+        Y1 = wcdist(X1, X2, 'rogerstanimoto')
+        Y2 = cdist(X1, X2, 'test_rogerstanimoto')
+        _assert_within_tol(Y1, Y2, eps, verbose > 2)
+
+    def test_cdist_russellrao_random(self):
+        eps = 1e-07
+        X1 = eo['cdist-X1'] < 0.5
+        X2 = eo['cdist-X2'] < 0.5
+        Y1 = wcdist(X1, X2, 'russellrao')
+        Y2 = cdist(X1, X2, 'test_russellrao')
+        _assert_within_tol(Y1, Y2, eps, verbose > 2)
+
+    def test_cdist_sokalmichener_random(self):
+        eps = 1e-07
+        X1 = eo['cdist-X1'] < 0.5
+        X2 = eo['cdist-X2'] < 0.5
+        Y1 = wcdist(X1, X2, 'sokalmichener')
+        Y2 = cdist(X1, X2, 'test_sokalmichener')
+        _assert_within_tol(Y1, Y2, eps, verbose > 2)
+
+    def test_cdist_sokalsneath_random(self):
+        eps = 1e-07
+        X1 = eo['cdist-X1'] < 0.5
+        X2 = eo['cdist-X2'] < 0.5
+        Y1 = wcdist(X1, X2, 'sokalsneath')
+        Y2 = cdist(X1, X2, 'test_sokalsneath')
+        _assert_within_tol(Y1, Y2, eps, verbose > 2)
 
 
 class TestPdist(TestCase):
-
-    def setUp(self):
-        self.rnd_eo_names = ['random-float32-data', 'random-int-data',
-                             'random-uint-data', 'random-double-data',
-                             'random-bool-data']
-        self.valid_upcasts = {'bool': [np.uint, np.int_, np.float32, np.double],
-                              'uint': [np.int_, np.float32, np.double],
-                              'int': [np.float32, np.double],
-                              'float32': [np.double]}
 
     def test_pdist_euclidean_random(self):
         eps = 1e-07
         X = eo['pdist-double-inp']
         Y_right = eo['pdist-euclidean']
-        Y_test1 = pdist(X, 'euclidean')
+        Y_test1 = wpdist_no_const(X, 'euclidean')
         _assert_within_tol(Y_test1, Y_right, eps)
 
     def test_pdist_euclidean_random_u(self):
         eps = 1e-07
         X = eo['pdist-double-inp']
         Y_right = eo['pdist-euclidean']
-        Y_test1 = pdist(X, u('euclidean'))
+        Y_test1 = wpdist_no_const(X, u('euclidean'))
         _assert_within_tol(Y_test1, Y_right, eps)
 
     def test_pdist_euclidean_random_float32(self):
         eps = 1e-07
         X = np.float32(eo['pdist-double-inp'])
         Y_right = eo['pdist-euclidean']
-        Y_test1 = pdist(X, 'euclidean')
+        Y_test1 = wpdist_no_const(X, 'euclidean')
         _assert_within_tol(Y_test1, Y_right, eps)
 
     def test_pdist_euclidean_random_nonC(self):
         eps = 1e-07
         X = eo['pdist-double-inp']
         Y_right = eo['pdist-euclidean']
-        Y_test2 = pdist(X, 'test_euclidean')
+        Y_test2 = wpdist_no_const(X, 'test_euclidean')
         _assert_within_tol(Y_test2, Y_right, eps)
 
     def test_pdist_euclidean_iris_double(self):
         eps = 1e-07
         X = eo['iris']
         Y_right = eo['pdist-euclidean-iris']
-        Y_test1 = pdist(X, 'euclidean')
+        Y_test1 = wpdist_no_const(X, 'euclidean')
         _assert_within_tol(Y_test1, Y_right, eps)
 
     def test_pdist_euclidean_iris_float32(self):
         eps = 1e-06
         X = np.float32(eo['iris'])
         Y_right = eo['pdist-euclidean-iris']
-        Y_test1 = pdist(X, 'euclidean')
+        Y_test1 = wpdist_no_const(X, 'euclidean')
         _assert_within_tol(Y_test1, Y_right, eps, verbose > 2)
 
     def test_pdist_euclidean_iris_nonC(self):
@@ -379,7 +560,7 @@ class TestPdist(TestCase):
         eps = 1e-07
         X = eo['iris']
         Y_right = eo['pdist-euclidean-iris']
-        Y_test2 = pdist(X, 'test_euclidean')
+        Y_test2 = wpdist_no_const(X, 'test_euclidean')
         _assert_within_tol(Y_test2, Y_right, eps)
 
     def test_pdist_seuclidean_random(self):
@@ -401,7 +582,7 @@ class TestPdist(TestCase):
         eps = 1e-05
         X = eo['pdist-double-inp']
         Y_right = eo['pdist-seuclidean']
-        Y_test2 = pdist(X, 'test_seuclidean')
+        Y_test2 = pdist(X, 'test_sqeuclidean')
         _assert_within_tol(Y_test2, Y_right, eps)
 
     def test_pdist_seuclidean_iris(self):
@@ -420,26 +601,26 @@ class TestPdist(TestCase):
         _assert_within_tol(Y_test1, Y_right, eps)
 
     def test_pdist_seuclidean_iris_nonC(self):
-        # Test pdist(X, 'test_seuclidean') [the non-C implementation] on the
+        # Test pdist(X, 'test_sqeuclidean') [the non-C implementation] on the
         # Iris data set.
         eps = 1e-05
         X = eo['iris']
         Y_right = eo['pdist-seuclidean-iris']
-        Y_test2 = pdist(X, 'test_seuclidean')
+        Y_test2 = pdist(X, 'test_sqeuclidean')
         _assert_within_tol(Y_test2, Y_right, eps)
 
     def test_pdist_cosine_random(self):
         eps = 1e-08
         X = eo['pdist-double-inp']
         Y_right = eo['pdist-cosine']
-        Y_test1 = pdist(X, 'cosine')
+        Y_test1 = wpdist(X, 'cosine')
         _assert_within_tol(Y_test1, Y_right, eps)
 
     def test_pdist_cosine_random_float32(self):
         eps = 1e-08
         X = np.float32(eo['pdist-double-inp'])
         Y_right = eo['pdist-cosine']
-        Y_test1 = pdist(X, 'cosine')
+        Y_test1 = wpdist(X, 'cosine')
         _assert_within_tol(Y_test1, Y_right, eps)
 
     def test_pdist_cosine_random_nonC(self):
@@ -447,72 +628,72 @@ class TestPdist(TestCase):
         eps = 1e-08
         X = eo['pdist-double-inp']
         Y_right = eo['pdist-cosine']
-        Y_test2 = pdist(X, 'test_cosine')
+        Y_test2 = wpdist(X, 'test_cosine')
         _assert_within_tol(Y_test2, Y_right, eps)
 
     def test_pdist_cosine_iris(self):
         eps = 1e-08
         X = eo['iris']
         Y_right = eo['pdist-cosine-iris']
-        Y_test1 = pdist(X, 'cosine')
+        Y_test1 = wpdist(X, 'cosine')
         _assert_within_tol(Y_test1, Y_right, eps)
 
     def test_pdist_cosine_iris_float32(self):
         eps = 1e-07
         X = np.float32(eo['iris'])
         Y_right = eo['pdist-cosine-iris']
-        Y_test1 = pdist(X, 'cosine')
+        Y_test1 = wpdist(X, 'cosine')
         _assert_within_tol(Y_test1, Y_right, eps, verbose > 2)
 
     def test_pdist_cosine_iris_nonC(self):
         eps = 1e-08
         X = eo['iris']
         Y_right = eo['pdist-cosine-iris']
-        Y_test2 = pdist(X, 'test_cosine')
+        Y_test2 = wpdist(X, 'test_cosine')
         _assert_within_tol(Y_test2, Y_right, eps)
 
     def test_pdist_cosine_bounds(self):
-        # Test adapted from @joernhees's example at gh-5208: case were
+        # Test adapted from @joernhees's example at gh-5208: case where
         # cosine distance used to be negative. XXX: very sensitive to the
         # specific norm computation.
         x = np.abs(np.random.RandomState(1337).rand(91))
         X = np.vstack([x, x])
-        assert_(pdist(X, 'cosine')[0] >= 0,
+        assert_(wpdist(X, 'cosine')[0] >= 0,
                 msg='cosine distance should be non-negative')
 
     def test_pdist_cityblock_random(self):
         eps = 1e-06
         X = eo['pdist-double-inp']
         Y_right = eo['pdist-cityblock']
-        Y_test1 = pdist(X, 'cityblock')
+        Y_test1 = wpdist_no_const(X, 'cityblock')
         _assert_within_tol(Y_test1, Y_right, eps)
 
     def test_pdist_cityblock_random_float32(self):
         eps = 1e-06
         X = np.float32(eo['pdist-double-inp'])
         Y_right = eo['pdist-cityblock']
-        Y_test1 = pdist(X, 'cityblock')
+        Y_test1 = wpdist_no_const(X, 'cityblock')
         _assert_within_tol(Y_test1, Y_right, eps)
 
     def test_pdist_cityblock_random_nonC(self):
         eps = 1e-06
         X = eo['pdist-double-inp']
         Y_right = eo['pdist-cityblock']
-        Y_test2 = pdist(X, 'test_cityblock')
+        Y_test2 = wpdist_no_const(X, 'test_cityblock')
         _assert_within_tol(Y_test2, Y_right, eps)
 
     def test_pdist_cityblock_iris(self):
         eps = 1e-14
         X = eo['iris']
         Y_right = eo['pdist-cityblock-iris']
-        Y_test1 = pdist(X, 'cityblock')
+        Y_test1 = wpdist_no_const(X, 'cityblock')
         _assert_within_tol(Y_test1, Y_right, eps)
 
     def test_pdist_cityblock_iris_float32(self):
         eps = 1e-06
         X = np.float32(eo['iris'])
         Y_right = eo['pdist-cityblock-iris']
-        Y_test1 = pdist(X, 'cityblock')
+        Y_test1 = wpdist_no_const(X, 'cityblock')
         _assert_within_tol(Y_test1, Y_right, eps, verbose > 2)
 
     def test_pdist_cityblock_iris_nonC(self):
@@ -521,147 +702,114 @@ class TestPdist(TestCase):
         eps = 1e-14
         X = eo['iris']
         Y_right = eo['pdist-cityblock-iris']
-        Y_test2 = pdist(X, 'test_cityblock')
+        Y_test2 = wpdist_no_const(X, 'test_cityblock')
         _assert_within_tol(Y_test2, Y_right, eps)
 
     def test_pdist_correlation_random(self):
         eps = 1e-07
         X = eo['pdist-double-inp']
         Y_right = eo['pdist-correlation']
-        Y_test1 = pdist(X, 'correlation')
+        Y_test1 = wpdist(X, 'correlation')
         _assert_within_tol(Y_test1, Y_right, eps)
 
     def test_pdist_correlation_random_float32(self):
         eps = 1e-07
         X = np.float32(eo['pdist-double-inp'])
         Y_right = eo['pdist-correlation']
-        Y_test1 = pdist(X, 'correlation')
+        Y_test1 = wpdist(X, 'correlation')
         _assert_within_tol(Y_test1, Y_right, eps)
 
     def test_pdist_correlation_random_nonC(self):
         eps = 1e-07
         X = eo['pdist-double-inp']
         Y_right = eo['pdist-correlation']
-        Y_test2 = pdist(X, 'test_correlation')
+        Y_test2 = wpdist(X, 'test_correlation')
         _assert_within_tol(Y_test2, Y_right, eps)
 
     def test_pdist_correlation_iris(self):
         eps = 1e-08
         X = eo['iris']
         Y_right = eo['pdist-correlation-iris']
-        Y_test1 = pdist(X, 'correlation')
+        Y_test1 = wpdist(X, 'correlation')
         _assert_within_tol(Y_test1, Y_right, eps)
 
     def test_pdist_correlation_iris_float32(self):
         eps = 1e-07
         X = eo['iris']
         Y_right = np.float32(eo['pdist-correlation-iris'])
-        Y_test1 = pdist(X, 'correlation')
+        Y_test1 = wpdist(X, 'correlation')
         _assert_within_tol(Y_test1, Y_right, eps, verbose > 2)
 
     def test_pdist_correlation_iris_nonC(self):
         eps = 1e-08
         X = eo['iris']
         Y_right = eo['pdist-correlation-iris']
-        Y_test2 = pdist(X, 'test_correlation')
+        Y_test2 = wpdist(X, 'test_correlation')
         _assert_within_tol(Y_test2, Y_right, eps)
 
     def test_pdist_minkowski_random(self):
         eps = 1e-05
         X = eo['pdist-double-inp']
         Y_right = eo['pdist-minkowski-3.2']
-        Y_test1 = pdist(X, 'minkowski', 3.2)
+        Y_test1 = wpdist_no_const(X, 'minkowski', 3.2)
         _assert_within_tol(Y_test1, Y_right, eps)
 
     def test_pdist_minkowski_random_float32(self):
         eps = 1e-05
         X = np.float32(eo['pdist-double-inp'])
         Y_right = eo['pdist-minkowski-3.2']
-        Y_test1 = pdist(X, 'minkowski', 3.2)
+        Y_test1 = wpdist_no_const(X, 'minkowski', 3.2)
         _assert_within_tol(Y_test1, Y_right, eps)
 
     def test_pdist_minkowski_random_nonC(self):
         eps = 1e-05
         X = eo['pdist-double-inp']
         Y_right = eo['pdist-minkowski-3.2']
-        Y_test2 = pdist(X, 'test_minkowski', 3.2)
+        Y_test2 = wpdist_no_const(X, 'test_minkowski', 3.2)
         _assert_within_tol(Y_test2, Y_right, eps)
 
     def test_pdist_minkowski_3_2_iris(self):
         eps = 1e-07
         X = eo['iris']
         Y_right = eo['pdist-minkowski-3.2-iris']
-        Y_test1 = pdist(X, 'minkowski', 3.2)
+        Y_test1 = wpdist_no_const(X, 'minkowski', 3.2)
         _assert_within_tol(Y_test1, Y_right, eps)
 
     def test_pdist_minkowski_3_2_iris_float32(self):
         eps = 1e-06
         X = np.float32(eo['iris'])
         Y_right = eo['pdist-minkowski-3.2-iris']
-        Y_test1 = pdist(X, 'minkowski', 3.2)
+        Y_test1 = wpdist_no_const(X, 'minkowski', 3.2)
         _assert_within_tol(Y_test1, Y_right, eps)
 
     def test_pdist_minkowski_3_2_iris_nonC(self):
         eps = 1e-07
         X = eo['iris']
         Y_right = eo['pdist-minkowski-3.2-iris']
-        Y_test2 = pdist(X, 'test_minkowski', 3.2)
+        Y_test2 = wpdist_no_const(X, 'test_minkowski', 3.2)
         _assert_within_tol(Y_test2, Y_right, eps)
 
     def test_pdist_minkowski_5_8_iris(self):
         eps = 1e-07
         X = eo['iris']
         Y_right = eo['pdist-minkowski-5.8-iris']
-        Y_test1 = pdist(X, 'minkowski', 5.8)
+        Y_test1 = wpdist_no_const(X, 'minkowski', 5.8)
         _assert_within_tol(Y_test1, Y_right, eps)
 
     def test_pdist_minkowski_5_8_iris_float32(self):
         eps = 1e-06
         X = np.float32(eo['iris'])
         Y_right = eo['pdist-minkowski-5.8-iris']
-        Y_test1 = pdist(X, 'minkowski', 5.8)
+        Y_test1 = wpdist_no_const(X, 'minkowski', 5.8)
         _assert_within_tol(Y_test1, Y_right, eps, verbose > 2)
 
     def test_pdist_minkowski_5_8_iris_nonC(self):
         eps = 1e-07
         X = eo['iris']
         Y_right = eo['pdist-minkowski-5.8-iris']
-        Y_test2 = pdist(X, 'test_minkowski', 5.8)
+        Y_test2 = wpdist_no_const(X, 'test_minkowski', 5.8)
         _assert_within_tol(Y_test2, Y_right, eps)
 
-    def test_pdist_wminkowski(self):
-        x = np.array([[0.0, 0.0, 0.0],
-                      [1.0, 0.0, 0.0],
-                      [0.0, 1.0, 0.0],
-                      [1.0, 1.0, 1.0]])
-
-        p2_expected = [1.0, 1.0, np.sqrt(3),
-                       np.sqrt(2), np.sqrt(2),
-                       np.sqrt(2)]
-        p1_expected = [0.5, 1.0, 3.5,
-                       1.5, 3.0,
-                       2.5]
-        dist = pdist(x, metric=wminkowski, w=[1.0, 1.0, 1.0])
-        assert_allclose(dist, p2_expected, rtol=1e-14)
-
-        dist = pdist(x, metric=wminkowski, w=[0.5, 1.0, 2.0], p=1)
-        assert_allclose(dist, p1_expected, rtol=1e-14)
-
-        dist = pdist(x, metric='wminkowski', w=[1.0, 1.0, 1.0])
-        assert_allclose(dist, p2_expected, rtol=1e-14)
-
-        dist = pdist(x, metric='wminkowski', w=[0.5, 1.0, 2.0], p=1)
-        assert_allclose(dist, p1_expected, rtol=1e-14)
-
-    def test_pdist_wminkowski_int_weights(self):
-        # regression test for int weights
-        x = np.array([[0.0, 0.0, 0.0],
-                      [1.0, 0.0, 0.0],
-                      [0.0, 1.0, 0.0],
-                      [1.0, 1.0, 1.0]])
-        dist1 = pdist(x, metric='wminkowski', w=np.arange(3), p=1)
-        dist2 = pdist(x, metric='wminkowski', w=[0., 1., 2.], p=1)
-        assert_allclose(dist1, dist2, rtol=1e-14)
 
     def test_pdist_mahalanobis(self):
         # 1-dimensional observations
@@ -678,379 +826,414 @@ class TestPdist(TestCase):
 
         # Too few observations
         assert_raises(ValueError,
-                      pdist, [[0, 1], [2, 3]], metric='mahalanobis')
+                      wpdist, [[0, 1], [2, 3]], metric='mahalanobis')
 
     def test_pdist_hamming_random(self):
         eps = 1e-07
         X = eo['pdist-boolean-inp']
         Y_right = eo['pdist-hamming']
-        Y_test1 = pdist(X, 'hamming')
+        Y_test1 = wpdist(X, 'hamming')
         _assert_within_tol(Y_test1, Y_right, eps)
 
     def test_pdist_hamming_random_float32(self):
         eps = 1e-07
         X = np.float32(eo['pdist-boolean-inp'])
         Y_right = eo['pdist-hamming']
-        Y_test1 = pdist(X, 'hamming')
+        Y_test1 = wpdist(X, 'hamming')
         _assert_within_tol(Y_test1, Y_right, eps)
 
     def test_pdist_hamming_random_nonC(self):
         eps = 1e-07
         X = eo['pdist-boolean-inp']
         Y_right = eo['pdist-hamming']
-        Y_test2 = pdist(X, 'test_hamming')
+        Y_test2 = wpdist(X, 'test_hamming')
         _assert_within_tol(Y_test2, Y_right, eps)
 
     def test_pdist_dhamming_random(self):
         eps = 1e-07
         X = np.float64(eo['pdist-boolean-inp'])
         Y_right = eo['pdist-hamming']
-        Y_test1 = pdist(X, 'hamming')
+        Y_test1 = wpdist(X, 'hamming')
         _assert_within_tol(Y_test1, Y_right, eps)
 
     def test_pdist_dhamming_random_float32(self):
         eps = 1e-07
         X = np.float32(eo['pdist-boolean-inp'])
         Y_right = eo['pdist-hamming']
-        Y_test1 = pdist(X, 'hamming')
+        Y_test1 = wpdist(X, 'hamming')
         _assert_within_tol(Y_test1, Y_right, eps)
 
     def test_pdist_dhamming_random_nonC(self):
         eps = 1e-07
         X = np.float64(eo['pdist-boolean-inp'])
         Y_right = eo['pdist-hamming']
-        Y_test2 = pdist(X, 'test_hamming')
+        Y_test2 = wpdist(X, 'test_hamming')
         _assert_within_tol(Y_test2, Y_right, eps)
 
     def test_pdist_jaccard_random(self):
         eps = 1e-08
         X = eo['pdist-boolean-inp']
         Y_right = eo['pdist-jaccard']
-        Y_test1 = pdist(X, 'jaccard')
+        Y_test1 = wpdist(X, 'jaccard')
         _assert_within_tol(Y_test1, Y_right, eps)
 
     def test_pdist_jaccard_random_float32(self):
         eps = 1e-08
         X = np.float32(eo['pdist-boolean-inp'])
         Y_right = eo['pdist-jaccard']
-        Y_test1 = pdist(X, 'jaccard')
+        Y_test1 = wpdist(X, 'jaccard')
         _assert_within_tol(Y_test1, Y_right, eps)
 
     def test_pdist_jaccard_random_nonC(self):
         eps = 1e-08
         X = eo['pdist-boolean-inp']
         Y_right = eo['pdist-jaccard']
-        Y_test2 = pdist(X, 'test_jaccard')
+        Y_test2 = wpdist(X, 'test_jaccard')
         _assert_within_tol(Y_test2, Y_right, eps)
 
     def test_pdist_djaccard_random(self):
         eps = 1e-08
         X = np.float64(eo['pdist-boolean-inp'])
         Y_right = eo['pdist-jaccard']
-        Y_test1 = pdist(X, 'jaccard')
+        Y_test1 = wpdist(X, 'jaccard')
         _assert_within_tol(Y_test1, Y_right, eps)
 
     def test_pdist_djaccard_random_float32(self):
         eps = 1e-08
         X = np.float32(eo['pdist-boolean-inp'])
         Y_right = eo['pdist-jaccard']
-        Y_test1 = pdist(X, 'jaccard')
+        Y_test1 = wpdist(X, 'jaccard')
         _assert_within_tol(Y_test1, Y_right, eps)
 
     def test_pdist_djaccard_random_nonC(self):
         eps = 1e-08
         X = np.float64(eo['pdist-boolean-inp'])
         Y_right = eo['pdist-jaccard']
-        Y_test2 = pdist(X, 'test_jaccard')
+        Y_test2 = wpdist(X, 'test_jaccard')
         _assert_within_tol(Y_test2, Y_right, eps)
 
     def test_pdist_chebychev_random(self):
         eps = 1e-08
         X = eo['pdist-double-inp']
         Y_right = eo['pdist-chebychev']
-        Y_test1 = pdist(X, 'chebychev')
+        Y_test1 = wpdist(X, 'chebychev')
         _assert_within_tol(Y_test1, Y_right, eps)
 
     def test_pdist_chebychev_random_float32(self):
         eps = 1e-07
         X = np.float32(eo['pdist-double-inp'])
         Y_right = eo['pdist-chebychev']
-        Y_test1 = pdist(X, 'chebychev')
+        Y_test1 = wpdist(X, 'chebychev')
         _assert_within_tol(Y_test1, Y_right, eps, verbose > 2)
 
     def test_pdist_chebychev_random_nonC(self):
         eps = 1e-08
         X = eo['pdist-double-inp']
         Y_right = eo['pdist-chebychev']
-        Y_test2 = pdist(X, 'test_chebychev')
+        Y_test2 = wpdist(X, 'test_chebychev')
         _assert_within_tol(Y_test2, Y_right, eps)
 
     def test_pdist_chebychev_iris(self):
         eps = 1e-15
         X = eo['iris']
         Y_right = eo['pdist-chebychev-iris']
-        Y_test1 = pdist(X, 'chebychev')
+        Y_test1 = wpdist(X, 'chebychev')
         _assert_within_tol(Y_test1, Y_right, eps)
 
     def test_pdist_chebychev_iris_float32(self):
         eps = 1e-06
         X = np.float32(eo['iris'])
         Y_right = eo['pdist-chebychev-iris']
-        Y_test1 = pdist(X, 'chebychev')
+        Y_test1 = wpdist(X, 'chebychev')
         _assert_within_tol(Y_test1, Y_right, eps, verbose > 2)
 
     def test_pdist_chebychev_iris_nonC(self):
         eps = 1e-15
         X = eo['iris']
         Y_right = eo['pdist-chebychev-iris']
-        Y_test2 = pdist(X, 'test_chebychev')
+        Y_test2 = wpdist(X, 'test_chebychev')
         _assert_within_tol(Y_test2, Y_right, eps)
 
     def test_pdist_matching_mtica1(self):
         # Test matching(*,*) with mtica example #1 (nums).
-        m = matching(np.array([1, 0, 1, 1, 0]),
-                     np.array([1, 1, 0, 1, 1]))
-        m2 = matching(np.array([1, 0, 1, 1, 0], dtype=bool),
-                      np.array([1, 1, 0, 1, 1], dtype=bool))
+        m = wmatching(np.array([1, 0, 1, 1, 0]),
+                      np.array([1, 1, 0, 1, 1]))
+        m2 = wmatching(np.array([1, 0, 1, 1, 0], dtype=bool),
+                       np.array([1, 1, 0, 1, 1], dtype=bool))
         assert_allclose(m, 0.6, rtol=0, atol=1e-10)
         assert_allclose(m2, 0.6, rtol=0, atol=1e-10)
 
     def test_pdist_matching_mtica2(self):
         # Test matching(*,*) with mtica example #2.
-        m = matching(np.array([1, 0, 1]),
-                     np.array([1, 1, 0]))
-        m2 = matching(np.array([1, 0, 1], dtype=bool),
-                      np.array([1, 1, 0], dtype=bool))
+        m = wmatching(np.array([1, 0, 1]),
+                      np.array([1, 1, 0]))
+        m2 = wmatching(np.array([1, 0, 1], dtype=bool),
+                       np.array([1, 1, 0], dtype=bool))
         assert_allclose(m, 2/3, rtol=0, atol=1e-10)
         assert_allclose(m2, 2/3, rtol=0, atol=1e-10)
 
+    def test_pdist_matching_match(self):
+        # Test pdist(X, 'matching') to see if the two implementations match on
+        # random boolean input data.
+        D = eo['random-bool-data']
+        B = np.bool_(D)
+        if verbose > 2:
+            print(B.shape, B.dtype)
+        eps = 1e-10
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            y1 = wpdist(B, "matching")
+            y2 = wpdist(B, "test_matching")
+            y3 = wpdist(D, "test_matching")
+        if verbose > 2:
+            print(np.abs(y1-y2).max())
+            print(np.abs(y1-y3).max())
+        _assert_within_tol(y1, y2, eps)
+        _assert_within_tol(y2, y3, eps)
+
     def test_pdist_jaccard_mtica1(self):
-        m = jaccard(np.array([1, 0, 1, 1, 0]),
-                    np.array([1, 1, 0, 1, 1]))
-        m2 = jaccard(np.array([1, 0, 1, 1, 0], dtype=bool),
-                     np.array([1, 1, 0, 1, 1], dtype=bool))
+        m = wjaccard(np.array([1, 0, 1, 1, 0]),
+                     np.array([1, 1, 0, 1, 1]))
+        m2 = wjaccard(np.array([1, 0, 1, 1, 0], dtype=bool),
+                      np.array([1, 1, 0, 1, 1], dtype=bool))
         assert_allclose(m, 0.6, rtol=0, atol=1e-10)
         assert_allclose(m2, 0.6, rtol=0, atol=1e-10)
 
     def test_pdist_jaccard_mtica2(self):
-        m = jaccard(np.array([1, 0, 1]),
-                    np.array([1, 1, 0]))
-        m2 = jaccard(np.array([1, 0, 1], dtype=bool),
-                     np.array([1, 1, 0], dtype=bool))
+        m = wjaccard(np.array([1, 0, 1]),
+                     np.array([1, 1, 0]))
+        m2 = wjaccard(np.array([1, 0, 1], dtype=bool),
+                      np.array([1, 1, 0], dtype=bool))
         assert_allclose(m, 2/3, rtol=0, atol=1e-10)
         assert_allclose(m2, 2/3, rtol=0, atol=1e-10)
 
+    def test_pdist_jaccard_match(self):
+        # Test pdist(X, 'jaccard') to see if the two implementations match on
+        # random double input data.
+        D = eo['random-bool-data']
+        if verbose > 2:
+            print(D.shape, D.dtype)
+        eps = 1e-10
+        y1 = wpdist(D, "jaccard")
+        y2 = wpdist(D, "test_jaccard")
+        y3 = wpdist(np.bool_(D), "test_jaccard")
+        if verbose > 2:
+            print(np.abs(y1-y2).max())
+            print(np.abs(y2-y3).max())
+        _assert_within_tol(y1, y2, eps)
+        _assert_within_tol(y2, y3, eps)
+
     def test_pdist_yule_mtica1(self):
-        m = yule(np.array([1, 0, 1, 1, 0]),
-                 np.array([1, 1, 0, 1, 1]))
-        m2 = yule(np.array([1, 0, 1, 1, 0], dtype=bool),
-                  np.array([1, 1, 0, 1, 1], dtype=bool))
+        m = wyule(np.array([1, 0, 1, 1, 0]),
+                  np.array([1, 1, 0, 1, 1]))
+        m2 = wyule(np.array([1, 0, 1, 1, 0], dtype=bool),
+                   np.array([1, 1, 0, 1, 1], dtype=bool))
         if verbose > 2:
             print(m)
         assert_allclose(m, 2, rtol=0, atol=1e-10)
         assert_allclose(m2, 2, rtol=0, atol=1e-10)
 
     def test_pdist_yule_mtica2(self):
-        m = yule(np.array([1, 0, 1]),
-                 np.array([1, 1, 0]))
-        m2 = yule(np.array([1, 0, 1], dtype=bool),
-                  np.array([1, 1, 0], dtype=bool))
+        m = wyule(np.array([1, 0, 1]),
+                  np.array([1, 1, 0]))
+        m2 = wyule(np.array([1, 0, 1], dtype=bool),
+                   np.array([1, 1, 0], dtype=bool))
         if verbose > 2:
             print(m)
         assert_allclose(m, 2, rtol=0, atol=1e-10)
         assert_allclose(m2, 2, rtol=0, atol=1e-10)
 
+    def test_pdist_yule_match(self):
+        D = eo['random-bool-data']
+        if verbose > 2:
+            print(D.shape, D.dtype)
+        eps = 1e-10
+        y1 = wpdist(D, "yule")
+        y2 = wpdist(D, "test_yule")
+        y3 = wpdist(np.bool_(D), "test_yule")
+        if verbose > 2:
+            print(np.abs(y1-y2).max())
+            print(np.abs(y2-y3).max())
+        _assert_within_tol(y1, y2, eps)
+        _assert_within_tol(y2, y3, eps)
+
     def test_pdist_dice_mtica1(self):
-        m = dice(np.array([1, 0, 1, 1, 0]),
-                 np.array([1, 1, 0, 1, 1]))
-        m2 = dice(np.array([1, 0, 1, 1, 0], dtype=bool),
-                  np.array([1, 1, 0, 1, 1], dtype=bool))
+        m = wdice(np.array([1, 0, 1, 1, 0]),
+                  np.array([1, 1, 0, 1, 1]))
+        m2 = wdice(np.array([1, 0, 1, 1, 0], dtype=bool),
+                   np.array([1, 1, 0, 1, 1], dtype=bool))
         if verbose > 2:
             print(m)
         assert_allclose(m, 3/7, rtol=0, atol=1e-10)
         assert_allclose(m2, 3/7, rtol=0, atol=1e-10)
 
     def test_pdist_dice_mtica2(self):
-        m = dice(np.array([1, 0, 1]),
-                 np.array([1, 1, 0]))
-        m2 = dice(np.array([1, 0, 1], dtype=bool),
-                  np.array([1, 1, 0], dtype=bool))
+        m = wdice(np.array([1, 0, 1]),
+                  np.array([1, 1, 0]))
+        m2 = wdice(np.array([1, 0, 1], dtype=bool),
+                   np.array([1, 1, 0], dtype=bool))
         if verbose > 2:
             print(m)
         assert_allclose(m, 0.5, rtol=0, atol=1e-10)
         assert_allclose(m2, 0.5, rtol=0, atol=1e-10)
 
+    def test_pdist_dice_match(self):
+        D = eo['random-bool-data']
+        if verbose > 2:
+            print(D.shape, D.dtype)
+        eps = 1e-10
+        y1 = wpdist(D, "dice")
+        y2 = wpdist(D, "test_dice")
+        y3 = wpdist(D, "test_dice")
+        if verbose > 2:
+            print(np.abs(y1-y2).max())
+            print(np.abs(y2-y3).max())
+        _assert_within_tol(y1, y2, eps)
+        _assert_within_tol(y2, y3, eps)
+
     def test_pdist_sokalsneath_mtica1(self):
-        m = sokalsneath(np.array([1, 0, 1, 1, 0]),
-                        np.array([1, 1, 0, 1, 1]))
-        m2 = sokalsneath(np.array([1, 0, 1, 1, 0], dtype=bool),
-                         np.array([1, 1, 0, 1, 1], dtype=bool))
+        m = wsokalsneath(np.array([1, 0, 1, 1, 0]),
+                         np.array([1, 1, 0, 1, 1]))
+        m2 = wsokalsneath(np.array([1, 0, 1, 1, 0], dtype=bool),
+                          np.array([1, 1, 0, 1, 1], dtype=bool))
         if verbose > 2:
             print(m)
         assert_allclose(m, 3/4, rtol=0, atol=1e-10)
         assert_allclose(m2, 3/4, rtol=0, atol=1e-10)
 
     def test_pdist_sokalsneath_mtica2(self):
-        m = sokalsneath(np.array([1, 0, 1]),
-                        np.array([1, 1, 0]))
-        m2 = sokalsneath(np.array([1, 0, 1], dtype=bool),
-                         np.array([1, 1, 0], dtype=bool))
+        m = wsokalsneath(np.array([1, 0, 1]),
+                         np.array([1, 1, 0]))
+        m2 = wsokalsneath(np.array([1, 0, 1], dtype=bool),
+                          np.array([1, 1, 0], dtype=bool))
         if verbose > 2:
             print(m)
         assert_allclose(m, 4/5, rtol=0, atol=1e-10)
         assert_allclose(m2, 4/5, rtol=0, atol=1e-10)
 
+    def test_pdist_sokalsneath_match(self):
+        D = eo['random-bool-data']
+        if verbose > 2:
+            print(D.shape, D.dtype)
+        eps = 1e-10
+        y1 = wpdist(D, "sokalsneath")
+        y2 = wpdist(D, "test_sokalsneath")
+        y3 = wpdist(np.bool_(D), "test_sokalsneath")
+        if verbose > 2:
+            print(np.abs(y1-y2).max())
+            print(np.abs(y2-y3).max())
+        _assert_within_tol(y1, y2, eps)
+        _assert_within_tol(y2, y3, eps)
+
     def test_pdist_rogerstanimoto_mtica1(self):
-        m = rogerstanimoto(np.array([1, 0, 1, 1, 0]),
-                           np.array([1, 1, 0, 1, 1]))
-        m2 = rogerstanimoto(np.array([1, 0, 1, 1, 0], dtype=bool),
-                            np.array([1, 1, 0, 1, 1], dtype=bool))
+        m = wrogerstanimoto(np.array([1, 0, 1, 1, 0]),
+                            np.array([1, 1, 0, 1, 1]))
+        m2 = wrogerstanimoto(np.array([1, 0, 1, 1, 0], dtype=bool),
+                             np.array([1, 1, 0, 1, 1], dtype=bool))
         if verbose > 2:
             print(m)
         assert_allclose(m, 3/4, rtol=0, atol=1e-10)
         assert_allclose(m2, 3/4, rtol=0, atol=1e-10)
 
     def test_pdist_rogerstanimoto_mtica2(self):
-        m = rogerstanimoto(np.array([1, 0, 1]),
-                           np.array([1, 1, 0]))
-        m2 = rogerstanimoto(np.array([1, 0, 1], dtype=bool),
-                            np.array([1, 1, 0], dtype=bool))
+        m = wrogerstanimoto(np.array([1, 0, 1]),
+                            np.array([1, 1, 0]))
+        m2 = wrogerstanimoto(np.array([1, 0, 1], dtype=bool),
+                             np.array([1, 1, 0], dtype=bool))
         if verbose > 2:
             print(m)
         assert_allclose(m, 4/5, rtol=0, atol=1e-10)
         assert_allclose(m2, 4/5, rtol=0, atol=1e-10)
 
+    def test_pdist_rogerstanimoto_match(self):
+        D = eo['random-bool-data']
+        if verbose > 2:
+            print(D.shape, D.dtype)
+        eps = 1e-10
+        y1 = wpdist(D, "rogerstanimoto")
+        y2 = wpdist(D, "test_rogerstanimoto")
+        y3 = wpdist(np.bool_(D), "test_rogerstanimoto")
+        if verbose > 2:
+            print(np.abs(y1-y2).max())
+            print(np.abs(y2-y3).max())
+        _assert_within_tol(y1, y2, eps)
+        _assert_within_tol(y2, y3, eps)
+
     def test_pdist_russellrao_mtica1(self):
-        m = russellrao(np.array([1, 0, 1, 1, 0]),
-                       np.array([1, 1, 0, 1, 1]))
-        m2 = russellrao(np.array([1, 0, 1, 1, 0], dtype=bool),
-                        np.array([1, 1, 0, 1, 1], dtype=bool))
+        m = wrussellrao(np.array([1, 0, 1, 1, 0]),
+                        np.array([1, 1, 0, 1, 1]))
+        m2 = wrussellrao(np.array([1, 0, 1, 1, 0], dtype=bool),
+                         np.array([1, 1, 0, 1, 1], dtype=bool))
         if verbose > 2:
             print(m)
         assert_allclose(m, 3/5, rtol=0, atol=1e-10)
         assert_allclose(m2, 3/5, rtol=0, atol=1e-10)
 
     def test_pdist_russellrao_mtica2(self):
-        m = russellrao(np.array([1, 0, 1]),
-                       np.array([1, 1, 0]))
-        m2 = russellrao(np.array([1, 0, 1], dtype=bool),
-                        np.array([1, 1, 0], dtype=bool))
+        m = wrussellrao(np.array([1, 0, 1]),
+                        np.array([1, 1, 0]))
+        m2 = wrussellrao(np.array([1, 0, 1], dtype=bool),
+                         np.array([1, 1, 0], dtype=bool))
         if verbose > 2:
             print(m)
         assert_allclose(m, 2/3, rtol=0, atol=1e-10)
         assert_allclose(m2, 2/3, rtol=0, atol=1e-10)
+
+    def test_pdist_russellrao_match(self):
+        D = eo['random-bool-data']
+        if verbose > 2:
+            print(D.shape, D.dtype)
+        eps = 1e-10
+        y1 = wpdist(D, "russellrao")
+        y2 = wpdist(D, "test_russellrao")
+        y3 = wpdist(np.bool_(D), "test_russellrao")
+        if verbose > 2:
+            print(np.abs(y1-y2).max())
+            print(np.abs(y2-y3).max())
+        _assert_within_tol(y1, y2, eps)
+        _assert_within_tol(y2, y3, eps)
+
+    def test_pdist_sokalmichener_match(self):
+        D = eo['random-bool-data']
+        if verbose > 2:
+            print(D.shape, D.dtype)
+        eps = 1e-10
+        y1 = wpdist(D, "sokalmichener")
+        y2 = wpdist(D, "test_sokalmichener")
+        y3 = wpdist(np.bool_(D), "test_sokalmichener")
+        if verbose > 2:
+            print(np.abs(y1-y2).max())
+            print(np.abs(y2-y3).max())
+        _assert_within_tol(y1, y2, eps)
+        _assert_within_tol(y2, y3, eps)
+
+    def test_pdist_kulsinski_match(self):
+        D = eo['random-bool-data']
+        if verbose > 2:
+            print(D.shape, D.dtype)
+        eps = 1e-10
+        y1 = wpdist(D, "kulsinski")
+        y2 = wpdist(D, "test_kulsinski")
+        y3 = wpdist(np.bool_(D), "test_kulsinski")
+        _assert_within_tol(y1, y2, eps, verbose > 2)
+        _assert_within_tol(y2, y3, eps)
 
     def test_pdist_canberra_match(self):
         D = eo['iris']
         if verbose > 2:
             print(D.shape, D.dtype)
         eps = 1e-10
-        y1 = pdist(D, "canberra")
-        y2 = pdist(D, "test_canberra")
+        y1 = wpdist_no_const(D, "canberra")
+        y2 = wpdist_no_const(D, "test_canberra")
         _assert_within_tol(y1, y2, eps, verbose > 2)
 
     def test_pdist_canberra_ticket_711(self):
         # Test pdist(X, 'canberra') to see if Canberra gives the right result
         # as reported on gh-1238.
         eps = 1e-8
-        pdist_y = pdist(([3.3], [3.4]), "canberra")
+        pdist_y = wpdist_no_const(([3.3], [3.4]), "canberra")
         right_y = 0.01492537
         _assert_within_tol(pdist_y, right_y, eps, verbose > 2)
-
-    def test_pdist_custom_notdouble(self):
-        # tests that when using a custom metric the data type is not altered
-        class myclass(object):
-            pass
-
-        def dummy_metric(x, y):
-            if not isinstance(x[0], myclass) or not isinstance(y[0], myclass):
-                raise ValueError("Type has been changed")
-            return 1.123
-        data = np.array([[myclass()], [myclass()]], dtype=object)
-        pdist_y = pdist(data, metric=dummy_metric)
-        right_y = 1.123
-        assert_equal(pdist_y, right_y, verbose=verbose > 2)
-
-    def _check_calling_conventions(self, X, metric, eps=1e-07, **kwargs):
-        # helper function for test_cdist_calling_conventions
-        try:
-            y1 = pdist(X, metric=metric, **kwargs)
-            y2 = pdist(X, metric=eval(metric), **kwargs)
-            y3 = pdist(X, metric="test_" + metric, **kwargs)
-        except Exception as e:
-            e_cls = e.__class__
-            if verbose > 2:
-                print(e_cls.__name__)
-                print(e)
-            assert_raises(e_cls, pdist, X, metric=metric, **kwargs)
-            assert_raises(e_cls, pdist, X, metric=eval(metric), **kwargs)
-            assert_raises(e_cls, pdist, X, metric="test_" + metric, **kwargs)
-        else:
-            _assert_within_tol(y1, y2, eps, verbose > 2)
-            _assert_within_tol(y1, y3, eps, verbose > 2)
-
-    def test_pdist_calling_conventions(self):
-        # Ensures that specifying the metric with a str or scipy function
-        # gives the same behaviour (i.e. same result or same exception).
-        # NOTE: The correctness should be checked within each metric tests.
-        # NOTE: Extra args should be checked with a dedicated test
-        eps = 1e-07
-        for eo_name in self.rnd_eo_names:
-            X = eo[eo_name][::2]
-            for metric in _metrics:
-                if verbose > 2:
-                    print("testing: ", metric, " with: ", eo_name)
-                if metric == 'yule' and 'bool' not in eo_name:
-                    # python raises a ZeroDivisionError while the C doesn't
-                    continue
-                self._check_calling_conventions(X, metric)
-
-                # Testing built-in metrics with extra args
-                if metric == "wminkowski":
-                    w = 1.0 / X.std(axis=0)
-                    self._check_calling_conventions(X, metric, w=w)
-                elif metric == "seuclidean":
-                    V = np.var(X.astype(np.double), axis=0, ddof=1)
-                    self._check_calling_conventions(X, metric, V=V)
-                elif metric == "mahalanobis":
-                    V = np.atleast_2d(np.cov(X.astype(np.double).T))
-                    VI = np.array(np.linalg.inv(V).T)
-                    self._check_calling_conventions(X, metric, VI=VI)
-
-    def test_pdist_dtype_equivalence(self):
-        # Tests that the result is not affected by type up-casting
-        eps = 1e-07
-        tests = [(eo['random-bool-data'], self.valid_upcasts['bool']),
-                 (eo['random-uint-data'], self.valid_upcasts['uint']),
-                 (eo['random-int-data'], self.valid_upcasts['int']),
-                 (eo['random-float32-data'], self.valid_upcasts['float32'])]
-        for metric in _metrics:
-            for test in tests:
-                X1 = test[0]
-                try:
-                    y1 = pdist(X1, metric=metric)
-                except Exception as e:
-                    e_cls = e.__class__
-                    if verbose > 2:
-                        print(e_cls.__name__)
-                        print(e)
-                    for new_type in test[1]:
-                        X2 = new_type(test[0])
-                        assert_raises(e_cls, pdist, X2, metric=metric)
-                else:
-                    for new_type in test[1]:
-                        y2 = pdist(new_type(X1), metric=metric)
-                        _assert_within_tol(y1, y2, eps, verbose > 2)
-
-
-def within_tol(a, b, tol):
-    return np.abs(a - b).max() < tol
-
-
-def _assert_within_tol(a, b, atol, verbose_=False):
-    if verbose_:
-        print(np.abs(a - b).max())
-    assert_allclose(a, b, rtol=0, atol=atol)
 
 
 class TestSomeDistanceFunctions(TestCase):
@@ -1070,43 +1253,33 @@ class TestSomeDistanceFunctions(TestCase):
 
     def test_minkowski(self):
         for x, y in self.cases:
-            dist1 = minkowski(x, y, p=1)
+            dist1 = wminkowski(x, y, p=1)
             assert_almost_equal(dist1, 3.0)
-            dist1p5 = minkowski(x, y, p=1.5)
+            dist1p5 = wminkowski(x, y, p=1.5)
             assert_almost_equal(dist1p5, (1.0+2.0**1.5)**(2./3))
-            dist2 = minkowski(x, y, p=2)
-            assert_almost_equal(dist2, np.sqrt(5))
-
-    def test_wminkowski(self):
-        w = np.array([1.0, 2.0, 0.5])
-        for x, y in self.cases:
-            dist1 = wminkowski(x, y, p=1, w=w)
-            assert_almost_equal(dist1, 3.0)
-            dist1p5 = wminkowski(x, y, p=1.5, w=w)
-            assert_almost_equal(dist1p5, (2.0**1.5+1.0)**(2./3))
-            dist2 = wminkowski(x, y, p=2, w=w)
+            dist2 = wminkowski(x, y, p=2)
             assert_almost_equal(dist2, np.sqrt(5))
 
     def test_euclidean(self):
         for x, y in self.cases:
-            dist = euclidean(x, y)
+            dist = weuclidean(x, y)
             assert_almost_equal(dist, np.sqrt(5))
 
     def test_sqeuclidean(self):
         for x, y in self.cases:
-            dist = sqeuclidean(x, y)
+            dist = wsqeuclidean(x, y)
             assert_almost_equal(dist, 5.0)
 
     def test_cosine(self):
         for x, y in self.cases:
-            dist = cosine(x, y)
+            dist = wcosine(x, y)
             assert_almost_equal(dist, 1.0 - 18.0/(np.sqrt(14)*np.sqrt(27)))
 
     def test_correlation(self):
         xm = np.array([-1.0, 0, 1.0])
         ym = np.array([-4.0/3, -4.0/3, 5.0-7.0/3])
         for x, y in self.cases:
-            dist = correlation(x, y)
+            dist = wcorrelation(x, y)
             assert_almost_equal(dist, 1.0 - np.dot(xm, ym)/(norm(xm)*norm(ym)))
 
     def test_mahalanobis(self):
@@ -1165,7 +1338,7 @@ class TestSquareForm(object):
 
     def check_squareform_multi_matrix(self, n):
         X = np.random.rand(n, 4)
-        Y = pdist(X)
+        Y = wpdist_no_const(X)
         assert_equal(len(Y.shape), 1)
         A = squareform(Y)
         Yr = squareform(A)
@@ -1190,7 +1363,7 @@ class TestNumObsY(TestCase):
     def test_num_obs_y_multi_matrix(self):
         for n in xrange(2, 10):
             X = np.random.rand(n, 4)
-            Y = pdist(X)
+            Y = wpdist_no_const(X)
             assert_equal(num_obs_y(Y), n)
 
     def test_num_obs_y_1(self):
@@ -1242,7 +1415,7 @@ class TestNumObsDM(TestCase):
     def test_num_obs_dm_multi_matrix(self):
         for n in xrange(1, 10):
             X = np.random.rand(n, 4)
-            Y = pdist(X)
+            Y = wpdist_no_const(X)
             A = squareform(Y)
             if verbose >= 3:
                 print(A.shape, Y.shape)
@@ -1406,25 +1579,25 @@ class TestIsValidY(TestCase):
 def test_bad_p():
     # Raise ValueError if p < 1.
     p = 0.5
-    assert_raises(ValueError, minkowski, [1, 2], [3, 4], p)
+    assert_raises(ValueError, wminkowski, [1, 2], [3, 4], p)
     assert_raises(ValueError, wminkowski, [1, 2], [3, 4], p, [1, 1])
 
 
 def test_sokalsneath_all_false():
     # Regression test for ticket #876
-    assert_raises(ValueError, sokalsneath, [False, False, False], [False, False, False])
+    assert_raises(ValueError, wsokalsneath, [False, False, False], [False, False, False])
 
 
 def test_canberra():
     # Regression test for ticket #1430.
-    assert_equal(canberra([1,2,3], [2,4,6]), 1)
-    assert_equal(canberra([1,1,0,0], [1,0,1,0]), 2)
+    assert_equal(wcanberra([1,2,3], [2,4,6]), 1)
+    assert_equal(wcanberra([1,1,0,0], [1,0,1,0]), 2)
 
 
 def test_braycurtis():
     # Regression test for ticket #1430.
-    assert_almost_equal(braycurtis([1,2,3], [2,4,6]), 1./3, decimal=15)
-    assert_almost_equal(braycurtis([1,1,0,0], [1,0,1,0]), 0.5, decimal=15)
+    assert_almost_equal(wbraycurtis([1,2,3], [2,4,6]), 1./3, decimal=15)
+    assert_almost_equal(wbraycurtis([1,1,0,0], [1,0,1,0]), 0.5, decimal=15)
 
 
 def test_euclideans():
@@ -1433,28 +1606,28 @@ def test_euclideans():
     x2 = np.array([0, 0, 0])
 
     # Basic test of the calculation.
-    assert_almost_equal(sqeuclidean(x1, x2), 3.0, decimal=14)
-    assert_almost_equal(euclidean(x1, x2), np.sqrt(3), decimal=14)
+    assert_almost_equal(wsqeuclidean(x1, x2), 3.0, decimal=14)
+    assert_almost_equal(weuclidean(x1, x2), np.sqrt(3), decimal=14)
 
     # Check flattening for (1, N) or (N, 1) inputs
-    assert_almost_equal(euclidean(x1[np.newaxis, :], x2[np.newaxis, :]),
+    assert_almost_equal(weuclidean(x1[np.newaxis, :], x2[np.newaxis, :]),
                         np.sqrt(3), decimal=14)
-    assert_almost_equal(sqeuclidean(x1[np.newaxis, :], x2[np.newaxis, :]),
+    assert_almost_equal(wsqeuclidean(x1[np.newaxis, :], x2[np.newaxis, :]),
                         3.0, decimal=14)
-    assert_almost_equal(sqeuclidean(x1[:, np.newaxis], x2[:, np.newaxis]),
+    assert_almost_equal(wsqeuclidean(x1[:, np.newaxis], x2[:, np.newaxis]),
                         3.0, decimal=14)
 
     # Distance metrics only defined for vectors (= 1-D)
     x = np.arange(4).reshape(2, 2)
-    assert_raises(ValueError, euclidean, x, x)
-    assert_raises(ValueError, sqeuclidean, x, x)
+    assert_raises(ValueError, weuclidean, x, x)
+    assert_raises(ValueError, wsqeuclidean, x, x)
 
     # Another check, with random data.
     rs = np.random.RandomState(1234567890)
     x = rs.rand(10)
     y = rs.rand(10)
-    d1 = euclidean(x, y)
-    d2 = sqeuclidean(x, y)
+    d1 = weuclidean(x, y)
+    d2 = wsqeuclidean(x, y)
     assert_almost_equal(d1**2, d2, decimal=14)
 
 
@@ -1463,7 +1636,7 @@ def test_hamming_unequal_length():
     x = [0, 0, 1]
     y = [1, 0, 1, 0]
     # Used to give an AttributeError from ndarray.mean called on bool
-    assert_raises(ValueError, hamming, x, y)
+    assert_raises(ValueError, whamming, x, y)
 
 
 def test_hamming_string_array():
@@ -1477,7 +1650,7 @@ def test_hamming_string_array():
                   'spam', 'spam', 'eggs', 'spam', 'spam', 'eggs'],
                   dtype='|S4')
     desired = 0.45
-    assert_allclose(hamming(a, b), desired)
+    assert_allclose(whamming(a, b), desired)
 
 
 def test_sqeuclidean_dtypes():
@@ -1488,12 +1661,12 @@ def test_sqeuclidean_dtypes():
     y = [4, 5, 6]
 
     for dtype in [np.int8, np.int16, np.int32, np.int64]:
-        d = sqeuclidean(np.asarray(x, dtype=dtype), np.asarray(y, dtype=dtype))
+        d = wsqeuclidean(np.asarray(x, dtype=dtype), np.asarray(y, dtype=dtype))
         assert_(np.issubdtype(d.dtype, np.floating))
 
     for dtype in [np.uint8, np.uint16, np.uint32, np.uint64]:
-        d1 = sqeuclidean([0], np.asarray([-1], dtype=dtype))
-        d2 = sqeuclidean(np.asarray([-1], dtype=dtype), [0])
+        d1 = wsqeuclidean([0], np.asarray([-1], dtype=dtype))
+        d2 = wsqeuclidean(np.asarray([-1], dtype=dtype), [0])
 
         assert_equal(d1, d2)
         assert_equal(d1, np.float64(np.iinfo(dtype).max) ** 2)
@@ -1506,7 +1679,7 @@ def test_sqeuclidean_dtypes():
             dtypes.append(getattr(np, dtype))
 
     for dtype in dtypes:
-        d = sqeuclidean(np.asarray(x, dtype=dtype), np.asarray(y, dtype=dtype))
+        d = wsqeuclidean(np.asarray(x, dtype=dtype), np.asarray(y, dtype=dtype))
         assert_equal(d.dtype, dtype)
 
 
@@ -1516,8 +1689,8 @@ def test_sokalmichener():
     q = [True, False, True]
     x = [int(b) for b in p]
     y = [int(b) for b in q]
-    dist1 = sokalmichener(p, q)
-    dist2 = sokalmichener(x, y)
+    dist1 = wsokalmichener(p, q)
+    dist2 = wsokalmichener(x, y)
     # These should be exactly the same.
     assert_equal(dist1, dist2)
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3826,7 +3826,7 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate'):
 WeightedTauResult = namedtuple('WeightedTauResult', ('correlation', 'pvalue'))
 
 def weightedtau(x, y, rank=True, weigher=None, additive=True):
-    """
+    r"""
     Computes a weighted version of Kendall's :math:`\tau`.
     The weighted :math:`\tau` is a weighted version of Kendall's
     :math:`\tau` in which exchanges of high weight are more influential than

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -402,7 +402,8 @@ def gmean(a, axis=0, dtype=None, weights=None):
     arrays automatically mask any non-finite values.
 
     """
-    a, weights, axis = _chk_weights([a], weights=weights, axis=axis, mask_screen=True)
+    a, weights, axis = _chk_weights([a], weights=weights, axis=axis,
+                                    mask_screen=True, pos_only=True)
     log_a = np.log(np.asanyarray(a, dtype=dtype))
     return np.exp(_avg(log_a, axis=axis, weights=weights))
 
@@ -451,7 +452,8 @@ def hmean(a, axis=0, dtype=None, weights=None):
     arise in the calculations such as Not a Number and infinity.
 
     """
-    a, weights, axis = _chk_weights([a], weights=weights, axis=axis, mask_screen=True)
+    a, weights, axis = _chk_weights([a], weights=weights, axis=axis,
+                                    mask_screen=True, pos_only=True)
     a = np.asanyarray(a, dtype=dtype)
     if not np.all(a > 0):
         # Harmonic mean only defined if greater than zero
@@ -3553,7 +3555,7 @@ def spearmanr(a, b=None, axis=0, nan_policy='propagate', weights=None):
             if br is None or ar.ndim > 1:
                 raise NotImplementedError("weighted matrix correlations not"
                                           "implemented with numpy < 1.10")
-            rs = pearsonr(ar, br, weights=weights)
+            rs = pearsonr(ar, br, weights=weights)[0]
         else:
             stddev = np.sqrt(np.diag(rs).real)
             rs /= stddev[:, None]

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -233,7 +233,7 @@ def _weight_masked(arrays, weights, axis):
         if a.ndim > 1:
             not_axes = tuple(i for i in range(a.ndim) if i != axis)
             axis_mask = axis_mask.any(axis=not_axes)
-        weights *= 1 - axis_mask
+        weights *= 1 - axis_mask.astype(int)
     return weights
 
 
@@ -404,7 +404,11 @@ def gmean(a, axis=0, dtype=None, weights=None):
     """
     a, weights, axis = _chk_weights([a], weights=weights, axis=axis,
                                     mask_screen=True, pos_only=True)
-    log_a = np.log(np.asanyarray(a, dtype=dtype))
+    if a.ndim == 1:  # fixes weird old numpy bug?
+        a = np.asarray(a, dtype=dtype)
+    else:
+        a = np.asanyarray(a, dtype=dtype)
+    log_a = np.log(a)
     return np.exp(_avg(log_a, axis=axis, weights=weights))
 
 
@@ -454,7 +458,10 @@ def hmean(a, axis=0, dtype=None, weights=None):
     """
     a, weights, axis = _chk_weights([a], weights=weights, axis=axis,
                                     mask_screen=True, pos_only=True)
-    a = np.asanyarray(a, dtype=dtype)
+    if a.ndim == 1:  # fixes weird old numpy bug?
+        a = np.asarray(a, dtype=dtype)
+    else:
+        a = np.asanyarray(a, dtype=dtype)
     if not np.all(a > 0):
         # Harmonic mean only defined if greater than zero
         raise ValueError("Harmonic mean only defined if all elements greater than zero")

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -204,7 +204,9 @@ __all__ = ['find_repeats', 'gmean', 'hmean', 'mode', 'tmean', 'tvar',
 
 def _chk_asarrays(arrays, axis=None):
     if axis is None:
-        arrays = [np.ravel(a) for a in arrays]
+        # np < 1.10 ravel removes subclass from arrays
+        arrays = [np.ravel(a) if a.ndim != 1 else 1
+                  for a in arrays]
         axis = 0
     arrays = tuple(np.atleast_1d(a) for a in arrays)
     if axis < 0:
@@ -404,10 +406,7 @@ def gmean(a, axis=0, dtype=None, weights=None):
     """
     a, weights, axis = _chk_weights([a], weights=weights, axis=axis,
                                     mask_screen=True, pos_only=True)
-    if a.ndim == 1:  # fixes weird old numpy bug?
-        a = np.asarray(a, dtype=dtype)
-    else:
-        a = np.asanyarray(a, dtype=dtype)
+    a = np.asanyarray(a, dtype=dtype)
     log_a = np.log(a)
     return np.exp(_avg(log_a, axis=axis, weights=weights))
 
@@ -458,10 +457,7 @@ def hmean(a, axis=0, dtype=None, weights=None):
     """
     a, weights, axis = _chk_weights([a], weights=weights, axis=axis,
                                     mask_screen=True, pos_only=True)
-    if a.ndim == 1:  # fixes weird old numpy bug?
-        a = np.asarray(a, dtype=dtype)
-    else:
-        a = np.asanyarray(a, dtype=dtype)
+    a = np.asanyarray(a, dtype=dtype)
     if not np.all(a > 0):
         # Harmonic mean only defined if greater than zero
         raise ValueError("Harmonic mean only defined if all elements greater than zero")

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -257,7 +257,6 @@ def _chk_weights(arrays, weights=None, axis=None,
     simplify_weights = simplify_weights and not force_weights
     if not force_weights and mask_screen:
         force_weights = any(np.ma.getmask(a) is not np.ma.nomask for a in arrays)
-        arrays = tuple(np.asarray(a) for a in arrays)
 
     if nan_screen:
         has_nans = [np.isnan(np.sum(a)) for a in arrays]

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -506,7 +506,7 @@ def mode(a, axis=0, nan_policy='propagate', weights=None):
     for score in scores:
         template = (a == score)
         if weights is not None:
-            template = weights * template #.astype(int)
+            template = weights * template
         counts = np.expand_dims(np.sum(template, axis), axis)
         mostfrequent = np.where(counts > oldcounts, score, oldmostfreq)
         oldcounts = np.maximum(counts, oldcounts)
@@ -609,7 +609,6 @@ def tmean(a, limits=None, inclusive=(True, True), axis=None, weights=None):
         limits = (None, None)
     am = _mask_to_limits(a, limits, inclusive)
     return np.ma.average(am, axis=axis, weights=weights)
-
 
 
 def tvar(a, limits=None, inclusive=(True, True), axis=0, ddof=1, weights=None):
@@ -1120,8 +1119,9 @@ def skew(a, axis=0, bias=True, nan_policy='propagate', weights=None):
     vals = _lazywhere(~zero, (m2, m3),
                       lambda m2, m3: m3 / m2**1.5,
                       0.)
-    if not bias: # TODO: weighted bias correction?
+    if not bias:
         if weights is not None:
+            # TODO: weighted bias correction
             raise NotImplementedError("weighted bias correction non-obvious")
         can_correct = (n > 2) & (m2 is not ma.masked and m2 > 0)
         if can_correct.any():
@@ -1200,8 +1200,9 @@ def kurtosis(a, axis=0, fisher=True, bias=True, nan_policy='propagate', weights=
     finally:
         np.seterr(**olderr)
 
-    if not bias: # TODO: weighted bias correction?
+    if not bias:
         if weights is not None:
+            # TODO: weighted bias correction
             raise NotImplementedError("weighted bias correction non-obvious")
         can_correct = (n > 3) & (m2 is not ma.masked and m2 > 0)
         if can_correct.any():
@@ -1274,7 +1275,7 @@ def describe(a, axis=0, ddof=1, bias=True, nan_policy='propagate', weights=None)
     >>> from scipy import stats
     >>> a = np.arange(10)
     >>> stats.describe(a)
-    DescribeResult(nobs=10, minmax=(0, 9), mean=4.5, variance=9.1666666666666661,
+    DescribeResult(nobs=10, minmax=(0, 9), mean=4.5, variance=9.1666666666666679,
                    skewness=0.0, kurtosis=-1.2242424242424244)
     >>> b = [[1, 2], [3, 4]]
     >>> stats.describe(b)
@@ -3875,12 +3876,14 @@ def weightedtau(x, y, rank=True, weigher=None, additive=True):
     >>> tau, p_value = stats.weightedtau(x, y, additive=False)
     >>> tau
     -0.62205716951801038
+
     NaNs are considered the smallest possible score:
     >>> x = [12, 2, 1, 12, 2]
     >>> y = [1, 4, 7, 1, np.nan]
     >>> tau, _ = stats.weightedtau(x, y)
     >>> tau
     -0.56694968153682723
+
     This is exactly Kendall's tau:
     >>> x = [12, 2, 1, 12, 2]
     >>> y = [1, 4, 7, 1, 0]
@@ -5783,7 +5786,7 @@ def rankdata(a, method='average', weights=None):
     # cumulative counts of each unique value
     if weights is None:
         count = np.r_[np.nonzero(obs)[0], len(obs)]
-    else: # weighted count
+    else:  # weighted count
         count = np.r_[0, np.roll(weights_arr.cumsum()[np.where(obs)[0]-1], -1)]
         # equivalently, slower, cleaner:
         #  count = np.r_[(weights_arr.cumsum() - weights_arr)[obs], weights_arr.sum()]

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -257,7 +257,7 @@ def _chk_weights(arrays, weights=None, axis=None,
     simplify_weights = simplify_weights and not force_weights
     if not force_weights and mask_screen:
         force_weights = any(np.ma.getmask(a) is not np.ma.nomask for a in arrays)
-        arrays = [np.asarray(a) for a in arrays]
+        arrays = tuple(np.asarray(a) for a in arrays)
 
     if nan_screen:
         has_nans = [np.isnan(np.sum(a)) for a in arrays]

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -203,9 +203,10 @@ __all__ = ['find_repeats', 'gmean', 'hmean', 'mode', 'tmean', 'tvar',
 
 
 def _chk_asarrays(arrays, axis=None):
+    arrays = [np.asanyarray(a) for a in arrays]
     if axis is None:
         # np < 1.10 ravel removes subclass from arrays
-        arrays = [np.ravel(a) if a.ndim != 1 else 1
+        arrays = [np.ravel(a) if a.ndim != 1 else a
                   for a in arrays]
         axis = 0
     arrays = tuple(np.atleast_1d(a) for a in arrays)

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -2434,7 +2434,7 @@ def zscore(a, axis=0, ddof=0, weights=None):
            [-0.22095197,  0.24468594,  1.19042819, -1.21416216],
            [-0.82780366,  1.4457416 , -0.43867764, -0.1792603 ]])
     """
-    a, weights, axis = _chk_weights([a], weights=weigths, axis=axis, ddof=ddof)
+    a, weights, axis = _chk_weights([a], weights=weights, axis=axis, ddof=ddof)
     mns = _avg(a, axis=axis, weights=weights)
     sstd = np.sqrt(_var(a, axis=axis, ddof=ddof, weights=weights))
     if axis and mns.ndim < a.ndim:
@@ -2489,7 +2489,7 @@ def zmap(scores, compare, axis=0, ddof=0, weights=None):
     >>> zmap(a, b)
     array([-1.06066017,  0.        ,  0.35355339,  0.70710678])
     """
-    score, compare, weights, axis = _chk_weights([scores, compare], weights=weigths,
+    score, compare, weights, axis = _chk_weights([scores, compare], weights=weights,
                                                  axis=axis, ddof=ddof)
     mns = _avg(compare, axis=axis, weights=weights)
     sstd = np.sqrt(_var(compare, axis=axis, ddof=ddof, weights=weights))

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -227,8 +227,8 @@ def _weight_masked(arrays, weights, axis):
         axis = 0
     weights = np.asanyarray(weights)
     for a in arrays:
-        axis_mask = np.ma.getmask(a)
-        if axis_mask is np.ma.nomask:
+        axis_mask = np.ma.getmaskarray(a)
+        if (~axis_mask).all():
             continue
         if a.ndim > 1:
             not_axes = tuple(i for i in range(a.ndim) if i != axis)
@@ -513,9 +513,9 @@ def mode(a, axis=0, nan_policy='propagate', weights=None):
     if a.size == 0:
         return np.array([]), np.array([])
     if weights is not None and weights.ndim == 1 and 1 < a.ndim:
-        weight_shape = [slice(None) if i == axis else np.newaxis
-                        for i in range(a.ndim)]
-        weights = np.broadcast_to(weights[weight_shape], a.shape)
+        weight_shape = [np.newaxis] * a.ndim
+        weight_shape[axis] = slice(None)
+        weights = weights[weight_shape]
 
     contains_nan, nan_policy = _contains_nan(a, nan_policy)
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -834,7 +834,7 @@ def tstd(a, limits=None, inclusive=(True, True), axis=0, ddof=1, weights=None):
     return np.sqrt(tvar(a, limits, inclusive, axis, ddof, weights=weights))
 
 
-def tsem(a, limits=None, inclusive=(True, True), axis=0, ddof=1, weights=None):
+def tsem(a, limits=None, inclusive=(True, True), axis=0, ddof=1):
     """
     Compute the trimmed standard error of the mean.
 
@@ -859,9 +859,6 @@ def tsem(a, limits=None, inclusive=(True, True), axis=0, ddof=1, weights=None):
         whole array `a`.
     ddof : int, optional
         Delta degrees of freedom.  Default is 1.
-    weights : array_like, optional
-        The weights for each value in `a`. Default is None, which gives each
-        value a weight of 1.0
 
     Returns
     -------
@@ -882,11 +879,11 @@ def tsem(a, limits=None, inclusive=(True, True), axis=0, ddof=1, weights=None):
     1.1547005383792515
 
     """
-    a, weights, axis = _chk_weights([a], weights=weights, axis=axis)
+    a, axis = _chk_asarrays([a], axis=axis)
     if limits is None:
         limits = (None, None)
     am = _mask_to_limits(a, limits, inclusive)
-    sd = np.sqrt(_var(am, axis=axis, ddof=ddof, weights=weights))
+    sd = np.std(am, axis=axis, ddof=ddof)
     n = am.count(axis=axis)
     return sd / np.sqrt(n)
 
@@ -1341,6 +1338,11 @@ def skewtest(a, axis=0, nan_policy='propagate'):
     -----
     The sample size must be at least 8.
 
+    References
+    ----------
+    .. [1] R. B. D'Agostino, A. J. Belanger and R. B. D'Agostino Jr.,
+            "A suggestion for using powerful and informative tests of
+            normality", American Statistician 44, pp. 316-321, 1990.
     """
     a, axis = _chk_asarrays([a], axis=axis)
 
@@ -1609,9 +1611,12 @@ def itemfreq(a, weights=None):
     return np.array([items, freq]).T
 
 
-def collapse_weights(a, weights=None, axis=None):
+def collapse_weights(a, weights=None, axis=0):
     """
-    Collapse a weigthed representation of an array.
+    Collapse a weighted representation of an array. If axis is not None, and ndim > 1,
+    then this functions considers a "record" to consist of all of the axes which are not
+    the axis specified. It looks for uniques among "records", and sums up their weight.
+    It assumes that `weights is None`, or `a.shape[axis] == weights.size`.
 
     Parameters
     ----------
@@ -1627,7 +1632,7 @@ def collapse_weights(a, weights=None, axis=None):
     Returns
     -------
     uniq_a : ndarray
-        An ndarray of the sorted record in `a`, without duplicates.
+        An ndarray of the sorted records in `a`, without duplicates.
     uniq_w : array
         The weights for each record in `uniq_a` along `axis`d that
         make it representationally equivalent.

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -228,7 +228,7 @@ def _weight_masked(arrays, weights, axis):
     weights = np.asanyarray(weights)
     for a in arrays:
         axis_mask = np.ma.getmaskarray(a)
-        if (~axis_mask).all():
+        if (~axis_mask).all():  # np.ma.getmask(a) is np.ma.nomask
             continue
         if a.ndim > 1:
             not_axes = tuple(i for i in range(a.ndim) if i != axis)
@@ -257,6 +257,7 @@ def _chk_weights(arrays, weights=None, axis=None,
     simplify_weights = simplify_weights and not force_weights
     if not force_weights and mask_screen:
         force_weights = any(np.ma.getmask(a) is not np.ma.nomask for a in arrays)
+        arrays = [np.asarray(a) for a in arrays]
 
     if nan_screen:
         has_nans = [np.isnan(np.sum(a)) for a in arrays]
@@ -919,7 +920,10 @@ def tsem(a, limits=None, inclusive=(True, True), axis=0, ddof=1, weights=None):
         n = am.count(axis)
     else:
         n = _weight_masked([am], weights, axis).sum()
-    return sd / np.sqrt(n)
+    result = sd / np.sqrt(n)
+    if not np.isscalar(result):
+        result = np.array(result)
+    return result
 
 
 #####################################
@@ -3848,6 +3852,7 @@ def weightedtau(x, y, rank=True, weigher=None, additive=True):
     ranks, rather than of scores (i.e., a larger value implies a lower
     rank) you must negate the ranks, so that elements of higher rank are
     associated with a larger value.
+
     Parameters
     ----------
     x, y : array_like
@@ -3871,6 +3876,7 @@ def weightedtau(x, y, rank=True, weigher=None, additive=True):
         If True, the weight of an exchange is computed by adding the
         weights of the ranks of the exchanged elements; otherwise, the weights
         are multiplied. The default is True.
+
     Returns
     -------
     correlation : float
@@ -3878,11 +3884,13 @@ def weightedtau(x, y, rank=True, weigher=None, additive=True):
     pvalue : float
        Presently ``np.nan``, as the null statistics is unknown (even in the
        additive hyperbolic case).
+
     See also
     --------
     kendalltau : Calculates Kendall's tau.
     spearmanr : Calculates a Spearman rank-order correlation coefficient.
     theilslopes : Computes the Theil-Sen estimator for a set of points (x, y).
+
     Notes
     -----
     This function uses an :math:`O(n \log n)`, mergesort-based algorithm
@@ -3893,6 +3901,7 @@ def weightedtau(x, y, rank=True, weigher=None, additive=True):
     generalization of Shieh's.
     NaNs are considered the smallest possible score.
     .. versionadded:: 0.19.0
+
     References
     ----------
     .. [1] Sebastiano Vigna, "A weighted correlation index for rankings with
@@ -3903,6 +3912,7 @@ def weightedtau(x, y, rank=True, weigher=None, additive=True):
            Vol. 61, No. 314, Part 1, pp. 436-439, 1966.
     .. [3] Grace S. Shieh. "A weighted Kendall's tau statistic", Statistics &
            Probability Letters, Vol. 39, No. 1, pp. 17-24, 1998.
+
     Examples
     --------
     >>> from scipy import stats

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -227,8 +227,8 @@ def _weight_masked(arrays, weights, axis):
         axis = 0
     weights = np.asanyarray(weights)
     for a in arrays:
-        axis_mask = np.ma.getmaskarray(a)
-        if (~axis_mask).all():  # np.ma.getmask(a) is np.ma.nomask
+        axis_mask = np.ma.getmask(a)
+        if axis_mask is np.ma.nomask:
             continue
         if a.ndim > 1:
             not_axes = tuple(i for i in range(a.ndim) if i != axis)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -191,7 +191,7 @@ class TestTrimmedStats(TestCase):
     dprec = np.finfo(np.float64).precision
 
     def test_tmean(self):
-        wtmean = _weight_checked(stats.tmean)
+        wtmean = _weight_checked(stats.tmean, ma_safe=False)
         y = wtmean(X, (2, 8), (True, True))
         assert_approx_equal(y, 5.0, significant=self.dprec)
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -272,14 +272,13 @@ class TestTrimmedStats(TestCase):
         assert_raises(ValueError, stats.tmax, x, nan_policy='foobar')
 
     def test_tsem(self):
-        wtsem = _weight_checked(stats.tsem, split_test=False, dud_test=False)
-        y = wtsem(X, limits=(3, 8), inclusive=(False, True))
+        y = stats.tsem(X, limits=(3, 8), inclusive=(False, True))
         y_ref = np.array([4, 5, 6, 7, 8])
         assert_approx_equal(y, y_ref.std(ddof=1) / np.sqrt(y_ref.size),
                             significant=self.dprec)
 
-        assert_approx_equal(wtsem(X, limits=[-1, 10]),
-                            wtsem(X, limits=None),
+        assert_approx_equal(stats.tsem(X, limits=[-1, 10]),
+                            stats.tsem(X, limits=None),
                             significant=self.dprec)
 
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3823,7 +3823,8 @@ class GeoMeanTestCase:
 
     def test_1dma0(self):
         #  Test a 1d masked array with zero element
-        a = np.ma.array([10, 20, 30, 40, 50, 60, 70, 80, 90, 0])
+        a = np.ma.array([10, 20, 30, 40, 50, 60, 70, 80, 90, 0],
+                        mask=[0,0,0,0,0,0,0,0,0,1])
         b = 41.4716627439
         olderr = np.seterr(all='ignore')
         try:
@@ -3833,7 +3834,8 @@ class GeoMeanTestCase:
 
     def test_1dmainf(self):
         #  Test a 1d masked array with negative element
-        a = np.ma.array([10, 20, 30, 40, 50, 60, 70, 80, 90, -1])
+        a = np.ma.array([10, 20, 30, 40, 50, 60, 70, 80, 90, -1],
+                        mask=[0,0,0,0,0,0,0,0,0,1])
         b = 41.4716627439
         olderr = np.seterr(all='ignore')
         try:
@@ -4053,7 +4055,8 @@ class TestTrim(object):
         assert_equal(stats.trim_mean([], 0.0), np.nan)
         assert_equal(stats.trim_mean([], 0.6), np.nan)
 
-wsigmaclip = _weight_checked(stats.sigmaclip, key=lambda x: (x[1], x[2]))
+# ma_safe=False for ancient versions of numpy
+wsigmaclip = _weight_checked(stats.sigmaclip, key=lambda x: (x[1], x[2]), ma_safe=False)
 class TestSigmaClip(object):
     def test_sigmaclip1(self):
         a = np.concatenate((np.linspace(9.5,10.5,31),np.linspace(0,20,5)))

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3235,7 +3235,7 @@ def test_ttest_1samp_new():
     finally:
         np.seterr(**olderr)
 
-wdescribe = _weight_checked(stats.describe, key=lambda x: x[1:])
+wdescribe = _weight_checked(stats.describe, key=lambda x: x[1:], ma_very_safe=False)
 class TestDescribe(TestCase):
     def test_describe_scalar(self):
         with warnings.catch_warnings():
@@ -3729,7 +3729,7 @@ class HarMeanTestCase:
 class TestHarMean(HarMeanTestCase, TestCase):
     def do(self, a, b, axis=None, dtype=None):
         x = whmean(a, axis=axis, dtype=dtype)
-        assert_almost_equal(b, x)
+        assert_almost_equal(x, b)
         assert_equal(x.dtype, dtype)
 
 
@@ -3848,7 +3848,7 @@ class TestGeoMean(GeoMeanTestCase, TestCase):
     def do(self, a, b, axis=None, dtype=None):
         # Note this doesn't test when axis is not specified
         x = wgmean(a, axis=axis, dtype=dtype)
-        assert_almost_equal(b, x)
+        assert_almost_equal(x, b)
         assert_equal(x.dtype, dtype)
 
 


### PR DESCRIPTION
Modifications to scipy.stats and scipy.distance.spatial
by mtartre@twosigma.com

Adds weight awareness to:
- scipy.stats:
  - gmean
  - hmean
  - mode*
  - tmean
  - tvar*
  - tstd*
  - tsem*
  - moment
  - variation
  - skew
  - kurtosis
  - describe
  - itemfreq*
  - collapse_weights (new function)
  - percentileofscore
  - sem
  - zscore
  - zmap
  - sigmaclip
  - pearsonr
  - spearmanr
  - rankdata
- scipy.distance.spatial:
  - minkowski*
  - euclidean*
  - sqeuclidean*
  - correlation
  - cosine
  - hamming
  - jaccard
  - kulsinski
  - cityblock
  - chebyshev
  - braycurtis
  - canberra*
  - yule
  - matching
  - dice
  - rogerstanimoto
  - russellrao
  - sokalmichener
  - sokalsneath

Asterisked functions do not follow all weight invariant operations (exceptions are noted as disabling certain invariant operations in tests). Fixes https://github.com/scipy/scipy/issues/5718. Tested on python 2.7 and python 3.6. Discussion to follow.