### PR TITLE
BUG: sparse: handle size-1 2D indexes correctly

### DIFF
--- a/scipy/sparse/sputils.py
+++ b/scipy/sparse/sputils.py
@@ -189,7 +189,7 @@ def isintlike(x):
     """Is x appropriate as an index into a sparse matrix? Returns True
     if it can be cast safely to a machine int.
     """
-    if issequence(x):
+    if not isscalarlike(x):
         return False
     try:
         return bool(int(x) == x)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2645,6 +2645,13 @@ class _TestFancyIndexing:
         assert_equal(A[s,:].todense(), B[2:4,:])
         assert_equal(A[:,s].todense(), B[:,2:4])
 
+        # Regression for gh-4917: index with tuple of 2D arrays
+        i = np.array([[1]], dtype=int)
+        assert_equal(A[i,i].todense(), B[i,i])
+
+        # Regression for gh-4917: index with tuple of empty nested lists
+        assert_equal(A[[[]], [[]]].todense(), B[[[]], [[]]])
+
     def test_fancy_indexing_randomized(self):
         np.random.seed(1234)  # make runs repeatable
 


### PR DESCRIPTION
Fixes #4917.

The issue was caused by `sputils.isintlike` checking for `issequence` but not `ismatrix`, which meant that `isintlike(np.array([0])) is False`, but `isintlike(np.array([[0]])) is True`. This lead to the strange edge-case errors noted in the linked issue.