### PR TITLE
TST: fix test failures in special on 32-bit Python.

### DIFF
--- a/scipy/special/tests/test_precompute_gammainc.py
+++ b/scipy/special/tests/test_precompute_gammainc.py
@@ -1,6 +1,7 @@
 from __future__ import division, print_function, absolute_import
 
-from numpy.testing import dec
+import numpy as np
+from numpy.testing import dec, run_module_suite
 
 from scipy._lib._testutils import xslow
 from scipy.special._testutils import MissingModule, check_version
@@ -21,6 +22,9 @@ except ImportError:
     mp = MissingModule('mpmath')
 
 
+_is_32bit_platform = np.intp(0).itemsize < 8
+
+
 @check_version(mp, '0.19')
 def test_g():
     # Test data for the g_k. See DLMF 5.11.4.
@@ -36,11 +40,13 @@ def test_g():
 @check_version(sympy, '0.7')
 def test_alpha():
     # Test data for the alpha_k. See DLMF 8.12.14.
+    rtol = 2e-11 if _is_32bit_platform else 1e-17
+
     with mp.workdps(30):
         alpha = [mp.mpf(0), mp.mpf(1), mp.mpf(1)/3, mp.mpf(1)/36,
                  -mp.mpf(1)/270, mp.mpf(1)/4320, mp.mpf(1)/17010,
                  -mp.mpf(139)/5443200, mp.mpf(1)/204120]
-        mp_assert_allclose(compute_alpha(9), alpha)
+        mp_assert_allclose(compute_alpha(9), alpha, rtol=rtol)
 
 
 @xslow
@@ -48,7 +54,7 @@ def test_alpha():
 @check_version(sympy, '0.7')
 def test_d():
     # Compare the d_{k, n} to the results in appendix F of [1].
-    # 
+    #
     # Sources
     # -------
     # [1] DiDonato and Morris, Computation of the Incomplete Gamma
@@ -110,3 +116,7 @@ def test_gammaincc():
                         lambda a, x: mp.gammainc(a, a=x, regularized=True),
                         [IntArg(1, 100), Arg(0, 100)],
                         nan_ok=False, rtol=1e-17, n=50, dps=50)
+
+
+if __name__ == "__main__":
+    run_module_suite()

--- a/scipy/special/tests/test_precompute_gammainc.py
+++ b/scipy/special/tests/test_precompute_gammainc.py
@@ -38,15 +38,14 @@ def test_g():
 @dec.slow
 @check_version(mp, '0.19')
 @check_version(sympy, '0.7')
+@dec.knownfailureif(_is_32bit_platform, "rtol only 2e-11, see gh-6938")
 def test_alpha():
     # Test data for the alpha_k. See DLMF 8.12.14.
-    rtol = 2e-11 if _is_32bit_platform else 1e-17
-
     with mp.workdps(30):
         alpha = [mp.mpf(0), mp.mpf(1), mp.mpf(1)/3, mp.mpf(1)/36,
                  -mp.mpf(1)/270, mp.mpf(1)/4320, mp.mpf(1)/17010,
                  -mp.mpf(139)/5443200, mp.mpf(1)/204120]
-        mp_assert_allclose(compute_alpha(9), alpha, rtol=rtol)
+        mp_assert_allclose(compute_alpha(9), alpha)
 
 
 @xslow

--- a/scipy/special/tests/test_precompute_utils.py
+++ b/scipy/special/tests/test_precompute_utils.py
@@ -26,23 +26,21 @@ class TestInversion(with_metaclass(DecoratorMeta, object)):
                   (check_version, (sympy, '0.7')),
                   (check_version, (mp, '0.19'))]
 
+    @dec.knownfailureif(_is_32bit_platform, "rtol only 2e-9, see gh-6938")
     def test_log(self):
-        rtol = 2e-9 if _is_32bit_platform else 1e-17
-
         with mp.workdps(30):
             logcoeffs = mp.taylor(lambda x: mp.log(1 + x), 0, 10)
             expcoeffs = mp.taylor(lambda x: mp.exp(x) - 1, 0, 10)
             invlogcoeffs = lagrange_inversion(logcoeffs)
-            mp_assert_allclose(invlogcoeffs, expcoeffs, rtol=rtol)
+            mp_assert_allclose(invlogcoeffs, expcoeffs)
 
+    @dec.knownfailureif(_is_32bit_platform, "rtol only 1e-15, see gh-6938")
     def test_sin(self):
-        rtol = 1e-15 if _is_32bit_platform else 1e-17
-
         with mp.workdps(30):
             sincoeffs = mp.taylor(mp.sin, 0, 10)
             asincoeffs = mp.taylor(mp.asin, 0, 10)
             invsincoeffs = lagrange_inversion(sincoeffs)
-            mp_assert_allclose(invsincoeffs, asincoeffs, atol=1e-30, rtol=rtol)
+            mp_assert_allclose(invsincoeffs, asincoeffs, atol=1e-30)
 
 
 if __name__ == "__main__":

--- a/scipy/special/tests/test_precompute_utils.py
+++ b/scipy/special/tests/test_precompute_utils.py
@@ -1,6 +1,7 @@
 from __future__ import division, print_function, absolute_import
 from scipy._lib.six import with_metaclass
-from numpy.testing import dec
+import numpy as np
+from numpy.testing import dec, run_module_suite
 
 from scipy.special._testutils import MissingModule, check_version, DecoratorMeta
 from scipy.special._mptestutils import mp_assert_allclose
@@ -17,21 +18,32 @@ except ImportError:
     mp = MissingModule('mpmath')
 
 
+_is_32bit_platform = np.intp(0).itemsize < 8
+
+
 class TestInversion(with_metaclass(DecoratorMeta, object)):
     decorators = [(dec.slow, None),
                   (check_version, (sympy, '0.7')),
                   (check_version, (mp, '0.19'))]
 
     def test_log(self):
+        rtol = 2e-9 if _is_32bit_platform else 1e-17
+
         with mp.workdps(30):
             logcoeffs = mp.taylor(lambda x: mp.log(1 + x), 0, 10)
             expcoeffs = mp.taylor(lambda x: mp.exp(x) - 1, 0, 10)
             invlogcoeffs = lagrange_inversion(logcoeffs)
-            mp_assert_allclose(invlogcoeffs, expcoeffs)
+            mp_assert_allclose(invlogcoeffs, expcoeffs, rtol=rtol)
 
     def test_sin(self):
+        rtol = 1e-15 if _is_32bit_platform else 1e-17
+
         with mp.workdps(30):
             sincoeffs = mp.taylor(mp.sin, 0, 10)
             asincoeffs = mp.taylor(mp.asin, 0, 10)
             invsincoeffs = lagrange_inversion(sincoeffs)
-            mp_assert_allclose(invsincoeffs, asincoeffs, atol=1e-30)
+            mp_assert_allclose(invsincoeffs, asincoeffs, atol=1e-30, rtol=rtol)
+
+
+if __name__ == "__main__":
+    run_module_suite()


### PR DESCRIPTION
These failures have been around for quite a while, finally got around to cleaning them up. They're the last ones for 32-bit, test suite is clean now.