### PR TITLE
improve efficiency of dok_matrix.tocoo

### DIFF
--- a/scipy/sparse/dok.py
+++ b/scipy/sparse/dok.py
@@ -11,7 +11,7 @@ import operator
 
 import numpy as np
 
-from scipy._lib.six import zip as izip, xrange, iteritems, itervalues
+from scipy._lib.six import zip as izip, xrange, iteritems, iterkeys, itervalues
 
 from .base import spmatrix, isspmatrix
 from .sputils import (isdense, getdtype, isshape, isintlike, isscalarlike,
@@ -474,9 +474,10 @@ class dok_matrix(spmatrix, IndexMixin, dict):
             return coo_matrix(self.shape, dtype=self.dtype)
 
         idx_dtype = get_index_dtype(maxval=max(self.shape))
-        data = np.asarray(_list(self.values()), dtype=self.dtype)
-        indices = np.asarray(_list(self.keys()), dtype=idx_dtype).T
-        A = coo_matrix((data, indices), shape=self.shape, dtype=self.dtype)
+        data = np.fromiter(itervalues(self), dtype=self.dtype, count=self.nnz)
+        I = np.fromiter((i for i,_ in iterkeys(self)), dtype=idx_dtype, count=self.nnz)
+        J = np.fromiter((j for _,j in iterkeys(self)), dtype=idx_dtype, count=self.nnz)
+        A = coo_matrix((data, (I, J)), shape=self.shape, dtype=self.dtype)
         A.has_canonical_format = True
         return A
 
@@ -507,7 +508,7 @@ class dok_matrix(spmatrix, IndexMixin, dict):
         M, N = self.shape
         if newM < M or newN < N:
             # Remove all elements outside new dimensions
-            for (i, j) in list(self.keys()):
+            for (i, j) in _list(self.keys()):
                 if i >= newM or j >= newN:
                     del self[i, j]
         self._shape = shape


### PR DESCRIPTION
Improve both memory usage and speed for `dok.tocoo()`.

Here the benchmark results : 

**master**
```
[100.00%] ··· Running sparse.Conversion.time_conversion                       ok
[100.00%] ···· 
               ============= =========== ==========
                from_format   to_format            
               ------------- ----------- ----------
                    dok          csr      41.30ms  
                    dok          csc      42.72ms  
                    dok          coo      40.26ms  
                    dok          dia      47.55ms  
                    dok          lil      62.13ms  
                    dok          dok      411.40ns 
               ============= =========== ==========
```

**patch**
```
[100.00%] ··· Running sparse.Conversion.time_conversion                       ok
[100.00%] ···· 
               ============= =========== ==========
                from_format   to_format            
               ------------- ----------- ----------
                    dok          csr      28.26ms  
                    dok          csc      27.55ms  
                    dok          coo      27.80ms  
                    dok          dia      30.51ms  
                    dok          lil      45.96ms  
                    dok          dok      346.86ns 
               ============= =========== ==========
```