### PR TITLE
MAINT: Docstring fixes and an additional test for linalg.solve

### DIFF
--- a/doc/release/0.19.0-notes.rst
+++ b/doc/release/0.19.0-notes.rst
@@ -25,6 +25,14 @@ New features
 `scipy.linalg` improvements
 ---------------------------
 
+The function `scipy.linalg.solve` obtained two more keywords ``assume_a`` and
+``transposed``. The underlying LAPACK routines are replaced with "expert"
+versions and now can also be used to solve symmetric, hermitian and positive
+definite coefficient matrices. Moreover, ill-conditioned matrices now cause
+a warning to be emitted with the estimated condition number information. Old
+``sym_pos`` keyword is kept for backwards compatibility reasons however it
+is identical to using ``assume_a='pos'``.
+
 The function `scipy.linalg.matrix_balance` was added to perform the so-called
 matrix balancing using the LAPACK xGEBAL routine family. This can be used to
 approximately equate the row and column norms through diagonal similarity

--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -71,10 +71,11 @@ def solve(a, b, sym_pos=False, lower=False, overwrite_a=False,
         Disabling may give a performance gain, but may result in problems
         (crashes, non-termination) if the inputs do contain infinities or NaNs.
     assume_a : str, optional
-        Valid entries are given in the docstring
+        Valid entries are explained above.
     transposed: bool, optional
         If True, depending on the data type ``a^T x = b`` or ``a^H x = b`` is
         solved (only taken into account for ``'gen'``).
+
     Returns
     -------
     x : (N, NRHS) array_like
@@ -119,6 +120,9 @@ def solve(a, b, sym_pos=False, lower=False, overwrite_a=False,
     a1 = atleast_2d(_asarray_validated(a, check_finite=check_finite))
     b1 = atleast_1d(_asarray_validated(b, check_finite=check_finite))
     n = a1.shape[0]
+
+    overwrite_a = overwrite_a or _datacopied(a1, a)
+    overwrite_b = overwrite_b or _datacopied(b1, b)
 
     if a1.shape[0] != a1.shape[1]:
         raise ValueError('Input a needs to be a square matrix.')

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -183,7 +183,7 @@ class TestSolveBanded(TestCase):
         assert_array_equal(x, [[0.5, 1.0, 1.5]])
         assert_equal(x.dtype, np.dtype('f8'))
         assert_array_equal(b, [[1.0, 2.0, 3.0]])
-        
+
     def test_native_list_arguments(self):
         a = [[1.0, 20, 0, 0],
              [-30, 4, 6, 0],
@@ -503,7 +503,7 @@ class TestSolveHBanded(TestCase):
         x = solveh_banded([[1]], [[1, 2, 3]])
         assert_array_equal(x, [[1.0, 2.0, 3.0]])
         assert_equal(x.dtype, np.dtype('f8'))
-        
+
     def test_native_list_arguments(self):
         # Same as test_01_upper, using python's native list.
         ab = [[0.0, 0.0, 2.0, 2.0],
@@ -688,10 +688,10 @@ class TestSolve(TestCase):
         assert_array_almost_equal(x, res)
 
     def test_pos_and_sym(self):
-        A = np.arange(1,10).reshape(3, 3)
-        x = solve(np.tril(A)/9,np.ones(3), assume_a='pos')
+        A = np.arange(1, 10).reshape(3, 3)
+        x = solve(np.tril(A)/9, np.ones(3), assume_a='pos')
         assert_array_almost_equal(x, [9., 1.8, 1.])
-        x = solve(np.tril(A)/9,np.ones(3), assume_a='sym')
+        x = solve(np.tril(A)/9, np.ones(3), assume_a='sym')
         assert_array_almost_equal(x, [9., 1.8, 1.])
 
     def test_singularity(self):
@@ -729,9 +729,9 @@ class TestSolve(TestCase):
 
     def test_transposed_keyword(self):
         A = np.arange(9).reshape(3, 3) + 1
-        x = solve(np.tril(A)/9,np.ones(3), transposed=1)
+        x = solve(np.tril(A)/9, np.ones(3), transposed=1)
         assert_array_almost_equal(x, [1.2, 0.2, 1])
-        x = solve(np.tril(A)/9,np.ones(3), transposed=0)
+        x = solve(np.tril(A)/9, np.ones(3), transposed=0)
         assert_array_almost_equal(x, [9, -5.4, -1.2])
 
     def test_nonsquare_a(self):
@@ -740,6 +740,9 @@ class TestSolve(TestCase):
     def test_size_mismatch_with_1D_b(self):
         assert_array_almost_equal(solve(np.eye(3), np.ones(3)), np.ones(3))
         assert_raises(ValueError, solve, np.eye(3), np.ones(4))
+
+    def test_assume_a_keyword(self):
+        assert_raises(ValueError, solve, 1, 1, assume_a='zxcv')
 
     def test_all_type_size_routine_combinations(self):
         sizes = [10, 100, 1000]
@@ -751,15 +754,15 @@ class TestSolve(TestCase):
             is_complex = dtype in (np.complex64, np.complex128)
             if assume_a == 'her' and not is_complex:
                 continue
-        
+
             err_msg = ("Failed for size: {}, assume_a: {},"
                        "dtype: {}".format(size, assume_a, dtype))
-        
+
             a = np.random.randn(size, size).astype(dtype)
             b = np.random.randn(size).astype(dtype)
             if is_complex:
                 a = a + (1j*np.random.randn(size, size)).astype(dtype)
-        
+
             if assume_a == 'sym':  # Can still be complex but only symmetric
                 a = a + a.T
             elif assume_a == 'her':  # Handle hermitian matrices here instead
@@ -771,7 +774,7 @@ class TestSolve(TestCase):
             tol = 1e-12 if dtype in (np.float64, np.complex128) else 1e-6
             assert_allclose(a.dot(x), b,
                             atol=tol * size,
-                            rtol=tol * size, 
+                            rtol=tol * size,
                             err_msg=err_msg)
 
 
@@ -1286,7 +1289,7 @@ class TestPinv(TestCase):
         assert_array_almost_equal(dot(a, a_pinv), np.eye(3))
         a_pinv = pinv2(a, check_finite=False)
         assert_array_almost_equal(dot(a, a_pinv), np.eye(3))
-        
+
     def test_native_list_argument(self):
         a = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
         a_pinv = pinv(a)
@@ -1319,7 +1322,7 @@ class TestPinvSymmetric(TestCase):
         a = np.dot(a, a.conj().T)
         a_pinv = pinvh(a)
         assert_array_almost_equal(np.dot(a, a_pinv), np.eye(3))
-        
+
     def test_native_list_argument(self):
         a = array([[1, 2, 3], [4, 5, 6], [7, 8, 10]], dtype=float)
         a = np.dot(a, a.T)
@@ -1535,7 +1538,7 @@ class TestSolveCirculant(TestCase):
         x = solve_circulant(np.swapaxes(c, 1, 2), b.T, caxis=1)
         assert_equal(x.shape, (4, 2, 3))
         assert_allclose(x, expected)
-        
+
     def test_native_list_arguments(self):
         # Same as test_basic1 using python's native list.
         c = [1, 2, 3, 5]


### PR DESCRIPTION
In addition to https://github.com/scipy/scipy/pull/6775, there were additional final comments and also a missing test for `assume_a` keyword that were not included in the PR.

Both of these are addressed. 