### PR TITLE
DEP: Deprecate the keyword "debug" from linalg.solve

### DIFF
--- a/doc/release/0.19.0-notes.rst
+++ b/doc/release/0.19.0-notes.rst
@@ -33,7 +33,7 @@ a warning to be emitted with the estimated condition number information. Old
 ``sym_pos`` keyword is kept for backwards compatibility reasons however it
 is identical to using ``assume_a='pos'``. Moreover, the ``debug`` keyword,
 which had no function but only printing the ``overwrite_<a, b>`` values, is
-removed.
+deprecated.
 
 The function `scipy.linalg.matrix_balance` was added to perform the so-called
 matrix balancing using the LAPACK xGEBAL routine family. This can be used to

--- a/doc/release/0.19.0-notes.rst
+++ b/doc/release/0.19.0-notes.rst
@@ -31,7 +31,9 @@ versions and now can also be used to solve symmetric, hermitian and positive
 definite coefficient matrices. Moreover, ill-conditioned matrices now cause
 a warning to be emitted with the estimated condition number information. Old
 ``sym_pos`` keyword is kept for backwards compatibility reasons however it
-is identical to using ``assume_a='pos'``.
+is identical to using ``assume_a='pos'``. Moreover, the ``debug`` keyword,
+which had no function but only printing the ``overwrite_<a, b>`` values, is
+removed.
 
 The function `scipy.linalg.matrix_balance` was added to perform the so-called
 matrix balancing using the LAPACK xGEBAL routine family. This can be used to

--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -23,7 +23,7 @@ __all__ = ['solve', 'solve_triangular', 'solveh_banded', 'solve_banded',
 
 # Linear equations
 def solve(a, b, sym_pos=False, lower=False, overwrite_a=False,
-          overwrite_b=False, debug=False, check_finite=True, assume_a='gen',
+          overwrite_b=False, check_finite=True, assume_a='gen',
           transposed=False):
     """
     Solves the linear equation set ``a * x = b`` for the unknown ``x``
@@ -78,7 +78,8 @@ def solve(a, b, sym_pos=False, lower=False, overwrite_a=False,
 
     Returns
     -------
-    x : (N, NRHS) array_like
+    x : (N, NRHS) ndarray
+        The solution array.
 
     Raises
     ------

--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -225,7 +225,7 @@ def solve(a, b, sym_pos=False, lower=False, overwrite_a=False,
 
 
 def solve_triangular(a, b, trans=0, lower=False, unit_diagonal=False,
-                     overwrite_b=False, debug=False, check_finite=True):
+                     overwrite_b=False, debug=None, check_finite=True):
     """
     Solve the equation `a x = b` for `x`, assuming a is a triangular matrix.
 
@@ -273,6 +273,13 @@ def solve_triangular(a, b, trans=0, lower=False, unit_diagonal=False,
     .. versionadded:: 0.9.0
 
     """
+
+    # Deprecate keyword "debug"
+    if debug is not None:
+        warnings.warn('Use of the "debug" keyword is deprecated '
+                      'and this keyword will be removed in the future '
+                      'versions of SciPy.', DeprecationWarning)
+
     a1 = _asarray_validated(a, check_finite=check_finite)
     b1 = _asarray_validated(b, check_finite=check_finite)
     if len(a1.shape) != 2 or a1.shape[0] != a1.shape[1]:
@@ -297,7 +304,7 @@ def solve_triangular(a, b, trans=0, lower=False, unit_diagonal=False,
 
 
 def solve_banded(l_and_u, ab, b, overwrite_ab=False, overwrite_b=False,
-                 debug=False, check_finite=True):
+                 debug=None, check_finite=True):
     """
     Solve the equation a x = b for x, assuming a is banded matrix.
 
@@ -336,6 +343,13 @@ def solve_banded(l_and_u, ab, b, overwrite_ab=False, overwrite_b=False,
         shape of `b`.
 
     """
+
+    # Deprecate keyword "debug"
+    if debug is not None:
+        warnings.warn('Use of the "debug" keyword is deprecated '
+                      'and this keyword will be removed in the future '
+                      'versions of SciPy.', DeprecationWarning)
+
     a1 = _asarray_validated(ab, check_finite=check_finite, as_inexact=True)
     b1 = _asarray_validated(b, check_finite=check_finite, as_inexact=True)
     # Validate shapes.

--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -23,7 +23,7 @@ __all__ = ['solve', 'solve_triangular', 'solveh_banded', 'solve_banded',
 
 # Linear equations
 def solve(a, b, sym_pos=False, lower=False, overwrite_a=False,
-          overwrite_b=False, check_finite=True, assume_a='gen',
+          overwrite_b=False, debug=None, check_finite=True, assume_a='gen',
           transposed=False):
     """
     Solves the linear equation set ``a * x = b`` for the unknown ``x``
@@ -155,6 +155,12 @@ def solve(a, b, sym_pos=False, lower=False, overwrite_a=False,
     else:
         raise ValueError('{} is not a recognized matrix structure'
                          ''.format(assume_a))
+
+    # Deprecate keyword "debug"
+    if debug is not None:
+        warnings.warn('Use of the "debug" keyword is deprecated '
+                      'and this keyword will be removed in the future '
+                      'versions of SciPy.', DeprecationWarning)
 
     # Backwards compatibility - old keyword.
     if sym_pos:


### PR DESCRIPTION
With #6775, scipy.linalg.solve has obtained two new keywords.

The old version (pre-v0.19) has a "debug" keyword whose function is surprisingly unnecessary or simply left as a historical artifact: It only does the following 

    if debug:
        print('solve:overwrite_a=', overwrite_a)
        print('solve:overwrite_b=', overwrite_b)

This PR is meant to deprecate it upon consensus.