### PR TITLE
BUG: Correctly treat large integers in MMIO (fixes #6397)

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -130,7 +130,7 @@ Jörg Dietrich for the k-sample Anderson Darling test.
 Blake Griffith for improvements to scipy.sparse.
 Andrew Nelson for scipy.optimize.differential_evolution.
 Brian Newsom for work on ctypes multivariate integration.
-Nathan Woods for work on multivariate integration. 
+Nathan Woods for work on multivariate integration.
 Brianna Laugher for bug fixes.
 Johannes Kulick for the Dirichlet distribution.
 Bastian Venthur for bug fixes.
@@ -168,6 +168,7 @@ Sebastiano Vigna for code in the stats package related to Kendall's tau.
 John Draper for bug fixes.
 Alvaro Sanchez-Gonzalez for axis-dependent modes in multidimensional filters.
 Alessandro Pietro Bardelli for improvements to pdist/cdist and to related tests.
+Jonathan T. Siebert for bug fixes.
 
 Institutions
 ------------

--- a/scipy/io/mmio.py
+++ b/scipy/io/mmio.py
@@ -17,7 +17,7 @@ import sys
 
 from numpy import (asarray, real, imag, conj, zeros, ndarray, concatenate,
                    ones, ascontiguousarray, vstack, savetxt, fromfile,
-                   fromstring)
+                   fromstring, can_cast)
 from numpy.compat import asbytes, asstr
 
 from scipy._lib.six import string_types
@@ -179,7 +179,7 @@ class MMFile (object):
             raise ValueError('unknown symmetry type %s, must be one of %s' %
                              (symmetry, self.SYMMETRY_VALUES))
 
-    DTYPES_BY_FIELD = {FIELD_INTEGER: 'i',
+    DTYPES_BY_FIELD = {FIELD_INTEGER: 'int',
                        FIELD_REAL: 'd',
                        FIELD_COMPLEX: 'D',
                        FIELD_PATTERN: 'd'}
@@ -493,6 +493,7 @@ class MMFile (object):
         dtype = self.DTYPES_BY_FIELD.get(field, None)
 
         has_symmetry = self.has_symmetry
+        is_integer = field == self.FIELD_INTEGER
         is_complex = field == self.FIELD_COMPLEX
         is_skew = symm == self.SYMMETRY_SKEW_SYMMETRIC
         is_herm = symm == self.SYMMETRY_HERMITIAN
@@ -506,7 +507,9 @@ class MMFile (object):
                 line = stream.readline()
                 if not line or line.startswith(b'%'):
                     continue
-                if is_complex:
+                if is_integer:
+                    aij = int(line)
+                elif is_complex:
                     aij = complex(*map(float, line.split()))
                 else:
                     aij = float(line)
@@ -541,7 +544,9 @@ class MMFile (object):
                 l = line.split()
                 i, j = map(int, l[:2])
                 i, j = i-1, j-1
-                if is_complex:
+                if is_integer:
+                    aij = int(l[2])
+                elif is_complex:
                     aij = complex(*map(float, l[2:]))
                 else:
                     aij = float(l[2])
@@ -564,35 +569,39 @@ class MMFile (object):
                 # empty matrix
                 return coo_matrix((rows, cols), dtype=dtype)
 
-            try:
-                if not _is_fromfile_compatible(stream):
-                    flat_data = fromstring(stream.read(), sep=' ')
-                else:
-                    # fromfile works for normal files
-                    flat_data = fromfile(stream, sep=' ')
-            except Exception:
-                # fallback - fromfile fails for some file-like objects
-                flat_data = fromstring(stream.read(), sep=' ')
-
-                # TODO use iterator (e.g. xreadlines) to avoid reading
-                # the whole file into memory
-
+            I = zeros(entries, dtype='intc')
+            J = zeros(entries, dtype='intc')
             if is_pattern:
-                flat_data = flat_data.reshape(-1, 2)
-                I = ascontiguousarray(flat_data[:, 0], dtype='intc')
-                J = ascontiguousarray(flat_data[:, 1], dtype='intc')
-                V = ones(len(I), dtype='int8')  # filler
+                V = ones(entries, dtype='int8')
+            elif is_integer:
+                V = zeros(entries, dtype='int')
             elif is_complex:
-                flat_data = flat_data.reshape(-1, 4)
-                I = ascontiguousarray(flat_data[:, 0], dtype='intc')
-                J = ascontiguousarray(flat_data[:, 1], dtype='intc')
-                V = ascontiguousarray(flat_data[:, 2], dtype='complex')
-                V.imag = flat_data[:, 3]
+                V = zeros(entries, dtype='complex')
             else:
-                flat_data = flat_data.reshape(-1, 3)
-                I = ascontiguousarray(flat_data[:, 0], dtype='intc')
-                J = ascontiguousarray(flat_data[:, 1], dtype='intc')
-                V = ascontiguousarray(flat_data[:, 2], dtype='float')
+                V = zeros(entries, dtype='float')
+
+            entry_number = 0
+            for line in stream:
+                if not line or line.startswith(b'%'):
+                    continue
+
+                if entry_number+1 > entries:
+                    raise ValueError("'entries' in header is smaller than "
+                                     "number of entries")
+                l = line.split()
+                I[entry_number], J[entry_number] = map(int, l[:2])
+
+                if not is_pattern:
+                    if is_integer:
+                        V[entry_number] = int(l[2])
+                    elif is_complex:
+                        V[entry_number] = complex(*map(float, l[2:]))
+                    else:
+                        V[entry_number] = float(l[2])
+                entry_number += 1
+            if entry_number < entries:
+                raise ValueError("'entries' in header is larger than "
+                                 "number of entries")
 
             I -= 1  # adjust indices (base 1 -> base 0)
             J -= 1
@@ -634,7 +643,10 @@ class MMFile (object):
             if field is not None:
 
                 if field == self.FIELD_INTEGER:
-                    a = a.astype('i')
+                    if not can_cast(a.dtype, 'int'):
+                        raise OverflowError("mmwrite does not support integer "
+                                            "dtypes larger than native 'int'.")
+                    a = a.astype('int')
                 elif field == self.FIELD_REAL:
                     if a.dtype.char not in 'fd':
                         a = a.astype('d')
@@ -659,6 +671,9 @@ class MMFile (object):
         if field is None:
             kind = a.dtype.kind
             if kind == 'i':
+                if not can_cast(a.dtype, 'int'):
+                    raise OverflowError("mmwrite does not support integer "
+                                        "dtypes larger than native 'int'.")
                 field = 'integer'
             elif kind == 'f':
                 field = 'real'
@@ -739,22 +754,21 @@ class MMFile (object):
             # write shape spec
             stream.write(asbytes('%i %i %i\n' % (rows, cols, coo.nnz)))
 
-            # make indices and data array
+            template = self._field_template(field, precision-1)
+
             if field == self.FIELD_PATTERN:
-                IJV = vstack((coo.row, coo.col)).T
-            elif field in [self.FIELD_INTEGER, self.FIELD_REAL]:
-                IJV = vstack((coo.row, coo.col, coo.data)).T
+                for r, c in zip(coo.row+1, coo.col+1):
+                    stream.write(asbytes("%i %i\n" % (r, c)))
+            elif field in (self.FIELD_INTEGER, self.FIELD_REAL):
+                for r, c, d in zip(coo.row+1, coo.col+1, coo.data):
+                    stream.write(asbytes(("%i %i " % (r, c)) +
+                                         (template % d)))
             elif field == self.FIELD_COMPLEX:
-                IJV = vstack((coo.row, coo.col, coo.data.real,
-                              coo.data.imag)).T
+                for r, c, d in zip(coo.row+1, coo.col+1, coo.data):
+                    stream.write(asbytes(("%i %i " % (r, c)) +
+                                         (template % (d.real, d.imag))))
             else:
                 raise TypeError('Unknown field type %s' % field)
-            IJV[:, :2] += 1  # change base 0 -> base 1
-
-            # formats for row indices, col indices and data columns
-            fmt = ('%i', '%i') + ('%%.%dg' % precision,) * (IJV.shape[1]-2)
-            # save to file
-            savetxt(stream, IJV, fmt=fmt)
 
 
 def _is_fromfile_compatible(stream):

--- a/scipy/io/tests/test_mmio.py
+++ b/scipy/io/tests/test_mmio.py
@@ -6,9 +6,10 @@ import os
 import shutil
 
 import numpy as np
-from numpy import array,transpose, pi
+from numpy import array, transpose, pi
 from numpy.testing import (TestCase, run_module_suite, assert_equal,
-                           assert_array_equal, assert_array_almost_equal)
+                           assert_array_equal, assert_array_almost_equal,
+                           assert_raises)
 
 import scipy.sparse
 from scipy.io.mmio import mminfo, mmread, mmwrite
@@ -28,21 +29,38 @@ class TestMMIOArray(TestCase):
         b = mmread(self.fn)
         assert_array_almost_equal(a, b)
 
+    def check_exact(self, a, info):
+        mmwrite(self.fn, a)
+        assert_equal(mminfo(self.fn), info)
+        b = mmread(self.fn)
+        assert_equal(a, b)
+
     def test_simple_integer(self):
-        self.check([[1, 2], [3, 4]],
-                   (2, 2, 4, 'array', 'integer', 'general'))
+        self.check_exact([[1, 2], [3, 4]],
+                         (2, 2, 4, 'array', 'integer', 'general'))
+
+    def test_32bit_integer(self):
+        a = array([[2**31-1, 2**31-2], [2**31-3, 2**31-4]], dtype=np.int32)
+        self.check_exact(a, (2, 2, 4, 'array', 'integer', 'general'))
+
+    def test_64bit_integer(self):
+        a = array([[2**31, 2**32], [2**63-2, 2**63-1]], dtype=np.int64)
+        if (np.intp(0).itemsize < 8):
+            assert_raises(OverflowError, mmwrite, self.fn, a)
+        else:
+            self.check_exact(a, (2, 2, 4, 'array', 'integer', 'general'))
 
     def test_simple_upper_triangle_integer(self):
-        self.check([[0, 1], [0, 0]],
-                   (2, 2, 4, 'array', 'integer', 'general'))
+        self.check_exact([[0, 1], [0, 0]],
+                         (2, 2, 4, 'array', 'integer', 'general'))
 
     def test_simple_lower_triangle_integer(self):
-        self.check([[0, 0], [1, 0]],
-                   (2, 2, 4, 'array', 'integer', 'general'))
+        self.check_exact([[0, 0], [1, 0]],
+                         (2, 2, 4, 'array', 'integer', 'general'))
 
     def test_simple_rectangular_integer(self):
-        self.check([[1, 2, 3], [4, 5, 6]],
-                   (2, 3, 6, 'array', 'integer', 'general'))
+        self.check_exact([[1, 2, 3], [4, 5, 6]],
+                         (2, 3, 6, 'array', 'integer', 'general'))
 
     def test_simple_rectangular_float(self):
         self.check([[1, 2], [3.5, 4], [5, 6]],
@@ -57,12 +75,12 @@ class TestMMIOArray(TestCase):
                    (2, 2, 4, 'array', 'complex', 'general'))
 
     def test_simple_symmetric_integer(self):
-        self.check([[1, 2], [2, 4]],
-                   (2, 2, 4, 'array', 'integer', 'symmetric'))
+        self.check_exact([[1, 2], [2, 4]],
+                         (2, 2, 4, 'array', 'integer', 'symmetric'))
 
     def test_simple_skew_symmetric_integer(self):
-        self.check([[1, 2], [-2, 4]],
-                   (2, 2, 4, 'array', 'integer', 'skew-symmetric'))
+        self.check_exact([[1, 2], [-2, 4]],
+                         (2, 2, 4, 'array', 'integer', 'skew-symmetric'))
 
     def test_simple_skew_symmetric_float(self):
         self.check(array([[1, 2], [-2.0, 4]], 'f'),
@@ -85,7 +103,6 @@ class TestMMIOArray(TestCase):
 
 
 class TestMMIOSparseCSR(TestMMIOArray):
-
     def setUp(self):
         self.tmpdir = mkdtemp()
         self.fn = os.path.join(self.tmpdir, 'testfile.mtx')
@@ -99,21 +116,42 @@ class TestMMIOSparseCSR(TestMMIOArray):
         b = mmread(self.fn)
         assert_array_almost_equal(a.todense(), b.todense())
 
+    def check_exact(self, a, info):
+        mmwrite(self.fn, a)
+        assert_equal(mminfo(self.fn), info)
+        b = mmread(self.fn)
+        assert_equal(a.todense(), b.todense())
+
     def test_simple_integer(self):
-        self.check(scipy.sparse.csr_matrix([[1, 2], [3, 4]]),
-                   (2, 2, 4, 'coordinate', 'integer', 'general'))
+        self.check_exact(scipy.sparse.csr_matrix([[1, 2], [3, 4]]),
+                         (2, 2, 4, 'coordinate', 'integer', 'general'))
+
+    def test_32bit_integer(self):
+        a = scipy.sparse.csr_matrix(array([[2**31-1, -2**31+2],
+                                           [2**31-3, 2**31-4]],
+                                          dtype=np.int32))
+        self.check_exact(a, (2, 2, 4, 'coordinate', 'integer', 'general'))
+
+    def test_64bit_integer(self):
+        a = scipy.sparse.csr_matrix(array([[2**32+1, 2**32+1],
+                                           [-2**63+2, 2**63-2]],
+                                          dtype=np.int64))
+        if (np.intp(0).itemsize < 8):
+            assert_raises(OverflowError, mmwrite, self.fn, a)
+        else:
+            self.check_exact(a, (2, 2, 4, 'coordinate', 'integer', 'general'))
 
     def test_simple_upper_triangle_integer(self):
-        self.check(scipy.sparse.csr_matrix([[0, 1], [0, 0]]),
-                   (2, 2, 1, 'coordinate', 'integer', 'general'))
+        self.check_exact(scipy.sparse.csr_matrix([[0, 1], [0, 0]]),
+                         (2, 2, 1, 'coordinate', 'integer', 'general'))
 
     def test_simple_lower_triangle_integer(self):
-        self.check(scipy.sparse.csr_matrix([[0, 0], [1, 0]]),
-                   (2, 2, 1, 'coordinate', 'integer', 'general'))
+        self.check_exact(scipy.sparse.csr_matrix([[0, 0], [1, 0]]),
+                         (2, 2, 1, 'coordinate', 'integer', 'general'))
 
     def test_simple_rectangular_integer(self):
-        self.check(scipy.sparse.csr_matrix([[1, 2, 3], [4, 5, 6]]),
-                   (2, 3, 6, 'coordinate', 'integer', 'general'))
+        self.check_exact(scipy.sparse.csr_matrix([[1, 2, 3], [4, 5, 6]]),
+                         (2, 3, 6, 'coordinate', 'integer', 'general'))
 
     def test_simple_rectangular_float(self):
         self.check(scipy.sparse.csr_matrix([[1, 2], [3.5, 4], [5, 6]]),
@@ -128,12 +166,12 @@ class TestMMIOSparseCSR(TestMMIOArray):
                    (2, 2, 4, 'coordinate', 'complex', 'general'))
 
     def test_simple_symmetric_integer(self):
-        self.check(scipy.sparse.csr_matrix([[1, 2], [2, 4]]),
-                   (2, 2, 3, 'coordinate', 'integer', 'symmetric'))
+        self.check_exact(scipy.sparse.csr_matrix([[1, 2], [2, 4]]),
+                         (2, 2, 3, 'coordinate', 'integer', 'symmetric'))
 
     def test_simple_skew_symmetric_integer(self):
-        self.check(scipy.sparse.csr_matrix([[1, 2], [-2, 4]]),
-                   (2, 2, 3, 'coordinate', 'integer', 'skew-symmetric'))
+        self.check_exact(scipy.sparse.csr_matrix([[1, 2], [-2, 4]]),
+                         (2, 2, 3, 'coordinate', 'integer', 'skew-symmetric'))
 
     def test_simple_skew_symmetric_float(self):
         self.check(scipy.sparse.csr_matrix(array([[1, 2], [-2.0, 4]], 'f')),
@@ -155,6 +193,178 @@ class TestMMIOSparseCSR(TestMMIOArray):
         a = np.random.random(sz)
         a = scipy.sparse.csr_matrix(a)
         self.check(a, (20, 15, 300, 'coordinate', 'real', 'general'))
+
+    def test_simple_pattern(self):
+        a = scipy.sparse.csr_matrix([[0, 1.5], [3.0, 2.5]])
+        p = np.zeros_like(a.todense())
+        p[a.todense() > 0] = 1
+        info = (2, 2, 3, 'coordinate', 'pattern', 'general')
+        mmwrite(self.fn, a, field='pattern')
+        assert_equal(mminfo(self.fn), info)
+        b = mmread(self.fn)
+        assert_array_almost_equal(p, b.todense())
+
+
+_32bit_integer_dense_example = '''\
+%%MatrixMarket matrix array integer general
+2  2
+2147483647
+2147483646
+2147483647
+2147483646
+'''
+
+_32bit_integer_sparse_example = '''\
+%%MatrixMarket matrix coordinate integer symmetric
+2  2  2
+1  1  2147483647
+2  2  2147483646
+'''
+
+_64bit_integer_dense_example = '''\
+%%MatrixMarket matrix array integer general
+2  2
+          2147483648
+-9223372036854775806
+         -2147483648
+ 9223372036854775807
+'''
+
+_64bit_integer_sparse_general_example = '''\
+%%MatrixMarket matrix coordinate integer general
+2  2  3
+1  1           2147483648
+1  2  9223372036854775807
+2  2  9223372036854775807
+'''
+
+_64bit_integer_sparse_symmetric_example = '''\
+%%MatrixMarket matrix coordinate integer symmetric
+2  2  3
+1  1            2147483648
+1  2  -9223372036854775807
+2  2   9223372036854775807
+'''
+
+_64bit_integer_sparse_skew_example = '''\
+%%MatrixMarket matrix coordinate integer skew-symmetric
+2  2  3
+1  1            2147483648
+1  2  -9223372036854775807
+2  2   9223372036854775807
+'''
+
+_over64bit_integer_dense_example = '''\
+%%MatrixMarket matrix array integer general
+2  2
+         2147483648
+9223372036854775807
+         2147483648
+9223372036854775808
+'''
+
+_over64bit_integer_sparse_example = '''\
+%%MatrixMarket matrix coordinate integer symmetric
+2  2  2
+1  1            2147483648
+2  2  19223372036854775808
+'''
+
+class TestMMIOReadLargeIntegers(TestCase):
+    def setUp(self):
+        self.tmpdir = mkdtemp()
+        self.fn = os.path.join(self.tmpdir, 'testfile.mtx')
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+    def check_read(self, example, a, info, dense, over32, over64):
+        with open(self.fn, 'w') as f:
+            f.write(example)
+        assert_equal(mminfo(self.fn), info)
+        if (over32 and (np.intp(0).itemsize < 8)) or over64:
+            assert_raises(OverflowError, mmread, self.fn)
+        else:
+            b = mmread(self.fn)
+            if not dense:
+                b = b.todense()
+            assert_equal(a, b)
+
+    def test_read_32bit_integer_dense(self):
+        a = array([[2**31-1, 2**31-1],
+                   [2**31-2, 2**31-2]], dtype=np.int64)
+        self.check_read(_32bit_integer_dense_example,
+                        a,
+                        (2, 2, 4, 'array', 'integer', 'general'),
+                        dense=True,
+                        over32=False,
+                        over64=False)
+
+    def test_read_32bit_integer_sparse(self):
+        a = array([[2**31-1, 0],
+                   [0, 2**31-2]], dtype=np.int64)
+        self.check_read(_32bit_integer_sparse_example,
+                        a,
+                        (2, 2, 2, 'coordinate', 'integer', 'symmetric'),
+                        dense=False,
+                        over32=False,
+                        over64=False)
+
+    def test_read_64bit_integer_dense(self):
+        a = array([[2**31, -2**31],
+                   [-2**63+2, 2**63-1]], dtype=np.int64)
+        self.check_read(_64bit_integer_dense_example,
+                        a,
+                        (2, 2, 4, 'array', 'integer', 'general'),
+                        dense=True,
+                        over32=True,
+                        over64=False)
+
+    def test_read_64bit_integer_sparse_general(self):
+        a = array([[2**31, 2**63-1],
+                   [0, 2**63-1]], dtype=np.int64)
+        self.check_read(_64bit_integer_sparse_general_example,
+                        a,
+                        (2, 2, 3, 'coordinate', 'integer', 'general'),
+                        dense=False,
+                        over32=True,
+                        over64=False)
+
+    def test_read_64bit_integer_sparse_symmetric(self):
+        a = array([[2**31, -2**63+1],
+                   [-2**63+1, 2**63-1]], dtype=np.int64)
+        self.check_read(_64bit_integer_sparse_symmetric_example,
+                        a,
+                        (2, 2, 3, 'coordinate', 'integer', 'symmetric'),
+                        dense=False,
+                        over32=True,
+                        over64=False)
+
+    def test_read_64bit_integer_sparse_skew(self):
+        a = array([[2**31, -2**63+1],
+                   [2**63-1, 2**63-1]], dtype=np.int64)
+        self.check_read(_64bit_integer_sparse_skew_example,
+                        a,
+                        (2, 2, 3, 'coordinate', 'integer', 'skew-symmetric'),
+                        dense=False,
+                        over32=True,
+                        over64=False)
+
+    def test_read_over64bit_integer_dense(self):
+        self.check_read(_over64bit_integer_dense_example,
+                        None,
+                        (2, 2, 4, 'array', 'integer', 'general'),
+                        dense=True,
+                        over32=True,
+                        over64=True)
+
+    def test_read_over64bit_integer_sparse(self):
+        self.check_read(_over64bit_integer_sparse_example,
+                        None,
+                        (2, 2, 2, 'coordinate', 'integer', 'symmetric'),
+                        dense=False,
+                        over32=True,
+                        over64=True)
 
 
 _general_example = '''\


### PR DESCRIPTION
Integers up to native 'int' bit size are now written and read correctly.
Out of range integers now throw an OverflowError rather than too
silently overflow. This fixes #6397.