### PR TITLE
ENH: Minor user-friendliness cleanup in LowLevelCallable

### DIFF
--- a/scipy/_lib/_ccallback.py
+++ b/scipy/_lib/_ccallback.py
@@ -33,6 +33,9 @@ class LowLevelCallable(tuple):
         Low-level callback function.
     user_data : {PyCapsule, ctypes void pointer, cffi void pointer}
         User data to pass on to the callback function.
+    signature : str, optional
+        Signature of the function. If omitted, determined from *function*,
+        if possible.
 
     Attributes
     ----------
@@ -40,9 +43,8 @@ class LowLevelCallable(tuple):
         Callback function given
     user_data
         User data given
-    signature : str
-        Signature of the function. If omitted, determined from *function*,
-        if possible.
+    signature
+        Signature of the function.
 
     Methods
     -------

--- a/scipy/_lib/tests/test_ccallback.py
+++ b/scipy/_lib/tests/test_ccallback.py
@@ -1,6 +1,6 @@
 from __future__ import division, print_function, absolute_import
 
-from numpy.testing import assert_equal, assert_raises
+from numpy.testing import assert_equal, assert_raises, assert_
 
 import time
 import nose
@@ -137,6 +137,15 @@ def test_bad_callbacks():
 
         # Test that passing in user_data also fails
         assert_raises(ValueError, caller, func2, 1.0)
+
+        # Test error message
+        llfunc = LowLevelCallable(func)
+        try:
+            caller(llfunc, 1.0)
+        except ValueError as err:
+            msg = str(err)
+            assert_(llfunc.signature in msg, msg)
+            assert_('double (double, double, int *, void *)' in msg, msg)
 
     for caller in sorted(CALLERS.keys()):
         for func in sorted(BAD_FUNCS.keys()):


### PR DESCRIPTION
Fix some issues in docstring + provide a more friendly error message on failure.