### PR TITLE
Silence expected numpy warnings in scipy.ndimage.interpolation.zoom()

### DIFF
--- a/scipy/ndimage/interpolation.py
+++ b/scipy/ndimage/interpolation.py
@@ -600,8 +600,11 @@ def zoom(input, zoom, output=None, order=3, mode='constant', cval=0.0,
                 "the returned array has changed.", UserWarning)
 
     zoom_div = numpy.array(output_shape, float) - 1
-    zoom = (numpy.array(input.shape) - 1) / zoom_div
-
+    err = numpy.seterr(divide='ignore', invalid='ignore')
+    try:
+        zoom = (numpy.array(input.shape) - 1) / zoom_div
+    finally:
+        numpy.seterr(**err)
     # Zooming to non-finite values is unpredictable, so just choose
     # zoom factor 1 instead
     zoom[~numpy.isfinite(zoom)] = 1

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -64,6 +64,14 @@ class TestNdimage:
         # list of boundary modes:
         self.modes = ['nearest', 'wrap', 'reflect', 'mirror', 'constant']
 
+        # Fail on warnings.
+        self.saved_warning_settings = warnings.catch_warnings()
+        self.saved_warning_settings.__enter__()
+        warnings.simplefilter("error")
+
+    def tearDown(self):
+        self.saved_warning_settings.__exit__()
+
     def test_correlate01(self):
         array = numpy.array([1, 2])
         weights = numpy.array([2])
@@ -2119,13 +2127,9 @@ class TestNdimage:
         assert_array_equal(out,arr)
 
     def test_zoom3(self):
-        err = numpy.seterr(invalid='ignore')
         arr = numpy.array([[1, 2]])
-        try:
-            out1 = ndimage.zoom(arr, (2, 1))
-            out2 = ndimage.zoom(arr, (1,2))
-        finally:
-            numpy.seterr(**err)
+        out1 = ndimage.zoom(arr, (2, 1))
+        out2 = ndimage.zoom(arr, (1,2))
 
         assert_array_almost_equal(out1, numpy.array([[1, 2], [1, 2]]))
         assert_array_almost_equal(out2, numpy.array([[1, 1, 2, 2]]))
@@ -2143,24 +2147,15 @@ class TestNdimage:
 
     def test_zoom_infinity(self):
         # Ticket #1419 regression test
-        err = numpy.seterr(divide='ignore')
-
-        try:
-            dim = 8
-            ndimage.zoom(numpy.zeros((dim, dim)), 1./dim, mode='nearest')
-        finally:
-            numpy.seterr(**err)
+        dim = 8
+        ndimage.zoom(numpy.zeros((dim, dim)), 1./dim, mode='nearest')
 
     def test_zoom_zoomfactor_one(self):
         # Ticket #1122 regression test
         arr = numpy.zeros((1, 5, 5))
         zoom = (1.0, 2.0, 2.0)
 
-        err = numpy.seterr(invalid='ignore')
-        try:
-            out = ndimage.zoom(arr, zoom, cval=7)
-        finally:
-            numpy.seterr(**err)
+        out = ndimage.zoom(arr, zoom, cval=7)
         ref = numpy.zeros((1, 10, 10))
         assert_array_almost_equal(out, ref)
 


### PR DESCRIPTION
Illegal values in division is handled afterwards, so silence the warnings. Thus can the warning suppression in the tests be removed as well. All warnings from the same suite will now be treated as errors.