### PR TITLE
ENH: added args and kwargs to Xdist

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -121,6 +121,40 @@ from . import _distance_wrap
 from . import _hausdorff
 from ..linalg import norm
 
+def _args_to_kwargs_xdist(args, kwargs, metric, func_name):
+    if func_name == "pdist":
+        old_arg_names = ["p", "w", "V", "VI"]
+    else:
+        old_arg_names = ["p", "V", "VI", "w"]
+    num_args = len(args)
+    if num_args:
+        if(callable(metric) and
+           metric not in [braycurtis, canberra, chebyshev, cityblock,
+                          correlation, cosine, dice, euclidean,
+                          hamming, jaccard, kulsinski, mahalanobis,
+                          matching, minkowski, rogerstanimoto,
+                          russellrao, seuclidean, sokalmichener,
+                          sokalsneath, sqeuclidean, yule, wminkowski]):
+            raise TypeError('When using a custom metric arguments must be passed'
+                            'as keyword (i.e., ARGNAME=ARGVALUE)')
+
+        warnings.warn('%d metric parameters have been passed as positional.'
+                      'This will raise an error in a future version.'
+                      'Please pass arguments as keywords'
+                      '(i.e., ARGNAME=ARGVALUE)' % num_args, DeprecationWarning)
+        if num_args > 4:
+            raise ValueError('Deprecated %s signature accepts only 4'
+                'positional arguments (p, w, V, VI), %d given.'
+                % (func_name, num_args))
+
+        for i, arg in enumerate(args):
+            if old_arg_names[i] in kwargs:
+                raise TypeError('%s() got multiple values for argument '
+                    '%s' % (func_name, old_arg_names[i]))
+            kwargs[old_arg_names[i]] = arg
+    return kwargs
+
+
 def _copy_array_if_base_present(a):
     """
     Copies the array if its base points to a parent array.
@@ -128,6 +162,31 @@ def _copy_array_if_base_present(a):
     if a.base is not None:
         return a.copy()
     return a
+
+
+def _correlation_cdist_wrap(XA, XB, dm, **kwargs):
+    XA -= XA.mean(axis=1)[:, np.newaxis]
+    XB -= XB.mean(axis=1)[:, np.newaxis]
+    _cosine_cdist_wrap(XA, XB, dm, **kwargs)
+
+
+def _correlation_pdist_wrap(X, dm, **kwargs):
+    X2 = X - X.mean(1)[:, np.newaxis]
+    norms = _row_norms(X2)
+    _distance_wrap.pdist_cosine_wrap(X2, dm, norms, **kwargs)
+
+
+def _cosine_cdist_wrap(XA, XB, dm):
+    np.dot(XA, XB.T, out=dm)
+    dm /= _row_norms(XA).reshape(-1, 1)
+    dm /= _row_norms(XB)
+    dm *= -1
+    dm += 1
+
+
+def _cosine_pdist_wrap(X, dm, **kwargs):
+    norms = _row_norms(X)
+    _distance_wrap.pdist_cosine_wrap(X, dm, norms, **kwargs)
 
 
 def _convert_to_bool(X):
@@ -138,11 +197,11 @@ def _convert_to_double(X):
     return np.ascontiguousarray(X, dtype=np.double)
 
 
-def _filter_deprecated_kwargs(**kwargs):
+def _filter_deprecated_kwargs(kwargs, args_blacklist):
     # Filtering out old default keywords
-    for k in ["p", "V", "w", "VI"]:
-        kw = kwargs.pop(k, None)
-        if kw is not None:
+    for k in args_blacklist:
+        if k in kwargs:
+            del kwargs[k]
             warnings.warn('Got unexpected kwarg %s. This will raise an error'
                           ' in a future version.' % k, DeprecationWarning)
 
@@ -183,6 +242,11 @@ def _nbool_correspond_ft_tf(u, v):
         nft = (not_u & v).sum()
         ntf = (u & not_v).sum()
     return (nft, ntf)
+
+
+def _row_norms(X):
+    norms = np.einsum('ij,ij->i', X, X, dtype=np.double)
+    return np.sqrt(norms, out=norms)
 
 
 def _validate_mahalanobis_args(X, m, n, VI):
@@ -1092,26 +1156,36 @@ _SIMPLE_CDIST = {}
 _SIMPLE_PDIST = {}
 
 for wrap_name, names, typ in [
-    ("bray_curtis", ['braycurtis'], "double"),
-    ("canberra", ['canberra'], "double"),
-    ("chebyshev", ['chebychev', 'chebyshev', 'cheby', 'cheb', 'ch'], "double"),
-    ("city_block", ["cityblock", "cblock", "cb", "c"], "double"),
-    ("euclidean", ["euclidean", "euclid", "eu", "e"], "double"),
-    ("sqeuclidean", ["sqeuclidean", "sqe", "sqeuclid"], "double"),
-    ("dice", ["dice"], "bool"),
-    ("kulsinski", ["kulsinski"], "bool"),
-    ("rogerstanimoto", ["rogerstanimoto"], "bool"),
-    ("russellrao", ["russellrao"], "bool"),
-    ("sokalmichener", ["sokalmichener"], "bool"),
-    ("sokalsneath", ["sokalsneath"], "bool"),
-    ("yule", ["yule"], "bool"),
+    ('bray_curtis', ['braycurtis'], 'double'),
+    ('canberra', ['canberra'], 'double'),
+    ('chebyshev', ['chebychev', 'chebyshev', 'cheby', 'cheb', 'ch'], 'double'),
+    ('city_block', ['cityblock', 'cblock', 'cb', 'c'], 'double'),
+    ('correlation', ['correlation', 'co'], 'double'),
+    ('cosine', ['cosine', 'cos'], 'double'),
+    ('dice', ['dice'], 'bool'),
+    ('euclidean', ['euclidean', 'euclid', 'eu', 'e'], 'double'),
+    ('kulsinski', ['kulsinski'], 'bool'),
+    ('mahalanobis', ['mahalanobis', 'mahal', 'mah'], 'double'),
+    ('minkowski',['minkowski', 'mi', 'm'], 'double'),
+    ('rogerstanimoto', ['rogerstanimoto'], 'bool'),
+    ('russellrao', ['russellrao'], 'bool'),
+    ('seuclidean', ['seuclidean', 'se', 's'], 'double'),
+    ('sokalmichener', ['sokalmichener'], 'bool'),
+    ('sokalsneath', ['sokalsneath'], 'bool'),
+    ('sqeuclidean', ['sqeuclidean', 'sqe', 'sqeuclid'], 'double'),
+    ('weighted_minkowski', ['wminkowski', 'wmi', 'wm', 'wpnorm'], 'double'),
+    ('yule', ['yule'], 'bool'),
 ]:
     converter = {"bool": _convert_to_bool,
                  "double": _convert_to_double}[typ]
-    fn_name = {"bool": "%s_bool_wrap",
-               "double": "%s_wrap"}[typ] % wrap_name
-    cdist_fn = getattr(_distance_wrap, "cdist_%s" % fn_name)
-    pdist_fn = getattr(_distance_wrap, "pdist_%s" % fn_name)
+    if wrap_name in ['cosine', 'correlation']:
+        cdist_fn = eval('_%s_cdist_wrap' % wrap_name)
+        pdist_fn = eval('_%s_pdist_wrap' % wrap_name)
+    else:
+        fn_name = {"bool": "%s_bool_wrap",
+                   "double": "%s_wrap"}[typ] % wrap_name
+        cdist_fn = getattr(_distance_wrap, "cdist_%s" % fn_name)
+        pdist_fn = getattr(_distance_wrap, "pdist_%s" % fn_name)
     for name in names:
         _SIMPLE_CDIST[name] = converter, cdist_fn
         _SIMPLE_PDIST[name] = converter, pdist_fn
@@ -1125,7 +1199,7 @@ _METRICS_NAMES = ['braycurtis', 'canberra', 'chebyshev', 'cityblock',
 _TEST_METRICS = {'test_' + name: eval(name) for name in _METRICS_NAMES}
 
 
-def pdist(X, metric='euclidean', p=None, w=None, V=None, VI=None):
+def pdist(X, metric='euclidean', *args, **kwargs):
     """
     Pairwise distances between observations in n-dimensional space.
 
@@ -1143,18 +1217,28 @@ def pdist(X, metric='euclidean', p=None, w=None, V=None, VI=None):
         'jaccard', 'kulsinski', 'mahalanobis', 'matching',
         'minkowski', 'rogerstanimoto', 'russellrao', 'seuclidean',
         'sokalmichener', 'sokalsneath', 'sqeuclidean', 'yule'.
-    p : double, optional
-        The p-norm to apply
-        Only for Minkowski, weighted and unweighted. Default: 2.
-    w : ndarray, optional
-        The weight vector.
-        Only for weighted Minkowski. Mandatory
-    V : ndarray, optional
-        The variance vector
-        Only for standardized Euclidean. Default: var(X, axis=0, ddof=1)
-    VI : ndarray, optional
-        The inverse of the covariance matrix
-        Only for Mahalanobis. Default: inv(cov(X.T)).T
+    *args : tuple. Deprecated.
+        Additional arguments should be passed as keyword arguments
+    **kwargs : dict, optional
+        Extra arguments to `metric`: refer to each metric documentation for a
+        list of all possible arguments.
+
+        Some possible arguments:
+
+        p : scalar.
+        The p-norm to apply for Minkowski, weighted and unweighted.
+        Default: 2.
+
+        w : ndarray.
+        The weight vector for weighted Minkowski.
+
+        V : ndarray.
+        The variance vector for standardized Euclidean.
+        Default: var(X, axis=0, ddof=1)
+
+        VI : ndarray.
+        The inverse of the covariance matrix for Mahalanobis.
+        Default: inv(cov(X.T)).T
 
     Returns
     -------
@@ -1183,7 +1267,7 @@ def pdist(X, metric='euclidean', p=None, w=None, V=None, VI=None):
        (2-norm) as the distance metric between the points. The points
        are arranged as m n-dimensional row vectors in the matrix X.
 
-    2. ``Y = pdist(X, 'minkowski', p)``
+    2. ``Y = pdist(X, 'minkowski', p=2.)``
 
        Computes the distances using the Minkowski distance
        :math:`||u-v||_p` (p-norm) where :math:`p \\geq 1`.
@@ -1330,7 +1414,7 @@ def pdist(X, metric='euclidean', p=None, w=None, V=None, VI=None):
        Computes the Sokal-Sneath distance between each pair of
        boolean vectors. (see sokalsneath function documentation)
 
-    22. ``Y = pdist(X, 'wminkowski')``
+    22. ``Y = pdist(X, 'wminkowski', p=2, w=w)``
 
        Computes the weighted Minkowski distance between each pair of
        vectors. (see wminkowski function documentation)
@@ -1364,6 +1448,8 @@ def pdist(X, metric='euclidean', p=None, w=None, V=None, VI=None):
     # between all pairs of vectors in X using the distance metric 'abc' but
     # with a more succinct, verifiable, but less efficient implementation.
 
+    kwargs = _args_to_kwargs_xdist(args, kwargs, metric, "pdist")
+
     X = np.asarray(X, order='c')
 
     # The C code doesn't do striding.
@@ -1379,22 +1465,25 @@ def pdist(X, metric='euclidean', p=None, w=None, V=None, VI=None):
     # validate input for multi-args metrics
     if(metric in ['minkowski', 'mi', 'm', 'pnorm', 'test_minkowski'] or
        metric == minkowski):
-        p = _validate_minkowski_args(p)
-        _filter_deprecated_kwargs(w=w, V=V, VI=VI)
+        kwargs_blacklist = ["w", "V", "VI"]
+        kwargs["p"] = _validate_minkowski_args(kwargs.pop("p", None))
     elif(metric in ['wminkowski', 'wmi', 'wm', 'wpnorm', 'test_wminkowski'] or
          metric == wminkowski):
-        p, w = _validate_wminkowski_args(p, w)
-        _filter_deprecated_kwargs(V=V, VI=VI)
+        kwargs_blacklist = ["V", "VI"]
+        kwargs["p"], kwargs["w"] = _validate_wminkowski_args(kwargs.pop("p", None),
+                                                             kwargs.pop("w", None))
     elif(metric in ['seuclidean', 'se', 's', 'test_seuclidean'] or
          metric == seuclidean):
-        V = _validate_seuclidean_args(X, n, V)
-        _filter_deprecated_kwargs(p=p, w=w, VI=VI)
+        kwargs_blacklist = ["p", "w", "VI"]
+        kwargs["V"] = _validate_seuclidean_args(X, n, kwargs.pop("V", None))
     elif(metric in ['mahalanobis', 'mahal', 'mah', 'test_mahalanobis'] or
          metric == mahalanobis):
-        VI = _validate_mahalanobis_args(X, m, n, VI)
-        _filter_deprecated_kwargs(p=p, w=w, V=V)
+        kwargs_blacklist = ["p", "w", "V"]
+        kwargs["VI"] = _validate_mahalanobis_args(X, m, n, kwargs.pop("VI", None))
     else:
-        _filter_deprecated_kwargs(p=p, w=w, V=V, VI=VI)
+        kwargs_blacklist = ["p", "w", "V", "VI"]
+
+    _filter_deprecated_kwargs(kwargs, kwargs_blacklist)
 
     if callable(metric):
         # metrics that expects only doubles:
@@ -1413,20 +1502,10 @@ def pdist(X, metric='euclidean', p=None, w=None, V=None, VI=None):
             else:
                 X = _convert_to_double(X)
 
-        # metrics that expects multiple args
-        if metric == minkowski:
-            metric = partial(minkowski, p=p)
-        elif metric == wminkowski:
-            metric = partial(wminkowski, p=p, w=w)
-        elif metric == seuclidean:
-            metric = partial(seuclidean, V=V)
-        elif metric == mahalanobis:
-            metric = partial(mahalanobis, VI=VI)
-
         k = 0
         for i in xrange(0, m - 1):
             for j in xrange(i + 1, m):
-                dm[k] = metric(X[i], X[j])
+                dm[k] = metric(X[i], X[j], **kwargs)
                 k = k + 1
 
     elif isinstance(metric, string_types):
@@ -1435,7 +1514,7 @@ def pdist(X, metric='euclidean', p=None, w=None, V=None, VI=None):
         try:
             validate, pdist_fn = _SIMPLE_PDIST[mstr]
             X = validate(X)
-            pdist_fn(X, dm)
+            pdist_fn(X, dm, **kwargs)
             return dm
         except KeyError:
             pass
@@ -1443,30 +1522,17 @@ def pdist(X, metric='euclidean', p=None, w=None, V=None, VI=None):
         if mstr in ['matching', 'hamming', 'hamm', 'ha', 'h']:
             if X.dtype == bool:
                 X = _convert_to_bool(X)
-                _distance_wrap.pdist_hamming_bool_wrap(X, dm)
+                _distance_wrap.pdist_hamming_bool_wrap(X, dm, **kwargs)
             else:
                 X = _convert_to_double(X)
-                _distance_wrap.pdist_hamming_wrap(X, dm)
+                _distance_wrap.pdist_hamming_wrap(X, dm, **kwargs)
         elif mstr in ['jaccard', 'jacc', 'ja', 'j']:
             if X.dtype == bool:
                 X = _convert_to_bool(X)
-                _distance_wrap.pdist_jaccard_bool_wrap(X, dm)
+                _distance_wrap.pdist_jaccard_bool_wrap(X, dm, **kwargs)
             else:
                 X = _convert_to_double(X)
-                _distance_wrap.pdist_jaccard_wrap(X, dm)
-        elif mstr in ['minkowski', 'mi', 'm']:
-            X = _convert_to_double(X)
-            _distance_wrap.pdist_minkowski_wrap(X, dm, p=p)
-        elif mstr in ['wminkowski', 'wmi', 'wm', 'wpnorm']:
-            X = _convert_to_double(X)
-            _distance_wrap.pdist_weighted_minkowski_wrap(X, dm, p=p, w=w)
-        elif mstr in ['seuclidean', 'se', 's']:
-            X = _convert_to_double(X)
-            _distance_wrap.pdist_seuclidean_wrap(X, dm, V=V)
-        elif mstr in ['cosine', 'cos']:
-            X = _convert_to_double(X)
-            norms = _row_norms(X)
-            _distance_wrap.pdist_cosine_wrap(X, dm, norms)
+                _distance_wrap.pdist_jaccard_wrap(X, dm, **kwargs)
         elif mstr in ['old_cosine', 'old_cos']:
             warnings.warn('"old_cosine" is deprecated and will be removed in '
                           'a future version. Use "cosine" instead.',
@@ -1481,17 +1547,8 @@ def pdist(X, metric='euclidean', p=None, w=None, V=None, VI=None):
             dm = 1.0 - (nm / de)
             dm[xrange(0, m), xrange(0, m)] = 0.0
             dm = squareform(dm)
-        elif mstr in ['correlation', 'co']:
-            X = _convert_to_double(X)
-            X2 = X - X.mean(1)[:, np.newaxis]
-            norms = _row_norms(X2)
-            _distance_wrap.pdist_cosine_wrap(X2, dm, norms)
-        elif mstr in ['mahalanobis', 'mahal', 'mah']:
-            X = _convert_to_double(X)
-            _distance_wrap.pdist_mahalanobis_wrap(X, dm, VI=VI)
         elif mstr.startswith("test_"):
             if mstr in _TEST_METRICS:
-                kwargs = {"p":p, "w":w, "V":V, "VI":VI}
                 dm = pdist(X, _TEST_METRICS[mstr], **kwargs)
             else:
                 raise ValueError('Unknown "Test" Distance Metric: %s' % mstr[5:])
@@ -1818,24 +1875,7 @@ def num_obs_y(Y):
     return d
 
 
-def _row_norms(X):
-    norms = np.einsum('ij,ij->i', X, X, dtype=np.double)
-    return np.sqrt(norms, out=norms)
-
-
-def _cosine_cdist(XA, XB, dm):
-    XA = _convert_to_double(XA)
-    XB = _convert_to_double(XB)
-
-    np.dot(XA, XB.T, out=dm)
-
-    dm /= _row_norms(XA).reshape(-1, 1)
-    dm /= _row_norms(XB)
-    dm *= -1
-    dm += 1
-
-
-def cdist(XA, XB, metric='euclidean', p=None, V=None, VI=None, w=None):
+def cdist(XA, XB, metric='euclidean', *args, **kwargs):
     """
     Computes distance between each pair of the two collections of inputs.
 
@@ -1858,18 +1898,28 @@ def cdist(XA, XB, metric='euclidean', p=None, V=None, VI=None, w=None):
         'mahalanobis', 'matching', 'minkowski', 'rogerstanimoto', 'russellrao',
         'seuclidean', 'sokalmichener', 'sokalsneath', 'sqeuclidean',
         'wminkowski', 'yule'.
-    p : double, optional
-        The p-norm to apply
-        Only for Minkowski, weighted and unweighted. Default: 2.
-    w : ndarray, optional
-        The weight vector.
-        Only for weighted Minkowski. Mandatory
-    V : ndarray, optional
-        The variance vector
-        Only for standardized Euclidean. Default: var(vstack([XA, XB]), axis=0, ddof=1)
-    VI : ndarray, optional
-        The inverse of the covariance matrix
-        Only for Mahalanobis. Default: inv(cov(vstack([XA, XB]).T)).T
+    *args : tuple. Deprecated.
+        Additional arguments should be passed as keyword arguments
+    **kwargs : dict, optional
+        Extra arguments to `metric`: refer to each metric documentation for a
+        list of all possible arguments.
+
+        Some possible arguments:
+
+        p : scalar.
+        The p-norm to apply for Minkowski, weighted and unweighted.
+        Default: 2.
+
+        w : ndarray.
+        The weight vector for weighted Minkowski.
+
+        V : ndarray.
+        The variance vector for standardized Euclidean.
+        Default: var(vstack([XA, XB]), axis=0, ddof=1)
+
+        VI : ndarray.
+        The inverse of the covariance matrix for Mahalanobis.
+        Default: inv(cov(vstack([XA, XB].T))).T
 
     Returns
     -------
@@ -1896,7 +1946,7 @@ def cdist(XA, XB, metric='euclidean', p=None, V=None, VI=None, w=None):
        points. The points are arranged as :math:`m`
        :math:`n`-dimensional row vectors in the matrix X.
 
-    2. ``Y = cdist(XA, XB, 'minkowski', p)``
+    2. ``Y = cdist(XA, XB, 'minkowski', p=2.)``
 
        Computes the distances using the Minkowski distance
        :math:`||u-v||_p` (:math:`p`-norm) where :math:`p \\geq 1`.
@@ -2043,7 +2093,7 @@ def cdist(XA, XB, metric='euclidean', p=None, V=None, VI=None, w=None):
        `sokalsneath` function documentation)
 
 
-    22. ``Y = cdist(XA, XB, 'wminkowski')``
+    22. ``Y = cdist(XA, XB, 'wminkowski', p=2., w=w)``
 
        Computes the weighted Minkowski distance between the
        vectors. (see `wminkowski` function documentation)
@@ -2115,8 +2165,7 @@ def cdist(XA, XB, metric='euclidean', p=None, V=None, VI=None, w=None):
     # between all pairs of vectors in XA and XB using the distance metric 'abc'
     # but with a more succinct, verifiable, but less efficient implementation.
 
-    # Store input arguments to check whether we can modify later.
-    input_XA, input_XB = XA, XB
+    kwargs = _args_to_kwargs_xdist(args, kwargs, metric, "cdist")
 
     XA = np.asarray(XA, order='c')
     XB = np.asarray(XB, order='c')
@@ -2144,22 +2193,26 @@ def cdist(XA, XB, metric='euclidean', p=None, V=None, VI=None, w=None):
     # validate input for multi-args metrics
     if(metric in ['minkowski', 'mi', 'm', 'pnorm', 'test_minkowski'] or
        metric == minkowski):
-        p = _validate_minkowski_args(p)
-        _filter_deprecated_kwargs(w=w, V=V, VI=VI)
+        kwargs_blacklist = ["w", "V", "VI"]
+        kwargs["p"] = _validate_minkowski_args(kwargs.pop("p", None))
     elif(metric in ['wminkowski', 'wmi', 'wm', 'wpnorm', 'test_wminkowski'] or
          metric == wminkowski):
-        p, w = _validate_wminkowski_args(p, w)
-        _filter_deprecated_kwargs(V=V, VI=VI)
+        kwargs_blacklist = ["V", "VI"]
+        kwargs["p"], kwargs["w"] = _validate_wminkowski_args(kwargs.pop("p", None),
+                                                             kwargs.pop("w", None))
     elif(metric in ['seuclidean', 'se', 's', 'test_seuclidean'] or
          metric == seuclidean):
-        V = _validate_seuclidean_args(np.vstack([XA, XB]), n, V)
-        _filter_deprecated_kwargs(p=p, w=w, VI=VI)
+        kwargs_blacklist = ["p", "w", "VI"]
+        kwargs["V"] = _validate_seuclidean_args(np.vstack([XA, XB]), n,
+                                                kwargs.pop("V", None))
     elif(metric in ['mahalanobis', 'mahal', 'mah', 'test_mahalanobis'] or
          metric == mahalanobis):
-        VI = _validate_mahalanobis_args(np.vstack([XA, XB]), mA + mB, n, VI)
-        _filter_deprecated_kwargs(p=p, w=w, V=V)
+        kwargs_blacklist = ["p", "w", "V"]
+        kwargs["VI"] = _validate_mahalanobis_args(np.vstack([XA, XB]), mA + mB,
+                                                  n, kwargs.pop("VI", None))
     else:
-        _filter_deprecated_kwargs(p=p, w=w, V=V, VI=VI)
+        kwargs_blacklist = ["p", "w", "V", "VI"]
+    _filter_deprecated_kwargs(kwargs, kwargs_blacklist)
 
     if callable(metric):
         # metrics that expects only doubles:
@@ -2182,19 +2235,9 @@ def cdist(XA, XB, metric='euclidean', p=None, V=None, VI=None, w=None):
                 XA = _convert_to_double(XA)
                 XB = _convert_to_double(XB)
 
-        # metrics that expects multiple args
-        if metric == minkowski:
-            metric = partial(minkowski, p=p)
-        elif metric == wminkowski:
-            metric = partial(wminkowski, p=p, w=w)
-        elif metric == seuclidean:
-            metric = partial(seuclidean, V=V)
-        elif metric == mahalanobis:
-            metric = partial(mahalanobis, VI=VI)
-
         for i in xrange(0, mA):
             for j in xrange(0, mB):
-                dm[i, j] = metric(XA[i, :], XB[j, :])
+                dm[i, j] = metric(XA[i], XB[j], **kwargs)
 
     elif isinstance(metric, string_types):
         mstr = metric.lower()
@@ -2203,7 +2246,7 @@ def cdist(XA, XB, metric='euclidean', p=None, V=None, VI=None, w=None):
             validate, cdist_fn = _SIMPLE_CDIST[mstr]
             XA = validate(XA)
             XB = validate(XB)
-            cdist_fn(XA, XB, dm)
+            cdist_fn(XA, XB, dm, **kwargs)
             return dm
         except KeyError:
             pass
@@ -2212,52 +2255,22 @@ def cdist(XA, XB, metric='euclidean', p=None, V=None, VI=None, w=None):
             if XA.dtype == bool:
                 XA = _convert_to_bool(XA)
                 XB = _convert_to_bool(XB)
-                _distance_wrap.cdist_hamming_bool_wrap(XA, XB, dm)
+                _distance_wrap.cdist_hamming_bool_wrap(XA, XB, dm, **kwargs)
             else:
                 XA = _convert_to_double(XA)
                 XB = _convert_to_double(XB)
-                _distance_wrap.cdist_hamming_wrap(XA, XB, dm)
+                _distance_wrap.cdist_hamming_wrap(XA, XB, dm, **kwargs)
         elif mstr in ['jaccard', 'jacc', 'ja', 'j']:
             if XA.dtype == bool:
                 XA = _convert_to_bool(XA)
                 XB = _convert_to_bool(XB)
-                _distance_wrap.cdist_jaccard_bool_wrap(XA, XB, dm)
+                _distance_wrap.cdist_jaccard_bool_wrap(XA, XB, dm, **kwargs)
             else:
                 XA = _convert_to_double(XA)
                 XB = _convert_to_double(XB)
-                _distance_wrap.cdist_jaccard_wrap(XA, XB, dm)
-        elif mstr in ['minkowski', 'mi', 'm', 'pnorm']:
-            XA = _convert_to_double(XA)
-            XB = _convert_to_double(XB)
-            _distance_wrap.cdist_minkowski_wrap(XA, XB, dm, p=p)
-        elif mstr in ['wminkowski', 'wmi', 'wm', 'wpnorm']:
-            XA = _convert_to_double(XA)
-            XB = _convert_to_double(XB)
-            _distance_wrap.cdist_weighted_minkowski_wrap(XA, XB, dm, p=p, w=w)
-        elif mstr in ['seuclidean', 'se', 's']:
-            XA = _convert_to_double(XA)
-            XB = _convert_to_double(XB)
-            _distance_wrap.cdist_seuclidean_wrap(XA, XB, dm, V=V)
-        elif mstr in ['cosine', 'cos']:
-            XA = _convert_to_double(XA)
-            XB = _convert_to_double(XB)
-            _cosine_cdist(XA, XB, dm)
-        elif mstr in ['correlation', 'co']:
-            XA = _convert_to_double(XA)
-            XB = _convert_to_double(XB)
-            XA = XA.copy() if XA is input_XA else XA
-            XB = XB.copy() if XB is input_XB else XB
-            XA -= XA.mean(axis=1)[:, np.newaxis]
-            XB -= XB.mean(axis=1)[:, np.newaxis]
-            _cosine_cdist(XA, XB, dm)
-        elif mstr in ['mahalanobis', 'mahal', 'mah']:
-            XA = _convert_to_double(XA)
-            XB = _convert_to_double(XB)
-            # sqrt((u-v)V^(-1)(u-v)^T)
-            _distance_wrap.cdist_mahalanobis_wrap(XA, XB, dm, VI=VI)
+                _distance_wrap.cdist_jaccard_wrap(XA, XB, dm, **kwargs)
         elif mstr.startswith("test_"):
             if mstr in _TEST_METRICS:
-                kwargs = {"p":p, "w":w, "V":V, "VI":VI}
                 dm = cdist(XA, XB, _TEST_METRICS[mstr], **kwargs)
             else:
                 raise ValueError('Unknown "Test" Distance Metric: %s' % mstr[5:])

--- a/scipy/spatial/src/distance_wrap.c
+++ b/scipy/spatial/src/distance_wrap.c
@@ -42,7 +42,7 @@
 #pragma GCC optimize("unroll-loops")
 #endif
 #endif
-
+#include <stdio.h>
 #include <math.h>
 #include <stdlib.h>
 #include <Python.h>
@@ -51,9 +51,30 @@
 
 #include "distance_impl.h"
 
+static NPY_INLINE double *_cosine_norms_buf(Py_ssize_t n)
+{
+    double * norms_buf = calloc(n, sizeof(double));
+    if (!norms_buf) {
+        PyErr_Format(PyExc_MemoryError, "could not allocate %zd * %zd bytes",
+                     n, sizeof(double));
+    }
+    return norms_buf;
+}
+
+static NPY_INLINE double *_mahalanobis_dimbuf(Py_ssize_t n)
+{
+    double *dimbuf;
+    dimbuf = calloc(n, 2 * sizeof(double));
+    if (!dimbuf) {
+        PyErr_Format(PyExc_MemoryError, "could not allocate %zd * %zd bytes",
+                     n, 2 * sizeof(double));
+    }
+    return dimbuf;
+}
+
 #define DEFINE_WRAP_CDIST(name, type)                                   \
     static PyObject *                                                   \
-    cdist_ ## name ## _wrap(PyObject *self, PyObject *args)             \
+    cdist_ ## name ## _ ## type ## _wrap(PyObject *self, PyObject *args)\
     {                                                                   \
         PyArrayObject *XA_, *XB_, *dm_;                                 \
         Py_ssize_t mA, mB, n;                                           \
@@ -87,22 +108,56 @@ DEFINE_WRAP_CDIST(hamming, double)
 DEFINE_WRAP_CDIST(jaccard, double)
 DEFINE_WRAP_CDIST(sqeuclidean, double)
 
-DEFINE_WRAP_CDIST(yule_bool, char)
+DEFINE_WRAP_CDIST(dice, char)
+DEFINE_WRAP_CDIST(hamming, char)
+DEFINE_WRAP_CDIST(jaccard, char)
+DEFINE_WRAP_CDIST(kulsinski, char)
+DEFINE_WRAP_CDIST(rogerstanimoto, char)
+DEFINE_WRAP_CDIST(russellrao, char)
+DEFINE_WRAP_CDIST(sokalmichener, char)
+DEFINE_WRAP_CDIST(sokalsneath, char)
+DEFINE_WRAP_CDIST(yule, char)
 
+static PyObject *cdist_cosine_double_wrap(PyObject *self, PyObject *args, 
+                                               PyObject *kwargs) {
+  PyArrayObject *XA_, *XB_, *dm_;
+  int mA, mB, n;
+  double *dm;
+  const double *XA, *XB;
+  static char *kwlist[] = {"XA", "XB", "dm", NULL};
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, 
+            "O!O!O!:cdist_cosine_double_wrap", kwlist,
+            &PyArray_Type, &XA_, &PyArray_Type, &XB_, 
+            &PyArray_Type, &dm_)) 
+  {
+    return 0;
+  }
+  else {
+    NPY_BEGIN_THREADS_DEF;
+    NPY_BEGIN_THREADS;
+    XA = (const double*)XA_->data;
+    XB = (const double*)XB_->data;
+    dm = (double*)dm_->data;
+    mA = XA_->dimensions[0];
+    mB = XB_->dimensions[0];
+    n = XA_->dimensions[1];
 
-static NPY_INLINE double *mahalanobis_dimbuf(Py_ssize_t n)
-{
-    double *dimbuf;
-    dimbuf = calloc(n, 2 * sizeof(double));
-    if (!dimbuf) {
-        PyErr_Format(PyExc_MemoryError, "could not allocate %zd * %zd bytes",
-                     n, 2 * sizeof(double));
+    double * norms_bufA = _cosine_norms_buf(mA);
+    double * norms_bufB = _cosine_norms_buf(mB);
+    if (!norms_bufA | !norms_bufB) {
+      NPY_END_THREADS;
+      return NULL;
     }
-    return dimbuf;
+    cdist_cosine(XA, XB, dm, mA, mB, n, norms_bufA, norms_bufB);
+    free(norms_bufA);
+    free(norms_bufB);
+    NPY_END_THREADS;
+  }
+  return Py_BuildValue("d", 0.0);
 }
 
-
-static PyObject *cdist_mahalanobis_wrap(PyObject *self, PyObject *args, PyObject *kwargs) {
+static PyObject *cdist_mahalanobis_double_wrap(PyObject *self, PyObject *args, 
+                                               PyObject *kwargs) {
   PyArrayObject *XA_, *XB_, *covinv_, *dm_;
   int mA, mB, n;
   double *dm, *dimbuf;
@@ -110,9 +165,10 @@ static PyObject *cdist_mahalanobis_wrap(PyObject *self, PyObject *args, PyObject
   const double *covinv;
   static char *kwlist[] = {"XA", "XB", "dm", "VI", NULL};
   if (!PyArg_ParseTupleAndKeywords(args, kwargs, 
-            "O!O!O!O!:cdist_mahalanobis_wrap", kwlist,
+            "O!O!O!O!:cdist_mahalanobis_double_wrap", kwlist,
             &PyArray_Type, &XA_, &PyArray_Type, &XB_, 
-            &PyArray_Type, &dm_, &PyArray_Type, &covinv_)) {
+            &PyArray_Type, &dm_, &PyArray_Type, &covinv_)) 
+  {
     return 0;
   }
   else {
@@ -126,7 +182,7 @@ static PyObject *cdist_mahalanobis_wrap(PyObject *self, PyObject *args, PyObject
     mB = XB_->dimensions[0];
     n = XA_->dimensions[1];
 
-    dimbuf = mahalanobis_dimbuf(n);
+    dimbuf = _mahalanobis_dimbuf(n);
     if (!dimbuf) {
       NPY_END_THREADS;
       return NULL;
@@ -138,14 +194,46 @@ static PyObject *cdist_mahalanobis_wrap(PyObject *self, PyObject *args, PyObject
   return Py_BuildValue("d", 0.0);
 }
 
-static PyObject *cdist_seuclidean_wrap(PyObject *self, PyObject *args, PyObject *kwargs) {
+static PyObject *cdist_minkowski_double_wrap(PyObject *self, PyObject *args, 
+                                             PyObject *kwargs) 
+{
+  PyArrayObject *XA_, *XB_, *dm_;
+  int mA, mB, n;
+  double *dm;
+  const double *XA, *XB;
+  double p;
+  static char *kwlist[] = {"XA", "XB", "dm", "p", NULL};
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, 
+            "O!O!O!d:cdist_minkowski_double_wrap", kwlist,
+            &PyArray_Type, &XA_, &PyArray_Type, &XB_, 
+            &PyArray_Type, &dm_,
+            &p)) {
+    return 0;
+  }
+  else {
+    NPY_BEGIN_ALLOW_THREADS;
+    XA = (const double*)XA_->data;
+    XB = (const double*)XB_->data;
+    dm = (double*)dm_->data;
+    mA = XA_->dimensions[0];
+    mB = XB_->dimensions[0];
+    n = XA_->dimensions[1];
+    cdist_minkowski(XA, XB, dm, mA, mB, n, p);
+    NPY_END_ALLOW_THREADS;
+  }
+  return Py_BuildValue("d", 0.0);
+}
+
+static PyObject *cdist_seuclidean_double_wrap(PyObject *self, PyObject *args, 
+                                              PyObject *kwargs) 
+{
   PyArrayObject *XA_, *XB_, *dm_, *var_;
   int mA, mB, n;
   double *dm;
   const double *XA, *XB, *var;
   static char *kwlist[] = {"XA", "XB", "dm", "V", NULL};
   if (!PyArg_ParseTupleAndKeywords(args, kwargs, 
-            "O!O!O!O!:cdist_seuclidean_wrap", kwlist,
+            "O!O!O!O!:cdist_seuclidean_double_wrap", kwlist,
             &PyArray_Type, &XA_, &PyArray_Type, &XB_, 
             &PyArray_Type, &dm_, &PyArray_Type, &var_)) {
     return 0;
@@ -166,85 +254,9 @@ static PyObject *cdist_seuclidean_wrap(PyObject *self, PyObject *args, PyObject 
   return Py_BuildValue("d", 0.0);
 }
 
-static PyObject *cdist_hamming_bool_wrap(PyObject *self, PyObject *args) {
-  PyArrayObject *XA_, *XB_, *dm_;
-  int mA, mB, n;
-  double *dm;
-  const char *XA, *XB;
-  if (!PyArg_ParseTuple(args, "O!O!O!",
-            &PyArray_Type, &XA_, &PyArray_Type, &XB_, 
-            &PyArray_Type, &dm_)) {
-    return 0;
-  }
-  else {
-    NPY_BEGIN_ALLOW_THREADS;
-    XA = (const char*)XA_->data;
-    XB = (const char*)XB_->data;
-    dm = (double*)dm_->data;
-    mA = XA_->dimensions[0];
-    mB = XB_->dimensions[0];
-    n = XA_->dimensions[1];
-
-    cdist_hamming_char(XA, XB, dm, mA, mB, n);
-    NPY_END_ALLOW_THREADS;
-  }
-  return Py_BuildValue("d", 0.0);
-}
-
-static PyObject *cdist_jaccard_bool_wrap(PyObject *self, PyObject *args) {
-  PyArrayObject *XA_, *XB_, *dm_;
-  int mA, mB, n;
-  double *dm;
-  const char *XA, *XB;
-  if (!PyArg_ParseTuple(args, "O!O!O!",
-            &PyArray_Type, &XA_, &PyArray_Type, &XB_, 
-            &PyArray_Type, &dm_)) {
-    return 0;
-  }
-  else {
-    NPY_BEGIN_ALLOW_THREADS;
-    XA = (const char*)XA_->data;
-    XB = (const char*)XB_->data;
-    dm = (double*)dm_->data;
-    mA = XA_->dimensions[0];
-    mB = XB_->dimensions[0];
-    n = XA_->dimensions[1];
-
-    cdist_jaccard_char(XA, XB, dm, mA, mB, n);
-    NPY_END_ALLOW_THREADS;
-  }
-  return Py_BuildValue("d", 0.0);
-}
-
-static PyObject *cdist_minkowski_wrap(PyObject *self, PyObject *args, PyObject *kwargs) {
-  PyArrayObject *XA_, *XB_, *dm_;
-  int mA, mB, n;
-  double *dm;
-  const double *XA, *XB;
-  double p;
-  static char *kwlist[] = {"XA", "XB", "dm", "p", NULL};
-  if (!PyArg_ParseTupleAndKeywords(args, kwargs, 
-            "O!O!O!d:cdist_minkowski_wrap", kwlist,
-            &PyArray_Type, &XA_, &PyArray_Type, &XB_, 
-            &PyArray_Type, &dm_,
-            &p)) {
-    return 0;
-  }
-  else {
-    NPY_BEGIN_ALLOW_THREADS;
-    XA = (const double*)XA_->data;
-    XB = (const double*)XB_->data;
-    dm = (double*)dm_->data;
-    mA = XA_->dimensions[0];
-    mB = XB_->dimensions[0];
-    n = XA_->dimensions[1];
-    cdist_minkowski(XA, XB, dm, mA, mB, n, p);
-    NPY_END_ALLOW_THREADS;
-  }
-  return Py_BuildValue("d", 0.0);
-}
-
-static PyObject *cdist_weighted_minkowski_wrap(PyObject *self, PyObject *args, PyObject *kwargs) {
+static PyObject *cdist_weighted_minkowski_double_wrap(
+                            PyObject *self, PyObject *args, PyObject *kwargs) 
+{
   PyArrayObject *XA_, *XB_, *dm_, *w_;
   int mA, mB, n;
   double *dm;
@@ -252,7 +264,7 @@ static PyObject *cdist_weighted_minkowski_wrap(PyObject *self, PyObject *args, P
   double p;
   static char *kwlist[] = {"XA", "XB", "dm", "p", "w", NULL};
   if (!PyArg_ParseTupleAndKeywords(args, kwargs, 
-            "O!O!O!dO!:cdist_weighted_minkowski_wrap", kwlist,
+            "O!O!O!dO!:cdist_weighted_minkowski_double_wrap", kwlist,
             &PyArray_Type, &XA_, &PyArray_Type, &XB_, 
             &PyArray_Type, &dm_,
             &p,
@@ -274,193 +286,87 @@ static PyObject *cdist_weighted_minkowski_wrap(PyObject *self, PyObject *args, P
   return Py_BuildValue("d", 0.0);
 }
 
-static PyObject *cdist_dice_bool_wrap(PyObject *self, PyObject *args) {
-  PyArrayObject *XA_, *XB_, *dm_;
-  int mA, mB, n;
-  double *dm;
-  const char *XA, *XB;
-  if (!PyArg_ParseTuple(args, "O!O!O!",
-            &PyArray_Type, &XA_, &PyArray_Type, &XB_, 
-            &PyArray_Type, &dm_)) {
-    return 0;
-  }
-  else {
-    NPY_BEGIN_ALLOW_THREADS;
-    XA = (const char*)XA_->data;
-    XB = (const char*)XB_->data;
-    dm = (double*)dm_->data;
-    mA = XA_->dimensions[0];
-    mB = XB_->dimensions[0];
-    n = XA_->dimensions[1];
-
-    cdist_dice_char(XA, XB, dm, mA, mB, n);
-    NPY_END_ALLOW_THREADS;
-  }
-  return Py_BuildValue("");
-}
-
-static PyObject *cdist_rogerstanimoto_bool_wrap(PyObject *self, PyObject *args) {
-  PyArrayObject *XA_, *XB_, *dm_;
-  int mA, mB, n;
-  double *dm;
-  const char *XA, *XB;
-  if (!PyArg_ParseTuple(args, "O!O!O!",
-            &PyArray_Type, &XA_, &PyArray_Type, &XB_, 
-            &PyArray_Type, &dm_)) {
-    return 0;
-  }
-  else {
-    NPY_BEGIN_ALLOW_THREADS;
-    XA = (const char*)XA_->data;
-    XB = (const char*)XB_->data;
-    dm = (double*)dm_->data;
-    mA = XA_->dimensions[0];
-    mB = XB_->dimensions[0];
-    n = XA_->dimensions[1];
-
-    cdist_rogerstanimoto_char(XA, XB, dm, mA, mB, n);
-    NPY_END_ALLOW_THREADS;
-  }
-  return Py_BuildValue("");
-}
-
-static PyObject *cdist_russellrao_bool_wrap(PyObject *self, PyObject *args) {
-  PyArrayObject *XA_, *XB_, *dm_;
-  int mA, mB, n;
-  double *dm;
-  const char *XA, *XB;
-  if (!PyArg_ParseTuple(args, "O!O!O!",
-            &PyArray_Type, &XA_, &PyArray_Type, &XB_, 
-            &PyArray_Type, &dm_)) {
-    return 0;
-  }
-  else {
-    NPY_BEGIN_ALLOW_THREADS;
-    XA = (const char*)XA_->data;
-    XB = (const char*)XB_->data;
-    dm = (double*)dm_->data;
-    mA = XA_->dimensions[0];
-    mB = XB_->dimensions[0];
-    n = XA_->dimensions[1];
-
-    cdist_russellrao_char(XA, XB, dm, mA, mB, n);
-    NPY_END_ALLOW_THREADS;
-  }
-  return Py_BuildValue("");
-}
-
-static PyObject *cdist_kulsinski_bool_wrap(PyObject *self, PyObject *args) {
-  PyArrayObject *XA_, *XB_, *dm_;
-  int mA, mB, n;
-  double *dm;
-  const char *XA, *XB;
-  if (!PyArg_ParseTuple(args, "O!O!O!",
-            &PyArray_Type, &XA_, &PyArray_Type, &XB_, 
-            &PyArray_Type, &dm_)) {
-    return 0;
-  }
-  else {
-    NPY_BEGIN_ALLOW_THREADS;
-    XA = (const char*)XA_->data;
-    XB = (const char*)XB_->data;
-    dm = (double*)dm_->data;
-    mA = XA_->dimensions[0];
-    mB = XB_->dimensions[0];
-    n = XA_->dimensions[1];
-
-    cdist_kulsinski_char(XA, XB, dm, mA, mB, n);
-    NPY_END_ALLOW_THREADS;
-  }
-  return Py_BuildValue("");
-}
-
-static PyObject *cdist_sokalmichener_bool_wrap(PyObject *self, PyObject *args) {
-  PyArrayObject *XA_, *XB_, *dm_;
-  int mA, mB, n;
-  double *dm;
-  const char *XA, *XB;
-  if (!PyArg_ParseTuple(args, "O!O!O!",
-            &PyArray_Type, &XA_, &PyArray_Type, &XB_, 
-            &PyArray_Type, &dm_)) {
-    return 0;
-  }
-  else {
-    NPY_BEGIN_ALLOW_THREADS;
-    XA = (const char*)XA_->data;
-    XB = (const char*)XB_->data;
-    dm = (double*)dm_->data;
-    mA = XA_->dimensions[0];
-    mB = XB_->dimensions[0];
-    n = XA_->dimensions[1];
-
-    cdist_sokalmichener_char(XA, XB, dm, mA, mB, n);
-    NPY_END_ALLOW_THREADS;
-  }
-  return Py_BuildValue("");
-}
-
-static PyObject *cdist_sokalsneath_bool_wrap(PyObject *self, PyObject *args) {
-  PyArrayObject *XA_, *XB_, *dm_;
-  int mA, mB, n;
-  double *dm;
-  const char *XA, *XB;
-  if (!PyArg_ParseTuple(args, "O!O!O!",
-            &PyArray_Type, &XA_, &PyArray_Type, &XB_, 
-            &PyArray_Type, &dm_)) {
-    return 0;
-  }
-  else {
-    NPY_BEGIN_ALLOW_THREADS;
-    XA = (const char*)XA_->data;
-    XB = (const char*)XB_->data;
-    dm = (double*)dm_->data;
-    mA = XA_->dimensions[0];
-    mB = XB_->dimensions[0];
-    n = XA_->dimensions[1];
-
-    cdist_sokalsneath_char(XA, XB, dm, mA, mB, n);
-    NPY_END_ALLOW_THREADS;
-  }
-  return Py_BuildValue("");
-}
-
 /***************************** pdist ***/
 
-#define DEFINE_WRAP_PDIST_DOUBLE(name)                                  \
+#define DEFINE_WRAP_PDIST(name, type)                                   \
     static PyObject *                                                   \
-    pdist_ ## name ## _wrap(PyObject *self, PyObject *args)             \
+    pdist_ ## name ## _ ## type ## _wrap(PyObject *self, PyObject *args)\
     {                                                                   \
         PyArrayObject *X_, *dm_;                                        \
         Py_ssize_t m, n;                                                \
         double *dm;                                                     \
-        const double *X;                                                \
+        const type *X;                                                  \
         if (!PyArg_ParseTuple(args, "O!O!", &PyArray_Type, &X_,         \
                                             &PyArray_Type, &dm_)) {     \
             return NULL;                                                \
         }                                                               \
         else {                                                          \
             NPY_BEGIN_ALLOW_THREADS;                                    \
-            X = (const double *)X_->data;                               \
+            X = (const type *)X_->data;                                 \
             dm = (double *)dm_->data;                                   \
             m = X_->dimensions[0];                                      \
             n = X_->dimensions[1];                                      \
-            pdist_ ## name ## _double(X, dm, m, n);                     \
+            pdist_ ## name ## _ ## type(X, dm, m, n);                   \
             NPY_END_ALLOW_THREADS;                                      \
         }                                                               \
         return Py_BuildValue("d", 0.);                                  \
     }
 
-DEFINE_WRAP_PDIST_DOUBLE(bray_curtis)
-DEFINE_WRAP_PDIST_DOUBLE(canberra)
-DEFINE_WRAP_PDIST_DOUBLE(chebyshev)
-DEFINE_WRAP_PDIST_DOUBLE(city_block)
-DEFINE_WRAP_PDIST_DOUBLE(euclidean)
-DEFINE_WRAP_PDIST_DOUBLE(hamming)
-DEFINE_WRAP_PDIST_DOUBLE(jaccard)
-DEFINE_WRAP_PDIST_DOUBLE(sqeuclidean)
+DEFINE_WRAP_PDIST(bray_curtis, double)
+DEFINE_WRAP_PDIST(canberra, double)
+DEFINE_WRAP_PDIST(chebyshev, double)
+DEFINE_WRAP_PDIST(city_block, double)
+DEFINE_WRAP_PDIST(euclidean, double)
+DEFINE_WRAP_PDIST(hamming, double)
+DEFINE_WRAP_PDIST(jaccard, double)
+DEFINE_WRAP_PDIST(sqeuclidean, double)
 
+DEFINE_WRAP_PDIST(dice, char)
+DEFINE_WRAP_PDIST(kulsinski, char)
+DEFINE_WRAP_PDIST(hamming, char)
+DEFINE_WRAP_PDIST(jaccard, char)
+DEFINE_WRAP_PDIST(rogerstanimoto, char)
+DEFINE_WRAP_PDIST(russellrao, char)
+DEFINE_WRAP_PDIST(sokalmichener, char)
+DEFINE_WRAP_PDIST(sokalsneath, char)
+DEFINE_WRAP_PDIST(yule, char)
 
-static PyObject *pdist_mahalanobis_wrap(PyObject *self, PyObject *args, PyObject *kwargs) {
+static PyObject *pdist_cosine_double_wrap(PyObject *self, PyObject *args, 
+                                          PyObject *kwargs) 
+{
+  PyArrayObject *X_, *dm_;
+  int m, n;
+  double *dm;
+  const double *X;
+  static char *kwlist[] = {"X", "dm", NULL};
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, 
+            "O!O!:pdist_cosine_double_wrap", kwlist,
+            &PyArray_Type, &X_,
+            &PyArray_Type, &dm_)) {
+    return 0;
+  }
+  else {
+    NPY_BEGIN_THREADS_DEF;
+    NPY_BEGIN_THREADS;
+    X = (const double*)X_->data;
+    dm = (double*)dm_->data;
+    m = X_->dimensions[0];
+    n = X_->dimensions[1];
+    
+    double * norms_buf = _cosine_norms_buf(m);
+    if (!norms_buf) {
+      NPY_END_THREADS;
+      return NULL;
+    }
+    pdist_cosine(X, dm, m, n, norms_buf);
+    free(norms_buf);
+    NPY_END_THREADS;
+  }
+  return Py_BuildValue("d", 0.0);
+}
+
+static PyObject *pdist_mahalanobis_double_wrap(PyObject *self, PyObject *args, 
+                                               PyObject *kwargs) {
   PyArrayObject *X_, *covinv_, *dm_;
   int m, n;
   double *dimbuf, *dm;
@@ -468,7 +374,7 @@ static PyObject *pdist_mahalanobis_wrap(PyObject *self, PyObject *args, PyObject
   const double *covinv;
   static char *kwlist[] = {"X", "dm", "VI", NULL};
   if (!PyArg_ParseTupleAndKeywords(args, kwargs, 
-            "O!O!O!:pdist_mahalanobis_wrap", kwlist,
+            "O!O!O!:pdist_mahalanobis_double_wrap", kwlist,
             &PyArray_Type, &X_,
             &PyArray_Type, &dm_, 
             &PyArray_Type, &covinv_)) {
@@ -483,7 +389,7 @@ static PyObject *pdist_mahalanobis_wrap(PyObject *self, PyObject *args, PyObject
     m = X_->dimensions[0];
     n = X_->dimensions[1];
 
-    dimbuf = mahalanobis_dimbuf(n);
+    dimbuf = _mahalanobis_dimbuf(n);
     if (!dimbuf) {
         NPY_END_THREADS;
         return NULL;
@@ -496,40 +402,44 @@ static PyObject *pdist_mahalanobis_wrap(PyObject *self, PyObject *args, PyObject
   return Py_BuildValue("d", 0.0);
 }
 
-
-static PyObject *pdist_cosine_wrap(PyObject *self, PyObject *args) {
-  PyArrayObject *X_, *dm_, *norms_;
+static PyObject *pdist_minkowski_double_wrap(PyObject *self, PyObject *args, 
+                                             PyObject *kwargs) 
+{
+  PyArrayObject *X_, *dm_;
   int m, n;
-  double *dm;
-  const double *X, *norms;
-  if (!PyArg_ParseTuple(args, "O!O!O!",
+  double *dm, *X;
+  double p;
+  static char *kwlist[] = {"X", "dm", "p", NULL};
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, 
+            "O!O!d:pdist_minkowski_double_wrap", kwlist,
             &PyArray_Type, &X_,
             &PyArray_Type, &dm_,
-            &PyArray_Type, &norms_)) {
+            &p)) {
     return 0;
   }
   else {
     NPY_BEGIN_ALLOW_THREADS;
-    X = (const double*)X_->data;
+    X = (double*)X_->data;
     dm = (double*)dm_->data;
-    norms = (const double*)norms_->data;
     m = X_->dimensions[0];
     n = X_->dimensions[1];
 
-    pdist_cosine(X, dm, m, n, norms);
+    pdist_minkowski(X, dm, m, n, p);
     NPY_END_ALLOW_THREADS;
   }
   return Py_BuildValue("d", 0.0);
 }
 
-static PyObject *pdist_seuclidean_wrap(PyObject *self, PyObject *args, PyObject *kwargs) {
+static PyObject *pdist_seuclidean_double_wrap(PyObject *self, PyObject *args, 
+                                              PyObject *kwargs) 
+{
   PyArrayObject *X_, *dm_, *var_;
   int m, n;
   double *dm;
   const double *X, *var;
   static char *kwlist[] = {"X", "dm", "V", NULL};
   if (!PyArg_ParseTupleAndKeywords(args, kwargs, 
-            "O!O!O!:pdist_seuclidean_wrap", kwlist,
+            "O!O!O!:pdist_seuclidean_double_wrap", kwlist,
             &PyArray_Type, &X_,
             &PyArray_Type, &dm_,
             &PyArray_Type, &var_)) {
@@ -549,86 +459,16 @@ static PyObject *pdist_seuclidean_wrap(PyObject *self, PyObject *args, PyObject 
   return Py_BuildValue("d", 0.0);
 }
 
-static PyObject *pdist_hamming_bool_wrap(PyObject *self, PyObject *args) {
-  PyArrayObject *X_, *dm_;
-  int m, n;
-  double *dm;
-  const char *X;
-  if (!PyArg_ParseTuple(args, "O!O!",
-            &PyArray_Type, &X_,
-            &PyArray_Type, &dm_)) {
-    return 0;
-  }
-  else {
-    NPY_BEGIN_ALLOW_THREADS;
-    X = (const char*)X_->data;
-    dm = (double*)dm_->data;
-    m = X_->dimensions[0];
-    n = X_->dimensions[1];
-
-    pdist_hamming_char(X, dm, m, n);
-    NPY_END_ALLOW_THREADS;
-  }
-  return Py_BuildValue("d", 0.0);
-}
-
-static PyObject *pdist_jaccard_bool_wrap(PyObject *self, PyObject *args) {
-  PyArrayObject *X_, *dm_;
-  int m, n;
-  double *dm;
-  const char *X;
-  if (!PyArg_ParseTuple(args, "O!O!",
-            &PyArray_Type, &X_,
-            &PyArray_Type, &dm_)) {
-    return 0;
-  }
-  else {
-    NPY_BEGIN_ALLOW_THREADS;
-    X = (const char*)X_->data;
-    dm = (double*)dm_->data;
-    m = X_->dimensions[0];
-    n = X_->dimensions[1];
-
-    pdist_jaccard_char(X, dm, m, n);
-    NPY_END_ALLOW_THREADS;
-  }
-  return Py_BuildValue("d", 0.0);
-}
-
-static PyObject *pdist_minkowski_wrap(PyObject *self, PyObject *args, PyObject *kwargs) {
-  PyArrayObject *X_, *dm_;
-  int m, n;
-  double *dm, *X;
-  double p;
-  static char *kwlist[] = {"X", "dm", "p", NULL};
-  if (!PyArg_ParseTupleAndKeywords(args, kwargs, 
-            "O!O!d:pdist_minkowski_wrap", kwlist,
-            &PyArray_Type, &X_,
-            &PyArray_Type, &dm_,
-            &p)) {
-    return 0;
-  }
-  else {
-    NPY_BEGIN_ALLOW_THREADS;
-    X = (double*)X_->data;
-    dm = (double*)dm_->data;
-    m = X_->dimensions[0];
-    n = X_->dimensions[1];
-
-    pdist_minkowski(X, dm, m, n, p);
-    NPY_END_ALLOW_THREADS;
-  }
-  return Py_BuildValue("d", 0.0);
-}
-
-static PyObject *pdist_weighted_minkowski_wrap(PyObject *self, PyObject *args, PyObject *kwargs) {
+static PyObject *pdist_weighted_minkowski_double_wrap(
+                            PyObject *self, PyObject *args, PyObject *kwargs) 
+{
   PyArrayObject *X_, *dm_, *w_;
   int m, n;
   double *dm, *X, *w;
   double p;
   static char *kwlist[] = {"X", "dm", "p", "w", NULL};
   if (!PyArg_ParseTupleAndKeywords(args, kwargs, 
-            "O!O!dO!:pdist_weighted_minkowski_wrap", kwlist,
+            "O!O!dO!:pdist_weighted_minkowski_double_wrap", kwlist,
             &PyArray_Type, &X_,
             &PyArray_Type, &dm_,
             &p,
@@ -650,168 +490,8 @@ static PyObject *pdist_weighted_minkowski_wrap(PyObject *self, PyObject *args, P
 }
 
 
-static PyObject *pdist_yule_bool_wrap(PyObject *self, PyObject *args) {
-  PyArrayObject *X_, *dm_;
-  int m, n;
-  double *dm;
-  const char *X;
-  if (!PyArg_ParseTuple(args, "O!O!",
-            &PyArray_Type, &X_,
-            &PyArray_Type, &dm_)) {
-    return 0;
-  }
-  else {
-    NPY_BEGIN_ALLOW_THREADS;
-    X = (const char*)X_->data;
-    dm = (double*)dm_->data;
-    m = X_->dimensions[0];
-    n = X_->dimensions[1];
-
-    pdist_yule_bool_char(X, dm, m, n);
-    NPY_END_ALLOW_THREADS;
-  }
-  return Py_BuildValue("");
-}
-
-static PyObject *pdist_dice_bool_wrap(PyObject *self, PyObject *args) {
-  PyArrayObject *X_, *dm_;
-  int m, n;
-  double *dm;
-  const char *X;
-  if (!PyArg_ParseTuple(args, "O!O!",
-            &PyArray_Type, &X_,
-            &PyArray_Type, &dm_)) {
-    return 0;
-  }
-  else {
-    NPY_BEGIN_ALLOW_THREADS;
-    X = (const char*)X_->data;
-    dm = (double*)dm_->data;
-    m = X_->dimensions[0];
-    n = X_->dimensions[1];
-
-    pdist_dice_char(X, dm, m, n);
-    NPY_END_ALLOW_THREADS;
-  }
-  return Py_BuildValue("");
-}
-
-static PyObject *pdist_rogerstanimoto_bool_wrap(PyObject *self, PyObject *args) {
-  PyArrayObject *X_, *dm_;
-  int m, n;
-  double *dm;
-  const char *X;
-  if (!PyArg_ParseTuple(args, "O!O!",
-            &PyArray_Type, &X_,
-            &PyArray_Type, &dm_)) {
-    return 0;
-  }
-  else {
-    NPY_BEGIN_ALLOW_THREADS;
-    X = (const char*)X_->data;
-    dm = (double*)dm_->data;
-    m = X_->dimensions[0];
-    n = X_->dimensions[1];
-
-    pdist_rogerstanimoto_char(X, dm, m, n);
-    NPY_END_ALLOW_THREADS;
-  }
-  return Py_BuildValue("");
-}
-
-static PyObject *pdist_russellrao_bool_wrap(PyObject *self, PyObject *args) {
-  PyArrayObject *X_, *dm_;
-  int m, n;
-  double *dm;
-  const char *X;
-  if (!PyArg_ParseTuple(args, "O!O!",
-            &PyArray_Type, &X_,
-            &PyArray_Type, &dm_)) {
-    return 0;
-  }
-  else {
-    NPY_BEGIN_ALLOW_THREADS;
-    X = (const char*)X_->data;
-    dm = (double*)dm_->data;
-    m = X_->dimensions[0];
-    n = X_->dimensions[1];
-
-    pdist_russellrao_char(X, dm, m, n);
-    NPY_END_ALLOW_THREADS;
-  }
-  return Py_BuildValue("");
-}
-
-static PyObject *pdist_kulsinski_bool_wrap(PyObject *self, PyObject *args) {
-  PyArrayObject *X_, *dm_;
-  int m, n;
-  double *dm;
-  const char *X;
-  if (!PyArg_ParseTuple(args, "O!O!",
-            &PyArray_Type, &X_,
-            &PyArray_Type, &dm_)) {
-    return 0;
-  }
-  else {
-    NPY_BEGIN_ALLOW_THREADS;
-    X = (const char*)X_->data;
-    dm = (double*)dm_->data;
-    m = X_->dimensions[0];
-    n = X_->dimensions[1];
-
-    pdist_kulsinski_char(X, dm, m, n);
-    NPY_END_ALLOW_THREADS;
-  }
-  return Py_BuildValue("");
-}
-
-static PyObject *pdist_sokalmichener_bool_wrap(PyObject *self, PyObject *args) {
-  PyArrayObject *X_, *dm_;
-  int m, n;
-  double *dm;
-  const char *X;
-  if (!PyArg_ParseTuple(args, "O!O!",
-            &PyArray_Type, &X_,
-            &PyArray_Type, &dm_)) {
-    return 0;
-  }
-  else {
-    NPY_BEGIN_ALLOW_THREADS;
-    X = (const char*)X_->data;
-    dm = (double*)dm_->data;
-    m = X_->dimensions[0];
-    n = X_->dimensions[1];
-
-    pdist_sokalmichener_char(X, dm, m, n);
-    NPY_END_ALLOW_THREADS;
-  }
-  return Py_BuildValue("");
-}
-
-static PyObject *pdist_sokalsneath_bool_wrap(PyObject *self, PyObject *args) {
-  PyArrayObject *X_, *dm_;
-  int m, n;
-  double *dm;
-  const char *X;
-  if (!PyArg_ParseTuple(args, "O!O!",
-            &PyArray_Type, &X_,
-            &PyArray_Type, &dm_)) {
-    return 0;
-  }
-  else {
-    NPY_BEGIN_ALLOW_THREADS;
-    X = (const char*)X_->data;
-    dm = (double*)dm_->data;
-    m = X_->dimensions[0];
-    n = X_->dimensions[1];
-
-    pdist_sokalsneath_char(X, dm, m, n);
-    NPY_END_ALLOW_THREADS;
-  }
-  return Py_BuildValue("");
-}
-
-static PyObject *to_squareform_from_vector_wrap(PyObject *self, PyObject *args) {
+static PyObject *to_squareform_from_vector_wrap(PyObject *self, PyObject *args) 
+{
   PyArrayObject *M_, *v_;
   int n, elsize;
   if (!PyArg_ParseTuple(args, "O!O!",
@@ -833,7 +513,8 @@ static PyObject *to_squareform_from_vector_wrap(PyObject *self, PyObject *args) 
   return Py_BuildValue("");
 }
 
-static PyObject *to_vector_from_squareform_wrap(PyObject *self, PyObject *args) {
+static PyObject *to_vector_from_squareform_wrap(PyObject *self, PyObject *args) 
+{
   PyArrayObject *M_, *v_;
   int n, s;
   char *v;
@@ -857,49 +538,50 @@ static PyObject *to_vector_from_squareform_wrap(PyObject *self, PyObject *args) 
 
 
 static PyMethodDef _distanceWrapMethods[] = {
-  {"cdist_bray_curtis_wrap", cdist_bray_curtis_wrap, METH_VARARGS},
-  {"cdist_canberra_wrap", cdist_canberra_wrap, METH_VARARGS},
-  {"cdist_chebyshev_wrap", cdist_chebyshev_wrap, METH_VARARGS},
-  {"cdist_city_block_wrap", cdist_city_block_wrap, METH_VARARGS},
-  {"cdist_dice_bool_wrap", cdist_dice_bool_wrap, METH_VARARGS},
-  {"cdist_euclidean_wrap", cdist_euclidean_wrap, METH_VARARGS},
-  {"cdist_sqeuclidean_wrap", cdist_sqeuclidean_wrap, METH_VARARGS},
-  {"cdist_hamming_wrap", cdist_hamming_wrap, METH_VARARGS},
-  {"cdist_hamming_bool_wrap", cdist_hamming_bool_wrap, METH_VARARGS},
-  {"cdist_jaccard_wrap", cdist_jaccard_wrap, METH_VARARGS},
-  {"cdist_jaccard_bool_wrap", cdist_jaccard_bool_wrap, METH_VARARGS},
-  {"cdist_kulsinski_bool_wrap", cdist_kulsinski_bool_wrap, METH_VARARGS},
-  {"cdist_mahalanobis_wrap", cdist_mahalanobis_wrap, METH_VARARGS | METH_KEYWORDS},
-  {"cdist_minkowski_wrap", cdist_minkowski_wrap, METH_VARARGS | METH_KEYWORDS},
-  {"cdist_weighted_minkowski_wrap", cdist_weighted_minkowski_wrap, METH_VARARGS | METH_KEYWORDS},
-  {"cdist_rogerstanimoto_bool_wrap", cdist_rogerstanimoto_bool_wrap, METH_VARARGS},
-  {"cdist_russellrao_bool_wrap", cdist_russellrao_bool_wrap, METH_VARARGS},
-  {"cdist_seuclidean_wrap", cdist_seuclidean_wrap, METH_VARARGS | METH_KEYWORDS},
-  {"cdist_sokalmichener_bool_wrap", cdist_sokalmichener_bool_wrap, METH_VARARGS},
-  {"cdist_sokalsneath_bool_wrap", cdist_sokalsneath_bool_wrap, METH_VARARGS},
-  {"cdist_yule_bool_wrap", cdist_yule_bool_wrap, METH_VARARGS},
-  {"pdist_bray_curtis_wrap", pdist_bray_curtis_wrap, METH_VARARGS},
-  {"pdist_canberra_wrap", pdist_canberra_wrap, METH_VARARGS},
-  {"pdist_chebyshev_wrap", pdist_chebyshev_wrap, METH_VARARGS},
-  {"pdist_city_block_wrap", pdist_city_block_wrap, METH_VARARGS},
-  {"pdist_cosine_wrap", pdist_cosine_wrap, METH_VARARGS},
-  {"pdist_dice_bool_wrap", pdist_dice_bool_wrap, METH_VARARGS},
-  {"pdist_euclidean_wrap", pdist_euclidean_wrap, METH_VARARGS},
-  {"pdist_sqeuclidean_wrap", pdist_sqeuclidean_wrap, METH_VARARGS},
-  {"pdist_hamming_wrap", pdist_hamming_wrap, METH_VARARGS},
-  {"pdist_hamming_bool_wrap", pdist_hamming_bool_wrap, METH_VARARGS},
-  {"pdist_jaccard_wrap", pdist_jaccard_wrap, METH_VARARGS},
-  {"pdist_jaccard_bool_wrap", pdist_jaccard_bool_wrap, METH_VARARGS},
-  {"pdist_kulsinski_bool_wrap", pdist_kulsinski_bool_wrap, METH_VARARGS},
-  {"pdist_mahalanobis_wrap", pdist_mahalanobis_wrap, METH_VARARGS | METH_KEYWORDS},
-  {"pdist_minkowski_wrap", pdist_minkowski_wrap, METH_VARARGS | METH_KEYWORDS},
-  {"pdist_weighted_minkowski_wrap", pdist_weighted_minkowski_wrap, METH_VARARGS | METH_KEYWORDS},
-  {"pdist_rogerstanimoto_bool_wrap", pdist_rogerstanimoto_bool_wrap, METH_VARARGS},
-  {"pdist_russellrao_bool_wrap", pdist_russellrao_bool_wrap, METH_VARARGS},
-  {"pdist_seuclidean_wrap", pdist_seuclidean_wrap, METH_VARARGS | METH_KEYWORDS},
-  {"pdist_sokalmichener_bool_wrap", pdist_sokalmichener_bool_wrap, METH_VARARGS},
-  {"pdist_sokalsneath_bool_wrap", pdist_sokalsneath_bool_wrap, METH_VARARGS},
-  {"pdist_yule_bool_wrap", pdist_yule_bool_wrap, METH_VARARGS},
+  {"cdist_braycurtis_double_wrap", cdist_bray_curtis_double_wrap, METH_VARARGS},
+  {"cdist_canberra_double_wrap", cdist_canberra_double_wrap, METH_VARARGS},
+  {"cdist_chebyshev_double_wrap", cdist_chebyshev_double_wrap, METH_VARARGS},
+  {"cdist_cityblock_double_wrap", cdist_city_block_double_wrap, METH_VARARGS},
+  {"cdist_cosine_double_wrap", cdist_cosine_double_wrap, METH_VARARGS | METH_KEYWORDS},
+  {"cdist_dice_bool_wrap", cdist_dice_char_wrap, METH_VARARGS},
+  {"cdist_euclidean_double_wrap", cdist_euclidean_double_wrap, METH_VARARGS},
+  {"cdist_sqeuclidean_double_wrap", cdist_sqeuclidean_double_wrap, METH_VARARGS},
+  {"cdist_hamming_double_wrap", cdist_hamming_double_wrap, METH_VARARGS},
+  {"cdist_hamming_bool_wrap", cdist_hamming_char_wrap, METH_VARARGS},
+  {"cdist_jaccard_double_wrap", cdist_jaccard_double_wrap, METH_VARARGS},
+  {"cdist_jaccard_bool_wrap", cdist_jaccard_char_wrap, METH_VARARGS},
+  {"cdist_kulsinski_bool_wrap", cdist_kulsinski_char_wrap, METH_VARARGS},
+  {"cdist_mahalanobis_double_wrap", cdist_mahalanobis_double_wrap, METH_VARARGS | METH_KEYWORDS},
+  {"cdist_minkowski_double_wrap", cdist_minkowski_double_wrap, METH_VARARGS | METH_KEYWORDS},
+  {"cdist_wminkowski_double_wrap", cdist_weighted_minkowski_double_wrap, METH_VARARGS | METH_KEYWORDS},
+  {"cdist_rogerstanimoto_bool_wrap", cdist_rogerstanimoto_char_wrap, METH_VARARGS},
+  {"cdist_russellrao_bool_wrap", cdist_russellrao_char_wrap, METH_VARARGS},
+  {"cdist_seuclidean_double_wrap", cdist_seuclidean_double_wrap, METH_VARARGS | METH_KEYWORDS},
+  {"cdist_sokalmichener_bool_wrap", cdist_sokalmichener_char_wrap, METH_VARARGS},
+  {"cdist_sokalsneath_bool_wrap", cdist_sokalsneath_char_wrap, METH_VARARGS},
+  {"cdist_yule_bool_wrap", cdist_yule_char_wrap, METH_VARARGS},
+  {"pdist_braycurtis_double_wrap", pdist_bray_curtis_double_wrap, METH_VARARGS},
+  {"pdist_canberra_double_wrap", pdist_canberra_double_wrap, METH_VARARGS},
+  {"pdist_chebyshev_double_wrap", pdist_chebyshev_double_wrap, METH_VARARGS},
+  {"pdist_cityblock_double_wrap", pdist_city_block_double_wrap, METH_VARARGS},
+  {"pdist_cosine_double_wrap", pdist_cosine_double_wrap, METH_VARARGS | METH_KEYWORDS},
+  {"pdist_dice_bool_wrap", pdist_dice_char_wrap, METH_VARARGS},
+  {"pdist_euclidean_double_wrap", pdist_euclidean_double_wrap, METH_VARARGS},
+  {"pdist_sqeuclidean_double_wrap", pdist_sqeuclidean_double_wrap, METH_VARARGS},
+  {"pdist_hamming_double_wrap", pdist_hamming_double_wrap, METH_VARARGS},
+  {"pdist_hamming_bool_wrap", pdist_hamming_char_wrap, METH_VARARGS},
+  {"pdist_jaccard_double_wrap", pdist_jaccard_double_wrap, METH_VARARGS},
+  {"pdist_jaccard_bool_wrap", pdist_jaccard_char_wrap, METH_VARARGS},
+  {"pdist_kulsinski_bool_wrap", pdist_kulsinski_char_wrap, METH_VARARGS},
+  {"pdist_mahalanobis_double_wrap", pdist_mahalanobis_double_wrap, METH_VARARGS | METH_KEYWORDS},
+  {"pdist_minkowski_double_wrap", pdist_minkowski_double_wrap, METH_VARARGS | METH_KEYWORDS},
+  {"pdist_wminkowski_double_wrap", pdist_weighted_minkowski_double_wrap, METH_VARARGS | METH_KEYWORDS},
+  {"pdist_rogerstanimoto_bool_wrap", pdist_rogerstanimoto_char_wrap, METH_VARARGS},
+  {"pdist_russellrao_bool_wrap", pdist_russellrao_char_wrap, METH_VARARGS},
+  {"pdist_seuclidean_double_wrap", pdist_seuclidean_double_wrap, METH_VARARGS | METH_KEYWORDS},
+  {"pdist_sokalmichener_bool_wrap", pdist_sokalmichener_char_wrap, METH_VARARGS},
+  {"pdist_sokalsneath_bool_wrap", pdist_sokalsneath_char_wrap, METH_VARARGS},
+  {"pdist_yule_bool_wrap", pdist_yule_char_wrap, METH_VARARGS},
   {"to_squareform_from_vector_wrap",
    to_squareform_from_vector_wrap, METH_VARARGS},
   {"to_vector_from_squareform_wrap",

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -128,6 +128,37 @@ class TestCdist(TestCase):
                               'int': [np.float32, np.double],
                               'float32': [np.double]}
 
+    def test_cdist_extra_args(self):
+        # Tests that args and kwargs are correctly handled
+        def _my_metric(x, y, arg, kwarg=1, kwarg2=2):
+            return arg + kwarg + kwarg2
+
+        X1 = [[1., 2., 3.], [1.2, 2.3, 3.4], [2.2, 2.3, 4.4]]
+        X2 = [[7., 5., 8.], [7.5, 5.8, 8.4], [5.5, 5.8, 4.4]]
+        kwargs = {'N0tV4l1D_p4raM': 3.14, "w":np.arange(3)}
+        args = [3.14] * 200
+        for metric in _METRICS_NAMES:
+            assert_raises(TypeError, cdist, X1, X2, metric=metric, **kwargs)
+            assert_raises(TypeError, cdist, X1, X2, metric=eval(metric), **kwargs)
+            assert_raises(TypeError, cdist, X1, X2, metric="test_" + metric, **kwargs)
+            assert_raises(TypeError, cdist, X1, X2, metric=metric, *args)
+            assert_raises(TypeError, cdist, X1, X2, metric=eval(metric), *args)
+            assert_raises(TypeError, cdist, X1, X2, metric="test_" + metric, *args)
+
+        assert_raises(TypeError, cdist, X1, X2, _my_metric)
+        assert_raises(TypeError, cdist, X1, X2, _my_metric, *args)
+        assert_raises(TypeError, cdist, X1, X2, _my_metric, **kwargs)
+        assert_raises(TypeError, cdist, X1, X2, _my_metric, kwarg=2.2, kwarg2=3.3)
+        assert_raises(TypeError, cdist, X1, X2, _my_metric, 1, 2, kwarg=2.2)
+
+        assert_raises(TypeError, cdist, X1, X2, _my_metric, 1.1, 2.2, 3.3)
+        assert_raises(TypeError, cdist, X1, X2, _my_metric, 1.1, 2.2)
+        assert_raises(TypeError, cdist, X1, X2, _my_metric, 1.1)
+        assert_raises(TypeError, cdist, X1, X2, _my_metric, 1.1, kwarg=2.2, kwarg2=3.3)
+
+        # this should work
+        assert_allclose(cdist(X1, X2, metric=_my_metric, arg=1.1, kwarg2=3.3), 5.4)
+
     def test_cdist_euclidean_random_unicode(self):
         eps = 1e-07
         X1 = eo['cdist-X1']
@@ -329,6 +360,36 @@ class TestPdist(TestCase):
                               'uint': [np.int_, np.float32, np.double],
                               'int': [np.float32, np.double],
                               'float32': [np.double]}
+
+    def test_pdist_extra_args(self):
+        # Tests that args and kwargs are correctly handled
+        def _my_metric(x, y, arg, kwarg=1, kwarg2=2):
+            return arg + kwarg + kwarg2
+
+        X1 = [[1., 2.], [1.2, 2.3], [2.2, 2.3]]
+        kwargs = {'N0tV4l1D_p4raM': 3.14, "w":np.arange(2)}
+        args = [3.14] * 200
+        for metric in _METRICS_NAMES:
+            assert_raises(TypeError, pdist, X1, metric=metric, **kwargs)
+            assert_raises(TypeError, pdist, X1, metric=eval(metric), **kwargs)
+            assert_raises(TypeError, pdist, X1, metric="test_" + metric, **kwargs)
+            assert_raises(TypeError, pdist, X1, metric=metric, *args)
+            assert_raises(TypeError, pdist, X1, metric=eval(metric), *args)
+            assert_raises(TypeError, pdist, X1, metric="test_" + metric, *args)
+
+        assert_raises(TypeError, pdist, X1, _my_metric)
+        assert_raises(TypeError, pdist, X1, _my_metric, *args)
+        assert_raises(TypeError, pdist, X1, _my_metric, **kwargs)
+        assert_raises(TypeError, pdist, X1, _my_metric, kwarg=2.2, kwarg2=3.3)
+        assert_raises(TypeError, pdist, X1, _my_metric, 1, 2, kwarg=2.2)
+
+        assert_raises(TypeError, pdist, X1, _my_metric, 1.1, 2.2, 3.3)
+        assert_raises(TypeError, pdist, X1, _my_metric, 1.1, 2.2)
+        assert_raises(TypeError, pdist, X1, _my_metric, 1.1)
+        assert_raises(TypeError, pdist, X1, _my_metric, 1.1, kwarg=2.2, kwarg2=3.3)
+
+        # these should work
+        assert_allclose(pdist(X1, metric=_my_metric, arg=1.1, kwarg2=3.3), 5.4)
 
     def test_pdist_euclidean_random(self):
         eps = 1e-07
@@ -1539,22 +1600,36 @@ def test_modifies_input():
 
 def test_Xdist_deprecated_args():
     # testing both cdist and pdist deprecated warnings
-    X1 = np.asarray([[1., 2., 3.], [1.2, 2.3, 3.4], [2.2, 2.3, 4.4]])
-    warn_msg = "Got unexpected kwarg"
+    X1 = np.asarray([[1., 2., 3.],
+                     [1.2, 2.3, 3.4],
+                     [2.2, 2.3, 4.4],
+                     [22.2, 23.3, 44.4]])
+    weights = np.arange(3)
+    warn_msg_kwargs = "Got unexpected kwarg"
+    warn_msg_args = "metric parameters have been passed as positional"
     for metric in _METRICS_NAMES:
-        if metric in ("minkowski", "wminkowski", "seuclidean", "mahalanobis"):
-            continue
+        kwargs = {"w": weights} if metric == "wminkowski" else dict()
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            cdist(X1, X1, metric, 2., **kwargs)
+            pdist(X1, metric, 2., **kwargs)
+            assert_(len(w) >= 2)
+            assert_(all([issubclass(warn.category, DeprecationWarning) for warn in w]))
+            assert_(issubclass(w[0].category, DeprecationWarning))
+            assert_(issubclass(w[1].category, DeprecationWarning))
+            assert_(sum([warn_msg_args in str(warn.message) for warn in w]) == 2)
+
         for arg in ["p", "V", "VI", "w"]:
             kwargs = {arg:"foo"}
 
             if metric == "wminkowski":
                 if "p" in kwargs or "w" in kwargs:
                     continue
-                kwargs["w"] = 1.0 / X1.std(axis=0)
+                kwargs["w"] = weights
 
             if((arg == "V" and metric == "seuclidean") or
                (arg == "VI" and metric == "mahalanobis") or
-               (arg == "w" and metric == "wminkowski")):
+               (arg == "p" and metric == "minkowski")):
                 continue
 
             with warnings.catch_warnings(record=True) as w:
@@ -1564,7 +1639,7 @@ def test_Xdist_deprecated_args():
                 assert_(len(w) == 2)
                 assert_(issubclass(w[0].category, DeprecationWarning))
                 assert_(issubclass(w[1].category, DeprecationWarning))
-                assert_(all([warn_msg in str(warn.message) for warn in w]))
+                assert_(all([warn_msg_kwargs in str(warn.message) for warn in w]))
 
 
 def test__validate_vector():


### PR DESCRIPTION
The current implementations of pdist and cdist takes as keyword arguments some extra parameters for a few specific metrics. At the same time, they do not allow for others args/kwargs that may be needed by a new user-defined metric.
Plus, in 0.19 it is possible to call:

    pdist([[1,2,3]], metric='euclidean', V=[1,2,3], w=[1,2,3])
    pdist([[1,2,3]], metric='seuclidean', VI=[1,2,3])

IMHO this is quite strange behaviour since I would have expected an error. 
In particular, in the second case, the error would also probably help debugging the code since it may be a copy-and-paste typo (seuclidean takes `V` as kwarg, while mahalanobis requires `VI`)

This PR introduces support for *args and **kwargs that gets passed on to the selected metric. The new functions should not break any existing code with the exception of the previous example.
However, if needed, I can try to catch those cases, and for now just raise a deprecate warning. 

what do you think?

p.s. @metaperture, I have "stolen" your very nice enhancement to call all the "test_*" metrics. Hope you don't mind. 