### PR TITLE
ENH: sparse: add scipy.sparse.linalg.spsolve_triangular

### DIFF
--- a/scipy/sparse/linalg/__init__.py
+++ b/scipy/sparse/linalg/__init__.py
@@ -42,6 +42,7 @@ Direct methods for linear equation systems:
    :toctree: generated/
 
    spsolve -- Solve the sparse linear system Ax=b
+   spsolve_triangular -- Solve the sparse linear system Ax=b for a triangular matrix
    factorized -- Pre-factorize matrix to a function solving a linear system
    MatrixRankWarning -- Warning on exactly singular matrices
    use_solver -- Select direct solver to use

--- a/scipy/sparse/linalg/dsolve/linsolve.py
+++ b/scipy/sparse/linalg/dsolve/linsolve.py
@@ -453,7 +453,7 @@ def spsolve_triangular(A, b, lower=True, copy_A=True, overwrite_b=False):
     else:
         x = b.copy()
 
-    # Chose forward or backward order.
+    # Choose forward or backward order.
     if lower:
         row_indices = range(len(b))
     else:

--- a/scipy/sparse/linalg/dsolve/linsolve.py
+++ b/scipy/sparse/linalg/dsolve/linsolve.py
@@ -461,6 +461,7 @@ def spsolve_triangular(A, b, lower=True, copy_A=True, overwrite_b=False):
 
     # Fill x iteratively.
     for i in row_indices:
+
         # Get indices for i-th row.
         indptr_start = A.indptr[i]
         indptr_stop = A.indptr[i+1]
@@ -476,15 +477,15 @@ def spsolve_triangular(A, b, lower=True, copy_A=True, overwrite_b=False):
             raise LinAlgError('A is singular: '
                 '{}th diagonal is zero!'.format(i))
         if A.indices[A_diagonal_index_row_i] > i:
-            raise LinAlgError('A is no triangular matrix: '
-                'entry [{},{}] is not zero!'.format(i, A.indices[A_diagonal_index_row_i]))
+            raise LinAlgError('A is no triangular matrix: entry '
+                '[{},{}] is not zero!'.format(i, A.indices[A_diagonal_index_row_i]))
+
+        # Incorporate off-diagonal entries.
+        A_column_indices_in_row_i = A.indices[A_off_diagonal_indices_row_i]
+        A_values_in_row_i = A.data[A_off_diagonal_indices_row_i]
+        x[i] -= np.dot(x[A_column_indices_in_row_i].T, A_values_in_row_i)
 
         # Compute i-th entry of x.
-        if indptr_stop - indptr_start > 1:
-            # Incorporate off-diagonal entries.
-            A_column_indices_in_row_i = A.indices[A_off_diagonal_indices_row_i]
-            A_values_in_row_i = A.data[A_off_diagonal_indices_row_i]
-            x[i] -= np.dot(x[A_column_indices_in_row_i].T, A_values_in_row_i)
         x[i] /= A.data[A_diagonal_index_row_i]
 
     return x

--- a/scipy/sparse/linalg/dsolve/linsolve.py
+++ b/scipy/sparse/linalg/dsolve/linsolve.py
@@ -450,7 +450,6 @@ def spsolve_triangular(A, b, lower=True, overwrite_b=False):
 
         ## fill forward
         indptr_start = A.indptr[0]
-
         for i in range(len(b)):
             indptr_stop = A.indptr[i+1]
 
@@ -464,14 +463,13 @@ def spsolve_triangular(A, b, lower=True, overwrite_b=False):
                 raise LinAlgError('A is no lower triangle matrix, since the '
                     'entry at ({},{}) is not zero!'.format(i, A.indices[indptr_stop-1]))
 
-            ## compute value
-            A_column_indices_in_row_i = A.indices[indptr_start:indptr_stop-1]    # skip diagonal entry
-            A_values_in_row_i = A.data[indptr_start:indptr_stop-1]
-
             ## compute x[i]
             x[i] = b[i]
-            x[i] -= np.sum(x[A_column_indices_in_row_i] * A_values_in_row_i)
-            x[i] /= A.data[indptr_stop-1]    # devide by i-th diagonal element of A
+            if indptr_stop - indptr_start > 1:      # more than just the diagonal entry
+                A_column_indices_in_row_i = A.indices[indptr_start:indptr_stop-1]    # skip diagonal entry
+                A_values_in_row_i = A.data[indptr_start:indptr_stop-1]
+                x[i] -= np.sum(x[A_column_indices_in_row_i] * A_values_in_row_i)
+            x[i] /= A.data[indptr_stop-1]           # devide by i-th diagonal element of A
 
             ## next row
             indptr_start = indptr_stop
@@ -479,7 +477,6 @@ def spsolve_triangular(A, b, lower=True, overwrite_b=False):
 
         ## fill backward
         indptr_stop = A.indptr[len(b)]
-
         for i in range(len(b)-1, -1, -1):
             indptr_start = A.indptr[i]
 
@@ -493,14 +490,13 @@ def spsolve_triangular(A, b, lower=True, overwrite_b=False):
                 raise LinAlgError('A is no upper triangle matrix, since the '
                     'entry at ({},{}) is not zero!'.format(i, A.indices[indptr_start]))
 
-            ## compute value
-            A_column_indices_in_row_i = A.indices[indptr_start+1:indptr_stop]    # skip diagonal entry
-            A_values_in_row_i = A.data[indptr_start+1:indptr_stop]
-
             ## compute x[i]
             x[i] = b[i]
-            x[i] -= np.sum(x[A_column_indices_in_row_i] * A_values_in_row_i)
-            x[i] /= A.data[indptr_start]    # devide by i-th diagonal element of A
+            if indptr_stop - indptr_start > 1:    # more than just the diagonal entry
+                A_column_indices_in_row_i = A.indices[indptr_start+1:indptr_stop]    # skip diagonal entry
+                A_values_in_row_i = A.data[indptr_start+1:indptr_stop]
+                x[i] -= np.sum(x[A_column_indices_in_row_i] * A_values_in_row_i)
+            x[i] /= A.data[indptr_start]          # devide by i-th diagonal element of A
 
             ## next row
             indptr_stop = indptr_start

--- a/scipy/sparse/linalg/dsolve/linsolve.py
+++ b/scipy/sparse/linalg/dsolve/linsolve.py
@@ -421,7 +421,7 @@ def spsolve_triangular(A, b, lower=True, overwrite_A=False, overwrite_b=False):
 
     Notes
     -----
-    .. versionadded:: 0.20.0
+    .. versionadded:: 0.19.0
     """
 
     # Check the input for correct type and format.

--- a/scipy/sparse/linalg/dsolve/linsolve.py
+++ b/scipy/sparse/linalg/dsolve/linsolve.py
@@ -490,7 +490,7 @@ def spsolve_triangular(A, b, lower=True, copy_A=True, overwrite_b=False):
                 raise LinAlgError('A is singular: '
                     '{}th diagonal is zero!'.format(i))
             if A.indices[indptr_start] < i:
-                raise LinAlgError('A is no lower triangular matrix: '
+                raise LinAlgError('A is no upper triangular matrix: '
                     'entry[{},{}] is not zero!'.format(i, A.indices[indptr_start]))
 
             # Compute i-th entry of x.

--- a/scipy/sparse/linalg/dsolve/linsolve.py
+++ b/scipy/sparse/linalg/dsolve/linsolve.py
@@ -468,7 +468,9 @@ def spsolve_triangular(A, b, lower=True, overwrite_b=False):
             if indptr_stop - indptr_start > 1:      # more than just the diagonal entry
                 A_column_indices_in_row_i = A.indices[indptr_start:indptr_stop-1]    # skip diagonal entry
                 A_values_in_row_i = A.data[indptr_start:indptr_stop-1]
-                x[i] -= np.sum(x[A_column_indices_in_row_i] * A_values_in_row_i)
+                if x.ndim > 1:
+                    A_values_in_row_i = A_values_in_row_i[:, np.newaxis]
+                x[i] -= np.sum(x[A_column_indices_in_row_i] * A_values_in_row_i, axis=0)
             x[i] /= A.data[indptr_stop-1]           # devide by i-th diagonal element of A
 
             ## next row
@@ -495,7 +497,9 @@ def spsolve_triangular(A, b, lower=True, overwrite_b=False):
             if indptr_stop - indptr_start > 1:    # more than just the diagonal entry
                 A_column_indices_in_row_i = A.indices[indptr_start+1:indptr_stop]    # skip diagonal entry
                 A_values_in_row_i = A.data[indptr_start+1:indptr_stop]
-                x[i] -= np.sum(x[A_column_indices_in_row_i] * A_values_in_row_i)
+                if x.ndim > 1:
+                    A_values_in_row_i = A_values_in_row_i[:, np.newaxis]
+                x[i] -= np.sum(x[A_column_indices_in_row_i] * A_values_in_row_i, axis=0)
             x[i] /= A.data[indptr_start]          # devide by i-th diagonal element of A
 
             ## next row

--- a/scipy/sparse/linalg/dsolve/linsolve.py
+++ b/scipy/sparse/linalg/dsolve/linsolve.py
@@ -473,9 +473,7 @@ def spsolve_triangular(A, b, lower=True, copy_A=True, overwrite_b=False):
             if indptr_stop - indptr_start > 1:      # Incorporate off-diagonal entries at i-th row of A.
                 A_column_indices_in_row_i = A.indices[indptr_start:indptr_stop-1]    # Skip diagonal entry of A.
                 A_values_in_row_i = A.data[indptr_start:indptr_stop-1]
-                if x.ndim > 1:
-                    A_values_in_row_i = A_values_in_row_i[:, np.newaxis]
-                x[i] -= np.sum(x[A_column_indices_in_row_i] * A_values_in_row_i, axis=0)
+                x[i] -= np.dot(x[A_column_indices_in_row_i].T, A_values_in_row_i)
             x[i] /= A.data[indptr_stop-1]           # Divide by i-th diagonal entry of A.
 
             # Go to next row of A.
@@ -499,9 +497,7 @@ def spsolve_triangular(A, b, lower=True, copy_A=True, overwrite_b=False):
             if indptr_stop - indptr_start > 1:    # Incorporate off-diagonal entries at i-th row of A.
                 A_column_indices_in_row_i = A.indices[indptr_start+1:indptr_stop]    # Skip diagonal entry of A.
                 A_values_in_row_i = A.data[indptr_start+1:indptr_stop]
-                if x.ndim > 1:
-                    A_values_in_row_i = A_values_in_row_i[:, np.newaxis]
-                x[i] -= np.sum(x[A_column_indices_in_row_i] * A_values_in_row_i, axis=0)
+                x[i] -= np.dot(x[A_column_indices_in_row_i].T, A_values_in_row_i)
             x[i] /= A.data[indptr_start]          # Divide by i-th diagonal entry of A.
 
             # Go to next row of A.

--- a/scipy/sparse/linalg/dsolve/linsolve.py
+++ b/scipy/sparse/linalg/dsolve/linsolve.py
@@ -386,7 +386,7 @@ def factorized(A):
         return splu(A).solve
 
 
-def spsolve_triangular(A, b, lower=True, copy_A=True, overwrite_b=False):
+def spsolve_triangular(A, b, lower=True, overwrite_A=False, overwrite_b=False):
     """
     Solve the equation `A x = b` for `x`, assuming A is a triangular matrix.
 
@@ -399,10 +399,10 @@ def spsolve_triangular(A, b, lower=True, copy_A=True, overwrite_b=False):
     lower : bool, optional
         Whether `A` is a lower or upper triangular matrix.
         Default is lower triangular matrix.
-    copy_A : bool, optional
-        Whether `A` should be copied so that it remains unmodified. The indices
-        of `A` are going to be sorted and zero entries going to be removed.
-        Disabling gives a performance gain. Default is True.
+    overwrite_A : bool, optional
+        Allow changing `A`. The indices of `A` are going to be sorted and zero
+        entries are going to be removed.
+        Enabling gives a performance gain. Default is False.
     overwrite_b : bool, optional
         Allow overwriting data in `b`.
         Enabling gives a performance gain. Default is False.
@@ -429,7 +429,7 @@ def spsolve_triangular(A, b, lower=True, copy_A=True, overwrite_b=False):
         warn('CSR matrix format is required. Converting to CSR matrix.',
              SparseEfficiencyWarning)
         A = csr_matrix(A)
-    elif copy_A:
+    elif not overwrite_A:
         A = A.copy()
 
     if A.shape[0] != A.shape[1]:

--- a/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
@@ -15,7 +15,7 @@ from scipy.linalg import norm, inv
 from scipy.sparse import (spdiags, SparseEfficiencyWarning, csc_matrix,
         csr_matrix, isspmatrix, dok_matrix, lil_matrix, bsr_matrix)
 from scipy.sparse.linalg.dsolve import (spsolve, use_solver, splu, spilu,
-        MatrixRankWarning, _superlu)
+        MatrixRankWarning, _superlu, spsolve_triangular)
 
 warnings.simplefilter('ignore',SparseEfficiencyWarning)
 
@@ -496,6 +496,53 @@ class TestSplu(object):
             t.join()
 
         assert_equal(len(oks), 20)
+
+
+class TestSpsolveTriangular(TestCase):
+
+    def test_singular(self):
+        n = 5
+        A = csr_matrix((n,n))
+        b = np.arange(n)
+        for lower in (True, False):
+            assert_raises(scipy.linalg.LinAlgError, spsolve_triangular, A, b, lower=lower)
+
+    def test_bad_shape(self):
+        # A is not square.
+        A = np.zeros((3, 4))
+        b = ones((4, 1))
+        assert_raises(ValueError, spsolve_triangular, A, b)
+        # A2 and b2 have incompatible shapes.
+        A2 = csr_matrix(eye(3))
+        b2 = array([1.0, 2.0])
+        assert_raises(ValueError, spsolve_triangular, A2, b2)
+
+    def test_input_types(self):
+        A = array([[1., 0.], [1., 2.]])
+        b = array([[2., 0.], [2., 2.]])
+        for matrix_type in (array, csc_matrix, csr_matrix):
+            x = spsolve_triangular(matrix_type(A), b, lower=True)
+            assert_array_almost_equal(np.matmul(A, x), b)
+
+    def test_random(self):
+        def random_triangle_matrix(n, lower=True):
+            A = scipy.sparse.random(n, n, density=0.1, format='csr')
+            if lower:
+                A = scipy.sparse.tril(A)
+            else:
+                A = scipy.sparse.triu(A)
+            A = A.tocsr()
+            for i in range(n):
+                A[i,i] = np.random.rand() + 1
+            return A
+
+        for n in (10, 10**2, 10**3):
+            for m in (1, 10):
+                b = np.random.rand(n, m)
+                for lower in (True, False):
+                    A = random_triangle_matrix(n, lower=lower)
+                    x = spsolve_triangular(A, b, lower=lower)
+                    assert_array_almost_equal(np.matmul(A.toarray(), x), b)
 
 
 if __name__ == "__main__":

--- a/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
@@ -536,6 +536,7 @@ class TestSpsolveTriangular(TestCase):
                 A[i,i] = np.random.rand() + 1
             return A
 
+        np.random.seed(1234)
         for n in (10, 10**2, 10**3):
             for m in (1, 10):
                 b = np.random.rand(n, m)

--- a/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
@@ -522,7 +522,7 @@ class TestSpsolveTriangular(TestCase):
         b = array([[2., 0.], [2., 2.]])
         for matrix_type in (array, csc_matrix, csr_matrix):
             x = spsolve_triangular(matrix_type(A), b, lower=True)
-            assert_array_almost_equal(np.dot(A, x), b)
+            assert_array_almost_equal(A.dot(x), b)
 
     def test_random(self):
         def random_triangle_matrix(n, lower=True):
@@ -542,7 +542,7 @@ class TestSpsolveTriangular(TestCase):
                 for lower in (True, False):
                     A = random_triangle_matrix(n, lower=lower)
                     x = spsolve_triangular(A, b, lower=lower)
-                    assert_array_almost_equal(np.dot(A.toarray(), x), b)
+                    assert_array_almost_equal(A.dot(x), b)
 
 
 if __name__ == "__main__":

--- a/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
@@ -526,12 +526,12 @@ class TestSpsolveTriangular(TestCase):
 
     def test_random(self):
         def random_triangle_matrix(n, lower=True):
-            A = scipy.sparse.random(n, n, density=0.1, format='csr')
+            A = scipy.sparse.random(n, n, density=0.1, format='coo')
             if lower:
                 A = scipy.sparse.tril(A)
             else:
                 A = scipy.sparse.triu(A)
-            A = A.tocsr()
+            A = A.tocsr(copy=False)
             for i in range(n):
                 A[i,i] = np.random.rand() + 1
             return A

--- a/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
@@ -522,7 +522,7 @@ class TestSpsolveTriangular(TestCase):
         b = array([[2., 0.], [2., 2.]])
         for matrix_type in (array, csc_matrix, csr_matrix):
             x = spsolve_triangular(matrix_type(A), b, lower=True)
-            assert_array_almost_equal(np.matmul(A, x), b)
+            assert_array_almost_equal(np.dot(A, x), b)
 
     def test_random(self):
         def random_triangle_matrix(n, lower=True):
@@ -542,7 +542,7 @@ class TestSpsolveTriangular(TestCase):
                 for lower in (True, False):
                     A = random_triangle_matrix(n, lower=lower)
                     x = spsolve_triangular(A, b, lower=lower)
-                    assert_array_almost_equal(np.matmul(A.toarray(), x), b)
+                    assert_array_almost_equal(np.dot(A.toarray(), x), b)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I would like to add the `scipy.sparse.linalg.spsolve_triangular` function. It solves linear equations `A x = b` for `x` with sparse triangular matrix `A`. Its API is inspired by `scipy.linalg.solve_triangular`. Tests are also included.