### PR TITLE
MAINT: spatial: updates to plotting utils

### DIFF
--- a/scipy/spatial/_plotutils.py
+++ b/scipy/spatial/_plotutils.py
@@ -13,8 +13,13 @@ def _held_figure(func, obj, ax=None, **kw):
     if ax is None:
         fig = plt.figure()
         ax = fig.gca()
+        return func(obj, ax=ax, **kw)
 
+    # As of matplotlib 2.0, the "hold" mechanism is deprecated.
+    # When matplotlib 1.x is no longer supported, this check can be removed.
     was_held = ax.ishold()
+    if was_held:
+        return func(obj, ax=ax, **kw)
     try:
         ax.hold(True)
         return func(obj, ax=ax, **kw)
@@ -23,11 +28,11 @@ def _held_figure(func, obj, ax=None, **kw):
 
 
 def _adjust_bounds(ax, points):
-    ptp_bound = points.ptp(axis=0)
-    ax.set_xlim(points[:,0].min() - 0.1*ptp_bound[0],
-                points[:,0].max() + 0.1*ptp_bound[0])
-    ax.set_ylim(points[:,1].min() - 0.1*ptp_bound[1],
-                points[:,1].max() + 0.1*ptp_bound[1])
+    margin = 0.1 * points.ptp(axis=0)
+    xy_min = points.min(axis=0) - margin 
+    xy_max = points.max(axis=0) + margin 
+    ax.set_xlim(xy_min[0], xy_max[0])
+    ax.set_ylim(xy_min[1], xy_max[1])
 
 
 @_held_figure
@@ -60,8 +65,9 @@ def delaunay_plot_2d(tri, ax=None):
     if tri.points.shape[1] != 2:
         raise ValueError("Delaunay triangulation is not 2-D")
 
-    ax.plot(tri.points[:,0], tri.points[:,1], 'o')
-    ax.triplot(tri.points[:,0], tri.points[:,1], tri.simplices.copy())
+    x, y = tri.points.T
+    ax.plot(x, y, 'o')
+    ax.triplot(x, y, tri.simplices.copy())
 
     _adjust_bounds(ax, tri.points)
 
@@ -100,9 +106,7 @@ def convex_hull_plot_2d(hull, ax=None):
         raise ValueError("Convex hull is not 2-D")
 
     ax.plot(hull.points[:,0], hull.points[:,1], 'o')
-    line_segments = []
-    for simplex in hull.simplices:
-        line_segments.append([(x, y) for x, y in hull.points[simplex]])
+    line_segments = [hull.points[simplex] for simplex in hull.simplices]
     ax.add_collection(LineCollection(line_segments,
                                      colors='k',
                                      linestyle='solid'))
@@ -161,25 +165,16 @@ def voronoi_plot_2d(vor, ax=None, **kw):
     line_width = kw.get('line_width', 1.0)
     line_alpha = kw.get('line_alpha', 1.0)
 
-    line_segments = []
-    for simplex in vor.ridge_vertices:
-        simplex = np.asarray(simplex)
-        if np.all(simplex >= 0):
-            line_segments.append([(x, y) for x, y in vor.vertices[simplex]])
-
-    lc = LineCollection(line_segments,
-                        colors=line_colors,
-                        lw=line_width,
-                        linestyle='solid')
-    lc.set_alpha(line_alpha)
-    ax.add_collection(lc)
+    center = vor.points.mean(axis=0)
     ptp_bound = vor.points.ptp(axis=0)
 
-    line_segments = []
-    center = vor.points.mean(axis=0)
+    finite_segments = []
+    infinite_segments = []
     for pointidx, simplex in zip(vor.ridge_points, vor.ridge_vertices):
         simplex = np.asarray(simplex)
-        if np.any(simplex < 0):
+        if np.all(simplex >= 0):
+            finite_segments.append(vor.vertices[simplex])
+        else:
             i = simplex[simplex >= 0][0]  # finite end Voronoi vertex
 
             t = vor.points[pointidx[1]] - vor.points[pointidx[0]]  # tangent
@@ -190,15 +185,19 @@ def voronoi_plot_2d(vor, ax=None, **kw):
             direction = np.sign(np.dot(midpoint - center, n)) * n
             far_point = vor.vertices[i] + direction * ptp_bound.max()
 
-            line_segments.append([(vor.vertices[i, 0], vor.vertices[i, 1]),
-                                  (far_point[0], far_point[1])])
+            infinite_segments.append([vor.vertices[i], far_point])
 
-    lc = LineCollection(line_segments,
-                        colors=line_colors,
-                        lw=line_width,
-                        linestyle='dashed')
-    lc.set_alpha(line_alpha)
-    ax.add_collection(lc)
+    ax.add_collection(LineCollection(finite_segments,
+                                     colors=line_colors,
+                                     lw=line_width,
+                                     alpha=line_alpha,
+                                     linestyle='solid'))
+    ax.add_collection(LineCollection(infinite_segments,
+                                     colors=line_colors,
+                                     lw=line_width,
+                                     alpha=line_alpha,
+                                     linestyle='dashed'))
+
     _adjust_bounds(ax, vor.points)
 
     return ax.figure


### PR DESCRIPTION
This PR avoids (most of) the cases in which the various plotting functions were throwing deprecation warnings under matplotlib 2.0:
```
~/scipy/build/testenv/lib/python2.7/site-packages/scipy/spatial/_plotutils.py:23: MatplotlibDeprecationWarning: axes.hold is deprecated.
    See the API Changes document (http://matplotlib.org/api/api_changes.html)
    for more details.
  ax.hold(was_held)
```

The deprecation warning is still triggered by the `ax.ishold()` check when a user-supplied Axes object is given, but I can't figure out a clean way to avoid that without parsing `matplotib.__version__`.

I also made some cosmetic touch-ups to the other functions in this module.