### PR TITLE
TST: Changed the test with a less singular example

### DIFF
--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -707,8 +707,8 @@ class TestSolve(TestCase):
         assert_raises(LinAlgError, solve, a, b)
 
     def test_ill_condition_warning(self):
-        a = np.arange(1, 10).reshape(3, 3)
-        b = np.array([[15], [15], [15]])
+        a = np.array([[1, 1], [1+1e-16, 1-1e-16]])
+        b = np.ones(2)
         with warnings.catch_warnings():
             warnings.simplefilter('error')
             assert_raises(RuntimeWarning, solve, a, b)


### PR DESCRIPTION
Closes #6984. 

Summary: As described in the issue, there was a build environment using OpenBLAS that could not identify the ill-conditionedness but assumed directly singular matrix in the linear equation solver. This replaces the test to something less singular such that it is also caught as an ill-conditioned problem. 