### PR TITLE
fix documentation of spearman rank corrcoef

### DIFF
--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -423,7 +423,7 @@ def spearmanr(x, y, use_ties=True):
     Spearman correlation does not assume that both datasets are normally
     distributed. Like other correlation coefficients, this one varies
     between -1 and +1 with 0 implying no correlation. Correlations of -1 or
-    +1 imply an exact linear relationship. Positive correlations imply that
+    +1 imply a monotonic relationship. Positive correlations imply that
     as `x` increases, so does `y`. Negative correlations imply that as `x`
     increases, `y` decreases.
 


### PR DESCRIPTION
The Spearman correlation should be 1  or -1 if the relation is monotonic, not only linear https://en.wikipedia.org/wiki/Spearman%27s_rank_correlation_coefficient