### PR TITLE
BUG: Fix division by zero in linregress() for 2 data points

### DIFF
--- a/scipy/stats/_stats_mstats_common.py
+++ b/scipy/stats/_stats_mstats_common.py
@@ -103,11 +103,19 @@ def linregress(x, y=None):
             r = -1.0
 
     df = n - 2
-    t = r * np.sqrt(df / ((1.0 - r + TINY)*(1.0 + r + TINY)))
-    prob = 2 * distributions.t.sf(np.abs(t), df)
     slope = r_num / ssxm
     intercept = ymean - slope*xmean
-    sterrest = np.sqrt((1 - r**2) * ssym / ssxm / df)
+    if n == 2:
+        # handle case when only two points are passed in
+        if y[0] == y[1]:
+            prob = 1.0
+        else:
+            prob = 0.0
+        sterrest = 0.0
+    else:
+        t = r * np.sqrt(df / ((1.0 - r + TINY)*(1.0 + r + TINY)))
+        prob = 2 * distributions.t.sf(np.abs(t), df)
+        sterrest = np.sqrt((1 - r**2) * ssym / ssxm / df)
 
     return LinregressResult(slope, intercept, r, prob, sterrest)
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -873,6 +873,24 @@ class TestRegression(TestCase):
         attributes = ('slope', 'intercept', 'rvalue', 'pvalue', 'stderr')
         check_named_results(res, attributes)
 
+    def test_regress_two_inputs(self):
+        # Regress a simple line formed by two points.
+        x = np.arange(2)
+        y = np.arange(3, 5)
+
+        res = stats.linregress(x, y)
+        assert_almost_equal(res[3], 0.0)  # non-horizontal line
+        assert_almost_equal(res[4], 0.0)  # zero stderr
+
+    def test_regress_two_inputs_horizontal_line(self):
+        # Regress a horizontal line formed by two points.
+        x = np.arange(2)
+        y = np.ones(2)
+
+        res = stats.linregress(x, y)
+        assert_almost_equal(res[3], 1.0)  # horizontal line
+        assert_almost_equal(res[4], 0.0)  # zero stderr
+
     def test_nist_norris(self):
         x = [0.2, 337.4, 118.2, 884.6, 10.1, 226.5, 666.3, 996.3, 448.6, 777.0,
              558.2, 0.4, 0.6, 775.5, 666.9, 338.0, 447.5, 11.6, 556.0, 228.1,


### PR DESCRIPTION
Fixes issue https://github.com/scipy/scipy/issues/6991 when only 2 data points are passed to linregress(), which causes a division by zero. The pvalue and stderr values returned in this case are NaN.