### PR TITLE
BUG: Fix problem in passing drop_rule to scipy.sparse.linalg.spilu

### DIFF
--- a/scipy/sparse/linalg/dsolve/_superluobject.c
+++ b/scipy/sparse/linalg/dsolve/_superluobject.c
@@ -1020,30 +1020,17 @@ static int droprule_cvt(PyObject * input, int *value)
 	*value = PyInt_AsLong(input);
 	return 1;
     }
-    else if (PyString_Check(input)) {
-	/* Comma-separated string */
-	seq = PyObject_CallMethod(input, "split", "s", ",");
-	if (seq == NULL || !PySequence_Check(seq))
-	    goto fail;
-    }
-    else if (PyUnicode_Check(input)) {
-	/* Comma-separated string */
+    else if (PyString_Check(input) || PyUnicode_Check(input)) {
+        /* Comma-separated string */
+        char *fmt = "s";
 #if PY_MAJOR_VERSION >= 3
-	seq = PyObject_CallMethod(input, "split", "s", ",");
+        if (PyBytes_Check(input)) {
+            fmt = "y";
+        }
+#endif
+	seq = PyObject_CallMethod(input, "split", fmt, ",");
 	if (seq == NULL || !PySequence_Check(seq))
 	    goto fail;
-#else
-        PyObject *s;
-        int ret;
-
-        s = PyUnicode_AsASCIIString(input);
-        if (s == NULL) {
-            goto fail;
-        }
-        ret = droprule_cvt(s, value);
-        Py_DECREF(s);
-        return ret;
-#endif
     }
     else if (PySequence_Check(input)) {
 	/* Sequence of strings or integers */

--- a/scipy/sparse/linalg/dsolve/_superluobject.c
+++ b/scipy/sparse/linalg/dsolve/_superluobject.c
@@ -1028,16 +1028,22 @@ static int droprule_cvt(PyObject * input, int *value)
     }
     else if (PyUnicode_Check(input)) {
 	/* Comma-separated string */
-	PyObject *s;
-	int ret;
-
-	s = PyUnicode_AsASCIIString(input);
-	if (s == NULL) {
+#if PY_MAJOR_VERSION >= 3
+	seq = PyObject_CallMethod(input, "split", "s", ",");
+	if (seq == NULL || !PySequence_Check(seq))
 	    goto fail;
-	}
-	ret = droprule_cvt(s, value);
-	Py_DECREF(s);
-	return ret;
+#else
+        PyObject *s;
+        int ret;
+
+        s = PyUnicode_AsASCIIString(input);
+        if (s == NULL) {
+            goto fail;
+        }
+        ret = droprule_cvt(s, value);
+        Py_DECREF(s);
+        return ret;
+#endif
     }
     else if (PySequence_Check(input)) {
 	/* Sequence of strings or integers */

--- a/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
@@ -343,8 +343,14 @@ class TestSplu(object):
         # Test passing in the drop_rule argument to spilu.
         A = identity(2)
 
-        # no error here.
-        assert_(isinstance(spilu(A, drop_rule='basic,area'), SuperLU))
+        rules = [
+            b'basic,area'.decode('ascii'),  # unicode
+            b'basic,area',  # ascii
+            [b'basic', b'area'.decode('ascii')]
+        ]
+        for rule in rules:
+            # Argument should be accepted
+            assert_(isinstance(spilu(A, drop_rule=rule), SuperLU))
 
     def test_splu_nnz0(self):
         A = csc_matrix((5,5), dtype='d')

--- a/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
@@ -13,7 +13,8 @@ from numpy.testing import (TestCase, run_module_suite,
 import scipy.linalg
 from scipy.linalg import norm, inv
 from scipy.sparse import (spdiags, SparseEfficiencyWarning, csc_matrix,
-        csr_matrix, isspmatrix, dok_matrix, lil_matrix, bsr_matrix)
+        csr_matrix, identity, isspmatrix, dok_matrix, lil_matrix, bsr_matrix)
+from scipy.sparse.linalg import SuperLU
 from scipy.sparse.linalg.dsolve import (spsolve, use_solver, splu, spilu,
         MatrixRankWarning, _superlu)
 
@@ -337,6 +338,13 @@ class TestSplu(object):
             self._smoketest(spilu, check, np.complex128)
 
             assert_(max(errors) > 1e-5)
+
+    def test_spilu_drop_rule(self):
+        # Test passing in the drop_rule argument to spilu.
+        A = identity(2)
+
+        # no error here.
+        assert_(isinstance(spilu(A, drop_rule='basic,area'), SuperLU))
 
     def test_splu_nnz0(self):
         A = csc_matrix((5,5), dtype='d')


### PR DESCRIPTION
Fixes issue #6917. Python strings are unicode objects by default, so we skip conversion into ASCII strings. This fixes the error TypeError: a bytes-like object is required, not 'str'.