### PR TITLE
Fix Typo: add a single quotation mark to fix a slight typo

### DIFF
--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -338,7 +338,7 @@ class interp1d(_Interpolator1D):
         axis must be equal to the length of `x`.
     kind : str or int, optional
         Specifies the kind of interpolation as a string
-        ('linear', 'nearest', 'zero', 'slinear', 'quadratic, 'cubic'
+        ('linear', 'nearest', 'zero', 'slinear', 'quadratic', 'cubic'
         where 'slinear', 'quadratic' and 'cubic' refer to a spline
         interpolation of first, second or third order) or as an integer
         specifying the order of the spline interpolator to use.


### PR DESCRIPTION
Add a single quotation mark to fix a slight typo in documents of interp1d.
('quadratic -> …'quadratic')