### PR TITLE
MAINT: stats: use machine constants from np.finfo, not machar

### DIFF
--- a/scipy/stats/_constants.py
+++ b/scipy/stats/_constants.py
@@ -11,14 +11,14 @@ import numpy as np
 _EPS = np.finfo(float).eps
 
 # The largest [in magnitude] usable floating value.
-_XMAX = np.finfo(float).machar.xmax
+_XMAX = np.finfo(float).max
 
 # The log of the largest usable floating value; useful for knowing
 # when exp(something) will overflow
 _LOGXMAX = np.log(_XMAX)
 
 # The smallest [in magnitude] usable floating value.
-_XMIN = np.finfo(float).machar.xmin
+_XMIN = np.finfo(float).tiny
 
 # -special.psi(1)
 _EULER = 0.577215664901532860606512090082402431042


### PR DESCRIPTION
fixes gh-7015

As suggested by Warren in https://github.com/scipy/scipy/issues/7015#issuecomment-278452609
