### PR TITLE
BUG: Fix linear_sum_assignment hanging on an undefined matrix

### DIFF
--- a/scipy/optimize/_hungarian.py
+++ b/scipy/optimize/_hungarian.py
@@ -84,6 +84,17 @@ def linear_sum_assignment(cost_matrix):
         raise ValueError("expected a matrix (2-d array), got a %r array"
                          % (cost_matrix.shape,))
 
+    if not (np.issubdtype(cost_matrix.dtype, np.number) or
+            cost_matrix.dtype is np.dtype(np.bool)):
+        raise ValueError("expected a matrix containing numerical entries, got %s"
+                         % (cost_matrix.dtype,))
+
+    if np.any(np.isinf(cost_matrix) | np.isnan(cost_matrix)):
+        raise ValueError("matrix contains invalid numeric entries")
+
+    if cost_matrix.dtype is np.dtype(np.bool):
+        cost_matrix = cost_matrix.astype(np.int)
+
     # The algorithm expects more columns than rows in the cost matrix.
     if cost_matrix.shape[1] < cost_matrix.shape[0]:
         cost_matrix = cost_matrix.T

--- a/scipy/optimize/tests/test_hungarian.py
+++ b/scipy/optimize/tests/test_hungarian.py
@@ -59,3 +59,15 @@ def test_linear_sum_assignment_input_validation():
                        linear_sum_assignment(np.asarray(C)))
     assert_array_equal(linear_sum_assignment(C),
                        linear_sum_assignment(np.matrix(C)))
+
+    I = np.identity(3)
+    assert_array_equal(linear_sum_assignment(I.astype(np.bool)),
+                       linear_sum_assignment(I))
+    assert_raises(ValueError, linear_sum_assignment, I.astype(str))
+
+    I[0][0] = np.nan
+    assert_raises(ValueError, linear_sum_assignment, I)
+
+    I = np.identity(3)
+    I[1][1] = np.inf
+    assert_raises(ValueError, linear_sum_assignment, I)


### PR DESCRIPTION
Fixes issues #6370, #7005 by checking if the matrix contains inf or nan. Also added additional checks for non-numeric data types. Related: #6900