### PR TITLE
ENH: Add more boundary options to signal.stft

### DIFF
--- a/doc/release/0.19.0-notes.rst
+++ b/doc/release/0.19.0-notes.rst
@@ -87,6 +87,12 @@ A new function has been added to choose the convolution/correlation method,
 `scipy.signal.choose_conv_method` which may be appropriate if convolutions or
 correlations are performed on many arrays of the same size.
 
+New functions have been added to calculate complex short time fourier
+transforms of an input signal, and to invert the transform to recover the
+original signal: `scipy.signal.stft` and `scipy.signal.istft`. This
+implementation also fixes the previously incorrect ouput of
+`scipy.signal.spectrogram` when complex output data were requested.
+
 The function `scipy.signal.sosfreqz` was added to compute the frequency
 response from second-order sections.
 

--- a/scipy/signal/_arraytools.py
+++ b/scipy/signal/_arraytools.py
@@ -207,3 +207,37 @@ def const_ext(x, n, axis=-1):
                           right_ext),
                          axis=axis)
     return ext
+
+
+def zero_ext(x, n, axis=-1):
+    """
+    Zero padding at the boundaries of an array
+
+    Generate a new ndarray that is a zero padded extension of `x` along
+    an axis.
+
+    Parameters
+    ----------
+    x : ndarray
+        The array to be extended.
+    n : int
+        The number of elements by which to extend `x` at each end of the
+        axis.
+    axis : int, optional
+        The axis along which to extend `x`.  Default is -1.
+
+    Examples
+    --------
+    >>> from scipy.signal._arraytools import zero_ext
+    >>> a = np.array([[1, 2, 3, 4, 5], [0, 1, 4, 9, 16]])
+    >>> zero_ext(a, 2)
+    array([[ 0,  0,  1,  2,  3,  4,  5,  0,  0],
+           [ 0,  0,  0,  1,  4,  9, 16,  0,  0]])
+    """
+    if n < 1:
+        return x
+    zeros_shape = list(x.shape)
+    zeros_shape[axis] = n
+    zeros = np.zeros(zeros_shape, dtype=x.dtype)
+    ext = np.concatenate((zeros, x, zeros), axis=axis)
+    return ext

--- a/scipy/signal/tests/test_array_tools.py
+++ b/scipy/signal/tests/test_array_tools.py
@@ -6,7 +6,7 @@ from numpy.testing import TestCase, run_module_suite, \
     assert_array_equal, assert_raises
 
 from scipy.signal._arraytools import axis_slice, axis_reverse, \
-     odd_ext, even_ext, const_ext
+     odd_ext, even_ext, const_ext, zero_ext
 
 
 class TestArrayTools(TestCase):
@@ -94,6 +94,22 @@ class TestArrayTools(TestCase):
                              [9, 8, 7, 6, 5],
                              [9, 8, 7, 6, 5]])
         assert_array_equal(const, expected)
+
+    def test_zero_ext(self):
+        a = np.array([[1, 2, 3, 4, 5],
+                      [9, 8, 7, 6, 5]])
+
+        zero = zero_ext(a, 2, axis=1)
+        expected = np.array([[0, 0, 1, 2, 3, 4, 5, 0, 0],
+                             [0, 0, 9, 8, 7, 6, 5, 0, 0]])
+        assert_array_equal(zero, expected)
+
+        zero = zero_ext(a, 1, axis=0)
+        expected = np.array([[0, 0, 0, 0, 0],
+                             [1, 2, 3, 4, 5],
+                             [9, 8, 7, 6, 5],
+                             [0, 0, 0, 0, 0]])
+        assert_array_equal(zero, expected)
 
 
 if __name__ == "__main__":

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -1189,17 +1189,19 @@ class TestSTFT(TestCase):
                            window=window, detrend=None, padded=True,
                            boundary=None)
 
-            _, _, zz_ext = stft(x, nperseg=nperseg, noverlap=noverlap,
-                               window=window, detrend=None, padded=True,
-                               boundary='even')
-
             _, xr = istft(zz, noverlap=noverlap, window=window, boundary=False)
-            _, xr_ext = istft(zz_ext, noverlap=noverlap, window=window,
-                              boundary=True)
 
-            msg = '{0}, {1}'.format(window, noverlap)
-            assert_allclose(x, xr, err_msg=msg)
-            assert_allclose(x, xr_ext, err_msg=msg)
+            for boundary in ['even', 'odd', 'constant', 'zeros']:
+                _, _, zz_ext = stft(x, nperseg=nperseg, noverlap=noverlap,
+                                window=window, detrend=None, padded=True,
+                                boundary=boundary)
+
+                _, xr_ext = istft(zz_ext, noverlap=noverlap, window=window,
+                                boundary=True)
+
+                msg = '{0}, {1}, {2}'.format(window, noverlap, boundary)
+                assert_allclose(x, xr, err_msg=msg)
+                assert_allclose(x, xr_ext, err_msg=msg)
 
     def test_roundtrip_padded_signal(self):
         np.random.seed(1234)


### PR DESCRIPTION
As suggested by @endolith in gh-6058, we want to let users choose from a few different boundary extension options in `stft`. This adds that, tests the new methods, and adds `stft` to the release notes (which I forgot to do in the last PR...)