### PR TITLE
MAINT: reduce the number of git conflicts in the release notes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -55,3 +55,6 @@ scipy/sparse/sparsetools/dia.py binary
 scipy/sparse/sparsetools/dia_wrap.cxx binary
 scipy/sparse/sparsetools/csgraph.py binary
 scipy/sparse/sparsetools/csgraph_wrap.cxx binary
+
+# Release notes, reduce number of conflicts.
+doc/release/*.rst merge=union


### PR DESCRIPTION
Inspired by https://github.com/numpy/numpy/pull/8612

Suggested in https://github.com/numpy/numpy/issues/8603, supposedly used by xarray, astropy.