### PR TITLE
DOC: Clairfy that windows are DFT-even by default

### DIFF
--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -29,10 +29,12 @@ def periodogram(x, fs=1.0, window='boxcar', nfft=None, detrend='constant',
     fs : float, optional
         Sampling frequency of the `x` time series. Defaults to 1.0.
     window : str or tuple or array_like, optional
-        Desired window to use. See `get_window` for a list of windows
-        and required parameters. If `window` is array_like it will be
-        used directly as the window and its length must be nperseg.
-        Defaults to 'boxcar'.
+        Desired window to use. If `window` is a string or tuple, it is
+        passed to `get_window` to generate the window values, which are
+        DFT-even by default. See `get_window` for a list of windows and
+        required parameters. If `window` is array_like it will be used
+        directly as the window and its length must be nperseg. Defaults
+        to 'boxcar'.
     nfft : int, optional
         Length of the FFT used. If `None` the length of `x` will be
         used.
@@ -165,10 +167,12 @@ def welch(x, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
     fs : float, optional
         Sampling frequency of the `x` time series. Defaults to 1.0.
     window : str or tuple or array_like, optional
-        Desired window to use. See `get_window` for a list of windows
-        and required parameters. If `window` is array_like it will be
-        used directly as the window and its length must be nperseg.
-        Defaults to a Hann window.
+        Desired window to use. If `window` is a string or tuple, it is
+        passed to `get_window` to generate the window values, which are
+        DFT-even by default. See `get_window` for a list of windows and
+        required parameters. If `window` is array_like it will be used
+        directly as the window and its length must be nperseg. Defaults
+        to a Hann window.
     nperseg : int, optional
         Length of each segment. Defaults to None, but if window is str or
         tuple, is set to 256, and if window is array_like, is set to the
@@ -214,8 +218,8 @@ def welch(x, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
     Notes
     -----
     An appropriate amount of overlap will depend on the choice of window
-    and on your requirements. For the default 'hann' window an overlap
-    of 50% is a reasonable trade off between accurately estimating the
+    and on your requirements. For the default Hann window an overlap of
+    50% is a reasonable trade off between accurately estimating the
     signal power, while not over counting any of the data. Narrower
     windows may require a larger overlap.
 
@@ -305,10 +309,12 @@ def csd(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
         Sampling frequency of the `x` and `y` time series. Defaults
         to 1.0.
     window : str or tuple or array_like, optional
-        Desired window to use. See `get_window` for a list of windows
-        and required parameters. If `window` is array_like it will be
-        used directly as the window and its length must be nperseg.
-        Defaults to a Hann window.
+        Desired window to use. If `window` is a string or tuple, it is
+        passed to `get_window` to generate the window values, which are
+        DFT-even by default. See `get_window` for a list of windows and
+        required parameters. If `window` is array_like it will be used
+        directly as the window and its length must be nperseg. Defaults
+        to a Hann window.
     nperseg : int, optional
         Length of each segment. Defaults to None, but if window is str or
         tuple, is set to 256, and if window is array_like, is set to the
@@ -362,8 +368,8 @@ def csd(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
     zero-padded to match.
 
     An appropriate amount of overlap will depend on the choice of window
-    and on your requirements. For the default 'hann' window an overlap
-    of 50% is a reasonable trade off between accurately estimating the
+    and on your requirements. For the default Hann window an overlap of
+    50% is a reasonable trade off between accurately estimating the
     signal power, while not over counting any of the data. Narrower
     windows may require a larger overlap.
 
@@ -436,9 +442,11 @@ def spectrogram(x, fs=1.0, window=('tukey',.25), nperseg=None, noverlap=None,
     fs : float, optional
         Sampling frequency of the `x` time series. Defaults to 1.0.
     window : str or tuple or array_like, optional
-        Desired window to use. See `get_window` for a list of windows
-        and required parameters. If `window` is array_like it will be
-        used directly as the window and its length must be nperseg.
+        Desired window to use. If `window` is a string or tuple, it is
+        passed to `get_window` to generate the window values, which are
+        DFT-even by default. See `get_window` for a list of windows and
+        required parameters. If `window` is array_like it will be used
+        directly as the window and its length must be nperseg.
         Defaults to a Tukey window with shape parameter of 0.25.
     nperseg : int, optional
         Length of each segment. Defaults to None, but if window is str or
@@ -586,9 +594,11 @@ def check_COLA(window, nperseg, noverlap, tol=1e-10):
     Parameters
     ----------
     window : str or tuple or array_like
-        Desired window to use. See `get_window` for a list of windows
-        and required parameters. If `window` is array_like it will be
-        used directly as the window and its length must be `nperseg`.
+        Desired window to use. If `window` is a string or tuple, it is
+        passed to `get_window` to generate the window values, which are
+        DFT-even by default. See `get_window` for a list of windows and
+        required parameters. If `window` is array_like it will be used
+        directly as the window and its length must be nperseg.
     nperseg : int
         Length of each segment.
     noverlap : int
@@ -717,10 +727,12 @@ def stft(x, fs=1.0, window='hann', nperseg=256, noverlap=None, nfft=None,
     fs : float, optional
         Sampling frequency of the `x` time series. Defaults to 1.0.
     window : str or tuple or array_like, optional
-        Desired window to use. See `get_window` for a list of windows
-        and required parameters. If `window` is array_like it will be
-        used directly as the window and its length must be nperseg.
-        Defaults to a Hann window.
+        Desired window to use. If `window` is a string or tuple, it is
+        passed to `get_window` to generate the window values, which are
+        DFT-even by default. See `get_window` for a list of windows and
+        required parameters. If `window` is array_like it will be used
+        directly as the window and its length must be nperseg. Defaults
+        to a Hann window.
     nperseg : int, optional
         Length of each segment. Defaults to 256.
     noverlap : int, optional
@@ -859,11 +871,13 @@ def istft(Zxx, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
     fs : float, optional
         Sampling frequency of the time series. Defaults to 1.0.
     window : str or tuple or array_like, optional
-        Desired window to use. See `get_window` for a list of windows
-        and required parameters. If `window` is array_like it will be
-        used directly as the window and its length must be `nperseg`.
-        Defaults to a Hann window. Must match the window used to
-        generate the STFT for faithful inversion.
+        Desired window to use. If `window` is a string or tuple, it is
+        passed to `get_window` to generate the window values, which are
+        DFT-even by default. See `get_window` for a list of windows and
+        required parameters. If `window` is array_like it will be used
+        directly as the window and its length must be nperseg. Defaults
+        to a Hann window. Must match the window used to generate the
+        STFT for faithful inversion.
     nperseg : int, optional
         Number of data points corresponding to each STFT segment. This
         parameter must be specified if the number of data points per
@@ -1140,10 +1154,12 @@ def coherence(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
         Sampling frequency of the `x` and `y` time series. Defaults
         to 1.0.
     window : str or tuple or array_like, optional
-        Desired window to use. See `get_window` for a list of windows
-        and required parameters. If `window` is array_like it will be
-        used directly as the window and its length must be `nperseg`.
-        Defaults to a Hann window.
+        Desired window to use. If `window` is a string or tuple, it is
+        passed to `get_window` to generate the window values, which are
+        DFT-even by default. See `get_window` for a list of windows and
+        required parameters. If `window` is array_like it will be used
+        directly as the window and its length must be nperseg. Defaults
+        to a Hann window.
     nperseg : int, optional
         Length of each segment. Defaults to None, but if window is str or
         tuple, is set to 256, and if window is array_like, is set to the
@@ -1181,8 +1197,8 @@ def coherence(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
     Notes
     --------
     An appropriate amount of overlap will depend on the choice of window
-    and on your requirements. For the default 'hann' window an overlap
-    of 50% is a reasonable trade off between accurately estimating the
+    and on your requirements. For the default Hann window an overlap of
+    50% is a reasonable trade off between accurately estimating the
     signal power, while not over counting any of the data. Narrower
     windows may require a larger overlap.
 
@@ -1258,10 +1274,12 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
     fs : float, optional
         Sampling frequency of the time series. Defaults to 1.0.
     window : str or tuple or array_like, optional
-        Desired window to use. See `get_window` for a list of windows
-        and required parameters. If `window` is array_like it will be
-        used directly as the window and its length must be `nperseg`.
-        Defaults to 'hann'.
+        Desired window to use. If `window` is a string or tuple, it is
+        passed to `get_window` to generate the window values, which are
+        DFT-even by default. See `get_window` for a list of windows and
+        required parameters. If `window` is array_like it will be used
+        directly as the window and its length must be nperseg. Defaults
+        to a Hann window.
     nperseg : int, optional
         Length of each segment. Defaults to None, but if window is str or
         tuple, is set to 256, and if window is array_like, is set to the


### PR DESCRIPTION
Closes gh-6963

Times like this really make me wish for a way of templating all of these very similar spectral function docstrings. Anyone every do something like that?