### PR TITLE
Added warning message to documentation for scipy.special.lqn

### DIFF
--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -1616,6 +1616,10 @@ def lqn(n, z):
     Compute sequence of Legendre functions of the second kind, Qn(z) and
     derivatives for all degrees from 0 to n (inclusive).
 
+    Warning: The computation of lqn(n,z) could fail for large n. Specifically,
+    if z^-n becomes very small (comparable to sys.float_info.min) then this may 
+    erroneously return all zeros.
+
     References
     ----------
     .. [1] Zhang, Shanjie and Jin, Jianming. "Computation of Special


### PR DESCRIPTION
Warning added to documentation for when scipy.special.lqn may give erroneous values. Specifically, if z^-n becomes very small (comparable to sys.float_info.min) then this may erroneously return all zeros.