### PR TITLE
Fix msvc 9 and 10 compile errors

### DIFF
--- a/scipy/interpolate/src/__fitpack.h
+++ b/scipy/interpolate/src/__fitpack.h
@@ -2,7 +2,7 @@
  * B-spline evaluation routine.
  */
 
-static inline void
+static NPY_INLINE void
 _deBoor_D(double *t, double x, int k, int ell, int m, double *result) {
     /*
      * On completion the result array stores

--- a/scipy/spatial/qhull/src/user_r.c
+++ b/scipy/spatial/qhull/src/user_r.c
@@ -153,13 +153,15 @@ int qh_new_qhull(qhT *qh, int dim, int numpoints, coordT *points, boolT ismalloc
       hulldim= dim-1;
       if(feaspoint)
       {
+        coordT* coords;
+        coordT* value;
+        int i;
         if (!(qh->feasible_point= (pointT*)qh_malloc(hulldim * sizeof(coordT)))) {
           qh_fprintf(qh, qh->ferr, 6079, "qhull error: insufficient memory for 'Hn,n,n'\n");
           qh_errexit(qh, qh_ERRmem, NULL, NULL);
         }
-        coordT* coords = qh->feasible_point;
-        coordT* value = feaspoint;
-        int i;
+        coords = qh->feasible_point;
+        value = feaspoint;
         for(i = 0; i < hulldim; ++i)
         {
           *(coords++) = *(value++);

--- a/scipy/special/cephes/igam.c
+++ b/scipy/special/cephes/igam.c
@@ -131,6 +131,8 @@ double asymptotic_series(double, double, int);
 double igam(a, x)
 double a, x;
 {
+    double absxma_a;
+
     /* Check zero integration limit first */
     if (x == 0)
 	return (0.0);
@@ -141,7 +143,7 @@ double a, x;
     }
 
     /* Asymptotic regime where a ~ x; see [2]. */
-    double absxma_a = fabs(x - a) / a;
+    absxma_a = fabs(x - a) / a;
     if ((a > SMALL) && (a < LARGE) && (absxma_a < SMALLRATIO)) {
 	return asymptotic_series(a, x, IGAM);
     } else if ((a > LARGE) && (absxma_a < LARGERATIO / sqrt(a))) {
@@ -158,6 +160,8 @@ double a, x;
 
 double igamc(double a, double x)
 {
+    double absxma_a;
+
     if ((x < 0) || (a <= 0)) {
 	mtherr("gammaincc", DOMAIN);
 	return (NPY_NAN);
@@ -168,7 +172,7 @@ double igamc(double a, double x)
     }
 
     /* Asymptotic regime where a ~ x; see [2]. */
-    double absxma_a = fabs(x - a) / a;
+    absxma_a = fabs(x - a) / a;
     if ((a > SMALL) && (a < LARGE) && (absxma_a < SMALLRATIO)) {
 	return asymptotic_series(a, x, IGAMC);
     } else if ((a > LARGE) && (absxma_a < LARGERATIO / sqrt(a))) {
@@ -207,8 +211,10 @@ double igamc(double a, double x)
  */
 double igam_fac(double a, double x)
 {
+    double ax, fac, res, num;
+
     if (fabs(a - x) > 0.4 * fabs(a)) {
-	double ax = a * log(x) - x - lgam(a);
+	ax = a * log(x) - x - lgam(a);
 	if (ax < -MAXLOG) {
 	    mtherr("igam", UNDERFLOW);
 	    return 0.0;
@@ -216,13 +222,13 @@ double igam_fac(double a, double x)
 	return exp(ax);
     }
     
-    double fac = a + lanczos_g - 0.5;
-    double res = sqrt(fac / exp(1)) / lanczos_sum_expg_scaled(a);
+    fac = a + lanczos_g - 0.5;
+    res = sqrt(fac / exp(1)) / lanczos_sum_expg_scaled(a);
 
     if ((a < 200) && (x < 200)) {
 	res *= exp(a - x) * pow(x / fac, a);
     } else {
-	double num = x - a - lanczos_g + 0.5;
+	num = x - a - lanczos_g + 0.5;
 	res *= exp(a * log1pmx(num / fac) + x * (0.5 - lanczos_g) / fac);
     }
     

--- a/scipy/special/sf_error.c
+++ b/scipy/special/sf_error.c
@@ -51,6 +51,8 @@ sf_action_t sf_error_get_action(sf_error_t code)
 
 void sf_error(const char *func_name, sf_error_t code, const char *fmt, ...)
 {
+    PyGILState_STATE save;
+    PyObject *scipy_special = NULL;
     char msg[2048], info[1024];
     static PyObject *py_SpecialFunctionWarning = NULL;
     sf_action_t action;
@@ -81,14 +83,13 @@ void sf_error(const char *func_name, sf_error_t code, const char *fmt, ...)
     }
 
 #ifdef WITH_THREAD
-    PyGILState_STATE save = PyGILState_Ensure();
+    save = PyGILState_Ensure();
 #endif
 
     if (PyErr_Occurred()) {
       goto skip_warn;
     }
 
-    PyObject *scipy_special = NULL;
     scipy_special = PyImport_ImportModule("scipy.special");
     if (scipy_special == NULL) {
 	PyErr_Clear();


### PR DESCRIPTION
Older Visual Studio C compilers don't know the `inline` specifier and need variables declared at the beginning of blocks.