### PR TITLE
Fix insufficient precision when calculating spearman/kendall correlations

### DIFF
--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -459,6 +459,9 @@ def spearmanr(x, y, use_ties=True):
     (x, y) = (x.ravel(), y.ravel())
 
     m = ma.mask_or(ma.getmask(x), ma.getmask(y))
+    # need int() here, otherwise numpy defaults to 32 bit
+    # integer on all Windows architectures, causing overflow.
+    # int() will keep it infinite precision.
     n -= int(m.sum())
     if m is not nomask:
         x = ma.array(x, mask=m, copy=True)
@@ -529,6 +532,9 @@ def kendalltau(x, y, use_ties=True, use_missing=False):
     if m is not nomask:
         x = ma.array(x, mask=m, copy=True)
         y = ma.array(y, mask=m, copy=True)
+        # need int() here, otherwise numpy defaults to 32 bit
+        # integer on all Windows architectures, causing overflow.
+        # int() will keep it infinite precision.
         n -= int(m.sum())
 
     if n < 2:

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -399,7 +399,6 @@ def pearsonr(x,y):
     # point arithmetic.
     r = min(r, 1.0)
     r = max(r, -1.0)
-    df = n - 2
 
     if r is masked or abs(r) == 1.0:
         prob = 0.
@@ -460,7 +459,7 @@ def spearmanr(x, y, use_ties=True):
     (x, y) = (x.ravel(), y.ravel())
 
     m = ma.mask_or(ma.getmask(x), ma.getmask(y))
-    n -= m.sum()
+    n -= int(m.sum())
     if m is not nomask:
         x = ma.array(x, mask=m, copy=True)
         y = ma.array(y, mask=m, copy=True)
@@ -530,7 +529,7 @@ def kendalltau(x, y, use_ties=True, use_missing=False):
     if m is not nomask:
         x = ma.array(x, mask=m, copy=True)
         y = ma.array(y, mask=m, copy=True)
-        n -= m.sum()
+        n -= int(m.sum())
 
     if n < 2:
         return KendalltauResult(np.nan, np.nan)

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -207,7 +207,7 @@ class TestCorr(TestCase):
         # some machines.
         x = np.arange(2000, dtype=np.float)
         y = np.arange(2000, dtype=np.float)
-        y = np.stack((y[1000:], y[:1000])).ravel()
+        y = np.concatenate((y[1000:], y[:1000]))
         assert_almost_equal(mstats.spearmanr(x,y)[0], -0.50000037)
 
         # test for namedtuple attributes
@@ -236,7 +236,7 @@ class TestCorr(TestCase):
         x = np.arange(2000, dtype=np.float)
         x = ma.masked_greater(x, 1995)
         y = np.arange(2000, dtype=np.float)
-        y = np.stack((y[1000:], y[:1000])).ravel()
+        y = np.concatenate((y[1000:], y[:1000]))
         assert_almost_equal(mstats.kendalltau(x,y)[1], 0.97344095)
 
         # test for namedtuple attributes

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -205,10 +205,15 @@ class TestCorr(TestCase):
         # The denominator's value is ~n^3 and used to be represented as an
         # int. 2000**3 > 2**32 so these arrays would cause overflow on
         # some machines.
-        x = np.arange(2000, dtype=np.float)
-        y = np.arange(2000, dtype=np.float)
-        y = np.concatenate((y[1000:], y[:1000]))
-        assert_almost_equal(mstats.spearmanr(x,y)[0], -0.50000037)
+        x = list(range(2000))
+        y = list(range(2000))
+        y[0], y[9] = y[9], y[0]
+        y[10], y[434] = y[434], y[10]
+        y[435], y[1509] = y[1509], y[435]
+        # rho = 1 - 6 * (2 * (9^2 + 424^2 + 1074^2))/(2000 * (2000^2 - 1))
+        #     = 1 - (1 / 500)
+        #     = 0.998
+        assert_almost_equal(mstats.spearmanr(x,y)[0], 0.998)
 
         # test for namedtuple attributes
         res = mstats.spearmanr(x, y)
@@ -233,11 +238,11 @@ class TestCorr(TestCase):
         assert_almost_equal(np.asarray(result), [-0.1585188, 0.4128009])
         # make sure internal variable use correct precision with
         # larger arrays
-        x = np.arange(2000, dtype=np.float)
+        x = np.arange(2000, dtype=float)
         x = ma.masked_greater(x, 1995)
-        y = np.arange(2000, dtype=np.float)
+        y = np.arange(2000, dtype=float)
         y = np.concatenate((y[1000:], y[:1000]))
-        assert_almost_equal(mstats.kendalltau(x,y)[1], 0.97344095)
+        assert_(np.isfinite(mstats.kendalltau(x,y)[1]))
 
         # test for namedtuple attributes
         res = mstats.kendalltau(x, y)

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -208,7 +208,7 @@ class TestCorr(TestCase):
         x = np.arange(2000, dtype=np.float)
         y = np.arange(2000, dtype=np.float)
         y = np.stack((y[1000:], y[:1000])).ravel()
-        assert_almost_equal(mstats.spearmanr(x,y)[0], -0.5)
+        assert_almost_equal(mstats.spearmanr(x,y)[0], -0.50000037)
 
         # test for namedtuple attributes
         res = mstats.spearmanr(x, y)
@@ -237,7 +237,7 @@ class TestCorr(TestCase):
         x = ma.masked_greater(x, 1995)
         y = np.arange(2000, dtype=np.float)
         y = np.stack((y[1000:], y[:1000])).ravel()
-        assert_almost_equal(mstats.kendalltau(x,y)[1], 0.9734409)
+        assert_almost_equal(mstats.kendalltau(x,y)[1], 0.97344095)
 
         # test for namedtuple attributes
         res = mstats.kendalltau(x, y)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -594,6 +594,18 @@ def test_spearmanr():
     res2 = stats.spearmanr(x1[:3], x2[:3], nan_policy='omit')
     assert_equal(res1, res2)
 
+    # Regression test for GitHub issue #6061 - Overflow on Windows
+    x = list(range(2000))
+    y = list(range(2000))
+    y[0], y[9] = y[9], y[0]
+    y[10], y[434] = y[434], y[10]
+    y[435], y[1509] = y[1509], y[435]
+    # rho = 1 - 6 * (2 * (9^2 + 424^2 + 1074^2))/(2000 * (2000^2 - 1))
+    #     = 1 - (1 / 500)
+    #     = 0.998
+    x.append(np.nan)
+    y.append(3.0)
+    assert_almost_equal(stats.spearmanr(x, y, nan_policy='omit')[0], 0.998)
 
 class TestCorrSpearmanrTies(TestCase):
     """Some tests of tie-handling by the spearmanr function."""
@@ -683,6 +695,12 @@ def test_kendalltau():
     assert_equal(np.nan, tau)
     assert_equal(np.nan, p_value)
 
+    # Regression test for GitHub issue #6061 - Overflow on Windows
+    x = np.arange(2000, dtype=float)
+    x = np.ma.masked_greater(x, 1995)
+    y = np.arange(2000, dtype=float)
+    y = np.concatenate((y[1000:], y[:1000]))
+    assert_(np.isfinite(stats.kendalltau(x,y)[1]))
 
 def test_kendalltau_vs_mstats_basic():
     np.random.seed(42)


### PR DESCRIPTION
This attempts to fix #6061 - insufficient precision was being used for some internal variables in the calculation of spearman's rho and kendall's tau. Notably, this was the case on Windows since the Windows `long int` is only 32 bits. See [here (stack overflow)](http://stackoverflow.com/questions/36278590/numpy-array-dtype-is-coming-as-int32-by-default-in-a-windows-10-64-bit-machine) for more information.

Two additional changes were made which contributors/members should feel free to shoot down. First, I removed a `df = n - 2` statement from `pearsonr` since it was already calculated (and unmodified) above it. Second, I (or rather, my editor upon saving the file) removed extraneous white space from the test `test_mode_modifies_input`.