### PR TITLE
MAINT: change dtype comparison in optimize.linear_sum_assignment.

### DIFF
--- a/scipy/optimize/_hungarian.py
+++ b/scipy/optimize/_hungarian.py
@@ -85,14 +85,14 @@ def linear_sum_assignment(cost_matrix):
                          % (cost_matrix.shape,))
 
     if not (np.issubdtype(cost_matrix.dtype, np.number) or
-            cost_matrix.dtype is np.dtype(np.bool)):
+            cost_matrix.dtype == np.dtype(np.bool)):
         raise ValueError("expected a matrix containing numerical entries, got %s"
                          % (cost_matrix.dtype,))
 
     if np.any(np.isinf(cost_matrix) | np.isnan(cost_matrix)):
         raise ValueError("matrix contains invalid numeric entries")
 
-    if cost_matrix.dtype is np.dtype(np.bool):
+    if cost_matrix.dtype == np.dtype(np.bool):
         cost_matrix = cost_matrix.astype(np.int)
 
     # The algorithm expects more columns than rows in the cost matrix.


### PR DESCRIPTION
Follow-up to gh-7031.  Thanks to @pv for pointing out that
dtypes must not be considered singletons.