### PR TITLE
Fix TestSphericalVoronoi error on Windows

### DIFF
--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -270,6 +270,7 @@ class SphericalVoronoi:
         array_associations = array_associations[np.lexsort((
                                                 array_associations[...,1],
                                                 array_associations[...,0]))]
+        array_associations = array_associations.astype(np.intp)
 
         # group by generator indices to produce
         # unsorted regions in nested list


### PR DESCRIPTION
Fix `ValueError: Buffer dtype mismatch, expected 'npy_intp' but got 'long'` in `File "scipy\spatial\_voronoi.pyx", line 43` reported in https://github.com/scipy/scipy/issues/7055:
```
======================================================================
ERROR: test_sort_vertices_of_regions (test_spherical_voronoi.TestSphericalVoronoi)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python35\lib\site-packages\scipy\spatial\tests\test_spherical_voronoi.py", line 112, in test_sort_vertices_of_regions
    sv.sort_vertices_of_regions()
  File "X:\Python35\lib\site-packages\scipy\spatial\_spherical_voronoi.py", line 306, in sort_vertices_of_regions
    self.regions)
  File "scipy\spatial\_voronoi.pyx", line 43, in scipy.spatial._voronoi.sort_vertices_of_regions (scipy\spatial\_voronoi.c:2607)
ValueError: Buffer dtype mismatch, expected 'npy_intp' but got 'long' 

======================================================================
ERROR: test_sort_vertices_of_regions_flattened (test_spherical_voronoi.TestSphericalVoronoi)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python35\lib\site-packages\scipy\spatial\tests\test_spherical_voronoi.py", line 121, in test_sort_vertices_of_regions_flattened
    sv.sort_vertices_of_regions()
  File "X:\Python35\lib\site-packages\scipy\spatial\_spherical_voronoi.py", line 306, in sort_vertices_of_regions
    self.regions)
  File "scipy\spatial\_voronoi.pyx", line 43, in scipy.spatial._voronoi.sort_vertices_of_regions (scipy\spatial\_voronoi.c:2607)
ValueError: Buffer dtype mismatch, expected 'npy_intp' but got 'long'
```