### PR TITLE
TST: Fix UnboundLocalError: local variable 'data' referenced before assignment on Windows

### DIFF
--- a/scipy/io/tests/test_wavfile.py
+++ b/scipy/io/tests/test_wavfile.py
@@ -80,21 +80,21 @@ def test_read_5():
 
 def test_read_fail():
     for mmap in [False, True]:
-        fp = open(datafile('example_1.nc'))
+        fp = open(datafile('example_1.nc'), 'rb')
         assert_raises(ValueError, wavfile.read, fp, mmap=mmap)
         fp.close()
 
 
 def test_read_early_eof():
     for mmap in [False, True]:
-        fp = open(datafile('test-44100Hz-le-1ch-4bytes-early-eof.wav'))
+        fp = open(datafile('test-44100Hz-le-1ch-4bytes-early-eof.wav'), 'rb')
         assert_raises(ValueError, wavfile.read, fp, mmap=mmap)
         fp.close()
 
 
 def test_read_incomplete_chunk():
     for mmap in [False, True]:
-        fp = open(datafile('test-44100Hz-le-1ch-4bytes-incomplete-chunk.wav'))
+        fp = open(datafile('test-44100Hz-le-1ch-4bytes-incomplete-chunk.wav'), 'rb')
         assert_raises(ValueError, wavfile.read, fp, mmap=mmap)
         fp.close()
 


### PR DESCRIPTION
Fixes one test error reported at https://github.com/scipy/scipy/issues/7055

```
======================================================================
ERROR: test_wavfile.test_read_early_eof
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27-x64\lib\site-packages\nose\case.py", line 197, in runTest
    self.test(*self.arg)
  File "X:\Python27-x64\lib\site-packages\scipy\io\tests\test_wavfile.py", line 91, in test_read_early_eof
    assert_raises(ValueError, wavfile.read, fp, mmap=mmap)
  File "X:\Python27-x64\lib\site-packages\numpy\testing\utils.py", line 1142, in assert_raises
    return nose.tools.assert_raises(*args,**kwargs)
  File "X:\Python27-x64\lib\unittest\case.py", line 473, in assertRaises
    callableObj(*args, **kwargs)
  File "X:\Python27-x64\lib\site-packages\scipy\io\wavfile.py", line 281, in read
    return fs, data
UnboundLocalError: local variable 'data' referenced before assignment
```