### PR TITLE
Fix OverflowError: Python int too large to convert to C long on Windows

### DIFF
--- a/scipy/io/mmio.py
+++ b/scipy/io/mmio.py
@@ -179,7 +179,7 @@ class MMFile (object):
             raise ValueError('unknown symmetry type %s, must be one of %s' %
                              (symmetry, self.SYMMETRY_VALUES))
 
-    DTYPES_BY_FIELD = {FIELD_INTEGER: 'int',
+    DTYPES_BY_FIELD = {FIELD_INTEGER: 'intp',
                        FIELD_REAL: 'd',
                        FIELD_COMPLEX: 'D',
                        FIELD_PATTERN: 'd'}
@@ -574,7 +574,7 @@ class MMFile (object):
             if is_pattern:
                 V = ones(entries, dtype='int8')
             elif is_integer:
-                V = zeros(entries, dtype='int')
+                V = zeros(entries, dtype='intp')
             elif is_complex:
                 V = zeros(entries, dtype='complex')
             else:
@@ -643,10 +643,10 @@ class MMFile (object):
             if field is not None:
 
                 if field == self.FIELD_INTEGER:
-                    if not can_cast(a.dtype, 'int'):
+                    if not can_cast(a.dtype, 'intp'):
                         raise OverflowError("mmwrite does not support integer "
-                                            "dtypes larger than native 'int'.")
-                    a = a.astype('int')
+                                            "dtypes larger than native 'intp'.")
+                    a = a.astype('intp')
                 elif field == self.FIELD_REAL:
                     if a.dtype.char not in 'fd':
                         a = a.astype('d')
@@ -671,9 +671,9 @@ class MMFile (object):
         if field is None:
             kind = a.dtype.kind
             if kind == 'i':
-                if not can_cast(a.dtype, 'int'):
+                if not can_cast(a.dtype, 'intp'):
                     raise OverflowError("mmwrite does not support integer "
-                                        "dtypes larger than native 'int'.")
+                                        "dtypes larger than native 'intp'.")
                 field = 'integer'
             elif kind == 'f':
                 field = 'real'


### PR DESCRIPTION
Please review.

Fixes several test errors on Windows reported at https://github.com/scipy/scipy/issues/7055:
```
======================================================================
ERROR: test_64bit_integer (test_mmio.TestMMIOArray)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python35\lib\site-packages\scipy\io\tests\test_mmio.py", line 50, in test_64bit_integer
    self.check_exact(a, (2, 2, 4, 'array', 'integer', 'general'))
  File "X:\Python35\lib\site-packages\scipy\io\tests\test_mmio.py", line 32, in check_exact
    mmwrite(self.fn, a)
  File "X:\Python35\lib\site-packages\scipy\io\mmio.py", line 102, in mmwrite
    MMFile().write(target, a, comment, field, precision, symmetry)
  File "X:\Python35\lib\site-packages\scipy\io\mmio.py", line 448, in write
    self._write(stream, a, comment, field, precision, symmetry)
  File "X:\Python35\lib\site-packages\scipy\io\mmio.py", line 675, in _write
    raise OverflowError("mmwrite does not support integer "
OverflowError: mmwrite does not support integer dtypes larger than native 'int'.

======================================================================
ERROR: test_read_64bit_integer_dense (test_mmio.TestMMIOReadLargeIntegers)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python35\lib\site-packages\scipy\io\tests\test_mmio.py", line 320, in test_read_64bit_integer_dense
    over64=False)
  File "X:\Python35\lib\site-packages\scipy\io\tests\test_mmio.py", line 287, in check_read
    b = mmread(self.fn)
  File "X:\Python35\lib\site-packages\scipy\io\mmio.py", line 76, in mmread
    return MMFile().read(source)
  File "X:\Python35\lib\site-packages\scipy\io\mmio.py", line 415, in read
    return self._parse_body(stream)
  File "X:\Python35\lib\site-packages\scipy\io\mmio.py", line 516, in _parse_body
    a[i, j] = aij
OverflowError: Python int too large to convert to C long

======================================================================
ERROR: test_read_64bit_integer_sparse_general (test_mmio.TestMMIOReadLargeIntegers)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python35\lib\site-packages\scipy\io\tests\test_mmio.py", line 330, in test_read_64bit_integer_sparse_general
    over64=False)
  File "X:\Python35\lib\site-packages\scipy\io\tests\test_mmio.py", line 287, in check_read
    b = mmread(self.fn)
  File "X:\Python35\lib\site-packages\scipy\io\mmio.py", line 76, in mmread
    return MMFile().read(source)
  File "X:\Python35\lib\site-packages\scipy\io\mmio.py", line 415, in read
    return self._parse_body(stream)
  File "X:\Python35\lib\site-packages\scipy\io\mmio.py", line 596, in _parse_body
    V[entry_number] = int(l[2])
OverflowError: Python int too large to convert to C long

======================================================================
ERROR: test_read_64bit_integer_sparse_skew (test_mmio.TestMMIOReadLargeIntegers)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python35\lib\site-packages\scipy\io\tests\test_mmio.py", line 350, in test_read_64bit_integer_sparse_skew
    over64=False)
  File "X:\Python35\lib\site-packages\scipy\io\tests\test_mmio.py", line 287, in check_read
    b = mmread(self.fn)
  File "X:\Python35\lib\site-packages\scipy\io\mmio.py", line 76, in mmread
    return MMFile().read(source)
  File "X:\Python35\lib\site-packages\scipy\io\mmio.py", line 415, in read
    return self._parse_body(stream)
  File "X:\Python35\lib\site-packages\scipy\io\mmio.py", line 596, in _parse_body
    V[entry_number] = int(l[2])
OverflowError: Python int too large to convert to C long

======================================================================
ERROR: test_read_64bit_integer_sparse_symmetric (test_mmio.TestMMIOReadLargeIntegers)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python35\lib\site-packages\scipy\io\tests\test_mmio.py", line 340, in test_read_64bit_integer_sparse_symmetric
    over64=False)
  File "X:\Python35\lib\site-packages\scipy\io\tests\test_mmio.py", line 287, in check_read
    b = mmread(self.fn)
  File "X:\Python35\lib\site-packages\scipy\io\mmio.py", line 76, in mmread
    return MMFile().read(source)
  File "X:\Python35\lib\site-packages\scipy\io\mmio.py", line 415, in read
    return self._parse_body(stream)
  File "X:\Python35\lib\site-packages\scipy\io\mmio.py", line 596, in _parse_body
    V[entry_number] = int(l[2])
OverflowError: Python int too large to convert to C long

======================================================================
ERROR: test_64bit_integer (test_mmio.TestMMIOSparseCSR)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python35\lib\site-packages\scipy\io\tests\test_mmio.py", line 141, in test_64bit_integer
    self.check_exact(a, (2, 2, 4, 'coordinate', 'integer', 'general'))
  File "X:\Python35\lib\site-packages\scipy\io\tests\test_mmio.py", line 119, in check_exact
    mmwrite(self.fn, a)
  File "X:\Python35\lib\site-packages\scipy\io\mmio.py", line 102, in mmwrite
    MMFile().write(target, a, comment, field, precision, symmetry)
  File "X:\Python35\lib\site-packages\scipy\io\mmio.py", line 448, in write
    self._write(stream, a, comment, field, precision, symmetry)
  File "X:\Python35\lib\site-packages\scipy\io\mmio.py", line 675, in _write
    raise OverflowError("mmwrite does not support integer "
OverflowError: mmwrite does not support integer dtypes larger than native 'int'.
```