### PR TITLE
TST: silence RuntimeWarning for nan test of stats.spearmanr

### DIFF
--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -553,9 +553,11 @@ def test_spearmanr():
     check_named_results(res, attributes)
 
     # with only ties in one or both inputs
-    assert_equal(stats.spearmanr([2,2,2], [2,2,2]), (np.nan, np.nan))
-    assert_equal(stats.spearmanr([2,0,2], [2,2,2]), (np.nan, np.nan))
-    assert_equal(stats.spearmanr([2,2,2], [2,0,2]), (np.nan, np.nan))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        assert_equal(stats.spearmanr([2,2,2], [2,2,2]), (np.nan, np.nan))
+        assert_equal(stats.spearmanr([2,0,2], [2,2,2]), (np.nan, np.nan))
+        assert_equal(stats.spearmanr([2,2,2], [2,0,2]), (np.nan, np.nan))
 
     # empty arrays provided as input
     assert_equal(stats.spearmanr([], []), (np.nan, np.nan))


### PR DESCRIPTION
This is the only test warning I see with 0.19.0rc1, so good to backport.