### PR TITLE
ENH: sparse: allow subclasses to override specific math operations

### DIFF
--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -326,18 +326,66 @@ class spmatrix(object):
     def __abs__(self):
         return abs(self.tocsr())
 
-    def __add__(self, other):   # self + other
-        return self.tocsr().__add__(other)
+    def _add_sparse(self, other):
+        return self.tocsr()._add_sparse(other)
 
-    def __radd__(self, other):  # other + self
-        return self.tocsr().__radd__(other)
+    def _add_dense(self, other):
+        return self.tocoo()._add_dense(other)
 
-    def __sub__(self, other):   # self - other
-        # note: this can't be replaced by self + (-other) for unsigned types
-        return self.tocsr().__sub__(other)
+    def _sub_sparse(self, other):
+        return self.tocsr()._sub_sparse(other)
 
-    def __rsub__(self, other):  # other - self
-        return self.tocsr().__rsub__(other)
+    def _sub_dense(self, other):
+        return self.todense() - other
+
+    def _rsub_dense(self, other):
+        # note: this can't be replaced by other + (-self) for unsigned types
+        return other - self.todense()
+
+    def __add__(self, other):  # self + other
+        if isscalarlike(other):
+            if other == 0:
+                return self.copy()
+            # Now we would add this scalar to every element.
+            raise NotImplementedError('adding a nonzero scalar to a '
+                                      'sparse matrix is not supported')
+        elif isspmatrix(other):
+            if other.shape != self.shape:
+                raise ValueError("inconsistent shapes")
+            return self._add_sparse(other)
+        elif isdense(other):
+            return self._add_dense(other)
+        else:
+            return NotImplemented
+
+    def __radd__(self,other):  # other + self
+        return self.__add__(other)
+
+    def __sub__(self, other):  # self - other
+        if isscalarlike(other):
+            if other == 0:
+                return self.copy()
+            raise NotImplementedError('subtracting a nonzero scalar from a '
+                                      'sparse matrix is not supported')
+        elif isspmatrix(other):
+            if other.shape != self.shape:
+                raise ValueError("inconsistent shapes")
+            return self._sub_sparse(other)
+        elif isdense(other):
+            return self._sub_dense(other)
+        else:
+            return NotImplemented
+
+    def __rsub__(self,other):  # other - self
+        if isscalarlike(other):
+            if other == 0:
+                return -self.copy()
+            raise NotImplementedError('subtracting a sparse matrix from a '
+                                      'nonzero scalar is not supported')
+        elif isdense(other):
+            return self._rsub_dense(other)
+        else:
+            return NotImplemented
 
     def __mul__(self, other):
         """interpret other and call one of the following

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -6,6 +6,7 @@ import sys
 import numpy as np
 
 from scipy._lib.six import xrange
+from scipy._lib._numpy_compat import broadcast_to
 from .sputils import (isdense, isscalarlike, isintlike,
                       get_sum_dtype, validateaxis)
 
@@ -354,6 +355,7 @@ class spmatrix(object):
                 raise ValueError("inconsistent shapes")
             return self._add_sparse(other)
         elif isdense(other):
+            other = broadcast_to(other, self.shape)
             return self._add_dense(other)
         else:
             return NotImplemented
@@ -372,6 +374,7 @@ class spmatrix(object):
                 raise ValueError("inconsistent shapes")
             return self._sub_sparse(other)
         elif isdense(other):
+            other = broadcast_to(other, self.shape)
             return self._sub_dense(other)
         else:
             return NotImplemented
@@ -383,6 +386,7 @@ class spmatrix(object):
             raise NotImplementedError('subtracting a sparse matrix from a '
                                       'nonzero scalar is not supported')
         elif isdense(other):
+            other = broadcast_to(other, self.shape)
             return self._rsub_dense(other)
         else:
             return NotImplemented

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -327,60 +327,11 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
     # Arithmatic operator overrides #
     #################################
 
-    def __add__(self,other):
-        # First check if argument is a scalar
-        if isscalarlike(other):
-            if other == 0:
-                return self.copy()
-            else:  # Now we would add this scalar to every element.
-                raise NotImplementedError('adding a nonzero scalar to a '
-                                          'sparse matrix is not supported')
-        elif isspmatrix(other):
-            if (other.shape != self.shape):
-                raise ValueError("inconsistent shapes")
+    def _add_sparse(self, other):
+        return self._binopt(other, '_plus_')
 
-            return self._binopt(other,'_plus_')
-        elif isdense(other):
-            # Convert this matrix to a dense matrix and add them
-            return self.todense() + other
-        else:
-            return NotImplemented
-
-    def __radd__(self,other):
-        return self.__add__(other)
-
-    def __sub__(self,other):
-        # First check if argument is a scalar
-        if isscalarlike(other):
-            if other == 0:
-                return self.copy()
-            else:  # Now we would add this scalar to every element.
-                raise NotImplementedError('adding a nonzero scalar to a '
-                                          'sparse matrix is not supported')
-        elif isspmatrix(other):
-            if (other.shape != self.shape):
-                raise ValueError("inconsistent shapes")
-
-            return self._binopt(other,'_minus_')
-        elif isdense(other):
-            # Convert this matrix to a dense matrix and subtract them
-            return self.todense() - other
-        else:
-            return NotImplemented
-
-    def __rsub__(self,other):  # other - self
-        # note: this can't be replaced by other + (-self) for unsigned types
-        if isscalarlike(other):
-            if other == 0:
-                return -self.copy()
-            else:  # Now we would add this scalar to every element.
-                raise NotImplementedError('adding a nonzero scalar to a '
-                                          'sparse matrix is not supported')
-        elif isdense(other):
-            # Convert this matrix to a dense matrix and subtract them
-            return other - self.todense()
-        else:
-            return NotImplemented
+    def _sub_sparse(self, other):
+        return self._binopt(other, '_minus_')
 
     def multiply(self, other):
         """Point-wise multiplication by another matrix, vector, or

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -489,6 +489,8 @@ class coo_matrix(_data_matrix, _minmax_mixin):
     #######################
 
     def _add_dense(self, other):
+        if other.shape != self.shape:
+            raise ValueError('Incompatible shapes.')
         dtype = upcast_char(self.dtype.char, other.dtype.char)
         result = np.array(other, dtype=dtype, copy=True)
         fortran = int(result.flags.f_contiguous)

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -484,9 +484,18 @@ class coo_matrix(_data_matrix, _minmax_mixin):
         self.row = self.row[mask]
         self.col = self.col[mask]
 
-    ###########################
-    # Multiplication handlers #
-    ###########################
+    #######################
+    # Arithmetic handlers #
+    #######################
+
+    def _add_dense(self, other):
+        dtype = upcast_char(self.dtype.char, other.dtype.char)
+        result = np.array(other, dtype=dtype, copy=True)
+        fortran = int(result.flags.f_contiguous)
+        M, N = self.shape
+        coo_todense(M, N, self.nnz, self.row, self.col, self.data,
+                    result.ravel('A'), fortran)
+        return result
 
     def _mul_vector(self, other):
         #output array

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1201,6 +1201,10 @@ class _TestCommon:
             assert_array_equal(c.todense(),
                                b.todense() + b.todense())
 
+            # test broadcasting
+            c = b + a[0]
+            assert_array_equal(c, b.todense() + a[0])
+
         for dtype in self.math_dtypes:
             yield check, dtype
 
@@ -1230,7 +1234,14 @@ class _TestCommon:
             assert_array_equal((datsp - A).todense(),dat - A.todense())
             assert_array_equal((A - datsp).todense(),A.todense() - dat)
 
+            # test broadcasting
+            assert_array_equal(datsp - dat[0], dat - dat[0])
+
         for dtype in self.math_dtypes:
+            if dtype == np.dtype('bool'):
+                # boolean array subtraction deprecated in 1.9.0
+                continue
+
             yield check, dtype
 
     def test_rsub(self):
@@ -1247,6 +1258,9 @@ class _TestCommon:
             assert_array_equal((A - dat),A.todense() - dat)
             assert_array_equal(A.todense() - datsp,A.todense() - dat)
             assert_array_equal(datsp - A.todense(),dat - A.todense())
+
+            # test broadcasting
+            assert_array_equal(dat[0] - datsp, dat[0] - dat)
 
         for dtype in self.math_dtypes:
             if dtype == np.dtype('bool'):


### PR DESCRIPTION
New methods `_(add/sub)_sparse` and `_(add/sub/rsub)_dense` allow spmatrix to handle the boilerplate delegation code of `__add__` and `__sub__`, and make it easy for subclasses to provide optimized implementations.

As an example, `coo_matrix._add_dense` can avoid densification, which results in a reasonably large speedup (depending on matrix size and density). The old situation for `coo + dense` was especially bad because it expanded to `coo -> csr -> coo -> dense`.