### PR TITLE
ENH: initial vectors in sparse.linalg.minres

### DIFF
--- a/scipy/sparse/linalg/isolve/minres.py
+++ b/scipy/sparse/linalg/isolve/minres.py
@@ -85,14 +85,13 @@ def minres(A, b, x0=None, shift=0.0, tol=1e-5, maxiter=None, xtype=None,
 
     eps = finfo(xtype).eps
 
-    x = zeros(n, dtype=xtype)
 
     # Set up y and v for the first Lanczos vector v1.
     # y  =  beta1 P' v1,  where  P = C**(-1).
     # v is really P' v1.
 
     y = b
-    r1 = b
+    r1 = b - A*x
 
     y = psolve(b)
 

--- a/scipy/sparse/linalg/isolve/minres.py
+++ b/scipy/sparse/linalg/isolve/minres.py
@@ -85,7 +85,6 @@ def minres(A, b, x0=None, shift=0.0, tol=1e-5, maxiter=None, xtype=None,
 
     eps = finfo(xtype).eps
 
-
     # Set up y and v for the first Lanczos vector v1.
     # y  =  beta1 P' v1,  where  P = C**(-1).
     # v is really P' v1.


### PR DESCRIPTION
In reference with the issue #6843, to intend to use the input x and not deprecate x0, in line 94,
r1 = b - Ax seems the correct solution. Please have a look and suggest me appropriate changes if any.