### PR TITLE
ENH: sparse: speed up CSR/CSC toarray()

### DIFF
--- a/benchmarks/benchmarks/sparse.py
+++ b/benchmarks/benchmarks/sparse.py
@@ -357,3 +357,18 @@ class Iteration(Benchmark):
     def time_iteration(self, density, format):
         for row in self.X:
             pass
+
+
+class Densify(Benchmark):
+    params = [
+        ['dia', 'csr', 'csc', 'dok', 'lil', 'coo', 'bsr'],
+        ['C', 'F'],
+    ]
+    param_names = ['format', 'order']
+
+    def setup(self, format, order):
+        self.X = sparse.rand(1000, 1000, format=format, density=0.01)
+
+    def time_toarray(self, format, order):
+        self.X.toarray(order=order)
+

--- a/scipy/sparse/bsr.py
+++ b/scipy/sparse/bsr.py
@@ -478,6 +478,11 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
         from .coo import coo_matrix
         return coo_matrix((data,(row,col)), shape=self.shape)
 
+    def toarray(self, order=None, out=None):
+        return self.tocoo(copy=False).toarray(order=order, out=out)
+
+    toarray.__doc__ = spmatrix.toarray.__doc__
+
     def transpose(self, axes=None, copy=False):
         if axes is not None:
             raise ValueError(("Sparse matrices do not support "

--- a/scipy/sparse/bsr.py
+++ b/scipy/sparse/bsr.py
@@ -330,6 +330,9 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
         """Multiply this sparse matrix by other matrix."""
         return self * other
 
+    def _add_dense(self, other):
+        return self.tocoo(copy=False)._add_dense(other)
+
     def _mul_vector(self, other):
         M,N = self.shape
         R,C = self.blocksize

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -327,6 +327,17 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
     # Arithmatic operator overrides #
     #################################
 
+    def _add_dense(self, other):
+        if other.shape != self.shape:
+            raise ValueError('Incompatible shapes.')
+        dtype = upcast_char(self.dtype.char, other.dtype.char)
+        order = self._swap('CF')[0]
+        result = np.array(other, dtype=dtype, order=order, copy=True)
+        M, N = self._swap(self.shape)
+        y = result if result.flags.c_contiguous else result.T
+        _sparsetools.csr_todense(M, N, self.indptr, self.indices, self.data, y)
+        return np.matrix(result, copy=False)
+
     def _add_sparse(self, other):
         return self._binopt(other, '_plus_')
 

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -922,6 +922,8 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
     tocoo.__doc__ = spmatrix.tocoo.__doc__
 
     def toarray(self, order=None, out=None):
+        if out is None and order is None:
+            order = self._swap('cf')[0]
         out = self._process_toarray_args(order, out)
         if not (out.flags.c_contiguous or out.flags.f_contiguous):
             raise ValueError('Output array must be C or F contiguous')

--- a/scipy/sparse/generate_sparsetools.py
+++ b/scipy/sparse/generate_sparsetools.py
@@ -77,6 +77,7 @@ csr_matmat_pass2    v iiIITIIT*I*I*T
 csr_diagonal        v iiIIT*T
 csr_tocsc           v iiIIT*I*I*T
 csr_tobsr           v iiiiIIT*I*I*T
+csr_todense         v iiIIT*T
 csr_matvec          v iiIITT*T
 csr_matvecs         v iiiIITT*T
 csr_elmul_csr       v iiIITIIT*I*I*T

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -440,12 +440,13 @@ class lil_matrix(spmatrix, IndexMixin):
     reshape.__doc__ = spmatrix.reshape.__doc__
 
     def toarray(self, order=None, out=None):
-        """See the docstring for `spmatrix.toarray`."""
         d = self._process_toarray_args(order, out)
         for i, row in enumerate(self.rows):
             for pos, j in enumerate(row):
                 d[i, j] = self.data[i][pos]
         return d
+
+    toarray.__doc__ = spmatrix.toarray.__doc__
 
     def transpose(self, axes=None, copy=False):
         return self.tocsr().transpose(axes=axes, copy=copy).tolil()

--- a/scipy/sparse/sparsetools/csr.h
+++ b/scipy/sparse/sparsetools/csr.h
@@ -246,6 +246,36 @@ void csr_tobsr(const I n_row,
 
 
 /*
+ * Compute B += A for CSR matrix A, C-contiguous dense matrix B
+ *
+ * Input Arguments:
+ *   I  n_row           - number of rows in A
+ *   I  n_col           - number of columns in A
+ *   I  Ap[n_row+1]     - row pointer
+ *   I  Aj[nnz(A)]      - column indices
+ *   T  Ax[nnz(A)]      - nonzero values
+ *   T  Bx[n_row*n_col] - dense matrix in row-major order
+ *
+ */
+template <class I, class T>
+void csr_todense(const I n_row,
+                 const I n_col,
+                 const I Ap[],
+                 const I Aj[],
+                 const T Ax[],
+                       T Bx[])
+{
+    T * Bx_row = Bx;
+    for(I i = 0; i < n_row; i++){
+        for(I jj = Ap[i]; jj < Ap[i+1]; jj++){
+            Bx_row[Aj[jj]] += Ax[jj];
+        }
+        Bx_row += (npy_intp)n_col;
+    }
+}
+
+
+/*
  * Determine whether the CSR column indices are in sorted order.
  *
  * Input Arguments:

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1059,11 +1059,10 @@ class _TestCommon:
     #    assert_equal( array(self.datsp), self.dat )
 
     def test_todense(self):
-        # Check C-contiguous (default).
+        # Check C- or F-contiguous (default).
         chk = self.datsp.todense()
         assert_array_equal(chk, self.dat)
-        assert_(chk.flags.c_contiguous)
-        assert_(not chk.flags.f_contiguous)
+        assert_(chk.flags.c_contiguous != chk.flags.f_contiguous)
         # Check C-contiguous (with arg).
         chk = self.datsp.todense(order='C')
         assert_array_equal(chk, self.dat)
@@ -1100,12 +1099,11 @@ class _TestCommon:
         assert_array_equal(spbool.todense(), matbool)
 
     def test_toarray(self):
-        # Check C-contiguous (default).
+        # Check C- or F-contiguous (default).
         dat = asarray(self.dat)
         chk = self.datsp.toarray()
         assert_array_equal(chk, dat)
-        assert_(chk.flags.c_contiguous)
-        assert_(not chk.flags.f_contiguous)
+        assert_(chk.flags.c_contiguous != chk.flags.f_contiguous)
         # Check C-contiguous (with arg).
         chk = self.datsp.toarray(order='C')
         assert_array_equal(chk, dat)


### PR DESCRIPTION
This PR adds a new function to sparsetools: `csr_todense`, which has the same semantics as `coo_todense` in that it's actually performing `D += S`. Unlike the COO version, this function requires that the dense array is in C-contiguous order.

@pv: I've never added functions to sparsetools before, so please let me know if I've missed something.

The one backwards-incompatible change here is that I set the default `csc_matrix.toarray` order to be F-contiguous, for efficiency reasons. Users can still specify an order explicitly, but the `mat.A` shorthand will now produce column-major matrices for CSC inputs.

There weren't any benchmarks testing `toarray` timing, so I added one. Here are the changes between current master and this PR:
```
BENCHMARK                                    BEFORE      AFTER     FACTOR
sparse.Densify.time_toarray('csc', 'F')    635.97μs   474.44μs   0.74600847x
sparse.Densify.time_toarray('csr', 'C')    629.63μs   468.08μs   0.74341441x
```

Finally, once gh-7079 is merged, this change will allow a more efficient implementation of `_add_dense`.