### PR TITLE
MAINT: Add missing PyType_Ready(&SuperLUGlobalType) for Py3

### DIFF
--- a/scipy/sparse/linalg/dsolve/_superlumodule.c
+++ b/scipy/sparse/linalg/dsolve/_superlumodule.c
@@ -330,6 +330,10 @@ PyObject *PyInit__superlu(void)
 	return NULL;
     }
 
+    if (PyType_Ready(&SuperLUGlobalType) < 0) {
+	return;
+    }
+
     m = PyModule_Create(&moduledef);
     d = PyModule_GetDict(m);
 


### PR DESCRIPTION
The Python 2 version of the code initialised SuperLUGlobalType correctly, but the 3 version didn't. I don't know how CPython 3.* managed to work, but this causes problems on pypy3.