### PR TITLE
Corrected typo in the doc of scipy.linalg.lstsq()

### DIFF
--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -929,7 +929,7 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
         Least-squares solution.  Return shape matches shape of `b`.
     residues : () or (1,) or (K,) ndarray
         Sums of residues, squared 2-norm for each column in ``b - a x``.
-        If rank of matrix a is ``< N`` or ``> M``, or ``'gelsy'`` is used,
+        If rank of matrix a is ``< N`` or ``N > M``, or ``'gelsy'`` is used,
         this is an empty array. If b was 1-D, this is an (1,) shape array,
         otherwise the shape is (K,).
     rank : int

--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -914,7 +914,7 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
         Whether to check that the input matrices contain only finite numbers.
         Disabling may give a performance gain, but may result in problems
         (crashes, non-termination) if the inputs do contain infinities or NaNs.
-    lapack_driver: str, optional
+    lapack_driver : str, optional
         Which LAPACK driver is used to solve the least-squares problem.
         Options are ``'gelsd'``, ``'gelsy'``, ``'gelss'``. Default
         (``'gelsd'``) is a good choice.  However, ``'gelsy'`` can be slightly


### PR DESCRIPTION
This is in reference with issue #3505 
The doc for lstsq() says:

residues : () or (1,) or (K,) ndarray
        Sums of residues, squared 2-norm for each column in ``b - a x``.
        If rank of matrix a is ``< N`` or ``> M``, or ``'gelsy'`` is used,
        this is an empty array. If b was 1-D, this is an (1,) shape array,
        otherwise the shape is (K,).

I should actually be - ``N > M`` which is consistent with the code. 






