### PR TITLE
TST: linalg: bump tolerance in test_falker

### DIFF
--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -230,7 +230,8 @@ class TestEig(object):
         length = np.empty(len(vr))
         for i in xrange(len(vr)):
             length[i] = norm(vr[:,i])
-        assert_allclose(length, np.ones(length.size), err_msg=msg)
+        assert_allclose(length, np.ones(length.size), err_msg=msg,
+                        atol=1e-7, rtol=1e-7)
 
         # Convert homogeneous coordinates
         beta_nonzero = (w[1,:] != 0)


### PR DESCRIPTION
`test_decomp.TestEig.test_falker` has been reported to fail on OS X in  https://github.com/scipy/scipy/issues/7039 and Windows in https://github.com/scipy/scipy/issues/7055.

From a quick glance (cannot repro myself) it looks like the failure is just that the test uses a default tolerance of `rtol=1e-7, atol=0`. So this PR bumps it to  `rtol=1e-7, atol=0`. 

@andyfaff would you be able to check if this fixes gh-7039 on your system?