### PR TITLE
Documented _argcheck for rv_discrete

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -2596,7 +2596,10 @@ class rv_discrete(rv_generic):
     Notes
     -----
 
-    This class is similar to `rv_continuous`, the main differences being:
+    This class is similar to `rv_continuous`. Whether a shape parameter is
+    valid is decided by an ``_argcheck`` method (which defaults to checking
+    that its arguments are strictly positive.)
+    The main differences are :
 
     - the support of the distribution is a set of integers
     - instead of the probability density function, ``pdf`` (and the

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -2599,7 +2599,7 @@ class rv_discrete(rv_generic):
     This class is similar to `rv_continuous`. Whether a shape parameter is
     valid is decided by an ``_argcheck`` method (which defaults to checking
     that its arguments are strictly positive.)
-    The main differences are :
+    The main differences are:
 
     - the support of the distribution is a set of integers
     - instead of the probability density function, ``pdf`` (and the


### PR DESCRIPTION
This is in reference to issue #7050 . 

Old : This class is similar to `rv_continuous`, the main differences being:

New : This class is similar to `rv_continuous`. Whether a shape parameter is valid is decided by an ``_argcheck`` method (which defaults to checking that its arguments are strictly positive.)
The main differences are: 