### PR TITLE
DOC: remove threat to deprecate loadmat option

### DIFF
--- a/scipy/io/matlab/mio5_params.py
+++ b/scipy/io/matlab/mio5_params.py
@@ -212,9 +212,9 @@ for _bytecode in '<>':
 class mat_struct(object):
     ''' Placeholder for holding read data from structs
 
-    We deprecate this method of holding struct information, and will
-    soon remove it, in favor of the recarray method (see loadmat
-    docstring)
+    We use instances of this class when the user passes False as a value to the
+    ``struct_as_record`` parameter of the :func:`scipy.io.matlab.loadmat`
+    function.
     '''
     pass
 


### PR DESCRIPTION
Remove comment threatening to deprecate optional return of MATLAB
structs as objects, instead of structured arrays.  It's pretty clear now
that it can be useful to return MATLAB structs this way, especially when
exploring returned values by tab completion in IPython.