### PR TITLE
MAINT: Fix mistake in PR #7082

### DIFF
--- a/scipy/sparse/linalg/dsolve/_superlumodule.c
+++ b/scipy/sparse/linalg/dsolve/_superlumodule.c
@@ -331,7 +331,7 @@ PyObject *PyInit__superlu(void)
     }
 
     if (PyType_Ready(&SuperLUGlobalType) < 0) {
-	return;
+	return NULL;
     }
 
     m = PyModule_Create(&moduledef);


### PR DESCRIPTION
It should have been `return NULL;` not `return;`, cf. comments on #7082. Sorry about that.