### PR TITLE
BF: return NULL from failed Py3 module check

### DIFF
--- a/scipy/sparse/linalg/dsolve/_superlumodule.c
+++ b/scipy/sparse/linalg/dsolve/_superlumodule.c
@@ -327,11 +327,11 @@ PyObject *PyInit__superlu(void)
     import_array();
 
     if (PyType_Ready(&SuperLUType) < 0) {
-	return NULL;
+        return NULL;
     }
 
     if (PyType_Ready(&SuperLUGlobalType) < 0) {
-	return;
+        return NULL;
     }
 
     m = PyModule_Create(&moduledef);


### PR DESCRIPTION
Return NULL rather than bare return from Python 3 module check.

This causes clang to error during build of form:

  scipy/sparse/linalg/dsolve/_superlumodule.c:334:2: error: non-void
  function 'PyInit__superlu' should return a value [-Wreturn-type]

            return;

See:
https://s3.amazonaws.com/archive.travis-ci.org/jobs/205184825/log.txt