### PR TITLE
MAINT: Customize ?TRSYL call in lyapunov solver

### DIFF
--- a/doc/release/1.0.0-notes.rst
+++ b/doc/release/1.0.0-notes.rst
@@ -33,6 +33,9 @@ Backwards incompatible changes
 Other changes
 =============
 
+In order to have consistent function names, the function
+`scipy.linalg.solve_lyapunov` is renamed to `scipy.linalg.solve_continuous_lyapunov`.
+The old name is kept for backwards-compatibility.
 
 Authors
 =======

--- a/scipy/linalg/__init__.py
+++ b/scipy/linalg/__init__.py
@@ -121,8 +121,8 @@ Matrix Equation Solvers
    solve_sylvester - Solve the Sylvester matrix equation
    solve_continuous_are - Solve the continuous-time algebraic Riccati equation
    solve_discrete_are - Solve the discrete-time algebraic Riccati equation
+   solve_continuous_lyapunov - Solve the continous-time Lyapunov equation
    solve_discrete_lyapunov - Solve the discrete-time Lyapunov equation
-   solve_lyapunov - Solve the (continous-time) Lyapunov equation
 
 
 Special Matrices

--- a/scipy/linalg/_solvers.py
+++ b/scipy/linalg/_solvers.py
@@ -23,7 +23,8 @@ from ._decomp_qz import ordqz
 from .decomp import _asarray_validated
 from .special_matrices import kron, block_diag
 
-__all__ = ['solve_sylvester', 'solve_lyapunov', 'solve_discrete_lyapunov',
+__all__ = ['solve_sylvester',
+           'solve_continuous_lyapunov', 'solve_discrete_lyapunov',
            'solve_continuous_are', 'solve_discrete_are']
 
 
@@ -105,11 +106,13 @@ def solve_continuous_lyapunov(a, q):
 
     Returns
     -------
-    x : array_like
+    x : ndarray
         Solution to the continuous Lyapunov equation
 
     See Also
     --------
+    solve_discrete_lyapunov : computes the solution to the discrete-time
+        Lyapunov equation
     solve_sylvester : computes the solution to the Sylvester equation
 
     Notes
@@ -127,7 +130,7 @@ def solve_continuous_lyapunov(a, q):
 
     r_or_c = float
 
-    for ind, _ in enumerate(a, q):
+    for ind, _ in enumerate((a, q)):
         if np.iscomplexobj(_):
             r_or_c = complex
 
@@ -145,10 +148,7 @@ def solve_continuous_lyapunov(a, q):
     f = u.conj().T.dot(q.dot(u))
 
     # Call the Sylvester equation solver
-    trsyl, = get_lapack_funcs(('trsyl',), (r, f))
-    if trsyl is None:
-        raise RuntimeError('LAPACK implementation does not contain a proper '
-                           'Sylvester equation solver (TRSYL)')
+    trsyl = get_lapack_funcs('trsyl', (r, f))
 
     dtype_string = 'T' if r_or_c == float else 'C'
     y, scale, info = trsyl(r, r, f, tranb=dtype_string)
@@ -159,7 +159,7 @@ def solve_continuous_lyapunov(a, q):
                          'LAPACK documentation for the ?TRSYL error codes.'
                          ''.format(-info))
     elif info == 1:
-        warnings.warn('Matrix a has an eigenvalue pair whose sum is '
+        warnings.warn('Input "a" has an eigenvalue pair whose sum is '
                       'very close to or exactly zero. The solution is '
                       'obtained via perturbing the coefficients.',
                       RuntimeWarning)
@@ -224,7 +224,8 @@ def solve_discrete_lyapunov(a, q, method=None):
 
     See Also
     --------
-    solve_lyapunov : computes the solution to the continuous Lyapunov equation
+    solve_continuous_lyapunov : computes the solution to the continuous-time
+        Lyapunov equation
 
     Notes
     -----

--- a/scipy/linalg/tests/test_solvers.py
+++ b/scipy/linalg/tests/test_solvers.py
@@ -9,7 +9,7 @@ from numpy.testing import assert_raises, assert_array_almost_equal
 from numpy.testing.noseclasses import KnownFailureTest
 
 from scipy.linalg import solve_sylvester
-from scipy.linalg import solve_lyapunov, solve_discrete_lyapunov
+from scipy.linalg import solve_continuous_lyapunov, solve_discrete_lyapunov
 from scipy.linalg import solve_continuous_are, solve_discrete_are
 from scipy.linalg import block_diag, solve
 
@@ -76,8 +76,15 @@ class TestSolveLyapunov(TestCase):
          (np.array(np.matrix([0, 3]).T * np.matrix([0, 3]).T.T))),
         ]
 
+    def test_continuous_squareness_and_shape(self):
+        nsq = np.ones((3, 2))
+        sq = np.eye(3)
+        assert_raises(ValueError, solve_continuous_lyapunov, nsq, sq)
+        assert_raises(ValueError, solve_continuous_lyapunov, sq, nsq)
+        assert_raises(ValueError, solve_continuous_lyapunov, sq, np.eye(2))
+
     def check_continuous_case(self, a, q):
-        x = solve_lyapunov(a, q)
+        x = solve_continuous_lyapunov(a, q)
         assert_array_almost_equal(
                           np.dot(a, x) + np.dot(x, a.conj().transpose()), q)
 

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -115,7 +115,8 @@ REFGUIDE_ALL_SKIPLIST = [
 # these names are not required to be in an autosummary:: listing
 # despite being in ALL
 REFGUIDE_AUTOSUMMARY_SKIPLIST = [
-    r'scipy\.special\..*_roots' # old aliases for scipy.special.*_roots
+    r'scipy\.special\..*_roots', # old aliases for scipy.special.*_roots
+	r'scipy\.linalg\.solve_lyapunov' # deprecated name
 ]
 
 


### PR DESCRIPTION
In the Lyapunov matrix equation solver the sylvester solver is invoked however due to the symmetry the ordqz call is not needed to be called twice. Hence instead of calling the high level solve_sylvester call, everthing is contained in the lyapunov call. Also argument checks are added. 

This has been also discussed previously (Issue https://github.com/scipy/scipy/issues/6622) about the naming consistency and the function name is changed to `solve_continuous_lyapunov`. The old name `solve_lyapunov` is left as an alias. 

There is a long-waiting overhaul plan for lyapunov solvers however it doesn't seem possible for me to make it to 0.19 hence at least this can make things a bit more consistent. 