### PR TITLE
BUG: stop cdist "correlation" modifying input

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -2115,6 +2115,9 @@ def cdist(XA, XB, metric='euclidean', p=None, V=None, VI=None, w=None):
     # between all pairs of vectors in XA and XB using the distance metric 'abc'
     # but with a more succinct, verifiable, but less efficient implementation.
 
+    # Store input arguments to check whether we can modify later.
+    input_XA, input_XB = XA, XB
+
     XA = np.asarray(XA, order='c')
     XB = np.asarray(XB, order='c')
 
@@ -2242,6 +2245,8 @@ def cdist(XA, XB, metric='euclidean', p=None, V=None, VI=None, w=None):
         elif mstr in ['correlation', 'co']:
             XA = _convert_to_double(XA)
             XB = _convert_to_double(XB)
+            XA = XA.copy() if XA is input_XA else XA
+            XB = XB.copy() if XB is input_XB else XB
             XA -= XA.mean(axis=1)[:, np.newaxis]
             XB -= XB.mean(axis=1)[:, np.newaxis]
             _cosine_cdist(XA, XB, dm)

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -1523,6 +1523,20 @@ def test_sokalmichener():
     assert_equal(dist1, dist2)
 
 
+def test_modifies_input():
+    # test whether cdist or pdist modifies input arrays
+    X1 = np.asarray([[1., 2., 3.],
+                     [1.2, 2.3, 3.4],
+                     [2.2, 2.3, 4.4],
+                     [22.2, 23.3, 44.4]])
+    X1_copy = X1.copy()
+    for metric in _METRICS_NAMES:
+        kwargs = {"w": 1.0 / X1.std(axis=0)} if metric == "wminkowski" else {}
+        cdist(X1, X1, metric, **kwargs)
+        pdist(X1, metric, **kwargs)
+        assert_array_equal(X1, X1_copy)
+
+
 def test_Xdist_deprecated_args():
     # testing both cdist and pdist deprecated warnings
     X1 = np.asarray([[1., 2., 3.], [1.2, 2.3, 3.4], [2.2, 2.3, 4.4]])


### PR DESCRIPTION
cdist "correlation" metric was subtracting the means from its inputs, if
the inputs were C-contiguous double arrays.  Check whether the working
arrays are the same as the inputs before subtracting the means.

Fixes gh-7100 (because the input arrays to the tests change).