### PR TITLE
Fix error message typo in UnivariateSpline

### DIFF
--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -42,7 +42,7 @@ gives the corresponding weighted sum of squared residuals (fp>s).
 """,
                     2:"""
 A theoretically impossible result was found during the iteration
-proces for finding a smoothing spline with fp = s: s too small.
+process for finding a smoothing spline with fp = s: s too small.
 There is an approximation returned but the corresponding weighted sum
 of squared residuals does not satisfy the condition abs(fp-s)/s < tol.""",
                     3:"""


### PR DESCRIPTION
The error message it gives you had misspelled 'process' as 'proces'. It's spelled correctly later in the file in a different error message.