### PR TITLE
fix docstring of NearestNDInterpolator

### DIFF
--- a/scipy/interpolate/ndgriddata.py
+++ b/scipy/interpolate/ndgriddata.py
@@ -21,7 +21,7 @@ __all__ = ['griddata', 'NearestNDInterpolator', 'LinearNDInterpolator',
 
 class NearestNDInterpolator(NDInterpolatorBase):
     """
-    NearestNDInterpolator(points, values)
+    NearestNDInterpolator(x, y)
 
     Nearest-neighbour interpolation in N dimensions.
 


### PR DESCRIPTION
There's a mismatch in args names:


![screenshot from 2017-03-09 11 44 11](https://cloud.githubusercontent.com/assets/1842780/23746847/c2fade90-04bd-11e7-83a1-912603548627.png)
