### PR TITLE
MAINT: special: remove deprecated variant of `gammaln`

### DIFF
--- a/scipy/special/_ufuncs.pyx
+++ b/scipy/special/_ufuncs.pyx
@@ -1202,10 +1202,6 @@ from _legacy cimport ellip_harmonic_unsafe as _func_ellip_harmonic_unsafe
 ctypedef double _proto_ellip_harmonic_unsafe_t(double, double, double, double, double, double, double) nogil
 cdef _proto_ellip_harmonic_unsafe_t *_proto_ellip_harmonic_unsafe_t_var = &_func_ellip_harmonic_unsafe
 cdef extern from "_ufuncs_defs.h":
-    cdef double _func_lgam "lgam"(double) nogil
-cdef extern from "_ufuncs_defs.h":
-    cdef double complex _func_clngamma_wrap "clngamma_wrap"(double complex) nogil
-cdef extern from "_ufuncs_defs.h":
     cdef double _func_igam_fac "igam_fac"(double, double) nogil
 from lambertw cimport lambertw_scalar as _func_lambertw_scalar
 ctypedef double complex _proto_lambertw_scalar_t(double complex, long, double) nogil
@@ -1563,6 +1559,8 @@ cdef extern from "_ufuncs_defs.h":
     cdef double _func_igami "igami"(double, double) nogil
 cdef extern from "_ufuncs_defs.h":
     cdef double _func_gammaincinv "gammaincinv"(double, double) nogil
+cdef extern from "_ufuncs_defs.h":
+    cdef double _func_lgam "lgam"(double) nogil
 cdef extern from "_ufuncs_defs.h":
     cdef double _func_gammasgn "gammasgn"(double) nogil
 cdef extern from "_ufuncs_defs.h":
@@ -2009,38 +2007,6 @@ ufunc__ellip_harm_data[0] = &ufunc__ellip_harm_ptr[2*0]
 ufunc__ellip_harm_data[1] = &ufunc__ellip_harm_ptr[2*1]
 ufunc__ellip_harm_data[2] = &ufunc__ellip_harm_ptr[2*2]
 _ellip_harm = np.PyUFunc_FromFuncAndData(ufunc__ellip_harm_loops, ufunc__ellip_harm_data, ufunc__ellip_harm_types, 3, 7, 1, 0, "_ellip_harm", ufunc__ellip_harm_doc, 0)
-
-cdef np.PyUFuncGenericFunction ufunc__gammaln_loops[4]
-cdef void *ufunc__gammaln_ptr[8]
-cdef void *ufunc__gammaln_data[4]
-cdef char ufunc__gammaln_types[8]
-cdef char *ufunc__gammaln_doc = (
-    "Internal function, use ``gammaln`` instead.")
-ufunc__gammaln_loops[0] = <np.PyUFuncGenericFunction>loop_d_d__As_f_f
-ufunc__gammaln_loops[1] = <np.PyUFuncGenericFunction>loop_d_d__As_d_d
-ufunc__gammaln_loops[2] = <np.PyUFuncGenericFunction>loop_D_D__As_F_F
-ufunc__gammaln_loops[3] = <np.PyUFuncGenericFunction>loop_D_D__As_D_D
-ufunc__gammaln_types[0] = <char>NPY_FLOAT
-ufunc__gammaln_types[1] = <char>NPY_FLOAT
-ufunc__gammaln_types[2] = <char>NPY_DOUBLE
-ufunc__gammaln_types[3] = <char>NPY_DOUBLE
-ufunc__gammaln_types[4] = <char>NPY_CFLOAT
-ufunc__gammaln_types[5] = <char>NPY_CFLOAT
-ufunc__gammaln_types[6] = <char>NPY_CDOUBLE
-ufunc__gammaln_types[7] = <char>NPY_CDOUBLE
-ufunc__gammaln_ptr[2*0] = <void*>_func_lgam
-ufunc__gammaln_ptr[2*0+1] = <void*>(<char*>"_gammaln")
-ufunc__gammaln_ptr[2*1] = <void*>_func_lgam
-ufunc__gammaln_ptr[2*1+1] = <void*>(<char*>"_gammaln")
-ufunc__gammaln_ptr[2*2] = <void*>_func_clngamma_wrap
-ufunc__gammaln_ptr[2*2+1] = <void*>(<char*>"_gammaln")
-ufunc__gammaln_ptr[2*3] = <void*>_func_clngamma_wrap
-ufunc__gammaln_ptr[2*3+1] = <void*>(<char*>"_gammaln")
-ufunc__gammaln_data[0] = &ufunc__gammaln_ptr[2*0]
-ufunc__gammaln_data[1] = &ufunc__gammaln_ptr[2*1]
-ufunc__gammaln_data[2] = &ufunc__gammaln_ptr[2*2]
-ufunc__gammaln_data[3] = &ufunc__gammaln_ptr[2*3]
-_gammaln = np.PyUFunc_FromFuncAndData(ufunc__gammaln_loops, ufunc__gammaln_data, ufunc__gammaln_types, 4, 1, 1, 0, "_gammaln", ufunc__gammaln_doc, 0)
 
 cdef np.PyUFuncGenericFunction ufunc__igam_fac_loops[2]
 cdef void *ufunc__igam_fac_ptr[4]
@@ -6565,6 +6531,49 @@ ufunc_gammaincinv_ptr[2*1+1] = <void*>(<char*>"gammaincinv")
 ufunc_gammaincinv_data[0] = &ufunc_gammaincinv_ptr[2*0]
 ufunc_gammaincinv_data[1] = &ufunc_gammaincinv_ptr[2*1]
 gammaincinv = np.PyUFunc_FromFuncAndData(ufunc_gammaincinv_loops, ufunc_gammaincinv_data, ufunc_gammaincinv_types, 2, 2, 1, 0, "gammaincinv", ufunc_gammaincinv_doc, 0)
+
+cdef np.PyUFuncGenericFunction ufunc_gammaln_loops[2]
+cdef void *ufunc_gammaln_ptr[4]
+cdef void *ufunc_gammaln_data[2]
+cdef char ufunc_gammaln_types[4]
+cdef char *ufunc_gammaln_doc = (
+    "Logarithm of the absolute value of the Gamma function.\n"
+    "\n"
+    "Parameters\n"
+    "----------\n"
+    "x : array-like\n"
+    "    Values on the real line at which to compute ``gammaln``\n"
+    "\n"
+    "Returns\n"
+    "-------\n"
+    "gammaln : ndarray\n"
+    "    Values of ``gammaln`` at x.\n"
+    "\n"
+    "See Also\n"
+    "--------\n"
+    "gammasgn : sign of the gamma function\n"
+    "loggamma : principal branch of the logarithm of the gamma function\n"
+    "\n"
+    "Notes\n"
+    "-----\n"
+    "When used in conjunction with `gammasgn`, this function is useful\n"
+    "for working in logspace on the real axis without having to deal with\n"
+    "complex numbers, via the relation ``exp(gammaln(x)) = gammasgn(x)*gamma(x)``.\n"
+    "\n"
+    "For complex-valued log-gamma, use `loggamma` instead of `gammaln`.")
+ufunc_gammaln_loops[0] = <np.PyUFuncGenericFunction>loop_d_d__As_f_f
+ufunc_gammaln_loops[1] = <np.PyUFuncGenericFunction>loop_d_d__As_d_d
+ufunc_gammaln_types[0] = <char>NPY_FLOAT
+ufunc_gammaln_types[1] = <char>NPY_FLOAT
+ufunc_gammaln_types[2] = <char>NPY_DOUBLE
+ufunc_gammaln_types[3] = <char>NPY_DOUBLE
+ufunc_gammaln_ptr[2*0] = <void*>_func_lgam
+ufunc_gammaln_ptr[2*0+1] = <void*>(<char*>"gammaln")
+ufunc_gammaln_ptr[2*1] = <void*>_func_lgam
+ufunc_gammaln_ptr[2*1+1] = <void*>(<char*>"gammaln")
+ufunc_gammaln_data[0] = &ufunc_gammaln_ptr[2*0]
+ufunc_gammaln_data[1] = &ufunc_gammaln_ptr[2*1]
+gammaln = np.PyUFunc_FromFuncAndData(ufunc_gammaln_loops, ufunc_gammaln_data, ufunc_gammaln_types, 2, 1, 1, 0, "gammaln", ufunc_gammaln_doc, 0)
 
 cdef np.PyUFuncGenericFunction ufunc_gammasgn_loops[2]
 cdef void *ufunc_gammasgn_ptr[4]

--- a/scipy/special/_ufuncs_defs.h
+++ b/scipy/special/_ufuncs_defs.h
@@ -1,9 +1,6 @@
 #ifndef UFUNCS_PROTO_H
 #define UFUNCS_PROTO_H 1
 #include "cephes.h"
-npy_double lgam(npy_double);
-#include "specfun_wrappers.h"
-npy_cdouble clngamma_wrap(npy_cdouble);
 npy_double igam_fac(npy_double, npy_double);
 npy_double lanczos_sum_expg_scaled(npy_double);
 npy_double lgam1p(npy_double);
@@ -24,6 +21,7 @@ npy_double bdtri(npy_int, npy_int, npy_double);
 #include "cdf_wrappers.h"
 npy_double cdfbin2_wrap(npy_double, npy_double, npy_double);
 npy_double cdfbin3_wrap(npy_double, npy_double, npy_double);
+#include "specfun_wrappers.h"
 npy_double bei_wrap(npy_double);
 npy_double beip_wrap(npy_double);
 npy_double ber_wrap(npy_double);
@@ -79,6 +77,7 @@ npy_double igam(npy_double, npy_double);
 npy_double igamc(npy_double, npy_double);
 npy_double igami(npy_double, npy_double);
 npy_double gammaincinv(npy_double, npy_double);
+npy_double lgam(npy_double);
 npy_double gammasgn(npy_double);
 npy_double gdtr(npy_double, npy_double, npy_double);
 npy_double gdtrc(npy_double, npy_double, npy_double);

--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -2538,9 +2538,32 @@ add_newdoc("scipy.special", "gammaincinv",
     Returns `x` such that ``gammainc(a, x) = y``.
     """)
 
-add_newdoc("scipy.special", "_gammaln",
+add_newdoc("scipy.special", "gammaln",
     """
-    Internal function, use ``gammaln`` instead.
+    Logarithm of the absolute value of the Gamma function.
+
+    Parameters
+    ----------
+    x : array-like
+        Values on the real line at which to compute ``gammaln``
+
+    Returns
+    -------
+    gammaln : ndarray
+        Values of ``gammaln`` at x.
+
+    See Also
+    --------
+    gammasgn : sign of the gamma function
+    loggamma : principal branch of the logarithm of the gamma function
+
+    Notes
+    -----
+    When used in conjunction with `gammasgn`, this function is useful
+    for working in logspace on the real axis without having to deal with
+    complex numbers, via the relation ``exp(gammaln(x)) = gammasgn(x)*gamma(x)``.
+
+    For complex-valued log-gamma, use `loggamma` instead of `gammaln`.
     """)
 
 add_newdoc("scipy.special", "gammasgn",

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -14,8 +14,8 @@ from numpy import (pi, asarray, floor, isscalar, iscomplex, real,
                    extract, less, inexact, nan, zeros, sinc)
 from . import _ufuncs as ufuncs
 from ._ufuncs import (ellipkm1, mathieu_a, mathieu_b, iv, jv, gamma,
-                      psi, _zeta, hankel1, hankel2, yv, kv, _gammaln,
-                      ndtri, poch, binom, hyp0f1)
+                      psi, _zeta, hankel1, hankel2, yv, kv, ndtri,
+                      poch, binom, hyp0f1)
 from . import specfun
 from . import orthogonal
 from ._comb import _comb_int
@@ -26,7 +26,7 @@ __all__ = ['agm', 'ai_zeros', 'assoc_laguerre', 'bei_zeros', 'beip_zeros',
            'bi_zeros', 'clpmn', 'comb', 'digamma', 'diric', 'ellipk',
            'erf_zeros', 'erfcinv', 'erfinv', 'euler', 'factorial',
            'factorialk', 'factorial2', 'fresnel_zeros',
-           'fresnelc_zeros', 'fresnels_zeros', 'gamma', 'gammaln', 'h1vp',
+           'fresnelc_zeros', 'fresnels_zeros', 'gamma', 'h1vp',
            'h2vp', 'hankel1', 'hankel2', 'hyp0f1', 'iv', 'ivp', 'jn_zeros',
            'jnjnp_zeros', 'jnp_zeros', 'jnyn_zeros', 'jv', 'jvp', 'kei_zeros',
            'keip_zeros', 'kelvin_zeros', 'ker_zeros', 'kerp_zeros', 'kv',
@@ -138,47 +138,6 @@ def diric(x, n):
     dsub = extract(mask, denom)
     place(y, mask, sin(nsub*xsub)/(nsub*dsub))
     return y
-
-
-def gammaln(x):
-    """
-    Logarithm of the absolute value of the Gamma function for real inputs.
-
-    Parameters
-    ----------
-    x : array-like
-        Values on the real line at which to compute ``gammaln``
-
-    Returns
-    -------
-    gammaln : ndarray
-        Values of ``gammaln`` at x.
-
-    See Also
-    --------
-    gammasgn : sign of the gamma function
-    loggamma : principal branch of the logarithm of the gamma function
-
-    Notes
-    -----
-    When used in conjunction with `gammasgn`, this function is useful
-    for working in logspace on the real axis without having to deal with
-    complex numbers, via the relation ``exp(gammaln(x)) = gammasgn(x)*gamma(x)``.
-
-    Note that `gammaln` currently accepts complex-valued inputs, but it is not
-    the same function as for real-valued inputs, and the branch is not
-    well-defined --- using `gammaln` with complex is deprecated and will be
-    disallowed in future Scipy versions.
-
-    For complex-valued log-gamma, use `loggamma` instead of `gammaln`.
-
-    """
-    if np.iscomplexobj(x):
-        warnings.warn(("Use of gammaln for complex arguments is "
-                       "deprecated as of scipy 0.18.0. Use "
-                       "scipy.special.loggamma instead."),
-                      DeprecationWarning)
-    return _gammaln(x)
 
 
 def jnjnp_zeros(nt):

--- a/scipy/special/cython_special.pxd
+++ b/scipy/special/cython_special.pxd
@@ -93,6 +93,7 @@ cpdef double gammainc(double x0, double x1) nogil
 cpdef double gammaincc(double x0, double x1) nogil
 cpdef double gammainccinv(double x0, double x1) nogil
 cpdef double gammaincinv(double x0, double x1) nogil
+cpdef double gammaln(double x0) nogil
 cpdef double gammasgn(double x0) nogil
 cpdef double gdtr(double x0, double x1, double x2) nogil
 cpdef double gdtrc(double x0, double x1, double x2) nogil

--- a/scipy/special/cython_special.pyx
+++ b/scipy/special/cython_special.pyx
@@ -391,6 +391,10 @@ Available Functions
 
         double gammaincinv(double, double)
 
+- :py:func:`~scipy.special.gammaln`::
+
+        double gammaln(double)
+
 - :py:func:`~scipy.special.gammasgn`::
 
         double gammasgn(double)
@@ -1263,6 +1267,8 @@ cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_igami "igami"(npy_double, npy_double)nogil
 cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_gammaincinv "gammaincinv"(npy_double, npy_double)nogil
+cdef extern from "_ufuncs_defs.h":
+    cdef npy_double _func_lgam "lgam"(npy_double)nogil
 cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_gammasgn "gammasgn"(npy_double)nogil
 cdef extern from "_ufuncs_defs.h":
@@ -2272,6 +2278,10 @@ cpdef double gammainccinv(double x0, double x1) nogil:
 cpdef double gammaincinv(double x0, double x1) nogil:
     """See the documentation for scipy.special.gammaincinv"""
     return _func_gammaincinv(x0, x1)
+
+cpdef double gammaln(double x0) nogil:
+    """See the documentation for scipy.special.gammaln"""
+    return _func_lgam(x0)
 
 cpdef double gammasgn(double x0) nogil:
     """See the documentation for scipy.special.gammasgn"""

--- a/scipy/special/generate_ufuncs.py
+++ b/scipy/special/generate_ufuncs.py
@@ -139,7 +139,7 @@ eval_hermitenorm -- eval_hermitenorm: ld->d                -- orthogonal_eval.px
 exp10 -- exp10: d->d                                       -- cephes.h
 exp2 -- exp2: d->d                                         -- cephes.h
 gamma -- Gamma: d->d, cgamma: D->D                         -- cephes.h, _loggamma.pxd
-_gammaln -- lgam: d->d, clngamma_wrap: D->D                -- cephes.h, specfun_wrappers.h
+gammaln -- lgam: d->d                                      -- cephes.h
 gammasgn -- gammasgn: d->d                                 -- c_misc/misc.h
 i0 -- i0: d->d                                             -- cephes.h
 i0e -- i0e: d->d                                           -- cephes.h

--- a/scipy/special/specfun_wrappers.c
+++ b/scipy/special/specfun_wrappers.c
@@ -69,14 +69,6 @@ extern void F_FUNC(ffk,FFK)(int*,double*,double*,double*,double*,double*,double*
 /* This must be linked with fortran
  */
 
-npy_cdouble clngamma_wrap( npy_cdouble z) {
-  int kf = 0;
-  npy_cdouble cy;
-
-  F_FUNC(cgama,CGAMA)(CADDR(z), &kf, CADDR(cy));
-  return cy;
-}
-
 npy_cdouble chyp2f1_wrap( double a, double b, double c, npy_cdouble z) {
   npy_cdouble outz;
   int l1, l0, isfer = 0;

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -154,7 +154,7 @@ class TestCephes(TestCase):
 
     def test_betaln(self):
         assert_equal(cephes.betaln(1,1),0.0)
-        assert_allclose(cephes.betaln(-100.3, 1e-200), cephes._gammaln(1e-200))
+        assert_allclose(cephes.betaln(-100.3, 1e-200), cephes.gammaln(1e-200))
         assert_allclose(cephes.betaln(0.0342, 170), 3.1811881124242447,
                         rtol=1e-14, atol=0)
 
@@ -377,7 +377,7 @@ class TestCephes(TestCase):
         assert_equal(cephes.gammainccinv(5,1),0.0)
 
     def test_gammaln(self):
-        cephes._gammaln(10)
+        cephes.gammaln(10)
 
     def test_gammasgn(self):
         vals = np.array([-4, -3.5, -2.3, 1, 4.2], np.float64)

--- a/scipy/special/tests/test_cython_special.py
+++ b/scipy/special/tests/test_cython_special.py
@@ -134,6 +134,7 @@ def test_cython_api():
         (special.gammaincc, cython_special.gammaincc, ('dd',), None),
         (special.gammainccinv, cython_special.gammainccinv, ('dd',), None),
         (special.gammaincinv, cython_special.gammaincinv, ('dd',), None),
+        (special.gammaln, cython_special.gammaln, ('d',), None),
         (special.gammasgn, cython_special.gammasgn, ('d',), None),
         (special.gdtr, cython_special.gdtr, ('ddd',), None),
         (special.gdtrc, cython_special.gdtrc, ('ddd',), None),


### PR DESCRIPTION
Using complex arguments for `gammaln` has now been deprecated for two
releases (0.18 and 0.19), so it is time to remove the complex
version. This also allows the function to be in `cython_special`.