### PR TITLE
DOC: fix docstring of NearestNDInterpolator

### DIFF
--- a/scipy/interpolate/ndgriddata.py
+++ b/scipy/interpolate/ndgriddata.py
@@ -21,7 +21,7 @@ __all__ = ['griddata', 'NearestNDInterpolator', 'LinearNDInterpolator',
 
 class NearestNDInterpolator(NDInterpolatorBase):
     """
-    NearestNDInterpolator(points, values)
+    NearestNDInterpolator(x, y)
 
     Nearest-neighbour interpolation in N dimensions.
 


### PR DESCRIPTION
(cherry picked from commit 7b01873b3c895a25a5cb81beced27bf8b4538aea)

[ci skip]

forward port of gh-7146, which I mistakenly merged into 0.18.x