### PR TITLE
BUG: special: fix sign of derivative when `x < 0` in `pbwa'

### DIFF
--- a/scipy/special/specfun_wrappers.c
+++ b/scipy/special/specfun_wrappers.c
@@ -679,18 +679,22 @@ double pmv_wrap(double m, double v, double x){
 }
 
 
-/* if x > 0 return w1f and w1d.
-    otherwise return w2f and w2d (after abs(x))
+/* 
+ * If x > 0 return w1f and w1d. Otherwise set x = abs(x) and return
+ * w2f and -w2d.
 */
 int pbwa_wrap(double a, double x, double *wf, double *wd) {
   int flag = 0;
   double w1f, w1d, w2f, w2d;
    
-  if (x < 0) {x=-x; flag=1;}
+  if (x < 0) {
+    x = -x;
+    flag=1;
+  }
   F_FUNC(pbwa,PBWA)(&a, &x, &w1f, &w1d, &w2f, &w2d);
   if (flag) {
     *wf = w2f;
-    *wd = w2d;
+    *wd = -w2d;
   }
   else {
     *wf = w1f;

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -1700,13 +1700,25 @@ class TestSystematic(with_metaclass(DecoratorMeta, object)):
                             lambda v, x: time_limited()(exception_to_nan(mpmath.pcfv))(v, x, **HYPERKW),
                             [Arg(), Arg()], n=1000)
 
-    @knownfailure_overridable()
     def test_pcfw(self):
         def pcfw(a, x):
             return sc.pbwa(a, x)[0]
+
+        def dpcfw(a, x):
+            return sc.pbwa(a, x)[1]
+
+        def mpmath_dpcfw(a, x):
+            return mpmath.diff(mpmath.pcfw, (a, x), (0, 1))
+
+        # The Zhang and Jin implementation only uses Taylor series and
+        # is thus accurate in only a very small range.
         assert_mpmath_equal(pcfw,
-                            lambda v, x: time_limited()(exception_to_nan(mpmath.pcfw))(v, x, **HYPERKW),
-                            [Arg(), Arg()], dps=50, n=1000)
+                            mpmath.pcfw,
+                            [Arg(-5, 5), Arg(-5, 5)], rtol=1e-12, n=100)
+
+        assert_mpmath_equal(dpcfw,
+                            mpmath_dpcfw,
+                            [Arg(-5, 5), Arg(-5, 5)], rtol=1e-12, n=100)
 
     @knownfailure_overridable("issues at large arguments (atol OK, rtol not) and <eps-close to z=0")
     def test_polygamma(self):


### PR DESCRIPTION
Closes gh-7133.

Also turn the mpmath tests back on and restrict them to the parameter ranges which the implementation is intended to be valid for.