### PR TITLE
ENH: optimize: changes to make BFGS implementation more efficient.

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -162,7 +162,7 @@ Bill Sacks for fixes to netcdf i/o.
 Kolja Glogowski for a bug fix in scipy.special.
 Surhud More for enhancing scipy.optimize.curve_fit to accept covariant errors
 on data.
-Antonio Ribeiro for implementing irrnotch and iirpeak functions.
+Antonio Ribeiro for irrnotch and iirpeak functions and improvements on BFGS method.
 Ilhan Polat for bug fixes on Riccati solvers.
 Sebastiano Vigna for code in the stats package related to Kendall's tau.
 John Draper for bug fixes.

--- a/doc/source/tutorial/optimize.rst
+++ b/doc/source/tutorial/optimize.rst
@@ -137,9 +137,9 @@ through the ``jac`` parameter as illustrated below.
     ...                options={'disp': True})
     Optimization terminated successfully.
              Current function value: 0.000000
-             Iterations: 51                     # may vary
-             Function evaluations: 63
-             Gradient evaluations: 63
+             Iterations: 32                     # may vary
+             Function evaluations: 34
+             Gradient evaluations: 34
     >>> res.x
     array([1., 1., 1., 1., 1.])
 

--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -313,9 +313,9 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
     ...                options={'gtol': 1e-6, 'disp': True})
     Optimization terminated successfully.
              Current function value: 0.000000
-             Iterations: 26
-             Function evaluations: 31
-             Gradient evaluations: 31
+             Iterations: 33
+             Function evaluations: 35
+             Gradient evaluations: 35
     >>> res.x
     array([ 1.,  1.,  1.,  1.,  1.])
     >>> print(res.message)

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -148,14 +148,14 @@ class CheckOptimizeParameterized(CheckOptimize):
                         atol=1e-6)
 
         # Ensure that function call counts are 'known good'; these are from
-        # Scipy 0.7.0. Don't allow them to increase.
-        assert_(self.funccalls == 10, self.funccalls)
-        assert_(self.gradcalls == 8, self.gradcalls)
+        # Scipy 1.0.0. Don't allow them to increase.
+        assert_(self.funccalls == 9, self.funccalls)
+        assert_(self.gradcalls == 7, self.gradcalls)
 
-        # Ensure that the function behaves the same; this is from Scipy 0.7.0
+        # Ensure that the function behaves the same; this is from Scipy 1.0.0
         assert_allclose(self.trace[6:8],
-                        [[0, -5.25060743e-01, 4.87748473e-01],
-                         [0, -5.24885582e-01, 4.87530347e-01]],
+                        [[7.323472e-15, -5.248650e-01, 4.875251e-01],
+                         [7.323472e-15, -5.248650e-01, 4.875251e-01]],
                         atol=1e-14, rtol=1e-7)
 
     @suppressed_stdout


### PR DESCRIPTION
I was browsing `scipy.optimize` files and realised that the BFGS implementation is not implemented in the most possible efficient way. I made three modifications to make it more efficient:
1) The current implementation uses the following formula to update the hessian inverse:
![screenshot 2017-03-12 17 19 05](https://cloud.githubusercontent.com/assets/16557411/23835620/587f26dc-0749-11e7-86ad-6ce27f06a4c0.png)
which I changed to:
![screenshot 2017-03-12 17 19 10](https://cloud.githubusercontent.com/assets/16557411/23835626/64b1cd6a-0749-11e7-974a-de80a11c95fd.png)
Both formulas produce the same results and one can be manipulated to get the other. However, while the first implements a matrix multiplication, requiring `O(n^3)` operations, the second uses only `O(n^2)` operations. Making the second a better choice for implementation
2) I am using BLAS function in order to explore the Hessian symmetry. This way the matrix operations are two times more efficient.
3) I am using the heuristic described in p.143, formula (6.20), Nocedal/Wright book to get a better initial guess for the inverse hessian `H_k`. 

In order to evaluate the effect of items (1) and (2), I have written the following [jupiter notebook](https://gist.github.com/antonior92/5c06cee871006ef4e91ef4f0d13314ba), that compare the update of `H_k` with and without the modifications (1) and (2). I have two different computers and the time results are very different depending on each I am running the tests (I think it is because of different numpy configurations). Nevertheless, the modifications (1) and (2) make the calculation of the hessian much faster for every case I have tested.

The modification (3) cause a reduction in the number of iterations for some benchmarks (``beale`` benchmark) and a increase for others (``rosenbrock`` benchmark):

![screenshot 2017-03-12 20 13 55](https://cloud.githubusercontent.com/assets/16557411/23837044/87f16ff8-0760-11e7-9f02-9adc197b547e.png)