### PR TITLE
BUG: Prevent infinite loop in optimize._lsq.trf_linear.py

### DIFF
--- a/scipy/optimize/_lsq/trf_linear.py
+++ b/scipy/optimize/_lsq/trf_linear.py
@@ -78,6 +78,7 @@ def backtracking(A, g, x, p, theta, p_dot_g, lb, ub):
         cost_change = -evaluate_quadratic(A, g, step)
         if cost_change > -0.1 * alpha * p_dot_g:
             break
+        alpha *= 0.5
 
     active = find_active_constraints(x_new, lb, ub)
     if np.any(active != 0):


### PR DESCRIPTION
Just noticed an obvious error in code which is unlikely to be executed often (if at all). So yes, it's untested code, but again it's very hard to trigger it. With the fix it should be pretty safe.

I will merge it in few days myself, unless someone really wants to dig deeper into this problem.