### PR TITLE
BUG: sparse: return a numpy matrix from _add_dense

### DIFF
--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -501,7 +501,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
         M, N = self.shape
         coo_todense(M, N, self.nnz, self.row, self.col, self.data,
                     result.ravel('A'), fortran)
-        return result
+        return np.matrix(result, copy=False)
 
     def _mul_vector(self, other):
         #output array


### PR DESCRIPTION
gh-7079 inadvertently changed the result type for all sparse + dense operations to ndarray instead of np.matrix. Unfortunately, that's a backwards-incompatible change, so I'm fixing it now.