### PR TITLE
Allow homogeneous coordinate transforms in affine_transform

### DIFF
--- a/scipy/ndimage/interpolation.py
+++ b/scipy/ndimage/interpolation.py
@@ -364,36 +364,33 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None,
     """
     Apply an affine transformation.
 
-    The given matrix and offset are used to find for each point in the
-    output the corresponding coordinates in the input by an affine
-    transformation. The value of the input at those coordinates is
-    determined by spline interpolation of the requested order. Points
-    outside the boundaries of the input are filled according to the given
-    mode.
-
     Given an output image pixel index vector ``o``, the pixel value
-    is determined from the input image at position ``np.dot(matrix,o) + offset``.
-
-    A diagonal matrix can be specified by supplying a one-dimensional
-    array-like to the matrix parameter, in which case a more efficient
-    algorithm is applied.
-
-    .. versionchanged:: 0.18.0
-        Previously, the exact interpretation of the affine transformation
-        depended on whether the matrix was supplied as a one-dimensional or
-        two-dimensional array. If a one-dimensional array was supplied
-        to the matrix parameter, the output pixel value at index ``o``
-        was determined from the input image at position ``matrix * (o + offset)``.
+    is determined from the input image at position
+    ``np.dot(matrix, o) + offset``.
 
     Parameters
     ----------
     input : ndarray
         The input array.
     matrix : ndarray
-        The matrix must be two-dimensional or can also be given as a
-        one-dimensional sequence or array. In the latter case, it is assumed
-        that the matrix is diagonal. A more efficient algorithm is then
-        applied that exploits the separability of the problem.
+        The inverse coordinate transformation matrix, mapping output
+        coordinates to input coordinates. If ``ndim`` is the number of
+        dimensions of ``input``, the given matrix must have one of the
+        following shapes:
+
+            - ``(ndim, ndim)``: the linear transformation matrix for each
+              output coordinate.
+            - ``(ndim,)``: assume that the 2D transformation matrix is
+              diagonal, with the diagonal specified by the given value. A more
+              efficient algorithm is then used that exploits the separability
+              of the problem.
+            - ``(ndim + 1, ndim + 1)``: assume that the transformation is
+              specified using homogeneous coordinates [1]_. In this case, any
+              value passed to ``offset`` is ignored.
+            - ``(ndim, ndim + 1)``: as above, but the bottom row of a
+              homogeneous transformation matrix is always ``[0, 0, ..., 1]``,
+              and may be omitted.
+
     offset : float or sequence, optional
         The offset into the array where the transform is applied. If a float,
         `offset` is the same for each axis. If a sequence, `offset` should
@@ -408,7 +405,8 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None,
         The order has to be in the range 0-5.
     mode : str, optional
         Points outside the boundaries of the input are filled according
-        to the given mode ('constant', 'nearest', 'reflect', 'mirror' or 'wrap').
+        to the given mode ('constant', 'nearest', 'reflect', 'mirror' or
+        'wrap').
         Default is 'constant'.
     cval : scalar, optional
         Value used for points outside the boundaries of the input if
@@ -425,6 +423,26 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None,
         The transformed input. If `output` is given as a parameter, None is
         returned.
 
+    Notes
+    -----
+    The given matrix and offset are used to find for each point in the
+    output the corresponding coordinates in the input by an affine
+    transformation. The value of the input at those coordinates is
+    determined by spline interpolation of the requested order. Points
+    outside the boundaries of the input are filled according to the given
+    mode.
+
+    .. versionchanged:: 0.18.0
+        Previously, the exact interpretation of the affine transformation
+        depended on whether the matrix was supplied as a one-dimensional or
+        two-dimensional array. If a one-dimensional array was supplied
+        to the matrix parameter, the output pixel value at index ``o``
+        was determined from the input image at position
+        ``matrix * (o + offset)``.
+
+    References
+    ----------
+    .. [1] https://en.wikipedia.org/wiki/Homogeneous_coordinates
     """
     if order < 0 or order > 5:
         raise RuntimeError('spline order not supported')

--- a/scipy/ndimage/interpolation.py
+++ b/scipy/ndimage/interpolation.py
@@ -445,6 +445,11 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None,
     matrix = numpy.asarray(matrix, dtype=numpy.float64)
     if matrix.ndim not in [1, 2] or matrix.shape[0] < 1:
         raise RuntimeError('no proper affine matrix provided')
+    if (matrix.ndim == 2 and matrix.shape[1] == input.ndim + 1 and
+            (matrix.shape[0] in [input.ndim, input.ndim + 1])):
+        # assume input is homogeneous coordinate transformation matrix
+        offset = matrix[:input.ndim, input.ndim]
+        matrix = matrix[:input.ndim, :input.ndim]
     if matrix.shape[0] != input.ndim:
         raise RuntimeError('affine matrix has wrong number of rows')
     if matrix.ndim == 2 and matrix.shape[1] != output.ndim:

--- a/scipy/ndimage/interpolation.py
+++ b/scipy/ndimage/interpolation.py
@@ -449,7 +449,7 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None,
             (matrix.shape[0] in [input.ndim, input.ndim + 1])):
         if matrix.shape[0] == input.ndim + 1:
             exptd = [0] * input.ndim + [1]
-            if not np.all(matrix[input.ndim] == exptd):
+            if not numpy.all(matrix[input.ndim] == exptd):
                 msg = ('Expected homogeneous transformation matrix with '
                        'shape %s for image shape %s, but bottom row was '
                        'not equal to %s' % (matrix.shape, input.shape, exptd))

--- a/scipy/ndimage/interpolation.py
+++ b/scipy/ndimage/interpolation.py
@@ -392,7 +392,7 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None,
     matrix : ndarray
         The matrix must be two-dimensional or can also be given as a
         one-dimensional sequence or array. In the latter case, it is assumed
-        that the matrix is diagonal. A more efficient algorithms is then
+        that the matrix is diagonal. A more efficient algorithm is then
         applied that exploits the separability of the problem.
     offset : float or sequence, optional
         The offset into the array where the transform is applied. If a float,

--- a/scipy/ndimage/interpolation.py
+++ b/scipy/ndimage/interpolation.py
@@ -447,6 +447,13 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None,
         raise RuntimeError('no proper affine matrix provided')
     if (matrix.ndim == 2 and matrix.shape[1] == input.ndim + 1 and
             (matrix.shape[0] in [input.ndim, input.ndim + 1])):
+        if matrix.shape[0] == input.ndim + 1:
+            exptd = [0] * input.ndim + [1]
+            if not np.all(matrix[input.ndim] == exptd):
+                msg = ('Expected homogeneous transformation matrix with '
+                       'shape %s for image shape %s, but bottom row was '
+                       'not equal to %s' % (matrix.shape, input.shape, exptd))
+                raise ValueError(msg)
         # assume input is homogeneous coordinate transformation matrix
         offset = matrix[:input.ndim, input.ndim]
         matrix = matrix[:input.ndim, :input.ndim]

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -2063,7 +2063,7 @@ class TestNdimage:
         tform_h1 = numpy.hstack((numpy.eye(2), -numpy.ones((2, 1))))
         tform_h2 = numpy.vstack((tform_h1, [[5, 2, 1]]))
         numpy.testing.assert_raises(ValueError,
-                                    ndimage.affine_transform, tform_h2)
+                                    ndimage.affine_transform, data, tform_h2)
 
     def test_shift01(self):
         data = numpy.array([1])

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -2055,6 +2055,16 @@ class TestNdimage:
                                                 [0, 4, 1, 3],
                                                 [0, 7, 6, 8]])
 
+    def test_affine_transform27(self):
+        # test valid homogeneous transformation matrix
+        data = numpy.array([[4, 1, 3, 2],
+                            [7, 6, 8, 5],
+                            [3, 5, 3, 6]])
+        tform_h1 = numpy.hstack((numpy.eye(2), -numpy.ones(2)))
+        tform_h2 = numpy.vstack((tform_h1, [5, 2, 1]))
+        numpy.testing.assert_raises(ValueError,
+                                    ndimage.affine_transform, tform_h2)
+
     def test_shift01(self):
         data = numpy.array([1])
         for order in range(0, 6):

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -2040,12 +2040,12 @@ class TestNdimage:
             else:
                 filtered = data
             tform_original = numpy.eye(2)
-            offset_original = -numpy.ones(2)
+            offset_original = -numpy.ones((2, 1))
             tform_h1 = numpy.hstack((tform_original, offset_original))
-            tform_h2 = numpy.vstack((tform_h1, [0, 0, 1]))
+            tform_h2 = numpy.vstack((tform_h1, [[0, 0, 1]]))
             out1 = ndimage.affine_transform(filtered, tform_original,
-                                            offset_original, order=order,
-                                            prefilter=False)
+                                            offset_original.ravel(),
+                                            order=order, prefilter=False)
             out2 = ndimage.affine_transform(filtered, tform_h1, order=order,
                                             prefilter=False)
             out3 = ndimage.affine_transform(filtered, tform_h2, order=order,
@@ -2060,8 +2060,8 @@ class TestNdimage:
         data = numpy.array([[4, 1, 3, 2],
                             [7, 6, 8, 5],
                             [3, 5, 3, 6]])
-        tform_h1 = numpy.hstack((numpy.eye(2), -numpy.ones(2)))
-        tform_h2 = numpy.vstack((tform_h1, [5, 2, 1]))
+        tform_h1 = numpy.hstack((numpy.eye(2), -numpy.ones((2, 1))))
+        tform_h2 = numpy.vstack((tform_h1, [[5, 2, 1]]))
         numpy.testing.assert_raises(ValueError,
                                     ndimage.affine_transform, tform_h2)
 

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -2039,10 +2039,10 @@ class TestNdimage:
                 filtered = ndimage.spline_filter(data, order=order)
             else:
                 filtered = data
-            tform_original = np.eye(2)
-            offset_original = -np.ones(2)
-            tform_h1 = np.hstack((tform_original, offset_original))
-            tform_h2 = np.vstack((tform_h1, [0, 0, 1]))
+            tform_original = numpy.eye(2)
+            offset_original = -numpy.ones(2)
+            tform_h1 = numpy.hstack((tform_original, offset_original))
+            tform_h2 = numpy.vstack((tform_h1, [0, 0, 1]))
             out1 = ndimage.affine_transform(filtered, tform_original,
                                             offset_original, order=order,
                                             prefilter=False)

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -2029,6 +2029,32 @@ class TestNdimage:
                                                 order=order)
             assert_array_almost_equal(out1, out2)
 
+    def test_affine_transform26(self):
+        # test homogeneous coordinates
+        data = numpy.array([[4, 1, 3, 2],
+                            [7, 6, 8, 5],
+                            [3, 5, 3, 6]])
+        for order in range(0, 6):
+            if (order > 1):
+                filtered = ndimage.spline_filter(data, order=order)
+            else:
+                filtered = data
+            tform_original = np.eye(2)
+            offset_original = -np.ones(2)
+            tform_h1 = np.hstack((tform_original, offset_original))
+            tform_h2 = np.vstack((tform_h1, [0, 0, 1]))
+            out1 = ndimage.affine_transform(filtered, tform_original,
+                                            offset_original, order=order,
+                                            prefilter=False)
+            out2 = ndimage.affine_transform(filtered, tform_h1, order=order,
+                                            prefilter=False)
+            out3 = ndimage.affine_transform(filtered, tform_h2, order=order,
+                                            prefilter=False)
+            for out in [out1, out2, out3]:
+                assert_array_almost_equal(out, [[0, 0, 0, 0],
+                                                [0, 4, 1, 3],
+                                                [0, 7, 6, 8]])
+
     def test_shift01(self):
         data = numpy.array([1])
         for order in range(0, 6):


### PR DESCRIPTION
There was some discussion in https://github.com/scipy/scipy/issues/2255#issuecomment-29190417 about including support for homogeneous coordinate transforms by detecting the shape of the transformation matrix as being 1 + the dimensionality of the image. This implements that change. Hopefully I haven't broken 50 things in the process. =P