### PR TITLE
MAINT: Remove hack modifying a readonly attr

### DIFF
--- a/scipy/special/orthogonal.py
+++ b/scipy/special/orthogonal.py
@@ -158,10 +158,12 @@ class orthopoly1d(np.poly1d):
         if p == 1.0:
             return
         try:
-            self._coeffs *= p
-        except ValueError:
-            # numpy < 1.13 raises ValueError on setting any property
+            self._coeffs
+        except AttributeError:
             self.__dict__['coeffs'] *= p
+        else:
+            # the coeffs attr is be made private in future versions of numpy
+            self._coeffs *= p
 
         evf = self._eval_func
         if evf:

--- a/scipy/special/orthogonal.py
+++ b/scipy/special/orthogonal.py
@@ -124,13 +124,8 @@ class orthopoly1d(np.poly1d):
 
     def __init__(self, roots, weights=None, hn=1.0, kn=1.0, wfunc=None,
                  limits=None, monic=False, eval_func=None):
-        np.poly1d.__init__(self, roots, r=1)
         equiv_weights = [weights[k] / wfunc(roots[k]) for
                          k in range(len(roots))]
-        self.__dict__['weights'] = np.array(list(zip(roots,
-                                                     weights, equiv_weights)))
-        self.__dict__['weight_func'] = wfunc
-        self.__dict__['limits'] = limits
         mu = sqrt(hn)
         if monic:
             evf = eval_func
@@ -138,8 +133,17 @@ class orthopoly1d(np.poly1d):
                 eval_func = lambda x: evf(x) / kn
             mu = mu / abs(kn)
             kn = 1.0
+            
+        # compute coefficients from roots, then scale
+        poly = np.poly1d(roots, r=True)
+        np.poly1d.__init__(self, poly.coeffs * float(kn))
+        
+        # TODO: In numpy 1.13, there is no need to use __dict__ to access attributes
+        self.__dict__['weights'] = np.array(list(zip(roots,
+                                                     weights, equiv_weights)))
+        self.__dict__['weight_func'] = wfunc
+        self.__dict__['limits'] = limits
         self.__dict__['normcoef'] = mu
-        self.__dict__['coeffs'] *= float(kn)
 
         # Note: eval_func will be discarded on arithmetic
         self.__dict__['_eval_func'] = eval_func

--- a/scipy/special/orthogonal.py
+++ b/scipy/special/orthogonal.py
@@ -157,8 +157,13 @@ class orthopoly1d(np.poly1d):
     def _scale(self, p):
         if p == 1.0:
             return
-        self.__dict__['coeffs'] *= p
-        evf = self.__dict__['_eval_func']
+        try:
+            self._coeffs *= p
+        except ValueError:
+            # numpy < 1.13 raises ValueError on setting any property
+            self.__dict__['coeffs'] *= p
+
+        evf = self._eval_func
         if evf:
             self.__dict__['_eval_func'] = lambda x: evf(x) * p
         self.__dict__['normcoef'] *= p


### PR DESCRIPTION
`coeffs` is clearly intended to be readonly. The previous code causes #7181.

This new version will work before and after that numpy change