### PR TITLE
MAINT: PPoly: improve error messages for wrong shape/axis

### DIFF
--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -661,8 +661,13 @@ class _PPolyBase(object):
             extrapolate = bool(extrapolate)
         self.extrapolate = extrapolate
 
+        if self.c.ndim < 2:
+            raise ValueError("Coefficients array must be at least "
+                             "2-dimensional.")
+
         if not (0 <= axis < self.c.ndim - 1):
-            raise ValueError("%s must be between 0 and %s" % (axis, c.ndim-1))
+            raise ValueError("axis=%s must be between 0 and %s" %
+                             (axis, self.c.ndim-1))
 
         self.axis = axis
         if axis != 0:

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -735,6 +735,11 @@ class TestPPolyCommon(TestCase):
         assert_raises(ValueError, PPoly, c, x)
         assert_raises(ValueError, BPoly, c, x)
 
+    def test_ctor_c(self):
+        # wrong shape: `c` must be at least 2-dimensional
+        with assert_raises(ValueError):
+            PPoly([1, 2], [0, 1])
+
     def test_extend(self):
         # Test adding new points to the piecewise polynomial
         np.random.seed(1234)


### PR DESCRIPTION
Before, `PPoly([1, 2], [0, 1])` would raise an AttributeError("list object does not have ndim attribute") because of `c.ndim` instead of `self.c.ndim`

While I'm at it, also improve a slightly cryptic error message emitted for a wrong axis, e.g. `0 must be between 0 and 0`.