### PR TITLE
DOC: Added docstrings to issparse/isspmatrix(_...) methods and added examples to scipy.sparse methods

### DIFF
--- a/scipy/sparse/_matrix_io.py
+++ b/scipy/sparse/_matrix_io.py
@@ -86,6 +86,29 @@ def load_npz(file):
     --------
     scipy.sparse.save_npz: Save a sparse matrix to a file using ``.npz`` format.
     numpy.load: Load several arrays from a ``.npz`` archive.
+
+    Examples
+    --------
+    Store sparse matrix to disk, and load it again:
+
+    >>> import scipy.sparse
+    >>> sparse_matrix = scipy.sparse.csc_matrix(np.array([[0, 0, 3], [4, 0, 0]]))
+    >>> sparse_matrix
+    <2x3 sparse matrix of type '<type 'numpy.int64'>'
+       with 2 stored elements in Compressed Sparse Column format>
+    >>> sparse_matrix.todense()
+    matrix([[0, 0, 3],
+            [4, 0, 0]], dtype=int64)
+
+    >>> scipy.sparse.save_npz('/tmp/sparse_matrix.npz', sparse_matrix)
+    >>> sparse_matrix = scipy.sparse.load_npz('/tmp/sparse_matrix.npz')
+
+    >>> sparse_matrix
+    <2x3 sparse matrix of type '<type 'numpy.int64'>'
+        with 2 stored elements in Compressed Sparse Column format>
+    >>> sparse_matrix.todense()
+    matrix([[0, 0, 3],
+            [4, 0, 0]], dtype=int64)
     """
 
     loaded = np.load(file)

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -1161,6 +1161,32 @@ class spmatrix(object):
 
 
 def isspmatrix(x):
+    """Is x of a sparse matrix type?
+
+    Parameters
+    ----------
+    x
+        object to check for being a sparse matrix
+
+    Returns
+    -------
+    bool
+        True if x is a sparse matrix, False otherwise
+
+    Notes
+    -----
+    issparse and isspmatrix are aliases for the same function.
+
+    Examples
+    --------
+    >>> from scipy.sparse import csr_matrix, isspmatrix
+    >>> isspmatrix(csr_matrix([[5]]))
+    True
+
+    >>> from scipy.sparse import isspmatrix
+    >>> isspmatrix(5)
+    False
+    """
     return isinstance(x, spmatrix)
 
 issparse = isspmatrix

--- a/scipy/sparse/bsr.py
+++ b/scipy/sparse/bsr.py
@@ -665,4 +665,26 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
 
 
 def isspmatrix_bsr(x):
+    """Is x of a bsr_matrix type?
+
+    Parameters
+    ----------
+    x
+        object to check for being a bsr matrix
+
+    Returns
+    -------
+    bool
+        True if x is a bsr matrix, False otherwise
+
+    Examples
+    --------
+    >>> from scipy.sparse import bsr_matrix, isspmatrix_bsr
+    >>> isspmatrix_bsr(bsr_matrix([[5]]))
+    True
+
+    >>> from scipy.sparse import bsr_matrix, csr_matrix, isspmatrix_bsr
+    >>> isspmatrix_bsr(csr_matrix([[5]]))
+    False
+    """
     return isinstance(x, bsr_matrix)

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -700,6 +700,10 @@ def random(m, n, density=0.01, format='coo', dtype=None,
         sampled using the same random state as is used for sampling
         the sparsity structure.
 
+    Returns
+    -------
+    res : sparse matrix
+
     Examples
     --------
     >>> from scipy.sparse import random
@@ -787,9 +791,29 @@ def rand(m, n, density=0.01, format="coo", dtype=None, random_state=None):
         Random number generator or random seed. If not given, the singleton
         numpy.random will be used.
 
+    Returns
+    -------
+    res : sparse matrix
+
     Notes
     -----
     Only float types are supported for now.
 
+    See Also
+    --------
+    scipy.sparse.random : Similar function that allows a user-specified random
+        data source.
+
+    Examples
+    --------
+    >>> from scipy.sparse import rand
+    >>> matrix = rand(3, 4, density=0.25, format="csr", random_state=42)
+    >>> matrix
+    <3x4 sparse matrix of type '<type 'numpy.float64'>'
+       with 3 stored elements in Compressed Sparse Row format>
+    >>> matrix.todense()
+    matrix([[ 0.        ,  0.59685016,  0.779691  ,  0.        ],
+            [ 0.        ,  0.        ,  0.        ,  0.44583275],
+            [ 0.        ,  0.        ,  0.        ,  0.        ]])
     """
     return random(m, n, density, format, dtype, random_state)

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -519,4 +519,26 @@ class coo_matrix(_data_matrix, _minmax_mixin):
 
 
 def isspmatrix_coo(x):
+    """Is x of coo_matrix type?
+
+    Parameters
+    ----------
+    x
+        object to check for being a coo matrix
+
+    Returns
+    -------
+    bool
+        True if x is a coo matrix, False otherwise
+
+    Examples
+    --------
+    >>> from scipy.sparse import coo_matrix, isspmatrix_coo
+    >>> isspmatrix_coo(coo_matrix([[5]]))
+    True
+
+    >>> from scipy.sparse import coo_matrix, csr_matrix, isspmatrix_coo
+    >>> isspmatrix_coo(csr_matrix([[5]]))
+    False
+    """
     return isinstance(x, coo_matrix)

--- a/scipy/sparse/csc.py
+++ b/scipy/sparse/csc.py
@@ -228,4 +228,26 @@ class csc_matrix(_cs_matrix, IndexMixin):
 
 
 def isspmatrix_csc(x):
+    """Is x of csc_matrix type?
+
+    Parameters
+    ----------
+    x
+        object to check for being a csc matrix
+
+    Returns
+    -------
+    bool
+        True if x is a csc matrix, False otherwise
+
+    Examples
+    --------
+    >>> from scipy.sparse import csc_matrix, isspmatrix_csc
+    >>> isspmatrix_csc(csc_matrix([[5]]))
+    True
+
+    >>> from scipy.sparse import csc_matrix, csr_matrix, isspmatrix_csc
+    >>> isspmatrix_csc(csr_matrix([[5]]))
+    False
+    """
     return isinstance(x, csc_matrix)

--- a/scipy/sparse/csr.py
+++ b/scipy/sparse/csr.py
@@ -464,4 +464,26 @@ class csr_matrix(_cs_matrix, IndexMixin):
 
 
 def isspmatrix_csr(x):
+    """Is x of csr_matrix type?
+
+    Parameters
+    ----------
+    x
+        object to check for being a csr matrix
+
+    Returns
+    -------
+    bool
+        True if x is a csr matrix, False otherwise
+
+    Examples
+    --------
+    >>> from scipy.sparse import csr_matrix, isspmatrix_csr
+    >>> isspmatrix_csr(csr_matrix([[5]]))
+    True
+
+    >>> from scipy.sparse import csc_matrix, csr_matrix, isspmatrix_csc
+    >>> isspmatrix_csr(csc_matrix([[5]]))
+    False
+    """
     return isinstance(x, csr_matrix)

--- a/scipy/sparse/dia.py
+++ b/scipy/sparse/dia.py
@@ -375,4 +375,26 @@ class dia_matrix(_data_matrix):
 
 
 def isspmatrix_dia(x):
+    """Is x of dia_matrix type?
+
+    Parameters
+    ----------
+    x
+        object to check for being a dia matrix
+
+    Returns
+    -------
+    bool
+        True if x is a dia matrix, False otherwise
+
+    Examples
+    --------
+    >>> from scipy.sparse import dia_matrix, isspmatrix_dia
+    >>> isspmatrix_dia(dia_matrix([[5]]))
+    True
+
+    >>> from scipy.sparse import dia_matrix, csr_matrix, isspmatrix_dia
+    >>> isspmatrix_dia(csr_matrix([[5]]))
+    False
+    """
     return isinstance(x, dia_matrix)

--- a/scipy/sparse/dok.py
+++ b/scipy/sparse/dok.py
@@ -522,6 +522,28 @@ def _list(x):
 
 
 def isspmatrix_dok(x):
+    """Is x of dok_matrix type?
+
+    Parameters
+    ----------
+    x
+        object to check for being a dok matrix
+
+    Returns
+    -------
+    bool
+        True if x is a dok matrix, False otherwise
+
+    Examples
+    --------
+    >>> from scipy.sparse import dok_matrix, isspmatrix_dok
+    >>> isspmatrix_dok(dok_matrix([[5]]))
+    True
+
+    >>> from scipy.sparse import dok_matrix, csr_matrix, isspmatrix_dok
+    >>> isspmatrix_dok(csr_matrix([[5]]))
+    False
+    """
     return isinstance(x, dok_matrix)
 
 

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -525,4 +525,26 @@ def _prepare_index_for_memoryview(i, j, x=None):
 
 
 def isspmatrix_lil(x):
+    """Is x of lil_matrix type?
+
+    Parameters
+    ----------
+    x
+        object to check for being a lil matrix
+
+    Returns
+    -------
+    bool
+        True if x is a lil matrix, False otherwise
+
+    Examples
+    --------
+    >>> from scipy.sparse import lil_matrix, isspmatrix_lil
+    >>> isspmatrix_lil(lil_matrix([[5]]))
+    True
+
+    >>> from scipy.sparse import lil_matrix, csr_matrix, isspmatrix_lil
+    >>> isspmatrix_lil(csr_matrix([[5]]))
+    False
+    """
     return isinstance(x, lil_matrix)


### PR DESCRIPTION
This fixes  #7168 for `scipy.sparse` (without `scipy.sparse.linalg`) by:

 - Adding docstrings (including simple examples) for `scipy.sparse`'s `issparse`, `isspmatrix`, and the `isspmatrix_...` functions.
 - Adding the example of `save_npz`ing and then `load_npz`ing a sparse matrix given in `scipy.sparse.save_npz`'s docstring to `scipy.sparse.load_npz`.
 - Add an example (and a "see also" for `scipy.sparse.random`) to `scipy.sparse.rand`.