### PR TITLE
BUG: convolve may yield inconsistent dtypes with method changed

### DIFF
--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -784,7 +784,7 @@ def convolve(in1, in2, mode='full', method='auto'):
 
     if method == 'fft':
         out = fftconvolve(volume, kernel, mode=mode)
-        if volume.dtype.kind in 'ui':
+        if volume.dtype.kind in 'ui' or kernel.dtype.kind in 'ui':
             out = np.around(out)
         return out.astype(np.result_type(volume, kernel))
 

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -786,7 +786,7 @@ def convolve(in1, in2, mode='full', method='auto'):
         out = fftconvolve(volume, kernel, mode=mode)
         if volume.dtype.kind in 'ui':
             out = np.around(out)
-        return out.astype(volume.dtype)
+        return out.astype(np.result_type(volume, kernel))
 
     # fastpath to faster numpy.convolve for 1d inputs when possible
     if _np_conv_ok(volume, kernel, mode):

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -675,6 +675,9 @@ def choose_conv_method(in1, in2, mode='full', measure=False):
         if max_value > 2**np.finfo('float').nmant - 1:
             return 'direct'
 
+    if _numeric_arrays([volume, kernel], kinds='b'):
+        return 'direct'
+
     if _numeric_arrays([volume, kernel]):
         if _fftconv_faster(volume, kernel, mode):
             return 'fft'
@@ -784,9 +787,10 @@ def convolve(in1, in2, mode='full', method='auto'):
 
     if method == 'fft':
         out = fftconvolve(volume, kernel, mode=mode)
-        if volume.dtype.kind in 'ui' or kernel.dtype.kind in 'ui':
+        result_type = np.result_type(volume, kernel)
+        if result_type.kind in {'u', 'i'}:
             out = np.around(out)
-        return out.astype(np.result_type(volume, kernel))
+        return out.astype(result_type)
 
     # fastpath to faster numpy.convolve for 1d inputs when possible
     if _np_conv_ok(volume, kernel, mode):

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -170,13 +170,15 @@ class TestConvolve(_TestConvolve):
         args = [(t1, t2, mode) for t1 in types for t2 in types
                                for mode in ['valid', 'full', 'same']]
 
+        # These are random arrays, which means test is much stronger than
+        # convolving testing by convolving two np.ones arrays
+        np.random.seed(42)
         array_types = {'i': np.random.choice([0, 1], size=n),
                        'f': np.random.randn(n)}
         array_types['b'] = array_types['u'] = array_types['i']
-        array_types['c'] = array_types['f'] + 0.5j * array_types['f']
+        array_types['c'] = array_types['f'] + 0.5j*array_types['f']
 
         for t1, t2, mode in args:
-            np.random.seed(42)
             x1 = array_types[np.dtype(t1).kind].astype(t1)
             x2 = array_types[np.dtype(t2).kind].astype(t2)
 
@@ -189,12 +191,16 @@ class TestConvolve(_TestConvolve):
                 assert_equal(choose_conv_method(x1, x2), 'direct')
                 continue
 
+            # Found by experiment. Found approx smallest value for (rtol, atol)
+            # threshold to have tests pass.
             if any([t in {'complex64', 'float32'} for t in [t1, t2]]):
-                kwargs = {'rtol': 8.0e-3, 'atol': 1e-3}
+                kwargs = {'rtol': 1.0e-4, 'atol': 1e-6}
             elif 'float16' in [t1, t2]:
-                kwargs = {'rtol': 1e-2, 'atol': 1e-5}
+                # atol is default for np.allclose
+                kwargs = {'rtol': 1e-3, 'atol': 1e-8}
             else:
-                kwargs = {'rtol': 1e-5, 'atol': 1e-5}
+                # defaults for np.allclose (different from assert_allclose)
+                kwargs = {'rtol': 1e-5, 'atol': 1e-8}
 
             assert_allclose(results['fft'], results['direct'], **kwargs)
 

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -156,40 +156,67 @@ class TestConvolve(_TestConvolve):
         self.assertRaises(ValueError, convolve, *(a, b), **{'mode': 'valid'})
         self.assertRaises(ValueError, convolve, *(b, a), **{'mode': 'valid'})
 
+    def test_convolve_method_diff_types(self, n=10):
+        types = sum([t for _, t in np.sctypes.items()], [])
+        types = {np.dtype(t).name for t in types}
+
+        # These types include 'bool' and all precisions (int8, int16, etc)
+        # The removed types throw errors in correlate or fftconvolve
+        for dtype in ['complex256', 'float128', 'str', 'void', 'bytes',
+                      'object', 'unicode', 'string']:
+            if dtype in types:
+                types.remove(dtype)
+
+        for t1 in types:
+            for t2 in types:
+                x1 = np.ones(n, dtype=t1)
+                x2 = np.ones(n, dtype=t2)
+                results = {key: convolve(x1, x2, method=key)
+                           for key in ['fft', 'direct']}
+
+                assert_equal(results['fft'].dtype, results['direct'].dtype)
+
+                if any([t in {'complex64', 'float32'} for t in [t1, t2]]):
+                    kwargs = {'rtol': 4.0e-3}
+                elif t1 in {'float16', 'complex128'} and t2 in {'float16',
+                        'complex128'}:
+                    kwargs = {'rtol': 1e-6}
+                else:
+                    kwargs = {}
+
+                assert_allclose(results['fft'], results['direct'], **kwargs)
+
     def test_convolve_method(self):
+        types = sum([t for _, t in np.sctypes.items()], [])
+        types = [np.dtype(t) for t in types]
         for mode in ['full', 'valid', 'same']:
-            for _, dtype_list in np.sctypes.items():
-                for dtype in dtype_list:
-                    if dtype == np.void or dtype == str:
-                        continue
-                    np.random.seed(42)
-                    x = (0.5 + np.random.rand(100)).astype(dtype)
-                    h = (0.5 + np.random.rand(50)).astype(dtype)
+            for dtype in types:
+                if dtype == np.void or dtype == str:
+                    continue
+                np.random.seed(42)
+                x = (0.5 + np.random.rand(100)).astype(dtype)
+                h = (0.5 + np.random.rand(50)).astype(dtype)
 
-                    if x.dtype.kind not in 'buifc' \
-                            or np.dtype(dtype).name in {'complex256', 'complex192'}:
-                        assert_equal(choose_conv_method(x, h, mode=mode), 'direct')
-                        # continues the for-loop; it will throw an error
-                        # because fftconv doesn't support the dtype
-                        continue
+                if x.dtype.kind not in 'buifc' \
+                        or np.dtype(dtype).name in {'complex256', 'complex192'}:
+                    assert_equal(choose_conv_method(x, h, mode=mode), 'direct')
+                    continue
 
-                    if x.dtype.kind != 'b':
-                        x += 1
-                        h += 1
+                if x.dtype.kind != 'b':
+                    x += 1
+                    h += 1
 
-                    if x.dtype.kind == 'c':
-                        x += 1j * np.random.rand(*x.shape).astype(dtype)
-                        h += 1j * np.random.rand(*h.shape).astype(dtype)
+                if x.dtype.kind == 'c':
+                    x += 1j * np.random.rand(*x.shape).astype(dtype)
+                    h += 1j * np.random.rand(*h.shape).astype(dtype)
 
-                    results = {'direct':convolve(x, h, mode=mode,
-                                                 method='direct'),
-                               'fft':convolve(x, h, mode=mode, method='fft')}
+                results = {key: convolve(x, h, mode=mode, method=key)
+                           for key in ['fft', 'direct']}
 
-                    rtol = {'rtol': 2.0e-3} if dtype in {np.complex64,
-                                                         np.float32} else {}
-                    if isinstance(results['direct'], np.ndarray):
-                        assert_allclose(results['fft'], results['direct'], **rtol)
-                        assert_equal(results['direct'].dtype, results['fft'].dtype)
+                rtol = {'rtol': 2.0e-3} if dtype in {np.dtype('complex64'),
+                                                     np.dtype('float32')} else {}
+                if isinstance(results['direct'], np.ndarray):
+                    assert_allclose(results['fft'], results['direct'], **rtol)
 
         # This is really a test that convolving two large integers goes to the
         # direct method even if they're in the fft method.
@@ -205,8 +232,8 @@ class TestConvolve(_TestConvolve):
                 assert_equal(fft, 2**(2*n))
                 assert_equal(direct, 2**(2*n))
 
-        assert_equal(convolve([4], [5], 'valid', 'fft'), 20)
-        assert_equal('direct', choose_conv_method(2 * [Decimal(3)], 2 * [Decimal(4)]))
+    assert_equal(convolve([4], [5], 'valid', 'fft'), 20)
+    assert_equal('direct', choose_conv_method(2 * [Decimal(3)], 2 * [Decimal(4)]))
 
 class _TestConvolve2d(TestCase):
 

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -156,12 +156,11 @@ class TestConvolve(_TestConvolve):
         self.assertRaises(ValueError, convolve, *(a, b), **{'mode': 'valid'})
         self.assertRaises(ValueError, convolve, *(b, a), **{'mode': 'valid'})
 
-    def test_convolve_method(self, n=int(10e3)):
-        np.random.seed(42)
+    def test_convolve_method(self, n=100):
         types = sum([t for _, t in np.sctypes.items()], [])
         types = {np.dtype(t).name for t in types}
 
-        # These types include 'bool' and all precisions (int8, int16, etc)
+        # These types include 'bool' and all precisions (int8, float32, etc)
         # The removed types throw errors in correlate or fftconvolve
         for dtype in ['complex256', 'float128', 'str', 'void', 'bytes',
                       'object', 'unicode', 'string']:
@@ -177,6 +176,7 @@ class TestConvolve(_TestConvolve):
         array_types['c'] = array_types['f'] + 0.5j * array_types['f']
 
         for t1, t2, mode in args:
+            np.random.seed(42)
             x1 = array_types[np.dtype(t1).kind].astype(t1)
             x2 = array_types[np.dtype(t2).kind].astype(t2)
 

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -156,7 +156,8 @@ class TestConvolve(_TestConvolve):
         self.assertRaises(ValueError, convolve, *(a, b), **{'mode': 'valid'})
         self.assertRaises(ValueError, convolve, *(b, a), **{'mode': 'valid'})
 
-    def test_convolve_method(self, n=300):
+    def test_convolve_method(self, n=int(10e3)):
+        np.random.seed(42)
         types = sum([t for _, t in np.sctypes.items()], [])
         types = {np.dtype(t).name for t in types}
 
@@ -170,20 +171,28 @@ class TestConvolve(_TestConvolve):
         args = [(t1, t2, mode) for t1 in types for t2 in types
                                for mode in ['valid', 'full', 'same']]
 
+        array_types = {'i': np.random.choice([0, 1], size=n),
+                       'f': np.random.randn(n)}
+        array_types['b'] = array_types['u'] = array_types['i']
+        array_types['c'] = array_types['f'] + 0.5j * array_types['f']
+
         for t1, t2, mode in args:
-            x1 = np.ones(n).astype(t1)
-            x2 = np.ones(n//5).astype(t2)
+            x1 = array_types[np.dtype(t1).kind].astype(t1)
+            x2 = array_types[np.dtype(t2).kind].astype(t2)
 
             results = {key: convolve(x1, x2, method=key, mode=mode)
                        for key in ['fft', 'direct']}
 
             assert_equal(results['fft'].dtype, results['direct'].dtype)
 
+            if 'bool' in t1 and 'bool' in t2:
+                assert_equal(choose_conv_method(x1, x2), 'direct')
+                continue
+
             if any([t in {'complex64', 'float32'} for t in [t1, t2]]):
-                kwargs = {'rtol': 4.0e-3, 'atol': 1e-5}
-            elif t1 in {'float16', 'complex128'} and t2 in {'float16',
-                        'complex128'}:
-                kwargs = {'rtol': 1e-5, 'atol': 1e-3}
+                kwargs = {'rtol': 8.0e-3, 'atol': 1e-3}
+            elif 'float16' in [t1, t2]:
+                kwargs = {'rtol': 1e-2, 'atol': 1e-5}
             else:
                 kwargs = {'rtol': 1e-5, 'atol': 1e-5}
 
@@ -203,6 +212,7 @@ class TestConvolve(_TestConvolve):
                 assert_equal(fft, direct)
                 assert_equal(fft, 2**(2*n))
                 assert_equal(direct, 2**(2*n))
+
 
 class _TestConvolve2d(TestCase):
 


### PR DESCRIPTION
Addresses #7193.

In this I cast the output as the value returned by `np.return_types` (thanks to @e-q's suggestion).

I also implement a test that ensures all 1D dtypes are the same when convolving with all possible types (two arrays are of different types). In #5608 I only tested to make sure that the dtypes matched when convolving two arrays *of the same type*.

~~Let me do some more verification before merge.~~