### PR TITLE
BUG: integrate: fix refcounting bug in quad()

### DIFF
--- a/scipy/integrate/__quadpack.h
+++ b/scipy/integrate/__quadpack.h
@@ -241,34 +241,47 @@ double quad_thunk(double *x)
     int error = 0;
 
     if (callback->py_function) {
-        PyObject *arg1, *argobj, *arglist, *res, *res2;
+        PyObject *arg1 = NULL, *argobj = NULL, *arglist = NULL, *res = NULL;
         PyObject *extra_arguments = (PyObject *)callback->info_p;
-
-        arg1 = PyTuple_New(1);
-        if (arg1 == NULL) {
-            goto error;
-        }
 
         argobj = PyFloat_FromDouble(*x);
         if (argobj == NULL) {
-            goto error;
+            error = 1;
+            goto done;
         }
+
+        arg1 = PyTuple_New(1);
+        if (arg1 == NULL) {
+            error = 1;
+            goto done;
+        }
+
         PyTuple_SET_ITEM(arg1, 0, argobj);
+        argobj = NULL;
 
         arglist = PySequence_Concat(arg1, extra_arguments);
         if (arglist == NULL) {
-            goto error;
+            error = 1;
+            goto done;
         }
 
         res = PyEval_CallObject(callback->py_function, arglist);
         if (res == NULL) {
-            goto error;
+            error = 1;
+            goto done;
         }
 
         result = PyFloat_AsDouble(res);
         if (PyErr_Occurred()) {
-            goto error;
+            error = 1;
+            goto done;
         }
+
+    done:
+        Py_XDECREF(arg1);
+        Py_XDECREF(argobj);
+        Py_XDECREF(arglist);
+        Py_XDECREF(res);
     }
     else {
         switch (callback->signature->value) {
@@ -295,12 +308,6 @@ double quad_thunk(double *x)
         }
     }
 
-    goto done;
-
-error:
-    error = 1;
-    
-done:
     if (error) {
         longjmp(callback->error_buf, 1);
     }


### PR DESCRIPTION
Decref'ing was completely forgotten in the callback, add it back.

This is a quite stupid bug. It's also high-impact, as anything calling quad/nquad will leak memory (possibly rapidly if the integrand is called many times).

Backport is needed.

Fixes gh-7214