### PR TITLE
BUG: don't choose method='fft' when convolving int & float

### DIFF
--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -675,6 +675,12 @@ def choose_conv_method(in1, in2, mode='full', measure=False):
         if max_value > 2**np.finfo('float').nmant - 1:
             return 'direct'
 
+        if any([_numeric_arrays([x], kinds='fc') for x in [volume, kernel]]):
+            return 'direct'
+
+    if _numeric_arrays([volume, kernel], kinds='b'):
+        return 'direct'
+
     if _numeric_arrays([volume, kernel]):
         if _fftconv_faster(volume, kernel, mode):
             return 'fft'

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1553,6 +1553,16 @@ def check_filtfilt_gust(b, a, shape, axis, irlen=None):
     assert_allclose(zg1, zo1, rtol=1e-9, atol=1e-10)
     assert_allclose(zg2, zo2, rtol=1e-9, atol=1e-10)
 
+def test_choose_conv_method_types(n=3000):
+    np.random.seed(42)
+    for t1, t2 in [(bool, bool), (int, float), (int, complex), (float, int),
+                   (complex, int)]:
+        x1 = np.random.randn(n).astype(t1)
+        x2 = np.random.randn(n).astype(t2)
+
+        float_method = choose_conv_method(x1.astype(complex), x2.astype(complex))
+        assert_(float_method == 'fft')
+        assert_(choose_conv_method(x1, x2) == 'direct')
 
 def test_choose_conv_method():
     for mode in ['valid', 'same', 'full']:


### PR DESCRIPTION
 I added a check in `choose_conv_method` for the error conditions mentioned in #7217 (and then return `direct` if met).

This resolves the default behavior when `method='auto'`; it does nothing when `method='fft'` is passed in.

Resolves #7217.