### PR TITLE
MAINT: special: Rewrite a test of wrightomega

### DIFF
--- a/scipy/special/tests/test_wrightomega.py
+++ b/scipy/special/tests/test_wrightomega.py
@@ -21,17 +21,18 @@ def test_wrightomega_inf_branch():
            complex(-np.inf, -np.pi/4),
            complex(-np.inf, 3*np.pi/4),
            complex(-np.inf, -3*np.pi/4)]
-    for p in pts:
+    expected_results = [complex(0.0, 0.0),
+                        complex(0.0, -0.0),
+                        complex(-0.0, 0.0),
+                        complex(-0.0, -0.0)]
+    for p, expected in zip(pts, expected_results):
         res = sc.wrightomega(p)
-        assert_equal(res, 0)
-        if abs(p.imag) <= np.pi/2:
-            assert_(np.signbit(res.real) == False)
-        else:
-            assert_(np.signbit(res.real) == True)
-        if p.imag >= 0:
-            assert_(np.signbit(res.imag) == False)
-        else:
-            assert_(np.signbit(res.imag) == True)
+        # We can't use assert_equal(res, expected) because in older versions of
+        # numpy, assert_equal doesn't check the sign of the real and imaginary
+        # parts when comparing complex zeros. It does check the sign when the
+        # arguments are *real* scalars.
+        assert_equal(res.real, expected.real)
+        assert_equal(res.imag, expected.imag)
 
 
 def test_wrightomega_inf():


### PR DESCRIPTION
assert_equal(res, 0) fails with the development version of numpy,
because assert_equal() now takes into account the signs of the
real and imaginary parts of +/- 0.0 +/- 0.0j.

To avoid that, the test now uses explicitly given expected results
with signed real and imaginary parts, and compares the actual results
with the expected results using assert_equal() with only real arguments.
This works for old numpy and should continue working with new versions
of numpy.

Closes gh-7227.