### PR TITLE
Fix issue #7232: Do not mask exceptions in objective func evaluation

### DIFF
--- a/scipy/optimize/slsqp.py
+++ b/scipy/optimize/slsqp.py
@@ -364,9 +364,10 @@ def _minimize_slsqp(func, x0, args=(), jac=None, bounds=None,
         if mode == 0 or mode == 1:  # objective and constraint evaluation requird
 
             # Compute objective function
+            fx = func(x)
             try:
-                fx = float(np.asarray(func(x)))
-            except:
+                fx = float(np.asarray(fx))
+            except TypeError:
                 raise ValueError("Objective function must return a scalar")
             # Compute the constraints
             if cons['eq']:

--- a/scipy/optimize/slsqp.py
+++ b/scipy/optimize/slsqp.py
@@ -367,7 +367,7 @@ def _minimize_slsqp(func, x0, args=(), jac=None, bounds=None,
             fx = func(x)
             try:
                 fx = float(np.asarray(fx))
-            except TypeError:
+            except (TypeError, ValueError):
                 raise ValueError("Objective function must return a scalar")
             # Compute the constraints
             if cons['eq']:


### PR DESCRIPTION
* evaluate `func(x)` outside try/except block
* catch a particular exception (`TypeError`), rather than _all_ exceptions in check