### PR TITLE
DEP: misc: deprecate imported names

### DIFF
--- a/scipy/misc/__init__.py
+++ b/scipy/misc/__init__.py
@@ -26,11 +26,8 @@ below are not available without it.
    imrotate - Rotate an image counter-clockwise [requires Pillow]
    imsave - Save an array to an image file [requires Pillow] 
    imshow - Simple showing of an image through an external viewer [requires Pillow]
-   info - Get help information for a function, class, or module
    lena - Get classic image processing example image Lena
    toimage - Takes a numpy array and returns a PIL image [requires Pillow]
-   source - Print function source code
-   who - Print the Numpy arrays in the given dictionary
 
 
 Deprecated aliases:
@@ -38,15 +35,18 @@ Deprecated aliases:
 .. autosummary::
    :toctree: generated/
 
-   comb - Combinations of N things taken k at a time, "N choose k" (imported from scipy.special)
+   comb - Combinations of N things taken k at a time, "N choose k" (imported from `scipy.special`)
    factorial  - The factorial function, ``n! = special.gamma(n+1)``
-                (imported from scipy.special)
-   factorial2 - Double factorial, ``(n!)!`` (imported from scipy.special)
-   factorialk - ``(...((n!)!)!...)!`` where there are k '!' (imported from scipy.special)
+                (imported from `scipy.special`)
+   factorial2 - Double factorial, ``(n!)!`` (imported from `scipy.special`)
+   factorialk - ``(...((n!)!)!...)!`` where there are k '!' (imported from `scipy.special`)
    logsumexp - Compute the log of the sum of exponentials of input elements
-               (imported from scipy.special)
+               (imported from `scipy.special`)
    pade - Pade approximation to function as the ratio of two polynomials.
-          (imported from scipy.interpolate)
+          (imported from `scipy.interpolate`)
+   info - Get help information for a function, class, or module. (imported from `numpy`)
+   source - Print function source code. (imported from `numpy`)
+   who - Print the Numpy arrays in the given dictionary. (imported from `numpy`) 
 
 """
 
@@ -57,7 +57,7 @@ __all__ = ['who', 'source', 'info', 'doccer', 'pade',
 
 from . import doccer
 from .common import *
-from numpy import who, source, info as _info
+from numpy import who as _who, source as _source, info as _info
 import numpy as np
 from scipy.interpolate._pade import pade as _pade
 from scipy.special import (comb as _comb, logsumexp as _lsm,
@@ -77,7 +77,12 @@ _msg = ("Importing `pade` from scipy.misc is deprecated in scipy 1.0.0. Use "
         "`scipy.interpolate.pade` instead.")
 pade = np.deprecate(_pade, message=_msg)
 
+_msg = ("Importing `%(name)s` from scipy.misc is deprecated in scipy 1.0.0. Use "
+        "`numpy.%(name)s` instead.")
+who = np.deprecate(_who, message=_msg % {"name": "who"})
+source = np.deprecate(_source, message=_msg % {"name": "source"})
 
+@np.deprecate(message=_msg % {"name": "info.(..., toplevel='scipy')"})
 def info(object=None,maxwidth=76,output=sys.stdout,toplevel='scipy'):
     return _info(object, maxwidth, output, toplevel)
 info.__doc__ = _info.__doc__

--- a/scipy/misc/__init__.py
+++ b/scipy/misc/__init__.py
@@ -17,12 +17,8 @@ below are not available without it.
    ascent - Get example image for processing
    bytescale - Byte scales an array (image) [requires Pillow]
    central_diff_weights - Weights for an n-point central m-th derivative
-   comb - Combinations of N things taken k at a time, "N choose k" (imported from scipy.special)
    derivative - Find the n-th derivative of a function at a point
    face - Get example image for processing
-   factorial  - The factorial function, n! = special.gamma(n+1) (imported from scipy.special)
-   factorial2 - Double factorial, (n!)! (imported from scipy.special)
-   factorialk - (...((n!)!)!...)! where there are k '!' (imported from scipy.special)
    fromimage - Return a copy of a PIL image as a numpy array [requires Pillow]
    imfilter - Simple filtering of an image [requires Pillow]
    imread - Read an image file from a filename [requires Pillow]
@@ -32,13 +28,25 @@ below are not available without it.
    imshow - Simple showing of an image through an external viewer [requires Pillow]
    info - Get help information for a function, class, or module
    lena - Get classic image processing example image Lena
+   toimage - Takes a numpy array and returns a PIL image [requires Pillow]
+   source - Print function source code
+   who - Print the Numpy arrays in the given dictionary
+
+
+Deprecated aliases:
+
+.. autosummary::
+   :toctree: generated/
+
+   comb - Combinations of N things taken k at a time, "N choose k" (imported from scipy.special)
+   factorial  - The factorial function, ``n! = special.gamma(n+1)``
+                (imported from scipy.special)
+   factorial2 - Double factorial, ``(n!)!`` (imported from scipy.special)
+   factorialk - ``(...((n!)!)!...)!`` where there are k '!' (imported from scipy.special)
    logsumexp - Compute the log of the sum of exponentials of input elements
                (imported from scipy.special)
    pade - Pade approximation to function as the ratio of two polynomials.
           (imported from scipy.interpolate)
-   toimage - Takes a numpy array and returns a PIL image [requires Pillow]
-   source - Print function source code
-   who - Print the Numpy arrays in the given dictionary
 
 """
 
@@ -50,10 +58,24 @@ __all__ = ['who', 'source', 'info', 'doccer', 'pade',
 from . import doccer
 from .common import *
 from numpy import who, source, info as _info
-from scipy.interpolate._pade import pade
-from scipy.special import comb, factorial, factorial2, factorialk, logsumexp
+import numpy as np
+from scipy.interpolate._pade import pade as _pade
+from scipy.special import (comb as _comb, logsumexp as _lsm,
+        factorial as _fact, factorial2 as _fact2, factorialk as _factk)
 
 import sys
+
+_msg = ("Importing `%(name)s` from scipy.misc is deprecated in scipy 1.0.0. Use "
+        "`scipy.special.%(name)s` instead.")
+comb = np.deprecate(_comb, message=_msg % {"name": _comb.__name__})
+logsumexp = np.deprecate(_lsm, message=_msg % {"name": _lsm.__name__})
+factorial = np.deprecate(_fact, message=_msg % {"name": _fact.__name__})
+factorial2 = np.deprecate(_fact2, message=_msg % {"name": _fact2.__name__})
+factorialk = np.deprecate(_factk, message=_msg % {"name": _factk.__name__})
+
+_msg = ("Importing `pade` from scipy.misc is deprecated in scipy 1.0.0. Use "
+        "`scipy.interpolate.pade` instead.")
+pade = np.deprecate(_pade, message=_msg)
 
 
 def info(object=None,maxwidth=76,output=sys.stdout,toplevel='scipy'):

--- a/scipy/misc/tests/test_common.py
+++ b/scipy/misc/tests/test_common.py
@@ -1,20 +1,27 @@
 from __future__ import division, print_function, absolute_import
 
-from numpy.testing import assert_equal, assert_
+import warnings
+
+from numpy.testing import assert_equal, assert_allclose
 
 from scipy.misc import pade, logsumexp, face, ascent
 from scipy.special import logsumexp as sc_logsumexp
-from scipy.interpolate import pade as i_pade
 
 
 def test_logsumexp():
     # make sure logsumexp can be imported from either scipy.misc or
     # scipy.special
-    assert_(logsumexp is sc_logsumexp)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', DeprecationWarning)
+        assert_allclose(logsumexp([0, 1]),
+                        sc_logsumexp([0, 1]), atol=1e-16)
 
 
 def test_pade():
-    assert_(pade is i_pade)
+    # make sure scipy.misc.pade exists
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', DeprecationWarning)
+        pade([1, 2], 1)
 
 
 def test_face():


### PR DESCRIPTION
Scipy Roadmap says that scipy.misc is slated for removal at some point in time. The first step is then to deprecate the use of the aliases of functions which have been moved to more appropriate subpackages:

- comb, factorials (factorial, factorial2, factorialk) are in special,
- pade is in interpolate.