### PR TITLE
ENH: SphericalVoronoi Input Handling

### DIFF
--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -105,6 +105,10 @@ class SphericalVoronoi:
         Radius of the sphere (Default: 1)
     center : ndarray of floats, shape (3,)
         Center of sphere (Default: origin)
+    threshold : float
+        Threshold for detecting duplicate points and
+        mismatches between points and sphere parameters.
+        (Default: 1e-06)
 
     Attributes
     ----------

--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -16,6 +16,7 @@ import numpy.matlib
 import scipy
 import itertools
 from . import _voronoi
+from scipy.spatial.distance import pdist
 
 __all__ = ['SphericalVoronoi']
 
@@ -206,6 +207,8 @@ class SphericalVoronoi:
         """
 
         self.points = points
+        if pdist(self.points).min() == 0:
+            raise ValueError("Duplicate generators present.")
         if np.any(center):
             self.center = center
         else:

--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -111,6 +111,12 @@ class SphericalVoronoi:
             the n-th entry is a list consisting of the indices
             of the vertices belonging to the n-th point in points
 
+    Raises
+    ------
+    ValueError
+        If there are duplicates in `points`.
+        If the provided `radius` is not consistent with `points`.
+
     Notes
     ----------
     The spherical Voronoi diagram algorithm proceeds as follows. The Convex

--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -28,7 +28,7 @@ def sphere_check(points, radius, center):
     actual_squared_radii = (((points[...,0] - center[0]) ** 2) +
                             ((points[...,1] - center[1]) ** 2) +
                             ((points[...,2] - center[2]) ** 2))
-    max_discrepancy = (actual_squared_radii - (radius ** 2)).max()
+    max_discrepancy = (np.sqrt(actual_squared_radii) - radius).max()
     return abs(max_discrepancy)
 
 def calc_circumcenters(tetrahedrons):
@@ -228,8 +228,6 @@ class SphericalVoronoi:
         """
 
         self.points = points
-        if pdist(self.points).min() <= threshold:
-            raise ValueError("Duplicate generators present.")
         if np.any(center):
             self.center = center
         else:
@@ -238,10 +236,14 @@ class SphericalVoronoi:
             self.radius = radius
         else:
             self.radius = 1
+
+        if pdist(self.points).min() <= threshold * self.radius:
+            raise ValueError("Duplicate generators present.")
+
         max_discrepancy = sphere_check(self.points,
                                        self.radius,
                                        self.center)
-        if max_discrepancy >= threshold:
+        if max_discrepancy >= threshold * self.radius:
             raise ValueError("Radius inconsistent with generators.")
         self.vertices = None
         self.regions = None

--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -217,6 +217,8 @@ class SphericalVoronoi:
             self.radius = radius
         else:
             self.radius = 1
+        if pdist(self.points).max() > (2. * self.radius):
+            raise ValueError("Radius inconsistent with generators.")
         self.vertices = None
         self.regions = None
         self._tri = None

--- a/scipy/spatial/tests/test_spherical_voronoi.py
+++ b/scipy/spatial/tests/test_spherical_voronoi.py
@@ -148,3 +148,12 @@ class TestSphericalVoronoi(TestCase):
         self.degenerate = np.concatenate((self.points, self.points))
         with assert_raises(ValueError):
             sv = spherical_voronoi.SphericalVoronoi(self.degenerate)
+
+    def test_incorrect_radius_handling(self):
+        # an exception should be raised if the radius provided
+        # cannot possibly match the input generators
+        # currently, only sensitive to the generators clearly
+        # belonging to a data set with a greater radius than provided
+        with assert_raises(ValueError):
+            sv = spherical_voronoi.SphericalVoronoi(self.points,
+                                                    radius=0.98)

--- a/scipy/spatial/tests/test_spherical_voronoi.py
+++ b/scipy/spatial/tests/test_spherical_voronoi.py
@@ -80,9 +80,12 @@ class TestSphericalVoronoi(TestCase):
         center = np.array([1, 2, 3])
         radius = 2
         s1 = SphericalVoronoi(self.points)
-        s2 = SphericalVoronoi(self.points, radius)
-        s3 = SphericalVoronoi(self.points, None, center)
-        s4 = SphericalVoronoi(self.points, radius, center)
+        # user input checks in SphericalVoronoi now require
+        # the radius / center to match the generators so adjust
+        # accordingly here
+        s2 = SphericalVoronoi(self.points * radius, radius)
+        s3 = SphericalVoronoi(self.points + center, None, center)
+        s4 = SphericalVoronoi(self.points * radius + center, radius, center)
         assert_array_equal(s1.center, np.array([0, 0, 0]))
         self.assertEqual(s1.radius, 1)
         assert_array_equal(s2.center, np.array([0, 0, 0]))
@@ -152,8 +155,13 @@ class TestSphericalVoronoi(TestCase):
     def test_incorrect_radius_handling(self):
         # an exception should be raised if the radius provided
         # cannot possibly match the input generators
-        # currently, only sensitive to the generators clearly
-        # belonging to a data set with a greater radius than provided
         with assert_raises(ValueError):
             sv = spherical_voronoi.SphericalVoronoi(self.points,
                                                     radius=0.98)
+
+    def test_incorrect_center_handling(self):
+        # an exception should be raised if the center provided
+        # cannot possibly match the input generators
+        with assert_raises(ValueError):
+            sv = spherical_voronoi.SphericalVoronoi(self.points,
+                                                    center=[0.1,0,0])

--- a/scipy/spatial/tests/test_spherical_voronoi.py
+++ b/scipy/spatial/tests/test_spherical_voronoi.py
@@ -5,7 +5,8 @@ from numpy.testing import (TestCase,
                            assert_equal,
                            assert_almost_equal,
                            assert_array_equal,
-                           assert_array_almost_equal)
+                           assert_array_almost_equal,
+                           assert_raises)
 from scipy.spatial import SphericalVoronoi, distance
 from scipy.spatial import _spherical_voronoi as spherical_voronoi
 
@@ -140,3 +141,10 @@ class TestSphericalVoronoi(TestCase):
             closest = np.array(sorted(distances)[0:3])
             assert_almost_equal(closest[0], closest[1], 7, str(vertex))
             assert_almost_equal(closest[0], closest[2], 7, str(vertex))
+
+    def test_duplicate_point_handling(self):
+        # an exception should be raised for degenerate generators
+        # related to Issue# 7046
+        self.degenerate = np.concatenate((self.points, self.points))
+        with assert_raises(ValueError):
+            sv = spherical_voronoi.SphericalVoronoi(self.degenerate)


### PR DESCRIPTION
Although issue #7046 didn't actually reveal any algorithm-level bugs in `SphericalVoronoi`, there was a suggestion to check the input points (generators) more thoroughly with respect to the input radius, and the original problem was that the user had degenerate input (duplicate generators).

This PR drafts a possible set of checks / exceptions raised for these two user input-related issues, along with the corresponding unit tests and documentation updates for the `Raises` section of `SphericalVoronoi`.

Considerations / Questions
---------------------------
1. `Voronoi` handles degenerate input silently -- i.e., the user is not notified that they have duplicate points using the default arguments / `Qhull` flags, and `Qhull` appears to take care of this (probably by removing the duplicate generators). Since my solution with `SphericalVoronoi` is to raise an exception with degenerate input, would we consider this presenting the user with an "inconsistent interface" in `scipy.spatial`? I think there's something to be said for explicit notification that you have duplicates in your input, but I may just be trying to avoid the extra work involved in removing them. If we do decide to go the duplicate-removal route instead of what I've done here, I suspect that is something that we'd want to abstract outside of `SphericalVoronoi`--many computational geometry algorithms do not tolerate degenerate input. 

2. An additional consideration is that the algorithm may not be able to tolerate points that are extremely close together (i.e., `d = 0.000000000000001`). Currently, `d = 0` is required to raise the exception--do we want to carefully check the floating point limit for degeneracy / proximity and use that instead of `0` proper? 

3. My changes introduce two identical `pdist` operations--I'm not sure we gain all that much by this--I was trying to avoid storing the condensed matrix in a variable in case that might alleviate space complexity issues for huge data sets, but this may actually not help at all and simply add to the calculation time? If so, we'd just switch to one `pdist` calculation, store the result in a variable, and take the `max()` and `min()` of the condensed distance matrix for the two input checks introduced here.

4. Note that the `radius` value check only works for cases where the generators are far enough part that the `radius` can't possibly be correct. The reverse determination (the `radius` is too big) would be more challenging since the user may only provide a subset of the points on the sphere, and we can't easily know for sure if we are i.e., just looking at points restricted to a subregion of the sphere for which the true diameter is never approached in a distance matrix.

