### PR TITLE
fix for issue #7255 - Circular statistics functions give wrong results when working with numpy uint8 data type

### DIFF
--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -2698,7 +2698,7 @@ def _circfuncs_common(samples, high, low):
     if samples.size == 0:
         return np.nan, np.nan
 
-    ang = (samples - low)*2*pi / (high - low)
+    ang = (samples - low)*2.*pi / (high - low)
     return samples, ang
 
 

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1231,7 +1231,7 @@ class TestCircFuncs(TestCase):
         assert_(m > -np.pi)
 
     def test_circfuncs_unit8(self):
-        # regression test for gh-7255: wrong results when working with
+        # regression test for gh-7255: overflow when working with
         # numpy uint8 data type
         x = np.array([150, 10], dtype='uint8')
         assert_equal(stats.circmean(x, high=180), 170.0)

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1230,6 +1230,13 @@ class TestCircFuncs(TestCase):
         assert_(m < np.pi)
         assert_(m > -np.pi)
 
+    def test_circfuncs_unit8(self):
+        # regression test for gh-7255: wrong results when working with
+        # numpy uint8 data type
+        x = np.array([150, 10], dtype='uint8')
+        assert_equal(stats.circmean(x, high=180), 170.0)
+        assert_allclose(stats.circvar(x, high=180), 437.45871686, rtol=1e-7)
+        assert_allclose(stats.circstd(x, high=180), 20.91551378, rtol=1e-7)
 
 def test_accuracy_wilcoxon():
     freq = [1, 4, 16, 15, 8, 4, 5, 1, 2]


### PR DESCRIPTION
Converting number to float to prevent overflow when uint8 value was received by the function ``_circfuncs_common``.  Closes gh-7255