### PR TITLE
ENH: add rv_scatter distribution

### DIFF
--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -17,6 +17,7 @@ Each univariate distribution is an instance of a subclass of `rv_continuous`
    rv_continuous
    rv_discrete
    rv_histogram
+   rv_scatter
 
 Continuous distributions
 ========================

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -5442,6 +5442,32 @@ class rv_scatter(rv_continuous):
     Examples
     --------
 
+    Create a bimodal distribution
+
+    >>> from scipy.stats import rv_scatter
+    >>> import numpy as np
+    >>> import matplotlib.pyplot as plt
+
+    >>> x = [0, 0.2, 0.8, 1, 1.5, 2, 2.5]
+    >>> y = [0, 1, 1, 0, 0, 1, 0]
+    >>> rv = rv_scatter((x, y))
+
+    PDF and CDF are normalised
+
+    >>> rv.pdf(0.5)
+    0.76923076923076916
+    >>> rv.cdf(2.5)
+    1.0
+    >>> xv = np.linspace(-0.1, 2.6, 201)
+    >>> plt.plot(xv, rv.pdf(xv), label='PDF')
+    >>> plt.plot(xv, rv.cdf(xv), label='CDF')
+    >>> plt.show()
+
+    Random variates follow the original scatter points
+
+    >>> n = rv.rvs(size=10000)
+    >>> plt.hist(n, bins=100)
+    >>> plt.show()
     """
     _support_mask = rv_continuous._support_mask
 

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -17,7 +17,7 @@ from ._continuous_distns import *
 from ._discrete_distns import *
 
 # For backwards compatibility e.g. pymc expects distributions.__all__.
-__all__ = ['entropy', 'rv_discrete', 'rv_continuous', 'rv_histogram']
+__all__ = ['entropy', 'rv_discrete', 'rv_continuous', 'rv_histogram', 'rv_scatter']
 
 # Add only the distribution names, not the *_gen names.
 __all__ += _continuous_distns._distn_names


### PR DESCRIPTION
`rv_scatter` is a subclass of `rv_continuous` and is meant as a scatter (x/y pairs) accompaniment to #6801. See also #6466.