### PR TITLE
CI: use python's faulthandler to ease tracing segfaults

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,6 +81,7 @@ cache:
   directories:
     - $HOME/.ccache
 before_install:
+  - export PYTHONFAULTHANDLER=1
   - export PATH=/usr/lib/ccache:$PATH
   - uname -a
   - free -m


### PR DESCRIPTION
Following what Matthew did in MacPython/nightly, it probably won't hurt to have a faulthandler enabled for our regular CI too.