### PR TITLE
Assign updated time_axis to correct variable in istft

### DIFF
--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -1207,7 +1207,7 @@ def istft(Zxx, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
         if freq_axis < 0:
             freq_axis = Zxx.ndim + freq_axis
         if time_axis < 0:
-            time = Zxx.ndim + time_axis
+            time_axis = Zxx.ndim + time_axis
         zouter = list(range(Zxx.ndim))
         for ax in sorted([time_axis, freq_axis], reverse=True):
             zouter.pop(ax)


### PR DESCRIPTION
In istft, `time_axis` is updated if a non-standard negative axis index is provided. It is currently assigned to an unused variable `time`. I changed `time` to the intended `time_axis`. This resolves an IndexError (`pop index out of range`) when the function tries to pop a non-existent negative index off of `zouter`. 