### PR TITLE
BUG: Fix broken axis handling in spectral functions

### DIFF
--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -1675,17 +1675,13 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
     if same_data and mode != 'stft':
         result = result.real
 
-    # Output is going to have new last axis for window index
-    if axis != -1:
-        # Specify as positive axis index
-        if axis < 0:
-            axis = len(result.shape)-1-axis
+    # Output is going to have new last axis for time/window index, so a
+    # negative axis index shifts down one
+    if axis < 0:
+        axis -= 1
 
-        # Roll frequency axis back to axis where the data came from
-        result = np.rollaxis(result, -1, axis)
-    else:
-        # Make sure window/time index is last axis
-        result = np.rollaxis(result, -1, -2)
+    # Roll frequency axis back to axis where the data came from
+    result = np.rollaxis(result, -1, axis)
 
     return freqs, time, result
 

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -1207,7 +1207,7 @@ def istft(Zxx, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
         if freq_axis < 0:
             freq_axis = Zxx.ndim + freq_axis
         if time_axis < 0:
-            time = Zxx.ndim + time_axis
+            time_axis = Zxx.ndim + time_axis
         zouter = list(range(Zxx.ndim))
         for ax in sorted([time_axis, freq_axis], reverse=True):
             zouter.pop(ax)


### PR DESCRIPTION
gh-7264 brought to light an unfortunate oversight in `signal.istft`, and a lack of tests to catch it. I've cherry-picked the fix from there, and added a regression test for it.

While writing the test for the above fix though, I found a bug in `_spectral_helper` that goes back to **0.16**: it crashes and burns if any negative axis other than -1 is specified. This is pretty bad. I've fixed it and added tests as well.