### PR TITLE
FIX 7262: ckdtree crashes in query_knn.

### DIFF
--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -654,7 +654,7 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
         k : list of integer or integer
             The list of k-th nearest neighbors to return. If k is an 
             integer it is treated as a list of [1, ... k] (range(1, k+1)).
-            Note that the counting starts from 1; the result is undefined
+            Note that the counting starts from 1.
             if k is not sorted.
         eps : non-negative float
             Return approximate nearest neighbors; the k-th returned value 
@@ -749,10 +749,12 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
         retshape = np.shape(x)[:-1]
         n = <np.intp_t> np.prod(retshape)
         xx = np.ascontiguousarray(x_arr).reshape(n, self.m)
+
+        # The C++ function touches all dd and ii entries,
+        # setting the missing values.
+
         dd = np.empty((n,len(k)),dtype=np.float64)
-        dd.fill(INFINITY)
         ii = np.empty((n,len(k)),dtype=np.intp)
-        ii.fill(self.n)
 
         # Do the query in an external C++ function. 
         # The GIL will be released in the external query function.

--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -655,7 +655,6 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
             The list of k-th nearest neighbors to return. If k is an 
             integer it is treated as a list of [1, ... k] (range(1, k+1)).
             Note that the counting starts from 1.
-            if k is not sorted.
         eps : non-negative float
             Return approximate nearest neighbors; the k-th returned value 
             is guaranteed to be no further than (1+eps) times the 

--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -654,7 +654,8 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
         k : list of integer or integer
             The list of k-th nearest neighbors to return. If k is an 
             integer it is treated as a list of [1, ... k] (range(1, k+1)).
-            Note that the counting starts from 1.
+            Note that the counting starts from 1; the result is undefined
+            if k is not sorted.
         eps : non-negative float
             Return approximate nearest neighbors; the k-th returned value 
             is guaranteed to be no further than (1+eps) times the 

--- a/scipy/spatial/ckdtree/src/query.cxx
+++ b/scipy/spatial/ckdtree/src/query.cxx
@@ -450,23 +450,30 @@ query_single_point(const ckdtree *self,
 
         }
     }
-    /* fill output arrays with sorted neighbors */
-    int j = nk - 1;
-    /* k must be sorted; to avoid making this O(n * nk). */
+
+    /* heapsort */
+    std::vector<heapitem> sorted_neighbors(kmax);
+    npy_intp nnb = neighbors.n;
     for(i = neighbors.n - 1; i >=0; --i) {
-        neighbor = neighbors.pop();
-        while(j >= 0 && i + 1 < k[j]) j --;
-        if(j < 0 || i + 1 > k[j]) continue;
-        /* if we are here i + 1 == k[j], we found a match */
-        result_indices[j] = neighbor.contents.intdata;
-        if (NPY_LIKELY(p == 2.0))
-            result_distances[j] = std::sqrt(-neighbor.priority);
-        else if ((p == 1.) || (ckdtree_isinf(p)))
-            result_distances[j] = -neighbor.priority;
-        else
-            result_distances[j] = std::pow((-neighbor.priority),(1./p));
+        sorted_neighbors[i] = neighbors.pop();
     }
 
+    /* fill output arrays with sorted neighbors */
+    for (i = 0; i < nk; ++i) {
+        if(k[i] - 1 >= nnb) {
+            result_indices[i] = self->n;
+            result_distances[i] = NPY_INFINITY;
+        } else {
+            neighbor = sorted_neighbors[k[i] - 1];
+            result_indices[i] = neighbor.contents.intdata;
+            if (NPY_LIKELY(p == 2.0))
+                result_distances[i] = std::sqrt(-neighbor.priority);
+            else if ((p == 1.) || (ckdtree_isinf(p)))
+                result_distances[i] = -neighbor.priority;
+            else
+                result_distances[i] = std::pow((-neighbor.priority),(1./p));
+        }
+    }
 }
 
 /* Query n points for their k nearest neighbors */

--- a/scipy/spatial/ckdtree/src/query.cxx
+++ b/scipy/spatial/ckdtree/src/query.cxx
@@ -460,7 +460,7 @@ query_single_point(const ckdtree *self,
 
     /* fill output arrays with sorted neighbors */
     for (i = 0; i < nk; ++i) {
-        if(k[i] - 1 >= nnb) {
+        if(NPY_UNLIKELY(k[i] - 1 >= nnb)) {
             result_indices[i] = self->n;
             result_distances[i] = NPY_INFINITY;
         } else {

--- a/scipy/spatial/ckdtree/src/query.cxx
+++ b/scipy/spatial/ckdtree/src/query.cxx
@@ -452,12 +452,12 @@ query_single_point(const ckdtree *self,
     }
     /* fill output arrays with sorted neighbors */
     int j = nk - 1;
-    while(k[j] > neighbors.n) {
-        j--;
-    }
-    for (i=neighbors.n-1; i>=0; --i) {
+    /* k must be sorted; to avoid making this O(n * nk). */
+    for(i = neighbors.n - 1; i >=0; --i) {
         neighbor = neighbors.pop();
-        if(i + 1 != k[j]) continue;
+        while(j >= 0 && i + 1 < k[j]) j --;
+        if(j < 0 || i + 1 > k[j]) continue;
+        /* if we are here i + 1 == k[j], we found a match */
         result_indices[j] = neighbor.contents.intdata;
         if (NPY_LIKELY(p == 2.0))
             result_distances[j] = std::sqrt(-neighbor.priority);
@@ -465,7 +465,6 @@ query_single_point(const ckdtree *self,
             result_distances[j] = -neighbor.priority;
         else
             result_distances[j] = std::pow((-neighbor.priority),(1./p));
-        --j;
     }
 
 }


### PR DESCRIPTION
This was because a loosen check on j >= 0 in the branches. The loop
was not carefully written. It has been replaced with a version that
is easier to understand.

Also added the docstring warning that if k is not sorted the result
is undefined. We can worry about adding a sorting wrapper in cython
later if there is a demand.

This fixes #7262