### PR TITLE
DOC: corrected docstring for interpolate.griddata

### DIFF
--- a/scipy/interpolate/ndgriddata.py
+++ b/scipy/interpolate/ndgriddata.py
@@ -92,14 +92,12 @@ def griddata(points, values, xi, method='linear', fill_value=np.nan,
 
     Parameters
     ----------
-    points : 2-D ndarray of floats with shape (n, D), or tuple of 1-D ndarrays
-        Data point coordinates. Can either be a 2-D ndarray with
-        shape (n, D), or a length D tuple of 1-D ndarrays with shape (n,).
+    points : 2-D ndarray of floats with shape (n, D), or length D tuple of 1-D ndarrays with shape (n,).
+        Data point coordinates. 
     values : 1-D ndarray of float or complex with shape (n,)
         Data values.
-    xi : 2-D ndarray of floats with shape (m, D), or tuple of ndarrays
-        Points at which to interpolate data. Can either be a 2-D ndarray with
-        shape (m, D), or a length D tuple of ndarrays with identical dimensions.
+    xi : 2-D ndarray of floats with shape (m, D), or length D tuple of ndarrays with identical shapes.
+        Points at which to interpolate data.
     method : {'linear', 'nearest', 'cubic'}, optional
         Method of interpolation. One of
 

--- a/scipy/interpolate/ndgriddata.py
+++ b/scipy/interpolate/ndgriddata.py
@@ -92,13 +92,14 @@ def griddata(points, values, xi, method='linear', fill_value=np.nan,
 
     Parameters
     ----------
-    points : ndarray of floats, shape (n, D)
-        Data point coordinates. Can either be an array of
-        shape (n, D), or a tuple of `ndim` arrays.
-    values : ndarray of float or complex, shape (n,)
+    points : 2-D ndarray of floats with shape (n, D), or tuple of 1-D ndarrays
+        Data point coordinates. Can either be a 2-D ndarray with
+        shape (n, D), or a length D tuple of 1-D ndarrays with shape (n,).
+    values : 1-D ndarray of float or complex with shape (n,)
         Data values.
-    xi : 2-D ndarray of float or tuple of 1-D array, shape (M, D)
-        Points at which to interpolate data.
+    xi : 2-D ndarray of floats with shape (m, D), or tuple of ndarrays
+        Points at which to interpolate data. Can either be a 2-D ndarray with
+        shape (m, D), or a length D tuple of ndarrays with identical dimensions.
     method : {'linear', 'nearest', 'cubic'}, optional
         Method of interpolation. One of
 
@@ -108,7 +109,7 @@ def griddata(points, values, xi, method='linear', fill_value=np.nan,
           more details.
 
         ``linear``
-          tesselate the input point set to n-dimensional
+          tesselate the input point set to D-dimensional
           simplices, and interpolate linearly on each simplex.  See
           `LinearNDInterpolator` for more details.
 


### PR DESCRIPTION
Clarified usage and fixed description to match actual implementation of griddata. Fixes #4802. 