### PR TITLE
Upcast half- and single-precision floats to doubles in BSpline et al

### DIFF
--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -29,6 +29,19 @@ def _get_dtype(dtype):
         return np.float_
 
 
+def _as_float_array(x, check_finite=False):
+    """Convert the input into a C contiguous float array.
+
+    NB: Upcasts half- and single-precision floats to double precision.
+    """
+    x = np.ascontiguousarray(x)
+    dtyp = _get_dtype(x.dtype)
+    x = x.astype(dtyp, copy=False)
+    if check_finite and not np.isfinite(x).all():
+        raise ValueError("Array must not contain infs or nans.")
+    return x
+
+
 class BSpline(object):
     r"""Univariate spline in the B-spline basis.
 
@@ -495,16 +508,6 @@ def _not_a_knot(x, k):
 def _augknt(x, k):
     """Construct a knot vector appropriate for the order-k interpolation."""
     return np.r_[(x[0],)*k, x, (x[-1],)*k]
-
-
-def _as_float_array(x, check_finite=False):
-    """Convert the input into a C contiguous float array."""
-    x = np.ascontiguousarray(x)
-    if not np.issubdtype(x.dtype, np.inexact):
-        x = x.astype(float)
-    if check_finite and not np.isfinite(x).all():
-        raise ValueError("Array must not contain infs or nans.")
-    return x
 
 
 def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -276,6 +276,15 @@ class TestInterp1D(object):
             assert_equal(yp.dtype, dtyp)
             assert_allclose(yp, y, atol=1e-15)
 
+    def test_slinear_dtypes(self):
+        # regression test for gh-7273: 1D slinear interpolation failes with
+        # float32 inputs
+        x = np.arange(0, 10, dtype=np.float32)
+        y = np.exp(-x/3.0)
+        f = interp1d(x, y, kind='slinear', bounds_error=False)
+        xnew = np.arange(0, 9, 0.1)
+        ynew = f(xnew)   # use interpolation function returned by `interp1d`        
+
     def test_cubic(self):
         # Check the actual implementation of spline interpolation.
         interp10 = interp1d(self.x10, self.y10, kind='cubic')


### PR DESCRIPTION
The simplest, *single precison? Who needs single precision?*, fix for gh-7273.

This is, strictly speaking, a back-compat break for interp1d. However, this makes BSpline, `make_*_spline` and `interp1d` spline kinds  consistent with PPoly and np.interp: both just upcast everything to float64.

An alternative would be to downcast inputs to the dtype of the data points, https://github.com/scipy/scipy/issues/7273#issuecomment-292562765
This is possible, but I don't believe it would be that useful. 

Either way, this is a regression of 0.19.0, so it would be good to backport.