### PR TITLE
MAINT: add issue template for bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,20 @@
+
+<<Please describe the issue in detail here, and for bug reports fill in the fields below.>>
+
+
+
+### Reproducing code example:
+```
+<<A short code example that reproduces the problem. It should be self-contained, i.e., possible to run as-is via 'python myproblem.py'>>
+```
+
+### Error message:
+```
+<<Full error message, if any (starting from line Traceback: ...)>>
+```
+
+### Scipy/Numpy/Python version information:
+```
+<<Output from 'import sys, scipy, numpy; print(scipy.__version__, numpy.__version__, sys.version_info)'>>
+```
+


### PR DESCRIPTION
It may be worthwhile to add an issue template to guide people on what information is useful to include in bug reports, especially in trying to push them to include self-contained test cases.