### PR TITLE
BUG: optimize/slsqp: clip initial guess to bounds

### DIFF
--- a/scipy/optimize/slsqp.py
+++ b/scipy/optimize/slsqp.py
@@ -349,6 +349,12 @@ def _minimize_slsqp(func, x0, args=(), jac=None, bounds=None,
         xl[infbnd[:, 0]] = np.nan
         xu[infbnd[:, 1]] = np.nan
 
+    # Clip initial guess to bounds (SLSQP may fail with bounds-infeasible initial point)
+    have_bound = np.isfinite(xl)
+    x[have_bound] = np.clip(x[have_bound], xl[have_bound], np.inf)
+    have_bound = np.isfinite(xu)
+    x[have_bound] = np.clip(x[have_bound], -np.inf, xu[have_bound])
+
     # Initialize the iteration counter and the mode value
     mode = array(0,int)
     acc = array(acc,float)


### PR DESCRIPTION
SLSQP fails to correctly deal with initial points outside the bounds, as
it may return false positives. Fix this by clipping the initial point
inside the bounds.

Infeasible initial points (vs. constraints) however appear to work
correctly.

Fixes gh-6859