### PR TITLE
MAINT: fix signal.resample for small input arrays

### DIFF
--- a/scipy/fftpack/basic.py
+++ b/scipy/fftpack/basic.py
@@ -215,8 +215,6 @@ def fft(x, n=None, axis=-1, overwrite_x=False):
 
             y(j) = sum[k=0..n-1] x[k] * exp(-sqrt(-1)*j*k* 2*pi/n), j = 0..n-1
 
-        Note that ``y(-j) = y(n-j).conjugate()``.
-
     See Also
     --------
     ifft : Inverse FFT
@@ -231,10 +229,6 @@ def fft(x, n=None, axis=-1, overwrite_x=False):
     transform, the frequencies of the result are [0, 1, 2, 3, -4, -3, -2, -1].
     To rearrange the fft output so that the zero-frequency component is
     centered, like [-4, -3, -2, -1,  0,  1,  2,  3], use `fftshift`.
-
-    For `n` even, ``A[n/2]`` contains the sum of the positive and
-    negative-frequency terms.  For `n` even and `x` real, ``A[n/2]`` will
-    always be real.
 
     Both single and double precision routines are implemented.  Half precision
     inputs will be converted to single precision.  Non floating-point inputs
@@ -395,8 +389,6 @@ def rfft(x, n=None, axis=-1, overwrite_x=False):
 
           y(j) = sum[k=0..n-1] x[k] * exp(-sqrt(-1)*j*k*2*pi/n)
           j = 0..n-1
-
-        Note that ``y(-j) == y(n-j).conjugate()``.
 
     See Also
     --------
@@ -579,7 +571,6 @@ def fftn(x, shape=None, axes=None, overwrite_x=False):
          x[k_1,..,k_d] * prod[i=1..d] exp(-sqrt(-1)*2*pi/n_i * j_i * k_i)
 
     where d = len(x.shape) and n = x.shape.
-    Note that ``y[..., -j_i, ...] = y[..., n_i-j_i, ...].conjugate()``.
 
     Parameters
     ----------

--- a/scipy/fftpack/basic.py
+++ b/scipy/fftpack/basic.py
@@ -238,6 +238,9 @@ def fft(x, n=None, axis=-1, overwrite_x=False):
     This function is most efficient when `n` is a power of two, and least
     efficient when `n` is prime.
 
+    Note that if ``x`` is real-valued then ``A[j] == A[n-j].conjugate()``.
+    If ``x`` is real-valued and ``n`` is even then ``A[n/2]`` is real. 
+    
     If the data type of `x` is real, a "real FFT" algorithm is automatically
     used, which roughly halves the computation time.  To increase efficiency
     a little further, use `rfft`, which does the same calculation, but only
@@ -600,6 +603,9 @@ def fftn(x, shape=None, axes=None, overwrite_x=False):
 
     Notes
     -----
+    If ``x`` is real-valued, then 
+    ``y[..., j_i, ...] == y[..., n_i-j_i, ...].conjugate()``.
+    
     Both single and double precision routines are implemented.  Half precision
     inputs will be converted to single precision.  Non floating-point inputs
     will be converted to double precision.  Long-double precision inputs are

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2233,16 +2233,16 @@ def resample(x, num, t=None, axis=0, window=None):
     sl[axis] = slice(-(N - 1) // 2, None)
     Y[sl] = X[sl]
 
-    if N%2==0: # special treatment if low number of points is even. So far we have set Y[-N/2]=X[-N/2]
-        if N<Nx: # if downsampling
-            sl[axis] = slice(N//2,N//2+1,None) # select the component at frequency N/2
-            Y[sl]+=X[sl] # add the component of X at N/2 
-        elif N<num: # if upsampling
-            sl[axis] = slice(num-N//2,num-N//2+1,None) # select the component at frequency -N/2
-            Y[sl]/=2 # halve the component at -N/2 
-            temp=Y[sl]
-            sl[axis] = slice(N//2,N//2+1,None) # select the component at +N/2
-            Y[sl]=temp # set that equal to the component at -N/2
+    if N % 2 == 0:  # special treatment if low number of points is even. So far we have set Y[-N/2]=X[-N/2]
+        if N < Nx:  # if downsampling
+            sl[axis] = slice(N//2,N//2+1,None)  # select the component at frequency N/2
+            Y[sl] += X[sl]  # add the component of X at N/2 
+        elif N < num:  # if upsampling
+            sl[axis] = slice(num-N//2,num-N//2+1,None)  # select the component at frequency -N/2
+            Y[sl] /= 2  # halve the component at -N/2 
+            temp = Y[sl]
+            sl[axis] = slice(N//2,N//2+1,None)  # select the component at +N/2
+            Y[sl] = temp  # set that equal to the component at -N/2
 
     y = fftpack.ifft(Y, axis=axis) * (float(num) / float(Nx))
 

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2232,6 +2232,18 @@ def resample(x, num, t=None, axis=0, window=None):
     Y[sl] = X[sl]
     sl[axis] = slice(-(N - 1) // 2, None)
     Y[sl] = X[sl]
+
+    if N%2==0: # special treatment if low number of points is even. So far we have set Y[-N/2]=X[-N/2]
+        if N<Nx: # if downsampling
+            sl[axis] = slice(N//2,N//2+1,None) # select the component at frequency N/2
+            Y[sl]+=X[sl] # add the component of X at N/2 
+        elif N<num: # if upsampling
+            sl[axis] = slice(num-N//2,num-N//2+1,None) # select the component at frequency -N/2
+            Y[sl]/=2 # halve the component at -N/2 
+            temp=Y[sl]
+            sl[axis] = slice(N//2,N//2+1,None) # select the component at +N/2
+            Y[sl]=temp # set that equal to the component at -N/2
+
     y = fftpack.ifft(Y, axis=axis) * (float(num) / float(Nx))
 
     if x.dtype.char not in ['F', 'D']:

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -612,13 +612,13 @@ class TestResample(TestCase):
 
         # More tests of fft method (Master 0.18.1 fails these)
         if method == 'fft':
-            x1=np.array([1.+0.j,0.+0.j])
-            y1_test=signal.resample(x1,4)
-            y1_true=np.array([1.+0.j,0.5+0.j,0.+0.j,0.5+0.j]) # upsampling a complex array
+            x1 = np.array([1.+0.j,0.+0.j])
+            y1_test = signal.resample(x1,4)
+            y1_true = np.array([1.+0.j,0.5+0.j,0.+0.j,0.5+0.j])  # upsampling a complex array
             assert_allclose(y1_test, y1_true, atol=1e-12)
-            x2=np.array([1.,0.5,0.,0.5])
-            y2_test=signal.resample(x2,2) # downsampling a real array
-            y2_true=np.array([1.,0.])
+            x2 = np.array([1.,0.5,0.,0.5])
+            y2_test = signal.resample(x2,2)  # downsampling a real array
+            y2_true = np.array([1.,0.])
             assert_allclose(y2_test, y2_true, atol=1e-12)
 
     def test_poly_vs_filtfilt(self):

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -610,6 +610,17 @@ class TestResample(TestCase):
             corr = np.corrcoef(y_to, y_resamp)[0, 1]
             assert_(corr > 0.99, msg=corr)
 
+        # More tests of fft method (Master 0.18.1 fails these)
+        if method == 'fft':
+            x1=np.array([1.+0.j,0.+0.j])
+            y1_test=signal.resample(x1,4)
+            y1_true=np.array([1.+0.j,0.5+0.j,0.+0.j,0.5+0.j]) # upsampling a complex array
+            assert_allclose(y1_test, y1_true, atol=1e-12)
+            x2=np.array([1.,0.5,0.,0.5])
+            y2_test=signal.resample(x2,2) # downsampling a real array
+            y2_true=np.array([1.,0.])
+            assert_allclose(y2_test, y2_true, atol=1e-12)
+
     def test_poly_vs_filtfilt(self):
         # Check that up=1.0 gives same answer as filtfilt + slicing
         random_state = np.random.RandomState(17)


### PR DESCRIPTION
This takes care of issue #7278. Edited code for signal.resample() in signal/signaltools.py. Wrote some unit tests in signal/tests/testsignaltools.py. Fixed some doc strings in fftpack/basic.py.