### PR TITLE
ENH: Fix tox config to allow testing with tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,15 +25,17 @@
 # installed and that they can be run as 'python2.6', 'python2.7', etc.
 
 [tox]
-toxworkdir = {homedir}/.tox/scipy/
-envlist = py26,py27,py31,py32,py33
+envlist = py27,py34,py35,py36
+skipsdist=True
 
 [testenv]
 deps=
-  nose
-  numpy
+    nose
+    numpy
+    cython
 changedir={envdir}
-commands=python {toxinidir}/runtests.py -n -m full {posargs:}
+commands=
+    {envpython} {toxinidir}/runtests.py {posargs: --mode full}
 
 [pep8]
 max_line_length = 79


### PR DESCRIPTION
The current tox config does not work (cython needs to be installed before calling sdist), and does not use the currently supported python versions.