### PR TITLE
fixing mistake in resample_poly doc

### DIFF
--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -166,10 +166,10 @@ def correlate(in1, in2, mode='full', method='auto'):
         z[...,k,...] = sum[..., i_l, ...] x[..., i_l,...] * conj(y[..., i_l - k,...])
 
     This way, if x and y are 1-D arrays and ``z = correlate(x, y, 'full')`` then
-      
+
     .. math::
 
-          z[k] = (x * y)(k - N + 1) 
+          z[k] = (x * y)(k - N + 1)
                = \sum_{l=0}^{||x||-1}x_l y_{l-k+N-1}^{*}
 
     for :math:`k = 0, 1, ..., ||x|| + ||y|| - 2`
@@ -2304,7 +2304,7 @@ def resample_poly(x, up, down, axis=0, window=('kaiser', 5.0)):
 
     The first sample of the returned vector is the same as the first
     sample of the input vector. The spacing between samples is changed
-    from ``dx`` to ``dx * up / float(down)``.
+    from ``dx`` to ``dx * down / float(up)``.
 
     Examples
     --------


### PR DESCRIPTION
Documentation for `scipy.signal.resample_poly` has a confusing mistake.

Documentation states "The resulting sample rate is `up / down` times the original sample rate" which is correct. But later on, the documentation states "The spacing between samples is changed from `dx` to `dx * up / float(down)`" which is incorrect:

```
s_old : original sampling rate
s_new : new sampling rate
dx_old : original spacing between samples
dx_new : new spacing between samples

s_new = s_old * up / down

dx_old = 1 / s_old
dx_new = 1 / s_new
       = 1 / (s_old * (up / down))
       = (1 / s_old) * (down / up)
       = dx_old * down / up
```

My editor also removed trailing whitespace from the file. Hopefully that's not a problem.