### PR TITLE
Simplify if-statements and constructor calls in `integrate._ode`

### DIFF
--- a/scipy/integrate/_ode.py
+++ b/scipy/integrate/_ode.py
@@ -1063,8 +1063,10 @@ class dop853(dopri5):
                  method=None,
                  verbosity=-1,  # no messages if negative
                  ):
-        super(self.__class__, self).__init__(rtol, atol, nsteps, max_step, first_step, safety, ifactor, dfactor,
-                                             beta, method, verbosity)
+        super(self.__class__, self).__init__(rtol, atol, nsteps, max_step,
+                                             first_step, safety, ifactor,
+                                             dfactor, beta, method,
+                                             verbosity)
 
     def reset(self, n, has_jac):
         work = zeros((11 * n + 21,), float)

--- a/scipy/integrate/_ode.py
+++ b/scipy/integrate/_ode.py
@@ -450,7 +450,7 @@ class ode(object):
                 self._integrator.reset(len(self._y), self.jac is not None)
         else:
             raise ValueError("selected integrator does not support solout,"
-                             + " choose another one")
+                             " choose another one")
 
 
 def _transform_banded_jac(bjac):
@@ -674,7 +674,7 @@ class IntegratorBase(object):
         raise NotImplementedError('%s does not support run_relax() method' %
                                   self.__class__.__name__)
 
-        # XXX: __str__ method for getting visual state of the integrator
+    # XXX: __str__ method for getting visual state of the integrator
 
 
 def _vode_banded_jac_wrapper(jacfunc, ml, jac_params):
@@ -801,24 +801,24 @@ class vode(IntegratorBase):
     def reset(self, n, has_jac):
         mf = self._determine_mf_and_set_bands(has_jac)
 
-        if type(mf) != int or mf < 10 or mf > 25 or (mf >= 16 and mf <= 19):
-            raise ValueError('Unexpected mf=%s' % mf)
-        elif mf == 10:
+        if mf == 10:
             lrw = 20 + 16 * n
-        elif mf <= 12:
+        if mf in [11, 12]:
             lrw = 22 + 16 * n + 2 * n * n
         elif mf == 13:
             lrw = 22 + 17 * n
-        elif mf <= 15:
+        elif mf in [14, 15]:
             lrw = 22 + 18 * n + (3 * self.ml + 2 * self.mu) * n
         elif mf == 20:
             lrw = 20 + 9 * n
-        elif mf <= 22:
+        elif mf in [21, 22]:
             lrw = 22 + 9 * n + 2 * n * n
         elif mf == 23:
             lrw = 22 + 10 * n
-        else:
+        elif mf in [24, 25]:
             lrw = 22 + 11 * n + (3 * self.ml + 2 * self.mu) * n
+        else:
+            raise ValueError('Unexpected mf=%s' % mf)
 
         if mf % 10 in [0, 3]:
             liw = 30

--- a/scipy/integrate/_ode.py
+++ b/scipy/integrate/_ode.py
@@ -674,7 +674,7 @@ class IntegratorBase(object):
         raise NotImplementedError('%s does not support run_relax() method' %
                                   self.__class__.__name__)
 
-    # XXX: __str__ method for getting visual state of the integrator
+        # XXX: __str__ method for getting visual state of the integrator
 
 
 def _vode_banded_jac_wrapper(jacfunc, ml, jac_params):
@@ -803,7 +803,7 @@ class vode(IntegratorBase):
 
         if mf == 10:
             lrw = 20 + 16 * n
-        if mf in [11, 12]:
+        elif mf in [11, 12]:
             lrw = 22 + 16 * n + 2 * n * n
         elif mf == 13:
             lrw = 22 + 17 * n

--- a/scipy/integrate/_ode.py
+++ b/scipy/integrate/_ode.py
@@ -674,7 +674,7 @@ class IntegratorBase(object):
         raise NotImplementedError('%s does not support run_relax() method' %
                                   self.__class__.__name__)
 
-        # XXX: __str__ method for getting visual state of the integrator
+    # XXX: __str__ method for getting visual state of the integrator
 
 
 def _vode_banded_jac_wrapper(jacfunc, ml, jac_params):

--- a/scipy/integrate/_ode.py
+++ b/scipy/integrate/_ode.py
@@ -39,7 +39,6 @@ an alternative to ode with the zvode solver, sometimes performing better.
 """
 from __future__ import division, print_function, absolute_import
 
-
 # XXX: Integrators must have:
 # ===========================
 # cvode - C version of vode and vodpk with many improvements.
@@ -95,9 +94,9 @@ from . import _dop
 from . import lsoda as _lsoda
 
 
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # User interface
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 
 
 class ode(object):
@@ -344,6 +343,7 @@ class ode(object):
         Springer-Verlag (1993)
 
     """
+
     def __init__(self, f, jac=None):
         self.stiff = 0
         self.f = f
@@ -384,7 +384,7 @@ class ode(object):
             # FIXME: this really should be raise an exception. Will that break
             # any code?
             warnings.warn('No integrator name match with %r or is not '
-                'available.' % name)
+                          'available.' % name)
         else:
             self._integrator = integrator(**integrator_params)
             if not len(self._y):
@@ -404,8 +404,8 @@ class ode(object):
 
         try:
             self._y, self.t = mth(self.f, self.jac or (lambda: None),
-                                self._y, self.t, t,
-                                self.f_params, self.jac_params)
+                                  self._y, self.t, t,
+                                  self.f_params, self.jac_params)
         except SystemError:
             # f2py issue with tuple returns, see ticket 1187.
             raise ValueError('Function to integrate must not return a tuple.')
@@ -450,7 +450,7 @@ class ode(object):
                 self._integrator.reset(len(self._y), self.jac is not None)
         else:
             raise ValueError("selected integrator does not support solout,"
-                            + " choose another one")
+                             + " choose another one")
 
 
 def _transform_banded_jac(bjac):
@@ -467,7 +467,7 @@ def _transform_banded_jac(bjac):
     """
     # Shift every other column.
     newjac = zeros((bjac.shape[0] + 1, bjac.shape[1]))
-    newjac[1:,::2] = bjac[:, ::2]
+    newjac[1:, ::2] = bjac[:, ::2]
     newjac[:-1, 1::2] = bjac[:, 1::2]
     return newjac
 
@@ -504,10 +504,10 @@ class complex_ode(ode):
     def __init__(self, f, jac=None):
         self.cf = f
         self.cjac = jac
-        if jac is not None:
-            ode.__init__(self, self._wrap, self._wrap_jac)
-        else:
+        if jac is None:
             ode.__init__(self, self._wrap, None)
+        else:
+            ode.__init__(self, self._wrap, self._wrap_jac)
 
     def _wrap(self, t, y, *f_args):
         f = self.cf(*((t, y[::2] + 1j * y[1::2]) + f_args))
@@ -525,7 +525,7 @@ class complex_ode(ode):
         # entry in jac, say 2+3j, becomes a 2x2 block of the form
         #     [2 -3]
         #     [3  2]
-        jac_tmp = zeros((2*jac.shape[0], 2*jac.shape[1]))
+        jac_tmp = zeros((2 * jac.shape[0], 2 * jac.shape[1]))
         jac_tmp[1::2, 1::2] = jac_tmp[::2, ::2] = real(jac)
         jac_tmp[1::2, ::2] = imag(jac)
         jac_tmp[::2, 1::2] = -jac_tmp[1::2, ::2]
@@ -565,8 +565,8 @@ class complex_ode(ode):
             # (which are for the complex Jacobian) with the bandwidths of
             # the corresponding real-valued Jacobian wrapper of the complex
             # Jacobian.
-            integrator_params['lband'] = 2*(lband or 0) + 1
-            integrator_params['uband'] = 2*(uband or 0) + 1
+            integrator_params['lband'] = 2 * (lband or 0) + 1
+            integrator_params['uband'] = 2 * (uband or 0) + 1
 
         return ode.set_integrator(self, name, **integrator_params)
 
@@ -604,9 +604,9 @@ class complex_ode(ode):
                             + "choose another one")
 
 
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # ODE integrators
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 
 def find_integrator(name):
     for cl in IntegratorBase.integrator_classes:
@@ -621,6 +621,7 @@ class IntegratorConcurrencyError(RuntimeError):
     only for a single problem at a time.
 
     """
+
     def __init__(self, name):
         msg = ("Integrator `%s` can be used to solve only a single problem "
                "at a time. If you want to integrate multiple problems, "
@@ -630,9 +631,8 @@ class IntegratorConcurrencyError(RuntimeError):
 
 
 class IntegratorBase(object):
-
-    runner = None            # runner is None => integrator is not available
-    success = None           # success==1 if integrator was called successfully
+    runner = None  # runner is None => integrator is not available
+    success = None  # success==1 if integrator was called successfully
     supports_run_relax = None
     supports_step = None
     supports_solout = False
@@ -662,19 +662,19 @@ class IntegratorBase(object):
         defines the stoppage coordinate of the result.
         """
         raise NotImplementedError('all integrators must define '
-                'run(f, jac, t0, t1, y0, f_params, jac_params)')
+                                  'run(f, jac, t0, t1, y0, f_params, jac_params)')
 
     def step(self, f, jac, y0, t0, t1, f_params, jac_params):
         """Make one integration step and return (y1,t1)."""
         raise NotImplementedError('%s does not support step() method' %
-                self.__class__.__name__)
+                                  self.__class__.__name__)
 
     def run_relax(self, f, jac, y0, t0, t1, f_params, jac_params):
         """Integrate from t=t0 to t>=t1 and return (y1,t)."""
         raise NotImplementedError('%s does not support run_relax() method' %
-                self.__class__.__name__)
+                                  self.__class__.__name__)
 
-    #XXX: __str__ method for getting visual state of the integrator
+        # XXX: __str__ method for getting visual state of the integrator
 
 
 def _vode_banded_jac_wrapper(jacfunc, ml, jac_params):
@@ -692,7 +692,6 @@ def _vode_banded_jac_wrapper(jacfunc, ml, jac_params):
 
 
 class vode(IntegratorBase):
-
     runner = getattr(_vode, 'dvode', None)
 
     messages = {-1: 'Excess work done on this call. (Perhaps wrong MF.)',
@@ -700,9 +699,9 @@ class vode(IntegratorBase):
                 -3: 'Illegal input detected. (See printed message.)',
                 -4: 'Repeated error test failures. (Check all input.)',
                 -5: 'Repeated convergence failures. (Perhaps bad'
-                ' Jacobian supplied or wrong choice of MF or tolerances.)',
+                    ' Jacobian supplied or wrong choice of MF or tolerances.)',
                 -6: 'Error weight became zero during problem. (Solution'
-                ' component i vanished, and ATOL or ATOL(i) = 0.)'
+                    ' component i vanished, and ATOL or ATOL(i) = 0.)'
                 }
     supports_run_relax = 1
     supports_step = 1
@@ -802,24 +801,24 @@ class vode(IntegratorBase):
     def reset(self, n, has_jac):
         mf = self._determine_mf_and_set_bands(has_jac)
 
-        if mf == 10:
+        if type(mf) != int or mf < 10 or mf > 25 or (mf >= 16 and mf <= 19):
+            raise ValueError('Unexpected mf=%s' % mf)
+        elif mf == 10:
             lrw = 20 + 16 * n
-        elif mf in [11, 12]:
+        elif mf <= 12:
             lrw = 22 + 16 * n + 2 * n * n
         elif mf == 13:
             lrw = 22 + 17 * n
-        elif mf in [14, 15]:
+        elif mf <= 15:
             lrw = 22 + 18 * n + (3 * self.ml + 2 * self.mu) * n
         elif mf == 20:
             lrw = 20 + 9 * n
-        elif mf in [21, 22]:
+        elif mf <= 22:
             lrw = 22 + 9 * n + 2 * n * n
         elif mf == 23:
             lrw = 22 + 10 * n
-        elif mf in [24, 25]:
-            lrw = 22 + 11 * n + (3 * self.ml + 2 * self.mu) * n
         else:
-            raise ValueError('Unexpected mf=%s' % mf)
+            lrw = 22 + 11 * n + (3 * self.ml + 2 * self.mu) * n
 
         if mf % 10 in [0, 3]:
             liw = 30
@@ -839,7 +838,7 @@ class vode(IntegratorBase):
             iwork[1] = self.mu
         iwork[4] = self.order
         iwork[5] = self.nsteps
-        iwork[6] = 2           # mxhnil
+        iwork[6] = 2  # mxhnil
         self.iwork = iwork
 
         self.call_args = [self.rtol, self.atol, 1, 1,
@@ -950,7 +949,7 @@ class zvode(vode):
             iwork[1] = self.mu
         iwork[4] = self.order
         iwork[5] = self.nsteps
-        iwork[6] = 2           # mxhnil
+        iwork[6] = 2  # mxhnil
         self.iwork = iwork
 
         self.call_args = [self.rtol, self.atol, 1, 1,
@@ -964,7 +963,6 @@ if zvode.runner is not None:
 
 
 class dopri5(IntegratorBase):
-
     runner = getattr(_dop, 'dopri5', None)
     name = 'dopri5'
     supports_solout = True
@@ -1032,7 +1030,7 @@ class dopri5(IntegratorBase):
                                           tuple(self.call_args) + (f_params,)))
         if idid < 0:
             warnings.warn(self.name + ': ' +
-                self.messages.get(idid, 'Unexpected idid=%s' % idid))
+                          self.messages.get(idid, 'Unexpected idid=%s' % idid))
             self.success = 0
         return y, x
 
@@ -1044,12 +1042,12 @@ class dopri5(IntegratorBase):
         else:
             return 1
 
+
 if dopri5.runner is not None:
     IntegratorBase.integrator_classes.append(dopri5)
 
 
 class dop853(dopri5):
-
     runner = getattr(_dop, 'dop853', None)
     name = 'dop853'
 
@@ -1065,18 +1063,8 @@ class dop853(dopri5):
                  method=None,
                  verbosity=-1,  # no messages if negative
                  ):
-        self.rtol = rtol
-        self.atol = atol
-        self.nsteps = nsteps
-        self.max_step = max_step
-        self.first_step = first_step
-        self.safety = safety
-        self.ifactor = ifactor
-        self.dfactor = dfactor
-        self.beta = beta
-        self.verbosity = verbosity
-        self.success = 1
-        self.set_solout(None)
+        super(self.__class__, self).__init__(rtol, atol, nsteps, max_step, first_step, safety, ifactor, dfactor,
+                                             beta, method, verbosity)
 
     def reset(self, n, has_jac):
         work = zeros((11 * n + 21,), float)
@@ -1095,12 +1083,12 @@ class dop853(dopri5):
                           self.iout, self.work, self.iwork]
         self.success = 1
 
+
 if dop853.runner is not None:
     IntegratorBase.integrator_classes.append(dop853)
 
 
 class lsoda(IntegratorBase):
-
     runner = getattr(_lsoda, 'lsoda', None)
     active_global_handle = 0
 
@@ -1198,7 +1186,7 @@ class lsoda(IntegratorBase):
         self.success = 1
         self.initialized = False
 
-    def run(self, f,jac,y0,t0,t1,f_params,jac_params):
+    def run(self, f, jac, y0, t0, t1, f_params, jac_params):
         if self.initialized:
             self.check_handle()
         else:
@@ -1229,6 +1217,7 @@ class lsoda(IntegratorBase):
         r = self.run(*args)
         self.call_args[2] = itask
         return r
+
 
 if lsoda.runner:
     IntegratorBase.integrator_classes.append(lsoda)


### PR DESCRIPTION
There were some pieces of code in _ode that were using negated `if`s for simple `if` constructs as in 

```python
if not a:
    b()
else:
    c()
```

Which I inverted to
```python
if a:
    c()
else:
    b()
```

for simplification and readability. Furthermore, I simplified some if statements. Finally, there was a child class where the constructor was explicitly called where it could have just been a one line call to the super constructor, which I simplified as well. 