### PR TITLE
REL: add `python_requires` to setup.py, fix Python version check.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,8 @@ import textwrap
 import warnings
 
 
-if sys.version_info[:2] < (2, 6) or (3, 0) <= sys.version_info[0:2] < (3, 2):
-    raise RuntimeError("Python version 2.6, 2.7 or >= 3.2 required.")
+if sys.version_info[:2] < (2, 7) or (3, 0) <= sys.version_info[:2] < (3, 4):
+    raise RuntimeError("Python version 2.7 or >= 3.4 required.")
 
 if sys.version_info[0] < 3:
     import __builtin__ as builtins
@@ -379,6 +379,7 @@ def setup_package():
         test_suite='nose.collector',
         setup_requires=build_requires,
         install_requires=build_requires,
+        python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
     )
 
     if "--force" in sys.argv:


### PR DESCRIPTION
This allows pip to figure out the last compatible version
with a particular Python version before attempting to
install.

Support for this field was added to setuptools last year:
https://github.com/pypa/setuptools/pull/631