### PR TITLE
io.FortranFile: write_record correclty writes list of mixed types

### DIFF
--- a/scipy/io/tests/test_fortran.py
+++ b/scipy/io/tests/test_fortran.py
@@ -2,7 +2,7 @@
 
 import tempfile
 import shutil
-from os import path
+from os import path, unlink
 from glob import iglob
 import re
 
@@ -75,6 +75,24 @@ def test_fortranfiles_write():
         finally:
             shutil.rmtree(tmpdir)
 
+def test_fortranfile_write_mixed_record():
+    tf = tempfile.mktemp()
+
+    a = [np.float32(2), np.float32(3), np.int32(100)]
+
+    try:
+        with FortranFile(tf, 'w') as f:
+            f.write_record(a)
+
+        with FortranFile(tf, 'r') as f:
+            b = f.read_record('f4,f4,i4')
+
+        assert_equal(b['f0'][0], a[0])
+        assert_equal(b['f1'][0], a[1])
+        assert_equal(b['f2'][0], a[2])
+
+    finally:
+        unlink(tf)
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
FortranFile.write_record should write each element in a list as its own
type, and write the total size of list of elements as a header. single
elements are written encapsulated in np.array's (as before), while
np.array's are also written directly since their elements should all be
the same type.

#7318