### PR TITLE
ENH: add n-dimensional DCT and IDCT to fftpack

### DIFF
--- a/scipy/fftpack/__init__.py
+++ b/scipy/fftpack/__init__.py
@@ -19,6 +19,8 @@ Fast Fourier Transforms (FFTs)
    irfft - Inverse of rfft
    dct - Discrete cosine transform
    idct - Inverse discrete cosine transform
+   dctn - n-dimensional Discrete cosine transform
+   idctn - n-dimensional Inverse discrete cosine transform
    dst - Discrete sine transform
    idst - Inverse discrete sine transform
 
@@ -102,7 +104,7 @@ for k in ['fft', 'ifft', 'fftn', 'ifftn', 'fft2', 'ifft2']:
 del k, register_func
 
 from .realtransforms import *
-__all__.extend(['dct', 'idct', 'dst', 'idst'])
+__all__.extend(['dct', 'idct', 'dst', 'idst', 'dctn', 'idctn'])
 
 from scipy._lib._testutils import PytestTester
 test = PytestTester(__name__)

--- a/scipy/fftpack/__init__.py
+++ b/scipy/fftpack/__init__.py
@@ -23,6 +23,8 @@ Fast Fourier Transforms (FFTs)
    idctn - n-dimensional Inverse discrete cosine transform
    dst - Discrete sine transform
    idst - Inverse discrete sine transform
+   dstn - n-dimensional Discrete sine transform
+   idstn - n-dimensional Inverse discrete sine transform
 
 Differential and pseudo-differential operators
 ==============================================
@@ -104,7 +106,8 @@ for k in ['fft', 'ifft', 'fftn', 'ifftn', 'fft2', 'ifft2']:
 del k, register_func
 
 from .realtransforms import *
-__all__.extend(['dct', 'idct', 'dst', 'idst', 'dctn', 'idctn'])
+__all__.extend(['dct', 'idct', 'dst', 'idst', 'dctn', 'idctn', 'dstn',
+                'idstn'])
 
 from scipy._lib._testutils import PytestTester
 test = PytestTester(__name__)

--- a/scipy/fftpack/realtransforms.py
+++ b/scipy/fftpack/realtransforms.py
@@ -156,6 +156,114 @@ def idctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
     return x
 
 
+def dstn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
+    """
+    Return multidimensional Discrete Sine Transform of x along the specified
+    axes.
+
+    Parameters
+    ----------
+    x : array_like
+        The input array.
+    type : {1, 2, 3}, optional
+        Type of the DCT (see Notes). Default type is 2.
+    shape : tuple of ints, optional
+        The shape of the result.  If both `shape` and `axes` (see below) are
+        None, `shape` is ``x.shape``; if `shape` is None but `axes` is
+        not None, then `shape` is ``scipy.take(x.shape, axes, axis=0)``.
+        If ``shape[i] > x.shape[i]``, the i-th dimension is padded with zeros.
+        If ``shape[i] < x.shape[i]``, the i-th dimension is truncated to
+        length ``shape[i]``.
+    axes : tuple or None, optional
+        Axes along which the DCT is computed; the default is over all axes.
+    norm : {None, 'ortho'}, optional
+        Normalization mode (see Notes). Default is None.
+    overwrite_x : bool, optional
+        If True, the contents of `x` can be destroyed; the default is False.
+
+    Returns
+    -------
+    y : ndarray of real
+        The transformed input array.
+
+    See Also
+    --------
+    idstn : Inverse multidimensional DST
+
+    Notes
+    -----
+    For full details of the DST types and normalization modes, as well as
+    references, see `dst`.
+
+    Examples
+    --------
+    >>> from scipy.fftpack import dstn, idstn
+    >>> y = np.random.randn(16, 16)
+    >>> np.allclose(y, idstn(dstn(y, norm='ortho'), norm='ortho'))
+    True
+
+    """
+    x = np.asanyarray(x)
+    shape, axes = _init_nd_shape_and_axes(x, shape, axes)
+    for n, ax in zip(shape, axes):
+        x = dst(x, type=type, n=n, axis=ax, norm=norm, overwrite_x=overwrite_x)
+    return x
+
+
+def idstn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
+    """
+    Return multidimensional Discrete Sine Transform of x along the specified
+    axes.
+
+    Parameters
+    ----------
+    x : array_like
+        The input array.
+    type : {1, 2, 3}, optional
+        Type of the DCT (see Notes). Default type is 2.
+    shape : tuple of ints, optional
+        The shape of the result.  If both `shape` and `axes` (see below) are
+        None, `shape` is ``x.shape``; if `shape` is None but `axes` is
+        not None, then `shape` is ``scipy.take(x.shape, axes, axis=0)``.
+        If ``shape[i] > x.shape[i]``, the i-th dimension is padded with zeros.
+        If ``shape[i] < x.shape[i]``, the i-th dimension is truncated to
+        length ``shape[i]``.
+    axes : tuple or None, optional
+        Axes along which the IDCT is computed; the default is over all axes.
+    norm : {None, 'ortho'}, optional
+        Normalization mode (see Notes). Default is None.
+    overwrite_x : bool, optional
+        If True, the contents of `x` can be destroyed; the default is False.
+
+    Returns
+    -------
+    y : ndarray of real
+        The transformed input array.
+
+    See Also
+    --------
+    dctn : multidimensional DST
+
+    Notes
+    -----
+    For full details of the IDST types and normalization modes, as well as
+    references, see `idst`.
+
+    Examples
+    --------
+    >>> from scipy.fftpack import dstn, idstn
+    >>> y = np.random.randn(16, 16)
+    >>> np.allclose(y, idstn(dctn(y, norm='ortho'), norm='ortho'))
+    True
+    """
+    x = np.asanyarray(x)
+    shape, axes = _init_nd_shape_and_axes(x, shape, axes)
+    for n, ax in zip(shape, axes):
+        x = idst(x, type=type, n=n, axis=ax, norm=norm,
+                 overwrite_x=overwrite_x)
+    return x
+
+
 def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
     """
     Return the Discrete Cosine Transform of arbitrary type sequence x.

--- a/scipy/fftpack/realtransforms.py
+++ b/scipy/fftpack/realtransforms.py
@@ -4,7 +4,7 @@ Real spectrum tranforms (DCT, DST, MDCT)
 from __future__ import division, print_function, absolute_import
 
 
-__all__ = ['dct', 'idct', 'dst', 'idst', 'dctn', 'idctn']
+__all__ = ['dct', 'idct', 'dst', 'idst', 'dctn', 'idctn', 'dstn', 'idstn']
 
 import numpy as np
 from scipy.fftpack import _fftpack
@@ -50,8 +50,7 @@ def _init_nd_shape_and_axes(x, shape, axes):
 
 def dctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
     """
-    Return multidimensional Discrete Cosine Transform of x along the specified
-    axes.
+    Return multidimensional Discrete Cosine Transform along the specified axes.
 
     Parameters
     ----------
@@ -104,8 +103,7 @@ def dctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
 
 def idctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
     """
-    Return multidimensional Discrete Cosine Transform of x along the specified
-    axes.
+    Return multidimensional Discrete Cosine Transform along the specified axes.
 
     Parameters
     ----------
@@ -158,8 +156,7 @@ def idctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
 
 def dstn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
     """
-    Return multidimensional Discrete Sine Transform of x along the specified
-    axes.
+    Return multidimensional Discrete Sine Transform along the specified axes.
 
     Parameters
     ----------
@@ -212,8 +209,7 @@ def dstn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
 
 def idstn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
     """
-    Return multidimensional Discrete Sine Transform of x along the specified
-    axes.
+    Return multidimensional Discrete Sine Transform along the specified axes.
 
     Parameters
     ----------
@@ -253,7 +249,7 @@ def idstn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
     --------
     >>> from scipy.fftpack import dstn, idstn
     >>> y = np.random.randn(16, 16)
-    >>> np.allclose(y, idstn(dctn(y, norm='ortho'), norm='ortho'))
+    >>> np.allclose(y, idstn(dstn(y, norm='ortho'), norm='ortho'))
     True
     """
     x = np.asanyarray(x)

--- a/scipy/fftpack/realtransforms.py
+++ b/scipy/fftpack/realtransforms.py
@@ -71,6 +71,8 @@ def dctn(x, type=2, n=None, axes=None, norm=None, overwrite_x=False):
         axes = np.arange(x.ndim)
     if np.isscalar(axes):
         axes = [axes, ]
+    if len(np.unique(axes)) != len(axes):
+        raise ValueError("All axes must be unique.")
     for ax in axes:
         x = dct(x, type=type, n=n, axis=ax, norm=norm, overwrite_x=overwrite_x)
     return x
@@ -124,6 +126,8 @@ def idctn(x, type=2, n=None, axes=None, norm=None, overwrite_x=False):
         axes = np.arange(x.ndim)
     if np.isscalar(axes):
         axes = [axes, ]
+    if len(np.unique(axes)) != len(axes):
+        raise ValueError("All axes must be unique.")
     for ax in axes:
         x = idct(x, type=type, n=n, axis=ax, norm=norm,
                  overwrite_x=overwrite_x)

--- a/scipy/fftpack/realtransforms.py
+++ b/scipy/fftpack/realtransforms.py
@@ -22,6 +22,32 @@ atexit.register(_fftpack.destroy_dst1_cache)
 atexit.register(_fftpack.destroy_dst2_cache)
 
 
+def _init_nd_shape_and_axes(x, shape, axes):
+    """Handle shape and axes arguments for dctn, idctn, dstn, idstn."""
+    if shape is None:
+        if axes is None:
+            shape = x.shape
+        else:
+            shape = np.take(x.shape, axes)
+    shape = tuple(shape)
+    for dim in shape:
+        if dim < 1:
+            raise ValueError("Invalid number of DCT data points "
+                             "(%s) specified." % (shape,))
+
+    if axes is None:
+        axes = list(range(-x.ndim, 0))
+    elif np.isscalar(axes):
+        axes = [axes, ]
+    if len(axes) != len(shape):
+        raise ValueError("when given, axes and shape arguments "
+                         "have to be of the same length")
+    if len(np.unique(axes)) != len(axes):
+        raise ValueError("All axes must be unique.")
+
+    return shape, axes
+
+
 def dctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
     """
     Return multidimensional Discrete Cosine Transform of x along the specified
@@ -70,28 +96,7 @@ def dctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
 
     """
     x = np.asanyarray(x)
-
-    if shape is None:
-        if axes is None:
-            shape = x.shape
-        else:
-            shape = np.take(x.shape, axes)
-    shape = tuple(shape)
-    for dim in shape:
-        if dim < 1:
-            raise ValueError("Invalid number of DCT data points "
-                             "(%s) specified." % (shape,))
-
-    if axes is None:
-        axes = list(range(-x.ndim, 0))
-    elif np.isscalar(axes):
-        axes = [axes, ]
-    if len(axes) != len(shape):
-        raise ValueError("when given, axes and shape arguments "
-                         "have to be of the same length")
-    if len(np.unique(axes)) != len(axes):
-        raise ValueError("All axes must be unique.")
-
+    shape, axes = _init_nd_shape_and_axes(x, shape, axes)
     for n, ax in zip(shape, axes):
         x = dct(x, type=type, n=n, axis=ax, norm=norm, overwrite_x=overwrite_x)
     return x
@@ -144,28 +149,7 @@ def idctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
     True
     """
     x = np.asanyarray(x)
-
-    if shape is None:
-        if axes is None:
-            shape = x.shape
-        else:
-            shape = np.take(x.shape, axes)
-    shape = tuple(shape)
-    for dim in shape:
-        if dim < 1:
-            raise ValueError("Invalid number of DCT data points "
-                             "(%s) specified." % (shape,))
-
-    if axes is None:
-        axes = list(range(-x.ndim, 0))
-    elif np.isscalar(axes):
-        axes = [axes, ]
-    if len(axes) != len(shape):
-        raise ValueError("when given, axes and shape arguments "
-                         "have to be of the same length")
-    if len(np.unique(axes)) != len(axes):
-        raise ValueError("All axes must be unique.")
-
+    shape, axes = _init_nd_shape_and_axes(x, shape, axes)
     for n, ax in zip(shape, axes):
         x = idct(x, type=type, n=n, axis=ax, norm=norm,
                  overwrite_x=overwrite_x)

--- a/scipy/fftpack/realtransforms.py
+++ b/scipy/fftpack/realtransforms.py
@@ -4,7 +4,7 @@ Real spectrum tranforms (DCT, DST, MDCT)
 from __future__ import division, print_function, absolute_import
 
 
-__all__ = ['dct', 'idct', 'dst', 'idst']
+__all__ = ['dct', 'idct', 'dst', 'idst', 'dctn', 'idctn']
 
 import numpy as np
 from scipy.fftpack import _fftpack
@@ -20,6 +20,114 @@ atexit.register(_fftpack.destroy_ddst1_cache)
 atexit.register(_fftpack.destroy_ddst2_cache)
 atexit.register(_fftpack.destroy_dst1_cache)
 atexit.register(_fftpack.destroy_dst2_cache)
+
+
+def dctn(x, type=2, n=None, axes=None, norm=None, overwrite_x=False):
+    """
+    Return multidimensional Discrete Cosine Transform of x along the specified
+    axes.
+
+    Parameters
+    ----------
+    x : array_like
+        The input array.
+    type : {1, 2, 3}, optional
+        Type of the DCT (see Notes). Default type is 2.
+    n : int, optional
+        Length of the transform.  If ``n < x.shape[axis]``, `x` is
+        truncated.  If ``n > x.shape[axis]``, `x` is zero-padded. The
+        default results in ``n = x.shape[axis]``.
+    axes : tuple or None, optional
+        Axes along which the DCT is computed; the default is over all axes.
+    norm : {None, 'ortho'}, optional
+        Normalization mode (see Notes). Default is None.
+    overwrite_x : bool, optional
+        If True, the contents of `x` can be destroyed; the default is False.
+
+    Returns
+    -------
+    y : ndarray of real
+        The transformed input array.
+
+    See Also
+    --------
+    idctn : Inverse multidimensional DCT
+
+    Notes
+    -----
+    For full details of the DCT types and normalization modes, as well as
+    references, see `dct`.
+
+    Examples
+    --------
+    >>> from scipy.fftpack import dctn, idctn
+    >>> y = np.random.randn(16, 16)
+    >>> np.allclose(y, idctn(dctn(y, norm='ortho'), norm='ortho'))
+    True
+
+    """
+    x = np.asanyarray(x)
+    if axes is None:
+        axes = np.arange(x.ndim)
+    if np.isscalar(axes):
+        axes = [axes, ]
+    for ax in axes:
+        x = dct(x, type=type, n=n, axis=ax, norm=norm, overwrite_x=overwrite_x)
+    return x
+
+
+def idctn(x, type=2, n=None, axes=None, norm=None, overwrite_x=False):
+    """
+    Return multidimensional Discrete Cosine Transform of x along the specified
+    axes.
+
+    Parameters
+    ----------
+    x : array_like
+        The input array.
+    type : {1, 2, 3}, optional
+        Type of the DCT (see Notes). Default type is 2.
+    n : int, optional
+        Length of the transform.  If ``n < x.shape[axis]``, `x` is
+        truncated.  If ``n > x.shape[axis]``, `x` is zero-padded. The
+        default results in ``n = x.shape[axis]``.
+    axes : tuple or None, optional
+        Axes along which the IDCT is computed; the default is over all axes.
+    norm : {None, 'ortho'}, optional
+        Normalization mode (see Notes). Default is None.
+    overwrite_x : bool, optional
+        If True, the contents of `x` can be destroyed; the default is False.
+
+    Returns
+    -------
+    y : ndarray of real
+        The transformed input array.
+
+    See Also
+    --------
+    dctn : multidimensional DCT
+
+    Notes
+    -----
+    For full details of the IDCT types and normalization modes, as well as
+    references, see `idct`.
+
+    Examples
+    --------
+    >>> from scipy.fftpack import dctn, idctn
+    >>> y = np.random.randn(16, 16)
+    >>> np.allclose(y, idctn(dctn(y, norm='ortho'), norm='ortho'))
+    True
+    """
+    x = np.asanyarray(x)
+    if axes is None:
+        axes = np.arange(x.ndim)
+    if np.isscalar(axes):
+        axes = [axes, ]
+    for ax in axes:
+        x = idct(x, type=type, n=n, axis=ax, norm=norm,
+                 overwrite_x=overwrite_x)
+    return x
 
 
 def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):

--- a/scipy/fftpack/tests/test_real_transforms.py
+++ b/scipy/fftpack/tests/test_real_transforms.py
@@ -4,6 +4,7 @@ from os.path import join, dirname
 
 import numpy as np
 from numpy.testing import assert_array_almost_equal, assert_equal
+from pytest import raises as assert_raises
 
 from scipy.fftpack.realtransforms import (
     dct, idct, dst, idst, dctn, idctn, dstn, idstn)
@@ -89,7 +90,7 @@ def idst_2d_ref(x, **kwargs):
     return x
 
 
-class TestComplex(TestCase):
+class TestComplex(object):
     def test_dct_complex64(self):
         y = dct(1j*np.arange(5, dtype=np.complex64))
         x = 1j*dct(np.arange(5))
@@ -563,7 +564,7 @@ class TestOverwrite(object):
             self._check_1d(idst, dtype, (2, 16), 1, overwritable)
 
 
-class Test_DCTN_IDCTN(TestCase):
+class Test_DCTN_IDCTN(object):
     dec = 14
     types = [1, 2, 3]
     norms = [None, 'ortho']
@@ -613,9 +614,40 @@ class Test_DCTN_IDCTN(TestCase):
             finverse_ref = function_set['inverse_ref']
             for dct_type in self.types:
                 for norm in self.norms:
+                    print(function_set, dct_type, norm)
                     if norm == 'ortho' and dct_type == 1:
                         continue  # 'ortho' not supported by DCT-I
                     fdata = dctn(self.data, type=dct_type, norm=norm)
                     y1 = finverse(fdata, type=dct_type, norm=norm)
                     y2 = finverse_ref(fdata, type=dct_type, norm=norm)
                     assert_array_almost_equal(y1, y2, decimal=11)
+
+    def test_axes_and_shape(self):
+        for function_set in self.function_sets:
+            fforward = function_set['forward']
+            finverse = function_set['inverse']
+
+            # shape must match the number of axes
+            assert_raises(ValueError, fforward, self.data,
+                          shape=(self.data.shape[0], ),
+                          axes=(0, 1))
+            assert_raises(ValueError, fforward, self.data,
+                          shape=(self.data.shape[0], ),
+                          axes=None)
+            assert_raises(ValueError, fforward, self.data,
+                          shape=self.data.shape,
+                          axes=(0, ))
+            # shape must be a tuple
+            assert_raises(TypeError, fforward, self.data,
+                          shape=self.data.shape[0],
+                          axes=(0, 1))
+
+            # shape=None works with a subset of axes
+            for axes in [(0, ), (1, )]:
+                tmp = fforward(self.data, shape=None, axes=axes, norm='ortho')
+                tmp = finverse(tmp, shape=None, axes=axes, norm='ortho')
+                assert_array_almost_equal(self.data, tmp, decimal=self.dec)
+
+            # non-default shape
+            tmp = fforward(self.data, shape=(128, 128), axes=None)
+            assert_equal(tmp.shape, (128, 128))


### PR DESCRIPTION
I recently needed an n-dimensional `dct` and `idct`.  This PR adds these.  

The implementation is trivial, as the existing 1D routines already had `axis` support, but I thought it may still be worth providing.

Unlike for the n-dimensional FFT routines, there is no underlying n-d implementation in the `fftpack` Fortran code.  This does not seem to be a big problem in terms of performance.  As is, it is similar or faster than `fftn` for real-valued inputs and a bit slower for complex-valued ones:

potential updates:

- [x] add `dstn` and `idstn` as well?
- [x] raise an error if duplicate axes are provided?



results from some quick speed tests in IPython:

```python
for shape in [(16, 16), (256, 256, 256)]:
    for dtype in np.float32, np.complex64:
        r = np.ones(shape, dtype)
        print("\n---------------------------")
        print("dctn for dtype {}, shape {}".format(dtype, shape))
        %timeit scipy.fftpack.dctn(r)
        print("\nfftn for dtype {}, shape {}".format(dtype, shape))
        %timeit scipy.fftpack.fftn(r)
```

```
---------------------------
dctn for dtype <class 'numpy.float32'>, shape (16, 16)
The slowest run took 4.43 times longer than the fastest. This could mean that an intermediate result is being cached.
10000 loops, best of 3: 60.2 µs per loop

fftn for dtype <class 'numpy.float32'>, shape (16, 16)
The slowest run took 9.49 times longer than the fastest. This could mean that an intermediate result is being cached.
10000 loops, best of 3: 69.5 µs per loop

---------------------------
dctn for dtype <class 'numpy.complex64'>, shape (16, 16)
10000 loops, best of 3: 131 µs per loop

fftn for dtype <class 'numpy.complex64'>, shape (16, 16)
10000 loops, best of 3: 67.3 µs per loop

---------------------------
dctn for dtype <class 'numpy.float32'>, shape (256, 256, 256)
1 loop, best of 3: 841 ms per loop

fftn for dtype <class 'numpy.float32'>, shape (256, 256, 256)
1 loop, best of 3: 1.43 s per loop

---------------------------
dctn for dtype <class 'numpy.complex64'>, shape (256, 256, 256)
1 loop, best of 3: 2.13 s per loop

fftn for dtype <class 'numpy.complex64'>, shape (256, 256, 256)
1 loop, best of 3: 1.49 s per loop
```