### PR TITLE
DEBUG, MAINT: Add __array_ufunc__ = None to spmatrix.

### DIFF
--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -65,6 +65,7 @@ class spmatrix(object):
     cannot be instantiated.  Most of the work is provided by subclasses.
     """
 
+    __array_ufunc__ = None
     __array_priority__ = 10.1
     ndim = 2
 


### PR DESCRIPTION
This provides unconditional operator forwarding to sparse arrays when
working with ndarrays or its subclasses.

This is mostly to check if this cures most of the scipy failures against current numpy master. It is not __the__ cure. 