### PR TITLE
ENH: Be more forgiving about integer-valued parameters

### DIFF
--- a/scipy/fftpack/helper.py
+++ b/scipy/fftpack/helper.py
@@ -1,6 +1,5 @@
 from __future__ import division, print_function, absolute_import
 
-import operator
 from numpy import arange
 from numpy.fft.helper import fftshift, ifftshift, fftfreq
 from bisect import bisect_left
@@ -42,8 +41,7 @@ def rfftfreq(n, d=1.0):
     array([ 0.  ,  1.25,  1.25,  2.5 ,  2.5 ,  3.75,  3.75,  5.  ])
 
     """
-    n = operator.index(n)
-    if n < 0:
+    if n != int(n) or n < 0:
         raise ValueError("n = %s is not valid. "
                          "n must be a nonnegative integer." % n)
 

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -3,7 +3,6 @@
 
 from __future__ import division, print_function, absolute_import
 
-import operator
 import threading
 import sys
 import timeit
@@ -2323,7 +2322,7 @@ def resample_poly(x, up, down, axis=0, window=('kaiser', 5.0)):
         raise ValueError('up and down must be >= 1')
 
     # Determine our up and down factors
-    # Use a rational approimation to save computation time on really long
+    # Use a rational approximation to save computation time on really long
     # signals
     g_ = gcd(up, down)
     up //= g_
@@ -3399,18 +3398,25 @@ def decimate(x, q, n=None, ftype='iir', axis=-1, zero_phase=True):
     """
 
     x = asarray(x)
-    q = operator.index(q)
 
-    if n is not None:
-        n = operator.index(n)
+    if q != int(q):
+        raise ValueError("q must be an integer")
+    q = int(q)
+
+    if n is not None and n != int(n):
+        raise ValueError("n must be an integer")
 
     if ftype == 'fir':
         if n is None:
             n = 30
+        else:
+            n = int(n)
         system = dlti(firwin(n+1, 1. / q, window='hamming'), 1.)
     elif ftype == 'iir':
         if n is None:
             n = 8
+        else:
+            n = int(n)
         system = dlti(*cheby1(n, 0.05, 0.8 / q))
     elif isinstance(ftype, dlti):
         system = ftype._as_tf()  # Avoids copying if already in TF form

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1673,8 +1673,8 @@ def test_filtfilt_gust():
 class TestDecimate(object):
     def test_bad_args(self):
         x = np.arange(12)
-        assert_raises(TypeError, signal.decimate, x, q=0.5, n=1)
-        assert_raises(TypeError, signal.decimate, x, q=2, n=0.5)
+        assert_raises(ValueError, signal.decimate, x, q=0.5, n=1)
+        assert_raises(ValueError, signal.decimate, x, q=2, n=0.5)
 
     def test_basic_IIR(self):
         x = np.arange(12)


### PR DESCRIPTION
If a value needs to be an integer, accept integer-equivalent values of different types (but don't silently truncate them to int).

Due to: https://dsp.stackexchange.com/a/40555/29