### PR TITLE
ENH: add Brunner Munzel test to scipy.stats.

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -189,6 +189,7 @@ Sean Quinn for the Moyal distribution
 Lars Grüter for contributions to peak finding in scipy.signal
 Jordan Heemskerk for exposing additional windowing functions in scipy.signal.
 Michael Tartre (Two Sigma Investments) for contributions to weighted distance functions.
+Shinya Suzuki for scipy.stats.brunnermunzel
 
 Institutions
 ------------

--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -255,6 +255,7 @@ which work for masked arrays.
    wilcoxon
    kruskal
    friedmanchisquare
+   brunnermunzel
    combine_pvalues
    jarque_bera
 

--- a/scipy/stats/mstats.py
+++ b/scipy/stats/mstats.py
@@ -86,6 +86,7 @@ is a relatively new package, some API changes are still possible.
    trimmed_std
    trimmed_var
    ttest_1samp
+   brunnermunzel
 
 """
 from __future__ import division, print_function, absolute_import

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5217,11 +5217,11 @@ def brunnermunzel(x, y, alternative="two-sided", distribution="t", nan_policy='p
     References
     ----------
     .. [1] Brunner, E. and Munzel, U. "The nonparametric Benhrens-Fisher
-    problem: Asymptotic theory and a small-sample approximation".
-    Biometrical Journal. Vol. 42(2000): 17-25.
+           problem: Asymptotic theory and a small-sample approximation".
+           Biometrical Journal. Vol. 42(2000): 17-25.
     .. [2] Neubert, K. and Brunner, E. "A studentized permutation test for the
-    non-parametric Behrens-Fisher problem". Computational Statistics and Data
-    Analysis. Vol. 51(2007): 5192-5204.
+           non-parametric Behrens-Fisher problem". Computational Statistics and
+           Data Analysis. Vol. 51(2007): 5192-5204.
 
     Examples
     --------

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5267,27 +5267,28 @@ def brunnermunzel(x, y, alternative="two-sided", distribution="t", nan_policy='p
     rankx_mean = np.mean(rankx)
     ranky_mean = np.mean(ranky)
 
-    Sx = np.sum(np.power(rankcx - rankx - rankcx_mean + rankx_mean, 2))
+    Sx = np.sum(np.power(rankcx - rankx - rankcx_mean + rankx_mean, 2.0))
     Sx /= nx - 1
-    Sy = np.sum(np.power(rankcy - ranky - rankcy_mean + ranky_mean, 2))
+    Sy = np.sum(np.power(rankcy - ranky - rankcy_mean + ranky_mean, 2.0))
     Sy /= ny - 1
 
-    sigmax = Sx / np.power(nc - nx, 2)
-    sigmay = Sx / np.power(nc - ny, 2)
-    sigmac = nc * (sigmax / nx + sigmay / ny)
+    sigmax = Sx / np.power(nc - nx, 2.0)
+    sigmay = Sx / np.power(nc - ny, 2.0)
 
     wbfn = nx * ny * (rankcy_mean - rankcx_mean)
     wbfn /= (nx + ny) * np.sqrt(nx * Sx + ny * Sy)
 
     if distribution == "t":
-        df = np.power(nx * Sx + ny * Sy,2)
-        df /= np.power(nx * Sx, 2) / (nx - 1) + np.power(ny * Sy,2) / (ny - 1)
+        df_numer = np.power(nx * Sx + ny * Sy, 2.0)
+        df_denom = np.power(nx * Sx, 2.0) / (nx - 1)
+        df_denom += np.power(ny * Sy, 2.0) / (ny - 1)
+        df = df_numer / df_denom
         p = distributions.t.cdf(wbfn, df)
-    elif distribution == "norm":
+    elif distribution == "normal":
         p = distributions.norm.cdf(wbfn)
     else:
         raise ValueError(
-            "distribution should be 't' or 'norm'")
+            "distribution should be 't' or 'normal'")
 
     if alternative == "greater":
         p = p

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5164,10 +5164,13 @@ def friedmanchisquare(*args):
 
     return FriedmanchisquareResult(chisq, distributions.chi2.sf(chisq, k - 1))
 
-BrunnerMunzelResult = namedtuple('BrunnerMunzelResult', ('statistic', 'pvalue'))
+
+BrunnerMunzelResult = namedtuple('BrunnerMunzelResult',
+                                 ('statistic', 'pvalue'))
 
 
-def brunnermunzel(x, y, alternative="two-sided", distribution="t", nan_policy='propagate'):
+def brunnermunzel(x, y, alternative="two-sided", distribution="t",
+                  nan_policy='propagate'):
     """
     Computes the Brunner-Munzel test on samples x and y
 
@@ -5175,9 +5178,9 @@ def brunnermunzel(x, y, alternative="two-sided", distribution="t", nan_policy='p
     when values are taken one by one from each group, the probabilities of
     getting large values in both groups are equal.
     Unlike the Wilcoxon-Mann-Whitney's U test, this does not require the
-    assumption of equivariance of two groups. Note that this does not assume the
-    distributions are same. This test works on two independent samples, which
-    may have different sizes.
+    assumption of equivariance of two groups. Note that this does not assume
+    the distributions are same. This test works on two independent samples,
+    which may have different sizes.
 
     Parameters
     ----------
@@ -5256,8 +5259,7 @@ def brunnermunzel(x, y, alternative="two-sided", distribution="t", nan_policy='p
     ny = len(y)
     if nx == 0 or ny == 0:
         return BrunnerMunzelResult(np.nan, np.nan)
-    nc = nx + ny
-    rankc = rankdata(np.concatenate((x,y)))
+    rankc = rankdata(np.concatenate((x, y)))
     rankcx = rankc[0:nx]
     rankcy = rankc[nx:nx+ny]
     rankcx_mean = np.mean(rankcx)
@@ -5271,9 +5273,6 @@ def brunnermunzel(x, y, alternative="two-sided", distribution="t", nan_policy='p
     Sx /= nx - 1
     Sy = np.sum(np.power(rankcy - ranky - rankcy_mean + ranky_mean, 2.0))
     Sy /= ny - 1
-
-    sigmax = Sx / np.power(nc - nx, 2.0)
-    sigmay = Sx / np.power(nc - ny, 2.0)
 
     wbfn = nx * ny * (rankcy_mean - rankcx_mean)
     wbfn /= (nx + ny) * np.sqrt(nx * Sx + ny * Sy)

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5167,37 +5167,52 @@ def friedmanchisquare(*args):
 BrunnerMunzelResult = namedtuple('BrunnerMunzelResult', ('statistic', 'pvalue'))
 
 
-def brunnermunzel(x, y, alternative="two-sided", distribution="t"):
+def brunnermunzel(x, y, alternative="two-sided", distribution="t", nan_policy='propagate'):
     """
     Computes the Brunner-Munzel test on samples x and y
+
+    The Brunner-Munzel test is a nonparametric test of the null hypothesis that
+    when values are taken one by one from each group, the probabilities of
+    getting large values in both groups are equal.
+    Unlike the Wilcoxon-Mann-Whitney's U test, this does not require the
+    assumption of equivariance of two groups. Note that this does not assume the
+    distributions are same. This test works on two independent samples, which
+    may have different sizes.
 
     Parameters
     ----------
     x, y : array_like
         Array of samples, should be one-dimensional.
-    alternative :  'less', 'two-sided', or 'greater'
+    alternative :  'less', 'two-sided', or 'greater', optional
         Whether to get the p-value for the one-sided hypothesis ('less'
         or 'greater') or for the two-sided hypothesis ('two-sided').
-        Defaults value is two-sided.
-    distribution: 't' or 'g_norm'
+        Defaults value is 'two-sided' .
+    distribution: 't' or 'normal', optional
         Whether to get the p-value by t-distribution or by standard normal
         distribution.
-        Defaults value is t.
-
+        Defaults value is 't' .
+    nan_policy : {'propagate', 'raise', 'omit'}, optional
+        Defines how to handle when input contains nan. 'propagate' returns nan,
+        'raise' throws an error, 'omit' performs the calculations ignoring nan
+        values. Default is 'propagate'.
 
     Returns
     -------
     statistic : float
-        The Brunner-Munzer W statistic
+        The Brunner-Munzer W statistic.
     pvalue : float
         p-value assuming an t distribution. One-sided or
-        two-sided, depending on the choice of `alternative`.
+        two-sided, depending on the choice of `alternative` and `distribution`.
+
+    See Also
+    --------
+    mannwhitneyu : Mann-Whitney rank test on two samples.
 
     Notes
     -------
     Brunner and Munzel recommended to estimate the p-value by t-distribution
     when the size of data is 50 or less. If the size is lower than 10, it would
-    be better to use permuted Brunner Munzel test (see [2]).
+    be better to use permuted Brunner Munzel test (see [2]_).
 
     References
     ----------

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5237,11 +5237,26 @@ def brunnermunzel(x, y, alternative="two-sided", distribution="t", nan_policy='p
     """
     x = np.asarray(x)
     y = np.asarray(y)
+
+    # check both x and y
+    cnx, npx = _contains_nan(x, nan_policy)
+    cny, npy = _contains_nan(y, nan_policy)
+    contains_nan = cnx or cny
+    if npx == "omit" or npy == "omit":
+        nan_policy = "omit"
+
+    if contains_nan and nan_policy == "propagate":
+        return BrunnerMunzelResult(np.nan, np.nan)
+    elif contains_nan and nan_policy == "omit":
+        x = ma.masked_invalid(x)
+        y = ma.masked_invalid(y)
+        return mstats_basic.brunnermunzel(x, y, alternative, distribution)
+
     nx = len(x)
     ny = len(y)
     if nx == 0 or ny == 0:
-        return np.nan, np.nan
-    nc = len(x) + len(y)
+        return BrunnerMunzelResult(np.nan, np.nan)
+    nc = nx + ny
     rankc = rankdata(np.concatenate((x,y)))
     rankcx = rankc[0:nx]
     rankcy = rankc[nx:nx+ny]

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -1276,10 +1276,11 @@ class TestCompareWithStats(object):
             assert_almost_equal(r.T, rm[0:len(x)])
 
 
-class TestBrunnerMunzel(TestCase):
+class TestBrunnerMunzel(object):
     # Data from (Lumley, 1996)
-    X = np.ma.masked_invalid([1,2,1,1,1,np.nan,1,1,1,1,1,2,4,1,1,np.nan])
-    Y = np.ma.masked_invalid([3,3,4,3,np.nan,1,2,3,1,1,5,4])
+    X = np.ma.masked_invalid([1, 2, 1, 1, 1, np.nan, 1, 1,
+                              1, 1, 1, 2, 4, 1, 1, np.nan])
+    Y = np.ma.masked_invalid([3, 3, 4, 3, np.nan, 1, 2, 3, 1, 1, 5, 4])
     significant = 14
 
     def test_brunnermunzel_one_sided(self):
@@ -1375,4 +1376,3 @@ class TestBrunnerMunzel(TestCase):
         assert_(np.isnan(p2))
         assert_(np.isnan(u3))
         assert_(np.isnan(p3))
-

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -1275,3 +1275,104 @@ class TestCompareWithStats(object):
             rm = stats.mstats.obrientransform(xm)
             assert_almost_equal(r.T, rm[0:len(x)])
 
+
+class TestBrunnerMunzel(TestCase):
+    # Data from (Lumley, 1996)
+    X = np.ma.masked_invalid([1,2,1,1,1,np.nan,1,1,1,1,1,2,4,1,1,np.nan])
+    Y = np.ma.masked_invalid([3,3,4,3,np.nan,1,2,3,1,1,5,4])
+    significant = 14
+
+    def test_brunnermunzel_one_sided(self):
+        # Results are compared with R's lawstat package.
+        u1, p1 = mstats.brunnermunzel(self.X, self.Y, alternative='less')
+        u2, p2 = mstats.brunnermunzel(self.Y, self.X, alternative='greater')
+        u3, p3 = mstats.brunnermunzel(self.X, self.Y, alternative='greater')
+        u4, p4 = mstats.brunnermunzel(self.Y, self.X, alternative='less')
+
+        assert_almost_equal(p1, p2, decimal=self.significant)
+        assert_almost_equal(p3, p4, decimal=self.significant)
+        assert_(p1 != p3)
+        assert_almost_equal(u1, 3.1374674823029505,
+                            decimal=self.significant)
+        assert_almost_equal(u2, -3.1374674823029505,
+                            decimal=self.significant)
+        assert_almost_equal(u3, 3.1374674823029505,
+                            decimal=self.significant)
+        assert_almost_equal(u4, -3.1374674823029505,
+                            decimal=self.significant)
+        assert_almost_equal(p1, 0.0028931043330757342,
+                            decimal=self.significant)
+        assert_almost_equal(p3, 0.99710689566692423,
+                            decimal=self.significant)
+
+    def test_brunnermunzel_two_sided(self):
+        # Results are compared with R's lawstat package.
+        u1, p1 = mstats.brunnermunzel(self.X, self.Y, alternative='two-sided')
+        u2, p2 = mstats.brunnermunzel(self.Y, self.X, alternative='two-sided')
+
+        assert_almost_equal(p1, p2, decimal=self.significant)
+        assert_almost_equal(u1, 3.1374674823029505,
+                            decimal=self.significant)
+        assert_almost_equal(u2, -3.1374674823029505,
+                            decimal=self.significant)
+        assert_almost_equal(p1, 0.0057862086661515377,
+                            decimal=self.significant)
+
+    def test_brunnermunzel_default(self):
+        # The default value for alternative is two-sided
+        u1, p1 = mstats.brunnermunzel(self.X, self.Y)
+        u2, p2 = mstats.brunnermunzel(self.Y, self.X)
+
+        assert_almost_equal(p1, p2, decimal=self.significant)
+        assert_almost_equal(u1, 3.1374674823029505,
+                            decimal=self.significant)
+        assert_almost_equal(u2, -3.1374674823029505,
+                            decimal=self.significant)
+        assert_almost_equal(p1, 0.0057862086661515377,
+                            decimal=self.significant)
+
+    def test_brunnermunzel_alternative_error(self):
+        alternative = "error"
+        distribution = "t"
+        assert_(alternative not in ["two-sided", "greater", "less"])
+        assert_raises(ValueError,
+                      mstats.brunnermunzel,
+                      self.X,
+                      self.Y,
+                      alternative,
+                      distribution)
+
+    def test_brunnermunzel_distribution_norm(self):
+        u1, p1 = mstats.brunnermunzel(self.X, self.Y, distribution="normal")
+        u2, p2 = mstats.brunnermunzel(self.Y, self.X, distribution="normal")
+        assert_almost_equal(p1, p2, decimal=self.significant)
+        assert_almost_equal(u1, 3.1374674823029505,
+                            decimal=self.significant)
+        assert_almost_equal(u2, -3.1374674823029505,
+                            decimal=self.significant)
+        assert_almost_equal(p1, 0.0017041417600383024,
+                            decimal=self.significant)
+
+    def test_brunnermunzel_distribution_error(self):
+        alternative = "two-sided"
+        distribution = "error"
+        assert_(alternative not in ["t", "normal"])
+        assert_raises(ValueError,
+                      mstats.brunnermunzel,
+                      self.X,
+                      self.Y,
+                      alternative,
+                      distribution)
+
+    def test_brunnermunzel_empty_imput(self):
+        u1, p1 = mstats.brunnermunzel(self.X, [])
+        u2, p2 = mstats.brunnermunzel([], self.Y)
+        u3, p3 = mstats.brunnermunzel([], [])
+
+        assert_(np.isnan(u1))
+        assert_(np.isnan(p1))
+        assert_(np.isnan(u2))
+        assert_(np.isnan(p2))
+        assert_(np.isnan(u3))
+        assert_(np.isnan(p3))
+

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4267,10 +4267,10 @@ class TestEnergyDistance(object):
                 np.nan)
 
 
-class TestBrunnerMunzel(TestCase):
+class TestBrunnerMunzel(object):
     # Data from (Lumley, 1996)
-    X = [1,2,1,1,1,1,1,1,1,1,2,4,1,1]
-    Y = [3,3,4,3,1,2,3,1,1,5,4]
+    X = [1, 2, 1, 1, 1, 1, 1, 1, 1, 1, 2, 4, 1, 1]
+    Y = [3, 3, 4, 3, 1, 2, 3, 1, 1, 5, 4]
     significant = 14
 
     def test_brunnermunzel_one_sided(self):
@@ -4280,17 +4280,17 @@ class TestBrunnerMunzel(TestCase):
         u3, p3 = stats.brunnermunzel(self.X, self.Y, alternative='greater')
         u4, p4 = stats.brunnermunzel(self.Y, self.X, alternative='less')
 
-        assert_approx_equal(p1, p2, significant = self.significant)
-        assert_approx_equal(p3, p4, significant = self.significant)
+        assert_approx_equal(p1, p2, significant=self.significant)
+        assert_approx_equal(p3, p4, significant=self.significant)
         assert_(p1 != p3)
         assert_approx_equal(u1, 3.1374674823029505,
-                            significant = self.significant)
+                            significant=self.significant)
         assert_approx_equal(u2, -3.1374674823029505,
-                            significant = self.significant)
+                            significant=self.significant)
         assert_approx_equal(u3, 3.1374674823029505,
-                            significant = self.significant)
+                            significant=self.significant)
         assert_approx_equal(u4, -3.1374674823029505,
-                            significant = self.significant)
+                            significant=self.significant)
         assert_approx_equal(p1, 0.0028931043330757342,
                             significant=self.significant)
         assert_approx_equal(p3, 0.99710689566692423,
@@ -4301,26 +4301,26 @@ class TestBrunnerMunzel(TestCase):
         u1, p1 = stats.brunnermunzel(self.X, self.Y, alternative='two-sided')
         u2, p2 = stats.brunnermunzel(self.Y, self.X, alternative='two-sided')
 
-        assert_approx_equal(p1, p2, significant = self.significant)
+        assert_approx_equal(p1, p2, significant=self.significant)
         assert_approx_equal(u1, 3.1374674823029505,
-                            significant = self.significant)
+                            significant=self.significant)
         assert_approx_equal(u2, -3.1374674823029505,
-                            significant = self.significant)
+                            significant=self.significant)
         assert_approx_equal(p1, 0.0057862086661515377,
-                            significant = self.significant)
+                            significant=self.significant)
 
     def test_brunnermunzel_default(self):
         # The default value for alternative is two-sided
         u1, p1 = stats.brunnermunzel(self.X, self.Y)
         u2, p2 = stats.brunnermunzel(self.Y, self.X)
 
-        assert_approx_equal(p1, p2, significant = self.significant)
+        assert_approx_equal(p1, p2, significant=self.significant)
         assert_approx_equal(u1, 3.1374674823029505,
-                            significant = self.significant)
+                            significant=self.significant)
         assert_approx_equal(u2, -3.1374674823029505,
-                            significant = self.significant)
+                            significant=self.significant)
         assert_approx_equal(p1, 0.0057862086661515377,
-                            significant = self.significant)
+                            significant=self.significant)
 
     def test_brunnermunzel_alternative_error(self):
         alternative = "error"
@@ -4338,13 +4338,13 @@ class TestBrunnerMunzel(TestCase):
     def test_brunnermunzel_distribution_norm(self):
         u1, p1 = stats.brunnermunzel(self.X, self.Y, distribution="normal")
         u2, p2 = stats.brunnermunzel(self.Y, self.X, distribution="normal")
-        assert_approx_equal(p1, p2, significant = self.significant)
+        assert_approx_equal(p1, p2, significant=self.significant)
         assert_approx_equal(u1, 3.1374674823029505,
-                            significant = self.significant)
+                            significant=self.significant)
         assert_approx_equal(u2, -3.1374674823029505,
-                            significant = self.significant)
+                            significant=self.significant)
         assert_approx_equal(p1, 0.0017041417600383024,
-                            significant = self.significant)
+                            significant=self.significant)
 
     def test_brunnermunzel_distribution_error(self):
         alternative = "two-sided"
@@ -4372,8 +4372,8 @@ class TestBrunnerMunzel(TestCase):
         assert_equal(p3, np.nan)
 
     def test_brunnermunzel_nan_input_propagate(self):
-        X = [1,2,1,1,1,1,1,1,1,1,2,4,1,1, np.nan]
-        Y = [3,3,4,3,1,2,3,1,1,5,4]
+        X = [1, 2, 1, 1, 1, 1, 1, 1, 1, 1, 2, 4, 1, 1, np.nan]
+        Y = [3, 3, 4, 3, 1, 2, 3, 1, 1, 5, 4]
         u1, p1 = stats.brunnermunzel(X, Y, nan_policy="propagate")
         u2, p2 = stats.brunnermunzel(Y, X, nan_policy="propagate")
 
@@ -4383,8 +4383,8 @@ class TestBrunnerMunzel(TestCase):
         assert_equal(p2, np.nan)
 
     def test_brunnermunzel_nan_input_raise(self):
-        X = [1,2,1,1,1,1,1,1,1,1,2,4,1,1, np.nan]
-        Y = [3,3,4,3,1,2,3,1,1,5,4]
+        X = [1, 2, 1, 1, 1, 1, 1, 1, 1, 1, 2, 4, 1, 1, np.nan]
+        Y = [3, 3, 4, 3, 1, 2, 3, 1, 1, 5, 4]
         alternative = "two-sided"
         distribution = "t"
         nan_policy = "raise"
@@ -4405,15 +4405,16 @@ class TestBrunnerMunzel(TestCase):
                       nan_policy)
 
     def test_brunnermunzel_nan_input_omit(self):
-        X = [1,2,1,1,1,1,1,1,1,1,2,4,1,1, np.nan]
-        Y = [3,3,4,3,1,2,3,1,1,5,4]
+        X = [1, 2, 1, 1, 1, 1, 1, 1, 1, 1, 2, 4, 1, 1, np.nan]
+        Y = [3, 3, 4, 3, 1, 2, 3, 1, 1, 5, 4]
         u1, p1 = stats.brunnermunzel(X, Y, nan_policy="omit")
         u2, p2 = stats.brunnermunzel(Y, X, nan_policy="omit")
 
-        assert_approx_equal(p1, p2, significant = self.significant)
+        assert_approx_equal(p1, p2, significant=self.significant)
         assert_approx_equal(u1, 3.1374674823029505,
-                            significant = self.significant)
+                            significant=self.significant)
         assert_approx_equal(u2, -3.1374674823029505,
-                            significant = self.significant)
+                            significant=self.significant)
         assert_approx_equal(p1, 0.0057862086661515377,
-                            significant = self.significant)
+                            significant=self.significant)
+

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4271,7 +4271,7 @@ class TestBrunnerMunzel(object):
     # Data from (Lumley, 1996)
     X = [1, 2, 1, 1, 1, 1, 1, 1, 1, 1, 2, 4, 1, 1]
     Y = [3, 3, 4, 3, 1, 2, 3, 1, 1, 5, 4]
-    significant = 14
+    significant = 13
 
     def test_brunnermunzel_one_sided(self):
         # Results are compared with R's lawstat package.

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4265,3 +4265,102 @@ class TestEnergyDistance(object):
             assert_equal(
                 stats.energy_distance([1, 2, np.inf], [np.inf, 1]),
                 np.nan)
+
+
+class TestBrunnerMunzel(TestCase):
+    # Data from (Lumley, 1996)
+    X = [1,2,1,1,1,1,1,1,1,1,2,4,1,1]
+    Y = [3,3,4,3,1,2,3,1,1,5,4]
+    significant = 14
+
+    def test_brunnermunzel_one_sided(self):
+        # Results are compared with R's lawstat package.
+        u1, p1 = stats.brunnermunzel(self.X, self.Y, alternative='less')
+        u2, p2 = stats.brunnermunzel(self.Y, self.X, alternative='greater')
+        u3, p3 = stats.brunnermunzel(self.X, self.Y, alternative='greater')
+        u4, p4 = stats.brunnermunzel(self.Y, self.X, alternative='less')
+
+        assert_approx_equal(p1, p2, significant = self.significant)
+        assert_approx_equal(p3, p4, significant = self.significant)
+        assert_(p1 != p3)
+        assert_approx_equal(u1, 3.1374674823029505,
+                            significant = self.significant)
+        assert_approx_equal(u2, -3.1374674823029505,
+                            significant = self.significant)
+        assert_approx_equal(u3, 3.1374674823029505,
+                            significant = self.significant)
+        assert_approx_equal(u4, -3.1374674823029505,
+                            significant = self.significant)
+        assert_approx_equal(p1, 0.0028931043330757342,
+                            significant=self.significant)
+        assert_approx_equal(p3, 0.99710689566692423,
+                            significant=self.significant)
+
+    def test_brunnermunzel_two_sided(self):
+        # Results are compared with R's lawstat package.
+        u1, p1 = stats.brunnermunzel(self.X, self.Y, alternative='two-sided')
+        u2, p2 = stats.brunnermunzel(self.Y, self.X, alternative='two-sided')
+
+        assert_approx_equal(p1, p2, significant = self.significant)
+        assert_approx_equal(u1, 3.1374674823029505,
+                            significant = self.significant)
+        assert_approx_equal(u2, -3.1374674823029505,
+                            significant = self.significant)
+        assert_approx_equal(p1, 0.0057862086661515377,
+                            significant = self.significant)
+
+    def test_brunnermunzel_default(self):
+        # The default value for alternative is two-sided
+        u1, p1 = stats.brunnermunzel(self.X, self.Y)
+        u2, p2 = stats.brunnermunzel(self.Y, self.X)
+
+        assert_approx_equal(p1, p2, significant = self.significant)
+        assert_approx_equal(u1, 3.1374674823029505,
+                            significant = self.significant)
+        assert_approx_equal(u2, -3.1374674823029505,
+                            significant = self.significant)
+        assert_approx_equal(p1, 0.0057862086661515377,
+                            significant = self.significant) 
+
+    def test_brunnermunzel_alternative_error(self):
+        alternative = "error"
+        assert_(alternative not in ["two-sided", "greater", "less"])
+        assert_raises(ValueError,
+                      stats.brunnermunzel,
+                      self.X,
+                      self.Y,
+                      alternative)
+
+    def test_brunnermunzel_distribution_error(self):
+        alternative = "two-sided"
+        distribution = "error"
+        assert_(alternative not in ["t", "norm"])
+        assert_raises(ValueError,
+                      stats.brunnermunzel,
+                      self.X,
+                      self.Y,
+                      alternative,
+                      distribution)
+
+    def test_brunnermunzel_empty_imput(self):
+        u1, p1 = stats.brunnermunzel(self.X, [])
+        u2, p2 = stats.brunnermunzel([], self.Y)
+        u3, p3 = stats.brunnermunzel([], [])
+
+        assert_equal(u1, np.nan)
+        assert_equal(p1, np.nan)
+        assert_equal(u2, np.nan)
+        assert_equal(p2, np.nan)
+        assert_equal(u3, np.nan)
+        assert_equal(p3, np.nan)
+
+    def test_brunnermunzel_distribution_norm(self):
+        u1, p1 = stats.brunnermunzel(self.X, self.Y, distribution="norm")
+        u2, p2 = stats.brunnermunzel(self.Y, self.X, distribution="norm")
+        assert_approx_equal(p1, p2, significant = self.significant)
+        assert_approx_equal(u1, 3.1374674823029505,
+                            significant = self.significant)
+        assert_approx_equal(u2, -3.1374674823029505,
+                            significant = self.significant)
+        assert_approx_equal(p1, 0.0017041417600383024,
+                            significant = self.significant) 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4320,27 +4320,44 @@ class TestBrunnerMunzel(TestCase):
         assert_approx_equal(u2, -3.1374674823029505,
                             significant = self.significant)
         assert_approx_equal(p1, 0.0057862086661515377,
-                            significant = self.significant) 
+                            significant = self.significant)
 
     def test_brunnermunzel_alternative_error(self):
         alternative = "error"
+        distribution = "t"
+        nan_policy = "propagate"
         assert_(alternative not in ["two-sided", "greater", "less"])
         assert_raises(ValueError,
                       stats.brunnermunzel,
                       self.X,
                       self.Y,
-                      alternative)
+                      alternative,
+                      distribution,
+                      nan_policy)
+
+    def test_brunnermunzel_distribution_norm(self):
+        u1, p1 = stats.brunnermunzel(self.X, self.Y, distribution="normal")
+        u2, p2 = stats.brunnermunzel(self.Y, self.X, distribution="normal")
+        assert_approx_equal(p1, p2, significant = self.significant)
+        assert_approx_equal(u1, 3.1374674823029505,
+                            significant = self.significant)
+        assert_approx_equal(u2, -3.1374674823029505,
+                            significant = self.significant)
+        assert_approx_equal(p1, 0.0017041417600383024,
+                            significant = self.significant)
 
     def test_brunnermunzel_distribution_error(self):
         alternative = "two-sided"
         distribution = "error"
-        assert_(alternative not in ["t", "norm"])
+        nan_policy = "propagate"
+        assert_(alternative not in ["t", "normal"])
         assert_raises(ValueError,
                       stats.brunnermunzel,
                       self.X,
                       self.Y,
                       alternative,
-                      distribution)
+                      distribution,
+                      nan_policy)
 
     def test_brunnermunzel_empty_imput(self):
         u1, p1 = stats.brunnermunzel(self.X, [])
@@ -4354,13 +4371,49 @@ class TestBrunnerMunzel(TestCase):
         assert_equal(u3, np.nan)
         assert_equal(p3, np.nan)
 
-    def test_brunnermunzel_distribution_norm(self):
-        u1, p1 = stats.brunnermunzel(self.X, self.Y, distribution="norm")
-        u2, p2 = stats.brunnermunzel(self.Y, self.X, distribution="norm")
+    def test_brunnermunzel_nan_input_propagate(self):
+        X = [1,2,1,1,1,1,1,1,1,1,2,4,1,1, np.nan]
+        Y = [3,3,4,3,1,2,3,1,1,5,4]
+        u1, p1 = stats.brunnermunzel(X, Y, nan_policy="propagate")
+        u2, p2 = stats.brunnermunzel(Y, X, nan_policy="propagate")
+
+        assert_equal(u1, np.nan)
+        assert_equal(p1, np.nan)
+        assert_equal(u2, np.nan)
+        assert_equal(p2, np.nan)
+
+    def test_brunnermunzel_nan_input_raise(self):
+        X = [1,2,1,1,1,1,1,1,1,1,2,4,1,1, np.nan]
+        Y = [3,3,4,3,1,2,3,1,1,5,4]
+        alternative = "two-sided"
+        distribution = "t"
+        nan_policy = "raise"
+
+        assert_raises(ValueError,
+                      stats.brunnermunzel,
+                      X,
+                      Y,
+                      alternative,
+                      distribution,
+                      nan_policy)
+        assert_raises(ValueError,
+                      stats.brunnermunzel,
+                      Y,
+                      X,
+                      alternative,
+                      distribution,
+                      nan_policy)
+
+    def test_brunnermunzel_nan_input_omit(self):
+        X = [1,2,1,1,1,1,1,1,1,1,2,4,1,1, np.nan]
+        Y = [3,3,4,3,1,2,3,1,1,5,4]
+        u1, p1 = stats.brunnermunzel(X, Y, nan_policy="omit")
+        u2, p2 = stats.brunnermunzel(Y, X, nan_policy="omit")
+
         assert_approx_equal(p1, p2, significant = self.significant)
         assert_approx_equal(u1, 3.1374674823029505,
                             significant = self.significant)
         assert_approx_equal(u2, -3.1374674823029505,
                             significant = self.significant)
-        assert_approx_equal(p1, 0.0017041417600383024,
-                            significant = self.significant) 
+        assert_approx_equal(p1, 0.0057862086661515377,
+                            significant = self.significant)


### PR DESCRIPTION
The Brunner-Munzel test is used in Biostatistics and Bioinformatics.
This non-parametric method is superior to Wilcoxon - Mann - Whitney 's U test in that it does not assume equidistribution of the distribution.