### PR TITLE
TST: optimize: avoid printing a summary in SLSQP tests

### DIFF
--- a/scipy/optimize/tests/test_slsqp.py
+++ b/scipy/optimize/tests/test_slsqp.py
@@ -316,7 +316,7 @@ class TestSLSQP(TestCase):
         # Test for Github Issue #5433 and PR #6691
         # Objective function should be able to return length-1 Python list
         #  containing the scalar
-        fmin_slsqp(lambda x: [0], [1, 2, 3])
+        fmin_slsqp(lambda x: [0], [1, 2, 3], iprint=0)
 
     def test_callback(self):
         # Minimize, method='SLSQP': unbounded, approximated jacobian. Check for callback


### PR DESCRIPTION
The default summary from fmin_slsqp is not needed here, just adds noise to the tests suite.