### PR TITLE
MAINT: bundle Mathjax with built docs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "doc/sphinxext"]
 	path = doc/sphinxext
 	url = https://github.com/numpy/numpydoc.git
+[submodule "doc/source/_static/scipy-mathjax"]
+	path = doc/source/_static/scipy-mathjax
+	url = https://github.com/scipy/scipy-mathjax.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -152,7 +152,7 @@ after_success:
         eval `ssh-agent -s`
         ssh-add tools/ci/devdocs-deploy.key
         git clone git@github.com:scipy/devdocs.git devdocs
-        python -u $OPTIMIZE runtests.py -g --shell -- -c 'make -C doc html-scipyorg'
+        python -u $OPTIMIZE runtests.py -g --shell -- -c 'make -C doc PYTHON=python html-scipyorg'
         pushd devdocs
         (git checkout --orphan tmp && git branch -D gh-pages || true)
         git checkout --orphan gh-pages

--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,7 @@ dependencies:
 
 test:
   override:
-    - python -u runtests.py -g --shell -- -c 'make -C doc html-scipyorg'
+    - python -u runtests.py -g --shell -- -c 'make -C doc PYTHON=python html-scipyorg'
 
 general:
   artifacts:

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -6,7 +6,7 @@ PYTHON = python$(PYVER)
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = LANG=C sphinx-build
+SPHINXBUILD   = LANG=C $(PYTHON) $(shell which sphinx-build)
 PAPER         =
 
 FILES=

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -141,7 +141,7 @@ html_file_suffix = '.html'
 
 htmlhelp_basename = 'scipy'
 
-mathjax_path = "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"
+mathjax_path = "scipy-mathjax/MathJax.js?config=scipy-mathjax"
 
 
 # -----------------------------------------------------------------------------

--- a/doc/source/tutorial/optimize.rst
+++ b/doc/source/tutorial/optimize.rst
@@ -43,7 +43,6 @@ in `scipy.optimize`. To demonstrate the minimization function consider the
 problem of minimizing the Rosenbrock function of :math:`N` variables:
 
 .. math::
-   :nowrap:
 
     f\left(\mathbf{x}\right)=\sum_{i=1}^{N-1}100\left(x_{i}-x_{i-1}^{2}\right)^{2}+\left(1-x_{i-1}\right)^{2}.
 
@@ -153,7 +152,6 @@ the local Hessian [NW]_.  Newton's method is based on fitting the function
 locally to a quadratic form:
 
 .. math::
-   :nowrap:
 
     f\left(\mathbf{x}\right)\approx f\left(\mathbf{x}_{0}\right)+\nabla f\left(\mathbf{x}_{0}\right)\cdot\left(\mathbf{x}-\mathbf{x}_{0}\right)+\frac{1}{2}\left(\mathbf{x}-\mathbf{x}_{0}\right)^{T}\mathbf{H}\left(\mathbf{x}_{0}\right)\left(\mathbf{x}-\mathbf{x}_{0}\right).
 
@@ -162,7 +160,6 @@ positive definite then the local minimum of this function can be found
 by setting the gradient of the quadratic form to zero, resulting in
 
 .. math::
-   :nowrap:
 
     \mathbf{x}_{\textrm{opt}}=\mathbf{x}_{0}-\mathbf{H}^{-1}\nabla f.
 
@@ -198,7 +195,6 @@ if :math:`i,j\in\left[1,N-2\right]` with :math:`i,j\in\left[0,N-1\right]` defini
 For example, the Hessian when :math:`N=5` is
 
 .. math::
-   :nowrap:
 
     \mathbf{H}=\left[\begin{array}{ccccc} 1200x_{0}^{2}-400x_{1}+2 & -400x_{0} & 0 & 0 & 0\\ -400x_{0} & 202+1200x_{1}^{2}-400x_{2} & -400x_{1} & 0 & 0\\ 0 & -400x_{1} & 202+1200x_{2}^{2}-400x_{3} & -400x_{2} & 0\\ 0 &  & -400x_{2} & 202+1200x_{3}^{2}-400x_{4} & -400x_{3}\\ 0 & 0 & 0 & -400x_{3} & 200\end{array}\right].
 
@@ -247,7 +243,6 @@ vector, then :math:`\mathbf{H}\left(\mathbf{x}\right)\mathbf{p}` has
 elements:
 
 .. math::
-   :nowrap:
 
     \mathbf{H}\left(\mathbf{x}\right)\mathbf{p}=\left[\begin{array}{c} \left(1200x_{0}^{2}-400x_{1}+2\right)p_{0}-400x_{0}p_{1}\\ \vdots\\ -400x_{i-1}p_{i-1}+\left(202+1200x_{i}^{2}-400x_{i+1}\right)p_{i}-400x_{i}p_{i+1}\\ \vdots\\ -400x_{N-2}p_{N-2}+200p_{N-1}\end{array}\right].
 
@@ -400,7 +395,6 @@ form:
 As an example, let us consider the problem of maximizing the function:
 
 .. math::
-    :nowrap:
 
     f(x, y) = 2 x y + 2 x - x^2 - 2 y^2
 
@@ -475,10 +469,12 @@ SciPy is capable of solving robustified bound constrained nonlinear
 least-squares problems:
 
 .. math::
-  \begin{align}
-  &\min_\mathbf{x} \frac{1}{2} \sum_{i = 1}^m \rho\left(f_i(\mathbf{x})^2\right) \\
-  &\text{subject to }\mathbf{lb} \leq \mathbf{x} \leq \mathbf{ub}
-  \end{align}
+   :nowrap:
+   
+   \begin{align}
+   &\min_\mathbf{x} \frac{1}{2} \sum_{i = 1}^m \rho\left(f_i(\mathbf{x})^2\right) \\
+   &\text{subject to }\mathbf{lb} \leq \mathbf{x} \leq \mathbf{ub}
+   \end{align}
 
 Here :math:`f_i(\mathbf{x})` are smooth functions from
 :math:`\mathbb{R}^n` to :math:`\mathbb{R}`, we refer to them as residuals.
@@ -516,6 +512,8 @@ the independent variable. The unknown vector of parameters is
 recommended to compute Jacobian matrix in a closed form:
 
 .. math::
+   :nowrap:
+
     \begin{align}
     &J_{i0} = \frac{\partial f_i}{\partial x_0} = \frac{u_i^2 + u_i x_1}{u_i^2 + u_i x_2 + x_3} \\
     &J_{i1} = \frac{\partial f_i}{\partial x_1} = \frac{u_i x_0}{u_i^2 + u_i x_2 + x_3} \\
@@ -778,7 +776,6 @@ The following example considers the single-variable transcendental
 equation
 
 .. math::
-   :nowrap:
 
     x+2\cos\left(x\right)=0,
 

--- a/doc/source/tutorial/stats.rst
+++ b/doc/source/tutorial/stats.rst
@@ -17,6 +17,12 @@ details.
 
 Note: This documentation is work in progress.
 
+.. toctree::
+   :maxdepth: 1
+
+   stats/discrete
+   stats/continuous
+
 
 Random Variables
 ----------------

--- a/doc/source/tutorial/stats/continuous_gennorm.rst
+++ b/doc/source/tutorial/stats/continuous_gennorm.rst
@@ -33,6 +33,8 @@ Moments
 -------
 
 .. math::
+   :nowrap:
+
     \begin{eqnarray*}
     \mu & = & 0 \\
     m_{n} & = & 0 \\

--- a/doc/source/tutorial/stats/discrete.rst
+++ b/doc/source/tutorial/stats/discrete.rst
@@ -12,7 +12,6 @@ parameter: :math:`L.` The relationship between the general distribution
 :math:`p` and the standard distribution :math:`p_{0}` is
 
 .. math::
-   :nowrap:
 
     p\left(x\right) = p_{0}\left(x-L\right)
 
@@ -21,7 +20,6 @@ is initialized, the discrete distribution can either specify the
 beginning and ending (integer) values :math:`a` and :math:`b` which must be such that
 
 .. math::
-   :nowrap:
 
     p_{0}\left(x\right) = 0\quad x < a \textrm{ or } x > b
 
@@ -37,7 +35,6 @@ The probability mass function of a random variable X is defined as the
 probability that the random variable takes on a particular value.
 
 .. math::
-   :nowrap:
 
     p\left(x_{k}\right)=P\left[X=x_{k}\right]
 
@@ -45,7 +42,6 @@ This is also sometimes called the probability density function,
 although technically
 
 .. math::
-   :nowrap:
 
     f\left(x\right)=\sum_{k}p\left(x_{k}\right)\delta\left(x-x_{k}\right)
 
@@ -62,14 +58,12 @@ Cumulative Distribution Function (CDF)
 The cumulative distribution function is
 
 .. math::
-   :nowrap:
 
     F\left(x\right)=P\left[X\leq x\right]=\sum_{x_{k}\leq x}p\left(x_{k}\right)
 
 and is also useful to be able to compute. Note that
 
 .. math::
-   :nowrap:
 
     F\left(x_{k}\right)-F\left(x_{k-1}\right)=p\left(x_{k}\right)
 
@@ -80,7 +74,6 @@ Survival Function
 The survival function is just
 
 .. math::
-   :nowrap:
 
     S\left(x\right)=1-F\left(x\right)=P\left[X>k\right]
 
@@ -95,7 +88,6 @@ The percent point function is the inverse of the cumulative
 distribution function and is
 
 .. math::
-   :nowrap:
 
     G\left(q\right)=F^{-1}\left(q\right)
 
@@ -111,7 +103,6 @@ Inverse survival function
 The inverse survival function is the inverse of the survival function
 
 .. math::
-   :nowrap:
 
     Z\left(\alpha\right)=S^{-1}\left(\alpha\right)=G\left(1-\alpha\right)
 
@@ -125,14 +116,12 @@ If desired, the hazard function and the cumulative hazard function
 could be defined as
 
 .. math::
-   :nowrap:
 
     h\left(x_{k}\right)=\frac{p\left(x_{k}\right)}{1-F\left(x_{k}\right)}
 
 and
 
 .. math::
-   :nowrap:
 
     H\left(x\right)=\sum_{x_{k}\leq x}h\left(x_{k}\right)=\sum_{x_{k}\leq x}\frac{F\left(x_{k}\right)-F\left(x_{k-1}\right)}{1-F\left(x_{k}\right)}.
 
@@ -143,7 +132,6 @@ Moments
 Non-central moments are defined using the PDF
 
 .. math::
-   :nowrap:
 
     \mu_{m}^{\prime}=E\left[X^{m}\right]=\sum_{k}x_{k}^{m}p\left(x_{k}\right).
 
@@ -157,28 +145,24 @@ Central moments are computed similarly :math:`\mu=\mu_{1}^{\prime}`
 The mean is the first moment
 
 .. math::
-   :nowrap:
 
     \mu=\mu_{1}^{\prime}=E\left[X\right]=\sum_{k}x_{k}p\left(x_{k}\right)
 
 the variance is the second central moment
 
 .. math::
-   :nowrap:
 
     \mu_{2}=E\left[\left(X-\mu\right)^{2}\right]=\sum_{x_{k}}x_{k}^{2}p\left(x_{k}\right)-\mu^{2}.
 
 Skewness is defined as
 
 .. math::
-   :nowrap:
 
     \gamma_{1}=\frac{\mu_{3}}{\mu_{2}^{3/2}}
 
 while (Fisher) kurtosis is
 
 .. math::
-   :nowrap:
 
     \gamma_{2}=\frac{\mu_{4}}{\mu_{2}^{2}}-3,
 
@@ -191,7 +175,6 @@ Moment generating function
 The moment generating function is defined as
 
 .. math::
-   :nowrap:
 
     M_{X}\left(t\right)=E\left[e^{Xt}\right]=\sum_{x_{k}}e^{x_{k}t}p\left(x_{k}\right)
 
@@ -211,7 +194,6 @@ If :math:`f_{i}\left(k;\boldsymbol{\theta}\right)` is the PDF of a random-variab
 random vector :math:`\mathbf{k}` is
 
 .. math::
-   :nowrap:
 
     f\left(\mathbf{k};\boldsymbol{\theta}\right)=\prod_{i=1}^{N}f_{i}\left(k_{i};\boldsymbol{\theta}\right).
 
@@ -236,7 +218,6 @@ Standard notation for mean
 We will use
 
 .. math::
-   :nowrap:
 
     \overline{y\left(\mathbf{x}\right)}=\frac{1}{N}\sum_{i=1}^{N}y\left(x_{i}\right)
 
@@ -249,7 +230,6 @@ Combinations
 Note that
 
 .. math::
-   :nowrap:
 
     k!=k\cdot\left(k-1\right)\cdot\left(k-2\right)\cdot\cdots\cdot1=\Gamma\left(k+1\right)
 
@@ -263,7 +243,6 @@ and has special cases of
 and
 
 .. math::
-   :nowrap:
 
     \left(\begin{array}{c} n\\ k\end{array}\right)=\frac{n!}{\left(n-k\right)!k!}.
 

--- a/doc/source/tutorial/stats/discrete_bernoulli.rst
+++ b/doc/source/tutorial/stats/discrete_bernoulli.rst
@@ -19,17 +19,14 @@ A Bernoulli random variable of parameter :math:`p` takes one of only two values 
     \end{eqnarray*}
 
 .. math::
-   :nowrap:
 
     M\left(t\right) = 1-p\left(1-e^{t}\right)
 
 .. math::
-   :nowrap:
 
     \mu_{m}^{\prime}=p
 
 .. math::
-   :nowrap:
 
     h\left[X\right]=p\log p+\left(1-p\right)\log\left(1-p\right)
 

--- a/doc/source/tutorial/stats/discrete_binom.rst
+++ b/doc/source/tutorial/stats/discrete_binom.rst
@@ -7,7 +7,6 @@ Binomial Distribution
 A binomial random variable with parameters :math:`\left(n,p\right)` can be described as the sum of :math:`n` independent Bernoulli random variables of parameter :math:`p;`
 
 .. math::
-   :nowrap:
 
     Y=\sum_{i=1}^{n}X_{i}.
 
@@ -22,7 +21,6 @@ success is :math:`p.`
 where the incomplete beta integral is
 
 .. math::
-   :nowrap:
 
     I_{x}\left(a,b\right)=\frac{\Gamma\left(a+b\right)}{\Gamma\left(a\right)\Gamma\left(b\right)}\int_{0}^{x}t^{a-1}\left(1-t\right)^{b-1}dt.
 
@@ -34,7 +32,6 @@ Now
     \begin{eqnarray*} \mu & = & np\\ \mu_{2} & = & np\left(1-p\right)\\ \gamma_{1} & = & \frac{1-2p}{\sqrt{np\left(1-p\right)}}\\ \gamma_{2} & = & \frac{1-6p\left(1-p\right)}{np\left(1-p\right)}.\end{eqnarray*}
 
 .. math::
-   :nowrap:
 
     M\left(t\right)=\left[1-p\left(1-e^{t}\right)\right]^{n}
 

--- a/doc/source/tutorial/stats/discrete_boltzmann.rst
+++ b/doc/source/tutorial/stats/discrete_boltzmann.rst
@@ -17,7 +17,6 @@ Define :math:`z=e^{-\lambda}`
     \begin{eqnarray*} \mu & = & \frac{z}{1-z}-\frac{Nz^{N}}{1-z^{N}}\\ \mu_{2} & = & \frac{z}{\left(1-z\right)^{2}}-\frac{N^{2}z^{N}}{\left(1-z^{N}\right)^{2}}\\ \gamma_{1} & = & \frac{z\left(1+z\right)\left(\frac{1-z^{N}}{1-z}\right)^{3}-N^{3}z^{N}\left(1+z^{N}\right)}{\left[z\left(\frac{1-z^{N}}{1-z}\right)^{2}-N^{2}z^{N}\right]^{3/2}}\\ \gamma_{2} & = & \frac{z\left(1+4z+z^{2}\right)\left(\frac{1-z^{N}}{1-z}\right)^{4}-N^{4}z^{N}\left(1+4z^{N}+z^{2N}\right)}{\left[z\left(\frac{1-z^{N}}{1-z}\right)^{2}-N^{2}z^{N}\right]^{2}}\end{eqnarray*}
 
 .. math::
-   :nowrap:
 
     M\left(t\right)=\frac{1-e^{N\left(t-\lambda\right)}}{1-e^{t-\lambda}}\frac{1-e^{-\lambda}}{1-e^{-\lambda N}}
 

--- a/doc/source/tutorial/stats/discrete_dlaplace.rst
+++ b/doc/source/tutorial/stats/discrete_dlaplace.rst
@@ -19,14 +19,12 @@ Defined over all integers for :math:`a>0`
 Thus,
 
 .. math::
-   :nowrap:
 
     \mu_{n}^{\prime}=M^{\left(n\right)}\left(0\right)=\left[1+\left(-1\right)^{n}\right]\textrm{Li}_{-n}\left(e^{-a}\right)
 
 where :math:`\textrm{Li}_{-n}\left(z\right)` is the polylogarithm function of order :math:`-n` evaluated at :math:`z.`
 
 .. math::
-   :nowrap:
 
     h\left[X\right]=-\log\left(\tanh\left(\frac{a}{2}\right)\right)+\frac{a}{\sinh a}
 

--- a/doc/source/tutorial/stats/discrete_logser.rst
+++ b/doc/source/tutorial/stats/discrete_logser.rst
@@ -15,7 +15,6 @@ series expansion of :math:`\log\left(1-p\right)`
 where
 
 .. math::
-   :nowrap:
 
     \Phi\left(z,s,a\right)=\sum_{k=0}^{\infty}\frac{z^{k}}{\left(a+k\right)^{s}}
 
@@ -34,7 +33,6 @@ is the Lerch Transcendent. Also define :math:`r=\log\left(1-p\right)`
 Thus,
 
 .. math::
-   :nowrap:
 
     \mu_{n}^{\prime}=\left.M^{\left(n\right)}\left(t\right)\right|_{t=0}=\left.\frac{\textrm{Li}_{1-n}\left(pe^{t}\right)}{\log\left(1-p\right)}\right|_{t=0}=-\frac{\textrm{Li}_{1-n}\left(p\right)}{\log\left(1-p\right)}.
 

--- a/doc/source/tutorial/stats/discrete_planck.rst
+++ b/doc/source/tutorial/stats/discrete_planck.rst
@@ -18,12 +18,10 @@ solved.
     \begin{eqnarray*} \mu & = & \frac{1}{e^{\lambda}-1}\\ \mu_{2} & = & \frac{e^{-\lambda}}{\left(1-e^{-\lambda}\right)^{2}}\\ \gamma_{1} & = & 2\cosh\left(\frac{\lambda}{2}\right)\\ \gamma_{2} & = & 4+2\cosh\left(\lambda\right)\end{eqnarray*}
 
 .. math::
-   :nowrap:
 
     M\left(t\right)=\frac{1-e^{-\lambda}}{1-e^{t-\lambda}}
 
 .. math::
-   :nowrap:
 
     h\left[X\right]=\frac{\lambda e^{-\lambda}}{1-e^{-\lambda}}-\log\left(1-e^{-\lambda}\right)
 

--- a/doc/source/tutorial/stats/discrete_poisson.rst
+++ b/doc/source/tutorial/stats/discrete_poisson.rst
@@ -14,7 +14,6 @@ in the interval :math:`\left[0,t\right]` for a process satisfying certain "spars
     \begin{eqnarray*} p\left(k;\lambda\right) & = & e^{-\lambda}\frac{\lambda^{k}}{k!}\quad k\geq0,\\ F\left(x;\lambda\right) & = & \sum_{n=0}^{\left\lfloor x\right\rfloor }e^{-\lambda}\frac{\lambda^{n}}{n!}=\frac{1}{\Gamma\left(\left\lfloor x\right\rfloor +1\right)}\int_{\lambda}^{\infty}t^{\left\lfloor x\right\rfloor }e^{-t}dt,\\ \mu & = & \lambda\\ \mu_{2} & = & \lambda\\ \gamma_{1} & = & \frac{1}{\sqrt{\lambda}}\\ \gamma_{2} & = & \frac{1}{\lambda}.\end{eqnarray*}
 
 .. math::
-   :nowrap:
 
     M\left(t\right)=\exp\left[\lambda\left(e^{t}-1\right)\right].
 

--- a/doc/source/tutorial/stats/discrete_zipf.rst
+++ b/doc/source/tutorial/stats/discrete_zipf.rst
@@ -15,7 +15,6 @@ distribution) with parameter :math:`\alpha>1` if it's probability mass function 
 where
 
 .. math::
-   :nowrap:
 
     \zeta\left(\alpha\right)=\sum_{n=1}^{\infty}\frac{1}{n^{\alpha}}
 
@@ -34,12 +33,10 @@ is the Riemann zeta function. Other functions of this distribution are
 where :math:`\zeta_{i}=\zeta\left(\alpha-i\right)` and :math:`\textrm{Li}_{n}\left(z\right)` is the :math:`n^{\textrm{th}}` polylogarithm function of :math:`z` defined as
 
 .. math::
-   :nowrap:
 
     \textrm{Li}_{n}\left(z\right)\equiv\sum_{k=1}^{\infty}\frac{z^{k}}{k^{n}}
 
 .. math::
-   :nowrap:
 
     \mu_{n}^{\prime}=\left.M^{\left(n\right)}\left(t\right)\right|_{t=0}=\left.\frac{\textrm{Li}_{\alpha-n}\left(e^{t}\right)}{\zeta\left(a\right)}\right|_{t=0}=\frac{\zeta\left(\alpha-n\right)}{\zeta\left(\alpha\right)}
 


### PR DESCRIPTION
Bundle a copy of Mathjax with the built docs.

scipy-mathjax repository is added as a submodule: https://github.com/scipy/scipy-mathjax
The `rebuild.sh` script there rebuilds the stripped-down Mathjax package from scratch, so the rebuild process hopefully remains reproducible in future if we need to update the bundled library. The stripping-down process is done with a (semi-?)official script by the mathjax authors.

circleci: https://circle-artifacts.com/gh/scipy/scipy/2732/artifacts/0/home/ubuntu/scipy/doc/build/html-scipyorg/index.html

Fixes gh-7286