### PR TITLE
MAINT: optimize: Better name for trust-region-exact method.

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -162,7 +162,7 @@ Bill Sacks for fixes to netcdf i/o.
 Kolja Glogowski for a bug fix in scipy.special.
 Surhud More for enhancing scipy.optimize.curve_fit to accept covariant errors
 on data.
-Antonio Ribeiro for implementing irrnotch, iirpeak and trust-region-exact methods
+Antonio H. Ribeiro for implementing irrnotch, iirpeak and trust-exact methods
     and for improvements on BFGS implemetation.
 Ilhan Polat for bug fixes on Riccati solvers.
 Sebastiano Vigna for code in the stats package related to Kendall's tau.

--- a/benchmarks/benchmarks/optimize.py
+++ b/benchmarks/benchmarks/optimize.py
@@ -209,7 +209,7 @@ class _BenchOptimizers(Benchmark):
         if methods is None:
             methods = ["COBYLA", 'Powell',
                        'L-BFGS-B', 'BFGS', 'CG', 'TNC', 'SLSQP',
-                       "Newton-CG", 'dogleg', 'trust-ncg', 'trust-region-exact']
+                       "Newton-CG", 'dogleg', 'trust-ncg', 'trust-exact']
 
         fonly_methods = ["COBYLA", 'Powell']
         for method in fonly_methods:
@@ -233,7 +233,7 @@ class _BenchOptimizers(Benchmark):
                 self.add_result(res, t1-t0, method)
 
         hessian_methods = ["Newton-CG", 'dogleg', 'trust-ncg',
-                           'trust-region-exact']
+                           'trust-exact']
         if self.hess is not None:
             for method in hessian_methods:
                 if method not in methods:
@@ -254,7 +254,7 @@ class BenchSmoothUnbounded(Benchmark):
          'sin_1d', 'booth', 'beale', 'LJ'],
         ["COBYLA", 'Powell',
          'L-BFGS-B', 'BFGS', 'CG', 'TNC', 'SLSQP',
-         "Newton-CG", 'dogleg', 'trust-ncg', 'trust-region-exact'],
+         "Newton-CG", 'dogleg', 'trust-ncg', 'trust-exact'],
         ["mean_nfev", "mean_time"]
     ]
     param_names = ["test function", "solver", "result type"]

--- a/doc/release/1.0.0-notes.rst
+++ b/doc/release/1.0.0-notes.rst
@@ -45,7 +45,7 @@ faster convergence.
 `scipy.optimize` improvements
 -----------------------------
 
-The method `trust-region-exact` was added to the function `scipy.optimize.minimize`.
+The method `trust-exact` was added to the function `scipy.optimize.minimize`.
 This new trust-region method solves the subproblem with higher accuracy at the cost
 of more Hessian factorizations (compared to dogleg) and is able to deal with indefinite
 Hessians. It seems very competitive against the other Newton methods implemented in scipy.

--- a/doc/source/optimize.minimize-trustexact.rst
+++ b/doc/source/optimize.minimize-trustexact.rst
@@ -1,8 +1,8 @@
 .. _optimize.minimize-trustexact:
 
-minimize(method='trust-region-exact')
+minimize(method='trust-exact')
 -------------------------------------------
 
 .. scipy-optimize:function:: scipy.optimize.minimize
    :impl: scipy.optimize._trustregion_exact._minimize_trustregion_exact
-   :method: trust-region-exact
+   :method: trust-exact

--- a/doc/source/tutorial/optimize.rst
+++ b/doc/source/tutorial/optimize.rst
@@ -338,7 +338,7 @@ Hessian product example:
     array([1., 1., 1., 1., 1.])
 
 
-Trust-Region Nearly Exact Algorithm (``method='trust-region-exact'``)
+Trust-Region Nearly Exact Algorithm (``method='trust-exact'``)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Both methods ``Newton-CG`` and ``trust-ncg`` are suitable for dealing with
@@ -359,7 +359,7 @@ trust-region methods. The Hessian product option is not supported by this algori
 example using the Rosenbrock function follows:
 
 
-    >>> res = minimize(rosen, x0, method='trust-region-exact',
+    >>> res = minimize(rosen, x0, method='trust-exact',
     ...                jac=rosen_der, hess=rosen_hess,
     ...                options={'gtol': 1e-8, 'disp': True})
     Optimization terminated successfully.

--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -76,7 +76,7 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
             - 'SLSQP'       :ref:`(see here) <optimize.minimize-slsqp>`
             - 'dogleg'      :ref:`(see here) <optimize.minimize-dogleg>`
             - 'trust-ncg'   :ref:`(see here) <optimize.minimize-trustncg>`
-            - 'trust-region-exact'   :ref:`(see here) <optimize.minimize-trustexact>`
+            - 'trust-exact' :ref:`(see here) <optimize.minimize-trustexact>`
             - custom - a callable object (added in version 0.14.0),
               see below for description.
 
@@ -205,7 +205,7 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
     and either the Hessian or a function that computes the product of
     the Hessian with a given vector. Suitable for large-scale problems.
 
-    Method :ref:`trust-region-exact <optimize.minimize-trustexact>`
+    Method :ref:`trust-exact <optimize.minimize-trustexact>`
     is a trust-region method for unconstrained minimization in which
     quadratic subproblems are solved almost exactly [13]_. This
     algorithm requires the gradient and the Hessian (which is
@@ -394,7 +394,7 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
              RuntimeWarning)
     # - hess
     if meth not in ('newton-cg', 'dogleg', 'trust-ncg',
-                    'trust-region-exact', '_custom') and hess is not None:
+                    'trust-exact', '_custom') and hess is not None:
         warn('Method %s does not use Hessian information (hess).' % method,
              RuntimeWarning)
     # - hessp
@@ -440,7 +440,7 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
         if meth in ['powell', 'l-bfgs-b', 'tnc', 'slsqp']:
             options.setdefault('ftol', tol)
         if meth in ['bfgs', 'cg', 'l-bfgs-b', 'tnc', 'dogleg',
-                    'trust-ncg', 'trust-region-exact']:
+                    'trust-ncg', 'trust-exact']:
             options.setdefault('gtol', tol)
         if meth in ['cobyla', '_custom']:
             options.setdefault('tol', tol)
@@ -477,7 +477,7 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
     elif meth == 'trust-ncg':
         return _minimize_trust_ncg(fun, x0, args, jac, hess, hessp,
                                    callback=callback, **options)
-    elif meth == 'trust-region-exact':
+    elif meth == 'trust-exact':
         return _minimize_trustregion_exact(fun, x0, args, jac, hess,
                                            callback=callback, **options)
     else:

--- a/scipy/optimize/tests/test_trustregion.py
+++ b/scipy/optimize/tests/test_trustregion.py
@@ -73,7 +73,7 @@ class TestTrustRegionSolvers(TestCase):
             r_ncg = minimize(f, x0, jac=g, hess=h, tol=1e-8,
                              method='newton-cg', options={'return_all': True})
             r_iterative = minimize(f, x0, jac=g, hess=h, tol=1e-8,
-                                   method='trust-region-exact',
+                                   method='trust-exact',
                                    options={'return_all': True})
             assert_allclose(self.x_opt, r_dogleg['x'])
             assert_allclose(self.x_opt, r_trust_ncg['x'])


### PR DESCRIPTION
I changed the name of the optimization method `trust-region-exact` to `trust-exact`.
The new name is more in the line of other trust-region optimization methods in scipy
(The idea of changing was suggested by @nmayorov  in the discussion following PR #7292).
