### PR TITLE
fix KroghInterpolator.derivatives failure with complex input

### DIFF
--- a/scipy/interpolate/polyint.py
+++ b/scipy/interpolate/polyint.py
@@ -335,23 +335,23 @@ class KroghInterpolator(_Interpolator1DWithDerivatives):
         w = np.zeros((n, len(x)))
         pi[0] = 1
         p = np.zeros((len(x), self.r), dtype=self.dtype)
-        p += self.c[0,np.newaxis,:]
+        p += self.c[0, np.newaxis, :]
 
-        for k in xrange(1,n):
+        for k in xrange(1, n):
             w[k-1] = x - self.xi[k-1]
-            pi[k] = w[k-1]*pi[k-1]
-            p += pi[k,:,np.newaxis]*self.c[k]
+            pi[k] = w[k-1] * pi[k-1]
+            p += pi[k, :, np.newaxis] * self.c[k]
 
-        cn = np.zeros((max(der,n+1), len(x), r), dtype=self.dtype)
-        cn[:n+1,:,:] += self.c[:n+1,np.newaxis,:]
+        cn = np.zeros((max(der, n+1), len(x), r), dtype=self.dtype)
+        cn[:n+1, :, :] += self.c[:n+1, np.newaxis, :]
         cn[0] = p
-        for k in xrange(1,n):
-            for i in xrange(1,n-k+1):
-                pi[i] = w[k+i-1]*pi[i-1]+pi[i]
-                cn[k] = cn[k]+pi[i,:,np.newaxis]*cn[k+i]
+        for k in xrange(1, n):
+            for i in xrange(1, n-k+1):
+                pi[i] = w[k+i-1]*pi[i-1] + pi[i]
+                cn[k] = cn[k] + pi[i, :, np.newaxis]*cn[k+i]
             cn[k] *= factorial(k)
 
-        cn[n,:,:] = 0
+        cn[n, :, :] = 0
         return cn[:der]
 
 

--- a/scipy/interpolate/polyint.py
+++ b/scipy/interpolate/polyint.py
@@ -334,7 +334,7 @@ class KroghInterpolator(_Interpolator1DWithDerivatives):
         pi = np.zeros((n, len(x)))
         w = np.zeros((n, len(x)))
         pi[0] = 1
-        p = np.zeros((len(x), self.r))
+        p = np.zeros((len(x), self.r), dtype=self.dtype)
         p += self.c[0,np.newaxis,:]
 
         for k in xrange(1,n):

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -264,6 +264,16 @@ class CheckKrogh(TestCase):
 
         assert_allclose(abs((f(x) - offset_cdf) / f.derivative(x, 1)), 0, atol=1e-10)
 
+    def test_derivatives_complex(self):
+        # regression test for gh-7381: krogh.derivatives(0) fails complex y
+        x, y = np.array([-1, -1, 0, 1, 1]), np.array([1, 1.0j, 0, -1, 1.0j])
+        func = KroghInterpolator(x, y)
+        cmplx = func.derivatives(0)
+
+        cmplx2 = (KroghInterpolator(x, y.real).derivatives(0) +
+                  1j*KroghInterpolator(x, y.imag).derivatives(0))
+        assert_allclose(cmplx, cmplx2, atol=1e-15)
+
 
 class CheckTaylor(TestCase):
     def test_exponential(self):

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -249,20 +249,26 @@ class CheckKrogh(TestCase):
         assert_array_equal(np.shape(P.derivatives([0,1])), (n,2,3))
 
     def test_wrapper(self):
-        P = KroghInterpolator(self.xs,self.ys)
-        assert_almost_equal(P(self.test_xs),krogh_interpolate(self.xs,self.ys,self.test_xs))
-        assert_almost_equal(P.derivative(self.test_xs,2),krogh_interpolate(self.xs,self.ys,self.test_xs,der=2))
-        assert_almost_equal(P.derivatives(self.test_xs,2),krogh_interpolate(self.xs,self.ys,self.test_xs,der=[0,1]))
+        P = KroghInterpolator(self.xs, self.ys)
+        ki = krogh_interpolate
+        assert_almost_equal(P(self.test_xs), ki(self.xs, self.ys, self.test_xs))
+        assert_almost_equal(P.derivative(self.test_xs, 2),
+                            ki(self.xs, self.ys, self.test_xs, der=2))
+        assert_almost_equal(P.derivatives(self.test_xs, 2),
+                            ki(self.xs, self.ys, self.test_xs, der=[0, 1]))
 
     def test_int_inputs(self):
         # Check input args are cast correctly to floats, gh-3669
-        x = [0, 234,468,702,936,1170,1404,2340,3744,6084,8424,13104,60000]
-        offset_cdf = np.array([-0.95, -0.86114777, -0.8147762, -0.64072425, -0.48002351,
-                               -0.34925329, -0.26503107, -0.13148093, -0.12988833, -0.12979296,
+        x = [0, 234, 468, 702, 936, 1170, 1404, 2340, 3744, 6084, 8424,
+             13104, 60000]
+        offset_cdf = np.array([-0.95, -0.86114777, -0.8147762, -0.64072425,
+                               -0.48002351, -0.34925329, -0.26503107,
+                               -0.13148093, -0.12988833, -0.12979296,
                                -0.12973574, -0.08582937, 0.05])
         f = KroghInterpolator(x, offset_cdf)
 
-        assert_allclose(abs((f(x) - offset_cdf) / f.derivative(x, 1)), 0, atol=1e-10)
+        assert_allclose(abs((f(x) - offset_cdf) / f.derivative(x, 1)),
+                        0, atol=1e-10)
 
     def test_derivatives_complex(self):
         # regression test for gh-7381: krogh.derivatives(0) fails complex y


### PR DESCRIPTION
fixes gh-7381.

While I'm at it, add some whitespace after commas, wrap some overly long lines. The bugfix commit is 	a192430.