### PR TITLE
"Weight" is actually mass. Add slugs and slinches/blobs to mass units in scipy.constants

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -176,6 +176,7 @@ Roman Feldbauer for improvements in scipy.sparse
 Dominic Antonacci for statistics documentation.
 David Hagen for the object-oriented ODE solver interface.
 Arno Onken for contributions to scipy.stats.
+Adam Cox for contributions to scipy.constants.
 
 Institutions
 ------------

--- a/scipy/constants/__init__.py
+++ b/scipy/constants/__init__.py
@@ -125,29 +125,6 @@ Binary prefixes
 ``yobi``      :math:`2^{80}`
 ============  =================================================================
 
-Weight
-------
-
-=================  ============================================================
-``gram``           :math:`10^{-3}` kg
-``metric_ton``     :math:`10^{3}` kg
-``grain``          one grain in kg
-``lb``             one pound (avoirdupous) in kg
-``pound``          one pound (avoirdupous) in kg
-``oz``             one ounce in kg
-``ounce``          one ounce in kg
-``stone``          one stone in kg
-``grain``          one grain in kg
-``long_ton``       one long ton in kg
-``short_ton``      one short ton in kg
-``troy_ounce``     one Troy ounce in kg
-``troy_pound``     one Troy pound in kg
-``carat``          one carat in kg
-``m_u``            atomic mass constant (in kg)
-``u``              atomic mass constant (in kg)
-``atomic_mass``    atomic mass constant (in kg)
-=================  ============================================================
-
 Angle
 -----
 
@@ -287,6 +264,30 @@ Power
 ``hp``                one horsepower in watts
 ``horsepower``        one horsepower in watts
 ====================  =======================================================
+
+Mass
+------
+
+=================  ============================================================
+``gram``           :math:`10^{-3}` kg
+``metric_ton``     :math:`10^{3}` kg
+``grain``          one grain in kg
+``lb``             one pound (avoirdupous) in kg
+``pound``          one pound (avoirdupous) in kg
+``slug``           one slug in kg
+``oz``             one ounce in kg
+``ounce``          one ounce in kg
+``stone``          one stone in kg
+``grain``          one grain in kg
+``long_ton``       one long ton in kg
+``short_ton``      one short ton in kg
+``troy_ounce``     one Troy ounce in kg
+``troy_pound``     one Troy pound in kg
+``carat``          one carat in kg
+``m_u``            atomic mass constant (in kg)
+``u``              atomic mass constant (in kg)
+``atomic_mass``    atomic mass constant (in kg)
+=================  ============================================================
 
 Force
 -----

--- a/scipy/constants/__init__.py
+++ b/scipy/constants/__init__.py
@@ -125,6 +125,32 @@ Binary prefixes
 ``yobi``      :math:`2^{80}`
 ============  =================================================================
 
+Mass
+------
+
+=================  ============================================================
+``gram``           :math:`10^{-3}` kg
+``metric_ton``     :math:`10^{3}` kg
+``grain``          one grain in kg
+``lb``             one pound (avoirdupous) in kg
+``pound``          one pound (avoirdupous) in kg
+``blob``           one inch version of a slug in kg (added in 1.0.0)
+``slinch``         one inch version of a slug in kg (added in 1.0.0)
+``slug``           one slug in kg (added in 1.0.0)
+``oz``             one ounce in kg
+``ounce``          one ounce in kg
+``stone``          one stone in kg
+``grain``          one grain in kg
+``long_ton``       one long ton in kg
+``short_ton``      one short ton in kg
+``troy_ounce``     one Troy ounce in kg
+``troy_pound``     one Troy pound in kg
+``carat``          one carat in kg
+``m_u``            atomic mass constant (in kg)
+``u``              atomic mass constant (in kg)
+``atomic_mass``    atomic mass constant (in kg)
+=================  ============================================================
+
 Angle
 -----
 
@@ -264,30 +290,6 @@ Power
 ``hp``                one horsepower in watts
 ``horsepower``        one horsepower in watts
 ====================  =======================================================
-
-Mass
-------
-
-=================  ============================================================
-``gram``           :math:`10^{-3}` kg
-``metric_ton``     :math:`10^{3}` kg
-``grain``          one grain in kg
-``lb``             one pound (avoirdupous) in kg
-``pound``          one pound (avoirdupous) in kg
-``slug``           one slug in kg
-``oz``             one ounce in kg
-``ounce``          one ounce in kg
-``stone``          one stone in kg
-``grain``          one grain in kg
-``long_ton``       one long ton in kg
-``short_ton``      one short ton in kg
-``troy_ounce``     one Troy ounce in kg
-``troy_pound``     one Troy pound in kg
-``carat``          one carat in kg
-``m_u``            atomic mass constant (in kg)
-``u``              atomic mass constant (in kg)
-``atomic_mass``    atomic mass constant (in kg)
-=================  ============================================================
 
 Force
 -----

--- a/scipy/constants/constants.py
+++ b/scipy/constants/constants.py
@@ -73,11 +73,12 @@ sigma = Stefan_Boltzmann = _cd('Stefan-Boltzmann constant')
 Wien = _cd('Wien wavelength displacement law constant')
 Rydberg = _cd('Rydberg constant')
 
-# weight in kg
+# mass in kg
 gram = 1e-3
 metric_ton = 1e3
 grain = 64.79891e-6
 lb = pound = 7000 * grain  # avoirdupois
+slug = pound * g / (12 * 0.0254)  # lbf/foot
 oz = ounce = pound / 16
 stone = 14 * pound
 long_ton = 2240 * pound

--- a/scipy/constants/constants.py
+++ b/scipy/constants/constants.py
@@ -78,7 +78,8 @@ gram = 1e-3
 metric_ton = 1e3
 grain = 64.79891e-6
 lb = pound = 7000 * grain  # avoirdupois
-slug = pound * g / (12 * 0.0254)  # lbf/foot
+blob = slinch = pound * g / 0.0254  # lbf*s**2/in (added in 1.0.0)
+slug = blob / 12  # lbf*s**2/foot (added in 1.0.0)
 oz = ounce = pound / 16
 stone = 14 * pound
 long_ton = 2240 * pound


### PR DESCRIPTION
The units listed in the documentation as weight are actually mass units. Edited documentation to account for that. Also, added slugs to mass units.