### PR TITLE
DOC: Add examples to linalg.solvers docstrings

### DIFF
--- a/scipy/linalg/_solvers.py
+++ b/scipy/linalg/_solvers.py
@@ -63,6 +63,22 @@ def solve_sylvester(a, b, q):
 
     .. versionadded:: 0.11.0
 
+    Examples
+    --------
+    Given `a`, `b`, and `q` solve for `x`:
+
+    >>> from scipy import linalg
+    >>> a = np.array([[-3, -2, 0], [-1, -1, 3], [3, -5, -1]])
+    >>> b = np.array([[1]])
+    >>> q = np.array([[1],[2],[3]])
+    >>> x = sp.linalg.solve_sylvester(a, b, q)
+    >>> x
+    array([[ 0.0625],
+           [-0.5625],
+           [ 0.6875]])
+    >>> np.allclose(a.dot(x) + x.dot(b), q)
+    True
+
     """
 
     # Compute the Schur decomp form of a
@@ -117,12 +133,26 @@ def solve_continuous_lyapunov(a, q):
 
     Notes
     -----
-    Because the continuous Lyapunov equation is just a special form of the
-    Sylvester equation, this solver relies entirely on solve_sylvester for a
-    solution.
+    The continuous Lyapunov equation is a special form of the Sylvester
+    equation, hence this solver relies on LAPACK routine ?TRSYL.
 
     .. versionadded:: 0.11.0
 
+    Examples
+    --------
+    Given `a` and `q` solve for `x`:
+
+    >>> from scipy import linalg
+    >>> a = np.array([[-3, -2, 0], [-1, -1, 0], [0, -5, -1]])
+    >>> b = np.array([2, 4, -1])
+    >>> q = np.eye(3)
+    >>> x = linalg.solve_continuous_lyapunov(a, q)
+    >>> x
+    array([[ -0.75  ,   0.875 ,  -3.75  ],
+           [  0.875 ,  -1.375 ,   5.3125],
+           [ -3.75  ,   5.3125, -27.0625]])
+    >>> np.allclose(a.dot(x) + x.dot(a.T), q)
+    True
     """
 
     a = np.atleast_2d(_asarray_validated(a, check_finite=True))
@@ -256,6 +286,20 @@ def solve_discrete_lyapunov(a, q, method=None):
        Lyapunov Matrix Equation in System Stability and Control.
        Dover Books on Engineering Series. Dover Publications.
 
+    Examples
+    --------
+    Given `a` and `q` solve for `x`:
+
+    >>> from scipy import linalg
+    >>> a = np.array([[0.2, 0.5],[0.7, -0.9]])
+    >>> q = np.eye(2)
+    >>> x = linalg.solve_discrete_lyapunov(a, q)
+    >>> x
+    array([[ 0.70872893,  1.43518822],
+           [ 1.43518822, -2.4266315 ]])
+    >>> np.allclose(a.dot(x).dot(a.T)-x, -q)
+    True
+
     """
     a = np.asarray(a)
     q = np.asarray(q)
@@ -377,6 +421,22 @@ def solve_continuous_are(a, b, q, r, e=None, s=None, balanced=True):
 
     .. [3] P. Benner, "Symplectic Balancing of Hamiltonian Matrices", 2001,
        SIAM J. Sci. Comput., 2001, Vol.22(5), DOI: 10.1137/S1064827500367993
+
+    Examples
+    --------
+    Given `a`, `b`, `q`, and `r` solve for `x`:
+
+    >>> from scipy import linalg
+    >>> a = np.array([[4, 3], [-4.5, -3.5]])
+    >>> b = np.array([[1], [-1]])
+    >>> q = np.array([[9, 6], [6, 4.]])
+    >>> r = 1
+    >>> x = linalg.solve_continuous_are(a, b, q, r)
+    >>> x
+    array([[ 21.72792206,  14.48528137],
+           [ 14.48528137,   9.65685425]])
+    >>> np.allclose(a.T.dot(x) + x.dot(a)-x.dot(b).dot(b.T).dot(x), -q)
+    True
 
     """
 
@@ -565,6 +625,23 @@ def solve_discrete_are(a, b, q, r, e=None, s=None, balanced=True):
 
     .. [3] P. Benner, "Symplectic Balancing of Hamiltonian Matrices", 2001,
        SIAM J. Sci. Comput., 2001, Vol.22(5), DOI: 10.1137/S1064827500367993
+
+    Examples
+    --------
+    Given `a`, `b`, `q`, and `r` solve for `x`:
+
+    >>> from scipy import linalg as la
+    >>> a = np.array([[0, 1], [0, -1]])
+    >>> b = np.array([[1, 0], [2, 1]])
+    >>> q = np.array([[-4, -4], [-4, 7]])
+    >>> r = np.array([[9, 3], [3, 1]])
+    >>> x = la.solve_discrete_are(a, b, q, r)
+    >>> x
+    array([[-4., -4.],
+           [-4.,  7.]])
+    >>> R = la.solve(r + b.T.dot(x).dot(b), b.T.dot(x).dot(a))
+    >>> np.allclose(a.T.dot(x).dot(a) - x - a.T.dot(x).dot(b).dot(R), -q)
+    True
 
     """
 

--- a/scipy/linalg/_solvers.py
+++ b/scipy/linalg/_solvers.py
@@ -71,7 +71,7 @@ def solve_sylvester(a, b, q):
     >>> a = np.array([[-3, -2, 0], [-1, -1, 3], [3, -5, -1]])
     >>> b = np.array([[1]])
     >>> q = np.array([[1],[2],[3]])
-    >>> x = sp.linalg.solve_sylvester(a, b, q)
+    >>> x = linalg.solve_sylvester(a, b, q)
     >>> x
     array([[ 0.0625],
            [-0.5625],

--- a/scipy/linalg/blas.py
+++ b/scipy/linalg/blas.py
@@ -197,6 +197,18 @@ def find_best_blas_type(arrays=(), dtype=None):
     prefer_fortran : bool
         Whether to prefer Fortran order routines over C order.
 
+    Examples
+    --------
+    >>> import scipy.linalg.blas as bla
+    >>> a = np.random.rand(10,15)
+    >>> b = np.asfortranarray(a)  # Change the memory layout order
+    >>> bla.find_best_blas_type((a,))
+    ('d', dtype('float64'), False)
+    >>> bla.find_best_blas_type((a*1j,))
+    ('z', dtype('complex128'), False)
+    >>> bla.find_best_blas_type((b,))
+    ('d', dtype('float64'), True)
+
     """
     dtype = _np.dtype(dtype)
     prefer_fortran = False
@@ -306,6 +318,18 @@ def get_blas_funcs(names, arrays=(), dtype=None):
     types {float32, float64, complex64, complex128} respectively.
     The code and the dtype are stored in attributes `typecode` and `dtype`
     of the returned functions.
+
+    Examples
+    --------
+    >>> import scipy.linalg as LA
+    >>> a = np.random.rand(3,2)
+    >>> x_gemv = LA.get_blas_funcs('gemv', (a,))
+    >>> x_gemv.typecode
+    'd'
+    >>> x_gemv = LA.get_blas_funcs('gemv',(a*1j,))
+    >>> x_gemv.typecode
+    'z'
+
     """
     return _get_funcs(names, arrays, dtype,
                       "BLAS", _fblas, _cblas, "fblas", "cblas",

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -482,14 +482,12 @@ def get_lapack_funcs(names, arrays=(), dtype=None):
         used, otherwise the most generic type in arrays will be used.
 
     dtype : str or dtype, optional
-        Data-type specifier. Not used if ``arrays`` is non-empty.
-
+        Data-type specifier. Not used if `arrays` is non-empty.
 
     Returns
     -------
     funcs : list
         List containing the found function(s).
-
 
     Notes
     -----
@@ -499,7 +497,7 @@ def get_lapack_funcs(names, arrays=(), dtype=None):
 
     In LAPACK, the naming convention is that all functions start with a
     type prefix, which depends on the type of the principal
-    matrix. These can be one of {`'s'`, `'d'`, `'c'`, `'z'`} for the numpy
+    matrix. These can be one of {'s', 'd', 'c', 'z'} for the numpy
     types {float32, float64, complex64, complex128} respectively, and
     are stored in attribute ``typecode`` of the returned functions.
 
@@ -509,14 +507,14 @@ def get_lapack_funcs(names, arrays=(), dtype=None):
     norm of an array. We pass our array in order to get the correct 'lange'
     flavor.
 
-    >>> from scipy.linalg import lapack as lap
+    >>> import scipy.linalg as LA
     >>> a = np.random.rand(3,2)
-    >>> x_lange = lap.get_lapack_funcs('lange', (a,))
-    >>> x_lange
-    <fortran dlange>
-    >>> x_lange = lap.get_lapack_funcs('lange',(a*1j,))
-    >>> x_lange
-    <fortran zlange>
+    >>> x_lange = LA.get_lapack_funcs('lange', (a,))
+    >>> x_lange.typecode
+    'd'
+    >>> x_lange = LA.get_lapack_funcs('lange',(a*1j,))
+    >>> x_lange.typecode
+    'z'
 
     Several LAPACK routines work best when its internal WORK array has
     the optimal size (big enough for fast computation and small enough to
@@ -524,17 +522,13 @@ def get_lapack_funcs(names, arrays=(), dtype=None):
     to the function which is often wrapped as a standalone function and
     commonly denoted as ``###_lwork``. Below is an example for ``?sysv``
 
-    >>> from scipy.linalg import lapack as lap
+    >>> import scipy.linalg as LA
     >>> a = np.random.rand(1000,1000)
     >>> b = np.random.rand(1000,1)*1j
     >>> # We pick up zsysv and zsysv_lwork due to b array
-    ... xsysv, xlwork = lap.get_lapack_funcs(('sysv', 'sysv_lwork'), (a, b))
-    >>> opt_lwork = lap._compute_lwork(xlwork, a.shape[0])
-    >>> udut, ipiv, x, info = xsysv(a, b, lwork=opt_lwork)
-
-    Note that it is also possible to call ``xlwork`` directly too. However it
-    is recommended to use ``_compute_lwork`` instead, especially if large
-    array sizes are involved.
+    ... xsysv, xlwork = LA.get_lapack_funcs(('sysv', 'sysv_lwork'), (a, b))
+    >>> opt_lwork, _ = xlwork(a.shape[0])  # returns a complex for 'z' prefix
+    >>> udut, ipiv, x, info = xsysv(a, b, lwork=int(opt_lwork.real))
 
     """
     return _get_funcs(names, arrays, dtype,


### PR DESCRIPTION
Following the cue in #7168 the straightforward examples are added to Riccati, Lyapunov and Sylvester solvers. 