### PR TITLE
BUG: stats: allow integers as kappa4 shape parameters

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -24,6 +24,14 @@ from ._distn_infrastructure import (get_distribution_names, _kurtosis,
 from ._constants import _XMIN, _EULER, _ZETA3, _XMAX, _LOGXMAX
 
 
+# In numpy 1.12 and above, np.power refuses to raise integers to negative
+# powers, and `np.float_power` is a new replacement. 
+try:
+    float_power = np.float_power
+except AttributeError:
+    float_power = np.power
+
+
 ## Kolmogorov-Smirnov one-sided and two-sided test statistics
 class ksone_gen(rv_continuous):
     """General Kolmogorov-Smirnov one-sided test.
@@ -3464,7 +3472,7 @@ class kappa4_gen(rv_continuous):
                     np.logical_and(h <= 0, k < 0)]
 
         def f0(h, k):
-            return (1.0 - h**(-k))/k
+            return (1.0 - float_power(h, -k))/k
 
         def f1(h, k):
             return np.log(h)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -813,6 +813,11 @@ class TestKappa4(TestCase):
         vals_comp = stats.uniform.cdf(x)
         assert_allclose(vals, vals_comp)
 
+    def test_integers_ctor(self):
+        # regression test for gh-7416: _argcheck fails for integer h and k
+        # in numpy 1.12
+        stats.kappa4(1, 2)
+
 
 class TestPoisson(TestCase):
 


### PR DESCRIPTION
Using integer h and k fails in numpy 1.12 and above because of the np.power(integer, negative integer) change. Thus, use the replacement, `np.float_power`, where available.

fixes gh-7416