### PR TITLE
Expand binnumbers with correct dimensions

### DIFF
--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -524,9 +524,10 @@ def binned_statistic_dd(sample, values, statistic='mean',
     nbin = np.asarray(nbin)
 
     # Compute the bin number each sample falls into, in each dimension
-    sampBin = {}
-    for i in xrange(Ndim):
-        sampBin[i] = np.digitize(sample[:, i], edges[i])
+    sampBin = [
+        np.digitize(sample[:, i], edges[i])
+        for i in xrange(Ndim)
+    ]
 
     # Using `digitize`, values that fall on an edge are put in the right bin.
     # For the rightmost bin, we want values equal to the right
@@ -541,12 +542,7 @@ def binned_statistic_dd(sample, values, statistic='mean',
         sampBin[i][on_edge] -= 1
 
     # Compute the sample indices in the flattened statistic matrix.
-    ni = nbin.argsort()
-    # `binnumbers` is which bin (in linearized `Ndim` space) each sample goes
-    binnumbers = np.zeros(Dlen, int)
-    for i in xrange(0, Ndim - 1):
-        binnumbers += sampBin[ni[i]] * nbin[ni[i + 1:]].prod()
-    binnumbers += sampBin[ni[-1]]
+    binnumbers = np.ravel_multi_index(sampBin, nbin)
 
     result = np.empty([Vdim, nbin.prod()], float)
 
@@ -608,13 +604,7 @@ def binned_statistic_dd(sample, values, statistic='mean',
                 result[vv, i] = statistic(values[vv, binnumbers == i])
 
     # Shape into a proper matrix
-    result = result.reshape(np.append(Vdim, np.sort(nbin)))
-
-    for i in xrange(nbin.size):
-        j = ni.argsort()[i]
-        # Accomodate the extra `Vdim` dimension-zero with `+1`
-        result = result.swapaxes(i+1, j+1)
-        ni[i], ni[j] = ni[j], ni[i]
+    result = result.reshape(np.append(Vdim, nbin))
 
     # Remove outliers (indices 0 and -1 for each bin-dimension).
     core = [slice(None)] + Ndim * [slice(1, -1)]

--- a/scipy/stats/tests/test_binned_statistic.py
+++ b/scipy/stats/tests/test_binned_statistic.py
@@ -296,11 +296,11 @@ class TestBinnedStatistic(object):
         y = self.y
         v = self.v
 
-        stat, edgesx, bcx = binned_statistic(x, v, 'mean', bins=10)
+        stat, edgesx, bcx = binned_statistic(x, v, 'mean', bins=20)
         stat, edgesy, bcy = binned_statistic(y, v, 'mean', bins=10)
 
         stat2, edgesx2, edgesy2, bc2 = binned_statistic_2d(
-            x, y, v, 'mean', bins=10, expand_binnumbers=True)
+            x, y, v, 'mean', bins=(20, 10), expand_binnumbers=True)
 
         bcx3 = np.searchsorted(edgesx, x, side='right')
         bcy3 = np.searchsorted(edgesy, y, side='right')
@@ -425,12 +425,12 @@ class TestBinnedStatistic(object):
         X = self.X
         v = self.v
 
-        stat, edgesx, bcx = binned_statistic(X[:, 0], v, 'mean', bins=10)
-        stat, edgesy, bcy = binned_statistic(X[:, 1], v, 'mean', bins=10)
+        stat, edgesx, bcx = binned_statistic(X[:, 0], v, 'mean', bins=15)
+        stat, edgesy, bcy = binned_statistic(X[:, 1], v, 'mean', bins=20)
         stat, edgesz, bcz = binned_statistic(X[:, 2], v, 'mean', bins=10)
 
         stat2, edges2, bc2 = binned_statistic_dd(
-            X, v, 'mean', bins=10, expand_binnumbers=True)
+            X, v, 'mean', bins=(15, 20, 10), expand_binnumbers=True)
 
         assert_allclose(bcx, bc2[0])
         assert_allclose(bcy, bc2[1])


### PR DESCRIPTION
This is a fix to https://github.com/scipy/scipy/issues/7010#issuecomment-302921713

Test code: 
```
import numpy as np
import scipy.stats

x = np.array([1, 2, 3, 4])
y = np.array([1, 2, 3, 4])
bins = np.array([
    np.linspace(0.5, 4.5, 5),
    np.linspace(0.5, 4.5, 3),
])
count, x_edges, y_edges, binnum = scipy.stats.binned_statistic_2d(
    x, y, None, 'count', bins=bins,
    expand_binnumbers=True
)
print('x: ', x)
print('y: ', y)
print('X Edges:', x_edges)
print('Y Edges:', y_edges)
print('Bin number:')
print(binnum)
```
Output before fix:
```
x:  [1 2 3 4]
y:  [1 2 3 4]
X Edges: [ 0.5  1.5  2.5  3.5  4.5]
Y Edges: [ 0.5  2.5  4.5]
Bin number:
[[1 2 3 4]
 [3 0 3 0]]
```
The expected bin number should be
```
[[1 2 3 4]
 [1 1 2 2]]
```

The binnumbers is encoded by the sorted dimensions but decoded by the unsorted dimensions, so the expanded binnumbers could be wrong if the input bins dimension is not in ascending order. In my example above, the input bin dimensions is `(6, 4)`, the current logic encode the binnumbers by `(4, 6)` and decode by `(6, 4)`. This pull request fix this problem by using the correct dimensions to decode the binnumbers, i.e. `(4, 6)` in the example, and then reorder the binnumbers to the input order, i.e. (x_binnums, y_binnums) instead of (y_binnums, x_binnums) in the example.