### PR TITLE
ENH: optimize: more complete callback signature

### DIFF
--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -135,7 +135,10 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
         For method-specific options, see :func:`show_options()`.
     callback : callable, optional
         Called after each iteration, as ``callback(xk)``, where ``xk`` is the
-        current parameter vector.
+        current parameter vector. Some of the solvers (namelly Nelder-Mead,
+        Powell, CG, BFGS, Newton-CG, dogleg, trust-ncg, trust-exact) allows
+        alternative signatures with additional parameters. Look into the
+        solver specific documentation for a complete description.
 
     Returns
     -------

--- a/scipy/optimize/_trustregion.py
+++ b/scipy/optimize/_trustregion.py
@@ -215,9 +215,13 @@ def _minimize_trust_region(fun, x0, args=(), jac=None, hess=None, hessp=None,
         # append the best guess, call back, increment the iteration count
         if return_all:
             allvecs.append(x)
-        if callback is not None:
-            callback(x)
         k += 1
+        if callback is not None:
+            try:
+                callback(x, m._f, nfun[0], m._g,
+                         njac[0], nhess[0], k)
+            except:
+                callback(x)
 
         # check if the gradient is small enough to stop
         if m.jac_mag < gtol:

--- a/scipy/optimize/_trustregion_dogleg.py
+++ b/scipy/optimize/_trustregion_dogleg.py
@@ -26,6 +26,19 @@ def _minimize_dogleg(fun, x0, args=(), jac=None, hess=None,
     gtol : float
         Gradient norm must be less than `gtol` before successful
         termination.
+    callback : callable
+        Callback function called after each iteration. Two different
+        signatures are allowed:
+
+            - ``callback(xk, fk, nfev, gk, njev, nhev, nit)``
+            - ``callback(xk)``
+
+        where ``xk`` is the current parameter vector, ``fk`` is the function
+        evaluated at ``xk``, ``nfev`` is the number of functions calls,
+        ``gk`` is the gradient evaluated at ``xk`` (or ``None`` if it has
+        not been computed for the current iteration), ``njev`` is the
+        number of gradient calls , ``nhev`` is the number of Hessian calls and
+        ``nit`` is the number of iterations.
 
     """
     if jac is None:

--- a/scipy/optimize/_trustregion_exact.py
+++ b/scipy/optimize/_trustregion_exact.py
@@ -30,6 +30,20 @@ def _minimize_trustregion_exact(fun, x0, args=(), jac=None, hess=None,
     gtol : float
         Gradient norm must be less than ``gtol`` before successful
         termination.
+    callback : callable
+        Callback function called after each iteration. Two different
+        signatures are allowed:
+
+            - ``callback(xk, fk, nfev, gk, njev, nhev, nit)``
+            - ``callback(xk)``
+
+        where ``xk`` is the current parameter vector, ``fk`` is the function
+        evaluated at ``xk``, ``nfev`` is the number of functions calls,
+        ``gk`` is the gradient evaluated at ``xk`` (or ``None`` if it has
+        not been computed for the current iteration), ``njev`` is the
+        number of gradient calls , ``nhev`` is the number of Hessian calls and
+        ``nit`` is the number of iterations.
+
     """
 
     if jac is None:

--- a/scipy/optimize/_trustregion_ncg.py
+++ b/scipy/optimize/_trustregion_ncg.py
@@ -28,6 +28,19 @@ def _minimize_trust_ncg(fun, x0, args=(), jac=None, hess=None, hessp=None,
     gtol : float
         Gradient norm must be less than `gtol` before successful
         termination.
+    callback : callable
+        Callback function called after each iteration. Two different
+        signatures are allowed:
+
+            - ``callback(xk, fk, nfev, gk, njev, nhev, nit)``
+            - ``callback(xk)``
+
+        where ``xk`` is the current parameter vector, ``fk`` is the function
+        evaluated at ``xk``, ``nfev`` is the number of functions calls,
+        ``gk`` is the gradient evaluated at ``xk`` (or ``None`` if it has
+        not been computed for the current iteration), ``njev`` is the
+        number of gradient calls , ``nhev`` is the number of Hessian calls and
+        ``nit`` is the number of iterations.
 
     """
     if jac is None:

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -433,6 +433,16 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
     fatol : number, optional
         Absolute error in func(xopt) between iterations that is acceptable for
         convergence.
+    callback : callable
+        Callback function called after each iteration. Two different
+        signatures are allowed:
+
+            - ``callback(xk, fk, nfev, nit)``
+            - ``callback(xk)``
+
+        where ``xk`` is the current parameter vector, ``fk`` is the function
+        evaluated at ``xk``, ``nfev`` is the number of functions calls and
+        ``nit`` is the number of iterations.
 
     """
     if 'ftol' in unknown_options:
@@ -579,10 +589,13 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
         sim = numpy.take(sim, ind, 0)
         fsim = numpy.take(fsim, ind, 0)
         if callback is not None:
-            callback(sim[0])
-        iterations += 1
+            try:
+                callback(sim[0], fsim[0], fcalls[0], iterations)
+            except:
+                callback(sim[0])
         if retall:
             allvecs.append(sim[0])
+        iterations += 1
 
     x = sim[0]
     fval = numpy.min(fsim)
@@ -893,6 +906,17 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, callback=None,
         Order of norm (Inf is max, -Inf is min).
     eps : float or ndarray
         If `jac` is approximated, use this value for the step size.
+    callback : callable
+        Callback function called after each iteration. Two different
+        signatures are allowed:
+
+            - ``callback(xk, fk, nfev, gk, njev, nit)``
+            - ``callback(xk)``
+
+        where ``xk`` is the current parameter vector, ``fk`` is the function
+        evaluated at ``xk``, ``fcalls`` is the number of functions calls,
+        ``gk`` is the gradient evaluated at ``xk``, ``njev`` is the number
+        of functions calls and ``nit`` is the number of iterations.
 
     """
     _check_unknown_options(unknown_options)
@@ -953,8 +977,6 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, callback=None,
 
         yk = gfkp1 - gfk
         gfk = gfkp1
-        if callback is not None:
-            callback(xk)
         gnorm = vecnorm(gfk, ord=norm)
         if (gnorm <= gtol):
             break
@@ -994,6 +1016,12 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, callback=None,
         Hk = syr(c, sk, a=Hk)
 
         k += 1
+
+        if callback is not None:
+            try:
+                callback(xk, old_fval, func_calls[0], gfk, grad_calls[0], k)
+            except:
+                callback(xk)
 
     # The matrix Hk is obtained from the
     # symmetric representation that were being
@@ -1236,6 +1264,17 @@ def _minimize_cg(fun, x0, args=(), jac=None, callback=None,
         Order of norm (Inf is max, -Inf is min).
     eps : float or ndarray
         If `jac` is approximated, use this value for the step size.
+    callback : callable
+        Callback function called after each iteration. Two different
+        signatures are allowed:
+
+            - ``callback(xk, fk, nfev, gk, njev, nit)``
+            - ``callback(xk)``
+
+        where ``xk`` is the current parameter vector, ``fk`` is the function
+        evaluated at ``xk``, ``nfev`` is the number of functions calls,
+        ``gk`` is the gradient evaluated at ``xk``, ``njev`` is the number
+        of gradien calls and ``nit`` is the number of iterations.
 
     """
     _check_unknown_options(unknown_options)
@@ -1287,9 +1326,13 @@ def _minimize_cg(fun, x0, args=(), jac=None, callback=None,
         pk = -gfkp1 + beta_k * pk
         gfk = gfkp1
         gnorm = vecnorm(gfk, ord=norm)
-        if callback is not None:
-            callback(xk)
         k += 1
+
+        if callback is not None:
+            try:
+                callback(xk, old_fval, func_calls[0], gfk, grad_calls[0], k)
+            except:
+                callback(xk)
 
     fval = old_fval
     if warnflag == 2:
@@ -1460,6 +1503,18 @@ def _minimize_newtoncg(fun, x0, args=(), jac=None, hess=None, hessp=None,
         Maximum number of iterations to perform.
     eps : float or ndarray
         If `jac` is approximated, use this value for the step size.
+    callback : callable
+        Callback function called after each iteration. Two different
+        signatures are allowed:
+
+            - ``callback(xk, fk, nfev, gk, njev, nhev, nit)``
+            - ``callback(xk)``
+
+        where ``xk`` is the current parameter vector, ``fk`` is the function
+        evaluated at ``xk``, ``nfev`` is the number of functions calls,
+        ``gk`` is the gradient evaluated at ``xk``, ``njev`` is the number
+        of gradient calls , ``nhev`` is the number of Hessian calls and
+        ``nit`` is the number of iterations.
 
     """
     _check_unknown_options(unknown_options)
@@ -1576,13 +1631,20 @@ def _minimize_newtoncg(fun, x0, args=(), jac=None, hess=None, hessp=None,
             msg = "Warning: " + _status_message['pr_loss']
             return terminate(2, msg)
 
+        k += 1
+        if callback is not None:
+            try:
+                callback(xk, old_old_fval, fcalls[0], gfk,
+                         gcalls[0], hcalls, k)
+            except:
+                callback(xk)
+
         update = alphak * pk
         xk = xk + update        # upcast if necessary
-        if callback is not None:
-            callback(xk)
         if retall:
             allvecs.append(xk)
-        k += 1
+
+
     else:
         msg = _status_message['success']
         return terminate(0, msg)
@@ -2416,6 +2478,16 @@ def _minimize_powell(func, x0, args=(), callback=None,
         first reached.
     direc : ndarray
         Initial set of direction vectors for the Powell method.
+    callback : callable
+        Callback function called after each iteration. Two different
+        signatures are allowed:
+
+            - ``callback(xk, fk, nfev, nit)``
+            - ``callback(xk)``
+
+        where ``xk`` is the current parameter vector, ``fk`` is the function
+        evaluated at ``xk``, ``nfev`` is the number of functions calls and
+        ``nit`` is the number of iterations.
 
     """
     _check_unknown_options(unknown_options)
@@ -2468,7 +2540,10 @@ def _minimize_powell(func, x0, args=(), callback=None,
                 bigind = i
         iter += 1
         if callback is not None:
-            callback(x)
+            try:
+                callback(x, fval, fcalls[0], iter)
+            except:
+                callback(x)
         if retall:
             allvecs.append(x)
         bnd = ftol * (numpy.abs(fx) + numpy.abs(fval)) + 1e-20


### PR DESCRIPTION
I have implemented a more complete signature to the callback function used in ``optimize``.
The default  signature  ``callback(xk)`` is still available for all solvers, but a more complete
list of parameters is also allowed:

- ``callback(xk, fk, nfev, nit)`` is the alternative signature for the methods ``Powell`` and ``Nelder-Mead``;
- ``callback(xk, fk, nfev, gk, njev, nit)``, for the methods ``CG`` and ``BFGS``;
- ``callback(xk, fk, nfev, gk, njev, nhev, nit)``, for the methods ``Newton-CG``, ``trust-ncg``, ``trust-exact`` and ``dogleg``.

The idea for this PR follows from the discussion with @mdhaber in Issue #7306 