### PR TITLE
BUG: Extend scipy.stats.arcsine.pdf to endpoints 0 and 1

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -272,15 +272,13 @@ class arcsine_gen(rv_continuous):
 
         arcsine.pdf(x) = 1/(pi*sqrt(x*(1-x)))
 
-    for ``0 < x < 1``.
+    for ``0 <= x <= 1``.
 
     %(after_notes)s
 
     %(example)s
 
     """
-    _support_mask = rv_continuous._open_support_mask
-
     def _pdf(self, x):
         return 1.0/np.pi/np.sqrt(x*(1-x))
 


### PR DESCRIPTION
Do not set the arcsine._support_mask to _open_support_mask.
THe arcsine distribution is theoretically the same as the
beta(0.5, 0.5) distribution,  but the arcsine code was restricting
itself to the interior points of the interval [0, 1] and the _pdf()
method was returning values different from
scipy.stats.beta(0.5, 0.5)._pdf().
By not setting arcsine._support_mask, the endpoints are no-longer
special-cased and the _pdf()s for the two distributions agree at the
endpoints.  See #7421.