### PR TITLE
BUG: Extend scipy.stats.arcsine.pdf to endpoints 0 and 1 #7427

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -272,15 +272,13 @@ class arcsine_gen(rv_continuous):
 
         arcsine.pdf(x) = 1/(pi*sqrt(x*(1-x)))
 
-    for ``0 < x < 1``.
+    for ``0 <= x <= 1``.
 
     %(after_notes)s
 
     %(example)s
 
     """
-    _support_mask = rv_continuous._open_support_mask
-
     def _pdf(self, x):
         return 1.0/np.pi/np.sqrt(x*(1-x))
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -135,7 +135,7 @@ def test_support():
         assert_almost_equal(dist.pdf(dist.b, *args), 0)
         assert_equal(dist.logpdf(dist.b, *args), -np.inf)
 
-    dists = ['alpha', 'arcsine', 'betaprime', 'burr', 'burr12',
+    dists = ['alpha', 'betaprime', 'burr', 'burr12',
              'fatiguelife', 'invgamma', 'invgauss', 'invweibull',
              'johnsonsb', 'levy', 'levy_l', 'lognorm', 'gilbrat',
              'powerlognorm', 'rayleigh', 'wald']


### PR DESCRIPTION
Do not set the arcsine._support_mask to _open_support_mask.
The arcsine distribution is theoretically the same as the
beta(0.5, 0.5) distribution,  but the arcsine code was restricting
itself to the interior points of the interval [0, 1] and the _pdf()
method was returning values different from
scipy.stats.beta(0.5, 0.5)._pdf().
By not setting arcsine._support_mask, the endpoints are no-longer
special-cased and the _pdf()s for the two distributions agree at the
endpoints.
Updated the testing so that arcsine is no longer tested in test_support().
See #7421.