### PR TITLE
Fix #7230: Allow sparse coo.toarray to handle nnz > 2**31

### DIFF
--- a/scipy/sparse/sparsetools/coo.h
+++ b/scipy/sparse/sparsetools/coo.h
@@ -82,7 +82,7 @@ void coo_tocsr(const I n_row,
  * Input Arguments:
  *   I  n_row           - number of rows in A
  *   I  n_col           - number of columns in A
- *   I  nnz             - number of nonzeros in A
+ *   npy_int64  nnz     - number of nonzeros in A
  *   I  Ai[nnz(A)]      - row indices
  *   I  Aj[nnz(A)]      - column indices
  *   T  Ax[nnz(A)]      - nonzeros 
@@ -92,7 +92,7 @@ void coo_tocsr(const I n_row,
 template <class I, class T>
 void coo_todense(const I n_row,
                  const I n_col,
-                 const I nnz,
+                 const npy_int64 nnz,
                  const I Ai[],
                  const I Aj[],
                  const T Ax[],
@@ -100,12 +100,12 @@ void coo_todense(const I n_row,
 		 int fortran)
 {
     if (!fortran) {
-        for(I n = 0; n < nnz; n++){
+        for(npy_int64 n = 0; n < nnz; n++){
             Bx[ (npy_intp)n_col * Ai[n] + Aj[n] ] += Ax[n];
         }
     }
     else {
-        for(I n = 0; n < nnz; n++){
+        for(npy_int64 n = 0; n < nnz; n++){
             Bx[ (npy_intp)n_row * Aj[n] + Ai[n] ] += Ax[n];
         }
     }
@@ -117,7 +117,7 @@ void coo_todense(const I n_row,
  *
  *
  * Input Arguments:
- *   I  nnz           - number of nonzeros in A
+ *   npy_int64  nnz   - number of nonzeros in A
  *   I  Ai[nnz]       - row indices
  *   I  Aj[nnz]       - column indices
  *   T  Ax[nnz]       - nonzero values
@@ -133,14 +133,14 @@ void coo_todense(const I n_row,
  * 
  */
 template <class I, class T>
-void coo_matvec(const I nnz,
+void coo_matvec(const npy_int64 nnz,
 	            const I Ai[], 
 	            const I Aj[], 
 	            const T Ax[],
 	            const T Xx[],
 	                  T Yx[])
 {
-    for(I n = 0; n < nnz; n++){
+    for(npy_int64 n = 0; n < nnz; n++){
         Yx[Ai[n]] += Ax[n] * Xx[Aj[n]];
     }
 }


### PR DESCRIPTION
Fixes #7230. Don't know if there is a pending PR for this.
This changes only the type of `nnz` from template `I` to `npy_int64`.

I don't have the memory to test it with other data types but at least the following test with `uint8` passes

~~~python
In [1]: import scipy
In [2]: X = scipy.sparse.csr_matrix(np.ones((2**16, 1),dtype=np.uint8))
In [3]: X
Out[3]: 
<65536x1 sparse matrix of type '<type 'numpy.uint8'>'
	with 65536 stored elements in Compressed Sparse Row format>

In [4]: (X*X[:2**15-1].T).toarray()
Out[4]: 
array([[1, 1, 1, ..., 1, 1, 1],
       [1, 1, 1, ..., 1, 1, 1],
       [1, 1, 1, ..., 1, 1, 1],
       ..., 
       [1, 1, 1, ..., 1, 1, 1],
       [1, 1, 1, ..., 1, 1, 1],
       [1, 1, 1, ..., 1, 1, 1]], dtype=uint8)

In [5]: (X*X[:2**15].T).toarray()
Out[5]: 
array([[1, 1, 1, ..., 1, 1, 1],
       [1, 1, 1, ..., 1, 1, 1],
       [1, 1, 1, ..., 1, 1, 1],
       ..., 
       [1, 1, 1, ..., 1, 1, 1],
       [1, 1, 1, ..., 1, 1, 1],
       [1, 1, 1, ..., 1, 1, 1]], dtype=uint8)
~~~
 
While running the same test with `uint8` on `0.19.0` I ran out of memory. Has anything changed since then? Is it gh-7081?  