### PR TITLE
FIX #7446 loadarff doesn't recognize milliseconds in DATE attribute

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -176,6 +176,7 @@ Roman Feldbauer for improvements in scipy.sparse
 Dominic Antonacci for statistics documentation.
 David Hagen for the object-oriented ODE solver interface.
 Arno Onken for contributions to scipy.stats.
+Oliver Steele for a bug fix in scipy.io.arff.
 
 Institutions
 ------------

--- a/scipy/io/arff/arffread.py
+++ b/scipy/io/arff/arffread.py
@@ -27,10 +27,6 @@ __all__ = ['MetaData', 'loadarff', 'ArffError', 'ParseArffError']
 #    is lost!
 #   - Replace ValueError by ParseError or something
 
-# We know can handle the following:
-#   - numeric and nominal attributes
-#   - missing values for numeric attributes
-
 r_meta = re.compile(r'^\s*@')
 # Match a comment
 r_comment = re.compile(r'^%')
@@ -177,6 +173,8 @@ def get_date_format(atrv):
     if m:
         pattern = m.group(1).strip()
         # convert time pattern from Java's SimpleDateFormat to C's format
+        # FIXME the Java spec appears to allow different numbers of repeating
+        # letters than just the ones hardcoded below
         datetime_unit = None
         if "yyyy" in pattern:
             pattern = pattern.replace("yyyy", "%Y")
@@ -199,6 +197,12 @@ def get_date_format(atrv):
         if "ss" in pattern:
             pattern = pattern.replace("ss", "%S")
             datetime_unit = "s"
+        if "SSS" in pattern:
+            pattern = pattern.replace("SSS", "%f")
+            datetime_unit = "s"
+        if "SS" in pattern:
+            pattern = pattern.replace("SS", "%f")
+            datetime_unit = "us"
         if "z" in pattern or "Z" in pattern:
             raise ValueError("Date type attributes with time zone not "
                              "supported, yet")
@@ -497,16 +501,13 @@ def loadarff(f):
     Notes
     -----
 
-    This function should be able to read most arff files. Not
-    implemented functionality include:
+    This function should be able to read most ARFF files. It does not handle
+    timezones in date attributes.
 
-    * date type attributes
-    * string type attributes
-
-    It can read files with numeric and nominal attributes.  It cannot read
-    files with sparse data ({} in the file).  However, this function can
-    read files with missing data (? in the file), representing the data
-    points as NaNs.
+    It can read files with numeric, nominal, string, and date attributes.
+    It cannot read files with sparse data ({} in the file).  However, this
+    function can read files with missing data (? in the file), representing
+    the data points as NaNs.
 
     Examples
     --------

--- a/scipy/io/arff/arffread.py
+++ b/scipy/io/arff/arffread.py
@@ -199,7 +199,7 @@ def get_date_format(atrv):
             datetime_unit = "s"
         if "SSS" in pattern:
             pattern = pattern.replace("SSS", "%f")
-            datetime_unit = "s"
+            datetime_unit = "us"
         if "SS" in pattern:
             pattern = pattern.replace("SS", "%f")
             datetime_unit = "us"

--- a/scipy/io/arff/tests/data/test9.arff
+++ b/scipy/io/arff/tests/data/test9.arff
@@ -1,8 +1,9 @@
 @RELATION test9
 
-@ATTRIBUTE attr_datetime_microsec	DATE "yyyy-MM-dd HH:mm:SS"
+@ATTRIBUTE attr_datetime_microsec2	DATE "yyyy-MM-dd HH:mm:SS"
+@ATTRIBUTE attr_datetime_microsec3	DATE "yyyy-MM-dd HH:mm:SSS"
 
 @DATA
-"1999-01-31 00:01:12"
-"2004-12-01 23:59:123"
-"1817-04-28 13:00:1234"
+"1999-01-31 00:01:12", "1999-01-31 00:01:12"
+"2004-12-01 23:59:123", "2004-12-01 23:59:123"
+"1817-04-28 13:00:1234", "1817-04-28 13:00:1234"

--- a/scipy/io/arff/tests/data/test9.arff
+++ b/scipy/io/arff/tests/data/test9.arff
@@ -1,0 +1,8 @@
+@RELATION test9
+
+@ATTRIBUTE attr_datetime_microsec	DATE "yyyy-MM-dd HH:mm:SS"
+
+@DATA
+"1999-01-31 00:01:12"
+"2004-12-01 23:59:123"
+"1817-04-28 13:00:1234"

--- a/scipy/io/arff/tests/test_arffread.py
+++ b/scipy/io/arff/tests/test_arffread.py
@@ -259,7 +259,8 @@ class DateAttributeTest(TestCase):
                               microsecond=123400),
         ])
 
-        assert_array_equal(data["attr_datetime_microsec"], expected)
+        assert_array_equal(data["attr_datetime_microsec2"], expected)
+        assert_array_equal(data["attr_datetime_microsec3"], expected)
 
 
 if __name__ == "__main__":

--- a/scipy/io/arff/tests/test_arffread.py
+++ b/scipy/io/arff/tests/test_arffread.py
@@ -31,6 +31,7 @@ test5 = pjoin(data_path, 'test5.arff')
 test6 = pjoin(data_path, 'test6.arff')
 test7 = pjoin(data_path, 'test7.arff')
 test8 = pjoin(data_path, 'test8.arff')
+test9 = pjoin(data_path, 'test9.arff')
 expect4_data = [(0.1, 0.2, 0.3, 0.4, 'class1'),
                 (-0.1, -0.2, -0.3, -0.4, 'class2'),
                 (1, 2, 3, 4, 'class3')]
@@ -242,7 +243,24 @@ class DateAttributeTest(TestCase):
         assert_array_equal(self.data["attr_datetime_missing"], expected)
 
     def test_datetime_timezone(self):
+        # This method reads a separate test file from the one in setUp
         assert_raises(ValueError, loadarff, test8)
+
+    def test_datetime_microsec(self):
+        # This method reads a separate test file from the one in setUp,
+        # and uses local variables instance of instance properties.
+        data, meta = loadarff(test9)
+        expected = np.array([
+            datetime.datetime(year=1999, month=1, day=31, hour=0, minute=1,
+                              microsecond=120000),
+            datetime.datetime(year=2004, month=12, day=1, hour=23, minute=59,
+                              microsecond=123000),
+            datetime.datetime(year=1817, month=4, day=28, hour=13, minute=0,
+                              microsecond=123400),
+        ])
+
+        assert_array_equal(data["attr_datetime_microsec"], expected)
+
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
* teach scipy.io.loadarff about milliseconds
* update loadarff docstring Notes to match implementation
* remove outdated comment (that is anyway redundant with docstring)