### PR TITLE
Bug: scipy.sparse.linalg.spsolve triangular: b with int dtype

### DIFF
--- a/scipy/sparse/linalg/dsolve/linsolve.py
+++ b/scipy/sparse/linalg/dsolve/linsolve.py
@@ -505,9 +505,8 @@ def spsolve_triangular(A, b, lower=True, overwrite_A=False, overwrite_b=False):
             x = b
         else:
             raise ValueError(
-                'b has dtype {} and A has dtype {}. Hence b can not store the '
-                'result. But overwrite_b is True. Please set overwrite_b to '
-                'False.'.format(b.dtype, A.data.dtype))
+                'Cannot overwrite b (dtype {}) with result '
+                'of type {}.'.format(b.dtype, x_dtype))
     else:
         x = b.astype(x_dtype, copy=True)
 
@@ -533,12 +532,11 @@ def spsolve_triangular(A, b, lower=True, overwrite_A=False, overwrite_b=False):
         # Check regularity and triangularity of A.
         if indptr_stop <= indptr_start or A.indices[A_diagonal_index_row_i] < i:
             raise LinAlgError(
-                'A is singular: '
-                '{}th diagonal is zero!'.format(i))
+                'A is singular: diagonal {} is zero.'.format(i))
         if A.indices[A_diagonal_index_row_i] > i:
             raise LinAlgError(
-                'A is no triangular matrix: entry '
-                '[{},{}] is not zero!'.format(i, A.indices[A_diagonal_index_row_i]))
+                'A is not triangular: A[{}, {}] is nonzero.'
+                ''.format(i, A.indices[A_diagonal_index_row_i]))
 
         # Incorporate off-diagonal entries.
         A_column_indices_in_row_i = A.indices[A_off_diagonal_indices_row_i]

--- a/scipy/sparse/linalg/dsolve/linsolve.py
+++ b/scipy/sparse/linalg/dsolve/linsolve.py
@@ -507,7 +507,7 @@ def spsolve_triangular(A, b, lower=True, overwrite_A=False, overwrite_b=False):
         x = b
     else:
         x_dtype = np.result_type(A.data, b, np.float)
-        x = b.astype(b_dtype, copy=True)
+        x = b.astype(x_dtype, copy=True)
 
     # Choose forward or backward order.
     if lower:

--- a/scipy/sparse/linalg/dsolve/linsolve.py
+++ b/scipy/sparse/linalg/dsolve/linsolve.py
@@ -505,10 +505,9 @@ def spsolve_triangular(A, b, lower=True, overwrite_A=False, overwrite_b=False):
             x = b
         else:
             raise ValueError(
-                'b has dtype {} '.format(b.dtype)
-                'and A has dtype {}. '.format(A.data.dtype)
-                'Hence b can not store the result. But overwrite_b is True. '
-                'Please set overwrite_b to False.')
+                'b has dtype {} and A has dtype {}. Hence b can not store the '
+                'result. But overwrite_b is True. Please set overwrite_b to '
+                'False.'.format(b.dtype, A.data.dtype))
     else:
         x = b.astype(x_dtype, copy=True)
 

--- a/scipy/sparse/linalg/dsolve/linsolve.py
+++ b/scipy/sparse/linalg/dsolve/linsolve.py
@@ -493,11 +493,14 @@ def spsolve_triangular(A, b, lower=True, overwrite_A=False, overwrite_b=False):
             'the size of the first dimension of b but the shape of A is '
             '{} and the shape of b is {}.'.format(A.shape, b.shape))
 
-    # Init x as copy of b.
+    # Init x as (a copy of) b.
     if overwrite_b:
+        if issubclass(b.dtype.type, np.integer):
+            warn('b has an integer data type and overwrite_b is true. '
+                 'This can lead to inaccurate results.')
         x = b
     else:
-        x = b.copy()
+        x = b.astype(np.float, copy=True)
 
     # Choose forward or backward order.
     if lower:

--- a/scipy/sparse/linalg/dsolve/linsolve.py
+++ b/scipy/sparse/linalg/dsolve/linsolve.py
@@ -442,6 +442,8 @@ def spsolve_triangular(A, b, lower=True, overwrite_A=False, overwrite_b=False):
     overwrite_b : bool, optional
         Allow overwriting data in `b`.
         Enabling gives a performance gain. Default is False.
+        If `overwrite_b` is True, it should be ensured that
+        `b` has not int as dtype.
 
     Returns
     -------
@@ -498,12 +500,14 @@ def spsolve_triangular(A, b, lower=True, overwrite_A=False, overwrite_b=False):
 
     # Init x as (a copy of) b.
     if overwrite_b:
-        if issubclass(b.dtype.type, np.integer):
-            warn('b has an integer data type and overwrite_b is true. '
-                 'This can lead to inaccurate results.')
+        if not np.issubdtype(b.dtype, np.inexact):
+            raise ValueError(
+                'b has an integer data type and overwrite_b is True.'
+                'Please set overwrite_b to False.')
         x = b
     else:
-        x = b.astype(np.float, copy=True)
+        x_dtype = np.result_type(A.data, b, np.float)
+        x = b.astype(b_dtype, copy=True)
 
     # Choose forward or backward order.
     if lower:

--- a/scipy/sparse/linalg/dsolve/linsolve.py
+++ b/scipy/sparse/linalg/dsolve/linsolve.py
@@ -443,7 +443,7 @@ def spsolve_triangular(A, b, lower=True, overwrite_A=False, overwrite_b=False):
         Allow overwriting data in `b`.
         Enabling gives a performance gain. Default is False.
         If `overwrite_b` is True, it should be ensured that
-        `b` has not int as dtype.
+        `b` has an appropriate dtype to be able to store the result.
 
     Returns
     -------
@@ -502,8 +502,14 @@ def spsolve_triangular(A, b, lower=True, overwrite_A=False, overwrite_b=False):
     if overwrite_b:
         if not np.issubdtype(b.dtype, np.inexact):
             raise ValueError(
-                'b has an integer data type and overwrite_b is True.'
-                'Please set overwrite_b to False.')
+                'b has an integer data type. '
+                'Hence b can not store the result. '
+                'But overwrite_b is True. Please set overwrite_b to False.')
+        if np.issubdtype(b.dtype, np.float) and np.issubdtype(A.dtype, np.complex):
+            raise ValueError(
+                'b has an float data type and A has an complex data type.'
+                'Hence b can not store the result. '
+                'But overwrite_b is True. Please set overwrite_b to False.')
         x = b
     else:
         x_dtype = np.result_type(A.data, b, np.float)

--- a/scipy/sparse/linalg/dsolve/linsolve.py
+++ b/scipy/sparse/linalg/dsolve/linsolve.py
@@ -479,7 +479,8 @@ def spsolve_triangular(A, b, lower=True, overwrite_A=False, overwrite_b=False):
         A = A.copy()
 
     if A.shape[0] != A.shape[1]:
-        raise ValueError('A must be a square matrix but its shape is {}.'.format(A.shape))
+        raise ValueError(
+            'A must be a square matrix but its shape is {}.'.format(A.shape))
 
     A.eliminate_zeros()
     A.sort_indices()
@@ -487,9 +488,11 @@ def spsolve_triangular(A, b, lower=True, overwrite_A=False, overwrite_b=False):
     b = np.asanyarray(b)
 
     if b.ndim not in [1, 2]:
-        raise ValueError('b must have 1 or 2 dims but its shape is {}.'.format(b.shape))
+        raise ValueError(
+            'b must have 1 or 2 dims but its shape is {}.'.format(b.shape))
     if A.shape[0] != b.shape[0]:
-        raise ValueError('The size of the dimensions of A must be equal to '
+        raise ValueError(
+            'The size of the dimensions of A must be equal to '
             'the size of the first dimension of b but the shape of A is '
             '{} and the shape of b is {}.'.format(A.shape, b.shape))
 
@@ -506,27 +509,29 @@ def spsolve_triangular(A, b, lower=True, overwrite_A=False, overwrite_b=False):
     if lower:
         row_indices = range(len(b))
     else:
-        row_indices = range(len(b)-1, -1, -1)
+        row_indices = range(len(b) - 1, -1, -1)
 
     # Fill x iteratively.
     for i in row_indices:
 
         # Get indices for i-th row.
         indptr_start = A.indptr[i]
-        indptr_stop = A.indptr[i+1]
+        indptr_stop = A.indptr[i + 1]
         if lower:
-            A_diagonal_index_row_i = indptr_stop-1
-            A_off_diagonal_indices_row_i = slice(indptr_start,indptr_stop-1)
+            A_diagonal_index_row_i = indptr_stop - 1
+            A_off_diagonal_indices_row_i = slice(indptr_start, indptr_stop - 1)
         else:
             A_diagonal_index_row_i = indptr_start
-            A_off_diagonal_indices_row_i = slice(indptr_start+1,indptr_stop)
+            A_off_diagonal_indices_row_i = slice(indptr_start + 1, indptr_stop)
 
         # Check regularity and triangularity of A.
         if indptr_stop <= indptr_start or A.indices[A_diagonal_index_row_i] < i:
-            raise LinAlgError('A is singular: '
+            raise LinAlgError(
+                'A is singular: '
                 '{}th diagonal is zero!'.format(i))
         if A.indices[A_diagonal_index_row_i] > i:
-            raise LinAlgError('A is no triangular matrix: entry '
+            raise LinAlgError(
+                'A is no triangular matrix: entry '
                 '[{},{}] is not zero!'.format(i, A.indices[A_diagonal_index_row_i]))
 
         # Incorporate off-diagonal entries.

--- a/scipy/sparse/linalg/dsolve/linsolve.py
+++ b/scipy/sparse/linalg/dsolve/linsolve.py
@@ -499,20 +499,17 @@ def spsolve_triangular(A, b, lower=True, overwrite_A=False, overwrite_b=False):
             '{} and the shape of b is {}.'.format(A.shape, b.shape))
 
     # Init x as (a copy of) b.
+    x_dtype = np.result_type(A.data, b, np.float)
     if overwrite_b:
-        if not np.issubdtype(b.dtype, np.inexact):
+        if np.can_cast(b.dtype, x_dtype, casting='same_kind'):
+            x = b
+        else:
             raise ValueError(
-                'b has an integer data type. '
-                'Hence b can not store the result. '
-                'But overwrite_b is True. Please set overwrite_b to False.')
-        if np.issubdtype(b.dtype, np.float) and np.issubdtype(A.dtype, np.complex):
-            raise ValueError(
-                'b has an float data type and A has an complex data type.'
-                'Hence b can not store the result. '
-                'But overwrite_b is True. Please set overwrite_b to False.')
-        x = b
+                'b has dtype {} '.format(b.dtype)
+                'and A has dtype {}. '.format(A.data.dtype)
+                'Hence b can not store the result. But overwrite_b is True. '
+                'Please set overwrite_b to False.')
     else:
-        x_dtype = np.result_type(A.data, b, np.float)
         x = b.astype(x_dtype, copy=True)
 
     # Choose forward or backward order.

--- a/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
@@ -551,13 +551,14 @@ class TestSpsolveTriangular(TestCase):
             return A
 
         np.random.seed(1234)
-        for n in (10, 10**2, 10**3):
-            for m in (1, 10):
-                b = np.random.rand(n, m)
-                for lower in (True, False):
-                    A = random_triangle_matrix(n, lower=lower)
-                    x = spsolve_triangular(A, b, lower=lower)
-                    assert_array_almost_equal(A.dot(x), b)
+        for lower in (True, False):
+            for n in (10, 10**2, 10**3):
+                A = random_triangle_matrix(n, lower=lower)
+                for m in (1, 10):
+                    for b in (np.random.rand(n, m),
+                              np.random.randint(-9, 9, (n, m))):
+                        x = spsolve_triangular(A, b, lower=lower)
+                        assert_array_almost_equal(A.dot(x), b)
 
 
 if __name__ == "__main__":

--- a/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
@@ -516,7 +516,7 @@ class TestSpsolveTriangular(TestCase):
 
     def test_singular(self):
         n = 5
-        A = csr_matrix((n,n))
+        A = csr_matrix((n, n))
         b = np.arange(n)
         for lower in (True, False):
             assert_raises(scipy.linalg.LinAlgError, spsolve_triangular, A, b, lower=lower)
@@ -547,7 +547,7 @@ class TestSpsolveTriangular(TestCase):
                 A = scipy.sparse.triu(A)
             A = A.tocsr(copy=False)
             for i in range(n):
-                A[i,i] = np.random.rand() + 1
+                A[i, i] = np.random.rand() + 1
             return A
 
         np.random.seed(1234)

--- a/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
@@ -556,7 +556,9 @@ class TestSpsolveTriangular(TestCase):
                 A = random_triangle_matrix(n, lower=lower)
                 for m in (1, 10):
                     for b in (np.random.rand(n, m),
-                              np.random.randint(-9, 9, (n, m))):
+                              np.random.randint(-9, 9, (n, m)),
+                              np.random.randint(-9, 9, (n, m)) +
+                              np.random.randint(-9, 9, (n, m)) * 1j):
                         x = spsolve_triangular(A, b, lower=lower)
                         assert_array_almost_equal(A.dot(x), b)
 


### PR DESCRIPTION
`scipy.sparse.linalg.spsolve triangular` is very inaccurate if `b` is of dtype `int`.

The problem is that in this case an array of dtype `int` is used as solution vector. I change this to an array of dtype `float`. If `b` is of dtype `int` and `overwrite_b` is `True` instead a warning is issued.

(I also removed some PEP8 problems.)