### PR TITLE
Add solar mass to constants

### DIFF
--- a/scipy/constants/__init__.py
+++ b/scipy/constants/__init__.py
@@ -146,6 +146,8 @@ Weight
 ``m_u``            atomic mass constant (in kg)
 ``u``              atomic mass constant (in kg)
 ``atomic_mass``    atomic mass constant (in kg)
+``M_sun``          solar mass (in kg)
+``solar_mass``     solar mass (in kg)
 =================  ============================================================
 
 Angle

--- a/scipy/constants/constants.py
+++ b/scipy/constants/constants.py
@@ -92,6 +92,8 @@ m_p = proton_mass = _cd('proton mass')
 m_n = neutron_mass = _cd('neutron mass')
 m_u = u = atomic_mass = _cd('atomic mass constant')
 
+M_sun = 1.98855e30
+
 # angle in rad
 degree = pi / 180
 arcmin = arcminute = degree / 60

--- a/scipy/constants/constants.py
+++ b/scipy/constants/constants.py
@@ -92,7 +92,7 @@ m_p = proton_mass = _cd('proton mass')
 m_n = neutron_mass = _cd('neutron mass')
 m_u = u = atomic_mass = _cd('atomic mass constant')
 
-M_sun = 1.98855e30
+M_sun = solar_mass = 1.98855e30
 
 # angle in rad
 degree = pi / 180


### PR DESCRIPTION
The solar mass is often used as an unit of mass in Astronomy therefore it might be helpful to add it to the `constants` module. 
The value is taken from Wikipedia.