### PR TITLE
Doc: Added tutorial documentation for stats distributions ksone and kstwobign

### DIFF
--- a/doc/source/tutorial/stats/continuous_ksone.rst
+++ b/doc/source/tutorial/stats/continuous_ksone.rst
@@ -4,4 +4,29 @@
 KSone Distribution
 ==================
 
+
+This is the distribution of maximum positive "gaps", when comparing a theoretical distribution with an empirical one.
+Writing :math:`D_n^+ = \sup_t [F_{theoretical}(t)-S_n(t)]`,  KSOne is the distribution of the :math:`D_n^+` values.
+
+One shape parameter
+
+.. math::
+   n, \textrm{a positive integer}
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} F\left(n, x\right) & = & 1 - \sum_{j=0}^{\lfloor n(1-x)\rfloor} \dbinom{n}{v} x (x+\frac{j}{n})^{j-1} (1-x-\frac{j}{n})^{n-j}\\ & = & 1 - \textrm{scipy.special.smirnov}(n, x) \\\lim_{n \rightarrow\infty} F\left(n, \frac{x}{\sqrt n}\right) & = & e^{-2 x^2} \end{eqnarray*}
+
+
+References
+----------
+
+-  "Kolmogorov-Smirnov test", Wikipedia
+   https://en.wikipedia.org/wiki/Kolmogorov-Smirnov_test
+
+-  Birnbaum, Z. W. and Fred H. Tingey (1951), One-sided confidence contours for probability distribution functions. *The Annals of Mathematical Statistics*, **22**/4, 592-596.
+
+
+
 Implementation: `scipy.stats.ksone`

--- a/doc/source/tutorial/stats/continuous_kstwobign.rst
+++ b/doc/source/tutorial/stats/continuous_kstwobign.rst
@@ -4,4 +4,24 @@
 KStwo Distribution
 ==================
 
+This is the distribution of maximum absolute gaps, when comparing
+two observations with m and n samples respectively, when m and n are "big".
+
+Writing :math:`D_{m,n} = \sup_t (F_{1,m}(t)-F_{2,n}(t))`,  where
+:math:`F_{1,m}` and :math:`F_{2,n}` are the empirical distribution functions, then
+KStwo is the distribution of the :math:`\sqrt\frac{mn}{m+n}D_{m,n}` values.
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*}  F\left(x\right) & = & 1 - 2 \sum_{k=1}^{\infty} (-1)^{k-1} e^{-2k^2 x^2}\\  & = & \frac{\sqrt{2\pi}}{x} \sum_{k=1}^{\infty} e^{-2(k-1)^2 \pi^2/(8x^2)}\\  & = & 1 - \textrm{scipy.special.kolmogorov}(n, x) \\ f\left(x\right) & = & 8x \sum_{k=1}^{\infty} (-1)^{k-1} k^2 e^{-2k^2 x^2} \end{eqnarray*}
+
+
+References
+----------
+
+-  "Kolmogorov-Smirnov test", Wikipedia
+   https://en.wikipedia.org/wiki/Kolmogorov-Smirnov_test
+
+
 Implementation: `scipy.stats.kstwobign`


### PR DESCRIPTION
The stats tutorial pages in the doc for these two distributions existed but were empty.  This adds a body for each of them.