### PR TITLE
Doc: Added tutorial documentation for stats distributions ksone and kstwobign

### DIFF
--- a/doc/source/tutorial/stats/continuous_ksone.rst
+++ b/doc/source/tutorial/stats/continuous_ksone.rst
@@ -4,4 +4,39 @@
 KSone Distribution
 ==================
 
+
+This is the distribution of maximum positive differences between an
+empirical distribution function, computed from n samples or observations,
+and a comparison (or target) cumulative distribution function.
+
+Writing :math:`D_n^+ = \sup_t \left(F_{target}(t)-F_{empirical,n}(t)\right)`,
+KSone is the distribution of the :math:`D_n^+` values.
+(The distribution of :math:`D_n^- = -\inf_t \left(F_{target}(t)-F_{empirical,n}(t)\right)`
+ differences follows the same distribution, so ksone can be used for one-sided tests on either side.)
+
+
+One shape parameter
+
+.. math::
+   n, \textrm{a positive integer}
+
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} F\left(n, x\right) & = & 1 - \sum_{j=0}^{\lfloor n(1-x)\rfloor} \dbinom{n}{j} x (x+\frac{j}{n})^{j-1} (1-x-\frac{j}{n})^{n-j}\\ & = & 1 - \textrm{scipy.special.smirnov}(n, x) \\ \lim_{n \rightarrow\infty} F\left(n, \frac{x}{\sqrt n}\right) & = & e^{-2 x^2} \end{eqnarray*}
+
+
+:math:`x\in\left[0,1\right]`
+
+References
+----------
+
+-  "Kolmogorov-Smirnov test", Wikipedia
+   https://en.wikipedia.org/wiki/Kolmogorov-Smirnov_test
+
+-  Birnbaum, Z. W. and Fred H. Tingey (1951), One-sided confidence contours for probability distribution functions. *The Annals of Mathematical Statistics*, **22**/4, 592-596.
+
+
+
 Implementation: `scipy.stats.ksone`

--- a/doc/source/tutorial/stats/continuous_ksone.rst
+++ b/doc/source/tutorial/stats/continuous_ksone.rst
@@ -6,28 +6,22 @@ KSone Distribution
 
 
 This is the distribution of maximum positive differences between an
-empirical distribution function, computed from n samples or observations,
+empirical distribution function, computed from :math:`n` samples or observations,
 and a comparison (or target) cumulative distribution function.
 
-Writing :math:`D_n^+ = \sup_t \left(F_{target}(t)-F_{empirical,n}(t)\right)`,
-KSone is the distribution of the :math:`D_n^+` values.
-(The distribution of :math:`D_n^- = -\inf_t \left(F_{target}(t)-F_{empirical,n}(t)\right)`
- differences follows the same distribution, so ksone can be used for one-sided tests on either side.)
+Writing :math:`D_n^+ = \sup_t \left(F_{empirical,n}(t)-F_{target}(t)\right)`,
+``ksone`` is the distribution of the :math:`D_n^+` values.
+(The distribution of :math:`D_n^- = \sup_t \left(F_{target}(t)-F_{empirical,n}(t)\right)`
+differences follows the same distribution, so ``ksone`` can be used for one-sided tests on either side.)
 
 
-One shape parameter
-
-.. math::
-   n, \textrm{a positive integer}
-
+There is one shape parameter :math:`n`, a positive integer, and the support is :math:`x\in\left[0,1\right]`.
 
 .. math::
    :nowrap:
 
-    \begin{eqnarray*} F\left(n, x\right) & = & 1 - \sum_{j=0}^{\lfloor n(1-x)\rfloor} \dbinom{n}{j} x (x+\frac{j}{n})^{j-1} (1-x-\frac{j}{n})^{n-j}\\ & = & 1 - \textrm{scipy.special.smirnov}(n, x) \\ \lim_{n \rightarrow\infty} F\left(n, \frac{x}{\sqrt n}\right) & = & e^{-2 x^2} \end{eqnarray*}
+    \begin{eqnarray*} F\left(n, x\right) & = & 1 - \sum_{j=0}^{\lfloor n(1-x)\rfloor} \dbinom{n}{j} x \left(x+\frac{j}{n}\right)^{j-1} \left(1-x-\frac{j}{n}\right)^{n-j}\\ & = & 1 - \textrm{scipy.special.smirnov}(n, x) \\ \lim_{n \rightarrow\infty} F\left(n, \frac{x}{\sqrt n}\right) & = & e^{-2 x^2} \end{eqnarray*}
 
-
-:math:`x\in\left[0,1\right]`
 
 References
 ----------
@@ -35,8 +29,8 @@ References
 -  "Kolmogorov-Smirnov test", Wikipedia
    https://en.wikipedia.org/wiki/Kolmogorov-Smirnov_test
 
--  Birnbaum, Z. W. and Fred H. Tingey (1951), One-sided confidence contours for probability distribution functions. *The Annals of Mathematical Statistics*, **22**/4, 592-596.
-
+-  Birnbaum, Z. W.; Tingey, Fred H. "One-Sided Confidence Contours for Probability Distribution Functions."
+   *Ann. Math. Statist*. 22 (1951), no. 4, 592--596.
 
 
 Implementation: `scipy.stats.ksone`

--- a/doc/source/tutorial/stats/continuous_kstwobign.rst
+++ b/doc/source/tutorial/stats/continuous_kstwobign.rst
@@ -4,22 +4,32 @@
 KStwo Distribution
 ==================
 
-This is the distribution of maximum absolute differences
-between two empirical distribution functions for sets of
-observations with m and n samples respectively, when m and n are "big".
+This is the limiting distribution of the normalized maximum absolute differences between an
+empirical distribution function, computed from n samples or observations,
+and a comparison (or target) cumulative distribution function.  (KSone is the distribution
+of the unnormalized positive differences, :math:`D_n^+)`.)
 
+Writing :math:`D_n = \sup_t \left|F_{target}(t)-F_{empirical,n}(t)\right|`,
+the normalization factor is :math:`\sqrt{n}`, and KStwo is the limiting distribution
+of the :math:`\sqrt{n} D_n` values as :math:`n\rightarrow\infty`.
+
+Note that :math:`D_n=max(D_n^+, D_n^-)`, but :math:`D_n^+` and :math:`D_n^-` are not independent.
+
+KStwo can also be used with the differences between two empirical distribution functions,
+for sets of observations with m and n samples respectively, when m and n are "big".
 Writing :math:`D_{m,n} = \sup_t \left|F_{1,m}(t)-F_{2,n}(t)\right|`,  where
 :math:`F_{1,m}` and :math:`F_{2,n}` are the two empirical distribution functions, then
-KStwo is the limiting distribution of the :math:`\sqrt{\left(\frac{mn}{m+n}\right)D_{m,n}}` values,
+KStwo is also the limiting distribution of the :math:`\sqrt{\left(\frac{mn}{m+n}\right)D_{m,n}}` values,
 as :math:`m,n\rightarrow\infty`.
 
+
 .. math::
-   :nowrap:
+    :nowrap:
 
     \begin{eqnarray*}  F\left(x\right) & = & 1 - 2 \sum_{k=1}^{\infty} (-1)^{k-1} e^{-2k^2 x^2}\\  & = & \frac{\sqrt{2\pi}}{x} \sum_{k=1}^{\infty} e^{-(2k-1)^2 \pi^2/(8x^2)}\\  & = & 1 - \textrm{scipy.special.kolmogorov}(n, x) \\ f\left(x\right) & = & 8x \sum_{k=1}^{\infty} (-1)^{k-1} k^2 e^{-2k^2 x^2} \end{eqnarray*}
 
 
-:math:`x\in\left[0,1\right]`
+:math:`x\in\left[0,\infty\right)`
 
 References
 ----------

--- a/doc/source/tutorial/stats/continuous_kstwobign.rst
+++ b/doc/source/tutorial/stats/continuous_kstwobign.rst
@@ -7,13 +7,13 @@ KStwo Distribution
 This is the limiting distribution of the normalized maximum absolute differences between an
 empirical distribution function, computed from n samples or observations,
 and a comparison (or target) cumulative distribution function.  (KSone is the distribution
-of the unnormalized positive differences, :math:`D_n^+)`.)
+of the unnormalized positive differences, :math:`D_n^+`.)
 
 Writing :math:`D_n = \sup_t \left|F_{target}(t)-F_{empirical,n}(t)\right|`,
 the normalization factor is :math:`\sqrt{n}`, and KStwo is the limiting distribution
 of the :math:`\sqrt{n} D_n` values as :math:`n\rightarrow\infty`.
 
-Note that :math:`D_n=max(D_n^+, D_n^-)`, but :math:`D_n^+` and :math:`D_n^-` are not independent.
+Note that :math:`D_n=\max(D_n^+, D_n^-)`, but :math:`D_n^+` and :math:`D_n^-` are not independent.
 
 KStwo can also be used with the differences between two empirical distribution functions,
 for sets of observations with m and n samples respectively, when m and n are "big".

--- a/doc/source/tutorial/stats/continuous_kstwobign.rst
+++ b/doc/source/tutorial/stats/continuous_kstwobign.rst
@@ -5,22 +5,25 @@ KStwo Distribution
 ==================
 
 This is the limiting distribution of the normalized maximum absolute differences between an
-empirical distribution function, computed from n samples or observations,
-and a comparison (or target) cumulative distribution function.  (KSone is the distribution
+empirical distribution function, computed from :math:`n` samples or observations,
+and a comparison (or target) cumulative distribution function.  (``ksone`` is the distribution
 of the unnormalized positive differences, :math:`D_n^+`.)
 
-Writing :math:`D_n = \sup_t \left|F_{target}(t)-F_{empirical,n}(t)\right|`,
-the normalization factor is :math:`\sqrt{n}`, and KStwo is the limiting distribution
+Writing :math:`D_n = \sup_t \left|F_{empirical,n}(t) - F_{target}(t)-\right|`,
+the normalization factor is :math:`\sqrt{n}`, and ``kstwobign`` is the limiting distribution
 of the :math:`\sqrt{n} D_n` values as :math:`n\rightarrow\infty`.
 
 Note that :math:`D_n=\max(D_n^+, D_n^-)`, but :math:`D_n^+` and :math:`D_n^-` are not independent.
 
-KStwo can also be used with the differences between two empirical distribution functions,
-for sets of observations with m and n samples respectively, when m and n are "big".
+``kstwobign`` can also be used with the differences between two empirical distribution functions,
+for sets of observations with :math:`m` and :math:`n` samples respectively,
+where :math:`m` and :math:`n` are "big".
 Writing :math:`D_{m,n} = \sup_t \left|F_{1,m}(t)-F_{2,n}(t)\right|`,  where
 :math:`F_{1,m}` and :math:`F_{2,n}` are the two empirical distribution functions, then
-KStwo is also the limiting distribution of the :math:`\sqrt{\left(\frac{mn}{m+n}\right)D_{m,n}}` values,
+``kstwobign`` is also the limiting distribution of the :math:`\sqrt{\left(\frac{mn}{m+n}\right)D_{m,n}}` values,
 as :math:`m,n\rightarrow\infty`.
+
+There are no shape parameters, and the support is :math:`x\in\left[0,\infty\right)`.
 
 
 .. math::
@@ -29,13 +32,17 @@ as :math:`m,n\rightarrow\infty`.
     \begin{eqnarray*}  F\left(x\right) & = & 1 - 2 \sum_{k=1}^{\infty} (-1)^{k-1} e^{-2k^2 x^2}\\  & = & \frac{\sqrt{2\pi}}{x} \sum_{k=1}^{\infty} e^{-(2k-1)^2 \pi^2/(8x^2)}\\  & = & 1 - \textrm{scipy.special.kolmogorov}(n, x) \\ f\left(x\right) & = & 8x \sum_{k=1}^{\infty} (-1)^{k-1} k^2 e^{-2k^2 x^2} \end{eqnarray*}
 
 
-:math:`x\in\left[0,\infty\right)`
-
 References
 ----------
 
 -  "Kolmogorov-Smirnov test", Wikipedia
    https://en.wikipedia.org/wiki/Kolmogorov-Smirnov_test
+
+-  Kolmogoroff, A. "Confidence Limits for an Unknown Distribution Function.""
+   *Ann. Math. Statist.* 12 (1941), no. 4, 461--463.
+
+-  Feller, W. "On the Kolmogorov-Smirnov Limit Theorems for Empirical Distributions."
+   *Ann. Math. Statist.* 19 (1948), no. 2, 177--189. and "Errata"  *Ann. Math. Statist.* 21 (1950), no. 2, 301--302.
 
 
 Implementation: `scipy.stats.kstwobign`

--- a/doc/source/tutorial/stats/continuous_kstwobign.rst
+++ b/doc/source/tutorial/stats/continuous_kstwobign.rst
@@ -4,4 +4,28 @@
 KStwo Distribution
 ==================
 
+This is the distribution of maximum absolute differences
+between two empirical distribution functions for sets of
+observations with m and n samples respectively, when m and n are "big".
+
+Writing :math:`D_{m,n} = \sup_t \left|F_{1,m}(t)-F_{2,n}(t)\right|`,  where
+:math:`F_{1,m}` and :math:`F_{2,n}` are the two empirical distribution functions, then
+KStwo is the limiting distribution of the :math:`\sqrt{\left(\frac{mn}{m+n}\right)D_{m,n}}` values,
+as :math:`m,n\rightarrow\infty`.
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*}  F\left(x\right) & = & 1 - 2 \sum_{k=1}^{\infty} (-1)^{k-1} e^{-2k^2 x^2}\\  & = & \frac{\sqrt{2\pi}}{x} \sum_{k=1}^{\infty} e^{-(2k-1)^2 \pi^2/(8x^2)}\\  & = & 1 - \textrm{scipy.special.kolmogorov}(n, x) \\ f\left(x\right) & = & 8x \sum_{k=1}^{\infty} (-1)^{k-1} k^2 e^{-2k^2 x^2} \end{eqnarray*}
+
+
+:math:`x\in\left[0,1\right]`
+
+References
+----------
+
+-  "Kolmogorov-Smirnov test", Wikipedia
+   https://en.wikipedia.org/wiki/Kolmogorov-Smirnov_test
+
+
 Implementation: `scipy.stats.kstwobign`


### PR DESCRIPTION
The stats tutorial pages in the doc for these two KS distributions existed but were empty. This adds a body for each of them.