### PR TITLE
Fix some ndimage.interpolation endianness bugs

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -176,7 +176,7 @@ Roman Feldbauer for improvements in scipy.sparse
 Dominic Antonacci for statistics documentation.
 David Hagen for the object-oriented ODE solver interface.
 Arno Onken for contributions to scipy.stats.
-Cathy Douglass for a bug fix in ndimage.
+Cathy Douglass for bug fixes in ndimage.
 
 Institutions
 ------------

--- a/THANKS.txt
+++ b/THANKS.txt
@@ -176,6 +176,7 @@ Roman Feldbauer for improvements in scipy.sparse
 Dominic Antonacci for statistics documentation.
 David Hagen for the object-oriented ODE solver interface.
 Arno Onken for contributions to scipy.stats.
+Cathy Douglass for a bug fix in ndimage.
 
 Institutions
 ------------

--- a/scipy/ndimage/interpolation.py
+++ b/scipy/ndimage/interpolation.py
@@ -56,7 +56,9 @@ def _fix_endianness(f):
     def wrapper(*args, **kwargs):
         output = kwargs.get("output")
         result = f(*args, **kwargs)
-        if isinstance(output, numpy.ndarray) and not output.dtype.isnative:
+        if isinstance(output, numpy.dtype) and not output.isnative:
+            result.byteswap(True)
+        elif isinstance(output, numpy.ndarray) and not output.dtype.isnative:
             output.byteswap(True)
         return result
 

--- a/scipy/ndimage/interpolation.py
+++ b/scipy/ndimage/interpolation.py
@@ -34,6 +34,7 @@ import math
 import numpy
 from . import _ni_support
 from . import _nd_image
+from functools import wraps
 
 import warnings
 
@@ -44,6 +45,22 @@ __all__ = ['spline_filter1d', 'spline_filter', 'geometric_transform',
 def _extend_mode_to_code(mode):
     mode = _ni_support._extend_mode_to_code(mode)
     return mode
+
+
+def _fix_endianness(f):
+    """
+    Decorator to work around endianness issues in _nd_image.geometric_transform
+    and _nd_image.zoom_shift
+    """
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        output = kwargs.get("output")
+        result = f(*args, **kwargs)
+        if isinstance(output, numpy.ndarray) and not output.dtype.isnative:
+            output.byteswap(True)
+        return result
+
+    return wrapper
 
 
 def spline_filter1d(input, order=3, axis=-1, output=numpy.float64):
@@ -121,22 +138,7 @@ def spline_filter(input, order=3, output=numpy.float64):
     return return_value
 
 
-def _geometric_transform(input, mapping, coordinates, matrix, offset, output,
-                         order, mode, cval, extra_arguments, extra_keywords):
-    """
-    Wrapper around _nd_image.geometric_transform to work around
-    endianness issues
-    """
-    _nd_image.geometric_transform(
-        input, mapping, coordinates, matrix, offset, output,
-        order, mode, cval, extra_arguments, extra_keywords)
-
-    if output is not None and not output.dtype.isnative:
-        output.byteswap(True)
-
-    return output
-
-
+@_fix_endianness
 def geometric_transform(input, mapping, output_shape=None,
                         output=None, order=3,
                         mode='constant', cval=0.0, prefilter=True,
@@ -254,11 +256,13 @@ def geometric_transform(input, mapping, output_shape=None,
         filtered = input
     output, return_value = _ni_support._get_output(output, input,
                                                    shape=output_shape)
-    _geometric_transform(filtered, mapping, None, None, None, output,
-                         order, mode, cval, extra_arguments, extra_keywords)
+    _nd_image.geometric_transform(filtered, mapping, None, None, None, output,
+                                  order, mode, cval, extra_arguments,
+                                  extra_keywords)
     return return_value
 
 
+@_fix_endianness
 def map_coordinates(input, coordinates, output=None, order=3,
                     mode='constant', cval=0.0, prefilter=True):
     """
@@ -353,11 +357,12 @@ def map_coordinates(input, coordinates, output=None, order=3,
         filtered = input
     output, return_value = _ni_support._get_output(output, input,
                                                    shape=output_shape)
-    _geometric_transform(filtered, None, coordinates, None, None,
-                         output, order, mode, cval, None, None)
+    _nd_image.geometric_transform(filtered, None, coordinates, None, None,
+                                  output, order, mode, cval, None, None)
     return return_value
 
 
+@_fix_endianness
 def affine_transform(input, matrix, offset=0.0, output_shape=None,
                      output=None, order=3,
                      mode='constant', cval=0.0, prefilter=True):
@@ -496,8 +501,8 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None,
         _nd_image.zoom_shift(filtered, matrix, offset/matrix, output, order,
                              mode, cval)
     else:
-        _geometric_transform(filtered, None, None, matrix, offset,
-                             output, order, mode, cval, None, None)
+        _nd_image.geometric_transform(filtered, None, None, matrix, offset,
+                                      output, order, mode, cval, None, None)
     return return_value
 
 

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -2065,6 +2065,17 @@ class TestNdimage:
         numpy.testing.assert_raises(ValueError,
                                     ndimage.affine_transform, data, tform_h2)
 
+    def test_affine_transform28(self):
+        # 1d affine transform given output ndarray with non-native endianness
+        # See issue #7388
+        data = numpy.ones((2, 2))
+        for out in [numpy.empty_like(data),
+                    numpy.empty_like(data).astype(data.dtype.newbyteorder())]:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", UserWarning)
+                ndimage.affine_transform(data, [1, 1], output=out)
+            assert_array_almost_equal(out, [[1, 1], [1, 1]])
+
     def test_shift01(self):
         data = numpy.array([1])
         for order in range(0, 6):

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -1422,24 +1422,6 @@ class TestNdimage:
                                                         order=order)
             assert_array_almost_equal(out, [1])
 
-    def test_geometric_transform01_with_output_parameter(self):
-        data = numpy.array([1])
-
-        def mapping(x):
-            return x
-        for order in range(0, 6):
-            out = numpy.empty_like(data)
-            ndimage.geometric_transform(data, mapping,
-                                        data.shape,
-                                        output=out)
-            assert_array_almost_equal(out, [1])
-
-            out = numpy.empty_like(data).astype(data.dtype.newbyteorder())
-            ndimage.geometric_transform(data, mapping,
-                                        data.shape,
-                                        output=out)
-            assert_array_almost_equal(out, [1])
-
     def test_geometric_transform02(self):
         data = numpy.ones([4])
 
@@ -1690,6 +1672,23 @@ class TestNdimage:
                                 extra_keywords={'b': 2})
             assert_array_almost_equal(out, [5, 7])
 
+    def test_geometric_transform_endianness_with_output_parameter(self):
+        # geometric transform given output ndarray or dtype with non-native endianness
+        # see issue #4127
+        data = numpy.array([1])
+
+        def mapping(x):
+            return x
+
+        for out in [data.dtype, data.dtype.newbyteorder(),
+                    numpy.empty_like(data),
+                    numpy.empty_like(data).astype(data.dtype.newbyteorder())]:
+            returned = ndimage.geometric_transform(data, mapping,
+                                        data.shape,
+                                        output=out)
+            result = out if returned is None else returned
+            assert_array_almost_equal(result, [1])
+
     def test_map_coordinates01(self):
         data = numpy.array([[4, 1, 3, 2],
                                [7, 6, 8, 5],
@@ -1701,25 +1700,6 @@ class TestNdimage:
             assert_array_almost_equal(out, [[0, 0, 0, 0],
                                        [0, 4, 1, 3],
                                        [0, 7, 6, 8]])
-
-    def test_map_coordinates01_with_output_parameter(self):
-        data = numpy.array([[4, 1, 3, 2],
-                            [7, 6, 8, 5],
-                            [3, 5, 3, 6]])
-        idx = numpy.indices(data.shape)
-        idx -= 1
-        expected = numpy.array([[0, 0, 0, 0],
-                                [0, 4, 1, 3],
-                                [0, 7, 6, 8]])
-        for order in range(0, 6):
-            out = numpy.empty_like(expected)
-            ndimage.map_coordinates(data, idx, order=order, output=out)
-            assert_array_almost_equal(out, expected)
-
-            out = numpy.empty_like(expected).astype(
-                expected.dtype.newbyteorder())
-            ndimage.map_coordinates(data, idx, order=order, output=out)
-            assert_array_almost_equal(out, expected)
 
     def test_map_coordinates02(self):
         data = numpy.array([[4, 1, 3, 2],
@@ -1753,6 +1733,19 @@ class TestNdimage:
         assert_array_almost_equal(out, [[0, 0], [0, 4], [0, 7]])
         assert_array_almost_equal(out, ndimage.shift(data[:,::2], (1, 1)))
 
+    def test_map_coordinates_endianness_with_output_parameter(self):
+        # output parameter given as array or dtype with either endianness
+        # see issue #4127
+        data = numpy.array([[1, 2], [7, 6]])
+        expected = numpy.array([[0, 0], [0, 1]])
+        idx = numpy.indices(data.shape)
+        idx -= 1
+        for out in [data.dtype, data.dtype.newbyteorder(), numpy.empty_like(expected),
+                    numpy.empty_like(expected).astype(expected.dtype.newbyteorder())]:
+            returned = ndimage.map_coordinates(data, idx, output=out)
+            result = out if returned is None else returned
+            assert_array_almost_equal(result, expected)
+
     # do not run on 32 bit or windows (no sparse memory)
     @dec.skipif('win32' in sys.platform or numpy.intp(0).itemsize < 8)
     def test_map_coordinates_large_data(self):
@@ -1771,21 +1764,6 @@ class TestNdimage:
         for order in range(0, 6):
             out = ndimage.affine_transform(data, [[1]],
                                                      order=order)
-            assert_array_almost_equal(out, [1])
-
-    def test_affine_transform01_with_output_parameter(self):
-        data = numpy.array([1])
-        for order in range(0, 6):
-            out = numpy.empty_like(data)
-            ndimage.affine_transform(data, [[1]],
-                                     order=order,
-                                     output=out)
-            assert_array_almost_equal(out, [1])
-
-            out = numpy.empty_like(data).astype(data.dtype.newbyteorder())
-            ndimage.affine_transform(data, [[1]],
-                                     order=order,
-                                     output=out)
             assert_array_almost_equal(out, [1])
 
     def test_affine_transform02(self):
@@ -2065,16 +2043,29 @@ class TestNdimage:
         numpy.testing.assert_raises(ValueError,
                                     ndimage.affine_transform, data, tform_h2)
 
-    def test_affine_transform28(self):
-        # 1d affine transform given output ndarray with non-native endianness
-        # See issue #7388
+    def test_affine_transform_1d_endianness_with_output_parameter(self):
+        # 1d affine transform given output ndarray or dtype with either endianness
+        # see issue #7388
         data = numpy.ones((2, 2))
         for out in [numpy.empty_like(data),
-                    numpy.empty_like(data).astype(data.dtype.newbyteorder())]:
+                    numpy.empty_like(data).astype(data.dtype.newbyteorder()),
+                    data.dtype, data.dtype.newbyteorder()]:
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", UserWarning)
-                ndimage.affine_transform(data, [1, 1], output=out)
-            assert_array_almost_equal(out, [[1, 1], [1, 1]])
+                returned = ndimage.affine_transform(data, [1, 1], output=out)
+            result = out if returned is None else returned
+            assert_array_almost_equal(result, [[1, 1], [1, 1]])
+
+    def test_affine_transform_multi_d_endianness_with_output_parameter(self):
+        # affine transform given output ndarray or dtype with either endianness
+        # see issue #4127
+        data = numpy.array([1])
+        for out in [data.dtype, data.dtype.newbyteorder(),
+                    numpy.empty_like(data),
+                    numpy.empty_like(data).astype(data.dtype.newbyteorder())]:
+            returned = ndimage.affine_transform(data, [[1]], output=out)
+            result = out if returned is None else returned
+            assert_array_almost_equal(result, [1])
 
     def test_shift01(self):
         data = numpy.array([1])


### PR DESCRIPTION
* 1d affine transform with output parameter given as an ndarray with non-native endianness (#7388)
* `affine_transform`, `geometric_transform`, and `map_coordinates` with output parameter given as a dtype with non-native endianness

Applied a `_fix_endianness` decorator to these three functions, replacing the existing `_geometric_transform` wrapper that fixed endianness when output parameter was given as an ndarray to `geometric_transform`, `map_coordinates`, and >1d case of `affine_transform`.

https://github.com/scipy/scipy/issues/7388#issuecomment-306246625 indicates this sort of issue is more widespread but I am undecided whether to cover more cases in this PR or leave it for later.