### PR TITLE
del redundance in interpolate.py

### DIFF
--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -410,7 +410,7 @@ class interp1d(_Interpolator1D):
         self.copy = copy
 
         if kind in ['zero', 'slinear', 'quadratic', 'cubic']:
-            order = {'nearest': 0, 'zero': 0, 'slinear': 1,
+            order = {'zero': 0, 'slinear': 1,
                      'quadratic': 2, 'cubic': 3}[kind]
             kind = 'spline'
         elif isinstance(kind, int):


### PR DESCRIPTION
The 'nearest' in 'order' is redundance in Line 413. 
This is because 'nearest' is not in the conditional statement in Line 412, and kind=='nearest' is never True in this 'if statement'.
By the way, kind=='nearest' is executed in Line 454.
