### PR TITLE
Added more testing of smirnov/smirnovi functions 

### DIFF
--- a/scipy/special/tests/test_kolmogorov.py
+++ b/scipy/special/tests/test_kolmogorov.py
@@ -3,13 +3,15 @@ from __future__ import division, print_function, absolute_import
 import itertools
 
 import numpy as np
-from numpy.testing import (TestCase, dec, assert_, run_module_suite)
+from numpy.testing import assert_
 from scipy.special._testutils import FuncData
+import pytest
+
 from scipy.special import smirnov, smirnovi, kolmogorov, kolmogi
 
 _rtol = 1e-10
 
-class TestSmirnov(TestCase):
+class TestSmirnov(object):
     def test_nan(self):
         assert_(np.isnan(smirnov(1, np.nan)))
 
@@ -87,11 +89,11 @@ class TestSmirnov(TestCase):
         FuncData(smirnov, dataset, (0, 1), 2, rtol=.05).check()
 
 
-class TestSmirnovi(TestCase):
+class TestSmirnovi(object):
     def test_nan(self):
         assert_(np.isnan(smirnovi(1, np.nan)))
 
-    @dec.knownfailureif(True, "test fails; smirnovi() is not always accurate")
+    @pytest.mark.xfail(reason="test fails; smirnovi() is not always accurate")
     def test_basic(self):
         dataset = [(1, 0.4, 0.6),
                    (1, 0.6, 0.4),
@@ -104,7 +106,7 @@ class TestSmirnovi(TestCase):
         dataset = np.asarray(dataset)
         FuncData(smirnovi, dataset, (0, 1), 2, rtol=_rtol).check()
 
-    @dec.knownfailureif(True, "test fails; smirnovi(_,0) is not accurate")
+    @pytest.mark.xfail(reason="test fails; smirnovi(_,0) is not accurate")
     def test_x_equals_0(self):
         dataset = [(n, 0, 1) for n in itertools.chain(range(2, 20), range(1010, 1020))]
         dataset = np.asarray(dataset)
@@ -115,14 +117,14 @@ class TestSmirnovi(TestCase):
         dataset = np.asarray(dataset)
         FuncData(smirnovi, dataset, (0, 1), 2, rtol=_rtol).check()
 
-    @dec.knownfailureif(True, "test fails; smirnovi(1,) is not accurate")
+    @pytest.mark.xfail(reason="test fails; smirnovi(1,) is not accurate")
     def test_n_equals_1(self):
         pp = np.linspace(0, 1, 101, endpoint=True)
         dataset = [(1, p, 1-p) for p in pp]
         dataset = np.asarray(dataset)
         FuncData(smirnovi, dataset, (0, 1), 2, rtol=_rtol).check()
 
-    @dec.knownfailureif(True, "test fails; smirnovi(2,_) is not accurate")
+    @pytest.mark.xfail(reason="test fails; smirnovi(2,_) is not accurate")
     def test_n_equals_2(self):
         x = np.linspace(0.5, 1, 101, endpoint=True)
         p = np.power(1-x, 2)
@@ -131,7 +133,7 @@ class TestSmirnovi(TestCase):
         # dataset = np.asarray(dataset)
         FuncData(smirnovi, dataset, (0, 1), 2, rtol=_rtol).check()
 
-    @dec.knownfailureif(True, "test fails; smirnovi(3,_) is not accurate")
+    @pytest.mark.xfail(reason="test fails; smirnovi(3,_) is not accurate")
     def test_n_equals_3(self):
         x = np.linspace(0.7, 1, 31, endpoint=True)
         p = np.power(1-x, 3)
@@ -140,7 +142,7 @@ class TestSmirnovi(TestCase):
         # dataset = np.asarray(dataset)
         FuncData(smirnovi, dataset, (0, 1), 2, rtol=_rtol).check()
 
-    @dec.knownfailureif(True, "test fails; smirnovi(_,_) is not accurate")
+    @pytest.mark.xfail(reason="test fails; smirnovi(_,_) is not accurate")
     def test_round_trip(self):
         def _sm_smi(n, p):
             return smirnov(n, smirnovi(n, p))
@@ -173,7 +175,7 @@ class TestSmirnovi(TestCase):
         FuncData(smirnovi, dataset, (0, 1), 2, rtol=_rtol).check()
 
 
-class TestKolmogorov(TestCase):
+class TestKolmogorov(object):
     def test_nan(self):
         assert_(np.isnan(kolmogorov(np.nan)))
 
@@ -196,7 +198,7 @@ class TestKolmogorov(TestCase):
         dataset = np.column_stack([x, 1-epsilon])
         FuncData(kolmogorov, dataset, (0,), 1, rtol=_rtol).check()
 
-    @dec.knownfailureif(True, "test fails; kolmogi() is not accurate for small p")
+    @pytest.mark.xfail(reason="test fails; kolmogi() is not accurate for small p")
     def test_round_trip(self):
         def _ki_k(_x):
             return kolmogi(kolmogorov(_x))
@@ -206,11 +208,11 @@ class TestKolmogorov(TestCase):
         FuncData(_ki_k, dataset, (0,), 1, rtol=_rtol).check()
 
 
-class TestKolmogi(TestCase):
+class TestKolmogi(object):
     def test_nan(self):
         assert_(np.isnan(kolmogi(np.nan)))
 
-    @dec.knownfailureif(True, "test fails; kolmogi() is not accurate for small p")
+    @pytest.mark.xfail(reason="test fails; kolmogi() is not accurate for small p")
     def test_basic(self):
         dataset = [(1.0, 0),
                    (0.96394524366487511, 0.5),
@@ -220,7 +222,7 @@ class TestKolmogi(TestCase):
         dataset = np.asarray(dataset)
         FuncData(kolmogi, dataset, (0,), 1, rtol=_rtol).check()
 
-    @dec.knownfailureif(True, "test fails; kolmogi() is not accurate for small p")
+    @pytest.mark.xfail(reason="test fails; kolmogi() is not accurate for small p")
     def test_smallp(self):
         epsilon = 0.1 ** np.arange(1, 14)
         x = np.array([0.571173265106, 0.441027698518, 0.374219690278, 0.331392659217,
@@ -238,7 +240,3 @@ class TestKolmogi(TestCase):
         p = np.linspace(0.1, 1.0, 10, endpoint=True)
         dataset = np.column_stack([p, p])
         FuncData(_k_ki, dataset, (0,), 1, rtol=_rtol).check()
-
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/scipy/special/tests/test_kolmogorov.py
+++ b/scipy/special/tests/test_kolmogorov.py
@@ -1,0 +1,172 @@
+from __future__ import division, print_function, absolute_import
+
+import itertools
+
+import numpy as np
+from numpy.testing import (TestCase, assert_, run_module_suite)
+from scipy.special._testutils import FuncData
+from scipy.special import smirnov, smirnovi
+
+_rtol = 1e-10
+
+
+class TestSmirnov(TestCase):
+    def test_nan(self):
+        assert_(np.isnan(smirnov(1, np.nan)))
+
+    def test_basic(self):
+        dataset = [(1, 0.1, 0.9),
+                   (1, 0.875, 0.125),
+                   (2, 0.875, 0.125 * 0.125),
+                   (3, 0.875, 0.125 * 0.125 * 0.125)]
+
+        dataset = np.asarray(dataset)
+        FuncData(smirnov, dataset, (0, 1), 2, rtol=_rtol).check()
+
+    def test_x_equals_0(self):
+        dataset = [(n, 0, 1) for n in itertools.chain(range(2, 20), range(1010, 1020))]
+        dataset = np.asarray(dataset)
+        FuncData(smirnov, dataset, (0, 1), 2, rtol=_rtol).check()
+
+    def test_x_equals_1(self):
+        dataset = [(n, 1, 0) for n in itertools.chain(range(2, 20), range(1010, 1020))]
+        dataset = np.asarray(dataset)
+        FuncData(smirnov, dataset, (0, 1), 2, rtol=_rtol).check()
+
+    def test_x_equals_0point5(self):
+        dataset = [(1, 0.5, 0.5),
+                   (2, 0.5, 0.25),
+                   (3, 0.5, 0.166666666667),
+                   (4, 0.5, 0.09375),
+                   (5, 0.5, 0.056),
+                   (6, 0.5, 0.0327932098765),
+                   (7, 0.5, 0.0191958707681),
+                   (8, 0.5, 0.0112953186035),
+                   (9, 0.5, 0.00661933257355),
+                   (10, 0.5, 0.003888705)]
+
+        dataset = np.asarray(dataset)
+        FuncData(smirnov, dataset, (0, 1), 2, rtol=_rtol).check()
+
+    def test_n_equals_1(self):
+        x = np.linspace(0, 1, 101, endpoint=True)
+        dataset = np.stack([[1]*len(x), x, 1-x], axis=1)
+        # dataset = np.asarray(dataset)
+        FuncData(smirnov, dataset, (0, 1), 2, rtol=_rtol).check()
+
+    def test_n_equals_2(self):
+        x = np.linspace(0.5, 1, 101, endpoint=True)
+        p = np.power(1-x, 2)
+        n = np.array([2] * len(x))
+        dataset = np.stack([n, x, p], axis=1)
+        # dataset = np.asarray(dataset)
+        FuncData(smirnov, dataset, (0, 1), 2, rtol=_rtol).check()
+
+    def test_n_equals_3(self):
+        x = np.linspace(0.7, 1, 31, endpoint=True)
+        p = np.power(1-x, 3)
+        n = np.array([3] * len(x))
+        dataset = np.stack([n, x, p], axis=1)
+        # dataset = np.asarray(dataset)
+        FuncData(smirnov, dataset, (0, 1), 2, rtol=_rtol).check()
+
+    def test_n_large(self):
+        # test for large values of n
+        # Probabilities should go down as n goes up
+        x = 0.4
+        pvals = np.array([smirnov(n, x) for n in range(400, 1100, 20)])
+        dfs = np.diff(pvals)
+        assert_(np.all(dfs <= 0), msg='Not all diffs negative %s' % dfs)
+
+        dataset = [(1000, 1 - 1.0/2000, np.power(2000.0, -1000))]
+        dataset = np.asarray(dataset)
+        FuncData(smirnov, dataset, (0, 1), 2, rtol=_rtol).check()
+
+        # Check asymptotic behaviour
+        dataset = [(n, 1.0 / np.sqrt(n), np.exp(-2)) for n in range(1000, 5000, 1000)]
+        dataset = np.asarray(dataset)
+        FuncData(smirnov, dataset, (0, 1), 2, rtol=.05).check()
+
+
+class TestSmirnovi(TestCase):
+    def test_nan(self):
+        assert_(np.isnan(smirnovi(1, np.nan)))
+
+    def test_basic(self):
+        dataset = [(1, 0.4, 0.6),
+                   (1, 0.6, 0.4),
+                   (1, 0.99, 0.01),
+                   (1, 0.01, 0.99),
+                   (2, 0.125 * 0.125, 0.875),
+                   (3, 0.125 * 0.125 * 0.125, 0.875),
+                   (10, 1.0 / 16 ** 10, 1 - 1.0 / 16)]
+
+        dataset = np.asarray(dataset)
+        FuncData(smirnovi, dataset, (0, 1), 2, rtol=_rtol).check()
+
+    def test_x_equals_0(self):
+        dataset = [(n, 0, 1) for n in itertools.chain(range(2, 20), range(1010, 1020))]
+        dataset = np.asarray(dataset)
+        FuncData(smirnovi, dataset, (0, 1), 2, rtol=_rtol).check()
+
+    def test_x_equals_1(self):
+        dataset = [(n, 1, 0) for n in itertools.chain(range(2, 20), range(1010, 1020))]
+        dataset = np.asarray(dataset)
+        FuncData(smirnovi, dataset, (0, 1), 2, rtol=_rtol).check()
+
+    def test_n_equals_1(self):
+        pp = np.linspace(0, 1, 101, endpoint=True)
+        dataset = [(1, p, 1-p) for p in pp]
+        dataset = np.asarray(dataset)
+        FuncData(smirnovi, dataset, (0, 1), 2, rtol=_rtol).check()
+
+    def test_n_equals_2(self):
+        x = np.linspace(0.5, 1, 101, endpoint=True)
+        p = np.power(1-x, 2)
+        n = np.array([2] * len(x))
+        dataset = np.stack([n, p, x], axis=1)
+        # dataset = np.asarray(dataset)
+        FuncData(smirnovi, dataset, (0, 1), 2, rtol=_rtol).check()
+
+    def test_n_equals_3(self):
+        x = np.linspace(0.7, 1, 31, endpoint=True)
+        p = np.power(1-x, 3)
+        n = np.array([3] * len(x))
+        dataset = np.stack([n, p, x], axis=1)
+        # dataset = np.asarray(dataset)
+        FuncData(smirnovi, dataset, (0, 1), 2, rtol=_rtol).check()
+
+    def test_round_trip(self):
+        def _sm_smi(n, p):
+            return smirnov(n, smirnovi(n, p))
+
+        dataset = [(1, 0.4, 0.4),
+                   (1, 0.6, 0.6),
+                   (2, 0.875, 0.875),
+                   (3, 0.875, 0.875),
+                   (3, 0.125, 0.125),
+                   (10, 0.999, 0.999),
+                   (10, 0.0001, 0.0001)]
+
+        dataset = np.asarray(dataset)
+        FuncData(_sm_smi, dataset, (0, 1), 2, rtol=_rtol).check()
+
+    def test_x_equals_0point5(self):
+        dataset = [(1, 0.5, 0.5),
+                   (2, 0.5, 0.366025403784),
+                   (2, 0.25, 0.5),
+                   (3, 0.5, 0.297156508177),
+                   (4, 0.5, 0.255520481121),
+                   (5, 0.5, 0.234559536069),
+                   (6, 0.5, 0.21715965898),
+                   (7, 0.5, 0.202722580034),
+                   (8, 0.5, 0.190621765256),
+                   (9, 0.5, 0.180363501362),
+                   (10, 0.5, 0.17157867006)]
+
+        dataset = np.asarray(dataset)
+        FuncData(smirnovi, dataset, (0, 1), 2, rtol=_rtol).check()
+
+
+if __name__ == "__main__":
+    run_module_suite()

--- a/scipy/special/tests/test_kolmogorov.py
+++ b/scipy/special/tests/test_kolmogorov.py
@@ -3,7 +3,7 @@ from __future__ import division, print_function, absolute_import
 import itertools
 
 import numpy as np
-from numpy.testing import (TestCase, assert_, run_module_suite)
+from numpy.testing import (TestCase, dec, assert_, run_module_suite)
 from scipy.special._testutils import FuncData
 from scipy.special import smirnov, smirnovi
 
@@ -92,6 +92,7 @@ class TestSmirnovi(TestCase):
     def test_nan(self):
         assert_(np.isnan(smirnovi(1, np.nan)))
 
+    @dec.knownfailureif(True, "test fails; smirnovi() is not always accurate")
     def test_basic(self):
         dataset = [(1, 0.4, 0.6),
                    (1, 0.6, 0.4),
@@ -104,6 +105,7 @@ class TestSmirnovi(TestCase):
         dataset = np.asarray(dataset)
         FuncData(smirnovi, dataset, (0, 1), 2, rtol=_rtol).check()
 
+    @dec.knownfailureif(True, "test fails; smirnovi(_,0) is not accurate")
     def test_x_equals_0(self):
         dataset = [(n, 0, 1) for n in itertools.chain(range(2, 20), range(1010, 1020))]
         dataset = np.asarray(dataset)
@@ -114,12 +116,14 @@ class TestSmirnovi(TestCase):
         dataset = np.asarray(dataset)
         FuncData(smirnovi, dataset, (0, 1), 2, rtol=_rtol).check()
 
+    @dec.knownfailureif(True, "test fails; smirnovi(1,) is not accurate")
     def test_n_equals_1(self):
         pp = np.linspace(0, 1, 101, endpoint=True)
         dataset = [(1, p, 1-p) for p in pp]
         dataset = np.asarray(dataset)
         FuncData(smirnovi, dataset, (0, 1), 2, rtol=_rtol).check()
 
+    @dec.knownfailureif(True, "test fails; smirnovi(2,_) is not accurate")
     def test_n_equals_2(self):
         x = np.linspace(0.5, 1, 101, endpoint=True)
         p = np.power(1-x, 2)
@@ -128,6 +132,7 @@ class TestSmirnovi(TestCase):
         # dataset = np.asarray(dataset)
         FuncData(smirnovi, dataset, (0, 1), 2, rtol=_rtol).check()
 
+    @dec.knownfailureif(True, "test fails; smirnovi(3,_) is not accurate")
     def test_n_equals_3(self):
         x = np.linspace(0.7, 1, 31, endpoint=True)
         p = np.power(1-x, 3)
@@ -136,6 +141,7 @@ class TestSmirnovi(TestCase):
         # dataset = np.asarray(dataset)
         FuncData(smirnovi, dataset, (0, 1), 2, rtol=_rtol).check()
 
+    @dec.knownfailureif(True, "test fails; smirnovi(_,_) is not accurate")
     def test_round_trip(self):
         def _sm_smi(n, p):
             return smirnov(n, smirnovi(n, p))

--- a/scipy/special/tests/test_kolmogorov.py
+++ b/scipy/special/tests/test_kolmogorov.py
@@ -50,7 +50,7 @@ class TestSmirnov(TestCase):
 
     def test_n_equals_1(self):
         x = np.linspace(0, 1, 101, endpoint=True)
-        dataset = np.stack([[1]*len(x), x, 1-x], axis=1)
+        dataset = np.column_stack([[1]*len(x), x, 1-x])
         # dataset = np.asarray(dataset)
         FuncData(smirnov, dataset, (0, 1), 2, rtol=_rtol).check()
 
@@ -58,7 +58,7 @@ class TestSmirnov(TestCase):
         x = np.linspace(0.5, 1, 101, endpoint=True)
         p = np.power(1-x, 2)
         n = np.array([2] * len(x))
-        dataset = np.stack([n, x, p], axis=1)
+        dataset = np.column_stack([n, x, p])
         # dataset = np.asarray(dataset)
         FuncData(smirnov, dataset, (0, 1), 2, rtol=_rtol).check()
 
@@ -66,7 +66,7 @@ class TestSmirnov(TestCase):
         x = np.linspace(0.7, 1, 31, endpoint=True)
         p = np.power(1-x, 3)
         n = np.array([3] * len(x))
-        dataset = np.stack([n, x, p], axis=1)
+        dataset = np.column_stack([n, x, p])
         # dataset = np.asarray(dataset)
         FuncData(smirnov, dataset, (0, 1), 2, rtol=_rtol).check()
 
@@ -128,7 +128,7 @@ class TestSmirnovi(TestCase):
         x = np.linspace(0.5, 1, 101, endpoint=True)
         p = np.power(1-x, 2)
         n = np.array([2] * len(x))
-        dataset = np.stack([n, p, x], axis=1)
+        dataset = np.column_stack([n, p, x])
         # dataset = np.asarray(dataset)
         FuncData(smirnovi, dataset, (0, 1), 2, rtol=_rtol).check()
 
@@ -137,7 +137,7 @@ class TestSmirnovi(TestCase):
         x = np.linspace(0.7, 1, 31, endpoint=True)
         p = np.power(1-x, 3)
         n = np.array([3] * len(x))
-        dataset = np.stack([n, p, x], axis=1)
+        dataset = np.column_stack([n, p, x])
         # dataset = np.asarray(dataset)
         FuncData(smirnovi, dataset, (0, 1), 2, rtol=_rtol).check()
 

--- a/scipy/special/tests/test_kolmogorov.py
+++ b/scipy/special/tests/test_kolmogorov.py
@@ -5,10 +5,9 @@ import itertools
 import numpy as np
 from numpy.testing import (TestCase, dec, assert_, run_module_suite)
 from scipy.special._testutils import FuncData
-from scipy.special import smirnov, smirnovi
+from scipy.special import smirnov, smirnovi, kolmogorov, kolmogi
 
 _rtol = 1e-10
-
 
 class TestSmirnov(TestCase):
     def test_nan(self):
@@ -172,6 +171,73 @@ class TestSmirnovi(TestCase):
 
         dataset = np.asarray(dataset)
         FuncData(smirnovi, dataset, (0, 1), 2, rtol=_rtol).check()
+
+
+class TestKolmogorov(TestCase):
+    def test_nan(self):
+        assert_(np.isnan(kolmogorov(np.nan)))
+
+    def test_basic(self):
+        dataset = [(0, 1.0),
+                   (0.5, 0.96394524366487511),
+                   (1, 0.26999967167735456),
+                   (2, 0.00067092525577969533)]
+
+        dataset = np.asarray(dataset)
+        FuncData(kolmogorov, dataset, (0,), 1, rtol=_rtol).check()
+
+    def test_smallx(self):
+        epsilon = 0.1 ** np.arange(1, 14)
+        x = np.array([0.571173265106, 0.441027698518, 0.374219690278, 0.331392659217,
+                      0.300820537459, 0.277539353999, 0.259023494805, 0.243829561254,
+                      0.231063086389, 0.220135543236, 0.210641372041, 0.202290283658,
+                      0.19487060742])
+
+        dataset = np.column_stack([x, 1-epsilon])
+        FuncData(kolmogorov, dataset, (0,), 1, rtol=_rtol).check()
+
+    @dec.knownfailureif(True, "test fails; kolmogi() is not accurate for small p")
+    def test_round_trip(self):
+        def _ki_k(_x):
+            return kolmogi(kolmogorov(_x))
+
+        x = np.linspace(0.0, 2.0, 21, endpoint=True)
+        dataset = np.column_stack([x, x])
+        FuncData(_ki_k, dataset, (0,), 1, rtol=_rtol).check()
+
+
+class TestKolmogi(TestCase):
+    def test_nan(self):
+        assert_(np.isnan(kolmogi(np.nan)))
+
+    @dec.knownfailureif(True, "test fails; kolmogi() is not accurate for small p")
+    def test_basic(self):
+        dataset = [(1.0, 0),
+                   (0.96394524366487511, 0.5),
+                   (0.26999967167735456, 1),
+                   (0.00067092525577969533, 2)]
+
+        dataset = np.asarray(dataset)
+        FuncData(kolmogi, dataset, (0,), 1, rtol=_rtol).check()
+
+    @dec.knownfailureif(True, "test fails; kolmogi() is not accurate for small p")
+    def test_smallp(self):
+        epsilon = 0.1 ** np.arange(1, 14)
+        x = np.array([0.571173265106, 0.441027698518, 0.374219690278, 0.331392659217,
+                      0.300820537459, 0.277539353999, 0.259023494805, 0.243829561254,
+                      0.231063086389, 0.220135543236, 0.210641372041, 0.202290283658,
+                      0.19487060742])
+
+        dataset = np.column_stack([1-epsilon, x])
+        FuncData(kolmogi, dataset, (0,), 1, rtol=_rtol).check()
+
+    def test_round_trip(self):
+        def _k_ki(_p):
+            return kolmogorov(kolmogi(_p))
+
+        p = np.linspace(0.1, 1.0, 10, endpoint=True)
+        dataset = np.column_stack([p, p])
+        FuncData(_k_ki, dataset, (0,), 1, rtol=_rtol).check()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Added test_kolmogorov.py to test `smirnov(n,x)` and `smirnovi(n,p)`, especially near the endpoints of the `[0,1]` interval.
Note: many of these tests fail with the current implementation of `smirnovi()`.  E.g.
test_basic (test_kolmogorov.TestSmirnovi) ... FAIL
test_n_equals_1 (test_kolmogorov.TestSmirnovi) ... FAIL
test_n_equals_2 (test_kolmogorov.TestSmirnovi) ... FAIL
test_n_equals_3 (test_kolmogorov.TestSmirnovi) ... FAIL
test_round_trip (test_kolmogorov.TestSmirnovi) ... FAIL
test_x_equals_0 (test_kolmogorov.TestSmirnovi) ... FAIL
