### PR TITLE
MAINT: update for new FutureWarning's in numpy 1.13.0

### DIFF
--- a/scipy/special/tests/test_orthogonal.py
+++ b/scipy/special/tests/test_orthogonal.py
@@ -270,7 +270,8 @@ class TestCall(object):
         try:
             for pstr in poly:
                 p = eval(pstr)
-                assert_almost_equal(p(0.315), np.poly1d(p)(0.315), err_msg=pstr)
+                assert_almost_equal(p(0.315), np.poly1d(p.coef)(0.315),
+                                    err_msg=pstr)
         finally:
             np.seterr(**olderr)
 

--- a/scipy/special/tests/test_orthogonal_eval.py
+++ b/scipy/special/tests/test_orthogonal_eval.py
@@ -57,7 +57,7 @@ class TestPolys(object):
                 x = x_range[0] + (x_range[1] - x_range[0])*np.random.rand(nx)
                 x[0] = x_range[0]  # always include domain start point
                 x[1] = x_range[1]  # always include domain end point
-                poly = np.poly1d(cls(*p))
+                poly = np.poly1d(cls(*p).coef)
                 z = np.c_[np.tile(p, (nx,1)), x, poly(x)]
                 dataset.append(z)
 

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -2487,8 +2487,8 @@ def plotting_positions(data, alpha=0.4, beta=0.4):
     n = data.count()
     plpos = np.empty(data.size, dtype=float)
     plpos[n:] = 0
-    plpos[data.argsort()[:n]] = ((np.arange(1, n+1) - alpha) /
-                                 (n + 1.0 - alpha - beta))
+    plpos[data.argsort(axis=None)[:n]] = ((np.arange(1, n+1) - alpha) /
+                                          (n + 1.0 - alpha - beta))
     return ma.array(plpos, mask=data._mask)
 
 meppf = plotting_positions


### PR DESCRIPTION
- pass only coefficients to the np.poly1d constructor
- explicitly pass axis=None to MaskedArray.argsort