### PR TITLE
DOC: correctly describe output shape of dirichlet.mean() and dirichlet.var()

### DIFF
--- a/doc/release/1.0.0-notes.rst
+++ b/doc/release/1.0.0-notes.rst
@@ -75,6 +75,9 @@ has been changed to True.
 
 `scipy.special.gammaln` does not accept complex arguments anymore.
 
+The method ``var`` for the Dirichlet distribution of `scipy.stats.multivariate`
+now returns a scalar rather than an ndarray when the length of alpha is 1.
+
 
 Other changes
 =============

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -473,7 +473,7 @@ class multivariate_normal_gen(multi_rv_generic):
 
         Returns
         -------
-        pdf : ndarray
+        pdf : ndarray or scalar
             Log of the probability density function evaluated at `x`
 
         Notes
@@ -499,7 +499,7 @@ class multivariate_normal_gen(multi_rv_generic):
 
         Returns
         -------
-        pdf : ndarray
+        pdf : ndarray or scalar
             Probability density function evaluated at `x`
 
         Notes
@@ -565,7 +565,7 @@ class multivariate_normal_gen(multi_rv_generic):
 
         Returns
         -------
-        cdf : ndarray
+        cdf : ndarray or scalar
             Log of the cumulative distribution function evaluated at `x`
 
         Notes
@@ -604,7 +604,7 @@ class multivariate_normal_gen(multi_rv_generic):
 
         Returns
         -------
-        cdf : ndarray
+        cdf : ndarray or scalar
             Cumulative distribution function evaluated at `x`
 
         Notes
@@ -1379,7 +1379,7 @@ class dirichlet_gen(multi_rv_generic):
 
         Returns
         -------
-        pdf : ndarray
+        pdf : ndarray or scalar
             Log of the probability density function evaluated at `x`.
 
         """
@@ -1401,7 +1401,7 @@ class dirichlet_gen(multi_rv_generic):
 
         Returns
         -------
-        pdf : ndarray
+        pdf : ndarray or scalar
             The probability density function evaluated at `x`.
 
         """
@@ -1421,8 +1421,8 @@ class dirichlet_gen(multi_rv_generic):
 
         Returns
         -------
-        mu : scalar
-            Mean of the Dirichlet distribution
+        mu : ndarray or scalar
+            Mean of the Dirichlet distribution.
 
         """
         alpha = _dirichlet_check_parameters(alpha)
@@ -1440,8 +1440,8 @@ class dirichlet_gen(multi_rv_generic):
 
         Returns
         -------
-        v : scalar
-            Variance of the Dirichlet distribution
+        v : ndarray or scalar
+            Variance of the Dirichlet distribution.
 
         """
 
@@ -1449,7 +1449,7 @@ class dirichlet_gen(multi_rv_generic):
 
         alpha0 = np.sum(alpha)
         out = (alpha * (alpha0 - alpha)) / ((alpha0 * alpha0) * (alpha0 + 1))
-        return out
+        return _squeeze_output(out)
 
     def entropy(self, alpha):
         """

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -708,16 +708,26 @@ class TestDirichlet(TestCase):
         assert_raises(ValueError, dirichlet.pdf, x, alpha)
         assert_raises(ValueError, dirichlet.logpdf, x, alpha)
 
-    def test_simple_values(self):
-        alpha = np.array([1, 1])
+    def test_mean_and_var(self):
+        alpha = np.array([1., 0.8, 0.2])
         d = dirichlet(alpha)
 
-        assert_almost_equal(d.mean(), 0.5)
-        assert_almost_equal(d.var(), 1. / 12.)
+        expected_var = [1. / 12., 0.08, 0.03]
+        expected_mean = [0.5, 0.4, 0.1]
 
-        b = beta(1, 1)
-        assert_almost_equal(d.mean(), b.mean())
-        assert_almost_equal(d.var(), b.var())
+        assert_array_almost_equal(d.var(), expected_var)
+        assert_array_almost_equal(d.mean(), expected_mean)
+
+    def test_scalar_values(self):
+        alpha = np.array([0.2])
+        d = dirichlet(alpha)
+
+        # For alpha of length 1, mean and var should be scalar instead of array
+        assert_equal(d.mean().ndim, 0)
+        assert_equal(d.var().ndim, 0)
+
+        assert_equal(d.pdf([1.]).ndim, 0)
+        assert_equal(d.logpdf([1.]).ndim, 0)
 
     def test_K_and_K_minus_1_calls_equal(self):
         # Test that calls with K and K-1 entries yield the same results.


### PR DESCRIPTION
Fixes #7444. Also updates test to check exact output, including shape, since the existing test was consistent with the incorrect docstring info. Also did the same for the similar situation of `dirichlet.mean()`.