### PR TITLE
Fix #7456, #7426, #7455 scipy.special.smirnovi & scipy.stats.ksone

### DIFF
--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -249,6 +249,7 @@ Raw Statistical Functions
    chndtrix     -- Inverse to `chndtr` vs `x`
    smirnov      -- Kolmogorov-Smirnov complementary cumulative distribution function
    smirnovi     -- Inverse to `smirnov`
+   smirnovp     -- Derivative of `smirnov`
    kolmogorov   -- Complementary cumulative distribution function of Kolmogorov distribution
    kolmogi      -- Inverse function to kolmogorov
    tklmbda      -- Tukey-Lambda cumulative distribution function

--- a/scipy/special/_legacy.pxd
+++ b/scipy/special/_legacy.pxd
@@ -29,6 +29,7 @@ cdef extern from "cephes.h":
     double yn(int n, double x) nogil
     double smirnov(int n, double e) nogil
     double smirnovi(int n, double p) nogil
+    double smirnovp(int n, double p) nogil
 
 cdef extern from "amos_wrappers.h":
     double cbesk_wrap_real_int(int n, double z) nogil
@@ -89,9 +90,15 @@ cdef inline double kn_unsafe(double n, double x) nogil:
 cdef inline double yn_unsafe(double n, double x) nogil:
     _legacy_cast_check("yn", n, 0)
     return yn(<int>n, x)
+
 cdef inline double smirnov_unsafe(double n, double e) nogil:
     _legacy_cast_check("smirnov", n, 0)
     return smirnov(<int>n, e)
+
 cdef inline double smirnovi_unsafe(double n, double p) nogil:
     _legacy_cast_check("smirnovi", n, 0)
     return smirnovi(<int>n, p)
+
+cdef inline double smirnovp_unsafe(double n, double p) nogil:
+    _legacy_cast_check("smirnovp", n, 0)
+    return smirnovp(<int>n, p)

--- a/scipy/special/_ufuncs.pyx
+++ b/scipy/special/_ufuncs.pyx
@@ -1879,6 +1879,11 @@ from _legacy cimport smirnovi_unsafe as _func_smirnovi_unsafe
 ctypedef double _proto_smirnovi_unsafe_t(double, double) nogil
 cdef _proto_smirnovi_unsafe_t *_proto_smirnovi_unsafe_t_var = &_func_smirnovi_unsafe
 cdef extern from "_ufuncs_defs.h":
+    cdef double _func_smirnovp "smirnovp"(int, double) nogil
+from _legacy cimport smirnovp_unsafe as _func_smirnovp_unsafe
+ctypedef double _proto_smirnovp_unsafe_t(double, double) nogil
+cdef _proto_smirnovp_unsafe_t *_proto_smirnovp_unsafe_t_var = &_func_smirnovp_unsafe
+cdef extern from "_ufuncs_defs.h":
     cdef double _func_spence "spence"(double) nogil
 from _spence cimport cspence as _func_cspence
 ctypedef double complex _proto_cspence_t(double complex) nogil
@@ -2867,8 +2872,8 @@ cdef char *ufunc_bdtrik_doc = (
     "Formula 26.5.24 of [1]_ is used to reduce the binomial distribution to the\n"
     "cumulative incomplete beta distribution.\n"
     "\n"
-    "Computation of `k` involves a seach for a value that produces the desired\n"
-    "value of `y`.  The search relies on the monotinicity of `y` with `k`.\n"
+    "Computation of `k` involves a search for a value that produces the desired\n"
+    "value of `y`.  The search relies on the monotonicity of `y` with `k`.\n"
     "\n"
     "Wrapper for the CDFLIB [2]_ Fortran routine `cdfbin`.\n"
     "\n"
@@ -2935,8 +2940,8 @@ cdef char *ufunc_bdtrin_doc = (
     "Formula 26.5.24 of [1]_ is used to reduce the binomial distribution to the\n"
     "cumulative incomplete beta distribution.\n"
     "\n"
-    "Computation of `n` involves a seach for a value that produces the desired\n"
-    "value of `y`.  The search relies on the monotinicity of `y` with `n`.\n"
+    "Computation of `n` involves a search for a value that produces the desired\n"
+    "value of `y`.  The search relies on the monotonicity of `y` with `n`.\n"
     "\n"
     "Wrapper for the CDFLIB [2]_ Fortran routine `cdfbin`.\n"
     "\n"
@@ -3518,9 +3523,9 @@ cdef char *ufunc_btdtria_doc = (
     "Wrapper for the CDFLIB [1]_ Fortran routine `cdfbet`.\n"
     "\n"
     "The cumulative distribution function `p` is computed using a routine by\n"
-    "DiDinato and Morris [2]_.  Computation of `a` involves a seach for a value\n"
+    "DiDinato and Morris [2]_.  Computation of `a` involves a search for a value\n"
     "that produces the desired value of `p`.  The search relies on the\n"
-    "monotinicity of `p` with `a`.\n"
+    "monotonicity of `p` with `a`.\n"
     "\n"
     "References\n"
     "----------\n"
@@ -3589,9 +3594,9 @@ cdef char *ufunc_btdtrib_doc = (
     "Wrapper for the CDFLIB [1]_ Fortran routine `cdfbet`.\n"
     "\n"
     "The cumulative distribution function `p` is computed using a routine by\n"
-    "DiDinato and Morris [2]_.  Computation of `b` involves a seach for a value\n"
+    "DiDinato and Morris [2]_.  Computation of `b` involves a search for a value\n"
     "that produces the desired value of `p`.  The search relies on the\n"
-    "monotinicity of `p` with `b`.\n"
+    "monotonicity of `p` with `b`.\n"
     "\n"
     "References\n"
     "----------\n"
@@ -5469,7 +5474,7 @@ cdef char *ufunc_eval_sh_chebyt_doc = (
     "roots_sh_chebyt : roots and quadrature weights of shifted\n"
     "                  Chebyshev polynomials of the first kind\n"
     "sh_chebyt : shifted Chebyshev polynomial object\n"
-    "eval_chebyt : evalaute Chebyshev polynomials of the first kind\n"
+    "eval_chebyt : evaluate Chebyshev polynomials of the first kind\n"
     "numpy.polynomial.chebyshev.Chebyshev : Chebyshev series")
 ufunc_eval_sh_chebyt_loops[0] = <np.PyUFuncGenericFunction>loop_d_ld__As_ld_d
 ufunc_eval_sh_chebyt_loops[1] = <np.PyUFuncGenericFunction>loop_d_dd__As_ff_f
@@ -6811,9 +6816,9 @@ cdef char *ufunc_gdtria_doc = (
     "Wrapper for the CDFLIB [1]_ Fortran routine `cdfgam`.\n"
     "\n"
     "The cumulative distribution function `p` is computed using a routine by\n"
-    "DiDinato and Morris [2]_.  Computation of `a` involves a seach for a value\n"
+    "DiDinato and Morris [2]_.  Computation of `a` involves a search for a value\n"
     "that produces the desired value of `p`.  The search relies on the\n"
-    "monotinicity of `p` with `a`.\n"
+    "monotonicity of `p` with `a`.\n"
     "\n"
     "References\n"
     "----------\n"
@@ -6899,9 +6904,9 @@ cdef char *ufunc_gdtrib_doc = (
     "Wrapper for the CDFLIB [1]_ Fortran routine `cdfgam`.\n"
     "\n"
     "The cumulative distribution function `p` is computed using a routine by\n"
-    "DiDinato and Morris [2]_.  Computation of `b` involves a seach for a value\n"
+    "DiDinato and Morris [2]_.  Computation of `b` involves a search for a value\n"
     "that produces the desired value of `p`.  The search relies on the\n"
-    "monotinicity of `p` with `b`.\n"
+    "monotonicity of `p` with `b`.\n"
     "\n"
     "References\n"
     "----------\n"
@@ -6988,9 +6993,9 @@ cdef char *ufunc_gdtrix_doc = (
     "Wrapper for the CDFLIB [1]_ Fortran routine `cdfgam`.\n"
     "\n"
     "The cumulative distribution function `p` is computed using a routine by\n"
-    "DiDinato and Morris [2]_.  Computation of `x` involves a seach for a value\n"
+    "DiDinato and Morris [2]_.  Computation of `x` involves a search for a value\n"
     "that produces the desired value of `p`.  The search relies on the\n"
-    "monotinicity of `p` with `x`.\n"
+    "monotonicity of `p` with `x`.\n"
     "\n"
     "References\n"
     "----------\n"
@@ -8301,10 +8306,10 @@ cdef char *ufunc_iv_doc = (
     "expansions are applied.\n"
     "\n"
     "For complex `z` and positive `v`, the AMOS [2]_ `zbesi` routine is\n"
-    "called. It uses a power series for small `z`, the asymptitic expansion\n"
+    "called. It uses a power series for small `z`, the asymptotic expansion\n"
     "for large `abs(z)`, the Miller algorithm normalized by the Wronskian\n"
     "and a Neumann series for intermediate magnitudes, and the uniform\n"
-    "asymptitic expansions for :math:`I_v(z)` and :math:`J_v(z)` for large\n"
+    "asymptotic expansions for :math:`I_v(z)` and :math:`J_v(z)` for large\n"
     "orders.  Backward recurrence is used to generate sequences or reduce\n"
     "orders when necessary.\n"
     "\n"
@@ -8389,9 +8394,9 @@ cdef char *ufunc_ive_doc = (
     "Notes\n"
     "-----\n"
     "For positive `v`, the AMOS [1]_ `zbesi` routine is called. It uses a\n"
-    "power series for small `z`, the asymptitic expansion for large\n"
+    "power series for small `z`, the asymptotic expansion for large\n"
     "`abs(z)`, the Miller algorithm normalized by the Wronskian and a\n"
-    "Neumann series for intermediate magnitudes, and the uniform asymptitic\n"
+    "Neumann series for intermediate magnitudes, and the uniform asymptotic\n"
     "expansions for :math:`I_v(z)` and :math:`J_v(z)` for large orders.\n"
     "Backward recurrence is used to generate sequences or reduce orders when\n"
     "necessary.\n"
@@ -10440,8 +10445,8 @@ cdef char *ufunc_nbdtrik_doc = (
     "is used to reduce calculation of the cumulative distribution function to\n"
     "that of a regularized incomplete beta :math:`I`.\n"
     "\n"
-    "Computation of `k` involves a seach for a value that produces the desired\n"
-    "value of `y`.  The search relies on the monotinicity of `y` with `k`.\n"
+    "Computation of `k` involves a search for a value that produces the desired\n"
+    "value of `y`.  The search relies on the monotonicity of `y` with `k`.\n"
     "\n"
     "References\n"
     "----------\n"
@@ -10514,8 +10519,8 @@ cdef char *ufunc_nbdtrin_doc = (
     "is used to reduce calculation of the cumulative distribution function to\n"
     "that of a regularized incomplete beta :math:`I`.\n"
     "\n"
-    "Computation of `n` involves a seach for a value that produces the desired\n"
-    "value of `y`.  The search relies on the monotinicity of `y` with `n`.\n"
+    "Computation of `n` involves a search for a value that produces the desired\n"
+    "value of `y`.  The search relies on the monotonicity of `y` with `n`.\n"
     "\n"
     "References\n"
     "----------\n"
@@ -11925,7 +11930,7 @@ cdef char ufunc_pro_rad2_types[12]
 cdef char *ufunc_pro_rad2_doc = (
     "pro_rad2(m, n, c, x)\n"
     "\n"
-    "Prolate spheroidal radial function of the secon kind and its derivative\n"
+    "Prolate spheroidal radial function of the second kind and its derivative\n"
     "\n"
     "Computes the prolate spheroidal radial function of the second kind\n"
     "and its derivative (with respect to `x`) for mode parameters m>=0\n"
@@ -12518,6 +12523,37 @@ ufunc_smirnovi_data[0] = &ufunc_smirnovi_ptr[2*0]
 ufunc_smirnovi_data[1] = &ufunc_smirnovi_ptr[2*1]
 ufunc_smirnovi_data[2] = &ufunc_smirnovi_ptr[2*2]
 smirnovi = np.PyUFunc_FromFuncAndData(ufunc_smirnovi_loops, ufunc_smirnovi_data, ufunc_smirnovi_types, 3, 2, 1, 0, "smirnovi", ufunc_smirnovi_doc, 0)
+
+cdef np.PyUFuncGenericFunction ufunc_smirnovp_loops[3]
+cdef void *ufunc_smirnovp_ptr[6]
+cdef void *ufunc_smirnovp_data[3]
+cdef char ufunc_smirnovp_types[9]
+cdef char *ufunc_smirnovp_doc = (
+    "smirnovp(n, y)\n"
+    "\n"
+    "Derivative of `smirnov`")
+ufunc_smirnovp_loops[0] = <np.PyUFuncGenericFunction>loop_d_id__As_ld_d
+ufunc_smirnovp_loops[1] = <np.PyUFuncGenericFunction>loop_d_dd__As_ff_f
+ufunc_smirnovp_loops[2] = <np.PyUFuncGenericFunction>loop_d_dd__As_dd_d
+ufunc_smirnovp_types[0] = <char>NPY_LONG
+ufunc_smirnovp_types[1] = <char>NPY_DOUBLE
+ufunc_smirnovp_types[2] = <char>NPY_DOUBLE
+ufunc_smirnovp_types[3] = <char>NPY_FLOAT
+ufunc_smirnovp_types[4] = <char>NPY_FLOAT
+ufunc_smirnovp_types[5] = <char>NPY_FLOAT
+ufunc_smirnovp_types[6] = <char>NPY_DOUBLE
+ufunc_smirnovp_types[7] = <char>NPY_DOUBLE
+ufunc_smirnovp_types[8] = <char>NPY_DOUBLE
+ufunc_smirnovp_ptr[2*0] = <void*>_func_smirnovp
+ufunc_smirnovp_ptr[2*0+1] = <void*>(<char*>"smirnovp")
+ufunc_smirnovp_ptr[2*1] = <void*>_func_smirnovp_unsafe
+ufunc_smirnovp_ptr[2*1+1] = <void*>(<char*>"smirnovp")
+ufunc_smirnovp_ptr[2*2] = <void*>_func_smirnovp_unsafe
+ufunc_smirnovp_ptr[2*2+1] = <void*>(<char*>"smirnovp")
+ufunc_smirnovp_data[0] = &ufunc_smirnovp_ptr[2*0]
+ufunc_smirnovp_data[1] = &ufunc_smirnovp_ptr[2*1]
+ufunc_smirnovp_data[2] = &ufunc_smirnovp_ptr[2*2]
+smirnovp = np.PyUFunc_FromFuncAndData(ufunc_smirnovp_loops, ufunc_smirnovp_data, ufunc_smirnovp_types, 3, 2, 1, 0, "smirnovp", ufunc_smirnovp_doc, 0)
 
 cdef np.PyUFuncGenericFunction ufunc_spence_loops[4]
 cdef void *ufunc_spence_ptr[8]

--- a/scipy/special/_ufuncs_defs.h
+++ b/scipy/special/_ufuncs_defs.h
@@ -199,6 +199,7 @@ npy_int sici(npy_double, npy_double *, npy_double *);
 npy_double sindg(npy_double);
 npy_double smirnov(npy_int, npy_double);
 npy_double smirnovi(npy_int, npy_double);
+npy_double smirnovp(npy_int, npy_double);
 npy_double spence(npy_double);
 npy_double cdft1_wrap(npy_double, npy_double);
 npy_double cdft3_wrap(npy_double, npy_double);

--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -5957,6 +5957,14 @@ add_newdoc("scipy.special", "smirnovi",
     Returns ``e`` such that ``smirnov(n, e) = y``.
     """)
 
+add_newdoc("scipy.special", "smirnovp",
+    """
+    smirnovp(n, y)
+
+    Derivative of `smirnov`
+    """)
+
+
 add_newdoc("scipy.special", "spence",
     r"""
     spence(z, out=None)

--- a/scipy/special/cephes.h
+++ b/scipy/special/cephes.h
@@ -197,6 +197,7 @@ extern double zeta ( double x, double q );
 extern double zetac ( double x );
 
 extern double smirnov (int n, double e );
+extern double smirnovp (int n, double x );
 extern double smirnovi (int n, double p );
 extern double kolmogorov ( double x );
 extern double kolmogi ( double p );

--- a/scipy/special/cephes/cephes_names.h
+++ b/scipy/special/cephes/cephes_names.h
@@ -91,6 +91,7 @@
 #define zetac cephes_zetac
 #define smirnov cephes_smirnov
 #define smirnovi cephes_smirnovi
+#define smirnovp cephes_smirnovp
 #define kolmogorov cephes_kolmogorov
 #define kolmogi cephes_kolmogi
 

--- a/scipy/special/cephes/kolmogorov.c
+++ b/scipy/special/cephes/kolmogorov.c
@@ -2,12 +2,11 @@
  * Main loop commented out.... */
 /*  Travis Oliphant Nov. 1998 */
 
-
 /* Re Kolmogorov statistics, here is Birnbaum and Tingey's formula for the
  * distribution of D+, the maximum of all positive deviations between a
  * theoretical distribution function P(x) and an empirical one Sn(x)
  * from n samples.
- * 
+ *
  *     +
  *    D  =         sup     [P(x) - S (x)]
  *     n     -inf < x < inf         n
@@ -18,56 +17,20 @@
  *    Pr{D   > e} =    >    C    e (e + v/n)    (1 - e - v/n)
  *        n            -   n v
  *                    v=0
- * 
+ *
  * [n(1-e)] is the largest integer not exceeding n(1-e).
- * nCv is the number of combinations of n things taken v at a time.  */
+ * nCv is the number of combinations of n things taken v at a time.
+ * "e" here is being used as an abbreviation of "epsilon", not of e=2.71828...
+ */
 
 
 #include "mconf.h"
+#include "float.h"
 extern double MAXLOG;
 
-/* Exact Smirnov statistic, for one-sided test.  */
-double smirnov(int n, double e)
-{
-    int v, nn;
-    double evn, omevn, p, t, c, lgamnp1;
-
-    /* This comparison should assure returning NaN whenever
-     * e is NaN itself.  In original || form it would proceed */
-    if (!(n > 0 && e >= 0.0 && e <= 1.0))
-	return (NPY_NAN);
-    if (e == 0.0)
-	return 1.0;
-    nn = (int) (floor((double) n * (1.0 - e)));
-    p = 0.0;
-    if (n < 1013) {
-	c = 1.0;
-	for (v = 0; v <= nn; v++) {
-	    evn = e + ((double) v) / n;
-	    p += c * pow(evn, (double) (v - 1))
-		* pow(1.0 - evn, (double) (n - v));
-	    /* Next combinatorial term; worst case error = 4e-15.  */
-	    c *= ((double) (n - v)) / (v + 1);
-	}
-    }
-    else {
-	lgamnp1 = lgam((double) (n + 1));
-	for (v = 0; v <= nn; v++) {
-	    evn = e + ((double) v) / n;
-	    omevn = 1.0 - evn;
-	    if (fabs(omevn) > 0.0) {
-		t = lgamnp1 - lgam((double) (v + 1))
-		    - lgam((double) (n - v + 1))
-		    + (v - 1) * log(evn)
-		    + (n - v) * log(omevn);
-		if (t > -MAXLOG)
-		    p += exp(t);
-	    }
-	}
-    }
-    return (p * e);
-}
-
+#ifndef MIN
+#define MIN(a,b) (((a) < (b)) ? (a) : (b))
+#endif
 
 /* Kolmogorov's limiting distribution of two-sided test, returns
  * probability that sqrt(n) * max deviation > y,
@@ -94,44 +57,6 @@ double kolmogorov(double y)
     }
     while ((t / p) > 1.1e-16);
     return (p + p);
-}
-
-/* Functional inverse of Smirnov distribution
- * finds e such that smirnov(n,e) = p.  */
-double smirnovi(int n, double p)
-{
-    double e, t, dpde;
-    int iterations;
-
-    if (!(p > 0.0 && p <= 1.0)) {
-	mtherr("smirnovi", DOMAIN);
-	return (NPY_NAN);
-    }
-    /* Start with approximation p = exp(-2 n e^2).  */
-    e = sqrt(-log(p) / (2.0 * n));
-    iterations = 0;
-    do {
-	/* Use approximate derivative in Newton iteration. */
-	t = -2.0 * n * e;
-	dpde = 2.0 * t * exp(t * e);
-	if (fabs(dpde) > 0.0)
-	    t = (p - smirnov(n, e)) / dpde;
-	else {
-	    mtherr("smirnovi", UNDERFLOW);
-	    return 0.0;
-	}
-	e = e + t;
-	if (e >= 1.0 || e <= 0.0) {
-	    mtherr("smirnovi", OVERFLOW);
-	    return 0.0;
-	}
-	if (++iterations > MAXITER) {
-	    mtherr("smirnovi", TOOMANY);
-	    return (e);
-	}
-    }
-    while (fabs(t / e) > 1e-10);
-    return (e);
 }
 
 
@@ -172,6 +97,471 @@ double kolmogi(double p)
     while (fabs(t / y) > 1.0e-10);
     return (y);
 }
+
+/* Now the Smirnov functions for one-sided testing. */
+
+/* For n bigger than 1028, nCv is no longer always representable in
+   64bit floating point. Back off a bit further to account for
+   the other factors in each term.
+   */
+#define MAX_N_NOLOG 1013
+
+/* Exact Smirnov statistic, for one-sided test.  */
+double smirnov(int n, double e)
+{
+    int v, nn;
+    double p;
+
+    /* This comparison should assure returning NaN whenever
+     * e is NaN itself.  In original || form it would proceed */
+    if (!(n > 0 && e >= 0.0 && e <= 1.0))
+	return (NPY_NAN);
+    if (e == 0.0)
+	return 1.0;
+    if (e == 1.0)
+	return 0.0;
+
+    nn = (int) (floor((double) n * (1.0 - e)));
+    nn = MIN(nn, n-1);
+    p = 0.0;
+    if (n < MAX_N_NOLOG) {
+	double c = 1.0;
+	double p0 = pow(1-e, (double)(n));
+	c *= n;
+	for (v = 1; v <= nn; v++) {
+	    double evn = e + ((double) v) / n;
+	    double omevn = 1.0-evn;
+	    double t;
+	    if (omevn <= 0) {
+		continue;
+	    }
+	    t = c * pow(evn, (double)(v - 1)) * pow(omevn, (double)(n - v));
+	    if (t == 0) {
+		/* Can happen if one of the two pow()'s above is very small so 0 is returned.
+		  Even though the full product would be non-zero, the order matters.
+		  Redo but include the pow()s half at a time.*/
+		double v2 = ((double)(v-1))/2;
+		int nmv2 = ((double)(n-v))/2;
+		double pwhalf = pow(evn, (double)v2) * pow(omevn, (double)nmv2);
+		if (pwhalf != 0) {
+		    t = (pwhalf * c) * pwhalf;
+		}
+	    }
+	    p += t;
+	    /* Next combinatorial term; worst case error = 4e-15.  */
+	    c *= ((double) (n - v)) / (v + 1);
+	}
+	p = p*e + p0;
+	return p;
+    }
+    else {
+	double lgamnp1 = lgam((double) (n + 1));
+	double lt, lc = 0.0;
+	for (v = 0; v <= nn; v++) {
+	    double evn = e + ((double) v) / n;
+	    if (1-evn <= 0) {
+		continue;
+	    }
+	    lc = lgamnp1 - lgam((double)(v + 1)) - lgam((double)(n - v + 1));
+	    lt = lc + (v - 1) * log(evn)  + (n - v) * log1p(-evn);
+	    if (lt >= -MAXLOG) {
+		p += exp(lt);
+	    }
+	}
+	p *= e;
+    }
+    return p;
+}
+
+
+/* Derivative of smirnov(n, x)
+
+    smirnov(n, x) = sum f_v(x)  over {v : 0 <= v <= (n-1)*x}
+    f_v  = nCv * x * pow(xvn, v-1) * pow(omxvn, n-v)     [but special case v=0,1,n below]
+    f_v' = nCv *     pow(xvn, v-2) * pow(omxvn, n-v-1) * (xvn*omxvn + (v-1)*x*omxvn -(n-v)*x*xvn)
+      where xvn = 1+v/n, omxvn = 1-xvn = 1-x-v/n
+    Specializations for v=0,1,n
+    f_0 = pow(omxvn, n)
+    f_1 = n * x * pow(omxvn, n-1)
+    f_n = x * pow(xvn, n-1)
+    f_v(x) has a zero of order (n-v) at x=(1-v/n) for v=0,1,...n-1;
+      and f_n(x) has a simple zero at x=0
+    As the zero of f_(n-1) at x=1/n is only a simple zero, there is a
+      discontinuity in smirnovp at x=1/n, and a fixable one at x=0.
+    smirnovp is continuous at all other values of x.
+
+    Note that the terms in these products can have wildly different magnitudes.
+    If one of the pow()s in the product is "zero", recalculate the product
+    in pieces and different order to avoid underflow.
+*/
+
+/* Use for small values of n, where nCv is representable as a double */
+static double smirnovp_pow(int n, double x)
+{
+    int v, nn;
+    double xvn, omxvn, pp, t;
+    double c = 1.0; /* Holds the nCv combinations value */
+
+    assert(n > 1);
+    assert(x > 0);
+    assert(x < 1);
+
+    nn = (int)floor(n * (1.0 - x));
+    /* The f_n term is not needed, and would introduce an inconvenient discontuity at x = 0.
+    Should only appear if x == 0 (or x is less than DBL_EPSILON, so that 1-x==1) */
+    nn = MIN(nn, n-1);
+    pp = 0.0;
+
+    /* Pull out v=0 */
+    pp = c * pow(1-x, n-1) * (-n);
+    c *= n;
+    for (v = 1; v <= nn; v++) {
+	xvn = x + ((double) v) / n;
+	omxvn = 1.0 - xvn;
+	if (omxvn <= 0.0) {  /* rounding issue */
+	    continue;
+	}
+	if (v == 1) {
+	    double coeff = (omxvn - (n-1)*x);
+	    if (coeff != 0) {
+		t = c * pow(omxvn, n-2) * coeff;
+		if (t == 0) {
+		    double nmv2 = (n-v-1)/2.0;
+		    double powhf = pow(omxvn, nmv2);
+		    if (powhf != 0) {
+			t = (powhf * c) * coeff * powhf;
+		    }
+		}
+		pp += t;
+	    }
+	}
+	else {
+	    double coeff = (xvn * omxvn + (v-1)*x*omxvn - (n-v) * x * xvn);
+	    if (coeff != 0) {
+		t = c * pow(omxvn, n - v -1) * pow(xvn, v - 2) * coeff;
+		if (t == 0) {
+		    double v2 = (v-2)/2.0;
+		    double nmv2 = (n-v-1)/2.0;
+		    double pwhalf = pow(xvn, v2) * pow(omxvn, nmv2);
+		    if (pwhalf != 0) {
+			t = (pwhalf * c) * coeff * pwhalf;
+		    }
+		}
+		pp += t;
+	    }
+	}
+	/* Next combinatorial term; worst case error = 4e-15.  */
+	c *= ((double) (n - v)) / (v + 1);
+    }
+    return pp;
+}
+
+/* Needed for larger values of n.
+   nCv is not always representable as a double if N >= 1028.
+   Use log(gamma(m+1)) and exponentiate later */
+static double smirnovp_gamma(int n, double x)
+{
+    int v, nn;
+    double xvn, omxvn, pp, t;
+
+    assert(n > 1);
+    assert(x > 0);
+    assert(x < 1);
+
+    nn = (int)floor(n * (1.0 - x));
+    /* The f_n term is not needed, and would introduce an additional
+        discontinuity at x = 0, so drop it.
+       nn=n  <==>  x == 0 (or x is less than DBL_EPSILON, so that 1-x=1) */
+    nn = MIN(nn, n-1);
+    pp = 0.0;
+    {
+	double logn = log((double) (n));
+	double lgamnp1 = lgam((double) (n + 1));
+	/* Pull out v=0 */
+	t = (n-1) * log1p(-x) + logn;
+	if (t > -MAXLOG) {
+	    pp = -exp(t);
+	}
+
+	for (v = 1; v <= nn; v++) {
+	    int signcoeff = 1;
+	    xvn = x + ((double) v) / n;
+	    omxvn = 1.0 - xvn;
+	    if (fabs(omxvn) <= 0.0) {
+		continue;
+	    }
+	    if (v == 1) {
+		/* f_1' = nC1 * pow(omxvn, n-2) * (omxvn-(n-1)x)*/
+		double coeff = (omxvn - (n-1)*x);
+		if (coeff == 0) {
+		    continue;
+		}
+		if (coeff < 0) {
+		    signcoeff = -1;
+		    coeff = -coeff;
+		}
+		t = (n-2) * log1p(-xvn) + log(coeff)+ logn;
+	    }
+	    else {
+		/*  f_v' = nCv * pow(xvn, v-2) * pow(omxvn, n-v-1) *
+			(xvn*omxvn + (v-1)*x*omxvn -(n-v)*x*xvn)   */
+		double lc;
+		double coeff = (xvn * omxvn) + (v-1)*x*omxvn - (n-v) * x * xvn;
+		if (coeff == 0) {
+		    continue;
+		}
+		if (coeff < 0) {
+		    signcoeff = -1;
+		    coeff = -coeff;
+		}
+		lc = (lgamnp1 - lgam((double)(v+1)) - lgam((double)(n-v+1)));
+		t = (v-2) * log(xvn) + (n-v-1) * log1p(-xvn);
+		t += lc + log(coeff);
+	    }
+	    if (t > -MAXLOG) {
+		pp += signcoeff * exp(t);
+	    }
+	}
+    }
+    return pp;
+}
+
+
+/* Derivative of smirnov(n, x)
+   One point of discontinuity at x=1/n
+*/
+double smirnovp(int n, double x)
+{
+    /* This comparison should assure returning NaN whenever
+     * x is NaN itself.  */
+    if (!(n > 0 && x >= 0.0 && x <= 1.0)) {
+	return (NPY_NAN);
+    }
+    if (n == 1) {
+	 /* Slope is always -1 for n ==1, even at x = 1.0 */
+	 return -1.0;
+    }
+    if (x == 1.0) {
+	return -0.0;
+    }
+    /* If x is 0, the derivative is discontinuous, but approaching
+       from the right the limit is -1 */
+    if (x == 0.0) {
+	return -1.0;
+    }
+    /* If n is too big, calculate using logs */
+    if (n < MAX_N_NOLOG) {
+	return smirnovp_pow(n, x);
+    }
+    return smirnovp_gamma(n, x);
+}
+
+
+static double _xtol = 2e-14;
+static double _rtol = 4*DBL_EPSILON;
+
+static int _within_tol(double x, double y, double atol, double rtol)
+{
+    double diff = fabs(x-y);
+    int result = (diff <=  (atol + rtol * fabs(y)));
+    return result;
+}
+
+#define MAX_BISECTION_STEPS 10
+#define MIN_N_ADJUST_ESTIMATE 5
+
+/* Solve smirnov(n, x) == p for p in [0, 1] with constraint 0<=x<=1.
+
+    Discussion:
+    smirnov(n, _) is easily invertible except for
+    values of p close to the endpoints, where it can be quite brutal.
+    Useful Asymptotic formula:
+	As n -> infinity,  smirnov(n, x*sqrt(n)) ~ exp(-2 * x**2).
+    Using this approximation to generate a starting point, and then
+    approximating the derivative with the derivative of the limit
+    sometimes (often?) succeeds, but also often results in
+    slow convergence or non-convergence (indicated by a return of NPY_NAN.)
+    Either the original estimate isn't a good starting point
+    for Newton-Raphson(NR), or the derivative of the asymptote isn't close
+    enough to the actual derivative.
+
+    Current Algorithm:
+    1. First handle the two endpoints: p=0, or p=1.
+    2. Handle n==1: smirnov(1,x) = 1-x
+    3. Exactly handle the case of extremely small p with a formula.
+       (corresponds to (n-1)/n < x < 1.0).
+    4a. Generate an initial estimate for x using the asymptotic limit.
+    4b. If indications are that the initial estimate is not
+        going to be good enough, use a few bisection steps
+        to get a better initial estimate, which, importantly, is
+        on the "correct" side of the true value.
+    4c. Use Newton-Raphson to find the root, ensuring estimates stay within the interval [0,1].
+        [Instrumentation suggest it converges in ~6-10 iterations for n<=100.]
+
+    Note on 3.
+    Small p (extremely small!):
+     smirnov(n, x) = (1-x)**n,     if n*(1-x) <= 1, so
+     smirnovi(n, p) = 1-p**(1/n),  if p is small enough, log(p) < -n*log(n).
+    Asymptotically this cutoff handles fewer and fewer values of p,
+    but smirnov(n, x) is not smooth at (1-1/n), so it is still useful.
+
+    Note on 4b.  The estimate is always > correct value of x.
+	 This can present a big problem if the true value lies on
+	 the "sloped" part of the graph, but the initial estimate lies on
+	  the "flat" part of the graph, (or if the estimate is bigger than 1.)
+     For x about 1/sqrt(n), should be OK.
+     For x >> 1/sqrt(n), then the problems appear.
+
+    Alternative approaches considered.
+    1. Only use bisection.
+       Pros: Convergence guaranteed.
+       Cons: Many iterations required to be within same tolerance.
+    2. Use a smarter bracketing algorithm, such as a modified false position or brentq.
+       Pros: Faster convergence than bisection.
+       Cons: Exists elsewhere in scipy (scipy.optimize) but not easily
+	     callable from here, so an implementation needed.
+       [This was tested from the Python side, and brentq had fewer correct digits with
+       the same number of iterations than did this combination of bisection & NR.]
+
+    Using the derivative results in needing fewer iterations
+    to achieve same (or better) accuracy.
+*/
+
+/* Functional inverse of Smirnov distribution
+ * finds x such that smirnov(n, x) = p.  */
+double smirnovi(int n, double p)
+{
+
+    double x, logp;
+    int iterations = 0;
+    int function_calls = 0;
+    double sqrtn;
+
+    if (!(n > 0 && p >= 0.0 && p <= 1.0)) {
+	mtherr("smirnovi", DOMAIN);
+	return (NPY_NAN);
+    }
+    if (p == 0.0) {
+	return 1.0;
+    } else if (p == 1.0) {
+	return 0.0;
+    } else if (n == 1) {
+	return 1-p;
+    }
+
+    /* Handle p *very* close to 0.  Correspond to (n-1)/n < x < 1  */
+    logp = log(p);
+    if (logp < -n * log(n)) {
+	x = - expm1(logp / n);
+	return x;
+    }
+
+    sqrtn = sqrt(n);
+    /* Start with approximation of x from smirnov(n, sqrt(n)*x) ~ exp(-2 n x^2) */
+    x = sqrt(-logp / (2.0 * n));
+    x = MIN(x, (n-1.0)/n);
+
+    if (n >= MIN_N_ADJUST_ESTIMATE && x > 1/sqrtn) {
+	/* Do some bisections to get an estimate close enough to use NR.
+	 If final is [low, high]:
+	   a) If high < sqrt(n), use x = high/n.
+	   b) If low > sqrt(n), use x = low/n
+	   c) Otherwise use x = (low+high)/2/n
+
+	 On the interval [j/n, (j+1)/n], smirnov(n, x) is a poly of degree n
+	 and NR will converge quickly after it gets close enough.
+	 */
+	int high = (int)ceil(n * x);
+	int low = 0;
+	high = MIN(high, n-1);
+	if (x >= 2/sqrtn) {
+	    low = (int)floor(sqrtn);
+	}
+	assert(smirnov(n, low*1.0/n) >= p);
+	function_calls++;
+	do {
+	    int idx = (int)((low+high)/2);
+	    double xidx = idx*1.0/n;
+	    double fidx = smirnov(n, xidx);
+	    ++function_calls;
+	    /* If fidx is NAN, that is actually ok.
+	       Just means we need to start further to the left. */
+	    if (npy_isnan(fidx) || fidx < p) {
+		high = idx;
+	    } else if (fidx == p) {
+		return xidx;
+	    } else if (fidx > p) {
+		assert (fidx > p);
+		low = idx;
+	    }
+	    if (++iterations >= MAX_BISECTION_STEPS) {
+		break;
+	    }
+	} while (low < high - 1);
+	x = (low > sqrtn ? low : (high < sqrtn ? high : (low+high)/2.0));
+	x /= n;
+    }
+    assert (x < 1);
+
+    /* smirnov should be well-enough behaved for NR starting at this location */
+    do {
+	double deriv, diff, x0 = x, deltax, val;
+	assert(x < 1);
+	assert(x > 0);
+
+	val = smirnov(n, x0);
+	++function_calls;
+	diff = val - p;
+	if (diff == 0) {
+	    return x;
+	}
+	deriv = smirnovp(n, x0);
+	++function_calls;
+	if (deriv == 0) {
+	    /* x was not within tolerance, but now we hit a 0 derivative.
+	    This implies that x >> 1/sqrt(n), and even then |smirnovp| >= |smirnov|
+	    so this condition is unexpected. */
+	    mtherr("smirnovi", UNDERFLOW);
+	    return (NPY_NAN);
+	}
+
+	deltax = diff / deriv;
+	x = x0 - deltax;
+	/* Check out-of-bounds.
+	Not expecting this to happen --- smirnov is convex near x=1 and
+	  concave near x=0, and we should be approaching from
+	  the "correct" side.
+	  If out-of-bounds, replace x with a value halfway
+	  to the endpoint. */
+	if (x <= 0) {
+	    x = x0 / 2;
+	    if (x <= 0.0) {
+		return 0;
+	    }
+	} else if (x >= 1) {
+	    x = (x0+1)/2;
+	    if (x >= 1.0) {
+		/* Could happen if true value of x lies in interval [1-DBL_EPSILON, 1]
+		Requires p**(1/n) < DBL_EPSILON, which is uncommon. */
+		return 1.0;
+	    }
+	}
+	/* Note that if p is close to 1, f(x) -> 1, f'(x) -> -1.
+	   => abs difference |x-x0| is approx |f(x)-p| >= DBL_EPSILON,
+	   => |x-x0|/x >= DBL_EPSILON/x.
+	   => cannot use a purely relative criteria as it will fail for x close to 0.
+	*/
+	if (_within_tol(x, x0, _xtol, _rtol)) {
+	    break;
+	}
+	if (++iterations > MAXITER) {
+	    mtherr("smirnovi", TOOMANY);
+	    return (x);
+	}
+    } while (1);
+    return x;
+}
+
 
 
 /* Type in a number.  */

--- a/scipy/special/cython_special.pxd
+++ b/scipy/special/cython_special.pxd
@@ -214,6 +214,7 @@ cdef void sici(Dd_number_t x0, Dd_number_t *y0, Dd_number_t *y1) nogil
 cpdef double sindg(double x0) nogil
 cpdef double smirnov(dl_number_t x0, double x1) nogil
 cpdef double smirnovi(dl_number_t x0, double x1) nogil
+cpdef double smirnovp(dl_number_t x0, double x1) nogil
 cpdef Dd_number_t spence(Dd_number_t x0) nogil
 cpdef double complex sph_harm(dl_number_t x0, dl_number_t x1, double x2, double x3) nogil
 cpdef double stdtr(double x0, double x1) nogil

--- a/scipy/special/cython_special.pyx
+++ b/scipy/special/cython_special.pyx
@@ -903,6 +903,11 @@ Available Functions
         double smirnovi(long, double)
         double smirnovi(double, double)
 
+- :py:func:`~scipy.special.smirnovp`::
+
+        double smirnovp(long, double)
+        double smirnovp(double, double)
+
 - :py:func:`~scipy.special.spence`::
 
         double spence(double)
@@ -1586,6 +1591,11 @@ cdef extern from "_ufuncs_defs.h":
 from _legacy cimport smirnovi_unsafe as _func_smirnovi_unsafe
 ctypedef double _proto_smirnovi_unsafe_t(double, double) nogil
 cdef _proto_smirnovi_unsafe_t *_proto_smirnovi_unsafe_t_var = &_func_smirnovi_unsafe
+cdef extern from "_ufuncs_defs.h":
+    cdef npy_double _func_smirnovp "smirnovp"(npy_int, npy_double)nogil
+from _legacy cimport smirnovp_unsafe as _func_smirnovp_unsafe
+ctypedef double _proto_smirnovp_unsafe_t(double, double) nogil
+cdef _proto_smirnovp_unsafe_t *_proto_smirnovp_unsafe_t_var = &_func_smirnovp_unsafe
 cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_spence "spence"(npy_double)nogil
 from _spence cimport cspence as _func_cspence
@@ -3179,6 +3189,15 @@ cpdef double smirnovi(dl_number_t x0, double x1) nogil:
         return _func_smirnovi(x0, x1)
     elif dl_number_t is double:
         return _func_smirnovi_unsafe(x0, x1)
+    else:
+        return NPY_NAN
+
+cpdef double smirnovp(dl_number_t x0, double x1) nogil:
+    """See the documentation for scipy.special.smirnovp"""
+    if dl_number_t is long:
+        return _func_smirnovp(x0, x1)
+    elif dl_number_t is double:
+        return _func_smirnovp_unsafe(x0, x1)
     else:
         return NPY_NAN
 

--- a/scipy/special/generate_ufuncs.py
+++ b/scipy/special/generate_ufuncs.py
@@ -162,6 +162,7 @@ pdtri -- pdtri: id->d, pdtri_unsafe: dd->d                 -- cephes.h, _legacy.
 yn -- yn: id->d, yn_unsafe: dd->d                          -- cephes.h, _legacy.pxd
 smirnov -- smirnov: id->d, smirnov_unsafe: dd->d           -- cephes.h, _legacy.pxd
 smirnovi -- smirnovi: id->d, smirnovi_unsafe: dd->d        -- cephes.h, _legacy.pxd
+smirnovp -- smirnovp: id->d, smirnovp_unsafe: dd->d        -- cephes.h, _legacy.pxd
 airy -- airy_wrap: d*dddd->*i, cairy_wrap: D*DDDD->*i      -- amos_wrappers.h
 itairy -- itairy_wrap: d*dddd->*i                          -- specfun_wrappers.h
 airye -- cairy_wrap_e_real: d*dddd->*i, cairy_wrap_e: D*DDDD->*i -- amos_wrappers.h

--- a/scipy/special/tests/test_cython_special.py
+++ b/scipy/special/tests/test_cython_special.py
@@ -255,6 +255,7 @@ def test_cython_api():
         (special.sindg, cython_special.sindg, ('d',), None),
         (special.smirnov, cython_special.smirnov, ('ld', 'dd'), None),
         (special.smirnovi, cython_special.smirnovi, ('ld', 'dd'), None),
+        (special.smirnovp, cython_special.smirnovp, ('ld', 'dd'), None),
         (special.spence, cython_special.spence, ('d', 'D'), None),
         (special.sph_harm, cython_special.sph_harm, ('lldd', 'dddd'), None),
         (special.stdtr, cython_special.stdtr, ('dd',), None),

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -42,8 +42,18 @@ class ksone_gen(rv_continuous):
     def _cdf(self, x, n):
         return 1.0 - sc.smirnov(n, x)
 
+    def _sf(self, x, n):
+        return sc.smirnov(n, x)
+
+    def _pdf(self, x, n):
+        return -sc.smirnovp(n, x)
+
     def _ppf(self, q, n):
         return sc.smirnovi(n, 1.0 - q)
+
+    def _isf(self, q, n):
+        return sc.smirnovi(n, q)
+
 ksone = ksone_gen(a=0.0, name='ksone')
 
 


### PR DESCRIPTION
Addresses #7456, #7426, #7455 (scipy.special.smirnov, scipy.stats.ksone)
 scipy.special.{smirnov,smirnovi} have accuracy & convergence issues
 incorrect values for scipy.stats.ksone.pdf()

Add a smirnovp(), derivative of smirnov(), function.
Use smirnovp() in smirnovi() instead of an asymptotic.
If the initial estimate for x in smirnovi() is not going to work
 for Newton-Raphson (because it is on a "bad" part of the curve),
 perform some bisection steps to get a better estimate, one which
 is on the correct side of the desired value.
Replace the relative stopping criteria with same logic used in np.allclose().
With these changes, the algorithm seems to converge in
 about 5 NR iterations (10 function evaluations) for most values of p.
Exposing smirnovp() allows its use in scipy.stats.ksone() which addresses
 the inaccurate pdf(). 