### PR TITLE
ENH: Addition/multiplication operators for StateSpace systems

### DIFF
--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -1294,6 +1294,7 @@ class StateSpace(LinearTimeInvariant):
 
     """
 
+    # Override Numpy binary operations and ufuncs
     __array_priority__ = 100.0
     __array_ufunc__ = None
 
@@ -1417,13 +1418,7 @@ class StateSpace(LinearTimeInvariant):
 
     def __add__(self, other):
         """
-        Add two systems
-
-        Adds two systems in the sense of frequency domain addition. That
-        means, given two systems E1(s) and E2(s), their addition,
-        H(s) = E1(s) + E2(s), means that applying H(s) to U(s)
-        is equivalent to applying E1(s) and E2(s) separately and adding up the
-        result.
+        Adds two systems in the sense of frequency domain addition.
         """
         if not self._check_binop_other(other):
             return NotImplemented
@@ -1459,7 +1454,7 @@ class StateSpace(LinearTimeInvariant):
             # A scalar/matrix is really just a static system (A=0, B=0, C=0)
             return StateSpace(self.A, self.B, self.C, self.D + other)
         else:
-            raise ValueError('Other needs to have compatible dimensions.')
+            raise ValueError("Cannot add systems with incompatible dimensions")
 
     def __sub__(self, other):
         if not self._check_binop_other(other):
@@ -1478,6 +1473,20 @@ class StateSpace(LinearTimeInvariant):
             return NotImplemented
 
         return (-self).__add__(other)
+
+    def __truediv__(self, other):
+        """
+        Divide by a scalar
+        """
+        # Division by non-StateSpace scalars
+        if not self._check_binop_other(other) or isinstance(other, StateSpace):
+            return NotImplemented
+
+        if isinstance(other, np.ndarray) and other.ndim > 0:
+            # It's ambiguous what this means, so disallow it
+            raise ValueError("Cannot divide StateSpace by non-scalar numpy arrays")
+
+        return self.__mul__(1/other)
 
     @property
     def A(self):

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -26,7 +26,7 @@ import warnings
 # np.linalg.qr fails on some tests with LinAlgError: zgeqrf returns -7
 # use scipy's qr until this is solved
 
-import six
+import scipy._lib.six as six
 from scipy.linalg import qr as s_qr
 from scipy import integrate, interpolate, linalg
 from scipy.interpolate import interp1d

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -13,7 +13,7 @@ from scipy.signal import (ss2tf, tf2ss, lsim2, impulse2, step2, lti,
 from scipy.signal.filter_design import BadCoefficients
 import scipy.linalg as linalg
 
-import six
+import scipy._lib.six as six
 
 
 def _assert_poles_close(P1,P2, rtol=1e-8, atol=1e-8):

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -814,12 +814,24 @@ class TestStateSpace(object):
             assert_allclose(lsim(typ(2) * s1, U=u, T=t)[1],
                             typ(2) * lsim(s1, U=u, T=t)[1])
 
+            assert_allclose(lsim(s1 * typ(2), U=u, T=t)[1],
+                            lsim(s1, U=u, T=t)[1] * typ(2))
+
+            assert_allclose(lsim(s1 / typ(2), U=u, T=t)[1],
+                            lsim(s1, U=u, T=t)[1] / typ(2))
+
+            with assert_raises(TypeError):
+                typ(2) / s1
+
         assert_allclose(lsim(s1 * 2, U=u, T=t)[1],
                         lsim(s1, U=2 * u, T=t)[1])
 
         assert_allclose(lsim(s1 * s2, U=u, T=t)[1],
                         lsim(s1, U=lsim(s2, U=u, T=t)[1], T=t)[1],
                         atol=1e-5)
+
+        with assert_raises(TypeError):
+            s1 / s1
 
         with assert_raises(TypeError):
             s1 * s_discrete
@@ -834,6 +846,12 @@ class TestStateSpace(object):
         with assert_raises(TypeError):
             BadType() * s1
 
+        with assert_raises(TypeError):
+            s1 / BadType()
+
+        with assert_raises(TypeError):
+            BadType() / s1
+
         # Test addition
         assert_allclose(lsim(s1 + 2, U=u, T=t)[1],
                         2 * u + lsim(s1, U=u, T=t)[1])
@@ -847,6 +865,9 @@ class TestStateSpace(object):
 
         with assert_raises(TypeError):
             s1 + s_discrete
+
+        with assert_raises(ValueError):
+            s1 / np.array([[1, 2], [3, 4]])
 
         with assert_raises(TypeError):
             # Check different discretization constants
@@ -864,6 +885,9 @@ class TestStateSpace(object):
         # Test substraction
         assert_allclose(lsim(s1 - 2, U=u, T=t)[1],
                         -2 * u + lsim(s1, U=u, T=t)[1])
+
+        assert_allclose(lsim(2 - s1, U=u, T=t)[1],
+                        2 * u + lsim(-s1, U=u, T=t)[1])
 
         assert_allclose(lsim(s1 - s2, U=u, T=t)[1],
                         lsim(s1, U=u, T=t)[1] - lsim(s2, U=u, T=t)[1])

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -780,6 +780,56 @@ class TestStateSpace(object):
         assert_equal(s.zeros, [0])
         assert_(s.dt is None)
 
+    def test_operators(self):
+        # Test +/-/* operators on systems
+        s1 = StateSpace(np.array([[-0.5, 0.7], [0.3, -0.8]]),
+                        np.array([[1], [0]]),
+                        np.array([[1, 0]]),
+                        np.array([[0]])
+                        )
+
+        s2 = StateSpace(np.array([[-0.2, -0.1], [0.4, -0.1]]),
+                        np.array([[1], [0]]),
+                        np.array([[1, 0]]),
+                        np.array([[0]])
+                        )
+
+        # Impulse response
+        t = np.linspace(0, 1, 100)
+        u = np.zeros_like(t)
+        u[0] = 1
+
+        # Test multiplication
+        assert_allclose(lsim(2 * s1, U=u, T=t)[1],
+                        2 * lsim(s1, U=u, T=t)[1])
+
+        assert_allclose(lsim(s1 * 2, U=u, T=t)[1],
+                        lsim(s1, U=2 * u, T=t)[1])
+
+        assert_allclose(lsim(s1 * s2, U=u, T=t)[1],
+                        lsim(s1, U=lsim(s2, U=u, T=t)[1], T=t)[1],
+                        atol=1e-5)
+
+        # Test addition
+        assert_allclose(lsim(s1 + 2, U=u, T=t)[1],
+                        2 * u + lsim(s1, U=u, T=t)[1])
+
+        assert_allclose(lsim(2 + s1, U=u, T=t)[1],
+                        2 * u + lsim(s1, U=u, T=t)[1])
+
+        assert_allclose(lsim(s1 + s2, U=u, T=t)[1],
+                        lsim(s1, U=u, T=t)[1] + lsim(s2, U=u, T=t)[1])
+
+        # Test substraction
+        assert_allclose(lsim(2 - s1, U=u, T=t)[1],
+                        2 * u - lsim(s1, U=u, T=t)[1])
+
+        assert_allclose(lsim(s1 - 2, U=u, T=t)[1],
+                        -2 * u + lsim(s1, U=u, T=t)[1])
+
+        assert_allclose(lsim(s1 - s2, U=u, T=t)[1],
+                        lsim(s1, U=u, T=t)[1] - lsim(s2, U=u, T=t)[1])
+
 
 class TestTransferFunction(object):
     def test_initialization(self):

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -785,7 +785,7 @@ class TestStateSpace(object):
         s1 = StateSpace(np.array([[-0.5, 0.7], [0.3, -0.8]]),
                         np.array([[1], [0]]),
                         np.array([[1, 0]]),
-                        np.array([[0]])
+                        np.array([[0]]),
                         )
 
         s2 = StateSpace(np.array([[-0.2, -0.1], [0.4, -0.1]]),
@@ -793,6 +793,9 @@ class TestStateSpace(object):
                         np.array([[1, 0]]),
                         np.array([[0]])
                         )
+
+        s_discrete = s1.to_discrete(0.1)
+        s2_discrete = s2.to_discrete(0.2)
 
         # Impulse response
         t = np.linspace(0, 1, 100)
@@ -810,20 +813,32 @@ class TestStateSpace(object):
                         lsim(s1, U=lsim(s2, U=u, T=t)[1], T=t)[1],
                         atol=1e-5)
 
+        with assert_raises(TypeError):
+            s1 * s_discrete
+
+        with assert_raises(TypeError):
+            # Check different discretization constants
+            s_discrete * s2_discrete
+
         # Test addition
         assert_allclose(lsim(s1 + 2, U=u, T=t)[1],
                         2 * u + lsim(s1, U=u, T=t)[1])
 
-        assert_allclose(lsim(2 + s1, U=u, T=t)[1],
-                        2 * u + lsim(s1, U=u, T=t)[1])
+        # Check for dimension missmatch
+        with assert_raises(ValueError):
+            s1 + np.array([1, 2])
+
+        with assert_raises(TypeError):
+            s1 + s_discrete
+
+        with assert_raises(TypeError):
+            # Check different discretization constants
+            s_discrete + s2_discrete
 
         assert_allclose(lsim(s1 + s2, U=u, T=t)[1],
                         lsim(s1, U=u, T=t)[1] + lsim(s2, U=u, T=t)[1])
 
         # Test substraction
-        assert_allclose(lsim(2 - s1, U=u, T=t)[1],
-                        2 * u - lsim(s1, U=u, T=t)[1])
-
         assert_allclose(lsim(s1 - 2, U=u, T=t)[1],
                         -2 * u + lsim(s1, U=u, T=t)[1])
 


### PR DESCRIPTION
This PR adds addition and multiplication operators for `StateSpace` systems, see also #2973. This allows for things like
```
s1 = StateSpace(1, 1, 1, 0)
s2 = SateSpace(2, 2, 2, 0)
new = s1 + s2
new = s1 - s2
new = s1 * s2
new = 2 * s2
```
These operations have a frequency-domain interpretation, where adding means the systems operate in parallel and their output is added, while multiplying `s1 * s2` means that the output of `s2` is applied as the input to system `s1`.