### PR TITLE
MAINT: Clean-up uses of np.asarray in ndimage

### DIFF
--- a/scipy/ndimage/filters.py
+++ b/scipy/ndimage/filters.py
@@ -1066,11 +1066,10 @@ def _min_or_max_filter(input, size, footprint, structure, output, mode,
                 raise RuntimeError("no footprint provided")
             separable = True
         else:
-            footprint = numpy.asarray(footprint)
-            footprint = footprint.astype(bool)
+            footprint = numpy.asarray(footprint, dtype=bool)
             if not footprint.any():
                 raise ValueError("All-zero footprint is not supported.")
-            if numpy.alltrue(numpy.ravel(footprint), axis=0):
+            if footprint.all():
                 size = footprint.shape
                 footprint = None
                 separable = True
@@ -1082,8 +1081,7 @@ def _min_or_max_filter(input, size, footprint, structure, output, mode,
         if footprint is None:
             footprint = numpy.ones(structure.shape, bool)
         else:
-            footprint = numpy.asarray(footprint)
-            footprint = footprint.astype(bool)
+            footprint = numpy.asarray(footprint, dtype=bool)
     input = numpy.asarray(input)
     if numpy.iscomplexobj(input):
         raise TypeError('Complex type not supported')
@@ -1519,8 +1517,7 @@ def generic_filter(input, function, size=None, footprint=None,
         sizes = _ni_support._normalize_sequence(size, input.ndim)
         footprint = numpy.ones(sizes, dtype=bool)
     else:
-        footprint = numpy.asarray(footprint)
-        footprint = footprint.astype(bool)
+        footprint = numpy.asarray(footprint, dtype=bool)
     fshape = [ii for ii in footprint.shape if ii > 0]
     if len(fshape) != input.ndim:
         raise RuntimeError('filter footprint array has incorrect shape.')

--- a/scipy/ndimage/morphology.py
+++ b/scipy/ndimage/morphology.py
@@ -205,13 +205,10 @@ def generate_binary_structure(rank, connectivity):
     if connectivity < 1:
         connectivity = 1
     if rank < 1:
-        if connectivity < 1:
-            return numpy.array(0, dtype=bool)
-        else:
-            return numpy.array(1, dtype=bool)
+        return numpy.array(True, dtype=bool)
     output = numpy.fabs(numpy.indices([3] * rank) - 1)
     output = numpy.add.reduce(output, 0)
-    return numpy.asarray(output <= connectivity, dtype=bool)
+    return output <= connectivity
 
 
 def _binary_erosion(input, structure, iterations, mask, output,
@@ -222,8 +219,7 @@ def _binary_erosion(input, structure, iterations, mask, output,
     if structure is None:
         structure = generate_binary_structure(input.ndim, 1)
     else:
-        structure = numpy.asarray(structure)
-        structure = structure.astype(bool)
+        structure = numpy.asarray(structure, dtype=bool)
     if structure.ndim != input.ndim:
         raise RuntimeError('structure and input must have same dimensionality')
     if not structure.flags.contiguous:
@@ -257,11 +253,7 @@ def _binary_erosion(input, structure, iterations, mask, output,
             if not structure.shape[ii] & 1:
                 origin[ii] -= 1
         if mask is not None:
-            msk = numpy.asarray(mask)
-            msk = mask.astype(numpy.int8)
-            if msk is mask:
-                msk = mask.copy()
-            mask = msk
+            mask = numpy.asarray(mask, dtype=numpy.int8)
         if not structure.flags.contiguous:
             structure = structure.copy()
         _nd_image.binary_erosion2(output, structure, mask, iterations - 1,


### PR DESCRIPTION
Originally about avoiding unnecessary copies being made by calling `.astype()` afterwards, rather than including the desired `dtype` in the call to `asarray()`.

Have also included removing some unreachable code paths and some unnecessary checks.