### PR TITLE
Correcting typo in documentation

### DIFF
--- a/scipy/special/_spherical_bessel.py
+++ b/scipy/special/_spherical_bessel.py
@@ -37,9 +37,9 @@ def spherical_jn(n, z, derivative=False):
     The derivative is computed using the relations [3]_,
 
     .. math::
-        j_n' = j_{n-1} - \frac{n + 1}{2} j_n.
+        j_n'(z) = j_{n-1}(z) - \frac{n + 1}{z} j_n(z).
 
-        j_0' = -j_1
+        j_0'(z) = -j_1(z)
 
 
     .. versionadded:: 0.18.0


### PR DESCRIPTION
There is a wrong factor of 2 in the relations used to compute the derivative of the spherical Bessel function. The function j_n' should have a factof or 1/z in the second term, rather than 1/2, as stated in the reference.

Edit: the typo only appears in the documentation. The function scipy.special.spherical_jn behaves as it should.