### PR TITLE
BUG: Make sure fs2 is float in _zpkbilinear

### DIFF
--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -1951,7 +1951,7 @@ def _zpkbilinear(z, p, k, fs):
 
     degree = _relative_degree(z, p)
 
-    fs2 = 2*fs
+    fs2 = 2.0*fs
 
     # Bilinear transform the poles and zeros
     z_z = (fs2 + z) / (fs2 - z)


### PR DESCRIPTION
This function is still private and so there are no problems in
production code (fs is always 2.0), but when trying to use it
standalone, if fs and z are integer type (which is common),
`prod(fs2 - z)` can overflow and `k` will be 0.