### PR TITLE
MAINT: remove overflow in Metropolis fixes #7495

### DIFF
--- a/scipy/optimize/_basinhopping.py
+++ b/scipy/optimize/_basinhopping.py
@@ -296,7 +296,7 @@ class Metropolis(object):
         self.random_state = check_random_state(random_state)
 
     def accept_reject(self, energy_new, energy_old):
-        w = min(1.0, np.exp(-(energy_new - energy_old) * self.beta))
+        w = np.exp(min(0, -(energy_new - energy_old) * self.beta))
         rand = self.random_state.rand()
         return w >= rand
 

--- a/scipy/optimize/tests/test__basinhopping.py
+++ b/scipy/optimize/tests/test__basinhopping.py
@@ -390,6 +390,13 @@ class Test_Metropolis(TestCase):
         assert_(one_accept)
         assert_(one_reject)
 
+    def test_GH7495(self):
+        # an overflow in exp was producing a RuntimeWarning
+        # create own object here in case someone changes self.T
+        met = Metropolis(2)
+        with np.errstate(over='raise'):
+            met.accept_reject(0, 2000)
+
 
 class Test_AdaptiveStepsize(TestCase):
     def setUp(self):


### PR DESCRIPTION
A RuntimeWarning was being raised from [np.exp](https://github.com/scipy/scipy/blob/master/scipy/optimize/_basinhopping.py#L299) if it's argument was too large. This change compares the exponent first, which should prevent the overflow error.
