### PR TITLE
TST: speed up full test suite by less eval points in mpmath tests.

### DIFF
--- a/scipy/special/_mptestutils.py
+++ b/scipy/special/_mptestutils.py
@@ -1,5 +1,6 @@
 from __future__ import division, print_function, absolute_import
 
+import os
 import sys
 import time
 
@@ -129,13 +130,25 @@ def get_args(argspec, n):
         args = np.array(np.broadcast_arrays(*np.ix_(*args))).reshape(nargs, -1).T
 
     return args
-    
+
 
 class MpmathData(object):
     def __init__(self, scipy_func, mpmath_func, arg_spec, name=None,
-                 dps=None, prec=None, n=5000, rtol=1e-7, atol=1e-300,
+                 dps=None, prec=None, n=None, rtol=1e-7, atol=1e-300,
                  ignore_inf_sign=False, distinguish_nan_and_inf=True,
                  nan_ok=True, param_filter=None):
+
+        # mpmath tests are really slow (see gh-6989).  Use a small number of
+        # points by default, increase back to 5000 (old default) if XSLOW is
+        # set
+        if n is None:
+            try:
+                is_xslow = int(os.environ.get('SCIPY_XSLOW', '0'))
+            except ValueError:
+                is_xslow = False
+
+            n = 5000 if is_xslow else 500
+
         self.scipy_func = scipy_func
         self.mpmath_func = mpmath_func
         self.arg_spec = arg_spec

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -1336,9 +1336,11 @@ class TestSystematic(with_metaclass(DecoratorMeta, object)):
     def test_hyp0f1(self):
         # mpmath reports no convergence unless maxterms is large enough
         KW = dict(maxprec=400, maxterms=1500)
+        # n=500 (non-xslow default) fails for one bad point
         assert_mpmath_equal(sc.hyp0f1,
                             lambda a, x: mpmath.hyp0f1(a, x, **KW),
-                            [Arg(-1e7, 1e7), Arg(0, 1e5)])
+                            [Arg(-1e7, 1e7), Arg(0, 1e5)],
+                            n=5000)
         # NB: The range of the second parameter ("z") is limited from below
         # because of an overflow in the intermediate calculations. The way
         # for fix it is to implement an asymptotic expansion for Bessel J
@@ -1733,9 +1735,11 @@ class TestSystematic(with_metaclass(DecoratorMeta, object)):
             else:
                 v = mpmath.rgamma(x)
             return v
+        # n=500 (non-xslow default) fails for one bad point
         assert_mpmath_equal(sc.rgamma,
                             rgamma,
                             [Arg()],
+                            n=5000,
                             ignore_inf_sign=True)
 
     def test_rgamma_complex(self):


### PR DESCRIPTION
This will address the TravisCI timeouts we're experiencing.

Closes gh-6989.