### PR TITLE
fix some alerts found with lgtm

### DIFF
--- a/scipy/cluster/vq.py
+++ b/scipy/cluster/vq.py
@@ -425,9 +425,8 @@ def _kmeans(obs, guess, thresh=1e-5):
         obs_code, distort = vq(obs, code_book)
         avg_dist.append(np.mean(distort, axis=-1))
         # recalc code_book as centroids of associated obs
-        if(diff > thresh):
-            code_book, has_members = _vq.update_cluster_means(obs, obs_code, nc)
-            code_book = code_book.compress(has_members, axis=0)
+        code_book, has_members = _vq.update_cluster_means(obs, obs_code, nc)
+        code_book = code_book.compress(has_members, axis=0)
         if len(avg_dist) > 1:
             diff = avg_dist[-2] - avg_dist[-1]
 

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -851,7 +851,7 @@ def make_lsq_spline(x, y, t, k=3, w=None, axis=0, check_finite=True):
     if x.ndim != 1 or np.any(x[1:] - x[:-1] <= 0):
         raise ValueError("Expect x to be a 1-D sorted array_like.")
     if x.shape[0] < k+1:
-        raise("Need more x points.")
+        raise ValueError("Need more x points.")
     if k < 0:
         raise ValueError("Expect non-negative k.")
     if t.ndim != 1 or np.any(t[1:] - t[:-1] < 0):

--- a/scipy/io/harwell_boeing/_fortran_format_parser.py
+++ b/scipy/io/harwell_boeing/_fortran_format_parser.py
@@ -203,9 +203,8 @@ class Tokenizer(object):
                 else:
                     self.curpos = m.end()
                     return Token(self.tokens[i], m.group(), self.curpos)
-            else:
-                raise SyntaxError("Unknown character at position %d (%s)"
-                                  % (self.curpos, self.data[curpos]))
+            raise SyntaxError("Unknown character at position %d (%s)"
+                              % (self.curpos, self.data[curpos]))
 
 
 # Grammar for fortran format:

--- a/scipy/linalg/special_matrices.py
+++ b/scipy/linalg/special_matrices.py
@@ -854,9 +854,9 @@ def pascal(n, kind='symmetric', exact=True):
     else:
         L_n = comb(*np.ogrid[:n, :n])
 
-    if kind is 'lower':
+    if kind == 'lower':
         p = L_n
-    elif kind is 'upper':
+    elif kind == 'upper':
         p = L_n.T
     else:
         p = np.dot(L_n, L_n.T)

--- a/scipy/optimize/nonlin.py
+++ b/scipy/optimize/nonlin.py
@@ -543,7 +543,7 @@ class Jacobian(object):
         self.dtype = F.dtype
         if self.__class__.setup is Jacobian.setup:
             # Call on the first point unless overridden
-            self.update(self, x, F)
+            self.update(x, F)
 
 
 class InverseJacobian(object):

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -3494,7 +3494,7 @@ def ellipap(N, rp, rs):
                       disp=0)
     if m < 0 or m > 1:
         m = optimize.fminbound(_kratio, 0, 1, args=(krat,), maxfun=250,
-                               maxiter=250, disp=0)
+                               disp=0)
 
     capk = special.ellipk(m)
 

--- a/scipy/sparse/linalg/_expm_multiply.py
+++ b/scipy/sparse/linalg/_expm_multiply.py
@@ -602,13 +602,13 @@ def _expm_multiply_interval(A, B, start=None, stop=None,
         else:
             return _expm_multiply_interval_core_0(A, X,
                     h, mu, q, norm_info, tol, ell,n0)
-    elif q > s and not (q % s):
+    elif not (q % s):
         if status_only:
             return 1
         else:
             return _expm_multiply_interval_core_1(A, X,
                     h, mu, m_star, s, q, tol)
-    elif q > s and (q % s):
+    elif (q % s):
         if status_only:
             return 2
         else:

--- a/scipy/sparse/linalg/eigen/arpack/setup.py
+++ b/scipy/sparse/linalg/eigen/arpack/setup.py
@@ -14,7 +14,7 @@ def configuration(parent_package='',top_path=None):
     if not lapack_opt:
         raise NotFoundError('no lapack/blas resources found')
 
-    config = Configuration('arpack',parent_package,top_path)
+    config = Configuration('arpack', parent_package, top_path)
 
     arpack_sources = [join('ARPACK','SRC', '*.f')]
     arpack_sources.extend([join('ARPACK','UTIL', '*.f')])

--- a/scipy/sparse/linalg/eigen/arpack/setup.py
+++ b/scipy/sparse/linalg/eigen/arpack/setup.py
@@ -9,12 +9,12 @@ def configuration(parent_package='',top_path=None):
     from numpy.distutils.misc_util import Configuration
     from scipy._build_utils import get_g77_abi_wrappers, get_sgemv_fix
 
-    config = Configuration('arpack',parent_package,top_path)
-
     lapack_opt = get_info('lapack_opt')
 
     if not lapack_opt:
         raise NotFoundError('no lapack/blas resources found')
+
+    config = Configuration('arpack',parent_package,top_path)
 
     arpack_sources = [join('ARPACK','SRC', '*.f')]
     arpack_sources.extend([join('ARPACK','UTIL', '*.f')])

--- a/scipy/sparse/linalg/eigen/arpack/setup.py
+++ b/scipy/sparse/linalg/eigen/arpack/setup.py
@@ -16,8 +16,6 @@ def configuration(parent_package='',top_path=None):
     if not lapack_opt:
         raise NotFoundError('no lapack/blas resources found')
 
-    config = Configuration('arpack', parent_package, top_path)
-
     arpack_sources = [join('ARPACK','SRC', '*.f')]
     arpack_sources.extend([join('ARPACK','UTIL', '*.f')])
 

--- a/scipy/sparse/linalg/interface.py
+++ b/scipy/sparse/linalg/interface.py
@@ -473,7 +473,7 @@ class _CustomLinearOperator(LinearOperator):
     def _rmatvec(self, x):
         func = self.__rmatvec_impl
         if func is None:
-            raise NotImplemented("rmatvec is not defined")
+            raise NotImplementedError("rmatvec is not defined")
         return self.__rmatvec_impl(x)
 
     def _adjoint(self):

--- a/scipy/special/generate_ufuncs.py
+++ b/scipy/special/generate_ufuncs.py
@@ -1120,8 +1120,8 @@ class FusedFunc(Func):
             for n, fused_type in enumerate(fused_types):
                 code = codes[n]
                 fused_codes.append(underscore(CY_TYPES[code]))
-                for n, outvar in enumerate(self.outvars):
-                    if self.outtypes[n] == fused_type:
+                for nn, outvar in enumerate(self.outvars):
+                    if self.outtypes[nn] == fused_type:
                         line = "{}[0] = {}".format(outvar, NAN_VALUE[code])
                         decs.append(line)
             if m == 0:


### PR DESCRIPTION
Hi,
I just wanted to quickly fix some alerts flagged by lgtm code queries. Most were minor/style but a few could result in a crash.

The standard lgtm deep code analysis highlights dependencies, vulnerabilities and currently flag 226 alerts for scipy (https://lgtm.com/projects/g/scipy/scipy/) - but you can investigate further by writing custom queries (https://lgtm.com/docs/ql/about-ql).

You might also want to try to turn PR integration on to get the chance to investigate new alerts before they find their way into the code base - see https://lgtm.com/docs/lgtm/config/pr-integration.

Hope that helps! and thanks for making scipy what it is :)