### PR TITLE
BUG: Fix roundoff errors in ndimage.uniform_filter1d.

### DIFF
--- a/scipy/ndimage/src/ni_filters.c
+++ b/scipy/ndimage/src/ni_filters.c
@@ -291,7 +291,7 @@ exit:
 
 int
 NI_UniformFilter1D(PyArrayObject *input, npy_intp filter_size,
-                                     int axis, PyArrayObject *output, NI_ExtendMode mode,
+                   int axis, PyArrayObject *output, NI_ExtendMode mode,
                    double cval, npy_intp origin)
 {
     npy_intp lines, kk, ll, length, size1, size2;
@@ -335,13 +335,13 @@ NI_UniformFilter1D(PyArrayObject *input, npy_intp filter_size,
             double tmp = 0.0;
             double *l1 = iline;
             double *l2 = iline + filter_size;
-            for(ll = 0; ll < filter_size; ll++)
+            for (ll = 0; ll < filter_size; ++ll) {
                 tmp += iline[ll];
-            tmp /= (double)filter_size;
-            oline[0] = tmp;
-            for(ll = 1; ll < length; ll++) {
-                tmp += (*l2++ - *l1++) / (double)filter_size;
-                oline[ll] = tmp;
+            }
+            oline[0] = tmp / filter_size;
+            for (ll = 1; ll < length; ++ll) {
+                tmp += *l2++ - *l1++;
+                oline[ll] = tmp / filter_size;
             }
         }
         /* copy lines from buffer to array: */

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -372,6 +372,14 @@ def test_minmaximum_filter1d():
     assert_equal([9, 9, 4, 5, 6, 7, 8, 9, 9, 9], out)
 
 
+def test_uniform_filter1d_roundoff_errors():
+    # gh-6930
+    in_ = np.repeat([0, 1, 0], [9, 9, 9])
+    for filter_size in range(3, 10):
+        out = sndi.uniform_filter1d(in_, filter_size)
+        assert_equal(out.sum(), 10 - filter_size)
+
+
 def test_footprint_all_zeros():
     # regression test for gh-6876: footprint of all zeros segfaults
     arr = np.random.randint(0, 100, (100, 100))


### PR DESCRIPTION
Fixes #6930.

Keep a running sum of the values in the filter, rather than a running mean, to avoid round-off errors when dealing with integer arrays.