### PR TITLE
TST: fix signal.convolve test that was effectively being skipped.

### DIFF
--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -502,28 +502,6 @@ def _np_conv_ok(volume, kernel, mode):
     return np_conv_ok and (volume.size >= kernel.size or mode != 'same')
 
 
-def _fftconvolve_valid(volume, kernel):
-    # fftconvolve doesn't support complex256
-    for not_fft_conv_supp in ["complex256", "complex192"]:
-        if hasattr(np, not_fft_conv_supp):
-            if volume.dtype == not_fft_conv_supp or kernel.dtype == not_fft_conv_supp:
-                return False
-
-    # for integer input,
-    # catch when more precision required than float provides (representing a
-    # integer as float can lose precision in fftconvolve if larger than 2**52)
-    if any([_numeric_arrays([x], kinds='ui') for x in [volume, kernel]]):
-        max_value = int(np.abs(volume).max()) * int(np.abs(kernel).max())
-        max_value *= int(min(volume.size, kernel.size))
-        if max_value > 2**np.finfo('float').nmant - 1:
-            return False
-
-    if _numeric_arrays([volume, kernel]):
-        return False
-
-    return True
-
-
 def _timeit_fast(stmt="pass", setup="pass", repeat=3):
     """
     Returns the time the statement/function took, in seconds.

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -21,7 +21,7 @@ from scipy.signal import (
     hilbert, hilbert2, lfilter, lfilter_zi, filtfilt, butter, zpk2tf, zpk2sos,
     invres, invresz, vectorstrength, lfiltic, tf2sos, sosfilt, sosfiltfilt,
     sosfilt_zi, tf2zpk)
-from scipy.signal.signaltools import _filtfilt_gust, _fftconvolve_valid
+from scipy.signal.signaltools import _filtfilt_gust
 
 if sys.version_info.major >= 3 and sys.version_info.minor >= 5:
     from math import gcd
@@ -162,8 +162,8 @@ class TestConvolve(_TestConvolve):
 
         # These types include 'bool' and all precisions (int8, float32, etc)
         # The removed types throw errors in correlate or fftconvolve
-        for dtype in ['complex256', 'float128', 'str', 'void', 'bytes',
-                      'object', 'unicode', 'string']:
+        for dtype in ['complex256', 'complex192', 'float128', 'float96',
+                      'str', 'void', 'bytes', 'object', 'unicode', 'string']:
             if dtype in types:
                 types.remove(dtype)
 
@@ -181,8 +181,6 @@ class TestConvolve(_TestConvolve):
         for t1, t2, mode in args:
             x1 = array_types[np.dtype(t1).kind].astype(t1)
             x2 = array_types[np.dtype(t2).kind].astype(t2)
-            if not _fftconvolve_valid(x1, x2):
-                continue
 
             results = {key: convolve(x1, x2, method=key, mode=mode)
                        for key in ['fft', 'direct']}


### PR DESCRIPTION
Fixes same issue as was fixed in gh-7355 (32-bit failures for
``complex192`` and ``float96``).  The fix from gh-7355 basically disabled
the test, because ``_fftconvolve_valid`` just doesn't work
(it always returns ``False``, due to the weird check for numerical
arrays at the end).

``_fftconvolve_valid`` wasn't used anywhere else, so just removed it rather than try to understand the convoluted logic in it.