### PR TITLE
MAINT: Refactor NI_LineExtend.

### DIFF
--- a/scipy/ndimage/src/ni_support.c
+++ b/scipy/ndimage/src/ni_support.c
@@ -195,125 +195,105 @@ int NI_InitLineBuffer(PyArrayObject *array, int axis, npy_intp size1,
 }
 
 /* Extend a line in memory to implement boundary conditions: */
-int NI_ExtendLine(double *line, npy_intp length, npy_intp size1,
-                  npy_intp size2, NI_ExtendMode mode, double constant_value)
+int NI_ExtendLine(double *buffer, npy_intp line_length,
+                  npy_intp size_before, npy_intp size_after,
+                  NI_ExtendMode extend_mode, double extend_value)
 {
-    npy_intp ii, jj, length1, nextend, rextend;
-    double *l1, *l2, *l3, val;
+    double *first = buffer + size_before;
+    double *last = first + line_length;
+    double *src, *dst, val;
 
-    switch (mode) {
-    case NI_EXTEND_WRAP:
-        /* deal with situation where data is shorter than needed
-           for filling the line */
-        nextend = size1 / length;
-        rextend = size1 - nextend * length;
-        l1 = line + size1 + length - rextend;
-        l2 = line;
-        for(ii = 0; ii < rextend; ii++)
-            *l2++ = *l1++;
-        for(ii = 0; ii < nextend; ii++) {
-            l1 = line + size1;
-            for(jj = 0; jj < length; jj++)
-                *l2++ = *l1++;
-        }
-        nextend = size2 / length;
-        rextend = size2 - nextend * length;
-        l1 = line + size1;
-        l2 = line + size1 + length;
-        for(ii = 0; ii < nextend; ii++) {
-            l3 = l1;
-            for(jj = 0; jj < length; jj++)
-                *l2++ = *l3++;
-        }
-        for(ii = 0; ii < rextend; ii++)
-            *l2++ = *l1++;
-        break;
-    case NI_EXTEND_MIRROR:
-        if (length == 1) {
-            l1 = line;
-            val = line[size1];
-            for(ii = 0; ii < size1; ii++)
-                *l1++ = val;
-            l1 = line + size1 + length;
-            val = line[size1 + length - 1];
-            for(ii = 0; ii < size2; ii++)
-                *l1++ = val;
-        } else {
-            length1 = length - 1;
-            nextend = size1 / length1;
-            rextend = size1 - nextend * length1;
-            l1 = line + size1 + 1;
-            l2 = l1 - 2;
-            for(ii = 0; ii < nextend; ii++) {
-                l3 = l1;
-                for(jj = 0; jj < length1; jj++)
-                    *l2-- = *l3++;
-                l1 -= length1;
+    switch (extend_mode) {
+        /* aaaaaaaa|abcd|dddddddd */
+        case NI_EXTEND_NEAREST:
+            src = first;
+            dst = buffer;
+            val = *src;
+            while (size_before--) {
+                *dst++ = val;
             }
-            for(ii = 0; ii < rextend; ii++)
-                *l2-- = *l1++;
-            nextend = size2 / length1;
-            rextend = size2 - nextend * length1;
-            l1 = line + size1 + length1 - 1;
-            l2 = l1 + 2;
-            for(ii = 0; ii < nextend; ii++) {
-                l3 = l1;
-                for(jj = 0; jj < length1; jj++)
-                    *l2++ = *l3--;
-                l1 += length1;
+            src = last - 1;
+            dst = last;
+            val = *src;
+            while (size_after--) {
+                *dst++ = val;
             }
-            for(ii = 0; ii < rextend; ii++)
-                *l2++ = *l1--;
-        }
-        break;
-    case NI_EXTEND_REFLECT:
-        nextend = size1 / length;
-        rextend = size1 - nextend * length;
-        l1 = line + size1;
-        l2 = l1 - 1;
-        for(ii = 0; ii < nextend; ii++) {
-            l3 = l1;
-            for(jj = 0; jj < length; jj++)
-                *l2-- = *l3++;
-            l1 -= length;
-        }
-        l3 = l1;
-        for(ii = 0; ii < rextend; ii++)
-            *l2-- = *l3++;
-        nextend = size2 / length;
-        rextend = size2 - nextend * length;
-        l1 = line + size1 + length - 1;
-        l2 = l1 + 1;
-        for(ii = 0; ii < nextend; ii++) {
-            l3 = l1;
-            for(jj = 0; jj < length; jj++)
-                *l2++ = *l3--;
-            l1 += length;
-        }
-        for(ii = 0; ii < rextend; ii++)
-            *l2++ = *l1--;
-        break;
-    case NI_EXTEND_NEAREST:
-        l1 = line;
-        val = line[size1];
-        for(ii = 0; ii < size1; ii++)
-            *l1++ = val;
-        l1 = line + size1 + length;
-        val = line[size1 + length - 1];
-        for(ii = 0; ii < size2; ii++)
-            *l1++ = val;
-        break;
-    case NI_EXTEND_CONSTANT:
-        l1 = line;
-        for(ii = 0; ii < size1; ii++)
-            *l1++ = constant_value;
-        l1 = line + size1 + length;
-        for(ii = 0; ii < size2; ii++)
-            *l1++ = constant_value;
-        break;
-    default:
-        PyErr_Format(PyExc_RuntimeError, "mode %d not supported", mode);
-        return 0;
+            break;
+        /* abcdabcd|abcd|abcdabcd */
+        case NI_EXTEND_WRAP:
+            src = last - 1;
+            dst = first - 1;
+            while (size_before--) {
+                *dst-- = *src--;
+            }
+            src = first;
+            dst = last;
+            while (size_after--) {
+                *dst++ = *src++;
+            }
+            break;
+        /* abcddcba|abcd|dcbaabcd */
+        case NI_EXTEND_REFLECT:
+            src = first;
+            dst = first - 1;
+            while (size_before && src < last) {
+                *dst-- = *src++;
+                --size_before;
+            }
+            src = last - 1;
+            while (size_before--) {
+                *dst-- = *src--;
+            }
+            src = last - 1;
+            dst = last;
+            while (size_after && src >= first) {
+                *dst++ = *src--;
+                --size_after;
+            }
+            src = first;
+            while (size_after--) {
+                *dst++ = *src++;
+            }
+            break;
+        /* cbabcdcb|abcd|cbabcdcb */
+        case NI_EXTEND_MIRROR:
+            src = first + 1;
+            dst = first - 1;
+            while (size_before && src < last) {
+                *dst-- = *src++;
+                --size_before;
+            }
+            src = last - 2;
+            while (size_before--) {
+                *dst-- = *src--;
+            }
+            src = last - 2;
+            dst = last;
+            while (size_after && src >= first) {
+                *dst++ = *src--;
+                --size_after;
+            }
+            src = first + 1;
+            while (size_after--) {
+                *dst++ = *src++;
+            }
+            break;
+        /* kkkkkkkk|abcd]kkkkkkkk */
+        case NI_EXTEND_CONSTANT:
+            val = extend_value;
+            dst = buffer;
+            while (size_before--) {
+                *dst++ = val;
+            }
+            dst = last;
+            while (size_after--) {
+                *dst++ = val;
+            }
+            break;
+        default:
+            PyErr_Format(PyExc_RuntimeError,
+                         "mode %d not supported", extend_mode);
+            return 0;
     }
     return 1;
 }


### PR DESCRIPTION
Simplify code to extend a buffer beyond the array's boundaries.

It also speeds things up for some of the modes, e.g. see these before/after timings:

```
a = np.random.rand(100, 10)

%timeit ndimage.uniform_filter1d(a, size=100, mode='nearest') 
10000 loops, best of 3: 21.6 µs per loop
10000 loops, best of 3: 20.8 µs per loop 

%timeit ndimage.uniform_filter1d(a, size=100, mode='wrap')
10000 loops, best of 3: 22.6 µs per loop
10000 loops, best of 3: 20.5 µs per loop

%timeit ndimage.uniform_filter1d(a, size=100, mode='reflect')
10000 loops, best of 3: 23.4 µs per loop
10000 loops, best of 3: 22.2 µs per loop

%timeit ndimage.uniform_filter1d(a, size=100, mode='mirror')
10000 loops, best of 3: 24.7 µs per loop
10000 loops, best of 3: 22.3 µs per loop

%timeit ndimage.uniform_filter1d(a, size=100, mode='constant')
10000 loops, best of 3: 20.1 µs per loop
10000 loops, best of 3: 20.6 µs per loop
```

So maybe up to 10% overall speed-up for `'wrap'`, `'reflect'` and `'mirror'`.