### PR TITLE
ENH: linalg: allow lstsq to work with 0-shaped arrays

### DIFF
--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -1084,6 +1084,13 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
         nrhs = 1
     if m != b1.shape[0]:
         raise ValueError('incompatible dimensions')
+    if m == 0 or n == 0:  # Zero-sized problem, confuses LAPACK
+        x = np.zeros((n,) + b1.shape[1:], dtype=np.common_type(a1, b1))
+        if n == 0:
+            residues = np.linalg.norm(b1, axis=0)**2
+        else:
+            residues = np.empty((0,))
+        return x, residues, 0, np.empty((0,))
 
     driver = lapack_driver
     if driver is None:

--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -1049,11 +1049,11 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
     -------
     x : (N,) or (N, K) ndarray
         Least-squares solution.  Return shape matches shape of `b`.
-    residues : () or (1,) or (K,) ndarray
+    residues : (0,) or () or (K,) ndarray
         Sums of residues, squared 2-norm for each column in ``b - a x``.
         If rank of matrix a is ``< N`` or ``N > M``, or ``'gelsy'`` is used,
-        this is an empty array. If b was 1-D, this is an (1,) shape array,
-        otherwise the shape is (K,).
+        this is a lenght zero array. If b was 1-D, this is a () shape array
+        (numpy scalar), otherwise the shape is (K,).
     rank : int
         Effective rank of matrix `a`.
     s : (min(M,N),) ndarray or None

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -1245,6 +1245,20 @@ class TestLstsq(TestCase):
                                           atol=25 * _eps_cast(a.dtype),
                                           err_msg="driver: %s" % lapack_driver)
 
+    def test_zero_size(self):
+        for a_shape, b_shape in (((0, 2), (0,)),
+                                 ((0, 4), (0, 2)),
+                                 ((4, 0), (4,)),
+                                 ((4, 0), (4, 2))):
+            b = np.ones(b_shape)
+            x, residues, rank, s = lstsq(np.zeros(a_shape), b)
+            assert_equal(x, np.zeros((a_shape[1],) + b_shape[1:]))
+            residues_should_be = (np.empty((0,)) if a_shape[1]
+                                  else np.linalg.norm(b, axis=0)**2)
+            assert_equal(residues, residues_should_be)
+            assert_(rank == 0, 'expected rank 0')
+            assert_equal(s, np.empty((0,)))
+
 
 class TestPinv(TestCase):
 


### PR DESCRIPTION
This is mostly to avoid dealing with corner cases in downstream code. The workaround is quite straightforward, but I thought it could be useful in scipy as well.