### PR TITLE
MAINT: Remove ndimage aliases for NPY_MAXDIMS.

### DIFF
--- a/scipy/ndimage/src/nd_image.h
+++ b/scipy/ndimage/src/nd_image.h
@@ -66,10 +66,6 @@ typedef enum
          tDefault=NPY_FLOAT64
 } NumarrayType;
 
-#define NI_MAXDIM NPY_MAXDIMS
-
-#define MAXDIM NPY_MAXDIMS
-
 #define HAS_UINT64 1
 
 

--- a/scipy/ndimage/src/ni_interpolation.c
+++ b/scipy/ndimage/src/ni_interpolation.c
@@ -362,11 +362,11 @@ NI_GeometricTransform(PyArrayObject *input, int (*map)(npy_intp*, double*,
 {
     char *po, *pi, *pc = NULL;
     npy_intp **edge_offsets = NULL, **data_offsets = NULL, filter_size;
-    npy_intp ftmp[MAXDIM], *fcoordinates = NULL, *foffsets = NULL;
+    npy_intp ftmp[NPY_MAXDIMS], *fcoordinates = NULL, *foffsets = NULL;
     npy_intp cstride = 0, kk, hh, ll, jj;
     npy_intp size;
-    double **splvals = NULL, icoor[MAXDIM];
-    npy_intp idimensions[MAXDIM], istrides[MAXDIM];
+    double **splvals = NULL, icoor[NPY_MAXDIMS];
+    npy_intp idimensions[NPY_MAXDIMS], istrides[NPY_MAXDIMS];
     NI_Iterator io, ic;
     Float64 *matrix = matrix_ar ? (Float64*)PyArray_DATA(matrix_ar) : NULL;
     Float64 *shift = shift_ar ? (Float64*)PyArray_DATA(shift_ar) : NULL;
@@ -672,9 +672,9 @@ int NI_ZoomShift(PyArrayObject *input, PyArrayObject* zoom_ar,
 {
     char *po, *pi;
     npy_intp **zeros = NULL, **offsets = NULL, ***edge_offsets = NULL;
-    npy_intp ftmp[MAXDIM], *fcoordinates = NULL, *foffsets = NULL;
-    npy_intp jj, hh, kk, filter_size, odimensions[MAXDIM];
-    npy_intp idimensions[MAXDIM], istrides[MAXDIM];
+    npy_intp ftmp[NPY_MAXDIMS], *fcoordinates = NULL, *foffsets = NULL;
+    npy_intp jj, hh, kk, filter_size, odimensions[NPY_MAXDIMS];
+    npy_intp idimensions[NPY_MAXDIMS], istrides[NPY_MAXDIMS];
     npy_intp size;
     double ***splvals = NULL;
     NI_Iterator io;

--- a/scipy/ndimage/src/ni_measure.h
+++ b/scipy/ndimage/src/ni_measure.h
@@ -2,7 +2,7 @@
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
- * are met: 
+ * are met:
  *
  * 1. Redistributions of source code must retain the above copyright
  *    notice, this list of conditions and the following disclaimer.
@@ -15,7 +15,7 @@
  * 3. The name of the author may not be used to endorse or promote
  *    products derived from this software without specific prior
  *    written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS
  * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -26,7 +26,7 @@
  * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
  * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.      
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef NI_MEASURE_H
@@ -36,7 +36,7 @@
 
 /* structure for array regions to find objects: */
 typedef struct {
-    int start[NI_MAXDIM], end[NI_MAXDIM];
+    int start[NPY_MAXDIMS], end[NPY_MAXDIMS];
 } NI_ObjectRegion;
 
 int NI_FindObjects(PyArrayObject*, npy_intp, npy_intp*);
@@ -52,7 +52,7 @@ int NI_Statistics(PyArrayObject*, PyArrayObject*, npy_intp, npy_intp,
                   npy_intp*, npy_intp, double*, npy_intp*, double*,
                   double*, double*, npy_intp*, npy_intp*);
 
-int NI_WatershedIFT(PyArrayObject*, PyArrayObject*, PyArrayObject*, 
+int NI_WatershedIFT(PyArrayObject*, PyArrayObject*, PyArrayObject*,
                                         PyArrayObject*);
 
 #endif

--- a/scipy/ndimage/src/ni_morphology.c
+++ b/scipy/ndimage/src/ni_morphology.c
@@ -946,7 +946,7 @@ int NI_EuclideanFeatureTransform(PyArrayObject* input,
                                                                  PyArrayObject* features)
 {
     int ii;
-    npy_intp coor[NI_MAXDIM], mx = 0, jj;
+    npy_intp coor[NPY_MAXDIMS], mx = 0, jj;
     npy_intp *tmp = NULL, **f = NULL, *g = NULL;
     char *pi, *pf;
     Float64 *sampling = sampling_arr ? ((void *)PyArray_DATA(sampling_arr)) : NULL;

--- a/scipy/ndimage/src/ni_support.c
+++ b/scipy/ndimage/src/ni_support.c
@@ -451,7 +451,7 @@ NI_InitFilterIterator(int rank, npy_intp *filter_shape,
                     npy_intp *origins, NI_FilterIterator *iterator)
 {
     int ii;
-    npy_intp fshape[MAXDIM], forigins[MAXDIM];
+    npy_intp fshape[NPY_MAXDIMS], forigins[NPY_MAXDIMS];
 
     for(ii = 0; ii < rank; ii++) {
         fshape[ii] = *filter_shape++;
@@ -490,8 +490,8 @@ int NI_InitFilterOffsets(PyArrayObject *array, Bool *footprint,
     int rank, ii;
     npy_intp kk, ll, filter_size = 1, offsets_size = 1, max_size = 0;
     npy_intp max_stride = 0, *ashape = NULL, *astrides = NULL;
-    npy_intp footprint_size = 0, coordinates[MAXDIM], position[MAXDIM];
-    npy_intp fshape[MAXDIM], forigins[MAXDIM], *po, *pc = NULL;
+    npy_intp footprint_size = 0, coordinates[NPY_MAXDIMS], position[NPY_MAXDIMS];
+    npy_intp fshape[NPY_MAXDIMS], forigins[NPY_MAXDIMS], *po, *pc = NULL;
 
     rank = array->nd;
     ashape = array->dimensions;

--- a/scipy/ndimage/src/ni_support.h
+++ b/scipy/ndimage/src/ni_support.h
@@ -103,10 +103,10 @@ int NI_NormalizeType(int type_num)
 /* the iterator structure: */
 typedef struct {
     int rank_m1;
-    npy_intp dimensions[MAXDIM];
-    npy_intp coordinates[MAXDIM];
-    npy_intp strides[MAXDIM];
-    npy_intp backstrides[MAXDIM];
+    npy_intp dimensions[NPY_MAXDIMS];
+    npy_intp coordinates[NPY_MAXDIMS];
+    npy_intp strides[NPY_MAXDIMS];
+    npy_intp backstrides[NPY_MAXDIMS];
 } NI_Iterator;
 
 /* initialize iterations over single array elements: */
@@ -232,8 +232,8 @@ int NI_LineBufferToArray(NI_LineBuffer*, char*);
 
 /* the filter iterator structure: */
 typedef struct {
-    npy_intp strides[MAXDIM], backstrides[MAXDIM];
-    npy_intp bound1[MAXDIM], bound2[MAXDIM];
+    npy_intp strides[NPY_MAXDIMS], backstrides[NPY_MAXDIMS];
+    npy_intp bound1[NPY_MAXDIMS], bound2[NPY_MAXDIMS];
 } NI_FilterIterator;
 
 /* Initialize a filter iterator: */
@@ -243,7 +243,7 @@ int NI_InitFilterIterator(int, npy_intp*, npy_intp, npy_intp*,
 /* Calculate the offsets to the filter points, for all border regions and
      the interior of the array: */
 int NI_InitFilterOffsets(PyArrayObject*, Bool*, npy_intp*,
-                         npy_intp*, NI_ExtendMode, npy_intp**, 
+                         npy_intp*, NI_ExtendMode, npy_intp**,
                          npy_intp*, npy_intp**);
 
 /* Move to the next point in an array, possible changing the filter


### PR DESCRIPTION
Use the standard define throughout, rather than the two aliases specific to ndimage that serve no purpose.