### PR TITLE
MAINT: Remove some uses of Numarray types in ndimage.

### DIFF
--- a/scipy/ndimage/src/nd_image.c
+++ b/scipy/ndimage/src/nd_image.c
@@ -53,10 +53,10 @@ typedef struct {
 /* Numarray Helper Functions */
 
 static PyArrayObject*
-NA_InputArray(PyObject *a, NumarrayType t, int requires)
+NA_InputArray(PyObject *a, enum NPY_TYPES t, int requires)
 {
     PyArray_Descr *descr;
-    if (t == tAny) {
+    if (t == NPY_NOTYPE) {
         descr = NULL;
     }
     else {
@@ -70,9 +70,10 @@ NA_InputArray(PyObject *a, NumarrayType t, int requires)
 the specified type.
 */
 static int
-satisfies(PyArrayObject *a, int requirements, NumarrayType t)
+satisfies(PyArrayObject *a, int requirements, enum NPY_TYPES t)
 {
-    int type_ok = (t == tAny) || PyArray_EquivTypenums(PyArray_TYPE(a), t);
+    int type_ok = (t == NPY_NOTYPE) ||
+                   PyArray_EquivTypenums(PyArray_TYPE(a), t);
 
     if (PyArray_ISCARRAY(a)) {
         return type_ok;
@@ -96,7 +97,7 @@ satisfies(PyArrayObject *a, int requirements, NumarrayType t)
 }
 
 static PyArrayObject *
-NA_OutputArray(PyObject *a, NumarrayType t, int requires)
+NA_OutputArray(PyObject *a, enum NPY_TYPES t, int requires)
 {
     PyArray_Descr *dtype;
     PyArrayObject *ret;
@@ -111,7 +112,7 @@ NA_OutputArray(PyObject *a, NumarrayType t, int requires)
         Py_INCREF(a);
         return (PyArrayObject *)a;
     }
-    if (t == tAny) {
+    if (t == NPY_NOTYPE) {
         dtype = PyArray_DESCR((PyArrayObject *)a);
         Py_INCREF(dtype);
     }
@@ -138,7 +139,7 @@ Unlike NA_InputArray, deallocating any resulting temporary array results in a
 copy from the temporary back to the original.
 */
 static PyArrayObject *
-NA_IoArray(PyObject *a, NumarrayType t, int requires)
+NA_IoArray(PyObject *a, enum NPY_TYPES t, int requires)
 {
     PyArrayObject *shadow = NA_InputArray(a, t, requires | NPY_ARRAY_UPDATEIFCOPY);
 
@@ -180,7 +181,7 @@ NA_ByteOrder(void)
 
 /* ignores bytestride */
 static PyArrayObject *
-NA_NewAllFromBuffer(int ndim, npy_intp *shape, NumarrayType type,
+NA_NewAllFromBuffer(int ndim, npy_intp *shape, enum NPY_TYPES type,
                     PyObject *bufferObject, npy_intp byteoffset,
                     npy_intp bytestride, int byteorder, int aligned,
                     int writeable)
@@ -188,8 +189,8 @@ NA_NewAllFromBuffer(int ndim, npy_intp *shape, NumarrayType type,
     PyArrayObject *self = NULL;
     PyArray_Descr *dtype;
 
-    if (type == tAny) {
-        type = tDefault;
+    if (type == NPY_NOTYPE) {
+        type = NPY_DOUBLE;
     }
 
     dtype = PyArray_DescrFromType(type);
@@ -237,7 +238,7 @@ NA_NewAllFromBuffer(int ndim, npy_intp *shape, NumarrayType type,
 }
 
 static PyArrayObject *
-NA_NewAll(int ndim, npy_intp *shape, NumarrayType type,
+NA_NewAll(int ndim, npy_intp *shape, enum NPY_TYPES type,
           void *buffer, npy_intp byteoffset, npy_intp bytestride,
           int byteorder, int aligned, int writeable)
 {
@@ -267,7 +268,7 @@ references a C_array: aligned, !byteswapped, contiguous, ...
 Call with buffer==NULL to allocate storage.
 */
 static PyArrayObject *
-NA_NewArray(void *buffer, NumarrayType type, int ndim, npy_intp *shape)
+NA_NewArray(void *buffer, enum NPY_TYPES type, int ndim, npy_intp *shape)
 {
     return (PyArrayObject *)NA_NewAll(ndim, shape, type, buffer, 0, 0,
                                       NA_ByteOrder(), 1, 1);
@@ -277,7 +278,7 @@ NA_NewArray(void *buffer, NumarrayType type, int ndim, npy_intp *shape)
 static int
 NI_ObjectToInputArray(PyObject *object, PyArrayObject **array)
 {
-    *array = NA_InputArray(object, tAny, NPY_ARRAY_ALIGNED|NPY_ARRAY_NOTSWAPPED);
+    *array = NA_InputArray(object, NPY_NOTYPE, NPY_ARRAY_ALIGNED|NPY_ARRAY_NOTSWAPPED);
     return *array ? 1 : 0;
 }
 
@@ -289,7 +290,7 @@ NI_ObjectToOptionalInputArray(PyObject *object, PyArrayObject **array)
         *array = NULL;
         return 1;
     } else {
-        *array = NA_InputArray(object, tAny, NPY_ARRAY_ALIGNED|NPY_ARRAY_NOTSWAPPED);
+        *array = NA_InputArray(object, NPY_NOTYPE, NPY_ARRAY_ALIGNED|NPY_ARRAY_NOTSWAPPED);
         return *array ? 1 : 0;
     }
 }
@@ -298,7 +299,7 @@ NI_ObjectToOptionalInputArray(PyObject *object, PyArrayObject **array)
 static int
 NI_ObjectToOutputArray(PyObject *object, PyArrayObject **array)
 {
-    *array = NA_OutputArray(object, tAny, NPY_ARRAY_ALIGNED|NPY_ARRAY_NOTSWAPPED);
+    *array = NA_OutputArray(object, NPY_NOTYPE, NPY_ARRAY_ALIGNED|NPY_ARRAY_NOTSWAPPED);
     return *array ? 1 : 0;
 }
 
@@ -310,7 +311,7 @@ NI_ObjectToOptionalOutputArray(PyObject *object, PyArrayObject **array)
         *array = NULL;
         return 1;
     } else {
-        *array = NA_OutputArray(object, tAny, NPY_ARRAY_ALIGNED|NPY_ARRAY_NOTSWAPPED);
+        *array = NA_OutputArray(object, NPY_NOTYPE, NPY_ARRAY_ALIGNED|NPY_ARRAY_NOTSWAPPED);
         return *array ? 1 : 0;
     }
 }
@@ -319,7 +320,7 @@ NI_ObjectToOptionalOutputArray(PyObject *object, PyArrayObject **array)
 static int
 NI_ObjectToIoArray(PyObject *object, PyArrayObject **array)
 {
-    *array = NA_IoArray(object, tAny, NPY_ARRAY_ALIGNED|NPY_ARRAY_NOTSWAPPED);
+    *array = NA_IoArray(object, NPY_NOTYPE, NPY_ARRAY_ALIGNED|NPY_ARRAY_NOTSWAPPED);
     return *array ? 1 : 0;
 }
 
@@ -590,8 +591,8 @@ static PyObject *Py_GenericFilter1D(PyObject *obj, PyObject *args)
 #if PY_VERSION_HEX < 0x03000000
     } else if (PyCObject_Check(fnc)) {
         /* 'Legacy' low-level callable on Py2 */
-	func = PyCObject_AsVoidPtr(fnc);
-	data = PyCObject_GetDesc(fnc);
+        func = PyCObject_AsVoidPtr(fnc);
+        data = PyCObject_GetDesc(fnc);
 #endif
     } else {
         int ret;
@@ -710,8 +711,8 @@ static PyObject *Py_GenericFilter(PyObject *obj, PyObject *args)
 #if PY_VERSION_HEX < 0x03000000
     } else if (PyCObject_Check(fnc)) {
         /* 'Legacy' low-level callable on Py2 */
-	func = PyCObject_AsVoidPtr(fnc);
-	data = PyCObject_GetDesc(fnc);
+        func = PyCObject_AsVoidPtr(fnc);
+        data = PyCObject_GetDesc(fnc);
 #endif
     } else {
         int ret;
@@ -907,7 +908,7 @@ static PyObject *Py_GeometricTransform(PyObject *obj, PyObject *args)
             goto exit;
         }
         if (PyCapsule_CheckExact(fnc) && PyCapsule_GetName(fnc) == NULL) {
-	    func = PyCapsule_GetPointer(fnc, NULL);
+            func = PyCapsule_GetPointer(fnc, NULL);
             data = PyCapsule_GetContext(fnc);
 #if PY_VERSION_HEX < 0x03000000
         } else if (PyCObject_Check(fnc)) {

--- a/scipy/ndimage/src/ni_filters.c
+++ b/scipy/ndimage/src/ni_filters.c
@@ -36,7 +36,7 @@
 #define BUFFER_SIZE 256000
 
 int NI_Correlate1D(PyArrayObject *input, PyArrayObject *weights,
-                                     int axis, PyArrayObject *output, NI_ExtendMode mode,
+                   int axis, PyArrayObject *output, NI_ExtendMode mode,
                    double cval, npy_intp origin)
 {
     int symmetric = 0, more;
@@ -134,28 +134,30 @@ exit:
     return PyErr_Occurred() ? 0 : 1;
 }
 
-#define CASE_CORRELATE_POINT(_pi, _weights, _offsets, _filter_size, \
-                                                         _cvalue, _type, _res, _mv)             \
-case t ## _type:                                                    \
-{                                                                   \
-    npy_intp _ii, _offset;                                            \
-    for(_ii = 0; _ii < _filter_size; _ii++) {                         \
-        _offset = _offsets[_ii];                                        \
-        if (_offset == _mv)                                             \
-            _res += _weights[_ii] * _cvalue;                              \
-        else                                                            \
-            _res += _weights[_ii] * (double)*(_type*)(_pi + _offset);     \
-    }                                                                 \
-}                                                                   \
+#define CASE_CORRELATE_POINT(_TYPE, _type, _pi, _weights, _offsets,        \
+                             _filter_size, _cvalue, _res, _mv)             \
+case _TYPE:                                                                \
+{                                                                          \
+    npy_intp _ii, _offset;                                                 \
+    for (_ii = 0; _ii < _filter_size; ++_ii) {                             \
+        _offset = _offsets[_ii];                                           \
+        if (_offset == _mv) {                                              \
+            _res += _weights[_ii] * _cvalue;                               \
+        }                                                                  \
+        else {                                                             \
+            _res += _weights[_ii] * (double)(*((_type *)(_pi + _offset))); \
+        }                                                                  \
+    }                                                                      \
+}                                                                          \
 break
 
-#define CASE_FILTER_OUT(_po, _tmp, _type) \
-case t ## _type:                          \
-    *(_type*)_po = (_type)_tmp;             \
+#define CASE_FILTER_OUT(_TYPE, _type, _po, _tmp) \
+case _TYPE:                                      \
+    *(_type *)_po = (_type)_tmp;                 \
     break
 
 int NI_Correlate(PyArrayObject* input, PyArrayObject* weights,
-                                                PyArrayObject* output, NI_ExtendMode mode,
+                 PyArrayObject* output, NI_ExtendMode mode,
                  double cvalue, npy_intp *origins)
 {
     Bool *pf = NULL;
@@ -166,7 +168,7 @@ int NI_Correlate(PyArrayObject* input, PyArrayObject* weights,
     char *pi, *po;
     Float64 *pw;
     Float64 *ww = NULL;
-    int ll, err = 0;
+    int err = 0;
     NPY_BEGIN_THREADS_DEF;
 
     /* get the the footprint: */
@@ -224,52 +226,67 @@ int NI_Correlate(PyArrayObject* input, PyArrayObject* weights,
     oo = offsets;
     for(jj = 0; jj < size; jj++) {
         double tmp = 0.0;
-        switch (NI_NormalizeType(PyArray_TYPE(input))) {
-            CASE_CORRELATE_POINT(pi, ww, oo, filter_size, cvalue, Bool,
-                                                     tmp, border_flag_value);
-            CASE_CORRELATE_POINT(pi, ww, oo, filter_size, cvalue, UInt8,
-                                                     tmp, border_flag_value);
-            CASE_CORRELATE_POINT(pi, ww, oo, filter_size, cvalue, UInt16,
-                                                     tmp, border_flag_value);
-            CASE_CORRELATE_POINT(pi, ww, oo, filter_size, cvalue, UInt32,
-                                                     tmp, border_flag_value);
-#if HAS_UINT64
-            CASE_CORRELATE_POINT(pi, ww, oo, filter_size, cvalue, UInt64,
-                                                     tmp, border_flag_value);
-#endif
-            CASE_CORRELATE_POINT(pi, ww, oo, filter_size, cvalue, Int8,
-                                                     tmp, border_flag_value);
-            CASE_CORRELATE_POINT(pi, ww, oo, filter_size, cvalue, Int16,
-                                                     tmp, border_flag_value);
-            CASE_CORRELATE_POINT(pi, ww, oo, filter_size, cvalue, Int32,
-                                                     tmp, border_flag_value);
-            CASE_CORRELATE_POINT(pi, ww, oo, filter_size, cvalue, Int64,
-                                                     tmp, border_flag_value);
-            CASE_CORRELATE_POINT(pi, ww, oo, filter_size, cvalue, Float32,
-                                                     tmp, border_flag_value);
-            CASE_CORRELATE_POINT(pi, ww, oo, filter_size, cvalue, Float64,
-                                                     tmp, border_flag_value);
-        default:
-            err = 1;
-            goto exit;
+        switch (PyArray_TYPE(input)) {
+            CASE_CORRELATE_POINT(NPY_BOOL, npy_bool,
+                                 pi, ww, oo, filter_size, cvalue, tmp,
+                                 border_flag_value);
+            CASE_CORRELATE_POINT(NPY_UBYTE, npy_ubyte,
+                                 pi, ww, oo, filter_size, cvalue, tmp,
+                                 border_flag_value);
+            CASE_CORRELATE_POINT(NPY_USHORT, npy_ushort,
+                                 pi, ww, oo, filter_size, cvalue, tmp,
+                                 border_flag_value);
+            CASE_CORRELATE_POINT(NPY_UINT, npy_uint,
+                                 pi, ww, oo, filter_size, cvalue, tmp,
+                                 border_flag_value);
+            CASE_CORRELATE_POINT(NPY_ULONG, npy_ulong,
+                                 pi, ww, oo, filter_size, cvalue, tmp,
+                                 border_flag_value);
+            CASE_CORRELATE_POINT(NPY_ULONGLONG, npy_ulonglong,
+                                 pi, ww, oo, filter_size, cvalue, tmp,
+                                 border_flag_value);
+            CASE_CORRELATE_POINT(NPY_BYTE, npy_byte,
+                                 pi, ww, oo, filter_size, cvalue, tmp,
+                                 border_flag_value);
+            CASE_CORRELATE_POINT(NPY_SHORT, npy_short,
+                                 pi, ww, oo, filter_size, cvalue, tmp,
+                                 border_flag_value);
+            CASE_CORRELATE_POINT(NPY_INT, npy_int,
+                                 pi, ww, oo, filter_size, cvalue, tmp,
+                                 border_flag_value);
+            CASE_CORRELATE_POINT(NPY_LONG, npy_long,
+                                 pi, ww, oo, filter_size, cvalue, tmp,
+                                 border_flag_value);
+            CASE_CORRELATE_POINT(NPY_LONGLONG, npy_longlong,
+                                 pi, ww, oo, filter_size, cvalue, tmp,
+                                 border_flag_value);
+            CASE_CORRELATE_POINT(NPY_FLOAT, npy_float,
+                                 pi, ww, oo, filter_size, cvalue, tmp,
+                                 border_flag_value);
+            CASE_CORRELATE_POINT(NPY_DOUBLE, npy_double,
+                                 pi, ww, oo, filter_size, cvalue, tmp,
+                                 border_flag_value);
+            default:
+                err = 1;
+                goto exit;
         }
-        switch (NI_NormalizeType(PyArray_TYPE(output))) {
-            CASE_FILTER_OUT(po, tmp, Bool);
-            CASE_FILTER_OUT(po, tmp, UInt8);
-            CASE_FILTER_OUT(po, tmp, UInt16);
-            CASE_FILTER_OUT(po, tmp, UInt32);
-#if HAS_UINT64
-            CASE_FILTER_OUT(po, tmp, UInt64);
-#endif
-            CASE_FILTER_OUT(po, tmp, Int8);
-            CASE_FILTER_OUT(po, tmp, Int16);
-            CASE_FILTER_OUT(po, tmp, Int32);
-            CASE_FILTER_OUT(po, tmp, Int64);
-            CASE_FILTER_OUT(po, tmp, Float32);
-            CASE_FILTER_OUT(po, tmp, Float64);
-        default:
-            err = 1;
-            goto exit;
+        switch (PyArray_TYPE(output)) {
+            CASE_FILTER_OUT(NPY_BOOL, npy_bool, po, tmp);
+            CASE_FILTER_OUT(NPY_UBYTE, npy_ubyte, po, tmp);
+            CASE_FILTER_OUT(NPY_USHORT, npy_ushort, po, tmp);
+            CASE_FILTER_OUT(NPY_UINT, npy_uint, po, tmp);
+            CASE_FILTER_OUT(NPY_ULONG, npy_ulong, po, tmp);
+            CASE_FILTER_OUT(NPY_ULONGLONG, npy_ulonglong, po, tmp);
+            CASE_FILTER_OUT(NPY_BYTE, npy_byte, po, tmp);
+            CASE_FILTER_OUT(NPY_SHORT, npy_short, po, tmp);
+            CASE_FILTER_OUT(NPY_INT, npy_int, po, tmp);
+            CASE_FILTER_OUT(NPY_LONG, npy_long, po, tmp);
+            CASE_FILTER_OUT(NPY_LONGLONG, npy_longlong, po, tmp);
+            CASE_FILTER_OUT(NPY_FLOAT, npy_float, po, tmp);
+            CASE_FILTER_OUT(NPY_DOUBLE, npy_double, po, tmp);
+            default:
+                err = 1;
+                goto exit;
         }
         NI_FILTER_NEXT2(fi, ii, io, oo, pi, po);
     }
@@ -352,15 +369,15 @@ NI_UniformFilter1D(PyArrayObject *input, npy_intp filter_size,
 }
 
 #define INCREASE_RING_PTR(ptr) \
-    (ptr)++;\
-    if ((ptr) >= end) { \
-        (ptr) = ring; \
+    (ptr)++;                   \
+    if ((ptr) >= end) {        \
+        (ptr) = ring;          \
     }
 
 #define DECREASE_RING_PTR(ptr) \
-    if ((ptr) == ring) { \
-        (ptr) = end; \
-    } \
+    if ((ptr) == ring) {       \
+        (ptr) = end;           \
+    }                          \
     (ptr)--;
 
 int
@@ -477,33 +494,40 @@ NI_MinOrMaxFilter1D(PyArrayObject *input, npy_intp filter_size,
 #undef INCREASE_RING_PTR
 
 
-#define CASE_MIN_OR_MAX_POINT(_pi, _offsets, _filter_size, _cval, \
-                                                            _type, _minimum, _res, _mv, _ss)    \
-case t ## _type:                                                  \
-{                                                                 \
-    npy_intp _ii, _oo = *_offsets;                                \
-    _type _cv = (_type)_cval, _tmp;                                 \
-    _res = _oo == _mv ? _cv : *(_type*)(_pi + _oo);                 \
-    if (_ss)                                                        \
-        _res += *_ss;                                                 \
-    for(_ii = 1; _ii < _filter_size; _ii++) {                       \
-        _oo = _offsets[_ii];                                          \
-        _tmp = _oo == _mv ? _cv : *(_type*)(_pi + _oo);               \
-        if (_ss)                                                      \
-            _tmp += _ss[_ii];                                           \
-        if (_minimum) {                                               \
-            if (_tmp < _res)                                            \
-                _res = (_type)_tmp;                                       \
-        } else {                                                      \
-            if (_tmp > _res)                                            \
-                _res = (_type)_tmp;                                       \
-        }                                                             \
-    }                                                               \
-}                                                                 \
+#define CASE_MIN_OR_MAX_POINT(_TYPE, _type, _pi, _offsets, _filter_size, \
+                              _cval, _minimum, _res, _mv, _ss)           \
+case _TYPE:                                                              \
+{                                                                        \
+    npy_intp _ii;                                                        \
+    npy_intp _oo = _offsets[0];                                          \
+    _type _tmp;                                                          \
+    _type _cv = (_type)_cval;                                            \
+    _res = _oo == _mv ? _cv : *(_type *)(_pi + _oo);                     \
+    if (_ss != NULL) {                                                   \
+        _res += _ss[0];                                                  \
+    }                                                                    \
+    for (_ii = 1; _ii < _filter_size; ++_ii) {                           \
+        _oo = _offsets[_ii];                                             \
+        _tmp = _oo == _mv ? _cv : *(_type *)(_pi + _oo);                 \
+        if (_ss != NULL) {                                               \
+            _tmp += _ss[_ii];                                            \
+        }                                                                \
+        if (_minimum) {                                                  \
+            if (_tmp < _res) {                                           \
+                _res = _tmp;                                             \
+            }                                                            \
+        }                                                                \
+        else {                                                           \
+            if (_tmp > _res) {                                           \
+                _res = _tmp;                                             \
+            }                                                            \
+        }                                                                \
+    }                                                                    \
+}                                                                        \
 break
 
 int NI_MinOrMaxFilter(PyArrayObject* input, PyArrayObject* footprint,
-                PyArrayObject* structure, PyArrayObject* output,
+                      PyArrayObject* structure, PyArrayObject* output,
                       NI_ExtendMode mode, double cvalue, npy_intp *origins,
                       int minimum)
 {
@@ -513,7 +537,7 @@ int NI_MinOrMaxFilter(PyArrayObject* input, PyArrayObject* footprint,
     NI_FilterIterator fi;
     NI_Iterator ii, io;
     char *pi, *po;
-    int ll, err = 0;
+    int err = 0;
     double *ss = NULL;
     Float64 *ps;
     NPY_BEGIN_THREADS_DEF;
@@ -568,52 +592,67 @@ int NI_MinOrMaxFilter(PyArrayObject* input, PyArrayObject* footprint,
     oo = offsets;
     for(jj = 0; jj < size; jj++) {
         double tmp = 0.0;
-        switch (NI_NormalizeType(PyArray_TYPE(input))) {
-            CASE_MIN_OR_MAX_POINT(pi, oo, filter_size, cvalue, Bool,
-                                                        minimum, tmp, border_flag_value, ss);
-            CASE_MIN_OR_MAX_POINT(pi, oo, filter_size, cvalue, UInt8,
-                                                        minimum, tmp, border_flag_value, ss);
-            CASE_MIN_OR_MAX_POINT(pi, oo, filter_size, cvalue, UInt16,
-                                                        minimum, tmp, border_flag_value, ss);
-            CASE_MIN_OR_MAX_POINT(pi, oo, filter_size, cvalue, UInt32,
-                                                        minimum, tmp, border_flag_value, ss);
-#if HAS_UINT64
-            CASE_MIN_OR_MAX_POINT(pi, oo, filter_size, cvalue, UInt64,
-                                                        minimum, tmp, border_flag_value, ss);
-#endif
-            CASE_MIN_OR_MAX_POINT(pi, oo, filter_size, cvalue, Int8,
-                                                        minimum, tmp, border_flag_value, ss);
-            CASE_MIN_OR_MAX_POINT(pi, oo, filter_size, cvalue, Int16,
-                                                        minimum, tmp, border_flag_value, ss);
-            CASE_MIN_OR_MAX_POINT(pi, oo, filter_size, cvalue, Int32,
-                                                        minimum, tmp, border_flag_value, ss);
-            CASE_MIN_OR_MAX_POINT(pi, oo, filter_size, cvalue, Int64,
-                                                        minimum, tmp, border_flag_value, ss);
-            CASE_MIN_OR_MAX_POINT(pi, oo, filter_size, cvalue, Float32,
-                                                        minimum, tmp, border_flag_value, ss);
-            CASE_MIN_OR_MAX_POINT(pi, oo, filter_size, cvalue, Float64,
-                                                        minimum, tmp, border_flag_value, ss);
-        default:
-            err = 1;
-            goto exit;
+        switch (PyArray_TYPE(input)) {
+            CASE_MIN_OR_MAX_POINT(NPY_BOOL, npy_bool,
+                                  pi, oo, filter_size, cvalue, minimum, tmp,
+                                  border_flag_value, ss);
+            CASE_MIN_OR_MAX_POINT(NPY_UBYTE, npy_ubyte,
+                                  pi, oo, filter_size, cvalue, minimum, tmp,
+                                  border_flag_value, ss);
+            CASE_MIN_OR_MAX_POINT(NPY_USHORT, npy_ushort,
+                                  pi, oo, filter_size, cvalue, minimum, tmp,
+                                  border_flag_value, ss);
+            CASE_MIN_OR_MAX_POINT(NPY_UINT, npy_uint,
+                                  pi, oo, filter_size, cvalue, minimum, tmp,
+                                  border_flag_value, ss);
+            CASE_MIN_OR_MAX_POINT(NPY_ULONG, npy_ulong,
+                                  pi, oo, filter_size, cvalue, minimum, tmp,
+                                  border_flag_value, ss);
+            CASE_MIN_OR_MAX_POINT(NPY_ULONGLONG, npy_ulonglong,
+                                  pi, oo, filter_size, cvalue, minimum, tmp,
+                                  border_flag_value, ss);
+            CASE_MIN_OR_MAX_POINT(NPY_BYTE, npy_byte,
+                                  pi, oo, filter_size, cvalue, minimum, tmp,
+                                  border_flag_value, ss);
+            CASE_MIN_OR_MAX_POINT(NPY_SHORT, npy_short,
+                                  pi, oo, filter_size, cvalue, minimum, tmp,
+                                  border_flag_value, ss);
+            CASE_MIN_OR_MAX_POINT(NPY_INT, npy_int,
+                                  pi, oo, filter_size, cvalue, minimum, tmp,
+                                  border_flag_value, ss);
+            CASE_MIN_OR_MAX_POINT(NPY_LONG, npy_long,
+                                  pi, oo, filter_size, cvalue, minimum, tmp,
+                                  border_flag_value, ss);
+            CASE_MIN_OR_MAX_POINT(NPY_LONGLONG, npy_longlong,
+                                  pi, oo, filter_size, cvalue, minimum, tmp,
+                                  border_flag_value, ss);
+            CASE_MIN_OR_MAX_POINT(NPY_FLOAT, npy_float,
+                                  pi, oo, filter_size, cvalue, minimum, tmp,
+                                  border_flag_value, ss);
+            CASE_MIN_OR_MAX_POINT(NPY_DOUBLE, npy_double,
+                                  pi, oo, filter_size, cvalue, minimum, tmp,
+                                  border_flag_value, ss);
+            default:
+                err = 1;
+                goto exit;
         }
-        switch (NI_NormalizeType(PyArray_TYPE(output))) {
-            CASE_FILTER_OUT(po, tmp, Bool);
-            CASE_FILTER_OUT(po, tmp, UInt8);
-            CASE_FILTER_OUT(po, tmp, UInt16);
-            CASE_FILTER_OUT(po, tmp, UInt32);
-#if HAS_UINT64
-            CASE_FILTER_OUT(po, tmp, UInt64);
-#endif
-            CASE_FILTER_OUT(po, tmp, Int8);
-            CASE_FILTER_OUT(po, tmp, Int16);
-            CASE_FILTER_OUT(po, tmp, Int32);
-            CASE_FILTER_OUT(po, tmp, Int64);
-            CASE_FILTER_OUT(po, tmp, Float32);
-            CASE_FILTER_OUT(po, tmp, Float64);
-        default:
-            err = 1;
-            goto exit;
+        switch (PyArray_TYPE(output)) {
+            CASE_FILTER_OUT(NPY_BOOL, npy_bool, po, tmp);
+            CASE_FILTER_OUT(NPY_UBYTE, npy_ubyte, po, tmp);
+            CASE_FILTER_OUT(NPY_USHORT, npy_ushort, po, tmp);
+            CASE_FILTER_OUT(NPY_UINT, npy_uint, po, tmp);
+            CASE_FILTER_OUT(NPY_ULONG, npy_ulong, po, tmp);
+            CASE_FILTER_OUT(NPY_ULONGLONG, npy_ulonglong, po, tmp);
+            CASE_FILTER_OUT(NPY_BYTE, npy_byte, po, tmp);
+            CASE_FILTER_OUT(NPY_SHORT, npy_short, po, tmp);
+            CASE_FILTER_OUT(NPY_INT, npy_int, po, tmp);
+            CASE_FILTER_OUT(NPY_LONG, npy_long, po, tmp);
+            CASE_FILTER_OUT(NPY_LONGLONG, npy_longlong, po, tmp);
+            CASE_FILTER_OUT(NPY_FLOAT, npy_float, po, tmp);
+            CASE_FILTER_OUT(NPY_DOUBLE, npy_double, po, tmp);
+            default:
+                err = 1;
+                goto exit;
         }
         NI_FILTER_NEXT2(fi, ii, io, oo, pi, po);
     }
@@ -662,24 +701,28 @@ static double NI_Select(double *buffer, npy_intp min,
         return NI_Select(buffer, jj + 1, max, rank - ii);
 }
 
-#define CASE_RANK_POINT(_pi, _offsets, _filter_size, _cval, _type, \
-                                                _rank, _buffer, _res, _mv)                 \
-case t ## _type:                                                   \
+#define CASE_RANK_POINT(_TYPE, _type, _pi, _offsets, _filter_size, \
+                        _cval, _rank, _buffer, _res, _mv)          \
+case _TYPE:                                                        \
 {                                                                  \
     npy_intp _ii;                                                  \
-    for(_ii = 0; _ii < _filter_size; _ii++) {                        \
+    for (_ii = 0; _ii < _filter_size; ++_ii) {                     \
         npy_intp _offset = _offsets[_ii];                          \
-        if (_offset == _mv)                                            \
-            _buffer[_ii] = (_type)_cval;                                 \
-        else                                                           \
-            _buffer[_ii] = *(_type*)(_pi + _offsets[_ii]);               \
-    }                                                                \
-    _res = (_type)NI_Select(_buffer, 0, _filter_size - 1, _rank);    \
+        if (_offset == _mv) {                                      \
+            _buffer[_ii] = (_type)_cval;                           \
+        }                                                          \
+        else {                                                     \
+            _buffer[_ii] = *(_type *)(_pi + _offset);              \
+        }                                                          \
+    }                                                              \
+    _res = (_type)NI_Select(_buffer, 0, _filter_size - 1, _rank);  \
 }                                                                  \
 break
 
+
+
 int NI_RankFilter(PyArrayObject* input, int rank,
-                                    PyArrayObject* footprint, PyArrayObject* output,
+                  PyArrayObject* footprint, PyArrayObject* output,
                   NI_ExtendMode mode, double cvalue, npy_intp *origins)
 {
     npy_intp fsize, jj, filter_size = 0, border_flag_value;
@@ -689,7 +732,7 @@ int NI_RankFilter(PyArrayObject* input, int rank,
     char *pi, *po;
     Bool *pf = NULL;
     double *buffer = NULL;
-    int ll, err = 0;
+    int err = 0;
     NPY_BEGIN_THREADS_DEF;
 
     /* get the the footprint: */
@@ -735,52 +778,67 @@ int NI_RankFilter(PyArrayObject* input, int rank,
     oo = offsets;
     for(jj = 0; jj < size; jj++) {
         double tmp = 0.0;
-        switch (NI_NormalizeType(PyArray_TYPE(input))) {
-            CASE_RANK_POINT(pi, oo, filter_size, cvalue, Bool,
-                                            rank, buffer, tmp, border_flag_value);
-            CASE_RANK_POINT(pi, oo, filter_size, cvalue, UInt8,
-                                            rank, buffer, tmp, border_flag_value);
-            CASE_RANK_POINT(pi, oo, filter_size, cvalue, UInt16,
-                                            rank, buffer, tmp, border_flag_value);
-            CASE_RANK_POINT(pi, oo, filter_size, cvalue, UInt32,
-                                            rank, buffer, tmp, border_flag_value);
-#if HAS_UINT64
-            CASE_RANK_POINT(pi, oo, filter_size, cvalue, UInt64,
-                                            rank, buffer, tmp, border_flag_value);
-#endif
-            CASE_RANK_POINT(pi, oo, filter_size, cvalue, Int8,
-                                            rank, buffer, tmp, border_flag_value);
-            CASE_RANK_POINT(pi, oo, filter_size, cvalue, Int16,
-                                            rank, buffer, tmp, border_flag_value);
-            CASE_RANK_POINT(pi, oo, filter_size, cvalue, Int32,
-                                            rank, buffer, tmp, border_flag_value);
-            CASE_RANK_POINT(pi, oo, filter_size, cvalue, Int64,
-                                            rank, buffer, tmp, border_flag_value);
-            CASE_RANK_POINT(pi, oo, filter_size, cvalue, Float32,
-                                            rank, buffer, tmp, border_flag_value);
-            CASE_RANK_POINT(pi, oo, filter_size, cvalue, Float64,
-                                            rank, buffer, tmp, border_flag_value);
-        default:
-            err = 1;
-            goto exit;
+        switch (PyArray_TYPE(input)) {
+            CASE_RANK_POINT(NPY_BOOL, npy_bool,
+                            pi, oo, filter_size, cvalue, rank, buffer, tmp,
+                            border_flag_value);
+            CASE_RANK_POINT(NPY_UBYTE, npy_ubyte,
+                            pi, oo, filter_size, cvalue, rank, buffer, tmp,
+                            border_flag_value);
+            CASE_RANK_POINT(NPY_USHORT, npy_ushort,
+                            pi, oo, filter_size, cvalue, rank, buffer, tmp,
+                            border_flag_value);
+            CASE_RANK_POINT(NPY_UINT, npy_uint,
+                            pi, oo, filter_size, cvalue, rank, buffer, tmp,
+                            border_flag_value);
+            CASE_RANK_POINT(NPY_ULONG, npy_ulong,
+                            pi, oo, filter_size, cvalue, rank, buffer, tmp,
+                            border_flag_value);
+            CASE_RANK_POINT(NPY_ULONGLONG, npy_ulonglong,
+                            pi, oo, filter_size, cvalue, rank, buffer, tmp,
+                            border_flag_value);
+            CASE_RANK_POINT(NPY_BYTE, npy_byte,
+                            pi, oo, filter_size, cvalue, rank, buffer, tmp,
+                            border_flag_value);
+            CASE_RANK_POINT(NPY_SHORT, npy_short,
+                            pi, oo, filter_size, cvalue, rank, buffer, tmp,
+                            border_flag_value);
+            CASE_RANK_POINT(NPY_INT, npy_int,
+                            pi, oo, filter_size, cvalue, rank, buffer, tmp,
+                            border_flag_value);
+            CASE_RANK_POINT(NPY_LONG, npy_long,
+                            pi, oo, filter_size, cvalue, rank, buffer, tmp,
+                            border_flag_value);
+            CASE_RANK_POINT(NPY_LONGLONG, npy_longlong,
+                            pi, oo, filter_size, cvalue, rank, buffer, tmp,
+                            border_flag_value);
+            CASE_RANK_POINT(NPY_FLOAT, npy_float,
+                            pi, oo, filter_size, cvalue, rank, buffer, tmp,
+                            border_flag_value);
+            CASE_RANK_POINT(NPY_DOUBLE, npy_double,
+                            pi, oo, filter_size, cvalue, rank, buffer, tmp,
+                            border_flag_value);
+            default:
+                err = 1;
+                goto exit;
         }
-        switch (NI_NormalizeType(PyArray_TYPE(output))) {
-            CASE_FILTER_OUT(po, tmp, Bool);
-            CASE_FILTER_OUT(po, tmp, UInt8);
-            CASE_FILTER_OUT(po, tmp, UInt16);
-            CASE_FILTER_OUT(po, tmp, UInt32);
-#if HAS_UINT64
-            CASE_FILTER_OUT(po, tmp, UInt64);
-#endif
-            CASE_FILTER_OUT(po, tmp, Int8);
-            CASE_FILTER_OUT(po, tmp, Int16);
-            CASE_FILTER_OUT(po, tmp, Int32);
-            CASE_FILTER_OUT(po, tmp, Int64);
-            CASE_FILTER_OUT(po, tmp, Float32);
-            CASE_FILTER_OUT(po, tmp, Float64);
-        default:
-            err = 1;
-            goto exit;
+        switch (PyArray_TYPE(output)) {
+            CASE_FILTER_OUT(NPY_BOOL, npy_bool, po, tmp);
+            CASE_FILTER_OUT(NPY_UBYTE, npy_ubyte, po, tmp);
+            CASE_FILTER_OUT(NPY_USHORT, npy_ushort, po, tmp);
+            CASE_FILTER_OUT(NPY_UINT, npy_uint, po, tmp);
+            CASE_FILTER_OUT(NPY_ULONG, npy_ulong, po, tmp);
+            CASE_FILTER_OUT(NPY_ULONGLONG, npy_ulonglong, po, tmp);
+            CASE_FILTER_OUT(NPY_BYTE, npy_byte, po, tmp);
+            CASE_FILTER_OUT(NPY_SHORT, npy_short, po, tmp);
+            CASE_FILTER_OUT(NPY_INT, npy_int, po, tmp);
+            CASE_FILTER_OUT(NPY_LONG, npy_long, po, tmp);
+            CASE_FILTER_OUT(NPY_LONGLONG, npy_longlong, po, tmp);
+            CASE_FILTER_OUT(NPY_FLOAT, npy_float, po, tmp);
+            CASE_FILTER_OUT(NPY_DOUBLE, npy_double, po, tmp);
+            default:
+                err = 1;
+                goto exit;
         }
         NI_FILTER_NEXT2(fi, ii, io, oo, pi, po);
     }
@@ -851,27 +909,30 @@ exit:
     return PyErr_Occurred() ? 0 : 1;
 }
 
-#define CASE_FILTER_POINT(_pi, _offsets, _filter_size, _cvalue, _type, \
-                                                    _res, _mv, _function, _data, _buffer)        \
-case t ## _type:                                                       \
-{                                                                      \
-    npy_intp _ii, _offset;                                             \
-    for(_ii = 0; _ii < _filter_size; _ii++) {                            \
-        _offset = _offsets[_ii];                                           \
-        if (_offset == _mv)                                                \
-            _buffer[_ii] = (double)_cvalue;                                  \
-        else                                                               \
-            _buffer[_ii] = (double)*(_type*)(_pi + _offset);                 \
-    }                                                                    \
-    if (!_function(_buffer, _filter_size, &_res, _data)) {               \
-        if (!PyErr_Occurred())                                             \
-            PyErr_SetString(PyExc_RuntimeError,                              \
-                                            "unknown error in filter function");             \
-            goto exit;                                                       \
-    }                                                                    \
-}                                                                      \
-break
 
+#define CASE_FILTER_POINT(_TYPE, _type, _pi, _offsets, _filter_size, _cvalue, \
+                          _res, _mv, _function, _data, _buffer)               \
+case _TYPE:                                                                   \
+{                                                                             \
+    npy_intp _ii;                                                             \
+    for (_ii = 0; _ii < _filter_size; ++_ii) {                                \
+        const npy_intp _offset = _offsets[_ii];                               \
+        if (_offset == _mv) {                                                 \
+            _buffer[_ii] = (double)_cvalue;                                   \
+        }                                                                     \
+        else {                                                                \
+            _buffer[_ii] = (double)(*(_type*)(_pi + _offset));                \
+        }                                                                     \
+    }                                                                         \
+    if (!_function(_buffer, _filter_size, &_res, _data)) {                    \
+        if (!PyErr_Occurred()) {                                              \
+            PyErr_SetString(PyExc_RuntimeError,                               \
+                            "unknown error in filter function");              \
+            goto exit;                                                        \
+        }                                                                     \
+    }                                                                         \
+}                                                                             \
+break
 
 int NI_GenericFilter(PyArrayObject* input,
             int (*function)(double*, npy_intp, double*, void*), void *data,
@@ -885,7 +946,6 @@ int NI_GenericFilter(PyArrayObject* input,
     NI_Iterator ii, io;
     char *pi, *po;
     double *buffer = NULL;
-    int ll;
 
     /* get the the footprint: */
     fsize = PyArray_SIZE(footprint);
@@ -925,52 +985,69 @@ int NI_GenericFilter(PyArrayObject* input,
     oo = offsets;
     for(jj = 0; jj < size; jj++) {
         double tmp = 0.0;
-        switch (NI_NormalizeType(PyArray_TYPE(input))) {
-            CASE_FILTER_POINT(pi, oo, filter_size, cvalue, Bool,
-                                                tmp, border_flag_value, function, data, buffer);
-            CASE_FILTER_POINT(pi, oo, filter_size, cvalue, UInt8,
-                                                tmp, border_flag_value, function, data, buffer);
-            CASE_FILTER_POINT(pi, oo, filter_size, cvalue, UInt16,
-                                                tmp, border_flag_value, function, data, buffer);
-            CASE_FILTER_POINT(pi, oo, filter_size, cvalue, UInt32,
-                                                tmp, border_flag_value, function, data, buffer);
-#if HAS_UINT64
-            CASE_FILTER_POINT(pi, oo, filter_size, cvalue, UInt64,
-                                                tmp, border_flag_value, function, data, buffer);
-#endif
-            CASE_FILTER_POINT(pi, oo, filter_size, cvalue, Int8,
-                                                tmp, border_flag_value, function, data, buffer);
-            CASE_FILTER_POINT(pi, oo, filter_size, cvalue, Int16,
-                                                tmp, border_flag_value, function, data, buffer);
-            CASE_FILTER_POINT(pi, oo, filter_size, cvalue, Int32,
-                                                tmp, border_flag_value, function, data, buffer);
-            CASE_FILTER_POINT(pi, oo, filter_size, cvalue, Int64,
-                                                tmp, border_flag_value, function, data, buffer);
-            CASE_FILTER_POINT(pi, oo, filter_size, cvalue, Float32,
-                                                tmp, border_flag_value, function, data, buffer);
-            CASE_FILTER_POINT(pi, oo, filter_size, cvalue, Float64,
-                                                tmp, border_flag_value, function, data, buffer);
-        default:
-            PyErr_SetString(PyExc_RuntimeError, "array type not supported");
-            goto exit;
+        switch (PyArray_TYPE(input)) {
+            CASE_FILTER_POINT(NPY_BOOL, npy_bool,
+                              pi, oo, filter_size, cvalue, tmp,
+                              border_flag_value, function, data, buffer);
+            CASE_FILTER_POINT(NPY_UBYTE, npy_ubyte,
+                              pi, oo, filter_size, cvalue, tmp,
+                              border_flag_value, function, data, buffer);
+            CASE_FILTER_POINT(NPY_USHORT, npy_ushort,
+                              pi, oo, filter_size, cvalue, tmp,
+                              border_flag_value, function, data, buffer);
+            CASE_FILTER_POINT(NPY_UINT, npy_uint,
+                              pi, oo, filter_size, cvalue, tmp,
+                              border_flag_value, function, data, buffer);
+            CASE_FILTER_POINT(NPY_ULONG, npy_ulong,
+                              pi, oo, filter_size, cvalue, tmp,
+                              border_flag_value, function, data, buffer);
+            CASE_FILTER_POINT(NPY_ULONGLONG, npy_ulonglong,
+                              pi, oo, filter_size, cvalue, tmp,
+                              border_flag_value, function, data, buffer);
+            CASE_FILTER_POINT(NPY_BYTE, npy_byte,
+                              pi, oo, filter_size, cvalue, tmp,
+                              border_flag_value, function, data, buffer);
+            CASE_FILTER_POINT(NPY_SHORT, npy_short,
+                              pi, oo, filter_size, cvalue, tmp,
+                              border_flag_value, function, data, buffer);
+            CASE_FILTER_POINT(NPY_INT, npy_int,
+                              pi, oo, filter_size, cvalue, tmp,
+                              border_flag_value, function, data, buffer);
+            CASE_FILTER_POINT(NPY_LONG, npy_long,
+                              pi, oo, filter_size, cvalue, tmp,
+                              border_flag_value, function, data, buffer);
+            CASE_FILTER_POINT(NPY_LONGLONG, npy_longlong,
+                              pi, oo, filter_size, cvalue, tmp,
+                              border_flag_value, function, data, buffer);
+            CASE_FILTER_POINT(NPY_FLOAT, npy_float,
+                              pi, oo, filter_size, cvalue, tmp,
+                              border_flag_value, function, data, buffer);
+            CASE_FILTER_POINT(NPY_DOUBLE, npy_double,
+                              pi, oo, filter_size, cvalue, tmp,
+                              border_flag_value, function, data, buffer);
+            default:
+                PyErr_SetString(PyExc_RuntimeError,
+                                "array type not supported");
+                goto exit;
         }
-        switch (NI_NormalizeType(PyArray_TYPE(output))) {
-            CASE_FILTER_OUT(po, tmp, Bool);
-            CASE_FILTER_OUT(po, tmp, UInt8);
-            CASE_FILTER_OUT(po, tmp, UInt16);
-            CASE_FILTER_OUT(po, tmp, UInt32);
-#if HAS_UINT64
-            CASE_FILTER_OUT(po, tmp, UInt64);
-#endif
-            CASE_FILTER_OUT(po, tmp, Int8);
-            CASE_FILTER_OUT(po, tmp, Int16);
-            CASE_FILTER_OUT(po, tmp, Int32);
-            CASE_FILTER_OUT(po, tmp, Int64);
-            CASE_FILTER_OUT(po, tmp, Float32);
-            CASE_FILTER_OUT(po, tmp, Float64);
-        default:
-            PyErr_SetString(PyExc_RuntimeError, "array type not supported");
-            goto exit;
+        switch (PyArray_TYPE(output)) {
+            CASE_FILTER_OUT(NPY_BOOL, npy_bool, po, tmp);
+            CASE_FILTER_OUT(NPY_UBYTE, npy_ubyte, po, tmp);
+            CASE_FILTER_OUT(NPY_USHORT, npy_ushort, po, tmp);
+            CASE_FILTER_OUT(NPY_UINT, npy_uint, po, tmp);
+            CASE_FILTER_OUT(NPY_ULONG, npy_ulong, po, tmp);
+            CASE_FILTER_OUT(NPY_ULONGLONG, npy_ulonglong, po, tmp);
+            CASE_FILTER_OUT(NPY_BYTE, npy_byte, po, tmp);
+            CASE_FILTER_OUT(NPY_SHORT, npy_short, po, tmp);
+            CASE_FILTER_OUT(NPY_INT, npy_int, po, tmp);
+            CASE_FILTER_OUT(NPY_LONG, npy_long, po, tmp);
+            CASE_FILTER_OUT(NPY_LONGLONG, npy_longlong, po, tmp);
+            CASE_FILTER_OUT(NPY_FLOAT, npy_float, po, tmp);
+            CASE_FILTER_OUT(NPY_DOUBLE, npy_double, po, tmp);
+            default:
+                PyErr_SetString(PyExc_RuntimeError,
+                                "array type not supported");
+                goto exit;
         }
         NI_FILTER_NEXT2(fi, ii, io, oo, pi, po);
     }


### PR DESCRIPTION
This is a first PR towards substituting the NumarrayTypes enum in ndimage with the standard NPY_TYPES enum.

In the changes to `ni_filters.c` note that there are more cases now: rather than using bit-sized types and call `NI_NormalizeType` to handle repeated types of the same size, we use the more standard numpy practice of including all three of `npy_int`, `npy_long` and `npy_longlong`, even though one is certain to be a duplicate of one of the others.

Similar changes have to be made to the other files before `NumarrayTypes` and `NI_NormalizeType` can be removed.