### PR TITLE
DOC: make a note in benchmarks README on how to run without rebuilding.

### DIFF
--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -25,6 +25,10 @@ Compare change in benchmark results to another branch::
 
     python runtests.py --bench-compare master sparse.Arithmetic
 
+Run benchmarks against the system-installed SciPy rather than rebuilding::
+
+    python runtests.py -n --bench sparse.Arithmetic
+
 Run ASV commands::
 
     cd benchmarks


### PR DESCRIPTION
``[ci skip]``

Suggestion of @mdhaber, documenting that option more prominently to avoid expensive builds makes sense I think.