### PR TITLE
MAINT: Fix some types from #7549 + miscellaneous warnings.

### DIFF
--- a/scipy/ndimage/src/ni_interpolation.c
+++ b/scipy/ndimage/src/ni_interpolation.c
@@ -367,7 +367,7 @@ NI_GeometricTransform(PyArrayObject *input, int (*map)(npy_intp*, double*,
     NI_Iterator io, ic;
     npy_double *matrix = matrix_ar ? (npy_double*)PyArray_DATA(matrix_ar) : NULL;
     npy_double *shift = shift_ar ? (npy_double*)PyArray_DATA(shift_ar) : NULL;
-    int irank = 0, orank, qq;
+    int irank = 0, orank;
     NPY_BEGIN_THREADS_DEF;
 
     NPY_BEGIN_THREADS;
@@ -697,7 +697,7 @@ int NI_ZoomShift(PyArrayObject *input, PyArrayObject* zoom_ar,
     NI_Iterator io;
     npy_double *zooms = zoom_ar ? (npy_double*)PyArray_DATA(zoom_ar) : NULL;
     npy_double *shifts = shift_ar ? (npy_double*)PyArray_DATA(shift_ar) : NULL;
-    int rank = 0, qq;
+    int rank = 0;
     NPY_BEGIN_THREADS_DEF;
 
     NPY_BEGIN_THREADS;

--- a/scipy/ndimage/src/ni_morphology.c
+++ b/scipy/ndimage/src/ni_morphology.c
@@ -314,7 +314,7 @@ case _TYPE:                                                                   \
     npy_intp _hh, _kk;                                                        \
     for (_hh = 0; _hh < _struct_size; _hh++) {                                \
         npy_intp _to = _offsets[_oo + _hh];                                   \
-        if (_to != _bf_value && *(_type *)(_pi + _to) == _true) {             \
+        if (_to != _bf_value && *(_type *)(_pi + _to) == (_type)_true) {      \
             if (_mklist) {                                                    \
                 npy_intp *_tc = &(_coordinate_offsets[(_oo + _hh) * _irank]); \
                 if (_block2 == NULL || _block2->size == _list2->block_size) { \
@@ -703,12 +703,12 @@ int NI_DistanceTransformBruteForce(PyArrayObject* input, int metric,
                     temp = temp->next;
                 }
                 if (distances)
-                    *(npy_int32*)pd = distance;
+                    *(npy_uint32*)pd = distance;
                 if (features)
                     *(npy_int32*)pf = min_index;
             } else {
                 if (distances)
-                    *(npy_int32*)pd = 0;
+                    *(npy_uint32*)pd = 0;
                 if (features)
                     *(npy_int32*)pf = jj;
             }
@@ -965,7 +965,7 @@ static void _ComputeFT(char *pi, char *pf, npy_intp *ishape,
         _VoronoiFT(pf, ishape[0], coor, rank, 0, fstrides[1], fstrides[0], f,
                              g, sampling);
     } else {
-        npy_int32 axes = 0;
+        npy_uint32 axes = 0;
         char *tf = pf;
         npy_intp size = 1;
         NI_Iterator ii;
@@ -979,7 +979,7 @@ static void _ComputeFT(char *pi, char *pf, npy_intp *ishape,
         }
 
         for(jj = 0; jj < d; jj++) {
-            axes |= (npy_int32)1 << (jj + 1);
+            axes |= (npy_uint32)1 << (jj + 1);
             size *= ishape[jj];
         }
         NI_InitPointIterator(features, &ii);

--- a/scipy/ndimage/src/ni_support.c
+++ b/scipy/ndimage/src/ni_support.c
@@ -53,12 +53,12 @@ int NI_InitPointIterator(PyArrayObject *array, NI_Iterator *iterator)
 
 
 /* initialize iteration over a lower sub-space: */
-int NI_SubspaceIterator(NI_Iterator *iterator, npy_int32 axes)
+int NI_SubspaceIterator(NI_Iterator *iterator, npy_uint32 axes)
 {
     int ii, last = 0;
 
     for(ii = 0; ii <= iterator->rank_m1; ii++) {
-        if (axes & (((npy_int32)1) << ii)) {
+        if (axes & (((npy_uint32)1) << ii)) {
             if (last != ii) {
                 iterator->dimensions[last] = iterator->dimensions[ii];
                 iterator->strides[last] = iterator->strides[ii];
@@ -74,7 +74,7 @@ int NI_SubspaceIterator(NI_Iterator *iterator, npy_int32 axes)
 /* initialize iteration over array lines: */
 int NI_LineIterator(NI_Iterator *iterator, int axis)
 {
-    npy_int32 axes = ((npy_int32)1) << axis;
+    npy_int32 axes = ((npy_uint32)1) << axis;
     return NI_SubspaceIterator(iterator, ~axes);
 }
 

--- a/scipy/ndimage/src/ni_support.h
+++ b/scipy/ndimage/src/ni_support.h
@@ -99,7 +99,7 @@ typedef struct {
 int NI_InitPointIterator(PyArrayObject*, NI_Iterator*);
 
 /* initialize iterations over an arbritrary sub-space: */
-int NI_SubspaceIterator(NI_Iterator*, npy_int32);
+int NI_SubspaceIterator(NI_Iterator*, npy_uint32);
 
 /* initialize iteration over array lines: */
 int NI_LineIterator(NI_Iterator*, int);


### PR DESCRIPTION
Fixes some types that were incorrectly set to `npy_int32`, when they should have been `npy_uint32`, in #7459.

It also silences some compiler warnings reported in #7553, although none of those are the root of the build errors there.