### PR TITLE
ENH: Add the first Wasserstein and the Cramér-von Mises statistical distances

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -178,6 +178,8 @@ David Hagen for the object-oriented ODE solver interface.
 Arno Onken for contributions to scipy.stats.
 Cathy Douglass for bug fixes in ndimage.
 Adam Cox for contributions to scipy.constants.
+Charles Masson for the Wasserstein and the Cramér-von Mises statistical
+    distances.
 
 Institutions
 ------------
@@ -189,3 +191,4 @@ UC Berkeley for providing travel money and hosting numerous sprints.
 The University of Stellenbosch for funding the development of
     the SciKits portal.
 Google Inc. for updating documentation of hypergeometric distribution.
+Datadog Inc. for contributions to scipy.stats.

--- a/doc/release/1.0.0-notes.rst
+++ b/doc/release/1.0.0-notes.rst
@@ -64,6 +64,9 @@ providing the cumulative distribution function of the multivariate normal
 distribution.  The underlying code is the classic one by Alan Genz (see
 `scipy/stats/mvndst.f`).
 
+New statistical distance functions were added, namely `wasserstein` for the
+first Wasserstein distance and `cramer` for the Cramér-von Mises distance.
+
 
 Deprecated features
 ===================

--- a/doc/release/1.0.0-notes.rst
+++ b/doc/release/1.0.0-notes.rst
@@ -64,8 +64,8 @@ providing the cumulative distribution function of the multivariate normal
 distribution.  The underlying code is the classic one by Alan Genz (see
 `scipy/stats/mvndst.f`).
 
-New statistical distance functions were added, namely `wasserstein` for the
-first Wasserstein distance and `energy_distance` for the energy distance.
+New statistical distance functions were added, namely `wasserstein_distance` for
+the first Wasserstein distance and `energy_distance` for the energy distance.
 
 
 Deprecated features

--- a/doc/release/1.0.0-notes.rst
+++ b/doc/release/1.0.0-notes.rst
@@ -65,7 +65,7 @@ distribution.  The underlying code is the classic one by Alan Genz (see
 `scipy/stats/mvndst.f`).
 
 New statistical distance functions were added, namely `wasserstein` for the
-first Wasserstein distance and `cramer` for the Cramér-von Mises distance.
+first Wasserstein distance and `energy_distance` for the energy distance.
 
 
 Deprecated features

--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -295,7 +295,7 @@ which work for masked arrays.
 .. autosummary::
    :toctree: generated/
 
-   wasserstein
+   wasserstein_distance
    energy_distance
 
 Circular statistical functions

--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -296,7 +296,7 @@ which work for masked arrays.
    :toctree: generated/
 
    wasserstein
-   cramer
+   energy_distance
 
 Circular statistical functions
 ==============================

--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -292,6 +292,12 @@ which work for masked arrays.
    chisqprob
    betai
 
+.. autosummary::
+   :toctree: generated/
+
+   wasserstein
+   cramer
+
 Circular statistical functions
 ==============================
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -141,7 +141,7 @@ Statistical Distances
 .. autosummary::
    :toctree: generated/
 
-   wasserstein
+   wasserstein_distance
    energy_distance
 
 ANOVA Functions
@@ -206,7 +206,7 @@ __all__ = ['find_repeats', 'gmean', 'hmean', 'mode', 'tmean', 'tvar',
            'chisqprob', 'betai',
            'f_value_wilks_lambda', 'f_value', 'f_value_multivariate',
            'ss', 'square_of_sums', 'fastsort', 'rankdata',
-           'combine_pvalues', 'wasserstein', 'energy_distance']
+           'combine_pvalues', 'wasserstein_distance', 'energy_distance']
 
 
 def _chk_asarray(a, axis):
@@ -5432,7 +5432,7 @@ def _betai(a, b, x):
 #       STATISTICAL DISTANCES       #
 #####################################
 
-def wasserstein(u_values, v_values, u_weights=None, v_weights=None):
+def wasserstein_distance(u_values, v_values, u_weights=None, v_weights=None):
     r"""
     Compute the first Wasserstein distance between two 1D distributions.
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5493,6 +5493,17 @@ def wasserstein_distance(u_values, v_values, u_weights=None, v_weights=None):
     .. [1] "Wasserstein metric", http://en.wikipedia.org/wiki/Wasserstein_metric
     .. [2] Ramdas, Garcia, Cuturi "On Wasserstein Two Sample Testing and Related
            Families of Nonparametric Tests" (2015). :arXiv:`1509.02237`.
+
+    Examples
+    --------
+    >>> from scipy.stats import wasserstein_distance
+    >>> wasserstein_distance([0, 1, 3], [5, 6, 8])
+    5.0
+    >>> wasserstein_distance([0, 1], [0, 1], [3, 1], [2, 2])
+    0.25
+    >>> wasserstein_distance([3.4, 3.9, 7.5, 7.8], [4.5, 1.4],
+    ...                      [1.4, 0.9, 3.1, 7.2], [3.2, 3.5])
+    4.0781331438047861
     """
     return _cdf_distance(1, u_values, v_values, u_weights, v_weights)
 
@@ -5564,6 +5575,16 @@ def energy_distance(u_values, v_values, u_weights=None, v_weights=None):
            Munos "The Cramer Distance as a Solution to Biased Wasserstein
            Gradients" (2017). :arXiv:`1705.10743`.
 
+    Examples
+    --------
+    >>> from scipy.stats import energy_distance
+    >>> energy_distance([0], [2])
+    2.0000000000000004
+    >>> energy_distance([0, 8], [0, 8], [3, 1], [2, 2])
+    1.0000000000000002
+    >>> energy_distance([0.7, 7.4, 2.4, 6.8], [1.4, 8. ],
+    ...                 [2.1, 4.2, 7.4, 8. ], [7.6, 8.8])
+    0.88003340976158217
     """
     return 2**.5 * _cdf_distance(2, u_values, v_values, u_weights, v_weights)
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5671,8 +5671,7 @@ def _cdf_distance(p, u_values, v_values, u_weights=None, v_weights=None):
     if p == 1:
         return np.sum(np.multiply(np.abs(u_cdf - v_cdf), deltas))
     if p == 2:
-        return np.sqrt(np.sum(np.multiply(np.square(np.abs(u_cdf - v_cdf)),
-                                          deltas)))
+        return np.sqrt(np.sum(np.multiply(np.square(u_cdf - v_cdf), deltas)))
     return np.power(np.sum(np.multiply(np.power(np.abs(u_cdf - v_cdf), p),
                                        deltas)), 1/p)
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5660,7 +5660,7 @@ def _validate_distribution(values, weights):
     # Validate the value array.
     values = np.array(values, dtype=float)
     if len(values) == 0:
-        raise ValueError('Distribution can\'t be empty.')
+        raise ValueError("Distribution can't be empty.")
 
     # Validate the weight array, if specified.
     if weights is not None:

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5436,31 +5436,10 @@ def wasserstein_distance(u_values, v_values, u_weights=None, v_weights=None):
     r"""
     Compute the first Wasserstein distance between two 1D distributions.
 
-    The first Wasserstein distance between the distributions :math:`u` and
-    :math:`v` is:
-
-    .. math::
-
-        l_1 (u, v) = \inf_{\pi \in \Gamma (u, v)} \int_{\mathbb{R} \times
-        \mathbb{R}} |x-y| \mathrm{d} \pi (x, y)
-
-    where :math:`\Gamma (u, v)` is the set of (probability) distributions on
-    :math:`\mathbb{R} \times \mathbb{R}` whose marginals are :math:`u` and
-    :math:`v` on the first and second factors respectively.
-
     This distance is also known as the earth mover's distance, since it can be
     seen as the minimum amount of "work" required to transform :math:`u` into
     :math:`v`, where "work" is measured as the amount of distribution weight
     that must be moved, multiplied by the distance it has to be moved.
-
-    If :math:`U` and :math:`V` are the respective CDFs of :math:`u` and
-    :math:`v`, this distance also equals to:
-
-    .. math::
-
-        l_1(u, v) = \int_{-\infty}^{+\infty} |U-V|
-
-    See [2]_ for a proof of the equivalence of both definitions.
 
     .. versionadded:: 1.0.0
 
@@ -5483,6 +5462,27 @@ def wasserstein_distance(u_values, v_values, u_weights=None, v_weights=None):
 
     Notes
     -----
+    The first Wasserstein distance between the distributions :math:`u` and
+    :math:`v` is:
+
+    .. math::
+
+        l_1 (u, v) = \inf_{\pi \in \Gamma (u, v)} \int_{\mathbb{R} \times
+        \mathbb{R}} |x-y| \mathrm{d} \pi (x, y)
+
+    where :math:`\Gamma (u, v)` is the set of (probability) distributions on
+    :math:`\mathbb{R} \times \mathbb{R}` whose marginals are :math:`u` and
+    :math:`v` on the first and second factors respectively.
+
+    If :math:`U` and :math:`V` are the respective CDFs of :math:`u` and
+    :math:`v`, this distance also equals to:
+
+    .. math::
+
+        l_1(u, v) = \int_{-\infty}^{+\infty} |U-V|
+
+    See [2]_ for a proof of the equivalence of both definitions.
+
     The input distributions can be empirical, therefore coming from samples
     whose values are effectively inputs of the function, or they can be seen as
     generalized functions, in which case they are weighted sums of Dirac delta
@@ -5512,6 +5512,27 @@ def energy_distance(u_values, v_values, u_weights=None, v_weights=None):
     r"""
     Compute the energy distance between two 1D distributions.
 
+    .. versionadded:: 1.0.0
+
+    Parameters
+    ----------
+    u_values, v_values : array_like
+        Values observed in the (empirical) distribution.
+    u_weights, v_weights : array_like, optional
+        Weight for each value. If unspecified, each value is assigned the same
+        weight.
+        `u_weights` (resp. `v_weights`) must have the same length as
+        `u_values` (resp. `v_values`). If the weight sum differs from 1, it
+        must still be positive and finite so that the weights can be normalized
+        to sum to 1.
+
+    Returns
+    -------
+    distance : float
+        The computed distance between the distributions.
+
+    Notes
+    -----
     The energy distance between two distributions :math:`u` and :math:`v`, whose
     respective CDFs are :math:`U` and :math:`V`, equals to:
 
@@ -5537,27 +5558,6 @@ def energy_distance(u_values, v_values, u_weights=None, v_weights=None):
     version of the distance. See [2]_ (section 2), for more details about both
     versions of the distance.
 
-    .. versionadded:: 1.0.0
-
-    Parameters
-    ----------
-    u_values, v_values : array_like
-        Values observed in the (empirical) distribution.
-    u_weights, v_weights : array_like, optional
-        Weight for each value. If unspecified, each value is assigned the same
-        weight.
-        `u_weights` (resp. `v_weights`) must have the same length as
-        `u_values` (resp. `v_values`). If the weight sum differs from 1, it
-        must still be positive and finite so that the weights can be normalized
-        to sum to 1.
-
-    Returns
-    -------
-    distance : float
-        The computed distance between the distributions.
-
-    Notes
-    -----
     The input distributions can be empirical, therefore coming from samples
     whose values are effectively inputs of the function, or they can be seen as
     generalized functions, in which case they are weighted sums of Dirac delta

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5434,8 +5434,7 @@ def _betai(a, b, x):
 
 def wasserstein(u_values, v_values, u_weights=None, v_weights=None):
     r"""
-    Compute the first Wasserstein distance between two one-dimensional
-    distributions.
+    Compute the first Wasserstein distance between two 1D distributions.
 
     The first Wasserstein distance between the distributions :math:`u` and
     :math:`v` is:
@@ -5500,8 +5499,7 @@ def wasserstein(u_values, v_values, u_weights=None, v_weights=None):
 
 def cramer(u_values, v_values, u_weights=None, v_weights=None):
     r"""
-    Compute the Cramer-von Mises distance between two one-dimensional
-    distributions.
+    Compute the Cramer-von Mises distance between two 1D distributions.
 
     The Cramer-von Mises distance between the distributions :math:`u` and
     :math:`v`, whose respective CDFs are :math:`U` and :math:`V`, equals to:

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -142,7 +142,7 @@ Statistical Distances
    :toctree: generated/
 
    wasserstein
-   cramer
+   energy_distance
 
 ANOVA Functions
 ---------------
@@ -206,7 +206,7 @@ __all__ = ['find_repeats', 'gmean', 'hmean', 'mode', 'tmean', 'tvar',
            'chisqprob', 'betai',
            'f_value_wilks_lambda', 'f_value', 'f_value_multivariate',
            'ss', 'square_of_sums', 'fastsort', 'rankdata',
-           'combine_pvalues', 'wasserstein', 'cramer']
+           'combine_pvalues', 'wasserstein', 'energy_distance']
 
 
 def _chk_asarray(a, axis):
@@ -5497,16 +5497,34 @@ def wasserstein(u_values, v_values, u_weights=None, v_weights=None):
     return _cdf_distance(1, u_values, v_values, u_weights, v_weights)
 
 
-def cramer(u_values, v_values, u_weights=None, v_weights=None):
+def energy_distance(u_values, v_values, u_weights=None, v_weights=None):
     r"""
-    Compute the Cramer-von Mises distance between two 1D distributions.
+    Compute the energy distance between two 1D distributions.
 
-    The Cramer-von Mises distance between the distributions :math:`u` and
-    :math:`v`, whose respective CDFs are :math:`U` and :math:`V`, equals to:
+    The energy distance between two distributions :math:`u` and :math:`v`, whose
+    respective CDFs are :math:`U` and :math:`V`, equals to:
 
     .. math::
 
-        l_2(u, v) = \left( \int_{-\infty}^{+\infty} (U-V)^2 \right)^{1/2}
+        D(u, v) = \left( 2\mathbb E|X - Y| - \mathbb E|X - X'| -
+        \mathbb E|Y - Y'| \right)^{1/2}
+
+    where :math:`X` and :math:`X'` (resp. :math:`Y` and :math:`Y'`) are
+    independent random variables whose probability distribution is :math:`u`
+    (resp. :math:`v`).
+
+    As shown in [2]_, for one-dimensional real-valued variables, the energy
+    distance is linked to the non-distribution-free version of the Cramer-von
+    Mises distance:
+
+    .. math::
+
+        D(u, v) = \sqrt{2} l_2(u, v) = \left( 2 \int_{-\infty}^{+\infty} (U-V)^2
+        \right)^{1/2}
+
+    Note that the common Cramer-von Mises criterion uses the distribution-free
+    version of the distance. See [2]_ (section 2), for more details about both
+    versions of the distance.
 
     .. versionadded:: 1.0.0
 
@@ -5536,17 +5554,18 @@ def cramer(u_values, v_values, u_weights=None, v_weights=None):
 
     References
     ----------
-    .. [1] Szekely "E-statistics: The energy of statistical samples." Bowling
+    .. [1] "Energy distance", https://en.wikipedia.org/wiki/Energy_distance
+    .. [2] Szekely "E-statistics: The energy of statistical samples." Bowling
            Green State University, Department of Mathematics and Statistics,
            Technical Report 02-16 (2002).
-    .. [2] Rizzo, Szekely "Energy distance." Wiley Interdisciplinary Reviews:
+    .. [3] Rizzo, Szekely "Energy distance." Wiley Interdisciplinary Reviews:
            Computational Statistics, 8(1):27-38 (2015).
-    .. [3] Bellemare, Danihelka, Dabney, Mohamed, Lakshminarayanan, Hoyer,
+    .. [4] Bellemare, Danihelka, Dabney, Mohamed, Lakshminarayanan, Hoyer,
            Munos "The Cramer Distance as a Solution to Biased Wasserstein
            Gradients" (2017). :arXiv:`1705.10743`.
 
     """
-    return _cdf_distance(2, u_values, v_values, u_weights, v_weights)
+    return 2**.5 * _cdf_distance(2, u_values, v_values, u_weights, v_weights)
 
 
 def _cdf_distance(p, u_values, v_values, u_weights=None, v_weights=None):
@@ -5560,7 +5579,7 @@ def _cdf_distance(p, u_values, v_values, u_weights=None, v_weights=None):
         l_p(u, v) = \left( \int_{-\infty}^{+\infty} |U-V|^p \right)^{1/p}
 
     p is a positive parameter; p = 1 gives the Wasserstein distance, p = 2
-    gives the Cramer-von Mises distance.
+    gives the energy distance.
 
     Parameters
     ----------

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5586,7 +5586,8 @@ def energy_distance(u_values, v_values, u_weights=None, v_weights=None):
     ...                 [2.1, 4.2, 7.4, 8. ], [7.6, 8.8])
     0.88003340976158217
     """
-    return 2**.5 * _cdf_distance(2, u_values, v_values, u_weights, v_weights)
+    return np.sqrt(2) * _cdf_distance(2, u_values, v_values,
+                                      u_weights, v_weights)
 
 
 def _cdf_distance(p, u_values, v_values, u_weights=None, v_weights=None):

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -136,6 +136,14 @@ Probability Calculations
    chisqprob
    betai
 
+Statistical Distances
+---------------------
+.. autosummary::
+   :toctree: generated/
+
+   wasserstein
+   cramer
+
 ANOVA Functions
 ---------------
 .. autosummary::
@@ -198,7 +206,7 @@ __all__ = ['find_repeats', 'gmean', 'hmean', 'mode', 'tmean', 'tvar',
            'chisqprob', 'betai',
            'f_value_wilks_lambda', 'f_value', 'f_value_multivariate',
            'ss', 'square_of_sums', 'fastsort', 'rankdata',
-           'combine_pvalues', ]
+           'combine_pvalues', 'wasserstein', 'cramer']
 
 
 def _chk_asarray(a, axis):
@@ -5418,6 +5426,258 @@ def _betai(a, b, x):
     x = np.asarray(x)
     x = np.where(x < 1.0, x, 1.0)  # if x > 1 then return 1.0
     return special.betainc(a, b, x)
+
+
+#####################################
+#       STATISTICAL DISTANCES       #
+#####################################
+
+def wasserstein(u_values, v_values, u_weights=None, v_weights=None):
+    r"""
+    Compute the first Wasserstein distance between two one-dimensional
+    distributions.
+
+    The first Wasserstein distance between the distributions :math:`u` and
+    :math:`v` is:
+
+    .. math::
+
+        l_1 (u, v) = \inf_{\pi \in \Gamma (u, v)} \int_{\mathbb{R} \times
+        \mathbb{R}} |x-y| \mathrm{d} \pi (x, y)
+
+    where :math:`\Gamma (u, v)` is the set of (probability) distributions on
+    :math:`\mathbb{R} \times \mathbb{R}` whose marginals are :math:`u` and
+    :math:`v` on the first and second factors respectively.
+
+    This distance is also known as the earth mover's distance, since it can be
+    seen as the minimum amount of "work" required to transform :math:`u` into
+    :math:`v`, where "work" is measured as the amount of distribution weight
+    that must be moved, multiplied by the distance it has to be moved.
+
+    If :math:`U` and :math:`V` are the respective CDFs of :math:`u` and
+    :math:`v`, this distance also equals to:
+
+    .. math::
+
+        l_1(u, v) = \int_{-\infty}^{+\infty} |U-V|
+
+    See [2]_ for a proof of the equivalence of both definitions.
+
+    .. versionadded:: 1.0.0
+
+    Parameters
+    ----------
+    u_values, v_values : array_like
+        Values observed in the (empirical) distribution.
+    u_weights, v_weights : array_like, optional
+        Weight for each value. If unspecified, each value is assigned the same
+        weight.
+        `u_weights` (resp. `v_weights`) must have the same length as
+        `u_values` (resp. `v_values`). If the weight sum differs from 1, it
+        must still be positive and finite so that the weights can be normalized
+        to sum to 1.
+
+    Returns
+    -------
+    distance : float
+        The computed distance between the distributions.
+
+    Notes
+    -----
+    The input distributions can be empirical, therefore coming from samples
+    whose values are effectively inputs of the function, or they can be seen as
+    generalized functions, in which case they are weighted sums of Dirac delta
+    functions located at the specified values.
+
+    References
+    ----------
+    .. [1] "Wasserstein metric", http://en.wikipedia.org/wiki/Wasserstein_metric
+    .. [2] Ramdas, Garcia, Cuturi "On Wasserstein Two Sample Testing and Related
+           Families of Nonparametric Tests" (2015). :arXiv:`1509.02237`.
+    """
+    return _cdf_distance(1, u_values, v_values, u_weights, v_weights)
+
+
+def cramer(u_values, v_values, u_weights=None, v_weights=None):
+    r"""
+    Compute the Cramer-von Mises distance between two one-dimensional
+    distributions.
+
+    The Cramer-von Mises distance between the distributions :math:`u` and
+    :math:`v`, whose respective CDFs are :math:`U` and :math:`V`, equals to:
+
+    .. math::
+
+        l_2(u, v) = \left( \int_{-\infty}^{+\infty} (U-V)^2 \right)^{1/2}
+
+    .. versionadded:: 1.0.0
+
+    Parameters
+    ----------
+    u_values, v_values : array_like
+        Values observed in the (empirical) distribution.
+    u_weights, v_weights : array_like, optional
+        Weight for each value. If unspecified, each value is assigned the same
+        weight.
+        `u_weights` (resp. `v_weights`) must have the same length as
+        `u_values` (resp. `v_values`). If the weight sum differs from 1, it
+        must still be positive and finite so that the weights can be normalized
+        to sum to 1.
+
+    Returns
+    -------
+    distance : float
+        The computed distance between the distributions.
+
+    Notes
+    -----
+    The input distributions can be empirical, therefore coming from samples
+    whose values are effectively inputs of the function, or they can be seen as
+    generalized functions, in which case they are weighted sums of Dirac delta
+    functions located at the specified values.
+
+    References
+    ----------
+    .. [1] Szekely "E-statistics: The energy of statistical samples." Bowling
+           Green State University, Department of Mathematics and Statistics,
+           Technical Report 02-16 (2002).
+    .. [2] Rizzo, Szekely "Energy distance." Wiley Interdisciplinary Reviews:
+           Computational Statistics, 8(1):27-38 (2015).
+    .. [3] Bellemare, Danihelka, Dabney, Mohamed, Lakshminarayanan, Hoyer,
+           Munos "The Cramer Distance as a Solution to Biased Wasserstein
+           Gradients" (2017). :arXiv:`1705.10743`.
+
+    """
+    return _cdf_distance(2, u_values, v_values, u_weights, v_weights)
+
+
+def _cdf_distance(p, u_values, v_values, u_weights=None, v_weights=None):
+    r"""
+    Compute, between two one-dimensional distributions :math:`u` and
+    :math:`v`, whose respective CDFs are :math:`U` and :math:`V`, the
+    statistical distance that is defined as:
+
+    .. math::
+
+        l_p(u, v) = \left( \int_{-\infty}^{+\infty} |U-V|^p \right)^{1/p}
+
+    p is a positive parameter; p = 1 gives the Wasserstein distance, p = 2
+    gives the Cramer-von Mises distance.
+
+    Parameters
+    ----------
+    u_values, v_values : array_like
+        Values observed in the (empirical) distribution.
+    u_weights, v_weights : array_like, optional
+        Weight for each value. If unspecified, each value is assigned the same
+        weight.
+        `u_weights` (resp. `v_weights`) must have the same length as
+        `u_values` (resp. `v_values`). If the weight sum differs from 1, it
+        must still be positive and finite so that the weights can be normalized
+        to sum to 1.
+
+    Returns
+    -------
+    distance : float
+        The computed distance between the distributions.
+
+    Notes
+    -----
+    The input distributions can be empirical, therefore coming from samples
+    whose values are effectively inputs of the function, or they can be seen as
+    generalized functions, in which case they are weighted sums of Dirac delta
+    functions located at the specified values.
+
+    References
+    ----------
+    .. [1] Bellemare, Danihelka, Dabney, Mohamed, Lakshminarayanan, Hoyer,
+           Munos "The Cramer Distance as a Solution to Biased Wasserstein
+           Gradients" (2017). :arXiv:`1705.10743`.
+    """
+    u_values, u_weights = _validate_distribution(u_values, u_weights)
+    v_values, v_weights = _validate_distribution(v_values, v_weights)
+
+    u_sorter = np.argsort(u_values)
+    v_sorter = np.argsort(v_values)
+
+    all_values = np.concatenate((u_values, v_values))
+    all_values.sort(kind='mergesort')
+
+    # Compute the differences between pairs of successive values of u and v.
+    deltas = np.diff(all_values)
+
+    # Get the repective positions of the values of u and v among the values of
+    # both distributions.
+    u_cdf_indices = u_values[u_sorter].searchsorted(all_values[:-1], 'right')
+    v_cdf_indices = v_values[v_sorter].searchsorted(all_values[:-1], 'right')
+
+    # Calculate the CDFs of u and v using their weights, if specified.
+    if u_weights is None:
+        u_cdf = u_cdf_indices / u_values.size
+    else:
+        u_sorted_cumweights = np.concatenate(([0],
+                                              np.cumsum(u_weights[u_sorter])))
+        u_cdf = u_sorted_cumweights[u_cdf_indices] / u_sorted_cumweights[-1]
+
+    if v_weights is None:
+        v_cdf = v_cdf_indices / v_values.size
+    else:
+        v_sorted_cumweights = np.concatenate(([0],
+                                              np.cumsum(v_weights[v_sorter])))
+        v_cdf = v_sorted_cumweights[v_cdf_indices] / v_sorted_cumweights[-1]
+
+    # Compute the value of the integral based on the CDFs.
+    # If p = 1 or p = 2, we avoid using np.power, which introduces an overhead
+    # of about 15%.
+    if p == 1:
+        return np.sum(np.multiply(np.abs(u_cdf - v_cdf), deltas))
+    if p == 2:
+        return np.sqrt(np.sum(np.multiply(np.square(np.abs(u_cdf - v_cdf)),
+                                          deltas)))
+    return np.power(np.sum(np.multiply(np.power(np.abs(u_cdf - v_cdf), p),
+                                       deltas)), 1/p)
+
+
+def _validate_distribution(values, weights):
+    """
+    Validate the values and weights from a distribution input of `cdf_distance`
+    and return them as ndarray objects.
+
+    Parameters
+    ----------
+    values : array_like
+        Values observed in the (empirical) distribution.
+    weights : array_like
+        Weight for each value.
+
+    Returns
+    -------
+    values : ndarray
+        Values as ndarray.
+    weights : ndarray
+        Weights as ndarray.
+    """
+    # Validate the value array.
+    values = np.array(values, dtype=float)
+    if len(values) == 0:
+        raise ValueError('Distribution can\'t be empty.')
+
+    # Validate the weight array, if specified.
+    if weights is not None:
+        weights = np.array(weights, dtype=float)
+        if len(weights) != len(values):
+            raise ValueError('Value and weight array-likes for the same '
+                             'empirical distribution must be of the same size.')
+        if np.any(weights < 0):
+            raise ValueError('All weights must be non-negative.')
+        if not 0 < np.sum(weights) < np.inf:
+            raise ValueError('Weight array-like sum must be positive and '
+                             'finite. Set as None for an equal distribution of '
+                             'weight.')
+
+        return values, weights
+
+    return values, None
 
 
 #####################################

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5658,13 +5658,13 @@ def _validate_distribution(values, weights):
         Weights as ndarray.
     """
     # Validate the value array.
-    values = np.array(values, dtype=float)
+    values = np.asarray(values, dtype=float)
     if len(values) == 0:
         raise ValueError("Distribution can't be empty.")
 
     # Validate the weight array, if specified.
     if weights is not None:
-        weights = np.array(weights, dtype=float)
+        weights = np.asarray(weights, dtype=float)
         if len(weights) != len(values):
             raise ValueError('Value and weight array-likes for the same '
                              'empirical distribution must be of the same size.')

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4346,16 +4346,16 @@ class TestEnergyDistance(object):
         # straightforward.
         assert_almost_equal(
             stats.energy_distance([0, 1], [0], [1, 1], [1]),
-            2**.5 * .5)
+            np.sqrt(2) * .5)
         assert_almost_equal(stats.energy_distance(
             [0, 1], [0], [3, 1], [1]),
-            2**.5 * .25)
+            np.sqrt(2) * .25)
         assert_almost_equal(stats.energy_distance(
             [0, 2], [0], [1, 1], [1]),
             2 * .5)
         assert_almost_equal(
             stats.energy_distance([0, 1, 2], [1, 2, 3]),
-            2**.5 * (3*(1./3**2))**.5)
+            np.sqrt(2) * (3*(1./3**2))**.5)
 
     def test_same_distribution(self):
         # Any distribution moved to itself should have a energy distance of
@@ -4368,8 +4368,10 @@ class TestEnergyDistance(object):
     def test_shift(self):
         # If a single-point distribution is shifted by x, then the energy
         # distance should be sqrt(2) * sqrt(x).
-        assert_almost_equal(stats.energy_distance([0], [1]), 2**.5 * 1)
-        assert_almost_equal(stats.energy_distance([-5], [5]), 2**.5 * 10**.5)
+        assert_almost_equal(stats.energy_distance([0], [1]), np.sqrt(2))
+        assert_almost_equal(
+            stats.energy_distance([-5], [5]),
+            np.sqrt(2) * 10**.5)
 
     def test_combine_weights(self):
         # Assigning a weight w to a value is equivalent to including that value

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4311,53 +4311,64 @@ class TestWasserstein(TestCase):
                       [1, 2, np.inf], [np.inf, 1])
 
 
-class TestCramer(TestCase):
-    """ Tests for cramer() output values.
+class TestEnergyDistance(TestCase):
+    """ Tests for energy_distance() output values.
     """
 
     def test_simple(self):
-        # For basic distributions, the value of the Cramer distance is
+        # For basic distributions, the value of the energy distance is
         # straightforward.
-        assert_almost_equal(stats.cramer([0, 1], [0], [1, 1], [1]), .5)
-        assert_almost_equal(stats.cramer([0, 1], [0], [3, 1], [1]), .25)
-        assert_almost_equal(stats.cramer([0, 2], [0], [1, 1], [1]), 2**.5*.5)
         assert_almost_equal(
-            stats.cramer([0, 1, 2], [1, 2, 3]),
-            (3*(1./3**2))**.5)
+            stats.energy_distance([0, 1], [0], [1, 1], [1]),
+            2**.5 * .5)
+        assert_almost_equal(stats.energy_distance(
+            [0, 1], [0], [3, 1], [1]),
+            2**.5 * .25)
+        assert_almost_equal(stats.energy_distance(
+            [0, 2], [0], [1, 1], [1]),
+            2 * .5)
+        assert_almost_equal(
+            stats.energy_distance([0, 1, 2], [1, 2, 3]),
+            2**.5 * (3*(1./3**2))**.5)
 
     def test_same_distribution(self):
-        # Any distribution moved to itself should have a Cramer distance of
+        # Any distribution moved to itself should have a energy distance of
         # zero.
-        assert_equal(stats.cramer([1, 2, 3], [2, 1, 3]), 0)
+        assert_equal(stats.energy_distance([1, 2, 3], [2, 1, 3]), 0)
         assert_equal(
-            stats.cramer([1, 1, 1, 4], [4, 1], [1, 1, 1, 1], [1, 3]),
+            stats.energy_distance([1, 1, 1, 4], [4, 1], [1, 1, 1, 1], [1, 3]),
             0)
 
     def test_shift(self):
-        # If a single-point distribution is shifted by x, then the Cramer
-        # distance should be sqrt(x).
-        assert_almost_equal(stats.cramer([0], [1]), 1)
-        assert_almost_equal(stats.cramer([-5], [5]), 10**.5)
+        # If a single-point distribution is shifted by x, then the energy
+        # distance should be sqrt(2) * sqrt(x).
+        assert_almost_equal(stats.energy_distance([0], [1]), 2**.5 * 1)
+        assert_almost_equal(stats.energy_distance([-5], [5]), 2**.5 * 10**.5)
 
     def test_combine_weights(self):
         # Assigning a weight w to a value is equivalent to including that value
         # w times in the value array with weight of 1.
         assert_almost_equal(
-            stats.cramer([0, 0, 1, 1, 1, 1, 5], [0, 3, 3, 3, 3, 4, 4],
-                         [1, 1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1, 1]),
-            stats.cramer([5, 0, 1], [0, 4, 3], [1, 2, 4], [1, 2, 4]))
+            stats.energy_distance([0, 0, 1, 1, 1, 1, 5], [0, 3, 3, 3, 3, 4, 4],
+                                  [1, 1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1, 1]),
+            stats.energy_distance([5, 0, 1], [0, 4, 3], [1, 2, 4], [1, 2, 4]))
 
     def test_zero_weight(self):
-        # Values with zero weight have no impact on the Cramer distance.
+        # Values with zero weight have no impact on the energy distance.
         assert_almost_equal(
-            stats.cramer([1, 2, 100000], [1, 1], [1, 1, 0], [1, 1]),
-            stats.cramer([1, 2], [1, 1], [1, 1], [1, 1]))
+            stats.energy_distance([1, 2, 100000], [1, 1], [1, 1, 0], [1, 1]),
+            stats.energy_distance([1, 2], [1, 1], [1, 1], [1, 1]))
 
     def test_inf_values(self):
         # Inf values can lead to an inf distance or trigger a RuntimeWarning
         # (and return NaN) if the distance is undefined.
-        assert_equal(stats.cramer([1, 2, np.inf], [1, 1]), np.inf)
-        assert_equal(stats.cramer([1, 2, np.inf], [-np.inf, 1]), np.inf)
-        assert_equal(stats.cramer([1, -np.inf, np.inf], [1, 1]), np.inf)
-        assert_raises(RuntimeWarning, stats.cramer, [1, 2, np.inf], [np.inf, 1])
+        assert_equal(stats.energy_distance([1, 2, np.inf], [1, 1]), np.inf)
+        assert_equal(
+            stats.energy_distance([1, 2, np.inf], [-np.inf, 1]),
+            np.inf)
+        assert_equal(
+            stats.energy_distance([1, -np.inf, np.inf], [1, 1]),
+            np.inf)
+        assert_raises(RuntimeWarning, stats.energy_distance,
+                      [1, 2, np.inf], [np.inf, 1])
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4208,106 +4208,129 @@ class TestCombinePvalues(object):
 
 class TestCdfDistanceValidation(TestCase):
     """
-    Test that _cdf_distance() (via wasserstein()) raises ValueErrors for bad
-    inputs.
+    Test that _cdf_distance() (via wasserstein_distance()) raises ValueErrors
+    for bad inputs.
     """
 
     def test_distinct_value_and_weight_lengths(self):
         # When the number of weights does not match the number of values,
         # a ValueError should be raised.
-        assert_raises(ValueError, stats.wasserstein, [1], [2], [4], [3, 1])
-        assert_raises(ValueError, stats.wasserstein, [1], [2], [1, 0])
+        assert_raises(ValueError, stats.wasserstein_distance,
+                      [1], [2], [4], [3, 1])
+        assert_raises(ValueError, stats.wasserstein_distance, [1], [2], [1, 0])
 
     def test_zero_weight(self):
         # When a distribution is given zero weight, a ValueError should be
         # raised.
-        assert_raises(ValueError, stats.wasserstein, [0, 1], [2], [0, 0])
-        assert_raises(ValueError, stats.wasserstein, [0, 1], [2], [3, 1], [0])
+        assert_raises(ValueError, stats.wasserstein_distance,
+                      [0, 1], [2], [0, 0])
+        assert_raises(ValueError, stats.wasserstein_distance,
+                      [0, 1], [2], [3, 1], [0])
 
     def test_negative_weights(self):
         # A ValueError should be raised if there are any negative weights.
-        assert_raises(ValueError, stats.wasserstein,
+        assert_raises(ValueError, stats.wasserstein_distance,
                       [0, 1], [2, 2], [1, 1], [3, -1])
 
     def test_empty_distribution(self):
         # A ValueError should be raised when trying to measure the distance
         # between something and nothing.
-        assert_raises(ValueError, stats.wasserstein, [], [2, 2])
-        assert_raises(ValueError, stats.wasserstein, [1], [])
+        assert_raises(ValueError, stats.wasserstein_distance, [], [2, 2])
+        assert_raises(ValueError, stats.wasserstein_distance, [1], [])
 
     def test_inf_weight(self):
         # An inf weight is not valid.
-        assert_raises(ValueError, stats.wasserstein,
+        assert_raises(ValueError, stats.wasserstein_distance,
                       [1, 2, 1], [1, 1], [1, np.inf, 1], [1, 1])
 
 
-class TestWasserstein(TestCase):
-    """ Tests for wasserstein() output values.
+class TestWassersteinDistance(TestCase):
+    """ Tests for wasserstein_distance() output values.
     """
 
     def test_simple(self):
         # For basic distributions, the value of the Wasserstein distance is
         # straightforward.
-        assert_almost_equal(stats.wasserstein([0, 1], [0], [1, 1], [1]), .5)
-        assert_almost_equal(stats.wasserstein([0, 1], [0], [3, 1], [1]), .25)
-        assert_almost_equal(stats.wasserstein([0, 2], [0], [1, 1], [1]), 1)
-        assert_almost_equal(stats.wasserstein([0, 1, 2], [1, 2, 3]), 1)
+        assert_almost_equal(
+            stats.wasserstein_distance([0, 1], [0], [1, 1], [1]),
+            .5)
+        assert_almost_equal(stats.wasserstein_distance(
+            [0, 1], [0], [3, 1], [1]),
+            .25)
+        assert_almost_equal(stats.wasserstein_distance(
+            [0, 2], [0], [1, 1], [1]),
+            1)
+        assert_almost_equal(stats.wasserstein_distance(
+            [0, 1, 2], [1, 2, 3]),
+            1)
 
     def test_same_distribution(self):
         # Any distribution moved to itself should have a Wasserstein distance of
         # zero.
-        assert_equal(stats.wasserstein([1, 2, 3], [2, 1, 3]), 0)
+        assert_equal(stats.wasserstein_distance([1, 2, 3], [2, 1, 3]), 0)
         assert_equal(
-            stats.wasserstein([1, 1, 1, 4], [4, 1], [1, 1, 1, 1], [1, 3]),
+            stats.wasserstein_distance([1, 1, 1, 4], [4, 1],
+                                       [1, 1, 1, 1], [1, 3]),
             0)
 
     def test_shift(self):
         # If the whole distribution is shifted by x, then the Wasserstein
         # distance should be x.
-        assert_almost_equal(stats.wasserstein([0], [1]), 1)
-        assert_almost_equal(stats.wasserstein([-5], [5]), 10)
+        assert_almost_equal(stats.wasserstein_distance([0], [1]), 1)
+        assert_almost_equal(stats.wasserstein_distance([-5], [5]), 10)
         assert_almost_equal(
-            stats.wasserstein([1, 2, 3, 4, 5], [11, 12, 13, 14, 15]),
+            stats.wasserstein_distance([1, 2, 3, 4, 5], [11, 12, 13, 14, 15]),
             10)
         assert_almost_equal(
-            stats.wasserstein([4.5, 6.7, 2.1], [4.6, 7, 9.2],
-                              [3, 1, 1], [1, 3, 1]),
+            stats.wasserstein_distance([4.5, 6.7, 2.1], [4.6, 7, 9.2],
+                                       [3, 1, 1], [1, 3, 1]),
             2.5)
 
     def test_combine_weights(self):
         # Assigning a weight w to a value is equivalent to including that value
         # w times in the value array with weight of 1.
         assert_almost_equal(
-            stats.wasserstein([0, 0, 1, 1, 1, 1, 5], [0, 3, 3, 3, 3, 4, 4],
-                              [1, 1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1, 1]),
-            stats.wasserstein([5, 0, 1], [0, 4, 3], [1, 2, 4], [1, 2, 4]))
+            stats.wasserstein_distance(
+                [0, 0, 1, 1, 1, 1, 5], [0, 3, 3, 3, 3, 4, 4],
+                [1, 1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1, 1]),
+            stats.wasserstein_distance([5, 0, 1], [0, 4, 3],
+                                       [1, 2, 4], [1, 2, 4]))
 
     def test_collapse(self):
         # Collapsing a distribution to a point distribution at zero is
         # equivalent to taking the average of the absolute values of the values.
         u = np.arange(-10, 30, 0.3)
         v = np.zeros_like(u)
-        assert_almost_equal(stats.wasserstein(u, v), np.mean(np.abs(u)))
+        assert_almost_equal(
+            stats.wasserstein_distance(u, v),
+            np.mean(np.abs(u)))
 
         u_weights = np.arange(len(u))
         v_weights = u_weights[::-1]
         assert_almost_equal(
-            stats.wasserstein(u, v, u_weights, v_weights),
+            stats.wasserstein_distance(u, v, u_weights, v_weights),
             np.average(np.abs(u), weights=u_weights))
 
     def test_zero_weight(self):
         # Values with zero weight have no impact on the Wasserstein distance.
         assert_almost_equal(
-            stats.wasserstein([1, 2, 100000], [1, 1], [1, 1, 0], [1, 1]),
-            stats.wasserstein([1, 2], [1, 1], [1, 1], [1, 1]))
+            stats.wasserstein_distance([1, 2, 100000], [1, 1],
+                                       [1, 1, 0], [1, 1]),
+            stats.wasserstein_distance([1, 2], [1, 1], [1, 1], [1, 1]))
 
     def test_inf_values(self):
         # Inf values can lead to an inf distance or trigger a RuntimeWarning
         # (and return NaN) if the distance is undefined.
-        assert_equal(stats.wasserstein([1, 2, np.inf], [1, 1]), np.inf)
-        assert_equal(stats.wasserstein([1, 2, np.inf], [-np.inf, 1]), np.inf)
-        assert_equal(stats.wasserstein([1, -np.inf, np.inf], [1, 1]), np.inf)
-        assert_raises(RuntimeWarning, stats.wasserstein,
+        assert_equal(
+            stats.wasserstein_distance([1, 2, np.inf], [1, 1]),
+            np.inf)
+        assert_equal(
+            stats.wasserstein_distance([1, 2, np.inf], [-np.inf, 1]),
+            np.inf)
+        assert_equal(
+            stats.wasserstein_distance([1, -np.inf, np.inf], [1, 1]),
+            np.inf)
+        assert_raises(RuntimeWarning, stats.wasserstein_distance,
                       [1, 2, np.inf], [np.inf, 1])
 
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4330,8 +4330,11 @@ class TestWassersteinDistance(object):
         assert_equal(
             stats.wasserstein_distance([1, -np.inf, np.inf], [1, 1]),
             np.inf)
-        assert_raises(RuntimeWarning, stats.wasserstein_distance,
-                      [1, 2, np.inf], [np.inf, 1])
+        with suppress_warnings() as sup:
+            r = sup.record(RuntimeWarning, "invalid value*")
+            assert_equal(
+                stats.wasserstein_distance([1, 2, np.inf], [np.inf, 1]),
+                np.nan)
 
 
 class TestEnergyDistance(object):
@@ -4392,6 +4395,8 @@ class TestEnergyDistance(object):
         assert_equal(
             stats.energy_distance([1, -np.inf, np.inf], [1, 1]),
             np.inf)
-        assert_raises(RuntimeWarning, stats.energy_distance,
-                      [1, 2, np.inf], [np.inf, 1])
-
+        with suppress_warnings() as sup:
+            r = sup.record(RuntimeWarning, "invalid value*")
+            assert_equal(
+                stats.energy_distance([1, 2, np.inf], [np.inf, 1]),
+                np.nan)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4206,7 +4206,7 @@ class TestCombinePvalues(object):
         assert_approx_equal(p, 0.1464, significant=4)
 
 
-class TestCdfDistanceValidation(TestCase):
+class TestCdfDistanceValidation(object):
     """
     Test that _cdf_distance() (via wasserstein_distance()) raises ValueErrors
     for bad inputs.
@@ -4244,7 +4244,7 @@ class TestCdfDistanceValidation(TestCase):
                       [1, 2, 1], [1, 1], [1, np.inf, 1], [1, 1])
 
 
-class TestWassersteinDistance(TestCase):
+class TestWassersteinDistance(object):
     """ Tests for wasserstein_distance() output values.
     """
 
@@ -4334,7 +4334,7 @@ class TestWassersteinDistance(TestCase):
                       [1, 2, np.inf], [np.inf, 1])
 
 
-class TestEnergyDistance(TestCase):
+class TestEnergyDistance(object):
     """ Tests for energy_distance() output values.
     """
 


### PR DESCRIPTION
This PR adds functions to compute statistical distances, namely the first Wasserstein distance and the Cramér-von Mises distances, which are useful to compare distributions and have applications in various domains.