### PR TITLE
ENH: special: Rewrite agm as a ufunc.

### DIFF
--- a/scipy/special/_agm.pxd
+++ b/scipy/special/_agm.pxd
@@ -1,0 +1,77 @@
+
+import cython
+
+from libc.math cimport log, exp, fabs, sqrt
+
+cdef extern from "_c99compat.h":
+    int sc_isnan(double x) nogil
+    int sc_isinf(double x) nogil
+
+cdef extern from "cephes.h":
+    double ellpk(double m) nogil
+
+from ._complexstuff cimport pi, nan
+
+
+cdef inline double _agm_iter(double a, double b) nogil:
+    # Arithmetic-geometric mean, iterative implementation
+    # a and b must be positive (not zero, not nan).
+
+    cdef double amean, gmean
+
+    cdef int count = 20
+    amean = 0.5*a + 0.5*b
+    while (count > 0) and (amean != a and amean != b):
+        gmean = sqrt(a)*sqrt(b)
+        a = amean
+        b = gmean
+        amean = 0.5*a + 0.5*b
+        count -= 1
+    return amean
+
+
+@cython.cdivision(True)
+cdef inline double agm(double a, double b) nogil:
+    # Arithmetic-geometric mean
+
+    # sqrthalfmax is sqrt(np.finfo(1.0).max/2)
+    # invsqrthalfmax is 1/sqrthalfmax
+    cdef double sqrthalfmax = 9.480751908109176e+153
+    cdef double invsqrthalfmax = 1.0547686614863e-154
+
+    cdef double e
+    cdef int sgn
+
+    if sc_isnan(a) or sc_isnan(b):
+        return nan
+
+    if (a < 0 and b > 0) or (a > 0 and b < 0):
+        # a and b have opposite sign.
+        return nan
+
+    if (sc_isinf(a) or sc_isinf(b)) and (a == 0 or b == 0):
+        # One value is inf and the other is 0.
+        return nan
+
+    if a == 0 or b == 0:
+        # At least one of the arguments is 0.
+        return 0.0 
+
+    if a == b:
+        return a
+
+    sgn = 1
+    if a < 0:
+        sgn = -1
+        a = -a
+        b = -b
+
+    # At this point, a and b are both positive and not nan.
+
+    if (invsqrthalfmax < a < sqrthalfmax) and (invsqrthalfmax < b < sqrthalfmax):
+        e = 4*a*b/(a + b)**2
+        return sgn*(pi/4)*(a + b)/ellpk(e)
+    else:
+        # At least one value is "extreme" (very big or very small).
+        # Use the iteration to avoid overflow or underflow.
+        return sgn*_agm_iter(a, b)

--- a/scipy/special/_ufuncs.pyx
+++ b/scipy/special/_ufuncs.pyx
@@ -1279,6 +1279,9 @@ cdef extern from "_ufuncs_defs.h":
     cdef double _func_struve_power_series "struve_power_series"(double, double, int, double *) nogil
 cdef extern from "_ufuncs_defs.h":
     cdef double _func_zeta "zeta"(double, double) nogil
+from ._agm cimport agm as _func_agm
+ctypedef double _proto_agm_t(double, double) nogil
+cdef _proto_agm_t *_proto_agm_t_var = &_func_agm
 cdef extern from "_ufuncs_defs.h":
     cdef int _func_airy_wrap "airy_wrap"(double, double *, double *, double *, double *) nogil
 cdef extern from "_ufuncs_defs.h":
@@ -2428,6 +2431,78 @@ ufunc__zeta_ptr[2*1+1] = <void*>(<char*>"_zeta")
 ufunc__zeta_data[0] = &ufunc__zeta_ptr[2*0]
 ufunc__zeta_data[1] = &ufunc__zeta_ptr[2*1]
 _zeta = np.PyUFunc_FromFuncAndData(ufunc__zeta_loops, ufunc__zeta_data, ufunc__zeta_types, 2, 2, 1, 0, "_zeta", ufunc__zeta_doc, 0)
+
+cdef np.PyUFuncGenericFunction ufunc_agm_loops[2]
+cdef void *ufunc_agm_ptr[4]
+cdef void *ufunc_agm_data[2]
+cdef char ufunc_agm_types[6]
+cdef char *ufunc_agm_doc = (
+    "agm(a, b)\n"
+    "\n"
+    "Compute the arithmetic-geometric mean of `a` and `b`.\n"
+    "\n"
+    "Start with a_0 = a and b_0 = b and iteratively compute::\n"
+    "\n"
+    "    a_{n+1} = (a_n + b_n)/2\n"
+    "    b_{n+1} = sqrt(a_n*b_n)\n"
+    "\n"
+    "a_n and b_n converge to the same limit as n increases; their common\n"
+    "limit is agm(a, b).\n"
+    "\n"
+    "Parameters\n"
+    "----------\n"
+    "a, b : array_like\n"
+    "    Real values only.  If the values are both negative, the result\n"
+    "    is negative.  If one value is negative and the other is positive,\n"
+    "    `nan` is returned.\n"
+    "\n"
+    "Returns\n"
+    "-------\n"
+    "float\n"
+    "    The arithmetic-geometric mean of `a` and `b`.\n"
+    "\n"
+    "Examples\n"
+    "--------\n"
+    ">>> from scipy.special import agm\n"
+    ">>> a, b = 24.0, 6.0\n"
+    ">>> agm(a, b)\n"
+    "13.458171481725614\n"
+    "\n"
+    "Compare that result to the iteration:\n"
+    "\n"
+    ">>> while a != b:\n"
+    "...     a, b = (a + b)/2, np.sqrt(a*b)\n"
+    "...     print(\"a = %19.16f  b=%19.16f\" % (a, b))\n"
+    "...\n"
+    "a = 15.0000000000000000  b=12.0000000000000000\n"
+    "a = 13.5000000000000000  b=13.4164078649987388\n"
+    "a = 13.4582039324993694  b=13.4581390309909850\n"
+    "a = 13.4581714817451772  b=13.4581714817060547\n"
+    "a = 13.4581714817256159  b=13.4581714817256159\n"
+    "\n"
+    "When array-like arguments are given, broadcasting applies:\n"
+    "\n"
+    ">>> a = np.array([[1.5], [3], [6]])  # a has shape (3, 1).\n"
+    ">>> b = np.array([6, 12, 24, 48])    # b has shape (4,).\n"
+    ">>> agm(a, b)\n"
+    "array([[  3.36454287,   5.42363427,   9.05798751,  15.53650756],\n"
+    "       [  4.37037309,   6.72908574,  10.84726853,  18.11597502],\n"
+    "       [  6.        ,   8.74074619,  13.45817148,  21.69453707]])")
+ufunc_agm_loops[0] = <np.PyUFuncGenericFunction>loop_d_dd__As_ff_f
+ufunc_agm_loops[1] = <np.PyUFuncGenericFunction>loop_d_dd__As_dd_d
+ufunc_agm_types[0] = <char>NPY_FLOAT
+ufunc_agm_types[1] = <char>NPY_FLOAT
+ufunc_agm_types[2] = <char>NPY_FLOAT
+ufunc_agm_types[3] = <char>NPY_DOUBLE
+ufunc_agm_types[4] = <char>NPY_DOUBLE
+ufunc_agm_types[5] = <char>NPY_DOUBLE
+ufunc_agm_ptr[2*0] = <void*>_func_agm
+ufunc_agm_ptr[2*0+1] = <void*>(<char*>"agm")
+ufunc_agm_ptr[2*1] = <void*>_func_agm
+ufunc_agm_ptr[2*1+1] = <void*>(<char*>"agm")
+ufunc_agm_data[0] = &ufunc_agm_ptr[2*0]
+ufunc_agm_data[1] = &ufunc_agm_ptr[2*1]
+agm = np.PyUFunc_FromFuncAndData(ufunc_agm_loops, ufunc_agm_data, ufunc_agm_types, 2, 2, 1, 0, "agm", ufunc_agm_doc, 0)
 
 cdef np.PyUFuncGenericFunction ufunc_airy_loops[4]
 cdef void *ufunc_airy_ptr[8]

--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -161,6 +161,62 @@ add_newdoc("scipy.special", "wrightomega",
 
     """)
 
+
+add_newdoc("scipy.special", "agm",
+    """
+    agm(a, b)
+
+    Compute the arithmetic-geometric mean of `a` and `b`.
+
+    Start with a_0 = a and b_0 = b and iteratively compute::
+
+        a_{n+1} = (a_n + b_n)/2
+        b_{n+1} = sqrt(a_n*b_n)
+
+    a_n and b_n converge to the same limit as n increases; their common
+    limit is agm(a, b).
+
+    Parameters
+    ----------
+    a, b : array_like
+        Real values only.  If the values are both negative, the result
+        is negative.  If one value is negative and the other is positive,
+        `nan` is returned.
+
+    Returns
+    -------
+    float
+        The arithmetic-geometric mean of `a` and `b`.
+
+    Examples
+    --------
+    >>> from scipy.special import agm
+    >>> a, b = 24.0, 6.0
+    >>> agm(a, b)
+    13.458171481725614
+
+    Compare that result to the iteration:
+
+    >>> while a != b:
+    ...     a, b = (a + b)/2, np.sqrt(a*b)
+    ...     print("a = %19.16f  b=%19.16f" % (a, b))
+    ...
+    a = 15.0000000000000000  b=12.0000000000000000
+    a = 13.5000000000000000  b=13.4164078649987388
+    a = 13.4582039324993694  b=13.4581390309909850
+    a = 13.4581714817451772  b=13.4581714817060547
+    a = 13.4581714817256159  b=13.4581714817256159
+
+    When array-like arguments are given, broadcasting applies:
+
+    >>> a = np.array([[1.5], [3], [6]])  # a has shape (3, 1).
+    >>> b = np.array([6, 12, 24, 48])    # b has shape (4,).
+    >>> agm(a, b)
+    array([[  3.36454287,   5.42363427,   9.05798751,  15.53650756],
+           [  4.37037309,   6.72908574,  10.84726853,  18.11597502],
+           [  6.        ,   8.74074619,  13.45817148,  21.69453707]])
+    """)
+
 add_newdoc("scipy.special", "airy",
     r"""
     airy(z)

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -21,7 +21,7 @@ from . import orthogonal
 from ._comb import _comb_int
 
 
-__all__ = ['agm', 'ai_zeros', 'assoc_laguerre', 'bei_zeros', 'beip_zeros',
+__all__ = ['ai_zeros', 'assoc_laguerre', 'bei_zeros', 'beip_zeros',
            'ber_zeros', 'bernoulli', 'berp_zeros', 'bessel_diff_formula',
            'bi_zeros', 'clpmn', 'comb', 'digamma', 'diric', 'ellipk',
            'erf_zeros', 'erfcinv', 'erfinv', 'euler', 'factorial',
@@ -2062,24 +2062,6 @@ def ellipk(m):
 
     """
     return ellipkm1(1 - asarray(m))
-
-
-def agm(a, b):
-    """Arithmetic, Geometric Mean.
-
-    Start with a_0=a and b_0=b and iteratively compute
-
-    a_{n+1} = (a_n+b_n)/2
-    b_{n+1} = sqrt(a_n*b_n)
-
-    until a_n=b_n.   The result is agm(a, b)
-
-    agm(a, b)=agm(b, a)
-    agm(a, a) = a
-    min(a, b) < agm(a, b) < max(a, b)
-    """
-    s = a + b + 0.0
-    return (pi / 4) * s / ellipkm1(4 * a * b / s ** 2)
 
 
 def comb(N, k, exact=False, repetition=False):

--- a/scipy/special/cython_special.pxd
+++ b/scipy/special/cython_special.pxd
@@ -14,6 +14,7 @@ ctypedef fused dl_number_t:
     double
     long
 
+cpdef double agm(double x0, double x1) nogil
 cdef void airy(Dd_number_t x0, Dd_number_t *y0, Dd_number_t *y1, Dd_number_t *y2, Dd_number_t *y3) nogil
 cdef void airye(Dd_number_t x0, Dd_number_t *y0, Dd_number_t *y1, Dd_number_t *y2, Dd_number_t *y3) nogil
 cpdef double bdtr(dl_number_t x0, dl_number_t x1, double x2) nogil

--- a/scipy/special/cython_special.pyx
+++ b/scipy/special/cython_special.pyx
@@ -31,6 +31,10 @@ cannot emit warnings like their counterparts in ``scipy.special``.
 Available Functions
 ===================
 
+- :py:func:`~scipy.special.agm`::
+
+        double agm(double, double)
+
 - :py:func:`~scipy.special.airy`::
 
         void airy(double, double *, double *, double *, double *)
@@ -987,50 +991,53 @@ Available Functions
 from __future__ import absolute_import
 include "_cython_special.pxi"
 
-cdef extern from "./_ufuncs_defs.h":
+from ._agm cimport agm as _func_agm
+ctypedef double _proto_agm_t(double, double) nogil
+cdef _proto_agm_t *_proto_agm_t_var = &_func_agm
+cdef extern from "_ufuncs_defs.h":
     cdef npy_int _func_airy_wrap "airy_wrap"(npy_double, npy_double *, npy_double *, npy_double *, npy_double *)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_int _func_cairy_wrap "cairy_wrap"(npy_cdouble, npy_cdouble *, npy_cdouble *, npy_cdouble *, npy_cdouble *)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_int _func_cairy_wrap_e_real "cairy_wrap_e_real"(npy_double, npy_double *, npy_double *, npy_double *, npy_double *)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_int _func_cairy_wrap_e "cairy_wrap_e"(npy_cdouble, npy_cdouble *, npy_cdouble *, npy_cdouble *, npy_cdouble *)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_bdtr "bdtr"(npy_int, npy_int, npy_double)nogil
 from ._legacy cimport bdtr_unsafe as _func_bdtr_unsafe
 ctypedef double _proto_bdtr_unsafe_t(double, double, double) nogil
 cdef _proto_bdtr_unsafe_t *_proto_bdtr_unsafe_t_var = &_func_bdtr_unsafe
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_bdtrc "bdtrc"(npy_int, npy_int, npy_double)nogil
 from ._legacy cimport bdtrc_unsafe as _func_bdtrc_unsafe
 ctypedef double _proto_bdtrc_unsafe_t(double, double, double) nogil
 cdef _proto_bdtrc_unsafe_t *_proto_bdtrc_unsafe_t_var = &_func_bdtrc_unsafe
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_bdtri "bdtri"(npy_int, npy_int, npy_double)nogil
 from ._legacy cimport bdtri_unsafe as _func_bdtri_unsafe
 ctypedef double _proto_bdtri_unsafe_t(double, double, double) nogil
 cdef _proto_bdtri_unsafe_t *_proto_bdtri_unsafe_t_var = &_func_bdtri_unsafe
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_cdfbin2_wrap "cdfbin2_wrap"(npy_double, npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_cdfbin3_wrap "cdfbin3_wrap"(npy_double, npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_bei_wrap "bei_wrap"(npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_beip_wrap "beip_wrap"(npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_ber_wrap "ber_wrap"(npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_berp_wrap "berp_wrap"(npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_besselpoly "besselpoly"(npy_double, npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_beta "beta"(npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_incbet "incbet"(npy_double, npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_incbi "incbi"(npy_double, npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_lbeta "lbeta"(npy_double, npy_double)nogil
 from .orthogonal_eval cimport binom as _func_binom
 ctypedef double _proto_binom_t(double, double) nogil
@@ -1041,54 +1048,54 @@ cdef _proto_boxcox_t *_proto_boxcox_t_var = &_func_boxcox
 from ._boxcox cimport boxcox1p as _func_boxcox1p
 ctypedef double _proto_boxcox1p_t(double, double) nogil
 cdef _proto_boxcox1p_t *_proto_boxcox1p_t_var = &_func_boxcox1p
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_btdtr "btdtr"(npy_double, npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_incbi "incbi"(npy_double, npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_cdfbet3_wrap "cdfbet3_wrap"(npy_double, npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_cdfbet4_wrap "cdfbet4_wrap"(npy_double, npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_cbrt "cbrt"(npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_chdtr "chdtr"(npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_chdtrc "chdtrc"(npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_chdtri "chdtri"(npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_cdfchi3_wrap "cdfchi3_wrap"(npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_cdfchn1_wrap "cdfchn1_wrap"(npy_double, npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_cdfchn3_wrap "cdfchn3_wrap"(npy_double, npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_cdfchn4_wrap "cdfchn4_wrap"(npy_double, npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_cdfchn2_wrap "cdfchn2_wrap"(npy_double, npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_cosdg "cosdg"(npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_cosm1 "cosm1"(npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_cotdg "cotdg"(npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_ellpe "ellpe"(npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_ellie "ellie"(npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_int _func_ellpj "ellpj"(npy_double, npy_double, npy_double *, npy_double *, npy_double *, npy_double *)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_ellik "ellik"(npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_ellpk "ellpk"(npy_double)nogil
 from ._convex_analysis cimport entr as _func_entr
 ctypedef double _proto_entr_t(double) nogil
 cdef _proto_entr_t *_proto_entr_t_var = &_func_entr
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_erf "erf"(npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_erfc "erfc"(npy_double)nogil
 from .orthogonal_eval cimport eval_chebyc as _func_eval_chebyc
 ctypedef double _proto_eval_chebyc_double__t(double, double) nogil
@@ -1213,30 +1220,30 @@ cdef _proto_eval_sh_legendre_double_complex__t *_proto_eval_sh_legendre_double_c
 from .orthogonal_eval cimport eval_sh_legendre_l as _func_eval_sh_legendre_l
 ctypedef double _proto_eval_sh_legendre_l_t(long, double) nogil
 cdef _proto_eval_sh_legendre_l_t *_proto_eval_sh_legendre_l_t_var = &_func_eval_sh_legendre_l
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_exp1_wrap "exp1_wrap"(npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_cdouble _func_cexp1_wrap "cexp1_wrap"(npy_cdouble)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_exp10 "exp10"(npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_exp2 "exp2"(npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_expi_wrap "expi_wrap"(npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_cdouble _func_cexpi_wrap "cexpi_wrap"(npy_cdouble)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_float _func_expitf "expitf"(npy_float)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_expit "expit"(npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_longdouble _func_expitl "expitl"(npy_longdouble)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_expm1 "expm1"(npy_double)nogil
 from ._cunity cimport cexpm1 as _func_cexpm1
 ctypedef double complex _proto_cexpm1_t(double complex) nogil
 cdef _proto_cexpm1_t *_proto_cexpm1_t_var = &_func_cexpm1
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_expn "expn"(npy_int, npy_double)nogil
 from ._legacy cimport expn_unsafe as _func_expn_unsafe
 ctypedef double _proto_expn_unsafe_t(double, double) nogil
@@ -1244,52 +1251,52 @@ cdef _proto_expn_unsafe_t *_proto_expn_unsafe_t_var = &_func_expn_unsafe
 from ._exprel cimport exprel as _func_exprel
 ctypedef double _proto_exprel_t(double) nogil
 cdef _proto_exprel_t *_proto_exprel_t_var = &_func_exprel
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_fdtr "fdtr"(npy_double, npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_fdtrc "fdtrc"(npy_double, npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_fdtri "fdtri"(npy_double, npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_cdff4_wrap "cdff4_wrap"(npy_double, npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_int _func_fresnl "fresnl"(npy_double, npy_double *, npy_double *)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_int _func_cfresnl_wrap "cfresnl_wrap"(npy_cdouble, npy_cdouble *, npy_cdouble *)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_Gamma "Gamma"(npy_double)nogil
 from ._loggamma cimport cgamma as _func_cgamma
 ctypedef double complex _proto_cgamma_t(double complex) nogil
 cdef _proto_cgamma_t *_proto_cgamma_t_var = &_func_cgamma
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_igam "igam"(npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_igamc "igamc"(npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_igami "igami"(npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_gammaincinv "gammaincinv"(npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_lgam "lgam"(npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_gammasgn "gammasgn"(npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_gdtr "gdtr"(npy_double, npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_gdtrc "gdtrc"(npy_double, npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_cdfgam4_wrap "cdfgam4_wrap"(npy_double, npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_cdfgam3_wrap "cdfgam3_wrap"(npy_double, npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_cdfgam2_wrap "cdfgam2_wrap"(npy_double, npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_cdouble _func_cbesh_wrap1 "cbesh_wrap1"(npy_double, npy_cdouble)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_cdouble _func_cbesh_wrap1_e "cbesh_wrap1_e"(npy_double, npy_cdouble)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_cdouble _func_cbesh_wrap2 "cbesh_wrap2"(npy_double, npy_cdouble)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_cdouble _func_cbesh_wrap2_e "cbesh_wrap2_e"(npy_double, npy_cdouble)nogil
 from ._convex_analysis cimport huber as _func_huber
 ctypedef double _proto_huber_t(double, double) nogil
@@ -1300,32 +1307,32 @@ cdef _proto__hyp0f1_real_t *_proto__hyp0f1_real_t_var = &_func__hyp0f1_real
 from ._hyp0f1 cimport _hyp0f1_cmplx as _func__hyp0f1_cmplx
 ctypedef double complex _proto__hyp0f1_cmplx_t(double, double complex) nogil
 cdef _proto__hyp0f1_cmplx_t *_proto__hyp0f1_cmplx_t_var = &_func__hyp0f1_cmplx
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_hyp1f1_wrap "hyp1f1_wrap"(npy_double, npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_cdouble _func_chyp1f1_wrap "chyp1f1_wrap"(npy_double, npy_double, npy_cdouble)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_onef2 "onef2"(npy_double, npy_double, npy_double, npy_double, npy_double *)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_hyp2f0 "hyp2f0"(npy_double, npy_double, npy_double, npy_int, npy_double *)nogil
 from ._legacy cimport hyp2f0_unsafe as _func_hyp2f0_unsafe
 ctypedef double _proto_hyp2f0_unsafe_t(double, double, double, double, double *) nogil
 cdef _proto_hyp2f0_unsafe_t *_proto_hyp2f0_unsafe_t_var = &_func_hyp2f0_unsafe
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_hyp2f1 "hyp2f1"(npy_double, npy_double, npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_cdouble _func_chyp2f1_wrap "chyp2f1_wrap"(npy_double, npy_double, npy_double, npy_cdouble)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_threef0 "threef0"(npy_double, npy_double, npy_double, npy_double, npy_double *)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_hypU_wrap "hypU_wrap"(npy_double, npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_i0 "i0"(npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_i0e "i0e"(npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_i1 "i1"(npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_i1e "i1e"(npy_double)nogil
 from ._boxcox cimport inv_boxcox as _func_inv_boxcox
 ctypedef double _proto_inv_boxcox_t(double, double) nogil
@@ -1333,217 +1340,217 @@ cdef _proto_inv_boxcox_t *_proto_inv_boxcox_t_var = &_func_inv_boxcox
 from ._boxcox cimport inv_boxcox1p as _func_inv_boxcox1p
 ctypedef double _proto_inv_boxcox1p_t(double, double) nogil
 cdef _proto_inv_boxcox1p_t *_proto_inv_boxcox1p_t_var = &_func_inv_boxcox1p
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_int _func_it2i0k0_wrap "it2i0k0_wrap"(npy_double, npy_double *, npy_double *)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_int _func_it2j0y0_wrap "it2j0y0_wrap"(npy_double, npy_double *, npy_double *)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_it2struve0_wrap "it2struve0_wrap"(npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_int _func_itairy_wrap "itairy_wrap"(npy_double, npy_double *, npy_double *, npy_double *, npy_double *)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_int _func_it1i0k0_wrap "it1i0k0_wrap"(npy_double, npy_double *, npy_double *)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_int _func_it1j0y0_wrap "it1j0y0_wrap"(npy_double, npy_double *, npy_double *)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_itmodstruve0_wrap "itmodstruve0_wrap"(npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_itstruve0_wrap "itstruve0_wrap"(npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_iv "iv"(npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_cdouble _func_cbesi_wrap "cbesi_wrap"(npy_double, npy_cdouble)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_cbesi_wrap_e_real "cbesi_wrap_e_real"(npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_cdouble _func_cbesi_wrap_e "cbesi_wrap_e"(npy_double, npy_cdouble)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_j0 "j0"(npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_j1 "j1"(npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_cbesj_wrap_real "cbesj_wrap_real"(npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_cdouble _func_cbesj_wrap "cbesj_wrap"(npy_double, npy_cdouble)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_cbesj_wrap_e_real "cbesj_wrap_e_real"(npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_cdouble _func_cbesj_wrap_e "cbesj_wrap_e"(npy_double, npy_cdouble)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_k0 "k0"(npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_k0e "k0e"(npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_k1 "k1"(npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_k1e "k1e"(npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_kei_wrap "kei_wrap"(npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_keip_wrap "keip_wrap"(npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_int _func_kelvin_wrap "kelvin_wrap"(npy_double, npy_cdouble *, npy_cdouble *, npy_cdouble *, npy_cdouble *)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_ker_wrap "ker_wrap"(npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_kerp_wrap "kerp_wrap"(npy_double)nogil
 from ._convex_analysis cimport kl_div as _func_kl_div
 ctypedef double _proto_kl_div_t(double, double) nogil
 cdef _proto_kl_div_t *_proto_kl_div_t_var = &_func_kl_div
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_cbesk_wrap_real_int "cbesk_wrap_real_int"(npy_int, npy_double)nogil
 from ._legacy cimport kn_unsafe as _func_kn_unsafe
 ctypedef double _proto_kn_unsafe_t(double, double) nogil
 cdef _proto_kn_unsafe_t *_proto_kn_unsafe_t_var = &_func_kn_unsafe
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_kolmogi "kolmogi"(npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_kolmogorov "kolmogorov"(npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_cbesk_wrap_real "cbesk_wrap_real"(npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_cdouble _func_cbesk_wrap "cbesk_wrap"(npy_double, npy_cdouble)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_cbesk_wrap_e_real "cbesk_wrap_e_real"(npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_cdouble _func_cbesk_wrap_e "cbesk_wrap_e"(npy_double, npy_cdouble)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_log1p "log1p"(npy_double)nogil
 from ._cunity cimport clog1p as _func_clog1p
 ctypedef double complex _proto_clog1p_t(double complex) nogil
 cdef _proto_clog1p_t *_proto_clog1p_t_var = &_func_clog1p
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_log_ndtr "log_ndtr"(npy_double)nogil
 from ._loggamma cimport loggamma as _func_loggamma
 ctypedef double complex _proto_loggamma_t(double complex) nogil
 cdef _proto_loggamma_t *_proto_loggamma_t_var = &_func_loggamma
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_float _func_logitf "logitf"(npy_float)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_logit "logit"(npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_longdouble _func_logitl "logitl"(npy_longdouble)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_pmv_wrap "pmv_wrap"(npy_double, npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_cem_cva_wrap "cem_cva_wrap"(npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_sem_cva_wrap "sem_cva_wrap"(npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_int _func_cem_wrap "cem_wrap"(npy_double, npy_double, npy_double, npy_double *, npy_double *)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_int _func_mcm1_wrap "mcm1_wrap"(npy_double, npy_double, npy_double, npy_double *, npy_double *)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_int _func_mcm2_wrap "mcm2_wrap"(npy_double, npy_double, npy_double, npy_double *, npy_double *)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_int _func_msm1_wrap "msm1_wrap"(npy_double, npy_double, npy_double, npy_double *, npy_double *)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_int _func_msm2_wrap "msm2_wrap"(npy_double, npy_double, npy_double, npy_double *, npy_double *)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_int _func_sem_wrap "sem_wrap"(npy_double, npy_double, npy_double, npy_double *, npy_double *)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_int _func_modified_fresnel_minus_wrap "modified_fresnel_minus_wrap"(npy_double, npy_cdouble *, npy_cdouble *)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_int _func_modified_fresnel_plus_wrap "modified_fresnel_plus_wrap"(npy_double, npy_cdouble *, npy_cdouble *)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_struve_l "struve_l"(npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_nbdtr "nbdtr"(npy_int, npy_int, npy_double)nogil
 from ._legacy cimport nbdtr_unsafe as _func_nbdtr_unsafe
 ctypedef double _proto_nbdtr_unsafe_t(double, double, double) nogil
 cdef _proto_nbdtr_unsafe_t *_proto_nbdtr_unsafe_t_var = &_func_nbdtr_unsafe
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_nbdtrc "nbdtrc"(npy_int, npy_int, npy_double)nogil
 from ._legacy cimport nbdtrc_unsafe as _func_nbdtrc_unsafe
 ctypedef double _proto_nbdtrc_unsafe_t(double, double, double) nogil
 cdef _proto_nbdtrc_unsafe_t *_proto_nbdtrc_unsafe_t_var = &_func_nbdtrc_unsafe
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_nbdtri "nbdtri"(npy_int, npy_int, npy_double)nogil
 from ._legacy cimport nbdtri_unsafe as _func_nbdtri_unsafe
 ctypedef double _proto_nbdtri_unsafe_t(double, double, double) nogil
 cdef _proto_nbdtri_unsafe_t *_proto_nbdtri_unsafe_t_var = &_func_nbdtri_unsafe
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_cdfnbn2_wrap "cdfnbn2_wrap"(npy_double, npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_cdfnbn3_wrap "cdfnbn3_wrap"(npy_double, npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_cdffnc1_wrap "cdffnc1_wrap"(npy_double, npy_double, npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_cdffnc2_wrap "cdffnc2_wrap"(npy_double, npy_double, npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_cdffnc4_wrap "cdffnc4_wrap"(npy_double, npy_double, npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_cdffnc3_wrap "cdffnc3_wrap"(npy_double, npy_double, npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_cdffnc5_wrap "cdffnc5_wrap"(npy_double, npy_double, npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_cdftnc1_wrap "cdftnc1_wrap"(npy_double, npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_cdftnc3_wrap "cdftnc3_wrap"(npy_double, npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_cdftnc4_wrap "cdftnc4_wrap"(npy_double, npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_cdftnc2_wrap "cdftnc2_wrap"(npy_double, npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_ndtr "ndtr"(npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_ndtri "ndtri"(npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_cdfnor3_wrap "cdfnor3_wrap"(npy_double, npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_cdfnor4_wrap "cdfnor4_wrap"(npy_double, npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_oblate_aswfa_nocv_wrap "oblate_aswfa_nocv_wrap"(npy_double, npy_double, npy_double, npy_double, npy_double *)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_int _func_oblate_aswfa_wrap "oblate_aswfa_wrap"(npy_double, npy_double, npy_double, npy_double, npy_double, npy_double *, npy_double *)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_oblate_segv_wrap "oblate_segv_wrap"(npy_double, npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_oblate_radial1_nocv_wrap "oblate_radial1_nocv_wrap"(npy_double, npy_double, npy_double, npy_double, npy_double *)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_int _func_oblate_radial1_wrap "oblate_radial1_wrap"(npy_double, npy_double, npy_double, npy_double, npy_double, npy_double *, npy_double *)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_oblate_radial2_nocv_wrap "oblate_radial2_nocv_wrap"(npy_double, npy_double, npy_double, npy_double, npy_double *)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_int _func_oblate_radial2_wrap "oblate_radial2_wrap"(npy_double, npy_double, npy_double, npy_double, npy_double, npy_double *, npy_double *)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_int _func_pbdv_wrap "pbdv_wrap"(npy_double, npy_double, npy_double *, npy_double *)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_int _func_pbvv_wrap "pbvv_wrap"(npy_double, npy_double, npy_double *, npy_double *)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_int _func_pbwa_wrap "pbwa_wrap"(npy_double, npy_double, npy_double *, npy_double *)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_pdtr "pdtr"(npy_int, npy_double)nogil
 from ._legacy cimport pdtr_unsafe as _func_pdtr_unsafe
 ctypedef double _proto_pdtr_unsafe_t(double, double) nogil
 cdef _proto_pdtr_unsafe_t *_proto_pdtr_unsafe_t_var = &_func_pdtr_unsafe
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_pdtrc "pdtrc"(npy_int, npy_double)nogil
 from ._legacy cimport pdtrc_unsafe as _func_pdtrc_unsafe
 ctypedef double _proto_pdtrc_unsafe_t(double, double) nogil
 cdef _proto_pdtrc_unsafe_t *_proto_pdtrc_unsafe_t_var = &_func_pdtrc_unsafe
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_pdtri "pdtri"(npy_int, npy_double)nogil
 from ._legacy cimport pdtri_unsafe as _func_pdtri_unsafe
 ctypedef double _proto_pdtri_unsafe_t(double, double) nogil
 cdef _proto_pdtri_unsafe_t *_proto_pdtri_unsafe_t_var = &_func_pdtri_unsafe
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_cdfpoi2_wrap "cdfpoi2_wrap"(npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_poch "poch"(npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_prolate_aswfa_nocv_wrap "prolate_aswfa_nocv_wrap"(npy_double, npy_double, npy_double, npy_double, npy_double *)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_int _func_prolate_aswfa_wrap "prolate_aswfa_wrap"(npy_double, npy_double, npy_double, npy_double, npy_double, npy_double *, npy_double *)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_prolate_segv_wrap "prolate_segv_wrap"(npy_double, npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_prolate_radial1_nocv_wrap "prolate_radial1_nocv_wrap"(npy_double, npy_double, npy_double, npy_double, npy_double *)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_int _func_prolate_radial1_wrap "prolate_radial1_wrap"(npy_double, npy_double, npy_double, npy_double, npy_double, npy_double *, npy_double *)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_prolate_radial2_nocv_wrap "prolate_radial2_nocv_wrap"(npy_double, npy_double, npy_double, npy_double, npy_double *)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_int _func_prolate_radial2_wrap "prolate_radial2_wrap"(npy_double, npy_double, npy_double, npy_double, npy_double, npy_double *, npy_double *)nogil
 from ._convex_analysis cimport pseudo_huber as _func_pseudo_huber
 ctypedef double _proto_pseudo_huber_t(double, double) nogil
@@ -1554,41 +1561,41 @@ cdef _proto_digamma_t *_proto_digamma_t_var = &_func_digamma
 from ._digamma cimport cdigamma as _func_cdigamma
 ctypedef double complex _proto_cdigamma_t(double complex) nogil
 cdef _proto_cdigamma_t *_proto_cdigamma_t_var = &_func_cdigamma
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_radian "radian"(npy_double, npy_double, npy_double)nogil
 from ._convex_analysis cimport rel_entr as _func_rel_entr
 ctypedef double _proto_rel_entr_t(double, double) nogil
 cdef _proto_rel_entr_t *_proto_rel_entr_t_var = &_func_rel_entr
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_rgamma "rgamma"(npy_double)nogil
 from ._loggamma cimport crgamma as _func_crgamma
 ctypedef double complex _proto_crgamma_t(double complex) nogil
 cdef _proto_crgamma_t *_proto_crgamma_t_var = &_func_crgamma
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_round "round"(npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_int _func_shichi "shichi"(npy_double, npy_double *, npy_double *)nogil
 from ._sici cimport cshichi as _func_cshichi
 ctypedef int _proto_cshichi_t(double complex, double complex *, double complex *) nogil
 cdef _proto_cshichi_t *_proto_cshichi_t_var = &_func_cshichi
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_int _func_sici "sici"(npy_double, npy_double *, npy_double *)nogil
 from ._sici cimport csici as _func_csici
 ctypedef int _proto_csici_t(double complex, double complex *, double complex *) nogil
 cdef _proto_csici_t *_proto_csici_t_var = &_func_csici
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_sindg "sindg"(npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_smirnov "smirnov"(npy_int, npy_double)nogil
 from ._legacy cimport smirnov_unsafe as _func_smirnov_unsafe
 ctypedef double _proto_smirnov_unsafe_t(double, double) nogil
 cdef _proto_smirnov_unsafe_t *_proto_smirnov_unsafe_t_var = &_func_smirnov_unsafe
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_smirnovi "smirnovi"(npy_int, npy_double)nogil
 from ._legacy cimport smirnovi_unsafe as _func_smirnovi_unsafe
 ctypedef double _proto_smirnovi_unsafe_t(double, double) nogil
 cdef _proto_smirnovi_unsafe_t *_proto_smirnovi_unsafe_t_var = &_func_smirnovi_unsafe
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_spence "spence"(npy_double)nogil
 from ._spence cimport cspence as _func_cspence
 ctypedef double complex _proto_cspence_t(double complex) nogil
@@ -1599,17 +1606,17 @@ cdef _proto_sph_harmonic_t *_proto_sph_harmonic_t_var = &_func_sph_harmonic
 from ._legacy cimport sph_harmonic_unsafe as _func_sph_harmonic_unsafe
 ctypedef double complex _proto_sph_harmonic_unsafe_t(double, double, double, double) nogil
 cdef _proto_sph_harmonic_unsafe_t *_proto_sph_harmonic_unsafe_t_var = &_func_sph_harmonic_unsafe
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_cdft1_wrap "cdft1_wrap"(npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_cdft3_wrap "cdft3_wrap"(npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_cdft2_wrap "cdft2_wrap"(npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_struve_h "struve_h"(npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_tandg "tandg"(npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_tukeylambdacdf "tukeylambdacdf"(npy_double, npy_double)nogil
 from ._xlogy cimport xlog1py as _func_xlog1py
 ctypedef double _proto_xlog1py_double__t(double, double) nogil
@@ -1623,25 +1630,29 @@ cdef _proto_xlogy_double__t *_proto_xlogy_double__t_var = &_func_xlogy[double]
 from ._xlogy cimport xlogy as _func_xlogy
 ctypedef double complex _proto_xlogy_double_complex__t(double complex, double complex) nogil
 cdef _proto_xlogy_double_complex__t *_proto_xlogy_double_complex__t_var = &_func_xlogy[double_complex]
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_y0 "y0"(npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_y1 "y1"(npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_yn "yn"(npy_int, npy_double)nogil
 from ._legacy cimport yn_unsafe as _func_yn_unsafe
 ctypedef double _proto_yn_unsafe_t(double, double) nogil
 cdef _proto_yn_unsafe_t *_proto_yn_unsafe_t_var = &_func_yn_unsafe
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_cbesy_wrap_real "cbesy_wrap_real"(npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_cdouble _func_cbesy_wrap "cbesy_wrap"(npy_double, npy_cdouble)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_cbesy_wrap_e_real "cbesy_wrap_e_real"(npy_double, npy_double)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_cdouble _func_cbesy_wrap_e "cbesy_wrap_e"(npy_double, npy_cdouble)nogil
-cdef extern from "./_ufuncs_defs.h":
+cdef extern from "_ufuncs_defs.h":
     cdef npy_double _func_zetac "zetac"(npy_double)nogil
+
+cpdef double agm(double x0, double x1) nogil:
+    """See the documentation for scipy.special.agm"""
+    return _func_agm(x0, x1)
 
 cdef void airy(Dd_number_t x0, Dd_number_t *y0, Dd_number_t *y1, Dd_number_t *y2, Dd_number_t *y3) nogil:
     """See the documentation for scipy.special.airy"""

--- a/scipy/special/generate_ufuncs.py
+++ b/scipy/special/generate_ufuncs.py
@@ -162,6 +162,7 @@ pdtri -- pdtri: id->d, pdtri_unsafe: dd->d                 -- cephes.h, _legacy.
 yn -- yn: id->d, yn_unsafe: dd->d                          -- cephes.h, _legacy.pxd
 smirnov -- smirnov: id->d, smirnov_unsafe: dd->d           -- cephes.h, _legacy.pxd
 smirnovi -- smirnovi: id->d, smirnovi_unsafe: dd->d        -- cephes.h, _legacy.pxd
+agm -- agm: dd->d                                          -- _agm.pxd
 airy -- airy_wrap: d*dddd->*i, cairy_wrap: D*DDDD->*i      -- amos_wrappers.h
 itairy -- itairy_wrap: d*dddd->*i                          -- specfun_wrappers.h
 airye -- cairy_wrap_e_real: d*dddd->*i, cairy_wrap_e: D*DDDD->*i -- amos_wrappers.h

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -3268,8 +3268,64 @@ def test_chi2_inv_smalldf():
 
 
 def test_agm_simple():
-    assert_allclose(special.agm(24, 6), 13.4581714817)
-    assert_allclose(special.agm(1e30, 1), 2.2292230559453832047768593e28)
+    rtol = 1e-13
+
+    # Gauss's constant
+    assert_allclose(1/special.agm(1, np.sqrt(2)), 0.834626841674073186,
+                    rtol=rtol)
+
+    # These values were computed using Wolfram Alpha, with the
+    # function ArithmeticGeometricMean[a, b].
+    agm13 = 1.863616783244897
+    agm15 = 2.604008190530940
+    agm35 = 3.936235503649555
+    assert_allclose(special.agm([[1], [3]], [1, 3, 5]),
+                    [[1, agm13, agm15],
+                     [agm13, 3, agm35]], rtol=rtol)
+
+    # Computed by the iteration formula using mpmath,
+    # with mpmath.mp.prec = 1000:
+    agm12 = 1.4567910310469068
+    assert_allclose(special.agm(1, 2), agm12, rtol=rtol)
+    assert_allclose(special.agm(2, 1), agm12, rtol=rtol)
+    assert_allclose(special.agm(-1, -2), -agm12, rtol=rtol)
+    assert_allclose(special.agm(24, 6), 13.458171481725614, rtol=rtol)
+    assert_allclose(special.agm(13, 123456789.5), 11111458.498599306,
+                    rtol=rtol)
+    assert_allclose(special.agm(1e30, 1), 2.229223055945383e+28, rtol=rtol)
+    assert_allclose(special.agm(1e-22, 1), 0.030182566420169886, rtol=rtol)
+    assert_allclose(special.agm(1e150, 1e180), 2.229223055945383e+178,
+                    rtol=rtol)
+    assert_allclose(special.agm(1e180, 1e-150), 2.0634722510162677e+177,
+                    rtol=rtol)
+    assert_allclose(special.agm(1e-150, 1e-170), 3.3112619670463756e-152,
+                    rtol=rtol)
+    fi = np.finfo(1.0)
+    assert_allclose(special.agm(fi.tiny, fi.max), 1.9892072050015473e+305,
+                    rtol=rtol)
+    assert_allclose(special.agm(0.75*fi.max, fi.max), 1.564904312298045e+308,
+                    rtol=rtol)
+    assert_allclose(special.agm(fi.tiny, 3*fi.tiny), 4.1466849866735005e-308,
+                    rtol=rtol)
+
+    # zero, nan and inf cases.
+    assert_equal(special.agm(0, 0), 0)
+    assert_equal(special.agm(99, 0), 0)
+
+    assert_equal(special.agm(-1, 10), np.nan)
+    assert_equal(special.agm(0, np.inf), np.nan)
+    assert_equal(special.agm(np.inf, 0), np.nan)
+    assert_equal(special.agm(0, -np.inf), np.nan)
+    assert_equal(special.agm(-np.inf, 0), np.nan)
+    assert_equal(special.agm(np.inf, -np.inf), np.nan)
+    assert_equal(special.agm(-np.inf, np.inf), np.nan)
+    assert_equal(special.agm(1, np.nan), np.nan)
+    assert_equal(special.agm(np.nan, -1), np.nan)
+
+    assert_equal(special.agm(1, np.inf), np.inf)
+    assert_equal(special.agm(np.inf, 1), np.inf)
+    assert_equal(special.agm(-1, -np.inf), -np.inf)
+    assert_equal(special.agm(-np.inf, -1), -np.inf)
 
 
 def test_legacy():

--- a/scipy/special/tests/test_cython_special.py
+++ b/scipy/special/tests/test_cython_special.py
@@ -46,6 +46,7 @@ def _generate_test_points(typecodes):
 
 def test_cython_api():
     params = [
+        (special.agm, cython_special.agm, ('dd',), None),
         (special.airy, cython_special._airy_pywrap, ('d', 'D'), None),
         (special.airye, cython_special._airye_pywrap, ('d', 'D'), None),
         (special.bdtr, cython_special.bdtr, ('lld', 'ddd'), None),


### PR DESCRIPTION
* Implemented the function `agm(a, b)` as a ufunc using cython.
  The new version can now correctly handle more extreme values
  of the parameters than the old version, e.g.

      >>> agm(1, 1e200)
      3.4007037462646784e+197
      >>> agm(1e-100, 1e-200)
      6.7810557455754512e-103

* Expanded the docstring.
* Added more extensive tests.
