### PR TITLE
Test janitoring

### DIFF
--- a/scipy/fftpack/tests/test_basic.py
+++ b/scipy/fftpack/tests/test_basic.py
@@ -127,7 +127,7 @@ def direct_irdft(x):
     return direct_idft(x1).real
 
 
-class _TestFFTBase(TestCase):
+class _TestFFTBase(object):
     def setUp(self):
         self.cdt = None
         self.rdt = None
@@ -217,7 +217,7 @@ class TestFloat16FFT(TestCase):
         assert_array_almost_equal(y[1], direct_dft(x2.astype(np.float32)))
 
 
-class _TestIFFTBase(TestCase):
+class _TestIFFTBase(object):
     def setUp(self):
         np.random.seed(1234)
 
@@ -311,7 +311,7 @@ class TestSingleIFFT(_TestIFFTBase):
         self.rdt = np.float32
 
 
-class _TestRFFTBase(TestCase):
+class _TestRFFTBase(object):
     def setUp(self):
         np.random.seed(1234)
 
@@ -378,7 +378,7 @@ class TestRFFTSingle(_TestRFFTBase):
         self.rdt = np.float32
 
 
-class _TestIRFFTBase(TestCase):
+class _TestIRFFTBase(object):
     def setUp(self):
         np.random.seed(1234)
 
@@ -696,7 +696,7 @@ class TestFftn(TestCase):
         assert_raises(ValueError, fftn, [[1,1],[2,2]], (4, -3))
 
 
-class _TestIfftn(TestCase):
+class _TestIfftn(object):
     dtype = None
     cdtype = None
 

--- a/scipy/fftpack/tests/test_real_transforms.py
+++ b/scipy/fftpack/tests/test_real_transforms.py
@@ -80,7 +80,7 @@ class TestComplex(TestCase):
         assert_array_almost_equal(x, y)
 
 
-class _TestDCTBase(TestCase):
+class _TestDCTBase(object):
     def setUp(self):
         self.rdt = None
         self.dec = 14
@@ -202,7 +202,7 @@ class TestDCTIIIInt(_TestDCTIIIBase):
         self.type = 3
 
 
-class _TestIDCTBase(TestCase):
+class _TestIDCTBase(object):
     def setUp(self):
         self.rdt = None
         self.dec = 14
@@ -288,7 +288,7 @@ class TestIDCTIIIInt(_TestIDCTBase):
         self.type = 3
 
 
-class _TestDSTBase(TestCase):
+class _TestDSTBase(object):
     def setUp(self):
         self.rdt = None  # dtype
         self.dec = None  # number of decimals to match
@@ -370,7 +370,7 @@ class TestDSTIIIInt(_TestDSTBase):
         self.type = 3
 
 
-class _TestIDSTBase(TestCase):
+class _TestIDSTBase(object):
     def setUp(self):
         self.rdt = None
         self.dec = None

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -524,15 +524,15 @@ def test_cell_with_one_thing_in_it():
 def test_writer_properties():
     # Tests getting, setting of properties of matrix writer
     mfw = MatFile5Writer(BytesIO())
-    yield assert_equal, mfw.global_vars, []
+    assert_equal(mfw.global_vars, [])
     mfw.global_vars = ['avar']
-    yield assert_equal, mfw.global_vars, ['avar']
-    yield assert_equal, mfw.unicode_strings, False
+    assert_equal(mfw.global_vars, ['avar'])
+    assert_equal(mfw.unicode_strings, False)
     mfw.unicode_strings = True
-    yield assert_equal, mfw.unicode_strings, True
-    yield assert_equal, mfw.long_field_names, False
+    assert_equal(mfw.unicode_strings, True)
+    assert_equal(mfw.long_field_names, False)
     mfw.long_field_names = True
-    yield assert_equal, mfw.long_field_names, True
+    assert_equal(mfw.long_field_names, True)
 
 
 def test_use_small_element():
@@ -547,12 +547,12 @@ def test_use_small_element():
     sio.truncate(0)
     sio.seek(0)
     wtr.put_variables({'aaaa': arr})
-    yield assert_, w_sz - len(sio.getvalue()) > 4
+    assert_(w_sz - len(sio.getvalue()) > 4)
     # Whereas increasing name size makes less difference
     sio.truncate(0)
     sio.seek(0)
     wtr.put_variables({'aaaaaa': arr})
-    yield assert_, len(sio.getvalue()) - w_sz < 4
+    assert_(len(sio.getvalue()) - w_sz < 4)
 
 
 def test_save_dict():
@@ -615,24 +615,24 @@ def test_compression():
     savemat(stream, {'arr':arr})
     raw_len = len(stream.getvalue())
     vals = loadmat(stream)
-    yield assert_array_equal, vals['arr'], arr
+    assert_array_equal(vals['arr'], arr)
     stream = BytesIO()
     savemat(stream, {'arr':arr}, do_compression=True)
     compressed_len = len(stream.getvalue())
     vals = loadmat(stream)
-    yield assert_array_equal, vals['arr'], arr
-    yield assert_, raw_len > compressed_len
+    assert_array_equal(vals['arr'], arr)
+    assert_(raw_len > compressed_len)
     # Concatenate, test later
     arr2 = arr.copy()
     arr2[0,0] = 1
     stream = BytesIO()
     savemat(stream, {'arr':arr, 'arr2':arr2}, do_compression=False)
     vals = loadmat(stream)
-    yield assert_array_equal, vals['arr2'], arr2
+    assert_array_equal(vals['arr2'], arr2)
     stream = BytesIO()
     savemat(stream, {'arr':arr, 'arr2':arr2}, do_compression=True)
     vals = loadmat(stream)
-    yield assert_array_equal, vals['arr2'], arr2
+    assert_array_equal(vals['arr2'], arr2)
 
 
 def test_single_object():
@@ -656,8 +656,8 @@ def test_skip_variable():
     # Prove that it loads with loadmat
     #
     d = loadmat(filename, struct_as_record=True)
-    yield assert_, 'first' in d
-    yield assert_, 'second' in d
+    assert_('first' in d)
+    assert_('second' in d)
     #
     # Make the factory
     #
@@ -666,7 +666,7 @@ def test_skip_variable():
     # This is where the factory breaks with an error in MatMatrixGetter.to_next
     #
     d = factory.get_variables('second')
-    yield assert_, 'second' in d
+    assert_('second' in d)
     factory.mat_stream.close()
 
 
@@ -787,18 +787,18 @@ def test_recarray():
     savemat(stream, {'arr': arr})
     d = loadmat(stream, struct_as_record=False)
     a20 = d['arr'][0,0]
-    yield assert_equal, a20.f1, 0.5
-    yield assert_equal, a20.f2, 'python'
+    assert_equal(a20.f1, 0.5)
+    assert_equal(a20.f2, 'python')
     d = loadmat(stream, struct_as_record=True)
     a20 = d['arr'][0,0]
-    yield assert_equal, a20['f1'], 0.5
-    yield assert_equal, a20['f2'], 'python'
+    assert_equal(a20['f1'], 0.5)
+    assert_equal(a20['f2'], 'python')
     # structs always come back as object types
-    yield assert_equal, a20.dtype, np.dtype([('f1', 'O'),
-                                             ('f2', 'O')])
+    assert_equal(a20.dtype, np.dtype([('f1', 'O'),
+                                      ('f2', 'O')]))
     a21 = d['arr'].flat[1]
-    yield assert_equal, a21['f1'], 99
-    yield assert_equal, a21['f2'], 'not perl'
+    assert_equal(a21['f1'], 99)
+    assert_equal(a21['f2'], 'not perl')
 
 
 def test_save_object():
@@ -983,13 +983,13 @@ def test_mat_dtype():
     rdr = MatFile5Reader(fp, mat_dtype=False)
     d = rdr.get_variables()
     fp.close()
-    yield assert_equal, d['testmatrix'].dtype.kind, 'u'
+    assert_equal(d['testmatrix'].dtype.kind, 'u')
 
     fp = open(double_eg, 'rb')
     rdr = MatFile5Reader(fp, mat_dtype=True)
     d = rdr.get_variables()
     fp.close()
-    yield assert_equal, d['testmatrix'].dtype.kind, 'f'
+    assert_equal(d['testmatrix'].dtype.kind, 'f')
 
 
 def test_sparse_in_struct():
@@ -999,7 +999,7 @@ def test_sparse_in_struct():
     stream = BytesIO()
     savemat(stream, {'a':st})
     d = loadmat(stream, struct_as_record=True)
-    yield assert_array_equal, d['a'][0,0]['sparsefield'].todense(), np.eye(4)
+    assert_array_equal(d['a'][0,0]['sparsefield'].todense(), np.eye(4))
 
 
 def test_mat_struct_squeeze():

--- a/scipy/io/matlab/tests/test_streams.py
+++ b/scipy/io/matlab/tests/test_streams.py
@@ -33,7 +33,7 @@ cs = None
 fname = None
 
 
-def setup():
+def setup_module():
     val = b'a\x00string'
     global fs, gs, cs, fname
     fd, fname = mkstemp()
@@ -45,7 +45,7 @@ def setup():
     cs = cStringIO(val)
 
 
-def teardown():
+def teardown_module():
     global fname, fs
     fs.close()
     del fs
@@ -66,17 +66,17 @@ def test_tell_seek():
     for s in (fs, gs, cs):
         st = make_stream(s)
         res = st.seek(0)
-        yield assert_equal, res, 0
-        yield assert_equal, st.tell(), 0
+        assert_equal(res, 0)
+        assert_equal(st.tell(), 0)
         res = st.seek(5)
-        yield assert_equal, res, 0
-        yield assert_equal, st.tell(), 5
+        assert_equal(res, 0)
+        assert_equal(st.tell(), 5)
         res = st.seek(2, 1)
-        yield assert_equal, res, 0
-        yield assert_equal, st.tell(), 7
+        assert_equal(res, 0)
+        assert_equal(st.tell(), 7)
         res = st.seek(-2, 2)
-        yield assert_equal, res, 0
-        yield assert_equal, st.tell(), 6
+        assert_equal(res, 0)
+        assert_equal(st.tell(), 6)
 
 
 def test_read():
@@ -85,24 +85,24 @@ def test_read():
         st = make_stream(s)
         st.seek(0)
         res = st.read(-1)
-        yield assert_equal, res, b'a\x00string'
+        assert_equal(res, b'a\x00string')
         st.seek(0)
         res = st.read(4)
-        yield assert_equal, res, b'a\x00st'
+        assert_equal(res, b'a\x00st')
         # read into
         st.seek(0)
         res = _read_into(st, 4)
-        yield assert_equal, res, b'a\x00st'
+        assert_equal(res, b'a\x00st')
         res = _read_into(st, 4)
-        yield assert_equal, res, b'ring'
-        yield assert_raises, IOError, _read_into, st, 2
+        assert_equal(res, b'ring')
+        assert_raises(IOError, _read_into, st, 2)
         # read alloc
         st.seek(0)
         res = _read_string(st, 4)
-        yield assert_equal, res, b'a\x00st'
+        assert_equal(res, b'a\x00st')
         res = _read_string(st, 4)
-        yield assert_equal, res, b'ring'
-        yield assert_raises, IOError, _read_string, st, 2
+        assert_equal(res, b'ring')
+        assert_raises(IOError, _read_string, st, 2)
 
 
 class TestZlibInputStream(object):

--- a/scipy/misc/tests/test_doccer.py
+++ b/scipy/misc/tests/test_doccer.py
@@ -42,28 +42,28 @@ filled_docstring = \
 
 
 def test_unindent():
-    yield assert_equal, doccer.unindent_string(param_doc1), param_doc1
-    yield assert_equal, doccer.unindent_string(param_doc2), param_doc2
-    yield assert_equal, doccer.unindent_string(param_doc3), param_doc1
+    assert_equal(doccer.unindent_string(param_doc1), param_doc1)
+    assert_equal(doccer.unindent_string(param_doc2), param_doc2)
+    assert_equal(doccer.unindent_string(param_doc3), param_doc1)
 
 
 def test_unindent_dict():
     d2 = doccer.unindent_dict(doc_dict)
-    yield assert_equal, d2['strtest1'], doc_dict['strtest1']
-    yield assert_equal, d2['strtest2'], doc_dict['strtest2']
-    yield assert_equal, d2['strtest3'], doc_dict['strtest1']
+    assert_equal(d2['strtest1'], doc_dict['strtest1'])
+    assert_equal(d2['strtest2'], doc_dict['strtest2'])
+    assert_equal(d2['strtest3'], doc_dict['strtest1'])
 
 
 def test_docformat():
     udd = doccer.unindent_dict(doc_dict)
     formatted = doccer.docformat(docstring, udd)
-    yield assert_equal, formatted, filled_docstring
+    assert_equal(formatted, filled_docstring)
     single_doc = 'Single line doc %(strtest1)s'
     formatted = doccer.docformat(single_doc, doc_dict)
     # Note - initial indent of format string does not
     # affect subsequent indent of inserted parameter
-    yield assert_equal, formatted, """Single line doc Another test
-   with some indent"""
+    assert_equal(formatted, """Single line doc Another test
+   with some indent""")
 
 
 @dec.skipif(DOCSTRINGS_STRIPPED)
@@ -76,10 +76,10 @@ def test_decorator():
         """ Docstring
         %(strtest3)s
         """
-    yield assert_equal, func.__doc__, """ Docstring
+    assert_equal(func.__doc__, """ Docstring
         Another test
            with some indent
-        """
+        """)
 
     # without unindentation of parameters
     decorator = doccer.filldoc(doc_dict, False)
@@ -89,10 +89,10 @@ def test_decorator():
         """ Docstring
         %(strtest3)s
         """
-    yield assert_equal, func.__doc__, """ Docstring
+    assert_equal(func.__doc__, """ Docstring
             Another test
                with some indent
-        """
+        """)
 
 
 @dec.skipif(DOCSTRINGS_STRIPPED)

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -69,12 +69,12 @@ def test_gaussian_kernel1d():
 def test_orders_gauss():
     # Check order inputs to Gaussians
     arr = np.zeros((1,))
-    yield assert_equal, 0, sndi.gaussian_filter(arr, 1, order=0)
-    yield assert_equal, 0, sndi.gaussian_filter(arr, 1, order=3)
-    yield assert_raises, ValueError, sndi.gaussian_filter, arr, 1, -1
-    yield assert_equal, 0, sndi.gaussian_filter1d(arr, 1, axis=-1, order=0)
-    yield assert_equal, 0, sndi.gaussian_filter1d(arr, 1, axis=-1, order=3)
-    yield assert_raises, ValueError, sndi.gaussian_filter1d, arr, 1, -1, -1
+    assert_equal(0, sndi.gaussian_filter(arr, 1, order=0))
+    assert_equal(0, sndi.gaussian_filter(arr, 1, order=3))
+    assert_raises(ValueError, sndi.gaussian_filter, arr, 1, -1)
+    assert_equal(0, sndi.gaussian_filter1d(arr, 1, axis=-1, order=0))
+    assert_equal(0, sndi.gaussian_filter1d(arr, 1, axis=-1, order=3))
+    assert_raises(ValueError, sndi.gaussian_filter1d, arr, 1, -1, -1)
 
 
 def test_valid_origins():

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -31,7 +31,7 @@ else:
     from fractions import gcd
 
 
-class _TestConvolve(TestCase):
+class _TestConvolve(object):
 
     def test_basic(self):
         a = [3, 4, 5, 6, 5, 4]
@@ -155,8 +155,8 @@ class TestConvolve(_TestConvolve):
         a = np.arange(1, 7).reshape((2, 3))
         b = np.arange(-6, 0).reshape((3, 2))
 
-        self.assertRaises(ValueError, convolve, *(a, b), **{'mode': 'valid'})
-        self.assertRaises(ValueError, convolve, *(b, a), **{'mode': 'valid'})
+        assert_raises(ValueError, convolve, *(a, b), **{'mode': 'valid'})
+        assert_raises(ValueError, convolve, *(b, a), **{'mode': 'valid'})
 
     def test_convolve_method(self, n=100):
         types = sum([t for _, t in np.sctypes.items()], [])
@@ -222,7 +222,7 @@ class TestConvolve(_TestConvolve):
                 assert_equal(direct, 2**(2*n))
 
 
-class _TestConvolve2d(TestCase):
+class _TestConvolve2d(object):
 
     def test_2d_arrays(self):
         a = [[1, 2, 3], [3, 4, 5]]
@@ -294,8 +294,8 @@ class _TestConvolve2d(TestCase):
         a = np.arange(1, 7).reshape((2, 3))
         b = np.arange(-6, 0).reshape((3, 2))
 
-        self.assertRaises(ValueError, convolve2d, *(a, b), **{'mode': 'valid'})
-        self.assertRaises(ValueError, convolve2d, *(b, a), **{'mode': 'valid'})
+        assert_raises(ValueError, convolve2d, *(a, b), **{'mode': 'valid'})
+        assert_raises(ValueError, convolve2d, *(b, a), **{'mode': 'valid'})
 
 
 class TestConvolve2d(_TestConvolve2d):
@@ -472,8 +472,8 @@ class TestFFTConvolve(TestCase):
         a = np.arange(1, 7).reshape((2, 3))
         b = np.arange(-6, 0).reshape((3, 2))
 
-        self.assertRaises(ValueError, fftconvolve, *(a, b), **{'mode': 'valid'})
-        self.assertRaises(ValueError, fftconvolve, *(b, a), **{'mode': 'valid'})
+        assert_raises(ValueError, fftconvolve, *(a, b), **{'mode': 'valid'})
+        assert_raises(ValueError, fftconvolve, *(b, a), **{'mode': 'valid'})
 
 
 class TestMedFilt(TestCase):
@@ -710,7 +710,7 @@ class TestOrderFilt(TestCase):
                            [2, 3, 2])
 
 
-class _TestLinearFilter(TestCase):
+class _TestLinearFilter(object):
     def generate(self, shape):
         x = np.linspace(0, np.prod(shape) - 1, np.prod(shape)).reshape(shape)
         return self.convert_dtype(x)
@@ -1140,7 +1140,7 @@ def test_lfilter_bad_object():
     assert_raises(TypeError, lfilter, [None], [1.0], [1.0, 2.0, 3.0])
 
 
-class _TestCorrelateReal(TestCase):
+class _TestCorrelateReal(object):
     dt = None
 
     def _setup_rank1(self):
@@ -1249,8 +1249,8 @@ class _TestCorrelateReal(TestCase):
         a = np.arange(1, 7).reshape((2, 3))
         b = np.arange(-6, 0).reshape((3, 2))
 
-        self.assertRaises(ValueError, correlate, *(a, b), **{'mode': 'valid'})
-        self.assertRaises(ValueError, correlate, *(b, a), **{'mode': 'valid'})
+        assert_raises(ValueError, correlate, *(a, b), **{'mode': 'valid'})
+        assert_raises(ValueError, correlate, *(b, a), **{'mode': 'valid'})
 
 
 def _get_testcorrelate_class(datatype, base):
@@ -1267,7 +1267,7 @@ for datatype in [np.ubyte, np.byte, np.ushort, np.short, np.uint, int,
     globals()[cls.__name__] = cls
 
 
-class _TestCorrelateComplex(TestCase):
+class _TestCorrelateComplex(object):
     # The numpy data type to use.
     dt = None
 
@@ -1369,8 +1369,8 @@ class TestCorrelate2d(TestCase):
         a = np.arange(1, 7).reshape((2, 3))
         b = np.arange(-6, 0).reshape((3, 2))
 
-        self.assertRaises(ValueError, signal.correlate2d, *(a, b), **{'mode': 'valid'})
-        self.assertRaises(ValueError, signal.correlate2d, *(b, a), **{'mode': 'valid'})
+        assert_raises(ValueError, signal.correlate2d, *(a, b), **{'mode': 'valid'})
+        assert_raises(ValueError, signal.correlate2d, *(b, a), **{'mode': 'valid'})
 
 
 # Create three classes, one for each complex data type. The actual class

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1792,14 +1792,14 @@ class TestHilbert(object):
         a = np.arange(18).reshape(3, 6)
         # test axis
         aa = hilbert(a, axis=-1)
-        yield assert_equal, hilbert(a.T, axis=0), aa.T
+        assert_equal(hilbert(a.T, axis=0), aa.T)
         # test 1d
-        yield assert_equal, hilbert(a[0]), aa[0]
+        assert_equal(hilbert(a[0]), aa[0])
 
         # test N
         aan = hilbert(a, N=20, axis=-1)
-        yield assert_equal, aan.shape, [3, 20]
-        yield assert_equal, hilbert(a.T, N=20, axis=0).shape, [20, 3]
+        assert_equal(aan.shape, [3, 20])
+        assert_equal(hilbert(a.T, N=20, axis=0).shape, [20, 3])
         # the next test is just a regression test,
         # no idea whether numbers make sense
         a0hilb = np.array([0.000000000000000e+00 - 1.72015830311905j,
@@ -1822,7 +1822,7 @@ class TestHilbert(object):
                            3.552713678800501e-16 - 0.403810179797771j,
                            8.881784197001253e-17 - 0.751023775297729j,
                            9.444121133484362e-17 - 0.79252210110103j])
-        yield assert_almost_equal, aan[0], a0hilb, 14, 'N regression'
+        assert_almost_equal(aan[0], a0hilb, 14, 'N regression')
 
 
 class TestHilbert2(object):

--- a/scipy/sparse/linalg/tests/test_matfuncs.py
+++ b/scipy/sparse/linalg/tests/test_matfuncs.py
@@ -86,16 +86,16 @@ class TestExpM(TestCase):
 
     def test_misc_types(self):
         A = expm(np.array([[1]]))
-        yield assert_allclose, expm(((1,),)), A
-        yield assert_allclose, expm([[1]]), A
-        yield assert_allclose, expm(np.matrix([[1]])), A
-        yield assert_allclose, expm(np.array([[1]])), A
-        yield assert_allclose, expm(csc_matrix([[1]])), A
+        assert_allclose(expm(((1,),)), A)
+        assert_allclose(expm([[1]]), A)
+        assert_allclose(expm(np.matrix([[1]])), A)
+        assert_allclose(expm(np.array([[1]])), A)
+        assert_allclose(expm(csc_matrix([[1]])).A, A)
         B = expm(np.array([[1j]]))
-        yield assert_allclose, expm(((1j,),)), B
-        yield assert_allclose, expm([[1j]]), B
-        yield assert_allclose, expm(np.matrix([[1j]])), B
-        yield assert_allclose, expm(csc_matrix([[1j]])), B
+        assert_allclose(expm(((1j,),)), B)
+        assert_allclose(expm([[1j]]), B)
+        assert_allclose(expm(np.matrix([[1j]])), B)
+        assert_allclose(expm(csc_matrix([[1j]])).A, B)
 
     def test_bidiagonal_sparse(self):
         A = csc_matrix([

--- a/scipy/special/tests/test_boxcox.py
+++ b/scipy/special/tests/test_boxcox.py
@@ -12,20 +12,20 @@ def test_boxcox_basic():
 
     # lambda = 0  =>  y = log(x)
     y = boxcox(x, 0)
-    yield assert_almost_equal, y, np.log(x)
+    assert_almost_equal(y, np.log(x))
 
     # lambda = 1  =>  y = x - 1
     y = boxcox(x, 1)
-    yield assert_almost_equal, y, x - 1
+    assert_almost_equal(y, x - 1)
 
     # lambda = 2  =>  y = 0.5*(x**2 - 1)
     y = boxcox(x, 2)
-    yield assert_almost_equal, y, 0.5*(x**2 - 1)
+    assert_almost_equal(y, 0.5*(x**2 - 1))
 
     # x = 0 and lambda > 0  =>  y = -1 / lambda
     lam = np.array([0.5, 1, 2])
     y = boxcox(0, lam)
-    yield assert_almost_equal, y, -1.0 / lam
+    assert_almost_equal(y, -1.0 / lam)
 
 def test_boxcox_underflow():
     x = 1 + 1e-15
@@ -38,12 +38,12 @@ def test_boxcox_nonfinite():
     # x < 0  =>  y = nan
     x = np.array([-1, -1, -0.5])
     y = boxcox(x, [0.5, 2.0, -1.5])
-    yield assert_equal, y, np.array([np.nan, np.nan, np.nan])
+    assert_equal(y, np.array([np.nan, np.nan, np.nan]))
 
     # x = 0 and lambda <= 0  =>  y = -inf
     x = 0
     y = boxcox(x, [-2.5, 0])
-    yield assert_equal, y, np.array([-np.inf, -np.inf])
+    assert_equal(y, np.array([-np.inf, -np.inf]))
 
 
 def test_boxcox1p_basic():
@@ -51,20 +51,20 @@ def test_boxcox1p_basic():
 
     # lambda = 0  =>  y = log(1+x)
     y = boxcox1p(x, 0)
-    yield assert_almost_equal, y, np.log1p(x)
+    assert_almost_equal(y, np.log1p(x))
 
     # lambda = 1  =>  y = x
     y = boxcox1p(x, 1)
-    yield assert_almost_equal, y, x
+    assert_almost_equal(y, x)
 
     # lambda = 2  =>  y = 0.5*((1+x)**2 - 1) = 0.5*x*(2 + x)
     y = boxcox1p(x, 2)
-    yield assert_almost_equal, y, 0.5*x*(2 + x)
+    assert_almost_equal(y, 0.5*x*(2 + x))
 
     # x = -1 and lambda > 0  =>  y = -1 / lambda
     lam = np.array([0.5, 1, 2])
     y = boxcox1p(-1, lam)
-    yield assert_almost_equal, y, -1.0 / lam
+    assert_almost_equal(y, -1.0 / lam)
 
 
 def test_boxcox1p_underflow():
@@ -78,12 +78,12 @@ def test_boxcox1p_nonfinite():
     # x < -1  =>  y = nan
     x = np.array([-2, -2, -1.5])
     y = boxcox1p(x, [0.5, 2.0, -1.5])
-    yield assert_equal, y, np.array([np.nan, np.nan, np.nan])
+    assert_equal(y, np.array([np.nan, np.nan, np.nan]))
 
     # x = -1 and lambda <= 0  =>  y = -inf
     x = -1
     y = boxcox1p(x, [-2.5, 0])
-    yield assert_equal, y, np.array([-np.inf, -np.inf])
+    assert_equal(y, np.array([-np.inf, -np.inf]))
 
 
 def test_inv_boxcox():

--- a/scipy/special/tests/test_orthogonal.py
+++ b/scipy/special/tests/test_orthogonal.py
@@ -139,7 +139,7 @@ class TestHermite(TestCase):
         assert_array_almost_equal(H5.c,he5.c,13)
 
 
-class _test_sh_legendre(TestCase):
+class _test_sh_legendre(object):
 
     def test_sh_legendre(self):
         # P*_n(x) = P_n(2x-1)
@@ -164,7 +164,7 @@ class _test_sh_legendre(TestCase):
         assert_array_almost_equal(Ps5.c,pse5.c,12)
 
 
-class _test_sh_chebyt(TestCase):
+class _test_sh_chebyt(object):
 
     def test_sh_chebyt(self):
         # T*_n(x) = T_n(2x-1)
@@ -189,7 +189,7 @@ class _test_sh_chebyt(TestCase):
         assert_array_almost_equal(Ts5.c,tse5.c,12)
 
 
-class _test_sh_chebyu(TestCase):
+class _test_sh_chebyu(object):
 
     def test_sh_chebyu(self):
         # U*_n(x) = U_n(2x-1)
@@ -214,7 +214,7 @@ class _test_sh_chebyu(TestCase):
         assert_array_almost_equal(Us5.c,use5.c,11)
 
 
-class _test_sh_jacobi(TestCase):
+class _test_sh_jacobi(object):
     def test_sh_jacobi(self):
         # G^(p,q)_n(x) = n! gamma(n+p)/gamma(2*n+p) * P^(p-q,q-1)_n(2*x-1)
         conv = lambda n,p: gamma(n+1)*gamma(n+p)/gamma(2*n+p)

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -216,7 +216,7 @@ def test_cont_basic_slow():
         if distname not in distslow:
             continue
 
-        if distname is 'levy_stable':
+        if distname == 'levy_stable':
             continue
 
         yield check, distname, arg
@@ -229,7 +229,7 @@ def test_moments():
             warnings.filterwarnings('ignore',
                                     category=integrate.IntegrationWarning)
 
-            if distname is 'levy_stable':
+            if distname == 'levy_stable':
                 return
 
             try:

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -71,15 +71,11 @@ test_histogram_instance = stats.rv_histogram(_h)
 
 def test_cont_basic():
     # this test skips slow distributions
-    with warnings.catch_warnings():
-        warnings.filterwarnings('ignore',
-                                category=integrate.IntegrationWarning)
-        
-        for distname, arg in distcont[:] + [(test_histogram_instance, tuple())]:
-            if distname in distslow:
-                continue
-            if distname is 'levy_stable':
-                continue
+
+    def check(distname, arg):
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore',
+                                    category=integrate.IntegrationWarning)
             try:
                 distfn = getattr(stats, distname)
             except TypeError:
@@ -92,20 +88,19 @@ def test_cont_basic():
             sv = rvs.var()
             m, v = distfn.stats(*arg)
 
-            yield (check_sample_meanvar_, distfn, arg, m, v, sm, sv, sn,
-                   distname + 'sample mean test')
-            yield check_cdf_ppf, distfn, arg, distname
-            yield check_sf_isf, distfn, arg, distname
-            yield check_pdf, distfn, arg, distname
-            yield check_pdf_logpdf, distfn, arg, distname
-            yield check_cdf_logcdf, distfn, arg, distname
-            yield check_sf_logsf, distfn, arg, distname
+            check_sample_meanvar_(distfn, arg, m, v, sm, sv, sn, distname + 'sample mean test')
+            check_cdf_ppf(distfn, arg, distname)
+            check_sf_isf(distfn, arg, distname)
+            check_pdf(distfn, arg, distname)
+            check_pdf_logpdf(distfn, arg, distname)
+            check_cdf_logcdf(distfn, arg, distname)
+            check_sf_logsf(distfn, arg, distname)
 
             alpha = 0.01
             if distname == 'rv_histogram_instance':
-                yield check_distribution_rvs, distfn.cdf, arg, alpha, rvs
+                check_distribution_rvs(distfn.cdf, arg, alpha, rvs)
             else:
-                yield check_distribution_rvs, distname, arg, alpha, rvs
+                check_distribution_rvs(distname, arg, alpha, rvs)
 
             locscale_defaults = (0, 1)
             meths = [distfn.pdf, distfn.logpdf, distfn.cdf, distfn.logcdf,
@@ -115,28 +110,41 @@ def test_cont_basic():
                       'pareto': 1.5, 'tukeylambda': 0.3,
                       'rv_histogram_instance': 5.0}
             x = spec_x.get(distname, 0.5)
-            yield check_named_args, distfn, x, arg, locscale_defaults, meths
-            yield check_random_state_property, distfn, arg
-            yield check_pickling, distfn, arg
+            check_named_args(distfn, x, arg, locscale_defaults, meths)
+            check_random_state_property(distfn, arg)
+            check_pickling(distfn, arg)
 
             # Entropy
-            skp = npt.dec.skipif
-            yield check_entropy, distfn, arg, distname
+            check_entropy(distfn, arg, distname)
 
             if distfn.numargs == 0:
-                yield check_vecentropy, distfn, arg
+                check_vecentropy(distfn, arg)
+
             if distfn.__class__._entropy != stats.rv_continuous._entropy:
-                yield check_private_entropy, distfn, arg, stats.rv_continuous
+                check_private_entropy(distfn, arg, stats.rv_continuous)
 
-            yield check_edge_support, distfn, arg
+            check_edge_support(distfn, arg)
 
-            yield check_meth_dtype, distfn, arg, meths
-            yield check_ppf_dtype, distfn, arg
-            yield skp(distname in fails_cmplx)(check_cmplx_deriv), distfn, arg
+            check_meth_dtype(distfn, arg, meths)
+            check_ppf_dtype(distfn, arg)
 
-            knf = npt.dec.knownfailureif
-            yield (knf(distname == 'truncnorm')(check_ppf_private), distfn,
-                   arg, distname)
+            if distname not in fails_cmplx:
+                check_cmplx_deriv(distfn, arg)
+
+            if distname != 'truncnorm':
+                check_ppf_private(distfn, arg, distname)
+
+    for distname, arg in distcont[:] + [(test_histogram_instance, tuple())]:
+        if distname in distslow:
+            continue
+
+        if distname == 'levy_stable':
+            continue
+
+        yield check, distname, arg
+
+        if distname == 'truncnorm':
+            yield npt.dec.knownfailureif(True)(check), distname
 
 
 def test_levy_stable_random_state_property():
@@ -149,14 +157,11 @@ def test_levy_stable_random_state_property():
 @npt.dec.slow
 def test_cont_basic_slow():
     # same as above for slow distributions
-    with warnings.catch_warnings():
-        warnings.filterwarnings('ignore',
-                                category=integrate.IntegrationWarning)
-        for distname, arg in distcont[:]:
-            if distname not in distslow:
-                continue
-            if distname is 'levy_stable':
-                continue
+
+    def check(distname, arg):
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore',
+                                    category=integrate.IntegrationWarning)
             distfn = getattr(stats, distname)
             np.random.seed(765456)
             sn = 500
@@ -164,18 +169,17 @@ def test_cont_basic_slow():
             sm = rvs.mean()
             sv = rvs.var()
             m, v = distfn.stats(*arg)
-            yield (check_sample_meanvar_, distfn, arg, m, v, sm, sv, sn,
-                   distname + 'sample mean test')
-            yield check_cdf_ppf, distfn, arg, distname
-            yield check_sf_isf, distfn, arg, distname
-            yield check_pdf, distfn, arg, distname
-            yield check_pdf_logpdf, distfn, arg, distname
-            yield check_cdf_logcdf, distfn, arg, distname
-            yield check_sf_logsf, distfn, arg, distname
-            # yield check_oth, distfn, arg # is still missing
+            check_sample_meanvar_(distfn, arg, m, v, sm, sv, sn, distname + 'sample mean test')
+            check_cdf_ppf(distfn, arg, distname)
+            check_sf_isf(distfn, arg, distname)
+            check_pdf(distfn, arg, distname)
+            check_pdf_logpdf(distfn, arg, distname)
+            check_cdf_logcdf(distfn, arg, distname)
+            check_sf_logsf(distfn, arg, distname)
+            # check_oth(distfn, arg # is still missing)
 
             alpha = 0.01
-            yield check_distribution_rvs, distname, arg, alpha, rvs
+            check_distribution_rvs(distname, arg, alpha, rvs)
 
             locscale_defaults = (0, 1)
             meths = [distfn.pdf, distfn.logpdf, distfn.cdf, distfn.logcdf,
@@ -186,58 +190,79 @@ def test_cont_basic_slow():
                 arg = (1,)
             elif distname == 'ksone':
                 arg = (3,)
-            yield check_named_args, distfn, x, arg, locscale_defaults, meths
-            yield check_random_state_property, distfn, arg
-            yield check_pickling, distfn, arg
+            check_named_args(distfn, x, arg, locscale_defaults, meths)
+            check_random_state_property(distfn, arg)
+            check_pickling(distfn, arg)
 
             # Entropy
-            skp = npt.dec.skipif
-            ks_cond = distname in ['ksone', 'kstwobign']
-            yield skp(ks_cond)(check_entropy), distfn, arg, distname
+            if distname not in ['ksone', 'kstwobign']:
+                check_entropy(distfn, arg, distname)
 
             if distfn.numargs == 0:
-                yield check_vecentropy, distfn, arg
+                check_vecentropy(distfn, arg)
             if (distfn.__class__._entropy != stats.rv_continuous._entropy
                     and distname != 'vonmises'):
-                yield check_private_entropy, distfn, arg, stats.rv_continuous
+                check_private_entropy(distfn, arg, stats.rv_continuous)
 
-            yield check_edge_support, distfn, arg
+            check_edge_support(distfn, arg)
 
-            yield check_meth_dtype, distfn, arg, meths
-            yield check_ppf_dtype, distfn, arg
-            yield skp(distname in fails_cmplx)(check_cmplx_deriv), distfn, arg
+            check_meth_dtype(distfn, arg, meths)
+            check_ppf_dtype(distfn, arg)
+
+            if distname not in fails_cmplx:
+                check_cmplx_deriv(distfn, arg)
+
+    for distname, arg in distcont[:]:
+        if distname not in distslow:
+            continue
+
+        if distname is 'levy_stable':
+            continue
+
+        yield check, distname, arg
 
 
 @npt.dec.slow
 def test_moments():
-    with warnings.catch_warnings():
-        warnings.filterwarnings('ignore',
-                                category=integrate.IntegrationWarning)
-        knf = npt.dec.knownfailureif
-        fail_normalization = set(['vonmises', 'ksone'])
-        fail_higher = set(['vonmises', 'ksone', 'ncf'])
-        for distname, arg in distcont[:] + [(test_histogram_instance, tuple())]:
+    def check(distname, arg, normalization_ok, higher_ok):
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore',
+                                    category=integrate.IntegrationWarning)
+
             if distname is 'levy_stable':
-                continue
+                return
+
             try:
                 distfn = getattr(stats, distname)
             except TypeError:
                 distfn = distname
                 distname = 'rv_histogram_instance'
+
             m, v, s, k = distfn.stats(*arg, moments='mvsk')
-            cond1 = distname in fail_normalization
-            cond2 = distname in fail_higher
+
+            if normalization_ok:
+                check_normalization(distfn, arg, distname)
+
+            if higher_ok:
+                check_mean_expect(distfn, arg, m, distname)
+                check_var_expect(distfn, arg, m, v, distname)
+                check_skew_expect(distfn, arg, m, v, s, distname)
+                check_kurt_expect(distfn, arg, m, v, k, distname)
+
+            check_loc_scale(distfn, arg, m, v, distname)
+            check_moment(distfn, arg, m, v, distname)
+
+    fail_normalization = set(['vonmises', 'ksone'])
+    fail_higher = set(['vonmises', 'ksone', 'ncf'])
+
+    for distname, arg in distcont[:] + [(test_histogram_instance, tuple())]:
+        cond1 = distname not in fail_normalization
+        cond2 = distname not in fail_higher
+        yield check, distname, arg, cond1, cond2
+
+        if not cond1 or not cond2:
             msg = distname + ' fails moments'
-            yield knf(cond1, msg)(check_normalization), distfn, arg, distname
-            yield knf(cond2, msg)(check_mean_expect), distfn, arg, m, distname
-            yield (knf(cond2, msg)(check_var_expect), distfn, arg, m, v,
-                   distname)
-            yield (knf(cond2, msg)(check_skew_expect), distfn, arg, m, v, s,
-                   distname)
-            yield (knf(cond2, msg)(check_kurt_expect), distfn, arg, m, v, k,
-                   distname)
-            yield check_loc_scale, distfn, arg, m, v, distname
-            yield check_moment, distfn, arg, m, v, distname
+            yield npt.dec.knownfailureif(True, msg)(check), distname, arg, True, True
 
 
 def test_rvs_broadcast():

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2283,18 +2283,18 @@ def test_percentileofscore():
     for (kind, result) in [('mean', 35.0),
                            ('strict', 30.0),
                            ('weak', 40.0)]:
-        yield assert_equal, pcos(np.arange(10) + 1,
+        assert_equal(pcos(np.arange(10) + 1,
                                                     4, kind=kind), \
-                                                    result
+                                                    result)
 
     # multiple - 2
     for (kind, result) in [('rank', 45.0),
                            ('strict', 30.0),
                            ('weak', 50.0),
                            ('mean', 40.0)]:
-        yield assert_equal, pcos([1,2,3,4,4,5,6,7,8,9],
+        assert_equal(pcos([1,2,3,4,4,5,6,7,8,9],
                                                     4, kind=kind), \
-                                                    result
+                                                    result)
 
     # multiple - 3
     assert_equal(pcos([1,2,3,4,4,4,5,6,7,8], 4), 50.0)
@@ -2303,60 +2303,60 @@ def test_percentileofscore():
                            ('strict', 30.0),
                            ('weak', 60.0)]:
 
-        yield assert_equal, pcos([1,2,3,4,4,4,5,6,7,8],
+        assert_equal(pcos([1,2,3,4,4,4,5,6,7,8],
                                                     4, kind=kind), \
-                                                    result
+                                                    result)
 
     # missing
     for kind in ('rank', 'mean', 'strict', 'weak'):
-        yield assert_equal, pcos([1,2,3,5,6,7,8,9,10,11],
+        assert_equal(pcos([1,2,3,5,6,7,8,9,10,11],
                                                     4, kind=kind), \
-                                                    30
+                                                    30)
 
     # larger numbers
     for (kind, result) in [('mean', 35.0),
                            ('strict', 30.0),
                            ('weak', 40.0)]:
-        yield assert_equal, \
+        assert_equal(
               pcos([10, 20, 30, 40, 50, 60, 70, 80, 90, 100], 40,
-                   kind=kind), result
+                   kind=kind), result)
 
     for (kind, result) in [('mean', 45.0),
                            ('strict', 30.0),
                            ('weak', 60.0)]:
-        yield assert_equal, \
+        assert_equal(
               pcos([10, 20, 30, 40, 40, 40, 50, 60, 70, 80],
-                   40, kind=kind), result
+                   40, kind=kind), result)
 
     for kind in ('rank', 'mean', 'strict', 'weak'):
-        yield assert_equal, \
+        assert_equal(
               pcos([10, 20, 30, 50, 60, 70, 80, 90, 100, 110],
-                   40, kind=kind), 30.0
+                   40, kind=kind), 30.0)
 
     # boundaries
     for (kind, result) in [('rank', 10.0),
                            ('mean', 5.0),
                            ('strict', 0.0),
                            ('weak', 10.0)]:
-        yield assert_equal, \
+        assert_equal(
               pcos([10, 20, 30, 50, 60, 70, 80, 90, 100, 110],
-                   10, kind=kind), result
+                   10, kind=kind), result)
 
     for (kind, result) in [('rank', 100.0),
                            ('mean', 95.0),
                            ('strict', 90.0),
                            ('weak', 100.0)]:
-        yield assert_equal, \
+        assert_equal(
               pcos([10, 20, 30, 50, 60, 70, 80, 90, 100, 110],
-                   110, kind=kind), result
+                   110, kind=kind), result)
 
     # out of bounds
     for (kind, score, result) in [('rank', 200, 100.0),
                                   ('mean', 200, 100.0),
                                   ('mean', 0, 0.0)]:
-        yield assert_equal, \
+        assert_equal(
               pcos([10, 20, 30, 50, 60, 70, 80, 90, 100, 110],
-                   score, kind=kind), result
+                   score, kind=kind), result)
 
     assert_raises(ValueError, pcos, [1, 2, 3, 3, 4], 3, kind='unrecognized')
 
@@ -3298,19 +3298,19 @@ def test_normalitytests():
     x = np.array((-2,-1,0,1,2,3)*4)**2
     attributes = ('statistic', 'pvalue')
 
-    yield assert_array_almost_equal, stats.normaltest(x), (st_normal, pv_normal)
+    assert_array_almost_equal(stats.normaltest(x), (st_normal, pv_normal))
     check_named_results(stats.normaltest(x), attributes)
-    yield assert_array_almost_equal, stats.skewtest(x), (st_skew, pv_skew)
+    assert_array_almost_equal(stats.skewtest(x), (st_skew, pv_skew))
     check_named_results(stats.skewtest(x), attributes)
-    yield assert_array_almost_equal, stats.kurtosistest(x), (st_kurt, pv_kurt)
+    assert_array_almost_equal(stats.kurtosistest(x), (st_kurt, pv_kurt))
     check_named_results(stats.kurtosistest(x), attributes)
 
     # Test axis=None (equal to axis=0 for 1-D input)
-    yield (assert_array_almost_equal, stats.normaltest(x, axis=None),
+    assert_array_almost_equal(stats.normaltest(x, axis=None),
            (st_normal, pv_normal))
-    yield (assert_array_almost_equal, stats.skewtest(x, axis=None),
+    assert_array_almost_equal(stats.skewtest(x, axis=None),
            (st_skew, pv_skew))
-    yield (assert_array_almost_equal, stats.kurtosistest(x, axis=None),
+    assert_array_almost_equal(stats.kurtosistest(x, axis=None),
            (st_kurt, pv_kurt))
 
     x = np.arange(10.)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2283,18 +2283,14 @@ def test_percentileofscore():
     for (kind, result) in [('mean', 35.0),
                            ('strict', 30.0),
                            ('weak', 40.0)]:
-        assert_equal(pcos(np.arange(10) + 1,
-                                                    4, kind=kind), \
-                                                    result)
+        assert_equal(pcos(np.arange(10) + 1, 4, kind=kind), result)
 
     # multiple - 2
     for (kind, result) in [('rank', 45.0),
                            ('strict', 30.0),
                            ('weak', 50.0),
                            ('mean', 40.0)]:
-        assert_equal(pcos([1,2,3,4,4,5,6,7,8,9],
-                                                    4, kind=kind), \
-                                                    result)
+        assert_equal(pcos([1,2,3,4,4,5,6,7,8,9], 4, kind=kind), result)
 
     # multiple - 3
     assert_equal(pcos([1,2,3,4,4,4,5,6,7,8], 4), 50.0)
@@ -2303,15 +2299,11 @@ def test_percentileofscore():
                            ('strict', 30.0),
                            ('weak', 60.0)]:
 
-        assert_equal(pcos([1,2,3,4,4,4,5,6,7,8],
-                                                    4, kind=kind), \
-                                                    result)
+        assert_equal(pcos([1,2,3,4,4,4,5,6,7,8], 4, kind=kind), result)
 
     # missing
     for kind in ('rank', 'mean', 'strict', 'weak'):
-        assert_equal(pcos([1,2,3,5,6,7,8,9,10,11],
-                                                    4, kind=kind), \
-                                                    30)
+        assert_equal(pcos([1,2,3,5,6,7,8,9,10,11], 4, kind=kind), 30)
 
     # larger numbers
     for (kind, result) in [('mean', 35.0),


### PR DESCRIPTION
Some test janitoring in view of potential pytest usage in future, also makes some sense regardless:

- Rewrite some stats test generators to do no actual work at testsuite collection time.
- `yield assert*(...) -> assert*(...)` --- not a good use case for test generators.
- Replace `TestCase -> object` in a few cases that seem problematic for pytest.
