### PR TITLE
ENH/MAINT: ndimage: implement `LineBufferIterator` class and wrappers.

### DIFF
--- a/scipy/ndimage/setup.py
+++ b/scipy/ndimage/setup.py
@@ -24,6 +24,11 @@ def configuration(parent_package='', top_path=None):
         include_dirs=include_dirs,
         **numpy_nodepr_api)
 
+    config.add_extension("_ni_iterators",
+        sources=["src/ni_iterator_pywrap.c", "src/ni_iterators.c"],
+        include_dirs=include_dirs,
+        **numpy_nodepr_api)
+
     # Cython wants the .c and .pyx to have the underscore.
     config.add_extension("_ni_label",
                          sources=["src/_ni_label.c",],

--- a/scipy/ndimage/src/nd_image.h
+++ b/scipy/ndimage/src/nd_image.h
@@ -39,4 +39,17 @@
 
 #include "numpy/npy_3kcompat.h"
 
+
+/* The different boundary conditions. */
+typedef enum {
+    NI_EXTEND_FIRST = 0,
+    NI_EXTEND_NEAREST = 0,
+    NI_EXTEND_WRAP = 1,
+    NI_EXTEND_REFLECT = 2,
+    NI_EXTEND_MIRROR = 3,
+    NI_EXTEND_CONSTANT = 4,
+    NI_EXTEND_LAST = NI_EXTEND_CONSTANT,
+    NI_EXTEND_DEFAULT = NI_EXTEND_MIRROR
+} NI_ExtendMode;
+
 #endif /* ND_IMAGE_H */

--- a/scipy/ndimage/src/ni_filters.c
+++ b/scipy/ndimage/src/ni_filters.c
@@ -28,7 +28,6 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
 #include "ni_support.h"
 #include "ni_filters.h"
 #include <math.h>

--- a/scipy/ndimage/src/ni_iterator_pywrap.c
+++ b/scipy/ndimage/src/ni_iterator_pywrap.c
@@ -1,0 +1,254 @@
+#include "nd_image.h"
+#include "ni_iterators.h"
+
+
+PyObject*
+PyUniformFilter1D(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    PyArrayObject *input = NULL;
+    PyArrayObject *output = NULL;
+    int axis = NPY_MAXDIMS;
+    npy_intp filter_size = 1;
+    npy_intp filter_offset = 0;
+    NI_ExtendMode extend_mode = NI_EXTEND_NEAREST;
+    npy_double extend_value = 0.0;
+    LineBufferIterator *lbiter = NULL;
+
+
+    static char *kwlist[] = {"input", "output", "axis", "filter_size",
+                             "filter_offset", "extend_mode", "extend_value",
+                             NULL};
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!O!in|nid", kwlist,
+                                     &PyArray_Type, &input,
+                                     &PyArray_Type, &output,
+                                     &axis, &filter_size, &filter_offset,
+                                     &extend_mode, &extend_value)) {
+        goto fail;
+    }
+
+    lbiter = LBI_New(input, axis, output, filter_size, filter_offset,
+                     extend_mode, extend_value);
+    if (lbiter == NULL) {
+        goto fail;
+    }
+
+    do {
+        const npy_double *read_front = LBI_GetInputBuffer(lbiter);
+        const npy_double *read_back = read_front;
+        npy_double *write = LBI_GetOutputBuffer(lbiter);
+        npy_double running_sum = 0.0;
+        npy_intp filter_size_copy = filter_size;
+        npy_intp line_length = LBI_GetLineLength(lbiter);
+
+        while (filter_size_copy--) {
+            running_sum += *read_front++;
+        }
+        *write++ = running_sum / filter_size;
+        while (--line_length) {
+            running_sum += *read_front++ - *read_back++;
+            *write++ = running_sum / filter_size;
+        }
+    } while(LBI_Next(lbiter));
+
+    LBI_Delete(lbiter);
+
+    Py_INCREF(output);
+    return (PyObject *)output;
+
+fail:
+    return (PyObject *)LBI_Delete(lbiter);
+}
+
+
+typedef struct {
+    PyObject_HEAD
+    LineBufferIterator *lbiter;
+    PyObject *in_buffer;
+    PyObject *out_buffer;
+    int iter_started;
+} PyLineBufferIterator;
+
+
+static PyObject*
+pylbi_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+{
+    PyLineBufferIterator *self;
+
+    self = (PyLineBufferIterator *)type->tp_alloc(type, 0);
+    if (self != NULL) {
+        self->lbiter = NULL;
+        self->in_buffer = NULL;
+        self->out_buffer = NULL;
+        self->iter_started = 0;
+    }
+
+    return (PyObject *)self;
+}
+
+
+static int
+pylbi_init(PyLineBufferIterator *self, PyObject *args, PyObject *kwds)
+{
+    PyArrayObject *input = NULL;
+    PyArrayObject *output = NULL;
+    int axis = NPY_MAXDIMS;
+    npy_intp filter_size = 1;
+    npy_intp filter_offset = 0;
+    NI_ExtendMode extend_mode = NI_EXTEND_NEAREST;
+    npy_double extend_value = 0.0;
+    npy_intp buffer_len;
+    static char *kwlist[] = {"input", "output", "axis", "filter_size",
+                             "filter_offset", "extend_mode", "extend_value",
+                             NULL};
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!O!in|nid", kwlist,
+                                     &PyArray_Type, &input,
+                                     &PyArray_Type, &output,
+                                     &axis, &filter_size, &filter_offset,
+                                     &extend_mode, &extend_value)) {
+        goto fail;
+    }
+
+    LBI_Delete(self->lbiter);
+    self->lbiter = LBI_New(input, axis, output, filter_size, filter_offset,
+                           extend_mode, extend_value);
+    if (self->lbiter == NULL) {
+        goto fail;
+    }
+
+    Py_XDECREF(self->out_buffer);
+    buffer_len = LBI_GetLineLength(self->lbiter);
+    self->out_buffer = PyArray_SimpleNewFromData(1, &buffer_len, NPY_DOUBLE,
+                                            LBI_GetOutputBuffer(self->lbiter));
+    if (self->out_buffer == NULL) {
+        goto fail;
+    }
+
+    Py_XDECREF(self->in_buffer);
+    buffer_len += filter_size - 1;
+    self->in_buffer = PyArray_SimpleNewFromData(1, &buffer_len, NPY_DOUBLE,
+                                            LBI_GetInputBuffer(self->lbiter));
+    if (self->in_buffer == NULL) {
+        goto fail;
+    }
+
+    self->iter_started = 0;
+
+    return 0;
+
+fail:
+    LBI_Delete(self->lbiter);
+    Py_XDECREF(self->in_buffer);
+    Py_XDECREF(self->out_buffer);
+    return -1;
+}
+
+
+PyObject*
+pylbi_getiter(PyLineBufferIterator *self)
+{
+    Py_INCREF((PyObject *)self);
+    return (PyObject *)self;
+}
+
+
+PyObject*
+pylbi_next(PyLineBufferIterator *self)
+{
+    if (!self->iter_started || LBI_Next(self->lbiter)) {
+        self->iter_started = 1;
+        return Py_BuildValue("OO", self->in_buffer, self->out_buffer);
+    }
+    return NULL;
+}
+
+
+static void
+pylbi_dealloc(PyLineBufferIterator* self)
+{
+    LBI_Delete(self->lbiter);
+    Py_XDECREF(self->in_buffer);
+    Py_XDECREF(self->out_buffer);
+    Py_TYPE(self)->tp_free((PyObject*)self);
+}
+
+
+NPY_NO_EXPORT PyTypeObject PyLineBufferIterator_Type = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "ndimage.LineBufferIterator",               /* tp_name */
+    sizeof(PyLineBufferIterator),               /* tp_basicsize */
+    0,                                          /* tp_itemsize */
+    /* methods */
+    (destructor)pylbi_dealloc,                  /* tp_dealloc */
+    0,                                          /* tp_print */
+    0,                                          /* tp_getattr */
+    0,                                          /* tp_setattr */
+#if defined(NPY_PY3K)
+    0,                                          /* tp_reserved */
+#else
+    0,                                          /* tp_compare */
+#endif
+    0,                                          /* tp_repr */
+    0,                                          /* tp_as_number */
+    0,                                          /* tp_as_sequence */
+    0,                                          /* tp_as_mapping */
+    0,                                          /* tp_hash */
+    0,                                          /* tp_call */
+    0,                                          /* tp_str */
+    0,                                          /* tp_getattro */
+    0,                                          /* tp_setattro */
+    0,                                          /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT,                         /* tp_flags */
+    0,                                          /* tp_doc */
+    0,                                          /* tp_traverse */
+    0,                                          /* tp_clear */
+    0,                                          /* tp_richcompare */
+    0,                                          /* tp_weaklistoffset */
+    (getiterfunc)pylbi_getiter,                 /* tp_iter */
+    (iternextfunc)pylbi_next,                   /* tp_iternext */
+    0,                                          /* tp_methods */
+    0,                                          /* tp_members */
+    0,                                          /* tp_getset */
+    0,                                          /* tp_base */
+    0,                                          /* tp_dict */
+    0,                                          /* tp_descr_get */
+    0,                                          /* tp_descr_set */
+    0,                                          /* tp_dictoffset */
+    (initproc)pylbi_init,                       /* tp_init */
+    0,                                          /* tp_alloc */
+    (newfunc)pylbi_new,                         /* tp_new */
+ };
+
+
+static PyMethodDef ni_iterators_methods[] = {
+
+    {"UniformFilter1D", (PyCFunction)PyUniformFilter1D,
+     METH_VARARGS | METH_KEYWORDS,
+     "LineBufferIterator version of ndimage.uniform_filter1D."},
+    {NULL, NULL, 0, NULL}        /* Sentinel */
+};
+
+
+#ifndef PyMODINIT_FUNC /* declarations for DLL import/export */
+#define PyMODINIT_FUNC void
+#endif
+PyMODINIT_FUNC
+init_ni_iterators(void)
+{
+    PyObject* m;
+
+    if (PyType_Ready(&PyLineBufferIterator_Type) < 0) {
+        return;
+    }
+
+    m = Py_InitModule("_ni_iterators", ni_iterators_methods);
+    if (m == NULL) {
+        return;
+    }
+
+    Py_INCREF(&PyLineBufferIterator_Type);
+    PyModule_AddObject(m, "LineBufferIterator",
+                      (PyObject *)&PyLineBufferIterator_Type);
+    import_array();
+}

--- a/scipy/ndimage/src/ni_iterator_utils.h
+++ b/scipy/ndimage/src/ni_iterator_utils.h
@@ -1,0 +1,393 @@
+/* Helper functionality used in ni_iterators. */
+
+#ifndef NI_ITERATOR_UTILS_H
+#define NI_ITERATOR_UTILS_H
+
+
+/*
+ ***********************************************************************
+ ***                         Generic helpers                         ***
+ ***********************************************************************
+ */
+
+static int
+_is_input_array(PyArrayObject *array)
+{
+    if (array == NULL) {
+        PyErr_SetString(PyExc_RuntimeError, "Unexpected NULL array.");
+        return 0;
+    }
+    if (!PyArray_ISALIGNED(array)) {
+        PyErr_SetString(PyExc_RuntimeError, "Expected an aligned array.");
+        return 0;
+    }
+    if (PyArray_ISBYTESWAPPED(array)) {
+        PyErr_SetString(PyExc_RuntimeError, "Unexpected byte swapped array.");
+        return 0;
+    }
+    if (PyArray_SIZE(array) == 0) {
+        PyErr_SetString(PyExc_RuntimeError, "Unexpected zero-sized array.");
+        return 0;
+    }
+    return 1;
+}
+
+
+static int
+_is_output_array(PyArrayObject *array)
+{
+    if (!_is_input_array(array)) {
+        return 0;
+    }
+    if (!PyArray_ISWRITEABLE(array)) {
+        PyErr_SetString(PyExc_RuntimeError, "Expected a writeable array.");
+        return 0;
+    }
+    return 1;
+}
+
+
+static int
+_is_valid_axis(PyArrayObject *array, int *axis)
+{
+    if (*axis < -PyArray_NDIM(array) || *axis >= PyArray_NDIM(array)) {
+        PyErr_Format(PyExc_ValueError,
+                     "axis %d out of bounds for %d-dimensional array.",
+                     *axis, PyArray_NDIM(array));
+        return 0;
+    }
+    if (*axis < 0) {
+        *axis += PyArray_NDIM(array);
+    }
+    return 1;
+}
+
+
+static int
+_intp_arrays_are_equal(npy_intp *one, npy_intp *two, npy_intp length)
+{
+    while (length--) {
+        if (*one++ != *two++) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+
+static int
+_arrays_are_compatible(PyArrayObject *one, PyArrayObject *two)
+{
+    if (PyArray_NDIM(one) != PyArray_NDIM(two)) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "Expected arrays with same number of dimensions.");
+        return 0;
+    }
+    if (!_intp_arrays_are_equal(PyArray_DIMS(one), PyArray_DIMS(two),
+                                PyArray_NDIM(one))) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "Expected arrays with same shape.");
+        return 0;
+    }
+    return 1;
+}
+
+
+static int
+_split_filter_size(npy_intp size, npy_intp offset,
+                   npy_intp *before, npy_intp *after)
+{
+    if (size < 1) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "Unexpected zero-sized filter.");
+        return 0;
+    }
+    *before = size / 2 + offset;
+    *after = size - *before - 1;
+    if (*before < 0 || after < 0) {
+        PyErr_Format(PyExc_ValueError,
+                     "offset %zd out of bounds for filter of size %zd.",
+                     offset, size);
+        return 0;
+    }
+    return 1;
+}
+
+
+static int
+_is_lbi_supported_type(enum NPY_TYPES numtype)
+{
+    if (numtype < NPY_BOOL || numtype > NPY_DOUBLE) {
+        PyErr_SetString(PyExc_RuntimeError, "Unsupported data type.");
+        return 0;
+    }
+    return 1;
+}
+
+
+/*
+ ***********************************************************************
+ ***                     Helpers for LBI_ReadLine                    ***
+ ***********************************************************************
+ */
+
+typedef void (read_line_func)(npy_double*, const char*, npy_intp, npy_intp);
+
+#define READ_LINE_FUNC(_type)                                  \
+static void                                                    \
+_read_line_##_type(npy_double *buffer, const char *line,       \
+                   npy_intp line_length, npy_intp line_stride) \
+{                                                              \
+    while (line_length--) {                                    \
+        *buffer++ = *(_type *)line;                            \
+        line += line_stride;                                   \
+    }                                                          \
+}
+
+READ_LINE_FUNC(npy_bool)
+READ_LINE_FUNC(npy_byte)
+READ_LINE_FUNC(npy_ubyte)
+READ_LINE_FUNC(npy_short)
+READ_LINE_FUNC(npy_ushort)
+READ_LINE_FUNC(npy_int)
+READ_LINE_FUNC(npy_uint)
+READ_LINE_FUNC(npy_long)
+READ_LINE_FUNC(npy_ulong)
+READ_LINE_FUNC(npy_longlong)
+READ_LINE_FUNC(npy_ulonglong)
+READ_LINE_FUNC(npy_float)
+READ_LINE_FUNC(npy_double)
+
+static read_line_func*
+_get_read_line_func(enum NPY_TYPES typenum)
+{
+    /* These functions must be in the same order as enum NPY_TYPES. */
+    read_line_func *_lbi_read_funcs[] = {
+        &_read_line_npy_bool,
+        &_read_line_npy_byte, &_read_line_npy_ubyte,
+        &_read_line_npy_short, &_read_line_npy_ushort,
+        &_read_line_npy_int, &_read_line_npy_uint,
+        &_read_line_npy_long, &_read_line_npy_ulong,
+        &_read_line_npy_longlong, &_read_line_npy_ulonglong,
+        &_read_line_npy_float, &_read_line_npy_double,
+    };
+    if (_is_lbi_supported_type(typenum)) {
+        return _lbi_read_funcs[typenum];
+    }
+    return NULL;
+}
+
+
+/*
+ ***********************************************************************
+ ***                    Helpers for LBI_WriteLine                    ***
+ ***********************************************************************
+ */
+
+
+typedef void (write_line_func)(npy_double*, char*, npy_intp, npy_intp);
+
+#define WRITE_LINE_FUNC(_type)                                  \
+static void                                                     \
+_write_line_##_type(npy_double *buffer, char *line,             \
+                    npy_intp line_length, npy_intp line_stride) \
+{                                                               \
+    while (line_length--) {                                     \
+        *(_type *)line = *buffer++;                             \
+        line += line_stride;                                    \
+    }                                                           \
+}
+
+WRITE_LINE_FUNC(npy_bool)
+WRITE_LINE_FUNC(npy_ubyte)
+WRITE_LINE_FUNC(npy_ushort)
+WRITE_LINE_FUNC(npy_uint)
+WRITE_LINE_FUNC(npy_ulong)
+WRITE_LINE_FUNC(npy_ulonglong)
+WRITE_LINE_FUNC(npy_byte)
+WRITE_LINE_FUNC(npy_short)
+WRITE_LINE_FUNC(npy_int)
+WRITE_LINE_FUNC(npy_long)
+WRITE_LINE_FUNC(npy_longlong)
+WRITE_LINE_FUNC(npy_float)
+WRITE_LINE_FUNC(npy_double)
+
+
+static NPY_INLINE write_line_func*
+_get_write_line_func(enum NPY_TYPES typenum)
+{
+    /* These functions must be in the same order as enum NPY_TYPES. */
+    write_line_func *_lbi_write_funcs[] = {
+        &_write_line_npy_bool,
+        &_write_line_npy_byte, &_write_line_npy_ubyte,
+        &_write_line_npy_short, &_write_line_npy_ushort,
+        &_write_line_npy_int, &_write_line_npy_uint,
+        &_write_line_npy_long, &_write_line_npy_ulong,
+        &_write_line_npy_longlong, &_write_line_npy_ulonglong,
+        &_write_line_npy_float, &_write_line_npy_double,
+    };
+    if (_is_lbi_supported_type(typenum)) {
+        return _lbi_write_funcs[typenum];
+    }
+    return NULL;
+}
+
+
+/*
+ ***********************************************************************
+ ***                    Helpers for LBI_ExtendLine                   ***
+ ***********************************************************************
+ */
+
+typedef void (extend_line_func)(npy_double*, npy_intp, npy_intp, npy_intp,
+                                npy_double);
+
+static void
+_extend_line_nearest(npy_double *buffer, npy_intp line_length,
+                     npy_intp size_before, npy_intp size_after,
+                     npy_double unused_value)
+{
+    /* aaaaaaaa|abcd|dddddddd */
+    npy_double * const first = buffer + size_before;
+    npy_double * const last = first + line_length;
+    npy_double *dst, val;
+
+    val = *first;
+    dst = buffer;
+    while (size_before--) {
+        *dst++ = val;
+    }
+    dst = last;
+    val = *(last - 1);
+    while (size_after--) {
+        *dst++ = val;
+    }
+}
+
+static void
+_extend_line_wrap(npy_double *buffer, npy_intp line_length,
+                  npy_intp size_before, npy_intp size_after,
+                  npy_double unused_value)
+{
+    /* abcdabcd|abcd|abcdabcd */
+    npy_double * const first = buffer + size_before;
+    npy_double * const last = first + line_length;
+    const npy_double *src;
+    npy_double *dst;
+
+    src = last - 1;
+    dst = first - 1;
+    while (size_before--) {
+        *dst-- = *src--;
+    }
+    src = first;
+    dst = last;
+    while (size_after--) {
+        *dst++ = *src++;
+    }
+}
+
+static void
+_extend_line_reflect(npy_double *buffer, npy_intp line_length,
+                     npy_intp size_before, npy_intp size_after,
+                     npy_double unused_value)
+{
+    /* abcddcba|abcd|dcbaabcd */
+    npy_double * const first = buffer + size_before;
+    npy_double * const last = first + line_length;
+    const npy_double *src;
+    npy_double *dst;
+
+    src = first;
+    dst = first - 1;
+    while (src < last && size_before--) {
+        *dst-- = *src++;
+    }
+    src = last - 1;
+    while (size_before--) {
+        *dst-- = *src--;
+    }
+    src = last - 1;
+    dst = last;
+    while (dst >= first && size_after--) {
+        *dst++ = *src--;
+    }
+    src = first;
+    while (size_after--) {
+        *dst++ = *src++;
+    }
+}
+
+static void
+_extend_line_mirror(npy_double *buffer, npy_intp line_length,
+                    npy_intp size_before, npy_intp size_after,
+                    npy_double unused_value)
+{
+    /* abcddcba|abcd|dcbaabcd */
+    npy_double * const first = buffer + size_before;
+    npy_double * const last = first + line_length;
+    const npy_double *src;
+    npy_double *dst;
+
+    src = first + 1;
+    dst = first - 1;
+    while (src < last && size_before--) {
+        *dst-- = *src++;
+    }
+    src = last - 2;
+    while (size_before--) {
+        *dst-- = *src--;
+    }
+    src = last - 2;
+    dst = last;
+    while (dst >= first && size_after--) {
+        *dst++ = *src--;
+    }
+    src = first + 1;
+    while (size_after--) {
+        *dst++ = *src++;
+    }
+}
+
+static void
+_extend_line_constant(npy_double *buffer, npy_intp line_length,
+                      npy_intp size_before, npy_intp size_after,
+                      const npy_double value)
+{
+        /* abcddcba|abcd|dcbaabcd */
+    npy_double * const last = buffer + size_before + line_length;
+    npy_double *dst;
+
+    dst = buffer;
+    while (size_before--) {
+        *dst++ = value;
+    }
+    dst = last;
+    while (size_after--) {
+        *dst++ = value;
+    }
+}
+
+static extend_line_func*
+_get_extend_line_func(NI_ExtendMode extend_mode)
+{
+    switch (extend_mode) {
+        case NI_EXTEND_NEAREST:
+            return &_extend_line_nearest;
+        case NI_EXTEND_WRAP:
+            return &_extend_line_wrap;
+        case NI_EXTEND_REFLECT:
+            return &_extend_line_reflect;
+        case NI_EXTEND_MIRROR:
+            return &_extend_line_mirror;
+        case NI_EXTEND_CONSTANT:
+            return &_extend_line_constant;
+        default:
+            PyErr_Format(PyExc_ValueError,
+                         "Unexpected extend mode %d.", extend_mode);
+            return NULL;
+    }
+}
+
+
+#endif /* NI_ITERATOR_UTILS_H */

--- a/scipy/ndimage/src/ni_iterators.c
+++ b/scipy/ndimage/src/ni_iterators.c
@@ -1,0 +1,331 @@
+#include "ni_iterators.h"
+#include "ni_iterator_utils.h"
+
+
+/*
+ ***********************************************************************
+ ***                           NDIterator                            ***
+ ***********************************************************************
+ */
+
+struct NDIterator_Internal {
+    /* Number of dimensions being iterated minus one. */
+    int ndim_1;
+    /* Total iterator size */
+    npy_intp size;
+    /* Sizes of the dimensions being iterated, minus 1 */
+    npy_intp dims_1[NPY_MAXDIMS];
+    /* Strides over the dimensions being iterated */
+    npy_intp strides[NPY_MAXDIMS];
+    /* How far to jump back for the dimensions being iterated */
+    npy_intp backstrides[NPY_MAXDIMS];
+    /* Current iterator position  */
+    npy_intp index;
+    /* Current iterator position for multidimensional iteration */
+    npy_intp coords[NPY_MAXDIMS];
+    /* Pointer to the current iteration item */
+    char *data;
+    /* The array being iterated */
+    PyArrayObject *array;
+};
+
+
+static NDIterator*
+_NDI_NewExceptAxes(PyArrayObject *array, npy_uint32 axes)
+{
+    NDIterator *nditer = malloc(sizeof(NDIterator));
+    int axis;
+
+    if (nditer == NULL) {
+        return (NDIterator *)PyErr_NoMemory();
+    }
+
+    Py_INCREF(array);
+    nditer->array = array;
+    nditer->data = PyArray_BYTES(array);
+    nditer->ndim_1 = -1;
+    nditer->size = 1;
+    for (axis = 0; axis < PyArray_NDIM(array); ++axis) {
+        if (!(axes & (npy_uint32)0x1)) {
+            const npy_intp dim = PyArray_DIM(array, axis);
+            const npy_intp stride = PyArray_STRIDE(array, axis);
+            const int iter_axis = ++(nditer->ndim_1);
+
+            nditer->size *= dim;
+            nditer->dims_1[iter_axis] = dim - 1;
+            nditer->strides[iter_axis] = stride;
+            nditer->backstrides[iter_axis] = stride * (dim - 1);
+            nditer->coords[iter_axis] = 0;
+        }
+        axes >>= 1;
+    }
+    nditer->index = 0;
+
+    return nditer;
+}
+
+NDIterator*
+NDI_New(PyArrayObject *array)
+{
+    if (!_is_input_array(array)) {
+        return NULL;
+    }
+
+    return _NDI_NewExceptAxes(array, (npy_uint32)0x0);
+}
+
+
+NDIterator*
+NDI_NewExceptAxis(PyArrayObject *array, int axis)
+{
+    if (!_is_input_array(array) || !_is_valid_axis(array, &axis)) {
+        return NULL;
+    }
+
+    return _NDI_NewExceptAxes(array, ((npy_uint32)0x1) << axis);
+}
+
+
+int
+NDI_Next(NDIterator *nditer)
+{
+    int axis;
+
+    if (++(nditer->index) >= nditer->size) {
+        return 0;
+    }
+
+    for (axis = nditer->ndim_1; axis >= 0; --axis) {
+        if (nditer->coords[axis] < nditer->dims_1[axis]) {
+            ++(nditer->coords[axis]);
+            nditer->data += nditer->strides[axis];
+            break;
+        }
+        else {
+            nditer->coords[axis] = 0;
+            nditer->data -= nditer->backstrides[axis];
+        }
+    }
+
+    return 1;
+}
+
+static int
+_NDI_NextForTwo(NDIterator *nditer1, NDIterator *nditer2)
+{
+    int axis;
+
+    ++(nditer1->index);
+    ++(nditer2->index);
+    if (nditer1->index >= nditer1->size) {
+        return 0;
+    }
+
+    for (axis = nditer1->ndim_1; axis >= 0; --axis) {
+        if (nditer1->coords[axis] < nditer1->dims_1[axis]) {
+            ++(nditer1->coords[axis]);
+            ++(nditer2->coords[axis]);
+            nditer1->data += nditer1->strides[axis];
+            nditer2->data += nditer2->strides[axis];
+            break;
+        }
+        else {
+            nditer1->coords[axis] = 0;
+            nditer2->coords[axis] = 0;
+            nditer1->data -= nditer1->backstrides[axis];
+            nditer2->data -= nditer2->backstrides[axis];
+        }
+    }
+
+    return 1;
+}
+
+
+void
+NDI_Delete(NDIterator *nditer)
+{
+    if (nditer != NULL) {
+        Py_DECREF(nditer->array);
+        free(nditer);
+    }
+}
+
+
+/*
+ ***********************************************************************
+ ***                       LineBufferIterator                        ***
+ ***********************************************************************
+ */
+
+struct LineBufferIterator_Internal {
+    /* Input and output buffers. */
+    npy_double *in_buffer;
+    npy_double *out_buffer;
+    /* Size of filter. */
+    npy_intp filter_size;
+    /* Size of filter before and after origin, size = before + 1 + after. */
+    npy_intp size_before;
+    npy_intp size_after;
+    /* Length of array lines. */
+    npy_intp line_length;
+    /* Iterators over input and output array lines. */
+    NDIterator *in_nditer;
+    NDIterator *out_nditer;
+    /* Line strides of the input and output arrays. */
+    npy_intp in_stride;
+    npy_intp out_stride;
+    /* Functions to read and write array lines from/to buffers. */
+    read_line_func *read_func;
+    write_line_func *write_func;
+    /* Extend function and value for constant mode. */
+    extend_line_func *extend_func;
+    npy_double extend_value;
+};
+
+
+static NPY_INLINE void
+_LBI_ExtendLine(LineBufferIterator *lbiter)
+{
+    lbiter->extend_func(lbiter->in_buffer, lbiter->line_length,
+                        lbiter->size_before, lbiter->size_after,
+                        lbiter->extend_value);
+}
+
+
+static NPY_INLINE void
+_LBI_ReadLine(LineBufferIterator *lbiter)
+{
+    lbiter->read_func(lbiter->in_buffer + lbiter->size_before,
+                      lbiter->in_nditer->data,
+                      lbiter->line_length, lbiter->in_stride);
+    _LBI_ExtendLine(lbiter);
+}
+
+
+LineBufferIterator*
+LBI_New(PyArrayObject *input, int axis, PyArrayObject *output,
+        npy_intp filter_size, npy_intp filter_offset,
+        NI_ExtendMode extend_mode, npy_double extend_value)
+{
+    LineBufferIterator *lbiter = NULL;
+
+    if (!_is_input_array(input) || !_is_output_array(output) ||
+            !_arrays_are_compatible(input, output) ||
+            !_is_valid_axis(input, &axis)) {
+        return NULL;
+    }
+
+    lbiter = malloc(sizeof(LineBufferIterator));
+    if (lbiter == NULL) {
+        return (LineBufferIterator *)PyErr_NoMemory();
+    }
+
+    lbiter->in_buffer = NULL;
+    lbiter->out_buffer = NULL;
+    lbiter->in_nditer = NULL;
+    lbiter->out_nditer = NULL;
+
+    if (!_split_filter_size(filter_size, filter_offset,
+                            &lbiter->size_before, &lbiter->size_after)) {
+        return LBI_Delete(lbiter);
+    }
+    lbiter->filter_size = filter_size;
+
+    lbiter->read_func = _get_read_line_func(PyArray_TYPE(input));
+    if (lbiter->read_func == NULL) {
+        return LBI_Delete(lbiter);
+    }
+    lbiter->in_nditer = NDI_NewExceptAxis(input, axis);
+    if (lbiter->in_nditer == NULL) {
+        return LBI_Delete(lbiter);
+    }
+
+    lbiter->write_func = _get_write_line_func(PyArray_TYPE(output));
+    if (lbiter->write_func == NULL) {
+        return LBI_Delete(lbiter);
+    }
+    lbiter->out_nditer = NDI_NewExceptAxis(output, axis);
+    if (lbiter->out_nditer == NULL) {
+        return LBI_Delete(lbiter);
+    }
+
+    lbiter->line_length = PyArray_DIM(input, axis);
+    lbiter->in_stride = PyArray_STRIDE(input, axis);
+    lbiter->out_stride = PyArray_STRIDE(output, axis);
+
+    lbiter->in_buffer = malloc(sizeof(npy_double) *
+            (lbiter->line_length + lbiter->size_before + lbiter->size_after));
+    if (lbiter->in_buffer == NULL) {
+        PyErr_NoMemory();
+        return LBI_Delete(lbiter);
+    }
+    lbiter->out_buffer = malloc(sizeof(npy_double) * lbiter->line_length);
+    if (lbiter->out_buffer == NULL) {
+        PyErr_NoMemory();
+        return LBI_Delete(lbiter);
+    }
+
+    lbiter->extend_func = _get_extend_line_func(extend_mode);
+    if (lbiter->extend_func == NULL) {
+        return LBI_Delete(lbiter);
+    }
+    lbiter->extend_value = extend_value;
+
+    _LBI_ReadLine(lbiter);
+
+    return lbiter;
+}
+
+
+npy_double*
+LBI_GetInputBuffer(LineBufferIterator *lbiter)
+{
+    return lbiter->in_buffer;
+}
+
+
+npy_double*
+LBI_GetOutputBuffer(LineBufferIterator *lbiter)
+{
+    return lbiter->out_buffer;
+}
+
+npy_intp
+LBI_GetLineLength(LineBufferIterator *lbiter)
+{
+    return lbiter->line_length;
+}
+
+
+static NPY_INLINE void
+_LBI_WriteLine(LineBufferIterator *lbiter)
+{
+    lbiter->write_func(lbiter->out_buffer, lbiter->out_nditer->data,
+                       lbiter->line_length, lbiter->out_stride);
+}
+
+
+int
+LBI_Next(LineBufferIterator *lbiter)
+{
+    _LBI_WriteLine(lbiter);
+    if (_NDI_NextForTwo(lbiter->in_nditer, lbiter->out_nditer)) {
+        _LBI_ReadLine(lbiter);
+        return 1;
+    }
+    return 0;
+}
+
+
+LineBufferIterator*
+LBI_Delete(LineBufferIterator *lbiter)
+{
+    if (lbiter != NULL) {
+        NDI_Delete(lbiter->in_nditer);
+        NDI_Delete(lbiter->out_nditer);
+        free(lbiter->in_buffer);
+        free(lbiter->out_buffer);
+        free(lbiter);
+    }
+    return NULL;
+}

--- a/scipy/ndimage/src/ni_iterators.h
+++ b/scipy/ndimage/src/ni_iterators.h
@@ -1,0 +1,74 @@
+#ifndef NI_ITERATORS_H
+#define NI_ITERATORS_H
+
+#define NO_IMPORT_ARRAY
+#include "nd_image.h"
+#undef NO_IMPORT_ARRAY
+
+
+/*
+ ***********************************************************************
+ ***                           NDIterator                            ***
+ ***********************************************************************
+ */
+
+/* The struct internals are a private implementation detail. */
+typedef struct NDIterator_Internal NDIterator;
+
+/* Creates a new iterator over all axes of the array. */
+NDIterator*
+NDI_New(PyArrayObject *array);
+
+/* Creates a new iterator over all except one axis of the array. */
+NDIterator*
+NDI_NewExceptAxis(PyArrayObject *array, int axis);
+
+/* Advances the iterator. Returns 0 if exhausted, else 1. */
+int
+NDI_Next(NDIterator *nditer);
+
+/* Releases all memory allocated by an iterator */
+void
+NDI_Delete(NDIterator *nditer);
+
+
+/*
+ ***********************************************************************
+ ***                       LineBufferIterator                        ***
+ ***********************************************************************
+ */
+
+/* The struct internals are a private implementation detail. */
+typedef struct LineBufferIterator_Internal LineBufferIterator;
+
+/* Creates a new line buffer iterator and reads the first line in. */
+LineBufferIterator*
+LBI_New(PyArrayObject *input, int axis, PyArrayObject *output,
+        npy_intp filter_size, npy_intp filter_offset,
+        NI_ExtendMode extend_mode, npy_double extend_value);
+
+/* Returns a pointer to the iterator's input buffer. */
+npy_double*
+LBI_GetInputBuffer(LineBufferIterator *lbiter);
+
+/* Returns a pointer to the iterator's output buffer. */
+npy_double*
+LBI_GetOutputBuffer(LineBufferIterator *lbiter);
+
+/* Returns the length of each of the iterator's lines. */
+npy_intp
+LBI_GetLineLength(LineBufferIterator *lbiter);
+
+/*
+ * Writes the output buffer to the output array, advances the iterator and
+ * reads a new line into the input buffer. Returns 0 if exhausted, else 1.
+ */
+int
+LBI_Next(LineBufferIterator *lbiter);
+
+/* Releases all memory allocated by the iterator. Always returns NULL. */
+LineBufferIterator*
+LBI_Delete(LineBufferIterator *lbiter);
+
+
+#endif /* NI_ITERATORS_H */

--- a/scipy/ndimage/src/ni_support.h
+++ b/scipy/ndimage/src/ni_support.h
@@ -47,20 +47,6 @@
 #include <limits.h>
 #include <assert.h>
 
-/* The different boundary conditions. The mirror condition is not used
-     by the python code, but C code is kept around in case we might wish
-     to add it. */
-typedef enum {
-    NI_EXTEND_FIRST = 0,
-    NI_EXTEND_NEAREST = 0,
-    NI_EXTEND_WRAP = 1,
-    NI_EXTEND_REFLECT = 2,
-    NI_EXTEND_MIRROR = 3,
-    NI_EXTEND_CONSTANT = 4,
-    NI_EXTEND_LAST = NI_EXTEND_CONSTANT,
-    NI_EXTEND_DEFAULT = NI_EXTEND_MIRROR
-} NI_ExtendMode;
-
 
 /******************************************************************/
 /* Iterators */

--- a/scipy/ndimage/tests/test_ni_iterators.py
+++ b/scipy/ndimage/tests/test_ni_iterators.py
@@ -1,0 +1,33 @@
+from __future__ import division, print_function, absolute_import
+
+import itertools
+
+import numpy as np
+from scipy.ndimage._ni_iterators import LineBufferIterator
+from numpy.testing import assert_array_equal, run_module_suite
+
+
+class TestLineBufferIterator:
+
+    valid_types = '?' + np.typecodes['AllInteger'] + 'fd'
+    input_array = np.arange(3 * 5 * 7).reshape(3, 5, 7)
+
+    def all_type_pairs(self):
+        return itertools.product(self.valid_types, repeat=2)
+
+    def test_all_types(self):
+        for input_type, output_type in self.all_type_pairs():
+            input_array = self.input_array.astype(input_type)
+            output_array = np.empty_like(input_array, dtype=output_type)
+            for axis in range(input_array.ndim):
+                lbiter = LineBufferIterator(input_array, output_array, axis, 1)
+                for input_buffer, output_buffer in lbiter:
+                    output_buffer[:] = input_buffer
+                if output_type == '?':
+                    input_array = input_array.astype('?')
+                assert_array_equal(input_array, output_array,
+                                   '{} -> {}'.format(input_type, output_type))
+
+
+if __name__ == '__main__':
+    run_module_suite()


### PR DESCRIPTION
**DO NOT MERGE**

This is pretty large PR, with a proof of concept of the way I would like to refactor `ndimage`. It includes:

 * An implementation of `NDIterator` (very similar to `NI_Iterator`) and `LineBufferIterator` (somewhat similar to `NI_LineBuffer`), spread over three files (`ni_iterators.h`, `ni_iterators.c` and `ni_iterator_utils.c`). Note that the exposed API, see `ni_iterators.h`, is pretty small compared to the equivalent existing objects.

 * A Python wrapper for the `LineBufferIterator` object, see `ni_iterator_pywrap.c`. This would not be meant to be exposed to the user (the implementation right now is not very safe), but to enable in depth testing of the C code. As an example some tests have been added in `test_ni_iterators.py`.

 * An implementation of the `uniform_filter1D` function using these new iterators, also in `ni_iterator_pywrap.c`. This was done to demonstrate that:
    - Implementing a simple filter requires much less boilerplate than before, and
    - There is no performance degradation vs. the existing implementation.

I have used C in the last two points mostly for my convenience, but if we can agree that this is the right path forward, I would propose to:

 1. Create a separate PR to merge the C part of this PR, mostly as is.
 2. In a separate PR, add Cython wrappers to these two objects, along the lines of what is demonstrated here.
 3. In a third PR, add in depth testing, a.k.a. test the shit out, of the two iterators through the Cython wrappers.
 4. In a fourth PR, add a Cython module that implements all the functions in `ni_filters.c` that would use the new `LineBufferIterator`.
 5. In subsequent PRs, do something similar with `NI_FilterIterator`, although the details for that are still TBD.