### PR TITLE
Test janitoring pt. 2

### DIFF
--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -34,7 +34,7 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import (TestCase, run_module_suite, dec, assert_raises,
+from numpy.testing import (run_module_suite, dec, assert_raises,
                            assert_allclose, assert_equal, assert_, assert_warns)
 
 from scipy._lib.six import xrange, u
@@ -489,7 +489,7 @@ class TestIsValidInconsistent(object):
             assert_raises(ValueError, is_valid_im, R, throw=True)
 
 
-class TestNumObsLinkage(TestCase):
+class TestNumObsLinkage(object):
     def test_num_obs_linkage_empty(self):
         # Tests num_obs_linkage(Z) with empty linkage.
         Z = np.zeros((0, 4), dtype=np.double)
@@ -550,7 +550,7 @@ class TestLeavesList(object):
                                         + node.get_right().pre_order()))
 
 
-class TestCorrespond(TestCase):
+class TestCorrespond(object):
     def test_correspond_empty(self):
         # Tests correspond(Z, y) with empty linkage and condensed distance matrix.
         y = np.zeros((0,))
@@ -602,7 +602,7 @@ class TestCorrespond(TestCase):
             assert_equal(num_obs_linkage(Z), n)
 
 
-class TestIsMonotonic(TestCase):
+class TestIsMonotonic(object):
     def test_is_monotonic_empty(self):
         # Tests is_monotonic(Z) on an empty linkage.
         Z = np.zeros((0, 4))

--- a/scipy/cluster/tests/test_vq.py
+++ b/scipy/cluster/tests/test_vq.py
@@ -6,7 +6,7 @@ import sys
 
 import numpy as np
 from numpy.testing import (assert_array_equal, assert_array_almost_equal,
-    TestCase, run_module_suite, assert_raises, assert_allclose, assert_equal,
+    run_module_suite, assert_raises, assert_allclose, assert_equal,
     assert_)
 from numpy.testing.decorators import skipif
 
@@ -71,7 +71,7 @@ CODET2 = np.array([[11.0/3, 8.0/3],
 LABEL1 = np.array([0, 1, 2, 2, 2, 2, 1, 2, 1, 1, 1])
 
 
-class TestWhiten(TestCase):
+class TestWhiten(object):
     def test_whiten(self):
         desired = np.array([[5.08738849, 2.97091878],
                             [3.19909255, 0.69660580],
@@ -111,7 +111,7 @@ class TestWhiten(TestCase):
                 assert_raises(ValueError, whiten, obs)
 
 
-class TestVq(TestCase):
+class TestVq(object):
     def test_py_vq(self):
         initc = np.concatenate(([[X[0]], [X[1]], [X[2]]]))
         for tp in np.array, np.matrix:
@@ -185,7 +185,7 @@ class TestVq(TestCase):
         assert_array_equal(codes0, codes1)
 
 
-class TestKMean(TestCase):
+class TestKMean(object):
     def test_large_features(self):
         # Generate a data set with large values, and run kmeans on it to
         # (regression for 1077).

--- a/scipy/fftpack/tests/test_basic.py
+++ b/scipy/fftpack/tests/test_basic.py
@@ -13,7 +13,7 @@ Run tests if fftpack is not installed:
 
 from numpy.testing import (assert_equal, assert_array_almost_equal,
         assert_array_almost_equal_nulp, assert_raises, run_module_suite,
-        assert_array_less, TestCase, dec)
+        assert_array_less, dec)
 from scipy.fftpack import ifft,fft,fftn,ifftn,rfft,irfft, fft2
 from scipy.fftpack import _fftpack as fftpack
 from scipy.fftpack.basic import _is_safe_size
@@ -198,7 +198,7 @@ class TestSingleFFT(_TestFFTBase):
         pass
 
 
-class TestFloat16FFT(TestCase):
+class TestFloat16FFT(object):
 
     def test_1_argument_real(self):
         x1 = np.array([1, 2, 3, 4], dtype=np.float16)
@@ -462,7 +462,7 @@ class TestIRFFTSingle(_TestIRFFTBase):
         self.ndec = 5
 
 
-class Testfft2(TestCase):
+class Testfft2(object):
     def setUp(self):
         np.random.seed(1234)
 
@@ -480,7 +480,7 @@ class Testfft2(TestCase):
         assert_raises(ValueError, fft2, [[1,1],[2,2]], (4, -3))
 
 
-class TestFftnSingle(TestCase):
+class TestFftnSingle(object):
     def setUp(self):
         np.random.seed(1234)
 
@@ -539,7 +539,7 @@ class TestFftnSingle(TestCase):
             assert_array_almost_equal_nulp(y1, y2, 2e6)
 
 
-class TestFftn(TestCase):
+class TestFftn(object):
     def setUp(self):
         np.random.seed(1234)
 
@@ -736,7 +736,7 @@ class TestIfftnSingle(_TestIfftn):
     maxnlp = 3500
 
 
-class TestLongDoubleFailure(TestCase):
+class TestLongDoubleFailure(object):
     def setUp(self):
         np.random.seed(1234)
 

--- a/scipy/fftpack/tests/test_basic.py
+++ b/scipy/fftpack/tests/test_basic.py
@@ -127,7 +127,7 @@ def direct_irdft(x):
     return direct_idft(x1).real
 
 
-class _TestFFTBase(TestCase):
+class _TestFFTBase(object):
     def setUp(self):
         self.cdt = None
         self.rdt = None
@@ -217,7 +217,7 @@ class TestFloat16FFT(TestCase):
         assert_array_almost_equal(y[1], direct_dft(x2.astype(np.float32)))
 
 
-class _TestIFFTBase(TestCase):
+class _TestIFFTBase(object):
     def setUp(self):
         np.random.seed(1234)
 
@@ -311,7 +311,7 @@ class TestSingleIFFT(_TestIFFTBase):
         self.rdt = np.float32
 
 
-class _TestRFFTBase(TestCase):
+class _TestRFFTBase(object):
     def setUp(self):
         np.random.seed(1234)
 
@@ -378,7 +378,7 @@ class TestRFFTSingle(_TestRFFTBase):
         self.rdt = np.float32
 
 
-class _TestIRFFTBase(TestCase):
+class _TestIRFFTBase(object):
     def setUp(self):
         np.random.seed(1234)
 
@@ -696,7 +696,7 @@ class TestFftn(TestCase):
         assert_raises(ValueError, fftn, [[1,1],[2,2]], (4, -3))
 
 
-class _TestIfftn(TestCase):
+class _TestIfftn(object):
     dtype = None
     cdtype = None
 

--- a/scipy/fftpack/tests/test_helper.py
+++ b/scipy/fftpack/tests/test_helper.py
@@ -11,7 +11,7 @@ Run tests if fftpack is not installed:
   python tests/test_helper.py [<level>]
 """
 
-from numpy.testing import (TestCase, assert_array_almost_equal,
+from numpy.testing import (assert_array_almost_equal,
                            run_module_suite, assert_equal, assert_)
 from scipy.fftpack import fftshift,ifftshift,fftfreq,rfftfreq
 from scipy.fftpack.helper import next_fast_len
@@ -19,7 +19,7 @@ from scipy.fftpack.helper import next_fast_len
 from numpy import pi, random
 
 
-class TestFFTShift(TestCase):
+class TestFFTShift(object):
 
     def test_definition(self):
         x = [0,1,2,3,4,-4,-3,-2,-1]
@@ -37,7 +37,7 @@ class TestFFTShift(TestCase):
             assert_array_almost_equal(ifftshift(fftshift(x)),x)
 
 
-class TestFFTFreq(TestCase):
+class TestFFTFreq(object):
 
     def test_definition(self):
         x = [0,1,2,3,4,-4,-3,-2,-1]
@@ -48,7 +48,7 @@ class TestFFTFreq(TestCase):
         assert_array_almost_equal(10*pi*fftfreq(10,pi),x)
 
 
-class TestRFFTFreq(TestCase):
+class TestRFFTFreq(object):
 
     def test_definition(self):
         x = [0,1,1,2,2,3,3,4,4]
@@ -59,7 +59,7 @@ class TestRFFTFreq(TestCase):
         assert_array_almost_equal(10*pi*rfftfreq(10,pi),x)
 
 
-class TestNextOptLen(TestCase):
+class TestNextOptLen(object):
 
     def test_next_opt_len(self):
         random.seed(1234)

--- a/scipy/fftpack/tests/test_import.py
+++ b/scipy/fftpack/tests/test_import.py
@@ -15,10 +15,10 @@ if sys.version_info >= (3, 4):
     from pathlib import Path
     import re
     import tokenize
-    from numpy.testing import TestCase, assert_, run_module_suite
+    from numpy.testing import assert_, run_module_suite
     import scipy
 
-    class TestFFTPackImport(TestCase):
+    class TestFFTPackImport(object):
         def test_fftpack_import(self):
             base = Path(scipy.__file__).parent
             regexp = r"\s*from.+\.fftpack import .*\n"

--- a/scipy/fftpack/tests/test_pseudo_diffs.py
+++ b/scipy/fftpack/tests/test_pseudo_diffs.py
@@ -11,7 +11,7 @@ Run tests if fftpack is not installed:
   python tests/test_pseudo_diffs.py [<level>]
 """
 
-from numpy.testing import (TestCase, assert_equal, assert_almost_equal,
+from numpy.testing import (assert_equal, assert_almost_equal,
                            assert_array_almost_equal, run_module_suite)
 from scipy.fftpack import (diff, fft, ifft, tilbert, itilbert, hilbert,
                            ihilbert, shift, fftfreq, cs_diff, sc_diff,
@@ -81,7 +81,7 @@ def direct_shift(x,a,period=None):
     return ifft(fft(x)*exp(k*a)).real
 
 
-class TestDiff(TestCase):
+class TestDiff(object):
 
     def test_definition(self):
         for n in [16,17,64,127,32]:
@@ -190,7 +190,7 @@ class TestDiff(TestCase):
                 assert_array_almost_equal(diff(diff(f,-k),k),f)
 
 
-class TestTilbert(TestCase):
+class TestTilbert(object):
 
     def test_definition(self):
         for h in [0.1,0.5,1,5.5,10]:
@@ -224,7 +224,7 @@ class TestTilbert(TestCase):
                 assert_array_almost_equal(tilbert(itilbert(f,h),h),f)
 
 
-class TestITilbert(TestCase):
+class TestITilbert(object):
 
     def test_definition(self):
         for h in [0.1,0.5,1,5.5,10]:
@@ -239,7 +239,7 @@ class TestITilbert(TestCase):
                                           direct_itilbert(sin(2*x),h))
 
 
-class TestHilbert(TestCase):
+class TestHilbert(object):
 
     def test_definition(self):
         for n in [16,17,64,127]:
@@ -281,7 +281,7 @@ class TestHilbert(TestCase):
             assert_array_almost_equal(hilbert(ihilbert(f)),f)
 
 
-class TestIHilbert(TestCase):
+class TestIHilbert(object):
 
     def test_definition(self):
         for n in [16,17,64,127]:
@@ -303,7 +303,7 @@ class TestIHilbert(TestCase):
             assert_array_almost_equal(y,y2)
 
 
-class TestShift(TestCase):
+class TestShift(object):
 
     def test_definition(self):
         for n in [18,17,64,127,32,2048,256]:

--- a/scipy/fftpack/tests/test_real_transforms.py
+++ b/scipy/fftpack/tests/test_real_transforms.py
@@ -80,7 +80,7 @@ class TestComplex(TestCase):
         assert_array_almost_equal(x, y)
 
 
-class _TestDCTBase(TestCase):
+class _TestDCTBase(object):
     def setUp(self):
         self.rdt = None
         self.dec = 14
@@ -202,7 +202,7 @@ class TestDCTIIIInt(_TestDCTIIIBase):
         self.type = 3
 
 
-class _TestIDCTBase(TestCase):
+class _TestIDCTBase(object):
     def setUp(self):
         self.rdt = None
         self.dec = 14
@@ -288,7 +288,7 @@ class TestIDCTIIIInt(_TestIDCTBase):
         self.type = 3
 
 
-class _TestDSTBase(TestCase):
+class _TestDSTBase(object):
     def setUp(self):
         self.rdt = None  # dtype
         self.dec = None  # number of decimals to match
@@ -370,7 +370,7 @@ class TestDSTIIIInt(_TestDSTBase):
         self.type = 3
 
 
-class _TestIDSTBase(TestCase):
+class _TestIDSTBase(object):
     def setUp(self):
         self.rdt = None
         self.dec = None

--- a/scipy/fftpack/tests/test_real_transforms.py
+++ b/scipy/fftpack/tests/test_real_transforms.py
@@ -3,7 +3,7 @@ from __future__ import division, print_function, absolute_import
 from os.path import join, dirname
 
 import numpy as np
-from numpy.testing import assert_array_almost_equal, assert_equal, TestCase
+from numpy.testing import assert_array_almost_equal, assert_equal
 
 from scipy.fftpack.realtransforms import dct, idct, dst, idst
 
@@ -48,7 +48,7 @@ def fftw_dst_ref(type, size, dt):
     return x, y, dt
 
 
-class TestComplex(TestCase):
+class TestComplex(object):
     def test_dct_complex64(self):
         y = dct(1j*np.arange(5, dtype=np.complex64))
         x = 1j*dct(np.arange(5))

--- a/scipy/integrate/tests/test_integrate.py
+++ b/scipy/integrate/tests/test_integrate.py
@@ -11,7 +11,7 @@ from numpy import (arange, zeros, array, dot, sqrt, cos, sin, eye, pi, exp,
 from scipy._lib.six import xrange
 
 from numpy.testing import (
-    assert_, TestCase, run_module_suite, assert_array_almost_equal,
+    assert_, run_module_suite, assert_array_almost_equal,
     assert_raises, assert_allclose, assert_array_equal, assert_equal)
 from scipy.integrate import odeint, ode, complex_ode
 
@@ -20,7 +20,7 @@ from scipy.integrate import odeint, ode, complex_ode
 #------------------------------------------------------------------------------
 
 
-class TestOdeint(TestCase):
+class TestOdeint(object):
     # Check integrate.odeint
     def _do_problem(self, problem):
         t = arange(0.0, problem.stop_t, 0.05)
@@ -35,7 +35,7 @@ class TestOdeint(TestCase):
             self._do_problem(problem)
 
 
-class TestODEClass(TestCase):
+class TestODEClass(object):
 
     ode_class = None   # Set in subclass.
 
@@ -211,7 +211,7 @@ class TestComplexOde(TestODEClass):
             self._do_problem(problem, 'dop853')
 
 
-class TestSolout(TestCase):
+class TestSolout(object):
     # Check integrate.ode correctly handles solout for dopri5 and dop853
     def _run_solout_test(self, integrator):
         # Check correct usage of solout
@@ -301,7 +301,7 @@ class TestSolout(TestCase):
             self._run_solout_break_test(integrator)
 
 
-class TestComplexSolout(TestCase):
+class TestComplexSolout(object):
     # Check integrate.ode correctly handles solout for dopri5 and dop853
     def _run_solout_test(self, integrator):
         # Check correct usage of solout
@@ -555,7 +555,6 @@ def jacv(t, x, omega):
 class ODECheckParameterUse(object):
     """Call an ode-class solver with several cases of parameter use."""
 
-    # This class is intentionally not a TestCase subclass.
     # solver_name must be set before tests can be run with this class.
 
     # Set these in subclasses.
@@ -610,27 +609,27 @@ class ODECheckParameterUse(object):
         self._check_solver(solver)
 
 
-class DOPRI5CheckParameterUse(ODECheckParameterUse, TestCase):
+class TestDOPRI5CheckParameterUse(ODECheckParameterUse):
     solver_name = 'dopri5'
     solver_uses_jac = False
 
 
-class DOP853CheckParameterUse(ODECheckParameterUse, TestCase):
+class TestDOP853CheckParameterUse(ODECheckParameterUse):
     solver_name = 'dop853'
     solver_uses_jac = False
 
 
-class VODECheckParameterUse(ODECheckParameterUse, TestCase):
+class TestVODECheckParameterUse(ODECheckParameterUse):
     solver_name = 'vode'
     solver_uses_jac = True
 
 
-class ZVODECheckParameterUse(ODECheckParameterUse, TestCase):
+class TestZVODECheckParameterUse(ODECheckParameterUse):
     solver_name = 'zvode'
     solver_uses_jac = True
 
 
-class LSODACheckParameterUse(ODECheckParameterUse, TestCase):
+class TestLSODACheckParameterUse(ODECheckParameterUse):
     solver_name = 'lsoda'
     solver_uses_jac = True
 

--- a/scipy/integrate/tests/test_quadpack.py
+++ b/scipy/integrate/tests/test_quadpack.py
@@ -4,7 +4,7 @@ import sys
 import math
 import numpy as np
 from numpy import sqrt, cos, sin, arctan, exp, log, pi, Inf
-from numpy.testing import (assert_, TestCase, run_module_suite, dec,
+from numpy.testing import (assert_, run_module_suite, dec,
         assert_allclose, assert_array_less, assert_almost_equal, assert_raises)
 from scipy.integrate import quad, dblquad, tplquad, nquad
 from scipy._lib.six import xrange
@@ -24,7 +24,7 @@ def assert_quad(value_and_err, tabled_value, errTol=1.5e-8):
         assert_array_less(err, errTol)
 
 
-class TestCtypesQuad(TestCase):
+class TestCtypesQuad(object):
     def setUp(self):
         if sys.platform == 'win32':
             if sys.version_info < (3, 5):
@@ -118,7 +118,7 @@ class TestCtypesQuad(TestCase):
                 assert_raises(ValueError, quad, func, 0, pi)
 
 
-class TestMultivariateCtypesQuad(TestCase):
+class TestMultivariateCtypesQuad(object):
     def setUp(self):
         self.lib = ctypes.CDLL(clib_test.__file__)
         restype = ctypes.c_double
@@ -162,7 +162,7 @@ class TestMultivariateCtypesQuad(TestCase):
         assert_(fast < 0.5*slow, (fast, slow))
 
 
-class TestQuad(TestCase):
+class TestQuad(object):
     def test_typical(self):
         # 1) Typical function with two extra arguments:
         def myfunc(x, n, z):       # Bessel function integrand
@@ -271,7 +271,7 @@ class TestQuad(TestCase):
                      2*8/3.0 * (b**4.0 - a**4.0))
 
 
-class TestNQuad(TestCase):
+class TestNQuad(object):
     def test_fixed_limits(self):
         def func1(x0, x1, x2, x3):
             val = (x0**2 + x1*x2 - x3**3 + np.sin(x0) +

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -3,7 +3,7 @@ from __future__ import division, print_function, absolute_import
 import warnings
 import numpy as np
 from numpy import cos, sin, pi
-from numpy.testing import TestCase, run_module_suite, assert_equal, \
+from numpy.testing import run_module_suite, assert_equal, \
     assert_almost_equal, assert_allclose, assert_
 
 from scipy.integrate import (quadrature, romberg, romb, newton_cotes,
@@ -29,7 +29,7 @@ class TestFixedQuad(object):
         assert_allclose(got, expected, rtol=1e-12)
 
 
-class TestQuadrature(TestCase):
+class TestQuadrature(object):
     def quad(self, x, a, b, args):
         raise NotImplementedError
 
@@ -158,7 +158,7 @@ class TestQuadrature(TestCase):
         assert_equal(simps(y, x=x, even='last'), 14)
 
 
-class TestCumtrapz(TestCase):
+class TestCumtrapz(object):
     def test_1d(self):
         x = np.linspace(-2, 2, num=5)
         y = x

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -494,7 +494,7 @@ class TestInterop(object):
     #
     # Test that FITPACK-based spl* functions can deal with BSpline objects
     #
-    def __init__(self):
+    def setup(self):
         xx = np.linspace(0, 4.*np.pi, 41)
         yy = np.cos(xx)
         b = make_interp_spline(xx, yy)

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -3,7 +3,7 @@ from __future__ import division, absolute_import, print_function
 import warnings
 
 import numpy as np
-from numpy.testing import (run_module_suite, TestCase, assert_equal,
+from numpy.testing import (run_module_suite, assert_equal,
         assert_allclose, assert_raises, assert_)
 from numpy.testing.decorators import knownfailureif
 
@@ -16,7 +16,7 @@ from scipy.interpolate._bsplines import _not_a_knot, _augknt
 import scipy.interpolate._fitpack_impl as _impl
 
 
-class TestBSpline(TestCase):
+class TestBSpline(object):
 
     def test_ctor(self):
         # knots should be an ordered 1D array of finite real numbers
@@ -687,7 +687,7 @@ class TestInterop(object):
         assert_(isinstance(bn2, BSpline))
         assert_(isinstance(tck_n2, tuple))   # back-compat: tck in, tck out
 
-class TestInterp(TestCase):
+class TestInterp(object):
     #
     # Test basic ways of constructing interpolating splines.
     #
@@ -987,7 +987,7 @@ def make_lsq_full_matrix(x, y, t, k=3):
     return c, (A, Y)
 
 
-class TestLSQ(TestCase):
+class TestLSQ(object):
     #
     # Test make_lsq_spline
     #

--- a/scipy/interpolate/tests/test_fitpack.py
+++ b/scipy/interpolate/tests/test_fitpack.py
@@ -297,7 +297,7 @@ class TestSplev(object):
 
 
 class TestSplder(object):
-    def __init__(self):
+    def setup(self):
         # non-uniform grid, just to make it sure
         x = np.linspace(0, 1, 100)**3
         y = np.sin(20 * x)

--- a/scipy/interpolate/tests/test_fitpack.py
+++ b/scipy/interpolate/tests/test_fitpack.py
@@ -4,7 +4,7 @@ import os
 
 import numpy as np
 from numpy.testing import (assert_equal, assert_allclose, assert_,
-    TestCase, assert_raises, run_module_suite, assert_almost_equal,
+    assert_raises, run_module_suite, assert_almost_equal,
     assert_raises, assert_array_almost_equal)
 from numpy import array, asarray, pi, sin, cos, arange, dot, ravel, sqrt, round
 from scipy import interpolate
@@ -65,7 +65,7 @@ def put(*a):
         sys.stderr.write("".join(map(str, a)) + "\n")
 
 
-class TestSmokeTests(TestCase):
+class TestSmokeTests(object):
     """
     Smoke tests (with a few asserts) for fitpack routines -- mostly
     check that they are runnable
@@ -258,7 +258,7 @@ class TestSmokeTests(TestCase):
         self.check_5()
 
 
-class TestSplev(TestCase):
+class TestSplev(object):
     def test_1d_shape(self):
         x = [1,2,3,4,5]
         y = [4,5,6,7,8]

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -3,7 +3,7 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 from numpy.testing import (assert_equal, assert_almost_equal, assert_array_equal,
-        assert_array_almost_equal, assert_allclose, assert_raises, TestCase,
+        assert_array_almost_equal, assert_allclose, assert_raises,
         run_module_suite)
 from scipy._lib._numpy_compat import suppress_warnings
 from numpy import array, diff, linspace, meshgrid, ones, pi, shape
@@ -15,7 +15,7 @@ from scipy.interpolate.fitpack2 import (UnivariateSpline,
         RectSphereBivariateSpline)
 
 
-class TestUnivariateSpline(TestCase):
+class TestUnivariateSpline(object):
     def test_linear_constant(self):
         x = [1,2,3]
         y = [3,3,3]
@@ -184,7 +184,7 @@ class TestUnivariateSpline(TestCase):
                 **dict(x=x, y=y, t=t, w=w, check_finite=True))
 
 
-class TestLSQBivariateSpline(TestCase):
+class TestLSQBivariateSpline(object):
     # NOTE: The systems in this test class are rank-deficient
     def test_linear_constant(self):
         x = [1,1,1,2,2,2,3,3,3]
@@ -262,7 +262,7 @@ class TestLSQBivariateSpline(TestCase):
         assert_array_equal(lut([], [], grid=False), np.zeros((0,)))
 
 
-class TestSmoothBivariateSpline(TestCase):
+class TestSmoothBivariateSpline(object):
     def test_linear_constant(self):
         x = [1,1,1,2,2,2,3,3,3]
         y = [1,2,3,1,2,3,1,2,3]
@@ -326,7 +326,7 @@ class TestSmoothBivariateSpline(TestCase):
         assert_almost_equal(res1, res2)
 
 
-class TestLSQSphereBivariateSpline(TestCase):
+class TestLSQSphereBivariateSpline(object):
     def setUp(self):
         # define the input data and coordinates
         ntheta, nphi = 70, 90
@@ -355,7 +355,7 @@ class TestLSQSphereBivariateSpline(TestCase):
         assert_array_almost_equal(self.lut_lsq([], [], grid=False), np.zeros((0,)))
 
 
-class TestSmoothSphereBivariateSpline(TestCase):
+class TestSmoothSphereBivariateSpline(object):
     def setUp(self):
         theta = array([.25*pi, .25*pi, .25*pi, .5*pi, .5*pi, .5*pi, .75*pi,
                        .75*pi, .75*pi])
@@ -374,7 +374,7 @@ class TestSmoothSphereBivariateSpline(TestCase):
         assert_array_almost_equal(self.lut([], [], grid=False), np.zeros((0,)))
 
 
-class TestRectBivariateSpline(TestCase):
+class TestRectBivariateSpline(object):
     def test_defaults(self):
         x = array([1,2,3,4,5])
         y = array([1,2,3,4,5])
@@ -430,7 +430,7 @@ class TestRectBivariateSpline(TestCase):
         assert_allclose(lut(x, y), lut(x[:,None], y[None,:], grid=False))
 
 
-class TestRectSphereBivariateSpline(TestCase):
+class TestRectSphereBivariateSpline(object):
     def test_defaults(self):
         y = linspace(0.01, 2*pi-0.01, 7)
         x = linspace(0.01, pi-0.01, 7)

--- a/scipy/interpolate/tests/test_gil.py
+++ b/scipy/interpolate/tests/test_gil.py
@@ -5,13 +5,13 @@ import threading
 import time
 
 import numpy as np
-from numpy.testing import TestCase, assert_equal, run_module_suite
+from numpy.testing import assert_equal, run_module_suite
 from numpy.testing.decorators import slow
 import scipy.interpolate
 from scipy._lib._testutils import knownfailure_overridable
 
 
-class TestGIL(TestCase):
+class TestGIL(object):
     """Check if the GIL is properly released by scipy.interpolate functions."""
 
     def setUp(self):

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -5,7 +5,7 @@ import warnings
 
 from numpy.testing import (assert_, assert_equal, assert_almost_equal,
         assert_array_almost_equal, assert_raises, assert_array_equal,
-        dec, TestCase, run_module_suite, assert_allclose)
+        dec, run_module_suite, assert_allclose)
 from numpy import mgrid, pi, sin, ogrid, poly1d, linspace
 import numpy as np
 
@@ -27,7 +27,7 @@ from scipy.integrate import nquad
 from scipy.special import binom
 
 
-class TestInterp2D(TestCase):
+class TestInterp2D(object):
     def test_interp2d(self):
         y, x = mgrid[0:2:20j, 0:pi:21j]
         z = sin(x+0.5*y)
@@ -655,7 +655,7 @@ class TestInterp1D(object):
                 assert_equal(out.shape, outn.shape)
 
 
-class TestLagrange(TestCase):
+class TestLagrange(object):
 
     def test_lagrange(self):
         p = poly1d([5,2,1,4,3])
@@ -665,7 +665,7 @@ class TestLagrange(TestCase):
         assert_array_almost_equal(p.coeffs,pl.coeffs)
 
 
-class TestAkima1DInterpolator(TestCase):
+class TestAkima1DInterpolator(object):
     def test_eval(self):
         x = np.arange(0., 11.)
         y = np.array([0., 2., 1., 3., 2., 6., 5.5, 5.5, 2.7, 5.1, 3.])
@@ -744,7 +744,7 @@ class TestAkima1DInterpolator(TestCase):
             raise
 
 
-class TestPPolyCommon(TestCase):
+class TestPPolyCommon(object):
     # test basic functionality for PPoly and BPoly
     def test_sort_check(self):
         c = np.array([[1, 4], [2, 5], [3, 6]])
@@ -887,7 +887,7 @@ class TestPPolyCommon(TestCase):
                 assert_raises(ValueError, cls, **dict(c=c, x=x, axis=axis))
 
 
-class TestPolySubclassing(TestCase):
+class TestPolySubclassing(object):
     class P(PPoly):
         pass
 
@@ -934,7 +934,7 @@ class TestPolySubclassing(TestCase):
         assert_equal(bp.__class__, self.B)
 
 
-class TestPPoly(TestCase):
+class TestPPoly(object):
     def test_simple(self):
         c = np.array([[1, 4], [2, 5], [3, 6]])
         x = np.array([0, 0.5, 1])
@@ -1395,7 +1395,7 @@ class TestPPoly(TestCase):
                 assert_allclose(pp.roots(), [1, -1])
 
 
-class TestBPoly(TestCase):
+class TestBPoly(object):
     def test_simple(self):
         x = [0, 1]
         c = [[3]]
@@ -1525,7 +1525,7 @@ class TestBPoly(TestCase):
                 assert_(not np.isnan(bp_d([-0.1, 2.1])).any())
 
 
-class TestBPolyCalculus(TestCase):
+class TestBPolyCalculus(object):
     def test_derivative(self):
         x = [0, 1, 3]
         c = [[3, 0], [0, 0], [0, 2]]
@@ -1680,7 +1680,7 @@ class TestBPolyCalculus(TestCase):
                         atol=1e-12, rtol=1e-12)
 
 
-class TestPolyConversions(TestCase):
+class TestPolyConversions(object):
     def test_bp_from_pp(self):
         x = [0, 1, 3]
         c = [[3, 2], [1, 8], [4, 3]]
@@ -1717,7 +1717,7 @@ class TestPolyConversions(TestCase):
         assert_allclose(bp(xp), bp1(xp))
 
 
-class TestBPolyFromDerivatives(TestCase):
+class TestBPolyFromDerivatives(object):
     def test_make_poly_1(self):
         c1 = BPoly._construct_from_derivatives(0, 1, [2], [3])
         assert_allclose(c1, [2., 3.])
@@ -1880,7 +1880,7 @@ class TestBPolyFromDerivatives(TestCase):
         orders = 1
 
 
-class TestPpform(TestCase):
+class TestPpform(object):
     def test_shape(self):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
@@ -2279,7 +2279,7 @@ def _ppoly4d_eval(c, xs, xnew, ynew, znew, unew, nu=None):
     return out
 
 
-class TestRegularGridInterpolator(TestCase):
+class TestRegularGridInterpolator(object):
     def _get_sample_4d(self):
         # create a 4d grid of 3 points in each dimension
         points = [(0., .5, 1.)] * 4
@@ -2524,7 +2524,7 @@ class MyValue(object):
         raise RuntimeError("No array representation")
 
 
-class TestInterpN(TestCase):
+class TestInterpN(object):
     def _sample_2d_data(self):
         x = np.arange(1, 6)
         x = np.array([.5, 2., 3., 4., 5.5])

--- a/scipy/interpolate/tests/test_interpolate_wrapper.py
+++ b/scipy/interpolate/tests/test_interpolate_wrapper.py
@@ -6,7 +6,7 @@ import warnings
 
 from numpy import arange, allclose, ones, isnan
 import numpy as np
-from numpy.testing import run_module_suite
+from numpy.testing import (run_module_suite, assert_, assert_allclose)
 
 # functionality to be tested
 from scipy.interpolate.interpolate_wrapper import (linear, logarithmic,
@@ -17,7 +17,7 @@ class Test(object):
 
     def assertAllclose(self, x, y, rtol=1.0e-5):
         for i, xi in enumerate(x):
-            self.assertTrue(allclose(xi, y[i], rtol) or (isnan(xi) and isnan(y[i])))
+            assert_(allclose(xi, y[i], rtol) or (isnan(xi) and isnan(y[i])))
 
     def test_nearest(self):
         N = 5
@@ -25,8 +25,8 @@ class Test(object):
         y = arange(N)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
-            self.assertAllclose(y, nearest(x, y, x+.1))
-            self.assertAllclose(y, nearest(x, y, x-.1))
+            assert_allclose(y, nearest(x, y, x+.1))
+            assert_allclose(y, nearest(x, y, x-.1))
 
     def test_linear(self):
         N = 3000.
@@ -37,7 +37,7 @@ class Test(object):
             warnings.simplefilter("ignore", DeprecationWarning)
             new_y = linear(x, y, new_x)
 
-        self.assertAllclose(new_y[:5], [0.5, 1.5, 2.5, 3.5, 4.5])
+        assert_allclose(new_y[:5], [0.5, 1.5, 2.5, 3.5, 4.5])
 
     def test_block_average_above(self):
         N = 3000
@@ -48,7 +48,7 @@ class Test(object):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             new_y = block_average_above(x, y, new_x)
-        self.assertAllclose(new_y[:5], [0.0, 0.5, 2.5, 4.5, 6.5])
+        assert_allclose(new_y[:5], [0.0, 0.5, 2.5, 4.5, 6.5])
 
     def test_linear2(self):
         N = 3000
@@ -58,7 +58,7 @@ class Test(object):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             new_y = linear(x, y, new_x)
-        self.assertAllclose(new_y[:5,:5],
+        assert_allclose(new_y[:5,:5],
                             [[0.5, 1.5, 2.5, 3.5, 4.5],
                              [0.5, 1.5, 2.5, 3.5, 4.5],
                              [0.5, 1.5, 2.5, 3.5, 4.5],
@@ -74,7 +74,7 @@ class Test(object):
             warnings.simplefilter("ignore", DeprecationWarning)
             new_y = logarithmic(x, y, new_x)
         correct_y = [np.NaN, 1.41421356, 2.44948974, 3.46410162, 4.47213595]
-        self.assertAllclose(new_y[:5], correct_y)
+        assert_allclose(new_y[:5], correct_y)
 
     def runTest(self):
         test_list = [name for name in dir(self) if name.find('test_') == 0]

--- a/scipy/interpolate/tests/test_interpolate_wrapper.py
+++ b/scipy/interpolate/tests/test_interpolate_wrapper.py
@@ -2,19 +2,18 @@
 """
 from __future__ import division, print_function, absolute_import
 
-# Unit Test
-import unittest
 import warnings
 
 from numpy import arange, allclose, ones, isnan
 import numpy as np
+from numpy.testing import run_module_suite
 
 # functionality to be tested
 from scipy.interpolate.interpolate_wrapper import (linear, logarithmic,
     block_average_above, nearest)
 
 
-class Test(unittest.TestCase):
+class Test(object):
 
     def assertAllclose(self, x, y, rtol=1.0e-5):
         for i, xi in enumerate(x):
@@ -82,5 +81,5 @@ class Test(unittest.TestCase):
         for test_name in test_list:
             exec("self.%s()" % test_name)
 
-if __name__ == '__main__':
-    unittest.main()
+if __name__ == "__main__":
+    run_module_suite()

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from numpy.testing import (
     assert_almost_equal, assert_array_equal, assert_array_almost_equal,
-    TestCase, run_module_suite, assert_allclose, assert_equal, assert_,
+    run_module_suite, assert_allclose, assert_equal, assert_,
     assert_raises)
 
 from scipy.interpolate import (
@@ -143,7 +143,7 @@ def test_complex():
         yield _check_complex, ip
 
 
-class CheckKrogh(TestCase):
+class TestKrogh(object):
     def setUp(self):
         self.true_poly = np.poly1d([-2,3,1,5,-4])
         self.test_xs = np.linspace(-1,1,100)
@@ -281,7 +281,7 @@ class CheckKrogh(TestCase):
         assert_allclose(cmplx, cmplx2, atol=1e-15)
 
 
-class CheckTaylor(TestCase):
+class TestTaylor(object):
     def test_exponential(self):
         degree = 5
         p = approximate_taylor_polynomial(np.exp, 0, degree, 1, 15)
@@ -291,7 +291,7 @@ class CheckTaylor(TestCase):
         assert_almost_equal(p(0),0)
 
 
-class CheckBarycentric(TestCase):
+class TestBarycentric(object):
     def setUp(self):
         self.true_poly = np.poly1d([-2,3,1,5,-4])
         self.test_xs = np.linspace(-1,1,100)
@@ -350,7 +350,7 @@ class CheckBarycentric(TestCase):
         assert_almost_equal(P(self.test_xs),barycentric_interpolate(self.xs,self.ys,self.test_xs))
 
 
-class TestPCHIP(TestCase):
+class TestPCHIP(object):
     def _make_random(self, npts=20):
         np.random.seed(1234)
         xi = np.sort(np.random.random(npts))

--- a/scipy/interpolate/tests/test_regression.py
+++ b/scipy/interpolate/tests/test_regression.py
@@ -2,10 +2,10 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 import scipy.interpolate as interp
-from numpy.testing import assert_almost_equal, TestCase
+from numpy.testing import assert_almost_equal
 
 
-class TestRegression(TestCase):
+class TestRegression(object):
     def test_spalde_scalar_input(self):
         """Ticket #629"""
         x = np.linspace(0,10)

--- a/scipy/io/arff/tests/test_arffread.py
+++ b/scipy/io/arff/tests/test_arffread.py
@@ -12,7 +12,7 @@ else:
 
 import numpy as np
 
-from numpy.testing import (TestCase, assert_array_almost_equal,
+from numpy.testing import (assert_array_almost_equal,
                            assert_array_equal, assert_equal, assert_,
                            assert_raises, dec, run_module_suite)
 
@@ -43,7 +43,7 @@ expect_missing['yop'] = expect_missing_raw[:, 0]
 expect_missing['yap'] = expect_missing_raw[:, 1]
 
 
-class DataTest(TestCase):
+class TestData(object):
     def test1(self):
         # Parsing trivial file with nothing.
         self._test(test4)
@@ -75,14 +75,14 @@ class DataTest(TestCase):
         assert_(repr(meta1) == repr(meta2))
 
 
-class MissingDataTest(TestCase):
+class TestMissingData(object):
     def test_missing(self):
         data, meta = loadarff(missing)
         for i in ['yop', 'yap']:
             assert_array_almost_equal(data[i], expect_missing[i])
 
 
-class NoDataTest(TestCase):
+class TestNoData(object):
     def test_nodata(self):
         # The file nodata.arff has no data in the @DATA section.
         # Reading it should result in an array with length 0.
@@ -97,7 +97,7 @@ class NoDataTest(TestCase):
         assert_equal(data.size, 0)
 
 
-class HeaderTest(TestCase):
+class TestHeader(object):
     def test_type_parsing(self):
         # Test parsing type of attribute from their value.
         ofile = open(test2)
@@ -177,7 +177,7 @@ class HeaderTest(TestCase):
         assert_(attrs[1][1] == 'DATE "yy-MM-dd HH:mm:ss z"')
 
 
-class DateAttributeTest(TestCase):
+class TestDateAttribute(object):
     def setUp(self):
         self.data, self.meta = loadarff(test7)
 

--- a/scipy/io/harwell_boeing/tests/test_fortran_format.py
+++ b/scipy/io/harwell_boeing/tests/test_fortran_format.py
@@ -2,14 +2,14 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 
-from numpy.testing import TestCase, assert_equal, assert_raises
+from numpy.testing import assert_equal, assert_raises
 
 from scipy.io.harwell_boeing._fortran_format_parser import \
         FortranFormatParser, IntFormat, ExpFormat, BadFortranFormat, \
         number_digits
 
 
-class TestFortranFormatParser(TestCase):
+class TestFortranFormatParser(object):
     def setUp(self):
         self.parser = FortranFormatParser()
 
@@ -44,7 +44,7 @@ class TestFortranFormatParser(TestCase):
         _test_invalid("(E4.E3)")
 
 
-class TestIntFormat(TestCase):
+class TestIntFormat(object):
     def test_to_fortran(self):
         f = [IntFormat(10), IntFormat(12, 10), IntFormat(12, 10, 3)]
         res = ["(I10)", "(I12.10)", "(3I12.10)"]
@@ -60,7 +60,7 @@ class TestIntFormat(TestCase):
             assert_equal(IntFormat.from_number(i).__dict__, j.__dict__)
 
 
-class TestExpFormat(TestCase):
+class TestExpFormat(object):
     def test_to_fortran(self):
         f = [ExpFormat(10, 5), ExpFormat(12, 10), ExpFormat(12, 10, min=3),
              ExpFormat(10, 5, repeat=3)]

--- a/scipy/io/harwell_boeing/tests/test_hb.py
+++ b/scipy/io/harwell_boeing/tests/test_hb.py
@@ -10,7 +10,7 @@ import tempfile
 
 import numpy as np
 
-from numpy.testing import TestCase, assert_equal, \
+from numpy.testing import assert_equal, \
     assert_array_almost_equal_nulp
 
 from scipy.sparse import coo_matrix, csc_matrix, rand
@@ -52,13 +52,13 @@ def assert_csc_almost_equal(r, l):
     assert_array_almost_equal_nulp(r.data, l.data, 10000)
 
 
-class TestHBReader(TestCase):
+class TestHBReader(object):
     def test_simple(self):
         m = hb_read(StringIO(SIMPLE))
         assert_csc_almost_equal(m, SIMPLE_MATRIX)
 
 
-class TestRBRoundtrip(TestCase):
+class TestRBRoundtrip(object):
     def test_simple(self):
         rm = rand(100, 1000, 0.05).tocsc()
         fd, filename = tempfile.mkstemp(suffix="rb")

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -524,15 +524,15 @@ def test_cell_with_one_thing_in_it():
 def test_writer_properties():
     # Tests getting, setting of properties of matrix writer
     mfw = MatFile5Writer(BytesIO())
-    yield assert_equal, mfw.global_vars, []
+    assert_equal(mfw.global_vars, [])
     mfw.global_vars = ['avar']
-    yield assert_equal, mfw.global_vars, ['avar']
-    yield assert_equal, mfw.unicode_strings, False
+    assert_equal(mfw.global_vars, ['avar'])
+    assert_equal(mfw.unicode_strings, False)
     mfw.unicode_strings = True
-    yield assert_equal, mfw.unicode_strings, True
-    yield assert_equal, mfw.long_field_names, False
+    assert_equal(mfw.unicode_strings, True)
+    assert_equal(mfw.long_field_names, False)
     mfw.long_field_names = True
-    yield assert_equal, mfw.long_field_names, True
+    assert_equal(mfw.long_field_names, True)
 
 
 def test_use_small_element():
@@ -547,12 +547,12 @@ def test_use_small_element():
     sio.truncate(0)
     sio.seek(0)
     wtr.put_variables({'aaaa': arr})
-    yield assert_, w_sz - len(sio.getvalue()) > 4
+    assert_(w_sz - len(sio.getvalue()) > 4)
     # Whereas increasing name size makes less difference
     sio.truncate(0)
     sio.seek(0)
     wtr.put_variables({'aaaaaa': arr})
-    yield assert_, len(sio.getvalue()) - w_sz < 4
+    assert_(len(sio.getvalue()) - w_sz < 4)
 
 
 def test_save_dict():
@@ -615,24 +615,24 @@ def test_compression():
     savemat(stream, {'arr':arr})
     raw_len = len(stream.getvalue())
     vals = loadmat(stream)
-    yield assert_array_equal, vals['arr'], arr
+    assert_array_equal(vals['arr'], arr)
     stream = BytesIO()
     savemat(stream, {'arr':arr}, do_compression=True)
     compressed_len = len(stream.getvalue())
     vals = loadmat(stream)
-    yield assert_array_equal, vals['arr'], arr
-    yield assert_, raw_len > compressed_len
+    assert_array_equal(vals['arr'], arr)
+    assert_(raw_len > compressed_len)
     # Concatenate, test later
     arr2 = arr.copy()
     arr2[0,0] = 1
     stream = BytesIO()
     savemat(stream, {'arr':arr, 'arr2':arr2}, do_compression=False)
     vals = loadmat(stream)
-    yield assert_array_equal, vals['arr2'], arr2
+    assert_array_equal(vals['arr2'], arr2)
     stream = BytesIO()
     savemat(stream, {'arr':arr, 'arr2':arr2}, do_compression=True)
     vals = loadmat(stream)
-    yield assert_array_equal, vals['arr2'], arr2
+    assert_array_equal(vals['arr2'], arr2)
 
 
 def test_single_object():
@@ -656,8 +656,8 @@ def test_skip_variable():
     # Prove that it loads with loadmat
     #
     d = loadmat(filename, struct_as_record=True)
-    yield assert_, 'first' in d
-    yield assert_, 'second' in d
+    assert_('first' in d)
+    assert_('second' in d)
     #
     # Make the factory
     #
@@ -666,7 +666,7 @@ def test_skip_variable():
     # This is where the factory breaks with an error in MatMatrixGetter.to_next
     #
     d = factory.get_variables('second')
-    yield assert_, 'second' in d
+    assert_('second' in d)
     factory.mat_stream.close()
 
 
@@ -787,18 +787,18 @@ def test_recarray():
     savemat(stream, {'arr': arr})
     d = loadmat(stream, struct_as_record=False)
     a20 = d['arr'][0,0]
-    yield assert_equal, a20.f1, 0.5
-    yield assert_equal, a20.f2, 'python'
+    assert_equal(a20.f1, 0.5)
+    assert_equal(a20.f2, 'python')
     d = loadmat(stream, struct_as_record=True)
     a20 = d['arr'][0,0]
-    yield assert_equal, a20['f1'], 0.5
-    yield assert_equal, a20['f2'], 'python'
+    assert_equal(a20['f1'], 0.5)
+    assert_equal(a20['f2'], 'python')
     # structs always come back as object types
-    yield assert_equal, a20.dtype, np.dtype([('f1', 'O'),
-                                             ('f2', 'O')])
+    assert_equal(a20.dtype, np.dtype([('f1', 'O'),
+                                      ('f2', 'O')]))
     a21 = d['arr'].flat[1]
-    yield assert_equal, a21['f1'], 99
-    yield assert_equal, a21['f2'], 'not perl'
+    assert_equal(a21['f1'], 99)
+    assert_equal(a21['f2'], 'not perl')
 
 
 def test_save_object():
@@ -983,13 +983,13 @@ def test_mat_dtype():
     rdr = MatFile5Reader(fp, mat_dtype=False)
     d = rdr.get_variables()
     fp.close()
-    yield assert_equal, d['testmatrix'].dtype.kind, 'u'
+    assert_equal(d['testmatrix'].dtype.kind, 'u')
 
     fp = open(double_eg, 'rb')
     rdr = MatFile5Reader(fp, mat_dtype=True)
     d = rdr.get_variables()
     fp.close()
-    yield assert_equal, d['testmatrix'].dtype.kind, 'f'
+    assert_equal(d['testmatrix'].dtype.kind, 'f')
 
 
 def test_sparse_in_struct():
@@ -999,7 +999,7 @@ def test_sparse_in_struct():
     stream = BytesIO()
     savemat(stream, {'a':st})
     d = loadmat(stream, struct_as_record=True)
-    yield assert_array_equal, d['a'][0,0]['sparsefield'].todense(), np.eye(4)
+    assert_array_equal(d['a'][0,0]['sparsefield'].todense(), np.eye(4))
 
 
 def test_mat_struct_squeeze():

--- a/scipy/io/matlab/tests/test_streams.py
+++ b/scipy/io/matlab/tests/test_streams.py
@@ -33,7 +33,7 @@ cs = None
 fname = None
 
 
-def setup():
+def setup_module():
     val = b'a\x00string'
     global fs, gs, cs, fname
     fd, fname = mkstemp()
@@ -45,7 +45,7 @@ def setup():
     cs = cStringIO(val)
 
 
-def teardown():
+def teardown_module():
     global fname, fs
     fs.close()
     del fs
@@ -66,17 +66,17 @@ def test_tell_seek():
     for s in (fs, gs, cs):
         st = make_stream(s)
         res = st.seek(0)
-        yield assert_equal, res, 0
-        yield assert_equal, st.tell(), 0
+        assert_equal(res, 0)
+        assert_equal(st.tell(), 0)
         res = st.seek(5)
-        yield assert_equal, res, 0
-        yield assert_equal, st.tell(), 5
+        assert_equal(res, 0)
+        assert_equal(st.tell(), 5)
         res = st.seek(2, 1)
-        yield assert_equal, res, 0
-        yield assert_equal, st.tell(), 7
+        assert_equal(res, 0)
+        assert_equal(st.tell(), 7)
         res = st.seek(-2, 2)
-        yield assert_equal, res, 0
-        yield assert_equal, st.tell(), 6
+        assert_equal(res, 0)
+        assert_equal(st.tell(), 6)
 
 
 def test_read():
@@ -85,24 +85,24 @@ def test_read():
         st = make_stream(s)
         st.seek(0)
         res = st.read(-1)
-        yield assert_equal, res, b'a\x00string'
+        assert_equal(res, b'a\x00string')
         st.seek(0)
         res = st.read(4)
-        yield assert_equal, res, b'a\x00st'
+        assert_equal(res, b'a\x00st')
         # read into
         st.seek(0)
         res = _read_into(st, 4)
-        yield assert_equal, res, b'a\x00st'
+        assert_equal(res, b'a\x00st')
         res = _read_into(st, 4)
-        yield assert_equal, res, b'ring'
-        yield assert_raises, IOError, _read_into, st, 2
+        assert_equal(res, b'ring')
+        assert_raises(IOError, _read_into, st, 2)
         # read alloc
         st.seek(0)
         res = _read_string(st, 4)
-        yield assert_equal, res, b'a\x00st'
+        assert_equal(res, b'a\x00st')
         res = _read_string(st, 4)
-        yield assert_equal, res, b'ring'
-        yield assert_raises, IOError, _read_string, st, 2
+        assert_equal(res, b'ring')
+        assert_raises(IOError, _read_string, st, 2)
 
 
 class TestZlibInputStream(object):

--- a/scipy/io/tests/test_mmio.py
+++ b/scipy/io/tests/test_mmio.py
@@ -6,7 +6,7 @@ import shutil
 
 import numpy as np
 from numpy import array, transpose, pi
-from numpy.testing import (TestCase, run_module_suite, assert_equal,
+from numpy.testing import (run_module_suite, assert_equal,
                            assert_array_equal, assert_array_almost_equal,
                            assert_raises)
 
@@ -14,7 +14,7 @@ import scipy.sparse
 from scipy.io.mmio import mminfo, mmread, mmwrite
 
 
-class TestMMIOArray(TestCase):
+class TestMMIOArray(object):
     def setUp(self):
         self.tmpdir = mkdtemp()
         self.fn = os.path.join(self.tmpdir, 'testfile.mtx')
@@ -269,7 +269,7 @@ _over64bit_integer_sparse_example = '''\
 2  2  19223372036854775808
 '''
 
-class TestMMIOReadLargeIntegers(TestCase):
+class TestMMIOReadLargeIntegers(object):
     def setUp(self):
         self.tmpdir = mkdtemp()
         self.fn = os.path.join(self.tmpdir, 'testfile.mtx')
@@ -449,7 +449,7 @@ _symmetric_pattern_example = '''\
 '''
 
 
-class TestMMIOCoordinate(TestCase):
+class TestMMIOCoordinate(object):
     def setUp(self):
         self.tmpdir = mkdtemp()
         self.fn = os.path.join(self.tmpdir, 'testfile.mtx')

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -14,7 +14,7 @@ from numpy import (arange, array, dot, zeros, identity, conjugate, transpose,
 import numpy.linalg as linalg
 from numpy.random import random
 
-from numpy.testing import (TestCase, run_module_suite, assert_raises,
+from numpy.testing import (run_module_suite, assert_raises,
                            assert_equal, assert_almost_equal, assert_,
                            assert_array_almost_equal, assert_allclose,
                            assert_array_equal, dec)
@@ -59,7 +59,7 @@ def _eps_cast(dtyp):
     return np.finfo(dt).eps
 
 
-class TestSolveBanded(TestCase):
+class TestSolveBanded(object):
 
     def test_real(self):
         a = array([[1.0, 20, 0, 0],
@@ -198,7 +198,7 @@ class TestSolveBanded(TestCase):
         assert_array_almost_equal(dot(a, x), b)
 
 
-class TestSolveHBanded(TestCase):
+class TestSolveHBanded(object):
 
     def test_01_upper(self):
         # Solve
@@ -513,7 +513,7 @@ class TestSolveHBanded(TestCase):
         assert_array_almost_equal(x, [0.0, 1.0, 0.0, 0.0])
 
 
-class TestSolve(TestCase):
+class TestSolve(object):
     def setUp(self):
         np.random.seed(1234)
 
@@ -777,7 +777,7 @@ class TestSolve(TestCase):
                             err_msg=err_msg)
 
 
-class TestSolveTriangular(TestCase):
+class TestSolveTriangular(object):
 
     def test_simple(self):
         """
@@ -819,7 +819,7 @@ class TestSolveTriangular(TestCase):
         assert_array_almost_equal(sol, [1, 0])
 
 
-class TestInv(TestCase):
+class TestInv(object):
     def setUp(self):
         np.random.seed(1234)
 
@@ -862,7 +862,7 @@ class TestInv(TestCase):
         assert_array_almost_equal(dot(a, a_inv), [[1, 0], [0, 1]])
 
 
-class TestDet(TestCase):
+class TestDet(object):
     def setUp(self):
         np.random.seed(1234)
 
@@ -909,7 +909,7 @@ def direct_lstsq(a, b, cmplx=0):
     return solve(a1, b1)
 
 
-class TestLstsq(TestCase):
+class TestLstsq(object):
 
     lapack_drivers = ('gelsd', 'gelss', 'gelsy', None)
 
@@ -1246,7 +1246,7 @@ class TestLstsq(TestCase):
                                           err_msg="driver: %s" % lapack_driver)
 
 
-class TestPinv(TestCase):
+class TestPinv(object):
 
     def test_simple_real(self):
         a = array([[1, 2, 3], [4, 5, 6], [7, 8, 10]], dtype=float)
@@ -1296,7 +1296,7 @@ class TestPinv(TestCase):
         assert_array_almost_equal(a_pinv, a_pinv2)
 
 
-class TestPinvSymmetric(TestCase):
+class TestPinvSymmetric(object):
 
     def test_simple_real(self):
         a = array([[1, 2, 3], [4, 5, 6], [7, 8, 10]], dtype=float)
@@ -1462,7 +1462,7 @@ class TestOverwrite(object):
         assert_no_overwrite(pinvh, [(3, 3)])
 
 
-class TestSolveCirculant(TestCase):
+class TestSolveCirculant(object):
 
     def test_basic1(self):
         c = np.array([1, 2, 3, 5])
@@ -1547,7 +1547,7 @@ class TestSolveCirculant(TestCase):
         assert_allclose(x, y)
 
 
-class TestMatrix_Balance(TestCase):
+class TestMatrix_Balance(object):
 
     def test_string_arg(self):
         assert_raises(ValueError, matrix_balance, 'Some string for fail')

--- a/scipy/linalg/tests/test_blas.py
+++ b/scipy/linalg/tests/test_blas.py
@@ -14,7 +14,7 @@ Run tests if scipy is installed:
 import math
 
 import numpy as np
-from numpy.testing import (TestCase, run_module_suite, assert_equal,
+from numpy.testing import (run_module_suite, assert_equal,
     assert_almost_equal, assert_array_almost_equal, assert_raises, assert_,
     assert_allclose)
 
@@ -76,7 +76,7 @@ def test_get_blas_funcs_alias():
     assert f is h
 
 
-class TestCBLAS1Simple(TestCase):
+class TestCBLAS1Simple(object):
 
     def test_axpy(self):
         for p in 'sd':
@@ -91,7 +91,7 @@ class TestCBLAS1Simple(TestCase):
             assert_array_almost_equal(f([1,2j,3],[2,-1,3],a=5),[7,10j-1,18])
 
 
-class TestFBLAS1Simple(TestCase):
+class TestFBLAS1Simple(object):
 
     def test_axpy(self):
         for p in 'sd':
@@ -207,7 +207,7 @@ class TestFBLAS1Simple(TestCase):
     #XXX: need tests for rot,rotm,rotg,rotmg
 
 
-class TestFBLAS2Simple(TestCase):
+class TestFBLAS2Simple(object):
 
     def test_gemv(self):
         for p in 'sd':
@@ -450,7 +450,7 @@ class TestFBLAS2Simple(TestCase):
             assert_raises(Exception, f, 1.0, x, y, a=np.zeros((2,2), 'd', 'F'))
  
 
-class TestFBLAS3Simple(TestCase):
+class TestFBLAS3Simple(object):
 
     def test_gemm(self):
         for p in 'sd':
@@ -476,7 +476,7 @@ def _get_func(func, ps='sdzc'):
         yield f
 
 
-class TestBLAS3Symm(TestCase):
+class TestBLAS3Symm(object):
 
     def setUp(self):
         self.a = np.array([[1., 2.],
@@ -520,7 +520,7 @@ class TestBLAS3Symm(TestCase):
             assert not np.allclose(res, self.t)
 
 
-class TestBLAS3Syrk(TestCase):
+class TestBLAS3Syrk(object):
     def setUp(self):
         self.a = np.array([[1., 0.],
                            [0., -2.],
@@ -556,7 +556,7 @@ class TestBLAS3Syrk(TestCase):
         # if C is supplied, it must have compatible dimensions
 
 
-class TestBLAS3Syr2k(TestCase):
+class TestBLAS3Syr2k(object):
     def setUp(self):
         self.a = np.array([[1., 0.],
                            [0., -2.],
@@ -594,7 +594,7 @@ class TestBLAS3Syr2k(TestCase):
         # if C is supplied, it must have compatible dimensions
 
 
-class TestSyHe(TestCase):
+class TestSyHe(object):
     """Quick and simple tests for (zc)-symm, syrk, syr2k."""
     def setUp(self):
         self.sigma_y = np.array([[0., -1.j],
@@ -633,7 +633,7 @@ class TestSyHe(TestCase):
             assert_array_almost_equal(np.triu(res), 2.*np.diag([1, 1]))
 
 
-class TestTRMM(TestCase):
+class TestTRMM(object):
     """Quick and simple tests for dtrmm."""
     def setUp(self):
         self.a = np.array([[1., 2., ],

--- a/scipy/linalg/tests/test_build.py
+++ b/scipy/linalg/tests/test_build.py
@@ -4,7 +4,7 @@ from subprocess import call, PIPE, Popen
 import sys
 import re
 
-from numpy.testing import TestCase, dec
+from numpy.testing import dec
 from numpy.compat import asbytes
 
 from scipy.linalg import _flapack as flapack
@@ -43,7 +43,7 @@ class FindDependenciesLdd:
         return founds
 
 
-class TestF77Mismatch(TestCase):
+class TestF77Mismatch(object):
     @dec.skipif(not(sys.platform[:5] == 'linux'),
                 "Skipping fortran compiler mismatch on non Linux platform")
     def test_lapack(self):

--- a/scipy/linalg/tests/test_build.py
+++ b/scipy/linalg/tests/test_build.py
@@ -4,7 +4,7 @@ from subprocess import call, PIPE, Popen
 import sys
 import re
 
-from numpy.testing import dec
+from numpy.testing import dec, assert_
 from numpy.compat import asbytes
 
 from scipy.linalg import _flapack as flapack
@@ -50,7 +50,7 @@ class TestF77Mismatch(object):
         f = FindDependenciesLdd()
         deps = f.grep_dependencies(flapack.__file__,
                                    ['libg2c', 'libgfortran'])
-        self.assertFalse(len(deps) > 1,
+        assert_(not (len(deps) > 1),
 """Both g77 and gfortran runtimes linked in scipy.linalg.flapack ! This is
 likely to cause random crashes and wrong results. See numpy INSTALL.rst.txt for
 more information.""")

--- a/scipy/linalg/tests/test_cython_blas.py
+++ b/scipy/linalg/tests/test_cython_blas.py
@@ -1,9 +1,9 @@
 import numpy as np
-from numpy.testing import (TestCase, run_module_suite, assert_allclose,
+from numpy.testing import (run_module_suite, assert_allclose,
                            assert_equal)
 import scipy.linalg.cython_blas as blas
 
-class test_dgemm(TestCase):
+class TestDGEMM(object):
     
     def test_transposes(self):
 
@@ -46,7 +46,7 @@ class test_dgemm(TestCase):
         blas._test_dgemm(1., b.T, a.T, 0., c.T)
         assert_allclose(c, b.T.dot(a.T).T)
         
-class test_wfunc_pointers(TestCase):
+class TestWfuncPointers(object):
     """ Test the function pointers that are expected to fail on
     Mac OS X without the additional entry statement in their definitions
     in fblas_l1.pyf.src. """

--- a/scipy/linalg/tests/test_cython_lapack.py
+++ b/scipy/linalg/tests/test_cython_lapack.py
@@ -1,9 +1,9 @@
-from numpy.testing import TestCase, run_module_suite, assert_allclose
+from numpy.testing import run_module_suite, assert_allclose
 from scipy.linalg import cython_lapack as cython_lapack
 from scipy.linalg import lapack
 
 
-class test_lamch(TestCase):
+class TestLamch(object):
 
     def test_slamch(self):
         for c in [b'e', b's', b'b', b'p', b'n', b'r', b'm', b'u', b'l', b'o']:

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -13,7 +13,7 @@ Run tests if linalg is not installed:
 """
 
 import numpy as np
-from numpy.testing import (TestCase, assert_equal, assert_almost_equal,
+from numpy.testing import (assert_equal, assert_almost_equal,
                            assert_array_almost_equal, assert_array_equal,
                            assert_raises, assert_, assert_allclose,
                            run_module_suite, dec)
@@ -117,7 +117,7 @@ def random_rot(dim):
     return H
 
 
-class TestEigVals(TestCase):
+class TestEigVals(object):
 
     def test_simple(self):
         a = [[1,2,3],[1,2,3],[2,5,6]]
@@ -360,11 +360,8 @@ class TestEig(object):
         assert_raises(ValueError, eig, B, A)
 
 
-class TestEigBanded(TestCase):
-
-    def __init__(self, *args):
-        TestCase.__init__(self, *args)
-
+class TestEigBanded(object):
+    def setup(self):
         self.create_bandmat()
 
     def create_bandmat(self):
@@ -726,11 +723,8 @@ def test_eigh_integer():
     w,z = eigh(a,b)
 
 
-class TestLU(TestCase):
-
-    def __init__(self, *args, **kw):
-        TestCase.__init__(self, *args, **kw)
-
+class TestLU(object):
+    def setup(self):
         self.a = array([[1,2,3],[1,2,3],[2,5,6]])
         self.ca = array([[1,2,3],[1,2,3],[2,5j,6]])
         # Those matrices are more robust to detect problems in permutation
@@ -823,7 +817,7 @@ class TestLUSingle(TestLU):
         self.cmed = self.vrect.astype(complex64)
 
 
-class TestLUSolve(TestCase):
+class TestLUSolve(object):
     def setUp(self):
         seed(1234)
 
@@ -852,7 +846,7 @@ class TestLUSolve(TestCase):
         assert_array_almost_equal(x1,x2)
 
 
-class TestSVD_GESDD(TestCase):
+class TestSVD_GESDD(object):
     def setUp(self):
         self.lapack_driver = 'gesdd'
         seed(1234)
@@ -995,7 +989,7 @@ class TestSVD_GESVD(TestSVD_GESDD):
         seed(1234)
 
 
-class TestSVDVals(TestCase):
+class TestSVDVals(object):
 
     def test_empty(self):
         for a in [[]], np.empty((2, 0)), np.ones((0, 3)):
@@ -1052,13 +1046,13 @@ class TestSVDVals(TestCase):
         svdvals(a)
 
 
-class TestDiagSVD(TestCase):
+class TestDiagSVD(object):
 
     def test_simple(self):
         assert_array_almost_equal(diagsvd([1,0,0],3,3),[[1,0,0],[0,0,0],[0,0,0]])
 
 
-class TestQR(TestCase):
+class TestQR(object):
 
     def setUp(self):
         seed(1234)
@@ -1599,7 +1593,7 @@ class TestQR(TestCase):
         assert_raises(Exception, qr, (a,), {'lwork':0})
         assert_raises(Exception, qr, (a,), {'lwork':2})
 
-class TestRQ(TestCase):
+class TestRQ(object):
 
     def setUp(self):
         seed(1234)
@@ -1707,7 +1701,7 @@ transp = transpose
 any = sometrue
 
 
-class TestSchur(TestCase):
+class TestSchur(object):
 
     def test_simple(self):
         a = [[8,12,3],[2,9,3],[10,3,6]]
@@ -1798,7 +1792,7 @@ class TestSchur(TestCase):
         assert_array_almost_equal(dot(dot(z,t),transp(conj(z))),a)
 
 
-class TestHessenberg(TestCase):
+class TestHessenberg(object):
 
     def test_simple(self):
         a = [[-149, -50,-154],
@@ -1875,7 +1869,7 @@ class TestHessenberg(TestCase):
         assert_array_almost_equal(h2, b)
 
 
-class TestQZ(TestCase):
+class TestQZ(object):
     def setUp(self):
         seed(12345)
 
@@ -2058,7 +2052,7 @@ def _make_pos(X):
     return np.sign(X)*X
 
 
-class TestOrdQZ(TestCase):
+class TestOrdQZ(object):
     @classmethod
     def setupClass(cls):
         # http://www.nag.com/lapack-ex/node119.html
@@ -2265,7 +2259,7 @@ class TestOrdQZ(TestCase):
                 assert_allclose(expected_eigvals, x)
 
 
-class TestOrdQZWorkspaceSize(TestCase):
+class TestOrdQZWorkspaceSize(object):
 
     def setUp(self):
         seed(12345)
@@ -2300,7 +2294,7 @@ class TestOrdQZWorkspaceSize(TestCase):
             [S,T,alpha,beta,U,V] = ordqz(A,B,sort='ouc')
 
 
-class TestDatacopied(TestCase):
+class TestDatacopied(object):
 
     def test_datacopied(self):
         from scipy.linalg.decomp import _datacopied

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -799,8 +799,8 @@ class TestLU(object):
 
 class TestLUSingle(TestLU):
     """LU testers for single precision, real and double"""
-    def __init__(self, *args, **kw):
-        TestLU.__init__(self, *args, **kw)
+    def setup(self):
+        TestLU.setup(self)
 
         self.a = self.a.astype(float32)
         self.ca = self.ca.astype(complex64)

--- a/scipy/linalg/tests/test_decomp_cholesky.py
+++ b/scipy/linalg/tests/test_decomp_cholesky.py
@@ -1,6 +1,6 @@
 from __future__ import division, print_function, absolute_import
 
-from numpy.testing import TestCase, assert_array_almost_equal
+from numpy.testing import assert_array_almost_equal
 
 from numpy import array, transpose, dot, conjugate, zeros_like
 from numpy.random import random
@@ -10,7 +10,7 @@ from scipy.linalg import cholesky, cholesky_banded, cho_solve_banded, \
 from scipy.linalg._testutils import assert_no_overwrite
 
 
-class TestCholesky(TestCase):
+class TestCholesky(object):
 
     def test_simple(self):
         a = [[8,2,3],[2,9,3],[3,3,6]]
@@ -67,7 +67,7 @@ class TestCholesky(TestCase):
             assert_array_almost_equal(cholesky(a,lower=1),c)
 
 
-class TestCholeskyBanded(TestCase):
+class TestCholeskyBanded(object):
     """Tests for cholesky_banded() and cho_solve_banded."""
 
     def test_check_finite(self):

--- a/scipy/linalg/tests/test_fblas.py
+++ b/scipy/linalg/tests/test_fblas.py
@@ -14,7 +14,7 @@ from scipy.linalg import _fblas as fblas
 
 from scipy._lib.six import xrange
 
-from numpy.testing import TestCase, run_module_suite, assert_array_equal, \
+from numpy.testing import run_module_suite, assert_array_equal, \
     assert_allclose, assert_array_almost_equal, assert_
 
 
@@ -107,7 +107,7 @@ class BaseAxpy(object):
         assert_(0)
 
 try:
-    class TestSaxpy(TestCase, BaseAxpy):
+    class TestSaxpy(BaseAxpy):
         blas_func = fblas.saxpy
         dtype = float32
 except AttributeError:
@@ -115,12 +115,12 @@ except AttributeError:
         pass
 
 
-class TestDaxpy(TestCase, BaseAxpy):
+class TestDaxpy(BaseAxpy):
     blas_func = fblas.daxpy
     dtype = float64
 
 try:
-    class TestCaxpy(TestCase, BaseAxpy):
+    class TestCaxpy(BaseAxpy):
         blas_func = fblas.caxpy
         dtype = complex64
 except AttributeError:
@@ -128,7 +128,7 @@ except AttributeError:
         pass
 
 
-class TestZaxpy(TestCase, BaseAxpy):
+class TestZaxpy(BaseAxpy):
     blas_func = fblas.zaxpy
     dtype = complex128
 
@@ -162,7 +162,7 @@ class BaseScal(object):
         assert_(0)
 
 try:
-    class TestSscal(TestCase, BaseScal):
+    class TestSscal(BaseScal):
         blas_func = fblas.sscal
         dtype = float32
 except AttributeError:
@@ -170,12 +170,12 @@ except AttributeError:
         pass
 
 
-class TestDscal(TestCase, BaseScal):
+class TestDscal(BaseScal):
     blas_func = fblas.dscal
     dtype = float64
 
 try:
-    class TestCscal(TestCase, BaseScal):
+    class TestCscal(BaseScal):
         blas_func = fblas.cscal
         dtype = complex64
 except AttributeError:
@@ -183,7 +183,7 @@ except AttributeError:
         pass
 
 
-class TestZscal(TestCase, BaseScal):
+class TestZscal(BaseScal):
     blas_func = fblas.zscal
     dtype = complex128
 
@@ -246,7 +246,7 @@ class BaseCopy(object):
     #    assert_array_equal(x,y)
 
 try:
-    class TestScopy(TestCase, BaseCopy):
+    class TestScopy(BaseCopy):
         blas_func = fblas.scopy
         dtype = float32
 except AttributeError:
@@ -254,12 +254,12 @@ except AttributeError:
         pass
 
 
-class TestDcopy(TestCase, BaseCopy):
+class TestDcopy(BaseCopy):
     blas_func = fblas.dcopy
     dtype = float64
 
 try:
-    class TestCcopy(TestCase, BaseCopy):
+    class TestCcopy(BaseCopy):
         blas_func = fblas.ccopy
         dtype = complex64
 except AttributeError:
@@ -267,7 +267,7 @@ except AttributeError:
         pass
 
 
-class TestZcopy(TestCase, BaseCopy):
+class TestZcopy(BaseCopy):
     blas_func = fblas.zcopy
     dtype = complex128
 
@@ -335,7 +335,7 @@ class BaseSwap(object):
         assert_(0)
 
 try:
-    class TestSswap(TestCase, BaseSwap):
+    class TestSswap(BaseSwap):
         blas_func = fblas.sswap
         dtype = float32
 except AttributeError:
@@ -343,12 +343,12 @@ except AttributeError:
         pass
 
 
-class TestDswap(TestCase, BaseSwap):
+class TestDswap(BaseSwap):
     blas_func = fblas.dswap
     dtype = float64
 
 try:
-    class TestCswap(TestCase, BaseSwap):
+    class TestCswap(BaseSwap):
         blas_func = fblas.cswap
         dtype = complex64
 except AttributeError:
@@ -356,7 +356,7 @@ except AttributeError:
         pass
 
 
-class TestZswap(TestCase, BaseSwap):
+class TestZswap(BaseSwap):
     blas_func = fblas.zswap
     dtype = complex128
 
@@ -460,7 +460,7 @@ class BaseGemv(object):
             pass
 
 try:
-    class TestSgemv(TestCase, BaseGemv):
+    class TestSgemv(BaseGemv):
         blas_func = fblas.sgemv
         dtype = float32
 
@@ -511,12 +511,12 @@ except AttributeError:
         pass
 
 
-class TestDgemv(TestCase, BaseGemv):
+class TestDgemv(BaseGemv):
     blas_func = fblas.dgemv
     dtype = float64
 
 try:
-    class TestCgemv(TestCase, BaseGemv):
+    class TestCgemv(BaseGemv):
         blas_func = fblas.cgemv
         dtype = complex64
 except AttributeError:
@@ -524,7 +524,7 @@ except AttributeError:
         pass
 
 
-class TestZgemv(TestCase, BaseGemv):
+class TestZgemv(BaseGemv):
     blas_func = fblas.zgemv
     dtype = complex128
 
@@ -533,7 +533,7 @@ class TestZgemv(TestCase, BaseGemv):
 ### Test blas ?ger
 ### This will be a mess to test all cases.
 
-class BaseGer(TestCase):
+class BaseGer(object):
     def get_data(self,x_stride=1,y_stride=1):
         from numpy.random import normal, seed
         seed(1234)

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -8,7 +8,7 @@ import sys
 import subprocess
 import time
 
-from numpy.testing import TestCase, run_module_suite, assert_equal, \
+from numpy.testing import run_module_suite, assert_equal, \
     assert_array_almost_equal, assert_, assert_raises, assert_allclose, \
     assert_almost_equal, assert_array_equal
 
@@ -32,7 +32,7 @@ COMPLEX_DTYPES = [np.complex64, np.complex128]
 DTYPES = REAL_DTYPES + COMPLEX_DTYPES
 
 
-class TestFlapackSimple(TestCase):
+class TestFlapackSimple(object):
 
     def test_gebal(self):
         a = [[1,2,3],[4,5,6],[7,8,9]]
@@ -125,7 +125,7 @@ class TestFlapackSimple(TestCase):
                     assert_equal(value, ref)
 
 
-class TestLapack(TestCase):
+class TestLapack(object):
 
     def test_flapack(self):
         if hasattr(flapack,'empty_module'):
@@ -137,7 +137,7 @@ class TestLapack(TestCase):
             # clapack module is empty
             pass
 
-class TestLeastSquaresSolvers(TestCase):
+class TestLeastSquaresSolvers(object):
 
     def test_gels(self):
         for dtype in REAL_DTYPES:
@@ -355,7 +355,7 @@ class TestLeastSquaresSolvers(TestCase):
                             dtype=dtype), rtol=25*np.finfo(dtype).eps)
 
 
-class TestRegression(TestCase):
+class TestRegression(object):
 
     def test_ticket_1645(self):
         # Check that RQ routines have correct lwork
@@ -376,7 +376,7 @@ class TestRegression(TestCase):
                 ungrq(rq[-2:], tau, lwork=2)
 
 
-class TestDpotr(TestCase):
+class TestDpotr(object):
     def test_gh_2691(self):
         # 'lower' argument of dportf/dpotri
         for lower in [True, False]:
@@ -395,7 +395,7 @@ class TestDpotr(TestCase):
                 else:
                     assert_allclose(np.triu(dpt), np.triu(inv(a)))
 
-class TestDlasd4(TestCase):
+class TestDlasd4(object):
     def test_sing_val_update(self):
 
         sigmas = np.array([4., 3., 2., 0])

--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -12,7 +12,7 @@ import functools
 
 import numpy as np
 from numpy import array, matrix, identity, dot, sqrt, double
-from numpy.testing import (TestCase, run_module_suite,
+from numpy.testing import (run_module_suite,
         assert_array_equal, assert_array_less, assert_equal,
         assert_array_almost_equal, assert_array_almost_equal_nulp,
         assert_allclose, assert_, decorators)
@@ -50,7 +50,7 @@ def _get_al_mohy_higham_2012_experiment_1():
     return A
 
 
-class TestSignM(TestCase):
+class TestSignM(object):
 
     def test_nils(self):
         a = array([[29.2, -24.2, 69.5, 49.8, 7.],
@@ -93,7 +93,7 @@ class TestSignM(TestCase):
         #XXX: what would be the correct result?
 
 
-class TestLogM(TestCase):
+class TestLogM(object):
 
     def test_nils(self):
         a = array([[-2., 25., 0., 0., 0., 0., 0.],
@@ -239,7 +239,7 @@ class TestLogM(TestCase):
         assert_allclose(logm(E), L, atol=1e-14)
 
 
-class TestSqrtM(TestCase):
+class TestSqrtM(object):
     def test_round_trip_random_float(self):
         np.random.seed(1234)
         for n in range(1, 6):
@@ -395,7 +395,7 @@ class TestSqrtM(TestCase):
         assert_allclose(sqrtm(M), R, atol=1e-14)
 
 
-class TestFractionalMatrixPower(TestCase):
+class TestFractionalMatrixPower(object):
     def test_round_trip_random_complex(self):
         np.random.seed(1234)
         for p in range(1, 5):
@@ -580,7 +580,7 @@ class TestFractionalMatrixPower(TestCase):
         assert_allclose(fractional_matrix_power(M, 0.5), R, atol=1e-14)
 
 
-class TestExpM(TestCase):
+class TestExpM(object):
     def test_zero(self):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
@@ -628,7 +628,7 @@ class TestExpM(TestCase):
                                               -0.84864425749518878))
 
 
-class TestExpmFrechet(TestCase):
+class TestExpmFrechet(object):
 
     def test_expm_frechet(self):
         # a test of the basic functionality
@@ -765,7 +765,7 @@ def _relative_error(f, A, perturbation):
     return norm(X_prime - X) / norm(X)
 
 
-class TestExpmConditionNumber(TestCase):
+class TestExpmConditionNumber(object):
     def test_expm_cond_smoke(self):
         np.random.seed(1234)
         for n in range(1, 4):

--- a/scipy/linalg/tests/test_solvers.py
+++ b/scipy/linalg/tests/test_solvers.py
@@ -3,7 +3,7 @@ from __future__ import division, print_function, absolute_import
 import os
 import numpy as np
 
-from numpy.testing import TestCase, run_module_suite
+from numpy.testing import run_module_suite
 from numpy.testing import assert_raises, assert_array_almost_equal
 
 from numpy.testing.noseclasses import KnownFailureTest
@@ -14,7 +14,7 @@ from scipy.linalg import solve_continuous_are, solve_discrete_are
 from scipy.linalg import block_diag, solve
 
 
-class TestSolveLyapunov(TestCase):
+class TestSolveLyapunov(object):
 
     cases = [
         (np.array([[1, 2], [3, 4]]),
@@ -694,7 +694,7 @@ def test_are_validate_args():
             assert_raises(ValueError, x, sq, sq, sq, sq, sq, nm)
 
 
-class TestSolveSylvester(TestCase):
+class TestSolveSylvester(object):
 
     cases = [
         # a, b, c all real.

--- a/scipy/linalg/tests/test_special_matrices.py
+++ b/scipy/linalg/tests/test_special_matrices.py
@@ -4,7 +4,7 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 from numpy import arange, add, array, eye, copy, sqrt
-from numpy.testing import (TestCase, run_module_suite, assert_raises,
+from numpy.testing import (run_module_suite, assert_raises,
     assert_equal, assert_array_equal, assert_array_almost_equal,
     assert_allclose)
 
@@ -24,7 +24,7 @@ def get_mat(n):
     return data
 
 
-class TestTri(TestCase):
+class TestTri(object):
     def test_basic(self):
         assert_equal(tri(4),array([[1,0,0,0],
                                    [1,1,0,0],
@@ -64,7 +64,7 @@ class TestTri(TestCase):
                                           [1,1,0]]))
 
 
-class TestTril(TestCase):
+class TestTril(object):
     def test_basic(self):
         a = (100*get_mat(5)).astype('l')
         b = a.copy()
@@ -87,7 +87,7 @@ class TestTril(TestCase):
         assert_equal(tril(a,k=-2),b)
 
 
-class TestTriu(TestCase):
+class TestTriu(object):
     def test_basic(self):
         a = (100*get_mat(5)).astype('l')
         b = a.copy()
@@ -110,7 +110,7 @@ class TestTriu(TestCase):
         assert_equal(triu(a,k=-2),b)
 
 
-class TestToeplitz(TestCase):
+class TestToeplitz(object):
 
     def test_basic(self):
         y = toeplitz([1,2,3])
@@ -157,7 +157,7 @@ class TestToeplitz(TestCase):
         assert_array_equal(t, [[1,2,3]])
 
 
-class TestHankel(TestCase):
+class TestHankel(object):
     def test_basic(self):
         y = hankel([1,2,3])
         assert_array_equal(y, [[1,2,3], [2,3,0], [3,0,0]])
@@ -165,13 +165,13 @@ class TestHankel(TestCase):
         assert_array_equal(y, [[1,2,3], [2,3,4], [3,4,5]])
 
 
-class TestCirculant(TestCase):
+class TestCirculant(object):
     def test_basic(self):
         y = circulant([1,2,3])
         assert_array_equal(y, [[1,3,2], [2,1,3], [3,2,1]])
 
 
-class TestHadamard(TestCase):
+class TestHadamard(object):
 
     def test_basic(self):
 
@@ -188,7 +188,7 @@ class TestHadamard(TestCase):
         assert_raises(ValueError, hadamard, 5)
 
 
-class TestLeslie(TestCase):
+class TestLeslie(object):
 
     def test_bad_shapes(self):
         assert_raises(ValueError, leslie, [[1,1],[2,2]], [3,4,5])
@@ -205,7 +205,7 @@ class TestLeslie(TestCase):
         assert_array_equal(a, expected)
 
 
-class TestCompanion(TestCase):
+class TestCompanion(object):
 
     def test_bad_shapes(self):
         assert_raises(ValueError, companion, [[1,1],[2,2]])
@@ -312,7 +312,7 @@ class TestKron:
         assert_array_equal(a, expected)
 
 
-class TestHelmert(TestCase):
+class TestHelmert(object):
 
     def test_orthogonality(self):
         for n in range(1, 7):
@@ -331,7 +331,7 @@ class TestHelmert(TestCase):
                 assert_allclose(U.T.dot(U), np.eye(n-1), atol=1e-12)
 
 
-class TestHilbert(TestCase):
+class TestHilbert(object):
 
     def test_basic(self):
         h3 = array([[1.0, 1/2., 1/3.],
@@ -345,7 +345,7 @@ class TestHilbert(TestCase):
         assert_equal(h0.shape, (0,0))
 
 
-class TestInvHilbert(TestCase):
+class TestInvHilbert(object):
 
     def test_basic(self):
         invh1 = array([[1]])
@@ -501,7 +501,7 @@ class TestInvHilbert(TestCase):
             assert_allclose(a.dot(b), eye(n), atol=1e-15*c, rtol=1e-15*c)
 
 
-class TestPascal(TestCase):
+class TestPascal(object):
 
     cases = [
         (1, array([[1]]), array([[1]])),

--- a/scipy/misc/tests/test_doccer.py
+++ b/scipy/misc/tests/test_doccer.py
@@ -42,28 +42,28 @@ filled_docstring = \
 
 
 def test_unindent():
-    yield assert_equal, doccer.unindent_string(param_doc1), param_doc1
-    yield assert_equal, doccer.unindent_string(param_doc2), param_doc2
-    yield assert_equal, doccer.unindent_string(param_doc3), param_doc1
+    assert_equal(doccer.unindent_string(param_doc1), param_doc1)
+    assert_equal(doccer.unindent_string(param_doc2), param_doc2)
+    assert_equal(doccer.unindent_string(param_doc3), param_doc1)
 
 
 def test_unindent_dict():
     d2 = doccer.unindent_dict(doc_dict)
-    yield assert_equal, d2['strtest1'], doc_dict['strtest1']
-    yield assert_equal, d2['strtest2'], doc_dict['strtest2']
-    yield assert_equal, d2['strtest3'], doc_dict['strtest1']
+    assert_equal(d2['strtest1'], doc_dict['strtest1'])
+    assert_equal(d2['strtest2'], doc_dict['strtest2'])
+    assert_equal(d2['strtest3'], doc_dict['strtest1'])
 
 
 def test_docformat():
     udd = doccer.unindent_dict(doc_dict)
     formatted = doccer.docformat(docstring, udd)
-    yield assert_equal, formatted, filled_docstring
+    assert_equal(formatted, filled_docstring)
     single_doc = 'Single line doc %(strtest1)s'
     formatted = doccer.docformat(single_doc, doc_dict)
     # Note - initial indent of format string does not
     # affect subsequent indent of inserted parameter
-    yield assert_equal, formatted, """Single line doc Another test
-   with some indent"""
+    assert_equal(formatted, """Single line doc Another test
+   with some indent""")
 
 
 @dec.skipif(DOCSTRINGS_STRIPPED)
@@ -76,10 +76,10 @@ def test_decorator():
         """ Docstring
         %(strtest3)s
         """
-    yield assert_equal, func.__doc__, """ Docstring
+    assert_equal(func.__doc__, """ Docstring
         Another test
            with some indent
-        """
+        """)
 
     # without unindentation of parameters
     decorator = doccer.filldoc(doc_dict, False)
@@ -89,10 +89,10 @@ def test_decorator():
         """ Docstring
         %(strtest3)s
         """
-    yield assert_equal, func.__doc__, """ Docstring
+    assert_equal(func.__doc__, """ Docstring
             Another test
                with some indent
-        """
+        """)
 
 
 @dec.skipif(DOCSTRINGS_STRIPPED)

--- a/scipy/misc/tests/test_pilutil.py
+++ b/scipy/misc/tests/test_pilutil.py
@@ -8,7 +8,8 @@ import glob
 
 from numpy.testing import (assert_equal, dec, decorate_methods,
                            run_module_suite, assert_allclose,
-                           assert_array_equal, assert_raises)
+                           assert_array_equal, assert_raises,
+                           assert_)
 from scipy._lib._numpy_compat import suppress_warnings
 from scipy import misc
 from numpy.ma.testutils import assert_mask_equal
@@ -86,7 +87,7 @@ class TestPILUtil(object):
         expected = [0, 255, 3]
         assert_equal(expected, actual)
         assert_mask_equal(a.mask, actual.mask)
-        self.assertTrue(isinstance(actual, np.ma.MaskedArray))
+        assert_(isinstance(actual, np.ma.MaskedArray))
 
     def test_bytescale_rounding(self):
         a = np.array([-0.5, 0.5, 1.5, 2.5, 3.5])

--- a/scipy/misc/tests/test_pilutil.py
+++ b/scipy/misc/tests/test_pilutil.py
@@ -7,7 +7,7 @@ import numpy as np
 import glob
 
 from numpy.testing import (assert_equal, dec, decorate_methods,
-                           TestCase, run_module_suite, assert_allclose,
+                           run_module_suite, assert_allclose,
                            assert_array_equal, assert_raises)
 from scipy._lib._numpy_compat import suppress_warnings
 from scipy import misc
@@ -27,7 +27,7 @@ _pilskip = dec.skipif(not _have_PIL, 'Need to import PIL for this test')
 datapath = os.path.dirname(__file__)
 
 
-class TestPILUtil(TestCase):
+class TestPILUtil(object):
     def test_imresize(self):
         im = np.random.random((10, 20))
         for T in np.sctypes['float'] + [float]:

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -69,12 +69,12 @@ def test_gaussian_kernel1d():
 def test_orders_gauss():
     # Check order inputs to Gaussians
     arr = np.zeros((1,))
-    yield assert_equal, 0, sndi.gaussian_filter(arr, 1, order=0)
-    yield assert_equal, 0, sndi.gaussian_filter(arr, 1, order=3)
-    yield assert_raises, ValueError, sndi.gaussian_filter, arr, 1, -1
-    yield assert_equal, 0, sndi.gaussian_filter1d(arr, 1, axis=-1, order=0)
-    yield assert_equal, 0, sndi.gaussian_filter1d(arr, 1, axis=-1, order=3)
-    yield assert_raises, ValueError, sndi.gaussian_filter1d, arr, 1, -1, -1
+    assert_equal(0, sndi.gaussian_filter(arr, 1, order=0))
+    assert_equal(0, sndi.gaussian_filter(arr, 1, order=3))
+    assert_raises(ValueError, sndi.gaussian_filter, arr, 1, -1)
+    assert_equal(0, sndi.gaussian_filter1d(arr, 1, axis=-1, order=0))
+    assert_equal(0, sndi.gaussian_filter1d(arr, 1, axis=-1, order=3))
+    assert_raises(ValueError, sndi.gaussian_filter1d, arr, 1, -1, -1)
 
 
 def test_valid_origins():

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from numpy.testing import (assert_equal, assert_raises, assert_allclose,
                            assert_array_equal, assert_almost_equal,
-                           TestCase, run_module_suite)
+                           run_module_suite)
 
 import scipy.ndimage as sndi
 from scipy.ndimage.filters import _gaussian_kernel1d
@@ -301,7 +301,7 @@ def test_gaussian_truncate():
     assert_equal(n, 15)
 
 
-class TestThreading(TestCase):
+class TestThreading(object):
     def check_func_thread(self, n, fun, args, out):
         from threading import Thread
         thrds = [Thread(target=fun, args=args, kwargs={'output': out[x]}) for x in range(n)]

--- a/scipy/ndimage/tests/test_measurements.py
+++ b/scipy/ndimage/tests/test_measurements.py
@@ -6,7 +6,7 @@ import warnings
 import numpy as np
 from numpy.testing import (assert_, assert_array_almost_equal, assert_equal,
                            assert_almost_equal, assert_array_equal,
-                           assert_raises, run_module_suite, TestCase)
+                           assert_raises, run_module_suite)
 
 import scipy.ndimage as ndimage
 
@@ -20,7 +20,7 @@ types = [np.int8, np.uint8, np.int16,
 np.mod(1., 1)  # Silence fmod bug on win-amd64. See #1408 and #1238.
 
 
-class Test_measurements_stats(TestCase):
+class Test_measurements_stats(object):
     """ndimage.measurements._stats() is a utility function used by other functions."""
 
     def test_a(self):
@@ -87,7 +87,7 @@ class Test_measurements_stats(TestCase):
             assert_array_equal(centers, [0.5, 8.0])
 
 
-class Test_measurements_select(TestCase):
+class Test_measurements_select(object):
     """ndimage.measurements._select() is a utility function used by other functions."""
 
     def test_basic(self):

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -33,7 +33,6 @@ from __future__ import division, print_function, absolute_import
 import warnings
 import math
 import sys
-from unittest import expectedFailure
 
 import numpy
 from numpy import fft

--- a/scipy/odr/tests/test_odr.py
+++ b/scipy/odr/tests/test_odr.py
@@ -3,7 +3,7 @@ from __future__ import division, print_function, absolute_import
 # Scipy imports.
 import numpy as np
 from numpy import pi
-from numpy.testing import (assert_array_almost_equal,
+from numpy.testing import (assert_array_almost_equal, assert_raises,
                            run_module_suite, assert_equal, assert_warns)
 from scipy.odr import Data, Model, ODR, RealData, OdrStop, OdrWarning
 
@@ -13,8 +13,8 @@ class TestODR(object):
     # Bad Data for 'x'
 
     def test_bad_data(self):
-        self.assertRaises(ValueError, Data, 2, 1)
-        self.assertRaises(ValueError, RealData, 2, 1)
+        assert_raises(ValueError, Data, 2, 1)
+        assert_raises(ValueError, RealData, 2, 1)
 
     # Empty Data for 'x'
     def empty_data_func(self, B, x):

--- a/scipy/odr/tests/test_odr.py
+++ b/scipy/odr/tests/test_odr.py
@@ -3,12 +3,12 @@ from __future__ import division, print_function, absolute_import
 # Scipy imports.
 import numpy as np
 from numpy import pi
-from numpy.testing import (assert_array_almost_equal, TestCase,
+from numpy.testing import (assert_array_almost_equal,
                            run_module_suite, assert_equal, assert_warns)
 from scipy.odr import Data, Model, ODR, RealData, OdrStop, OdrWarning
 
 
-class TestODR(TestCase):
+class TestODR(object):
 
     # Bad Data for 'x'
 

--- a/scipy/optimize/tests/test__basinhopping.py
+++ b/scipy/optimize/tests/test__basinhopping.py
@@ -4,7 +4,7 @@ Unit tests for the basin hopping global minimization algorithm.
 from __future__ import division, print_function, absolute_import
 import copy
 
-from numpy.testing import (TestCase, run_module_suite, assert_raises,
+from numpy.testing import (run_module_suite, assert_raises,
                            assert_almost_equal, assert_equal, assert_)
 import numpy as np
 from numpy import cos, sin
@@ -106,7 +106,7 @@ class MyCallBack(object):
             return True
 
 
-class TestBasinHopping(TestCase):
+class TestBasinHopping(object):
 
     def setUp(self):
         """ Tests setup.
@@ -305,7 +305,7 @@ class TestBasinHopping(TestCase):
         assert_equal(np.array(f_1), np.array(f_2))
 
 
-class Test_Storage(TestCase):
+class Test_Storage(object):
     def setUp(self):
         self.x0 = np.array(1)
         self.f0 = 0
@@ -339,7 +339,7 @@ class Test_Storage(TestCase):
         assert_(ret)
 
 
-class Test_RandomDisplacement(TestCase):
+class Test_RandomDisplacement(object):
     def setUp(self):
         self.stepsize = 1.0
         self.displace = RandomDisplacement(stepsize=self.stepsize)
@@ -356,7 +356,7 @@ class Test_RandomDisplacement(TestCase):
         assert_almost_equal(np.var(x), v, 1)
 
 
-class Test_Metropolis(TestCase):
+class Test_Metropolis(object):
     def setUp(self):
         self.T = 2.
         self.met = Metropolis(self.T)
@@ -398,7 +398,7 @@ class Test_Metropolis(TestCase):
             met.accept_reject(0, 2000)
 
 
-class Test_AdaptiveStepsize(TestCase):
+class Test_AdaptiveStepsize(object):
     def setUp(self):
         self.stepsize = 1.
         self.ts = RandomDisplacement(stepsize=self.stepsize)

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -6,12 +6,12 @@ from scipy.optimize._differentialevolution import DifferentialEvolutionSolver
 from scipy.optimize import differential_evolution
 import numpy as np
 from scipy.optimize import rosen
-from numpy.testing import (assert_equal, TestCase, assert_allclose,
+from numpy.testing import (assert_equal, assert_allclose,
                            run_module_suite, assert_almost_equal,
                            assert_string_equal, assert_raises, assert_)
 
 
-class TestDifferentialEvolutionSolver(TestCase):
+class TestDifferentialEvolutionSolver(object):
 
     def setUp(self):
         self.old_seterr = np.seterr(invalid='raise')

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -135,26 +135,26 @@ class TestDifferentialEvolutionSolver(object):
                                              self.bounds,
                                              mutation=mutation)
 
-        self.assertEqual(solver.dither, list(mutation))
+        assert_equal(solver.dither, list(mutation))
 
     def test_invalid_mutation_values_arent_accepted(self):
         func = rosen
         mutation = (0.5, 3)
-        self.assertRaises(ValueError,
+        assert_raises(ValueError,
                           DifferentialEvolutionSolver,
                           func,
                           self.bounds,
                           mutation=mutation)
 
         mutation = (-1, 1)
-        self.assertRaises(ValueError,
+        assert_raises(ValueError,
                           DifferentialEvolutionSolver,
                           func,
                           self.bounds,
                           mutation=mutation)
 
         mutation = (0.1, np.nan)
-        self.assertRaises(ValueError,
+        assert_raises(ValueError,
                           DifferentialEvolutionSolver,
                           func,
                           self.bounds,
@@ -234,7 +234,7 @@ class TestDifferentialEvolutionSolver(object):
         # test that passing an invalid strategy raises ValueError
         func = rosen
         bounds = [(-3, 3)]
-        self.assertRaises(ValueError,
+        assert_raises(ValueError,
                           differential_evolution,
                           func,
                           bounds,
@@ -244,17 +244,17 @@ class TestDifferentialEvolutionSolver(object):
         # test that the bounds checking works
         func = rosen
         bounds = [(-3, None)]
-        self.assertRaises(ValueError,
+        assert_raises(ValueError,
                           differential_evolution,
                           func,
                           bounds)
         bounds = [(-3)]
-        self.assertRaises(ValueError,
+        assert_raises(ValueError,
                           differential_evolution,
                           func,
                           bounds)
         bounds = [(-3, 3), (3, 4, 5)]
-        self.assertRaises(ValueError,
+        assert_raises(ValueError,
                           differential_evolution,
                           func,
                           bounds)

--- a/scipy/optimize/tests/test__numdiff.py
+++ b/scipy/optimize/tests/test__numdiff.py
@@ -382,7 +382,7 @@ class TestApproxDerivativesDense(object):
 
 class TestApproxDerivativeSparse(object):
     # Example from Numerical Optimization 2nd edition, p. 198.
-    def __init__(self):
+    def setup(self):
         np.random.seed(0)
         self.n = 50
         self.lb = -0.1 * (1 + np.arange(self.n))

--- a/scipy/optimize/tests/test_cobyla.py
+++ b/scipy/optimize/tests/test_cobyla.py
@@ -3,13 +3,13 @@ from __future__ import division, print_function, absolute_import
 import math
 import numpy as np
 
-from numpy.testing import assert_allclose, TestCase, run_module_suite, \
+from numpy.testing import assert_allclose, run_module_suite, \
      assert_
 
 from scipy.optimize import fmin_cobyla, minimize
 
 
-class TestCobyla(TestCase):
+class TestCobyla(object):
     def setUp(self):
         self.x0 = [4.95, 0.66]
         self.solution = [math.sqrt(25 - (2.0/3)**2), 2.0/3]

--- a/scipy/optimize/tests/test_lbfgsb_hessinv.py
+++ b/scipy/optimize/tests/test_lbfgsb_hessinv.py
@@ -1,7 +1,7 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import assert_, TestCase, run_module_suite, assert_allclose
+from numpy.testing import assert_, run_module_suite, assert_allclose
 import scipy.linalg
 from scipy.optimize import minimize
 

--- a/scipy/optimize/tests/test_linesearch.py
+++ b/scipy/optimize/tests/test_linesearch.py
@@ -90,7 +90,7 @@ class TestLineSearch(object):
 
     # --
 
-    def __init__(self):
+    def setup(self):
         self.scalar_funcs = []
         self.line_funcs = []
         self.N = 20
@@ -110,7 +110,6 @@ class TestLineSearch(object):
                 self.line_funcs.append(
                     (name, bind_index(value, 0), bind_index(value, 1)))
 
-    def setUp(self):
         np.random.seed(1234)
         self.A = np.random.randn(self.N, self.N)
 

--- a/scipy/optimize/tests/test_lsq_common.py
+++ b/scipy/optimize/tests/test_lsq_common.py
@@ -113,7 +113,7 @@ class TestBounds(object):
 
 
 class TestQuadraticFunction(object):
-    def __init__(self):
+    def setup(self):
         self.J = np.array([
             [0.1, 0.2],
             [-1.0, 1.0],

--- a/scipy/optimize/tests/test_lsq_linear.py
+++ b/scipy/optimize/tests/test_lsq_linear.py
@@ -16,7 +16,7 @@ b = np.array([0.074, 1.014, -0.383])
 
 
 class BaseMixin(object):
-    def __init__(self):
+    def setup(self):
         self.rnd = np.random.RandomState(0)
 
     def test_dense_no_bounds(self):

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -6,7 +6,7 @@ from __future__ import division, print_function, absolute_import
 import warnings
 
 from numpy.testing import (assert_, assert_almost_equal, assert_array_equal,
-        assert_array_almost_equal, TestCase, run_module_suite, assert_raises,
+        assert_array_almost_equal, run_module_suite, assert_raises,
         assert_allclose)
 import numpy as np
 from numpy import array, float64, matrix
@@ -100,7 +100,7 @@ def pressure_network_fun_and_grad(flow_rates, Qtot, k):
             pressure_network_jacobian(flow_rates, Qtot, k))
 
 
-class TestFSolve(TestCase):
+class TestFSolve(object):
     def test_pressure_network_no_gradient(self):
         # fsolve without gradient, equal pipes -> equal flows.
         k = np.ones(4) * 0.5
@@ -151,7 +151,7 @@ class TestFSolve(TestCase):
         assert_allclose(func(p), [0, 0], atol=1e-3)
 
 
-class TestRootHybr(TestCase):
+class TestRootHybr(object):
     def test_pressure_network_no_gradient(self):
         # root/hybr without gradient, equal pipes -> equal flows
         k = np.ones(4) * 0.5
@@ -183,7 +183,7 @@ class TestRootHybr(TestCase):
         assert_array_almost_equal(final_flows, np.ones(4))
 
 
-class TestRootLM(TestCase):
+class TestRootLM(object):
     def test_pressure_network_no_gradient(self):
         # root/lm without gradient, equal pipes -> equal flows
         k = np.ones(4) * 0.5
@@ -194,7 +194,7 @@ class TestRootLM(TestCase):
         assert_array_almost_equal(final_flows, np.ones(4))
 
 
-class TestLeastSq(TestCase):
+class TestLeastSq(object):
     def setUp(self):
         x = np.linspace(0, 10, 40)
         a,b,c = 3.1, 42, -304.2
@@ -275,7 +275,7 @@ class TestLeastSq(TestCase):
         assert_((func(p1,x,y)**2).sum() < 1e-4 * (func(p0,x,y)**2).sum())
 
 
-class TestCurveFit(TestCase):
+class TestCurveFit(object):
     def setUp(self):
         self.y = array([1.0, 3.2, 9.5, 13.7])
         self.x = array([1.0, 2.0, 3.0, 4.0])
@@ -589,7 +589,7 @@ class TestCurveFit(TestCase):
                 assert_allclose(pcov1, pcov2, atol=1e-14)
 
 
-class TestFixedPoint(TestCase):
+class TestFixedPoint(object):
 
     def test_scalar_trivial(self):
         # f(x) = 2x; fixed point should be x=0

--- a/scipy/optimize/tests/test_nnls.py
+++ b/scipy/optimize/tests/test_nnls.py
@@ -4,14 +4,14 @@ Sep 2008
 """
 from __future__ import division, print_function, absolute_import
 
-from numpy.testing import assert_, TestCase, run_module_suite
+from numpy.testing import assert_, run_module_suite
 
 from scipy.optimize import nnls
 from numpy import arange, dot
 from numpy.linalg import norm
 
 
-class TestNNLS(TestCase):
+class TestNNLS(object):
 
     def test_nnls(self):
         a = arange(25.0).reshape(-1,5)

--- a/scipy/optimize/tests/test_nonlin.py
+++ b/scipy/optimize/tests/test_nonlin.py
@@ -4,7 +4,7 @@ May 2007
 """
 from __future__ import division, print_function, absolute_import
 
-from numpy.testing import assert_, dec, TestCase, run_module_suite
+from numpy.testing import assert_, dec, run_module_suite
 
 from scipy._lib.six import xrange
 from scipy.optimize import nonlin, root
@@ -145,7 +145,7 @@ class TestNonlin(object):
                 yield self._check_root, f, meth
 
 
-class TestSecant(TestCase):
+class TestSecant(object):
     """Check that some Jacobian approximations satisfy the secant condition"""
 
     xs = [np.array([1,2,3,4,5], float),
@@ -221,7 +221,7 @@ class TestSecant(TestCase):
         self._check_secant(nonlin.Anderson, M=3, w0=0, npoints=3)
 
 
-class TestLinear(TestCase):
+class TestLinear(object):
     """Solve a linear equation;
     some methods find the exact solution in a finite number of steps"""
 
@@ -358,7 +358,7 @@ class TestJacobianDotSolve(object):
         self._check_dot(nonlin.KrylovJacobian, complex=True, tol=1e-3)
 
 
-class TestNonlinOldTests(TestCase):
+class TestNonlinOldTests(object):
     """ Test case for a simple constrained entropy maximization problem
     (the machine translation example of Berger et al in
     Computational Linguistics, vol 22, num 1, pp 39--72, 1996.)

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -16,7 +16,7 @@ import itertools
 
 import numpy as np
 from numpy.testing import (assert_raises, assert_allclose, assert_equal,
-                           assert_, TestCase, run_module_suite, dec,
+                           assert_, run_module_suite, dec,
                            assert_almost_equal, assert_warns,
                            assert_array_less)
 
@@ -821,7 +821,7 @@ class TestOptimizeSimple(CheckOptimize):
                 pass
 
 
-class TestLBFGSBBounds(TestCase):
+class TestLBFGSBBounds(object):
     def setUp(self):
         self.bounds = ((1, None), (None, None))
         self.solution = (1, 0)
@@ -857,7 +857,7 @@ class TestLBFGSBBounds(TestCase):
         assert_allclose(res.x, self.solution, atol=1e-6)
 
 
-class TestOptimizeScalar(TestCase):
+class TestOptimizeScalar(object):
     def setUp(self):
         self.solution = 1.5
 
@@ -1049,7 +1049,7 @@ class TestNewtonCg(object):
         assert_allclose(sol.fun, himmelblau_min, atol=1e-4)
 
 
-class TestRosen(TestCase):
+class TestRosen(object):
 
     def test_hess(self):
         # Compare rosen_hess(x) times p with rosen_hess_prod(x,p).  See gh-1775
@@ -1108,7 +1108,7 @@ def test_minimize_multiple_constraints():
     assert_allclose(res.x, [125, 0, 0], atol=1e-10)
 
 
-class TestOptimizeResultAttributes(TestCase):
+class TestOptimizeResultAttributes(object):
     # Test that all minimizers return an OptimizeResult containing
     # all the OptimizeResult attributes
     def setUp(self):
@@ -1182,7 +1182,7 @@ class TestBrute:
         assert_allclose(resbrute[1], self.func(self.solution, *self.params),
                         atol=1e-3)
 
-class TestIterationLimits(TestCase):
+class TestIterationLimits(object):
     # Tests that optimisation does not give up before trying requested
     # number of iterations or evaluations. And that it does not succeed
     # by exceeding the limits.

--- a/scipy/optimize/tests/test_regression.py
+++ b/scipy/optimize/tests/test_regression.py
@@ -4,13 +4,13 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import TestCase, run_module_suite, assert_almost_equal, \
+from numpy.testing import run_module_suite, assert_almost_equal, \
         assert_raises
 
 import scipy.optimize
 
 
-class TestRegression(TestCase):
+class TestRegression(object):
 
     def test_newton_x0_is_0(self):
         # Regression test for gh-1601

--- a/scipy/optimize/tests/test_slsqp.py
+++ b/scipy/optimize/tests/test_slsqp.py
@@ -3,7 +3,7 @@ Unit test for SLSQP optimization.
 """
 from __future__ import division, print_function, absolute_import
 
-from numpy.testing import (assert_, assert_array_almost_equal, TestCase,
+from numpy.testing import (assert_, assert_array_almost_equal,
                            assert_allclose, assert_equal, run_module_suite,
                            assert_raises)
 import numpy as np
@@ -26,7 +26,7 @@ class MyCallBack(object):
         self.ncalls += 1
 
 
-class TestSLSQP(TestCase):
+class TestSLSQP(object):
     """
     Test SLSQP algorithm using Example 14.4 from Numerical Methods for
     Engineers by Steven Chapra and Raymond Canale.

--- a/scipy/optimize/tests/test_tnc.py
+++ b/scipy/optimize/tests/test_tnc.py
@@ -2,7 +2,7 @@
 Unit tests for TNC optimization routine from tnc.py
 """
 
-from numpy.testing import (assert_allclose, assert_equal, TestCase,
+from numpy.testing import (assert_allclose, assert_equal,
                            run_module_suite)
 
 from scipy import optimize
@@ -10,7 +10,7 @@ import numpy as np
 from math import pow
 
 
-class TestTnc(TestCase):
+class TestTnc(object):
     """TNC non-linear optimization.
 
     These tests are taken from Prof. K. Schittkowski's test examples

--- a/scipy/optimize/tests/test_trustregion.py
+++ b/scipy/optimize/tests/test_trustregion.py
@@ -10,7 +10,7 @@ from __future__ import division, print_function, absolute_import
 import numpy as np
 from scipy.optimize import (minimize, rosen, rosen_der, rosen_hess,
                             rosen_hess_prod)
-from numpy.testing import (TestCase, assert_, assert_equal, assert_allclose,
+from numpy.testing import (assert_, assert_equal, assert_allclose,
                            run_module_suite)
 
 
@@ -28,7 +28,7 @@ class Accumulator:
             self.accum += x
 
 
-class TestTrustRegionSolvers(TestCase):
+class TestTrustRegionSolvers(object):
 
     def setUp(self):
         self.x_opt = [1.0, 1.0]

--- a/scipy/optimize/tests/test_trustregion_exact.py
+++ b/scipy/optimize/tests/test_trustregion_exact.py
@@ -15,7 +15,7 @@ from scipy.optimize._trustregion_exact import (
 from scipy.linalg import (svd, get_lapack_funcs, det,
                           cho_factor, cho_solve, qr,
                           eigvalsh, eig, norm)
-from numpy.testing import (TestCase, assert_, assert_array_equal,
+from numpy.testing import (assert_, assert_array_equal,
                            assert_equal, assert_array_almost_equal,
                            assert_array_less, run_module_suite)
 
@@ -50,7 +50,7 @@ def random_entry(n, min_eig, max_eig, case):
     return A, g
 
 
-class TestEstimateSmallestSingularValue(TestCase):
+class TestEstimateSmallestSingularValue(object):
 
     def test_for_ill_condiotioned_matrix(self):
 
@@ -75,7 +75,7 @@ class TestEstimateSmallestSingularValue(TestCase):
         assert_array_almost_equal(abs(zmin), abs(zmin_svd), decimal=8)
 
 
-class TestSingularLeadingSubmatrix(TestCase):
+class TestSingularLeadingSubmatrix(object):
 
     def test_for_already_singular_leading_submatrix(self):
 
@@ -155,7 +155,7 @@ class TestSingularLeadingSubmatrix(TestCase):
         assert_array_almost_equal(quadratic_term, 0)
 
 
-class TestIterativeSubproblem(TestCase):
+class TestIterativeSubproblem(object):
 
     def test_for_the_easy_case(self):
 

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -2,7 +2,7 @@ from __future__ import division, print_function, absolute_import
 
 from math import sqrt, exp, sin, cos
 
-from numpy.testing import (TestCase, assert_warns, assert_, 
+from numpy.testing import (assert_warns, assert_, 
                            run_module_suite, assert_allclose,
                            assert_equal)
 from numpy import finfo
@@ -14,7 +14,7 @@ from scipy.optimize import zeros
 from scipy.optimize._tstutils import functions, fstrings
 
 
-class TestBasic(TestCase):
+class TestBasic(object):
     def run_check(self, method, name):
         a = .5
         b = sqrt(3)

--- a/scipy/signal/tests/test_array_tools.py
+++ b/scipy/signal/tests/test_array_tools.py
@@ -2,14 +2,14 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 
-from numpy.testing import TestCase, run_module_suite, \
+from numpy.testing import run_module_suite, \
     assert_array_equal, assert_raises
 
 from scipy.signal._arraytools import axis_slice, axis_reverse, \
      odd_ext, even_ext, const_ext, zero_ext
 
 
-class TestArrayTools(TestCase):
+class TestArrayTools(object):
 
     def test_axis_slice(self):
         a = np.arange(12).reshape(3, 4)

--- a/scipy/signal/tests/test_cont2discrete.py
+++ b/scipy/signal/tests/test_cont2discrete.py
@@ -1,7 +1,7 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import TestCase, run_module_suite, \
+from numpy.testing import run_module_suite, \
                           assert_array_almost_equal, assert_almost_equal, \
                           assert_allclose
 
@@ -13,7 +13,7 @@ from scipy.signal import dlsim, ss2tf, ss2zpk, lsim2, lti
 # March 29, 2011
 
 
-class TestC2D(TestCase):
+class TestC2D(object):
     def test_zoh(self):
         ac = np.eye(2)
         bc = 0.5 * np.ones((2, 1))
@@ -303,7 +303,7 @@ class TestC2D(TestCase):
         assert_allclose(den, den1, rtol=1e-13)
         assert_allclose(den, den2, rtol=1e-13)
 
-class TestC2dLti(TestCase):
+class TestC2dLti(object):
     def test_c2d_ss(self):
         # StateSpace
         A = np.array([[-0.3, 0.1], [0.2, -0.7]])
@@ -336,7 +336,7 @@ class TestC2dLti(TestCase):
         assert_allclose(sys.den, den_res, atol=0.02)
         assert_allclose(sys.num, num_res, atol=0.02)
 
-class TestC2dLti(TestCase):
+class TestC2dLti(object):
     def test_c2d_ss(self):
         # StateSpace
         A = np.array([[-0.3, 0.1], [0.2, -0.7]])

--- a/scipy/signal/tests/test_cont2discrete.py
+++ b/scipy/signal/tests/test_cont2discrete.py
@@ -3,7 +3,7 @@ from __future__ import division, print_function, absolute_import
 import numpy as np
 from numpy.testing import run_module_suite, \
                           assert_array_almost_equal, assert_almost_equal, \
-                          assert_allclose
+                          assert_allclose, assert_equal
 
 import warnings
 from scipy.signal import cont2discrete as c2d
@@ -275,7 +275,7 @@ class TestC2D(object):
         tf = ([[1, 0], [1, 1]], [1, 1])
         num, den, dt = c2d(tf, 0.01)
 
-        self.assertEqual(dt, 0.01)  # sanity check
+        assert_equal(dt, 0.01)  # sanity check
         assert_allclose(den, [1, -0.990404983], rtol=1e-3)
         assert_allclose(num, [[1, -1], [1, -0.99004983]], rtol=1e-3)
 
@@ -292,8 +292,8 @@ class TestC2D(object):
         num2, den2, dt2 = c2d(tf2, ts)
 
         # Sanity checks
-        self.assertEqual(dt, dt1)
-        self.assertEqual(dt, dt2)
+        assert_equal(dt, dt1)
+        assert_equal(dt, dt2)
 
         # Check that we get the same results
         assert_allclose(num, np.vstack((num1, num2)), rtol=1e-13)

--- a/scipy/signal/tests/test_dltisys.py
+++ b/scipy/signal/tests/test_dltisys.py
@@ -5,7 +5,7 @@ from __future__ import division, print_function, absolute_import
 
 import warnings
 import numpy as np
-from numpy.testing import (TestCase, run_module_suite, assert_equal,
+from numpy.testing import (run_module_suite, assert_equal,
                            assert_array_almost_equal, assert_array_equal,
                            assert_allclose, assert_, assert_raises,
                            assert_almost_equal)
@@ -15,7 +15,7 @@ from scipy.signal import (dlsim, dstep, dimpulse, tf2zpk, lti, dlti,
                           dfreqresp, dbode, BadCoefficients)
 
 
-class TestDLTI(TestCase):
+class TestDLTI(object):
 
     def test_dlsim(self):
 
@@ -397,7 +397,7 @@ class TestZerosPolesGain(object):
         assert_(s.to_zpk() is not s)
 
 
-class Test_dfreqresp(TestCase):
+class Test_dfreqresp(object):
 
     def test_manual(self):
         # Test dfreqresp() real part calculation (manual sanity check).

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -4,7 +4,7 @@ import warnings
 
 from distutils.version import LooseVersion
 import numpy as np
-from numpy.testing import (TestCase, assert_array_almost_equal,
+from numpy.testing import (assert_array_almost_equal,
                            assert_array_equal, assert_array_less,
                            assert_raises, assert_equal, assert_,
                            run_module_suite, assert_allclose, assert_warns,
@@ -35,7 +35,7 @@ def mpmath_check(min_ver):
                       "mpmath version >= %s required" % min_ver)
 
 
-class TestCplxPair(TestCase):
+class TestCplxPair(object):
 
     def test_trivial_input(self):
         assert_equal(_cplxpair([]).size, 0)
@@ -105,7 +105,7 @@ class TestCplxPair(TestCase):
         assert_raises(ValueError, _cplxpair, [1-3j])
 
 
-class TestCplxReal(TestCase):
+class TestCplxReal(object):
 
     def test_trivial_input(self):
         assert_equal(_cplxreal([]), ([], []))
@@ -157,7 +157,7 @@ class TestCplxReal(TestCase):
         assert_array_equal(zr, [0, 1, 2, 4])
 
 
-class TestTf2zpk(TestCase):
+class TestTf2zpk(object):
 
     def test_simple(self):
         z_r = np.array([0.5, -0.5])
@@ -183,7 +183,7 @@ class TestTf2zpk(TestCase):
             assert_raises(BadCoefficients, tf2zpk, [1e-15], [1.0, 1.0])
 
 
-class TestZpk2Tf(TestCase):
+class TestZpk2Tf(object):
 
     def test_identity(self):
         """Test the identity transfer function."""
@@ -202,7 +202,7 @@ class TestZpk2Tf(TestCase):
         assert_(isinstance(a, np.ndarray))
 
 
-class TestSos2Zpk(TestCase):
+class TestSos2Zpk(object):
 
     def test_basic(self):
         sos = [[1, 0, 1, 1, 0, -0.81],
@@ -240,7 +240,7 @@ class TestSos2Zpk(TestCase):
         assert_allclose(k2, k)
 
 
-class TestSos2Tf(TestCase):
+class TestSos2Tf(object):
 
     def test_basic(self):
         sos = [[1, 1, 1, 1, 0, -1],
@@ -250,7 +250,7 @@ class TestSos2Tf(TestCase):
         assert_array_almost_equal(a, [1, 10, 0, -10, -1])
 
 
-class TestTf2Sos(TestCase):
+class TestTf2Sos(object):
 
     def test_basic(self):
         num = [2, 16, 44, 56, 32]
@@ -268,7 +268,7 @@ class TestTf2Sos(TestCase):
         # assert_array_almost_equal(sos, sos2, decimal=4)
 
 
-class TestZpk2Sos(TestCase):
+class TestZpk2Sos(object):
 
     def test_basic(self):
         for pairing in ('nearest', 'keep_odd'):
@@ -405,7 +405,7 @@ class TestZpk2Sos(TestCase):
             assert_array_almost_equal(sos, sos2, decimal=4)
 
 
-class TestFreqs(TestCase):
+class TestFreqs(object):
 
     def test_basic(self):
         _, h = freqs([1.0], [1.0], worN=8)
@@ -443,7 +443,7 @@ class TestFreqs(TestCase):
         freqs([1.0], [1.0], worN=8, plot=plot)
 
 
-class TestFreqs_zpk(TestCase):
+class TestFreqs_zpk(object):
 
     def test_basic(self):
         _, h = freqs_zpk([1.0], [1.0], [1.0], worN=8)
@@ -483,7 +483,7 @@ class TestFreqs_zpk(TestCase):
         assert_allclose(h1, h2, rtol=1e-6)
 
 
-class TestFreqz(TestCase):
+class TestFreqz(object):
 
     def test_ticket1441(self):
         """Regression test for ticket 1441."""
@@ -515,7 +515,7 @@ class TestFreqz(TestCase):
         freqz([1.0], worN=8, plot=plot)
 
 
-class TestSOSFreqz(TestCase):
+class TestSOSFreqz(object):
 
     def test_sosfreqz_basic(self):
         # Compare the results of freqz and sosfreqz for a low order
@@ -648,7 +648,7 @@ class TestSOSFreqz(TestCase):
         assert_allclose(h, h_mp, rtol=1e-12, atol=1e-14)
 
 
-class TestFreqz_zpk(TestCase):
+class TestFreqz_zpk(object):
 
     def test_ticket1441(self):
         """Regression test for ticket 1441."""
@@ -679,7 +679,7 @@ class TestFreqz_zpk(TestCase):
         assert_allclose(h1, h2, rtol=1e-6)
 
 
-class TestNormalize(TestCase):
+class TestNormalize(object):
 
     def test_allclose(self):
         """Test for false positive on allclose in normalize() in
@@ -738,7 +738,7 @@ class TestNormalize(TestCase):
         assert_raises(ValueError, normalize, [[[1, 2]]], 1)
 
 
-class TestLp2lp(TestCase):
+class TestLp2lp(object):
 
     def test_basic(self):
         b = [1]
@@ -748,7 +748,7 @@ class TestLp2lp(TestCase):
         assert_array_almost_equal(a_lp, [1, 0.5455, 0.1488], decimal=4)
 
 
-class TestLp2hp(TestCase):
+class TestLp2hp(object):
 
     def test_basic(self):
         b = [0.25059432325190018]
@@ -758,7 +758,7 @@ class TestLp2hp(TestCase):
         assert_allclose(a_hp, [1, 1.1638e5, 2.3522e9, 1.2373e14], rtol=1e-4)
 
 
-class TestLp2bp(TestCase):
+class TestLp2bp(object):
 
     def test_basic(self):
         b = [1]
@@ -769,7 +769,7 @@ class TestLp2bp(TestCase):
                                1.3965e18, 1.0028e22, 2.5202e26], rtol=1e-4)
 
 
-class TestLp2bs(TestCase):
+class TestLp2bs(object):
 
     def test_basic(self):
         b = [1]
@@ -779,7 +779,7 @@ class TestLp2bs(TestCase):
         assert_array_almost_equal(a_bs, [1, 0.18461, 0.17407], decimal=5)
 
 
-class TestBilinear(TestCase):
+class TestBilinear(object):
 
     def test_basic(self):
         b = [0.14879732743343033]
@@ -798,7 +798,7 @@ class TestBilinear(TestCase):
                                   decimal=4)
 
 
-class TestPrototypeType(TestCase):
+class TestPrototypeType(object):
 
     def test_output_type(self):
         # Prototypes should consistently output arrays, not lists
@@ -819,7 +819,7 @@ def dB(x):
     return 20 * np.log10(abs(x))
 
 
-class TestButtord(TestCase):
+class TestButtord(object):
 
     def test_lowpass(self):
         wp = 0.2
@@ -908,7 +908,7 @@ class TestButtord(TestCase):
         assert_equal(buttord(1, 1.2, 1, 80, analog=True)[0], 55)
 
 
-class TestCheb1ord(TestCase):
+class TestCheb1ord(object):
 
     def test_lowpass(self):
         wp = 0.2
@@ -991,7 +991,7 @@ class TestCheb1ord(TestCase):
         assert_equal(cheb1ord(1, 1.2, 1, 80, analog=True)[0], 17)
 
 
-class TestCheb2ord(TestCase):
+class TestCheb2ord(object):
 
     def test_lowpass(self):
         wp = 0.2
@@ -1077,7 +1077,7 @@ class TestCheb2ord(TestCase):
                         rtol=1e-15)
 
 
-class TestEllipord(TestCase):
+class TestEllipord(object):
 
     def test_lowpass(self):
         wp = 0.2
@@ -1162,7 +1162,7 @@ class TestEllipord(TestCase):
         assert_equal(ellipord(1, 1.2, 1, 80, analog=True)[0], 9)
 
 
-class TestBessel(TestCase):
+class TestBessel(object):
 
     def test_degenerate(self):
         for norm in ('delay', 'phase', 'mag'):
@@ -1625,7 +1625,7 @@ class TestBessel(TestCase):
         assert_raises(ValueError, _bessel_poly, 3.3)
 
 
-class TestButter(TestCase):
+class TestButter(object):
 
     def test_degenerate(self):
         # 0-order filter is just a passthrough
@@ -1862,7 +1862,7 @@ class TestButter(TestCase):
         assert_allclose(a, a2, rtol=1e-14)
 
 
-class TestCheby1(TestCase):
+class TestCheby1(object):
 
     def test_degenerate(self):
         # 0-order filter is just a passthrough
@@ -2113,7 +2113,7 @@ class TestCheby1(TestCase):
         assert_allclose(a, a2, rtol=1e-14)
 
 
-class TestCheby2(TestCase):
+class TestCheby2(object):
 
     def test_degenerate(self):
         # 0-order filter is just a passthrough
@@ -2380,7 +2380,7 @@ class TestCheby2(TestCase):
         assert_allclose(a, a2, rtol=1e-14)
 
 
-class TestEllip(TestCase):
+class TestEllip(object):
 
     def test_degenerate(self):
         # 0-order filter is just a passthrough
@@ -2690,7 +2690,7 @@ def test_sos_consistency():
         assert_allclose(sos, zpk2sos(*zpk), err_msg="%s(4,...)" % name)
 
 
-class TestIIRNotch(TestCase):
+class TestIIRNotch(object):
 
     def test_ba_output(self):
         # Compare coeficients with Matlab ones
@@ -2751,7 +2751,7 @@ class TestIIRNotch(TestCase):
         assert_raises(TypeError, iirnotch, w0=-1, Q=[1, 2, 3])
 
 
-class TestIIRPeak(TestCase):
+class TestIIRPeak(object):
 
     def test_ba_output(self):
         # Compare coeficients with Matlab ones
@@ -2811,7 +2811,7 @@ class TestIIRPeak(TestCase):
         assert_raises(TypeError, iirpeak, w0=-1, Q=[1, 2, 3])
 
 
-class TestIIRFilter(TestCase):
+class TestIIRFilter(object):
 
     def test_symmetry(self):
         # All built-in IIR filters are real, so should have perfectly
@@ -2854,7 +2854,7 @@ class TestIIRFilter(TestCase):
         assert_raises(ValueError, iirfilter, 1, [10, 20], btype='stop')
 
 
-class TestGroupDelay(TestCase):
+class TestGroupDelay(object):
     def test_identity_filter(self):
         w, gd = group_delay((1, 1))
         assert_array_almost_equal(w, pi * np.arange(512) / 512)

--- a/scipy/signal/tests/test_fir_filter_design.py
+++ b/scipy/signal/tests/test_fir_filter_design.py
@@ -45,7 +45,7 @@ class TestFirwin(object):
         for freq, expected in expected_response:
             actual = abs(np.sum(h*np.exp(-1.j*np.pi*m*freq)))
             mse = abs(actual-expected)**2
-            self.assertTrue(mse < tol, 'response not as expected, mse=%g > %g'
+            assert_(mse < tol, 'response not as expected, mse=%g > %g'
                % (mse, tol))
 
     def test_response(self):
@@ -120,7 +120,7 @@ class TestFirwin(object):
                     cutoff = [0] + cutoff
                 else:
                     cutoff = cutoff + [1]
-            self.assertTrue(self.mse(h, [cutoff]) < self.mse(hs, [cutoff]),
+            assert_(self.mse(h, [cutoff]) < self.mse(hs, [cutoff]),
                 'least squares violation')
             self.check_response(hs, [expected_response], 1e-12)
 

--- a/scipy/signal/tests/test_fir_filter_design.py
+++ b/scipy/signal/tests/test_fir_filter_design.py
@@ -3,7 +3,7 @@ from __future__ import division, print_function, absolute_import
 import warnings
 
 import numpy as np
-from numpy.testing import TestCase, run_module_suite, assert_raises, \
+from numpy.testing import run_module_suite, assert_raises, \
         assert_almost_equal, assert_array_almost_equal, assert_equal, \
         assert_, assert_allclose, assert_warns
 from scipy.special import sinc
@@ -36,7 +36,7 @@ def test_kaiserord():
     assert_equal((numtaps, beta), (2, 0.0))
 
 
-class TestFirwin(TestCase):
+class TestFirwin(object):
 
     def check_response(self, h, expected_response, tol=.05):
         N = len(h)
@@ -125,7 +125,7 @@ class TestFirwin(TestCase):
             self.check_response(hs, [expected_response], 1e-12)
 
 
-class TestFirWinMore(TestCase):
+class TestFirWinMore(object):
     """Different author, different style, different tests..."""
 
     def test_lowpass(self):
@@ -240,7 +240,7 @@ class TestFirWinMore(TestCase):
         assert_raises(ValueError, firwin, 40, [.25, 0.5])
 
 
-class TestFirwin2(TestCase):
+class TestFirwin2(object):
 
     def test_invalid_args(self):
         # `freq` and `gain` have different lengths.
@@ -357,7 +357,7 @@ class TestFirwin2(TestCase):
         assert_array_almost_equal(taps1, taps2)
 
 
-class TestRemez(TestCase):
+class TestRemez(object):
 
     def test_bad_args(self):
         assert_raises(ValueError, remez, 11, [0.1, 0.4], [1], type='pooka')
@@ -410,7 +410,7 @@ class TestRemez(TestCase):
         assert_allclose(remez(21, [0, 0.8, 0.9, 1], [0, 1], Hz=2.), h)
 
 
-class TestFirls(TestCase):
+class TestFirls(object):
 
     def test_bad_args(self):
         # even numtaps
@@ -497,7 +497,7 @@ class TestFirls(TestCase):
         assert_allclose(taps, known_taps)
 
 
-class TestMinimumPhase(TestCase):
+class TestMinimumPhase(object):
 
     def test_bad_args(self):
         # not enough taps

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -4,7 +4,7 @@ import warnings
 
 import numpy as np
 from numpy.testing import (assert_almost_equal, assert_equal, assert_allclose,
-                           assert_, assert_raises, TestCase, run_module_suite)
+                           assert_, assert_raises, run_module_suite)
 from scipy._lib._numpy_compat import suppress_warnings
 from scipy.signal import (ss2tf, tf2ss, lsim2, impulse2, step2, lti,
                           dlti, bode, freqresp, lsim, impulse, step,
@@ -35,7 +35,7 @@ def _assert_poles_close(P1,P2, rtol=1e-8, atol=1e-8):
             raise ValueError("Can't find pole " + str(p1) + " in " + str(P2))
 
 
-class TestPlacePoles(TestCase):
+class TestPlacePoles(object):
 
     def _check(self, A, B, P, **kwargs):
         """

--- a/scipy/signal/tests/test_max_len_seq.py
+++ b/scipy/signal/tests/test_max_len_seq.py
@@ -1,14 +1,14 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import (TestCase, assert_raises, run_module_suite,
+from numpy.testing import (assert_raises, run_module_suite,
                            assert_allclose, assert_array_equal)
 from numpy.fft import fft, ifft
 
 from scipy.signal import max_len_seq
 
 
-class TestMLS(TestCase):
+class TestMLS(object):
 
     def test_mls_inputs(self):
         # can't all be zero state

--- a/scipy/signal/tests/test_peak_finding.py
+++ b/scipy/signal/tests/test_peak_finding.py
@@ -3,7 +3,7 @@ from __future__ import division, print_function, absolute_import
 import copy
 
 import numpy as np
-from numpy.testing import (TestCase, run_module_suite, assert_equal,
+from numpy.testing import (run_module_suite, assert_equal,
     assert_array_equal, assert_)
 from scipy.signal._peak_finding import (argrelmax, argrelmin,
     find_peaks_cwt, _identify_ridge_lines)
@@ -70,7 +70,7 @@ def _gen_ridge_line(start_locs, max_locs, length, distances, gaps):
     return [locs[:, 0], locs[:, 1]]
 
 
-class TestRidgeLines(TestCase):
+class TestRidgeLines(object):
 
     def test_empty(self):
         test_matr = np.zeros([20, 100])
@@ -162,7 +162,7 @@ class TestRidgeLines(TestCase):
             np.testing.assert_array_less(np.abs(agaps), max(gaps) + 0.1)
 
 
-class TestArgrel(TestCase):
+class TestArgrel(object):
 
     def test_empty(self):
         # Regression test for gh-2832.
@@ -245,7 +245,7 @@ class TestArgrel(TestCase):
             assert_((act_locs == (rel_max_cols[inds] - rot_factor*rw)).all())
 
 
-class TestFindPeaks(TestCase):
+class TestFindPeaks(object):
 
     def test_find_peaks_exact(self):
         """

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -8,7 +8,7 @@ from itertools import product
 
 from nose import SkipTest
 from numpy.testing import (
-    TestCase, run_module_suite, assert_equal,
+    run_module_suite, assert_equal,
     assert_almost_equal, assert_array_equal, assert_array_almost_equal,
     assert_raises, assert_allclose, assert_, dec)
 from scipy._lib._numpy_compat import suppress_warnings
@@ -343,7 +343,7 @@ class TestConvolve2d(_TestConvolve2d):
                 signal.convolve(a, b, mode=mode))
 
 
-class TestFFTConvolve(TestCase):
+class TestFFTConvolve(object):
 
     def test_real(self):
         x = array([1, 2, 3])
@@ -476,7 +476,7 @@ class TestFFTConvolve(TestCase):
         assert_raises(ValueError, fftconvolve, *(b, a), **{'mode': 'valid'})
 
 
-class TestMedFilt(TestCase):
+class TestMedFilt(object):
 
     def test_basic(self):
         f = [[50, 50, 50, 50, 50, 92, 18, 27, 65, 46],
@@ -519,7 +519,7 @@ class TestMedFilt(TestCase):
         assert_(signal.medfilt(a, 1) == 5.)
 
 
-class TestWiener(TestCase):
+class TestWiener(object):
 
     def test_basic(self):
         g = array([[5, 6, 4, 3],
@@ -534,7 +534,7 @@ class TestWiener(TestCase):
         assert_array_almost_equal(signal.wiener(g, mysize=3), h, decimal=6)
 
 
-class TestResample(TestCase):
+class TestResample(object):
 
     def test_basic(self):
         # Some basic tests
@@ -672,7 +672,7 @@ class TestResample(TestCase):
                 assert_allclose(yf, y, atol=1e-7, rtol=1e-7)
 
 
-class TestCSpline1DEval(TestCase):
+class TestCSpline1DEval(object):
 
     def test_basic(self):
         y = array([1, 2, 3, 4, 3, 2, 1, 2, 3.0])
@@ -703,7 +703,7 @@ class TestCSpline1DEval(TestCase):
 
         assert_equal(ynew.dtype, y.dtype)
 
-class TestOrderFilt(TestCase):
+class TestOrderFilt(object):
 
     def test_basic(self):
         assert_array_equal(signal.order_filter([1, 2, 3], [1, 0, 1], 1),
@@ -1339,7 +1339,7 @@ class _TestCorrelateComplex(object):
         assert_equal(y.dtype, self.dt)
 
 
-class TestCorrelate2d(TestCase):
+class TestCorrelate2d(object):
 
     def test_consistency_correlate_funcs(self):
         # Compare np.correlate, signal.correlate, signal.correlate2d
@@ -1381,7 +1381,7 @@ for datatype in [np.csingle, np.cdouble, np.clongdouble]:
     globals()[cls.__name__] = cls
 
 
-class TestLFilterZI(TestCase):
+class TestLFilterZI(object):
 
     def test_basic(self):
         a = np.array([1.0, -1.0, 0.5])
@@ -1400,7 +1400,7 @@ class TestLFilterZI(TestCase):
         assert_allclose(zi2, zi1, rtol=1e-12)
 
 
-class TestFiltFilt(TestCase):
+class TestFiltFilt(object):
     filtfilt_kind = 'tf'
 
     def filtfilt(self, zpk, x, axis=-1, padtype='odd', padlen=None,
@@ -1649,7 +1649,7 @@ def test_filtfilt_gust():
     yield check_filtfilt_gust, b, a, (length,), 0, approx_impulse_len
 
 
-class TestDecimate(TestCase):
+class TestDecimate(object):
     def test_bad_args(self):
         x = np.arange(12)
         assert_raises(TypeError, signal.decimate, x, q=0.5, n=1)
@@ -1843,7 +1843,7 @@ class TestHilbert2(object):
         assert_raises(ValueError, hilbert2, x, N=(2,))
 
 
-class TestPartialFractionExpansion(TestCase):
+class TestPartialFractionExpansion(object):
     def test_invresz_one_coefficient_bug(self):
         # Regression test for issue in gh-4646.
         r = [1]
@@ -1900,7 +1900,7 @@ class TestPartialFractionExpansion(TestCase):
         assert_raises(ValueError, invres, r, p, k, rtype='median')
 
 
-class TestVectorstrength(TestCase):
+class TestVectorstrength(object):
 
     def test_single_1dperiod(self):
         events = np.array([.5])
@@ -2049,7 +2049,7 @@ class TestVectorstrength(TestCase):
         assert_raises(ValueError, vectorstrength, events, period)
 
 
-class TestSOSFilt(TestCase):
+class TestSOSFilt(object):
 
     # For sosfilt we only test a single datatype. Since sosfilt wraps
     # to lfilter under the hood, it's hopefully good enough to ensure

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -31,7 +31,7 @@ else:
     from fractions import gcd
 
 
-class _TestConvolve(TestCase):
+class _TestConvolve(object):
 
     def test_basic(self):
         a = [3, 4, 5, 6, 5, 4]
@@ -155,8 +155,8 @@ class TestConvolve(_TestConvolve):
         a = np.arange(1, 7).reshape((2, 3))
         b = np.arange(-6, 0).reshape((3, 2))
 
-        self.assertRaises(ValueError, convolve, *(a, b), **{'mode': 'valid'})
-        self.assertRaises(ValueError, convolve, *(b, a), **{'mode': 'valid'})
+        assert_raises(ValueError, convolve, *(a, b), **{'mode': 'valid'})
+        assert_raises(ValueError, convolve, *(b, a), **{'mode': 'valid'})
 
     def test_convolve_method(self, n=100):
         types = sum([t for _, t in np.sctypes.items()], [])
@@ -222,7 +222,7 @@ class TestConvolve(_TestConvolve):
                 assert_equal(direct, 2**(2*n))
 
 
-class _TestConvolve2d(TestCase):
+class _TestConvolve2d(object):
 
     def test_2d_arrays(self):
         a = [[1, 2, 3], [3, 4, 5]]
@@ -294,8 +294,8 @@ class _TestConvolve2d(TestCase):
         a = np.arange(1, 7).reshape((2, 3))
         b = np.arange(-6, 0).reshape((3, 2))
 
-        self.assertRaises(ValueError, convolve2d, *(a, b), **{'mode': 'valid'})
-        self.assertRaises(ValueError, convolve2d, *(b, a), **{'mode': 'valid'})
+        assert_raises(ValueError, convolve2d, *(a, b), **{'mode': 'valid'})
+        assert_raises(ValueError, convolve2d, *(b, a), **{'mode': 'valid'})
 
 
 class TestConvolve2d(_TestConvolve2d):
@@ -472,8 +472,8 @@ class TestFFTConvolve(TestCase):
         a = np.arange(1, 7).reshape((2, 3))
         b = np.arange(-6, 0).reshape((3, 2))
 
-        self.assertRaises(ValueError, fftconvolve, *(a, b), **{'mode': 'valid'})
-        self.assertRaises(ValueError, fftconvolve, *(b, a), **{'mode': 'valid'})
+        assert_raises(ValueError, fftconvolve, *(a, b), **{'mode': 'valid'})
+        assert_raises(ValueError, fftconvolve, *(b, a), **{'mode': 'valid'})
 
 
 class TestMedFilt(TestCase):
@@ -710,7 +710,7 @@ class TestOrderFilt(TestCase):
                            [2, 3, 2])
 
 
-class _TestLinearFilter(TestCase):
+class _TestLinearFilter(object):
     def generate(self, shape):
         x = np.linspace(0, np.prod(shape) - 1, np.prod(shape)).reshape(shape)
         return self.convert_dtype(x)
@@ -1140,7 +1140,7 @@ def test_lfilter_bad_object():
     assert_raises(TypeError, lfilter, [None], [1.0], [1.0, 2.0, 3.0])
 
 
-class _TestCorrelateReal(TestCase):
+class _TestCorrelateReal(object):
     dt = None
 
     def _setup_rank1(self):
@@ -1249,8 +1249,8 @@ class _TestCorrelateReal(TestCase):
         a = np.arange(1, 7).reshape((2, 3))
         b = np.arange(-6, 0).reshape((3, 2))
 
-        self.assertRaises(ValueError, correlate, *(a, b), **{'mode': 'valid'})
-        self.assertRaises(ValueError, correlate, *(b, a), **{'mode': 'valid'})
+        assert_raises(ValueError, correlate, *(a, b), **{'mode': 'valid'})
+        assert_raises(ValueError, correlate, *(b, a), **{'mode': 'valid'})
 
 
 def _get_testcorrelate_class(datatype, base):
@@ -1267,7 +1267,7 @@ for datatype in [np.ubyte, np.byte, np.ushort, np.short, np.uint, int,
     globals()[cls.__name__] = cls
 
 
-class _TestCorrelateComplex(TestCase):
+class _TestCorrelateComplex(object):
     # The numpy data type to use.
     dt = None
 
@@ -1369,8 +1369,8 @@ class TestCorrelate2d(TestCase):
         a = np.arange(1, 7).reshape((2, 3))
         b = np.arange(-6, 0).reshape((3, 2))
 
-        self.assertRaises(ValueError, signal.correlate2d, *(a, b), **{'mode': 'valid'})
-        self.assertRaises(ValueError, signal.correlate2d, *(b, a), **{'mode': 'valid'})
+        assert_raises(ValueError, signal.correlate2d, *(a, b), **{'mode': 'valid'})
+        assert_raises(ValueError, signal.correlate2d, *(b, a), **{'mode': 'valid'})
 
 
 # Create three classes, one for each complex data type. The actual class

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1792,14 +1792,14 @@ class TestHilbert(object):
         a = np.arange(18).reshape(3, 6)
         # test axis
         aa = hilbert(a, axis=-1)
-        yield assert_equal, hilbert(a.T, axis=0), aa.T
+        assert_equal(hilbert(a.T, axis=0), aa.T)
         # test 1d
-        yield assert_equal, hilbert(a[0]), aa[0]
+        assert_equal(hilbert(a[0]), aa[0])
 
         # test N
         aan = hilbert(a, N=20, axis=-1)
-        yield assert_equal, aan.shape, [3, 20]
-        yield assert_equal, hilbert(a.T, N=20, axis=0).shape, [20, 3]
+        assert_equal(aan.shape, [3, 20])
+        assert_equal(hilbert(a.T, N=20, axis=0).shape, [20, 3])
         # the next test is just a regression test,
         # no idea whether numbers make sense
         a0hilb = np.array([0.000000000000000e+00 - 1.72015830311905j,
@@ -1822,7 +1822,7 @@ class TestHilbert(object):
                            3.552713678800501e-16 - 0.403810179797771j,
                            8.881784197001253e-17 - 0.751023775297729j,
                            9.444121133484362e-17 - 0.79252210110103j])
-        yield assert_almost_equal, aan[0], a0hilb, 14, 'N regression'
+        assert_almost_equal(aan[0], a0hilb, 14, 'N regression')
 
 
 class TestHilbert2(object):

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -2,7 +2,7 @@ from __future__ import division, print_function, absolute_import
 
 import warnings
 import numpy as np
-from numpy.testing import (assert_, run_module_suite, TestCase, dec,
+from numpy.testing import (assert_, run_module_suite, dec,
                            assert_allclose, assert_array_equal, assert_equal,
                            assert_array_almost_equal_nulp, assert_raises,
                            assert_approx_equal)
@@ -12,7 +12,7 @@ from scipy.signal import (periodogram, welch, lombscargle, csd, coherence,
 from scipy.signal.spectral import _spectral_helper
 
 
-class TestPeriodogram(TestCase):
+class TestPeriodogram(object):
     def test_real_onesided_even(self):
         x = np.zeros(16)
         x[0] = 1
@@ -216,7 +216,7 @@ class TestPeriodogram(TestCase):
         assert_(p.dtype == q.dtype)
 
 
-class TestWelch(TestCase):
+class TestWelch(object):
     def test_real_onesided_even(self):
         x = np.zeros(16)
         x[0] = 1
@@ -842,7 +842,7 @@ class TestCSD:
         assert_allclose(f, fodd)
         assert_allclose(f, feven)
 
-class TestCoherence(TestCase):
+class TestCoherence(object):
     def test_identical_input(self):
         x = np.random.randn(20)
         y = np.copy(x)  # So `y is x` -> False
@@ -866,7 +866,7 @@ class TestCoherence(TestCase):
         assert_allclose(C, C1)
 
 
-class TestSpectrogram(TestCase):
+class TestSpectrogram(object):
     def test_average_all_segments(self):
         x = np.random.randn(1024)
 
@@ -918,7 +918,7 @@ class TestSpectrogram(TestCase):
         assert_allclose(f1, f3)
         assert_allclose(p1, p3)
 
-class TestLombscargle(TestCase):
+class TestLombscargle(object):
     def test_frequency(self):
         """Test if frequency location of peak corresponds to frequency of
         generated input signal.
@@ -1065,7 +1065,7 @@ class TestLombscargle(TestCase):
         q = lombscargle(t, x, f*2*np.pi)
 
 
-class TestSTFT(TestCase):
+class TestSTFT(object):
     def test_input_validation(self):
         assert_raises(ValueError, check_COLA, 'hann', -10, 0)
         assert_raises(ValueError, check_COLA, 'hann', 10, 20)

--- a/scipy/signal/tests/test_upfirdn.py
+++ b/scipy/signal/tests/test_upfirdn.py
@@ -34,7 +34,7 @@
 
 import numpy as np
 from itertools import product
-from numpy.testing import (TestCase, run_module_suite, assert_equal,
+from numpy.testing import (run_module_suite, assert_equal,
                            assert_raises, assert_allclose)
 
 from scipy.signal import upfirdn, firwin, lfilter
@@ -103,7 +103,7 @@ class UpFIRDnCase(object):
         assert_allclose(yr, y)
 
 
-class test_upfirdn(TestCase):
+class TestUpfirdn(object):
 
     def test_valid_input(self):
         assert_raises(ValueError, upfirdn, [1], [1], 1, 0)  # up or down < 1

--- a/scipy/signal/tests/test_waveforms.py
+++ b/scipy/signal/tests/test_waveforms.py
@@ -1,7 +1,7 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import (TestCase, assert_almost_equal, assert_equal,
+from numpy.testing import (assert_almost_equal, assert_equal,
                            assert_, assert_raises, run_module_suite,
                            assert_allclose, assert_array_equal)
 
@@ -46,7 +46,7 @@ def compute_frequency(t, theta):
     return tf, f
 
 
-class TestChirp(TestCase):
+class TestChirp(object):
 
     def test_linear_at_zero(self):
         w = waveforms.chirp(t=0, f0=1.0, f1=2.0, t1=1.0, method='linear')
@@ -221,7 +221,7 @@ class TestChirp(TestCase):
         assert_equal(int_result, float_result, err_msg=err_msg)
 
 
-class TestSweepPoly(TestCase):
+class TestSweepPoly(object):
 
     def test_sweep_poly_quad1(self):
         p = np.poly1d([1.0, 0.0, 1.0])
@@ -289,7 +289,7 @@ class TestSweepPoly(TestCase):
         assert_(abserr < 1e-6)
 
 
-class TestGaussPulse(TestCase):
+class TestGaussPulse(object):
 
     def test_integer_fc(self):
         float_result = waveforms.gausspulse('cutoff', fc=1000.0)
@@ -316,7 +316,7 @@ class TestGaussPulse(TestCase):
         assert_equal(int_result, float_result, err_msg=err_msg)
 
 
-class TestUnitImpulse(TestCase):
+class TestUnitImpulse(object):
 
     def test_no_index(self):
         assert_array_equal(waveforms.unit_impulse(7), [1, 0, 0, 0, 0, 0, 0])

--- a/scipy/signal/tests/test_wavelets.py
+++ b/scipy/signal/tests/test_wavelets.py
@@ -1,14 +1,14 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import TestCase, run_module_suite, assert_equal, \
+from numpy.testing import run_module_suite, assert_equal, \
     assert_array_equal, assert_array_almost_equal, assert_array_less, assert_
 from scipy._lib.six import xrange
 
 from scipy.signal import wavelets
 
 
-class TestWavelets(TestCase):
+class TestWavelets(object):
     def test_qmf(self):
         assert_array_equal(wavelets.qmf([1, 1]), [1, -1])
 

--- a/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
@@ -6,7 +6,7 @@ import threading
 import numpy as np
 from numpy import array, finfo, arange, eye, all, unique, ones, dot, matrix
 import numpy.random as random
-from numpy.testing import (TestCase, run_module_suite,
+from numpy.testing import (run_module_suite,
         assert_array_almost_equal, assert_raises, assert_almost_equal,
         assert_equal, assert_array_equal, assert_, assert_allclose)
 
@@ -35,7 +35,7 @@ def toarray(a):
         return a
 
 
-class TestLinsolve(TestCase):
+class TestLinsolve(object):
     def test_singular(self):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=MatrixRankWarning)
@@ -522,7 +522,7 @@ class TestSplu(object):
         assert_equal(len(oks), 20)
 
 
-class TestSpsolveTriangular(TestCase):
+class TestSpsolveTriangular(object):
 
     def test_singular(self):
         n = 5

--- a/scipy/sparse/linalg/isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/isolve/tests/test_iterative.py
@@ -7,7 +7,7 @@ import warnings
 
 import numpy as np
 
-from numpy.testing import (TestCase, assert_equal, assert_array_equal,
+from numpy.testing import (assert_equal, assert_array_equal,
      assert_, assert_allclose, assert_raises, run_module_suite)
 
 from numpy import zeros, arange, array, abs, max, ones, eye, iscomplexobj
@@ -283,7 +283,7 @@ def _check_reentrancy(solver, is_reentrant):
 
 #------------------------------------------------------------------------------
 
-class TestQMR(TestCase):
+class TestQMR(object):
     def test_leftright_precond(self):
         """Check that QMR works with left and right preconditioners"""
 
@@ -325,7 +325,7 @@ class TestQMR(TestCase):
             assert_normclose(A*x, b, tol=1e-8)
 
 
-class TestGMRES(TestCase):
+class TestGMRES(object):
     def test_callback(self):
 
         def store_residual(r, rvec):

--- a/scipy/sparse/linalg/isolve/tests/test_lgmres.py
+++ b/scipy/sparse/linalg/isolve/tests/test_lgmres.py
@@ -3,7 +3,7 @@
 
 from __future__ import division, print_function, absolute_import
 
-from numpy.testing import TestCase, assert_, assert_allclose, assert_equal, run_module_suite
+from numpy.testing import assert_, assert_allclose, assert_equal, run_module_suite
 
 import numpy as np
 from numpy import zeros, array, allclose
@@ -39,7 +39,7 @@ def do_solve(**kw):
     return x0, count_0
 
 
-class TestLGMRES(TestCase):
+class TestLGMRES(object):
     def test_preconditioner(self):
         # Check that preconditioning works
         pc = splu(Am.tocsc())

--- a/scipy/sparse/linalg/tests/test_expm_multiply.py
+++ b/scipy/sparse/linalg/tests/test_expm_multiply.py
@@ -6,7 +6,7 @@ from __future__ import division, print_function, absolute_import
 import warnings
 
 import numpy as np
-from numpy.testing import (TestCase, run_module_suite, assert_allclose,
+from numpy.testing import (run_module_suite, assert_allclose,
         assert_, assert_equal)
 
 from scipy.sparse import SparseEfficiencyWarning
@@ -20,7 +20,7 @@ def less_than_or_close(a, b):
     return np.allclose(a, b) or (a < b)
 
 
-class TestExpmActionSimple(TestCase):
+class TestExpmActionSimple(object):
     """
     These tests do not consider the case of multiple time steps in one call.
     """
@@ -133,7 +133,7 @@ class TestExpmActionSimple(TestCase):
         assert_allclose(observed, expected)
 
 
-class TestExpmActionInterval(TestCase):
+class TestExpmActionInterval(object):
 
     def test_sparse_expm_multiply_interval(self):
         with warnings.catch_warnings():

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -8,7 +8,7 @@ from itertools import product
 import operator
 import nose
 
-from numpy.testing import TestCase, assert_, assert_equal, \
+from numpy.testing import assert_, assert_equal, \
         assert_raises
 
 import numpy as np
@@ -21,7 +21,7 @@ from scipy.sparse.linalg import interface
 TEST_MATMUL = hasattr(operator, 'matmul')
 
 
-class TestLinearOperator(TestCase):
+class TestLinearOperator(object):
     def setUp(self):
         self.A = np.array([[1,2,3],
                            [4,5,6]])
@@ -163,7 +163,7 @@ class TestLinearOperator(TestCase):
         assert_raises(ValueError, operator.matmul, 2, A)
 
 
-class TestAsLinearOperator(TestCase):
+class TestAsLinearOperator(object):
     def setUp(self):
         self.cases = []
 

--- a/scipy/sparse/linalg/tests/test_matfuncs.py
+++ b/scipy/sparse/linalg/tests/test_matfuncs.py
@@ -86,16 +86,16 @@ class TestExpM(TestCase):
 
     def test_misc_types(self):
         A = expm(np.array([[1]]))
-        yield assert_allclose, expm(((1,),)), A
-        yield assert_allclose, expm([[1]]), A
-        yield assert_allclose, expm(np.matrix([[1]])), A
-        yield assert_allclose, expm(np.array([[1]])), A
-        yield assert_allclose, expm(csc_matrix([[1]])), A
+        assert_allclose(expm(((1,),)), A)
+        assert_allclose(expm([[1]]), A)
+        assert_allclose(expm(np.matrix([[1]])), A)
+        assert_allclose(expm(np.array([[1]])), A)
+        assert_allclose(expm(csc_matrix([[1]])).A, A)
         B = expm(np.array([[1j]]))
-        yield assert_allclose, expm(((1j,),)), B
-        yield assert_allclose, expm([[1j]]), B
-        yield assert_allclose, expm(np.matrix([[1j]])), B
-        yield assert_allclose, expm(csc_matrix([[1j]])), B
+        assert_allclose(expm(((1j,),)), B)
+        assert_allclose(expm([[1j]]), B)
+        assert_allclose(expm(np.matrix([[1j]])), B)
+        assert_allclose(expm(csc_matrix([[1j]])).A, B)
 
     def test_bidiagonal_sparse(self):
         A = csc_matrix([

--- a/scipy/sparse/linalg/tests/test_matfuncs.py
+++ b/scipy/sparse/linalg/tests/test_matfuncs.py
@@ -13,7 +13,7 @@ import warnings
 import numpy as np
 from numpy import array, eye, exp, random
 from numpy.linalg import matrix_power
-from numpy.testing import (TestCase, run_module_suite,
+from numpy.testing import (run_module_suite,
         assert_allclose, assert_, assert_array_almost_equal, assert_equal,
         assert_array_almost_equal_nulp)
 
@@ -71,7 +71,7 @@ def test_onenorm_matrix_power_nnm():
             assert_allclose(observed, expected)
 
 
-class TestExpM(TestCase):
+class TestExpM(object):
     def test_zero_ndarray(self):
         a = array([[0.,0],[0,0]])
         assert_array_almost_equal(expm(a),[[1,0],[0,1]])
@@ -491,7 +491,7 @@ class TestExpM(TestCase):
         assert_allclose(actual, desired)
 
 
-class TestOperators(TestCase):
+class TestOperators(object):
 
     def test_product_operator(self):
         random.seed(1234)

--- a/scipy/sparse/linalg/tests/test_norm.py
+++ b/scipy/sparse/linalg/tests/test_norm.py
@@ -6,14 +6,14 @@ from __future__ import division, print_function, absolute_import
 import numpy as np
 from numpy.linalg import norm as npnorm
 from numpy.testing import (assert_raises, assert_equal, assert_allclose,
-        TestCase, dec)
+        dec)
 
 from scipy._lib._version import NumpyVersion
 import scipy.sparse
 from scipy.sparse.linalg import norm as spnorm
 
 
-class TestNorm(TestCase):
+class TestNorm(object):
     def setUp(self):
         a = np.arange(9) - 4
         b = a.reshape((3, 3))
@@ -68,7 +68,7 @@ class TestNorm(TestCase):
         assert_raises(ValueError, spnorm, m, 'plate_of_shrimp', (0, 1))
 
 
-class TestVsNumpyNorm(TestCase):
+class TestVsNumpyNorm(object):
     _sparse_types = (
             scipy.sparse.bsr_matrix,
             scipy.sparse.coo_matrix,

--- a/scipy/sparse/linalg/tests/test_onenormest.py
+++ b/scipy/sparse/linalg/tests/test_onenormest.py
@@ -5,7 +5,7 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 from numpy.testing import (assert_allclose, assert_equal, assert_,
-        decorators, TestCase, run_module_suite)
+        decorators, run_module_suite)
 import scipy.linalg
 import scipy.sparse.linalg
 from scipy.sparse.linalg._onenormest import _onenormest_core, _algorithm_2_2
@@ -40,7 +40,7 @@ class MatrixProductOperator(scipy.sparse.linalg.LinearOperator):
         return MatrixProductOperator(self.B.T, self.A.T)
 
 
-class TestOnenormest(TestCase):
+class TestOnenormest(object):
 
     @decorators.slow
     @decorators.skipif(True, 'this test is annoyingly slow')
@@ -235,7 +235,7 @@ class TestOnenormest(TestCase):
         assert_allclose(A.dot(v), w, rtol=1e-9)
 
 
-class TestAlgorithm_2_2(TestCase):
+class TestAlgorithm_2_2(object):
 
     def test_randn_inv(self):
         np.random.seed(1234)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -247,8 +247,9 @@ class _TestCommon:
     """test common functionality shared by all sparse formats"""
     math_dtypes = supported_dtypes
 
-    # TODO: Why this decorator is necessary when there is a module level
-    #       suppression, is completely puzzeling to me.
+    # XXX: __init__ method that will be called at test collection time.
+    #      It also requires the extra warning suppression decorator.
+    #      This should be implemented in a different way.
     @sup_sparse_efficiency2
     def __init__(self):
         # Canonical data.

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -4,7 +4,7 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 from numpy import array, matrix
-from numpy.testing import (TestCase, run_module_suite, assert_equal, assert_,
+from numpy.testing import (run_module_suite, assert_equal, assert_,
         assert_array_equal, assert_raises, assert_array_almost_equal_nulp)
 from scipy._lib._numpy_compat import assert_raises_regex
 
@@ -29,7 +29,7 @@ def _sprandn(m, n, density=0.01, format="coo", dtype=None, random_state=None):
                             random_state, data_rvs)
 
 
-class TestConstructUtils(TestCase):
+class TestConstructUtils(object):
     def test_spdiags(self):
         diags1 = array([[1, 2, 3, 4, 5]])
         diags2 = array([[1, 2, 3, 4, 5],

--- a/scipy/sparse/tests/test_extract.py
+++ b/scipy/sparse/tests/test_extract.py
@@ -2,14 +2,14 @@
 
 from __future__ import division, print_function, absolute_import
 
-from numpy.testing import TestCase, assert_equal
+from numpy.testing import assert_equal
 from scipy.sparse import csr_matrix
 
 import numpy as np
 from scipy.sparse import extract
 
 
-class TestExtract(TestCase):
+class TestExtract(object):
     def setUp(self):
         self.cases = [
             csr_matrix([[1,2]]),

--- a/scipy/sparse/tests/test_sparsetools.py
+++ b/scipy/sparse/tests/test_sparsetools.py
@@ -69,15 +69,14 @@ class TestInt32Overflow(object):
     routines used to suffer from int32 wraparounds; here, we try to
     check that the wraparounds don't occur any more.
     """
-
-    def __init__(self):
-        # choose n large enough
-        self.n = 50000
-        assert self.n**2 > np.iinfo(np.int32).max
+    # choose n large enough
+    n = 50000
 
     @dec.skipif(not sys.platform.startswith('linux'), "test requires Linux")
     @dec.skipif(np.dtype(np.intp).itemsize < 8, "test requires 64-bit system")
     def setUp(self):
+        assert self.n**2 > np.iinfo(np.int32).max
+
         check_free_memory(5000)
 
     def tearDown(self):

--- a/scipy/sparse/tests/test_spfuncs.py
+++ b/scipy/sparse/tests/test_spfuncs.py
@@ -1,7 +1,7 @@
 from __future__ import division, print_function, absolute_import
 
 from numpy import array, kron, matrix, diag
-from numpy.testing import TestCase, run_module_suite, assert_, assert_equal
+from numpy.testing import run_module_suite, assert_, assert_equal
 
 from scipy.sparse import spfuncs
 from scipy.sparse import csr_matrix, csc_matrix, bsr_matrix
@@ -9,7 +9,7 @@ from scipy.sparse._sparsetools import csr_scale_rows, csr_scale_columns, \
         bsr_scale_rows, bsr_scale_columns
 
 
-class TestSparseFunctions(TestCase):
+class TestSparseFunctions(object):
     def test_scale_rows_and_cols(self):
         D = matrix([[1,0,0,2,3],
                     [0,4,0,5,0],

--- a/scipy/sparse/tests/test_sputils.py
+++ b/scipy/sparse/tests/test_sputils.py
@@ -3,12 +3,12 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import (TestCase, run_module_suite, assert_equal,
+from numpy.testing import (run_module_suite, assert_equal,
                            assert_raises)
 from scipy.sparse import sputils
 
 
-class TestSparseUtils(TestCase):
+class TestSparseUtils(object):
 
     def test_upcast(self):
         assert_equal(sputils.upcast('intc'), np.intc)

--- a/scipy/spatial/tests/test__procrustes.py
+++ b/scipy/spatial/tests/test__procrustes.py
@@ -1,13 +1,13 @@
 from __future__ import absolute_import, division, print_function
 
 import numpy as np
-from numpy.testing import (TestCase, run_module_suite, assert_allclose,
+from numpy.testing import (run_module_suite, assert_allclose,
                            assert_equal, assert_almost_equal, assert_raises)
 
 from scipy.spatial import procrustes
 
 
-class ProcrustesTests(TestCase):
+class TestProcrustes(object):
     def setUp(self):
         """creates inputs"""
         # an L

--- a/scipy/spatial/tests/test__procrustes.py
+++ b/scipy/spatial/tests/test__procrustes.py
@@ -53,7 +53,7 @@ class TestProcrustes(object):
 
         # at worst, data3 is an 'L' with one point off by .5
         m1, m3, disp13 = procrustes(self.data1, self.data3)
-        #self.assertTrue(disp13 < 0.5 ** 2)
+        #assert_(disp13 < 0.5 ** 2)
 
     def test_procrustes2(self):
         # procrustes disparity should not depend on order of matrices

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -40,7 +40,7 @@ from scipy._lib.six import xrange, u
 
 import numpy as np
 from numpy.linalg import norm
-from numpy.testing import (verbose, TestCase, run_module_suite, assert_,
+from numpy.testing import (verbose, run_module_suite, assert_,
                            assert_raises, assert_array_equal, assert_equal,
                            assert_almost_equal, assert_allclose)
 
@@ -117,7 +117,7 @@ def load_testing_files():
 load_testing_files()
 
 
-class TestCdist(TestCase):
+class TestCdist(object):
 
     def setUp(self):
         self.rnd_eo_names = ['random-float32-data', 'random-int-data',
@@ -319,7 +319,7 @@ class TestCdist(TestCase):
                         _assert_within_tol(y1, y2, eps, verbose > 2)
 
 
-class TestPdist(TestCase):
+class TestPdist(object):
 
     def setUp(self):
         self.rnd_eo_names = ['random-float32-data', 'random-int-data',
@@ -1054,7 +1054,7 @@ def _assert_within_tol(a, b, atol, verbose_=False):
     assert_allclose(a, b, rtol=0, atol=atol)
 
 
-class TestSomeDistanceFunctions(TestCase):
+class TestSomeDistanceFunctions(object):
 
     def setUp(self):
         # 1D arrays
@@ -1186,7 +1186,7 @@ class TestSquareForm(object):
                     assert_equal(A[i, j], 0)
 
 
-class TestNumObsY(TestCase):
+class TestNumObsY(object):
 
     def test_num_obs_y_multi_matrix(self):
         for n in xrange(2, 10):
@@ -1238,7 +1238,7 @@ class TestNumObsY(TestCase):
         return np.random.rand((n * (n - 1)) // 2)
 
 
-class TestNumObsDM(TestCase):
+class TestNumObsDM(object):
 
     def test_num_obs_dm_multi_matrix(self):
         for n in xrange(1, 10):
@@ -1277,7 +1277,7 @@ def is_valid_dm_throw(D):
     return is_valid_dm(D, throw=True)
 
 
-class TestIsValidDM(TestCase):
+class TestIsValidDM(object):
 
     def test_is_valid_dm_improper_shape_1D_E(self):
         D = np.zeros((5,), dtype=np.double)
@@ -1350,7 +1350,7 @@ def is_valid_y_throw(y):
     return is_valid_y(y, throw=True)
 
 
-class TestIsValidY(TestCase):
+class TestIsValidY(object):
     # If test case name ends on "_E" then an exception is expected for the
     # given input, if it ends in "_F" then False is expected for the is_valid_y
     # check.  Otherwise the input is expected to be valid.

--- a/scipy/spatial/tests/test_hausdorff.py
+++ b/scipy/spatial/tests/test_hausdorff.py
@@ -1,13 +1,12 @@
 import numpy as np
-from numpy.testing import (TestCase,
-                           assert_almost_equal,
+from numpy.testing import (assert_almost_equal,
                            assert_array_equal,
                            assert_equal)
 from scipy.spatial.distance import directed_hausdorff
 from scipy.spatial import distance
 from scipy._lib._util import check_random_state
 
-class TestHausdorff(TestCase):
+class TestHausdorff(object):
     # Test various properties of the directed Hausdorff code.
 
     def setUp(self):

--- a/scipy/spatial/tests/test_hausdorff.py
+++ b/scipy/spatial/tests/test_hausdorff.py
@@ -1,7 +1,8 @@
 import numpy as np
 from numpy.testing import (assert_almost_equal,
                            assert_array_equal,
-                           assert_equal)
+                           assert_equal,
+                           assert_)
 from scipy.spatial.distance import directed_hausdorff
 from scipy.spatial import distance
 from scipy._lib._util import check_random_state
@@ -34,7 +35,7 @@ class TestHausdorff(object):
 
         forward = directed_hausdorff(self.path_1, self.path_2)[0]
         reverse = directed_hausdorff(self.path_2, self.path_1)[0]
-        self.assertNotEqual(forward, reverse)
+        assert_(forward != reverse)
 
     def test_brute_force_comparison_forward(self):
         # Ensure that the algorithm for directed_hausdorff gives the

--- a/scipy/spatial/tests/test_spherical_voronoi.py
+++ b/scipy/spatial/tests/test_spherical_voronoi.py
@@ -82,13 +82,13 @@ class TestSphericalVoronoi(object):
         s3 = SphericalVoronoi(self.points, None, center)
         s4 = SphericalVoronoi(self.points, radius, center)
         assert_array_equal(s1.center, np.array([0, 0, 0]))
-        self.assertEqual(s1.radius, 1)
+        assert_equal(s1.radius, 1)
         assert_array_equal(s2.center, np.array([0, 0, 0]))
-        self.assertEqual(s2.radius, 2)
+        assert_equal(s2.radius, 2)
         assert_array_equal(s3.center, center)
-        self.assertEqual(s3.radius, 1)
+        assert_equal(s3.radius, 1)
         assert_array_equal(s4.center, center)
-        self.assertEqual(s4.radius, radius)
+        assert_equal(s4.radius, radius)
 
     def test_vertices_regions_translation_invariance(self):
         sv_origin = SphericalVoronoi(self.points)

--- a/scipy/spatial/tests/test_spherical_voronoi.py
+++ b/scipy/spatial/tests/test_spherical_voronoi.py
@@ -1,8 +1,7 @@
 from __future__ import print_function
 import numpy as np
 import itertools
-from numpy.testing import (TestCase,
-                           assert_equal,
+from numpy.testing import (assert_equal,
                            assert_almost_equal,
                            assert_array_equal,
                            assert_array_almost_equal)
@@ -10,7 +9,7 @@ from scipy.spatial import SphericalVoronoi, distance
 from scipy.spatial import _spherical_voronoi as spherical_voronoi
 
 
-class TestCircumcenters(TestCase):
+class TestCircumcenters(object):
 
     def test_circumcenters(self):
         tetrahedrons = np.array([
@@ -34,7 +33,7 @@ class TestCircumcenters(TestCase):
         assert_array_almost_equal(result, expected)
 
 
-class TestProjectToSphere(TestCase):
+class TestProjectToSphere(object):
 
     def test_unit_sphere(self):
         points = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
@@ -61,7 +60,7 @@ class TestProjectToSphere(TestCase):
         assert_array_almost_equal(translated, projected)
 
 
-class TestSphericalVoronoi(TestCase):
+class TestSphericalVoronoi(object):
 
     def setUp(self):
         self.points = np.array([

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -31,7 +31,7 @@ from numpy import (array, isnan, r_, arange, finfo, pi, sin, cos, tan, exp,
 
 from numpy.testing import (assert_equal, assert_almost_equal,
         assert_array_equal, assert_array_almost_equal, assert_approx_equal,
-        assert_, dec, TestCase, run_module_suite, assert_allclose,
+        assert_, dec, run_module_suite, assert_allclose,
         assert_raises, assert_array_almost_equal_nulp)
 
 from scipy import special
@@ -46,7 +46,7 @@ from scipy._lib._version import NumpyVersion
 import math
 
 
-class TestCephes(TestCase):
+class TestCephes(object):
     def test_airy(self):
         cephes.airy(0)
 
@@ -953,7 +953,7 @@ class TestCephes(TestCase):
         assert_func_equal(cephes.wofz, w, z, rtol=1e-13)
 
 
-class TestAiry(TestCase):
+class TestAiry(object):
     def test_airy(self):
         # This tests the airy function to ensure 8 place accuracy in computation
 
@@ -1063,7 +1063,7 @@ class TestAiry(TestCase):
              -6.7812944460, -7.9401786892, -9.0195833588], rtol=1e-10)
 
 
-class TestAssocLaguerre(TestCase):
+class TestAssocLaguerre(object):
     def test_assoc_laguerre(self):
         a1 = special.genlaguerre(11,1)
         a2 = special.assoc_laguerre(.2,11,1)
@@ -1072,12 +1072,12 @@ class TestAssocLaguerre(TestCase):
         assert_array_almost_equal(a2,a1(1),8)
 
 
-class TestBesselpoly(TestCase):
+class TestBesselpoly(object):
     def test_besselpoly(self):
         pass
 
 
-class TestKelvin(TestCase):
+class TestKelvin(object):
     def test_bei(self):
         mbei = special.bei(2)
         assert_almost_equal(mbei, 0.9722916273066613,5)  # this may not be exact
@@ -1230,7 +1230,7 @@ class TestKelvin(TestCase):
                                                 20.53068]),4)
 
 
-class TestBernoulli(TestCase):
+class TestBernoulli(object):
     def test_bernoulli(self):
         brn = special.bernoulli(5)
         assert_array_almost_equal(brn,array([1.0000,
@@ -1241,7 +1241,7 @@ class TestBernoulli(TestCase):
                                              0.0000]),4)
 
 
-class TestBeta(TestCase):
+class TestBeta(object):
     def test_beta(self):
         bet = special.beta(2,4)
         betg = (special.gamma(2)*special.gamma(4))/special.gamma(6)
@@ -1262,7 +1262,7 @@ class TestBeta(TestCase):
         assert_almost_equal(comp,.5,5)
 
 
-class TestCombinatorics(TestCase):
+class TestCombinatorics(object):
     def test_comb(self):
         assert_array_almost_equal(special.comb([10, 10], [3, 4]), [120., 210.])
         assert_almost_equal(special.comb(10, 3), 120.)
@@ -1308,7 +1308,7 @@ class TestCombinatorics(TestCase):
                 [0., 0., 0., 720.])
 
 
-class TestTrigonometric(TestCase):
+class TestTrigonometric(object):
     def test_cbrt(self):
         cb = special.cbrt(27)
         cbrl = 27**(1.0/3.0)
@@ -1377,7 +1377,7 @@ class TestTrigonometric(TestCase):
         assert_almost_equal(snm1,snmrl1,8)
 
 
-class TestTandg(TestCase):
+class TestTandg(object):
 
     def test_tandg(self):
         tn = special.tandg(30)
@@ -1406,7 +1406,7 @@ class TestTandg(TestCase):
         assert_almost_equal(special.tandg(-315), 1.0, 14)
 
 
-class TestEllip(TestCase):
+class TestEllip(object):
     def test_ellipj_nan(self):
         """Regression test for #912."""
         special.ellipj(0.5, np.nan)
@@ -1541,7 +1541,7 @@ class TestEllip(TestCase):
         assert_array_almost_equal_nulp(f1, 3.3471442287390509 * np.ones_like(f1), 4)
 
 
-class TestErf(TestCase):
+class TestErf(object):
 
     def test_erf(self):
         er = special.erf(.25)
@@ -1663,7 +1663,7 @@ class TestErf(TestCase):
         assert_allclose(special.wofz(vals), expected, rtol=1e-15)
 
 
-class TestEuler(TestCase):
+class TestEuler(object):
     def test_euler(self):
         eu0 = special.euler(0)
         eu1 = special.euler(1)
@@ -1691,7 +1691,7 @@ class TestEuler(TestCase):
         assert_almost_equal(errmax, 0.0, 14)
 
 
-class TestExp(TestCase):
+class TestExp(object):
     def test_exp2(self):
         ex = special.exp2(2)
         exrl = 2**2
@@ -1723,7 +1723,7 @@ class TestExp(TestCase):
         assert_array_almost_equal(ex1,exrl1,8)
 
 
-class TestFactorialFunctions(TestCase):
+class TestFactorialFunctions(object):
     def test_factorial(self):
         # Some known values, float math
         assert_array_almost_equal(special.factorial(0), 1)
@@ -1792,7 +1792,7 @@ class TestFactorialFunctions(TestCase):
         assert_equal(special.factorialk(5, 3, exact=True), 10)
 
 
-class TestFresnel(TestCase):
+class TestFresnel(object):
     def test_fresnel(self):
         frs = array(special.fresnel(.5))
         assert_array_almost_equal(frs,array([0.064732432859999287, 0.49234422587144644]),8)
@@ -1837,7 +1837,7 @@ class TestFresnel(TestCase):
         assert_array_almost_equal(frs,szo,12)
 
 
-class TestGamma(TestCase):
+class TestGamma(object):
     def test_gamma(self):
         gam = special.gamma(5)
         assert_equal(gam,24.0)
@@ -1917,7 +1917,7 @@ class TestGamma(TestCase):
         assert_equal(special.rgamma(-1), 0)
 
 
-class TestHankel(TestCase):
+class TestHankel(object):
 
     def test_negv1(self):
         assert_almost_equal(special.hankel1(-3,2), -special.hankel1(3,2), 14)
@@ -1952,7 +1952,7 @@ class TestHankel(TestCase):
         assert_almost_equal(hank2e,hankrl2e,8)
 
 
-class TestHyper(TestCase):
+class TestHyper(object):
     def test_h1vp(self):
         h1 = special.h1vp(1,.1)
         h1real = (special.jvp(1,.1) + special.yvp(1,.1)*1j)
@@ -2177,7 +2177,7 @@ class TestHyper(TestCase):
                             0.048360918656699191, 12)
 
 
-class TestBessel(TestCase):
+class TestBessel(object):
     def test_itj0y0(self):
         it0 = array(special.itj0y0(.2))
         assert_array_almost_equal(it0,array([0.19933433254006822, -0.34570883800412566]),8)
@@ -2738,7 +2738,7 @@ class TestBessel(TestCase):
         assert_almost_equal(x,y,10)
 
 
-class TestLaguerre(TestCase):
+class TestLaguerre(object):
     def test_laguerre(self):
         lag0 = special.laguerre(0)
         lag1 = special.laguerre(1)
@@ -2766,7 +2766,7 @@ class TestLaguerre(TestCase):
 
 
 # Base polynomials come from Abrahmowitz and Stegan
-class TestLegendre(TestCase):
+class TestLegendre(object):
     def test_legendre(self):
         leg0 = special.legendre(0)
         leg1 = special.legendre(1)
@@ -2782,7 +2782,7 @@ class TestLegendre(TestCase):
         assert_almost_equal(leg5.c, array([63,0,-70,0,15,0])/8.0)
 
 
-class TestLambda(TestCase):
+class TestLambda(object):
     def test_lmbda(self):
         lam = special.lmbda(1,.1)
         lamr = (array([special.jn(0,.1), 2*special.jn(1,.1)/.1]),
@@ -2790,7 +2790,7 @@ class TestLambda(TestCase):
         assert_array_almost_equal(lam,lamr,8)
 
 
-class TestLog1p(TestCase):
+class TestLog1p(object):
     def test_log1p(self):
         l1p = (special.log1p(10), special.log1p(11), special.log1p(12))
         l1prl = (log(11), log(12), log(13))
@@ -2802,7 +2802,7 @@ class TestLog1p(TestCase):
         assert_array_almost_equal(l1pm,l1pmrl,8)
 
 
-class TestLegendreFunctions(TestCase):
+class TestLegendreFunctions(object):
     def test_clpmn(self):
         z = 0.5+0.3j
         clp = special.clpmn(2, 2, z, 3)
@@ -2937,7 +2937,7 @@ class TestLegendreFunctions(TestCase):
                                        array([1.3333, 1.216, -0.8427])),4)
 
 
-class TestMathieu(TestCase):
+class TestMathieu(object):
 
     def test_mathieu_a(self):
         pass
@@ -2951,7 +2951,7 @@ class TestMathieu(TestCase):
         pass
 
 
-class TestFresnelIntegral(TestCase):
+class TestFresnelIntegral(object):
 
     def test_modfresnelp(self):
         pass
@@ -2960,7 +2960,7 @@ class TestFresnelIntegral(TestCase):
         pass
 
 
-class TestOblCvSeq(TestCase):
+class TestOblCvSeq(object):
     def test_obl_cv_seq(self):
         obl = special.obl_cv_seq(0,3,1)
         assert_array_almost_equal(obl,array([-0.348602,
@@ -2969,7 +2969,7 @@ class TestOblCvSeq(TestCase):
                                               11.492120]),5)
 
 
-class TestParabolicCylinder(TestCase):
+class TestParabolicCylinder(object):
     def test_pbdn_seq(self):
         pb = special.pbdn_seq(1,.1)
         assert_array_almost_equal(pb,(array([0.9975,
@@ -3015,7 +3015,7 @@ class TestParabolicCylinder(TestCase):
         assert_tol_equal(p[1], dp, rtol=1e-6, atol=1e-6)
 
 
-class TestPolygamma(TestCase):
+class TestPolygamma(object):
     # from Table 6.2 (pg. 271) of A&S
     def test_polygamma(self):
         poly2 = special.polygamma(2,1)
@@ -3040,7 +3040,7 @@ class TestPolygamma(TestCase):
                             expected)
 
 
-class TestProCvSeq(TestCase):
+class TestProCvSeq(object):
     def test_pro_cv_seq(self):
         prol = special.pro_cv_seq(0,3,1)
         assert_array_almost_equal(prol,array([0.319000,
@@ -3049,13 +3049,13 @@ class TestProCvSeq(TestCase):
                                                12.514462]),5)
 
 
-class TestPsi(TestCase):
+class TestPsi(object):
     def test_psi(self):
         ps = special.psi(1)
         assert_almost_equal(ps,-0.57721566490153287,8)
 
 
-class TestRadian(TestCase):
+class TestRadian(object):
     def test_radian(self):
         rad = special.radian(90,0,0)
         assert_almost_equal(rad,pi/2.0,5)
@@ -3065,7 +3065,7 @@ class TestRadian(TestCase):
         assert_almost_equal(rad1,pi/2+0.0005816135199345904,5)
 
 
-class TestRiccati(TestCase):
+class TestRiccati(object):
     def test_riccati_jn(self):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
@@ -3081,7 +3081,7 @@ class TestRiccati(TestCase):
         assert_array_almost_equal(ricyn,ynrl,8)
 
 
-class TestRound(TestCase):
+class TestRound(object):
     def test_round(self):
         rnd = list(map(int,(special.round(10.1),special.round(10.4),special.round(10.5),special.round(10.6))))
 
@@ -3134,7 +3134,7 @@ def test_sph_harm_ufunc_loop_selection():
     assert_equal(special.sph_harm([0], [0], [0], [0]).dtype, dt)
 
 
-class TestSpherical(TestCase):
+class TestSpherical(object):
     def test_sph_harm(self):
         # see test_sph_harm function
         pass

--- a/scipy/special/tests/test_boxcox.py
+++ b/scipy/special/tests/test_boxcox.py
@@ -12,20 +12,20 @@ def test_boxcox_basic():
 
     # lambda = 0  =>  y = log(x)
     y = boxcox(x, 0)
-    yield assert_almost_equal, y, np.log(x)
+    assert_almost_equal(y, np.log(x))
 
     # lambda = 1  =>  y = x - 1
     y = boxcox(x, 1)
-    yield assert_almost_equal, y, x - 1
+    assert_almost_equal(y, x - 1)
 
     # lambda = 2  =>  y = 0.5*(x**2 - 1)
     y = boxcox(x, 2)
-    yield assert_almost_equal, y, 0.5*(x**2 - 1)
+    assert_almost_equal(y, 0.5*(x**2 - 1))
 
     # x = 0 and lambda > 0  =>  y = -1 / lambda
     lam = np.array([0.5, 1, 2])
     y = boxcox(0, lam)
-    yield assert_almost_equal, y, -1.0 / lam
+    assert_almost_equal(y, -1.0 / lam)
 
 def test_boxcox_underflow():
     x = 1 + 1e-15
@@ -38,12 +38,12 @@ def test_boxcox_nonfinite():
     # x < 0  =>  y = nan
     x = np.array([-1, -1, -0.5])
     y = boxcox(x, [0.5, 2.0, -1.5])
-    yield assert_equal, y, np.array([np.nan, np.nan, np.nan])
+    assert_equal(y, np.array([np.nan, np.nan, np.nan]))
 
     # x = 0 and lambda <= 0  =>  y = -inf
     x = 0
     y = boxcox(x, [-2.5, 0])
-    yield assert_equal, y, np.array([-np.inf, -np.inf])
+    assert_equal(y, np.array([-np.inf, -np.inf]))
 
 
 def test_boxcox1p_basic():
@@ -51,20 +51,20 @@ def test_boxcox1p_basic():
 
     # lambda = 0  =>  y = log(1+x)
     y = boxcox1p(x, 0)
-    yield assert_almost_equal, y, np.log1p(x)
+    assert_almost_equal(y, np.log1p(x))
 
     # lambda = 1  =>  y = x
     y = boxcox1p(x, 1)
-    yield assert_almost_equal, y, x
+    assert_almost_equal(y, x)
 
     # lambda = 2  =>  y = 0.5*((1+x)**2 - 1) = 0.5*x*(2 + x)
     y = boxcox1p(x, 2)
-    yield assert_almost_equal, y, 0.5*x*(2 + x)
+    assert_almost_equal(y, 0.5*x*(2 + x))
 
     # x = -1 and lambda > 0  =>  y = -1 / lambda
     lam = np.array([0.5, 1, 2])
     y = boxcox1p(-1, lam)
-    yield assert_almost_equal, y, -1.0 / lam
+    assert_almost_equal(y, -1.0 / lam)
 
 
 def test_boxcox1p_underflow():
@@ -78,12 +78,12 @@ def test_boxcox1p_nonfinite():
     # x < -1  =>  y = nan
     x = np.array([-2, -2, -1.5])
     y = boxcox1p(x, [0.5, 2.0, -1.5])
-    yield assert_equal, y, np.array([np.nan, np.nan, np.nan])
+    assert_equal(y, np.array([np.nan, np.nan, np.nan]))
 
     # x = -1 and lambda <= 0  =>  y = -inf
     x = -1
     y = boxcox1p(x, [-2.5, 0])
-    yield assert_equal, y, np.array([-np.inf, -np.inf])
+    assert_equal(y, np.array([-np.inf, -np.inf]))
 
 
 def test_inv_boxcox():

--- a/scipy/special/tests/test_logit.py
+++ b/scipy/special/tests/test_logit.py
@@ -1,12 +1,12 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import (TestCase, assert_equal, assert_almost_equal,
+from numpy.testing import (assert_equal, assert_almost_equal,
         assert_allclose)
 from scipy.special import logit, expit
 
 
-class TestLogit(TestCase):
+class TestLogit(object):
     def check_logit_out(self, dtype, expected):
         a = np.linspace(0,1,10)
         a = np.array(a, dtype=dtype)
@@ -47,7 +47,7 @@ class TestLogit(TestCase):
         assert_equal(expected, actual)
 
 
-class TestExpit(TestCase):
+class TestExpit(object):
     def check_expit_out(self, dtype, expected):
         a = np.linspace(-4,4,10)
         a = np.array(a, dtype=dtype)

--- a/scipy/special/tests/test_orthogonal.py
+++ b/scipy/special/tests/test_orthogonal.py
@@ -139,7 +139,7 @@ class TestHermite(TestCase):
         assert_array_almost_equal(H5.c,he5.c,13)
 
 
-class _test_sh_legendre(TestCase):
+class _test_sh_legendre(object):
 
     def test_sh_legendre(self):
         # P*_n(x) = P_n(2x-1)
@@ -164,7 +164,7 @@ class _test_sh_legendre(TestCase):
         assert_array_almost_equal(Ps5.c,pse5.c,12)
 
 
-class _test_sh_chebyt(TestCase):
+class _test_sh_chebyt(object):
 
     def test_sh_chebyt(self):
         # T*_n(x) = T_n(2x-1)
@@ -189,7 +189,7 @@ class _test_sh_chebyt(TestCase):
         assert_array_almost_equal(Ts5.c,tse5.c,12)
 
 
-class _test_sh_chebyu(TestCase):
+class _test_sh_chebyu(object):
 
     def test_sh_chebyu(self):
         # U*_n(x) = U_n(2x-1)
@@ -214,7 +214,7 @@ class _test_sh_chebyu(TestCase):
         assert_array_almost_equal(Us5.c,use5.c,11)
 
 
-class _test_sh_jacobi(TestCase):
+class _test_sh_jacobi(object):
     def test_sh_jacobi(self):
         # G^(p,q)_n(x) = n! gamma(n+p)/gamma(2*n+p) * P^(p-q,q-1)_n(2*x-1)
         conv = lambda n,p: gamma(n+1)*gamma(n+p)/gamma(2*n+p)

--- a/scipy/special/tests/test_orthogonal.py
+++ b/scipy/special/tests/test_orthogonal.py
@@ -2,7 +2,7 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 from numpy import array, sqrt
-from numpy.testing import (TestCase, assert_array_almost_equal, assert_equal,
+from numpy.testing import (assert_array_almost_equal, assert_equal,
                            assert_almost_equal, assert_allclose, assert_raises,
                            run_module_suite)
 
@@ -13,7 +13,7 @@ from scipy.special import gamma
 import scipy.special.orthogonal as orth
 
 
-class TestCheby(TestCase):
+class TestCheby(object):
     def test_chebyc(self):
         C0 = orth.chebyc(0)
         C1 = orth.chebyc(1)
@@ -76,7 +76,7 @@ class TestCheby(TestCase):
         assert_array_almost_equal(U5.c,[32,0,-32,0,6,0],13)
 
 
-class TestGegenbauer(TestCase):
+class TestGegenbauer(object):
 
     def test_gegenbauer(self):
         a = 5*np.random.random() - 0.5
@@ -100,7 +100,7 @@ class TestGegenbauer(TestCase):
                                                0,15*orth.poch(a,3),0])/15.0,11)
 
 
-class TestHermite(TestCase):
+class TestHermite(object):
     def test_hermite(self):
         H0 = orth.hermite(0)
         H1 = orth.hermite(1)
@@ -276,7 +276,7 @@ class TestCall(object):
             np.seterr(**olderr)
 
 
-class TestGenlaguerre(TestCase):
+class TestGenlaguerre(object):
     def test_regression(self):
         assert_equal(orth.genlaguerre(1, 1, monic=False)(0), 2.)
         assert_equal(orth.genlaguerre(1, 1, monic=True)(0), -2.)

--- a/scipy/special/tests/test_spfun_stats.py
+++ b/scipy/special/tests/test_spfun_stats.py
@@ -1,13 +1,13 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import assert_array_equal, TestCase, run_module_suite, \
+from numpy.testing import assert_array_equal, run_module_suite, \
     assert_array_almost_equal_nulp, assert_raises, assert_almost_equal
 
 from scipy.special import gammaln, multigammaln
 
 
-class TestMultiGammaLn(TestCase):
+class TestMultiGammaLn(object):
 
     def test1(self):
         # A test of the identity

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -216,7 +216,7 @@ def test_cont_basic_slow():
         if distname not in distslow:
             continue
 
-        if distname is 'levy_stable':
+        if distname == 'levy_stable':
             continue
 
         yield check, distname, arg
@@ -229,7 +229,7 @@ def test_moments():
             warnings.filterwarnings('ignore',
                                     category=integrate.IntegrationWarning)
 
-            if distname is 'levy_stable':
+            if distname == 'levy_stable':
                 return
 
             try:

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -71,15 +71,11 @@ test_histogram_instance = stats.rv_histogram(_h)
 
 def test_cont_basic():
     # this test skips slow distributions
-    with warnings.catch_warnings():
-        warnings.filterwarnings('ignore',
-                                category=integrate.IntegrationWarning)
-        
-        for distname, arg in distcont[:] + [(test_histogram_instance, tuple())]:
-            if distname in distslow:
-                continue
-            if distname is 'levy_stable':
-                continue
+
+    def check(distname, arg):
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore',
+                                    category=integrate.IntegrationWarning)
             try:
                 distfn = getattr(stats, distname)
             except TypeError:
@@ -92,20 +88,19 @@ def test_cont_basic():
             sv = rvs.var()
             m, v = distfn.stats(*arg)
 
-            yield (check_sample_meanvar_, distfn, arg, m, v, sm, sv, sn,
-                   distname + 'sample mean test')
-            yield check_cdf_ppf, distfn, arg, distname
-            yield check_sf_isf, distfn, arg, distname
-            yield check_pdf, distfn, arg, distname
-            yield check_pdf_logpdf, distfn, arg, distname
-            yield check_cdf_logcdf, distfn, arg, distname
-            yield check_sf_logsf, distfn, arg, distname
+            check_sample_meanvar_(distfn, arg, m, v, sm, sv, sn, distname + 'sample mean test')
+            check_cdf_ppf(distfn, arg, distname)
+            check_sf_isf(distfn, arg, distname)
+            check_pdf(distfn, arg, distname)
+            check_pdf_logpdf(distfn, arg, distname)
+            check_cdf_logcdf(distfn, arg, distname)
+            check_sf_logsf(distfn, arg, distname)
 
             alpha = 0.01
             if distname == 'rv_histogram_instance':
-                yield check_distribution_rvs, distfn.cdf, arg, alpha, rvs
+                check_distribution_rvs(distfn.cdf, arg, alpha, rvs)
             else:
-                yield check_distribution_rvs, distname, arg, alpha, rvs
+                check_distribution_rvs(distname, arg, alpha, rvs)
 
             locscale_defaults = (0, 1)
             meths = [distfn.pdf, distfn.logpdf, distfn.cdf, distfn.logcdf,
@@ -115,28 +110,41 @@ def test_cont_basic():
                       'pareto': 1.5, 'tukeylambda': 0.3,
                       'rv_histogram_instance': 5.0}
             x = spec_x.get(distname, 0.5)
-            yield check_named_args, distfn, x, arg, locscale_defaults, meths
-            yield check_random_state_property, distfn, arg
-            yield check_pickling, distfn, arg
+            check_named_args(distfn, x, arg, locscale_defaults, meths)
+            check_random_state_property(distfn, arg)
+            check_pickling(distfn, arg)
 
             # Entropy
-            skp = npt.dec.skipif
-            yield check_entropy, distfn, arg, distname
+            check_entropy(distfn, arg, distname)
 
             if distfn.numargs == 0:
-                yield check_vecentropy, distfn, arg
+                check_vecentropy(distfn, arg)
+
             if distfn.__class__._entropy != stats.rv_continuous._entropy:
-                yield check_private_entropy, distfn, arg, stats.rv_continuous
+                check_private_entropy(distfn, arg, stats.rv_continuous)
 
-            yield check_edge_support, distfn, arg
+            check_edge_support(distfn, arg)
 
-            yield check_meth_dtype, distfn, arg, meths
-            yield check_ppf_dtype, distfn, arg
-            yield skp(distname in fails_cmplx)(check_cmplx_deriv), distfn, arg
+            check_meth_dtype(distfn, arg, meths)
+            check_ppf_dtype(distfn, arg)
 
-            knf = npt.dec.knownfailureif
-            yield (knf(distname == 'truncnorm')(check_ppf_private), distfn,
-                   arg, distname)
+            if distname not in fails_cmplx:
+                check_cmplx_deriv(distfn, arg)
+
+            if distname != 'truncnorm':
+                check_ppf_private(distfn, arg, distname)
+
+    for distname, arg in distcont[:] + [(test_histogram_instance, tuple())]:
+        if distname in distslow:
+            continue
+
+        if distname == 'levy_stable':
+            continue
+
+        yield check, distname, arg
+
+        if distname == 'truncnorm':
+            yield npt.dec.knownfailureif(True)(check), distname
 
 
 def test_levy_stable_random_state_property():
@@ -149,14 +157,11 @@ def test_levy_stable_random_state_property():
 @npt.dec.slow
 def test_cont_basic_slow():
     # same as above for slow distributions
-    with warnings.catch_warnings():
-        warnings.filterwarnings('ignore',
-                                category=integrate.IntegrationWarning)
-        for distname, arg in distcont[:]:
-            if distname not in distslow:
-                continue
-            if distname is 'levy_stable':
-                continue
+
+    def check(distname, arg):
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore',
+                                    category=integrate.IntegrationWarning)
             distfn = getattr(stats, distname)
             np.random.seed(765456)
             sn = 500
@@ -164,18 +169,17 @@ def test_cont_basic_slow():
             sm = rvs.mean()
             sv = rvs.var()
             m, v = distfn.stats(*arg)
-            yield (check_sample_meanvar_, distfn, arg, m, v, sm, sv, sn,
-                   distname + 'sample mean test')
-            yield check_cdf_ppf, distfn, arg, distname
-            yield check_sf_isf, distfn, arg, distname
-            yield check_pdf, distfn, arg, distname
-            yield check_pdf_logpdf, distfn, arg, distname
-            yield check_cdf_logcdf, distfn, arg, distname
-            yield check_sf_logsf, distfn, arg, distname
-            # yield check_oth, distfn, arg # is still missing
+            check_sample_meanvar_(distfn, arg, m, v, sm, sv, sn, distname + 'sample mean test')
+            check_cdf_ppf(distfn, arg, distname)
+            check_sf_isf(distfn, arg, distname)
+            check_pdf(distfn, arg, distname)
+            check_pdf_logpdf(distfn, arg, distname)
+            check_cdf_logcdf(distfn, arg, distname)
+            check_sf_logsf(distfn, arg, distname)
+            # check_oth(distfn, arg # is still missing)
 
             alpha = 0.01
-            yield check_distribution_rvs, distname, arg, alpha, rvs
+            check_distribution_rvs(distname, arg, alpha, rvs)
 
             locscale_defaults = (0, 1)
             meths = [distfn.pdf, distfn.logpdf, distfn.cdf, distfn.logcdf,
@@ -186,58 +190,79 @@ def test_cont_basic_slow():
                 arg = (1,)
             elif distname == 'ksone':
                 arg = (3,)
-            yield check_named_args, distfn, x, arg, locscale_defaults, meths
-            yield check_random_state_property, distfn, arg
-            yield check_pickling, distfn, arg
+            check_named_args(distfn, x, arg, locscale_defaults, meths)
+            check_random_state_property(distfn, arg)
+            check_pickling(distfn, arg)
 
             # Entropy
-            skp = npt.dec.skipif
-            ks_cond = distname in ['ksone', 'kstwobign']
-            yield skp(ks_cond)(check_entropy), distfn, arg, distname
+            if distname not in ['ksone', 'kstwobign']:
+                check_entropy(distfn, arg, distname)
 
             if distfn.numargs == 0:
-                yield check_vecentropy, distfn, arg
+                check_vecentropy(distfn, arg)
             if (distfn.__class__._entropy != stats.rv_continuous._entropy
                     and distname != 'vonmises'):
-                yield check_private_entropy, distfn, arg, stats.rv_continuous
+                check_private_entropy(distfn, arg, stats.rv_continuous)
 
-            yield check_edge_support, distfn, arg
+            check_edge_support(distfn, arg)
 
-            yield check_meth_dtype, distfn, arg, meths
-            yield check_ppf_dtype, distfn, arg
-            yield skp(distname in fails_cmplx)(check_cmplx_deriv), distfn, arg
+            check_meth_dtype(distfn, arg, meths)
+            check_ppf_dtype(distfn, arg)
+
+            if distname not in fails_cmplx:
+                check_cmplx_deriv(distfn, arg)
+
+    for distname, arg in distcont[:]:
+        if distname not in distslow:
+            continue
+
+        if distname is 'levy_stable':
+            continue
+
+        yield check, distname, arg
 
 
 @npt.dec.slow
 def test_moments():
-    with warnings.catch_warnings():
-        warnings.filterwarnings('ignore',
-                                category=integrate.IntegrationWarning)
-        knf = npt.dec.knownfailureif
-        fail_normalization = set(['vonmises', 'ksone'])
-        fail_higher = set(['vonmises', 'ksone', 'ncf'])
-        for distname, arg in distcont[:] + [(test_histogram_instance, tuple())]:
+    def check(distname, arg, normalization_ok, higher_ok):
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore',
+                                    category=integrate.IntegrationWarning)
+
             if distname is 'levy_stable':
-                continue
+                return
+
             try:
                 distfn = getattr(stats, distname)
             except TypeError:
                 distfn = distname
                 distname = 'rv_histogram_instance'
+
             m, v, s, k = distfn.stats(*arg, moments='mvsk')
-            cond1 = distname in fail_normalization
-            cond2 = distname in fail_higher
+
+            if normalization_ok:
+                check_normalization(distfn, arg, distname)
+
+            if higher_ok:
+                check_mean_expect(distfn, arg, m, distname)
+                check_var_expect(distfn, arg, m, v, distname)
+                check_skew_expect(distfn, arg, m, v, s, distname)
+                check_kurt_expect(distfn, arg, m, v, k, distname)
+
+            check_loc_scale(distfn, arg, m, v, distname)
+            check_moment(distfn, arg, m, v, distname)
+
+    fail_normalization = set(['vonmises', 'ksone'])
+    fail_higher = set(['vonmises', 'ksone', 'ncf'])
+
+    for distname, arg in distcont[:] + [(test_histogram_instance, tuple())]:
+        cond1 = distname not in fail_normalization
+        cond2 = distname not in fail_higher
+        yield check, distname, arg, cond1, cond2
+
+        if not cond1 or not cond2:
             msg = distname + ' fails moments'
-            yield knf(cond1, msg)(check_normalization), distfn, arg, distname
-            yield knf(cond2, msg)(check_mean_expect), distfn, arg, m, distname
-            yield (knf(cond2, msg)(check_var_expect), distfn, arg, m, v,
-                   distname)
-            yield (knf(cond2, msg)(check_skew_expect), distfn, arg, m, v, s,
-                   distname)
-            yield (knf(cond2, msg)(check_kurt_expect), distfn, arg, m, v, k,
-                   distname)
-            yield check_loc_scale, distfn, arg, m, v, distname
-            yield check_moment, distfn, arg, m, v, distname
+            yield npt.dec.knownfailureif(True, msg)(check), distname, arg, True, True
 
 
 def test_rvs_broadcast():

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1329,9 +1329,9 @@ class TestDocstring(object):
     def test_docstrings(self):
         # See ticket #761
         if stats.rayleigh.__doc__ is not None:
-            self.assertTrue("rayleigh" in stats.rayleigh.__doc__.lower())
+            assert_("rayleigh" in stats.rayleigh.__doc__.lower())
         if stats.bernoulli.__doc__ is not None:
-            self.assertTrue("bernoulli" in stats.bernoulli.__doc__.lower())
+            assert_("bernoulli" in stats.bernoulli.__doc__.lower())
 
     def test_no_name_arg(self):
         # If name is not given, construction shouldn't fail.  See #1508.

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -8,7 +8,7 @@ import re
 import sys
 import pickle
 
-from numpy.testing import (TestCase, run_module_suite, assert_equal,
+from numpy.testing import (run_module_suite, assert_equal,
     assert_array_equal, assert_almost_equal, assert_array_almost_equal,
     assert_allclose, assert_, assert_raises, assert_warns, dec)
 from nose import SkipTest
@@ -146,7 +146,7 @@ def test_support():
         yield check_open_support, dist, args
 
 
-class TestRandInt(TestCase):
+class TestRandInt(object):
     def test_rvs(self):
         vals = stats.randint.rvs(5, 30, size=100)
         assert_(numpy.all(vals < 30) & numpy.all(vals >= 5))
@@ -174,7 +174,7 @@ class TestRandInt(TestCase):
         assert_array_almost_equal(vals, out, decimal=12)
 
 
-class TestBinom(TestCase):
+class TestBinom(object):
     def test_rvs(self):
         vals = stats.binom.rvs(10, 0.75, size=(2, 50))
         assert_(numpy.all(vals >= 0) & numpy.all(vals <= 10))
@@ -217,7 +217,7 @@ class TestBinom(TestCase):
             assert_equal(stats.binom(n=2, p=0).std(), 0)
 
 
-class TestBernoulli(TestCase):
+class TestBernoulli(object):
     def test_rvs(self):
         vals = stats.bernoulli.rvs(0.75, size=(2, 50))
         assert_(numpy.all(vals >= 0) & numpy.all(vals <= 1))
@@ -245,7 +245,7 @@ class TestBernoulli(TestCase):
         assert_equal(h, 0.0)
 
 
-class TestBradford(TestCase):
+class TestBradford(object):
     # gh-6216
     def test_cdf_ppf(self):
         c = 0.1
@@ -255,7 +255,7 @@ class TestBradford(TestCase):
         assert_allclose(x, xx)
 
 
-class TestNBinom(TestCase):
+class TestNBinom(object):
     def test_rvs(self):
         vals = stats.nbinom.rvs(10, 0.75, size=(2, 50))
         assert_(numpy.all(vals >= 0))
@@ -276,7 +276,7 @@ class TestNBinom(TestCase):
         assert_equal(val, 0)
 
 
-class TestGeom(TestCase):
+class TestGeom(object):
     def test_rvs(self):
         vals = stats.geom.rvs(0.75, size=(2, 50))
         assert_(numpy.all(vals >= 0))
@@ -322,7 +322,7 @@ class TestGeom(TestCase):
         assert_array_almost_equal(vals, expected)
 
 
-class TestGennorm(TestCase):
+class TestGennorm(object):
     def test_laplace(self):
         # test against Laplace (special case for beta=1)
         points = [1, 2, 3]
@@ -338,7 +338,7 @@ class TestGennorm(TestCase):
         assert_almost_equal(pdf1, pdf2)
 
 
-class TestHalfgennorm(TestCase):
+class TestHalfgennorm(object):
     def test_expon(self):
         # test against exponential (special case for beta=1)
         points = [1, 2, 3]
@@ -361,7 +361,7 @@ class TestHalfgennorm(TestCase):
         assert_almost_equal(pdf1, 2*pdf2)
 
 
-class TestTruncnorm(TestCase):
+class TestTruncnorm(object):
     def test_ppf_ticket1131(self):
         vals = stats.truncnorm.ppf([-0.5, 0, 1e-4, 0.5, 1-1e-4, 1, 2], -1., 1.,
                                    loc=[3]*7, scale=2)
@@ -398,7 +398,7 @@ class TestTruncnorm(TestCase):
         assert_(low < x.min() < x.max() < high)
 
 
-class TestHypergeom(TestCase):
+class TestHypergeom(object):
     def test_rvs(self):
         vals = stats.hypergeom.rvs(20, 10, 3, size=(2, 50))
         assert_(numpy.all(vals >= 0) &
@@ -483,7 +483,7 @@ class TestHypergeom(TestCase):
         assert_almost_equal(result, exspected, decimal=3)
 
 
-class TestLoggamma(TestCase):
+class TestLoggamma(object):
 
     def test_stats(self):
         # The following precomputed values are from the table in section 2.2
@@ -501,7 +501,7 @@ class TestLoggamma(TestCase):
                                       decimal=4)
 
 
-class TestLogistic(TestCase):
+class TestLogistic(object):
     # gh-6226
     def test_cdf_ppf(self):
         x = np.linspace(-20, 20)
@@ -523,7 +523,7 @@ class TestLogistic(TestCase):
         assert_allclose(stats.logistic.isf(p), desired)
 
 
-class TestLogser(TestCase):
+class TestLogser(object):
     def test_rvs(self):
         vals = stats.logser.rvs(0.75, size=(2, 50))
         assert_(numpy.all(vals >= 1))
@@ -560,7 +560,7 @@ class TestLogser(TestCase):
         assert_allclose(m, 1.000000005)
 
 
-class TestPareto(TestCase):
+class TestPareto(object):
     def test_stats(self):
         # Check the stats() method with some simple values. Also check
         # that the calculations do not trigger RuntimeWarnings.
@@ -630,7 +630,7 @@ class TestPareto(TestCase):
         assert_allclose(p, expected)
 
 
-class TestGenpareto(TestCase):
+class TestGenpareto(object):
     def test_ab(self):
         # c >= 0: a, b = [0, inf]
         for c in [1., 0.]:
@@ -731,7 +731,7 @@ class TestGenpareto(TestCase):
         assert_allclose(logp, -1842.0680753952365)
 
 
-class TestPearson3(TestCase):
+class TestPearson3(object):
     def test_rvs(self):
         vals = stats.pearson3.rvs(0.1, size=(2, 50))
         assert_(numpy.shape(vals) == (2, 50))
@@ -764,7 +764,7 @@ class TestPearson3(TestCase):
                                5.06649130e-01, 8.41442111e-01], atol=1e-6)
 
 
-class TestKappa4(TestCase):
+class TestKappa4(object):
     def test_cdf_genpareto(self):
         # h = 1 and k != 0 is generalized Pareto
         x = [0.0, 0.1, 0.2, 0.5]
@@ -827,7 +827,7 @@ class TestKappa4(TestCase):
         stats.kappa4(1, 2)
 
 
-class TestPoisson(TestCase):
+class TestPoisson(object):
 
     def test_pmf_basic(self):
         # Basic case
@@ -867,7 +867,7 @@ class TestPoisson(TestCase):
         assert_allclose(result, expected)
 
 
-class TestZipf(TestCase):
+class TestZipf(object):
     def test_rvs(self):
         vals = stats.zipf.rvs(1.5, size=(2, 50))
         assert_(numpy.all(vals >= 1))
@@ -889,7 +889,7 @@ class TestZipf(TestCase):
         assert_(not np.isfinite([s, k]).all())
 
 
-class TestDLaplace(TestCase):
+class TestDLaplace(object):
     def test_rvs(self):
         vals = stats.dlaplace.rvs(1.5, size=(2, 50))
         assert_(numpy.shape(vals) == (2, 50))
@@ -922,7 +922,7 @@ class TestDLaplace(TestCase):
         assert_allclose((v, k), (4., 3.25))
 
 
-class TestInvGamma(TestCase):
+class TestInvGamma(object):
     def test_invgamma_inf_gh_1866(self):
         # invgamma's moments are only finite for a>n
         # specific numbers checked w/ boost 1.54
@@ -963,7 +963,7 @@ class TestInvGamma(TestCase):
         assert_allclose(x, xx, rtol=1.0)
 
 
-class TestF(TestCase):
+class TestF(object):
     def test_f_moments(self):
         # n-th moment of F distributions is only finite for n < dfd / 2
         m, v, s, k = stats.f.stats(11, 6.5, moments='mvsk')
@@ -989,7 +989,7 @@ def test_rvgeneric_std():
     assert_array_almost_equal(stats.t.std([5, 6]), [1.29099445, 1.22474487])
 
 
-class TestRvDiscrete(TestCase):
+class TestRvDiscrete(object):
     def test_rvs(self):
         states = [-1, 0, 1, 2, 3, 4]
         probability = [0.0, 0.3, 0.4, 0.0, 0.3, 0.0]
@@ -1077,7 +1077,7 @@ class TestRvDiscrete(TestCase):
         assert_raises(ValueError, stats.rv_discrete, **dict(values=(xk, pk)))
 
 
-class TestSkewNorm(TestCase):
+class TestSkewNorm(object):
 
     def test_normal(self):
         # When the skewness is 0 the distribution is normal
@@ -1105,7 +1105,7 @@ class TestSkewNorm(TestCase):
                                    decimal=2)
 
 
-class TestExpon(TestCase):
+class TestExpon(object):
     def test_zero(self):
         assert_equal(stats.expon.pdf(0), 1)
 
@@ -1114,7 +1114,7 @@ class TestExpon(TestCase):
         assert_equal(stats.expon.isf(stats.expon.sf(40)), 40)
 
 
-class TestExponNorm(TestCase):
+class TestExponNorm(object):
     def test_moments(self):
         # Some moment test cases based on non-loc/scaled formula
         def get_moms(lam, sig, mu):
@@ -1148,7 +1148,7 @@ class TestExponNorm(TestCase):
         assert_almost_equal(stats.exponnorm.pdf(+900, 1), 0.0)
 
 
-class TestGenExpon(TestCase):
+class TestGenExpon(object):
     def test_pdf_unity_area(self):
         from scipy.integrate import simps
         # PDF should integrate to one
@@ -1161,14 +1161,14 @@ class TestGenExpon(TestCase):
         assert_(numpy.all((0 <= cdf) & (cdf <= 1)))
 
 
-class TestExponpow(TestCase):
+class TestExponpow(object):
     def test_tail(self):
         assert_almost_equal(stats.exponpow.cdf(1e-10, 2.), 1e-20)
         assert_almost_equal(stats.exponpow.isf(stats.exponpow.sf(5, .8), .8),
                             5)
 
 
-class TestSkellam(TestCase):
+class TestSkellam(object):
     def test_pmf(self):
         # comparison to R
         k = numpy.arange(-10, 15)
@@ -1212,7 +1212,7 @@ class TestSkellam(TestCase):
         assert_almost_equal(stats.skellam.cdf(k, mu1, mu2), skcdfR, decimal=5)
 
 
-class TestLognorm(TestCase):
+class TestLognorm(object):
     def test_pdf(self):
         # Regression test for Ticket #1471: avoid nan with 0/0 situation
         # Also make sure there are no warnings at x=0, cf gh-5202
@@ -1230,7 +1230,7 @@ class TestLognorm(TestCase):
                         stats.norm.logsf(np.log(x2-mu)/sigma))
 
 
-class TestBeta(TestCase):
+class TestBeta(object):
     def test_logpdf(self):
         # Regression test for Ticket #1326: avoid nan with 0*log(0) situation
         logpdf = stats.beta.logpdf(0, 1, 0.5)
@@ -1246,7 +1246,7 @@ class TestBeta(TestCase):
         assert_allclose(b.pdf(x), np.exp(b.logpdf(x)))
 
 
-class TestBetaPrime(TestCase):
+class TestBetaPrime(object):
     def test_logpdf(self):
         alpha, beta = 267, 1472
         x = np.array([0.2, 0.5, 0.6])
@@ -1271,7 +1271,7 @@ class TestBetaPrime(TestCase):
         assert_allclose(cdfs, cdfs_g, atol=0, rtol=2e-12)
 
 
-class TestGamma(TestCase):
+class TestGamma(object):
     def test_pdf(self):
         # a few test cases to compare with R
         pdf = stats.gamma.pdf(90, 394, scale=1./5)
@@ -1287,7 +1287,7 @@ class TestGamma(TestCase):
         assert_almost_equal(logpdf, 0)
 
 
-class TestChi2(TestCase):
+class TestChi2(object):
     # regression tests after precision improvements, ticket:1041, not verified
     def test_precision(self):
         assert_almost_equal(stats.chi2.pdf(1000, 1000), 8.919133934753128e-003,
@@ -1295,7 +1295,7 @@ class TestChi2(TestCase):
         assert_almost_equal(stats.chi2.pdf(100, 100), 0.028162503162596778,
                             decimal=14)
 
-class TestGumbelL(TestCase):
+class TestGumbelL(object):
     # gh-6228
     def test_cdf_ppf(self):
         x = np.linspace(-100, -4)
@@ -1318,14 +1318,14 @@ class TestGumbelL(TestCase):
         assert_allclose(x, xx)
 
 
-class TestArrayArgument(TestCase):  # test for ticket:992
+class TestArrayArgument(object):  # test for ticket:992
     def test_noexception(self):
         rvs = stats.norm.rvs(loc=(np.arange(5)), scale=np.ones(5),
                              size=(10, 5))
         assert_equal(rvs.shape, (10, 5))
 
 
-class TestDocstring(TestCase):
+class TestDocstring(object):
     def test_docstrings(self):
         # See ticket #761
         if stats.rayleigh.__doc__ is not None:
@@ -1339,7 +1339,7 @@ class TestDocstring(TestCase):
         stats.rv_discrete()
 
 
-class TestEntropy(TestCase):
+class TestEntropy(object):
     def test_entropy_positive(self):
         # See ticket #497
         pk = [0.5, 0.2, 0.3]
@@ -1618,7 +1618,7 @@ class TestFitMethod(object):
         assert_raises(TypeError, dist.fit, data, **dct)
 
 
-class TestFrozen(TestCase):
+class TestFrozen(object):
     # Test that a frozen distribution gives the same results as the original
     # object.
     #
@@ -1823,7 +1823,7 @@ class TestFrozen(TestCase):
         assert_allclose(p_val, poisson_val)
 
 
-class TestExpect(TestCase):
+class TestExpect(object):
     # Test for expect method.
     #
     # Uses normal distribution and beta distribution for finite bounds, and
@@ -1979,7 +1979,7 @@ class TestExpect(TestCase):
             assert_allclose(m5, poiss_moment5(mu), rtol=1e-10)
 
 
-class TestNct(TestCase):
+class TestNct(object):
     def test_nc_parameter(self):
         # Parameter values c<=0 were not enabled (gh-2402).
         # For negative values c and for c=0 results of rv.cdf(0) below were nan
@@ -2015,7 +2015,7 @@ class TestNct(TestCase):
         assert_equal(k, np.nan)
 
 
-class TestRice(TestCase):
+class TestRice(object):
     def test_rice_zero_b(self):
         # rice distribution should work with b=0, cf gh-2164
         x = [0.2, 1., 5.]
@@ -2043,7 +2043,7 @@ class TestRice(TestCase):
         assert_equal(rvs(b=3., size=(3, 5)).shape, (3, 5))
 
 
-class TestErlang(TestCase):
+class TestErlang(object):
     def test_erlang_runtimewarning(self):
         # erlang should generate a RuntimeWarning if a non-integer
         # shape parameter is used.
@@ -2064,7 +2064,7 @@ class TestErlang(TestCase):
             assert_allclose(result_erlang, result_gamma, rtol=1e-3)
 
 
-class TestRayleigh(TestCase):
+class TestRayleigh(object):
     # gh-6227
     def test_logpdf(self):
         y = stats.rayleigh.logpdf(50)
@@ -2075,7 +2075,7 @@ class TestRayleigh(TestCase):
         assert_allclose(y, -1250)
 
 
-class TestExponWeib(TestCase):
+class TestExponWeib(object):
 
     def test_pdf_logpdf(self):
         # Regression test for gh-3508.
@@ -2119,7 +2119,7 @@ class TestExponWeib(TestCase):
         assert_allclose(logp, expected)
 
 
-class TestWeibull(TestCase):
+class TestWeibull(object):
 
     def test_logpdf(self):
         # gh-6217
@@ -2211,7 +2211,7 @@ class TestWeibull(TestCase):
         assert_allclose(ls, np.log(-special.expm1(-1/9000000000000000000)))
 
 
-class TestRdist(TestCase):
+class TestRdist(object):
     @dec.slow
     def test_rdist_cdf_gh1285(self):
         # check workaround in rdist._cdf for issue gh-1285.
@@ -2221,7 +2221,7 @@ class TestRdist(TestCase):
                             values, decimal=5)
 
 
-class TestTrapz(TestCase):
+class TestTrapz(object):
     def test_reduces_to_triang(self):
         modes = [0.3, 0.5]
         for mode in modes:
@@ -2704,7 +2704,7 @@ class _distr6_gen(stats.rv_continuous):
         return 42 * a + x
 
 
-class TestSubclassingExplicitShapes(TestCase):
+class TestSubclassingExplicitShapes(object):
     # Construct a distribution w/ explicit shapes parameter and test it.
 
     def test_correct_shapes(self):
@@ -2824,7 +2824,7 @@ class TestSubclassingExplicitShapes(TestCase):
         assert_equal(dist.pdf(0.5), stats.norm.pdf(0.5))
 
 
-class TestSubclassingNoShapes(TestCase):
+class TestSubclassingNoShapes(object):
     # Construct a distribution w/o explicit shapes parameter and test it.
 
     def test_only__pdf(self):
@@ -3037,7 +3037,7 @@ def test_argus_function():
         assert_equal(stats.argus.cdf(1.0, chi=i), 1.0 - stats.argus.sf(1.0, chi=i))
 
 
-class TestHistogram(TestCase):
+class TestHistogram(object):
     def setUp(self):
         # We have 8 bins
         # [1,2), [2,3), [3,4), [4,5), [5,6), [6,7), [7,8), [8,9)

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -8,7 +8,7 @@ import warnings
 
 import numpy as np
 from numpy.random import RandomState
-from numpy.testing import (TestCase, run_module_suite, assert_array_equal,
+from numpy.testing import (run_module_suite, assert_array_equal,
     assert_almost_equal, assert_array_less, assert_array_almost_equal,
     assert_raises, assert_, assert_allclose, assert_equal, dec, assert_warns)
 from scipy._lib._numpy_compat import suppress_warnings
@@ -36,7 +36,7 @@ g9 = [1.002, 0.998, 0.996, 0.995, 0.996, 1.004, 1.004, 0.998, 0.999, 0.991]
 g10 = [0.991, 0.995, 0.984, 0.994, 0.997, 0.997, 0.991, 0.998, 1.004, 0.997]
 
 
-class TestBayes_mvs(TestCase):
+class TestBayes_mvs(object):
     def test_basic(self):
         # Expected values in this test simply taken from the function.  For
         # some checks regarding correctness of implementation, see review in
@@ -67,7 +67,7 @@ class TestBayes_mvs(TestCase):
             check_named_results(i, attributes)
 
 
-class TestMvsdist(TestCase):
+class TestMvsdist(object):
     def test_basic(self):
         data = [6, 9, 12, 7, 8, 8, 13]
         mean, var, std = stats.mvsdist(data)
@@ -100,7 +100,7 @@ class TestMvsdist(TestCase):
             [x.mean() for x in stats.mvsdist([1, 2, 3, 4, 5])]
 
 
-class TestShapiro(TestCase):
+class TestShapiro(object):
     def test_basic(self):
         x1 = [0.11, 7.87, 4.61, 10.14, 7.95, 3.14, 0.46,
               4.43, 0.21, 4.75, 0.71, 1.52, 3.24,
@@ -168,7 +168,7 @@ class TestShapiro(TestCase):
         assert_almost_equal(pw, 1.0)
 
 
-class TestAnderson(TestCase):
+class TestAnderson(object):
     def test_normal(self):
         rs = RandomState(1234567890)
         x1 = rs.standard_exponential(size=50)
@@ -254,7 +254,7 @@ class TestAnderson(TestCase):
         assert_(A2 > crit2[-1])
 
 
-class TestAndersonKSamp(TestCase):
+class TestAndersonKSamp(object):
     def test_example1a(self):
         # Example data from Scholz & Stephens (1987), originally
         # published in Lehmann (1995, Nonparametrics, Statistical
@@ -388,7 +388,7 @@ class TestAndersonKSamp(TestCase):
         check_named_results(res, attributes)
 
 
-class TestAnsari(TestCase):
+class TestAnsari(object):
 
     def test_small(self):
         x = [1, 2, 3, 3, 4]
@@ -432,7 +432,7 @@ class TestAnsari(TestCase):
         check_named_results(res, attributes)
 
 
-class TestBartlett(TestCase):
+class TestBartlett(object):
 
     def test_data(self):
         args = [g1, g2, g3, g4, g5, g6, g7, g8, g9, g10]
@@ -455,7 +455,7 @@ class TestBartlett(TestCase):
         assert_equal((np.nan, np.nan), stats.bartlett(*args))
 
 
-class TestLevene(TestCase):
+class TestLevene(object):
 
     def test_data(self):
         args = [g1, g2, g3, g4, g5, g6, g7, g8, g9, g10]
@@ -518,7 +518,7 @@ class TestLevene(TestCase):
         check_named_results(res, attributes)
 
 
-class TestBinomP(TestCase):
+class TestBinomP(object):
 
     def test_data(self):
         pval = stats.binom_test(100, 250)
@@ -553,7 +553,7 @@ class TestBinomP(TestCase):
         assert_almost_equal(res, 0.0437479701823997)
 
 
-class TestFligner(TestCase):
+class TestFligner(object):
 
     def test_data(self):
         # numbers from R: fligner.test in package stats
@@ -614,7 +614,7 @@ class TestFligner(TestCase):
         assert_equal((np.nan, np.nan), stats.fligner(x, x**2, []))
 
 
-class TestMood(TestCase):
+class TestMood(object):
     def test_mood(self):
         # numbers from R: mood.test in package stats
         x1 = np.arange(5)
@@ -717,7 +717,7 @@ class TestMood(TestCase):
         assert_raises(ValueError, stats.mood, [1], [])
 
 
-class TestProbplot(TestCase):
+class TestProbplot(object):
 
     def test_basic(self):
         np.random.seed(12345)
@@ -832,7 +832,7 @@ def test_wilcoxon_arg_type():
     _ = stats.wilcoxon(arr, zero_method="wilcox")
 
 
-class TestKstat(TestCase):
+class TestKstat(object):
     def test_moments_normal_distribution(self):
         np.random.seed(32149)
         data = np.random.randn(12345)
@@ -865,7 +865,7 @@ class TestKstat(TestCase):
             assert_raises(ValueError, stats.kstat, data, n=n)
 
 
-class TestKstatVar(TestCase):
+class TestKstatVar(object):
     def test_empty_input(self):
         assert_raises(ValueError, stats.kstatvar, [])
 
@@ -882,7 +882,7 @@ class TestKstatVar(TestCase):
         assert_raises(ValueError, stats.kstatvar, data, n=n)
 
 
-class TestPpccPlot(TestCase):
+class TestPpccPlot(object):
     def setUp(self):
         np.random.seed(7654321)
         self.x = stats.loggamma.rvs(5, size=500) + 5
@@ -938,7 +938,7 @@ class TestPpccPlot(TestCase):
         assert_allclose(ppcc, np.zeros(80, dtype=float))
 
 
-class TestPpccMax(TestCase):
+class TestPpccMax(object):
     def test_ppcc_max_bad_arg(self):
         # Raise ValueError when given an invalid distribution.
         data = [1]
@@ -981,7 +981,7 @@ class TestPpccMax(TestCase):
                             -0.71215366521264145, decimal=5)
 
 
-class TestBoxcox_llf(TestCase):
+class TestBoxcox_llf(object):
 
     def test_basic(self):
         np.random.seed(54321)
@@ -1014,7 +1014,7 @@ class TestBoxcox_llf(TestCase):
         assert_(np.isnan(stats.boxcox_llf(1, [])))
 
 
-class TestBoxcox(TestCase):
+class TestBoxcox(object):
 
     def test_fixed_lmbda(self):
         np.random.seed(12345)
@@ -1069,7 +1069,7 @@ class TestBoxcox(TestCase):
         assert_(stats.boxcox([]).shape == (0,))
 
 
-class TestBoxcoxNormmax(TestCase):
+class TestBoxcoxNormmax(object):
     def setUp(self):
         np.random.seed(12345)
         self.x = stats.loggamma.rvs(5, size=50) + 5
@@ -1091,7 +1091,7 @@ class TestBoxcoxNormmax(TestCase):
         assert_allclose(maxlog_all, [1.804465, 1.758101], rtol=1e-6)
 
 
-class TestBoxcoxNormplot(TestCase):
+class TestBoxcoxNormplot(object):
     def setUp(self):
         np.random.seed(7654321)
         self.x = stats.loggamma.rvs(5, size=500) + 5
@@ -1128,7 +1128,7 @@ class TestBoxcoxNormplot(TestCase):
         assert_(stats.boxcox_normplot([], 0, 1).size == 0)
 
 
-class TestCircFuncs(TestCase):
+class TestCircFuncs(object):
     def test_circfuncs(self):
         x = np.array([355, 5, 2, 359, 10, 350])
         M = stats.circmean(x, high=360)
@@ -1297,7 +1297,7 @@ def test_wilcoxon_tie():
     assert_allclose(p, expected_p, rtol=1e-6)
 
 
-class TestMedianTest(TestCase):
+class TestMedianTest(object):
 
     def test_bad_n_samples(self):
         # median_test requires at least two samples.

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -13,14 +13,14 @@ from numpy.ma import masked, nomask
 import scipy.stats.mstats as mstats
 from scipy import stats
 from common_tests import check_named_results
-from numpy.testing import TestCase, run_module_suite
+from numpy.testing import run_module_suite
 from numpy.testing.decorators import skipif
 from numpy.ma.testutils import (assert_equal, assert_almost_equal,
     assert_array_almost_equal, assert_array_almost_equal_nulp, assert_,
     assert_allclose, assert_raises, assert_array_equal)
 
 
-class TestMquantiles(TestCase):
+class TestMquantiles(object):
     def test_mquantiles_limit_keyword(self):
         # Regression test for Trac ticket #867
         data = np.array([[6., 7., 1.],
@@ -41,7 +41,7 @@ class TestMquantiles(TestCase):
         assert_almost_equal(quants, desired)
 
 
-class TestGMean(TestCase):
+class TestGMean(object):
     def test_1D(self):
         a = (1,2,3,4)
         actual = mstats.gmean(a)
@@ -85,7 +85,7 @@ class TestGMean(TestCase):
         assert_array_almost_equal(actual, desired, decimal=14)
 
 
-class TestHMean(TestCase):
+class TestHMean(object):
     def test_1D(self):
         a = (1,2,3,4)
         actual = mstats.hmean(a)
@@ -125,10 +125,7 @@ class TestHMean(TestCase):
         assert_array_almost_equal(actual1, desired, decimal=14)
 
 
-class TestRanking(TestCase):
-    def __init__(self, *args, **kwargs):
-        TestCase.__init__(self, *args, **kwargs)
-
+class TestRanking(object):
     def test_ranking(self):
         x = ma.array([0,1,1,1,2,3,4,5,5,6,])
         assert_almost_equal(mstats.rankdata(x),
@@ -150,7 +147,7 @@ class TestRanking(TestCase):
                            [[1,1,1,1,1], [2,2,2,2,2,]])
 
 
-class TestCorr(TestCase):
+class TestCorr(object):
     def test_pearsonr(self):
         # Tests some computations of Pearson's r
         x = ma.arange(10)
@@ -275,7 +272,7 @@ class TestCorr(TestCase):
         check_named_results(res, attributes, ma=True)
 
 
-class TestTrimming(TestCase):
+class TestTrimming(object):
 
     def test_trim(self):
         a = ma.arange(10)
@@ -350,7 +347,7 @@ class TestTrimming(TestCase):
         assert_equal(winsorized.mask, data.mask)
 
 
-class TestMoments(TestCase):
+class TestMoments(object):
     # Comparison numbers are found using R v.1.5.1
     # note that length(testcase) = 4
     # testmathworks comes from documentation for the
@@ -474,7 +471,7 @@ class TestMoments(TestCase):
         assert_equal(im, cp)
 
 
-class TestPercentile(TestCase):
+class TestPercentile(object):
     def setUp(self):
         self.a1 = [3,4,5,10,-3,-5,6]
         self.a2 = [3,-6,-2,8,7,4,2,1]
@@ -495,7 +492,7 @@ class TestPercentile(TestCase):
         assert_equal(mstats.scoreatpercentile(x,50), [1,1,1])
 
 
-class TestVariability(TestCase):
+class TestVariability(object):
     """  Comparison numbers are found using R v.1.5.1
          note that length(testcase) = 4
     """
@@ -535,7 +532,7 @@ class TestVariability(TestCase):
         assert_almost_equal(desired, y, decimal=12)
 
 
-class TestMisc(TestCase):
+class TestMisc(object):
 
     def test_obrientransform(self):
         args = [[5]*5+[6]*11+[7]*9+[8]*3+[9]*2+[10]*2,
@@ -926,7 +923,7 @@ class TestTtest_1samp():
                                (np.nan, np.nan))
 
 
-class TestCompareWithStats(TestCase):
+class TestCompareWithStats(object):
     """
     Class to compare mstats results with stats results.
 

--- a/scipy/stats/tests/test_mstats_extras.py
+++ b/scipy/stats/tests/test_mstats_extras.py
@@ -15,15 +15,11 @@ import numpy.ma as ma
 import scipy.stats.mstats as ms
 #import scipy.stats.mmorestats as mms
 
-from numpy.testing import TestCase, run_module_suite, assert_equal, \
+from numpy.testing import run_module_suite, assert_equal, \
     assert_almost_equal, assert_
 
 
-class TestMisc(TestCase):
-
-    def __init__(self, *args, **kwargs):
-        TestCase.__init__(self, *args, **kwargs)
-
+class TestMisc(object):
     def test_mjci(self):
         "Tests the Marits-Jarrett estimator"
         data = ma.array([77, 87, 88,114,151,210,219,246,253,262,
@@ -56,11 +52,7 @@ class TestMisc(TestCase):
 #..............................................................................
 
 
-class TestQuantiles(TestCase):
-
-    def __init__(self, *args, **kwargs):
-        TestCase.__init__(self, *args, **kwargs)
-
+class TestQuantiles(object):
     def test_hdquantiles(self):
         data = [0.706560797,0.727229578,0.990399276,0.927065621,0.158953014,
             0.887764025,0.239407086,0.349638551,0.972791145,0.149789972,

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -9,7 +9,7 @@ import pickle
 from numpy.testing import (assert_allclose, assert_almost_equal,
                            assert_array_almost_equal, assert_equal,
                            assert_array_less, assert_raises, assert_,
-                           run_module_suite, TestCase)
+                           run_module_suite)
 
 from test_continuous_basic import check_distribution_rvs
 
@@ -34,7 +34,7 @@ from scipy.integrate import romb
 from common_tests import check_random_state_property
 
 
-class TestMultivariateNormal(TestCase):
+class TestMultivariateNormal(object):
     def test_input_shape(self):
         mu = np.arange(3)
         cov = np.identity(2)
@@ -432,7 +432,7 @@ class TestMultivariateNormal(TestCase):
 
         assert_almost_equal(np.exp(_lnB(alpha)), desired)
 
-class TestMatrixNormal(TestCase):
+class TestMatrixNormal(object):
 
     def test_bad_input(self):
         # Check that bad inputs raise errors
@@ -608,7 +608,7 @@ class TestMatrixNormal(TestCase):
                                                         N*num_cols,num_rows).T)
         assert_allclose(sample_rowcov, U, atol=0.1)
 
-class TestDirichlet(TestCase):
+class TestDirichlet(object):
 
     def test_frozen_dirichlet(self):
         np.random.seed(2846)
@@ -809,7 +809,7 @@ def test_multivariate_normal_dimensions_mismatch():
         assert_equal(str(e)[:len(msg)], msg)
 
 
-class TestWishart(TestCase):
+class TestWishart(object):
     def test_scale_dimensions(self):
         # Test that we can call the Wishart with various scale dimensions
 
@@ -996,7 +996,7 @@ class TestWishart(TestCase):
         alpha = 0.01
         check_distribution_rvs('chi2', args, alpha, rvs)
 
-class TestMultinomial(TestCase):
+class TestMultinomial(object):
     def test_logpmf(self):
         vals1 = multinomial.logpmf((3,4), 7, (0.3, 0.7))
         assert_allclose(vals1, -1.483270127243324, rtol=1e-8)
@@ -1138,7 +1138,7 @@ class TestMultinomial(TestCase):
         assert_allclose(mn_frozen.logpmf(x), multinomial.logpmf(x, n, pvals))
         assert_allclose(mn_frozen.entropy(), multinomial.entropy(n, pvals))
 
-class TestInvwishart(TestCase):
+class TestInvwishart(object):
     def test_frozen(self):
         # Test that the frozen and non-frozen inverse Wishart gives the same
         # answers
@@ -1261,7 +1261,7 @@ class TestInvwishart(TestCase):
         assert_allclose(frozen_iw_rvs, manual_iw_rvs)
 
 
-class TestSpecialOrthoGroup(TestCase):
+class TestSpecialOrthoGroup(object):
     def test_reproducibility(self):
         np.random.seed(514)
         x = special_ortho_group.rvs(3)
@@ -1330,7 +1330,7 @@ class TestSpecialOrthoGroup(TestCase):
         ks_tests = [ks_2samp(proj[p0], proj[p1])[1] for (p0, p1) in pairs]
         assert_array_less([ks_prob]*len(pairs), ks_tests)
 
-class TestOrthoGroup(TestCase):
+class TestOrthoGroup(object):
     def test_reproducibility(self):
         np.random.seed(514)
         x = ortho_group.rvs(3)
@@ -1390,7 +1390,7 @@ class TestOrthoGroup(TestCase):
         ks_tests = [ks_2samp(proj[p0], proj[p1])[1] for (p0, p1) in pairs]
         assert_array_less([ks_prob]*len(pairs), ks_tests)
 
-class TestRandomCorrelation(TestCase):
+class TestRandomCorrelation(object):
     def test_reproducibility(self):
         np.random.seed(514)
         eigs = (.5, .8, 1.2, 1.5)
@@ -1481,7 +1481,7 @@ class TestRandomCorrelation(TestCase):
         assert_allclose(m[0,0], 1)
 
 
-class TestUnitaryGroup(TestCase):
+class TestUnitaryGroup(object):
     def test_reproducibility(self):
         np.random.seed(514)
         x = unitary_group.rvs(3)

--- a/scipy/stats/tests/test_rank.py
+++ b/scipy/stats/tests/test_rank.py
@@ -1,13 +1,13 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import TestCase, run_module_suite, assert_equal, \
+from numpy.testing import run_module_suite, assert_equal, \
     assert_array_equal, dec
 
 from scipy.stats import rankdata, tiecorrect
 
 
-class TestTieCorrect(TestCase):
+class TestTieCorrect(object):
 
     def test_empty(self):
         """An empty array requires no correction, should return 1.0."""
@@ -73,7 +73,7 @@ class TestTieCorrect(TestCase):
         assert_equal(out, 1.0 - k * (ntie**3 - ntie) / float(n**3 - n))
 
 
-class TestRankData(TestCase):
+class TestRankData(object):
 
     def test_empty(self):
         """stats.rankdata([]) should return an empty array."""

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -13,7 +13,7 @@ import sys
 import warnings
 from collections import namedtuple
 
-from numpy.testing import (TestCase, assert_, assert_equal,
+from numpy.testing import (assert_, assert_equal,
                            assert_almost_equal, assert_array_almost_equal,
                            assert_array_equal, assert_approx_equal,
                            assert_raises, run_module_suite, assert_allclose,
@@ -54,7 +54,7 @@ HUGE = array([1e+12,2e+12,3e+12,4e+12,5e+12,6e+12,7e+12,8e+12,9e+12], float)
 TINY = array([1e-12,2e-12,3e-12,4e-12,5e-12,6e-12,7e-12,8e-12,9e-12], float)
 ROUND = array([0.5,1.5,2.5,3.5,4.5,5.5,6.5,7.5,8.5], float)
 
-class TestTrimmedStats(TestCase):
+class TestTrimmedStats(object):
     # TODO: write these tests to handle missing values properly
     dprec = np.finfo(np.float64).precision
 
@@ -136,7 +136,7 @@ class TestTrimmedStats(TestCase):
                             significant=self.dprec)
 
 
-class TestCorrPearsonr(TestCase):
+class TestCorrPearsonr(object):
     """ W.II.D. Compute a correlation matrix on all the variables.
 
         All the correlations, except for ZERO and MISS, shoud be exactly 1.
@@ -273,7 +273,7 @@ class TestCorrPearsonr(TestCase):
         assert_approx_equal(prob, 1.0/3)
 
 
-class TestFisherExact(TestCase):
+class TestFisherExact(object):
     """Some tests to show that fisher_exact() works correctly.
 
     Note that in SciPy 0.9.0 this was not working well for large numbers due to
@@ -403,7 +403,7 @@ class TestFisherExact(TestCase):
         odds, pvalue = stats.fisher_exact([[1, 2], [9, 84419233]])
 
 
-class TestCorrSpearmanr(TestCase):
+class TestCorrSpearmanr(object):
     """ W.II.D. Compute a correlation matrix on all the variables.
 
         All the correlations, except for ZERO and MISS, shoud be exactly 1.
@@ -608,7 +608,7 @@ def test_spearmanr():
     y.append(3.0)
     assert_almost_equal(stats.spearmanr(x, y, nan_policy='omit')[0], 0.998)
 
-class TestCorrSpearmanrTies(TestCase):
+class TestCorrSpearmanrTies(object):
     """Some tests of tie-handling by the spearmanr function."""
 
     def test_tie1(self):
@@ -831,7 +831,7 @@ def test_weightedtau_vs_quadratic():
             np.random.shuffle(rank)
 
 
-class TestFindRepeats(TestCase):
+class TestFindRepeats(object):
 
     def test_basic(self):
         a = [1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 5]
@@ -847,7 +847,7 @@ class TestFindRepeats(TestCase):
             assert_array_equal(counts, [])
 
 
-class TestRegression(TestCase):
+class TestRegression(object):
     def test_linregressBIGX(self):
         # W.II.F.  Regress BIG on X.
         # The constant should be 99999990 and the regression coefficient should be 1.
@@ -1016,7 +1016,7 @@ def test_theilslopes():
     assert_almost_equal(lower, 3.71, decimal=2)
 
 
-class TestHistogram(TestCase):
+class TestHistogram(object):
     # Tests that histogram works as it should, and keeps old behaviour
     #
     # what is untested:
@@ -1185,7 +1185,7 @@ def test_relfreq():
     assert_array_almost_equal(relfreqs, relfreqs2)
 
 
-class TestGMean(TestCase):
+class TestGMean(object):
 
     def test_1D_list(self):
         a = (1,2,3,4)
@@ -1231,7 +1231,7 @@ class TestGMean(TestCase):
         assert_approx_equal(actual, 1e200, significant=13)
 
 
-class TestHMean(TestCase):
+class TestHMean(object):
     def test_1D_list(self):
         a = (1,2,3,4)
         actual = stats.hmean(a)
@@ -1272,7 +1272,7 @@ class TestHMean(TestCase):
         assert_array_almost_equal(actual1, desired1, decimal=14)
 
 
-class TestScoreatpercentile(TestCase):
+class TestScoreatpercentile(object):
     def setUp(self):
         self.a1 = [3, 4, 5, 10, -3, -5, 6]
         self.a2 = [3, -6, -2, 8, 7, 4, 2, 1]
@@ -1426,7 +1426,7 @@ class TestItemfreq(object):
         assert_equal(tuple(v[2, 0]), tuple(bb[2]))
 
 
-class TestMode(TestCase):
+class TestMode(object):
     def test_empty(self):
         vals, counts = stats.mode([])
         assert_equal(vals, np.array([]))
@@ -1538,7 +1538,7 @@ class TestMode(TestCase):
         assert_raises(ValueError, stats.mode, data1, nan_policy='foobar')
 
 
-class TestVariability(TestCase):
+class TestVariability(object):
 
     testcase = [1,2,3,4]
     scalar_testcase = 4.
@@ -1704,7 +1704,7 @@ def _check_warnings(warn_list, expected_type, expected_len):
         assert_(warn_.category is expected_type)
 
 
-class TestIQR(TestCase):
+class TestIQR(object):
 
     def test_basic(self):
         x = np.arange(8) * 0.5
@@ -2041,7 +2041,7 @@ class TestIQR(TestCase):
         assert_raises(ValueError, stats.iqr, x, scale='foobar')
 
 
-class TestMoments(TestCase):
+class TestMoments(object):
     """
         Comparison numbers are found using R v.1.5.1
         note that length(testcase) = 4
@@ -2204,7 +2204,7 @@ class TestMoments(TestCase):
                             stats.moment(self.testcase_moment_accuracy, 42))
 
 
-class TestThreshold(TestCase):
+class TestThreshold(object):
     def test_basic(self):
         a = [-1, 2, 3, 4, 5, -1, -2]
         with suppress_warnings() as sup:
@@ -2218,7 +2218,7 @@ class TestThreshold(TestCase):
                                [0, 2, 3, 4, 0, 0, 0])
 
 
-class TestStudentTest(TestCase):
+class TestStudentTest(object):
     X1 = np.array([-1, 0, 1])
     X2 = np.array([0, 1, 2])
     T1_0 = 0
@@ -3181,7 +3181,7 @@ def test_ttest_1samp_new():
         assert_equal(stats.ttest_1samp(anan, 0), ([0, np.nan], [1, np.nan]))
 
 
-class TestDescribe(TestCase):
+class TestDescribe(object):
     def test_describe_scalar(self):
         with suppress_warnings() as sup, np.errstate(invalid="ignore"):
             sup.filter(RuntimeWarning, "Degrees of freedom <= 0 for slice")
@@ -3339,14 +3339,14 @@ def test_normalitytests():
     assert_raises(ValueError, stats.normaltest, x, nan_policy='foobar')
 
 
-class TestRankSums(TestCase):
+class TestRankSums(object):
     def test_ranksums_result_attributes(self):
         res = stats.ranksums(np.arange(5), np.arange(25))
         attributes = ('statistic', 'pvalue')
         check_named_results(res, attributes)
 
 
-class TestJarqueBera(TestCase):
+class TestJarqueBera(object):
     def test_jarque_bera_stats(self):
         np.random.seed(987654321)
         x = np.random.normal(0, 1, 100000)
@@ -3386,7 +3386,7 @@ def test_kurtosistest_too_few_samples():
     assert_raises(ValueError, stats.kurtosistest, x)
 
 
-class TestMannWhitneyU(TestCase):
+class TestMannWhitneyU(object):
     X = [19.8958398126694, 19.5452691647182, 19.0577309166425, 21.716543054589,
          20.3269502208702, 20.0009273294025, 19.3440043632957, 20.4216806548105,
          19.0649894736528, 18.7808043120398, 19.3680942943298, 19.4848044069953,
@@ -3672,7 +3672,7 @@ class HarMeanTestCase:
         self.do(np.matrix(a), b, axis=1)
 
 
-class TestHarMean(HarMeanTestCase, TestCase):
+class TestHarMean(HarMeanTestCase):
     def do(self, a, b, axis=None, dtype=None):
         x = stats.hmean(a, axis=axis, dtype=dtype)
         assert_almost_equal(b, x)
@@ -3788,7 +3788,7 @@ class GeoMeanTestCase:
             np.seterr(**olderr)
 
 
-class TestGeoMean(GeoMeanTestCase, TestCase):
+class TestGeoMean(GeoMeanTestCase):
     def do(self, a, b, axis=None, dtype=None):
         # Note this doesn't test when axis is not specified
         x = stats.gmean(a, axis=axis, dtype=dtype)
@@ -4040,7 +4040,7 @@ class TestSigamClip(object):
         attributes = ('clipped', 'lower', 'upper')
         check_named_results(res, attributes)
 
-class TestFOneWay(TestCase):
+class TestFOneWay(object):
     def test_trivial(self):
         # A trivial test of stats.f_oneway, with F=0.
         F, p = stats.f_oneway([0,2], [0,2])
@@ -4098,7 +4098,7 @@ class TestFOneWay(TestCase):
                             err_msg='Failing testcase: %s' % test_case)
 
 
-class TestKruskal(TestCase):
+class TestKruskal(object):
     def test_simple(self):
         x = [1]
         y = [2]
@@ -4174,7 +4174,7 @@ class TestKruskal(TestCase):
         assert_raises(ValueError, stats.kruskal, x, x, nan_policy='foobar')
 
 
-class TestCombinePvalues(TestCase):
+class TestCombinePvalues(object):
 
     def test_fisher(self):
         # Example taken from http://en.wikipedia.org/wiki/Fisher's_exact_test#Example

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2283,18 +2283,18 @@ def test_percentileofscore():
     for (kind, result) in [('mean', 35.0),
                            ('strict', 30.0),
                            ('weak', 40.0)]:
-        yield assert_equal, pcos(np.arange(10) + 1,
+        assert_equal(pcos(np.arange(10) + 1,
                                                     4, kind=kind), \
-                                                    result
+                                                    result)
 
     # multiple - 2
     for (kind, result) in [('rank', 45.0),
                            ('strict', 30.0),
                            ('weak', 50.0),
                            ('mean', 40.0)]:
-        yield assert_equal, pcos([1,2,3,4,4,5,6,7,8,9],
+        assert_equal(pcos([1,2,3,4,4,5,6,7,8,9],
                                                     4, kind=kind), \
-                                                    result
+                                                    result)
 
     # multiple - 3
     assert_equal(pcos([1,2,3,4,4,4,5,6,7,8], 4), 50.0)
@@ -2303,60 +2303,60 @@ def test_percentileofscore():
                            ('strict', 30.0),
                            ('weak', 60.0)]:
 
-        yield assert_equal, pcos([1,2,3,4,4,4,5,6,7,8],
+        assert_equal(pcos([1,2,3,4,4,4,5,6,7,8],
                                                     4, kind=kind), \
-                                                    result
+                                                    result)
 
     # missing
     for kind in ('rank', 'mean', 'strict', 'weak'):
-        yield assert_equal, pcos([1,2,3,5,6,7,8,9,10,11],
+        assert_equal(pcos([1,2,3,5,6,7,8,9,10,11],
                                                     4, kind=kind), \
-                                                    30
+                                                    30)
 
     # larger numbers
     for (kind, result) in [('mean', 35.0),
                            ('strict', 30.0),
                            ('weak', 40.0)]:
-        yield assert_equal, \
+        assert_equal(
               pcos([10, 20, 30, 40, 50, 60, 70, 80, 90, 100], 40,
-                   kind=kind), result
+                   kind=kind), result)
 
     for (kind, result) in [('mean', 45.0),
                            ('strict', 30.0),
                            ('weak', 60.0)]:
-        yield assert_equal, \
+        assert_equal(
               pcos([10, 20, 30, 40, 40, 40, 50, 60, 70, 80],
-                   40, kind=kind), result
+                   40, kind=kind), result)
 
     for kind in ('rank', 'mean', 'strict', 'weak'):
-        yield assert_equal, \
+        assert_equal(
               pcos([10, 20, 30, 50, 60, 70, 80, 90, 100, 110],
-                   40, kind=kind), 30.0
+                   40, kind=kind), 30.0)
 
     # boundaries
     for (kind, result) in [('rank', 10.0),
                            ('mean', 5.0),
                            ('strict', 0.0),
                            ('weak', 10.0)]:
-        yield assert_equal, \
+        assert_equal(
               pcos([10, 20, 30, 50, 60, 70, 80, 90, 100, 110],
-                   10, kind=kind), result
+                   10, kind=kind), result)
 
     for (kind, result) in [('rank', 100.0),
                            ('mean', 95.0),
                            ('strict', 90.0),
                            ('weak', 100.0)]:
-        yield assert_equal, \
+        assert_equal(
               pcos([10, 20, 30, 50, 60, 70, 80, 90, 100, 110],
-                   110, kind=kind), result
+                   110, kind=kind), result)
 
     # out of bounds
     for (kind, score, result) in [('rank', 200, 100.0),
                                   ('mean', 200, 100.0),
                                   ('mean', 0, 0.0)]:
-        yield assert_equal, \
+        assert_equal(
               pcos([10, 20, 30, 50, 60, 70, 80, 90, 100, 110],
-                   score, kind=kind), result
+                   score, kind=kind), result)
 
     assert_raises(ValueError, pcos, [1, 2, 3, 3, 4], 3, kind='unrecognized')
 
@@ -3298,19 +3298,19 @@ def test_normalitytests():
     x = np.array((-2,-1,0,1,2,3)*4)**2
     attributes = ('statistic', 'pvalue')
 
-    yield assert_array_almost_equal, stats.normaltest(x), (st_normal, pv_normal)
+    assert_array_almost_equal(stats.normaltest(x), (st_normal, pv_normal))
     check_named_results(stats.normaltest(x), attributes)
-    yield assert_array_almost_equal, stats.skewtest(x), (st_skew, pv_skew)
+    assert_array_almost_equal(stats.skewtest(x), (st_skew, pv_skew))
     check_named_results(stats.skewtest(x), attributes)
-    yield assert_array_almost_equal, stats.kurtosistest(x), (st_kurt, pv_kurt)
+    assert_array_almost_equal(stats.kurtosistest(x), (st_kurt, pv_kurt))
     check_named_results(stats.kurtosistest(x), attributes)
 
     # Test axis=None (equal to axis=0 for 1-D input)
-    yield (assert_array_almost_equal, stats.normaltest(x, axis=None),
+    assert_array_almost_equal(stats.normaltest(x, axis=None),
            (st_normal, pv_normal))
-    yield (assert_array_almost_equal, stats.skewtest(x, axis=None),
+    assert_array_almost_equal(stats.skewtest(x, axis=None),
            (st_skew, pv_skew))
-    yield (assert_array_almost_equal, stats.kurtosistest(x, axis=None),
+    assert_array_almost_equal(stats.kurtosistest(x, axis=None),
            (st_kurt, pv_kurt))
 
     x = np.arange(10.)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2283,18 +2283,14 @@ def test_percentileofscore():
     for (kind, result) in [('mean', 35.0),
                            ('strict', 30.0),
                            ('weak', 40.0)]:
-        assert_equal(pcos(np.arange(10) + 1,
-                                                    4, kind=kind), \
-                                                    result)
+        assert_equal(pcos(np.arange(10) + 1, 4, kind=kind), result)
 
     # multiple - 2
     for (kind, result) in [('rank', 45.0),
                            ('strict', 30.0),
                            ('weak', 50.0),
                            ('mean', 40.0)]:
-        assert_equal(pcos([1,2,3,4,4,5,6,7,8,9],
-                                                    4, kind=kind), \
-                                                    result)
+        assert_equal(pcos([1,2,3,4,4,5,6,7,8,9], 4, kind=kind), result)
 
     # multiple - 3
     assert_equal(pcos([1,2,3,4,4,4,5,6,7,8], 4), 50.0)
@@ -2303,15 +2299,11 @@ def test_percentileofscore():
                            ('strict', 30.0),
                            ('weak', 60.0)]:
 
-        assert_equal(pcos([1,2,3,4,4,4,5,6,7,8],
-                                                    4, kind=kind), \
-                                                    result)
+        assert_equal(pcos([1,2,3,4,4,4,5,6,7,8], 4, kind=kind), result)
 
     # missing
     for kind in ('rank', 'mean', 'strict', 'weak'):
-        assert_equal(pcos([1,2,3,5,6,7,8,9,10,11],
-                                                    4, kind=kind), \
-                                                    30)
+        assert_equal(pcos([1,2,3,5,6,7,8,9,10,11], 4, kind=kind), 30)
 
     # larger numbers
     for (kind, result) in [('mean', 35.0),


### PR DESCRIPTION
Comes on top of gh-7568 (pending review) --- the first four commits are there.

More test janitoring, cleaning up stuff that pytest doesn't like.

- Remove all use of unittests.TestCase. Nose doesn't care about it, but pytest collects them differently. The only thing to watch out here is that the class names should be `Test*` so they'll be collected when they don't inherit from TestCase.

- Replace all use of `self.assert*` with `numpy.testing` methods.

- Remove uses of `__init__` in test classes --- pytest ignores classes that have it defined. Nose runs the `__init__` at some point, but it seems when is not well specified (it comes before setup_module apparently), so probably they shouldn't be used with nose either. There aren't that many of these, and the intent seemed to be the same as for `setup()`.

There's one remaining `Test*.__init__` in `sparse:test_base.py:_TestCommon` --- changing this requires changes in the yield tests, so I'll leave that for later.

NB. this PR doesn't change test count:
Before (456f0ad):
Ran 22314 tests in 1170.538s
OK (KNOWNFAIL=139, SKIP=1439)
After (14088e0):
Ran 22314 tests in 1183.089s
OK (KNOWNFAIL=139, SKIP=1439)