### PR TITLE
TST: Remove ignore warnings filters from sparse, clean up warning suppression

### DIFF
--- a/scipy/sparse/csgraph/tests/test_graph_components.py
+++ b/scipy/sparse/csgraph/tests/test_graph_components.py
@@ -1,34 +1,37 @@
 from __future__ import division, print_function, absolute_import
 
-import warnings
-
 import numpy as np
 from numpy.testing import assert_, assert_equal, run_module_suite
+from scipy._lib._numpy_compat import suppress_warnings
+
 from scipy.sparse import csr_matrix, csgraph
 
 
 def test_cs_graph_components():
     D = np.eye(4, dtype=bool)
 
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore",
-                    message="`cs_graph_components` is deprecated")
-
+    with suppress_warnings() as sup:
+        sup.filter(DeprecationWarning, "`cs_graph_components` is deprecated!")
         n_comp, flag = csgraph.cs_graph_components(csr_matrix(D))
-        assert_(n_comp == 4)
-        assert_equal(flag, [0, 1, 2, 3])
 
-        D[0, 1] = D[1, 0] = 1
+    assert_(n_comp == 4)
+    assert_equal(flag, [0, 1, 2, 3])
 
+    D[0, 1] = D[1, 0] = 1
+
+    with suppress_warnings() as sup:
+        sup.filter(DeprecationWarning, "`cs_graph_components` is deprecated!")
         n_comp, flag = csgraph.cs_graph_components(csr_matrix(D))
-        assert_(n_comp == 3)
-        assert_equal(flag, [0, 0, 1, 2])
+    assert_(n_comp == 3)
+    assert_equal(flag, [0, 0, 1, 2])
 
-        # A pathological case...
-        D[2, 2] = 0
+    # A pathological case...
+    D[2, 2] = 0
+    with suppress_warnings() as sup:
+        sup.filter(DeprecationWarning, "`cs_graph_components` is deprecated!")
         n_comp, flag = csgraph.cs_graph_components(csr_matrix(D))
-        assert_(n_comp == 2)
-        assert_equal(flag, [0, 0, -2, 1])
+    assert_(n_comp == 2)
+    assert_equal(flag, [0, 0, -2, 1])
 
 
 if __name__ == "__main__":

--- a/scipy/sparse/linalg/tests/test_matfuncs.py
+++ b/scipy/sparse/linalg/tests/test_matfuncs.py
@@ -8,14 +8,13 @@ from __future__ import division, print_function, absolute_import
 
 import math
 
-import warnings
-
 import numpy as np
 from numpy import array, eye, exp, random
 from numpy.linalg import matrix_power
 from numpy.testing import (run_module_suite,
         assert_allclose, assert_, assert_array_almost_equal, assert_equal,
         assert_array_almost_equal_nulp)
+from scipy._lib._numpy_compat import suppress_warnings
 
 from scipy.sparse import csc_matrix, SparseEfficiencyWarning
 from scipy.sparse.construct import eye as speye
@@ -130,24 +129,26 @@ class TestExpM(object):
     def test_padecases_dtype_sparse_float(self):
         # float32 and complex64 lead to errors in spsolve/UMFpack
         dtype = np.float64
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=SparseEfficiencyWarning)
-            for scale in [1e-2, 1e-1, 5e-1, 1, 10]:
-                a = scale * speye(3, 3, dtype=dtype, format='csc')
-                e = exp(scale) * eye(3, dtype=dtype)
+        for scale in [1e-2, 1e-1, 5e-1, 1, 10]:
+            a = scale * speye(3, 3, dtype=dtype, format='csc')
+            e = exp(scale) * eye(3, dtype=dtype)
+            with suppress_warnings() as sup:
+                sup.filter(SparseEfficiencyWarning,
+                           "Changing the sparsity structure of a csc_matrix is expensive.")
                 exact_onenorm = _expm(a, use_exact_onenorm=True).toarray()
                 inexact_onenorm = _expm(a, use_exact_onenorm=False).toarray()
-                assert_array_almost_equal_nulp(exact_onenorm, e, nulp=100)
-                assert_array_almost_equal_nulp(inexact_onenorm, e, nulp=100)
+            assert_array_almost_equal_nulp(exact_onenorm, e, nulp=100)
+            assert_array_almost_equal_nulp(inexact_onenorm, e, nulp=100)
 
     def test_padecases_dtype_sparse_complex(self):
         # float32 and complex64 lead to errors in spsolve/UMFpack
         dtype = np.complex128
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=SparseEfficiencyWarning)
-            for scale in [1e-2, 1e-1, 5e-1, 1, 10]:
-                a = scale * speye(3, 3, dtype=dtype, format='csc')
-                e = exp(scale) * eye(3, dtype=dtype)
+        for scale in [1e-2, 1e-1, 5e-1, 1, 10]:
+            a = scale * speye(3, 3, dtype=dtype, format='csc')
+            e = exp(scale) * eye(3, dtype=dtype)
+            with suppress_warnings() as sup:
+                sup.filter(SparseEfficiencyWarning,
+                           "Changing the sparsity structure of a csc_matrix is expensive.")
                 assert_array_almost_equal_nulp(expm(a).toarray(), e, nulp=100)
 
     def test_logm_consistency(self):

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -19,7 +19,6 @@ Run tests if sparse is not installed:
   python tests/test_base.py
 """
 
-import warnings
 import operator
 import contextlib
 
@@ -27,7 +26,7 @@ import numpy as np
 from scipy._lib.six import xrange, zip as izip
 from numpy import (arange, zeros, array, dot, matrix, asmatrix, asarray,
                    vstack, ndarray, transpose, diag, kron, inf, conjugate,
-                   int8, ComplexWarning, power)
+                   int8, ComplexWarning)
 
 import random
 from numpy.testing import (assert_raises, assert_equal, assert_array_equal,
@@ -70,14 +69,6 @@ np.add(_UFuncCheck(), np.array([1]))
 
 # Only test matmul operator (A @ B) when available (Python 3.5+)
 TEST_MATMUL = hasattr(operator, 'matmul')
-
-# Decorators to ignore the commen sparse efficiency (and complex) warnings
-# Two decorators are necessary, due to some nested calls and the inability
-# to enter a context twice.
-sup_sparse_efficiency = suppress_warnings()
-sup_sparse_efficiency.filter(SparseEfficiencyWarning)
-sup_sparse_efficiency2 = suppress_warnings()
-sup_sparse_efficiency2.filter(SparseEfficiencyWarning)
 
 sup_complex = suppress_warnings()
 sup_complex.filter(ComplexWarning)
@@ -692,7 +683,6 @@ class _TestCommon:
         assert_equal(self.spmatrix((40, 16130)).diagonal(), np.zeros(40))
 
     @dec.slow
-    @sup_sparse_efficiency
     def test_setdiag_comprehensive(self):
         def dense_setdiag(a, v, k):
             v = np.asarray(v)
@@ -717,7 +707,9 @@ class _TestCommon:
                     v = np.random.randint(1, 20, size=r)
 
                 dense_setdiag(a, v, k)
-                b.setdiag(v, k)
+                with suppress_warnings() as sup:
+                    sup.filter(SparseEfficiencyWarning, "Changing the sparsity structure of a cs[cr]_matrix is expensive")
+                    b.setdiag(v, k)
 
                 # check that dense_setdiag worked
                 d = np.diag(a, k)
@@ -746,26 +738,28 @@ class _TestCommon:
                     for k2 in np.random.choice(ks, size=min(len(ks), 5)):
                         check_setdiag(a, b, k2)
 
-    @sup_sparse_efficiency
     def test_setdiag(self):
         # simple test cases
         m = self.spmatrix(np.eye(3))
         values = [3, 2, 1]
-        assert_raises(ValueError, m.setdiag, values, k=4)
-        m.setdiag(values)
-        assert_array_equal(m.diagonal(), values)
-        m.setdiag(values, k=1)
-        assert_array_equal(m.A, np.array([[3, 3, 0],
-                                          [0, 2, 2],
-                                          [0, 0, 1]]))
-        m.setdiag(values, k=-2)
-        assert_array_equal(m.A, np.array([[3, 3, 0],
-                                          [0, 2, 2],
-                                          [3, 0, 1]]))
-        m.setdiag((9,), k=2)
-        assert_array_equal(m.A[0,2], 9)
-        m.setdiag((9,), k=-2)
-        assert_array_equal(m.A[2,0], 9)
+        with suppress_warnings() as sup:
+            sup.filter(SparseEfficiencyWarning,
+                       "Changing the sparsity structure of a cs[cr]_matrix is expensive")
+            assert_raises(ValueError, m.setdiag, values, k=4)
+            m.setdiag(values)
+            assert_array_equal(m.diagonal(), values)
+            m.setdiag(values, k=1)
+            assert_array_equal(m.A, np.array([[3, 3, 0],
+                                              [0, 2, 2],
+                                              [0, 0, 1]]))
+            m.setdiag(values, k=-2)
+            assert_array_equal(m.A, np.array([[3, 3, 0],
+                                              [0, 2, 2],
+                                              [3, 0, 1]]))
+            m.setdiag((9,), k=2)
+            assert_array_equal(m.A[0,2], 9)
+            m.setdiag((9,), k=-2)
+            assert_array_equal(m.A[2,0], 9)
 
     def test_nonzero(self):
         A = array([[1, 0, 1],[0, 1, 1],[0, 0, 1]])
@@ -975,26 +969,39 @@ class _TestCommon:
         assert_array_almost_equal(dat_mean, datsp_mean)
         assert_equal(dat_mean.dtype, datsp_mean.dtype)
 
-    @sup_sparse_efficiency
     def test_expm(self):
         M = array([[1, 0, 2], [0, 0, 3], [-4, 5, 6]], float)
         sM = self.spmatrix(M, shape=(3,3), dtype=float)
         Mexp = scipy.linalg.expm(M)
-        sMexp = expm(sM).todense()
-        assert_array_almost_equal((sMexp - Mexp), zeros((3, 3)))
 
         N = array([[3., 0., 1.], [0., 2., 0.], [0., 0., 0.]])
         sN = self.spmatrix(N, shape=(3,3), dtype=float)
         Nexp = scipy.linalg.expm(N)
-        sNexp = expm(sN).todense()
+
+        with suppress_warnings() as sup:
+            sup.filter(SparseEfficiencyWarning, "splu requires CSC matrix format")
+            sup.filter(SparseEfficiencyWarning,
+                       "spsolve is more efficient when sparse b is in the CSC matrix format")
+            sup.filter(SparseEfficiencyWarning,
+                       "spsolve requires A be CSC or CSR matrix format")
+            sMexp = expm(sM).todense()
+            sNexp = expm(sN).todense()
+
+        assert_array_almost_equal((sMexp - Mexp), zeros((3, 3)))
         assert_array_almost_equal((sNexp - Nexp), zeros((3, 3)))
 
-    @sup_sparse_efficiency
     def test_inv(self):
         def check(dtype):
             M = array([[1, 0, 2], [0, 0, 3], [-4, 5, 6]], dtype)
-            sM = self.spmatrix(M, shape=(3,3), dtype=dtype)
-            sMinv = inv(sM)
+            with suppress_warnings() as sup:
+                sup.filter(SparseEfficiencyWarning,
+                           "spsolve requires A be CSC or CSR matrix format")
+                sup.filter(SparseEfficiencyWarning,
+                           "spsolve is more efficient when sparse b is in the CSC matrix format")
+                sup.filter(SparseEfficiencyWarning,
+                           "splu requires CSC matrix format")
+                sM = self.spmatrix(M, shape=(3,3), dtype=dtype)
+                sMinv = inv(sM)
             assert_array_almost_equal(sMinv.dot(sM).todense(), np.eye(3))
         for dtype in [float]:
             yield check, dtype
@@ -1562,7 +1569,7 @@ class _TestCommon:
         assert_array_almost_equal(B.todense(), A.todense() * A.T.todense())
         assert_array_almost_equal(B.todense(), A.todense() * A.todense().T)
 
-        # check dimension mismatch  2x2 times 3x2
+        # check dimension mismatch 2x2 times 3x2
         A = self.spmatrix([[1,2],[3,4]])
         B = self.spmatrix([[1,2],[3,4],[5,6]])
         assert_raises(ValueError, A.__mul__, B)
@@ -1679,7 +1686,6 @@ class _TestCommon:
 
             yield check, dtype
 
-    @sup_sparse_efficiency
     def test_maximum_minimum(self):
         A_dense = np.array([[1, 0, 3], [0, 4, 5], [0, 0, 0]])
         B_dense = np.array([[1, 1, 2], [0, 3, 6], [1, -1, 0]])
@@ -1702,12 +1708,17 @@ class _TestCommon:
             else:
                 raise ValueError()
 
-            max_s = A.maximum(B)
+            with suppress_warnings() as sup:
+                sup.filter(SparseEfficiencyWarning,
+                           "Taking maximum .minimum. with > 0 .< 0. number results to a dense matrix")
+
+                max_s = A.maximum(B)
+                min_s = A.minimum(B)
+
             max_d = np.maximum(todense(A), todense(B))
             assert_array_equal(todense(max_s), max_d)
             assert_equal(max_s.dtype, max_d.dtype)
 
-            min_s = A.minimum(B)
             min_d = np.minimum(todense(A), todense(B))
             assert_array_equal(todense(min_s), min_d)
             assert_equal(min_s.dtype, min_d.dtype)
@@ -2142,17 +2153,19 @@ class _TestGetSet:
         for dtype in supported_dtypes:
             yield check, np.dtype(dtype)
 
-    @sup_sparse_efficiency
     def test_setelement(self):
         def check(dtype):
             A = self.spmatrix((3,4), dtype=dtype)
-            A[0, 0] = dtype.type(0)  # bug 870
-            A[1, 2] = dtype.type(4.0)
-            A[0, 1] = dtype.type(3)
-            A[2, 0] = dtype.type(2.0)
-            A[0,-1] = dtype.type(8)
-            A[-1,-2] = dtype.type(7)
-            A[0, 1] = dtype.type(5)
+            with suppress_warnings() as sup:
+                sup.filter(SparseEfficiencyWarning,
+                           "Changing the sparsity structure of a cs[cr]_matrix is expensive")
+                A[0, 0] = dtype.type(0)  # bug 870
+                A[1, 2] = dtype.type(4.0)
+                A[0, 1] = dtype.type(3)
+                A[2, 0] = dtype.type(2.0)
+                A[0,-1] = dtype.type(8)
+                A[-1,-2] = dtype.type(7)
+                A[0, 1] = dtype.type(5)
 
             if dtype != np.bool_:
                 assert_array_equal(A.todense(),[[0,5,0,8],[0,0,4,0],[2,0,7,0]])
@@ -2171,26 +2184,30 @@ class _TestGetSet:
         for dtype in supported_dtypes:
             yield check, np.dtype(dtype)
 
-    @sup_sparse_efficiency
     def test_negative_index_assignment(self):
         # Regression test for github issue 4428.
 
         def check(dtype):
             A = self.spmatrix((3, 10), dtype=dtype)
-            A[0, -4] = 1
+            with suppress_warnings() as sup:
+                sup.filter(SparseEfficiencyWarning,
+                           "Changing the sparsity structure of a cs[cr]_matrix is expensive")
+                A[0, -4] = 1
             assert_equal(A[0, -4], 1)
 
         for dtype in self.math_dtypes:
             yield check, np.dtype(dtype)
 
-    @sup_sparse_efficiency
     def test_scalar_assign_2(self):
         n, m = (5, 10)
 
         def _test_set(i, j, nitems):
             msg = "%r ; %r ; %r" % (i, j, nitems)
             A = self.spmatrix((n, m))
-            A[i, j] = 1
+            with suppress_warnings() as sup:
+                sup.filter(SparseEfficiencyWarning,
+                           "Changing the sparsity structure of a cs[cr]_matrix is expensive")
+                A[i, j] = 1
             assert_almost_equal(A.sum(), nitems, err_msg=msg)
             assert_almost_equal(A[i, j], 1, err_msg=msg)
 
@@ -2199,19 +2216,20 @@ class _TestGetSet:
                      (array(-1), array(-2))]:
             _test_set(i, j, 1)
 
-    @sup_sparse_efficiency
     def test_index_scalar_assign(self):
         A = self.spmatrix((5, 5))
         B = np.zeros((5, 5))
-        for C in [A, B]:
-            C[0,1] = 1
-            C[3,0] = 4
-            C[3,0] = 9
+        with suppress_warnings() as sup:
+            sup.filter(SparseEfficiencyWarning,
+                       "Changing the sparsity structure of a cs[cr]_matrix is expensive")
+            for C in [A, B]:
+                C[0,1] = 1
+                C[3,0] = 4
+                C[3,0] = 9
         assert_array_equal(A.toarray(), B)
 
 
 class _TestSolve:
-    @sup_sparse_efficiency
     def test_solve(self):
         # Test whether the lu_solve command segfaults, as reported by Nils
         # Wagner for a 64-bit machine, 02 March 2005 (EJS)
@@ -2227,7 +2245,9 @@ class _TestSolve:
             A[i,i+1] = y[i]
             A[i+1,i] = conjugate(y[i])
         A = self.spmatrix(A)
-        x = splu(A).solve(r)
+        with suppress_warnings() as sup:
+            sup.filter(SparseEfficiencyWarning, "splu requires CSC matrix format")
+            x = splu(A).solve(r)
         assert_almost_equal(A*x,r)
 
 
@@ -2435,26 +2455,30 @@ class _TestSlicing:
 
 
 class _TestSlicingAssign:
-    @sup_sparse_efficiency
     def test_slice_scalar_assign(self):
         A = self.spmatrix((5, 5))
         B = np.zeros((5, 5))
-        for C in [A, B]:
-            C[0:1,1] = 1
-            C[3:0,0] = 4
-            C[3:4,0] = 9
-            C[0,4:] = 1
-            C[3::-1,4:] = 9
+        with suppress_warnings() as sup:
+            sup.filter(SparseEfficiencyWarning,
+                       "Changing the sparsity structure of a cs[cr]_matrix is expensive")
+            for C in [A, B]:
+                C[0:1,1] = 1
+                C[3:0,0] = 4
+                C[3:4,0] = 9
+                C[0,4:] = 1
+                C[3::-1,4:] = 9
         assert_array_equal(A.toarray(), B)
 
-    @sup_sparse_efficiency
     def test_slice_assign_2(self):
         n, m = (5, 10)
 
         def _test_set(i, j):
             msg = "i=%r; j=%r" % (i, j)
             A = self.spmatrix((n, m))
-            A[i, j] = 1
+            with suppress_warnings() as sup:
+                sup.filter(SparseEfficiencyWarning,
+                           "Changing the sparsity structure of a cs[cr]_matrix is expensive")
+                A[i, j] = 1
             B = np.zeros((n, m))
             B[i, j] = 1
             assert_array_almost_equal(A.todense(), B, err_msg=msg)
@@ -2463,87 +2487,93 @@ class _TestSlicingAssign:
                      (array(2), slice(5, -2))]:
             _test_set(i, j)
 
-    @sup_sparse_efficiency
     def test_self_self_assignment(self):
         # Tests whether a row of one lil_matrix can be assigned to
         # another.
         B = self.spmatrix((4,3))
-        B[0,0] = 2
-        B[1,2] = 7
-        B[2,1] = 3
-        B[3,0] = 10
+        with suppress_warnings() as sup:
+            sup.filter(SparseEfficiencyWarning,
+                       "Changing the sparsity structure of a cs[cr]_matrix is expensive")
+            B[0,0] = 2
+            B[1,2] = 7
+            B[2,1] = 3
+            B[3,0] = 10
 
-        A = B / 10
-        B[0,:] = A[0,:]
-        assert_array_equal(A[0,:].A, B[0,:].A)
+            A = B / 10
+            B[0,:] = A[0,:]
+            assert_array_equal(A[0,:].A, B[0,:].A)
 
-        A = B / 10
-        B[:,:] = A[:1,:1]
-        assert_array_equal(np.zeros((4,3)) + A[0,0], B.A)
+            A = B / 10
+            B[:,:] = A[:1,:1]
+            assert_array_equal(np.zeros((4,3)) + A[0,0], B.A)
 
-        A = B / 10
-        B[:-1,0] = A[0,:].T
-        assert_array_equal(A[0,:].A.T, B[:-1,0].A)
+            A = B / 10
+            B[:-1,0] = A[0,:].T
+            assert_array_equal(A[0,:].A.T, B[:-1,0].A)
 
-    @sup_sparse_efficiency
     def test_slice_assignment(self):
         B = self.spmatrix((4,3))
-        B[0,0] = 5
-        B[1,2] = 3
-        B[2,1] = 7
-
         expected = array([[10,0,0],
                           [0,0,6],
                           [0,14,0],
                           [0,0,0]])
-
-        B[:,:] = B+B
-        assert_array_equal(B.todense(),expected)
-
         block = [[1,0],[0,4]]
-        B[:2,:2] = csc_matrix(array(block))
-        assert_array_equal(B.todense()[:2,:2],block)
 
-    @sup_sparse_efficiency
+        with suppress_warnings() as sup:
+            sup.filter(SparseEfficiencyWarning,
+                       "Changing the sparsity structure of a cs[cr]_matrix is expensive")
+            B[0,0] = 5
+            B[1,2] = 3
+            B[2,1] = 7
+            B[:,:] = B+B
+            assert_array_equal(B.todense(),expected)
+
+            B[:2,:2] = csc_matrix(array(block))
+            assert_array_equal(B.todense()[:2,:2],block)
+
     def test_sparsity_modifying_assignment(self):
         B = self.spmatrix((4,3))
-        B[0,0] = 5
-        B[1,2] = 3
-        B[2,1] = 7
-        B[3,0] = 10
+        with suppress_warnings() as sup:
+            sup.filter(SparseEfficiencyWarning,
+                       "Changing the sparsity structure of a cs[cr]_matrix is expensive")
+            B[0,0] = 5
+            B[1,2] = 3
+            B[2,1] = 7
+            B[3,0] = 10
+            B[:3] = csr_matrix(np.eye(3))
 
         expected = array([[1,0,0],[0,1,0],[0,0,1],[10,0,0]])
-        B[:3] = csr_matrix(np.eye(3))
         assert_array_equal(B.toarray(), expected)
 
-    @sup_sparse_efficiency
     def test_set_slice(self):
         A = self.spmatrix((5,10))
         B = matrix(zeros((5,10), float))
-
         s_ = np.s_
         slices = [s_[:2], s_[1:2], s_[3:], s_[3::2],
                   s_[8:3:-1], s_[4::-2], s_[:5:-1],
                   0, 1, s_[:], s_[1:5], -1, -2, -5,
                   array(-1), np.int8(-3)]
 
-        for j, a in enumerate(slices):
-            A[a] = j
-            B[a] = j
-            assert_array_equal(A.todense(), B, repr(a))
+        with suppress_warnings() as sup:
+            sup.filter(SparseEfficiencyWarning,
+                       "Changing the sparsity structure of a cs[cr]_matrix is expensive")
+            for j, a in enumerate(slices):
+                A[a] = j
+                B[a] = j
+                assert_array_equal(A.todense(), B, repr(a))
 
-        for i, a in enumerate(slices):
-            for j, b in enumerate(slices):
-                A[a,b] = 10*i + 1000*(j+1)
-                B[a,b] = 10*i + 1000*(j+1)
-                assert_array_equal(A.todense(), B, repr((a, b)))
+            for i, a in enumerate(slices):
+                for j, b in enumerate(slices):
+                    A[a,b] = 10*i + 1000*(j+1)
+                    B[a,b] = 10*i + 1000*(j+1)
+                    assert_array_equal(A.todense(), B, repr((a, b)))
 
-        A[0, 1:10:2] = xrange(1,10,2)
-        B[0, 1:10:2] = xrange(1,10,2)
-        assert_array_equal(A.todense(), B)
-        A[1:5:2,0] = np.array(range(1,5,2))[:,None]
-        B[1:5:2,0] = np.array(range(1,5,2))[:,None]
-        assert_array_equal(A.todense(), B)
+            A[0, 1:10:2] = xrange(1,10,2)
+            B[0, 1:10:2] = xrange(1,10,2)
+            assert_array_equal(A.todense(), B)
+            A[1:5:2,0] = np.array(range(1,5,2))[:,None]
+            B[1:5:2,0] = np.array(range(1,5,2))[:,None]
+            assert_array_equal(A.todense(), B)
 
         # The next commands should raise exceptions
         assert_raises(ValueError, A.__setitem__, (0, 0), list(range(100)))
@@ -2774,16 +2804,18 @@ class _TestFancyIndexingAssign:
         assert_raises((IndexError, ValueError, TypeError), A.__setitem__, "foo", 2)
         assert_raises((IndexError, ValueError, TypeError), A.__setitem__, (2, "foo"), 5)
 
-    @sup_sparse_efficiency
     def test_fancy_indexing_set(self):
         n, m = (5, 10)
 
         def _test_set_slice(i, j):
             A = self.spmatrix((n, m))
-            with check_remains_sorted(A):
-                A[i, j] = 1
             B = asmatrix(np.zeros((n, m)))
-            B[i, j] = 1
+            with suppress_warnings() as sup:
+                sup.filter(SparseEfficiencyWarning,
+                           "Changing the sparsity structure of a cs[cr]_matrix is expensive")
+                B[i, j] = 1
+                with check_remains_sorted(A):
+                    A[i, j] = 1
             assert_array_almost_equal(A.todense(), B)
         # [1:2,1:2]
         for i, j in [((2, 3, 4), slice(None, 10, 4)),
@@ -2793,21 +2825,22 @@ class _TestFancyIndexingAssign:
         for i, j in [(np.arange(3), np.arange(3)), ((0, 3, 4), (1, 2, 4))]:
             _test_set_slice(i, j)
 
-    @sup_sparse_efficiency
     def test_fancy_assignment_dtypes(self):
         def check(dtype):
             A = self.spmatrix((5, 5), dtype=dtype)
-            A[[0,1],[0,1]] = dtype.type(1)
-            assert_equal(A.sum(), dtype.type(1)*2)
-            A[0:2,0:2] = dtype.type(1.0)
-            assert_equal(A.sum(), dtype.type(1)*4)
-            A[2,2] = dtype.type(1.0)
-            assert_equal(A.sum(), dtype.type(1)*4 + dtype.type(1))
+            with suppress_warnings() as sup:
+                sup.filter(SparseEfficiencyWarning,
+                           "Changing the sparsity structure of a cs[cr]_matrix is expensive")
+                A[[0,1],[0,1]] = dtype.type(1)
+                assert_equal(A.sum(), dtype.type(1)*2)
+                A[0:2,0:2] = dtype.type(1.0)
+                assert_equal(A.sum(), dtype.type(1)*4)
+                A[2,2] = dtype.type(1.0)
+                assert_equal(A.sum(), dtype.type(1)*4 + dtype.type(1))
 
         for dtype in supported_dtypes:
             yield check, np.dtype(dtype)
 
-    @sup_sparse_efficiency
     def test_sequence_assignment(self):
         A = self.spmatrix((4,3))
         B = self.spmatrix(eye(3,4))
@@ -2816,40 +2849,43 @@ class _TestFancyIndexingAssign:
         i1 = (0,1,2)
         i2 = array(i0)
 
-        with check_remains_sorted(A):
-            A[0,i0] = B[i0,0].T
-            A[1,i1] = B[i1,1].T
-            A[2,i2] = B[i2,2].T
-        assert_array_equal(A.todense(),B.T.todense())
+        with suppress_warnings() as sup:
+            sup.filter(SparseEfficiencyWarning,
+                       "Changing the sparsity structure of a cs[cr]_matrix is expensive")
+            with check_remains_sorted(A):
+                A[0,i0] = B[i0,0].T
+                A[1,i1] = B[i1,1].T
+                A[2,i2] = B[i2,2].T
+            assert_array_equal(A.todense(),B.T.todense())
 
-        # column slice
-        A = self.spmatrix((2,3))
-        with check_remains_sorted(A):
-            A[1,1:3] = [10,20]
-        assert_array_equal(A.todense(), [[0,0,0],[0,10,20]])
+            # column slice
+            A = self.spmatrix((2,3))
+            with check_remains_sorted(A):
+                A[1,1:3] = [10,20]
+            assert_array_equal(A.todense(), [[0,0,0],[0,10,20]])
 
-        # row slice
-        A = self.spmatrix((3,2))
-        with check_remains_sorted(A):
-            A[1:3,1] = [[10],[20]]
-        assert_array_equal(A.todense(), [[0,0],[0,10],[0,20]])
+            # row slice
+            A = self.spmatrix((3,2))
+            with check_remains_sorted(A):
+                A[1:3,1] = [[10],[20]]
+            assert_array_equal(A.todense(), [[0,0],[0,10],[0,20]])
 
-        # both slices
-        A = self.spmatrix((3,3))
-        B = asmatrix(np.zeros((3,3)))
-        with check_remains_sorted(A):
-            for C in [A, B]:
-                C[[0,1,2], [0,1,2]] = [4,5,6]
-        assert_array_equal(A.toarray(), B)
+            # both slices
+            A = self.spmatrix((3,3))
+            B = asmatrix(np.zeros((3,3)))
+            with check_remains_sorted(A):
+                for C in [A, B]:
+                    C[[0,1,2], [0,1,2]] = [4,5,6]
+            assert_array_equal(A.toarray(), B)
 
-        # both slices (2)
-        A = self.spmatrix((4, 3))
-        with check_remains_sorted(A):
-            A[(1, 2, 3), (0, 1, 2)] = [1, 2, 3]
-        assert_almost_equal(A.sum(), 6)
-        B = asmatrix(np.zeros((4, 3)))
-        B[(1, 2, 3), (0, 1, 2)] = [1, 2, 3]
-        assert_array_equal(A.todense(), B)
+            # both slices (2)
+            A = self.spmatrix((4, 3))
+            with check_remains_sorted(A):
+                A[(1, 2, 3), (0, 1, 2)] = [1, 2, 3]
+            assert_almost_equal(A.sum(), 6)
+            B = asmatrix(np.zeros((4, 3)))
+            B[(1, 2, 3), (0, 1, 2)] = [1, 2, 3]
+            assert_array_equal(A.todense(), B)
 
     def test_fancy_assign_empty(self):
         B = asmatrix(arange(50).reshape(5,10))
@@ -2944,13 +2980,14 @@ class _TestFancyMultidimAssign:
         assert_raises(IndexError, S.__setitem__, (I_bad,J), C)
         assert_raises(IndexError, S.__setitem__, (I,J_bad), C)
 
-    @sup_sparse_efficiency
     def test_fancy_indexing_multidim_set(self):
         n, m = (5, 10)
 
         def _test_set_slice(i, j):
             A = self.spmatrix((n, m))
-            with check_remains_sorted(A):
+            with check_remains_sorted(A), suppress_warnings() as sup:
+                sup.filter(SparseEfficiencyWarning,
+                           "Changing the sparsity structure of a cs[cr]_matrix is expensive")
                 A[i, j] = 1
             B = asmatrix(np.zeros((n, m)))
             B[i, j] = 1
@@ -3371,7 +3408,12 @@ def sparse_test_class(getset=True, slicing=True, slicing_assign=True,
 #------------------------------------------------------------------------------
 
 class TestCSR(sparse_test_class()):
-    spmatrix = csr_matrix
+    @classmethod
+    def spmatrix(cls, *args, **kwargs):
+        with suppress_warnings() as sup:
+            sup.filter(SparseEfficiencyWarning,
+                       "Changing the sparsity structure of a csr_matrix is expensive")
+            return csr_matrix(*args, **kwargs)
     math_dtypes = [np.bool_, np.int_, np.float_, np.complex_]
 
     def test_constructor1(self):
@@ -3589,7 +3631,12 @@ class TestCSR(sparse_test_class()):
 
 
 class TestCSC(sparse_test_class()):
-    spmatrix = csc_matrix
+    @classmethod
+    def spmatrix(cls, *args, **kwargs):
+        with suppress_warnings() as sup:
+            sup.filter(SparseEfficiencyWarning,
+                       "Changing the sparsity structure of a csc_matrix is expensive")
+            return csc_matrix(*args, **kwargs)
     math_dtypes = [np.bool_, np.int_, np.float_, np.complex_]
 
     def test_constructor1(self):
@@ -4261,7 +4308,6 @@ def _same_sum_duplicate(data, *inds, **kwargs):
 
 
 class _NonCanonicalMixin(object):
-    @sup_sparse_efficiency2
     def spmatrix(self, D, sorted_indices=False, **kwargs):
         """Replace D with a non-canonical equivalent: containing
         duplicate elements and explicit zeros"""
@@ -4272,9 +4318,10 @@ class _NonCanonicalMixin(object):
         has_zeros = (zero_pos[0].size > 0)
         if has_zeros:
             k = zero_pos[0].size//2
-            M = self._insert_explicit_zero(M,
-                                           zero_pos[0][k],
-                                           zero_pos[1][k])
+            with suppress_warnings() as sup:
+                sup.filter(SparseEfficiencyWarning,
+                           "Changing the sparsity structure of a cs[cr]_matrix is expensive")
+                M = self._insert_explicit_zero(M, zero_pos[0][k], zero_pos[1][k])
 
         arg1 = self._arg1_for_noncanonical(M, sorted_indices)
         if 'shape' not in kwargs:
@@ -4335,22 +4382,20 @@ class _NonCanonicalCompressedMixin(_NonCanonicalMixin):
 class _NonCanonicalCSMixin(_NonCanonicalCompressedMixin):
     def test_getelement(self):
         def check(dtype, sorted_indices):
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore", category=SparseEfficiencyWarning)
-                D = array([[1,0,0],
-                           [4,3,0],
-                           [0,2,0],
-                           [0,0,0]], dtype=dtype)
-                A = self.spmatrix(D, sorted_indices=sorted_indices)
+            D = array([[1,0,0],
+                       [4,3,0],
+                       [0,2,0],
+                       [0,0,0]], dtype=dtype)
+            A = self.spmatrix(D, sorted_indices=sorted_indices)
 
-                M,N = D.shape
+            M,N = D.shape
 
-                for i in range(-M, M):
-                    for j in range(-N, N):
-                        assert_equal(A[i,j], D[i,j])
+            for i in range(-M, M):
+                for j in range(-N, N):
+                    assert_equal(A[i,j], D[i,j])
 
-                for ij in [(0,3),(-1,3),(4,0),(4,3),(4,-1), (1, 2, 3)]:
-                    assert_raises((IndexError, TypeError), A.__getitem__, ij)
+            for ij in [(0,3),(-1,3),(4,0),(4,3),(4,-1), (1, 2, 3)]:
+                assert_raises((IndexError, TypeError), A.__getitem__, ij)
 
         for dtype in supported_dtypes:
             for sorted_indices in [False, True]:


### PR DESCRIPTION
Work towards #7524. Also makes warning suppression in scipy/sparse/tests/test_base.py more specific.