### PR TITLE
DOC: Add examples to scipy.optimize

### DIFF
--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -2478,6 +2478,21 @@ def fmin_powell(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None,
        fraction of the decrease in the function value from that iteration of
        the inner loop.
 
+    Examples
+    --------
+    >>> def f(x):
+    ...     return x**2
+
+    >>> from scipy import optimize
+
+    >>> minimum = optimize.fmin(f, -1)
+    Optimization terminated successfully.
+             Current function value: 0.000000
+             Iterations: 2
+             Function evaluations: 18
+    >>> minimum[0]
+    0.0
+
     References
     ----------
     Powell M.J.D. (1964) An efficient method for finding the minimum of a

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -371,6 +371,22 @@ def fmin(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None, maxfun=None,
     converge to the minimum, or how fast it will if it does. Both the ftol and
     xtol criteria must be met for convergence.
 
+    Examples
+    --------
+    
+    >>> def f(x):
+    ...     return x**2
+
+    >>> from scipy import optimize
+
+    >>> minimum = optimize.fmin(f, 1)
+    Optimization terminated successfully.
+             Current function value: 0.000000
+             Iterations: 17
+             Function evaluations: 34
+    >>> minimum[0]
+    -8.8817841970012523e-16
+
     References
     ----------
     .. [1] Nelder, J.A. and Mead, R. (1965), "A simplex method for function

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -2182,17 +2182,17 @@ def golden(func, args=(), brack=None, tol=_epsilon,
     We illustrate the behaviour of the function when `brack` is of
     size 2 and 3 respectively. In the case where `brack` is of the
     form (xa,xb), we can see for the given values, the output need
-    not necessarily lie in the range (xa,xb).
+    not necessarily lie in the range ``(xa, xb)``.
 
     >>> def f(x):
     ...     return x**2
     
     >>> from scipy import optimize
 
-    >>> minimum = optimize.golden(f,brack=(1,2))
+    >>> minimum = optimize.golden(f, brack=(1, 2))
     >>> minimum
     1.5717277788484873e-162
-    >>> minimum = optimize.golden(f,brack=(-1,0.5,2))
+    >>> minimum = optimize.golden(f, brack=(-1, 0.5, 2))
     >>> minimum
     -1.5717277788484873e-162
 

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -1684,6 +1684,21 @@ def fminbound(func, x1, x2, args=(), xtol=1e-5, maxfun=500,
     interval x1 < xopt < x2 using Brent's method.  (See `brent`
     for auto-bracketing).
 
+    Examples
+    --------
+    `fminbound` finds the minimum of the function in the given range. The following examples illustrate the same
+
+    >>> def f(x):
+    ...     return x**2
+    
+    >>> from scipy import optimize
+
+    >>> minimum = optimize.fminbound(f,-1,2)
+    >>> minimum
+    0.0
+    >>> minimum = optimize.fminbound(f,1,2)
+    >>> minimum
+    -2.7755575615628914e-17
     """
     options = {'xatol': xtol,
                'maxiter': maxfun,

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -1691,13 +1691,13 @@ def fminbound(func, x1, x2, args=(), xtol=1e-5, maxfun=500,
 
     >>> def f(x):
     ...     return x**2
-    
+
     >>> from scipy import optimize
 
-    >>> minimum = optimize.fminbound(f,-1,2)
+    >>> minimum = optimize.fminbound(f, -1, 2)
     >>> minimum
     0.0
-    >>> minimum = optimize.fminbound(f,1,2)
+    >>> minimum = optimize.fminbound(f, 1, 2)
     >>> minimum
     1.0000059608609866
     """

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -373,7 +373,6 @@ def fmin(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None, maxfun=None,
 
     Examples
     --------
-    
     >>> def f(x):
     ...     return x**2
 

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -2485,7 +2485,7 @@ def fmin_powell(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None,
 
     >>> from scipy import optimize
 
-    >>> minimum = optimize.fmin(f, -1)
+    >>> minimum = optimize.fmin_powell(f, -1)
     Optimization terminated successfully.
              Current function value: 0.000000
              Iterations: 2

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -2126,7 +2126,8 @@ def _minimize_scalar_brent(func, brack=None, args=(),
 def golden(func, args=(), brack=None, tol=_epsilon,
            full_output=0, maxiter=5000):
     """
-    Return the minimum of a function of one variable.
+    Return the minimum of a function of one variable using golden section
+    method.
 
     Given a function of one variable and a possible bracketing interval,
     return the minimum of the function isolated to a fractional precision of
@@ -2160,6 +2161,25 @@ def golden(func, args=(), brack=None, tol=_epsilon,
     -----
     Uses analog of bisection method to decrease the bracketed
     interval.
+
+    Examples
+    --------
+    We illustrate the behaviour of the function when `brack` is of
+    size 2 and 3 respectively. In the case where `brack` is of the
+    form (xa,xb), we can see for the given values, the output need
+    not necessarily lie in the range (xa,xb).
+
+    >>> def f(x):
+    ...     return x**2
+    
+    >>> from scipy import optimize
+
+    >>> minimum = optimize.golden(f,brack=(1,2))
+    >>> minimum
+    1.5717277788484873e-162
+    >>> minimum = optimize.golden(f,brack=(-1,0.5,2))
+    >>> minimum
+    -1.5717277788484873e-162
 
     """
     options = {'xtol': tol, 'maxiter': maxiter}

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -2490,8 +2490,8 @@ def fmin_powell(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None,
              Current function value: 0.000000
              Iterations: 2
              Function evaluations: 18
-    >>> minimum[0]
-    0.0
+    >>> minimum
+    array(0.0)
 
     References
     ----------

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -1699,7 +1699,7 @@ def fminbound(func, x1, x2, args=(), xtol=1e-5, maxfun=500,
     0.0
     >>> minimum = optimize.fminbound(f,1,2)
     >>> minimum
-    -2.7755575615628914e-17
+    1.0000059608609866
     """
     options = {'xatol': xtol,
                'maxiter': maxfun,

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -1686,7 +1686,8 @@ def fminbound(func, x1, x2, args=(), xtol=1e-5, maxfun=500,
 
     Examples
     --------
-    `fminbound` finds the minimum of the function in the given range. The following examples illustrate the same
+    `fminbound` finds the minimum of the function in the given range.
+    The following examples illustrate the same
 
     >>> def f(x):
     ...     return x**2

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -126,24 +126,26 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
     Examples
     --------
 
-    ``fprime`` and ``fprime2`` not provided, use secant method
-    Only ``fprime`` provided, use Newton Raphson method
-    ``fprime2`` provided, ``fprime`` provided/not provided use parabolic
-    Halley's method
-
     >>> def f(x):
     ...     return (x**3 - 1)  # only one real root at x = 1
     
     >>> from scipy import optimize
+
+    ``fprime`` and ``fprime2`` not provided, use secant method
     
     >>> root = optimize.newton(f, 1.5)
     >>> root
     1.0000000000000016
+
+    Only ``fprime`` provided, use Newton Raphson method
     
     >>> root = optimize.newton(f, 1.5, fprime=lambda x: 3 * x**2)
     >>> root
     1.0
     
+    ``fprime2`` provided, ``fprime`` provided/not provided use parabolic
+    Halley's method
+
     >>> root = optimize.newton(f, 1.5, fprime2=lambda x: 6 * x)
     >>> root
     1.0000000000000016

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -430,6 +430,20 @@ def brentq(f, a, b, args=(),
     -----
     `f` must be continuous.  f(a) and f(b) must have opposite signs.
 
+    Examples
+    --------
+    >>> def f(x):
+    ...     return (x**2 - 1)
+
+    >>> from scipy import optimize
+
+    >>> root = optimize.brentq(f, -2, 0)
+    >>> root
+    -1.0
+
+    >>> root = optimize.brentq(f, 0, 2)
+    >>> root
+    1.0
 
     References
     ----------
@@ -510,6 +524,21 @@ def brenth(f, a, b, args=(),
     r : RootResults (present if ``full_output = True``)
         Object containing information about the convergence.  In particular,
         ``r.converged`` is True if the routine converged.
+
+    Examples
+    --------
+    >>> def f(x):
+    ...     return (x**2 - 1)
+
+    >>> from scipy import optimize
+
+    >>> root = optimize.brenth(f, -2, 0)
+    >>> root
+    -1.0
+
+    >>> root = optimize.brenth(f, 0, 2)
+    >>> root
+    1.0
 
     See Also
     --------

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -123,6 +123,33 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
     sign. The brentq algorithm is recommended for general use in one
     dimensional problems when such an interval has been found.
 
+    Examples
+    --------
+    >>> def f(x):
+    ...     return (x**3 - 1)  # only one real root at x = 1
+    
+    >>> from scipy import optimize
+    
+    >>> # fprime and fprime2 not provided, use secant method
+    >>> root = optimize.newton(f, 1.5)
+    >>> root
+    1.0000000000000016
+    
+    >>> # Only fprime provided, use Newton Raphson method
+    >>> root = optimize.newton(f, 1.5, fprime=lambda x: 3 * x**2)
+    >>> root
+    1.0
+    
+    >>> # fprime2 provided, fprime provided/not provided use parabolic Halley's
+    >>> # method
+    >>> root = optimize.newton(f, 1.5, fprime2=lambda x: 6 * x)
+    >>> root
+    1.0000000000000016
+    >>> root = optimize.newton(f, 1.5, fprime=lambda x: 3 *
+                           x**2, fprime2=lambda x: 6 * x)
+    >>> root
+    1.0
+
     """
     if tol <= 0:
         raise ValueError("tol too small (%g <= 0)" % tol)

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -274,6 +274,10 @@ def bisect(f, a, b, args=(),
     >>> root
     1.0
 
+    >>> root = optimize.bisect(f, -2, 0)
+    >>> root
+    -1.0
+
     See Also
     --------
     brentq, brenth, bisect, newton
@@ -351,6 +355,22 @@ def ridder(f, a, b, args=(),
 
     The routine used here diverges slightly from standard presentations in
     order to be a bit more careful of tolerance.
+
+    Examples
+    --------
+
+    >>> def f(x):
+    ...     return (x**2 - 1)
+
+    >>> from scipy import optimize
+
+    >>> root = optimize.ridder(f, 0, 2)
+    >>> root
+    1.0
+
+    >>> root = optimize.ridder(f, -2, 0)
+    >>> root
+    -1.0
 
     References
     ----------

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -236,7 +236,7 @@ def bisect(f, a, b, args=(),
     Examples
     --------
     The bisection algorithm fails if `f(a)` and `f(b)` have the same sign.
-    
+
     >>> def f(x):
     ...     return (x**2 - 1)
 
@@ -245,7 +245,7 @@ def bisect(f, a, b, args=(),
     >>> root = optimize.bisect(f,0,2)
     >>> root
     1.0
-    >>> root = optimize.fminbound(f,2,2)
+    >>> root = optimize.bisect(f,-2,2)
     >>> root
     ValueError: f(a) and f(b) must have different signs
 

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -235,18 +235,15 @@ def bisect(f, a, b, args=(),
 
     Examples
     --------
-    The bisection algorithm fails if `f(a)` and `f(b)` have the same sign.
 
     >>> def f(x):
     ...     return (x**2 - 1)
 
     >>> from scipy import optimize
 
-    >>> root = optimize.bisect(f,0,2)
+    >>> root = optimize.bisect(f, 0, 2)
     >>> root
     1.0
-    >>> root = optimize.bisect(f,-2,2)
-    ValueError: f(a) and f(b) must have different signs
 
     See Also
     --------

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -125,28 +125,29 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
 
     Examples
     --------
+
+    ``fprime`` and ``fprime2`` not provided, use secant method
+    Only ``fprime`` provided, use Newton Raphson method
+    ``fprime2`` provided, ``fprime`` provided/not provided use parabolic
+    Halley's method
+
     >>> def f(x):
     ...     return (x**3 - 1)  # only one real root at x = 1
     
     >>> from scipy import optimize
     
-    >>> # fprime and fprime2 not provided, use secant method
     >>> root = optimize.newton(f, 1.5)
     >>> root
     1.0000000000000016
     
-    >>> # Only fprime provided, use Newton Raphson method
     >>> root = optimize.newton(f, 1.5, fprime=lambda x: 3 * x**2)
     >>> root
     1.0
     
-    >>> # fprime2 provided, fprime provided/not provided use parabolic Halley's
-    >>> # method
     >>> root = optimize.newton(f, 1.5, fprime2=lambda x: 6 * x)
     >>> root
     1.0000000000000016
-    >>> root = optimize.newton(f, 1.5, fprime=lambda x: 3 *
-                           x**2, fprime2=lambda x: 6 * x)
+    >>> root = optimize.newton(f, 1.5, fprime=lambda x: 3 * x**2, fprime2=lambda x: 6 * x)
     >>> root
     1.0
 

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -246,7 +246,6 @@ def bisect(f, a, b, args=(),
     >>> root
     1.0
     >>> root = optimize.bisect(f,-2,2)
-    >>> root
     ValueError: f(a) and f(b) must have different signs
 
     See Also

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -233,6 +233,22 @@ def bisect(f, a, b, args=(),
         Object containing information about the convergence.  In particular,
         ``r.converged`` is True if the routine converged.
 
+    Examples
+    --------
+    The bisection algorithm fails if `f(a)` and `f(b)` have the same sign.
+    
+    >>> def f(x):
+    ...     return (x**2 - 1)
+
+    >>> from scipy import optimize
+
+    >>> root = optimize.bisect(f,0,2)
+    >>> root
+    1.0
+    >>> root = optimize.fminbound(f,2,2)
+    >>> root
+    ValueError: f(a) and f(b) must have different signs
+
     See Also
     --------
     brentq, brenth, bisect, newton

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -147,7 +147,8 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
     >>> root = optimize.newton(f, 1.5, fprime2=lambda x: 6 * x)
     >>> root
     1.0000000000000016
-    >>> root = optimize.newton(f, 1.5, fprime=lambda x: 3 * x**2, fprime2=lambda x: 6 * x)
+    >>> root = optimize.newton(f, 1.5, fprime=lambda x: 3 * x**2,
+    ...                        fprime2=lambda x: 6 * x)
     >>> root
     1.0
 


### PR DESCRIPTION
I have currently added examples to `fminbound` and `bisect` methods.

I plan on adding to `newton`, `golden`, `fmin`, `brenth`, `brentq` and some others too.

Are examples similar to `brent` (#7299) enough for `brenth` and `brentq`?
Examples added to :-
- [x] fminbound
- [x] bisect
- [x] brenth
- [x] brentq
- [x] fmin
- [x] golden
- [x] newton
- [x] fmin_powell
- [x] ridder