### PR TITLE
TST: Add tests for ndimage converter functions.

### DIFF
--- a/scipy/ndimage/src/nd_image.c
+++ b/scipy/ndimage/src/nd_image.c
@@ -78,6 +78,7 @@ Py_TestConverters(PyObject *object, PyObject *args)
     PyArray_Dims origin = {NULL, 0};
     PyArrayObject *origin_array = NULL;
     PyArrayObject *zeros_like_origin = NULL;
+    npy_intp shape1d;
 
     if (!PyArg_ParseTuple(args, "O&O&O&O&O&O&",
                           NI_ObjectToInputArray, &input,
@@ -99,11 +100,12 @@ Py_TestConverters(PyObject *object, PyObject *args)
         PyErr_SetString(PyExc_ValueError, "Found misbehaved array");
         goto fail;
     }
-    origin_array = NI_NewArray(origin.ptr, NPY_INTP, 1, &origin.len);
+    shape1d = origin.len;
+    origin_array = NI_NewArray(origin.ptr, NPY_INTP, 1, &shape1d);
     if (origin_array == NULL) {
         goto fail;
     }
-    zeros_like_origin = NI_NewArray(NULL, NPY_INTP, 1, &origin.len);
+    zeros_like_origin = NI_NewArray(NULL, NPY_INTP, 1, &shape1d);
     if (zeros_like_origin == NULL) {
         goto fail;
     }

--- a/scipy/ndimage/src/ni_converters.h
+++ b/scipy/ndimage/src/ni_converters.h
@@ -1,0 +1,131 @@
+#ifndef NI_CONVERTERS_H
+#define NI_CONVERTERS_H
+
+/*
+ * Creates a new numpy array of the requested type and shape, and either
+ * copies into it the contents of buffer, or sets it to all zeros if
+ * buffer is NULL.
+ */
+static PyArrayObject *
+NI_NewArray(void *buffer, enum NPY_TYPES type, int ndim, npy_intp *shape)
+{
+    PyArrayObject *result;
+
+    if (type == NPY_NOTYPE) {
+        type = NPY_DOUBLE;
+    }
+
+    result = (PyArrayObject *)PyArray_SimpleNew(ndim, shape, type);
+    if (result == NULL) {
+        return NULL;
+    }
+
+    if (buffer == NULL) {
+        memset(PyArray_DATA(result), 0, PyArray_NBYTES(result));
+    }
+    else {
+        memcpy(PyArray_DATA(result), buffer, PyArray_NBYTES(result));
+    }
+
+    return result;
+}
+
+/* Converts a Python array-like object into a behaved input array. */
+static int
+NI_ObjectToInputArray(PyObject *object, PyArrayObject **array)
+{
+    int flags = NPY_ARRAY_ALIGNED | NPY_ARRAY_NOTSWAPPED;
+    *array = (PyArrayObject *)PyArray_CheckFromAny(object, NULL, 0, 0, flags,
+                                                   NULL);
+    return *array != NULL;
+}
+
+/* Like NI_ObjectToInputArray, but with special handling for Py_None. */
+static int
+NI_ObjectToOptionalInputArray(PyObject *object, PyArrayObject **array)
+{
+    if (object == Py_None) {
+        *array = NULL;
+        return 1;
+    }
+    return NI_ObjectToInputArray(object, array);
+}
+
+/* Converts a Python array-like object into a behaved output array. */
+static int
+NI_ObjectToOutputArray(PyObject *object, PyArrayObject **array)
+{
+    int flags = NPY_ARRAY_BEHAVED_NS | NPY_ARRAY_UPDATEIFCOPY;
+    /*
+     * These would also be caught by the PyArray_CheckFromAny call, but
+     * we check them explicitly here to provide a saner error message.
+     */
+    if (!PyArray_Check(object)) {
+        PyErr_SetString(PyExc_TypeError, "output array must be an array");
+        return 0;
+    }
+    if (!PyArray_ISWRITEABLE((PyArrayObject *)object)) {
+        PyErr_SetString(PyExc_ValueError, "output array is read-only");
+        return 0;
+    }
+    /*
+     * If the output array is not aligned or is byteswapped, this call
+     * will create a new aligned, native byte order array, and copy the
+     * contents of object into it. For an output array, the copy is
+     * unnecessary, so this could be optimized. It is very easy to not
+     * do NPY_ARRAY_UPDATEIFCOPY right, so we let NumPy do it for us
+     * and pay the performance price.
+     */
+    *array = (PyArrayObject *)PyArray_CheckFromAny(object, NULL, 0, 0, flags,
+                                                   NULL);
+    return *array != NULL;
+}
+
+/* Like NI_ObjectToOutputArray, but with special handling for Py_None. */
+static int
+NI_ObjectToOptionalOutputArray(PyObject *object, PyArrayObject **array)
+{
+    if (object == Py_None) {
+        *array = NULL;
+        return 1;
+    }
+    return NI_ObjectToOutputArray(object, array);
+}
+
+/* Converts a Python array-like object into a behaved input/output array. */
+static int
+NI_ObjectToInputOutputArray(PyObject *object, PyArrayObject **array)
+{
+    int flags = NPY_ARRAY_BEHAVED_NS | NPY_ARRAY_UPDATEIFCOPY;
+    /*
+     * These would also be caught by the PyArray_CheckFromAny call, but
+     * we check them explicitly here to provide a saner error message.
+     */
+    if (!PyArray_Check(object)) {
+        PyErr_SetString(PyExc_TypeError,
+                        "input-output array must be an array");
+        return 0;
+    }
+    if (!PyArray_ISWRITEABLE((PyArrayObject *)object)) {
+        PyErr_SetString(PyExc_ValueError, "input-output array is read-only");
+        return 0;
+    }
+    *array = (PyArrayObject *)PyArray_CheckFromAny(object, NULL, 0, 0, flags,
+                                                   NULL);
+    return *array != NULL;}
+
+/* Checks that an origin value was received for each array dimension. */
+static int
+_validate_origin(PyArrayObject *array, PyArray_Dims origin)
+{
+    if (origin.len != PyArray_NDIM(array)) {
+        PyErr_Format(PyExc_ValueError,
+                     "invalid %d element 'origin' sequence for "
+                     "%d-dimensional input array",
+                     origin.len, PyArray_NDIM(array));
+        return 0;
+    }
+    return 1;
+}
+
+#endif  /* NI_CONVERTERS_H */

--- a/scipy/ndimage/tests/test_ni_converters.py
+++ b/scipy/ndimage/tests/test_ni_converters.py
@@ -4,8 +4,7 @@ import gc
 import itertools
 
 import numpy as np
-from numpy.testing import (assert_, assert_array_equal, assert_raises_regex,
-                           run_module_suite)
+from numpy.testing import assert_, assert_array_equal, assert_raises_regex
 from scipy.ndimage._nd_image import _test_converters
 
 
@@ -198,7 +197,3 @@ class TestNIConverters:
         assert_array_equal(
             (0, 0, 0),
             _test_converters(array1, None, array2, array3, None, origin)[6])
-
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/scipy/ndimage/tests/test_ni_converters.py
+++ b/scipy/ndimage/tests/test_ni_converters.py
@@ -186,7 +186,7 @@ class TestNIConverters:
         array2 = make_array(self.shape)
         array3 = make_array(self.shape)
         assert_raises_regex(
-            TypeError, "an integer is required",
+            TypeError, "object cannot be interpreted",
             _test_converters , array1, None, array2, array3, None, 'letters')
         assert_raises_regex(
             ValueError, "invalid 2 element 'origin' sequence",

--- a/scipy/ndimage/tests/test_ni_converters.py
+++ b/scipy/ndimage/tests/test_ni_converters.py
@@ -4,7 +4,8 @@ import gc
 import itertools
 
 import numpy as np
-from numpy.testing import assert_, assert_array_equal, assert_raises_regex
+from numpy.testing import assert_, assert_array_equal, assert_raises
+from scipy._lib._numpy_compat import assert_raises_regex
 from scipy.ndimage._nd_image import _test_converters
 
 
@@ -184,12 +185,12 @@ class TestNIConverters:
         array1 = make_array(self.shape)
         array2 = make_array(self.shape)
         array3 = make_array(self.shape)
-        assert_raises_regex(
-            TypeError, "object cannot be interpreted",
-            _test_converters , array1, None, array2, array3, None, 'letters')
+        assert_raises(
+            TypeError,
+            _test_converters, array1, None, array2, array3, None, 'letters')
         assert_raises_regex(
             ValueError, "invalid 2 element 'origin' sequence",
-            _test_converters , array1, None, array2, array3, None, (11, 13))
+            _test_converters, array1, None, array2, array3, None, (11, 13))
         origin = (17, 19, 23)
         assert_array_equal(
             origin,

--- a/scipy/ndimage/tests/test_ni_converters.py
+++ b/scipy/ndimage/tests/test_ni_converters.py
@@ -1,0 +1,204 @@
+from __future__ import division, print_function, absolute_import
+
+import gc
+import itertools
+
+import numpy as np
+from numpy.testing import (assert_, assert_array_equal, assert_raises_regex,
+                           run_module_suite)
+from scipy.ndimage._nd_image import _test_converters
+
+
+def make_array(shape, dtype=np.intp, byteswapped=False, misaligned=False,
+               readonly=False):
+    """Creates an array with the required characteristics."""
+    dtype = np.dtype(dtype)
+    if ((byteswapped and not dtype.isnative) or
+            (not byteswapped and dtype.isnative)):
+        dtype = dtype.newbyteorder()
+    size = np.product(shape)
+    if misaligned and dtype.itemsize > 1:
+        base_array = np.arange(size + 1).astype(dtype).view(np.uint8)
+        base_array = base_array[dtype.itemsize - 1:-1].view(dtype)
+    else:
+        base_array = np.arange(size).astype(dtype)
+    array = base_array.reshape(shape)
+    if readonly:
+        array.flags.writeable = False
+    return array
+
+
+def check_converted_input_array(array, converted_array):
+    # Converted array must have same contents as original.
+    assert_array_equal(array, converted_array)
+    # Converted array must be aligned and not swapped.
+    assert_(converted_array.flags.aligned)
+    assert_(converted_array.dtype.isnative)
+
+
+def check_converted_output_array(array, converted_array):
+    # Converted array must be writeable, aligned and not swapped.
+    assert_(converted_array.flags.writeable)
+    assert_(converted_array.flags.aligned)
+    assert_(converted_array.dtype.isnative)
+    # Either the array is passed unchanged...
+    if converted_array is not array:
+        # ...or it should use the updateifcopy mechanism.
+        assert_(converted_array.flags.updateifcopy)
+    # Changes to the converted array should be reflected in the
+    # original one after deletion of the former.
+    converted_array[:] = 1
+
+
+def check_converted_input_output_array(array, converted_array):
+    # Converted array must have same contents as original.
+    assert_array_equal(array, converted_array)
+    # Everything else is the same as a converted output array.
+    check_converted_output_array(array, converted_array)
+
+
+class TestNIConverters:
+
+    def setUp(self):
+        self.shape = (3, 5, 7)
+        all_types = '?' + np.typecodes['AllInteger'] + 'fd'
+        f_t = (False, True)
+        self.all_args = list(itertools.product(all_types, f_t, f_t, f_t))
+
+    def test_input_array(self):
+        other_array1 = make_array(self.shape)
+        other_array2 = make_array(self.shape)
+        origin = (1,) * len(self.shape)
+        for args in self.all_args:
+            in_array = make_array(self.shape, *args)
+            check_converted_input_array(
+                in_array,
+                _test_converters(in_array, None, other_array1, other_array2,
+                                 None, origin)[0])
+
+    def test_optional_input_array(self):
+        other_array1 = make_array(self.shape)
+        other_array2 = make_array(self.shape)
+        other_array3 = make_array(self.shape)
+        origin = (1,) * len(self.shape)
+        # When passing None the return should also be None.
+        assert_(_test_converters(other_array1, None, other_array2,
+                                 other_array3, None, origin)[1]
+                is None)
+        for args in self.all_args:
+            opt_in_array = make_array(self.shape, *args)
+            check_converted_input_array(
+                opt_in_array,
+                _test_converters(other_array1, opt_in_array, other_array2,
+                                 other_array3, None, origin)[1])
+
+    def test_input_output_array(self):
+        other_array1 = make_array(self.shape)
+        other_array2 = make_array(self.shape)
+        origin = (1,) * len(self.shape)
+        # Passing a non-array should raise an error.
+        assert_raises_regex(
+            TypeError, 'input-output array must be an array',
+            _test_converters, other_array1, None, None, other_array2, None,
+            origin)
+        for args in self.all_args:
+            dt, bs, ma, ro = args
+            in_out_array = make_array(self.shape, *args)
+            if ro:
+                assert_raises_regex(
+                    ValueError, 'input-output array is read-only',
+                    _test_converters, other_array1, None, in_out_array,
+                    other_array2, None, origin)
+            else:
+                check_converted_input_output_array(
+                    in_out_array,
+                    _test_converters(other_array1, None, in_out_array,
+                                     other_array2, None, origin)[2])
+                # Changes to the converted array should be reflected in the
+                # original one after deletion of the former.
+                assert_(np.all(in_out_array == 1))
+                # In the end, the original array must again be writeable.
+                assert_(in_out_array.flags.writeable)
+
+    def test_output_array(self):
+        other_array1 = make_array(self.shape)
+        other_array2 = make_array(self.shape)
+        origin = (1,) * len(self.shape)
+        # Passing a non-array should raise an error.
+        assert_raises_regex(
+            TypeError, 'output array must be an array',
+            _test_converters, other_array1, None, other_array2, None, None,
+            origin)
+        for args in self.all_args:
+            dt, bs, ma, ro = args
+            out_array = make_array(self.shape, *args)
+            if ro:
+                assert_raises_regex(
+                    ValueError, 'output array is read-only',
+                    _test_converters, other_array1, None, other_array2,
+                    out_array, None, origin)
+            else:
+                check_converted_output_array(
+                    out_array,
+                    _test_converters(other_array1, None, other_array2,
+                                     out_array, None, origin)[3])
+                # Changes to the converted array should be reflected in the
+                # original one after deletion of the former.
+                assert_(np.all(out_array == 1))
+                # In the end, the original array must again be writeable.
+                assert_(out_array.flags.writeable)
+
+    def test_optional_output_array(self):
+        other_array1 = make_array(self.shape)
+        other_array2 = make_array(self.shape)
+        other_array3 = make_array(self.shape)
+        origin = (1,) * len(self.shape)
+        # When passing None the return should also be None.
+        assert_(_test_converters(other_array1, None, other_array2,
+                                 other_array3, None, origin)[4]
+                is None)
+        # Passing a non-array should raise an error.
+        assert_raises_regex(
+            TypeError, 'output array must be an array',
+            _test_converters, other_array1, None, other_array2, None,
+            'not an array', origin)
+        for args in self.all_args:
+            dt, bs, ma, ro = args
+            opt_out_array = make_array(self.shape, *args)
+            if ro:
+                assert_raises_regex(
+                    ValueError, 'output array is read-only',
+                    _test_converters, other_array1, None, other_array2,
+                    other_array3, opt_out_array, origin)
+            else:
+                check_converted_output_array(
+                    opt_out_array,
+                    _test_converters(other_array1, None, other_array2,
+                                     other_array3, opt_out_array, origin)[4])
+                # Changes to the converted array should be reflected in the
+                # original one after deletion of the former.
+                assert_(np.all(opt_out_array == 1))
+                # In the end, the original array must again be writeable.
+                assert_(opt_out_array.flags.writeable)
+
+    def test_origin_and_new_array(self):
+        array1 = make_array(self.shape)
+        array2 = make_array(self.shape)
+        array3 = make_array(self.shape)
+        assert_raises_regex(
+            TypeError, "an integer is required",
+            _test_converters , array1, None, array2, array3, None, 'letters')
+        assert_raises_regex(
+            ValueError, "invalid 2 element 'origin' sequence",
+            _test_converters , array1, None, array2, array3, None, (11, 13))
+        origin = (17, 19, 23)
+        assert_array_equal(
+            origin,
+            _test_converters(array1, None, array2, array3, None, origin)[5])
+        assert_array_equal(
+            (0, 0, 0),
+            _test_converters(array1, None, array2, array3, None, origin)[6])
+
+
+if __name__ == "__main__":
+    run_module_suite()


### PR DESCRIPTION
This PR:
 * moves the converter functions to their own header file, `ni_converters.h`,
 * adds a Python function implemented in C, `_test_converters`,  that uses all the converters in `ni_converters.h`,
 * adds tests for the converters using this function in `test_ni_converters.py`, and
 * fixes a segfault detected by these tests due to freeing an uninitialized `PyArrayDims` pointer.