### PR TITLE
Added a sanity check to signal.savgol_filter

### DIFF
--- a/scipy/signal/_savitzky_golay.py
+++ b/scipy/signal/_savitzky_golay.py
@@ -235,7 +235,8 @@ def savgol_filter(x, window_length, polyorder, deriv=0, delta=1.0,
         before filtering.
     window_length : int
         The length of the filter window (i.e. the number of coefficients).
-        `window_length` must be a positive odd integer.
+        `window_length` must be a positive odd integer. If mode is interp,
+        `window_length` must be less than or equal to the size of x.
     polyorder : int
         The order of the polynomial used to fit the samples.
         `polyorder` must be less than `window_length`.
@@ -332,6 +333,10 @@ def savgol_filter(x, window_length, polyorder, deriv=0, delta=1.0,
     coeffs = savgol_coeffs(window_length, polyorder, deriv=deriv, delta=delta)
 
     if mode == "interp":
+        if (window_length > x.size):
+            raise ValueError("If mode is 'interp', window_length must be less "
+                             "than or equal to the size of x.")
+
         # Do not pad.  Instead, for the elements within `window_length // 2`
         # of the ends of the sequence, use the polynomial that is fitted to
         # the last `window_length` elements.

--- a/scipy/signal/_savitzky_golay.py
+++ b/scipy/signal/_savitzky_golay.py
@@ -333,7 +333,7 @@ def savgol_filter(x, window_length, polyorder, deriv=0, delta=1.0,
     coeffs = savgol_coeffs(window_length, polyorder, deriv=deriv, delta=delta)
 
     if mode == "interp":
-        if (window_length > x.size):
+        if window_length > x.size:
             raise ValueError("If mode is 'interp', window_length must be less "
                              "than or equal to the size of x.")
 

--- a/scipy/signal/_savitzky_golay.py
+++ b/scipy/signal/_savitzky_golay.py
@@ -235,7 +235,7 @@ def savgol_filter(x, window_length, polyorder, deriv=0, delta=1.0,
         before filtering.
     window_length : int
         The length of the filter window (i.e. the number of coefficients).
-        `window_length` must be a positive odd integer. If `mode` is "interp",
+        `window_length` must be a positive odd integer. If `mode` is 'interp',
         `window_length` must be less than or equal to the size of `x`.
     polyorder : int
         The order of the polynomial used to fit the samples.

--- a/scipy/signal/_savitzky_golay.py
+++ b/scipy/signal/_savitzky_golay.py
@@ -235,8 +235,8 @@ def savgol_filter(x, window_length, polyorder, deriv=0, delta=1.0,
         before filtering.
     window_length : int
         The length of the filter window (i.e. the number of coefficients).
-        `window_length` must be a positive odd integer. If mode is interp,
-        `window_length` must be less than or equal to the size of x.
+        `window_length` must be a positive odd integer. If `mode` is "interp",
+        `window_length` must be less than or equal to the size of `x`.
     polyorder : int
         The order of the polynomial used to fit the samples.
         `polyorder` must be less than `window_length`.


### PR DESCRIPTION
ENH: added a sanity check to the scipy.signal.savgol_filter

When using savgol_filter with mode's default parameter "interp", passing an x array with a size less than the `window_length` results in a rather cryptic TypeError raised back in numpy.polyfit with the message "expected x and y to have the same length". This message offers no indication that the x size in relation to the window_length is causing the issue. I've included a value check with a more informative error message. The check piggy backs off of the `mode == "interp"` code flow, as it only affects that mode.