### PR TITLE
MAINT: Remove unnecessary warning filter by avoding unnecessary cast

### DIFF
--- a/doc/release/1.0.0-notes.rst
+++ b/doc/release/1.0.0-notes.rst
@@ -69,6 +69,10 @@ Deprecated features
 are deprecated.  This was a never finished set of wrapper functions which is
 not relevant anymore.
 
+The ``fillvalue`` of ``scipy.signal.convolve2d`` will be cast directly to the
+dtypes of the input arrays in the future and checked that it is a scalar or
+an array with a single element.
+
 
 Backwards incompatible changes
 ==============================

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1019,12 +1019,7 @@ def convolve2d(in1, in2, mode='full', boundary='fill', fillvalue=0):
 
     val = _valfrommode(mode)
     bval = _bvalfromboundary(boundary)
-
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore', np.ComplexWarning)
-        # FIXME: some cast generates a warning here
-        out = sigtools._convolve2d(in1, in2, 1, val, bval, fillvalue)
-
+    out = sigtools._convolve2d(in1, in2, 1, val, bval, fillvalue)
     return out
 
 
@@ -1117,11 +1112,7 @@ def correlate2d(in1, in2, mode='full', boundary='fill', fillvalue=0):
 
     val = _valfrommode(mode)
     bval = _bvalfromboundary(boundary)
-
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore', np.ComplexWarning)
-        # FIXME: some cast generates a warning here
-        out = sigtools._convolve2d(in1, in2, 0, val, bval, fillvalue)
+    out = sigtools._convolve2d(in1, in2, 0, val, bval, fillvalue)
 
     if swapped_inputs:
         out = out[::-1, ::-1]


### PR DESCRIPTION
The original code is from 2001 (and was never changed), so I doubt there
was a big reason for this right now.