### PR TITLE
Convert yield tests to pytest parametrized tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -131,8 +131,7 @@ before_install:
   # Need to install Cython 0.23.4 from source to avoid errors for Python 3.6
   - travis_retry pip install --install-option="--no-cython-compile" Cython==0.23.4
   - travis_retry pip install $NUMPYSPEC
-  # Note: install dev version of pytest --- change to standard install after pytest 3.1.4 is released
-  - travis_retry pip install git+https://github.com/pytest-dev/pytest.git@81cec9f5e3416e151939e65174dd64163d7a7b1d pytest-xdist nose mpmath argparse Pillow codecov
+  - travis_retry pip install pytest pytest-xdist nose mpmath argparse Pillow codecov
   - travis_retry pip install --upgrade pip setuptools
   - travis_retry pip install gmpy2  # speeds up mpmath (scipy.special tests)
   - if [ "${TESTMODE}" == "full" ]; then pip install pytest-cov coverage; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -132,7 +132,7 @@ before_install:
   - travis_retry pip install --install-option="--no-cython-compile" Cython==0.23.4
   - travis_retry pip install $NUMPYSPEC
   # Note: install dev version of pytest --- change to standard install after pytest 3.1.4 is released
-  - travis_retry pip install git+https://github.com/pytest-dev/pytest.git@81cec9f5e3416e151939e65174dd64163d7a7b1d nose mpmath argparse Pillow codecov
+  - travis_retry pip install git+https://github.com/pytest-dev/pytest.git@81cec9f5e3416e151939e65174dd64163d7a7b1d pytest-xdist nose mpmath argparse Pillow codecov
   - travis_retry pip install --upgrade pip setuptools
   - travis_retry pip install gmpy2  # speeds up mpmath (scipy.special tests)
   - if [ "${TESTMODE}" == "full" ]; then pip install pytest-cov coverage; fi
@@ -164,7 +164,7 @@ script:
         popd
         USE_WHEEL_BUILD="--no-build"
     fi
-  - python -u $OPTIMIZE runtests.py -g -m $TESTMODE $COVERAGE $USE_WHEEL_BUILD -- -rfEX 2>&1 | tee runtests.log
+  - python -u $OPTIMIZE runtests.py -g -m $TESTMODE $COVERAGE $USE_WHEEL_BUILD -- -rfEX -n 2 2>&1 | tee runtests.log
   - tools/validate_runtests_log.py $TESTMODE < runtests.log
   - if [ "${REFGUIDE_CHECK}" == "1" ]; then python runtests.py -g --refguide-check; fi
 after_success:

--- a/HACKING.rst.txt
+++ b/HACKING.rst.txt
@@ -300,7 +300,7 @@ command ``source scipy-dev/bin/activate``, and ``deactivate`` to exit from the
 virtual environment and back to your previous shell.  With scipy-dev
 activated, install first Scipy's dependencies::
 
-    $ pip install Numpy Nose Cython
+    $ pip install Numpy pytest Cython
 
 After that, you can install a development version of Scipy, for example via::
 
@@ -386,47 +386,6 @@ the environment variable ``SCIPY_XSLOW=1`` before running the test
 suite.
 
 
-*How do I write tests with test generators?*
-
-The Nose_ test framework supports so-called test generators, which can come
-useful if you need to have multiple tests where just a parameter changes.
-Using test generators so that they are more useful than harmful is tricky, and
-we recommend the following pattern::
-
-    def test_something():
-	some_array = (...)
-
-	def check(some_param):
-	    c = compute_result(some_array, some_param)
-	    known_result = (...)
-	    assert_allclose(c, known_result)
-
-	for some_param in ['a', 'b', 'c']:
-	    yield check, some_param
-
-We require the following:
-
-- All asserts and all computation that is tested must only be reached after a
-  yield. (Rationale: the generator body is part of no test, and a failure in it
-  will show neither the test name nor for what parameters the test failed.)
-
-- Arrays must not be passed as yield parameters. Either use variables from
-  outer scope (eg. with some index passed to yield), or capsulate test data to
-  a class with a sensible ``__repr__``. (Rationale: Nose truncates the printed
-  form of arrays in test output, and this makes it impossible to know for what
-  parameters a test failed. Arrays are big, and clutter test output
-  unnecessarily.)
-
-- Test generators cannot be used in test classes inheriting from
-  unittest.TestCase; either use object as base class, or use standalone test
-  functions.  (Rationale: Nose does not run test generators in
-  TestCase-inheriting classes.)
-
-If in doubt, do not use test generators. You can track for what parameter
-things failed also by passing ``err_msg=repr((param1, param2, ...))`` to the
-various assert functions.
-
-
 .. _scikit-learn: http://scikit-learn.org
 
 .. _scikit-image: http://scikit-image.org/
@@ -479,4 +438,4 @@ various assert functions.
 
 .. _bsd pitch: http://nipy.sourceforge.net/nipy/stable/faq/johns_bsd_pitch.html
 
-.. _Nose: http://nose.readthedocs.org/en/latest/
+.. _Pytest: https://pytest.org/

--- a/INSTALL.rst.txt
+++ b/INSTALL.rst.txt
@@ -154,11 +154,11 @@ To run the full test suite use
 
    >>> scipy.test('full')
 
-Please note that you must have version 1.0 or later of the 'nose' test
-framework installed in order to run the tests.  More information about nose is
+Please note that you must have version 1.0 or later of the Pytest test
+framework installed in order to run the tests.  More information about Pytest is
 available on the website__.
 
-__ https://nose.readthedocs.org/en/latest/
+__ https://pytest.org/
 
 COMPILER NOTES
 ==============

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,4 +2,3 @@
 filterwarnings =
     error
     once:.*LAPACK bug 0038.*:RuntimeWarning
-    once::scipy._lib._testutils.TestutilDeprecationWarning

--- a/scipy/_lib/_testutils.py
+++ b/scipy/_lib/_testutils.py
@@ -1,5 +1,5 @@
 """
-Generic test utilities and decorators.
+Generic test utilities.
 
 """
 
@@ -8,46 +8,8 @@ from __future__ import division, print_function, absolute_import
 import os
 import sys
 
-import warnings
 
-from scipy._lib.decorator import decorator
-
-
-__all__ = ['skipif_yield', 'xslow_yield']
-
-
-class TestutilDeprecationWarning(DeprecationWarning):
-    pass
-
-
-@decorator
-def xslow_yield(func, *a, **kw):
-    try:
-        v = int(os.environ.get('SCIPY_XSLOW', '0'))
-        if not v:
-            raise ValueError()
-    except ValueError:
-        import pytest
-        pytest.skip("very slow test; set environment variable "
-                    "SCIPY_XSLOW=1 to run it")
-    return func(*a, **kw)
-
-
-def skipif_yield(condition, reason, msg=""):
-    """
-    Similar to pytest.mark.skipif, for use in yield tests.
-
-    For yield tests, pytest.mark.skipif does not work as expected ---
-    if any condition evaluates to true, *all* of the yielded tests are
-    skipped.
-    """
-    @decorator
-    def wrapper(func, *a, **kw):
-        import pytest
-        if condition:
-            pytest.skip(reason)
-        return func(*a, **kw)
-    return wrapper
+__all__ = ['PytestTester']
 
 
 class PytestTester(object):

--- a/scipy/_lib/_testutils.py
+++ b/scipy/_lib/_testutils.py
@@ -13,29 +13,11 @@ import warnings
 from scipy._lib.decorator import decorator
 
 
-__all__ = ['suppressed_stdout', 'xslow_yield']
+__all__ = ['skipif_yield', 'xslow_yield']
 
 
 class TestutilDeprecationWarning(DeprecationWarning):
     pass
-
-
-def suppressed_stdout(f):
-    import nose
-
-    def pwrapper(*arg, **kwargs):
-        warnings.warn("scipy._lib._testutils.suppressed_stdout is deprecated "
-                      "-- should use pytest capture fixture instead",
-                      category=TestutilDeprecationWarning, stacklevel=1)
-
-        oldstdout = sys.stdout
-        sys.stdout = open(os.devnull, 'w')
-        try:
-            return f(*arg, **kwargs)
-        finally:
-            sys.stdout.close()
-            sys.stdout = oldstdout
-    return nose.tools.make_decorator(f)(pwrapper)
 
 
 @decorator

--- a/scipy/_lib/tests/test_ccallback.py
+++ b/scipy/_lib/tests/test_ccallback.py
@@ -117,7 +117,7 @@ def test_callbacks():
     for caller in sorted(CALLERS.keys()):
         for func in sorted(FUNCS.keys()):
             for user_data in sorted(USER_DATAS.keys()):
-                yield check, caller, func, user_data
+                check(caller, func, user_data)
 
 
 def test_bad_callbacks():
@@ -150,7 +150,7 @@ def test_bad_callbacks():
     for caller in sorted(CALLERS.keys()):
         for func in sorted(BAD_FUNCS.keys()):
             for user_data in sorted(USER_DATAS.keys()):
-                yield check, caller, func, user_data
+                check(caller, func, user_data)
 
 
 def test_signature_override():
@@ -195,4 +195,4 @@ def test_threadsafety():
         assert_equal(results, [2.0**count]*len(threads))
 
     for caller in CALLERS.keys():
-        yield check, caller
+        check(caller)

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -811,11 +811,11 @@ class TestDendrogram(object):
         Z = linkage(hierarchy_test_data.ytdist, 'single')
         assert_raises(ValueError, dendrogram, Z, orientation="foo")
 
+    @pytest.mark.skipif(not have_matplotlib, reason="no matplotlib")
     def test_dendrogram_plot(self):
         for orientation in ['top', 'bottom', 'left', 'right']:
             self.check_dendrogram_plot(orientation)
 
-    @pytest.mark.skipif(not have_matplotlib, reason="no matplotlib")
     def check_dendrogram_plot(self, orientation):
         # Tests dendrogram plotting.
         Z = linkage(hierarchy_test_data.ytdist, 'single')

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -83,7 +83,7 @@ class TestLinkage(object):
 
     def test_linkage_tdist(self):
         for method in ['single', 'complete', 'average', 'weighted', u('single')]:
-            yield self.check_linkage_tdist, method
+            self.check_linkage_tdist(method)
 
     def check_linkage_tdist(self, method):
         # Tests linkage(Y, method) on the tdist data set.
@@ -93,7 +93,7 @@ class TestLinkage(object):
 
     def test_linkage_X(self):
         for method in ['centroid', 'median', 'ward']:
-            yield self.check_linkage_q, method
+            self.check_linkage_q(method)
 
     def check_linkage_q(self, method):
         # Tests linkage(Y, method) on the Q data set.
@@ -138,7 +138,7 @@ class TestLinkageTies(object):
 
     def test_linkage_ties(self):
         for method in ['single', 'complete', 'average', 'weighted', 'centroid', 'median', 'ward']:
-            yield self.check_linkage_ties, method
+            self.check_linkage_ties(method)
 
     def check_linkage_ties(self, method):
         X = np.array([[-1, -1], [0, 0], [1, 1]])
@@ -150,7 +150,7 @@ class TestLinkageTies(object):
 class TestInconsistent(object):
     def test_inconsistent_tdist(self):
         for depth in hierarchy_test_data.inconsistent_ytdist:
-            yield self.check_inconsistent_tdist, depth
+            self.check_inconsistent_tdist(depth)
 
     def check_inconsistent_tdist(self, depth):
         Z = hierarchy_test_data.linkage_ytdist_single
@@ -209,11 +209,11 @@ class TestMLabLinkageConversion(object):
 class TestFcluster(object):
     def test_fclusterdata(self):
         for t in hierarchy_test_data.fcluster_inconsistent:
-            yield self.check_fclusterdata, t, 'inconsistent'
+            self.check_fclusterdata(t, 'inconsistent')
         for t in hierarchy_test_data.fcluster_distance:
-            yield self.check_fclusterdata, t, 'distance'
+            self.check_fclusterdata(t, 'distance')
         for t in hierarchy_test_data.fcluster_maxclust:
-            yield self.check_fclusterdata, t, 'maxclust'
+            self.check_fclusterdata(t, 'maxclust')
 
     def check_fclusterdata(self, t, criterion):
         # Tests fclusterdata(X, criterion=criterion, t=t) on a random 3-cluster data set.
@@ -224,11 +224,11 @@ class TestFcluster(object):
 
     def test_fcluster(self):
         for t in hierarchy_test_data.fcluster_inconsistent:
-            yield self.check_fcluster, t, 'inconsistent'
+            self.check_fcluster(t, 'inconsistent')
         for t in hierarchy_test_data.fcluster_distance:
-            yield self.check_fcluster, t, 'distance'
+            self.check_fcluster(t, 'distance')
         for t in hierarchy_test_data.fcluster_maxclust:
-            yield self.check_fcluster, t, 'maxclust'
+            self.check_fcluster(t, 'maxclust')
 
     def check_fcluster(self, t, criterion):
         # Tests fcluster(Z, criterion=criterion, t=t) on a random 3-cluster data set.
@@ -239,9 +239,9 @@ class TestFcluster(object):
 
     def test_fcluster_monocrit(self):
         for t in hierarchy_test_data.fcluster_distance:
-            yield self.check_fcluster_monocrit, t
+            self.check_fcluster_monocrit(t)
         for t in hierarchy_test_data.fcluster_maxclust:
-            yield self.check_fcluster_maxclust_monocrit, t
+            self.check_fcluster_maxclust_monocrit(t)
 
     def check_fcluster_monocrit(self, t):
         expectedT = hierarchy_test_data.fcluster_distance[t]
@@ -314,14 +314,14 @@ class TestIsIsomorphic(object):
         # Tests is_isomorphic on test case #5 (1000 observations, 2/3/5 random
         # clusters, random permutation of the labeling).
         for nc in [2, 3, 5]:
-            yield self.help_is_isomorphic_randperm, 1000, nc
+            self.help_is_isomorphic_randperm(1000, nc)
 
     def test_is_isomorphic_6(self):
         # Tests is_isomorphic on test case #5A (1000 observations, 2/3/5 random
         # clusters, random permutation of the labeling, slightly
         # nonisomorphic.)
         for nc in [2, 3, 5]:
-            yield self.help_is_isomorphic_randperm, 1000, nc, True, 5
+            self.help_is_isomorphic_randperm(1000, nc, True, 5)
             
     def test_is_isomorphic_7(self):
         # Regression test for gh-6271
@@ -346,7 +346,7 @@ class TestIsValidLinkage(object):
     def test_is_valid_linkage_various_size(self):
         for nrow, ncol, valid in [(2, 5, False), (2, 3, False),
                                   (1, 4, True), (2, 4, True)]:
-            yield self.check_is_valid_linkage_various_size, nrow, ncol, valid
+            self.check_is_valid_linkage_various_size(nrow, ncol, valid)
 
     def check_is_valid_linkage_various_size(self, nrow, ncol, valid):
         # Tests is_valid_linkage(Z) with linkage matrics of various sizes
@@ -430,7 +430,7 @@ class TestIsValidInconsistent(object):
     def test_is_valid_im_various_size(self):
         for nrow, ncol, valid in [(2, 5, False), (2, 3, False),
                                   (1, 4, True), (2, 4, True)]:
-            yield self.check_is_valid_im_various_size, nrow, ncol, valid
+            self.check_is_valid_im_various_size(nrow, ncol, valid)
 
     def check_is_valid_im_various_size(self, nrow, ncol, valid):
         # Tests is_valid_im(R) with linkage matrics of various sizes
@@ -533,7 +533,7 @@ class TestLeavesList(object):
     def test_leaves_list_Q(self):
         for method in ['single', 'complete', 'average', 'weighted', 'centroid',
                        'median', 'ward']:
-            yield self.check_leaves_list_Q, method
+            self.check_leaves_list_Q(method)
 
     def check_leaves_list_Q(self, method):
         # Tests leaves_list(Z) on the Q data set
@@ -690,7 +690,7 @@ class TestMaxDists(object):
 
     def test_maxdists_Q_linkage(self):
         for method in ['single', 'complete', 'ward', 'centroid', 'median']:
-            yield self.check_maxdists_Q_linkage, method
+            self.check_maxdists_Q_linkage(method)
 
     def check_maxdists_Q_linkage(self, method):
         # Tests maxdists(Z) on the Q data set
@@ -725,7 +725,7 @@ class TestMaxInconsts(object):
 
     def test_maxinconsts_Q_linkage(self):
         for method in ['single', 'complete', 'ward', 'centroid', 'median']:
-            yield self.check_maxinconsts_Q_linkage, method
+            self.check_maxinconsts_Q_linkage(method)
 
     def check_maxinconsts_Q_linkage(self, method):
         # Tests maxinconsts(Z, R) on the Q data set
@@ -740,7 +740,7 @@ class TestMaxInconsts(object):
 class TestMaxRStat(object):
     def test_maxRstat_invalid_index(self):
         for i in [3.3, -1, 4]:
-            yield self.check_maxRstat_invalid_index, i
+            self.check_maxRstat_invalid_index(i)
 
     def check_maxRstat_invalid_index(self, i):
         # Tests maxRstat(Z, R, i). Expecting exception.
@@ -753,7 +753,7 @@ class TestMaxRStat(object):
 
     def test_maxRstat_empty_linkage(self):
         for i in range(4):
-            yield self.check_maxRstat_empty_linkage, i
+            self.check_maxRstat_empty_linkage(i)
 
     def check_maxRstat_empty_linkage(self, i):
         # Tests maxRstat(Z, R, i) on empty linkage. Expecting exception.
@@ -763,7 +763,7 @@ class TestMaxRStat(object):
 
     def test_maxRstat_difrow_linkage(self):
         for i in range(4):
-            yield self.check_maxRstat_difrow_linkage, i
+            self.check_maxRstat_difrow_linkage(i)
 
     def check_maxRstat_difrow_linkage(self, i):
         # Tests maxRstat(Z, R, i) on linkage and inconsistency matrices with
@@ -774,7 +774,7 @@ class TestMaxRStat(object):
 
     def test_maxRstat_one_cluster_linkage(self):
         for i in range(4):
-            yield self.check_maxRstat_one_cluster_linkage, i
+            self.check_maxRstat_one_cluster_linkage(i)
 
     def check_maxRstat_one_cluster_linkage(self, i):
         # Tests maxRstat(Z, R, i) on linkage with one cluster.
@@ -787,7 +787,7 @@ class TestMaxRStat(object):
     def test_maxRstat_Q_linkage(self):
         for method in ['single', 'complete', 'ward', 'centroid', 'median']:
             for i in range(4):
-                yield self.check_maxRstat_Q_linkage, method, i
+                self.check_maxRstat_Q_linkage(method, i)
 
     def check_maxRstat_Q_linkage(self, method, i):
         # Tests maxRstat(Z, R, i) on the Q data set
@@ -813,7 +813,7 @@ class TestDendrogram(object):
 
     def test_dendrogram_plot(self):
         for orientation in ['top', 'bottom', 'left', 'right']:
-            yield self.check_dendrogram_plot, orientation
+            self.check_dendrogram_plot(orientation)
 
     @pytest.mark.skipif(not have_matplotlib, reason="no matplotlib")
     def check_dendrogram_plot(self, orientation):

--- a/scipy/integrate/tests/test_banded_ode_solvers.py
+++ b/scipy/integrate/tests/test_banded_ode_solvers.py
@@ -182,7 +182,7 @@ def test_banded_ode_solvers():
              [False, True],      # with_jacobian
              [False, True]]      # banded
         for solver, meth, use_jac, with_jac, banded in itertools.product(*p):
-            yield check_real, idx, solver, meth, use_jac, with_jac, banded
+            check_real(idx, solver, meth, use_jac, with_jac, banded)
 
     # --- Complex arrays for testing the "zvode" solver ---
 
@@ -220,5 +220,5 @@ def test_banded_ode_solvers():
              [False, True],      # with_jacobian
              [False, True]]      # banded
         for meth, use_jac, with_jac, banded in itertools.product(*p):
-            yield check_complex, idx, "zvode", meth, use_jac, with_jac, banded
+            check_complex(idx, "zvode", meth, use_jac, with_jac, banded)
 

--- a/scipy/integrate/tests/test_ivp.py
+++ b/scipy/integrate/tests/test_ivp.py
@@ -55,18 +55,6 @@ def sol_rational(t):
     return np.asarray((t / (t + 10), 10 * t / (t + 10) ** 2))
 
 
-def event_rational_1(t, y):
-    return y[0] - y[1] ** 0.7
-
-
-def event_rational_2(t, y):
-    return y[1] ** 0.6 - y[0]
-
-
-def event_rational_3(t, y):
-    return t - 7.4
-
-
 def fun_medazko(t, y):
     n = y.shape[0] // 2
     k = 100
@@ -308,6 +296,15 @@ def test_integration_const_jac():
 
 
 def test_events():
+    def event_rational_1(t, y):
+        return y[0] - y[1] ** 0.7
+
+    def event_rational_2(t, y):
+        return y[1] ** 0.6 - y[0]
+
+    def event_rational_3(t, y):
+        return t - 7.4
+
     event_rational_3.terminal = True
 
     for method in ['RK23', 'RK45', 'Radau', 'BDF', 'LSODA']:

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -379,9 +379,9 @@ def test_knots_multiplicity():
     for k in [1, 2, 3, 4, 5]:
         b = _make_random_spline(k=k)
         for j, b1 in enumerate(_make_multiples(b)):
-            yield check_splev, b1, j
+            check_splev(b1, j)
             for der in range(1, k+1):
-                yield check_splev, b1, j, der, 1e-12, 1e-12
+                check_splev(b1, j, der, 1e-12, 1e-12)
 
 
 ### stolen from @pv, verbatim

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -65,11 +65,11 @@ def test_shapes():
             for s2 in SHAPES:
                 for axis in range(-len(s2), len(s2)):
                     if ip != CubicSpline:
-                        yield check_shape, ip, s1, s2, None, axis
+                        check_shape(ip, s1, s2, None, axis)
                     else:
                         for bc in ['natural', 'clamped']:
                             extra = {'bc_type': bc}
-                            yield check_shape, ip, s1, s2, None, axis, extra
+                            check_shape(ip, s1, s2, None, axis, extra)
 
 def test_derivs_shapes():
     def krogh_derivs(x, y, axis=0):
@@ -78,7 +78,7 @@ def test_derivs_shapes():
     for s1 in SHAPES:
         for s2 in SHAPES:
             for axis in range(-len(s2), len(s2)):
-                yield check_shape, krogh_derivs, s1, s2, (6,), axis
+                check_shape(krogh_derivs, s1, s2, (6,), axis)
 
 
 def test_deriv_shapes():
@@ -128,7 +128,7 @@ def test_deriv_shapes():
         for s1 in SHAPES:
             for s2 in SHAPES:
                 for axis in range(-len(s2), len(s2)):
-                    yield check_shape, ip, s1, s2, (), axis
+                    check_shape(ip, s1, s2, (), axis)
 
 
 def _check_complex(ip):
@@ -140,7 +140,7 @@ def _check_complex(ip):
 
 def test_complex():
     for ip in [KroghInterpolator, BarycentricInterpolator, pchip, CubicSpline]:
-        yield _check_complex, ip
+        _check_complex(ip)
 
 
 class TestKrogh(object):

--- a/scipy/interpolate/tests/test_rbf.py
+++ b/scipy/interpolate/tests/test_rbf.py
@@ -48,9 +48,9 @@ def check_rbf3d_interpolation(function):
 
 def test_rbf_interpolation():
     for function in FUNCTIONS:
-        yield check_rbf1d_interpolation, function
-        yield check_rbf2d_interpolation, function
-        yield check_rbf3d_interpolation, function
+        check_rbf1d_interpolation(function)
+        check_rbf2d_interpolation(function)
+        check_rbf3d_interpolation(function)
 
 
 def check_rbf1d_regularity(function, atol):
@@ -82,7 +82,7 @@ def test_rbf_regularity():
         'linear': 0.2
     }
     for function in FUNCTIONS:
-        yield check_rbf1d_regularity, function, tolerances.get(function, 1e-2)
+        check_rbf1d_regularity(function, tolerances.get(function, 1e-2))
 
 
 def check_rbf1d_stability(function):
@@ -103,7 +103,7 @@ def check_rbf1d_stability(function):
 
 def test_rbf_stability():
     for function in FUNCTIONS:
-        yield check_rbf1d_stability, function
+        check_rbf1d_stability(function)
 
 
 def test_default_construction():

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -337,7 +337,7 @@ def test_load():
         files = glob(filt)
         assert_(len(files) > 0,
                 "No files for test %s using filter %s" % (name, filt))
-        yield _load_check_case, name, files, expected
+        _load_check_case(name, files, expected)
 
 
 # generator for whos tests
@@ -350,7 +350,7 @@ def test_whos():
         files = glob(filt)
         assert_(len(files) > 0,
                 "No files for test %s using filter %s" % (name, filt))
-        yield _whos_check_case, name, files, expected, classes
+        _whos_check_case(name, files, expected, classes)
 
 
 # generator for round trip tests
@@ -360,7 +360,7 @@ def test_round_trip():
         name = case['name'] + '_round_trip'
         expected = case['expected']
         for format in (['4', '5'] if case['name'] in case_table4_names else ['5']):
-            yield _rt_check_case, name, expected, format
+            _rt_check_case(name, expected, format)
 
 
 def test_gzip_simple():

--- a/scipy/io/matlab/tests/test_streams.py
+++ b/scipy/io/matlab/tests/test_streams.py
@@ -126,7 +126,7 @@ class TestZlibInputStream(object):
 
         for size in SIZES:
             for read_size in READ_SIZES:
-                yield check, size, read_size
+                check(size, read_size)
 
     def test_read_max_length(self):
         size = 1234

--- a/scipy/io/tests/test_wavfile.py
+++ b/scipy/io/tests/test_wavfile.py
@@ -155,5 +155,5 @@ def test_write_roundtrip():
                     for rate in (8000, 32000):
                         for channels in (1, 2, 5):
                             dt = np.dtype('%s%s%s' % (endianness, dtypechar, size))
-                            yield _check_roundtrip, realfile, rate, dt, channels
+                            _check_roundtrip(realfile, rate, dt, channels)
 

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -643,11 +643,11 @@ def test_eigh():
                 for turbo in v['turbo']:
                     for eigenvalues in v['eigvals']:
                         for lower in v['lower']:
-                            yield (eigenhproblem_standard,
+                            eigenhproblem_standard(
                                    'ordinary',
                                    dim, typ, overwrite, lower,
                                    turbo, eigenvalues)
-                            yield (eigenhproblem_general,
+                            eigenhproblem_general(
                                    'general ',
                                    dim, typ, overwrite, lower,
                                    turbo, eigenvalues)
@@ -2360,7 +2360,6 @@ def test_aligned_mem_complex():
     eig(z.T, overwrite_a=True)
 
 
-@pytest.mark.xfail(run=False, reason="Ticket #1152, triggers a segfault in rare cases.")
 def check_lapack_misaligned(func, args, kwargs):
     args = list(args)
     for i in range(len(args)):
@@ -2378,6 +2377,7 @@ def check_lapack_misaligned(func, args, kwargs):
                 func(*a,**kwargs)
 
 
+@pytest.mark.xfail(run=False, reason="Ticket #1152, triggers a segfault in rare cases.")
 def test_lapack_misaligned():
     M = np.eye(10,dtype=float)
     R = np.arange(100)
@@ -2405,7 +2405,7 @@ def test_lapack_misaligned():
             (hessenberg,(S,),dict(overwrite_a=True)),  # crash
             (schur,(S,),dict(overwrite_a=True)),  # crash
             ]:
-        yield check_lapack_misaligned, func, args, kwargs
+        check_lapack_misaligned(func, args, kwargs)
 # not properly tested
 # cholesky, rsf2csf, lu_solve, solve, eig_banded, eigvals_banded, eigh, diagsvd
 

--- a/scipy/linalg/tests/test_decomp_polar.py
+++ b/scipy/linalg/tests/test_decomp_polar.py
@@ -83,10 +83,10 @@ def verify_polar(a):
 
 def test_precomputed_cases():
     for a, side, expected_u, expected_p in precomputed_cases:
-        yield check_precomputed_polar, a, side, expected_u, expected_p
+        check_precomputed_polar(a, side, expected_u, expected_p)
 
 
 def test_verify_cases():
     for a in verify_cases:
-        yield verify_polar, a
+        verify_polar(a)
 

--- a/scipy/linalg/tests/test_decomp_update.py
+++ b/scipy/linalg/tests/test_decomp_update.py
@@ -1650,10 +1650,10 @@ def test_form_qTu():
     for qo, qs, uo, us, d in \
             itertools.product(q_order, q_shape, u_order, u_shape, dtype):
         if us == 1:
-            yield check_form_qTu, qo, qs, uo, us, 1, d
-            yield check_form_qTu, qo, qs, uo, us, 2, d
+            check_form_qTu(qo, qs, uo, us, 1, d)
+            check_form_qTu(qo, qs, uo, us, 2, d)
         else:
-            yield check_form_qTu, qo, qs, uo, us, 2, d
+            check_form_qTu(qo, qs, uo, us, 2, d)
     
 def check_form_qTu(q_order, q_shape, u_order, u_shape, u_ndim, dtype):
     np.random.seed(47)

--- a/scipy/linalg/tests/test_interpolative.py
+++ b/scipy/linalg/tests/test_interpolative.py
@@ -43,7 +43,7 @@ def _debug_print(s):
 class TestInterpolativeDecomposition(object):
     def test_id(self):
         for dtype in [np.float64, np.complex128]:
-            yield self.check_id, dtype
+            self.check_id(dtype)
 
     def check_id(self, dtype):
         # Test ID routines on a Hilbert matrix.

--- a/scipy/linalg/tests/test_solvers.py
+++ b/scipy/linalg/tests/test_solvers.py
@@ -298,7 +298,7 @@ def test_solve_continuous_are():
         assert_array_almost_equal(res, np.zeros_like(res), decimal=dec)
 
     for ind, case in enumerate(cases):
-        yield _test_factory, case, min_decimal[ind]
+        _test_factory(case, min_decimal[ind])
 
 
 def test_solve_discrete_are():
@@ -519,7 +519,7 @@ def test_solve_discrete_are():
         assert_array_almost_equal(res, np.zeros_like(res), decimal=dec)
 
     for ind, case in enumerate(cases):
-        yield _test_factory, case, min_decimal[ind]
+        _test_factory(case, min_decimal[ind])
 
 
 def test_solve_generalized_continuous_are():
@@ -569,7 +569,7 @@ def test_solve_generalized_continuous_are():
         assert_array_almost_equal(res, np.zeros_like(res), decimal=dec)
 
     for ind, case in enumerate(cases):
-        yield _test_factory, case, min_decimal[ind]
+        _test_factory(case, min_decimal[ind])
 
 
 def test_solve_generalized_discrete_are():
@@ -640,7 +640,7 @@ def test_solve_generalized_discrete_are():
         assert_array_almost_equal(res, np.zeros_like(res), decimal=dec)
 
     for ind, case in enumerate(cases):
-        yield _test_factory, case, min_decimal[ind]
+        _test_factory(case, min_decimal[ind])
 
 
 def test_are_validate_args():

--- a/scipy/linalg/tests/test_special_matrices.py
+++ b/scipy/linalg/tests/test_special_matrices.py
@@ -573,26 +573,26 @@ def test_invpascal():
     for n in ns:
         for kind in kinds:
             for exact in [True, False]:
-                yield check_invpascal, n, kind, exact
+                check_invpascal(n, kind, exact)
 
     ns = [19, 34, 35, 50]
     for n in ns:
         for kind in kinds:
-            yield check_invpascal, n, kind, True
+            check_invpascal(n, kind, True)
 
 
 def test_dft():
     m = dft(2)
     expected = array([[1.0, 1.0], [1.0, -1.0]])
-    yield (assert_array_almost_equal, m, expected)
+    assert_array_almost_equal(m, expected)
     m = dft(2, scale='n')
-    yield (assert_array_almost_equal, m, expected/2.0)
+    assert_array_almost_equal(m, expected/2.0)
     m = dft(2, scale='sqrtn')
-    yield (assert_array_almost_equal, m, expected/sqrt(2.0))
+    assert_array_almost_equal(m, expected/sqrt(2.0))
 
     x = array([0, 1, 2, 3, 4, 5, 0, 1])
     m = dft(8)
     mx = m.dot(x)
     fx = fftpack.fft(x)
-    yield (assert_array_almost_equal, mx, fx)
+    assert_array_almost_equal(mx, fx)
 

--- a/scipy/misc/tests/test_pilutil.py
+++ b/scipy/misc/tests/test_pilutil.py
@@ -144,8 +144,7 @@ class TestPILUtil(object):
                 shutil.rmtree(tmpdir)
 
 
-@_pilskip
-def tst_fromimage(filename, irange, shape):
+def check_fromimage(filename, irange, shape):
     fp = open(filename, "rb")
     img = misc.fromimage(PIL.Image.open(fp))
     fp.close()
@@ -155,6 +154,7 @@ def tst_fromimage(filename, irange, shape):
     assert_equal(img.shape, shape)
 
 
+@_pilskip
 def test_fromimage():
     # Test generator for parametric tests
     # Tuples in the list are (filename, (datamin, datamax), shape).
@@ -162,7 +162,7 @@ def test_fromimage():
              ('icon_mono.png', (0, 255), (48, 48, 4)),
              ('icon_mono_flat.png', (0, 255), (48, 48, 3))]
     for fn, irange, shape in files:
-        yield tst_fromimage, os.path.join(datapath, 'data', fn), irange, shape
+        check_fromimage(os.path.join(datapath, 'data', fn), irange, shape)
 
 
 @_pilskip

--- a/scipy/ndimage/tests/test_c_api.py
+++ b/scipy/ndimage/tests/test_c_api.py
@@ -55,7 +55,7 @@ def test_generic_filter():
         assert_allclose(res, std, err_msg="#{} failed".format(j))
 
     for j, func in enumerate(FILTER2D_FUNCTIONS):
-        yield check, j
+        check(j)
 
 
 def test_generic_filter1d():
@@ -79,7 +79,7 @@ def test_generic_filter1d():
         assert_allclose(res, std, err_msg="#{} failed".format(j))
 
     for j, func in enumerate(FILTER1D_FUNCTIONS):
-        yield check, j
+        check(j)
 
 
 def test_geometric_transform():
@@ -97,4 +97,4 @@ def test_geometric_transform():
         assert_allclose(res, std, err_msg="#{} failed".format(j))
 
     for j, func in enumerate(TRANSFORM_FUNCTIONS):
-        yield check, j
+        check(j)

--- a/scipy/optimize/tests/test_nonlin.py
+++ b/scipy/optimize/tests/test_nonlin.py
@@ -120,9 +120,9 @@ class TestNonlin(object):
             for func in SOLVERS.values():
                 if func in f.KNOWN_BAD.values():
                     if func in MUST_WORK.values():
-                        yield self._check_func_fail, f, func
+                        self._check_func_fail(f, func)
                     continue
-                yield self._check_nonlin_func, f, func
+                self._check_nonlin_func(f, func)
 
     def test_tol_norm_called(self):
         # Check that supplying tol_norm keyword to nonlin_solve works
@@ -141,9 +141,9 @@ class TestNonlin(object):
             for meth in SOLVERS:
                 if meth in f.KNOWN_BAD:
                     if meth in MUST_WORK:
-                        yield self._check_func_fail, f, meth
+                        self._check_func_fail(f, meth)
                     continue
-                yield self._check_root, f, meth
+                self._check_root(f, meth)
 
 
 class TestSecant(object):

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -21,7 +21,6 @@ from numpy.testing import (assert_raises, assert_allclose, assert_equal,
 import pytest
 
 from scipy._lib._numpy_compat import suppress_warnings
-from scipy._lib._testutils import suppressed_stdout
 from scipy import optimize
 
 
@@ -93,7 +92,6 @@ class CheckOptimize(object):
 
 class CheckOptimizeParameterized(CheckOptimize):
 
-    @suppressed_stdout
     def test_cg(self):
         # conjugate gradient optimization routine
         if self.use_wrapper:
@@ -136,7 +134,6 @@ class CheckOptimizeParameterized(CheckOptimize):
             assert_(sol.success)
             assert_allclose(sol.x, [0.5], rtol=1e-5)
 
-    @suppressed_stdout
     def test_bfgs(self):
         # Broyden-Fletcher-Goldfarb-Shanno optimization routine
         if self.use_wrapper:
@@ -170,7 +167,6 @@ class CheckOptimizeParameterized(CheckOptimize):
                          [7.323472e-15, -5.248650e-01, 4.875251e-01]],
                         atol=1e-14, rtol=1e-7)
 
-    @suppressed_stdout
     def test_bfgs_infinite(self):
         # Test corner case where -Inf is the minimum.  See gh-2019.
         func = lambda x: -np.e**-x
@@ -188,7 +184,6 @@ class CheckOptimizeParameterized(CheckOptimize):
         finally:
             np.seterr(**olderr)
 
-    @suppressed_stdout
     def test_powell(self):
         # Powell (direction set) optimization routine
         if self.use_wrapper:
@@ -230,7 +225,6 @@ class CheckOptimizeParameterized(CheckOptimize):
                          [1.72949016, -0.44156936, 0.47576729]],
                         atol=1e-14, rtol=1e-7)
 
-    @suppressed_stdout
     def test_neldermead(self):
         # Nelder-Mead simplex algorithm
         if self.use_wrapper:
@@ -262,7 +256,6 @@ class CheckOptimizeParameterized(CheckOptimize):
                          [0.19572515, -0.63648426, 0.35838135]],
                         atol=1e-14, rtol=1e-7)
 
-    @suppressed_stdout
     def test_neldermead_initial_simplex(self):
         # Nelder-Mead simplex algorithm
         simplex = np.zeros((4, 3))
@@ -301,7 +294,6 @@ class CheckOptimizeParameterized(CheckOptimize):
                          [0.14474003, -0.5282084, 0.48743951]],
                         atol=1e-14, rtol=1e-7)
 
-    @suppressed_stdout
     def test_neldermead_initial_simplex_bad(self):
         # Check it fails with a bad simplices
         bad_simplices = []
@@ -328,7 +320,6 @@ class CheckOptimizeParameterized(CheckOptimize):
                               full_output=True, disp=False, retall=False,
                               initial_simplex=simplex)
 
-    @suppressed_stdout
     def test_ncg(self):
         # line-search Newton conjugate gradient optimization routine
         if self.use_wrapper:
@@ -362,7 +353,6 @@ class CheckOptimizeParameterized(CheckOptimize):
                          [-4.35700753e-07, -5.24869401e-01, 4.87527774e-01]],
                         atol=1e-6, rtol=1e-7)
 
-    @suppressed_stdout
     def test_ncg_hess(self):
         # Newton conjugate gradient with Hessian
         if self.use_wrapper:
@@ -397,7 +387,6 @@ class CheckOptimizeParameterized(CheckOptimize):
                          [-4.35700753e-07, -5.24869401e-01, 4.87527774e-01]],
                         atol=1e-6, rtol=1e-7)
 
-    @suppressed_stdout
     def test_ncg_hessp(self):
         # Newton conjugate gradient with Hessian times a vector p.
         if self.use_wrapper:
@@ -1164,7 +1153,6 @@ class TestBrute:
     def func(self, z, *params):
         return self.f1(z, *params) + self.f2(z, *params) + self.f3(z, *params)
 
-    @suppressed_stdout
     def test_brute(self):
         # test fmin
         resbrute = optimize.brute(self.func, self.rranges, args=self.params,

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -692,7 +692,9 @@ class TestOptimizeSimple(CheckOptimize):
             assert_(func(sol1.x) < func(sol2.x),
                     "%s: %s vs. %s" % (method, func(sol1.x), func(sol2.x)))
 
-    def test_no_increase(self):
+    @pytest.mark.parametrize('method', ['nelder-mead', 'powell', 'cg', 'bfgs', 'newton-cg',
+                              'l-bfgs-b', 'tnc', 'cobyla', 'slsqp'])
+    def test_no_increase(self, method):
         # Check that the solver doesn't return a value worse than the
         # initial point.
 
@@ -704,24 +706,18 @@ class TestOptimizeSimple(CheckOptimize):
             # where line searches start failing
             return 2*(x - 1) * (-1) - 2
 
-        def check(method):
-            x0 = np.array([2.0])
-            f0 = func(x0)
-            jac = bad_grad
-            if method in ['nelder-mead', 'powell', 'cobyla']:
-                jac = None
-            sol = optimize.minimize(func, x0, jac=jac, method=method,
-                                    options=dict(maxiter=20))
-            assert_equal(func(sol.x), sol.fun)
+        x0 = np.array([2.0])
+        f0 = func(x0)
+        jac = bad_grad
+        if method in ['nelder-mead', 'powell', 'cobyla']:
+            jac = None
+        sol = optimize.minimize(func, x0, jac=jac, method=method,
+                                options=dict(maxiter=20))
+        assert_equal(func(sol.x), sol.fun)
 
-            if method == 'slsqp':
-                pytest.xfail("SLSQP returns slightly worse")
-            assert_(func(sol.x) <= f0)
-
-        for method in ['nelder-mead', 'powell', 'cg', 'bfgs',
-                       'newton-cg', 'l-bfgs-b', 'tnc',
-                       'cobyla', 'slsqp']:
-            yield check, method
+        if method == 'slsqp':
+            pytest.xfail("SLSQP returns slightly worse")
+        assert_(func(sol.x) <= f0)
 
     def test_slsqp_respect_bounds(self):
         # Regression test for gh-3108

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -238,7 +238,7 @@ class TestPlacePoles(object):
 
 class TestSS2TF:
 
-    def tst_matrix_shapes(self, p, q, r):
+    def check_matrix_shapes(self, p, q, r):
         ss2tf(np.zeros((p, p)),
               np.zeros((p, q)),
               np.zeros((r, p)),
@@ -248,7 +248,7 @@ class TestSS2TF:
         # Each tuple holds:
         #   number of states, number of inputs, number of outputs
         for p, q, r in [(3, 3, 3), (1, 3, 3), (1, 1, 1)]:
-            yield self.tst_matrix_shapes, p, q, r
+            self.check_matrix_shapes(p, q, r)
 
     def test_basic(self):
         # Test a round trip through tf2ss and ss2tf.

--- a/scipy/signal/tests/test_savitzky_golay.py
+++ b/scipy/signal/tests/test_savitzky_golay.py
@@ -30,7 +30,7 @@ def test_polyder():
         ([[3, 2, 1], [5, 6, 7]], 3, [[0], [0]]),
     ]
     for p, m, expected in cases:
-        yield check_polyder, np.array(p).T, m, np.array(expected).T
+        check_polyder(np.array(p).T, m, np.array(expected).T)
 
 
 #--------------------------------------------------------------------
@@ -89,7 +89,7 @@ def test_sg_coeffs_compare():
     # Compare savgol_coeffs() to alt_sg_coeffs().
     for window_length in range(1, 8, 2):
         for order in range(window_length):
-            yield compare_coeffs_to_alt, window_length, order
+            compare_coeffs_to_alt(window_length, order)
 
 
 def test_sg_coeffs_exact():

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1665,19 +1665,19 @@ def test_filtfilt_gust():
         signal_len = 5 * approx_impulse_len
 
         # 1-d test case
-        yield check_filtfilt_gust, b, a, (signal_len,), 0, irlen
+        check_filtfilt_gust(b, a, (signal_len,), 0, irlen)
 
         # 3-d test case; test each axis.
         for axis in range(3):
             shape = [2, 2, 2]
             shape[axis] = signal_len
-            yield check_filtfilt_gust, b, a, shape, axis, irlen
+            check_filtfilt_gust(b, a, shape, axis, irlen)
 
     # Test case with length less than 2*approx_impulse_len.
     # In this case, `filtfilt_gust` should behave the same as if
     # `irlen=None` was given.
     length = 2*approx_impulse_len - 50
-    yield check_filtfilt_gust, b, a, (length,), 0, approx_impulse_len
+    check_filtfilt_gust(b, a, (length,), 0, approx_impulse_len)
 
 
 class TestDecimate(object):

--- a/scipy/sparse/csgraph/tests/test_graph_laplacian.py
+++ b/scipy/sparse/csgraph/tests/test_graph_laplacian.py
@@ -68,7 +68,7 @@ def test_symmetric_graph_laplacian():
             'np.vander(np.arange(4)) + np.vander(np.arange(4)).T')
     for mat_str in symmetric_mats:
         for normed in True, False:
-            yield _check_symmetric_graph_laplacian, mat_str, normed
+            _check_symmetric_graph_laplacian(mat_str, normed)
 
 
 def _assert_allclose_sparse(a, b, **kwargs):
@@ -132,5 +132,5 @@ def test_sparse_formats():
     for fmt in ('csr', 'csc', 'coo', 'lil', 'dok', 'dia', 'bsr'):
         mat = sparse.diags([1, 1], [-1, 1], shape=(4,4), format=fmt)
         for normed in True, False:
-            yield _check_symmetric_graph_laplacian, mat, normed
+            _check_symmetric_graph_laplacian(mat, normed)
 

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -68,7 +68,7 @@ def test_dijkstra_limit():
         assert_array_almost_equal(SP, result)
 
     for limit, result in zip(limits, results):
-        yield check, limit, result
+        check(limit, result)
 
 
 def test_directed():
@@ -78,7 +78,7 @@ def test_directed():
         assert_array_almost_equal(SP, directed_SP)
 
     for method in methods:
-        yield check, method
+        check(method)
 
 
 def test_undirected():
@@ -94,7 +94,7 @@ def test_undirected():
 
     for method in methods:
         for directed_in in (True, False):
-            yield check, method, directed_in
+            check(method, directed_in)
 
 
 def test_shortest_path_indices():
@@ -108,7 +108,7 @@ def test_shortest_path_indices():
 
     for indshape in [(4,), (4, 1), (2, 2)]:
         for func in (dijkstra, bellman_ford, johnson, shortest_path):
-            yield check, func, indshape
+            check(func, indshape)
 
     assert_raises(ValueError, shortest_path, directed_G, method='FW',
                   indices=indices)
@@ -129,7 +129,7 @@ def test_predecessors():
 
     for method in methods:
         for directed in (True, False):
-            yield check, method, directed
+            check(method, directed)
 
 
 def test_construct_shortest_path():
@@ -143,7 +143,7 @@ def test_construct_shortest_path():
 
     for method in methods:
         for directed in (True, False):
-            yield check, method, directed
+            check(method, directed)
 
 
 def test_unweighted_path():
@@ -160,7 +160,7 @@ def test_unweighted_path():
 
     for method in methods:
         for directed in (True, False):
-            yield check, method, directed
+            check(method, directed)
 
 
 def test_negative_cycles():
@@ -175,7 +175,7 @@ def test_negative_cycles():
 
     for method in ['FW', 'J', 'BF']:
         for directed in (True, False):
-            yield check, method, directed
+            check(method, directed)
 
 
 def test_masked_input():
@@ -187,7 +187,7 @@ def test_masked_input():
         assert_array_almost_equal(SP, directed_SP)
 
     for method in methods:
-        yield check, method
+        check(method)
 
 
 def test_overwrite():

--- a/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
@@ -376,8 +376,8 @@ def test_symmetric_modes():
                 for mattype in params.mattypes:
                     for (sigma, modes) in params.sigmas_modes.items():
                         for mode in modes:
-                            yield (eval_evec, symmetric, D, typ, k, which,
-                                    None, sigma, mattype, None, mode)
+                            eval_evec(symmetric, D, typ, k, which,
+                                      None, sigma, mattype, None, mode)
 
 
 def test_hermitian_modes():
@@ -391,8 +391,8 @@ def test_hermitian_modes():
                     continue  # BE invalid for complex
                 for mattype in params.mattypes:
                     for sigma in params.sigmas_modes:
-                        yield (eval_evec, symmetric, D, typ, k, which,
-                                None, sigma, mattype)
+                        eval_evec(symmetric, D, typ, k, which,
+                                  None, sigma, mattype)
 
 
 def test_symmetric_starting_vector():
@@ -402,7 +402,7 @@ def test_symmetric_starting_vector():
         for D in params.real_test_cases:
             for typ in 'fd':
                 v0 = random.rand(len(D['v0'])).astype(typ)
-                yield (eval_evec, symmetric, D, typ, k, 'LM', v0)
+                eval_evec(symmetric, D, typ, k, 'LM', v0)
 
 
 def test_symmetric_no_convergence():
@@ -430,8 +430,8 @@ def test_real_nonsymmetric_modes():
                 for mattype in params.mattypes:
                     for sigma, OPparts in params.sigmas_OPparts.items():
                         for OPpart in OPparts:
-                            yield (eval_evec, symmetric, D, typ, k, which,
-                                   None, sigma, mattype, OPpart)
+                            eval_evec(symmetric, D, typ, k, which,
+                                      None, sigma, mattype, OPpart)
 
 
 def test_complex_nonsymmetric_modes():
@@ -443,8 +443,8 @@ def test_complex_nonsymmetric_modes():
             for which in params.which:
                 for mattype in params.mattypes:
                     for sigma in params.sigmas_OPparts:
-                        yield (eval_evec, symmetric, D, typ, k, which,
-                               None, sigma, mattype)
+                        eval_evec(symmetric, D, typ, k, which,
+                                  None, sigma, mattype)
 
 
 def test_standard_nonsymmetric_starting_vector():
@@ -457,7 +457,7 @@ def test_standard_nonsymmetric_starting_vector():
                 A = d['mat']
                 n = A.shape[0]
                 v0 = random.rand(n).astype(typ)
-                yield (eval_evec, symmetric, d, typ, k, "LM", v0, sigma)
+                eval_evec(symmetric, d, typ, k, "LM", v0, sigma)
 
 
 def test_general_nonsymmetric_starting_vector():
@@ -470,7 +470,7 @@ def test_general_nonsymmetric_starting_vector():
                 A = d['mat']
                 n = A.shape[0]
                 v0 = random.rand(n).astype(typ)
-                yield (eval_evec, symmetric, d, typ, k, "LM", v0, sigma)
+                eval_evec(symmetric, d, typ, k, "LM", v0, sigma)
 
 
 def test_standard_nonsymmetric_no_convergence():

--- a/scipy/sparse/linalg/isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/isolve/tests/test_iterative.py
@@ -162,7 +162,7 @@ def test_maxiter():
     for solver in params.solvers:
         if solver in case.skip:
             continue
-        yield check_maxiter, solver, case
+        check_maxiter(solver, case)
 
 
 def assert_normclose(a, b, tol=1e-8):
@@ -195,7 +195,7 @@ def test_convergence():
         for case in params.cases:
             if solver in case.skip:
                 continue
-            yield check_convergence, solver, case
+            check_convergence(solver, case)
 
 
 def check_precond_dummy(solver, case):
@@ -236,7 +236,7 @@ def test_precond_dummy():
     for solver in params.solvers:
         if solver in case.skip:
             continue
-        yield check_precond_dummy, solver, case
+        check_precond_dummy(solver, case)
 
 
 def test_gmres_basic():
@@ -254,7 +254,7 @@ def test_reentrancy():
     non_reentrant = [cg, cgs, bicg, bicgstab, gmres, qmr]
     reentrant = [lgmres, minres]
     for solver in reentrant + non_reentrant:
-        yield _check_reentrancy, solver, solver in reentrant
+        _check_reentrancy(solver, solver in reentrant)
 
 
 def _check_reentrancy(solver, is_reentrant):

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -262,10 +262,11 @@ class _TestCommon(object):
             assert_raises(ValueError, bool, datsp)
             assert_(self.spmatrix([1]))
             assert_(not self.spmatrix([0]))
+
+        if isinstance(self, TestDOK):
+            pytest.skip("Cannot create a rank <= 2 DOK matrix.")
         for dtype in self.checked_dtypes:
-            fails = isinstance(self, TestDOK)
-            msg = "Cannot create a rank <= 2 DOK matrix."
-            yield skipif_yield(fails, reason=msg)(check), dtype
+            check(dtype)
 
     def test_bool_rollover(self):
         # bool's underlying dtype is 1 byte, check that it does not
@@ -309,10 +310,10 @@ class _TestCommon(object):
             assert_array_equal(dat == 1, (datsp == 1).todense())
             assert_array_equal(dat == np.nan, (datsp == np.nan).todense())
 
-        msg = "Bool comparisons only implemented for BSR, CSC, and CSR."
-        fails = not isinstance(self, (TestBSR, TestCSC, TestCSR))
+        if not isinstance(self, (TestBSR, TestCSC, TestCSR)):
+            pytest.skip("Bool comparisons only implemented for BSR, CSC, and CSR.")
         for dtype in self.checked_dtypes:
-            yield skipif_yield(fails, reason=msg)(check), dtype
+            check(dtype)
 
     def test_ne(self):
         sup = suppress_warnings()
@@ -347,10 +348,10 @@ class _TestCommon(object):
             assert_array_equal(1 != dat, (1 != datsp).todense())
             assert_array_equal(dat != np.nan, (datsp != np.nan).todense())
 
-        msg = "Bool comparisons only implemented for BSR, CSC, and CSR."
-        fails = not isinstance(self, (TestBSR, TestCSC, TestCSR))
+        if not isinstance(self, (TestBSR, TestCSC, TestCSR)):
+            pytest.skip("Bool comparisons only implemented for BSR, CSC, and CSR.")
         for dtype in self.checked_dtypes:
-            yield skipif_yield(fails, reason=msg)(check), dtype
+            check(dtype)
 
     def test_lt(self):
         sup = suppress_warnings()
@@ -414,11 +415,10 @@ class _TestCommon(object):
             # dense rhs
             assert_array_equal(dat < datsp2, datsp < dat2)
 
-        msg = "Bool comparisons only implemented for BSR, CSC, and CSR."
-        fails = not isinstance(self, (TestBSR, TestCSC, TestCSR))
+        if not isinstance(self, (TestBSR, TestCSC, TestCSR)):
+            pytest.skip("Bool comparisons only implemented for BSR, CSC, and CSR.")
         for dtype in self.checked_dtypes:
-            with np.errstate(invalid='ignore'):
-                yield skipif_yield(fails, reason=msg)(check), dtype
+            check(dtype)
 
     def test_gt(self):
         sup = suppress_warnings()
@@ -481,10 +481,10 @@ class _TestCommon(object):
             # dense rhs
             assert_array_equal(dat > datsp2, datsp > dat2)
 
-        msg = "Bool comparisons only implemented for BSR, CSC, and CSR."
-        fails = not isinstance(self, (TestBSR, TestCSC, TestCSR))
+        if not isinstance(self, (TestBSR, TestCSC, TestCSR)):
+            pytest.skip("Bool comparisons only implemented for BSR, CSC, and CSR.")
         for dtype in self.checked_dtypes:
-            yield skipif_yield(fails, reason=msg)(check), dtype
+            check(dtype)
 
     def test_le(self):
         sup = suppress_warnings()
@@ -543,10 +543,10 @@ class _TestCommon(object):
             # dense rhs
             assert_array_equal(dat <= datsp2, datsp <= dat2)
 
-        msg = "Bool comparisons only implemented for BSR, CSC, and CSR."
-        fails = not isinstance(self, (TestBSR, TestCSC, TestCSR))
+        if not isinstance(self, (TestBSR, TestCSC, TestCSR)):
+            pytest.skip("Bool comparisons only implemented for BSR, CSC, and CSR.")
         for dtype in self.checked_dtypes:
-            yield skipif_yield(fails, reason=msg)(check), dtype
+            check(dtype)
 
     def test_ge(self):
         sup = suppress_warnings()
@@ -606,10 +606,10 @@ class _TestCommon(object):
             # dense rhs
             assert_array_equal(dat >= datsp2, datsp >= dat2)
 
-        msg = "Bool comparisons only implemented for BSR, CSC, and CSR."
-        fails = not isinstance(self, (TestBSR, TestCSC, TestCSR))
+        if not isinstance(self, (TestBSR, TestCSC, TestCSR)):
+            pytest.skip("Bool comparisons only implemented for BSR, CSC, and CSR.")
         for dtype in self.checked_dtypes:
-            yield skipif_yield(fails, reason=msg)(check), dtype
+            check(dtype)
 
     def test_empty(self):
         # create empty matrices
@@ -845,7 +845,7 @@ class _TestCommon(object):
 
         for dtype in self.checked_dtypes:
             for j in range(len(matrices)):
-                yield check, dtype, j
+                check(dtype, j)
 
     def test_sum_invalid_params(self):
         out = np.asmatrix(np.zeros((1, 3)))
@@ -873,7 +873,7 @@ class _TestCommon(object):
             assert_equal(dat_mean.dtype, datsp_mean.dtype)
 
         for dtype in self.checked_dtypes:
-            yield check, dtype
+            check(dtype)
 
     def test_sum_out(self):
         dat = np.matrix([[0, 1, 2],
@@ -930,7 +930,7 @@ class _TestCommon(object):
             assert_equal(dat.mean(axis=-1).dtype, datsp.mean(axis=-1).dtype)
 
         for dtype in self.checked_dtypes:
-            yield check, dtype
+            check(dtype)
 
     def test_mean_invalid_params(self):
         out = np.asmatrix(np.zeros((1, 3)))
@@ -958,7 +958,7 @@ class _TestCommon(object):
             assert_equal(dat_mean.dtype, datsp_mean.dtype)
 
         for dtype in self.checked_dtypes:
-            yield check, dtype
+            check(dtype)
 
     def test_mean_out(self):
         dat = np.matrix([[0, 1, 2],
@@ -1028,7 +1028,7 @@ class _TestCommon(object):
                 sMinv = inv(sM)
             assert_array_almost_equal(sMinv.dot(sM).todense(), np.eye(3))
         for dtype in [float]:
-            yield check, dtype
+            check(dtype)
 
     @sup_complex
     def test_from_array(self):
@@ -1196,7 +1196,7 @@ class _TestCommon(object):
             assert_array_equal(dat*17.3,(datsp*17.3).todense())
 
         for dtype in self.math_dtypes:
-            yield check, dtype
+            check(dtype)
 
     def test_rmul_scalar(self):
         def check(dtype):
@@ -1207,7 +1207,7 @@ class _TestCommon(object):
             assert_array_equal(17.3*dat,(17.3*datsp).todense())
 
         for dtype in self.math_dtypes:
-            yield check, dtype
+            check(dtype)
 
     def test_add(self):
         def check(dtype):
@@ -1229,7 +1229,7 @@ class _TestCommon(object):
             assert_array_equal(c, b.todense() + a[0])
 
         for dtype in self.math_dtypes:
-            yield check, dtype
+            check(dtype)
 
     def test_radd(self):
         def check(dtype):
@@ -1243,7 +1243,7 @@ class _TestCommon(object):
             assert_array_equal(c, a + b.todense())
 
         for dtype in self.math_dtypes:
-            yield check, dtype
+            check(dtype)
 
     def test_sub(self):
         def check(dtype):
@@ -1265,7 +1265,7 @@ class _TestCommon(object):
                 # boolean array subtraction deprecated in 1.9.0
                 continue
 
-            yield check, dtype
+            check(dtype)
 
     def test_rsub(self):
         def check(dtype):
@@ -1290,7 +1290,7 @@ class _TestCommon(object):
                 # boolean array subtraction deprecated in 1.9.0
                 continue
 
-            yield check, dtype
+            check(dtype)
 
     def test_add0(self):
         def check(dtype):
@@ -1305,7 +1305,7 @@ class _TestCommon(object):
             assert_almost_equal(sumS.todense(), sumD)
 
         for dtype in self.math_dtypes:
-            yield check, dtype
+            check(dtype)
 
     def test_elementwise_multiply(self):
         # real/real
@@ -1666,7 +1666,7 @@ class _TestCommon(object):
 
         for dtype in self.checked_dtypes:
             for j in range(len(matrices)):
-                yield check, dtype, j
+                check(dtype, j)
 
     def test_add_dense(self):
         def check(dtype):
@@ -1680,7 +1680,7 @@ class _TestCommon(object):
             assert_array_equal(sum2, dat + dat)
 
         for dtype in self.math_dtypes:
-            yield check, dtype
+            check(dtype)
 
     def test_sub_dense(self):
         # subtracting a dense matrix to/from a sparse matrix
@@ -1708,7 +1708,7 @@ class _TestCommon(object):
                 # boolean array subtraction deprecated in 1.9.0
                 continue
 
-            yield check, dtype
+            check(dtype)
 
     def test_maximum_minimum(self):
         A_dense = np.array([[1, 0, 3], [0, 4, 5], [0, 0, 0]])
@@ -1750,7 +1750,7 @@ class _TestCommon(object):
         for dtype in self.math_dtypes:
             for dtype2 in [np.int8, np.float_, np.complex_]:
                 for btype in ['scalar', 'scalar2', 'dense', 'sparse']:
-                    yield check, np.dtype(dtype), np.dtype(dtype2), btype
+                    check(np.dtype(dtype), np.dtype(dtype2), btype)
 
     def test_copy(self):
         # Check whether the copy=True and copy=False keywords work
@@ -1903,8 +1903,9 @@ class _TestCommon(object):
                      "arcsinh", "arctanh", "rint", "sign", "expm1", "log1p",
                      "deg2rad", "rad2deg", "floor", "ceil", "trunc", "sqrt",
                      "abs"]:
-            yield check, name
+            check(name)
 
+    @skipif_yield(not HAS_NUMPY_UFUNC, reason="feature requires Numpy with __numpy_ufunc__")
     def test_binary_ufunc_overrides(self):
         # data
         a = np.array([[1, 2, 3],
@@ -1923,7 +1924,6 @@ class _TestCommon(object):
         a_items = dict(dense=a, scalar=c, cplx_scalar=d, int_scalar=e, sparse=asp)
         b_items = dict(dense=b, scalar=c, cplx_scalar=d, int_scalar=e, sparse=bsp)
 
-        @skipif_yield(not HAS_NUMPY_UFUNC, reason="feature requires Numpy with __numpy_ufunc__")
         def check(i, j, dtype):
             ax = a_items[i]
             bx = b_items[j]
@@ -2022,7 +2022,7 @@ class _TestCommon(object):
             for j in b_items.keys():
                 for dtype in [np.int_, np.float_, np.complex_]:
                     if i == 'sparse' or j == 'sparse':
-                        yield check, i, j, dtype
+                        check(i, j, dtype)
 
     @skipif_yield(not HAS_NUMPY_UFUNC, reason="feature requires Numpy with __numpy_ufunc__")
     def test_ufunc_object_array(self):
@@ -2107,7 +2107,7 @@ class _TestInplaceArithmetic(object):
                 assert_array_equal(b, a.todense())
 
         for dtype in self.math_dtypes:
-            yield check, dtype
+            check(dtype)
 
     def test_idiv_scalar(self):
         def check(dtype):
@@ -2132,7 +2132,7 @@ class _TestInplaceArithmetic(object):
             # /= should only be used with float dtypes to avoid implicit
             # casting.
             if not np.can_cast(dtype, np.int_):
-                yield check, dtype
+                check(dtype)
 
     def test_inplace_success(self):
         # Inplace ops should work even if a specialized version is not
@@ -2175,7 +2175,7 @@ class _TestGetSet(object):
                 assert_raises((IndexError, TypeError), A.__getitem__, ij)
 
         for dtype in supported_dtypes:
-            yield check, np.dtype(dtype)
+            check(np.dtype(dtype))
 
     def test_setelement(self):
         def check(dtype):
@@ -2206,7 +2206,7 @@ class _TestGetSet(object):
                     assert_raises(TypeError, A.__setitem__, (0,0), v)
 
         for dtype in supported_dtypes:
-            yield check, np.dtype(dtype)
+            check(np.dtype(dtype))
 
     def test_negative_index_assignment(self):
         # Regression test for github issue 4428.
@@ -2220,7 +2220,7 @@ class _TestGetSet(object):
             assert_equal(A[0, -4], 1)
 
         for dtype in self.math_dtypes:
-            yield check, np.dtype(dtype)
+            check(np.dtype(dtype))
 
     def test_scalar_assign_2(self):
         n, m = (5, 10)
@@ -2415,7 +2415,7 @@ class _TestSlicing(object):
                     assert_array_equal(x.todense(), y, repr(a))
 
         for j, a in enumerate(slices):
-            yield check_1, a
+            check_1(a)
 
         def check_2(a, b):
             # Indexing np.matrix with 0-d arrays seems to be broken,
@@ -2443,7 +2443,7 @@ class _TestSlicing(object):
 
         for i, a in enumerate(slices):
             for j, b in enumerate(slices):
-                yield check_2, a, b
+                check_2(a, b)
 
     def test_ellipsis_slicing(self):
         b = asmatrix(arange(50).reshape(5,10))
@@ -2863,7 +2863,7 @@ class _TestFancyIndexingAssign(object):
                 assert_equal(A.sum(), dtype.type(1)*4 + dtype.type(1))
 
         for dtype in supported_dtypes:
-            yield check, np.dtype(dtype)
+            check(np.dtype(dtype))
 
     def test_sequence_assignment(self):
         A = self.spmatrix((4,3))
@@ -4437,7 +4437,7 @@ class _NonCanonicalCSMixin(_NonCanonicalCompressedMixin):
 
         for dtype in supported_dtypes:
             for sorted_indices in [False, True]:
-                yield check, np.dtype(dtype), sorted_indices
+                check(np.dtype(dtype), sorted_indices)
 
     @pytest.mark.xfail(run=False, reason='inverse broken with non-canonical matrix')
     def test_inv(self):
@@ -4503,6 +4503,7 @@ class Test64Bit(object):
     # The following features are missing, so skip the tests:
     SKIP_TESTS = {
         'test_expm': 'expm for 64-bit indices not available',
+        'test_inv': 'linsolve for 64-bit indices not available',
         'test_solve': 'linsolve for 64-bit indices not available',
         'test_scalar_idx_dtype': 'test implemented in base class',
     }
@@ -4533,7 +4534,7 @@ class Test64Bit(object):
             assert_(self._compare_index_dtype(m, np.int64))
 
         for mat_cls in self.MAT_CLASSES:
-            yield check, mat_cls
+            check(mat_cls)
 
     def test_decorator_maxval_random(self):
         # Test that the with_64bit_maxval_limit decorator works (2)
@@ -4552,7 +4553,7 @@ class Test64Bit(object):
                 raise AssertionError("both 32 and 64 bit indices not seen")
 
         for mat_cls in self.MAT_CLASSES:
-            yield check, mat_cls
+            check(mat_cls)
 
     def _check_resiliency(self, **kw):
         # Resiliency test, to check that sparse matrices deal reasonably

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -4490,7 +4490,6 @@ class TestCOONonCanonical(_NonCanonicalMixin, TestCOO):
         assert_(np.all(np.diff(m.col) >= 0))
 
 
-
 def cases_64bit():
     TEST_CLASSES = [TestBSR, TestCOO, TestCSC, TestCSR, TestDIA,
                     # lil/dok->other conversion operations have get_index_dtype

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -21,6 +21,7 @@ Run tests if sparse is not installed:
 
 import operator
 import contextlib
+import functools
 
 import numpy as np
 from scipy._lib.six import xrange, zip as izip
@@ -3367,6 +3368,7 @@ def _possibly_unimplemented(cls, require=True):
         return cls
     else:
         def wrap(fc):
+            @functools.wraps(fc)
             def wrapper(*a, **kw):
                 try:
                     return fc(*a, **kw)
@@ -3374,7 +3376,6 @@ def _possibly_unimplemented(cls, require=True):
                         IndexError, AttributeError):
                     raise pytest.skip("feature not implemented")
 
-            wrapper.__name__ = fc.__name__
             return wrapper
 
         new_dict = dict(cls.__dict__)
@@ -4505,7 +4506,7 @@ def cases_64bit():
     }
 
     for cls in TEST_CLASSES:
-        for method_name in dir(cls):
+        for method_name in sorted(dir(cls)):
             method = getattr(cls, method_name)
             if (method_name.startswith('test_') and
                     not getattr(method, 'slow', False)):

--- a/scipy/sparse/tests/test_csr.py
+++ b/scipy/sparse/tests/test_csr.py
@@ -26,7 +26,7 @@ def test_csr_rowslice():
 
     for i in range(N):
         for sl in slices:
-            yield _check_csr_rowslice, i, sl, X, Xcsr
+            _check_csr_rowslice(i, sl, X, Xcsr)
 
 
 def test_csr_getrow():

--- a/scipy/sparse/tests/test_sparsetools.py
+++ b/scipy/sparse/tests/test_sparsetools.py
@@ -11,7 +11,6 @@ from numpy.testing import (assert_raises, assert_equal, assert_, assert_allclose
 from scipy.sparse import (_sparsetools, coo_matrix, csr_matrix, csc_matrix,
                           bsr_matrix, dia_matrix)
 from scipy.sparse.sputils import supported_dtypes
-from scipy._lib._testutils import xslow_yield
 
 import pytest
 
@@ -60,6 +59,8 @@ def test_regression_std_vector_dtypes():
 
         # getcol is one function using std::vector typemaps, and should not fail
         assert_equal(a.getcol(0).todense(), ad[:,0])
+
+
 
 
 @pytest.mark.skipif(not (sys.platform.startswith('linux') and np.dtype(np.intp).itemsize >= 8),
@@ -135,9 +136,16 @@ class TestInt32Overflow(object):
         del data, offsets, m, v, r
         gc.collect()
 
+
+    _bsr_ops = [pytest.param("matmat", marks=pytest.mark.xslow),
+                pytest.param("matvecs", marks=pytest.mark.xslow),
+                "matvec",
+                "diagonal",
+                "sort_indices",
+                pytest.param("transpose", marks=pytest.mark.xslow)]
+
     @pytest.mark.slow
-    @pytest.mark.parametrize("op", ["matmat", "matvecs", "matvec", "diagonal",
-                                    "sort_indices", "transpose"])
+    @pytest.mark.parametrize("op", _bsr_ops)
     def test_bsr_1_block(self, op):
         # Check: huge bsr_matrix (1-block)
         #
@@ -159,8 +167,7 @@ class TestInt32Overflow(object):
             gc.collect()
 
     @pytest.mark.slow
-    @pytest.mark.parametrize("op", ["matmat", "matvecs", "matvec", "diagonal",
-                                    "sort_indices", "transpose"])
+    @pytest.mark.parametrize("op", _bsr_ops)
     def test_bsr_n_block(self, op):
         # Check: huge bsr_matrix (n-block)
         #
@@ -182,7 +189,6 @@ class TestInt32Overflow(object):
         finally:
             gc.collect()
 
-    @xslow_yield
     def _check_bsr_matvecs(self, m):
         m = m()
         n = self.n
@@ -212,13 +218,11 @@ class TestInt32Overflow(object):
         m = m()
         m.sort_indices()
 
-    @xslow_yield
     def _check_bsr_transpose(self, m):
         # _transpose
         m = m()
         m.transpose()
 
-    @xslow_yield
     def _check_bsr_matmat(self, m):
         m = m()
         n = self.n

--- a/scipy/sparse/tests/test_sparsetools.py
+++ b/scipy/sparse/tests/test_sparsetools.py
@@ -61,8 +61,6 @@ def test_regression_std_vector_dtypes():
         assert_equal(a.getcol(0).todense(), ad[:,0])
 
 
-
-
 @pytest.mark.skipif(not (sys.platform.startswith('linux') and np.dtype(np.intp).itemsize >= 8),
                     reason="test requires 64-bit Linux")
 class TestInt32Overflow(object):
@@ -135,7 +133,6 @@ class TestInt32Overflow(object):
         assert_equal(r[0], np.int8(n))
         del data, offsets, m, v, r
         gc.collect()
-
 
     _bsr_ops = [pytest.param("matmat", marks=pytest.mark.xslow),
                 pytest.param("matvecs", marks=pytest.mark.xslow),

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -1124,11 +1124,11 @@ class TestSquareForm(object):
 
     def test_squareform_matrix(self):
         for dtype in self.checked_dtypes:
-            yield self.check_squareform_matrix, dtype
+            self.check_squareform_matrix(dtype)
 
     def test_squareform_vector(self):
         for dtype in self.checked_dtypes:
-            yield self.check_squareform_vector, dtype
+            self.check_squareform_vector(dtype)
 
     def check_squareform_matrix(self, dtype):
         A = np.zeros((0,0), dtype=dtype)
@@ -1162,7 +1162,7 @@ class TestSquareForm(object):
 
     def test_squareform_multi_matrix(self):
         for n in xrange(2, 5):
-            yield self.check_squareform_multi_matrix, n
+            self.check_squareform_multi_matrix(n)
 
     def check_squareform_multi_matrix(self, n):
         X = np.random.rand(n, 4)

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -800,16 +800,16 @@ def test_onetree_query():
     k = 4
     points = np.random.randn(n,k)
     T = KDTree(points)
-    yield check_onetree_query, T, 0.1
+    check_onetree_query(T, 0.1)
 
     points = np.random.randn(3*n,k)
     points[:n] *= 0.001
     points[n:2*n] += 2
     T = KDTree(points)
-    yield check_onetree_query, T, 0.1
-    yield check_onetree_query, T, 0.001
-    yield check_onetree_query, T, 0.00001
-    yield check_onetree_query, T, 1e-6
+    check_onetree_query(T, 0.1)
+    check_onetree_query(T, 0.001)
+    check_onetree_query(T, 0.00001)
+    check_onetree_query(T, 1e-6)
 
 
 def test_onetree_query_compiled():
@@ -818,16 +818,16 @@ def test_onetree_query_compiled():
     k = 4
     points = np.random.randn(n,k)
     T = cKDTree(points)
-    yield check_onetree_query, T, 0.1
+    check_onetree_query(T, 0.1)
 
     points = np.random.randn(3*n,k)
     points[:n] *= 0.001
     points[n:2*n] += 2
     T = cKDTree(points)
-    yield check_onetree_query, T, 0.1
-    yield check_onetree_query, T, 0.001
-    yield check_onetree_query, T, 0.00001
-    yield check_onetree_query, T, 1e-6
+    check_onetree_query(T, 0.1)
+    check_onetree_query(T, 0.001)
+    check_onetree_query(T, 0.00001)
+    check_onetree_query(T, 1e-6)
 
 
 def test_query_pairs_single_node():

--- a/scipy/special/_testutils.py
+++ b/scipy/special/_testutils.py
@@ -4,6 +4,8 @@ import os
 
 from distutils.version import LooseVersion
 
+import functools
+
 import numpy as np
 from numpy.testing import assert_
 import pytest
@@ -39,12 +41,11 @@ def with_special_errors(func):
     Enable special function errors (such as underflow, overflow,
     loss of precision, etc.)
     """
+    @functools.wraps(func)
     def wrapper(*a, **kw):
         with sc.errstate(all='raise'):
             res = func(*a, **kw)
         return res
-    wrapper.__name__ = func.__name__
-    wrapper.__doc__ = func.__doc__
     return wrapper
 
 

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -3106,22 +3106,22 @@ def test_sph_harm():
     sqrt = np.sqrt
     sin = np.sin
     cos = np.cos
-    yield (assert_array_almost_equal, sh(0,0,0,0),
+    assert_array_almost_equal(sh(0,0,0,0),
            0.5/sqrt(pi))
-    yield (assert_array_almost_equal, sh(-2,2,0.,pi/4),
+    assert_array_almost_equal(sh(-2,2,0.,pi/4),
            0.25*sqrt(15./(2.*pi)) *
            (sin(pi/4))**2.)
-    yield (assert_array_almost_equal, sh(-2,2,0.,pi/2),
+    assert_array_almost_equal(sh(-2,2,0.,pi/2),
            0.25*sqrt(15./(2.*pi)))
-    yield (assert_array_almost_equal, sh(2,2,pi,pi/2),
+    assert_array_almost_equal(sh(2,2,pi,pi/2),
            0.25*sqrt(15/(2.*pi)) *
            exp(0+2.*pi*1j)*sin(pi/2.)**2.)
-    yield (assert_array_almost_equal, sh(2,4,pi/4.,pi/3.),
+    assert_array_almost_equal(sh(2,4,pi/4.,pi/3.),
            (3./8.)*sqrt(5./(2.*pi)) *
            exp(0+2.*pi/4.*1j) *
            sin(pi/3.)**2. *
            (7.*cos(pi/3.)**2.-1))
-    yield (assert_array_almost_equal, sh(4,4,pi/8.,pi/6.),
+    assert_array_almost_equal(sh(4,4,pi/8.,pi/6.),
            (3./16.)*sqrt(35./(2.*pi)) *
            exp(0+4.*pi/8.*1j)*sin(pi/6.)**4.)
 

--- a/scipy/special/tests/test_cython_special.py
+++ b/scipy/special/tests/test_cython_special.py
@@ -329,4 +329,4 @@ def test_cython_api():
                 assert_allclose(cyval, pyval, err_msg="{} {} {}".format(pt, typecodes, signature))
 
     for param in params:
-        yield check, param
+        check(param)

--- a/scipy/special/tests/test_data.py
+++ b/scipy/special/tests/test_data.py
@@ -5,6 +5,7 @@ import os
 import numpy as np
 from numpy import arccosh, arcsinh, arctanh
 from scipy._lib._numpy_compat import suppress_warnings
+import pytest
 
 from scipy.special import (
     lpn, lpmn, lpmv, lqn, lqmn, sph_harm, eval_legendre, eval_hermite,
@@ -198,8 +199,7 @@ def clog1p(x, y):
     z = log1p(x + 1j*y)
     return z.real, z.imag
 
-def test_boost():
-    TESTS = [
+BOOST_TESTS = [
         data(arccosh, 'acosh_data_ipp-acosh_data', 0, 1, rtol=5e-13),
         data(arccosh, 'acosh_data_ipp-acosh_data', 0j, 1, rtol=5e-13),
 
@@ -438,14 +438,15 @@ def test_boost():
         # 'powm1_sqrtp1m1_test_cpp-sqrtp1m1_data',
         # 'test_gamma_data_ipp-gammap1m1_data',
         # 'tgamma_ratio_data_ipp-tgamma_ratio_data',
-    ]
-
-    for test in TESTS:
-        yield _test_factory, test
+]
 
 
-def test_gsl():
-    TESTS = [
+@pytest.mark.parametrize('test', BOOST_TESTS, ids=repr)
+def test_boost(test):
+    _test_factory(test)
+
+
+GSL_TESTS = [
         data_gsl(mathieu_a, 'mathieu_ab', (0, 1), 2, rtol=1e-13, atol=1e-13),
         data_gsl(mathieu_b, 'mathieu_ab', (0, 1), 3, rtol=1e-13, atol=1e-13),
 
@@ -458,33 +459,30 @@ def test_gsl():
 
         data_gsl(mathieu_mc2_scaled, 'mathieu_mc_ms', (0, 1, 2), 5, rtol=1e-7, atol=1e-13),
         data_gsl(mathieu_ms2_scaled, 'mathieu_mc_ms', (0, 1, 2), 6, rtol=1e-7, atol=1e-13),
-    ]
-
-    for test in TESTS:
-        yield _test_factory, test
+]
 
 
-def test_local():
-    TESTS = [
-        data_local(ellipkinc, 'ellipkinc_neg_m', (0, 1), 2),
-        data_local(ellipkm1, 'ellipkm1', 0, 1),
-        data_local(ellipeinc, 'ellipeinc_neg_m', (0, 1), 2),
-        data_local(clog1p, 'log1p_expm1_complex', (0,1), (2,3), rtol=1e-14),
-        data_local(cexpm1, 'log1p_expm1_complex', (0,1), (4,5), rtol=1e-14),
-        data_local(gammainc, 'gammainc', (0, 1), 2, rtol=1e-12),
-        data_local(gammaincc, 'gammaincc', (0, 1), 2, rtol=1e-11)
-    ]
+@pytest.mark.parametrize('test', GSL_TESTS, ids=repr)
+def test_gsl(test):
+    _test_factory(test)
 
-    for test in TESTS:
-        yield _test_factory, test
 
-    TESTS = [
-        data_local(ellip_harm_2, 'ellip',(0, 1, 2, 3, 4), 6, rtol=1e-10, atol=1e-13),
-        data_local(ellip_harm, 'ellip',(0, 1, 2, 3, 4), 5, rtol=1e-10, atol=1e-13),
-    ]
+LOCAL_TESTS = [
+    data_local(ellipkinc, 'ellipkinc_neg_m', (0, 1), 2),
+    data_local(ellipkm1, 'ellipkm1', 0, 1),
+    data_local(ellipeinc, 'ellipeinc_neg_m', (0, 1), 2),
+    data_local(clog1p, 'log1p_expm1_complex', (0,1), (2,3), rtol=1e-14),
+    data_local(cexpm1, 'log1p_expm1_complex', (0,1), (4,5), rtol=1e-14),
+    data_local(gammainc, 'gammainc', (0, 1), 2, rtol=1e-12),
+    data_local(gammaincc, 'gammaincc', (0, 1), 2, rtol=1e-11),
+    data_local(ellip_harm_2, 'ellip',(0, 1, 2, 3, 4), 6, rtol=1e-10, atol=1e-13),
+    data_local(ellip_harm, 'ellip',(0, 1, 2, 3, 4), 5, rtol=1e-10, atol=1e-13),
+]
 
-    for test in TESTS:
-        yield _test_factory, test
+
+@pytest.mark.parametrize('test', LOCAL_TESTS, ids=repr)
+def test_local(test):
+    _test_factory(test)
 
 
 def _test_factory(test, dtype=np.double):

--- a/scipy/special/tests/test_spfun_stats.py
+++ b/scipy/special/tests/test_spfun_stats.py
@@ -58,5 +58,5 @@ def test_multigammaln_array_arg():
     ]
 
     for a, d in cases:
-        yield _check_multigammaln_array_result, a, d
+        _check_multigammaln_array_result(a, d)
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -151,6 +151,9 @@ def test_support(dist):
 
 
 class TestRandInt(object):
+    def setup_method(self):
+        np.random.seed(1234)
+
     def test_rvs(self):
         vals = stats.randint.rvs(5, 30, size=100)
         assert_(numpy.all(vals < 30) & numpy.all(vals >= 5))
@@ -179,6 +182,9 @@ class TestRandInt(object):
 
 
 class TestBinom(object):
+    def setup_method(self):
+        np.random.seed(1234)
+
     def test_rvs(self):
         vals = stats.binom.rvs(10, 0.75, size=(2, 50))
         assert_(numpy.all(vals >= 0) & numpy.all(vals <= 10))
@@ -222,6 +228,9 @@ class TestBinom(object):
 
 
 class TestBernoulli(object):
+    def setup_method(self):
+        np.random.seed(1234)
+
     def test_rvs(self):
         vals = stats.bernoulli.rvs(0.75, size=(2, 50))
         assert_(numpy.all(vals >= 0) & numpy.all(vals <= 1))
@@ -260,6 +269,9 @@ class TestBradford(object):
 
 
 class TestNBinom(object):
+    def setup_method(self):
+        np.random.seed(1234)
+
     def test_rvs(self):
         vals = stats.nbinom.rvs(10, 0.75, size=(2, 50))
         assert_(numpy.all(vals >= 0))
@@ -281,6 +293,9 @@ class TestNBinom(object):
 
 
 class TestGeom(object):
+    def setup_method(self):
+        np.random.seed(1234)
+
     def test_rvs(self):
         vals = stats.geom.rvs(0.75, size=(2, 50))
         assert_(numpy.all(vals >= 0))
@@ -366,6 +381,9 @@ class TestHalfgennorm(object):
 
 
 class TestTruncnorm(object):
+    def setup_method(self):
+        np.random.seed(1234)
+
     def test_ppf_ticket1131(self):
         vals = stats.truncnorm.ppf([-0.5, 0, 1e-4, 0.5, 1-1e-4, 1, 2], -1., 1.,
                                    loc=[3]*7, scale=2)
@@ -403,6 +421,9 @@ class TestTruncnorm(object):
 
 
 class TestHypergeom(object):
+    def setup_method(self):
+        np.random.seed(1234)
+
     def test_rvs(self):
         vals = stats.hypergeom.rvs(20, 10, 3, size=(2, 50))
         assert_(numpy.all(vals >= 0) &
@@ -528,6 +549,9 @@ class TestLogistic(object):
 
 
 class TestLogser(object):
+    def setup_method(self):
+        np.random.seed(1234)
+
     def test_rvs(self):
         vals = stats.logser.rvs(0.75, size=(2, 50))
         assert_(numpy.all(vals >= 1))
@@ -736,6 +760,9 @@ class TestGenpareto(object):
 
 
 class TestPearson3(object):
+    def setup_method(self):
+        np.random.seed(1234)
+
     def test_rvs(self):
         vals = stats.pearson3.rvs(0.1, size=(2, 50))
         assert_(numpy.shape(vals) == (2, 50))
@@ -832,6 +859,8 @@ class TestKappa4(object):
 
 
 class TestPoisson(object):
+    def setup_method(self):
+        np.random.seed(1234)
 
     def test_pmf_basic(self):
         # Basic case
@@ -872,6 +901,9 @@ class TestPoisson(object):
 
 
 class TestZipf(object):
+    def setup_method(self):
+        np.random.seed(1234)
+
     def test_rvs(self):
         vals = stats.zipf.rvs(1.5, size=(2, 50))
         assert_(numpy.all(vals >= 1))
@@ -894,6 +926,9 @@ class TestZipf(object):
 
 
 class TestDLaplace(object):
+    def setup_method(self):
+        np.random.seed(1234)
+
     def test_rvs(self):
         vals = stats.dlaplace.rvs(1.5, size=(2, 50))
         assert_(numpy.shape(vals) == (2, 50))
@@ -994,6 +1029,9 @@ def test_rvgeneric_std():
 
 
 class TestRvDiscrete(object):
+    def setup_method(self):
+        np.random.seed(1234)
+
     def test_rvs(self):
         states = [-1, 0, 1, 2, 3, 4]
         probability = [0.0, 0.3, 0.4, 0.0, 0.3, 0.0]
@@ -1082,6 +1120,8 @@ class TestRvDiscrete(object):
 
 
 class TestSkewNorm(object):
+    def setup_method(self):
+        np.random.seed(1234)
 
     def test_normal(self):
         # When the skewness is 0 the distribution is normal
@@ -1323,6 +1363,9 @@ class TestGumbelL(object):
 
 
 class TestArrayArgument(object):  # test for ticket:992
+    def setup_method(self):
+        np.random.seed(1234)
+
     def test_noexception(self):
         rvs = stats.norm.rvs(loc=(np.arange(5)), scale=np.ones(5),
                              size=(10, 5))
@@ -1404,6 +1447,9 @@ def TestArgsreduce():
 
 class TestFitMethod(object):
     skip = ['ncf']
+
+    def setup_method(self):
+        np.random.seed(1234)
 
     @pytest.mark.slow
     @pytest.mark.parametrize('dist,args,alpha', cases_test_all_distributions())
@@ -1617,6 +1663,9 @@ class TestFitMethod(object):
 
 
 class TestFrozen(object):
+    def setup_method(self):
+        np.random.seed(1234)
+
     # Test that a frozen distribution gives the same results as the original
     # object.
     #
@@ -2042,6 +2091,9 @@ class TestRice(object):
 
 
 class TestErlang(object):
+    def setup_method(self):
+        np.random.seed(1234)
+
     def test_erlang_runtimewarning(self):
         # erlang should generate a RuntimeWarning if a non-integer
         # shape parameter is used.
@@ -2584,6 +2636,8 @@ def test_hypergeom_interval_1802():
 
 
 def test_distribution_too_many_args():
+    np.random.seed(1234)
+
     # Check that a TypeError is raised when too many args are given to a method
     # Regression test for ticket 1815.
     x = np.linspace(0.1, 0.7, num=5)
@@ -3031,6 +3085,8 @@ def test_argus_function():
 
 class TestHistogram(object):
     def setup_method(self):
+        np.random.seed(1234)
+
         # We have 8 bins
         # [1,2), [2,3), [3,4), [4,5), [5,6), [6,7), [7,8), [8,9)
         # But actually np.histogram will put the last 9 also in the [8,9) bin!

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -108,13 +108,13 @@ def check_vonmises_cdf_periodic(k, l, s, x):
 def test_vonmises_pdf_periodic():
     for k in [0.1, 1, 101]:
         for x in [0, 1, numpy.pi, 10, 100]:
-            yield check_vonmises_pdf_periodic, k, 0, 1, x
-            yield check_vonmises_pdf_periodic, k, 1, 1, x
-            yield check_vonmises_pdf_periodic, k, 0, 10, x
+            check_vonmises_pdf_periodic(k, 0, 1, x)
+            check_vonmises_pdf_periodic(k, 1, 1, x)
+            check_vonmises_pdf_periodic(k, 0, 10, x)
 
-            yield check_vonmises_cdf_periodic, k, 0, 1, x
-            yield check_vonmises_cdf_periodic, k, 1, 1, x
-            yield check_vonmises_cdf_periodic, k, 0, 10, x
+            check_vonmises_cdf_periodic(k, 0, 1, x)
+            check_vonmises_cdf_periodic(k, 1, 1, x)
+            check_vonmises_cdf_periodic(k, 0, 10, x)
 
 
 def test_vonmises_line_support():

--- a/scipy/stats/tests/test_fit.py
+++ b/scipy/stats/tests/test_fit.py
@@ -45,18 +45,19 @@ skip_fit = [
 ]
 
 
-@pytest.mark.slow
-def test_cont_fit():
+def cases_test_cont_fit():
     # this tests the closeness of the estimated parameters to the true
     # parameters with fit method of continuous distributions
     # Note: is slow, some distributions don't converge with sample size <= 10000
 
     for distname, arg in distcont:
         if distname not in skip_fit:
-            yield check_cont_fit, distname,arg
+            yield distname, arg
 
 
-def check_cont_fit(distname,arg):
+@pytest.mark.slow
+@pytest.mark.parametrize('distname,arg', cases_test_cont_fit())
+def test_cont_fit(distname, arg):
     if distname in failing_fits:
         # Skip failing fits unless overridden
         xfail = True
@@ -110,8 +111,8 @@ def _check_loc_scale_mle_fit(name, data, desired, atol=None):
 
 def test_non_default_loc_scale_mle_fit():
     data = np.array([1.01, 1.78, 1.78, 1.78, 1.88, 1.88, 1.88, 2.00])
-    yield _check_loc_scale_mle_fit, 'uniform', data, [1.01, 0.99], 1e-3
-    yield _check_loc_scale_mle_fit, 'expon', data, [1.01, 0.73875], 1e-3
+    _check_loc_scale_mle_fit('uniform', data, [1.01, 0.99], 1e-3)
+    _check_loc_scale_mle_fit('expon', data, [1.01, 0.73875], 1e-3)
 
 
 def test_expon_fit():

--- a/scipy/stats/tests/test_rank.py
+++ b/scipy/stats/tests/test_rank.py
@@ -214,11 +214,6 @@ _cases = (
 
 
 def test_cases():
-
-    def check_case(values, method, expected):
+    for values, method, expected in _cases:
         r = rankdata(values, method=method)
         assert_array_equal(r, expected)
-
-    for values, method, expected in _cases:
-        yield check_case, values, method, expected
-

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1408,7 +1408,7 @@ class TestItemfreq(object):
         dtypes = [np.int32, np.int64, np.float32, np.float64,
                   np.complex64, np.complex128]
         for dt in dtypes:
-            yield _check_itemfreq, dt
+            _check_itemfreq(dt)
 
     def test_object_arrays(self):
         a, b = self.a, self.b
@@ -2450,50 +2450,50 @@ class TestPowerDivergence(object):
 
     def test_basic(self):
         for case in power_div_1d_cases:
-            yield (self.check_power_divergence,
+            self.check_power_divergence(
                    case.f_obs, case.f_exp, case.ddof, case.axis,
                    None, case.chi2)
-            yield (self.check_power_divergence,
+            self.check_power_divergence(
                    case.f_obs, case.f_exp, case.ddof, case.axis,
                    "pearson", case.chi2)
-            yield (self.check_power_divergence,
+            self.check_power_divergence(
                    case.f_obs, case.f_exp, case.ddof, case.axis,
                    1, case.chi2)
-            yield (self.check_power_divergence,
+            self.check_power_divergence(
                    case.f_obs, case.f_exp, case.ddof, case.axis,
                    "log-likelihood", case.log)
-            yield (self.check_power_divergence,
+            self.check_power_divergence(
                    case.f_obs, case.f_exp, case.ddof, case.axis,
                    "mod-log-likelihood", case.mod_log)
-            yield (self.check_power_divergence,
+            self.check_power_divergence(
                    case.f_obs, case.f_exp, case.ddof, case.axis,
                    "cressie-read", case.cr)
-            yield (self.check_power_divergence,
+            self.check_power_divergence(
                    case.f_obs, case.f_exp, case.ddof, case.axis,
                    2/3, case.cr)
 
     def test_basic_masked(self):
         for case in power_div_1d_cases:
             mobs = np.ma.array(case.f_obs)
-            yield (self.check_power_divergence,
+            self.check_power_divergence(
                    mobs, case.f_exp, case.ddof, case.axis,
                    None, case.chi2)
-            yield (self.check_power_divergence,
+            self.check_power_divergence(
                    mobs, case.f_exp, case.ddof, case.axis,
                    "pearson", case.chi2)
-            yield (self.check_power_divergence,
+            self.check_power_divergence(
                    mobs, case.f_exp, case.ddof, case.axis,
                    1, case.chi2)
-            yield (self.check_power_divergence,
+            self.check_power_divergence(
                    mobs, case.f_exp, case.ddof, case.axis,
                    "log-likelihood", case.log)
-            yield (self.check_power_divergence,
+            self.check_power_divergence(
                    mobs, case.f_exp, case.ddof, case.axis,
                    "mod-log-likelihood", case.mod_log)
-            yield (self.check_power_divergence,
+            self.check_power_divergence(
                    mobs, case.f_exp, case.ddof, case.axis,
                    "cressie-read", case.cr)
-            yield (self.check_power_divergence,
+            self.check_power_divergence(
                    mobs, case.f_exp, case.ddof, case.axis,
                    2/3, case.cr)
 
@@ -2505,21 +2505,21 @@ class TestPowerDivergence(object):
                            case1.f_exp))
         # Check the four computational code paths in power_divergence
         # using a 2D array with axis=1.
-        yield (self.check_power_divergence,
+        self.check_power_divergence(
                f_obs, f_exp, 0, 1,
                "pearson", [case0.chi2, case1.chi2])
-        yield (self.check_power_divergence,
+        self.check_power_divergence(
                f_obs, f_exp, 0, 1,
                "log-likelihood", [case0.log, case1.log])
-        yield (self.check_power_divergence,
+        self.check_power_divergence(
                f_obs, f_exp, 0, 1,
                "mod-log-likelihood", [case0.mod_log, case1.mod_log])
-        yield (self.check_power_divergence,
+        self.check_power_divergence(
                f_obs, f_exp, 0, 1,
                "cressie-read", [case0.cr, case1.cr])
         # Reshape case0.f_obs to shape (2,2), and use axis=None.
         # The result should be the same.
-        yield (self.check_power_divergence,
+        self.check_power_divergence(
                np.array(case0.f_obs).reshape(2, 2), None, 0, None,
                "pearson", case0.chi2)
 
@@ -2554,16 +2554,16 @@ class TestPowerDivergence(object):
     def test_empty_cases(self):
         with warnings.catch_warnings():
             for case in power_div_empty_cases:
-                yield (self.check_power_divergence,
+                self.check_power_divergence(
                        case.f_obs, case.f_exp, case.ddof, case.axis,
                        "pearson", case.chi2)
-                yield (self.check_power_divergence,
+                self.check_power_divergence(
                        case.f_obs, case.f_exp, case.ddof, case.axis,
                        "log-likelihood", case.log)
-                yield (self.check_power_divergence,
+                self.check_power_divergence(
                        case.f_obs, case.f_exp, case.ddof, case.axis,
                        "mod-log-likelihood", case.mod_log)
-                yield (self.check_power_divergence,
+                self.check_power_divergence(
                        case.f_obs, case.f_exp, case.ddof, case.axis,
                        "cressie-read", case.cr)
 
@@ -3284,9 +3284,9 @@ class TestDescribe(object):
 
 
 def test_normalitytests():
-    yield (assert_raises, ValueError, stats.skewtest, 4.)
-    yield (assert_raises, ValueError, stats.kurtosistest, 4.)
-    yield (assert_raises, ValueError, stats.normaltest, 4.)
+    assert_raises(ValueError, stats.skewtest, 4.)
+    assert_raises(ValueError, stats.kurtosistest, 4.)
+    assert_raises(ValueError, stats.normaltest, 4.)
 
     # numbers verified with R: dagoTest in package fBasics
     st_normal, st_skew, st_kurt = (3.92371918, 1.98078826, -0.01403734)

--- a/tools/validate_runtests_log.py
+++ b/tools/validate_runtests_log.py
@@ -31,10 +31,10 @@ if __name__ == "__main__":
         raise ValueError("Usage: validate.py {full|fast} < logfile.")
 
     # fetch the expected number of tests
-    # these numbers are for 6abad09
+    # these numbers are for 10d5dfe8b7
     # XXX: this should probably track the commit hash or commit date
-    expected_size = {'full': 19055,
-                     'fast': 17738}
+    expected_size = {'full': 11000,
+                     'fast': 10000}
 
     # read in the log, parse for the pytest printout
     r1 = re.compile("(?P<num_failed>\d+) failed, (?P<num_passed>\d+) passed,.* in (?P<time>\d+\S+)")


### PR DESCRIPTION
(On top of gh-7572)
Convert all nose yield test generators to either:

- plain for loops
- pytest.mark.parametrize

The reason for using nose yield tests previously was partly because nose test failures do not give much information on e.g. which test case the failure occurred at in for loops. Pytest can however print local variables (enabled by default in scipy.test), so this reason for parametrization becomes less relevant. So in many tests where there is no strong reason for parametrization, such as if there's just a  for loop over test cases, the parametrization can be just removed.

In other cases, the yield tests are converted to pytest.mark.parametrize, for example in stats tests that loop over different distributions. The advantage of parametrization is that you can run each test separately if needed (this works in pytest, wasn't possible in nose iirc). The natural code structure here seems to be that the `yield` for loop goes to a separate `cases_*` method that generates the parameter values, and the `check` method becomes the test body.

(As a nice bonus, after this, parallelized test runs work with pytes-xdist; cf. `python3 runtests.py -- -n 4`)