### PR TITLE
ENH: scipy.sparse.spmatrix.astype: casting and copy parameter added

### DIFF
--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -145,9 +145,9 @@ class spmatrix(object):
             like float64 to float32, are allowed.
             'unsafe' means any data conversions may be done.
         copy : bool, optional
-            By default, astype always returns a newly allocated matrix.
-            If this is set to false, and `dtype` is satisfied,
-            this matrix is returned instead of a copy.
+            If `copy` is `False`, the result might share some memory with this
+            matrix. If `copy` is `True`, it is guaranteed that the result and
+            this matrix do not share any memory.
         """
 
         dtype = np.dtype(dtype)

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -131,19 +131,19 @@ class spmatrix(object):
     def astype(self, dtype, casting='unsafe', copy=True):
         """Cast the matrix elements to a specified type.
 
-        The data will be copied.
-
         Parameters
         ----------
         dtype : string or numpy dtype
             Typecode or data-type to which to cast the data.
-        casting : {`no`, `equiv`, `safe`, `same_kind`, `unsafe`}, optional
-            Controls what kind of data casting may occur. Defaults to `unsafe` for backwards compatibility.
-            `no` means the data types should not be cast at all.
-            `equiv` means only byte-order changes are allowed.
-            `safe` means only casts which can preserve values are allowed.
-            `same_kind` means only safe casts or casts within a kind, like float64 to float32, are allowed.
-            `unsafe` means any data conversions may be done.
+        casting : {'no', 'equiv', 'safe', 'same_kind', 'unsafe'}, optional
+            Controls what kind of data casting may occur.
+            Defaults to 'unsafe' for backwards compatibility.
+            'no' means the data types should not be cast at all.
+            'equiv' means only byte-order changes are allowed.
+            'safe' means only casts which can preserve values are allowed.
+            'same_kind' means only safe casts or casts within a kind,
+            like float64 to float32, are allowed.
+            'unsafe' means any data conversions may be done.
         copy : bool, optional
             By default, astype always returns a newly allocated matrix.
             If this is set to false, and `dtype` is satisfied,

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -163,16 +163,12 @@ class spmatrix(object):
         """Upcast matrix to a floating point format (if necessary)"""
 
         fp_types = ['f', 'd', 'F', 'D']
+        for fp_type in fp_types:
+            if self.dtype <= np.dtype(fp_type):
+                return self.astype(fp_type, copy=False)
 
-        if self.dtype.char in fp_types:
-            return self
-        else:
-            for fp_type in fp_types:
-                if self.dtype <= np.dtype(fp_type):
-                    return self.astype(fp_type)
-
-            raise TypeError('cannot upcast [%s] to a floating '
-                            'point format' % self.dtype.name)
+        raise TypeError('cannot upcast [%s] to a floating '
+                        'point format' % self.dtype.name)
 
     def __iter__(self):
         for r in xrange(self.shape[0]):

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -137,13 +137,13 @@ class spmatrix(object):
         ----------
         dtype : string or numpy dtype
             Typecode or data-type to which to cast the data.
-        casting : {‘no’, ‘equiv’, ‘safe’, ‘same_kind’, ‘unsafe’}, optional
-            Controls what kind of data casting may occur. Defaults to ‘unsafe’ for backwards compatibility.
-            ‘no’ means the data types should not be cast at all.
-            ‘equiv’ means only byte-order changes are allowed.
-            ‘safe’ means only casts which can preserve values are allowed.
-            ‘same_kind’ means only safe casts or casts within a kind, like float64 to float32, are allowed.
-            ‘unsafe’ means any data conversions may be done.
+        casting : {`no`, `equiv`, `safe`, `same_kind`, `unsafe`}, optional
+            Controls what kind of data casting may occur. Defaults to `unsafe` for backwards compatibility.
+            `no` means the data types should not be cast at all.
+            `equiv` means only byte-order changes are allowed.
+            `safe` means only casts which can preserve values are allowed.
+            `same_kind` means only safe casts or casts within a kind, like float64 to float32, are allowed.
+            `unsafe` means any data conversions may be done.
         copy : bool, optional
             By default, astype always returns a newly allocated matrix.
             If this is set to false, and `dtype` is satisfied,

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -128,17 +128,35 @@ class spmatrix(object):
         raise NotImplementedError("Reshaping not implemented for %s." %
                                   self.__class__.__name__)
 
-    def astype(self, t):
+    def astype(self, dtype, casting='unsafe', copy=True):
         """Cast the matrix elements to a specified type.
 
         The data will be copied.
 
         Parameters
         ----------
-        t : string or numpy dtype
+        dtype : string or numpy dtype
             Typecode or data-type to which to cast the data.
+        casting : {‘no’, ‘equiv’, ‘safe’, ‘same_kind’, ‘unsafe’}, optional
+            Controls what kind of data casting may occur. Defaults to ‘unsafe’ for backwards compatibility.
+            ‘no’ means the data types should not be cast at all.
+            ‘equiv’ means only byte-order changes are allowed.
+            ‘safe’ means only casts which can preserve values are allowed.
+            ‘same_kind’ means only safe casts or casts within a kind, like float64 to float32, are allowed.
+            ‘unsafe’ means any data conversions may be done.
+        copy : bool, optional
+            By default, astype always returns a newly allocated matrix.
+            If this is set to false, and `dtype` is satisfied,
+            this matrix is returned instead of a copy.
         """
-        return self.tocsr().astype(t).asformat(self.format)
+
+        dtype = np.dtype(dtype)
+        if self.dtype != t:
+            return self.tocsr().astype(dtype, casting=casting, copy=copy).asformat(self.format)
+        elif copy:
+            return self.copy()
+        else:
+            return self
 
     def asfptype(self):
         """Upcast matrix to a floating point format (if necessary)"""

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -163,12 +163,16 @@ class spmatrix(object):
         """Upcast matrix to a floating point format (if necessary)"""
 
         fp_types = ['f', 'd', 'F', 'D']
-        for fp_type in fp_types:
-            if self.dtype <= np.dtype(fp_type):
-                return self.astype(fp_type, copy=False)
 
-        raise TypeError('cannot upcast [%s] to a floating '
-                        'point format' % self.dtype.name)
+        if self.dtype.char in fp_types:
+            return self
+        else:
+            for fp_type in fp_types:
+                if self.dtype <= np.dtype(fp_type):
+                    return self.astype(fp_type)
+
+            raise TypeError('cannot upcast [%s] to a floating '
+                            'point format' % self.dtype.name)
 
     def __iter__(self):
         for r in xrange(self.shape[0]):

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -151,7 +151,7 @@ class spmatrix(object):
         """
 
         dtype = np.dtype(dtype)
-        if self.dtype != t:
+        if self.dtype != dtype:
             return self.tocsr().astype(dtype, casting=casting, copy=copy).asformat(self.format)
         elif copy:
             return self.copy()

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -152,7 +152,8 @@ class spmatrix(object):
 
         dtype = np.dtype(dtype)
         if self.dtype != dtype:
-            return self.tocsr().astype(dtype, casting=casting, copy=copy).asformat(self.format)
+            return self.tocsr().astype(
+                dtype, casting=casting, copy=copy).asformat(self.format)
         elif copy:
             return self.copy()
         else:

--- a/scipy/sparse/data.py
+++ b/scipy/sparse/data.py
@@ -69,7 +69,7 @@ class _data_matrix(spmatrix):
         if self.dtype != dtype:
             return self._with_data(
                 self._deduped_data().astype(dtype, casting=casting, copy=copy),
-                copy=copy)
+                copy=True)
         elif copy:
             return self.copy()
         else:

--- a/scipy/sparse/data.py
+++ b/scipy/sparse/data.py
@@ -64,8 +64,14 @@ class _data_matrix(spmatrix):
         else:
             return NotImplemented
 
-    def astype(self, t):
-        return self._with_data(self._deduped_data().astype(t))
+    def astype(self, dtype, casting='unsafe', copy=True):
+        dtype = np.dtype(dtype)
+        if self.dtype != dtype:
+            return self._with_data(self._deduped_data().astype(dtype, casting=casting, copy=copy))
+        elif copy:
+            return self.copy()
+        else:
+            return self
 
     astype.__doc__ = spmatrix.astype.__doc__
 

--- a/scipy/sparse/data.py
+++ b/scipy/sparse/data.py
@@ -68,7 +68,8 @@ class _data_matrix(spmatrix):
         dtype = np.dtype(dtype)
         if self.dtype != dtype:
             return self._with_data(
-                self._deduped_data().astype(dtype, casting=casting, copy=copy))
+                self._deduped_data().astype(dtype, casting=casting, copy=copy)
+                copy=False)
         elif copy:
             return self.copy()
         else:

--- a/scipy/sparse/data.py
+++ b/scipy/sparse/data.py
@@ -68,7 +68,7 @@ class _data_matrix(spmatrix):
         dtype = np.dtype(dtype)
         if self.dtype != dtype:
             return self._with_data(
-                self._deduped_data().astype(dtype, casting=casting, copy=copy)
+                self._deduped_data().astype(dtype, casting=casting, copy=copy),
                 copy=False)
         elif copy:
             return self.copy()

--- a/scipy/sparse/data.py
+++ b/scipy/sparse/data.py
@@ -67,7 +67,8 @@ class _data_matrix(spmatrix):
     def astype(self, dtype, casting='unsafe', copy=True):
         dtype = np.dtype(dtype)
         if self.dtype != dtype:
-            return self._with_data(self._deduped_data().astype(dtype, casting=casting, copy=copy))
+            return self._with_data(
+                self._deduped_data().astype(dtype, casting=casting, copy=copy))
         elif copy:
             return self.copy()
         else:

--- a/scipy/sparse/data.py
+++ b/scipy/sparse/data.py
@@ -69,7 +69,7 @@ class _data_matrix(spmatrix):
         if self.dtype != dtype:
             return self._with_data(
                 self._deduped_data().astype(dtype, casting=casting, copy=copy),
-                copy=True)
+                copy=copy)
         elif copy:
             return self.copy()
         else:

--- a/scipy/sparse/data.py
+++ b/scipy/sparse/data.py
@@ -69,7 +69,7 @@ class _data_matrix(spmatrix):
         if self.dtype != dtype:
             return self._with_data(
                 self._deduped_data().astype(dtype, casting=casting, copy=copy),
-                copy=False)
+                copy=copy)
         elif copy:
             return self.copy()
         else:

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1157,14 +1157,24 @@ class _TestCommon:
             assert S_casted.astype(x, copy=False) is S_casted
             S_copied = S_casted.astype(x, copy=True)
             assert S_copied is not S_casted
-            for (a, b) in ((S_copied.indices, S_casted.indices),
-                           (S_copied.indptr, S_casted.indptr),
-                           (S_copied.data, S_casted.data)):
-                # Check that arrays are equal but not the same
+
+            def check_equal_but_not_same_array_attribute(attribute):
+                a = get(S_casted, attribute)
+                b = get(S_copied, attribute)
                 assert_array_equal(a, b)
                 assert a is not b
                 a[0] = not a[0]
                 assert_(a[0] != b[0])
+
+            if S_casted.format in ('csr', 'csc', 'bsr'):
+                for attribute in ('indices', 'indptr', 'data'):
+                    check_equal_but_not_same_array_attribute(attribute)
+            elif S_casted.format == 'coo':
+                for attribute in ('row', 'col', 'data'):
+                    check_equal_but_not_same_array_attribute(attribute)
+            elif S_casted.format == 'dia':
+                for attribute in ('offsets', 'data'):
+                    check_equal_but_not_same_array_attribute(attribute)
 
     def test_asfptype(self):
         A = self.spmatrix(arange(6,dtype='int32').reshape(2,3))

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1146,16 +1146,24 @@ class _TestCommon:
         S = self.spmatrix(D)
 
         for x in supported_dtypes:
-            # Check correct casted
+            # Check correctly casted
             D_casted = D.astype(x)
             for copy in (True, False):
                 S_casted = S.astype(x, copy=copy)
                 assert_equal(S_casted.dtype, D_casted.dtype)  # correct type
                 assert_equal(S_casted.toarray(), D_casted)    # correct values
                 assert_equal(S_casted.format, S.format)       # format preserved
-            # Check correct copied
+            # Check correctly copied
             assert S_casted.astype(x, copy=False) is S_casted
-            assert S_casted.astype(x, copy=True) is not S_casted
+            S_copied = S_casted.astype(x, copy=True)
+            assert S_copied is not S_casted
+            for (a, b) in ((S_copied.indices, S_casted.indices),
+                           (S_copied.indptr, S_casted.indptr),
+                           (S_copied.data, S_casted.data)):
+                assert a is not b
+                assert_array_equal(a, b)
+                a[0] += 1
+                assert_(a[0] != b[0])
 
     def test_asfptype(self):
         A = self.spmatrix(arange(6,dtype='int32').reshape(2,3))

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1163,7 +1163,7 @@ class _TestCommon:
                 b = getattr(S_copied, attribute)
                 assert_array_equal(a, b)
                 assert a is not b
-                i = (0,)*b.ndim
+                i = (0,) * b.ndim
                 b_i = b[i]
                 b[i] = not b[i]
                 assert_(a[i] != b[i])

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1146,13 +1146,16 @@ class _TestCommon:
         S = self.spmatrix(D)
 
         for x in supported_dtypes:
+            # Check correct casted
             D_casted = D.astype(x)
             for copy in (True, False):
                 S_casted = S.astype(x, copy=copy)
                 assert_equal(S_casted.dtype, D_casted.dtype)  # correct type
                 assert_equal(S_casted.toarray(), D_casted)    # correct values
                 assert_equal(S_casted.format, S.format)       # format preserved
+            # Check correct copied
             assert S_casted.astype(x, copy=False) is S_casted
+            assert S_casted.astype(x, copy=True) is not S_casted
 
     def test_asfptype(self):
         A = self.spmatrix(arange(6,dtype='int32').reshape(2,3))

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1163,10 +1163,11 @@ class _TestCommon:
                 b = getattr(S_copied, attribute)
                 assert_array_equal(a, b)
                 assert a is not b
-                b_0 = b[0]
-                b[0] = not b[0]
-                assert_(a[0] != b[0])
-                b[0] = b_0
+                i = (0,)*b.ndim
+                b_i = b[i]
+                b[i] = not b[i]
+                assert_(a[i] != b[i])
+                b[i] = b_i
 
             if S_casted.format in ('csr', 'csc', 'bsr'):
                 for attribute in ('indices', 'indptr', 'data'):

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1154,9 +1154,9 @@ class _TestCommon:
                 assert_equal(S_casted.toarray(), D_casted)    # correct values
                 assert_equal(S_casted.format, S.format)       # format preserved
             # Check correctly copied
-            assert S_casted.astype(x, copy=False) is S_casted
+            assert_(S_casted.astype(x, copy=False) is S_casted)
             S_copied = S_casted.astype(x, copy=True)
-            assert S_copied is not S_casted
+            assert_(S_copied is not S_casted)
 
             def check_equal_but_not_same_array_attribute(attribute):
                 a = getattr(S_casted, attribute)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1159,8 +1159,8 @@ class _TestCommon:
             assert S_copied is not S_casted
 
             def check_equal_but_not_same_array_attribute(attribute):
-                a = get(S_casted, attribute)
-                b = get(S_copied, attribute)
+                a = getattr(S_casted, attribute)
+                b = getattr(S_copied, attribute)
                 assert_array_equal(a, b)
                 assert a is not b
                 a[0] = not a[0]

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1162,7 +1162,7 @@ class _TestCommon:
                 a = getattr(S_casted, attribute)
                 b = getattr(S_copied, attribute)
                 assert_array_equal(a, b)
-                assert a is not b
+                assert_(a is not b)
                 i = (0,) * b.ndim
                 b_i = b[i]
                 b[i] = not b[i]

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1146,9 +1146,13 @@ class _TestCommon:
         S = self.spmatrix(D)
 
         for x in supported_dtypes:
-            assert_equal(S.astype(x).dtype, D.astype(x).dtype)  # correct type
-            assert_equal(S.astype(x).toarray(), D.astype(x))        # correct values
-            assert_equal(S.astype(x).format, S.format)           # format preserved
+            D_casted = D.astype(x)
+            for copy in (True, False):
+                S_casted = S.astype(x, copy=copy)
+                assert_equal(S_casted.dtype, D_casted.dtype)  # correct type
+                assert_equal(S_casted.toarray(), D_casted)    # correct values
+                assert_equal(S_casted.format, S.format)       # format preserved
+            assert S_casted.astype(x, copy=False) is S_casted
 
     def test_asfptype(self):
         A = self.spmatrix(arange(6,dtype='int32').reshape(2,3))

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1163,8 +1163,10 @@ class _TestCommon:
                 b = getattr(S_copied, attribute)
                 assert_array_equal(a, b)
                 assert a is not b
-                a[0] = not a[0]
+                b_0 = b[0]
+                b[0] = not b[0]
                 assert_(a[0] != b[0])
+                b[0] = b_0
 
             if S_casted.format in ('csr', 'csc', 'bsr'):
                 for attribute in ('indices', 'indptr', 'data'):

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1160,9 +1160,10 @@ class _TestCommon:
             for (a, b) in ((S_copied.indices, S_casted.indices),
                            (S_copied.indptr, S_casted.indptr),
                            (S_copied.data, S_casted.data)):
-                assert a is not b
+                # Check that arrays are equal but not the same
                 assert_array_equal(a, b)
-                a[0] += 1
+                assert a is not b
+                a[0] = not a[0]
                 assert_(a[0] != b[0])
 
     def test_asfptype(self):


### PR DESCRIPTION
I would like to add `casting` and `copy` parameters to the `astype` method of the sparse matrices in `scipy.sparse` analogous to NumPys `astype` method for arrays.