### PR TITLE
Expose VODE/ZVODE/LSODE IDID return code to user

### DIFF
--- a/scipy/integrate/tests/test_integrate.py
+++ b/scipy/integrate/tests/test_integrate.py
@@ -64,7 +64,7 @@ class TestODEClass(object):
 
         assert_array_equal(z, ig.y)
         assert_(ig.successful(), (problem, method))
-        assert_(ig.get_return_code()>0, (problem, method))
+        assert_(ig.get_return_code() > 0, (problem, method))
         assert_(problem.verify(array([z]), problem.stop_t), (problem, method))
 
 

--- a/scipy/integrate/tests/test_integrate.py
+++ b/scipy/integrate/tests/test_integrate.py
@@ -64,6 +64,7 @@ class TestODEClass(object):
 
         assert_array_equal(z, ig.y)
         assert_(ig.successful(), (problem, method))
+        assert_(ig.get_return_code()>0, (problem, method))
         assert_(problem.verify(array([z]), problem.stop_t), (problem, method))
 
 


### PR DESCRIPTION
Added support for returning the VODE, ZVODE, and LSODE IDID parameter to the user. Also set corresponding IDID values for the Runge-Kutta solvers dopri5 and dop853. See feature request #7603.