### PR TITLE
MAINT: special: remove out-of-date comment for `ellpk`

### DIFF
--- a/scipy/special/cephes/ellpk.c
+++ b/scipy/special/cephes/ellpk.c
@@ -6,9 +6,9 @@
  *
  * SYNOPSIS:
  *
- * double m, y, ellpk();
+ * double m1, y, ellpk();
  *
- * y = ellpk( m ); 
+ * y = ellpk( m1 );
  *
  *
  *
@@ -58,10 +58,6 @@
  * Cephes Math Library, Release 2.0:  April, 1987
  * Copyright 1984, 1987 by Stephen L. Moshier
  * Direct inquiries to 30 Frost Street, Cambridge, MA 02140
- * 
- * Feb, 2002:  altered by Travis Oliphant 
- * so that it is called with argument m 
- * (which gets immediately converted to m1 = 1-m)
  */
 
 #include "mconf.h"


### PR DESCRIPTION
The comment reflects behavior that was reverted in
da453dcacafae8d5520004921b3352d33343944e. Also clean up the function
definition at the top of the file to be correct again.