### PR TITLE
TST: Add a test for "ignore" warning filters

### DIFF
--- a/scipy/_lib/_numpy_compat.py
+++ b/scipy/_lib/_numpy_compat.py
@@ -234,7 +234,7 @@ if NumpyVersion(np.__version__) > '1.12.0.dev':
     polyvalfromroots = np.polynomial.polynomial.polyvalfromroots
 else:
     def polyvalfromroots(x, r, tensor=True):
-        """
+        r"""
         Evaluate a polynomial specified by its roots at points x.
 
         This function is copypasted from numpy 1.12.0.dev.

--- a/scipy/_lib/tests/test_warnings.py
+++ b/scipy/_lib/tests/test_warnings.py
@@ -1,0 +1,85 @@
+"""
+Tests which scan for certain occurrences in the code, they may not find
+all of these occurrences but should catch almost all. This file was adapted
+from numpy.
+"""
+
+
+from __future__ import division, absolute_import, print_function
+
+
+import sys
+if sys.version_info >= (3, 4):
+    from pathlib import Path
+    import ast
+    import tokenize
+    import scipy
+    from numpy.testing import run_module_suite
+    from numpy.testing.decorators import slow
+
+
+    class ParseCall(ast.NodeVisitor):
+        def __init__(self):
+            self.ls = []
+
+        def visit_Attribute(self, node):
+            ast.NodeVisitor.generic_visit(self, node)
+            self.ls.append(node.attr)
+
+        def visit_Name(self, node):
+            self.ls.append(node.id)
+
+
+    class FindFuncs(ast.NodeVisitor):
+        def __init__(self, filename):
+            super().__init__()
+            self.__filename = filename
+
+        def visit_Call(self, node):
+            p = ParseCall()
+            p.visit(node.func)
+            ast.NodeVisitor.generic_visit(self, node)
+
+            if p.ls[-1] == 'simplefilter' or p.ls[-1] == 'filterwarnings':
+                if node.args[0].s == "ignore":
+                    raise AssertionError(
+                        "ignore filter should not be used; found in "
+                        "{} on line {}".format(self.__filename, node.lineno))
+
+            if p.ls[-1] == 'warn' and (
+                    len(p.ls) == 1 or p.ls[-2] == 'warnings'):
+
+                if "_lib/tests/test_warnings.py" is self.__filename:
+                    # This file
+                    return
+
+                # See if stacklevel exists:
+                # if len(node.args) == 3:
+                #     return
+                # args = {kw.arg for kw in node.keywords}
+                # if "stacklevel" in args:
+                #     return
+                # raise AssertionError(
+                #     "warnings should have an appropriate stacklevel; found in "
+                #     "{} on line {}".format(self.__filename, node.lineno))
+
+
+    @slow
+    def test_warning_calls():
+        # combined "ignore" and stacklevel error
+        base = Path(scipy.__file__).parent
+
+        for path in base.rglob("*.py"):
+            # There is still one missing occurance in optimize.py,
+            # this is one that should be fixed and this removed then.
+            if path == base / "optimize" / "optimize.py":
+                continue
+            # use tokenize to auto-detect encoding on systems where no
+            # default encoding is defined (e.g. LANG='C')
+            with tokenize.open(str(path)) as file:
+                tree = ast.parse(file.read())
+                FindFuncs(path).visit(tree)
+
+
+    if __name__ == "__main__":
+        run_module_suite()

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -351,7 +351,7 @@ def freqz(b, a=1, worN=None, whole=False, plot=None):
 
 
 def freqz_zpk(z, p, k, worN=None, whole=False):
-    """
+    r"""
     Compute the frequency response of a digital filter in ZPK form.
 
     Given the Zeros, Poles and Gain of a digital filter, compute its frequency


### PR DESCRIPTION
This file currently ignores the scipy/optimize/optimize.py file
because of one (or actually two identical) remaining filters there.

A commented out part, can be used to find all occurances of missing
stacklevels to `warnings.warn`.

This will not find errors in cython files though.

---

Dunno if you want it already even with the one file missing. One can put a print around the assertion error to get all the missing stacklevels in python files, so thought I just leave the thing commented out.