### PR TITLE
DEP: deprecate args usage in xdist

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -122,37 +122,43 @@ from . import _distance_wrap
 from . import _hausdorff
 from ..linalg import norm
 
+
 def _args_to_kwargs_xdist(args, kwargs, metric, func_name):
-    if func_name == "pdist":
-        old_arg_names = ["p", "w", "V", "VI"]
+    """
+    Convert legacy positional arguments to keyword arguments for pdist/cdist.
+    """
+    if not args:
+        return kwargs
+
+    if (callable(metric) and metric not in [
+            braycurtis, canberra, chebyshev, cityblock, correlation, cosine,
+            dice, euclidean, hamming, jaccard, kulsinski, mahalanobis,
+            matching, minkowski, rogerstanimoto, russellrao, seuclidean,
+            sokalmichener, sokalsneath, sqeuclidean, yule, wminkowski]):
+        raise TypeError('When using a custom metric arguments must be passed'
+                        'as keyword (i.e., ARGNAME=ARGVALUE)')
+
+    if func_name == 'pdist':
+        old_arg_names = ['p', 'w', 'V', 'VI']
     else:
-        old_arg_names = ["p", "V", "VI", "w"]
+        old_arg_names = ['p', 'V', 'VI', 'w']
+
     num_args = len(args)
-    if num_args:
-        if(callable(metric) and
-           metric not in [braycurtis, canberra, chebyshev, cityblock,
-                          correlation, cosine, dice, euclidean,
-                          hamming, jaccard, kulsinski, mahalanobis,
-                          matching, minkowski, rogerstanimoto,
-                          russellrao, seuclidean, sokalmichener,
-                          sokalsneath, sqeuclidean, yule, wminkowski]):
-            raise TypeError('When using a custom metric arguments must be passed'
-                            'as keyword (i.e., ARGNAME=ARGVALUE)')
+    warnings.warn('%d metric parameters have been passed as positional.'
+                  'This will raise an error in a future version.'
+                  'Please pass arguments as keywords(i.e., ARGNAME=ARGVALUE)'
+                  % num_args, DeprecationWarning)
 
-        warnings.warn('%d metric parameters have been passed as positional.'
-                      'This will raise an error in a future version.'
-                      'Please pass arguments as keywords'
-                      '(i.e., ARGNAME=ARGVALUE)' % num_args, DeprecationWarning)
-        if num_args > 4:
-            raise ValueError('Deprecated %s signature accepts only 4'
-                'positional arguments (p, w, V, VI), %d given.'
-                % (func_name, num_args))
+    if num_args > 4:
+        raise ValueError('Deprecated %s signature accepts only 4'
+                         'positional arguments (%s), %d given.'
+                         % (func_name, ', '.join(old_arg_names), num_args))
 
-        for i, arg in enumerate(args):
-            if old_arg_names[i] in kwargs:
-                raise TypeError('%s() got multiple values for argument '
-                    '%s' % (func_name, old_arg_names[i]))
-            kwargs[old_arg_names[i]] = arg
+    for old_arg, arg in zip(old_arg_names, args):
+        if old_arg in kwargs:
+            raise TypeError('%s() got multiple values for argument %s'
+                            % (func_name, old_arg))
+        kwargs[old_arg] = arg
     return kwargs
 
 

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -35,7 +35,6 @@
 from __future__ import division, print_function, absolute_import
 
 import os.path
-import warnings
 from scipy._lib.six import xrange, u
 
 import numpy as np
@@ -44,6 +43,7 @@ from numpy.testing import (verbose, assert_,
                            assert_raises, assert_array_equal, assert_equal,
                            assert_almost_equal, assert_allclose)
 
+from scipy._lib._numpy_compat import suppress_warnings
 from scipy.spatial.distance import (squareform, pdist, cdist, num_obs_y,
                                     num_obs_dm, is_valid_dm, is_valid_y,
                                     _validate_vector, _METRICS_NAMES)
@@ -127,6 +127,48 @@ class TestCdist(object):
                               'uint': [np.int_, np.float32, np.double],
                               'int': [np.float32, np.double],
                               'float32': [np.double]}
+
+    def test_cdist_extra_args(self):
+        # Tests that args and kwargs are correctly handled
+        def _my_metric(x, y, arg, kwarg=1, kwarg2=2):
+            return arg + kwarg + kwarg2
+
+        X1 = [[1., 2., 3.], [1.2, 2.3, 3.4], [2.2, 2.3, 4.4]]
+        X2 = [[7., 5., 8.], [7.5, 5.8, 8.4], [5.5, 5.8, 4.4]]
+        kwargs = {'N0tV4l1D_p4raM': 3.14, "w":np.arange(3)}
+        args = [3.14] * 200
+        with suppress_warnings() as w:
+            w.filter(DeprecationWarning)
+            for metric in _METRICS_NAMES:
+                assert_raises(TypeError, cdist, X1, X2,
+                              metric=metric, **kwargs)
+                assert_raises(TypeError, cdist, X1, X2,
+                              metric=eval(metric), **kwargs)
+                assert_raises(TypeError, cdist, X1, X2,
+                              metric="test_" + metric, **kwargs)
+                assert_raises(TypeError, cdist, X1, X2,
+                              metric=metric, *args)
+                assert_raises(TypeError, cdist, X1, X2,
+                              metric=eval(metric), *args)
+                assert_raises(TypeError, cdist, X1, X2,
+                              metric="test_" + metric, *args)
+
+            assert_raises(TypeError, cdist, X1, X2, _my_metric)
+            assert_raises(TypeError, cdist, X1, X2, _my_metric, *args)
+            assert_raises(TypeError, cdist, X1, X2, _my_metric, **kwargs)
+            assert_raises(TypeError, cdist, X1, X2, _my_metric,
+                          kwarg=2.2, kwarg2=3.3)
+            assert_raises(TypeError, cdist, X1, X2, _my_metric, 1, 2, kwarg=2.2)
+
+            assert_raises(TypeError, cdist, X1, X2, _my_metric, 1.1, 2.2, 3.3)
+            assert_raises(TypeError, cdist, X1, X2, _my_metric, 1.1, 2.2)
+            assert_raises(TypeError, cdist, X1, X2, _my_metric, 1.1)
+            assert_raises(TypeError, cdist, X1, X2, _my_metric, 1.1,
+                          kwarg=2.2, kwarg2=3.3)
+
+            # this should work
+            assert_allclose(cdist(X1, X2, metric=_my_metric,
+                                  arg=1.1, kwarg2=3.3), 5.4)
 
     def test_cdist_euclidean_random_unicode(self):
         eps = 1e-07
@@ -329,6 +371,44 @@ class TestPdist(object):
                               'uint': [np.int_, np.float32, np.double],
                               'int': [np.float32, np.double],
                               'float32': [np.double]}
+
+    def test_pdist_extra_args(self):
+        # Tests that args and kwargs are correctly handled
+        def _my_metric(x, y, arg, kwarg=1, kwarg2=2):
+            return arg + kwarg + kwarg2
+
+        X1 = [[1., 2.], [1.2, 2.3], [2.2, 2.3]]
+        kwargs = {'N0tV4l1D_p4raM': 3.14, "w":np.arange(2)}
+        args = [3.14] * 200
+        with suppress_warnings() as w:
+            w.filter(DeprecationWarning)
+            for metric in _METRICS_NAMES:
+                assert_raises(TypeError, pdist, X1, metric=metric, **kwargs)
+                assert_raises(TypeError, pdist, X1,
+                              metric=eval(metric), **kwargs)
+                assert_raises(TypeError, pdist, X1,
+                              metric="test_" + metric, **kwargs)
+                assert_raises(TypeError, pdist, X1, metric=metric, *args)
+                assert_raises(TypeError, pdist, X1, metric=eval(metric), *args)
+                assert_raises(TypeError, pdist, X1,
+                              metric="test_" + metric, *args)
+
+            assert_raises(TypeError, pdist, X1, _my_metric)
+            assert_raises(TypeError, pdist, X1, _my_metric, *args)
+            assert_raises(TypeError, pdist, X1, _my_metric, **kwargs)
+            assert_raises(TypeError, pdist, X1, _my_metric,
+                          kwarg=2.2, kwarg2=3.3)
+            assert_raises(TypeError, pdist, X1, _my_metric, 1, 2, kwarg=2.2)
+
+            assert_raises(TypeError, pdist, X1, _my_metric, 1.1, 2.2, 3.3)
+            assert_raises(TypeError, pdist, X1, _my_metric, 1.1, 2.2)
+            assert_raises(TypeError, pdist, X1, _my_metric, 1.1)
+            assert_raises(TypeError, pdist, X1, _my_metric, 1.1,
+                          kwarg=2.2, kwarg2=3.3)
+
+            # these should work
+            assert_allclose(pdist(X1, metric=_my_metric,
+                                  arg=1.1, kwarg2=3.3), 5.4)
 
     def test_pdist_euclidean_random(self):
         eps = 1e-07
@@ -1539,32 +1619,41 @@ def test_modifies_input():
 
 def test_Xdist_deprecated_args():
     # testing both cdist and pdist deprecated warnings
-    X1 = np.asarray([[1., 2., 3.], [1.2, 2.3, 3.4], [2.2, 2.3, 4.4]])
-    warn_msg = "Got unexpected kwarg"
+    X1 = np.asarray([[1., 2., 3.],
+                     [1.2, 2.3, 3.4],
+                     [2.2, 2.3, 4.4],
+                     [22.2, 23.3, 44.4]])
+    weights = np.arange(3)
+    warn_msg_kwargs = "Got unexpected kwarg"
+    warn_msg_args = "metric parameters have been passed as positional"
     for metric in _METRICS_NAMES:
-        if metric in ("minkowski", "wminkowski", "seuclidean", "mahalanobis"):
-            continue
+        kwargs = {"w": weights} if metric == "wminkowski" else dict()
+        with suppress_warnings() as w:
+            log = w.record(DeprecationWarning)
+            cdist(X1, X1, metric, 2., **kwargs)
+            pdist(X1, metric, 2., **kwargs)
+            assert_(len(log) >= 2)
+            assert_(sum([warn_msg_args in str(warn.message) for warn in log]) == 2)
+
         for arg in ["p", "V", "VI", "w"]:
             kwargs = {arg:"foo"}
 
             if metric == "wminkowski":
                 if "p" in kwargs or "w" in kwargs:
                     continue
-                kwargs["w"] = 1.0 / X1.std(axis=0)
+                kwargs["w"] = weights
 
             if((arg == "V" and metric == "seuclidean") or
                (arg == "VI" and metric == "mahalanobis") or
-               (arg == "w" and metric == "wminkowski")):
+               (arg == "p" and metric == "minkowski")):
                 continue
 
-            with warnings.catch_warnings(record=True) as w:
-                warnings.simplefilter("always")
+            with suppress_warnings() as w:
+                log = w.record(DeprecationWarning)
                 cdist(X1, X1, metric, **kwargs)
                 pdist(X1, metric, **kwargs)
-                assert_(len(w) == 2)
-                assert_(issubclass(w[0].category, DeprecationWarning))
-                assert_(issubclass(w[1].category, DeprecationWarning))
-                assert_(all([warn_msg in str(warn.message) for warn in w]))
+                assert_(len(log) == 2)
+                assert_(all([warn_msg_kwargs in str(warn.message) for warn in log]))
 
 
 def test__validate_vector():


### PR DESCRIPTION
- usage of positional args is now deprecated
- added kwargs to support custom metrics
- simplified cdist/pdist code
- updated doc

2nd part of #6974, already rebased on #7628