### PR TITLE
FIX: LAPACK - Avoid "lda" to be 0 in ?POTRF calls

### DIFF
--- a/scipy/linalg/decomp_cholesky.py
+++ b/scipy/linalg/decomp_cholesky.py
@@ -17,27 +17,30 @@ def _cholesky(a, lower=False, overwrite_a=False, clean=True,
     """Common code for cholesky() and cho_factor()."""
 
     a1 = asarray_chkfinite(a) if check_finite else asarray(a)
-
-    # Quick return for empty arrays
-    if a1.size == 0:
-        return a, lower
-
     a1 = atleast_2d(a1)
 
-    # Shape consistency checks
+    # Dimension check
     if a1.ndim != 2:
-        raise ValueError('Input is not 2D.')
+        raise ValueError('Input array needs to be 2 dimensional but received '
+                         'a {}d-array.'.format(a1.ndim))
+    # Squareness check
     if a1.shape[0] != a1.shape[1]:
-        raise ValueError('Input array is not square')
+        raise ValueError('Input array is expected to be square but has '
+                         'the shape: {}.'.format(a1.shape))
+
+    # Quick return for square empty array
+    if a1.size == 0:
+        return a1, lower
 
     overwrite_a = overwrite_a or _datacopied(a1, a)
     potrf, = get_lapack_funcs(('potrf',), (a1,))
     c, info = potrf(a1, lower=lower, overwrite_a=overwrite_a, clean=clean)
     if info > 0:
-        raise LinAlgError("%d-th leading minor not positive definite" % info)
+        raise LinAlgError("%d-th leading minor of the array is not positive "
+                          "definite" % info)
     if info < 0:
-        raise ValueError('illegal value in %d-th argument of internal potrf'
-                         % -info)
+        raise ValueError('LAPACK reported an illegal value in {}-th argument'
+                         'on entry to "POTRF".'.format(-info))
     return c, lower
 
 

--- a/scipy/linalg/decomp_cholesky.py
+++ b/scipy/linalg/decomp_cholesky.py
@@ -30,7 +30,7 @@ def _cholesky(a, lower=False, overwrite_a=False, clean=True,
 
     # Quick return for square empty array
     if a1.size == 0:
-        return a1, lower
+        return a1.copy(), lower
 
     overwrite_a = overwrite_a or _datacopied(a1, a)
     potrf, = get_lapack_funcs(('potrf',), (a1,))

--- a/scipy/linalg/decomp_cholesky.py
+++ b/scipy/linalg/decomp_cholesky.py
@@ -88,7 +88,7 @@ def cholesky(a, lower=False, overwrite_a=False, check_finite=True):
 
     """
     c, lower = _cholesky(a, lower=lower, overwrite_a=overwrite_a, clean=True,
-                            check_finite=check_finite)
+                         check_finite=check_finite)
     return c
 
 
@@ -139,7 +139,7 @@ def cho_factor(a, lower=False, overwrite_a=False, check_finite=True):
 
     """
     c, lower = _cholesky(a, lower=lower, overwrite_a=overwrite_a, clean=False,
-                            check_finite=check_finite)
+                         check_finite=check_finite)
     return c, lower
 
 
@@ -187,7 +187,7 @@ def cho_solve(c_and_lower, b, overwrite_b=False, check_finite=True):
     x, info = potrs(c, b1, lower=lower, overwrite_b=overwrite_b)
     if info != 0:
         raise ValueError('illegal value in %d-th argument of internal potrs'
-                                                                    % -info)
+                         % -info)
     return x
 
 
@@ -243,7 +243,7 @@ def cholesky_banded(ab, overwrite_ab=False, lower=False, check_finite=True):
         raise LinAlgError("%d-th leading minor not positive definite" % info)
     if info < 0:
         raise ValueError('illegal value in %d-th argument of internal pbtrf'
-                                                                    % -info)
+                         % -info)
     return c
 
 
@@ -297,5 +297,5 @@ def cho_solve_banded(cb_and_lower, b, overwrite_b=False, check_finite=True):
         raise LinAlgError("%d-th leading minor not positive definite" % info)
     if info < 0:
         raise ValueError('illegal value in %d-th argument of internal pbtrs'
-                                                                    % -info)
+                         % -info)
     return x

--- a/scipy/linalg/flapack.pyf.src
+++ b/scipy/linalg/flapack.pyf.src
@@ -2303,7 +2303,7 @@ interface
 
    end subroutine <prefix>pocon
 
-   subroutine <prefix2>potrf(n,a,info,lower,clean)
+   subroutine <prefix2>potrf(n,a,lda,info,lower,clean)
 
      ! c,info = potrf(a,lower=0,clean=1,overwrite_a=0)
      ! Compute Cholesky decomposition of symmetric positive defined matrix:
@@ -2312,19 +2312,19 @@ interface
      ! C is triangular matrix of the corresponding Cholesky decomposition.
      ! clean==1 zeros strictly lower or upper parts of U or L, respectively
 
-     callstatement (*f2py_func)((lower?"L":"U"),&n,a,&n,&info); if(clean){int i,j;if(lower){for(i=0;i\<n;++i) for(j=i+1;j\<n;++j) *(a+j*n+i)=0.0;} else {for(i=0;i\<n;++i) for(j=i+1;j<n;++j) *(a+i*n+j)=0.0;}}
+     callstatement (*f2py_func)((lower?"L":"U"),&n,a,&lda,&info); if(clean){int i,j;if(lower){for(i=0;i\<n;++i) for(j=i+1;j\<n;++j) *(a+j*n+i)=0.0;} else {for(i=0;i\<n;++i) for(j=i+1;j<n;++j) *(a+i*n+j)=0.0;}}
      callprotoargument char*,int*,<ctype2>*,int*,int*
 
      integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
      integer optional,intent(in),check(clean==0||clean==1) :: clean = 1
-     integer depend(a),intent(hide):: n = shape(a,0)
-     <ftype2> dimension(n,n),intent(in,out,copy,out=c) :: a
-     check(shape(a,0)==shape(a,1)) :: a
+     integer depend(a),intent(hide) :: n = shape(a,0)
+     <ftype2> dimension(n,n),check(shape(a,0)==shape(a,1)),intent(in,out,copy,out=c) :: a
+     integer depend(n),intent(hide) :: lda = MAX(1,n)
      integer intent(out) :: info
 
    end subroutine <prefix2>potrf
 
-   subroutine <prefix2c>potrf(n,a,info,lower,clean)
+   subroutine <prefix2c>potrf(n,a,lda,info,lower,clean)
 
      ! c,info = potrf(a,lower=0,clean=1,overwrite_a=0)
      ! Compute Cholesky decomposition of symmetric positive defined matrix:
@@ -2333,14 +2333,14 @@ interface
      ! C is triangular matrix of the corresponding Cholesky decomposition.
      ! clean==1 zeros strictly lower or upper parts of U or L, respectively
 
-     callstatement (*f2py_func)((lower?"L":"U"),&n,a,&n,&info); if(clean){int i,j,k;if(lower){for(i=0;i\<n;++i) for(j=i+1;j\<n;++j) {k=j*n+i;(a+k)->r=(a+k)->i=0.0;}} else {for(i=0;i\<n;++i) for(j=i+1;j\<n;++j) {k=i*n+j;(a+k)->r=(a+k)->i=0.0;}}}
+     callstatement (*f2py_func)((lower?"L":"U"),&n,a,&lda,&info); if(clean){int i,j,k;if(lower){for(i=0;i\<n;++i) for(j=i+1;j\<n;++j) {k=j*n+i;(a+k)->r=(a+k)->i=0.0;}} else {for(i=0;i\<n;++i) for(j=i+1;j\<n;++j) {k=i*n+j;(a+k)->r=(a+k)->i=0.0;}}}
      callprotoargument char*,int*,<ctype2c>*,int*,int*
 
      integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
      integer optional,intent(in),check(clean==0||clean==1) :: clean = 1
      integer depend(a),intent(hide):: n = shape(a,0)
-     <ftype2c> dimension(n,n),intent(in,out,copy,out=c) :: a
-     check(shape(a,0)==shape(a,1)) :: a
+     <ftype2c> dimension(n,n),check(shape(a,0)==shape(a,1)),intent(in,out,copy,out=c) :: a
+     integer depend(n),intent(hide) :: lda = MAX(1,n)
      integer intent(out) :: info
 
    end subroutine <prefix2c>potrf

--- a/scipy/linalg/tests/test_decomp_cholesky.py
+++ b/scipy/linalg/tests/test_decomp_cholesky.py
@@ -1,8 +1,8 @@
 from __future__ import division, print_function, absolute_import
 
-from numpy.testing import assert_array_almost_equal
+from numpy.testing import assert_array_almost_equal, assert_array_equal
 
-from numpy import array, transpose, dot, conjugate, zeros_like
+from numpy import array, transpose, dot, conjugate, zeros_like, empty
 from numpy.random import random
 from scipy.linalg import cholesky, cholesky_banded, cho_solve_banded, \
      cho_factor, cho_solve
@@ -13,58 +13,58 @@ from scipy.linalg._testutils import assert_no_overwrite
 class TestCholesky(object):
 
     def test_simple(self):
-        a = [[8,2,3],[2,9,3],[3,3,6]]
+        a = [[8, 2, 3], [2, 9, 3], [3, 3, 6]]
         c = cholesky(a)
-        assert_array_almost_equal(dot(transpose(c),c),a)
+        assert_array_almost_equal(dot(transpose(c), c), a)
         c = transpose(c)
-        a = dot(c,transpose(c))
-        assert_array_almost_equal(cholesky(a,lower=1),c)
+        a = dot(c, transpose(c))
+        assert_array_almost_equal(cholesky(a, lower=1), c)
 
     def test_check_finite(self):
-        a = [[8,2,3],[2,9,3],[3,3,6]]
+        a = [[8, 2, 3], [2, 9, 3], [3, 3, 6]]
         c = cholesky(a, check_finite=False)
-        assert_array_almost_equal(dot(transpose(c),c),a)
+        assert_array_almost_equal(dot(transpose(c), c), a)
         c = transpose(c)
-        a = dot(c,transpose(c))
-        assert_array_almost_equal(cholesky(a,lower=1, check_finite=False),c)
+        a = dot(c, transpose(c))
+        assert_array_almost_equal(cholesky(a, lower=1, check_finite=False), c)
 
     def test_simple_complex(self):
-        m = array([[3+1j,3+4j,5],[0,2+2j,2+7j],[0,0,7+4j]])
-        a = dot(transpose(conjugate(m)),m)
+        m = array([[3+1j, 3+4j, 5], [0, 2+2j, 2+7j], [0, 0, 7+4j]])
+        a = dot(transpose(conjugate(m)), m)
         c = cholesky(a)
-        a1 = dot(transpose(conjugate(c)),c)
-        assert_array_almost_equal(a,a1)
+        a1 = dot(transpose(conjugate(c)), c)
+        assert_array_almost_equal(a, a1)
         c = transpose(c)
-        a = dot(c,transpose(conjugate(c)))
-        assert_array_almost_equal(cholesky(a,lower=1),c)
+        a = dot(c, transpose(conjugate(c)))
+        assert_array_almost_equal(cholesky(a, lower=1), c)
 
     def test_random(self):
         n = 20
         for k in range(2):
-            m = random([n,n])
+            m = random([n, n])
             for i in range(n):
-                m[i,i] = 20*(.1+m[i,i])
-            a = dot(transpose(m),m)
+                m[i, i] = 20*(.1+m[i, i])
+            a = dot(transpose(m), m)
             c = cholesky(a)
-            a1 = dot(transpose(c),c)
-            assert_array_almost_equal(a,a1)
+            a1 = dot(transpose(c), c)
+            assert_array_almost_equal(a, a1)
             c = transpose(c)
-            a = dot(c,transpose(c))
-            assert_array_almost_equal(cholesky(a,lower=1),c)
+            a = dot(c, transpose(c))
+            assert_array_almost_equal(cholesky(a, lower=1), c)
 
     def test_random_complex(self):
         n = 20
         for k in range(2):
-            m = random([n,n])+1j*random([n,n])
+            m = random([n, n])+1j*random([n, n])
             for i in range(n):
-                m[i,i] = 20*(.1+abs(m[i,i]))
-            a = dot(transpose(conjugate(m)),m)
+                m[i, i] = 20*(.1+abs(m[i, i]))
+            a = dot(transpose(conjugate(m)), m)
             c = cholesky(a)
-            a1 = dot(transpose(conjugate(c)),c)
-            assert_array_almost_equal(a,a1)
+            a1 = dot(transpose(conjugate(c)), c)
+            assert_array_almost_equal(a, a1)
             c = transpose(c)
-            a = dot(c,transpose(conjugate(c)))
-            assert_array_almost_equal(cholesky(a,lower=1),c)
+            a = dot(c, transpose(conjugate(c)))
+            assert_array_almost_equal(cholesky(a, lower=1), c)
 
 
 class TestCholeskyBanded(object):
@@ -73,16 +73,16 @@ class TestCholeskyBanded(object):
     def test_check_finite(self):
         # Symmetric positive definite banded matrix `a`
         a = array([[4.0, 1.0, 0.0, 0.0],
-                    [1.0, 4.0, 0.5, 0.0],
-                    [0.0, 0.5, 4.0, 0.2],
-                    [0.0, 0.0, 0.2, 4.0]])
+                   [1.0, 4.0, 0.5, 0.0],
+                   [0.0, 0.5, 4.0, 0.2],
+                   [0.0, 0.0, 0.2, 4.0]])
         # Banded storage form of `a`.
         ab = array([[-1.0, 1.0, 0.5, 0.2],
-                     [4.0, 4.0, 4.0, 4.0]])
+                    [4.0, 4.0, 4.0, 4.0]])
         c = cholesky_banded(ab, lower=False, check_finite=False)
         ufac = zeros_like(a)
-        ufac[list(range(4)),list(range(4))] = c[-1]
-        ufac[(0,1,2),(1,2,3)] = c[0,1:]
+        ufac[list(range(4)), list(range(4))] = c[-1]
+        ufac[(0, 1, 2), (1, 2, 3)] = c[0, 1:]
         assert_array_almost_equal(a, dot(ufac.T, ufac))
 
         b = array([0.0, 0.5, 4.2, 4.2])
@@ -92,16 +92,16 @@ class TestCholeskyBanded(object):
     def test_upper_real(self):
         # Symmetric positive definite banded matrix `a`
         a = array([[4.0, 1.0, 0.0, 0.0],
-                    [1.0, 4.0, 0.5, 0.0],
-                    [0.0, 0.5, 4.0, 0.2],
-                    [0.0, 0.0, 0.2, 4.0]])
+                   [1.0, 4.0, 0.5, 0.0],
+                   [0.0, 0.5, 4.0, 0.2],
+                   [0.0, 0.0, 0.2, 4.0]])
         # Banded storage form of `a`.
         ab = array([[-1.0, 1.0, 0.5, 0.2],
-                     [4.0, 4.0, 4.0, 4.0]])
+                    [4.0, 4.0, 4.0, 4.0]])
         c = cholesky_banded(ab, lower=False)
         ufac = zeros_like(a)
-        ufac[list(range(4)),list(range(4))] = c[-1]
-        ufac[(0,1,2),(1,2,3)] = c[0,1:]
+        ufac[list(range(4)), list(range(4))] = c[-1]
+        ufac[(0, 1, 2), (1, 2, 3)] = c[0, 1:]
         assert_array_almost_equal(a, dot(ufac.T, ufac))
 
         b = array([0.0, 0.5, 4.2, 4.2])
@@ -111,16 +111,16 @@ class TestCholeskyBanded(object):
     def test_upper_complex(self):
         # Hermitian positive definite banded matrix `a`
         a = array([[4.0, 1.0, 0.0, 0.0],
-                    [1.0, 4.0, 0.5, 0.0],
-                    [0.0, 0.5, 4.0, -0.2j],
-                    [0.0, 0.0, 0.2j, 4.0]])
+                   [1.0, 4.0, 0.5, 0.0],
+                   [0.0, 0.5, 4.0, -0.2j],
+                   [0.0, 0.0, 0.2j, 4.0]])
         # Banded storage form of `a`.
         ab = array([[-1.0, 1.0, 0.5, -0.2j],
-                     [4.0, 4.0, 4.0, 4.0]])
+                    [4.0, 4.0, 4.0, 4.0]])
         c = cholesky_banded(ab, lower=False)
         ufac = zeros_like(a)
-        ufac[list(range(4)),list(range(4))] = c[-1]
-        ufac[(0,1,2),(1,2,3)] = c[0,1:]
+        ufac[list(range(4)), list(range(4))] = c[-1]
+        ufac[(0, 1, 2), (1, 2, 3)] = c[0, 1:]
         assert_array_almost_equal(a, dot(ufac.conj().T, ufac))
 
         b = array([0.0, 0.5, 4.0-0.2j, 0.2j + 4.0])
@@ -130,16 +130,16 @@ class TestCholeskyBanded(object):
     def test_lower_real(self):
         # Symmetric positive definite banded matrix `a`
         a = array([[4.0, 1.0, 0.0, 0.0],
-                    [1.0, 4.0, 0.5, 0.0],
-                    [0.0, 0.5, 4.0, 0.2],
-                    [0.0, 0.0, 0.2, 4.0]])
+                   [1.0, 4.0, 0.5, 0.0],
+                   [0.0, 0.5, 4.0, 0.2],
+                   [0.0, 0.0, 0.2, 4.0]])
         # Banded storage form of `a`.
         ab = array([[4.0, 4.0, 4.0, 4.0],
                     [1.0, 0.5, 0.2, -1.0]])
         c = cholesky_banded(ab, lower=True)
         lfac = zeros_like(a)
-        lfac[list(range(4)),list(range(4))] = c[0]
-        lfac[(1,2,3),(0,1,2)] = c[1,:3]
+        lfac[list(range(4)), list(range(4))] = c[0]
+        lfac[(1, 2, 3), (0, 1, 2)] = c[1, :3]
         assert_array_almost_equal(a, dot(lfac, lfac.T))
 
         b = array([0.0, 0.5, 4.2, 4.2])
@@ -149,16 +149,16 @@ class TestCholeskyBanded(object):
     def test_lower_complex(self):
         # Hermitian positive definite banded matrix `a`
         a = array([[4.0, 1.0, 0.0, 0.0],
-                    [1.0, 4.0, 0.5, 0.0],
-                    [0.0, 0.5, 4.0, -0.2j],
-                    [0.0, 0.0, 0.2j, 4.0]])
+                   [1.0, 4.0, 0.5, 0.0],
+                   [0.0, 0.5, 4.0, -0.2j],
+                   [0.0, 0.0, 0.2j, 4.0]])
         # Banded storage form of `a`.
         ab = array([[4.0, 4.0, 4.0, 4.0],
                     [1.0, 0.5, 0.2j, -1.0]])
         c = cholesky_banded(ab, lower=True)
         lfac = zeros_like(a)
-        lfac[list(range(4)),list(range(4))] = c[0]
-        lfac[(1,2,3),(0,1,2)] = c[1,:3]
+        lfac[list(range(4)), list(range(4))] = c[0]
+        lfac[(1, 2, 3), (0, 1, 2)] = c[1, :3]
         assert_array_almost_equal(a, dot(lfac, lfac.conj().T))
 
         b = array([0.0, 0.5j, 3.8j, 3.8])
@@ -168,21 +168,35 @@ class TestCholeskyBanded(object):
 
 class TestOverwrite(object):
     def test_cholesky(self):
-        assert_no_overwrite(cholesky, [(3,3)])
+        assert_no_overwrite(cholesky, [(3, 3)])
 
     def test_cho_factor(self):
-        assert_no_overwrite(cho_factor, [(3,3)])
+        assert_no_overwrite(cho_factor, [(3, 3)])
 
     def test_cho_solve(self):
-        x = array([[2,-1,0], [-1,2,-1], [0,-1,2]])
+        x = array([[2, -1, 0], [-1, 2, -1], [0, -1, 2]])
         xcho = cho_factor(x)
         assert_no_overwrite(lambda b: cho_solve(xcho, b), [(3,)])
 
     def test_cholesky_banded(self):
-        assert_no_overwrite(cholesky_banded, [(2,3)])
+        assert_no_overwrite(cholesky_banded, [(2, 3)])
 
     def test_cho_solve_banded(self):
         x = array([[0, -1, -1], [2, 2, 2]])
         xcho = cholesky_banded(x)
         assert_no_overwrite(lambda b: cho_solve_banded((xcho, False), b),
                             [(3,)])
+
+
+class TestEmptyArray(object):
+    def test_cho_factor_empty_square(self):
+        a = empty((0, 0))
+        b = array([])
+        c = array([[]])
+
+        x, _ = cho_factor(a)
+        y, _ = cho_factor(b)
+        z, _ = cho_factor(c)
+        assert_array_equal(x, a)
+        assert_array_equal(y, b)
+        assert_array_equal(z, c)

--- a/scipy/linalg/tests/test_decomp_cholesky.py
+++ b/scipy/linalg/tests/test_decomp_cholesky.py
@@ -1,6 +1,7 @@
 from __future__ import division, print_function, absolute_import
 
-from numpy.testing import assert_array_almost_equal, assert_array_equal
+from numpy.testing import assert_array_almost_equal, assert_array_equal, \
+    assert_raises
 
 from numpy import array, transpose, dot, conjugate, zeros_like, empty
 from numpy.random import random
@@ -193,10 +194,11 @@ class TestEmptyArray(object):
         a = empty((0, 0))
         b = array([])
         c = array([[]])
+        d = []
+        e = [[]]
 
         x, _ = cho_factor(a)
-        y, _ = cho_factor(b)
-        z, _ = cho_factor(c)
         assert_array_equal(x, a)
-        assert_array_equal(y, b)
-        assert_array_equal(z, c)
+
+        for x in ([b, c, d, e]):
+            assert_raises(ValueError, cho_factor, x)


### PR DESCRIPTION
Closes #7631 

In the wrappers for ?POTRF routines, the leading dimension `lda` of the argument A was linked directly to the `A.shape[0]`. However, this is causing kernel crashes when A is a `(0,0)` array. For empty arhuments POTRF already has a quick return and lda is not meant to set to zero.

This PR includes a fix for this issue and moreover sets up more traps to catch empty arrays before the LAPACK is called in `_cholesky` used by `cho_factor`. 

