### PR TITLE
interpolate.splprep: Test some error cases, give slightly better error on invalid inputs

### DIFF
--- a/scipy/interpolate/src/_fitpackmodule.c
+++ b/scipy/interpolate/src/_fitpackmodule.c
@@ -446,6 +446,7 @@ fitpack_parcur(PyObject *dummy, PyObject *args)
                 &s, &nest, &n, t, &nc, c, &fp, wrk, &lwrk, iwrk, &ier);
     }
     if (ier == 10) {
+        PyErr_SetString(PyExc_ValueError, "Invalid inputs.");
         goto fail;
     }
     if (ier > 0 && n == 0) {

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -598,6 +598,18 @@ class TestInterop(object):
         assert_raises_regex(TypeError, "m > k must hold", splprep, [x])
         assert_raises_regex(TypeError, "m > k must hold", _impl.splprep, [x])
 
+        # automatically calculated parameters are non-increasing
+        # see gh-7589
+        x = [-50.49072266, -50.49072266, -54.49072266, -54.49072266]
+        assert_raises_regex(ValueError, "Invalid inputs", splprep, [x])
+        assert_raises_regex(ValueError, "Invalid inputs", _impl.splprep, [x])
+
+        # given non-increasing parameter values u
+        x = [1, 3, 2, 4]
+        u = [0, 0.3, 0.2, 1]
+        assert_raises_regex(ValueError, "Invalid inputs", splprep,
+                            *[[x], None, u])
+
     def test_sproot(self):
         b, b2 = self.b, self.b2
         roots = np.array([0.5, 1.5, 2.5, 3.5])*np.pi


### PR DESCRIPTION
For instance instead of `SystemError: error return without exception set` the example in #7589 would now raise `ValueError: Invalid inputs`, the same way `splrep` (which uses the `curfit` subroutine) and `bisplrep` (which uses the `surfit` subroutine) already seem to.

To get a much better error message, I could either duplicate some of the Fortran validity checks in Python or have the Fortran set different `ier` values for different sorts of bad input.