### PR TITLE
Add out parameter to pdist and cdist

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -178,6 +178,7 @@ David Hagen for the object-oriented ODE solver interface.
 Arno Onken for contributions to scipy.stats.
 Cathy Douglass for bug fixes in ndimage.
 Adam Cox for contributions to scipy.constants.
+Dezmond Goff for adding optional out parameter to pdist/cdist
 
 Institutions
 ------------

--- a/doc/release/1.0.0-notes.rst
+++ b/doc/release/1.0.0-notes.rst
@@ -61,6 +61,12 @@ providing the cumulative distribution function of the multivariate normal
 distribution.  The underlying code is the classic one by Alan Genz (see
 `scipy/stats/mvndst.f`).
 
+`scipy.spatial.distance` improvements
+-------------------------------------
+
+Optional `out` parameter was added to pdist and cdist allowing the user to 
+specify where the resulting distance matrix is to be stored
+
 
 Deprecated features
 ===================

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -1125,7 +1125,7 @@ _METRICS_NAMES = ['braycurtis', 'canberra', 'chebyshev', 'cityblock',
 _TEST_METRICS = {'test_' + name: eval(name) for name in _METRICS_NAMES}
 
 
-def pdist(X, metric='euclidean', p=None, w=None, V=None, VI=None):
+def pdist(X, metric='euclidean', p=None, w=None, V=None, VI=None, out=None):
     """
     Pairwise distances between observations in n-dimensional space.
 
@@ -1155,6 +1155,8 @@ def pdist(X, metric='euclidean', p=None, w=None, V=None, VI=None):
     VI : ndarray, optional
         The inverse of the covariance matrix
         Only for Mahalanobis. Default: inv(cov(X.T)).T
+    out : ndarray, optional
+        If not None, condensed distance matrix is stored in this array.
 
     Returns
     -------
@@ -1374,7 +1376,13 @@ def pdist(X, metric='euclidean', p=None, w=None, V=None, VI=None):
         raise ValueError('A 2-dimensional array must be passed.')
 
     m, n = s
-    dm = np.zeros((m * (m - 1)) // 2, dtype=np.double)
+    if out is None:
+      dm = np.zeros((m * (m - 1)) // 2, dtype=np.double)
+    else:
+      if out.shape != (m * (m - 1)) // 2, ):
+         raise ValueError("output array has incorrect shape.")
+      dm = out
+      
 
     # validate input for multi-args metrics
     if(metric in ['minkowski', 'mi', 'm', 'pnorm', 'test_minkowski'] or
@@ -1835,7 +1843,7 @@ def _cosine_cdist(XA, XB, dm):
     dm += 1
 
 
-def cdist(XA, XB, metric='euclidean', p=None, V=None, VI=None, w=None):
+def cdist(XA, XB, metric='euclidean', p=None, V=None, VI=None, w=None, out=None):
     """
     Computes distance between each pair of the two collections of inputs.
 
@@ -1870,6 +1878,8 @@ def cdist(XA, XB, metric='euclidean', p=None, V=None, VI=None, w=None):
     VI : ndarray, optional
         The inverse of the covariance matrix
         Only for Mahalanobis. Default: inv(cov(vstack([XA, XB]).T)).T
+    out ; ndarray, optional
+        If not None, the distance matrix Y is stored in this array.
 
     Returns
     -------
@@ -2139,7 +2149,12 @@ def cdist(XA, XB, metric='euclidean', p=None, V=None, VI=None, w=None):
     mA = s[0]
     mB = sB[0]
     n = s[1]
-    dm = np.zeros((mA, mB), dtype=np.double)
+    if out is None:
+      dm = np.zeros((mA, mB), dtype=np.double)
+    else:
+      if out.shape != (mA, mB):
+         raise ValueError("Output array has incorrect shape.")
+      dm = out
 
     # validate input for multi-args metrics
     if(metric in ['minkowski', 'mi', 'm', 'pnorm', 'test_minkowski'] or

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -1379,7 +1379,7 @@ def pdist(X, metric='euclidean', p=None, w=None, V=None, VI=None, out=None):
     if out is None:
         dm = np.zeros((m * (m - 1)) // 2, dtype=np.double)
     else:
-        if out.shape != (m * (m - 1)) // 2, ):
+        if out.shape != (m * (m - 1) // 2, ):
             raise ValueError("output array has incorrect shape.")
         if out.shape != (mA, mB):
             raise ValueError("Output array has wrong dimension.")

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -1377,12 +1377,17 @@ def pdist(X, metric='euclidean', p=None, w=None, V=None, VI=None, out=None):
 
     m, n = s
     if out is None:
-      dm = np.zeros((m * (m - 1)) // 2, dtype=np.double)
+        dm = np.zeros((m * (m - 1)) // 2, dtype=np.double)
     else:
-      if out.shape != (m * (m - 1)) // 2, ):
-         raise ValueError("output array has incorrect shape.")
-      dm = out
-      
+        if out.shape != (m * (m - 1)) // 2, ):
+            raise ValueError("output array has incorrect shape.")
+        if out.shape != (mA, mB):
+            raise ValueError("Output array has wrong dimension.")
+        if not out.flags.c_contiguous:
+            raise ValueError("Output array must be C-contiguous.")
+        if out.dtype != np.double:
+            raise ValueError("Output array must be double type.")
+        dm = out
 
     # validate input for multi-args metrics
     if(metric in ['minkowski', 'mi', 'm', 'pnorm', 'test_minkowski'] or
@@ -2150,12 +2155,16 @@ def cdist(XA, XB, metric='euclidean', p=None, V=None, VI=None, w=None, out=None)
     mB = sB[0]
     n = s[1]
     if out is None:
-      dm = np.zeros((mA, mB), dtype=np.double)
+        dm = np.zeros((mA, mB), dtype=np.double)
     else:
-      if out.shape != (mA, mB):
-         raise ValueError("Output array has incorrect shape.")
-      dm = out
-
+        if out.shape != (mA, mB):
+            raise ValueError("Output array has wrong dimension.")
+        if not out.flags.c_contiguous:
+            raise ValueError("Output array must be C-contiguous.")
+        if out.dtype != np.double:
+            raise ValueError("Output array must be double type.")
+        dm = out
+    
     # validate input for multi-args metrics
     if(metric in ['minkowski', 'mi', 'm', 'pnorm', 'test_minkowski'] or
        metric == minkowski):

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -1156,7 +1156,8 @@ def pdist(X, metric='euclidean', p=None, w=None, V=None, VI=None, out=None):
         The inverse of the covariance matrix
         Only for Mahalanobis. Default: inv(cov(X.T)).T
     out : ndarray, optional
-        If not None, condensed distance matrix is stored in this array.
+        The output array
+        If not None, condensed distance matrix Y is stored in this array.
 
     Returns
     -------
@@ -1379,10 +1380,8 @@ def pdist(X, metric='euclidean', p=None, w=None, V=None, VI=None, out=None):
     if out is None:
         dm = np.zeros((m * (m - 1)) // 2, dtype=np.double)
     else:
-        if out.shape != (m * (m - 1) // 2, ):
+        if out.shape != (m * (m - 1) // 2,):
             raise ValueError("output array has incorrect shape.")
-        if out.shape != (mA, mB):
-            raise ValueError("Output array has wrong dimension.")
         if not out.flags.c_contiguous:
             raise ValueError("Output array must be C-contiguous.")
         if out.dtype != np.double:
@@ -1883,7 +1882,8 @@ def cdist(XA, XB, metric='euclidean', p=None, V=None, VI=None, w=None, out=None)
     VI : ndarray, optional
         The inverse of the covariance matrix
         Only for Mahalanobis. Default: inv(cov(vstack([XA, XB]).T)).T
-    out ; ndarray, optional
+    out : ndarray, optional
+        The output array
         If not None, the distance matrix Y is stored in this array.
 
     Returns
@@ -2158,13 +2158,13 @@ def cdist(XA, XB, metric='euclidean', p=None, V=None, VI=None, w=None, out=None)
         dm = np.zeros((mA, mB), dtype=np.double)
     else:
         if out.shape != (mA, mB):
-            raise ValueError("Output array has wrong dimension.")
+            raise ValueError("Output array has incorrect shape.")
         if not out.flags.c_contiguous:
             raise ValueError("Output array must be C-contiguous.")
         if out.dtype != np.double:
             raise ValueError("Output array must be double type.")
         dm = out
-    
+
     # validate input for multi-args metrics
     if(metric in ['minkowski', 'mi', 'm', 'pnorm', 'test_minkowski'] or
        metric == minkowski):

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -317,6 +317,22 @@ class TestCdist(object):
                     for new_type in test[1]:
                         y2 = cdist(new_type(X1), new_type(X2), metric=metric)
                         _assert_within_tol(y1, y2, eps, verbose > 2)
+                        
+    def test_cdist_out(self):
+        esp = 1e-07
+        out1 = np.empty((10, 20), dtype=np.double)
+        out2 = np.empty((9, 19), dtype=np.double)
+        out3 = np.empty((100, 200), dtype=np.double)[::10, ::10]
+        out4 = np.empty((10, 20), dtype=np.int64)
+        X1 = eo['cdist-X1']
+        X2 = eo['cdist-X2']
+        Y1 = cdist(X1, X2, u('euclidean'))
+        Y2 = cdist(X1, X2, u('euclidean'), out=out1)
+        _assert_within_tol(Y1, Y2, eps, verbose > 2)
+        assert_true(Y1 is out1)
+        assert_raises(ValueError, cdist, X1, X2, u('euclidean'), out=out2)
+        assert_raises(ValueError, cdist, X1, X2, u('euclidean'), out=out3)
+        assert_raises(ValueError, cdist, X1, X2, u('euclidean'), out=out4)
 
 
 class TestPdist(object):
@@ -1042,6 +1058,21 @@ class TestPdist(object):
                     for new_type in test[1]:
                         y2 = pdist(new_type(X1), metric=metric)
                         _assert_within_tol(y1, y2, eps, verbose > 2)
+      
+    def test_pdist_out(self):
+        eps = 1e-07
+        out1 = np.empty(190, dtype=np.double)
+        out2 = np.empty(19, dtype=np.double)
+        out3 = np.empty(1900, dtype=np.double)[::10]
+        out4 = np.empty(190, dtype=np.int64)
+        X = eo['pdist-double-inp']
+        Y_right = eo['pdist-euclidean']
+        Y_test1 = pdist(X, 'euclidean', out=out1)
+        _assert_within_tol(Y_test1, Y_right, eps)
+        assert_true(Y_test1 is out1)
+        assert_raises(ValueError, pdist, X, u('euclidean'), out=out2)
+        assert_raises(ValueError, pdist, X, u('euclidean'), out=out3)
+        assert_raises(ValueError, pdist, X, u('euclidean'), out=out4)
 
 
 def within_tol(a, b, tol):

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -326,8 +326,8 @@ class TestCdist(object):
         out4 = np.empty((10, 20), dtype=np.int64)
         X1 = eo['cdist-X1']
         X2 = eo['cdist-X2']
-        Y1 = cdist(X1, X2, u('euclidean'))
-        Y2 = cdist(X1, X2, u('euclidean'), out=out1)
+        Y1 = cdist(X1, X2, u('euclidean'), out=out1)
+        Y2 = cdist(X1, X2, u('euclidean'))
         _assert_within_tol(Y1, Y2, eps, verbose > 2)
         assert_true(Y1 is out1)
         assert_raises(ValueError, cdist, X1, X2, u('euclidean'), out=out2)

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -329,7 +329,7 @@ class TestCdist(object):
         Y1 = cdist(X1, X2, u('euclidean'), out=out1)
         Y2 = cdist(X1, X2, u('euclidean'))
         _assert_within_tol(Y1, Y2, eps, verbose > 2)
-        assert_true(Y1 is out1)
+        assert_(Y1 is out1)
         assert_raises(ValueError, cdist, X1, X2, u('euclidean'), out=out2)
         assert_raises(ValueError, cdist, X1, X2, u('euclidean'), out=out3)
         assert_raises(ValueError, cdist, X1, X2, u('euclidean'), out=out4)
@@ -1069,7 +1069,7 @@ class TestPdist(object):
         Y_right = eo['pdist-euclidean']
         Y_test1 = pdist(X, 'euclidean', out=out1)
         _assert_within_tol(Y_test1, Y_right, eps)
-        assert_true(Y_test1 is out1)
+        assert_(Y_test1 is out1)
         assert_raises(ValueError, pdist, X, u('euclidean'), out=out2)
         assert_raises(ValueError, pdist, X, u('euclidean'), out=out3)
         assert_raises(ValueError, pdist, X, u('euclidean'), out=out4)


### PR DESCRIPTION
To reduce memory load of repeated calls to pdist/cdist. I don't think `out`needs to be set to zero, does it?