### PR TITLE
Fix #7636, add PEP 519 test coverage to remaining I/O functions

### DIFF
--- a/scipy/io/arff/tests/test_arffread.py
+++ b/scipy/io/arff/tests/test_arffread.py
@@ -14,7 +14,8 @@ import numpy as np
 
 from numpy.testing import (assert_array_almost_equal,
                            assert_array_equal, assert_equal, assert_,
-                           assert_raises, dec)
+                           assert_raises)
+import pytest
 
 from scipy.io.arff.arffread import loadarff
 from scipy.io.arff.arffread import read_header, parse_type, ParseArffError
@@ -22,9 +23,9 @@ from scipy.io.arff.arffread import read_header, parse_type, ParseArffError
 
 data_path = pjoin(os.path.dirname(__file__), 'data')
 
-test1 = os.path.join(data_path, 'test1.arff')
-test2 = os.path.join(data_path, 'test2.arff')
-test3 = os.path.join(data_path, 'test3.arff')
+test1 = pjoin(data_path, 'test1.arff')
+test2 = pjoin(data_path, 'test2.arff')
+test3 = pjoin(data_path, 'test3.arff')
 
 test4 = pjoin(data_path, 'test4.arff')
 test5 = pjoin(data_path, 'test5.arff')
@@ -74,6 +75,19 @@ class TestData(object):
         assert_(data1 == data2)
         assert_(repr(meta1) == repr(meta2))
 
+    @pytest.mark.skipif(sys.version_info < (3, 6),
+                        reason='Passing path-like objects to IO functions requires Python >= 3.6')
+    def test_path(self):
+        # Test reading from `pathlib.Path` object
+        from pathlib import Path
+
+        with open(test1) as f1:
+            data1, meta1 = loadarff(f1)
+
+        data2, meta2 = loadarff(Path(test1))
+
+        assert_(data1 == data2)
+        assert_(repr(meta1) == repr(meta2))
 
 class TestMissingData(object):
     def test_missing(self):

--- a/scipy/io/tests/test_paths.py
+++ b/scipy/io/tests/test_paths.py
@@ -1,7 +1,6 @@
 """
 Ensure that we can use pathlib.Path objects in all relevant IO functions.
 """
-import os
 import sys
 
 try:
@@ -16,6 +15,7 @@ from numpy.testing import assert_
 import pytest
 
 import scipy.io
+import scipy.io.wavfile
 from scipy._lib._tmpdirs import tempdir
 import scipy.sparse
 
@@ -55,7 +55,7 @@ class TestPaths(object):
             assert_(contents[0] == ('data', (1, 5), 'int64'))
 
     def test_readsav(self):
-        path = Path(__file__).parent / 'data' / 'scalar_string.sav'
+        path = Path(__file__).parent / 'data/scalar_string.sav'
         scipy.io.readsav(path)
 
     def test_hb_read(self):
@@ -74,3 +74,20 @@ class TestPaths(object):
             path = Path(temp_dir) / 'data.hb'
             scipy.io.harwell_boeing.hb_write(path, data)
             assert_(path.is_file())
+
+    def test_netcdf_file(self):
+        path = Path(__file__).parent / 'data/example_1.nc'
+        scipy.io.netcdf.netcdf_file(path)
+
+    def test_wavfile_read(self):
+        path = Path(__file__).parent / 'data/test-8000Hz-le-2ch-1byteu.wav'
+        scipy.io.wavfile.read(path)
+
+    def test_wavfile_write(self):
+        # Read from str path, write to Path
+        input_path = Path(__file__).parent / 'data/test-8000Hz-le-2ch-1byteu.wav'
+        rate, data = scipy.io.wavfile.read(str(input_path))
+
+        with tempdir() as temp_dir:
+            output_path = Path(temp_dir) / input_path.name
+            scipy.io.wavfile.write(output_path, rate, data)

--- a/scipy/io/tests/test_paths.py
+++ b/scipy/io/tests/test_paths.py
@@ -19,11 +19,6 @@ import scipy.io.wavfile
 from scipy._lib._tmpdirs import tempdir
 import scipy.sparse
 
-# Bit of a hack to keep the test runner from exploding in Python 2.7.
-# FileNotFoundError was added in Python 3.3.
-if sys.version_info < (3, 3):
-    FileNotFoundError = IOError
-
 
 @pytest.mark.skipif(sys.version_info < (3, 6),
                     reason='Passing path-like objects to IO functions requires Python >= 3.6')

--- a/scipy/io/tests/test_paths.py
+++ b/scipy/io/tests/test_paths.py
@@ -12,7 +12,7 @@ except ImportError:
     pass
 
 import numpy as np
-from numpy.testing import assert_, assert_raises
+from numpy.testing import assert_
 import pytest
 
 import scipy.io
@@ -28,7 +28,7 @@ if sys.version_info < (3, 3):
 @pytest.mark.skipif(sys.version_info < (3, 6),
                     reason='Passing path-like objects to IO functions requires Python >= 3.6')
 class TestPaths(object):
-    data = np.arange(5)
+    data = np.arange(5).astype(np.int64)
 
     def test_savemat(self):
         with tempdir() as temp_dir:
@@ -55,8 +55,7 @@ class TestPaths(object):
             assert_(contents[0] == ('data', (1, 5), 'int64'))
 
     def test_readsav(self):
-        filename = os.path.join(os.path.dirname(__file__), 'data', 'scalar_string.sav')
-        path = Path(filename)
+        path = Path(__file__).parent / 'data' / 'scalar_string.sav'
         scipy.io.readsav(path)
 
     def test_hb_read(self):


### PR DESCRIPTION
Apparently integers are stored as int32 on 32-bit Python, so just check the
name and shape of what's stored in the file.