### PR TITLE
Fix up ccache usage on Travis + try enabling on OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -152,15 +152,25 @@ script:
   - python -c 'import mpmath.libmp; assert mpmath.libmp.BACKEND == "gmpy"'
   - |
     if [ "${USE_WHEEL}" == "1" ]; then
-        # Need verbose output or TravisCI will terminate after 10 minutes
-        pip wheel . -v
-        pip install scipy*.whl -v
+        # Run setup.py build before pip wheel, to build in current directory
+        # and make more efficient use of ccache
+        echo "setup.py build"
+        python tools/suppress_output.py python setup.py build
+        echo "pip wheel"
+        python tools/suppress_output.py pip wheel .
+        pip install scipy*.whl
         USE_WHEEL_BUILD="--no-build"
     elif [ "${USE_SDIST}" == "1" ]; then
-        python setup.py sdist
+        echo "setup.py sdist"
+        python tools/suppress_output.py python setup.py sdist
         # Move out of source directory to avoid finding local scipy
         pushd dist
-        pip install scipy* -v
+        # Use pip --build option to make ccache work better.
+        # However, this option is partially broken
+        # (see https://github.com/pypa/pip/issues/4242)
+        # and some shenanigans are needed to make it work.
+        echo "pip install"
+        python ../tools/suppress_output.py pip install --build="$HOME/builds" --upgrade "file://`echo -n $PWD/scipy*`#egg=scipy" -v
         popd
         USE_WHEEL_BUILD="--no-build"
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,6 @@ matrix:
         - TESTMODE=fast
         - COVERAGE=
         - NUMPYSPEC=numpy
-        - USE_SDIST=1
         - MB_PYTHON_VERSION=3.6
 addons:
   apt:
@@ -93,23 +92,32 @@ before_install:
       pip install --upgrade virtualenv
       virtualenv --python=python venv
       source venv/bin/activate
+      export PATH=/usr/lib/ccache:$PATH
       free -m
     elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      brew install gcc
+      brew install gcc ccache
       touch config.sh
       git clone https://github.com/matthew-brett/multibuild.git
       source multibuild/common_utils.sh
       source multibuild/travis_steps.sh
       before_install
-      export CXX=clang++
-      export CC=clang
+      which ccache
+      ln -s ccache /usr/local/bin/gcc
+      ln -s ccache /usr/local/bin/g++
+      ln -s ccache /usr/local/bin/cc
+      ln -s ccache /usr/local/bin/c++
+      ln -s ccache /usr/local/bin/clang
+      ln -s ccache /usr/local/bin/clang++
+      export USE_CCACHE=1
+      export CCACHE_COMPRESS=1
+      export CCACHE_MAXSIZE=200M
+      export CCACHE_CPP2=1
       export CFLAGS="-arch x86_64"
       export CXXFLAGS="-arch x86_64"
       printenv
     fi
   - python --version # just to check
   - export PYTHONFAULTHANDLER=1
-  - export PATH=/usr/lib/ccache:$PATH
   - uname -a
   - df -h
   - ulimit -a
@@ -142,6 +150,7 @@ before_install:
         travis_retry pip install matplotlib Sphinx==1.5.5
     fi
   - python -V
+  - ccache -s
   - popd
   - set -o pipefail
 script:
@@ -178,6 +187,7 @@ script:
   - tools/validate_runtests_log.py $TESTMODE < runtests.log
   - if [ "${REFGUIDE_CHECK}" == "1" ]; then python runtests.py -g --refguide-check; fi
 after_success:
+  - ccache -s
   # Upload development docs, using deploy key from travis-ci encrypted file
   # https://developer.github.com/guides/managing-deploy-keys/
   # http://docs.travis-ci.com/user/encrypting-files/

--- a/tools/cythonize.py
+++ b/tools/cythonize.py
@@ -181,12 +181,14 @@ def process(path, fromfile, tofile, processor_function, hash_db, pxi_hashes):
 
     if not file_changed and not pxi_changed:
         print('%s has not changed' % fullfrompath)
+        sys.stdout.flush()
         return
 
     orig_cwd = os.getcwd()
     try:
         os.chdir(path)
         print('Processing %s' % fullfrompath)
+        sys.stdout.flush()
         processor_function(fromfile, tofile)
     finally:
         os.chdir(orig_cwd)

--- a/tools/suppress_output.py
+++ b/tools/suppress_output.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python
+"""Usage: python suppress_output.py COMMAND...
+
+Run the given command and print "in progress..." messages to stderr,
+one per minute, as long as the command is producing some output.  If
+the command has not recently produced any output, no further messages
+will be printed until it does.
+
+When the command exits with return code 0, exit with code 0.
+
+When the command exits with any other return code, print all output
+produced by the command and exit with the same return code.
+
+"""
+from __future__ import division, absolute_import, print_function
+
+import sys
+import os
+import re
+import subprocess
+import signal
+import time
+import tempfile
+import shutil
+
+
+TIMEOUT = 60
+
+
+def main():
+    command = sys.argv[1:]
+
+    with tempfile.TemporaryFile("a+b", 0) as log:
+        p = subprocess.Popen(command, stdout=log, stderr=subprocess.STDOUT)
+
+        # Rather than handling some signals ourselves, forward them.
+
+        def forward_signal(signum, frame):
+            p.send_signal(signum)
+
+        signal.signal(signal.SIGINT, forward_signal)
+        signal.signal(signal.SIGTERM, forward_signal)
+        signal.signal(signal.SIGQUIT, forward_signal)
+        signal.signal(signal.SIGHUP, forward_signal)
+
+        # Wait for it to finish, and print something to indicate the
+        # process is alive, but only if the log file has grown (to
+        # allow continuous integration environments kill a hanging
+        # process accurately if it produces no output).
+
+        start_time = time.time()
+        last_blip = time.time()
+        last_log_size = log.tell()
+        counter = [0]
+
+        # Just poll it -- other approaches are more complex
+
+        try:
+            sleep_time = 0.001
+            while p.poll() is None:
+                sleep_time = min(2*sleep_time, 0.5)
+                time.sleep(sleep_time)
+                if time.time() - last_blip > TIMEOUT:
+                    log_size = log.tell()
+                    if log_size > last_log_size:
+                        msg = "    ... in progress ({0} elapsed)".format(elapsed(time.time() - start_time))
+                        print(msg, file=sys.stderr)
+                        sys.stderr.flush()
+                        counter[0] += 1
+                        last_blip = time.time()
+                        last_log_size = log_size
+
+            ret = p.wait()
+        except:
+            p.terminate()
+            raise
+
+        if counter[0] > 0:
+            if ret == 0:
+                msg = "    ... ok ({0} elapsed)".format(elapsed(time.time() - start_time))
+                print(msg, file=sys.stderr)
+                sys.stderr.flush()
+            else:
+                msg = "    ... failed ({0} elapsed, exit code {1})".format(
+                    elapsed(time.time() - start_time), ret)
+                print(msg, file=sys.stderr)
+                sys.stderr.flush()
+
+        if ret != 0:
+            log.seek(0)
+            if sys.version_info[0] >= 3:
+                shutil.copyfileobj(log, sys.stdout.buffer)
+            else:
+                shutil.copyfileobj(log, sys.stdout)
+
+    sys.exit(ret)
+
+
+def elapsed(t):
+    if t < 0:
+        sgn = '-'
+        t = abs(t)
+    else:
+        sgn = ''
+
+    if t < 60:
+        return "{0}{1:.0f} s".format(sgn, round(t)) 
+    elif t < 3600:
+        mins, secs = divmod(t, 60)
+        return "{0}{1:.0f} min {2:.0f} s".format(sgn, mins, secs)
+    else:
+        hours, mins = divmod(t, 3600)
+        mins, secs = divmod(mins, 60)
+        return "{0}{1:.0f} h {2:.0f} min {3:.0f} s".format(sgn, hours, mins, secs)
+
+
+def test_elapsed():
+    assert elapsed(0.4) == '0 s'
+    assert elapsed(30.3) == '30 s'
+    assert elapsed(59.5) == '60 s'
+    assert elapsed(60.5) == '1 min 0 s'
+    assert elapsed(2*60 + 40.51) == '2 min 41 s'
+    assert elapsed(60 * 59.999) == '59 min 60 s'
+    assert elapsed(60 * 60.0) == '1 h 0 min 0 s'
+    assert elapsed(266*3600 + 13*60 + 12.4243) == '266 h 13 min 12 s'
+
+
+def test_exitcode():
+    r0 = subprocess.call([sys.executable, __file__, sys.executable, '-c',
+                          'import sys; sys.exit(0)'])
+    assert r0 == 0
+    r1 = subprocess.call([sys.executable, __file__, sys.executable, '-c',
+                          'import sys; sys.exit(1)'])
+    assert r1 == 1
+    rs = subprocess.call([sys.executable, __file__, sys.executable, '-c',
+                          'import os; os.kill(os.getpid(), 15)'])
+    assert rs != 0
+
+
+def test_suppress(tmpdir):
+    p = subprocess.Popen([sys.executable, __file__, sys.executable, '-c',
+                          'import sys; '
+                          'sys.stdout.write("OUT"); '
+                          'sys.stderr.write("ERR"); '
+                          'sys.exit(0)'],
+                         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    out, err = p.communicate()
+    assert p.returncode == 0
+    assert out == b''
+    assert err == b''
+
+    p = subprocess.Popen([sys.executable, __file__, sys.executable, '-c',
+                          'import sys; '
+                          'sys.stdout.write("OUT"); '
+                          'sys.stdout.flush(); '
+                          'sys.stderr.write("ERR"); '
+                          'sys.exit(1)'],
+                         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    out, err = p.communicate()
+    assert p.returncode == 1
+    assert out == b'OUTERR'
+    assert err == b''
+
+
+def run_script_fast(path, script):
+    fn = os.path.join(path, 'suppress_output.py')
+
+    with open(__file__, 'rb') as f:
+        text = f.read()
+        text = text.replace(b'TIMEOUT = 60', b'TIMEOUT = 1')
+
+    with open(fn, 'wb') as f:
+        f.write(text)
+
+    p = subprocess.Popen([sys.executable, fn, sys.executable, '-c', script],
+                         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    out, err = p.communicate()
+    return p.returncode, out, err
+
+
+def test_suppress_long_ok(tmpdir):
+    returncode, out, err = run_script_fast(str(tmpdir),
+                                           'import sys, time; '
+                                           'sys.stdout.write("OUT"); '
+                                           'time.sleep(1.5); '
+                                           'sys.stderr.write("ERR"); '
+                                           'sys.exit(0)')
+    assert returncode == 0
+    assert out == b''
+    assert re.match(b'^    \.\.\. in progress \([0-9 sminh]* elapsed\)\n'
+                    b'    \.\.\. ok \([0-9 sminh]* elapsed\)\n$', err,
+                    re.S)
+
+
+def test_suppress_long_failed(tmpdir):
+    returncode, out, err = run_script_fast(str(tmpdir),
+                                           'import sys, time; '
+                                           'sys.stdout.write("OUT"); '
+                                           'time.sleep(1.5); '
+                                           'sys.stdout.flush(); '
+                                           'sys.stderr.write("ERR"); '
+                                           'sys.exit(1)')
+    assert returncode == 1
+    assert out == b'OUTERR'
+    assert re.match(b'^    \.\.\. in progress \([0-9 sminh]* elapsed\)\n'
+                    b'    \.\.\. failed \([0-9 sminh]* elapsed, exit code 1\)\n$', err,
+                    re.S)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fix up ccache usage on USE_SDIST and USE_WHEEL targets.
Pip by default builds in a directory with random name, which throws off the compiler result caching.

Also try to enable the caching on OSX, based on gh-7647 which was quite close.

Finally, add and use some tools for suppressing the huge output from scipy build commands
in the USE_SDIST and USE_WHEEL targets.