### PR TITLE
BENCH: fix optimize.BenchGlobal.  Closes gh-7658.

### DIFF
--- a/benchmarks/benchmarks/optimize.py
+++ b/benchmarks/benchmarks/optimize.py
@@ -487,7 +487,7 @@ class BenchGlobal(Benchmark):
 
     def setup_cache(self):
         if not self.enabled:
-            return {}
+            return
 
         # create the logfile to start with
         with open(self.dump_fn, 'w') as f:


### PR DESCRIPTION
Checked that this works now:

    SCIPY_GLOBAL_BENCH=AMGM python runtests.py --bench optimize.BenchGlobal

Thanks to @pv for suggesting the solution.

[ci skip]