### PR TITLE
STY: c89 style issues

### DIFF
--- a/scipy/spatial/src/distance_impl.h
+++ b/scipy/spatial/src/distance_impl.h
@@ -388,13 +388,13 @@ pdist_mahalanobis(const double *X, double *dm, const npy_intp num_rows,
                   const npy_intp num_cols, const double *covinv)
 {
     npy_intp i, j;
-
     double *dimbuf1 = calloc(2 * num_cols, sizeof(double));
+    double *dimbuf2;
     if (!dimbuf1) {
         return -1;
     }
 
-    double *dimbuf2 = dimbuf1 + num_cols;
+    dimbuf2 = dimbuf1 + num_cols;
 
     for (i = 0; i < num_rows; ++i) {
         const double *u = X + (num_cols * i);
@@ -546,10 +546,11 @@ cdist_cosine(const double *XA, const double *XB, double *dm, const npy_intp num_
     npy_intp i, j;
 
     double * norms_buffA = calloc(num_rowsA + num_rowsB, sizeof(double));
+    double * norms_buffB;
     if (!norms_buffA)
         return -1;
 
-    double * norms_buffB = norms_buffA + num_rowsA;
+    norms_buffB = norms_buffA + num_rowsA;
 
     _row_norms(XA, num_rowsA, num_cols, norms_buffA);
     _row_norms(XB, num_rowsB, num_cols, norms_buffB);
@@ -578,10 +579,11 @@ cdist_mahalanobis(const double *XA, const double *XB, double *dm,
     npy_intp i, j;
 
     double *dimbuf1 = calloc(2 * num_cols, sizeof(double));
+    double *dimbuf2;
     if (!dimbuf1) {
         return -1;
     }
-    double *dimbuf2 = dimbuf1 + num_cols;
+    dimbuf2 = dimbuf1 + num_cols;
 
     for (i = 0; i < num_rowsA; ++i) {
         const double *u = XA + (num_cols * i);

--- a/scipy/spatial/src/distance_wrap.c
+++ b/scipy/spatial/src/distance_wrap.c
@@ -100,7 +100,7 @@ DEFINE_WRAP_CDIST(yule, char)
 static PyObject *cdist_cosine_double_wrap(PyObject *self, PyObject *args, 
                                                PyObject *kwargs) {
   PyArrayObject *XA_, *XB_, *dm_;
-  int mA, mB, n;
+  int mA, mB, n, status;
   double *dm;
   const double *XA, *XB;
   static char *kwlist[] = {"XA", "XB", "dm", NULL};
@@ -121,7 +121,7 @@ static PyObject *cdist_cosine_double_wrap(PyObject *self, PyObject *args,
     mB = XB_->dimensions[0];
     n = XA_->dimensions[1];
 
-    const int status = cdist_cosine(XA, XB, dm, mA, mB, n);
+    status = cdist_cosine(XA, XB, dm, mA, mB, n);
     NPY_END_THREADS;
     if(status < 0)
         return PyErr_NoMemory();
@@ -132,7 +132,7 @@ static PyObject *cdist_cosine_double_wrap(PyObject *self, PyObject *args,
 static PyObject *cdist_mahalanobis_double_wrap(PyObject *self, PyObject *args, 
                                                PyObject *kwargs) {
   PyArrayObject *XA_, *XB_, *covinv_, *dm_;
-  int mA, mB, n;
+  int mA, mB, n, status;
   double *dm, *dimbuf;
   const double *XA, *XB;
   const double *covinv;
@@ -155,7 +155,7 @@ static PyObject *cdist_mahalanobis_double_wrap(PyObject *self, PyObject *args,
     mB = XB_->dimensions[0];
     n = XA_->dimensions[1];
 
-    const int status = cdist_mahalanobis(XA, XB, dm, mA, mB, n, covinv);
+    status = cdist_mahalanobis(XA, XB, dm, mA, mB, n, covinv);
     NPY_END_THREADS;
     if(status < 0)
         return PyErr_NoMemory();
@@ -304,7 +304,7 @@ static PyObject *pdist_cosine_double_wrap(PyObject *self, PyObject *args,
                                           PyObject *kwargs) 
 {
   PyArrayObject *X_, *dm_;
-  int m, n;
+  int m, n, status;
   double *dm;
   const double *X;
   static char *kwlist[] = {"X", "dm", NULL};
@@ -322,7 +322,7 @@ static PyObject *pdist_cosine_double_wrap(PyObject *self, PyObject *args,
     m = X_->dimensions[0];
     n = X_->dimensions[1];
     
-    const int status = pdist_cosine(X, dm, m, n);
+    status = pdist_cosine(X, dm, m, n);
     NPY_END_THREADS;
     if(status < 0)
         return PyErr_NoMemory();
@@ -333,7 +333,7 @@ static PyObject *pdist_cosine_double_wrap(PyObject *self, PyObject *args,
 static PyObject *pdist_mahalanobis_double_wrap(PyObject *self, PyObject *args, 
                                                PyObject *kwargs) {
   PyArrayObject *X_, *covinv_, *dm_;
-  int m, n;
+  int m, n, status;
   double *dimbuf, *dm;
   const double *X;
   const double *covinv;
@@ -354,7 +354,7 @@ static PyObject *pdist_mahalanobis_double_wrap(PyObject *self, PyObject *args,
     m = X_->dimensions[0];
     n = X_->dimensions[1];
 
-    const int status = pdist_mahalanobis(X, dm, m, n, covinv);
+    status = pdist_mahalanobis(X, dm, m, n, covinv);
     NPY_END_THREADS;
     if(status < 0)
         return PyErr_NoMemory();
@@ -575,6 +575,6 @@ PyObject *PyInit__distance_wrap(void)
 PyMODINIT_FUNC init_distance_wrap(void)
 {
   (void) Py_InitModule("_distance_wrap", _distanceWrapMethods);
-  import_array();  // Must be present for NumPy.  Called first after above line.
+  import_array();  /* Must be present for NumPy.  Called first after above line.*/
 }
 #endif


### PR DESCRIPTION
fixes errors with c89 compilers #7628

@pv I fixed all warnings marked as "ISO C90 forbids mixed declarations and code". Please check to see if it is enough. 