### PR TITLE
BUG: wolfe2 line/scalar search now uses amax parameter

### DIFF
--- a/scipy/optimize/linesearch.py
+++ b/scipy/optimize/linesearch.py
@@ -193,7 +193,7 @@ line_search = line_search_wolfe1
 
 def line_search_wolfe2(f, myfprime, xk, pk, gfk=None, old_fval=None,
                        old_old_fval=None, args=(), c1=1e-4, c2=0.9, amax=50,
-                       extra_condition=None):
+                       extra_condition=None, maxiter=10):
     """Find alpha that satisfies strong Wolfe conditions.
 
     Parameters
@@ -230,6 +230,8 @@ def line_search_wolfe2(f, myfprime, xk, pk, gfk=None, old_fval=None,
         for the step length, the algorithm will continue with 
         new iterates. The callable is only called for iterates 
         satisfying the strong Wolfe conditions.
+    maxiter : int, optional
+        Maximum number of iterations to perform
 
     Returns
     -------
@@ -304,7 +306,7 @@ def line_search_wolfe2(f, myfprime, xk, pk, gfk=None, old_fval=None,
 
     alpha_star, phi_star, old_fval, derphi_star = scalar_search_wolfe2(
             phi, derphi, old_fval, old_old_fval, derphi0, c1, c2, amax,
-            extra_condition2)
+            extra_condition2, maxiter=maxiter)
 
     if derphi_star is None:
         warn('The line search algorithm did not converge', LineSearchWarning)
@@ -321,7 +323,7 @@ def line_search_wolfe2(f, myfprime, xk, pk, gfk=None, old_fval=None,
 def scalar_search_wolfe2(phi, derphi=None, phi0=None,
                          old_phi0=None, derphi0=None,
                          c1=1e-4, c2=0.9, amax=50,
-                         extra_condition=None):
+                         extra_condition=None, maxiter=10):
     """Find alpha that satisfies strong Wolfe conditions.
 
     alpha > 0 is assumed to be a descent direction.
@@ -352,6 +354,8 @@ def scalar_search_wolfe2(phi, derphi=None, phi0=None,
         the algorithm will continue with new iterates.
         The callable is only called for iterates satisfying
         the strong Wolfe conditions.
+    maxiter : int, optional
+        Maximum number of iterations to perform
 
     Returns
     -------
@@ -399,7 +403,6 @@ def scalar_search_wolfe2(phi, derphi=None, phi0=None,
     if extra_condition is None:
         extra_condition = lambda alpha, phi: True
 
-    maxiter = 10
     for i in xrange(maxiter):
         if alpha1 == 0 or alpha0 == amax:
             # alpha1 == 0: This shouldn't happen. Perhaps the increment has

--- a/scipy/optimize/linesearch.py
+++ b/scipy/optimize/linesearch.py
@@ -192,7 +192,7 @@ line_search = line_search_wolfe1
 #------------------------------------------------------------------------------
 
 def line_search_wolfe2(f, myfprime, xk, pk, gfk=None, old_fval=None,
-                       old_old_fval=None, args=(), c1=1e-4, c2=0.9, amax=50,
+                       old_old_fval=None, args=(), c1=1e-4, c2=0.9, amax=None,
                        extra_condition=None, maxiter=10):
     """Find alpha that satisfies strong Wolfe conditions.
 
@@ -322,7 +322,7 @@ def line_search_wolfe2(f, myfprime, xk, pk, gfk=None, old_fval=None,
 
 def scalar_search_wolfe2(phi, derphi=None, phi0=None,
                          old_phi0=None, derphi0=None,
-                         c1=1e-4, c2=0.9, amax=50,
+                         c1=1e-4, c2=0.9, amax=None,
                          extra_condition=None, maxiter=10):
     """Find alpha that satisfies strong Wolfe conditions.
 
@@ -404,7 +404,7 @@ def scalar_search_wolfe2(phi, derphi=None, phi0=None,
         extra_condition = lambda alpha, phi: True
 
     for i in xrange(maxiter):
-        if alpha1 == 0 or alpha0 == amax:
+        if alpha1 == 0 or (amax is not None and alpha0 == amax):
             # alpha1 == 0: This shouldn't happen. Perhaps the increment has
             # slipped below machine precision?
             alpha_star = None
@@ -444,7 +444,9 @@ def scalar_search_wolfe2(phi, derphi=None, phi0=None,
                               phi0, derphi0, c1, c2, extra_condition)
             break
 
-        alpha2 = min(amax, 2 * alpha1)   # increase by factor of two on each iteration
+        alpha2 = 2 * alpha1  # increase by factor of two on each iteration
+        if amax is not None:
+            alpha2 = min(alpha2, amax)
         alpha0 = alpha1
         alpha1 = alpha2
         phi_a0 = phi_a1

--- a/scipy/optimize/tests/test_linesearch.py
+++ b/scipy/optimize/tests/test_linesearch.py
@@ -209,7 +209,7 @@ class TestLineSearch(object):
                 assert_line_wolfe(x, p, s, f, fprime, err_msg=name)
         assert_(c > 3)  # check that the iterator really works...
 
-    def test_line_search_wolfe2_amax(self):
+    def test_line_search_wolfe2_bounds(self):
         # See gh-7475
 
         # For this f and p, starting at a point on axis 0, the strong Wolfe
@@ -230,6 +230,10 @@ class TestLineSearch(object):
                                         ls.line_search_wolfe2, f, fp, x, p,
                                         amax=29, c2=c2)
         assert_(s is None)
+
+        # s=30 will only be tried on the 6th iteration, so this won't converge
+        assert_warns(LineSearchWarning, ls.line_search_wolfe2, f, fp, x, p,
+                     c2=c2, maxiter=5)
 
     def test_line_search_armijo(self):
         c = 0


### PR DESCRIPTION
Also added maxiter parameter as suggested in this comment: https://github.com/scipy/scipy/issues/7475#issuecomment-310879180