### PR TITLE
MAINT: _lib/ccallback.h: PyCapsule_GetName returns const char*

### DIFF
--- a/scipy/_lib/src/ccallback.h
+++ b/scipy/_lib/src/ccallback.h
@@ -199,7 +199,7 @@ static ccallback_t *ccallback_obtain(void)
  *     The mismatcing signature from user-provided PyCapsule.
  */
 static void ccallback__err_invalid_signature(ccallback_signature_t *signatures,
-                                             char *capsule_signature)
+                                             const char *capsule_signature)
 {
     PyObject *sig_list = NULL;
     ccallback_signature_t *sig;


### PR DESCRIPTION
not `char *`. (https://docs.python.org/3/c-api/capsule.html)

This seems to fix a trivial warning,

```
In file included from scipy/ndimage/src/nd_image.c:45:0:
scipy/_lib/src/ccallback.h: In function ‘ccallback_prepare’:
scipy/_lib/src/ccallback.h:370:13: warning: passing argument 2 of ‘ccallback__err_invalid_signature’ discards ‘const’ qualifier from pointer target type [enabled by default]
scipy/_lib/src/ccallback.h:201:13: note: expected ‘char *’ but argument is of type ‘const char *’
```