### PR TITLE
TST: interpolate: test integrating periodic b-splines against ppoly

### DIFF
--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -371,6 +371,17 @@ class TestBSpline(object):
         assert_allclose(b.integrate(-9, -10), i(0) - i(1))
         assert_allclose(b.integrate(0, -9), i(1) - i(2) - 4 * period_int)
 
+    def test_integrate_ppoly(self):
+        # test .integrate method to be consistent with PPoly.integrate
+        x = [0, 1, 2, 3, 4]
+        b = make_interp_spline(x, x)
+        b.extrapolate = 'periodic'
+        p = PPoly.from_spline(b)
+
+        for x0, x1 in [(-5, 0.5), (0.5, 5), (-4, 13)]:
+            assert_allclose(b.integrate(x0, x1),
+                            p.integrate(x0, x1))
+
     def test_subclassing(self):
         # classmethods should not decay to the base class
         class B(BSpline):


### PR DESCRIPTION
A follow-up to https://github.com/scipy/scipy/pull/7185

Periodicity makes integrating polynomials and splines fairly convoluted and error-prone; these routines took quite a bit of effort to iron out, mostly Nikolay's and Aman's. This PR adds a smoke test to make sure these routines stay in sync. 

cc @amanp10 