### PR TITLE
dok_matrix updates

### DIFF
--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -378,7 +378,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
 
         self.sum_duplicates()
         dok = dok_matrix((self.shape), dtype=self.dtype)
-        dok.update(izip(izip(self.row,self.col),self.data))
+        dok._update(izip(izip(self.row,self.col),self.data))
 
         return dok
 

--- a/scipy/sparse/dok.py
+++ b/scipy/sparse/dok.py
@@ -8,6 +8,7 @@ __all__ = ['dok_matrix', 'isspmatrix_dok']
 
 import functools
 import operator
+import itertools
 
 import numpy as np
 
@@ -290,21 +291,19 @@ class dok_matrix(spmatrix, IndexMixin, dict):
                     del self[key]
 
     def __add__(self, other):
-        # First check if argument is a scalar
-        if isscalarlike(other):
+        if isscalarlike(other):  # check if argument is a scalar
             res_dtype = upcast_scalar(self.dtype, other)
             new = dok_matrix(self.shape, dtype=res_dtype)
             # Add this scalar to every element.
             M, N = self.shape
-            for i in xrange(M):
-                for j in xrange(N):
-                    aij = self.get((i, j), 0) + other
-                    if aij != 0:
-                        new[i, j] = aij
+            for i, j in itertools.product(xrange(M), xrange(N)):
+                aij = dict.get(self, (i, j), 0) + other
+                if aij:
+                    new[i, j] = aij
             # new.dtype.char = self.dtype.char
         elif isinstance(other, dok_matrix):
             if other.shape != self.shape:
-                raise ValueError("matrix dimensions are not equal")
+                raise ValueError("Matrix dimensions are not equal.")
             # We could alternatively set the dimensions to the largest of
             # the two matrices to be summed.  Would this be a good idea?
             res_dtype = upcast(self.dtype, other.dtype)
@@ -323,19 +322,16 @@ class dok_matrix(spmatrix, IndexMixin, dict):
         return new
 
     def __radd__(self, other):
-        # First check if argument is a scalar
-        if isscalarlike(other):
+        if isscalarlike(other):  # Check if argument is a scalar
             new = dok_matrix(self.shape, dtype=self.dtype)
             # Add this scalar to every element.
             M, N = self.shape
-            for i in xrange(M):
-                for j in xrange(N):
-                    aij = self.get((i, j), 0) + other
-                    if aij != 0:
-                        new[i, j] = aij
-        elif isinstance(other, dok_matrix):
+            for i, j in itertools.product(xrange(M), xrange(N)):
+                aij = dict.get(self, (i, j), 0) + other
+                if aij:
+                    new[i, j] = aij
             if other.shape != self.shape:
-                raise ValueError("matrix dimensions are not equal")
+                raise ValueError("matrix dimensions are not equal.")
             new = dok_matrix(self.shape, dtype=self.dtype)
             new.update(self)
             for key in other:

--- a/scipy/sparse/dok.py
+++ b/scipy/sparse/dok.py
@@ -301,7 +301,7 @@ class dok_matrix(spmatrix, IndexMixin, dict):
                 if aij:
                     new[i, j] = aij
             # new.dtype.char = self.dtype.char
-        elif isinstance(other, dok_matrix):
+        elif isspmatrix_dok(other):
             if other.shape != self.shape:
                 raise ValueError("Matrix dimensions are not equal.")
             # We could alternatively set the dimensions to the largest of
@@ -330,6 +330,7 @@ class dok_matrix(spmatrix, IndexMixin, dict):
                 aij = dict.get(self, (i, j), 0) + other
                 if aij:
                     new[i, j] = aij
+        elif isspmatrix_dok(other):
             if other.shape != self.shape:
                 raise ValueError("matrix dimensions are not equal.")
             new = dok_matrix(self.shape, dtype=self.dtype)

--- a/scipy/sparse/dok.py
+++ b/scipy/sparse/dok.py
@@ -101,10 +101,10 @@ class dok_matrix(spmatrix, IndexMixin, dict):
             try:
                 arg1 = np.asarray(arg1)
             except:
-                raise TypeError('invalid input format')
+                raise TypeError('Invalid input format.')
 
             if len(arg1.shape) != 2:
-                raise TypeError('expected rank <=2 dense array or matrix')
+                raise TypeError('Expected rank <=2 dense array or matrix.')
 
             from .coo import coo_matrix
             d = coo_matrix(arg1, dtype=dtype).todok()
@@ -114,8 +114,8 @@ class dok_matrix(spmatrix, IndexMixin, dict):
 
     def update(self, val):
         # Prevent direct usage of update
-        raise NotImplementedError("Direct modification of dok_matrix elements "
-                                  "is not allowed")
+        raise NotImplementedError("Direct modification to dok_matrix element "
+                                  "is not allowed.")
 
     def _update(self, data):
         """ An update method for dict data defined for direct access to
@@ -127,8 +127,8 @@ class dok_matrix(spmatrix, IndexMixin, dict):
 
     def getnnz(self, axis=None):
         if axis is not None:
-            raise NotImplementedError("getnnz over an axis is not implemented "
-                                      "for DOK format")
+            raise NotImplementedError("Getnnz over an axis is not implemented "
+                                      "for DOK format.")
         return dict.__len__(self)
 
     def count_nonzero(self):
@@ -154,7 +154,7 @@ class dok_matrix(spmatrix, IndexMixin, dict):
         return dict.get(self, key, default)
 
     def __getitem__(self, index):
-        """If key=(i,j) is a pair of integers, return the corresponding
+        """ If key=(i,j) is a pair of integers, return the corresponding
         element.  If either i or j is a slice or sequence, return a new sparse
         matrix with just these elements.
         """
@@ -204,7 +204,7 @@ class dok_matrix(spmatrix, IndexMixin, dict):
 
         min_i = i.min()
         if min_i < -self.shape[0] or i.max() >= self.shape[0]:
-            raise IndexError('index (%d) out of range -%d to %d)' %
+            raise IndexError('Index (%d) out of range -%d to %d.' %
                              (i.min(), self.shape[0], self.shape[0]-1))
         if min_i < 0:
             i = i.copy()
@@ -212,7 +212,7 @@ class dok_matrix(spmatrix, IndexMixin, dict):
 
         min_j = j.min()
         if min_j < -self.shape[1] or j.max() >= self.shape[1]:
-            raise IndexError('index (%d) out of range -%d to %d)' %
+            raise IndexError('Index (%d) out of range -%d to %d.' %
                              (j.min(), self.shape[1], self.shape[1]-1))
         if min_j < 0:
             j = j.copy()
@@ -220,11 +220,10 @@ class dok_matrix(spmatrix, IndexMixin, dict):
 
         newdok = dok_matrix(i.shape, dtype=self.dtype)
 
-        for a in xrange(i.shape[0]):
-            for b in xrange(i.shape[1]):
-                v = dict.get(self, (i[a,b], j[a,b]), zero)
-                if v != 0:
-                    dict.__setitem__(newdok, (a, b), v)
+        for key in itertools.product(xrange(i.shape[0]), xrange(i.shape[1])):
+            v = dict.get(self, (i[key], j[key]), zero)
+            if v:
+                dict.__setitem__(newdok, key, v)
 
         return newdok
 
@@ -308,10 +307,10 @@ class dok_matrix(spmatrix, IndexMixin, dict):
             new = dok_matrix(self.shape, dtype=res_dtype)
             # Add this scalar to every element.
             M, N = self.shape
-            for i, j in itertools.product(xrange(M), xrange(N)):
-                aij = dict.get(self, (i, j), 0) + other
+            for key in itertools.product(xrange(M), xrange(N)):
+                aij = dict.get(self, (key), 0) + other
                 if aij:
-                    new[i, j] = aij
+                    new[key] = aij
             # new.dtype.char = self.dtype.char
         elif isspmatrix_dok(other):
             if other.shape != self.shape:
@@ -502,7 +501,7 @@ class dok_matrix(spmatrix, IndexMixin, dict):
     tocsc.__doc__ = spmatrix.tocsc.__doc__
 
     def resize(self, shape):
-        """ Resize the matrix in-place to dimensions given by 'shape'.
+        """ Resize the matrix in-place to dimensions given by `shape`.
 
         Any non-zero elements that lie outside the new shape are removed.
         """

--- a/scipy/sparse/dok.py
+++ b/scipy/sparse/dok.py
@@ -414,6 +414,9 @@ class dok_matrix(spmatrix, IndexMixin, dict):
         else:
             return NotImplemented
 
+    def __reduce__(self):
+        return dict.__reduce__(self)
+
     # What should len(sparse) return? For consistency with dense matrices,
     # perhaps it should be the number of rows?  For now it returns the number
     # of non-zeros.

--- a/scipy/sparse/dok.py
+++ b/scipy/sparse/dok.py
@@ -427,8 +427,8 @@ class dok_matrix(spmatrix, IndexMixin, dict):
         M, N = self.shape
         new = dok_matrix((N, M), dtype=self.dtype, copy=copy)
 
-        for key, value in iteritems(self):
-            new[key[1], key[0]] = value
+        for (lhs, rhs), value in iteritems(self):
+            new[rhs, lhs] = value
 
         return new
 

--- a/scipy/sparse/dok.py
+++ b/scipy/sparse/dok.py
@@ -409,6 +409,9 @@ class dok_matrix(spmatrix, IndexMixin, dict):
         return NotImplemented
 
     def __reduce__(self):
+        # this approach is necessary because __setstate__ is called after
+        # __setitem__ upon unpickleing and since __init__ is not called there
+        # is no shape attribute hence it is not possible to unpickle it.
         return dict.__reduce__(self)
 
     # What should len(sparse) return? For consistency with dense matrices,

--- a/scipy/sparse/dok.py
+++ b/scipy/sparse/dok.py
@@ -119,16 +119,15 @@ class dok_matrix(spmatrix, IndexMixin, dict):
                                   "is not allowed.")
 
     def _update(self, data):
-        """ An update method for dict data defined for direct access to
-        `dok_matrix` data. Main purpose is to be used for effient conversion
-        from other spmatrix classes. Has no checking if `data` is valid.
-        """
+        """An update method for dict data defined for direct access to
+        `dok_matrix` data. Main purpose is to be used for effcient conversion
+        from other spmatrix classes. Has no checking if `data` is valid."""
         return dict.update(self, data)
 
 
     def getnnz(self, axis=None):
         if axis is not None:
-            raise NotImplementedError("Getnnz over an axis is not implemented "
+            raise NotImplementedError("getnnz over an axis is not implemented "
                                       "for DOK format.")
         return dict.__len__(self)
 
@@ -149,13 +148,13 @@ class dok_matrix(spmatrix, IndexMixin, dict):
             i, j = key
             assert isintlike(i) and isintlike(j)
         except (AssertionError, TypeError, ValueError):
-            raise IndexError('index must be a pair of integers')
+            raise IndexError('Index must be a pair of integers.')
         if (i < 0 or i >= self.shape[0] or j < 0 or j >= self.shape[1]):
-            raise IndexError('index out of bounds')
+            raise IndexError('Index out of bounds.')
         return dict.get(self, key, default)
 
     def __getitem__(self, index):
-        """ If key=(i,j) is a pair of integers, return the corresponding
+        """If key=(i, j) is a pair of integers, return the corresponding
         element.  If either i or j is a slice or sequence, return a new sparse
         matrix with just these elements.
         """
@@ -171,11 +170,11 @@ class dok_matrix(spmatrix, IndexMixin, dict):
             if i < 0:
                 i += self.shape[0]
             if i < 0 or i >= self.shape[0]:
-                raise IndexError('index out of bounds')
+                raise IndexError('Index out of bounds.')
             if j < 0:
                 j += self.shape[1]
             if j < 0 or j >= self.shape[1]:
-                raise IndexError('index out of bounds')
+                raise IndexError('Index out of bounds.')
             return dict.get(self, (i,j), zero)
         elif ((i_intlike or isinstance(i, slice)) and
               (j_intlike or isinstance(j, slice))):
@@ -410,7 +409,7 @@ class dok_matrix(spmatrix, IndexMixin, dict):
 
     def __reduce__(self):
         # this approach is necessary because __setstate__ is called after
-        # __setitem__ upon unpickleing and since __init__ is not called there
+        # __setitem__ upon unpickling and since __init__ is not called there
         # is no shape attribute hence it is not possible to unpickle it.
         return dict.__reduce__(self)
 
@@ -433,7 +432,7 @@ class dok_matrix(spmatrix, IndexMixin, dict):
     transpose.__doc__ = spmatrix.transpose.__doc__
 
     def conjtransp(self):
-        """ Return the conjugate transpose. """
+        """Return the conjugate transpose."""
         M, N = self.shape
         new = dok_matrix((N, M), dtype=self.dtype)
         dict.update(new, (((right, left), np.conj(val))
@@ -448,15 +447,13 @@ class dok_matrix(spmatrix, IndexMixin, dict):
     copy.__doc__ = spmatrix.copy.__doc__
 
     def getrow(self, i):
-        """ Returns a copy of row with index `i` of the matrix as a (1 x n) DOK
-        matrix. """
+        """Returns the i-th row as a (1 x n) DOK matrix."""
         new = dok_matrix((1, self.shape[1]), dtype=self.dtype)
         dict.update(new, (((0, j), self[i, j]) for j in xrange(self.shape[1])))
         return new
 
     def getcol(self, j):
-        """ Returns a copy of column with index j of the matrix as a (m x 1)
-        DOK matrix. """
+        """Returns the j-th column as a (m x 1) DOK matrix."""
         new = dok_matrix((self.shape[0], 1), dtype=self.dtype)
         dict.update(new, (((i, 0), self[i, j]) for i in xrange(self.shape[0])))
         return new
@@ -489,7 +486,7 @@ class dok_matrix(spmatrix, IndexMixin, dict):
     tocsc.__doc__ = spmatrix.tocsc.__doc__
 
     def resize(self, shape):
-        """ Resize the matrix in-place to dimensions given by `shape`.
+        """Resize the matrix in-place to dimensions given by `shape`.
 
         Any non-zero elements that lie outside the new shape are removed.
         """

--- a/scipy/sparse/dok.py
+++ b/scipy/sparse/dok.py
@@ -232,7 +232,7 @@ class dok_matrix(spmatrix, IndexMixin, dict):
 
         newdok = dok_matrix(shape, dtype=self.dtype)
 
-        for (ii, jj) in self.keys():
+        for (ii, jj) in iterkeys(self):
             # ditto for numpy scalars
             ii = int(ii)
             jj = int(jj)
@@ -493,7 +493,7 @@ class dok_matrix(spmatrix, IndexMixin, dict):
         M, N = self.shape
         if newM < M or newN < N:
             # Remove all elements outside new dimensions
-            for (i, j) in list(self.keys()):
+            for (i, j) in list(iterkeys(self)):
                 if i >= newM or j >= newN:
                     del self[i, j]
         self._shape = shape

--- a/scipy/sparse/dok.py
+++ b/scipy/sparse/dok.py
@@ -78,7 +78,6 @@ class dok_matrix(spmatrix, IndexMixin, dict):
     format = 'dok'
 
     def __init__(self, arg1, shape=None, dtype=None, copy=False):
-        # TODO: constructor from iterable?
         dict.__init__(self)
         spmatrix.__init__(self)
 
@@ -123,7 +122,6 @@ class dok_matrix(spmatrix, IndexMixin, dict):
         `dok_matrix` data. Main purpose is to be used for effcient conversion
         from other spmatrix classes. Has no checking if `data` is valid."""
         return dict.update(self, data)
-
 
     def getnnz(self, axis=None):
         if axis is not None:
@@ -246,7 +244,6 @@ class dok_matrix(spmatrix, IndexMixin, dict):
                 continue
             dict.__setitem__(newdok, (a, b),
                              dict.__getitem__(self, (ii, jj)))
-
         return newdok
 
     def __setitem__(self, index, x):
@@ -380,9 +377,9 @@ class dok_matrix(spmatrix, IndexMixin, dict):
 
     def _mul_multivector(self, other):
         # matrix * multivector
-        M, N = self.shape
-        n_vecs = other.shape[1]
-        result = np.zeros((M, n_vecs), dtype=upcast(self.dtype, other.dtype))
+        result_shape = (self.shape[0], other.shape[1])
+        result_dtype = upcast(self.dtype, other.dtype)
+        result = np.zeros(result_shape, dtype=result_dtype)
         for (i, j), v in iteritems(self):
             result[i,:] += v * other[j,:]
         return result

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1909,13 +1909,13 @@ class _TestCommon(object):
             for protocol in range(pickle.HIGHEST_PROTOCOL):
                 sploaded = pickle.loads(pickle.dumps(datsp, protocol=protocol))
                 assert_equal(datsp.shape, sploaded.shape)
-                assert_array_equal(datsp.todense(), sploaded.todense())
+                assert_array_equal(datsp.toarray(), sploaded.toarray())
                 assert_equal(datsp.format, sploaded.format)
                 for key, val in datsp.__dict__.items():
                     if isinstance(val, np.ndarray):
                         assert_array_equal(val, sploaded.__dict__[key])
-                        continue
-                    assert_(val == sploaded.__dict__[key])
+                    else:
+                        assert_(val == sploaded.__dict__[key])
         check()
 
     def test_unary_ufunc_overrides(self):

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1898,6 +1898,26 @@ class _TestCommon(object):
             assert_array_equal(spm.todok().A, m)
             assert_array_equal(spm.tobsr().A, m)
 
+    def test_pickle(self):
+        import pickle
+        sup = suppress_warnings()
+        sup.filter(SparseEfficiencyWarning)
+
+        @sup
+        def check():
+            datsp = self.datsp.copy()
+            for protocol in range(pickle.HIGHEST_PROTOCOL):
+                sploaded = pickle.loads(pickle.dumps(datsp, protocol=protocol))
+                assert_equal(datsp.shape, sploaded.shape)
+                assert_array_equal(datsp.todense(), sploaded.todense())
+                assert_equal(datsp.format, sploaded.format)
+                for key, val in datsp.__dict__.items():
+                    if isinstance(val, np.ndarray):
+                        assert_array_equal(val, sploaded.__dict__[key])
+                        continue
+                    assert_(val == sploaded.__dict__[key])
+        check()
+
     def test_unary_ufunc_overrides(self):
         def check(name):
             if not HAS_NUMPY_UFUNC:
@@ -3941,17 +3961,6 @@ class TestDOK(sparse_test_class(minmax=False, nnz_axis=False)):
         b = dok_matrix((3,3))
         b[:,0] = 0
         assert_(len(b.keys()) == 0, "Unexpected entries in keys")
-
-
-
-    def test_pickle(self):
-        import pickle
-        m = self.spmatrix([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
-        m_load = pickle.loads(pickle.dumps(m))
-        assert_(m.shape == m_load.shape)
-        assert_(m.items() == m_load.items())
-        assert_(m.__dict__ == m_load.__dict__)
-        assert_(m.maxprint == m_load.maxprint)
 
 TestDOK.init_class()
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -3942,6 +3942,17 @@ class TestDOK(sparse_test_class(minmax=False, nnz_axis=False)):
         b[:,0] = 0
         assert_(len(b.keys()) == 0, "Unexpected entries in keys")
 
+
+
+    def test_pickle(self):
+        import pickle
+        m = self.spmatrix([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+        m_load = pickle.loads(pickle.dumps(m))
+        assert_(m.shape == m_load.shape)
+        assert_(m.items() == m_load.items())
+        assert_(m.__dict__ == m_load.__dict__)
+        assert_(m.maxprint == m_load.maxprint)
+
 TestDOK.init_class()
 
 


### PR DESCRIPTION
Hi,

I had problem recently when using pickle on dok_matrix and I saw it was unfixed for quite some time (issue #1188)  hence I decided to fix it. 

But I also added one additional test (not sure if necessary) and made some changes to ``dok_matrix``'s ``__add__`` and ``__radd__`` methods. Namely there are some sort of bound checking that should probably be avoided in these methods. I've also wrote small [script](https://gist.github.com/akstrfn/c3c62e5c798c2fa3211934bec3decc5a) to benchmark some of these things and it looks like that using ``iterkeys`` or ``keys`` is comparably slower. Note I tested only py3 so difference on py2 should be even bigger when using ``keys``.

Please let me know what you think of it and if this looks good I can try to adapt other methods to directly access the data i.e. without bounds checks when useful.

Summary of changes in this PL:
- fix pickle for ``dok_matrix`` in python3 (related issue #1188)
- double for loops changed to ``itertools.product``
- changed some calls to directly call ``dict`` to avoid additional checks
- prevent unintentional usage of ``dok_matrix.update`` since it directly sets the data for ``dok_matrix`` with no checks if the input is valid.
- using generator in combination with ``dict.update`` whenever possible


Cheers,
Aleks