### PR TITLE
Tests tuning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,7 +112,6 @@ before_install:
       printenv
     fi
   - python --version # just to check
-  - export PYTHONFAULTHANDLER=1
   - export NPY_NUM_BUILD_JOBS=2
   - uname -a
   - df -h
@@ -135,7 +134,7 @@ before_install:
   # Need to install Cython 0.23.4 from source to avoid errors for Python 3.6
   - travis_retry pip install --install-option="--no-cython-compile" Cython==0.23.4
   - travis_retry pip install $NUMPYSPEC
-  - travis_retry pip install pytest pytest-xdist nose mpmath argparse Pillow codecov
+  - travis_retry pip install pytest pytest-xdist pytest-faulthandler nose mpmath argparse Pillow codecov
   - travis_retry pip install --upgrade pip setuptools
   - travis_retry pip install gmpy2  # speeds up mpmath (scipy.special tests)
   - if [ "${TESTMODE}" == "full" ]; then pip install pytest-cov coverage; fi

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,8 @@
 [pytest]
+addopts = -l
+markers =
+    slow: mark test as slow
+    xslow: mark test as extremely slow (not run unless explicitly requested)
 filterwarnings =
     error
     once:.*LAPACK bug 0038.*:RuntimeWarning

--- a/scipy/sparse/tests/test_sparsetools.py
+++ b/scipy/sparse/tests/test_sparsetools.py
@@ -76,7 +76,14 @@ class TestInt32Overflow(object):
     def setup_method(self):
         assert self.n**2 > np.iinfo(np.int32).max
 
-        check_free_memory(9000)
+        # check there's enough memory even if everything is run at the
+        # same time
+        try:
+            parallel_count = int(os.environ.get('PYTEST_XDIST_WORKER_COUNT', '1'))
+        except ValueError:
+            parallel_count = np.inf
+
+        check_free_memory(3000 * parallel_count)
 
     def teardown_method(self):
         gc.collect()


### PR DESCRIPTION
- Declare marks used in pytest.ini.
- Use pytest-faulthandler, for compatibility with parallel testing.
- Fix up sparsetools test memory check (these tests are crashing sometimes on travis, maybe this helps).