### PR TITLE
MAINT: _lib: add user-overridable available memory determination

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -177,6 +177,7 @@ script:
         popd
         USE_WHEEL_BUILD="--no-build"
     fi
+  - export SCIPY_AVAILABLE_MEM=3G
   - python -u $OPTIMIZE runtests.py -g -m $TESTMODE $COVERAGE $USE_WHEEL_BUILD -- -rfEX -n 2 2>&1 | tee runtests.log
   - tools/validate_runtests_log.py $TESTMODE < runtests.log
   - if [ "${REFGUIDE_CHECK}" == "1" ]; then python runtests.py -g --refguide-check; fi

--- a/scipy/_lib/_testutils.py
+++ b/scipy/_lib/_testutils.py
@@ -6,10 +6,11 @@ Generic test utilities.
 from __future__ import division, print_function, absolute_import
 
 import os
+import re
 import sys
 
 
-__all__ = ['PytestTester']
+__all__ = ['PytestTester', 'check_free_memory']
 
 
 class PytestTester(object):
@@ -57,3 +58,66 @@ class PytestTester(object):
             code = exc.code
 
         return (code == 0)
+
+
+def check_free_memory(free_mb):
+    """
+    Check *free_mb* of memory is available, otherwise do pytest.skip
+    """
+    import pytest
+
+    try:
+        mem_free = _parse_size(os.environ['SCIPY_AVAILABLE_MEM'])
+        msg = '{0} MB memory required, but environment SCIPY_AVAILABLE_MEM={1}'.format(
+            free_mb, os.environ['SCIPY_AVAILABLE_MEM'])
+    except KeyError:
+        mem_free = _get_mem_available()
+        if mem_free is None:
+            pytest.skip("Could not determine available memory; set SCIPY_AVAILABLE_MEM "
+                        "variable to free memory in MB to run the test.")
+        msg = '{0} MB memory required, but {1} MB available'.format(
+            free_mb, mem_free/1e6)
+
+    if mem_free < free_mb * 1e6:
+        pytest.skip(msg)
+
+
+def _parse_size(size_str):
+    suffixes = {'': 1e6,
+                'b': 1.0,
+                'k': 1e3, 'M': 1e6, 'G': 1e9, 'T': 1e12,
+                'kb': 1e3, 'Mb': 1e6, 'Gb': 1e9, 'Tb': 1e12,
+                'kib': 1024.0, 'Mib': 1024.0**2, 'Gib': 1024.0**3, 'Tib': 1024.0**4}
+    m = re.match(r'^\s*(\d+)\s*({0})\s*$'.format('|'.join(suffixes.keys())),
+                 size_str,
+                 re.I)
+    if not m or m.group(2) not in suffixes:
+        raise ValueError("Invalid size string")
+
+    return float(m.group(1)) * suffixes[m.group(2)]
+
+
+def _get_mem_available():
+    """
+    Get information about memory available, not counting swap.
+    """
+    try:
+        import psutil
+        return psutil.virtual_memory().available
+    except (ImportError, AttributeError):
+        pass
+
+    if sys.platform.startswith('linux'):
+        info = {}
+        with open('/proc/meminfo', 'r') as f:
+            for line in f:
+                p = line.split()
+                info[p[0].strip(':').lower()] = float(p[1]) * 1e3
+
+        if 'memavailable' in info:
+            # Linux >= 3.14
+            return info['memavailable']
+        else:
+            return info['memfree'] + info['memcached']
+
+    return None

--- a/scipy/_lib/tests/test__gcutils.py
+++ b/scipy/_lib/tests/test__gcutils.py
@@ -1,5 +1,7 @@
 """ Test for assert_deallocated context manager and gc utilities
 """
+from __future__ import division, print_function, absolute_import
+
 import gc
 
 from scipy._lib._gcutils import set_gc_state, gc_state, assert_deallocated, ReferenceError

--- a/scipy/_lib/tests/test__testutils.py
+++ b/scipy/_lib/tests/test__testutils.py
@@ -1,0 +1,34 @@
+from __future__ import division, print_function, absolute_import
+
+import sys
+from scipy._lib._testutils import _parse_size, _get_mem_available
+import pytest
+
+
+def test__parse_size():
+    expected = {
+        '12': 12e6,
+        '12 b': 12,
+        '12k': 12e3,
+        '  12  M  ': 12e6,
+        '  12  G  ': 12e9,
+        ' 12Tb ': 12e12,
+        '12  Mib ': 12 * 1024.0**2,
+        '12Tib': 12 * 1024.0**4,
+    }
+
+    for inp, outp in sorted(expected.items()):
+        if outp is None:
+            with pytest.raises(ValueError):
+                _parse_size(inp)
+        else:
+            assert _parse_size(inp) == outp
+
+
+def test__mem_available():
+    # May return None on non-Linux platforms
+    available = _get_mem_available()
+    if sys.platform.startswith('linux'):
+        assert available >= 0
+    else:
+        assert available is None or available >= 0

--- a/scipy/sparse/tests/test_sparsetools.py
+++ b/scipy/sparse/tests/test_sparsetools.py
@@ -11,6 +11,7 @@ from numpy.testing import (assert_raises, assert_equal, assert_, assert_allclose
 from scipy.sparse import (_sparsetools, coo_matrix, csr_matrix, csc_matrix,
                           bsr_matrix, dia_matrix)
 from scipy.sparse.sputils import supported_dtypes
+from scipy._lib._testutils import check_free_memory
 
 import pytest
 
@@ -305,42 +306,3 @@ def test_endianness():
 
     assert_allclose(a.dot(v), [1, 3, 6, 5])
     assert_allclose(b.dot(v), [1, 3, 6, 5])
-
-
-def check_free_memory(free_mb):
-    if not sys.platform.startswith('linux'):
-        pytest.skip("Test runs only on linux.")
-
-    meminfo = get_mem_info_linux()
-
-    if meminfo['memfree'] + meminfo['cached'] < free_mb * 1e6:
-        pytest.skip("test requires %d MB of free memory" % (int(free_mb),))
-
-
-def get_mem_info_linux():
-    """
-    Get information about available memory.
-
-    Returns a dict of items in /proc/meminfo
-    """
-    info = {}
-    with open('/proc/meminfo', 'r') as f:
-        for line in f:
-            p = line.split()
-            info[p[0].strip(':').lower()] = float(p[1]) * 1e3
-    return info
-
-
-def get_own_memusage_linux():
-    """
-    Return the memory usage of the current process (in bytes)
-    """
-    with open('/proc/%d/status' % os.getpid(), 'r') as f:
-        procdata = f.read()
-
-    m = re.search(r'VmRSS:\s*(\d+)\s*kB', procdata, re.S | re.I)
-    if m is not None:
-        memusage = float(m.group(1)) * 1e3
-        return memusage
-
-    return np.nan


### PR DESCRIPTION
Add user-overridable way to determine memory available for tests.

Also, set the amount manually to 3G on Travis-CI --- in their documentation they say 4GB but let's play it slightly safe. Apparently, /proc/meminfo in their docker environment does not return the actually available memory, so we need to specify this manually. This probably should solve the spurious test failures seen recently...