### PR TITLE
ENH: allow int-like parameters in several routines

### DIFF
--- a/scipy/fftpack/helper.py
+++ b/scipy/fftpack/helper.py
@@ -1,5 +1,6 @@
 from __future__ import division, print_function, absolute_import
 
+import operator
 from numpy import arange
 from numpy.fft.helper import fftshift, ifftshift, fftfreq
 from bisect import bisect_left
@@ -41,7 +42,8 @@ def rfftfreq(n, d=1.0):
     array([ 0.  ,  1.25,  1.25,  2.5 ,  2.5 ,  3.75,  3.75,  5.  ])
 
     """
-    if n != int(n) or n < 0:
+    n = operator.index(n)
+    if n < 0:
         raise ValueError("n = %s is not valid. "
                          "n must be a nonnegative integer." % n)
 

--- a/scipy/fftpack/helper.py
+++ b/scipy/fftpack/helper.py
@@ -41,7 +41,7 @@ def rfftfreq(n, d=1.0):
     array([ 0.  ,  1.25,  1.25,  2.5 ,  2.5 ,  3.75,  3.75,  5.  ])
 
     """
-    if not isinstance(n, int) or n < 0:
+    if n != int(n) or n < 0:
         raise ValueError("n = %s is not valid. "
                          "n must be a nonnegative integer." % n)
 

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -3360,7 +3360,7 @@ def decimate(x, q, n=None, ftype='iir', axis=-1, zero_phase=True):
 
     Parameters
     ----------
-    x : ndarray
+    x : array_like
         The signal to be downsampled, as an N-dimensional array.
     q : int
         The downsampling factor. For downsampling factors higher than 13, it is
@@ -3397,6 +3397,8 @@ def decimate(x, q, n=None, ftype='iir', axis=-1, zero_phase=True):
     The possibility to use instances of ``dlti`` as ``ftype`` was added in
     0.18.0.
     """
+
+    x = asarray(x)
 
     if q != int(q):
         raise ValueError("q must be an integer")

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -3,7 +3,7 @@
 
 from __future__ import division, print_function, absolute_import
 
-import warnings
+import operator
 import threading
 import sys
 import timeit
@@ -3399,26 +3399,18 @@ def decimate(x, q, n=None, ftype='iir', axis=-1, zero_phase=True):
     """
 
     x = asarray(x)
+    q = operator.index(q)
 
-    if q != int(q):
-        raise ValueError("q must be an integer")
-
-    if n is not None and n != int(n):
-        raise ValueError("n must be an integer")
-
-    q = int(q)
+    if n is not None:
+        n = operator.index(n)
 
     if ftype == 'fir':
         if n is None:
             n = 30
-        else:
-            n = int(n)
         system = dlti(firwin(n+1, 1. / q, window='hamming'), 1.)
     elif ftype == 'iir':
         if n is None:
             n = 8
-        else:
-            n = int(n)
         system = dlti(*cheby1(n, 0.05, 0.8 / q))
     elif isinstance(ftype, dlti):
         system = ftype._as_tf()  # Avoids copying if already in TF form

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2313,6 +2313,10 @@ def resample_poly(x, up, down, axis=0, window=('kaiser', 5.0)):
     >>> plt.show()
     """
     x = asarray(x)
+    if up != int(up):
+        raise ValueError("up must be an integer")
+    if down != int(down):
+        raise ValueError("down must be an integer")
     up = int(up)
     down = int(down)
     if up < 1 or down < 1:
@@ -3394,19 +3398,25 @@ def decimate(x, q, n=None, ftype='iir', axis=-1, zero_phase=True):
     0.18.0.
     """
 
-    if not isinstance(q, int):
-        raise TypeError("q must be an integer")
+    if q != int(q):
+        raise ValueError("q must be an integer")
 
-    if n is not None and not isinstance(n, int):
-        raise TypeError("n must be an integer")
+    if n is not None and n != int(n):
+        raise ValueError("n must be an integer")
+
+    q = int(q)
 
     if ftype == 'fir':
         if n is None:
             n = 30
+        else:
+            n = int(n)
         system = dlti(firwin(n+1, 1. / q, window='hamming'), 1.)
     elif ftype == 'iir':
         if n is None:
             n = 8
+        else:
+            n = int(n)
         system = dlti(*cheby1(n, 0.05, 0.8 / q))
     elif isinstance(ftype, dlti):
         system = ftype._as_tf()  # Avoids copying if already in TF form

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1673,8 +1673,8 @@ def test_filtfilt_gust():
 class TestDecimate(object):
     def test_bad_args(self):
         x = np.arange(12)
-        assert_raises(ValueError, signal.decimate, x, q=0.5, n=1)
-        assert_raises(ValueError, signal.decimate, x, q=2, n=0.5)
+        assert_raises(TypeError, signal.decimate, x, q=0.5, n=1)
+        assert_raises(TypeError, signal.decimate, x, q=2, n=0.5)
 
     def test_basic_IIR(self):
         x = np.arange(12)

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1673,8 +1673,8 @@ def test_filtfilt_gust():
 class TestDecimate(object):
     def test_bad_args(self):
         x = np.arange(12)
-        assert_raises(TypeError, signal.decimate, x, q=0.5, n=1)
-        assert_raises(TypeError, signal.decimate, x, q=2, n=0.5)
+        assert_raises(ValueError, signal.decimate, x, q=0.5, n=1)
+        assert_raises(ValueError, signal.decimate, x, q=2, n=0.5)
 
     def test_basic_IIR(self):
         x = np.arange(12)

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -39,6 +39,14 @@ __all__ = ['ai_zeros', 'assoc_laguerre', 'bei_zeros', 'beip_zeros',
            'yn_zeros', 'ynp_zeros', 'yv', 'yvp', 'zeta']
 
 
+def _nonneg_int_or_fail(n, var_name):
+    int_n = int(n)
+    if n != int_n or n < 0:
+        raise ValueError(var_name + " must be a non-negative integer.")
+    else:
+        return int_n
+
+
 def diric(x, n):
     """Periodic sinc function, also called the Dirichlet function.
 
@@ -443,8 +451,7 @@ def jvp(v, z, n=1):
            http://dlmf.nist.gov/10.6.E7
 
     """
-    if not isinstance(n, int) or (n < 0):
-        raise ValueError("n must be a non-negative integer.")
+    n = _nonneg_int_or_fail(n, 'n')
     if n == 0:
         return jv(v, z)
     else:
@@ -476,8 +483,7 @@ def yvp(v, z, n=1):
            http://dlmf.nist.gov/10.6.E7
 
     """
-    if not isinstance(n, int) or (n < 0):
-        raise ValueError("n must be a non-negative integer.")
+    n = _nonneg_int_or_fail(n, 'n')
     if n == 0:
         return yv(v, z)
     else:
@@ -530,8 +536,7 @@ def kvp(v, z, n=1):
            http://dlmf.nist.gov/10.29.E5
 
     """
-    if not isinstance(n, int) or (n < 0):
-        raise ValueError("n must be a non-negative integer.")
+    n = _nonneg_int_or_fail(n, 'n')
     if n == 0:
         return kv(v, z)
     else:
@@ -564,8 +569,7 @@ def ivp(v, z, n=1):
            http://dlmf.nist.gov/10.29.E5
 
     """
-    if not isinstance(n, int) or (n < 0):
-        raise ValueError("n must be a non-negative integer.")
+    n = _nonneg_int_or_fail(n, 'n')
     if n == 0:
         return iv(v, z)
     else:
@@ -597,8 +601,7 @@ def h1vp(v, z, n=1):
            http://dlmf.nist.gov/10.6.E7
 
     """
-    if not isinstance(n, int) or (n < 0):
-        raise ValueError("n must be a non-negative integer.")
+    n = _nonneg_int_or_fail(n, 'n')
     if n == 0:
         return hankel1(v, z)
     else:
@@ -681,8 +684,7 @@ def riccati_jn(n, x):
     """
     if not (isscalar(n) and isscalar(x)):
         raise ValueError("arguments must be scalars.")
-    if (n != floor(n)) or (n < 0):
-        raise ValueError("n must be a non-negative integer.")
+    n = _nonneg_int_or_fail(n, 'n')
     if (n == 0):
         n1 = 1
     else:
@@ -734,8 +736,7 @@ def riccati_yn(n, x):
     """
     if not (isscalar(n) and isscalar(x)):
         raise ValueError("arguments must be scalars.")
-    if (n != floor(n)) or (n < 0):
-        raise ValueError("n must be a non-negative integer.")
+    n = _nonneg_int_or_fail(n, 'n')
     if (n == 0):
         n1 = 1
     else:
@@ -1248,8 +1249,7 @@ def lpn(n, z):
     """
     if not (isscalar(n) and isscalar(z)):
         raise ValueError("arguments must be scalars.")
-    if (n != floor(n)) or (n < 0):
-        raise ValueError("n must be a non-negative integer.")
+    n = _nonneg_int_or_fail(n, 'n')
     if (n < 1):
         n1 = 1
     else:
@@ -1276,8 +1276,7 @@ def lqn(n, z):
     """
     if not (isscalar(n) and isscalar(z)):
         raise ValueError("arguments must be scalars.")
-    if (n != floor(n)) or (n < 0):
-        raise ValueError("n must be a non-negative integer.")
+    n = _nonneg_int_or_fail(n, 'n')
     if (n < 1):
         n1 = 1
     else:

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -4,8 +4,7 @@
 
 from __future__ import division, print_function, absolute_import
 
-import warnings
-
+import operator
 import numpy as np
 import math
 from scipy._lib.six import xrange
@@ -39,12 +38,20 @@ __all__ = ['ai_zeros', 'assoc_laguerre', 'bei_zeros', 'beip_zeros',
            'yn_zeros', 'ynp_zeros', 'yv', 'yvp', 'zeta']
 
 
-def _nonneg_int_or_fail(n, var_name):
-    int_n = int(n)
-    if n != int_n or n < 0:
-        raise ValueError(var_name + " must be a non-negative integer.")
-    else:
-        return int_n
+def _nonneg_int_or_fail(n, var_name, strict=True):
+    try:
+        if strict:
+            # Raises an exception if float
+            n = operator.index(n)
+        elif n == floor(n):
+            n = int(n)
+        else:
+            raise ValueError()
+        if n < 0:
+            raise ValueError()
+    except (ValueError, TypeError) as err:
+        raise err.__class__("{} must be a non-negative integer".format(var_name))
+    return n
 
 
 def diric(x, n):
@@ -633,8 +640,7 @@ def h2vp(v, z, n=1):
            http://dlmf.nist.gov/10.6.E7
 
     """
-    if not isinstance(n, int) or (n < 0):
-        raise ValueError("n must be a non-negative integer.")
+    n = _nonneg_int_or_fail(n, 'n')
     if n == 0:
         return hankel2(v, z)
     else:
@@ -684,7 +690,7 @@ def riccati_jn(n, x):
     """
     if not (isscalar(n) and isscalar(x)):
         raise ValueError("arguments must be scalars.")
-    n = _nonneg_int_or_fail(n, 'n')
+    n = _nonneg_int_or_fail(n, 'n', strict=False)
     if (n == 0):
         n1 = 1
     else:
@@ -736,7 +742,7 @@ def riccati_yn(n, x):
     """
     if not (isscalar(n) and isscalar(x)):
         raise ValueError("arguments must be scalars.")
-    n = _nonneg_int_or_fail(n, 'n')
+    n = _nonneg_int_or_fail(n, 'n', strict=False)
     if (n == 0):
         n1 = 1
     else:
@@ -1249,7 +1255,7 @@ def lpn(n, z):
     """
     if not (isscalar(n) and isscalar(z)):
         raise ValueError("arguments must be scalars.")
-    n = _nonneg_int_or_fail(n, 'n')
+    n = _nonneg_int_or_fail(n, 'n', strict=False)
     if (n < 1):
         n1 = 1
     else:
@@ -1276,7 +1282,7 @@ def lqn(n, z):
     """
     if not (isscalar(n) and isscalar(z)):
         raise ValueError("arguments must be scalars.")
-    n = _nonneg_int_or_fail(n, 'n')
+    n = _nonneg_int_or_fail(n, 'n', strict=False)
     if (n < 1):
         n1 = 1
     else:


### PR DESCRIPTION
This is a follow-up to gh-7351 taking the operator.index approach.

Afaik this is backward compatible, apart from the checks added in resample_poly. operator.index accepts anything that can be safely cast to a Python integer scalar. This includes stuff like numpy integers, 0d numpy arrays etc. --- but not floating point inputs which is intentional.

- Replace `isinstance(n, int)` checks by `n = operator.index`, making them more lenient.
- Factor out `floor(n) != n` to a helper function in scipy.special.
- Add integer-valuedness check to resample_poly (more of a bugfix, doesn't require deprecation cycle imho)