### PR TITLE
fix `ma.rray` to `ma.array` in func `median_cihs`

### DIFF
--- a/scipy/stats/mstats_extras.py
+++ b/scipy/stats/mstats_extras.py
@@ -333,7 +333,7 @@ def median_cihs(data, alpha=0.05, axis=None):
         lims = (lambd*data[k] + (1-lambd)*data[k-1],
                 lambd*data[n-k-1] + (1-lambd)*data[n-k])
         return lims
-    data = ma.rray(data, copy=False)
+    data = ma.array(data, copy=False)
     # Computes quantiles along axis (or globally)
     if (axis is None):
         result = _cihs_1D(data.compressed(), alpha)

--- a/scipy/stats/mstats_extras.py
+++ b/scipy/stats/mstats_extras.py
@@ -336,7 +336,7 @@ def median_cihs(data, alpha=0.05, axis=None):
     data = ma.array(data, copy=False)
     # Computes quantiles along axis (or globally)
     if (axis is None):
-        result = _cihs_1D(data.compressed(), alpha)
+        result = _cihs_1D(data, alpha)
     else:
         if data.ndim > 2:
             raise ValueError("Array 'data' must be at most two dimensional, "


### PR DESCRIPTION
`ma.rray` should be a typo? It seems the tests haven't cover it?