### PR TITLE
BUG: integrate: fix value error in ode warnings

### DIFF
--- a/scipy/integrate/_ode.py
+++ b/scipy/integrate/_ode.py
@@ -922,7 +922,7 @@ class vode(IntegratorBase):
         y1, t, istate = self.runner(*args)
         self.istate = istate
         if istate < 0:
-            unexpected_istate_msg = 'Unexpected istate={:s}'.format(istate)
+            unexpected_istate_msg = 'Unexpected istate={:d}'.format(istate)
             warnings.warn('{:s}: {:s}'.format(self.__class__.__name__,
                           self.messages.get(istate, unexpected_istate_msg)))
             self.success = 0
@@ -1090,7 +1090,7 @@ class dopri5(IntegratorBase):
                                           tuple(self.call_args) + (f_params,)))
         self.istate = istate
         if istate < 0:
-            unexpected_istate_msg = 'Unexpected istate={:s}'.format(istate)
+            unexpected_istate_msg = 'Unexpected istate={:d}'.format(istate)
             warnings.warn('{:s}: {:s}'.format(self.__class__.__name__,
                           self.messages.get(istate, unexpected_istate_msg)))
             self.success = 0
@@ -1261,7 +1261,7 @@ class lsoda(IntegratorBase):
         y1, t, istate = self.runner(*args)
         self.istate = istate
         if istate < 0:
-            unexpected_istate_msg = 'Unexpected istate={:s}'.format(istate)
+            unexpected_istate_msg = 'Unexpected istate={:d}'.format(istate)
             warnings.warn('{:s}: {:s}'.format(self.__class__.__name__,
                           self.messages.get(istate, unexpected_istate_msg)))
             self.success = 0

--- a/scipy/integrate/tests/test_integrate.py
+++ b/scipy/integrate/tests/test_integrate.py
@@ -8,6 +8,7 @@ import numpy as np
 from numpy import (arange, zeros, array, dot, sqrt, cos, sin, eye, pi, exp,
                    allclose)
 
+from scipy._lib._numpy_compat import _assert_warns
 from scipy._lib.six import xrange
 
 from numpy.testing import (
@@ -608,6 +609,14 @@ class ODECheckParameterUse(object):
         if self.solver_uses_jac:
             solver.set_jac_params(omega)
         self._check_solver(solver)
+
+    def test_warns_on_failure(self):
+        # Set nsteps small to ensure failure
+        solver = self._get_solver(f, jac)
+        solver.set_integrator(self.solver_name, nsteps=1)
+        ic = [1.0, 0.0]
+        solver.set_initial_value(ic, 0.0)
+        _assert_warns(UserWarning, solver.integrate, pi)
 
 
 class TestDOPRI5CheckParameterUse(ODECheckParameterUse):


### PR DESCRIPTION
Formatting from #7627 led to value errors in case of failure:
```
unexpected_istate_msg = 'Unexpected istate={:s}'.format(istate)
ValueError: Unknown format code 's' for object of type 'int'
```
This fixes the format string and adds a test covering that path.