### PR TITLE
BLD: integrate: avoid symbol clash between lsoda and vode

### DIFF
--- a/scipy/integrate/setup.py
+++ b/scipy/integrate/setup.py
@@ -18,8 +18,14 @@ def configuration(parent_package='',top_path=None):
     lapack_libs = lapack_opt.pop('libraries', [])
 
     mach_src = [join('mach','*.f')]
-    quadpack_src = [join('quadpack','*.f')]
-    odepack_src = [join('odepack','*.f')]
+    quadpack_src = [join('quadpack', '*.f')]
+    lsoda_src = [join('odepack', fn) for fn in [
+        'blkdta000.f', 'bnorm.f', 'cfode.f',
+        'ewset.f', 'fnorm.f', 'intdy.f',
+        'lsoda.f', 'prja.f', 'solsy.f', 'srcma.f',
+        'stoda.f', 'vmnorm.f', 'xerrwv.f', 'xsetf.f',
+        'xsetun.f']]
+    vode_src = [join('odepack', 'vode.f'), join('odepack', 'zvode.f')]
     dop_src = [join('dop','*.f')]
     quadpack_test_src = [join('tests','_test_multivariate.c')]
     odeint_banded_test_src = [join('tests', 'banded5x5.f')]
@@ -27,7 +33,8 @@ def configuration(parent_package='',top_path=None):
     config.add_library('mach', sources=mach_src,
                        config_fc={'noopt':(__file__,1)})
     config.add_library('quadpack', sources=quadpack_src)
-    config.add_library('odepack', sources=odepack_src)
+    config.add_library('lsoda', sources=lsoda_src)
+    config.add_library('vode', sources=vode_src)
     config.add_library('dop', sources=dop_src)
 
     # Extensions
@@ -39,37 +46,33 @@ def configuration(parent_package='',top_path=None):
 
     config.add_extension('_quadpack',
                          sources=['_quadpackmodule.c'],
-                         libraries=(['quadpack', 'mach'] + lapack_libs),
+                         libraries=['quadpack', 'mach'] + lapack_libs,
                          depends=(['__quadpack.h']
                                   + quadpack_src + mach_src),
                          include_dirs=include_dirs,
                          **lapack_opt)
 
-    # odepack
-    odepack_libs = ['odepack','mach'] + lapack_libs
-
+    # odepack/lsoda-odeint
     odepack_opts = lapack_opt.copy()
     odepack_opts.update(numpy_nodepr_api)
     config.add_extension('_odepack',
                          sources=['_odepackmodule.c'],
-                         libraries=odepack_libs,
-                         depends=(odepack_src + mach_src),
+                         libraries=['lsoda', 'mach'] + lapack_libs,
+                         depends=(lsoda_src + mach_src),
                          **odepack_opts)
 
     # vode
     config.add_extension('vode',
                          sources=['vode.pyf'],
-                         libraries=odepack_libs,
-                         depends=(odepack_src
-                                  + mach_src),
+                         libraries=['vode'] + lapack_libs,
+                         depends=vode_src,
                          **lapack_opt)
 
     # lsoda
     config.add_extension('lsoda',
                          sources=['lsoda.pyf'],
-                         libraries=odepack_libs,
-                         depends=(odepack_src
-                                  + mach_src),
+                         libraries=['lsoda', 'mach'] + lapack_libs,
+                         depends=(lsoda_src + mach_src),
                          **lapack_opt)
 
     # dop
@@ -84,8 +87,8 @@ def configuration(parent_package='',top_path=None):
     # Fortran+f2py extension module for testing odeint.
     config.add_extension('_test_odeint_banded',
                          sources=odeint_banded_test_src,
-                         libraries=odepack_libs,
-                         depends=(odepack_src + mach_src),
+                         libraries=['lsoda', 'mach'] + lapack_libs,
+                         depends=(lsoda_src + mach_src),
                          **lapack_opt)
 
     config.add_subpackage('_ivp')


### PR DESCRIPTION
Split lsoda and vode to different libraries, since the symbols "xsetf"
and "xsetun" clash. Doesn't matter on Linux but may matter on other
platforms.

Should fix the issue in the appveyor build.