### PR TITLE
TST: _lib: make test_parallel_threads to not fail falsely

### DIFF
--- a/scipy/_lib/tests/test__threadsafety.py
+++ b/scipy/_lib/tests/test__threadsafety.py
@@ -2,21 +2,34 @@ from __future__ import division, print_function, absolute_import
 
 import threading
 import time
+import traceback
 
-from numpy.testing import assert_equal, assert_raises
+from numpy.testing import assert_raises, assert_
 
 from scipy._lib._threadsafety import ReentrancyLock, non_reentrant, ReentrancyError
 
 
 def test_parallel_threads():
-    results = []
+    # Check that ReentrancyLock serializes work in parallel threads.
+    #
+    # The test is not fully deterministic, and may succeed falsely if
+    # the timings go wrong.
 
     lock = ReentrancyLock("failure")
 
+    failflag = [False]
+    exceptions_raised = []
+
     def worker(k):
-        with lock:
-            time.sleep(0.01*(3 - k))
-            results.append(k)
+        try:
+            with lock:
+                assert_(not failflag[0])
+                failflag[0] = True
+                time.sleep(0.1 * k)
+                assert_(failflag[0])
+                failflag[0] = False
+        except:
+            exceptions_raised.append(traceback.format_exc(2))
 
     threads = [threading.Thread(target=lambda k=k: worker(k))
                for k in range(3)]
@@ -25,10 +38,13 @@ def test_parallel_threads():
     for t in threads:
         t.join()
 
-    assert_equal(results, sorted(results))
+    exceptions_raised = "\n".join(exceptions_raised)
+    assert_(not exceptions_raised, exceptions_raised)
 
 
 def test_reentering():
+    # Check that ReentrancyLock prevents re-entering from the same thread.
+
     @non_reentrant()
     def func(x):
         return func(x)


### PR DESCRIPTION
Make test_parallel_threads to not fail falsely.
The revised version may succeed falsely if the scheduler doesn't time
the threads as expected (which is usually unlikely). However, the test
can no longer fail spuriously.

Fixes gh-7710