### PR TITLE
TST: special: fix time_limited decorator to work on non-POSIX

### DIFF
--- a/scipy/special/_mptestutils.py
+++ b/scipy/special/_mptestutils.py
@@ -334,7 +334,7 @@ def time_limited(timeout=0.5, return_val=np.nan, use_sigalrm=True):
                 def trace(frame, event, arg):
                     if time.time() - start_time > timeout:
                         raise TimeoutError()
-                    return None  # turn off tracing except at function calls
+                    return trace
                 sys.settrace(trace)
                 try:
                     return func(*a, **kw)


### PR DESCRIPTION
The settrace approach needs to trace all lines, in order to be able
to break out from tight loops inside mpmath.

Only affects non-posix platforms.