### PR TITLE
MAINT: fix deprecated use of numpy.issubdtype

### DIFF
--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -193,7 +193,7 @@ class TestLogM(object):
             w = scipy.linalg.eigvals(X)
             assert_(1e-2 < np.absolute(w.imag).sum())
             Y, info = logm(X, disp=False)
-            assert_(np.issubdtype(Y.dtype, dt))
+            assert_(np.issubdtype(Y.dtype, np.inexact))
             assert_allclose(expm(Y), X)
 
     def test_real_mixed_sign_spectrum(self):
@@ -205,7 +205,7 @@ class TestLogM(object):
             for dt in float, complex:
                 A = np.array(M, dtype=dt)
                 A_logm, info = logm(A, disp=False)
-                assert_(np.issubdtype(A_logm.dtype, complex))
+                assert_(np.issubdtype(A_logm.dtype, np.complexfloating))
 
     def test_exactly_singular(self):
         A = np.array([[0, 0], [1j, 1j]])

--- a/scipy/misc/pilutil.py
+++ b/scipy/misc/pilutil.py
@@ -495,10 +495,10 @@ def imresize(arr, size, interp='bilinear', mode=None):
     """
     im = toimage(arr, mode=mode)
     ts = type(size)
-    if issubdtype(ts, int):
+    if issubdtype(ts, numpy.signedinteger):
         percent = size / 100.0
         size = tuple((array(im.size)*percent).astype(int))
-    elif issubdtype(type(size), float):
+    elif issubdtype(type(size), numpy.floating):
         size = tuple((array(im.size)*size).astype(int))
     else:
         size = (size[1], size[0])

--- a/scipy/ndimage/measurements.py
+++ b/scipy/ndimage/measurements.py
@@ -428,7 +428,7 @@ def labeled_comprehension(input, labels, index, func, out_dtype, default, pass_p
 def _safely_castable_to_int(dt):
     """Test whether the numpy data type `dt` can be safely cast to an int."""
     int_size = np.dtype(int).itemsize
-    safe = ((np.issubdtype(dt, int) and dt.itemsize <= int_size) or
+    safe = ((np.issubdtype(dt, np.signedinteger) and dt.itemsize <= int_size) or
             (np.issubdtype(dt, np.unsignedinteger) and dt.itemsize < int_size))
     return safe
 

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -372,8 +372,8 @@ def fftconvolve(in1, in2, mode="full"):
 
     s1 = array(in1.shape)
     s2 = array(in2.shape)
-    complex_result = (np.issubdtype(in1.dtype, complex) or
-                      np.issubdtype(in2.dtype, complex))
+    complex_result = (np.issubdtype(in1.dtype, np.complexfloating) or
+                      np.issubdtype(in2.dtype, np.complexfloating))
     shape = s1 + s2 - 1
 
     # Check that input sizes are compatible with 'valid' mode

--- a/scipy/signal/tests/test_waveforms.py
+++ b/scipy/signal/tests/test_waveforms.py
@@ -344,10 +344,10 @@ class TestUnitImpulse(object):
 
     def test_dtype(self):
         imp = waveforms.unit_impulse(7)
-        assert_(np.issubdtype(imp.dtype, np.float))
+        assert_(np.issubdtype(imp.dtype, np.floating))
 
         imp = waveforms.unit_impulse(5, 3, dtype=int)
         assert_(np.issubdtype(imp.dtype, np.integer))
 
         imp = waveforms.unit_impulse((5, 2), (3, 1), dtype=complex)
-        assert_(np.issubdtype(imp.dtype, np.complex))
+        assert_(np.issubdtype(imp.dtype, np.complexfloating))

--- a/scipy/sparse/csgraph/_laplacian.py
+++ b/scipy/sparse/csgraph/_laplacian.py
@@ -69,7 +69,7 @@ def laplacian(csgraph, normed=False, return_diag=False, use_out_degree=False):
     if csgraph.ndim != 2 or csgraph.shape[0] != csgraph.shape[1]:
         raise ValueError('csgraph must be a square matrix or array')
 
-    if normed and (np.issubdtype(csgraph.dtype, int)
+    if normed and (np.issubdtype(csgraph.dtype, np.signedinteger)
                    or np.issubdtype(csgraph.dtype, np.uint)):
         csgraph = csgraph.astype(float)
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -3543,7 +3543,7 @@ class TestCSR(sparse_test_class()):
         data = [1, 2, 3, 4]
         csr = csr_matrix((data, indices, indptr))
         assert_array_equal(csr.shape, (3,6))
-        assert_(np.issubdtype(csr.dtype, int))
+        assert_(np.issubdtype(csr.dtype, np.signedinteger))
 
     def test_sort_indices(self):
         data = arange(5)
@@ -3745,7 +3745,7 @@ class TestCSC(sparse_test_class()):
         data = [1, 2, 3, 4]
         csc = csc_matrix((data, indices, indptr))
         assert_array_equal(csc.shape,(6,3))
-        assert_(np.issubdtype(csc.dtype, int))
+        assert_(np.issubdtype(csc.dtype, np.signedinteger))
 
     def test_eliminate_zeros(self):
         data = array([1, 0, 0, 0, 2, 0, 3, 0])

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -184,7 +184,7 @@ class test_vectorization:
     def test_single_query(self):
         d, i = self.kdtree.query(np.array([0,0,0]))
         assert_(isinstance(d,float))
-        assert_(np.issubdtype(i, int))
+        assert_(np.issubdtype(i, np.signedinteger))
 
     def test_vectorized_query(self):
         d, i = self.kdtree.query(np.zeros((2,4,3)))


### PR DESCRIPTION
Numpy f307cec3 requires the following changes to not emit warnings:

np.issubdtype(X, int) -> np.issubdtype(X, np.signedinteger)
np.issubdtype(X, float) -> np.issubdtype(X, np.floating)
np.issubdtype(X, complex) -> np.issubdtype(X, np.complexfloating)

One case in test_matfuncs.py also had np.inexact on the rhs.

This fixes current travis failures.