### PR TITLE
MAINT: mstats.winsorize inclusion bug fix

### DIFF
--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -1818,13 +1818,13 @@ def winsorize(a, limits=None, inclusive=(True, True), inplace=False,
             if low_include:
                 lowidx = int(low_limit * n)
             else:
-                lowidx = np.round(low_limit * n)
+                lowidx = np.round(low_limit * n).astype(int)
             a[idx[:lowidx]] = a[idx[lowidx]]
         if up_limit is not None:
             if up_include:
                 upidx = n - int(n * up_limit)
             else:
-                upidx = n - np.round(n * up_limit)
+                upidx = n - np.round(n * up_limit).astype(int)
             a[idx[upidx:]] = a[idx[upidx - 1]]
         return a
 

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -342,6 +342,9 @@ class TestTrimming(object):
                          296,299,306,376,428,515,666,1310,2611])
         assert_almost_equal(mstats.winsorize(data,(0.2,0.2)).var(ddof=1),
                             21551.4, 1)
+        assert_almost_equal(
+            mstats.winsorize(data, (0.2,0.2),(False,False)).var(ddof=1),
+            11887.3, 1)
         data[5] = masked
         winsorized = mstats.winsorize(data)
         assert_equal(winsorized.mask, data.mask)


### PR DESCRIPTION
An attempt to fix the bug referenced in issue #7656 

np.round returns a float, which numpy will not allow as an index to slice an array. The fix was to cast it as an int. 

The corresponding test was added because there's no test of the inclusive argument.

That said, the way function works doesn't appear to be consistent with the documentation. The documentation says that the number of data points being masked should be rounded in the True case and truncated in the False case, i.e. the number of data points being masked in the False case should always be less than or equal to the number of data points masked in the True case. As we can see in the test case just added, the number of data points being masked in the False case actually increases (since the variance decreases) compared to the True case (the test above which uses the default True argument). I was unsure whether the documentation or the actual function was correct.