### PR TITLE
BUG: special/cdflib: deal with nan and nonfinite inputs

### DIFF
--- a/scipy/special/cdf_wrappers.c
+++ b/scipy/special/cdf_wrappers.c
@@ -1,6 +1,10 @@
-/* This file is a collection (more can be added) of wrappers around some
- *  CDF Fortran algorithms, so that they can be called from
- *  cephesmodule.so
+/*
+ * This file is a collection (more can be added) of wrappers around some
+ * CDFLIB Fortran algorithms.
+ */
+
+/*
+ * Notice q and p are used in reverse from their meanings in distributions.py
  */
 
 #include "cdf_wrappers.h"
@@ -19,67 +23,101 @@
 #endif
 #endif
 
-/* This must be linked with fortran
+/*
+ * Call macros for different numbers of distribution parameters.
  */
 
-/* Notice q and p are used in reverse from their meanings in distributions.py
+#define CDFLIB_CALL2(func, name, a, b, result, return_bound)            \
+    if (npy_isnan(p) || npy_isnan(q) || npy_isnan(a) || npy_isnan(b) || \
+        npy_isnan(bound)) {                                             \
+        return NPY_NAN;                                                 \
+    }                                                                   \
+    func(&which, &p, &q, &a, &b, &status, &bound);                      \
+    return get_result(name, status, bound, result, return_bound)
+
+#define CDFLIB_CALL3(func, name, a, b, c, result, return_bound)         \
+    if (npy_isnan(p) || npy_isnan(q) || npy_isnan(a) || npy_isnan(b) || \
+        npy_isnan(c) || npy_isnan(bound)) {                             \
+        return NPY_NAN;                                                 \
+    }                                                                   \
+    func(&which, &p, &q, &a, &b, &c, &status, &bound);                  \
+    return get_result(name, status, bound, result, return_bound)
+
+#define CDFLIB_CALL4(func, name, a, b, c, d, result, return_bound)      \
+    if (npy_isnan(p) || npy_isnan(q) || npy_isnan(a) || npy_isnan(b) || \
+        npy_isnan(c) || npy_isnan(d) || npy_isnan(bound)) {             \
+        return NPY_NAN;                                                 \
+    }                                                                   \
+    func(&which, &p, &q, &a, &b, &c, &d, &status, &bound);              \
+    return get_result(name, status, bound, result, return_bound)
+
+
+/* Return nan on status==1,2 */
+#define NO_RETURN_BOUND 0
+/* Return bound on status==1,2 */
+#define RETURN_BOUND 1
+
+
+/*
+ * Return status checking function
  */
 
-static void show_error(char *func, int status, int bound) {
-  /* show_error message */
-
+static double get_result(char *name, int status, double bound, double result, int return_bound) {
   if (status < 0) {
-      sf_error(func, SF_ERROR_ARG, "(Fortran) input parameter %d is out of range", (-status));
+      sf_error(name, SF_ERROR_ARG, "(Fortran) input parameter %d is out of range", (-status));
   }
   else {
     switch (status) {
+    case 0:
+      /* no error */
+      return result;
     case 1:
-      sf_error(func, SF_ERROR_OTHER, "Answer appears to be lower than lowest search bound (%d)", bound);
+      sf_error(name, SF_ERROR_OTHER, "Answer appears to be lower than lowest search bound (%g)", bound);
+      if (return_bound) {
+          return bound;
+      }
       break;
     case 2:
-      sf_error(func, SF_ERROR_OTHER, "Answer appears to be higher than highest search bound (%d)", bound);
+      sf_error(name, SF_ERROR_OTHER, "Answer appears to be higher than highest search bound (%g)", bound);
+      if (return_bound) {
+          return bound;
+      }
       break;
     case 3:
     case 4:
-      sf_error(func, SF_ERROR_OTHER, "Two parameters that should sum to 1.0 do not");
+      sf_error(name, SF_ERROR_OTHER, "Two parameters that should sum to 1.0 do not");
       break;
     case 10:
-      sf_error(func, SF_ERROR_OTHER, "Computational error");
+      sf_error(name, SF_ERROR_OTHER, "Computational error");
       break;
     default:
-      sf_error(func, SF_ERROR_OTHER, "Unknown error");
+      sf_error(name, SF_ERROR_OTHER, "Unknown error");
     }
   }
+  return NPY_NAN;
 }
+
 
 extern void F_FUNC(cdfbet,CDFBET)(int*,double*,double*,double*,double*,double*,double*,int*,double*);
 
 double cdfbet3_wrap(double p, double b, double x) {
   int which=3;
-  double q=1.0-p, y=1.0-x, a, bound;
-  int status;  
-  
-  F_FUNC(cdfbet,CDFBET)(&which, &p, &q, &x, &y, &a, &b, &status, &bound);
-  if (status) {
-    show_error("cdfbet3", status, bound);
-    if ((status < 0) || (status==3) || (status==4)) return (NPY_NAN);
-    if ((status == 1) || (status == 2)) return bound;
-  }
-  return a;
+  double q=1.0-p, y=1.0-x, a=0, bound=0;
+  int status=10;
+
+  CDFLIB_CALL4(F_FUNC(cdfbet,CDFBET), "btdtria",
+               x, y, a, b,
+               a, RETURN_BOUND);
 }
 
 double cdfbet4_wrap(double a, double p, double x) {
   int which=4;
-  double q=1.0-p, y=1.0-x, b, bound;
-  int status;  
-  
-  F_FUNC(cdfbet,CDFBET)(&which, &p, &q, &x, &y, &a, &b, &status, &bound);
-  if (status) {
-    show_error("cdfbet4", status, bound);
-    if ((status < 0) || (status==3) || (status==4)) return (NPY_NAN);
-    if ((status == 1) || (status == 2)) return bound;
-  }
-  return b;
+  double q=1.0-p, y=1.0-x, b=0, bound=0;
+  int status=10;
+
+  CDFLIB_CALL4(F_FUNC(cdfbet,CDFBET), "btdtrib",
+               x, y, a, b,
+               b, RETURN_BOUND);
 }
 
 
@@ -87,101 +125,74 @@ extern void F_FUNC(cdfbin,CDFBIN)(int*,double*,double*,double*,double*,double*,d
 
 double cdfbin2_wrap(double p, double xn, double pr) {
   int which=2;
-  double q=1.0-p, s, ompr=1.0-pr, bound;
-  int status;  
-  
-  F_FUNC(cdfbin,CDFBIN)(&which, &p, &q, &s, &xn, &pr, &ompr, &status, &bound);
-  if (status) {
-    show_error("cdfbin2", status, bound);
-    if ((status < 0) || (status==3) || (status==4)) return (NPY_NAN);
-    if ((status == 1) || (status == 2)) return bound;
-  }
-  return s;
+  double q=1.0-p, s=0, ompr=1.0-pr, bound=0;
+  int status=10;
+
+  CDFLIB_CALL4(F_FUNC(cdfbin,CDFBIN), "bdtrik",
+               s, xn, pr, ompr,
+               s, RETURN_BOUND);
 }
 
 double cdfbin3_wrap(double s, double p, double pr) {
   int which=3;
-  double q=1.0-p, xn, ompr=1.0-pr, bound;
-  int status;  
+  double q=1.0-p, xn=0, ompr=1.0-pr, bound=0;
+  int status=10;
 
-  F_FUNC(cdfbin,CDFBIN)(&which, &p, &q, &s, &xn, &pr, &ompr, &status, &bound); 
-  if (status) {
-    show_error("cdfbin3", status, bound);
-    if ((status < 0) || (status==3) || (status==4)) return (NPY_NAN);
-    if ((status == 1) || (status == 2)) return bound;
-  }
-  return xn;
+  CDFLIB_CALL4(F_FUNC(cdfbin,CDFBIN), "bdtrin",
+               s, xn, pr, ompr,
+               xn, RETURN_BOUND);
 }
 
 extern void F_FUNC(cdfchi,CDFCHI)(int*,double*,double*,double*,double*,int*,double*);
 double cdfchi3_wrap(double p, double x){
   int which=3;
-  double q=1.0-p, df, bound;
-  int status;  
+  double q=1.0-p, df=0, bound=0;
+  int status=10;
 
-  F_FUNC(cdfchi,CDFCHI)(&which, &p, &q, &x, &df, &status, &bound); 
-  if (status) {
-    show_error("cdfchi3", status, bound);
-    if ((status < 0) || (status==3) || (status==4)) return (NPY_NAN);
-    if ((status == 1) || (status == 2)) return bound;
-  }
-  return df;
+  CDFLIB_CALL2(F_FUNC(cdfchi,CDFCHI), "chdtriv",
+               x, df,
+               df, RETURN_BOUND);
 }
 
 extern void F_FUNC(cdfchn,CDFCHN)(int*,double*,double*,double*,double*,double*,int*,double*);
 double cdfchn1_wrap(double x, double df, double nc) {
   int which=1;
-  double q, p, bound;
-  int status;  
+  double q=0, p=0, bound=0;
+  int status=10;
 
-  F_FUNC(cdfchn,CDFCHN)(&which, &p, &q, &x, &df, &nc, &status, &bound); 
-  if (status) {
-    show_error("cdfchn1", status, bound);
-    if ((status < 0) || (status==3) || (status==4)) return (NPY_NAN);
-    if ((status == 1) || (status == 2)) return bound;
-  }
-  return p;
+  CDFLIB_CALL3(F_FUNC(cdfchn,CDFCHN), "chndtr",
+               x, df, nc,
+               p, RETURN_BOUND);
 }
 
 double cdfchn2_wrap(double p, double df, double nc) {
   int which=2;
-  double q=1.0-p, x, bound;
-  int status;  
+  double q=1.0-p, x=0, bound=0;
+  int status=10;
 
-  F_FUNC(cdfchn,CDFCHN)(&which, &p, &q, &x, &df, &nc, &status, &bound); 
-  if (status) {
-    show_error("cdfchn2", status, bound);
-    if ((status < 0) || (status==3) || (status==4)) return (NPY_NAN);
-  }
-  return x;
+  CDFLIB_CALL3(F_FUNC(cdfchn,CDFCHN), "chndtrix",
+               x, df, nc,
+               x, NO_RETURN_BOUND);
 }
 
 double cdfchn3_wrap(double x, double p, double nc) {
   int which=3;
-  double q=1.0-p, df, bound;
-  int status;  
+  double q=1.0-p, df=0, bound=0;
+  int status=10;
 
-  F_FUNC(cdfchn,CDFCHN)(&which, &p, &q, &x, &df, &nc, &status, &bound); 
-  if (status) {
-    show_error("cdfchn3", status, bound);
-    if ((status < 0) || (status==3) || (status==4)) return (NPY_NAN);
-    if ((status == 1) || (status == 2)) return bound;
-  }
-  return df;
+  CDFLIB_CALL3(F_FUNC(cdfchn,CDFCHN), "chndtridf",
+               x, df, nc,
+               df, RETURN_BOUND);
 }
 
 double cdfchn4_wrap(double x, double df, double p) {
   int which=4;
-  double q=1.0-p, nc, bound;
-  int status;  
+  double q=1.0-p, nc=0, bound=0;
+  int status=10;
 
-  F_FUNC(cdfchn,CDFCHN)(&which, &p, &q, &x, &df, &nc, &status, &bound); 
-  if (status) {
-    show_error("cdfchn", status, bound);
-    if ((status < 0) || (status==3) || (status==4)) return (NPY_NAN);
-    if ((status == 1) || (status == 2)) return bound;
-  }
-  return nc;
+  CDFLIB_CALL3(F_FUNC(cdfchn,CDFCHN), "chndtrinc",
+               x, df, nc,
+               nc, RETURN_BOUND);
 }
 
 extern void F_FUNC(cdff,CDFF)(int*,double*,double*,double*,double*,double*,int*,double*);
@@ -189,128 +200,96 @@ extern void F_FUNC(cdff,CDFF)(int*,double*,double*,double*,double*,double*,int*,
 double cdff1_wrap(double dfn, double dfd, double f) {
   int which=1;
   double q, p, bound;
-  int status;
+  int status=10;
 
-  F_FUNC(cdff,CDFF)(&which, &p, &q, &f, &dfn, &dfd, &status, &bound); 
-  if (status) {
-    show_error("cdff1", status, bound);
-    if ((status < 0) || (status==3) || (status==4)) return (NPY_NAN);
-  }
-  return p;
+  CDFLIB_CALL3(F_FUNC(cdff,CDFF), "fdtr",
+               f, dfn, dfd,
+               p, NO_RETURN_BOUND);
 }
 
 double cdff2_wrap(double dfn, double dfd, double p) {
   int which=2;
   double q=1.0-p, f, bound;
-  int status;
+  int status=10;
 
-  F_FUNC(cdff,CDFF)(&which, &p, &q, &f, &dfn, &dfd, &status, &bound); 
-  if (status) {
-    show_error("cdff2", status, bound);
-    if ((status < 0) || (status==3) || (status==4)) return (NPY_NAN);
-  }
-  return f;
+  CDFLIB_CALL3(F_FUNC(cdff,CDFF), "fdtri",
+               f, dfn, dfd,
+               f, NO_RETURN_BOUND);
 }
 */
 
 /* This seem to give some trouble.  No idea why... */
 double cdff3_wrap(double p, double dfd, double f) {
   int which=3;
-  double q=1.0-p, dfn, bound;
-  int status;
+  double q=1.0-p, dfn=0, bound=0;
+  int status=10;
 
-  F_FUNC(cdff,CDFF)(&which, &p, &q, &f, &dfn, &dfd, &status, &bound); 
-  if (status) {
-    show_error("cdff3", status, bound);
-    if ((status < 0) || (status==3) || (status==4)) return (NPY_NAN);
-    if ((status == 1) || (status == 2)) return bound;
-  }
-  return dfn;
+  CDFLIB_CALL3(F_FUNC(cdff,CDFF), "fdtridfn",
+               f, dfn, dfd,
+               dfn, RETURN_BOUND);
 }
 
 double cdff4_wrap(double dfn, double p, double f) {
   int which=4;
-  double q=1.0-p, dfd, bound;
-  int status;  
+  double q=1.0-p, dfd=0, bound=0;
+  int status=10;
 
-  F_FUNC(cdff,CDFF)(&which, &p, &q, &f, &dfn, &dfd, &status, &bound); 
-  if (status) {
-    show_error("cdff4", status, bound);
-    if ((status < 0) || (status==3) || (status==4)) return (NPY_NAN);
-    if ((status == 1) || (status == 2)) return bound;
-  }
-  return dfd;
+  CDFLIB_CALL3(F_FUNC(cdff,CDFF), "fdtridfd",
+               f, dfn, dfd,
+               dfd, RETURN_BOUND);
 }
 
 
 extern void F_FUNC(cdffnc,CDFFNC)(int*,double*,double*,double*,double*,double*,double*,int*,double*);
 double cdffnc1_wrap(double dfn, double dfd, double nc, double f) {
   int which=1;
-  double q, p, bound;
-  int status;
+  double q=0, p=0, bound=0;
+  int status=10;
 
-  F_FUNC(cdffnc,CDFFNC)(&which, &p, &q, &f, &dfn, &dfd, &nc, &status, &bound); 
-  if (status) {
-    show_error("cdffnc1", status, bound);
-    if ((status < 0) || (status==3) || (status==4)) return (NPY_NAN);
-  }
-  return p;
+  CDFLIB_CALL4(F_FUNC(cdffnc,CDFFNC), "ncfdtr",
+               f, dfn, dfd, nc,
+               p, NO_RETURN_BOUND);
 }
 
 double cdffnc2_wrap(double dfn, double dfd, double nc, double p) {
   int which=2;
-  double q=1.0-p, f, bound;
-  int status;
+  double q=1.0-p, f=0, bound=0;
+  int status=10;
 
-  F_FUNC(cdffnc,CDFFNC)(&which, &p, &q, &f, &dfn, &dfd, &nc, &status, &bound); 
-  if (status) {
-    show_error("cdffnc2", status, bound);
-    if ((status < 0) || (status==3) || (status==4)) return (NPY_NAN);
-    if ((status == 1) || (status == 2)) return bound;
-  }
-  return f;
+  CDFLIB_CALL4(F_FUNC(cdffnc,CDFFNC), "ncfdtri",
+               f, dfn, dfd, nc,
+               f, RETURN_BOUND);
 }
 
 
 double cdffnc3_wrap(double p, double dfd, double nc, double f) {
   int which=3;
-  double q=1.0-p, dfn, bound;
-  int status;
+  double q=1.0-p, dfn=0, bound=0;
+  int status=10;
 
-  F_FUNC(cdffnc,CDFFNC)(&which, &p, &q, &f, &dfn, &dfd, &nc, &status, &bound); 
-  if (status) {
-    show_error("cdffnc3", status, bound);
-    if ((status < 0) || (status==3) || (status==4)) return (NPY_NAN);
-    if ((status == 1) || (status == 2)) return bound;
-  }
-  return dfn;
+  CDFLIB_CALL4(F_FUNC(cdffnc,CDFFNC), "ncfdtridfn",
+               f, dfn, dfd, nc,
+               dfn, RETURN_BOUND);
 }
+
 double cdffnc4_wrap(double dfn, double p, double nc, double f) {
   int which=4;
-  double q=1.0-p, dfd, bound;
-  int status;
+  double q=1.0-p, dfd=0, bound=0;
+  int status=10;
 
-  F_FUNC(cdffnc,CDFFNC)(&which, &p, &q, &f, &dfn, &dfd, &nc, &status, &bound); 
-  if (status) {
-    show_error("cdffnc4", status, bound);
-    if ((status < 0) || (status==3) || (status==4)) return (NPY_NAN);
-    if ((status == 1) || (status == 2)) return bound;
-  }
-  return dfd;
+  CDFLIB_CALL4(F_FUNC(cdffnc,CDFFNC), "ncfdtridfd",
+               f, dfn, dfd, nc,
+               dfd, RETURN_BOUND);
 }
 
 double cdffnc5_wrap(double dfn, double dfd, double p, double f) {
   int which=5;
-  double q=1.0-p, nc, bound;
-  int status;
+  double q=1.0-p, nc=0, bound=0;
+  int status=10;
 
-  F_FUNC(cdffnc,CDFFNC)(&which, &p, &q, &f, &dfn, &dfd, &nc, &status, &bound); 
-  if (status) {
-    show_error("cdffnc5", status, bound);
-    if ((status < 0) || (status==3) || (status==4)) return (NPY_NAN);
-    if ((status == 1) || (status == 2)) return bound;
-  }
-  return nc;
+  CDFLIB_CALL4(F_FUNC(cdffnc,CDFFNC), "ncfdtrinc",
+               f, dfn, dfd, nc,
+               nc, RETURN_BOUND);
 }
 
 /* scl == a in gdtr
@@ -319,230 +298,165 @@ double cdffnc5_wrap(double dfn, double dfd, double p, double f) {
 extern void F_FUNC(cdfgam,CDFGAM)(int*,double*,double*,double*,double*,double*,int*,double*);
 double cdfgam1_wrap(double scl, double shp, double x) {
   int which=1;
-  double q, p, bound;
-  int status;
+  double q=0, p=0, bound=0;
+  int status=10;
 
-  F_FUNC(cdfgam,CDFGAM)(&which, &p, &q, &x, &shp, &scl, &status, &bound); 
-  if (status) {
-    show_error("cdfgam1", status, bound);
-    if ((status < 0) || (status==3) || (status==4)) return (NPY_NAN);
-  }
-  return p;
+  CDFLIB_CALL3(F_FUNC(cdfgam,CDFGAM), "gdtr",
+               x, shp, scl,
+               p, NO_RETURN_BOUND);
 }
 
 double cdfgam2_wrap(double scl, double shp, double p) {
   int which=2;
-  double q=1.0-p, x, bound;
-  int status;
+  double q=1.0-p, x=0, bound=0;
+  int status=10;
 
-  F_FUNC(cdfgam,CDFGAM)(&which, &p, &q, &x, &shp, &scl,  &status, &bound); 
-  if (status) {
-    show_error("cdfgam2", status, bound);
-    if ((status < 0) || (status==3) || (status==4)) return (NPY_NAN);
-    if ((status == 1) || (status == 2)) return bound;
-  }
-  return x;
+  CDFLIB_CALL3(F_FUNC(cdfgam,CDFGAM), "gdtrix",
+               x, shp, scl,
+               x, RETURN_BOUND);
 }
 
 double cdfgam3_wrap(double scl, double p, double x) {
   int which=3;
-  double q=1.0-p, shp, bound;
-  int status;
+  double q=1.0-p, shp=0, bound=0;
+  int status=10;
 
-  F_FUNC(cdfgam,CDFGAM)(&which, &p, &q, &x, &shp, &scl, &status, &bound); 
-  if (status) {
-    show_error("cdfgam3", status, bound);
-    if ((status < 0) || (status==3) || (status==4)) return (NPY_NAN);
-    if ((status == 1) || (status == 2)) return bound;
-  }
-  return shp;
+  CDFLIB_CALL3(F_FUNC(cdfgam,CDFGAM), "gdtrib",
+               x, shp, scl,
+               shp, RETURN_BOUND);
 }
 
 double cdfgam4_wrap(double p, double shp, double x) {
   int which=4;
-  double q=1.0-p, scl, bound;
-  int status;
+  double q=1.0-p, scl=0, bound=0;
+  int status=10;
 
-  F_FUNC(cdfgam,CDFGAM)(&which, &p, &q, &x, &shp, &scl, &status, &bound); 
-  if (status) {
-    show_error("cdfgam4", status, bound);
-    if ((status < 0) || (status==3) || (status==4)) return (NPY_NAN);
-    if ((status == 1) || (status == 2)) return bound;
-  }
-  return scl;
+  CDFLIB_CALL3(F_FUNC(cdfgam,CDFGAM), "gdtria",
+               x, shp, scl,
+               scl, RETURN_BOUND);
 }
 
 extern void F_FUNC(cdfnbn,CDFNBN)(int*,double*,double*,double*,double*,double*,double*,int*,double*);
 double cdfnbn2_wrap(double p, double xn, double pr) {
   int which=2;
-  double q=1.0-p, s, ompr=1.0-pr, bound;
-  int status;  
-  
-  F_FUNC(cdfnbn,CDFNBN)(&which, &p, &q, &s, &xn, &pr, &ompr, &status, &bound);
-  if (status) {
-    show_error("cdfnbn2", status, bound);
-    if ((status < 0) || (status==3) || (status==4)) return (NPY_NAN);
-    if ((status == 1) || (status == 2)) return bound;
-  }
-  return s;
+  double q=1.0-p, s=0, ompr=1.0-pr, bound=0;
+  int status=10;
+
+  CDFLIB_CALL4(F_FUNC(cdfnbn,CDFNBN), "nbdtrik",
+               s, xn, pr, ompr,
+               s, RETURN_BOUND);
 }
 
 double cdfnbn3_wrap(double s, double p, double pr) {
   int which=3;
-  double q=1.0-p, xn, ompr=1.0-pr, bound;
-  int status;  
+  double q=1.0-p, xn=0, ompr=1.0-pr, bound=0;
+  int status=10;
 
-  F_FUNC(cdfnbn,CDFNBN)(&which, &p, &q, &s, &xn, &pr, &ompr, &status, &bound);
-  if (status) {
-    show_error("cdfnbn3", status, bound);
-    if ((status < 0) || (status==3) || (status==4)) return (NPY_NAN);
-    if ((status == 1) || (status == 2)) return bound;
-  }
-  return xn;
+  CDFLIB_CALL4(F_FUNC(cdfnbn,CDFNBN), "nbdtrin",
+               s, xn, pr, ompr,
+               xn, RETURN_BOUND);
 }
 
 extern void F_FUNC(cdfnor,CDFNOR)(int*,double*,double*,double*,double*,double*,int*,double*);
 double cdfnor3_wrap(double p, double std, double x) {
   int which=3;
-  double q=1.0-p, mn, bound;
-  int status;  
+  double q=1.0-p, mn=0, bound=0;
+  int status=10;
 
-  F_FUNC(cdfnor,CDFNOR)(&which, &p, &q, &x, &mn, &std, &status, &bound); 
-  if (status) {
-    show_error("cdfnor3", status, bound);
-    if ((status < 0) || (status==3) || (status==4)) return (NPY_NAN);
-    if ((status == 1) || (status == 2)) return bound;
-  }
-  return mn;
+  CDFLIB_CALL3(F_FUNC(cdfnor,CDFNOR), "nrdtrimn",
+               x, mn, std,
+               mn, RETURN_BOUND);
 }
 
 double cdfnor4_wrap(double mn, double p, double x) {
   int which=4;
-  double q=1.0-p, std, bound;
-  int status;  
+  double q=1.0-p, std=0, bound=0;
+  int status=10;
 
-  F_FUNC(cdfnor,CDFNOR)(&which, &p, &q, &x, &mn, &std, &status, &bound); 
-  if (status) {
-    show_error("cdfnor4", status, bound);
-    if ((status < 0) || (status==3) || (status==4)) return (NPY_NAN);
-    if ((status == 1) || (status == 2)) return bound;
-  }
-  return std;
+  CDFLIB_CALL3(F_FUNC(cdfnor,CDFNOR), "nrdtrisd",
+               x, mn, std,
+               std, RETURN_BOUND);
 }
 
 extern void F_FUNC(cdfpoi,CDFPOI)(int*,double*,double*,double*,double*,int*,double*);
 double cdfpoi2_wrap(double p, double xlam){
   int which=2;
-  double q=1.0-p, s, bound;
-  int status;  
+  double q=1.0-p, s=0, bound=0;
+  int status=10;
 
-  F_FUNC(cdfpoi,CDFPOI)(&which, &p, &q, &s, &xlam, &status, &bound); 
-  if (status) {
-    show_error("cdfpoi2", status, bound);
-    if ((status < 0) || (status==3) || (status==4)) return (NPY_NAN);
-    if ((status == 1) || (status == 2)) return bound;
-  }
-  return s;
+  CDFLIB_CALL2(F_FUNC(cdfpoi,CDFPOI), "pdtrik",
+               s, xlam,
+               s, RETURN_BOUND);
 }
 
 extern void F_FUNC(cdft,CDFT)(int*,double*,double*,double*,double*,int*,double*);
 double cdft1_wrap(double df, double t){
   int which=1;
-  double q, p, bound;
-  int status;  
+  double q=0, p=0, bound=0;
+  int status=10;
 
-  F_FUNC(cdft,CDFT)(&which, &p, &q, &t, &df, &status, &bound); 
-  if (status) {
-    show_error("cdft1", status, bound);
-    if ((status < 0) || (status==3) || (status==4)) return (NPY_NAN);
-  }
-  return p;
+  CDFLIB_CALL2(F_FUNC(cdft,CDFT), "stdtr",
+               t, df,
+               p, NO_RETURN_BOUND);
 }
 
 double cdft2_wrap(double df, double p){
   int which=2;
-  double q=1.0-p, t, bound;
-  int status;  
+  double q=1.0-p, t=0, bound=0;
+  int status=10;
 
-  F_FUNC(cdft,CDFT)(&which, &p, &q, &t, &df, &status, &bound); 
-  if (status) {
-    show_error("cdft2", status, bound);
-    if ((status < 0) || (status==3) || (status==4)) return (NPY_NAN);
-    if ((status == 1) || (status == 2)) return bound;
-  }
-  return t;
+  CDFLIB_CALL2(F_FUNC(cdft,CDFT), "stdtrit",
+               t, df,
+               t, RETURN_BOUND);
 }
 
 double cdft3_wrap(double p, double t){
   int which=3;
-  double q=1.0-p, df, bound;
-  int status;  
+  double q=1.0-p, df=0, bound=0;
+  int status=10;
 
-  F_FUNC(cdft,CDFT)(&which, &p, &q, &t, &df, &status, &bound); 
-  if (status) {
-    show_error("cdft3", status, bound);
-    if ((status < 0) || (status==3) || (status==4)) return (NPY_NAN);
-    if ((status == 1) || (status == 2)) return bound;
-  }
-  return df;
+  CDFLIB_CALL2(F_FUNC(cdft,CDFT), "stdtridf",
+               t, df,
+               df, RETURN_BOUND);
 }
 
 extern void F_FUNC(cdftnc,CDFTNC)(int*,double*,double*,double*,double*,double*,int*,double*);
 double cdftnc1_wrap(double df, double nc, double t) {
   int which=1;
-  double q, p, bound;
-  int status;  
+  double q=0, p=0, bound=0;
+  int status=10;
 
-  F_FUNC(cdftnc,CDFTNC)(&which, &p, &q, &t, &df, &nc, &status, &bound); 
-  if (status) {
-    show_error("cdftnc1", status, bound);
-    if ((status < 0) || (status==3) || (status==4)) return (NPY_NAN);
-    if ((status == 1) || (status == 2)) return bound;
-  }
-  return p;
+  CDFLIB_CALL3(F_FUNC(cdftnc,CDFTNC), "nctdtr",
+               t, df, nc,
+               p, RETURN_BOUND);
 }
 
 double cdftnc2_wrap(double df, double nc, double p) {
   int which=2;
-  double q=1.0-p, t, bound;
-  int status;  
+  double q=1.0-p, t=0, bound=0;
+  int status=10;
 
-  F_FUNC(cdftnc,CDFTNC)(&which, &p, &q, &t, &df, &nc, &status, &bound); 
-  if (status) {
-    show_error("cdftnc2", status, bound);
-    if ((status < 0) || (status==3) || (status==4)) return (NPY_NAN);
-    if ((status == 1) || (status == 2)) return bound;
-  }
-  return t;
+  CDFLIB_CALL3(F_FUNC(cdftnc,CDFTNC), "nctdtrit",
+               t, df, nc,
+               t, RETURN_BOUND);
 }
 
 double cdftnc3_wrap(double p, double nc, double t) {
   int which=3;
-  double q=1.0-p, df, bound;
-  int status;  
+  double q=1.0-p, df=0, bound=0;
+  int status=10;
 
-  F_FUNC(cdftnc,CDFTNC)(&which, &p, &q, &t, &df, &nc, &status, &bound); 
-  if (status) {
-    show_error("cdftnc3", status, bound);
-    if ((status < 0) || (status==3) || (status==4)) return (NPY_NAN);
-    if ((status == 1) || (status == 2)) return bound;
-  }
-  return df;
+  CDFLIB_CALL3(F_FUNC(cdftnc,CDFTNC), "nctdtridf",
+               t, df, nc,
+               df, RETURN_BOUND);
 }
 
 double cdftnc4_wrap(double df, double p, double t) {
   int which=4;
-  double q=1.0-p, nc, bound;
-  int status;  
+  double q=1.0-p, nc=0, bound=0;
+  int status=10;
 
-  F_FUNC(cdftnc,CDFTNC)(&which, &p, &q, &t, &df, &nc, &status, &bound); 
-  if (status) {
-    show_error("cdftnc4", status, bound);
-    if ((status < 0) || (status==3) || (status==4)) return (NPY_NAN);
-    if ((status == 1) || (status == 2)) return bound;
-
-  }
-  return nc;
+  CDFLIB_CALL3(F_FUNC(cdftnc,CDFTNC), "nctdtrinc",
+               t, df, nc,
+               nc, RETURN_BOUND);
 }
-
-

--- a/scipy/special/cdflib/bfrac.f
+++ b/scipy/special/cdflib/bfrac.f
@@ -59,7 +59,7 @@ C
 C
       r0 = r
       r = anp1/bnp1
-      IF (abs(r-r0).LE.eps*r) GO TO 20
+      IF (.NOT.(abs(r-r0).GT.eps*r)) GO TO 20
 C
 C        RESCALE AN, BN, ANP1, AND BNP1
 C

--- a/scipy/special/cdflib/cdffnc.f
+++ b/scipy/special/cdflib/cdffnc.f
@@ -118,6 +118,7 @@ C     .. Scalar Arguments ..
 C     ..
 C     .. Local Scalars ..
       DOUBLE PRECISION ccum,cum,fx
+      INTEGER errflag
       LOGICAL qhi,qleft
 C     ..
 C     .. External Subroutines ..
@@ -172,7 +173,11 @@ C     ..
 
   140 CONTINUE
   150 IF ((1).EQ. (which)) THEN
-          CALL cumfnc(f,dfn,dfd,phonc,p,q)
+          CALL cumfnc(f,dfn,dfd,phonc,p,q,errflag)
+          IF (errflag.NE.0) THEN
+             status = 10
+             RETURN
+          ENDIF
           status = 0
 
       ELSE IF ((2).EQ. (which)) THEN
@@ -181,7 +186,11 @@ C     ..
           status = 0
           CALL dinvr(status,f,fx,qleft,qhi)
   160     IF (.NOT. (status.EQ.1)) GO TO 170
-          CALL cumfnc(f,dfn,dfd,phonc,cum,ccum)
+          CALL cumfnc(f,dfn,dfd,phonc,cum,ccum,errflag)
+          IF (errflag.NE.0) THEN
+             status = 10
+             RETURN
+          ENDIF
           fx = cum - p
           CALL dinvr(status,f,fx,qleft,qhi)
           GO TO 160
@@ -203,7 +212,11 @@ C     ..
           status = 0
           CALL dinvr(status,dfn,fx,qleft,qhi)
   210     IF (.NOT. (status.EQ.1)) GO TO 220
-          CALL cumfnc(f,dfn,dfd,phonc,cum,ccum)
+          CALL cumfnc(f,dfn,dfd,phonc,cum,ccum,errflag)
+          IF (errflag.NE.0) THEN
+             status = 10
+             RETURN
+          ENDIF
           fx = cum - p
           CALL dinvr(status,dfn,fx,qleft,qhi)
           GO TO 210
@@ -225,7 +238,11 @@ C     ..
           status = 0
           CALL dinvr(status,dfd,fx,qleft,qhi)
   260     IF (.NOT. (status.EQ.1)) GO TO 270
-          CALL cumfnc(f,dfn,dfd,phonc,cum,ccum)
+          CALL cumfnc(f,dfn,dfd,phonc,cum,ccum,errflag)
+          IF (errflag.NE.0) THEN
+             status = 10
+             RETURN
+          ENDIF
           fx = cum - p
           CALL dinvr(status,dfd,fx,qleft,qhi)
           GO TO 260
@@ -247,7 +264,11 @@ C     ..
           status = 0
           CALL dinvr(status,phonc,fx,qleft,qhi)
   310     IF (.NOT. (status.EQ.1)) GO TO 320
-          CALL cumfnc(f,dfn,dfd,phonc,cum,ccum)
+          CALL cumfnc(f,dfn,dfd,phonc,cum,ccum,errflag)
+          IF (errflag.NE.0) THEN
+             status = 10
+             RETURN
+          ENDIF
           fx = cum - p
           CALL dinvr(status,phonc,fx,qleft,qhi)
           GO TO 310

--- a/scipy/special/cdflib/cumchn.f
+++ b/scipy/special/cdflib/cumchn.f
@@ -80,7 +80,7 @@ C     .. Data statements ..
       DATA abstol/1.0D-300/
 C     ..
 C     .. Statement Function definitions ..
-      qsmall(xx) = sum .LT. abstol .OR. xx .LT. eps*sum
+      qsmall(xx) = .NOT. (sum .GE. abstol .AND. xx .GE. eps*sum)
       dg(i) = df + 2.0D0*dble(i)
 C     ..
 C

--- a/scipy/special/cdflib/cumfnc.f
+++ b/scipy/special/cdflib/cumfnc.f
@@ -1,4 +1,4 @@
-      SUBROUTINE cumfnc(f,dfn,dfd,pnonc,cum,ccum)
+      SUBROUTINE cumfnc(f,dfn,dfd,pnonc,cum,ccum,status)
 C**********************************************************************
 C
 C               F -NON- -C-ENTRAL F DISTRIBUTION
@@ -66,7 +66,7 @@ C     .. Local Scalars ..
       DOUBLE PRECISION dsum,dummy,prod,xx,yy
       DOUBLE PRECISION adn,aup,b,betdn,betup,centwt,dnterm,eps,sum,
      +                 upterm,xmult,xnonc,x,abstol
-      INTEGER i,icent,ierr
+      INTEGER i,icent,ierr,status
 C     ..
 C     .. External Functions ..
       DOUBLE PRECISION alngam
@@ -92,10 +92,11 @@ C     .. Data statements ..
       DATA abstol/1.0D-300/
 C     ..
 C     .. Statement Function definitions ..
-      qsmall(x) = sum .LT. abstol .OR. x .LT. eps*sum
+      qsmall(x) = .NOT. (sum .GE. abstol .AND. x .GE. eps*sum)
 C     ..
 C     .. Executable Statements ..
 C
+      status = 0
       IF (.NOT. (f.LE.0.0D0)) GO TO 10
       cum = 0.0D0
       ccum = 1.0D0
@@ -114,6 +115,10 @@ C     (essentially) zero.
 C     Calculate the central term of the poisson weighting factor.
 
       icent = xnonc
+      IF (.NOT.(DABS(xnonc-icent).LT.1)) THEN
+         status = 1
+         RETURN
+      ENDIF
       IF (icent.EQ.0) icent = 1
 
 C     Compute central weight term

--- a/scipy/special/cdflib/dinvr.f
+++ b/scipy/special/cdflib/dinvr.f
@@ -56,6 +56,7 @@ C                    QHI is LOGICAL
 
 C
 C**********************************************************************
+      IMPLICIT NONE
 C     .. Scalar Arguments ..
       DOUBLE PRECISION fx,x,zabsst,zabsto,zbig,zrelst,zrelto,zsmall,
      +                 zstpmu
@@ -328,6 +329,38 @@ C     to find the zero of the function F(X)-Y. This is routine
 C     QRZERO.
 C
 C**********************************************************************
+
+C     Reset all saved variables to known values
+      absstp = 0d0
+      abstol = 0d0
+      big = 0d0
+      fbig = 0d0
+      fsmall = 0d0
+      relstp = 0d0
+      reltol = 0d0
+      small = 0d0
+      step = 0d0
+      stpmul = 0d0
+      xhi = 0d0
+      xlb = 0d0
+      xlo = 0d0
+      xsave = 0d0
+      xub = 0d0
+      yy = 0d0
+      zx = 0d0
+      zy = 0d0
+      zz = 0d0
+      i99999 = 0
+      qbdd = .FALSE.
+      qcond = .FALSE.
+      qdum1 = .FALSE.
+      qdum2 = .FALSE.
+      qincr = .FALSE.
+      qlim = .FALSE.
+      qok = .FALSE.
+      qup = .FALSE.
+
+C     Set initial values
       small = zsmall
       big = zbig
       absstp = zabsst

--- a/scipy/special/cdflib/dzror.f
+++ b/scipy/special/cdflib/dzror.f
@@ -58,6 +58,7 @@ C              termination of the search.
 C                    QHI is LOGICAL
 C
 C**********************************************************************
+      IMPLICIT NONE
 C     .. Scalar Arguments ..
       DOUBLE PRECISION fx,x,xhi,xlo,zabstl,zreltl,zxhi,zxlo
       INTEGER status
@@ -266,6 +267,35 @@ C     Mathematical Software, Volume 1, no. 4 page 330
 C     (Dec. '75) is employed to find the zero of F(X)-Y.
 C
 C**********************************************************************
+
+C     Reset all saved variables to known values
+      a = 0d0
+      abstol = 0d0
+      b = 0d0
+      c = 0d0
+      d = 0d0
+      fa = 0d0
+      fb = 0d0
+      fc = 0d0
+      fd = 0d0
+      fda = 0d0
+      fdb = 0d0
+      m = 0d0
+      mb = 0d0
+      p = 0d0
+      q = 0d0
+      reltol = 0d0
+      tol = 0d0
+      w = 0d0
+      xxhi = 0d0
+      xxlo = 0d0
+      zx = 0d0
+      ext = 0
+      i99999 = 0
+      first = .FALSE.
+      qrzero = .FALSE.
+
+C     Set initial values
       xxlo = zxlo
       xxhi = zxhi
       abstol = zabstl

--- a/scipy/special/cdflib/gratio.f
+++ b/scipy/special/cdflib/gratio.f
@@ -212,7 +212,7 @@ C
       n = 20
 C
   120 sum = t
-  130 IF (abs(t).LE.acc) GO TO 140
+  130 IF (.NOT.(abs(t).GT.acc)) GO TO 140
       amn = amn - 1.0D0
       t = t* (amn/x)
       sum = sum + t

--- a/scipy/special/cephes/tukey.c
+++ b/scipy/special/cephes/tukey.c
@@ -8,6 +8,9 @@
  * Author:  Travis Oliphant 
  */
 
+#include <Python.h>
+#include <numpy/npy_math.h>
+
 #include <math.h>
 
 #define SMALLVAL 1e-4
@@ -18,6 +21,10 @@ double tukeylambdacdf(double x, double lmbda)
 {
     double pmin, pmid, pmax, plow, phigh, xeval;
     int count;
+
+    if (npy_isnan(x) || npy_isnan(lmbda)) {
+        return NPY_NAN;
+    }
 
     xeval = 1.0 / lmbda;
     if (lmbda > 0.0) {

--- a/scipy/special/tests/test_cdflib.py
+++ b/scipy/special/tests/test_cdflib.py
@@ -21,7 +21,10 @@ The following functions still need tests:
 """
 from __future__ import division, print_function, absolute_import
 
+import itertools
+
 import numpy as np
+from numpy.testing import assert_equal
 import pytest
 
 import scipy.special as sp
@@ -349,3 +352,58 @@ class TestCDFlib(object):
             _tukey_lmbda_quantile,
             0, [ProbArg(), Arg(0, 100, inclusive_a=False)],
             spfunc_first=False, rtol=1e-5)
+
+
+def test_nonfinite():
+    funcs = [
+        ("btdtria", 3),
+        ("btdtrib", 3),
+        ("bdtrik", 3),
+        ("bdtrin", 3),
+        ("chdtriv", 2),
+        ("chndtr", 3),
+        ("chndtrix", 3),
+        ("chndtridf", 3),
+        ("chndtrinc", 3),
+        ("fdtridfd", 3),
+        ("ncfdtr", 4),
+        ("ncfdtri", 4),
+        ("ncfdtridfn", 4),
+        ("ncfdtridfd", 4),
+        ("ncfdtrinc", 4),
+        ("gdtrix", 3),
+        ("gdtrib", 3),
+        ("gdtria", 3),
+        ("nbdtrik", 3),
+        ("nbdtrin", 3),
+        ("nrdtrimn", 3),
+        ("nrdtrisd", 3),
+        ("pdtrik", 2),
+        ("stdtr", 2),
+        ("stdtrit", 2),
+        ("stdtridf", 2),
+        ("nctdtr", 3),
+        ("nctdtrit", 3),
+        ("nctdtridf", 3),
+        ("nctdtrinc", 3),
+        ("tklmbda", 2),
+    ]
+
+    np.random.seed(1)
+
+    for func, numargs in funcs:
+        func = getattr(sp, func)
+
+        args_choices = [(float(x), np.nan, np.inf, -np.inf) for x in
+                        np.random.rand(numargs)]
+
+        for args in itertools.product(*args_choices):
+            res = func(*args)
+
+            if any(np.isnan(x) for x in args):
+                # Nan inputs should result to nan output
+                assert_equal(res, np.nan)
+            else:
+                # All other inputs should return something (but not
+                # raise exceptions or cause hangs)
+                pass


### PR DESCRIPTION
The CDFLIB code in scipy.special is not safe for non-finite inputs. 
In particular, in several places it can enter into nonterminating loops.

Add explicit nan checks to the cdflib wrappers.
Rewrite cdflib code in several parts, mainly changing `if (a < b) then terminate` to the nan-safe `if (.not.(a >= b)) then terminate`.
In one place, also check that cast of float to integer retains precision.

I suspect the 32-bit failures on appveyor are related to this. I don't think these changes 
will fix the issue, but they <s>should at least</s> convert the hang to a wrong  result computed,
see https://ci.appveyor.com/project/scipy/scipy/build/1.0.111/job/749md249mc77mpbr#L6337

Locally for win32, this PR changes the hang in TestCephes::test_ncfdtridfn to just a wrong 
computed value (but note that it is only produced sporadically ie. there is some random
component determining when it occurs). Interestingly, the wrong value is not produced 
if compiled with `-O0` in gfortran, and does not occur if only tests for scipy.special are 
run. So the issue is probably not that simple.