### PR TITLE
MAINT: use automated OpenBLAS with gcc names

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ environment:
   global:
       MINGW_32: C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin
       MINGW_64: C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin
-      OPENBLAS_32: https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-5f998ef_win32.zip
+      OPENBLAS_32: https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-5f998ef_gcc7_1_0_win32.zip
       OPENBLAS_64: https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-5f998ef_gcc7_1_0_win64.zip
       NUMPY_HEAD: https://github.com/xoviat/numpy.git
       NUMPY_BRANCH: distutils


### PR DESCRIPTION
Use OpenBLAS builds with library and archive names from gcc version.

These builds from:

* https://github.com/matthew-brett/build-openblas
* https://ci.appveyor.com/project/matthew-brett/build-openblas

See discussion at https://github.com/scipy/scipy/issues/7726