### PR TITLE
BUG: Fixes #7735: Prevent integer overflow in concatenated index pointer

### DIFF
--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -409,7 +409,7 @@ def _compressed_sparse_stack(blocks, axis):
                                 maxval=data.size)
     indptr = np.empty(np.sum([b.shape[axis] for b in blocks])+1,
                       dtype=idx_dtype)
-    last_indptr = idx_dtype(0)
+    last_indptr = 0
     constant_dim = blocks[0].shape[other_axis]
     sum_dim = 0
     for b in blocks:

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -404,13 +404,13 @@ def _compressed_sparse_stack(blocks, axis):
     """
     other_axis = 1 if axis == 0 else 0
     data = np.concatenate([b.data for b in blocks])
+    constant_dim = blocks[0].shape[other_axis]
     idx_dtype = get_index_dtype(arrays=[b.indptr for b in blocks],
-                                maxval=data.size)
+                                maxval=max(data.size, constant_dim)
     indices = np.empty(data.size, dtype=idx_dtype)
     indptr = np.empty(np.sum([b.shape[axis] for b in blocks])+1,
                       dtype=idx_dtype)
     last_indptr = 0
-    constant_dim = blocks[0].shape[other_axis]
     sum_dim = 0
     sum_indices = 0
     for b in blocks:

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -408,8 +408,7 @@ def _compressed_sparse_stack(blocks, axis):
     idx_dtype = get_index_dtype(arrays=[b.indptr for b in blocks],
                                 maxval=max(data.size, constant_dim))
     indices = np.empty(data.size, dtype=idx_dtype)
-    indptr = np.empty(np.sum([b.shape[axis] for b in blocks])+1,
-                      dtype=idx_dtype)
+    indptr = np.empty(sum(b.shape[axis] for b in blocks) + 1, dtype=idx_dtype)
     last_indptr = 0
     sum_dim = 0
     sum_indices = 0

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -404,10 +404,9 @@ def _compressed_sparse_stack(blocks, axis):
     """
     other_axis = 1 if axis == 0 else 0
     data = np.concatenate([b.data for b in blocks])
+    indices = np.concatenate([b.indices for b in blocks])
     idx_dtype = get_index_dtype(arrays=[b.indptr for b in blocks],
                                 maxval=data.size)
-    indices = np.concatenate([np.asarray(b.indices, dtype=idx_dtype)
-                              for b in blocks])
     indptr = []
     last_indptr = idx_dtype(0)
     constant_dim = blocks[0].shape[other_axis]

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -415,7 +415,9 @@ def _compressed_sparse_stack(blocks, axis):
     for b in blocks:
         if b.shape[other_axis] != constant_dim:
             raise ValueError('incompatible dimensions for axis %d' % other_axis)
-        indptr[sum_dim:sum_dim+b.shape[axis]] = b.indptr[:-1] + last_indptr
+        idxs = slice(sum_dim, sum_dim + b.shape[axis])
+        indptr[idxs] = b.indptr[:-1]
+        indptr[idxs] += last_indptr
         sum_dim += b.shape[axis]
         last_indptr += b.indptr[-1]
     indptr[-1] = last_indptr

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -404,9 +404,10 @@ def _compressed_sparse_stack(blocks, axis):
     """
     other_axis = 1 if axis == 0 else 0
     data = np.concatenate([b.data for b in blocks])
-    indices = np.concatenate([b.indices for b in blocks])
     idx_dtype = get_index_dtype(arrays=[b.indptr for b in blocks],
                                 maxval=data.size)
+    indices = np.concatenate([np.asarray(b.indices, dtype=idx_dtype)
+                              for b in blocks])
     indptr = []
     last_indptr = idx_dtype(0)
     constant_dim = blocks[0].shape[other_axis]
@@ -415,7 +416,8 @@ def _compressed_sparse_stack(blocks, axis):
         if b.shape[other_axis] != constant_dim:
             raise ValueError('incompatible dimensions for axis %d' % other_axis)
         sum_dim += b.shape[axis]
-        indptr.append(b.indptr[:-1].astype(idx_dtype) + last_indptr)
+        indptr.append(np.asarray(b.indptr[:-1], dtype=idx_dtype)
+                      + last_indptr)
         last_indptr += b.indptr[-1]
     indptr.append([last_indptr])
     indptr = np.concatenate(indptr)

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -409,7 +409,7 @@ def _compressed_sparse_stack(blocks, axis):
                                 maxval=max(data.size, constant_dim))
     indices = np.empty(data.size, dtype=idx_dtype)
     indptr = np.empty(sum(b.shape[axis] for b in blocks) + 1, dtype=idx_dtype)
-    last_indptr = 0
+    last_indptr = idx_dtype(0)
     sum_dim = 0
     sum_indices = 0
     for b in blocks:

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -406,7 +406,7 @@ def _compressed_sparse_stack(blocks, axis):
     data = np.concatenate([b.data for b in blocks])
     constant_dim = blocks[0].shape[other_axis]
     idx_dtype = get_index_dtype(arrays=[b.indptr for b in blocks],
-                                maxval=max(data.size, constant_dim)
+                                maxval=max(data.size, constant_dim))
     indices = np.empty(data.size, dtype=idx_dtype)
     indptr = np.empty(np.sum([b.shape[axis] for b in blocks])+1,
                       dtype=idx_dtype)

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -405,15 +405,17 @@ def _compressed_sparse_stack(blocks, axis):
     other_axis = 1 if axis == 0 else 0
     data = np.concatenate([b.data for b in blocks])
     indices = np.concatenate([b.indices for b in blocks])
+    idx_dtype = get_index_dtype(arrays=[b.indptr for b in blocks],
+                                maxval=data.size)
     indptr = []
-    last_indptr = 0
+    last_indptr = idx_dtype(0)
     constant_dim = blocks[0].shape[other_axis]
     sum_dim = 0
     for b in blocks:
         if b.shape[other_axis] != constant_dim:
             raise ValueError('incompatible dimensions for axis %d' % other_axis)
         sum_dim += b.shape[axis]
-        indptr.append(b.indptr[:-1] + last_indptr)
+        indptr.append(b.indptr[:-1].astype(idx_dtype) + last_indptr)
         last_indptr += b.indptr[-1]
     indptr.append([last_indptr])
     indptr = np.concatenate(indptr)

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -404,17 +404,20 @@ def _compressed_sparse_stack(blocks, axis):
     """
     other_axis = 1 if axis == 0 else 0
     data = np.concatenate([b.data for b in blocks])
-    indices = np.concatenate([b.indices for b in blocks])
     idx_dtype = get_index_dtype(arrays=[b.indptr for b in blocks],
                                 maxval=data.size)
+    indices = np.empty(data.size, dtype=idx_dtype)
     indptr = np.empty(np.sum([b.shape[axis] for b in blocks])+1,
                       dtype=idx_dtype)
     last_indptr = 0
     constant_dim = blocks[0].shape[other_axis]
     sum_dim = 0
+    sum_indices = 0
     for b in blocks:
         if b.shape[other_axis] != constant_dim:
             raise ValueError('incompatible dimensions for axis %d' % other_axis)
+        indices[sum_indices:sum_indices+b.indices.size] = b.indices
+        sum_indices += b.indices.size
         idxs = slice(sum_dim, sum_dim + b.shape[axis])
         indptr[idxs] = b.indptr[:-1]
         indptr[idxs] += last_indptr

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -380,7 +380,7 @@ class TestConstructUtils(object):
                             construct.bmat, [[A,C]])
 
     @pytest.mark.slow
-    def test_concatenate_int32_overflow():
+    def test_concatenate_int32_overflow(self):
         """ test for indptr overflow when concatenating matrices """
         check_free_memory(30000)
         

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -381,7 +381,7 @@ class TestConstructUtils(object):
         check_free_memory(30000)
         
         n = 33000
-        A = csr_matrix(np.ones((n, n)), dtype=bool))
+        A = csr_matrix(np.ones((n, n), dtype=bool))
         B = A.copy()
         C = construct._compressed_sparse_stack((A,B), 0)
         

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -312,7 +312,6 @@ class TestConstructUtils(object):
 
         A = coo_matrix([[1,2],[3,4]])
         B = coo_matrix([[5,6]])
-        C = 
 
         expected = matrix([[1, 2],
                            [3, 4],

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -6,7 +6,9 @@ import numpy as np
 from numpy import array, matrix
 from numpy.testing import (assert_equal, assert_,
         assert_array_equal, assert_raises, assert_array_almost_equal_nulp)
+import pytest
 from scipy._lib._numpy_compat import assert_raises_regex
+from scipy._lib._testutils import check_free_memory
 
 from scipy.sparse import csr_matrix, coo_matrix
 
@@ -372,6 +374,20 @@ class TestConstructUtils(object):
         assert_raises_regex(ValueError,
                             r'Got blocks\[0,1\]\.shape\[0\] == 1, expected 2',
                             construct.bmat, [[A,C]])
+
+    @pytest.mark.slow
+    def test_concatenate_int32_overflow():
+        """ test for indptr overflow when concatenating matrices """
+        check_free_memory(30000)
+        
+        n = 33000
+        A = csr_matrix(np.ones((n, n)), dtype=bool))
+        B = A.copy()
+        C = construct._compressed_sparse_stack((A,B), 0)
+        
+        assert_(np.all(np.equal(np.diff(C.indptr), n)))
+        assert_equal(C.indices.dtype, np.int64)
+        assert_equal(C.indptr.dtype, np.int64)
 
     def test_block_diag_basic(self):
         """ basic test for block_diag """

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -312,6 +312,7 @@ class TestConstructUtils(object):
 
         A = coo_matrix([[1,2],[3,4]])
         B = coo_matrix([[5,6]])
+        C = 
 
         expected = matrix([[1, 2],
                            [3, 4],
@@ -322,6 +323,10 @@ class TestConstructUtils(object):
                      expected)
         assert_equal(construct.vstack([A.tocsr(),B.tocsr()], dtype=np.float32).dtype,
                      np.float32)
+        assert_equal(construct.vstack([A.tocsr(),B.tocsr()],
+                                      dtype=np.float32).indices.dtype, np.int32)
+        assert_equal(construct.vstack([A.tocsr(),B.tocsr()],
+                                      dtype=np.float32).indptr.dtype, np.int32)
 
     def test_hstack(self):
 


### PR DESCRIPTION
This determines the best data type of the new index pointer and applies it.

This does not have a unittest, but I am not sure whether this makes sense here as one would need to either generate a ~30 Gb sparse matrix for it to appear or use int8 (or similar) pointers on purpose.

I have also not checked whether similar issues appear when concatenating other sparse matrix types