### PR TITLE
DOC: rename indices/indptr for spatial.Delaunay vertex_neighbor_vertices

### DIFF
--- a/scipy/interpolate/interpnd.pyx
+++ b/scipy/interpolate/interpnd.pyx
@@ -438,9 +438,9 @@ cdef int _estimate_gradients_2d_global(qhull.DelaunayInfo_t *d, double *data,
                 s[k] = 0
 
             # walk over neighbours of given point
-            for jpoint2 in xrange(d.vertex_neighbors_indices[ipoint],
-                                  d.vertex_neighbors_indices[ipoint+1]):
-                ipoint2 = d.vertex_neighbors_indptr[jpoint2]
+            for jpoint2 in xrange(d.vertex_neighbors_indptr[ipoint],
+                                  d.vertex_neighbors_indptr[ipoint+1]):
+                ipoint2 = d.vertex_neighbors_indices[jpoint2]
 
                 # edge
                 ex = d.points[2*ipoint2 + 0] - d.points[2*ipoint + 0]

--- a/scipy/spatial/qhull.pyx
+++ b/scipy/spatial/qhull.pyx
@@ -1778,9 +1778,9 @@ class Delaunay(_QhullUser):
         .. versionadded:: 0.12.0
     vertices
         Same as `simplices`, but deprecated.
-    vertex_neighbor_vertices : tuple of two ndarrays of int; (indices, indptr)
+    vertex_neighbor_vertices : tuple of two ndarrays of int; (indptr, indices)
         Neighboring vertices of vertices. The indices of neighboring
-        vertices of vertex `k` are ``indptr[indices[k]:indices[k+1]]``.
+        vertices of vertex `k` are ``indices[indptr[k]:indptr[k+1]]``.
 
     Raises
     ------
@@ -1990,9 +1990,9 @@ class Delaunay(_QhullUser):
         """
         Neighboring vertices of vertices.
 
-        Tuple of two ndarrays of int: (indices, indptr). The indices of
+        Tuple of two ndarrays of int: (indptr, indices). The indices of
         neighboring vertices of vertex `k` are
-        ``indptr[indices[k]:indices[k+1]]``.
+        ``indices[indptr[k]:indptr[k+1]]``.
 
         """
         cdef int i, j, k, m, is_neighbor, is_missing, ndata, idata
@@ -2275,7 +2275,7 @@ cdef int _get_delaunay_info(DelaunayInfo_t *info,
     else:
         info.vertex_to_simplex = NULL
     if compute_vertex_neighbor_vertices:
-        vn_indices, vn_indptr = obj.vertex_neighbor_vertices
+        vn_indptr, vn_indices = obj.vertex_neighbor_vertices
         info.vertex_neighbors_indices = <int*>vn_indices.data
         info.vertex_neighbors_indptr = <int*>vn_indptr.data
     else:

--- a/scipy/spatial/setlist.pxd
+++ b/scipy/spatial/setlist.pxd
@@ -98,33 +98,33 @@ cdef inline object tocsr(setlist_t *setlist):
     """
     Convert list of sets to CSR format
 
-    Integers for set `i` reside in data[indices[i]:indices[i+1]]
+    Integers for set `i` reside in data[indptr[i]:indptr[i+1]]
 
     Returns
     -------
-    indices
-        CSR indices
+    indptr
+        CSR indptr
     data
         CSR data
 
     """
     cdef size_t i, j, pos
     cdef size_t total_size
-    cdef np.ndarray[np.npy_int, ndim=1] indices, data
+    cdef np.ndarray[np.npy_int, ndim=1] indptr, data
 
     total_size = 0
     for j in xrange(setlist.n):
         total_size += setlist.sizes[j]
 
-    indices = np.empty((setlist.n+1,), dtype=np.intc)
+    indptr = np.empty((setlist.n+1,), dtype=np.intc)
     data = np.empty((total_size,), dtype=np.intc)
 
     pos = 0
     for i in xrange(setlist.n):
-        indices[i] = pos
+        indptr[i] = pos
         for j in xrange(setlist.sizes[i]):
             data[pos] = setlist.sets[i][j]
             pos += 1
-    indices[setlist.n] = pos
+    indptr[setlist.n] = pos
 
-    return indices, data
+    return indptr, data

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -417,11 +417,11 @@ class TestVertexNeighborVertices(object):
                     if a != b:
                         expected[a].add(b)
 
-        indices, indptr = tri.vertex_neighbor_vertices
+        indptr, indices = tri.vertex_neighbor_vertices
 
         got = []
         for j in range(tri.points.shape[0]):
-            got.append(set(map(int, indptr[indices[j]:indices[j+1]])))
+            got.append(set(map(int, indices[indptr[j]:indptr[j+1]])))
 
         assert_equal(got, expected, err_msg="%r != %r" % (got, expected))
 


### PR DESCRIPTION
Fixes gh-7733 by using the correct names for CSR-like indices.

This shouldn't cause backwards-incompatibility, as the function of the two arrays in `vertex_neighbor_vertices` hasn't changed order. The `DelaunayInfo_t` struct returned by `_get_delaunay_info` is affected, but that's not accessible to downstream users.