### PR TITLE
ENH: Speed up freqz computation

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -217,8 +217,9 @@ latex_use_modindex = False
 # Intersphinx configuration
 # -----------------------------------------------------------------------------
 intersphinx_mapping = {
-        'http://docs.python.org/dev': None,
-        'https://docs.scipy.org/doc/numpy': None,
+        'python': ('http://docs.python.org/dev', None),
+        'numpy': ('https://docs.scipy.org/doc/numpy', None),
+        'matplotlib': ('http://matplotlib.org', None),
 }
 
 

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -318,9 +318,9 @@ def freqz(b, a=1, worN=None, whole=False, plot=None):
     1. An integer value is given for `worN`.
     2. `worN` is fast to compute via FFT (i.e.,
        `next_fast_len(worN) <scipy.fftpack.next_fast_len>` equals `worN`).
-    3. The numerator coefficients are a single value (``a.size == 1``).
+    3. The numerator coefficients are a single value (``a.shape[0] == 1``).
     4. `worN` is at least as long as the denominator coefficients
-       (``worN >= b.shape[axis]``).
+       (``worN >= b.shape[0]``).
 
     For long FIR filters, the FFT approach can have lower error and be much
     faster than the equivalent direct polynomial calculation.
@@ -351,8 +351,8 @@ def freqz(b, a=1, worN=None, whole=False, plot=None):
     """
     b = atleast_1d(b)
     a = atleast_1d(a)
-    a_len = a.shape[0]
     b_len = b.shape[0]
+    a_len = a.shape[0]
 
     if worN is None:
         worN = 512

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -393,15 +393,15 @@ def freqz(b, a=1, worN=None, whole=False, plot=None, axis=0):
             b_trim = [slice(None)] * b.ndim
             if b_len > 1:
                 b_trim[axis] = slice(worN)
-            # If we ever go back to allowing b_len > 1, we'll also need this:
+            # If we ever go back to allowing a_len > 1, we'll also need this:
             # a_trim = [slice(None)] * a.ndim
             # if a_len > 1:
             #     a_trim[axis] = slice(worN)
 
             b_fft = fft_func(b, n=n_fft, axis=axis)[b_trim] if b_len > 1 else b
-            # If we ever go back to using b_len != 1, we can use:
+            # If we ever go back to using a_len != 1, we can use:
             #     a_fft = fft_func(a, n=n_fft, axis=axis)[a_trim]
-            # and divide by a_fft. But because we know b_len == 1, we just do:
+            # and divide by a_fft. But because we know a_len == 1, we just do:
             h = b_fft / a  # don't do inplace to allow broadcasting
             if fft_func is np.fft.rfft and whole:
                 if a_len == 1 and b_len == 1:
@@ -657,8 +657,8 @@ def sosfreqz(sos, worN=None, whole=False):
         If single integer (default 512, same as None), then compute at `worN`
         frequencies equally spaced around the unit circle. Using a number that
         is fast for FFT computations can result in faster computations
-        (see Notes). If an array_like, compute the response at the frequencies
-        given (in radians/sample).
+        (see Notes of `freqz`). If an array_like, compute the response at the
+        frequencies given (in radians/sample).
     whole : bool, optional
         Normally, frequencies are computed from 0 to the Nyquist frequency,
         pi radians/sample (upper-half of unit-circle).  If `whole` is True,

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -287,8 +287,8 @@ def freqz(b, a=1, worN=None, whole=False, plot=None, axis=0):
         `w` and `h` are passed to plot. Useful for plotting the frequency
         response inside `freqz`.
     axis : int
-        The axis to treat as coefficients in `a` and `b` (default 0)
-        when broadcasting the arrays together.
+        The axis to treat as coefficients in `a` and `b` (default 0).
+        All other axes must be compatible with broadcasting rules.
 
     Returns
     -------
@@ -297,7 +297,8 @@ def freqz(b, a=1, worN=None, whole=False, plot=None, axis=0):
         radians/sample.
     h : ndarray
         The frequency response, as complex numbers, with shape corresponding
-        to standard broadcasting rules for `a` and `b`.
+        to standard broadcasting rules for `a` and `b` along the non-frequency
+        dimension.
 
     See Also
     --------
@@ -378,8 +379,8 @@ def freqz(b, a=1, worN=None, whole=False, plot=None, axis=0):
         lastpoint = 2 * pi if whole else pi
         w = np.linspace(0, lastpoint, worN, endpoint=False)
         min_size = b_len  # would be max(a_len, b_len) in the general `a` case
-        if a_len == 1 and worN >= min_size and \
-                fftpack.next_fast_len(worN) == worN:
+        if (a_len == 1 and worN >= min_size and
+                fftpack.next_fast_len(worN) == worN):
             # if worN is fast, 2 * worN will be fast, too,
             # so no need to check that one
             n_fft = worN if whole else worN * 2

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -536,6 +536,9 @@ class TestFreqz(object):
         w, h = freqz(b.T, a.T, worN=4, whole=True)  # default axis is 0
         assert_array_almost_equal(w, expected_w)
         assert_array_almost_equal(h, h_whole.T)
+        w, h = freqz(b.T, a.T, worN=w, whole=True)  # default axis is 0
+        assert_array_almost_equal(w, expected_w)
+        assert_array_almost_equal(h, h_whole.T)
         # broadcasting
         b = np.random.rand(1, 4, 3)
         a = np.random.rand(2, 4, 1)

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -524,65 +524,45 @@ class TestFreqz(object):
         t = np.linspace(0, 1, 4, endpoint=False)
         b = np.array([[1., 0, 0, 0], np.sin(2 * np.pi * t)])
         a = np.array([[1., 0, 0, 0], [0.5, 0, 0, 0]])
-        h_whole = np.array([[1., 1., 1., 1.], [0, -4j, 0, 4j]])
-        w, h = freqz(b, a, worN=4, whole=True, axis=-1)
+        h_whole = np.array([[1., 1., 1., 1.], [0, -4j, 0, 4j]]).T
+        w, h = freqz(b.T, a.T, worN=4, whole=True)
         expected_w = np.linspace(0, 2 * np.pi, 4, endpoint=False)
         assert_array_almost_equal(w, expected_w)
         assert_array_almost_equal(h, h_whole)
         # simultaneously check int-like support
-        w, h = freqz(b, a, worN=np.int32(4), whole=True, axis=-1)
+        w, h = freqz(b.T, a.T, worN=np.int32(4), whole=True)
         assert_array_almost_equal(w, expected_w)
         assert_array_almost_equal(h, h_whole)
-        w, h = freqz(b.T, a.T, worN=4, whole=True)  # default axis is 0
+        w, h = freqz(b.T, a.T, worN=w, whole=True)
         assert_array_almost_equal(w, expected_w)
-        assert_array_almost_equal(h, h_whole.T)
-        w, h = freqz(b.T, a.T, worN=w, whole=True)  # default axis is 0
-        assert_array_almost_equal(w, expected_w)
-        assert_array_almost_equal(h, h_whole.T)
+        assert_array_almost_equal(h, h_whole)
         # broadcasting
-        b = np.random.rand(1, 4, 3)
-        a = np.random.rand(2, 4, 1)
-        w, h = freqz(b, a, worN=5, axis=1)
+        b = np.random.rand(4, 1, 3)
+        a = np.random.rand(4, 2, 1)
+        w, h = freqz(b, a, worN=5)
         assert_array_equal(w.shape, (5,))
-        assert_array_equal(h.shape, (2, 5, 3))
+        assert_array_equal(h.shape, (5, 2, 3))
         b = np.random.rand(2, 3)
-        a = np.random.rand(3,)
-        w, h = freqz(b, a, worN=4, axis=-1)
+        a = np.random.rand(10,)
+        w, h = freqz(b, a, worN=4)
         assert_array_equal(w.shape, (4,))
-        assert_array_equal(h.shape, (2, 4))
+        assert_array_equal(h.shape, (4, 3))
         # length-1 cases, with broadcasting and axis arguments
         for factor in (1., 1j):
             b = np.ones((1,) * 4) * factor
             a = np.ones((1,) * 2)
-            assert_raises(ValueError, freqz, b, a, axis=10)
-            assert_raises(ValueError, freqz, b, a, axis=-11)
-            for axis in range(4):
-                w, h = freqz(b, a, worN=5, axis=axis)
-                assert_array_equal(w.shape, (5,))
-                expected = np.repeat(b, 5, axis=axis)
-                assert_allclose(h, expected, atol=1e-12)
-        # axis arguments
-        b = np.random.rand(2, 7)
-        a = np.random.rand(2, 7)
-        w, h = freqz(b, a, worN=12, axis=1)
-        assert_array_equal(w.shape, (12,))
-        assert_array_equal(h.shape, (2, 12))
-        w, h = freqz(b, a, worN=12, axis=0)
-        assert_array_equal(w.shape, (12,))
-        assert_array_equal(h.shape, (12, 7))
-        w, h = freqz(b, worN=6, axis=1)
-        assert_array_equal(w.shape, (6,))
-        assert_array_equal(h.shape, (2, 6))
-        b = np.random.rand(2, 3, 4)
-        for ii in range(3):
-            for axis in (ii, ii - 3):
-                expected_shape = list(b.shape)
-                expected_shape[axis] = 5
-                w, h = freqz(b, worN=5, axis=axis)
-                assert_array_equal(w.shape, (5,))
-                assert_array_equal(h.shape, expected_shape)
+            w, h = freqz(b, a, worN=5)
+            assert_array_equal(w.shape, (5,))
+            expected = np.repeat(b, 5, axis=0)
+            assert_allclose(h, expected, atol=1e-12)
         assert_raises(ValueError, freqz, b, worN=0)
         assert_raises(ValueError, freqz, b, worN=[])
+        b = np.ones((3, 5, 1))
+        a = np.ones((2, 1))
+        w, h = freqz(b, a, worN=512)
+        assert_array_equal(h.shape, (512, 5, 1))
+        w, h = freqz(b, a, worN=w)
+        assert_array_equal(h.shape, (512, 5, 1))
 
     def test_fft_wrapping(self):
         # Some simple real FIR filters


### PR DESCRIPTION
This speeds up `freqz` by using FFT as suggested by @WarrenWeckesser in #7734.

It also updates our `doc/conf.py` to use the new `intersphinx_mapping` format and adds `matplotlib` linking, since the `freqz` docstring could/should probably link to `matplotlib.pyplot.plot`.