### PR TITLE
TST: ignore ncfdtridfn failure in win32 & warn on FPU mode changes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -65,10 +65,6 @@ environment:
       SKIP_NOTAG: true
       TEST_MODE: full
 
-matrix:
-  allow_failures:
-    - PYTHON_ARCH: 32
-
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
   - "ECHO \"%APPVEYOR_SCHEDULED_BUILD%\""

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,6 +5,7 @@ markers =
     xslow: mark test as extremely slow (not run unless explicitly requested)
 filterwarnings =
     error
+    always::scipy._lib._testutils.FPUModeChangeWarning
     once:.*LAPACK bug 0038.*:RuntimeWarning
 env =
     PYTHONHASHSEED=0

--- a/scipy/_lib/_fpumode.c
+++ b/scipy/_lib/_fpumode.c
@@ -35,7 +35,7 @@ get_fpu_mode(PyObject *self, PyObject *args)
         return PyLong_FromLongLong(cw);
     }
 #else
-    return Py_RETURN_NONE;
+    Py_RETURN_NONE;
 #endif
 }
 

--- a/scipy/_lib/_fpumode.c
+++ b/scipy/_lib/_fpumode.c
@@ -1,0 +1,75 @@
+#include <Python.h>
+
+#include <stdio.h>
+
+
+#ifdef _MSC_VER
+#pragma fenv_access (on)
+#endif
+
+
+static char get_fpu_mode_doc[] = (
+    "get_fpu_mode()\n"
+    "\n"
+    "Get the current FPU control word, in a platform-dependent format.\n"
+    "Returns None if not implemented on current platform.");
+
+
+static PyObject *
+get_fpu_mode(PyObject *self, PyObject *args)
+{
+    if (!PyArg_ParseTuple(args, "")) {
+        return NULL;
+    }
+
+#if defined(_MSC_VER)
+    {
+        unsigned int result = 0;
+        result = _controlfp(0, 0);
+        return PyLong_FromLongLong(result);
+    }
+#elif defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__))
+    {
+        unsigned short cw = 0;
+        __asm__("fstcw %w0" : "=m" (cw));
+        return PyLong_FromLongLong(cw);
+    }
+#else
+    return Py_RETURN_NONE;
+#endif
+}
+
+
+static struct PyMethodDef methods[] = {
+    {"get_fpu_mode", get_fpu_mode, METH_VARARGS, get_fpu_mode_doc},
+    {NULL, NULL, 0, NULL}
+};
+
+
+#if PY_MAJOR_VERSION >= 3
+
+static struct PyModuleDef moduledef = {
+    PyModuleDef_HEAD_INIT,
+    "_fpumode",
+    NULL,
+    -1,
+    methods,
+    NULL,
+    NULL,
+    NULL,
+    NULL
+};
+
+PyObject *PyInit__fpumode(void)
+{
+    return PyModule_Create(&moduledef);
+}
+
+#else
+
+PyMODINIT_FUNC init_fpumode(void)
+{
+    Py_InitModule("_fpumode", methods);
+}
+
+#endif

--- a/scipy/_lib/_testutils.py
+++ b/scipy/_lib/_testutils.py
@@ -13,6 +13,11 @@ import sys
 __all__ = ['PytestTester', 'check_free_memory']
 
 
+class FPUModeChangeWarning(RuntimeWarning):
+    """Warning about FPU mode change"""
+    pass
+
+
 class PytestTester(object):
     """
     Pytest test runner entry point.

--- a/scipy/_lib/setup.py
+++ b/scipy/_lib/setup.py
@@ -22,6 +22,9 @@ def configuration(parent_package='',top_path=None):
                          depends=depends,
                          include_dirs=[include_dir])
 
+    config.add_extension("_fpumode",
+                         sources=["_fpumode.c"])
+
     return config
 
 

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -1,7 +1,12 @@
 # Pytest customization
+from __future__ import division, absolute_import, print_function
 
 import os
 import pytest
+import warnings
+
+from scipy._lib._fpumode import get_fpu_mode
+from scipy._lib._testutils import FPUModeChangeWarning
 
 
 def pytest_runtest_setup(item):
@@ -13,3 +18,18 @@ def pytest_runtest_setup(item):
             v = False
         if not v:
             pytest.skip("very slow test; set environment variable SCIPY_XSLOW=1 to run it")
+
+
+@pytest.fixture(scope="function", autouse=True)
+def check_fpu_mode(request):
+    """
+    Check FPU mode was not changed during the test.
+    """
+    old_mode = get_fpu_mode()
+    yield
+    new_mode = get_fpu_mode()
+
+    if old_mode != new_mode:
+        warnings.warn("FPU mode changed from {0:#x} to {1:#x} during "
+                      "the test".format(old_mode, new_mode),
+                      category=FPUModeChangeWarning, stacklevel=0)

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -19,6 +19,8 @@
 
 from __future__ import division, print_function, absolute_import
 
+import sys
+import platform
 import itertools
 
 import numpy as np
@@ -699,6 +701,11 @@ class TestCephes(object):
         p = cephes.ncfdtr(2, dfd, 0.25, 15)
         assert_allclose(cephes.ncfdtridfd(2, p, 0.25, 15), dfd)
 
+    @pytest.mark.xfail((sys.platform == "win32" and
+                        platform.architecture()[0] == "32bit" and
+                        NumpyVersion(np.__version__) < "1.14.0"),
+                       reason=("Can fail on win32 if FPU is in wrong mode, "
+                               "see gh-7726"))
     def test_ncfdtridfn(self):
         dfn = [1, 2, 3]
         p = cephes.ncfdtr(dfn, 2, 0.25, 15)


### PR DESCRIPTION
Ignore a failure in TestCephes.test_ncfdtridfn appearing on win32 
when FPU is in a non-default precision mode. This shouldn't usually happen,
but MSVC has a bug that flips the mode.

Add machinery to the test suite to produce warnings when a change in the
FPU mode is observed. It produces warnings instead of errors, because
this can occur due to e.g. issues in numpy in which case it can in principle 
arise in several unrelated tests.

Make Appveyor to require successful run on 32-bit environment; this should
be the last known failure for py36 there.

cf gh-7726