### PR TITLE
Fix overflow in Anderson-Darling k-sample test

### DIFF
--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -1692,8 +1692,10 @@ def anderson_ksamp(samples, midrank=True):
     pf = np.polyfit(critical, log(np.array([0.25, 0.1, 0.05, 0.025, 0.01])), 2)
     if A2 < critical.min() or A2 > critical.max():
         warnings.warn("approximate p-value will be computed by extrapolation")
-
-    p = math.exp(np.polyval(pf, A2))
+    try:
+        p = math.exp(np.polyval(pf, A2))
+    except (OverflowError,):
+        p = float("inf")
     return Anderson_ksampResult(A2, critical, p)
 
 

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -390,7 +390,7 @@ class TestAndersonKSamp(object):
 
     def test_overflow(self):
         # when significance_level approximation overflows, should still return
-         with suppress_warnings() as sup:
+        with suppress_warnings() as sup:
             sup.filter(UserWarning, message='approximate p-value')
             res = stats.anderson_ksamp([[-20, -10] * 100, [-10, 40, 12] * 100])
             assert_almost_equal(res[0], 272.796, 3)

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -388,6 +388,13 @@ class TestAndersonKSamp(object):
         attributes = ('statistic', 'critical_values', 'significance_level')
         check_named_results(res, attributes)
 
+    def test_overflow(self):
+        # when significance_level approximation overflows, should still return
+         with suppress_warnings() as sup:
+            sup.filter(UserWarning, message='approximate p-value')
+            res = stats.anderson_ksamp([[-20, -10] * 100, [-10, 40, 12] * 100])
+            assert_almost_equal(res[0], 272.796, 3)
+
 
 class TestAnsari(object):
 


### PR DESCRIPTION
In cases where the distributions compared are very different, it's possible to overflow the `significance_level` computation of the Anderson-Darling k-sample test without overflowing the test statistic itself.
This PR makes the function return (`statistic`, `critical_values`, `inf`) instead of throwing an `OverflowError`.