### PR TITLE
BUG: optimize: show_options('linprog', method='interior-point') failed.

### DIFF
--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -2999,6 +2999,7 @@ def show_options(solver=None, method=None, disp=True):
         ),
         'linprog': (
             ('simplex', 'scipy.optimize._linprog._linprog_simplex'),
+            ('interior-point', 'scipy.optimize._linprog._linprog_ip'),
         ),
         'minimize_scalar': (
             ('brent', 'scipy.optimize.optimize._minimize_scalar_brent'),


### PR DESCRIPTION
The entry for solver='linprog' and method='interior-point' was missing
from the doc_routines dictionary.