### PR TITLE
WIP: DOC: add a SciPy Code of Conduct.

### DIFF
--- a/doc/source/dev/conduct/code_of_conduct.md
+++ b/doc/source/dev/conduct/code_of_conduct.md
@@ -1,0 +1,132 @@
+# SciPy Code of Conduct
+
+SciPy is an engaged and respectful community made up of people
+from all over the world. Your involvement helps us to further our
+mission and to create an open platform that serves a broad range of
+communities, from research and education, to journalism, industry and
+beyond.
+
+Naturally, this implies diversity of ideas and perspectives on often complex
+problems. Disagreement and healthy discussion of conflicting viewpoints is
+welcome: the best solutions to hard problems rarely come from a single angle.
+But disagreement is not an excuse for aggression: humans tend to take
+disagreement personally and easily drift into behavior that ultimately degrades
+a community. This is particularly acute with online communication across
+language and cultural gaps, where many cues of human behavior are unavailable.
+We are outlining here a set of principles and processes to support a
+healthy community in the face of these challenges.
+
+Fundamentally, we are committed to fostering a productive, harassment-free
+environment for everyone. Rather than considering this code an exhaustive list
+of things that you can’t do, take it in the spirit it is intended - a guide to
+make it easier to enrich all of us and the communities in which we participate.
+
+Importantly: as a member of our community, *you are also a steward of these
+values*.  Not all problems need to be resolved via formal processes, and often
+a quick, friendly but clear word on an online forum or in person can help
+resolve a misunderstanding and de-escalate things.
+
+However, sometimes these informal processes may be inadequate: they fail to
+work, there is urgency or risk to someone, nobody is intervening publicly and
+you don't feel comfortable speaking in public, etc.  For these or other
+reasons, structured follow-up may be necessary and here we provide the means
+for that: we welcome reports by emailing
+[*conduct@scipy.org*](mailto:conduct@scipy.org) *TODO: decide on this email address*
+or alternatively by contacting
+the NumFOCUS reporting contact (https://www.numfocus.org/about/code-of-conduct/).
+For more details please see our [Reporting Guidelines](reporting.md).
+
+This code applies equally to founders, developers, mentors and new community
+members, in all spaces managed by SciPy. This
+includes the mailing lists, our GitHub organization and any other forums created
+by the project team. In addition, violations of this code outside these spaces
+may affect a person's ability to participate within them.
+
+By embracing the following principles, guidelines and actions to follow or
+avoid, you will help us make SciPy a welcoming and productive community. Feel
+free to contact the Code of Conduct Committee at
+*TODO: email address* with any questions.
+
+
+1. **Be friendly and patient**.
+
+2. **Be welcoming**. We strive to be a community that welcomes and supports
+   people of all backgrounds and identities. This includes, but is not limited
+   to, members of any race, ethnicity, culture, national origin, color,
+   immigration status, social and economic class, educational level, sex, sexual
+   orientation, gender identity and expression, age, physical appearance, family
+   status, political belief, technological or professional choices, academic
+   discipline, religion, mental ability, and physical ability.
+
+3. **Be considerate**. Your work will be used by other people, and you in turn
+   will depend on the work of others. Any decision you take will affect users
+   and colleagues, and you should take those consequences into account when
+   making decisions. Remember that we're a world-wide community. You may be
+   communicating with someone with a different primary language or cultural
+   background.
+
+4. **Be respectful**. Not all of us will agree all the time, but disagreement is
+   no excuse for poor behavior or poor manners. We might all experience some
+   frustration now and then, but we cannot allow that frustration to turn into a
+   personal attack. It’s important to remember that a community where people
+   feel uncomfortable or threatened is not a productive one.
+
+5. **Be careful in the words that you choose**. Be kind to others. Do not insult
+   or put down other community members. Harassment and other exclusionary
+   behavior are not acceptable. This includes, but is not limited to:
+   * Violent threats or violent language directed against another person
+   * Discriminatory jokes and language
+   * Posting sexually explicit or violent material
+   * Posting (or threatening to post) other people's personally identifying
+     information ("doxing")
+   * Personal insults, especially those using racist or sexist terms
+   * Unwelcome sexual attention
+   * Advocating for, or encouraging, any of the above behavior
+   * Repeated harassment of others. In general, if someone asks you to stop,
+     then stop
+
+6. **Moderate your expectations**. Please respect that community members choose
+   how they spend their time in the project. A thoughtful question about your
+   expectations is preferable to demands for another person's time.
+
+7. **When we disagree, try to understand why**. Disagreements, both social and
+   technical, happen all the time and SciPy is no exception.  Try to
+   understand where others are coming from, as seeing a question from their
+   viewpoint may help find a new path forward.  And don’t forget that it is
+   human to err: blaming each other doesn’t get us anywhere, while we can learn
+   from mistakes to find better solutions.
+
+8. **A simple apology can go a long way**. It can often de-escalate a situation,
+   and telling someone that you are sorry is an act of empathy that doesn’t
+   automatically imply an admission of guilt.
+
+
+## Reporting
+
+If you believe someone is violating the code of conduct, please report this in
+a timely manner. Code of conduct violations reduce the value of the community
+for everyone and we take them seriously.
+
+You can file a report by emailing *TODO: email address* or alternatively by contacting
+the NumFOCUS reporting contact (https://www.numfocus.org/about/code-of-conduct/).
+For more details, please see our [Reporting Guidelines](link).
+
+You can request that we follow up with you directly.  If you prefer to keep your
+report anonymous, please send it from an email account that isn't linked to your
+identity in a manner that can be found publicly.  While we cannot follow up
+with you directly on an anonymous report, we will take appropriate action.
+
+
+## Enforcement
+
+For information on enforcement, please view the [*Enforcement
+Manual*](enforcement.md).
+
+Original text courtesy of the [Jupyter](https://github.com/jupyter/governance/),
+[*Speak Up!*](http://web.archive.org/web/20141109123859/http://speakup.io/coc.html)
+and [*Django*](https://www.djangoproject.com/conduct) Projects,
+modified by the SciPy project.  We are grateful to those projects for contributing
+these materials under open licensing terms for us to easily reuse.
+
+All content on this page is licensed under a [*Creative Commons
+Attribution*](http://creativecommons.org/licenses/by/3.0/) license.

--- a/doc/source/dev/conduct/enforcement.md
+++ b/doc/source/dev/conduct/enforcement.md
@@ -1,0 +1,211 @@
+# SciPy Code of Conduct - Enforcement Manual
+
+This is the enforcement manual followed by SciPy's Code of Conduct
+Committee. It's used when we respond to an issue to make sure we're consistent
+and fair.
+
+## The Code of Conduct Committee
+
+All responses to reports of conduct violations will be managed by a Code of
+Conduct Committee ("the committee"), currently comprised of
+[*note:* still gathering volunteers, this will be filled in as they become
+available and prior to final upload into the rendered site]:
+
+* Person One foo@email (Chair of the Committee)
+* ...
+* Person Three bar@email
+
+The SciPy Steering Council will approve the members of this three person
+committee. The members will be drawn from our entire community, and we intend
+that it *not* be only Steering Council members: anyone who is actively engaged
+with SciPy can propose to join this committee (we'll explicitly solicit
+volunteers when short of three members).  One member will be designated chair of
+the group and will be responsible for all reports back to the Steering Council.
+
+
+## Enforcement guidelines and principles
+
+Enforcing the Code of Conduct impacts our community today and for the future.
+It's an action that we do not take lightly. When reviewing enforcement
+measures, the Code of Conduct Committee will keep the following values and
+guidelines in mind:
+
+* Act in a personal manner rather than impersonal.  The Committee can engage
+  the parties to understand the situation, while respecting the privacy and any
+  necessary confidentiality of reporters.  However, sometimes it is necessary
+  to communicate with one or more individuals directly: the Committee's goal is
+  to improve the health of our community rather than only produce a formal
+  decision.
+
+* Emphasize empathy for individuals rather than judging behavior, avoiding
+  binary labels of "good" and "bad/evil". Overt, clear-cut aggression and
+  harassment exists and will be addressed unambiguously.  But many scenarios
+  that can prove challenging to resolve are those where normal disagreements
+  devolve into inappropriate behavior from multiple parties.  Understanding the
+  full context and finding a path that re-engages all is hard, but ultimately
+  the most productive for our community.
+
+* Help increase engagement in good discussion practice: try to identify where
+  discussion may have broken down and provide actionable information, pointers
+  and resources that can help enact positive change on these points.
+
+* Be mindful of the needs of new members: provide them with explicit support
+  and consideration, with the aim of increasing participation from
+  underrepresented groups in particular.
+
+* Individuals come from different cultural backgrounds and native languages.
+  While lack of intent to harm is not an excuse, try to identify any honest
+  misunderstandings caused by a non-native speaker and help them understand the
+  issue and how to change.  Complex discussion in a foreign language can be
+  very intimidating, and we want to grow our diversity also across
+  nationalities and cultures.
+
+* Our actions will reflect compassion for all individuals. We will seek to
+  understand, to educate, and, as necessary, take action.
+
+
+**Mediation:** voluntary, informal mediation is a tool at our disposal.  In
+contexts such as when two or more parties have all escalated to the point of
+inappropriate behavior (something sadly common in human conflict), it may be
+useful to facilitate a mediation process. This is only an example: the
+Committee can consider mediation in any case, mindful that the process is meant
+to be strictly voluntary and no party can be pressured to participate. If the
+Committee suggests mediation, it should:
+
+* Find a candidate who can serve as a mediator.
+* Obtain the agreement of the reporter(s). The reporter(s) have complete
+  freedom to decline the mediation idea, or to propose an alternate mediator.
+* Obtain the agreement of the reported person(s).
+* Settle on the mediator: while parties can propose a different mediator than
+  the suggested candidate, only if common agreement is reached on all terms can
+  the process move forward.
+* Establish a timeline for mediation to complete, ideally within two weeks.
+
+The mediator will engage with all the parties and seek a resolution that is
+satisfactory to all.  Upon completion, the mediator will provide a report
+(vetted by all parties to the process) to the Committee, with recommendations
+on further steps.  The Committee will then evaluate these results (whether
+satisfactory resolution was achieved or not) and decide on any additional
+action deemed necessary.
+
+
+## How the committee will respond to reports
+
+When a report is sent to the committee they will immediately reply to the
+reporter to confirm receipt. This reply must be sent within 72 hours, and the
+group should strive to respond much quicker than that.
+
+See the [Reporting Guidelines](*reporting.md*) for details of
+what reports should contain. If a report doesn't contain enough information, the
+committee will obtain all relevant data before acting. The committee is
+empowered to act on the Steering Council’s behalf in contacting any individuals
+involved to get a more complete account of events.
+
+The committee will then review the incident and determine, to the best of their
+ability:
+
+* What happened.
+* Whether this event constitutes a Code of Conduct violation.
+* Who are the responsible party(ies).
+* Whether this is an ongoing situation, and there is a threat to anyone's
+  physical safety.
+
+This information will be collected in writing, and whenever possible the
+group's deliberations will be recorded and retained (i.e. chat transcripts,
+email discussions, recorded conference calls, summaries of voice conversations,
+etc).
+
+It is important to retain an archive of all activities of this committee to
+ensure consistency in behavior and provide institutional memory for the
+project.  To assist in this, the default channel of discussion for this
+committee will be a private mailing list accessible to current and future
+members of the committee as well as members of the Steering Council upon
+justified request. If the Committee finds the need to use off-list
+communications (e.g. phone calls for early/rapid response), it should in all
+cases summarize these back to the list so there's a good record of the process.
+
+The Code of Conduct Committee should aim to have a resolution agreed upon within
+one week. In the event that a resolution can't be determined in that time, the
+committee will respond to the reporter(s) with an update and projected timeline
+for resolution.
+
+
+## Incident Response and Committee Actions
+
+If the act is ongoing, or involves a threat to anyone's safety (e.g. threats of
+violence), any committee member may act immediately (before reaching consensus)
+to address the situation. In ongoing situations, any member may decide to employ
+any of the tools available to the committee, including bans and blocks.
+
+If the incident involves physical danger, any member of the committee may -- and
+should -- act unilaterally to protect the safety of those involved. This can
+include contacting law enforcement (or other local personnel) and speaking on
+behalf of the SciPy Steering Council.
+
+In situations where an individual committee member acts unilaterally, they must
+report their actions to the committee for review within 24 hours.
+
+At events where no Committee members may be present, an event organizer will act
+as their delegate. They will forward any reports to the Committee, as well as a
+summary of any action they may have taken during the event.
+
+
+## Resolutions
+
+The committee must agree on a resolution by consensus. If the group cannot reach
+consensus and deadlocks for over a week, the group will turn the matter over to
+the Steering Council for resolution.
+
+
+Possible responses may include:
+
+* Taking no further action
+  - if we determine no violations have occurred.
+  - if the matter has been resolved publicly while the committee was
+    considering responses.
+* Coordinating voluntary mediation: if all involved parties agree, the
+  Committee may facilitate a mediation process as detailed above.
+* Remind publicly, and point out that some behavior/actions/language have been
+  judged inappropriate and why in the current context, or can but hurtful to
+  some people, requesting the community to self-adjust.
+* A private reprimand from the committee to the individual(s) involved. In this
+  case, the group chair will deliver that reprimand to the individual(s) over
+  email, cc'ing the group.
+* A public reprimand. In this case, the committee chair will deliver that
+  reprimand in the same venue that the violation occurred, within the limits of
+  practicality. E.g., the original mailing list for an email violation, but
+  for a chat room discussion where the person/context may be gone, they can be
+  reached by other means. The group may choose to publish this message
+  elsewhere for documentation purposes.
+* A request for a public or private apology, assuming the reporter agrees to
+  this idea: they may at their discretion refuse further contact with the
+  violator. The chair will deliver this request. The committee may, if it
+  chooses, attach "strings" to this request: for example, the group may ask a
+  violator to apologize in order to retain one’s membership on a mailing list.
+* A "mutually agreed upon hiatus" where the committee asks the individual to
+  temporarily refrain from community participation. If the individual chooses
+  not to take a temporary break voluntarily, the committee may issue a
+  "mandatory cooling off period".
+* A permanent or temporary ban from some or all SciPy spaces (mailing lists,
+  gitter.im, etc.). The group will maintain records of all such bans so that
+  they may be reviewed in the future or otherwise maintained.
+
+Once a resolution is agreed upon, but before it is enacted, the committee will
+contact the original reporter and any other affected parties and explain the
+proposed resolution. The committee will ask if this resolution is acceptable,
+and must note feedback for the record. However, the committee is not required to
+act on this feedback.
+
+Finally, the committee will make a report to the SciPy Steering Council (as
+well as the SciPy core team in the event of an ongoing resolution, such as a
+ban).
+
+The committee will never publicly discuss the issue; all public statements will
+be made by the chair of the Code of Conduct Committee or the SciPy Steering
+Council.
+
+
+## Conflicts of Interest
+
+In the event of any conflict of interest, a committee member must immediately
+notify the other members, and recuse themselves if necessary.

--- a/doc/source/dev/conduct/faq.md
+++ b/doc/source/dev/conduct/faq.md
@@ -1,0 +1,59 @@
+# SciPy Code of Conduct - Frequently Asked Questions
+
+This FAQ attempts to address common questions and concerns around the SciPy
+community's Code of Conduct. If you still have questions after reading it,
+please feel free to contact us at *TODO: email address*.
+
+### Why have you adopted a Code of Conduct?
+
+We think the SciPy community is awesome. If you're familiar with the SciPy
+community, you'll probably notice that the Code basically matches what we
+already do. Think of this as documentation: we're taking implicit expectations
+about behavior and making them explicit.
+
+SciPy has grown past the point where it's possible to know the whole community,
+and we think it's very important to be clear about our values.
+
+We know that the SciPy community is open, friendly, and welcoming. We want to
+make sure everyone else knows it too.
+
+### What does it mean to "adopt" a Code of Conduct?
+
+For the most part, we don't think it means large changes. We think that the text
+does a really good job describing the way the SciPy community already conducts
+itself. We expect that most people will simply continue to behave as they have
+in the past.
+
+However, we do expect that people will abide by the spirit and words of the Code
+of Conduct when in "official" SciPy spaces.  In practice, SciPy spaces include
+mailing lists, GitHub repositories and various other communication channels.
+
+### What happens if someone violates the Code of Conduct?
+
+We are all stewards of our community, and are encouraged to participate in ways
+that defend the values highlighted in this document and help others understand
+when their actions go against these values (by engaging them and directing them
+to this document if necessary). If that doesn't work, or if you need more help,
+you can contact *TODO: email address*. For more details please see our [Reporting
+Guidelines](*reporting.md*).
+
+### Why do we need a Code of Conduct? Everyone knows not to be a jerk.
+
+Sadly, not everyone knows this.
+
+However, even if everyone was kind, everyone was compassionate, and everyone was
+familiar with codes of conduct it would still be incumbent upon our community to
+publish our own. Maintaining a Code of Conduct forces us to consider and
+articulate what kind of community we want to be, and serves as a constant
+reminder to put our best foot forward. But most importantly, it serves as a
+signpost to people looking to join our community that we feel these values are
+important.
+
+### This is censorship! I have the right to say whatever I want!
+
+You do -- in your space. If you'd like to hang out in our spaces, we have some
+simple guidelines to follow. If you want to, for example, form a group where
+SciPy is discussed using language inappropriate for general channels then
+nobody's stopping you. We respect your right to establish whatever codes of
+conduct you want in the spaces that belong to you. Please honor this Code of
+Conduct in our spaces.

--- a/doc/source/dev/conduct/reporting.md
+++ b/doc/source/dev/conduct/reporting.md
@@ -1,0 +1,65 @@
+# SciPy Code of Conduct - Reporting Guide - Online Community
+
+If you believe someone is violating the code of conduct we ask that you report
+it to SciPy by emailing *TODO email address* or alternatively by contacting
+the NumFOCUS reporting contact (https://www.numfocus.org/about/code-of-conduct/).
+All reports will be kept confidential.
+In some cases we may determine that a public statement will need
+to be made. If that's the case, the identities of all involved will remain
+confidential unless those individuals instruct us otherwise.
+
+If you believe anyone is in physical danger, please notify appropriate law
+enforcement first. If you are unsure what law enforcement agency is appropriate,
+please include this in your report and we will attempt to notify them.
+
+Please include the following information:
+
+* Your contact info (not required, if you would like to remain anonymous please
+  use the form)
+* Names (real, nicknames, or pseudonyms) of any individuals involved. If there
+  were other witnesses besides you, try to include them as well
+* When and where the incident occurred. Please be as specific as possible.
+* Your account of what occurred. If there is a publicly available record (e.g. a
+  mailing list archive or GitHub/gitter.im) please include a link
+* Any extra context you believe exists for the incident
+* If you believe this incident is ongoing
+* Any other information you believe we should have
+
+*Note:* with anonymous reports, there are inherent limits in our ability to do
+follow-up or collect additional information.  Hence we suggest that if you
+would like to remain anonymous, you at least create a throw-away email address
+without your real name.
+
+## What happens after you file a report?
+
+You will receive an email from the SciPy Code of Conduct Committee
+acknowledging receipt immediately. We promise to acknowledge receipt within 72
+hours (and will aim for much quicker than that).
+
+The working group will immediately meet to review the incident and determine:
+* What happened
+* Whether this event constitutes a Code of Conduct violation
+* Who the individual(s) involved were
+* Whether this is an ongoing situation, or if there is a threat to anyone's
+  physical safety
+
+If this is determined to be an ongoing incident or a threat to physical safety,
+the committee's immediate priority will be to protect everyone involved. This
+means we may delay an "official" response until we believe that the situation
+has ended and that everyone is physically safe.
+
+The Code of Conduct committee will then follow the
+[standard procedure][enforcement.md#Resolutions] to arrive at and
+communicate a resolution.
+
+
+## Appealing the Code of Conduct Committee’s Response
+
+To appeal a decision of the Code of Conduct Committee, contact the SciPy
+Steering Council at
+[*scipy-core-dev-team@googlegroups.com*](mailto:scipy-core-dev-team@googlegroups.com)
+with your appeal and they will review the case.
+
+The Steering Council will gather all relevant information from the Committee
+and provide a resolution within two weeks.  If more time is required, it should
+inform the appellant within that time frame.


### PR DESCRIPTION
*Main discussion for this on the mailing list*.

To be done:

- [ ] decide what email address to use (conduct@scipy.org may be hard to set up or taken by the SciPy conference).
- [ ] move this from Markdown to reST and integrate with the rest of the docs
- [ ] add a top-level ``CODE_OF_CONDUCT`` file which links to this content