### PR TITLE
Add the _sf and _logsf function for planck dist

### DIFF
--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -529,6 +529,13 @@ class planck_gen(rv_discrete):
         k = floor(x)
         return 1-exp(-lambda_*(k+1))
 
+    def _sf(self, x, lambda_):
+        return np.exp(self._logsf(x, lambda_))
+
+    def _logsf(self, x, lambda_):
+        k = floor(x)
+        return -lambda_*(k+1)
+
     def _ppf(self, q, lambda_):
         vals = ceil(-1.0/lambda_ * log1p(-q)-1)
         vals1 = (vals-1).clip(self.a, np.inf)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -341,6 +341,21 @@ class TestGeom(object):
         assert_array_almost_equal(vals, expected)
 
 
+class TestPlanck(object):
+    def setup_method(self):
+        np.random.seed(1234)
+
+    def test_sf(self):
+        vals = stats.planck.sf([1, 2, 3], 5.)
+        expected = array([4.5399929762484854e-05, 3.0590232050182579e-07, 2.0611536224385579e-09])
+        assert_array_almost_equal(vals, expected)
+
+    def test_logsf(self):
+        vals = stats.planck.logsf([1000., 2000., 3000.], 1000.)
+        expected = array([-1001000., -2001000., -3001000.])
+        assert_array_almost_equal(vals, expected)
+
+
 class TestGennorm(object):
     def test_laplace(self):
         # test against Laplace (special case for beta=1)


### PR DESCRIPTION
Add the _sf and _logsf function for planck dist

Bugfix: Add the _sf and _logsf function for planck dist

=======
Reprise of bug:

from scipy.stats import planck
planck.logsf(1000, 1000)

Incorrect Output: -inf
Revised Output: -11000000

=======
Why there is a bug:

Originally, planck only has CDF function, which is defined as 1-exp(-lambda_*(k+1)). When sf and logsf is needed, the codes in rv_generic._sf() uses 1.0-self._cdf(x, *args) to calculate sf, and rv_generic._logsf() uses log(self._sf(x, *args)) to calculate logsf.

However, when the k is very large, exp(-lambda_*(k+1)) is very small (close to 0), so 1-exp(-lambda_*(k+1)) becomes 1 (actually smaller than 1, but presented as exactly 1 in Python). Then sf becomes 0 since it is defined as (1-cdf), and logsf return -inf since it tries to calculate log(0).

=======
Resolve:
Add the _sf and _logsf function to calculate SF and logSF directly.