### PR TITLE
DOC: Replace rotten links in the docstring of minres

### DIFF
--- a/scipy/sparse/linalg/isolve/minres.py
+++ b/scipy/sparse/linalg/isolve/minres.py
@@ -31,10 +31,10 @@ References
 Solution of sparse indefinite systems of linear equations,
     C. C. Paige and M. A. Saunders (1975),
     SIAM J. Numer. Anal. 12(4), pp. 617-629.
-    http://www.stanford.edu/group/SOL/software/minres.html
+    https://web.stanford.edu/group/SOL/software/minres/
 
 This file is a translation of the following MATLAB implementation:
-    http://www.stanford.edu/group/SOL/software/minres/matlab/
+    https://web.stanford.edu/group/SOL/software/minres/minres-matlab.zip
 """
 
 


### PR DESCRIPTION
There are two links in the docstring of `scipy.sparse.linalg.minres` that are now broken. This PR provides a fix, but I'm not sure this is the best solution.

The first link refers to the source project website, but in the context of a publication. I updated the link to the project website, but maybe it would make more sense to link to the publication itself [which is also hosted on the project website](https://web.stanford.edu/group/SOL/software/symmlq/PS75.pdf) along with three other potential references. Pro: the link in the docstring would refer to the publication as the context would suggest. Con: linking to a specific pdf file seems more likely to rot again in the future.

The second link referred to the specific implementation which was translated to scipy. I replaced this with a direct link to the matlab package (a zip file), it seems likely that the original link had a separate webpage. This again might not be the best solution, pros and cons are the same as with link 1 (specificity is good, link rot is bad).

Perhaps these linked references should be rewritten altogether, with
 1. a link to the publication
 2. a link the project
 3. an explanation that the "original MATLAB" implementation formed the basis of the scipy version.

On a related note, there is also a huge shouting warning in the docstring that goes
> THIS FUNCTION IS EXPERIMENTAL AND SUBJECT TO CHANGE!

I find this pretty weird (and frankly, somewhat off-putting), and [I couldn't find similar warnings elsewhere](https://github.com/scipy/scipy/search?p=1&q=experimental&type=&utf8=%E2%9C%93). While we're at it, perhaps we should address this too.