### PR TITLE
MAINT: set rcond explicitly for np.linalg.lstsq calls

### DIFF
--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -1093,7 +1093,7 @@ class TestLSQ(object):
 
         # also check against numpy.lstsq
         aa, yy = AY
-        c1, _, _, _ = np.linalg.lstsq(aa, y)
+        c1, _, _, _ = np.linalg.lstsq(aa, y, rcond=-1)
         assert_allclose(b.c, c1)
 
     def test_weights(self):

--- a/scipy/optimize/_lsq/bvls.py
+++ b/scipy/optimize/_lsq/bvls.py
@@ -66,7 +66,7 @@ def bvls(A, b, x_lsq, lb, ub, tol, max_iter, verbose):
 
         A_free = A[:, free_set]
         b_free = b - A.dot(x * active_set)
-        z = lstsq(A_free, b_free)[0]
+        z = lstsq(A_free, b_free, rcond=-1)[0]
 
         lbv = z < lb[free_set]
         ubv = z > ub[free_set]
@@ -132,7 +132,7 @@ def bvls(A, b, x_lsq, lb, ub, tol, max_iter, verbose):
 
         A_free = A[:, free_set]
         b_free = b - A.dot(x * active_set)
-        z = lstsq(A_free, b_free)[0]
+        z = lstsq(A_free, b_free, rcond=-1)[0]
 
         lbv, = np.nonzero(z < lb_free)
         ubv, = np.nonzero(z > ub_free)

--- a/scipy/optimize/_lsq/dogbox.py
+++ b/scipy/optimize/_lsq/dogbox.py
@@ -222,7 +222,7 @@ def dogbox(fun, jac, x0, f0, J0, lb, ub, ftol, xtol, gtol, max_nfev, x_scale,
         # Compute (Gauss-)Newton and build quadratic model for Cauchy step.
         if tr_solver == 'exact':
             J_free = J[:, free_set]
-            newton_step = lstsq(J_free, -f)[0]
+            newton_step = lstsq(J_free, -f, rcond=-1)[0]
 
             # Coefficients for the quadratic model along the anti-gradient.
             a, b = build_quadratic_1d(J_free, g_free, -g_free)

--- a/scipy/optimize/_lsq/lsq_linear.py
+++ b/scipy/optimize/_lsq/lsq_linear.py
@@ -2,7 +2,7 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.linalg import norm, lstsq
+from numpy.linalg import norm
 from scipy.sparse import issparse, csr_matrix
 from scipy.sparse.linalg import LinearOperator, lsmr
 from scipy.optimize import OptimizeResult
@@ -275,7 +275,7 @@ def lsq_linear(A, b, bounds=(-np.inf, np.inf), method='trf', tol=1e-10,
                          "upper bound.")
 
     if lsq_solver == 'exact':
-        x_lsq = np.linalg.lstsq(A, b)[0]
+        x_lsq = np.linalg.lstsq(A, b, rcond=-1)[0]
     elif lsq_solver == 'lsmr':
         x_lsq = lsmr(A, b, atol=tol, btol=tol)[0]
 

--- a/scipy/optimize/tests/test_lsq_linear.py
+++ b/scipy/optimize/tests/test_lsq_linear.py
@@ -22,7 +22,7 @@ class BaseMixin(object):
     def test_dense_no_bounds(self):
         for lsq_solver in self.lsq_solvers:
             res = lsq_linear(A, b, method=self.method, lsq_solver=lsq_solver)
-            assert_allclose(res.x, lstsq(A, b)[0])
+            assert_allclose(res.x, lstsq(A, b, rcond=-1)[0])
 
     def test_dense_bounds(self):
         # Solutions for comparison are taken from MATLAB.
@@ -31,7 +31,7 @@ class BaseMixin(object):
         for lsq_solver in self.lsq_solvers:
             res = lsq_linear(A, b, (lb, ub), method=self.method,
                              lsq_solver=lsq_solver)
-            assert_allclose(res.x, lstsq(A, b)[0])
+            assert_allclose(res.x, lstsq(A, b, rcond=-1)[0])
 
         lb = np.array([0.0, -np.inf])
         for lsq_solver in self.lsq_solvers:

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -2935,7 +2935,7 @@ def place_poles(A, B, poles, method="YT", rtol=1e-3, maxiter=30):
                 diag_poles[idx+1, idx] = np.imag(p)
                 idx += 1  # skip next one
             idx += 1
-        gain_matrix = np.linalg.lstsq(B, diag_poles-A)[0]
+        gain_matrix = np.linalg.lstsq(B, diag_poles-A, rcond=-1)[0]
         transfer_matrix = np.eye(A.shape[0])
         cur_rtol = np.nan
         nb_iter = np.nan

--- a/scipy/sparse/linalg/isolve/tests/test_lgmres.py
+++ b/scipy/sparse/linalg/isolve/tests/test_lgmres.py
@@ -163,7 +163,7 @@ class TestLGMRES(object):
             resp = np.linalg.norm(A.dot(xp) - b)
 
             K = np.c_[b, A.dot(b), A.dot(A.dot(b)), A.dot(A.dot(A.dot(b)))]
-            y, _, _, _ = np.linalg.lstsq(A.dot(K), b)
+            y, _, _, _ = np.linalg.lstsq(A.dot(K), b, rcond=-1)
             x = K.dot(y)
             res = np.linalg.norm(A.dot(x) - b)
 


### PR DESCRIPTION
Numpy will change the default value from the old default rcond=-1 to a
different value in the future. Here, we keep explicitly using the old
default value, which has worked so far.

Fixes gh-7772

See https://github.com/numpy/numpy/pull/9582