### PR TITLE
remove leftover `nose` imports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -118,7 +118,7 @@ before_install:
   # Need to install Cython 0.23.4 from source to avoid errors for Python 3.6
   - travis_retry pip install --install-option="--no-cython-compile" Cython==0.23.4
   - travis_retry pip install $NUMPYSPEC
-  - travis_retry pip install pytest pytest-xdist pytest-faulthandler nose mpmath argparse Pillow codecov
+  - travis_retry pip install pytest pytest-xdist pytest-faulthandler mpmath argparse Pillow codecov
   - travis_retry pip install --upgrade pip setuptools
   - travis_retry pip install gmpy2  # speeds up mpmath (scipy.special tests)
   - if [ "${TESTMODE}" == "full" ]; then pip install pytest-cov coverage; fi

--- a/scipy/_lib/_numpy_compat.py
+++ b/scipy/_lib/_numpy_compat.py
@@ -13,28 +13,6 @@ import numpy as np
 from scipy._lib._version import NumpyVersion
 
 
-def import_nose():
-    """ Import nose only when needed.
-    """
-    nose_is_good = True
-    minimum_nose_version = (1, 0, 0)
-    try:
-        import nose
-    except ImportError:
-        nose_is_good = False
-    else:
-        if nose.__versioninfo__ < minimum_nose_version:
-            nose_is_good = False
-
-    if not nose_is_good:
-        msg = ('Need nose >= %d.%d.%d for tests - see '
-               'http://nose.readthedocs.io' %
-               minimum_nose_version)
-        raise ImportError(msg)
-
-    return nose
-
-
 if NumpyVersion(np.__version__) > '1.7.0.dev':
     _assert_warns = np.testing.assert_warns
 else:
@@ -71,31 +49,6 @@ else:
                 raise AssertionError("First warning for %s is not a "
                         "%s( is %s)" % (func.__name__, warning_class, l[0]))
         return result
-
-
-def assert_raises_regex(exception_class, expected_regexp,
-                        callable_obj=None, *args, **kwargs):
-    """
-    Fail unless an exception of class exception_class and with message that
-    matches expected_regexp is thrown by callable when invoked with arguments
-    args and keyword arguments kwargs.
-    Name of this function adheres to Python 3.2+ reference, but should work in
-    all versions down to 2.6.
-    Notes
-    -----
-    .. versionadded:: 1.8.0
-    """
-    __tracebackhide__ = True  # Hide traceback for py.test
-    nose = import_nose()
-
-    if sys.version_info.major >= 3:
-        funcname = nose.tools.assert_raises_regex
-    else:
-        # Only present in Python 2.7, missing from unittest in 2.6
-            funcname = nose.tools.assert_raises_regexp
-
-    return funcname(exception_class, expected_regexp, callable_obj,
-                    *args, **kwargs)
 
 
 if NumpyVersion(np.__version__) >= '1.10.0':

--- a/scipy/_lib/tests/test__gcutils.py
+++ b/scipy/_lib/tests/test__gcutils.py
@@ -6,8 +6,9 @@ import gc
 
 from scipy._lib._gcutils import set_gc_state, gc_state, assert_deallocated, ReferenceError
 
-from nose.tools import assert_equal, raises
+from numpy.testing import assert_equal
 
+import pytest
 
 def test_set_gc_state():
     gc_status = gc.isenabled()
@@ -63,30 +64,30 @@ def test_assert_deallocated():
             assert_equal(gc.isenabled(), gc_current)
 
 
-@raises(ReferenceError)
 def test_assert_deallocated_nodel():
     class C(object):
         pass
-    # Need to delete after using if in with-block context
-    with assert_deallocated(C) as c:
-        pass
+    with pytest.raises(ReferenceError):
+        # Need to delete after using if in with-block context
+        with assert_deallocated(C) as c:
+            pass
 
 
-@raises(ReferenceError)
 def test_assert_deallocated_circular():
     class C(object):
         def __init__(self):
             self._circular = self
-    # Circular reference, no automatic garbage collection
-    with assert_deallocated(C) as c:
-        del c
+    with pytest.raises(ReferenceError):
+        # Circular reference, no automatic garbage collection
+        with assert_deallocated(C) as c:
+            del c
 
 
-@raises(ReferenceError)
 def test_assert_deallocated_circular2():
     class C(object):
         def __init__(self):
             self._circular = self
-    # Still circular reference, no automatic garbage collection
-    with assert_deallocated(C):
-        pass
+    with pytest.raises(ReferenceError):
+        # Still circular reference, no automatic garbage collection
+        with assert_deallocated(C):
+            pass

--- a/scipy/_lib/tests/test__threadsafety.py
+++ b/scipy/_lib/tests/test__threadsafety.py
@@ -4,7 +4,8 @@ import threading
 import time
 import traceback
 
-from numpy.testing import assert_raises, assert_
+from numpy.testing import assert_
+from pytest import raises as assert_raises
 
 from scipy._lib._threadsafety import ReentrancyLock, non_reentrant, ReentrancyError
 

--- a/scipy/_lib/tests/test__util.py
+++ b/scipy/_lib/tests/test__util.py
@@ -1,7 +1,8 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import assert_equal, assert_, assert_raises
+from numpy.testing import assert_equal, assert_
+from pytest import raises as assert_raises
 
 from scipy._lib._util import _aligned_zeros, check_random_state
 

--- a/scipy/_lib/tests/test__version.py
+++ b/scipy/_lib/tests/test__version.py
@@ -1,4 +1,7 @@
-from numpy.testing import assert_, assert_raises
+from __future__ import division, absolute_import, print_function
+
+from numpy.testing import assert_
+from pytest import raises as assert_raises
 from scipy._lib._version import NumpyVersion
 
 

--- a/scipy/_lib/tests/test_ccallback.py
+++ b/scipy/_lib/tests/test_ccallback.py
@@ -1,6 +1,7 @@
 from __future__ import division, print_function, absolute_import
 
-from numpy.testing import assert_equal, assert_raises, assert_
+from numpy.testing import assert_equal, assert_
+from pytest import raises as assert_raises
 
 import time
 import pytest

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -34,9 +34,9 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import (assert_raises,
-                           assert_allclose, assert_equal, assert_, assert_warns)
+from numpy.testing import assert_allclose, assert_equal, assert_, assert_warns
 import pytest
+from pytest import raises as assert_raises
 
 from scipy._lib.six import xrange, u
 

--- a/scipy/cluster/tests/test_vq.py
+++ b/scipy/cluster/tests/test_vq.py
@@ -6,10 +6,10 @@ import sys
 
 import numpy as np
 from numpy.testing import (assert_array_equal, assert_array_almost_equal,
-    assert_raises, assert_allclose, assert_equal,
-    assert_)
+    assert_allclose, assert_equal, assert_)
 from scipy._lib._numpy_compat import suppress_warnings
 import pytest
+from pytest import raises as assert_raises
 
 from scipy.cluster.vq import (kmeans, kmeans2, py_vq, vq, whiten,
     ClusterError, _krandinit)

--- a/scipy/fftpack/tests/test_basic.py
+++ b/scipy/fftpack/tests/test_basic.py
@@ -12,9 +12,9 @@ Run tests if fftpack is not installed:
 """
 
 from numpy.testing import (assert_equal, assert_array_almost_equal,
-        assert_array_almost_equal_nulp, assert_raises,
-        assert_array_less)
+        assert_array_almost_equal_nulp, assert_array_less)
 import pytest
+from pytest import raises as assert_raises
 from scipy.fftpack import ifft,fft,fftn,ifftn,rfft,irfft, fft2
 from scipy.fftpack import _fftpack as fftpack
 from scipy.fftpack.basic import _is_safe_size

--- a/scipy/integrate/tests/test_bvp.py
+++ b/scipy/integrate/tests/test_bvp.py
@@ -9,7 +9,9 @@ except ImportError:
 
 import numpy as np
 from numpy.testing import (assert_, assert_array_equal, assert_allclose,
-                           assert_raises, assert_equal)
+                           assert_equal)
+from pytest import raises as assert_raises
+
 from scipy.sparse import coo_matrix
 from scipy.special import erf
 from scipy.integrate._bvp import (modify_mesh, estimate_fun_jac,

--- a/scipy/integrate/tests/test_integrate.py
+++ b/scipy/integrate/tests/test_integrate.py
@@ -13,7 +13,8 @@ from scipy._lib.six import xrange
 
 from numpy.testing import (
     assert_, assert_array_almost_equal,
-    assert_raises, assert_allclose, assert_array_equal, assert_equal)
+    assert_allclose, assert_array_equal, assert_equal)
+from pytest import raises as assert_raises
 from scipy.integrate import odeint, ode, complex_ode
 
 #------------------------------------------------------------------------------

--- a/scipy/integrate/tests/test_ivp.py
+++ b/scipy/integrate/tests/test_ivp.py
@@ -1,7 +1,8 @@
 from __future__ import division, print_function, absolute_import
 from itertools import product
 from numpy.testing import (assert_, assert_allclose,
-                           assert_equal, assert_raises, assert_no_warnings)
+                           assert_equal, assert_no_warnings)
+from pytest import raises as assert_raises
 from scipy._lib._numpy_compat import suppress_warnings
 import numpy as np
 from scipy.optimize._numdiff import group_columns

--- a/scipy/integrate/tests/test_quadpack.py
+++ b/scipy/integrate/tests/test_quadpack.py
@@ -5,8 +5,9 @@ import math
 import numpy as np
 from numpy import sqrt, cos, sin, arctan, exp, log, pi, Inf
 from numpy.testing import (assert_,
-        assert_allclose, assert_array_less, assert_almost_equal, assert_raises)
+        assert_allclose, assert_array_less, assert_almost_equal)
 import pytest
+from pytest import raises as assert_raises
 
 from scipy.integrate import quad, dblquad, tplquad, nquad
 from scipy._lib.six import xrange

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -1,9 +1,9 @@
 from __future__ import division, absolute_import, print_function
 
 import numpy as np
-from numpy.testing import (assert_equal,
-        assert_allclose, assert_raises, assert_)
-from scipy._lib._numpy_compat import assert_raises_regex, suppress_warnings
+from numpy.testing import assert_equal, assert_allclose, assert_
+from scipy._lib._numpy_compat import suppress_warnings
+from pytest import raises as assert_raises
 import pytest
 
 from scipy.interpolate import (BSpline, BPoly, PPoly, make_interp_spline,
@@ -624,12 +624,16 @@ class TestInterop(object):
         x, y = self.xx, self.yy
         y2 = np.c_[y, y]
         msg = "failed in converting 3rd argument `y' of dfitpack.curfit to C/Fortran array"
-        assert_raises_regex(Exception, msg, splrep, x, y2)
-        assert_raises_regex(Exception, msg, _impl.splrep, x, y2)
+        with assert_raises(Exception, message=msg):
+            splrep(x, y2)
+        with assert_raises(Exception, message=msg):
+            _impl.splrep(x, y2)
 
         # input below minimum size
-        assert_raises_regex(TypeError, "m > k must hold", splrep, x[:3], y[:3])
-        assert_raises_regex(TypeError, "m > k must hold", _impl.splrep, x[:3], y[:3])
+        with assert_raises(TypeError, message="m > k must hold"):
+            splrep(x[:3], y[:3])
+        with assert_raises(TypeError, message="m > k must hold"):
+            _impl.splrep(x[:3], y[:3])
 
     def test_splprep(self):
         x = np.arange(15).reshape((3, 5))
@@ -649,25 +653,31 @@ class TestInterop(object):
     def test_splprep_errors(self):
         # test that both "old" and "new" code paths raise for x.ndim > 2
         x = np.arange(3*4*5).reshape((3, 4, 5))
-        assert_raises_regex(ValueError, "too many values to unpack", splprep, x)
-        assert_raises_regex(ValueError, "too many values to unpack", _impl.splprep, x)
+        with assert_raises(ValueError, message="too many values to unpack"):
+            splprep(x)
+        with assert_raises(ValueError, message="too many values to unpack"):
+            _impl.splprep(x)
 
         # input below minimum size
         x = np.linspace(0, 40, num=3)
-        assert_raises_regex(TypeError, "m > k must hold", splprep, [x])
-        assert_raises_regex(TypeError, "m > k must hold", _impl.splprep, [x])
+        with assert_raises(TypeError, message="m > k must hold"):
+            splprep([x])
+        with assert_raises(TypeError, message="m > k must hold"):
+            _impl.splprep([x])
 
         # automatically calculated parameters are non-increasing
         # see gh-7589
         x = [-50.49072266, -50.49072266, -54.49072266, -54.49072266]
-        assert_raises_regex(ValueError, "Invalid inputs", splprep, [x])
-        assert_raises_regex(ValueError, "Invalid inputs", _impl.splprep, [x])
+        with assert_raises(ValueError, message="Invalid inputs"):
+            splprep([x])
+        with assert_raises(ValueError, message="Invalid inputs"):
+            _impl.splprep([x])
 
         # given non-increasing parameter values u
         x = [1, 3, 2, 4]
         u = [0, 0.3, 0.2, 1]
-        assert_raises_regex(ValueError, "Invalid inputs", splprep,
-                            *[[x], None, u])
+        with assert_raises(ValueError, message="Invalid inputs"):
+            splprep(*[[x], None, u])
 
     def test_sproot(self):
         b, b2 = self.b, self.b2

--- a/scipy/interpolate/tests/test_fitpack.py
+++ b/scipy/interpolate/tests/test_fitpack.py
@@ -4,8 +4,9 @@ import os
 
 import numpy as np
 from numpy.testing import (assert_equal, assert_allclose, assert_,
-    assert_raises, assert_almost_equal,
-    assert_raises, assert_array_almost_equal)
+                           assert_almost_equal, assert_array_almost_equal)
+from pytest import raises as assert_raises
+
 from numpy import array, asarray, pi, sin, cos, arange, dot, ravel, sqrt, round
 from scipy import interpolate
 from scipy.interpolate.fitpack import (splrep, splev, bisplrep, bisplev,

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -3,8 +3,10 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 from numpy.testing import (assert_equal, assert_almost_equal, assert_array_equal,
-        assert_array_almost_equal, assert_allclose, assert_raises)
+        assert_array_almost_equal, assert_allclose)
 from scipy._lib._numpy_compat import suppress_warnings
+from pytest import raises as assert_raises
+
 from numpy import array, diff, linspace, meshgrid, ones, pi, shape
 from scipy.interpolate.fitpack import bisplrep, bisplev
 from scipy.interpolate.fitpack2 import (UnivariateSpline,

--- a/scipy/interpolate/tests/test_interpnd.py
+++ b/scipy/interpolate/tests/test_interpnd.py
@@ -3,8 +3,8 @@ from __future__ import division, print_function, absolute_import
 import os
 
 import numpy as np
-from numpy.testing import assert_equal, assert_allclose, assert_almost_equal, \
-        assert_raises
+from numpy.testing import assert_equal, assert_allclose, assert_almost_equal
+from pytest import raises as assert_raises
 from scipy._lib._numpy_compat import suppress_warnings
 
 import scipy.interpolate.interpnd as interpnd

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -3,8 +3,10 @@ from __future__ import division, print_function, absolute_import
 import itertools
 
 from numpy.testing import (assert_, assert_equal, assert_almost_equal,
-        assert_array_almost_equal, assert_raises, assert_array_equal,
+        assert_array_almost_equal, assert_array_equal,
         dec, assert_allclose)
+from pytest import raises as assert_raises
+
 from numpy import mgrid, pi, sin, ogrid, poly1d, linspace
 import numpy as np
 

--- a/scipy/interpolate/tests/test_ndgriddata.py
+++ b/scipy/interpolate/tests/test_ndgriddata.py
@@ -1,8 +1,8 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import (assert_equal, assert_array_equal, assert_allclose,
-        assert_raises)
+from numpy.testing import assert_equal, assert_array_equal, assert_allclose
+from pytest import raises as assert_raises
 
 from scipy.interpolate import griddata, NearestNDInterpolator
 

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -6,8 +6,8 @@ import numpy as np
 
 from numpy.testing import (
     assert_almost_equal, assert_array_equal, assert_array_almost_equal,
-    assert_allclose, assert_equal, assert_,
-    assert_raises)
+    assert_allclose, assert_equal, assert_)
+from pytest import raises as assert_raises
 
 from scipy.interpolate import (
     KroghInterpolator, krogh_interpolate,

--- a/scipy/io/arff/tests/test_arffread.py
+++ b/scipy/io/arff/tests/test_arffread.py
@@ -13,9 +13,9 @@ else:
 import numpy as np
 
 from numpy.testing import (assert_array_almost_equal,
-                           assert_array_equal, assert_equal, assert_,
-                           assert_raises)
+                           assert_array_equal, assert_equal, assert_)
 import pytest
+from pytest import raises as assert_raises
 
 from scipy.io.arff.arffread import loadarff
 from scipy.io.arff.arffread import read_header, parse_type, ParseArffError

--- a/scipy/io/harwell_boeing/tests/test_fortran_format.py
+++ b/scipy/io/harwell_boeing/tests/test_fortran_format.py
@@ -2,11 +2,12 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 
-from numpy.testing import assert_equal, assert_raises
+from numpy.testing import assert_equal
+from pytest import raises as assert_raises
 
-from scipy.io.harwell_boeing._fortran_format_parser import \
-        FortranFormatParser, IntFormat, ExpFormat, BadFortranFormat, \
-        number_digits
+from scipy.io.harwell_boeing._fortran_format_parser import (
+        FortranFormatParser, IntFormat, ExpFormat, BadFortranFormat,
+        number_digits)
 
 
 class TestFortranFormatParser(object):

--- a/scipy/io/matlab/tests/test_byteordercodes.py
+++ b/scipy/io/matlab/tests/test_byteordercodes.py
@@ -4,7 +4,8 @@ from __future__ import division, print_function, absolute_import
 
 import sys
 
-from numpy.testing import assert_raises, assert_
+from numpy.testing import assert_
+from pytest import raises as assert_raises
 
 import scipy.io.matlab.byteordercodes as sibc
 

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -19,8 +19,8 @@ import shutil
 import gzip
 
 from numpy.testing import (assert_array_equal, assert_array_almost_equal,
-                           assert_equal, assert_raises,
-                           assert_)
+                           assert_equal, assert_)
+from pytest import raises as assert_raises
 from scipy._lib._numpy_compat import suppress_warnings
 
 import numpy as np

--- a/scipy/io/matlab/tests/test_mio5_utils.py
+++ b/scipy/io/matlab/tests/test_mio5_utils.py
@@ -10,8 +10,8 @@ cStringIO = BytesIO
 
 import numpy as np
 
-from numpy.testing import (assert_array_equal, assert_equal, assert_raises,
-                           assert_)
+from numpy.testing import assert_array_equal, assert_equal, assert_
+from pytest import raises as assert_raises
 
 from scipy._lib.six import u
 

--- a/scipy/io/matlab/tests/test_mio5_utils.py
+++ b/scipy/io/matlab/tests/test_mio5_utils.py
@@ -10,9 +10,8 @@ cStringIO = BytesIO
 
 import numpy as np
 
-from nose.tools import (assert_true, assert_equal, assert_raises)
-
-from numpy.testing import (assert_array_equal)
+from numpy.testing import (assert_array_equal, assert_equal, assert_raises,
+                           assert_)
 
 from scipy._lib.six import u
 
@@ -152,7 +151,7 @@ def test_read_numeric_writeable():
     a_str = a.tostring()
     _write_stream(str_io, a_str)
     el = c_reader.read_numeric()
-    assert_true(el.flags.writeable)
+    assert_(el.flags.writeable is True)
 
 
 def test_zero_byte_string():

--- a/scipy/io/matlab/tests/test_miobase.py
+++ b/scipy/io/matlab/tests/test_miobase.py
@@ -3,7 +3,8 @@
 
 import numpy as np
 
-from numpy.testing import assert_raises, assert_equal
+from numpy.testing import assert_equal
+from pytest import raises as assert_raises
 
 from scipy.io.matlab.miobase import matdims
 

--- a/scipy/io/matlab/tests/test_pathological.py
+++ b/scipy/io/matlab/tests/test_pathological.py
@@ -6,7 +6,8 @@ from __future__ import division, print_function, absolute_import
 
 from os.path import dirname, join as pjoin
 
-from numpy.testing import assert_, assert_raises
+from numpy.testing import assert_
+from pytest import raises as assert_raises
 
 from scipy.io.matlab.mio import loadmat
 

--- a/scipy/io/matlab/tests/test_streams.py
+++ b/scipy/io/matlab/tests/test_streams.py
@@ -20,11 +20,12 @@ from contextlib import contextmanager
 
 import numpy as np
 
-from numpy.testing import (assert_, assert_equal, assert_raises)
+from numpy.testing import assert_, assert_equal
+from pytest import raises as assert_raises
 
-from scipy.io.matlab.streams import make_stream, \
-    GenericStream, cStringStream, FileStream, ZlibInputStream, \
-    _read_into, _read_string
+from scipy.io.matlab.streams import (make_stream,
+    GenericStream, cStringStream, FileStream, ZlibInputStream,
+    _read_into, _read_string)
 
 
 @contextmanager

--- a/scipy/io/tests/test_mmio.py
+++ b/scipy/io/tests/test_mmio.py
@@ -7,8 +7,8 @@ import shutil
 import numpy as np
 from numpy import array, transpose, pi
 from numpy.testing import (assert_equal,
-                           assert_array_equal, assert_array_almost_equal,
-                           assert_raises)
+                           assert_array_equal, assert_array_almost_equal)
+from pytest import raises as assert_raises
 
 import scipy.sparse
 from scipy.io.mmio import mminfo, mmread, mmwrite

--- a/scipy/io/tests/test_netcdf.py
+++ b/scipy/io/tests/test_netcdf.py
@@ -356,7 +356,7 @@ def test_append_recordDimension():
         with netcdf_file('withRecordDimension.nc') as f:
             with assert_raises(KeyError) as ar:            
                 f.variables['testData']._attributes['data']
-            ex = ar.exception
+            ex = ar.value
             assert_equal(ex.args[0], 'data')
 
 def test_maskandscale():

--- a/scipy/io/tests/test_netcdf.py
+++ b/scipy/io/tests/test_netcdf.py
@@ -11,8 +11,8 @@ from glob import glob
 from contextlib import contextmanager
 
 import numpy as np
-from numpy.testing import (assert_, assert_allclose, assert_raises,
-    assert_equal)
+from numpy.testing import assert_, assert_allclose, assert_equal
+from pytest import raises as assert_raises
 
 from scipy.io.netcdf import netcdf_file
 

--- a/scipy/io/tests/test_wavfile.py
+++ b/scipy/io/tests/test_wavfile.py
@@ -6,8 +6,8 @@ import tempfile
 from io import BytesIO
 
 import numpy as np
-from numpy.testing import (assert_equal, assert_, assert_raises,
-    assert_array_equal)
+from numpy.testing import assert_equal, assert_, assert_array_equal
+from pytest import raises as assert_raises
 from scipy._lib._numpy_compat import suppress_warnings
 
 from scipy.io import wavfile

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -14,11 +14,11 @@ from numpy import (arange, array, dot, zeros, identity, conjugate, transpose,
 import numpy.linalg as linalg
 from numpy.random import random
 
-from numpy.testing import (assert_raises,
-                           assert_equal, assert_almost_equal, assert_,
+from numpy.testing import (assert_equal, assert_almost_equal, assert_,
                            assert_array_almost_equal, assert_allclose,
                            assert_array_equal)
 import pytest
+from pytest import raises as assert_raises
 from scipy._lib._numpy_compat import suppress_warnings
 
 from scipy.linalg import (solve, inv, det, lstsq, pinv, pinv2, pinvh, norm,

--- a/scipy/linalg/tests/test_blas.py
+++ b/scipy/linalg/tests/test_blas.py
@@ -14,9 +14,9 @@ Run tests if scipy is installed:
 import math
 
 import numpy as np
-from numpy.testing import (assert_equal,
-    assert_almost_equal, assert_array_almost_equal, assert_raises, assert_,
-    assert_allclose)
+from numpy.testing import (assert_equal, assert_almost_equal, assert_,
+                           assert_array_almost_equal, assert_allclose)
+from pytest import raises as assert_raises
 
 from scipy.linalg import _fblas as fblas, get_blas_funcs
 

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -13,9 +13,10 @@ Run tests if scipy is installed:
 import numpy as np
 from numpy.testing import (assert_equal, assert_almost_equal,
                            assert_array_almost_equal, assert_array_equal,
-                           assert_raises, assert_, assert_allclose)
+                           assert_, assert_allclose)
 
 import pytest
+from pytest import raises as assert_raises
 
 from scipy._lib.six import xrange
 

--- a/scipy/linalg/tests/test_decomp_cholesky.py
+++ b/scipy/linalg/tests/test_decomp_cholesky.py
@@ -1,7 +1,7 @@
 from __future__ import division, print_function, absolute_import
 
-from numpy.testing import assert_array_almost_equal, assert_array_equal, \
-    assert_raises
+from numpy.testing import assert_array_almost_equal, assert_array_equal
+from pytest import raises as assert_raises
 
 from numpy import array, transpose, dot, conjugate, zeros_like, empty
 from numpy.random import random

--- a/scipy/linalg/tests/test_decomp_update.py
+++ b/scipy/linalg/tests/test_decomp_update.py
@@ -3,8 +3,8 @@ from __future__ import division, print_function, absolute_import
 import itertools
 
 import numpy as np
-from numpy.testing import (assert_, assert_allclose, assert_raises,
-         assert_equal)
+from numpy.testing import assert_, assert_allclose, assert_equal
+from pytest import raises as assert_raises
 from scipy import linalg
 import scipy.linalg._decomp_update as _decomp_update
 from scipy.linalg._decomp_update import *

--- a/scipy/linalg/tests/test_interpolative.py
+++ b/scipy/linalg/tests/test_interpolative.py
@@ -32,7 +32,8 @@ from scipy.linalg import hilbert, svdvals, norm
 from scipy.sparse.linalg import aslinearoperator
 import time
 
-from numpy.testing import assert_, assert_allclose, assert_raises
+from numpy.testing import assert_, assert_allclose
+from pytest import raises as assert_raises
 
 
 def _debug_print(s):

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -8,10 +8,11 @@ import sys
 import subprocess
 import time
 
-from numpy.testing import assert_equal, \
-    assert_array_almost_equal, assert_, assert_raises, assert_allclose, \
-    assert_almost_equal, assert_array_equal
+from numpy.testing import (assert_equal, assert_array_almost_equal, assert_,
+                           assert_allclose, assert_almost_equal,
+                           assert_array_equal)
 import pytest
+from pytest import raises as assert_raises
 
 import numpy as np
 

--- a/scipy/linalg/tests/test_procrustes.py
+++ b/scipy/linalg/tests/test_procrustes.py
@@ -1,7 +1,8 @@
 from itertools import product, permutations
 
 import numpy as np
-from numpy.testing import assert_array_less, assert_allclose, assert_raises
+from numpy.testing import assert_array_less, assert_allclose
+from pytest import raises as assert_raises
 
 from scipy.linalg import inv, eigh, norm
 from scipy.linalg import orthogonal_procrustes

--- a/scipy/linalg/tests/test_solve_toeplitz.py
+++ b/scipy/linalg/tests/test_solve_toeplitz.py
@@ -1,12 +1,14 @@
 """Test functions for linalg._solve_toeplitz module
 """
 from __future__ import division, print_function, absolute_import
+
 import numpy as np
 from scipy.linalg._solve_toeplitz import levinson
 from scipy.linalg import solve, toeplitz, solve_toeplitz
-from numpy.testing import (assert_equal, assert_allclose,
-                           assert_raises)
+from numpy.testing import assert_equal, assert_allclose
+
 import pytest
+from pytest import raises as assert_raises
 
 
 def test_solve_equivalence():

--- a/scipy/linalg/tests/test_solvers.py
+++ b/scipy/linalg/tests/test_solvers.py
@@ -3,8 +3,9 @@ from __future__ import division, print_function, absolute_import
 import os
 import numpy as np
 
-from numpy.testing import assert_raises, assert_array_almost_equal
+from numpy.testing import assert_array_almost_equal
 import pytest
+from pytest import raises as assert_raises
 
 from scipy.linalg import solve_sylvester
 from scipy.linalg import solve_continuous_lyapunov, solve_discrete_lyapunov

--- a/scipy/linalg/tests/test_special_matrices.py
+++ b/scipy/linalg/tests/test_special_matrices.py
@@ -4,9 +4,9 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 from numpy import arange, add, array, eye, copy, sqrt
-from numpy.testing import (assert_raises,
-    assert_equal, assert_array_equal, assert_array_almost_equal,
-    assert_allclose)
+from numpy.testing import (assert_equal, assert_array_equal,
+                           assert_array_almost_equal, assert_allclose)
+from pytest import raises as assert_raises
 
 from scipy._lib.six import xrange
 

--- a/scipy/misc/tests/test_pilutil.py
+++ b/scipy/misc/tests/test_pilutil.py
@@ -7,10 +7,9 @@ import numpy as np
 import glob
 
 import pytest
-from numpy.testing import (assert_equal,
-                           assert_allclose,
-                           assert_array_equal, assert_raises,
-                           assert_)
+from pytest import raises as assert_raises
+from numpy.testing import (assert_equal, assert_allclose,
+                           assert_array_equal, assert_)
 from scipy._lib._numpy_compat import suppress_warnings
 from scipy import misc
 from numpy.ma.testutils import assert_mask_equal

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -4,8 +4,9 @@ from __future__ import division, print_function, absolute_import
 import sys
 import numpy as np
 
-from numpy.testing import (assert_equal, assert_raises, assert_allclose,
+from numpy.testing import (assert_equal, assert_allclose,
                            assert_array_equal, assert_almost_equal)
+from pytest import raises as assert_raises
 
 import scipy.ndimage as sndi
 from scipy.ndimage.filters import _gaussian_kernel1d

--- a/scipy/ndimage/tests/test_measurements.py
+++ b/scipy/ndimage/tests/test_measurements.py
@@ -4,8 +4,8 @@ import os.path
 
 import numpy as np
 from numpy.testing import (assert_, assert_array_almost_equal, assert_equal,
-                           assert_almost_equal, assert_array_equal,
-                           assert_raises)
+                           assert_almost_equal, assert_array_equal)
+from pytest import raises as assert_raises
 from scipy._lib._numpy_compat import suppress_warnings
 
 import scipy.ndimage as ndimage

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -38,6 +38,7 @@ from numpy import fft
 from numpy.testing import (assert_, assert_equal, assert_array_equal,
         assert_array_almost_equal, assert_almost_equal)
 import pytest
+from pytest import raises as assert_raises
 from scipy._lib._numpy_compat import suppress_warnings
 import scipy.ndimage as ndimage
 
@@ -2031,8 +2032,7 @@ class TestNdimage:
                             [3, 5, 3, 6]])
         tform_h1 = numpy.hstack((numpy.eye(2), -numpy.ones((2, 1))))
         tform_h2 = numpy.vstack((tform_h1, [[5, 2, 1]]))
-        numpy.testing.assert_raises(ValueError,
-                                    ndimage.affine_transform, data, tform_h2)
+        assert_raises(ValueError, ndimage.affine_transform, data, tform_h2)
 
     def test_affine_transform_1d_endianness_with_output_parameter(self):
         # 1d affine transform given output ndarray or dtype with either endianness

--- a/scipy/odr/tests/test_odr.py
+++ b/scipy/odr/tests/test_odr.py
@@ -3,8 +3,9 @@ from __future__ import division, print_function, absolute_import
 # Scipy imports.
 import numpy as np
 from numpy import pi
-from numpy.testing import (assert_array_almost_equal, assert_raises,
+from numpy.testing import (assert_array_almost_equal,
                            assert_equal, assert_warns)
+from pytest import raises as assert_raises
 from scipy.odr import Data, Model, ODR, RealData, OdrStop, OdrWarning
 
 

--- a/scipy/optimize/tests/test__basinhopping.py
+++ b/scipy/optimize/tests/test__basinhopping.py
@@ -4,12 +4,12 @@ Unit tests for the basin hopping global minimization algorithm.
 from __future__ import division, print_function, absolute_import
 import copy
 
-from numpy.testing import (assert_raises,
-                           assert_almost_equal, assert_equal, assert_)
+from numpy.testing import assert_almost_equal, assert_equal, assert_
+from pytest import raises as assert_raises
 import numpy as np
 from numpy import cos, sin
 
-from scipy.optimize import (basinhopping, OptimizeResult)
+from scipy.optimize import basinhopping, OptimizeResult
 from scipy.optimize._basinhopping import (
     Storage, RandomDisplacement, Metropolis, AdaptiveStepsize)
 

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -8,8 +8,8 @@ import numpy as np
 from scipy.optimize import rosen
 from numpy.testing import (assert_equal, assert_allclose,
                            assert_almost_equal,
-                           assert_string_equal, assert_raises, assert_)
-
+                           assert_string_equal, assert_)
+from pytest import raises as assert_raises
 
 class TestDifferentialEvolutionSolver(object):
 

--- a/scipy/optimize/tests/test__linprog_ip_clean_inputs.py
+++ b/scipy/optimize/tests/test__linprog_ip_clean_inputs.py
@@ -4,7 +4,8 @@ Unit test for Linear Programming via Simplex Algorithm.
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import (assert_, assert_raises, assert_allclose)
+from numpy.testing import assert_, assert_allclose
+from pytest import raises as assert_raises
 from scipy.optimize._linprog_ip import _clean_inputs
 from copy import deepcopy
 

--- a/scipy/optimize/tests/test__numdiff.py
+++ b/scipy/optimize/tests/test__numdiff.py
@@ -4,8 +4,9 @@ import math
 from itertools import product
 
 import numpy as np
-from numpy.testing import (assert_raises, assert_allclose, assert_equal,
-                           assert_)
+from numpy.testing import assert_allclose, assert_equal, assert_
+from pytest import raises as assert_raises
+
 from scipy.sparse import csr_matrix, csc_matrix, lil_matrix
 
 from scipy.optimize._numdiff import (

--- a/scipy/optimize/tests/test_cobyla.py
+++ b/scipy/optimize/tests/test_cobyla.py
@@ -3,8 +3,7 @@ from __future__ import division, print_function, absolute_import
 import math
 import numpy as np
 
-from numpy.testing import assert_allclose, \
-     assert_
+from numpy.testing import assert_allclose, assert_
 
 from scipy.optimize import fmin_cobyla, minimize
 

--- a/scipy/optimize/tests/test_hungarian.py
+++ b/scipy/optimize/tests/test_hungarian.py
@@ -1,7 +1,8 @@
 # Author: Brian M. Clapper, G. Varoquaux, Lars Buitinck
 # License: BSD
 
-from numpy.testing import assert_array_equal, assert_raises
+from numpy.testing import assert_array_equal
+from pytest import raises as assert_raises
 
 import numpy as np
 

--- a/scipy/optimize/tests/test_least_squares.py
+++ b/scipy/optimize/tests/test_least_squares.py
@@ -5,7 +5,8 @@ from itertools import product
 import numpy as np
 from numpy.linalg import norm
 from numpy.testing import (assert_, assert_allclose,
-                           assert_raises, assert_equal)
+                           assert_equal)
+from pytest import raises as assert_raises
 from scipy._lib._numpy_compat import suppress_warnings
 
 from scipy.sparse import issparse, lil_matrix

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -4,8 +4,8 @@ Unit test for Linear Programming
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import (assert_, assert_allclose, assert_raises,
-                           assert_equal)
+from numpy.testing import assert_, assert_allclose, assert_equal
+from pytest import raises as assert_raises
 from scipy.optimize import linprog, OptimizeWarning
 from scipy._lib._numpy_compat import _assert_warns, suppress_warnings
 from scipy.sparse.linalg import MatrixRankWarning

--- a/scipy/optimize/tests/test_lsq_common.py
+++ b/scipy/optimize/tests/test_lsq_common.py
@@ -1,5 +1,7 @@
-from numpy.testing import (assert_, assert_allclose,
-                           assert_raises, assert_equal)
+from __future__ import division, absolute_import, print_function
+
+from numpy.testing import assert_, assert_allclose, assert_equal
+from pytest import raises as assert_raises
 import numpy as np
 
 from scipy.optimize._lsq.common import (

--- a/scipy/optimize/tests/test_lsq_linear.py
+++ b/scipy/optimize/tests/test_lsq_linear.py
@@ -1,7 +1,8 @@
 import numpy as np
 from numpy.linalg import lstsq
-from numpy.testing import (assert_allclose, assert_equal, assert_,
-                           assert_raises)
+from numpy.testing import assert_allclose, assert_equal, assert_
+from pytest import raises as assert_raises
+
 from scipy.sparse import rand
 from scipy.sparse.linalg import aslinearoperator
 from scipy.optimize import lsq_linear

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -4,8 +4,8 @@ Unit tests for optimization routines from minpack.py.
 from __future__ import division, print_function, absolute_import
 
 from numpy.testing import (assert_, assert_almost_equal, assert_array_equal,
-        assert_array_almost_equal, assert_raises,
-        assert_allclose)
+        assert_array_almost_equal, assert_allclose)
+from pytest import raises as assert_raises
 import numpy as np
 from numpy import array, float64, matrix
 

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -14,11 +14,12 @@ from __future__ import division, print_function, absolute_import
 import itertools
 
 import numpy as np
-from numpy.testing import (assert_raises, assert_allclose, assert_equal,
+from numpy.testing import (assert_allclose, assert_equal,
                            assert_,
                            assert_almost_equal, assert_warns,
                            assert_array_less)
 import pytest
+from pytest import raises as assert_raises
 
 from scipy._lib._numpy_compat import suppress_warnings
 from scipy import optimize

--- a/scipy/optimize/tests/test_regression.py
+++ b/scipy/optimize/tests/test_regression.py
@@ -4,8 +4,8 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import assert_almost_equal, \
-        assert_raises
+from numpy.testing import assert_almost_equal
+from pytest import raises as assert_raises
 
 import scipy.optimize
 

--- a/scipy/optimize/tests/test_slsqp.py
+++ b/scipy/optimize/tests/test_slsqp.py
@@ -5,8 +5,8 @@ from __future__ import division, print_function, absolute_import
 
 import pytest
 from numpy.testing import (assert_, assert_array_almost_equal,
-                           assert_allclose, assert_equal,
-                           assert_raises)
+                           assert_allclose, assert_equal)
+from pytest import raises as assert_raises
 import numpy as np
 
 from scipy.optimize import fmin_slsqp, minimize

--- a/scipy/signal/tests/test_array_tools.py
+++ b/scipy/signal/tests/test_array_tools.py
@@ -2,11 +2,11 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 
-from numpy.testing import \
-    assert_array_equal, assert_raises
+from numpy.testing import assert_array_equal
+from pytest import raises as assert_raises
 
-from scipy.signal._arraytools import axis_slice, axis_reverse, \
-     odd_ext, even_ext, const_ext, zero_ext
+from scipy.signal._arraytools import (axis_slice, axis_reverse,
+     odd_ext, even_ext, const_ext, zero_ext)
 
 
 class TestArrayTools(object):

--- a/scipy/signal/tests/test_dltisys.py
+++ b/scipy/signal/tests/test_dltisys.py
@@ -6,8 +6,8 @@ from __future__ import division, print_function, absolute_import
 import numpy as np
 from numpy.testing import (assert_equal,
                            assert_array_almost_equal, assert_array_equal,
-                           assert_allclose, assert_, assert_raises,
-                           assert_almost_equal)
+                           assert_allclose, assert_, assert_almost_equal)
+from pytest import raises as assert_raises
 from scipy._lib._numpy_compat import suppress_warnings
 from scipy.signal import (dlsim, dstep, dimpulse, tf2zpk, lti, dlti,
                           StateSpace, TransferFunction, ZerosPolesGain,

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -6,12 +6,13 @@ from distutils.version import LooseVersion
 import numpy as np
 from numpy.testing import (assert_array_almost_equal,
                            assert_array_equal, assert_array_less,
-                           assert_raises, assert_equal, assert_,
+                           assert_equal, assert_,
                            assert_allclose, assert_warns)
-from numpy import array, spacing, sin, pi, sort
 import pytest
-
+from pytest import raises as assert_raises
 from scipy._lib._numpy_compat import suppress_warnings
+
+from numpy import array, spacing, sin, pi, sort
 from scipy.signal import (BadCoefficients, bessel, besselap, bilinear, buttap,
                           butter, buttord, cheb1ap, cheb1ord, cheb2ap,
                           cheb2ord, cheby1, cheby2, ellip, ellipap, ellipord,

--- a/scipy/signal/tests/test_fir_filter_design.py
+++ b/scipy/signal/tests/test_fir_filter_design.py
@@ -1,9 +1,11 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import assert_raises, \
-        assert_almost_equal, assert_array_almost_equal, assert_equal, \
-        assert_, assert_allclose, assert_warns
+from numpy.testing import (assert_almost_equal, assert_array_almost_equal,
+                           assert_equal, assert_,
+                           assert_allclose, assert_warns)
+from pytest import raises as assert_raises
+
 from scipy.special import sinc
 
 from scipy.signal import kaiser_beta, kaiser_atten, kaiserord, \

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -4,7 +4,9 @@ import warnings
 
 import numpy as np
 from numpy.testing import (assert_almost_equal, assert_equal, assert_allclose,
-                           assert_, assert_raises)
+                           assert_)
+from pytest import raises as assert_raises
+
 from scipy._lib._numpy_compat import suppress_warnings
 from scipy.signal import (ss2tf, tf2ss, lsim2, impulse2, step2, lti,
                           dlti, bode, freqresp, lsim, impulse, step,

--- a/scipy/signal/tests/test_max_len_seq.py
+++ b/scipy/signal/tests/test_max_len_seq.py
@@ -1,8 +1,9 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import (assert_raises,
-                           assert_allclose, assert_array_equal)
+from numpy.testing import assert_allclose, assert_array_equal
+from pytest import raises as assert_raises
+
 from numpy.fft import fft, ifft
 
 from scipy.signal import max_len_seq

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -8,10 +8,11 @@ from itertools import product
 import warnings
 
 import pytest
+from pytest import raises as assert_raises
 from numpy.testing import (
     assert_equal,
     assert_almost_equal, assert_array_equal, assert_array_almost_equal,
-    assert_raises, assert_allclose, assert_, assert_warns)
+    assert_allclose, assert_, assert_warns)
 from scipy._lib._numpy_compat import suppress_warnings
 from numpy import array, arange
 import numpy as np

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -1,11 +1,12 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import (assert_,
+from numpy.testing import (assert_, assert_approx_equal,
                            assert_allclose, assert_array_equal, assert_equal,
-                           assert_array_almost_equal_nulp, assert_raises,
-                           assert_approx_equal)
+                           assert_array_almost_equal_nulp)
 import pytest
+from pytest import raises as assert_raises
+
 from scipy._lib._numpy_compat import suppress_warnings
 from scipy import signal, fftpack
 from scipy.signal import (periodogram, welch, lombscargle, csd, coherence,

--- a/scipy/signal/tests/test_upfirdn.py
+++ b/scipy/signal/tests/test_upfirdn.py
@@ -34,8 +34,9 @@
 
 import numpy as np
 from itertools import product
-from numpy.testing import (assert_equal,
-                           assert_raises, assert_allclose)
+
+from numpy.testing import assert_equal, assert_allclose
+from pytest import raises as assert_raises
 
 from scipy.signal import upfirdn, firwin, lfilter
 from scipy.signal._upfirdn import _output_len

--- a/scipy/signal/tests/test_waveforms.py
+++ b/scipy/signal/tests/test_waveforms.py
@@ -2,8 +2,8 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 from numpy.testing import (assert_almost_equal, assert_equal,
-                           assert_, assert_raises,
-                           assert_allclose, assert_array_equal)
+                           assert_, assert_allclose, assert_array_equal)
+from pytest import raises as assert_raises
 
 import scipy.signal.waveforms as waveforms
 

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -3,8 +3,10 @@ from __future__ import division, print_function, absolute_import
 import numpy as np
 from numpy import array
 from numpy.testing import (assert_array_almost_equal, assert_array_equal,
-                           assert_raises, assert_allclose,
+                           assert_allclose,
                            assert_equal, assert_, assert_array_less)
+from pytest import raises as assert_raises
+
 from scipy._lib._numpy_compat import suppress_warnings
 from scipy import signal, fftpack
 

--- a/scipy/sparse/csgraph/tests/test_graph_laplacian.py
+++ b/scipy/sparse/csgraph/tests/test_graph_laplacian.py
@@ -4,8 +4,8 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import (assert_allclose,
-        assert_array_almost_equal, assert_raises)
+from numpy.testing import assert_allclose, assert_array_almost_equal
+from pytest import raises as assert_raises
 from scipy import sparse
 
 from scipy.sparse import csgraph

--- a/scipy/sparse/csgraph/tests/test_reordering.py
+++ b/scipy/sparse/csgraph/tests/test_reordering.py
@@ -2,8 +2,8 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 from numpy.testing import assert_equal
-from scipy.sparse.csgraph import reverse_cuthill_mckee,\
-        maximum_bipartite_matching, structural_rank
+from scipy.sparse.csgraph import (reverse_cuthill_mckee,
+        maximum_bipartite_matching, structural_rank)
 from scipy.sparse import diags, csc_matrix, csr_matrix, coo_matrix
 
 def test_graph_reverse_cuthill_mckee():

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -1,8 +1,8 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import (assert_array_almost_equal, assert_raises,
-    assert_array_equal)
+from numpy.testing import assert_array_almost_equal, assert_array_equal
+from pytest import raises as assert_raises
 from scipy.sparse.csgraph import (shortest_path, dijkstra, johnson,
     bellman_ford, construct_dist_matrix, NegativeCycleError)
 

--- a/scipy/sparse/csgraph/tests/test_traversal.py
+++ b/scipy/sparse/csgraph/tests/test_traversal.py
@@ -2,8 +2,8 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 from numpy.testing import assert_array_almost_equal
-from scipy.sparse.csgraph import breadth_first_tree, depth_first_tree,\
-    csgraph_to_dense, csgraph_from_dense
+from scipy.sparse.csgraph import (breadth_first_tree, depth_first_tree,
+    csgraph_to_dense, csgraph_from_dense)
 
 
 def test_graph_breadth_first():

--- a/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
@@ -10,9 +10,9 @@ import threading
 
 import numpy as np
 
-from numpy.testing import assert_allclose, \
-        assert_array_almost_equal_nulp, \
-        assert_raises, assert_equal, assert_array_equal
+from numpy.testing import (assert_allclose, assert_array_almost_equal_nulp,
+                           assert_equal, assert_array_equal)
+from pytest import raises as assert_raises
 
 from numpy import dot, conj, random
 from scipy.linalg import eig, eigh

--- a/scipy/sparse/linalg/isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/isolve/tests/test_iterative.py
@@ -6,7 +6,8 @@ from __future__ import division, print_function, absolute_import
 import numpy as np
 
 from numpy.testing import (assert_equal, assert_array_equal,
-     assert_, assert_allclose, assert_raises)
+     assert_, assert_allclose)
+from pytest import raises as assert_raises
 from scipy._lib._numpy_compat import suppress_warnings
 
 from numpy import zeros, arange, array, abs, max, ones, eye, iscomplexobj

--- a/scipy/sparse/linalg/isolve/tests/test_utils.py
+++ b/scipy/sparse/linalg/isolve/tests/test_utils.py
@@ -1,7 +1,7 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import assert_raises
+from pytest import raises as assert_raises
 
 from scipy.sparse.linalg import utils
 

--- a/scipy/sparse/linalg/tests/test_expm_multiply.py
+++ b/scipy/sparse/linalg/tests/test_expm_multiply.py
@@ -4,8 +4,7 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import (assert_allclose,
-        assert_, assert_equal)
+from numpy.testing import assert_allclose, assert_, assert_equal
 from scipy._lib._numpy_compat import suppress_warnings
 
 from scipy.sparse import SparseEfficiencyWarning

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -7,9 +7,8 @@ from functools import partial
 from itertools import product
 import operator
 import pytest
-
-from numpy.testing import assert_, assert_equal, \
-        assert_raises
+from pytest import raises as assert_raises
+from numpy.testing import assert_, assert_equal
 
 import numpy as np
 import scipy.sparse as sparse

--- a/scipy/sparse/linalg/tests/test_norm.py
+++ b/scipy/sparse/linalg/tests/test_norm.py
@@ -5,7 +5,8 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 from numpy.linalg import norm as npnorm
-from numpy.testing import (assert_raises, assert_equal, assert_allclose)
+from numpy.testing import assert_equal, assert_allclose
+from pytest import raises as assert_raises
 
 from scipy._lib._version import NumpyVersion
 import scipy.sparse

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -30,9 +30,10 @@ from numpy import (arange, zeros, array, dot, matrix, asmatrix, asarray,
                    int8, ComplexWarning)
 
 import random
-from numpy.testing import (assert_raises, assert_equal, assert_array_equal,
+from numpy.testing import (assert_equal, assert_array_equal,
         assert_array_almost_equal, assert_almost_equal, assert_,
         assert_allclose)
+from pytest import raises as assert_raises
 from scipy._lib._numpy_compat import suppress_warnings
 
 import scipy.linalg

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -5,9 +5,9 @@ from __future__ import division, print_function, absolute_import
 import numpy as np
 from numpy import array, matrix
 from numpy.testing import (assert_equal, assert_,
-        assert_array_equal, assert_raises, assert_array_almost_equal_nulp)
+        assert_array_equal, assert_array_almost_equal_nulp)
 import pytest
-from scipy._lib._numpy_compat import assert_raises_regex
+from pytest import raises as assert_raises
 from scipy._lib._testutils import check_free_memory
 
 from scipy.sparse import csr_matrix, coo_matrix
@@ -372,12 +372,13 @@ class TestConstructUtils(object):
         assert_equal(construct.bmat([[None,D],[C,None]]).todense(), expected)
 
         # test failure cases
-        assert_raises_regex(ValueError,
-                            r'Got blocks\[1,0\]\.shape\[1\] == 1, expected 2',
-                            construct.bmat, [[A],[B]])
-        assert_raises_regex(ValueError,
-                            r'Got blocks\[0,1\]\.shape\[0\] == 1, expected 2',
-                            construct.bmat, [[A,C]])
+        with assert_raises(ValueError) as excinfo:
+            construct.bmat([[A], [B]])
+        excinfo.match(r'Got blocks\[1,0\]\.shape\[1\] == 1, expected 2')
+
+        with assert_raises(ValueError) as excinfo:
+            construct.bmat([[A, C]])
+        excinfo.match(r'Got blocks\[0,1\]\.shape\[0\] == 1, expected 2')
 
     @pytest.mark.slow
     def test_concatenate_int32_overflow(self):

--- a/scipy/sparse/tests/test_matrix_io.py
+++ b/scipy/sparse/tests/test_matrix_io.py
@@ -6,10 +6,12 @@ import numpy as np
 import tempfile
 
 import pytest
-from numpy.testing import assert_equal, assert_, assert_raises
+from pytest import raises as assert_raises
+from numpy.testing import assert_equal, assert_
 from scipy._lib._version import NumpyVersion
 
-from scipy.sparse import csc_matrix, csr_matrix, bsr_matrix, dia_matrix, coo_matrix, save_npz, load_npz
+from scipy.sparse import (csc_matrix, csr_matrix, bsr_matrix, dia_matrix,
+                          coo_matrix, save_npz, load_npz)
 
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')

--- a/scipy/sparse/tests/test_sparsetools.py
+++ b/scipy/sparse/tests/test_sparsetools.py
@@ -7,14 +7,14 @@ import re
 import threading
 
 import numpy as np
-from numpy.testing import (assert_raises, assert_equal, assert_, assert_allclose)
+from numpy.testing import assert_equal, assert_, assert_allclose
 from scipy.sparse import (_sparsetools, coo_matrix, csr_matrix, csc_matrix,
                           bsr_matrix, dia_matrix)
 from scipy.sparse.sputils import supported_dtypes
 from scipy._lib._testutils import check_free_memory
 
 import pytest
-
+from pytest import raises as assert_raises
 
 def test_exception():
     assert_raises(MemoryError, _sparsetools.test_throw_error)

--- a/scipy/sparse/tests/test_spfuncs.py
+++ b/scipy/sparse/tests/test_spfuncs.py
@@ -5,8 +5,8 @@ from numpy.testing import assert_, assert_equal
 
 from scipy.sparse import spfuncs
 from scipy.sparse import csr_matrix, csc_matrix, bsr_matrix
-from scipy.sparse._sparsetools import csr_scale_rows, csr_scale_columns, \
-        bsr_scale_rows, bsr_scale_columns
+from scipy.sparse._sparsetools import (csr_scale_rows, csr_scale_columns,
+                                       bsr_scale_rows, bsr_scale_columns)
 
 
 class TestSparseFunctions(object):

--- a/scipy/sparse/tests/test_sputils.py
+++ b/scipy/sparse/tests/test_sputils.py
@@ -3,8 +3,8 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import (assert_equal,
-                           assert_raises)
+from numpy.testing import assert_equal, assert_raises
+from pytest import raises as assert_raises
 from scipy.sparse import sputils
 
 

--- a/scipy/spatial/tests/test__procrustes.py
+++ b/scipy/spatial/tests/test__procrustes.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
 import numpy as np
-from numpy.testing import (assert_allclose,
-                           assert_equal, assert_almost_equal, assert_raises)
+from numpy.testing import assert_allclose, assert_equal, assert_almost_equal
+from pytest import raises as assert_raises
 
 from scipy.spatial import procrustes
 

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -41,8 +41,9 @@ from scipy._lib.six import xrange, u
 import numpy as np
 from numpy.linalg import norm
 from numpy.testing import (verbose, assert_,
-                           assert_raises, assert_array_equal, assert_equal,
+                           assert_array_equal, assert_equal,
                            assert_almost_equal, assert_allclose)
+from pytest import raises as assert_raises
 
 from scipy.spatial.distance import (squareform, pdist, cdist, num_obs_y,
                                     num_obs_dm, is_valid_dm, is_valid_y,

--- a/scipy/spatial/tests/test_hausdorff.py
+++ b/scipy/spatial/tests/test_hausdorff.py
@@ -1,3 +1,5 @@
+from __future__ import division, absolute_import, print_function
+
 import numpy as np
 from numpy.testing import (assert_almost_equal,
                            assert_array_equal,

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -4,8 +4,8 @@
 from __future__ import division, print_function, absolute_import
 
 from numpy.testing import (assert_equal, assert_array_equal,
-    assert_almost_equal, assert_array_almost_equal, assert_,
-    assert_raises)
+    assert_almost_equal, assert_array_almost_equal, assert_)
+from pytest import raises as assert_raises
 
 import numpy as np
 from scipy.spatial import KDTree, Rectangle, distance_matrix, cKDTree

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -5,10 +5,10 @@ import copy
 
 import numpy as np
 from numpy.testing import (assert_equal, assert_almost_equal,
-                           assert_, assert_allclose, assert_array_equal,
-                           assert_raises)
-from scipy._lib.six import xrange
+                           assert_, assert_allclose, assert_array_equal)
 import pytest
+from pytest import raises as assert_raises
+from scipy._lib.six import xrange
 
 import scipy.spatial.qhull as qhull
 from scipy.spatial import cKDTree as KDTree

--- a/scipy/spatial/tests/test_spherical_voronoi.py
+++ b/scipy/spatial/tests/test_spherical_voronoi.py
@@ -4,8 +4,8 @@ import itertools
 from numpy.testing import (assert_equal,
                            assert_almost_equal,
                            assert_array_equal,
-                           assert_array_almost_equal,
-                           assert_raises)
+                           assert_array_almost_equal)
+from pytest import raises as assert_raises
 from scipy.spatial import SphericalVoronoi, distance
 from scipy.spatial import _spherical_voronoi as spherical_voronoi
 

--- a/scipy/special/_ufuncs_extra_code.pxi
+++ b/scipy/special/_ufuncs_extra_code.pxi
@@ -126,11 +126,11 @@ def seterr(**kwargs):
     Examples
     --------
     >>> import scipy.special as sc
-    >>> from numpy.testing import assert_raises
+    >>> from pytest import raises
     >>> sc.gammaln(0)
     inf
     >>> olderr = sc.seterr(singular='raise')
-    >>> with assert_raises(sc.SpecialFunctionError):
+    >>> with raises(sc.SpecialFunctionError):
     ...     sc.gammaln(0)
     ...
     >>> _ = sc.seterr(**olderr)
@@ -140,7 +140,7 @@ def seterr(**kwargs):
     >>> olderr = sc.seterr(all='raise', singular='ignore')
     >>> sc.gammaln(0)
     inf
-    >>> with assert_raises(sc.SpecialFunctionError):
+    >>> with raises(sc.SpecialFunctionError):
     ...     sc.spence(-1)
     ...
     >>> _ = sc.seterr(**olderr)
@@ -190,11 +190,11 @@ class errstate(object):
     Examples
     --------
     >>> import scipy.special as sc
-    >>> from numpy.testing import assert_raises
+    >>> from pytest import raises
     >>> sc.gammaln(0)
     inf
     >>> with sc.errstate(singular='raise'):
-    ...     with assert_raises(sc.SpecialFunctionError):
+    ...     with raises(sc.SpecialFunctionError):
     ...         sc.gammaln(0)
     ...
     >>> sc.gammaln(0)
@@ -204,7 +204,7 @@ class errstate(object):
 
     >>> with sc.errstate(all='raise', singular='ignore'):
     ...     sc.gammaln(0)
-    ...     with assert_raises(sc.SpecialFunctionError):
+    ...     with raises(sc.SpecialFunctionError):
     ...         sc.spence(-1)
     ...
     inf

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -28,10 +28,11 @@ from numpy import (array, isnan, r_, arange, finfo, pi, sin, cos, tan, exp,
         log, zeros, sqrt, asarray, inf, nan_to_num, real, arctan, float_)
 
 import pytest
+from pytest import raises as assert_raises
 from numpy.testing import (assert_equal, assert_almost_equal,
         assert_array_equal, assert_array_almost_equal, assert_approx_equal,
         assert_, assert_allclose,
-        assert_raises, assert_array_almost_equal_nulp)
+        assert_array_almost_equal_nulp)
 
 from scipy import special
 import scipy.special._ufuncs as cephes

--- a/scipy/special/tests/test_loggamma.py
+++ b/scipy/special/tests/test_loggamma.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function, absolute_import
+
 import numpy as np
 from numpy.testing import assert_allclose
 

--- a/scipy/special/tests/test_orthogonal.py
+++ b/scipy/special/tests/test_orthogonal.py
@@ -3,7 +3,8 @@ from __future__ import division, print_function, absolute_import
 import numpy as np
 from numpy import array, sqrt
 from numpy.testing import (assert_array_almost_equal, assert_equal,
-                           assert_almost_equal, assert_allclose, assert_raises)
+                           assert_almost_equal, assert_allclose)
+from pytest import raises as assert_raises
 
 from scipy._lib.six import xrange
 from scipy import integrate

--- a/scipy/special/tests/test_sf_error.py
+++ b/scipy/special/tests/test_sf_error.py
@@ -2,9 +2,10 @@ from __future__ import division, print_function, absolute_import
 
 import warnings
 
-from numpy.testing import assert_, assert_equal, assert_raises
+from numpy.testing import assert_, assert_equal
 from scipy._lib._numpy_compat import suppress_warnings
 import pytest
+from pytest import raises as assert_raises
 
 import scipy.special as sc
 from scipy.special._ufuncs import _sf_error_test_function

--- a/scipy/special/tests/test_sici.py
+++ b/scipy/special/tests/test_sici.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function, absolute_import
+
 import numpy as np
 
 import scipy.special as sc

--- a/scipy/special/tests/test_spence.py
+++ b/scipy/special/tests/test_spence.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function, absolute_import
+
 import numpy as np
 from numpy import sqrt, log, pi
 from scipy.special._testutils import FuncData

--- a/scipy/special/tests/test_spfun_stats.py
+++ b/scipy/special/tests/test_spfun_stats.py
@@ -1,8 +1,9 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import assert_array_equal, \
-    assert_array_almost_equal_nulp, assert_raises, assert_almost_equal
+from numpy.testing import (assert_array_equal,
+        assert_array_almost_equal_nulp, assert_almost_equal)
+from pytest import raises as assert_raises
 
 from scipy.special import gammaln, multigammaln
 

--- a/scipy/special/tests/test_trig.py
+++ b/scipy/special/tests/test_trig.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function, absolute_import
+
 import numpy as np
 from numpy.testing import assert_equal, assert_allclose
 

--- a/scipy/special/tests/test_wrightomega.py
+++ b/scipy/special/tests/test_wrightomega.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function, absolute_import
+
 import numpy as np
 from numpy.testing import assert_, assert_equal
 

--- a/scipy/stats/tests/common_tests.py
+++ b/scipy/stats/tests/common_tests.py
@@ -5,6 +5,8 @@ import pickle
 import numpy as np
 import numpy.testing as npt
 from numpy.testing import assert_allclose, assert_equal
+from pytest import raises as assert_raises
+
 import numpy.ma.testutils as ma_npt
 
 from scipy._lib._util import getargspec_no_self as _getargspec
@@ -156,7 +158,7 @@ def check_named_args(distfn, x, shape_args, defaults, meths):
 
     # unknown arguments should not go through:
     k.update({'kaboom': 42})
-    npt.assert_raises(TypeError, distfn.cdf, x, **k)
+    assert_raises(TypeError, distfn.cdf, x, **k)
 
 
 def check_random_state_property(distfn, args):

--- a/scipy/stats/tests/test_contingency.py
+++ b/scipy/stats/tests/test_contingency.py
@@ -2,8 +2,9 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 from numpy.testing import (assert_equal, assert_array_equal,
-         assert_array_almost_equal, assert_approx_equal, assert_raises,
-         assert_allclose)
+         assert_array_almost_equal, assert_approx_equal, assert_allclose)
+from pytest import raises as assert_raises
+
 from scipy.special import xlogy
 from scipy.stats.contingency import margins, expected_freq, chi2_contingency
 

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -3,6 +3,7 @@ from __future__ import division, print_function, absolute_import
 import numpy as np
 import numpy.testing as npt
 import pytest
+from pytest import raises as assert_raises
 from scipy._lib._numpy_compat import suppress_warnings
 from scipy.integrate import IntegrationWarning
 
@@ -263,10 +264,10 @@ def test_rvs_gh2069_regression():
     d = np.diff(vals.ravel())
     npt.assert_(np.all(d != 0), "All the values are equal, but they shouldn't be!")
 
-    npt.assert_raises(ValueError, stats.norm.rvs, [[0, 0], [0, 0]],
+    assert_raises(ValueError, stats.norm.rvs, [[0, 0], [0, 0]],
                   [[1, 1], [1, 1]], 1)
-    npt.assert_raises(ValueError, stats.gamma.rvs, [2, 3, 4, 5], 0, 1, (2, 2))
-    npt.assert_raises(ValueError, stats.gamma.rvs, [1, 1, 1, 1], [0, 0, 0, 0],
+    assert_raises(ValueError, stats.gamma.rvs, [2, 3, 4, 5], 0, 1, (2, 2))
+    assert_raises(ValueError, stats.gamma.rvs, [1, 1, 1, 1], [0, 0, 0, 0],
                      [[1], [2]], (4,))
 
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -10,8 +10,9 @@ import pickle
 
 from numpy.testing import (assert_equal,
     assert_array_equal, assert_almost_equal, assert_array_almost_equal,
-    assert_allclose, assert_, assert_raises, assert_warns)
+    assert_allclose, assert_, assert_warns)
 import pytest
+from pytest import raises as assert_raises
 from scipy._lib._numpy_compat import suppress_warnings
 
 import numpy

--- a/scipy/stats/tests/test_kdeoth.py
+++ b/scipy/stats/tests/test_kdeoth.py
@@ -2,8 +2,9 @@ from __future__ import division, print_function, absolute_import
 
 from scipy import stats
 import numpy as np
-from numpy.testing import assert_almost_equal, assert_, assert_raises, \
-    assert_array_almost_equal, assert_array_almost_equal_nulp
+from numpy.testing import (assert_almost_equal, assert_,
+    assert_array_almost_equal, assert_array_almost_equal_nulp)
+from pytest import raises as assert_raises
 
 
 def test_kde_1d():

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -10,9 +10,11 @@ import numpy as np
 from numpy.random import RandomState
 from numpy.testing import (assert_array_equal,
     assert_almost_equal, assert_array_less, assert_array_almost_equal,
-    assert_raises, assert_, assert_allclose, assert_equal, assert_warns)
+    assert_, assert_allclose, assert_equal, assert_warns)
 import pytest
+from pytest import raises as assert_raises
 from scipy._lib._numpy_compat import suppress_warnings
+
 from scipy import stats
 from .common_tests import check_named_results
 

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -14,9 +14,10 @@ import scipy.stats.mstats as mstats
 from scipy import stats
 from .common_tests import check_named_results
 import pytest
+from pytest import raises as assert_raises
 from numpy.ma.testutils import (assert_equal, assert_almost_equal,
     assert_array_almost_equal, assert_array_almost_equal_nulp, assert_,
-    assert_allclose, assert_raises, assert_array_equal)
+    assert_allclose, assert_array_equal)
 from scipy._lib._numpy_compat import suppress_warnings
 
 

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -8,7 +8,8 @@ import pickle
 
 from numpy.testing import (assert_allclose, assert_almost_equal,
                            assert_array_almost_equal, assert_equal,
-                           assert_array_less, assert_raises, assert_)
+                           assert_array_less, assert_)
+from pytest import raises as assert_raises
 
 from .test_continuous_basic import check_distribution_rvs
 

--- a/scipy/stats/tests/test_rank.py
+++ b/scipy/stats/tests/test_rank.py
@@ -1,8 +1,7 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import assert_equal, \
-    assert_array_equal, dec
+from numpy.testing import assert_equal, assert_array_equal
 
 from scipy.stats import rankdata, tiecorrect
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -16,9 +16,10 @@ from collections import namedtuple
 from numpy.testing import (assert_, assert_equal,
                            assert_almost_equal, assert_array_almost_equal,
                            assert_array_equal, assert_approx_equal,
-                           assert_raises, assert_allclose)
+                           assert_allclose)
 import pytest
-from scipy._lib._numpy_compat import assert_raises_regex, suppress_warnings
+from pytest import raises as assert_raises
+from scipy._lib._numpy_compat import suppress_warnings
 import numpy.ma.testutils as mat
 from numpy import array, arange, float32, float64, power
 import numpy as np
@@ -101,11 +102,9 @@ class TestTrimmedStats(object):
             assert_equal(stats.tmin(x, nan_policy='omit'), 0.)
             assert_raises(ValueError, stats.tmin, x, nan_policy='raise')
             assert_raises(ValueError, stats.tmin, x, nan_policy='foobar')
-            assert_raises_regex(ValueError,
-                            "'propagate', 'raise', 'omit'",
-                            stats.tmin,
-                            x,
-                            nan_policy='foo')
+            msg = "'propagate', 'raise', 'omit'"
+            with assert_raises(ValueError, message=msg):
+                stats.tmin(x, nan_policy='foo')
 
     def test_tmax(self):
         assert_equal(stats.tmax(4), 4)
@@ -2743,7 +2742,7 @@ def test_friedmanchisquare():
                               (18.9428571428571, 0.000280938375189499))
     assert_array_almost_equal(stats.friedmanchisquare(x3[0],x3[1],x3[2],x3[3]),
                               (10.68, 0.0135882729582176))
-    np.testing.assert_raises(ValueError, stats.friedmanchisquare,x3[0],x3[1])
+    assert_raises(ValueError, stats.friedmanchisquare,x3[0],x3[1])
 
     # test for namedtuple attribute results
     attributes = ('statistic', 'pvalue')
@@ -2760,7 +2759,7 @@ def test_friedmanchisquare():
     assert_array_almost_equal(mstats.friedmanchisquare(x3[0], x3[1],
                                                        x3[2], x3[3]),
                               (10.68, 0.0135882729582176))
-    np.testing.assert_raises(ValueError, mstats.friedmanchisquare,x3[0],x3[1])
+    assert_raises(ValueError, mstats.friedmanchisquare,x3[0],x3[1])
 
 
 def test_kstest():

--- a/scipy/stats/tests/test_tukeylambda_stats.py
+++ b/scipy/stats/tests/test_tukeylambda_stats.py
@@ -3,8 +3,8 @@ from __future__ import division, print_function, absolute_import
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 
-from scipy.stats._tukeylambda_stats import tukeylambda_variance, \
-                                            tukeylambda_kurtosis
+from scipy.stats._tukeylambda_stats import (tukeylambda_variance,
+                                            tukeylambda_kurtosis)
 
 
 def test_tukeylambda_stats_known_exact():

--- a/tools/ci/appveyor/requirements.txt
+++ b/tools/ci/appveyor/requirements.txt
@@ -1,6 +1,5 @@
 numpy
 cython
-nose
 pytest-timeout
 pytest-xdist
 pytest-env


### PR DESCRIPTION
Convert nose imports to equivalent pytest imports. With this, `$ python runtests.py` passes the collection stage if nose is not present. Tests still fail because of gh-7776.