### PR TITLE
Fix test errors introduced by gh-5910

### DIFF
--- a/scipy/sparse/linalg/isolve/lgmres.py
+++ b/scipy/sparse/linalg/isolve/lgmres.py
@@ -173,6 +173,10 @@ def lgmres(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
                                          outer_v=outer_v,
                                          prepend_outer_v=prepend_outer_v)
             y *= inner_res_0
+            if not np.isfinite(y).all():
+                # Overflow etc. in computation. There's no way to
+                # recover from this, so we have to bail out.
+                raise LinAlgError()
         except LinAlgError:
             # Floating point over/underflow, non-finite result from
             # matmul etc. -- report failure.

--- a/scipy/sparse/linalg/isolve/tests/test_gcrotmk.py
+++ b/scipy/sparse/linalg/isolve/tests/test_gcrotmk.py
@@ -137,6 +137,19 @@ class TestGCROTMK(object):
             assert_(count_1 < count_0/2)
             assert_allclose(x1, x0, atol=1e-14)
 
+    def test_denormals(self):
+        # Check that no warnings are emitted if the matrix contains
+        # numbers for which 1/x has no float representation, and that
+        # the solver behaves properly.
+        A = np.array([[1, 2], [3, 4]], dtype=float)
+        A *= 100 * np.nextafter(0, 1)
+
+        b = np.array([1, 1])
+
+        xp, info = gcrotmk(A, b)
+
+        if info == 0:
+            assert_allclose(A.dot(xp), b)
 
 if __name__ == "__main__":
     run_module_suite()

--- a/scipy/sparse/linalg/isolve/tests/test_gcrotmk.py
+++ b/scipy/sparse/linalg/isolve/tests/test_gcrotmk.py
@@ -4,7 +4,7 @@
 
 from __future__ import division, print_function, absolute_import
 
-from numpy.testing import TestCase, assert_, assert_allclose, assert_equal, run_module_suite
+from numpy.testing import assert_, assert_allclose, assert_equal
 
 import numpy as np
 from numpy import zeros, array, allclose
@@ -150,6 +150,3 @@ class TestGCROTMK(object):
 
         if info == 0:
             assert_allclose(A.dot(xp), b)
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/scipy/sparse/linalg/isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/isolve/tests/test_iterative.py
@@ -291,7 +291,7 @@ def test_precond_inverse():
             continue
         if solver is qmr:
             continue
-        yield check_precond_inverse, solver, case
+        check_precond_inverse(solver, case)
 
 
 def test_gmres_basic():


### PR DESCRIPTION
Fix some test errors introduced in gh-5910.

- Remove yield tests and run_module_suite.
- In LGMRES, bail out early with error if non-finite results were produced in Arnoldi cycle --- there's no way the algorithm can recover from this. (In `test_denormals`, the results overflow --- the solution is actually probably out of floating point range due to the denormals.)