### PR TITLE
MAINT: fix syntax in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,8 @@
 requires = [
     "wheel",
     "setuptools",
-    "numpy==1.8.2; python_version<=3.4",
-    "numpy==1.9.3; python_version==3.5",
-    "numpy==1.12.1; python_version==3.6",
-    "numpy==1.13.1; python_version>=3.7",
+    "numpy==1.8.2; python_version<='3.4'",
+    "numpy==1.9.3; python_version=='3.5'",
+    "numpy==1.12.1; python_version=='3.6'",
+    "numpy==1.13.1; python_version>='3.7'",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 requires = [
     "wheel",
     "setuptools",
+    "Cython>=0.23.4",
     "numpy==1.8.2; python_version<='3.4'",
     "numpy==1.9.3; python_version=='3.5'",
     "numpy==1.12.1; python_version=='3.6'",


### PR DESCRIPTION
Add missing quotes in environment specs in pyproject.toml

Also, add Cython.

Indeed:
```
>>> import pkg_resources
>>> list(pkg_resources.parse_requirements(["numpy==1.13.1; python_version >= '3.7'"]))
[Requirement.parse('numpy==1.13.1; python_version >= "3.7"')]
>>> list(pkg_resources.parse_requirements(["numpy==1.13.1; python_version >= 3.7"]))
Traceback (most recent call last):
  File "<ipython-input-30-26cc25707b3f>", line 1, in <module>
    list(pkg_resources.parse_requirements(["numpy==1.13.1; python_version >= 3.7"]))
  File "/usr/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2886, in parse_requirements
    yield Requirement(line)
  File "/usr/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2895, in __init__
    raise RequirementParseError(str(e))
RequirementParseError: Invalid requirement, parse error at "'; python'"
```