### PR TITLE
WIP: MAINT: collect release note fragments from Github pull requests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+
+*Write description of pull request here.*
+
+----
+
+[release-notes type="feature|deprecation|change|other" section="scipy.submodule"]
+*Text to insert to release notes, if any, in standard Github markdown format.
+Must be included for new features, added deprecations, and backward-incompatible
+changes. For major features, add also a title inside the [release-notes] block.
+If submitting a pull request, you can also add this information afterward if
+unsure.*
+[/release-notes]

--- a/doc/source/dev/releasing.rst
+++ b/doc/source/dev/releasing.rst
@@ -59,6 +59,9 @@ Before branching, ensure that the release notes are updated as far as possible.
 Include the output of ``tools/gh_lists.py`` and ``tools/authors.py`` in the
 release notes.
 
+The script ``tools/gh_lists.py`` also collects and formats release
+note fragments from Github pull requests assigned to the milestone.
+
 Maintenance branches are named ``maintenance/<major>.<minor>.x`` (e.g. 0.19.x).
 To create one, simply push a branch with the correct name to the scipy repo.
 Immediately after, push a commit where you increment the version number on the

--- a/tools/gh_lists.rst
+++ b/tools/gh_lists.rst
@@ -1,0 +1,89 @@
+{{# gh_lists.rst -- Tempita template for gh_lists.py output
+
+The following items are predefined in the context:
+
+milestone = "X.Y.Z"
+issues = list of issues: [namedtuple('Issue', ('id', 'title', 'url')), ...]
+prs = list of pull requests: [namedtuple('Issue', ('id', 'title', 'url')), ...]
+all_fragments = release note fragments: namedtuple('ReleaseNoteFragment',
+                                             ('issue_id', 'type', 'section', 'text',
+                                              'has_title'))
+sections = {type: {section: [fragment1, fragment2, ...], ...}, ...}
+types = list of types of fragments present
+
+def warn(msg): emit warning message
+def format_title(title, underline="-"): return rst underlined title
+def format_list(issue_list): return rst formatted list of issues
+}}
+
+{{py:
+
+TYPES = ["feature", "deprecation", "change", "other"]
+
+new_fragments = []
+for fragment in all_fragments:
+    if fragment.type not in TYPES and fragment.type != "other":
+        warn("gh-{}: unknown fragment type {}".format(fragment.issue_id, fragment.type))
+}}
+
+==========================
+SciPy {{milestone}} Release Notes
+==========================
+
+{{if sections.get("feature")}}
+New features
+============
+
+
+{{for section, fragments in sorted(sections["feature"].items())}}
+{{format_title("`{}` improvements".format(section))}}
+{{for fragment in fragments}}
+{{fragment.text}}
+{{endfor}}
+{{endfor}}
+{{endif}}
+
+{{if sections.get("deprecated")}}
+Deprecated features
+===================
+
+
+{{for section, fragments in sorted(sections["deprecation"].items())}}
+{{for fragment in fragments}}
+{{fragment.text}}
+{{endfor}}
+{{endfor}}
+{{endif}}
+
+{{if sections.get("change")}}
+Backwards incompatible changes
+==============================
+
+
+{{for section, fragments in sorted(sections["change"].items())}}
+{{for fragment in fragments}}
+{{fragment.text}}
+{{endfor}}
+{{endfor}}
+{{endif}}
+
+Other changes
+=============
+
+
+{{for types, secs in sorted(sections.items())}}
+{{for section, fragments in sorted(secs.items())}}
+{{for fragment in fragments}}
+{{if fragment.type not in ["feature", "deprecation", "change"]}}
+{{fragment.text}}
+{{endif}}
+{{endfor}}
+{{endfor}}
+{{endfor}}
+
+
+{{format_title("Issues closed for {}".format(milestone), "=")}}
+{{format_list(issues)}}
+
+{{format_title("Pull requests for {}".format(milestone), "=")}}
+{{format_list(prs)}}


### PR DESCRIPTION
Collect release note fragments from Github pull requests.

The fragments can be specified in the format

----

[release-notes type="feature|deprecation|change|other" section="scipy.cluster"]
### Title (optional), mainly for major features

Text to insert to release notes, if any, written in markdown. 
Must be included for new features, added deprecations, and 
backward-incompatible changes.
[/release-notes]

----

This is a POC for a suggestion by @charris in gh-7793.

I'm not 100% sure this is a good idea in the final picture (i.e. should reduce work required from release manager), but maybe useful for discussion.