### PR TITLE
DOC: changed coo doc to make duplicate index summing behavior clearer

### DIFF
--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -87,16 +87,15 @@ class coo_matrix(_data_matrix, _minmax_mixin):
 
     Examples
     --------
-    Constructing an empty matrix
-
+    
+    >>> # Constructing an empty matrix
     >>> from scipy.sparse import coo_matrix
     >>> coo_matrix((3, 4), dtype=np.int8).toarray()
     array([[0, 0, 0, 0],
            [0, 0, 0, 0],
            [0, 0, 0, 0]], dtype=int8)
 
-   Constructing a matrix using ijv format
-
+    >>> # Constructing a matrix using ijv format
     >>> row  = np.array([0, 3, 1, 0])
     >>> col  = np.array([0, 3, 1, 2])
     >>> data = np.array([4, 5, 7, 9])
@@ -106,8 +105,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
            [0, 0, 0, 0],
            [0, 0, 0, 5]])
 
-    Constructing a matrix with duplicate indices
-
+    >>> # Constructing a matrix with duplicate indices
     >>> row  = np.array([0, 0, 1, 3, 1, 0, 0])
     >>> col  = np.array([0, 2, 1, 3, 1, 0, 0])
     >>> data = np.array([1, 1, 1, 1, 1, 1, 1])
@@ -115,7 +113,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
     >>> # Duplicate indices are maintained until implicitly or explicitly summed
     >>> np.max(coo.data)
     1
-    >>> coo.to_array()
+    >>> coo.toarray()
     array([[3, 0, 1, 0],
            [0, 2, 0, 0],
            [0, 0, 0, 0],

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -87,7 +87,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
 
     Examples
     --------
-    Constructing a empty matrix
+    Constructing an empty matrix
 
     >>> from scipy.sparse import coo_matrix
     >>> coo_matrix((3, 4), dtype=np.int8).toarray()
@@ -106,13 +106,13 @@ class coo_matrix(_data_matrix, _minmax_mixin):
            [0, 0, 0, 0],
            [0, 0, 0, 5]])
 
-    Construcing a matrix with duplicates indicies
+    Constructing a matrix with duplicate indices
 
     >>> row  = np.array([0, 0, 1, 3, 1, 0, 0])
     >>> col  = np.array([0, 2, 1, 3, 1, 0, 0])
     >>> data = np.array([1, 1, 1, 1, 1, 1, 1])
     >>> coo = coo_matrix((data, (row, col)), shape=(4, 4))
-    >>> # duplicate indicies are maintained until implicitly or explicitly summed
+    >>> # Duplicate indices are maintained until implicitly or explicitly summed
     >>> np.max(coo.data)
     1
     >>> coo.to_array()

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -87,11 +87,15 @@ class coo_matrix(_data_matrix, _minmax_mixin):
 
     Examples
     --------
+    Constructing a empty matrix
+
     >>> from scipy.sparse import coo_matrix
     >>> coo_matrix((3, 4), dtype=np.int8).toarray()
     array([[0, 0, 0, 0],
            [0, 0, 0, 0],
            [0, 0, 0, 0]], dtype=int8)
+
+   Constructing a matrix using ijv format
 
     >>> row  = np.array([0, 3, 1, 0])
     >>> col  = np.array([0, 3, 1, 2])
@@ -102,11 +106,16 @@ class coo_matrix(_data_matrix, _minmax_mixin):
            [0, 0, 0, 0],
            [0, 0, 0, 5]])
 
-    >>> # example with duplicates
+    Construcing a matrix with duplicates indicies
+
     >>> row  = np.array([0, 0, 1, 3, 1, 0, 0])
     >>> col  = np.array([0, 2, 1, 3, 1, 0, 0])
     >>> data = np.array([1, 1, 1, 1, 1, 1, 1])
-    >>> coo_matrix((data, (row, col)), shape=(4, 4)).toarray()
+    >>> coo = coo_matrix((data, (row, col)), shape=(4, 4))
+    >>> # duplicate indicies are maintained until implicitly or explicitly summed
+    >>> np.max(coo.data)
+    1
+    >>> coo.to_array()
     array([[3, 0, 1, 0],
            [0, 2, 0, 0],
            [0, 0, 0, 0],


### PR DESCRIPTION
I recently spent about 3 hours trying to figure out why I wasn't getting the duplicate index summing behaviour that I expected from the coo constructor. I was following the documented example for the coo matrix, but totally missed the point.

I thought this was a bug, but #5807 makes it clear that the issue is deeper than that. 

In the end, I just wanted to make it clear when the summation is happening, instead of having it implicitly occur in the to_array() method.