### PR TITLE
ENH: sketches - Clarkson Woodruff Transform

### DIFF
--- a/scipy/linalg/__init__.py
+++ b/scipy/linalg/__init__.py
@@ -127,7 +127,7 @@ Matrix Equation Solvers
 
 
 Sketches and Random Projections
-==============
+===============================
 
 .. autosummary::
    :toctree: generated/

--- a/scipy/linalg/__init__.py
+++ b/scipy/linalg/__init__.py
@@ -126,6 +126,14 @@ Matrix Equation Solvers
    solve_discrete_lyapunov - Solve the discrete-time Lyapunov equation
 
 
+Sketches and Random Projections
+==============
+
+.. autosummary::
+   :toctree: generated/
+
+   clarkson_woodruff_transform - Applies the Clarkson Woodruff Sketch (a.k.a CountMin Sketch)
+
 Special Matrices
 ================
 
@@ -190,6 +198,7 @@ from .special_matrices import *
 from ._solvers import *
 from ._procrustes import *
 from ._decomp_update import *
+from ._sketches import *
 
 __all__ = [s for s in dir() if not s.startswith('_')]
 

--- a/scipy/linalg/_sketches.py
+++ b/scipy/linalg/_sketches.py
@@ -11,11 +11,11 @@ __all__ = ['clarkson_woodruff_transform']
 
 
 def cwt_matrix(n_rows, n_columns):
-    """
-    Generate a matrix S for the Clarkson-Woodruff sketch.
-    Given the desired size of matrix, the method returns a matrix S of size (n_rows, n_columns)
-    where each column has all the entries set to 0 less one position which has been randomly set to
-    +1 o -1 with equal probability.
+    r""""
+    Generate a matrix S for the Clarkson-Woodruff sketch. Given the desired
+    size of matrix, the method returns a matrix S of size (n_rows, n_columns)
+    where each column has all the entries set to 0 less one position which has
+    been randomly set to +1 o -1 with equal probability.
 
     Parameters
     ----------
@@ -30,7 +30,8 @@ def cwt_matrix(n_rows, n_columns):
 
     Notes
     -----
-    Given a matrix A, with probability at least 9/10, norm(SA) == (1+epsilon)*norm(A)
+    Given a matrix A, with probability at least 9/10,
+    .. math:: ||SA|| == (1 \pm \epsilon)||A||
     Where epsilon is related to the size of S
     """
     S = np.zeros((n_rows, n_columns))
@@ -42,15 +43,15 @@ def cwt_matrix(n_rows, n_columns):
     return S
 
 def clarkson_woodruff_transform(input_matrix, sketch_size):
-    """
-    Given an input_matrix  of size (n, d), compute a matrix A' of size  (sketch_size, d)
-    which holds:
+    r""""
+    Given an input_matrix  of size (n, d), compute a matrix A' of size
+    (sketch_size, d) which holds:
     
-    .. math:: ||Ax|| = (1 \pm \epsilon) ||A'x||
+    .. math:: ||Ax|| = (1 \pm \epsilon)||A'x||
 
     with high probability.
 
-    The error is related to the number of rows of the sketch. It is bounded 
+    The error is related to the number of rows of the sketch and it is bounded
     
     .. math:: poly(r(\epsilon^{-1}))
     
@@ -68,9 +69,12 @@ def clarkson_woodruff_transform(input_matrix, sketch_size):
 
     Notes
     -----
-    This is an implementation of the Clarckson-Woodruff Transform (also known as CountSketch) introduced for
-    first time in Kenneth L. Clarkson and David P. Woodruff. Low rank approximation and regression in input sparsity time. In STOC, 2013.
-    A' can be computed in O(nnz(A)) but we don't take advantage of sparse matrix in this implementation
+    This is an implementation of the Clarkson-Woodruff Transform
+    (also known as CountSketch) introduced for first time in
+    Kenneth L. Clarkson and David P. Woodruff. Low rank approximation and
+    regression in input sparsity time. In STOC, 2013.
+    A' can be computed in O(nnz(A)) but we don't take advantage of
+    sparse matrix in this implementation
     """
 
     S = cwt_matrix(sketch_size, input_matrix.shape[0])

--- a/scipy/linalg/_sketches.py
+++ b/scipy/linalg/_sketches.py
@@ -78,18 +78,17 @@ def clarkson_woodruff_transform(input_matrix, sketch_size):
     Given a big dense matrix `A`:
 
     >>> from scipy import linalg
-    >>> n_rows, n_colums, sketch_n_rows = (2000, 100, 100)
+    >>> n_rows, n_columns, sketch_n_rows = (2000, 100, 100)
     >>> threshold = 0.1
-    >>> tmp = np.random.normal(mu, sigma, n_rows*n_columns)
+    >>> tmp = np.random.normal(0, 0.1, n_rows*n_columns)
     >>> A = np.reshape(tmp, (n_rows, n_columns))
     >>> sketch = linalg.clarkson_woodruff_transform(A, sketch_n_rows)
     >>> sketch.shape
     (100, 100)
-    >>> normA = np.norm(A)
-    >>> normSketch = np.norm(sketch)
-    >>> # with high probability!
-    >>> abs(normA-normSketch) < threshold
-    True
+    >>> normA = linalg.norm(A)
+    >>> normSketch = linalg.norm(sketch)
+    >>> # with high probability
+    >>> # abs(normA-normSketch) < threshold
 
     References
     ----------

--- a/scipy/linalg/_sketches.py
+++ b/scipy/linalg/_sketches.py
@@ -12,9 +12,9 @@ __all__ = ['clarkson_woodruff_transform']
 
 def cwt_matrix(n_rows, n_columns):
     """
-    Generate a matrix S to be used in the Clarkson-Woodruff sketch.
-    Given the size of a desired matrix, the method returns a matrix S of size (n_rows, n_columns)
-    where each column has all the entries set to 0 less one position with has been randomly set to
+    Generate a matrix S for the Clarkson-Woodruff sketch.
+    Given the desired size of matrix, the method returns a matrix S of size (n_rows, n_columns)
+    where each column has all the entries set to 0 less one position which has been randomly set to
     +1 o -1 with equal probability.
 
     Parameters
@@ -46,9 +46,13 @@ def clarkson_woodruff_transform(input_matrix, sketch_size):
     Given an input_matrix  of size (n, d), compute a matrix A' of size  (sketch_size, d)
     which holds:
     
+    .. math:: ||Ax|| = (1 \pm \epsilon) ||A'x||
+
     with high probability.
 
-    The error is related to the number of rows of the sketch. sketch_size =
+    The error is related to the number of rows of the sketch. 
+    
+    .. math:: sketch_size = poly(r(\epsilon^{-1}))
     
     Parameters
     ----------

--- a/scipy/linalg/_sketches.py
+++ b/scipy/linalg/_sketches.py
@@ -34,6 +34,34 @@ def cwt_matrix(n_rows, n_columns):
     values = np.random.choice([1, -1], n_columns)
     for i in range(n_columns):
         S[nz_positions[i]][i] = values[i]
-    
+
     return S
 
+def clarkson_woodruff_transform(input_matrix, sketch_size):
+    """
+    Given an input_matrix  of size (n, d), compute a matrix A' of size  (sketch_size, d)
+    which holds:
+        $||Ax|| = (1 \pm \epsilon) ||A'x||$
+    with high probability.
+
+    The error is related to the number of rows of the sketch. sketch_size = $poly(r*\epsilon^{-1})$
+    
+    Parameters
+    ----------
+    input_matrix: (n, d) array_like
+        Input matrix
+    sketch_size: int
+        number of rows for the sketch
+    Returns
+    -------
+    A' : (sketch_size, d) array_like
+        Sketch of A
+    Notes
+    -----
+    This is an implementation of the Clarckson-Woodruff Transform (also known as CountSketch) introduced for
+    first time in Kenneth L. Clarkson and David P. Woodruff. Low rank approximation and regression in input sparsity time. In STOC, 2013.
+    A' can be computed in O(nnz(A)) but we don't take advantage of sparse matrix in this implementation
+    """
+
+    S = cwt_matrix(sketch_size, input_matrix.shape[0])
+    return np.dot(S, input_matrix)

--- a/scipy/linalg/_sketches.py
+++ b/scipy/linalg/_sketches.py
@@ -69,12 +69,31 @@ def clarkson_woodruff_transform(input_matrix, sketch_size):
 
     Notes
     -----
-    This is an implementation of the Clarkson-Woodruff Transform
-    (also known as CountSketch) introduced for first time in
-    Kenneth L. Clarkson and David P. Woodruff. Low rank approximation and
-    regression in input sparsity time. In STOC, 2013.
-    A' can be computed in O(nnz(A)) but we don't take advantage of
-    sparse matrix in this implementation
+    This is an implementation of the Clarkson-Woodruff Transform (CountSketch)
+    A' can be computed in O(nnz(A)) but we don't take advantage of sparse
+    matrices in this implementation
+
+    Examples
+    --------
+    Given a big dense matrix `A`:
+
+    >>> from scipy import linalg
+    >>> n_rows, n_colums, sketch_n_rows = (2000, 100, 100)
+    >>> threshold = 0.1
+    >>> A = make_random_dense_matrix(n_rows, n_columns)
+    >>> sketch = linalg.clarkson_woodruff_transform(A, sketch_n_rows)
+    >>> sketch.shape
+    (100, 100)
+    >>> normA = np.norm(A)
+    >>> normSketch = np.norm(sketch)
+    >>> # with high probability!
+    >>> abs(normA-normSketch) < threshold
+    True
+
+    References
+    ----------
+    .. [1] Kenneth L. Clarkson and David P. Woodruff. Low rank approximation and
+           regression in input sparsity time. In STOC, 2013.
     """
 
     S = cwt_matrix(sketch_size, input_matrix.shape[0])

--- a/scipy/linalg/_sketches.py
+++ b/scipy/linalg/_sketches.py
@@ -50,9 +50,9 @@ def clarkson_woodruff_transform(input_matrix, sketch_size):
 
     with high probability.
 
-    The error is related to the number of rows of the sketch. 
+    The error is related to the number of rows of the sketch. It is bounded 
     
-    .. math:: sketch_size = poly(r(\epsilon^{-1}))
+    .. math:: poly(r(\epsilon^{-1}))
     
     Parameters
     ----------

--- a/scipy/linalg/_sketches.py
+++ b/scipy/linalg/_sketches.py
@@ -14,19 +14,24 @@ __all__ = ['clarkson_woodruff_transform']
 
 def cwt_matrix(n_rows, n_columns, seed=None):
     r""""
-    Generate a matrix S for the Clarkson-Woodruff sketch. Given the desired
-    size of matrix, the method returns a matrix S of size (n_rows, n_columns)
-    where each column has all the entries set to 0 less one position which has
-    been randomly set to +1 o -1 with equal probability.
+    Generate a matrix S for the Clarkson-Woodruff sketch.
+
+    Given the desired size of matrix, the method returns a matrix S of size
+    (n_rows, n_columns) where each column has all the entries set to 0 less one
+    position which has been randomly set to +1 or -1 with equal probability.
 
     Parameters
     ----------
     n_rows: int
-        number of rows of S
+        Number of rows of S
     n_columns: int
-        number of columns of S
-    seed: int
-        Seed the generator
+        Number of columns of S
+    seed : None or int or `numpy.random.RandomState` instance, optional
+        This parameter defines the ``RandomState`` object to use for drawing
+        random variates.
+        If None (or ``np.random``), the global ``np.random`` state is used.
+        If integer, it is used to seed the local ``RandomState`` instance.
+        Default is None.
 
     Returns
     -------
@@ -47,42 +52,50 @@ def cwt_matrix(n_rows, n_columns, seed=None):
 
     return S
 
+
 def clarkson_woodruff_transform(input_matrix, sketch_size, seed=None):
     r""""
-    Given an input_matrix  of size (n, d), compute a matrix A' of size
-    (sketch_size, d) which holds:
-    
+    Find low-rank matrix approximation via the Clarkson-Woodruff Transform.
+
+    Given an input_matrix ``A`` of size ``(n, d)``, compute a matrix ``A'`` of
+    size (sketch_size, d) which holds:
+
     .. math:: ||Ax|| = (1 \pm \epsilon)||A'x||
 
     with high probability.
 
     The error is related to the number of rows of the sketch and it is bounded
-    
+
     .. math:: poly(r(\epsilon^{-1}))
-    
+
     Parameters
     ----------
-    input_matrix: (n, d) array_like
-        Input matrix
+    input_matrix: array_like
+        Input matrix, of shape ``(n, d)``.
     sketch_size: int
-        number of rows for the sketch
-    seed: int
-        Seed the generator
+        Number of rows for the sketch.
+    seed : None or int or `numpy.random.RandomState` instance, optional
+        This parameter defines the ``RandomState`` object to use for drawing
+        random variates.
+        If None (or ``np.random``), the global ``np.random`` state is used.
+        If integer, it is used to seed the local ``RandomState`` instance.
+        Default is None.
 
     Returns
     -------
-    A' : (sketch_size, d) array_like
-        Sketch of A
+    A' : array_like
+        Sketch of the input matrix ``A``, of size ``(sketch_size, d)``.
 
     Notes
     -----
-    This is an implementation of the Clarkson-Woodruff Transform (CountSketch)
-    A' can be computed in O(nnz(A)) but we don't take advantage of sparse
-    matrices in this implementation
+    This is an implementation of the Clarkson-Woodruff Transform (CountSketch).
+    ``A'`` can be computed in principle in ``O(nnz(A))`` (with ``nnz`` meaning
+    the number of nonzero entries), however we don't take advantage of sparse
+    matrices in this implementation.
 
     Examples
     --------
-    Given a big dense matrix `A`:
+    Given a big dense matrix ``A``:
 
     >>> from scipy import linalg
     >>> n_rows, n_columns, sketch_n_rows = (2000, 100, 100)
@@ -93,15 +106,16 @@ def clarkson_woodruff_transform(input_matrix, sketch_size, seed=None):
     >>> sketch.shape
     (100, 100)
     >>> normA = linalg.norm(A)
-    >>> normSketch = linalg.norm(sketch)
-    >>> # with high probability
-    >>> # abs(normA-normSketch) < threshold
+    >>> norm_sketch = linalg.norm(sketch)
+
+    Now with high probability, the condition ``abs(normA-normSketch) <
+    threshold`` holds.
 
     References
     ----------
     .. [1] Kenneth L. Clarkson and David P. Woodruff. Low rank approximation and
            regression in input sparsity time. In STOC, 2013.
-    """
 
+    """
     S = cwt_matrix(sketch_size, input_matrix.shape[0], seed)
     return np.dot(S, input_matrix)

--- a/scipy/linalg/_sketches.py
+++ b/scipy/linalg/_sketches.py
@@ -80,7 +80,8 @@ def clarkson_woodruff_transform(input_matrix, sketch_size):
     >>> from scipy import linalg
     >>> n_rows, n_colums, sketch_n_rows = (2000, 100, 100)
     >>> threshold = 0.1
-    >>> A = make_random_dense_matrix(n_rows, n_columns)
+    >>> tmp = np.random.normal(mu, sigma, n_rows*n_columns)
+    >>> A = np.reshape(tmp, (n_rows, n_columns))
     >>> sketch = linalg.clarkson_woodruff_transform(A, sketch_n_rows)
     >>> sketch.shape
     (100, 100)

--- a/scipy/linalg/_sketches.py
+++ b/scipy/linalg/_sketches.py
@@ -67,6 +67,7 @@ def clarkson_woodruff_transform(input_matrix, sketch_size):
     This is an implementation of the Clarckson-Woodruff Transform (also known as CountSketch) introduced for
     first time in Kenneth L. Clarkson and David P. Woodruff. Low rank approximation and regression in input sparsity time. In STOC, 2013.
     A' can be computed in O(nnz(A)) but we don't take advantage of sparse matrix in this implementation
+
     """
 
     S = cwt_matrix(sketch_size, input_matrix.shape[0])

--- a/scipy/linalg/_sketches.py
+++ b/scipy/linalg/_sketches.py
@@ -7,10 +7,12 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 
+from scipy._lib._util import check_random_state
+
 __all__ = ['clarkson_woodruff_transform']
 
 
-def cwt_matrix(n_rows, n_columns):
+def cwt_matrix(n_rows, n_columns, seed=None):
     r""""
     Generate a matrix S for the Clarkson-Woodruff sketch. Given the desired
     size of matrix, the method returns a matrix S of size (n_rows, n_columns)
@@ -23,6 +25,8 @@ def cwt_matrix(n_rows, n_columns):
         number of rows of S
     n_columns: int
         number of columns of S
+    seed: int
+        Seed the generator
 
     Returns
     -------
@@ -36,13 +40,14 @@ def cwt_matrix(n_rows, n_columns):
     """
     S = np.zeros((n_rows, n_columns))
     nz_positions = np.random.randint(0, n_rows, n_columns)
-    values = np.random.choice([1, -1], n_columns)
+    rng = check_random_state(seed)
+    values = rng.choice([1, -1], n_columns)
     for i in range(n_columns):
         S[nz_positions[i]][i] = values[i]
 
     return S
 
-def clarkson_woodruff_transform(input_matrix, sketch_size):
+def clarkson_woodruff_transform(input_matrix, sketch_size, seed=None):
     r""""
     Given an input_matrix  of size (n, d), compute a matrix A' of size
     (sketch_size, d) which holds:
@@ -61,6 +66,8 @@ def clarkson_woodruff_transform(input_matrix, sketch_size):
         Input matrix
     sketch_size: int
         number of rows for the sketch
+    seed: int
+        Seed the generator
 
     Returns
     -------
@@ -96,5 +103,5 @@ def clarkson_woodruff_transform(input_matrix, sketch_size):
            regression in input sparsity time. In STOC, 2013.
     """
 
-    S = cwt_matrix(sketch_size, input_matrix.shape[0])
+    S = cwt_matrix(sketch_size, input_matrix.shape[0], seed)
     return np.dot(S, input_matrix)

--- a/scipy/linalg/_sketches.py
+++ b/scipy/linalg/_sketches.py
@@ -7,6 +7,8 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 
+__all__ = ['clarkson_woodruff_transform']
+
 
 def cwt_matrix(n_rows, n_columns):
     """
@@ -14,12 +16,14 @@ def cwt_matrix(n_rows, n_columns):
     Given the size of a desired matrix, the method returns a matrix S of size (n_rows, n_columns)
     where each column has all the entries set to 0 less one position with has been randomly set to
     +1 o -1 with equal probability.
+
     Parameters
     ----------
     n_rows: int
         number of rows of S
     n_columns: int
         number of columns of S
+
     Returns
     -------
     S : (n_rows, n_columns) array_like
@@ -41,7 +45,7 @@ def clarkson_woodruff_transform(input_matrix, sketch_size):
     """
     Given an input_matrix  of size (n, d), compute a matrix A' of size  (sketch_size, d)
     which holds:
-        $||Ax|| = (1 \pm \epsilon) ||A'x||$
+    $||Ax|| = (1 \pm \epsilon) ||A'x||$
     with high probability.
 
     The error is related to the number of rows of the sketch. sketch_size = $poly(r*\epsilon^{-1})$
@@ -52,10 +56,12 @@ def clarkson_woodruff_transform(input_matrix, sketch_size):
         Input matrix
     sketch_size: int
         number of rows for the sketch
+
     Returns
     -------
     A' : (sketch_size, d) array_like
         Sketch of A
+
     Notes
     -----
     This is an implementation of the Clarckson-Woodruff Transform (also known as CountSketch) introduced for

--- a/scipy/linalg/_sketches.py
+++ b/scipy/linalg/_sketches.py
@@ -1,0 +1,39 @@
+""" Sketching-based Matrix Computations """
+
+# Author: Jordi Montes <jomsdev@gmail.com>
+# August 28, 2017
+
+from __future__ import division, print_function, absolute_import
+
+import numpy as np
+
+
+def cwt_matrix(n_rows, n_columns):
+    """
+    Generate a matrix S to be used in the Clarkson-Woodruff sketch.
+    Given the size of a desired matrix, the method returns a matrix S of size (n_rows, n_columns)
+    where each column has all the entries set to 0 less one position with has been randomly set to
+    +1 o -1 with equal probability.
+    Parameters
+    ----------
+    n_rows: int
+        number of rows of S
+    n_columns: int
+        number of columns of S
+    Returns
+    -------
+    S : (n_rows, n_columns) array_like
+
+    Notes
+    -----
+    Given a matrix A, with probability at least 9/10, norm(SA) == (1+epsilon)*norm(A)
+    Where epsilon is related to the size of S
+    """
+    S = np.zeros((n_rows, n_columns))
+    nz_positions = np.random.randint(0, n_rows, n_columns)
+    values = np.random.choice([1, -1], n_columns)
+    for i in range(n_columns):
+        S[nz_positions[i]][i] = values[i]
+    
+    return S
+

--- a/scipy/linalg/_sketches.py
+++ b/scipy/linalg/_sketches.py
@@ -45,10 +45,10 @@ def clarkson_woodruff_transform(input_matrix, sketch_size):
     """
     Given an input_matrix  of size (n, d), compute a matrix A' of size  (sketch_size, d)
     which holds:
-    $||Ax|| = (1 \pm \epsilon) ||A'x||$
+    
     with high probability.
 
-    The error is related to the number of rows of the sketch. sketch_size = $poly(r*\epsilon^{-1})$
+    The error is related to the number of rows of the sketch. sketch_size =
     
     Parameters
     ----------
@@ -67,7 +67,6 @@ def clarkson_woodruff_transform(input_matrix, sketch_size):
     This is an implementation of the Clarckson-Woodruff Transform (also known as CountSketch) introduced for
     first time in Kenneth L. Clarkson and David P. Woodruff. Low rank approximation and regression in input sparsity time. In STOC, 2013.
     A' can be computed in O(nnz(A)) but we don't take advantage of sparse matrix in this implementation
-
     """
 
     S = cwt_matrix(sketch_size, input_matrix.shape[0])

--- a/scipy/linalg/tests/test_sketches.py
+++ b/scipy/linalg/tests/test_sketches.py
@@ -1,0 +1,82 @@
+"""Tests for _sketches.py."""
+
+from __future__ import division, print_function, absolute_import
+import numpy as np
+from scipy.linalg import clarkson_woodruff_transform
+
+__usage__ = """
+Build linalg:
+  python setup_linalg.py build
+Run tests if scipy is installed:
+  python -c 'import scipy;scipy.linalg.test()'
+"""
+
+from numpy.testing import (assert_equal, assert_almost_equal,
+                           assert_array_almost_equal, assert_array_equal,
+                           assert_raises, assert_, assert_allclose)
+from nose.tools import (assert_true)
+
+import pytest
+
+
+def make_random_dense_gaussian_matrix(n_rows, n_columns, mu=0, sigma=0.01):
+    """
+    Make some random data with Gaussian distributed values
+    """
+    res = np.random.normal(mu, sigma, n_rows*n_columns)
+    return np.reshape(res, (n_rows, n_columns))
+
+class TestClarksonWoodruffTransform(object):
+    """
+    Testing the Clarkson Woodruff Transform
+    """
+    # Big dense matrix dimensions
+    n_matrix_rows = 2000
+    n_matrix_columns = 100
+
+    # Sketch matrix dimensions
+    n_sketch_rows = 100
+
+    # Repetitions/max_errors per test
+    repetitions_per_test = 10
+    n_max_errors = 3
+
+    # Error threshold
+    threshold = 0.1
+
+    dense_big_matrix = make_random_dense_gaussian_matrix(n_matrix_rows,
+        n_matrix_columns)
+    
+
+    def test_sketch_dimensions(self):
+        sketch = clarkson_woodruff_transform(
+            self.dense_big_matrix,
+            self.n_sketch_rows
+        )
+
+        assert_true(
+            sketch.shape == (
+                self.n_sketch_rows,
+                self.dense_big_matrix.shape[1]
+            )
+        )
+
+
+    def test_sketch_rows_norm(self):
+        # Given the probabilistic nature of the sketches
+        # we run the 'test' multiple times and check that
+        # we pass all/almost all the tries
+        
+        n_errors = 0
+        for _ in range(self.repetitions_per_test):
+            sketch = clarkson_woodruff_transform(
+                self.dense_big_matrix,
+                self.n_sketch_rows
+            )
+
+            #we could use other norms (like L2)
+            err = np.linalg.norm(self.dense_big_matrix) - np.linalg.norm(sketch)
+            if err > self.threshold:
+                n_errors+=1
+        
+        assert_true(n_errors <= self.n_max_errors)

--- a/scipy/linalg/tests/test_sketches.py
+++ b/scipy/linalg/tests/test_sketches.py
@@ -51,7 +51,7 @@ class TestClarksonWoodruffTransform(object):
             self.dense_big_matrix,
             self.n_sketch_rows)
 
-        assert(sketch.shape == (
+        assert_(sketch.shape == (
             self.n_sketch_rows,
             self.dense_big_matrix.shape[1]))
 
@@ -69,4 +69,4 @@ class TestClarksonWoodruffTransform(object):
             err = np.linalg.norm(self.dense_big_matrix) - np.linalg.norm(sketch)
             if err > self.threshold:
                 n_errors += 1
-        assert(n_errors <= self.n_max_errors)
+        assert_(n_errors <= self.n_max_errors)

--- a/scipy/linalg/tests/test_sketches.py
+++ b/scipy/linalg/tests/test_sketches.py
@@ -47,36 +47,28 @@ class TestClarksonWoodruffTransform(object):
     dense_big_matrix = make_random_dense_gaussian_matrix(n_matrix_rows,
         n_matrix_columns)
     
-
     def test_sketch_dimensions(self):
         sketch = clarkson_woodruff_transform(
             self.dense_big_matrix,
-            self.n_sketch_rows
-        )
+            self.n_sketch_rows)
 
         assert_true(
             sketch.shape == (
                 self.n_sketch_rows,
-                self.dense_big_matrix.shape[1]
-            )
-        )
-
+                self.dense_big_matrix.shape[1]))
 
     def test_sketch_rows_norm(self):
         # Given the probabilistic nature of the sketches
         # we run the 'test' multiple times and check that
         # we pass all/almost all the tries
-        
         n_errors = 0
         for _ in range(self.repetitions_per_test):
             sketch = clarkson_woodruff_transform(
                 self.dense_big_matrix,
-                self.n_sketch_rows
-            )
+                self.n_sketch_rows)
 
             #we could use other norms (like L2)
             err = np.linalg.norm(self.dense_big_matrix) - np.linalg.norm(sketch)
             if err > self.threshold:
-                n_errors+=1
-        
+                n_errors += 1
         assert_true(n_errors <= self.n_max_errors)

--- a/scipy/linalg/tests/test_sketches.py
+++ b/scipy/linalg/tests/test_sketches.py
@@ -51,10 +51,9 @@ class TestClarksonWoodruffTransform(object):
             self.dense_big_matrix,
             self.n_sketch_rows)
 
-        assert(
-            sketch.shape == (
-                self.n_sketch_rows,
-                self.dense_big_matrix.shape[1]))
+        assert(sketch.shape == (
+            self.n_sketch_rows,
+            self.dense_big_matrix.shape[1]))
 
     def test_sketch_rows_norm(self):
         # Given the probabilistic nature of the sketches

--- a/scipy/linalg/tests/test_sketches.py
+++ b/scipy/linalg/tests/test_sketches.py
@@ -4,13 +4,6 @@ from __future__ import division, print_function, absolute_import
 import numpy as np
 from scipy.linalg import clarkson_woodruff_transform
 
-__usage__ = """
-Build linalg:
-  python setup_linalg.py build
-Run tests if scipy is installed:
-  python -c 'import scipy;scipy.linalg.test()'
-"""
-
 from numpy.testing import (assert_equal, assert_almost_equal,
                            assert_array_almost_equal, assert_array_equal,
                            assert_raises, assert_, assert_allclose)

--- a/scipy/linalg/tests/test_sketches.py
+++ b/scipy/linalg/tests/test_sketches.py
@@ -4,19 +4,17 @@ from __future__ import division, print_function, absolute_import
 import numpy as np
 from scipy.linalg import clarkson_woodruff_transform
 
-from numpy.testing import (assert_equal, assert_almost_equal,
-                           assert_array_almost_equal, assert_array_equal,
-                           assert_raises, assert_, assert_allclose)
-
-import pytest
+from numpy.testing import assert_
 
 
 def make_random_dense_gaussian_matrix(n_rows, n_columns, mu=0, sigma=0.01):
     """
     Make some random data with Gaussian distributed values
     """
+    np.random.seed(142352345)
     res = np.random.normal(mu, sigma, n_rows*n_columns)
     return np.reshape(res, (n_rows, n_columns))
+
 
 class TestClarksonWoodruffTransform(object):
     """
@@ -33,16 +31,14 @@ class TestClarksonWoodruffTransform(object):
     threshold = 0.1
 
     dense_big_matrix = make_random_dense_gaussian_matrix(n_matrix_rows,
-        n_matrix_columns)
-    
-    def test_sketch_dimensions(self):
-        sketch = clarkson_woodruff_transform(
-            self.dense_big_matrix,
-            self.n_sketch_rows)
+                                                         n_matrix_columns)
 
-        assert_(sketch.shape == (
-            self.n_sketch_rows,
-            self.dense_big_matrix.shape[1]))
+    def test_sketch_dimensions(self):
+        sketch = clarkson_woodruff_transform(self.dense_big_matrix,
+                                             self.n_sketch_rows)
+
+        assert_(sketch.shape == (self.n_sketch_rows,
+                                 self.dense_big_matrix.shape[1]))
 
     def test_sketch_rows_norm(self):
         # Given the probabilistic nature of the sketches
@@ -54,13 +50,12 @@ class TestClarksonWoodruffTransform(object):
                  1302443994, 1521083269, 1501189312, 1126232505, 1533465685]
 
         for seed_ in seeds:
-            sketch = clarkson_woodruff_transform(
-                self.dense_big_matrix,
-                self.n_sketch_rows,
-                seed_)
+            sketch = clarkson_woodruff_transform(self.dense_big_matrix,
+                                                 self.n_sketch_rows, seed_)
 
-            #we could use other norms (like L2)
+            # We could use other norms (like L2)
             err = np.linalg.norm(self.dense_big_matrix) - np.linalg.norm(sketch)
             if err > self.threshold:
                 n_errors += 1
+
         assert_(n_errors == 0)

--- a/scipy/linalg/tests/test_sketches.py
+++ b/scipy/linalg/tests/test_sketches.py
@@ -29,10 +29,6 @@ class TestClarksonWoodruffTransform(object):
     # Sketch matrix dimensions
     n_sketch_rows = 100
 
-    # Repetitions/max_errors per test
-    repetitions_per_test = 10
-    n_max_errors = 3
-
     # Error threshold
     threshold = 0.1
 
@@ -53,13 +49,18 @@ class TestClarksonWoodruffTransform(object):
         # we run the 'test' multiple times and check that
         # we pass all/almost all the tries
         n_errors = 0
-        for _ in range(self.repetitions_per_test):
+
+        seeds = [1755490010, 934377150, 1391612830, 1752708722, 2008891431,
+                 1302443994, 1521083269, 1501189312, 1126232505, 1533465685]
+
+        for seed_ in seeds:
             sketch = clarkson_woodruff_transform(
                 self.dense_big_matrix,
-                self.n_sketch_rows)
+                self.n_sketch_rows,
+                seed_)
 
             #we could use other norms (like L2)
             err = np.linalg.norm(self.dense_big_matrix) - np.linalg.norm(sketch)
             if err > self.threshold:
                 n_errors += 1
-        assert_(n_errors <= self.n_max_errors)
+        assert_(n_errors == 0)

--- a/scipy/linalg/tests/test_sketches.py
+++ b/scipy/linalg/tests/test_sketches.py
@@ -14,7 +14,6 @@ Run tests if scipy is installed:
 from numpy.testing import (assert_equal, assert_almost_equal,
                            assert_array_almost_equal, assert_array_equal,
                            assert_raises, assert_, assert_allclose)
-from nose.tools import (assert_true)
 
 import pytest
 
@@ -52,7 +51,7 @@ class TestClarksonWoodruffTransform(object):
             self.dense_big_matrix,
             self.n_sketch_rows)
 
-        assert_true(
+        assert(
             sketch.shape == (
                 self.n_sketch_rows,
                 self.dense_big_matrix.shape[1]))
@@ -71,4 +70,4 @@ class TestClarksonWoodruffTransform(object):
             err = np.linalg.norm(self.dense_big_matrix) - np.linalg.norm(sketch)
             if err > self.threshold:
                 n_errors += 1
-        assert_true(n_errors <= self.n_max_errors)
+        assert(n_errors <= self.n_max_errors)

--- a/scipy/spatial/qhull_misc_config.h
+++ b/scipy/spatial/qhull_misc_config.h
@@ -1,0 +1,1 @@
+#define HAVE_OPEN_MEMSTREAM 1

--- a/scipy/spatial/qhull_misc_config.h
+++ b/scipy/spatial/qhull_misc_config.h
@@ -1,1 +1,0 @@
-#define HAVE_OPEN_MEMSTREAM 1


### PR DESCRIPTION
Hello,

This pull request contains an implementation of the Clarkson Woodruff Trasnformation (CountMin Sketch/ CWT) for dense numpy arrays.

I suggested to integrate some methods of Randomized Numerical Linear Algebra (RandNLA) to scipy some time ago. After some discussion [here](https://github.com/scipy/scipy/issues/7122) and in the mailing list I decided to start with this one.

Long story short sketching is a way to compress matrices that preserve essential matrix properties. The idea is given a problem that involves some matrices "project" it to some smaller vector space and solve the problem there. These methods give us some warranties about the result (it can be estimated before the computations). 

RandNLA can be applied to solve problems like least-squares and robust regression, eigenvector analysis, non-negative matrix factorization, etc...

This CWT implementation is based on my library called [RandNLA](https://github.com/jomsdev/randNLA) which is based on the [original paper](https://arxiv.org/abs/1207.6365). There is room for further optimizations and improvements like taking advantage of sparsity. If the community shows interest on them I would not have any problem in taking the time to improve it.

How to use the `clarkson_woodruff_transform` is quite intuitive:

```python
# big_dense_matrix is a matrix of size (n, d) with rank r
# sketch becomes a matrix of size (n_sketch_rows, d)
# which holds ||big_dense_matrix||_k == (1+epsilon)||sketch||_k
# where epsilon is bound poly(r*epsilon^-1) with high probability
sketch = clarkson_woodruff_transform(
            big_dense_matrix,
            n_sketch_rows
        )
```

Given the interest shown by other members of the community I put the code under a new file `scipy/linalg/_sketches.py` where other sketches/random projections can be implemented.

Thanks for taking the time of checking the code,

Jordi.

**Warning:** _This is my first, (I hope of many) pull request to this project. I would advice you to take it with a grain of salt and tell me as many modifications as are necessary to preserve the quality of this library_ 

