### PR TITLE
ENH: Add eig(vals)_tridiagonal

### DIFF
--- a/scipy/linalg/__init__.py
+++ b/scipy/linalg/__init__.py
@@ -54,8 +54,8 @@ Eigenvalue Problems
    eigvalsh - Find just the eigenvalues of a Hermitian or symmetric matrix
    eig_banded - Find the eigenvalues and eigenvectors of a banded matrix
    eigvals_banded - Find just the eigenvalues of a banded matrix
-   eig_tridiagonal - Find the eigenvalues and eigenvectors of a tridiagonal matrix
-   eigvals_tridiagonal - Find just the eigenvalues of a tridiagonal matrix
+   eigh_tridiagonal - Find the eigenvalues and eigenvectors of a tridiagonal matrix
+   eigvalsh_tridiagonal - Find just the eigenvalues of a tridiagonal matrix
 
 Decompositions
 ==============

--- a/scipy/linalg/__init__.py
+++ b/scipy/linalg/__init__.py
@@ -54,6 +54,8 @@ Eigenvalue Problems
    eigvalsh - Find just the eigenvalues of a Hermitian or symmetric matrix
    eig_banded - Find the eigenvalues and eigenvectors of a banded matrix
    eigvals_banded - Find just the eigenvalues of a banded matrix
+   eig_tridiagonal - Find the eigenvalues and eigenvectors of a tridiagonal matrix
+   eigvals_tridiagonal - Find just the eigenvalues of a tridiagonal matrix
 
 Decompositions
 ==============
@@ -167,7 +169,7 @@ Low-level routines
 
    `scipy.linalg.cython_lapack` -- Low-level LAPACK functions for Cython
 
-"""
+"""  # noqa: E501
 
 from __future__ import division, print_function, absolute_import
 

--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -16,7 +16,7 @@ from __future__ import division, print_function, absolute_import
 
 __all__ = ['eig', 'eigvals', 'eigh', 'eigvalsh',
            'eig_banded', 'eigvals_banded',
-           'eig_tridiagonal', 'eigvals_tridiagonal', 'hessenberg']
+           'eigh_tridiagonal', 'eigvalsh_tridiagonal', 'hessenberg']
 
 import numpy
 from numpy import (array, isfinite, inexact, nonzero, iscomplexobj, cast,
@@ -178,7 +178,7 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False,
     eigh : Eigenvalues and right eigenvectors for symmetric/Hermitian arrays.
     eig_banded : eigenvalues and right eigenvectors for symmetric/Hermitian
         band matrices
-    eig_tridiagonal : eigenvalues and right eiegenvectors for
+    eigh_tridiagonal : eigenvalues and right eiegenvectors for
         symmetric/Hermitian tridiagonal matrices
     """
     a1 = _asarray_validated(a, check_finite=check_finite)
@@ -323,7 +323,7 @@ def eigh(a, b=None, lower=True, eigvals_only=False, overwrite_a=False,
     eigvalsh : eigenvalues of symmetric or Hermitian arrays
     eig : eigenvalues and right eigenvectors for non-symmetric arrays
     eigh : eigenvalues and right eigenvectors for symmetric/Hermitian arrays
-    eig_tridiagonal : eigenvalues and right eiegenvectors for
+    eigh_tridiagonal : eigenvalues and right eiegenvectors for
         symmetric/Hermitian tridiagonal matrices
     """
     a1 = _asarray_validated(a, check_finite=check_finite)
@@ -569,7 +569,7 @@ def eig_banded(a_band, lower=False, eigvals_only=False, overwrite_a_band=False,
     eigvals_banded : eigenvalues for symmetric/Hermitian band matrices
     eig : eigenvalues and right eigenvectors of general arrays.
     eigh : eigenvalues and right eigenvectors for symmetric/Hermitian arrays
-    eig_tridiagonal : eigenvalues and right eiegenvectors for
+    eigh_tridiagonal : eigenvalues and right eiegenvectors for
         symmetric/Hermitian tridiagonal matrices
     """
     if eigvals_only or overwrite_a_band:
@@ -679,7 +679,7 @@ def eigvals(a, b=None, overwrite_a=False, check_finite=True,
     eig : eigenvalues and right eigenvectors of general arrays.
     eigvalsh : eigenvalues of symmetric or Hermitian arrays
     eigvals_banded : eigenvalues for symmetric/Hermitian band matrices
-    eigvals_tridiagonal : eigenvalues of symmetric/Hermitian tridiagonal
+    eigvalsh_tridiagonal : eigenvalues of symmetric/Hermitian tridiagonal
         matrices
     """
     return eig(a, b=b, left=0, right=0, overwrite_a=overwrite_a,
@@ -755,7 +755,7 @@ def eigvalsh(a, b=None, lower=True, overwrite_a=False,
     eigh : eigenvalues and right eigenvectors for symmetric/Hermitian arrays
     eigvals : eigenvalues of general arrays
     eigvals_banded : eigenvalues for symmetric/Hermitian band matrices
-    eigvals_tridiagonal : eigenvalues of symmetric/Hermitian tridiagonal
+    eigvalsh_tridiagonal : eigenvalues of symmetric/Hermitian tridiagonal
         matrices
     """
     return eigh(a, b=b, lower=lower, eigvals_only=True,
@@ -836,7 +836,7 @@ def eigvals_banded(a_band, lower=False, overwrite_a_band=False,
     --------
     eig_banded : eigenvalues and right eigenvectors for symmetric/Hermitian
         band matrices
-    eigvals_tridiagonal : eigenvalues of symmetric/Hermitian tridiagonal
+    eigvalsh_tridiagonal : eigenvalues of symmetric/Hermitian tridiagonal
         matrices
     eigvals : eigenvalues of general arrays
     eigh : eigenvalues and right eigenvectors for symmetric/Hermitian arrays
@@ -847,10 +847,10 @@ def eigvals_banded(a_band, lower=False, overwrite_a_band=False,
                       select_range=select_range, check_finite=check_finite)
 
 
-def eigvals_tridiagonal(d, e, select='a', select_range=None, check_finite=True,
-                        tol=0., lapack_driver='auto'):
+def eigvalsh_tridiagonal(d, e, select='a', select_range=None,
+                         check_finite=True, tol=0., lapack_driver='auto'):
     """
-    Solve tridiagonal eigenvalue problem.
+    Solve eigenvalue problem for a real symmetric tridiagonal matrix.
 
     Find eigenvalues `w` of ``a``::
 
@@ -908,18 +908,18 @@ def eigvals_tridiagonal(d, e, select='a', select_range=None, check_finite=True,
 
     See Also
     --------
-    eig_tridiagonal : eigenvalues and right eiegenvectors for
+    eigh_tridiagonal : eigenvalues and right eiegenvectors for
         symmetric/Hermitian tridiagonal matrices
     """
-    return eig_tridiagonal(
+    return eigh_tridiagonal(
         d, e, eigvals_only=True, select=select, select_range=select_range,
         check_finite=check_finite, tol=tol, lapack_driver=lapack_driver)
 
 
-def eig_tridiagonal(d, e, eigvals_only=False, select='a', select_range=None,
-                    check_finite=True, tol=0., lapack_driver='auto'):
+def eigh_tridiagonal(d, e, eigvals_only=False, select='a', select_range=None,
+                     check_finite=True, tol=0., lapack_driver='auto'):
     """
-    Solve tridiagonal eigenvalue problem.
+    Solve eigenvalue problem for a real symmetric tridiagonal matrix.
 
     Find eigenvalues `w` and optionally right eigenvectors `v` of ``a``::
 
@@ -983,7 +983,7 @@ def eig_tridiagonal(d, e, eigvals_only=False, select='a', select_range=None,
 
     See Also
     --------
-    eigvals_tridiagonal : eigenvalues of symmetric/Hermitian tridiagonal
+    eigvalsh_tridiagonal : eigenvalues of symmetric/Hermitian tridiagonal
         matrices
     eig : eigenvalues and right eigenvectors for non-symmetric arrays
     eigh : eigenvalues and right eigenvectors for symmetric/Hermitian arrays
@@ -1044,7 +1044,7 @@ def eig_tridiagonal(d, e, eigvals_only=False, select='a', select_range=None,
         e_[:-1] = e
         m, w, v, info = func(d, e_, select, vl, vu, il, iu,
                              compute_v=compute_v)
-    _check_info(info, lapack_driver + ' (eig_tridiagonal)')
+    _check_info(info, lapack_driver + ' (eigh_tridiagonal)')
     w = w[:m]
     if eigvals_only:
         return w
@@ -1053,7 +1053,7 @@ def eig_tridiagonal(d, e, eigvals_only=False, select='a', select_range=None,
         if lapack_driver == 'stebz':
             func, = get_lapack_funcs(('stein',), (d, e))
             v, info = func(d, e, w, iblock, isplit)
-            _check_info(info, 'stein (eig_tridiagonal)',
+            _check_info(info, 'stein (eigh_tridiagonal)',
                         positive='%d eigenvectors failed to converge')
             # Convert block-order to matrix-order
             order = argsort(w)

--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -1042,8 +1042,12 @@ def eigh_tridiagonal(d, e, eigvals_only=False, select='a', select_range=None,
         # ?STEMR annoyingly requires size N instead of N-1
         e_ = empty(e.size+1, e.dtype)
         e_[:-1] = e
+        stemr_lwork, = get_lapack_funcs(('stemr_lwork',), (d, e))
+        lwork, liwork, info = stemr_lwork(d, e_, select, vl, vu, il, iu,
+                                          compute_v=compute_v)
+        _check_info(info, 'stemr_lwork')
         m, w, v, info = func(d, e_, select, vl, vu, il, iu,
-                             compute_v=compute_v)
+                             compute_v=compute_v, lwork=lwork, liwork=liwork)
     _check_info(info, lapack_driver + ' (eigh_tridiagonal)')
     w = w[:m]
     if eigvals_only:

--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -14,15 +14,17 @@
 
 from __future__ import division, print_function, absolute_import
 
-__all__ = ['eig', 'eigh', 'eig_banded', 'eigvals', 'eigvalsh',
-           'eigvals_banded', 'hessenberg']
+__all__ = ['eig', 'eigvals', 'eigh', 'eigvalsh',
+           'eig_banded', 'eigvals_banded',
+           'eig_tridiagonal', 'eigvals_tridiagonal', 'hessenberg']
 
 import numpy
 from numpy import (array, isfinite, inexact, nonzero, iscomplexobj, cast,
-                   flatnonzero, conj)
+                   flatnonzero, conj, asarray, argsort, empty)
 # Local imports
 from scipy._lib.six import xrange
 from scipy._lib._util import _asarray_validated
+from scipy._lib.six import string_types
 from .misc import LinAlgError, _datacopied, norm
 from .lapack import get_lapack_funcs, _compute_lwork
 
@@ -62,7 +64,7 @@ def _make_eigvals(alpha, beta, homogeneous_eigvals):
             # Use numpy.inf for complex values too since
             # 1/numpy.inf = 0, i.e. it correctly behaves as projective
             # infinity.
-            w[~alpha_zero & beta_zero] = numpy.inf 
+            w[~alpha_zero & beta_zero] = numpy.inf
             if numpy.all(alpha.imag == 0):
                 w[alpha_zero & beta_zero] = numpy.nan
             else:
@@ -70,7 +72,8 @@ def _make_eigvals(alpha, beta, homogeneous_eigvals):
             return w
 
 
-def _geneig(a1, b1, left, right, overwrite_a, overwrite_b, homogeneous_eigvals):
+def _geneig(a1, b1, left, right, overwrite_a, overwrite_b,
+            homogeneous_eigvals):
     ggev, = get_lapack_funcs(('ggev',), (a1, b1))
     cvl, cvr = left, right
     res = ggev(a1, b1, lwork=-1)
@@ -176,8 +179,12 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False,
 
     See Also
     --------
+    eigvals : eigenvalues of general arrays
     eigh : Eigenvalues and right eigenvectors for symmetric/Hermitian arrays.
-
+    eig_banded : eigenvalues and right eigenvectors for symmetric/Hermitian
+        band matrices
+    eig_tridiagonal : eigenvalues and right eiegenvectors for
+        symmetric/Hermitian tridiagonal matrices
     """
     a1 = _asarray_validated(a, check_finite=check_finite)
     if len(a1.shape) != 2 or a1.shape[0] != a1.shape[1]:
@@ -321,8 +328,11 @@ def eigh(a, b=None, lower=True, eigvals_only=False, overwrite_a=False,
 
     See Also
     --------
+    eigvalsh : eigenvalues of symmetric or Hermitian arrays
     eig : eigenvalues and right eigenvectors for non-symmetric arrays
-
+    eigh : eigenvalues and right eigenvectors for symmetric/Hermitian arrays
+    eig_tridiagonal : eigenvalues and right eiegenvectors for
+        symmetric/Hermitian tridiagonal matrices
     """
     a1 = _asarray_validated(a, check_finite=check_finite)
     if len(a1.shape) != 2 or a1.shape[0] != a1.shape[1]:
@@ -445,6 +455,42 @@ def eigh(a, b=None, lower=True, eigvals_only=False, overwrite_a=False,
                           " computed." % (info-b1.shape[0]))
 
 
+_conv_dict = {0: 0, 1: 1, 2: 2,
+              'all': 0, 'value': 1, 'index': 2,
+              'a': 0, 'v': 1, 'i': 2}
+
+
+def _check_select(select, select_range, max_ev, max_len):
+    """Check that select is valid, convert to Fortran style."""
+    if isinstance(select, string_types):
+        select = select.lower()
+    try:
+        select = _conv_dict[select]
+    except KeyError:
+        raise ValueError('invalid argument for select')
+    vl, vu = 0., 1.
+    il = iu = 1
+    if select != 0:  # (non-all)
+        sr = asarray(select_range)
+        if sr.ndim != 1 or sr.size != 2 or sr[1] < sr[0]:
+            raise ValueError('select_range must be a 2-element array-like '
+                             'in nondecreasing order')
+        if select == 1:  # (value)
+            vl, vu = sr
+            if max_ev == 0:
+                max_ev = max_len
+        else:  # 2 (index)
+            if sr.dtype.char.lower() not in 'lih':
+                raise ValueError('when using select="i", select_range must '
+                                 'contain integers, got dtype %s' % sr.dtype)
+            # translate Python (0 ... N-1) into Fortran (1 ... N) with + 1
+            il, iu = sr + 1
+            if min(il, iu) < 1 or max(il, iu) > max_len:
+                raise ValueError('select_range out of bounds')
+            max_ev = iu - il + 1
+    return select, vl, vu, il, iu, max_ev
+
+
 def eig_banded(a_band, lower=False, eigvals_only=False, overwrite_a_band=False,
                select='a', select_range=None, max_ev=0, check_finite=True):
     """
@@ -520,8 +566,18 @@ def eig_banded(a_band, lower=False, eigvals_only=False, overwrite_a_band=False,
         The normalized eigenvector corresponding to the eigenvalue w[i] is
         the column v[:,i].
 
-    Raises LinAlgError if eigenvalue computation does not converge
+    Raises
+    ------
+    LinAlgError
+        If eigenvalue computation does not converge.
 
+    See Also
+    --------
+    eigvals_banded : eigenvalues for symmetric/Hermitian band matrices
+    eig : eigenvalues and right eigenvectors of general arrays.
+    eigh : eigenvalues and right eigenvectors for symmetric/Hermitian arrays
+    eig_tridiagonal : eigenvalues and right eiegenvectors for
+        symmetric/Hermitian tridiagonal matrices
     """
     if eigvals_only or overwrite_a_band:
         a1 = _asarray_validated(a_band, check_finite=check_finite)
@@ -534,37 +590,25 @@ def eig_banded(a_band, lower=False, eigvals_only=False, overwrite_a_band=False,
 
     if len(a1.shape) != 2:
         raise ValueError('expected two-dimensional array')
-    if select.lower() not in [0, 1, 2, 'a', 'v', 'i', 'all', 'value', 'index']:
-        raise ValueError('invalid argument for select')
-    if select.lower() in [0, 'a', 'all']:
+    select, vl, vu, il, iu, max_ev = _check_select(
+        select, select_range, max_ev, a1.shape[1])
+    del select_range
+    if select == 0:
         if a1.dtype.char in 'GFD':
-            bevd, = get_lapack_funcs(('hbevd',), (a1,))
             # FIXME: implement this somewhen, for now go with builtin values
             # FIXME: calc optimal lwork by calling ?hbevd(lwork=-1)
             #        or by using calc_lwork.f ???
             # lwork = calc_lwork.hbevd(bevd.typecode, a1.shape[0], lower)
             internal_name = 'hbevd'
         else:  # a1.dtype.char in 'fd':
-            bevd, = get_lapack_funcs(('sbevd',), (a1,))
             # FIXME: implement this somewhen, for now go with builtin values
             #         see above
             # lwork = calc_lwork.sbevd(bevd.typecode, a1.shape[0], lower)
             internal_name = 'sbevd'
+        bevd, = get_lapack_funcs((internal_name,), (a1,))
         w, v, info = bevd(a1, compute_v=not eigvals_only,
                           lower=lower, overwrite_ab=overwrite_a_band)
-    if select.lower() in [1, 2, 'i', 'v', 'index', 'value']:
-        # calculate certain range only
-        if select.lower() in [2, 'i', 'index']:
-            select = 2
-            vl, vu, il, iu = 0.0, 0.0, min(select_range), max(select_range)
-            if min(il, iu) < 0 or max(il, iu) >= a1.shape[1]:
-                raise ValueError('select_range out of bounds')
-            max_ev = iu - il + 1
-        else:  # 1, 'v', 'value'
-            select = 1
-            vl, vu, il, iu = min(select_range), max(select_range), 0, 0
-            if max_ev == 0:
-                max_ev = a_band.shape[1]
+    else:  # select in [1, 2]
         if eigvals_only:
             max_ev = 1
         # calculate optimal abstol for dsbevx (see manpage)
@@ -574,19 +618,14 @@ def eig_banded(a_band, lower=False, eigvals_only=False, overwrite_a_band=False,
             lamch, = get_lapack_funcs(('lamch',), (array(0, dtype='d'),))
         abstol = 2 * lamch('s')
         if a1.dtype.char in 'GFD':
-            bevx, = get_lapack_funcs(('hbevx',), (a1,))
             internal_name = 'hbevx'
         else:  # a1.dtype.char in 'gfd'
-            bevx, = get_lapack_funcs(('sbevx',), (a1,))
             internal_name = 'sbevx'
-        # il+1, iu+1: translate python indexing (0 ... N-1) into Fortran
-        # indexing (1 ... N)
-        w, v, m, ifail, info = bevx(a1, vl, vu, il+1, iu+1,
-                                    compute_v=not eigvals_only,
-                                    mmax=max_ev,
-                                    range=select, lower=lower,
-                                    overwrite_ab=overwrite_a_band,
-                                    abstol=abstol)
+        bevx, = get_lapack_funcs((internal_name,), (a1,))
+        w, v, m, ifail, info = bevx(
+            a1, vl, vu, il, iu, compute_v=not eigvals_only, mmax=max_ev,
+            range=select, lower=lower, overwrite_ab=overwrite_a_band,
+            abstol=abstol)
         # crop off w and v
         w = w[:m]
         if not eigvals_only:
@@ -648,10 +687,11 @@ def eigvals(a, b=None, overwrite_a=False, check_finite=True,
 
     See Also
     --------
-    eigvalsh : eigenvalues of symmetric or Hermitian arrays,
     eig : eigenvalues and right eigenvectors of general arrays.
-    eigh : eigenvalues and eigenvectors of symmetric/Hermitian arrays.
-
+    eigvalsh : eigenvalues of symmetric or Hermitian arrays
+    eigvals_banded : eigenvalues for symmetric/Hermitian band matrices
+    eigvals_tridiagonal : eigenvalues of symmetric/Hermitian tridiagonal
+        matrices
     """
     return eig(a, b=b, left=0, right=0, overwrite_a=overwrite_a,
                check_finite=check_finite,
@@ -723,10 +763,11 @@ def eigvalsh(a, b=None, lower=True, overwrite_a=False,
 
     See Also
     --------
-    eigvals : eigenvalues of general arrays
     eigh : eigenvalues and right eigenvectors for symmetric/Hermitian arrays
-    eig : eigenvalues and right eigenvectors for non-symmetric arrays
-
+    eigvals : eigenvalues of general arrays
+    eigvals_banded : eigenvalues for symmetric/Hermitian band matrices
+    eigvals_tridiagonal : eigenvalues of symmetric/Hermitian tridiagonal
+        matrices
     """
     return eigh(a, b=b, lower=lower, eigvals_only=True,
                 overwrite_a=overwrite_a, overwrite_b=overwrite_b,
@@ -797,22 +838,243 @@ def eigvals_banded(a_band, lower=False, overwrite_a_band=False,
         The eigenvalues, in ascending order, each repeated according to its
         multiplicity.
 
-    Raises LinAlgError if eigenvalue computation does not converge
+    Raises
+    ------
+    LinAlgError
+        If eigenvalue computation does not converge.
 
     See Also
     --------
     eig_banded : eigenvalues and right eigenvectors for symmetric/Hermitian
         band matrices
+    eigvals_tridiagonal : eigenvalues of symmetric/Hermitian tridiagonal
+        matrices
     eigvals : eigenvalues of general arrays
     eigh : eigenvalues and right eigenvectors for symmetric/Hermitian arrays
     eig : eigenvalues and right eigenvectors for non-symmetric arrays
-
     """
     return eig_banded(a_band, lower=lower, eigvals_only=1,
                       overwrite_a_band=overwrite_a_band, select=select,
                       select_range=select_range, check_finite=check_finite)
 
-_double_precision = ['i', 'l', 'd']
+
+def eigvals_tridiagonal(d, e, select='a', select_range=None, check_finite=True,
+                        tol=0., lapack_driver='auto'):
+    """
+    Solve tridiagonal eigenvalue problem.
+
+    Find eigenvalues `w` of ``a``::
+
+        a v[:,i] = w[i] v[:,i]
+        v.H v    = identity
+
+    For a real symmetric matrix ``a`` with diagonal elements `d` and
+    off-diagonal elements `e`.
+
+    Parameters
+    ----------
+    d : ndarray, shape (ndim,)
+        The diagonal elements of the array.
+    e : ndarray, shape (ndim-1,)
+        The off-diagonal elements of the array.
+    select : {'a', 'v', 'i'}, optional
+        Which eigenvalues to calculate
+
+        ======  ========================================
+        select  calculated
+        ======  ========================================
+        'a'     All eigenvalues
+        'v'     Eigenvalues in the interval (min, max]
+        'i'     Eigenvalues with indices min <= i <= max
+        ======  ========================================
+    select_range : (min, max), optional
+        Range of selected eigenvalues
+    check_finite : bool, optional
+        Whether to check that the input matrix contains only finite numbers.
+        Disabling may give a performance gain, but may result in problems
+        (crashes, non-termination) if the inputs do contain infinities or NaNs.
+    tol : float
+        The absolute tolerance to which each eigenvalue is required
+        (only used when ``lapack_driver='stebz'``).
+        An eigenvalue (or cluster) is considered to have converged if it
+        lies in an interval of this width. If <= 0. (default),
+        the value ``eps*|a|`` is used where eps is the machine precision,
+        and ``|a|`` is the 1-norm of the matrix ``a``.
+    lapack_driver : str
+        LAPACK function to use, can be 'auto', 'stemr', 'stebz',  'sterf',
+        or 'stev'. When 'auto' (default), it will use 'stemr' if ``select='a'``
+        and 'stebz' otherwise. 'sterf' and 'stev' can only be used when
+        ``select='a'``.
+
+    Returns
+    -------
+    w : (M,) ndarray
+        The eigenvalues, in ascending order, each repeated according to its
+        multiplicity.
+
+    Raises
+    ------
+    LinAlgError
+        If eigenvalue computation does not converge.
+
+    See Also
+    --------
+    eig_tridiagonal : eigenvalues and right eiegenvectors for
+        symmetric/Hermitian tridiagonal matrices
+    """
+    return eig_tridiagonal(
+        d, e, eigvals_only=True, select=select, select_range=select_range,
+        check_finite=check_finite, tol=tol, lapack_driver=lapack_driver)
+
+
+def eig_tridiagonal(d, e, eigvals_only=False, select='a', select_range=None,
+                    check_finite=True, tol=0., lapack_driver='auto'):
+    """
+    Solve tridiagonal eigenvalue problem.
+
+    Find eigenvalues `w` and optionally right eigenvectors `v` of ``a``::
+
+        a v[:,i] = w[i] v[:,i]
+        v.H v    = identity
+
+    For a real symmetric matrix ``a`` with diagonal elements `d` and
+    off-diagonal elements `e`.
+
+    Parameters
+    ----------
+    d : ndarray, shape (ndim,)
+        The diagonal elements of the array.
+    e : ndarray, shape (ndim-1,)
+        The off-diagonal elements of the array.
+    select : {'a', 'v', 'i'}, optional
+        Which eigenvalues to calculate
+
+        ======  ========================================
+        select  calculated
+        ======  ========================================
+        'a'     All eigenvalues
+        'v'     Eigenvalues in the interval (min, max]
+        'i'     Eigenvalues with indices min <= i <= max
+        ======  ========================================
+    select_range : (min, max), optional
+        Range of selected eigenvalues
+    check_finite : bool, optional
+        Whether to check that the input matrix contains only finite numbers.
+        Disabling may give a performance gain, but may result in problems
+        (crashes, non-termination) if the inputs do contain infinities or NaNs.
+    tol : float
+        The absolute tolerance to which each eigenvalue is required
+        (only used when 'stebz' is the `lapack_driver`).
+        An eigenvalue (or cluster) is considered to have converged if it
+        lies in an interval of this width. If <= 0. (default),
+        the value ``eps*|a|`` is used where eps is the machine precision,
+        and ``|a|`` is the 1-norm of the matrix ``a``.
+    lapack_driver : str
+        LAPACK function to use, can be 'auto', 'stemr', 'stebz', 'sterf',
+        or 'stev'. When 'auto' (default), it will use 'stemr' if ``select='a'``
+        and 'stebz' otherwise. When 'stebz' is used to find the eigenvalues and
+        ``eigvals_only=False``, then a second LAPACK call (to ``?STEIN``) is
+        used to find the corresponding eigenvectors. 'sterf' can only be
+        used when ``eigvals_only=True`` and ``select='a'``. 'stev' can only
+        be used when ``select='a'``.
+
+    Returns
+    -------
+    w : (M,) ndarray
+        The eigenvalues, in ascending order, each repeated according to its
+        multiplicity.
+    v : (M, M) ndarray
+        The normalized eigenvector corresponding to the eigenvalue ``w[i]`` is
+        the column ``v[:,i]``.
+
+    Raises
+    ------
+    LinAlgError
+        If eigenvalue computation does not converge.
+
+    See Also
+    --------
+    eigvals_tridiagonal : eigenvalues of symmetric/Hermitian tridiagonal
+        matrices
+    eig : eigenvalues and right eigenvectors for non-symmetric arrays
+    eigh : eigenvalues and right eigenvectors for symmetric/Hermitian arrays
+    eig_banded : eigenvalues and right eigenvectors for symmetric/Hermitian
+        band matrices
+
+    Notes
+    -----
+    This function makes use of LAPACK ``S/DSTEMR`` routines.
+    """
+    d = _asarray_validated(d, check_finite=check_finite)
+    e = _asarray_validated(e, check_finite=check_finite)
+    for check in (d, e):
+        if check.ndim != 1:
+            raise ValueError('expected one-dimensional array')
+        if check.dtype.char in 'GFD':  # complex
+            raise TypeError('Only real arrays currently supported')
+    if d.size != e.size + 1:
+        raise ValueError('d (%s) must have one more element than e (%s)'
+                         % (d.size, e.size))
+    select, vl, vu, il, iu, _ = _check_select(
+        select, select_range, 0, d.size)
+    if not isinstance(lapack_driver, string_types):
+        raise TypeError('lapack_driver must be str')
+    drivers = ('auto', 'stemr', 'sterf', 'stebz', 'stev')
+    if lapack_driver not in drivers:
+        raise ValueError('lapack_driver must be one of %s, got %s'
+                         % (drivers, lapack_driver))
+    if lapack_driver == 'auto':
+        lapack_driver = 'stemr' if select == 0 else 'stebz'
+    func, = get_lapack_funcs((lapack_driver,), (d, e))
+    compute_v = not eigvals_only
+    if lapack_driver == 'sterf':
+        if select != 0:
+            raise ValueError('sterf can only be used when select == "a"')
+        if not eigvals_only:
+            raise ValueError('sterf can only be used when eigvals_only is '
+                             'True')
+        w, info = func(d, e)
+        m = len(w)
+    elif lapack_driver == 'stev':
+        if select != 0:
+            raise ValueError('stev can only be used when select == "a"')
+        w, v, info = func(d, e, compute_v=compute_v)
+        m = len(w)
+    elif lapack_driver == 'stebz':
+        tol = float(tol)
+        internal_name = 'stebz'
+        stebz, = get_lapack_funcs((internal_name,), (d, e))
+        # If getting eigenvectors, needs to be block-ordered (B) instead of
+        # matirx-ordered (E), and we will reorder later
+        order = 'E' if eigvals_only else 'B'
+        m, w, iblock, isplit, info = stebz(d, e, select, vl, vu, il, iu, tol,
+                                           order)
+    else:   # 'stemr'
+        # ?STEMR annoyingly requires size N instead of N-1
+        e_ = empty(e.size+1, e.dtype)
+        e_[:-1] = e
+        m, w, v, info = func(d, e_, select, vl, vu, il, iu,
+                             compute_v=compute_v)
+    if info < 0:
+        raise ValueError('illegal value in argument %d of internal %s'
+                         % (-info, lapack_driver))
+    if info > 0:
+        raise LinAlgError("eigvals_tridiagonal algorithm %s did not converge "
+                          "(%d)" % (lapack_driver, info,))
+    w = w[:m]
+    if eigvals_only:
+        return w
+    else:
+        # Do we still need to compute the eigenvalues?
+        if lapack_driver == 'stebz':
+            func, = get_lapack_funcs(('stein',), (d, e))
+            v, info = func(d, e, w, iblock, isplit)
+            # Convert block-order to matrix-order
+            order = argsort(w)
+            w, v = w[order], v[:, order]
+        else:
+            v = v[:, :m]
+        return w, v
 
 
 def hessenberg(a, calc_q=False, overwrite_a=False, check_finite=True):

--- a/scipy/linalg/flapack.pyf.src
+++ b/scipy/linalg/flapack.pyf.src
@@ -2796,7 +2796,7 @@ subroutine <prefix2>stebz(d,e,range,vl,vu,il,iu,tol,order,n,work,iwork,m,nsplit,
   callprotoargument char*,char*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,int*,int*,int*,int*
 
   <ftype2> dimension(n),intent(in) :: d
-  <ftype2> dimension(n-1),intent(in) :: e
+  <ftype2> dimension(n-1),depend(n),intent(in) :: e
   <ftype2> intent(in) :: vl
   <ftype2> intent(in) :: vu
   character intent(in) :: order
@@ -2823,7 +2823,7 @@ subroutine <prefix2>sterf(d,e,n,info)
   callprotoargument int*,<ctype2>*,<ctype2>*,int*
 
   <ftype2> dimension(n),intent(in,out,copy,out=vals) :: d
-  <ftype2> dimension(n-1),intent(in,copy) :: e
+  <ftype2> dimension(n-1),depend(n),intent(in,copy) :: e
   integer depend(d),intent(hide) :: n = shape(d,0)
   integer intent(out) :: info
 end subroutine <prefix2>sterf
@@ -2837,17 +2837,17 @@ subroutine <prefix2>stein(d,e,w,iblock,isplit,m,n,z,ldz,work,iwork,ifail,info)
   callprotoargument int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,int*,int*,int*
 
   <ftype2> dimension(n),intent(in) :: d
-  <ftype2> dimension(n-1),intent(in) :: e
+  <ftype2> dimension(n-1),depend(n),intent(in) :: e
   <ftype2> dimension(m),intent(in) :: w
   integer depend(w),intent(hide) :: m = shape(w,0)
   integer depend(d),intent(hide),check(n>0) :: n = shape(d,0)
-  integer dimension(n),intent(in) :: iblock
-  integer dimension(n),intent(in) :: isplit
+  integer dimension(n),depend(n),intent(in) :: iblock
+  integer dimension(n),depend(n),intent(in) :: isplit
   <ftype2> dimension(ldz,m),intent(out) :: z
   integer depend(n),intent(hide) :: ldz = n
   <ftype2> dimension(5*n),intent(hide) :: work
   integer dimension(n),intent(hide) :: iwork
-  integer dimension(n),intent(hide) :: ifail  ! really dimension(m), but not known ahead of time
+  integer dimension(m),depend(m),intent(hide) :: ifail
   integer intent(out) :: info
 end subroutine <prefix2>stein
 
@@ -2871,7 +2871,7 @@ subroutine <prefix2>stemr(d,e,range,vl,vu,il,iu,compute_v,n,m,w,z,ldz,nzc,isuppz
   <ftype2> dimension(n),depend(n),intent(out) :: w
   <ftype2> dimension(n,n),depend(n),intent(out) :: z
   integer depend(n),intent(hide) :: ldz = (compute_v?n:1)  ! could be made more efficient for index queries
-  integer depend(n),intent(hide) :: nzc = n
+  integer depend(n),intent(hide) :: nzc = n  ! can also be passed as -1 to do a query
   integer dimension((compute_v?2*n:1)),depend(n),intent(hide) :: isuppz
   integer intent(hide) :: tryrac = 1
   integer depend(n),intent(hide) :: lwork = (compute_v?18*n:12*n)

--- a/scipy/linalg/flapack.pyf.src
+++ b/scipy/linalg/flapack.pyf.src
@@ -488,7 +488,7 @@ interface
    end subroutine <prefix2c>unghr
 
    subroutine <prefix2c>unghr_lwork(n,lo,hi,a,tau,work,lwork,info)
-     ! LWORK computation ofr orghr
+     ! LWORK computation for orghr
      fortranname <prefix2c>unghr
      callstatement { hi++; lo++; (*f2py_func)(&n,&lo,&hi,&a,&n,&tau,&work,&lwork,&info); }
      callprotoargument int*,int*,int*,<ctype2c>*,int*,<ctype2c>*,<ctype2c>*,int*,int*
@@ -2874,12 +2874,43 @@ subroutine <prefix2>stemr(d,e,range,vl,vu,il,iu,compute_v,n,m,w,z,ldz,nzc,isuppz
   integer depend(n),intent(hide) :: nzc = n  ! can also be passed as -1 to do a query
   integer dimension((compute_v?2*n:1)),depend(n),intent(hide) :: isuppz
   integer intent(hide) :: tryrac = 1
-  integer depend(n),intent(hide) :: lwork = (compute_v?18*n:12*n)
+  integer depend(n),optional,intent(in),check(lwork>=(compute_v?18*n:12*n)) :: lwork = (compute_v?18*n:12*n)
   <ftype2> dimension(lwork),depend(lwork),intent(hide) :: work
-  integer intent(hide) :: liwork = (compute_v?10*n:8*n)
+  integer depend(n),optional,intent(in),check(liwork>=(compute_v?10*n:8*n)) :: liwork = (compute_v?10*n:8*n)
   integer dimension(liwork),depend(liwork),intent(hide) :: iwork
   integer intent(out) :: info
 end subroutine <prefix2>stemr
+
+
+subroutine <prefix2>stemr_lwork(d,e,range,vl,vu,il,iu,compute_v,n,m,w,z,ldz,nzc,isuppz,tryrac,work,lwork,iwork,liwork,info)
+  ! LWORK=-1, LIWORK=-1 call for STEMR
+
+  fortranname <prefix2c>stemr
+  callstatement (*f2py_func)((compute_v?"V":"N"),(range>0?(range==1?"V":"I"):"A"),&n,d,e,&vl,&vu,&il,&iu,&m,w,z,&ldz,&nzc,isuppz,&tryrac,&work,&lwork,&iwork,&liwork,&info)
+  callprotoargument char*,char*,int*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,int*,int*,int*,<ctype2>*,<ctype2>*,int*,int*,int*,int*,<ctype2>*,int*,int*,int*,int*
+
+  <ftype2> dimension(n),intent(in,copy) :: d
+  <ftype2> dimension(n),intent(in,copy) :: e
+  integer intent(in) :: range
+  <ftype2> intent(in) :: vl
+  <ftype2> intent(in) :: vu
+  integer intent(in) :: il
+  integer intent(in) :: iu
+  integer optional,intent(in) :: compute_v = 1
+  integer intent(hide),depend(d),check(n>0) :: n = shape(d,0)
+  integer intent(hide) :: m
+  <ftype2> dimension(n),depend(n),intent(hide) :: w
+  <ftype2> dimension(n,n),depend(n),intent(hide) :: z
+  integer depend(n),intent(hide) :: ldz = (compute_v?n:1)  ! could be made more efficient for index queries
+  integer depend(n),intent(hide) :: nzc = n  ! can also be passed as -1 to do a query
+  integer dimension((compute_v?2*n:1)),depend(n),intent(hide) :: isuppz
+  integer intent(hide) :: tryrac = 1
+  integer depend(n),intent(hide) :: lwork = -1
+  <ftype2> intent(out) :: work
+  integer intent(hide) :: liwork = -1
+  integer intent(out) :: iwork
+  integer intent(out) :: info
+end subroutine <prefix2>stemr_lwork
 
 
 subroutine <prefix2>stev(d,e,compute_v,n,z,ldz,work,info)

--- a/scipy/linalg/flapack.pyf.src
+++ b/scipy/linalg/flapack.pyf.src
@@ -2788,6 +2788,100 @@ subroutine <prefix2>sbevx(ab,ldab,compute_v,range,lower,n,kd,q,ldq,vl,vu,il,iu,a
 end subroutine <prefix2>sbevx
 
 
+subroutine <prefix2>stebz(d,e,range,vl,vu,il,iu,tol,order,n,work,iwork,m,nsplit,w,iblock,isplit,info)
+  ! computes all or selected eigenvalues of a real, symmetric tridiagonal
+  ! matrix.
+
+  callstatement (*f2py_func)((range>0?(range==1?"V":"I"):"A"),order,&n,&vl,&vu,&il,&iu,&tol,d,e,&m,&nsplit,w,iblock,isplit,work,iwork,&info)
+  callprotoargument char*,char*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,int*,int*,int*,int*
+
+  <ftype2> dimension(n),intent(in) :: d
+  <ftype2> dimension(n-1),intent(in) :: e
+  <ftype2> intent(in) :: vl
+  <ftype2> intent(in) :: vu
+  character intent(in) :: order
+  integer intent(in) :: il
+  integer intent(in) :: iu
+  <ftype2> intent(in) :: tol
+  integer intent(in) :: range
+  integer depend(d),intent(hide) :: n = shape(d,0)
+  <ftype2> dimension(MAX(1,4*n)),depend(n),intent(hide) :: work  ! The dimension of work must be at least max(1, 4n).
+  integer dimension(MAX(1,3*n)),depend(n),intent(hide) :: iwork  ! Array, size at least max(1, 3n).
+  integer intent(out) :: m
+  integer intent(hide) :: nsplit
+  <ftype2> dimension(MAX(1,n)),depend(n),intent(out) :: w  ! Array, size at least max(1, n).
+  integer dimension(MAX(1,n)),depend(n),intent(out) :: iblock  ! Arrays, size at least max(1, n).
+  integer dimension(MAX(1,n)),depend(n),intent(out) :: isplit
+  integer intent(out) :: info
+end subroutine <prefix2>stebz
+
+
+subroutine <prefix2>sterf(d,e,n,info)
+  ! computes all eigenvalues of a real, symmetric tridiagonal matrix.
+
+  callstatement (*f2py_func)(&n,d,e,&info)
+  callprotoargument int*,<ctype2>*,<ctype2>*,int*
+
+  <ftype2> dimension(n),intent(in,out,copy,out=vals) :: d
+  <ftype2> dimension(n-1),intent(in,copy) :: e
+  integer depend(d),intent(hide) :: n = shape(d,0)
+  integer intent(out) :: info
+end subroutine <prefix2>sterf
+
+
+subroutine <prefix2>stein(d,e,w,iblock,isplit,m,n,z,ldz,work,iwork,ifail,info)
+  ! computes eigenvectors corresponding to eigenvalues of a real, symmetric
+  ! tridiagonal matrix.
+
+  callstatement (*f2py_func)(&n,d,e,&m,w,iblock,isplit,z,&ldz,work,iwork,ifail,&info)
+  callprotoargument int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,int*,int*,int*
+
+  <ftype2> dimension(n),intent(in) :: d
+  <ftype2> dimension(n-1),intent(in) :: e
+  <ftype2> dimension(m),intent(in) :: w
+  integer depend(w),intent(hide) :: m = shape(w,0)
+  integer depend(d),intent(hide) :: n = shape(d,0)
+  integer dimension(n),intent(in) :: iblock
+  integer dimension(n),intent(in) :: isplit
+  <ftype2> dimension(ldz,m),intent(out) :: z
+  integer depend(n),intent(hide) :: ldz = MAX(1,n)
+  <ftype2> dimension(5*n),intent(hide) :: work
+  integer dimension(n),intent(hide) :: iwork
+  integer dimension(n),intent(hide) :: ifail  ! really dimension(m), but not known ahead of time
+  integer intent(out) :: info
+end subroutine <prefix2>stein
+
+
+subroutine <prefix2>stemr(d,e,range,vl,vu,il,iu,compute_v,n,m,w,z,ldz,nzc,isuppz,tryrac,work,lwork,iwork,liwork,info)
+  ! computes all eigenvalues of a real, symmetric tridiagonal matrix.
+
+  callstatement (*f2py_func)((compute_v?"V":"N"),(range>0?(range==1?"V":"I"):"A"),&n,d,e,&vl,&vu,&il,&iu,&m,w,z,&ldz,&nzc,isuppz,&tryrac,work,&lwork,iwork,&liwork,&info)
+  callprotoargument char*,char*,int*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,int*,int*,int*,<ctype2>*,<ctype2>*,int*,int*,int*,int*,<ctype2>*,int*,int*,int*,int*
+
+  <ftype2> dimension(n),intent(in,copy) :: d
+  <ftype2> dimension(n),intent(in) :: e
+  integer intent(in) :: range
+  <ftype2> intent(in) :: vl
+  <ftype2> intent(in) :: vu
+  integer intent(in) :: il
+  integer intent(in) :: iu
+  integer optional,intent(in) :: compute_v = 1
+  integer intent(hide),depend(d) :: n = shape(d,0)
+  integer intent(out) :: m
+  <ftype2> dimension(MAX(1,n)),depend(n),intent(out) :: w
+  <ftype2> dimension(MAX(1,n),MAX(1,n)),depend(n),intent(out) :: z
+  integer depend(n),intent(hide) :: ldz = (compute_v?MAX(1,n):1)  ! could be made more efficient for index queries
+  integer depend(n),intent(hide) :: nzc = MAX(1,n)
+  integer dimension((compute_v?2*MAX(1,n):1)),depend(n),intent(hide) :: isuppz
+  integer intent(hide) :: tryrac = 1
+  integer depend(n),intent(hide) :: lwork = MAX(1,(compute_v?18*n:12*n))
+  <ftype2> dimension(lwork),depend(lwork),intent(hide) :: work
+  integer intent(hide) :: liwork = MAX(1,(compute_v?10*n:8*n))
+  integer dimension(liwork),depend(liwork),intent(hide) :: iwork
+  integer intent(out) :: info
+end subroutine <prefix2>stemr
+
+
 subroutine <prefix2>stev(d,e,compute_v,n,z,ldz,work,info)
   ! computes all eigenvalues, and, optionally eigvectors of a real,
   ! symmetric tridiagonal matrix.

--- a/scipy/linalg/flapack.pyf.src
+++ b/scipy/linalg/flapack.pyf.src
@@ -2804,14 +2804,14 @@ subroutine <prefix2>stebz(d,e,range,vl,vu,il,iu,tol,order,n,work,iwork,m,nsplit,
   integer intent(in) :: iu
   <ftype2> intent(in) :: tol
   integer intent(in) :: range
-  integer depend(d),intent(hide) :: n = shape(d,0)
-  <ftype2> dimension(MAX(1,4*n)),depend(n),intent(hide) :: work  ! The dimension of work must be at least max(1, 4n).
-  integer dimension(MAX(1,3*n)),depend(n),intent(hide) :: iwork  ! Array, size at least max(1, 3n).
+  integer depend(d),intent(hide),check(n>0) :: n = shape(d,0)
+  <ftype2> dimension(4*n),depend(n),intent(hide) :: work
+  integer dimension(3*n),depend(n),intent(hide) :: iwork
   integer intent(out) :: m
   integer intent(hide) :: nsplit
-  <ftype2> dimension(MAX(1,n)),depend(n),intent(out) :: w  ! Array, size at least max(1, n).
-  integer dimension(MAX(1,n)),depend(n),intent(out) :: iblock  ! Arrays, size at least max(1, n).
-  integer dimension(MAX(1,n)),depend(n),intent(out) :: isplit
+  <ftype2> dimension(n),depend(n),intent(out) :: w
+  integer dimension(n),depend(n),intent(out) :: iblock
+  integer dimension(n),depend(n),intent(out) :: isplit
   integer intent(out) :: info
 end subroutine <prefix2>stebz
 
@@ -2840,11 +2840,11 @@ subroutine <prefix2>stein(d,e,w,iblock,isplit,m,n,z,ldz,work,iwork,ifail,info)
   <ftype2> dimension(n-1),intent(in) :: e
   <ftype2> dimension(m),intent(in) :: w
   integer depend(w),intent(hide) :: m = shape(w,0)
-  integer depend(d),intent(hide) :: n = shape(d,0)
+  integer depend(d),intent(hide),check(n>0) :: n = shape(d,0)
   integer dimension(n),intent(in) :: iblock
   integer dimension(n),intent(in) :: isplit
   <ftype2> dimension(ldz,m),intent(out) :: z
-  integer depend(n),intent(hide) :: ldz = MAX(1,n)
+  integer depend(n),intent(hide) :: ldz = n
   <ftype2> dimension(5*n),intent(hide) :: work
   integer dimension(n),intent(hide) :: iwork
   integer dimension(n),intent(hide) :: ifail  ! really dimension(m), but not known ahead of time
@@ -2866,17 +2866,17 @@ subroutine <prefix2>stemr(d,e,range,vl,vu,il,iu,compute_v,n,m,w,z,ldz,nzc,isuppz
   integer intent(in) :: il
   integer intent(in) :: iu
   integer optional,intent(in) :: compute_v = 1
-  integer intent(hide),depend(d) :: n = shape(d,0)
+  integer intent(hide),depend(d),check(n>0) :: n = shape(d,0)
   integer intent(out) :: m
-  <ftype2> dimension(MAX(1,n)),depend(n),intent(out) :: w
-  <ftype2> dimension(MAX(1,n),MAX(1,n)),depend(n),intent(out) :: z
-  integer depend(n),intent(hide) :: ldz = (compute_v?MAX(1,n):1)  ! could be made more efficient for index queries
-  integer depend(n),intent(hide) :: nzc = MAX(1,n)
-  integer dimension((compute_v?2*MAX(1,n):1)),depend(n),intent(hide) :: isuppz
+  <ftype2> dimension(n),depend(n),intent(out) :: w
+  <ftype2> dimension(n,n),depend(n),intent(out) :: z
+  integer depend(n),intent(hide) :: ldz = (compute_v?n:1)  ! could be made more efficient for index queries
+  integer depend(n),intent(hide) :: nzc = n
+  integer dimension((compute_v?2*n:1)),depend(n),intent(hide) :: isuppz
   integer intent(hide) :: tryrac = 1
-  integer depend(n),intent(hide) :: lwork = MAX(1,(compute_v?18*n:12*n))
+  integer depend(n),intent(hide) :: lwork = (compute_v?18*n:12*n)
   <ftype2> dimension(lwork),depend(lwork),intent(hide) :: work
-  integer intent(hide) :: liwork = MAX(1,(compute_v?10*n:8*n))
+  integer intent(hide) :: liwork = (compute_v?10*n:8*n)
   integer dimension(liwork),depend(liwork),intent(hide) :: iwork
   integer intent(out) :: info
 end subroutine <prefix2>stemr
@@ -2891,7 +2891,7 @@ subroutine <prefix2>stev(d,e,compute_v,n,z,ldz,work,info)
 
   integer optional,intent(in):: compute_v = 1
   <ftype2> dimension(n),intent(in,out,copy,out=vals) :: d
-  integer depend(d),intent(hide) :: n = shape(d,0)
+  integer depend(d),intent(hide),check(n>0) :: n = shape(d,0)
   <ftype2> depend(n),dimension(MAX(n-1,1)),intent(in,copy) :: e
   integer intent(hide),depend(n) :: ldz=(compute_v?n:1)
   <ftype2> dimension(ldz,(compute_v?n:1)),intent(out),depend(n,ldz) :: z

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -382,6 +382,18 @@ All functions
    ssbevx
    dsbevx
 
+   sstebz
+   dstebz
+
+   sstemr
+   dstemr
+
+   ssterf
+   dsterf
+
+   sstein
+   dstein
+
    sstev
    dstev
 

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -23,7 +23,7 @@ from scipy._lib.six import xrange
 from scipy.linalg import (eig, eigvals, lu, svd, svdvals, cholesky, qr,
      schur, rsf2csf, lu_solve, lu_factor, solve, diagsvd, hessenberg, rq,
      eig_banded, eigvals_banded, eigh, eigvalsh, qr_multiply, qz, orth, ordqz,
-     subspace_angles, hadamard)
+     subspace_angles, hadamard, eigvals_tridiagonal, eig_tridiagonal)
 from scipy.linalg.lapack import dgbtrf, dgbtrs, zgbtrf, zgbtrs, \
      dsbev, dsbevd, dsbevx, zhbevd, zhbevx
 from scipy.linalg.misc import norm
@@ -628,6 +628,117 @@ class TestEigBanded(object):
 
         y_lin = linalg.solve(self.comp_mat, self.bc)
         assert_array_almost_equal(y, y_lin)
+
+
+class TestEigTridiagonal(object):
+    def setup_method(self):
+        self.create_trimat()
+
+    def create_trimat(self):
+        """Create the full matrix `self.fullmat`, `self.d`, and `self.e`."""
+        N = 10
+
+        # symmetric band matrix
+        self.d = 1.0*ones(N)
+        self.e = -1.0*ones(N-1)
+        self.full_mat = (diag(self.d) + diag(self.e, -1) + diag(self.e, 1))
+
+        ew, ev = linalg.eig(self.full_mat)
+        ew = ew.real
+        args = argsort(ew)
+        self.w = ew[args]
+        self.evec = ev[:, args]
+
+    def test_degenerate(self):
+        """Test error conditions."""
+        # Wrong sizes
+        assert_raises(ValueError, eigvals_tridiagonal, self.d, self.e[:-1])
+        # Must be real
+        assert_raises(TypeError, eigvals_tridiagonal, self.d, self.e * 1j)
+        # Bad driver
+        assert_raises(TypeError, eigvals_tridiagonal, self.d, self.e,
+                      lapack_driver=1.)
+        assert_raises(ValueError, eigvals_tridiagonal, self.d, self.e,
+                      lapack_driver='foo')
+        # Bad bounds
+        assert_raises(ValueError, eigvals_tridiagonal, self.d, self.e,
+                      select='i', select_range=(0, -1))
+
+    def test_eigvals_tridiagonal(self):
+        """Compare eigenvalues of eigvals_tridiagonal with those of eig."""
+        # can't use ?STERF with subselection
+        for driver in ('sterf', 'stev', 'stebz', 'stemr', 'auto'):
+            w = eigvals_tridiagonal(self.d, self.e, lapack_driver=driver)
+            assert_array_almost_equal(sort(w), self.w)
+
+        for driver in ('sterf', 'stev'):
+            assert_raises(ValueError, eigvals_tridiagonal, self.d, self.e,
+                          lapack_driver='stev', select='i',
+                          select_range=(0, 1))
+        for driver in ('stebz', 'stemr', 'auto'):
+            # extracting eigenvalues with respect to the full index range
+            w_ind = eigvals_tridiagonal(
+                self.d, self.e, select='i', select_range=(0, len(self.d)-1),
+                lapack_driver=driver)
+            assert_array_almost_equal(sort(w_ind), self.w)
+
+            # extracting eigenvalues with respect to an index range
+            ind1 = 2
+            ind2 = 6
+            w_ind = eigvals_tridiagonal(
+                self.d, self.e, select='i', select_range=(ind1, ind2),
+                lapack_driver=driver)
+            assert_array_almost_equal(sort(w_ind), self.w[ind1:ind2+1])
+
+            # extracting eigenvalues with respect to a value range
+            v_lower = self.w[ind1] - 1.0e-5
+            v_upper = self.w[ind2] + 1.0e-5
+            w_val = eigvals_tridiagonal(
+                self.d, self.e, select='v', select_range=(v_lower, v_upper),
+                lapack_driver=driver)
+            assert_array_almost_equal(sort(w_val), self.w[ind1:ind2+1])
+
+    def test_eig_tridiagonal(self):
+        """Compare eigenvalues and eigenvectors of eig_tridiagonal
+           with those of eig. """
+        # can't use ?STERF when eigenvectors are requested
+        assert_raises(ValueError, eig_tridiagonal, self.d, self.e,
+                      lapack_driver='sterf')
+        for driver in ('stebz', 'stev', 'stemr', 'auto'):
+            w, evec = eig_tridiagonal(self.d, self.e, lapack_driver=driver)
+            evec_ = evec[:, argsort(w)]
+            assert_array_almost_equal(sort(w), self.w)
+            assert_array_almost_equal(abs(evec_), abs(self.evec))
+
+        assert_raises(ValueError, eig_tridiagonal, self.d, self.e,
+                      lapack_driver='stev', select='i', select_range=(0, 1))
+        for driver in ('stebz', 'stemr', 'auto'):
+            # extracting eigenvalues with respect to an index range
+            ind1 = 0
+            ind2 = len(self.d)-1
+            w, evec = eig_tridiagonal(
+                self.d, self.e, select='i', select_range=(ind1, ind2),
+                lapack_driver=driver)
+            assert_array_almost_equal(sort(w), self.w)
+            assert_array_almost_equal(abs(evec), abs(self.evec))
+            ind1 = 2
+            ind2 = 6
+            w, evec = eig_tridiagonal(
+                self.d, self.e, select='i', select_range=(ind1, ind2),
+                lapack_driver=driver)
+            assert_array_almost_equal(sort(w), self.w[ind1:ind2+1])
+            assert_array_almost_equal(abs(evec),
+                                      abs(self.evec[:, ind1:ind2+1]))
+
+            # extracting eigenvalues with respect to a value range
+            v_lower = self.w[ind1] - 1.0e-5
+            v_upper = self.w[ind2] + 1.0e-5
+            w, evec = eig_tridiagonal(
+                self.d, self.e, select='v', select_range=(v_lower, v_upper),
+                lapack_driver=driver)
+            assert_array_almost_equal(sort(w), self.w[ind1:ind2+1])
+            assert_array_almost_equal(abs(evec),
+                                      abs(self.evec[:, ind1:ind2+1]))
 
 
 def test_eigh():

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -23,7 +23,7 @@ from scipy._lib.six import xrange
 from scipy.linalg import (eig, eigvals, lu, svd, svdvals, cholesky, qr,
      schur, rsf2csf, lu_solve, lu_factor, solve, diagsvd, hessenberg, rq,
      eig_banded, eigvals_banded, eigh, eigvalsh, qr_multiply, qz, orth, ordqz,
-     subspace_angles, hadamard, eigvals_tridiagonal, eig_tridiagonal)
+     subspace_angles, hadamard, eigvalsh_tridiagonal, eigh_tridiagonal)
 from scipy.linalg.lapack import dgbtrf, dgbtrs, zgbtrf, zgbtrs, \
      dsbev, dsbevd, dsbevx, zhbevd, zhbevx
 from scipy.linalg.misc import norm
@@ -652,32 +652,32 @@ class TestEigTridiagonal(object):
     def test_degenerate(self):
         """Test error conditions."""
         # Wrong sizes
-        assert_raises(ValueError, eigvals_tridiagonal, self.d, self.e[:-1])
+        assert_raises(ValueError, eigvalsh_tridiagonal, self.d, self.e[:-1])
         # Must be real
-        assert_raises(TypeError, eigvals_tridiagonal, self.d, self.e * 1j)
+        assert_raises(TypeError, eigvalsh_tridiagonal, self.d, self.e * 1j)
         # Bad driver
-        assert_raises(TypeError, eigvals_tridiagonal, self.d, self.e,
+        assert_raises(TypeError, eigvalsh_tridiagonal, self.d, self.e,
                       lapack_driver=1.)
-        assert_raises(ValueError, eigvals_tridiagonal, self.d, self.e,
+        assert_raises(ValueError, eigvalsh_tridiagonal, self.d, self.e,
                       lapack_driver='foo')
         # Bad bounds
-        assert_raises(ValueError, eigvals_tridiagonal, self.d, self.e,
+        assert_raises(ValueError, eigvalsh_tridiagonal, self.d, self.e,
                       select='i', select_range=(0, -1))
 
-    def test_eigvals_tridiagonal(self):
-        """Compare eigenvalues of eigvals_tridiagonal with those of eig."""
+    def test_eigvalsh_tridiagonal(self):
+        """Compare eigenvalues of eigvalsh_tridiagonal with those of eig."""
         # can't use ?STERF with subselection
         for driver in ('sterf', 'stev', 'stebz', 'stemr', 'auto'):
-            w = eigvals_tridiagonal(self.d, self.e, lapack_driver=driver)
+            w = eigvalsh_tridiagonal(self.d, self.e, lapack_driver=driver)
             assert_array_almost_equal(sort(w), self.w)
 
         for driver in ('sterf', 'stev'):
-            assert_raises(ValueError, eigvals_tridiagonal, self.d, self.e,
+            assert_raises(ValueError, eigvalsh_tridiagonal, self.d, self.e,
                           lapack_driver='stev', select='i',
                           select_range=(0, 1))
         for driver in ('stebz', 'stemr', 'auto'):
             # extracting eigenvalues with respect to the full index range
-            w_ind = eigvals_tridiagonal(
+            w_ind = eigvalsh_tridiagonal(
                 self.d, self.e, select='i', select_range=(0, len(self.d)-1),
                 lapack_driver=driver)
             assert_array_almost_equal(sort(w_ind), self.w)
@@ -685,7 +685,7 @@ class TestEigTridiagonal(object):
             # extracting eigenvalues with respect to an index range
             ind1 = 2
             ind2 = 6
-            w_ind = eigvals_tridiagonal(
+            w_ind = eigvalsh_tridiagonal(
                 self.d, self.e, select='i', select_range=(ind1, ind2),
                 lapack_driver=driver)
             assert_array_almost_equal(sort(w_ind), self.w[ind1:ind2+1])
@@ -693,37 +693,37 @@ class TestEigTridiagonal(object):
             # extracting eigenvalues with respect to a value range
             v_lower = self.w[ind1] - 1.0e-5
             v_upper = self.w[ind2] + 1.0e-5
-            w_val = eigvals_tridiagonal(
+            w_val = eigvalsh_tridiagonal(
                 self.d, self.e, select='v', select_range=(v_lower, v_upper),
                 lapack_driver=driver)
             assert_array_almost_equal(sort(w_val), self.w[ind1:ind2+1])
 
-    def test_eig_tridiagonal(self):
-        """Compare eigenvalues and eigenvectors of eig_tridiagonal
+    def test_eigh_tridiagonal(self):
+        """Compare eigenvalues and eigenvectors of eigh_tridiagonal
            with those of eig. """
         # can't use ?STERF when eigenvectors are requested
-        assert_raises(ValueError, eig_tridiagonal, self.d, self.e,
+        assert_raises(ValueError, eigh_tridiagonal, self.d, self.e,
                       lapack_driver='sterf')
         for driver in ('stebz', 'stev', 'stemr', 'auto'):
-            w, evec = eig_tridiagonal(self.d, self.e, lapack_driver=driver)
+            w, evec = eigh_tridiagonal(self.d, self.e, lapack_driver=driver)
             evec_ = evec[:, argsort(w)]
             assert_array_almost_equal(sort(w), self.w)
             assert_array_almost_equal(abs(evec_), abs(self.evec))
 
-        assert_raises(ValueError, eig_tridiagonal, self.d, self.e,
+        assert_raises(ValueError, eigh_tridiagonal, self.d, self.e,
                       lapack_driver='stev', select='i', select_range=(0, 1))
         for driver in ('stebz', 'stemr', 'auto'):
             # extracting eigenvalues with respect to an index range
             ind1 = 0
             ind2 = len(self.d)-1
-            w, evec = eig_tridiagonal(
+            w, evec = eigh_tridiagonal(
                 self.d, self.e, select='i', select_range=(ind1, ind2),
                 lapack_driver=driver)
             assert_array_almost_equal(sort(w), self.w)
             assert_array_almost_equal(abs(evec), abs(self.evec))
             ind1 = 2
             ind2 = 6
-            w, evec = eig_tridiagonal(
+            w, evec = eigh_tridiagonal(
                 self.d, self.e, select='i', select_range=(ind1, ind2),
                 lapack_driver=driver)
             assert_array_almost_equal(sort(w), self.w[ind1:ind2+1])
@@ -733,7 +733,7 @@ class TestEigTridiagonal(object):
             # extracting eigenvalues with respect to a value range
             v_lower = self.w[ind1] - 1.0e-5
             v_upper = self.w[ind2] + 1.0e-5
-            w, evec = eig_tridiagonal(
+            w, evec = eigh_tridiagonal(
                 self.d, self.e, select='v', select_range=(v_lower, v_upper),
                 lapack_driver=driver)
             assert_array_almost_equal(sort(w), self.w[ind1:ind2+1])


### PR DESCRIPTION
This PR:

1. Adds LAPACK wrappers for [?STEMR](http://www.netlib.org/lapack/explore-html/da/dba/group__double_o_t_h_e_rcomputational_ga14daa3ac4e7b5d3712244f54ce40cc92.html#ga14daa3ac4e7b5d3712244f54ce40cc92), [?STERF](http://www.netlib.org/lapack/explore-html/d2/d24/group__aux_o_t_h_e_rcomputational_gaf0616552c11358ae8298d0ac18ac023c.html#gaf0616552c11358ae8298d0ac18ac023c), [?STEBZ](http://www.netlib.org/lapack/explore-html/d2/d24/group__aux_o_t_h_e_rcomputational_ga28f88843da09a0ee400daf46caaabec6.html#ga28f88843da09a0ee400daf46caaabec6), and [?STEIN](http://www.netlib.org/lapack/explore-html/da/dba/group__double_o_t_h_e_rcomputational_ga215c9e229f4b54fed9993f58285aba8a.html#ga215c9e229f4b54fed9993f58285aba8a).
2. Adds real, symmetric tridiagonal eigenvalue solvers with eigenvalue/vector subselection. 
3. I was originally just going to use STEMR in the tridiagonal code, but then I read the docs for [?SYVER](http://www.netlib.org/lapack/explore-html/d2/d8a/group__double_s_yeigen_gaeed8a131adf56eaa2a9e5b1e0cce5718.html#gaeed8a131adf56eaa2a9e5b1e0cce5718), which has to make choices about tridiagonal eigenvalue/vector decompositions. It uses STEMR when doing a full decomposition, and STEMR(->STEBZ) when doing a selection. So I made `lapack_driver='auto'` behave like this. If there is some LAPACK expert who knows why, that might better justify these choices...
4. Cleans up / unifies some docstring links between `eig*` functions.

Every once in a while I was hitting some segfault while testing, so I might have some bug in the Fortran conversion -- that could probably use an extra set of eyes.

STEMR requires ieee-754 floating point standard compiliance -- is it safe to assume this for SciPy? (Should I note it in the docstring?)

Ready for review from my end. Needed for #7802.