### PR TITLE
WIP: Basin hopping improvements

### DIFF
--- a/scipy/optimize/__init__.py
+++ b/scipy/optimize/__init__.py
@@ -19,7 +19,7 @@ Common functions and objects, shared across different solvers, are:
    show_options - Show specific options optimization solvers.
    OptimizeResult - The optimization result returned by some optimizers.
    OptimizeWarning - The optimization encountered problems.
-
+   InvalidResult - The optimization failed and result is invalid.
 
 Optimization
 ============

--- a/scipy/optimize/_basinhopping.py
+++ b/scipy/optimize/_basinhopping.py
@@ -64,11 +64,11 @@ class BasinHoppingRunner(object):
 
         self.nstep = 0
 
-        # initialize return object
+        # Initialize return object
         self.res = scipy.optimize.OptimizeResult()
         self.res.minimization_failures = 0
 
-        # do initial minimization
+        # Do initial minimization
         minres = minimizer(self.x)
         if not minres.success:
             self.res.minimization_failures += 1
@@ -79,9 +79,10 @@ class BasinHoppingRunner(object):
         if self.disp:
             print("basinhopping step %d: f %g" % (self.nstep, self.energy))
 
-        # initialize storage class
+        # Initialize storage class
         self.storage = Storage(minres)
 
+        # Counters to keep track of global totals
         if hasattr(minres, "nfev"):
             self.res.nfev = minres.nfev
         if hasattr(minres, "njev"):

--- a/scipy/optimize/_basinhopping.py
+++ b/scipy/optimize/_basinhopping.py
@@ -73,9 +73,18 @@ class BasinHoppingRunner(object):
         if not minres.success:
             self.res.minimization_failures += 1
             if self.disp:
-                print("warning: basinhopping: local minimization failure")
-        self.x = np.copy(minres.x)
-        self.energy = minres.fun
+                print("warning: basinhopping: initial minimization failure")
+
+        if minres.success is scipy.optimize.InvalidResult:
+            # Result was invalid, so keep original x and don't put invalid
+            # value in storage.  Any minima found will be lower in
+            # function value and replace this
+            self.energy = float('inf')
+            minres.fun = float('inf')
+        else:
+            # Update starting point to the minimum that was found
+            self.x = np.copy(minres.x)
+            self.energy = minres.fun
         if self.disp:
             print("basinhopping step %d: f %g" % (self.nstep, self.energy))
 

--- a/scipy/optimize/_basinhopping.py
+++ b/scipy/optimize/_basinhopping.py
@@ -152,7 +152,7 @@ class BasinHoppingRunner(object):
 
         accept, minres = self._monte_carlo_step()
 
-        if accept:
+        if accept and minres.success is not scipy.optimize.InvalidResult:
             self.energy = minres.fun
             self.x = np.copy(minres.x)
             new_global_min = self.storage.update(minres)

--- a/scipy/optimize/cobyla.py
+++ b/scipy/optimize/cobyla.py
@@ -15,7 +15,7 @@ from threading import RLock
 
 import numpy as np
 from scipy.optimize import _cobyla
-from .optimize import OptimizeResult, _check_unknown_options
+from .optimize import OptimizeResult, _check_unknown_options, InvalidResult
 try:
     from itertools import izip
 except ImportError:
@@ -265,9 +265,16 @@ def _minimize_cobyla(fun, x0, args=(), constraints=(),
         # Check constraint violation
         info[0] = 4
 
+    if info[0] == 1:
+        success = True
+    elif info[0] == 4:  # = constraint violation. TODO: Is 3 also Invalid?
+        success = InvalidResult
+    else:
+        success = False
+
     return OptimizeResult(x=xopt,
                           status=int(info[0]),
-                          success=info[0] == 1,
+                          success=success,
                           message={1: 'Optimization terminated successfully.',
                                    2: 'Maximum number of function evaluations '
                                       'has been exceeded.',

--- a/scipy/optimize/lbfgsb.py
+++ b/scipy/optimize/lbfgsb.py
@@ -379,6 +379,8 @@ def _minimize_lbfgsb(fun, x0, args=(), jac=None, bounds=None,
         warnflag = 1
     else:
         warnflag = 2
+        # TODO: This contains several task_str, some of which may be
+        # InvalidResult?
 
     # These two portions of the workspace are described in the mainlb
     # subroutine in lbfgsb.f. See line 363.

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -21,7 +21,7 @@ __all__ = ['fmin', 'fmin_powell', 'fmin_bfgs', 'fmin_ncg', 'fmin_cg',
            'fminbound', 'brent', 'golden', 'bracket', 'rosen', 'rosen_der',
            'rosen_hess', 'rosen_hess_prod', 'brute', 'approx_fprime',
            'line_search', 'check_grad', 'OptimizeResult', 'show_options',
-           'OptimizeWarning']
+           'OptimizeWarning', 'InvalidResult']
 
 __docformat__ = "restructuredtext en"
 
@@ -86,8 +86,12 @@ class OptimizeResult(dict):
     ----------
     x : ndarray
         The solution of the optimization.
-    success : bool
-        Whether or not the optimizer exited successfully.
+    success : {True, False, InvalidResult}
+        Whether or not the optimizer exited successfully.  If False, then
+        minimization failed, but the result is still a valid function value.
+        If InvalidResult, then minimization failed, and result is invalid
+        because of a bounds or constraint violation, etc.
+        ``bool(InvalidResult) == False``
     status : int
         Termination status of the optimizer. Its value depends on the
         underlying solver. Refer to `message` for details.
@@ -140,6 +144,28 @@ class OptimizeResult(dict):
 
 class OptimizeWarning(UserWarning):
     pass
+
+
+class InvalidResultType(object):
+    """
+    Indicates that minimization has failed and result is invalid (such as a
+    boundary or constraint violation)
+    """
+    def __repr__(self):
+        return 'InvalidResult'
+
+    def __reduce__(self):
+        return 'InvalidResult'
+
+    def __bool__(self):  # Python 3
+        # Should be False for backwards compatibility, and to convey
+        # "minimization failed (and result is also invalid)"
+        return False
+
+    __nonzero__ = __bool__  # Python 2
+
+
+InvalidResult = InvalidResultType()
 
 
 def _check_unknown_options(unknown_options):

--- a/scipy/optimize/slsqp.py
+++ b/scipy/optimize/slsqp.py
@@ -20,7 +20,7 @@ from scipy.optimize._slsqp import slsqp
 from numpy import (zeros, array, linalg, append, asfarray, concatenate, finfo,
                    sqrt, vstack, exp, inf, isfinite, atleast_1d)
 from .optimize import (OptimizeResult, _check_unknown_options,
-                       _prepare_scalar_function)
+                       _prepare_scalar_function, InvalidResult)
 from ._numdiff import approx_derivative
 from ._constraints import old_bound_to_new, _arr_to_scalar
 
@@ -451,9 +451,16 @@ def _minimize_slsqp(func, x0, args=(), jac=None, bounds=None,
         print("            Function evaluations:", sf.nfev)
         print("            Gradient evaluations:", sf.ngev)
 
+    if mode == 0:
+        success = True
+    elif mode in (4, 8):  # Constraints incompatible or search is out of bounds
+        success = InvalidResult
+    else:
+        success = False
+
     return OptimizeResult(x=x, fun=fx, jac=g[:-1], nit=int(majiter),
                           nfev=sf.nfev, njev=sf.ngev, status=int(mode),
-                          message=exit_modes[int(mode)], success=(mode == 0))
+                          message=exit_modes[int(mode)], success=success)
 
 
 def _eval_constraint(x, cons):

--- a/scipy/optimize/tests/test__basinhopping.py
+++ b/scipy/optimize/tests/test__basinhopping.py
@@ -16,17 +16,28 @@ from scipy._lib._pep440 import Version
 
 
 def func1d(x):
+    """
+    1D test function of parabola + sinusoidal variation, with minimum around
+    f(x) = -1.0 at x = -0.195
+    """
     f = cos(14.5 * x - 0.3) + (x + 0.2) * x
     df = np.array(-14.5 * sin(14.5 * x - 0.3) + 2. * x + 0.2)
     return f, df
 
 
 def func2d_nograd(x):
+    """
+    2D test function of paraboloid with sinusoidal variation, with minimum
+    around f(x) = -1.0 at x = (-0.195, -0.1)
+    """
     f = cos(14.5 * x[0] - 0.3) + (x[1] + 0.2) * x[1] + (x[0] + 0.2) * x[0]
     return f
 
 
 def func2d(x):
+    """
+    Same as func2d_nograd
+    """
     f = cos(14.5 * x[0] - 0.3) + (x[1] + 0.2) * x[1] + (x[0] + 0.2) * x[0]
     df = np.zeros(2)
     df[0] = -14.5 * sin(14.5 * x[0] - 0.3) + 2. * x[0] + 0.2
@@ -35,6 +46,9 @@ def func2d(x):
 
 
 def func2d_easyderiv(x):
+    """
+    Paraboloid with minimum of f(x) = -6 at (2, -1)
+    """
     f = 2.0*x[0]**2 + 2.0*x[0]*x[1] + 2.0*x[1]**2 - 6.0*x[0]
     df = np.zeros(2)
     df[0] = 4.0*x[0] + 2.0*x[1] - 6.0

--- a/scipy/optimize/tests/test_cobyla.py
+++ b/scipy/optimize/tests/test_cobyla.py
@@ -3,7 +3,7 @@ import numpy as np
 
 from numpy.testing import assert_allclose, assert_
 
-from scipy.optimize import fmin_cobyla, minimize
+from scipy.optimize import fmin_cobyla, minimize, InvalidResult
 
 
 class TestCobyla(object):
@@ -68,6 +68,7 @@ class TestCobyla(object):
                        options={'catol': 1e-6})
         assert_(sol.maxcv > 1e-6)
         assert_(not sol.success)
+        assert_(sol.success is InvalidResult)
 
 
 def test_vector_constraints():

--- a/scipy/optimize/tnc.py
+++ b/scipy/optimize/tnc.py
@@ -34,7 +34,7 @@ value of the function, and whose second argument is the gradient of the function
 
 from scipy.optimize import moduleTNC
 from .optimize import (MemoizeJac, OptimizeResult, _check_unknown_options,
-                       _prepare_scalar_function)
+                       _prepare_scalar_function, InvalidResult)
 from ._constraints import old_bound_to_new
 
 from numpy import inf, array, zeros, asfarray
@@ -418,9 +418,16 @@ def _minimize_tnc(fun, x0, args=(), jac=None, bounds=None,
 
     funv, jacv = func_and_grad(x)
 
+    if (-1 < rc < 3):
+        success = True
+    elif rc < 0 or rc == 5:  # TODO: is this correct?
+        success = InvalidResult
+    else:
+        success = False
+
     return OptimizeResult(x=x, fun=funv, jac=jacv, nfev=sf.nfev,
                           nit=nit, status=rc, message=RCSTRINGS[rc],
-                          success=(-1 < rc < 3))
+                          success=success)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Based on https://github.com/scipy/scipy/issues/7799

- [ ] Improve documentation
- [x] Keep local minima even if step is rejected?
  - This will never happen with the default `Metropolis`, but could happen with a custom `accept_test`
  - Not sure, save for another PR
- [x] Don't keep local minima if ~~minimization fails~~ result is invalid
  - [ ] But the step location should still be kept in that case? 
    - If it's just out of bounds it's ok to keep, but maybe a bad idea.
    - If it's numerically wrong then it shouldn't be kept.  Not sure if this is possible.
- [ ] Should be possible to specify `stepsize` of same shape as starting guess (when variables have different units/scales)
- [x] Support Monotonic Basin-Hopping (T=0)
  - Fixed in https://github.com/scipy/scipy/pull/7954 and https://github.com/scipy/scipy/pull/8050
- [x] ~~Support Multistart?  (or just explain how to configure it (reject all steps and make stepsize wide enough to cover area of interest))~~
  - Should just be a different function, with a more clear interface and parallelization: https://github.com/scipy/scipy/issues/6381
- [x] First minimization should behave identically to subsequent ones? (reject InvalidResult, etc.)
  - This requires initializing with a dummy result with function value +infinity so that subsequent results replace it.
- [ ] Write tests for new stuff
- Add InvalidResult test to `brute()` (separate PR)