### PR TITLE
BUG: memory leak in messagestream / qhull.pyx

### DIFF
--- a/scipy/_lib/messagestream.pyx
+++ b/scipy/_lib/messagestream.pyx
@@ -80,13 +80,13 @@ cdef class MessageStream:
         stdio.rewind(self.handle)
 
     def close(self):
-        if self._memstream_ptr != NULL:
-            stdlib.free(self._memstream_ptr)
-            self._memstream_ptr = NULL
-
         if self.handle != NULL:
             stdio.fclose(self.handle)
             self.handle = NULL
+
+        if self._memstream_ptr != NULL:
+            stdlib.free(self._memstream_ptr)
+            self._memstream_ptr = NULL
 
         if not self._removed:
             stdio.remove(self._filename)


### PR DESCRIPTION
The buffer must be freed after file is closed, not before.

See https://stackoverflow.com/q/36016168/3781929

Issue #7800 found this as a definitely loss record in test_interpnd.py