### PR TITLE
CI: appveyor: switch numpy-distutils branch

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,8 +14,8 @@ environment:
       MINGW_64: C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin
       OPENBLAS_32: https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-5f998ef_gcc7_1_0_win32.zip
       OPENBLAS_64: https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-5f998ef_gcc7_1_0_win64.zip
-      NUMPY_HEAD: https://github.com/pv/numpy.git
-      NUMPY_BRANCH: distutils
+      NUMPY_HEAD: https://github.com/numpy/numpy.git
+      NUMPY_BRANCH: master
       APPVEYOR_SAVE_CACHE_ON_ERROR: true
       APPVEYOR_SKIP_FINALIZE_ON_EXIT: true
       TEST_TIMEOUT: 1000


### PR DESCRIPTION
The necessary numpy distutils patches landed in numpy master, so use
that.