### PR TITLE
ENH: Automatic FIR order for `decimate`

### DIFF
--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -3363,11 +3363,12 @@ def decimate(x, q, n=None, ftype='iir', axis=-1, zero_phase=True):
     x : array_like
         The signal to be downsampled, as an N-dimensional array.
     q : int
-        The downsampling factor. For downsampling factors higher than 13, it is
-        recommended to call `decimate` multiple times.
+        The downsampling factor. When using IIR downsampling, it is recommended
+        to call `decimate` multiple times for downsampling factors higher than
+        13.
     n : int, optional
         The order of the filter (1 less than the length for 'fir'). Defaults to
-        8 for 'iir' and 30 for 'fir'.
+        8 for 'iir' and 20 times the downsampling factor for 'fir'.
     ftype : str {'iir', 'fir'} or ``dlti`` instance, optional
         If 'iir' or 'fir', specifies the type of lowpass filter. If an instance
         of an `dlti` object, uses that object to filter before downsampling.
@@ -3406,7 +3407,8 @@ def decimate(x, q, n=None, ftype='iir', axis=-1, zero_phase=True):
 
     if ftype == 'fir':
         if n is None:
-            n = 30
+            half_len = 10 * q  # reasonable cutoff for our sinc-like function
+            n = 2 * half_len
         system = dlti(firwin(n+1, 1. / q, window='hamming'), 1.)
     elif ftype == 'iir':
         if n is None:


### PR DESCRIPTION
Taking over #7192. Should be ready for review/merge since people were happy there except for me, and I've added a test.

@e-q I changed it to give `b, a` directly instead of routing through `dlti` because it was emitting what I think were errant bad coefficient warnings -- we'll probably want to fix that separately later instead of holding this up.