### PR TITLE
BUG: special/cdflib: fix fatal loss of precision issues in cumfnc

### DIFF
--- a/scipy/special/cdflib/cumfnc.f
+++ b/scipy/special/cdflib/cumfnc.f
@@ -69,8 +69,8 @@ C     .. Local Scalars ..
       INTEGER i,icent,ierr,status
 C     ..
 C     .. External Functions ..
-      DOUBLE PRECISION alngam
-      EXTERNAL alngam
+      DOUBLE PRECISION alngam, betaln
+      EXTERNAL alngam, betaln
 C     ..
 C     .. Intrinsic Functions ..
       INTRINSIC log,dble,exp
@@ -151,8 +151,14 @@ C     Now sum terms backward from icent until convergence or all done
 
       xmult = centwt
       i = icent
-      dnterm = exp(alngam(adn+b)-alngam(adn+1.0D0)-alngam(b)+
+      IF (adn.LT.2D0) THEN
+          dnterm = exp(alngam(adn+b)-alngam(adn+1.0D0)-alngam(b)+
      +         adn*log(xx)+b*log(yy))
+      ELSE
+C         Same expression, but avoid problems for large adn
+          dnterm = exp(-betaln(adn,b)-log(adn)+
+     +         adn*log(xx)+b*log(yy))
+      END IF
    30 IF (qsmall(xmult*betdn) .OR. i.LE.0) GO TO 40
       xmult = xmult* (i/xnonc)
       i = i - 1
@@ -172,8 +178,14 @@ C     Now sum forwards until convergence
      +             b*log(yy))
 
       ELSE
-          upterm = exp(alngam(aup-1+b)-alngam(aup)-alngam(b)+
+          IF (aup.LT.2D0) THEN
+              upterm = exp(alngam(aup-1+b)-alngam(aup)-alngam(b)+
      +             (aup-1)*log(xx)+b*log(yy))
+          ELSE
+C             Same expression, but avoid problems for large aup
+              upterm = exp(-betaln(aup-1,b)-log(aup-1)+
+     +             (aup-1)*log(xx)+b*log(yy))
+          END IF
       END IF
 
       GO TO 60

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -702,15 +702,10 @@ class TestCephes(object):
         p = cephes.ncfdtr(2, dfd, 0.25, 15)
         assert_allclose(cephes.ncfdtridfd(2, p, 0.25, 15), dfd)
 
-    @pytest.mark.xfail((sys.platform == "win32" and
-                        platform.architecture()[0] == "32bit" and
-                        NumpyVersion(np.__version__) < "1.14.0"),
-                       reason=("Can fail on win32 if FPU is in wrong mode, "
-                               "see gh-7726"))
     def test_ncfdtridfn(self):
-        dfn = [1, 2, 3]
+        dfn = [0.1, 1, 2, 3, 1e4]
         p = cephes.ncfdtr(dfn, 2, 0.25, 15)
-        assert_allclose(cephes.ncfdtridfn(p, 2, 0.25, 15), dfn)
+        assert_allclose(cephes.ncfdtridfn(p, 2, 0.25, 15), dfn, rtol=1e-5)
 
     def test_ncfdtrinc(self):
         nc = [0.5, 1.5, 2.0]


### PR DESCRIPTION
Replace gammaln(a+b)-gammaln(a)-gammaln(b) -> -betaln(a,b)
to avoid loss of precision in cancellations for large a, and
make use of gammaln(a+1) == gammaln(a) + log(a) for a > 0.

Whether the previous code worked correctly or not for very large values depends
on floating point issues --- it is dangerous to rely on
gammaln(a) and gammaln(a+b) returning exactly the same floating point
value when a==a+b up to fp precision, as this is apparently not
guaranteed by gfortran optimizations.

Fixes gh-7828

There in principle may be other issues with this function since
it does not appear to be properly tested, but this is at least one obviously
correct fix...