### PR TITLE
dummy statement for undefined WITH_THREAD

### DIFF
--- a/scipy/special/sf_error.c
+++ b/scipy/special/sf_error.c
@@ -130,6 +130,8 @@ void sf_error(const char *func_name, sf_error_t code, const char *fmt, ...)
     skip_warn:
 #ifdef WITH_THREAD
         PyGILState_Release(save);
+#else
+	;
 #endif
 }
 


### PR DESCRIPTION
If WITH_THREAD is undefined (rare case, yes) then there still must be a statement after the label `skip_warn`, but there is none, 
and one gets a compilation error.
(with `clang-3.8`, I didn't check other compilers, but it is clear from C standard that a statement is needed)