### PR TITLE
MAINT: add license texts to binary distributions

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -34,36 +34,15 @@ THE POSSIBILITY OF SUCH DAMAGE.
 SciPy bundles a number of libraries that are compatibly licensed.  We list
 these here.
 
-Name: ID
-Files: scipy/linalg/src/id_dist/*
-License: 3-clause BSD
-  For details, see scipy/linalg/src/id_dist/doc/doc.tex
+Name: Numpydoc
+Files: doc/sphinxext/numpydoc/*
+License: 2-clause BSD
+  For details, see doc/sphinxext/LICENSE.txt
 
-Name: SuperLU
-Files: scipy/sparse/linalg/dsolve/SuperLU/*
-License: 3-clause BSD
-  For details, see scipy/sparse/linalg/dsolve/SuperLU/License.txt
-
-Name: ARPACK
-Files: scipy/sparse/linalg/eigen/arpack/ARPACK/*
-License: 3-clause BSD
-  For details, see scipy/sparse/linalg/eigen/arpack/ARPACK/COPYING
-
-Name: L-BFGS-B
-Files: scipy/optimize/lbfgsb/*
-License: BSD license
-  For details, see scipy/optimize/lbfgsb/README
-
-Name: Qhull
-Files: scipy/spatial/qhull/*
-License: Qhull license (BSD-like)
-  For details, see scipy/spatial/qhull/COPYING.txt
-
-Name: Cephes
-Files: scipy/special/cephes/*
-License: 3-clause BSD
-  Distributed under the same license as SciPy with permission from the author,
-  see https://lists.debian.org/debian-legal/2004/12/msg00295.html
+Name: scipy-sphinx-theme
+Files: doc/scipy-sphinx-theme/*
+License: 3-clause BSD, PSF and Apache 2.0
+  For details, see doc/sphinxext/LICENSE.txt
 
 Name: Six
 Files: scipy/_lib/six.py
@@ -75,18 +54,88 @@ Files: scipy/_lib/decorator.py
 License: 2-clause BSD
   For details, see the header inside scipy/_lib/decorator.py
 
+Name: ID
+Files: scipy/linalg/src/id_dist/*
+License: 3-clause BSD
+  For details, see scipy/linalg/src/id_dist/doc/doc.tex
+
+Name: L-BFGS-B
+Files: scipy/optimize/lbfgsb/*
+License: BSD license
+  For details, see scipy/optimize/lbfgsb/README
+
+Name: SuperLU
+Files: scipy/sparse/linalg/dsolve/SuperLU/*
+License: 3-clause BSD
+  For details, see scipy/sparse/linalg/dsolve/SuperLU/License.txt
+
+Name: ARPACK
+Files: scipy/sparse/linalg/eigen/arpack/ARPACK/*
+License: 3-clause BSD
+  For details, see scipy/sparse/linalg/eigen/arpack/ARPACK/COPYING
+
+Name: Qhull
+Files: scipy/spatial/qhull/*
+License: Qhull license (BSD-like)
+  For details, see scipy/spatial/qhull/COPYING.txt
+
+Name: Cephes
+Files: scipy/special/cephes/*
+License: 3-clause BSD
+  Distributed under 3-clause BSD license with permission from the author,
+  see https://lists.debian.org/debian-legal/2004/12/msg00295.html
+  
+  Cephes Math Library Release 2.8:  June, 2000
+  Copyright 1984, 1995, 2000 by Stephen L. Moshier
+  
+  This software is derived from the Cephes Math Library and is
+  incorporated herein by permission of the author.
+  
+  All rights reserved.
+  
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+      * Redistributions of source code must retain the above copyright
+        notice, this list of conditions and the following disclaimer.
+      * Redistributions in binary form must reproduce the above copyright
+        notice, this list of conditions and the following disclaimer in the
+        documentation and/or other materials provided with the distribution.
+      * Neither the name of the <organization> nor the
+        names of its contributors may be used to endorse or promote products
+        derived from this software without specific prior written permission.
+  
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 Name: Faddeeva
 Files: scipy/special/Faddeeva.*
 License: MIT
-  For details, see the headers inside scipy/special/Faddeeva.*
-
-Name: Numpydoc
-Files: doc/sphinxext/numpydoc/*
-License: 2-clause BSD
-  For details, see doc/sphinxext/LICENSE.txt
-
-Name: scipy-sphinx-theme
-Files: doc/scipy-sphinx-theme/*
-License: 3-clause BSD, PSF and Apache 2.0
-  For details, see doc/sphinxext/LICENSE.txt
+  Copyright (c) 2012 Massachusetts Institute of Technology
+  
+  Permission is hereby granted, free of charge, to any person obtaining
+  a copy of this software and associated documentation files (the
+  "Software"), to deal in the Software without restriction, including
+  without limitation the rights to use, copy, modify, merge, publish,
+  distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so, subject to
+  the following conditions:
+  
+  The above copyright notice and this permission notice shall be
+  included in all copies or substantial portions of the Software.
+  
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. 
 

--- a/scipy/linalg/setup.py
+++ b/scipy/linalg/setup.py
@@ -161,6 +161,10 @@ def configuration(parent_package='', top_path=None):
     config.add_extension('_decomp_update',
                          sources=['_decomp_update.c'])
 
+    # Add any license files
+    config.add_data_files('src/id_dist/doc/doc.tex')
+    config.add_data_files('src/lapack_deprecations/LICENSE')
+
     return config
 
 

--- a/scipy/optimize/setup.py
+++ b/scipy/optimize/setup.py
@@ -75,6 +75,10 @@ def configuration(parent_package='',top_path=None):
     config.add_subpackage('_trlib')
 
     config.add_data_dir('tests')
+
+    # Add license files
+    config.add_data_files('lbfgsb/README')
+
     return config
 
 

--- a/scipy/sparse/linalg/dsolve/setup.py
+++ b/scipy/sparse/linalg/dsolve/setup.py
@@ -47,6 +47,9 @@ def configuration(parent_package='',top_path=None):
                          **numpy_nodepr_api
                          )
 
+    # Add license files
+    config.add_data_files('SuperLU/License.txt')
+
     return config
 
 if __name__ == '__main__':

--- a/scipy/sparse/linalg/eigen/arpack/setup.py
+++ b/scipy/sparse/linalg/eigen/arpack/setup.py
@@ -33,6 +33,10 @@ def configuration(parent_package='',top_path=None):
                          )
 
     config.add_data_dir('tests')
+
+    # Add license files
+    config.add_data_files('ARPACK/COPYING')
+
     return config
 
 if __name__ == '__main__':

--- a/scipy/spatial/setup.py
+++ b/scipy/spatial/setup.py
@@ -75,6 +75,9 @@ def configuration(parent_package='', top_path=None):
     config.add_extension('_hausdorff',
                          sources=['_hausdorff.c'])
 
+    # Add license files
+    config.add_data_files('qhull/COPYING.txt')
+
     return config
 
 


### PR DESCRIPTION
Ensure license texts are present also in binary distributions: either
contained in LICENSE.txt, or added as data files and referred to in
LICENSE.txt

Also reorder the bundled library list in alphabetical order vs. file names.