### PR TITLE
MAINT: sparse: Simplify sputils.isintlike

### DIFF
--- a/scipy/sparse/sputils.py
+++ b/scipy/sparse/sputils.py
@@ -190,6 +190,8 @@ def isintlike(x):
     """Is x appropriate as an index into a sparse matrix? Returns True
     if it can be cast safely to a machine int.
     """
+    # Fast-path check to eliminate non-scalar values. operator.index would
+    # catch this case too, but the exception catching is slow.
     if np.ndim(x) != 0:
         return False
     try:

--- a/scipy/sparse/sputils.py
+++ b/scipy/sparse/sputils.py
@@ -3,6 +3,7 @@
 
 from __future__ import division, print_function, absolute_import
 
+import operator
 import warnings
 import numpy as np
 
@@ -192,9 +193,17 @@ def isintlike(x):
     if np.ndim(x) != 0:
         return False
     try:
-        return bool(int(x) == x)
+        operator.index(x)
     except (TypeError, ValueError):
-        return False
+        try:
+            loose_int = bool(int(x) == x)
+        except (TypeError, ValueError):
+            return False
+        if loose_int:
+            warnings.warn("Inexact indices to sparse matrices are deprecated "
+                          "as of scipy 1.0")
+        return loose_int
+    return True
 
 
 def isshape(x):

--- a/scipy/sparse/sputils.py
+++ b/scipy/sparse/sputils.py
@@ -200,8 +200,8 @@ def isintlike(x):
         except (TypeError, ValueError):
             return False
         if loose_int:
-            warnings.warn("Inexact indices to sparse matrices are deprecated "
-                          "as of scipy 1.0")
+            warnings.warn("Inexact indices into sparse matrices are deprecated",
+                          DeprecationWarning)
         return loose_int
     return True
 

--- a/scipy/sparse/sputils.py
+++ b/scipy/sparse/sputils.py
@@ -189,7 +189,7 @@ def isintlike(x):
     """Is x appropriate as an index into a sparse matrix? Returns True
     if it can be cast safely to a machine int.
     """
-    if not isscalarlike(x):
+    if np.ndim(x) != 0:
         return False
     try:
         return bool(int(x) == x)

--- a/scipy/sparse/tests/test_sputils.py
+++ b/scipy/sparse/tests/test_sputils.py
@@ -6,6 +6,7 @@ import numpy as np
 from numpy.testing import assert_equal, assert_raises
 from pytest import raises as assert_raises
 from scipy.sparse import sputils
+from scipy._lib._numpy_compat import suppress_warnings
 
 
 class TestSparseUtils(object):
@@ -36,10 +37,13 @@ class TestSparseUtils(object):
         assert_equal(sputils.isscalarlike((1, 2)), False)
 
     def test_isintlike(self):
-        assert_equal(sputils.isintlike(3.0), True)
         assert_equal(sputils.isintlike(-4), True)
         assert_equal(sputils.isintlike(np.array(3)), True)
         assert_equal(sputils.isintlike(np.array([3])), False)
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning,
+                       "Inexact indices into sparse matrices are deprecated")
+            assert_equal(sputils.isintlike(3.0), True)
 
         assert_equal(sputils.isintlike(2.5), False)
         assert_equal(sputils.isintlike(1 + 3j), False)


### PR DESCRIPTION
This works around gh-7860 by not calling np.isscalar, as suggested by @eric-wieser [here](https://github.com/scipy/scipy/pull/6936#discussion_r139197358).

Some objects that fail `sputils.isscalarlike` will pass the `np.ndim` check (i.e. `object`), but these are handled by the try-except check, which *should be* cheap for anything where `np.ndim(x) == 0`.