### PR TITLE
ENH: Improved speed of copy into L, U matrices

### DIFF
--- a/scipy/linalg/src/lu.f
+++ b/scipy/linalg/src/lu.f
@@ -28,26 +28,28 @@ cf2py callprotoargument double*,double*,double*,double*,int*,int*,int*,int*,int*
       if (info.lt.0) then
          return
       endif
-      do 20 i=1,m
-         do 10, j=1,n
-            if (j.le.k) then
-               if (i.eq.j) then
-                  l(i,j) = 1d0
-               elseif (i.gt.j) then
-                  l(i,j) = a(i,j)
-               endif
-            endif
-            if (i.le.k.and.i.le.j) then
-               u(i,j) = a(i,j)
-            endif
+      do 20 j=1,k
+         l(j,j) = 1d0
+         do 10, i=j+1,m
+            l(i,j) = a(i,j)
  10      continue
  20   continue
+      do 40 j=1,k
+         do 30, i=1,j
+            u(i,j) = a(i,j)
+ 30      continue
+ 40   continue
+      do 60 j=k+1,n
+         do 50, i=1,k
+            u(i,j) = a(i,j)
+ 50      continue
+ 60   continue
       if (permute_l.ne.0) then
          call dlaswp(k,l,m,1,k,piv,-1)
       else
-         do 25 i=1,m
+         do 65 i=1,m
             p(i,i)=1d0
- 25       continue
+ 65       continue
          call dlaswp(m,p,m,1,k,piv,-1)
       endif
       end
@@ -75,26 +77,28 @@ cf2py callprotoargument double*,complex_double*,complex_double*,complex_double*,
       if (info.lt.0) then
          return
       endif
-      do 20 i=1,m
-         do 10, j=1,n
-            if (j.le.k) then
-               if (i.eq.j) then
-                  l(i,j) = 1d0
-               elseif (i.gt.j) then
-                  l(i,j) = a(i,j)
-               endif
-            endif
-            if (i.le.k.and.i.le.j) then
-               u(i,j) = a(i,j)
-            endif
+      do 20 j=1,k
+         l(j,j) = 1d0
+         do 10, i=j+1,m
+            l(i,j) = a(i,j)
  10      continue
  20   continue
+      do 40 j=1,k
+         do 30, i=1,j
+            u(i,j) = a(i,j)
+ 30      continue
+ 40   continue
+      do 60 j=k+1,n
+         do 50, i=1,k
+            u(i,j) = a(i,j)
+ 50      continue
+ 60   continue
       if (permute_l.ne.0) then
          call zlaswp(k,l,m,1,k,piv,-1)
       else
-         do 25 i=1,m
+         do 65 i=1,m
             p(i,i)=1d0
- 25       continue
+ 65       continue
          call dlaswp(m,p,m,1,k,piv,-1)
       endif
       end
@@ -122,26 +126,28 @@ cf2py callprotoargument float*,float*,float*,float*,int*,int*,int*,int*,int*,int
       if (info.lt.0) then
          return
       endif
-      do 20 i=1,m
-         do 10, j=1,n
-            if (j.le.k) then
-               if (i.eq.j) then
-                  l(i,j) = 1e0
-               elseif (i.gt.j) then
-                  l(i,j) = a(i,j)
-               endif
-            endif
-            if (i.le.k.and.i.le.j) then
-               u(i,j) = a(i,j)
-            endif
+      do 20 j=1,k
+         l(j,j) = 1d0
+         do 10, i=j+1,m
+            l(i,j) = a(i,j)
  10      continue
  20   continue
+      do 40 j=1,k
+         do 30, i=1,j
+            u(i,j) = a(i,j)
+ 30      continue
+ 40   continue
+      do 60 j=k+1,n
+         do 50, i=1,k
+            u(i,j) = a(i,j)
+ 50      continue
+ 60   continue
       if (permute_l.ne.0) then
          call slaswp(k,l,m,1,k,piv,-1)
       else
-         do 25 i=1,m
+         do 65 i=1,m
             p(i,i)=1e0
- 25       continue
+ 65       continue
          call slaswp(m,p,m,1,k,piv,-1)
       endif
       end
@@ -169,26 +175,28 @@ cf2py callprotoargument float*,complex_float*,complex_float*,complex_float*,int*
       if (info.lt.0) then
          return
       endif
-      do 20 i=1,m
-         do 10, j=1,n
-            if (j.le.k) then
-               if (i.eq.j) then
-                  l(i,j) = 1e0
-               elseif (i.gt.j) then
-                  l(i,j) = a(i,j)
-               endif
-            endif
-            if (i.le.k.and.i.le.j) then
-               u(i,j) = a(i,j)
-            endif
+      do 20 j=1,k
+         l(j,j) = 1d0
+         do 10, i=j+1,m
+            l(i,j) = a(i,j)
  10      continue
  20   continue
+      do 40 j=1,k
+         do 30, i=1,j
+            u(i,j) = a(i,j)
+ 30      continue
+ 40   continue
+      do 60 j=k+1,n
+         do 50, i=1,k
+            u(i,j) = a(i,j)
+ 50      continue
+ 60   continue
       if (permute_l.ne.0) then
          call claswp(k,l,m,1,k,piv,-1)
       else
-         do 25 i=1,m
+         do 65 i=1,m
             p(i,i)=1e0
- 25       continue
+ 65       continue
          call slaswp(m,p,m,1,k,piv,-1)
       endif
       end


### PR DESCRIPTION
1. Split a single loop copying data from output of ?getrf to
   L and U matrices into three different loops to avoid conditional
   branching in the loop.

2. Swapped the order of iterators: iteration over the first index of
   matrix should be innermost to take better advantage of memory
   locality, since the first index moves contiguously in memory with
   Fortran data layout.

This change results in

  * 40% performance improvement on KNL for input
    of shape (23000, 27845) and in double precision.
  * 15% performance improvement on HSW for input
    of shape (17845, 13000) and in double precision

when building both the base and the improved sources using
Intel Compiler using MKL 2018.0.0 for BLAS/LAPACK.

The following script was used to measure timing:

```python
import numpy as np
from scipy.linalg import lu
import time
import copy
try:
   from numpy.random_intel import RandomState
   rs = RandomState(seed=124, brng='SFMT19937')
except ImportError:
   rs = np.random.RandomState(124)


for n,m in ((23000, 27845), (27845, 23000), (35000,35000)):
    rnd = copy.deepcopy(rs)
    mat = rnd.rand(n, m)
    print("LU-decomposition input shape: {}".format(mat.shape))
    for it in range(3):
        t0 = time.time()
        el, u = lu(mat, permute_l=True)
        t1 = time.time()
        print("\tIteration {it}, execution time = {time:.5g} seconds".format(it=it,time=t1-t0))

    print("  (L, U) shapes are {} and {}".format(el.shape, u.shape))
    print("  U[1,5] == {}".format(u[1, 5]))
    del el, u, mat
```

