### PR TITLE
DEP: deprecate misc.pilutil functions

### DIFF
--- a/doc/release/1.0.0-notes.rst
+++ b/doc/release/1.0.0-notes.rst
@@ -124,6 +124,12 @@ specify where the resulting distance matrix is to be stored
 Deprecated features
 ===================
 
+The following functions in `scipy.misc` are deprecated: ``bytescale``,
+``fromimage``, ``imfilter``, ``imread``, ``imresize``, ``imrotate``,
+``imsave``, ``imshow`` and ``toimage``.  Most of those functions have unexpected
+behavior (like rescaling and type casting image data without the user asking
+for that).  Other functions simply have better alternatives.
+
 ``scipy.interpolate.interpolate_wrapper`` and all functions in that submodule
 are deprecated.  This was a never finished set of wrapper functions which is
 not relevant anymore.

--- a/scipy/misc/__init__.py
+++ b/scipy/misc/__init__.py
@@ -15,16 +15,22 @@ below are not available without it.
    :toctree: generated/
 
    ascent - Get example image for processing
-   bytescale - Byte scales an array (image) [requires Pillow]
    central_diff_weights - Weights for an n-point central m-th derivative
    derivative - Find the n-th derivative of a function at a point
    face - Get example image for processing
+
+Deprecated functions:
+
+.. autosummary::
+   :toctree: generated/
+
+   bytescale - Byte scales an array (image) [requires Pillow]
    fromimage - Return a copy of a PIL image as a numpy array [requires Pillow]
    imfilter - Simple filtering of an image [requires Pillow]
    imread - Read an image file from a filename [requires Pillow]
    imresize - Resize an image [requires Pillow]
    imrotate - Rotate an image counter-clockwise [requires Pillow]
-   imsave - Save an array to an image file [requires Pillow] 
+   imsave - Save an array to an image file [requires Pillow]
    imshow - Simple showing of an image through an external viewer [requires Pillow]
    lena - Get classic image processing example image Lena
    toimage - Takes a numpy array and returns a PIL image [requires Pillow]
@@ -46,7 +52,7 @@ Deprecated aliases:
           (imported from `scipy.interpolate`)
    info - Get help information for a function, class, or module. (imported from `numpy`)
    source - Print function source code. (imported from `numpy`)
-   who - Print the Numpy arrays in the given dictionary. (imported from `numpy`) 
+   who - Print the Numpy arrays in the given dictionary. (imported from `numpy`)
 
 """
 

--- a/scipy/misc/__init__.py
+++ b/scipy/misc/__init__.py
@@ -32,7 +32,6 @@ Deprecated functions:
    imrotate - Rotate an image counter-clockwise [requires Pillow]
    imsave - Save an array to an image file [requires Pillow]
    imshow - Simple showing of an image through an external viewer [requires Pillow]
-   lena - Get classic image processing example image Lena
    toimage - Takes a numpy array and returns a PIL image [requires Pillow]
 
 

--- a/scipy/misc/common.py
+++ b/scipy/misc/common.py
@@ -5,10 +5,9 @@ Functions which are common and require SciPy Base and Level 1 SciPy
 
 from __future__ import division, print_function, absolute_import
 
-import numpy as np
 from numpy import arange, newaxis, hstack, product, array, fromstring
 
-__all__ = ['central_diff_weights', 'derivative', 'lena', 'ascent', 'face']
+__all__ = ['central_diff_weights', 'derivative', 'ascent', 'face']
 
 
 def central_diff_weights(Np, ndiv=1):
@@ -118,38 +117,6 @@ def derivative(func, x0, dx=1.0, n=1, args=(), order=3):
     for k in range(order):
         val += weights[k]*func(x0+(k-ho)*dx,*args)
     return val / product((dx,)*n,axis=0)
-
-
-def lena():
-    """
-    Function that previously returned an example image
-
-    .. note:: Removed in 0.17
-
-    Parameters
-    ----------
-    None
-
-    Returns
-    -------
-    None
-
-    Raises
-    ------
-    RuntimeError
-        This functionality has been removed due to licensing reasons.
-
-    Notes
-    -----
-    The image previously returned by this function has an incompatible license
-    and has been removed from SciPy. Please use `face` or `ascent` instead.
-
-    See Also
-    --------
-    face, ascent
-    """
-    raise RuntimeError('lena() is no longer included in SciPy, please use '
-                       'ascent() or face() instead')
 
 
 def ascent():

--- a/scipy/misc/pilutil.py
+++ b/scipy/misc/pilutil.py
@@ -29,7 +29,7 @@ __all__ = ['fromimage', 'toimage', 'imsave', 'imread', 'bytescale',
            'imrotate', 'imresize', 'imshow', 'imfilter']
 
 
-# Returns a byte-scaled image
+@numpy.deprecate(message="`bytescale` is deprecated in SciPy 1.0.0.")
 def bytescale(data, cmin=None, cmax=None, high=255, low=0):
     """
     Byte scales an array (image).
@@ -104,6 +104,8 @@ def bytescale(data, cmin=None, cmax=None, high=255, low=0):
     return (bytedata.clip(low, high) + 0.5).astype(uint8)
 
 
+@numpy.deprecate(message="`imread` is deprecated in SciPy 1.0.0.\n"
+                         "Use ``matplotlib.pyplot.imread`` instead.")
 def imread(name, flatten=False, mode=None):
     """
     Read an image from a file as an array.
@@ -161,6 +163,8 @@ def imread(name, flatten=False, mode=None):
     return fromimage(im, flatten=flatten, mode=mode)
 
 
+@numpy.deprecate(message="`imsave` is deprecated in SciPy 1.0.0. "
+                         "Use ``matplotlib.pyplot.imsave`` instead.")
 def imsave(name, arr, format=None):
     """
     Save an array as an image.
@@ -213,6 +217,8 @@ def imsave(name, arr, format=None):
     return
 
 
+@numpy.deprecate(message="`fromimage` is deprecated in SciPy 1.0.0.\n"
+                         "Use ``np.asarray(im)`` instead.")
 def fromimage(im, flatten=False, mode=None):
     """
     Return a copy of a PIL image as a numpy array.
@@ -270,6 +276,8 @@ def fromimage(im, flatten=False, mode=None):
 _errstr = "Mode is unknown or incompatible with input array shape."
 
 
+@numpy.deprecate(message="`toimage` is deprecated in SciPy 1.0.0.\n"
+            "Use Pillow's ``Image.fromarray`` directly instead.")
 def toimage(arr, high=255, low=0, cmin=None, cmax=None, pal=None,
             mode=None, channel_axis=None):
     """Takes a numpy array and returns a PIL image.
@@ -391,6 +399,8 @@ def toimage(arr, high=255, low=0, cmin=None, cmax=None, pal=None,
     return image
 
 
+@numpy.deprecate(message="`imrotate` is deprecated in SciPy 1.0.0.\n"
+                         "Use ``skimage.transform.rotate`` instead.")
 def imrotate(arr, angle, interp='bilinear'):
     """
     Rotate an image counter-clockwise by angle degrees.
@@ -430,6 +440,8 @@ def imrotate(arr, angle, interp='bilinear'):
     return fromimage(im)
 
 
+@numpy.deprecate(message="`imshow` is deprecated in SciPy 1.0.0.\n"
+                         "Use ``matplotlib.pyplot.imshow`` instead.")
 def imshow(arr):
     """
     Simple showing of an image through an external viewer.
@@ -479,6 +491,8 @@ def imshow(arr):
         raise RuntimeError('Could not execute image viewer.')
 
 
+@numpy.deprecate(message="`imresize` is deprecated in SciPy 1.0.0.\n"
+                         "Use ``skimage.transform.resize`` instead.")
 def imresize(arr, size, interp='bilinear', mode=None):
     """
     Resize an image.
@@ -533,6 +547,8 @@ def imresize(arr, size, interp='bilinear', mode=None):
     return fromimage(imnew)
 
 
+@numpy.deprecate(message="`imfilter` is deprecated in SciPy 1.0.0.\n"
+                         "Use Pillow filtering functionality directly.")
 def imfilter(arr, ftype):
     """
     Simple filtering of an image.

--- a/scipy/misc/pilutil.py
+++ b/scipy/misc/pilutil.py
@@ -12,7 +12,7 @@ from __future__ import division, print_function, absolute_import
 import numpy
 import tempfile
 
-from numpy import (amin, amax, ravel, asarray, cast, arange, ones, newaxis,
+from numpy import (amin, amax, ravel, asarray, arange, ones, newaxis,
                    transpose, iscomplexobj, uint8, issubdtype, array)
 
 try:
@@ -167,6 +167,11 @@ def imsave(name, arr, format=None):
 
     This function is only available if Python Imaging Library (PIL) is installed.
 
+    **Warning**: this function uses `bytescale` under the hood to rescale
+    images to use the full (0, 255) range if ``mode`` is one of ``None, 'L',
+    'P', 'l'``.  It will also cast data for 2-D images to ``uint32`` for
+    ``mode=None`` (which is the default).
+
     Parameters
     ----------
     name : str or file object
@@ -278,6 +283,11 @@ def toimage(arr, high=255, low=0, cmin=None, cmax=None, pal=None,
     (from 0 to 255) then ``mode='P'``, otherwise ``mode='L'``, unless mode
     is given as 'F' or 'I' in which case a float and/or integer array is made.
 
+    **Warning**: this function uses `bytescale` under the hood to rescale
+    images to use the full (0, 255) range if ``mode`` is one of ``None, 'L',
+    'P', 'l'``.  It will also cast data for 2-D images to ``uint32`` for
+    ``mode=None`` (which is the default).
+
     Notes
     -----
     For 3-D arrays, the `channel_axis` argument tells which dimension of the
@@ -387,6 +397,11 @@ def imrotate(arr, angle, interp='bilinear'):
 
     This function is only available if Python Imaging Library (PIL) is installed.
 
+    **Warning**: this function uses `bytescale` under the hood to rescale
+    images to use the full (0, 255) range if ``mode`` is one of ``None, 'L',
+    'P', 'l'``.  It will also cast data for 2-D images to ``uint32`` for
+    ``mode=None`` (which is the default).
+
     Parameters
     ----------
     arr : ndarray
@@ -424,6 +439,11 @@ def imshow(arr):
     Uses the image viewer specified by the environment variable
     SCIPY_PIL_IMAGE_VIEWER, or if that is not defined then `see`,
     to view a temporary file generated from array data.
+
+    **Warning**: this function uses `bytescale` under the hood to rescale
+    images to use the full (0, 255) range if ``mode`` is one of ``None, 'L',
+    'P', 'l'``.  It will also cast data for 2-D images to ``uint32`` for
+    ``mode=None`` (which is the default).
 
     Parameters
     ----------
@@ -465,22 +485,28 @@ def imresize(arr, size, interp='bilinear', mode=None):
 
     This function is only available if Python Imaging Library (PIL) is installed.
 
+    **Warning**: this function uses `bytescale` under the hood to rescale
+    images to use the full (0, 255) range if ``mode`` is one of ``None, 'L',
+    'P', 'l'``.  It will also cast data for 2-D images to ``uint32`` for
+    ``mode=None`` (which is the default).
+
     Parameters
     ----------
     arr : ndarray
         The array of image to be resized.
-
     size : int, float or tuple
         * int   - Percentage of current size.
         * float - Fraction of current size.
         * tuple - Size of the output image (height, width).
 
     interp : str, optional
-        Interpolation to use for re-sizing ('nearest', 'lanczos', 'bilinear', 'bicubic'
-        or 'cubic').
-
+        Interpolation to use for re-sizing ('nearest', 'lanczos', 'bilinear',
+        'bicubic' or 'cubic').
     mode : str, optional
         The PIL image mode ('P', 'L', etc.) to convert `arr` before resizing.
+        If ``mode=None`` (the default), 2-D images will be treated like
+        ``mode='L'``, i.e. casting to long integer.  For 3-D and 4-D arrays,
+        `mode` will be set to ``'RGB'`` and ``'RGBA'`` respectively.
 
     Returns
     -------
@@ -512,6 +538,11 @@ def imfilter(arr, ftype):
     Simple filtering of an image.
 
     This function is only available if Python Imaging Library (PIL) is installed.
+
+    **Warning**: this function uses `bytescale` under the hood to rescale
+    images to use the full (0, 255) range if ``mode`` is one of ``None, 'L',
+    'P', 'l'``.  It will also cast data for 2-D images to ``uint32`` for
+    ``mode=None`` (which is the default).
 
     Parameters
     ----------

--- a/scipy/misc/pilutil.py
+++ b/scipy/misc/pilutil.py
@@ -29,7 +29,8 @@ __all__ = ['fromimage', 'toimage', 'imsave', 'imread', 'bytescale',
            'imrotate', 'imresize', 'imshow', 'imfilter']
 
 
-@numpy.deprecate(message="`bytescale` is deprecated in SciPy 1.0.0.")
+@numpy.deprecate(message="`bytescale` is deprecated in SciPy 1.0.0, "
+                         "and will be removed in 1.2.0.")
 def bytescale(data, cmin=None, cmax=None, high=255, low=0):
     """
     Byte scales an array (image).
@@ -104,8 +105,9 @@ def bytescale(data, cmin=None, cmax=None, high=255, low=0):
     return (bytedata.clip(low, high) + 0.5).astype(uint8)
 
 
-@numpy.deprecate(message="`imread` is deprecated in SciPy 1.0.0.\n"
-                         "Use ``matplotlib.pyplot.imread`` instead.")
+@numpy.deprecate(message="`imread` is deprecated in SciPy 1.0.0, "
+                         "and will be removed in 1.2.0.\n"
+                         "Use ``imageio.imread`` instead.")
 def imread(name, flatten=False, mode=None):
     """
     Read an image from a file as an array.
@@ -163,18 +165,21 @@ def imread(name, flatten=False, mode=None):
     return fromimage(im, flatten=flatten, mode=mode)
 
 
-@numpy.deprecate(message="`imsave` is deprecated in SciPy 1.0.0. "
-                         "Use ``matplotlib.pyplot.imsave`` instead.")
+@numpy.deprecate(message="`imsave` is deprecated in SciPy 1.0.0, "
+                         "and will be removed in 1.2.0.\n"
+                         "Use ``imageio.imwrite`` instead.")
 def imsave(name, arr, format=None):
     """
     Save an array as an image.
 
     This function is only available if Python Imaging Library (PIL) is installed.
 
-    **Warning**: this function uses `bytescale` under the hood to rescale
-    images to use the full (0, 255) range if ``mode`` is one of ``None, 'L',
-    'P', 'l'``.  It will also cast data for 2-D images to ``uint32`` for
-    ``mode=None`` (which is the default).
+    .. warning::
+
+        This function uses `bytescale` under the hood to rescale images to use
+        the full (0, 255) range if ``mode`` is one of ``None, 'L', 'P', 'l'``.
+        It will also cast data for 2-D images to ``uint32`` for ``mode=None``
+        (which is the default).
 
     Parameters
     ----------
@@ -217,7 +222,8 @@ def imsave(name, arr, format=None):
     return
 
 
-@numpy.deprecate(message="`fromimage` is deprecated in SciPy 1.0.0.\n"
+@numpy.deprecate(message="`fromimage` is deprecated in SciPy 1.0.0. "
+                         "and will be removed in 1.2.0.\n"
                          "Use ``np.asarray(im)`` instead.")
 def fromimage(im, flatten=False, mode=None):
     """
@@ -276,7 +282,8 @@ def fromimage(im, flatten=False, mode=None):
 _errstr = "Mode is unknown or incompatible with input array shape."
 
 
-@numpy.deprecate(message="`toimage` is deprecated in SciPy 1.0.0.\n"
+@numpy.deprecate(message="`toimage` is deprecated in SciPy 1.0.0, "
+                         "and will be removed in 1.2.0.\n"
             "Use Pillow's ``Image.fromarray`` directly instead.")
 def toimage(arr, high=255, low=0, cmin=None, cmax=None, pal=None,
             mode=None, channel_axis=None):
@@ -291,10 +298,12 @@ def toimage(arr, high=255, low=0, cmin=None, cmax=None, pal=None,
     (from 0 to 255) then ``mode='P'``, otherwise ``mode='L'``, unless mode
     is given as 'F' or 'I' in which case a float and/or integer array is made.
 
-    **Warning**: this function uses `bytescale` under the hood to rescale
-    images to use the full (0, 255) range if ``mode`` is one of ``None, 'L',
-    'P', 'l'``.  It will also cast data for 2-D images to ``uint32`` for
-    ``mode=None`` (which is the default).
+    .. warning::
+
+        This function uses `bytescale` under the hood to rescale images to use
+        the full (0, 255) range if ``mode`` is one of ``None, 'L', 'P', 'l'``.
+        It will also cast data for 2-D images to ``uint32`` for ``mode=None``
+        (which is the default).
 
     Notes
     -----
@@ -399,7 +408,8 @@ def toimage(arr, high=255, low=0, cmin=None, cmax=None, pal=None,
     return image
 
 
-@numpy.deprecate(message="`imrotate` is deprecated in SciPy 1.0.0.\n"
+@numpy.deprecate(message="`imrotate` is deprecated in SciPy 1.0.0, "
+                         "and will be removed in 1.2.0.\n"
                          "Use ``skimage.transform.rotate`` instead.")
 def imrotate(arr, angle, interp='bilinear'):
     """
@@ -407,10 +417,12 @@ def imrotate(arr, angle, interp='bilinear'):
 
     This function is only available if Python Imaging Library (PIL) is installed.
 
-    **Warning**: this function uses `bytescale` under the hood to rescale
-    images to use the full (0, 255) range if ``mode`` is one of ``None, 'L',
-    'P', 'l'``.  It will also cast data for 2-D images to ``uint32`` for
-    ``mode=None`` (which is the default).
+    .. warning::
+
+        This function uses `bytescale` under the hood to rescale images to use
+        the full (0, 255) range if ``mode`` is one of ``None, 'L', 'P', 'l'``.
+        It will also cast data for 2-D images to ``uint32`` for ``mode=None``
+        (which is the default).
 
     Parameters
     ----------
@@ -440,7 +452,8 @@ def imrotate(arr, angle, interp='bilinear'):
     return fromimage(im)
 
 
-@numpy.deprecate(message="`imshow` is deprecated in SciPy 1.0.0.\n"
+@numpy.deprecate(message="`imshow` is deprecated in SciPy 1.0.0, "
+                         "and will be removed in 1.2.0.\n"
                          "Use ``matplotlib.pyplot.imshow`` instead.")
 def imshow(arr):
     """
@@ -452,10 +465,12 @@ def imshow(arr):
     SCIPY_PIL_IMAGE_VIEWER, or if that is not defined then `see`,
     to view a temporary file generated from array data.
 
-    **Warning**: this function uses `bytescale` under the hood to rescale
-    images to use the full (0, 255) range if ``mode`` is one of ``None, 'L',
-    'P', 'l'``.  It will also cast data for 2-D images to ``uint32`` for
-    ``mode=None`` (which is the default).
+    .. warning::
+
+        This function uses `bytescale` under the hood to rescale images to use
+        the full (0, 255) range if ``mode`` is one of ``None, 'L', 'P', 'l'``.
+        It will also cast data for 2-D images to ``uint32`` for ``mode=None``
+        (which is the default).
 
     Parameters
     ----------
@@ -491,7 +506,8 @@ def imshow(arr):
         raise RuntimeError('Could not execute image viewer.')
 
 
-@numpy.deprecate(message="`imresize` is deprecated in SciPy 1.0.0.\n"
+@numpy.deprecate(message="`imresize` is deprecated in SciPy 1.0.0, "
+                         "and will be removed in 1.2.0.\n"
                          "Use ``skimage.transform.resize`` instead.")
 def imresize(arr, size, interp='bilinear', mode=None):
     """
@@ -499,10 +515,12 @@ def imresize(arr, size, interp='bilinear', mode=None):
 
     This function is only available if Python Imaging Library (PIL) is installed.
 
-    **Warning**: this function uses `bytescale` under the hood to rescale
-    images to use the full (0, 255) range if ``mode`` is one of ``None, 'L',
-    'P', 'l'``.  It will also cast data for 2-D images to ``uint32`` for
-    ``mode=None`` (which is the default).
+    .. warning::
+
+        This function uses `bytescale` under the hood to rescale images to use
+        the full (0, 255) range if ``mode`` is one of ``None, 'L', 'P', 'l'``.
+        It will also cast data for 2-D images to ``uint32`` for ``mode=None``
+        (which is the default).
 
     Parameters
     ----------
@@ -547,7 +565,8 @@ def imresize(arr, size, interp='bilinear', mode=None):
     return fromimage(imnew)
 
 
-@numpy.deprecate(message="`imfilter` is deprecated in SciPy 1.0.0.\n"
+@numpy.deprecate(message="`imfilter` is deprecated in SciPy 1.0.0, "
+                         "and will be removed in 1.2.0.\n"
                          "Use Pillow filtering functionality directly.")
 def imfilter(arr, ftype):
     """
@@ -555,10 +574,12 @@ def imfilter(arr, ftype):
 
     This function is only available if Python Imaging Library (PIL) is installed.
 
-    **Warning**: this function uses `bytescale` under the hood to rescale
-    images to use the full (0, 255) range if ``mode`` is one of ``None, 'L',
-    'P', 'l'``.  It will also cast data for 2-D images to ``uint32`` for
-    ``mode=None`` (which is the default).
+    .. warning::
+
+        This function uses `bytescale` under the hood to rescale images to use
+        the full (0, 255) range if ``mode`` is one of ``None, 'L', 'P', 'l'``.
+        It will also cast data for 2-D images to ``uint32`` for ``mode=None``
+        (which is the default).
 
     Parameters
     ----------

--- a/scipy/misc/tests/test_pilutil.py
+++ b/scipy/misc/tests/test_pilutil.py
@@ -33,57 +33,75 @@ class TestPILUtil(object):
         im = np.random.random((10, 20))
         for T in np.sctypes['float'] + [float]:
             # 1.1 rounds to below 1.1 for float16, 1.101 works
-            im1 = misc.imresize(im, T(1.101))
+            with suppress_warnings() as sup:
+                sup.filter(DeprecationWarning)
+                im1 = misc.imresize(im, T(1.101))
             assert_equal(im1.shape, (11, 22))
 
     def test_imresize2(self):
         im = np.random.random((20, 30))
-        im2 = misc.imresize(im, (30, 40), interp='bicubic')
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning)
+            im2 = misc.imresize(im, (30, 40), interp='bicubic')
         assert_equal(im2.shape, (30, 40))
 
     def test_imresize3(self):
         im = np.random.random((15, 30))
-        im2 = misc.imresize(im, (30, 60), interp='nearest')
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning)
+            im2 = misc.imresize(im, (30, 60), interp='nearest')
         assert_equal(im2.shape, (30, 60))
 
     def test_imresize4(self):
         im = np.array([[1, 2],
                        [3, 4]])
         # Check that resizing by target size, float and int are the same
-        im2 = misc.imresize(im, (4, 4), mode='F')  # output size
-        im3 = misc.imresize(im, 2., mode='F')  # fraction
-        im4 = misc.imresize(im, 200, mode='F')  # percentage
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning)
+            im2 = misc.imresize(im, (4, 4), mode='F')  # output size
+            im3 = misc.imresize(im, 2., mode='F')  # fraction
+            im4 = misc.imresize(im, 200, mode='F')  # percentage
         assert_equal(im2, im3)
         assert_equal(im2, im4)
 
     def test_imresize5(self):
         im = np.random.random((25, 15))
-        im2 = misc.imresize(im, (30, 60), interp='lanczos')
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning)
+            im2 = misc.imresize(im, (30, 60), interp='lanczos')
         assert_equal(im2.shape, (30, 60))
 
     def test_bytescale(self):
         x = np.array([0, 1, 2], np.uint8)
         y = np.array([0, 1, 2])
-        assert_equal(misc.bytescale(x), x)
-        assert_equal(misc.bytescale(y), [0, 128, 255])
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning)
+            assert_equal(misc.bytescale(x), x)
+            assert_equal(misc.bytescale(y), [0, 128, 255])
 
     def test_bytescale_keywords(self):
         x = np.array([40, 60, 120, 200, 300, 500])
-        res_lowhigh = misc.bytescale(x, low=10, high=143)
-        assert_equal(res_lowhigh, [10, 16, 33, 56, 85, 143])
-        res_cmincmax = misc.bytescale(x, cmin=60, cmax=300)
-        assert_equal(res_cmincmax, [0, 0, 64, 149, 255, 255])
-        assert_equal(misc.bytescale(np.array([3, 3, 3]), low=4), [4, 4, 4])
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning)
+            res_lowhigh = misc.bytescale(x, low=10, high=143)
+            assert_equal(res_lowhigh, [10, 16, 33, 56, 85, 143])
+            res_cmincmax = misc.bytescale(x, cmin=60, cmax=300)
+            assert_equal(res_cmincmax, [0, 0, 64, 149, 255, 255])
+            assert_equal(misc.bytescale(np.array([3, 3, 3]), low=4), [4, 4, 4])
 
     def test_bytescale_cscale_lowhigh(self):
         a = np.arange(10)
-        actual = misc.bytescale(a, cmin=3, cmax=6, low=100, high=200)
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning)
+            actual = misc.bytescale(a, cmin=3, cmax=6, low=100, high=200)
         expected = [100, 100, 100, 100, 133, 167, 200, 200, 200, 200]
         assert_equal(actual, expected)
 
     def test_bytescale_mask(self):
         a = np.ma.MaskedArray(data=[1, 2, 3], mask=[False, False, True])
-        actual = misc.bytescale(a)
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning)
+            actual = misc.bytescale(a)
         expected = [0, 255, 3]
         assert_equal(expected, actual)
         assert_mask_equal(a.mask, actual.mask)
@@ -91,25 +109,35 @@ class TestPILUtil(object):
 
     def test_bytescale_rounding(self):
         a = np.array([-0.5, 0.5, 1.5, 2.5, 3.5])
-        actual = misc.bytescale(a, cmin=0, cmax=10, low=0, high=10)
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning)
+            actual = misc.bytescale(a, cmin=0, cmax=10, low=0, high=10)
         expected = [0, 1, 2, 3, 4]
         assert_equal(actual, expected)
 
     def test_bytescale_low_greaterthan_high(self):
         with assert_raises(ValueError):
-            misc.bytescale(np.arange(3), low=10, high=5)
+            with suppress_warnings() as sup:
+                sup.filter(DeprecationWarning)
+                misc.bytescale(np.arange(3), low=10, high=5)
 
     def test_bytescale_low_lessthan_0(self):
         with assert_raises(ValueError):
-            misc.bytescale(np.arange(3), low=-1)
+            with suppress_warnings() as sup:
+                sup.filter(DeprecationWarning)
+                misc.bytescale(np.arange(3), low=-1)
 
     def test_bytescale_high_greaterthan_255(self):
         with assert_raises(ValueError):
-            misc.bytescale(np.arange(3), high=256)
+            with suppress_warnings() as sup:
+                sup.filter(DeprecationWarning)
+                misc.bytescale(np.arange(3), high=256)
 
     def test_bytescale_low_equals_high(self):
         a = np.arange(3)
-        actual = misc.bytescale(a, low=10, high=10)
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning)
+            actual = misc.bytescale(a, low=10, high=10)
         expected = [10, 10, 10]
         assert_equal(actual, expected)
 
@@ -119,6 +147,7 @@ class TestPILUtil(object):
             with suppress_warnings() as sup:
                 # PIL causes a Py3k ResourceWarning
                 sup.filter(message="unclosed file")
+                sup.filter(DeprecationWarning)
                 img = misc.imread(png)
             tmpdir = tempfile.mkdtemp()
             try:
@@ -127,12 +156,14 @@ class TestPILUtil(object):
                 with suppress_warnings() as sup:
                     # PIL causes a Py3k ResourceWarning
                     sup.filter(message="unclosed file")
+                    sup.filter(DeprecationWarning)
                     misc.imsave(fn1, img)
                     misc.imsave(fn2, img, 'PNG')
 
                 with suppress_warnings() as sup:
                     # PIL causes a Py3k ResourceWarning
                     sup.filter(message="unclosed file")
+                    sup.filter(DeprecationWarning)
                     data1 = misc.imread(fn1)
                     data2 = misc.imread(fn2)
                 assert_allclose(data1, img)
@@ -145,7 +176,9 @@ class TestPILUtil(object):
 
 def check_fromimage(filename, irange, shape):
     fp = open(filename, "rb")
-    img = misc.fromimage(PIL.Image.open(fp))
+    with suppress_warnings() as sup:
+        sup.filter(DeprecationWarning)
+        img = misc.fromimage(PIL.Image.open(fp))
     fp.close()
     imin, imax = irange
     assert_equal(img.min(), imin)
@@ -161,7 +194,9 @@ def test_fromimage():
              ('icon_mono.png', (0, 255), (48, 48, 4)),
              ('icon_mono_flat.png', (0, 255), (48, 48, 3))]
     for fn, irange, shape in files:
-        check_fromimage(os.path.join(datapath, 'data', fn), irange, shape)
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning)
+            check_fromimage(os.path.join(datapath, 'data', fn), irange, shape)
 
 
 @_pilskip
@@ -186,7 +221,9 @@ def test_imread_indexed_png():
 
     filename = os.path.join(datapath, 'data', 'foo3x5x4indexed.png')
     with open(filename, 'rb') as f:
-        im = misc.imread(f)
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning)
+            im = misc.imread(f)
     assert_array_equal(im, data)
 
 
@@ -196,7 +233,9 @@ def test_imread_1bit():
     # The border pixels are 1 and the rest are 0.
     filename = os.path.join(datapath, 'data', 'box1.png')
     with open(filename, 'rb') as f:
-        im = misc.imread(f)
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning)
+            im = misc.imread(f)
     assert_equal(im.dtype, np.uint8)
     expected = np.zeros((48, 48), dtype=np.uint8)
     # When scaled up from 1 bit to 8 bits, 1 becomes 255.
@@ -216,7 +255,9 @@ def test_imread_2bit():
     # When scaled up to 8 bits, the values become [0, 85, 170, 255].
     filename = os.path.join(datapath, 'data', 'blocks2bit.png')
     with open(filename, 'rb') as f:
-        im = misc.imread(f)
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning)
+            im = misc.imread(f)
     assert_equal(im.dtype, np.uint8)
     expected = np.zeros((12, 12), dtype=np.uint8)
     expected[:6, 6:] = 85
@@ -232,7 +273,9 @@ def test_imread_4bit():
     # When scaled up to 8 bits, the values become [0, 17, 34, ..., 255].
     filename = os.path.join(datapath, 'data', 'pattern4bit.png')
     with open(filename, 'rb') as f:
-        im = misc.imread(f)
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning)
+            im = misc.imread(f)
     assert_equal(im.dtype, np.uint8)
     j, i = np.meshgrid(np.arange(12), np.arange(31), indexing='ij')
     expected = 17*(np.maximum(j, i) % 16).astype(np.uint8)

--- a/scipy/ndimage/io.py
+++ b/scipy/ndimage/io.py
@@ -1,5 +1,7 @@
 from __future__ import division, print_function, absolute_import
 
+import numpy as np
+
 
 _have_pil = True
 try:
@@ -19,6 +21,8 @@ __all__ = ['imread']
 # Unfortunately, because the argument names are different, that
 # introduces a backwards incompatibility.
 
+@np.deprecate(message="`imread` is deprecated in SciPy 1.0.0.\n"
+                      "Use ``matplotlib.pyplot.imread`` instead.")
 def imread(fname, flatten=False, mode=None):
     if _have_pil:
         return _imread(fname, flatten, mode)

--- a/scipy/ndimage/tests/test_io.py
+++ b/scipy/ndimage/tests/test_io.py
@@ -20,16 +20,19 @@ def test_imread():
     with suppress_warnings() as sup:
         # PIL causes a Py3k ResourceWarning
         sup.filter(message="unclosed file")
+        sup.filter(DeprecationWarning)
         img = ndi.imread(lp, mode="RGB")
     assert_array_equal(img.shape, (300, 420, 3))
 
     with suppress_warnings() as sup:
         # PIL causes a Py3k ResourceWarning
         sup.filter(message="unclosed file")
+        sup.filter(DeprecationWarning)
         img = ndi.imread(lp, flatten=True)
     assert_array_equal(img.shape, (300, 420))
 
     with open(lp, 'rb') as fobj:
-        img = ndi.imread(fobj, mode="RGB")
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning)
+            img = ndi.imread(fobj, mode="RGB")
         assert_array_equal(img.shape, (300, 420, 3))
-


### PR DESCRIPTION
The reasons for these deprecations are:
  1. Many of the functions have bugs and unexpected behavior.
  2. There are better alternatives for pretty much every function.

Summary of issues:

- ``imsave`` rescales images (gh-5305)
- ``imresize`` rescales images (gh-4458) and casts to different dtype (gh-6417)
- Many functions suffer from a shape handling bug for (3, 100, 3) RGB and (4, 100, 4) RGBA images (gh-2347)
- ``toimage`` is the root cause of casting and scaling issues, one more separate bug report at gh-2300
- ``imfilter``, ``imrotate`` and ``imshow`` don't have a bug reported against them, but suffer from casting/rescaling as well.

The functions that seem sort of OK:
- ``imread``. Exposed also as ``ndimage.imread``.  Want to move to ``scipy.io``. Also note the discussion in #6242 (comment) about
  ``imsave``. Want to rename to ``imwrite`` and move to ``scipy.io`` (or write a new one without the rescaling issues and put that in ``io``).
- ``fromimage``.  Changes PIL image to ndarray.
- ``bytescale``.  Does some simple scaling of range of an array.

Closes gh-2347
Closes gh-2300
Closes gh-2442
Closes gh-3154
Closes gh-4458
Closes gh-4893
Closes gh-5305
Closes gh-6242
Closes gh-6417
Closes gh-7259
Closes gh-7458

See discussion about introducing scipy.io.imread/imwrite in http://thread.gmane.org/gmane.comp.python.scientific.devel/20063. I didn't actually do that here, seems duplicate with matplotlib, scikit-image, etc.  Can always be done separately if deemed a good idea.  See also PR gh-5458, which makes an attempt at this.