### PR TITLE
ENH: sparse: Add 64-bit integer to sparsetools

### DIFF
--- a/scipy/sparse/generate_sparsetools.py
+++ b/scipy/sparse/generate_sparsetools.py
@@ -161,7 +161,7 @@ T_TYPES = [
 #
 
 THUNK_TEMPLATE = """
-static Py_ssize_t %(name)s_thunk(int I_typenum, int T_typenum, void **a)
+static PY_LONG_LONG %(name)s_thunk(int I_typenum, int T_typenum, void **a)
 {
     %(thunk_content)s
 }

--- a/scipy/sparse/generate_sparsetools.py
+++ b/scipy/sparse/generate_sparsetools.py
@@ -13,6 +13,7 @@ Type codes used:
     'W':  std::vector<data>*
     '*':  indicates that the next argument is an output argument
     'v':  void
+    'l':  64-bit integer scalar
 
 See sparsetools.cxx for more details.
 
@@ -110,8 +111,8 @@ csr_has_canonical_format  i iII
 # coo.h, dia.h, csgraph.h
 OTHER_ROUTINES = """
 coo_tocsr           v iiiIIT*I*I*T
-coo_todense         v iiiIIT*Ti
-coo_matvec          v iIITT*T
+coo_todense         v iilIIT*Ti
+coo_matvec          v lIITT*T
 dia_matvec          v iiiiITT*T
 cs_graph_components i iII*I
 """
@@ -282,6 +283,8 @@ def parse_routine(name, args, types):
                 if const:
                     raise ValueError("'W' argument must be an output arg")
                 args.append("(std::vector<%s>*)a[%d]" % (T_type, j,))
+            elif t == 'l':
+                args.append("*(%snpy_int64*)a[%d]" % (const, j))
             else:
                 raise ValueError("Invalid spec character %r" % (t,))
             j += 1

--- a/scipy/sparse/sparsetools/coo.h
+++ b/scipy/sparse/sparsetools/coo.h
@@ -82,7 +82,7 @@ void coo_tocsr(const I n_row,
  * Input Arguments:
  *   I  n_row           - number of rows in A
  *   I  n_col           - number of columns in A
- *   I  nnz             - number of nonzeros in A
+ *   npy_int64  nnz     - number of nonzeros in A
  *   I  Ai[nnz(A)]      - row indices
  *   I  Aj[nnz(A)]      - column indices
  *   T  Ax[nnz(A)]      - nonzeros 
@@ -92,20 +92,20 @@ void coo_tocsr(const I n_row,
 template <class I, class T>
 void coo_todense(const I n_row,
                  const I n_col,
-                 const I nnz,
+                 const npy_int64 nnz,
                  const I Ai[],
                  const I Aj[],
                  const T Ax[],
                        T Bx[],
-		 int fortran)
+                 const int fortran)
 {
     if (!fortran) {
-        for(I n = 0; n < nnz; n++){
+        for(npy_int64 n = 0; n < nnz; n++){
             Bx[ (npy_intp)n_col * Ai[n] + Aj[n] ] += Ax[n];
         }
     }
     else {
-        for(I n = 0; n < nnz; n++){
+        for(npy_int64 n = 0; n < nnz; n++){
             Bx[ (npy_intp)n_row * Aj[n] + Ai[n] ] += Ax[n];
         }
     }
@@ -117,7 +117,7 @@ void coo_todense(const I n_row,
  *
  *
  * Input Arguments:
- *   I  nnz           - number of nonzeros in A
+ *   npy_int64  nnz   - number of nonzeros in A
  *   I  Ai[nnz]       - row indices
  *   I  Aj[nnz]       - column indices
  *   T  Ax[nnz]       - nonzero values
@@ -133,14 +133,14 @@ void coo_todense(const I n_row,
  * 
  */
 template <class I, class T>
-void coo_matvec(const I nnz,
-	            const I Ai[], 
-	            const I Aj[], 
-	            const T Ax[],
-	            const T Xx[],
-	                  T Yx[])
+void coo_matvec(const npy_int64 nnz,
+                const I Ai[],
+                const I Aj[],
+                const T Ax[],
+                const T Xx[],
+                      T Yx[])
 {
-    for(I n = 0; n < nnz; n++){
+    for(npy_int64 n = 0; n < nnz; n++){
         Yx[Ai[n]] += Ax[n] * Xx[Aj[n]];
     }
 }

--- a/scipy/sparse/sparsetools/sparsetools.cxx
+++ b/scipy/sparse/sparsetools/sparsetools.cxx
@@ -286,7 +286,7 @@ call_thunk(char ret_spec, const char *spec, thunk_t *thunk, PyObject *args)
                 arg_list[j] = std::malloc(sizeof(npy_int64));
                 *(npy_int64*)arg_list[j] = (npy_int64)value;
             }
-            else if (PyArray_EquivTypenums(I_typenum, NPY_INT32)
+            else if (*p == 'i' && PyArray_EquivTypenums(I_typenum, NPY_INT32)
                      && value == (npy_int32)value) {
                 arg_list[j] = std::malloc(sizeof(npy_int32));
                 *(npy_int32*)arg_list[j] = (npy_int32)value;
@@ -377,6 +377,9 @@ call_thunk(char ret_spec, const char *spec, thunk_t *thunk, PyObject *args)
     case 'i':
         return_value = PyInt_FromSsize_t(ret);
         break;
+    case 'l':
+        return_value = PyInt_FromLong(ret);
+        break;
     case 'v':
         Py_INCREF(Py_None);
         return_value = Py_None;
@@ -446,7 +449,7 @@ fail:
             continue;
         }
         Py_XDECREF(arg_arrays[j]);
-        if (*p == 'i' && arg_list[j] != NULL) {
+        if ((*p == 'i' || *p == 'l') && arg_list[j] != NULL) {
             std::free(arg_list[j]);
         }
         else if (*p == 'V' && arg_list[j] != NULL) {

--- a/scipy/sparse/sparsetools/sparsetools.cxx
+++ b/scipy/sparse/sparsetools/sparsetools.cxx
@@ -37,12 +37,6 @@
 
 #define MAX_ARGS 16
 
-#if PY_VERSION_HEX >= 0x03000000
-#define PyInt_AsSsize_t PyLong_AsSsize_t
-#define PyInt_FromSsize_t PyLong_FromSsize_t
-#define PyInt_FromLong PyLong_FromLong
-#endif
-
 static const int supported_I_typenums[] = {NPY_INT32, NPY_INT64};
 static const int n_supported_I_typenums = sizeof(supported_I_typenums) / sizeof(int);
 
@@ -83,7 +77,7 @@ static PyObject *c_array_from_object(PyObject *obj, int typenum, int is_output);
  *     'W': std::vector<data>
  *     'B': npy_bool array
  *     '*': indicates that the next argument is an output argument
- * thunk : Py_ssize_t thunk(int I_typenum, int T_typenum, void **)
+ * thunk : PY_LONG_LONG thunk(int I_typenum, int T_typenum, void **)
  *     Thunk function to call. It is passed a void** array of pointers to
  *     arguments, constructed according to `spec`. The types of data pointed
  *     to by each element agree with I_typenum and T_typenum, or are bools.
@@ -111,7 +105,7 @@ call_thunk(char ret_spec, const char *spec, thunk_t *thunk, PyObject *args)
     int next_is_output = 0;
     int j, k, arg_j;
     const char *p;
-    Py_ssize_t ret;
+    PY_LONG_LONG ret;
     Py_ssize_t max_array_size = 0;
     NPY_BEGIN_THREADS_DEF;
 
@@ -376,10 +370,8 @@ call_thunk(char ret_spec, const char *spec, thunk_t *thunk, PyObject *args)
 
     switch (ret_spec) {
     case 'i':
-        return_value = PyInt_FromSsize_t(ret);
-        break;
     case 'l':
-        return_value = PyInt_FromLong(ret);
+        return_value = PyLong_FromLongLong(ret);
         break;
     case 'v':
         Py_INCREF(Py_None);

--- a/scipy/sparse/sparsetools/sparsetools.cxx
+++ b/scipy/sparse/sparsetools/sparsetools.cxx
@@ -40,6 +40,7 @@
 #if PY_VERSION_HEX >= 0x03000000
 #define PyInt_AsSsize_t PyLong_AsSsize_t
 #define PyInt_FromSsize_t PyLong_FromSsize_t
+#define PyInt_FromLong PyLong_FromLong
 #endif
 
 static const int supported_I_typenums[] = {NPY_INT32, NPY_INT64};

--- a/scipy/sparse/sparsetools/sparsetools.cxx
+++ b/scipy/sparse/sparsetools/sparsetools.cxx
@@ -154,6 +154,7 @@ call_thunk(char ret_spec, const char *spec, thunk_t *thunk, PyObject *args)
             --arg_j;
             continue;
         case 'i':
+        case 'l':
             /* Integer scalars */
             arg = PyTuple_GetItem(args, arg_j);
             if (arg == NULL) {
@@ -262,7 +263,7 @@ call_thunk(char ret_spec, const char *spec, thunk_t *thunk, PyObject *args)
             --j;
             continue;
         }
-        else if (*p == 'i') {
+        else if (*p == 'i' || *p == 'l') {
             /* Integer scalars */
             PY_LONG_LONG value;
 
@@ -280,7 +281,7 @@ call_thunk(char ret_spec, const char *spec, thunk_t *thunk, PyObject *args)
                 goto fail;
             }
 
-            if (PyArray_EquivTypenums(I_typenum, NPY_INT64)
+            if ((*p == 'l' || PyArray_EquivTypenums(I_typenum, NPY_INT64))
                     && value == (npy_int64)value) {
                 arg_list[j] = std::malloc(sizeof(npy_int64));
                 *(npy_int64*)arg_list[j] = (npy_int64)value;

--- a/scipy/sparse/sparsetools/sparsetools.h
+++ b/scipy/sparse/sparsetools/sparsetools.h
@@ -9,7 +9,7 @@
 #include "bool_ops.h"
 #include "complex_ops.h"
 
-typedef Py_ssize_t thunk_t(int I_typenum, int T_typenum, void **args);
+typedef PY_LONG_LONG thunk_t(int I_typenum, int T_typenum, void **args);
 
 NPY_VISIBILITY_HIDDEN PyObject *
 call_thunk(char ret_spec, const char *spec, thunk_t *thunk, PyObject *args);


### PR DESCRIPTION
This supersedes gh-7435 and fixes gh-7230, by allowing sparsetools functions to accept 64-bit integers even when the index dtype is 32-bit.

It's a little tricky to verify that this works without gobs of RAM, but here's one way to do it:
```python
import numpy as np
import scipy.sparse
from scipy.sparse._sparsetools import coo_todense

a = scipy.sparse.rand(5, 4, density=0.5)  # produces coo_matrix with index dtype = int32
out = np.zeros_like(a.toarray())
nnz = 2**32
coo_todense(5, 4, nnz, a.row, a.col, a.data, out.ravel('A'), 0)
```

Without this PR, the sparsetools machinery tries to cast `nnz` to int32, fails, and raises an error.

With this PR, we are able to pass `nnz` as a 64-bit integer and `coo_todense` promptly segfaults (as expected).
