### PR TITLE
TST: fix an optimize.linprog test that fails intermittently.

### DIFF
--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -687,7 +687,7 @@ class BaseTestLinprogIP(LinprogCommonTests):
             sol = linprog(c, A_ub=A_ub, b_ub=b_ub, A_eq=A_eq, b_eq=b_eq,
                           bounds=bounds, method=self.method,
                           options=self.options)
-        _assert_success(sol, desired_fun=-1.191)
+        _assert_success(sol, desired_fun=-1.191, rtol=1e-6)
 
     def test_bug_5400(self):
         # https://github.com/scipy/scipy/issues/5400


### PR DESCRIPTION
The tolerance for this test was borderline.  It fails about 1 in 3
runs on 32-bit Linux.  Note that this test is run in 3 subclasses
with different ``options`` dicts.  There's no pattern in the failures
it seems, they all fail intermittently.
    
[ci skip]