### PR TITLE
ENH: re-enabled old sv lapack routine as defaults

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -182,6 +182,7 @@ Charles Masson for the Wasserstein and the Cramér-von Mises statistical
     distances.
 Felix Lenders for implementing trust-trlib method.
 Dezmond Goff for adding optional out parameter to pdist/cdist
+Nick R. Papior for allowing a wider choice of solvers
 
 Institutions
 ------------

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -750,6 +750,9 @@ class TestSolve(object):
         with warnings.catch_warnings():
             warnings.simplefilter('error')
             assert_raises(DeprecationWarning, solve, a, b, transposed=1)
+        with warnings.catch_warnings():
+            warnings.simplefilter('error')
+            assert_raises(DeprecationWarning, solve, a, b, transposed=False)
 
     def test_nonsquare_a(self):
         assert_raises(ValueError, solve, [1, 2], 1)

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -714,6 +714,9 @@ class TestSolve(object):
         with warnings.catch_warnings():
             warnings.simplefilter('error')
             assert_raises(RuntimeWarning, solve, a, b)
+        with warnings.catch_warnings():
+            warnings.simplefilter('error')
+            assert_raises(RuntimeWarning, solve, a, b, refine=True)
 
     def test_empty_rhs(self):
         a = np.eye(2)
@@ -728,12 +731,25 @@ class TestSolve(object):
         x = solve(a, b)
         assert_array_almost_equal(x, b)
 
-    def test_transposed_keyword(self):
+    def test_form_keyword(self):
         A = np.arange(9).reshape(3, 3) + 1
-        x = solve(np.tril(A)/9, np.ones(3), transposed=1)
+        x = solve(np.tril(A)/9, np.ones(3), form='trans')
         assert_array_almost_equal(x, [1.2, 0.2, 1])
-        x = solve(np.tril(A)/9, np.ones(3), transposed=0)
+        x = solve(np.tril(A)/9, np.ones(3), form='none')
         assert_array_almost_equal(x, [9, -5.4, -1.2])
+        x = solve(np.tril(A)/9, np.ones(3), form='trans', refine=True)
+        assert_array_almost_equal(x, [1.2, 0.2, 1])
+        x = solve(np.tril(A)/9, np.ones(3), form='none', refine=True)
+        assert_array_almost_equal(x, [9, -5.4, -1.2])
+        assert_raises(ValueError, solve, 1, 1, form='zxcv')
+        assert_raises(ValueError, solve, 1, 1, assume_a='her', form='anything')
+
+    def test_transposed_warning(self):
+        a = np.array([[1, 1], [1+1e-16, 1-1e-16]])
+        b = np.ones(2)
+        with warnings.catch_warnings():
+            warnings.simplefilter('error')
+            assert_raises(DeprecationWarning, solve, a, b, transposed=1)
 
     def test_nonsquare_a(self):
         assert_raises(ValueError, solve, [1, 2], 1)
@@ -771,12 +787,48 @@ class TestSolve(object):
             elif assume_a == 'pos':
                 a = a.conj().T.dot(a) + 0.1*np.eye(size)
 
-            x = solve(a, b, assume_a=assume_a)
             tol = 1e-12 if dtype in (np.float64, np.complex128) else 1e-6
+
+            x = solve(a, b, assume_a=assume_a, refine=True)
             assert_allclose(a.dot(x), b,
                             atol=tol * size,
                             rtol=tol * size,
                             err_msg=err_msg)
+
+            if assume_a == 'sym':
+                x = solve(a, b, form='trans', refine=True)
+                assert_allclose(a.dot(x), b,
+                                atol=tol * size,
+                                rtol=tol * size,
+                                err_msg=err_msg)
+
+            elif assume_a == 'her':
+                x = solve(a, b, form='conj', refine=True)
+                assert_allclose(a.dot(x), b,
+                                atol=tol * size,
+                                rtol=tol * size,
+                                err_msg=err_msg)
+
+            if assume_a in ['gen', 'sym', 'her']:
+                # For the symmetric case, the tolerance cannot be
+                # as high as for the refined case.
+                # We thus revert the tolerance from before
+                #   4b4a6e7c34fa4060533db38f9a819b98fa81476c
+                if dtype in (np.float32, np.complex64):
+                    tol *= 10
+
+            x = solve(a, b, assume_a=assume_a)
+            assert_allclose(a.dot(x), b,
+                            atol=tol * size,
+                            rtol=tol * size,
+                            err_msg=err_msg)
+
+            if assume_a == 'her':
+                x = solve(a, b, form='conj')
+                assert_allclose(a.dot(x), b,
+                                atol=tol * size,
+                                rtol=tol * size,
+                                err_msg=err_msg)
 
 
 class TestSolveTriangular(object):

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -347,6 +347,7 @@ class LinprogCommonTests(object):
             with suppress_warnings() as sup:
                 sup.filter(RuntimeWarning, "scipy.linalg.solve\nIll...")
                 sup.filter(OptimizeWarning, "A_eq does not appear...")
+                sup.filter(OptimizeWarning, "Solving system with option...")
                 res = linprog(c=cost, A_eq=A_eq, b_eq=b_eq, bounds=bounds,
                               method=self.method, options=self.options)
         _assert_success(res, desired_fun=14)
@@ -865,6 +866,7 @@ class TestLinprogIPSpecific:
         A, b, c = lpgen_2d(20, 20)
         with suppress_warnings() as sup:
             sup.filter(RuntimeWarning, "scipy.linalg.solve\nIll...")
+            sup.filter(OptimizeWarning, "Solving system with option...")
             res = linprog(c, A_ub=A, b_ub=b, method=self.method,
                           options={"ip": True, "disp": True})
             # ip code is independent of sparse/dense

--- a/scipy/sparse/linalg/tests/test_matfuncs.py
+++ b/scipy/sparse/linalg/tests/test_matfuncs.py
@@ -199,7 +199,10 @@ class TestExpM(object):
         tiny = 1e-17
         A_logm_perturbed = A_logm.copy()
         A_logm_perturbed[1, 0] = tiny
-        A_expm_logm_perturbed = expm(A_logm_perturbed)
+        with suppress_warnings() as sup:
+            sup.filter(RuntimeWarning,
+                       "scipy.linalg.solve\nIll-conditioned.*")
+            A_expm_logm_perturbed = expm(A_logm_perturbed)
         rtol = 1e-4
         atol = 100 * tiny
         assert_(not np.allclose(A_expm_logm_perturbed, A, rtol=rtol, atol=atol))


### PR DESCRIPTION
This fixes the speed regression in #7847. Since the default
change of sv to svx the solve routine suffered a huge performance
penalty for anything but low order NRHS.

This commit fixes that issue by enabling the use of either 1) the
svx or 2) the sv routines. With a default on the latter.

However, the main funtionality by using svx was the easy check
of the condition number to assert a non-singular matrix.
This commit adds a call to the con routines to extract the
appropriate condition number. This force the addition of:

   - lamch (machine precision extraction)
   - gecon (condition number calculation from LU factorization)
   - lange (1-norm of matrix)

This commit adds to arguments (and deprecates one) by:
  - refine, bool, decides whether the svx (true) or sv (false)
    routines should be used.
  - form = 'none', 'trans', 'conj' which refers to the form
    of the solution step. This is only valid if refine=True
    A ValueError will be issued if not none and refine=False.
    This keyword deprecates the "transposed" boolean value which
    only allowed 'T' (real) and 'C' (complex) but not 'T' for
    complex.

A fix for the deprecated sym_pos keyword which wasn't used in the previous
version.

A couple of additional tests have been added, mainly to check the arguments.