### PR TITLE
DOC: Update 1.0.0-notes.rst

### DIFF
--- a/doc/release/1.0.0-notes.rst
+++ b/doc/release/1.0.0-notes.rst
@@ -187,6 +187,13 @@ The ``fillvalue`` of `scipy.signal.convolve2d` will be cast directly to the
 dtypes of the input arrays in the future and checked that it is a scalar or
 an array with a single element.
 
+``scipy.spatial.distance.wminkowski`` and ``scipy.spatial.distance.matching``
+are now alias of ``scipy.spatial.distance.minkowski`` 
+and ``scipy.spatial.distance.hamming`` respectively.
+
+Positional arguments of ``pdist`` and ``cdist`` should be replaced with 
+their keyword version. 
+
 
 Backwards incompatible changes
 ==============================
@@ -250,6 +257,10 @@ was a corner case for which it was unclear that the behavior was well-defined.
 
 The method ``var`` of `scipy.stats.dirichlet` now returns a scalar rather than
 an ndarray when the length of alpha is 1.
+
+Behaviour of the weighted version ``scipy.spatial.distance.minkowski`` has changed 
+with respect to the old ``scipy.spatial.distance.wminkowski`` to fix a wrong 
+interpretation of the metric definition.
 
 
 Other changes


### PR DESCRIPTION
Added some infos about:
Deprecation of wminkowski and hamming.
Deprecation of args in Xdist.
Different implementation/behaviour of weighted minkowski.