### PR TITLE
DOC: remove mentions of wheels.scipy.org

### DIFF
--- a/doc/source/dev/distributing.rst
+++ b/doc/source/dev/distributing.rst
@@ -131,6 +131,13 @@ and distributing them on PyPI or elsewhere.
 
 **Windows**
 
+- The currently most easily available toolchain for building
+  Python.org compatible binaries for Scipy is installing MSVC (see
+  https://wiki.python.org/moin/WindowsCompilers) and mingw64-gfortran.
+  Support for this configuration requires numpy.distutils from
+  Numpy >= 1.14.dev and a gcc/gfortran-compiled static ``openblas.a``.
+  This configuration is currently used in the Appveyor configuration for
+  https://github.com/MacPython/scipy-wheels
 - For 64-bit Windows installers built with a free toolchain, use the method
   documented at https://github.com/numpy/numpy/wiki/Mingw-static-toolchain.
   That method will likely be used for Scipy itself once it's clear that the
@@ -164,12 +171,13 @@ and distributing them on PyPI or elsewhere.
 
 **Linux**
 
-Besides PyPi not allowing Linux wheels (which is about to change with `PEP 513
-<https://www.python.org/dev/peps/pep-0513>`_), there are no specific issues with
-building binaries.  To build a set of wheels for a Linux distribution and
-providing them in a Wheelhouse_, look at the wheel_ and Wheelhouse_ docs.  A
-Wheelhouse for wheels compatible with TravisCI is http://wheels.scipy.org.
+- PyPi-compatible Linux wheels can be produced via the manylinux_ project.
+  The corresponding build setup for TravisCI for Scipy is set up in
+  https://github.com/MacPython/scipy-wheels.
 
+Other Linux build-setups result to PyPi incompatible wheels, which
+would need to be distributed via custom channels, e.g. in a
+Wheelhouse_, see at the wheel_ and Wheelhouse_ docs.
 
 
 .. _Numpy: http://numpy.org
@@ -190,3 +198,4 @@ Wheelhouse for wheels compatible with TravisCI is http://wheels.scipy.org.
 .. _Sphinx: http://sphinx-doc.org/
 .. _six: https://pypi.python.org/pypi/six
 .. _decorator: https://github.com/micheles/decorator
+.. _manylinux: https://github.com/pypa/manylinux/

--- a/doc/source/dev/releasing.rst
+++ b/doc/source/dev/releasing.rst
@@ -113,16 +113,18 @@ the ``scipy-wheels`` build scripts automatically build the last tag.
 
 To build wheels, push a commit to the master branch of
 https://github.com/MacPython/scipy-wheels .  This triggers builds for all needed
-Python versions on TravisCI.  Check in the ``.travis.yml`` config file what
-version of Python and Numpy are used for the builds (it needs to be the lowest
-supported Numpy version for each Python version).  See the README file in the
-scipy-wheels repo for more details.
+Python versions on TravisCI.  Update and check the ``.travis.yml`` and ``appveyor.yml``
+config files what tag to build, and what Python and Numpy are used for the builds
+(it needs to be the lowest supported Numpy version for each Python version).
+See the README file in the scipy-wheels repo for more details.
 
-The TravisCI builds run the tests from the built wheels and if they pass upload
-the wheels to http://wheels.scipy.org/.  From there you can download them for
-uploading to PyPI.  This can be done in an automated fashion with ``terryfy``
-(note the -n switch which makes it only download the wheels and skip the upload
-to PyPI step - we want to be able to check the wheels and put their checksums
+The TravisCI and Appveyor builds run the tests from the built wheels and if they pass,
+upload the wheels to a container pointed to at https://github.com/MacPython/scipy-wheels
+
+From there you can download them for uploading to PyPI.  This can be
+done in an automated fashion with ``terryfy`` (note the -n switch
+which makes it only download the wheels and skip the upload to PyPI
+step - we want to be able to check the wheels and put their checksums
 into README first)::
 
   $ python wheel-uploader -n -v -c -w ~/PATH_TO_STORE_WHEELS -t manylinux1 scipy 0.19.0


### PR DESCRIPTION
The wheels.scipy.org dns name is accessible only via HTTP, and should
not be used.  The HTTPS-accessible containers have long names --- those
are mentioned in the scipy-wheels repository README, and probably best
to not write them again here.

Also update information on linux and windows builds.