### PR TITLE
DOC: Show probability density functions as math

### DIFF
--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -17,15 +17,17 @@ from ._distn_infrastructure import (
 
 
 class binom_gen(rv_discrete):
-    """A binomial discrete random variable.
+    r"""A binomial discrete random variable.
 
     %(before_notes)s
 
     Notes
     -----
-    The probability mass function for `binom` is::
+    The probability mass function for `binom` is:
 
-       binom.pmf(k) = choose(n, k) * p**k * (1-p)**(n-k)
+    .. math::
+
+       f(k) = \binom{n}{k} p^k (1-p)^{n-k}
 
     for ``k`` in ``{0, 1,..., n}``.
 
@@ -49,6 +51,7 @@ class binom_gen(rv_discrete):
         return combiln + special.xlogy(k, p) + special.xlog1py(n-k, -p)
 
     def _pmf(self, x, n, p):
+        # binom.pmf(k) = choose(n, k) * p**k * (1-p)**(n-k)
         return exp(self._logpmf(x, n, p))
 
     def _cdf(self, x, n, p):
@@ -85,20 +88,22 @@ binom = binom_gen(name='binom')
 
 
 class bernoulli_gen(binom_gen):
-    """A Bernoulli discrete random variable.
+    r"""A Bernoulli discrete random variable.
 
     %(before_notes)s
 
     Notes
     -----
-    The probability mass function for `bernoulli` is::
+    The probability mass function for `bernoulli` is:
 
-       bernoulli.pmf(k) = 1-p  if k = 0
-                        = p    if k = 1
+    .. math::
 
-    for ``k`` in ``{0, 1}``.
+       f(k) = \begin{cases}1-p  &\text{if } k = 0\\
+                           p    &\text{if } k = 1\end{cases}
 
-    `bernoulli` takes ``p`` as shape parameter.
+    for :math:`k` in :math:`\{0, 1\}`.
+
+    `bernoulli` takes :math:`p` as shape parameter.
 
     %(after_notes)s
 
@@ -115,6 +120,8 @@ class bernoulli_gen(binom_gen):
         return binom._logpmf(x, 1, p)
 
     def _pmf(self, x, p):
+        # bernoulli.pmf(k) = 1-p  if k = 0
+        #                  = p    if k = 1
         return binom._pmf(x, 1, p)
 
     def _cdf(self, x, p):
@@ -135,23 +142,25 @@ bernoulli = bernoulli_gen(b=1, name='bernoulli')
 
 
 class nbinom_gen(rv_discrete):
-    """A negative binomial discrete random variable.
+    r"""A negative binomial discrete random variable.
 
     %(before_notes)s
 
     Notes
     -----
-    Negative binomial distribution describes a sequence of i.i.d. Bernoulli 
+    Negative binomial distribution describes a sequence of i.i.d. Bernoulli
     trials, repeated until a predefined, non-random number of successes occurs.
 
-    The probability mass function of the number of failures for `nbinom` is::
+    The probability mass function of the number of failures for `nbinom` is:
 
-       nbinom.pmf(k) = choose(k+n-1, n-1) * p**n * (1-p)**k
+    .. math::
 
-    for ``k >= 0``.
+       f(k) = \binom{k+n-1}{n-1} p^n (1-p)^k
 
-    `nbinom` takes ``n`` and ``p`` as shape parameters where n is the number of
-    successes, whereas p is the probability of a single success.
+    for :math:`k \ge 0`.
+
+    `nbinom` takes :math:`n` and :math:`p` as shape parameters where n is the
+    number of successes, whereas p is the probability of a single success.
 
     %(after_notes)s
 
@@ -165,6 +174,7 @@ class nbinom_gen(rv_discrete):
         return (n > 0) & (p >= 0) & (p <= 1)
 
     def _pmf(self, x, n, p):
+        # nbinom.pmf(k) = choose(k+n-1, n-1) * p**n * (1-p)**k
         return exp(self._logpmf(x, n, p))
 
     def _logpmf(self, x, n, p):
@@ -198,19 +208,21 @@ nbinom = nbinom_gen(name='nbinom')
 
 
 class geom_gen(rv_discrete):
-    """A geometric discrete random variable.
+    r"""A geometric discrete random variable.
 
     %(before_notes)s
 
     Notes
     -----
-    The probability mass function for `geom` is::
+    The probability mass function for `geom` is:
 
-        geom.pmf(k) = (1-p)**(k-1)*p
+    .. math::
 
-    for ``k >= 1``.
+        f(k) = (1-p)^{k-1} p
 
-    `geom` takes ``p`` as shape parameter.
+    for :math:`k \ge 1`.
+
+    `geom` takes :math:`p` as shape parameter.
 
     %(after_notes)s
 
@@ -224,6 +236,7 @@ class geom_gen(rv_discrete):
         return (p <= 1) & (p >= 0)
 
     def _pmf(self, k, p):
+        # geom.pmf(k) = (1-p)**(k-1)*p
         return np.power(1-p, k-1) * p
 
     def _logpmf(self, k, p):
@@ -273,7 +286,8 @@ class hypergeom_gen(rv_discrete):
 
     The probability mass function is defined as,
 
-    .. math:: p(k, M, n, N) = \frac{\binom{n}{k} \binom{M - n}{N - k}}{\binom{M}{N}}
+    .. math:: p(k, M, n, N) = \frac{\binom{n}{k} \binom{M - n}{N - k}}
+                                   {\binom{M}{N}}
 
     for :math:`k \in [\max(0, N - M + n), \min(n, N)]`, where the binomial
     coefficients are defined as,
@@ -373,7 +387,7 @@ class hypergeom_gen(rv_discrete):
             k2 = np.arange(quant + 1, draw + 1)
             res.append(np.sum(self._pmf(k2, tot, good, draw)))
         return np.asarray(res)
-        
+
     def _logsf(self, k, M, n, N):
         """
         More precise calculation than log(sf)
@@ -389,19 +403,21 @@ hypergeom = hypergeom_gen(name='hypergeom')
 
 # FIXME: Fails _cdfvec
 class logser_gen(rv_discrete):
-    """A Logarithmic (Log-Series, Series) discrete random variable.
+    r"""A Logarithmic (Log-Series, Series) discrete random variable.
 
     %(before_notes)s
 
     Notes
     -----
-    The probability mass function for `logser` is::
+    The probability mass function for `logser` is:
 
-        logser.pmf(k) = - p**k / (k*log(1-p))
+    .. math::
 
-    for ``k >= 1``.
+        f(k) = - \frac{p^k}{k \log(1-p)}
 
-    `logser` takes ``p`` as shape parameter.
+    for :math:`k \ge 1`.
+
+    `logser` takes :math:`p` as shape parameter.
 
     %(after_notes)s
 
@@ -417,6 +433,7 @@ class logser_gen(rv_discrete):
         return (p > 0) & (p < 1)
 
     def _pmf(self, k, p):
+        # logser.pmf(k) = - p**k / (k*log(1-p))
         return -np.power(p, k) * 1.0 / k / special.log1p(-p)
 
     def _stats(self, p):
@@ -437,19 +454,21 @@ logser = logser_gen(a=1, name='logser', longname='A logarithmic')
 
 
 class poisson_gen(rv_discrete):
-    """A Poisson discrete random variable.
+    r"""A Poisson discrete random variable.
 
     %(before_notes)s
 
     Notes
     -----
-    The probability mass function for `poisson` is::
+    The probability mass function for `poisson` is:
 
-        poisson.pmf(k) = exp(-mu) * mu**k / k!
+    .. math::
 
-    for ``k >= 0``.
+        f(k) = \exp(-\mu) \frac{mu^k}{k!}
 
-    `poisson` takes ``mu`` as shape parameter.
+    for :math:`k \ge 0`.
+
+    `poisson` takes :math:`\mu` as shape parameter.
 
     %(after_notes)s
 
@@ -469,6 +488,7 @@ class poisson_gen(rv_discrete):
         return Pk
 
     def _pmf(self, k, mu):
+        # poisson.pmf(k) = exp(-mu) * mu**k / k!
         return exp(self._logpmf(k, mu))
 
     def _cdf(self, x, mu):
@@ -497,19 +517,21 @@ poisson = poisson_gen(name="poisson", longname='A Poisson')
 
 
 class planck_gen(rv_discrete):
-    """A Planck discrete exponential random variable.
+    r"""A Planck discrete exponential random variable.
 
     %(before_notes)s
 
     Notes
     -----
-    The probability mass function for `planck` is::
+    The probability mass function for `planck` is:
 
-        planck.pmf(k) = (1-exp(-lambda_))*exp(-lambda_*k)
+    .. math::
 
-    for ``k*lambda_ >= 0``.
+        f(k) = (1-\exp(-\lambda)) \exp(-\lambda k)
 
-    `planck` takes ``lambda_`` as shape parameter.
+    for :math:`k \lambda \ge 0`.
+
+    `planck` takes :math:`\lambda` as shape parameter.
 
     %(after_notes)s
 
@@ -522,6 +544,7 @@ class planck_gen(rv_discrete):
         return lambda_ != 0
 
     def _pmf(self, k, lambda_):
+        # planck.pmf(k) = (1-exp(-lambda_))*exp(-lambda_*k)
         fact = (1-exp(-lambda_))
         return fact*exp(-lambda_*k)
 
@@ -557,19 +580,21 @@ planck = planck_gen(name='planck', longname='A discrete exponential ')
 
 
 class boltzmann_gen(rv_discrete):
-    """A Boltzmann (Truncated Discrete Exponential) random variable.
+    r"""A Boltzmann (Truncated Discrete Exponential) random variable.
 
     %(before_notes)s
 
     Notes
     -----
-    The probability mass function for `boltzmann` is::
+    The probability mass function for `boltzmann` is:
 
-        boltzmann.pmf(k) = (1-exp(-lambda_)*exp(-lambda_*k)/(1-exp(-lambda_*N))
+    .. math::
 
-    for ``k = 0,..., N-1``.
+        f(k) = (1-\exp(-\lambda) \exp(-\lambda k)/(1-\exp(-\lambda N))
 
-    `boltzmann` takes ``lambda_`` and ``N`` as shape parameters.
+    for :math:`k = 0,..., N-1`.
+
+    `boltzmann` takes :math:`\lambda` and :math:`N` as shape parameters.
 
     %(after_notes)s
 
@@ -577,6 +602,8 @@ class boltzmann_gen(rv_discrete):
 
     """
     def _pmf(self, k, lambda_, N):
+        # boltzmann.pmf(k) =
+        #               (1-exp(-lambda_)*exp(-lambda_*k)/(1-exp(-lambda_*N))
         fact = (1-exp(-lambda_))/(1-exp(-lambda_*N))
         return fact*exp(-lambda_*k)
 
@@ -608,15 +635,17 @@ boltzmann = boltzmann_gen(name='boltzmann',
 
 
 class randint_gen(rv_discrete):
-    """A uniform discrete random variable.
+    r"""A uniform discrete random variable.
 
     %(before_notes)s
 
     Notes
     -----
-    The probability mass function for `randint` is::
+    The probability mass function for `randint` is:
 
-        randint.pmf(k) = 1./(high - low)
+    .. math::
+
+        f(k) = \frac{1}{high - low}
 
     for ``k = low, ..., high - 1``.
 
@@ -633,6 +662,7 @@ class randint_gen(rv_discrete):
         return (high > low)
 
     def _pmf(self, k, low, high):
+        # randint.pmf(k) = 1./(high - low)
         p = np.ones_like(k) / (high - low)
         return np.where((k >= low) & (k < high), p, 0.)
 
@@ -676,19 +706,21 @@ randint = randint_gen(name='randint', longname='A discrete uniform '
 
 # FIXME: problems sampling.
 class zipf_gen(rv_discrete):
-    """A Zipf discrete random variable.
+    r"""A Zipf discrete random variable.
 
     %(before_notes)s
 
     Notes
     -----
-    The probability mass function for `zipf` is::
+    The probability mass function for `zipf` is:
 
-        zipf.pmf(k, a) = 1/(zeta(a) * k**a)
+    .. math::
 
-    for ``k >= 1``.
+        f(k, a) = \frac{1}{\zeta(a) k^a}
 
-    `zipf` takes ``a`` as shape parameter.
+    for :math:`k \ge 1`.
+
+    `zipf` takes :math:`a` as shape parameter.
 
     %(after_notes)s
 
@@ -702,6 +734,7 @@ class zipf_gen(rv_discrete):
         return a > 1
 
     def _pmf(self, k, a):
+        # zipf.pmf(k, a) = 1/(zeta(a) * k**a)
         Pk = 1.0 / special.zeta(a, 1) / k**a
         return Pk
 
@@ -714,19 +747,21 @@ zipf = zipf_gen(a=1, name='zipf', longname='A Zipf')
 
 
 class dlaplace_gen(rv_discrete):
-    """A  Laplacian discrete random variable.
+    r"""A  Laplacian discrete random variable.
 
     %(before_notes)s
 
     Notes
     -----
-    The probability mass function for `dlaplace` is::
+    The probability mass function for `dlaplace` is:
 
-        dlaplace.pmf(k) = tanh(a/2) * exp(-a*abs(k))
+    .. math::
 
-    for ``a > 0``.
+        f(k) = \tanh(a/2) \exp(-a |k|)
 
-    `dlaplace` takes ``a`` as shape parameter.
+    for :math:`a > 0`.
+
+    `dlaplace` takes :math:`a` as shape parameter.
 
     %(after_notes)s
 
@@ -734,6 +769,7 @@ class dlaplace_gen(rv_discrete):
 
     """
     def _pmf(self, k, a):
+        # dlaplace.pmf(k) = tanh(a/2) * exp(-a*abs(k))
         return tanh(a/2.0) * exp(-a * abs(k))
 
     def _cdf(self, x, a):
@@ -762,7 +798,7 @@ dlaplace = dlaplace_gen(a=-np.inf,
 
 
 class skellam_gen(rv_discrete):
-    """A  Skellam discrete random variable.
+    r"""A  Skellam discrete random variable.
 
     %(before_notes)s
 
@@ -771,18 +807,20 @@ class skellam_gen(rv_discrete):
     Probability distribution of the difference of two correlated or
     uncorrelated Poisson random variables.
 
-    Let k1 and k2 be two Poisson-distributed r.v. with expected values
-    lam1 and lam2. Then, ``k1 - k2`` follows a Skellam distribution with
-    parameters ``mu1 = lam1 - rho*sqrt(lam1*lam2)`` and
-    ``mu2 = lam2 - rho*sqrt(lam1*lam2)``, where rho is the correlation
-    coefficient between k1 and k2. If the two Poisson-distributed r.v.
-    are independent then ``rho = 0``.
+    Let :math:`k_1` and :math:`k_2` be two Poisson-distributed r.v. with
+    expected values lam1 and lam2. Then, :math:`k_1 - k_2` follows a Skellam
+    distribution with parameters
+    :math:`\mu_1 = \lambda_1 - \rho \sqrt{\lambda_1 \lambda_2}` and
+    :math:`\mu_2 = \lambda_2 - \rho \sqrt{\lambda_1 \lambda_2}`, where
+    :math:`\rho` is the correlation coefficient between :math:`k_1` and
+    :math:`k_2`. If the two Poisson-distributed r.v. are independent then
+    :math:`\rho = 0`.
 
-    Parameters mu1 and mu2 must be strictly positive.
+    Parameters :math:`\mu_1` and :math:`\mu_2` must be strictly positive.
 
     For details see: http://en.wikipedia.org/wiki/Skellam_distribution
 
-    `skellam` takes ``mu1`` and ``mu2`` as shape parameters.
+    `skellam` takes :math:`\mu_1` and :math:`\mu_2` as shape parameters.
 
     %(after_notes)s
 


### PR DESCRIPTION
Follow-up for pull request #7756 /
commit c8f91ae303af8487f702c3a3266d5eb59b82eefa

For LaTeX, the following rules were decided:

* No \left ( ... \right )
* \le, \ge, \ne and not \leq, \geq, \neq
* No \cdot for multiplication (just ommit it)
* No grouping {...}^x
* exp vs e: https://tex.stackexchange.com/a/254786/5645

All of this aims at making the source code easy to read
while still having a nice rendered formula

The pseudocode was kept in the comments for easier
maintainability.