### PR TITLE
ENH: backport #7879 to 1.0.x

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -182,6 +182,7 @@ Charles Masson for the Wasserstein and the Cramér-von Mises statistical
     distances.
 Felix Lenders for implementing trust-trlib method.
 Dezmond Goff for adding optional out parameter to pdist/cdist
+Nick R. Papior for allowing a wider choice of solvers
 
 Institutions
 ------------

--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -198,7 +198,7 @@ def solve(a, b, sym_pos=False, lower=False, overwrite_a=False,
     if transposed:
         trans = 1
         norm = 'I'
-        if not r_or_c is float:
+        if r_or_c is not float:
             raise ValueError('scipy.linalg.solve can not solve a^T x = b '
                              'for complex matrices. See version 1.1.X.')
     else:

--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -91,8 +91,8 @@ def solve(a, b, sym_pos=False, lower=False, overwrite_a=False,
     assume_a : str, optional
         Valid entries are explained above.
     transposed: bool, optional
-        If True, depending on the data type ``a^T x = b`` or ``a^H x = b`` is
-        solved (only taken into account for ``'gen'``).
+        If True, ``a^T x = b`` or ``a^H x = b`` is solved (only taken into
+        account for ``'gen'``). Currently not working for complex matrices.
 
     Returns
     -------
@@ -199,8 +199,8 @@ def solve(a, b, sym_pos=False, lower=False, overwrite_a=False,
         trans = 1
         norm = 'I'
         if r_or_c is not float:
-            raise ValueError('scipy.linalg.solve can not solve a^T x = b '
-                             'for complex matrices. See version 1.1.X.')
+            raise ValueError('scipy.linalg.solve can currently not solve '
+                             'a^T x = b or a^H x = b for complex matrices.')
     else:
         trans = 0
         norm = '1'

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -730,9 +730,9 @@ class TestSolve(object):
 
     def test_transposed_keyword(self):
         A = np.arange(9).reshape(3, 3) + 1
-        x = solve(np.tril(A)/9, np.ones(3), transposed=1)
+        x = solve(np.tril(A)/9, np.ones(3), transposed=True)
         assert_array_almost_equal(x, [1.2, 0.2, 1])
-        x = solve(np.tril(A)/9, np.ones(3), transposed=0)
+        x = solve(np.tril(A)/9, np.ones(3))
         assert_array_almost_equal(x, [9, -5.4, -1.2])
 
     def test_nonsquare_a(self):
@@ -771,12 +771,26 @@ class TestSolve(object):
             elif assume_a == 'pos':
                 a = a.conj().T.dot(a) + 0.1*np.eye(size)
 
-            x = solve(a, b, assume_a=assume_a)
             tol = 1e-12 if dtype in (np.float64, np.complex128) else 1e-6
+
+            if assume_a in ['gen', 'sym', 'her']:
+                # We revert the tolerance from before
+                #   4b4a6e7c34fa4060533db38f9a819b98fa81476c
+                if dtype in (np.float32, np.complex64):
+                    tol *= 10
+
+            x = solve(a, b, assume_a=assume_a)
             assert_allclose(a.dot(x), b,
                             atol=tol * size,
                             rtol=tol * size,
                             err_msg=err_msg)
+
+            if assume_a == 'sym' and dtype not in (np.complex64, np.complex128):
+                x = solve(a, b, assume_a=assume_a, transposed=True)
+                assert_allclose(a.dot(x), b,
+                                atol=tol * size,
+                                rtol=tol * size,
+                                err_msg=err_msg)
 
 
 class TestSolveTriangular(object):

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -732,8 +732,13 @@ class TestSolve(object):
         A = np.arange(9).reshape(3, 3) + 1
         x = solve(np.tril(A)/9, np.ones(3), transposed=True)
         assert_array_almost_equal(x, [1.2, 0.2, 1])
-        x = solve(np.tril(A)/9, np.ones(3))
+        x = solve(np.tril(A)/9, np.ones(3), transposed=False)
         assert_array_almost_equal(x, [9, -5.4, -1.2])
+
+    def test_transposed_notimplemented(self):
+        a = np.eye(3).astype(complex)
+        with assert_raises(NotImplementedError):
+            solve(a, a, transposed=True)
 
     def test_nonsquare_a(self):
         assert_raises(ValueError, solve, [1, 2], 1)

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -347,6 +347,7 @@ class LinprogCommonTests(object):
             with suppress_warnings() as sup:
                 sup.filter(RuntimeWarning, "scipy.linalg.solve\nIll...")
                 sup.filter(OptimizeWarning, "A_eq does not appear...")
+                sup.filter(OptimizeWarning, "Solving system with option...")
                 res = linprog(c=cost, A_eq=A_eq, b_eq=b_eq, bounds=bounds,
                               method=self.method, options=self.options)
         _assert_success(res, desired_fun=14)
@@ -865,6 +866,7 @@ class TestLinprogIPSpecific:
         A, b, c = lpgen_2d(20, 20)
         with suppress_warnings() as sup:
             sup.filter(RuntimeWarning, "scipy.linalg.solve\nIll...")
+            sup.filter(OptimizeWarning, "Solving system with option...")
             res = linprog(c, A_ub=A, b_ub=b, method=self.method,
                           options={"ip": True, "disp": True})
             # ip code is independent of sparse/dense

--- a/scipy/sparse/linalg/tests/test_matfuncs.py
+++ b/scipy/sparse/linalg/tests/test_matfuncs.py
@@ -199,7 +199,10 @@ class TestExpM(object):
         tiny = 1e-17
         A_logm_perturbed = A_logm.copy()
         A_logm_perturbed[1, 0] = tiny
-        A_expm_logm_perturbed = expm(A_logm_perturbed)
+        with suppress_warnings() as sup:
+            sup.filter(RuntimeWarning,
+                       "scipy.linalg.solve\nIll-conditioned.*")
+            A_expm_logm_perturbed = expm(A_logm_perturbed)
         rtol = 1e-4
         atol = 100 * tiny
         assert_(not np.allclose(A_expm_logm_perturbed, A, rtol=rtol, atol=atol))


### PR DESCRIPTION
This fixes the speed regression in #7847. Since the default
change of sv to svx the solve routine suffered a huge performance
penalty for anything but low order NRHS.

This commit fixes that issue by converting to the sv routines,
with condition number checking.

However, the main funtionality by using svx was the easy check
of the condition number to assert a non-singular matrix.
This commit adds a call to the con routines to extract the
appropriate condition number. This forces the addition of:

   - lamch (machine precision extraction)
   - gecon (condition number calculation from LU factorization)
   - lange (1/I-norm of matrix)

This commit adds a ValueError issued for complex matrices
an transposed=True (which was a bug in prior versions).
The complex transposed case could be solved, but it is ambiguous whether
it should be the transposed or Hermitian transposed. Hence, a valueerror is
raised. See master (#7879) for a fix.

A couple of additional tests have been added, mainly to check the arguments.