### PR TITLE
FIX: Avoid bad __del__ (close) behavior

### DIFF
--- a/scipy/io/netcdf.py
+++ b/scipy/io/netcdf.py
@@ -276,7 +276,7 @@ class netcdf_file(object):
 
     def close(self):
         """Closes the NetCDF file."""
-        if not self.fp.closed:
+        if hasattr(self, 'fp') and not self.fp.closed:
             try:
                 self.flush()
             finally:
@@ -511,8 +511,8 @@ class netcdf_file(object):
             # Handle rec vars with shape[0] < nrecs.
             if self._recs > len(var.data):
                 shape = (self._recs,) + var.data.shape[1:]
-                # Resize in-place does not always work since 
-                # the array might not be single-segment                              
+                # Resize in-place does not always work since
+                # the array might not be single-segment
                 try:
                     var.data.resize(shape)
                 except ValueError:
@@ -987,8 +987,8 @@ class netcdf_variable(object):
                 recs = rec_index + 1
             if recs > len(self.data):
                 shape = (recs,) + self._shape[1:]
-                # Resize in-place does not always work since 
-                # the array might not be single-segment                              
+                # Resize in-place does not always work since
+                # the array might not be single-segment
                 try:
                     self.data.resize(shape)
                 except ValueError:


### PR DESCRIPTION
In `refguide-check` we always get:
```
Exception ignored in: <bound method netcdf_file.close of <scipy.io.netcdf.netcdf_file object at 0x7faf253dcdd8>>
Traceback (most recent call last):
  File "/home/travis/build/scipy/scipy/build/testenv/lib/python3.5/site-packages/scipy/io/netcdf.py", line 279, in close
    if not self.fp.closed:
AttributeError: 'netcdf_file' object has no attribute 'fp'
```
I assume this is due to `__del__` (which is `close`) being called before `self.fp` is ever set, so this should avoid the warning.

There are two small whitespace fixes in here, too. (Hope it's okay for a very small PR.)