### PR TITLE
ENH: allow `sqrtm` to compute the root of some singular matrices

### DIFF
--- a/scipy/linalg/_matfuncs_sqrtm.py
+++ b/scipy/linalg/_matfuncs_sqrtm.py
@@ -83,9 +83,13 @@ def _sqrtm_triu(T, blocksize=64):
                 if j - i > 1:
                     s = R[i, i+1:j].dot(R[i+1:j, j])
                 denom = R[i, i] + R[j, j]
-                if not denom:
+                num = T[i, j] - s
+                if denom != 0:
+                    R[i, j] = (T[i, j] - s) / denom
+                elif denom == 0 and num == 0:
+                    R[i, j] = 0
+                else:
                     raise SqrtmError('failed to find the matrix square root')
-                R[i, j] = (T[i, j] - s) / denom
 
     # Between-block interactions.
     for j in range(nblocks):
@@ -179,10 +183,7 @@ def sqrtm(A, disp=True, blocksize=64):
         X.fill(np.nan)
 
     if disp:
-        nzeig = np.any(np.diag(T) == 0)
-        if nzeig:
-            print("Matrix is singular and may not have a square root.")
-        elif failflag:
+        if failflag:
             print("Failed to find a square root.")
         return X
     else:

--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -393,6 +393,30 @@ class TestSqrtM(object):
         assert_allclose(np.dot(R, R), M, atol=1e-14)
         assert_allclose(sqrtm(M), R, atol=1e-14)
 
+    def test_gh4866(self):
+        M = np.array([[1, 0, 0, 1],
+                      [0, 0, 0, 0],
+                      [0, 0, 0, 0],
+                      [1, 0, 0, 1]])
+        R = np.array([[sqrt(0.5), 0, 0, sqrt(0.5)],
+                      [0, 0, 0, 0],
+                      [0, 0, 0, 0],
+                      [sqrt(0.5), 0, 0, sqrt(0.5)]])
+        assert_allclose(np.dot(R, R), M, atol=1e-14)
+        assert_allclose(sqrtm(M), R, atol=1e-14)
+
+    def test_gh5336(self):
+        M = np.diag([2, 1, 0])
+        R = np.diag([sqrt(2), 1, 0])
+        assert_allclose(np.dot(R, R), M, atol=1e-14)
+        assert_allclose(sqrtm(M), R, atol=1e-14)
+
+    def test_gh7839(self):
+        M = np.zeros((2, 2))
+        R = np.zeros((2, 2))
+        assert_allclose(np.dot(R, R), M, atol=1e-14)
+        assert_allclose(sqrtm(M), R, atol=1e-14)
+
 
 class TestFractionalMatrixPower(object):
     def test_round_trip_random_complex(self):
@@ -810,4 +834,3 @@ class TestExpmConditionNumber(object):
             # eps times the condition number kappa.
             # In the limit as eps approaches zero it should never be greater.
             assert_array_less(p_best_relerr, (1 + 2*eps) * eps * kappa)
-


### PR DESCRIPTION
Previously the algorithm broke down when solving the scalar Sylvester
equation `U_ii*U_ij + U_ij*U_jj = R` when `U_ii + U_jj = 0`. This
equation is still solvable, however, when `R = 0`. This changes
the algorithm to continue in this case by choosing `U_ij = 0`.

Closes gh-7839, gh-5336, and gh-4866.