### PR TITLE
MAINT: Avoid unnecessary array copies in xdist

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -270,7 +270,7 @@ def _validate_mahalanobis_kwargs(X, m, n, **kwargs):
                              "are required." % (m, n, n + 1))
         CV = np.atleast_2d(np.cov(X.astype(np.double).T))
         VI = np.linalg.inv(CV).T.copy()
-    kwargs["VI"] = _copy_array_if_base_present(_convert_to_double(VI))
+    kwargs["VI"] = _convert_to_double(VI)
     return kwargs
 
 

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -1616,9 +1616,6 @@ def pdist(X, metric='euclidean', *args, **kwargs):
 
     X = np.asarray(X, order='c')
 
-    # The C code doesn't do striding.
-    X = _copy_array_if_base_present(X)
-
     s = X.shape
     if len(s) != 2:
         raise ValueError('A 2-dimensional array must be passed.')
@@ -2336,10 +2333,6 @@ def cdist(XA, XB, metric='euclidean', *args, **kwargs):
 
     XA = np.asarray(XA, order='c')
     XB = np.asarray(XB, order='c')
-
-    # The C code doesn't do striding.
-    XA = _copy_array_if_base_present(XA)
-    XB = _copy_array_if_base_present(XB)
 
     s = XA.shape
     sB = XB.shape

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -628,12 +628,12 @@ class TestCdist(object):
             kwargs = dict()
             if metric in ['minkowski', 'wminkowski']:
                 kwargs['p'] = 1.23
-            if metric == 'wminkowski':
-                kwargs['w'] = 1.0 / X1.std(axis=0)
+                if metric == 'wminkowski':
+                    kwargs['w'] = 1.0 / X1.std(axis=0)
             Y1 = cdist(X1, X2, metric, **kwargs)
             Y2 = cdist(X1_copy, X2_copy, metric, **kwargs)
             # test that output is numerically equivalent
-            _assert_within_tol(Y1, Y2, eps, verbose > 2)
+            _assert_equal(Y1, Y2, eps, verbose > 2)
 
 class TestPdist(object):
 

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -618,6 +618,9 @@ class TestCdist(object):
         X1_copy = X1.copy()
         X2_copy = X2.copy()
 
+        # confirm equivalence
+        assert_equal(X1, X1_copy)
+        assert_equal(X2, X2_copy)
         # confirm contiguity
         assert_(not X1.flags.c_contiguous)
         assert_(not X2.flags.c_contiguous)
@@ -633,7 +636,7 @@ class TestCdist(object):
             Y1 = cdist(X1, X2, metric, **kwargs)
             Y2 = cdist(X1_copy, X2_copy, metric, **kwargs)
             # test that output is numerically equivalent
-            _assert_equal(Y1, Y2, eps, verbose > 2)
+            _assert_within_tol(Y1, Y2, eps, verbose > 2)
 
 class TestPdist(object):
 

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -1910,4 +1910,3 @@ def test__validate_vector():
 
     x = [[1, 2], [3, 4]]
     assert_raises(ValueError, _validate_vector, x)
-

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -609,6 +609,31 @@ class TestCdist(object):
             out5 = np.empty((out_r, out_c), dtype=np.int64)
             assert_raises(ValueError, cdist, X1, X2, metric, out=out5, **kwargs)
 
+    def test_striding(self):
+        # test that striding is handled correct with calls to
+        # _copy_array_if_base_present
+        eps = 1e-07
+        X1 = eo['cdist-X1'][::2, ::2]
+        X2 = eo['cdist-X2'][::2, ::2]
+        X1_copy = X1.copy()
+        X2_copy = X2.copy()
+
+        # confirm contiguity
+        assert_(not X1.flags.c_contiguous)
+        assert_(not X2.flags.c_contiguous)
+        assert_(X1_copy.flags.c_contiguous)
+        assert_(X2_copy.flags.c_contiguous)
+
+        for metric in _METRICS_NAMES:
+            kwargs = dict()
+            if metric in ['minkowski', 'wminkowski']:
+                kwargs['p'] = 1.23
+            if metric == 'wminkowski':
+                kwargs['w'] = 1.0 / X1.std(axis=0)
+            Y1 = cdist(X1, X2, metric, **kwargs)
+            Y2 = cdist(X1_copy, X2_copy, metric, **kwargs)
+            # test that output is numerically equivalent
+            _assert_within_tol(Y1, Y2, eps, verbose > 2)
 
 class TestPdist(object):
 
@@ -1365,6 +1390,27 @@ class TestPdist(object):
             out5 = np.empty(out_size, dtype=np.int64)
             assert_raises(ValueError, pdist, X, metric, out=out5, **kwargs)
 
+    def test_striding(self):
+        # test that striding is handled correct with calls to
+        # _copy_array_if_base_present
+        eps = 1e-07
+        X = eo['random-float32-data'][::5, ::2]
+        X_copy = X.copy()
+
+        # confirm contiguity
+        assert_(not X.flags.c_contiguous)
+        assert_(X_copy.flags.c_contiguous)
+
+        for metric in _METRICS_NAMES:
+            kwargs = dict()
+            if metric in ['minkowski', 'wminkowski']:
+                kwargs['p'] = 1.23
+            if metric == 'wminkowski':
+                kwargs['w'] = 1.0 / X.std(axis=0)
+            Y1 = pdist(X, metric, **kwargs)
+            Y2 = pdist(X_copy, metric, **kwargs)
+            # test that output is numerically equivalent
+            _assert_within_tol(Y1, Y2, eps, verbose > 2)
 
 class TestSomeDistanceFunctions(object):
 


### PR DESCRIPTION
Striding problems are already dealt with by the call to np.ascontinguousarray in _convert_to_type. This avoids making unnecessary copies if X, etc. are contiguous views.