### PR TITLE
DOC: Clarifies the meaning of `initial` of scipy.integrate.cumtrapz()

### DIFF
--- a/scipy/integrate/quadrature.py
+++ b/scipy/integrate/quadrature.py
@@ -222,7 +222,7 @@ def cumtrapz(y, x=None, dx=1.0, axis=-1, initial=None):
     axis : int, optional
         Specifies the axis to cumulate.  Default is -1 (last axis).
     initial : scalar, optional
-        If given, uses this value as the first value in the returned result.
+        If given, insert this value at the beginning of the returned result.
         Typically this value should be 0.  Default is None, which means no
         value at ``x[0]`` is returned and `res` has one element less than `y`
         along the axis of integration.


### PR DESCRIPTION
Fixes #7890 

Clarifies the meaning of `initial` argument in the docstring of `scipy.integrate.cumtrapz()`