### PR TITLE
BUG: sparse.linalg: fix wrong use of __new__ in LinearOperator

### DIFF
--- a/scipy/sparse/linalg/interface.py
+++ b/scipy/sparse/linalg/interface.py
@@ -130,7 +130,7 @@ class LinearOperator(object):
     def __new__(cls, *args, **kwargs):
         if cls is LinearOperator:
             # Operate as _CustomLinearOperator factory.
-            return _CustomLinearOperator(*args, **kwargs)
+            return super(LinearOperator, cls).__new__(_CustomLinearOperator)
         else:
             obj = super(LinearOperator, cls).__new__(cls)
 

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -340,3 +340,15 @@ def test_dtypes_of_operator_sum():
 
     assert_equal(sum_real.dtype, np.float64)
     assert_equal(sum_complex.dtype, np.complex128)
+
+def test_no_double_init():
+    call_count = [0]
+
+    def matvec(v):
+        call_count[0] += 1
+        return v
+
+    # It should call matvec exactly once (in order to determine the
+    # operator dtype)
+    A = interface.LinearOperator((2, 2), matvec=matvec)
+    assert_equal(call_count[0], 1)


### PR DESCRIPTION
The ``__new__`` method should only construct the object, because ``__init__``
will be called automatically by Python.

Fixes gh-7915