### PR TITLE
BUG: special: Allow dfn and dfd down to 0 in fdtr, fdtrc, and fdtri.

### DIFF
--- a/scipy/special/cephes/fdtr.c
+++ b/scipy/special/cephes/fdtr.c
@@ -48,9 +48,10 @@
  * fdtr domain     a<0, b<0, x<0         0.0
  *
  */
-/*							fdtrc()
+
+/*                         fdtrc()
  *
- *	Complemented F distribution
+ *  Complemented F distribution
  *
  *
  *
@@ -80,7 +81,7 @@
  * The incomplete beta integral is used, according to the
  * formula
  *
- *	P(x) = incbet( df2/2, df1/2, (df2/(df2 + df1*x) ).
+ *  P(x) = incbet( df2/2, df1/2, (df2/(df2 + df1*x) ).
  *
  *
  * ACCURACY:
@@ -100,9 +101,10 @@
  * fdtrc domain    a<0, b<0, x<0         0.0
  *
  */
-/*							fdtri()
+
+/*                         fdtri()
  *
- *	Inverse of F distribution
+ *  Inverse of F distribution
  *
  *
  *
@@ -152,7 +154,6 @@
  *                     v < 1
  *
  */
-
 
 /*
  * Cephes Math Library Release 2.3:  March, 1995
@@ -162,45 +163,41 @@
 
 #include "mconf.h"
 
-double fdtrc(a, b, x)
-double a, b;
-double x;
+
+double fdtrc(double a, double b, double x)
 {
     double w;
 
     if ((a < 1.0) || (b < 1.0) || (x < 0.0)) {
-	mtherr("fdtrc", DOMAIN);
-	return (NPY_NAN);
+        mtherr("fdtrc", DOMAIN);
+        return NPY_NAN;
     }
     w = b / (b + a * x);
-    return (incbet(0.5 * b, 0.5 * a, w));
+    return incbet(0.5 * b, 0.5 * a, w);
 }
 
-double fdtr(a, b, x)
-double a, b;
-double x;
+
+double fdtr(double a, double b, double x)
 {
     double w;
 
     if ((a < 1.0) || (b < 1.0) || (x < 0.0)) {
-	mtherr("fdtr", DOMAIN);
-	return (NPY_NAN);
+        mtherr("fdtr", DOMAIN);
+        return NPY_NAN;
     }
     w = a * x;
     w = w / (b + w);
-    return (incbet(0.5 * a, 0.5 * b, w));
+    return incbet(0.5 * a, 0.5 * b, w);
 }
 
 
-double fdtri(a, b, y)
-double a, b;
-double y;
+double fdtri(double a, double b, double y)
 {
     double w, x;
 
     if ((a < 1.0) || (b < 1.0) || (y <= 0.0) || (y > 1.0)) {
-	mtherr("fdtri", DOMAIN);
-	return (NPY_NAN);
+        mtherr("fdtri", DOMAIN);
+        return NPY_NAN;
     }
     y = 1.0 - y;
     /* Compute probability for x = 0.5.  */
@@ -208,12 +205,12 @@ double y;
     /* If that is greater than y, then the solution w < .5.
      * Otherwise, solve at 1-y to remove cancellation in (b - b*w).  */
     if (w > y || y < 0.001) {
-	w = incbi(0.5 * b, 0.5 * a, y);
-	x = (b - b * w) / (a * w);
+        w = incbi(0.5 * b, 0.5 * a, y);
+        x = (b - b * w) / (a * w);
     }
     else {
-	w = incbi(0.5 * a, 0.5 * b, 1.0 - y);
-	x = b * w / (a * (1.0 - w));
+        w = incbi(0.5 * a, 0.5 * b, 1.0 - y);
+        x = b * w / (a * (1.0 - w));
     }
-    return (x);
+    return x;
 }

--- a/scipy/special/cephes/fdtr.c
+++ b/scipy/special/cephes/fdtr.c
@@ -168,7 +168,7 @@ double fdtrc(double a, double b, double x)
 {
     double w;
 
-    if ((a < 1.0) || (b < 1.0) || (x < 0.0)) {
+    if ((a <= 0.0) || (b <= 0.0) || (x < 0.0)) {
         mtherr("fdtrc", DOMAIN);
         return NPY_NAN;
     }
@@ -181,7 +181,7 @@ double fdtr(double a, double b, double x)
 {
     double w;
 
-    if ((a < 1.0) || (b < 1.0) || (x < 0.0)) {
+    if ((a <= 0.0) || (b <= 0.0) || (x < 0.0)) {
         mtherr("fdtr", DOMAIN);
         return NPY_NAN;
     }
@@ -195,7 +195,7 @@ double fdtri(double a, double b, double y)
 {
     double w, x;
 
-    if ((a < 1.0) || (b < 1.0) || (y <= 0.0) || (y > 1.0)) {
+    if ((a <= 0.0) || (b <= 0.0) || (y <= 0.0) || (y > 1.0)) {
         mtherr("fdtri", DOMAIN);
         return NPY_NAN;
     }

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -349,15 +349,25 @@ class TestCephes(object):
         assert_array_almost_equal_nulp(found.real, expected.real, 20)
 
     def test_fdtr(self):
-        assert_equal(cephes.fdtr(1,1,0),0.0)
+        assert_equal(cephes.fdtr(1, 1, 0), 0.0)
+        # Computed using Wolfram Alpha: CDF[FRatioDistribution[1e-6, 5], 10]
+        assert_allclose(cephes.fdtr(1e-6, 5, 10), 0.9999940790193488,
+                        rtol=1e-12)
 
     def test_fdtrc(self):
-        assert_equal(cephes.fdtrc(1,1,0),1.0)
+        assert_equal(cephes.fdtrc(1, 1, 0), 1.0)
+        # Computed using Wolfram Alpha:
+        #   1 - CDF[FRatioDistribution[2, 1/10], 1e10]
+        assert_allclose(cephes.fdtrc(2, 0.1, 1e10), 0.27223784621293512,
+                        rtol=1e-12)
 
     def test_fdtri(self):
-        # cephes.fdtri(1,1,0.5)  #BUG: gives NaN, should be 1
-        assert_allclose(cephes.fdtri(1, 1, [0.499, 0.501]),
-                        array([0.9937365, 1.00630298]), rtol=1e-6)
+        assert_allclose(cephes.fdtri(1, 1, [0.499, 0.5, 0.501]),
+                        array([0.9937365, 1.0, 1.00630298]), rtol=1e-6)
+        # From Wolfram Alpha:
+        #   CDF[FRatioDistribution[1/10, 1], 3] = 0.8756751669632105666874...
+        p = 0.8756751669632105666874
+        assert_allclose(cephes.fdtri(0.1, 1, p), 3, rtol=1e-12)
 
     def test_fdtridfd(self):
         assert_equal(cephes.fdtridfd(1,0,0),5.0)


### PR DESCRIPTION
Apparently in the original Cephes library, the arguments for the degrees of freedom were integers, so the existing checks made sense.