### PR TITLE
BENCH: split spatial benchmark imports

### DIFF
--- a/benchmarks/benchmarks/spatial.py
+++ b/benchmarks/benchmarks/spatial.py
@@ -3,8 +3,22 @@ from __future__ import division, absolute_import, print_function
 import numpy as np
 
 try:
-    from scipy.spatial import (cKDTree, KDTree, SphericalVoronoi, distance,
-    ConvexHull, Voronoi)
+    from scipy.spatial import cKDTree, KDTree
+except ImportError:
+    pass
+
+try:
+    from scipy.spatial import distance
+except ImportError:
+    pass
+
+try:
+    from scipy.spatial import ConvexHull, Voronoi
+except ImportError:
+    pass
+
+try:
+    from scipy.spatial import SphericalVoronoi
 except ImportError:
     pass
 


### PR DESCRIPTION
As the different parts were added at different times, it's better to
import them separately so that only specific benchmarks stop working for
old scipy versions.