### PR TITLE
BUG: spatial/qhull: Qhull.__del__ -> __dealloc__

### DIFF
--- a/scipy/spatial/qhull.pyx
+++ b/scipy/spatial/qhull.pyx
@@ -354,7 +354,7 @@ cdef class _Qhull:
             raise QhullError(msg)
 
     @cython.final
-    def __del__(self):
+    def __dealloc__(self):
         self.close()
         self._messages.close()
 


### PR DESCRIPTION
Cython documentation gives only `__dealloc__` as a valid way to deallocate
extension types. The `__del__` method also seemed to work, but it's better
to follow the "official" way.