### PR TITLE
MAINT: special: Mark a test that fails on i686 as a known failure.

### DIFF
--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -362,12 +362,16 @@ class TestCephes(object):
                         rtol=1e-12)
 
     def test_fdtri(self):
-        assert_allclose(cephes.fdtri(1, 1, [0.499, 0.5, 0.501]),
-                        array([0.9937365, 1.0, 1.00630298]), rtol=1e-6)
+        assert_allclose(cephes.fdtri(1, 1, [0.499, 0.501]),
+                        array([0.9937365, 1.00630298]), rtol=1e-6)
         # From Wolfram Alpha:
         #   CDF[FRatioDistribution[1/10, 1], 3] = 0.8756751669632105666874...
         p = 0.8756751669632105666874
         assert_allclose(cephes.fdtri(0.1, 1, p), 3, rtol=1e-12)
+
+    @pytest.mark.xfail(reason='Returns nan on i686.')
+    def test_fdtri_mysterious_failure(self):
+        assert_allclose(cephes.fdtri(1, 1, 0.5), 1)
 
     def test_fdtridfd(self):
         assert_equal(cephes.fdtridfd(1,0,0),5.0)


### PR DESCRIPTION
The calculation `special.fdtri(1, 1, 0.5)` sometimes returns nan on i686
systems.  Before the change in https://github.com/scipy/scipy/pull/7919,
the test suite had this comment:

    # cephes.fdtri(1,1,0.5)  #BUG: gives NaN, should be 1

but there was no issue for tracking the problem.  That test was restored
in gh-7919, and it passes on 64 bit architectures.

This change makes that calculation a separate test that is marked as a
known failure.  The github issue for this test is now gh-7931.