### PR TITLE
ENH: Implement reshape method on sparse matrices

### DIFF
--- a/scipy/io/matlab/mio4.py
+++ b/scipy/io/matlab/mio4.py
@@ -253,7 +253,8 @@ class VarReader4(object):
         '''
         res = self.read_sub_array(hdr)
         tmp = res[:-1,:]
-        dims = res[-1,0:2]
+        # All numbers are float64 in Matlab, but Scipy sparse expects int shape
+        dims = (int(res[-1,0]), int(res[-1,1]))
         I = np.ascontiguousarray(tmp[:,0],dtype='intc')  # fixes byte order also
         J = np.ascontiguousarray(tmp[:,1],dtype='intc')
         I -= 1  # for 1-based indexing

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -83,7 +83,11 @@ class spmatrix(object):
             raise ValueError('invalid shape')
 
         if (self._shape != shape) and (self._shape is not None):
-            raise NotImplementedError('sparse matrix shape setting magic is broken')
+            raise NotImplementedError(
+                    'Changing the shape of a sparse matrix by directly '
+                    'modifying its .shape property is not currently '
+                    'supported.  Please consider using the .reshape() '
+                    'member function instead!')
             try:
                 self = self.reshape(shape)
             except NotImplementedError:

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -95,8 +95,9 @@ class spmatrix(object):
 
     shape = property(fget=get_shape, fset=set_shape)
 
-    def reshape(self,shape):
-        raise NotImplementedError
+    def reshape(self, shape):
+        """Returns a coo_matrix with shape `shape`."""
+        return self.tocoo().reshape(shape)
 
     def astype(self, t):
         return self.tocsr().astype(t).asformat(self.format)

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -96,8 +96,7 @@ class spmatrix(object):
     shape = property(fget=get_shape, fset=set_shape)
 
     def reshape(self, shape):
-        """Returns a coo_matrix with shape `shape`."""
-        return self.tocoo().reshape(shape)
+        return self.tocoo().reshape(shape).asformat(self.format)
 
     def astype(self, t):
         return self.tocsr().astype(t).asformat(self.format)

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -657,7 +657,7 @@ class spmatrix(object):
         return self.tocsr().tobsr(blocksize=blocksize)
 
     def copy(self):
-        return self.__class__(self,copy=True)
+        return self.__class__(self, copy=True)
 
     def sum(self, axis=None):
         """Sum the matrix over the given axis.  If the axis is None, sum

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -83,6 +83,7 @@ class spmatrix(object):
             raise ValueError('invalid shape')
 
         if (self._shape != shape) and (self._shape is not None):
+            raise NotImplementedError('sparse matrix shape setting magic is broken')
             try:
                 self = self.reshape(shape)
             except NotImplementedError:

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -8,7 +8,8 @@ import numpy as np
 from scipy._lib.six import xrange
 from scipy._lib._numpy_compat import broadcast_to
 from .sputils import (isdense, isscalarlike, isintlike,
-                      get_sum_dtype, validateaxis, check_reshape_kwargs)
+                      get_sum_dtype, validateaxis, check_reshape_kwargs,
+                      check_shape)
 
 __all__ = ['spmatrix', 'isspmatrix', 'issparse',
            'SparseWarning', 'SparseEfficiencyWarning']
@@ -118,9 +119,17 @@ class spmatrix(object):
         --------
         np.matrix.reshape : NumPy's implementation of 'reshape' for matrices
         """
+        # If the shape already matches, don't bother doing an actual reshape
+        # Otherwise, the default is ot convert to COO and use its reshape
+        shape = check_shape(args, self.shape)
         order, copy = check_reshape_kwargs(kwargs)
+        if shape == self.shape:
+            if copy:
+                return self.copy()
+            else:
+                return self
 
-        return self.tocoo(copy=copy).reshape(*args, order=order, copy=False)
+        return self.tocoo(copy=copy).reshape(shape, order=order, copy=False)
 
     def astype(self, dtype, casting='unsafe', copy=True):
         """Cast the matrix elements to a specified type.

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -116,7 +116,7 @@ class spmatrix(object):
         --------
         np.matrix.reshape : NumPy's implementation of 'reshape' for matrices
         """
-        return (self.tocoo(copy=copy).reshape(*args, order=order, copy=True)
+        return (self.tocoo(copy=copy).reshape(*args, order=order, copy=False)
                 .asformat(self.format))
 
     def astype(self, dtype, casting='unsafe', copy=True):

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -120,7 +120,7 @@ class spmatrix(object):
         np.matrix.reshape : NumPy's implementation of 'reshape' for matrices
         """
         # If the shape already matches, don't bother doing an actual reshape
-        # Otherwise, the default is ot convert to COO and use its reshape
+        # Otherwise, the default is to convert to COO and use its reshape
         shape = check_shape(args, self.shape)
         order, copy = check_reshape_kwargs(kwargs)
         if shape == self.shape:

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -77,31 +77,10 @@ class spmatrix(object):
 
     def set_shape(self, shape):
         """See `reshape`."""
-        shape = tuple(shape)
-
-        if len(shape) != 2:
-            raise ValueError("Only two-dimensional sparse "
-                             "arrays are supported.")
-        try:
-            shape = int(shape[0]), int(shape[1])  # floats, other weirdness
-        except:
-            raise TypeError('invalid shape')
-
-        if not (shape[0] >= 0 and shape[1] >= 0):
-            raise ValueError('invalid shape')
-
-        if (self._shape != shape) and (self._shape is not None):
-            raise NotImplementedError(
-                    'Changing the shape of a sparse matrix by directly '
-                    'modifying its .shape property is not currently '
-                    'supported.  Please consider using the .reshape() '
-                    'member function instead!')
-            try:
-                self = self.reshape(shape)
-            except NotImplementedError:
-                raise NotImplementedError("Reshaping not implemented for %s." %
-                                          self.__class__.__name__)
-        self._shape = shape
+        # Make sure copy is False since this is in place
+        # Make sure format is unchanged because we are doing a __dict__ swap
+        new_matrix = self.reshape(shape, copy=False).asformat(self.format)
+        self.__dict__ = new_matrix.__dict__
 
     def get_shape(self):
         """Get shape of a matrix."""
@@ -109,8 +88,10 @@ class spmatrix(object):
 
     shape = property(fget=get_shape, fset=set_shape)
 
-    def reshape(self, shape, order='C', copy=False):
-        """Gives a new shape to a sparse matrix without changing its data.
+    def reshape(self, *args, order='C', copy=False):
+        """reshape(self, shape, order='C', copy=False)
+
+        Gives a new shape to a sparse matrix without changing its data.
 
         Parameters
         ----------
@@ -135,7 +116,7 @@ class spmatrix(object):
         --------
         np.matrix.reshape : NumPy's implementation of 'reshape' for matrices
         """
-        return (self.tocoo(copy=copy).reshape(shape, order=order, copy=True)
+        return (self.tocoo(copy=copy).reshape(*args, order=order, copy=True)
                 .asformat(self.format))
 
     def astype(self, dtype, casting='unsafe', copy=True):

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -110,14 +110,15 @@ class spmatrix(object):
 
         Returns
         -------
-        reshaped_matrix : `self` with the new dimensions of `shape`
+        reshaped_matrix : sparse matrix
+            A sparse matrix with the given `shape`, not necessarily of the same
+            format as the current object.
 
         See Also
         --------
         np.matrix.reshape : NumPy's implementation of 'reshape' for matrices
         """
-        return (self.tocoo(copy=copy).reshape(*args, order=order, copy=False)
-                .asformat(self.format))
+        return self.tocoo(copy=copy).reshape(*args, order=order, copy=False)
 
     def astype(self, dtype, casting='unsafe', copy=True):
         """Cast the matrix elements to a specified type.

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -8,7 +8,7 @@ import numpy as np
 from scipy._lib.six import xrange
 from scipy._lib._numpy_compat import broadcast_to
 from .sputils import (isdense, isscalarlike, isintlike,
-                      get_sum_dtype, validateaxis)
+                      get_sum_dtype, validateaxis, check_reshape_kwargs)
 
 __all__ = ['spmatrix', 'isspmatrix', 'issparse',
            'SparseWarning', 'SparseEfficiencyWarning']
@@ -88,7 +88,7 @@ class spmatrix(object):
 
     shape = property(fget=get_shape, fset=set_shape)
 
-    def reshape(self, *args, order='C', copy=False):
+    def reshape(self, *args, **kwargs):
         """reshape(self, shape, order='C', copy=False)
 
         Gives a new shape to a sparse matrix without changing its data.
@@ -118,6 +118,8 @@ class spmatrix(object):
         --------
         np.matrix.reshape : NumPy's implementation of 'reshape' for matrices
         """
+        order, copy = check_reshape_kwargs(kwargs)
+
         return self.tocoo(copy=copy).reshape(*args, order=order, copy=False)
 
     def astype(self, dtype, casting='unsafe', copy=True):

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -109,18 +109,23 @@ class spmatrix(object):
 
     shape = property(fget=get_shape, fset=set_shape)
 
-    def reshape(self, shape, order='C'):
-        """
-        Gives a new shape to a sparse matrix without changing its data.
+    def reshape(self, shape, order='C', copy=False):
+        """Gives a new shape to a sparse matrix without changing its data.
 
         Parameters
         ----------
         shape : length-2 tuple of ints
             The new shape should be compatible with the original shape.
-        order : 'C', optional
-            This argument is in the signature *solely* for NumPy
-            compatibility reasons. Do not pass in anything except
-            for the default value, as this argument is not used.
+        order : {'C', 'F'}, optional
+            Read the elements using this index order. 'C' means to read and
+            write the elements using C-like index order; e.g. read entire first
+            row, then second row, etc. 'F' means to read and write the elements
+            using Fortran-like index order; e.g. read entire first column, then
+            second column, etc.
+        copy : bool, optional
+            Indicates whether or not attributes of self should be copied
+            whenever possible. The degree to which attributes are copied varies
+            depending on the type of sparse matrix being used.
 
         Returns
         -------
@@ -130,7 +135,8 @@ class spmatrix(object):
         --------
         np.matrix.reshape : NumPy's implementation of 'reshape' for matrices
         """
-        return self.tocoo().reshape(shape).asformat(self.format)
+        return (self.tocoo(copy=copy).reshape(shape, order=order, copy=True)
+                .asformat(self.format))
 
     def astype(self, dtype, casting='unsafe', copy=True):
         """Cast the matrix elements to a specified type.

--- a/scipy/sparse/bsr.py
+++ b/scipy/sparse/bsr.py
@@ -13,7 +13,8 @@ import numpy as np
 from .data import _data_matrix, _minmax_mixin
 from .compressed import _cs_matrix
 from .base import isspmatrix, _formats, spmatrix
-from .sputils import isshape, getdtype, to_native, upcast, get_index_dtype
+from .sputils import isshape, getdtype, to_native, upcast, get_index_dtype, \
+    check_shape
 from . import _sparsetools
 from ._sparsetools import (bsr_matvec, bsr_matvecs, csr_matmat_pass1,
                            bsr_matmat_pass2, bsr_transpose, bsr_sort_indices)
@@ -130,7 +131,7 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
         elif isinstance(arg1,tuple):
             if isshape(arg1):
                 # it's a tuple of matrix dimensions (M,N)
-                self.shape = arg1
+                self._shape = check_shape(arg1)
                 M,N = self.shape
                 # process blocksize
                 if blocksize is None:
@@ -186,7 +187,7 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
             self._set_self(arg1)
 
         if shape is not None:
-            self.shape = shape   # spmatrix will check for errors
+            self._shape = check_shape(shape)
         else:
             if self.shape is None:
                 # shape not already set, try to infer dimensions
@@ -197,14 +198,14 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
                     raise ValueError('unable to infer matrix dimensions')
                 else:
                     R,C = self.blocksize
-                    self.shape = (M*R,N*C)
+                    self._shape = check_shape((M*R,N*C))
 
         if self.shape is None:
             if shape is None:
                 # TODO infer shape here
                 raise ValueError('need to infer shape')
             else:
-                self.shape = shape
+                self._shape = check_shape(shape)
 
         if dtype is not None:
             self.data = self.data.astype(dtype)

--- a/scipy/sparse/bsr.py
+++ b/scipy/sparse/bsr.py
@@ -13,8 +13,8 @@ import numpy as np
 from .data import _data_matrix, _minmax_mixin
 from .compressed import _cs_matrix
 from .base import isspmatrix, _formats, spmatrix
-from .sputils import isshape, getdtype, to_native, upcast, get_index_dtype, \
-    check_shape
+from .sputils import (isshape, getdtype, to_native, upcast, get_index_dtype,
+                      check_shape)
 from . import _sparsetools
 from ._sparsetools import (bsr_matvec, bsr_matvecs, csr_matmat_pass1,
                            bsr_matmat_pass2, bsr_transpose, bsr_sort_indices)

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -16,7 +16,7 @@ from .dia import dia_matrix
 from . import _sparsetools
 from .sputils import (upcast, upcast_char, to_native, isdense, isshape,
                       getdtype, isscalarlike, IndexMixin, get_index_dtype,
-                      downcast_intp_index, get_sum_dtype)
+                      downcast_intp_index, get_sum_dtype, check_shape)
 
 
 class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
@@ -36,7 +36,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             if isshape(arg1):
                 # It's a tuple of matrix dimensions (M, N)
                 # create empty matrix
-                self.shape = arg1   # spmatrix checks for errors here
+                self._shape = check_shape(arg1)
                 M, N = self.shape
                 # Select index dtype large enough to pass array and
                 # scalar parameters to sparsetools
@@ -80,7 +80,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
 
         # Read matrix dimensions given, if any
         if shape is not None:
-            self.shape = shape   # spmatrix will check for errors
+            self._shape = check_shape(shape)
         else:
             if self.shape is None:
                 # shape not already set, try to infer dimensions
@@ -90,7 +90,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                 except:
                     raise ValueError('unable to infer matrix dimensions')
                 else:
-                    self.shape = self._swap((major_dim,minor_dim))
+                    self._shape = check_shape(self._swap((major_dim,minor_dim)))
 
         if dtype is not None:
             self.data = np.asarray(self.data, dtype=dtype)
@@ -123,7 +123,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         self.data = other.data
         self.indices = other.indices
         self.indptr = other.indptr
-        self.shape = other.shape
+        self._shape = check_shape(other.shape)
 
     def check_format(self, full_check=True):
         """check whether the matrix format is valid

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -205,7 +205,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
 
         self._check()
 
-    def reshape(self, shape, copy=True):
+    def reshape(self, shape, copy=False):
         """Returns a coo_matrix with shape `shape`."""
         if not isshape(shape):
             raise ValueError('`shape` must be a sequence of two integers')

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -213,7 +213,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
         nrows, ncols = self.shape
         size = nrows * ncols
 
-        new_size =  shape[0] * shape[1]
+        new_size = shape[0] * shape[1]
         if new_size != size:
             raise ValueError('total size of new array must be unchanged')
 

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -207,7 +207,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
 
     def reshape(self, shape, copy=True):
         """Returns a coo_matrix with shape `shape`."""
-        if not hasattr(shape, '__len__') or len(shape) != 2:
+        if not isshape(shape):
             raise ValueError('`shape` must be a sequence of two integers')
 
         nrows, ncols = self.shape

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -205,7 +205,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
 
         self._check()
 
-    def reshape(self, shape):
+    def reshape(self, shape, copy=True):
         """Returns a coo_matrix with shape `shape`."""
         if not hasattr(shape, '__len__') or len(shape) != 2:
             raise ValueError('`shape` must be a sequence of two integers')
@@ -220,7 +220,8 @@ class coo_matrix(_data_matrix, _minmax_mixin):
         flat_indices = ncols * self.row + self.col
         new_row, new_col = divmod(flat_indices, shape[1])
 
-        return coo_matrix((self.data, (new_row, new_col)), shape=shape)
+        return coo_matrix((self.data, (new_row, new_col)),
+                          shape=shape, copy=copy)
 
     def getnnz(self, axis=None):
         """Get the count of explicitly-stored values (nonzeros)

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -205,6 +205,23 @@ class coo_matrix(_data_matrix, _minmax_mixin):
 
         self._check()
 
+    def reshape(self, shape):
+        """Returns a coo_matrix with shape `shape`."""
+        if not hasattr(shape, '__len__') or len(shape) != 2:
+            raise ValueError('`shape` must be a sequence of two integers')
+
+        nrows, ncols = self.shape
+        size = nrows * ncols
+
+        new_size =  shape[0] * shape[1]
+        if new_size != size:
+            raise ValueError('total size of new array must be unchanged')
+
+        flat_indices = ncols * self.row + self.col
+        new_row, new_col = divmod(flat_indices, shape[1])
+
+        return coo_matrix((self.data, (new_row, new_col)), shape=shape)
+
     def getnnz(self, axis=None):
         """Get the count of explicitly-stored values (nonzeros)
 

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -190,8 +190,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
 
         self._check()
 
-    def reshape(self, shape, copy=False):
-        """Returns a coo_matrix with shape `shape`."""
+    def reshape(self, shape, order='C', copy=False):
         if not isshape(shape):
             raise ValueError('`shape` must be a sequence of two integers')
 
@@ -202,11 +201,19 @@ class coo_matrix(_data_matrix, _minmax_mixin):
         if new_size != size:
             raise ValueError('total size of new array must be unchanged')
 
-        flat_indices = ncols * self.row + self.col
-        new_row, new_col = divmod(flat_indices, shape[1])
+        if order == 'C':
+            flat_indices = ncols * self.row + self.col
+            new_row, new_col = divmod(flat_indices, shape[1])
+        elif order == 'F':
+            flat_indices = self.row + nrows * self.col
+            new_col, new_row = divmod(flat_indices, shape[0])
+        else:
+            ValueError("`order` must be 'C' or 'F'")
 
         return coo_matrix((self.data, (new_row, new_col)),
                           shape=shape, copy=copy)
+
+    reshape.__doc__ = spmatrix.reshape.__doc__
 
     def getnnz(self, axis=None):
         if axis is None:

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -15,7 +15,8 @@ from ._sparsetools import coo_tocsr, coo_todense, coo_matvec
 from .base import isspmatrix, SparseEfficiencyWarning, spmatrix
 from .data import _data_matrix, _minmax_mixin
 from .sputils import (upcast, upcast_char, to_native, isshape, getdtype,
-                      get_index_dtype, downcast_intp_index, check_shape)
+                      get_index_dtype, downcast_intp_index, check_shape,
+                      check_reshape_kwargs)
 
 
 class coo_matrix(_data_matrix, _minmax_mixin):
@@ -190,8 +191,9 @@ class coo_matrix(_data_matrix, _minmax_mixin):
 
         self._check()
 
-    def reshape(self, *args, order='C', copy=False):
+    def reshape(self, *args, **kwargs):
         shape = check_shape(args, self.shape)
+        order, copy = check_reshape_kwargs(kwargs)
 
         nrows, ncols = self.shape
 

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -202,10 +202,17 @@ class coo_matrix(_data_matrix, _minmax_mixin):
             flat_indices = self.row + nrows * self.col
             new_col, new_row = divmod(flat_indices, shape[0])
         else:
-            ValueError("'order' must be 'C' or 'F'")
+            raise ValueError("'order' must be 'C' or 'F'")
 
-        return coo_matrix((self.data, (new_row, new_col)),
-                          shape=shape, copy=copy)
+        # Handle copy here rather than passing on to the constructor so that no
+        # copy will be made of new_row and new_col regardless
+        if copy:
+            new_data = self.data.copy()
+        else:
+            new_data = self.data
+
+        return coo_matrix((new_data, (new_row, new_col)),
+                          shape=shape, copy=False)
 
     reshape.__doc__ = spmatrix.reshape.__doc__
 

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -195,6 +195,13 @@ class coo_matrix(_data_matrix, _minmax_mixin):
         shape = check_shape(args, self.shape)
         order, copy = check_reshape_kwargs(kwargs)
 
+        # Return early if reshape is not required
+        if shape == self.shape:
+            if copy:
+                return self.copy()
+            else:
+                return self
+
         nrows, ncols = self.shape
 
         if order == 'C':

--- a/scipy/sparse/dia.py
+++ b/scipy/sparse/dia.py
@@ -11,7 +11,7 @@ import numpy as np
 from .base import isspmatrix, _formats, spmatrix
 from .data import _data_matrix
 from .sputils import (isshape, upcast_char, getdtype, get_index_dtype,
-                      get_sum_dtype, validateaxis)
+                      get_sum_dtype, validateaxis, check_shape)
 from ._sparsetools import dia_matvec
 
 
@@ -83,7 +83,7 @@ class dia_matrix(_data_matrix):
                 arg1 = arg1.copy()
             self.data = arg1.data
             self.offsets = arg1.offsets
-            self.shape = arg1.shape
+            self._shape = check_shape(arg1.shape)
         elif isspmatrix(arg1):
             if isspmatrix_dia(arg1) and copy:
                 A = arg1.copy()
@@ -91,12 +91,12 @@ class dia_matrix(_data_matrix):
                 A = arg1.todia()
             self.data = A.data
             self.offsets = A.offsets
-            self.shape = A.shape
+            self._shape = check_shape(A.shape)
         elif isinstance(arg1, tuple):
             if isshape(arg1):
                 # It's a tuple of matrix dimensions (M, N)
                 # create empty matrix
-                self.shape = arg1   # spmatrix checks for errors here
+                self._shape = check_shape(arg1)
                 self.data = np.zeros((0,0), getdtype(dtype, default=float))
                 idx_dtype = get_index_dtype(maxval=max(self.shape))
                 self.offsets = np.zeros((0), dtype=idx_dtype)
@@ -113,7 +113,7 @@ class dia_matrix(_data_matrix):
                     self.offsets = np.atleast_1d(np.array(arg1[1],
                                                           dtype=get_index_dtype(maxval=max(shape)),
                                                           copy=copy))
-                    self.shape = shape
+                    self._shape = check_shape(shape)
         else:
             #must be dense, convert to COO first, then to DIA
             try:
@@ -125,7 +125,7 @@ class dia_matrix(_data_matrix):
             A = coo_matrix(arg1, dtype=dtype, shape=shape).todia()
             self.data = A.data
             self.offsets = A.offsets
-            self.shape = A.shape
+            self._shape = check_shape(A.shape)
 
         if dtype is not None:
             self.data = self.data.astype(dtype)

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -371,33 +371,6 @@ class lil_matrix(spmatrix, IndexMixin):
         else:
             return self
 
-    def _concatenated_data(self):
-        """ Helper function for format conversions. """
-        data = []
-        for x in self.data:
-            data.extend(x)
-        return np.asarray(data, dtype=self.dtype)
-
-    def _concatenated_indices(self, idx_dtype):
-        """ Helper function for format conversions. """
-        indices = []
-        for x in self.rows:
-            indices.extend(x)
-        return np.asarray(indices, dtype=idx_dtype)
-
-    def tocoo(self):
-        """ Return a COO formatted sparse matrix.
-        """
-        lst = [len(x) for x in self.rows]
-        idx_dtype = get_index_dtype(maxval=max(self.shape[1], sum(lst)))
-
-        rows = np.repeat(np.arange(len(lst), dtype=idx_dtype), lst)
-        cols = self._concatenated_indices(idx_dtype)
-        data = self._concatenated_data()
-
-        from .coo import coo_matrix
-        return coo_matrix((data, (rows, cols)), shape=self.shape)
-
     def tocsr(self):
         """ Return Compressed Sparse Row format arrays for this matrix.
         """
@@ -405,8 +378,8 @@ class lil_matrix(spmatrix, IndexMixin):
         idx_dtype = get_index_dtype(maxval=max(self.shape[1], sum(lst)))
 
         indptr = np.cumsum([0] + lst, dtype=idx_dtype)
-        indices = self._concatenated_indices(idx_dtype)
-        data = self._concatenated_data()
+        indices = np.array([x for y in self.rows for x in y], dtype=idx_dtype)
+        data = np.array([x for y in self.data for x in y], dtype=self.dtype)
 
         from .csr import csr_matrix
         return csr_matrix((data, indices, indptr), shape=self.shape)

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -399,10 +399,7 @@ class lil_matrix(spmatrix, IndexMixin):
         lst = [len(x) for x in self.rows]
         idx_dtype = get_index_dtype(maxval=max(self.shape[1], sum(lst)))
 
-        indptr = np.asarray(lst, dtype=idx_dtype)
-        indptr = np.concatenate((np.array([0], dtype=idx_dtype),
-                                 np.cumsum(indptr, dtype=idx_dtype)))
-
+        indptr = np.cumsum([0] + lst, dtype=idx_dtype)
         indices = self._concatenated_indices(idx_dtype)
         data = self._concatenated_data()
 

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -146,6 +146,7 @@ class lil_matrix(spmatrix, IndexMixin):
             raise ValueError('invalid shape')
 
         if (self._shape != shape) and (self._shape is not None):
+            raise NotImplementedError('sparse matrix shape setting magic is broken')
             try:
                 self = self.reshape(shape)
             except NotImplementedError:

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -146,7 +146,11 @@ class lil_matrix(spmatrix, IndexMixin):
             raise ValueError('invalid shape')
 
         if (self._shape != shape) and (self._shape is not None):
-            raise NotImplementedError('sparse matrix shape setting magic is broken')
+            raise NotImplementedError(
+                    'Changing the shape of a sparse matrix by directly '
+                    'modifying its .shape property is not currently '
+                    'supported.  Please consider using the .reshape() '
+                    'member function instead!')
             try:
                 self = self.reshape(shape)
             except NotImplementedError:

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -349,15 +349,6 @@ class lil_matrix(spmatrix, IndexMixin):
         new.rows = deepcopy(self.rows)
         return new
 
-    def reshape(self,shape):
-        new = lil_matrix(shape, dtype=self.dtype)
-        j_max = self.shape[1]
-        for i,row in enumerate(self.rows):
-            for col,j in enumerate(row):
-                new_r,new_c = np.unravel_index(i*j_max + j,shape)
-                new[new_r,new_c] = self[i,j]
-        return new
-
     def toarray(self, order=None, out=None):
         """See the docstring for `spmatrix.toarray`."""
         d = self._process_toarray_args(order, out)

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -385,6 +385,29 @@ class lil_matrix(spmatrix, IndexMixin):
 
     copy.__doc__ = spmatrix.copy.__doc__
 
+    def reshape(self, *args, order='C', copy=False):
+        shape = check_shape(args, self.shape)
+        new = lil_matrix(shape, dtype=self.dtype)
+
+        if order == 'C':
+            ncols = self.shape[1]
+            for i, row in enumerate(self.rows):
+                for col, j in enumerate(row):
+                    new_r, new_c = np.unravel_index(i * ncols + j, shape)
+                    new[new_r, new_c] = self[i, j]
+        elif order == 'F':
+            nrows = self.shape[0]
+            for i, row in enumerate(self.rows):
+                for col, j in enumerate(row):
+                    new_r, new_c = np.unravel_index(i + j * nrows, shape, order)
+                    new[new_r, new_c] = self[i, j]
+        else:
+            raise ValueError("'order' must be 'C' or 'F'")
+
+        return new
+
+    reshape.__doc__ = spmatrix.reshape.__doc__
+
     def toarray(self, order=None, out=None):
         d = self._process_toarray_args(order, out)
         for i, row in enumerate(self.rows):

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -390,6 +390,13 @@ class lil_matrix(spmatrix, IndexMixin):
         shape = check_shape(args, self.shape)
         order, copy = check_reshape_kwargs(kwargs)
 
+        # Return early if reshape is not required
+        if shape == self.shape:
+            if copy:
+                return self.copy()
+            else:
+                return self
+
         new = lil_matrix(shape, dtype=self.dtype)
 
         if order == 'C':

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -12,7 +12,8 @@ import numpy as np
 from scipy._lib.six import xrange
 from .base import spmatrix, isspmatrix
 from .sputils import (getdtype, isshape, isscalarlike, IndexMixin,
-                      upcast_scalar, get_index_dtype, isintlike, check_shape)
+                      upcast_scalar, get_index_dtype, isintlike, check_shape,
+                      check_reshape_kwargs)
 from . import _csparsetools
 
 
@@ -385,8 +386,10 @@ class lil_matrix(spmatrix, IndexMixin):
 
     copy.__doc__ = spmatrix.copy.__doc__
 
-    def reshape(self, *args, order='C', copy=False):
+    def reshape(self, *args, **kwargs):
         shape = check_shape(args, self.shape)
+        order, copy = check_reshape_kwargs(kwargs)
+
         new = lil_matrix(shape, dtype=self.dtype)
 
         if order == 'C':

--- a/scipy/sparse/sputils.py
+++ b/scipy/sparse/sputils.py
@@ -3,6 +3,7 @@
 
 from __future__ import division, print_function, absolute_import
 
+import operator
 import warnings
 import numpy as np
 
@@ -253,16 +254,6 @@ def validateaxis(axis):
 
 def check_shape(args, current_shape=None):
     """Imitate numpy.matrix handling of shape arguments"""
-    def check_int(arg):
-        if np.issubdtype(type(arg), np.integer):
-            return int(arg)
-        elif (isinstance(arg, np.ndarray) and np.isscalar(arg) and
-                np.issubdtype(arg.dtype, np.integer)):
-            return int(arg)
-        else:
-            raise TypeError("'{}' object cannot be interpreted as an "
-                            "integer".format(args[0].__class__.__name__))
-
     if len(args) == 0:
         raise TypeError("function missing 1 required positional argument: "
                         "'shape'")
@@ -270,11 +261,11 @@ def check_shape(args, current_shape=None):
         try:
             shape_iter = iter(args[0])
         except TypeError:
-            new_shape = (check_int(args[0]), )
+            new_shape = (operator.index(args[0]), )
         else:
-            new_shape = tuple(check_int(arg) for arg in shape_iter)
+            new_shape = tuple(operator.index(arg) for arg in shape_iter)
     else:
-        new_shape = tuple(check_int(arg) for arg in args)
+        new_shape = tuple(operator.index(arg) for arg in args)
 
     # Check the current size only if needed
     if current_shape is not None:

--- a/scipy/sparse/sputils.py
+++ b/scipy/sparse/sputils.py
@@ -316,6 +316,23 @@ def check_shape(args, current_shape=None):
     return new_shape
 
 
+def check_reshape_kwargs(kwargs):
+    """Unpack keyword arguments for reshape function.
+
+    This is useful because keyword arguments after star arguments are not
+    allowed in Python 2, but star keyword arguments are. This function unpacks
+    'order' and 'copy' from the star keyword arguments (with defaults) and
+    throws an error for any remaining.
+    """
+
+    order = kwargs.pop('order', 'C')
+    copy = kwargs.pop('copy', False)
+    if kwargs:  # Some unused kwargs remain
+        raise TypeError('reshape() got unexpected keywords arguments: {}'
+                        .format(', '.join(kwargs.keys())))
+    return order, copy
+
+
 class IndexMixin(object):
     """
     This class simply exists to hold the methods necessary for fancy indexing.

--- a/scipy/sparse/sputils.py
+++ b/scipy/sparse/sputils.py
@@ -251,6 +251,61 @@ def validateaxis(axis):
             raise ValueError("axis out of range")
 
 
+def check_shape(args, current_shape=None):
+    """Imitate numpy.matrix handling of shape arguments"""
+    int_types = (int, np.int8, np.int16, np.int32, np.int64,
+                 np.uint8, np.uint16, np.uint32, np.uint64,
+                 np.intc, np.intp)
+
+    def check_int(arg):
+        if isinstance(arg, int_types):
+            return int(arg)
+        elif isinstance(arg, np.ndarray) and np.isscalar(arg) and \
+                arg.dtype in int_types:
+            return int(arg)
+        else:
+            raise TypeError("'{}' object cannot be interpreted as an "
+                            "integer".format(args[0].__class__.__name__))
+
+    if len(args) == 0:
+        raise TypeError("'reshape' missing 1 required positional argument: "
+                        "'shape'")
+    elif len(args) == 1:
+        try:
+            shape_iter = iter(args[0])
+        except TypeError:
+            new_shape = (check_int(args[0]), )
+        else:
+            new_shape = tuple(check_int(arg) for arg in shape_iter)
+    else:
+        new_shape = tuple(check_int(arg) for arg in args)
+
+    # Check the current size only if needed
+    if current_shape is not None:
+        current_size = np.prod(current_shape, dtype=int)
+        new_size = np.prod(new_shape, dtype=int)
+        if new_size != current_size:
+            raise ValueError('cannot reshape array of size {} into shape {}'
+                             .format(new_size, new_shape))
+
+    # Add and remove ones like numpy.matrix.reshape
+    if len(new_shape) != 2:
+        new_shape = tuple(arg for arg in new_shape if arg != 1)
+
+        if len(new_shape) == 0:
+            new_shape = (1, 1)
+        elif len(new_shape) == 1:
+            new_shape = (1, new_shape[0])
+        elif len(new_shape) > 2:
+            raise ValueError('shape too large to be a matrix')
+
+    # Check for negatives
+    if new_shape[0] < 0 or new_shape[1] < 0:
+        raise ValueError("'shape' elements cannot be negative")
+
+    return new_shape
+
+
 class IndexMixin(object):
     """
     This class simply exists to hold the methods necessary for fancy indexing.

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -3653,6 +3653,20 @@ class TestCOO(sparse_test_class(getset=False,
         dok = coo.todok()
         assert_array_equal(dok.A, coo.A)
 
+    def test_reshape_copy(self):
+        arr = [[0, 10, 0, 0], [0, 0, 0, 0], [0, 20, 30, 40]]
+        new_shape = (2, 6)
+        x = coo_matrix(arr)
+
+        y = x.reshape(new_shape)
+        assert_(y.data is not x.data)
+
+        y = x.reshape(new_shape, copy=True)
+        assert_(y.data is not x.data)
+
+        y = x.reshape(new_shape, copy=False)
+        assert_(y.data is x.data)
+
 
 class TestDIA(sparse_test_class(getset=False, slicing=False, slicing_assign=False,
                                 fancy_indexing=False, fancy_assign=False,

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -621,10 +621,18 @@ class _TestCommon:
             assert_equal(self.spmatrix(m).diagonal(),diag(m))
 
     def test_reshape(self):
+        # This first example is taken from the lil_matrix reshaping test.
         x = self.spmatrix([[1, 0, 7], [0, 0, 0], [0, 3, 0], [0, 0, 5]])
         for s in [(12,1),(1,12)]:
             assert_array_equal(x.reshape(s).todense(),
                                x.todense().reshape(s))
+
+        # This example is taken from the stackoverflow answer at
+        # http://stackoverflow.com/questions/16511879
+        x = self.spmatrix([[0, 10, 0, 0], [0, 0, 0, 0], [0, 20, 30, 40]])
+        y = x.reshape((2, 6))
+        desired = [[0, 10, 0, 0, 0, 0], [0, 0, 0, 20, 30, 40]]
+        assert_array_equal(y.A, desired)
 
     @dec.slow
     def test_setdiag(self):

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -3659,13 +3659,13 @@ class TestCOO(sparse_test_class(getset=False,
         x = coo_matrix(arr)
 
         y = x.reshape(new_shape)
-        assert_(not np.may_share_memory(y.data, x.data))
-
-        y = x.reshape(new_shape, copy=True)
-        assert_(not np.may_share_memory(y.data, x.data))
+        assert_(y.data is x.data)
 
         y = x.reshape(new_shape, copy=False)
         assert_(y.data is x.data)
+
+        y = x.reshape(new_shape, copy=True)
+        assert_(not np.may_share_memory(y.data, x.data))
 
 
 class TestDIA(sparse_test_class(getset=False, slicing=False, slicing_assign=False,

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -620,6 +620,12 @@ class _TestCommon:
         for m in mats:
             assert_equal(self.spmatrix(m).diagonal(),diag(m))
 
+    def test_reshape(self):
+        x = self.spmatrix([[1, 0, 7], [0, 0, 0], [0, 3, 0], [0, 0, 5]])
+        for s in [(12,1),(1,12)]:
+            assert_array_equal(x.reshape(s).todense(),
+                               x.todense().reshape(s))
+
     @dec.slow
     def test_setdiag(self):
         def dense_setdiag(a, v, k):

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -3500,17 +3500,6 @@ class TestLIL(sparse_test_class(minmax=False)):
         x = x*0
         assert_equal(x[0,0],0)
 
-    def test_reshape(self):
-        x = lil_matrix((4,3))
-        x[0,0] = 1
-        x[2,1] = 3
-        x[3,2] = 5
-        x[0,2] = 7
-
-        for s in [(12,1),(1,12)]:
-            assert_array_equal(x.reshape(s).todense(),
-                               x.todense().reshape(s))
-
     def test_inplace_ops(self):
         A = lil_matrix([[0,2,3],[4,0,6]])
         B = lil_matrix([[0,1,0],[0,2,3]])

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -3659,10 +3659,10 @@ class TestCOO(sparse_test_class(getset=False,
         x = coo_matrix(arr)
 
         y = x.reshape(new_shape)
-        assert_(y.data is not x.data)
+        assert_(not np.may_share_memory(y.data, x.data))
 
         y = x.reshape(new_shape, copy=True)
-        assert_(y.data is not x.data)
+        assert_(not np.may_share_memory(y.data, x.data))
 
         y = x.reshape(new_shape, copy=False)
         assert_(y.data is x.data)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -632,6 +632,7 @@ class _TestCommon:
         x = self.spmatrix([[0, 10, 0, 0], [0, 0, 0, 0], [0, 20, 30, 40]])
         y = x.reshape((2, 6))
         desired = [[0, 10, 0, 0, 0, 0], [0, 0, 0, 20, 30, 40]]
+        assert_equal(y.format, x.format)
         assert_array_equal(y.A, desired)
 
     @dec.slow

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -710,14 +710,15 @@ class _TestCommon(object):
     def test_reshape(self):
         # This first example is taken from the lil_matrix reshaping test.
         x = self.spmatrix([[1, 0, 7], [0, 0, 0], [0, 3, 0], [0, 0, 5]])
-        for s in [(12,1),(1,12)]:
-            assert_array_equal(x.reshape(s).todense(),
-                               x.todense().reshape(s))
+        for order in ['C', 'F']:
+            for s in [(12, 1), (1, 12)]:
+                assert_array_equal(x.reshape(s, order=order).todense(),
+                                   x.todense().reshape(s, order=order))
 
         # This example is taken from the stackoverflow answer at
         # http://stackoverflow.com/questions/16511879
         x = self.spmatrix([[0, 10, 0, 0], [0, 0, 0, 0], [0, 20, 30, 40]])
-        y = x.reshape((2, 6))
+        y = x.reshape((2, 6))  # Default order is 'C'
         desired = [[0, 10, 0, 0, 0, 0], [0, 0, 0, 20, 30, 40]]
         assert_equal(y.format, x.format)
         assert_array_equal(y.A, desired)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -722,7 +722,14 @@ class _TestCommon(object):
         desired = [[0, 10, 0, 0, 0, 0], [0, 0, 0, 20, 30, 40]]
         assert_array_equal(y.A, desired)
 
-        # Ensure reshape did not original size
+        # Reshape with negative indexes
+        y = x.reshape((2, -1))
+        assert_array_equal(y.A, desired)
+        y = x.reshape((-1, 6))
+        assert_array_equal(y.A, desired)
+        assert_raises(ValueError, x.reshape, (-1, -1))
+
+        # Ensure reshape did not alter original size
         assert_array_equal(x.shape, (3, 4))
 
         # Reshape in place

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -720,8 +720,14 @@ class _TestCommon(object):
         x = self.spmatrix([[0, 10, 0, 0], [0, 0, 0, 0], [0, 20, 30, 40]])
         y = x.reshape((2, 6))  # Default order is 'C'
         desired = [[0, 10, 0, 0, 0, 0], [0, 0, 0, 20, 30, 40]]
-        assert_equal(y.format, x.format)
         assert_array_equal(y.A, desired)
+
+        # Ensure reshape did not original size
+        assert_array_equal(x.shape, (3, 4))
+
+        # Reshape in place
+        x.shape = (2, 6)
+        assert_array_equal(x.A, desired)
 
     @pytest.mark.slow
     def test_setdiag_comprehensive(self):

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -729,6 +729,17 @@ class _TestCommon(object):
         assert_array_equal(y.A, desired)
         assert_raises(ValueError, x.reshape, (-1, -1))
 
+        # Reshape with star args
+        y = x.reshape(2, 6)
+        assert_array_equal(y.A, desired)
+        assert_raises(TypeError, x.reshape, 2, 6, not_an_arg=1)
+
+        # Reshape with same size is noop unless copy=True
+        y = x.reshape((3, 4))
+        assert_(y is x)
+        y = x.reshape((3, 4), copy=True)
+        assert_(y is not x)
+
         # Ensure reshape did not alter original size
         assert_array_equal(x.shape, (3, 4))
 


### PR DESCRIPTION
Currently, the reshape method is defined on the base class of sparse matrices, but only implemented for LIL matrices. This defines an implementation for COO sparse matrices and then adds a implementation to the base class that first converts to COO to use its reshape then converts back.

The discussion began at #3507. The original COO implementation is merged from #3957.