### PR TITLE
ENH: add a unique function for sparse matrices

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -183,6 +183,7 @@ Charles Masson for the Wasserstein and the Cramér-von Mises statistical
 Felix Lenders for implementing trust-trlib method.
 Dezmond Goff for adding optional out parameter to pdist/cdist
 Nick R. Papior for allowing a wider choice of solvers
+Jesse Dunietz for adding a unique function to scipy.sparse
 
 Institutions
 ------------

--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -62,6 +62,7 @@ Sparse matrix tools:
    :toctree: generated/
 
    find
+   unique
 
 Identifying sparse matrices:
 

--- a/scipy/sparse/extract.py
+++ b/scipy/sparse/extract.py
@@ -211,10 +211,12 @@ def unique(mat, return_indices=False, return_inverse=False, return_counts=False)
 
         Note that, because the matrix is sparse, the full array of indices is
         not returned. Instead, a 2 x n array i is returned such that the
-        following code will reproduce the original matrix:
-            m = np.zeros(np.prod(mat.shape), dtype=mat.dtype) # or sparse matrix
-            m[i[0]] = unique[i[1]]
-            np.reshape(m, mat.shape)
+        following code will reproduce the original matrix::
+
+            >>> m = np.zeros(np.prod(mat.shape), dtype=mat.dtype) # or sparse matrix
+            >>> m[i[0]] = unique[i[1]]
+            >>> np.reshape(m, mat.shape)
+
     unique_counts : ndarray, optional
         The number of times each of the unique values comes up in the
         original array. Only provided if `return_counts` is True.

--- a/scipy/sparse/extract.py
+++ b/scipy/sparse/extract.py
@@ -232,7 +232,7 @@ def unique(mat, return_indices=False, return_inverse=False, return_counts=False)
     # return_indices options.) Also, CSR is fairly memory-efficient and quick to
     # convert to from other formats.
     mat = mat.tocsr()
-    size = mat.shape[0] * mat.shape[1] # mat.size just gives nnz
+    size = mat.shape[0] * mat.shape[1]  # mat.size just gives nnz
 
     unique_data = np.unique(mat.data, return_indices, return_inverse,
                             return_counts)
@@ -294,7 +294,7 @@ def unique(mat, return_indices=False, return_inverse=False, return_counts=False)
             offset_i = i + offset
             flattened_index = row * mat.shape[1] + col
             difference = flattened_index - offset_i
-            if difference > 0: # We've found one or more zero entries!
+            if difference > 0:  # We've found one or more zero entries!
                 if return_indices:
                     indices[np.where(indices >= offset_i)] += difference
                     if first_zero is None:
@@ -307,12 +307,12 @@ def unique(mat, return_indices=False, return_inverse=False, return_counts=False)
                 offset += difference
 
         if return_indices:
-            if first_zero is None: # Didn't find a zero amidst nonzeros;
-                try:               # all zeros are trailing
+            if first_zero is None:  # Didn't find a zero amidst nonzeros;
+                try:                # all zeros are trailing
                     first_zero = (nonzero[0][-1] * mat.shape[0] +
                                   nonzero[1][-1] + 1)
-                except IndexError: # nonzero is empty; mat is all zeros!
-                    indices.dtype = int # Fix dtype from np.unique call on []
+                except IndexError:  # nonzero is empty; mat is all zeros!
+                    indices.dtype = int  # Fix dtype from np.unique call on []
                     first_zero = 0
                 indices = np.insert(indices, 0, first_zero)
             ret += (indices,)

--- a/scipy/sparse/extract.py
+++ b/scipy/sparse/extract.py
@@ -7,7 +7,7 @@ __docformat__ = "restructuredtext en"
 
 __all__ = ['find', 'tril', 'triu', 'unique']
 
-from itertools import izip
+from six.moves import zip
 
 import numpy as np
 
@@ -290,7 +290,7 @@ def unique(mat, return_indices=False, return_inverse=False, return_counts=False)
         mat.sort_indices()
         nonzero = mat.nonzero()
 
-        for i, (row, col) in enumerate(izip(nonzero[0], nonzero[1])):
+        for i, (row, col) in enumerate(zip(nonzero[0], nonzero[1])):
             offset_i = i + offset
             flattened_index = row * mat.shape[1] + col
             difference = flattened_index - offset_i

--- a/scipy/sparse/extract.py
+++ b/scipy/sparse/extract.py
@@ -197,7 +197,7 @@ def unique(mat, return_indices=False, return_inverse=False, return_counts=False)
         to reconstruct `mat`.
     return_counts : bool, optional
         If True, also return the number of times each unique value comes up
-        in `mat`.
+        in `mat`. Must be False for Numpy versions <= 1.8.2.
 
     Returns
     -------

--- a/scipy/sparse/extract.py
+++ b/scipy/sparse/extract.py
@@ -236,7 +236,7 @@ def unique(mat, return_indices=False, return_inverse=False, return_counts=False)
     mat = mat.tocsr()
     size = mat.shape[0] * mat.shape[1]  # mat.size just gives nnz
 
-    unique_data = np.unique(mat.data, return_indices, return_inverse,
+    unique_data = np.unique(mat._deduped_data(), return_indices, return_inverse,
                             return_counts)
 
     # If there are no zeros, we can just pretend we're operating on a normal

--- a/scipy/sparse/extract.py
+++ b/scipy/sparse/extract.py
@@ -5,8 +5,9 @@ from __future__ import division, print_function, absolute_import
 
 __docformat__ = "restructuredtext en"
 
-__all__ = ['find', 'tril', 'triu']
+__all__ = ['find', 'tril', 'triu', 'unique']
 
+import numpy as np
 
 from .coo import coo_matrix
 
@@ -169,3 +170,150 @@ def _masked_coo(A, mask):
     col = A.col[mask]
     data = A.data[mask]
     return coo_matrix((data, (row, col)), shape=A.shape, dtype=A.dtype)
+
+
+def unique(mat, return_index=False, return_inverse=False, return_counts=False):
+    """
+    Find the unique elements of a sparse matrix
+
+    Returns the sorted unique elements of a sparse matrix. There are two
+    optional outputs in addition to the unique elements: the indices of the
+    input matrix that give the unique values, and the indices of the unique
+    matrix that reconstruct the input matrix.
+
+    Parameters
+    ----------
+    mat : sparse matrix
+        Input matrix. This will be converted to the CSR representation
+        internally.
+    return_index : bool, optional
+        If True, also return the indices of `mat` that result in the unique
+        array.
+    return_inverse : bool, optional
+        If True, also return the indices of the unique array that can be used
+        to reconstruct `mat`.
+    return_counts : bool, optional
+        If True, also return the number of times each unique value comes up
+        in `mat`.
+
+    Returns
+    -------
+    unique : ndarray
+        The sorted unique values.
+    unique_indices : ndarray, optional
+        The indices of the first occurrences of the unique values in the
+        (flattened) original array. Only provided if `return_index` is True.
+    unique_inverse : ndarray, optional
+        The indices to reconstruct the (flattened) original array from the
+        unique array. Only provided if `return_inverse` is True.
+
+        Note that, because the matrix is sparse, the full array of indices is
+        not returned. Instead, an array i is returned such that, given an empty
+        sparse matrix m with the same number of columns as there were elements
+        in mat, setting m[0, i[0]] = unique[i[1]] will reproduce the original
+        matrix.
+    unique_counts : ndarray, optional
+        The number of times each of the unique values comes up in the
+        original array. Only provided if `return_counts` is True.
+
+    See Also
+    --------
+    numpy.lib.arraysetops.unique : Basis for this function, but only works for
+                                   dense matrices/arrays.
+    """
+    # Convert to CSR because this format has a .data matrix, which is the main
+    # thing we need, and which is stored in sorted order of rows -> columns.
+    # This means that np.unique returns the indices and inverse in terms of a
+    # sensibly linearized matrix. (The nonzero indices are also returned in
+    # row -> column order, which is useful for the return_inverse and
+    # return_index options.) Also, CSR is fairly memory-efficient and quick to
+    # convert to from other formats.
+    mat = mat.tocsr()
+    size = mat.shape[0] * mat.shape[1] # mat.size just gives nnz
+
+    unique_data = np.unique(mat.data, return_index, return_inverse,
+                            return_counts)
+
+    # If there are no zeros, we can just pretend we're operating on a normal
+    # dense array. All we have to do then is check whether we need to adapt the
+    # inverse return value to our special sparse inverse format.
+    if mat.nnz == size:
+        if return_inverse:
+            inv_index = (2 if return_index else 1)
+            inverse = np.vstack((range(size), unique_data[inv_index]))
+            unique_data = list(unique_data)
+            unique_data[inv_index] = inverse
+            unique_data = tuple(unique_data)
+        return unique_data
+
+    # OK, there are some zeros.
+    # Our lives are simplest if the only thing requested was the unique values.
+    if not isinstance(unique_data, tuple):
+        # We got here because there are zeros, so we know 0 should be in the
+        # list of unique values.
+        return np.insert(unique_data, 0, 0.0)
+
+    # If more values were requested, process other return values in the tuple
+    # as necessary.
+    unique_data = list(reversed(unique_data))
+    unique_values = unique_data.pop()
+    unique_values = np.insert(unique_values, 0, 0.0)
+    ret = (unique_values,)
+
+    # Offset returned indices to account for missing zero entries.
+    if return_index or return_inverse:
+        if return_index:
+            indices = unique_data.pop()
+        if return_inverse:
+            inverse = unique_data.pop()
+
+            # We're going to use inverse[0] as the array indices at which
+            # values in the original matrix reside, and inverse[1] as the
+            # indices in the unique array from which to draw those values.
+            # We must add 1 to inverse[1] to account for the 0 in the initial
+            # position.
+
+            # The indices for the inverse matrix aren't accounting for the
+            # presence of a zero value at the start of the list.
+            inverse_unique_indices = inverse + 1
+            # Initialize positions in original matrix to values' current
+            # positions in the inverse array. As we detect 0 values in the
+            # original matrix, we'll increase these indices accordingly.
+            inverse_orig_pos_indices = np.array(range(len(inverse)))
+
+        first_zero = None
+        offset = 0
+        mat.sort_indices()
+        nonzero = mat.nonzero()
+
+        for i, (row, col) in enumerate(izip(nonzero[0], nonzero[1])):
+            offset_i = i + offset
+            flattened_index = row * mat.shape[1] + col
+            difference = flattened_index - offset_i
+            if difference > 0: # We've found one or more zero entries!
+                if return_index:
+                    indices[np.where(indices >= offset_i)] += difference
+                    if first_zero is None:
+                        first_zero = i
+                        indices = np.insert(indices, 0, first_zero)
+                if return_inverse:
+                    inverse_orig_pos_indices[
+                        np.where(inverse_orig_pos_indices >= offset_i)
+                        ] += difference
+                offset += difference
+
+        if return_index:
+            ret += (indices,)
+
+        if return_inverse:
+            inverse = np.vstack((inverse_orig_pos_indices,
+                                 inverse_unique_indices))
+            ret += (inverse,)
+
+    # Add counts for 0 value.
+    if return_counts:
+        counts = unique_data.pop()
+        counts = np.insert(counts, 0, size - mat.nnz)
+        ret += (counts,)
+
+    return ret

--- a/scipy/sparse/extract.py
+++ b/scipy/sparse/extract.py
@@ -8,6 +8,7 @@ __docformat__ = "restructuredtext en"
 __all__ = ['find', 'tril', 'triu', 'unique']
 
 from scipy._lib.six import zip
+from scipy._lib._version import NumpyVersion
 
 import numpy as np
 
@@ -241,8 +242,16 @@ def unique(mat, return_indices=False, return_inverse=False, return_counts=False)
     mat = mat.tocsr()
     size = mat.shape[0] * mat.shape[1]  # mat.size just gives nnz
 
-    unique_data = np.unique(mat._deduped_data(), return_indices, return_inverse,
-                            return_counts)
+    if NumpyVersion(np.__version__) <= '1.8.2':
+        if return_counts:
+            raise NotImplementedError(
+                "Numpy version %s is too low for 'return_counts' parameter"
+                % np.__version__)
+        unique_data = np.unique(mat._deduped_data(), return_indices,
+                                return_inverse)
+    else:
+        unique_data = np.unique(mat._deduped_data(), return_indices,
+                                return_inverse, return_counts)
 
     # If there are no zeros, we can just pretend we're operating on a normal
     # dense array. All we have to do then is adapt the inverse return value, if

--- a/scipy/sparse/extract.py
+++ b/scipy/sparse/extract.py
@@ -210,8 +210,8 @@ def unique(mat, return_indices=False, return_inverse=False, return_counts=False)
         unique array. Only provided if `return_inverse` is True.
 
         Note that, because the matrix is sparse, the full array of indices is
-        not returned. Instead, an array i is returned such that the following
-        code will reproduce the original matrix:
+        not returned. Instead, a 2 x n array i is returned such that the
+        following code will reproduce the original matrix:
             m = np.zeros(np.prod(mat.shape), dtype=mat.dtype) # or sparse matrix
             m[i[0]] = unique[i[1]]
             np.reshape(m, mat.shape)

--- a/scipy/sparse/extract.py
+++ b/scipy/sparse/extract.py
@@ -7,6 +7,8 @@ __docformat__ = "restructuredtext en"
 
 __all__ = ['find', 'tril', 'triu', 'unique']
 
+from itertools import izip
+
 import numpy as np
 
 from .coo import coo_matrix

--- a/scipy/sparse/extract.py
+++ b/scipy/sparse/extract.py
@@ -210,10 +210,11 @@ def unique(mat, return_index=False, return_inverse=False, return_counts=False):
         unique array. Only provided if `return_inverse` is True.
 
         Note that, because the matrix is sparse, the full array of indices is
-        not returned. Instead, an array i is returned such that, given an empty
-        sparse matrix m with the same number of columns as there were elements
-        in mat, setting m[0, i[0]] = unique[i[1]] will reproduce the original
-        matrix.
+        not returned. Instead, an array i is returned such that the following
+        code will reproduce the original matrix:
+            m = np.zeros(np.prod(mat.shape))
+            m[i[0]] = unique[i[1]]
+            m.reshape(mat.shape)
     unique_counts : ndarray, optional
         The number of times each of the unique values comes up in the
         original array. Only provided if `return_counts` is True.
@@ -237,8 +238,8 @@ def unique(mat, return_index=False, return_inverse=False, return_counts=False):
                             return_counts)
 
     # If there are no zeros, we can just pretend we're operating on a normal
-    # dense array. All we have to do then is check whether we need to adapt the
-    # inverse return value to our special sparse inverse format.
+    # dense array. All we have to do then is adapt the inverse return value, if
+    # there is one, to our special sparse inverse format.
     if mat.nnz == size:
         if return_inverse:
             inv_index = (2 if return_index else 1)
@@ -276,7 +277,7 @@ def unique(mat, return_index=False, return_inverse=False, return_counts=False):
             # position.
 
             # The indices for the inverse matrix aren't accounting for the
-            # presence of a zero value at the start of the list.
+            # presence of a zero value at the start of the uniques list.
             inverse_unique_indices = inverse + 1
             # Initialize positions in original matrix to values' current
             # positions in the inverse array. As we detect 0 values in the

--- a/scipy/sparse/extract.py
+++ b/scipy/sparse/extract.py
@@ -7,7 +7,7 @@ __docformat__ = "restructuredtext en"
 
 __all__ = ['find', 'tril', 'triu', 'unique']
 
-from six.moves import zip
+from scipy._lib.six import zip
 
 import numpy as np
 

--- a/scipy/sparse/extract.py
+++ b/scipy/sparse/extract.py
@@ -210,12 +210,17 @@ def unique(mat, return_indices=False, return_inverse=False, return_counts=False)
         unique array. Only provided if `return_inverse` is True.
 
         Note that, because the matrix is sparse, the full array of indices is
-        not returned. Instead, a 2 x n array i is returned such that the
-        following code will reproduce the original matrix::
+        not returned. Instead, a 2 x n array is returned where the first row is
+        the linearized indices of nonzero values in the original matrix, and the
+        second row is the corresponding indices for the values in the vector of
+        uniques. Thus, code like the following reproduces the original matrix::
 
-            >>> m = np.zeros(np.prod(mat.shape), dtype=mat.dtype) # or sparse matrix
-            >>> m[i[0]] = unique[i[1]]
-            >>> np.reshape(m, mat.shape)
+            >>> from scipy.sparse import lil_matrix, extract
+            >>> mat = lil_matrix([[1, 0], [2, 0]])
+            >>> uniques, inverse = extract.unique(mat, return_inverse=True)
+            >>> recovered = lil_matrix((np.prod(mat.shape), 1), dtype=mat.dtype)
+            >>> recovered[inverse[0]] = uniques[inverse[1]] # How to use inverse
+            >>> recovered = recovered.reshape(mat.shape)
 
     unique_counts : ndarray, optional
         The number of times each of the unique values comes up in the

--- a/scipy/sparse/tests/test_extract.py
+++ b/scipy/sparse/tests/test_extract.py
@@ -6,6 +6,7 @@ from itertools import product
 
 from numpy.testing import assert_equal
 from scipy.sparse import csr_matrix
+from scipy._lib._version import NumpyVersion
 
 import numpy as np
 from scipy.sparse import extract, spmatrix
@@ -49,8 +50,14 @@ class TestExtract(object):
     def test_unique(self):
         for A in self.cases:
             B = A.toarray()
+            if NumpyVersion(np.__version__) <= '1.8.2':
+                # return_counts is not compatible with these versions of Numpy.
+                return_counts_options = [False]
+            else:
+                return_counts_options = [True, False]
+
             for return_indices, return_inverse, return_counts in (
-                    product(*([[True, False]] * 3))):
+                    product(*([[True, False]] * 2 + return_counts_options))):
                 sparse_result = extract.unique(
                     A, return_indices, return_inverse, return_counts)
                 np_result = np.unique(

--- a/scipy/sparse/tests/test_extract.py
+++ b/scipy/sparse/tests/test_extract.py
@@ -55,7 +55,7 @@ class TestExtract(object):
                     A, return_indices, return_inverse, return_counts)
                 np_result = np.unique(
                     B, return_indices, return_inverse, return_counts)
-                if not isinstance(sparse_result, tuple): # Just the uniques
+                if not isinstance(sparse_result, tuple):  # Just the uniques
                     assert_equal(sparse_result, np_result)
                     continue
 
@@ -66,7 +66,7 @@ class TestExtract(object):
                 np_uniques = np_result.pop()
                 assert_equal(sparse_uniques, np_uniques)
 
-                if return_indices: # Compare indices of first unique values
+                if return_indices:  # Compare indices of first unique values
                     assert_equal(sparse_result.pop(), np_result.pop())
 
                 if return_inverse:
@@ -76,12 +76,12 @@ class TestExtract(object):
                     sparse_inv = sparse_result.pop()
                     sparse_recon = np.zeros(np.prod(A.shape), dtype=B.dtype)
                     sparse_recon[sparse_inv[0]] = (
-                        sparse_uniques[sparse_inv[1]]) # don't bother to reshape
+                        sparse_uniques[sparse_inv[1]])  # don't bother w reshape
 
                     np_inv = np_result.pop()
                     np_recon = np_uniques[np_inv]
 
                     assert_equal(sparse_recon, np_recon)
 
-                if return_counts: # Compare counts
+                if return_counts:  # Compare counts
                     assert_equal(sparse_result.pop(), np_result.pop())

--- a/scipy/sparse/tests/test_extract.py
+++ b/scipy/sparse/tests/test_extract.py
@@ -48,23 +48,23 @@ class TestExtract(object):
     def test_unique(self):
         for A in self.cases:
             B = A.toarray()
-            for return_index, return_inverse, return_counts in (
+            for return_indices, return_inverse, return_counts in (
                     product(*([[True, False]] * 3))):
                 sparse_result = list(reversed(extract.unique(
-                    A, return_index, return_inverse, return_counts)))
+                    A, return_indices, return_inverse, return_counts)))
                 np_result = list(reversed(np.unique(
-                    B, return_index, return_inverse, return_counts)))
+                    B, return_indices, return_inverse, return_counts)))
 
                 sparse_uniques = sparse_result.pop()
                 np_uniques = np_result.pop()
                 assert_equal(sparse_uniques, np_uniques)
 
-                if return_index: # Compare indices of first unique values
+                if return_indices: # Compare indices of first unique values
                     assert_equal(sparse_result.pop(), np_result.pop())
 
                 if return_inverse:
                     # Special check for inverse indices, since they have
-                    # different structure. Instead of comparing return values,
+                    # different structures. Instead of comparing return values,
                     # compare the reconstructed matrices.
                     sparse_inverse = sparse_result.pop()
                     sparse_reconstructed = np.zeros(np.prod(A.shape))

--- a/scipy/sparse/tests/test_extract.py
+++ b/scipy/sparse/tests/test_extract.py
@@ -2,11 +2,13 @@
 
 from __future__ import division, print_function, absolute_import
 
+from itertools import product
+
 from numpy.testing import assert_equal
 from scipy.sparse import csr_matrix
 
 import numpy as np
-from scipy.sparse import extract
+from scipy.sparse import extract, spmatrix
 
 
 class TestExtract(object):
@@ -42,3 +44,38 @@ class TestExtract(object):
             B = A.toarray()
             for k in [-3,-2,-1,0,1,2,3]:
                 assert_equal(extract.triu(A,k=k).toarray(), np.triu(B,k=k))
+
+    def test_unique(self):
+        for A in self.cases:
+            B = A.toarray()
+            for return_index, return_inverse, return_counts in (
+                    product(*([[True, False]] * 3))):
+                sparse_result = list(reversed(extract.unique(
+                    A, return_index, return_inverse, return_counts)))
+                np_result = list(reversed(np.unique(
+                    B, return_index, return_inverse, return_counts)))
+
+                sparse_uniques = sparse_result.pop()
+                np_uniques = np_result.pop()
+                assert_equal(sparse_uniques, np_uniques)
+
+                if return_index: # Compare indices of first unique values
+                    assert_equal(sparse_result.pop(), np_result.pop())
+
+                if return_inverse:
+                    # Special check for inverse indices, since they have
+                    # different structure. Instead of comparing return values,
+                    # compare the reconstructed matrices.
+                    sparse_inverse = sparse_result.pop()
+                    sparse_reconstructed = np.zeros(np.prod(A.shape))
+                    sparse_reconstructed[sparse_inverse[0]] = (
+                        sparse_uniques[sparse_inverse[1]])
+                    sparse_reconstructed.reshape(A.shape)
+
+                    np_inverse = np_result.pop()
+                    np_reconstructed = np_uniques[np_inverse]
+
+                    assert_equal(sparse_reconstructed, np_reconstructed)
+
+                if return_counts: # Compare counts
+                    assert_equal(sparse_result.pop(), np_result.pop())

--- a/scipy/sparse/tests/test_extract.py
+++ b/scipy/sparse/tests/test_extract.py
@@ -52,9 +52,9 @@ class TestExtract(object):
             B = A.toarray()
             if NumpyVersion(np.__version__) <= '1.8.2':
                 # return_counts is not compatible with these versions of Numpy.
-                return_counts_options = [False]
+                return_counts_options = [[False]]
             else:
-                return_counts_options = [True, False]
+                return_counts_options = [[True, False]]
 
             for return_indices, return_inverse, return_counts in (
                     product(*([[True, False]] * 2 + return_counts_options))):


### PR DESCRIPTION
I was surprised a while back to find that while there's a [`numpy.unique`](https://docs.scipy.org/doc/numpy/reference/generated/numpy.unique.html) function, there was no equivalent function for sparse SciPy matrices. So I wrote one. :slightly_smiling_face:

After I'd built it for the application I was working on, it was already close to in shape for submission, so I figured I might as well share first and discuss later. Happy to implement any suggested changes, of course.

The basic strategy is to convert to a CSR matrix, run `numpy.unique` on the `.data` attribute of that matrix, and modify the results to account for all the missing zeros.

I had to make one important modification to the `numpy.unique` interface: when returning `unique_inverse`, the indices to reconstruct the original array from the unique array, it doesn't make sense for a sparse matrix to return the indices of all those zeros. Instead, I return a 2 x n array, where the first row gives the linearized indices of the nonzero elements in the original matrix, and the second row gives the indices into the uniques array where those nonzero elements' values can be found.