### PR TITLE
ENH: Basin-hopping changes

### DIFF
--- a/scipy/optimize/_basinhopping.py
+++ b/scipy/optimize/_basinhopping.py
@@ -4,6 +4,7 @@ basinhopping: The basinhopping global optimization algorithm
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
+import math
 from numpy import cos, sin
 import scipy.optimize
 import collections
@@ -303,7 +304,7 @@ class Metropolis(object):
         If new is higher than old, there is a chance it will be accepted,
         less likely for larger differences.
         """
-        w = np.exp(min(0, -(energy_new - energy_old) * self.beta))
+        w = math.exp(min(0, -(energy_new - energy_old) * self.beta))
         rand = self.random_state.rand()
         return w >= rand
 

--- a/scipy/optimize/_basinhopping.py
+++ b/scipy/optimize/_basinhopping.py
@@ -295,7 +295,10 @@ class Metropolis(object):
         Random number generator used for acceptance test
     """
     def __init__(self, T, random_state=None):
-        self.beta = 1.0 / T
+        # Avoid ZeroDivisionError since "MBH can be regarded as a special case
+        # of the BH framework with the Metropolis criterion, where temperature
+        # T = 0."  (Reject all steps that increase energy.)
+        self.beta = 1.0 / T if T != 0 else float('inf')
         self.random_state = check_random_state(random_state)
 
     def accept_reject(self, energy_new, energy_old):
@@ -467,6 +470,9 @@ def basinhopping(func, x0, niter=100, T=1.0, stepsize=0.5,
 
     So, for best results, ``T`` should to be comparable to the typical
     difference in function values between local minima.
+
+    If ``T`` is 0, the algorithm becomes Monotonic Basin-Hopping, in which all
+    steps that increase energy are rejected.
 
     .. versionadded:: 0.12.0
 

--- a/scipy/optimize/_basinhopping.py
+++ b/scipy/optimize/_basinhopping.py
@@ -131,6 +131,9 @@ class BasinHoppingRunner(object):
             if testres == 'force accept':
                 accept = True
                 break
+            elif testres is None:
+                raise ValueError("accept_tests must return True, False, or "
+                                 "'force accept'")
             elif not testres:
                 accept = False
 

--- a/scipy/optimize/_basinhopping.py
+++ b/scipy/optimize/_basinhopping.py
@@ -223,11 +223,11 @@ class AdaptiveStepsize(object):
         old_stepsize = self.takestep.stepsize
         accept_rate = float(self.naccept) / self.nstep
         if accept_rate > self.target_accept_rate:
-            #We're accepting too many steps.  This generally means we're
-            #trapped in a basin.  Take bigger steps
+            # We're accepting too many steps.  This generally means we're
+            # trapped in a basin.  Take bigger steps
             self.takestep.stepsize /= self.factor
         else:
-            #We're not accepting enough steps.  Take smaller steps
+            # We're not accepting enough steps.  Take smaller steps
             self.takestep.stepsize *= self.factor
         if self.verbose:
             print("adaptive stepsize: acceptance rate %f target %f new "
@@ -266,7 +266,8 @@ class RandomDisplacement(object):
         self.random_state = check_random_state(random_state)
 
     def __call__(self, x):
-        x += self.random_state.uniform(-self.stepsize, self.stepsize, np.shape(x))
+        x += self.random_state.uniform(-self.stepsize, self.stepsize,
+                                       np.shape(x))
         return x
 
 
@@ -375,8 +376,8 @@ def basinhopping(func, x0, niter=100, T=1.0, stepsize=0.5,
     callback : callable, ``callback(x, f, accept)``, optional
         A callback function which will be called for all minima found.  ``x``
         and ``f`` are the coordinates and function value of the trial minimum,
-        and ``accept`` is whether or not that minimum was accepted.  This can be
-        used, for example, to save the lowest N minima found.  Also,
+        and ``accept`` is whether or not that minimum was accepted.  This can
+        be used, for example, to save the lowest N minima found.  Also,
         ``callback`` can be used to specify a user defined stop criterion by
         optionally returning True to stop the ``basinhopping`` routine.
     interval : integer, optional
@@ -402,13 +403,13 @@ def basinhopping(func, x0, niter=100, T=1.0, stepsize=0.5,
     Returns
     -------
     res : OptimizeResult
-        The optimization result represented as a ``OptimizeResult`` object.  Important
-        attributes are: ``x`` the solution array, ``fun`` the value of the
-        function at the solution, and ``message`` which describes the cause of
-        the termination. The ``OptimizeResult`` object returned by the selected
-        minimizer at the lowest minimum is also contained within this object
-        and can be accessed through the ``lowest_optimization_result`` attribute.
-        See `OptimizeResult` for a description of other attributes.
+        The optimization result represented as a ``OptimizeResult`` object.
+        Important attributes are: ``x`` the solution array, ``fun`` the value
+        of the function at the solution, and ``message`` which describes the
+        cause of the termination. The ``OptimizeResult`` object returned by the
+        selected minimizer at the lowest minimum is also contained within this
+        object and can be accessed through the ``lowest_optimization_result``
+        attribute.  See `OptimizeResult` for a description of other attributes.
 
     See Also
     --------
@@ -696,6 +697,7 @@ def _test_func2d(x):
     df[0] = -14.5 * sin(14.5 * x[0] - 0.3) + 2. * x[0] + 0.2 + x[1]
     df[1] = -14.5 * sin(14.5 * x[1] - 0.3) + 2. * x[1] + 0.2 + x[0]
     return f, df
+
 
 if __name__ == "__main__":
     print("\n\nminimize a 2d function without gradient")

--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -410,7 +410,7 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
         options = {}
     # check if optional parameters are supported by the selected method
     # - jac
-    if meth in ['nelder-mead', 'powell', 'cobyla'] and bool(jac):
+    if meth in ('nelder-mead', 'powell', 'cobyla') and bool(jac):
         warn('Method %s does not use gradient information (jac).' % method,
              RuntimeWarning)
     # - hess
@@ -424,21 +424,21 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
         warn('Method %s does not use Hessian-vector product '
              'information (hessp).' % method, RuntimeWarning)
     # - constraints or bounds
-    if (meth in ['nelder-mead', 'powell', 'cg', 'bfgs', 'newton-cg', 'dogleg',
-                 'trust-ncg'] and (bounds is not None or np.any(constraints))):
+    if (meth in ('nelder-mead', 'powell', 'cg', 'bfgs', 'newton-cg', 'dogleg',
+                 'trust-ncg') and (bounds is not None or np.any(constraints))):
         warn('Method %s cannot handle constraints nor bounds.' % method,
              RuntimeWarning)
-    if meth in ['l-bfgs-b', 'tnc'] and np.any(constraints):
+    if meth in ('l-bfgs-b', 'tnc') and np.any(constraints):
         warn('Method %s cannot handle constraints.' % method,
              RuntimeWarning)
     if meth == 'cobyla' and bounds is not None:
         warn('Method %s cannot handle bounds.' % method,
              RuntimeWarning)
     # - callback
-    if (meth in ['cobyla'] and callback is not None):
+    if (meth in ('cobyla',) and callback is not None):
         warn('Method %s does not support callback.' % method, RuntimeWarning)
     # - return_all
-    if (meth in ['l-bfgs-b', 'tnc', 'cobyla', 'slsqp'] and
+    if (meth in ('l-bfgs-b', 'tnc', 'cobyla', 'slsqp') and
             options.get('return_all', False)):
         warn('Method %s does not support the return_all option.' % method,
              RuntimeWarning)
@@ -457,14 +457,14 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
         if meth == 'nelder-mead':
             options.setdefault('xatol', tol)
             options.setdefault('fatol', tol)
-        if meth in ['newton-cg', 'powell', 'tnc']:
+        if meth in ('newton-cg', 'powell', 'tnc'):
             options.setdefault('xtol', tol)
-        if meth in ['powell', 'l-bfgs-b', 'tnc', 'slsqp']:
+        if meth in ('powell', 'l-bfgs-b', 'tnc', 'slsqp'):
             options.setdefault('ftol', tol)
-        if meth in ['bfgs', 'cg', 'l-bfgs-b', 'tnc', 'dogleg',
-                    'trust-ncg', 'trust-exact', 'trust-krylov']:
+        if meth in ('bfgs', 'cg', 'l-bfgs-b', 'tnc', 'dogleg',
+                    'trust-ncg', 'trust-exact', 'trust-krylov'):
             options.setdefault('gtol', tol)
-        if meth in ['cobyla', '_custom']:
+        if meth in ('cobyla', '_custom'):
             options.setdefault('tol', tol)
 
     if meth == '_custom':

--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -20,9 +20,9 @@ from scipy._lib.six import callable
 
 # unconstrained minimization
 from .optimize import (_minimize_neldermead, _minimize_powell, _minimize_cg,
-                      _minimize_bfgs, _minimize_newtoncg,
-                      _minimize_scalar_brent, _minimize_scalar_bounded,
-                      _minimize_scalar_golden, MemoizeJac)
+                       _minimize_bfgs, _minimize_newtoncg,
+                       _minimize_scalar_brent, _minimize_scalar_bounded,
+                       _minimize_scalar_golden, MemoizeJac)
 from ._trustregion_dogleg import _minimize_dogleg
 from ._trustregion_ncg import _minimize_trust_ncg
 from ._trustregion_krylov import _minimize_trust_krylov
@@ -422,7 +422,7 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
     if meth not in ('newton-cg', 'dogleg', 'trust-ncg',
                     'trust-krylov', '_custom') and hessp is not None:
         warn('Method %s does not use Hessian-vector product '
-                'information (hessp).' % method, RuntimeWarning)
+             'information (hessp).' % method, RuntimeWarning)
     # - constraints or bounds
     if (meth in ['nelder-mead', 'powell', 'cg', 'bfgs', 'newton-cg', 'dogleg',
                  'trust-ncg'] and (bounds is not None or np.any(constraints))):

--- a/scipy/optimize/tests/test__basinhopping.py
+++ b/scipy/optimize/tests/test__basinhopping.py
@@ -38,6 +38,7 @@ def func2d(x):
     df[1] = 2. * x[1] + 0.2
     return f, df
 
+
 def func2d_easyderiv(x):
     f = 2.0*x[0]**2 + 2.0*x[0]*x[1] + 2.0*x[1]**2 - 6.0*x[0]
     df = np.zeros(2)
@@ -45,6 +46,7 @@ def func2d_easyderiv(x):
     df[1] = 2.0*x[0] + 4.0*x[1]
 
     return f, df
+
 
 class MyTakeStep1(RandomDisplacement):
     """use a copy of displace, but have it set a special parameter to
@@ -60,7 +62,7 @@ class MyTakeStep1(RandomDisplacement):
 
 def myTakeStep2(x):
     """redo RandomDisplacement in function form without the attribute stepsize
-    to make sure still everything works ok
+    to make sure everything still works ok
     """
     s = 0.5
     x += np.random.uniform(-s, s, np.shape(x))
@@ -115,7 +117,7 @@ class TestBasinHopping(object):
         """
         self.x0 = (1.0, [1.0, 1.0])
         self.sol = (-0.195, np.array([-0.195, -0.1]))
-        
+
         self.tol = 3  # number of decimal places
 
         self.niter = 100
@@ -132,10 +134,10 @@ class TestBasinHopping(object):
         i = 1
         # if take_step is passed, it must be callable
         assert_raises(TypeError, basinhopping, func2d, self.x0[i],
-                          take_step=1)
+                      take_step=1)
         # if accept_test is passed, it must be callable
         assert_raises(TypeError, basinhopping, func2d, self.x0[i],
-                          accept_test=1)
+                      accept_test=1)
 
     def test_1d_grad(self):
         # test 1d minimizations with gradient
@@ -176,9 +178,10 @@ class TestBasinHopping(object):
 
         assert_(hasattr(res.lowest_optimization_result, "jac"))
 
-        #in this case, the jacobian is just [df/dx, df/dy]
+        # in this case, the jacobian is just [df/dx, df/dy]
         _, jacobian = func2d_easyderiv(res.x)
-        assert_almost_equal(res.lowest_optimization_result.jac, jacobian, self.tol)
+        assert_almost_equal(res.lowest_optimization_result.jac, jacobian,
+                            self.tol)
 
     def test_2d_nograd(self):
         # test 2d minimizations without gradient
@@ -280,8 +283,8 @@ class TestBasinHopping(object):
     def test_niter_zero(self):
         # gh5915, what happens if you call basinhopping with niter=0
         i = 0
-        res = basinhopping(func1d, self.x0[i], minimizer_kwargs=self.kwargs,
-                           niter=0, disp=self.disp)
+        basinhopping(func1d, self.x0[i], minimizer_kwargs=self.kwargs,
+                     niter=0, disp=self.disp)
 
     def test_seed_reproducibility(self):
         # seed should ensure reproducibility between runs
@@ -404,7 +407,7 @@ class Test_AdaptiveStepsize(object):
         self.ts = RandomDisplacement(stepsize=self.stepsize)
         self.target_accept_rate = 0.5
         self.takestep = AdaptiveStepsize(takestep=self.ts, verbose=False,
-                                          accept_rate=self.target_accept_rate)
+                                         accept_rate=self.target_accept_rate)
 
     def test_adaptive_increase(self):
         # if few steps are rejected, the stepsize should increase
@@ -441,4 +444,3 @@ class Test_AdaptiveStepsize(object):
             self.takestep(x)
             self.takestep.report(False)
         assert_(self.ts.stepsize < self.stepsize)
-


### PR DESCRIPTION
Since https://github.com/scipy/scipy/pull/7819 will involve more work and discussion, I'm submitting some of the smaller (hopefully easy to accept) changes in the meantime.

- Allow T=0 for monotonic basin-hopping (reject all steps to higher energy)
- Use math.exp instead of np.exp since energy will always be a scalar
- Don't create lists of strings just to check membership, use tuples (Logically should be sets, but ~~SciPy still supports Python 2.6 which doesn't have set literals and~~ those might be slower anyway)
- Raise an exception if someone made a mistake and accept_test doesn't return anything
- Reword comments and PEP8 pedantry
