### PR TITLE
TST: spatial: fix test_kdtree class names so that the tests are run

### DIFF
--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -93,7 +93,7 @@ class ConsistencyTests:
         assert_(np.all(d <= d_real*(1+eps)))
 
 
-class test_random(ConsistencyTests):
+class Test_random(ConsistencyTests):
     def setup_method(self):
         self.n = 100
         self.m = 4
@@ -104,13 +104,13 @@ class test_random(ConsistencyTests):
         self.d = 0.2
         self.k = 10
 
-class test_random_far(test_random):
+class Test_random_far(Test_random):
     def setup_method(self):
-        test_random.setUp(self)
+        Test_random.setup_method(self)
         self.x = np.random.randn(self.m)+10
 
 
-class test_small(ConsistencyTests):
+class Test_small(ConsistencyTests):
     def setup_method(self):
         self.data = np.array([[0,0,0],
                               [0,0,1],
@@ -139,37 +139,37 @@ class test_small(ConsistencyTests):
                 ([0.1,0.9],[0,1]))
 
 
-class test_small_nonleaf(test_small):
+class Test_small_nonleaf(Test_small):
     def setup_method(self):
-        test_small.setUp(self)
+        Test_small.setup_method(self)
         self.kdtree = KDTree(self.data,leafsize=1)
 
 
-class test_small_compiled(test_small):
+class Test_small_compiled(Test_small):
     def setup_method(self):
-        test_small.setUp(self)
+        Test_small.setup_method(self)
         self.kdtree = cKDTree(self.data)
 
 
-class test_small_nonleaf_compiled(test_small):
+class Test_small_nonleaf_compiled(Test_small):
     def setup_method(self):
-        test_small.setUp(self)
+        Test_small.setup_method(self)
         self.kdtree = cKDTree(self.data,leafsize=1)
 
 
-class test_random_compiled(test_random):
+class Test_random_compiled(Test_random):
     def setup_method(self):
-        test_random.setUp(self)
+        Test_random.setup_method(self)
         self.kdtree = cKDTree(self.data)
 
 
-class test_random_far_compiled(test_random_far):
+class Test_random_far_compiled(Test_random_far):
     def setup_method(self):
-        test_random_far.setUp(self)
+        Test_random_far.setup_method(self)
         self.kdtree = cKDTree(self.data)
 
 
-class test_vectorization:
+class Test_vectorization:
     def setup_method(self):
         self.data = np.array([[0,0,0],
                               [0,0,1],
@@ -223,7 +223,7 @@ class test_vectorization:
         assert_(isinstance(i[0,0],list))
 
 
-class test_vectorization_compiled:
+class Test_vectorization_compiled:
     def setup_method(self):
         self.data = np.array([[0,0,0],
                               [0,0,1],
@@ -287,7 +287,7 @@ class ball_consistency:
         assert_(np.all(self.distance(self.data[c],self.x,self.p) >= self.d/(1.+self.eps)))
 
 
-class test_random_ball(ball_consistency):
+class Test_random_ball(ball_consistency):
 
     def setup_method(self):
         n = 100
@@ -301,7 +301,7 @@ class test_random_ball(ball_consistency):
         self.d = 0.2
 
 
-class test_random_ball_compiled(ball_consistency):
+class Test_random_ball_compiled(ball_consistency):
 
     def setup_method(self):
         n = 100
@@ -314,7 +314,7 @@ class test_random_ball_compiled(ball_consistency):
         self.eps = 0
         self.d = 0.2
 
-class test_random_ball_compiled_periodic(ball_consistency):
+class Test_random_ball_compiled_periodic(ball_consistency):
     def distance(self, a, b, p):
         return distance_box(a, b, p, 1.0)
 
@@ -347,76 +347,76 @@ class test_random_ball_compiled_periodic(ball_consistency):
         c[l] = False
         assert_(np.all(self.distance(self.data[c],self.x,self.p) >= self.d/(1.+self.eps)))
 
-class test_random_ball_approx(test_random_ball):
+class Test_random_ball_approx(Test_random_ball):
 
     def setup_method(self):
-        test_random_ball.setUp(self)
+        Test_random_ball.setup_method(self)
         self.eps = 0.1
 
 
-class test_random_ball_approx_compiled(test_random_ball_compiled):
+class Test_random_ball_approx_compiled(Test_random_ball_compiled):
 
     def setup_method(self):
-        test_random_ball_compiled.setUp(self)
+        Test_random_ball_compiled.setup_method(self)
         self.eps = 0.1
 
-class test_random_ball_approx_compiled_periodic(test_random_ball_compiled_periodic):
+class Test_random_ball_approx_compiled_periodic(Test_random_ball_compiled_periodic):
 
     def setup_method(self):
-        test_random_ball_compiled_periodic.setUp(self)
+        Test_random_ball_compiled_periodic.setup_method(self)
         self.eps = 0.1
 
 
-class test_random_ball_far(test_random_ball):
+class Test_random_ball_far(Test_random_ball):
 
     def setup_method(self):
-        test_random_ball.setUp(self)
+        Test_random_ball.setup_method(self)
         self.d = 2.
 
 
-class test_random_ball_far_compiled(test_random_ball_compiled):
+class Test_random_ball_far_compiled(Test_random_ball_compiled):
 
     def setup_method(self):
-        test_random_ball_compiled.setUp(self)
+        Test_random_ball_compiled.setup_method(self)
         self.d = 2.
 
-class test_random_ball_far_compiled_periodic(test_random_ball_compiled_periodic):
+class Test_random_ball_far_compiled_periodic(Test_random_ball_compiled_periodic):
 
     def setup_method(self):
-        test_random_ball_compiled_periodic.setUp(self)
+        Test_random_ball_compiled_periodic.setup_method(self)
         self.d = 2.
 
 
-class test_random_ball_l1(test_random_ball):
+class Test_random_ball_l1(Test_random_ball):
 
     def setup_method(self):
-        test_random_ball.setUp(self)
+        Test_random_ball.setup_method(self)
         self.p = 1
 
 
-class test_random_ball_l1_compiled(test_random_ball_compiled):
+class Test_random_ball_l1_compiled(Test_random_ball_compiled):
 
     def setup_method(self):
-        test_random_ball_compiled.setUp(self)
+        Test_random_ball_compiled.setup_method(self)
         self.p = 1
 
-class test_random_ball_l1_compiled_periodic(test_random_ball_compiled_periodic):
+class Test_random_ball_l1_compiled_periodic(Test_random_ball_compiled_periodic):
 
     def setup_method(self):
-        test_random_ball_compiled_periodic.setUp(self)
+        Test_random_ball_compiled_periodic.setup_method(self)
         self.p = 1
 
 
-class test_random_ball_linf(test_random_ball):
+class Test_random_ball_linf(Test_random_ball):
 
     def setup_method(self):
-        test_random_ball.setUp(self)
+        Test_random_ball.setup_method(self)
         self.p = np.inf
 
-class test_random_ball_linf_compiled_periodic(test_random_ball_compiled_periodic):
+class Test_random_ball_linf_compiled_periodic(Test_random_ball_compiled_periodic):
 
     def setup_method(self):
-        test_random_ball_compiled_periodic.setUp(self)
+        Test_random_ball_compiled_periodic.setup_method(self)
         self.p = np.inf
 
 
@@ -481,7 +481,7 @@ class two_trees_consistency:
             assert_(np.all(self.distance(self.data2[c],self.data1[i],self.p) >= self.d/(1.+self.eps)))
 
 
-class test_two_random_trees(two_trees_consistency):
+class Test_two_random_trees(two_trees_consistency):
 
     def setup_method(self):
         n = 50
@@ -496,7 +496,7 @@ class test_two_random_trees(two_trees_consistency):
         self.d = 0.2
 
 
-class test_two_random_trees_compiled(two_trees_consistency):
+class Test_two_random_trees_compiled(two_trees_consistency):
 
     def setup_method(self):
         n = 50
@@ -510,7 +510,7 @@ class test_two_random_trees_compiled(two_trees_consistency):
         self.eps = 0
         self.d = 0.2
 
-class test_two_random_trees_compiled_periodic(two_trees_consistency):
+class Test_two_random_trees_compiled_periodic(two_trees_consistency):
     def distance(self, a, b, p):
         return distance_box(a, b, p, 1.0)
 
@@ -526,47 +526,47 @@ class test_two_random_trees_compiled_periodic(two_trees_consistency):
         self.eps = 0
         self.d = 0.2
 
-class test_two_random_trees_far(test_two_random_trees):
+class Test_two_random_trees_far(Test_two_random_trees):
 
     def setup_method(self):
-        test_two_random_trees.setUp(self)
+        Test_two_random_trees.setup_method(self)
         self.d = 2
 
 
-class test_two_random_trees_far_compiled(test_two_random_trees_compiled):
+class Test_two_random_trees_far_compiled(Test_two_random_trees_compiled):
 
     def setup_method(self):
-        test_two_random_trees_compiled.setUp(self)
+        Test_two_random_trees_compiled.setup_method(self)
         self.d = 2
 
-class test_two_random_trees_far_compiled_periodic(test_two_random_trees_compiled_periodic):
+class Test_two_random_trees_far_compiled_periodic(Test_two_random_trees_compiled_periodic):
 
     def setup_method(self):
-        test_two_random_trees_compiled_periodic.setUp(self)
+        Test_two_random_trees_compiled_periodic.setup_method(self)
         self.d = 2
 
 
-class test_two_random_trees_linf(test_two_random_trees):
+class Test_two_random_trees_linf(Test_two_random_trees):
 
     def setup_method(self):
-        test_two_random_trees.setUp(self)
+        Test_two_random_trees.setup_method(self)
         self.p = np.inf
 
 
-class test_two_random_trees_linf_compiled(test_two_random_trees_compiled):
+class Test_two_random_trees_linf_compiled(Test_two_random_trees_compiled):
 
     def setup_method(self):
-        test_two_random_trees_compiled.setUp(self)
+        Test_two_random_trees_compiled.setup_method(self)
         self.p = np.inf
 
-class test_two_random_trees_linf_compiled_periodic(test_two_random_trees_compiled_periodic):
+class Test_two_random_trees_linf_compiled_periodic(Test_two_random_trees_compiled_periodic):
 
     def setup_method(self):
-        test_two_random_trees_compiled_periodic.setUp(self)
+        Test_two_random_trees_compiled_periodic.setup_method(self)
         self.p = np.inf
 
 
-class test_rectangle:
+class Test_rectangle:
 
     def setup_method(self):
         self.rect = Rectangle([0,0],[1,1])
@@ -634,7 +634,7 @@ class count_neighbors_consistency:
         for r,result in zip(rs, results):
             assert_equal(self.T1.count_neighbors(self.T2, r), result)
 
-class test_count_neighbors(count_neighbors_consistency):
+class Test_count_neighbors(count_neighbors_consistency):
 
     def setup_method(self):
         n = 50
@@ -644,7 +644,7 @@ class test_count_neighbors(count_neighbors_consistency):
         self.T2 = KDTree(np.random.randn(n,m),leafsize=2)
 
 
-class test_count_neighbors_compiled(count_neighbors_consistency):
+class Test_count_neighbors_compiled(count_neighbors_consistency):
 
     def setup_method(self):
         n = 50
@@ -674,7 +674,7 @@ class sparse_distance_matrix_consistency:
         # raises an exception for bug 870 (FIXME: Does it?)
         self.T1.sparse_distance_matrix(self.T1, self.r)
 
-class test_sparse_distance_matrix(sparse_distance_matrix_consistency):
+class Test_sparse_distance_matrix(sparse_distance_matrix_consistency):
 
     def setup_method(self):
         n = 50
@@ -691,7 +691,7 @@ class test_sparse_distance_matrix(sparse_distance_matrix_consistency):
         self.n = n
         self.m = m
 
-class test_sparse_distance_matrix_compiled(sparse_distance_matrix_consistency):
+class Test_sparse_distance_matrix_compiled(sparse_distance_matrix_consistency):
 
     def setup_method(self):
         n = 50


### PR DESCRIPTION
Some test classes in test_kdtree.py did not get run because of having names not starting with `Test`.