### PR TITLE
TST: special: mark a failing hyp2f1 test as xfail

### DIFF
--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -102,11 +102,12 @@ def test_hyp0f1_gh_1609():
 # hyp2f1
 # ------------------------------------------------------------------------------
 
-@check_version(mpmath, '0.14')
+@pytest.mark.xfail(reason="hyp2f1 produces wrong/nonstandard values (gh-7961)")
+@check_version(mpmath, '1.0.0')
 def test_hyp2f1_strange_points():
     pts = [
-        (2, -1, -1, 0.7),
-        (2, -2, -2, 0.7),
+        (2, -1, -1, 0.7),  # expected: 2.4
+        (2, -2, -2, 0.7),  # expected: 3.87
     ]
     kw = dict(eliminate=True)
     dataset = [p + (float(mpmath.hyp2f1(*p, **kw)),) for p in pts]


### PR DESCRIPTION
mpmath prior to 1.0.0 had the same bug, so this wasn't caught before.
Also remove workaround in a test_rf that's not necessary for mpmath>=1.0.0. 

Backport needed...