### PR TITLE
DOC: add a SciPy Code of Conduct.

### DIFF
--- a/doc/source/dev/conduct/code_of_conduct.rst
+++ b/doc/source/dev/conduct/code_of_conduct.rst
@@ -73,27 +73,6 @@ We strive to:
     - Repeated harassment of others. In general, if someone asks you to stop, then stop.
     - Advocating for, or encouraging, any of the above behaviour.
 
-5. Be concise. Keep in mind that what you write once will be read by hundreds
-   of persons. Writing a short email means people can understand the
-   conversation as efficiently as possible. Short emails should always strive
-   to be empathetic, welcoming, friendly and patient. When a long explanation
-   is necessary, consider adding a summary.
-
-6. Try to bring new ideas to a conversation so that each mail adds something
-   unique to the thread, keeping in mind that the rest of the thread still
-   contains the other messages with arguments that have already been made.
-
-7. Try to stay on topic, especially in discussions that are already fairly
-   large.
-
-8. Step down considerately. Members of every project come and go. When somebody
-   leaves or disengages from the project they should tell people they are
-   leaving and take the proper steps to ensure that others can pick up where
-   they left off. In doing so, they should remain respectful of those who
-   continue to participate in the project and should not misrepresent the
-   project's goals or achievements. Likewise, community members should respect
-   any individual's choice to leave the project.
-
 
 Diversity Statement
 -------------------
@@ -128,14 +107,12 @@ and point out this code of conduct. Such messages may be in public or in
 private, whatever is most appropriate. However, regardless of whether the
 message is public or not, it should still adhere to the relevant parts of this
 code of conduct; in particular, it should not be abusive or disrespectful.
+Assume good faith; it is more likely that participants are unaware of their bad
+behaviour than that they intentionally try to degrade the quality of the
+discussion.
 
-If you believe someone is violating this code of conduct, you may reply to them
-and point out this code of conduct. Such messages may be in public or in
-private, whatever is most appropriate. Assume good faith; it is more likely
-that participants are unaware of their bad behaviour than that they
-intentionally try to degrade the quality of the discussion. Should there be
-difficulties in dealing with the situation, you may report your compliance
-issues in confidence to either:
+Should there be difficulties in dealing with the situation, you may report your
+compliance issues in confidence to either:
 
 - The SciPy Code of Conduct Committee, at conduct@TODO (preferred)
   Members of this committee are TODO
@@ -148,6 +125,9 @@ Or alternatively to:
 
 Incident reporting resolution & Code of Conduct enforcement
 -----------------------------------------------------------
+
+*This section summarizes the most important points, more details can be found
+in* :ref:`CoC_reporting_manual`.
 
 All complaints will be reviewed and investigated and will result in a response
 that is deemed necessary and appropriate to the circumstances. The SciPy Code
@@ -164,8 +144,7 @@ high level (for all but the most severe cases) will be:
 4. enforcement via transparent decision by the Code of Conduct Committee (if mediation failed)
 
 The committee will respond to any report as soon as possible, and at most
-within 72 hours.  More details on how reports are handled can be found in
-:ref:`CoC_reporting_manual`.
+within 72 hours.
 
 
 Endnotes

--- a/doc/source/dev/conduct/code_of_conduct.rst
+++ b/doc/source/dev/conduct/code_of_conduct.rst
@@ -95,22 +95,21 @@ in all their interactions and help others to do so as well (see next section).
 Reporting Guidelines
 --------------------
 
-While this code of conduct should be adhered to by participants, we recognize
-that sometimes people may have a bad day, or be unaware of some of the
-guidelines in this code of conduct. Thus, when someone behaves in an
-inappropriate way, you may reply to them and point out this code of conduct.
-Such messages may be in public or in private, whatever is most appropriate.
-However, regardless of whether the message is public or not, it should still
-adhere to the relevant parts of this code of conduct; in particular, it should
-not be abusive or disrespectful.  Assume good faith; it is more likely that
-participants are unaware of their bad behaviour, rather than trying to degrade
-the quality of the discussion.
+We know that it is painfully common for internet communication to start at or
+devolve into obvious and flagrant abuse.  We also recognize that sometimes
+people may have a bad day, or be unaware of some of the guidelines in this Code
+of Conduct. Please keep this in mind when deciding on how to respond to a
+breach of this Code.
 
-Should there be difficulties in dealing with the situation, you may report your
-compliance issues in confidence to either:
+For clearly intentional breaches, report those to the Code of Conduct committee
+(see below). For possibly unintentional breaches, you may reply to the person
+and point out this code of conduct (either in public or in private, whatever is
+most appropriate). If you would prefer not to do that, please feel free to
+report to the Code of Conduct Committee directly, or ask the Committee for
+advice, in confidence.
 
-You can report issues to the SciPy Code of Conduct committee, at conduct@TODO.
-Currently, the committee consists of:
+You can report issues to the SciPy Code of Conduct committee, at
+scipy-conduct@googlegroups.com. Currently, the committee consists of:
 
 - Stefan van der Walt
 - Nathaniel J. Smith
@@ -118,7 +117,7 @@ Currently, the committee consists of:
 
 If your report involves any members of the committee, or if they feel they have
 a conflict of interest in handling it, then they will recuse themselves from
-considering your report.  Alternatively, if for any reason you feel
+considering your report. Alternatively, if for any reason you feel
 uncomfortable making a report to the committee, then you can also contact:
 
 - Chair of the SciPy Steering Committee: Ralf Gommers, or
@@ -137,18 +136,17 @@ of Conduct Committee, and the SciPy Steering Committee (if involved), are
 obligated to protect the identity of the reporter, and to treat the content of
 complaints with confidentiality (unless discussed with the reporter).
 
-There are two tracks of response; the first is for severe and obvious
-breaches, where the communication involves personal threat or violent, sexist
-or racist language.  We will immediately disconnect the originator from Scipy
-communication channels in this case; please see the manual for details.
+In case of severe and obvious breaches, e.g. personal threat or violent, sexist
+or racist language, we will immediately disconnect the originator from Scipy
+communication channels; please see the manual for details.
 
-In cases that are less extreme, the process for acting on any received code of
-conduct violation report will be:
+In cases not involving clear intentional breaches of this code of conduct, the
+process for acting on any received code of conduct violation report will be:
 
 1. acknowledge report is received
 2. reasonable discussion/feedback
-3. mediation (if feedback didn't help)
-4. enforcement via transparent decision by the Code of Conduct Committee (if mediation failed)
+3. mediation (if feedback didn't help, and only if both reporter and reportee agree to this)
+4. enforcement via transparent decision by the Code of Conduct Committee
 
 The committee will respond to any report as soon as possible, and at most
 within 72 hours.

--- a/doc/source/dev/conduct/code_of_conduct.rst
+++ b/doc/source/dev/conduct/code_of_conduct.rst
@@ -129,18 +129,18 @@ Incident reporting resolution & Code of Conduct enforcement
 *This section summarizes the most important points, more details can be found
 in* :ref:`CoC_reporting_manual`.
 
-All complaints will be reviewed and investigated and will result in a response
-that is deemed necessary and appropriate to the circumstances. The SciPy Code
-of Conduct Committee, and the SciPy Steering Committee (if involved), are
-obligated to protect the identity of the reporter, and to treat the content of
-complaints with confidentiality (unless discussed with the reporter).
+We will investigate and respond to all complaints. The SciPy Code of Conduct
+Committee and the SciPy Steering Committee (if involved) will protect the
+identity of the reporter, and treat the content of complaints as confidential
+(unless the reporter agrees otherwise).
 
 In case of severe and obvious breaches, e.g. personal threat or violent, sexist
 or racist language, we will immediately disconnect the originator from SciPy
 communication channels; please see the manual for details.
 
-In cases not involving clear intentional breaches of this code of conduct, the
-process for acting on any received code of conduct violation report will be:
+In cases not involving clear severe and obvious breaches of this code of
+conduct, the process for acting on any received code of conduct violation
+report will be:
 
 1. acknowledge report is received
 2. reasonable discussion/feedback

--- a/doc/source/dev/conduct/code_of_conduct.rst
+++ b/doc/source/dev/conduct/code_of_conduct.rst
@@ -1,0 +1,185 @@
+SciPy Code of Conduct
+=====================
+
+
+Introduction
+------------
+
+This code of conduct applies to all spaces managed by the SciPy project,
+including all public and private mailing lists, issue trackers, wikis, blogs,
+Twitter, and any other communication channel used by our community.  The SciPy
+project does not organise in-person events, however we expect events relevant
+to our community to have a code of conduct similar in spirit to this one.
+
+We expect this code of conduct to be honored by everyone who participates in
+the SciPy community formally or informally, or claims any affiliation with the
+project, in any project-related activities and especially when representing the
+project, in any role.
+
+This code is not exhaustive or complete. It serves to distill our common
+understanding of a collaborative, shared environment and goals. We expect it to
+be followed in spirit as much as in the letter, so that it can enrich all of us
+and the technical community in which we participate.
+
+
+Specific Guidelines
+-------------------
+
+We strive to:
+
+1. Be open. We invite anyone to participate in our community. We preferably use
+   public methods of communication for project-related messages, unless
+   discussing something sensitive. This applies to messages for help or
+   project-related support, too; not only is a public support request much more
+   likely to result in an answer to a question, it also makes sure that any
+   inadvertent mistakes made by people answering will be more easily detected
+   and corrected.
+
+2. Be empathetic, welcoming, friendly, and patient. We work together to resolve
+   conflict, assume good intentions, and do our best to act in an empathetic
+   fashion. We may all experience some frustration from time to time, but we do
+   not allow frustration to turn into a personal attack. A community where
+   people feel uncomfortable or threatened is not a productive one. We should
+   be respectful when dealing with other community members as well as with
+   people outside our community.
+
+3. Be collaborative. Our work will be used by other people, and in turn we will
+   depend on the work of others. When we make something for the benefit of the
+   project, we are willing to explain to others how it works, so that they can
+   build on the work to make it even better. Any decision we make will affect
+   users and colleagues, and we take those consequences seriously when making
+   decisions.
+
+3. Be inquisitive. Nobody knows everything! Asking questions early avoids many
+   problems later, so questions are encouraged, though they may be directed to
+   the appropriate forum. Those who are asked should be responsive and helpful,
+   within the context of our shared goal of improving SciPy project code,
+   documentation and other content.
+
+4. Be careful in the words that we choose. Whether we are participating as
+   professionals or volunteers, we value professionalism in all interactions,
+   and take responsibility for our own speech. Be kind to others. Do not insult
+   or put down other participants. Harassment and other exclusionary behaviour
+   are not acceptable. This includes, but is not limited to:
+
+    - Violent threats or language directed against another person.
+    - Sexist, racist, or otherwise discriminatory jokes and language.
+    - Posting sexually explicit or violent material.
+    - Posting (or threatening to post) other people's personally identifying information ("doxing").
+    - Sharing private content, such as emails sent privately or non-publicly, or unlogged forums such as IRC channel history.
+    - Personal insults, especially those using racist or sexist terms.
+    - Unwelcome sexual attention.
+    - Excessive or unnecessary profanity.
+    - Repeated harassment of others. In general, if someone asks you to stop, then stop.
+    - Advocating for, or encouraging, any of the above behaviour.
+
+5. Be concise. Keep in mind that what you write once will be read by hundreds
+   of persons. Writing a short email means people can understand the
+   conversation as efficiently as possible. Short emails should always strive
+   to be empathetic, welcoming, friendly and patient. When a long explanation
+   is necessary, consider adding a summary.
+
+6. Try to bring new ideas to a conversation so that each mail adds something
+   unique to the thread, keeping in mind that the rest of the thread still
+   contains the other messages with arguments that have already been made.
+
+7. Try to stay on topic, especially in discussions that are already fairly
+   large.
+
+8. Step down considerately. Members of every project come and go. When somebody
+   leaves or disengages from the project they should tell people they are
+   leaving and take the proper steps to ensure that others can pick up where
+   they left off. In doing so, they should remain respectful of those who
+   continue to participate in the project and should not misrepresent the
+   project's goals or achievements. Likewise, community members should respect
+   any individual's choice to leave the project.
+
+
+Diversity Statement
+-------------------
+
+The SciPy project welcomes and encourages participation by everyone. We are
+committed to being a community that everyone feels good about joining. Although
+we may not be able to satisfy everyone, we will always work to treat everyone
+well.
+
+No matter how you identify yourself or how others perceive you: we welcome you.
+Though no list can hope to be comprehensive, we explicitly honour diversity in:
+age, culture, ethnicity, genotype, gender identity or expression, language,
+national origin, neurotype, phenotype, political beliefs, profession, race,
+religion, sexual orientation, socioeconomic status, subculture and technical
+ability.
+
+Though we welcome people fluent in all languages, SciPy development is
+conducted in English.
+
+Standards for behaviour in the SciPy community are detailed in the Code of
+Conduct above. We expect participants in our community to meet these standards
+in all their interactions and to help others to do so as well.
+
+
+Reporting Guidelines
+--------------------
+
+While this code of conduct should be adhered to by participants, we recognize
+that sometimes people may have a bad day, or be unaware of some of the
+guidelines in this code of conduct. When that happens, you may reply to them
+and point out this code of conduct. Such messages may be in public or in
+private, whatever is most appropriate. However, regardless of whether the
+message is public or not, it should still adhere to the relevant parts of this
+code of conduct; in particular, it should not be abusive or disrespectful.
+
+If you believe someone is violating this code of conduct, you may reply to them
+and point out this code of conduct. Such messages may be in public or in
+private, whatever is most appropriate. Assume good faith; it is more likely
+that participants are unaware of their bad behaviour than that they
+intentionally try to degrade the quality of the discussion. Should there be
+difficulties in dealing with the situation, you may report your compliance
+issues in confidence to either:
+
+- The SciPy Code of Conduct Committee, at conduct@TODO (preferred)
+  Members of this committee are TODO
+
+Or alternatively to:
+
+- Chair of the SciPy Steering Committee: Ralf Gommers
+- Executive Director of NumFOCUS: Leah Silen
+
+
+Incident reporting resolution & Code of Conduct enforcement
+-----------------------------------------------------------
+
+All complaints will be reviewed and investigated and will result in a response
+that is deemed necessary and appropriate to the circumstances. The SciPy Code
+of Conduct Committee, and the SciPy Steering Committee (if involved), are
+obligated to maintain confidentiality with regard to the reporter of an
+incident. 
+
+The process for acting on any received code of conduct violation report at a
+high level (for all but the most severe cases) will be:
+
+1. acknowledge report is received
+2. reasonable discussion/feedback
+3. mediation (if feedback didn't help)
+4. enforcement via transparent decision by the Code of Conduct Committee (if mediation failed)
+
+The committee will respond to any report as soon as possible, and at most
+within 72 hours.  More details on how reports are handled can be found in
+:ref:`CoC_reporting_manual`.
+
+
+Endnotes
+--------
+
+This Code defines empathy as "a vicarious participation in the emotions, ideas,
+or opinions of others; the ability to imagine oneself in the condition or
+predicament of another." Empathetic is the adjectival form of empathy.
+
+This statement thanks the following, on which it draws for content and
+inspiration:
+
+- `The Apache Foundation Code of Conduct <https://www.apache.org/foundation/policies/conduct.html>`_
+- `The Contributor Covenant <https://www.contributor-covenant.org/version/1/4/code-of-conduct/>`_
+- `Jupyter Code of Conduct <https://github.com/jupyter/governance/tree/master/conduct>`_
+- `Open Source Guides - Code of Conduct <https://opensource.guide/code-of-conduct/>`_
+

--- a/doc/source/dev/conduct/code_of_conduct.rst
+++ b/doc/source/dev/conduct/code_of_conduct.rst
@@ -8,7 +8,7 @@ Introduction
 This code of conduct applies to all spaces managed by the SciPy project,
 including all public and private mailing lists, issue trackers, wikis, blogs,
 Twitter, and any other communication channel used by our community.  The SciPy
-project does not organise in-person events, however we expect events relevant
+project does not organise in-person events, however we expect events related
 to our community to have a code of conduct similar in spirit to this one.
 
 We expect this code of conduct to be honored by everyone who participates in
@@ -18,8 +18,8 @@ project, in any role.
 
 This code is not exhaustive or complete. It serves to distill our common
 understanding of a collaborative, shared environment and goals. We expect it to
-be followed in spirit as much as in the letter, so that it can enrich all of us
-and the technical community in which we participate.
+be followed in spirit as much as in letter, to create a friendly and productive
+environment that enriches the surrounding community.
 
 
 Specific Guidelines
@@ -31,17 +31,14 @@ We strive to:
    public methods of communication for project-related messages, unless
    discussing something sensitive. This applies to messages for help or
    project-related support, too; not only is a public support request much more
-   likely to result in an answer to a question, it also makes sure that any
-   inadvertent mistakes made by people answering will be more easily detected
-   and corrected.
+   likely to result in an answer to a question, it also ensures that any
+   inadvertent mistakes in answering are more easily detected and corrected.
 
 2. Be empathetic, welcoming, friendly, and patient. We work together to resolve
    conflict, assume good intentions, and do our best to act in an empathetic
    fashion. We may all experience some frustration from time to time, but we do
    not allow frustration to turn into a personal attack. A community where
-   people feel uncomfortable or threatened is not a productive one. We should
-   be respectful when dealing with other community members as well as with
-   people outside our community.
+   people feel uncomfortable or threatened is not a productive one.
 
 3. Be collaborative. Our work will be used by other people, and in turn we will
    depend on the work of others. When we make something for the benefit of the
@@ -69,7 +66,7 @@ We strive to:
     - Sharing private content, such as emails sent privately or non-publicly, or unlogged forums such as IRC channel history.
     - Personal insults, especially those using racist or sexist terms.
     - Unwelcome sexual attention.
-    - Excessive or unnecessary profanity.
+    - Excessive profanity.
     - Repeated harassment of others. In general, if someone asks you to stop, then stop.
     - Advocating for, or encouraging, any of the above behaviour.
 
@@ -78,9 +75,9 @@ Diversity Statement
 -------------------
 
 The SciPy project welcomes and encourages participation by everyone. We are
-committed to being a community that everyone feels good about joining. Although
-we may not be able to satisfy everyone, we will always work to treat everyone
-well.
+committed to being a community that everyone enjoys being part of. Although
+we may not always be able to accommodate each individual's preferences, we try
+our best to treat everyone kindly.
 
 No matter how you identify yourself or how others perceive you: we welcome you.
 Though no list can hope to be comprehensive, we explicitly honour diversity in:
@@ -94,7 +91,8 @@ conducted in English.
 
 Standards for behaviour in the SciPy community are detailed in the Code of
 Conduct above. We expect participants in our community to meet these standards
-in all their interactions and to help others to do so as well.
+in all their interactions and to help others to do so as well (see next
+section).
 
 
 Reporting Guidelines
@@ -102,14 +100,14 @@ Reporting Guidelines
 
 While this code of conduct should be adhered to by participants, we recognize
 that sometimes people may have a bad day, or be unaware of some of the
-guidelines in this code of conduct. When that happens, you may reply to them
-and point out this code of conduct. Such messages may be in public or in
-private, whatever is most appropriate. However, regardless of whether the
-message is public or not, it should still adhere to the relevant parts of this
-code of conduct; in particular, it should not be abusive or disrespectful.
-Assume good faith; it is more likely that participants are unaware of their bad
-behaviour than that they intentionally try to degrade the quality of the
-discussion.
+guidelines in this code of conduct. Thus, when someone behaves in an
+inappropriate way, you may reply to them and point out this code of conduct.
+Such messages may be in public or in private, whatever is most appropriate.
+However, regardless of whether the message is public or not, it should still
+adhere to the relevant parts of this code of conduct; in particular, it should
+not be abusive or disrespectful.  Assume good faith; it is more likely that
+participants are unaware of their bad behaviour, rather than trying to degrade
+the quality of the discussion.
 
 Should there be difficulties in dealing with the situation, you may report your
 compliance issues in confidence to either:
@@ -132,8 +130,8 @@ in* :ref:`CoC_reporting_manual`.
 All complaints will be reviewed and investigated and will result in a response
 that is deemed necessary and appropriate to the circumstances. The SciPy Code
 of Conduct Committee, and the SciPy Steering Committee (if involved), are
-obligated to maintain confidentiality with regard to the reporter of an
-incident. 
+obligated to protect the identity of the reporter, and to treat the content of
+complaints with confidentiality (unless discussed with the reporter).
 
 The process for acting on any received code of conduct violation report at a
 high level (for all but the most severe cases) will be:
@@ -154,8 +152,8 @@ This Code defines empathy as "a vicarious participation in the emotions, ideas,
 or opinions of others; the ability to imagine oneself in the condition or
 predicament of another." Empathetic is the adjectival form of empathy.
 
-This statement thanks the following, on which it draws for content and
-inspiration:
+We are thankful to the groups behind the following documents, from which we
+drew content and inspiration:
 
 - `The Apache Foundation Code of Conduct <https://www.apache.org/foundation/policies/conduct.html>`_
 - `The Contributor Covenant <https://www.contributor-covenant.org/version/1/4/code-of-conduct/>`_

--- a/doc/source/dev/conduct/code_of_conduct.rst
+++ b/doc/source/dev/conduct/code_of_conduct.rst
@@ -8,18 +8,18 @@ Introduction
 This code of conduct applies to all spaces managed by the SciPy project,
 including all public and private mailing lists, issue trackers, wikis, blogs,
 Twitter, and any other communication channel used by our community.  The SciPy
-project does not organise in-person events, however we expect events related
-to our community to have a code of conduct similar in spirit to this one.
+project does not organise in-person events, however events related to our
+community should have a code of conduct similar in spirit to this one.
 
-We expect this code of conduct to be honored by everyone who participates in
+This code of conduct should be honored by everyone who participates in
 the SciPy community formally or informally, or claims any affiliation with the
 project, in any project-related activities and especially when representing the
 project, in any role.
 
 This code is not exhaustive or complete. It serves to distill our common
-understanding of a collaborative, shared environment and goals. We expect it to
-be followed in spirit as much as in letter, to create a friendly and productive
-environment that enriches the surrounding community.
+understanding of a collaborative, shared environment and goals. Please try to
+follow this code in spirit as much as in letter, to create a friendly and
+productive environment that enriches the surrounding community.
 
 
 Specific Guidelines
@@ -27,7 +27,7 @@ Specific Guidelines
 
 We strive to:
 
-1. Be open. We invite anyone to participate in our community. We preferably use
+1. Be open. We invite anyone to participate in our community. We prefer to use
    public methods of communication for project-related messages, unless
    discussing something sensitive. This applies to messages for help or
    project-related support, too; not only is a public support request much more
@@ -35,10 +35,10 @@ We strive to:
    inadvertent mistakes in answering are more easily detected and corrected.
 
 2. Be empathetic, welcoming, friendly, and patient. We work together to resolve
-   conflict, assume good intentions, and do our best to act in an empathetic
-   fashion. We may all experience some frustration from time to time, but we do
-   not allow frustration to turn into a personal attack. A community where
-   people feel uncomfortable or threatened is not a productive one.
+   conflict, and assume good intentions. We may all experience some frustration
+   from time to time, but we do not allow frustration to turn into a personal
+   attack. A community where people feel uncomfortable or threatened is not a
+   productive one.
 
 3. Be collaborative. Our work will be used by other people, and in turn we will
    depend on the work of others. When we make something for the benefit of the
@@ -47,26 +47,24 @@ We strive to:
    users and colleagues, and we take those consequences seriously when making
    decisions.
 
-3. Be inquisitive. Nobody knows everything! Asking questions early avoids many
-   problems later, so questions are encouraged, though they may be directed to
-   the appropriate forum. Those who are asked should be responsive and helpful,
-   within the context of our shared goal of improving SciPy project code,
-   documentation and other content.
+4. Be inquisitive. Nobody knows everything! Asking questions early avoids many
+   problems later, so we encourage questions, although we may direct them to
+   the appropriate forum. We will try hard to be responsive and helpful.
 
-4. Be careful in the words that we choose. Whether we are participating as
-   professionals or volunteers, we value professionalism in all interactions,
-   and take responsibility for our own speech. Be kind to others. Do not insult
-   or put down other participants. Harassment and other exclusionary behaviour
-   are not acceptable. This includes, but is not limited to:
+5. Be careful in the words that we choose.  We are careful and respectful in
+   our communication and we take responsibility for our own speech. Be kind to
+   others. Do not insult or put down other participants.  We will not accept
+   harassment or other exclusionary behaviour. This includes, but is not
+   limited to:
 
     - Violent threats or language directed against another person.
     - Sexist, racist, or otherwise discriminatory jokes and language.
     - Posting sexually explicit or violent material.
     - Posting (or threatening to post) other people's personally identifying information ("doxing").
-    - Sharing private content, such as emails sent privately or non-publicly, or unlogged forums such as IRC channel history.
+    - Sharing private content, such as emails sent privately or non-publicly, or unlogged forums such as IRC channel history, without the sender's consent.
     - Personal insults, especially those using racist or sexist terms.
     - Unwelcome sexual attention.
-    - Excessive profanity.
+    - Excessive profanity. Please avoid swearwords; people differ greatly in their sensitivity to swearing.
     - Repeated harassment of others. In general, if someone asks you to stop, then stop.
     - Advocating for, or encouraging, any of the above behaviour.
 
@@ -90,9 +88,8 @@ Though we welcome people fluent in all languages, SciPy development is
 conducted in English.
 
 Standards for behaviour in the SciPy community are detailed in the Code of
-Conduct above. We expect participants in our community to meet these standards
-in all their interactions and to help others to do so as well (see next
-section).
+Conduct above. Participants in our community should uphold these standards
+in all their interactions and help others to do so as well (see next section).
 
 
 Reporting Guidelines
@@ -112,12 +109,19 @@ the quality of the discussion.
 Should there be difficulties in dealing with the situation, you may report your
 compliance issues in confidence to either:
 
-- The SciPy Code of Conduct Committee, at conduct@TODO (preferred)
-  Members of this committee are TODO
+You can report issues to the SciPy Code of Conduct committee, at conduct@TODO.
+Currently, the committee consists of:
 
-Or alternatively to:
+- Stefan van der Walt
+- Nathaniel J. Smith
+- Ralf Gommers
 
-- Chair of the SciPy Steering Committee: Ralf Gommers
+If your report involves any members of the committee, or if they feel they have
+a conflict of interest in handling it, then they will recuse themselves from
+considering your report.  Alternatively, if for any reason you feel
+uncomfortable making a report to the committee, then you can also contact:
+
+- Chair of the SciPy Steering Committee: Ralf Gommers, or
 - Executive Director of NumFOCUS: Leah Silen
 
 
@@ -147,10 +151,6 @@ within 72 hours.
 
 Endnotes
 --------
-
-This Code defines empathy as "a vicarious participation in the emotions, ideas,
-or opinions of others; the ability to imagine oneself in the condition or
-predicament of another." Empathetic is the adjectival form of empathy.
 
 We are thankful to the groups behind the following documents, from which we
 drew content and inspiration:

--- a/doc/source/dev/conduct/code_of_conduct.rst
+++ b/doc/source/dev/conduct/code_of_conduct.rst
@@ -137,8 +137,13 @@ of Conduct Committee, and the SciPy Steering Committee (if involved), are
 obligated to protect the identity of the reporter, and to treat the content of
 complaints with confidentiality (unless discussed with the reporter).
 
-The process for acting on any received code of conduct violation report at a
-high level (for all but the most severe cases) will be:
+There are two tracks of response; the first is for severe and obvious
+breaches, where the communication involves personal threat or violent, sexist
+or racist language.  We will immediately disconnect the originator from Scipy
+communication channels in this case; please see the manual for details.
+
+In cases that are less extreme, the process for acting on any received code of
+conduct violation report will be:
 
 1. acknowledge report is received
 2. reasonable discussion/feedback

--- a/doc/source/dev/conduct/code_of_conduct.rst
+++ b/doc/source/dev/conduct/code_of_conduct.rst
@@ -54,8 +54,7 @@ We strive to:
 5. Be careful in the words that we choose.  We are careful and respectful in
    our communication and we take responsibility for our own speech. Be kind to
    others. Do not insult or put down other participants.  We will not accept
-   harassment or other exclusionary behaviour. This includes, but is not
-   limited to:
+   harassment or other exclusionary behaviour, such as:
 
     - Violent threats or language directed against another person.
     - Sexist, racist, or otherwise discriminatory jokes and language.
@@ -137,7 +136,7 @@ obligated to protect the identity of the reporter, and to treat the content of
 complaints with confidentiality (unless discussed with the reporter).
 
 In case of severe and obvious breaches, e.g. personal threat or violent, sexist
-or racist language, we will immediately disconnect the originator from Scipy
+or racist language, we will immediately disconnect the originator from SciPy
 communication channels; please see the manual for details.
 
 In cases not involving clear intentional breaches of this code of conduct, the
@@ -146,7 +145,8 @@ process for acting on any received code of conduct violation report will be:
 1. acknowledge report is received
 2. reasonable discussion/feedback
 3. mediation (if feedback didn't help, and only if both reporter and reportee agree to this)
-4. enforcement via transparent decision by the Code of Conduct Committee
+4. enforcement via transparent decision (see :ref:`CoC_resolutions`) by the
+   Code of Conduct Committee
 
 The committee will respond to any report as soon as possible, and at most
 within 72 hours.

--- a/doc/source/dev/conduct/report_handling_manual.rst
+++ b/doc/source/dev/conduct/report_handling_manual.rst
@@ -1,0 +1,171 @@
+.. label: CoC_reporting_manual
+
+SciPy Code of Conduct - How to follow up on a report
+----------------------------------------------------
+
+This is the manual followed by SciPy's Code of Conduct Committee. It's used
+when we respond to an issue to make sure we're consistent and fair.
+
+Enforcing the Code of Conduct impacts our community today and for the future.
+It's an action that we do not take lightly. When reviewing enforcement
+measures, the Code of Conduct Committee will keep the following values and
+guidelines in mind:
+
+* Act in a personal manner rather than impersonal.  The Committee can engage
+  the parties to understand the situation, while respecting the privacy and any
+  necessary confidentiality of reporters.  However, sometimes it is necessary
+  to communicate with one or more individuals directly: the Committee's goal is
+  to improve the health of our community rather than only produce a formal
+  decision.
+
+* Emphasize empathy for individuals rather than judging behavior, avoiding
+  binary labels of "good" and "bad/evil". Overt, clear-cut aggression and
+  harassment exists and will be addressed unambiguously.  But many scenarios
+  that can prove challenging to resolve are those where normal disagreements
+  devolve into inappropriate behavior from multiple parties.  Understanding the
+  full context and finding a path that re-engages all is hard, but ultimately
+  the most productive for our community.
+
+* Help increase engagement in good discussion practice: try to identify where
+  discussion may have broken down and provide actionable information, pointers
+  and resources that can help enact positive change on these points.
+
+* Be mindful of the needs of new members: provide them with explicit support
+  and consideration, with the aim of increasing participation from
+  underrepresented groups in particular.
+
+* Individuals come from different cultural backgrounds and native languages.
+  While lack of intent to harm is not an excuse, try to identify any honest
+  misunderstandings caused by a non-native speaker and help them understand the
+  issue and how to change.  Complex discussion in a foreign language can be
+  very intimidating, and we want to grow our diversity also across
+  nationalities and cultures.
+
+
+*Mediation*: voluntary, informal mediation is a tool at our disposal.  In
+contexts such as when two or more parties have all escalated to the point of
+inappropriate behavior (something sadly common in human conflict), it may be
+useful to facilitate a mediation process. This is only an example: the
+Committee can consider mediation in any case, mindful that the process is meant
+to be strictly voluntary and no party can be pressured to participate. If the
+Committee suggests mediation, it should:
+
+* Find a candidate who can serve as a mediator.
+* Obtain the agreement of the reporter(s). The reporter(s) have complete
+  freedom to decline the mediation idea, or to propose an alternate mediator.
+* Obtain the agreement of the reported person(s).
+* Settle on the mediator: while parties can propose a different mediator than
+  the suggested candidate, only if common agreement is reached on all terms can
+  the process move forward.
+* Establish a timeline for mediation to complete, ideally within two weeks.
+
+The mediator will engage with all the parties and seek a resolution that is
+satisfactory to all.  Upon completion, the mediator will provide a report
+(vetted by all parties to the process) to the Committee, with recommendations
+on further steps.  The Committee will then evaluate these results (whether
+satisfactory resolution was achieved or not) and decide on any additional
+action deemed necessary.
+
+
+How the committee will respond to reports
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When a report is sent to the committee they will immediately reply to the
+reporter to confirm receipt. This reply must be sent within 72 hours, and the
+group should strive to respond much quicker than that.
+
+If a report doesn't contain enough information, the committee will obtain all
+relevant data before acting. The committee is empowered to act on the Steering
+Council’s behalf in contacting any individuals involved to get a more complete
+account of events.
+
+The committee will then review the incident and determine, to the best of their
+ability:
+
+* What happened.
+* Whether this event constitutes a Code of Conduct violation.
+* Who are the responsible party(ies).
+* Whether this is an ongoing situation, and there is a threat to anyone's
+  physical safety.
+
+This information will be collected in writing, and whenever possible the
+group's deliberations will be recorded and retained (i.e. chat transcripts,
+email discussions, recorded conference calls, summaries of voice conversations,
+etc).
+
+It is important to retain an archive of all activities of this committee to
+ensure consistency in behavior and provide institutional memory for the
+project.  To assist in this, the default channel of discussion for this
+committee will be a private mailing list accessible to current and future
+members of the committee as well as members of the Steering Council upon
+justified request. If the Committee finds the need to use off-list
+communications (e.g. phone calls for early/rapid response), it should in all
+cases summarize these back to the list so there's a good record of the process.
+
+The Code of Conduct Committee should aim to have a resolution agreed upon within
+two weeks. In the event that a resolution can't be determined in that time, the
+committee will respond to the reporter(s) with an update and projected timeline
+for resolution.
+
+
+Resolutions
+~~~~~~~~~~~
+
+The committee must agree on a resolution by consensus. If the group cannot reach
+consensus and deadlocks for over a week, the group will turn the matter over to
+the Steering Council for resolution.
+
+
+Possible responses may include:
+
+* Taking no further action
+  - if we determine no violations have occurred.
+  - if the matter has been resolved publicly while the committee was
+    considering responses.
+* Coordinating voluntary mediation: if all involved parties agree, the
+  Committee may facilitate a mediation process as detailed above.
+* Remind publicly, and point out that some behavior/actions/language have been
+  judged inappropriate and why in the current context, or can but hurtful to
+  some people, requesting the community to self-adjust.
+* A private reprimand from the committee to the individual(s) involved. In this
+  case, the group chair will deliver that reprimand to the individual(s) over
+  email, cc'ing the group.
+* A public reprimand. In this case, the committee chair will deliver that
+  reprimand in the same venue that the violation occurred, within the limits of
+  practicality. E.g., the original mailing list for an email violation, but
+  for a chat room discussion where the person/context may be gone, they can be
+  reached by other means. The group may choose to publish this message
+  elsewhere for documentation purposes.
+* A request for a public or private apology, assuming the reporter agrees to
+  this idea: they may at their discretion refuse further contact with the
+  violator. The chair will deliver this request. The committee may, if it
+  chooses, attach "strings" to this request: for example, the group may ask a
+  violator to apologize in order to retain one’s membership on a mailing list.
+* A "mutually agreed upon hiatus" where the committee asks the individual to
+  temporarily refrain from community participation. If the individual chooses
+  not to take a temporary break voluntarily, the committee may issue a
+  "mandatory cooling off period".
+* A permanent or temporary ban from some or all SciPy spaces (mailing lists,
+  gitter.im, etc.). The group will maintain records of all such bans so that
+  they may be reviewed in the future or otherwise maintained.
+
+Once a resolution is agreed upon, but before it is enacted, the committee will
+contact the original reporter and any other affected parties and explain the
+proposed resolution. The committee will ask if this resolution is acceptable,
+and must note feedback for the record. However, the committee is not required to
+act on this feedback.
+
+Finally, the committee will make a report to the SciPy Steering Council (as
+well as the SciPy core team in the event of an ongoing resolution, such as a
+ban).
+
+The committee will never publicly discuss the issue; all public statements will
+be made by the chair of the Code of Conduct Committee or the SciPy Steering
+Council.
+
+
+Conflicts of Interest
+~~~~~~~~~~~~~~~~~~~~~
+
+In the event of any conflict of interest, a committee member must immediately
+notify the other members, and recuse themselves if necessary.

--- a/doc/source/dev/conduct/report_handling_manual.rst
+++ b/doc/source/dev/conduct/report_handling_manual.rst
@@ -1,4 +1,4 @@
-.. label: CoC_reporting_manual
+.. _CoC_reporting_manual:
 
 SciPy Code of Conduct - How to follow up on a report
 ----------------------------------------------------
@@ -119,9 +119,10 @@ the Steering Council for resolution.
 Possible responses may include:
 
 * Taking no further action
+
   - if we determine no violations have occurred.
-  - if the matter has been resolved publicly while the committee was
-    considering responses.
+  - if the matter has been resolved publicly while the committee was considering responses.
+
 * Coordinating voluntary mediation: if all involved parties agree, the
   Committee may facilitate a mediation process as detailed above.
 * Remind publicly, and point out that some behavior/actions/language have been

--- a/doc/source/dev/conduct/report_handling_manual.rst
+++ b/doc/source/dev/conduct/report_handling_manual.rst
@@ -83,48 +83,48 @@ action deemed necessary.
 How the committee will respond to reports
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-There are two tracks of response; one is specific to clear and severe breaches
-(as defined below).
+When the committee (or a committee member) receives a report, they will first
+determine whether the report is about a clear and severe breach (as defined
+below).  If so, immediate action needs to be taken in addition to the regular
+report handling process.
 
-Clear and severe breach
-+++++++++++++++++++++++
+Clear and severe breach actions
++++++++++++++++++++++++++++++++
 
 We know that it is painfully common for internet communication to start at or
-devolve into obvious and flagrant abuse.  We define a clear and severe breach
-as being: personal threats, violent, sexist or racist language.
+devolve into obvious and flagrant abuse.  We will deal quickly with clear and
+severe breaches like personal threats, violent, sexist or racist language.
 
-In what follows, we define a Scipy contributor as someone who has done any of
+In what follows, we define a SciPy contributor as someone who has done any of
 the following, at least a week prior to the incident in question:
 
-* sent more than one substantial email to the mailing list;
+* sent at least one substantial email to the mailing list;
 * submitted a substantial pull request;
 * submitted a substantial issue report.
 
-If any member sees a communication that qualifies as a personal threat, or
-violent, sexist or racist language, we ask them to contact a member of the
-Code of Conduct Committee immediately, via the conduct@email, and / or via
-their personal email addresses.  When a member of the committee becomes aware
-of such a communication, they will do the following:
+When a member of the Code of Conduct committee becomes aware of a clear and
+severe breach, they will do the following:
 
-* Immediately disconnect the originator from all Scipy communication channels.
+* Immediately disconnect the originator from all SciPy communication channels.
+* Reply to the reporter that their report has been received and that the
+  originator has been disconnected.
 * If the originator appears to be a previous contributor, the moderator may
   try to contact the contributor by some other means to check whether their
   account has been hacked.
 * If the originator is in fact a previous contributor, and the contributor
-  wants to be reconnected to the Scipy channels, then the acting moderator may
+  wants to be reconnected to the SciPy channels, then the acting moderator may
   consider some cooling off period, an agreement not to repeat the behavior,
   and email moderation.  A previous contributor also has the right to an
   appeal to the code of conduct committee.
 * In every case, the moderator should make a reasonable effort to contact the
-  originator, and tell them specifically how their language qualifies as
-  "personal threat, violent, racist or sexist language", and they should copy
-  this explanation to the Code of Conduct Committee.  The Code of Conduct
-  Committee will formally review and sign off on these cases every year to
-  make sure this mechanism is not being used to control ordinary heated
-  disagreement.
+  originator, and tell them specifically how their language or actions
+  qualifies as a "clear and severe breach", and they should copy this
+  explanation to the Code of Conduct Committee.  The Code of Conduct Committee
+  will formally review and sign off on these cases to make sure this mechanism
+  is not being used to control ordinary heated disagreement.
 
-Other breaches
-++++++++++++++
+Report handling
++++++++++++++++
 
 When a report is sent to the committee they will immediately reply to the
 reporter to confirm receipt. This reply must be sent within 72 hours, and the

--- a/doc/source/dev/conduct/report_handling_manual.rst
+++ b/doc/source/dev/conduct/report_handling_manual.rst
@@ -26,6 +26,21 @@ guidelines in mind:
   Understanding the full context and finding a path that re-engages all is
   hard, but ultimately the most productive for our community.
 
+* We understand that email is a difficult medium and can be isolating.
+  Receiving criticism over email, without personal contact, can be
+  particularly painful.  This makes it especially important to keep an
+  atmosphere of open-minded respect of the views of others.  It also means
+  that we must be transparent in our actions, and that we will do everything
+  in our power to make sure that all our members are treated fairly and with
+  sympathy.
+
+* Discrimination can be subtle and it can be unconscious. It can show itself
+  as unfairness and hostility in otherwise ordinary interactions.  We know
+  that this does occur, and we will take care to look out for it.  We would
+  very much like to hear from you if you feel you have been treated unfairly,
+  and we will use these procedures to make sure that your complaint is heard
+  and addressed.
+
 * Help increase engagement in good discussion practice: try to identify where
   discussion may have broken down and provide actionable information, pointers
   and resources that can lead to positive change on these points.
@@ -39,7 +54,6 @@ guidelines in mind:
   and help them understand the issue and what they can change to avoid causing
   offence.  Complex discussion in a foreign language can be very intimidating,
   and we want to grow our diversity also across nationalities and cultures.
-
 
 *Mediation*: voluntary, informal mediation is a tool at our disposal.  In
 contexts such as when two or more parties have all escalated to the point of
@@ -68,6 +82,49 @@ action deemed necessary.
 
 How the committee will respond to reports
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+There are two tracks of response; one is specific to clear and severe breaches
+(as defined below).
+
+Clear and severe breach
++++++++++++++++++++++++
+
+We know that it is painfully common for internet communication to start at or
+devolve into obvious and flagrant abuse.  We define a clear and severe breach
+as being: personal threats, violent, sexist or racist language.
+
+In what follows, we define a Scipy contributor as someone who has done any of
+the following, at least a week prior to the incident in question:
+
+* sent more than one substantial email to the mailing list;
+* submitted a substantial pull request;
+* submitted a substantial issue report.
+
+If any member sees a communication that qualifies as a personal threat, or
+violent, sexist or racist language, we ask them to contact a member of the
+Code of Conduct Committee immediately, via the conduct@email, and / or via
+their personal email addresses.  When a member of the committee becomes aware
+of such a communication, they will do the following:
+
+* Immediately disconnect the originator from all Scipy communication channels.
+* If the originator appears to be a previous contributor, the moderator may
+  try to contact the contributor by some other means to check whether their
+  account has been hacked.
+* If the originator is in fact a previous contributor, and the contributor
+  wants to be reconnected to the Scipy channels, then the acting moderator may
+  consider some cooling off period, an agreement not to repeat the behavior,
+  and email moderation.  A previous contributor also has the right to an
+  appeal to the code of conduct committee.
+* In every case, the moderator should make a reasonable effort to contact the
+  originator, and tell them specifically how their language qualifies as
+  "personal threat, violent, racist or sexist language", and they should copy
+  this explanation to the Code of Conduct Committee.  The Code of Conduct
+  Committee will formally review and sign off on these cases every year to
+  make sure this mechanism is not being used to control ordinary heated
+  disagreement.
+
+Other breaches
+++++++++++++++
 
 When a report is sent to the committee they will immediately reply to the
 reporter to confirm receipt. This reply must be sent within 72 hours, and the

--- a/doc/source/dev/conduct/report_handling_manual.rst
+++ b/doc/source/dev/conduct/report_handling_manual.rst
@@ -103,7 +103,7 @@ severe breach, they will do the following:
   originator has been disconnected.
 * In every case, the moderator should make a reasonable effort to contact the
   originator, and tell them specifically how their language or actions
-  qualifies as a "clear and severe breach".  The moderator should also say
+  qualify as a "clear and severe breach".  The moderator should also say
   that, if the originator believes this is unfair or they want to be
   reconnected to SciPy, they have the right to ask for a review, as below, by
   the Code of Conduct Committee.

--- a/doc/source/dev/conduct/report_handling_manual.rst
+++ b/doc/source/dev/conduct/report_handling_manual.rst
@@ -20,26 +20,25 @@ guidelines in mind:
 
 * Emphasize empathy for individuals rather than judging behavior, avoiding
   binary labels of "good" and "bad/evil". Overt, clear-cut aggression and
-  harassment exists and will be addressed unambiguously.  But many scenarios
+  harassment exists and we will be address that firmly.  But many scenarios
   that can prove challenging to resolve are those where normal disagreements
-  devolve into inappropriate behavior from multiple parties.  Understanding the
-  full context and finding a path that re-engages all is hard, but ultimately
-  the most productive for our community.
+  devolve into unhelpful or harmful behavior from multiple parties.
+  Understanding the full context and finding a path that re-engages all is
+  hard, but ultimately the most productive for our community.
 
 * Help increase engagement in good discussion practice: try to identify where
   discussion may have broken down and provide actionable information, pointers
-  and resources that can help enact positive change on these points.
+  and resources that can lead to positive change on these points.
 
 * Be mindful of the needs of new members: provide them with explicit support
   and consideration, with the aim of increasing participation from
   underrepresented groups in particular.
 
 * Individuals come from different cultural backgrounds and native languages.
-  While lack of intent to harm is not an excuse, try to identify any honest
-  misunderstandings caused by a non-native speaker and help them understand the
-  issue and how to change.  Complex discussion in a foreign language can be
-  very intimidating, and we want to grow our diversity also across
-  nationalities and cultures.
+  Try to identify any honest misunderstandings caused by a non-native speaker
+  and help them understand the issue and what they can change to avoid causing
+  offence.  Complex discussion in a foreign language can be very intimidating,
+  and we want to grow our diversity also across nationalities and cultures.
 
 
 *Mediation*: voluntary, informal mediation is a tool at our disposal.  In

--- a/doc/source/dev/conduct/report_handling_manual.rst
+++ b/doc/source/dev/conduct/report_handling_manual.rst
@@ -153,8 +153,7 @@ Possible responses may include:
 Once a resolution is agreed upon, but before it is enacted, the committee will
 contact the original reporter and any other affected parties and explain the
 proposed resolution. The committee will ask if this resolution is acceptable,
-and must note feedback for the record. However, the committee is not required to
-act on this feedback.
+and must note feedback for the record.
 
 Finally, the committee will make a report to the SciPy Steering Council (as
 well as the SciPy core team in the event of an ongoing resolution, such as a

--- a/doc/source/dev/conduct/report_handling_manual.rst
+++ b/doc/source/dev/conduct/report_handling_manual.rst
@@ -95,33 +95,22 @@ We know that it is painfully common for internet communication to start at or
 devolve into obvious and flagrant abuse.  We will deal quickly with clear and
 severe breaches like personal threats, violent, sexist or racist language.
 
-In what follows, we define a SciPy contributor as someone who has done any of
-the following, at least a week prior to the incident in question:
-
-* sent at least one substantial email to the mailing list;
-* submitted a substantial pull request;
-* submitted a substantial issue report.
-
 When a member of the Code of Conduct committee becomes aware of a clear and
 severe breach, they will do the following:
 
 * Immediately disconnect the originator from all SciPy communication channels.
 * Reply to the reporter that their report has been received and that the
   originator has been disconnected.
-* If the originator appears to be a previous contributor, the moderator may
-  try to contact the contributor by some other means to check whether their
-  account has been hacked.
-* If the originator is in fact a previous contributor, and the contributor
-  wants to be reconnected to the SciPy channels, then the acting moderator may
-  consider some cooling off period, an agreement not to repeat the behavior,
-  and email moderation.  A previous contributor also has the right to an
-  appeal to the code of conduct committee.
 * In every case, the moderator should make a reasonable effort to contact the
   originator, and tell them specifically how their language or actions
-  qualifies as a "clear and severe breach", and they should copy this
-  explanation to the Code of Conduct Committee.  The Code of Conduct Committee
-  will formally review and sign off on these cases to make sure this mechanism
-  is not being used to control ordinary heated disagreement.
+  qualifies as a "clear and severe breach".  The moderator should also say
+  that, if the originator believes this is unfair or they want to be
+  reconnected to SciPy, they have the right to ask for a review, as below, by
+  the Code of Conduct Committee.
+  The moderator should copy this explanation to the Code of Conduct Committee.
+* The Code of Conduct Committee will formally review and sign off on all cases
+  where this mechanism has been applied to make sure it is not being used to
+  control ordinary heated disagreement.
 
 Report handling
 +++++++++++++++
@@ -163,6 +152,8 @@ two weeks. In the event that a resolution can't be determined in that time, the
 committee will respond to the reporter(s) with an update and projected timeline
 for resolution.
 
+
+.. _CoC_resolutions:
 
 Resolutions
 ~~~~~~~~~~~

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -33,6 +33,7 @@ maintenance activities and policies.
 .. toctree::
    :maxdepth: 1
 
+   dev/conduct/code_of_conduct
    hacking
    dev/index
    dev/governance/governance


### PR DESCRIPTION
This code of conduct has been discussed on the mailing list so far (https://mail.python.org/pipermail/scipy-dev/2017-September/022100.html). It starts with an adaptation of the Apache CoC. The later bits about reporting and handling reports are derived from the Contributor Covenant and the Jupyter CoC.