### PR TITLE
QUADPACK Errors - human friendly errors to replace 'Invalid Input'

### DIFF
--- a/scipy/integrate/quadpack.py
+++ b/scipy/integrate/quadpack.py
@@ -66,11 +66,11 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
             double func(int n, double *xx, void *user_data)
 
         The ``user_data`` is the data contained in the `scipy.LowLevelCallable`.
-        In the call forms with ``xx``,  ``n`` is the length of the ``xx`` 
+        In the call forms with ``xx``,  ``n`` is the length of the ``xx``
         array which contains ``xx[0] == x`` and the rest of the items are
         numbers contained in the ``args`` argument of quad.
 
-        In addition, certain ctypes call signatures are supported for 
+        In addition, certain ctypes call signatures are supported for
         backward compatibility, but those should not be used in new code.
     a : float
         Lower limit of integration (use -numpy.inf for -infinity).
@@ -363,8 +363,40 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
         else:
             warnings.warn(msg, IntegrationWarning)
             return retval[:-1]
-    else:
-        raise ValueError(msg)
+
+    elif ier == 6: # Forensic decision tree when QUADPACK throws ier=6
+        if epsabs <= 0: #Small error tolerance - applies to all methods
+            if epsrel <= 50 * sys.float_info.epsilon or epsrel < 5e-29:
+                msg =- "If ``errabs<=0``, `epsrel` must be greater than both 5e-29 and 50*(machine epsilon)."
+            elif weight in ['sin','cos'] and (abs(a) + abs(b) == Inf):
+                msg = "sin- or cos- weighted intergals with infinite bounds must have ``epsabs>0``."
+
+        elif weight is None:
+            if points is None: #QAGSE/QAGIE
+                msg = "Number of subintervals `limit` must be >=1."
+            else: #QAGPE
+                if max(points) > max(a,b) or min(points) < min(a,b):
+                    msg = "All break points in `points` must lie within the integration bonds."
+                elif len(points) >= limit:
+                    msg = "Number of break points ({:d}) must be less than subinterval limit ({:d})".format(len(points), limit)
+
+        else:
+            if maxp1 < 1:
+                msg = "Chebyshev moment limit `maxp1` must be >=1."
+
+            elif weight in ('cos','sin') and abs(a+b) == Inf: #QAWFE
+                msg = "`limlst` must be >=3."
+            
+            elif weight[:3] == 'alg':#QAWSE
+                if min(wvar) < -1:
+                    msg = "`wvar` parameters ``(alpha,beta)`` must both be >= -1."
+                if b<a:
+                    msg = "Integration limits `a`,`b` must satistfy ``a<b``."
+            
+            elif weight == 'cauchy' and wvar in (a,b):
+                msg = "Parameter `wvar` must not equal integration limits `a` or `b`."
+
+    raise ValueError(msg)
 
 
 def _quad(func,a,b,args,full_output,epsabs,epsrel,limit,points):
@@ -399,7 +431,6 @@ def _quad(func,a,b,args,full_output,epsabs,epsrel,limit,points):
 
 
 def _quad_weight(func,a,b,args,full_output,epsabs,epsrel,limlst,limit,maxp1,weight,wvar,wopts):
-
     if weight not in ['cos','sin','alg','alg-loga','alg-logb','alg-log','cauchy']:
         raise ValueError("%s not a recognized weighting function." % weight)
 
@@ -502,7 +533,7 @@ def dblquad(func, a, b, gfun, hfun, args=(), epsabs=1.49e-8, epsrel=1.49e-8):
     """
     def temp_ranges(*args):
         return [gfun(args[0]), hfun(args[0])]
-    return nquad(func, [temp_ranges, [a, b]], args=args, 
+    return nquad(func, [temp_ranges, [a, b]], args=args,
             opts={"epsabs": epsabs, "epsrel": epsrel})
 
 
@@ -575,7 +606,7 @@ def tplquad(func, a, b, gfun, hfun, qfun, rfun, args=(), epsabs=1.49e-8,
         return [gfun(args[0]), hfun(args[0])]
 
     ranges = [ranges0, ranges1, [a, b]]
-    return nquad(func, ranges, args=args, 
+    return nquad(func, ranges, args=args,
             opts={"epsabs": epsabs, "epsrel": epsrel})
 
 
@@ -605,7 +636,7 @@ def nquad(func, ranges, args=None, opts=None, full_output=False):
             double func(int n, double *xx, void *user_data)
 
         where ``n`` is the number of extra parameters and args is an array
-        of doubles of the additional parameters, the ``xx`` array contains the 
+        of doubles of the additional parameters, the ``xx`` array contains the
         coordinates. The ``user_data`` is the data contained in the
         `scipy.LowLevelCallable`.
     ranges : iterable object
@@ -613,7 +644,7 @@ def nquad(func, ranges, args=None, opts=None, full_output=False):
         a callable that returns such a sequence.  ``ranges[0]`` corresponds to
         integration over x0, and so on.  If an element of ranges is a callable,
         then it will be called with all of the integration arguments available,
-        as well as any parametric arguments. e.g. if 
+        as well as any parametric arguments. e.g. if
         ``func = f(x0, x1, x2, t0, t1)``, then ``ranges[0]`` may be defined as
         either ``(a, b)`` or else as ``(a, b) = range0(x1, x2, t0, t1)``.
     args : iterable object, optional
@@ -625,7 +656,7 @@ def nquad(func, ranges, args=None, opts=None, full_output=False):
         default options from scipy.integrate.quad are used.  If a dict, the same
         options are used for all levels of integraion.  If a sequence, then each
         element of the sequence corresponds to a particular integration. e.g.
-        opts[0] corresponds to integration over x0, and so on. If a callable, 
+        opts[0] corresponds to integration over x0, and so on. If a callable,
         the signature must be the same as for ``ranges``. The available
         options together with their default values are:
 
@@ -640,8 +671,8 @@ def nquad(func, ranges, args=None, opts=None, full_output=False):
         For more information on these options, see `quad` and `quad_explain`.
 
     full_output : bool, optional
-        Partial implementation of ``full_output`` from scipy.integrate.quad. 
-        The number of integrand function evaluations ``neval`` can be obtained 
+        Partial implementation of ``full_output`` from scipy.integrate.quad.
+        The number of integrand function evaluations ``neval`` can be obtained
         by setting ``full_output=True`` when calling nquad.
 
     Returns
@@ -652,7 +683,7 @@ def nquad(func, ranges, args=None, opts=None, full_output=False):
         The maximum of the estimates of the absolute error in the various
         integration results.
     out_dict : dict, optional
-        A dict containing additional information on the integration. 
+        A dict containing additional information on the integration.
 
     See Also
     --------

--- a/scipy/integrate/quadpack.py
+++ b/scipy/integrate/quadpack.py
@@ -356,7 +356,7 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
 
     if ier in [1,2,3,4,5,7]:
         if full_output:
-            if weight in ['cos','sin'] and (b == Inf or a == Inf):
+            if weight in ['cos', 'sin'] and (b == Inf or a == Inf):
                 return retval[:-1] + (msg, explain)
             else:
                 return retval[:-1] + (msg,)
@@ -367,18 +367,24 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
     elif ier == 6:  # Forensic decision tree when QUADPACK throws ier=6
         if epsabs <= 0:  # Small error tolerance - applies to all methods
             if epsrel < max(50 * sys.float_info.epsilon, 5e-29):
-                msg = "If errabs<=0, epsrel must be greater than both 5e-29 and 50*(machine epsilon)."
+                msg = ("If 'errabs'<=0, 'epsrel' must be greater than both"
+                       " 5e-29 and 50*(machine epsilon).")
             elif weight in ['sin', 'cos'] and (abs(a) + abs(b) == Inf):
-                msg = "sine or cosine weighted intergals with infinite domain must have epsabs>0."
+                msg = ("Sine or cosine weighted intergals with infinite domain"
+                       " must have 'epsabs'>0.")
 
         elif weight is None:
             if points is None:  # QAGSE/QAGIE
-                msg = "Number of subintervals limit must be >=1." #TODO: Rephrase
+                msg = ("Invalid 'limit' argument. There must be"
+                       " at least one subinterval")
             else:  # QAGPE
-                if not (min(a,b) <= min(points) <= max(points) <= max(a,b)):
-                    msg = "All break points in `points` must lie within the integration limits."
+                if not (min(a, b) <= min(points) <= max(points) <= max(a, b)):
+                    msg = ("All break points in 'points' must lie within the"
+                           " integration limits.")
                 elif len(points) >= limit:
-                    msg = "Number of break points ({:d}) must be less than subinterval limit ({:d})".format(len(points), limit)
+                    msg = ("Number of break points ({:d})"
+                           " must be less than subinterval"
+                           " limit ({:d})").format(len(points), limit)
 
         else:
             if maxp1 < 1:
@@ -394,7 +400,8 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
                     msg = "Integration limits a, b must satistfy a<b."
 
             elif weight == 'cauchy' and wvar in (a, b):
-                msg = "Parameter wvar must not equal integration limits a or b."
+                msg = ("Parameter 'wvar' must not equal"
+                       " integration limits 'a' or 'b'.")
 
     raise ValueError(msg)
 
@@ -473,7 +480,7 @@ def _quad_weight(func,a,b,args,full_output,epsabs,epsrel,limlst,limit,maxp1,weig
         if a in [-Inf,Inf] or b in [-Inf,Inf]:
             raise ValueError("Cannot integrate with this weight over an infinite interval.")
 
-        if weight[:3] == 'alg':
+        if weight.startswith('alg'):
             integr = strdict[weight]
             return _quadpack._qawse(func, a, b, wvar, integr, args,
                                     full_output, epsabs, epsrel, limit)

--- a/scipy/integrate/quadpack.py
+++ b/scipy/integrate/quadpack.py
@@ -366,35 +366,35 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
 
     elif ier == 6:  # Forensic decision tree when QUADPACK throws ier=6
         if epsabs <= 0:  # Small error tolerance - applies to all methods
-            if epsrel <= 50 * sys.float_info.epsilon or epsrel < 5e-29:
-                msg =- "If ``errabs<=0``, `epsrel` must be greater than both 5e-29 and 50*(machine epsilon)."
+            if epsrel < max(50 * sys.float_info.epsilon, 5e-29):
+                msg = "If errabs<=0, epsrel must be greater than both 5e-29 and 50*(machine epsilon)."
             elif weight in ['sin', 'cos'] and (abs(a) + abs(b) == Inf):
-                msg = "sin- or cos- weighted intergals with infinite bounds must have ``epsabs>0``."
+                msg = "sine or cosine weighted intergals with infinite domain must have epsabs>0."
 
         elif weight is None:
             if points is None:  # QAGSE/QAGIE
-                msg = "Number of subintervals `limit` must be >=1."
+                msg = "Number of subintervals limit must be >=1." #TODO: Rephrase
             else:  # QAGPE
-                if max(points) > max(a,b) or min(points) < min(a,b):
-                    msg = "All break points in `points` must lie within the integration bonds."
+                if not (min(a,b) <= min(points) <= max(points) <= max(a,b)):
+                    msg = "All break points in `points` must lie within the integration limits."
                 elif len(points) >= limit:
                     msg = "Number of break points ({:d}) must be less than subinterval limit ({:d})".format(len(points), limit)
 
         else:
             if maxp1 < 1:
-                msg = "Chebyshev moment limit `maxp1` must be >=1."
+                msg = "Chebyshev moment limit maxp1 must be >=1."
 
             elif weight in ('cos', 'sin') and abs(a+b) == Inf:  # QAWFE
-                msg = "`limlst` must be >=3."
+                msg = "Cycle limit limlst must be >=3."
 
-            elif weight[:3] == 'alg':  # QAWSE
+            elif weight.startswith('alg'):  # QAWSE
                 if min(wvar) < -1:
-                    msg = "`wvar` parameters ``(alpha,beta)`` must both be >= -1."
+                    msg = "wvar parameters (alpha, beta) must both be >= -1."
                 if b < a:
-                    msg = "Integration limits `a`,`b` must satistfy ``a<b``."
+                    msg = "Integration limits a, b must satistfy a<b."
 
             elif weight == 'cauchy' and wvar in (a, b):
-                msg = "Parameter `wvar` must not equal integration limits `a` or `b`."
+                msg = "Parameter wvar must not equal integration limits a or b."
 
     raise ValueError(msg)
 

--- a/scipy/integrate/quadpack.py
+++ b/scipy/integrate/quadpack.py
@@ -364,17 +364,17 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
             warnings.warn(msg, IntegrationWarning)
             return retval[:-1]
 
-    elif ier == 6: # Forensic decision tree when QUADPACK throws ier=6
-        if epsabs <= 0: #Small error tolerance - applies to all methods
+    elif ier == 6:  # Forensic decision tree when QUADPACK throws ier=6
+        if epsabs <= 0:  # Small error tolerance - applies to all methods
             if epsrel <= 50 * sys.float_info.epsilon or epsrel < 5e-29:
                 msg =- "If ``errabs<=0``, `epsrel` must be greater than both 5e-29 and 50*(machine epsilon)."
-            elif weight in ['sin','cos'] and (abs(a) + abs(b) == Inf):
+            elif weight in ['sin', 'cos'] and (abs(a) + abs(b) == Inf):
                 msg = "sin- or cos- weighted intergals with infinite bounds must have ``epsabs>0``."
 
         elif weight is None:
-            if points is None: #QAGSE/QAGIE
+            if points is None:  # QAGSE/QAGIE
                 msg = "Number of subintervals `limit` must be >=1."
-            else: #QAGPE
+            else:  # QAGPE
                 if max(points) > max(a,b) or min(points) < min(a,b):
                     msg = "All break points in `points` must lie within the integration bonds."
                 elif len(points) >= limit:
@@ -384,16 +384,16 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
             if maxp1 < 1:
                 msg = "Chebyshev moment limit `maxp1` must be >=1."
 
-            elif weight in ('cos','sin') and abs(a+b) == Inf: #QAWFE
+            elif weight in ('cos', 'sin') and abs(a+b) == Inf:  # QAWFE
                 msg = "`limlst` must be >=3."
-            
-            elif weight[:3] == 'alg':#QAWSE
+
+            elif weight[:3] == 'alg':  # QAWSE
                 if min(wvar) < -1:
                     msg = "`wvar` parameters ``(alpha,beta)`` must both be >= -1."
-                if b<a:
+                if b < a:
                     msg = "Integration limits `a`,`b` must satistfy ``a<b``."
-            
-            elif weight == 'cauchy' and wvar in (a,b):
+
+            elif weight == 'cauchy' and wvar in (a, b):
                 msg = "Parameter `wvar` must not equal integration limits `a` or `b`."
 
     raise ValueError(msg)


### PR DESCRIPTION
Addresses #7958
When QUADPACK throws ier=6, "Invalid Input", look at user input and produce a human-friendly message about where things went wrong.