### PR TITLE
BUG: fixed keyword in 'info' in _get_mem_available utility

### DIFF
--- a/scipy/_lib/_testutils.py
+++ b/scipy/_lib/_testutils.py
@@ -123,6 +123,6 @@ def _get_mem_available():
             # Linux >= 3.14
             return info['memavailable']
         else:
-            return info['memfree'] + info['memcached']
+            return info['memfree'] + info['cached']
 
     return None


### PR DESCRIPTION
This addresses GH-7972.

After the change the example from the issue behaves as expected:

```
>>> from scipy._lib._testutils import _get_mem_available
>>> _get_mem_available()
27932612000.0
```