### PR TITLE
Make sure integrate.quad doesn't double-count singular points

### DIFF
--- a/scipy/integrate/quadpack.py
+++ b/scipy/integrate/quadpack.py
@@ -392,8 +392,11 @@ def _quad(func,a,b,args,full_output,epsabs,epsrel,limit,points):
         if infbounds != 0:
             raise ValueError("Infinity inputs cannot be used with break points.")
         else:
-            the_points = set(p for p in points if a < p < b)
-            the_points = numpy.array(list(the_points)+[0,0], float)
+            #Duplicates force function evaluation at sinular points
+            the_points = numpy.unique(points)
+            the_points = the_points[a < the_points]
+            the_points = the_points[the_points < b]
+            the_points = numpy.concatenate( (the_points, (0., 0.)) )
             return _quadpack._qagpe(func,a,b,the_points,args,full_output,epsabs,epsrel,limit)
 
 

--- a/scipy/integrate/quadpack.py
+++ b/scipy/integrate/quadpack.py
@@ -392,9 +392,8 @@ def _quad(func,a,b,args,full_output,epsabs,epsrel,limit,points):
         if infbounds != 0:
             raise ValueError("Infinity inputs cannot be used with break points.")
         else:
-            nl = len(points)
-            the_points = numpy.zeros((nl+2,), float)
-            the_points[:nl] = points
+            the_points = set(p for p in points if a < p < b)
+            the_points = numpy.array(list(the_points)+[0,0], float)
             return _quadpack._qagpe(func,a,b,the_points,args,full_output,epsabs,epsrel,limit)
 
 

--- a/scipy/integrate/quadpack.py
+++ b/scipy/integrate/quadpack.py
@@ -396,7 +396,7 @@ def _quad(func,a,b,args,full_output,epsabs,epsrel,limit,points):
             the_points = numpy.unique(points)
             the_points = the_points[a < the_points]
             the_points = the_points[the_points < b]
-            the_points = numpy.concatenate( (the_points, (0., 0.)) )
+            the_points = numpy.concatenate((the_points, (0., 0.)))
             return _quadpack._qagpe(func,a,b,the_points,args,full_output,epsabs,epsrel,limit)
 
 


### PR DESCRIPTION
When invoking QUADPACK's QAGPE with `quad(f, a, b, points=(c,d,e))`
make sure that a,b,c,d,e are unique to prevent integrating
zero-width intervals and invoking `f()` at bad points.

Addresses issue described in #7555 