### PR TITLE
BUG: optimize: Protect _minpack calls with a lock.

### DIFF
--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -16,7 +16,7 @@ from ._lsq import least_squares
 from ._lsq.common import make_strictly_feasible
 from ._lsq.least_squares import prepare_bounds
 
-_MINPACK_LOCK = threading.Lock()
+_MINPACK_LOCK = threading.RLock()
 error = _minpack.error
 
 __all__ = ['fsolve', 'leastsq', 'fixed_point', 'curve_fit']

--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -1,5 +1,6 @@
 from __future__ import division, print_function, absolute_import
 
+import threading
 import warnings
 from . import _minpack
 
@@ -15,7 +16,7 @@ from ._lsq import least_squares
 from ._lsq.common import make_strictly_feasible
 from ._lsq.least_squares import prepare_bounds
 
-
+_MINPACK_LOCK = threading.Lock()
 error = _minpack.error
 
 __all__ = ['fsolve', 'leastsq', 'fixed_point', 'curve_fit']
@@ -220,14 +221,16 @@ def _root_hybr(func, x0, args=(), jac=None,
             ml, mu = band[:2]
         if maxfev == 0:
             maxfev = 200 * (n + 1)
-        retval = _minpack._hybrd(func, x0, args, 1, xtol, maxfev,
-                                 ml, mu, epsfcn, factor, diag)
+        with _MINPACK_LOCK:
+            retval = _minpack._hybrd(func, x0, args, 1, xtol, maxfev,
+                                     ml, mu, epsfcn, factor, diag)
     else:
         _check_func('fsolve', 'fprime', Dfun, x0, args, n, (n, n))
         if (maxfev == 0):
             maxfev = 100 * (n + 1)
-        retval = _minpack._hybrj(func, Dfun, x0, args, 1,
-                                 col_deriv, xtol, maxfev, factor, diag)
+        with _MINPACK_LOCK:
+            retval = _minpack._hybrj(func, Dfun, x0, args, 1,
+                                     col_deriv, xtol, maxfev, factor, diag)
 
     x, status = retval[0], retval[-1]
 
@@ -383,8 +386,9 @@ def leastsq(func, x0, args=(), Dfun=None, full_output=0,
     if Dfun is None:
         if maxfev == 0:
             maxfev = 200*(n + 1)
-        retval = _minpack._lmdif(func, x0, args, full_output, ftol, xtol,
-                                 gtol, maxfev, epsfcn, factor, diag)
+        with _MINPACK_LOCK:
+            retval = _minpack._lmdif(func, x0, args, full_output, ftol, xtol,
+                                     gtol, maxfev, epsfcn, factor, diag)
     else:
         if col_deriv:
             _check_func('leastsq', 'Dfun', Dfun, x0, args, n, (n, m))
@@ -392,8 +396,10 @@ def leastsq(func, x0, args=(), Dfun=None, full_output=0,
             _check_func('leastsq', 'Dfun', Dfun, x0, args, n, (m, n))
         if maxfev == 0:
             maxfev = 100 * (n + 1)
-        retval = _minpack._lmder(func, Dfun, x0, args, full_output, col_deriv,
-                                 ftol, xtol, gtol, maxfev, factor, diag)
+        with _MINPACK_LOCK:
+            retval = _minpack._lmder(func, Dfun, x0, args, full_output,
+                                     col_deriv, ftol, xtol, gtol, maxfev,
+                                     factor, diag)
 
     errors = {0: ["Improper input parameters.", TypeError],
               1: ["Both actual and predicted relative reductions "
@@ -810,11 +816,13 @@ def check_gradient(fcn, Dfcn, x0, args=(), col_deriv=0):
     xp = zeros((n,), float)
     err = zeros((m,), float)
     fvecp = None
-    _minpack._chkder(m, n, x, fvec, fjac, ldfjac, xp, fvecp, 1, err)
+    with _MINPACK_LOCK:
+        _minpack._chkder(m, n, x, fvec, fjac, ldfjac, xp, fvecp, 1, err)
 
     fvecp = atleast_1d(fcn(xp, *args))
     fvecp = fvecp.reshape((m,))
-    _minpack._chkder(m, n, x, fvec, fjac, ldfjac, xp, fvecp, 2, err)
+    with _MINPACK_LOCK:
+        _minpack._chkder(m, n, x, fvec, fjac, ldfjac, xp, fvecp, 2, err)
 
     good = (product(greater(err, 0.5), axis=0))
 


### PR DESCRIPTION
This fixes -- gh-3500, three years overdue!

I just followed @sturlamolden's suggestion to protect all `_minpack` calls with a lock. This should allow users to call `leastsq` (and other minpack-based code) from multiple threads without risking memory corruption.