### PR TITLE
BUG: connected_components warning for complex data

### DIFF
--- a/scipy/sparse/csgraph/_traversal.pyx
+++ b/scipy/sparse/csgraph/_traversal.pyx
@@ -71,6 +71,7 @@ def connected_components(csgraph, directed=True, connection='weak',
         directed = False
 
     csgraph = validate_graph(csgraph, directed,
+                             dtype=csgraph.dtype,
                              dense_output=False)
 
     labels = np.empty(csgraph.shape[0], dtype=ITYPE)


### PR DESCRIPTION
The `connected_components` routine gives a casting warning when the input csgraph has complex data.  Of course, the connected components do not depend on data type. This is because the dtype for `validate_graph` is float64 by default.  This Pull passes the dtype of csgraph to the validation function to remove this warning.