### PR TITLE
DOC: update docstring in anderson to reflect name of returned variable

### DIFF
--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -1374,9 +1374,9 @@ def anderson(x, dist='norm'):
     Gumbel
         25%, 10%, 5%, 2.5%, 1%
 
-    If A2 is larger than these critical values then for the corresponding
-    significance level, the null hypothesis that the data come from the
-    chosen distribution can be rejected.
+    If the returned statistic is larger than these critical values then
+    for the corresponding significance level, the null hypothesis that
+    the data come from the chosen distribution can be rejected.
 
     References
     ----------

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -1334,8 +1334,7 @@ def anderson(x, dist='norm'):
     """
     Anderson-Darling test for data coming from a particular distribution
 
-    The Anderson-Darling test is a modification of the Kolmogorov-
-    Smirnov test `kstest` for the null hypothesis that a sample is
+    The Anderson-Darling tests the null hypothesis that a sample is
     drawn from a population that follows a particular distribution.
     For the Anderson-Darling test, the critical values depend on
     which distribution is being tested against.  This function works
@@ -1363,6 +1362,10 @@ def anderson(x, dist='norm'):
         differing set of significance levels depending on the
         distribution that is being tested against.
 
+    See Also
+    --------
+    kstest : The Kolmogorov-Smirnov test for goodness-of-fit.
+
     Notes
     -----
     Critical values provided are for the following significance levels:
@@ -1377,6 +1380,7 @@ def anderson(x, dist='norm'):
     If the returned statistic is larger than these critical values then
     for the corresponding significance level, the null hypothesis that
     the data come from the chosen distribution can be rejected.
+    The returned statistic is referred to as 'A2' in the references.
 
     References
     ----------


### PR DESCRIPTION
This is minor update on the documentation for the 'anderson' function docstring. 

Fixes:
- In the current docstring for the function, the note refers to the returned statistic as 'A2'. Though this is what the variable is called in the code, it is not mentioned that this stat (the first returned item) is what 'A2' refers to anywhere else in the docstring, and so looking only at the docs is a bit confusing, especially for the new user / one unfamiliar with the test. Here, simply replace the reference to 'A2' with 'statistic', as it is otherwise referred to in the docs, for consistency. 