### PR TITLE
DOC: special: remove `jn` from the refguide (again)

### DIFF
--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -68,7 +68,6 @@ Bessel Functions
    :toctree: generated/
 
    jv       -- Bessel function of the first kind of real order and complex argument.
-   jn       -- Bessel function of the first kind of real order and complex argument
    jve      -- Exponentially scaled Bessel function of order `v`.
    yn       -- Bessel function of the second kind of integer order and real argument.
    yv       -- Bessel function of the second kind of real order and complex argument.

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -128,6 +128,7 @@ REFGUIDE_ALL_SKIPLIST = [
 # despite being in ALL
 REFGUIDE_AUTOSUMMARY_SKIPLIST = [
     r'scipy\.special\..*_roots',  # old aliases for scipy.special.*_roots
+    r'scipy\.special\.jn',  # alias for jv
     r'scipy\.linalg\.solve_lyapunov',  # deprecated name
 ]
 # deprecated windows in scipy.signal namespace


### PR DESCRIPTION
This was done previously in gh-3684, but it crept back in
somehow. Closes gh-7741.