### PR TITLE
MAINT: fix test failures with NumPy master

### DIFF
--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -2598,10 +2598,8 @@ def friedmanchisquare(*args):
         ranked = ranked._data
     (k,n) = ranked.shape
     # Ties correction
-    repeats = [find_repeats(_) for _ in ranked.T]
-    ties = [(x, y) for x, y in repeats if x.size > 0]
-    ties = np.array(ties, dtype=object).reshape(-1, 2)[:,-1].astype(int)
-
+    repeats = [find_repeats(row) for row in ranked.T]
+    ties = np.array([y for x, y in repeats if x.size > 0])
     tie_correction = 1 - (ties**3-ties).sum()/float(n*(k**3-k))
 
     ssbg = np.sum((ranked.sum(-1) - n*(k+1)/2.)**2)

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -2598,8 +2598,10 @@ def friedmanchisquare(*args):
         ranked = ranked._data
     (k,n) = ranked.shape
     # Ties correction
-    repeats = np.array([find_repeats(_) for _ in ranked.T], dtype=object)
-    ties = repeats[repeats.nonzero()].reshape(-1,2)[:,-1].astype(int)
+    repeats = [find_repeats(_) for _ in ranked.T]
+    ties = [(x, y) for x, y in repeats if x.size > 0]
+    ties = np.array(ties, dtype=object).reshape(-1, 2)[:,-1].astype(int)
+
     tie_correction = 1 - (ties**3-ties).sum()/float(n*(k**3-k))
 
     ssbg = np.sum((ranked.sum(-1) - n*(k+1)/2.)**2)


### PR DESCRIPTION
The failures were caused by `friedmanchisquare` calling `np.nonzero`
on empty arrays, and fixed by instead checking whether the size of the
arrays was positive. Closes gh-8016.