### PR TITLE
DOC: spatial: Simplify Delaunay plotting

### DIFF
--- a/doc/source/tutorial/spatial.rst
+++ b/doc/source/tutorial/spatial.rst
@@ -31,7 +31,7 @@ Delaunay triangulation can be computed using `scipy.spatial` as follows:
    We can visualize it:
    
    >>> import matplotlib.pyplot as plt
-   >>> plt.triplot(points[:,0], points[:,1], tri.simplices.copy())
+   >>> plt.triplot(points[:,0], points[:,1], tri.simplices)
    >>> plt.plot(points[:,0], points[:,1], 'o')
    
    And add some further decorations:

--- a/scipy/spatial/qhull.pyx
+++ b/scipy/spatial/qhull.pyx
@@ -1731,7 +1731,7 @@ class Delaunay(_QhullUser):
     We can plot it:
 
     >>> import matplotlib.pyplot as plt
-    >>> plt.triplot(points[:,0], points[:,1], tri.simplices.copy())
+    >>> plt.triplot(points[:,0], points[:,1], tri.simplices)
     >>> plt.plot(points[:,0], points[:,1], 'o')
     >>> plt.show()
 


### PR DESCRIPTION
This fixes #8020 by removing a workaround for a Matplotlib issue that was fixed in 2012.