### PR TITLE
BUG: io.matlab: fix saving unicode matrix names on py2

### DIFF
--- a/scipy/io/matlab/mio5.py
+++ b/scipy/io/matlab/mio5.py
@@ -437,7 +437,7 @@ def to_writeable(source):
         for field, value in source.items():
             if (isinstance(field, string_types) and
                     field[0] not in '_0123456789'):
-                dtype.append((field, object))
+                dtype.append((str(field), object))
                 values.append(value)
         if dtype:
             return np.array([tuple(values)], dtype)

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -1229,3 +1229,8 @@ def test_bad_utf8():
     assert_equal(res['bad_string'],
                  b'\x80 am broken'.decode('utf8', 'replace'))
 
+
+def test_save_unicode_field(tmpdir):
+    filename = os.path.join(str(tmpdir), 'test.mat')
+    test_dict = {u'a':{u'b':1,u'c':'test_str'}}
+    savemat(filename, test_dict)


### PR DESCRIPTION
Fix for issue when field is of type unicode. 

Fixes  #8026