### PR TITLE
BUG: special: some fixes for `lambertw`

### DIFF
--- a/scipy/special/_precompute/lambertw.py
+++ b/scipy/special/_precompute/lambertw.py
@@ -1,0 +1,72 @@
+"""Compute a Pade approximation for the principle branch of the
+Lambert W function around 0 and compare it to various other
+approximations.
+
+"""
+from __future__ import division, print_function, absolute_import
+
+import numpy as np
+
+try:
+    import mpmath
+    import matplotlib.pyplot as plt
+except ImportError:
+    pass
+
+
+def lambertw_pade():
+    derivs = []
+    for n in range(6):
+        derivs.append(mpmath.diff(mpmath.lambertw, 0, n=n))
+    p, q = mpmath.pade(derivs, 3, 2)
+    return p, q
+
+
+def main():
+    print(__doc__)
+    with mpmath.workdps(50):
+        p, q = lambertw_pade()
+        p, q = p[::-1], q[::-1]
+        print("p = {}".format(p))
+        print("q = {}".format(q))
+
+    x, y = np.linspace(-1.5, 1.5, 75), np.linspace(-1.5, 1.5, 75)
+    x, y = np.meshgrid(x, y)
+    z = x + 1j*y
+    lambertw_std = []
+    for z0 in z.flatten():
+        lambertw_std.append(complex(mpmath.lambertw(z0)))
+    lambertw_std = np.array(lambertw_std).reshape(x.shape)
+
+    fig, axes = plt.subplots(nrows=3, ncols=1)
+    # Compare Pade approximation to true result
+    p = np.array([float(p0) for p0 in p])
+    q = np.array([float(q0) for q0 in q])
+    pade_approx = np.polyval(p, z)/np.polyval(q, z)
+    pade_err = abs(pade_approx - lambertw_std)
+    axes[0].pcolormesh(x, y, pade_err)
+    # Compare two terms of asymptotic series to true result
+    asy_approx = np.log(z) - np.log(np.log(z))
+    asy_err = abs(asy_approx - lambertw_std)
+    axes[1].pcolormesh(x, y, asy_err)
+    # Compare two terms of the series around the branch point to the
+    # true result
+    p = np.sqrt(2*(np.exp(1)*z + 1))
+    series_approx = -1 + p - p**2/3
+    series_err = abs(series_approx - lambertw_std)
+    im = axes[2].pcolormesh(x, y, series_err)
+
+    fig.colorbar(im, ax=axes.ravel().tolist())
+    plt.show()
+
+    fig, ax = plt.subplots(nrows=1, ncols=1)
+    pade_better = pade_err < asy_err
+    im = ax.pcolormesh(x, y, pade_better)
+    t = np.linspace(-0.3, 0.3)
+    ax.plot(-2.5*abs(t) - 0.2, t, 'r')
+    fig.colorbar(im, ax=ax)
+    plt.show()
+
+
+if __name__ == '__main__':
+    main()

--- a/scipy/special/lambertw.pxd
+++ b/scipy/special/lambertw.pxd
@@ -1,11 +1,11 @@
 # -*-cython-*-
 #
-# Implementation of the Lambert W function [1]. Based on the MPMath 
+# Implementation of the Lambert W function [1]. Based on the MPMath
 # implementation [2], and documentaion [3].
 #
 # Copyright: Yosef Meller, 2009
 # Author email: mellerf@netvision.net.il
-# 
+#
 # Distributed under the same license as SciPy
 #
 # References:
@@ -15,9 +15,6 @@
 #     http://code.google.com/p/mpmath/source/browse/trunk/mpmath/functions.py?spec=svn994&r=992
 # [3] mpmath source code, Subversion revision 994
 #     http://code.google.com/p/mpmath/source/browse/trunk/mpmath/function_docs.py?spec=svn994&r=994
-
-# NaN checking as per suggestions of the cython-users list,
-# http://groups.google.com/group/cython-users/browse_thread/thread/ff03eed8221bc36d
 
 # TODO: use a series expansion when extremely close to the branch point
 # at `-1/e` and make sure that the proper branch is chosen there
@@ -32,83 +29,58 @@ cdef extern from "math.h":
 
 from ._complexstuff cimport *
 
-# Heavy lifting is here:
+DEF EXPN1 = 0.36787944117144232159553  # exp(-1)
+
 
 @cython.cdivision(True)
 cdef inline double complex lambertw_scalar(double complex z, long k, double tol) nogil:
-    """
-    This is just the implementation of W for a single input z.
-    See the docstring for lambertw() below for the full description.
-    """
-    # Comments copied verbatim from [2] are marked with '>'
+    cdef int i
+    cdef double absz
+    cdef double complex w
+    cdef double complex ew, wew, wewz, wn
+
     if zisnan(z):
         return z
-
-    # Return value:
-    cdef double complex w
-    
-    #> We must be extremely careful near the singularities at -1/e and 0
-    cdef double u
-    u = exp(-1)
-    
-    cdef double absz
-    absz = zabs(z)
-    if absz <= u:
-        if z == 0:
-            #> w(0,0) = 0; for all other branches we hit the pole
-            if k == 0:
-                return z
-            sf_error.error("lambertw", sf_error.SINGULAR, NULL)
-            return -inf
-        
+    elif z.real == inf:
+        return z + 2*k*pi*1j
+    elif z.real == -inf:
+        return -z + (2*k+1)*pi*1j
+    elif z == 0:
         if k == 0:
-            w = z # Initial guess for iteration
-        #> For small real z < 0, the -1 branch beaves roughly like log(-z)
-        elif k == -1 and z.imag ==0 and z.real < 0:
-            w = log(-z.real)
-        #> Use a simple asymptotic approximation.
-        else:
-            w = zlog(z)
-            #> The branches are roughly logarithmic. This approximation
-            #> gets better for large |k|; need to check that this always
-            #> works for k ~= -1, 0, 1.
-            if k: w = w + k*2*pi*1j
-    
-    elif k == 0 and z.imag and zabs(z) <= 0.7:
-        #> Both the W(z) ~= z and W(z) ~= ln(z) approximations break
-        #> down around z ~= -0.5 (converging to the wrong branch), so patch
-        #> with a constant approximation (adjusted for sign)
-        if zabs(z+0.5) < 0.1:
-            if z.imag > 0:
-                w = 0.7 + 0.7j
-            else:
-                w = 0.7 - 0.7j
-        else:
-            w = z
-    
-    else:
-        if z.real == inf:
-            if k == 0:
-                return z
-            else:
-                return z + 2*k*pi*1j
-        
-        if z.real == -inf:
-            return (-z) + (2*k+1)*pi*1j
-                
-        #> Simple asymptotic approximation as above
-        w = zlog(z)
-        if k: w = w + k*2*pi*1j
+            return z
+        sf_error.error("lambertw", sf_error.SINGULAR, NULL)
+        return -inf
 
-    #> Use Halley iteration to solve w*exp(w) = z
-    cdef double complex ew, wew, wewz, wn
-    cdef int i
+    absz = zabs(z)
+    # Get an initial guess for Halley's method
+    if k == 0:
+        if absz <= EXPN1:
+            w = z
+        elif z.imag and absz <= 0.7:
+            if zabs(z + 0.5) < 0.1:
+                if z.imag > 0:
+                    w = 0.7 + 0.7j
+                else:
+                    w = 0.7 - 0.7j
+            else:
+                w = z
+        else:
+            w = zlog(z) + 2*pi*k*1j
+    elif k == -1:
+        if absz <= EXPN1 and z.imag == 0 and z.real < 0:
+            w = log(-z.real)
+        else:
+            w = zlog(z) + 2*pi*k*1j
+    else:
+        w = zlog(z) + 2*pi*k*1j
+
+    # Halley's method
     for i in range(100):
         ew = zexp(w)
         wew = w*ew
-        wewz = wew-z
+        wewz = wew - z
         wn = w - wewz / (wew + ew - (w + 2)*wewz/(2*w + 2))
-        if zabs(wn-w) < tol*zabs(wn):
+        if zabs(wn - w) < tol*zabs(wn):
             return wn
         else:
             w = wn

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -1504,10 +1504,11 @@ class TestSystematic(object):
                             [IntArg(), Arg()], n=20000)
 
     @pytest.mark.xfail(condition=_is_32bit_platform, reason="see gh-3551 for bad points")
-    def test_lambertw(self):
-        assert_mpmath_equal(lambda x, k: sc.lambertw(x, int(k)),
-                            lambda x, k: mpmath.lambertw(x, int(k)),
-                            [Arg(), IntArg(0, 10)])
+    def test_lambertw_real(self):
+        assert_mpmath_equal(lambda x, k: sc.lambertw(x, int(k.real)),
+                            lambda x, k: mpmath.lambertw(x, int(k.real)),
+                            [ComplexArg(-np.inf, np.inf), IntArg(0, 10)],
+                            rtol=1e-13, nan_ok=False)
 
     def test_lanczos_sum_expg_scaled(self):
         maxgamma = 171.624376956302725

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -113,7 +113,7 @@ def test_hyp2f1_strange_points():
     ]
     pts += list(itertools.product([2, 1, -0.7, -1000], repeat=4))
     pts = [
-        (a, b, c, x) for a, b, c, x in pts 
+        (a, b, c, x) for a, b, c, x in pts
         if b == c and round(b) == b and b < 0 and b != -1000
     ]
     kw = dict(eliminate=True)
@@ -668,6 +668,25 @@ def test_wrightomega_region2():
     dataset = np.asarray(dataset)
 
     FuncData(sc.wrightomega, dataset, 0, 1, rtol=1e-15).check()
+
+
+# ------------------------------------------------------------------------------
+# lambertw
+# ------------------------------------------------------------------------------
+
+@pytest.mark.slow
+@check_version(mpmath, '0.19')
+def test_lambertw_smallz():
+    x, y = np.linspace(-1, 1, 25), np.linspace(-1, 1, 25)
+    x, y = np.meshgrid(x, y)
+    z = (x + 1j*y).flatten()
+
+    dataset = []
+    for z0 in z:
+        dataset.append((z0, complex(mpmath.lambertw(z0))))
+    dataset = np.asarray(dataset)
+
+    FuncData(sc.lambertw, dataset, 0, 1, rtol=1e-13).check()
 
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
This:

- Cleans up the code for `lambertw` to make it more readable. In particular, special cases are moved to the beginning of the function and the branch cut logic for the initial guess is simplified
- Fixes the `lambertw` mpmath tests, which were not actually checking the majority of the test points (`nan_ok = True` strikes again).
- Prevents overflow in the Halley iterations by being careful about exponentials