### PR TITLE
MAINT: special: remove complex division hack

### DIFF
--- a/scipy/special/_complexstuff.pxd
+++ b/scipy/special/_complexstuff.pxd
@@ -139,43 +139,6 @@ cdef inline double_complex zpack(double zr, double zi) nogil:
     return double_complex_from_npy_cdouble(z)
 
 @cython.cdivision(True)
-cdef inline double complex zdiv(double complex x, double complex y) nogil:
-    """
-    Cython 0.24 uses the naive complex division algorithm which
-    overflows far before it should. See
-
-    https://groups.google.com/forum/#!topic/cython-users/1oSGbfiX7qw
-
-    This function implements Smith's method to get around the
-    problem. Smith's method can be further improved, see
-
-    http://arxiv.org/pdf/1210.4539v2.pdf
-
-    This is an UGLY HACK and should be removed as soon as the problem
-    is fixed upstream.
-
-    """
-    cdef:
-        double a = x.real
-        double b = x.imag
-        double c = y.real
-        double d = y.imag
-        double ratio, denom
-        double complex out
-
-    if libc.math.fabs(d) < libc.math.fabs(c):
-        ratio = d/c
-        denom = c + d*ratio
-        out.real = (a + b*ratio)/denom
-        out.imag = (b - a*ratio)/denom
-    else:
-        ratio = c/d
-        denom = c*ratio + d
-        out.real = (a*ratio + b)/denom
-        out.imag = (b*ratio - a)/denom
-    return out
-
-@cython.cdivision(True)
 cdef inline double complex zlog1(double complex z) nogil:
     """
     Compute log, paying special attention to accuracy around 1. We

--- a/scipy/special/_digamma.pxd
+++ b/scipy/special/_digamma.pxd
@@ -12,7 +12,7 @@
 
 import cython
 from libc.math cimport ceil, fabs, M_PI
-from ._complexstuff cimport number_t, nan, zlog, zabs, zdiv
+from ._complexstuff cimport number_t, nan, zlog, zabs
 from ._trig cimport sinpi, cospi
 from . cimport sf_error
 
@@ -150,7 +150,7 @@ cdef inline double complex backward_recurrence(double complex z,
     cdef:
         int k
         double complex res = psiz
-        
+
     for k in range(1, n + 1):
         res -= 1/(z - k)
     return res
@@ -169,19 +169,19 @@ cdef inline double complex asymptotic_series(double complex z) nogil:
         # The Bernoulli numbers B_2k for 1 <= k <= 16.
         double *bernoulli2k = [
             0.166666666666666667, -0.0333333333333333333,
-            0.0238095238095238095, -0.0333333333333333333, 
+            0.0238095238095238095, -0.0333333333333333333,
             0.0757575757575757576, -0.253113553113553114,
             1.16666666666666667, -7.09215686274509804,
             54.9711779448621554, -529.124242424242424,
             6192.12318840579710, -86580.2531135531136,
             1425517.16666666667, -27298231.0678160920,
             601580873.900642368, -15116315767.0921569]
-        double complex rzz = zdiv(zdiv(1, z), z)
+        double complex rzz = 1/z/z
         double complex zfac = 1
         double complex term
         double complex res
 
-    res = zlog(z) - zdiv(1.0, 2*z)
+    res = zlog(z) - 0.5/z
     for k in range(1, 17):
         zfac *= rzz
         term = -bernoulli2k[k-1]*zfac/(2*k)

--- a/scipy/special/_loggamma.pxd
+++ b/scipy/special/_loggamma.pxd
@@ -19,7 +19,7 @@ from . cimport sf_error
 from libc.math cimport M_PI, floor, fabs
 
 from ._complexstuff cimport (
-    nan, zisnan, zabs, zlog, zlog1, zexp, zdiv, zpack 
+    nan, zisnan, zabs, zlog, zlog1, zexp, zpack
 )
 from ._trig cimport sinpi
 from ._evalpoly cimport cevalpoly
@@ -62,7 +62,7 @@ cdef inline double complex loggamma(double complex z) nogil:
         return loggamma_recurrence(z)
     else:
         return loggamma_recurrence(z.conjugate()).conjugate()
-        
+
 
 @cython.cdivision(True)
 cdef inline double complex loggamma_recurrence(double complex z) nogil:
@@ -79,7 +79,7 @@ cdef inline double complex loggamma_recurrence(double complex z) nogil:
 
     z.real += 1
     while z.real <= SMALLX:
-        shiftprod *= z 
+        shiftprod *= z
         nsb = npy_signbit(shiftprod.imag)
         signflips += 1 if nsb != 0 and sb == 0 else 0
         sb = nsb
@@ -90,7 +90,7 @@ cdef inline double complex loggamma_recurrence(double complex z) nogil:
 @cython.cdivision(True)
 cdef inline double complex loggamma_stirling(double complex z) nogil:
     """Stirling series for log-Gamma.
-    
+
     The coefficients are B[2*n]/(2*n*(2*n - 1)) where B[2*n] is the
     (2*n)th Bernoulli number. See (1.1) in [1].
 
@@ -102,8 +102,8 @@ cdef inline double complex loggamma_stirling(double complex z) nogil:
             -5.952380952380952381e-4, 7.9365079365079365079e-4,
             -2.7777777777777777778e-3, 8.3333333333333333333e-2
         ]
-        double complex rz = zdiv(1.0, z)
-        double complex rzz = zdiv(rz, z)
+        double complex rz = 1.0/z
+        double complex rzz = rz/z
 
     return (z - 0.5)*zlog(z) - z + HLOG2PI + rz*cevalpoly(coeffs, 7, rzz)
 

--- a/scipy/special/_spence.pxd
+++ b/scipy/special/_spence.pxd
@@ -12,7 +12,7 @@
 # Released under the same license as Scipy.
 
 import cython
-from ._complexstuff cimport zlog1, zabs, zdiv
+from ._complexstuff cimport zlog1, zabs
 
 # Relative tolerance for the series
 DEF TOL = 2.220446092504131e-16
@@ -36,8 +36,7 @@ cdef inline double complex cspence(double complex z) nogil:
         # This step isn't necessary, but this series converges faster.
         return cspence_series0(z)
     elif zabs(1 - z) > 1:
-        # Use of zdiv is an UGLY HACK.
-        return -cspence_series1(zdiv(z, z - 1)) - PISQ_6 - 0.5*zlog1(z - 1)**2
+        return -cspence_series1(z/(z - 1)) - PISQ_6 - 0.5*zlog1(z - 1)**2
     else:
         return cspence_series1(z)
 


### PR DESCRIPTION
This is now possible since we bumped the minimum Cython version to
0.25, which is the minimum version that implements Smith's algorithm.