### PR TITLE
ENH: Cythonize pyx files if pxd dependencies change

### DIFF
--- a/scipy/special/_generate_pyx.py
+++ b/scipy/special/_generate_pyx.py
@@ -1616,15 +1616,7 @@ def main():
     if len(args) != 0:
         p.error('invalid number of arguments')
 
-    src_files = set()
-    for line in FUNCS.split('\n'):
-        if line:
-            src = [s.strip() for s in line.split('--')[2].split(',')]
-            src = [s for s in src if '.pxd' in s]
-            src_files.update(src)
-    src_files.add(os.path.abspath(__file__))
-    src_files = list(src_files)
-
+    src_files = (os.path.abspath(__file__),)
     dst_files = ('_ufuncs.pyx',
                  '_ufuncs_defs.h',
                  '_ufuncs_cxx.pyx',


### PR DESCRIPTION
This:

- Reverts the changes in https://github.com/scipy/scipy/pull/7996, which were an incorrect attempt to do what this PR does
- Changes `cythonize.py` to scan pyx files for relative pxd cimports and recythonize the file if a pxd dependency has changed

The upshot is that if you edit e.g. `special/_xlogy.pxd` then `_ufuncs.pyx` will get cythonized while building, whereas before you would either have to clean or cythonize by hand.