### PR TITLE
TST: stats: reduce required precision in test_fligner

### DIFF
--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -573,10 +573,17 @@ class TestFligner(object):
                                   11)
 
     def test_trimmed1(self):
+        # Perturb input to break ties in the transformed data 
+        # See https://github.com/scipy/scipy/pull/8042 for more details
+        rs = np.random.RandomState(123)
+        _perturb = lambda g: (np.asarray(g) + 1e-10*rs.randn(len(g))).tolist()
+        g1_ = _perturb(g1)
+        g2_ = _perturb(g2)
+        g3_ = _perturb(g3)
         # Test that center='trimmed' gives the same result as center='mean'
         # when proportiontocut=0.
-        Xsq1, pval1 = stats.fligner(g1, g2, g3, center='mean')
-        Xsq2, pval2 = stats.fligner(g1, g2, g3, center='trimmed',
+        Xsq1, pval1 = stats.fligner(g1_, g2_, g3_, center='mean')
+        Xsq2, pval2 = stats.fligner(g1_, g2_, g3_, center='trimmed',
                                     proportiontocut=0.0)
         assert_almost_equal(Xsq1, Xsq2)
         assert_almost_equal(pval1, pval2)


### PR DESCRIPTION
Value of the test statistics depends on the ordering of values, and hence
is greatly influenced by differences in rounding errors. Vectorizing floating
point arithmetic operations may result in introduction of such rounding errors,
and result in the change of statistics value causing the test to fail.

Based on the following experiment:

```python
# Value of statistic changes as inputs are perturbed by random machine epsilons,
# with standard deviation at 6.3e-3 warranting decimal == 2
#
#   In [67]: fVec = np.array([ stats.fligner(*[
#    ...:        [ x + 0.5*u*np.finfo(np.double).eps for x, u in 
#    ....              zip(g,np.random.randn(len(g)))] for g in (g1,g2,g3)
#    ...:        ], center='mean').statistic  for __ in range(1000) ])
#
#   In [68]: fVec.mean()
#   Out[68]: 0.34248805994929105
#
#   In [69]: fVec.std()
#   Out[69]: 0.00063681836805062626
#
# Even though 'trimmed with proptioncut=0.0 does not change the dataset, it reorders it, 
# and hence np.mean(x) may change.
```

decreased value of keyword argument decimal from default value of 6, to value of 2.

This change was prompted by adjusting scipy tests to pass in [Intel (R) Distribution for Python*](https://software.intel.com/en-us/distribution-for-python).

This change was included in a patch in the `info/recipe` directory of scipy's conda [tar-ball](https://anaconda.org/intel/scipy) on Intel (R) channel on Anaconda cloud.

@rgommers 