### PR TITLE
MAINT: Initialize local blas_t variable

### DIFF
--- a/scipy/linalg/_decomp_update.pyx.in
+++ b/scipy/linalg/_decomp_update.pyx.in
@@ -806,7 +806,7 @@ cdef void thin_qr_rank_1_update(int m, int n, blas_t* q, int* qs, bint qisF,
        and V is N.  s is a 2*n work array.
     """
     cdef int j
-    cdef blas_t c, sn, rlast, t, rcond = 0.0
+    cdef blas_t c = 0.0, sn, rlast, t, rcond = 0.0
 
     reorth(m, n, q, qs, qisF, u, us, s, &rcond)
 


### PR DESCRIPTION
Fixed an unreferenced test failure when executing test suite on some platform due to unintialized fused type variable `c` by initializing it to `0.0`. 

Not sure whether this behaves correctly for all of the fused types, but my attempts to cast constant 0.0 to the widest of the fused types `cdef blas_t c = <double_complex> 0.0` resulted in Cython errors.