### PR TITLE
Unhelpful error message when calling scipy.sparse.save_npz on a dok_matrix #7718

### DIFF
--- a/scipy/sparse/_matrix_io.py
+++ b/scipy/sparse/_matrix_io.py
@@ -60,10 +60,7 @@ def save_npz(file, matrix, compressed=True):
     matrix([[0, 0, 3],
             [4, 0, 0]], dtype=int64)
     """
-
-    arrays_dict = dict(format=matrix.format.encode('ascii'),
-                       shape=matrix.shape,
-                       data=matrix.data)
+    arrays_dict = {}
     if matrix.format in ('csc', 'csr', 'bsr'):
         arrays_dict.update(indices=matrix.indices, indptr=matrix.indptr)
     elif matrix.format == 'dia':
@@ -72,7 +69,9 @@ def save_npz(file, matrix, compressed=True):
         arrays_dict.update(row=matrix.row, col=matrix.col)
     else:
         raise NotImplementedError('Save is not implemented for sparse matrix of format {}.'.format(matrix.format))
-
+    arrays_dict = dict(format=matrix.format.encode('ascii'),
+                       shape=matrix.shape,
+                       data=matrix.data)
     if compressed:
         np.savez_compressed(file, **arrays_dict)
     else:

--- a/scipy/sparse/_matrix_io.py
+++ b/scipy/sparse/_matrix_io.py
@@ -69,9 +69,11 @@ def save_npz(file, matrix, compressed=True):
         arrays_dict.update(row=matrix.row, col=matrix.col)
     else:
         raise NotImplementedError('Save is not implemented for sparse matrix of format {}.'.format(matrix.format))
-    arrays_dict = dict(format=matrix.format.encode('ascii'),
-                       shape=matrix.shape,
-                       data=matrix.data)
+    arrays_dict.update(
+        format=matrix.format.encode('ascii'),
+        shape=matrix.shape,
+        data=matrix.data
+    )
     if compressed:
         np.savez_compressed(file, **arrays_dict)
     else:

--- a/scipy/sparse/tests/test_matrix_io.py
+++ b/scipy/sparse/tests/test_matrix_io.py
@@ -7,7 +7,7 @@ import tempfile
 
 import pytest
 from pytest import raises as assert_raises
-from numpy.testing import assert_equal, assert_, assert_raises
+from numpy.testing import assert_equal, assert_
 from scipy._lib._version import NumpyVersion
 
 from scipy.sparse import (csc_matrix, csr_matrix, bsr_matrix, dia_matrix,
@@ -87,9 +87,7 @@ def test_implemented_error():
     # Attempts to save an unsupported type and checks that an
     # NotImplementedError is raised.
 
-    def save_dok():
-        x = dok_matrix((2,3))
-        x[0,1] = 1
-        save_npz('x.npz', x)
+    x = dok_matrix((2,3))
+    x[0,1] = 1
 
-    assert_raises(NotImplementedError, save_dok)
+    assert_raises(NotImplementedError, save_npz, 'x.npz', x)

--- a/scipy/sparse/tests/test_matrix_io.py
+++ b/scipy/sparse/tests/test_matrix_io.py
@@ -7,11 +7,11 @@ import tempfile
 
 import pytest
 from pytest import raises as assert_raises
-from numpy.testing import assert_equal, assert_
+from numpy.testing import assert_equal, assert_, assert_raises
 from scipy._lib._version import NumpyVersion
 
 from scipy.sparse import (csc_matrix, csr_matrix, bsr_matrix, dia_matrix,
-                          coo_matrix, save_npz, load_npz)
+                          coo_matrix, save_npz, load_npz, dok_matrix)
 
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
@@ -83,3 +83,13 @@ def test_py23_compatibility():
     assert_equal(a.toarray(), c.toarray())
     assert_equal(b.toarray(), c.toarray())
 
+def test_implemented_error():
+    # Attempts to save an unsupported type and checks that an
+    # NotImplementedError is raised.
+
+    def save_dok():
+        x = dok_matrix((2,3))
+        x[0,1] = 1
+        save_npz('x.npz', x)
+
+    assert_raises(NotImplementedError, save_dok)


### PR DESCRIPTION
https://github.com/scipy/scipy/issues/7718

The comments in the issue were implemented and now a `NotImplementedError: Save is not implemented for sparse matrix of format {}.`  error is raised.