### PR TITLE
TST, DOC: Basin-hopping changes attempt 2

### DIFF
--- a/scipy/optimize/__init__.py
+++ b/scipy/optimize/__init__.py
@@ -206,10 +206,10 @@ The `linprog` function supports the following methods:
    optimize.linprog-interior-point
 
 The simplex method supports callback functions, such as:
-    
+
 .. autosummary::
    :toctree: generated/
-   
+
    linprog_verbose_callback -- Sample callback function for linprog (simplex)
 
 Assignment problems:

--- a/scipy/optimize/_basinhopping.py
+++ b/scipy/optimize/_basinhopping.py
@@ -311,7 +311,7 @@ class Metropolis(object):
         If new is higher than old, there is a chance it will be accepted,
         less likely for larger differences.
         """
-        w = math.exp(min(0, -(energy_new - energy_old) * self.beta))
+        w = math.exp(min(0, -float(energy_new - energy_old) * self.beta))
         rand = self.random_state.rand()
         return w >= rand
 

--- a/scipy/optimize/_basinhopping.py
+++ b/scipy/optimize/_basinhopping.py
@@ -330,6 +330,16 @@ def basinhopping(func, x0, niter=100, T=1.0, stepsize=0.5,
     """
     Find the global minimum of a function using the basin-hopping algorithm
 
+    Basin-hopping is a two-phase method that combines a global stepping
+    algorithm with local minimization at each step.  Designed to mimic
+    the natural process of energy minimization of clusters of atoms, it works
+    well for similar problems with "funnel-like, but rugged" energy landscapes
+    [5]_.
+
+    As the step-taking, step acceptance, and minimization methods are all
+    customizable, this function can also be used to implement other two-phase
+    methods.
+
     Parameters
     ----------
     func : callable ``f(x, *args)``
@@ -460,20 +470,24 @@ def basinhopping(func, x0, niter=100, T=1.0, stepsize=0.5,
     minimum.
 
     Choosing ``stepsize``:  This is a crucial parameter in ``basinhopping`` and
-    depends on the problem being solved.  Ideally it should be comparable to
-    the typical separation between local minima of the function being
-    optimized.  ``basinhopping`` will, by default, adjust ``stepsize`` to find
-    an optimal value, but this may take many iterations.  You will get quicker
-    results if you set a sensible value for ``stepsize``.
+    depends on the problem being solved.  The step is chosen uniformly in the
+    region from x0-stepsize to x0+stepsize, in each dimension.  Ideally it
+    should be comparable to the typical separation (in argument values) between
+    local minima of the function being optimized.  ``basinhopping`` will, by
+    default, adjust ``stepsize`` to find an optimal value, but this may take
+    many iterations.  You will get quicker results if you set a sensible
+    initial value for ``stepsize``.
 
-    Choosing ``T``: The parameter ``T`` is the temperature used in the
-    Metropolis criterion.  Basinhopping steps are accepted with probability
-    ``1`` if ``func(xnew) < func(xold)``, or otherwise with probability::
+    Choosing ``T``: The parameter ``T`` is the "temperature" used in the
+    Metropolis criterion.  Basinhopping steps are always accepted if
+    ``func(xnew) < func(xold)``.  Otherwise, they are accepted with
+    probability::
 
         exp( -(func(xnew) - func(xold)) / T )
 
     So, for best results, ``T`` should to be comparable to the typical
-    difference in function values between local minima.
+    difference (in function values) between local minima.  (The height of
+    "walls" between local minima is irrelevant.)
 
     If ``T`` is 0, the algorithm becomes Monotonic Basin-Hopping, in which all
     steps that increase energy are rejected.
@@ -492,6 +506,10 @@ def basinhopping(func, x0, niter=100, T=1.0, stepsize=0.5,
         1987, 84, 6611.
     .. [4] Wales, D. J. and Scheraga, H. A., Global optimization of clusters,
         crystals, and biomolecules, Science, 1999, 285, 1368.
+    .. [5] Olson, B., Hashmi, I., Molloy, K., and Shehu1, A., Basin Hopping as
+        a General and Versatile Optimization Framework for the Characterization
+        of Biological Macromolecules, Advances in Artificial Intelligence,
+        Volume 2012 (2012), Article ID 674832, :doi:`10.1155/2012/674832`
 
     Examples
     --------

--- a/scipy/optimize/cobyla.py
+++ b/scipy/optimize/cobyla.py
@@ -260,15 +260,14 @@ def _minimize_cobyla(fun, x0, args=(), constraints=(),
                           status=int(info[0]),
                           success=info[0] == 1,
                           message={1: 'Optimization terminated successfully.',
-                                   2: 'Maximum number of function evaluations has '
-                                      'been exceeded.',
-                                   3: 'Rounding errors are becoming damaging in '
-                                      'COBYLA subroutine.',
-                                   4: 'Did not converge to a solution satisfying '
-                                      'the constraints. See `maxcv` for magnitude '
-                                      'of violation.'
+                                   2: 'Maximum number of function evaluations '
+                                      'has been exceeded.',
+                                   3: 'Rounding errors are becoming damaging '
+                                      'in COBYLA subroutine.',
+                                   4: 'Did not converge to a solution '
+                                      'satisfying the constraints. See '
+                                      '`maxcv` for magnitude of violation.'
                                    }.get(info[0], 'Unknown exit status.'),
                           nfev=int(info[1]),
                           fun=info[2],
                           maxcv=info[3])
-

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -456,9 +456,9 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
     ----------
     .. [1] Gao, F. and Han, L.
        Implementing the Nelder-Mead simplex algorithm with adaptive
-       parameters. 2012. Computational Optimization and Applications. 
+       parameters. 2012. Computational Optimization and Applications.
        51:1, pp. 259-277
-       
+
     """
     if 'ftol' in unknown_options:
         warnings.warn("ftol is deprecated for Nelder-Mead,"
@@ -486,7 +486,7 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
     retall = return_all
 
     fcalls, func = wrap_function(func, args)
-           
+
     if adaptive:
         dim = float(len(x0))
         rho = 1
@@ -498,7 +498,7 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
         chi = 2
         psi = 0.5
         sigma = 0.5
-        
+
     nonzdelt = 0.05
     zdelt = 0.00025
 
@@ -2069,7 +2069,7 @@ def brent(func, args=(), brack=None, tol=1.48e-8, full_output=0, maxiter=500):
 
     Does not ensure that the minimum lies in the range specified by
     `brack`. See `fminbound`.
-    
+
     Examples
     --------
     We illustrate the behaviour of the function when `brack` is of
@@ -2079,7 +2079,7 @@ def brent(func, args=(), brack=None, tol=1.48e-8, full_output=0, maxiter=500):
 
     >>> def f(x):
     ...     return x**2
-    
+
     >>> from scipy import optimize
 
     >>> minimum = optimize.brent(f,brack=(1,2))
@@ -2178,7 +2178,7 @@ def golden(func, args=(), brack=None, tol=_epsilon,
 
     >>> def f(x):
     ...     return x**2
-    
+
     >>> from scipy import optimize
 
     >>> minimum = optimize.golden(f, brack=(1, 2))

--- a/scipy/optimize/tests/test__basinhopping.py
+++ b/scipy/optimize/tests/test__basinhopping.py
@@ -20,12 +20,6 @@ def func1d(x):
     return f, df
 
 
-def func1d_nograd(x):
-    f = cos(14.5 * x - 0.3) + (x + 0.2) * x
-    df = np.array(-14.5 * sin(14.5 * x - 0.3) + 2. * x + 0.2)
-    return f, df
-
-
 def func2d_nograd(x):
     f = cos(14.5 * x[0] - 0.3) + (x[1] + 0.2) * x[1] + (x[0] + 0.2) * x[0]
     return f

--- a/scipy/optimize/tests/test__basinhopping.py
+++ b/scipy/optimize/tests/test__basinhopping.py
@@ -301,6 +301,13 @@ class TestBasinHopping(object):
                      niter=10, callback=callback2, seed=10)
         assert_equal(np.array(f_1), np.array(f_2))
 
+    def test_monotonic_basin_hopping(self):
+        # test 1d minimizations with gradient and T=0
+        i = 0
+        res = basinhopping(func1d, self.x0[i], minimizer_kwargs=self.kwargs,
+                           niter=self.niter, disp=self.disp, T=0)
+        assert_almost_equal(res.x, self.sol[i], self.tol)
+
 
 class Test_Storage(object):
     def setup_method(self):


### PR DESCRIPTION
I should have been more careful in https://github.com/scipy/scipy/pull/7954

I added a test, and it failed, because the energy values fed to Metropolis are arrays, not floats, and causing a RuntimeWarning.  This should fix it.

Also made some changes to the docstrings

(Also all the whitespace and PEP8 things that Spyder complains about)