### PR TITLE
TST: special: simplify `Arg`

### DIFF
--- a/scipy/special/tests/test_cdflib.py
+++ b/scipy/special/tests/test_cdflib.py
@@ -46,7 +46,7 @@ class ProbArg(object):
         # Include the endpoints for compatibility with Arg et. al.
         self.a = 0
         self.b = 1
-    
+
     def values(self, n):
         """Return an array containing approximatively n numbers."""
         m = max(1, n//3)
@@ -68,7 +68,7 @@ class EndpointFilter(object):
         mask1 = np.abs(x - self.a) < self.rtol*np.abs(self.a) + self.atol
         mask2 = np.abs(x - self.b) < self.rtol*np.abs(self.b) + self.atol
         return np.where(mask1 | mask2, False, True)
-            
+
 
 class _CDFData(object):
     def __init__(self, spfunc, mpfunc, index, argspec, spfunc_first=True,
@@ -83,7 +83,7 @@ class _CDFData(object):
         self.n = n
         self.rtol = rtol
         self.atol = atol
-        
+
         if not isinstance(argspec, list):
             self.endpt_rtol = None
             self.endpt_atol = None
@@ -123,7 +123,7 @@ class _CDFData(object):
     def get_param_filter(self):
         if self.endpt_rtol is None and self.endpt_atol is None:
             return None
-        
+
         filters = []
         for rtol, atol, spec in zip(self.endpt_rtol, self.endpt_atol, self.argspec):
             if rtol is None and atol is None:
@@ -136,7 +136,7 @@ class _CDFData(object):
 
             filters.append(EndpointFilter(spec.a, spec.b, rtol, atol))
         return filters
-        
+
     def check(self):
         # Generate values for the arguments
         args = get_args(self.argspec, self.n)
@@ -173,7 +173,7 @@ def _f_cdf(dfn, dfd, x):
     ub = dfn*x/(dfn*x + dfd)
     res = mpmath.betainc(dfn/2, dfd/2, x2=ub, regularized=True)
     return res
-    
+
 
 def _student_t_cdf(df, t, dps=None):
     if dps is None:
@@ -224,7 +224,7 @@ class TestCDFlib(object):
             _binomial_cdf,
             1, [IntArg(1, 1000), ProbArg(), ProbArg()],
             rtol=1e-4, endpt_atol=[None, None, 1e-6])
-    
+
     def test_btdtria(self):
         _assert_inverts(
             sp.btdtria,
@@ -240,7 +240,7 @@ class TestCDFlib(object):
             lambda a, b, x: mpmath.betainc(a, b, x2=x, regularized=True),
             1, [Arg(0, 1e2, inclusive_a=False), ProbArg(),
              Arg(0, 1, inclusive_a=False, inclusive_b=False)],
-            rtol=1e-7, endpt_atol=[None, 1e-20, 1e-20])
+            rtol=1e-7, endpt_atol=[None, 1e-18, 1e-14])
 
     @pytest.mark.xfail(run=False)
     def test_fdtridfd(self):
@@ -249,14 +249,14 @@ class TestCDFlib(object):
             _f_cdf,
             1, [IntArg(1, 100), ProbArg(), Arg(0, 100, inclusive_a=False)],
             rtol=1e-7)
-        
+
     def test_gdtria(self):
         _assert_inverts(
             sp.gdtria,
             lambda a, b, x: mpmath.gammainc(b, b=a*x, regularized=True),
             0, [ProbArg(), Arg(0, 1e3, inclusive_a=False),
                 Arg(0, 1e4, inclusive_a=False)], rtol=1e-7,
-            endpt_atol=[None, 1e-10, 1e-10])
+            endpt_atol=[1e-6, 1e-2, 1e-3])
 
     def test_gdtrib(self):
         # Use small values of a and x or mpmath doesn't converge
@@ -272,7 +272,7 @@ class TestCDFlib(object):
             lambda a, b, x: mpmath.gammainc(b, b=a*x, regularized=True),
             2, [Arg(0, 1e3, inclusive_a=False), Arg(0, 1e3, inclusive_a=False),
                 ProbArg()], rtol=1e-7,
-            endpt_atol=[None, 1e-10, 1e-10])
+            endpt_atol=[None, 1e-2, None])
 
     def test_stdtr(self):
         # Ideally the left endpoint for Arg() should be 0.
@@ -319,7 +319,7 @@ class TestCDFlib(object):
             _noncentral_chi_cdf,
             2, [Arg(0, 100, inclusive_a=False), IntArg(1, 100), ProbArg()],
             n=1000, rtol=1e-4, atol=1e-15)
-        
+
     def test_chndtrix(self):
         # Use a larger atol since mpmath is doing numerical integration
         _assert_inverts(
@@ -341,7 +341,7 @@ class TestCDFlib(object):
         _assert_inverts(
             sp.tklmbda,
             _tukey_lmbda_quantile,
-            0, [ProbArg(), Arg(-np.inf, 0, inclusive_b=False)],
+            0, [ProbArg(), Arg(-1e1, -1e-4, inclusive_b=False)],
             spfunc_first=False, rtol=1e-5,
             endpt_atol=[1e-9, None])
 

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -113,7 +113,7 @@ def test_hyp2f1_strange_points():
     ]
     pts += list(itertools.product([2, 1, -0.7, -1000], repeat=4))
     pts = [
-        (a, b, c, x) for a, b, c, x in pts 
+        (a, b, c, x) for a, b, c, x in pts
         if b == c and round(b) == b and b < 0 and b != -1000
     ]
     kw = dict(eliminate=True)
@@ -1300,7 +1300,7 @@ class TestSystematic(object):
             return r
         assert_mpmath_equal(sc_gegenbauer,
                             exception_to_nan(gegenbauer),
-                            [IntArg(0, 100), Arg(), Arg()],
+                            [IntArg(0, 100), Arg(-1e9, 1e9), Arg()],
                             n=40000, dps=100,
                             ignore_inf_sign=True)
 
@@ -1515,7 +1515,15 @@ class TestSystematic(object):
         g = 6.024680040776729583740234375
 
         def gamma(x):
-            return ((x + g - 0.5)/e)**(x - 0.5)*_lanczos_sum_expg_scaled(x)
+            with np.errstate(over='ignore'):
+                fac = ((x + g - 0.5)/e)**(x - 0.5)
+                if fac != np.inf:
+                    res = fac*_lanczos_sum_expg_scaled(x)
+                else:
+                    fac = ((x + g - 0.5)/e)**(0.5*(x - 0.5))
+                    res = fac*_lanczos_sum_expg_scaled(x)
+                    res *= fac
+            return res
 
         assert_mpmath_equal(gamma,
                             mpmath.gamma,
@@ -1568,7 +1576,7 @@ class TestSystematic(object):
                 else:
                     return 0
 
-            if abs(z) < 1e-15:
+            if abs(z) <= 1e-15:
                 # mpmath has bad performance here
                 return np.nan
 
@@ -1583,7 +1591,8 @@ class TestSystematic(object):
 
         assert_mpmath_equal(lpnm,
                             legenp,
-                            [IntArg(-100, 100), IntArg(-100, 100), Arg()])
+                            [IntArg(-100, 100), IntArg(-100, 100),
+                             Arg(-1e153, 1e153)])
 
         assert_mpmath_equal(lpnm_2,
                             legenp,
@@ -1840,7 +1849,7 @@ class TestSystematic(object):
                             mpmath.spherharm,
                             [IntArg(0, 100), IntArg(0, 100),
                              Arg(a=0, b=pi), Arg(a=0, b=2*pi)],
-                            atol=1e-8, n=6000,
+                            atol=5e-8, n=6000,
                             dps=150)
 
     def test_struveh(self):


### PR DESCRIPTION
This fixes a couple of things:

- Before the `TestSystematic` tests in `test_mpmath` could severely
   overestimate the desired number of points.
- Before the spread of points returned from `Arg` could be fairly
   different than what was requested.

Note, however, that this changes the test points for a lot of tests. (And requires tweaking tolerances accordingly.) On the one hand, the points we thought we were testing at weren't necessarily the points we were testing at. On the other hand, there's a lot of potential for this to break things and make us have to track down a new crop of failures.

Examples
----------

```
>>> import scipy
>>> scipy.__version__
'0.19.0'
>>> from scipy.special._mptestutils import Arg, ComplexArg, get_args
>>> args = get_args([Arg(), ComplexArg()], 500)
>>> args.shape
(9261, 2)
>>> Arg(-200, 200).values(20)
array([ -1.00000000e+01,  -9.00000000e+00,  -5.50000000e+00,
        -1.00000000e+00,  -6.00000000e-01,  -2.00000000e-01,
        -1.00000000e-01,  -3.16227766e-16,  -1.00000000e-30,
         0.00000000e+00,   1.00000000e-30,   3.16227766e-16,
         1.00000000e-01,   2.00000000e-01,   6.00000000e-01,
         1.00000000e+00,   5.50000000e+00,   9.00000000e+00,
         1.00000000e+01])
```

```
>>> import scipy
>>> scipy.__version__
'1.1.0.dev0+59d4448'
>>> from scipy.special._mptestutils import Arg, ComplexArg, get_args
>>> args = get_args([Arg(), ComplexArg()], 500)
>>> args.shape
(546, 2)
>>> Arg(-200, 200).values(20)
array([ -2.00000000e+02,  -5.15260277e-02,  -1.32746577e-05,
        -3.41995189e-09,  -8.81082680e-13,  -2.26993453e-16,
        -5.84803548e-20,  -1.50663019e-23,  -3.88153345e-27,
        -1.00000000e-30,   0.00000000e+00,   1.00000000e-30,
         1.09050773e-26,   1.18920712e-22,   1.29683955e-18,
         1.41421356e-14,   1.54221083e-10,   1.68179283e-06,
         1.83400809e-02,   2.00000000e+02])
```


