### PR TITLE
ENH: special: add long double implentations of `expi`, `exp1`

### DIFF
--- a/scipy/special/_expi.pxd
+++ b/scipy/special/_expi.pxd
@@ -1,0 +1,64 @@
+# Compute the exponential integral.
+
+from ._floatingstuff cimport *
+
+
+cdef inline floating expi(floating x) nogil:
+    """Compute the exponential integral Ei(x)."""
+    cdef int k
+    cdef floating ei, one, r
+
+    if x == <floating>0:
+        ei = -infinity(x)
+    elif x < <floating>0:
+        ei = -exp1(-x)
+    elif fabs(x) <= <floating>40:
+        # Power series around x = 0
+        ei = <floating>1
+        r = <floating>1
+        for k in range(1, 101):
+            r *= k*x/(k + <floating>1)**2
+            ei += r
+            if fabs(r) <= eps(x)*fabs(ei):
+                break
+        ei = euler(x) + log(x) + x*ei
+    else:
+        # Asymptotic expansion
+        ei = <floating>1
+        r = <floating>1
+        for k in range(1, 21):
+            r *= k/x
+            ei += r
+        ei = exp(x)/x*ei
+    return ei
+
+
+cdef inline floating exp1(floating x) nogil:
+    """Compute the exponential integral E1(x)."""
+    cdef int k, m
+    cdef floating e1, r, t, t0
+
+    if x == <floating>0:
+        e1 = infinity(x)
+    if x < <floating>0:
+        return nan(x)
+    elif x <= <floating>1:
+        e1 = <floating>1
+        r = <floating>1
+        for k in range(1,26):
+            r *= -k*x/(k + <floating>1)**2
+            e1 += r
+            if fabs(r) <= eps(x)*fabs(e1):
+                break
+        e1 = -euler(x) - log(x) + x*e1
+    else:
+        m = 20 + <int>(<floating>80/x)
+        t0 = <floating>0
+        # Work around https://github.com/cython/cython/issues/532
+        k = m
+        while k > 0:
+            t0 = k/(<floating>1 + k/(x+t0))
+            k -= 1
+        t = (<floating>1)/(x + t0)
+        e1 = exp(-x)*t
+    return e1

--- a/scipy/special/_floatingstuff.pxd
+++ b/scipy/special/_floatingstuff.pxd
@@ -1,0 +1,98 @@
+# Utilities for writing generic functions with floating-point
+# arugments.
+
+ctypedef long double long_double
+
+ctypedef fused floating:
+    float
+    double
+    long_double
+
+cdef extern from "numpy/npy_math.h":
+    float NPY_INFINITYF
+    double NPY_INFINITY
+    long double NPY_INFINITYL
+    float NPY_NANF
+    double NPY_NAN
+    long double NPY_NANL
+    float NPY_EULERf
+    double NPY_EULER
+    long double NPY_EULERl
+
+cimport libc.math
+cdef extern from "math.h" nogil:
+    # These aren't in Cython's `math.pxd`
+    float logf(float)
+    long double logl(long double)
+    float fabsf(float)
+    long double fabsl(long double)
+    float expf(float)
+    long double expl(long double)
+
+cdef extern from "float.h":
+    float FLT_EPSILON
+    double DBL_EPSILON
+    long double LDBL_EPSILON
+
+
+cdef inline floating eps(floating x) nogil:
+    if floating is float:
+        return FLT_EPSILON
+    elif floating is double:
+        return DBL_EPSILON
+    else:
+        return LDBL_EPSILON
+
+
+cdef inline floating infinity(floating x) nogil:
+    if floating is float:
+        return NPY_INFINITYF
+    elif floating is double:
+        return NPY_INFINITY
+    else:
+        return NPY_INFINITYL
+
+
+cdef inline floating nan(floating x) nogil:
+    if floating is float:
+        return NPY_NANF
+    elif floating is double:
+        return NPY_NAN
+    else:
+        return NPY_NANL
+
+
+cdef inline floating euler(floating x) nogil:
+    if floating is float:
+        return NPY_EULERf
+    elif floating is double:
+        return NPY_EULER
+    else:
+        return NPY_EULERl
+
+
+cdef inline floating fabs(floating x) nogil:
+    if floating is float:
+        return fabsf(x)
+    elif floating is double:
+        return libc.math.fabs(x)
+    else:
+        return fabsl(x)
+
+
+cdef inline floating log(floating x) nogil:
+    if floating is float:
+        return logf(x)
+    elif floating is double:
+        return libc.math.log(x)
+    else:
+        return logl(x)
+
+
+cdef inline floating exp(floating x) nogil:
+    if floating is float:
+        return expf(x)
+    elif floating is double:
+        return libc.math.exp(x)
+    else:
+        return expl(x)

--- a/scipy/special/_generate_pyx.py
+++ b/scipy/special/_generate_pyx.py
@@ -152,8 +152,8 @@ iv -- iv: dd->d, cbesi_wrap: dD->D                         -- cephes.h, amos_wra
 ive -- cbesi_wrap_e_real: dd->d, cbesi_wrap_e: dD->D       -- amos_wrappers.h
 ellipj -- ellpj: dd*dddd->*i                               -- cephes.h
 expn -- expn: id->d, expn_unsafe: dd->d                    -- cephes.h, _legacy.pxd
-exp1 -- exp1_wrap: d->d, cexp1_wrap: D->D                  -- specfun_wrappers.h
-expi -- expi_wrap: d->d, cexpi_wrap: D->D                  -- specfun_wrappers.h
+exp1 -- exp1[float]: f->f, exp1[double]: d->d, exp1[long_double]: g->g, cexp1_wrap: D->D -- _expi.pxd, _expi.pxd, _expi.pxd, specfun_wrappers.h
+expi -- expi[float]: f->f, expi[double]: d->d, expi[long_double]: g->g, cexpi_wrap: D->D -- _expi.pxd, _expi.pxd, _expi.pxd, specfun_wrappers.h
 kn -- cbesk_wrap_real_int: id->d, kn_unsafe: dd->d         -- cephes.h, _legacy.pxd
 pdtrc -- pdtrc: id->d, pdtrc_unsafe: dd->d                 -- cephes.h, _legacy.pxd
 pdtr -- pdtr: id->d, pdtr_unsafe: dd->d                    -- cephes.h, _legacy.pxd

--- a/scipy/special/_mptestutils.py
+++ b/scipy/special/_mptestutils.py
@@ -248,6 +248,31 @@ def nonfunctional_tooslow(func):
 # Tools for dealing with mpmath quirks
 # ------------------------------------------------------------------------------
 
+def longdouble2mpf(x):
+    """Mpmath doesn't know how to convert np.longdouble to mpf."""
+    digits = int(-np.log10(np.finfo(np.longdouble).resolution)) + 1
+    fmt = "{{:.{}e}}".format(digits)
+    return mpmath.mpf(fmt.format(x))
+
+
+def mpf2longdouble(x):
+    """NumPy won't correctly convert mpf to longdouble."""
+    digits = int(-np.log10(np.finfo(np.longdouble).resolution)) + 1
+    try:
+        return np.longdouble(mpmath.nstr(x, digits))
+    except ValueError:
+        # The result couldn't be represented, and NumPy raises instead
+        # of overflowing/underflowing
+        if x > 1:
+            return np.longdouble(np.inf)
+        elif x > 0:
+            return np.longdouble(0.0)
+        elif x < -1:
+            return -np.longdouble(np.inf)
+        else:
+            return np.longdouble(-0.0)
+
+
 def mpf2float(x):
     """
     Convert an mpf to the nearest floating point number. Just using

--- a/scipy/special/_mptestutils.py
+++ b/scipy/special/_mptestutils.py
@@ -256,24 +256,6 @@ def longdouble2mpf(x):
     return mpmath.mpf(x)
 
 
-def mpf2longdouble(x):
-    """NumPy won't correctly convert mpf to longdouble."""
-    digits = int(-np.log10(np.finfo(np.longdouble).resolution)) + 5
-    try:
-        return np.longdouble(mpmath.nstr(x, digits))
-    except ValueError:
-        # The result couldn't be represented, and NumPy raises instead
-        # of overflowing/underflowing
-        if x > 1:
-            return np.longdouble(np.inf)
-        elif x > 0:
-            return np.longdouble(0.0)
-        elif x < -1:
-            return -np.longdouble(np.inf)
-        else:
-            return np.longdouble(-0.0)
-
-
 def mpf2float(x):
     """
     Convert an mpf to the nearest floating point number. Just using
@@ -415,7 +397,7 @@ def mp_assert_allclose(res, std, atol=0, rtol=1e-17):
         except AssertionError:
             failures.append(k)
 
-    ndigits = int(abs(np.log10(rtol)))
+    ndigits = int(abs(mpmath.log10(rtol)))
     msg = [""]
     msg.append("Bad results ({} out of {}) for the following points:"
                .format(len(failures), n))

--- a/scipy/special/_mptestutils.py
+++ b/scipy/special/_mptestutils.py
@@ -250,14 +250,15 @@ def nonfunctional_tooslow(func):
 
 def longdouble2mpf(x):
     """Mpmath doesn't know how to convert np.longdouble to mpf."""
-    digits = int(-np.log10(np.finfo(np.longdouble).resolution)) + 1
-    fmt = "{{:.{}e}}".format(digits)
-    return mpmath.mpf(fmt.format(x))
+    digits = int(-np.log10(np.finfo(np.longdouble).resolution)) + 5
+    x = np.array([x], dtype=np.longdouble)
+    x = np.array_str(x, precision=digits).strip('[]')
+    return mpmath.mpf(x)
 
 
 def mpf2longdouble(x):
     """NumPy won't correctly convert mpf to longdouble."""
-    digits = int(-np.log10(np.finfo(np.longdouble).resolution)) + 1
+    digits = int(-np.log10(np.finfo(np.longdouble).resolution)) + 5
     try:
         return np.longdouble(mpmath.nstr(x, digits))
     except ValueError:

--- a/scipy/special/_ufuncs_extra_code.pxi
+++ b/scipy/special/_ufuncs_extra_code.pxi
@@ -1,6 +1,7 @@
 cimport scipy.special._ufuncs_cxx
 import numpy as np
 
+ctypedef long double long_double
 
 _sf_error_code_map = {
     # skip 'ok'
@@ -65,7 +66,7 @@ def geterr():
     singular: ignore
     slow: ignore
     underflow: ignore
-    
+
     """
     err = {}
     for key, code in _sf_error_code_map.items():
@@ -212,7 +213,7 @@ class errstate(object):
     """
     def __init__(self, **kwargs):
         self.kwargs = kwargs
-    
+
     def __enter__(self):
         self.oldstate = seterr(**self.kwargs)
 

--- a/scipy/special/specfun/specfun.f
+++ b/scipy/special/specfun/specfun.f
@@ -5584,45 +5584,6 @@ C
 
 C       **********************************
 
-        SUBROUTINE EIX(X,EI)
-C
-C       ============================================
-C       Purpose: Compute exponential integral Ei(x)
-C       Input :  x  --- Argument of Ei(x)
-C       Output:  EI --- Ei(x)
-C       ============================================
-C
-        IMPLICIT DOUBLE PRECISION (A-H,O-Z)
-        IF (X.EQ.0.0) THEN
-           EI=-1.0D+300
-        ELSE IF (X .LT. 0) THEN
-           CALL E1XB(-X, EI)
-           EI = -EI
-        ELSE IF (DABS(X).LE.40.0) THEN
-C          Power series around x=0
-           EI=1.0D0
-           R=1.0D0
-           DO 15 K=1,100
-              R=R*K*X/(K+1.0D0)**2
-              EI=EI+R
-              IF (DABS(R/EI).LE.1.0D-15) GO TO 20
-15         CONTINUE
-20         GA=0.5772156649015328D0
-           EI=GA+DLOG(X)+X*EI
-        ELSE
-C          Asymptotic expansion (the series is not convergent)
-           EI=1.0D0
-           R=1.0D0
-           DO 25 K=1,20
-              R=R*K/X
-25            EI=EI+R
-           EI=DEXP(X)/X*EI
-        ENDIF
-        RETURN
-        END
-
-C       **********************************
-
         SUBROUTINE EIXZ(Z,CEI)
 C
 C       ============================================
@@ -5645,41 +5606,6 @@ C
            IF (DBLE(Z).GT.0) THEN
               CEI = CEI - (0d0,1d0)*PI
            ENDIF
-        ENDIF
-        RETURN
-        END
-
-C       **********************************
-
-        SUBROUTINE E1XB(X,E1)
-C
-C       ============================================
-C       Purpose: Compute exponential integral E1(x)
-C       Input :  x  --- Argument of E1(x)
-C       Output:  E1 --- E1(x)  ( x > 0 )
-C       ============================================
-C
-        IMPLICIT DOUBLE PRECISION (A-H,O-Z)
-        IF (X.EQ.0.0) THEN
-           E1=1.0D+300
-        ELSE IF (X.LE.1.0) THEN
-           E1=1.0D0
-           R=1.0D0
-           DO 10 K=1,25
-              R=-R*K*X/(K+1.0D0)**2
-              E1=E1+R
-              IF (DABS(R).LE.DABS(E1)*1.0D-15) GO TO 15
-10         CONTINUE
-15         GA=0.5772156649015328D0
-           E1=-GA-DLOG(X)+X*E1
-        ELSE
-           M=20+INT(80.0/X)
-           T0=0.0D0
-           DO 20 K=M,1,-1
-              T0=K/(1.0D0+K/(X+T0))
-20         CONTINUE
-           T=1.0D0/(X+T0)
-           E1=DEXP(-X)*T
         ENDIF
         RETURN
         END
@@ -12043,32 +11969,6 @@ C
 25         DK(K)=-SK(K-1)-(K+1.0D0)/X*SK(K)
         RETURN
         END
-
-C       **********************************
-
-        SUBROUTINE ENXA(N,X,EN)
-C
-C       ============================================
-C       Purpose: Compute exponential integral En(x)
-C       Input :  x --- Argument of En(x) ( x ≤ 20 )
-C                n --- Order of En(x)
-C       Output:  EN(n) --- En(x)
-C       Routine called: E1XB for computing E1(x)
-C       ============================================
-C
-        IMPLICIT DOUBLE PRECISION (A-H,O-Z)
-        DIMENSION EN(0:N)
-        EN(0)=DEXP(-X)/X
-        CALL E1XB(X,E1)
-        EN(1)=E1
-        DO 10 K=2,N
-           EK=(DEXP(-X)-X*E1)/(K-1.0D0)
-           EN(K)=EK
-10         E1=EK
-        RETURN
-        END
-
-
 
 C       **********************************
 

--- a/scipy/special/specfun_wrappers.c
+++ b/scipy/special/specfun_wrappers.c
@@ -160,29 +160,12 @@ int itairy_wrap(double x, double *apt, double *bpt, double *ant, double *bnt) {
   return 0;
 }
 
-
-double exp1_wrap(double x) {
-  double out;
-
-  F_FUNC(e1xb,E1XB)(&x, &out);
-  CONVINF("exp1", out);
-  return out;
-}
-
 npy_cdouble cexp1_wrap(npy_cdouble z) {
   npy_cdouble outz;
 
   F_FUNC(e1z,E1Z)(&z, &outz);
   ZCONVINF("cexp1", outz);
   return outz;
-}
-
-double expi_wrap(double x) {
-  double out;
-
-  F_FUNC(eix,EIX)(&x, &out);
-  CONVINF("expi", out);
-  return out;
 }
 
 npy_cdouble cexpi_wrap(npy_cdouble z) {

--- a/scipy/special/specfun_wrappers.h
+++ b/scipy/special/specfun_wrappers.h
@@ -1,5 +1,5 @@
 /* This file is a collection of wrappers around the
- *  Special Function  Fortran library of functions 
+ *  Special Function  Fortran library of functions
  *  to be compiled with the other special functions in cephes
  *
  * Functions written by Shanjie Zhang and Jianming Jin.
@@ -47,8 +47,6 @@ npy_cdouble chyp2f1_wrap( double a, double b, double c, npy_cdouble z);
 npy_cdouble chyp1f1_wrap( double a, double b, npy_cdouble z);
 double hyp1f1_wrap( double a, double b, double x);
 double hypU_wrap(double a, double b, double x);
-double exp1_wrap(double x);
-double expi_wrap(double x);
 npy_cdouble cexp1_wrap(npy_cdouble z);
 npy_cdouble cexpi_wrap(npy_cdouble z);
 npy_cdouble cerf_wrap(npy_cdouble z);
@@ -111,15 +109,3 @@ double oblate_segv_wrap(double, double, double);
 int modified_fresnel_plus_wrap(double x, npy_cdouble *F, npy_cdouble *K);
 int modified_fresnel_minus_wrap(double x, npy_cdouble *F, npy_cdouble *K);
 #endif
-
-
-
-
-  
-
-
-
-
-
-
-

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -20,7 +20,7 @@ from scipy.special._testutils import (
 from scipy.special._mptestutils import (
     Arg, FixedArg, ComplexArg, IntArg, assert_mpmath_equal,
     nonfunctional_tooslow, trace_args, time_limited, exception_to_nan,
-    inf_to_nan)
+    inf_to_nan, longdouble2mpf, mpf2longdouble)
 from scipy.special._ufuncs import (
     _sinpi, _cospi, _lgam1p, _lanczos_sum_expg_scaled, _log1pmx,
     _igam_fac)
@@ -49,6 +49,51 @@ def test_expi_complex():
 
     FuncData(sc.expi, dataset, 0, 1).check()
 
+
+@check_version(mpmath, '0.19')
+def test_expi_large_arguments():
+    # Function behaves roughly like exp(x); test it at extreme long
+    # double arguments.
+    info = np.finfo(np.longdouble)
+    eps = info.eps
+    digits = int(-np.log10(info.resolution)) + 1
+
+    xmax = 0.5*np.finfo(np.longdouble).max
+    xmin = 1e-100*xmax
+    xmax, xmin = np.log(xmax), np.log(xmin)
+    pospts = np.logspace(np.log10(xmin), np.log10(xmax),
+                         dtype=np.longdouble)
+
+    dataset = []
+    with mpmath.workdps(digits + 10):
+        for x in np.hstack((-pospts, pospts)):
+            res = mpf2longdouble(mpmath.ei(longdouble2mpf(x)))
+            dataset.append((x, res))
+    dataset = np.array(dataset, dtype=np.longdouble)
+
+    FuncData(sc.expi, dataset, 0, 1, rtol=2**13*eps).check()
+
+
+# ------------------------------------------------------------------------------
+# exp1
+# ------------------------------------------------------------------------------
+
+@check_version(mpmath, '0.19')
+def test_exp1_large_arguments():
+    # Function behaves roughly like exp(-x); test it at extreme long
+    # double arguments.
+    eps = np.finfo(np.longdouble).eps
+    xmax = 0.1*np.finfo(np.longdouble).max
+    xmin = 1e-100*xmax
+    xmax, xmin = np.log(xmax), np.log(xmin)
+
+    dataset = []
+    for x in np.logspace(np.log10(xmin), np.log10(xmax)):
+        res = mpf2longdouble(mpmath.e1(longdouble2mpf(x)))
+        dataset.append((x, res))
+    dataset = np.array(dataset, dtype=np.longdouble)
+
+    FuncData(sc.exp1, dataset, 0, 1, rtol=2**10*eps).check()
 
 # ------------------------------------------------------------------------------
 # expn

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -71,7 +71,8 @@ def test_expi_large_arguments():
             dataset.append((x, res))
     dataset = np.array(dataset, dtype=np.longdouble)
 
-    FuncData(sc.expi, dataset, 0, 1, rtol=2**13*eps).check()
+    rtol = np.ldexp(eps, 3)
+    FuncData(sc.expi, dataset, 0, 1, rtol=rtol).check()
 
 
 # ------------------------------------------------------------------------------
@@ -82,18 +83,23 @@ def test_expi_large_arguments():
 def test_exp1_large_arguments():
     # Function behaves roughly like exp(-x); test it at extreme long
     # double arguments.
-    eps = np.finfo(np.longdouble).eps
-    xmax = 0.1*np.finfo(np.longdouble).max
+    info = np.finfo(np.longdouble)
+    eps = info.eps
+    digits = int(-np.log10(info.resolution)) + 1
+
+    xmax = 0.5*np.finfo(np.longdouble).max
     xmin = 1e-100*xmax
     xmax, xmin = np.log(xmax), np.log(xmin)
 
     dataset = []
-    for x in np.logspace(np.log10(xmin), np.log10(xmax)):
-        res = mpf2longdouble(mpmath.e1(longdouble2mpf(x)))
-        dataset.append((x, res))
+    with mpmath.workdps(digits + 10):
+        for x in np.logspace(np.log10(xmin), np.log10(xmax)):
+            res = mpf2longdouble(mpmath.e1(longdouble2mpf(x)))
+            dataset.append((x, res))
     dataset = np.array(dataset, dtype=np.longdouble)
 
-    FuncData(sc.exp1, dataset, 0, 1, rtol=2**10*eps).check()
+    rtol = np.ldexp(eps, 3)
+    FuncData(sc.exp1, dataset, 0, 1, rtol=rtol).check()
 
 # ------------------------------------------------------------------------------
 # expn

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -71,7 +71,7 @@ def test_expi_large_arguments():
             dataset.append((x, res))
     dataset = np.array(dataset, dtype=np.longdouble)
 
-    rtol = np.ldexp(eps, 3)
+    rtol = np.ldexp(eps, 5)
     FuncData(sc.expi, dataset, 0, 1, rtol=rtol).check()
 
 
@@ -98,7 +98,7 @@ def test_exp1_large_arguments():
             dataset.append((x, res))
     dataset = np.array(dataset, dtype=np.longdouble)
 
-    rtol = np.ldexp(eps, 3)
+    rtol = np.ldexp(eps, 5)
     FuncData(sc.exp1, dataset, 0, 1, rtol=rtol).check()
 
 # ------------------------------------------------------------------------------

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -20,7 +20,7 @@ from scipy.special._testutils import (
 from scipy.special._mptestutils import (
     Arg, FixedArg, ComplexArg, IntArg, assert_mpmath_equal,
     nonfunctional_tooslow, trace_args, time_limited, exception_to_nan,
-    inf_to_nan, longdouble2mpf, mpf2longdouble)
+    inf_to_nan, longdouble2mpf, mp_assert_allclose)
 from scipy.special._ufuncs import (
     _sinpi, _cospi, _lgam1p, _lanczos_sum_expg_scaled, _log1pmx,
     _igam_fac)
@@ -55,24 +55,23 @@ def test_expi_large_arguments():
     # Function behaves roughly like exp(x); test it at extreme long
     # double arguments.
     info = np.finfo(np.longdouble)
-    eps = info.eps
     digits = int(-np.log10(info.resolution)) + 1
 
     xmax = 0.5*np.finfo(np.longdouble).max
     xmin = 1e-100*xmax
     xmax, xmin = np.log(xmax), np.log(xmin)
-    pospts = np.logspace(np.log10(xmin), np.log10(xmax),
-                         dtype=np.longdouble)
+    pospts = np.logspace(np.log10(xmin), np.log10(xmax))
+    pts = np.hstack((-pospts, pospts))
 
-    dataset = []
+    std = []
     with mpmath.workdps(digits + 10):
-        for x in np.hstack((-pospts, pospts)):
-            res = mpf2longdouble(mpmath.ei(longdouble2mpf(x)))
-            dataset.append((x, res))
-    dataset = np.array(dataset, dtype=np.longdouble)
+        for x in pts:
+            std.append(mpmath.ei(longdouble2mpf(x)))
+        res = [longdouble2mpf(x) for x in sc.expi(pts)]
 
-    rtol = np.ldexp(eps, 5)
-    FuncData(sc.expi, dataset, 0, 1, rtol=rtol).check()
+        atol = longdouble2mpf(5*info.tiny)
+        rtol = longdouble2mpf(np.ldexp(info.eps, 5))
+        mp_assert_allclose(res, std, atol=atol, rtol=rtol)
 
 
 # ------------------------------------------------------------------------------
@@ -84,22 +83,23 @@ def test_exp1_large_arguments():
     # Function behaves roughly like exp(-x); test it at extreme long
     # double arguments.
     info = np.finfo(np.longdouble)
-    eps = info.eps
     digits = int(-np.log10(info.resolution)) + 1
 
     xmax = 0.5*np.finfo(np.longdouble).max
     xmin = 1e-100*xmax
     xmax, xmin = np.log(xmax), np.log(xmin)
+    pts = np.logspace(np.log10(xmin), np.log10(xmax))
 
-    dataset = []
+    std = []
     with mpmath.workdps(digits + 10):
-        for x in np.logspace(np.log10(xmin), np.log10(xmax)):
-            res = mpf2longdouble(mpmath.e1(longdouble2mpf(x)))
-            dataset.append((x, res))
-    dataset = np.array(dataset, dtype=np.longdouble)
+        for x in pts:
+            std.append(mpmath.e1(longdouble2mpf(x)))
+        res = [longdouble2mpf(x) for x in sc.exp1(pts)]
 
-    rtol = np.ldexp(eps, 5)
-    FuncData(sc.exp1, dataset, 0, 1, rtol=rtol).check()
+        atol = longdouble2mpf(5*info.tiny)
+        rtol = longdouble2mpf(np.ldexp(info.eps, 5))
+        mp_assert_allclose(res, std, atol=atol, rtol=rtol)
+
 
 # ------------------------------------------------------------------------------
 # expn


### PR DESCRIPTION
This ports the current Fortran implementation to Cython and uses fused
types so that the new dispatches share a common implementation.

Closes gh-1853.

Note that some of the testing machinery is not set up to handle long doubles. If we want to do more of this in the future (I think we should) then we'll have to improve it.