### PR TITLE
BUG: fix solve_lyapunov import

### DIFF
--- a/scipy/linalg/_solvers.py
+++ b/scipy/linalg/_solvers.py
@@ -25,6 +25,7 @@ from .special_matrices import kron, block_diag
 
 __all__ = ['solve_sylvester',
            'solve_continuous_lyapunov', 'solve_discrete_lyapunov',
+           'solve_lyapunov',
            'solve_continuous_are', 'solve_discrete_are']
 
 


### PR DESCRIPTION
Currently, `scipy.linalg.solve_lyapunov` is not importable.

The documentation says:
"The old name is kept for backwards-compatibility."
https://docs.scipy.org/doc/scipy/reference/release.1.0.0.html#other-changes

However, the old name is missing from `__all__`, so it is not picked up
by `__init__.py`, despite the request in issue #6622 which sparked the
rename:
https://github.com/scipy/scipy/issues/6622#issuecomment-249624589