### PR TITLE
BLD: Fix npy_isnan of integer variables in cephes

### DIFF
--- a/scipy/special/cephes/bdtr.c
+++ b/scipy/special/cephes/bdtr.c
@@ -154,7 +154,7 @@ double p;
 {
     double dk, dn;
 
-    if (npy_isnan(k) || npy_isnan(n) || npy_isnan(p)) {
+    if (npy_isnan(p)) {
 	return NPY_NAN;
     }
     if ((p < 0.0) || (p > 1.0)) {


### PR DESCRIPTION
Commit ede5590b12dbeecd244fdafa4443b6c3a9d9ef40 (BUG: special: fix
ufunc results for nan arguments) started to apply npy_isnan to integer
arguments by mistake.  GCC's __builtin_isnan issues errors when
applied to integers, so depending on which implementation is chosen by
numpy, this can result in build errors.