### PR TITLE
ENH: Allow non-integral popsize for differential_evolution

### DIFF
--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -9,6 +9,7 @@ from scipy.optimize.optimize import _status_message
 from scipy._lib._util import check_random_state
 from scipy._lib.six import xrange
 import warnings
+from math import ceil
 
 
 __all__ = ['differential_evolution']
@@ -63,9 +64,9 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
         The maximum number of generations over which the entire population is
         evolved. The maximum number of function evaluations (with no polishing)
         is: ``(maxiter + 1) * popsize * len(x)``
-    popsize : int, optional
+    popsize : float, optional
         A multiplier for setting the total population size.  The population has
-        ``popsize * len(x)`` individuals.
+        ``ceil(popsize * len(x))`` individuals.
     tol : float, optional
         Relative tolerance for convergence, the solving stops when
         ``np.std(pop) <= atol + tol * np.abs(np.mean(population_energies))``,
@@ -252,9 +253,9 @@ class DifferentialEvolutionSolver(object):
         The maximum number of generations over which the entire population is
         evolved. The maximum number of function evaluations (with no polishing)
         is: ``(maxiter + 1) * popsize * len(x)``
-    popsize : int, optional
+    popsize : float, optional
         A multiplier for setting the total population size.  The population has
-        ``popsize * len(x)`` individuals.
+        ``ceil(popsize * len(x))`` individuals.
     tol : float, optional
         Relative tolerance for convergence, the solving stops when
         ``np.std(pop) <= atol + tol * np.abs(np.mean(population_energies))``,
@@ -394,7 +395,7 @@ class DifferentialEvolutionSolver(object):
 
         # default population initialization is a latin hypercube design, but
         # there are other population initializations possible.
-        self.num_population_members = popsize * self.parameter_count
+        self.num_population_members = int(ceil(popsize * self.parameter_count))
 
         self.population_shape = (self.num_population_members,
                                  self.parameter_count)

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -426,3 +426,11 @@ class TestDifferentialEvolutionSolver(object):
         assert_equal(solver._nfev, 0)
         assert_(np.all(np.isinf(solver.population_energies)))
 
+    def test_non_integral_popsize(self):
+        # non-integral popsize
+        solver = DifferentialEvolutionSolver(rosen, self.bounds, popsize=5.1)
+        assert_equal(solver.num_population_members, 11)
+
+        # non-integral popsize < 1.0
+        solver = DifferentialEvolutionSolver(rosen, self.bounds, popsize=0.1)
+        assert_equal(solver.num_population_members, 1)


### PR DESCRIPTION
For large optimisation problems with expensive fitness functions it is not really practical to have the population size be an integer multiple of the number of parameters.

IMO the popsize parameter should directly specify the population size (instead of being a multiple) but in order to not break existing code we can allow floating point multiples to be used instead.