### PR TITLE
ENH: Add rand-to-best mutation strategy to differential_evolution.

### DIFF
--- a/doc/release/1.1.0-notes.rst
+++ b/doc/release/1.1.0-notes.rst
@@ -32,6 +32,14 @@ The function `scipy.linalg.ldl` has been added for factorization of
 indefinite symmetric/hermitian matrices into triangular and block
 diagonal matrices.
 
+`scipy.optimize` improvements
+-----------------------------
+
+Random-to-Best/1/bin and Random-to-Best/1/exp mutation strategies were added to
+`scipy.optimize.differential_evolution` as 'randtobest1bin' and
+'randtobest1exp', respectively. Note: These names were already in use but
+implemented a different mutation strategy. See Backwards incompatible changes,
+below.
 
 Deprecated features
 ===================
@@ -45,6 +53,12 @@ appropriate for double precision numbers also for single-precision
 input. The cutoff value is now tunable, and the default has been
 changed to depend on the input data precision.
 
+In previous versions of Scipy, the 'randtobest1bin' and 'randtobest1exp'
+mutation strategies in `scipy.optimize.differential_evolution` were actually
+implemented using the Current-to-Best/1/bin and Current-to-Best/1/exp
+strategies, respectively. These strategies were renamed to 'currenttobest1bin'
+and 'currenttobest1exp' and the implementations of 'randtobest1bin' and
+'randtobest1exp' strategies were corrected.
 
 Other changes
 =============

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -703,8 +703,7 @@ class DifferentialEvolutionSolver(object):
 
         fill_point = rng.randint(0, self.parameter_count)
 
-        if (self.strategy == 'currenttobest1exp' or
-                self.strategy == 'currenttobest1bin'):
+        if self.strategy == ['currenttobest1exp', 'currenttobest1bin']:
             bprime = self.mutation_func(candidate,
                                         self._select_samples(candidate, 5))
         else:
@@ -764,10 +763,9 @@ class DifferentialEvolutionSolver(object):
         currenttobest1bin, currenttobest1exp
         """
         r0, r1 = samples[:2]
-        bprime = np.copy(self.population[candidate])
-        bprime += self.scale * (self.population[0] - bprime)
-        bprime += self.scale * (self.population[r0] -
-                                self.population[r1])
+        bprime = (self.population[candidate] + self.scale * 
+                  (self.population[0] - self.population[candidate] +
+                   self.population[r0] - self.population[r1]))
         return bprime
 
     def _best2(self, samples):

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -51,9 +51,11 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
             - 'best1exp'
             - 'rand1exp'
             - 'randtobest1exp'
+            - 'currenttobest1exp'
             - 'best2exp'
             - 'rand2exp'
             - 'randtobest1bin'
+            - 'currenttobest1bin'
             - 'best2bin'
             - 'rand2bin'
             - 'rand1bin'
@@ -239,9 +241,11 @@ class DifferentialEvolutionSolver(object):
             - 'best1exp'
             - 'rand1exp'
             - 'randtobest1exp'
+            - 'currenttobest1exp'
             - 'best2exp'
             - 'rand2exp'
             - 'randtobest1bin'
+            - 'currenttobest1bin'
             - 'best2bin'
             - 'rand2bin'
             - 'rand1bin'
@@ -315,12 +319,14 @@ class DifferentialEvolutionSolver(object):
     # Dispatch of mutation strategy method (binomial or exponential).
     _binomial = {'best1bin': '_best1',
                  'randtobest1bin': '_randtobest1',
+                 'currenttobest1bin': '_currenttobest1',
                  'best2bin': '_best2',
                  'rand2bin': '_rand2',
                  'rand1bin': '_rand1'}
     _exponential = {'best1exp': '_best1',
                     'rand1exp': '_rand1',
                     'randtobest1exp': '_randtobest1',
+                    'currenttobest1exp': '_currenttobest1',
                     'best2exp': '_best2',
                     'rand2exp': '_rand2'}
 
@@ -697,8 +703,8 @@ class DifferentialEvolutionSolver(object):
 
         fill_point = rng.randint(0, self.parameter_count)
 
-        if (self.strategy == 'randtobest1exp' or
-                self.strategy == 'randtobest1bin'):
+        if (self.strategy == 'currenttobest1exp' or
+                self.strategy == 'currenttobest1bin'):
             bprime = self.mutation_func(candidate,
                                         self._select_samples(candidate, 5))
         else:
@@ -742,9 +748,20 @@ class DifferentialEvolutionSolver(object):
         return (self.population[r0] + self.scale *
                 (self.population[r1] - self.population[r2]))
 
-    def _randtobest1(self, candidate, samples):
+    def _randtobest1(self, samples):
         """
         randtobest1bin, randtobest1exp
+        """
+        r0, r1, r2 = samples[:3]
+        bprime = np.copy(self.population[r0])
+        bprime += self.scale * (self.population[0] - bprime)
+        bprime += self.scale * (self.population[r1] -
+                                self.population[r2])
+        return bprime
+
+    def _currenttobest1(self, candidate, samples):
+        """
+        currenttobest1bin, currenttobest1exp
         """
         r0, r1 = samples[:2]
         bprime = np.copy(self.population[candidate])

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -703,7 +703,7 @@ class DifferentialEvolutionSolver(object):
 
         fill_point = rng.randint(0, self.parameter_count)
 
-        if self.strategy == ['currenttobest1exp', 'currenttobest1bin']:
+        if self.strategy in ['currenttobest1exp', 'currenttobest1bin']:
             bprime = self.mutation_func(candidate,
                                         self._select_samples(candidate, 5))
         else:

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -101,6 +101,18 @@ class TestDifferentialEvolutionSolver(object):
         assert_equal(solver.strategy, 'randtobest1exp')
         assert_equal(solver.mutation_func.__name__, '_randtobest1')
 
+        solver = DifferentialEvolutionSolver(rosen,
+                                             self.bounds,
+                                             strategy='currenttobest1bin')
+        assert_equal(solver.strategy, 'currenttobest1bin')
+        assert_equal(solver.mutation_func.__name__, '_currenttobest1')
+
+        solver = DifferentialEvolutionSolver(rosen,
+                                             self.bounds,
+                                             strategy='currenttobest1exp')
+        assert_equal(solver.strategy, 'currenttobest1exp')
+        assert_equal(solver.mutation_func.__name__, '_currenttobest1')
+
     def test__mutate1(self):
         # strategies */1/*, i.e. rand/1/bin, best/1/exp, etc.
         result = np.array([0.05])
@@ -125,8 +137,14 @@ class TestDifferentialEvolutionSolver(object):
 
     def test__randtobest1(self):
         # strategies randtobest/1/*
+        result = np.array([0.15])
+        trial = self.dummy_solver2._randtobest1((2, 3, 4, 5, 6))
+        assert_allclose(trial, result)
+
+    def test__currenttobest1(self):
+        # strategies currenttobest/1/*
         result = np.array([0.1])
-        trial = self.dummy_solver2._randtobest1(1, (2, 3, 4, 5, 6))
+        trial = self.dummy_solver2._currenttobest1(1, (2, 3, 4, 5, 6))
         assert_allclose(trial, result)
 
     def test_can_init_with_dithering(self):


### PR DESCRIPTION
The existing 'randtobest1exp' and 'randtobest1bin' strategies actually perform current-to-best mutation.
This PR renames them to 'currenttobest1exp' and 'currenttobest1bin' and add the correct rand-to-best mutation methods.