### PR TITLE
TST: special: simplify `Arg`

### DIFF
--- a/scipy/special/_mptestutils.py
+++ b/scipy/special/_mptestutils.py
@@ -22,66 +22,114 @@ except ImportError:
 # ------------------------------------------------------------------------------
 
 class Arg(object):
-    """
-    Generate a set of numbers on the real axis, concentrating on
+    """Generate a set of numbers on the real axis, concentrating on
     'interesting' regions and covering all orders of magnitude.
+
     """
 
     def __init__(self, a=-np.inf, b=np.inf, inclusive_a=True, inclusive_b=True):
-        self.a = a
-        self.b = b
-        self.inclusive_a = inclusive_a
-        self.inclusive_b = inclusive_b
-        if self.a == -np.inf:
-            self.a = -np.finfo(float).max/2
-        if self.b == np.inf:
-            self.b = np.finfo(float).max/2
+        if a > b:
+            raise ValueError("a should be less than or equal to b")
+        if a == -np.inf:
+            a = -0.5*np.finfo(float).max
+        if b == np.inf:
+            b = 0.5*np.finfo(float).max
+        self.a, self.b = a, b
+
+        self.inclusive_a, self.inclusive_b = inclusive_a, inclusive_b
+
+    def _positive_values(self, a, b, n):
+        if a < 0:
+            raise ValueError("a should be positive")
+
+        # Try to put half of the points into a linspace between a and
+        # 10 the other half in a logspace.
+        if n % 2 == 0:
+            nlogpts = n//2
+            nlinpts = nlogpts
+        else:
+            nlogpts = n//2
+            nlinpts = nlogpts + 1
+
+        if a >= 10:
+            # Outside of linspace range; just return a logspace.
+            pts = np.logspace(np.log10(a), np.log10(b), n)
+        elif a > 0 and b < 10:
+            # Outside of logspace range; just return a linspace
+            pts = np.linspace(a, b, n)
+        elif a > 0:
+            # Linspace between a and 10 and a logspace between 10 and
+            # b.
+            linpts = np.linspace(a, 10, nlinpts, endpoint=False)
+            logpts = np.logspace(1, np.log10(b), nlogpts)
+            pts = np.hstack((linpts, logpts))
+        elif a == 0 and b <= 10:
+            # Linspace between 0 and b and a logspace between 0 and
+            # the smallest positive point of the linspace
+            linpts = np.linspace(0, b, nlinpts)
+            if linpts.size > 1:
+                right = np.log10(linpts[1])
+            else:
+                right = -30
+            logpts = np.logspace(-30, right, nlogpts, endpoint=False)
+            pts = np.hstack((logpts, linpts))
+        else:
+            # Linspace between 0 and 10, logspace between 0 and the
+            # smallest positive point of the linspace, and a logspace
+            # between 10 and b.
+            if nlogpts % 2 == 0:
+                nlogpts1 = nlogpts//2
+                nlogpts2 = nlogpts1
+            else:
+                nlogpts1 = nlogpts//2
+                nlogpts2 = nlogpts1 + 1
+            linpts = np.linspace(0, 10, nlinpts, endpoint=False)
+            if linpts.size > 1:
+                right = np.log10(linpts[1])
+            else:
+                right = -30
+            logpts1 = np.logspace(-30, right, nlogpts1, endpoint=False)
+            logpts2 = np.logspace(1, np.log10(b), nlogpts2)
+            pts = np.hstack((logpts1, linpts, logpts2))
+
+        return np.sort(pts)
 
     def values(self, n):
-        """Return an array containing approximatively `n` numbers."""
-        n1 = max(2, int(0.3*n))
-        n2 = max(2, int(0.2*n))
-        n3 = max(8, n - n1 - n2)
+        """Return an array containing n numbers."""
+        a, b = self.a, self.b
+        if a == b:
+            return np.zeros(n)
 
-        v1 = np.linspace(-1, 1, n1)
-        v2 = np.r_[np.linspace(-10, 10, max(0, n2-4)),
-                   -9, -5.5, 5.5, 9]
-        if self.a >= 0 and self.b > 0:
-            v3 = np.r_[
-                np.logspace(-30, -1, 2 + n3//4),
-                np.logspace(5, np.log10(self.b), 1 + n3//4),
-                ]
-            v4 = np.logspace(1, 5, 1 + n3//2)
-        elif self.a < 0 < self.b:
-            v3 = np.r_[
-                np.logspace(-30, -1, 2 + n3//8),
-                np.logspace(5, np.log10(self.b), 1 + n3//8),
-                -np.logspace(-30, -1, 2 + n3//8),
-                -np.logspace(5, np.log10(-self.a), 1 + n3//8)
-                ]
-            v4 = np.r_[
-                np.logspace(1, 5, 1 + n3//4),
-                -np.logspace(1, 5, 1 + n3//4)
-                ]
-        elif self.b < 0:
-            v3 = np.r_[
-                -np.logspace(-30, -1, 2 + n3//4),
-                -np.logspace(5, np.log10(-self.b), 1 + n3//4),
-                ]
-            v4 = -np.logspace(1, 5, 1 + n3//2)
+        if not self.inclusive_a:
+            n += 1
+        if not self.inclusive_b:
+            n += 1
+
+        if n % 2 == 0:
+            n1 = n//2
+            n2 = n1
         else:
-            v3 = []
-            v4 = []
-        v = np.r_[v1, v2, v3, v4, 0]
-        if self.inclusive_a:
-            v = v[v >= self.a]
+            n1 = n//2
+            n2 = n1 + 1
+
+        if a >= 0:
+            pospts = self._positive_values(a, b, n)
+            negpts = []
+        elif b <= 0:
+            pospts = []
+            negpts = -self._positive_values(-b, -a, n)
         else:
-            v = v[v > self.a]
-        if self.inclusive_b:
-            v = v[v <= self.b]
-        else:
-            v = v[v < self.b]
-        return np.unique(v)
+            pospts = self._positive_values(0, b, n1)
+            negpts = -self._positive_values(0, -a, n2 + 1)
+            # Don't want to get zero twice
+            negpts = negpts[1:]
+        pts = np.hstack((negpts[::-1], pospts))
+
+        if not self.inclusive_a:
+            pts = pts[1:]
+        if not self.inclusive_b:
+            pts = pts[:-1]
+        return pts
 
 
 class FixedArg(object):
@@ -98,9 +146,9 @@ class ComplexArg(object):
         self.imag = Arg(a.imag, b.imag)
 
     def values(self, n):
-        m = max(2, int(np.sqrt(n)))
+        m = int(np.floor(np.sqrt(n)))
         x = self.real.values(m)
-        y = self.imag.values(m)
+        y = self.imag.values(m + 1)
         return (x[:,None] + 1j*y[None,:]).ravel()
 
 

--- a/scipy/special/tests/test_cdflib.py
+++ b/scipy/special/tests/test_cdflib.py
@@ -46,7 +46,7 @@ class ProbArg(object):
         # Include the endpoints for compatibility with Arg et. al.
         self.a = 0
         self.b = 1
-    
+
     def values(self, n):
         """Return an array containing approximatively n numbers."""
         m = max(1, n//3)
@@ -68,7 +68,7 @@ class EndpointFilter(object):
         mask1 = np.abs(x - self.a) < self.rtol*np.abs(self.a) + self.atol
         mask2 = np.abs(x - self.b) < self.rtol*np.abs(self.b) + self.atol
         return np.where(mask1 | mask2, False, True)
-            
+
 
 class _CDFData(object):
     def __init__(self, spfunc, mpfunc, index, argspec, spfunc_first=True,
@@ -83,7 +83,7 @@ class _CDFData(object):
         self.n = n
         self.rtol = rtol
         self.atol = atol
-        
+
         if not isinstance(argspec, list):
             self.endpt_rtol = None
             self.endpt_atol = None
@@ -123,7 +123,7 @@ class _CDFData(object):
     def get_param_filter(self):
         if self.endpt_rtol is None and self.endpt_atol is None:
             return None
-        
+
         filters = []
         for rtol, atol, spec in zip(self.endpt_rtol, self.endpt_atol, self.argspec):
             if rtol is None and atol is None:
@@ -136,7 +136,7 @@ class _CDFData(object):
 
             filters.append(EndpointFilter(spec.a, spec.b, rtol, atol))
         return filters
-        
+
     def check(self):
         # Generate values for the arguments
         args = get_args(self.argspec, self.n)
@@ -173,7 +173,7 @@ def _f_cdf(dfn, dfd, x):
     ub = dfn*x/(dfn*x + dfd)
     res = mpmath.betainc(dfn/2, dfd/2, x2=ub, regularized=True)
     return res
-    
+
 
 def _student_t_cdf(df, t, dps=None):
     if dps is None:
@@ -224,12 +224,12 @@ class TestCDFlib(object):
             _binomial_cdf,
             1, [IntArg(1, 1000), ProbArg(), ProbArg()],
             rtol=1e-4, endpt_atol=[None, None, 1e-6])
-    
+
     def test_btdtria(self):
         _assert_inverts(
             sp.btdtria,
             lambda a, b, x: mpmath.betainc(a, b, x2=x, regularized=True),
-            0, [ProbArg(), Arg(0, 1e3, inclusive_a=False),
+            0, [ProbArg(), Arg(0, 1e2, inclusive_a=False),
                 Arg(0, 1, inclusive_a=False, inclusive_b=False)],
             rtol=1e-6)
 
@@ -240,7 +240,7 @@ class TestCDFlib(object):
             lambda a, b, x: mpmath.betainc(a, b, x2=x, regularized=True),
             1, [Arg(0, 1e2, inclusive_a=False), ProbArg(),
              Arg(0, 1, inclusive_a=False, inclusive_b=False)],
-            rtol=1e-7, endpt_atol=[None, 1e-20, 1e-20])
+            rtol=1e-7, endpt_atol=[None, 1e-18, 1e-15])
 
     @pytest.mark.xfail(run=False)
     def test_fdtridfd(self):
@@ -249,14 +249,14 @@ class TestCDFlib(object):
             _f_cdf,
             1, [IntArg(1, 100), ProbArg(), Arg(0, 100, inclusive_a=False)],
             rtol=1e-7)
-        
+
     def test_gdtria(self):
         _assert_inverts(
             sp.gdtria,
             lambda a, b, x: mpmath.gammainc(b, b=a*x, regularized=True),
             0, [ProbArg(), Arg(0, 1e3, inclusive_a=False),
                 Arg(0, 1e4, inclusive_a=False)], rtol=1e-7,
-            endpt_atol=[None, 1e-10, 1e-10])
+            endpt_atol=[None, 1e-7, 1e-10])
 
     def test_gdtrib(self):
         # Use small values of a and x or mpmath doesn't converge
@@ -272,7 +272,7 @@ class TestCDFlib(object):
             lambda a, b, x: mpmath.gammainc(b, b=a*x, regularized=True),
             2, [Arg(0, 1e3, inclusive_a=False), Arg(0, 1e3, inclusive_a=False),
                 ProbArg()], rtol=1e-7,
-            endpt_atol=[None, 1e-10, 1e-10])
+            endpt_atol=[None, 1e-7, 1e-10])
 
     def test_stdtr(self):
         # Ideally the left endpoint for Arg() should be 0.
@@ -319,7 +319,7 @@ class TestCDFlib(object):
             _noncentral_chi_cdf,
             2, [Arg(0, 100, inclusive_a=False), IntArg(1, 100), ProbArg()],
             n=1000, rtol=1e-4, atol=1e-15)
-        
+
     def test_chndtrix(self):
         # Use a larger atol since mpmath is doing numerical integration
         _assert_inverts(
@@ -341,9 +341,9 @@ class TestCDFlib(object):
         _assert_inverts(
             sp.tklmbda,
             _tukey_lmbda_quantile,
-            0, [ProbArg(), Arg(-np.inf, 0, inclusive_b=False)],
+            0, [ProbArg(), Arg(-25, 0, inclusive_b=False)],
             spfunc_first=False, rtol=1e-5,
-            endpt_atol=[1e-9, None])
+            endpt_atol=[1e-9, 1e-5])
 
     @pytest.mark.xfail(run=False)
     def test_tklmbda_pos_shape(self):

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -906,7 +906,7 @@ class TestSystematic(object):
                             np.array(bad_points),
                             dps=400,
                             ignore_inf_sign=True,
-                            atol=1e-14)
+                            atol=1e-11)
 
     def test_betainc(self):
         assert_mpmath_equal(sc.betainc,
@@ -1303,8 +1303,10 @@ class TestSystematic(object):
 
             # Mpmath 0.17 gives wrong results (spurious zero) in some cases, so
             # compute the value by perturbing the result
-            if float(r) == 0 and n <= 1-a and a < -1 and float(a) == int(float(a)):
+            if float(r) == 0 and a < -1 and float(a) == int(float(a)):
                 r = mpmath.gegenbauer(n, a + mpmath.mpf('1e-50'), x)
+                if abs(r) < mpmath.mpf('1e-50'):
+                    r = mpmath.mpf('0.0')
 
             # Differing overflow thresholds in scipy vs. mpmath
             if abs(r) > 1e270:
@@ -1319,9 +1321,9 @@ class TestSystematic(object):
             return r
         assert_mpmath_equal(sc_gegenbauer,
                             exception_to_nan(gegenbauer),
-                            [IntArg(0, 100), Arg(), Arg()],
+                            [IntArg(0, 100), Arg(-1e9, 1e9), Arg()],
                             n=40000, dps=100,
-                            ignore_inf_sign=True)
+                            ignore_inf_sign=True, rtol=1e-6)
 
         # Check the small-x expansion
         assert_mpmath_equal(sc_gegenbauer,
@@ -1377,7 +1379,7 @@ class TestSystematic(object):
     def test_hyp0f1_complex(self):
         assert_mpmath_equal(lambda a, z: sc.hyp0f1(a.real, z),
                             exception_to_nan(lambda a, x: mpmath.hyp0f1(a, x, **HYPERKW)),
-                            [Arg(-25, 25), ComplexArg(complex(-120, -120), complex(120, 120))])
+                            [Arg(-10, 10), ComplexArg(complex(-120, -120), complex(120, 120))])
         # NB: The range of the first parameter ("v") are limited by an overflow
         # in the intermediate calculations. Can be fixed by implementing an
         # asymptotic expansion for Bessel functions for large order.
@@ -1535,7 +1537,15 @@ class TestSystematic(object):
         g = 6.024680040776729583740234375
 
         def gamma(x):
-            return ((x + g - 0.5)/e)**(x - 0.5)*_lanczos_sum_expg_scaled(x)
+            with np.errstate(over='ignore'):
+                fac = ((x + g - 0.5)/e)**(x - 0.5)
+                if fac != np.inf:
+                    res = fac*_lanczos_sum_expg_scaled(x)
+                else:
+                    fac = ((x + g - 0.5)/e)**(0.5*(x - 0.5))
+                    res = fac*_lanczos_sum_expg_scaled(x)
+                    res *= fac
+            return res
 
         assert_mpmath_equal(gamma,
                             mpmath.gamma,
@@ -1607,7 +1617,8 @@ class TestSystematic(object):
 
         assert_mpmath_equal(lpnm_2,
                             legenp,
-                            [IntArg(-100, 100), Arg(-100, 100), Arg(-1, 1)])
+                            [IntArg(-100, 100), Arg(-100, 100), Arg(-1, 1)],
+                            atol=1e-10)
 
     def test_legenp_complex_2(self):
         def clpnm(n, m, z):
@@ -1745,11 +1756,11 @@ class TestSystematic(object):
         # is thus accurate in only a very small range.
         assert_mpmath_equal(pcfw,
                             mpmath.pcfw,
-                            [Arg(-5, 5), Arg(-5, 5)], rtol=1e-12, n=100)
+                            [Arg(-5, 5), Arg(-5, 5)], rtol=1e-8, n=100)
 
         assert_mpmath_equal(dpcfw,
                             mpmath_dpcfw,
-                            [Arg(-5, 5), Arg(-5, 5)], rtol=1e-12, n=100)
+                            [Arg(-5, 5), Arg(-5, 5)], rtol=1e-9, n=100)
 
     @pytest.mark.xfail(run=False, reason="issues at large arguments (atol OK, rtol not) and <eps-close to z=0")
     def test_polygamma(self):
@@ -1776,7 +1787,9 @@ class TestSystematic(object):
                             exception_to_nan(mpmath.rgamma),
                             [ComplexArg()], rtol=5e-13)
 
-    @pytest.mark.xfail(condition=_is_32bit_platform, reason="see gh-3551 for bad points")
+    @pytest.mark.xfail(reason=("see gh-3551 for bad points on 32 bit "
+                               "systems and gh-8095 for another bad "
+                               "point"))
     def test_rf(self):
         if LooseVersion(mpmath.__version__) >= LooseVersion("1.0.0"):
             # no workarounds needed


### PR DESCRIPTION
Take two of https://github.com/scipy/scipy/pull/8058; opened a new PR because the approach is different.

Roughly speaking this breaks up the test points into linearly-spaced points in `[-10, 10]`, log-spaced points near 0, and log-spaced points for large arguments while making sure endpoints are included and exactly the desired number of points is returned.

Closes gh-7924.