### PR TITLE
Input checking for scipy.sparse.linalg.inverse()

### DIFF
--- a/scipy/sparse/linalg/matfuncs.py
+++ b/scipy/sparse/linalg/matfuncs.py
@@ -72,7 +72,7 @@ def inv(A):
     """
     #check input
     if not scipy.sparse.isspmatrix(A):
-        raise TypeError('expected A to be a sparse matrix')
+        raise TypeError('Input must be a sparse matrix')
 
     I = speye(A.shape[0], A.shape[1], dtype=A.dtype, format=A.format)
     Ainv = spsolve(A, I)

--- a/scipy/sparse/linalg/matfuncs.py
+++ b/scipy/sparse/linalg/matfuncs.py
@@ -70,6 +70,10 @@ def inv(A):
     .. versionadded:: 0.12.0
 
     """
+    #check input
+    if not scipy.sparse.isspmatrix(A):
+        raise TypeError('expected A to be a sparse matrix')
+
     I = speye(A.shape[0], A.shape[1], dtype=A.dtype, format=A.format)
     Ainv = spsolve(A, I)
     return Ainv

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1068,6 +1068,7 @@ class _TestCommon(object):
                 sM = self.spmatrix(M, shape=(3,3), dtype=dtype)
                 sMinv = inv(sM)
             assert_array_almost_equal(sMinv.dot(sM).todense(), np.eye(3))
+            assert_raises(TypeError, inv, M)
         for dtype in [float]:
             check(dtype)
 


### PR DESCRIPTION
`scipy.sparse.linalg.inverse()` uses `speye()` and `spsolve()`, and therefore works only on sparse matrices, failing with a somewhat cryptic `AttributeError: 'matrix' object has no attribute 'format'` if a non-sparse matrix-like is passed.

This PR adds minimal input checking, raising a `TypeError` if a non-sparse matrix is passed.