### PR TITLE
DOC: Add missing colons in docstrings

### DIFF
--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -214,7 +214,7 @@ def freqs_zpk(z, p, k, worN=None):
 
     Notes
     -----
-    .. versionadded: 0.19.0
+    .. versionadded:: 0.19.0
 
     Examples
     --------
@@ -493,7 +493,7 @@ def freqz_zpk(z, p, k, worN=None, whole=False):
 
     Notes
     -----
-    .. versionadded: 0.19.0
+    .. versionadded:: 0.19.0
 
     Examples
     --------
@@ -583,7 +583,7 @@ def group_delay(system, w=None, whole=False):
 
     For the details of numerical computation of the group delay refer to [1]_.
 
-    .. versionadded: 0.16.0
+    .. versionadded:: 0.16.0
 
     See Also
     --------
@@ -3963,7 +3963,7 @@ def iirnotch(w0, Q):
 
     Notes
     -----
-    .. versionadded: 0.19.0
+    .. versionadded:: 0.19.0
 
     References
     ----------
@@ -4042,7 +4042,7 @@ def iirpeak(w0, Q):
 
     Notes
     -----
-    .. versionadded: 0.19.0
+    .. versionadded:: 0.19.0
 
     References
     ----------

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -914,14 +914,14 @@ class spmatrix(object):
             integer is used while if `a` is unsigned then an unsigned integer
             of the same precision as the platform integer is used.
 
-            .. versionadded: 0.18.0
+            .. versionadded:: 0.18.0
 
         out : np.matrix, optional
             Alternative output matrix in which to place the result. It must
             have the same shape as the expected output, but the type of the
             output values will be cast if necessary.
 
-            .. versionadded: 0.18.0
+            .. versionadded:: 0.18.0
 
         Returns
         -------
@@ -987,14 +987,14 @@ class spmatrix(object):
             is `float64`; for floating point inputs, it is the same as the
             input dtype.
 
-            .. versionadded: 0.18.0
+            .. versionadded:: 0.18.0
 
         out : np.matrix, optional
             Alternative output matrix in which to place the result. It must
             have the same shape as the expected output, but the type of the
             output values will be cast if necessary.
 
-            .. versionadded: 0.18.0
+            .. versionadded:: 0.18.0
 
         Returns
         -------
@@ -1050,7 +1050,7 @@ class spmatrix(object):
             Which diagonal to set, corresponding to elements a[i, i+k].
             Default: 0 (the main diagonal).
 
-            .. versionadded: 1.0
+            .. versionadded:: 1.0
 
         See also
         --------

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -5761,7 +5761,7 @@ class crystalball_gen(rv_continuous):
 
     %(after_notes)s
 
-    .. versionadded: 0.19.0
+    .. versionadded:: 0.19.0
 
     %(example)s
     """


### PR DESCRIPTION
Hey, in the context of another pull requests I was going through all versionadded directives in scipy and found a few where the second colon was missing. So assuming these were left out by mistake I corrected them.