### PR TITLE
Change to avoid use of `fmod` in scipy.signal.chebwin

### DIFF
--- a/scipy/signal/windows/windows.py
+++ b/scipy/signal/windows/windows.py
@@ -1399,7 +1399,7 @@ def chebwin(M, at, sym=True):
     # from scipy.special. Using the expansion in scipy.special leads to errors.
     p = np.zeros(x.shape)
     p[x > 1] = np.cosh(order * np.arccosh(x[x > 1]))
-    p[x < -1] = (1 - 2 * (order % 2)) * np.cosh(order * np.arccosh(-x[x < -1]))
+    p[x < -1] = (2 * (M % 2) - 1) * np.cosh(order * np.arccosh(-x[x < -1]))
     p[np.abs(x) <= 1] = np.cos(order * np.arccos(x[np.abs(x) <= 1]))
 
     # Appropriate IDFT and filling up


### PR DESCRIPTION
Since `order` is a floating point variable equal to M - 1.0, computing

```
  1 - 2 * (order % 2)
```

is equivalent to

```
   2 * (M % 2) - 1
```

but the latter expression uses interger `M`, rather than a floating point number `order`.

This change works around a sporadic test failure on Windows with Python 2.7 resulting from
a bug in MS run-time:

https://support.microsoft.com/en-us/help/982107/fix-the-fmod-function-returns-an-indeterminate-ind-value-instead-of-th

Essentially, when running the test suite, test_morlet performs operations that result in underflow (the value
of exponential is denormal), and a call to `fmod` with FE status bit, corresponding to underflow, set, the `fmod`
return NAN due to a fault in `fmod` code.