### PR TITLE
relax relative tolerance parameter in TestMinumumPhase.test_hilbert

### DIFF
--- a/scipy/signal/tests/test_fir_filter_design.py
+++ b/scipy/signal/tests/test_fir_filter_design.py
@@ -549,7 +549,7 @@ class TestMinimumPhase(object):
         k = [0.349585548646686, 0.373552164395447, 0.326082685363438,
              0.077152207480935, -0.129943946349364, -0.059355880509749]
         m = minimum_phase(h, 'hilbert')
-        assert_allclose(m, k, rtol=1e-3)
+        assert_allclose(m, k, rtol=2e-3)
 
         # f=[0 0.8 0.9 1];
         # a=[0 0 1 1];
@@ -560,4 +560,4 @@ class TestMinimumPhase(object):
              0.100787844523204, -0.065832656741252, 0.035361328741024,
              -0.014977068692269, -0.158416139047557]
         m = minimum_phase(h, 'hilbert', n_fft=2**19)
-        assert_allclose(m, k, rtol=1e-3)
+        assert_allclose(m, k, rtol=2e-3)


### PR DESCRIPTION
With use of mkl_fft to monkey patch scipy.fftpack in Intel Distribution for Python, test runs on machines with processors supporting different extensions the result of FFT computations may be slightly different.

On some of these machines the result of minimum_phase(h, 'hilbert') is different from MATLAB reference value a little of the set threshold. Doubling the relative tolerance fixes these failures.

See https://software.intel.com/en-us/comment/1914612