### PR TITLE
WIP: directed_hausdorff speedup attempt

### DIFF
--- a/scipy/spatial/_hausdorff.pyx
+++ b/scipy/spatial/_hausdorff.pyx
@@ -25,11 +25,11 @@ cdef extern from "hausdorff_util.h":
         int index_1
         int index_2
 
-    void hausdorff_loop(int data_dims,
-                    double ar1[],
-                    double ar2[],
-                    int N1,
-                    int N2,
+    void hausdorff_loop(const int data_dims,
+                    const double ar1[],
+                    const double ar2[],
+                    const int N1,
+                    const int N2,
                     return_values *ret_vals)
 
 @cython.boundscheck(False)

--- a/scipy/spatial/_hausdorff.pyx
+++ b/scipy/spatial/_hausdorff.pyx
@@ -35,7 +35,6 @@ cdef extern from "hausdorff_util.h":
 @cython.boundscheck(False)
 def directed_hausdorff(double[:,::1] ar1, double[:,::1] ar2, seed=0):
 
-    cdef double cmax = 0
     cdef int N1 = ar1.shape[0]
     cdef int N2 = ar2.shape[0]
     cdef int data_dims = ar1.shape[1]

--- a/scipy/spatial/_hausdorff.pyx
+++ b/scipy/spatial/_hausdorff.pyx
@@ -25,13 +25,12 @@ cdef extern from "hausdorff_util.h":
         int index_1
         int index_2
 
-    double hausdorff_loop(int data_dims,
+    void hausdorff_loop(int data_dims,
                     double ar1[],
                     double ar2[],
                     int N1,
-                    int N2)
-
-cdef return_values ret_vals
+                    int N2,
+                    return_values *ret_vals)
 
 @cython.boundscheck(False)
 def directed_hausdorff(double[:,::1] ar1, double[:,::1] ar2, seed=0):
@@ -41,6 +40,7 @@ def directed_hausdorff(double[:,::1] ar1, double[:,::1] ar2, seed=0):
     cdef int N2 = ar2.shape[0]
     cdef int data_dims = ar1.shape[1]
     cdef long[:] resort1, resort2
+    cdef return_values ret_vals
 
     # shuffling the points in each array generally increases the likelihood of
     # an advantageous break in the inner search loop and never decreases the
@@ -53,10 +53,10 @@ def directed_hausdorff(double[:,::1] ar1, double[:,::1] ar2, seed=0):
     ar1 = np.asarray(ar1)[resort1]
     ar2 = np.asarray(ar2)[resort2]
 
-    cmax = hausdorff_loop(data_dims, &ar1[0,0], &ar2[0,0],
-                          N1, N2)
+    hausdorff_loop(data_dims, &ar1[0,0], &ar2[0,0],
+                          N1, N2, &ret_vals)
 
-    #return (sqrt(ret_vals.cmax),
-            #resort1[ret_vals.index_1],
-            #resort2[ret_vals.index_2])
-    return (sqrt(cmax), 1, 5)
+    return (sqrt(ret_vals.cmax),
+            resort1[ret_vals.index_1],
+            resort2[ret_vals.index_2])
+

--- a/scipy/spatial/hausdorff_util.h
+++ b/scipy/spatial/hausdorff_util.h
@@ -53,7 +53,7 @@ void hausdorff_loop(const int data_dims,
                 cmin = d;
         ar1 -= data_dims;
         }
-        if ( (cmin != INFINITY) && (cmin >= (ret_vals->cmax)) && (no_break_happened)) {
+        if ( (cmin >= (ret_vals->cmax)) && (no_break_happened)) {
             ret_vals->cmax = cmin;
             ret_vals->index_1 = (ar1 + data_dims - ar1_start_Ptr + 1) / data_dims - 1;
             ret_vals->index_2 = (ar2 - ar2_start_Ptr + 1) / data_dims - 1;

--- a/scipy/spatial/hausdorff_util.h
+++ b/scipy/spatial/hausdorff_util.h
@@ -40,23 +40,27 @@ void hausdorff_loop(const int data_dims,
                 diff = *ar1 - *ar2;
                 d += (diff * diff);
             }
-            if (d < (ret_vals->cmax)) {
-                ar1 -= data_dims;
+            if (d < ret_vals->cmax)
                 goto main_loop_continue;
-            }
 
             if (d < cmin)
                 cmin = d;
-        ar1 -= data_dims;
+
+            ar1 -= data_dims;
         }
 
         if ( cmin >= ret_vals->cmax) {
             ret_vals->cmax = cmin;
-            ret_vals->index_1 = (ar1 + data_dims - ar1_start_Ptr + 1) / data_dims - 1;
-            ret_vals->index_2 = (ar2 - ar2_start_Ptr + 1) / data_dims - 1;
+            ret_vals->index_1 = (ar1 + data_dims - ar1_start_Ptr + 1);
+            ret_vals->index_2 = (ar2 - ar2_start_Ptr + 1);
         }
 
-    main_loop_continue:
     ar1 += data_dims;
+    main_loop_continue: ;
     }
+    // minimize processing of hausdorff pair
+    // indices by placing operations outside
+    // looping logic
+    ret_vals->index_1 = (ret_vals->index_1 / data_dims) - 1;
+    ret_vals->index_2 = (ret_vals->index_2 / data_dims) - 1;
 }

--- a/scipy/spatial/hausdorff_util.h
+++ b/scipy/spatial/hausdorff_util.h
@@ -22,7 +22,7 @@ void hausdorff_loop(const int data_dims,
                     int N2,
                     struct return_values * ret_vals)
 {
-    double               d, cmin;
+    double               d, cmin, diff;
     bool                 no_break_happened;
     double * const ar1_start_Ptr = ar1;
     double * const ar2_start_Ptr = ar2;
@@ -40,7 +40,8 @@ void hausdorff_loop(const int data_dims,
         while (ar2 <= ar2_end_Ptr) {
             d = 0;
             for ( int k = 0; k < data_dims; ++k, ++ar1, ++ar2) {
-                d += ((*ar1 - *ar2) * (*ar1 - *ar2));
+                diff = *ar1 - *ar2;
+                d += (diff * diff);
             }
             if (d < (ret_vals->cmax)) {
                 --no_break_happened;

--- a/scipy/spatial/hausdorff_util.h
+++ b/scipy/spatial/hausdorff_util.h
@@ -2,7 +2,6 @@
 // Try to improve on the performance of the original Cython directed_hausdorff
 
 #include <stdlib.h>
-#include <stdbool.h>
 #include <math.h>
 #include <stddef.h>
 #include <stdio.h>
@@ -23,7 +22,6 @@ void hausdorff_loop(const int data_dims,
                     struct return_values * ret_vals)
 {
     double               d, cmin, diff;
-    bool                 no_break_happened;
     double * const ar1_start_Ptr = ar1;
     double * const ar2_start_Ptr = ar2;
     int size_ar1 = data_dims * N1;
@@ -34,7 +32,6 @@ void hausdorff_loop(const int data_dims,
     ret_vals->cmax = 0;
     
     while (ar1 <= ar1_end_Ptr) {
-        no_break_happened = 1;
         cmin = INFINITY;
         ar2 = ar2_start_Ptr;
         while (ar2 <= ar2_end_Ptr) {
@@ -44,9 +41,8 @@ void hausdorff_loop(const int data_dims,
                 d += (diff * diff);
             }
             if (d < (ret_vals->cmax)) {
-                --no_break_happened;
                 ar1 -= data_dims;
-                break;
+                goto main_loop_continue;
             }
 
             if (d < cmin)
@@ -54,15 +50,13 @@ void hausdorff_loop(const int data_dims,
         ar1 -= data_dims;
         }
 
-        if (!no_break_happened) {
-            ar1 += data_dims;
-            continue;
-        }
-        else if ( cmin >= ret_vals->cmax) {
+        if ( cmin >= ret_vals->cmax) {
             ret_vals->cmax = cmin;
             ret_vals->index_1 = (ar1 + data_dims - ar1_start_Ptr + 1) / data_dims - 1;
             ret_vals->index_2 = (ar2 - ar2_start_Ptr + 1) / data_dims - 1;
         }
+
+    main_loop_continue:
     ar1 += data_dims;
     }
 }

--- a/scipy/spatial/hausdorff_util.h
+++ b/scipy/spatial/hausdorff_util.h
@@ -24,7 +24,6 @@ void hausdorff_loop(const int data_dims,
 {
     double               d, cmin;
     bool                 no_break_happened;
-    unsigned int         i_store = 0, j_store = 0;
     double * const ar1_start_Ptr = ar1;
     double * const ar2_start_Ptr = ar2;
     int size_ar1 = data_dims * N1;
@@ -49,19 +48,16 @@ void hausdorff_loop(const int data_dims,
                 break;
             }
 
-            if (d < cmin) {
+            if (d < cmin)
                 cmin = d;
-                i_store = (ar1 - ar1_start_Ptr + 1) / data_dims - 1;
-                j_store = (ar2 - ar2_start_Ptr + 1) / data_dims - 1;
-            }
         ar1 -= data_dims;
         }
-        ar2 = ar2_start_Ptr;
         if ( (cmin != INFINITY) && (cmin >= (ret_vals->cmax)) && (no_break_happened)) {
             ret_vals->cmax = cmin;
-            ret_vals->index_1 = i_store;
-            ret_vals->index_2 = j_store;
+            ret_vals->index_1 = (ar1 + data_dims - ar1_start_Ptr + 1) / data_dims - 1;
+            ret_vals->index_2 = (ar2 - ar2_start_Ptr + 1) / data_dims - 1;
         }
+        ar2 = ar2_start_Ptr;
     ar1 += data_dims;
     }
 }

--- a/scipy/spatial/hausdorff_util.h
+++ b/scipy/spatial/hausdorff_util.h
@@ -1,10 +1,7 @@
 // Utility C code for directed_hausdorff
 // Try to improve on the performance of the original Cython directed_hausdorff
 
-#include <stdlib.h>
 #include <math.h>
-#include <stddef.h>
-#include <stdio.h>
 
 struct return_values 
 {
@@ -28,39 +25,35 @@ void hausdorff_loop(const int data_dims,
     const int size_ar2 = data_dims * N2;
     const double * const ar1_end_Ptr = &ar1[size_ar1 - 1];
     const double * const ar2_end_Ptr = &ar2[size_ar2 - 1];
+    int k;
 
     ret_vals->cmax = 0;
     
-    while (ar1 <= ar1_end_Ptr) {
+    for ( ; ar1 <= ar1_end_Ptr; ar1 += data_dims ) {
         cmin = INFINITY;
-        ar2 = ar2_start_Ptr;
-        while (ar2 <= ar2_end_Ptr) {
+        for ( ar2 = ar2_start_Ptr; ar2 <= ar2_end_Ptr; ar2 += data_dims) {
             d = 0;
-            for ( int k = 0; k < data_dims; ++k, ++ar1, ++ar2) {
-                diff = *ar1 - *ar2;
+            for ( k = 0; k < data_dims; ++k ) {
+                diff = *(ar1 + k) - *(ar2 + k);
                 d += (diff * diff);
             }
             if (d < ret_vals->cmax)
                 goto main_loop_continue;
-
-            if (d < cmin)
+            else if (d < cmin)
                 cmin = d;
-
-            ar1 -= data_dims;
         }
 
         if ( cmin >= ret_vals->cmax) {
             ret_vals->cmax = cmin;
-            ret_vals->index_1 = (ar1 + data_dims - ar1_start_Ptr + 1);
-            ret_vals->index_2 = (ar2 - ar2_start_Ptr + 1);
+            ret_vals->index_1 = ar1 - ar1_start_Ptr;
+            ret_vals->index_2 = ar2 - ar2_start_Ptr;
         }
 
-    ar1 += data_dims;
     main_loop_continue: ;
     }
     // minimize processing of hausdorff pair
     // indices by placing operations outside
     // looping logic
-    ret_vals->index_1 = (ret_vals->index_1 / data_dims) - 1;
-    ret_vals->index_2 = (ret_vals->index_2 / data_dims) - 1;
+    ret_vals->index_1 = (++ret_vals->index_1) / data_dims;
+    ret_vals->index_2 = ret_vals->index_2 / data_dims - 1;
 }

--- a/scipy/spatial/hausdorff_util.h
+++ b/scipy/spatial/hausdorff_util.h
@@ -14,19 +14,17 @@ struct return_values
     int    index_2;
 };
 
-struct return_values ret_vals;
-
 // function for inner loop of directed_hausdorff algorithm
-double hausdorff_loop(const int data_dims,
+void hausdorff_loop(const int data_dims,
                     double ar1[],
                     double ar2[],
                     int N1,
-                    int N2)
+                    int N2,
+                    struct return_values * ret_vals)
 {
     double               d, cmin;
     bool                 no_break_happened;
     unsigned int         i_store = 0, j_store = 0;
-    struct return_values ret_vals;
     double * const ar1_start_Ptr = ar1;
     double * const ar2_start_Ptr = ar2;
     int size_ar1 = data_dims * N1;
@@ -34,38 +32,36 @@ double hausdorff_loop(const int data_dims,
     const double * const ar1_end_Ptr = &ar1[size_ar1 - 1];
     const double * const ar2_end_Ptr = &ar2[size_ar2 - 1];
 
-    ret_vals.cmax = 0;
+    ret_vals->cmax = 0;
     
-    while (ar1 < ar1_end_Ptr) {
+    while (ar1 <= ar1_end_Ptr) {
         no_break_happened = 1;
         cmin = INFINITY;
-        while (ar2 < ar2_end_Ptr) {
+        while (ar2 <= ar2_end_Ptr) {
             d = 0;
             for ( int k = 0; k < data_dims; ++k, ++ar1, ++ar2) {
                 d += ((*ar1 - *ar2) * (*ar1 - *ar2));
             }
-            ar1 -= data_dims;
-            if (d < ret_vals.cmax) {
+            if (d < (ret_vals->cmax)) {
                 --no_break_happened;
+                ar1 -= data_dims;
                 ar2 = ar2_start_Ptr;
                 break;
             }
 
             if (d < cmin) {
                 cmin = d;
-                i_store = ar1 - ar1_start_Ptr;
-                j_store = ar2 - ar2_start_Ptr;
+                i_store = (ar1 - ar1_start_Ptr + 1) / data_dims - 1;
+                j_store = (ar2 - ar2_start_Ptr + 1) / data_dims - 1;
             }
+        ar1 -= data_dims;
         }
         ar2 = ar2_start_Ptr;
-        if ( (cmin != INFINITY) && (cmin > ret_vals.cmax) && (no_break_happened)) {
-            ret_vals.cmax = cmin;
-            ret_vals.index_1 = i_store;
-            ret_vals.index_2 = j_store;
+        if ( (cmin != INFINITY) && (cmin >= (ret_vals->cmax)) && (no_break_happened)) {
+            ret_vals->cmax = cmin;
+            ret_vals->index_1 = i_store;
+            ret_vals->index_2 = j_store;
         }
     ar1 += data_dims;
     }
-    printf("i: %i\n", ret_vals.index_1);
-    printf("j: %i\n", ret_vals.index_2);
-    return ret_vals.cmax;
 }

--- a/scipy/spatial/hausdorff_util.h
+++ b/scipy/spatial/hausdorff_util.h
@@ -36,6 +36,7 @@ void hausdorff_loop(const int data_dims,
     while (ar1 <= ar1_end_Ptr) {
         no_break_happened = 1;
         cmin = INFINITY;
+        ar2 = ar2_start_Ptr;
         while (ar2 <= ar2_end_Ptr) {
             d = 0;
             for ( int k = 0; k < data_dims; ++k, ++ar1, ++ar2) {
@@ -44,7 +45,6 @@ void hausdorff_loop(const int data_dims,
             if (d < (ret_vals->cmax)) {
                 --no_break_happened;
                 ar1 -= data_dims;
-                ar2 = ar2_start_Ptr;
                 break;
             }
 
@@ -57,7 +57,6 @@ void hausdorff_loop(const int data_dims,
             ret_vals->index_1 = (ar1 + data_dims - ar1_start_Ptr + 1) / data_dims - 1;
             ret_vals->index_2 = (ar2 - ar2_start_Ptr + 1) / data_dims - 1;
         }
-        ar2 = ar2_start_Ptr;
     ar1 += data_dims;
     }
 }

--- a/scipy/spatial/hausdorff_util.h
+++ b/scipy/spatial/hausdorff_util.h
@@ -53,7 +53,12 @@ void hausdorff_loop(const int data_dims,
                 cmin = d;
         ar1 -= data_dims;
         }
-        if ( (cmin >= (ret_vals->cmax)) && (no_break_happened)) {
+
+        if (!no_break_happened) {
+            ar1 += data_dims;
+            continue;
+        }
+        else if ( cmin >= ret_vals->cmax) {
             ret_vals->cmax = cmin;
             ret_vals->index_1 = (ar1 + data_dims - ar1_start_Ptr + 1) / data_dims - 1;
             ret_vals->index_2 = (ar2 - ar2_start_Ptr + 1) / data_dims - 1;

--- a/scipy/spatial/hausdorff_util.h
+++ b/scipy/spatial/hausdorff_util.h
@@ -15,17 +15,17 @@ struct return_values
 
 // function for inner loop of directed_hausdorff algorithm
 void hausdorff_loop(const int data_dims,
-                    double ar1[],
-                    double ar2[],
-                    int N1,
-                    int N2,
+                    const double ar1[],
+                    const double ar2[],
+                    const int N1,
+                    const int N2,
                     struct return_values * ret_vals)
 {
     double               d, cmin, diff;
-    double * const ar1_start_Ptr = ar1;
-    double * const ar2_start_Ptr = ar2;
-    int size_ar1 = data_dims * N1;
-    int size_ar2 = data_dims * N2;
+    const double * const ar1_start_Ptr = ar1;
+    const double * const ar2_start_Ptr = ar2;
+    const int size_ar1 = data_dims * N1;
+    const int size_ar2 = data_dims * N2;
     const double * const ar1_end_Ptr = &ar1[size_ar1 - 1];
     const double * const ar2_end_Ptr = &ar2[size_ar2 - 1];
 

--- a/scipy/spatial/hausdorff_util.h
+++ b/scipy/spatial/hausdorff_util.h
@@ -1,0 +1,71 @@
+// Utility C code for directed_hausdorff
+// Try to improve on the performance of the original Cython directed_hausdorff
+
+#include <stdlib.h>
+#include <stdbool.h>
+#include <math.h>
+#include <stddef.h>
+#include <stdio.h>
+
+struct return_values 
+{
+    double cmax;
+    int    index_1;
+    int    index_2;
+};
+
+struct return_values ret_vals;
+
+// function for inner loop of directed_hausdorff algorithm
+double hausdorff_loop(const int data_dims,
+                    double ar1[],
+                    double ar2[],
+                    int N1,
+                    int N2)
+{
+    double               d, cmin;
+    bool                 no_break_happened;
+    unsigned int         i_store = 0, j_store = 0;
+    struct return_values ret_vals;
+    double * const ar1_start_Ptr = ar1;
+    double * const ar2_start_Ptr = ar2;
+    int size_ar1 = data_dims * N1;
+    int size_ar2 = data_dims * N2;
+    const double * const ar1_end_Ptr = &ar1[size_ar1 - 1];
+    const double * const ar2_end_Ptr = &ar2[size_ar2 - 1];
+
+    ret_vals.cmax = 0;
+    
+    while (ar1 < ar1_end_Ptr) {
+        no_break_happened = 1;
+        cmin = INFINITY;
+        while (ar2 < ar2_end_Ptr) {
+            d = 0;
+            for ( int k = 0; k < data_dims; ++k, ++ar1, ++ar2) {
+                d += ((*ar1 - *ar2) * (*ar1 - *ar2));
+            }
+            ar1 -= data_dims;
+            if (d < ret_vals.cmax) {
+                --no_break_happened;
+                ar2 = ar2_start_Ptr;
+                break;
+            }
+
+            if (d < cmin) {
+                cmin = d;
+                i_store = ar1 - ar1_start_Ptr;
+                j_store = ar2 - ar2_start_Ptr;
+            }
+        }
+        ar2 = ar2_start_Ptr;
+        if ( (cmin != INFINITY) && (cmin > ret_vals.cmax) && (no_break_happened)) {
+            ret_vals.cmax = cmin;
+            ret_vals.index_1 = i_store;
+            ret_vals.index_2 = j_store;
+        }
+    ar1 += data_dims;
+    }
+    printf("i: %i\n", ret_vals.index_1);
+    printf("j: %i\n", ret_vals.index_2);
+    return ret_vals.cmax;
+}


### PR DESCRIPTION
This WIP PR attempts to improve the performance of `directed_hausdorff` by abstracting the heavy-lifting to an external C module. It was admittedly motivated by an attempt to use some newly-acquired knolwedge of the C language & see what (if any) performance benefits might be achieved. So far, only very modest improvements have been achieved & the increase in complexity / maintenance burden is likely not justified at this stage.

Perhaps some of the C gurus will have some additional suggestions? I'll put a few notes below. We can always just close / archive this in case there's interest in the C version for whatever reason later.

C code notes:
- uses the controversial `goto` statement & there wasn't really much performance benefit for adding this (to circumvent a boolean variable + check for nested loop continuation) -- could refactor to a function that uses a `return` perhaps or just restore the original boolean variable and `break` statement
- there's likely no compelling reason to use so much pointer arithmetic -- this was again admittedly mostly for the learning experience, and there may even be drawbacks to that (vs. conventional array indexing) as these details may best be left to the compiler
- line profiling the Cython `pyx` + associated C header file seems to be a bit painful -- would be really nice if this were much simpler to drill right down to the C code lines in parallel with Cython lines; I tried various permutations of `%%cython` magic in Jupyter notebooks and `lprof` and so on, but each approach seems to have drawbacks or require quite a bit of manual intervention
- overall, Cython does seem to do a really good job & the ROI for time writing better raw C code so far seems questionable

Sample benchmark comparison with latest commit hash vs. master branch point:
`asv continuous --bench Hausdorff 355a8e08fb 38eb3e47d`

```
· Creating environments
· Discovering benchmarks
·· Uninstalling from conda-py3.6-Cython0.26-Tempita-numpy-pytest-six
·· Installing into conda-py3.6-Cython0.26-Tempita-numpy-pytest-six
· Running 2 total benchmarks (2 commits * 1 environments * 1 benchmarks)
[  0.00%] · For scipy commit hash 38eb3e47:
[  0.00%] ·· Building for conda-py3.6-Cython0.26-Tempita-numpy-pytest-six
[  0.00%] ·· Benchmarking conda-py3.6-Cython0.26-Tempita-numpy-pytest-six
[ 50.00%] ··· Running spatial.Hausdorff.time_directed_hausdorff               ok
[ 50.00%] ···· 
               ============ ============
                num_points
               ------------ ------------
                    10       26.9±0.1μs
                   100       96.2±0.2μs
                   1000       1.11±0ms
                  10000      24.6±0.2ms
                  100000      1.43±0s
               ============ ============

[ 50.00%] · For scipy commit hash 355a8e08:
[ 50.00%] ·· Building for conda-py3.6-Cython0.26-Tempita-numpy-pytest-six
[ 50.00%] ·· Benchmarking conda-py3.6-Cython0.26-Tempita-numpy-pytest-six
[100.00%] ··· Running spatial.Hausdorff.time_directed_hausdorff               ok
[100.00%] ···· 
               ============ ============
                num_points
               ------------ ------------
                    10       28.1±0.1μs
                   100        104±1μs
                   1000       1.23±0ms
                  10000      26.6±0.4ms
                  100000     1.53±0.01s
               ============ ============
       before           after         ratio
     [355a8e08]       [38eb3e47]
-        1.23±0ms         1.11±0ms     0.90  spatial.Hausdorff.time_directed_hausdorff(1000)

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.

```
ping @kain88-de @orbeckst for possible interest