### PR TITLE
MAINT: special: small fixes for `digamma`

### DIFF
--- a/scipy/special/cephes/psi.c
+++ b/scipy/special/cephes/psi.c
@@ -146,10 +146,19 @@ double psi_asy(double x)
 double psi(double x)
 {
     double y = 0.0;
-    double q, r, w;
+    double q, r;
     int i, n;
 
-    if (x == 0) {
+    if (npy_isnan(x)) {
+	return x;
+    }
+    else if (x == NPY_INFINITY) {
+	return x;
+    }
+    else if (x == -NPY_INFINITY) {
+	return NPY_NAN;
+    }
+    else if (x == 0) {
 	mtherr("psi", SING);
 	return npy_copysign(NPY_INFINITY, -x);
     }
@@ -166,10 +175,9 @@ double psi(double x)
 
     /* check for positive integer up to 10 */
     if ((x <= 10.0) && (x == floor(x))) {
-	n = x;
+	n = (int)x;
 	for (i = 1; i < n; i++) {
-	    w = i;
-	    y += 1.0 / w;
+	    y += 1.0 / i;
 	}
 	y -= NPY_EULER;
 	return y;

--- a/scipy/special/tests/test_digamma.py
+++ b/scipy/special/tests/test_digamma.py
@@ -1,8 +1,11 @@
-from __future__ import division
+from __future__ import division, print_function, absolute_import
+
 import numpy as np
 from numpy import pi, log, sqrt
+from numpy.testing import assert_, assert_equal
+
 from scipy.special._testutils import FuncData
-from scipy.special import digamma
+import scipy.special as sc
 
 # Euler-Mascheroni constant
 euler = 0.57721566490153286
@@ -14,8 +17,8 @@ def test_consistency():
 
     # It's all poles after -1e16
     x = np.r_[-np.logspace(15, -30, 200), np.logspace(-30, 300, 200)]
-    dataset = np.vstack((x + 0j, digamma(x))).T
-    FuncData(digamma, dataset, 0, 1, rtol=5e-14, nan_ok=True).check()
+    dataset = np.vstack((x + 0j, sc.digamma(x))).T
+    FuncData(sc.digamma, dataset, 0, 1, rtol=5e-14, nan_ok=True).check()
 
 
 def test_special_values():
@@ -31,4 +34,11 @@ def test_special_values():
                (1/8, -pi/2 - 4*log(2) - (pi + log(2 + sqrt(2)) - log(2 - sqrt(2)))/sqrt(2) - euler)]
 
     dataset = np.asarray(dataset)
-    FuncData(digamma, dataset, 0, 1, rtol=1e-14).check()
+    FuncData(sc.digamma, dataset, 0, 1, rtol=1e-14).check()
+
+
+def test_nonfinite():
+    pts = [0.0, -0.0, np.inf]
+    std = [-np.inf, np.inf, np.inf]
+    assert_equal(sc.digamma(pts), std)
+    assert_(all(np.isnan(sc.digamma([-np.inf, -1]))))


### PR DESCRIPTION
- Remove an unnecessary variable
- Handle nonfinite values correctly
- Add a test for nonfinite values.