### PR TITLE
ENH: Improve performance of DE's `_ensure_constraint`

### DIFF
--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -689,9 +689,8 @@ class DifferentialEvolutionSolver(object):
         """
         make sure the parameters lie between the limits
         """
-        for index, param in enumerate(trial):
-            if param > 1 or param < 0:
-                trial[index] = self.random_number_generator.rand()
+        values = self.random_number_generator.rand(trial.size)
+        np.putmask(trial, (trial < 0) | (trial > 1), values)
 
     def _mutate(self, candidate):
         """


### PR DESCRIPTION
Having profiled my script that uses `optimize.differential_evolution`, I was surprised that significant amount of time was spent in DE's internals rather than within my slow fitness function. The main culprit seems to be the `_ensure_constraint` method. This PR rewrites it with `np.where`.

I have compared the performance of the two methods using 3 array sizes (10, 100, 1000) and 3 ratios of out-of-bounds elements (0.1%, 0.5%, 1.0%). The results are as follows:

```
dim	ratio	method				result
10	0.001	ensure_constraint_scipy:	10000 loops, best of 3: 5.38 usec per loop
10	0.005	ensure_constraint_scipy:	10000 loops, best of 3: 5.23 usec per loop
10	0.01	ensure_constraint_scipy:	10000 loops, best of 3: 5.54 usec per loop
100	0.001	ensure_constraint_scipy:	10000 loops, best of 3: 44.1 usec per loop
100	0.005	ensure_constraint_scipy:	10000 loops, best of 3: 44.3 usec per loop
100	0.01	ensure_constraint_scipy:	10000 loops, best of 3: 44.4 usec per loop
1000	0.001	ensure_constraint_scipy:	10000 loops, best of 3: 444 usec per loop
1000	0.005	ensure_constraint_scipy:	10000 loops, best of 3: 454 usec per loop
1000	0.01	ensure_constraint_scipy:	10000 loops, best of 3: 452 usec per loop
10	0.001	ensure_constraint_where:	10000 loops, best of 3: 4.93 usec per loop
10	0.005	ensure_constraint_where:	10000 loops, best of 3: 4.88 usec per loop
10	0.01	ensure_constraint_where:	10000 loops, best of 3: 5.26 usec per loop
100	0.001	ensure_constraint_where:	10000 loops, best of 3: 4.67 usec per loop
100	0.005	ensure_constraint_where:	10000 loops, best of 3: 5.08 usec per loop
100	0.01	ensure_constraint_where:	10000 loops, best of 3: 5.05 usec per loop
1000	0.001	ensure_constraint_where:	10000 loops, best of 3: 5.7 usec per loop
1000	0.005	ensure_constraint_where:	10000 loops, best of 3: 5.52 usec per loop
1000	0.01	ensure_constraint_where:	10000 loops, best of 3: 6 usec per loop
```

Benchmarks were run on 
```
> python3 --version
Python 3.6.3
> sysctl -n machdep.cpu.brand_string
Intel(R) Core(TM) i5-4278U CPU @ 2.60GHz
```