### PR TITLE
BUG: riccati solvers don't catch ill-conditioned problems sufficiently well

### DIFF
--- a/scipy/linalg/_solvers.py
+++ b/scipy/linalg/_solvers.py
@@ -513,11 +513,12 @@ def solve_continuous_are(a, b, q, r, e=None, s=None, balanced=True):
     if balanced:
         x *= sca[:m, None] * sca[:m]
 
-    # Check the deviation from symmetry for success
+    # Check the deviation from symmetry for lack of success
+    # See proof of Thm.5 item 3 in [2]
     u_sym = u00.conj().T.dot(u10)
     n_u_sym = norm(u_sym, 1)
     u_sym = u_sym - u_sym.conj().T
-    sym_threshold = np.max([np.spacing(1000.), n_u_sym])
+    sym_threshold = np.max([np.spacing(1000.), 0.1*n_u_sym])
 
     if norm(u_sym, 1) > sym_threshold:
         raise LinAlgError('The associated Hamiltonian pencil has eigenvalues '
@@ -720,11 +721,12 @@ def solve_discrete_are(a, b, q, r, e=None, s=None, balanced=True):
     if balanced:
         x *= sca[:m, None] * sca[:m]
 
-    # Check the deviation from symmetry for success
+    # Check the deviation from symmetry for lack of success
+    # See proof of Thm.5 item 3 in [2]
     u_sym = u00.conj().T.dot(u10)
     n_u_sym = norm(u_sym, 1)
     u_sym = u_sym - u_sym.conj().T
-    sym_threshold = np.max([np.spacing(1000.), n_u_sym])
+    sym_threshold = np.max([np.spacing(1000.), 0.1*n_u_sym])
 
     if norm(u_sym, 1) > sym_threshold:
         raise LinAlgError('The associated symplectic pencil has eigenvalues'

--- a/scipy/linalg/tests/test_solvers.py
+++ b/scipy/linalg/tests/test_solvers.py
@@ -10,7 +10,7 @@ from pytest import raises as assert_raises
 from scipy.linalg import solve_sylvester
 from scipy.linalg import solve_continuous_lyapunov, solve_discrete_lyapunov
 from scipy.linalg import solve_continuous_are, solve_discrete_are
-from scipy.linalg import block_diag, solve
+from scipy.linalg import block_diag, solve, LinAlgError
 
 
 def _load_data(name):
@@ -528,6 +528,14 @@ def test_solve_discrete_are():
     for ind, case in enumerate(cases):
         _test_factory(case, min_decimal[ind])
 
+    # An infeasible example taken from https://arxiv.org/abs/1505.04861v1
+    A = np.triu(np.ones((3, 3)))
+    A[0, 1] = -1
+    B = np.array([[1, 1, 0], [0, 0, 1]]).T
+    Q = -2*np.ones_like(A) + np.diag([8, -1, -1.9])
+    R = np.diag([-10, 0.1])
+    assert_raises(LinAlgError, solve_continuous_are, A, B, Q, R)
+
 
 def test_solve_generalized_continuous_are():
     cases = [
@@ -757,4 +765,3 @@ class TestSolveSylvester(object):
         c = np.array([2.0, 2.0]).reshape(-1, 1)
         x = solve_sylvester(a, b, c)
         assert_array_almost_equal(x, np.array([1.0, 1.0]).reshape(-1, 1))
-


### PR DESCRIPTION
While parsing a paper given in the code comments, turns out that the stopping criteria was not strict enough. Added extra test and tightened the tolerances. 