### PR TITLE
sparse.linalg.svds: ensure non-negative singular values for which='SM'

### DIFF
--- a/scipy/sparse/linalg/eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/arpack.py
@@ -1641,7 +1641,7 @@ def _herm(x):
 
 def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
          maxiter=None, return_singular_vectors=True):
-    """Compute the largest k singular values/vectors for a sparse matrix.
+    """Compute the largest or smallest k singular values/vectors for a sparse matrix.
 
     Parameters
     ----------

--- a/scipy/sparse/linalg/eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/arpack.py
@@ -1763,12 +1763,12 @@ def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
     eigvals, eigvec = eigsh(XH_X, k=k, tol=tol ** 2, maxiter=maxiter,
                                   ncv=ncv, which=which, v0=v0)
 
+    # Gramian matrices have real non-negative eigenvalues.
+    eigvals = np.maximum(eigvals.real, 0)
+
     # In 'LM' mode try to be clever about small eigenvalues.
     # Otherwise in 'SM' mode do not try to be clever.
     if which == 'LM':
-
-        # Gramian matrices have real non-negative eigenvalues.
-        eigvals = np.maximum(eigvals.real, 0)
 
         # Use the sophisticated detection of small eigenvalues from pinvh.
         t = eigvec.dtype.char.lower()


### PR DESCRIPTION
When estimating the smallest magnitude singular values of a singular
matrix, it is common for ARPACK to return tiny negative values.  These
are handled carefully in which='LM', but not for which='SM'.  Simple
examples such as
    
      A = csr_matrix(([1.,1,1,1,1], ([0,1,1,2,3],[0,0,1,0,1])), shape=(4,3))
      svds(A, which='SM', k=2, return_singular_vectors=False)

 produce `FloatingPointError: invalid value encountered in sqrt`.  This
commit ensures that the estimated eigenvalues are non-negative.
