### PR TITLE
BUG: correctly pad netCDF files with null bytes

### DIFF
--- a/scipy/io/netcdf.py
+++ b/scipy/io/netcdf.py
@@ -62,27 +62,39 @@ NC_DOUBLE = b'\x00\x00\x00\x06'
 NC_DIMENSION = b'\x00\x00\x00\n'
 NC_VARIABLE = b'\x00\x00\x00\x0b'
 NC_ATTRIBUTE = b'\x00\x00\x00\x0c'
-
+FILL_BYTE = b'\x81'
+FILL_CHAR = b'\x00'
+FILL_SHORT = b'\x80\x01'
+FILL_INT = b'\x80\x00\x00\x01'
+FILL_FLOAT = b'\x7C\xF0\x00\x00'
+FILL_DOUBLE = b'\x47\x9E\x00\x00\x00\x00\x00\x00'
 
 TYPEMAP = {NC_BYTE: ('b', 1),
-            NC_CHAR: ('c', 1),
-            NC_SHORT: ('h', 2),
-            NC_INT: ('i', 4),
-            NC_FLOAT: ('f', 4),
-            NC_DOUBLE: ('d', 8)}
+           NC_CHAR: ('c', 1),
+           NC_SHORT: ('h', 2),
+           NC_INT: ('i', 4),
+           NC_FLOAT: ('f', 4),
+           NC_DOUBLE: ('d', 8)}
+
+FILLMAP = {NC_BYTE: FILL_BYTE,
+           NC_CHAR: FILL_CHAR,
+           NC_SHORT: FILL_SHORT,
+           NC_INT: FILL_INT,
+           NC_FLOAT: FILL_FLOAT,
+           NC_DOUBLE: FILL_DOUBLE}
 
 REVERSE = {('b', 1): NC_BYTE,
-            ('B', 1): NC_CHAR,
-            ('c', 1): NC_CHAR,
-            ('h', 2): NC_SHORT,
-            ('i', 4): NC_INT,
-            ('f', 4): NC_FLOAT,
-            ('d', 8): NC_DOUBLE,
+           ('B', 1): NC_CHAR,
+           ('c', 1): NC_CHAR,
+           ('h', 2): NC_SHORT,
+           ('i', 4): NC_INT,
+           ('f', 4): NC_FLOAT,
+           ('d', 8): NC_DOUBLE,
 
-            # these come from asarray(1).dtype.char and asarray('foo').dtype.char,
-            # used when getting the types from generic attributes.
-            ('l', 4): NC_INT,
-            ('S', 1): NC_CHAR}
+           # these come from asarray(1).dtype.char and asarray('foo').dtype.char,
+           # used when getting the types from generic attributes.
+           ('l', 4): NC_INT,
+           ('S', 1): NC_CHAR}
 
 
 class netcdf_file(object):
@@ -496,10 +508,6 @@ class netcdf_file(object):
     def _write_var_data(self, name):
         var = self.variables[name]
 
-        # TODO: for full compliance with the netCDF spec, use _FillValue for
-        # padding instead of instead of always using using the null byte.
-        encoded_fill_value = b'\x00'
-
         # Set begin in file header.
         the_beguine = self.fp.tell()
         self.fp.seek(var._begin)
@@ -510,7 +518,7 @@ class netcdf_file(object):
         if not var.isrec:
             self.fp.write(var.data.tostring())
             count = var.data.size * var.data.itemsize
-            self.fp.write(encoded_fill_value * (var._vsize - count))
+            self._write_var_padding(var, var._vsize - count)
         else:  # record variable
             # Handle rec vars with shape[0] < nrecs.
             if self._recs > len(var.data):
@@ -533,10 +541,15 @@ class netcdf_file(object):
                 self.fp.write(rec.tostring())
                 # Padding
                 count = rec.size * rec.itemsize
-                self.fp.write(encoded_fill_value * (var._vsize - count))
+                self._write_var_padding(var, var._vsize - count)
                 pos += self._recsize
                 self.fp.seek(pos)
             self.fp.seek(pos0 + var._vsize)
+
+    def _write_var_padding(self, var, size):
+        encoded_fill_value = var._get_encoded_fill_value()
+        num_fills = size // len(encoded_fill_value)
+        self.fp.write(encoded_fill_value * num_fills)
 
     def _write_att_values(self, values):
         if hasattr(values, 'dtype'):
@@ -998,6 +1011,30 @@ class netcdf_variable(object):
                 except ValueError:
                     self.__dict__['data'] = np.resize(self.data, shape).astype(self.data.dtype)
         self.data[index] = data
+
+    def _default_encoded_fill_value(self):
+        """
+        The default encoded fill-value for this Variable's data type.
+        """
+        nc_type = REVERSE[self.typecode(), self.itemsize()]
+        return FILLMAP[nc_type]
+
+    def _get_encoded_fill_value(self):
+        """
+        Returns the encoded fill value for this variable as bytes.
+
+        This is taken from either the _FillValue attribute, or the default fill
+        value for this variable's data type.
+        """
+        if '_FillValue' in self._attributes:
+            fill_value = np.array(self._attributes['_FillValue'],
+                                  dtype=self.data.dtype).tostring()
+            if len(fill_value) == self.itemsize():
+                return fill_value
+            else:
+                return self._default_encoded_fill_value()
+        else:
+            return self._default_encoded_fill_value()
 
     def _get_missing_value(self):
         """


### PR DESCRIPTION
Per the netCDF spec, variable names and attributes should be padded with null
padding to the nearest 4-byte boundary, but scipy has been padding with b'0'
instead:
http://www.unidata.ucar.edu/software/netcdf/docs/file_format_specifications.html

This surfaced recently after the netCDF-C library added more stringent checks
in version 4.5.0 which rendered it unable to read files written with SciPy:
https://github.com/Unidata/netcdf-c/issues/657

This change to netCDF-C is likely going to be rolled back, but it's still a
good idea for us to write compliant files. Apparently there are other netCDF
implementations that also insist on padding with nulls.