### PR TITLE
FIX: linalg._qz String formatter syntax error

### DIFF
--- a/scipy/linalg/_decomp_qz.py
+++ b/scipy/linalg/_decomp_qz.py
@@ -5,7 +5,7 @@ import warnings
 import numpy as np
 from numpy import asarray_chkfinite
 
-from .misc import LinAlgError, _datacopied
+from .misc import LinAlgError, _datacopied, LinAlgWarning
 from .lapack import get_lapack_funcs
 
 from scipy._lib.six import callable
@@ -78,7 +78,7 @@ def _qz(A, B, output='real', lwork=None, sort=None, overwrite_a=False,
         raise ValueError("The 'sort' input of qz() has to be None and will be "
                          "removed in a future release. Use ordqz instead.")
 
-    if output not in ['real', 'complex', 'r', 'c']:
+    if output.lower() not in ['real', 'complex', 'r', 'c']:
         raise ValueError("argument must be 'real', or 'complex'")
 
     if check_finite:
@@ -126,11 +126,12 @@ def _qz(A, B, output='real', lwork=None, sort=None, overwrite_a=False,
 
     info = result[-1]
     if info < 0:
-        raise ValueError("Illegal value in argument %d of gges" % -info)
+        raise ValueError("Illegal value in argument {} of gges".format(-info))
     elif info > 0 and info <= a_n:
         warnings.warn("The QZ iteration failed. (a,b) are not in Schur "
                       "form, but ALPHAR(j), ALPHAI(j), and BETA(j) should be "
-                      "correct for J=%d,...,N" % info-1, UserWarning)
+                      "correct for J={},...,N".format(info-1), LinAlgWarning,
+                      stacklevel=3)
     elif info == a_n+1:
         raise LinAlgError("Something other than QZ iteration failed")
     elif info == a_n+2:
@@ -334,15 +335,15 @@ def ordqz(A, B, sort='lhp', output='real', overwrite_a=False,
     that would result if the 2-by-2 diagonal blocks of the real generalized
     Schur form of (A,B) were further reduced to triangular form using complex
     unitary transformations. If ALPHAI(j) is zero, then the j-th eigenvalue is
-    real; if positive, then the ``j``-th and ``(j+1)``-st eigenvalues are a complex
-    conjugate pair, with ``ALPHAI(j+1)`` negative.
+    real; if positive, then the ``j``-th and ``(j+1)``-st eigenvalues are a
+    complex conjugate pair, with ``ALPHAI(j+1)`` negative.
 
     See also
     --------
     qz
 
     """
-    #NOTE: should users be able to set these?
+    # NOTE: should users be able to set these?
     lwork = None
     result, typ = _qz(A, B, output=output, lwork=lwork, sort=None,
                       overwrite_a=overwrite_a, overwrite_b=overwrite_b,

--- a/scipy/linalg/_decomp_qz.py
+++ b/scipy/linalg/_decomp_qz.py
@@ -78,7 +78,7 @@ def _qz(A, B, output='real', lwork=None, sort=None, overwrite_a=False,
         raise ValueError("The 'sort' input of qz() has to be None and will be "
                          "removed in a future release. Use ordqz instead.")
 
-    if output.lower() not in ['real', 'complex', 'r', 'c']:
+    if output not in ['real', 'complex', 'r', 'c']:
         raise ValueError("argument must be 'real', or 'complex'")
 
     if check_finite:


### PR DESCRIPTION
In the `_qz` function the warning has the string formatting command 

    warnings.warn('.... %d ...' % info -1)

which leads to a `TypeError` since the argument is not inside brackets. Thus, switched to the "modern" version with `'...{}...'.format(info-1)`.

In the meantime also changed the warning type and set the `stacklevel` and some housekeeping.

To trigger the problem I've used 
```
a = np.array([[-0.0566335083203545, 0.7618601631045951, 0.1380799881600429,  -0.2496547271520516],
              [-0.6953017686620624, 0.1721825836377841, 0.3524311236692528,  -0.0976480305217913],
              [-0.2778527965349485, 0.0822406719680793, 0.3642622234574927,  0.4324046824057498],
              [0.1630969211638234, -0.1925663248287017, 0.4859689326072161,  0.5655695646632785]])

b = np.array([[-0.6282702999111819, 0.2566040837956725, -0.0590286999428144,  -0.4484746121151296],
              [ 2.993120574942286,  -3.0140376750215672, -2.4376036127193954,  -0.1083956777260289],
              [-0.3395903200140198, -0.0297149078005973,  0.5974019693416047,   0.3581544256691085],
              [ 0.19152708930348,    2.3546781693565211, -2.1809506731995891,  -3.6531715901566919]])

aa, bb, *_ = sp.linalg.qz(a, b, output='complex')
``` 