### PR TITLE
TST: Added pdist to asv spatial benchmark suite

### DIFF
--- a/benchmarks/benchmarks/spatial.py
+++ b/benchmarks/benchmarks/spatial.py
@@ -226,7 +226,7 @@ class SphericalVorSort(Benchmark):
         """
         self.sv.sort_vertices_of_regions()
 
-class Cdist(Benchmark):
+class Xdist(Benchmark):
     params = ([10, 100, 1000], ['euclidean', 'minkowski', 'cityblock',
     'seuclidean', 'sqeuclidean', 'cosine', 'correlation', 'hamming', 'jaccard',
     'chebyshev', 'canberra', 'braycurtis', 'mahalanobis', 'yule', 'dice',
@@ -237,12 +237,26 @@ class Cdist(Benchmark):
     def setup(self, num_points, metric):
         np.random.seed(123)
         self.points = np.random.random_sample((num_points, 3))
+        # use an equal weight vector to satisfy those metrics
+        # that require weights
+        if metric == 'wminkowski':
+            self.wcdist = np.ones(3)
+            self.wpdist = np.ones(3)
+        else:
+            self.wcdist = None
+            self.wpdist = None
 
     def time_cdist(self, num_points, metric):
         """Time scipy.spatial.distance.cdist over a range of input data
         sizes and metrics.
         """
-        distance.cdist(self.points, self.points, metric)
+        distance.cdist(self.points, self.points, metric, w=self.wcdist)
+
+    def time_pdist(self, num_points, metric):
+        """Time scipy.spatial.distance.pdist over a range of input data
+        sizes and metrics.
+        """
+        distance.pdist(self.points, metric, w=self.wpdist)
 
 
 class ConvexHullBench(Benchmark):

--- a/benchmarks/benchmarks/spatial.py
+++ b/benchmarks/benchmarks/spatial.py
@@ -240,23 +240,21 @@ class Xdist(Benchmark):
         # use an equal weight vector to satisfy those metrics
         # that require weights
         if metric == 'wminkowski':
-            self.wcdist = np.ones(3)
-            self.wpdist = np.ones(3)
+            self.w = np.ones(3)
         else:
-            self.wcdist = None
-            self.wpdist = None
+            self.w = None
 
     def time_cdist(self, num_points, metric):
         """Time scipy.spatial.distance.cdist over a range of input data
         sizes and metrics.
         """
-        distance.cdist(self.points, self.points, metric, w=self.wcdist)
+        distance.cdist(self.points, self.points, metric, w=self.w)
 
     def time_pdist(self, num_points, metric):
         """Time scipy.spatial.distance.pdist over a range of input data
         sizes and metrics.
         """
-        distance.pdist(self.points, metric, w=self.wpdist)
+        distance.pdist(self.points, metric, w=self.w)
 
 
 class ConvexHullBench(Benchmark):


### PR DESCRIPTION
Adding simple `asv` benchmarks for `pdist`. This is a pretty minor contribution since we already have `cdist` covered, but for completeness perhaps it doesn't hurt. May also allow for more comprehensive evaluation of https://github.com/scipy/scipy/pull/5763.

In running the affected benchmarks with:
`asv continuous --bench Xdist 8bdc4489 73f723a6 -e >& log.txt`

I noticed that the `wminkowski` metric now requires a weight vector, so this adjustment is also accounted for here, though I now realise that we may get away with using the same weight vector for `pdist` and `cdist` in the `setup` method so I should perhaps clean that up.

The log output from running the above `asv` command is rather large so I'm [linking the file here](https://github.com/scipy/scipy/files/1489076/log.txt).
