### PR TITLE
BUG: correctly handle inputs with nan's and ties in spearmanr

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3298,11 +3298,11 @@ def spearmanr(a, b=None, axis=0, nan_policy='propagate'):
             b = ma.masked_invalid(b)
 
             if nan_policy == 'propagate':
-                rho, pval = mstats_basic.spearmanr(a, b, axis)
+                rho, pval = mstats_basic.spearmanr(a, b, use_ties=True)
                 return SpearmanrResult(rho * np.nan, pval * np.nan)
 
             if nan_policy == 'omit':
-                return mstats_basic.spearmanr(a, b, axis)
+                return mstats_basic.spearmanr(a, b, use_ties=True)
 
         br = np.apply_along_axis(rankdata, axisout, b)
     n = a.shape[axisout]

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -627,6 +627,20 @@ class TestCorrSpearmanrTies(object):
         pr = stats.pearsonr(xr, yr)
         assert_almost_equal(sr, pr)
 
+    def test_tie2(self):
+        # Test tie-handling if inputs contain nan's
+        # Data without nan's
+        x1 = [1, 2, 2.5, 2]
+        y1 = [1, 3, 2.5, 4]
+        # Same data with nan's
+        x2 = [1, 2, 2.5, 2, np.nan]
+        y2 = [1, 3, 2.5, 4, np.nan]
+
+        # Results for two data sets should be the same if nan's are ignored
+        sr1 = stats.spearmanr(x1, y1)
+        sr2 = stats.spearmanr(x2, y2, nan_policy='omit')
+        assert_almost_equal(sr1, sr2)
+
 
 #    W.II.E.  Tabulate X against X, using BIG as a case weight.  The values
 #    should appear on the diagonal and the total should be 899999955.


### PR DESCRIPTION
The stats.spearmanr function gives incorrect results when the input variables contain both repeated values (i.e. tied ranks) and nan's. This commit fixes the bug by forcing a correction for ties when the mstats_basic.spearmanr function is called. (This bug is described with an example in issue #6654.)

Closes #6654 