### PR TITLE
MAINT: missed triang edge case.

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -5240,26 +5240,31 @@ class triang_gen(rv_continuous):
         return (c >= 0) & (c <= 1)
 
     def _pdf(self, x, c):
+        # 0: edge case where c=0
+        # 1: generalised case for x < c, don't use x <= c, as it doesn't cope
+        #    with c = 0.
+        # 2: generalised case for x >= c, but doesn't cope with c = 1
+        # 3: edge case where c=1
         r = _lazyselect([c == 0,
-                         c == 1,
                          x < c,
-                         x >= c],
-                        [lambda x, c: 2 - 2*x,
-                         lambda x, c: 2 * x,
+                         (x >= c) & (c != 1),
+                         c == 1],
+                        [lambda x, c: 2 - 2 * x,
                          lambda x, c: 2 * x / c,
-                         lambda x, c: 2 * (1-x) / (1-c)],
+                         lambda x, c: 2 * (1 - x) / (1 - c),
+                         lambda x, c: 2 * x],
                         (x, c))
         return r
 
     def _cdf(self, x, c):
         r = _lazyselect([c == 0,
-                         c == 1,
                          x < c,
-                         x >= c],
+                         (x >= c) & (c != 1),
+                         c == 1],
                         [lambda x, c: 2*x - x*x,
-                         lambda x, c: x * x,
                          lambda x, c: x * x / c,
-                         lambda x, c: (x*x - 2*x + c) / (c-1)],
+                         lambda x, c: (x*x - 2*x + c) / (c-1),
+                         lambda x, c: x * x],
                         (x, c))
         return r
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2349,12 +2349,22 @@ class TestTrapz(object):
 
 class TestTriang(object):
     def test_edge_cases(self):
-        assert_equal(stats.triang.pdf(0.5, 0), 1.)
-        assert_equal(stats.triang.pdf(0.5, 1), 1.)
+        with np.errstate(all='raise'):
+            assert_equal(stats.triang.pdf(0, 0), 2.)
+            assert_equal(stats.triang.pdf(0.5, 0), 1.)
+            assert_equal(stats.triang.pdf(1, 0), 0.)
 
-        assert_equal(stats.triang.cdf(0.5, 0.), 0.75)
-        assert_equal(stats.triang.cdf(0.5, 1.), 0.25)
+            assert_equal(stats.triang.pdf(0, 1), 0)
+            assert_equal(stats.triang.pdf(0.5, 1), 1.)
+            assert_equal(stats.triang.pdf(1, 1), 2)
 
+            assert_equal(stats.triang.cdf(0., 0.), 0.)
+            assert_equal(stats.triang.cdf(0.5, 0.), 0.75)
+            assert_equal(stats.triang.cdf(1.0, 0.), 1.0)
+
+            assert_equal(stats.triang.cdf(0., 1.), 0.)
+            assert_equal(stats.triang.cdf(0.5, 1.), 0.25)
+            assert_equal(stats.triang.cdf(1., 1.), 1)
 
 def test_540_567():
     # test for nan returned in tickets 540, 567


### PR DESCRIPTION
@rgommers sorry, I missed an edge case for `stats.triang`

```
>>> from scipy.stats import triang
>>> triang.pdf(1, 1)
/Users/anz/miniconda3/envs/dev3/lib/python3.6/site-packages/ipykernel_launcher.py:9: RuntimeWarning: invalid value encountered in true_divide
  if __name__ == '__main__':
Out[58]:
array(nan)
```

I rectified that, and added more tests to cover the missed edge case (testing all pdf/cdf edge cases now).