### PR TITLE
MAINT: signal.sosfreqz: rename to `freqz_sos`

### DIFF
--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -93,7 +93,7 @@ Filter design
    freqs_zpk     -- Analog filter frequency response from ZPK coefficients.
    freqz         -- Digital filter frequency response from TF coefficients.
    freqz_zpk     -- Digital filter frequency response from ZPK coefficients.
-   sosfreqz      -- Digital filter frequency response for SOS format filter.
+   freqz_sos     -- Digital filter frequency response for SOS format filter.
    gammatone     -- FIR and IIR gammatone filter design.
    group_delay   -- Digital filter group delay.
    iirdesign     -- IIR filter design given bands and gains.

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -26,7 +26,7 @@ __all__ = ['findfreqs', 'freqs', 'freqz', 'tf2zpk', 'zpk2tf', 'normalize',
            'buttap', 'cheb1ap', 'cheb2ap', 'ellipap', 'besselap',
            'BadCoefficients', 'freqs_zpk', 'freqz_zpk',
            'tf2sos', 'sos2tf', 'zpk2sos', 'sos2zpk', 'group_delay',
-           'sosfreqz', 'iirnotch', 'iirpeak', 'bilinear_zpk',
+           'sosfreqz', 'freqz_sos', 'iirnotch', 'iirpeak', 'bilinear_zpk',
            'lp2lp_zpk', 'lp2hp_zpk', 'lp2bp_zpk', 'lp2bs_zpk',
            'gammatone', 'iircomb']
 
@@ -338,7 +338,7 @@ def freqz(b, a=1, worN=512, whole=False, plot=None, fs=2*pi, include_nyquist=Fal
     See Also
     --------
     freqz_zpk
-    sosfreqz
+    freqz_sos
 
     Notes
     -----
@@ -712,7 +712,7 @@ def _validate_sos(sos):
     return sos, n_sections
 
 
-def sosfreqz(sos, worN=512, whole=False, fs=2*pi):
+def freqz_sos(sos, worN=512, whole=False, fs=2*pi):
     r"""
     Compute the frequency response of a digital filter in SOS format.
 
@@ -777,7 +777,7 @@ def sosfreqz(sos, worN=512, whole=False, fs=2*pi):
 
     Compute the frequency response at 1500 points from DC to Nyquist.
 
-    >>> w, h = signal.sosfreqz(sos, worN=1500)
+    >>> w, h = signal.freqz_sos(sos, worN=1500)
 
     Plot the response.
 
@@ -832,6 +832,11 @@ def sosfreqz(sos, worN=512, whole=False, fs=2*pi):
         w, rowh = freqz(row[:3], row[3:], worN=worN, whole=whole, fs=fs)
         h *= rowh
     return w, h
+
+
+@np.deprecate(new_name='freqz_sos')
+def sosfreqz(*args, **kwargs):
+    return freqz_sos(*args, **kwargs)
 
 
 def _cplxreal(z, tol=None):

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -14,11 +14,11 @@ from scipy.signal import (argrelextrema, BadCoefficients, bessel, besselap, bili
                           buttap, butter, buttord, cheb1ap, cheb1ord, cheb2ap,
                           cheb2ord, cheby1, cheby2, ellip, ellipap, ellipord,
                           firwin, freqs_zpk, freqs, freqz, freqz_zpk,
-                          gammatone, group_delay, iircomb, iirdesign, iirfilter, 
-                          iirnotch, iirpeak, lp2bp, lp2bs, lp2hp, lp2lp, normalize, 
-                          sos2tf, sos2zpk, sosfreqz, tf2sos, tf2zpk, zpk2sos, 
+                          gammatone, group_delay, iircomb, iirdesign, iirfilter,
+                          iirnotch, iirpeak, lp2bp, lp2bs, lp2hp, lp2lp, normalize,
+                          sos2tf, sos2zpk, sosfreqz, tf2sos, tf2zpk, zpk2sos,
                           zpk2tf, bilinear_zpk, lp2lp_zpk, lp2hp_zpk, lp2bp_zpk,
-                          lp2bs_zpk)
+                          lp2bs_zpk, freqz_sos)
 from scipy.signal.filter_design import (_cplxreal, _cplxpair, _norm_factor,
                                         _bessel_poly, _bessel_zeros)
 
@@ -828,10 +828,10 @@ class TestFreqz:
         assert_array_almost_equal(h1, h2)
 
 
-class TestSOSFreqz:
+class TestFreqz_SOS:
 
-    def test_sosfreqz_basic(self):
-        # Compare the results of freqz and sosfreqz for a low order
+    def test_freqz_sos_basic(self):
+        # Compare the results of freqz and freqz_sos for a low order
         # Butterworth filter.
 
         N = 500
@@ -839,27 +839,27 @@ class TestSOSFreqz:
         b, a = butter(4, 0.2)
         sos = butter(4, 0.2, output='sos')
         w, h = freqz(b, a, worN=N)
-        w2, h2 = sosfreqz(sos, worN=N)
+        w2, h2 = freqz_sos(sos, worN=N)
         assert_equal(w2, w)
         assert_allclose(h2, h, rtol=1e-10, atol=1e-14)
 
         b, a = ellip(3, 1, 30, (0.2, 0.3), btype='bandpass')
         sos = ellip(3, 1, 30, (0.2, 0.3), btype='bandpass', output='sos')
         w, h = freqz(b, a, worN=N)
-        w2, h2 = sosfreqz(sos, worN=N)
+        w2, h2 = freqz_sos(sos, worN=N)
         assert_equal(w2, w)
         assert_allclose(h2, h, rtol=1e-10, atol=1e-14)
         # must have at least one section
-        assert_raises(ValueError, sosfreqz, sos[:0])
+        assert_raises(ValueError, freqz_sos, sos[:0])
 
-    def test_sosfrez_design(self):
-        # Compare sosfreqz output against expected values for different
+    def test_freqz_sos_design(self):
+        # Compare freqz_sos output against expected values for different
         # filter types
 
         # from cheb2ord
         N, Wn = cheb2ord([0.1, 0.6], [0.2, 0.5], 3, 60)
         sos = cheby2(N, 60, Wn, 'stop', output='sos')
-        w, h = sosfreqz(sos)
+        w, h = freqz_sos(sos)
         h = np.abs(h)
         w /= np.pi
         assert_allclose(20 * np.log10(h[w <= 0.1]), 0, atol=3.01)
@@ -868,7 +868,7 @@ class TestSOSFreqz:
 
         N, Wn = cheb2ord([0.1, 0.6], [0.2, 0.5], 3, 150)
         sos = cheby2(N, 150, Wn, 'stop', output='sos')
-        w, h = sosfreqz(sos)
+        w, h = freqz_sos(sos)
         dB = 20*np.log10(np.abs(h))
         w /= np.pi
         assert_allclose(dB[w <= 0.1], 0, atol=3.01)
@@ -878,7 +878,7 @@ class TestSOSFreqz:
         # from cheb1ord
         N, Wn = cheb1ord(0.2, 0.3, 3, 40)
         sos = cheby1(N, 3, Wn, 'low', output='sos')
-        w, h = sosfreqz(sos)
+        w, h = freqz_sos(sos)
         h = np.abs(h)
         w /= np.pi
         assert_allclose(20 * np.log10(h[w <= 0.2]), 0, atol=3.01)
@@ -886,7 +886,7 @@ class TestSOSFreqz:
 
         N, Wn = cheb1ord(0.2, 0.3, 1, 150)
         sos = cheby1(N, 1, Wn, 'low', output='sos')
-        w, h = sosfreqz(sos)
+        w, h = freqz_sos(sos)
         dB = 20*np.log10(np.abs(h))
         w /= np.pi
         assert_allclose(dB[w <= 0.2], 0, atol=1.01)
@@ -895,7 +895,7 @@ class TestSOSFreqz:
         # adapted from ellipord
         N, Wn = ellipord(0.3, 0.2, 3, 60)
         sos = ellip(N, 0.3, 60, Wn, 'high', output='sos')
-        w, h = sosfreqz(sos)
+        w, h = freqz_sos(sos)
         h = np.abs(h)
         w /= np.pi
         assert_allclose(20 * np.log10(h[w >= 0.3]), 0, atol=3.01)
@@ -904,7 +904,7 @@ class TestSOSFreqz:
         # adapted from buttord
         N, Wn = buttord([0.2, 0.5], [0.14, 0.6], 3, 40)
         sos = butter(N, Wn, 'band', output='sos')
-        w, h = sosfreqz(sos)
+        w, h = freqz_sos(sos)
         h = np.abs(h)
         w /= np.pi
         assert_allclose(h[w <= 0.14], 0., atol=1e-2)  # <= -40 dB
@@ -914,17 +914,17 @@ class TestSOSFreqz:
 
         N, Wn = buttord([0.2, 0.5], [0.14, 0.6], 3, 100)
         sos = butter(N, Wn, 'band', output='sos')
-        w, h = sosfreqz(sos)
+        w, h = freqz_sos(sos)
         dB = 20*np.log10(np.maximum(np.abs(h), 1e-10))
         w /= np.pi
         assert_array_less(dB[(w > 0) & (w <= 0.14)], -99.9)
         assert_array_less(dB[w >= 0.6], -99.9)
         assert_allclose(dB[(w >= 0.2) & (w <= 0.5)], 0, atol=3.01)
 
-    def test_sosfreqz_design_ellip(self):
+    def test_freqz_sos_design_ellip(self):
         N, Wn = ellipord(0.3, 0.1, 3, 60)
         sos = ellip(N, 0.3, 60, Wn, 'high', output='sos')
-        w, h = sosfreqz(sos)
+        w, h = freqz_sos(sos)
         h = np.abs(h)
         w /= np.pi
         assert_allclose(20 * np.log10(h[w >= 0.3]), 0, atol=3.01)
@@ -932,7 +932,7 @@ class TestSOSFreqz:
 
         N, Wn = ellipord(0.3, 0.2, .5, 150)
         sos = ellip(N, .5, 150, Wn, 'high', output='sos')
-        w, h = sosfreqz(sos)
+        w, h = freqz_sos(sos)
         dB = 20*np.log10(np.maximum(np.abs(h), 1e-10))
         w /= np.pi
         assert_allclose(dB[w >= 0.3], 0, atol=.55)
@@ -940,7 +940,7 @@ class TestSOSFreqz:
 
     @mpmath_check("0.10")
     def test_sos_freqz_against_mp(self):
-        # Compare the result of sosfreqz applied to a high order Butterworth
+        # Compare the result of freqz_sos applied to a high order Butterworth
         # filter against the result computed using mpmath.  (signal.freqz fails
         # miserably with such high order filters.)
         from . import mpsig
@@ -954,7 +954,7 @@ class TestSOSFreqz:
         h_mp = np.array([complex(x) for x in h_mp])
 
         sos = butter(order, Wn, output='sos')
-        w, h = sosfreqz(sos, worN=N)
+        w, h = freqz_sos(sos, worN=N)
         assert_allclose(w, w_mp, rtol=1e-12, atol=1e-14)
         assert_allclose(h, h_mp, rtol=1e-12, atol=1e-14)
 
@@ -965,34 +965,34 @@ class TestSOSFreqz:
                [1.0, 1.0, 0.0, 1.0, -0.9495739996946778, 0.45125966317124144]]
 
         # N = None, whole=False
-        w1, h1 = sosfreqz(sos, fs=fs)
-        w2, h2 = sosfreqz(sos)
+        w1, h1 = freqz_sos(sos, fs=fs)
+        w2, h2 = freqz_sos(sos)
         assert_allclose(h1, h2)
         assert_allclose(w1, np.linspace(0, fs/2, 512, endpoint=False))
 
         # N = None, whole=True
-        w1, h1 = sosfreqz(sos, whole=True, fs=fs)
-        w2, h2 = sosfreqz(sos, whole=True)
+        w1, h1 = freqz_sos(sos, whole=True, fs=fs)
+        w2, h2 = freqz_sos(sos, whole=True)
         assert_allclose(h1, h2)
         assert_allclose(w1, np.linspace(0, fs, 512, endpoint=False))
 
         # N = 5, whole=False
-        w1, h1 = sosfreqz(sos, 5, fs=fs)
-        w2, h2 = sosfreqz(sos, 5)
+        w1, h1 = freqz_sos(sos, 5, fs=fs)
+        w2, h2 = freqz_sos(sos, 5)
         assert_allclose(h1, h2)
         assert_allclose(w1, np.linspace(0, fs/2, 5, endpoint=False))
 
         # N = 5, whole=True
-        w1, h1 = sosfreqz(sos, 5, whole=True, fs=fs)
-        w2, h2 = sosfreqz(sos, 5, whole=True)
+        w1, h1 = freqz_sos(sos, 5, whole=True, fs=fs)
+        w2, h2 = freqz_sos(sos, 5, whole=True)
         assert_allclose(h1, h2)
         assert_allclose(w1, np.linspace(0, fs, 5, endpoint=False))
 
         # w is an array_like
         for w in ([123], (123,), np.array([123]), (50, 123, 230),
                   np.array([50, 123, 230])):
-            w1, h1 = sosfreqz(sos, w, fs=fs)
-            w2, h2 = sosfreqz(sos, 2*pi*np.array(w)/fs)
+            w1, h1 = freqz_sos(sos, w, fs=fs)
+            w2, h2 = freqz_sos(sos, 2*pi*np.array(w)/fs)
             assert_allclose(h1, h2)
             assert_allclose(w, w1)
 
@@ -1003,18 +1003,18 @@ class TestSOSFreqz:
                   8, np.int8(8), np.int16(8), np.int32(8), np.int64(8),
                   np.array(8)):
 
-            w, h = sosfreqz([1, 0, 0, 1, 0, 0], worN=N)
+            w, h = freqz_sos([1, 0, 0, 1, 0, 0], worN=N)
             assert_array_almost_equal(w, np.pi * np.arange(N) / N)
             assert_array_almost_equal(h, np.ones(N))
 
-            w, h = sosfreqz([1, 0, 0, 1, 0, 0], worN=N, fs=100)
+            w, h = freqz_sos([1, 0, 0, 1, 0, 0], worN=N, fs=100)
             assert_array_almost_equal(w, np.linspace(0, 50, N, endpoint=False))
             assert_array_almost_equal(h, np.ones(N))
 
         # Measure at frequency 8 Hz
         for w in (8.0, 8.0+0j):
             # Only makes sense when fs is specified
-            w_out, h = sosfreqz([1, 0, 0, 1, 0, 0], worN=w, fs=100)
+            w_out, h = freqz_sos([1, 0, 0, 1, 0, 0], worN=w, fs=100)
             assert_array_almost_equal(w_out, [8])
             assert_array_almost_equal(h, [1])
 
@@ -1726,7 +1726,7 @@ class TestEllipord:
         rs = 1000
         N, Wn = ellipord(wp, ws, rp, rs, False)
         sos = ellip(N, rp, rs, Wn, 'lp', False, output='sos')
-        w, h = sosfreqz(sos)
+        w, h = freqz_sos(sos)
         w /= np.pi
         assert_array_less(-rp - 0.1, dB(h[w <= wp]))
         assert_array_less(dB(h[ws <= w]), -rs + 0.1)


### PR DESCRIPTION
The name `sosfreqz` is inconsistent with `freqz_zpk`, `lp2lp_zpk`, etc.

The function's purpose (`freqz`) should be the first part of the
name, so that all variants come up during tab completion.

`sosfreqz` is left as an explanatory alias function for backwards
compatibility.

`sosfilt` `sosfilt_zi` `sosfiltfilt` should also be renamed by the same logic?

(Split off from https://github.com/scipy/scipy/pull/8146 since this depends on https://github.com/scipy/scipy/issues/8319)