### PR TITLE
Fixes Numpy datatype compatibility issues

### DIFF
--- a/scipy/ndimage/src/ni_support.c
+++ b/scipy/ndimage/src/ni_support.c
@@ -179,6 +179,12 @@ int NI_InitLineBuffer(PyArrayObject *array, int axis, npy_intp size1,
     buffer->buffer_data = buffer_data;
     buffer->buffer_lines = buffer_lines;
     buffer->array_type = NI_CanonicalType(PyArray_TYPE(array));
+    if (buffer->array_type > 12)
+    {
+        PyErr_Format(PyExc_RuntimeError, "array type %d not supported",
+                    buffer->array_type);
+        return 0;
+    }
     buffer->array_lines = array_lines;
     buffer->next_line = 0;
     buffer->size1 = size1;

--- a/scipy/ndimage/src/ni_support.c
+++ b/scipy/ndimage/src/ni_support.c
@@ -158,6 +158,7 @@ int NI_InitLineBuffer(PyArrayObject *array, int axis, npy_intp size1,
         NI_ExtendMode extend_mode, double extend_value, NI_LineBuffer *buffer)
 {
     npy_intp line_length = 0, array_lines = 0, size;
+    int array_type;
 
     size = PyArray_SIZE(array);
     /* check if the buffer is big enough: */
@@ -165,6 +166,37 @@ int NI_InitLineBuffer(PyArrayObject *array, int axis, npy_intp size1,
         PyErr_SetString(PyExc_RuntimeError, "buffer too small");
         return 0;
     }
+    /*
+     * Check that the data type is supported, against the types listed in
+     * NI_ArrayToLineBuffer
+     */
+    array_type = NI_CanonicalType(PyArray_TYPE(array));
+    switch (array_type) {
+    case NPY_BOOL:
+    case NPY_UBYTE:
+    case NPY_USHORT:
+    case NPY_UINT:
+    case NPY_ULONG:
+    case NPY_ULONGLONG:
+    case NPY_BYTE:
+    case NPY_SHORT:
+    case NPY_INT:
+    case NPY_LONG:
+    case NPY_LONGLONG:
+    case NPY_FLOAT:
+    case NPY_DOUBLE:
+        break;
+    default:
+#if PY_VERSION_HEX >= 0x03040000
+        PyErr_Format(PyExc_RuntimeError, "array type %R not supported",
+                     (PyObject *)PyArray_DTYPE(array));
+#else
+        PyErr_Format(PyExc_RuntimeError, "array type %d not supported",
+                     array_type);
+#endif
+        return 0;
+    }
+
     /* Initialize a line iterator to move over the array: */
     if (!NI_InitPointIterator(array, &(buffer->iterator)))
         return 0;
@@ -178,13 +210,7 @@ int NI_InitLineBuffer(PyArrayObject *array, int axis, npy_intp size1,
     buffer->array_data = (void *)PyArray_DATA(array);
     buffer->buffer_data = buffer_data;
     buffer->buffer_lines = buffer_lines;
-    buffer->array_type = NI_CanonicalType(PyArray_TYPE(array));
-    if (buffer->array_type > 12)
-    {
-        PyErr_Format(PyExc_RuntimeError, "array type %d not supported",
-                    buffer->array_type);
-        return 0;
-    }
+    buffer->array_type = array_type;
     buffer->array_lines = array_lines;
     buffer->next_line = 0;
     buffer->size1 = size1;

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -400,3 +400,11 @@ def test_footprint_all_zeros():
     kernel = np.zeros((3, 3), bool)
     with assert_raises(ValueError):
         sndi.maximum_filter(arr, footprint=kernel)
+
+def test_gaussian_filter():
+    # Test gaussian filter with np.float16
+    # gh-8207
+    data = np.array([1],dtype = np.float16)
+    sigma = 1.0
+    with assert_raises(RuntimeError):
+        sndi.gaussian_filter(data,sigma)


### PR DESCRIPTION
Fixes #8207 
Taking input as float16 datatype will give segmentation fault, since there are no corresponding types for it in C language. Here I am taking input as float64 type to avoid datatype incompatibility.
 