### PR TITLE
BUG: sparse: Use deduped data for numpy ufuncs

### DIFF
--- a/scipy/sparse/data.py
+++ b/scipy/sparse/data.py
@@ -124,9 +124,8 @@ for npfunc in _ufuncs_with_fixed_point_at_zero:
 
     def _create_method(op):
         def method(self):
-            result = op(self.data)
-            x = self._with_data(result, copy=True)
-            return x
+            result = op(self._deduped_data())
+            return self._with_data(result, copy=True)
 
         method.__doc__ = ("Element-wise %s.\n\n"
                           "See numpy.%s for more information." % (name, name))

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -4475,10 +4475,6 @@ class _NonCanonicalMixin(object):
     def test_empty(self):
         pass
 
-    @pytest.mark.xfail(run=False, reason='unary ufunc overrides broken with non-canonical matrix')
-    def test_unary_ufunc_overrides(self):
-        pass
-
 
 class _NonCanonicalCompressedMixin(_NonCanonicalMixin):
     def _arg1_for_noncanonical(self, M, sorted_indices=False):


### PR DESCRIPTION
Fixes gh-8228. Technically only required for ufuncs where `f(a) + f(b) != f(a+b)`, but this is a simple-enough fix for the general case.