### PR TITLE
Fix #8235

### DIFF
--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -2947,7 +2947,7 @@ class multinomial_gen(multi_rv_generic):
         p[...,-1] = 1. - p[...,:-1].sum(axis=-1)
 
         # true for bad p
-        pcond = np.any(p <= 0, axis=-1)
+        pcond = np.any(p < 0, axis=-1)
         pcond |= np.any(p > 1, axis=-1)
 
         n = np.array(n, dtype=np.int, copy=True)

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -1030,9 +1030,6 @@ class TestMultinomial(object):
         vals3 = multinomial.logpmf([3, 4], 0, [-2, 3])
         assert_allclose(vals3, np.NAN, rtol=1e-8)
         
-        vals4 = multinomial.pmf([3, 3, 0], 6, [2/3.0, 1/3.0, 0])
-        assert_allclose(vals4, 0.219478737997, rtol=1e-8)
-
     def test_reduces_binomial(self):
         # test that the multinomial pmf reduces to the binomial pmf in the 2d
         # case
@@ -1085,6 +1082,10 @@ class TestMultinomial(object):
 
         vals4 = multinomial.pmf([1,2], 4, (.3, .7))
         assert_allclose(vals4, 0, rtol=1e-8)
+        
+        vals5 = multinomial.pmf([3, 3, 0], 6, [2/3.0, 1/3.0, 0])
+        assert_allclose(vals5, 0.219478737997, rtol=1e-8)
+
 
     def test_pmf_broadcasting(self):
         vals0 = multinomial.pmf([1, 2], 3, [[.1, .9], [.2, .8]])

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -1029,6 +1029,9 @@ class TestMultinomial(object):
 
         vals3 = multinomial.logpmf([3, 4], 0, [-2, 3])
         assert_allclose(vals3, np.NAN, rtol=1e-8)
+        
+        vals4 = multinomial.pmf([3, 3, 0], 6, [2/3.0, 1/3.0, 0])
+        assert_allclose(vals4, 0.219478737997, rtol=1e-8)
 
     def test_reduces_binomial(self):
         # test that the multinomial pmf reduces to the binomial pmf in the 2d

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -1086,7 +1086,6 @@ class TestMultinomial(object):
         vals5 = multinomial.pmf([3, 3, 0], 6, [2/3.0, 1/3.0, 0])
         assert_allclose(vals5, 0.219478737997, rtol=1e-8)
 
-
     def test_pmf_broadcasting(self):
         vals0 = multinomial.pmf([1, 2], 3, [[.1, .9], [.2, .8]])
         assert_allclose(vals0, [.243, .384], rtol=1e-8)


### PR DESCRIPTION
Fixes #8235  

Makes the inequality strict in [stats/_multivariate.py](https://github.com/scipy/scipy/blob/master/scipy/stats/_multivariate.py) where `multinomial.pmf` was returning `nan` if parameter `p` had any value equal to 0. @ilayn @WarrenWeckesser @rfire01