### PR TITLE
BUG: Fix runtime warning in scipy.integrate.solve_ivp

### DIFF
--- a/scipy/integrate/_ivp/rk.py
+++ b/scipy/integrate/_ivp/rk.py
@@ -140,7 +140,10 @@ class RungeKutta(OdeSolver):
             scale = atol + np.maximum(np.abs(y), np.abs(y_new)) * rtol
             error_norm = norm(error / scale)
 
-            if error_norm < 1:
+            if error_norm == 0.0:
+                h_abs *= MAX_FACTOR
+                step_accepted = True
+            elif error_norm < 1:
                 h_abs *= min(MAX_FACTOR,
                              max(1, SAFETY * error_norm ** (-1 / (order + 1))))
                 step_accepted = True


### PR DESCRIPTION
When running scipy.integrate.solve_ivp with time-dependent inputs, a
runtime warning is displayed although the result is OK.
This happens when the error in the ODE solver is zero and the
error_norm is zero. When trying to calculate the next step-size, there
is a division by zero.
Closes #8238.