### PR TITLE
FIX: Fixed Documentation Issue #7750

### DIFF
--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -1765,15 +1765,15 @@ def winsorize(a, limits=None, inclusive=(True, True), inplace=False,
         idx = a.argsort()
         if low_limit:
             if low_include:
-                lowidx = int(low_limit * n)
-            else:
                 lowidx = np.round(low_limit * n).astype(int)
+            else:
+                lowidx = int(low_limit * n)
             a[idx[:lowidx]] = a[idx[lowidx]]
         if up_limit is not None:
             if up_include:
-                upidx = n - int(n * up_limit)
-            else:
                 upidx = n - np.round(n * up_limit).astype(int)
+            else:
+                upidx = n - int(n * up_limit)
             a[idx[upidx:]] = a[idx[upidx - 1]]
         return a
 


### PR DESCRIPTION
An attempt to fix the issue [#7750 ](https://github.com/scipy/scipy/issues/7750)

It was labeled as a Documentation issue and in the winsorize function, according to the documentation if inclusive is True then the number of data being masked on each side should be rounded and if False, then it should be truncated. But the code in scipy/scipystats/mstats_basic.py did the reverse. 

I believe the documentation is correct, so I changed the if condition to satisfy the documentation.