### PR TITLE
BUG: Issue #4464 Fixed residuez which failed for Complex Numbers

### DIFF
--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1980,13 +1980,13 @@ def residuez(b, a, tol=1e-3, rtype='avg'):
     p = roots(a)
     r = p * 0.0
     for i in range(len(p)):
-        round_p=p[i]*0.0
+        round_p = p[i]*0.0
         if iscomplex(p[i]):
-            round_p=round_p+round(p[i].real,3)
-            round_p=round_p+round(p[i].imag,3)*1j
+            round_p = round_p+round(p[i].real,3)
+            round_p = round_p+round(p[i].imag,3)*1j
         else:
-            round_p=round(p[i],3)
-        p[i]=round_p
+            round_p = round(p[i],3)
+        p[i] = round_p
     pout, mult = unique_roots(p, tol=tol, rtype=rtype)
     p = []
     for n in range(len(pout)):

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1981,11 +1981,12 @@ def residuez(b, a, tol=1e-3, rtype='avg'):
     r = p * 0.0
     for i in range(len(p)):
         round_p = p[i]*0.0
+        sig_digits=int(math.ceil(-math.log(tol,10)))
         if iscomplex(p[i]):
-            round_p = round_p+round(p[i].real,3)
-            round_p = round_p+round(p[i].imag,3)*1j
+            round_p = round_p+round(p[i].real,sig_digits)
+            round_p = round_p+round(p[i].imag,sig_digits)*1j
         else:
-            round_p = round(p[i],3)
+            round_p = round(p[i],sig_digits)
         p[i] = round_p
     pout, mult = unique_roots(p, tol=tol, rtype=rtype)
     p = []

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -20,6 +20,7 @@ from numpy import (allclose, angle, arange, argsort, array, asarray,
                    product, r_, ravel, real_if_close, reshape,
                    roots, sort, take, transpose, unique, where, zeros,
                    zeros_like)
+from numpy.lib.type_check import iscomplex
 import numpy as np
 import math
 from scipy.special import factorial
@@ -1978,6 +1979,14 @@ def residuez(b, a, tol=1e-3, rtype='avg'):
     b = brev[::-1]
     p = roots(a)
     r = p * 0.0
+    for i in range(len(p)):
+        round_p=p[i]*0.0
+        if iscomplex(p[i]):
+            round_p=round_p+round(p[i].real,3)
+            round_p=round_p+round(p[i].imag,3)*1j
+        else:
+            round_p=round(p[i],3)
+        p[i]=round_p
     pout, mult = unique_roots(p, tol=tol, rtype=rtype)
     p = []
     for n in range(len(pout)):

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1981,14 +1981,15 @@ def residuez(b, a, tol=1e-3, rtype='avg'):
     r = p * 0.0
     for i in range(len(p)):
         round_p = p[i]*0.0
-        sig_digits=int(math.ceil(-math.log(tol,10)))
-        if iscomplex(p[i]):
-            round_p = round_p+round(p[i].real,sig_digits)
-            round_p = round_p+round(p[i].imag,sig_digits)*1j
-        else:
-            round_p = round(p[i],sig_digits)
-        p[i] = round_p
+        sig_digits = int(math.ceil(-math.log(tol,10)))
+        # if iscomplex(p[i]):
+        #     round_p = round_p+round(p[i].real,sig_digits)
+        #     round_p = round_p+round(p[i].imag,sig_digits)*1j
+        # else:
+        #     round_p = round(p[i],sig_digits)
+        # p[i] = round_p
     pout, mult = unique_roots(p, tol=tol, rtype=rtype)
+    print(pout)
     p = []
     for n in range(len(pout)):
         p.extend([pout[n]] * mult[n])

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1982,14 +1982,13 @@ def residuez(b, a, tol=1e-3, rtype='avg'):
     for i in range(len(p)):
         round_p = p[i]*0.0
         sig_digits = int(math.ceil(-math.log(tol,10)))
-        # if iscomplex(p[i]):
-        #     round_p = round_p+round(p[i].real,sig_digits)
-        #     round_p = round_p+round(p[i].imag,sig_digits)*1j
-        # else:
-        #     round_p = round(p[i],sig_digits)
-        # p[i] = round_p
+        if iscomplex(p[i]):
+            round_p = round_p+round(p[i].real,sig_digits)
+            round_p = round_p+round(p[i].imag,sig_digits)*1j
+        else:
+            round_p = round(p[i],sig_digits)
+        p[i] = round_p
     pout, mult = unique_roots(p, tol=tol, rtype=rtype)
-    print(pout)
     p = []
     for n in range(len(pout)):
         p.extend([pout[n]] * mult[n])

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -1747,7 +1747,7 @@ def winsorize(a, limits=None, inclusive=(True, True), inplace=False,
         indicate an open interval.
     inclusive : {(True, True) tuple}, optional
         Tuple indicating whether the number of data being masked on each side
-        should be rounded (True) or truncated (False).
+        should be truncated (True) or rounded (False).
     inplace : {False, True}, optional
         Whether to winsorize in place (True) or to use a copy (False)
     axis : {None, int}, optional
@@ -1765,15 +1765,15 @@ def winsorize(a, limits=None, inclusive=(True, True), inplace=False,
         idx = a.argsort()
         if low_limit:
             if low_include:
-                lowidx = np.round(low_limit * n).astype(int)
-            else:
                 lowidx = int(low_limit * n)
+            else:
+                lowidx = np.round(low_limit * n).astype(int)
             a[idx[:lowidx]] = a[idx[lowidx]]
         if up_limit is not None:
             if up_include:
-                upidx = n - np.round(n * up_limit).astype(int)
-            else:
                 upidx = n - int(n * up_limit)
+            else:
+                upidx = n - np.round(n * up_limit).astype(int)
             a[idx[upidx:]] = a[idx[upidx - 1]]
         return a
 

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -1765,15 +1765,15 @@ def winsorize(a, limits=None, inclusive=(True, True), inplace=False,
         idx = a.argsort()
         if low_limit:
             if low_include:
-                lowidx = int(low_limit * n)
-            else:
                 lowidx = np.round(low_limit * n).astype(int)
+            else:
+                lowidx = int(low_limit * n)
             a[idx[:lowidx]] = a[idx[lowidx]]
         if up_limit is not None:
             if up_include:
-                upidx = n - int(n * up_limit)
-            else:
                 upidx = n - np.round(n * up_limit).astype(int)
+            else:
+                upidx = n - int(n * up_limit)
             a[idx[upidx:]] = a[idx[upidx - 1]]
         return a
 


### PR DESCRIPTION
Fixed the bug in issue #4464 
The function raised a TypeError:
```
TypeError: Cannot cast ufunc subtract output from dtype('complex128') to dtype('float64') with casting rule 'same_kind'
```
To fix it, I fixed the polydiv function in `numpy/lib/polynomial.py`. I created a PR in [numpy repo](https://github.com/numpy/numpy/pull/10473). 
Further, in cases with repeated roots, the obtained roots were of the form 0.9999998 and 1.000001. These were treated as two different roots with multiplicity 1 each. This led to wrong values of the residue. I rounded them off to 3 decimal digits as the `tol` value was set to be 1e-3. This gives the correct answer.

Previous Commit:

Attempt to fix documentation issue [#7750 ](https://github.com/scipy/scipy/issues/7750)
According to the behavior of the function and the tests given in _scipy/stats/tests/test_mstats_basic.py_ when the inclusive tuple is True, the number of data being masked on each side gets truncated and when its False, it gets rounded. 

I changed the documentation accordingly i.e. 
> inclusive : {(True, True) tuple}, optional
>         Tuple indicating whether the number of data being masked on each side
>         should be truncated (True) or rounded (False).  