### PR TITLE
Option to follow original Storn and Price algorithm and its parallelisation

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -6,6 +6,7 @@ import sys
 import warnings
 import numbers
 from collections import namedtuple
+from multiprocessing import Pool
 import inspect
 
 import numpy as np
@@ -337,3 +338,76 @@ except AttributeError:
         if argspec.args[0] == 'self':
             argspec.args.pop(0)
         return argspec
+
+
+class PoolWrapper(object):
+    """
+    Wrapper for working with objects that have map-like methods, such as
+    `multiprocessing.Pool`. Used for parallelisation.
+
+    Parameters
+    ----------
+    pool : int or map-like object
+        If `pool` is an `int` then it specifies the number of threads to
+        use for parallelization. If `int(pool) == 1`, then no parallel
+        processing is used and the map builtin is used. If `pool == -1` then
+        the pool will utilise all available CPU.
+        If pool is an object with a map method that follows the same
+        calling sequence as the built-in map function, then this pool is
+        used for parallelisation.
+    """
+    def __init__(self, pool=1):
+        self.pool = None
+        self._mapfunc = map
+        self._own_pool = False
+
+        if hasattr(pool, 'map'):
+            self.pool = pool
+            self._mapfunc = self.pool.map
+        else:
+            # user supplies a number
+            if int(pool) == -1:
+                # use as many processors as possible
+                self.pool = Pool()
+                self._mapfunc = self.pool.map
+                self._own_pool = True
+            elif int(pool) == 1:
+                pass
+            elif int(pool) > 1:
+                # use the number of processors requested
+                self.pool = Pool(processes=int(pool))
+                self._mapfunc = self.pool.map
+                self._own_pool = True
+            else:
+                raise RuntimeError("Number of workers specified must be -1,"
+                                   " an int >= 1, or an object with a 'map' method")
+
+    def __enter__(self):
+        return self
+
+    def __del__(self):
+        self.close()
+
+    def terminate(self):
+        if self._own_pool:
+            self.pool.terminate()
+
+    def join(self):
+        if self._own_pool:
+            self.pool.join()
+
+    def close(self):
+        if self._own_pool:
+            self.pool.close()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if self._own_pool:
+            if exc_type is None:
+                self.pool.close()
+                self.pool.join()
+            else:
+                self.pool.terminate()
+
+    def map(self, func, iterable):
+        # only accept one iterable because that's all Pool.map accepts
+        return self._mapfunc(func, iterable)

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -348,11 +348,11 @@ class MapWrapper(object):
     Parameters
     ----------
     pool : int or map-like callable
-        If `pool` is an `int` then it specifies the number of threads to
-        use for parallelization. If `int(pool) == 1`, then no parallel
-        processing is used and the map builtin is used. If `pool == -1` then
-        the pool will utilise all available CPU..
-        If pool is a map-like callable that follows the same
+        If `pool` is an integer, then it specifies the number of threads to
+        use for parallelization. If ``int(pool) == 1``, then no parallel
+        processing is used and the map builtin is used.
+        If ``pool == -1``, then the pool will utilise all available CPUs.
+        If `pool` is a map-like callable that follows the same
         calling sequence as the built-in map function, then this callable is
         used for parallelisation.
     """

--- a/scipy/_lib/tests/test__util.py
+++ b/scipy/_lib/tests/test__util.py
@@ -1,10 +1,12 @@
 from __future__ import division, print_function, absolute_import
+from multiprocessing import Pool
+from multiprocessing.pool import Pool as PWL
 
 import numpy as np
 from numpy.testing import assert_equal, assert_
 from pytest import raises as assert_raises
 
-from scipy._lib._util import _aligned_zeros, check_random_state
+from scipy._lib._util import _aligned_zeros, check_random_state, PoolWrapper
 
 
 def test__aligned_zeros():
@@ -54,3 +56,55 @@ def test_check_random_state():
     rsi = check_random_state(None)
     assert_equal(type(rsi), np.random.RandomState)
     assert_raises(ValueError, check_random_state, 'a')
+
+
+class TestPoolWrapper(object):
+
+    def setup_method(self):
+        self.input = np.arange(10.)
+        self.output = np.sin(self.input)
+
+    def test_serial(self):
+        p = PoolWrapper(1)
+        assert_(p._mapfunc is map)
+        assert_(p.pool is None)
+        assert_(p._own_pool is False)
+        out = list(p.map(np.sin, self.input))
+        assert_equal(out, self.output)
+
+        with assert_raises(RuntimeError):
+            p = PoolWrapper(0)
+
+    def test_parallel(self):
+        with PoolWrapper(2) as p:
+            out = p.map(np.sin, self.input)
+            assert_equal(list(out), self.output)
+
+            assert_(p._own_pool is True)
+            assert_(isinstance(p.pool, PWL))
+            assert_(p._mapfunc is not None)
+
+        # the context manager should've closed the internal pool
+        # check that it has by asking it to calculate again.
+        with assert_raises(Exception) as excinfo:
+            p.map(np.sin, self.input)
+
+        # on py27 an AssertionError is raised, on >py27 it's a ValueError
+        err_type = excinfo.type
+        assert_((err_type is ValueError) or (err_type is AssertionError))
+
+        # can also set a PoolWrapper up with a Pool instance
+        try:
+            p = Pool(2)
+            q = PoolWrapper(p)
+
+            assert_(q._own_pool is False)
+            assert_(isinstance(q.pool, PWL))
+            q.close()
+
+            # closing the PoolWrapper shouldn't close the internal pool
+            # because it didn't create it
+            out = p.map(np.sin, self.input)
+            assert_equal(out, self.output)
+        finally:
+            p.close()

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -897,7 +897,7 @@ class DifferentialEvolutionSolver(object):
         make sure the parameters lie between the limits
         """
         mask = np.where((trial > 1) | (trial < 0))
-        trial[mask] = np.random.random(mask[0].size)
+        trial[mask] = self.random_number_generator.rand(mask[0].size)
 
     def _mutate(self, candidate):
         """

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -24,6 +24,7 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
                            init='latinhypercube', atol=0, updating='immediate',
                            workers=1):
     """Finds the global minimum of a multivariate function.
+
     Differential Evolution is stochastic in nature (does not use gradient
     methods) to find the minimium, and can search large areas of candidate
     space, but often requires larger numbers of function evaluations than
@@ -135,24 +136,25 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
         where and `atol` and `tol` are the absolute and relative tolerance
         respectively.
     updating : {'immediate', 'deferred'}, optional
-        If `immediate` the best solution vector is continuously updated within
-        a single generation [4]_. This can lead to faster convergence as trial
-        vectors can take advantage of continuous improvements in the best
+        If ``'immediate'``, the best solution vector is continuously updated
+        within a single generation [4]_. This can lead to faster convergence as
+        trial vectors can take advantage of continuous improvements in the best
         solution.
-        With `deferred` the best solution vector is updated once per
-        generation. Only `deferred` is compatible with parallelization, and the
-        `workers` keyword can over-ride this option.
+        With ``'deferred'``, the best solution vector is updated once per
+        generation. Only ``'deferred'`` is compatible with parallelization, and
+        the `workers` keyword can over-ride this option.
 
         .. versionadded:: 1.2.0
+
     workers : int or map-like callable, optional
         If `workers` is an int the population is subdivided into `workers`
         sections and evaluated in parallel (uses `multiprocessing.Pool`).
-        Supply `-1` to use all cores available to the Process.
+        Supply -1 to use all available CPU cores.
         Alternatively supply a map-like callable, such as
         `multiprocessing.Pool.map` for evaluating the population in parallel.
         This evaluation is carried out as ``workers(func, iterable)``.
         This option will override the `updating` keyword to
-        `updating='deferred'` if `workers != 1`.
+        ``updating='deferred'`` if ``workers != 1``.
         Requires that `func` be pickleable.
 
         .. versionadded:: 1.2.0
@@ -186,12 +188,12 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
 
     A trial vector is then constructed. Starting with a randomly chosen 'i'th
     parameter the trial is sequentially filled (in modulo) with parameters from
-    `b'` or the original candidate. The choice of whether to use `b'` or the
+    ``b'`` or the original candidate. The choice of whether to use ``b'`` or the
     original candidate is made with a binomial distribution (the 'bin' in
     'best1bin') - a random number in [0, 1) is generated.  If this number is
     less than the `recombination` constant then the parameter is loaded from
-    `b'`, otherwise it is loaded from the original candidate.  The final
-    parameter is always loaded from `b'`.  Once the trial candidate is built
+    ``b'``, otherwise it is loaded from the original candidate.  The final
+    parameter is always loaded from ``b'``.  Once the trial candidate is built
     its fitness is assessed. If the trial is better than the original candidate
     then it takes its place. If it is also better than the best overall
     candidate it also replaces that.
@@ -200,11 +202,11 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
     values. This has the effect of widening the search radius, but slowing
     convergence.
     By default the best solution vector is updated continuously within a single
-    iteration (`updating='immediate'`). This is a modification [4]_ of the
+    iteration (``updating='immediate'``). This is a modification [4]_ of the
     original differential evolution algorithm which can lead to faster
     convergence as trial vectors can immediately benefit from improved
     solutions. To use the original Storn and Price behaviour, updating the best
-    solution once per iteration, set `updating='deferred'`.
+    solution once per iteration, set ``updating='deferred'``.
 
     .. versionadded:: 0.15.0
 
@@ -592,7 +594,7 @@ class DifferentialEvolutionSolver(object):
         init : np.ndarray
             Array specifying subset of the initial population. The array should
             have shape (M, len(x)), where len(x) is the number of parameters.
-            The population is clipped to the lower and upper `bounds`.
+            The population is clipped to the lower and upper bounds.
         """
         # make sure you're using a float array
         popn = np.asfarray(init)
@@ -749,17 +751,17 @@ class DifferentialEvolutionSolver(object):
 
         Parameters
         ----------
-        population : np.ndarray
+        population : ndarray
             An array of parameter vectors normalised to [0, 1] using lower
-            and upper limits. Has shape `(np.size(population, 0), len(x))`.
+            and upper limits. Has shape ``(np.size(population, 0), len(x))``.
 
         Returns
         -------
-        energies : np.ndarray
+        energies : ndarray
             An array of energies corresponding to each population member. If
             maxfun will be exceeded during this call, then the number of
             function evaluations will be reduced and energies will be
-            right-padded with np.inf. Has shape `(np.size(population, 0),)`
+            right-padded with np.inf. Has shape ``(np.size(population, 0),)``
         """
         num_members = np.size(population, 0)
         nfevs = min(num_members,
@@ -891,28 +893,20 @@ class DifferentialEvolutionSolver(object):
     next = __next__
 
     def _scale_parameters(self, trial):
-        """
-        scale from a number between 0 and 1 to parameters.
-        """
+        """Scale from a number between 0 and 1 to parameters."""
         return self.__scale_arg1 + (trial - 0.5) * self.__scale_arg2
 
     def _unscale_parameters(self, parameters):
-        """
-        scale from parameters to a number between 0 and 1.
-        """
+        """Scale from parameters to a number between 0 and 1."""
         return (parameters - self.__scale_arg1) / self.__scale_arg2 + 0.5
 
     def _ensure_constraint(self, trial):
-        """
-        make sure the parameters lie between the limits
-        """
+        """Make sure the parameters lie between the limits."""
         mask = np.where((trial > 1) | (trial < 0))
         trial[mask] = self.random_number_generator.rand(mask[0].size)
 
     def _mutate(self, candidate):
-        """
-        create a trial vector based on a mutation strategy
-        """
+        """Create a trial vector based on a mutation strategy."""
         trial = np.copy(self.population[candidate])
 
         rng = self.random_number_generator
@@ -948,25 +942,19 @@ class DifferentialEvolutionSolver(object):
             return trial
 
     def _best1(self, samples):
-        """
-        best1bin, best1exp
-        """
+        """best1bin, best1exp"""
         r0, r1 = samples[:2]
         return (self.population[0] + self.scale *
                 (self.population[r0] - self.population[r1]))
 
     def _rand1(self, samples):
-        """
-        rand1bin, rand1exp
-        """
+        """rand1bin, rand1exp"""
         r0, r1, r2 = samples[:3]
         return (self.population[r0] + self.scale *
                 (self.population[r1] - self.population[r2]))
 
     def _randtobest1(self, samples):
-        """
-        randtobest1bin, randtobest1exp
-        """
+        """randtobest1bin, randtobest1exp"""
         r0, r1, r2 = samples[:3]
         bprime = np.copy(self.population[r0])
         bprime += self.scale * (self.population[0] - bprime)
@@ -975,19 +963,15 @@ class DifferentialEvolutionSolver(object):
         return bprime
 
     def _currenttobest1(self, candidate, samples):
-        """
-        currenttobest1bin, currenttobest1exp
-        """
+        """currenttobest1bin, currenttobest1exp"""
         r0, r1 = samples[:2]
-        bprime = (self.population[candidate] + self.scale * 
+        bprime = (self.population[candidate] + self.scale *
                   (self.population[0] - self.population[candidate] +
                    self.population[r0] - self.population[r1]))
         return bprime
 
     def _best2(self, samples):
-        """
-        best2bin, best2exp
-        """
+        """best2bin, best2exp"""
         r0, r1, r2, r3 = samples[:4]
         bprime = (self.population[0] + self.scale *
                   (self.population[r0] + self.population[r1] -
@@ -996,9 +980,7 @@ class DifferentialEvolutionSolver(object):
         return bprime
 
     def _rand2(self, samples):
-        """
-        rand2bin, rand2exp
-        """
+        """rand2bin, rand2exp"""
         r0, r1, r2, r3, r4 = samples
         bprime = (self.population[r0] + self.scale *
                   (self.population[r1] + self.population[r2] -

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -509,7 +509,7 @@ class TestDifferentialEvolutionSolver(object):
         bounds = [(0., 2.), (0., 2.), (0, 2), (0, 2)]
         solver = DifferentialEvolutionSolver(rosen, bounds, updating='deferred')
         assert_(solver._updating == 'deferred')
-        assert_(solver._poolwrapper._mapfunc is map)
+        assert_(solver._mapwrapper._mapfunc is map)
         solver.solve()
 
     def test_immediate_updating(self):
@@ -530,7 +530,7 @@ class TestDifferentialEvolutionSolver(object):
         with DifferentialEvolutionSolver(rosen, bounds,
                                          updating='deferred',
                                          workers=2) as solver:
-            assert_(solver._poolwrapper.pool is not None)
+            assert_(solver._mapwrapper.pool is not None)
             assert_(solver._updating == 'deferred')
             solver.solve()
 

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -645,6 +645,12 @@ def _run_doctests(tests, full_name, verbose, doctest_warnings):
             else:
                 out(msg)
 
+        # a flush method is required when a doctest uses multiprocessing
+        # multiprocessing/popen_fork.py flushes sys.stderr
+        def flush(self):
+            if doctest_warnings:
+                sys.stdout.flush()
+
     # Run tests, trying to restore global state afterward
     old_printoptions = np.get_printoptions()
     old_errstate = np.seterr()


### PR DESCRIPTION
Addresses all the points in #8256.
viz:
- aggressive keyword allows the original Storn and Price algorithm to be followed. The aggressive keyword is used to control whether the best solution is continuously updated within a generation
- when a better solution is found with the aggressive=True option it is swapped with the previous best solution (it doesn't replace it).

The PR takes advantage of the aggressive keyword to introduce parallelisation, a previous attempt was made in #5141. This PR therefore closes #5141, closes #4864 and closes #8256 if and when it's merged.