### PR TITLE
MAINT: flatten param array - optimize.brute

### DIFF
--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -2835,7 +2835,7 @@ def brute(func, ranges, args=(), Ns=20, full_output=0, finish=fmin,
         lrange = lrange[0]
 
     def _scalarfunc(*params):
-        params = squeeze(asarray(params))
+        params = asarray(params).flatten()
         return func(params, *args)
 
     vecfunc = vectorize(_scalarfunc)

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -1190,6 +1190,18 @@ class TestBrute:
         assert_allclose(resbrute[1], self.func(self.solution, *self.params),
                         atol=1e-3)
 
+    def test_1D(self):
+        # test that for a 1D problem the test function is passed an array,
+        # not a scalar.
+        def f(x):
+            # we would like the parame
+            assert_(len(x.shape) == 1)
+            assert_(x.shape[0] == 1)
+            return x ** 2
+
+        optimize.brute(f, [(-1, 1)], Ns=3, finish=None)
+
+
 class TestIterationLimits(object):
     # Tests that optimisation does not give up before trying requested
     # number of iterations or evaluations. And that it does not succeed

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -1194,7 +1194,6 @@ class TestBrute:
         # test that for a 1D problem the test function is passed an array,
         # not a scalar.
         def f(x):
-            # we would like the parame
             assert_(len(x.shape) == 1)
             assert_(x.shape[0] == 1)
             return x ** 2


### PR DESCRIPTION
#7708 expresses surprise that the parameter array supplied to a test function in brute receives a float to start with, then an array during the finishing step.

The examples presented was a 1D test problem. The offending code was in brute at L2818. A length 1 tuple was converted to an array which was then squeezed, producing a scalar. Instead the parameter should probably be flattened.
 
Closes  #7708