### PR TITLE
ENH: Extend peak finding capabilities in scipy.signal

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -184,6 +184,7 @@ Felix Lenders for implementing trust-trlib method.
 Dezmond Goff for adding optional out parameter to pdist/cdist
 Nick R. Papior for allowing a wider choice of solvers
 Sean Quinn for the Moyal distribution
+Lars Grüter for contributions to peak finding in scipy.signal
 
 Institutions
 ------------

--- a/doc/release/1.1.0-notes.rst
+++ b/doc/release/1.1.0-notes.rst
@@ -45,6 +45,18 @@ can now accept an array. This array allows the user to specify the entire
 population.
 
 
+`scipy.signal` improvements
+---------------------------
+
+Three new functions for peak finding in one-dimensional arrays were added.
+`scipy.signal.find_peaks` searches for peaks (local maxima) based on simple value
+comparison of neighbouring samples and returns those peaks whose properties match
+optionally specified conditions for their height, prominence, width, threshold
+and distance to each other. `scipy.signal.peak_prominences` and
+`scipy.signal.peak_width` can directly calculate the prominences or widths of
+known peaks.
+
+
 `scipy.sparse` improvements
 ----------------------------
 

--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -281,6 +281,7 @@ Peak finding
    argrelmin        -- Calculate the relative minima of data
    argrelmax        -- Calculate the relative maxima of data
    argrelextrema    -- Calculate the relative extrema of data
+   find_peaks       -- Find a subset of peaks inside a signal.
    find_peaks_cwt   -- Find peaks in a 1-D array with wavelet transformation.
    peak_prominences -- Calculate the prominence of each peak in a signal.
    peak_widths      -- Calculate the width of each peak in a signal.

--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -283,6 +283,7 @@ Peak finding
    argrelextrema    -- Calculate the relative extrema of data
    find_peaks_cwt   -- Find peaks in a 1-D array with wavelet transformation.
    peak_prominences -- Calculate the prominence of each peak in a signal.
+   peak_widths      -- Calculate the width of each peak in a signal.
 
 Spectral Analysis
 =================

--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -278,10 +278,11 @@ Peak finding
 .. autosummary::
    :toctree: generated/
 
-   find_peaks_cwt -- Attempt to find the peaks in the given 1-D array
-   argrelmin      -- Calculate the relative minima of data
-   argrelmax      -- Calculate the relative maxima of data
-   argrelextrema  -- Calculate the relative extrema of data
+   argrelmin        -- Calculate the relative minima of data
+   argrelmax        -- Calculate the relative maxima of data
+   argrelextrema    -- Calculate the relative extrema of data
+   find_peaks_cwt   -- Find peaks in a 1-D array with wavelet transformation.
+   peak_prominences -- Calculate the prominence of each peak in a signal.
 
 Spectral Analysis
 =================

--- a/scipy/signal/_peak_finding.py
+++ b/scipy/signal/_peak_finding.py
@@ -412,7 +412,7 @@ def peak_widths(x, peaks, rel_height=0.5, **kwargs):
         Indices of peaks in `x`.
     rel_height : float, optional
         Chooses the relative height at which the peak width is measured as a
-        percentage of its prominence. 1. calculates the width of the peak at its
+        percentage of its prominence. 1.0 calculates the width of the peak at its
         lowest contour line while 0.5 evaluates at half the prominence height.
         Must be a number greater 0. See notes for further explanation.
     prominences : ndarray, optional
@@ -420,7 +420,7 @@ def peak_widths(x, peaks, rel_height=0.5, **kwargs):
     left_bases, right_bases : ndarray, optional
         The peaks' bases as indices in `x` to the left and right of each peak.
     wlen : int, optional
-        A window length in samples (see `scipy.signal.peak_prominences`). This
+        A window length in samples (see `peak_prominences`). This
         argument is only used if the above three parameters aren't given in
         which case they are calculated using `wlen`.
 
@@ -452,9 +452,9 @@ def peak_widths(x, peaks, rel_height=0.5, **kwargs):
     * Draw a horizontal line at the evaluation height to both sides, starting at
       the peak's current vertical position until the lines either intersect a
       slope, the signal border or cross the vertical position of the peak's
-      base (see `scipy.signal.peak_prominences` for an definition). For the first
-      case, intersection with the signal, the true intersection point is
-      estimated with linear interpolation.
+      base (see `peak_prominences` for an definition). For the first case,
+      intersection with the signal, the true intersection point is estimated with
+      linear interpolation.
     * Calculate the width as the horizontal distance between the intersection
       points on both sides.
 
@@ -470,16 +470,16 @@ def peak_widths(x, peaks, rel_height=0.5, **kwargs):
     Prepare a test signal with growing peak widths
 
     >>> from scipy.signal import chirp, find_peaks, peak_widths
-    >>> x = np.arange(0, 500)
-    >>> x = abs(chirp(x, 1e-4, x.max(), 1.1e-2)) + 2 * x / x.max()
+    >>> x = np.linspace(0, 500, 500)
+    >>> x = abs(chirp(x, 1e-4, x.max(), 1.1e-2)) + 2.0 * x / x.max()
 
-    Find all peaks and calculate their widths at half the prominence height
+    Find all peaks and calculate their widths at the relative height of 0.5
 
     >>> peaks, _ = find_peaks(x)
-    >>> widths, heights, lpos, rpos = peak_widths(x, peaks)
+    >>> widths, heights, lpos, rpos = peak_widths(x, peaks, rel_height=0.5)
     >>> widths
-    array([ 77.858817  ,  61.89410638,  45.78585182,  37.96839594,
-            33.15842405,  29.92968807])
+    array([77.7462348 , 62.19574776, 45.57709222, 37.902356  , 33.33210357,
+           29.81097122])
 
     Plot signal, peaks and contour lines at which the widths where calculated
 
@@ -567,7 +567,7 @@ def peak_widths(x, peaks, rel_height=0.5, **kwargs):
 
 def _unpack_filter_args(interval, x, peaks):
     """
-    Parse filter arguments for `scipy.signal.find_peaks`.
+    Parse filter arguments for `find_peaks`.
 
     Parameters
     ----------
@@ -808,12 +808,11 @@ def find_peaks(x, height=None, threshold=None, distance=None,
     wlen : number, optional
         Used for calculation of the peaks prominences thus it is only used if
         one of the arguments `prominence` or `width` is given. See argument
-        `wlen` in `scipy.signal.peak_prominences` for a full description of its
-        effects.
+        `wlen` in `peak_prominences` for a full description of its effects.
     rel_height : float, optional
         Used for calculation of the peaks width thus it is only used if `width`
-        is given. See argument  `rel_height` in `scipy.signal.peak_widths` for a
-        full description of its effects.
+        is given. See argument  `rel_height` in `peak_widths` for a full
+        description of its effects.
 
     Returns
     -------
@@ -829,11 +828,10 @@ def find_peaks(x, height=None, threshold=None, distance=None,
           'right_thresholds' contain a peaks vertical distance to its
           neighbouring samples.
         * If `prominence` is given, the keys 'prominences', 'left_bases' and
-          'right_bases' are accessible. See `scipy.signal.peak_prominences` for
-          a description of their content.
+          'right_bases' are accessible. See `peak_prominences` for a description
+          of their content.
         * If `width` is given, the keys 'wheights', 'left_ips' and 'right_ips'
-          are accessible. See `scipy.signal.peak_widths` for a description of
-          their content.
+          are accessible. See `peak_widths` for a description of their content.
 
     See Also
     --------
@@ -869,8 +867,7 @@ def find_peaks(x, height=None, threshold=None, distance=None,
       needs to be evaluated. Try to reduce the number of peaks with cheaper
       (previous) filter options first.
     * Use `wlen` to reduce the time it takes to filter by prominence or width if
-      `x` is large or has many local maxima (see
-      `scipy.signal.peak_prominences`).
+      `x` is large or has many local maxima (see `peak_prominences`).
     * For several filter options the interval borders can be specified with
       arrays matching `x` in shape which enables dynamic filter constrains.
 

--- a/scipy/signal/_peak_finding.py
+++ b/scipy/signal/_peak_finding.py
@@ -103,11 +103,15 @@ def argrelmin(data, axis=0, order=1, mode='clip'):
 
     See Also
     --------
-    argrelextrema, argrelmax
+    argrelextrema, argrelmax, find_peaks
 
     Notes
     -----
-    This function uses `argrelextrema` with np.less as comparator.
+    This function uses `argrelextrema` with np.less as comparator. Therefore it
+    requires a strict inequality on both sides of a value to consider it a
+    minimum. This means flat minima (more than one sample wide) are not detected.
+    In case of one-dimensional `data` `find_peaks` can be used to detect all
+    local minima, including flat ones, by calling it with negated `data`.
 
     .. versionadded:: 0.11.0
 
@@ -156,11 +160,15 @@ def argrelmax(data, axis=0, order=1, mode='clip'):
 
     See Also
     --------
-    argrelextrema, argrelmin
+    argrelextrema, argrelmin, find_peaks
 
     Notes
     -----
-    This function uses `argrelextrema` with np.greater as comparator.
+    This function uses `argrelextrema` with np.greater as comparator. Therefore
+    it  requires a strict inequality on both sides of a value to consider it a
+    maximum. This means flat maxima (more than one sample wide) are not detected.
+    In case of one-dimensional `data` `find_peaks` can be used to detect all
+    local maxima, including flat ones.
 
     .. versionadded:: 0.11.0
 

--- a/scipy/signal/tests/test_peak_finding.py
+++ b/scipy/signal/tests/test_peak_finding.py
@@ -488,15 +488,23 @@ class TestFindPeaks(object):
         """
         Test behavior for signal without local maxima.
         """
-        peaks = find_peaks(np.ones(10))[0]
+        open_interval = (None, None)
+        property_keys = {'peak_heights', 'left_thresholds', 'right_thresholds',
+                         'prominences', 'left_bases', 'right_bases', 'widths',
+                         'width_heights', 'left_ips', 'right_ips'}
+        peaks, props = find_peaks(np.ones(10),
+                                  height=open_interval, threshold=open_interval,
+                                  prominence=open_interval, width=open_interval)
         assert_(peaks.size == 0)
+        for key in property_keys:
+            assert_(props[key].size == 0)
 
     def test_filter_by_height(self):
         """
         Test filtering by peak height.
         """
         x = (0., 1/3, 0., 2.5, 0, 4., 0)
-        peaks, props = find_peaks(x, height=0)
+        peaks, props = find_peaks(x, height=(None, None))
         assert_equal(peaks, np.array([1, 3, 5]))
         assert_equal(props['peak_heights'], np.array([1/3, 2.5, 4.]))
         assert_equal(find_peaks(x, height=0.5)[0], np.array([3, 5]))
@@ -508,7 +516,7 @@ class TestFindPeaks(object):
         Test filtering by threshold.
         """
         x = (0, 2, 1, 4, -1)
-        peaks, props = find_peaks(x, threshold=1)
+        peaks, props = find_peaks(x, threshold=(None, None))
         assert_equal(peaks, np.array([1, 3]))
         assert_equal(props['left_thresholds'], np.array([2, 3]))
         assert_equal(props['right_thresholds'], np.array([1, 5]))
@@ -568,7 +576,7 @@ class TestFindPeaks(object):
         assert_(peaks.size == 1)
         assert_(peaks == 7)
         assert_(props['widths'] == 1.35)
-        assert_(props['wheights'] == 1.)
+        assert_(props['width_heights'] == 1.)
         assert_(props['left_ips'] == 6.4)
         assert_(props['right_ips'] == 7.75)
 

--- a/scipy/signal/tests/test_peak_finding.py
+++ b/scipy/signal/tests/test_peak_finding.py
@@ -2,14 +2,14 @@ from __future__ import division, print_function, absolute_import
 
 import copy
 
+import numpy as np
+from numpy.testing import (assert_equal, assert_array_equal, assert_)
 import pytest
 from pytest import raises
 
-import numpy as np
-from numpy.testing import assert_equal, assert_array_equal, assert_
-
 from scipy._lib.six import xrange
 from scipy.signal._peak_finding import (argrelmax, argrelmin,
+    peak_prominences, peak_widths, _unpack_filter_args, find_peaks,
     find_peaks_cwt, _identify_ridge_lines)
 from scipy.signal._peak_finding_utils import _argmaxima1d
 
@@ -301,7 +301,300 @@ class TestArgrel(object):
             assert_((act_locs == (rel_max_cols[inds] - rot_factor*rw)).all())
 
 
+class TestPeakProminences(object):
+
+    def test_empty(self):
+        """
+        Test if an empty array is returned if no peaks are provided.
+        """
+        proms = peak_prominences([], [])[0]
+        assert_(isinstance(proms, np.ndarray))
+        assert_equal(proms.size, 0)
+        proms = peak_prominences([1, 2, 3], [])[0]
+        assert_(isinstance(proms, np.ndarray))
+        assert_equal(proms.size, 0)
+        out = peak_prominences([], [])
+        for arr in out:
+            assert_(isinstance(arr, np.ndarray))
+            assert_equal(arr.size, 0)
+
+    def test_basic(self):
+        """
+        Test if height of prominences is correctly calculated in signal with
+        rising baseline (peak widths are 1 sample).
+        """
+        x = np.linspace(1, 4, 7)  # Rising baseline
+        peak_heights = [2, 4, 1.2]  # Peak heights
+        peak_pos = [1, 3, 5]
+        desired = []
+        for h, p in zip(peak_heights, peak_pos):
+            x[p] += h
+            # Peak prominence is difference between vector[peak] and next
+            # sample to the right
+            desired.append(x[p] - x[p + 1])
+        actual = peak_prominences(x, [1, 3, 5])[0]
+        assert_equal(actual, desired)
+
+    def test_wlen(self):
+        """
+        Test if wlen actually shrinks the evaluation range.
+        """
+        t = np.linspace(0, 4 * np.pi, 1000)
+        x = abs(np.sin(t))
+        peaks = argrelmax(x)[0]
+        # Raise 2 baseline of peaks in the middle
+        x[250:750] += 0.3
+        # If entire x is used the middle two peaks should have a prominence
+        # of approx. 1 + 0.3, otherwise minima between second and third peak
+        # should be lowest contour line and prominence should be < 1.1
+        proms_wlen = peak_prominences(x, peaks, wlen=600)[0]
+        assert_(np.all(proms_wlen < 1.1))
+        # If window length is 2
+        assert_equal(peak_prominences(x, peaks)[0],
+                     peak_prominences(x, peaks, wlen=(x.size * 2))[0])
+
+    def test_raises(self):
+        """
+        Verfiy that argument validation works as intended.
+        """
+        with raises(ValueError, match='dimension'):
+            # x with dimension > 1
+            peak_prominences(np.zeros((3, 4)), np.ones(3))
+        with raises(ValueError, match='dimension'):
+            # x with dimension < 1
+            peak_prominences(3, [0,])
+        with raises(ValueError, match='dimension'):
+            # peaks with dimension > 1
+            peak_prominences(np.arange(10), np.ones((3, 2)))
+        with raises(ValueError, match='dimension'):
+            # peaks with dimension < 1
+            peak_prominences(np.arange(10), 3)
+        with raises(ValueError, match='index'):
+            # peak pos exceeds x.size
+            peak_prominences(np.arange(10), [8, 11])
+        with raises(ValueError, match='index'):
+            # empty x with peaks supplied
+            peak_prominences([], [1, 2])
+        with raises(ValueError, match='integers'):
+            # peak is not of subtype int
+            peak_prominences(np.arange(10), [1.1, 2.3])
+        with raises(ValueError, match='wlen'):
+            # wlen < 3
+            peak_prominences(np.arange(10), [3, 5], wlen=2)
+
+
+class TestPeakWidths(object):
+
+    def test_empty(self):
+        """
+        Test if an empty array is returned if no peaks are provided.
+        """
+        widths = peak_widths([], [])[0]
+        assert_(isinstance(widths, np.ndarray))
+        assert_equal(widths.size, 0)
+        widths = peak_widths([1, 2, 3], [])[0]
+        assert_(isinstance(widths, np.ndarray))
+        assert_equal(widths.size, 0)
+        out = peak_widths([], [])
+        for arr in out:
+            assert_(isinstance(arr, np.ndarray))
+            assert_equal(arr.size, 0)
+
+    def test_basic(self):
+        """
+        Test a simple use case with easy to verify results at different relative
+        heights.
+        """
+        x = np.array([1, 0, 1, 2, 1, 0, -1])
+        prominence = 2
+        iteration = [
+            # rh, w_true, lip_true, rip_true
+            (0., 0., 3., 3.),
+            (0.25, 1., 2.5, 3.5),
+            (0.5, 2., 2., 4.),
+            (0.75, 3., 1.5, 4.5),
+            (1., 4., 1., 5.),
+            (2., 5., 1., 6.),
+            (3., 5., 1., 6.)
+        ]
+        for rh, w_true, lip_true, rip_true in iteration:
+            w_calc, height, lip_calc, rip_calc = peak_widths(x, [3], rh)
+            assert_(w_calc == w_true)
+            assert_(height == 2 - rh * prominence)
+            assert_(lip_calc == lip_true)
+            assert_(rip_calc == rip_true)
+        # Additional test without argument ret_pos
+        assert_(peak_widths([1, 2, 1], [1])[0], 1)
+
+    def test_raises(self):
+        """
+        Verfiy that argument validation works as intended.
+        """
+        with raises(ValueError, match='dimension'):
+            # x with dimension > 1
+            peak_widths(np.zeros((3, 4)), np.ones(3))
+        with raises(ValueError, match='dimension'):
+            # x with dimension < 1
+            peak_widths(3, [0, ])
+        with raises(ValueError, match='dimension'):
+            # peaks with dimension > 1
+            peak_widths(np.arange(10), np.ones((3, 2)))
+        with raises(ValueError, match='dimension'):
+            # peaks with dimension < 1
+            peak_widths(np.arange(10), 3)
+        with raises(ValueError, match='index'):
+            # peak pos exceeds x.size
+            peak_widths(np.arange(10), [8, 11])
+        with raises(ValueError, match='index'):
+            # empty x with peaks supplied
+            peak_widths([], [1, 2])
+        with raises(ValueError, match='integers'):
+            # peak is not of subtype int
+            peak_widths(np.arange(10), [1.1, 2.3])
+        with raises(ValueError, match='rel_height'):
+            # rel_height is < 0
+            peak_widths(np.arange(10), [1, 2], rel_height=-1)
+
+
+def test_unpack_filter_args():
+    """
+    Verify parsing of filter arguments for `scipy.signal.find_peaks` function.
+    """
+    x = np.arange(10)
+    amin_true = x
+    amax_true = amin_true + 10
+    peaks = amin_true[1::2]
+
+    # Test unpacking with None or full interval
+    assert_((1, None) == _unpack_filter_args(1, x, peaks))
+    assert_((None, 2) == _unpack_filter_args((None, 2), x, peaks))
+    assert_((3., 4.5) == _unpack_filter_args((3., 4.5), x, peaks))
+
+    # Test if borders are correctly reduced with `peaks`
+    amin_calc, amax_calc = _unpack_filter_args((amin_true, amax_true), x, peaks)
+    assert_equal(amin_calc, amin_true[peaks])
+    assert_equal(amax_calc, amax_true[peaks])
+
+    # Test raises if array borders don't match x
+    with raises(ValueError, match="array size of lower"):
+        _unpack_filter_args(amin_true, np.arange(11), peaks)
+    with raises(ValueError, match="array size of upper"):
+        _unpack_filter_args((None, amin_true), np.arange(11), peaks)
+
+
 class TestFindPeaks(object):
+
+    def test_constant(self):
+        """
+        Test behavior for signal without local maxima.
+        """
+        peaks = find_peaks(np.ones(10))[0]
+        assert_(peaks.size == 0)
+
+    def test_filter_by_height(self):
+        """
+        Test filtering by peak height.
+        """
+        x = (0., 1/3, 0., 2.5, 0, 4., 0)
+        peaks, props = find_peaks(x, height=0)
+        assert_equal(peaks, np.array([1, 3, 5]))
+        assert_equal(props['peak_heights'], np.array([1/3, 2.5, 4.]))
+        assert_equal(find_peaks(x, height=0.5)[0], np.array([3, 5]))
+        assert_equal(find_peaks(x, height=(None, 3))[0], np.array([1, 3]))
+        assert_equal(find_peaks(x, height=(2, 3))[0], np.array([3]))
+
+    def test_filter_by_threshold(self):
+        """
+        Test filtering by threshold.
+        """
+        x = (0, 2, 1, 4, -1)
+        peaks, props = find_peaks(x, threshold=1)
+        assert_equal(peaks, np.array([1, 3]))
+        assert_equal(props['left_thresholds'], np.array([2, 3]))
+        assert_equal(props['right_thresholds'], np.array([1, 5]))
+        assert_equal(find_peaks(x, threshold=2)[0], np.array([3]))
+        assert_equal(find_peaks(x, threshold=3.5)[0], np.array([]))
+        assert_equal(find_peaks(x, threshold=(None, 5))[0], np.array([1, 3]))
+        assert_equal(find_peaks(x, threshold=(None, 4))[0], np.array([1]))
+        assert_equal(find_peaks(x, threshold=(2, 4))[0], np.array([]))
+
+    def test_filter_by_distance(self):
+        """
+        Test filtering by peak distance.
+        """
+        # Peaks of different height with constant distance
+        peaks_all = np.arange(1, 21, 3)
+        x = np.zeros(21)
+        x[peaks_all] += np.linspace(1, 2, peaks_all.size)
+        # Filter every second peak
+        peaks_filt = find_peaks(x, distance=4)[0]
+        # Test if peaks_filt is subset of peaks_all
+        assert_(
+            np.setdiff1d(peaks_filt, peaks_all, assume_unique=True).size == 0
+        )
+        # Test that every second peak was removed
+        assert_equal(np.diff(peaks_filt), 6)
+
+        # Test priority of peak removal
+        x = [-2, 1, -1, 0, -3]
+        peaks_filt = find_peaks(x, distance=10)[0]  # use distance > x size
+        assert_(peaks_filt.size == 1 and peaks_filt[0] == 1)
+
+    def test_filter_by_prominence(self):
+        """
+        Test filtering by peak prominence.
+        """
+        x = np.linspace(0, 10, 100)
+        peaks = np.arange(1, 99, 2)
+        offset = np.linspace(1, 10, peaks.size)
+        x[peaks] += offset
+        prominences = x[peaks] - x[peaks + 1]
+        interval = (3, 9)
+        keep = np.where(
+            (interval[0] <= prominences) & (prominences <= interval[1]))
+
+        peaks_filt, properties = find_peaks(x, prominence=interval)
+        assert_equal(peaks_filt, peaks[keep])
+        assert_equal(properties['prominences'], prominences[keep])
+        assert_equal(properties['left_bases'], 0)
+        assert_equal(properties['right_bases'], peaks[keep] + 1)
+
+    def test_filter_by_width(self):
+        """
+        Test filtering by peak width.
+        """
+        x = np.array([1, 0, 1, 2, 1, 0, -1, 4, 0])
+        peaks, props = find_peaks(x, width=(None, 2), rel_height=0.75)
+        assert_(peaks.size == 1)
+        assert_(peaks == 7)
+        assert_(props['widths'] == 1.35)
+        assert_(props['wheights'] == 1.)
+        assert_(props['left_ips'] == 6.4)
+        assert_(props['right_ips'] == 7.75)
+
+    def test_properties(self):
+        """
+        Test filtering with returned properties.
+        """
+        x = [0, 1, 0, 2, 1.5, 0, 3, 0, 5, 9]
+        peaks, properties = find_peaks(x, height=1.5, threshold=1, width=0)
+        assert_(len(properties) == 10)
+        for array in properties.values():
+            assert_(peaks.size == array.size)
+
+    def test_raises(self):
+        """
+        Test excpetions raised by function.
+        """
+        with raises(ValueError, match="dimension"):
+            find_peaks(np.array(1))
+        with raises(ValueError, match="dimension"):
+            find_peaks(np.ones((2, 2)))
+        with raises(ValueError, match="distance"):
+            find_peaks(np.arange(10), distance=-1)
+
+
+class TestFindPeaksCwt(object):
 
     def test_find_peaks_exact(self):
         """


### PR DESCRIPTION
This follows #8211 and I feel the progress is advanced enough to make feedback possible. Thank you all in advance for taking the time to review this PR and any feedback given.

### Motivation

The motivation for this pull request is that SciPy and other scientific Python libraries lack a function for simple peak finding and filtering like Matlab's [findpeaks](https://de.mathworks.com/help/signal/ref/findpeaks.html?requestedDomain=de.mathworks.com) function.

In my opinion the use case (simple peak finding and filtering) is currently not very well covered by SciPy and its [find_peaks_cwt](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.find_peaks_cwt.html) function. I think these new functions would fit well into SciPy's signal module and its potential usefulness in many domains is underlined by Matlab's implementation which got extended and improved over the years.

### Short description of changes
(I'll keep this up-to date with the current progress)

* New function `peak_prominences`: This function allows to calculate the prominince of a peak in a signal. The prominence is a measure for how much a peak stands out from the base line of a signal.
* New function `peak_widths`: This function allows to calculate the width of a peak in a signal. The width is the horizontal distance between a peaks rising and falling slope at a chosen height.
* New function `find_peaks`: This function allows to find a subset of all local maxima in a vector
by specifying conditions e.g. peak height, distance, etc. It wraps and uses the two public functions described above and makes use of the following private functions (if this organization is useful is up for debate)
   * `_unpack_condition_args`: Parse condition arguments for `find_peaks`.
   * `_select_by_property`: Evaluate where the generic property of peaks confirms to an interval.
   * `_select_by_peak_threshold`: Evaluate which peaks fulfill the threshold condition.
   * `_select_by_peak_distance`: Evaluate which peaks fulfill the distance condition.
* Changes to the docstring of the old function `find_peaks_cwt` to make distinction to new function clearer.

### To do & open questions

* <strike>Still missing are unit tests for the new functions. Which will be added next.</strike>
* <strike>Ensure that `_filter_by_peak_distance` complies with the license of Marcos Duarte's [detect_peaks](http://nbviewer.jupyter.org/github/demotu/BMC/blob/master/notebooks/DetectPeaks.ipynb) function (MIT, should be compatible to SciPy's license). I'm not really sure how to include the copyright?</strike>
* <strike>How to handle if invalid peaks are passed to `peak_prominences` and `peak_widths`? Is it okay to describe this as undefined behavior in the documentation?</strike>
* <strike>[argrelmax](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.argrelmax.html) doesn't catch peaks that are wider than one sample. Decide how to deal with this. I have implemented an alternative [here](http://nbviewer.jupyter.org/urls/gitlab.com/snippets/1695752/raw). This may be a better solution (download notebook [here](https://gitlab.com/snippets/1695752))</strike>
* <strike>Should this be included in the tutorial for `scipy.signal`? I feel like that would be the best place to show more complex examples which are out of place in the docstrings itself.</strike> -> I'd prefer to include a tutorial if wanted in another PR because this one is already quite large. 
* Decide whether `find_peaks` should have a special postfix like `find_peaks_cwt`. If so which one?

### Related discussions and links

* Related issue #7393 
* [Blog post](https://blog.ytotech.com/2015/11/01/findpeaks-in-python/) giving an overview over current state of peak finding with Python and the related [GitHub Repo](https://github.com/MonsieurV/py-findpeaks)
* Closes #3749 
* Closes #6848
* Closes #8211