### PR TITLE
BUG fixed printing of convergence message in minimize_scalar in scipy/optimize

### DIFF
--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -655,6 +655,11 @@ def minimize_scalar(fun, bracket=None, bounds=None, args=(),
         if bounds is None:
             raise ValueError('The `bounds` parameter is mandatory for '
                              'method `bounded`.')
+        # replace boolean "disp" option, if specified, by an integer value, as
+        # expected by _minimize_scalar_bounded()
+        disp = options.get('disp')
+        if isinstance(disp, bool):
+            options['disp'] = 2 * int(disp)
         return _minimize_scalar_bounded(fun, bounds, args, **options)
     elif meth == 'golden':
         return _minimize_scalar_golden(fun, bracket, args, **options)

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -1728,8 +1728,12 @@ def _minimize_scalar_bounded(func, bounds, args=(),
     -------
     maxiter : int
         Maximum number of iterations to perform.
-    disp : bool
-        Set to True to print convergence messages.
+    disp: int, optional
+        If non-zero, print messages.
+            0 : no message printing.
+            1 : non-convergence notification messages only.
+            2 : print a message on convergence too.
+            3 : print iteration results.
     xatol : float
         Absolute error in solution `xopt` acceptable for convergence.
 

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -1720,9 +1720,8 @@ def fminbound(func, x1, x2, args=(), xtol=1e-5, maxfun=500,
         return res['x']
 
 
-def _minimize_scalar_bounded(func, bounds, args=(),
-                             xatol=1e-5, maxiter=500, disp=0,
-                             **unknown_options):
+def _minimize_scalar_bounded(func, bounds, args=(), xatol=1e-5, maxiter=500,
+                             disp=False, **unknown_options):
     """
     Options
     -------
@@ -1767,7 +1766,7 @@ def _minimize_scalar_bounded(func, bounds, args=(),
     tol1 = sqrt_eps * numpy.abs(xf) + xatol / 3.0
     tol2 = 2.0 * tol1
 
-    if disp > 2:
+    if disp:
         print(" ")
         print(header)
         print("%5.0f   %12.6g %12.6g %s" % (fmin_data + (step,)))
@@ -1813,7 +1812,7 @@ def _minimize_scalar_bounded(func, bounds, args=(),
         fu = func(x, *args)
         num += 1
         fmin_data = (num, x, fu)
-        if disp > 2:
+        if disp:
             print("%5.0f   %12.6g %12.6g %s" % (fmin_data + (step,)))
 
         if fu <= fx:
@@ -1844,7 +1843,7 @@ def _minimize_scalar_bounded(func, bounds, args=(),
             break
 
     fval = fx
-    if disp > 0:
+    if disp:
         _endprint(x, flag, fval, maxfun, xatol, disp)
 
     result = OptimizeResult(fun=fval, status=flag, success=(flag == 0),
@@ -2655,7 +2654,7 @@ def _minimize_powell(func, x0, args=(), callback=None,
 
 def _endprint(x, flag, fval, maxfun, xtol, disp):
     if flag == 0:
-        if disp > 1:
+        if disp:
             print("\nOptimization terminated successfully;\n"
                   "The returned value satisfies the termination criteria\n"
                   "(using xtol = ", xtol, ")")

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -1720,8 +1720,9 @@ def fminbound(func, x1, x2, args=(), xtol=1e-5, maxfun=500,
         return res['x']
 
 
-def _minimize_scalar_bounded(func, bounds, args=(), xatol=1e-5, maxiter=500,
-                             disp=False, **unknown_options):
+def _minimize_scalar_bounded(func, bounds, args=(),
+                             xatol=1e-5, maxiter=500, disp=0,
+                             **unknown_options):
     """
     Options
     -------
@@ -1766,7 +1767,7 @@ def _minimize_scalar_bounded(func, bounds, args=(), xatol=1e-5, maxiter=500,
     tol1 = sqrt_eps * numpy.abs(xf) + xatol / 3.0
     tol2 = 2.0 * tol1
 
-    if disp:
+    if disp > 2:
         print(" ")
         print(header)
         print("%5.0f   %12.6g %12.6g %s" % (fmin_data + (step,)))
@@ -1812,7 +1813,7 @@ def _minimize_scalar_bounded(func, bounds, args=(), xatol=1e-5, maxiter=500,
         fu = func(x, *args)
         num += 1
         fmin_data = (num, x, fu)
-        if disp:
+        if disp > 2:
             print("%5.0f   %12.6g %12.6g %s" % (fmin_data + (step,)))
 
         if fu <= fx:
@@ -1843,7 +1844,7 @@ def _minimize_scalar_bounded(func, bounds, args=(), xatol=1e-5, maxiter=500,
             break
 
     fval = fx
-    if disp:
+    if disp > 0:
         _endprint(x, flag, fval, maxfun, xatol, disp)
 
     result = OptimizeResult(fun=fval, status=flag, success=(flag == 0),
@@ -2654,7 +2655,7 @@ def _minimize_powell(func, x0, args=(), callback=None,
 
 def _endprint(x, flag, fval, maxfun, xtol, disp):
     if flag == 0:
-        if disp:
+        if disp > 1:
             print("\nOptimization terminated successfully;\n"
                   "The returned value satisfies the termination criteria\n"
                   "(using xtol = ", xtol, ")")


### PR DESCRIPTION
to display convergence messages, call minimize_scalar with disp=True. However, if method='Bounded', it does not print messages as condition is "if disp > 2" instead of "if disp". fixed in this commit (function
_minimize_scalar_bounded)

Example before my commit:
```
f = lambda x: x**2
optimize.minimize_scalar(f, bounds=((2, 3)), method='Bounded', options={'disp': True}) # does not print
optimize.minimize_scalar(f, bounds=((2, 3)), method='Bounded', options={'disp': 2.5}) # does print convergence messages
```
 
  