### PR TITLE
BUG: fixing crash from scipy/issue/8207

### DIFF
--- a/scipy/ndimage/src/ni_support.c
+++ b/scipy/ndimage/src/ni_support.c
@@ -347,9 +347,13 @@ int NI_ArrayToLineBuffer(NI_LineBuffer *buffer,
                                    pa, pb, length, buffer->line_stride);
             CASE_COPY_DATA_TO_LINE(NPY_LONGLONG, npy_longlong,
                                    pa, pb, length, buffer->line_stride);
+            CASE_COPY_DATA_TO_LINE(NPY_HALF, npy_half,
+                                   pa, pb, length, buffer->line_stride);
             CASE_COPY_DATA_TO_LINE(NPY_FLOAT, npy_float,
                                    pa, pb, length, buffer->line_stride);
             CASE_COPY_DATA_TO_LINE(NPY_DOUBLE, npy_double,
+                                   pa, pb, length, buffer->line_stride);
+            CASE_COPY_DATA_TO_LINE(NPY_LONGDOUBLE, npy_longdouble,
                                    pa, pb, length, buffer->line_stride);
         default:
             PyErr_Format(PyExc_RuntimeError, "array type %d not supported",
@@ -425,9 +429,13 @@ int NI_LineBufferToArray(NI_LineBuffer *buffer)
                                    pb, pa, length, buffer->line_stride);
             CASE_COPY_LINE_TO_DATA(NPY_LONGLONG, npy_longlong,
                                    pb, pa, length, buffer->line_stride);
+            CASE_COPY_LINE_TO_DATA(NPY_HALF, npy_half,
+                                   pb, pa, length, buffer->line_stride);
             CASE_COPY_LINE_TO_DATA(NPY_FLOAT, npy_float,
                                    pb, pa, length, buffer->line_stride);
             CASE_COPY_LINE_TO_DATA(NPY_DOUBLE, npy_double,
+                                   pb, pa, length, buffer->line_stride);
+            CASE_COPY_LINE_TO_DATA(NPY_LONGDOUBLE, npy_longdouble,
                                    pb, pa, length, buffer->line_stride);
         default:
             PyErr_Format(PyExc_RuntimeError, "array type %d not supported",

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -400,3 +400,12 @@ def test_footprint_all_zeros():
     kernel = np.zeros((3, 3), bool)
     with assert_raises(ValueError):
         sndi.maximum_filter(arr, footprint=kernel)
+
+
+def test_gaussian_filter():
+    # gh-8207
+    for dt in [np.half, np.single, np.float_, np.longfloat]:
+        data = np.ones(1, dtype=dt)
+        out = sndi.gaussian_filter(data, 1)
+        assert_equal(out.dtype, data.dtype)
+        assert_equal(out, data)


### PR DESCRIPTION
Closes #8207.

Fixes missing entries for type `NPY_HALF` in two switch statements in `ni_support.c` addressing crash from https://github.com/scipy/scipy/issues/8207.

What I am not sure about is why executing the `default:` case resulted in the crash:

```
In [1]: from scipy.ndimage.filters import gaussian_filter

In [2]: import numpy as np

In [3]: gaussian_filter(np.array([1],dtype=np.float16), 1)
Out[3]: array([1.], dtype=float16)

In [4]: gaussian_filter(np.array([1],dtype=np.float32), 1)
Out[4]: array([1.], dtype=float32)

In [5]: gaussian_filter(np.array([1],dtype=np.float64), 1)
Out[5]: array([1.])
```