### PR TITLE
MAINT: weightedtau, change search for nan

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3708,9 +3708,9 @@ def weightedtau(x, y, rank=True, weigher=None, additive=True):
         return WeightedTauResult(np.nan, np.nan)  # Return NaN if arrays are empty
 
     # If there are NaNs we apply _toint64()
-    if np.isnan(x).any():
+    if np.isnan(np.sum(x)):
         x = _toint64(x)
-    if np.isnan(y).any():
+    if np.isnan(np.sum(x)):
         y = _toint64(y)
 
     # Reduce to ranks unsupported types

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3708,10 +3708,10 @@ def weightedtau(x, y, rank=True, weigher=None, additive=True):
         return WeightedTauResult(np.nan, np.nan)  # Return NaN if arrays are empty
 
     # If there are NaNs we apply _toint64()
-    if np.isnan(np.min(x)):
-            x = _toint64(x)
-    if np.isnan(np.min(y)):
-            y = _toint64(y)
+    if np.isnan(x).any():
+        x = _toint64(x)
+    if np.isnan(y).any():
+        y = _toint64(y)
 
     # Reduce to ranks unsupported types
     if x.dtype != y.dtype:


### PR DESCRIPTION
Appveyor is currently failing due to an issue with [weightedtau](https://github.com/scipy/scipy/blob/master/scipy/stats/tests/test_stats.py#L792). There's a runtime warning from `np.min` if the array contains a NaN. However, I'm having problems reproducing the warning in a repeatable fashion. I suspect it's probably due to something changing in numpy 1.14.  I'm asking on the numpy ML what this could be.

The changes in this PR should fix the test breakage, I would even hazard to say that it's more pythonic than the original.