### PR TITLE
Improving documentation of solve_ivp and the underlying solvers

### DIFF
--- a/scipy/integrate/_ivp/bdf.py
+++ b/scipy/integrate/_ivp/bdf.py
@@ -70,72 +70,73 @@ def solve_bdf_system(fun, t_new, y_predict, c, psi, LU, solve_lu, scale, tol):
 
 
 class BDF(OdeSolver):
-    """Implicit method based on Backward Differentiation Formulas.
+    """Implicit method based on backward-differentiation formulas.
 
     This is a variable order method with the order varying automatically from
     1 to 5. The general framework of the BDF algorithm is described in [1]_.
-    This class implements a quasi-constant step size approach as explained
-    in [2]_. The error estimation strategy for the constant step BDF is derived
-    in [3]_. An accuracy enhancement using modified formulas (NDF) [2]_ is also
-    implemented.
+    This class implements a quasi-constant step size as explained in [2]_.
+    The error estimation strategy for the constant-step BDF is derived in [3]_.
+    An accuracy enhancement using modified formulas (NDF) [2]_ is also implemented.
 
-    Can be applied in a complex domain.
+    Can be applied in the complex domain.
 
     Parameters
     ----------
     fun : callable
         Right-hand side of the system. The calling signature is ``fun(t, y)``.
-        Here ``t`` is a scalar and there are two options for ndarray ``y``.
-        It can either have shape (n,), then ``fun`` must return array_like with
-        shape (n,). Or alternatively it can have shape (n, k), then ``fun``
-        must return array_like with shape (n, k), i.e. each column
+        Here ``t`` is a scalar, and there are two options for the ndarray ``y``:
+        It can either have shape (n,); then ``fun`` must return array_like with
+        shape (n,). Alternatively it can have shape (n, k); then ``fun``
+        must return an array_like with shape (n, k), i.e. each column
         corresponds to a single column in ``y``. The choice between the two
         options is determined by `vectorized` argument (see below). The
-        vectorized implementation allows faster approximation of the Jacobian
-        by finite differences.
+        vectorized implementation allows a faster approximation of the Jacobian
+        by finite differences (required for this solver).
     t0 : float
         Initial time.
     y0 : array_like, shape (n,)
         Initial state.
     t_bound : float
-        Boundary time --- the integration won't continue beyond it. It also
+        Boundary time – the integration won't continue beyond it. It also
         determines the direction of the integration.
     max_step : float, optional
-        Maximum allowed step size. Default is np.inf, i.e. the step is not
+        Maximum allowed step size. Default is np.inf, i.e. the step size is not
         bounded and determined solely by the solver.
     rtol, atol : float and array_like, optional
         Relative and absolute tolerances. The solver keeps the local error
         estimates less than ``atol + rtol * abs(y)``. Here `rtol` controls a
         relative accuracy (number of correct digits). But if a component of `y`
-        is approximately below `atol` then the error only needs to fall within
+        is approximately below `atol`, the error only needs to fall within
         the same `atol` threshold, and the number of correct digits is not
         guaranteed. If components of y have different scales, it might be
         beneficial to set different `atol` values for different components by
         passing array_like with shape (n,) for `atol`. Default values are
         1e-3 for `rtol` and 1e-6 for `atol`.
     jac : {None, array_like, sparse_matrix, callable}, optional
-        Jacobian matrix of the right-hand side of the system with respect to
-        y, required only by 'Radau' and 'BDF' methods. The Jacobian matrix
-        has shape (n, n) and its element (i, j) is equal to ``d f_i / d y_j``.
-        There are 3 ways to define the Jacobian:
+        Jacobian matrix of the right-hand side of the system with respect to y,
+        required by this method. The Jacobian matrix has shape (n, n) and its
+        element (i, j) is equal to ``d f_i / d y_j``.
+        There are three ways to define the Jacobian:
 
-            * If array_like or sparse_matrix, then the Jacobian is assumed to
+            * If array_like or sparse_matrix, the Jacobian is assumed to
               be constant.
-            * If callable, then the Jacobian is assumed to depend on both
-              t and y, and will be called as ``jac(t, y)`` as necessary. The
-              return value might be a sparse matrix.
-            * If None (default), then the Jacobian will be approximated by
+            * If callable, the Jacobian is assumed to depend on both
+              t and y; it will be called as ``jac(t, y)`` as necessary.
+              For the 'Radau' and 'BDF' methods, the return value might be a
+              sparse matrix.
+            * If None (default), the Jacobian will be approximated by
               finite differences.
 
         It is generally recommended to provide the Jacobian rather than
-        relying on a finite difference approximation.
+        relying on a finite-difference approximation.
     jac_sparsity : {None, array_like, sparse matrix}, optional
-        Defines a sparsity structure of the Jacobian matrix for a finite
-        difference approximation, its shape must be (n, n). If the Jacobian has
-        only few non-zero elements in *each* row, providing the sparsity
-        structure will greatly speed up the computations [4]_. A zero
-        entry means that a corresponding element in the Jacobian is identically
-        zero. If None (default), the Jacobian is assumed to be dense.
+        Defines a sparsity structure of the Jacobian matrix for a
+        finite-difference approximation. Its shape must be (n, n). This argument
+        is ignored if `jac` is not `None`. If the Jacobian has only few non-zero
+        elements in *each* row, providing the sparsity structure will greatly
+        speed up the computations [10]_. A zero entry means that a corresponding
+        element in the Jacobian is always zero. If None (default), the Jacobian
+        is assumed to be dense.
     vectorized : bool, optional
         Whether `fun` is implemented in a vectorized fashion. Default is False.
 
@@ -158,9 +159,9 @@ class BDF(OdeSolver):
     step_size : float
         Size of the last successful step. None if no steps were made yet.
     nfev : int
-        Number of the system's rhs evaluations.
+        Number of evaluations of the right-hand side.
     njev : int
-        Number of the Jacobian evaluations.
+        Number of evaluations of the Jacobian.
     nlu : int
         Number of LU decompositions.
 

--- a/scipy/integrate/_ivp/ivp.py
+++ b/scipy/integrate/_ivp/ivp.py
@@ -17,7 +17,7 @@ METHODS = {'RK23': RK23,
            'LSODA': LSODA}
 
 
-MESSAGES = {0: "The solver successfully reached the interval end.",
+MESSAGES = {0: "The solver successfully reached the end of the integration interval.",
             1: "A termination event occurred."}
 
 
@@ -164,69 +164,69 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
         dy / dt = f(t, y)
         y(t0) = y0
 
-    Here t is a 1-dimensional independent variable (time), y(t) is an
-    n-dimensional vector-valued function (state) and an n-dimensional
+    Here t is a one-dimensional independent variable (time), y(t) is an
+    n-dimensional vector-valued function (state), and an n-dimensional
     vector-valued function f(t, y) determines the differential equations.
     The goal is to find y(t) approximately satisfying the differential
     equations, given an initial value y(t0)=y0.
 
-    Some of the solvers support integration in a complex domain, but note that
-    for stiff ODE solvers the right hand side must be complex differentiable
-    (satisfy Cauchy-Riemann equations [11]_). To solve a problem in a complex
-    domain, pass y0 with a complex data type. Another option always available
-    is to rewrite your problem for real and imaginary parts separately.
+    Some of the solvers support integration in the complex domain, but note that
+    for stiff ODE solvers, the right-hand side must be complex-differentiable
+    (satisfy Cauchy-Riemann equations [11]_). To solve a problem in the complex
+    domain, pass y0 with a complex data type. Another option is always to
+    rewrite your problem for real and imaginary parts separately.
 
     Parameters
     ----------
     fun : callable
         Right-hand side of the system. The calling signature is ``fun(t, y)``.
-        Here ``t`` is a scalar and there are two options for ndarray ``y``.
-        It can either have shape (n,), then ``fun`` must return array_like with
-        shape (n,). Or alternatively it can have shape (n, k), then ``fun``
-        must return array_like with shape (n, k), i.e. each column
+        Here ``t`` is a scalar, and there are two options for the ndarray ``y``:
+        It can either have shape (n,); then ``fun`` must return array_like with
+        shape (n,). Alternatively it can have shape (n, k); then ``fun``
+        must return an array_like with shape (n, k), i.e. each column
         corresponds to a single column in ``y``. The choice between the two
         options is determined by `vectorized` argument (see below). The
-        vectorized implementation allows faster approximation of the Jacobian
+        vectorized implementation allows a faster approximation of the Jacobian
         by finite differences (required for stiff solvers).
     t_span : 2-tuple of floats
         Interval of integration (t0, tf). The solver starts with t=t0 and
         integrates until it reaches t=tf.
     y0 : array_like, shape (n,)
-        Initial state. For problems in a complex domain pass `y0` with a
+        Initial state. For problems in the complex domain, pass `y0` with a
         complex data type (even if the initial guess is purely real).
     method : string or `OdeSolver`, optional
         Integration method to use:
 
             * 'RK45' (default): Explicit Runge-Kutta method of order 5(4) [1]_.
-              The error is controlled assuming 4th order accuracy, but steps
-              are taken using a 5th order accurate formula (local extrapolation
-              is done). A quartic interpolation polynomial is used for the
-              dense output [2]_. Can be applied in a complex domain.
+              The error is controlled assuming accuracy of the fourth-order
+              method, but steps are taken using the fifth-order accurate formula
+              (local extrapolation is done). A quartic interpolation polynomial
+              is used for the dense output [2]_. Can be applied in the complex domain.
             * 'RK23': Explicit Runge-Kutta method of order 3(2) [3]_. The error
-              is controlled assuming 2nd order accuracy, but steps are taken
-              using a 3rd order accurate formula (local extrapolation is done).
-              A cubic Hermit polynomial is used for the dense output.
-              Can be applied in a complex domain.
-            * 'Radau': Implicit Runge-Kutta method of Radau IIA family of
-              order 5 [4]_. The error is controlled for a 3rd order accurate
+              is controlled assuming accuracy of the second-order method, but
+              steps are taken using the third-order accurate formula (local
+              extrapolation is done). A cubic Hermite polynomial is used for the
+              dense output. Can be applied in the complex domain.
+            * 'Radau': Implicit Runge-Kutta method of the Radau IIA family of
+              order 5 [4]_. The error is controlled with a third-order accurate
               embedded formula. A cubic polynomial which satisfies the
               collocation conditions is used for the dense output.
-            * 'BDF': Implicit multi-step variable order (1 to 5) method based
-              on a Backward Differentiation Formulas for the derivative
-              approximation [5]_. An implementation approach follows the one
-              described in [6]_. A quasi-constant step scheme is used
-              and accuracy enhancement using NDF modification is also
-              implemented. Can be applied in a complex domain.
+            * 'BDF': Implicit multi-step variable-order (1 to 5) method based
+              on a backward differentiation formula for the derivative
+              approximation [5]_. The implementation follows the one described
+              in [6]_. A quasi-constant step scheme is used and accuracy is
+              enhanced using the NDF modification. Can be applied in the complex
+              domain.
             * 'LSODA': Adams/BDF method with automatic stiffness detection and
               switching [7]_, [8]_. This is a wrapper of the Fortran solver
               from ODEPACK.
 
-        You should use 'RK45' or 'RK23' methods for non-stiff problems and
+        You should use the 'RK45' or 'RK23' method for non-stiff problems and
         'Radau' or 'BDF' for stiff problems [9]_. If not sure, first try to run
-        'RK45' and if it does unusual many iterations or diverges then your
+        'RK45'. If needs unusually many iterations, diverges, or fails, your
         problem is likely to be stiff and you should use 'Radau' or 'BDF'.
         'LSODA' can also be a good universal choice, but it might be somewhat
-        less  convenient to work with as it wraps an old Fortran code.
+        less convenient to work with as it wraps old Fortran code.
 
         You can also pass an arbitrary class derived from `OdeSolver` which
         implements the solver.
@@ -234,37 +234,37 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
         Whether to compute a continuous solution. Default is False.
     t_eval : array_like or None, optional
         Times at which to store the computed solution, must be sorted and lie
-        within `t_span`. If None (default), use points selected by a solver.
+        within `t_span`. If None (default), use points selected by the solver.
     events : callable, list of callables or None, optional
-        Events to track. Events are defined by functions which take
-        a zero value at a point of an event. Each function must have a
-        signature ``event(t, y)`` and return float, the solver will find an
-        accurate value of ``t`` at which ``event(t, y(t)) = 0`` using a root
-        finding algorithm. Additionally each ``event`` function might have
-        attributes:
+        Types of events to track. Each is defined by a continuous function of
+        time and state that becomes zero value in case of an event. Each function
+        must have the signature ``event(t, y)`` and return a float. The solver will
+        find an accurate value of ``t`` at which ``event(t, y(t)) = 0`` using a
+        root-finding algorithm. Additionally each ``event`` function might have
+        the following attributes:
 
             * terminal: bool, whether to terminate integration if this
               event occurs. Implicitly False if not assigned.
-            * direction: float, direction of crossing a zero. If `direction`
-              is positive then `event` must go from negative to positive, and
-              vice-versa if `direction` is negative. If 0, then either way will
-              count. Implicitly 0 if not assigned.
+            * direction: float, direction of a zero crossing. If `direction`
+              is positive, `event` must go from negative to positive, and
+              vice versa if `direction` is negative. If 0, then either direction
+              will count. Implicitly 0 if not assigned.
 
         You can assign attributes like ``event.terminal = True`` to any
         function in Python. If None (default), events won't be tracked.
     vectorized : bool, optional
         Whether `fun` is implemented in a vectorized fashion. Default is False.
     options
-        Options passed to a chosen solver constructor. All options available
-        for already implemented solvers are listed below.
+        Options passed to a chosen solver. All options available for already
+        implemented solvers are listed below.
     max_step : float, optional
-        Maximum allowed step size. Default is np.inf, i.e. step is not
+        Maximum allowed step size. Default is np.inf, i.e. the step size is not
         bounded and determined solely by the solver.
     rtol, atol : float and array_like, optional
         Relative and absolute tolerances. The solver keeps the local error
         estimates less than ``atol + rtol * abs(y)``. Here `rtol` controls a
         relative accuracy (number of correct digits). But if a component of `y`
-        is approximately below `atol` then the error only needs to fall within
+        is approximately below `atol`, the error only needs to fall within
         the same `atol` threshold, and the number of correct digits is not
         guaranteed. If components of y have different scales, it might be
         beneficial to set different `atol` values for different components by
@@ -272,34 +272,34 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
         1e-3 for `rtol` and 1e-6 for `atol`.
     jac : {None, array_like, sparse_matrix, callable}, optional
         Jacobian matrix of the right-hand side of the system with respect to
-        y, required by 'Radau', 'BDF' and 'LSODA' methods. The Jacobian matrix
+        y, required by the 'Radau', 'BDF' and 'LSODA' method. The Jacobian matrix
         has shape (n, n) and its element (i, j) is equal to ``d f_i / d y_j``.
-        There are 3 ways to define the Jacobian:
+        There are three ways to define the Jacobian:
 
-            * If array_like or sparse_matrix, then the Jacobian is assumed to
+            * If array_like or sparse_matrix, the Jacobian is assumed to
               be constant. Not supported by 'LSODA'.
-            * If callable, then the Jacobian is assumed to depend on both
-              t and y, and will be called as ``jac(t, y)`` as necessary.
-              For 'Radau' and 'BDF' methods the return value might be a sparse
-              matrix.
-            * If None (default), then the Jacobian will be approximated by
+            * If callable, the Jacobian is assumed to depend on both
+              t and y; it will be called as ``jac(t, y)`` as necessary.
+              For the 'Radau' and 'BDF' methods, the return value might be a
+              sparse matrix.
+            * If None (default), the Jacobian will be approximated by
               finite differences.
 
         It is generally recommended to provide the Jacobian rather than
-        relying on a finite difference approximation.
+        relying on a finite-difference approximation.
     jac_sparsity : {None, array_like, sparse matrix}, optional
-        Defines a sparsity structure of the Jacobian matrix for a finite
-        difference approximation, its shape must be (n, n). If the Jacobian has
-        only few non-zero elements in *each* row, providing the sparsity
-        structure will greatly speed up the computations [10]_. A zero
-        entry means that a corresponding element in the Jacobian is identically
-        zero. If None (default), the Jacobian is assumed to be dense.
+        Defines a sparsity structure of the Jacobian matrix for a
+        finite-difference approximation. Its shape must be (n, n). This argument
+        is ignored if `jac` is not `None`. If the Jacobian has only few non-zero
+        elements in *each* row, providing the sparsity structure will greatly
+        speed up the computations [10]_. A zero entry means that a corresponding
+        element in the Jacobian is always zero. If None (default), the Jacobian
+        is assumed to be dense.
         Not supported by 'LSODA', see `lband` and `uband` instead.
     lband, uband : int or None
-        Parameters defining the Jacobian matrix bandwidth for 'LSODA' method.
-        The Jacobian bandwidth means that
-        ``jac[i, j] != 0 only for i - lband <= j <= i + uband``. Setting these
-        requires your jac routine to return the Jacobian in the packed format:
+        Parameters defining the bandwidth of the Jacobian for the 'LSODA' method,
+        i.e., ``jac[i, j] != 0 only for i - lband <= j <= i + uband``. Setting
+        these requires your jac routine to return the Jacobian in the packed format:
         the returned array must have ``n`` columns and ``uband + lband + 1``
         rows in which Jacobian diagonals are written. Specifically
         ``jac_packed[uband + i - j , j] = jac[i, j]``. The same format is used
@@ -317,29 +317,28 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
     t : ndarray, shape (n_points,)
         Time points.
     y : ndarray, shape (n, n_points)
-        Solution values at `t`.
+        Values of the solution at `t`.
     sol : `OdeSolution` or None
-        Found solution as `OdeSolution` instance, None if `dense_output` was
+        Found solution as `OdeSolution` instance; None if `dense_output` was
         set to False.
     t_events : list of ndarray or None
-        Contains arrays with times at each a corresponding event was detected,
-        the length of the list equals to the number of events. None if `events`
-        was None.
+        Contains for each event type a list of arrays at which an event of
+        that type event was detected. None if `events` was None.
     nfev : int
-        Number of the system rhs evaluations.
+        Number of evaluations of the right-hand side.
     njev : int
-        Number of the Jacobian evaluations.
+        Number of evaluations of the Jacobian.
     nlu : int
         Number of LU decompositions.
     status : int
         Reason for algorithm termination:
 
             * -1: Integration step failed.
-            * 0: The solver successfully reached the interval end.
-            * 1: A termination event occurred.
+            *  0: The solver successfully reached the end of `tspan`.
+            *  1: A termination event occurred.
 
     message : string
-        Verbal description of the termination reason.
+        Human-readable description of the termination reason.
     success : bool
         True if the solver reached the interval end or a termination event
         occurred (``status >= 0``).

--- a/scipy/integrate/_ivp/lsoda.py
+++ b/scipy/integrate/_ivp/lsoda.py
@@ -15,35 +15,35 @@ class LSODA(OdeSolver):
     ----------
     fun : callable
         Right-hand side of the system. The calling signature is ``fun(t, y)``.
-        Here ``t`` is a scalar and there are two options for ndarray ``y``.
-        It can either have shape (n,), then ``fun`` must return array_like with
-        shape (n,). Or alternatively it can have shape (n, k), then ``fun``
-        must return array_like with shape (n, k), i.e. each column
+        Here ``t`` is a scalar, and there are two options for the ndarray ``y``:
+        It can either have shape (n,); then ``fun`` must return array_like with
+        shape (n,). Alternatively it can have shape (n, k); then ``fun``
+        must return an array_like with shape (n, k), i.e. each column
         corresponds to a single column in ``y``. The choice between the two
         options is determined by `vectorized` argument (see below). The
-        vectorized implementation allows faster approximation of the Jacobian
-        by finite differences.
+        vectorized implementation allows a faster approximation of the Jacobian
+        by finite differences (required for this solver).
     t0 : float
         Initial time.
     y0 : array_like, shape (n,)
         Initial state.
     t_bound : float
-        Boundary time --- the integration won't continue beyond it. It also
+        Boundary time – the integration won't continue beyond it. It also
         determines the direction of the integration.
     first_step : float or None, optional
         Initial step size. Default is ``None`` which means that the algorithm
         should choose.
     min_step : float, optional
-        Minimum allowed step size. Default is 0.0, i.e. the step is not
+        Minimum allowed step size. Default is 0.0, i.e. the step size is not
         bounded and determined solely by the solver.
     max_step : float, optional
-        Maximum allowed step size. Default is ``np.inf``, i.e. the step is not
+        Maximum allowed step size. Default is np.inf, i.e. the step size is not
         bounded and determined solely by the solver.
     rtol, atol : float and array_like, optional
         Relative and absolute tolerances. The solver keeps the local error
         estimates less than ``atol + rtol * abs(y)``. Here `rtol` controls a
         relative accuracy (number of correct digits). But if a component of `y`
-        is approximately below `atol` then the error only needs to fall within
+        is approximately below `atol`, the error only needs to fall within
         the same `atol` threshold, and the number of correct digits is not
         guaranteed. If components of y have different scales, it might be
         beneficial to set different `atol` values for different components by
@@ -53,14 +53,14 @@ class LSODA(OdeSolver):
         Jacobian matrix of the right-hand side of the system with respect to
         ``y``. The Jacobian matrix has shape (n, n) and its element (i, j) is
         equal to ``d f_i / d y_j``. The function will be called as
-        ``jac(t, y)``. If None (default), then the Jacobian will be
+        ``jac(t, y)``. If None (default), the Jacobian will be
         approximated by finite differences. It is generally recommended to
-        provide the Jacobian rather than relying on a finite difference
+        provide the Jacobian rather than relying on a finite-difference
         approximation.
-    lband, uband : int or None, optional
-        Jacobian band width:
-        ``jac[i, j] != 0 only for i - lband <= j <= i + uband``. Setting these
-        requires your jac routine to return the Jacobian in the packed format:
+    lband, uband : int or None
+        Parameters defining the bandwidth of the Jacobian,
+        i.e., ``jac[i, j] != 0 only for i - lband <= j <= i + uband``. Setting
+        these requires your jac routine to return the Jacobian in the packed format:
         the returned array must have ``n`` columns and ``uband + lband + 1``
         rows in which Jacobian diagonals are written. Specifically
         ``jac_packed[uband + i - j , j] = jac[i, j]``. The same format is used
@@ -88,9 +88,9 @@ class LSODA(OdeSolver):
     t_old : float
         Previous time. None if no steps were made yet.
     nfev : int
-        Number of the system's rhs evaluations.
+        Number of evaluations of the right-hand side.
     njev : int
-        Number of the Jacobian evaluations.
+        Number of evaluations of the Jacobian.
 
     References
     ----------

--- a/scipy/integrate/_ivp/radau.py
+++ b/scipy/integrate/_ivp/radau.py
@@ -180,37 +180,37 @@ def predict_factor(h_abs, h_abs_old, error_norm, error_norm_old):
 class Radau(OdeSolver):
     """Implicit Runge-Kutta method of Radau IIA family of order 5.
 
-    Implementation follows [1]_. The error is controlled for a 3rd order
-    accurate embedded formula. A cubic polynomial which satisfies the
-    collocation conditions is used for the dense output.
+    The implementation follows [1]_. The error is controlled with a
+    third-order accurate embedded formula. A cubic polynomial which satisfies
+    the collocation conditions is used for the dense output.
 
     Parameters
     ----------
     fun : callable
         Right-hand side of the system. The calling signature is ``fun(t, y)``.
-        Here ``t`` is a scalar and there are two options for ndarray ``y``.
-        It can either have shape (n,), then ``fun`` must return array_like with
-        shape (n,). Or alternatively it can have shape (n, k), then ``fun``
-        must return array_like with shape (n, k), i.e. each column
+        Here ``t`` is a scalar, and there are two options for the ndarray ``y``:
+        It can either have shape (n,); then ``fun`` must return array_like with
+        shape (n,). Alternatively it can have shape (n, k); then ``fun``
+        must return an array_like with shape (n, k), i.e. each column
         corresponds to a single column in ``y``. The choice between the two
         options is determined by `vectorized` argument (see below). The
-        vectorized implementation allows faster approximation of the Jacobian
-        by finite differences.
+        vectorized implementation allows a faster approximation of the Jacobian
+        by finite differences (required for this solver).
     t0 : float
         Initial time.
     y0 : array_like, shape (n,)
         Initial state.
     t_bound : float
-        Boundary time --- the integration won't continue beyond it. It also
+        Boundary time – the integration won't continue beyond it. It also
         determines the direction of the integration.
     max_step : float, optional
-        Maximum allowed step size. Default is np.inf, i.e. the step is not
+        Maximum allowed step size. Default is np.inf, i.e. the step size is not
         bounded and determined solely by the solver.
     rtol, atol : float and array_like, optional
         Relative and absolute tolerances. The solver keeps the local error
         estimates less than ``atol + rtol * abs(y)``. Here `rtol` controls a
         relative accuracy (number of correct digits). But if a component of `y`
-        is approximately below `atol` then the error only needs to fall within
+        is approximately below `atol`, the error only needs to fall within
         the same `atol` threshold, and the number of correct digits is not
         guaranteed. If components of y have different scales, it might be
         beneficial to set different `atol` values for different components by
@@ -218,27 +218,29 @@ class Radau(OdeSolver):
         1e-3 for `rtol` and 1e-6 for `atol`.
     jac : {None, array_like, sparse_matrix, callable}, optional
         Jacobian matrix of the right-hand side of the system with respect to
-        y, required only by 'Radau' and 'BDF' methods. The Jacobian matrix
-        has shape (n, n) and its element (i, j) is equal to ``d f_i / d y_j``.
-        There are 3 ways to define the Jacobian:
+        y, required by this method. The Jacobian matrix has shape (n, n) and
+        its element (i, j) is equal to ``d f_i / d y_j``.
+        There are three ways to define the Jacobian:
 
-            * If array_like or sparse_matrix, then the Jacobian is assumed to
+            * If array_like or sparse_matrix, the Jacobian is assumed to
               be constant.
-            * If callable, then the Jacobian is assumed to depend on both
-              t and y, and will be called as ``jac(t, y)`` as necessary. The
-              return value might be a sparse matrix.
-            * If None (default), then the Jacobian will be approximated by
+            * If callable, the Jacobian is assumed to depend on both
+              t and y; it will be called as ``jac(t, y)`` as necessary.
+              For the 'Radau' and 'BDF' methods, the return value might be a
+              sparse matrix.
+            * If None (default), the Jacobian will be approximated by
               finite differences.
 
         It is generally recommended to provide the Jacobian rather than
-        relying on a finite difference approximation.
+        relying on a finite-difference approximation.
     jac_sparsity : {None, array_like, sparse matrix}, optional
-        Defines a sparsity structure of the Jacobian matrix for a finite
-        difference approximation, its shape must be (n, n). If the Jacobian has
-        only few non-zero elements in *each* row, providing the sparsity
-        structure will greatly speed up the computations [2]_. A zero
-        entry means that a corresponding element in the Jacobian is identically
-        zero. If None (default), the Jacobian is assumed to be dense.
+        Defines a sparsity structure of the Jacobian matrix for a
+        finite-difference approximation. Its shape must be (n, n). This argument
+        is ignored if `jac` is not `None`. If the Jacobian has only few non-zero
+        elements in *each* row, providing the sparsity structure will greatly
+        speed up the computations [10]_. A zero entry means that a corresponding
+        element in the Jacobian is always zero. If None (default), the Jacobian
+        is assumed to be dense.
     vectorized : bool, optional
         Whether `fun` is implemented in a vectorized fashion. Default is False.
 
@@ -261,9 +263,9 @@ class Radau(OdeSolver):
     step_size : float
         Size of the last successful step. None if no steps were made yet.
     nfev : int
-        Number of the system's rhs evaluations.
+        Number of evaluations of the right-hand side.
     njev : int
-        Number of the Jacobian evaluations.
+        Number of evaluations of the Jacobian.
     nlu : int
         Number of LU decompositions.
 

--- a/scipy/integrate/_ivp/rk.py
+++ b/scipy/integrate/_ivp/rk.py
@@ -169,12 +169,12 @@ class RungeKutta(OdeSolver):
 class RK23(RungeKutta):
     """Explicit Runge-Kutta method of order 3(2).
 
-    The Bogacki-Shamping pair of formulas is used [1]_. The error is controlled
-    assuming 2nd order accuracy, but steps are taken using a 3rd order accurate
-    formula (local extrapolation is done). A cubic Hermit polynomial is used
-    for the dense output.
+    This uses the Bogacki–Shampine pair of formulas [1]_. The error is controlled
+    assuming accuracy of the second-order method, but steps are taken using the
+    third-order accurate formula (local extrapolation is done). A cubic Hermite
+    polynomial is used for the dense output.
 
-    Can be applied in a complex domain.
+    Can be applied in the complex domain.
 
     Parameters
     ----------
@@ -185,24 +185,22 @@ class RK23(RungeKutta):
         shape (n,). Or alternatively it can have shape (n, k), then ``fun``
         must return array_like with shape (n, k), i.e. each column
         corresponds to a single column in ``y``. The choice between the two
-        options is determined by `vectorized` argument (see below). The
-        vectorized implementation allows faster approximation of the Jacobian
-        by finite differences.
+        options is determined by `vectorized` argument (see below).
     t0 : float
         Initial time.
     y0 : array_like, shape (n,)
         Initial state.
     t_bound : float
-        Boundary time --- the integration won't continue beyond it. It also
+        Boundary time – the integration won't continue beyond it. It also
         determines the direction of the integration.
     max_step : float, optional
-        Maximum allowed step size. Default is np.inf, i.e. the step is not
+        Maximum allowed step size. Default is np.inf, i.e. the step size is not
         bounded and determined solely by the solver.
     rtol, atol : float and array_like, optional
         Relative and absolute tolerances. The solver keeps the local error
         estimates less than ``atol + rtol * abs(y)``. Here `rtol` controls a
         relative accuracy (number of correct digits). But if a component of `y`
-        is approximately below `atol` then the error only needs to fall within
+        is approximately below `atol`, the error only needs to fall within
         the same `atol` threshold, and the number of correct digits is not
         guaranteed. If components of y have different scales, it might be
         beneficial to set different `atol` values for different components by
@@ -230,11 +228,11 @@ class RK23(RungeKutta):
     step_size : float
         Size of the last successful step. None if no steps were made yet.
     nfev : int
-        Number of the system's rhs evaluations.
+        Number evaluations of the system's right-hand side.
     njev : int
-        Number of the Jacobian evaluations.
+        Number of evaluations of the Jacobian. Is always 0 for this solver as it does not use the Jacobian.
     nlu : int
-        Number of LU decompositions.
+        Number of LU decompositions. Is always 0 for this solver.
 
     References
     ----------
@@ -257,40 +255,38 @@ class RK23(RungeKutta):
 class RK45(RungeKutta):
     """Explicit Runge-Kutta method of order 5(4).
 
-    The Dormand-Prince pair of formulas is used [1]_. The error is controlled
-    assuming 4th order accuracy, but steps are taken using a 5th
-    order accurate formula (local extrapolation is done). A quartic
-    interpolation polynomial is used for the dense output [2]_.
+    This uses the Dormand-Prince pair of formulas [1]_. The error is controlled
+    assuming accuracy of the fourth-order method accuracy, but steps are taken
+    using the fifth-order accurate formula (local extrapolation is done).
+    A quartic interpolation polynomial is used for the dense output [2]_.
 
-    Can be applied in a complex domain.
+    Can be applied in the complex domain.
 
     Parameters
     ----------
     fun : callable
         Right-hand side of the system. The calling signature is ``fun(t, y)``.
-        Here ``t`` is a scalar and there are two options for ndarray ``y``.
-        It can either have shape (n,), then ``fun`` must return array_like with
-        shape (n,). Or alternatively it can have shape (n, k), then ``fun``
-        must return array_like with shape (n, k), i.e. each column
+        Here ``t`` is a scalar, and there are two options for the ndarray ``y``:
+        It can either have shape (n,); then ``fun`` must return array_like with
+        shape (n,). Alternatively it can have shape (n, k); then ``fun``
+        must return an array_like with shape (n, k), i.e. each column
         corresponds to a single column in ``y``. The choice between the two
-        options is determined by `vectorized` argument (see below). The
-        vectorized implementation allows faster approximation of the Jacobian
-        by finite differences.
+        options is determined by `vectorized` argument (see below).
     t0 : float
-        Initial value of the independent variable.
+        Initial time.
     y0 : array_like, shape (n,)
-        Initial values of the dependent variable.
+        Initial state.
     t_bound : float
-        Boundary time --- the integration won't continue beyond it. It also
+        Boundary time – the integration won't continue beyond it. It also
         determines the direction of the integration.
     max_step : float, optional
-        Maximum allowed step size. Default is np.inf, i.e. the step is not
+        Maximum allowed step size. Default is np.inf, i.e. the step size is not
         bounded and determined solely by the solver.
     rtol, atol : float and array_like, optional
         Relative and absolute tolerances. The solver keeps the local error
         estimates less than ``atol + rtol * abs(y)``. Here `rtol` controls a
         relative accuracy (number of correct digits). But if a component of `y`
-        is approximately below `atol` then the error only needs to fall within
+        is approximately below `atol`, the error only needs to fall within
         the same `atol` threshold, and the number of correct digits is not
         guaranteed. If components of y have different scales, it might be
         beneficial to set different `atol` values for different components by
@@ -318,11 +314,11 @@ class RK45(RungeKutta):
     step_size : float
         Size of the last successful step. None if no steps were made yet.
     nfev : int
-        Number of the system's rhs evaluations.
+        Number evaluations of the system's right-hand side.
     njev : int
-        Number of the Jacobian evaluations.
+        Number of evaluations of the Jacobian. Is always 0 for this solver as it does not use the Jacobian.
     nlu : int
-        Number of LU decompositions.
+        Number of LU decompositions. Is always 0 for this solver.
 
     References
     ----------


### PR DESCRIPTION
This includes:

* spelling,
* punctuation,
* grammar,
* style,
* expanded explanations,
* removing or adapting references to Jacobian for Runge–Kutta methods (which do not use it),
* removing references to other methods that do not apply (such as “This does not work for LSODA” in the documentation of Radau).

I do all of this in one huge commit since there are at times multiple changes per paragraph and it would be tedious to change the manual line wrapping every time (why is this still a thing?).