### PR TITLE
CI: use numpy 1.13 for refguide check build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -122,6 +122,10 @@ before_install:
   - |
     if [ "${REFGUIDE_CHECK}" == "1" ]; then
         travis_retry pip install matplotlib Sphinx==1.5.5
+        # XXX: Install older numpy as a workaround for float printing changes.
+        # XXX: We'll remove this once numpy 1.14.1 is released to fix its printing
+        # XXX: bugs
+        travis_retry pip install 'numpy!=1.14.0'
     fi
   - python -V
   - ccache -s

--- a/scipy/integrate/_ivp/bdf.py
+++ b/scipy/integrate/_ivp/bdf.py
@@ -134,7 +134,7 @@ class BDF(OdeSolver):
         finite-difference approximation. Its shape must be (n, n). This argument
         is ignored if `jac` is not `None`. If the Jacobian has only few non-zero
         elements in *each* row, providing the sparsity structure will greatly
-        speed up the computations [10]_. A zero entry means that a corresponding
+        speed up the computations [4]_. A zero entry means that a corresponding
         element in the Jacobian is always zero. If None (default), the Jacobian
         is assumed to be dense.
     vectorized : bool, optional

--- a/scipy/integrate/_ivp/radau.py
+++ b/scipy/integrate/_ivp/radau.py
@@ -238,7 +238,7 @@ class Radau(OdeSolver):
         finite-difference approximation. Its shape must be (n, n). This argument
         is ignored if `jac` is not `None`. If the Jacobian has only few non-zero
         elements in *each* row, providing the sparsity structure will greatly
-        speed up the computations [10]_. A zero entry means that a corresponding
+        speed up the computations [2]_. A zero entry means that a corresponding
         element in the Jacobian is always zero. If None (default), the Jacobian
         is assumed to be dense.
     vectorized : bool, optional


### PR DESCRIPTION
Because numpy float printing is partly broken in 1.14.0, don't use it in refguide check.

When these bugs are fixed, we can go forward with gh-8279 to update the docstrings
to numpy 1.14.x new-style float printing.

This PR should probably be merged "fast" (assuming it work), in order to get the CI back to working order.