### PR TITLE
ENH add ratio-of-uniforms method for rv generation to scipy.stats

### DIFF
--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -294,6 +294,7 @@ Statistical distances
 
    wasserstein_distance
    energy_distance
+   rvs_ratio_unif
 
 Circular statistical functions
 ==============================

--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -294,7 +294,14 @@ Statistical distances
 
    wasserstein_distance
    energy_distance
-   rvs_ratio_unif
+
+Random variate generation
+=========================
+
+.. autosummary::
+   :toctree: generated/
+
+   rvs_ratio_uniforms
 
 Circular statistical functions
 ==============================

--- a/scipy/stats/_rvs_sampling.py
+++ b/scipy/stats/_rvs_sampling.py
@@ -15,12 +15,12 @@ def rvs_ratio_uniforms(pdf, umax, vmin, vmax, size=1, c=0, random_state=None):
     pdf : callable
         A function with signature `pdf(x)` that is the probability
         density function of the distribution.
+    umax : float
+        The upper bound of the bounding rectangle in the y-direction.
     vmin : float
         The lower bound of the bounding rectangle in the x-direction.
     vmax : float
         The upper bound of the bounding rectangle in the x-direction.
-    umax : float
-        The upper bound of the bounding rectangle in the y-direction.
     size : int or tuple of ints, optional
         Defining number of random variates (default is 1).
     c : float, optional.
@@ -38,41 +38,41 @@ def rvs_ratio_uniforms(pdf, umax, vmin, vmax, size=1, c=0, random_state=None):
 
     Notes
     -----
-    Given a univariate probability density function (pdf) f and a constant c,
-    define the set ``A = {(u, v) : 0 < u <= sqrt(f(v/u + c))}``.
-    If ``(U, V)`` is a random vector uniformly distributed over ``A``,
-    then ``V/U + c`` follows a distribution with pdf ``f``.
+    Given a univariate probability density function `pdf` and a constant `c`,
+    define the set ``A = {(u, v) : 0 < u <= sqrt(pdf(v/u + c))}``.
+    If `(U, V)` is a random vector uniformly distributed over `A`,
+    then `V/U + c` follows a distribution according to `pdf`.
 
     The above result (see [1]_, [2]_) can be used to sample random variables
     using only the pdf, i.e. no inversion of the cdf is required. Typical
-    choices of c are zero or the mode of f. The set ``A`` is a subset of the
-    rectangle ``R = [0, umax] x [vmin, vmax]`` where
+    choices of `c` are zero or the mode of `pdf`. The set `A` is a subset of
+    the rectangle ``R = [0, umax] x [vmin, vmax]`` where
 
-    - ``umax = sup sqrt(f(x))``
-    - ``vmin = inf (x - c) sqrt(f(x))``
-    - ``vmax = sup (x - c) sqrt(f(x))``
+    - ``umax = sup sqrt(pdf(x))``
+    - ``vmin = inf (x - c) sqrt(pdf(x))``
+    - ``vmax = sup (x - c) sqrt(pdf(x))``
 
-    In particular, these values are finite if `f` is bounded and
-    ``x**2 * f(x)`` is bounded (i.e. subquadratic tails).
-    One can generate ``(U, V)`` uniformly on ``R`` and return
-    ``V/U + c`` if ``(U, V)`` are also in ``A`` which can be directly
+    In particular, these values are finite if `pdf` is bounded and
+    ``x**2 * pdf(x)`` is bounded (i.e. subquadratic tails).
+    One can generate `(U, V)` uniformly on `R` and return
+    `V/U + c` if `(U, V)` are also in `A` which can be directly
     verified.
 
-    Intuitively, the method works well if ``A`` fills up most of the
-    enclosing rectangle such that the probability is high that ``(U, V)``
-    lies in ``A`` whenever it lies in ``R`` as the number of required
+    Intuitively, the method works well if `A` fills up most of the
+    enclosing rectangle such that the probability is high that `(U, V)`
+    lies in `A` whenever it lies in `R` as the number of required
     iterations becomes too large otherwise. To be more precise, note that
-    the expected number of iterations to draw ``(U, V)`` uniformly
-    distributed on ``R`` such that ``(U, V)`` is also in ``A`` is given by
+    the expected number of iterations to draw `(U, V)` uniformly
+    distributed on `R` such that `(U, V)` is also in `A` is given by
     the ratio ``area(R) / area(A) = 2 * umax * (vmax - vmin)``, using the fact
-    that the area of ``A`` is equal to 1/2 (Theorem 7.1 in [1]_). A warning
+    that the area of `A` is equal to 1/2 (Theorem 7.1 in [1]_). A warning
     is displayed if this ratio is larger than 20. Moreover, if the sampling
-    fails to generate a single random variate after 50'000 iterations (i.e.
-    not a single draw is in ``A``), an exception is raised.
+    fails to generate a single random variate after 50000 iterations (i.e.
+    not a single draw is in `A`), an exception is raised.
 
     If the bounding rectangle is not correctly specified (i.e. if it does not
-    contain ``A``), the algorithm samples from a distribution different from
-    the one given by the pdf. It is therefore recommended to perform a
+    contain `A`), the algorithm samples from a distribution different from
+    the one given by `pdf`. It is therefore recommended to perform a
     test such as `stats.kstest` as a check.
 
     References
@@ -101,7 +101,7 @@ def rvs_ratio_uniforms(pdf, umax, vmin, vmax, size=1, c=0, random_state=None):
     >>> rvs = stats.rvs_ratio_uniforms(f, umax, vmin, vmax, size=2500)
 
     The K-S test confirms that the random variates are indeed normally
-    distributed (p-value does not reject normality):
+    distributed (normality is not rejected at 5% significance level):
 
     >>> stats.kstest(rvs, 'norm')[1]
     0.3420173467307603

--- a/scipy/stats/_rvs_sampling.py
+++ b/scipy/stats/_rvs_sampling.py
@@ -1,0 +1,156 @@
+from __future__ import division, print_function, absolute_import
+
+import numpy as np
+import warnings
+from scipy._lib._util import check_random_state
+
+
+def rvs_ratio_uniforms(pdf, umax, vmin, vmax, size=1, c=0, random_state=None):
+    """
+    Generate random samples from a probability density function using the
+    ratio-of-uniforms method.
+
+    Parameters
+    ----------
+    pdf : callable
+        The probability density function of the distribution.
+    vmin : float
+        The lower bound of the bounding rectangle in the x-direction.
+    vmax : float
+        The upper bound of the bounding rectangle in the x-direction.
+    umax : float
+        The upper bound of the bounding rectangle in the y-direction.
+    size : int or tuple of ints, optional
+        Defining number of random variates (default is 1).
+    c : float, optional.
+        Shift parameter of ratio-of-uniforms method, see Notes. Default is 0.
+    random_state : None or int or np.random.RandomState instance, optional
+        If already a RandomState instance, use it.
+        If seed is an int, return a new RandomState instance seeded with seed.
+        If None, use np.random.RandomState. Default is None.
+
+    Returns
+    -------
+    rvs : ndarray
+        the random variates distributed according to the probability
+        distrubtion, pdf
+
+    Notes
+    -----
+    Given a univariate probability density function (pdf) f and a constant c,
+    define the set ``A = {(u, v) : 0 < u <= sqrt(f(v/u + c))}``.
+    If ``(U, V)`` is a random vector uniformly distributed over ``A``,
+    then ``V/U + c`` follows a distribution with pdf ``f``.
+
+    The above result (see [1]_, [2]_) can be used to sample random variables
+    using only the pdf, i.e. no inversion of the cdf is required. Typical
+    choices of c are zero or the mode of f. The set ``A`` is a subset of the
+    rectangle ``R = [0, umax] x [vmin, vmax]`` where
+
+    - ``umax = sup sqrt(f(x))``
+    - ``vmin = inf (x - c) sqrt(f(x))``
+    - ``vmax = sup (x - c) sqrt(f(x))``
+
+    In particular, these values are finite if `f` is bounded and
+    ``x**2 * f(x)`` is bounded (i.e. subquadratic tails).
+    One can generate ``(U, V)`` uniformly on ``R`` and return
+    ``V/U + c`` if ``(U, V)`` are also in ``A`` which can be directly
+    verified.
+
+    Intuitively, the method works well if ``A`` fills up most of the
+    enclosing rectangle such that the probability is high that ``(U, V)``
+    lies in ``A`` whenever it lies in ``R`` as the number of required
+    iterations becomes too large otherwise. To be more precise, note that
+    the expected number of iterations to draw ``(U, V)`` uniformly
+    distributed on ``R`` such that ``(U, V)`` is also in ``A`` is given by
+    the ratio ``area(R) / area(A) = 2 * umax * (vmax - vmin)``, using the fact
+    that the area of ``A`` is equal to 1/2 (Theorem 7.1 in [1]_). A warning
+    is displayed if this ratio is larger than 20.
+
+    If the bounding rectangle is not correctly specified (i.e. if it does not
+    contain ``A``), the algorithm samples from a distribution different from
+    the one given by the pdf. It is therefore recommended to perform a
+    test such as `stats.kstest` as a check.
+
+    References
+    ----------
+    .. [1] L. Devroye, "Non-Uniform Random Variate Generation",
+       Springer-Verlag, 1986.
+
+    .. [2] W. Hoermann and J. Leydold, "Generating generalized inverse Gaussian
+       random variates", Statistics and Computing, 24(4), p. 547--557, 2014.
+
+    .. [3] A.J. Kinderman and J.F. Monahan, "Computer Generation of Random
+       Variables Using the Ratio of Uniform Deviates",
+       ACM Transactions on Mathematical Software, 3(3), p. 257--260, 1977.
+
+    Examples
+    --------
+    >>> from scipy import stats
+
+    Simulate normally distributed random variables. It is easy to compute the
+    bounding rectangle explicitly in that case.
+
+    >>> f = stats.norm.pdf
+    >>> v_bound = np.sqrt(f(np.sqrt(2))) * np.sqrt(2)
+    >>> umax, vmin, vmax = np.sqrt(f(0)), -v_bound, v_bound
+    >>> np.random.seed(12345)
+    >>> rvs = stats.rvs_ratio_uniforms(f, umax, vmin, vmax, size=2500)
+
+    The K-S test confirms that the random variates are indeed normally
+    distributed (p-value does not reject normality):
+
+    >>> stats.kstest(rvs, 'norm')[1]
+    0.3420173467307603
+
+    The exponential distribution provides another example where the bounding
+    rectangle can be determined explicitly.
+
+    >>> np.random.seed(12345)
+    >>> rvs = stats.rvs_ratio_uniforms(lambda x: np.exp(-x), umax=1,
+    ...                                vmin=0, vmax=2*np.exp(-1), size=1000)
+    >>> stats.kstest(rvs, 'expon')[1]
+    0.928454552559516
+
+    Sometimes it can be helpful to use a non-zero shift parameter `c`, see e.g.
+    [2]_ above in the case of the generalized inverse Gaussian distribution.
+
+    """
+
+    if vmin >= vmax:
+        raise ValueError("vmin must be smaller than vmax.")
+
+    if umax <= 0:
+        raise ValueError("umax must be positive.")
+
+    exp_iter = 2 * (vmax - vmin) * umax  # rejection constant (see [1])
+    if exp_iter > 20:
+        msg = "The expected number of iterations to generate a single random" \
+              " number from the desired distribution is larger than " \
+              "{}, potentially causing bad performance.".format(int(exp_iter))
+        warnings.warn(msg, RuntimeWarning)
+
+    size1d = tuple(np.atleast_1d(size))
+    N = np.prod(size1d)  # number of rvs needed, reshape upon return
+
+    # start sampling using ratio of uniforms method
+    rng = check_random_state(random_state)
+    x = np.zeros(N)
+    simulated = 0
+
+    # loop until N rvs have been generated: expected runtime is finite
+    while True:
+        k = N - simulated
+        # simulate uniform rvs on [0, umax] and [vmin, vmax]
+        u1 = umax * rng.random_sample(size=k)
+        v1 = vmin + (vmax - vmin) * rng.random_sample(size=k)
+        # apply rejection method
+        rvs = v1 / u1 + c
+        accept = (u1**2 <= pdf(rvs))
+        num_accept = np.sum(accept)
+        if num_accept > 0:
+            take = min(num_accept, N - simulated)
+            x[simulated:(simulated + take)] = rvs[accept][0:take]
+            simulated += take
+        if simulated >= N:
+            return np.reshape(x, size1d)

--- a/scipy/stats/_rvs_sampling.py
+++ b/scipy/stats/_rvs_sampling.py
@@ -16,16 +16,16 @@ def rvs_ratio_uniforms(pdf, umax, vmin, vmax, size=1, c=0, random_state=None):
         A function with signature `pdf(x)` that is the probability
         density function of the distribution.
     umax : float
-        The upper bound of the bounding rectangle in the y-direction.
+        The upper bound of the bounding rectangle in the u-direction.
     vmin : float
-        The lower bound of the bounding rectangle in the x-direction.
+        The lower bound of the bounding rectangle in the v-direction.
     vmax : float
-        The upper bound of the bounding rectangle in the x-direction.
+        The upper bound of the bounding rectangle in the v-direction.
     size : int or tuple of ints, optional
         Defining number of random variates (default is 1).
     c : float, optional.
         Shift parameter of ratio-of-uniforms method, see Notes. Default is 0.
-    random_state : None or int or np.random.RandomState instance, optional
+    random_state : int or np.random.RandomState instance, optional
         If already a RandomState instance, use it.
         If seed is an int, return a new RandomState instance seeded with seed.
         If None, use np.random.RandomState. Default is None.
@@ -128,9 +128,9 @@ def rvs_ratio_uniforms(pdf, umax, vmin, vmax, size=1, c=0, random_state=None):
 
     exp_iter = 2 * (vmax - vmin) * umax  # rejection constant (see [1])
     if exp_iter > 20:
-        msg = "The expected number of iterations to generate a single random" \
-              " number from the desired distribution is larger than " \
-              "{}, potentially causing bad performance.".format(int(exp_iter))
+        msg = ("The expected number of iterations to generate a single random "
+               "number from the desired distribution is larger than {}, "
+               "potentially causing bad performance.".format(int(exp_iter)))
         warnings.warn(msg, RuntimeWarning)
 
     size1d = tuple(np.atleast_1d(size))
@@ -161,9 +161,9 @@ def rvs_ratio_uniforms(pdf, umax, vmin, vmax, size=1, c=0, random_state=None):
         if simulated >= N:
             return np.reshape(x, size1d)
         if (simulated == 0) and (i*N >= 50000):
-            msg = "Not a single random variate could be generated in {} " \
-                  "attempts. The ratio of uniforms method does not appear " \
-                  "to work for the provided parameters. Please check the "\
-                  "pdf and the bounds.".format(i*N)
+            msg = ("Not a single random variate could be generated in {} "
+                   "attempts. The ratio of uniforms method does not appear "
+                   "to work for the provided parameters. Please check the "
+                   "pdf and the bounds.".format(i*N))
             raise RuntimeError(msg)
         i += 1

--- a/scipy/stats/_rvs_sampling.py
+++ b/scipy/stats/_rvs_sampling.py
@@ -33,7 +33,7 @@ def rvs_ratio_uniforms(pdf, umax, vmin, vmax, size=1, c=0, random_state=None):
     -------
     rvs : ndarray
         the random variates distributed according to the probability
-        distrubtion, pdf
+        distribution defined by the pdf
 
     Notes
     -----

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -167,16 +167,15 @@ import numpy as np
 from numpy import array, asarray, ma, zeros
 
 from scipy._lib.six import callable, string_types
-from scipy._lib._util import check_random_state
 from scipy._lib._version import NumpyVersion
 from scipy._lib._util import _lazywhere
 import scipy.special as special
 import scipy.linalg as linalg
-import scipy.optimize as optimize
 from . import distributions
 from . import mstats_basic
 from ._stats_mstats_common import _find_repeats, linregress, theilslopes
 from ._stats import _kendall_dis, _toint64, _weightedrankedtau
+from ._rvs_sampling import rvs_ratio_uniforms
 
 
 __all__ = ['find_repeats', 'gmean', 'hmean', 'mode', 'tmean', 'tvar',
@@ -5942,154 +5941,3 @@ def rankdata(a, method='average'):
 
     # average method
     return .5 * (count[dense] + count[dense - 1] + 1)
-
-
-def rvs_ratio_uniforms(pdf, umax, vmin, vmax, size=1, c=0, random_state=None):
-    """
-    Generate random samples from a probability density function using the
-    ratio-of-uniforms method.
-
-    Parameters
-    ----------
-    pdf : callable
-        The probability density function of the distribution.
-    vmin : float
-        The lower bound of the bounding rectangle in the x-direction.
-    vmax : float
-        The upper bound of the bounding rectangle in the x-direction.
-    umax : float
-        The upper bound of the bounding rectangle in the y-direction.
-    size : int or tuple of ints, optional
-        Defining number of random variates (default is 1).
-    c : float, optional.
-        Shift parameter of ratio-of-uniforms method, see Notes. Default is 0.
-    random_state : None or int or np.random.RandomState instance, optional
-        If already a RandomState instance, use it.
-        If seed is an int, return a new RandomState instance seeded with seed.
-        If None, use np.random.RandomState. Default is None.
-
-    Returns
-    -------
-    rvs : ndarray
-        the random variates distributed according to the probability
-        distrubtion, pdf
-
-    Notes
-    -----
-    Given a univariate probability density function (pdf) f and a constant c,
-    define the set ``A = {(u, v) : 0 < u <= sqrt(f(v/u + c))}``.
-    If ``(U, V)`` is a random vector uniformly distributed over ``A``,
-    then ``V/U + c`` follows a distribution with pdf ``f``.
-
-    The above result (see [1]_, [2]_) can be used to sample random variables
-    using only the pdf, i.e. no inversion of the cdf is required. Typical
-    choices of c are zero or the mode of f. The set ``A`` is a subset of the
-    rectangle ``R = [0, umax] x [vmin, vmax]`` where
-
-    - ``umax = sup sqrt(f(x))``
-    - ``vmin = inf (x - c) sqrt(f(x))``
-    - ``vmax = sup (x - c) sqrt(f(x))``
-
-    In particular, these values are finite if `f` is bounded and
-    ``x**2 * f(x)`` is bounded (i.e. subquadratic tails).
-    One can generate ``(U, V)`` uniformly on ``R`` and return
-    ``V/U + c`` if ``(U, V)`` are also in ``A`` which can be directly
-    verified.
-
-    Intuitively, the method works well if ``A`` fills up most of the
-    enclosing rectangle such that the probability is high that ``(U, V)``
-    lies in ``A`` whenever it lies in ``R`` as the number of required
-    iterations becomes too large otherwise. To be more precise, note that
-    the expected number of iterations to draw ``(U, V)`` uniformly
-    distributed on ``R`` such that ``(U, V)`` is also in ``A`` is given by
-    the ratio ``area(R) / area(A) = 2 * umax * (vmax - vmin)``, using the fact
-    that the area of ``A`` is equal to 1/2 (Theorem 7.1 in [1]_). A warning
-    is displayed if this ratio is larger than 20.
-
-    If the bounding rectangle is not correctly specified (i.e. if it does not
-    contain ``A``), the algorithm samples from a distribution different from
-    the one given by the pdf. It is therefore recommended to perform a
-    test such as `stats.kstest` as a check.
-
-    References
-    ----------
-    .. [1] L. Devroye, "Non-Uniform Random Variate Generation",
-       Springer-Verlag, 1986.
-
-    .. [2] W. Hoermann and J. Leydold, "Generating generalized inverse Gaussian
-       random variates", Statistics and Computing, 24(4), p. 547--557, 2014.
-
-    .. [3] A.J. Kinderman and J.F. Monahan, "Computer Generation of Random
-       Variables Using the Ratio of Uniform Deviates",
-       ACM Transactions on Mathematical Software, 3(3), p. 257--260, 1977.
-
-    Examples
-    --------
-    >>> from scipy import stats
-
-    Simulate normally distributed random variables. It is easy to compute the
-    bounding rectangle explicitly in that case.
-
-    >>> f = stats.norm.pdf
-    >>> v_bound = np.sqrt(f(np.sqrt(2))) * np.sqrt(2)
-    >>> umax, vmin, vmax = np.sqrt(f(0)), -v_bound, v_bound
-    >>> np.random.seed(12345)
-    >>> rvs = stats.rvs_ratio_uniforms(f, umax, vmin, vmax, size=1500)
-
-    The K-S test confirms that the random variates are indeed normally
-    distributed (p-value does not reject normality):
-
-    >>> stats.kstest(rvs, 'norm')[1]
-    0.5092431215510014
-
-    The exponential distribution provides another example where the bounding
-    rectangle can be determined explicitly.
-
-    >>> np.random.seed(12345)
-    >>> rvs = stats.rvs_ratio_uniforms(lambda x: np.exp(-x), umax=1,
-    ...                                vmin=0, vmax=2*np.exp(-1), size=1000)
-    >>> stats.kstest(rvs, 'expon')[1]
-    0.928454552559516
-
-    Sometimes it can be helpful to use a non-zero shift parameter `c`, see e.g.
-    [2]_ above in the case of the generalized inverse Gaussian distribution.
-
-    """
-
-    if vmin >= vmax:
-        raise ValueError("vmin must be smaller than vmax.")
-
-    if umax <= 0:
-        raise ValueError("umax must be positive.")
-
-    exp_iter = 2 * (vmax - vmin) * umax  # rejection constant (see [1])
-    if exp_iter > 20:
-        msg = "The expected number of iterations to generate a single random" \
-              " number from the desired distribution is larger than " \
-              "{}, potentially causing bad performance.".format(int(exp_iter))
-        warnings.warn(msg, RuntimeWarning)
-
-    size1d = tuple(np.atleast_1d(size))
-    N = np.prod(size1d)  # number of rvs needed, reshape upon return
-
-    # start sampling using ratio of uniforms method
-    rng = check_random_state(random_state)
-    x = np.zeros(N)
-    simulated = 0
-
-    # loop until N rvs have been generated: expected runtime is finite
-    while True:
-        k = N - simulated
-        # simulate uniform rvs on [0, umax] and [vmin, vmax]
-        u1 = umax * rng.random_sample(size=k)
-        v1 = vmin + (vmax - vmin) * rng.random_sample(size=k)
-        # apply rejection method
-        rvs = v1 / u1 + c
-        accept = (u1**2 <= pdf(rvs))
-        num_accept = np.sum(accept)
-        if num_accept > 0:
-            take = min(num_accept, N - simulated)
-            x[simulated:(simulated + take)] = rvs[accept][0:take]
-            simulated += take
-        if simulated >= N:
-            return np.reshape(x, size1d)

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -6036,7 +6036,7 @@ def rvs_ratio_unif(pdf, size=1, x1=None, x2=None, y2=None, shift=0,
     >>> x_bound = np.sqrt(f(np.sqrt(2))) * np.sqrt(2)
     >>> x1, x2, y2 = -x_bound, x_bound, np.sqrt(f(0))
     >>> np.random.seed(12345)
-    >>> rvs = rvs_ratio_unif(f, x1=x1, x2=x2, y2=y2, size=2500)
+    >>> rvs = stats.rvs_ratio_unif(f, x1=x1, x2=x2, y2=y2, size=2500)
 
     The K-S test confirms that the random variates are indeed normally
     distributed (p-value does not reject normality):
@@ -6047,15 +6047,15 @@ def rvs_ratio_unif(pdf, size=1, x1=None, x2=None, y2=None, shift=0,
     numerically over the region specified by `bounds`.
 
     >>> np.random.seed(12345)
-    >>> rvs = rvs_ratio_unif(f, size=2500, bounds=(-100, 100))
+    >>> rvs = stats.rvs_ratio_unif(f, size=2500, bounds=(-100, 100))
     >>> stats.kstest(rvs, 'norm')[1]
     0.3732986992033126
 
     The exponential distribution provides another example where the bounding
     rectangle can be determined explicitly.
     >>> np.random.seed(12345)
-    >>> rvs = rvs_ratio_unif(lambda x: np.exp(-x), x1=0, x2=2*np.exp(-1), y2=1,
-    >>> ...                  size=1000)
+    >>> rvs = stats.rvs_ratio_unif(lambda x: np.exp(-x), x1=0, x2=2*np.exp(-1),
+    >>> ...                        y2=1, size=1000)
     >>> stats.kstest(rvs, 'expon')[1]
     0.52369231518316373
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -6032,7 +6032,7 @@ def rvs_ratio_uniforms(pdf, umax, vmin, vmax, size=1, c=0, random_state=None):
 
     >>> f = stats.norm.pdf
     >>> v_bound = np.sqrt(f(np.sqrt(2))) * np.sqrt(2)
-    >>> umax, vmin, vmax =  np.sqrt(f(0)), -v_bound, v_bound
+    >>> umax, vmin, vmax = np.sqrt(f(0)), -v_bound, v_bound
     >>> np.random.seed(12345)
     >>> rvs = stats.rvs_ratio_uniforms(f, umax, vmin, vmax, size=2500)
 
@@ -6046,7 +6046,7 @@ def rvs_ratio_uniforms(pdf, umax, vmin, vmax, size=1, c=0, random_state=None):
     rectangle can be determined explicitly.
 
     >>> np.random.seed(12345)
-    >>> rvs = stats.rvs_ratio_uniforms(lambda x: np.exp(-x), umax=1, 
+    >>> rvs = stats.rvs_ratio_uniforms(lambda x: np.exp(-x), umax=1,
     ...                                vmin=0, vmax=2*np.exp(-1), size=1000)
     >>> stats.kstest(rvs, 'expon')[1]
     0.52369231518316373
@@ -6054,7 +6054,7 @@ def rvs_ratio_uniforms(pdf, umax, vmin, vmax, size=1, c=0, random_state=None):
     Sometimes it can be helpful to use a non-zero shift parameter `c`, see e.g.
     [2]_ above in the case of the generalized inverse Gaussian distribution.
 
-    """    
+    """
 
     if vmin >= vmax:
         raise ValueError("vmin must be smaller than vmax.")
@@ -6082,7 +6082,7 @@ def rvs_ratio_uniforms(pdf, umax, vmin, vmax, size=1, c=0, random_state=None):
         k = N - simulated
         # simulate uniform rvs on [0, umax] and [vmin, vmax]
         u1 = umax * rng.random_sample(size=k)
-        v1 = vmin + (vmax - vmin) * rng.random_sample(size=k)        
+        v1 = vmin + (vmax - vmin) * rng.random_sample(size=k)
         # apply rejection method
         rvs = v1 / u1 + c
         accept = (u1**2 <= pdf(rvs))

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1,4 +1,4 @@
-# Copyright 2002 Gary Strangman.  All rights reserved
+﻿# Copyright 2002 Gary Strangman.  All rights reserved
 # Copyright 2002-2016 The SciPy Developers
 #
 # The original code from Gary Strangman was heavily adapted for
@@ -6012,7 +6012,7 @@ def ratio_unif(f, size=1, x1=None, x2=None, y2=None, shift=0, maxiter=None,
     ----------
     .. [1] L. Devroye, "Non-Uniform Random Variate Generation",
     Springer-Verlag, 1986.
-    .. [2] W. Hörman and J. Leydold, "Generating generalized inverse Gaussian
+    .. [2] W. Hoermann and J. Leydold, "Generating generalized inverse Gaussian
     random variates", Statistics and Computing, Vol 24(4), p. 547--557, 2014.
 
     Examples

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5960,13 +5960,17 @@ def ratio_unif(f, size=1, x1=None, x2=None, y2=None, shift=0, maxiter=None,
     - x2 = sup (x - c) sqrt(f(x))
     - y2 = sup sqrt(f(x))
 
-    In particular, these values are finite if f is bounded and x**2 f(x) is
+    In particular, these values are finite if f is bounded and x**2 * f(x) is
     bounded (i.e. subquadratic tails). One can generate (U, V) uniformly on
     R and return U/V + c if (U, V) are also in A(c) which can be directly
     verified. Intuitively, this works well if A(c) fills up most of the
     enclosing rectangle such that the probability is high that (U, V) lies in
     A(c) whenever it lies in R(c) as the number of required iterations
-    becomes too large otherwise.
+    becomes too large otherwise. To be more precise, note that the expected
+    number of iterations to draw (U, V) uniformly distributed on R(c) such that
+    (U, V) is also in A(c) is given by the ratio
+    area(R(c)) / area(A(c)) = 2 * y2 * (x2 - x1), using the fact that
+    the area of A(c) is equal to 1/2 (Theorem 7.1 in [1]_).
 
     Parameters
     ----------
@@ -5988,8 +5992,8 @@ def ratio_unif(f, size=1, x1=None, x2=None, y2=None, shift=0, maxiter=None,
         Default is None. In that case, maxiter is set to a value that
         ensures successful simulation with a high probability.
     bounds : tuple of floats (a, b), optional
-        Default is none. In case any of the boundaries of the bounding
-        rectangle is not specified, attempt to find missing boundary
+        Default is None. In case any of the boundaries of the bounding
+        rectangle are not specified, attempt to find missing boundary
         numerically over the range specified by bounds.
 
     Returns
@@ -6063,7 +6067,8 @@ def ratio_unif(f, size=1, x1=None, x2=None, y2=None, shift=0, maxiter=None,
         return opt_res.fun
 
     # in case bounding rectangle is not given, attempt to find it numerically
-    def f_opt(x): return (x - shift) * np.sqrt(f(x))
+    def f_opt(x):
+        return (x - shift) * np.sqrt(f(x))
 
     if x1 is None:
         x1 = find_rect_bounds(f_opt, bounds=bounds)
@@ -6101,7 +6106,7 @@ def ratio_unif(f, size=1, x1=None, x2=None, y2=None, shift=0, maxiter=None,
             x[simulated:(simulated + take)] = rvs[accept][0:take]
             simulated += take
         if simulated < size:
-            j = j + 1
+            j += 1
         else:
             return x
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -6022,9 +6022,10 @@ def rvs_ratio_unif(pdf, size=1, x1=None, x2=None, y2=None, shift=0,
     References
     ----------
     .. [1] L. Devroye, "Non-Uniform Random Variate Generation",
-    Springer-Verlag, 1986.
+       Springer-Verlag, 1986.
+
     .. [2] W. Hoermann and J. Leydold, "Generating generalized inverse Gaussian
-    random variates", Statistics and Computing, Vol 24(4), p. 547--557, 2014.
+       random variates", Statistics and Computing, 24(4), p. 547--557, 2014.
 
     Examples
     --------

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -6007,7 +6007,7 @@ def rvs_ratio_uniforms(pdf, umax, vmin, vmax, size=1, c=0, random_state=None):
     is displayed if this ratio is larger than 20.
 
     If the bounding rectangle is not correctly specified (i.e. if it does not
-    contain ``A``, the algorithm samples from a distribution different from
+    contain ``A``), the algorithm samples from a distribution different from
     the one given by the pdf. It is therefore recommended to perform a
     test such as `stats.kstest` as a check.
 
@@ -6034,13 +6034,13 @@ def rvs_ratio_uniforms(pdf, umax, vmin, vmax, size=1, c=0, random_state=None):
     >>> v_bound = np.sqrt(f(np.sqrt(2))) * np.sqrt(2)
     >>> umax, vmin, vmax = np.sqrt(f(0)), -v_bound, v_bound
     >>> np.random.seed(12345)
-    >>> rvs = stats.rvs_ratio_uniforms(f, umax, vmin, vmax, size=2500)
+    >>> rvs = stats.rvs_ratio_uniforms(f, umax, vmin, vmax, size=1500)
 
     The K-S test confirms that the random variates are indeed normally
     distributed (p-value does not reject normality):
 
     >>> stats.kstest(rvs, 'norm')[1]
-    0.373298699196806752
+    0.5092431215510014
 
     The exponential distribution provides another example where the bounding
     rectangle can be determined explicitly.
@@ -6049,7 +6049,7 @@ def rvs_ratio_uniforms(pdf, umax, vmin, vmax, size=1, c=0, random_state=None):
     >>> rvs = stats.rvs_ratio_uniforms(lambda x: np.exp(-x), umax=1,
     ...                                vmin=0, vmax=2*np.exp(-1), size=1000)
     >>> stats.kstest(rvs, 'expon')[1]
-    0.52369231518316373
+    0.928454552559516
 
     Sometimes it can be helpful to use a non-zero shift parameter `c`, see e.g.
     [2]_ above in the case of the generalized inverse Gaussian distribution.

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -6055,7 +6055,7 @@ def rvs_ratio_unif(pdf, size=1, x1=None, x2=None, y2=None, shift=0,
     rectangle can be determined explicitly.
     >>> np.random.seed(12345)
     >>> rvs = stats.rvs_ratio_unif(lambda x: np.exp(-x), x1=0, x2=2*np.exp(-1),
-    >>> ...                        y2=1, size=1000)
+    ...                            y2=1, size=1000)
     >>> stats.kstest(rvs, 'expon')[1]
     0.52369231518316373
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -6076,7 +6076,7 @@ def rvs_ratio_uniforms(pdf, size=1, x1=None, x2=None, y2=None, c=0,
         if bounds is None:
             raise ValueError("The parameter bounds needs to be specified if " +
                              var + " is None.")
-        opt_res = optimize.minimize_scalar(g, bounds=bounds, method='Bounded')
+        opt_res = optimize.minimize_scalar(g, bounds=bounds, method='bounded')
         if not opt_res.success:
             raise RuntimeError("Optimization failed when attempting to find " +
                                var + ": " + opt_res.message)

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2002 Gary Strangman.  All rights reserved
+# Copyright 2002 Gary Strangman.  All rights reserved
 # Copyright 2002-2016 The SciPy Developers
 #
 # The original code from Gary Strangman was heavily adapted for

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -6094,6 +6094,13 @@ def rvs_ratio_unif(pdf, size=1, x1=None, x2=None, y2=None, shift=0,
     if y2 < 0:
         raise ValueError("y2 must be positive.")
 
+    exp_iter = 2 * (x2 - x1) * y2  # rejection constant (see [1])
+    if exp_iter > 30:
+        msg = "The expected number of iterations to generate a single random" \
+              " number from the desired distribution is larger than " \
+              "{}, potentially causing bad performance.".format(int(exp_iter))
+        warnings.warn(msg, RuntimeWarning)
+
     size1d = tuple(np.atleast_1d(size))
     N = np.prod(size1d)  # number of rvs needed, reshape upon return
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5943,7 +5943,7 @@ def rankdata(a, method='average'):
     return .5 * (count[dense] + count[dense - 1] + 1)
 
 
-def ratio_unif(f, size=1, x1=None, x2=None, y2=None, shift=0, max_iter=None,
+def ratio_unif(f, size=1, x1=None, x2=None, y2=None, shift=0, maxiter=None,
                bounds=None):
     """
     Generate random variables using ratio-of-uniforms method.
@@ -5983,9 +5983,9 @@ def ratio_unif(f, size=1, x1=None, x2=None, y2=None, shift=0, max_iter=None,
     y2 : float, optional
         The upper bound of the bounding rectangle in the y-direction.
         Default is None. In that case, attempt to find bound numerically.
-    max_iter : int, optional
+    maxiter : int, optional
         Maximum number of iterations to generate the random variables.
-        Default is None. In that case, max_iter is set to a value that
+        Default is None. In that case, maxiter is set to a value that
         ensures successful simulation with a high probability.
     bounds : tuple of floats (a, b), optional
         Default is none. In case any of the boundaries of the bounding
@@ -6078,16 +6078,16 @@ def ratio_unif(f, size=1, x1=None, x2=None, y2=None, shift=0, max_iter=None,
     if y2 < 0:
         raise ValueError("y2 must be positive.")
 
-    if max_iter is None:
+    if maxiter is None:
         # set no of iterations to ensure that method fails with proba. p_fail
         # in case point in [x1, x2] x [0, y2] is accepted with prob. p_accept
         p_fail, p_accept = 0.001, 0.25
-        max_iter = 10 + size * np.log(1 / p_fail) / np.log(1 / (1 - p_accept))
+        maxiter = 10 + size * np.log(1 / p_fail) / np.log(1 / (1 - p_accept))
 
     # start sampling using ratio of uniforms method
     x = np.zeros(size)
     j, simulated = 1, 0
-    while (j <= max_iter):
+    while (j <= maxiter):
         k = size - simulated
         # simulate uniform rvs on [x1, x2] and [0,y2]
         u1 = distributions.uniform.rvs(loc=x1, scale=(x2 - x1), size=k)
@@ -6106,5 +6106,5 @@ def ratio_unif(f, size=1, x1=None, x2=None, y2=None, shift=0, max_iter=None,
             return x
 
     raise Exception("Only {} of {} random variables".format(simulated, size) +
-                    " could generated after {}".format(round(max_iter, 0)) +
-                    " iterations. Consider increasing max_iter.")
+                    " could generated after {}".format(round(maxiter, 0)) +
+                    " iterations. Consider increasing maxiter.")

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5987,10 +5987,10 @@ def ratio_unif(f, size=1, x1=None, x2=None, y2=None, shift=0, max_iter=None,
         Maximum number of iterations to generate the random variables.
         Default is None. In that case, max_iter is set to a value that
         ensures successful simulation with a high probability.
-    bounds : tuple of floats (a, b)
-        In case any of the boundaries of the bounding rectangle is not
-        specified, attempt to find missing boundary numerically over the range
-        specified by bounds.
+    bounds : tuple of floats (a, b), optional
+        Default is none. In case any of the boundaries of the bounding
+        rectangle is not specified, attempt to find missing boundary
+        numerically over the range specified by bounds.
 
     Returns
     -------

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1,4 +1,4 @@
-﻿dens# Copyright 2002 Gary Strangman.  All rights reserved
+﻿# Copyright 2002 Gary Strangman.  All rights reserved
 # Copyright 2002-2016 The SciPy Developers
 #
 # The original code from Gary Strangman was heavily adapted for

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4511,7 +4511,7 @@ class TestRatioUniforms(object):
         # normal distribution
         f = stats.norm.pdf
         v_bound = np.sqrt(f(np.sqrt(2))) * np.sqrt(2)
-        umax, vmin, vmax =  np.sqrt(f(0)), -v_bound, v_bound
+        umax, vmin, vmax = np.sqrt(f(0)), -v_bound, v_bound
         rvs = stats.rvs_ratio_uniforms(f, umax, vmin, vmax, size=2500,
                                        random_state=12345)
         assert_equal(stats.kstest(rvs, 'norm')[1] > 0.25, True)
@@ -4523,16 +4523,16 @@ class TestRatioUniforms(object):
         assert_equal(stats.kstest(rvs, 'expon')[1] > 0.25, True)
 
     def test_shape(self):
-        # test shape of return value depending on size parameter        
+        # test shape of return value depending on size parameter
         f = stats.norm.pdf
         v_bound = np.sqrt(f(np.sqrt(2))) * np.sqrt(2)
-        umax, vmin, vmax =  np.sqrt(f(0)), -v_bound, v_bound
-        
+        umax, vmin, vmax = np.sqrt(f(0)), -v_bound, v_bound
+
         r1 = stats.rvs_ratio_uniforms(f, umax, vmin, vmax, size=3,
                                       random_state=1234)
         r2 = stats.rvs_ratio_uniforms(f, umax, vmin, vmax, size=(3,),
                                       random_state=1234)
-        r3 = stats.rvs_ratio_uniforms(f, umax, vmin, vmax, size=(3, 1), 
+        r3 = stats.rvs_ratio_uniforms(f, umax, vmin, vmax, size=(3, 1),
                                       random_state=1234)
         assert_equal(r1, r2)
         assert_equal(r2, r3.flatten())
@@ -4557,7 +4557,7 @@ class TestRatioUniforms(object):
     def test_random_state(self):
         f = stats.norm.pdf
         v_bound = np.sqrt(f(np.sqrt(2))) * np.sqrt(2)
-        umax, vmin, vmax =  np.sqrt(f(0)), -v_bound, v_bound
+        umax, vmin, vmax = np.sqrt(f(0)), -v_bound, v_bound
         np.random.seed(1234)
         r1 = stats.rvs_ratio_uniforms(f, umax, vmin, vmax, size=(3, 4))
         r2 = stats.rvs_ratio_uniforms(f, umax, vmin, vmax, size=(3, 4),

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4510,68 +4510,72 @@ class TestRatioUniforms(object):
         # use KS test to check distribution of rvs
         # normal distribution
         f = stats.norm.pdf
-        x_bound = np.sqrt(f(np.sqrt(2))) * np.sqrt(2)
-        x1, x2, y2 = -x_bound, x_bound, np.sqrt(f(0))
-        rvs = stats.rvs_ratio_uniforms(f, x1, x2, y2, size=2500,
+        v_bound = np.sqrt(f(np.sqrt(2))) * np.sqrt(2)
+        umax, vmin, vmax =  np.sqrt(f(0)), -v_bound, v_bound
+        rvs = stats.rvs_ratio_uniforms(f, umax, vmin, vmax, size=2500,
                                        random_state=12345)
         assert_equal(stats.kstest(rvs, 'norm')[1] > 0.25, True)
 
         # exponential distribution
-        rvs = stats.rvs_ratio_uniforms(lambda x: np.exp(-x), x1=0, x2=2*np.exp(-1),
-                                       y2=1, size=1000, random_state=12345)
+        rvs = stats.rvs_ratio_uniforms(lambda x: np.exp(-x), umax=1,
+                                       vmin=0, vmax=2*np.exp(-1),
+                                       size=1000, random_state=12345)
         assert_equal(stats.kstest(rvs, 'expon')[1] > 0.25, True)
 
     def test_shape(self):
         # test shape of return value depending on size parameter        
         f = stats.norm.pdf
-        x_bound = np.sqrt(f(np.sqrt(2))) * np.sqrt(2)
-        x1, x2, y2 = -x_bound, x_bound, np.sqrt(f(0))
+        v_bound = np.sqrt(f(np.sqrt(2))) * np.sqrt(2)
+        umax, vmin, vmax =  np.sqrt(f(0)), -v_bound, v_bound
         
-        r1 = stats.rvs_ratio_uniforms(f, x1, x2, y2, size=3, random_state=1234)
-        r2 = stats.rvs_ratio_uniforms(f, x1, x2, y2, size=(3,),
+        r1 = stats.rvs_ratio_uniforms(f, umax, vmin, vmax, size=3,
                                       random_state=1234)
-        r3 = stats.rvs_ratio_uniforms(f, x1, x2, y2, size=(3, 1), 
+        r2 = stats.rvs_ratio_uniforms(f, umax, vmin, vmax, size=(3,),
+                                      random_state=1234)
+        r3 = stats.rvs_ratio_uniforms(f, umax, vmin, vmax, size=(3, 1), 
                                       random_state=1234)
         assert_equal(r1, r2)
         assert_equal(r2, r3.flatten())
         assert_equal(r1.shape, (3,))
         assert_equal(r3.shape, (3, 1))
 
-        r4 = stats.rvs_ratio_uniforms(f, x1, x2, y2, size=(3, 3, 3),
+        r4 = stats.rvs_ratio_uniforms(f, umax, vmin, vmax, size=(3, 3, 3),
                                       random_state=12)
-        r5 = stats.rvs_ratio_uniforms(f, x1, x2, y2, size=27, random_state=12)
+        r5 = stats.rvs_ratio_uniforms(f, umax, vmin, vmax, size=27,
+                                      random_state=12)
         assert_equal(r4.flatten(), r5)
         assert_equal(r4.shape, (3, 3, 3))
 
-        r6 = stats.rvs_ratio_uniforms(f, x1, x2, y2, random_state=1234)
-        r7 = stats.rvs_ratio_uniforms(f, x1, x2, y2, size=1, random_state=1234)
-        r8 = stats.rvs_ratio_uniforms(f, x1, x2, y2, size=(1, ),
+        r6 = stats.rvs_ratio_uniforms(f, umax, vmin, vmax, random_state=1234)
+        r7 = stats.rvs_ratio_uniforms(f, umax, vmin, vmax, size=1,
+                                      random_state=1234)
+        r8 = stats.rvs_ratio_uniforms(f, umax, vmin, vmax, size=(1, ),
                                       random_state=1234)
         assert_equal(r6, r7)
         assert_equal(r7, r8)
 
     def test_random_state(self):
         f = stats.norm.pdf
-        x_bound = np.sqrt(f(np.sqrt(2))) * np.sqrt(2)
-        x1, x2, y2 = -x_bound, x_bound, np.sqrt(f(0))
+        v_bound = np.sqrt(f(np.sqrt(2))) * np.sqrt(2)
+        umax, vmin, vmax =  np.sqrt(f(0)), -v_bound, v_bound
         np.random.seed(1234)
-        r1 = stats.rvs_ratio_uniforms(f, x1, x2, y2, size=(3, 4))
-        r2 = stats.rvs_ratio_uniforms(f, x1, x2, y2, size=(3, 4),
+        r1 = stats.rvs_ratio_uniforms(f, umax, vmin, vmax, size=(3, 4))
+        r2 = stats.rvs_ratio_uniforms(f, umax, vmin, vmax, size=(3, 4),
                                       random_state=1234)
         assert_equal(r1, r2)
 
     def test_exceptions(self):
         f = stats.norm.pdf
-        # need x1 < x2
+        # need vmin < vmax
         assert_raises(ValueError,
-                      stats.rvs_ratio_uniforms, pdf=f, x1=3, x2=1, y2=1)
+                      stats.rvs_ratio_uniforms, pdf=f, umax=1, vmin=3, vmax=1)
         assert_raises(ValueError,
-                      stats.rvs_ratio_uniforms, pdf=f, x1=1, x2=1, y2=1)
-        # need y2 > 0
+                      stats.rvs_ratio_uniforms, pdf=f, umax=1, vmin=1, vmax=1)
+        # need umax > 0
         assert_raises(ValueError,
-                      stats.rvs_ratio_uniforms, pdf=f, x1=1, x2=1, y2=-1)
+                      stats.rvs_ratio_uniforms, pdf=f, umax=-1, vmin=1, vmax=1)
         assert_raises(ValueError,
-                      stats.rvs_ratio_uniforms, pdf=f, x1=1, x2=1, y2=0)
+                      stats.rvs_ratio_uniforms, pdf=f, umax=0, vmin=1, vmax=1)
 
     def test_gig(self):
         # test generalized inverse gaussian distribution
@@ -4590,11 +4594,11 @@ class TestRatioUniforms(object):
             return np.array(cdf)
 
         s = kv(p+2, b) / kv(p, b)
-        x2 = np.sqrt(gig_pdf(gig_mode(p + 2, b), p + 2, b) * s)
-        y2 = np.sqrt(gig_pdf(gig_mode(p, b), p, b))
+        vmax = np.sqrt(gig_pdf(gig_mode(p + 2, b), p + 2, b) * s)
+        umax = np.sqrt(gig_pdf(gig_mode(p, b), p, b))
 
-        rvs = stats.rvs_ratio_uniforms(lambda x: gig_pdf(x, p, b), x1=0, x2=x2,
-                                       y2=y2, random_state=1234, size=1500)
+        rvs = stats.rvs_ratio_uniforms(lambda x: gig_pdf(x, p, b), umax,
+                                       0, vmax, random_state=1234, size=1500)
 
         assert_equal(stats.kstest(rvs, lambda x: gig_cdf(x, p, b))[1] > 0.25,
                      True)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4503,45 +4503,49 @@ class TestBrunnerMunzel(object):
                             significant=self.significant)
 
 
-class TestRatioUnif(object):
-    """ Tests for rvs_ratio_unif.
+class TestRatioUniforms(object):
+    """ Tests for rvs_ratio_uniforms.
     """
     def test_rv_generation(self):
         # normal distribution
         f = stats.norm.pdf
         x2, y2 = np.sqrt(f(np.sqrt(2))) * np.sqrt(2), np.sqrt(f(0))
-        rvs = stats.rvs_ratio_unif(f, x1=-x2, x2=x2, y2=y2, size=2500,
-                                   random_state=12345)
+        rvs = stats.rvs_ratio_uniforms(f, x1=-x2, x2=x2, y2=y2, size=2500,
+                                       random_state=12345)
         assert_equal(stats.kstest(rvs, 'norm')[1] > 0.25, True)
         # same but find x1, x2, y2 numerically
-        rvs = stats.rvs_ratio_unif(f, size=2500, bounds=(-100, 100),
-                                   random_state=12345)
+        rvs = stats.rvs_ratio_uniforms(f, size=2500, bounds=(-100, 100),
+                                       random_state=12345)
         assert_equal(stats.kstest(rvs, 'norm')[1] > 0.25, True)
         # exponential distribution
-        rvs = stats.rvs_ratio_unif(lambda x: np.exp(-x), x1=0, x2=2*np.exp(-1),
-                                   y2=1, size=1000, random_state=12345)
+        rvs = stats.rvs_ratio_uniforms(lambda x: np.exp(-x), x1=0, x2=2*np.exp(-1),
+                                       y2=1, size=1000, random_state=12345)
         assert_equal(stats.kstest(rvs, 'expon')[1] > 0.25, True)
 
     def test_shape(self):
         # test shape of return value depending on size parameter
         f = stats.norm.pdf
         b = (-3, 3)
-        r1 = stats.rvs_ratio_unif(f, size=3, bounds=b, random_state=1234)
-        r2 = stats.rvs_ratio_unif(f, size=(3,), bounds=b, random_state=1234)
-        r3 = stats.rvs_ratio_unif(f, size=(3, 1), bounds=b, random_state=1234)
+        r1 = stats.rvs_ratio_uniforms(f, size=3, bounds=b, random_state=1234)
+        r2 = stats.rvs_ratio_uniforms(f, size=(3,), bounds=b,
+                                      random_state=1234)
+        r3 = stats.rvs_ratio_uniforms(f, size=(3, 1), bounds=b,
+                                      random_state=1234)
         assert_equal(r1, r2)
         assert_equal(r2, r3.flatten())
         assert_equal(r1.shape, (3,))
         assert_equal(r3.shape, (3, 1))
 
-        r4 = stats.rvs_ratio_unif(f, size=(3, 3, 3), bounds=b, random_state=12)
-        r5 = stats.rvs_ratio_unif(f, size=27, bounds=b, random_state=12)
+        r4 = stats.rvs_ratio_uniforms(f, size=(3, 3, 3), bounds=b,
+                                      random_state=12)
+        r5 = stats.rvs_ratio_uniforms(f, size=27, bounds=b, random_state=12)
         assert_equal(r4.flatten(), r5)
         assert_equal(r4.shape, (3, 3, 3))
 
-        r6 = stats.rvs_ratio_unif(f, bounds=b, random_state=1234)
-        r7 = stats.rvs_ratio_unif(f, size=1, bounds=b, random_state=1234)
-        r8 = stats.rvs_ratio_unif(f, size=(1, ), bounds=b, random_state=1234)
+        r6 = stats.rvs_ratio_uniforms(f, bounds=b, random_state=1234)
+        r7 = stats.rvs_ratio_uniforms(f, size=1, bounds=b, random_state=1234)
+        r8 = stats.rvs_ratio_uniforms(f, size=(1, ), bounds=b,
+                                      random_state=1234)
         assert_equal(r6, r7)
         assert_equal(r7, r8)
 
@@ -4549,26 +4553,27 @@ class TestRatioUnif(object):
         f = stats.norm.pdf
         b = (-3, 3)
         np.random.seed(1234)
-        r1 = stats.rvs_ratio_unif(f, size=(3, 4), bounds=b)
-        r2 = stats.rvs_ratio_unif(f, size=(3, 4), bounds=b, random_state=1234)
+        r1 = stats.rvs_ratio_uniforms(f, size=(3, 4), bounds=b)
+        r2 = stats.rvs_ratio_uniforms(f, size=(3, 4), bounds=b,
+                                      random_state=1234)
         assert_equal(r1, r2)
 
     def test_exceptions(self):
         f = stats.norm.pdf
         # bounds not specified in case any of x1, x2, y2 is None
-        assert_raises(Exception, stats.rvs_ratio_unif, pdf=f, x1=0, x2=1)
-        assert_raises(Exception, stats.rvs_ratio_unif, pdf=f, x2=1, y2=1)
-        assert_raises(Exception, stats.rvs_ratio_unif, pdf=f, x2=1, y2=1)
+        assert_raises(Exception, stats.rvs_ratio_uniforms, pdf=f, x1=0, x2=1)
+        assert_raises(Exception, stats.rvs_ratio_uniforms, pdf=f, x2=1, y2=1)
+        assert_raises(Exception, stats.rvs_ratio_uniforms, pdf=f, x2=1, y2=1)
         # need x1 < x2
         assert_raises(ValueError,
-                      stats.rvs_ratio_unif, pdf=f, x1=3, x2=1, y2=1)
+                      stats.rvs_ratio_uniforms, pdf=f, x1=3, x2=1, y2=1)
         assert_raises(ValueError,
-                      stats.rvs_ratio_unif, pdf=f, x1=1, x2=1, y2=1)
+                      stats.rvs_ratio_uniforms, pdf=f, x1=1, x2=1, y2=1)
         # need y2 > 0
         assert_raises(ValueError,
-                      stats.rvs_ratio_unif, pdf=f, x1=1, x2=1, y2=-1)
+                      stats.rvs_ratio_uniforms, pdf=f, x1=1, x2=1, y2=-1)
         assert_raises(ValueError,
-                      stats.rvs_ratio_unif, pdf=f, x1=1, x2=1, y2=0)     
+                      stats.rvs_ratio_uniforms, pdf=f, x1=1, x2=1, y2=0)
 
     def test_gig(self):
         # test generalized inverse gaussian distribution
@@ -4590,8 +4595,8 @@ class TestRatioUnif(object):
         x2 = np.sqrt(gig_pdf(gig_mode(p + 2, b), p + 2, b) * s)
         y2 = np.sqrt(gig_pdf(gig_mode(p, b), p, b))
 
-        rvs = stats.rvs_ratio_unif(lambda x: gig_pdf(x, p, b), x1=0, x2=x2,
-                                   y2=y2, random_state=1234, size=1500)
+        rvs = stats.rvs_ratio_uniforms(lambda x: gig_pdf(x, p, b), x1=0, x2=x2,
+                                       y2=y2, random_state=1234, size=1500)
 
         assert_equal(stats.kstest(rvs, lambda x: gig_cdf(x, p, b))[1] > 0.25,
                      True)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4500,3 +4500,37 @@ class TestBrunnerMunzel(object):
         assert_approx_equal(p1, 0.0057862086661515377,
                             significant=self.significant)
 
+
+class TestRatioUnif(object):
+    """ Tests for rvs_ratio_unif.
+    """
+    def test_rv_generation(self):
+        # normal distribution
+        f = stats.norm.pdf
+        x_bound = np.sqrt(f(np.sqrt(2))) * np.sqrt(2)
+        x1, x2, y2 = -x_bound, x_bound, np.sqrt(f(0))
+        rvs = stats.rvs_ratio_unif(f, x1=x1, x2=x2, y2=y2, size=2500,
+                                   random_state=12345)
+        assert_equal(stats.kstest(rvs, 'norm')[1] > 0.25, True)
+        # same but find x1, x2, y2 numerically
+        rvs = stats.rvs_ratio_unif(f, size=2500, bounds=(-100, 100),
+                                   random_state=12345)
+        assert_equal(stats.kstest(rvs, 'norm')[1] > 0.25, True)
+        # exponential distribution
+        rvs = stats.rvs_ratio_unif(lambda x: np.exp(-x), x1=0, x2=2*np.exp(-1),
+                                   y2=1, size=1000, random_state=12345)
+        assert_equal(stats.kstest(rvs, 'expon')[1] > 0.25, True)
+
+    def test_shape(self):
+        # test shape of return value
+        f = stats.norm.pdf
+        b = (-3, 3)
+        r1 = stats.rvs_ratio_unif(f, size=3, bounds=b, random_state=1234)
+        r2 = stats.rvs_ratio_unif(f, size=(3,), bounds=b, random_state=1234)
+        r3 = stats.rvs_ratio_unif(f, size=(3, 1), bounds=b, random_state=1234)
+        assert_equal(r1, r2)
+        assert_equal(r2, r3.flatten())
+
+        r4 = stats.rvs_ratio_unif(f, size=(3, 3, 3), bounds=b, random_state=12)
+        r5 = stats.rvs_ratio_unif(f, size=27, bounds=b, random_state=12)
+        assert_equal(r4.flatten(), r5)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4507,63 +4507,61 @@ class TestRatioUniforms(object):
     """ Tests for rvs_ratio_uniforms.
     """
     def test_rv_generation(self):
+        # use KS test to check distribution of rvs
         # normal distribution
         f = stats.norm.pdf
-        x2, y2 = np.sqrt(f(np.sqrt(2))) * np.sqrt(2), np.sqrt(f(0))
-        rvs = stats.rvs_ratio_uniforms(f, x1=-x2, x2=x2, y2=y2, size=2500,
+        x_bound = np.sqrt(f(np.sqrt(2))) * np.sqrt(2)
+        x1, x2, y2 = -x_bound, x_bound, np.sqrt(f(0))
+        rvs = stats.rvs_ratio_uniforms(f, x1, x2, y2, size=2500,
                                        random_state=12345)
         assert_equal(stats.kstest(rvs, 'norm')[1] > 0.25, True)
-        # same but find x1, x2, y2 numerically
-        rvs = stats.rvs_ratio_uniforms(f, size=2500, bounds=(-100, 100),
-                                       random_state=12345)
-        assert_equal(stats.kstest(rvs, 'norm')[1] > 0.25, True)
+
         # exponential distribution
         rvs = stats.rvs_ratio_uniforms(lambda x: np.exp(-x), x1=0, x2=2*np.exp(-1),
                                        y2=1, size=1000, random_state=12345)
         assert_equal(stats.kstest(rvs, 'expon')[1] > 0.25, True)
 
     def test_shape(self):
-        # test shape of return value depending on size parameter
+        # test shape of return value depending on size parameter        
         f = stats.norm.pdf
-        b = (-3, 3)
-        r1 = stats.rvs_ratio_uniforms(f, size=3, bounds=b, random_state=1234)
-        r2 = stats.rvs_ratio_uniforms(f, size=(3,), bounds=b,
+        x_bound = np.sqrt(f(np.sqrt(2))) * np.sqrt(2)
+        x1, x2, y2 = -x_bound, x_bound, np.sqrt(f(0))
+        
+        r1 = stats.rvs_ratio_uniforms(f, x1, x2, y2, size=3, random_state=1234)
+        r2 = stats.rvs_ratio_uniforms(f, x1, x2, y2, size=(3,),
                                       random_state=1234)
-        r3 = stats.rvs_ratio_uniforms(f, size=(3, 1), bounds=b,
+        r3 = stats.rvs_ratio_uniforms(f, x1, x2, y2, size=(3, 1), 
                                       random_state=1234)
         assert_equal(r1, r2)
         assert_equal(r2, r3.flatten())
         assert_equal(r1.shape, (3,))
         assert_equal(r3.shape, (3, 1))
 
-        r4 = stats.rvs_ratio_uniforms(f, size=(3, 3, 3), bounds=b,
+        r4 = stats.rvs_ratio_uniforms(f, x1, x2, y2, size=(3, 3, 3),
                                       random_state=12)
-        r5 = stats.rvs_ratio_uniforms(f, size=27, bounds=b, random_state=12)
+        r5 = stats.rvs_ratio_uniforms(f, x1, x2, y2, size=27, random_state=12)
         assert_equal(r4.flatten(), r5)
         assert_equal(r4.shape, (3, 3, 3))
 
-        r6 = stats.rvs_ratio_uniforms(f, bounds=b, random_state=1234)
-        r7 = stats.rvs_ratio_uniforms(f, size=1, bounds=b, random_state=1234)
-        r8 = stats.rvs_ratio_uniforms(f, size=(1, ), bounds=b,
+        r6 = stats.rvs_ratio_uniforms(f, x1, x2, y2, random_state=1234)
+        r7 = stats.rvs_ratio_uniforms(f, x1, x2, y2, size=1, random_state=1234)
+        r8 = stats.rvs_ratio_uniforms(f, x1, x2, y2, size=(1, ),
                                       random_state=1234)
         assert_equal(r6, r7)
         assert_equal(r7, r8)
 
     def test_random_state(self):
         f = stats.norm.pdf
-        b = (-3, 3)
+        x_bound = np.sqrt(f(np.sqrt(2))) * np.sqrt(2)
+        x1, x2, y2 = -x_bound, x_bound, np.sqrt(f(0))
         np.random.seed(1234)
-        r1 = stats.rvs_ratio_uniforms(f, size=(3, 4), bounds=b)
-        r2 = stats.rvs_ratio_uniforms(f, size=(3, 4), bounds=b,
+        r1 = stats.rvs_ratio_uniforms(f, x1, x2, y2, size=(3, 4))
+        r2 = stats.rvs_ratio_uniforms(f, x1, x2, y2, size=(3, 4),
                                       random_state=1234)
         assert_equal(r1, r2)
 
     def test_exceptions(self):
         f = stats.norm.pdf
-        # bounds not specified in case any of x1, x2, y2 is None
-        assert_raises(Exception, stats.rvs_ratio_uniforms, pdf=f, x1=0, x2=1)
-        assert_raises(Exception, stats.rvs_ratio_uniforms, pdf=f, x2=1, y2=1)
-        assert_raises(Exception, stats.rvs_ratio_uniforms, pdf=f, x2=1, y2=1)
         # need x1 < x2
         assert_raises(ValueError,
                       stats.rvs_ratio_uniforms, pdf=f, x1=3, x2=1, y2=1)


### PR DESCRIPTION
General method to sample random variates based on the density only. 

- can be useful to generate rvs in case a distribution is not part of scipy.stats and cdf cannot be easily inverted (such as the generalized inverse Gaussian). 
- I intend to add the generalized inverse Gaussian in a separate project based on this method (approach is referenced in the docstring which should also fix current restriction on parameters of `invgauss.rvs` as a special case)
- once gen. inverse Gaussian is available, one can also add generalized hyperbolic distributions

Tests to be added, but I checked that the approach works in general using `stats.kstest` and a couple of examples (see docstring).

