### PR TITLE
BUG: Fix slowness in stats.mode

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -190,6 +190,7 @@ Lars Grüter for contributions to peak finding in scipy.signal
 Jordan Heemskerk for exposing additional windowing functions in scipy.signal.
 Michael Tartre (Two Sigma Investments) for contributions to weighted distance functions.
 Shinya Suzuki for scipy.stats.brunnermunzel
+Graham Clenaghan for bug fixes and optimizations in scipy.stats.
 
 Institutions
 ------------

--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -92,5 +92,18 @@ class Distribution(Benchmark):
                 stats.beta.rvs(size=1000, a=5, b=3, loc=4, scale=10)
             elif properties == 'fit':
                 stats.beta.fit(self.x, a=5, b=3, loc=4, scale=10)
-        
+
+
+class DescriptiveStats(Benchmark):
+    param_names = ['n_levels']
+    params = [
+        [10, 1000]
+    ]
+
+    def setup(self, n_levels):
+        np.random.seed(12345678)
+        self.levels = np.random.randint(n_levels, size=(1000, 10))
+
+    def time_mode(self, n_levels):
+        stats.mode(self.levels, axis=0)
 

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -312,9 +312,7 @@ def mode(a, axis=0):
         elif cnt.size:
             return (rep[cnt.argmax()], cnt.max())
         else:
-            not_masked_indices = ma.flatnotmasked_edges(a)
-            first_not_masked_index = not_masked_indices[0]
-            return (a[first_not_masked_index], 1)
+            return (a.min(), 1)
 
     if axis is None:
         output = _mode1D(ma.ravel(a))

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1359,7 +1359,6 @@ class TestMode(object):
         assert_equal(vals[0][0], 'showers')
         assert_equal(vals[1][0], 2)
 
-    @pytest.mark.xfail(sys.version_info > (3,), reason='numpy github issue 641')
     def test_mixed_objects(self):
         objects = [10, True, np.nan, 'hello', 10]
         arr = np.empty((5,), dtype=object)
@@ -1421,6 +1420,16 @@ class TestMode(object):
         assert_equal(actual, (6, 3))
         assert_raises(ValueError, stats.mode, data1, nan_policy='raise')
         assert_raises(ValueError, stats.mode, data1, nan_policy='foobar')
+
+    @pytest.mark.parametrize("data", [
+        [3, 5, 1, 1, 3],
+        [3, np.nan, 5, 1, 1, 3],
+        [3, 5, 1],
+        [3, np.nan, 5, 1],
+    ])
+    def test_smallest_equal(self, data):
+        result = stats.mode(data, nan_policy='omit')
+        assert_equal(result[0][0], 1)
 
 
 class TestVariability(object):


### PR DESCRIPTION
Currently, the main thread of stats.mode is O(size of array * number of distinct elements), which is often O(N^2). Confusingly, if `nan_policy='omit'` and there is at least one `nan`, then it uses a completely different implementation which is fast. I mostly followed that implementation with one twist to allow any type.

I also spotted another bug: the omit implementation returned the first element and not the smallest when there were no repeated items. I added a test for this.

I also noticed that `nan_policy='propagate'` behaves exactly the same as `nan_policy='omit'`. There was actually a test for this (test_stats.py line 1398) so I left that alone for now but I'm pretty sure something is wrong here. I believe after `_contains_nan` it should just return early. This is an easy add but I wanted to ask before messing around with old tests as a new contributor. Most importantly, it probably breaks a lot of people's code.

Fixes #1432