### PR TITLE
Fixed bug reported in issue #8181

### DIFF
--- a/scipy/io/matlab/mio.py
+++ b/scipy/io/matlab/mio.py
@@ -36,7 +36,7 @@ def _open_file(file_like, appendmat):
         if isinstance(file_like, string_types):
             if appendmat and not file_like.endswith('.mat'):
                 file_like += '.mat'
-                return open(file_like, 'rb'), True
+            return open(file_like, 'rb'), True
         else:
             raise IOError('Reader needs file name or open file-like object')
 

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -1234,3 +1234,9 @@ def test_save_unicode_field(tmpdir):
     filename = os.path.join(str(tmpdir), 'test.mat')
     test_dict = {u'a':{u'b':1,u'c':'test_str'}}
     savemat(filename, test_dict)
+
+
+def test_filenotfound():
+    # Check the correct error is thrown
+    assert_raises(FileNotFoundError, loadmat, "NotExistentFile00.mat")
+    assert_raises(FileNotFoundError, loadmat, "NotExistentFile00")

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -1238,5 +1238,5 @@ def test_save_unicode_field(tmpdir):
 
 def test_filenotfound():
     # Check the correct error is thrown
-    assert_raises(FileNotFoundError, loadmat, "NotExistentFile00.mat")
-    assert_raises(FileNotFoundError, loadmat, "NotExistentFile00")
+    assert_raises(IOError, loadmat, "NotExistentFile00.mat")
+    assert_raises(IOError, loadmat, "NotExistentFile00")


### PR DESCRIPTION
The problem consisted of a single tabulation which shouldn't have been there, and caused the function _open_file never to return, when ".mat" was to be appended. I removed the tabulation, and nothing else.

Fixes #8181 