### PR TITLE
make sure _onenorm_matrix_power_nnm actually returns a float

### DIFF
--- a/scipy/sparse/linalg/matfuncs.py
+++ b/scipy/sparse/linalg/matfuncs.py
@@ -105,7 +105,7 @@ def _onenorm_matrix_power_nnm(A, p):
     M = A.T
     for i in range(p):
         v = M.dot(v)
-    return max(v)
+    return np.max(v)
 
 
 def _onenorm(A):


### PR DESCRIPTION
The function [`_onenorm_matrix_power_nnm()` ](https://github.com/scipy/scipy/blob/master/scipy/sparse/linalg/matfuncs.py#L78) computes the 1-norm of a non-negative integer power of a non-negative matrix and
```
Returns
    -------
    out : float
        The 1-norm of the matrix power p of A.
```
However, it really does return `numpy.array([alpha])` with `alpha` being the 1-norm. This PR fixes things by actually returning a `float`.

Before:
```python
print(_onenorm_matrix_power_nnm(A, p))   # array([1.31])
```
After:
```python
print(_onenorm_matrix_power_nnm(A, p))   # 1.31
```

The change is probably too small to warrant an explicit test.