### PR TITLE
Optional Pythran support for scipy.signal.max_len_seq_inner

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,7 @@ jobs:
             python3 -m venv venv
             . venv/bin/activate
             pip install --install-option="--no-cython-compile" cython
+            pip install pythran
             pip install numpy
             pip install nose mpmath argparse Pillow codecov matplotlib "Sphinx!=3.1.0" asv
             pip install pybind11

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,6 @@ jobs:
             python3 -m venv venv
             . venv/bin/activate
             pip install --install-option="--no-cython-compile" cython
-            pip install pythran
             pip install numpy
             pip install nose mpmath argparse Pillow codecov matplotlib "Sphinx!=3.1.0" asv
             pip install pybind11

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,7 @@
 [run]
 branch = True
 include = */scipy/*
+omit =
+    scipy/setup.py
+    scipy/*/setup.py
+    scipy/signal/_max_len_seq_inner.py

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -36,6 +36,7 @@ jobs:
           python3.7-dbg -m pip install --upgrade pip setuptools wheel cython pytest pytest-xdist argparse pybind11
           python3.7-dbg -m pip install --upgrade mpmath gmpy2
           python3.7-dbg -m pip install --upgrade --no-cache-dir numpy
+          python3.7-dbg -m pip install --upgrade pythran
           python3.7-dbg -m pip uninstall -y nose
           cd ..
       - name: Building SciPy
@@ -75,6 +76,7 @@ jobs:
     - name: Install packages
       run: |
         python3.9 -m pip install --user numpy setuptools wheel cython pytest pytest-xdist pybind11 pytest-xdist
+        python3.9 -m pip install --user pythran
 
     - name: Test SciPy
       run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -34,9 +34,8 @@ jobs:
         run: |      
           python3.7-dbg -c 'import sys; print("Python debug build:", hasattr(sys, "gettotalrefcount"))'
           python3.7-dbg -m pip install --upgrade pip setuptools wheel cython pytest pytest-xdist argparse pybind11
-          python3.7-dbg -m pip install --upgrade mpmath gmpy2
+          python3.7-dbg -m pip install --upgrade mpmath gmpy2 pythran
           python3.7-dbg -m pip install --upgrade --no-cache-dir numpy
-          python3.7-dbg -m pip install --upgrade pythran
           python3.7-dbg -m pip uninstall -y nose
           cd ..
       - name: Building SciPy
@@ -75,8 +74,7 @@ jobs:
 
     - name: Install packages
       run: |
-        python3.9 -m pip install --user numpy setuptools wheel cython pytest pytest-xdist pybind11 pytest-xdist
-        python3.9 -m pip install --user pythran
+        python3.9 -m pip install --user numpy setuptools wheel cython pytest pytest-xdist pybind11 pytest-xdist pythran
 
     - name: Test SciPy
       run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -75,7 +75,9 @@ jobs:
       run: |
         pip install ${{ matrix.numpy-version }}
         pip install setuptools wheel cython pytest pytest-xdist pybind11 pytest-xdist mpmath gmpy2
+        pip install pythran
 
     - name: Test SciPy
       run: |
-        python -u runtests.py
+        SCIPY_USE_PYTHRAN=0 python -u runtests.py
+        SCIPY_USE_PYTHRAN=1 python -u runtests.py

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -74,10 +74,8 @@ jobs:
     - name: Install packages
       run: |
         pip install ${{ matrix.numpy-version }}
-        pip install setuptools wheel cython pytest pytest-xdist pybind11 pytest-xdist mpmath gmpy2
-        pip install pythran
+        pip install setuptools wheel cython pytest pytest-xdist pybind11 pytest-xdist mpmath gmpy2 pythran
 
     - name: Test SciPy
       run: |
-        SCIPY_USE_PYTHRAN=0 python -u runtests.py
-        SCIPY_USE_PYTHRAN=1 python -u runtests.py
+        SCIPY_USE_PYTHRAN=`test ${{ matrix.python-version }} != 3.9; echo $?` python -u runtests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ addons:
     - ccache
     - swig
     - libmpc-dev
+    - g++
 
 env:
   global:
@@ -80,6 +81,10 @@ before_install:
       echo "library_dirs = $target/lib" >> site.cfg
       echo "include_dirs = $target/include" >> site.cfg
       echo "runtime_library_dirs = $target/lib" >> site.cfg
+      # pythran setup
+      echo '[compiler]' > ~/.pythranrc
+      echo 'CXX=g++-7' >> ~/.pythranrc
+      echo 'CC=gcc-7' >> ~/.pythranrc
     fi
   - export CCACHE_COMPRESS=1
   - if [ -n "$CC" ]; then ln -s `which ccache` "/usr/lib/ccache/$CC" || true; fi
@@ -102,6 +107,7 @@ before_install:
   - python -c 'import sys; print("Python debug build:", hasattr(sys, "gettotalrefcount"))'
   - travis_retry pip install --upgrade pip==20.2.4 setuptools wheel $OTHERSPEC cython pytest pytest-xdist mpmath argparse gmpy2 pybind11
   - travis_retry pip install --upgrade $NUMPYSPEC
+  - travis_retry pip install --upgrade pythran
   - |
     if [ -z "${USE_DEBUG}" -a "${TRAVIS_CPU_ARCH}" == "amd64" -a "${TRAVIS_PYTHON_VERSION}" != "3.8" ]; then
         if ! expr "$NUMPYSPEC" : ".*--pre.*" > /dev/null; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -105,9 +105,8 @@ before_install:
     fi
   - python --version
   - python -c 'import sys; print("Python debug build:", hasattr(sys, "gettotalrefcount"))'
-  - travis_retry pip install --upgrade pip==20.2.4 setuptools wheel $OTHERSPEC cython pytest pytest-xdist mpmath argparse gmpy2 pybind11
+  - travis_retry pip install --upgrade pip==20.2.4 setuptools wheel $OTHERSPEC cython pytest pytest-xdist mpmath argparse gmpy2 pybind11 pythran
   - travis_retry pip install --upgrade $NUMPYSPEC
-  - travis_retry pip install --upgrade pythran
   - |
     if [ -z "${USE_DEBUG}" -a "${TRAVIS_CPU_ARCH}" == "amd64" -a "${TRAVIS_PYTHON_VERSION}" != "3.8" ]; then
         if ! expr "$NUMPYSPEC" : ".*--pre.*" > /dev/null; then

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -173,6 +173,7 @@ jobs:
            python3.7 get-pip.py && \
            pip3 --version && \
            pip3 install setuptools wheel numpy==1.16.6 cython==0.29.18 pybind11 pytest pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath matplotlib==3.1.3 --user && \
+           pip3 install pythran --user && \
            apt-get -y install gcc-5 g++-5 gfortran-5 wget && \
            cd .. && \
            mkdir openblas && cd openblas && \
@@ -211,11 +212,13 @@ jobs:
           PYTHON_ARCH: 'x86'
           TEST_MODE: fast
           BITS: 32
+          SCIPY_USE_PYTHRAN: 0
         Python37-64bit-full:
           PYTHON_VERSION: '3.7'
           PYTHON_ARCH: 'x64'
           TEST_MODE: full
           BITS: 64
+          SCIPY_USE_PYTHRAN: 0
         Python38-64bit-full-ilp64:
           PYTHON_VERSION: '3.8'
           PYTHON_ARCH: 'x64'
@@ -223,11 +226,25 @@ jobs:
           NPY_USE_BLAS_ILP64: 1
           BITS: 64
           OPENBLAS64_: $(OPENBLAS)
+          SCIPY_USE_PYTHRAN: 0
         Python39-64bit-full:
           PYTHON_VERSION: '3.9'
           PYTHON_ARCH: 'x64'
           TEST_MODE: full
           BITS: 64
+          SCIPY_USE_PYTHRAN: 0
+        Python37-32bit-fast-pythran:
+          PYTHON_VERSION: '3.7'
+          PYTHON_ARCH: 'x86'
+          TEST_MODE: fast
+          BITS: 32
+          SCIPY_USE_PYTHRAN: 1
+        Python39-64bit-fast-pythran:
+          PYTHON_VERSION: '3.9'
+          PYTHON_ARCH: 'x64'
+          TEST_MODE: fast
+          BITS: 64
+          SCIPY_USE_PYTHRAN: 1
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -256,6 +273,14 @@ jobs:
           Download-OpenBLAS('1')
       }
     displayName: 'Download / Install OpenBLAS'
+  - script: |
+      choco install -y llvm
+      set PATH=C:\Program Files\LLVM\bin;%PATH%
+      echo '##vso[task.setvariable variable=PATH]%PATH%'
+    displayName: 'Install clang-cl'
+  - script: |
+      clang-cl.exe --version
+    displayName: 'clang-cl version'
   - powershell: |
       # wheels appear to use mingw64 version 6.3.0, but 6.4.0
       # is the closest match available from choco package manager
@@ -276,6 +301,10 @@ jobs:
       pytest-timeout
       pytest-xdist==1.34.0
     displayName: 'Install dependencies'
+  - script: >-
+      python -m pip install
+      pythran
+    displayName: 'Install pythran'
   # DLL resolution mechanics were changed in
   # Python 3.8: https://bugs.python.org/issue36085
   # While we normally leave adjustment of _distributor_init.py
@@ -302,6 +331,9 @@ jobs:
           $env:CFLAGS = "-m32"
           $env:LDFLAGS = "-m32"
           refreshenv
+          python -c "import os; fd = open(os.path.expanduser(os.path.join('~', '.pythranrc')), 'w'); fd.write('[compiler]\nCXX=clang-cl.exe\nCC=clang-cl.exe\ncflags=/std:c++14 -m32\nblas=none\n'); fd.close()"
+      }else{
+          python -c "import os; fd = open(os.path.expanduser(os.path.join('~', '.pythranrc')), 'w'); fd.write('[compiler]\nCXX=clang-cl.exe\nCC=clang-cl.exe\nblas=none\n'); fd.close()"
       }
       $env:PATH = "C:\\ProgramData\\chocolatey\\lib\\mingw\\tools\\install\\mingw$(BITS)\\bin;" + $env:PATH
 
@@ -313,6 +345,7 @@ jobs:
     displayName: 'Build SciPy'
   - powershell: |
       $env:PATH = "C:\\ProgramData\\chocolatey\\lib\\mingw\\tools\\install\\mingw$(BITS)\\bin;" + $env:PATH
+      $env:SCIPY_USE_PYTHRAN=$(SCIPY_USE_PYTHRAN)
       python runtests.py -n --mode=$(TEST_MODE) -- -n 2 -rsx --junitxml=junit/test-results.xml --cov=scipy --cov-report=xml --cov-report=html --durations=10
     displayName: 'Run SciPy Test Suite'
   - task: PublishTestResults@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -172,8 +172,7 @@ jobs:
            curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
            python3.7 get-pip.py && \
            pip3 --version && \
-           pip3 install setuptools wheel numpy==1.16.6 cython==0.29.18 pybind11 pytest pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath matplotlib==3.1.3 --user && \
-           pip3 install pythran --user && \
+           pip3 install setuptools wheel numpy==1.16.6 cython==0.29.18 pybind11 pytest pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath matplotlib==3.1.3 pythran --user && \
            apt-get -y install gcc-5 g++-5 gfortran-5 wget && \
            cd .. && \
            mkdir openblas && cd openblas && \
@@ -212,7 +211,7 @@ jobs:
           PYTHON_ARCH: 'x86'
           TEST_MODE: fast
           BITS: 32
-          SCIPY_USE_PYTHRAN: 0
+          SCIPY_USE_PYTHRAN: 1
         Python37-64bit-full:
           PYTHON_VERSION: '3.7'
           PYTHON_ARCH: 'x64'
@@ -226,25 +225,13 @@ jobs:
           NPY_USE_BLAS_ILP64: 1
           BITS: 64
           OPENBLAS64_: $(OPENBLAS)
-          SCIPY_USE_PYTHRAN: 0
+          SCIPY_USE_PYTHRAN: 1
         Python39-64bit-full:
           PYTHON_VERSION: '3.9'
           PYTHON_ARCH: 'x64'
           TEST_MODE: full
           BITS: 64
           SCIPY_USE_PYTHRAN: 0
-        Python37-32bit-fast-pythran:
-          PYTHON_VERSION: '3.7'
-          PYTHON_ARCH: 'x86'
-          TEST_MODE: fast
-          BITS: 32
-          SCIPY_USE_PYTHRAN: 1
-        Python39-64bit-fast-pythran:
-          PYTHON_VERSION: '3.9'
-          PYTHON_ARCH: 'x64'
-          TEST_MODE: fast
-          BITS: 64
-          SCIPY_USE_PYTHRAN: 1
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -295,16 +282,13 @@ jobs:
       numpy
       Pillow
       pybind11
+      pythran
       pytest==5.4.3
       pytest-cov
       pytest-env
       pytest-timeout
       pytest-xdist==1.34.0
     displayName: 'Install dependencies'
-  - script: >-
-      python -m pip install
-      pythran
-    displayName: 'Install pythran'
   # DLL resolution mechanics were changed in
   # Python 3.8: https://bugs.python.org/issue36085
   # While we normally leave adjustment of _distributor_init.py

--- a/ci/azure-travis-template.yaml
+++ b/ci/azure-travis-template.yaml
@@ -73,6 +73,10 @@ steps:
     pytest
     pytest-xdist
   displayName: 'Install common python dependencies'
+- script: >-
+    pip install ${{parameters.other_spec}}
+    pythran
+  displayName: 'Install pythran'
 - ${{ if eq(parameters.test_mode, 'full') }}:
   - script: pip install matplotlib scikit-umfpack scikit-sparse
     displayName: 'Install full mode dependencies'

--- a/ci/azure-travis-template.yaml
+++ b/ci/azure-travis-template.yaml
@@ -69,14 +69,11 @@ steps:
     cython
     gmpy2
     mpmath
+    pythran
     pybind11
     pytest
     pytest-xdist
   displayName: 'Install common python dependencies'
-- script: >-
-    pip install ${{parameters.other_spec}}
-    pythran
-  displayName: 'Install pythran'
 - ${{ if eq(parameters.test_mode, 'full') }}:
   - script: pip install matplotlib scikit-umfpack scikit-sparse
     displayName: 'Install full mode dependencies'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ requires = [
     "wheel",
     "setuptools",
     "Cython>=0.29.18",
+    "pythran",
     "numpy==1.16.5; python_version=='3.7'",
     "numpy==1.17.3; python_version=='3.8'",
     # do not pin numpy on future versions of python to avoid incompatible numpy and python versions

--- a/scipy/signal/_max_len_seq.py
+++ b/scipy/signal/_max_len_seq.py
@@ -112,7 +112,7 @@ def max_len_seq(nbits, state=None, length=None, taps=None):
         if np.any(taps < 0) or np.any(taps > nbits) or taps.size < 1:
             raise ValueError('taps must be non-empty with values between '
                              'zero and nbits (inclusive)')
-        taps = np.ascontiguousarray(taps)  # needed for Cython
+        taps = np.array(taps)  # needed for Cython and Pythran
     n_max = (2**nbits) - 1
     if length is None:
         length = n_max

--- a/scipy/signal/_max_len_seq_inner.py
+++ b/scipy/signal/_max_len_seq_inner.py
@@ -1,0 +1,22 @@
+# Author: Eric Larson
+# 2014
+
+import numpy as np
+
+#pythran export _max_len_seq_inner(intp[], int8[], int, int, int8[])
+
+# Fast inner loop of max_len_seq.
+def _max_len_seq_inner(taps, state, nbits, length, seq):
+    # Here we compute MLS using a shift register, indexed using a ring buffer
+    # technique (faster than using something like np.roll to shift)
+    n_taps = taps.shape[0]
+    idx = 0
+    for i in range(length):
+        feedback = state[idx]
+        seq[i] = feedback
+        for ti in range(n_taps):
+            feedback ^= state[(taps[ti] + idx) % nbits]
+        state[idx] = feedback
+        idx = (idx + 1) % nbits
+    # state must be rolled s.t. next run, when idx==0, it's in the right place
+    return np.roll(state, -idx, axis=0)

--- a/scipy/signal/setup.py
+++ b/scipy/signal/setup.py
@@ -1,4 +1,5 @@
 from scipy._build_utils import numpy_nodepr_api
+import os
 
 
 def configuration(parent_package='', top_path=None):
@@ -22,8 +23,17 @@ def configuration(parent_package='', top_path=None):
 
     config.add_extension(
         '_spectral', sources=['_spectral.c'])
-    config.add_extension(
-        '_max_len_seq_inner', sources=['_max_len_seq_inner.c'])
+
+    if int(os.environ.get('SCIPY_USE_PYTHRAN', 0)):
+        import pythran
+        ext = pythran.dist.PythranExtension(
+            'scipy.signal._max_len_seq_inner',
+            sources=["scipy/signal/_max_len_seq_inner.py"])
+        config.ext_modules.append(ext)
+    else:
+        config.add_extension(
+            '_max_len_seq_inner', sources=['_max_len_seq_inner.c'])
+
     config.add_extension(
         '_peak_finding_utils', sources=['_peak_finding_utils.c'])
     config.add_extension(

--- a/setup.py
+++ b/setup.py
@@ -223,9 +223,22 @@ def get_build_ext_override():
     """
     Custom build_ext command to tweak extension building.
     """
-    from numpy.distutils.command.build_ext import build_ext as old_build_ext
+    from numpy.distutils.command.build_ext import build_ext as npy_build_ext
+    if int(os.environ.get('SCIPY_USE_PYTHRAN', 0)):
+        # PythranBuildExt does *not* derive from npy_build_ext
+        # Win the monkey patching race here and patch base class
+        # before it's loaded by Pythran. This should be removed
+        # once Pythran has proper support for base class selection.
+        assert 'pythran' not in sys.modules
+        import distutils.command.build_ext
+        distutils_build_ext = distutils.command.build_ext.build_ext
+        distutils.command.build_ext.build_ext = npy_build_ext
+        from pythran.dist import PythranBuildExt as BaseBuildExt
+        distutils.command.build_ext.build_ext = distutils_build_ext
+    else:
+        BaseBuildExt = npy_build_ext
 
-    class build_ext(old_build_ext):
+    class build_ext(BaseBuildExt):
         def finalize_options(self):
             super().finalize_options()
 
@@ -254,7 +267,7 @@ def get_build_ext_override():
             hooks = getattr(ext, '_pre_build_hook', ())
             _run_pre_build_hooks(hooks, (self, ext))
 
-            old_build_ext.build_extension(self, ext)
+            super(build_ext, self).build_extension(ext)
 
         def __is_using_gnu_linker(self, ext):
             if not sys.platform.startswith('linux'):

--- a/setup.py
+++ b/setup.py
@@ -233,8 +233,12 @@ def get_build_ext_override():
         import distutils.command.build_ext
         distutils_build_ext = distutils.command.build_ext.build_ext
         distutils.command.build_ext.build_ext = npy_build_ext
-        from pythran.dist import PythranBuildExt as BaseBuildExt
-        distutils.command.build_ext.build_ext = distutils_build_ext
+        try:
+            from pythran.dist import PythranBuildExt as BaseBuildExt
+        except ImportError:
+            BaseBuildExt = npy_build_ext
+        finally:
+            distutils.command.build_ext.build_ext = distutils_build_ext
     else:
         BaseBuildExt = npy_build_ext
 

--- a/setup.py
+++ b/setup.py
@@ -224,7 +224,7 @@ def get_build_ext_override():
     Custom build_ext command to tweak extension building.
     """
     from numpy.distutils.command.build_ext import build_ext as npy_build_ext
-    if int(os.environ.get('SCIPY_USE_PYTHRAN', 0)):
+    if int(os.environ.get('SCIPY_USE_PYTHRAN', 1)):
         # PythranBuildExt does *not* derive from npy_build_ext
         # Win the monkey patching race here and patch base class
         # before it's loaded by Pythran. This should be removed

--- a/tools/ci/appveyor/requirements.txt
+++ b/tools/ci/appveyor/requirements.txt
@@ -1,5 +1,6 @@
 numpy
 cython
+pythran
 pybind11
 pytest
 pytest-timeout


### PR DESCRIPTION
Opt-in support to compile `signal._max_len_seq_inner package` with Pythran instead of Cython, if available.

In addition to the easier maintainability, I get a x4 speedup with AVX instructions enabled on my local setup.