### PR TITLE
MAINT: simps works with non-monotonic x fixes #8230

### DIFF
--- a/doc/release/1.1.0-notes.rst
+++ b/doc/release/1.1.0-notes.rst
@@ -44,12 +44,16 @@ The ``init`` keyword for the `scipy.optimize.differential_evolution` function
 can now accept an array. This array allows the user to specify the entire
 population.
 
-
 `scipy.sparse` improvements
 ----------------------------
 
 An in-place ``resize`` method has been added to all sparse matrix formats,
 which was only available for ``scipy.sparse.dok_matrix`` in previous releases.
+
+`scipy.integrate` improvements
+------------------------------
+``scipy.integrate.simps`` can now handle non-monotonically arranged `x` arrays.
+
 
 Deprecated features
 ===================

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -337,3 +337,44 @@ except AttributeError:
         if argspec.args[0] == 'self':
             argspec.args.pop(0)
         return argspec
+
+
+def _argsort_indices(a, axis=-1):
+    """
+    Like argsort, but returns an index suitable for sorting the
+    the original array even if that array is multidimensional
+
+    Parameters
+    ----------
+    arr : array-like
+
+    Returns
+    -------
+    ind : tuple
+        Indices for sorting original array along an axis
+
+    Examples
+    --------
+    Sort an array along a given axis
+
+    >>> arr = np.arange(25)
+    >>> np.random.shuffle(arr)
+    >>> arr = arr.reshape(5, 5)
+    >>> print(arr)
+    [[ 3 14 11 19 13]
+     [ 9  8 21 17 24]
+     [12  0 23  4 10]
+     [ 1  5 15 16 20]
+     [ 7  2  6 22 18]]
+    >>> print(arr[_argsort_indices(arr, 1)])
+    [[ 3 11 13 14 19]
+     [ 8  9 17 21 24]
+     [ 0  4 10 12 23]
+     [ 1  5 15 16 20]
+     [ 2  6  7 18 22]]
+    """
+    # lifted from numpy#6078
+    a = np.asarray(a)
+    ind = list(np.ix_(*[np.arange(d) for d in a.shape]))
+    ind[axis] = a.argsort(axis)
+    return tuple(ind)

--- a/scipy/integrate/quadrature.py
+++ b/scipy/integrate/quadrature.py
@@ -316,7 +316,11 @@ def _basic_simps(y, start, stop, x, dx, axis):
         # Account for possibly different spacings.
         #    Simpson's rule changes a bit.
 
-        # x, y might not be sorted
+        # x, y might not be sorted, so sort them.
+        # first we need to broadcast because _argsort_indices won't work if
+        # x and y don't have the same shape
+        x, y = np.broadcast_arrays(x, y)
+
         indices = _argsort_indices(x, axis=axis)
         x = x[indices]
         y = y[indices]

--- a/scipy/integrate/quadrature.py
+++ b/scipy/integrate/quadrature.py
@@ -10,6 +10,7 @@ from numpy import trapz
 from scipy.special import roots_legendre
 from scipy.special import gammaln
 from scipy._lib.six import xrange
+from scipy._lib._util import _argsort_indices
 
 __all__ = ['fixed_quad', 'quadrature', 'romberg', 'trapz', 'simps', 'romb',
            'cumtrapz', 'newton_cotes']
@@ -314,7 +315,13 @@ def _basic_simps(y, start, stop, x, dx, axis):
     else:
         # Account for possibly different spacings.
         #    Simpson's rule changes a bit.
-        h = np.diff(x, axis=axis)
+
+        # x, y might not be sorted
+        indices = _argsort_indices(x, axis=axis)
+        x_sorted = x[indices]
+        y_sorted = y[indices]
+
+        h = np.diff(x_sorted, axis=axis)
         sl0 = tupleset(slice_all, axis, slice(start, stop, step))
         sl1 = tupleset(slice_all, axis, slice(start+1, stop+1, step))
         h0 = h[sl0]
@@ -322,9 +329,9 @@ def _basic_simps(y, start, stop, x, dx, axis):
         hsum = h0 + h1
         hprod = h0 * h1
         h0divh1 = h0 / h1
-        tmp = hsum/6.0 * (y[slice0]*(2-1.0/h0divh1) +
-                          y[slice1]*hsum*hsum/hprod +
-                          y[slice2]*(2-h0divh1))
+        tmp = hsum/6.0 * (y_sorted[slice0]*(2-1.0/h0divh1) +
+                          y_sorted[slice1]*hsum*hsum/hprod +
+                          y_sorted[slice2]*(2-h0divh1))
         result = np.sum(tmp, axis=axis)
     return result
 

--- a/scipy/integrate/quadrature.py
+++ b/scipy/integrate/quadrature.py
@@ -318,10 +318,10 @@ def _basic_simps(y, start, stop, x, dx, axis):
 
         # x, y might not be sorted
         indices = _argsort_indices(x, axis=axis)
-        x_sorted = x[indices]
-        y_sorted = y[indices]
+        x = x[indices]
+        y = y[indices]
 
-        h = np.diff(x_sorted, axis=axis)
+        h = np.diff(x, axis=axis)
         sl0 = tupleset(slice_all, axis, slice(start, stop, step))
         sl1 = tupleset(slice_all, axis, slice(start+1, stop+1, step))
         h0 = h[sl0]
@@ -329,9 +329,9 @@ def _basic_simps(y, start, stop, x, dx, axis):
         hsum = h0 + h1
         hprod = h0 * h1
         h0divh1 = h0 / h1
-        tmp = hsum/6.0 * (y_sorted[slice0]*(2-1.0/h0divh1) +
-                          y_sorted[slice1]*hsum*hsum/hprod +
-                          y_sorted[slice2]*(2-h0divh1))
+        tmp = hsum/6.0 * (y[slice0]*(2-1.0/h0divh1) +
+                          y[slice1]*hsum*hsum/hprod +
+                          y[slice2]*(2-h0divh1))
         result = np.sum(tmp, axis=axis)
     return result
 

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -159,9 +159,9 @@ class TestQuadrature(object):
     def test_simps_non_sorted(self):
         # gh8230
         # check that simps works on un-sorted arrays.
-        # v1 = simps([1, 2, 3], [1, 2, 3])
-        # v2 = simps([1, 3, 2], [1, 3, 2])
-        # assert_equal(v2, v1)
+        v1 = simps([1, 2, 3], [1, 2, 3])
+        v2 = simps([1, 3, 2], [1, 3, 2])
+        assert_equal(v2, v1)
 
         a = np.arange(27.).reshape(3, 3, 3)
         b = np.copy(a)

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -170,6 +170,43 @@ class TestQuadrature(object):
         b[:, 2, :] = a[:, 0, :]
         assert_equal(simps(b, b, axis=1), simps(a, a, axis=1))
 
+    def test_ndim(self):
+        x = np.linspace(0, 1, 3)
+        y = np.linspace(0, 2, 8)
+        z = np.linspace(0, 3, 13)
+
+        wx = np.ones_like(x) * (x[1] - x[0])
+        wx[0] /= 2
+        wx[-1] /= 2
+        wy = np.ones_like(y) * (y[1] - y[0])
+        wy[0] /= 2
+        wy[-1] /= 2
+        wz = np.ones_like(z) * (z[1] - z[0])
+        wz[0] /= 2
+        wz[-1] /= 2
+
+        q = x[:, None, None] + y[None,:, None] + z[None, None,:]
+
+        qx = (q * wx[:, None, None]).sum(axis=0)
+        qy = (q * wy[None, :, None]).sum(axis=1)
+        qz = (q * wz[None, None, :]).sum(axis=2)
+
+        # n-d `x`
+        r = simps(q, x=x[:, None, None], axis=0)
+        assert_almost_equal(r, qx)
+        r = simps(q, x=y[None,:, None], axis=1)
+        assert_almost_equal(r, qy)
+        r = simps(q, x=z[None, None,:], axis=2)
+        assert_almost_equal(r, qz)
+
+        # 1-d `x`
+        r = simps(q, x=x, axis=0)
+        assert_almost_equal(r, qx)
+        r = simps(q, x=y, axis=1)
+        assert_almost_equal(r, qy)
+        r = simps(q, x=z, axis=2)
+        assert_almost_equal(r, qz)
+
 
 class TestCumtrapz(object):
     def test_1d(self):

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -156,6 +156,20 @@ class TestQuadrature(object):
         assert_equal(simps(y, x=x, even='first'), 13.75)
         assert_equal(simps(y, x=x, even='last'), 14)
 
+    def test_simps_non_sorted(self):
+        # gh8230
+        # check that simps works on un-sorted arrays.
+        # v1 = simps([1, 2, 3], [1, 2, 3])
+        # v2 = simps([1, 3, 2], [1, 3, 2])
+        # assert_equal(v2, v1)
+
+        a = np.arange(27.).reshape(3, 3, 3)
+        b = np.copy(a)
+        b[:, 0, :] = a[:, 1, :]
+        b[:, 1, :] = a[:, 2, :]
+        b[:, 2, :] = a[:, 0, :]
+        assert_equal(simps(b, b, axis=1), simps(a, a, axis=1))
+
 
 class TestCumtrapz(object):
     def test_1d(self):


### PR DESCRIPTION
Fixes #8230.
- fix works by sorting x, y in `integrate.quadrature._basic_simps`.
- tests on 1 and 3-D arrays
- added utility function, `_lib._util._argsort_indices`, that provides argsort indices for sorting along an arbitrary axis in a multidimensional array.