### PR TITLE
BENCH: bump pinned Cython version

### DIFF
--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -29,7 +29,7 @@
     "matrix": {
         "numpy": ["1.8.2"],
         "Tempita": ["0.5.2"],
-        "Cython": ["0.23.4"],
+        "Cython": ["0.27.3"],
         "pytest": [],
         "six": [],
     },


### PR DESCRIPTION
Building scipy requires Cython>=0.25, so bump the version pinned in the benchmark environments.