### PR TITLE
ENH: odeint: Add the argument 'tfirst' to odeint.

### DIFF
--- a/doc/release/1.1.0-notes.rst
+++ b/doc/release/1.1.0-notes.rst
@@ -25,12 +25,23 @@ This release requires Python 2.7 or 3.4+ and NumPy 1.8.2 or greater.
 New features
 ============
 
+`scipy.integrate` improvements
+------------------------------
+
+The argument ``tfirst`` has been added to the function
+`scipy.integrate.odeint`.  This allows `odeint` to use the same
+user functions as `scipy.integrate.solve_ivp` and `scipy.integrate.ode`
+without the need for wrapping them in a function that swaps the first
+two arguments.
+
+
 `scipy.linalg` improvements
 ----------------------------
 
 The function `scipy.linalg.ldl` has been added for factorization of
 indefinite symmetric/hermitian matrices into triangular and block
 diagonal matrices.
+
 
 `scipy.optimize` improvements
 -----------------------------

--- a/scipy/integrate/odepack.py
+++ b/scipy/integrate/odepack.py
@@ -77,6 +77,8 @@ def odeint(func, y0, t, args=(), Dfun=None, col_deriv=0, full_output=0,
         If True, the first two arguments of `func` (and `Dfun`, if given)
         must ``t, y`` instead of the default ``y, t``.
 
+        .. versionadded:: 1.1.0
+
     Returns
     -------
     y : array, shape (len(t), len(y0))

--- a/scipy/integrate/odepack.py
+++ b/scipy/integrate/odepack.py
@@ -154,6 +154,7 @@ def odeint(func, y0, t, args=(), Dfun=None, col_deriv=0, full_output=0,
 
     See Also
     --------
+    solve_ivp : Solve an initial value problem for a system of ODEs.
     ode : a more object-oriented integrator based on VODE.
     quad : for finding the area under a curve.
 
@@ -187,12 +188,12 @@ def odeint(func, y0, t, args=(), Dfun=None, col_deriv=0, full_output=0,
     >>> c = 5.0
 
     For initial conditions, we assume the pendulum is nearly vertical
-    with `theta(0)` = `pi` - 0.1, and it initially at rest, so
+    with `theta(0)` = `pi` - 0.1, and is initially at rest, so
     `omega(0)` = 0.  Then the vector of initial conditions is
 
     >>> y0 = [np.pi - 0.1, 0.0]
 
-    We generate a solution 101 evenly spaced samples in the interval
+    We will generate a solution at 101 evenly spaced samples in the interval
     0 <= `t` <= 10.  So our array of times is:
 
     >>> t = np.linspace(0, 10, 101)

--- a/scipy/integrate/odepack.py
+++ b/scipy/integrate/odepack.py
@@ -25,7 +25,7 @@ _msgs = {2: "Integration successful.",
 def odeint(func, y0, t, args=(), Dfun=None, col_deriv=0, full_output=0,
            ml=None, mu=None, rtol=None, atol=None, tcrit=None, h0=0.0,
            hmax=0.0, hmin=0.0, ixpr=0, mxstep=0, mxhnil=0, mxordn=12,
-           mxords=5, printmessg=0):
+           mxords=5, printmessg=0, tfirst=False):
     """
     Integrate a system of ordinary differential equations.
     
@@ -38,18 +38,23 @@ def odeint(func, y0, t, args=(), Dfun=None, col_deriv=0, full_output=0,
     Solves the initial value problem for stiff or non-stiff systems
     of first order ode-s::
 
-        dy/dt = func(y, t, ...)
+        dy/dt = func(y, t, ...)  [or func(t, y, ...)]
 
     where y can be a vector.
 
-    .. note:: The first two arguments of ``func(y, t, ...)`` are in the
-              opposite order of the arguments in the system definition
-              function used by the `scipy.integrate.ode` class.
+    .. note:: By default, the required order of the first two arguments of
+              `func` are in the opposite order of the arguments in the system
+              definition function used by the `scipy.integrate.ode` class and
+              the function `scipy.integrate.solve_ivp`.  To use a function with
+              the signature ``func(t, y, ...)``, the argument `tfirst` must be
+              set to ``True``.
 
     Parameters
     ----------
-    func : callable(y, t, ...)
+    func : callable(y, t, ...) or callable(t, y, ...)
         Computes the derivative of y at t.
+        If the signature is ``callable(t, y, ...)``, then the argument
+        `tfirst` must be set ``True``.
     y0 : array
         Initial condition on y (can be a vector).
     t : array
@@ -57,8 +62,10 @@ def odeint(func, y0, t, args=(), Dfun=None, col_deriv=0, full_output=0,
         value point should be the first element of this sequence.
     args : tuple, optional
         Extra arguments to pass to function.
-    Dfun : callable(y, t, ...)
+    Dfun : callable(y, t, ...) or callable(t, y, ...)
         Gradient (Jacobian) of `func`.
+        If the signature is ``callable(t, y, ...)``, then the argument
+        `tfirst` must be set ``True``.
     col_deriv : bool, optional
         True if `Dfun` defines derivatives down columns (faster),
         otherwise `Dfun` should define derivatives across rows.
@@ -66,6 +73,9 @@ def odeint(func, y0, t, args=(), Dfun=None, col_deriv=0, full_output=0,
         True if to return a dictionary of optional outputs as the second output
     printmessg : bool, optional
         Whether to print the convergence message
+    tfirst: bool, optional
+        If True, the first two arguments of `func` (and `Dfun`, if given)
+        must ``t, y`` instead of the default ``y, t``.
 
     Returns
     -------
@@ -215,7 +225,8 @@ def odeint(func, y0, t, args=(), Dfun=None, col_deriv=0, full_output=0,
     y0 = copy(y0)
     output = _odepack.odeint(func, y0, t, args, Dfun, col_deriv, ml, mu,
                              full_output, rtol, atol, tcrit, h0, hmax, hmin,
-                             ixpr, mxstep, mxhnil, mxordn, mxords)
+                             ixpr, mxstep, mxhnil, mxordn, mxords,
+                             int(bool(tfirst)))
     if output[-1] < 0:
         warning_msg = _msgs[output[-1]] + " Run with full_output = 1 to get quantitative information."
         warnings.warn(warning_msg, ODEintWarning)


### PR DESCRIPTION
When odeint is called with the argument 'tfirst=True', the first two
arguments of 'func' and 'Dfun' must be 't, y' instead of the default
'y, t'.  This allows users to write their functions once and use them with
`ode`, `solve_ivp` and `odeint` without having to create a wrapper to swap
the first arguments.