### PR TITLE
Increase max number of NNLS iterations

### DIFF
--- a/scipy/optimize/nnls/nnls.f
+++ b/scipy/optimize/nnls/nnls.f
@@ -44,7 +44,7 @@ C             MEANINGS.
 C             1     THE SOLUTION HAS BEEN COMPUTED SUCCESSFULLY.
 C             2     THE DIMENSIONS OF THE PROBLEM ARE BAD.  
 C                   EITHER M .LE. 0 OR N .LE. 0.
-C             3    ITERATION COUNT EXCEEDED.  MORE THAN 3*N ITERATIONS. 
+C             3    ITERATION COUNT EXCEEDED.  MORE THAN 30*N ITERATIONS. 
 C   
 C     ------------------------------------------------------------------
       SUBROUTINE NNLS (A,MDA,M,N,B,X,RNORM,W,ZZ,INDEX,MODE) 
@@ -67,7 +67,7 @@ C     ------------------------------------------------------------------
          RETURN
       endif
       ITER=0
-      ITMAX=3*N 
+      ITMAX=30*N 
 C   
 C                    INITIALIZE THE ARRAYS INDEX() AND X(). 
 C   


### PR DESCRIPTION
The default maximum number of iterations in NNLS is `ITMAX=3*N`, but this number can be too stringent. Ideally one would want to include `itmax` as an optional keyword to `optimize.nnls` (see #4161). But a quick fix is to simply increase the maximum number of iterations.