### PR TITLE
ENH: add a maxiter argument to NNLS

### DIFF
--- a/scipy/optimize/nnls.py
+++ b/scipy/optimize/nnls.py
@@ -6,7 +6,7 @@ from numpy import asarray_chkfinite, zeros, double
 __all__ = ['nnls']
 
 
-def nnls(A, b):
+def nnls(A, b, maxiter=None):
     """
     Solve ``argmin_x || Ax - b ||_2`` for ``x>=0``. This is a wrapper
     for a FORTRAN non-negative least squares solver.
@@ -17,6 +17,9 @@ def nnls(A, b):
         Matrix ``A`` as shown above.
     b : ndarray
         Right-hand side vector.
+    maxiter: int, optional
+        Maximum number of iterations, optional.
+        Default is ``3 * A.shape[1]``.
 
     Returns
     -------
@@ -49,11 +52,13 @@ def nnls(A, b):
     if m != b.shape[0]:
         raise ValueError("incompatible dimensions")
 
+    maxiter = -1 if maxiter is None else int(maxiter)
+
     w = zeros((n,), dtype=double)
     zz = zeros((m,), dtype=double)
     index = zeros((n,), dtype=int)
 
-    x, rnorm, mode = _nnls.nnls(A, m, n, b, w, zz, index)
+    x, rnorm, mode = _nnls.nnls(A, m, n, b, w, zz, index, maxiter)
     if mode != 1:
         raise RuntimeError("too many iterations")
 

--- a/scipy/optimize/nnls/nnls.f
+++ b/scipy/optimize/nnls/nnls.f
@@ -1,4 +1,4 @@
-C     SUBROUTINE NNLS  (A,MDA,M,N,B,X,RNORM,W,ZZ,INDEX,MODE)
+C     SUBROUTINE NNLS  (A,MDA,M,N,B,X,RNORM,W,ZZ,INDEX,MODE,MAXITER)
 C   
 C  Algorithm NNLS: NONNEGATIVE LEAST SQUARES
 C   
@@ -44,13 +44,16 @@ C             MEANINGS.
 C             1     THE SOLUTION HAS BEEN COMPUTED SUCCESSFULLY.
 C             2     THE DIMENSIONS OF THE PROBLEM ARE BAD.  
 C                   EITHER M .LE. 0 OR N .LE. 0.
-C             3    ITERATION COUNT EXCEEDED.  MORE THAN 3*N ITERATIONS. 
+C             3    ITERATION COUNT EXCEEDED.  MORE THAN MAXITER ITERATIONS.
+C     MAXITER THE MAXIMUM ALLOWED NUMBER OF ITERATIONS.
+C             IF NEGATIVE, THE LIMIT IS TAKEN AS THE DEFAULT, 3*N.              
 C   
 C     ------------------------------------------------------------------
-      SUBROUTINE NNLS (A,MDA,M,N,B,X,RNORM,W,ZZ,INDEX,MODE) 
+      SUBROUTINE NNLS (A,MDA,M,N,B,X,RNORM,W,ZZ,INDEX,MODE,MAXITER) 
 C     ------------------------------------------------------------------
       integer I, II, IP, ITER, ITMAX, IZ, IZ1, IZ2, IZMAX, J, JJ, JZ, L
       integer M, MDA, MODE,N, NPP1, NSETP, RTNKEY
+      integer MAXITER
 c     integer INDEX(N)  
 c     double precision A(MDA,N), B(M), W(N), X(N), ZZ(M)   
       integer INDEX(*)  
@@ -67,7 +70,11 @@ C     ------------------------------------------------------------------
          RETURN
       endif
       ITER=0
-      ITMAX=3*N 
+      IF (MAXITER .le. 0) then
+          ITMAX=3*N 
+      ELSE
+          ITMAX = MAXITER
+      ENDIF
 C   
 C                    INITIALIZE THE ARRAYS INDEX() AND X(). 
 C   

--- a/scipy/optimize/nnls/nnls.pyf
+++ b/scipy/optimize/nnls/nnls.pyf
@@ -3,7 +3,7 @@
 
 python module _nnls ! in 
     interface  ! in :_nnls
-        subroutine nnls(a,mda,m,n,b,x,rnorm,w,zz,index_bn,mode) ! in :nnls:NNLS.F
+        subroutine nnls(a,mda,m,n,b,x,rnorm,w,zz,index_bn,mode,maxiter) ! in :nnls:NNLS.F
             double precision dimension(mda,*), intent(copy) :: a
             integer optional,check(shape(a,0)==mda),depend(a) :: mda=shape(a,0)
             integer :: m
@@ -15,6 +15,7 @@ python module _nnls ! in
             double precision dimension(*) :: zz
             integer dimension(*) :: index_bn
             integer , intent(out):: mode
+            integer :: maxiter
         end subroutine nnls
 end python module _nnls
 

--- a/scipy/optimize/tests/test_nnls.py
+++ b/scipy/optimize/tests/test_nnls.py
@@ -4,7 +4,10 @@ Sep 2008
 """
 from __future__ import division, print_function, absolute_import
 
+import numpy as np
+
 from numpy.testing import assert_
+from pytest import raises as assert_raises
 
 from scipy.optimize import nnls
 from numpy import arange, dot
@@ -20,3 +23,14 @@ class TestNNLS(object):
         x, res = nnls(a,y)
         assert_(res < 1e-7)
         assert_(norm(dot(a,x)-y) < 1e-7)
+
+    def test_maxiter(self):
+        # test that maxiter argument does stop iterations
+        # NB: did not manage to find a test case where the default value
+        # of maxiter is not sufficient, so use a too-small value
+        rndm = np.random.RandomState(1234)
+        a = rndm.uniform(size=(100, 100))
+        b = rndm.uniform(size=100)
+        with assert_raises(RuntimeError):
+            nnls(a, b, maxiter=1)
+


### PR DESCRIPTION
As an alternative to https://github.com/scipy/scipy/pull/8323, this adds an optional `maxiter` argument to `nnls`.

closes https://github.com/scipy/scipy/issues/4161