### PR TITLE
TST: stats: don't use exact equality check for hdmedian test

### DIFF
--- a/scipy/stats/tests/test_mstats_extras.py
+++ b/scipy/stats/tests/test_mstats_extras.py
@@ -20,10 +20,10 @@ def test_compare_medians_ms():
 def test_hdmedian():
     # 1-D array
     x = ma.arange(11)
-    assert_equal(ms.hdmedian(x), 5)
+    assert_allclose(ms.hdmedian(x), 5, rtol=1e-14)
     x.mask = ma.make_mask(x)
     x.mask[:7] = False
-    assert_equal(ms.hdmedian(x), 3)
+    assert_allclose(ms.hdmedian(x), 3, rtol=1e-14)
 
     # Check that `var` keyword returns a value.  TODO: check whether returned
     # value is actually correct.


### PR DESCRIPTION
The test uses floating-point arithmetic, so better allow for rounding error.

Travis shows some spurious test failures on OSX on some runs, and this will hopefully eliminate them.