### PR TITLE
ENH: Add _argmaxima1d for maxima detection in 1D arrays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,6 +185,7 @@ scipy/optimize/nnls/_nnlsmodule.c
 scipy/optimize/slsqp/_slsqpmodule.c
 scipy/optimize/_lsq/givens_elimination.c
 scipy/optimize/_trlib/_trlib.c
+scipy/signal/_peak_finding_utils.c
 scipy/signal/_spectral.c
 scipy/signal/_max_len_seq_inner.c
 scipy/signal/_upfirdn_apply.c

--- a/scipy/signal/_peak_finding_utils.pyx
+++ b/scipy/signal/_peak_finding_utils.pyx
@@ -1,0 +1,72 @@
+"""
+Utility functions for finding peaks in signals.
+"""
+
+import numpy as np
+cimport numpy as np
+import cython
+
+
+__all__ = ['_argmaxima1d']
+
+
+@cython.wraparound(False)
+@cython.boundscheck(False)
+def _argmaxima1d(np.ndarray[np.float64_t, ndim=1] x not None):
+    """
+    Find indices of local maxima in a 1D array.
+
+    This function finds all local maxima in a 1D array and returns their
+    indices. For maxima who are wider than one sample the index of the center
+    sample is returned (rounded down in case the number of samples is even).
+
+    Parameters
+    ----------
+    x : ndarray
+        The array to search for local maxima.
+
+    Returns
+    -------
+    maxima : ndarray
+        Indices of local maxima in `x`.
+
+    See Also
+    --------
+    argrelmax
+
+    Notes
+    -----
+    A maxima is defined as one or more samples of equal value that are
+    surrounded on both sides by atleast one smaller sample.
+
+    .. versionadded:: 1.1.0
+    """
+    # Preallocate, there can't be more maxima than half the size of `x`
+    cdef np.ndarray[np.int64_t, ndim=1] maxima
+    maxima = np.empty(x.shape[0] // 2, dtype=np.int64)
+    cdef Py_ssize_t m = 0  # Pointer to the end of valid area in `maxima`
+
+    # Variables to loop over `x`
+    cdef Py_ssize_t i = 1  # Pointer to curent sample, first one can't be maxima
+    cdef Py_ssize_t i_max = x.shape[0] - 1  # Last sample can't be maxima
+    cdef Py_ssize_t i_ahead  # Pointer to look ahead of current sample
+
+    while i < i_max:
+        # Test if previous sample is smaller
+        if x[i - 1] < x[i]:
+            i_ahead = i + 1
+
+            # Find next sample that is unequal to x[i]
+            while i_ahead < i_max and x[i_ahead] == x[i]:
+                i_ahead += 1
+
+            # Maxima is found if next unequal sample is smaller than x[i]
+            if x[i_ahead] < x[i]:
+                # Store sample in the center of flat area (round down)
+                maxima[m] = (i + i_ahead - 1) // 2
+                m += 1
+                # Skip samples that can't be maxima
+                i = i_ahead
+        i += 1
+
+    return maxima[:m]  # Return only valid part of array

--- a/scipy/signal/_peak_finding_utils.pyx
+++ b/scipy/signal/_peak_finding_utils.pyx
@@ -12,7 +12,7 @@ __all__ = ['_argmaxima1d']
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def _argmaxima1d(np.ndarray[np.float64_t, ndim=1] x not None):
+def _argmaxima1d(np.float64_t[:] x not None):
     """
     Find indices of local maxima in a 1D array.
 
@@ -36,8 +36,11 @@ def _argmaxima1d(np.ndarray[np.float64_t, ndim=1] x not None):
 
     Notes
     -----
-    A maxima is defined as one or more samples of equal value that are
-    surrounded on both sides by atleast one smaller sample.
+    - Compared to `argrelmax` this function is significantly faster and can
+      detect maxima that are more than one sample wide. However this comes at
+      the cost of beeing only applicable to 1D arrays.
+    - A maxima is defined as one or more samples of equal value that are
+      surrounded on both sides by atleast one smaller sample.
 
     .. versionadded:: 1.1.0
     """

--- a/scipy/signal/bento.info
+++ b/scipy/signal/bento.info
@@ -12,6 +12,8 @@ Library:
         Sources: _spectral.c
     Extension: _max_len_seq_inner
         Sources: _max_len_seq_inner.c
+    Extension: _peak_finding_utils
+        Sources: _peak_finding_utils.c
     Extension: _upfirdn_apply
         Sources: _upfirdn_apply.c
     Extension: spline

--- a/scipy/signal/setup.py
+++ b/scipy/signal/setup.py
@@ -22,6 +22,8 @@ def configuration(parent_package='', top_path=None):
 
     config.add_extension('_spectral', sources=['_spectral.c'])
     config.add_extension('_max_len_seq_inner', sources=['_max_len_seq_inner.c'])
+    config.add_extension('_peak_finding_utils',
+                         sources=['_peak_finding_utils.c'])
     config.add_extension('_upfirdn_apply', sources=['_upfirdn_apply.c'])
     spline_src = ['splinemodule.c', 'S_bspline_util.c', 'D_bspline_util.c',
                   'C_bspline_util.c', 'Z_bspline_util.c', 'bspline_util.c']

--- a/scipy/signal/tests/test_peak_finding.py
+++ b/scipy/signal/tests/test_peak_finding.py
@@ -73,7 +73,7 @@ def _gen_ridge_line(start_locs, max_locs, length, distances, gaps):
     return [locs[:, 0], locs[:, 1]]
 
 
-class TestArgMaxma1d(object):
+class TestArgmaxima1d(object):
 
     def test_empty(self):
         """Test with empty signal."""
@@ -109,9 +109,11 @@ class TestArgMaxma1d(object):
         """Test input validation and raised exceptions."""
         with raises(ValueError, match="wrong number of dimensions"):
             _argmaxima1d(np.ones((1, 1)))
-        with raises(ValueError, match="expected 'float64_t' but got 'long'"):
+        with raises(ValueError, match="expected 'float64_t'"):
             _argmaxima1d(np.ones(1, dtype=int))
-        with raises(TypeError, match="expected numpy.ndarray, got NoneType"):
+        with raises(TypeError, match="a bytes-like object is required"):
+            _argmaxima1d([1., 2.])
+        with raises(TypeError, match="'x' must not be None"):
             _argmaxima1d(None)
 
 

--- a/scipy/signal/tests/test_peak_finding.py
+++ b/scipy/signal/tests/test_peak_finding.py
@@ -2,12 +2,15 @@ from __future__ import division, print_function, absolute_import
 
 import copy
 
+from pytest import raises
+
 import numpy as np
-from numpy.testing import (assert_equal,
-    assert_array_equal, assert_)
+from numpy.testing import assert_equal, assert_array_equal, assert_
+
+from scipy._lib.six import xrange
 from scipy.signal._peak_finding import (argrelmax, argrelmin,
     find_peaks_cwt, _identify_ridge_lines)
-from scipy._lib.six import xrange
+from scipy.signal._peak_finding_utils import _argmaxima1d
 
 
 def _gen_gaussians(center_locs, sigmas, total_length):
@@ -68,6 +71,48 @@ def _gen_ridge_line(start_locs, max_locs, length, distances, gaps):
         locs[ind, :] = [nextrow, nextcol]
 
     return [locs[:, 0], locs[:, 1]]
+
+
+class TestArgMaxma1d(object):
+
+    def test_empty(self):
+        """Test with empty signal."""
+        x = np.array([], dtype=np.float64)
+        assert_equal(_argmaxima1d(x), np.array([]))
+
+    def test_linear(self):
+        """Test with linear signal."""
+        x = np.linspace(0, 100)
+        assert_equal(_argmaxima1d(x), np.array([]))
+
+    def test_simple(self):
+        """Test with simple signal."""
+        x = np.linspace(-10, 10, 50)
+        x[2::3] += 1
+        assert_equal(_argmaxima1d(x), np.arange(2, 50, 3))
+
+    def test_flat_maxima(self):
+        """Test if flat maxima are detected correctly."""
+        x = np.array([-1.3, 0, 1, 0, 2, 2, 0, 3, 3, 3, 0, 4, 4, 4, 4, 0, 5])
+        assert_equal(_argmaxima1d(x), np.array([2, 4, 8, 12]))
+
+    def test_signal_edges(self):
+        """Test if correct behavior on signal edges."""
+        x1 = np.array([1., 0, 2])
+        assert_equal(_argmaxima1d(x1), np.array([]))
+        x2 = np.array([3., 3, 0, 4, 4])
+        assert_equal(_argmaxima1d(x2), np.array([]))
+        x3 = np.array([5., 5, 5, 0, 6, 6, 6])
+        assert_equal(_argmaxima1d(x3), np.array([]))
+
+    def test_exceptions(self):
+        """Test input validation and raised exceptions."""
+        with raises(ValueError, match="wrong number of dimensions"):
+            _argmaxima1d(np.ones((1, 1)))
+        with raises(ValueError, match="expected 'float64_t' but got 'long'"):
+            _argmaxima1d(np.ones(1, dtype=int))
+        with raises(TypeError, match="expected numpy.ndarray, got NoneType"):
+            _argmaxima1d(None)
 
 
 class TestRidgeLines(object):

--- a/scipy/signal/tests/test_peak_finding.py
+++ b/scipy/signal/tests/test_peak_finding.py
@@ -111,7 +111,7 @@ class TestArgmaxima1d(object):
             _argmaxima1d(np.ones((1, 1)))
         with raises(ValueError, match="expected 'float64_t'"):
             _argmaxima1d(np.ones(1, dtype=int))
-        with raises(TypeError, match="a bytes-like object is required"):
+        with raises(TypeError, match="list"):
             _argmaxima1d([1., 2.])
         with raises(TypeError, match="'x' must not be None"):
             _argmaxima1d(None)


### PR DESCRIPTION
This new Cython function is intended to be wrapped by a peak finding function proposed in #8264. It finds all local maxima in a 1D array. 

### Motivation

There already exists a similar function in SciPy: [scipy.signal.argrelmax](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.argrelmax.html). However  it has the following disadvantages compared to the proposed function:

* It can't detect flat maxima (more than one sample wide).
* it is "relatively" slow compared to this Cython implementation 

Please see this [comparison](http://nbviewer.jupyter.org/urls/gitlab.com/snippets/1696398/raw) for a demonstration of these points.

### Summary of changes

* Added `_peak_finding_utils.pyx` with the new function `_argmaxima1d`
* Added appropriate unit tests in `test_peak_finding.py`.
* Added instruction to compile new extension in appropriate files.
* Added generated c-file to gitignore.

### To do & open questions

* <strike>The current version requires the input array to have the dtype `np.float64` and requires conversion if it is used with other dtypes such as (unsigned) integers. Using Cythons `ctypedef fused` statement this function could be made more flexible at the cost of an increased binary. What is the preferred behavior here?</strike>

### Related discussions & links

* Pull Request #8264.
* [Performance comparison](http://nbviewer.jupyter.org/urls/gitlab.com/snippets/1696398/raw) with `scipy.signal.argrelmax`
* Related [discussion](https://mail.python.org/pipermail/scipy-dev/2018-January/022405.html) on SciPy-Dev mailing list

--

Thank you all in advance for taking the time to review this PR and any feedback given.