### PR TITLE
ENH: Add hyperbolic squared secant distribution - stats.hypsecant2

### DIFF
--- a/doc/source/tutorial/stats.rst
+++ b/doc/source/tutorial/stats.rst
@@ -102,7 +102,7 @@ introspection:
     >>> dist_discrete = [d for d in dir(stats) if
     ...                  isinstance(getattr(stats, d), stats.rv_discrete)]
     >>> print('number of continuous distributions: %d' % len(dist_continu))
-    number of continuous distributions: 97
+    number of continuous distributions: 98
     >>> print('number of discrete distributions:   %d' % len(dist_discrete))
     number of discrete distributions:   13
 

--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -70,6 +70,7 @@ Continuous distributions
    halfnorm          -- Half Normal
    halfgennorm       -- Generalized Half Normal
    hypsecant         -- Hyperbolic Secant
+   hypsecant2        -- Hyperbolic Squared Secant
    invgamma          -- Inverse Gamma
    invgauss          -- Inverse Gaussian
    invweibull        -- Inverse Weibull

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -2919,6 +2919,32 @@ class hypsecant_gen(rv_continuous):
 hypsecant = hypsecant_gen(name='hypsecant')
 
 
+class hypsecant2_gen(rv_continuous):
+    r"""A hyperbolic squared secant continuous random variable.
+
+    %(before_notes)s
+
+    Notes
+    -----
+    The probability density function for `hypsecant2` is:
+
+    .. math::
+
+        f(x) = \frac{\pi}{4\sqrt(3)} sech^(2)(\pi*x/2/\sqrt(3))
+
+    %(after_notes)s
+
+    %(example)s
+
+    """
+    def _pdf(self, x):
+        return np.pi/4./np.sqrt(3)/np.cosh(np.pi*x/2./np.sqrt(3.))
+
+    def _cdf(self, x):
+        return 0.5*(1 + np.tanh(x*np.pi/2./np.sqrt(3.)))
+hypsecant2 = hypsecant2_gen(name='hypsecant2')
+
+
 class gausshyper_gen(rv_continuous):
     r"""A Gauss hypergeometric continuous random variable.
 

--- a/scipy/stats/_distr_params.py
+++ b/scipy/stats/_distr_params.py
@@ -51,6 +51,7 @@ distcont = [
     ['halflogistic', ()],
     ['halfnorm', ()],
     ['hypsecant', ()],
+    ['hypsecant2', ()],
     ['invgamma', (4.0668996136993067,)],
     ['invgauss', (0.14546264555347513,)],
     ['invweibull', (10.58,)],

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -45,7 +45,8 @@ dists = ['uniform', 'norm', 'lognorm', 'expon', 'beta',
          'genlogistic', 'logistic', 'gumbel_l', 'gumbel_r', 'gompertz',
          'hypsecant', 'laplace', 'reciprocal', 'trapz', 'triang', 'tukeylambda',
          'vonmises', 'vonmises_line', 'pearson3', 'gennorm', 'halfgennorm',
-         'rice', 'kappa4', 'kappa3', 'truncnorm', 'argus', 'crystalball']
+         'rice', 'kappa4', 'kappa3', 'truncnorm', 'argus', 'crystalball',
+         'hypsecant2']
 
 
 def _assert_hasattr(a, b, msg=None):


### PR DESCRIPTION
Adds a secant-squared distribution to `stats`.
The CDF of this distribution (hyperbolic tangent) is frequently used for modelling scattering data (see appendix A in https://doi.org/10.1107/S1600576717013632, eqns 25 and 26).

CDF = 0.5 * {1 + tanh(pi * (x - loc) / 2 / sqrt(3) / scale)}
PDF = (pi / 4 / sqrt(3) / scale) * (cosh(pi * (x - loc) / 2 / sqrt(3) / scale))**-2

I'm guessing the name should be hypsecant2.

From running the tests on my computer it fails `test_cont_basic` at the moment, specifically the `check_cmplx_deriv` part.
