### PR TITLE
DOC: Corrected Documentation Issue #7750 winsorize function

### DIFF
--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -1747,7 +1747,7 @@ def winsorize(a, limits=None, inclusive=(True, True), inplace=False,
         indicate an open interval.
     inclusive : {(True, True) tuple}, optional
         Tuple indicating whether the number of data being masked on each side
-        should be rounded (True) or truncated (False).
+        should be truncated (True) or rounded (False).
     inplace : {False, True}, optional
         Whether to winsorize in place (True) or to use a copy (False)
     axis : {None, int}, optional


### PR DESCRIPTION
Attempt to fix documentation issue: Fixes #7750
According to the behavior of the function and the tests given in scipy/stats/tests/test_mstats_basic.py when the inclusive tuple is True, the number of data being masked on each side gets truncated and when its False, it gets rounded.

I changed the documentation accordingly i.e.

    inclusive : {(True, True) tuple}, optional
    Tuple indicating whether the number of data being masked on each side
    should be truncated (True) or rounded (False).
