### PR TITLE
ENH: stats: Use explicit MLE formulas in lognorm.fit and expon.fit

### DIFF
--- a/scipy/misc/doccer.py
+++ b/scipy/misc/doccer.py
@@ -125,6 +125,50 @@ def inherit_docstring_from(cls):
     return _doc
 
 
+def extend_notes_in_docstring(cls, notes):
+    """
+    This decorator replaces the decorated function's docstring
+    with the docstring from corresponding method in `cls`.
+    It extends the 'Notes' section of that docstring to include
+    the given `notes`.
+    """
+    def _doc(func):
+        cls_docstring = getattr(cls, func.__name__).__doc__
+        end_of_notes = cls_docstring.find('        References\n')
+        if end_of_notes == -1:
+            end_of_notes = cls_docstring.find('        Examples\n')
+            if end_of_notes == -1:
+                end_of_notes = len(cls_docstring)
+        func.__doc__ = (cls_docstring[:end_of_notes] + notes +
+                        cls_docstring[end_of_notes:])
+        return func
+    return _doc
+
+
+def replace_notes_in_docstring(cls, notes):
+    """
+    This decorator replaces the decorated function's docstring
+    with the docstring from corresponding method in `cls`.
+    It replaces the 'Notes' section of that docstring with
+    the given `notes`.
+    """
+    def _doc(func):
+        cls_docstring = getattr(cls, func.__name__).__doc__
+        notes_header = '        Notes\n        -----\n'
+        # XXX The following assumes that there is a Notes section.
+        start_of_notes = cls_docstring.find(notes_header)
+        end_of_notes = cls_docstring.find('        References\n')
+        if end_of_notes == -1:
+            end_of_notes = cls_docstring.find('        Examples\n')
+            if end_of_notes == -1:
+                end_of_notes = len(cls_docstring)
+        func.__doc__ = (cls_docstring[:start_of_notes + len(notes_header)] +
+                        notes +
+                        cls_docstring[end_of_notes:])
+        return func
+    return _doc
+
+
 def indentcount_lines(lines):
     ''' Minimum indent for all lines in line list
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -3686,6 +3686,65 @@ class lognorm_gen(rv_continuous):
 
     def _entropy(self, s):
         return 0.5 * (1 + np.log(2*np.pi) + 2 * np.log(s))
+
+    @inherit_docstring_from(rv_continuous)
+    def fit(self, data, *args, **kwds):
+        floc = kwds.get('floc', None)
+        if floc is None:
+            # loc is not fixed.  Use the default fit method.
+            return super(lognorm_gen, self).fit(data, *args, **kwds)
+
+        f0 = (kwds.get('f0', None) or kwds.get('fs', None) or
+              kwds.get('fix_s', None))
+        fscale = kwds.get('fscale', None)
+
+        if len(args) > 1:
+            raise TypeError("Too many input arguments.")
+        for name in ['f0', 'fs', 'fix_s', 'floc', 'fscale', 'loc', 'scale',
+                     'optimizer']:
+            kwds.pop(name, None)
+        if kwds:
+            raise TypeError("Unknown arguments: %s." % kwds)
+
+        # Special case: loc is fixed.  Use the maximum likelihood formulas
+        # instead of the numerical solver.
+
+        if f0 is not None and fscale is not None:
+            # This check is for consistency with `rv_continuous.fit`.
+            raise ValueError("All parameters fixed. There is nothing to "
+                             "optimize.")
+
+        data = np.asarray(data)
+        floc = float(floc)
+        if floc != 0:
+            # Shifting the data by floc. Don't do the subtraction in-place,
+            # because `data` might be a view of the input array.
+            data = data - floc
+        if np.any(data <= 0):
+            raise FitDataError("lognorm", lower=floc, upper=np.inf)
+        lndata = np.log(data)
+
+        # Three cases to handle:
+        # * shape and scale both free
+        # * shape fixed, scale free
+        # * shape free, scale fixed
+
+        if fscale is None:
+            # scale is free.
+            scale = np.exp(lndata.mean())
+            if f0 is None:
+                # shape is free.
+                shape = lndata.std()
+            else:
+                # shape is fixed.
+                shape = float(f0)
+        else:
+            # scale is fixed, shape is free
+            scale = float(fscale)
+            shape = np.sqrt(((lndata - np.log(scale))**2).mean())
+
+        return shape, floc, scale
+
 lognorm = lognorm_gen(a=0.0, name='lognorm')
 
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -8,7 +8,8 @@ import warnings
 
 import numpy as np
 
-from scipy.misc.doccer import inherit_docstring_from
+from scipy.misc.doccer import (extend_notes_in_docstring,
+                               replace_notes_in_docstring)
 from scipy import optimize
 from scipy import integrate
 import scipy.special as sc
@@ -164,13 +165,11 @@ class norm_gen(rv_continuous):
     def _entropy(self):
         return 0.5*(np.log(2*np.pi)+1)
 
-    @inherit_docstring_from(rv_continuous)
+    @replace_notes_in_docstring(rv_continuous, notes="""\
+        This function uses explicit formulas for the maximum likelihood
+        estimation of the normal distribution parameters, so the
+        `optimizer` argument is ignored.\n\n""")
     def fit(self, data, **kwds):
-        """%(super)s
-        This function (norm_gen.fit) uses explicit formulas for the maximum
-        likelihood estimation of the parameters, so the `optimizer` argument
-        is ignored.
-        """
         floc = kwds.get('floc', None)
         fscale = kwds.get('fscale', None)
 
@@ -432,13 +431,11 @@ class beta_gen(rv_continuous):
         a, b = optimize.fsolve(func, (1.0, 1.0))
         return super(beta_gen, self)._fitstart(data, args=(a, b))
 
-    @inherit_docstring_from(rv_continuous)
-    def fit(self, data, *args, **kwds):
-        """%(super)s
+    @extend_notes_in_docstring(rv_continuous, notes="""\
         In the special case where both `floc` and `fscale` are given, a
         `ValueError` is raised if any value `x` in `data` does not satisfy
-        `floc < x < floc + fscale`.
-        """
+        `floc < x < floc + fscale`.\n\n""")
+    def fit(self, data, *args, **kwds):
         # Override rv_continuous.fit, so we can more efficiently handle the
         # case where floc and fscale are given.
 
@@ -1187,13 +1184,11 @@ class expon_gen(rv_continuous):
     def _entropy(self):
         return 1.0
 
-    @inherit_docstring_from(rv_continuous)
+    @replace_notes_in_docstring(rv_continuous, notes="""\
+        This function uses explicit formulas for the maximum likelihood
+        estimation of the exponential distribution parameters, so the
+        `optimizer`, `loc` and `scale` keyword arguments are ignored.\n\n""")
     def fit(self, data, *args, **kwds):
-        """%(super)s
-        This function (expon_gen.fit) uses explicit formulas for the maximum
-        likelihood estimation of the parameters, so the `optimizer`, `loc`
-        and `scale` keyword arguments are ignored.
-        """
         if len(args) > 0:
             raise TypeError("Too many arguments.")
 
@@ -2402,7 +2397,11 @@ class gamma_gen(rv_continuous):
         a = 4 / (1e-8 + _skew(data)**2)
         return super(gamma_gen, self)._fitstart(data, args=(a,))
 
-    @inherit_docstring_from(rv_continuous)
+    @extend_notes_in_docstring(rv_continuous, notes="""\
+        When the location is fixed by using the argument `floc`, this
+        function uses explicit formulas or solves a simpler numerical
+        problem than the full ML optimization problem.  So in that case,
+        the `optimizer`, `loc` and `scale` arguments are ignored.\n\n""")
     def fit(self, data, *args, **kwds):
         f0 = (kwds.get('f0', None) or kwds.get('fa', None) or
               kwds.get('fix_a', None))
@@ -3687,7 +3686,11 @@ class lognorm_gen(rv_continuous):
     def _entropy(self, s):
         return 0.5 * (1 + np.log(2*np.pi) + 2 * np.log(s))
 
-    @inherit_docstring_from(rv_continuous)
+    @extend_notes_in_docstring(rv_continuous, notes="""\
+        When the location parameter is fixed by using the `floc` argument,
+        this function uses explicit formulas for the maximum likelihood
+        estimation of the log-normal shape and scale parameters, so the
+        `optimizer`, `loc` and `scale` keyword arguments are ignored.\n\n""")
     def fit(self, data, *args, **kwds):
         floc = kwds.get('floc', None)
         if floc is None:

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -2138,7 +2138,6 @@ class rv_continuous(rv_generic):
         returned answer is not guaranteed to be the globally optimal MLE, it
         may only be locally optimal, or the optimization may fail altogether.
 
-
         Examples
         --------
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1635,6 +1635,21 @@ class TestFitMethod(object):
         assert_raises(ValueError, stats.beta.fit, y, f0=0, f1=1,
                       floc=2, fscale=3)
 
+    def test_expon_fit(self):
+        x = np.array([2, 2, 4, 4, 4, 4, 4, 8])
+
+        loc, scale = stats.expon.fit(x)
+        assert_equal(loc, 2)    # x.min()
+        assert_equal(scale, 2)  # x.mean() - x.min()
+
+        loc, scale = stats.expon.fit(x, fscale=3)
+        assert_equal(loc, 2)    # x.min()
+        assert_equal(scale, 3)  # fscale
+
+        loc, scale = stats.expon.fit(x, floc=0)
+        assert_equal(loc, 0)    # floc
+        assert_equal(scale, 4)  # x.mean() - loc
+
     def test_fshapes(self):
         # take a beta distribution, with shapes='a, b', and make sure that
         # fa is equivalent to f0, and fb is equivalent to f1


### PR DESCRIPTION
The log-normal and exponential distributions have explicit formulas for the maximum likelihood estimation of their parameters, so let's use them when we can.  These formulas are more accurate and *much* faster than using the default numerical optimization routine.
