### PR TITLE
Remove `ravel()` from `stats.tstd`

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -591,7 +591,7 @@ def tvar(a, limits=None, inclusive=(True, True), axis=0, ddof=1):
 
     """
     a = asarray(a)
-    a = a.astype(float).ravel()
+    a = a.astype(float)
     if limits is None:
         n = len(a)
         return a.var() * n / (n - 1.)


### PR DESCRIPTION
Array should not be flattened, `axis` argument should take care of that.
It is passed to `np.ma.var` which should take care of possible flattening.