### PR TITLE
BUG: Issue #4464 Fixed residuez which failed for Complex Numbers

### DIFF
--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1980,7 +1980,7 @@ def residuez(b, a, tol=1e-3, rtype='avg'):
     r = p * 0.0
     for i in range(len(p)):
         round_p = p[i]*0.0
-        sig_digits=int(math.ceil(-math.log(tol,10)))
+        sig_digits = int(math.ceil(-math.log(tol,10)))
         if iscomplex(p[i]):
             round_p = round_p+round(p[i].real,sig_digits)
             round_p = round_p+round(p[i].imag,sig_digits)*1j

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -14,7 +14,7 @@ from scipy._lib.six import callable
 from scipy._lib._version import NumpyVersion
 from scipy import fftpack, linalg
 from numpy import (allclose, angle, arange, argsort, array, asarray,
-                   atleast_1d, atleast_2d, cast, dot, exp, expand_dims,
+                   atleast_1d, atleast_2d, cast, dot, exp, expand_dims,iscomplex, 
                    iscomplexobj, mean, ndarray, newaxis, ones, pi,
                    poly, polyadd, polyder, polydiv, polymul, polysub, polyval,
                    product, r_, ravel, real_if_close, reshape,
@@ -1978,16 +1978,19 @@ def residuez(b, a, tol=1e-3, rtype='avg'):
     b = brev[::-1]
     p = roots(a)
     r = p * 0.0
-    pout, mult = unique_roots(p, tol=tol, rtype=rtype)
-    p = []
-    for n in range(len(pout)):
-        p.extend([pout[n]] * mult[n])
+    for i in range(len(p)):
+        round_p = p[i]*0.0
+        sig_digits=int(math.ceil(-math.log(tol,10)))
         if iscomplex(p[i]):
             round_p = round_p+round(p[i].real,sig_digits)
             round_p = round_p+round(p[i].imag,sig_digits)*1j
         else:
             round_p = round(p[i],sig_digits)
         p[i] = round_p
+    pout, mult = unique_roots(p, tol=tol, rtype=rtype)
+    p = []
+    for n in range(len(pout)):
+        p.extend([pout[n]] * mult[n])
     p = asarray(p)
     # Compute the residue from the general formula (for discrete-time)
     #  the polynomial is in z**(-1) and the multiplication is by terms

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1982,6 +1982,12 @@ def residuez(b, a, tol=1e-3, rtype='avg'):
     p = []
     for n in range(len(pout)):
         p.extend([pout[n]] * mult[n])
+        if iscomplex(p[i]):
+            round_p = round_p+round(p[i].real,sig_digits)
+            round_p = round_p+round(p[i].imag,sig_digits)*1j
+        else:
+            round_p = round(p[i],sig_digits)
+        p[i] = round_p
     p = asarray(p)
     # Compute the residue from the general formula (for discrete-time)
     #  the polynomial is in z**(-1) and the multiplication is by terms


### PR DESCRIPTION
Fixed the bug in issue #4464 
The function raised a TypeError:
```
TypeError: Cannot cast ufunc subtract output from dtype('complex128') to dtype('float64') with casting rule 'same_kind'
```
To fix it, I fixed the polydiv function in `numpy/lib/polynomial.py`. I created a PR in [numpy repo](https://github.com/numpy/numpy/pull/10473). 
Further, in cases with repeated roots, the obtained roots were of the form 0.9999998 and 1.000001. These were treated as two different roots with multiplicity 1 each. This led to wrong values of the residue. I rounded them off to `-log(tol)` decimal digits i.e. the exponent value of `tol`. This gives the correct answer.