### PR TITLE
BUG: gh7854, maxiter for l-bfgs-b closes #7854

### DIFF
--- a/scipy/optimize/lbfgsb.py
+++ b/scipy/optimize/lbfgsb.py
@@ -335,15 +335,15 @@ def _minimize_lbfgsb(fun, x0, args=(), jac=None, bounds=None,
             f, g = func_and_grad(x)
         elif task_str.startswith(b'NEW_X'):
             # new iteration
-            if n_iterations > maxiter:
-                task[:] = 'STOP: TOTAL NO. of ITERATIONS EXCEEDS LIMIT'
+            n_iterations += 1
+            if callback is not None:
+                callback(x)
+
+            if n_iterations >= maxiter:
+                task[:] = 'STOP: TOTAL NO. of ITERATIONS REACHED LIMIT'
             elif n_function_evals[0] > maxfun:
                 task[:] = ('STOP: TOTAL NO. of f AND g EVALUATIONS '
                            'EXCEEDS LIMIT')
-            else:
-                n_iterations += 1
-                if callback is not None:
-                    callback(x)
         else:
             break
 
@@ -352,7 +352,7 @@ def _minimize_lbfgsb(fun, x0, args=(), jac=None, bounds=None,
         warnflag = 0
     elif n_function_evals[0] > maxfun:
         warnflag = 1
-    elif n_iterations > maxiter:
+    elif n_iterations >= maxiter:
         warnflag = 1
     else:
         warnflag = 2

--- a/scipy/optimize/lbfgsb.py
+++ b/scipy/optimize/lbfgsb.py
@@ -350,9 +350,7 @@ def _minimize_lbfgsb(fun, x0, args=(), jac=None, bounds=None,
     task_str = task.tostring().strip(b'\x00').strip()
     if task_str.startswith(b'CONV'):
         warnflag = 0
-    elif n_function_evals[0] > maxfun:
-        warnflag = 1
-    elif n_iterations >= maxiter:
+    elif n_function_evals[0] > maxfun or n_iterations >= maxiter:
         warnflag = 1
     else:
         warnflag = 2

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -594,6 +594,9 @@ class TestOptimizeSimple(CheckOptimize):
         assert_equal(res.nit, 5)
         assert_almost_equal(res.x, c.x)
         assert_almost_equal(res.fun, c.fun)
+        assert_equal(res.status, 1)
+        assert_(res.success is False)
+        assert_equal(res.message.decode(), 'STOP: TOTAL NO. of ITERATIONS REACHED LIMIT')
 
     def test_minimize_l_bfgs_b(self):
         # Minimize with L-BFGS-B method

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -573,6 +573,28 @@ class TestOptimizeSimple(CheckOptimize):
         assert_allclose(self.func(params), self.func(self.solution),
                         atol=1e-6)
 
+    def test_l_bfgs_b_maxiter(self):
+        # gh7854
+        # Ensure that not more than maxiters are ever run.
+        class Callback(object):
+            def __init__(self):
+                self.nit = 0
+                self.fun = None
+                self.x = None
+
+            def __call__(self, x):
+                self.x = x
+                self.fun = optimize.rosen(x)
+                self.nit += 1
+
+        c = Callback()
+        res = optimize.minimize(optimize.rosen, [0., 0.], method='l-bfgs-b',
+                                callback=c, options={'maxiter': 5})
+
+        assert_equal(res.nit, 5)
+        assert_almost_equal(res.x, c.x)
+        assert_almost_equal(res.fun, c.fun)
+
     def test_minimize_l_bfgs_b(self):
         # Minimize with L-BFGS-B method
         opts = {'disp': False, 'maxiter': self.maxiter}


### PR DESCRIPTION
I think this fixes #7854, with test.
Note: the error message has to change ('STOP: TOTAL NO. of ITERATIONS REACHED LIMIT' from 'STOP: TOTAL NO. of ITERATIONS EXCEEDS LIMIT'), because now we don't exceed `maxiter`. I'm not sure if this is going to break backcompat on downstream projects if they were expecting a certain error message.