### PR TITLE
CI: enable gcov coverage on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
     - python: 3.6
       env:
         - TESTMODE=full
-        - COVERAGE=--coverage
+        - COVERAGE="--coverage --gcov"
         - NUMPYSPEC=numpy
     - python: 3.5
       env:
@@ -168,10 +168,16 @@ script:
 after_success:
   - ccache -s
   # Upload coverage information
-  - if [ "${COVERAGE}" == "--coverage" ]; then
-        pushd build/testenv/lib/python*/site-packages/;
-        codecov;
-        popd;
+  - |
+    if [ -n "${COVERAGE}" ]; then
+        RUN_DIR=`echo build/testenv/lib/python*/site-packages`
+        # Produce gcov output for codecov to find
+        find build -name '*.gcno' -type f -exec gcov -pb {} +
+        mv *.gcov "$RUN_DIR/"
+        # Run codecov
+        pushd "$RUN_DIR"
+        codecov -X gcov
+        popd
     fi
 notifications:
   # Perhaps we should have status emails sent to the mailing list, but

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,7 @@
 codecov:
   notify:
     require_ci_to_pass: no
+    after_n_builds: 1
 coverage:
   status:
     project:


### PR DESCRIPTION
Enable gcov on travis to produce codecov output for C files.

<s>Fortran would in principle be possible, but that looks like it may need some numpy distutils patching to get it to work, so that's for later if at all.</s>