### PR TITLE
TravisCI: tool pep8 is now pycodestyle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,11 @@ matrix:
         - PEP8=1
         - NUMPYSPEC=numpy
       before_install:
-        - pip install pep8==1.7.0
+        - pip install pycodestyle==1.7.0
         - pip install pyflakes==1.1.0
       script:
         - PYFLAKES_NODOCTEST=1 pyflakes scipy benchmarks/benchmarks | grep -E -v 'unable to detect undefined names|assigned to but never used|imported but unused|redefinition of unused|may be undefined, or defined from star imports' > test.out; cat test.out; test \! -s test.out
-        - pep8 scipy benchmarks/benchmarks
+        - pycodestyle scipy benchmarks/benchmarks
     - python: 2.7
       env:
         - TESTMODE=fast

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
         - PEP8=1
         - NUMPYSPEC=numpy
       before_install:
-        - pip install pycodestyle==1.7.0
+        - pip install pycodestyle==2.3.1
         - pip install pyflakes==1.1.0
       script:
         - PYFLAKES_NODOCTEST=1 pyflakes scipy benchmarks/benchmarks | grep -E -v 'unable to detect undefined names|assigned to but never used|imported but unused|redefinition of unused|may be undefined, or defined from star imports' > test.out; cat test.out; test \! -s test.out

--- a/tox.ini
+++ b/tox.ini
@@ -38,8 +38,8 @@ changedir={envdir}
 commands=
     {envpython} {toxinidir}/runtests.py {posargs: --mode full}
 
-[pep8]
+[pycodestyle]
 max_line_length = 79
 statistics = True
-ignore = E121,E122,E123,E125,E126,E127,E128,E226,E231,E251,E265,E266,E302,E402,E501,E712,E721,E731,W291,W293,W391,W503
+ignore = E121,E122,E123,E125,E126,E127,E128,E226,E231,E251,E265,E266,E302,E305,E402,E501,E712,E721,E722,E731,E741,W291,W293,W391,W503
 exclude = scipy/__config__.py


### PR DESCRIPTION
Note: I have left the environment variable as PEP8

This package used to be called pep8 but was renamed to pycodestyle to reduce confusion. Further discussion can be found in the [issue where Guido requested this change](https://github.com/PyCQA/pycodestyle/issues/466), or in the lightning talk at PyCon 2016 by @IanLee1521: [slides](https://speakerdeck.com/ianlee1521/pep8-vs-pep-8) [video](https://youtu.be/PulzIT8KYLk?t=36m).