### PR TITLE
DOC: Replace old type names in ndimage tutorial.

### DIFF
--- a/doc/source/tutorial/ndimage.rst
+++ b/doc/source/tutorial/ndimage.rst
@@ -317,7 +317,7 @@ second derivative along a given direction.
   following signature
 
   .. code:: python
-      
+
      derivative2(input, axis, output, mode, cval, *extra_arguments, **extra_keywords)
 
   It should calculate the second derivative along the dimension
@@ -380,7 +380,7 @@ second derivative function:
 - The function :func:`laplace` calculates the Laplace using discrete
   differentiation for the second derivative (i.e. convolution with
   ``[1, -2, 1]``).
-  
+
 - The function :func:`gaussian_laplace` calculates the Laplace filter
   using :func:`gaussian_filter` to calculate the second
   derivatives. The standard-deviations of the Gaussian filter along
@@ -399,7 +399,7 @@ function that calculats the gradient magnitude of an array.
   :func:`derivative` should have the following signature
 
   .. code:: python
-	    
+
      derivative(input, axis, output, mode, cval, *extra_arguments, **extra_keywords)
 
   It should calculate the derivative along the dimension *axis*. If
@@ -461,7 +461,7 @@ information).
   object). The :func:`generic_filter1d` function iterates over the
   lines of an array and calls :func:`function` at each line. The
   arguments that are passed to :func:`function` are one-dimensional
-  arrays of the :c:type:`tFloat64` type. The first contains the values
+  arrays of the :class:`np.float64` type. The first contains the values
   of the current line.  It is extended at the beginning end the end,
   according to the *filter_size* and *origin* arguments. The second
   array should be modified in-place to provide the output values of
@@ -524,7 +524,7 @@ information).
   python function (or other callable object). The
   :func:`generic_filter` function iterates over the array and calls
   :func:`function` at each element. The argument of :func:`function`
-  is a one-dimensional array of the :c:type:`tFloat64` type, that
+  is a one-dimensional array of the :class:`np.float64` type, that
   contains the values around the current element that are within the
   footprint of the filter. The function should return a single value
   that can be converted to a double precision number. For example
@@ -790,7 +790,7 @@ is used.
   shape and type.
 
   For example:
-  
+
   .. code:: python
 
      >>> a = np.arange(12).reshape(4,3).astype(np.float64)
@@ -832,7 +832,7 @@ is used.
 	    [ 0.    ,  8.2625,  9.6375]])
 
   .. note::
-     
+
      The mapping function can also be written in C and passed using a
      `scipy.LowLevelCallable`. See :ref:`ndimage-ccallbacks` for more
      information.
@@ -1160,7 +1160,7 @@ Euclidean, City Block, and Chessboard distances.
 
   The *distances* and *indices* arguments can be used to give optional
   output arrays that must be of the correct size and type (both
-  :c:type:`Int32`). The basics of the algorithm used to implement this
+  :class:`np.int32`). The basics of the algorithm used to implement this
   function is described in [2]_.
 
 - The function :func:`distance_transform_edt` calculates the exact
@@ -1182,7 +1182,7 @@ Euclidean, City Block, and Chessboard distances.
 
   The *distances* and *indices* arguments can be used to give optional
   output arrays that must be of the correct size and type
-  (:c:type:`Float64` and :c:type:`Int32`).The algorithm used to
+  (:class:`np.float64` and :class:`np.int32`).The algorithm used to
   implement this function is described in [3]_.
 
 - The function :func:`distance_transform_bf` uses a brute-force
@@ -1207,7 +1207,7 @@ Euclidean, City Block, and Chessboard distances.
 
   The *distances* and *indices* arguments can be used to give optional
   output arrays that must be of the correct size and type
-  (:c:type:`Float64` and :c:type:`Int32`).
+  (:class:`np.float64` and :class:`np.int32`).
 
   .. note::
 
@@ -1311,7 +1311,7 @@ for the objects:
 - The :func:`watershed_ift` function applies a watershed from markers
   algorithm, using an Iterative Forest Transform, as described in
   [4]_.
-    
+
 - The inputs of this function are the array to which the transform is
   applied, and an array of markers that designate the objects by a
   unique label, where any non-zero value is a marker. For instance:
@@ -1413,7 +1413,7 @@ for the objects:
   .. note::
 
      The implementation of :func:`watershed_ift` limits the data types
-     of the input to :c:type:`UInt8` and :c:type:`UInt16`.
+     of the input to :class:`np.uint8` and :class:`np.uint16`.
 
 .. _ndimage-object-measurements:
 
@@ -1597,7 +1597,7 @@ lists, if *index* is a sequence.
   ``None``, all elements of *input* are used in the calculation.
   Histograms are defined by their minimum (*min*), maximum (*max*) and
   the number of bins (*bins*). They are returned as one-dimensional
-  arrays of type :c:type:`Int32`.
+  arrays of type :class:`np.int32`.
 
 .. _ndimage-ccallbacks:
 


### PR DESCRIPTION
Closes #6794.