### PR TITLE
ENH: Add `fs=` parameter to filter design functions

### DIFF
--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -365,7 +365,7 @@ def freqz(b, a=1, worN=512, whole=False, plot=None, fs=2*pi):
     >>> import matplotlib.pyplot as plt
     >>> fig = plt.figure()
     >>> plt.title('Digital filter frequency response')
-    >>> ax1 = fig.add_subplot(111)
+    >>> ax1 = fig.add_subplot(1, 1, 1)
 
     >>> plt.plot(w, 20 * np.log10(abs(h)), 'b')
     >>> plt.ylabel('Amplitude [dB]', color='b')
@@ -1998,7 +1998,7 @@ def iirfilter(N, Wn, rp=None, rs=None, btype='band', analog=False,
     ...                         btype='band', analog=True, ftype='cheby2')
     >>> w, h = signal.freqs(b, a, 1000)
     >>> fig = plt.figure()
-    >>> ax = fig.add_subplot(111)
+    >>> ax = fig.add_subplot(1, 1, 1)
     >>> ax.semilogx(w / (2*np.pi), 20 * np.log10(abs(h)))
     >>> ax.set_title('Chebyshev Type II bandpass frequency response')
     >>> ax.set_xlabel('Frequency [Hz]')

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -2489,7 +2489,8 @@ def butter(N, Wn, btype='low', analog=False, output='ba', fs=None):
 
     Examples
     --------
-    Plot the filter's frequency response, showing the critical points:
+    Design an analog filter and plot its frequency response, showing the
+    critical points:
 
     >>> from scipy import signal
     >>> import matplotlib.pyplot as plt
@@ -2505,6 +2506,27 @@ def butter(N, Wn, btype='low', analog=False, output='ba', fs=None):
     >>> plt.axvline(100, color='green') # cutoff frequency
     >>> plt.show()
 
+    Generate a signal made up of 10 Hz and 20 Hz, sampled at 1 kHz
+
+    >>> t = np.linspace(0, 1, 1000)  # 1 second
+    >>> sig = np.sin(2*np.pi*10*t) + np.sin(2*np.pi*20*t)
+    >>> fig, (ax1, ax2) = plt.subplots(2, 1, sharex=True)
+    >>> ax1.plot(t, sig)
+    >>> ax1.set_title('10 Hz and 20 Hz sinusoids')
+    >>> ax1.axis([0, 1, -2, 2])
+
+    Design a digital high-pass filter at 15 Hz to remove the 10 Hz tone, and
+    apply it to the signal.  (It's recommended to use second-order sections
+    format when filtering, to avoid numerical error with transfer function
+    (``ba``) format):
+
+    >>> sos = signal.butter(10, 15, 'hp', fs=1000, output='sos')
+    >>> filtered = signal.sosfilt(sos, sig)
+    >>> ax2.plot(t, filtered)
+    >>> ax2.set_title('After 15 Hz high-pass filter')
+    >>> ax2.axis([0, 1, -2, 2])
+    >>> ax2.set_xlabel('Time [seconds]')
+    >>> plt.show()
     """
     return iirfilter(N, Wn, btype=btype, analog=analog,
                      output=output, ftype='butter', fs=fs)
@@ -2581,7 +2603,8 @@ def cheby1(N, rp, Wn, btype='low', analog=False, output='ba', fs=None):
 
     Examples
     --------
-    Plot the filter's frequency response, showing the critical points:
+    Design an analog filter and plot its frequency response, showing the
+    critical points:
 
     >>> from scipy import signal
     >>> import matplotlib.pyplot as plt
@@ -2598,6 +2621,27 @@ def cheby1(N, rp, Wn, btype='low', analog=False, output='ba', fs=None):
     >>> plt.axhline(-5, color='green') # rp
     >>> plt.show()
 
+    Generate a signal made up of 10 Hz and 20 Hz, sampled at 1 kHz
+
+    >>> t = np.linspace(0, 1, 1000)  # 1 second
+    >>> sig = np.sin(2*np.pi*10*t) + np.sin(2*np.pi*20*t)
+    >>> fig, (ax1, ax2) = plt.subplots(2, 1, sharex=True)
+    >>> ax1.plot(t, sig)
+    >>> ax1.set_title('10 Hz and 20 Hz sinusoids')
+    >>> ax1.axis([0, 1, -2, 2])
+
+    Design a digital high-pass filter at 15 Hz to remove the 10 Hz tone, and
+    apply it to the signal.  (It's recommended to use second-order sections
+    format when filtering, to avoid numerical error with transfer function
+    (``ba``) format):
+
+    >>> sos = signal.cheby1(10, 1, 15, 'hp', fs=1000, output='sos')
+    >>> filtered = signal.sosfilt(sos, sig)
+    >>> ax2.plot(t, filtered)
+    >>> ax2.set_title('After 15 Hz high-pass filter')
+    >>> ax2.axis([0, 1, -2, 2])
+    >>> ax2.set_xlabel('Time [seconds]')
+    >>> plt.show()
     """
     return iirfilter(N, Wn, rp=rp, btype=btype, analog=analog,
                      output=output, ftype='cheby1', fs=fs)
@@ -2669,7 +2713,8 @@ def cheby2(N, rs, Wn, btype='low', analog=False, output='ba', fs=None):
 
     Examples
     --------
-    Plot the filter's frequency response, showing the critical points:
+    Design an analog filter and plot its frequency response, showing the
+    critical points:
 
     >>> from scipy import signal
     >>> import matplotlib.pyplot as plt
@@ -2686,6 +2731,27 @@ def cheby2(N, rs, Wn, btype='low', analog=False, output='ba', fs=None):
     >>> plt.axhline(-40, color='green') # rs
     >>> plt.show()
 
+    Generate a signal made up of 10 Hz and 20 Hz, sampled at 1 kHz
+
+    >>> t = np.linspace(0, 1, 1000)  # 1 second
+    >>> sig = np.sin(2*np.pi*10*t) + np.sin(2*np.pi*20*t)
+    >>> fig, (ax1, ax2) = plt.subplots(2, 1, sharex=True)
+    >>> ax1.plot(t, sig)
+    >>> ax1.set_title('10 Hz and 20 Hz sinusoids')
+    >>> ax1.axis([0, 1, -2, 2])
+
+    Design a digital high-pass filter at 17 Hz to remove the 10 Hz tone, and
+    apply it to the signal.  (It's recommended to use second-order sections
+    format when filtering, to avoid numerical error with transfer function
+    (``ba``) format):
+
+    >>> sos = signal.cheby2(12, 20, 17, 'hp', fs=1000, output='sos')
+    >>> filtered = signal.sosfilt(sos, sig)
+    >>> ax2.plot(t, filtered)
+    >>> ax2.set_title('After 17 Hz high-pass filter')
+    >>> ax2.axis([0, 1, -2, 2])
+    >>> ax2.set_xlabel('Time [seconds]')
+    >>> plt.show()
     """
     return iirfilter(N, Wn, rs=rs, btype=btype, analog=analog,
                      output=output, ftype='cheby2', fs=fs)
@@ -2768,7 +2834,8 @@ def ellip(N, rp, rs, Wn, btype='low', analog=False, output='ba', fs=None):
 
     Examples
     --------
-    Plot the filter's frequency response, showing the critical points:
+    Design an analog filter and plot its frequency response, showing the
+    critical points:
 
     >>> from scipy import signal
     >>> import matplotlib.pyplot as plt
@@ -2786,6 +2853,27 @@ def ellip(N, rp, rs, Wn, btype='low', analog=False, output='ba', fs=None):
     >>> plt.axhline(-5, color='green') # rp
     >>> plt.show()
 
+    Generate a signal made up of 10 Hz and 20 Hz, sampled at 1 kHz
+
+    >>> t = np.linspace(0, 1, 1000)  # 1 second
+    >>> sig = np.sin(2*np.pi*10*t) + np.sin(2*np.pi*20*t)
+    >>> fig, (ax1, ax2) = plt.subplots(2, 1, sharex=True)
+    >>> ax1.plot(t, sig)
+    >>> ax1.set_title('10 Hz and 20 Hz sinusoids')
+    >>> ax1.axis([0, 1, -2, 2])
+
+    Design a digital high-pass filter at 17 Hz to remove the 10 Hz tone, and
+    apply it to the signal.  (It's recommended to use second-order sections
+    format when filtering, to avoid numerical error with transfer function
+    (``ba``) format):
+
+    >>> sos = signal.ellip(8, 1, 100, 17, 'hp', fs=1000, output='sos')
+    >>> filtered = signal.sosfilt(sos, sig)
+    >>> ax2.plot(t, filtered)
+    >>> ax2.set_title('After 17 Hz high-pass filter')
+    >>> ax2.axis([0, 1, -2, 2])
+    >>> ax2.set_xlabel('Time [seconds]')
+    >>> plt.show()
     """
     return iirfilter(N, Wn, rs=rs, rp=rp, btype=btype, analog=analog,
                      output=output, ftype='elliptic', fs=fs)

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -325,8 +325,8 @@ def freqz(b, a=1, worN=512, whole=False, plot=None, fs=2*pi):
     Returns
     -------
     w : ndarray
-        The frequencies at which `h` was computed.  If `fs` is specified,
-        these are in the same units.  Otherwise they are in radians/sample.
+        The frequencies at which `h` was computed, in the same units as `fs`.
+        By default, `w` is normalized to the range [0, pi) (radians/sample).
     h : ndarray
         The frequency response, as complex numbers.
 
@@ -517,10 +517,10 @@ def freqz_zpk(z, p, k, worN=512, whole=False, fs=2*pi):
     Returns
     -------
     w : ndarray
-        The frequencies at which `h` was computed.  If `fs` is specified,
-        these are in the same units.  Otherwise they are in radians/sample.
+        The frequencies at which `h` was computed, in the same units as `fs`.
+        By default, `w` is normalized to the range [0, pi) (radians/sample).
     h : ndarray
-        The frequency response.
+        The frequency response, as complex numbers.
 
     See Also
     --------
@@ -618,9 +618,9 @@ def group_delay(system, w=512, whole=False, fs=2*pi):
     Returns
     -------
     w : ndarray
-        The frequencies at which group delay was computed.  If `fs` is
-        specified, these are in the same units.  Otherwise they are in
-        radians/sample.
+        The frequencies at which group delay was computed, in the same units
+        as `fs`.  By default, `w` is normalized to the range [0, pi)
+        (radians/sample).
     gd : ndarray
         The group delay.
 
@@ -749,8 +749,8 @@ def sosfreqz(sos, worN=512, whole=False, fs=2*pi):
     Returns
     -------
     w : ndarray
-        The frequencies at which `h` was computed.  If `fs` is specified,
-        these are in the same units.  Otherwise they are in radians/sample.
+        The frequencies at which `h` was computed, in the same units as `fs`.
+        By default, `w` is normalized to the range [0, pi) (radians/sample).
     h : ndarray
         The frequency response, as complex numbers.
 

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -293,23 +293,24 @@ def freqz(b, a=1, worN=512, whole=False, plot=None, fs=None):
         If a single integer, then compute at that many frequencies.  This is
         a convenient alternative to::
 
-            np.linspace(0, 2*pi if whole else pi, N, endpoint=False)
+            np.linspace(0, fs if whole else fs/2, N, endpoint=False)
 
         Using a number that is fast for FFT computations can result in
-        faster computations (see Notes).
-        If an array_like, compute the response at the frequencies given.  If
-        `fs` is specified, these are in the same units as `fs`, otherwise,
-        they are in radians/sample.
+        faster computations (see Notes).  If None (default), then N=512.
+
+        If an array_like, compute the response at the frequencies given.
+        These are in the same units as `fs`.
     whole : bool, optional
         Normally, frequencies are computed from 0 to the Nyquist frequency,
-        pi radians/sample (upper-half of unit-circle).  If `whole` is True,
-        compute frequencies from 0 to 2*pi radians/sample.
+        fs/2 (upper-half of unit-circle).  If `whole` is True, compute
+        frequencies from 0 to fs.
     plot : callable
         A callable that takes two arguments. If given, the return parameters
         `w` and `h` are passed to plot. Useful for plotting the frequency
         response inside `freqz`.
     fs : float
-        The sampling frequency of the digital system.
+        The sampling frequency of the digital system.  Defaults to 2*pi
+        radians/sample (so w is from 0 to pi).
 
         .. versionadded:: 1.1.0
 
@@ -477,7 +478,7 @@ def freqz_zpk(z, p, k, worN=512, whole=False, fs=None):
     Compute the frequency response of a digital filter in ZPK form.
 
     Given the Zeros, Poles and Gain of a digital filter, compute its frequency
-    response::
+    response:
 
     :math:`H(z)=k \prod_i (z - Z[i]) / \prod_j (z - P[j])`
 
@@ -493,17 +494,18 @@ def freqz_zpk(z, p, k, worN=512, whole=False, fs=None):
     k : scalar
         Gain of a linear filter
     worN : {None, int, array_like}, optional
-        If single integer (default 512, same as None), then compute at `worN`
-        frequencies equally spaced around the unit circle. If an array_like,
-        compute the response at the frequencies given. If `fs` is specified,
-        these are in the same units as `fs`, otherwise, they are in
-        radians/sample.
+        If a single integer, then compute at that many frequencies.  If None
+        (default), then N=512.
+
+        If an array_like, compute the response at the frequencies given.
+        These are in the same units as `fs`.
     whole : bool, optional
         Normally, frequencies are computed from 0 to the Nyquist frequency,
-        pi radians/sample (upper-half of unit-circle).  If `whole` is True,
-        compute frequencies from 0 to 2*pi radians/sample.
+        fs/2 (upper-half of unit-circle).  If `whole` is True, compute
+        frequencies from 0 to fs.
     fs : float
-        The sampling frequency of the digital system.
+        The sampling frequency of the digital system.  Defaults to 2*pi
+        radians/sample (so w is from 0 to pi).
 
         .. versionadded:: 1.1.0
 
@@ -592,19 +594,19 @@ def group_delay(system, w=512, whole=False, fs=None):
     ----------
     system : tuple of array_like (b, a)
         Numerator and denominator coefficients of a filter transfer function.
-    w : {None, int, array-like}, optional
-        If None, then compute at 512 frequencies equally spaced
-        around the unit circle.
-        If a single integer, then compute at that many frequencies.
-        If array, compute the delay at the frequencies given. If
-        `fs` is specified, these are in the same units as `fs`, otherwise,
-        they are in radians/sample.
+    w : {None, int, array_like}, optional
+        If a single integer, then compute at that many frequencies.  If None
+        (default), then N=512.
+
+        If an array_like, compute the delay at the frequencies given.  These
+        are in the same units as `fs`.
     whole : bool, optional
         Normally, frequencies are computed from 0 to the Nyquist frequency,
-        pi radians/sample (upper-half of unit-circle).  If `whole` is True,
-        compute frequencies from 0 to ``2*pi`` radians/sample.
+        fs/2 (upper-half of unit-circle).  If `whole` is True, compute
+        frequencies from 0 to fs.
     fs : float
-        The sampling frequency of the digital system.
+        The sampling frequency of the digital system.  Defaults to 2*pi
+        radians/sample (so w is from 0 to pi).
 
         .. versionadded:: 1.1.0
 
@@ -728,20 +730,20 @@ def sosfreqz(sos, worN=None, whole=False, fs=None):
         coefficients and the last three providing the denominator
         coefficients.
     worN : {None, int, array_like}, optional
-        If None (default), then compute at 512 frequencies equally spaced
-        around the unit circle.
         If a single integer, then compute at that many frequencies.
         Using a number that is fast for FFT computations can result in
-        faster computations (see Notes of `freqz`).
+        faster computations (see Notes of `freqz`).  If None (default), then
+        N=512.
+
         If an array_like, compute the response at the frequencies given (must
-        be 1D). If `fs` is specified, these are in the same units as `fs`,
-        otherwise, they are in radians/sample.
+        be 1D).  These are in the same units as `fs`.
     whole : bool, optional
         Normally, frequencies are computed from 0 to the Nyquist frequency,
-        pi radians/sample (upper-half of unit-circle).  If `whole` is True,
-        compute frequencies from 0 to 2*pi radians/sample.
+        fs/2 (upper-half of unit-circle).  If `whole` is True, compute
+        frequencies from 0 to fs.
     fs : float
-        The sampling frequency of the digital system.
+        The sampling frequency of the digital system.  Defaults to 2*pi
+        radians/sample (so w is from 0 to pi).
 
         .. versionadded:: 1.1.0
 
@@ -1831,16 +1833,14 @@ def iirdesign(wp, ws, gpass, gstop, analog=False, ftype='ellip', output='ba',
     ----------
     wp, ws : float
         Passband and stopband edge frequencies.
-        For digital filters, these are normalized from 0 to 1, where 1 is the
-        Nyquist frequency, pi radians/sample.  (`wp` and `ws` are thus in
-        half-cycles / sample.)  For example:
+        For digital filters, these are in the same units as `fs`.  By default,
+        `fs` is 2 half-cycles/sample, so these are normalized from 0 to 1,
+        where 1 is the Nyquist frequency.  For example:
 
             - Lowpass:   wp = 0.2,          ws = 0.3
             - Highpass:  wp = 0.3,          ws = 0.2
             - Bandpass:  wp = [0.2, 0.5],   ws = [0.1, 0.6]
             - Bandstop:  wp = [0.1, 0.6],   ws = [0.2, 0.5]
-
-        Or, if `fs` is specified, these are in the same units as `fs`.
 
         For analog filters, `wp` and `ws` are angular frequencies (e.g. rad/s).
     gpass : float
@@ -2477,10 +2477,10 @@ def butter(N, Wn, btype='low', analog=False, output='ba', fs=None):
         For a Butterworth filter, this is the point at which the gain
         drops to 1/sqrt(2) that of the passband (the "-3 dB point").
 
-        For digital filters, `Wn` is normalized from 0 to 1, where 1 is the
-        Nyquist frequency, pi radians/sample.  (`Wn` is thus in
-        half-cycles / sample.) Or, if `fs` is specified, `Wn` is in the same
-        units as `fs`.
+        For digital filters, `Wn` are in the same units as `fs`.  By default,
+        `fs` is 2 half-cycles/sample, so these are normalized from 0 to 1,
+        where 1 is the Nyquist frequency.  (`Wn` is thus in
+        half-cycles / sample.)
 
         For analog filters, `Wn` is an angular frequency (e.g. rad/s).
     btype : {'lowpass', 'highpass', 'bandpass', 'bandstop'}, optional
@@ -2583,10 +2583,10 @@ def cheby1(N, rp, Wn, btype='low', analog=False, output='ba', fs=None):
         For Type I filters, this is the point in the transition band at which
         the gain first drops below -`rp`.
 
-        For digital filters, `Wn` is normalized from 0 to 1, where 1 is the
-        Nyquist frequency, pi radians/sample.  (`Wn` is thus in
-        half-cycles / sample.) Or, if `fs` is specified, `Wn` is in the same
-        units as `fs`.
+        For digital filters, `Wn` are in the same units as `fs`.  By default,
+        `fs` is 2 half-cycles/sample, so these are normalized from 0 to 1,
+        where 1 is the Nyquist frequency.  (`Wn` is thus in
+        half-cycles / sample.)
 
         For analog filters, `Wn` is an angular frequency (e.g. rad/s).
     btype : {'lowpass', 'highpass', 'bandpass', 'bandstop'}, optional
@@ -2698,10 +2698,10 @@ def cheby2(N, rs, Wn, btype='low', analog=False, output='ba', fs=None):
         For Type II filters, this is the point in the transition band at which
         the gain first reaches -`rs`.
 
-        For digital filters, `Wn` is normalized from 0 to 1, where 1 is the
-        Nyquist frequency, pi radians/sample.  (`Wn` is thus in
-        half-cycles / sample.) Or, if `fs` is specified, `Wn` is in the same
-        units as `fs`.
+        For digital filters, `Wn` are in the same units as `fs`.  By default,
+        `fs` is 2 half-cycles/sample, so these are normalized from 0 to 1,
+        where 1 is the Nyquist frequency.  (`Wn` is thus in
+        half-cycles / sample.)
 
         For analog filters, `Wn` is an angular frequency (e.g. rad/s).
     btype : {'lowpass', 'highpass', 'bandpass', 'bandstop'}, optional
@@ -2811,10 +2811,10 @@ def ellip(N, rp, rs, Wn, btype='low', analog=False, output='ba', fs=None):
         For elliptic filters, this is the point in the transition band at
         which the gain first drops below -`rp`.
 
-        For digital filters, `Wn` is normalized from 0 to 1, where 1 is the
-        Nyquist frequency, pi radians/sample.  (`Wn` is thus in
-        half-cycles / sample.) Or, if `fs` is specified, `Wn` is in the same
-        units as `fs`.
+        For digital filters, `Wn` are in the same units as `fs`.  By default,
+        `fs` is 2 half-cycles/sample, so these are normalized from 0 to 1,
+        where 1 is the Nyquist frequency.  (`Wn` is thus in
+        half-cycles / sample.)
 
         For analog filters, `Wn` is an angular frequency (e.g. rad/s).
     btype : {'lowpass', 'highpass', 'bandpass', 'bandstop'}, optional
@@ -2928,10 +2928,10 @@ def bessel(N, Wn, btype='low', analog=False, output='ba', norm='phase',
         by the `norm` parameter).
         For analog filters, `Wn` is an angular frequency (e.g. rad/s).
 
-        For digital filters, `Wn` is normalized from 0 to 1, where 1 is the
-        Nyquist frequency, pi radians/sample.  (`Wn` is thus in
-        half-cycles / sample.) Or, if `fs` is specified, `Wn` is in the same
-        units as `fs`.
+        For digital filters, `Wn` are in the same units as `fs`.  By default,
+        `fs` is 2 half-cycles/sample, so these are normalized from 0 to 1,
+        where 1 is the Nyquist frequency.  (`Wn` is thus in
+        half-cycles / sample.)
     btype : {'lowpass', 'highpass', 'bandpass', 'bandstop'}, optional
         The type of filter.  Default is 'lowpass'.
     analog : bool, optional
@@ -3148,16 +3148,16 @@ def buttord(wp, ws, gpass, gstop, analog=False, fs=None):
     ----------
     wp, ws : float
         Passband and stopband edge frequencies.
-        For digital filters, these are normalized from 0 to 1, where 1 is the
-        Nyquist frequency, pi radians/sample.  (`wp` and `ws` are thus in
+
+        For digital filters, these are in the same units as `fs`.  By default,
+        `fs` is 2 half-cycles/sample, so these are normalized from 0 to 1,
+        where 1 is the Nyquist frequency.  (`wp` and `ws` are thus in
         half-cycles / sample.)  For example:
 
             - Lowpass:   wp = 0.2,          ws = 0.3
             - Highpass:  wp = 0.3,          ws = 0.2
             - Bandpass:  wp = [0.2, 0.5],   ws = [0.1, 0.6]
             - Bandstop:  wp = [0.1, 0.6],   ws = [0.2, 0.5]
-
-        Or, if `fs` is specified, these are in the same units as `fs`.
 
         For analog filters, `wp` and `ws` are angular frequencies (e.g. rad/s).
     gpass : float
@@ -3318,16 +3318,16 @@ def cheb1ord(wp, ws, gpass, gstop, analog=False, fs=None):
     ----------
     wp, ws : float
         Passband and stopband edge frequencies.
-        For digital filters, these are normalized from 0 to 1, where 1 is the
-        Nyquist frequency, pi radians/sample.  (`wp` and `ws` are thus in
+
+        For digital filters, these are in the same units as `fs`.  By default,
+        `fs` is 2 half-cycles/sample, so these are normalized from 0 to 1,
+        where 1 is the Nyquist frequency.  (`wp` and `ws` are thus in
         half-cycles / sample.)  For example:
 
             - Lowpass:   wp = 0.2,          ws = 0.3
             - Highpass:  wp = 0.3,          ws = 0.2
             - Bandpass:  wp = [0.2, 0.5],   ws = [0.1, 0.6]
             - Bandstop:  wp = [0.1, 0.6],   ws = [0.2, 0.5]
-
-        Or, if `fs` is specified, these are in the same units as `fs`.
 
         For analog filters, `wp` and `ws` are angular frequencies (e.g. rad/s).
     gpass : float
@@ -3456,16 +3456,16 @@ def cheb2ord(wp, ws, gpass, gstop, analog=False, fs=None):
     ----------
     wp, ws : float
         Passband and stopband edge frequencies.
-        For digital filters, these are normalized from 0 to 1, where 1 is the
-        Nyquist frequency, pi radians/sample.  (`wp` and `ws` are thus in
+
+        For digital filters, these are in the same units as `fs`.  By default,
+        `fs` is 2 half-cycles/sample, so these are normalized from 0 to 1,
+        where 1 is the Nyquist frequency.  (`wp` and `ws` are thus in
         half-cycles / sample.)  For example:
 
             - Lowpass:   wp = 0.2,          ws = 0.3
             - Highpass:  wp = 0.3,          ws = 0.2
             - Bandpass:  wp = [0.2, 0.5],   ws = [0.1, 0.6]
             - Bandstop:  wp = [0.1, 0.6],   ws = [0.2, 0.5]
-
-        Or, if `fs` is specified, these are in the same units as `fs`.
 
         For analog filters, `wp` and `ws` are angular frequencies (e.g. rad/s).
     gpass : float
@@ -3618,16 +3618,16 @@ def ellipord(wp, ws, gpass, gstop, analog=False, fs=None):
     ----------
     wp, ws : float
         Passband and stopband edge frequencies.
-        For digital filters, these are normalized from 0 to 1, where 1 is the
-        Nyquist frequency, pi radians/sample.  (`wp` and `ws` are thus in
+
+        For digital filters, these are in the same units as `fs`.  By default,
+        `fs` is 2 half-cycles/sample, so these are normalized from 0 to 1,
+        where 1 is the Nyquist frequency.  (`wp` and `ws` are thus in
         half-cycles / sample.)  For example:
 
             - Lowpass:   wp = 0.2,          ws = 0.3
             - Highpass:  wp = 0.3,          ws = 0.2
             - Bandpass:  wp = [0.2, 0.5],   ws = [0.1, 0.6]
             - Bandstop:  wp = [0.1, 0.6],   ws = [0.2, 0.5]
-
-        Or, if `fs` is specified, these are in the same units as `fs`.
 
         For analog filters, `wp` and `ws` are angular frequencies (e.g. rad/s).
     gpass : float
@@ -4272,7 +4272,7 @@ def iirnotch(w0, Q, fs=None):
     ----------
     w0 : float
         Frequency to remove from a signal. If `fs` is specified, this is in
-        the same units as `fs`. Otherwise, it is a normalized scalar that must
+        the same units as `fs`. By default, it is a normalized scalar that must
         satisfy  ``0 < w0 < 1``, with ``w0 = 1`` corresponding to half of the
         sampling frequency.
     Q : float
@@ -4356,7 +4356,7 @@ def iirpeak(w0, Q, fs=None):
     ----------
     w0 : float
         Frequency to be retained in a signal. If `fs` is specified, this is in
-        the same units as `fs`. Otherwise, it is a normalized scalar that must
+        the same units as `fs`. By default, it is a normalized scalar that must
         satisfy  ``0 < w0 < 1``, with ``w0 = 1`` corresponding to half of the
         sampling frequency.
     Q : float
@@ -4435,7 +4435,8 @@ def _design_notch_peak_filter(w0, Q, ftype, fs=None):
     Parameters
     ----------
     w0 : float
-        Normalized frequency to remove from a signal. It is a
+        Normalized frequency to remove from a signal. If `fs` is specified,
+        this is in the same units as `fs`. By default, it is a normalized
         scalar that must satisfy  ``0 < w0 < 1``, with ``w0 = 1``
         corresponding to half of the sampling frequency.
     Q : float

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -308,8 +308,8 @@ def freqz(b, a=1, worN=512, whole=False, plot=None, fs=None):
     Returns
     -------
     w : ndarray
-        The normalized frequencies at which `h` was computed, in
-        radians/sample.
+        The frequencies at which `h` was computed.  If `fs` is specified,
+        these are in the same units.  Otherwise they are in radians/sample.
     h : ndarray
         The frequency response, as complex numbers.
 
@@ -451,6 +451,10 @@ def freqz(b, a=1, worN=512, whole=False, plot=None, fs=None):
         zm1 = exp(-1j * w)
         h = (npp_polyval(zm1, b, tensor=False) /
              npp_polyval(zm1, a, tensor=False))
+
+    if fs is not None:
+        w = w*fs/(2*pi)
+
     if plot is not None:
         plot(w, h)
 
@@ -495,8 +499,8 @@ def freqz_zpk(z, p, k, worN=512, whole=False, fs=None):
     Returns
     -------
     w : ndarray
-        The normalized frequencies at which `h` was computed, in
-        radians/sample.
+        The frequencies at which `h` was computed.  If `fs` is specified,
+        these are in the same units.  Otherwise they are in radians/sample.
     h : ndarray
         The frequency response.
 
@@ -552,6 +556,9 @@ def freqz_zpk(z, p, k, worN=512, whole=False, fs=None):
     zm1 = exp(1j * w)
     h = k * polyvalfromroots(zm1, z) / polyvalfromroots(zm1, p)
 
+    if fs is not None:
+        w = w*fs/(2*pi)
+
     return w, h
 
 
@@ -589,8 +596,9 @@ def group_delay(system, w=512, whole=False, fs=None):
     Returns
     -------
     w : ndarray
-        The normalized frequencies at which the group delay was computed,
-        in radians/sample.
+        The frequencies at which group delay was computed.  If `fs` is
+        specified, these are in the same units.  Otherwise they are in
+        radians/sample.
     gd : ndarray
         The group delay.
 
@@ -657,6 +665,10 @@ def group_delay(system, w=512, whole=False, fs=None):
 
     gd = np.zeros_like(w)
     gd[~singular] = np.real(num[~singular] / den[~singular]) - a.size + 1
+
+    if fs is not None:
+        w = w*fs/(2*pi)
+
     return w, gd
 
 
@@ -716,8 +728,8 @@ def sosfreqz(sos, worN=None, whole=False, fs=None):
     Returns
     -------
     w : ndarray
-        The normalized frequencies at which `h` was computed, in
-        radians/sample.
+        The frequencies at which `h` was computed.  If `fs` is specified,
+        these are in the same units.  Otherwise they are in radians/sample.
     h : ndarray
         The frequency response, as complex numbers.
 
@@ -3146,7 +3158,8 @@ def buttord(wp, ws, gpass, gstop, analog=False, fs=None):
         The lowest order for a Butterworth filter which meets specs.
     wn : ndarray or float
         The Butterworth natural frequency (i.e. the "3dB frequency").  Should
-        be used with `butter` to give filter results.
+        be used with `butter` to give filter results. If `fs` is specified,
+        this is in the same units, and `fs` must also be passed to `butter`.
 
     See Also
     --------
@@ -3267,6 +3280,10 @@ def buttord(wp, ws, gpass, gstop, analog=False, fs=None):
 
     if len(wn) == 1:
         wn = wn[0]
+
+    if fs is not None:
+        wn = wn*fs/2
+
     return ord, wn
 
 
@@ -3311,7 +3328,8 @@ def cheb1ord(wp, ws, gpass, gstop, analog=False, fs=None):
         The lowest order for a Chebyshev type I filter that meets specs.
     wn : ndarray or float
         The Chebyshev natural frequency (the "3dB frequency") for use with
-        `cheby1` to give filter results.
+        `cheby1` to give filter results. If `fs` is specified,
+        this is in the same units, and `fs` must also be passed to `cheby1`.
 
     See Also
     --------
@@ -3400,6 +3418,10 @@ def cheb1ord(wp, ws, gpass, gstop, analog=False, fs=None):
 
     if len(wn) == 1:
         wn = wn[0]
+
+    if fs is not None:
+        wn = wn*fs/2
+
     return ord, wn
 
 
@@ -3444,7 +3466,8 @@ def cheb2ord(wp, ws, gpass, gstop, analog=False, fs=None):
         The lowest order for a Chebyshev type II filter that meets specs.
     wn : ndarray or float
         The Chebyshev natural frequency (the "3dB frequency") for use with
-        `cheby2` to give filter results.
+        `cheby2` to give filter results. If `fs` is specified,
+        this is in the same units, and `fs` must also be passed to `cheby2`.
 
     See Also
     --------
@@ -3557,6 +3580,10 @@ def cheb2ord(wp, ws, gpass, gstop, analog=False, fs=None):
 
     if len(wn) == 1:
         wn = wn[0]
+
+    if fs is not None:
+        wn = wn*fs/2
+
     return ord, wn
 
 
@@ -3601,7 +3628,8 @@ def ellipord(wp, ws, gpass, gstop, analog=False, fs=None):
         The lowest order for an Elliptic (Cauer) filter that meets specs.
     wn : ndarray or float
         The Chebyshev natural frequency (the "3dB frequency") for use with
-        `ellip` to give filter results.
+        `ellip` to give filter results. If `fs` is specified,
+        this is in the same units, and `fs` must also be passed to `ellip`.
 
     See Also
     --------
@@ -3691,6 +3719,10 @@ def ellipord(wp, ws, gpass, gstop, analog=False, fs=None):
 
     if len(wn) == 1:
         wn = wn[0]
+
+    if fs is not None:
+        wn = wn*fs/2
+
     return ord, wn
 
 

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -2009,7 +2009,8 @@ def iirfilter(N, Wn, rp=None, rs=None, btype='band', analog=False,
 
     Create a digital filter with the same properties, in a system with
     sampling rate of 2000 Hz, and plot the frequency response.  (Second-order
-    sections implementation is required for a filter of this order):
+    sections implementation is required to ensure stability of a filter of
+    this order):
 
     >>> sos = signal.iirfilter(17, [50, 200], rs=60, btype='band',
     ...                        analog=False, ftype='cheby2', fs=2000,

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -304,7 +304,7 @@ def freqz(b, a=1, worN=512, whole=False, plot=None, fs=None):
     whole : bool, optional
         Normally, frequencies are computed from 0 to the Nyquist frequency,
         fs/2 (upper-half of unit-circle).  If `whole` is True, compute
-        frequencies from 0 to fs.
+        frequencies from 0 to fs.  Ignored if w is array_like.
     plot : callable
         A callable that takes two arguments. If given, the return parameters
         `w` and `h` are passed to plot. Useful for plotting the frequency
@@ -501,7 +501,7 @@ def freqz_zpk(z, p, k, worN=512, whole=False, fs=None):
     whole : bool, optional
         Normally, frequencies are computed from 0 to the Nyquist frequency,
         fs/2 (upper-half of unit-circle).  If `whole` is True, compute
-        frequencies from 0 to fs.
+        frequencies from 0 to fs.  Ignored if w is array_like.
     fs : float
         The sampling frequency of the digital system.  Defaults to 2*pi
         radians/sample (so w is from 0 to pi).
@@ -603,7 +603,7 @@ def group_delay(system, w=512, whole=False, fs=None):
     whole : bool, optional
         Normally, frequencies are computed from 0 to the Nyquist frequency,
         fs/2 (upper-half of unit-circle).  If `whole` is True, compute
-        frequencies from 0 to fs.
+        frequencies from 0 to fs.  Ignored if w is array_like.
     fs : float
         The sampling frequency of the digital system.  Defaults to 2*pi
         radians/sample (so w is from 0 to pi).

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -320,7 +320,7 @@ def freqz(b, a=1, worN=512, whole=False, plot=None, fs=2*pi):
         The sampling frequency of the digital system.  Defaults to 2*pi
         radians/sample (so w is from 0 to pi).
 
-        .. versionadded:: 1.1.0
+        .. versionadded:: 1.2.0
 
     Returns
     -------
@@ -512,7 +512,7 @@ def freqz_zpk(z, p, k, worN=512, whole=False, fs=2*pi):
         The sampling frequency of the digital system.  Defaults to 2*pi
         radians/sample (so w is from 0 to pi).
 
-        .. versionadded:: 1.1.0
+        .. versionadded:: 1.2.0
 
     Returns
     -------
@@ -613,7 +613,7 @@ def group_delay(system, w=512, whole=False, fs=2*pi):
         The sampling frequency of the digital system.  Defaults to 2*pi
         radians/sample (so w is from 0 to pi).
 
-        .. versionadded:: 1.1.0
+        .. versionadded:: 1.2.0
 
     Returns
     -------
@@ -744,7 +744,7 @@ def sosfreqz(sos, worN=512, whole=False, fs=2*pi):
         The sampling frequency of the digital system.  Defaults to 2*pi
         radians/sample (so w is from 0 to pi).
 
-        .. versionadded:: 1.1.0
+        .. versionadded:: 1.2.0
 
     Returns
     -------
@@ -1873,7 +1873,7 @@ def iirdesign(wp, ws, gpass, gstop, analog=False, ftype='ellip', output='ba',
     fs : float, optional
         The sampling frequency of the digital system.
 
-        .. versionadded:: 1.1.0
+        .. versionadded:: 1.2.0
 
     Returns
     -------
@@ -1970,7 +1970,7 @@ def iirfilter(N, Wn, rp=None, rs=None, btype='band', analog=False,
     fs : float, optional
         The sampling frequency of the digital system.
 
-        .. versionadded:: 1.1.0
+        .. versionadded:: 1.2.0
 
     Returns
     -------
@@ -2521,7 +2521,7 @@ def butter(N, Wn, btype='low', analog=False, output='ba', fs=None):
     fs : float, optional
         The sampling frequency of the digital system.
 
-        .. versionadded:: 1.1.0
+        .. versionadded:: 1.2.0
 
     Returns
     -------
@@ -2628,7 +2628,7 @@ def cheby1(N, rp, Wn, btype='low', analog=False, output='ba', fs=None):
     fs : float, optional
         The sampling frequency of the digital system.
 
-        .. versionadded:: 1.1.0
+        .. versionadded:: 1.2.0
 
     Returns
     -------
@@ -2744,7 +2744,7 @@ def cheby2(N, rs, Wn, btype='low', analog=False, output='ba', fs=None):
     fs : float, optional
         The sampling frequency of the digital system.
 
-        .. versionadded:: 1.1.0
+        .. versionadded:: 1.2.0
 
     Returns
     -------
@@ -2857,7 +2857,7 @@ def ellip(N, rp, rs, Wn, btype='low', analog=False, output='ba', fs=None):
     fs : float, optional
         The sampling frequency of the digital system.
 
-        .. versionadded:: 1.1.0
+        .. versionadded:: 1.2.0
 
     Returns
     -------
@@ -2997,7 +2997,7 @@ def bessel(N, Wn, btype='low', analog=False, output='ba', norm='phase',
     fs : float, optional
         The sampling frequency of the digital system.
 
-        .. versionadded:: 1.1.0
+        .. versionadded:: 1.2.0
 
     Returns
     -------
@@ -3200,7 +3200,7 @@ def buttord(wp, ws, gpass, gstop, analog=False, fs=None):
     fs : float, optional
         The sampling frequency of the digital system.
 
-        .. versionadded:: 1.1.0
+        .. versionadded:: 1.2.0
 
     Returns
     -------
@@ -3370,7 +3370,7 @@ def cheb1ord(wp, ws, gpass, gstop, analog=False, fs=None):
     fs : float, optional
         The sampling frequency of the digital system.
 
-        .. versionadded:: 1.1.0
+        .. versionadded:: 1.2.0
 
     Returns
     -------
@@ -3508,7 +3508,7 @@ def cheb2ord(wp, ws, gpass, gstop, analog=False, fs=None):
     fs : float, optional
         The sampling frequency of the digital system.
 
-        .. versionadded:: 1.1.0
+        .. versionadded:: 1.2.0
 
     Returns
     -------
@@ -3670,7 +3670,7 @@ def ellipord(wp, ws, gpass, gstop, analog=False, fs=None):
     fs : float, optional
         The sampling frequency of the digital system.
 
-        .. versionadded:: 1.1.0
+        .. versionadded:: 1.2.0
 
     Returns
     -------
@@ -4312,7 +4312,7 @@ def iirnotch(w0, Q, fs=2.0):
     fs : float, optional
         The sampling frequency of the digital system.
 
-        .. versionadded:: 1.1.0
+        .. versionadded:: 1.2.0
 
     Returns
     -------
@@ -4393,7 +4393,7 @@ def iirpeak(w0, Q, fs=2.0):
     fs : float, optional
         The sampling frequency of the digital system.
 
-        .. versionadded:: 1.1.0
+        .. versionadded:: 1.2.0
 
     Returns
     -------
@@ -4475,7 +4475,7 @@ def _design_notch_peak_filter(w0, Q, ftype, fs=2.0):
     fs : float, optional
         The sampling frequency of the digital system.
 
-        .. versionadded:: 1.1.0:
+        .. versionadded:: 1.2.0:
 
     Returns
     -------

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -172,6 +172,7 @@ def freqs(b, a, worN=200, plot=None):
 
     """
     if worN is None:
+        # For backwards compatibility
         w = findfreqs(b, a, 200)
     elif _is_int_type(worN):
         w = findfreqs(b, a, worN)
@@ -250,6 +251,7 @@ def freqs_zpk(z, p, k, worN=200):
         raise ValueError('k must be a single scalar gain')
 
     if worN is None:
+        # For backwards compatibility
         w = findfreqs(z, p, 200, kind='zp')
     elif _is_int_type(worN):
         w = findfreqs(z, p, worN, kind='zp')
@@ -419,6 +421,7 @@ def freqz(b, a=1, worN=512, whole=False, plot=None, fs=None):
     a = atleast_1d(a)
 
     if worN is None:
+        # For backwards compatibility
         worN = 512
 
     h = None
@@ -562,6 +565,7 @@ def freqz_zpk(z, p, k, worN=512, whole=False, fs=None):
         lastpoint = pi
 
     if worN is None:
+        # For backwards compatibility
         w = numpy.linspace(0, lastpoint, 512, endpoint=False)
     elif _is_int_type(worN):
         w = numpy.linspace(0, lastpoint, worN, endpoint=False)
@@ -656,6 +660,7 @@ def group_delay(system, w=512, whole=False, fs=None):
 
     """
     if w is None:
+        # For backwards compatibility
         w = 512
 
     if _is_int_type(w):

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -2556,7 +2556,7 @@ def butter(N, Wn, btype='low', analog=False, output='ba', fs=None):
 
     Generate a signal made up of 10 Hz and 20 Hz, sampled at 1 kHz
 
-    >>> t = np.linspace(0, 1, 1000)  # 1 second
+    >>> t = np.linspace(0, 1, 1000, False)  # 1 second
     >>> sig = np.sin(2*np.pi*10*t) + np.sin(2*np.pi*20*t)
     >>> fig, (ax1, ax2) = plt.subplots(2, 1, sharex=True)
     >>> ax1.plot(t, sig)
@@ -2671,7 +2671,7 @@ def cheby1(N, rp, Wn, btype='low', analog=False, output='ba', fs=None):
 
     Generate a signal made up of 10 Hz and 20 Hz, sampled at 1 kHz
 
-    >>> t = np.linspace(0, 1, 1000)  # 1 second
+    >>> t = np.linspace(0, 1, 1000, False)  # 1 second
     >>> sig = np.sin(2*np.pi*10*t) + np.sin(2*np.pi*20*t)
     >>> fig, (ax1, ax2) = plt.subplots(2, 1, sharex=True)
     >>> ax1.plot(t, sig)
@@ -2781,7 +2781,7 @@ def cheby2(N, rs, Wn, btype='low', analog=False, output='ba', fs=None):
 
     Generate a signal made up of 10 Hz and 20 Hz, sampled at 1 kHz
 
-    >>> t = np.linspace(0, 1, 1000)  # 1 second
+    >>> t = np.linspace(0, 1, 1000, False)  # 1 second
     >>> sig = np.sin(2*np.pi*10*t) + np.sin(2*np.pi*20*t)
     >>> fig, (ax1, ax2) = plt.subplots(2, 1, sharex=True)
     >>> ax1.plot(t, sig)
@@ -2903,7 +2903,7 @@ def ellip(N, rp, rs, Wn, btype='low', analog=False, output='ba', fs=None):
 
     Generate a signal made up of 10 Hz and 20 Hz, sampled at 1 kHz
 
-    >>> t = np.linspace(0, 1, 1000)  # 1 second
+    >>> t = np.linspace(0, 1, 1000, False)  # 1 second
     >>> sig = np.sin(2*np.pi*10*t) + np.sin(2*np.pi*20*t)
     >>> fig, (ax1, ax2) = plt.subplots(2, 1, sharex=True)
     >>> ax1.plot(t, sig)

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -40,7 +40,13 @@ abs = absolute
 
 
 def _is_int_type(x):
+    """
+    Check if input is of a scalar integer type (so ``5`` and ``array(5)`` will
+    pass, while ``5.0`` and ``array([5])`` will fail.
+    """
     if np.ndim(x) != 0:
+        # Older versions of numpy did not raise for np.array([1]).__index__()
+        # This is safe to remove when support for those versions is dropped
         return False
     try:
         operator.index(x)

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -2575,6 +2575,7 @@ def butter(N, Wn, btype='low', analog=False, output='ba', fs=None):
     >>> ax2.set_title('After 15 Hz high-pass filter')
     >>> ax2.axis([0, 1, -2, 2])
     >>> ax2.set_xlabel('Time [seconds]')
+    >>> plt.tight_layout()
     >>> plt.show()
     """
     return iirfilter(N, Wn, btype=btype, analog=analog,
@@ -2690,6 +2691,7 @@ def cheby1(N, rp, Wn, btype='low', analog=False, output='ba', fs=None):
     >>> ax2.set_title('After 15 Hz high-pass filter')
     >>> ax2.axis([0, 1, -2, 2])
     >>> ax2.set_xlabel('Time [seconds]')
+    >>> plt.tight_layout()
     >>> plt.show()
     """
     return iirfilter(N, Wn, rp=rp, btype=btype, analog=analog,
@@ -2922,6 +2924,7 @@ def ellip(N, rp, rs, Wn, btype='low', analog=False, output='ba', fs=None):
     >>> ax2.set_title('After 17 Hz high-pass filter')
     >>> ax2.axis([0, 1, -2, 2])
     >>> ax2.set_xlabel('Time [seconds]')
+    >>> plt.tight_layout()
     >>> plt.show()
     """
     return iirfilter(N, Wn, rs=rs, rp=rp, btype=btype, analog=analog,

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -701,7 +701,7 @@ def _validate_sos(sos):
     return sos, n_sections
 
 
-def sosfreqz(sos, worN=None, whole=False, fs=2*pi):
+def sosfreqz(sos, worN=512, whole=False, fs=2*pi):
     """
     Compute the frequency response of a digital filter in SOS format.
 

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -708,7 +708,7 @@ def _validate_sos(sos):
 
 
 def sosfreqz(sos, worN=512, whole=False, fs=2*pi):
-    """
+    r"""
     Compute the frequency response of a digital filter in SOS format.
 
     Given `sos`, an array with shape (n, 6) of second order sections of
@@ -789,7 +789,7 @@ def sosfreqz(sos, worN=512, whole=False, fs=2*pi):
     >>> plt.plot(w/np.pi, np.angle(h))
     >>> plt.grid(True)
     >>> plt.yticks([-np.pi, -0.5*np.pi, 0, 0.5*np.pi, np.pi],
-    ...            [r'$-\\pi$', r'$-\\pi/2$', '0', r'$\\pi/2$', r'$\\pi$'])
+    ...            [r'$-\pi$', r'$-\pi/2$', '0', r'$\pi/2$', r'$\pi$'])
     >>> plt.ylabel('Phase [rad]')
     >>> plt.xlabel('Normalized frequency (1.0 = Nyquist)')
     >>> plt.show()
@@ -803,8 +803,18 @@ def sosfreqz(sos, worN=512, whole=False, fs=2*pi):
     >>> plt.subplot(2, 1, 1)
     >>> db = 20*np.log10(np.abs(h))
     >>> plt.plot(w/np.pi, db)
+    >>> plt.ylim(-75, 5)
+    >>> plt.grid(True)
+    >>> plt.yticks([0, -20, -40, -60])
+    >>> plt.ylabel('Gain [dB]')
+    >>> plt.title('Frequency Response')
     >>> plt.subplot(2, 1, 2)
     >>> plt.plot(w/np.pi, np.angle(h))
+    >>> plt.grid(True)
+    >>> plt.yticks([-np.pi, -0.5*np.pi, 0, 0.5*np.pi, np.pi],
+    ...            [r'$-\pi$', r'$-\pi/2$', '0', r'$\pi/2$', r'$\pi$'])
+    >>> plt.ylabel('Phase [rad]')
+    >>> plt.xlabel('Normalized frequency (1.0 = Nyquist)')
     >>> plt.show()
 
     """

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -162,9 +162,13 @@ def freqs(b, a, worN=200, plot=None):
     """
     if worN is None:
         w = findfreqs(b, a, 200)
-    elif isinstance(worN, int):
-        N = worN
-        w = findfreqs(b, a, N)
+    elif np.ndim(worN) == 0:
+        try:
+            N = operator.index(worN)
+        except TypeError:
+            pass
+        else:
+            w = findfreqs(b, a, N)
     else:
         w = worN
     w = atleast_1d(w)
@@ -241,9 +245,13 @@ def freqs_zpk(z, p, k, worN=200):
 
     if worN is None:
         w = findfreqs(z, p, 200, kind='zp')
-    elif isinstance(worN, int):
-        N = worN
-        w = findfreqs(z, p, N, kind='zp')
+    elif np.ndim(worN) == 0:
+        try:
+            N = operator.index(worN)
+        except TypeError:
+            pass
+        else:
+            w = findfreqs(z, p, N, kind='zp')
     else:
         w = worN
 
@@ -413,7 +421,10 @@ def freqz(b, a=1, worN=512, whole=False, plot=None, fs=None):
 
     h = None
     try:
-        worN = operator.index(worN)
+        if np.ndim(worN) == 0:
+            worN = operator.index(worN)
+        else:
+            raise TypeError
     except TypeError:  # not int-like
         w = atleast_1d(worN)
         if fs is not None:
@@ -545,9 +556,13 @@ def freqz_zpk(z, p, k, worN=512, whole=False, fs=None):
         lastpoint = pi
     if worN is None:
         w = numpy.linspace(0, lastpoint, 512, endpoint=False)
-    elif isinstance(worN, int):
-        N = worN
-        w = numpy.linspace(0, lastpoint, N, endpoint=False)
+    elif np.ndim(worN) == 0:
+        try:
+            N = operator.index(worN)
+        except TypeError:
+            pass
+        else:
+            w = numpy.linspace(0, lastpoint, N, endpoint=False)
     else:
         w = atleast_1d(worN)
         if fs is not None:
@@ -641,11 +656,16 @@ def group_delay(system, w=512, whole=False, fs=None):
     if w is None:
         w = 512
 
-    if isinstance(w, int):
-        if whole:
-            w = np.linspace(0, 2 * pi, w, endpoint=False)
+    if np.ndim(w) == 0:
+        try:
+            w = operator.index(w)
+        except TypeError:
+            pass
         else:
-            w = np.linspace(0, pi, w, endpoint=False)
+            if whole:
+                w = np.linspace(0, 2 * pi, w, endpoint=False)
+            else:
+                w = np.linspace(0, pi, w, endpoint=False)
 
     w = np.atleast_1d(w)
     if fs is not None:

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -4280,7 +4280,7 @@ def besselap(N, norm='phase'):
     return asarray([]), asarray(p, dtype=complex), float(k)
 
 
-def iirnotch(w0, Q, fs=2):
+def iirnotch(w0, Q, fs=2.0):
     """
     Design second-order IIR notch digital filter.
 
@@ -4361,7 +4361,7 @@ def iirnotch(w0, Q, fs=2):
     return _design_notch_peak_filter(w0, Q, "notch", fs)
 
 
-def iirpeak(w0, Q, fs=2):
+def iirpeak(w0, Q, fs=2.0):
     """
     Design second-order IIR peak (resonant) digital filter.
 
@@ -4442,7 +4442,7 @@ def iirpeak(w0, Q, fs=2):
     return _design_notch_peak_filter(w0, Q, "peak", fs)
 
 
-def _design_notch_peak_filter(w0, Q, ftype, fs=2):
+def _design_notch_peak_filter(w0, Q, ftype, fs=2.0):
     """
     Design notch or peak digital filter.
 

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -266,7 +266,7 @@ def freqs_zpk(z, p, k, worN=200):
     return w, h
 
 
-def freqz(b, a=1, worN=512, whole=False, plot=None, fs=None):
+def freqz(b, a=1, worN=512, whole=False, plot=None, fs=2*pi):
     """
     Compute the frequency response of a digital filter.
 
@@ -292,14 +292,13 @@ def freqz(b, a=1, worN=512, whole=False, plot=None, fs=None):
         and ``b.shape[1:]``, ``a.shape[1:]``, and the shape of the frequencies
         array must be compatible for broadcasting.
     worN : {None, int, array_like}, optional
-        If None, then compute at 512 equally spaced frequencies.
-        If a single integer, then compute at that many frequencies.  This is
-        a convenient alternative to::
+        If a single integer, then compute at that many frequencies (default is
+        N=512).  This is a convenient alternative to::
 
             np.linspace(0, fs if whole else fs/2, N, endpoint=False)
 
         Using a number that is fast for FFT computations can result in
-        faster computations (see Notes).  If None (default), then N=512.
+        faster computations (see Notes).
 
         If an array_like, compute the response at the frequencies given.
         These are in the same units as `fs`.
@@ -311,7 +310,7 @@ def freqz(b, a=1, worN=512, whole=False, plot=None, fs=None):
         A callable that takes two arguments. If given, the return parameters
         `w` and `h` are passed to plot. Useful for plotting the frequency
         response inside `freqz`.
-    fs : float
+    fs : float, optional
         The sampling frequency of the digital system.  Defaults to 2*pi
         radians/sample (so w is from 0 to pi).
 
@@ -458,16 +457,14 @@ def freqz(b, a=1, worN=512, whole=False, plot=None, fs=None):
     else:
         w = atleast_1d(worN)
         del worN
-        if fs is not None:
-            w = 2*pi*w/fs
+        w = 2*pi*w/fs
 
     if h is None:  # still need to compute using freqs w
         zm1 = exp(-1j * w)
         h = (npp_polyval(zm1, b, tensor=False) /
              npp_polyval(zm1, a, tensor=False))
 
-    if fs is not None:
-        w = w*fs/(2*pi)
+    w = w*fs/(2*pi)
 
     if plot is not None:
         plot(w, h)
@@ -475,7 +472,7 @@ def freqz(b, a=1, worN=512, whole=False, plot=None, fs=None):
     return w, h
 
 
-def freqz_zpk(z, p, k, worN=512, whole=False, fs=None):
+def freqz_zpk(z, p, k, worN=512, whole=False, fs=2*pi):
     r"""
     Compute the frequency response of a digital filter in ZPK form.
 
@@ -496,8 +493,8 @@ def freqz_zpk(z, p, k, worN=512, whole=False, fs=None):
     k : scalar
         Gain of a linear filter
     worN : {None, int, array_like}, optional
-        If a single integer, then compute at that many frequencies.  If None
-        (default), then N=512.
+        If a single integer, then compute at that many frequencies (default is
+        N=512).
 
         If an array_like, compute the response at the frequencies given.
         These are in the same units as `fs`.
@@ -505,7 +502,7 @@ def freqz_zpk(z, p, k, worN=512, whole=False, fs=None):
         Normally, frequencies are computed from 0 to the Nyquist frequency,
         fs/2 (upper-half of unit-circle).  If `whole` is True, compute
         frequencies from 0 to fs.  Ignored if w is array_like.
-    fs : float
+    fs : float, optional
         The sampling frequency of the digital system.  Defaults to 2*pi
         radians/sample (so w is from 0 to pi).
 
@@ -571,19 +568,17 @@ def freqz_zpk(z, p, k, worN=512, whole=False, fs=None):
         w = numpy.linspace(0, lastpoint, worN, endpoint=False)
     else:
         w = atleast_1d(worN)
-        if fs is not None:
-            w = 2*pi*w/fs
+        w = 2*pi*w/fs
 
     zm1 = exp(1j * w)
     h = k * polyvalfromroots(zm1, z) / polyvalfromroots(zm1, p)
 
-    if fs is not None:
-        w = w*fs/(2*pi)
+    w = w*fs/(2*pi)
 
     return w, h
 
 
-def group_delay(system, w=512, whole=False, fs=None):
+def group_delay(system, w=512, whole=False, fs=2*pi):
     r"""Compute the group delay of a digital filter.
 
     The group delay measures by how many samples amplitude envelopes of
@@ -599,8 +594,8 @@ def group_delay(system, w=512, whole=False, fs=None):
     system : tuple of array_like (b, a)
         Numerator and denominator coefficients of a filter transfer function.
     w : {None, int, array_like}, optional
-        If a single integer, then compute at that many frequencies.  If None
-        (default), then N=512.
+        If a single integer, then compute at that many frequencies (default is
+        N=512).
 
         If an array_like, compute the delay at the frequencies given.  These
         are in the same units as `fs`.
@@ -608,7 +603,7 @@ def group_delay(system, w=512, whole=False, fs=None):
         Normally, frequencies are computed from 0 to the Nyquist frequency,
         fs/2 (upper-half of unit-circle).  If `whole` is True, compute
         frequencies from 0 to fs.  Ignored if w is array_like.
-    fs : float
+    fs : float, optional
         The sampling frequency of the digital system.  Defaults to 2*pi
         radians/sample (so w is from 0 to pi).
 
@@ -670,8 +665,7 @@ def group_delay(system, w=512, whole=False, fs=None):
             w = np.linspace(0, pi, w, endpoint=False)
     else:
         w = np.atleast_1d(w)
-        if fs is not None:
-            w = 2*pi*w/fs
+        w = 2*pi*w/fs
 
     b, a = map(np.atleast_1d, system)
     c = np.convolve(b, a[::-1])
@@ -689,8 +683,7 @@ def group_delay(system, w=512, whole=False, fs=None):
     gd = np.zeros_like(w)
     gd[~singular] = np.real(num[~singular] / den[~singular]) - a.size + 1
 
-    if fs is not None:
-        w = w*fs/(2*pi)
+    w = w*fs/(2*pi)
 
     return w, gd
 
@@ -708,7 +701,7 @@ def _validate_sos(sos):
     return sos, n_sections
 
 
-def sosfreqz(sos, worN=None, whole=False, fs=None):
+def sosfreqz(sos, worN=None, whole=False, fs=2*pi):
     """
     Compute the frequency response of a digital filter in SOS format.
 
@@ -731,10 +724,9 @@ def sosfreqz(sos, worN=None, whole=False, fs=None):
         coefficients and the last three providing the denominator
         coefficients.
     worN : {None, int, array_like}, optional
-        If a single integer, then compute at that many frequencies.
-        Using a number that is fast for FFT computations can result in
-        faster computations (see Notes of `freqz`).  If None (default), then
-        N=512.
+        If a single integer, then compute at that many frequencies (default is
+        N=512).  Using a number that is fast for FFT computations can result
+        in faster computations (see Notes of `freqz`).
 
         If an array_like, compute the response at the frequencies given (must
         be 1D).  These are in the same units as `fs`.
@@ -742,7 +734,7 @@ def sosfreqz(sos, worN=None, whole=False, fs=None):
         Normally, frequencies are computed from 0 to the Nyquist frequency,
         fs/2 (upper-half of unit-circle).  If `whole` is True, compute
         frequencies from 0 to fs.
-    fs : float
+    fs : float, optional
         The sampling frequency of the digital system.  Defaults to 2*pi
         radians/sample (so w is from 0 to pi).
 
@@ -1862,7 +1854,7 @@ def iirdesign(wp, ws, gpass, gstop, analog=False, ftype='ellip', output='ba',
     output : {'ba', 'zpk', 'sos'}, optional
         Type of output:  numerator/denominator ('ba'), pole-zero ('zpk'), or
         second-order sections ('sos'). Default is 'ba'.
-    fs : float
+    fs : float, optional
         The sampling frequency of the digital system.
 
         .. versionadded:: 1.1.0
@@ -1959,7 +1951,7 @@ def iirfilter(N, Wn, rp=None, rs=None, btype='band', analog=False,
     output : {'ba', 'zpk', 'sos'}, optional
         Type of output:  numerator/denominator ('ba'), pole-zero ('zpk'), or
         second-order sections ('sos'). Default is 'ba'.
-    fs : float
+    fs : float, optional
         The sampling frequency of the digital system.
 
         .. versionadded:: 1.1.0
@@ -2509,7 +2501,7 @@ def butter(N, Wn, btype='low', analog=False, output='ba', fs=None):
     output : {'ba', 'zpk', 'sos'}, optional
         Type of output:  numerator/denominator ('ba'), pole-zero ('zpk'), or
         second-order sections ('sos'). Default is 'ba'.
-    fs : float
+    fs : float, optional
         The sampling frequency of the digital system.
 
         .. versionadded:: 1.1.0
@@ -2615,7 +2607,7 @@ def cheby1(N, rp, Wn, btype='low', analog=False, output='ba', fs=None):
     output : {'ba', 'zpk', 'sos'}, optional
         Type of output:  numerator/denominator ('ba'), pole-zero ('zpk'), or
         second-order sections ('sos'). Default is 'ba'.
-    fs : float
+    fs : float, optional
         The sampling frequency of the digital system.
 
         .. versionadded:: 1.1.0
@@ -2730,7 +2722,7 @@ def cheby2(N, rs, Wn, btype='low', analog=False, output='ba', fs=None):
     output : {'ba', 'zpk', 'sos'}, optional
         Type of output:  numerator/denominator ('ba'), pole-zero ('zpk'), or
         second-order sections ('sos'). Default is 'ba'.
-    fs : float
+    fs : float, optional
         The sampling frequency of the digital system.
 
         .. versionadded:: 1.1.0
@@ -2843,7 +2835,7 @@ def ellip(N, rp, rs, Wn, btype='low', analog=False, output='ba', fs=None):
     output : {'ba', 'zpk', 'sos'}, optional
         Type of output:  numerator/denominator ('ba'), pole-zero ('zpk'), or
         second-order sections ('sos'). Default is 'ba'.
-    fs : float
+    fs : float, optional
         The sampling frequency of the digital system.
 
         .. versionadded:: 1.1.0
@@ -2982,7 +2974,7 @@ def bessel(N, Wn, btype='low', analog=False, output='ba', norm='phase',
             angular frequency `Wn`.
 
         .. versionadded:: 0.18.0
-    fs : float
+    fs : float, optional
         The sampling frequency of the digital system.
 
         .. versionadded:: 1.1.0
@@ -3185,7 +3177,7 @@ def buttord(wp, ws, gpass, gstop, analog=False, fs=None):
     analog : bool, optional
         When True, return an analog filter, otherwise a digital filter is
         returned.
-    fs : float
+    fs : float, optional
         The sampling frequency of the digital system.
 
         .. versionadded:: 1.1.0
@@ -3355,7 +3347,7 @@ def cheb1ord(wp, ws, gpass, gstop, analog=False, fs=None):
     analog : bool, optional
         When True, return an analog filter, otherwise a digital filter is
         returned.
-    fs : float
+    fs : float, optional
         The sampling frequency of the digital system.
 
         .. versionadded:: 1.1.0
@@ -3493,7 +3485,7 @@ def cheb2ord(wp, ws, gpass, gstop, analog=False, fs=None):
     analog : bool, optional
         When True, return an analog filter, otherwise a digital filter is
         returned.
-    fs : float
+    fs : float, optional
         The sampling frequency of the digital system.
 
         .. versionadded:: 1.1.0
@@ -3655,7 +3647,7 @@ def ellipord(wp, ws, gpass, gstop, analog=False, fs=None):
     analog : bool, optional
         When True, return an analog filter, otherwise a digital filter is
         returned.
-    fs : float
+    fs : float, optional
         The sampling frequency of the digital system.
 
         .. versionadded:: 1.1.0
@@ -4278,7 +4270,7 @@ def besselap(N, norm='phase'):
     return asarray([]), asarray(p, dtype=complex), float(k)
 
 
-def iirnotch(w0, Q, fs=None):
+def iirnotch(w0, Q, fs=2):
     """
     Design second-order IIR notch digital filter.
 
@@ -4297,7 +4289,7 @@ def iirnotch(w0, Q, fs=None):
         Quality factor. Dimensionless parameter that characterizes
         notch filter -3 dB bandwidth ``bw`` relative to its center
         frequency, ``Q = w0/bw``.
-    fs : float
+    fs : float, optional
         The sampling frequency of the digital system.
 
         .. versionadded:: 1.1.0
@@ -4359,7 +4351,7 @@ def iirnotch(w0, Q, fs=None):
     return _design_notch_peak_filter(w0, Q, "notch", fs)
 
 
-def iirpeak(w0, Q, fs=None):
+def iirpeak(w0, Q, fs=2):
     """
     Design second-order IIR peak (resonant) digital filter.
 
@@ -4378,7 +4370,7 @@ def iirpeak(w0, Q, fs=None):
         Quality factor. Dimensionless parameter that characterizes
         peak filter -3 dB bandwidth ``bw`` relative to its center
         frequency, ``Q = w0/bw``.
-    fs : float
+    fs : float, optional
         The sampling frequency of the digital system.
 
         .. versionadded:: 1.1.0
@@ -4440,7 +4432,7 @@ def iirpeak(w0, Q, fs=None):
     return _design_notch_peak_filter(w0, Q, "peak", fs)
 
 
-def _design_notch_peak_filter(w0, Q, ftype, fs=None):
+def _design_notch_peak_filter(w0, Q, ftype, fs=2):
     """
     Design notch or peak digital filter.
 
@@ -4460,7 +4452,7 @@ def _design_notch_peak_filter(w0, Q, ftype, fs=None):
 
             - notch filter : ``notch``
             - peak filter  : ``peak``
-    fs : float
+    fs : float, optional
         The sampling frequency of the digital system.
 
         .. versionadded:: 1.1.0:
@@ -4475,8 +4467,7 @@ def _design_notch_peak_filter(w0, Q, ftype, fs=None):
     # Guarantee that the inputs are floats
     w0 = float(w0)
     Q = float(Q)
-    if fs is not None:
-        w0 = 2*w0/fs
+    w0 = 2*w0/fs
 
     # Checks if w0 is within the range
     if w0 > 1.0 or w0 < 0.0:

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -704,13 +704,13 @@ class TestFreqz(object):
         for whole in [False, True]:
             for worN in [np.random.rand(6, 7), np.empty((6, 0))]:
                 w, h = freqz(b, a, worN=worN, whole=whole)
-                assert_array_equal(w, worN)
+                assert_allclose(w, worN, rtol=1e-14)
                 assert_equal(h.shape, (2,) + worN.shape)
                 for k in range(2):
                     ww, hh = freqz(b[:, k, 0, 0], a[:, k, 0, 0],
                                    worN=worN.ravel(),
                                    whole=whole)
-                    assert_equal(ww, worN.ravel())
+                    assert_allclose(ww, worN.ravel(), rtol=1e-14)
                     assert_allclose(hh, h[k, :, :].ravel())
 
     def test_backward_compat(self):

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -678,8 +678,8 @@ class TestFreqz(object):
                 assert_array_equal(w, worN)
                 assert_equal(h.shape, (2,) + worN.shape)
                 for k in range(2):
-                    ww, hh = freqz(b[:, k, 0, 0], a[:, k, 0, 0], worN=worN.ravel(),
-                                   whole=whole)
+                    ww, hh = freqz(b[:, k, 0, 0], a[:, k, 0, 0],
+                                   worN=worN.ravel(), whole=whole)
                     assert_equal(ww, worN.ravel())
                     assert_allclose(hh, h[k, :, :].ravel())
 
@@ -689,6 +689,43 @@ class TestFreqz(object):
         w2, h2 = freqz([1.0], 1, None)
         assert_array_almost_equal(w1, w2)
         assert_array_almost_equal(h1, h2)
+
+    def test_fs_param(self):
+        fs = 900
+        b = [0.039479155677484369, 0.11843746703245311, 0.11843746703245311,
+             0.039479155677484369]
+        a = [1.0, -1.3199152021838287, 0.80341991081938424,
+             -0.16767146321568049]
+
+        # N = None
+        w1, h1 = freqz(b, a, whole=False, fs=fs)
+        w2, h2 = freqz(b, a, whole=False)
+        assert_allclose(h1, h2)
+        assert_allclose(w1, np.linspace(0, fs/2, 512, endpoint=False))
+
+        w1, h1 = freqz(b, a, whole=True, fs=fs)
+        w2, h2 = freqz(b, a, whole=True)
+        assert_allclose(h1, h2)
+        assert_allclose(w1, np.linspace(0, fs, 512, endpoint=False))
+
+        # N = 5
+        w1, h1 = freqz(b, a, 5, whole=False, fs=fs)
+        w2, h2 = freqz(b, a, 5, whole=False)
+        assert_allclose(h1, h2)
+        assert_allclose(w1, np.linspace(0, fs/2, 5, endpoint=False))
+
+        w1, h1 = freqz(b, a, 5, whole=True, fs=fs)
+        w2, h2 = freqz(b, a, 5, whole=True)
+        assert_allclose(h1, h2)
+        assert_allclose(w1, np.linspace(0, fs, 5, endpoint=False))
+
+        # w is an array
+        for w in ([123], (123,), np.array([123]), (50, 123, 230),
+                  np.array([50, 123, 230])):
+            w1, h1 = freqz(b, a, w, fs=fs)
+            w2, h2 = freqz(b, a, 2*pi*np.array(w)/fs)
+            assert_allclose(h1, h2)
+            assert_allclose(w, w1)
 
 
 class TestSOSFreqz(object):
@@ -823,6 +860,42 @@ class TestSOSFreqz(object):
         assert_allclose(w, w_mp, rtol=1e-12, atol=1e-14)
         assert_allclose(h, h_mp, rtol=1e-12, atol=1e-14)
 
+    def test_fs_param(self):
+        fs = 900
+        sos = [[0.03934683014103762, 0.07869366028207524, 0.03934683014103762,
+                1.0, -0.37256600288916636, 0.0],
+               [1.0, 1.0, 0.0, 1.0, -0.9495739996946778, 0.45125966317124144]]
+
+        # N = None
+        w1, h1 = sosfreqz(sos, whole=False, fs=fs)
+        w2, h2 = sosfreqz(sos, whole=False)
+        assert_allclose(h1, h2)
+        assert_allclose(w1, np.linspace(0, fs/2, 512, endpoint=False))
+
+        w1, h1 = sosfreqz(sos, whole=True, fs=fs)
+        w2, h2 = sosfreqz(sos, whole=True)
+        assert_allclose(h1, h2)
+        assert_allclose(w1, np.linspace(0, fs, 512, endpoint=False))
+
+        # N = 5
+        w1, h1 = sosfreqz(sos, 5, whole=False, fs=fs)
+        w2, h2 = sosfreqz(sos, 5, whole=False)
+        assert_allclose(h1, h2)
+        assert_allclose(w1, np.linspace(0, fs/2, 5, endpoint=False))
+
+        w1, h1 = sosfreqz(sos, 5, whole=True, fs=fs)
+        w2, h2 = sosfreqz(sos, 5, whole=True)
+        assert_allclose(h1, h2)
+        assert_allclose(w1, np.linspace(0, fs, 5, endpoint=False))
+
+        # w is an array
+        for w in ([123], (123,), np.array([123]), (50, 123, 230),
+                  np.array([50, 123, 230])):
+            w1, h1 = sosfreqz(sos, w, fs=fs)
+            w2, h2 = sosfreqz(sos, 2*pi*np.array(w)/fs)
+            assert_allclose(h1, h2)
+            assert_allclose(w, w1)
+
 
 class TestFreqz_zpk(object):
 
@@ -860,6 +933,44 @@ class TestFreqz_zpk(object):
         w2, h2 = freqz_zpk([0.5], [0.5], 1.0, None)
         assert_array_almost_equal(w1, w2)
         assert_array_almost_equal(h1, h2)
+
+    def test_fs_param(self):
+        fs = 900
+        z = [-1, -1, -1]
+        p = [0.4747869998473389+0.4752230717749344j, 0.37256600288916636,
+             0.4747869998473389-0.4752230717749344j]
+        k = 0.03934683014103762
+
+        # N = None
+        w1, h1 = freqz_zpk(z, p, k, whole=False, fs=fs)
+        w2, h2 = freqz_zpk(z, p, k, whole=False)
+        assert_allclose(h1, h2)
+        assert_allclose(w1, np.linspace(0, fs/2, 512, endpoint=False))
+
+        w1, h1 = freqz_zpk(z, p, k, whole=True, fs=fs)
+        w2, h2 = freqz_zpk(z, p, k, whole=True)
+        assert_allclose(h1, h2)
+        assert_allclose(w1, np.linspace(0, fs, 512, endpoint=False))
+
+        # N = 5
+        w1, h1 = freqz_zpk(z, p, k, 5, whole=False, fs=fs)
+        w2, h2 = freqz_zpk(z, p, k, 5, whole=False)
+        assert_allclose(h1, h2)
+        assert_allclose(w1, np.linspace(0, fs/2, 5, endpoint=False))
+
+        w1, h1 = freqz_zpk(z, p, k, 5, whole=True, fs=fs)
+        w2, h2 = freqz_zpk(z, p, k, 5, whole=True)
+        assert_allclose(h1, h2)
+        assert_allclose(w1, np.linspace(0, fs, 5, endpoint=False))
+
+        # w is an array
+        for w in ([123], (123,), np.array([123]), (50, 123, 230),
+                  np.array([50, 123, 230])):
+            w1, h1 = freqz_zpk(z, p, k, w, fs=fs)
+            w2, h2 = freqz_zpk(z, p, k, 2*pi*np.array(w)/fs)
+            assert_allclose(h1, h2)
+            assert_allclose(w, w1)
+
 
 class TestNormalize(object):
 
@@ -1189,6 +1300,24 @@ class TestButtord(object):
 
         assert_equal(buttord(1, 1.2, 1, 80, analog=True)[0], 55)
 
+    def test_fs_param(self):
+        wp = [4410, 11025]
+        ws = [2205, 13230]
+        rp = 3
+        rs = 80
+        fs = 44100
+        N, Wn = buttord(wp, ws, rp, rs, False, fs=fs)
+        b, a = butter(N, Wn, 'bandpass', False, fs=fs)
+        w, h = freqz(b, a, fs=fs)
+        assert_array_less(-rp - 0.1,
+                          dB(h[np.logical_and(wp[0] <= w, w <= wp[1])]))
+        assert_array_less(dB(h[np.logical_or(w <= ws[0], ws[1] <= w)]),
+                          -rs + 0.1)
+
+        assert_equal(N, 18)
+        assert_allclose(Wn, [4409.722701715714, 11025.47178084662],
+                        rtol=1e-15)
+
 
 class TestCheb1ord(object):
 
@@ -1271,6 +1400,21 @@ class TestCheb1ord(object):
         assert_allclose(Wn, 700, rtol=1e-15)
 
         assert_equal(cheb1ord(1, 1.2, 1, 80, analog=True)[0], 17)
+
+    def test_fs_param(self):
+        wp = 4800
+        ws = 7200
+        rp = 3
+        rs = 60
+        fs = 48000
+        N, Wn = cheb1ord(wp, ws, rp, rs, False, fs=fs)
+        b, a = cheby1(N, rp, Wn, 'low', False, fs=fs)
+        w, h = freqz(b, a, fs=fs)
+        assert_array_less(-rp - 0.1, dB(h[w <= wp]))
+        assert_array_less(dB(h[ws <= w]), -rs + 0.1)
+
+        assert_equal(N, 8)
+        assert_allclose(Wn, 4800, rtol=1e-15)
 
 
 class TestCheb2ord(object):
@@ -1358,6 +1502,21 @@ class TestCheb2ord(object):
         assert_allclose(Wn, [1.673740595370124e+01, 5.974641487254268e+01],
                         rtol=1e-15)
 
+    def test_fs_param(self):
+        wp = 150
+        ws = 100
+        rp = 3
+        rs = 70
+        fs = 1000
+        N, Wn = cheb2ord(wp, ws, rp, rs, False, fs=fs)
+        b, a = cheby2(N, rs, Wn, 'hp', False, fs=fs)
+        w, h = freqz(b, a, fs=fs)
+        assert_array_less(-rp - 0.1, dB(h[wp <= w]))
+        assert_array_less(dB(h[w <= ws]), -rs + 0.1)
+
+        assert_equal(N, 9)
+        assert_allclose(Wn, 103.4874609145164, rtol=1e-15)
+
 
 class TestEllipord(object):
 
@@ -1442,6 +1601,23 @@ class TestEllipord(object):
         assert_allclose(Wn, [1666.6666, 6000])
 
         assert_equal(ellipord(1, 1.2, 1, 80, analog=True)[0], 9)
+
+    def test_fs_param(self):
+        wp = [400, 2400]
+        ws = [800, 2000]
+        rp = 3
+        rs = 90
+        fs = 8000
+        N, Wn = ellipord(wp, ws, rp, rs, False, fs=fs)
+        b, a = ellip(N, rp, rs, Wn, 'bs', False, fs=fs)
+        w, h = freqz(b, a, fs=fs)
+        assert_array_less(-rp - 0.1,
+                          dB(h[np.logical_or(w <= wp[0], wp[1] <= w)]))
+        assert_array_less(dB(h[np.logical_and(ws[0] <= w, w <= ws[1])]),
+                          -rs + 0.1)
+
+        assert_equal(N, 7)
+        assert_allclose(Wn, [590.3293117737195, 2400], rtol=1e-5)
 
 
 class TestBessel(object):
@@ -1906,6 +2082,23 @@ class TestBessel(object):
         assert_raises(ValueError, _bessel_poly, -3)
         assert_raises(ValueError, _bessel_poly, 3.3)
 
+    def test_fs_param(self):
+        for norm in ('phase', 'mag', 'delay'):
+            for fs in (900, 900.1, 1234.567):
+                for N in (0, 1, 2, 3, 10):
+                    for fc in (100, 100.1, 432.12345):
+                        for btype in ('lp', 'hp'):
+                            ba1 = bessel(N, fc, btype, fs=fs)
+                            ba2 = bessel(N, fc/(fs/2), btype)
+                            assert_allclose(ba1, ba2)
+                    for fc in ((100, 200), (100.1, 200.2), (321.123, 432.123)):
+                        for btype in ('bp', 'bs'):
+                            ba1 = bessel(N, fc, btype, fs=fs)
+                            for seq in (list, tuple, array):
+                                fcnorm = seq([f/(fs/2) for f in fc])
+                                ba2 = bessel(N, fcnorm, btype)
+                                assert_allclose(ba1, ba2)
+
 
 class TestButter(object):
 
@@ -2142,6 +2335,22 @@ class TestButter(object):
               8.099999999999991e+17]
         assert_allclose(b, b2, rtol=1e-14)
         assert_allclose(a, a2, rtol=1e-14)
+
+    def test_fs_param(self):
+        for fs in (900, 900.1, 1234.567):
+            for N in (0, 1, 2, 3, 10):
+                for fc in (100, 100.1, 432.12345):
+                    for btype in ('lp', 'hp'):
+                        ba1 = butter(N, fc, btype, fs=fs)
+                        ba2 = butter(N, fc/(fs/2), btype)
+                        assert_allclose(ba1, ba2)
+                for fc in ((100, 200), (100.1, 200.2), (321.123, 432.123)):
+                    for btype in ('bp', 'bs'):
+                        ba1 = butter(N, fc, btype, fs=fs)
+                        for seq in (list, tuple, array):
+                            fcnorm = seq([f/(fs/2) for f in fc])
+                            ba2 = butter(N, fcnorm, btype)
+                            assert_allclose(ba1, ba2)
 
 
 class TestCheby1(object):
@@ -2393,6 +2602,22 @@ class TestCheby1(object):
               ]
         assert_allclose(b, b2, rtol=1e-14)
         assert_allclose(a, a2, rtol=1e-14)
+
+    def test_fs_param(self):
+        for fs in (900, 900.1, 1234.567):
+            for N in (0, 1, 2, 3, 10):
+                for fc in (100, 100.1, 432.12345):
+                    for btype in ('lp', 'hp'):
+                        ba1 = cheby1(N, 1, fc, btype, fs=fs)
+                        ba2 = cheby1(N, 1, fc/(fs/2), btype)
+                        assert_allclose(ba1, ba2)
+                for fc in ((100, 200), (100.1, 200.2), (321.123, 432.123)):
+                    for btype in ('bp', 'bs'):
+                        ba1 = cheby1(N, 1, fc, btype, fs=fs)
+                        for seq in (list, tuple, array):
+                            fcnorm = seq([f/(fs/2) for f in fc])
+                            ba2 = cheby1(N, 1, fcnorm, btype)
+                            assert_allclose(ba1, ba2)
 
 
 class TestCheby2(object):
@@ -2661,6 +2886,21 @@ class TestCheby2(object):
         assert_allclose(b, b2, rtol=1e-14)
         assert_allclose(a, a2, rtol=1e-14)
 
+    def test_fs_param(self):
+        for fs in (900, 900.1, 1234.567):
+            for N in (0, 1, 2, 3, 10):
+                for fc in (100, 100.1, 432.12345):
+                    for btype in ('lp', 'hp'):
+                        ba1 = cheby2(N, 20, fc, btype, fs=fs)
+                        ba2 = cheby2(N, 20, fc/(fs/2), btype)
+                        assert_allclose(ba1, ba2)
+                for fc in ((100, 200), (100.1, 200.2), (321.123, 432.123)):
+                    for btype in ('bp', 'bs'):
+                        ba1 = cheby2(N, 20, fc, btype, fs=fs)
+                        for seq in (list, tuple, array):
+                            fcnorm = seq([f/(fs/2) for f in fc])
+                            ba2 = cheby2(N, 20, fcnorm, btype)
+                            assert_allclose(ba1, ba2)
 
 class TestEllip(object):
 
@@ -2947,6 +3187,22 @@ class TestEllip(object):
         assert_allclose(b, b2, rtol=1e-6)
         assert_allclose(a, a2, rtol=1e-4)
 
+    def test_fs_param(self):
+        for fs in (900, 900.1, 1234.567):
+            for N in (0, 1, 2, 3, 10):
+                for fc in (100, 100.1, 432.12345):
+                    for btype in ('lp', 'hp'):
+                        ba1 = ellip(N, 1, 20, fc, btype, fs=fs)
+                        ba2 = ellip(N, 1, 20, fc/(fs/2), btype)
+                        assert_allclose(ba1, ba2)
+                for fc in ((100, 200), (100.1, 200.2), (321.123, 432.123)):
+                    for btype in ('bp', 'bs'):
+                        ba1 = ellip(N, 1, 20, fc, btype, fs=fs)
+                        for seq in (list, tuple, array):
+                            fcnorm = seq([f/(fs/2) for f in fc])
+                            ba2 = ellip(N, 1, 20, fcnorm, btype)
+                            assert_allclose(ba1, ba2)
+
 
 def test_sos_consistency():
     # Consistency checks of output='sos' for the specialized IIR filter
@@ -3032,6 +3288,38 @@ class TestIIRNotch(object):
         assert_raises(ValueError, iirnotch, w0="blabla", Q=30)
         assert_raises(TypeError, iirnotch, w0=-1, Q=[1, 2, 3])
 
+    def test_fs_param(self):
+        # Get filter coeficients
+        b, a = iirnotch(1500, 30, fs=10000)
+
+        # Get frequency response
+        w, h = freqz(b, a, 1000, fs=10000)
+
+        # Pick 5 point
+        p = [200,  # w0 = 1000
+             295,  # w0 = 1475
+             300,  # w0 = 1500
+             305,  # w0 = 1525
+             400]  # w0 = 2000
+
+        # Get frequency response correspondent to each of those points
+        hp = h[p]
+
+        # Check if the frequency response fulfil the specifications:
+        # hp[0] and hp[4]  correspond to frequencies distant from
+        # w0 = 1500 and should be close to 1
+        assert_allclose(abs(hp[0]), 1, rtol=1e-2)
+        assert_allclose(abs(hp[4]), 1, rtol=1e-2)
+
+        # hp[1] and hp[3] correspond to frequencies approximately
+        # on the edges of the passband and should be close to -3dB
+        assert_allclose(abs(hp[1]), 1/np.sqrt(2), rtol=1e-2)
+        assert_allclose(abs(hp[3]), 1/np.sqrt(2), rtol=1e-2)
+
+        # hp[2] correspond to the frequency that should be removed
+        # the frequency response should be very close to 0
+        assert_allclose(abs(hp[2]), 0, atol=1e-10)
+
 
 class TestIIRPeak(object):
 
@@ -3091,6 +3379,38 @@ class TestIIRPeak(object):
         # are not float (or cannot be converted to one)
         assert_raises(ValueError, iirpeak, w0="blabla", Q=30)
         assert_raises(TypeError, iirpeak, w0=-1, Q=[1, 2, 3])
+
+    def test_fs_param(self):
+        # Get filter coeficients
+        b, a = iirpeak(1200, 30, fs=8000)
+
+        # Get frequency response
+        w, h = freqz(b, a, 1000, fs=8000)
+
+        # Pick 5 point
+        p = [30,  # w0 = 120
+             295,  # w0 = 1180
+             300,  # w0 = 1200
+             305,  # w0 = 1220
+             800]  # w0 = 3200
+
+        # Get frequency response correspondent to each of those points
+        hp = h[p]
+
+        # Check if the frequency response fulfil the specifications:
+        # hp[0] and hp[4]  correspond to frequencies distant from
+        # w0 = 1200 and should be close to 0
+        assert_allclose(abs(hp[0]), 0, atol=1e-2)
+        assert_allclose(abs(hp[4]), 0, atol=1e-2)
+
+        # hp[1] and hp[3] correspond to frequencies approximately
+        # on the edges of the passband and should be close to 10**(-3/20)
+        assert_allclose(abs(hp[1]), 1/np.sqrt(2), rtol=1e-2)
+        assert_allclose(abs(hp[3]), 1/np.sqrt(2), rtol=1e-2)
+
+        # hp[2] correspond to the frequency that should be retained and
+        # the frequency response should be very close to 1
+        assert_allclose(abs(hp[2]), 1, rtol=1e-10)
 
 
 class TestIIRFilter(object):
@@ -3189,3 +3509,16 @@ class TestGroupDelay(object):
         w2, gd2 = group_delay((1, 1), None)
         assert_array_almost_equal(w1, w2)
         assert_array_almost_equal(gd1, gd2)
+
+    def test_fs_param(self):
+        # Let's design Butterworth filter and test the group delay at
+        # some points against the normalized frequency answer.
+        b, a = butter(4, 4800, fs=96000)
+        w = np.linspace(0, 96000/2, num=10, endpoint=False)
+        w, gd = group_delay((b, a), w=w, fs=96000)
+        norm_gd = np.array([8.249313898506037, 11.958947880907104,
+                            2.452325615326005, 1.048918665702008,
+                            0.611382575635897, 0.418293269460578,
+                            0.317932917836572, 0.261371844762525,
+                            0.229038045801298, 0.212185774208521])
+        assert_array_almost_equal(gd, norm_gd)

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -451,6 +451,13 @@ class TestFreqs(object):
         assert_array_almost_equal(w1, w2)
         assert_array_almost_equal(h1, h2)
 
+    def test_w_types(self):
+        for w in (8, np.int8(8), np.int16(8), np.int32(8), np.int64(8),
+                  np.array(8)):
+            w, h = freqs([1.0], [1.0], worN=w)
+            assert_equal(len(w), 8)
+            assert_array_almost_equal(h, np.ones(8))
+
 
 class TestFreqs_zpk(object):
 
@@ -727,6 +734,13 @@ class TestFreqz(object):
             assert_allclose(h1, h2)
             assert_allclose(w, w1)
 
+    def test_w_types(self):
+        for w in (8, np.int8(8), np.int16(8), np.int32(8), np.int64(8),
+                  np.array(8)):
+            w, h = freqz([1.0], worN=w)
+            assert_array_almost_equal(w, np.pi * np.arange(8) / 8.)
+            assert_array_almost_equal(h, np.ones(8))
+
 
 class TestSOSFreqz(object):
 
@@ -896,6 +910,13 @@ class TestSOSFreqz(object):
             assert_allclose(h1, h2)
             assert_allclose(w, w1)
 
+    def test_w_types(self):
+        for w in (8, np.int8(8), np.int16(8), np.int32(8), np.int64(8),
+                  np.array(8)):
+            w, h = sosfreqz([1, 0, 0, 1, 0, 0], worN=w)
+            assert_array_almost_equal(w, np.pi * np.arange(8) / 8.)
+            assert_array_almost_equal(h, np.ones(8))
+
 
 class TestFreqz_zpk(object):
 
@@ -970,6 +991,13 @@ class TestFreqz_zpk(object):
             w2, h2 = freqz_zpk(z, p, k, 2*pi*np.array(w)/fs)
             assert_allclose(h1, h2)
             assert_allclose(w, w1)
+
+    def test_w_types(self):
+        for w in (8, np.int8(8), np.int16(8), np.int32(8), np.int64(8),
+                  np.array(8)):
+            w, h = freqz_zpk([], [], 1, worN=w)
+            assert_array_almost_equal(w, np.pi * np.arange(8) / 8.)
+            assert_array_almost_equal(h, np.ones(8))
 
 
 class TestNormalize(object):
@@ -3522,3 +3550,10 @@ class TestGroupDelay(object):
                             0.317932917836572, 0.261371844762525,
                             0.229038045801298, 0.212185774208521])
         assert_array_almost_equal(gd, norm_gd)
+
+    def test_w_types(self):
+        for w in (8, np.int8(8), np.int16(8), np.int32(8), np.int64(8),
+                  np.array(8)):
+            w, gd = group_delay((1, 1), w)
+            assert_array_almost_equal(w, pi * np.arange(8) / 8)
+            assert_array_almost_equal(gd, np.zeros(8))


### PR DESCRIPTION
This is just a more convenient way of specifying normalized frequencies for digital filters.  Instead of having to remember that `butter` uses `fc/(fs/2)`, while `freqz` uses `fc/(fs/(2*pi))`, for instance, you can just specify the frequencies in Hz and the sampling rate in Hz.

Old way:

```
>>> fc = 1000
>>> fs = 3000
>>> b, a = butter(2, fc/(fs/2))
>>> abs(freqz(b, a, [fc/(fs/(2*pi))])[1])
array([ 0.70710678])
```

New way:

```
>>> fc = 1000
>>> fs = 3000
>>> b, a = butter(2, fc, fs=fs)
>>> abs(freqz(b, a, [fc], fs=fs)[1])
array([ 0.70710678])
```


I proposed this a while ago and no one seemed interested, but it's easy enough to implement so we'll see what people think.

Examples of confusion:

- https://dsp.stackexchange.com/q/46915/29
- https://dsp.stackexchange.com/q/24989/29#comment45751_24992
- https://mail.python.org/pipermail/scipy-user/2008-March/015944.html