### PR TITLE
ENH:special:Tighten cdflib precision to 1e-15

### DIFF
--- a/scipy/special/_cdflib.pyx
+++ b/scipy/special/_cdflib.pyx
@@ -1181,7 +1181,7 @@ cdef inline (double, double, int, double) cdfbet_which2(
     double p, double q, double a, double b) noexcept nogil:
 
     cdef double ccum, cum, xx, yy
-    cdef double tol = 1e-8
+    cdef double tol = 1e-15
     cdef double atol = 1e-50
     cdef bint qporq
     # Cython doesn't allow for default values in structs
@@ -1234,7 +1234,7 @@ cdef inline (double, double, int, double) cdfbet_which2(
 
 cdef inline (double, int, double) cdfbet_which3(
     double p, double q, double x, double y, double b) noexcept nogil:
-    cdef double tol = 1e-8
+    cdef double tol = 1e-15
     cdef double atol = 1e-50
     cdef bint qporq = p <= q
     cdef DinvrState DS = DinvrState(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -1281,7 +1281,7 @@ cdef inline (double, int, double) cdfbet_which3(
 
 cdef inline (double, int, double) cdfbet_which4(
     double p, double q, double x, double y, double a) noexcept nogil:
-    cdef double tol = 1e-8
+    cdef double tol = 1e-15
     cdef double atol = 1e-50
     cdef bint qporq = p <= q
 
@@ -1437,7 +1437,7 @@ cdef inline (double, double, int, double) cdfbin_which1(
 cdef inline (double, int, double) cdfbin_which2(
     double p, double q, double xn, double pr, double ompr) noexcept nogil:
     cdef double ccum, cum
-    cdef double tol = 1e-8
+    cdef double tol = 1e-15
     cdef double atol = 1e-50
     cdef bint qporq = p <= q
     cdef DinvrState DS = DinvrState(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -1485,7 +1485,7 @@ cdef inline (double, int, double) cdfbin_which2(
 cdef inline (double, int, double) cdfbin_which3(
     double p, double q, double s, double pr, double ompr) noexcept nogil:
     cdef double ccum, cum
-    cdef double tol = 1e-8
+    cdef double tol = 1e-15
     cdef double atol = 1e-50
     cdef bint qporq = p <= q
     cdef DinvrState DS = DinvrState(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -1533,7 +1533,7 @@ cdef inline (double, int, double) cdfbin_which3(
 cdef inline (double, double, int, double) cdfbin_which4(
     double p, double q, double s, double xn) noexcept nogil:
     cdef double ccum, cum, pr, ompr
-    cdef double tol = 1e-8
+    cdef double tol = 1e-15
     cdef double atol = 1e-50
     cdef bint qporq = p <= q
     # Cython doesn't allow for default values in structs
@@ -1680,7 +1680,7 @@ cdef inline (double, int, double) cdfchi_which2(
     cdef bint qporq = p <= q
     cdef double porq = p if qporq else q
     cdef double ccum, cum
-    cdef double tol = 1e-8
+    cdef double tol = 1e-15
     cdef double atol = 1e-50
     cdef DinvrState DS = DinvrState(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                                     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -1725,7 +1725,7 @@ cdef inline (double, int, double) cdfchi_which3(
     cdef bint qporq = p <= q
     cdef double porq = p if qporq else q
     cdef double ccum, cum
-    cdef double tol = 1e-8
+    cdef double tol = 1e-15
     cdef double atol = 1e-50
     cdef DinvrState DS = DinvrState(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                                     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -1876,7 +1876,7 @@ cdef inline (double, double, int, double) cdfchn_which1(
 cdef inline (double, int, double) cdfchn_which2(
     double p, double df, double pnonc) noexcept nogil:
     cdef double cum
-    cdef double tol = 1e-8
+    cdef double tol = 1e-15
     cdef double atol = 1e-50
     cdef DinvrState DS = DinvrState(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                                     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -1919,7 +1919,7 @@ cdef inline (double, int, double) cdfchn_which2(
 cdef inline (double, int, double) cdfchn_which3(
     double p, double x, double pnonc) noexcept nogil:
     cdef double cum
-    cdef double tol = 1e-8
+    cdef double tol = 1e-15
     cdef double atol = 1e-50
     cdef DinvrState DS = DinvrState(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                                     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -1962,7 +1962,7 @@ cdef inline (double, int, double) cdfchn_which3(
 cdef inline (double, int, double) cdfchn_which4(
     double p, double x, double df) noexcept nogil:
     cdef double cum
-    cdef double tol = 1e-8
+    cdef double tol = 1e-15
     cdef double atol = 1e-50
     cdef DinvrState DS = DinvrState(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                                     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -2107,7 +2107,7 @@ cdef inline (double, double, int, double) cdff_which1(
 cdef inline (double, int, double) cdff_which2(
     double p, double q, double dfn, double dfd) noexcept nogil:
     cdef double cum, ccum
-    cdef double tol = 1e-8
+    cdef double tol = 1e-15
     cdef double atol = 1e-50
     cdef bint qporq = p <= q
     cdef DinvrState DS = DinvrState(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -2152,7 +2152,7 @@ cdef inline (double, int, double) cdff_which2(
 cdef inline (double, int, double) cdff_which3(
     double p, double q, double f, double dfd) noexcept nogil:
     cdef double cum, ccum
-    cdef double tol = 1e-8
+    cdef double tol = 1e-15
     cdef double atol = 1e-50
     cdef bint qporq = p <= q
     cdef DinvrState DS = DinvrState(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -2197,7 +2197,7 @@ cdef inline (double, int, double) cdff_which3(
 cdef inline (double, int, double) cdff_which4(
     double p, double q, double f, double dfn) noexcept nogil:
     cdef double cum, ccum
-    cdef double tol = 1e-8
+    cdef double tol = 1e-15
     cdef double atol = 1e-50
     cdef bint qporq = p <= q
     cdef DinvrState DS = DinvrState(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -2365,7 +2365,7 @@ cdef (double, double, int, double) cdffnc_which1(
 cdef (double, int, double) cdffnc_which2(
     double p, double q, double dfn, double dfd, double phonc) noexcept nogil:
     cdef double cum
-    cdef double tol = 1e-8
+    cdef double tol = 1e-15
     cdef double atol = 1e-50
     cdef int ierr
     cdef DinvrState DS = DinvrState(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -2410,7 +2410,7 @@ cdef (double, int, double) cdffnc_which2(
 cdef (double, int, double) cdffnc_which3(
     double p, double q, double f, double dfd, double phonc) noexcept nogil:
     cdef double cum
-    cdef double tol = 1e-8
+    cdef double tol = 1e-15
     cdef double atol = 1e-50
     cdef int ierr
     cdef DinvrState DS = DinvrState(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -2455,7 +2455,7 @@ cdef (double, int, double) cdffnc_which3(
 cdef (double, int, double) cdffnc_which4(
     double p, double q, double f, double dfn, double phonc) noexcept nogil:
     cdef double cum
-    cdef double tol = 1e-8
+    cdef double tol = 1e-15
     cdef double atol = 1e-50
     cdef int ierr
     cdef DinvrState DS = DinvrState(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -2500,7 +2500,7 @@ cdef (double, int, double) cdffnc_which4(
 cdef (double, int, double) cdffnc_which5(
     double p, double q, double f, double dfn, double dfd) noexcept nogil:
     cdef double cum
-    cdef double tol = 1e-8
+    cdef double tol = 1e-15
     cdef double atol = 1e-50
     cdef int ierr
     cdef DinvrState DS = DinvrState(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -2682,7 +2682,7 @@ cdef (double, int, double) cdfgam_which3(
     double p, double q, double x, double scale) noexcept nogil:
     cdef double cum, ccum
     cdef double xscale = x*scale
-    cdef double tol = 1e-8
+    cdef double tol = 1e-15
     cdef double atol = 1e-50
     cdef bint qporq = p <= q
 
@@ -2870,7 +2870,7 @@ cdef inline (double, double, int, double) cdfnbn_which1(
 cdef inline (double, int, double) cdfnbn_which2(
     double p, double q, double xn, double pr, double ompr) noexcept nogil:
     cdef double ccum, cum
-    cdef double tol = 1e-8
+    cdef double tol = 1e-15
     cdef double atol = 1e-50
     cdef bint qporq = p <= q
     cdef DinvrState DS = DinvrState(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -2918,7 +2918,7 @@ cdef inline (double, int, double) cdfnbn_which2(
 cdef inline (double, int, double) cdfnbn_which3(
     double p, double q, double s, double pr, double ompr) noexcept nogil:
     cdef double ccum, cum
-    cdef double tol = 1e-8
+    cdef double tol = 1e-15
     cdef double atol = 1e-50
     cdef bint qporq = p <= q
     cdef DinvrState DS = DinvrState(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -2967,7 +2967,7 @@ cdef inline (double, int, double) cdfnbn_which3(
 cdef inline (double, double, int, double) cdfnbn_which4(
     double p, double q, double s, double xn) noexcept nogil:
     cdef double ccum, cum, pr, ompr
-    cdef double tol = 1e-8
+    cdef double tol = 1e-15
     cdef double atol = 1e-50
     cdef bint qporq = p <= q
     # Cython doesn't allow for default values in structs
@@ -3237,7 +3237,7 @@ cdef inline (double, double, int, double) cdfpoi_which1(
 cdef inline (double, int, double) cdfpoi_which2(
     double p, double q, double xlam) noexcept nogil:
     cdef double ccum, cum
-    cdef double tol = 1e-8
+    cdef double tol = 1e-15
     cdef double atol = 1e-50
     cdef bint qporq = p <= q
     cdef DinvrState DS = DinvrState(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -3282,7 +3282,7 @@ cdef inline (double, int, double) cdfpoi_which2(
 cdef inline (double, int, double) cdfpoi_which3(
     double p, double q, double s) noexcept nogil:
     cdef double ccum, cum
-    cdef double tol = 1e-8
+    cdef double tol = 1e-15
     cdef double atol = 1e-50
     cdef bint qporq = p <= q
     cdef DinvrState DS = DinvrState(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -3407,7 +3407,7 @@ cdef inline (double, double, int, double) cdft_which1(
 cdef inline (double, int, double) cdft_which2(
     double p, double q, double df) noexcept nogil:
     cdef double ccum, cum
-    cdef double tol = 1e-8
+    cdef double tol = 1e-15
     cdef double atol = 1e-50
     cdef bint qporq = p <= q
     cdef DinvrState DS = DinvrState(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -3449,7 +3449,7 @@ cdef inline (double, int, double) cdft_which2(
 cdef inline (double, int, double) cdft_which3(
     double p, double q, double t) noexcept nogil:
     cdef double ccum, cum
-    cdef double tol = 1e-8
+    cdef double tol = 1e-15
     cdef double atol = 1e-50
     cdef bint qporq = p <= q
     cdef DinvrState DS = DinvrState(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -3578,7 +3578,7 @@ cdef inline (double, double, int, double) cdftnc_which1(
 cdef inline (double, int, double) cdftnc_which2(
     double p, double q, double df, double pnonc) noexcept nogil:
     cdef double cum
-    cdef double tol = 1e-8
+    cdef double tol = 1e-15
     cdef double atol = 1e-50
     cdef DinvrState DS = DinvrState(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                                     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -3622,7 +3622,7 @@ cdef inline (double, int, double) cdftnc_which2(
 cdef inline (double, int, double) cdftnc_which3(
     double p, double q, double t, double pnonc) noexcept nogil:
     cdef double cum
-    cdef double tol = 1e-8
+    cdef double tol = 1e-15
     cdef double atol = 1e-50
     cdef DinvrState DS = DinvrState(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                                     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -3665,7 +3665,7 @@ cdef inline (double, int, double) cdftnc_which3(
 cdef inline (double, int, double) cdftnc_which4(
     double p, double q, double t, double df) noexcept nogil:
     cdef double cum
-    cdef double tol = 1e-8
+    cdef double tol = 1e-15
     cdef double atol = 1e-50
     cdef DinvrState DS = DinvrState(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                                     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,

--- a/scipy/special/tests/test_cdft_asymptotic.py
+++ b/scipy/special/tests/test_cdft_asymptotic.py
@@ -33,7 +33,7 @@ def test_stdtrit_vs_R_large_df():
              -1.2815515655454472466,
              -1.2815515655446008125,
              -1.2815515655446008125]
-    assert_allclose(res, res_R, rtol=1e-15)
+    assert_allclose(res, res_R, rtol=1e-14, atol=1e-15)
     # last value should also agree with ndtri
     assert_equal(res[3], ndtri(0.1))
 

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -91,8 +91,8 @@ class TestMvsdist:
         data = [6, 9, 12, 7, 8, 8, 13]
         mean, var, std = stats.mvsdist(data)
         assert_almost_equal(mean.mean(), 9.0)
-        assert_allclose(mean.interval(0.9), (7.1036502226125329,
-                                             10.896349777387467), rtol=1e-14)
+        assert_allclose(mean.interval(0.9), (7.103650222492964,
+                                             10.896349777507034), rtol=1e-14)
 
         assert_almost_equal(var.mean(), 10.0)
         assert_allclose(var.interval(0.9), (3.1767242068607087,

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -63,7 +63,7 @@ class TestBayes_mvs:
         data = [6, 9, 12, 7, 8, 8, 13]
         mean, var, std = stats.bayes_mvs(data)
         assert_almost_equal(mean.statistic, 9.0)
-        assert_allclose(mean.minmax, (7.1036502226125329, 10.896349777387467),
+        assert_allclose(mean.minmax, (7.103650222492964, 10.896349777507034),
                         rtol=1e-14)
 
         assert_almost_equal(var.statistic, 10.0)

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -64,7 +64,7 @@ class TestBayes_mvs:
         mean, var, std = stats.bayes_mvs(data)
         assert_almost_equal(mean.statistic, 9.0)
         assert_allclose(mean.minmax, (7.103650222492964, 10.896349777507034),
-                        rtol=1e-14)
+                        rtol=1e-6)
 
         assert_almost_equal(var.statistic, 10.0)
         assert_allclose(var.minmax, (3.1767242068607087, 24.45910381334018),


### PR DESCRIPTION
A potential fix for #8398 , I just edited all occurence (found with grep) of 1e-8 to 1e16 so that it would have double precision, since as of now it returns fake double precision.

Hopefully it still works and does not break everything, I'm waiting for the buildbots to tell me if my fortran editing is fine.

Closes gh-8398