### PR TITLE
BUG: sparse.linalg: fix termination bugs for cg, cgs

### DIFF
--- a/scipy/sparse/linalg/isolve/iterative/CGSREVCOM.f.src
+++ b/scipy/sparse/linalg/isolve/iterative/CGSREVCOM.f.src
@@ -11,6 +11,7 @@
 *     Eijkhout, Pozo, Romine, and van der Vorst, SIAM Publications,
 *     1993. (ftp netlib2.cs.utk.edu; cd linalg; get templates.ps).
 *
+      IMPLICIT NONE
 *     .. Scalar Arguments ..
       INTEGER            N, LDW, ITER, INFO
       <rt=real,double precision,real,double precision>    RESID
@@ -410,7 +411,12 @@
 *
 *     Set breakdown flag.
 *
-      IF ( ABS( RHO ).LT.RHOTOL ) INFO = -10
+      IF ( ABS( RHO ).LT.RHOTOL ) THEN
+         INFO = -10
+         RLBL = -1
+         IJOB = -1
+         RETURN
+      ENDIF
 *
    30 CONTINUE
 *

--- a/scipy/sparse/linalg/isolve/iterative/QMRREVCOM.f.src
+++ b/scipy/sparse/linalg/isolve/iterative/QMRREVCOM.f.src
@@ -12,6 +12,7 @@
 *     Eijkhout, Pozo, Romine, and van der Vorst, SIAM Publications,
 *     1993. (ftp netlib2.cs.utk.edu; cd linalg; get templates.ps).
 *
+      IMPLICIT NONE
 *     .. Scalar Arguments ..
       INTEGER            N, LDW, ITER, INFO
       <rt=real,double precision,real,double precision>  RESID

--- a/scipy/sparse/linalg/isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/isolve/tests/test_iterative.py
@@ -380,12 +380,6 @@ def test_atol(solver):
         residual = A.dot(x) - b
         err = np.linalg.norm(residual)
         atol2 = tol * b_norm
-
-        # XXX: cg and cgs use approximate residual for termination
-        if solver in (cg, cgs):
-            atol *= 2
-            atol2 *= 2
-
         assert_(err <= max(atol, atol2))
 
 
@@ -406,7 +400,15 @@ def test_zero_rhs(solver):
             assert_equal(info, 0)
             assert_allclose(x, 0, atol=1e-15)
 
+            x, info = solver(A, b, tol=tol, x0=ones(10))
+            assert_equal(info, 0)
+            assert_allclose(x, 0, atol=tol)
+
             if solver is not minres:
+                x, info = solver(A, b, tol=tol, atol=0, x0=ones(10))
+                if info == 0:
+                    assert_allclose(x, 0)
+
                 x, info = solver(A, b, tol=tol, atol=tol)
                 assert_equal(info, 0)
                 assert_allclose(x, 0, atol=1e-300)


### PR DESCRIPTION
<s>(This goes on top of gh-8400, only the last commit is new. This is split to a separate PR for simpler reviewing since it's a different issue.)</s>

Both cg and cgs solvers accumulate rounding errors, which can make the residual termination checks inaccurate. Fix this by recomputing the residual on apparently successful convergence.

The CGS solver has a breakdown condition, which the Fortran code does not report correctly, it sets INFO=-10, but resets it to INFO=0, IJOB=-1 on the next lines before returning so that the algorithm may terminate even if the residual does not satisfy the termination condition. The matlab code by the  authors of these fortran codes on the other hand does it correctly, see http://www.netlib.org/templates/matlab/cgs.m. This PR fixes the breakdown reporting and changes the Python implementation to do a separate convergence check at breakdown.