### PR TITLE
Setting "unknown" message in OptimizeResult when calling MINPACK.

### DIFF
--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -256,7 +256,7 @@ def _root_hybr(func, x0, args=(), jac=None,
     try:
         sol['message'] = errors[status]
     except KeyError:
-        info['message'] = errors['unknown']
+        sol['message'] = errors['unknown']
 
     return sol
 


### PR DESCRIPTION
The current code looks like it **used to** use `info` and then never got updated once an `OptimizeResult` was introduced.