### PR TITLE
ENH: scipy.sparse: copy keyword added for conj methods

### DIFF
--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -712,11 +712,11 @@ class spmatrix(object):
         Parameters
         ----------
         copy : bool, optional
-            Whether always a copy should be returned.
+            If True, the result is guaranteed to not share data with self.
 
         Returns
         -------
-        A : `self` with the data element-wise complex conjugated.
+        A : The element-wise complex conjugate.
 
         """
         if np.issubdtype(self.dtype, np.complexfloating):

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -720,7 +720,7 @@ class spmatrix(object):
 
         """
         if np.issubdtype(self.dtype, np.complexfloating):
-            return self.tocsr().conj()
+            return self.tocsr(copy=copy).conj()
         elif copy:
             return self.copy()
         else:

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -720,7 +720,7 @@ class spmatrix(object):
 
         """
         if np.issubdtype(self.dtype, np.complexfloating):
-            return self.tocsr(copy=copy).conj()
+            return self.tocsr(copy=copy).conj(copy=False)
         elif copy:
             return self.copy()
         else:

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -703,16 +703,31 @@ class spmatrix(object):
         """
         return self.tocsr().transpose(axes=axes, copy=copy)
 
-    def conj(self):
+    def conj(self, copy=True):
         """Element-wise complex conjugation.
 
-        If the matrix is of non-complex data type, then this method does
-        nothing and the data is not copied.
-        """
-        return self.tocsr().conj()
+        If the matrix is of non-complex data type and `copy` is False,
+        this method does nothing and the data is not copied.
 
-    def conjugate(self):
-        return self.conj()
+        Parameters
+        ----------
+        copy : bool, optional
+            Whether always a copy should be returned.
+
+        Returns
+        -------
+        A : `self` with the data element-wise complex conjugated.
+
+        """
+        if np.issubdtype(self.dtype, np.complexfloating):
+            return self.tocsr().conj()
+        elif copy:
+            return self.copy()
+        else:
+            return self
+
+    def conjugate(self, copy=True):
+        return self.conj(copy=copy)
 
     conjugate.__doc__ = conj.__doc__
 

--- a/scipy/sparse/data.py
+++ b/scipy/sparse/data.py
@@ -85,7 +85,6 @@ class _data_matrix(spmatrix):
         else:
             return self
 
-
     conj.__doc__ = spmatrix.conj.__doc__
 
     def copy(self):

--- a/scipy/sparse/data.py
+++ b/scipy/sparse/data.py
@@ -77,8 +77,14 @@ class _data_matrix(spmatrix):
 
     astype.__doc__ = spmatrix.astype.__doc__
 
-    def conj(self):
-        return self._with_data(self.data.conj())
+    def conj(self, copy=True):
+        if np.issubdtype(self.dtype, np.complexfloating):
+            return self._with_data(self.data.conj(), copy=copy)
+        elif copy:
+            return self.copy()
+        else:
+            return self
+
 
     conj.__doc__ = spmatrix.conj.__doc__
 


### PR DESCRIPTION
A `copy` keyword was added to the `conj` and `conjugate` methods of the sparse matrices in `scipy.sparse`. As a result, the method can be faster in some cases if `copy` is `False`.