### PR TITLE
MAINT: scipy.sparse: less copies at transpose method

### DIFF
--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -701,7 +701,7 @@ class spmatrix(object):
         np.matrix.transpose : NumPy's implementation of 'transpose'
                               for matrices
         """
-        return self.tocsr().transpose(axes=axes, copy=copy)
+        return self.tocsr(copy=copy).transpose(axes=axes, copy=False)
 
     def conj(self):
         """Element-wise complex conjugation.

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -455,7 +455,7 @@ class lil_matrix(spmatrix, IndexMixin):
     toarray.__doc__ = spmatrix.toarray.__doc__
 
     def transpose(self, axes=None, copy=False):
-        return self.tocsr().transpose(axes=axes, copy=copy).tolil()
+        return self.tocsr(copy=copy).transpose(axes=axes, copy=False).tolil(copy=False)
 
     transpose.__doc__ = spmatrix.transpose.__doc__
 


### PR DESCRIPTION
Avoid some unnecessary copies in `transpose` method of some matrices in `scipy.sparse`.