### PR TITLE
BUG: correct behavior for skew-symmetric matrices in io.mmwrite

### DIFF
--- a/scipy/io/mmio.py
+++ b/scipy/io/mmio.py
@@ -718,7 +718,6 @@ class MMFile (object):
             stream.write(asbytes('%i %i\n' % (rows, cols)))
 
             if field in (self.FIELD_INTEGER, self.FIELD_REAL):
-				
                 if symmetry == self.SYMMETRY_GENERAL:
                     for j in range(cols):
                         for i in range(rows):

--- a/scipy/io/mmio.py
+++ b/scipy/io/mmio.py
@@ -503,6 +503,10 @@ class MMFile (object):
             a = zeros((rows, cols), dtype=dtype)
             line = 1
             i, j = 0, 0
+            if is_skew:
+                a[i, j] = 0
+                if i < rows - 1:
+                    i += 1
             while line:
                 line = stream.readline()
                 if not line or line.startswith(b'%'):
@@ -529,8 +533,17 @@ class MMFile (object):
                         i = 0
                     else:
                         i = j
-            if not (i in [0, j] and j == cols):
-                raise ValueError("Parse error, did not read all lines.")
+                        if is_skew:
+                            a[i, j] = 0
+                            if i < rows-1:
+                                i += 1     
+                                
+            if is_skew:
+                if not (i in [0, j] and j == cols - 1):
+                    raise ValueError("Parse error, did not read all lines.")
+            else:
+                if not (i in [0, j] and j == cols):
+                    raise ValueError("Parse error, did not read all lines.")
 
         elif format == self.FORMAT_COORDINATE and coo_matrix is None:
             # Read sparse matrix to dense when coo_matrix is not available.
@@ -699,19 +712,23 @@ class MMFile (object):
             stream.write(asbytes('%%%s\n' % (line)))
 
         template = self._field_template(field, precision)
-
         # write dense format
         if rep == self.FORMAT_ARRAY:
-
             # write shape spec
             stream.write(asbytes('%i %i\n' % (rows, cols)))
 
             if field in (self.FIELD_INTEGER, self.FIELD_REAL):
-
+				
                 if symmetry == self.SYMMETRY_GENERAL:
                     for j in range(cols):
                         for i in range(rows):
                             stream.write(asbytes(template % a[i, j]))
+                            
+                elif symmetry == self.SYMMETRY_SKEW_SYMMETRIC:
+                    for j in range(cols):
+                        for i in range(j + 1, rows):
+                            stream.write(asbytes(template % a[i, j]))
+                            
                 else:
                     for j in range(cols):
                         for i in range(j, rows):

--- a/scipy/io/tests/test_mmio.py
+++ b/scipy/io/tests/test_mmio.py
@@ -78,11 +78,11 @@ class TestMMIOArray(object):
                          (2, 2, 4, 'array', 'integer', 'symmetric'))
 
     def test_simple_skew_symmetric_integer(self):
-        self.check_exact([[1, 2], [-2, 4]],
+        self.check_exact([[0, 2], [-2, 0]],
                          (2, 2, 4, 'array', 'integer', 'skew-symmetric'))
 
     def test_simple_skew_symmetric_float(self):
-        self.check(array([[1, 2], [-2.0, 4]], 'f'),
+        self.check(array([[0, 2], [-2.0, 0.0]], 'f'),
                    (2, 2, 4, 'array', 'real', 'skew-symmetric'))
 
     def test_simple_hermitian_complex(self):


### PR DESCRIPTION
Hello!
I've created some changes in io files for skew_symmetrix matrix. The reason is in #7836. I also had to change tests for this types of matrixes because they were actually wrong - matrix in tests weren't skew-symmetric(correct me if I'm wrong). I hope everything is fine.
Fixes #7836