### PR TITLE
TST: Generalize doctest stopwords .axis( .plot(

### DIFF
--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -516,7 +516,7 @@ class Checker(doctest.OutputChecker):
     vanilla = doctest.OutputChecker()
     rndm_markers = {'# random', '# Random', '#random', '#Random', "# may vary"}
     stopwords = {'plt.', '.hist', '.show', '.ylim', '.subplot(',
-                 'set_title', 'imshow', 'plt.show', 'ax.axis', 'plt.plot(',
+                 'set_title', 'imshow', 'plt.show', '.axis(', '.plot(',
                  '.bar(', '.title', '.ylabel', '.xlabel', 'set_ylim', 'set_xlim',
                  '# reformatted', '.set_xlabel(', '.set_ylabel(', '.set_zlabel(',
                  '.set(xlim=', '.set(ylim=', '.set(xlabel=', '.set(ylabel='}


### PR DESCRIPTION
Lines like 
    ax1.axis(...)
return a list, but we don't care for doctest purposes.

From @larsoner 's comment https://github.com/scipy/scipy/pull/8397#issuecomment-364993257