### PR TITLE
Fix `ndimage.morphology.x_tophat` functions for boolean arrays

### DIFF
--- a/scipy/ndimage/morphology.py
+++ b/scipy/ndimage/morphology.py
@@ -224,7 +224,7 @@ def _binary_erosion(input, structure, iterations, mask, output,
         raise RuntimeError('structure and input must have same dimensionality')
     if not structure.flags.contiguous:
         structure = structure.copy()
-    if numpy.product(structure.shape,axis=0) < 1:
+    if numpy.product(structure.shape, axis=0) < 1:
         raise RuntimeError('structure must not be empty')
     if mask is not None:
         mask = numpy.asarray(mask)
@@ -1687,11 +1687,17 @@ def white_tophat(input, size=None, footprint=None, structure=None,
     if isinstance(output, numpy.ndarray):
         grey_dilation(tmp, size, footprint, structure, output, mode, cval,
                       origin)
-        return numpy.subtract(input, output, output)
+        if input.dtype == numpy.bool_:
+            return numpy.bitwise_xor(input, output, output)
+        else:
+            return numpy.subtract(input, output, output)
     else:
         tmp = grey_dilation(tmp, size, footprint, structure, None, mode,
                             cval, origin)
-        return input - tmp
+        if input.dtype == numpy.bool_:
+            return numpy.bitwise_xor(input, tmp)
+        else:
+            return numpy.subtract(input, tmp)
 
 
 def black_tophat(input, size=None, footprint=None,
@@ -1741,11 +1747,17 @@ def black_tophat(input, size=None, footprint=None,
     if isinstance(output, numpy.ndarray):
         grey_erosion(tmp, size, footprint, structure, output, mode, cval,
                      origin)
-        return numpy.subtract(output, input, output)
+        if input.dtype == numpy.bool_:
+            return numpy.bitwise_xor(output, input, output)
+        else:
+            return numpy.subtract(output, input, output)
     else:
         tmp = grey_erosion(tmp, size, footprint, structure, None, mode,
                            cval, origin)
-        return tmp - input
+        if input.dtype == numpy.bool_:
+            return numpy.bitwise_xor(tmp, input)
+        else:
+            return numpy.subtract(tmp, input)
 
 
 def distance_transform_bf(input, metric="euclidean", sampling=None,

--- a/scipy/ndimage/morphology.py
+++ b/scipy/ndimage/morphology.py
@@ -241,11 +241,12 @@ def _binary_erosion(input, structure, iterations, mask, output,
 
     if iterations == 1:
         _nd_image.binary_erosion(input, structure, mask, output,
-                                     border_value, origin, invert, cit, 0)
+                                 border_value, origin, invert, cit, 0)
         return return_value
     elif cit and not brute_force:
-        changed, coordinate_list = _nd_image.binary_erosion(input,
-             structure, mask, output, border_value, origin, invert, cit, 1)
+        changed, coordinate_list = _nd_image.binary_erosion(
+            input, structure, mask, output,
+            border_value, origin, invert, cit, 1)
         structure = structure[tuple([slice(None, None, -1)] *
                                     structure.ndim)]
         for ii in range(len(origin)):
@@ -267,20 +268,22 @@ def _binary_erosion(input, structure, iterations, mask, output,
             tmp_out = numpy.zeros(input.shape, bool)
         if not iterations & 1:
             tmp_in, tmp_out = tmp_out, tmp_in
-        changed = _nd_image.binary_erosion(input, structure, mask,
-                            tmp_out, border_value, origin, invert, cit, 0)
+        changed = _nd_image.binary_erosion(
+            input, structure, mask, tmp_out,
+            border_value, origin, invert, cit, 0)
         ii = 1
         while (ii < iterations) or (iterations < 1) and changed:
             tmp_in, tmp_out = tmp_out, tmp_in
-            changed = _nd_image.binary_erosion(tmp_in, structure, mask,
-                            tmp_out, border_value, origin, invert, cit, 0)
+            changed = _nd_image.binary_erosion(
+                tmp_in, structure, mask, tmp_out,
+                border_value, origin, invert, cit, 0)
             ii += 1
         if return_value is not None:
             return tmp_out
 
 
-def binary_erosion(input, structure=None, iterations=1, mask=None,
-        output=None, border_value=0, origin=0, brute_force=False):
+def binary_erosion(input, structure=None, iterations=1, mask=None, output=None,
+                   border_value=0, origin=0, brute_force=False):
     """
     Multi-dimensional binary erosion with a given structuring element.
 
@@ -371,7 +374,8 @@ def binary_erosion(input, structure=None, iterations=1, mask=None,
 
 
 def binary_dilation(input, structure=None, iterations=1, mask=None,
-        output=None, border_value=0, origin=0, brute_force=False):
+                    output=None, border_value=0, origin=0,
+                    brute_force=False):
     """
     Multi-dimensional binary dilation with the given structuring element.
 
@@ -1164,7 +1168,7 @@ def grey_erosion(input, size=None, footprint=None, structure=None,
 
 
 def grey_dilation(input, size=None, footprint=None, structure=None,
-                 output=None, mode="reflect", cval=0.0, origin=0):
+                  output=None, mode="reflect", cval=0.0, origin=0):
     """
     Calculate a greyscale dilation, using either a structuring element,
     or a footprint corresponding to a flat structuring element.
@@ -1473,9 +1477,8 @@ def grey_closing(input, size=None, footprint=None, structure=None,
                         cval, origin)
 
 
-def morphological_gradient(input, size=None, footprint=None,
-                        structure=None, output=None, mode="reflect",
-                        cval=0.0, origin=0):
+def morphological_gradient(input, size=None, footprint=None, structure=None,
+                           output=None, mode="reflect", cval=0.0, origin=0):
     """
     Multi-dimensional morphological gradient.
 
@@ -1882,9 +1885,8 @@ def distance_transform_bf(input, metric="euclidean", sampling=None,
         return None
 
 
-def distance_transform_cdt(input, metric='chessboard',
-                        return_distances=True, return_indices=False,
-                        distances=None, indices=None):
+def distance_transform_cdt(input, metric='chessboard', return_distances=True,
+                           return_indices=False, distances=None, indices=None):
     """
     Distance transform for chamfer type of transforms.
 
@@ -1955,7 +1957,7 @@ def distance_transform_cdt(input, metric='chessboard',
 
     rank = dt.ndim
     if return_indices:
-        sz = numpy.product(dt.shape,axis=0)
+        sz = numpy.product(dt.shape, axis=0)
         ft = numpy.arange(sz, dtype=numpy.int32)
         ft.shape = dt.shape
     else:
@@ -1999,9 +2001,8 @@ def distance_transform_cdt(input, metric='chessboard',
         return None
 
 
-def distance_transform_edt(input, sampling=None,
-                        return_distances=True, return_indices=False,
-                        distances=None, indices=None):
+def distance_transform_edt(input, sampling=None, return_distances=True,
+                           return_indices=False, distances=None, indices=None):
     """
     Exact euclidean distance transform.
 
@@ -2130,8 +2131,7 @@ def distance_transform_edt(input, sampling=None,
         if ft.dtype.type != numpy.int32:
             raise RuntimeError('indices must be of int32 type')
     else:
-        ft = numpy.zeros((input.ndim,) + input.shape,
-                            dtype=numpy.int32)
+        ft = numpy.zeros((input.ndim,) + input.shape, dtype=numpy.int32)
 
     _nd_image.euclidean_feature_transform(input, sampling, ft)
     # if requested, calculate the distance transform

--- a/scipy/ndimage/morphology.py
+++ b/scipy/ndimage/morphology.py
@@ -1684,20 +1684,16 @@ def white_tophat(input, size=None, footprint=None, structure=None,
     """
     tmp = grey_erosion(input, size, footprint, structure, None, mode,
                        cval, origin)
-    if isinstance(output, numpy.ndarray):
-        grey_dilation(tmp, size, footprint, structure, output, mode, cval,
-                      origin)
-        if input.dtype == numpy.bool_:
-            return numpy.bitwise_xor(input, output, output)
-        else:
-            return numpy.subtract(input, output, output)
+    tmp = grey_dilation(tmp, size, footprint, structure, output, mode,
+                        cval, origin)
+    if tmp is None:
+        tmp = output
+
+    if input.dtype == numpy.bool_ and tmp.dtype == numpy.bool_:
+        numpy.bitwise_xor(input, tmp, out=tmp)
     else:
-        tmp = grey_dilation(tmp, size, footprint, structure, None, mode,
-                            cval, origin)
-        if input.dtype == numpy.bool_:
-            return numpy.bitwise_xor(input, tmp)
-        else:
-            return numpy.subtract(input, tmp)
+        numpy.subtract(input, tmp, out=tmp)
+    return tmp
 
 
 def black_tophat(input, size=None, footprint=None,
@@ -1744,20 +1740,16 @@ def black_tophat(input, size=None, footprint=None,
     """
     tmp = grey_dilation(input, size, footprint, structure, None, mode,
                         cval, origin)
-    if isinstance(output, numpy.ndarray):
-        grey_erosion(tmp, size, footprint, structure, output, mode, cval,
-                     origin)
-        if input.dtype == numpy.bool_:
-            return numpy.bitwise_xor(output, input, output)
-        else:
-            return numpy.subtract(output, input, output)
+    tmp = grey_erosion(tmp, size, footprint, structure, output, mode,
+                       cval, origin)
+    if tmp is None:
+        tmp = output
+
+    if input.dtype == numpy.bool_ and tmp.dtype == numpy.bool_:
+        numpy.bitwise_xor(tmp, input, out=tmp)
     else:
-        tmp = grey_erosion(tmp, size, footprint, structure, None, mode,
-                           cval, origin)
-        if input.dtype == numpy.bool_:
-            return numpy.bitwise_xor(tmp, input)
-        else:
-            return numpy.subtract(tmp, input)
+        numpy.subtract(tmp, input, out=tmp)
+    return tmp
 
 
 def distance_transform_bf(input, metric="euclidean", sampling=None,

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -36,7 +36,7 @@ import sys
 import numpy
 from numpy import fft
 from numpy.testing import (assert_, assert_equal, assert_array_equal,
-        assert_array_almost_equal, assert_almost_equal)
+                           assert_array_almost_equal, assert_almost_equal)
 import pytest
 from pytest import raises as assert_raises
 from scipy._lib._numpy_compat import suppress_warnings
@@ -53,9 +53,9 @@ def sumsq(a, b):
 class TestNdimage:
     def setup_method(self):
         # list of numarray data types
-        self.integer_types = [numpy.int8, numpy.uint8, numpy.int16,
-                numpy.uint16, numpy.int32, numpy.uint32,
-                numpy.int64, numpy.uint64]
+        self.integer_types = [
+            numpy.int8, numpy.uint8, numpy.int16, numpy.uint16,
+            numpy.int32, numpy.uint32, numpy.int64, numpy.uint64]
 
         self.float_types = [numpy.float32, numpy.float64]
 
@@ -205,9 +205,9 @@ class TestNdimage:
 
     def test_correlate11(self):
         array = numpy.array([[1, 2, 3],
-                                [4, 5, 6]])
+                             [4, 5, 6]])
         kernel = numpy.array([[1, 1],
-                                 [1, 1]])
+                              [1, 1]])
         output = ndimage.correlate(array, kernel)
         assert_array_almost_equal([[4, 6, 10], [10, 12, 16]], output)
         output = ndimage.convolve(array, kernel)
@@ -215,9 +215,9 @@ class TestNdimage:
 
     def test_correlate12(self):
         array = numpy.array([[1, 2, 3],
-                                [4, 5, 6]])
+                             [4, 5, 6]])
         kernel = numpy.array([[1, 0],
-                                 [0, 1]])
+                              [0, 1]])
         output = ndimage.correlate(array, kernel)
         assert_array_almost_equal([[2, 3, 5], [5, 6, 8]], output)
         output = ndimage.convolve(array, kernel)
@@ -230,8 +230,7 @@ class TestNdimage:
             array = numpy.array([[1, 2, 3],
                                  [4, 5, 6]], type1)
             for type2 in self.types:
-                output = ndimage.correlate(array, kernel,
-                                                    output=type2)
+                output = ndimage.correlate(array, kernel, output=type2)
                 assert_array_almost_equal([[2, 3, 5], [5, 6, 8]], output)
                 assert_equal(output.dtype.type, type2)
 
@@ -275,17 +274,14 @@ class TestNdimage:
 
     def test_correlate16(self):
         kernel = numpy.array([[0.5, 0],
-                                 [0, 0.5]])
+                              [0, 0.5]])
         for type1 in self.types:
-            array = numpy.array([[1, 2, 3],
-                                    [4, 5, 6]], type1)
-            output = ndimage.correlate(array, kernel,
-                                                output=numpy.float32)
+            array = numpy.array([[1, 2, 3], [4, 5, 6]], type1)
+            output = ndimage.correlate(array, kernel, output=numpy.float32)
             assert_array_almost_equal([[1, 1.5, 2.5], [2.5, 3, 4]], output)
             assert_equal(output.dtype.type, numpy.float32)
 
-            output = ndimage.convolve(array, kernel,
-                                      output=numpy.float32)
+            output = ndimage.convolve(array, kernel, output=numpy.float32)
             assert_array_almost_equal([[3, 4, 4.5], [4.5, 5.5, 6]], output)
             assert_equal(output.dtype.type, numpy.float32)
 
@@ -305,13 +301,13 @@ class TestNdimage:
 
     def test_correlate18(self):
         kernel = numpy.array([[1, 0],
-                                 [0, 1]])
+                              [0, 1]])
         for type1 in self.types:
             array = numpy.array([[1, 2, 3],
-                                    [4, 5, 6]], type1)
+                                 [4, 5, 6]], type1)
             output = ndimage.correlate(array, kernel,
-                                        output=numpy.float32,
-                                        mode='nearest', origin=-1)
+                                       output=numpy.float32,
+                                       mode='nearest', origin=-1)
             assert_array_almost_equal([[6, 8, 9], [9, 11, 12]], output)
             assert_equal(output.dtype.type, numpy.float32)
 
@@ -344,7 +340,7 @@ class TestNdimage:
         expected = [[5, 10, 15], [7, 14, 21]]
         for type1 in self.types:
             array = numpy.array([[1, 2, 3],
-                                    [2, 4, 6]], type1)
+                                 [2, 4, 6]], type1)
             for type2 in self.types:
                 output = numpy.zeros((2, 3), type2)
                 ndimage.correlate1d(array, weights, axis=0,
@@ -356,7 +352,7 @@ class TestNdimage:
 
     def test_correlate21(self):
         array = numpy.array([[1, 2, 3],
-                                [2, 4, 6]])
+                             [2, 4, 6]])
         expected = [[5, 10, 15], [7, 14, 21]]
         weights = numpy.array([1, 2, 1])
         output = ndimage.correlate1d(array, weights, axis=0)
@@ -369,14 +365,14 @@ class TestNdimage:
         expected = [[6, 12, 18], [6, 12, 18]]
         for type1 in self.types:
             array = numpy.array([[1, 2, 3],
-                                    [2, 4, 6]], type1)
+                                 [2, 4, 6]], type1)
             for type2 in self.types:
                 output = numpy.zeros((2, 3), type2)
                 ndimage.correlate1d(array, weights, axis=0,
-                                            mode='wrap', output=output)
+                                    mode='wrap', output=output)
                 assert_array_almost_equal(output, expected)
                 ndimage.convolve1d(array, weights, axis=0,
-                                            mode='wrap', output=output)
+                                   mode='wrap', output=output)
                 assert_array_almost_equal(output, expected)
 
     def test_correlate23(self):
@@ -384,14 +380,14 @@ class TestNdimage:
         expected = [[5, 10, 15], [7, 14, 21]]
         for type1 in self.types:
             array = numpy.array([[1, 2, 3],
-                                    [2, 4, 6]], type1)
+                                 [2, 4, 6]], type1)
             for type2 in self.types:
                 output = numpy.zeros((2, 3), type2)
                 ndimage.correlate1d(array, weights, axis=0,
-                                         mode='nearest', output=output)
+                                    mode='nearest', output=output)
                 assert_array_almost_equal(output, expected)
                 ndimage.convolve1d(array, weights, axis=0,
-                                         mode='nearest', output=output)
+                                   mode='nearest', output=output)
                 assert_array_almost_equal(output, expected)
 
     def test_correlate24(self):
@@ -400,14 +396,14 @@ class TestNdimage:
         tcov = [[4, 8, 12], [5, 10, 15]]
         for type1 in self.types:
             array = numpy.array([[1, 2, 3],
-                                    [2, 4, 6]], type1)
+                                 [2, 4, 6]], type1)
             for type2 in self.types:
                 output = numpy.zeros((2, 3), type2)
                 ndimage.correlate1d(array, weights, axis=0,
-                           mode='nearest', output=output, origin=-1)
+                                    mode='nearest', output=output, origin=-1)
                 assert_array_almost_equal(output, tcor)
                 ndimage.convolve1d(array, weights, axis=0,
-                           mode='nearest', output=output, origin=-1)
+                                   mode='nearest', output=output, origin=-1)
                 assert_array_almost_equal(output, tcov)
 
     def test_correlate25(self):
@@ -420,10 +416,10 @@ class TestNdimage:
             for type2 in self.types:
                 output = numpy.zeros((2, 3), type2)
                 ndimage.correlate1d(array, weights, axis=0,
-                             mode='nearest', output=output, origin=1)
+                                    mode='nearest', output=output, origin=1)
                 assert_array_almost_equal(output, tcor)
                 ndimage.convolve1d(array, weights, axis=0,
-                             mode='nearest', output=output, origin=1)
+                                   mode='nearest', output=output, origin=1)
                 assert_array_almost_equal(output, tcov)
 
     def test_gauss01(self):
@@ -450,15 +446,15 @@ class TestNdimage:
 
         # input.sum() is 49995000.0.  With single precision floats, we can't
         # expect more than 8 digits of accuracy, so use decimal=0 in this test.
-        assert_almost_equal(output.sum(dtype='d'), input.sum(dtype='d'), decimal=0)
+        assert_almost_equal(output.sum(dtype='d'), input.sum(dtype='d'),
+                            decimal=0)
         assert_(sumsq(input, output) > 1.0)
 
     def test_gauss04(self):
         input = numpy.arange(100 * 100).astype(numpy.float32)
         input.shape = (100, 100)
         otype = numpy.float64
-        output = ndimage.gaussian_filter(input, [1.0, 1.0],
-                                                            output=otype)
+        output = ndimage.gaussian_filter(input, [1.0, 1.0], output=otype)
         assert_equal(output.dtype.type, numpy.float64)
         assert_equal(input.shape, output.shape)
         assert_(sumsq(input, output) > 1.0)
@@ -468,7 +464,7 @@ class TestNdimage:
         input.shape = (100, 100)
         otype = numpy.float64
         output = ndimage.gaussian_filter(input, [1.0, 1.0],
-                                                 order=1, output=otype)
+                                         order=1, output=otype)
         assert_equal(output.dtype.type, numpy.float64)
         assert_equal(input.shape, output.shape)
         assert_(sumsq(input, output) > 1.0)
@@ -477,132 +473,130 @@ class TestNdimage:
         input = numpy.arange(100 * 100).astype(numpy.float32)
         input.shape = (100, 100)
         otype = numpy.float64
-        output1 = ndimage.gaussian_filter(input, [1.0, 1.0],
-                                                            output=otype)
-        output2 = ndimage.gaussian_filter(input, 1.0,
-                                                            output=otype)
+        output1 = ndimage.gaussian_filter(input, [1.0, 1.0], output=otype)
+        output2 = ndimage.gaussian_filter(input, 1.0, output=otype)
         assert_array_almost_equal(output1, output2)
 
     def test_prewitt01(self):
-        for type in self.types:
+        for type_ in self.types:
             array = numpy.array([[3, 2, 5, 1, 4],
-                                    [5, 8, 3, 7, 1],
-                                    [5, 6, 9, 3, 5]], type)
+                                 [5, 8, 3, 7, 1],
+                                 [5, 6, 9, 3, 5]], type_)
             t = ndimage.correlate1d(array, [-1.0, 0.0, 1.0], 0)
             t = ndimage.correlate1d(t, [1.0, 1.0, 1.0], 1)
             output = ndimage.prewitt(array, 0)
             assert_array_almost_equal(t, output)
 
     def test_prewitt02(self):
-        for type in self.types:
+        for type_ in self.types:
             array = numpy.array([[3, 2, 5, 1, 4],
-                                    [5, 8, 3, 7, 1],
-                                    [5, 6, 9, 3, 5]], type)
+                                 [5, 8, 3, 7, 1],
+                                 [5, 6, 9, 3, 5]], type_)
             t = ndimage.correlate1d(array, [-1.0, 0.0, 1.0], 0)
             t = ndimage.correlate1d(t, [1.0, 1.0, 1.0], 1)
-            output = numpy.zeros(array.shape, type)
+            output = numpy.zeros(array.shape, type_)
             ndimage.prewitt(array, 0, output)
             assert_array_almost_equal(t, output)
 
     def test_prewitt03(self):
-        for type in self.types:
+        for type_ in self.types:
             array = numpy.array([[3, 2, 5, 1, 4],
-                                    [5, 8, 3, 7, 1],
-                                    [5, 6, 9, 3, 5]], type)
+                                 [5, 8, 3, 7, 1],
+                                 [5, 6, 9, 3, 5]], type_)
             t = ndimage.correlate1d(array, [-1.0, 0.0, 1.0], 1)
             t = ndimage.correlate1d(t, [1.0, 1.0, 1.0], 0)
             output = ndimage.prewitt(array, 1)
             assert_array_almost_equal(t, output)
 
     def test_prewitt04(self):
-        for type in self.types:
+        for type_ in self.types:
             array = numpy.array([[3, 2, 5, 1, 4],
-                                    [5, 8, 3, 7, 1],
-                                    [5, 6, 9, 3, 5]], type)
+                                 [5, 8, 3, 7, 1],
+                                 [5, 6, 9, 3, 5]], type_)
             t = ndimage.prewitt(array, -1)
             output = ndimage.prewitt(array, 1)
             assert_array_almost_equal(t, output)
 
     def test_sobel01(self):
-        for type in self.types:
+        for type_ in self.types:
             array = numpy.array([[3, 2, 5, 1, 4],
-                                    [5, 8, 3, 7, 1],
-                                    [5, 6, 9, 3, 5]], type)
+                                 [5, 8, 3, 7, 1],
+                                 [5, 6, 9, 3, 5]], type_)
             t = ndimage.correlate1d(array, [-1.0, 0.0, 1.0], 0)
             t = ndimage.correlate1d(t, [1.0, 2.0, 1.0], 1)
             output = ndimage.sobel(array, 0)
             assert_array_almost_equal(t, output)
 
     def test_sobel02(self):
-        for type in self.types:
+        for type_ in self.types:
             array = numpy.array([[3, 2, 5, 1, 4],
-                                    [5, 8, 3, 7, 1],
-                                    [5, 6, 9, 3, 5]], type)
+                                 [5, 8, 3, 7, 1],
+                                 [5, 6, 9, 3, 5]], type_)
             t = ndimage.correlate1d(array, [-1.0, 0.0, 1.0], 0)
             t = ndimage.correlate1d(t, [1.0, 2.0, 1.0], 1)
-            output = numpy.zeros(array.shape, type)
+            output = numpy.zeros(array.shape, type_)
             ndimage.sobel(array, 0, output)
             assert_array_almost_equal(t, output)
 
     def test_sobel03(self):
-        for type in self.types:
+        for type_ in self.types:
             array = numpy.array([[3, 2, 5, 1, 4],
-                                    [5, 8, 3, 7, 1],
-                                    [5, 6, 9, 3, 5]], type)
+                                 [5, 8, 3, 7, 1],
+                                 [5, 6, 9, 3, 5]], type_)
             t = ndimage.correlate1d(array, [-1.0, 0.0, 1.0], 1)
             t = ndimage.correlate1d(t, [1.0, 2.0, 1.0], 0)
-            output = numpy.zeros(array.shape, type)
+            output = numpy.zeros(array.shape, type_)
             output = ndimage.sobel(array, 1)
             assert_array_almost_equal(t, output)
 
     def test_sobel04(self):
-        for type in self.types:
+        for type_ in self.types:
             array = numpy.array([[3, 2, 5, 1, 4],
-                                    [5, 8, 3, 7, 1],
-                                    [5, 6, 9, 3, 5]], type)
+                                 [5, 8, 3, 7, 1],
+                                 [5, 6, 9, 3, 5]], type_)
             t = ndimage.sobel(array, -1)
             output = ndimage.sobel(array, 1)
             assert_array_almost_equal(t, output)
 
     def test_laplace01(self):
-        for type in [numpy.int32, numpy.float32, numpy.float64]:
+        for type_ in [numpy.int32, numpy.float32, numpy.float64]:
             array = numpy.array([[3, 2, 5, 1, 4],
-                                    [5, 8, 3, 7, 1],
-                                    [5, 6, 9, 3, 5]], type) * 100
+                                 [5, 8, 3, 7, 1],
+                                 [5, 6, 9, 3, 5]], type_) * 100
             tmp1 = ndimage.correlate1d(array, [1, -2, 1], 0)
             tmp2 = ndimage.correlate1d(array, [1, -2, 1], 1)
             output = ndimage.laplace(array)
             assert_array_almost_equal(tmp1 + tmp2, output)
 
     def test_laplace02(self):
-        for type in [numpy.int32, numpy.float32, numpy.float64]:
+        for type_ in [numpy.int32, numpy.float32, numpy.float64]:
             array = numpy.array([[3, 2, 5, 1, 4],
-                                    [5, 8, 3, 7, 1],
-                                    [5, 6, 9, 3, 5]], type) * 100
+                                 [5, 8, 3, 7, 1],
+                                 [5, 6, 9, 3, 5]], type_) * 100
             tmp1 = ndimage.correlate1d(array, [1, -2, 1], 0)
             tmp2 = ndimage.correlate1d(array, [1, -2, 1], 1)
-            output = numpy.zeros(array.shape, type)
+            output = numpy.zeros(array.shape, type_)
             ndimage.laplace(array, output=output)
             assert_array_almost_equal(tmp1 + tmp2, output)
 
     def test_gaussian_laplace01(self):
-        for type in [numpy.int32, numpy.float32, numpy.float64]:
+        for type_ in [numpy.int32, numpy.float32, numpy.float64]:
             array = numpy.array([[3, 2, 5, 1, 4],
-                                    [5, 8, 3, 7, 1],
-                                    [5, 6, 9, 3, 5]], type) * 100
+                                 [5, 8, 3, 7, 1],
+                                 [5, 6, 9, 3, 5]], type_) * 100
             tmp1 = ndimage.gaussian_filter(array, 1.0, [2, 0])
             tmp2 = ndimage.gaussian_filter(array, 1.0, [0, 2])
             output = ndimage.gaussian_laplace(array, 1.0)
             assert_array_almost_equal(tmp1 + tmp2, output)
 
     def test_gaussian_laplace02(self):
-        for type in [numpy.int32, numpy.float32, numpy.float64]:
+        for type_ in [numpy.int32, numpy.float32, numpy.float64]:
             array = numpy.array([[3, 2, 5, 1, 4],
-                                    [5, 8, 3, 7, 1],
-                                    [5, 6, 9, 3, 5]], type) * 100
+                                 [5, 8, 3, 7, 1],
+                                 [5, 6, 9, 3, 5]], type_) * 100
             tmp1 = ndimage.gaussian_filter(array, 1.0, [2, 0])
             tmp2 = ndimage.gaussian_filter(array, 1.0, [0, 2])
-            output = numpy.zeros(array.shape, type)
+            output = numpy.zeros(array.shape, type_)
             ndimage.gaussian_laplace(array, 1.0, output)
             assert_array_almost_equal(tmp1 + tmp2, output)
 
@@ -614,47 +608,46 @@ class TestNdimage:
             order[axis] = 2
             return ndimage.gaussian_filter(input, sigma, order,
                                            output, mode, cval)
-        for type in self.types:
+        for type_ in self.types:
             array = numpy.array([[3, 2, 5, 1, 4],
-                                    [5, 8, 3, 7, 1],
-                                    [5, 6, 9, 3, 5]], type)
-            output = numpy.zeros(array.shape, type)
+                                 [5, 8, 3, 7, 1],
+                                 [5, 6, 9, 3, 5]], type_)
+            output = numpy.zeros(array.shape, type_)
             tmp = ndimage.generic_laplace(array, derivative2,
-                    extra_arguments=(1.0,), extra_keywords={'b': 2.0})
+                                          extra_arguments=(1.0,),
+                                          extra_keywords={'b': 2.0})
             ndimage.gaussian_laplace(array, 1.0, output)
             assert_array_almost_equal(tmp, output)
 
     def test_gaussian_gradient_magnitude01(self):
-        for type in [numpy.int32, numpy.float32, numpy.float64]:
+        for type_ in [numpy.int32, numpy.float32, numpy.float64]:
             array = numpy.array([[3, 2, 5, 1, 4],
-                                    [5, 8, 3, 7, 1],
-                                    [5, 6, 9, 3, 5]], type) * 100
+                                 [5, 8, 3, 7, 1],
+                                 [5, 6, 9, 3, 5]], type_) * 100
             tmp1 = ndimage.gaussian_filter(array, 1.0, [1, 0])
             tmp2 = ndimage.gaussian_filter(array, 1.0, [0, 1])
-            output = ndimage.gaussian_gradient_magnitude(array,
-                                                                       1.0)
+            output = ndimage.gaussian_gradient_magnitude(array, 1.0)
             expected = tmp1 * tmp1 + tmp2 * tmp2
-            expected = numpy.sqrt(expected).astype(type)
+            expected = numpy.sqrt(expected).astype(type_)
             assert_array_almost_equal(expected, output)
 
     def test_gaussian_gradient_magnitude02(self):
-        for type in [numpy.int32, numpy.float32, numpy.float64]:
+        for type_ in [numpy.int32, numpy.float32, numpy.float64]:
             array = numpy.array([[3, 2, 5, 1, 4],
-                                    [5, 8, 3, 7, 1],
-                                    [5, 6, 9, 3, 5]], type) * 100
+                                 [5, 8, 3, 7, 1],
+                                 [5, 6, 9, 3, 5]], type_) * 100
             tmp1 = ndimage.gaussian_filter(array, 1.0, [1, 0])
             tmp2 = ndimage.gaussian_filter(array, 1.0, [0, 1])
-            output = numpy.zeros(array.shape, type)
-            ndimage.gaussian_gradient_magnitude(array, 1.0,
-                                                           output)
+            output = numpy.zeros(array.shape, type_)
+            ndimage.gaussian_gradient_magnitude(array, 1.0, output)
             expected = tmp1 * tmp1 + tmp2 * tmp2
-            expected = numpy.sqrt(expected).astype(type)
+            expected = numpy.sqrt(expected).astype(type_)
             assert_array_almost_equal(expected, output)
 
     def test_generic_gradient_magnitude01(self):
         array = numpy.array([[3, 2, 5, 1, 4],
-                                [5, 8, 3, 7, 1],
-                                [5, 6, 9, 3, 5]], numpy.float64)
+                             [5, 8, 3, 7, 1],
+                             [5, 6, 9, 3, 5]], numpy.float64)
 
         def derivative(input, axis, output, mode, cval, a, b):
             sigma = [a, b / 2.0]
@@ -662,18 +655,17 @@ class TestNdimage:
             order = [0] * input.ndim
             order[axis] = 1
             return ndimage.gaussian_filter(input, sigma, order,
-                                        output, mode, cval)
+                                           output, mode, cval)
         tmp1 = ndimage.gaussian_gradient_magnitude(array, 1.0)
-        tmp2 = ndimage.generic_gradient_magnitude(array,
-                derivative, extra_arguments=(1.0,),
-                extra_keywords={'b': 2.0})
+        tmp2 = ndimage.generic_gradient_magnitude(
+            array, derivative, extra_arguments=(1.0,),
+            extra_keywords={'b': 2.0})
         assert_array_almost_equal(tmp1, tmp2)
 
     def test_uniform01(self):
         array = numpy.array([2, 4, 6])
         size = 2
-        output = ndimage.uniform_filter1d(array, size,
-                                                   origin=-1)
+        output = ndimage.uniform_filter1d(array, size, origin=-1)
         assert_array_almost_equal([3, 5, 6], output)
 
     def test_uniform02(self):
@@ -704,10 +696,10 @@ class TestNdimage:
         filter_shape = [2, 2]
         for type1 in self.types:
             array = numpy.array([[4, 8, 12],
-                                    [16, 20, 24]], type1)
+                                 [16, 20, 24]], type1)
             for type2 in self.types:
-                output = ndimage.uniform_filter(array,
-                                        filter_shape, output=type2)
+                output = ndimage.uniform_filter(
+                    array, filter_shape, output=type2)
                 assert_array_almost_equal([[4, 6, 10], [10, 12, 16]], output)
                 assert_equal(output.dtype.type, type2)
 
@@ -737,57 +729,54 @@ class TestNdimage:
 
     def test_minimum_filter05(self):
         array = numpy.array([[3, 2, 5, 1, 4],
-                                [7, 6, 9, 3, 5],
-                                [5, 8, 3, 7, 1]])
+                             [7, 6, 9, 3, 5],
+                             [5, 8, 3, 7, 1]])
         filter_shape = numpy.array([2, 3])
         output = ndimage.minimum_filter(array, filter_shape)
         assert_array_almost_equal([[2, 2, 1, 1, 1],
-                              [2, 2, 1, 1, 1],
-                              [5, 3, 3, 1, 1]], output)
+                                   [2, 2, 1, 1, 1],
+                                   [5, 3, 3, 1, 1]], output)
 
     def test_minimum_filter06(self):
         array = numpy.array([[3, 2, 5, 1, 4],
-                                [7, 6, 9, 3, 5],
-                                [5, 8, 3, 7, 1]])
+                             [7, 6, 9, 3, 5],
+                             [5, 8, 3, 7, 1]])
         footprint = [[1, 1, 1], [1, 1, 1]]
-        output = ndimage.minimum_filter(array,
-                                                 footprint=footprint)
+        output = ndimage.minimum_filter(array, footprint=footprint)
         assert_array_almost_equal([[2, 2, 1, 1, 1],
-                              [2, 2, 1, 1, 1],
-                              [5, 3, 3, 1, 1]], output)
+                                   [2, 2, 1, 1, 1],
+                                   [5, 3, 3, 1, 1]], output)
 
     def test_minimum_filter07(self):
         array = numpy.array([[3, 2, 5, 1, 4],
-                                [7, 6, 9, 3, 5],
-                                [5, 8, 3, 7, 1]])
+                             [7, 6, 9, 3, 5],
+                             [5, 8, 3, 7, 1]])
         footprint = [[1, 0, 1], [1, 1, 0]]
-        output = ndimage.minimum_filter(array,
-                                                 footprint=footprint)
+        output = ndimage.minimum_filter(array, footprint=footprint)
         assert_array_almost_equal([[2, 2, 1, 1, 1],
-                              [2, 3, 1, 3, 1],
-                              [5, 5, 3, 3, 1]], output)
+                                   [2, 3, 1, 3, 1],
+                                   [5, 5, 3, 3, 1]], output)
 
     def test_minimum_filter08(self):
         array = numpy.array([[3, 2, 5, 1, 4],
-                                [7, 6, 9, 3, 5],
-                                [5, 8, 3, 7, 1]])
+                             [7, 6, 9, 3, 5],
+                             [5, 8, 3, 7, 1]])
         footprint = [[1, 0, 1], [1, 1, 0]]
-        output = ndimage.minimum_filter(array,
-                                       footprint=footprint, origin=-1)
+        output = ndimage.minimum_filter(array, footprint=footprint, origin=-1)
         assert_array_almost_equal([[3, 1, 3, 1, 1],
-                              [5, 3, 3, 1, 1],
-                              [3, 3, 1, 1, 1]], output)
+                                   [5, 3, 3, 1, 1],
+                                   [3, 3, 1, 1, 1]], output)
 
     def test_minimum_filter09(self):
         array = numpy.array([[3, 2, 5, 1, 4],
-                                [7, 6, 9, 3, 5],
-                                [5, 8, 3, 7, 1]])
+                             [7, 6, 9, 3, 5],
+                             [5, 8, 3, 7, 1]])
         footprint = [[1, 0, 1], [1, 1, 0]]
-        output = ndimage.minimum_filter(array,
-                                  footprint=footprint, origin=[-1, 0])
+        output = ndimage.minimum_filter(array, footprint=footprint,
+                                        origin=[-1, 0])
         assert_array_almost_equal([[2, 3, 1, 3, 1],
-                              [5, 5, 3, 3, 1],
-                              [5, 3, 3, 1, 1]], output)
+                                   [5, 5, 3, 3, 1],
+                                   [5, 3, 3, 1, 1]], output)
 
     def test_maximum_filter01(self):
         array = numpy.array([1, 2, 3, 4, 5])
@@ -815,57 +804,54 @@ class TestNdimage:
 
     def test_maximum_filter05(self):
         array = numpy.array([[3, 2, 5, 1, 4],
-                                [7, 6, 9, 3, 5],
-                                [5, 8, 3, 7, 1]])
+                             [7, 6, 9, 3, 5],
+                             [5, 8, 3, 7, 1]])
         filter_shape = numpy.array([2, 3])
         output = ndimage.maximum_filter(array, filter_shape)
         assert_array_almost_equal([[3, 5, 5, 5, 4],
-                              [7, 9, 9, 9, 5],
-                              [8, 9, 9, 9, 7]], output)
+                                   [7, 9, 9, 9, 5],
+                                   [8, 9, 9, 9, 7]], output)
 
     def test_maximum_filter06(self):
         array = numpy.array([[3, 2, 5, 1, 4],
-                                [7, 6, 9, 3, 5],
-                                [5, 8, 3, 7, 1]])
+                             [7, 6, 9, 3, 5],
+                             [5, 8, 3, 7, 1]])
         footprint = [[1, 1, 1], [1, 1, 1]]
-        output = ndimage.maximum_filter(array,
-                                                 footprint=footprint)
+        output = ndimage.maximum_filter(array, footprint=footprint)
         assert_array_almost_equal([[3, 5, 5, 5, 4],
-                              [7, 9, 9, 9, 5],
-                              [8, 9, 9, 9, 7]], output)
+                                   [7, 9, 9, 9, 5],
+                                   [8, 9, 9, 9, 7]], output)
 
     def test_maximum_filter07(self):
         array = numpy.array([[3, 2, 5, 1, 4],
-                                [7, 6, 9, 3, 5],
-                                [5, 8, 3, 7, 1]])
+                             [7, 6, 9, 3, 5],
+                             [5, 8, 3, 7, 1]])
         footprint = [[1, 0, 1], [1, 1, 0]]
-        output = ndimage.maximum_filter(array,
-                                                 footprint=footprint)
+        output = ndimage.maximum_filter(array, footprint=footprint)
         assert_array_almost_equal([[3, 5, 5, 5, 4],
-                              [7, 7, 9, 9, 5],
-                              [7, 9, 8, 9, 7]], output)
+                                   [7, 7, 9, 9, 5],
+                                   [7, 9, 8, 9, 7]], output)
 
     def test_maximum_filter08(self):
         array = numpy.array([[3, 2, 5, 1, 4],
-                                [7, 6, 9, 3, 5],
-                                [5, 8, 3, 7, 1]])
+                             [7, 6, 9, 3, 5],
+                             [5, 8, 3, 7, 1]])
         footprint = [[1, 0, 1], [1, 1, 0]]
-        output = ndimage.maximum_filter(array,
-                                      footprint=footprint, origin=-1)
+        output = ndimage.maximum_filter(array, footprint=footprint, origin=-1)
         assert_array_almost_equal([[7, 9, 9, 5, 5],
-                              [9, 8, 9, 7, 5],
-                              [8, 8, 7, 7, 7]], output)
+                                   [9, 8, 9, 7, 5],
+                                   [8, 8, 7, 7, 7]], output)
 
     def test_maximum_filter09(self):
         array = numpy.array([[3, 2, 5, 1, 4],
                                 [7, 6, 9, 3, 5],
                                 [5, 8, 3, 7, 1]])
         footprint = [[1, 0, 1], [1, 1, 0]]
-        output = ndimage.maximum_filter(array,
-                                 footprint=footprint, origin=[-1, 0])
+        output = ndimage.maximum_filter(array, footprint=footprint,
+                                        origin=[-1, 0])
         assert_array_almost_equal([[7, 7, 9, 9, 5],
-                              [7, 9, 8, 9, 7],
-                              [8, 8, 8, 7, 7]], output)
+                                   [7, 9, 8, 9, 7],
+                                   [8, 8, 8, 7, 7]], output)
 
     def test_rank01(self):
         array = numpy.array([1, 2, 3, 4, 5])
@@ -910,36 +896,34 @@ class TestNdimage:
 
     def test_rank06(self):
         array = numpy.array([[3, 2, 5, 1, 4],
-                                [5, 8, 3, 7, 1],
-                                [5, 6, 9, 3, 5]])
+                             [5, 8, 3, 7, 1],
+                             [5, 6, 9, 3, 5]])
         expected = [[2, 2, 1, 1, 1],
-                [3, 3, 2, 1, 1],
-                [5, 5, 3, 3, 1]]
+                    [3, 3, 2, 1, 1],
+                    [5, 5, 3, 3, 1]]
         output = ndimage.rank_filter(array, 1, size=[2, 3])
         assert_array_almost_equal(expected, output)
-        output = ndimage.percentile_filter(array, 17,
-                                                    size=(2, 3))
+        output = ndimage.percentile_filter(array, 17, size=(2, 3))
         assert_array_almost_equal(expected, output)
 
     def test_rank07(self):
         array = numpy.array([[3, 2, 5, 1, 4],
-                                [5, 8, 3, 7, 1],
-                                [5, 6, 9, 3, 5]])
+                             [5, 8, 3, 7, 1],
+                             [5, 6, 9, 3, 5]])
         expected = [[3, 5, 5, 5, 4],
-                [5, 5, 7, 5, 4],
-                [6, 8, 8, 7, 5]]
+                    [5, 5, 7, 5, 4],
+                    [6, 8, 8, 7, 5]]
         output = ndimage.rank_filter(array, -2, size=[2, 3])
         assert_array_almost_equal(expected, output)
 
     def test_rank08(self):
         array = numpy.array([[3, 2, 5, 1, 4],
-                                [5, 8, 3, 7, 1],
-                                [5, 6, 9, 3, 5]])
+                             [5, 8, 3, 7, 1],
+                             [5, 6, 9, 3, 5]])
         expected = [[3, 3, 2, 4, 4],
-                [5, 5, 5, 4, 4],
-                [5, 6, 7, 5, 5]]
-        output = ndimage.percentile_filter(array, 50.0,
-                                                    size=(2, 3))
+                    [5, 5, 5, 4, 4],
+                    [5, 6, 7, 5, 5]]
+        output = ndimage.percentile_filter(array, 50.0, size=(2, 3))
         assert_array_almost_equal(expected, output)
         output = ndimage.rank_filter(array, 3, size=(2, 3))
         assert_array_almost_equal(expected, output)
@@ -948,107 +932,99 @@ class TestNdimage:
 
     def test_rank09(self):
         expected = [[3, 3, 2, 4, 4],
-                [3, 5, 2, 5, 1],
-                [5, 5, 8, 3, 5]]
+                    [3, 5, 2, 5, 1],
+                    [5, 5, 8, 3, 5]]
         footprint = [[1, 0, 1], [0, 1, 0]]
-        for type in self.types:
+        for type_ in self.types:
             array = numpy.array([[3, 2, 5, 1, 4],
-                                    [5, 8, 3, 7, 1],
-                                    [5, 6, 9, 3, 5]], type)
-            output = ndimage.rank_filter(array, 1,
-                                                  footprint=footprint)
+                                 [5, 8, 3, 7, 1],
+                                 [5, 6, 9, 3, 5]], type_)
+            output = ndimage.rank_filter(array, 1, footprint=footprint)
             assert_array_almost_equal(expected, output)
-            output = ndimage.percentile_filter(array, 35,
-                                                    footprint=footprint)
+            output = ndimage.percentile_filter(array, 35, footprint=footprint)
             assert_array_almost_equal(expected, output)
 
     def test_rank10(self):
         array = numpy.array([[3, 2, 5, 1, 4],
-                                [7, 6, 9, 3, 5],
-                                [5, 8, 3, 7, 1]])
+                             [7, 6, 9, 3, 5],
+                             [5, 8, 3, 7, 1]])
         expected = [[2, 2, 1, 1, 1],
-                [2, 3, 1, 3, 1],
-                [5, 5, 3, 3, 1]]
+                    [2, 3, 1, 3, 1],
+                    [5, 5, 3, 3, 1]]
         footprint = [[1, 0, 1], [1, 1, 0]]
-        output = ndimage.rank_filter(array, 0,
-                                              footprint=footprint)
+        output = ndimage.rank_filter(array, 0, footprint=footprint)
         assert_array_almost_equal(expected, output)
-        output = ndimage.percentile_filter(array, 0.0,
-                                                    footprint=footprint)
+        output = ndimage.percentile_filter(array, 0.0, footprint=footprint)
         assert_array_almost_equal(expected, output)
 
     def test_rank11(self):
         array = numpy.array([[3, 2, 5, 1, 4],
-                                [7, 6, 9, 3, 5],
-                                [5, 8, 3, 7, 1]])
+                             [7, 6, 9, 3, 5],
+                             [5, 8, 3, 7, 1]])
         expected = [[3, 5, 5, 5, 4],
-                [7, 7, 9, 9, 5],
-                [7, 9, 8, 9, 7]]
+                    [7, 7, 9, 9, 5],
+                    [7, 9, 8, 9, 7]]
         footprint = [[1, 0, 1], [1, 1, 0]]
-        output = ndimage.rank_filter(array, -1,
-                                              footprint=footprint)
+        output = ndimage.rank_filter(array, -1, footprint=footprint)
         assert_array_almost_equal(expected, output)
-        output = ndimage.percentile_filter(array, 100.0,
-                                                    footprint=footprint)
+        output = ndimage.percentile_filter(array, 100.0, footprint=footprint)
         assert_array_almost_equal(expected, output)
 
     def test_rank12(self):
         expected = [[3, 3, 2, 4, 4],
-                [3, 5, 2, 5, 1],
-                [5, 5, 8, 3, 5]]
+                    [3, 5, 2, 5, 1],
+                    [5, 5, 8, 3, 5]]
         footprint = [[1, 0, 1], [0, 1, 0]]
-        for type in self.types:
+        for type_ in self.types:
             array = numpy.array([[3, 2, 5, 1, 4],
-                                    [5, 8, 3, 7, 1],
-                                    [5, 6, 9, 3, 5]], type)
-            output = ndimage.rank_filter(array, 1,
-                                                  footprint=footprint)
+                                 [5, 8, 3, 7, 1],
+                                 [5, 6, 9, 3, 5]], type_)
+            output = ndimage.rank_filter(array, 1, footprint=footprint)
             assert_array_almost_equal(expected, output)
             output = ndimage.percentile_filter(array, 50.0,
-                                                     footprint=footprint)
+                                               footprint=footprint)
             assert_array_almost_equal(expected, output)
-            output = ndimage.median_filter(array,
-                                                    footprint=footprint)
+            output = ndimage.median_filter(array, footprint=footprint)
             assert_array_almost_equal(expected, output)
 
     def test_rank13(self):
         expected = [[5, 2, 5, 1, 1],
-                [5, 8, 3, 5, 5],
-                [6, 6, 5, 5, 5]]
+                    [5, 8, 3, 5, 5],
+                    [6, 6, 5, 5, 5]]
         footprint = [[1, 0, 1], [0, 1, 0]]
-        for type in self.types:
+        for type_ in self.types:
             array = numpy.array([[3, 2, 5, 1, 4],
-                                    [5, 8, 3, 7, 1],
-                                    [5, 6, 9, 3, 5]], type)
-            output = ndimage.rank_filter(array, 1,
-                                       footprint=footprint, origin=-1)
+                                 [5, 8, 3, 7, 1],
+                                 [5, 6, 9, 3, 5]], type_)
+            output = ndimage.rank_filter(array, 1, footprint=footprint,
+                                         origin=-1)
             assert_array_almost_equal(expected, output)
 
     def test_rank14(self):
         expected = [[3, 5, 2, 5, 1],
-                [5, 5, 8, 3, 5],
-                [5, 6, 6, 5, 5]]
+                    [5, 5, 8, 3, 5],
+                    [5, 6, 6, 5, 5]]
         footprint = [[1, 0, 1], [0, 1, 0]]
-        for type in self.types:
+        for type_ in self.types:
             array = numpy.array([[3, 2, 5, 1, 4],
-                                    [5, 8, 3, 7, 1],
-                                    [5, 6, 9, 3, 5]], type)
-            output = ndimage.rank_filter(array, 1,
-                                  footprint=footprint, origin=[-1, 0])
+                                 [5, 8, 3, 7, 1],
+                                 [5, 6, 9, 3, 5]], type_)
+            output = ndimage.rank_filter(array, 1, footprint=footprint,
+                                         origin=[-1, 0])
             assert_array_almost_equal(expected, output)
 
     def test_rank15(self):
         "rank filter 15"
         expected = [[2, 3, 1, 4, 1],
-                [5, 3, 7, 1, 1],
-                [5, 5, 3, 3, 3]]
+                    [5, 3, 7, 1, 1],
+                    [5, 5, 3, 3, 3]]
         footprint = [[1, 0, 1], [0, 1, 0]]
-        for type in self.types:
+        for type_ in self.types:
             array = numpy.array([[3, 2, 5, 1, 4],
-                                    [5, 8, 3, 7, 1],
-                                    [5, 6, 9, 3, 5]], type)
-            output = ndimage.rank_filter(array, 0,
-                                  footprint=footprint, origin=[-1, 0])
+                                 [5, 8, 3, 7, 1],
+                                 [5, 6, 9, 3, 5]], type_)
+            output = ndimage.rank_filter(array, 0, footprint=footprint,
+                                         origin=[-1, 0])
             assert_array_almost_equal(expected, output)
 
     def test_generic_filter1d01(self):
@@ -1060,14 +1036,14 @@ class TestNdimage:
                 output[ii] = input[ii] * fltr[0]
                 output[ii] += input[ii + 1] * fltr[1]
                 output[ii] += input[ii + 2] * fltr[2]
-        for type in self.types:
-            a = numpy.arange(12, dtype=type)
-            a.shape = (3,4)
-            r1 = ndimage.correlate1d(a, weights / weights.sum(), 0,
-                                              origin=-1)
-            r2 = ndimage.generic_filter1d(a, _filter_func, 3,
-                      axis=0, origin=-1, extra_arguments=(weights,),
-                      extra_keywords={'total': weights.sum()})
+        for type_ in self.types:
+            a = numpy.arange(12, dtype=type_)
+            a.shape = (3, 4)
+            r1 = ndimage.correlate1d(a, weights / weights.sum(), 0, origin=-1)
+            r2 = ndimage.generic_filter1d(
+                a, _filter_func, 3, axis=0, origin=-1,
+                extra_arguments=(weights,),
+                extra_keywords={'total': weights.sum()})
             assert_array_almost_equal(r1, r2)
 
     def test_generic_filter01(self):
@@ -1078,40 +1054,40 @@ class TestNdimage:
         def _filter_func(buffer, weights, total=1.0):
             weights = cf / total
             return (buffer * weights).sum()
-        for type in self.types:
-            a = numpy.arange(12, dtype=type)
-            a.shape = (3,4)
+        for type_ in self.types:
+            a = numpy.arange(12, dtype=type_)
+            a.shape = (3, 4)
             r1 = ndimage.correlate(a, filter_ * footprint)
-            if type in self.float_types:
+            if type_ in self.float_types:
                 r1 /= 5
             else:
                 r1 //= 5
-            r2 = ndimage.generic_filter(a, _filter_func,
-                            footprint=footprint, extra_arguments=(cf,),
-                            extra_keywords={'total': cf.sum()})
+            r2 = ndimage.generic_filter(
+                a, _filter_func, footprint=footprint, extra_arguments=(cf,),
+                extra_keywords={'total': cf.sum()})
             assert_array_almost_equal(r1, r2)
 
     def test_extend01(self):
         array = numpy.array([1, 2, 3])
         weights = numpy.array([1, 0])
         expected_values = [[1, 1, 2],
-                       [3, 1, 2],
-                       [1, 1, 2],
-                       [2, 1, 2],
-                       [0, 1, 2]]
+                           [3, 1, 2],
+                           [1, 1, 2],
+                           [2, 1, 2],
+                           [0, 1, 2]]
         for mode, expected_value in zip(self.modes, expected_values):
             output = ndimage.correlate1d(array, weights, 0,
                                          mode=mode, cval=0)
-            assert_array_equal(output,expected_value)
+            assert_array_equal(output, expected_value)
 
     def test_extend02(self):
         array = numpy.array([1, 2, 3])
         weights = numpy.array([1, 0, 0, 0, 0, 0, 0, 0])
         expected_values = [[1, 1, 1],
-                       [3, 1, 2],
-                       [3, 3, 2],
-                       [1, 2, 3],
-                       [0, 0, 0]]
+                           [3, 1, 2],
+                           [3, 3, 2],
+                           [1, 2, 3],
+                           [0, 0, 0]]
         for mode, expected_value in zip(self.modes, expected_values):
             output = ndimage.correlate1d(array, weights, 0,
                                          mode=mode, cval=0)
@@ -1121,10 +1097,10 @@ class TestNdimage:
         array = numpy.array([1, 2, 3])
         weights = numpy.array([0, 0, 1])
         expected_values = [[2, 3, 3],
-                       [2, 3, 1],
-                       [2, 3, 3],
-                       [2, 3, 2],
-                       [2, 3, 0]]
+                           [2, 3, 1],
+                           [2, 3, 3],
+                           [2, 3, 2],
+                           [2, 3, 0]]
         for mode, expected_value in zip(self.modes, expected_values):
             output = ndimage.correlate1d(array, weights, 0,
                                          mode=mode, cval=0)
@@ -1134,10 +1110,10 @@ class TestNdimage:
         array = numpy.array([1, 2, 3])
         weights = numpy.array([0, 0, 0, 0, 0, 0, 0, 0, 1])
         expected_values = [[3, 3, 3],
-                       [2, 3, 1],
-                       [2, 1, 1],
-                       [1, 2, 3],
-                       [0, 0, 0]]
+                           [2, 3, 1],
+                           [2, 1, 1],
+                           [1, 2, 3],
+                           [0, 0, 0]]
         for mode, expected_value in zip(self.modes, expected_values):
             output = ndimage.correlate1d(array, weights, 0,
                                          mode=mode, cval=0)
@@ -1149,10 +1125,10 @@ class TestNdimage:
                              [7, 8, 9]])
         weights = numpy.array([[1, 0], [0, 0]])
         expected_values = [[[1, 1, 2], [1, 1, 2], [4, 4, 5]],
-                       [[9, 7, 8], [3, 1, 2], [6, 4, 5]],
-                       [[1, 1, 2], [1, 1, 2], [4, 4, 5]],
-                       [[5, 4, 5], [2, 1, 2], [5, 4, 5]],
-                       [[0, 0, 0], [0, 1, 2], [0, 4, 5]]]
+                           [[9, 7, 8], [3, 1, 2], [6, 4, 5]],
+                           [[1, 1, 2], [1, 1, 2], [4, 4, 5]],
+                           [[5, 4, 5], [2, 1, 2], [5, 4, 5]],
+                           [[0, 0, 0], [0, 1, 2], [0, 4, 5]]]
         for mode, expected_value in zip(self.modes, expected_values):
             output = ndimage.correlate(array, weights,
                                        mode=mode, cval=0)
@@ -1160,14 +1136,14 @@ class TestNdimage:
 
     def test_extend06(self):
         array = numpy.array([[1, 2, 3],
-                                [4, 5, 6],
-                                [7, 8, 9]])
+                             [4, 5, 6],
+                             [7, 8, 9]])
         weights = numpy.array([[0, 0, 0], [0, 0, 0], [0, 0, 1]])
         expected_values = [[[5, 6, 6], [8, 9, 9], [8, 9, 9]],
-                       [[5, 6, 4], [8, 9, 7], [2, 3, 1]],
-                       [[5, 6, 6], [8, 9, 9], [8, 9, 9]],
-                       [[5, 6, 5], [8, 9, 8], [5, 6, 5]],
-                       [[5, 6, 0], [8, 9, 0], [0, 0, 0]]]
+                           [[5, 6, 4], [8, 9, 7], [2, 3, 1]],
+                           [[5, 6, 6], [8, 9, 9], [8, 9, 9]],
+                           [[5, 6, 5], [8, 9, 8], [5, 6, 5]],
+                           [[5, 6, 0], [8, 9, 0], [0, 0, 0]]]
         for mode, expected_value in zip(self.modes, expected_values):
             output = ndimage.correlate(array, weights,
                                        mode=mode, cval=0)
@@ -1177,37 +1153,34 @@ class TestNdimage:
         array = numpy.array([1, 2, 3])
         weights = numpy.array([0, 0, 0, 0, 0, 0, 0, 0, 1])
         expected_values = [[3, 3, 3],
-                       [2, 3, 1],
-                       [2, 1, 1],
-                       [1, 2, 3],
-                       [0, 0, 0]]
+                           [2, 3, 1],
+                           [2, 1, 1],
+                           [1, 2, 3],
+                           [0, 0, 0]]
         for mode, expected_value in zip(self.modes, expected_values):
-            output = ndimage.correlate(array, weights,
-                                                 mode=mode, cval=0)
+            output = ndimage.correlate(array, weights, mode=mode, cval=0)
             assert_array_equal(output, expected_value)
 
     def test_extend08(self):
         array = numpy.array([[1], [2], [3]])
-        weights = numpy.array([[0], [0], [0], [0], [0], [0], [0],
-                                  [0], [1]])
+        weights = numpy.array([[0], [0], [0], [0], [0], [0], [0], [0], [1]])
         expected_values = [[[3], [3], [3]],
-                       [[2], [3], [1]],
-                       [[2], [1], [1]],
-                       [[1], [2], [3]],
-                       [[0], [0], [0]]]
+                           [[2], [3], [1]],
+                           [[2], [1], [1]],
+                           [[1], [2], [3]],
+                           [[0], [0], [0]]]
         for mode, expected_value in zip(self.modes, expected_values):
-            output = ndimage.correlate(array, weights,
-                                                 mode=mode, cval=0)
+            output = ndimage.correlate(array, weights, mode=mode, cval=0)
             assert_array_equal(output, expected_value)
 
     def test_extend09(self):
         array = numpy.array([1, 2, 3])
         weights = numpy.array([0, 0, 0, 0, 0, 0, 0, 0, 1])
         expected_values = [[3, 3, 3],
-                       [2, 3, 1],
-                       [2, 1, 1],
-                       [1, 2, 3],
-                       [0, 0, 0]]
+                           [2, 3, 1],
+                           [2, 1, 1],
+                           [1, 2, 3],
+                           [0, 0, 0]]
         for mode, expected_value in zip(self.modes, expected_values):
             output = ndimage.correlate(array, weights,
                                        mode=mode, cval=0)
@@ -1215,13 +1188,12 @@ class TestNdimage:
 
     def test_extend10(self):
         array = numpy.array([[1], [2], [3]])
-        weights = numpy.array([[0], [0], [0], [0], [0], [0], [0],
-                                  [0], [1]])
+        weights = numpy.array([[0], [0], [0], [0], [0], [0], [0], [0], [1]])
         expected_values = [[[3], [3], [3]],
-                       [[2], [3], [1]],
-                       [[2], [1], [1]],
-                       [[1], [2], [3]],
-                       [[0], [0], [0]]]
+                           [[2], [3], [1]],
+                           [[2], [1], [1]],
+                           [[1], [2], [3]],
+                           [[0], [0], [0]]]
         for mode, expected_value in zip(self.modes, expected_values):
             output = ndimage.correlate(array, weights,
                                        mode=mode, cval=0)
@@ -1231,78 +1203,74 @@ class TestNdimage:
         def shift(x):
             return (x[0] + 0.5,)
 
-        data = numpy.array([1,2,3,4.])
-        expected = {'constant': [1.5,2.5,3.5,-1,-1,-1,-1],
-                    'wrap': [1.5,2.5,3.5,1.5,2.5,3.5,1.5],
-                    'mirror': [1.5,2.5,3.5,3.5,2.5,1.5,1.5],
-                    'nearest': [1.5,2.5,3.5,4,4,4,4]}
+        data = numpy.array([1, 2, 3, 4])
+        expected = {'constant': [1.5, 2.5, 3.5, -1, -1, -1, -1],
+                    'wrap': [1.5, 2.5, 3.5, 1.5, 2.5, 3.5, 1.5],
+                    'mirror': [1.5, 2.5, 3.5, 3.5, 2.5, 1.5, 1.5],
+                    'nearest': [1.5, 2.5, 3.5, 4, 4, 4, 4]}
 
         for mode in expected:
-            assert_array_equal(expected[mode],
-                               ndimage.geometric_transform(data,shift,
-                                                           cval=-1,mode=mode,
-                                                           output_shape=(7,),
-                                                           order=1))
+            assert_array_equal(
+                expected[mode],
+                ndimage.geometric_transform(data, shift, cval=-1, mode=mode,
+                                            output_shape=(7,), order=1))
 
     def test_boundaries2(self):
         def shift(x):
             return (x[0] - 0.9,)
 
-        data = numpy.array([1,2,3,4])
-        expected = {'constant': [-1,1,2,3],
-                    'wrap': [3,1,2,3],
-                    'mirror': [2,1,2,3],
-                    'nearest': [1,1,2,3]}
+        data = numpy.array([1, 2, 3, 4])
+        expected = {'constant': [-1, 1, 2, 3],
+                    'wrap': [3, 1, 2, 3],
+                    'mirror': [2, 1, 2, 3],
+                    'nearest': [1, 1, 2, 3]}
 
         for mode in expected:
-            assert_array_equal(expected[mode],
-                               ndimage.geometric_transform(data,shift,
-                                                           cval=-1,mode=mode,
-                                                           output_shape=(4,)))
+            assert_array_equal(
+                expected[mode],
+                ndimage.geometric_transform(data, shift, cval=-1, mode=mode,
+                                            output_shape=(4,)))
 
     def test_fourier_gaussian_real01(self):
         for shape in [(32, 16), (31, 15)]:
-            for type, dec in zip([numpy.float32, numpy.float64], [6, 14]):
-                a = numpy.zeros(shape, type)
+            for type_, dec in zip([numpy.float32, numpy.float64], [6, 14]):
+                a = numpy.zeros(shape, type_)
                 a[0, 0] = 1.0
                 a = fft.rfft(a, shape[0], 0)
                 a = fft.fft(a, shape[1], 1)
-                a = ndimage.fourier_gaussian(a, [5.0, 2.5],
-                                                       shape[0], 0)
+                a = ndimage.fourier_gaussian(a, [5.0, 2.5], shape[0], 0)
                 a = fft.ifft(a, shape[1], 1)
                 a = fft.irfft(a, shape[0], 0)
                 assert_almost_equal(ndimage.sum(a), 1, decimal=dec)
 
     def test_fourier_gaussian_complex01(self):
         for shape in [(32, 16), (31, 15)]:
-            for type, dec in zip([numpy.complex64, numpy.complex128], [6, 14]):
-                a = numpy.zeros(shape, type)
+            for type_, dec in zip([numpy.complex64, numpy.complex128], [6, 14]):
+                a = numpy.zeros(shape, type_)
                 a[0, 0] = 1.0
                 a = fft.fft(a, shape[0], 0)
                 a = fft.fft(a, shape[1], 1)
-                a = ndimage.fourier_gaussian(a, [5.0, 2.5], -1,
-                                                       0)
+                a = ndimage.fourier_gaussian(a, [5.0, 2.5], -1, 0)
                 a = fft.ifft(a, shape[1], 1)
                 a = fft.ifft(a, shape[0], 0)
                 assert_almost_equal(ndimage.sum(a.real), 1.0, decimal=dec)
 
     def test_fourier_uniform_real01(self):
         for shape in [(32, 16), (31, 15)]:
-            for type, dec in zip([numpy.float32, numpy.float64], [6, 14]):
-                a = numpy.zeros(shape, type)
+            for type_, dec in zip([numpy.float32, numpy.float64], [6, 14]):
+                a = numpy.zeros(shape, type_)
                 a[0, 0] = 1.0
                 a = fft.rfft(a, shape[0], 0)
                 a = fft.fft(a, shape[1], 1)
-                a = ndimage.fourier_uniform(a, [5.0, 2.5],
-                                                      shape[0], 0)
+                a = ndimage.fourier_uniform(a, [5.0, 2.5], shape[0], 0)
                 a = fft.ifft(a, shape[1], 1)
                 a = fft.irfft(a, shape[0], 0)
                 assert_almost_equal(ndimage.sum(a), 1.0, decimal=dec)
 
     def test_fourier_uniform_complex01(self):
         for shape in [(32, 16), (31, 15)]:
-            for type, dec in zip([numpy.complex64, numpy.complex128], [6, 14]):
-                a = numpy.zeros(shape, type)
+            for type_, dec in zip([numpy.complex64, numpy.complex128], [6, 14]):
+                a = numpy.zeros(shape, type_)
                 a[0, 0] = 1.0
                 a = fft.fft(a, shape[0], 0)
                 a = fft.fft(a, shape[1], 1)
@@ -1313,35 +1281,38 @@ class TestNdimage:
 
     def test_fourier_shift_real01(self):
         for shape in [(32, 16), (31, 15)]:
-            for dtype, dec in zip([numpy.float32, numpy.float64], [4, 11]):
-                expected = numpy.arange(shape[0] * shape[1], dtype=dtype)
+            for type_, dec in zip([numpy.float32, numpy.float64], [4, 11]):
+                expected = numpy.arange(shape[0] * shape[1], dtype=type_)
                 expected.shape = shape
                 a = fft.rfft(expected, shape[0], 0)
                 a = fft.fft(a, shape[1], 1)
                 a = ndimage.fourier_shift(a, [1, 1], shape[0], 0)
                 a = fft.ifft(a, shape[1], 1)
                 a = fft.irfft(a, shape[0], 0)
-                assert_array_almost_equal(a[1:, 1:], expected[:-1, :-1], decimal=dec)
-                assert_array_almost_equal(a.imag, numpy.zeros(shape), decimal=dec)
+                assert_array_almost_equal(a[1:, 1:], expected[:-1, :-1],
+                                          decimal=dec)
+                assert_array_almost_equal(a.imag, numpy.zeros(shape),
+                                          decimal=dec)
 
     def test_fourier_shift_complex01(self):
         for shape in [(32, 16), (31, 15)]:
-            for type, dec in zip([numpy.complex64, numpy.complex128], [4, 11]):
-                expected = numpy.arange(shape[0] * shape[1],
-                                       dtype=type)
+            for type_, dec in zip([numpy.complex64, numpy.complex128], [4, 11]):
+                expected = numpy.arange(shape[0] * shape[1], dtype=type_)
                 expected.shape = shape
                 a = fft.fft(expected, shape[0], 0)
                 a = fft.fft(a, shape[1], 1)
                 a = ndimage.fourier_shift(a, [1, 1], -1, 0)
                 a = fft.ifft(a, shape[1], 1)
                 a = fft.ifft(a, shape[0], 0)
-                assert_array_almost_equal(a.real[1:, 1:], expected[:-1, :-1], decimal=dec)
-                assert_array_almost_equal(a.imag, numpy.zeros(shape), decimal=dec)
+                assert_array_almost_equal(a.real[1:, 1:], expected[:-1, :-1],
+                                          decimal=dec)
+                assert_array_almost_equal(a.imag, numpy.zeros(shape),
+                                          decimal=dec)
 
     def test_fourier_ellipsoid_real01(self):
         for shape in [(32, 16), (31, 15)]:
-            for type, dec in zip([numpy.float32, numpy.float64], [5, 14]):
-                a = numpy.zeros(shape, type)
+            for type_, dec in zip([numpy.float32, numpy.float64], [5, 14]):
+                a = numpy.zeros(shape, type_)
                 a[0, 0] = 1.0
                 a = fft.rfft(a, shape[0], 0)
                 a = fft.fft(a, shape[1], 1)
@@ -1353,56 +1324,55 @@ class TestNdimage:
 
     def test_fourier_ellipsoid_complex01(self):
         for shape in [(32, 16), (31, 15)]:
-            for type, dec in zip([numpy.complex64, numpy.complex128],
-                                 [5, 14]):
-                a = numpy.zeros(shape, type)
+            for type_, dec in zip([numpy.complex64, numpy.complex128],
+                                  [5, 14]):
+                a = numpy.zeros(shape, type_)
                 a[0, 0] = 1.0
                 a = fft.fft(a, shape[0], 0)
                 a = fft.fft(a, shape[1], 1)
-                a = ndimage.fourier_ellipsoid(a, [5.0, 2.5], -1,
-                                                        0)
+                a = ndimage.fourier_ellipsoid(a, [5.0, 2.5], -1, 0)
                 a = fft.ifft(a, shape[1], 1)
                 a = fft.ifft(a, shape[0], 0)
                 assert_almost_equal(ndimage.sum(a.real), 1.0, decimal=dec)
 
     def test_spline01(self):
-        for type in self.types:
-            data = numpy.ones([], type)
+        for type_ in self.types:
+            data = numpy.ones([], type_)
             for order in range(2, 6):
                 out = ndimage.spline_filter(data, order=order)
                 assert_array_almost_equal(out, 1)
 
     def test_spline02(self):
-        for type in self.types:
-            data = numpy.array([1])
+        for type_ in self.types:
+            data = numpy.array([1], type_)
             for order in range(2, 6):
                 out = ndimage.spline_filter(data, order=order)
                 assert_array_almost_equal(out, [1])
 
     def test_spline03(self):
-        for type in self.types:
-            data = numpy.ones([], type)
+        for type_ in self.types:
+            data = numpy.ones([], type_)
             for order in range(2, 6):
                 out = ndimage.spline_filter(data, order,
-                                            output=type)
+                                            output=type_)
                 assert_array_almost_equal(out, 1)
 
     def test_spline04(self):
-        for type in self.types:
-            data = numpy.ones([4], type)
+        for type_ in self.types:
+            data = numpy.ones([4], type_)
             for order in range(2, 6):
                 out = ndimage.spline_filter(data, order)
                 assert_array_almost_equal(out, [1, 1, 1, 1])
 
     def test_spline05(self):
-        for type in self.types:
-            data = numpy.ones([4, 4], type)
+        for type_ in self.types:
+            data = numpy.ones([4, 4], type_)
             for order in range(2, 6):
                 out = ndimage.spline_filter(data, order=order)
                 assert_array_almost_equal(out, [[1, 1, 1, 1],
-                                           [1, 1, 1, 1],
-                                           [1, 1, 1, 1],
-                                           [1, 1, 1, 1]])
+                                                [1, 1, 1, 1],
+                                                [1, 1, 1, 1],
+                                                [1, 1, 1, 1]])
 
     def test_geometric_transform01(self):
         data = numpy.array([1])
@@ -1410,9 +1380,8 @@ class TestNdimage:
         def mapping(x):
             return x
         for order in range(0, 6):
-            out = ndimage.geometric_transform(data, mapping,
-                                                        data.shape,
-                                                        order=order)
+            out = ndimage.geometric_transform(data, mapping, data.shape,
+                                              order=order)
             assert_array_almost_equal(out, [1])
 
     def test_geometric_transform02(self):
@@ -1421,8 +1390,8 @@ class TestNdimage:
         def mapping(x):
             return x
         for order in range(0, 6):
-            out = ndimage.geometric_transform(data, mapping,
-                                                  data.shape, order=order)
+            out = ndimage.geometric_transform(data, mapping, data.shape,
+                                              order=order)
             assert_array_almost_equal(out, [1, 1, 1, 1])
 
     def test_geometric_transform03(self):
@@ -1431,8 +1400,8 @@ class TestNdimage:
         def mapping(x):
             return (x[0] - 1,)
         for order in range(0, 6):
-            out = ndimage.geometric_transform(data, mapping,
-                                                   data.shape, order=order)
+            out = ndimage.geometric_transform(data, mapping, data.shape,
+                                              order=order)
             assert_array_almost_equal(out, [0, 1, 1, 1])
 
     def test_geometric_transform04(self):
@@ -1441,84 +1410,83 @@ class TestNdimage:
         def mapping(x):
             return (x[0] - 1,)
         for order in range(0, 6):
-            out = ndimage.geometric_transform(data, mapping,
-                                                   data.shape, order=order)
+            out = ndimage.geometric_transform(data, mapping, data.shape,
+                                              order=order)
             assert_array_almost_equal(out, [0, 4, 1, 3])
 
     def test_geometric_transform05(self):
         data = numpy.array([[1, 1, 1, 1],
-                               [1, 1, 1, 1],
-                               [1, 1, 1, 1]])
+                            [1, 1, 1, 1],
+                            [1, 1, 1, 1]])
 
         def mapping(x):
             return (x[0], x[1] - 1)
         for order in range(0, 6):
-            out = ndimage.geometric_transform(data, mapping,
-                                                   data.shape, order=order)
+            out = ndimage.geometric_transform(data, mapping, data.shape,
+                                              order=order)
             assert_array_almost_equal(out, [[0, 1, 1, 1],
-                                       [0, 1, 1, 1],
-                                       [0, 1, 1, 1]])
+                                            [0, 1, 1, 1],
+                                            [0, 1, 1, 1]])
 
     def test_geometric_transform06(self):
         data = numpy.array([[4, 1, 3, 2],
-                               [7, 6, 8, 5],
-                               [3, 5, 3, 6]])
+                            [7, 6, 8, 5],
+                            [3, 5, 3, 6]])
 
         def mapping(x):
             return (x[0], x[1] - 1)
         for order in range(0, 6):
-            out = ndimage.geometric_transform(data, mapping,
-                                                   data.shape, order=order)
+            out = ndimage.geometric_transform(data, mapping, data.shape,
+                                              order=order)
             assert_array_almost_equal(out, [[0, 4, 1, 3],
-                                       [0, 7, 6, 8],
-                                       [0, 3, 5, 3]])
+                                            [0, 7, 6, 8],
+                                            [0, 3, 5, 3]])
 
     def test_geometric_transform07(self):
         data = numpy.array([[4, 1, 3, 2],
-                               [7, 6, 8, 5],
-                               [3, 5, 3, 6]])
+                            [7, 6, 8, 5],
+                            [3, 5, 3, 6]])
 
         def mapping(x):
             return (x[0] - 1, x[1])
         for order in range(0, 6):
-            out = ndimage.geometric_transform(data, mapping,
-                                                   data.shape, order=order)
+            out = ndimage.geometric_transform(data, mapping, data.shape,
+                                              order=order)
             assert_array_almost_equal(out, [[0, 0, 0, 0],
-                                       [4, 1, 3, 2],
-                                       [7, 6, 8, 5]])
+                                            [4, 1, 3, 2],
+                                            [7, 6, 8, 5]])
 
     def test_geometric_transform08(self):
         data = numpy.array([[4, 1, 3, 2],
-                               [7, 6, 8, 5],
-                               [3, 5, 3, 6]])
+                            [7, 6, 8, 5],
+                            [3, 5, 3, 6]])
 
         def mapping(x):
             return (x[0] - 1, x[1] - 1)
         for order in range(0, 6):
-            out = ndimage.geometric_transform(data, mapping,
-                                                   data.shape, order=order)
+            out = ndimage.geometric_transform(data, mapping, data.shape,
+                                              order=order)
             assert_array_almost_equal(out, [[0, 0, 0, 0],
-                                       [0, 4, 1, 3],
-                                       [0, 7, 6, 8]])
+                                            [0, 4, 1, 3],
+                                            [0, 7, 6, 8]])
 
     def test_geometric_transform10(self):
         data = numpy.array([[4, 1, 3, 2],
-                               [7, 6, 8, 5],
-                               [3, 5, 3, 6]])
+                            [7, 6, 8, 5],
+                            [3, 5, 3, 6]])
 
         def mapping(x):
             return (x[0] - 1, x[1] - 1)
         for order in range(0, 6):
             if (order > 1):
-                filtered = ndimage.spline_filter(data,
-                                                           order=order)
+                filtered = ndimage.spline_filter(data, order=order)
             else:
                 filtered = data
-            out = ndimage.geometric_transform(filtered, mapping,
-                               data.shape, order=order, prefilter=False)
+            out = ndimage.geometric_transform(filtered, mapping, data.shape,
+                                              order=order, prefilter=False)
             assert_array_almost_equal(out, [[0, 0, 0, 0],
-                                       [0, 4, 1, 3],
-                                       [0, 7, 6, 8]])
+                                            [0, 4, 1, 3],
+                                            [0, 7, 6, 8]])
 
     def test_geometric_transform13(self):
         data = numpy.ones([2], numpy.float64)
@@ -1526,8 +1494,7 @@ class TestNdimage:
         def mapping(x):
             return (x[0] // 2,)
         for order in range(0, 6):
-            out = ndimage.geometric_transform(data, mapping,
-                                                        [4], order=order)
+            out = ndimage.geometric_transform(data, mapping, [4], order=order)
             assert_array_almost_equal(out, [1, 1, 1, 1])
 
     def test_geometric_transform14(self):
@@ -1536,8 +1503,7 @@ class TestNdimage:
         def mapping(x):
             return (2 * x[0],)
         for order in range(0, 6):
-            out = ndimage.geometric_transform(data, mapping,
-                                                        [4], order=order)
+            out = ndimage.geometric_transform(data, mapping, [4], order=order)
             assert_array_almost_equal(out, [1, 2, 3, 4])
 
     def test_geometric_transform15(self):
@@ -1546,8 +1512,7 @@ class TestNdimage:
         def mapping(x):
             return (x[0] / 2,)
         for order in range(0, 6):
-            out = ndimage.geometric_transform(data, mapping,
-                                                        [8], order=order)
+            out = ndimage.geometric_transform(data, mapping, [8], order=order)
             assert_array_almost_equal(out[::2], [1, 2, 3, 4])
 
     def test_geometric_transform16(self):
@@ -1558,8 +1523,8 @@ class TestNdimage:
         def mapping(x):
             return (x[0], x[1] * 2)
         for order in range(0, 6):
-            out = ndimage.geometric_transform(data, mapping,
-                                                       (3, 2), order=order)
+            out = ndimage.geometric_transform(data, mapping, (3, 2),
+                                              order=order)
             assert_array_almost_equal(out, [[1, 3], [5, 7], [9, 11]])
 
     def test_geometric_transform17(self):
@@ -1570,8 +1535,8 @@ class TestNdimage:
         def mapping(x):
             return (x[0] * 2, x[1])
         for order in range(0, 6):
-            out = ndimage.geometric_transform(data, mapping,
-                                                       (1, 4), order=order)
+            out = ndimage.geometric_transform(data, mapping, (1, 4),
+                                              order=order)
             assert_array_almost_equal(out, [[1, 2, 3, 4]])
 
     def test_geometric_transform18(self):
@@ -1582,8 +1547,8 @@ class TestNdimage:
         def mapping(x):
             return (x[0] * 2, x[1] * 2)
         for order in range(0, 6):
-            out = ndimage.geometric_transform(data, mapping,
-                                                       (1, 2), order=order)
+            out = ndimage.geometric_transform(data, mapping, (1, 2),
+                                              order=order)
             assert_array_almost_equal(out, [[1, 3]])
 
     def test_geometric_transform19(self):
@@ -1594,8 +1559,8 @@ class TestNdimage:
         def mapping(x):
             return (x[0], x[1] / 2)
         for order in range(0, 6):
-            out = ndimage.geometric_transform(data, mapping,
-                                                       (3, 8), order=order)
+            out = ndimage.geometric_transform(data, mapping, (3, 8),
+                                              order=order)
             assert_array_almost_equal(out[..., ::2], data)
 
     def test_geometric_transform20(self):
@@ -1606,8 +1571,8 @@ class TestNdimage:
         def mapping(x):
             return (x[0] / 2, x[1])
         for order in range(0, 6):
-            out = ndimage.geometric_transform(data, mapping,
-                                                       (6, 4), order=order)
+            out = ndimage.geometric_transform(data, mapping, (6, 4),
+                                              order=order)
             assert_array_almost_equal(out[::2, ...], data)
 
     def test_geometric_transform21(self):
@@ -1618,14 +1583,14 @@ class TestNdimage:
         def mapping(x):
             return (x[0] / 2, x[1] / 2)
         for order in range(0, 6):
-            out = ndimage.geometric_transform(data, mapping,
-                                                      (6, 8), order=order)
+            out = ndimage.geometric_transform(data, mapping, (6, 8),
+                                              order=order)
             assert_array_almost_equal(out[::2, ::2], data)
 
     def test_geometric_transform22(self):
         data = numpy.array([[1, 2, 3, 4],
-                               [5, 6, 7, 8],
-                               [9, 10, 11, 12]], numpy.float64)
+                            [5, 6, 7, 8],
+                            [9, 10, 11, 12]], numpy.float64)
 
         def mapping1(x):
             return (x[0] / 2, x[1] / 2)
@@ -1647,8 +1612,7 @@ class TestNdimage:
         def mapping(x):
             return (1, x[0] * 2)
         for order in range(0, 6):
-            out = ndimage.geometric_transform(data, mapping,
-                                                        (2,), order=order)
+            out = ndimage.geometric_transform(data, mapping, (2,), order=order)
             out = out.astype(numpy.int32)
             assert_array_almost_equal(out, [5, 7])
 
@@ -1660,14 +1624,14 @@ class TestNdimage:
         def mapping(x, a, b):
             return (a, x[0] * b)
         for order in range(0, 6):
-            out = ndimage.geometric_transform(data, mapping,
-                                (2,), order=order, extra_arguments=(1,),
-                                extra_keywords={'b': 2})
+            out = ndimage.geometric_transform(
+                data, mapping, (2,), order=order, extra_arguments=(1,),
+                extra_keywords={'b': 2})
             assert_array_almost_equal(out, [5, 7])
 
     def test_geometric_transform_endianness_with_output_parameter(self):
-        # geometric transform given output ndarray or dtype with non-native endianness
-        # see issue #4127
+        # geometric transform given output ndarray or dtype with
+        # non-native endianness. see issue #4127
         data = numpy.array([1])
 
         def mapping(x):
@@ -1676,55 +1640,53 @@ class TestNdimage:
         for out in [data.dtype, data.dtype.newbyteorder(),
                     numpy.empty_like(data),
                     numpy.empty_like(data).astype(data.dtype.newbyteorder())]:
-            returned = ndimage.geometric_transform(data, mapping,
-                                        data.shape,
-                                        output=out)
+            returned = ndimage.geometric_transform(data, mapping, data.shape,
+                                                   output=out)
             result = out if returned is None else returned
             assert_array_almost_equal(result, [1])
 
     def test_map_coordinates01(self):
         data = numpy.array([[4, 1, 3, 2],
-                               [7, 6, 8, 5],
-                               [3, 5, 3, 6]])
+                            [7, 6, 8, 5],
+                            [3, 5, 3, 6]])
         idx = numpy.indices(data.shape)
         idx -= 1
         for order in range(0, 6):
             out = ndimage.map_coordinates(data, idx, order=order)
             assert_array_almost_equal(out, [[0, 0, 0, 0],
-                                       [0, 4, 1, 3],
-                                       [0, 7, 6, 8]])
+                                            [0, 4, 1, 3],
+                                            [0, 7, 6, 8]])
 
     def test_map_coordinates02(self):
         data = numpy.array([[4, 1, 3, 2],
-                               [7, 6, 8, 5],
-                               [3, 5, 3, 6]])
+                            [7, 6, 8, 5],
+                            [3, 5, 3, 6]])
         idx = numpy.indices(data.shape, numpy.float64)
         idx -= 0.5
         for order in range(0, 6):
             out1 = ndimage.shift(data, 0.5, order=order)
-            out2 = ndimage.map_coordinates(data, idx,
-                                                     order=order)
+            out2 = ndimage.map_coordinates(data, idx, order=order)
             assert_array_almost_equal(out1, out2)
 
     def test_map_coordinates03(self):
         data = numpy.array([[4, 1, 3, 2],
-                               [7, 6, 8, 5],
-                               [3, 5, 3, 6]], order='F')
+                            [7, 6, 8, 5],
+                            [3, 5, 3, 6]], order='F')
         idx = numpy.indices(data.shape) - 1
         out = ndimage.map_coordinates(data, idx)
         assert_array_almost_equal(out, [[0, 0, 0, 0],
-                                   [0, 4, 1, 3],
-                                   [0, 7, 6, 8]])
+                                        [0, 4, 1, 3],
+                                        [0, 7, 6, 8]])
         assert_array_almost_equal(out, ndimage.shift(data, (1, 1)))
         idx = numpy.indices(data[::2].shape) - 1
         out = ndimage.map_coordinates(data[::2], idx)
         assert_array_almost_equal(out, [[0, 0, 0, 0],
-                                   [0, 4, 1, 3]])
+                                        [0, 4, 1, 3]])
         assert_array_almost_equal(out, ndimage.shift(data[::2], (1, 1)))
-        idx = numpy.indices(data[:,::2].shape) - 1
-        out = ndimage.map_coordinates(data[:,::2], idx)
+        idx = numpy.indices(data[:, ::2].shape) - 1
+        out = ndimage.map_coordinates(data[:, ::2], idx)
         assert_array_almost_equal(out, [[0, 0], [0, 4], [0, 7]])
-        assert_array_almost_equal(out, ndimage.shift(data[:,::2], (1, 1)))
+        assert_array_almost_equal(out, ndimage.shift(data[:, ::2], (1, 1)))
 
     def test_map_coordinates_endianness_with_output_parameter(self):
         # output parameter given as array or dtype with either endianness
@@ -1747,7 +1709,7 @@ class TestNdimage:
             n = 30000
             a = numpy.empty(n**2, dtype=numpy.float32).reshape(n, n)
             # fill the part we might read
-            a[n - 3:,n - 3:] = 0
+            a[n-3:, n-3:] = 0
             ndimage.map_coordinates(a, [[n - 1.5], [n - 1.5]], order=1)
         except MemoryError:
             raise pytest.skip("Not enough memory available")
@@ -1755,115 +1717,104 @@ class TestNdimage:
     def test_affine_transform01(self):
         data = numpy.array([1])
         for order in range(0, 6):
-            out = ndimage.affine_transform(data, [[1]],
-                                                     order=order)
+            out = ndimage.affine_transform(data, [[1]], order=order)
             assert_array_almost_equal(out, [1])
 
     def test_affine_transform02(self):
         data = numpy.ones([4])
         for order in range(0, 6):
-            out = ndimage.affine_transform(data, [[1]],
-                                                     order=order)
+            out = ndimage.affine_transform(data, [[1]], order=order)
             assert_array_almost_equal(out, [1, 1, 1, 1])
 
     def test_affine_transform03(self):
         data = numpy.ones([4])
         for order in range(0, 6):
-            out = ndimage.affine_transform(data, [[1]], -1,
-                                                     order=order)
+            out = ndimage.affine_transform(data, [[1]], -1, order=order)
             assert_array_almost_equal(out, [0, 1, 1, 1])
 
     def test_affine_transform04(self):
         data = numpy.array([4, 1, 3, 2])
         for order in range(0, 6):
-            out = ndimage.affine_transform(data, [[1]], -1,
-                                                     order=order)
+            out = ndimage.affine_transform(data, [[1]], -1, order=order)
             assert_array_almost_equal(out, [0, 4, 1, 3])
 
     def test_affine_transform05(self):
         data = numpy.array([[1, 1, 1, 1],
-                               [1, 1, 1, 1],
-                               [1, 1, 1, 1]])
+                            [1, 1, 1, 1],
+                            [1, 1, 1, 1]])
         for order in range(0, 6):
-            out = ndimage.affine_transform(data, [[1, 0],
-                                                            [0, 1]],
-                                                     [0, -1], order=order)
+            out = ndimage.affine_transform(data, [[1, 0], [0, 1]],
+                                           [0, -1], order=order)
             assert_array_almost_equal(out, [[0, 1, 1, 1],
-                                       [0, 1, 1, 1],
-                                       [0, 1, 1, 1]])
+                                            [0, 1, 1, 1],
+                                            [0, 1, 1, 1]])
 
     def test_affine_transform06(self):
         data = numpy.array([[4, 1, 3, 2],
-                               [7, 6, 8, 5],
-                               [3, 5, 3, 6]])
+                            [7, 6, 8, 5],
+                            [3, 5, 3, 6]])
         for order in range(0, 6):
-            out = ndimage.affine_transform(data, [[1, 0],
-                                                            [0, 1]],
-                                                     [0, -1], order=order)
+            out = ndimage.affine_transform(data, [[1, 0], [0, 1]],
+                                           [0, -1], order=order)
             assert_array_almost_equal(out, [[0, 4, 1, 3],
-                                       [0, 7, 6, 8],
-                                       [0, 3, 5, 3]])
+                                            [0, 7, 6, 8],
+                                            [0, 3, 5, 3]])
 
     def test_affine_transform07(self):
         data = numpy.array([[4, 1, 3, 2],
-                               [7, 6, 8, 5],
-                               [3, 5, 3, 6]])
+                            [7, 6, 8, 5],
+                            [3, 5, 3, 6]])
         for order in range(0, 6):
-            out = ndimage.affine_transform(data, [[1, 0],
-                                                            [0, 1]],
-                                                     [-1, 0], order=order)
+            out = ndimage.affine_transform(data, [[1, 0], [0, 1]],
+                                           [-1, 0], order=order)
             assert_array_almost_equal(out, [[0, 0, 0, 0],
-                                       [4, 1, 3, 2],
-                                       [7, 6, 8, 5]])
+                                            [4, 1, 3, 2],
+                                            [7, 6, 8, 5]])
 
     def test_affine_transform08(self):
         data = numpy.array([[4, 1, 3, 2],
-                               [7, 6, 8, 5],
-                               [3, 5, 3, 6]])
+                            [7, 6, 8, 5],
+                            [3, 5, 3, 6]])
         for order in range(0, 6):
-            out = ndimage.affine_transform(data, [[1, 0],
-                                                            [0, 1]],
-                                                     [-1, -1], order=order)
+            out = ndimage.affine_transform(data, [[1, 0], [0, 1]],
+                                           [-1, -1], order=order)
             assert_array_almost_equal(out, [[0, 0, 0, 0],
-                                       [0, 4, 1, 3],
-                                       [0, 7, 6, 8]])
+                                            [0, 4, 1, 3],
+                                            [0, 7, 6, 8]])
 
     def test_affine_transform09(self):
         data = numpy.array([[4, 1, 3, 2],
-                               [7, 6, 8, 5],
-                               [3, 5, 3, 6]])
+                            [7, 6, 8, 5],
+                            [3, 5, 3, 6]])
         for order in range(0, 6):
             if (order > 1):
-                filtered = ndimage.spline_filter(data,
-                                                           order=order)
+                filtered = ndimage.spline_filter(data, order=order)
             else:
                 filtered = data
-            out = ndimage.affine_transform(filtered,[[1, 0],
-                                                               [0, 1]],
-                                  [-1, -1], order=order, prefilter=False)
+            out = ndimage.affine_transform(filtered, [[1, 0], [0, 1]],
+                                           [-1, -1], order=order,
+                                           prefilter=False)
             assert_array_almost_equal(out, [[0, 0, 0, 0],
-                                       [0, 4, 1, 3],
-                                       [0, 7, 6, 8]])
+                                            [0, 4, 1, 3],
+                                            [0, 7, 6, 8]])
 
     def test_affine_transform10(self):
         data = numpy.ones([2], numpy.float64)
         for order in range(0, 6):
-            out = ndimage.affine_transform(data, [[0.5]],
-                                          output_shape=(4,), order=order)
+            out = ndimage.affine_transform(data, [[0.5]], output_shape=(4,),
+                                           order=order)
             assert_array_almost_equal(out, [1, 1, 1, 0])
 
     def test_affine_transform11(self):
         data = [1, 5, 2, 6, 3, 7, 4, 4]
         for order in range(0, 6):
-            out = ndimage.affine_transform(data, [[2]], 0, (4,),
-                                                     order=order)
+            out = ndimage.affine_transform(data, [[2]], 0, (4,), order=order)
             assert_array_almost_equal(out, [1, 2, 3, 4])
 
     def test_affine_transform12(self):
         data = [1, 2, 3, 4]
         for order in range(0, 6):
-            out = ndimage.affine_transform(data, [[0.5]], 0,
-                                                     (8,), order=order)
+            out = ndimage.affine_transform(data, [[0.5]], 0, (8,), order=order)
             assert_array_almost_equal(out[::2], [1, 2, 3, 4])
 
     def test_affine_transform13(self):
@@ -1871,9 +1822,8 @@ class TestNdimage:
                 [5, 6, 7, 8],
                 [9.0, 10, 11, 12]]
         for order in range(0, 6):
-            out = ndimage.affine_transform(data, [[1, 0],
-                                                            [0, 2]], 0,
-                                                     (3, 2), order=order)
+            out = ndimage.affine_transform(data, [[1, 0], [0, 2]], 0, (3, 2),
+                                           order=order)
             assert_array_almost_equal(out, [[1, 3], [5, 7], [9, 11]])
 
     def test_affine_transform14(self):
@@ -1881,9 +1831,8 @@ class TestNdimage:
                 [5, 6, 7, 8],
                 [9, 10, 11, 12]]
         for order in range(0, 6):
-            out = ndimage.affine_transform(data, [[2, 0],
-                                                            [0, 1]], 0,
-                                                     (1, 4), order=order)
+            out = ndimage.affine_transform(data, [[2, 0], [0, 1]], 0, (1, 4),
+                                           order=order)
             assert_array_almost_equal(out, [[1, 2, 3, 4]])
 
     def test_affine_transform15(self):
@@ -1891,9 +1840,8 @@ class TestNdimage:
                 [5, 6, 7, 8],
                 [9, 10, 11, 12]]
         for order in range(0, 6):
-            out = ndimage.affine_transform(data, [[2, 0],
-                                                            [0, 2]], 0,
-                                                     (1, 2), order=order)
+            out = ndimage.affine_transform(data, [[2, 0], [0, 2]], 0, (1, 2),
+                                           order=order)
             assert_array_almost_equal(out, [[1, 3]])
 
     def test_affine_transform16(self):
@@ -1901,9 +1849,8 @@ class TestNdimage:
                 [5, 6, 7, 8],
                 [9, 10, 11, 12]]
         for order in range(0, 6):
-            out = ndimage.affine_transform(data, [[1, 0.0],
-                                                            [0, 0.5]], 0,
-                                                     (3, 8), order=order)
+            out = ndimage.affine_transform(data, [[1, 0.0], [0, 0.5]], 0,
+                                           (3, 8), order=order)
             assert_array_almost_equal(out[..., ::2], data)
 
     def test_affine_transform17(self):
@@ -1911,9 +1858,8 @@ class TestNdimage:
                 [5, 6, 7, 8],
                 [9, 10, 11, 12]]
         for order in range(0, 6):
-            out = ndimage.affine_transform(data, [[0.5, 0],
-                                                            [0, 1]], 0,
-                                                     (6, 4), order=order)
+            out = ndimage.affine_transform(data, [[0.5, 0], [0, 1]], 0,
+                                           (6, 4), order=order)
             assert_array_almost_equal(out[::2, ...], data)
 
     def test_affine_transform18(self):
@@ -1921,25 +1867,19 @@ class TestNdimage:
                 [5, 6, 7, 8],
                 [9, 10, 11, 12]]
         for order in range(0, 6):
-            out = ndimage.affine_transform(data,
-                                                     [[0.5, 0],
-                                                      [0, 0.5]], 0,
-                                                     (6, 8), order=order)
+            out = ndimage.affine_transform(data, [[0.5, 0], [0, 0.5]], 0,
+                                           (6, 8), order=order)
             assert_array_almost_equal(out[::2, ::2], data)
 
     def test_affine_transform19(self):
         data = numpy.array([[1, 2, 3, 4],
-                               [5, 6, 7, 8],
-                               [9, 10, 11, 12]], numpy.float64)
+                            [5, 6, 7, 8],
+                            [9, 10, 11, 12]], numpy.float64)
         for order in range(0, 6):
-            out = ndimage.affine_transform(data,
-                                                     [[0.5, 0],
-                                                      [0, 0.5]], 0,
-                                                     (6, 8), order=order)
-            out = ndimage.affine_transform(out,
-                                                     [[2.0, 0],
-                                                      [0, 2.0]], 0,
-                                                     (3, 4), order=order)
+            out = ndimage.affine_transform(data, [[0.5, 0], [0, 0.5]], 0,
+                                           (6, 8), order=order)
+            out = ndimage.affine_transform(out, [[2.0, 0], [0, 2.0]], 0,
+                                           (3, 4), order=order)
             assert_array_almost_equal(out, data)
 
     def test_affine_transform20(self):
@@ -1947,8 +1887,8 @@ class TestNdimage:
                 [5, 6, 7, 8],
                 [9, 10, 11, 12]]
         for order in range(0, 6):
-            out = ndimage.affine_transform(data, [[0], [2]], 0,
-                                                     (2,), order=order)
+            out = ndimage.affine_transform(data, [[0], [2]], 0, (2,),
+                                           order=order)
             assert_array_almost_equal(out, [1, 3])
 
     def test_affine_transform21(self):
@@ -1956,24 +1896,24 @@ class TestNdimage:
                 [5, 6, 7, 8],
                 [9, 10, 11, 12]]
         for order in range(0, 6):
-            out = ndimage.affine_transform(data, [[2], [0]], 0,
-                                                     (2,), order=order)
+            out = ndimage.affine_transform(data, [[2], [0]], 0, (2,),
+                                           order=order)
             assert_array_almost_equal(out, [1, 9])
 
     def test_affine_transform22(self):
         # shift and offset interaction; see issue #1547
         data = numpy.array([4, 1, 3, 2])
         for order in range(0, 6):
-            out = ndimage.affine_transform(data, [[2]], [-1],
-                                           (3,),order=order)
+            out = ndimage.affine_transform(data, [[2]], [-1], (3,),
+                                           order=order)
             assert_array_almost_equal(out, [0, 1, 2])
 
     def test_affine_transform23(self):
         # shift and offset interaction; see issue #1547
         data = numpy.array([4, 1, 3, 2])
         for order in range(0, 6):
-            out = ndimage.affine_transform(data, [[0.5]], [-1],
-                                           (8,),order=order)
+            out = ndimage.affine_transform(data, [[0.5]], [-1], (8,),
+                                           order=order)
             assert_array_almost_equal(out[::2], [0, 4, 1, 3])
 
     def test_affine_transform24(self):
@@ -1984,8 +1924,7 @@ class TestNdimage:
                 sup.filter(UserWarning,
                            "The behaviour of affine_transform with a one-dimensional array .* has changed")
                 out1 = ndimage.affine_transform(data, [2], -1, order=order)
-            out2 = ndimage.affine_transform(data, [[2]], -1,
-                                                order=order)
+            out2 = ndimage.affine_transform(data, [[2]], -1, order=order)
             assert_array_almost_equal(out1, out2)
 
     def test_affine_transform25(self):
@@ -1996,8 +1935,7 @@ class TestNdimage:
                 sup.filter(UserWarning,
                            "The behaviour of affine_transform with a one-dimensional array .* has changed")
                 out1 = ndimage.affine_transform(data, [0.5], -1, order=order)
-            out2 = ndimage.affine_transform(data, [[0.5]], -1,
-                                                order=order)
+            out2 = ndimage.affine_transform(data, [[0.5]], -1, order=order)
             assert_array_almost_equal(out1, out2)
 
     def test_affine_transform26(self):
@@ -2036,8 +1974,8 @@ class TestNdimage:
         assert_raises(ValueError, ndimage.affine_transform, data, tform_h2)
 
     def test_affine_transform_1d_endianness_with_output_parameter(self):
-        # 1d affine transform given output ndarray or dtype with either endianness
-        # see issue #7388
+        # 1d affine transform given output ndarray or dtype with
+        # either endianness. see issue #7388
         data = numpy.ones((2, 2))
         for out in [numpy.empty_like(data),
                     numpy.empty_like(data).astype(data.dtype.newbyteorder()),
@@ -2086,81 +2024,79 @@ class TestNdimage:
 
     def test_shift05(self):
         data = numpy.array([[1, 1, 1, 1],
-                               [1, 1, 1, 1],
-                               [1, 1, 1, 1]])
+                            [1, 1, 1, 1],
+                            [1, 1, 1, 1]])
         for order in range(0, 6):
             out = ndimage.shift(data, [0, 1], order=order)
             assert_array_almost_equal(out, [[0, 1, 1, 1],
-                                       [0, 1, 1, 1],
-                                       [0, 1, 1, 1]])
+                                            [0, 1, 1, 1],
+                                            [0, 1, 1, 1]])
 
     def test_shift06(self):
         data = numpy.array([[4, 1, 3, 2],
-                               [7, 6, 8, 5],
-                               [3, 5, 3, 6]])
+                            [7, 6, 8, 5],
+                            [3, 5, 3, 6]])
         for order in range(0, 6):
             out = ndimage.shift(data, [0, 1], order=order)
             assert_array_almost_equal(out, [[0, 4, 1, 3],
-                                       [0, 7, 6, 8],
-                                       [0, 3, 5, 3]])
+                                            [0, 7, 6, 8],
+                                            [0, 3, 5, 3]])
 
     def test_shift07(self):
         data = numpy.array([[4, 1, 3, 2],
-                               [7, 6, 8, 5],
-                               [3, 5, 3, 6]])
+                            [7, 6, 8, 5],
+                            [3, 5, 3, 6]])
         for order in range(0, 6):
             out = ndimage.shift(data, [1, 0], order=order)
             assert_array_almost_equal(out, [[0, 0, 0, 0],
-                                       [4, 1, 3, 2],
-                                       [7, 6, 8, 5]])
+                                            [4, 1, 3, 2],
+                                            [7, 6, 8, 5]])
 
     def test_shift08(self):
         data = numpy.array([[4, 1, 3, 2],
-                               [7, 6, 8, 5],
-                               [3, 5, 3, 6]])
+                            [7, 6, 8, 5],
+                            [3, 5, 3, 6]])
         for order in range(0, 6):
             out = ndimage.shift(data, [1, 1], order=order)
             assert_array_almost_equal(out, [[0, 0, 0, 0],
-                                       [0, 4, 1, 3],
-                                       [0, 7, 6, 8]])
+                                            [0, 4, 1, 3],
+                                            [0, 7, 6, 8]])
 
     def test_shift09(self):
         data = numpy.array([[4, 1, 3, 2],
-                               [7, 6, 8, 5],
-                               [3, 5, 3, 6]])
+                            [7, 6, 8, 5],
+                            [3, 5, 3, 6]])
         for order in range(0, 6):
             if (order > 1):
-                filtered = ndimage.spline_filter(data,
-                                                           order=order)
+                filtered = ndimage.spline_filter(data, order=order)
             else:
                 filtered = data
-            out = ndimage.shift(filtered, [1, 1], order=order,
-                                          prefilter=False)
+            out = ndimage.shift(filtered, [1, 1], order=order, prefilter=False)
             assert_array_almost_equal(out, [[0, 0, 0, 0],
-                                       [0, 4, 1, 3],
-                                       [0, 7, 6, 8]])
+                                            [0, 4, 1, 3],
+                                            [0, 7, 6, 8]])
 
     def test_zoom1(self):
-        for order in range(0,6):
-            for z in [2,[2,2]]:
-                arr = numpy.array(list(range(25))).reshape((5,5)).astype(float)
+        for order in range(0, 6):
+            for z in [2, [2, 2]]:
+                arr = numpy.array(list(range(25))).reshape((5, 5)).astype(float)
                 arr = ndimage.zoom(arr, z, order=order)
-                assert_equal(arr.shape,(10,10))
-                assert_(numpy.all(arr[-1,:] != 0))
-                assert_(numpy.all(arr[-1,:] >= (20 - eps)))
-                assert_(numpy.all(arr[0,:] <= (5 + eps)))
+                assert_equal(arr.shape, (10, 10))
+                assert_(numpy.all(arr[-1, :] != 0))
+                assert_(numpy.all(arr[-1, :] >= (20 - eps)))
+                assert_(numpy.all(arr[0, :] <= (5 + eps)))
                 assert_(numpy.all(arr >= (0 - eps)))
                 assert_(numpy.all(arr <= (24 + eps)))
 
     def test_zoom2(self):
-        arr = numpy.arange(12).reshape((3,4))
-        out = ndimage.zoom(ndimage.zoom(arr,2),0.5)
-        assert_array_equal(out,arr)
+        arr = numpy.arange(12).reshape((3, 4))
+        out = ndimage.zoom(ndimage.zoom(arr, 2), 0.5)
+        assert_array_equal(out, arr)
 
     def test_zoom3(self):
         arr = numpy.array([[1, 2]])
         out1 = ndimage.zoom(arr, (2, 1))
-        out2 = ndimage.zoom(arr, (1,2))
+        out2 = ndimage.zoom(arr, (1, 2))
 
         assert_array_almost_equal(out1, numpy.array([[1, 2], [1, 2]]))
         assert_array_almost_equal(out2, numpy.array([[1, 1, 2, 2]]))
@@ -2202,16 +2138,16 @@ class TestNdimage:
 
     def test_rotate01(self):
         data = numpy.array([[0, 0, 0, 0],
-                               [0, 1, 1, 0],
-                               [0, 0, 0, 0]], dtype=numpy.float64)
+                            [0, 1, 1, 0],
+                            [0, 0, 0, 0]], dtype=numpy.float64)
         for order in range(0, 6):
             out = ndimage.rotate(data, 0)
             assert_array_almost_equal(out, data)
 
     def test_rotate02(self):
         data = numpy.array([[0, 0, 0, 0],
-                               [0, 1, 0, 0],
-                               [0, 0, 0, 0]], dtype=numpy.float64)
+                            [0, 1, 0, 0],
+                            [0, 0, 0, 0]], dtype=numpy.float64)
         expected = numpy.array([[0, 0, 0],
                                [0, 0, 0],
                                [0, 1, 0],
@@ -2222,8 +2158,8 @@ class TestNdimage:
 
     def test_rotate03(self):
         data = numpy.array([[0, 0, 0, 0, 0],
-                               [0, 1, 1, 0, 0],
-                               [0, 0, 0, 0, 0]], dtype=numpy.float64)
+                            [0, 1, 1, 0, 0],
+                            [0, 0, 0, 0, 0]], dtype=numpy.float64)
         expected = numpy.array([[0, 0, 0],
                                [0, 0, 0],
                                [0, 1, 0],
@@ -2235,61 +2171,60 @@ class TestNdimage:
 
     def test_rotate04(self):
         data = numpy.array([[0, 0, 0, 0, 0],
-                               [0, 1, 1, 0, 0],
-                               [0, 0, 0, 0, 0]], dtype=numpy.float64)
+                            [0, 1, 1, 0, 0],
+                            [0, 0, 0, 0, 0]], dtype=numpy.float64)
         expected = numpy.array([[0, 0, 0, 0, 0],
-                               [0, 0, 1, 0, 0],
-                               [0, 0, 1, 0, 0]], dtype=numpy.float64)
+                                [0, 0, 1, 0, 0],
+                                [0, 0, 1, 0, 0]], dtype=numpy.float64)
         for order in range(0, 6):
             out = ndimage.rotate(data, 90, reshape=False)
             assert_array_almost_equal(out, expected)
 
     def test_rotate05(self):
-        data = numpy.empty((4,3,3))
+        data = numpy.empty((4, 3, 3))
         for i in range(3):
-            data[:,:,i] = numpy.array([[0,0,0],
-                                       [0,1,0],
-                                       [0,1,0],
-                                       [0,0,0]], dtype=numpy.float64)
+            data[:, :, i] = numpy.array([[0, 0, 0],
+                                         [0, 1, 0],
+                                         [0, 1, 0],
+                                         [0, 0, 0]], dtype=numpy.float64)
 
-        expected = numpy.array([[0,0,0,0],
-                            [0,1,1,0],
-                            [0,0,0,0]], dtype=numpy.float64)
+        expected = numpy.array([[0, 0, 0, 0],
+                                [0, 1, 1, 0],
+                                [0, 0, 0, 0]], dtype=numpy.float64)
 
         for order in range(0, 6):
             out = ndimage.rotate(data, 90)
             for i in range(3):
-                assert_array_almost_equal(out[:,:,i], expected)
+                assert_array_almost_equal(out[:, :, i], expected)
 
     def test_rotate06(self):
-        data = numpy.empty((3,4,3))
+        data = numpy.empty((3, 4, 3))
         for i in range(3):
-            data[:,:,i] = numpy.array([[0,0,0,0],
-                                       [0,1,1,0],
-                                       [0,0,0,0]], dtype=numpy.float64)
+            data[:, :, i] = numpy.array([[0, 0, 0, 0],
+                                         [0, 1, 1, 0],
+                                         [0, 0, 0, 0]], dtype=numpy.float64)
 
-        expected = numpy.array([[0,0,0],
-                            [0,1,0],
-                            [0,1,0],
-                            [0,0,0]], dtype=numpy.float64)
+        expected = numpy.array([[0, 0, 0],
+                                [0, 1, 0],
+                                [0, 1, 0],
+                                [0, 0, 0]], dtype=numpy.float64)
 
         for order in range(0, 6):
             out = ndimage.rotate(data, 90)
             for i in range(3):
-                assert_array_almost_equal(out[:,:,i], expected)
+                assert_array_almost_equal(out[:, :, i], expected)
 
     def test_rotate07(self):
         data = numpy.array([[[0, 0, 0, 0, 0],
                              [0, 1, 1, 0, 0],
-                             [0, 0, 0, 0, 0]]] * 2,
-                           dtype=numpy.float64)
+                             [0, 0, 0, 0, 0]]] * 2, dtype=numpy.float64)
         data = data.transpose()
         expected = numpy.array([[[0, 0, 0],
-                                [0, 1, 0],
-                                [0, 1, 0],
-                                [0, 0, 0],
-                                [0, 0, 0]]] * 2, dtype=numpy.float64)
-        expected = expected.transpose([2,1,0])
+                                 [0, 1, 0],
+                                 [0, 1, 0],
+                                 [0, 0, 0],
+                                 [0, 0, 0]]] * 2, dtype=numpy.float64)
+        expected = expected.transpose([2, 1, 0])
 
         for order in range(0, 6):
             out = ndimage.rotate(data, 90, axes=(0, 1))
@@ -2297,42 +2232,37 @@ class TestNdimage:
 
     def test_rotate08(self):
         data = numpy.array([[[0, 0, 0, 0, 0],
-                                [0, 1, 1, 0, 0],
-                                [0, 0, 0, 0, 0]]] * 2,
-                              dtype=numpy.float64)
+                             [0, 1, 1, 0, 0],
+                             [0, 0, 0, 0, 0]]] * 2, dtype=numpy.float64)
         data = data.transpose()
         expected = numpy.array([[[0, 0, 1, 0, 0],
-                                [0, 0, 1, 0, 0],
-                                [0, 0, 0, 0, 0]]] * 2,
-                              dtype=numpy.float64)
+                                 [0, 0, 1, 0, 0],
+                                 [0, 0, 0, 0, 0]]] * 2, dtype=numpy.float64)
         expected = expected.transpose()
         for order in range(0, 6):
-            out = ndimage.rotate(data, 90, axes=(0, 1),
-                                           reshape=False)
+            out = ndimage.rotate(data, 90, axes=(0, 1), reshape=False)
             assert_array_almost_equal(out, expected)
 
     def test_watershed_ift01(self):
         data = numpy.array([[0, 0, 0, 0, 0, 0, 0],
-                               [0, 1, 1, 1, 1, 1, 0],
-                               [0, 1, 0, 0, 0, 1, 0],
-                               [0, 1, 0, 0, 0, 1, 0],
-                               [0, 1, 0, 0, 0, 1, 0],
-                               [0, 1, 1, 1, 1, 1, 0],
-                               [0, 0, 0, 0, 0, 0, 0],
-                               [0, 0, 0, 0, 0, 0, 0]], numpy.uint8)
+                            [0, 1, 1, 1, 1, 1, 0],
+                            [0, 1, 0, 0, 0, 1, 0],
+                            [0, 1, 0, 0, 0, 1, 0],
+                            [0, 1, 0, 0, 0, 1, 0],
+                            [0, 1, 1, 1, 1, 1, 0],
+                            [0, 0, 0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 0]], numpy.uint8)
         markers = numpy.array([[-1, 0, 0, 0, 0, 0, 0],
-                                  [0, 0, 0, 0, 0, 0, 0],
-                                  [0, 0, 0, 0, 0, 0, 0],
-                                  [0, 0, 0, 1, 0, 0, 0],
-                                  [0, 0, 0, 0, 0, 0, 0],
-                                  [0, 0, 0, 0, 0, 0, 0],
-                                  [0, 0, 0, 0, 0, 0, 0],
-                                  [0, 0, 0, 0, 0, 0, 0]],
-                                 numpy.int8)
-        out = ndimage.watershed_ift(data, markers,
-                                     structure=[[1,1,1],
-                                                [1,1,1],
-                                                [1,1,1]])
+                               [0, 0, 0, 0, 0, 0, 0],
+                               [0, 0, 0, 0, 0, 0, 0],
+                               [0, 0, 0, 1, 0, 0, 0],
+                               [0, 0, 0, 0, 0, 0, 0],
+                               [0, 0, 0, 0, 0, 0, 0],
+                               [0, 0, 0, 0, 0, 0, 0],
+                               [0, 0, 0, 0, 0, 0, 0]], numpy.int8)
+        out = ndimage.watershed_ift(data, markers, structure=[[1, 1, 1],
+                                                              [1, 1, 1],
+                                                              [1, 1, 1]])
         expected = [[-1, -1, -1, -1, -1, -1, -1],
                     [-1, 1, 1, 1, 1, 1, -1],
                     [-1, 1, 1, 1, 1, 1, -1],
@@ -2345,22 +2275,21 @@ class TestNdimage:
 
     def test_watershed_ift02(self):
         data = numpy.array([[0, 0, 0, 0, 0, 0, 0],
-                               [0, 1, 1, 1, 1, 1, 0],
-                               [0, 1, 0, 0, 0, 1, 0],
-                               [0, 1, 0, 0, 0, 1, 0],
-                               [0, 1, 0, 0, 0, 1, 0],
-                               [0, 1, 1, 1, 1, 1, 0],
-                               [0, 0, 0, 0, 0, 0, 0],
-                               [0, 0, 0, 0, 0, 0, 0]], numpy.uint8)
+                            [0, 1, 1, 1, 1, 1, 0],
+                            [0, 1, 0, 0, 0, 1, 0],
+                            [0, 1, 0, 0, 0, 1, 0],
+                            [0, 1, 0, 0, 0, 1, 0],
+                            [0, 1, 1, 1, 1, 1, 0],
+                            [0, 0, 0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 0]], numpy.uint8)
         markers = numpy.array([[-1, 0, 0, 0, 0, 0, 0],
-                                  [0, 0, 0, 0, 0, 0, 0],
-                                  [0, 0, 0, 0, 0, 0, 0],
-                                  [0, 0, 0, 1, 0, 0, 0],
-                                  [0, 0, 0, 0, 0, 0, 0],
-                                  [0, 0, 0, 0, 0, 0, 0],
-                                  [0, 0, 0, 0, 0, 0, 0],
-                                  [0, 0, 0, 0, 0, 0, 0]],
-                                 numpy.int8)
+                               [0, 0, 0, 0, 0, 0, 0],
+                               [0, 0, 0, 0, 0, 0, 0],
+                               [0, 0, 0, 1, 0, 0, 0],
+                               [0, 0, 0, 0, 0, 0, 0],
+                               [0, 0, 0, 0, 0, 0, 0],
+                               [0, 0, 0, 0, 0, 0, 0],
+                               [0, 0, 0, 0, 0, 0, 0]], numpy.int8)
         out = ndimage.watershed_ift(data, markers)
         expected = [[-1, -1, -1, -1, -1, -1, -1],
                     [-1, -1, 1, 1, 1, -1, -1],
@@ -2374,20 +2303,19 @@ class TestNdimage:
 
     def test_watershed_ift03(self):
         data = numpy.array([[0, 0, 0, 0, 0, 0, 0],
-                               [0, 1, 1, 1, 1, 1, 0],
-                               [0, 1, 0, 1, 0, 1, 0],
-                               [0, 1, 0, 1, 0, 1, 0],
-                               [0, 1, 0, 1, 0, 1, 0],
-                               [0, 1, 1, 1, 1, 1, 0],
-                               [0, 0, 0, 0, 0, 0, 0]], numpy.uint8)
+                            [0, 1, 1, 1, 1, 1, 0],
+                            [0, 1, 0, 1, 0, 1, 0],
+                            [0, 1, 0, 1, 0, 1, 0],
+                            [0, 1, 0, 1, 0, 1, 0],
+                            [0, 1, 1, 1, 1, 1, 0],
+                            [0, 0, 0, 0, 0, 0, 0]], numpy.uint8)
         markers = numpy.array([[0, 0, 0, 0, 0, 0, 0],
-                                  [0, 0, 0, 0, 0, 0, 0],
-                                  [0, 0, 0, 0, 0, 0, 0],
-                                  [0, 0, 2, 0, 3, 0, 0],
-                                  [0, 0, 0, 0, 0, 0, 0],
-                                  [0, 0, 0, 0, 0, 0, 0],
-                                  [0, 0, 0, 0, 0, 0, -1]],
-                                 numpy.int8)
+                               [0, 0, 0, 0, 0, 0, 0],
+                               [0, 0, 0, 0, 0, 0, 0],
+                               [0, 0, 2, 0, 3, 0, 0],
+                               [0, 0, 0, 0, 0, 0, 0],
+                               [0, 0, 0, 0, 0, 0, 0],
+                               [0, 0, 0, 0, 0, 0, -1]], numpy.int8)
         out = ndimage.watershed_ift(data, markers)
         expected = [[-1, -1, -1, -1, -1, -1, -1],
                     [-1, -1, 2, -1, 3, -1, -1],
@@ -2400,12 +2328,12 @@ class TestNdimage:
 
     def test_watershed_ift04(self):
         data = numpy.array([[0, 0, 0, 0, 0, 0, 0],
-                               [0, 1, 1, 1, 1, 1, 0],
-                               [0, 1, 0, 1, 0, 1, 0],
-                               [0, 1, 0, 1, 0, 1, 0],
-                               [0, 1, 0, 1, 0, 1, 0],
-                               [0, 1, 1, 1, 1, 1, 0],
-                               [0, 0, 0, 0, 0, 0, 0]], numpy.uint8)
+                            [0, 1, 1, 1, 1, 1, 0],
+                            [0, 1, 0, 1, 0, 1, 0],
+                            [0, 1, 0, 1, 0, 1, 0],
+                            [0, 1, 0, 1, 0, 1, 0],
+                            [0, 1, 1, 1, 1, 1, 0],
+                            [0, 0, 0, 0, 0, 0, 0]], numpy.uint8)
         markers = numpy.array([[0, 0, 0, 0, 0, 0, 0],
                                [0, 0, 0, 0, 0, 0, 0],
                                [0, 0, 0, 0, 0, 0, 0],
@@ -2415,9 +2343,9 @@ class TestNdimage:
                                [0, 0, 0, 0, 0, 0, -1]],
                               numpy.int8)
         out = ndimage.watershed_ift(data, markers,
-                                    structure=[[1,1,1],
-                                               [1,1,1],
-                                               [1,1,1]])
+                                    structure=[[1, 1, 1],
+                                               [1, 1, 1],
+                                               [1, 1, 1]])
         expected = [[-1, -1, -1, -1, -1, -1, -1],
                     [-1, 2, 2, 3, 3, 3, -1],
                     [-1, 2, 2, 3, 3, 3, -1],
@@ -2444,9 +2372,9 @@ class TestNdimage:
                                [0, 0, 0, 0, 0, 0, -1]],
                               numpy.int8)
         out = ndimage.watershed_ift(data, markers,
-                                    structure=[[1,1,1],
-                                               [1,1,1],
-                                               [1,1,1]])
+                                    structure=[[1, 1, 1],
+                                               [1, 1, 1],
+                                               [1, 1, 1]])
         expected = [[-1, -1, -1, -1, -1, -1, -1],
                     [-1, 3, 3, 2, 2, 2, -1],
                     [-1, 3, 3, 2, 2, 2, -1],
@@ -2458,22 +2386,21 @@ class TestNdimage:
 
     def test_watershed_ift06(self):
         data = numpy.array([[0, 1, 0, 0, 0, 1, 0],
-                               [0, 1, 0, 0, 0, 1, 0],
-                               [0, 1, 0, 0, 0, 1, 0],
-                               [0, 1, 1, 1, 1, 1, 0],
-                               [0, 0, 0, 0, 0, 0, 0],
-                               [0, 0, 0, 0, 0, 0, 0]], numpy.uint8)
+                            [0, 1, 0, 0, 0, 1, 0],
+                            [0, 1, 0, 0, 0, 1, 0],
+                            [0, 1, 1, 1, 1, 1, 0],
+                            [0, 0, 0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 0]], numpy.uint8)
         markers = numpy.array([[-1, 0, 0, 0, 0, 0, 0],
-                                  [0, 0, 0, 1, 0, 0, 0],
-                                  [0, 0, 0, 0, 0, 0, 0],
-                                  [0, 0, 0, 0, 0, 0, 0],
-                                  [0, 0, 0, 0, 0, 0, 0],
-                                  [0, 0, 0, 0, 0, 0, 0]],
-                                 numpy.int8)
+                               [0, 0, 0, 1, 0, 0, 0],
+                               [0, 0, 0, 0, 0, 0, 0],
+                               [0, 0, 0, 0, 0, 0, 0],
+                               [0, 0, 0, 0, 0, 0, 0],
+                               [0, 0, 0, 0, 0, 0, 0]], numpy.int8)
         out = ndimage.watershed_ift(data, markers,
-                                              structure=[[1,1,1],
-                                                         [1,1,1],
-                                                         [1,1,1]])
+                                    structure=[[1, 1, 1],
+                                               [1, 1, 1],
+                                               [1, 1, 1]])
         expected = [[-1, 1, 1, 1, 1, 1, -1],
                     [-1, 1, 1, 1, 1, 1, -1],
                     [-1, 1, 1, 1, 1, 1, -1],
@@ -2487,25 +2414,24 @@ class TestNdimage:
         data = numpy.zeros(shape, dtype=numpy.uint8)
         data = data.transpose()
         data[...] = numpy.array([[0, 1, 0, 0, 0, 1, 0],
-                                    [0, 1, 0, 0, 0, 1, 0],
-                                    [0, 1, 0, 0, 0, 1, 0],
-                                    [0, 1, 1, 1, 1, 1, 0],
-                                    [0, 0, 0, 0, 0, 0, 0],
-                                    [0, 0, 0, 0, 0, 0, 0]], numpy.uint8)
+                                 [0, 1, 0, 0, 0, 1, 0],
+                                 [0, 1, 0, 0, 0, 1, 0],
+                                 [0, 1, 1, 1, 1, 1, 0],
+                                 [0, 0, 0, 0, 0, 0, 0],
+                                 [0, 0, 0, 0, 0, 0, 0]], numpy.uint8)
         markers = numpy.array([[-1, 0, 0, 0, 0, 0, 0],
-                                  [0, 0, 0, 1, 0, 0, 0],
-                                  [0, 0, 0, 0, 0, 0, 0],
-                                  [0, 0, 0, 0, 0, 0, 0],
-                                  [0, 0, 0, 0, 0, 0, 0],
-                                  [0, 0, 0, 0, 0, 0, 0]],
-                                 numpy.int8)
+                               [0, 0, 0, 1, 0, 0, 0],
+                               [0, 0, 0, 0, 0, 0, 0],
+                               [0, 0, 0, 0, 0, 0, 0],
+                               [0, 0, 0, 0, 0, 0, 0],
+                               [0, 0, 0, 0, 0, 0, 0]], numpy.int8)
         out = numpy.zeros(shape, dtype=numpy.int16)
         out = out.transpose()
         ndimage.watershed_ift(data, markers,
-                               structure=[[1,1,1],
-                                          [1,1,1],
-                                          [1,1,1]],
-                               output=out)
+                              structure=[[1, 1, 1],
+                                         [1, 1, 1],
+                                         [1, 1, 1]],
+                              output=out)
         expected = [[-1, 1, 1, 1, 1, 1, -1],
                     [-1, 1, 1, 1, 1, 1, -1],
                     [-1, 1, 1, 1, 1, 1, -1],
@@ -2516,7 +2442,7 @@ class TestNdimage:
 
     def test_distance_transform_bf01(self):
         # brute force (bf) distance transform
-        for type in self.types:
+        for type_ in self.types:
             data = numpy.array([[0, 0, 0, 0, 0, 0, 0, 0, 0],
                                 [0, 0, 0, 0, 0, 0, 0, 0, 0],
                                 [0, 0, 0, 1, 1, 1, 0, 0, 0],
@@ -2525,7 +2451,7 @@ class TestNdimage:
                                 [0, 0, 1, 1, 1, 1, 1, 0, 0],
                                 [0, 0, 0, 1, 1, 1, 0, 0, 0],
                                 [0, 0, 0, 0, 0, 0, 0, 0, 0],
-                                [0, 0, 0, 0, 0, 0, 0, 0, 0]], type)
+                                [0, 0, 0, 0, 0, 0, 0, 0, 0]], type_)
         out, ft = ndimage.distance_transform_bf(data, 'euclidean',
                                                 return_indices=True)
         expected = [[0, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -2560,16 +2486,16 @@ class TestNdimage:
         assert_array_almost_equal(ft, expected)
 
     def test_distance_transform_bf02(self):
-        for type in self.types:
+        for type_ in self.types:
             data = numpy.array([[0, 0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 1, 1, 1, 0, 0, 0],
-                                   [0, 0, 1, 1, 1, 1, 1, 0, 0],
-                                   [0, 0, 1, 1, 1, 1, 1, 0, 0],
-                                   [0, 0, 1, 1, 1, 1, 1, 0, 0],
-                                   [0, 0, 0, 1, 1, 1, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0, 0]], type)
+                                [0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 1, 1, 1, 0, 0, 0],
+                                [0, 0, 1, 1, 1, 1, 1, 0, 0],
+                                [0, 0, 1, 1, 1, 1, 1, 0, 0],
+                                [0, 0, 1, 1, 1, 1, 1, 0, 0],
+                                [0, 0, 0, 1, 1, 1, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0, 0]], type_)
         out, ft = ndimage.distance_transform_bf(data, 'cityblock',
                                                 return_indices=True)
 
@@ -2605,7 +2531,7 @@ class TestNdimage:
         assert_array_almost_equal(expected, ft)
 
     def test_distance_transform_bf03(self):
-        for type in self.types:
+        for type_ in self.types:
             data = numpy.array([[0, 0, 0, 0, 0, 0, 0, 0, 0],
                                 [0, 0, 0, 0, 0, 0, 0, 0, 0],
                                 [0, 0, 0, 1, 1, 1, 0, 0, 0],
@@ -2614,7 +2540,7 @@ class TestNdimage:
                                 [0, 0, 1, 1, 1, 1, 1, 0, 0],
                                 [0, 0, 0, 1, 1, 1, 0, 0, 0],
                                 [0, 0, 0, 0, 0, 0, 0, 0, 0],
-                                [0, 0, 0, 0, 0, 0, 0, 0, 0]], type)
+                                [0, 0, 0, 0, 0, 0, 0, 0, 0]], type_)
         out, ft = ndimage.distance_transform_bf(data, 'chessboard',
                                                 return_indices=True)
 
@@ -2650,7 +2576,7 @@ class TestNdimage:
         assert_array_almost_equal(ft, expected)
 
     def test_distance_transform_bf04(self):
-        for type in self.types:
+        for type_ in self.types:
             data = numpy.array([[0, 0, 0, 0, 0, 0, 0, 0, 0],
                                 [0, 0, 0, 0, 0, 0, 0, 0, 0],
                                 [0, 0, 0, 1, 1, 1, 0, 0, 0],
@@ -2659,39 +2585,38 @@ class TestNdimage:
                                 [0, 0, 1, 1, 1, 1, 1, 0, 0],
                                 [0, 0, 0, 1, 1, 1, 0, 0, 0],
                                 [0, 0, 0, 0, 0, 0, 0, 0, 0],
-                                [0, 0, 0, 0, 0, 0, 0, 0, 0]], type)
-        tdt, tft = ndimage.distance_transform_bf(data,
-                                                 return_indices=1)
+                                [0, 0, 0, 0, 0, 0, 0, 0, 0]], type_)
+        tdt, tft = ndimage.distance_transform_bf(data, return_indices=1)
         dts = []
         fts = []
         dt = numpy.zeros(data.shape, dtype=numpy.float64)
         ndimage.distance_transform_bf(data, distances=dt)
         dts.append(dt)
-        ft = ndimage.distance_transform_bf(data,
-                            return_distances=False, return_indices=1)
+        ft = ndimage.distance_transform_bf(
+            data, return_distances=False, return_indices=1)
         fts.append(ft)
         ft = numpy.indices(data.shape, dtype=numpy.int32)
-        ndimage.distance_transform_bf(data,
-             return_distances=False, return_indices=True, indices=ft)
+        ndimage.distance_transform_bf(
+            data, return_distances=False, return_indices=True, indices=ft)
         fts.append(ft)
-        dt, ft = ndimage.distance_transform_bf(data,
-                                                       return_indices=1)
+        dt, ft = ndimage.distance_transform_bf(
+            data, return_indices=1)
         dts.append(dt)
         fts.append(ft)
         dt = numpy.zeros(data.shape, dtype=numpy.float64)
-        ft = ndimage.distance_transform_bf(data, distances=dt,
-                                                     return_indices=True)
+        ft = ndimage.distance_transform_bf(
+            data, distances=dt, return_indices=True)
         dts.append(dt)
         fts.append(ft)
         ft = numpy.indices(data.shape, dtype=numpy.int32)
-        dt = ndimage.distance_transform_bf(data,
-                                       return_indices=True, indices=ft)
+        dt = ndimage.distance_transform_bf(
+            data, return_indices=True, indices=ft)
         dts.append(dt)
         fts.append(ft)
         dt = numpy.zeros(data.shape, dtype=numpy.float64)
         ft = numpy.indices(data.shape, dtype=numpy.int32)
-        ndimage.distance_transform_bf(data, distances=dt,
-                                       return_indices=True, indices=ft)
+        ndimage.distance_transform_bf(
+            data, distances=dt, return_indices=True, indices=ft)
         dts.append(dt)
         fts.append(ft)
         for dt in dts:
@@ -2700,18 +2625,18 @@ class TestNdimage:
             assert_array_almost_equal(tft, ft)
 
     def test_distance_transform_bf05(self):
-        for type in self.types:
+        for type_ in self.types:
             data = numpy.array([[0, 0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 1, 1, 1, 0, 0, 0],
-                                   [0, 0, 1, 1, 1, 1, 1, 0, 0],
-                                   [0, 0, 1, 1, 1, 1, 1, 0, 0],
-                                   [0, 0, 1, 1, 1, 1, 1, 0, 0],
-                                   [0, 0, 0, 1, 1, 1, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0, 0]], type)
-        out, ft = ndimage.distance_transform_bf(data,
-                     'euclidean', return_indices=True, sampling=[2, 2])
+                                [0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 1, 1, 1, 0, 0, 0],
+                                [0, 0, 1, 1, 1, 1, 1, 0, 0],
+                                [0, 0, 1, 1, 1, 1, 1, 0, 0],
+                                [0, 0, 1, 1, 1, 1, 1, 0, 0],
+                                [0, 0, 0, 1, 1, 1, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0, 0]], type_)
+        out, ft = ndimage.distance_transform_bf(
+            data, 'euclidean', return_indices=True, sampling=[2, 2])
         expected = [[0, 0, 0, 0, 0, 0, 0, 0, 0],
                     [0, 0, 0, 0, 0, 0, 0, 0, 0],
                     [0, 0, 0, 4, 4, 4, 0, 0, 0],
@@ -2744,18 +2669,18 @@ class TestNdimage:
         assert_array_almost_equal(ft, expected)
 
     def test_distance_transform_bf06(self):
-        for type in self.types:
+        for type_ in self.types:
             data = numpy.array([[0, 0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 1, 1, 1, 0, 0, 0],
-                                   [0, 0, 1, 1, 1, 1, 1, 0, 0],
-                                   [0, 0, 1, 1, 1, 1, 1, 0, 0],
-                                   [0, 0, 1, 1, 1, 1, 1, 0, 0],
-                                   [0, 0, 0, 1, 1, 1, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0, 0]], type)
-        out, ft = ndimage.distance_transform_bf(data,
-                     'euclidean', return_indices=True, sampling=[2, 1])
+                                [0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 1, 1, 1, 0, 0, 0],
+                                [0, 0, 1, 1, 1, 1, 1, 0, 0],
+                                [0, 0, 1, 1, 1, 1, 1, 0, 0],
+                                [0, 0, 1, 1, 1, 1, 1, 0, 0],
+                                [0, 0, 0, 1, 1, 1, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0, 0]], type_)
+        out, ft = ndimage.distance_transform_bf(
+            data, 'euclidean', return_indices=True, sampling=[2, 1])
         expected = [[0, 0, 0, 0, 0, 0, 0, 0, 0],
                     [0, 0, 0, 0, 0, 0, 0, 0, 0],
                     [0, 0, 0, 1, 4, 1, 0, 0, 0],
@@ -2788,19 +2713,19 @@ class TestNdimage:
         assert_array_almost_equal(ft, expected)
 
     def test_distance_transform_cdt01(self):
-        #chamfer type distance (cdt) transform
-        for type in self.types:
+        # chamfer type distance (cdt) transform
+        for type_ in self.types:
             data = numpy.array([[0, 0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 1, 1, 1, 0, 0, 0],
-                                   [0, 0, 1, 1, 1, 1, 1, 0, 0],
-                                   [0, 0, 1, 1, 1, 1, 1, 0, 0],
-                                   [0, 0, 1, 1, 1, 1, 1, 0, 0],
-                                   [0, 0, 0, 1, 1, 1, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0, 0]], type)
-        out, ft = ndimage.distance_transform_cdt(data,
-                                        'cityblock', return_indices=True)
+                                [0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 1, 1, 1, 0, 0, 0],
+                                [0, 0, 1, 1, 1, 1, 1, 0, 0],
+                                [0, 0, 1, 1, 1, 1, 1, 0, 0],
+                                [0, 0, 1, 1, 1, 1, 1, 0, 0],
+                                [0, 0, 0, 1, 1, 1, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0, 0]], type_)
+        out, ft = ndimage.distance_transform_cdt(
+            data, 'cityblock', return_indices=True)
         bf = ndimage.distance_transform_bf(data, 'cityblock')
         assert_array_almost_equal(bf, out)
 
@@ -2821,11 +2746,11 @@ class TestNdimage:
                      [0, 1, 1, 1, 4, 5, 6, 7, 8],
                      [0, 1, 2, 2, 4, 5, 6, 7, 8],
                      [0, 1, 2, 3, 4, 5, 6, 7, 8],
-                     [0, 1, 2, 3, 4, 5, 6, 7, 8],]]
+                     [0, 1, 2, 3, 4, 5, 6, 7, 8]]]
         assert_array_almost_equal(ft, expected)
 
     def test_distance_transform_cdt02(self):
-        for type in self.types:
+        for type_ in self.types:
             data = numpy.array([[0, 0, 0, 0, 0, 0, 0, 0, 0],
                                 [0, 0, 0, 0, 0, 0, 0, 0, 0],
                                 [0, 0, 0, 1, 1, 1, 0, 0, 0],
@@ -2834,7 +2759,7 @@ class TestNdimage:
                                 [0, 0, 1, 1, 1, 1, 1, 0, 0],
                                 [0, 0, 0, 1, 1, 1, 0, 0, 0],
                                 [0, 0, 0, 0, 0, 0, 0, 0, 0],
-                                [0, 0, 0, 0, 0, 0, 0, 0, 0]], type)
+                                [0, 0, 0, 0, 0, 0, 0, 0, 0]], type_)
         out, ft = ndimage.distance_transform_cdt(data, 'chessboard',
                                                  return_indices=True)
         bf = ndimage.distance_transform_bf(data, 'chessboard')
@@ -2857,46 +2782,45 @@ class TestNdimage:
                      [0, 1, 1, 2, 6, 6, 7, 7, 8],
                      [0, 1, 2, 2, 5, 6, 6, 7, 8],
                      [0, 1, 2, 3, 4, 5, 6, 7, 8],
-                     [0, 1, 2, 3, 4, 5, 6, 7, 8],]]
+                     [0, 1, 2, 3, 4, 5, 6, 7, 8]]]
         assert_array_almost_equal(ft, expected)
 
     def test_distance_transform_cdt03(self):
-        for type in self.types:
+        for type_ in self.types:
             data = numpy.array([[0, 0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 1, 1, 1, 0, 0, 0],
-                                   [0, 0, 1, 1, 1, 1, 1, 0, 0],
-                                   [0, 0, 1, 1, 1, 1, 1, 0, 0],
-                                   [0, 0, 1, 1, 1, 1, 1, 0, 0],
-                                   [0, 0, 0, 1, 1, 1, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0, 0]], type)
-        tdt, tft = ndimage.distance_transform_cdt(data,
-                                                     return_indices=True)
+                                [0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 1, 1, 1, 0, 0, 0],
+                                [0, 0, 1, 1, 1, 1, 1, 0, 0],
+                                [0, 0, 1, 1, 1, 1, 1, 0, 0],
+                                [0, 0, 1, 1, 1, 1, 1, 0, 0],
+                                [0, 0, 0, 1, 1, 1, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0, 0]], type_)
+        tdt, tft = ndimage.distance_transform_cdt(data, return_indices=True)
         dts = []
         fts = []
         dt = numpy.zeros(data.shape, dtype=numpy.int32)
         ndimage.distance_transform_cdt(data, distances=dt)
         dts.append(dt)
-        ft = ndimage.distance_transform_cdt(data,
-                           return_distances=False, return_indices=True)
+        ft = ndimage.distance_transform_cdt(
+            data, return_distances=False, return_indices=True)
         fts.append(ft)
         ft = numpy.indices(data.shape, dtype=numpy.int32)
-        ndimage.distance_transform_cdt(data,
-             return_distances=False, return_indices=True, indices=ft)
+        ndimage.distance_transform_cdt(
+            data, return_distances=False, return_indices=True, indices=ft)
         fts.append(ft)
-        dt, ft = ndimage.distance_transform_cdt(data,
-                                                     return_indices=True)
+        dt, ft = ndimage.distance_transform_cdt(
+            data, return_indices=True)
         dts.append(dt)
         fts.append(ft)
         dt = numpy.zeros(data.shape, dtype=numpy.int32)
-        ft = ndimage.distance_transform_cdt(data, distances=dt,
-                                                     return_indices=True)
+        ft = ndimage.distance_transform_cdt(
+            data, distances=dt, return_indices=True)
         dts.append(dt)
         fts.append(ft)
         ft = numpy.indices(data.shape, dtype=numpy.int32)
-        dt = ndimage.distance_transform_cdt(data,
-                                       return_indices=True, indices=ft)
+        dt = ndimage.distance_transform_cdt(
+            data, return_indices=True, indices=ft)
         dts.append(dt)
         fts.append(ft)
         dt = numpy.zeros(data.shape, dtype=numpy.int32)
@@ -2911,19 +2835,18 @@ class TestNdimage:
             assert_array_almost_equal(tft, ft)
 
     def test_distance_transform_edt01(self):
-        #euclidean distance transform (edt)
-        for type in self.types:
+        # euclidean distance transform (edt)
+        for type_ in self.types:
             data = numpy.array([[0, 0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 1, 1, 1, 0, 0, 0],
-                                   [0, 0, 1, 1, 1, 1, 1, 0, 0],
-                                   [0, 0, 1, 1, 1, 1, 1, 0, 0],
-                                   [0, 0, 1, 1, 1, 1, 1, 0, 0],
-                                   [0, 0, 0, 1, 1, 1, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0, 0]], type)
-        out, ft = ndimage.distance_transform_edt(data,
-                                                     return_indices=True)
+                                [0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 1, 1, 1, 0, 0, 0],
+                                [0, 0, 1, 1, 1, 1, 1, 0, 0],
+                                [0, 0, 1, 1, 1, 1, 1, 0, 0],
+                                [0, 0, 1, 1, 1, 1, 1, 0, 0],
+                                [0, 0, 0, 1, 1, 1, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0, 0]], type_)
+        out, ft = ndimage.distance_transform_edt(data, return_indices=True)
         bf = ndimage.distance_transform_bf(data, 'euclidean')
         assert_array_almost_equal(bf, out)
 
@@ -2936,48 +2859,47 @@ class TestNdimage:
         assert_array_almost_equal(bf, dt)
 
     def test_distance_transform_edt02(self):
-        for type in self.types:
+        for type_ in self.types:
             data = numpy.array([[0, 0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 1, 1, 1, 0, 0, 0],
-                                   [0, 0, 1, 1, 1, 1, 1, 0, 0],
-                                   [0, 0, 1, 1, 1, 1, 1, 0, 0],
-                                   [0, 0, 1, 1, 1, 1, 1, 0, 0],
-                                   [0, 0, 0, 1, 1, 1, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0, 0]], type)
-        tdt, tft = ndimage.distance_transform_edt(data,
-                                                     return_indices=True)
+                                [0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 1, 1, 1, 0, 0, 0],
+                                [0, 0, 1, 1, 1, 1, 1, 0, 0],
+                                [0, 0, 1, 1, 1, 1, 1, 0, 0],
+                                [0, 0, 1, 1, 1, 1, 1, 0, 0],
+                                [0, 0, 0, 1, 1, 1, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0, 0]], type_)
+        tdt, tft = ndimage.distance_transform_edt(data, return_indices=True)
         dts = []
         fts = []
         dt = numpy.zeros(data.shape, dtype=numpy.float64)
         ndimage.distance_transform_edt(data, distances=dt)
         dts.append(dt)
-        ft = ndimage.distance_transform_edt(data,
-                               return_distances=0, return_indices=True)
+        ft = ndimage.distance_transform_edt(
+            data, return_distances=0, return_indices=True)
         fts.append(ft)
         ft = numpy.indices(data.shape, dtype=numpy.int32)
-        ndimage.distance_transform_edt(data,
-              return_distances=False,return_indices=True, indices=ft)
+        ndimage.distance_transform_edt(
+            data, return_distances=False,return_indices=True, indices=ft)
         fts.append(ft)
-        dt, ft = ndimage.distance_transform_edt(data,
-                                                     return_indices=True)
+        dt, ft = ndimage.distance_transform_edt(
+            data, return_indices=True)
         dts.append(dt)
         fts.append(ft)
         dt = numpy.zeros(data.shape, dtype=numpy.float64)
-        ft = ndimage.distance_transform_edt(data, distances=dt,
-                                                     return_indices=True)
+        ft = ndimage.distance_transform_edt(
+            data, distances=dt, return_indices=True)
         dts.append(dt)
         fts.append(ft)
         ft = numpy.indices(data.shape, dtype=numpy.int32)
-        dt = ndimage.distance_transform_edt(data,
-                                       return_indices=True, indices=ft)
+        dt = ndimage.distance_transform_edt(
+            data, return_indices=True, indices=ft)
         dts.append(dt)
         fts.append(ft)
         dt = numpy.zeros(data.shape, dtype=numpy.float64)
         ft = numpy.indices(data.shape, dtype=numpy.int32)
-        ndimage.distance_transform_edt(data, distances=dt,
-                                       return_indices=True, indices=ft)
+        ndimage.distance_transform_edt(
+            data, distances=dt, return_indices=True, indices=ft)
         dts.append(dt)
         fts.append(ft)
         for dt in dts:
@@ -2986,41 +2908,37 @@ class TestNdimage:
             assert_array_almost_equal(tft, ft)
 
     def test_distance_transform_edt03(self):
-        for type in self.types:
+        for type_ in self.types:
             data = numpy.array([[0, 0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 1, 1, 1, 0, 0, 0],
-                                   [0, 0, 1, 1, 1, 1, 1, 0, 0],
-                                   [0, 0, 1, 1, 1, 1, 1, 0, 0],
-                                   [0, 0, 1, 1, 1, 1, 1, 0, 0],
-                                   [0, 0, 0, 1, 1, 1, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0, 0]], type)
-        ref = ndimage.distance_transform_bf(data, 'euclidean',
-                                                      sampling=[2, 2])
-        out = ndimage.distance_transform_edt(data,
-                                                       sampling=[2, 2])
+                                [0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 1, 1, 1, 0, 0, 0],
+                                [0, 0, 1, 1, 1, 1, 1, 0, 0],
+                                [0, 0, 1, 1, 1, 1, 1, 0, 0],
+                                [0, 0, 1, 1, 1, 1, 1, 0, 0],
+                                [0, 0, 0, 1, 1, 1, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0, 0]], type_)
+        ref = ndimage.distance_transform_bf(data, 'euclidean', sampling=[2, 2])
+        out = ndimage.distance_transform_edt(data, sampling=[2, 2])
         assert_array_almost_equal(ref, out)
 
     def test_distance_transform_edt4(self):
-        for type in self.types:
+        for type_ in self.types:
             data = numpy.array([[0, 0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 1, 1, 1, 0, 0, 0],
-                                   [0, 0, 1, 1, 1, 1, 1, 0, 0],
-                                   [0, 0, 1, 1, 1, 1, 1, 0, 0],
-                                   [0, 0, 1, 1, 1, 1, 1, 0, 0],
-                                   [0, 0, 0, 1, 1, 1, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0, 0]], type)
-        ref = ndimage.distance_transform_bf(data, 'euclidean',
-                                                      sampling=[2, 1])
-        out = ndimage.distance_transform_edt(data,
-                                                       sampling=[2, 1])
+                                [0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 1, 1, 1, 0, 0, 0],
+                                [0, 0, 1, 1, 1, 1, 1, 0, 0],
+                                [0, 0, 1, 1, 1, 1, 1, 0, 0],
+                                [0, 0, 1, 1, 1, 1, 1, 0, 0],
+                                [0, 0, 0, 1, 1, 1, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0, 0]], type_)
+        ref = ndimage.distance_transform_bf(data, 'euclidean', sampling=[2, 1])
+        out = ndimage.distance_transform_edt(data, sampling=[2, 1])
         assert_array_almost_equal(ref, out)
 
     def test_distance_transform_edt5(self):
-        #Ticket #954 regression test
+        # Ticket #954 regression test
         out = ndimage.distance_transform_edt(False)
         assert_array_almost_equal(out, [0.])
 
@@ -3035,14 +2953,14 @@ class TestNdimage:
     def test_generate_structure03(self):
         struct = ndimage.generate_binary_structure(2, 1)
         assert_array_almost_equal(struct, [[0, 1, 0],
-                                      [1, 1, 1],
-                                      [0, 1, 0]])
+                                           [1, 1, 1],
+                                           [0, 1, 0]])
 
     def test_generate_structure04(self):
         struct = ndimage.generate_binary_structure(2, 2)
         assert_array_almost_equal(struct, [[1, 1, 1],
-                                      [1, 1, 1],
-                                      [1, 1, 1]])
+                                           [1, 1, 1],
+                                           [1, 1, 1]])
 
     def test_iterate_structure01(self):
         struct = [[0, 1, 0],
@@ -3050,10 +2968,10 @@ class TestNdimage:
                   [0, 1, 0]]
         out = ndimage.iterate_structure(struct, 2)
         assert_array_almost_equal(out, [[0, 0, 1, 0, 0],
-                                   [0, 1, 1, 1, 0],
-                                   [1, 1, 1, 1, 1],
-                                   [0, 1, 1, 1, 0],
-                                   [0, 0, 1, 0, 0]])
+                                        [0, 1, 1, 1, 0],
+                                        [1, 1, 1, 1, 1],
+                                        [0, 1, 1, 1, 0],
+                                        [0, 0, 1, 0, 0]])
 
     def test_iterate_structure02(self):
         struct = [[0, 1],
@@ -3061,10 +2979,10 @@ class TestNdimage:
                   [0, 1]]
         out = ndimage.iterate_structure(struct, 2)
         assert_array_almost_equal(out, [[0, 0, 1],
-                                   [0, 1, 1],
-                                   [1, 1, 1],
-                                   [0, 1, 1],
-                                   [0, 0, 1]])
+                                        [0, 1, 1],
+                                        [1, 1, 1],
+                                        [0, 1, 1],
+                                        [0, 0, 1]])
 
     def test_iterate_structure03(self):
         struct = [[0, 1, 0],
@@ -3080,221 +2998,214 @@ class TestNdimage:
         assert_equal(out[1], [2, 2])
 
     def test_binary_erosion01(self):
-        for type in self.types:
-            data = numpy.ones([], type)
+        for type_ in self.types:
+            data = numpy.ones([], type_)
             out = ndimage.binary_erosion(data)
             assert_array_almost_equal(out, 1)
 
     def test_binary_erosion02(self):
-        for type in self.types:
-            data = numpy.ones([], type)
+        for type_ in self.types:
+            data = numpy.ones([], type_)
             out = ndimage.binary_erosion(data, border_value=1)
             assert_array_almost_equal(out, 1)
 
     def test_binary_erosion03(self):
-        for type in self.types:
-            data = numpy.ones([1], type)
+        for type_ in self.types:
+            data = numpy.ones([1], type_)
             out = ndimage.binary_erosion(data)
             assert_array_almost_equal(out, [0])
 
     def test_binary_erosion04(self):
-        for type in self.types:
-            data = numpy.ones([1], type)
+        for type_ in self.types:
+            data = numpy.ones([1], type_)
             out = ndimage.binary_erosion(data, border_value=1)
             assert_array_almost_equal(out, [1])
 
     def test_binary_erosion05(self):
-        for type in self.types:
-            data = numpy.ones([3], type)
+        for type_ in self.types:
+            data = numpy.ones([3], type_)
             out = ndimage.binary_erosion(data)
             assert_array_almost_equal(out, [0, 1, 0])
 
     def test_binary_erosion06(self):
-        for type in self.types:
-            data = numpy.ones([3], type)
+        for type_ in self.types:
+            data = numpy.ones([3], type_)
             out = ndimage.binary_erosion(data, border_value=1)
             assert_array_almost_equal(out, [1, 1, 1])
 
     def test_binary_erosion07(self):
-        for type in self.types:
-            data = numpy.ones([5], type)
+        for type_ in self.types:
+            data = numpy.ones([5], type_)
             out = ndimage.binary_erosion(data)
             assert_array_almost_equal(out, [0, 1, 1, 1, 0])
 
     def test_binary_erosion08(self):
-        for type in self.types:
-            data = numpy.ones([5], type)
+        for type_ in self.types:
+            data = numpy.ones([5], type_)
             out = ndimage.binary_erosion(data, border_value=1)
             assert_array_almost_equal(out, [1, 1, 1, 1, 1])
 
     def test_binary_erosion09(self):
-        for type in self.types:
-            data = numpy.ones([5], type)
+        for type_ in self.types:
+            data = numpy.ones([5], type_)
             data[2] = 0
             out = ndimage.binary_erosion(data)
             assert_array_almost_equal(out, [0, 0, 0, 0, 0])
 
     def test_binary_erosion10(self):
-        for type in self.types:
-            data = numpy.ones([5], type)
+        for type_ in self.types:
+            data = numpy.ones([5], type_)
             data[2] = 0
             out = ndimage.binary_erosion(data, border_value=1)
             assert_array_almost_equal(out, [1, 0, 0, 0, 1])
 
     def test_binary_erosion11(self):
-        for type in self.types:
-            data = numpy.ones([5], type)
+        for type_ in self.types:
+            data = numpy.ones([5], type_)
             data[2] = 0
             struct = [1, 0, 1]
-            out = ndimage.binary_erosion(data, struct,
-                                                   border_value=1)
+            out = ndimage.binary_erosion(data, struct, border_value=1)
             assert_array_almost_equal(out, [1, 0, 1, 0, 1])
 
     def test_binary_erosion12(self):
-        for type in self.types:
-            data = numpy.ones([5], type)
+        for type_ in self.types:
+            data = numpy.ones([5], type_)
             data[2] = 0
             struct = [1, 0, 1]
-            out = ndimage.binary_erosion(data, struct,
-                                                   border_value=1,
-                                                   origin=-1)
+            out = ndimage.binary_erosion(data, struct, border_value=1,
+                                         origin=-1)
             assert_array_almost_equal(out, [0, 1, 0, 1, 1])
 
     def test_binary_erosion13(self):
-        for type in self.types:
-            data = numpy.ones([5], type)
+        for type_ in self.types:
+            data = numpy.ones([5], type_)
             data[2] = 0
             struct = [1, 0, 1]
-            out = ndimage.binary_erosion(data, struct,
-                                                   border_value=1,
-                                                   origin=1)
+            out = ndimage.binary_erosion(data, struct, border_value=1,
+                                         origin=1)
             assert_array_almost_equal(out, [1, 1, 0, 1, 0])
 
     def test_binary_erosion14(self):
-        for type in self.types:
-            data = numpy.ones([5], type)
+        for type_ in self.types:
+            data = numpy.ones([5], type_)
             data[2] = 0
             struct = [1, 1]
-            out = ndimage.binary_erosion(data, struct,
-                                                   border_value=1)
+            out = ndimage.binary_erosion(data, struct, border_value=1)
             assert_array_almost_equal(out, [1, 1, 0, 0, 1])
 
     def test_binary_erosion15(self):
-        for type in self.types:
-            data = numpy.ones([5], type)
+        for type_ in self.types:
+            data = numpy.ones([5], type_)
             data[2] = 0
             struct = [1, 1]
-            out = ndimage.binary_erosion(data, struct,
-                                                   border_value=1,
-                                                   origin=-1)
+            out = ndimage.binary_erosion(data, struct, border_value=1,
+                                         origin=-1)
             assert_array_almost_equal(out, [1, 0, 0, 1, 1])
 
     def test_binary_erosion16(self):
-        for type in self.types:
-            data = numpy.ones([1, 1], type)
+        for type_ in self.types:
+            data = numpy.ones([1, 1], type_)
             out = ndimage.binary_erosion(data, border_value=1)
             assert_array_almost_equal(out, [[1]])
 
     def test_binary_erosion17(self):
-        for type in self.types:
-            data = numpy.ones([1, 1], type)
+        for type_ in self.types:
+            data = numpy.ones([1, 1], type_)
             out = ndimage.binary_erosion(data)
             assert_array_almost_equal(out, [[0]])
 
     def test_binary_erosion18(self):
-        for type in self.types:
-            data = numpy.ones([1, 3], type)
+        for type_ in self.types:
+            data = numpy.ones([1, 3], type_)
             out = ndimage.binary_erosion(data)
             assert_array_almost_equal(out, [[0, 0, 0]])
 
     def test_binary_erosion19(self):
-        for type in self.types:
-            data = numpy.ones([1, 3], type)
+        for type_ in self.types:
+            data = numpy.ones([1, 3], type_)
             out = ndimage.binary_erosion(data, border_value=1)
             assert_array_almost_equal(out, [[1, 1, 1]])
 
     def test_binary_erosion20(self):
-        for type in self.types:
-            data = numpy.ones([3, 3], type)
+        for type_ in self.types:
+            data = numpy.ones([3, 3], type_)
             out = ndimage.binary_erosion(data)
             assert_array_almost_equal(out, [[0, 0, 0],
-                                       [0, 1, 0],
-                                       [0, 0, 0]])
+                                            [0, 1, 0],
+                                            [0, 0, 0]])
 
     def test_binary_erosion21(self):
-        for type in self.types:
-            data = numpy.ones([3, 3], type)
+        for type_ in self.types:
+            data = numpy.ones([3, 3], type_)
             out = ndimage.binary_erosion(data, border_value=1)
             assert_array_almost_equal(out, [[1, 1, 1],
-                                       [1, 1, 1],
-                                       [1, 1, 1]])
+                                            [1, 1, 1],
+                                            [1, 1, 1]])
 
     def test_binary_erosion22(self):
         expected = [[0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 1, 0, 0],
-                [0, 0, 0, 1, 1, 0, 0, 0],
-                [0, 0, 1, 0, 0, 1, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0]]
-        for type in self.types:
+                    [0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 1, 0, 0],
+                    [0, 0, 0, 1, 1, 0, 0, 0],
+                    [0, 0, 1, 0, 0, 1, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0]]
+        for type_ in self.types:
             data = numpy.array([[0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 1, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 1, 1, 1],
-                                   [0, 0, 1, 1, 1, 1, 1, 1],
-                                   [0, 0, 1, 1, 1, 1, 0, 0],
-                                   [0, 1, 1, 1, 1, 1, 1, 0],
-                                   [0, 1, 1, 0, 0, 1, 1, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0]], type)
+                                [0, 1, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 1, 1, 1],
+                                [0, 0, 1, 1, 1, 1, 1, 1],
+                                [0, 0, 1, 1, 1, 1, 0, 0],
+                                [0, 1, 1, 1, 1, 1, 1, 0],
+                                [0, 1, 1, 0, 0, 1, 1, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0]], type_)
             out = ndimage.binary_erosion(data, border_value=1)
             assert_array_almost_equal(out, expected)
 
     def test_binary_erosion23(self):
         struct = ndimage.generate_binary_structure(2, 2)
         expected = [[0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 1, 1, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0]]
-        for type in self.types:
+                    [0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 1, 1, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0]]
+        for type_ in self.types:
             data = numpy.array([[0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 1, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 1, 1, 1],
-                                   [0, 0, 1, 1, 1, 1, 1, 1],
-                                   [0, 0, 1, 1, 1, 1, 0, 0],
-                                   [0, 1, 1, 1, 1, 1, 1, 0],
-                                   [0, 1, 1, 0, 0, 1, 1, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0]], type)
-            out = ndimage.binary_erosion(data, struct,
-                                                   border_value=1)
+                                [0, 1, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 1, 1, 1],
+                                [0, 0, 1, 1, 1, 1, 1, 1],
+                                [0, 0, 1, 1, 1, 1, 0, 0],
+                                [0, 1, 1, 1, 1, 1, 1, 0],
+                                [0, 1, 1, 0, 0, 1, 1, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0]], type_)
+            out = ndimage.binary_erosion(data, struct, border_value=1)
             assert_array_almost_equal(out, expected)
 
     def test_binary_erosion24(self):
         struct = [[0, 1],
                   [1, 1]]
         expected = [[0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 1, 1, 1],
-                [0, 0, 0, 1, 1, 1, 0, 0],
-                [0, 0, 1, 1, 1, 1, 0, 0],
-                [0, 0, 1, 0, 0, 0, 1, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0]]
-        for type in self.types:
+                    [0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 1, 1, 1],
+                    [0, 0, 0, 1, 1, 1, 0, 0],
+                    [0, 0, 1, 1, 1, 1, 0, 0],
+                    [0, 0, 1, 0, 0, 0, 1, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0]]
+        for type_ in self.types:
             data = numpy.array([[0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 1, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 1, 1, 1],
-                                   [0, 0, 1, 1, 1, 1, 1, 1],
-                                   [0, 0, 1, 1, 1, 1, 0, 0],
-                                   [0, 1, 1, 1, 1, 1, 1, 0],
-                                   [0, 1, 1, 0, 0, 1, 1, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0]], type)
-            out = ndimage.binary_erosion(data, struct,
-                                                   border_value=1)
+                                [0, 1, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 1, 1, 1],
+                                [0, 0, 1, 1, 1, 1, 1, 1],
+                                [0, 0, 1, 1, 1, 1, 0, 0],
+                                [0, 1, 1, 1, 1, 1, 1, 0],
+                                [0, 1, 1, 0, 0, 1, 1, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0]], type_)
+            out = ndimage.binary_erosion(data, struct, border_value=1)
             assert_array_almost_equal(out, expected)
 
     def test_binary_erosion25(self):
@@ -3302,24 +3213,23 @@ class TestNdimage:
                   [1, 0, 1],
                   [0, 1, 0]]
         expected = [[0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 1, 0, 0],
-                [0, 0, 0, 1, 0, 0, 0, 0],
-                [0, 0, 1, 0, 0, 1, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0]]
-        for type in self.types:
+                    [0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 1, 0, 0],
+                    [0, 0, 0, 1, 0, 0, 0, 0],
+                    [0, 0, 1, 0, 0, 1, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0]]
+        for type_ in self.types:
             data = numpy.array([[0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 1, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 1, 1, 1],
-                                   [0, 0, 1, 1, 1, 0, 1, 1],
-                                   [0, 0, 1, 0, 1, 1, 0, 0],
-                                   [0, 1, 0, 1, 1, 1, 1, 0],
-                                   [0, 1, 1, 0, 0, 1, 1, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0]], type)
-            out = ndimage.binary_erosion(data, struct,
-                                                   border_value=1)
+                                [0, 1, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 1, 1, 1],
+                                [0, 0, 1, 1, 1, 0, 1, 1],
+                                [0, 0, 1, 0, 1, 1, 0, 0],
+                                [0, 1, 0, 1, 1, 1, 1, 0],
+                                [0, 1, 1, 0, 0, 1, 1, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0]], type_)
+            out = ndimage.binary_erosion(data, struct, border_value=1)
             assert_array_almost_equal(out, expected)
 
     def test_binary_erosion26(self):
@@ -3327,24 +3237,24 @@ class TestNdimage:
                   [1, 0, 1],
                   [0, 1, 0]]
         expected = [[0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 1],
-                [0, 0, 0, 0, 1, 0, 0, 1],
-                [0, 0, 1, 0, 0, 0, 0, 0],
-                [0, 1, 0, 0, 1, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 1]]
-        for type in self.types:
+                    [0, 0, 0, 0, 0, 0, 0, 1],
+                    [0, 0, 0, 0, 1, 0, 0, 1],
+                    [0, 0, 1, 0, 0, 0, 0, 0],
+                    [0, 1, 0, 0, 1, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 1]]
+        for type_ in self.types:
             data = numpy.array([[0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 1, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 1, 1, 1],
-                                   [0, 0, 1, 1, 1, 0, 1, 1],
-                                   [0, 0, 1, 0, 1, 1, 0, 0],
-                                   [0, 1, 0, 1, 1, 1, 1, 0],
-                                   [0, 1, 1, 0, 0, 1, 1, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0]], type)
-            out = ndimage.binary_erosion(data, struct,
-                                      border_value=1, origin=(-1, -1))
+                                [0, 1, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 1, 1, 1],
+                                [0, 0, 1, 1, 1, 0, 1, 1],
+                                [0, 0, 1, 0, 1, 1, 0, 0],
+                                [0, 1, 0, 1, 1, 1, 1, 0],
+                                [0, 1, 1, 0, 0, 1, 1, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0]], type_)
+            out = ndimage.binary_erosion(data, struct, border_value=1,
+                                         origin=(-1, -1))
             assert_array_almost_equal(out, expected)
 
     def test_binary_erosion27(self):
@@ -3352,21 +3262,21 @@ class TestNdimage:
                   [1, 1, 1],
                   [0, 1, 0]]
         expected = [[0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 1, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0]]
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 1, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0]]
         data = numpy.array([[0, 0, 0, 0, 0, 0, 0],
-                               [0, 0, 0, 1, 0, 0, 0],
-                               [0, 0, 1, 1, 1, 0, 0],
-                               [0, 1, 1, 1, 1, 1, 0],
-                               [0, 0, 1, 1, 1, 0, 0],
-                               [0, 0, 0, 1, 0, 0, 0],
-                               [0, 0, 0, 0, 0, 0, 0]], bool)
-        out = ndimage.binary_erosion(data, struct,
-                                         border_value=1, iterations=2)
+                            [0, 0, 0, 1, 0, 0, 0],
+                            [0, 0, 1, 1, 1, 0, 0],
+                            [0, 1, 1, 1, 1, 1, 0],
+                            [0, 0, 1, 1, 1, 0, 0],
+                            [0, 0, 0, 1, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 0]], bool)
+        out = ndimage.binary_erosion(data, struct, border_value=1,
+                                     iterations=2)
         assert_array_almost_equal(out, expected)
 
     def test_binary_erosion28(self):
@@ -3374,22 +3284,22 @@ class TestNdimage:
                   [1, 1, 1],
                   [0, 1, 0]]
         expected = [[0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 1, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0]]
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 1, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0]]
         data = numpy.array([[0, 0, 0, 0, 0, 0, 0],
-                               [0, 0, 0, 1, 0, 0, 0],
-                               [0, 0, 1, 1, 1, 0, 0],
-                               [0, 1, 1, 1, 1, 1, 0],
-                               [0, 0, 1, 1, 1, 0, 0],
-                               [0, 0, 0, 1, 0, 0, 0],
-                               [0, 0, 0, 0, 0, 0, 0]], bool)
+                            [0, 0, 0, 1, 0, 0, 0],
+                            [0, 0, 1, 1, 1, 0, 0],
+                            [0, 1, 1, 1, 1, 1, 0],
+                            [0, 0, 1, 1, 1, 0, 0],
+                            [0, 0, 0, 1, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 0]], bool)
         out = numpy.zeros(data.shape, bool)
         ndimage.binary_erosion(data, struct, border_value=1,
-                                         iterations=2, output=out)
+                               iterations=2, output=out)
         assert_array_almost_equal(out, expected)
 
     def test_binary_erosion29(self):
@@ -3397,21 +3307,21 @@ class TestNdimage:
                   [1, 1, 1],
                   [0, 1, 0]]
         expected = [[0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 1, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0]]
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 1, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0]]
         data = numpy.array([[0, 0, 0, 1, 0, 0, 0],
-                               [0, 0, 1, 1, 1, 0, 0],
-                               [0, 1, 1, 1, 1, 1, 0],
-                               [1, 1, 1, 1, 1, 1, 1],
-                               [0, 1, 1, 1, 1, 1, 0],
-                               [0, 0, 1, 1, 1, 0, 0],
-                               [0, 0, 0, 1, 0, 0, 0]], bool)
+                            [0, 0, 1, 1, 1, 0, 0],
+                            [0, 1, 1, 1, 1, 1, 0],
+                            [1, 1, 1, 1, 1, 1, 1],
+                            [0, 1, 1, 1, 1, 1, 0],
+                            [0, 0, 1, 1, 1, 0, 0],
+                            [0, 0, 0, 1, 0, 0, 0]], bool)
         out = ndimage.binary_erosion(data, struct,
-                                         border_value=1, iterations=3)
+                                     border_value=1, iterations=3)
         assert_array_almost_equal(out, expected)
 
     def test_binary_erosion30(self):
@@ -3419,22 +3329,22 @@ class TestNdimage:
                   [1, 1, 1],
                   [0, 1, 0]]
         expected = [[0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 1, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0]]
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 1, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0]]
         data = numpy.array([[0, 0, 0, 1, 0, 0, 0],
-                               [0, 0, 1, 1, 1, 0, 0],
-                               [0, 1, 1, 1, 1, 1, 0],
-                               [1, 1, 1, 1, 1, 1, 1],
-                               [0, 1, 1, 1, 1, 1, 0],
-                               [0, 0, 1, 1, 1, 0, 0],
-                               [0, 0, 0, 1, 0, 0, 0]], bool)
+                            [0, 0, 1, 1, 1, 0, 0],
+                            [0, 1, 1, 1, 1, 1, 0],
+                            [1, 1, 1, 1, 1, 1, 1],
+                            [0, 1, 1, 1, 1, 1, 0],
+                            [0, 0, 1, 1, 1, 0, 0],
+                            [0, 0, 0, 1, 0, 0, 0]], bool)
         out = numpy.zeros(data.shape, bool)
         ndimage.binary_erosion(data, struct, border_value=1,
-                                         iterations=3, output=out)
+                               iterations=3, output=out)
         assert_array_almost_equal(out, expected)
 
     def test_binary_erosion31(self):
@@ -3442,22 +3352,22 @@ class TestNdimage:
                   [1, 1, 1],
                   [0, 1, 0]]
         expected = [[0, 0, 1, 0, 0, 0, 0],
-                [0, 1, 1, 1, 0, 0, 0],
-                [1, 1, 1, 1, 1, 0, 1],
-                [0, 1, 1, 1, 0, 0, 0],
-                [0, 0, 1, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 1, 0, 0, 0, 1]]
+                    [0, 1, 1, 1, 0, 0, 0],
+                    [1, 1, 1, 1, 1, 0, 1],
+                    [0, 1, 1, 1, 0, 0, 0],
+                    [0, 0, 1, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 1, 0, 0, 0, 1]]
         data = numpy.array([[0, 0, 0, 1, 0, 0, 0],
-                               [0, 0, 1, 1, 1, 0, 0],
-                               [0, 1, 1, 1, 1, 1, 0],
-                               [1, 1, 1, 1, 1, 1, 1],
-                               [0, 1, 1, 1, 1, 1, 0],
-                               [0, 0, 1, 1, 1, 0, 0],
-                               [0, 0, 0, 1, 0, 0, 0]], bool)
+                            [0, 0, 1, 1, 1, 0, 0],
+                            [0, 1, 1, 1, 1, 1, 0],
+                            [1, 1, 1, 1, 1, 1, 1],
+                            [0, 1, 1, 1, 1, 1, 0],
+                            [0, 0, 1, 1, 1, 0, 0],
+                            [0, 0, 0, 1, 0, 0, 0]], bool)
         out = numpy.zeros(data.shape, bool)
         ndimage.binary_erosion(data, struct, border_value=1,
-                          iterations=1, output=out, origin=(-1, -1))
+                               iterations=1, output=out, origin=(-1, -1))
         assert_array_almost_equal(out, expected)
 
     def test_binary_erosion32(self):
@@ -3465,21 +3375,21 @@ class TestNdimage:
                   [1, 1, 1],
                   [0, 1, 0]]
         expected = [[0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 1, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0]]
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 1, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0]]
         data = numpy.array([[0, 0, 0, 0, 0, 0, 0],
-                               [0, 0, 0, 1, 0, 0, 0],
-                               [0, 0, 1, 1, 1, 0, 0],
-                               [0, 1, 1, 1, 1, 1, 0],
-                               [0, 0, 1, 1, 1, 0, 0],
-                               [0, 0, 0, 1, 0, 0, 0],
-                               [0, 0, 0, 0, 0, 0, 0]], bool)
+                            [0, 0, 0, 1, 0, 0, 0],
+                            [0, 0, 1, 1, 1, 0, 0],
+                            [0, 1, 1, 1, 1, 1, 0],
+                            [0, 0, 1, 1, 1, 0, 0],
+                            [0, 0, 0, 1, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 0]], bool)
         out = ndimage.binary_erosion(data, struct,
-                                         border_value=1, iterations=2)
+                                     border_value=1, iterations=2)
         assert_array_almost_equal(out, expected)
 
     def test_binary_erosion33(self):
@@ -3487,12 +3397,12 @@ class TestNdimage:
                   [1, 1, 1],
                   [0, 1, 0]]
         expected = [[0, 0, 0, 0, 0, 1, 1],
-                [0, 0, 0, 0, 0, 0, 1],
-                [0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0]]
+                    [0, 0, 0, 0, 0, 0, 1],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0]]
         mask = [[1, 1, 1, 1, 1, 0, 0],
                 [1, 1, 1, 1, 1, 1, 0],
                 [1, 1, 1, 1, 1, 1, 1],
@@ -3501,14 +3411,14 @@ class TestNdimage:
                 [1, 1, 1, 1, 1, 1, 1],
                 [1, 1, 1, 1, 1, 1, 1]]
         data = numpy.array([[0, 0, 0, 0, 0, 1, 1],
-                               [0, 0, 0, 1, 0, 0, 1],
-                               [0, 0, 1, 1, 1, 0, 0],
-                               [0, 0, 1, 1, 1, 0, 0],
-                               [0, 0, 1, 1, 1, 0, 0],
-                               [0, 0, 0, 1, 0, 0, 0],
-                               [0, 0, 0, 0, 0, 0, 0]], bool)
+                            [0, 0, 0, 1, 0, 0, 1],
+                            [0, 0, 1, 1, 1, 0, 0],
+                            [0, 0, 1, 1, 1, 0, 0],
+                            [0, 0, 1, 1, 1, 0, 0],
+                            [0, 0, 0, 1, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 0]], bool)
         out = ndimage.binary_erosion(data, struct,
-                            border_value=1, mask=mask, iterations=-1)
+                                     border_value=1, mask=mask, iterations=-1)
         assert_array_almost_equal(out, expected)
 
     def test_binary_erosion34(self):
@@ -3516,12 +3426,12 @@ class TestNdimage:
                   [1, 1, 1],
                   [0, 1, 0]]
         expected = [[0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 1, 0, 0, 0],
-                [0, 0, 0, 1, 0, 0, 0],
-                [0, 1, 1, 1, 1, 1, 0],
-                [0, 0, 0, 1, 0, 0, 0],
-                [0, 0, 0, 1, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0]]
+                    [0, 0, 0, 1, 0, 0, 0],
+                    [0, 0, 0, 1, 0, 0, 0],
+                    [0, 1, 1, 1, 1, 1, 0],
+                    [0, 0, 0, 1, 0, 0, 0],
+                    [0, 0, 0, 1, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0]]
         mask = [[0, 0, 0, 0, 0, 0, 0],
                 [0, 0, 0, 0, 0, 0, 0],
                 [0, 0, 1, 1, 1, 0, 0],
@@ -3530,14 +3440,14 @@ class TestNdimage:
                 [0, 0, 0, 0, 0, 0, 0],
                 [0, 0, 0, 0, 0, 0, 0]]
         data = numpy.array([[0, 0, 0, 0, 0, 0, 0],
-                               [0, 0, 0, 1, 0, 0, 0],
-                               [0, 0, 1, 1, 1, 0, 0],
-                               [0, 1, 1, 1, 1, 1, 0],
-                               [0, 0, 1, 1, 1, 0, 0],
-                               [0, 0, 0, 1, 0, 0, 0],
-                               [0, 0, 0, 0, 0, 0, 0]], bool)
+                            [0, 0, 0, 1, 0, 0, 0],
+                            [0, 0, 1, 1, 1, 0, 0],
+                            [0, 1, 1, 1, 1, 1, 0],
+                            [0, 0, 1, 1, 1, 0, 0],
+                            [0, 0, 0, 1, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 0]], bool)
         out = ndimage.binary_erosion(data, struct,
-                                            border_value=1, mask=mask)
+                                     border_value=1, mask=mask)
         assert_array_almost_equal(out, expected)
 
     def test_binary_erosion35(self):
@@ -3552,12 +3462,12 @@ class TestNdimage:
                 [0, 0, 0, 0, 0, 0, 0],
                 [0, 0, 0, 0, 0, 0, 0]]
         data = numpy.array([[0, 0, 0, 1, 0, 0, 0],
-                               [0, 0, 1, 1, 1, 0, 0],
-                               [0, 1, 1, 1, 1, 1, 0],
-                               [1, 1, 1, 1, 1, 1, 1],
-                               [0, 1, 1, 1, 1, 1, 0],
-                               [0, 0, 1, 1, 1, 0, 0],
-                               [0, 0, 0, 1, 0, 0, 0]], bool)
+                            [0, 0, 1, 1, 1, 0, 0],
+                            [0, 1, 1, 1, 1, 1, 0],
+                            [1, 1, 1, 1, 1, 1, 1],
+                            [0, 1, 1, 1, 1, 1, 0],
+                            [0, 0, 1, 1, 1, 0, 0],
+                            [0, 0, 0, 1, 0, 0, 0]], bool)
         tmp = [[0, 0, 1, 0, 0, 0, 0],
                [0, 1, 1, 1, 0, 0, 0],
                [1, 1, 1, 1, 1, 0, 1],
@@ -3570,8 +3480,8 @@ class TestNdimage:
         expected = numpy.logical_or(expected, tmp)
         out = numpy.zeros(data.shape, bool)
         ndimage.binary_erosion(data, struct, border_value=1,
-                                         iterations=1, output=out,
-                                         origin=(-1, -1), mask=mask)
+                               iterations=1, output=out,
+                               origin=(-1, -1), mask=mask)
         assert_array_almost_equal(out, expected)
 
     def test_binary_erosion36(self):
@@ -3595,281 +3505,278 @@ class TestNdimage:
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0, 0, 1]]
         data = numpy.array([[0, 0, 0, 0, 0, 0, 0, 0],
-                               [0, 1, 0, 0, 0, 0, 0, 0],
-                               [0, 0, 0, 0, 0, 1, 1, 1],
-                               [0, 0, 1, 1, 1, 0, 1, 1],
-                               [0, 0, 1, 0, 1, 1, 0, 0],
-                               [0, 1, 0, 1, 1, 1, 1, 0],
-                               [0, 1, 1, 0, 0, 1, 1, 0],
-                               [0, 0, 0, 0, 0, 0, 0, 0]])
+                            [0, 1, 0, 0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 1, 1, 1],
+                            [0, 0, 1, 1, 1, 0, 1, 1],
+                            [0, 0, 1, 0, 1, 1, 0, 0],
+                            [0, 1, 0, 1, 1, 1, 1, 0],
+                            [0, 1, 1, 0, 0, 1, 1, 0],
+                            [0, 0, 0, 0, 0, 0, 0, 0]])
         expected = numpy.logical_and(tmp, mask)
         tmp = numpy.logical_and(data, numpy.logical_not(mask))
         expected = numpy.logical_or(expected, tmp)
         out = ndimage.binary_erosion(data, struct, mask=mask,
-                                       border_value=1, origin=(-1, -1))
+                                     border_value=1, origin=(-1, -1))
         assert_array_almost_equal(out, expected)
 
     def test_binary_dilation01(self):
-        for type in self.types:
-            data = numpy.ones([], type)
+        for type_ in self.types:
+            data = numpy.ones([], type_)
             out = ndimage.binary_dilation(data)
             assert_array_almost_equal(out, 1)
 
     def test_binary_dilation02(self):
-        for type in self.types:
-            data = numpy.zeros([], type)
+        for type_ in self.types:
+            data = numpy.zeros([], type_)
             out = ndimage.binary_dilation(data)
             assert_array_almost_equal(out, 0)
 
     def test_binary_dilation03(self):
-        for type in self.types:
-            data = numpy.ones([1], type)
+        for type_ in self.types:
+            data = numpy.ones([1], type_)
             out = ndimage.binary_dilation(data)
             assert_array_almost_equal(out, [1])
 
     def test_binary_dilation04(self):
-        for type in self.types:
-            data = numpy.zeros([1], type)
+        for type_ in self.types:
+            data = numpy.zeros([1], type_)
             out = ndimage.binary_dilation(data)
             assert_array_almost_equal(out, [0])
 
     def test_binary_dilation05(self):
-        for type in self.types:
-            data = numpy.ones([3], type)
+        for type_ in self.types:
+            data = numpy.ones([3], type_)
             out = ndimage.binary_dilation(data)
             assert_array_almost_equal(out, [1, 1, 1])
 
     def test_binary_dilation06(self):
-        for type in self.types:
-            data = numpy.zeros([3], type)
+        for type_ in self.types:
+            data = numpy.zeros([3], type_)
             out = ndimage.binary_dilation(data)
             assert_array_almost_equal(out, [0, 0, 0])
 
     def test_binary_dilation07(self):
-        for type in self.types:
-            data = numpy.zeros([3], type)
+        for type_ in self.types:
+            data = numpy.zeros([3], type_)
             data[1] = 1
             out = ndimage.binary_dilation(data)
             assert_array_almost_equal(out, [1, 1, 1])
 
     def test_binary_dilation08(self):
-        for type in self.types:
-            data = numpy.zeros([5], type)
+        for type_ in self.types:
+            data = numpy.zeros([5], type_)
             data[1] = 1
             data[3] = 1
             out = ndimage.binary_dilation(data)
             assert_array_almost_equal(out, [1, 1, 1, 1, 1])
 
     def test_binary_dilation09(self):
-        for type in self.types:
-            data = numpy.zeros([5], type)
+        for type_ in self.types:
+            data = numpy.zeros([5], type_)
             data[1] = 1
             out = ndimage.binary_dilation(data)
             assert_array_almost_equal(out, [1, 1, 1, 0, 0])
 
     def test_binary_dilation10(self):
-        for type in self.types:
-            data = numpy.zeros([5], type)
+        for type_ in self.types:
+            data = numpy.zeros([5], type_)
             data[1] = 1
             out = ndimage.binary_dilation(data, origin=-1)
             assert_array_almost_equal(out, [0, 1, 1, 1, 0])
 
     def test_binary_dilation11(self):
-        for type in self.types:
-            data = numpy.zeros([5], type)
+        for type_ in self.types:
+            data = numpy.zeros([5], type_)
             data[1] = 1
             out = ndimage.binary_dilation(data, origin=1)
             assert_array_almost_equal(out, [1, 1, 0, 0, 0])
 
     def test_binary_dilation12(self):
-        for type in self.types:
-            data = numpy.zeros([5], type)
+        for type_ in self.types:
+            data = numpy.zeros([5], type_)
             data[1] = 1
             struct = [1, 0, 1]
             out = ndimage.binary_dilation(data, struct)
             assert_array_almost_equal(out, [1, 0, 1, 0, 0])
 
     def test_binary_dilation13(self):
-        for type in self.types:
-            data = numpy.zeros([5], type)
+        for type_ in self.types:
+            data = numpy.zeros([5], type_)
             data[1] = 1
             struct = [1, 0, 1]
-            out = ndimage.binary_dilation(data, struct,
-                                                    border_value=1)
+            out = ndimage.binary_dilation(data, struct, border_value=1)
             assert_array_almost_equal(out, [1, 0, 1, 0, 1])
 
     def test_binary_dilation14(self):
-        for type in self.types:
-            data = numpy.zeros([5], type)
+        for type_ in self.types:
+            data = numpy.zeros([5], type_)
             data[1] = 1
             struct = [1, 0, 1]
-            out = ndimage.binary_dilation(data, struct,
-                                                    origin=-1)
+            out = ndimage.binary_dilation(data, struct, origin=-1)
             assert_array_almost_equal(out, [0, 1, 0, 1, 0])
 
     def test_binary_dilation15(self):
-        for type in self.types:
-            data = numpy.zeros([5], type)
+        for type_ in self.types:
+            data = numpy.zeros([5], type_)
             data[1] = 1
             struct = [1, 0, 1]
             out = ndimage.binary_dilation(data, struct,
-                                            origin=-1, border_value=1)
+                                          origin=-1, border_value=1)
             assert_array_almost_equal(out, [1, 1, 0, 1, 0])
 
     def test_binary_dilation16(self):
-        for type in self.types:
-            data = numpy.ones([1, 1], type)
+        for type_ in self.types:
+            data = numpy.ones([1, 1], type_)
             out = ndimage.binary_dilation(data)
             assert_array_almost_equal(out, [[1]])
 
     def test_binary_dilation17(self):
-        for type in self.types:
-            data = numpy.zeros([1, 1], type)
+        for type_ in self.types:
+            data = numpy.zeros([1, 1], type_)
             out = ndimage.binary_dilation(data)
             assert_array_almost_equal(out, [[0]])
 
     def test_binary_dilation18(self):
-        for type in self.types:
-            data = numpy.ones([1, 3], type)
+        for type_ in self.types:
+            data = numpy.ones([1, 3], type_)
             out = ndimage.binary_dilation(data)
             assert_array_almost_equal(out, [[1, 1, 1]])
 
     def test_binary_dilation19(self):
-        for type in self.types:
-            data = numpy.ones([3, 3], type)
+        for type_ in self.types:
+            data = numpy.ones([3, 3], type_)
             out = ndimage.binary_dilation(data)
             assert_array_almost_equal(out, [[1, 1, 1],
-                               [1, 1, 1],
-                               [1, 1, 1]])
+                                            [1, 1, 1],
+                                            [1, 1, 1]])
 
     def test_binary_dilation20(self):
-        for type in self.types:
-            data = numpy.zeros([3, 3], type)
+        for type_ in self.types:
+            data = numpy.zeros([3, 3], type_)
             data[1, 1] = 1
             out = ndimage.binary_dilation(data)
             assert_array_almost_equal(out, [[0, 1, 0],
-                                       [1, 1, 1],
-                                       [0, 1, 0]])
+                                            [1, 1, 1],
+                                            [0, 1, 0]])
 
     def test_binary_dilation21(self):
         struct = ndimage.generate_binary_structure(2, 2)
-        for type in self.types:
-            data = numpy.zeros([3, 3], type)
+        for type_ in self.types:
+            data = numpy.zeros([3, 3], type_)
             data[1, 1] = 1
             out = ndimage.binary_dilation(data, struct)
             assert_array_almost_equal(out, [[1, 1, 1],
-                                       [1, 1, 1],
-                                       [1, 1, 1]])
+                                            [1, 1, 1],
+                                            [1, 1, 1]])
 
     def test_binary_dilation22(self):
         expected = [[0, 1, 0, 0, 0, 0, 0, 0],
-                [1, 1, 1, 0, 0, 0, 0, 0],
-                [0, 1, 0, 0, 0, 1, 0, 0],
-                [0, 0, 0, 1, 1, 1, 1, 0],
-                [0, 0, 1, 1, 1, 1, 0, 0],
-                [0, 1, 1, 1, 1, 1, 1, 0],
-                [0, 0, 1, 0, 0, 1, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0]]
+                    [1, 1, 1, 0, 0, 0, 0, 0],
+                    [0, 1, 0, 0, 0, 1, 0, 0],
+                    [0, 0, 0, 1, 1, 1, 1, 0],
+                    [0, 0, 1, 1, 1, 1, 0, 0],
+                    [0, 1, 1, 1, 1, 1, 1, 0],
+                    [0, 0, 1, 0, 0, 1, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0]]
 
-        for type in self.types:
+        for type_ in self.types:
             data = numpy.array([[0, 0, 0, 0, 0, 0, 0, 0],
-                                           [0, 1, 0, 0, 0, 0, 0, 0],
-                                           [0, 0, 0, 0, 0, 0, 0, 0],
-                                           [0, 0, 0, 0, 0, 1, 0, 0],
-                                           [0, 0, 0, 1, 1, 0, 0, 0],
-                                           [0, 0, 1, 0, 0, 1, 0, 0],
-                                           [0, 0, 0, 0, 0, 0, 0, 0],
-                                           [0, 0, 0, 0, 0, 0, 0, 0]], type)
+                                [0, 1, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 1, 0, 0],
+                                [0, 0, 0, 1, 1, 0, 0, 0],
+                                [0, 0, 1, 0, 0, 1, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0]], type_)
             out = ndimage.binary_dilation(data)
             assert_array_almost_equal(out, expected)
 
     def test_binary_dilation23(self):
         expected = [[1, 1, 1, 1, 1, 1, 1, 1],
-                [1, 1, 1, 0, 0, 0, 0, 1],
-                [1, 1, 0, 0, 0, 1, 0, 1],
-                [1, 0, 0, 1, 1, 1, 1, 1],
-                [1, 0, 1, 1, 1, 1, 0, 1],
-                [1, 1, 1, 1, 1, 1, 1, 1],
-                [1, 0, 1, 0, 0, 1, 0, 1],
-                [1, 1, 1, 1, 1, 1, 1, 1]]
+                    [1, 1, 1, 0, 0, 0, 0, 1],
+                    [1, 1, 0, 0, 0, 1, 0, 1],
+                    [1, 0, 0, 1, 1, 1, 1, 1],
+                    [1, 0, 1, 1, 1, 1, 0, 1],
+                    [1, 1, 1, 1, 1, 1, 1, 1],
+                    [1, 0, 1, 0, 0, 1, 0, 1],
+                    [1, 1, 1, 1, 1, 1, 1, 1]]
 
-        for type in self.types:
+        for type_ in self.types:
             data = numpy.array([[0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 1, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 1, 0, 0],
-                                   [0, 0, 0, 1, 1, 0, 0, 0],
-                                   [0, 0, 1, 0, 0, 1, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0]], type)
+                                [0, 1, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 1, 0, 0],
+                                [0, 0, 0, 1, 1, 0, 0, 0],
+                                [0, 0, 1, 0, 0, 1, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0]], type_)
             out = ndimage.binary_dilation(data, border_value=1)
             assert_array_almost_equal(out, expected)
 
     def test_binary_dilation24(self):
         expected = [[1, 1, 0, 0, 0, 0, 0, 0],
-                [1, 0, 0, 0, 1, 0, 0, 0],
-                [0, 0, 1, 1, 1, 1, 0, 0],
-                [0, 1, 1, 1, 1, 0, 0, 0],
-                [1, 1, 1, 1, 1, 1, 0, 0],
-                [0, 1, 0, 0, 1, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0]]
+                    [1, 0, 0, 0, 1, 0, 0, 0],
+                    [0, 0, 1, 1, 1, 1, 0, 0],
+                    [0, 1, 1, 1, 1, 0, 0, 0],
+                    [1, 1, 1, 1, 1, 1, 0, 0],
+                    [0, 1, 0, 0, 1, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0]]
 
-        for type in self.types:
+        for type_ in self.types:
             data = numpy.array([[0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 1, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 1, 0, 0],
-                                   [0, 0, 0, 1, 1, 0, 0, 0],
-                                   [0, 0, 1, 0, 0, 1, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0]], type)
+                                [0, 1, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 1, 0, 0],
+                                [0, 0, 0, 1, 1, 0, 0, 0],
+                                [0, 0, 1, 0, 0, 1, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0]], type_)
             out = ndimage.binary_dilation(data, origin=(1, 1))
             assert_array_almost_equal(out, expected)
 
     def test_binary_dilation25(self):
         expected = [[1, 1, 0, 0, 0, 0, 1, 1],
-                [1, 0, 0, 0, 1, 0, 1, 1],
-                [0, 0, 1, 1, 1, 1, 1, 1],
-                [0, 1, 1, 1, 1, 0, 1, 1],
-                [1, 1, 1, 1, 1, 1, 1, 1],
-                [0, 1, 0, 0, 1, 0, 1, 1],
-                [1, 1, 1, 1, 1, 1, 1, 1],
-                [1, 1, 1, 1, 1, 1, 1, 1]]
+                    [1, 0, 0, 0, 1, 0, 1, 1],
+                    [0, 0, 1, 1, 1, 1, 1, 1],
+                    [0, 1, 1, 1, 1, 0, 1, 1],
+                    [1, 1, 1, 1, 1, 1, 1, 1],
+                    [0, 1, 0, 0, 1, 0, 1, 1],
+                    [1, 1, 1, 1, 1, 1, 1, 1],
+                    [1, 1, 1, 1, 1, 1, 1, 1]]
 
-        for type in self.types:
+        for type_ in self.types:
             data = numpy.array([[0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 1, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 1, 0, 0],
-                                   [0, 0, 0, 1, 1, 0, 0, 0],
-                                   [0, 0, 1, 0, 0, 1, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0]], type)
-            out = ndimage.binary_dilation(data, origin=(1, 1),
-                                                         border_value=1)
+                                [0, 1, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 1, 0, 0],
+                                [0, 0, 0, 1, 1, 0, 0, 0],
+                                [0, 0, 1, 0, 0, 1, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0]], type_)
+            out = ndimage.binary_dilation(data, origin=(1, 1), border_value=1)
             assert_array_almost_equal(out, expected)
 
     def test_binary_dilation26(self):
         struct = ndimage.generate_binary_structure(2, 2)
         expected = [[1, 1, 1, 0, 0, 0, 0, 0],
-                [1, 1, 1, 0, 0, 0, 0, 0],
-                [1, 1, 1, 0, 1, 1, 1, 0],
-                [0, 0, 1, 1, 1, 1, 1, 0],
-                [0, 1, 1, 1, 1, 1, 1, 0],
-                [0, 1, 1, 1, 1, 1, 1, 0],
-                [0, 1, 1, 1, 1, 1, 1, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0]]
+                    [1, 1, 1, 0, 0, 0, 0, 0],
+                    [1, 1, 1, 0, 1, 1, 1, 0],
+                    [0, 0, 1, 1, 1, 1, 1, 0],
+                    [0, 1, 1, 1, 1, 1, 1, 0],
+                    [0, 1, 1, 1, 1, 1, 1, 0],
+                    [0, 1, 1, 1, 1, 1, 1, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0]]
 
-        for type in self.types:
+        for type_ in self.types:
             data = numpy.array([[0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 1, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 1, 0, 0],
-                                   [0, 0, 0, 1, 1, 0, 0, 0],
-                                   [0, 0, 1, 0, 0, 1, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0]], type)
+                                [0, 1, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 1, 0, 0],
+                                [0, 0, 0, 1, 1, 0, 0, 0],
+                                [0, 0, 1, 0, 0, 1, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0]], type_)
             out = ndimage.binary_dilation(data, struct)
             assert_array_almost_equal(out, expected)
 
@@ -3877,37 +3784,37 @@ class TestNdimage:
         struct = [[0, 1],
                   [1, 1]]
         expected = [[0, 1, 0, 0, 0, 0, 0, 0],
-                [1, 1, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 1, 0, 0],
-                [0, 0, 0, 1, 1, 1, 0, 0],
-                [0, 0, 1, 1, 1, 1, 0, 0],
-                [0, 1, 1, 0, 1, 1, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0]]
+                    [1, 1, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 1, 0, 0],
+                    [0, 0, 0, 1, 1, 1, 0, 0],
+                    [0, 0, 1, 1, 1, 1, 0, 0],
+                    [0, 1, 1, 0, 1, 1, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0]]
 
-        for type in self.types:
+        for type_ in self.types:
             data = numpy.array([[0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 1, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 1, 0, 0],
-                                   [0, 0, 0, 1, 1, 0, 0, 0],
-                                   [0, 0, 1, 0, 0, 1, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0]], type)
+                                [0, 1, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 1, 0, 0],
+                                [0, 0, 0, 1, 1, 0, 0, 0],
+                                [0, 0, 1, 0, 0, 1, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0]], type_)
             out = ndimage.binary_dilation(data, struct)
             assert_array_almost_equal(out, expected)
 
     def test_binary_dilation28(self):
         expected = [[1, 1, 1, 1],
-                [1, 0, 0, 1],
-                [1, 0, 0, 1],
-                [1, 1, 1, 1]]
+                    [1, 0, 0, 1],
+                    [1, 0, 0, 1],
+                    [1, 1, 1, 1]]
 
-        for type in self.types:
+        for type_ in self.types:
             data = numpy.array([[0, 0, 0, 0],
-                                   [0, 0, 0, 0],
-                                   [0, 0, 0, 0],
-                                   [0, 0, 0, 0]], type)
+                                [0, 0, 0, 0],
+                                [0, 0, 0, 0],
+                                [0, 0, 0, 0]], type_)
             out = ndimage.binary_dilation(data, border_value=1)
             assert_array_almost_equal(out, expected)
 
@@ -3915,74 +3822,70 @@ class TestNdimage:
         struct = [[0, 1],
                   [1, 1]]
         expected = [[0, 0, 0, 0, 0],
-                [0, 0, 0, 1, 0],
-                [0, 0, 1, 1, 0],
-                [0, 1, 1, 1, 0],
-                [0, 0, 0, 0, 0]]
+                    [0, 0, 0, 1, 0],
+                    [0, 0, 1, 1, 0],
+                    [0, 1, 1, 1, 0],
+                    [0, 0, 0, 0, 0]]
 
         data = numpy.array([[0, 0, 0, 0, 0],
-                               [0, 0, 0, 0, 0],
-                               [0, 0, 0, 0, 0],
-                               [0, 0, 0, 1, 0],
-                               [0, 0, 0, 0, 0]], bool)
-        out = ndimage.binary_dilation(data, struct,
-                                                iterations=2)
+                            [0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0],
+                            [0, 0, 0, 1, 0],
+                            [0, 0, 0, 0, 0]], bool)
+        out = ndimage.binary_dilation(data, struct, iterations=2)
         assert_array_almost_equal(out, expected)
 
     def test_binary_dilation30(self):
         struct = [[0, 1],
                   [1, 1]]
         expected = [[0, 0, 0, 0, 0],
-                [0, 0, 0, 1, 0],
-                [0, 0, 1, 1, 0],
-                [0, 1, 1, 1, 0],
-                [0, 0, 0, 0, 0]]
+                    [0, 0, 0, 1, 0],
+                    [0, 0, 1, 1, 0],
+                    [0, 1, 1, 1, 0],
+                    [0, 0, 0, 0, 0]]
 
         data = numpy.array([[0, 0, 0, 0, 0],
-                               [0, 0, 0, 0, 0],
-                               [0, 0, 0, 0, 0],
-                               [0, 0, 0, 1, 0],
-                               [0, 0, 0, 0, 0]], bool)
+                            [0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0],
+                            [0, 0, 0, 1, 0],
+                            [0, 0, 0, 0, 0]], bool)
         out = numpy.zeros(data.shape, bool)
-        ndimage.binary_dilation(data, struct, iterations=2,
-                                          output=out)
+        ndimage.binary_dilation(data, struct, iterations=2, output=out)
         assert_array_almost_equal(out, expected)
 
     def test_binary_dilation31(self):
         struct = [[0, 1],
                   [1, 1]]
         expected = [[0, 0, 0, 1, 0],
-                [0, 0, 1, 1, 0],
-                [0, 1, 1, 1, 0],
-                [1, 1, 1, 1, 0],
-                [0, 0, 0, 0, 0]]
+                    [0, 0, 1, 1, 0],
+                    [0, 1, 1, 1, 0],
+                    [1, 1, 1, 1, 0],
+                    [0, 0, 0, 0, 0]]
 
         data = numpy.array([[0, 0, 0, 0, 0],
-                               [0, 0, 0, 0, 0],
-                               [0, 0, 0, 0, 0],
-                               [0, 0, 0, 1, 0],
-                               [0, 0, 0, 0, 0]], bool)
-        out = ndimage.binary_dilation(data, struct,
-                                                iterations=3)
+                            [0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0],
+                            [0, 0, 0, 1, 0],
+                            [0, 0, 0, 0, 0]], bool)
+        out = ndimage.binary_dilation(data, struct, iterations=3)
         assert_array_almost_equal(out, expected)
 
     def test_binary_dilation32(self):
         struct = [[0, 1],
                   [1, 1]]
         expected = [[0, 0, 0, 1, 0],
-                [0, 0, 1, 1, 0],
-                [0, 1, 1, 1, 0],
-                [1, 1, 1, 1, 0],
-                [0, 0, 0, 0, 0]]
+                    [0, 0, 1, 1, 0],
+                    [0, 1, 1, 1, 0],
+                    [1, 1, 1, 1, 0],
+                    [0, 0, 0, 0, 0]]
 
         data = numpy.array([[0, 0, 0, 0, 0],
-                               [0, 0, 0, 0, 0],
-                               [0, 0, 0, 0, 0],
-                               [0, 0, 0, 1, 0],
-                               [0, 0, 0, 0, 0]], bool)
+                            [0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0],
+                            [0, 0, 0, 1, 0],
+                            [0, 0, 0, 0, 0]], bool)
         out = numpy.zeros(data.shape, bool)
-        ndimage.binary_dilation(data, struct, iterations=3,
-                                          output=out)
+        ndimage.binary_dilation(data, struct, iterations=3, output=out)
         assert_array_almost_equal(out, expected)
 
     def test_binary_dilation33(self):
@@ -3990,32 +3893,32 @@ class TestNdimage:
                   [1, 1, 1],
                   [0, 1, 0]]
         expected = numpy.array([[0, 1, 0, 0, 0, 0, 0, 0],
-                               [0, 0, 0, 0, 0, 0, 0, 0],
-                               [0, 0, 0, 0, 0, 0, 0, 0],
-                               [0, 0, 0, 0, 1, 1, 0, 0],
-                               [0, 0, 1, 1, 1, 0, 0, 0],
-                               [0, 1, 1, 0, 1, 1, 0, 0],
-                               [0, 0, 0, 0, 0, 0, 0, 0],
-                               [0, 0, 0, 0, 0, 0, 0, 0]], bool)
+                                [0, 0, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 0, 1, 1, 0, 0],
+                                [0, 0, 1, 1, 1, 0, 0, 0],
+                                [0, 1, 1, 0, 1, 1, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0]], bool)
         mask = numpy.array([[0, 1, 0, 0, 0, 0, 0, 0],
-                               [0, 0, 0, 0, 0, 0, 0, 0],
-                               [0, 0, 0, 0, 0, 0, 1, 0],
-                               [0, 0, 0, 0, 1, 1, 0, 0],
-                               [0, 0, 1, 1, 1, 0, 0, 0],
-                               [0, 1, 1, 0, 1, 1, 0, 0],
-                               [0, 0, 0, 0, 0, 0, 0, 0],
-                               [0, 0, 0, 0, 0, 0, 0, 0]], bool)
+                            [0, 0, 0, 0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 1, 0],
+                            [0, 0, 0, 0, 1, 1, 0, 0],
+                            [0, 0, 1, 1, 1, 0, 0, 0],
+                            [0, 1, 1, 0, 1, 1, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 0, 0]], bool)
         data = numpy.array([[0, 1, 0, 0, 0, 0, 0, 0],
-                               [0, 0, 0, 0, 0, 0, 0, 0],
-                               [0, 0, 0, 0, 0, 0, 0, 0],
-                               [0, 0, 0, 0, 0, 0, 0, 0],
-                               [0, 0, 0, 0, 0, 0, 0, 0],
-                               [0, 1, 0, 0, 0, 0, 0, 0],
-                               [0, 0, 0, 0, 0, 0, 0, 0],
-                               [0, 0, 0, 0, 0, 0, 0, 0]], bool)
+                            [0, 0, 0, 0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 0, 0],
+                            [0, 1, 0, 0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 0, 0]], bool)
 
-        out = ndimage.binary_dilation(data, struct,
-                           iterations=-1, mask=mask, border_value=0)
+        out = ndimage.binary_dilation(data, struct, iterations=-1,
+                                      mask=mask, border_value=0)
         assert_array_almost_equal(out, expected)
 
     def test_binary_dilation34(self):
@@ -4023,24 +3926,24 @@ class TestNdimage:
                   [1, 1, 1],
                   [0, 1, 0]]
         expected = [[0, 1, 0, 0, 0, 0, 0, 0],
-                [0, 1, 1, 0, 0, 0, 0, 0],
-                [0, 0, 1, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0]]
+                    [0, 1, 1, 0, 0, 0, 0, 0],
+                    [0, 0, 1, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0]]
         mask = numpy.array([[0, 1, 0, 0, 0, 0, 0, 0],
-                               [0, 1, 1, 0, 0, 0, 0, 0],
-                               [0, 0, 1, 0, 0, 0, 0, 0],
-                               [0, 0, 0, 0, 0, 1, 0, 0],
-                               [0, 0, 0, 1, 1, 0, 0, 0],
-                               [0, 0, 1, 0, 0, 1, 0, 0],
-                               [0, 0, 0, 0, 0, 0, 0, 0],
-                               [0, 0, 0, 0, 0, 0, 0, 0]], bool)
+                            [0, 1, 1, 0, 0, 0, 0, 0],
+                            [0, 0, 1, 0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 1, 0, 0],
+                            [0, 0, 0, 1, 1, 0, 0, 0],
+                            [0, 0, 1, 0, 0, 1, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 0, 0]], bool)
         data = numpy.zeros(mask.shape, bool)
-        out = ndimage.binary_dilation(data, struct,
-                          iterations=-1, mask=mask, border_value=1)
+        out = ndimage.binary_dilation(data, struct, iterations=-1,
+                                      mask=mask, border_value=1)
         assert_array_almost_equal(out, expected)
 
     def test_binary_dilation35(self):
@@ -4053,13 +3956,13 @@ class TestNdimage:
                [1, 1, 1, 1, 1, 1, 1, 1],
                [1, 1, 1, 1, 1, 1, 1, 1]]
         data = numpy.array([[0, 0, 0, 0, 0, 0, 0, 0],
-                               [0, 1, 0, 0, 0, 0, 0, 0],
-                               [0, 0, 0, 0, 0, 0, 0, 0],
-                               [0, 0, 0, 0, 0, 1, 0, 0],
-                               [0, 0, 0, 1, 1, 0, 0, 0],
-                               [0, 0, 1, 0, 0, 1, 0, 0],
-                               [0, 0, 0, 0, 0, 0, 0, 0],
-                               [0, 0, 0, 0, 0, 0, 0, 0]])
+                            [0, 1, 0, 0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 1, 0, 0],
+                            [0, 0, 0, 1, 1, 0, 0, 0],
+                            [0, 0, 1, 0, 0, 1, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 0, 0]])
         mask = [[0, 0, 0, 0, 0, 0, 0, 0],
                 [0, 0, 0, 0, 0, 0, 0, 0],
                 [0, 0, 0, 0, 0, 0, 0, 0],
@@ -4071,17 +3974,17 @@ class TestNdimage:
         expected = numpy.logical_and(tmp, mask)
         tmp = numpy.logical_and(data, numpy.logical_not(mask))
         expected = numpy.logical_or(expected, tmp)
-        for type in self.types:
+        for type_ in self.types:
             data = numpy.array([[0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 1, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 1, 0, 0],
-                                   [0, 0, 0, 1, 1, 0, 0, 0],
-                                   [0, 0, 1, 0, 0, 1, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0]], type)
+                                [0, 1, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 1, 0, 0],
+                                [0, 0, 0, 1, 1, 0, 0, 0],
+                                [0, 0, 1, 0, 0, 1, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0]], type_)
             out = ndimage.binary_dilation(data, mask=mask,
-                                        origin=(1, 1), border_value=1)
+                                          origin=(1, 1), border_value=1)
             assert_array_almost_equal(out, expected)
 
     def test_binary_propagation01(self):
@@ -4097,24 +4000,24 @@ class TestNdimage:
                                [0, 0, 0, 0, 0, 0, 0, 0],
                                [0, 0, 0, 0, 0, 0, 0, 0]], bool)
         mask = numpy.array([[0, 1, 0, 0, 0, 0, 0, 0],
-                               [0, 0, 0, 0, 0, 0, 0, 0],
-                               [0, 0, 0, 0, 0, 0, 1, 0],
-                               [0, 0, 0, 0, 1, 1, 0, 0],
-                               [0, 0, 1, 1, 1, 0, 0, 0],
-                               [0, 1, 1, 0, 1, 1, 0, 0],
-                               [0, 0, 0, 0, 0, 0, 0, 0],
-                               [0, 0, 0, 0, 0, 0, 0, 0]], bool)
+                            [0, 0, 0, 0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 1, 0],
+                            [0, 0, 0, 0, 1, 1, 0, 0],
+                            [0, 0, 1, 1, 1, 0, 0, 0],
+                            [0, 1, 1, 0, 1, 1, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 0, 0]], bool)
         data = numpy.array([[0, 1, 0, 0, 0, 0, 0, 0],
-                               [0, 0, 0, 0, 0, 0, 0, 0],
-                               [0, 0, 0, 0, 0, 0, 0, 0],
-                               [0, 0, 0, 0, 0, 0, 0, 0],
-                               [0, 0, 0, 0, 0, 0, 0, 0],
-                               [0, 1, 0, 0, 0, 0, 0, 0],
-                               [0, 0, 0, 0, 0, 0, 0, 0],
-                               [0, 0, 0, 0, 0, 0, 0, 0]], bool)
+                            [0, 0, 0, 0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 0, 0],
+                            [0, 1, 0, 0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 0, 0]], bool)
 
         out = ndimage.binary_propagation(data, struct,
-                                            mask=mask, border_value=0)
+                                         mask=mask, border_value=0)
         assert_array_almost_equal(out, expected)
 
     def test_binary_propagation02(self):
@@ -4122,400 +4025,396 @@ class TestNdimage:
                   [1, 1, 1],
                   [0, 1, 0]]
         expected = [[0, 1, 0, 0, 0, 0, 0, 0],
-                [0, 1, 1, 0, 0, 0, 0, 0],
-                [0, 0, 1, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0]]
+                    [0, 1, 1, 0, 0, 0, 0, 0],
+                    [0, 0, 1, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0]]
         mask = numpy.array([[0, 1, 0, 0, 0, 0, 0, 0],
-                               [0, 1, 1, 0, 0, 0, 0, 0],
-                               [0, 0, 1, 0, 0, 0, 0, 0],
-                               [0, 0, 0, 0, 0, 1, 0, 0],
-                               [0, 0, 0, 1, 1, 0, 0, 0],
-                               [0, 0, 1, 0, 0, 1, 0, 0],
-                               [0, 0, 0, 0, 0, 0, 0, 0],
-                               [0, 0, 0, 0, 0, 0, 0, 0]], bool)
+                            [0, 1, 1, 0, 0, 0, 0, 0],
+                            [0, 0, 1, 0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 1, 0, 0],
+                            [0, 0, 0, 1, 1, 0, 0, 0],
+                            [0, 0, 1, 0, 0, 1, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 0, 0]], bool)
         data = numpy.zeros(mask.shape, bool)
         out = ndimage.binary_propagation(data, struct,
-                                             mask=mask, border_value=1)
+                                         mask=mask, border_value=1)
         assert_array_almost_equal(out, expected)
 
     def test_binary_opening01(self):
         expected = [[0, 1, 0, 0, 0, 0, 0, 0],
-                [1, 1, 1, 0, 0, 0, 0, 0],
-                [0, 1, 0, 0, 0, 1, 0, 0],
-                [0, 0, 0, 0, 1, 1, 1, 0],
-                [0, 0, 1, 0, 0, 1, 0, 0],
-                [0, 1, 1, 1, 1, 1, 1, 0],
-                [0, 0, 1, 0, 0, 1, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0]]
-        for type in self.types:
+                    [1, 1, 1, 0, 0, 0, 0, 0],
+                    [0, 1, 0, 0, 0, 1, 0, 0],
+                    [0, 0, 0, 0, 1, 1, 1, 0],
+                    [0, 0, 1, 0, 0, 1, 0, 0],
+                    [0, 1, 1, 1, 1, 1, 1, 0],
+                    [0, 0, 1, 0, 0, 1, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0]]
+        for type_ in self.types:
             data = numpy.array([[0, 1, 0, 0, 0, 0, 0, 0],
-                                   [1, 1, 1, 0, 0, 0, 0, 0],
-                                   [0, 1, 0, 0, 0, 1, 0, 0],
-                                   [0, 0, 0, 1, 1, 1, 1, 0],
-                                   [0, 0, 1, 1, 0, 1, 0, 0],
-                                   [0, 1, 1, 1, 1, 1, 1, 0],
-                                   [0, 0, 1, 0, 0, 1, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0]], type)
+                                [1, 1, 1, 0, 0, 0, 0, 0],
+                                [0, 1, 0, 0, 0, 1, 0, 0],
+                                [0, 0, 0, 1, 1, 1, 1, 0],
+                                [0, 0, 1, 1, 0, 1, 0, 0],
+                                [0, 1, 1, 1, 1, 1, 1, 0],
+                                [0, 0, 1, 0, 0, 1, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0]], type_)
             out = ndimage.binary_opening(data)
             assert_array_almost_equal(out, expected)
 
     def test_binary_opening02(self):
         struct = ndimage.generate_binary_structure(2, 2)
         expected = [[1, 1, 1, 0, 0, 0, 0, 0],
-                [1, 1, 1, 0, 0, 0, 0, 0],
-                [1, 1, 1, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 1, 1, 1, 0, 0, 0, 0],
-                [0, 1, 1, 1, 0, 0, 0, 0],
-                [0, 1, 1, 1, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0]]
-        for type in self.types:
+                    [1, 1, 1, 0, 0, 0, 0, 0],
+                    [1, 1, 1, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 1, 1, 1, 0, 0, 0, 0],
+                    [0, 1, 1, 1, 0, 0, 0, 0],
+                    [0, 1, 1, 1, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0]]
+        for type_ in self.types:
             data = numpy.array([[1, 1, 1, 0, 0, 0, 0, 0],
-                                   [1, 1, 1, 0, 0, 0, 0, 0],
-                                   [1, 1, 1, 1, 1, 1, 1, 0],
-                                   [0, 0, 1, 1, 1, 1, 1, 0],
-                                   [0, 1, 1, 1, 0, 1, 1, 0],
-                                   [0, 1, 1, 1, 1, 1, 1, 0],
-                                   [0, 1, 1, 1, 1, 1, 1, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0]], type)
+                                [1, 1, 1, 0, 0, 0, 0, 0],
+                                [1, 1, 1, 1, 1, 1, 1, 0],
+                                [0, 0, 1, 1, 1, 1, 1, 0],
+                                [0, 1, 1, 1, 0, 1, 1, 0],
+                                [0, 1, 1, 1, 1, 1, 1, 0],
+                                [0, 1, 1, 1, 1, 1, 1, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0]], type_)
             out = ndimage.binary_opening(data, struct)
             assert_array_almost_equal(out, expected)
 
     def test_binary_closing01(self):
         expected = [[0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 1, 1, 0, 0, 0, 0, 0],
-                [0, 1, 1, 1, 0, 1, 0, 0],
-                [0, 0, 1, 1, 1, 1, 1, 0],
-                [0, 0, 1, 1, 1, 1, 0, 0],
-                [0, 1, 1, 1, 1, 1, 1, 0],
-                [0, 0, 1, 0, 0, 1, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0]]
-        for type in self.types:
+                    [0, 1, 1, 0, 0, 0, 0, 0],
+                    [0, 1, 1, 1, 0, 1, 0, 0],
+                    [0, 0, 1, 1, 1, 1, 1, 0],
+                    [0, 0, 1, 1, 1, 1, 0, 0],
+                    [0, 1, 1, 1, 1, 1, 1, 0],
+                    [0, 0, 1, 0, 0, 1, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0]]
+        for type_ in self.types:
             data = numpy.array([[0, 1, 0, 0, 0, 0, 0, 0],
-                                   [1, 1, 1, 0, 0, 0, 0, 0],
-                                   [0, 1, 0, 0, 0, 1, 0, 0],
-                                   [0, 0, 0, 1, 1, 1, 1, 0],
-                                   [0, 0, 1, 1, 0, 1, 0, 0],
-                                   [0, 1, 1, 1, 1, 1, 1, 0],
-                                   [0, 0, 1, 0, 0, 1, 0, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0]], type)
+                                [1, 1, 1, 0, 0, 0, 0, 0],
+                                [0, 1, 0, 0, 0, 1, 0, 0],
+                                [0, 0, 0, 1, 1, 1, 1, 0],
+                                [0, 0, 1, 1, 0, 1, 0, 0],
+                                [0, 1, 1, 1, 1, 1, 1, 0],
+                                [0, 0, 1, 0, 0, 1, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0]], type_)
             out = ndimage.binary_closing(data)
             assert_array_almost_equal(out, expected)
 
     def test_binary_closing02(self):
         struct = ndimage.generate_binary_structure(2, 2)
         expected = [[0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 1, 1, 0, 0, 0, 0, 0],
-                [0, 1, 1, 1, 1, 1, 1, 0],
-                [0, 1, 1, 1, 1, 1, 1, 0],
-                [0, 1, 1, 1, 1, 1, 1, 0],
-                [0, 1, 1, 1, 1, 1, 1, 0],
-                [0, 1, 1, 1, 1, 1, 1, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0]]
-        for type in self.types:
+                    [0, 1, 1, 0, 0, 0, 0, 0],
+                    [0, 1, 1, 1, 1, 1, 1, 0],
+                    [0, 1, 1, 1, 1, 1, 1, 0],
+                    [0, 1, 1, 1, 1, 1, 1, 0],
+                    [0, 1, 1, 1, 1, 1, 1, 0],
+                    [0, 1, 1, 1, 1, 1, 1, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0]]
+        for type_ in self.types:
             data = numpy.array([[1, 1, 1, 0, 0, 0, 0, 0],
-                                   [1, 1, 1, 0, 0, 0, 0, 0],
-                                   [1, 1, 1, 1, 1, 1, 1, 0],
-                                   [0, 0, 1, 1, 1, 1, 1, 0],
-                                   [0, 1, 1, 1, 0, 1, 1, 0],
-                                   [0, 1, 1, 1, 1, 1, 1, 0],
-                                   [0, 1, 1, 1, 1, 1, 1, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0]], type)
+                                [1, 1, 1, 0, 0, 0, 0, 0],
+                                [1, 1, 1, 1, 1, 1, 1, 0],
+                                [0, 0, 1, 1, 1, 1, 1, 0],
+                                [0, 1, 1, 1, 0, 1, 1, 0],
+                                [0, 1, 1, 1, 1, 1, 1, 0],
+                                [0, 1, 1, 1, 1, 1, 1, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0]], type_)
             out = ndimage.binary_closing(data, struct)
             assert_array_almost_equal(out, expected)
 
     def test_binary_fill_holes01(self):
         expected = numpy.array([[0, 0, 0, 0, 0, 0, 0, 0],
-                               [0, 0, 1, 1, 1, 1, 0, 0],
-                               [0, 0, 1, 1, 1, 1, 0, 0],
-                               [0, 0, 1, 1, 1, 1, 0, 0],
-                               [0, 0, 1, 1, 1, 1, 0, 0],
-                               [0, 0, 1, 1, 1, 1, 0, 0],
-                               [0, 0, 0, 0, 0, 0, 0, 0]], bool)
+                                [0, 0, 1, 1, 1, 1, 0, 0],
+                                [0, 0, 1, 1, 1, 1, 0, 0],
+                                [0, 0, 1, 1, 1, 1, 0, 0],
+                                [0, 0, 1, 1, 1, 1, 0, 0],
+                                [0, 0, 1, 1, 1, 1, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0]], bool)
         data = numpy.array([[0, 0, 0, 0, 0, 0, 0, 0],
-                               [0, 0, 1, 1, 1, 1, 0, 0],
-                               [0, 0, 1, 0, 0, 1, 0, 0],
-                               [0, 0, 1, 0, 0, 1, 0, 0],
-                               [0, 0, 1, 0, 0, 1, 0, 0],
-                               [0, 0, 1, 1, 1, 1, 0, 0],
-                               [0, 0, 0, 0, 0, 0, 0, 0]], bool)
+                            [0, 0, 1, 1, 1, 1, 0, 0],
+                            [0, 0, 1, 0, 0, 1, 0, 0],
+                            [0, 0, 1, 0, 0, 1, 0, 0],
+                            [0, 0, 1, 0, 0, 1, 0, 0],
+                            [0, 0, 1, 1, 1, 1, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 0, 0]], bool)
         out = ndimage.binary_fill_holes(data)
         assert_array_almost_equal(out, expected)
 
     def test_binary_fill_holes02(self):
         expected = numpy.array([[0, 0, 0, 0, 0, 0, 0, 0],
-                               [0, 0, 0, 1, 1, 0, 0, 0],
-                               [0, 0, 1, 1, 1, 1, 0, 0],
-                               [0, 0, 1, 1, 1, 1, 0, 0],
-                               [0, 0, 1, 1, 1, 1, 0, 0],
-                               [0, 0, 0, 1, 1, 0, 0, 0],
-                               [0, 0, 0, 0, 0, 0, 0, 0]], bool)
+                                [0, 0, 0, 1, 1, 0, 0, 0],
+                                [0, 0, 1, 1, 1, 1, 0, 0],
+                                [0, 0, 1, 1, 1, 1, 0, 0],
+                                [0, 0, 1, 1, 1, 1, 0, 0],
+                                [0, 0, 0, 1, 1, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0]], bool)
         data = numpy.array([[0, 0, 0, 0, 0, 0, 0, 0],
-                               [0, 0, 0, 1, 1, 0, 0, 0],
-                               [0, 0, 1, 0, 0, 1, 0, 0],
-                               [0, 0, 1, 0, 0, 1, 0, 0],
-                               [0, 0, 1, 0, 0, 1, 0, 0],
-                               [0, 0, 0, 1, 1, 0, 0, 0],
-                               [0, 0, 0, 0, 0, 0, 0, 0]], bool)
+                            [0, 0, 0, 1, 1, 0, 0, 0],
+                            [0, 0, 1, 0, 0, 1, 0, 0],
+                            [0, 0, 1, 0, 0, 1, 0, 0],
+                            [0, 0, 1, 0, 0, 1, 0, 0],
+                            [0, 0, 0, 1, 1, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 0, 0]], bool)
         out = ndimage.binary_fill_holes(data)
         assert_array_almost_equal(out, expected)
 
     def test_binary_fill_holes03(self):
         expected = numpy.array([[0, 0, 0, 0, 0, 0, 0, 0],
-                               [0, 0, 1, 0, 0, 0, 0, 0],
-                               [0, 1, 1, 1, 0, 1, 1, 1],
-                               [0, 1, 1, 1, 0, 1, 1, 1],
-                               [0, 1, 1, 1, 0, 1, 1, 1],
-                               [0, 0, 1, 0, 0, 1, 1, 1],
-                               [0, 0, 0, 0, 0, 0, 0, 0]], bool)
+                                [0, 0, 1, 0, 0, 0, 0, 0],
+                                [0, 1, 1, 1, 0, 1, 1, 1],
+                                [0, 1, 1, 1, 0, 1, 1, 1],
+                                [0, 1, 1, 1, 0, 1, 1, 1],
+                                [0, 0, 1, 0, 0, 1, 1, 1],
+                                [0, 0, 0, 0, 0, 0, 0, 0]], bool)
         data = numpy.array([[0, 0, 0, 0, 0, 0, 0, 0],
-                               [0, 0, 1, 0, 0, 0, 0, 0],
-                               [0, 1, 0, 1, 0, 1, 1, 1],
-                               [0, 1, 0, 1, 0, 1, 0, 1],
-                               [0, 1, 0, 1, 0, 1, 0, 1],
-                               [0, 0, 1, 0, 0, 1, 1, 1],
-                               [0, 0, 0, 0, 0, 0, 0, 0]], bool)
+                            [0, 0, 1, 0, 0, 0, 0, 0],
+                            [0, 1, 0, 1, 0, 1, 1, 1],
+                            [0, 1, 0, 1, 0, 1, 0, 1],
+                            [0, 1, 0, 1, 0, 1, 0, 1],
+                            [0, 0, 1, 0, 0, 1, 1, 1],
+                            [0, 0, 0, 0, 0, 0, 0, 0]], bool)
         out = ndimage.binary_fill_holes(data)
         assert_array_almost_equal(out, expected)
 
     def test_grey_erosion01(self):
         array = numpy.array([[3, 2, 5, 1, 4],
-                                [7, 6, 9, 3, 5],
-                                [5, 8, 3, 7, 1]])
+                             [7, 6, 9, 3, 5],
+                             [5, 8, 3, 7, 1]])
         footprint = [[1, 0, 1], [1, 1, 0]]
-        output = ndimage.grey_erosion(array,
-                                                footprint=footprint)
+        output = ndimage.grey_erosion(array, footprint=footprint)
         assert_array_almost_equal([[2, 2, 1, 1, 1],
-                              [2, 3, 1, 3, 1],
-                              [5, 5, 3, 3, 1]], output)
+                                   [2, 3, 1, 3, 1],
+                                   [5, 5, 3, 3, 1]], output)
 
     def test_grey_erosion02(self):
         array = numpy.array([[3, 2, 5, 1, 4],
-                                [7, 6, 9, 3, 5],
-                                [5, 8, 3, 7, 1]])
+                             [7, 6, 9, 3, 5],
+                             [5, 8, 3, 7, 1]])
         footprint = [[1, 0, 1], [1, 1, 0]]
         structure = [[0, 0, 0], [0, 0, 0]]
-        output = ndimage.grey_erosion(array,
-                              footprint=footprint, structure=structure)
+        output = ndimage.grey_erosion(array, footprint=footprint,
+                                      structure=structure)
         assert_array_almost_equal([[2, 2, 1, 1, 1],
-                              [2, 3, 1, 3, 1],
-                              [5, 5, 3, 3, 1]], output)
+                                   [2, 3, 1, 3, 1],
+                                   [5, 5, 3, 3, 1]], output)
 
     def test_grey_erosion03(self):
         array = numpy.array([[3, 2, 5, 1, 4],
-                                [7, 6, 9, 3, 5],
-                                [5, 8, 3, 7, 1]])
+                             [7, 6, 9, 3, 5],
+                             [5, 8, 3, 7, 1]])
         footprint = [[1, 0, 1], [1, 1, 0]]
         structure = [[1, 1, 1], [1, 1, 1]]
-        output = ndimage.grey_erosion(array,
-                              footprint=footprint, structure=structure)
+        output = ndimage.grey_erosion(array, footprint=footprint,
+                                      structure=structure)
         assert_array_almost_equal([[1, 1, 0, 0, 0],
-                              [1, 2, 0, 2, 0],
-                              [4, 4, 2, 2, 0]], output)
+                                   [1, 2, 0, 2, 0],
+                                   [4, 4, 2, 2, 0]], output)
 
     def test_grey_dilation01(self):
         array = numpy.array([[3, 2, 5, 1, 4],
-                                [7, 6, 9, 3, 5],
-                                [5, 8, 3, 7, 1]])
+                             [7, 6, 9, 3, 5],
+                             [5, 8, 3, 7, 1]])
         footprint = [[0, 1, 1], [1, 0, 1]]
-        output = ndimage.grey_dilation(array,
-                                                 footprint=footprint)
+        output = ndimage.grey_dilation(array, footprint=footprint)
         assert_array_almost_equal([[7, 7, 9, 9, 5],
-                              [7, 9, 8, 9, 7],
-                              [8, 8, 8, 7, 7]], output)
+                                   [7, 9, 8, 9, 7],
+                                   [8, 8, 8, 7, 7]], output)
 
     def test_grey_dilation02(self):
         array = numpy.array([[3, 2, 5, 1, 4],
-                                [7, 6, 9, 3, 5],
-                                [5, 8, 3, 7, 1]])
+                             [7, 6, 9, 3, 5],
+                             [5, 8, 3, 7, 1]])
         footprint = [[0, 1, 1], [1, 0, 1]]
         structure = [[0, 0, 0], [0, 0, 0]]
-        output = ndimage.grey_dilation(array,
-                             footprint=footprint, structure=structure)
+        output = ndimage.grey_dilation(array, footprint=footprint,
+                                       structure=structure)
         assert_array_almost_equal([[7, 7, 9, 9, 5],
-                              [7, 9, 8, 9, 7],
-                              [8, 8, 8, 7, 7]], output)
+                                   [7, 9, 8, 9, 7],
+                                   [8, 8, 8, 7, 7]], output)
 
     def test_grey_dilation03(self):
         array = numpy.array([[3, 2, 5, 1, 4],
-                                [7, 6, 9, 3, 5],
-                                [5, 8, 3, 7, 1]])
+                             [7, 6, 9, 3, 5],
+                             [5, 8, 3, 7, 1]])
         footprint = [[0, 1, 1], [1, 0, 1]]
         structure = [[1, 1, 1], [1, 1, 1]]
-        output = ndimage.grey_dilation(array,
-                             footprint=footprint, structure=structure)
+        output = ndimage.grey_dilation(array, footprint=footprint,
+                                       structure=structure)
         assert_array_almost_equal([[8, 8, 10, 10, 6],
-                              [8, 10, 9, 10, 8],
-                              [9, 9, 9, 8, 8]], output)
+                                   [8, 10, 9, 10, 8],
+                                   [9, 9, 9, 8, 8]], output)
 
     def test_grey_opening01(self):
         array = numpy.array([[3, 2, 5, 1, 4],
-                                [7, 6, 9, 3, 5],
-                                [5, 8, 3, 7, 1]])
+                             [7, 6, 9, 3, 5],
+                             [5, 8, 3, 7, 1]])
         footprint = [[1, 0, 1], [1, 1, 0]]
         tmp = ndimage.grey_erosion(array, footprint=footprint)
         expected = ndimage.grey_dilation(tmp, footprint=footprint)
-        output = ndimage.grey_opening(array,
-                                                footprint=footprint)
+        output = ndimage.grey_opening(array, footprint=footprint)
         assert_array_almost_equal(expected, output)
 
     def test_grey_opening02(self):
         array = numpy.array([[3, 2, 5, 1, 4],
-                                [7, 6, 9, 3, 5],
-                                [5, 8, 3, 7, 1]])
+                             [7, 6, 9, 3, 5],
+                             [5, 8, 3, 7, 1]])
         footprint = [[1, 0, 1], [1, 1, 0]]
         structure = [[0, 0, 0], [0, 0, 0]]
         tmp = ndimage.grey_erosion(array, footprint=footprint,
-                                             structure=structure)
+                                   structure=structure)
         expected = ndimage.grey_dilation(tmp, footprint=footprint,
-                                               structure=structure)
-        output = ndimage.grey_opening(array,
-                             footprint=footprint, structure=structure)
+                                         structure=structure)
+        output = ndimage.grey_opening(array, footprint=footprint,
+                                      structure=structure)
         assert_array_almost_equal(expected, output)
 
     def test_grey_closing01(self):
         array = numpy.array([[3, 2, 5, 1, 4],
-                                [7, 6, 9, 3, 5],
-                                [5, 8, 3, 7, 1]])
+                             [7, 6, 9, 3, 5],
+                             [5, 8, 3, 7, 1]])
         footprint = [[1, 0, 1], [1, 1, 0]]
         tmp = ndimage.grey_dilation(array, footprint=footprint)
         expected = ndimage.grey_erosion(tmp, footprint=footprint)
-        output = ndimage.grey_closing(array,
-                                                footprint=footprint)
+        output = ndimage.grey_closing(array, footprint=footprint)
         assert_array_almost_equal(expected, output)
 
     def test_grey_closing02(self):
         array = numpy.array([[3, 2, 5, 1, 4],
-                                [7, 6, 9, 3, 5],
-                                [5, 8, 3, 7, 1]])
+                             [7, 6, 9, 3, 5],
+                             [5, 8, 3, 7, 1]])
         footprint = [[1, 0, 1], [1, 1, 0]]
         structure = [[0, 0, 0], [0, 0, 0]]
         tmp = ndimage.grey_dilation(array, footprint=footprint,
-                                              structure=structure)
+                                    structure=structure)
         expected = ndimage.grey_erosion(tmp, footprint=footprint,
-                                              structure=structure)
-        output = ndimage.grey_closing(array,
-                              footprint=footprint, structure=structure)
+                                        structure=structure)
+        output = ndimage.grey_closing(array, footprint=footprint,
+                                      structure=structure)
         assert_array_almost_equal(expected, output)
 
     def test_morphological_gradient01(self):
         array = numpy.array([[3, 2, 5, 1, 4],
-                                [7, 6, 9, 3, 5],
-                                [5, 8, 3, 7, 1]])
+                             [7, 6, 9, 3, 5],
+                             [5, 8, 3, 7, 1]])
         footprint = [[1, 0, 1], [1, 1, 0]]
         structure = [[0, 0, 0], [0, 0, 0]]
-        tmp1 = ndimage.grey_dilation(array,
-                             footprint=footprint, structure=structure)
+        tmp1 = ndimage.grey_dilation(array, footprint=footprint,
+                                     structure=structure)
         tmp2 = ndimage.grey_erosion(array, footprint=footprint,
-                                              structure=structure)
+                                    structure=structure)
         expected = tmp1 - tmp2
         output = numpy.zeros(array.shape, array.dtype)
-        ndimage.morphological_gradient(array,
-                footprint=footprint, structure=structure, output=output)
+        ndimage.morphological_gradient(array, footprint=footprint,
+                                       structure=structure, output=output)
         assert_array_almost_equal(expected, output)
 
     def test_morphological_gradient02(self):
         array = numpy.array([[3, 2, 5, 1, 4],
-                                [7, 6, 9, 3, 5],
-                                [5, 8, 3, 7, 1]])
+                             [7, 6, 9, 3, 5],
+                             [5, 8, 3, 7, 1]])
         footprint = [[1, 0, 1], [1, 1, 0]]
         structure = [[0, 0, 0], [0, 0, 0]]
-        tmp1 = ndimage.grey_dilation(array,
-                             footprint=footprint, structure=structure)
+        tmp1 = ndimage.grey_dilation(array, footprint=footprint,
+                                     structure=structure)
         tmp2 = ndimage.grey_erosion(array, footprint=footprint,
-                                              structure=structure)
+                                    structure=structure)
         expected = tmp1 - tmp2
-        output = ndimage.morphological_gradient(array,
-                                footprint=footprint, structure=structure)
+        output = ndimage.morphological_gradient(array, footprint=footprint,
+                                                structure=structure)
         assert_array_almost_equal(expected, output)
 
     def test_morphological_laplace01(self):
         array = numpy.array([[3, 2, 5, 1, 4],
-                                [7, 6, 9, 3, 5],
-                                [5, 8, 3, 7, 1]])
+                             [7, 6, 9, 3, 5],
+                             [5, 8, 3, 7, 1]])
         footprint = [[1, 0, 1], [1, 1, 0]]
         structure = [[0, 0, 0], [0, 0, 0]]
-        tmp1 = ndimage.grey_dilation(array,
-                              footprint=footprint, structure=structure)
+        tmp1 = ndimage.grey_dilation(array, footprint=footprint,
+                                     structure=structure)
         tmp2 = ndimage.grey_erosion(array, footprint=footprint,
-                                              structure=structure)
+                                    structure=structure)
         expected = tmp1 + tmp2 - 2 * array
         output = numpy.zeros(array.shape, array.dtype)
         ndimage.morphological_laplace(array, footprint=footprint,
-                                     structure=structure, output=output)
+                                      structure=structure, output=output)
         assert_array_almost_equal(expected, output)
 
     def test_morphological_laplace02(self):
         array = numpy.array([[3, 2, 5, 1, 4],
-                                [7, 6, 9, 3, 5],
-                                [5, 8, 3, 7, 1]])
+                             [7, 6, 9, 3, 5],
+                             [5, 8, 3, 7, 1]])
         footprint = [[1, 0, 1], [1, 1, 0]]
         structure = [[0, 0, 0], [0, 0, 0]]
-        tmp1 = ndimage.grey_dilation(array,
-                             footprint=footprint, structure=structure)
+        tmp1 = ndimage.grey_dilation(array, footprint=footprint,
+                                     structure=structure)
         tmp2 = ndimage.grey_erosion(array, footprint=footprint,
-                                              structure=structure)
+                                    structure=structure)
         expected = tmp1 + tmp2 - 2 * array
-        output = ndimage.morphological_laplace(array,
-                                footprint=footprint, structure=structure)
+        output = ndimage.morphological_laplace(array, footprint=footprint,
+                                               structure=structure)
         assert_array_almost_equal(expected, output)
 
     def test_white_tophat01(self):
         array = numpy.array([[3, 2, 5, 1, 4],
-                                [7, 6, 9, 3, 5],
-                                [5, 8, 3, 7, 1]])
+                             [7, 6, 9, 3, 5],
+                             [5, 8, 3, 7, 1]])
         footprint = [[1, 0, 1], [1, 1, 0]]
         structure = [[0, 0, 0], [0, 0, 0]]
         tmp = ndimage.grey_opening(array, footprint=footprint,
-                                             structure=structure)
+                                   structure=structure)
         expected = array - tmp
         output = numpy.zeros(array.shape, array.dtype)
         ndimage.white_tophat(array, footprint=footprint,
-                                      structure=structure, output=output)
+                             structure=structure, output=output)
         assert_array_almost_equal(expected, output)
 
     def test_white_tophat02(self):
         array = numpy.array([[3, 2, 5, 1, 4],
-                                [7, 6, 9, 3, 5],
-                                [5, 8, 3, 7, 1]])
+                             [7, 6, 9, 3, 5],
+                             [5, 8, 3, 7, 1]])
         footprint = [[1, 0, 1], [1, 1, 0]]
         structure = [[0, 0, 0], [0, 0, 0]]
         tmp = ndimage.grey_opening(array, footprint=footprint,
-                                             structure=structure)
+                                   structure=structure)
         expected = array - tmp
         output = ndimage.white_tophat(array, footprint=footprint,
-                                                structure=structure)
+                                      structure=structure)
         assert_array_almost_equal(expected, output)
 
     def test_black_tophat01(self):
         array = numpy.array([[3, 2, 5, 1, 4],
-                                [7, 6, 9, 3, 5],
-                                [5, 8, 3, 7, 1]])
+                             [7, 6, 9, 3, 5],
+                             [5, 8, 3, 7, 1]])
         footprint = [[1, 0, 1], [1, 1, 0]]
         structure = [[0, 0, 0], [0, 0, 0]]
         tmp = ndimage.grey_closing(array, footprint=footprint,
-                                             structure=structure)
+                                   structure=structure)
         expected = tmp - array
         output = numpy.zeros(array.shape, array.dtype)
         ndimage.black_tophat(array, footprint=footprint,
-                                      structure=structure, output=output)
+                             structure=structure, output=output)
         assert_array_almost_equal(expected, output)
 
     def test_black_tophat02(self):
         array = numpy.array([[3, 2, 5, 1, 4],
-                                [7, 6, 9, 3, 5],
-                                [5, 8, 3, 7, 1]])
+                             [7, 6, 9, 3, 5],
+                             [5, 8, 3, 7, 1]])
         footprint = [[1, 0, 1], [1, 1, 0]]
         structure = [[0, 0, 0], [0, 0, 0]]
         tmp = ndimage.grey_closing(array, footprint=footprint,
-                                             structure=structure)
+                                   structure=structure)
         expected = tmp - array
         output = ndimage.black_tophat(array, footprint=footprint,
-                                                structure=structure)
+                                      structure=structure)
         assert_array_almost_equal(expected, output)
 
     def test_hit_or_miss01(self):
@@ -4523,25 +4422,24 @@ class TestNdimage:
                   [1, 1, 1],
                   [0, 1, 0]]
         expected = [[0, 0, 0, 0, 0],
-                [0, 1, 0, 0, 0],
-                [0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0]]
-        for type in self.types:
+                    [0, 1, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0]]
+        for type_ in self.types:
             data = numpy.array([[0, 1, 0, 0, 0],
-                                   [1, 1, 1, 0, 0],
-                                   [0, 1, 0, 1, 1],
-                                   [0, 0, 1, 1, 1],
-                                   [0, 1, 1, 1, 0],
-                                   [0, 1, 1, 1, 1],
-                                   [0, 1, 1, 1, 1],
-                                   [0, 0, 0, 0, 0]], type)
+                                [1, 1, 1, 0, 0],
+                                [0, 1, 0, 1, 1],
+                                [0, 0, 1, 1, 1],
+                                [0, 1, 1, 1, 0],
+                                [0, 1, 1, 1, 1],
+                                [0, 1, 1, 1, 1],
+                                [0, 0, 0, 0, 0]], type_)
             out = numpy.zeros(data.shape, bool)
-            ndimage.binary_hit_or_miss(data, struct,
-                                                 output=out)
+            ndimage.binary_hit_or_miss(data, struct, output=out)
             assert_array_almost_equal(expected, out)
 
     def test_hit_or_miss02(self):
@@ -4549,14 +4447,14 @@ class TestNdimage:
                   [1, 1, 1],
                   [0, 1, 0]]
         expected = [[0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 1, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0]]
-        for type in self.types:
+                    [0, 1, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0]]
+        for type_ in self.types:
             data = numpy.array([[0, 1, 0, 0, 1, 1, 1, 0],
-                                   [1, 1, 1, 0, 0, 1, 0, 0],
-                                   [0, 1, 0, 1, 1, 1, 1, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0]], type)
+                                [1, 1, 1, 0, 0, 1, 0, 0],
+                                [0, 1, 0, 1, 1, 1, 1, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0]], type_)
             out = ndimage.binary_hit_or_miss(data, struct)
             assert_array_almost_equal(expected, out)
 
@@ -4568,24 +4466,23 @@ class TestNdimage:
                    [0, 0, 0],
                    [1, 1, 1]]
         expected = [[0, 0, 0, 0, 0, 1, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 1, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0]]
-        for type in self.types:
+                    [0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 1, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0]]
+        for type_ in self.types:
             data = numpy.array([[0, 1, 0, 0, 1, 1, 1, 0],
-                                   [1, 1, 1, 0, 0, 0, 0, 0],
-                                   [0, 1, 0, 1, 1, 1, 1, 0],
-                                   [0, 0, 1, 1, 1, 1, 1, 0],
-                                   [0, 1, 1, 1, 0, 1, 1, 0],
-                                   [0, 0, 0, 0, 1, 1, 1, 0],
-                                   [0, 1, 1, 1, 1, 1, 1, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0]], type)
-            out = ndimage.binary_hit_or_miss(data, struct1,
-                                              struct2)
+                                [1, 1, 1, 0, 0, 0, 0, 0],
+                                [0, 1, 0, 1, 1, 1, 1, 0],
+                                [0, 0, 1, 1, 1, 1, 1, 0],
+                                [0, 1, 1, 1, 0, 1, 1, 0],
+                                [0, 0, 0, 0, 1, 1, 1, 0],
+                                [0, 1, 1, 1, 1, 1, 1, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0]], type_)
+            out = ndimage.binary_hit_or_miss(data, struct1, struct2)
             assert_array_almost_equal(expected, out)
 
 
@@ -4593,11 +4490,11 @@ class TestDilateFix:
 
     def setup_method(self):
         # dilation related setup
-        self.array = numpy.array([[0, 0, 0, 0, 0,],
-                                  [0, 0, 0, 0, 0,],
-                                  [0, 0, 0, 1, 0,],
-                                  [0, 0, 1, 1, 0,],
-                                  [0, 0, 0, 0, 0,]], dtype=numpy.uint8)
+        self.array = numpy.array([[0, 0, 0, 0, 0],
+                                  [0, 0, 0, 0, 0],
+                                  [0, 0, 0, 1, 0],
+                                  [0, 0, 1, 1, 0],
+                                  [0, 0, 0, 0, 0]], dtype=numpy.uint8)
 
         self.sq3x3 = numpy.ones((3, 3))
         dilated3x3 = ndimage.binary_dilation(self.array, structure=self.sq3x3)

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -1203,7 +1203,7 @@ class TestNdimage:
         def shift(x):
             return (x[0] + 0.5,)
 
-        data = numpy.array([1, 2, 3, 4])
+        data = numpy.array([1, 2, 3, 4.])
         expected = {'constant': [1.5, 2.5, 3.5, -1, -1, -1, -1],
                     'wrap': [1.5, 2.5, 3.5, 1.5, 2.5, 3.5, 1.5],
                     'mirror': [1.5, 2.5, 3.5, 3.5, 2.5, 1.5, 1.5],
@@ -2880,7 +2880,7 @@ class TestNdimage:
         fts.append(ft)
         ft = numpy.indices(data.shape, dtype=numpy.int32)
         ndimage.distance_transform_edt(
-            data, return_distances=False,return_indices=True, indices=ft)
+            data, return_distances=False, return_indices=True, indices=ft)
         fts.append(ft)
         dt, ft = ndimage.distance_transform_edt(
             data, return_indices=True)
@@ -4390,6 +4390,26 @@ class TestNdimage:
                                       structure=structure)
         assert_array_almost_equal(expected, output)
 
+    def test_white_tophat03(self):
+        array = numpy.array([[1, 0, 0, 0, 0, 0, 0],
+                             [0, 1, 1, 1, 1, 1, 0],
+                             [0, 1, 1, 1, 1, 1, 0],
+                             [0, 1, 1, 1, 1, 1, 0],
+                             [0, 1, 1, 1, 0, 1, 0],
+                             [0, 1, 1, 1, 1, 1, 0],
+                             [0, 0, 0, 0, 0, 0, 1]], dtype=numpy.bool_)
+        structure = numpy.ones((3, 3), dtype=numpy.bool_)
+        expected = numpy.array([[0, 1, 1, 0, 0, 0, 0],
+                                [1, 0, 0, 1, 1, 1, 0],
+                                [1, 0, 0, 1, 1, 1, 0],
+                                [0, 1, 1, 0, 0, 0, 1],
+                                [0, 1, 1, 0, 1, 0, 1],
+                                [0, 1, 1, 0, 0, 0, 1],
+                                [0, 0, 0, 1, 1, 1, 1]], dtype=numpy.bool_)
+
+        output = ndimage.white_tophat(array, structure=structure)
+        assert_array_equal(expected, output)
+
     def test_black_tophat01(self):
         array = numpy.array([[3, 2, 5, 1, 4],
                              [7, 6, 9, 3, 5],
@@ -4416,6 +4436,26 @@ class TestNdimage:
         output = ndimage.black_tophat(array, footprint=footprint,
                                       structure=structure)
         assert_array_almost_equal(expected, output)
+
+    def test_black_tophat03(self):
+        array = numpy.array([[1, 0, 0, 0, 0, 0, 0],
+                             [0, 1, 1, 1, 1, 1, 0],
+                             [0, 1, 1, 1, 1, 1, 0],
+                             [0, 1, 1, 1, 1, 1, 0],
+                             [0, 1, 1, 1, 0, 1, 0],
+                             [0, 1, 1, 1, 1, 1, 0],
+                             [0, 0, 0, 0, 0, 0, 1]], dtype=numpy.bool_)
+        structure = numpy.ones((3, 3), dtype=numpy.bool_)
+        expected = numpy.array([[0, 1, 1, 1, 1, 1, 1],
+                                [1, 0, 0, 0, 0, 0, 1],
+                                [1, 0, 0, 0, 0, 0, 1],
+                                [1, 0, 0, 0, 0, 0, 1],
+                                [1, 0, 0, 0, 1, 0, 1],
+                                [1, 0, 0, 0, 0, 0, 1],
+                                [1, 1, 1, 1, 1, 1, 0]], dtype=numpy.bool_)
+
+        output = ndimage.black_tophat(array, structure=structure)
+        assert_array_equal(expected, output)
 
     def test_hit_or_miss01(self):
         struct = [[0, 1, 0],

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -4410,6 +4410,14 @@ class TestNdimage:
         output = ndimage.white_tophat(array, structure=structure)
         assert_array_equal(expected, output)
 
+    def test_white_tophat04(self):
+        array = numpy.eye(5, dtype=numpy.bool_)
+        structure = numpy.ones((3, 3), dtype=numpy.bool_)
+
+        # Check that type missmatch is properly handled
+        output = numpy.empty_like(array, dtype=numpy.float)
+        ndimage.white_tophat(array, structure=structure, output=output)
+
     def test_black_tophat01(self):
         array = numpy.array([[3, 2, 5, 1, 4],
                              [7, 6, 9, 3, 5],
@@ -4456,6 +4464,14 @@ class TestNdimage:
 
         output = ndimage.black_tophat(array, structure=structure)
         assert_array_equal(expected, output)
+
+    def test_black_tophat04(self):
+        array = numpy.eye(5, dtype=numpy.bool_)
+        structure = numpy.ones((3, 3), dtype=numpy.bool_)
+
+        # Check that type missmatch is properly handled
+        output = numpy.empty_like(array, dtype=numpy.float)
+        ndimage.black_tophat(array, structure=structure, output=output)
 
     def test_hit_or_miss01(self):
         struct = [[0, 1, 0],


### PR DESCRIPTION
This PR fixes support for boolean arrays for `white_tophat` and `black_tophat` functions, adds couple of tests, and solves a lot of PEP8 issues in `morphology.py` and `test_ndimage.py`.

Morphology and PEP8 fixes are split by commits and can be reviewed separately.

Closes https://github.com/scipy/scipy/issues/7493.