### PR TITLE
MAINT: Simplify return value of ndimage functions.

### DIFF
--- a/scipy/ndimage/_ni_support.py
+++ b/scipy/ndimage/_ni_support.py
@@ -73,19 +73,14 @@ def _get_output(output, input, shape=None):
         shape = input.shape
     if output is None:
         output = numpy.zeros(shape, dtype=input.dtype.name)
-        return_value = output
     elif type(output) in [type(type), type(numpy.zeros((4,)).dtype)]:
         output = numpy.zeros(shape, dtype=output)
-        return_value = output
     elif type(output) in string_types:
         output = numpy.typeDict[output]
         output = numpy.zeros(shape, dtype=output)
-        return_value = output
-    else:
-        if output.shape != shape:
-            raise RuntimeError("output shape not correct")
-        return_value = None
-    return output, return_value
+    elif output.shape != shape:
+        raise RuntimeError("output shape not correct")
+    return output
 
 
 def _check_axis(axis, rank):

--- a/scipy/ndimage/filters.py
+++ b/scipy/ndimage/filters.py
@@ -145,7 +145,7 @@ def correlate1d(input, weights, axis=-1, output=None, mode="reflect",
     input = numpy.asarray(input)
     if numpy.iscomplexobj(input):
         raise TypeError('Complex type not supported')
-    output, return_value = _ni_support._get_output(output, input)
+    output = _ni_support._get_output(output, input)
     weights = numpy.asarray(weights, dtype=numpy.float64)
     if weights.ndim != 1 or weights.shape[0] < 1:
         raise RuntimeError('no filter weights given')
@@ -158,7 +158,7 @@ def correlate1d(input, weights, axis=-1, output=None, mode="reflect",
     mode = _ni_support._extend_mode_to_code(mode)
     _nd_image.correlate1d(input, weights, axis, output, mode, cval,
                           origin)
-    return return_value
+    return output
 
 
 @docfiller
@@ -341,7 +341,7 @@ def gaussian_filter(input, sigma, order=0, output=None,
     >>> plt.show()
     """
     input = numpy.asarray(input)
-    output, return_value = _ni_support._get_output(output, input)
+    output = _ni_support._get_output(output, input)
     orders = _ni_support._normalize_sequence(order, input.ndim)
     sigmas = _ni_support._normalize_sequence(sigma, input.ndim)
     modes = _ni_support._normalize_sequence(mode, input.ndim)
@@ -355,7 +355,7 @@ def gaussian_filter(input, sigma, order=0, output=None,
             input = output
     else:
         output[...] = input[...]
-    return return_value
+    return output
 
 
 @docfiller
@@ -386,13 +386,13 @@ def prewitt(input, axis=-1, output=None, mode="reflect", cval=0.0):
     """
     input = numpy.asarray(input)
     axis = _ni_support._check_axis(axis, input.ndim)
-    output, return_value = _ni_support._get_output(output, input)
+    output = _ni_support._get_output(output, input)
     modes = _ni_support._normalize_sequence(mode, input.ndim)
     correlate1d(input, [-1, 0, 1], axis, output, modes[axis], cval, 0)
     axes = [ii for ii in range(input.ndim) if ii != axis]
     for ii in axes:
         correlate1d(output, [1, 1, 1], ii, output, modes[ii], cval, 0,)
-    return return_value
+    return output
 
 
 @docfiller
@@ -423,13 +423,13 @@ def sobel(input, axis=-1, output=None, mode="reflect", cval=0.0):
     """
     input = numpy.asarray(input)
     axis = _ni_support._check_axis(axis, input.ndim)
-    output, return_value = _ni_support._get_output(output, input)
+    output = _ni_support._get_output(output, input)
     modes = _ni_support._normalize_sequence(mode, input.ndim)
     correlate1d(input, [-1, 0, 1], axis, output, modes[axis], cval, 0)
     axes = [ii for ii in range(input.ndim) if ii != axis]
     for ii in axes:
         correlate1d(output, [1, 2, 1], ii, output, modes[ii], cval, 0)
-    return return_value
+    return output
 
 
 @docfiller
@@ -459,7 +459,7 @@ def generic_laplace(input, derivative2, output=None, mode="reflect",
     if extra_keywords is None:
         extra_keywords = {}
     input = numpy.asarray(input)
-    output, return_value = _ni_support._get_output(output, input)
+    output = _ni_support._get_output(output, input)
     axes = list(range(input.ndim))
     if len(axes) > 0:
         modes = _ni_support._normalize_sequence(mode, len(axes))
@@ -471,7 +471,7 @@ def generic_laplace(input, derivative2, output=None, mode="reflect",
             output += tmp
     else:
         output[...] = input[...]
-    return return_value
+    return output
 
 
 @docfiller
@@ -580,7 +580,7 @@ def generic_gradient_magnitude(input, derivative, output=None,
     if extra_keywords is None:
         extra_keywords = {}
     input = numpy.asarray(input)
-    output, return_value = _ni_support._get_output(output, input)
+    output = _ni_support._get_output(output, input)
     axes = list(range(input.ndim))
     if len(axes) > 0:
         modes = _ni_support._normalize_sequence(mode, len(axes))
@@ -596,7 +596,7 @@ def generic_gradient_magnitude(input, derivative, output=None,
         numpy.sqrt(output, output, casting='unsafe')
     else:
         output[...] = input[...]
-    return return_value
+    return output
 
 
 @docfiller
@@ -669,10 +669,10 @@ def _correlate_or_convolve(input, weights, output, mode, cval, origin,
             raise ValueError('invalid origin')
     if not weights.flags.contiguous:
         weights = weights.copy()
-    output, return_value = _ni_support._get_output(output, input)
+    output = _ni_support._get_output(output, input)
     mode = _ni_support._extend_mode_to_code(mode)
     _nd_image.correlate(input, weights, output, mode, cval, origins)
-    return return_value
+    return output
 
 
 @docfiller
@@ -859,13 +859,13 @@ def uniform_filter1d(input, size, axis=-1, output=None,
     axis = _ni_support._check_axis(axis, input.ndim)
     if size < 1:
         raise RuntimeError('incorrect filter size')
-    output, return_value = _ni_support._get_output(output, input)
+    output = _ni_support._get_output(output, input)
     if (size // 2 + origin < 0) or (size // 2 + origin >= size):
         raise ValueError('invalid origin')
     mode = _ni_support._extend_mode_to_code(mode)
     _nd_image.uniform_filter1d(input, size, axis, output, mode, cval,
                                origin)
-    return return_value
+    return output
 
 
 @docfiller
@@ -913,7 +913,7 @@ def uniform_filter(input, size=3, output=None, mode="reflect",
     >>> plt.show()
     """
     input = numpy.asarray(input)
-    output, return_value = _ni_support._get_output(output, input)
+    output = _ni_support._get_output(output, input)
     sizes = _ni_support._normalize_sequence(size, input.ndim)
     origins = _ni_support._normalize_sequence(origin, input.ndim)
     modes = _ni_support._normalize_sequence(mode, input.ndim)
@@ -927,7 +927,7 @@ def uniform_filter(input, size=3, output=None, mode="reflect",
             input = output
     else:
         output[...] = input[...]
-    return return_value
+    return output
 
 
 @docfiller
@@ -973,13 +973,13 @@ def minimum_filter1d(input, size, axis=-1, output=None,
     axis = _ni_support._check_axis(axis, input.ndim)
     if size < 1:
         raise RuntimeError('incorrect filter size')
-    output, return_value = _ni_support._get_output(output, input)
+    output = _ni_support._get_output(output, input)
     if (size // 2 + origin < 0) or (size // 2 + origin >= size):
         raise ValueError('invalid origin')
     mode = _ni_support._extend_mode_to_code(mode)
     _nd_image.min_or_max_filter1d(input, size, axis, output, mode, cval,
                                   origin, 1)
-    return return_value
+    return output
 
 
 @docfiller
@@ -1030,13 +1030,13 @@ def maximum_filter1d(input, size, axis=-1, output=None,
     axis = _ni_support._check_axis(axis, input.ndim)
     if size < 1:
         raise RuntimeError('incorrect filter size')
-    output, return_value = _ni_support._get_output(output, input)
+    output = _ni_support._get_output(output, input)
     if (size // 2 + origin < 0) or (size // 2 + origin >= size):
         raise ValueError('invalid origin')
     mode = _ni_support._extend_mode_to_code(mode)
     _nd_image.min_or_max_filter1d(input, size, axis, output, mode, cval,
                                   origin, 0)
-    return return_value
+    return output
 
 
 def _min_or_max_filter(input, size, footprint, structure, output, mode,
@@ -1066,7 +1066,7 @@ def _min_or_max_filter(input, size, footprint, structure, output, mode,
     input = numpy.asarray(input)
     if numpy.iscomplexobj(input):
         raise TypeError('Complex type not supported')
-    output, return_value = _ni_support._get_output(output, input)
+    output = _ni_support._get_output(output, input)
     origins = _ni_support._normalize_sequence(origin, input.ndim)
     if separable:
         sizes = _ni_support._normalize_sequence(size, input.ndim)
@@ -1101,7 +1101,7 @@ def _min_or_max_filter(input, size, footprint, structure, output, mode,
         mode = _ni_support._extend_mode_to_code(mode)
         _nd_image.min_or_max_filter(input, footprint, structure, output,
                                     mode, cval, origins, minimum)
-    return return_value
+    return output
 
 
 @docfiller
@@ -1224,11 +1224,11 @@ def _rank_filter(input, rank, size=None, footprint=None, output=None,
         return maximum_filter(input, None, footprint, output, mode, cval,
                               origins)
     else:
-        output, return_value = _ni_support._get_output(output, input)
+        output = _ni_support._get_output(output, input)
         mode = _ni_support._extend_mode_to_code(mode)
         _nd_image.rank_filter(input, rank, footprint, output, mode, cval,
                               origins)
-        return return_value
+        return output
 
 
 @docfiller
@@ -1418,7 +1418,7 @@ def generic_filter1d(input, function, filter_size, axis=-1,
     input = numpy.asarray(input)
     if numpy.iscomplexobj(input):
         raise TypeError('Complex type not supported')
-    output, return_value = _ni_support._get_output(output, input)
+    output = _ni_support._get_output(output, input)
     if filter_size < 1:
         raise RuntimeError('invalid filter size')
     axis = _ni_support._check_axis(axis, input.ndim)
@@ -1429,7 +1429,7 @@ def generic_filter1d(input, function, filter_size, axis=-1,
     _nd_image.generic_filter1d(input, function, filter_size, axis, output,
                                mode, cval, origin, extra_arguments,
                                extra_keywords)
-    return return_value
+    return output
 
 
 @docfiller
@@ -1507,8 +1507,8 @@ def generic_filter(input, function, size=None, footprint=None,
             raise ValueError('invalid origin')
     if not footprint.flags.contiguous:
         footprint = footprint.copy()
-    output, return_value = _ni_support._get_output(output, input)
+    output = _ni_support._get_output(output, input)
     mode = _ni_support._extend_mode_to_code(mode)
     _nd_image.generic_filter(input, function, footprint, output, mode,
                              cval, origins, extra_arguments, extra_keywords)
-    return return_value
+    return output

--- a/scipy/ndimage/fourier.py
+++ b/scipy/ndimage/fourier.py
@@ -45,18 +45,14 @@ def _get_output_fourier(output, input):
             output = numpy.zeros(input.shape, dtype=input.dtype)
         else:
             output = numpy.zeros(input.shape, dtype=numpy.float64)
-        return_value = output
     elif type(output) is type:
         if output not in [numpy.complex64, numpy.complex128,
                           numpy.float32, numpy.float64]:
             raise RuntimeError("output type not supported")
         output = numpy.zeros(input.shape, dtype=output)
-        return_value = output
-    else:
-        if output.shape != input.shape:
-            raise RuntimeError("output shape not correct")
-        return_value = None
-    return output, return_value
+    elif output.shape != input.shape:
+        raise RuntimeError("output shape not correct")
+    return output
 
 
 def _get_output_fourier_complex(output, input):
@@ -65,17 +61,13 @@ def _get_output_fourier_complex(output, input):
             output = numpy.zeros(input.shape, dtype=input.dtype)
         else:
             output = numpy.zeros(input.shape, dtype=numpy.complex128)
-        return_value = output
     elif type(output) is type:
         if output not in [numpy.complex64, numpy.complex128]:
             raise RuntimeError("output type not supported")
         output = numpy.zeros(input.shape, dtype=output)
-        return_value = output
-    else:
-        if output.shape != input.shape:
-            raise RuntimeError("output shape not correct")
-        return_value = None
-    return output, return_value
+    elif output.shape != input.shape:
+        raise RuntimeError("output shape not correct")
+    return output
 
 
 def fourier_gaussian(input, sigma, n=-1, axis=-1, output=None):
@@ -107,9 +99,8 @@ def fourier_gaussian(input, sigma, n=-1, axis=-1, output=None):
 
     Returns
     -------
-    fourier_gaussian : ndarray or None
-        The filtered input. If `output` is given as a parameter, None is
-        returned.
+    fourier_gaussian : ndarray
+        The filtered input.
 
     Examples
     --------
@@ -127,7 +118,7 @@ def fourier_gaussian(input, sigma, n=-1, axis=-1, output=None):
     >>> plt.show()
     """
     input = numpy.asarray(input)
-    output, return_value = _get_output_fourier(output, input)
+    output = _get_output_fourier(output, input)
     axis = _ni_support._check_axis(axis, input.ndim)
     sigmas = _ni_support._normalize_sequence(sigma, input.ndim)
     sigmas = numpy.asarray(sigmas, dtype=numpy.float64)
@@ -135,7 +126,7 @@ def fourier_gaussian(input, sigma, n=-1, axis=-1, output=None):
         sigmas = sigmas.copy()
 
     _nd_image.fourier_filter(input, sigmas, n, axis, output, 0)
-    return return_value
+    return output
 
 
 def fourier_uniform(input, size, n=-1, axis=-1, output=None):
@@ -167,9 +158,8 @@ def fourier_uniform(input, size, n=-1, axis=-1, output=None):
 
     Returns
     -------
-    fourier_uniform : ndarray or None
-        The filtered input. If `output` is given as a parameter, None is
-        returned.
+    fourier_uniform : ndarray
+        The filtered input.
 
     Examples
     --------
@@ -187,14 +177,14 @@ def fourier_uniform(input, size, n=-1, axis=-1, output=None):
     >>> plt.show()
     """
     input = numpy.asarray(input)
-    output, return_value = _get_output_fourier(output, input)
+    output = _get_output_fourier(output, input)
     axis = _ni_support._check_axis(axis, input.ndim)
     sizes = _ni_support._normalize_sequence(size, input.ndim)
     sizes = numpy.asarray(sizes, dtype=numpy.float64)
     if not sizes.flags.contiguous:
         sizes = sizes.copy()
     _nd_image.fourier_filter(input, sizes, n, axis, output, 1)
-    return return_value
+    return output
 
 
 def fourier_ellipsoid(input, size, n=-1, axis=-1, output=None):
@@ -226,9 +216,8 @@ def fourier_ellipsoid(input, size, n=-1, axis=-1, output=None):
 
     Returns
     -------
-    fourier_ellipsoid : ndarray or None
-        The filtered input. If `output` is given as a parameter, None is
-        returned.
+    fourier_ellipsoid : ndarray
+        The filtered input.
 
     Notes
     -----
@@ -250,14 +239,14 @@ def fourier_ellipsoid(input, size, n=-1, axis=-1, output=None):
     >>> plt.show()
     """
     input = numpy.asarray(input)
-    output, return_value = _get_output_fourier(output, input)
+    output = _get_output_fourier(output, input)
     axis = _ni_support._check_axis(axis, input.ndim)
     sizes = _ni_support._normalize_sequence(size, input.ndim)
     sizes = numpy.asarray(sizes, dtype=numpy.float64)
     if not sizes.flags.contiguous:
         sizes = sizes.copy()
     _nd_image.fourier_filter(input, sizes, n, axis, output, 2)
-    return return_value
+    return output
 
 
 def fourier_shift(input, shift, n=-1, axis=-1, output=None):
@@ -288,9 +277,8 @@ def fourier_shift(input, shift, n=-1, axis=-1, output=None):
 
     Returns
     -------
-    fourier_shift : ndarray or None
-        The shifted input. If `output` is given as a parameter, None is
-        returned.
+    fourier_shift : ndarray
+        The shifted input.
 
     Examples
     --------
@@ -308,11 +296,11 @@ def fourier_shift(input, shift, n=-1, axis=-1, output=None):
     >>> plt.show()
     """
     input = numpy.asarray(input)
-    output, return_value = _get_output_fourier_complex(output, input)
+    output = _get_output_fourier_complex(output, input)
     axis = _ni_support._check_axis(axis, input.ndim)
     shifts = _ni_support._normalize_sequence(shift, input.ndim)
     shifts = numpy.asarray(shifts, dtype=numpy.float64)
     if not shifts.flags.contiguous:
         shifts = shifts.copy()
     _nd_image.fourier_shift(input, shifts, n, axis, output)
-    return return_value
+    return output

--- a/scipy/ndimage/interpolation.py
+++ b/scipy/ndimage/interpolation.py
@@ -64,9 +64,8 @@ def spline_filter1d(input, order=3, axis=-1, output=numpy.float64):
 
     Returns
     -------
-    spline_filter1d : ndarray or None
-        The filtered input. If `output` is given as a parameter, None is
-        returned.
+    spline_filter1d : ndarray
+        The filtered input.
 
     """
     if order < 0 or order > 5:
@@ -74,13 +73,13 @@ def spline_filter1d(input, order=3, axis=-1, output=numpy.float64):
     input = numpy.asarray(input)
     if numpy.iscomplexobj(input):
         raise TypeError('Complex type not supported')
-    output, return_value = _ni_support._get_output(output, input)
+    output = _ni_support._get_output(output, input)
     if order in [0, 1]:
         output[...] = numpy.array(input)
     else:
         axis = _ni_support._check_axis(axis, input.ndim)
         _nd_image.spline_filter1d(input, order, axis, output)
-    return return_value
+    return output
 
 
 def spline_filter(input, order=3, output=numpy.float64):
@@ -107,14 +106,14 @@ def spline_filter(input, order=3, output=numpy.float64):
     input = numpy.asarray(input)
     if numpy.iscomplexobj(input):
         raise TypeError('Complex type not supported')
-    output, return_value = _ni_support._get_output(output, input)
+    output = _ni_support._get_output(output, input)
     if order not in [0, 1] and input.ndim > 0:
         for axis in range(input.ndim):
             spline_filter1d(input, order, axis, output=output)
             input = output
     else:
         output[...] = input[...]
-    return return_value
+    return output
 
 
 def geometric_transform(input, mapping, output_shape=None,
@@ -164,9 +163,8 @@ def geometric_transform(input, mapping, output_shape=None,
 
     Returns
     -------
-    return_value : ndarray or None
-        The filtered input. If `output` is given as a parameter, None is
-        returned.
+    output : ndarray
+        The filtered input.
 
     See Also
     --------
@@ -246,12 +244,12 @@ def geometric_transform(input, mapping, output_shape=None,
         filtered = spline_filter(input, order, output=numpy.float64)
     else:
         filtered = input
-    output, return_value = _ni_support._get_output(output, input,
+    output = _ni_support._get_output(output, input,
                                                    shape=output_shape)
     _nd_image.geometric_transform(filtered, mapping, None, None, None, output,
                                   order, mode, cval, extra_arguments,
                                   extra_keywords)
-    return return_value
+    return output
 
 
 def map_coordinates(input, coordinates, output=None, order=3,
@@ -346,11 +344,11 @@ def map_coordinates(input, coordinates, output=None, order=3,
         filtered = spline_filter(input, order, output=numpy.float64)
     else:
         filtered = input
-    output, return_value = _ni_support._get_output(output, input,
+    output = _ni_support._get_output(output, input,
                                                    shape=output_shape)
     _nd_image.geometric_transform(filtered, None, coordinates, None, None,
                                   output, order, mode, cval, None, None)
-    return return_value
+    return output
 
 
 def affine_transform(input, matrix, offset=0.0, output_shape=None,
@@ -414,9 +412,8 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None,
 
     Returns
     -------
-    affine_transform : ndarray or None
-        The transformed input. If `output` is given as a parameter, None is
-        returned.
+    affine_transform : ndarray
+        The transformed input.
 
     Notes
     -----
@@ -453,7 +450,7 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None,
         filtered = spline_filter(input, order, output=numpy.float64)
     else:
         filtered = input
-    output, return_value = _ni_support._get_output(output, input,
+    output = _ni_support._get_output(output, input,
                                                    shape=output_shape)
     matrix = numpy.asarray(matrix, dtype=numpy.float64)
     if matrix.ndim not in [1, 2] or matrix.shape[0] < 1:
@@ -493,7 +490,7 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None,
     else:
         _nd_image.geometric_transform(filtered, None, None, matrix, offset,
                                       output, order, mode, cval, None, None)
-    return return_value
+    return output
 
 
 def shift(input, shift, output=None, order=3, mode='constant', cval=0.0,
@@ -533,9 +530,8 @@ def shift(input, shift, output=None, order=3, mode='constant', cval=0.0,
 
     Returns
     -------
-    shift : ndarray or None
-        The shifted input. If `output` is given as a parameter, None is
-        returned.
+    shift : ndarray
+        The shifted input.
 
     """
     if order < 0 or order > 5:
@@ -550,14 +546,14 @@ def shift(input, shift, output=None, order=3, mode='constant', cval=0.0,
         filtered = spline_filter(input, order, output=numpy.float64)
     else:
         filtered = input
-    output, return_value = _ni_support._get_output(output, input)
+    output = _ni_support._get_output(output, input)
     shift = _ni_support._normalize_sequence(shift, input.ndim)
     shift = [-ii for ii in shift]
     shift = numpy.asarray(shift, dtype=numpy.float64)
     if not shift.flags.contiguous:
         shift = shift.copy()
     _nd_image.zoom_shift(filtered, None, shift, output, order, mode, cval)
-    return return_value
+    return output
 
 
 def zoom(input, zoom, output=None, order=3, mode='constant', cval=0.0,
@@ -595,9 +591,8 @@ def zoom(input, zoom, output=None, order=3, mode='constant', cval=0.0,
 
     Returns
     -------
-    zoom : ndarray or None
-        The zoomed input. If `output` is given as a parameter, None is
-        returned.
+    zoom : ndarray
+        The zoomed input.
 
     Examples
     --------
@@ -650,11 +645,11 @@ def zoom(input, zoom, output=None, order=3, mode='constant', cval=0.0,
                         out=numpy.ones_like(input.shape, dtype=numpy.float64),
                         where=zoom_div != 0)
 
-    output, return_value = _ni_support._get_output(output, input,
+    output = _ni_support._get_output(output, input,
                                                    shape=output_shape)
     zoom = numpy.ascontiguousarray(zoom)
     _nd_image.zoom_shift(filtered, zoom, None, output, order, mode, cval)
-    return return_value
+    return output
 
 
 def _minmax(coor, minc, maxc):
@@ -711,9 +706,8 @@ def rotate(input, angle, axes=(1, 0), reshape=True,
 
     Returns
     -------
-    rotate : ndarray or None
-        The rotated input. If `output` is given as a parameter, None is
-        returned.
+    rotate : ndarray
+        The rotated input.
 
     """
     input = numpy.asarray(input)
@@ -764,7 +758,7 @@ def rotate(input, angle, axes=(1, 0), reshape=True,
     output_shape[axes[0]] = oy
     output_shape[axes[1]] = ox
     output_shape = tuple(output_shape)
-    output, return_value = _ni_support._get_output(output, input,
+    output = _ni_support._get_output(output, input,
                                                    shape=output_shape)
     if input.ndim <= 2:
         affine_transform(input, matrix, offset, output_shape, output,
@@ -795,4 +789,4 @@ def rotate(input, angle, axes=(1, 0), reshape=True,
                     break
                 else:
                     coordinates[jj] = 0
-    return return_value
+    return output

--- a/scipy/ndimage/measurements.py
+++ b/scipy/ndimage/measurements.py
@@ -1462,6 +1462,6 @@ def watershed_ift(input, markers, structure=None, output=None):
     else:
         output = markers.dtype
 
-    output, return_value = _ni_support._get_output(output, input)
+    output = _ni_support._get_output(output, input)
     _nd_image.watershed_ift(input, markers, structure, output)
-    return return_value
+    return output

--- a/scipy/ndimage/morphology.py
+++ b/scipy/ndimage/morphology.py
@@ -237,12 +237,12 @@ def _binary_erosion(input, structure, iterations, mask, output,
             raise TypeError('Complex output type not supported')
     else:
         output = bool
-    output, return_value = _ni_support._get_output(output, input)
+    output = _ni_support._get_output(output, input)
 
     if iterations == 1:
         _nd_image.binary_erosion(input, structure, mask, output,
                                  border_value, origin, invert, cit, 0)
-        return return_value
+        return output
     elif cit and not brute_force:
         changed, coordinate_list = _nd_image.binary_erosion(
             input, structure, mask, output,
@@ -259,27 +259,25 @@ def _binary_erosion(input, structure, iterations, mask, output,
             structure = structure.copy()
         _nd_image.binary_erosion2(output, structure, mask, iterations - 1,
                                   origin, invert, coordinate_list)
-        return return_value
+        return output
     else:
-        tmp_in = numpy.zeros(input.shape, bool)
-        if return_value is None:
-            tmp_out = output
-        else:
-            tmp_out = numpy.zeros(input.shape, bool)
-        if not iterations & 1:
+        tmp_in = np.empty_like(input, dtype=bool)
+        tmp_out = output
+        if iterations >= 1 and not iterations & 1:
             tmp_in, tmp_out = tmp_out, tmp_in
         changed = _nd_image.binary_erosion(
             input, structure, mask, tmp_out,
             border_value, origin, invert, cit, 0)
         ii = 1
-        while (ii < iterations) or (iterations < 1) and changed:
+        while ii < iterations or (iteration < 1 and changed):
             tmp_in, tmp_out = tmp_out, tmp_in
             changed = _nd_image.binary_erosion(
                 tmp_in, structure, mask, tmp_out,
                 border_value, origin, invert, cit, 0)
             ii += 1
-        if return_value is not None:
-            return tmp_out
+        if tmp_out is not output:
+            output[:] = tmp_out
+        return output
 
 
 def binary_erosion(input, structure=None, iterations=1, mask=None, output=None,

--- a/scipy/ndimage/morphology.py
+++ b/scipy/ndimage/morphology.py
@@ -275,8 +275,6 @@ def _binary_erosion(input, structure, iterations, mask, output,
                 tmp_in, structure, mask, tmp_out,
                 border_value, origin, invert, cit, 0)
             ii += 1
-        if tmp_out is not output:
-            output[:] = tmp_out
         return output
 
 

--- a/scipy/ndimage/morphology.py
+++ b/scipy/ndimage/morphology.py
@@ -261,7 +261,7 @@ def _binary_erosion(input, structure, iterations, mask, output,
                                   origin, invert, coordinate_list)
         return output
     else:
-        tmp_in = np.empty_like(input, dtype=bool)
+        tmp_in = numpy.empty_like(input, dtype=bool)
         tmp_out = output
         if iterations >= 1 and not iterations & 1:
             tmp_in, tmp_out = tmp_out, tmp_in
@@ -269,7 +269,7 @@ def _binary_erosion(input, structure, iterations, mask, output,
             input, structure, mask, tmp_out,
             border_value, origin, invert, cit, 0)
         ii = 1
-        while ii < iterations or (iteration < 1 and changed):
+        while ii < iterations or (iterations < 1 and changed):
             tmp_in, tmp_out = tmp_out, tmp_in
             changed = _nd_image.binary_erosion(
                 tmp_in, structure, mask, tmp_out,

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -3519,6 +3519,19 @@ class TestNdimage:
                                      border_value=1, origin=(-1, -1))
         assert_array_almost_equal(out, expected)
 
+    def test_binary_erosion37(self):
+        a = numpy.array([[1, 0, 1],
+                         [0, 1, 0],
+                         [1, 0, 1]], dtype=bool)
+        b = numpy.zeros_like(a)
+        out = ndimage.binary_erosion(a, structure=a, output=b, iterations=0,
+                                     border_value=True, brute_force=True)
+        assert_(out is b)
+        assert_array_equal(
+            ndimage.binary_erosion(a, structure=a, iterations=0,
+                                   border_value=True),
+            b)
+
     def test_binary_dilation01(self):
         for type_ in self.types:
             data = numpy.ones([], type_)


### PR DESCRIPTION
Simplifies the return value of ndimage functions, so that the `output` array is always returned, instead of the awkward current behavior, where many (but not all) functions only return the `output` array if it has been allocated by the function, and return `None` if it has been passed by the user through the `output=` keyword argument.