### PR TITLE
MAINT: bench nelder-mead, slow func evaluations

### DIFF
--- a/benchmarks/benchmarks/test_functions.py
+++ b/benchmarks/benchmarks/test_functions.py
@@ -1,6 +1,9 @@
 from __future__ import division
+import time
+
 import numpy as np
 from numpy import sin, cos, pi, exp, sqrt, abs
+from scipy.optimize import rosen
 
 
 class SimpleQuadratic(object):
@@ -27,6 +30,13 @@ class AsymmetricQuadratic(object):
 
     def hess(self, x):
         return 2. * np.eye(x.size)
+
+
+class SlowRosen(object):
+
+    def fun(self, x):
+        time.sleep(50e-6)
+        return rosen(x)
 
 
 class LJ(object):


### PR DESCRIPTION
This PR adds nelder-mead, L-BFGS-B, and BFGS to `fonly_methods` in the optimizer benchmarks. The purpose of this is to examine solver performance when numerical differentiation is used.`

Two new benchmarks are added:

`rosenbrock_nograd` - rosenbrock function with no gradient
`rosenbrock_slow` -   has a 50us delay on each function evaluation. By comparing to rosenbrock_nograd it should be possible to figure out how much time a minimizer uses internally, compared to the time required for function evaluation.