### PR TITLE
MAINT: hide symbols on Linux when using GNU linker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -165,6 +165,8 @@ script:
   - python -u $OPTIMIZE runtests.py -g -m $TESTMODE $COVERAGE $USE_WHEEL_BUILD -- -rfEX -n 3 2>&1 | tee runtests.log
   - tools/validate_runtests_log.py $TESTMODE < runtests.log
   - if [ "${REFGUIDE_CHECK}" == "1" ]; then python runtests.py -g --refguide-check; fi
+  # Check dynamic symbol hiding works on Linux
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./tools/check_pyext_symbol_hiding.sh build; fi
 after_script:
   - ccache -s
   # Upload coverage information

--- a/benchmarks/benchmarks/integrate.py
+++ b/benchmarks/benchmarks/integrate.py
@@ -91,11 +91,15 @@ class Quad(Benchmark):
         self.f_python = lambda x: sin(x)
         self.f_cython = from_cython(_ccallback_c, "sine")
 
-        lib = ctypes.CDLL(clib_test.__file__)
-
-        self.f_ctypes = lib._multivariate_sin
-        self.f_ctypes.restype = ctypes.c_double
-        self.f_ctypes.argtypes = (ctypes.c_int, ctypes.c_double)  # sic -- for backward compat
+        try:
+            from scipy.integrate.tests.test_quadpack import get_clib_test_routine
+            self.f_ctypes = get_clib_test_routine('_multivariate_sin', ctypes.c_double,
+                                                  ctypes.c_int, ctypes.c_double)
+        except ImportError:
+            lib = ctypes.CDLL(clib_test.__file__)
+            self.f_ctypes = lib._multivariate_sin
+            self.f_ctypes.restype = ctypes.c_double
+            self.f_ctypes.argtypes = (ctypes.c_int, ctypes.c_double)
 
         if cffi is not None:
             voidp = ctypes.cast(self.f_ctypes, ctypes.c_void_p)

--- a/scipy/integrate/tests/_test_multivariate.c
+++ b/scipy/integrate/tests/_test_multivariate.c
@@ -1,71 +1,101 @@
 #include <Python.h>
 
-/*
-  Backwards compatibility:
-  Python2.2 used LONG_LONG instead of PY_LONG_LONG
-*/
-#if defined(HAVE_LONG_LONG) && !defined(PY_LONG_LONG)
-#define PY_LONG_LONG LONG_LONG
-#endif
-
-#ifdef MS_WIN32
-#include <windows.h>
-#endif
-
-#if defined(MS_WIN32) || defined(__CYGWIN__)
-#define EXPORT(x) __declspec(dllexport) x
-#else
-#define EXPORT(x) x
-#endif
-
 #include "math.h"
+
 const double PI = 3.141592653589793238462643383279502884;
-EXPORT(double)
+
+static double
 _multivariate_typical(int n, double *args)
 {
     return cos(args[1] * args[0] - args[2] * sin(args[0])) / PI;
 }
 
-EXPORT(double)
+static double
 _multivariate_indefinite(int n, double *args)
 {
     return -exp(-args[0]) * log(args[0]);
 }
 
-EXPORT(double)
+static double
 _multivariate_sin(int n, double *args)
 {
     return sin(args[0]);
 }
 
-EXPORT(double)
+static double
 _sin_0(double x, void *user_data)
 {
     return sin(x);
 }
 
-EXPORT(double)
+static double
 _sin_1(int ndim, double *x, void *user_data)
 {
     return sin(x[0]);
 }
 
-EXPORT(double)
+static double
 _sin_2(double x)
 {
     return sin(x);
 }
 
-EXPORT(double)
+static double
 _sin_3(int ndim, double *x)
 {
     return sin(x[0]);
 }
 
-/*
-  This won't allow you to actually use the methods here. It just
-  lets you load the module so you can get at the __file__ attribute.
-*/
+
+typedef struct {
+    char *name;
+    void *ptr;
+} routine_t;
+
+
+static const routine_t routines[] = {
+    {"_multivariate_typical", &_multivariate_typical},
+    {"_multivariate_indefinite", &_multivariate_indefinite},
+    {"_multivariate_sin", &_multivariate_sin},
+    {"_sin_0", &_sin_0},
+    {"_sin_1", &_sin_1},
+    {"_sin_2", &_sin_2},
+    {"_sin_3", &_sin_3}
+};
+
+
+static int create_capsules(PyObject *module)
+{
+    PyObject *d, *capsule = NULL;
+    int i;
+
+    d = PyModule_GetDict(module);
+    if (d == NULL) {
+        goto fail;
+    }
+
+    for (i = 0; i < sizeof(routines) / sizeof(routine_t); ++i) {
+        capsule = PyCapsule_New(routines[i].ptr, NULL, NULL);
+        if (capsule == NULL) {
+            goto fail;
+        }
+
+        if (PyDict_SetItemString(d, routines[i].name, capsule)) {
+            goto fail;
+        }
+
+        Py_DECREF(capsule);
+        capsule = NULL;
+    }
+
+    Py_XDECREF(capsule);
+    return 0;
+
+fail:
+    Py_XDECREF(capsule);
+    return -1;
+}
+
 
 #if PY_MAJOR_VERSION >= 3
 static struct PyModuleDef moduledef = {
@@ -83,7 +113,16 @@ static struct PyModuleDef moduledef = {
 PyMODINIT_FUNC
 PyInit__test_multivariate(void)
 {
-    return PyModule_Create(&moduledef);
+    PyObject *m;
+    m = PyModule_Create(&moduledef);
+    if (m == NULL) {
+        return NULL;
+    }
+    if (create_capsules(m)) {
+        Py_DECREF(m);
+        return NULL;
+    }
+    return m;
 }
 
 #else
@@ -91,6 +130,11 @@ PyInit__test_multivariate(void)
 PyMODINIT_FUNC
 init_test_multivariate(void)
 {
-    Py_InitModule("_test_multivariate", NULL);
+    PyObject *m;
+    m = Py_InitModule("_test_multivariate", NULL);
+    if (m == NULL) {
+        return;
+    }
+    create_capsules(m);
 }
 #endif

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ import sys
 import subprocess
 import textwrap
 import warnings
+import sysconfig
 
 
 if sys.version_info[:2] < (2, 7) or (3, 0) <= sys.version_info[:2] < (3, 4):
@@ -190,6 +191,52 @@ class sdist_checked(sdist):
     def run(self):
         check_submodules()
         sdist.run(self)
+
+
+def get_build_ext_override():
+    """
+    Custom build_ext command to tweak extension building.
+    """
+    from numpy.distutils.command.build_ext import build_ext as old_build_ext
+
+    class build_ext(old_build_ext):
+        def build_extension(self, ext):
+            # When compiling with GNU compilers, use a version script to
+            # hide symbols during linking.
+            if self.__is_using_gnu_linker(ext):
+                export_symbols = self.get_export_symbols(ext)
+                text = '{global: %s; local: *; };' % (';'.join(export_symbols),)
+
+                script_fn = os.path.join(self.build_temp, 'link-version-{}.map'.format(ext.name))
+                with open(script_fn, 'w') as f:
+                    f.write(text)
+                    ext.extra_link_args.append('-Wl,--version-script=' + script_fn)
+
+            old_build_ext.build_extension(self, ext)
+
+        def __is_using_gnu_linker(self, ext):
+            if not sys.platform.startswith('linux'):
+                return False
+
+            # Fortran compilation with gfortran uses it also for
+            # linking. For the C compiler, we detect gcc in a similar
+            # way as distutils does it in
+            # UnixCCompiler.runtime_library_dir_option
+            if ext.language == 'f90':
+                is_gcc = (self._f90_compiler.compiler_type in ('gnu', 'gnu95'))
+            elif ext.language == 'f77':
+                is_gcc = (self._f77_compiler.compiler_type in ('gnu', 'gnu95'))
+            else:
+                is_gcc = False
+                if self.compiler.compiler_type == 'unix':
+                    cc = sysconfig.get_config_var("CC")
+                    if not cc:
+                        cc = ""
+                    compiler_name = os.path.basename(cc)
+                    is_gcc = "gcc" in compiler_name or "g++" in compiler_name
+            return is_gcc and sysconfig.get_config_var('GNULD') == 'yes'
+
+    return build_ext
 
 
 def generate_cython():
@@ -393,6 +440,10 @@ def setup_package():
 
     if run_build:
         from numpy.distutils.core import setup
+
+        # Customize extension building
+        cmdclass['build_ext'] = get_build_ext_override()
+
         cwd = os.path.abspath(os.path.dirname(__file__))
         if not os.path.exists(os.path.join(cwd, 'PKG-INFO')):
             # Generate Cython sources, unless building from source release

--- a/tools/check_pyext_symbol_hiding.sh
+++ b/tools/check_pyext_symbol_hiding.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# check_pyext_symbol_hiding.sh PATHS...
+#
+# Check that .so files under the given directories export only a
+# single public dynamic symbol each.
+#
+
+set -e
+
+count_text_symbols() {
+    nm -D --defined-only "$1" | wc -l
+}
+
+check_symbols() {
+    NUM=`count_text_symbols "$1"`
+    if [[ "$NUM" != "1" ]]; then
+        echo "$1: too many public symbols!"
+        nm -D --defined-only "$1"
+        exit 1
+    fi
+}
+
+find "$@" -type f -name '*.so' -print | while read F; do
+    check_symbols "$F"
+done
+
+echo "Symbol hiding OK"
+exit 0


### PR DESCRIPTION
Hide unnecessary symbols in .so libraries, using a GNU linker version script on linux.

This is a general solution to the discussion in https://github.com/scipy/scipy/pull/8451

Overriding the distutils logic by a custom build_ext seemed the cleanest option. The logic of detecting when a GNU linker is similar to what distutils does internally, didn't find a nicer way and this information doesn't seem to be available otherwise.

There was a testing module `scipy.integrate._test_multivariate` that tried to look up some test symbols with ctypes --- rewrote that to use a different approach.

This may also work on OSX, but I'll leave that to someone else.
(Windows already does something like this in standard Python distutils with MSVC, so no changes necessary for that platform.)