### PR TITLE
ENH: in scipy.sparse.linalg.norm implement spectral norm

### DIFF
--- a/scipy/sparse/linalg/_norm.py
+++ b/scipy/sparse/linalg/_norm.py
@@ -162,7 +162,7 @@ def norm(x, ord=None, axis=None):
         elif ord == 'spec':
             from scipy.sparse import csc_matrix 
             from scipy.sparse.linalg import svds, eigs
-            x = csr_matrix(x, dtype=float)
+            x = csc_matrix(x, dtype=float)
             u, s, vt = svds(x, k=1)
             return s[0]
         else:
@@ -180,7 +180,7 @@ def norm(x, ord=None, axis=None):
             # Spectral norm
             from scipy.sparse import csc_matrix 
             from scipy.sparse.linalg import svds, eigs
-            x = csr_matrix(x, dtype=float)
+            x = csc_matrix(x, dtype=float)
             u, s, vt = svds(x, k=1)
             return s[0]
         elif ord == 0:

--- a/scipy/sparse/linalg/_norm.py
+++ b/scipy/sparse/linalg/_norm.py
@@ -58,7 +58,8 @@ def norm(x, ord=None, axis=None):
     ord    norm for sparse matrices             
     =====  ============================  
     None   Frobenius norm                
-    'fro'  Frobenius norm                
+    'fro'  Frobenius norm
+    'spec' Spectral norm                
     inf    max(sum(abs(x), axis=1))      
     -inf   min(sum(abs(x), axis=1))      
     0      abs(x).sum(axis=axis)                           
@@ -72,6 +73,8 @@ def norm(x, ord=None, axis=None):
     The Frobenius norm is given by [1]_:
 
         :math:`||A||_F = [\\sum_{i,j} abs(a_{i,j})^2]^{1/2}`
+    
+    The Spectral norm is just the largest singular value.
 
     References
     ----------
@@ -105,6 +108,8 @@ def norm(x, ord=None, axis=None):
     7
     >>> norm(b, -1)
     6
+    >>> norm(b, 'spec')
+    7.3484692283495345
 
     """
     if not issparse(x):
@@ -154,6 +159,12 @@ def norm(x, ord=None, axis=None):
         elif ord in (None, 'f', 'fro'):
             # The axis order does not matter for this norm.
             return _sparse_frobenius_norm(x)
+        elif ord == 'spec':
+            from scipy.sparse import csc_matrix 
+            from scipy.sparse.linalg import svds, eigs
+            x = csr_matrix(x, dtype=float)
+            u, s, vt = svds(x, k=1)
+            return s[0]
         else:
             raise ValueError("Invalid norm order for matrices.")
     elif len(axis) == 1:
@@ -165,6 +176,13 @@ def norm(x, ord=None, axis=None):
             M = abs(x).max(axis=a)
         elif ord == -Inf:
             M = abs(x).min(axis=a)
+        elif ord == 'spec':
+            # Spectral norm
+            from scipy.sparse import csc_matrix 
+            from scipy.sparse.linalg import svds, eigs
+            x = csr_matrix(x, dtype=float)
+            u, s, vt = svds(x, k=1)
+            return s[0]
         elif ord == 0:
             # Zero norm
             M = (x != 0).sum(axis=a)

--- a/scipy/sparse/linalg/_norm.py
+++ b/scipy/sparse/linalg/_norm.py
@@ -65,7 +65,7 @@ def norm(x, ord=None, axis=None):
     0      abs(x).sum(axis=axis)                           
     1      max(sum(abs(x), axis=0))      
     -1     min(sum(abs(x), axis=0))      
-    2      Not implemented  
+    2      Spectral norm  
     -2     Not implemented      
     other  Not implemented                               
     =====  ============================  
@@ -110,6 +110,8 @@ def norm(x, ord=None, axis=None):
     6
     >>> norm(b, 'spec')
     7.3484692283495345
+    >>> norm(b, 2)
+    7.3484692283495345
 
     """
     if not issparse(x):
@@ -142,9 +144,11 @@ def norm(x, ord=None, axis=None):
                              (axis, x.shape))
         if row_axis % nd == col_axis % nd:
             raise ValueError('Duplicate axes given.')
-        if ord == 2:
-            raise NotImplementedError
-            #return _multi_svd_norm(x, row_axis, col_axis, amax)
+        if ord in (2, 'spec'):
+            # spectral norm
+            from scipy.sparse.linalg import svds
+            u, s, vt = svds(x, k=1)
+            return s[0]
         elif ord == -2:
             raise NotImplementedError
             #return _multi_svd_norm(x, row_axis, col_axis, amin)
@@ -159,12 +163,6 @@ def norm(x, ord=None, axis=None):
         elif ord in (None, 'f', 'fro'):
             # The axis order does not matter for this norm.
             return _sparse_frobenius_norm(x)
-        elif ord == 'spec':
-            from scipy.sparse import csc_matrix 
-            from scipy.sparse.linalg import svds, eigs
-            x = csc_matrix(x, dtype=float)
-            u, s, vt = svds(x, k=1)
-            return s[0]
         else:
             raise ValueError("Invalid norm order for matrices.")
     elif len(axis) == 1:
@@ -178,9 +176,7 @@ def norm(x, ord=None, axis=None):
             M = abs(x).min(axis=a)
         elif ord == 'spec':
             # Spectral norm
-            from scipy.sparse import csc_matrix 
-            from scipy.sparse.linalg import svds, eigs
-            x = csc_matrix(x, dtype=float)
+            from scipy.sparse.linalg import svds
             u, s, vt = svds(x, k=1)
             return s[0]
         elif ord == 0:

--- a/scipy/sparse/linalg/_norm.py
+++ b/scipy/sparse/linalg/_norm.py
@@ -54,21 +54,21 @@ def norm(x, ord=None, axis=None):
 
     The following norms can be calculated:
 
-    =====  ============================  
-    ord    norm for sparse matrices             
-    =====  ============================  
-    None   Frobenius norm                
-    'fro'  Frobenius norm
-    'spec' Spectral norm                
-    inf    max(sum(abs(x), axis=1))      
-    -inf   min(sum(abs(x), axis=1))      
-    0      abs(x).sum(axis=axis)                           
-    1      max(sum(abs(x), axis=0))      
-    -1     min(sum(abs(x), axis=0))      
-    2      Spectral norm  
-    -2     Not implemented      
-    other  Not implemented                               
-    =====  ============================  
+    ======  ============================  
+    ord     norm for sparse matrices             
+    ======  ============================  
+    None    Frobenius norm                
+    'fro'   Frobenius norm
+    'spec'  Spectral norm                
+    inf     max(sum(abs(x), axis=1))      
+    -inf    min(sum(abs(x), axis=1))      
+    0       abs(x).sum(axis=axis)                           
+    1       max(sum(abs(x), axis=0))      
+    -1      min(sum(abs(x), axis=0))      
+    2       Spectral norm  
+    -2      Not implemented      
+    other   Not implemented                               
+    ======  ============================  
 
     The Frobenius norm is given by [1]_:
 

--- a/scipy/sparse/linalg/_norm.py
+++ b/scipy/sparse/linalg/_norm.py
@@ -146,7 +146,9 @@ def norm(x, ord=None, axis=None):
             raise ValueError('Duplicate axes given.')
         if ord in (2, 'spec'):
             # spectral norm
+            from scipy.sparse import csc_matrix 
             from scipy.sparse.linalg import svds
+            x = csc_matrix(x, dtype=float)
             u, s, vt = svds(x, k=1)
             return s[0]
         elif ord == -2:
@@ -176,7 +178,9 @@ def norm(x, ord=None, axis=None):
             M = abs(x).min(axis=a)
         elif ord == 'spec':
             # Spectral norm
+            from scipy.sparse import csc_matrix 
             from scipy.sparse.linalg import svds
+            x = csc_matrix(x, dtype=float)
             u, s, vt = svds(x, k=1)
             return s[0]
         elif ord == 0:

--- a/scipy/sparse/linalg/tests/test_norm.py
+++ b/scipy/sparse/linalg/tests/test_norm.py
@@ -29,9 +29,10 @@ class TestNorm(object):
         assert_allclose(spnorm(self.b, -np.inf), 2)
         assert_allclose(spnorm(self.b, 1), 7)
         assert_allclose(spnorm(self.b, -1), 6)
+        assert_allclose(spnorm(self.b, 2), 7.348469228349534)
+        assert_allclose(spnorm(self.b, 'spec'), 7.348469228349534)
 
         # _multi_svd_norm is not implemented for sparse matrix
-        assert_raises(NotImplementedError, spnorm, self.b, 2)
         assert_raises(NotImplementedError, spnorm, self.b, -2)
 
     def test_matrix_norm_axis(self):


### PR DESCRIPTION
ENH: in scipy.sparse.linalg.norm implement spectral norm

Reference to: https://github.com/scipy/scipy/issues/7268