### PR TITLE
BUG: stats: fix skewnorm.cdf losing precision at large x

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -5401,6 +5401,9 @@ class skew_norm_gen(rv_continuous):
     def _pdf(self, x, a):
         return 2.*_norm_pdf(x)*_norm_cdf(a*x)
 
+    def _cdf(self, x, a):
+        return _norm_cdf(x) - 2*sc.owens_t(x, a)
+
     def _rvs(self, a):
         u0 = self._random_state.normal(size=self._size)
         v = self._random_state.normal(size=self._size)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1207,6 +1207,11 @@ class TestSkewNorm(object):
         computed = stats.skewnorm.stats(a=-4, loc=5, scale=2, moments='mvsk')
         assert_array_almost_equal(computed, expected, decimal=2)
 
+    def test_cdf_large_arg(self):
+        # gh-7746: cdf loses precision for large arguments
+        x = np.linspace(10, 50, 20)
+        assert_allclose(stats.skewnorm.cdf(x, -1), 1)
+
 
 class TestExpon(object):
     def test_zero(self):


### PR DESCRIPTION
Now that Owen's T function is available, can use it for the skew normal distribution.

closes https://github.com/scipy/scipy/issues/7746