### PR TITLE
TST: _lib: disable refcounting tests on PyPy

### DIFF
--- a/scipy/_lib/_gcutils.py
+++ b/scipy/_lib/_gcutils.py
@@ -11,10 +11,14 @@ Module for testing automatic garbage collection of objects
 """
 import weakref
 import gc
+import sys
 
 from contextlib import contextmanager
 
 __all__ = ['set_gc_state', 'gc_state', 'assert_deallocated']
+
+
+IS_PYPY = '__pypy__' in sys.modules
 
 
 class ReferenceError(AssertionError):
@@ -61,6 +65,8 @@ def assert_deallocated(func, *args, **kwargs):
     reference counting, without requiring gc to break reference cycles.
     GC is disabled inside the context manager.
 
+    This check is not available on PyPy.
+
     Parameters
     ----------
     func : callable
@@ -87,6 +93,9 @@ def assert_deallocated(func, *args, **kwargs):
         ...
     ReferenceError: Remaining reference(s) to object
     """
+    if IS_PYPY:
+        raise RuntimeError("assert_deallocated is unavailable on PyPy")
+
     with gc_state(False):
         obj = func(*args, **kwargs)
         ref = weakref.ref(obj)

--- a/scipy/_lib/tests/test__gcutils.py
+++ b/scipy/_lib/tests/test__gcutils.py
@@ -4,11 +4,13 @@ from __future__ import division, print_function, absolute_import
 
 import gc
 
-from scipy._lib._gcutils import set_gc_state, gc_state, assert_deallocated, ReferenceError
+from scipy._lib._gcutils import (set_gc_state, gc_state, assert_deallocated,
+                                 ReferenceError, IS_PYPY)
 
 from numpy.testing import assert_equal
 
 import pytest
+
 
 def test_set_gc_state():
     gc_status = gc.isenabled()
@@ -47,6 +49,7 @@ def test_gc_state():
             gc.enable()
 
 
+@pytest.mark.skipif(IS_PYPY, reason="Test not meaningful on PyPy")
 def test_assert_deallocated():
     # Ordinary use
     class C(object):
@@ -64,6 +67,7 @@ def test_assert_deallocated():
             assert_equal(gc.isenabled(), gc_current)
 
 
+@pytest.mark.skipif(IS_PYPY, reason="Test not meaningful on PyPy")
 def test_assert_deallocated_nodel():
     class C(object):
         pass
@@ -73,6 +77,7 @@ def test_assert_deallocated_nodel():
             pass
 
 
+@pytest.mark.skipif(IS_PYPY, reason="Test not meaningful on PyPy")
 def test_assert_deallocated_circular():
     class C(object):
         def __init__(self):
@@ -83,6 +88,7 @@ def test_assert_deallocated_circular():
             del c
 
 
+@pytest.mark.skipif(IS_PYPY, reason="Test not meaningful on PyPy")
 def test_assert_deallocated_circular2():
     class C(object):
         def __init__(self):

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -6,6 +6,7 @@ from numpy.testing import (assert_, assert_equal, assert_almost_equal,
         assert_array_almost_equal, assert_array_equal,
         assert_allclose)
 from pytest import raises as assert_raises
+import pytest
 
 from numpy import mgrid, pi, sin, ogrid, poly1d, linspace
 import numpy as np
@@ -22,7 +23,7 @@ from scipy.special import poch, gamma
 
 from scipy.interpolate import _ppoly
 
-from scipy._lib._gcutils import assert_deallocated
+from scipy._lib._gcutils import assert_deallocated, IS_PYPY
 
 from scipy.integrate import nquad
 
@@ -612,6 +613,7 @@ class TestInterp1D(object):
             self._check_complex(np.complex64, kind)
             self._check_complex(np.complex128, kind)
 
+    @pytest.mark.skipif(IS_PYPY, reason="Test not meaningful on PyPy")
     def test_circular_refs(self):
         # Test interp1d can be automatically garbage collected
         x = np.linspace(0, 1)

--- a/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
@@ -1,5 +1,6 @@
 from __future__ import division, print_function, absolute_import
 
+import sys
 import threading
 
 import numpy as np
@@ -546,6 +547,7 @@ class TestSplu(object):
         lu = splu(a_)
         assert_array_equal(lu.perm_r, lu.perm_c)
 
+    @pytest.mark.skipif(not hasattr(sys, 'getrefcount'), reason="no sys.getrefcount")
     def test_lu_refcount(self):
         # Test that we are keeping track of the reference count with splu.
         n = 30
@@ -557,7 +559,6 @@ class TestSplu(object):
         lu = splu(a_)
 
         # And now test that we don't have a refcount bug
-        import sys
         rc = sys.getrefcount(lu)
         for attr in ('perm_r', 'perm_c'):
             perm = getattr(lu, attr)

--- a/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
@@ -13,6 +13,7 @@ import numpy as np
 from numpy.testing import (assert_allclose, assert_array_almost_equal_nulp,
                            assert_equal, assert_array_equal)
 from pytest import raises as assert_raises
+import pytest
 
 from numpy import dot, conj, random
 from scipy.linalg import eig, eigh
@@ -23,7 +24,7 @@ from scipy.sparse.linalg.eigen.arpack import eigs, eigsh, svds, \
 
 from scipy.linalg import svd, hilbert
 
-from scipy._lib._gcutils import assert_deallocated
+from scipy._lib._gcutils import assert_deallocated, IS_PYPY
 
 
 # precision for tests
@@ -783,6 +784,7 @@ def test_svd_linop():
                                 np.dot(U2, np.dot(np.diag(s2), VH2)), rtol=eps)
 
 
+@pytest.mark.skipif(IS_PYPY, reason="Test not meaningful on PyPy")
 def test_linearoperator_deallocation():
     # Check that the linear operators used by the Arpack wrappers are
     # deallocatable by reference counting -- they are big objects, so


### PR DESCRIPTION
Because PyPy uses a different GC approach, such tests are not meaningful
when running on it.