### PR TITLE
BUG: signal/signaltools: fix wrong refcounting in PyArray_OrderFilterND

### DIFF
--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -552,6 +552,21 @@ class TestMedFilt(object):
         a.strides = 16
         assert_(signal.medfilt(a, 1) == 5.)
 
+    def test_refcounting(self):
+        # Check a refcounting-related crash
+        a = Decimal(123)
+        x = np.array([a, a], dtype=object)
+        if hasattr(sys, 'getrefcount'):
+            n = 2 * sys.getrefcount(a)
+        else:
+            n = 10
+        # Shouldn't segfault:
+        for j in range(n):
+            signal.medfilt(x)
+        if hasattr(sys, 'getrefcount'):
+            assert_(sys.getrefcount(a) < n)
+        assert_equal(x, [a, a])
+
 
 class TestWiener(object):
 


### PR DESCRIPTION
Use copyswap to get correct refcounting when copying values out from
sort_buffer (which has borrowed references).  Add a test that previously
triggered a segfault.

Copyswap for object arrays is here basically `Py_INCREF(*src); Py_DECREF(*dst); *dst = *src;`,
but also deals with the problem that `*src` may be invalid for non-aligned 
arrays on some (non-x86) processors.

The test demonstrating this segfaulted before both on PyPy and on CPython.