### PR TITLE
BUG: io/matlab: fix issues in matlab i/o on pypy

### DIFF
--- a/scipy/io/matlab/streams.pyx
+++ b/scipy/io/matlab/streams.pyx
@@ -37,9 +37,14 @@ cdef extern from "py3k.h":
     int npy_PyFile_DupClose(object file, FILE *handle) except -1
     int npy_PyFile_Check(object file)
 
-       
-# initialize cStringIO
-PycString_IMPORT
+
+cdef bint IS_PYPY = ('__pypy__' in sys.modules)
+cdef bint HAS_PYCCSTRINGIO = not IS_PYPY
+
+if HAS_PYCCSTRINGIO:
+    # initialize cStringIO
+    PycString_IMPORT
+
 
 DEF BLOCK_SIZE = 131072
 
@@ -354,11 +359,11 @@ cpdef GenericStream make_stream(object fobj):
     """ Make stream of correct type for file-like `fobj`
     """
     if npy_PyFile_Check(fobj):
-        if <int>sys.version_info[0] >= 3:
+        if <int>sys.version_info[0] >= 3 or IS_PYPY:
             return GenericStream(fobj)
         else:
             return FileStream(fobj)
-    elif PycStringIO_InputCheck(fobj) or PycStringIO_OutputCheck(fobj):
+    elif HAS_PYCCSTRINGIO and (PycStringIO_InputCheck(fobj) or PycStringIO_OutputCheck(fobj)):
         return cStringStream(fobj)
     elif isinstance(fobj, GenericStream):
         return fobj

--- a/scipy/io/matlab/streams.pyx
+++ b/scipy/io/matlab/streams.pyx
@@ -332,20 +332,22 @@ cdef class FileStream(GenericStream):
 def _read_into(GenericStream st, size_t n):
     # for testing only.  Use st.read instead
     cdef char * d_ptr
-    my_str = b' ' * n
+    # use bytearray because bytes() is immutable
+    my_str = bytearray(b' ' * n)
     d_ptr = my_str
     st.read_into(d_ptr, n)
-    return my_str
+    return bytes(my_str)
 
 
 def _read_string(GenericStream st, size_t n):
     # for testing only.  Use st.read instead
     cdef void *d_ptr
     cdef object obj = st.read_string(n, &d_ptr, True)
-    my_str = b'A' * n
+    # use bytearray because bytes() is immutable
+    my_str = bytearray(b'A' * n)
     cdef char *mys_ptr = my_str
     memcpy(mys_ptr, d_ptr, n)
-    return my_str
+    return bytes(my_str)
 
 
 cpdef GenericStream make_stream(object fobj):

--- a/scipy/io/matlab/tests/test_streams.py
+++ b/scipy/io/matlab/tests/test_streams.py
@@ -27,6 +27,8 @@ from scipy.io.matlab.streams import (make_stream,
     GenericStream, cStringStream, FileStream, ZlibInputStream,
     _read_into, _read_string)
 
+IS_PYPY = ('__pypy__' in sys.modules)
+
 
 @contextmanager
 def setup_test_file():
@@ -46,7 +48,7 @@ def test_make_stream():
     with setup_test_file() as (fs, gs, cs):
         # test stream initialization
         assert_(isinstance(make_stream(gs), GenericStream))
-        if sys.version_info[0] < 3:
+        if sys.version_info[0] < 3 and not IS_PYPY:
             assert_(isinstance(make_stream(cs), cStringStream))
             assert_(isinstance(make_stream(fs), FileStream))
 


### PR DESCRIPTION
Fix two minor bugs in scipy.io.matlab:

- invalid use of bytes() as mutable buffers, must use bytearray()
- don't use FILE* and cStringIO i/o on PyPy2 (fall back to the Python 3 code path)