### PR TITLE
ENH: io/netcdf: make mmap=False the default on PyPy

### DIFF
--- a/scipy/io/netcdf.py
+++ b/scipy/io/netcdf.py
@@ -36,6 +36,7 @@ from __future__ import division, print_function, absolute_import
 __all__ = ['netcdf_file']
 
 
+import sys
 import warnings
 import weakref
 from operator import mul
@@ -50,6 +51,8 @@ from numpy import little_endian as LITTLE_ENDIAN
 from functools import reduce
 
 from scipy._lib.six import integer_types, text_type, binary_type
+
+IS_PYPY = ('__pypy__' in sys.modules)
 
 ABSENT = b'\x00\x00\x00\x00\x00\x00\x00\x00'
 ZERO = b'\x00\x00\x00\x00'
@@ -248,7 +251,10 @@ class netcdf_file(object):
             omode = 'r+' if mode == 'a' else mode
             self.fp = open(self.filename, '%sb' % omode)
             if mmap is None:
-                mmap = True
+                # Mmapped files on PyPy cannot be usually closed
+                # before the GC runs, so it's better to use mmap=False
+                # as the default.
+                mmap = (not IS_PYPY)
 
         if mode != 'r':
             # Cannot read write-only files

--- a/scipy/io/tests/test_netcdf.py
+++ b/scipy/io/tests/test_netcdf.py
@@ -14,7 +14,7 @@ import numpy as np
 from numpy.testing import assert_, assert_allclose, assert_equal
 from pytest import raises as assert_raises
 
-from scipy.io.netcdf import netcdf_file
+from scipy.io.netcdf import netcdf_file, IS_PYPY
 
 from scipy._lib._numpy_compat import suppress_warnings
 from scipy._lib._tmpdirs import in_tempdir
@@ -82,8 +82,8 @@ def test_read_write_files():
 
         # To read the NetCDF file we just created::
         with netcdf_file('simple.nc') as f:
-            # Using mmap is the default
-            assert_(f.use_mmap)
+            # Using mmap is the default (but not on pypy)
+            assert_equal(f.use_mmap, not IS_PYPY)
             check_simple(f)
             assert_equal(f._attributes['appendRan'], 1)
 
@@ -111,10 +111,14 @@ def test_read_write_files():
                 check_simple(f)
 
         # Read file from fileobj, with mmap
-        with open('simple.nc', 'rb') as fobj:
-            with netcdf_file(fobj, mmap=True) as f:
-                assert_(f.use_mmap)
-                check_simple(f)
+        with suppress_warnings() as sup:
+            if IS_PYPY:
+                sup.filter(RuntimeWarning,
+                           "Cannot close a netcdf_file opened with mmap=True.*")
+            with open('simple.nc', 'rb') as fobj:
+                with netcdf_file(fobj, mmap=True) as f:
+                    assert_(f.use_mmap)
+                    check_simple(f)
 
         # Again read it in append mode (adding another att)
         with open('simple.nc', 'r+b') as fobj:
@@ -314,12 +318,13 @@ def test_ticket_1720():
 def test_mmaps_segfault():
     filename = pjoin(TEST_DATA_PATH, 'example_1.nc')
 
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        with netcdf_file(filename, mmap=True) as f:
-            x = f.variables['lat'][:]
-            # should not raise warnings
-            del x
+    if not IS_PYPY:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            with netcdf_file(filename, mmap=True) as f:
+                x = f.variables['lat'][:]
+                # should not raise warnings
+                del x
 
     def doit():
         with netcdf_file(filename, mmap=True) as f:


### PR DESCRIPTION
On PyPy mmapped files usually can only be closed when the GC runs,
because variables referring to the mmap stay alive.

This is undesirable, so change the default value to mmap=False on pypy.
Also silence related warnings in tests.