### PR TITLE
BUG: io/matlab: work around issue in to_writeable on PyPy

### DIFF
--- a/scipy/io/matlab/mio5.py
+++ b/scipy/io/matlab/mio5.py
@@ -427,7 +427,10 @@ def to_writeable(source):
     is_mapping = (hasattr(source, 'keys') and hasattr(source, 'values') and
                   hasattr(source, 'items'))
     # Objects that don't implement mappings, but do have dicts
-    if not is_mapping and hasattr(source, '__dict__'):
+    if isinstance(source, np.generic):
+        # Numpy scalars are never mappings (pypy issue workaround)
+        pass
+    elif not is_mapping and hasattr(source, '__dict__'):
         source = dict((key, value) for key, value in source.__dict__.items()
                       if not key.startswith('_'))
         is_mapping = True


### PR DESCRIPTION
In to_writeable, mark numpy scalars explicitly as non-mappings.

This is how it works on CPython (numpy scalar instances don't have a
`__dict__`), but on PyPy-5.10, objects defined by C extensions have a
`__dict__`, which confuses the code here.

After this (and the other PyPy PRs), the test suite has 2 remaining minor
failures (TestRFFT*.test_non_ndarray_with_dtype in fftpack test code) on PyPy3, which are due to 
https://bitbucket.org/pypy/pypy/issues/2760