### PR TITLE
BUG: ENH: use common halley's method instead of parabolic variant

### DIFF
--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -113,7 +113,7 @@ class TestRootResults:
         assert_equal(repr(r), expected_repr)
 
 
-def test_complex_halley(self):
+def test_complex_halley():
     """Test Halley's works with complex roots"""
     def f(x, *a):
         return a[0] * x**2 + a[1] * x + a[2]

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -121,7 +121,7 @@ class TestRootResults:
         assert_equal(repr(r), expected_repr)
 
 
-@pytest.mark.skipif(mpmath is None)  # skip if mpmath is None
+@pytest.mark.skipif(mpmath is None, reason="skip if mpmath is None")
 def test_halley_convergence():
     """addresses gh5922: Suboptimal convergence of Halley's"""
     points = []

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -10,8 +10,10 @@ except ImportError:
 from numpy.testing import (assert_warns, assert_, 
                            assert_allclose,
                            assert_equal, assert_array_less)
-from numpy.testing.decorators import skipif
+
 from numpy import finfo
+
+import pytest
 
 from scipy.optimize import zeros as cc
 from scipy.optimize import zeros
@@ -119,7 +121,7 @@ class TestRootResults:
         assert_equal(repr(r), expected_repr)
 
 
-@skipif(mpmath is None)  # skip if mpmath is None
+@pytest.mark.skipif(mpmath is None)  # skip if mpmath is None
 def test_halley_convergence():
     """addresses gh5922: Suboptimal convergence of Halley's"""
     points = []

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -125,6 +125,7 @@ def test_complex_halley():
         return 2 * a[0]
 
     z = complex(1.0, 2.0)
-    y = zeros.newton(f, z, args=(2., 3., 4.), fprime=f_1, fprime2=f_2, tol=1e-6)
+    coeffs = (2.0, 3.0, 4.0)
+    y = zeros.newton(f, z, args=coeffs, fprime=f_1, fprime2=f_2, tol=1e-6)
     # (-0.75000000000000078+1.1989578808281789j)
-    assert_allclose(f(y), 0, atol=1e-6)
+    assert_allclose(f(y, *coeffs), 0, atol=1e-6)

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -71,7 +71,7 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
     Find a zero of the function `func` given a nearby starting point `x0`.
     The Newton-Raphson method is used if the derivative `fprime` of `func`
     is provided, otherwise the secant method is used.  If the second order
-    derivate `fprime2` of `func` is provided, then Halley's method is used.
+    derivative `fprime2` of `func` is provided, then Halley's method is used.
 
     Parameters
     ----------

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -173,13 +173,16 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
                 warnings.warn(msg, RuntimeWarning)
                 return p0
             fval = func(*myargs)
+            newton_step = fval / fder
             if fprime2 is None:
                 # Newton step
-                p = p0 - fval / fder
+                p = p0 - newton_step
             else:
                 fder2 = fprime2(*myargs)
                 # Halley's method
-                p = p0 - 2 * fval * fder / (2 * fder ** 2 - fval * fder2)
+                p = p0 - newton_step / (1.0 - 0.5 * newton_step * fder2 / fder)
+                # refactor common form to reduce overflow or divide by zero
+                # p = p0 - 2 * fval * fder / (2 * fder ** 2 - fval * fder2)
             if abs(p - p0) < tol:
                 return p
             p0 = p

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -181,8 +181,6 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
                 fder2 = fprime2(*myargs)
                 # Halley's method
                 p = p0 - newton_step / (1.0 - 0.5 * newton_step * fder2 / fder)
-                # refactor common form to reduce overflow or divide by zero
-                # p = p0 - 2 * fval * fder / (2 * fder ** 2 - fval * fder2)
             if abs(p - p0) < tol:
                 return p
             p0 = p

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -71,8 +71,7 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
     Find a zero of the function `func` given a nearby starting point `x0`.
     The Newton-Raphson method is used if the derivative `fprime` of `func`
     is provided, otherwise the secant method is used.  If the second order
-    derivate `fprime2` of `func` is provided, parabolic Halley's method
-    is used.
+    derivate `fprime2` of `func` is provided, then Halley's method is used.
 
     Parameters
     ----------
@@ -95,8 +94,8 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
     fprime2 : function, optional
         The second order derivative of the function when available and
         convenient. If it is None (default), then the normal Newton-Raphson
-        or the secant method is used. If it is given, parabolic Halley's
-        method is used.
+        or the secant method is used. If it is not None, then Halley's method
+        is used.
 
     Returns
     -------
@@ -131,9 +130,12 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
     
     >>> from scipy import optimize
 
-    ``fprime`` and ``fprime2`` not provided, use secant method
+    ``fprime`` not provided, use secant method
     
     >>> root = optimize.newton(f, 1.5)
+    >>> root
+    1.0000000000000016
+    >>> root = optimize.newton(f, 1.5, fprime2=lambda x: 6 * x)
     >>> root
     1.0000000000000016
 
@@ -143,12 +145,8 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
     >>> root
     1.0
     
-    ``fprime2`` provided, ``fprime`` provided/not provided use parabolic
-    Halley's method
+    Both ``fprime2`` and ``fprime`` provided, use Halley's method
 
-    >>> root = optimize.newton(f, 1.5, fprime2=lambda x: 6 * x)
-    >>> root
-    1.0000000000000016
     >>> root = optimize.newton(f, 1.5, fprime=lambda x: 3 * x**2,
     ...                        fprime2=lambda x: 6 * x)
     >>> root

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -173,18 +173,13 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
                 warnings.warn(msg, RuntimeWarning)
                 return p0
             fval = func(*myargs)
-            if fprime2 is not None:
-                fder2 = fprime2(*myargs)
-            if fder2 == 0:
+            if fprime2 is None:
                 # Newton step
                 p = p0 - fval / fder
             else:
-                # Parabolic Halley's method
-                discr = fder ** 2 - 2 * fval * fder2
-                if discr < 0:
-                    p = p0 - fder / fder2
-                else:
-                    p = p0 - 2*fval / (fder + sign(fder) * sqrt(discr))
+                fder2 = fprime2(*myargs)
+                # Halley's method
+                p = p0 - 2 * fval * fder / (2 * fder ** 2 - fval * fder2)
             if abs(p - p0) < tol:
                 return p
             p0 = p


### PR DESCRIPTION
I would like to propose that we change the form of the Halley's method in scipy.optimize.zeros from the ["parabolic" variant]( https://de.wikipedia.org/wiki/Halley-Verfahren) currently in use (see issue #5922 ) with the more common form found in several other popular libraries and references (see list at end of email).

I think that there are at least four advantages to using the more common form:

1. the parabolic variant has an unnecessary branching condition, which IMHO makes the file a bit more difficult to read, understand and maintain,
2. the proposed changes actually make the `zeros.py` file smaller by removing about 5 lines,
3. the common form seems to have more documentation and widespread usage, so it is easier to find, and should increase confidence in it's usage, and
4. without branching conditions, it is easier to vectorize these methods, so that they can process numerous scalar, univariate cases simulataneously using numpy arrays or in a tight cythonized loop, with exit conditions that are similar to the multivariate case:

    * if derivatives are badly conditioned, then exit or
    * if absoluate max of all of the Newton steps is less than a given tolerance.  

Thanks for your consideration!

#### List of libraries and references using the more common form of Halley's method:

1. [Boost](http://www.boost.org/doc/libs/1_62_0/libs/math/doc/html/math_toolkit/roots/roots_deriv.html#math_toolkit.roots.roots_deriv.halley)
2. [the English language Wikipedia](https://en.wikipedia.org/wiki/Halley%27s_method)
3. [Wolfram's](http://mathworld.wolfram.com/HalleysMethod.html)
4. [JuliaLang  `Roots.jl`](https://github.com/JuliaMath/Roots.jl/blob/master/src/newton.jl#L111)
5. [the R `pracma` package in `newton.R`](https://cran.r-project.org/web/packages/pracma/index.html)

