### PR TITLE
DOC: fix typos

### DIFF
--- a/doc/release/1.0.0-notes.rst
+++ b/doc/release/1.0.0-notes.rst
@@ -798,7 +798,7 @@ Pull requests for 1.0.0
 - `#7606 <https://github.com/scipy/scipy/pull/7606>`__: MAINT: Remove unused function ``NI_NormalizeType``.
 - `#7607 <https://github.com/scipy/scipy/pull/7607>`__: TST: add osx to travis matrix
 - `#7608 <https://github.com/scipy/scipy/pull/7608>`__: DOC: improve HACKING guide - mention reviewing PRs as contribution.
-- `#7609 <https://github.com/scipy/scipy/pull/7609>`__: MAINT: Remove unnecessary warning filter by avoding unnecessary...
+- `#7609 <https://github.com/scipy/scipy/pull/7609>`__: MAINT: Remove unnecessary warning filter by avoiding unnecessary...
 - `#7610 <https://github.com/scipy/scipy/pull/7610>`__: #7557 : fix example code in periodogram
 - `#7611 <https://github.com/scipy/scipy/pull/7611>`__: #7220 : fix TypeError while raising ValueError for invalid shape
 - `#7612 <https://github.com/scipy/scipy/pull/7612>`__: Convert yield tests to pytest parametrized tests
@@ -868,7 +868,7 @@ Pull requests for 1.0.0
 - `#7757 <https://github.com/scipy/scipy/pull/7757>`__: MAINT: remove outdated OS X build scripts. Fixes pytest failure.
 - `#7758 <https://github.com/scipy/scipy/pull/7758>`__: MAINT: stats: pep8, wrap lines
 - `#7760 <https://github.com/scipy/scipy/pull/7760>`__: DOC: special: add instructions on how to add special functions
-- `#7761 <https://github.com/scipy/scipy/pull/7761>`__: DOC: allow specifing Python version for Sphinx makefile
+- `#7761 <https://github.com/scipy/scipy/pull/7761>`__: DOC: allow specifying Python version for Sphinx makefile
 - `#7765 <https://github.com/scipy/scipy/pull/7765>`__: TST: fix test coverage of ``mstats_extras.py``
 - `#7767 <https://github.com/scipy/scipy/pull/7767>`__: DOC: update 1.0 release notes.
 - `#7768 <https://github.com/scipy/scipy/pull/7768>`__: DOC: update notes on how to release. Also change paver file to...

--- a/scipy/optimize/linesearch.py
+++ b/scipy/optimize/linesearch.py
@@ -550,7 +550,7 @@ def _zoom(a_lo, a_hi, phi_lo, phi_hi, derphi_lo,
         #
         # if the result is too close to the end points (or out of the
         # interval) then use quadratic interpolation with phi_lo,
-        # derphi_lo and phi_hi if the result is stil too close to the
+        # derphi_lo and phi_hi if the result is still too close to the
         # end points (or out of the interval) then use bisection
 
         if (i > 0):

--- a/scipy/signal/_peak_finding_utils.pyx
+++ b/scipy/signal/_peak_finding_utils.pyx
@@ -38,7 +38,7 @@ def _argmaxima1d(np.float64_t[:] x not None):
     -----
     - Compared to `argrelmax` this function is significantly faster and can
       detect maxima that are more than one sample wide. However this comes at
-      the cost of beeing only applicable to 1D arrays.
+      the cost of being only applicable to 1D arrays.
     - A maxima is defined as one or more samples of equal value that are
       surrounded on both sides by atleast one smaller sample.
 
@@ -50,7 +50,7 @@ def _argmaxima1d(np.float64_t[:] x not None):
     cdef Py_ssize_t m = 0  # Pointer to the end of valid area in `maxima`
 
     # Variables to loop over `x`
-    cdef Py_ssize_t i = 1  # Pointer to curent sample, first one can't be maxima
+    cdef Py_ssize_t i = 1  # Pointer to current sample, first one can't be maxima
     cdef Py_ssize_t i_max = x.shape[0] - 1  # Last sample can't be maxima
     cdef Py_ssize_t i_ahead  # Pointer to look ahead of current sample
 


### PR DESCRIPTION
Found via `codespell` and `grep`