### PR TITLE
MAINT: Ensure _argmaxima1d doesn't keep unneeded memory.

### DIFF
--- a/scipy/signal/_peak_finding_utils.pyx
+++ b/scipy/signal/_peak_finding_utils.pyx
@@ -45,7 +45,7 @@ def _argmaxima1d(np.float64_t[:] x not None):
     .. versionadded:: 1.1.0
     """
     # Preallocate, there can't be more maxima than half the size of `x`
-    cdef np.ndarray[np.int64_t, ndim=1] maxima
+    cdef np.ndarray[np.intp_t, ndim=1] maxima
     maxima = np.empty(x.shape[0] // 2, dtype=np.intp)
     cdef Py_ssize_t m = 0  # Pointer to the end of valid area in `maxima`
 

--- a/scipy/signal/_peak_finding_utils.pyx
+++ b/scipy/signal/_peak_finding_utils.pyx
@@ -46,7 +46,7 @@ def _argmaxima1d(np.float64_t[:] x not None):
     """
     # Preallocate, there can't be more maxima than half the size of `x`
     cdef np.ndarray[np.int64_t, ndim=1] maxima
-    maxima = np.empty(x.shape[0] // 2, dtype=np.int64)
+    maxima = np.empty(x.shape[0] // 2, dtype=np.intp)
     cdef Py_ssize_t m = 0  # Pointer to the end of valid area in `maxima`
 
     # Variables to loop over `x`
@@ -72,4 +72,5 @@ def _argmaxima1d(np.float64_t[:] x not None):
                 i = i_ahead
         i += 1
 
-    return maxima[:m]  # Return only valid part of array
+    maxima.resize(m, refcheck=False)  # Keep only valid part of array memory.
+    return maxima

--- a/scipy/signal/tests/test_peak_finding.py
+++ b/scipy/signal/tests/test_peak_finding.py
@@ -114,7 +114,6 @@ class TestArgmaxima1d(object):
         assert_equal(maxima, np.array([]))
         assert_(maxima.base is None)
 
-
     def test_exceptions(self):
         """Test input validation and raised exceptions."""
         with raises(ValueError, match="wrong number of dimensions"):

--- a/scipy/signal/tests/test_peak_finding.py
+++ b/scipy/signal/tests/test_peak_finding.py
@@ -2,6 +2,7 @@ from __future__ import division, print_function, absolute_import
 
 import copy
 
+import pytest
 from pytest import raises
 
 import numpy as np
@@ -78,32 +79,41 @@ class TestArgmaxima1d(object):
     def test_empty(self):
         """Test with empty signal."""
         x = np.array([], dtype=np.float64)
-        assert_equal(_argmaxima1d(x), np.array([]))
+        maxima = _argmaxima1d(x)
+        assert_equal(maxima, np.array([]))
+        assert_(maxima.base is None)
 
     def test_linear(self):
         """Test with linear signal."""
         x = np.linspace(0, 100)
-        assert_equal(_argmaxima1d(x), np.array([]))
+        maxima = _argmaxima1d(x)
+        assert_equal(maxima, np.array([]))
+        assert_(maxima.base is None)
 
     def test_simple(self):
         """Test with simple signal."""
         x = np.linspace(-10, 10, 50)
         x[2::3] += 1
-        assert_equal(_argmaxima1d(x), np.arange(2, 50, 3))
+        maxima = _argmaxima1d(x)
+        assert_equal(maxima, np.arange(2, 50, 3))
+        assert_(maxima.base is None)
 
     def test_flat_maxima(self):
         """Test if flat maxima are detected correctly."""
         x = np.array([-1.3, 0, 1, 0, 2, 2, 0, 3, 3, 3, 0, 4, 4, 4, 4, 0, 5])
-        assert_equal(_argmaxima1d(x), np.array([2, 4, 8, 12]))
+        maxima = _argmaxima1d(x)
+        assert_equal(maxima, np.array([2, 4, 8, 12]))
+        assert_(maxima.base is None)
 
-    def test_signal_edges(self):
+    @pytest.mark.parametrize(
+        'x', [np.array([1., 0, 2]), np.array([3., 3, 0, 4, 4]),
+              np.array([5., 5, 5, 0, 6, 6, 6])])
+    def test_signal_edges(self, x):
         """Test if correct behavior on signal edges."""
-        x1 = np.array([1., 0, 2])
-        assert_equal(_argmaxima1d(x1), np.array([]))
-        x2 = np.array([3., 3, 0, 4, 4])
-        assert_equal(_argmaxima1d(x2), np.array([]))
-        x3 = np.array([5., 5, 5, 0, 6, 6, 6])
-        assert_equal(_argmaxima1d(x3), np.array([]))
+        maxima = _argmaxima1d(x)
+        assert_equal(maxima, np.array([]))
+        assert_(maxima.base is None)
+
 
     def test_exceptions(self):
         """Test input validation and raised exceptions."""


### PR DESCRIPTION
Call `.resize` on the return array, rather than taking a view, to prevent memory being unnecessarily held by the array.