### PR TITLE
BENCH: forgot to add nelder-mead to list of methods

### DIFF
--- a/benchmarks/benchmarks/optimize.py
+++ b/benchmarks/benchmarks/optimize.py
@@ -255,7 +255,7 @@ class BenchSmoothUnbounded(Benchmark):
         ['rosenbrock_slow', 'rosenbrock_nograd', 'rosenbrock', 'rosenbrock_tight',
          'simple_quadratic', 'asymmetric_quadratic',
          'sin_1d', 'booth', 'beale', 'LJ'],
-        ["COBYLA", 'Powell',
+        ["COBYLA", 'Powell', 'nelder-mead',
          'L-BFGS-B', 'BFGS', 'CG', 'TNC', 'SLSQP',
          "Newton-CG", 'dogleg', 'trust-ncg', 'trust-exact',
          'trust-krylov'],

--- a/benchmarks/benchmarks/test_functions.py
+++ b/benchmarks/benchmarks/test_functions.py
@@ -35,7 +35,7 @@ class AsymmetricQuadratic(object):
 class SlowRosen(object):
 
     def fun(self, x):
-        time.sleep(50e-6)
+        time.sleep(40e-6)
         return rosen(x)
 
 


### PR DESCRIPTION
I forgot to add 'nelder-mead' to the methods used in #8462.