### PR TITLE
MAINT: Move spline interpolation code to spline.c

### DIFF
--- a/scipy/ndimage/setup.py
+++ b/scipy/ndimage/setup.py
@@ -17,10 +17,14 @@ def configuration(parent_package='', top_path=None):
                     os.path.join(os.path.dirname(__file__), '..', '_lib', 'src')]
 
     config.add_extension("_nd_image",
-        sources=["src/nd_image.c","src/ni_filters.c",
-                 "src/ni_fourier.c","src/ni_interpolation.c",
+        sources=["src/nd_image.c",
+                 "src/ni_filters.c",
+                 "src/ni_fourier.c",
+                 "src/ni_interpolation.c",
                  "src/ni_measure.c",
-                 "src/ni_morphology.c","src/ni_support.c"],
+                 "src/ni_morphology.c",
+                 "src/ni_splines.c",
+                 "src/ni_support.c"],
         include_dirs=include_dirs,
         **numpy_nodepr_api)
 

--- a/scipy/ndimage/src/ni_splines.c
+++ b/scipy/ndimage/src/ni_splines.c
@@ -1,0 +1,225 @@
+#include "ni_support.h"
+#include "ni_splines.h"
+#include <math.h>
+
+
+int
+get_spline_interpolation_weights(double x, int order, double *weights)
+{
+    int i;
+    double y, z, t;
+
+    /* Convert x to the delta to the middle knot. */
+    x -= floor(order & 1 ? x : x + 0.5);
+    y = x;
+    z = 1.0 - x;
+
+    switch (order) {
+        case 1:
+            /* 0 <= x < 1*/
+            weights[0] = 1.0 - x;
+            break;
+        case 2:
+            /* -0.5 < x <= 0.5 */
+            weights[1] = 0.75 - x * x;
+            /* For weights[0] we'd normally do:
+             *
+             *   y = 1 + x  # 0.5 < y <= 1.5
+             *   yy = 1.5 - y  # yy = 0.5 - x
+             *   weights[0] = 0.5 * yy * yy
+             *
+             * So we set y = 0.5 - x directly instead.
+             */
+            y = 0.5 - x;
+            weights[0] = 0.5 * y * y;
+            break;
+        case 3:
+            /* y = x, 0 <= y < 1 */
+            weights[1] = (y * y * (y - 2.0) * 3.0 + 4.0) / 6.0;
+            /* z = 1 - x, 0 < z <= 1 */
+            weights[2] = (z * z * (z - 2.0) * 3.0 + 4.0) / 6.0;
+            /*
+             * For weights[0] we would normally do:
+             *
+             *   y += 1.0  # y = 1.0 + x, 1 <= y < 2
+             *   yy = 2.0 - y  # yy = 1 - x
+             *   weights[0] = yy * yy * yy / 6.0
+             *
+             * But we already have yy in z.
+             */
+            weights[0] = z * z * z / 6.0;
+            break;
+        case 4:
+            /* -0.5 < x <= 0.5 */
+            t = x * x;
+            weights[2] = t * (t * 0.25 - 0.625) + 115.0 / 192.0;
+            /* y = 1 + x, 0.5 < y <= 1.5 */
+            y = 1.0 + x;
+            weights[1] = y * (y * (y * (5.0 - y) / 6.0 - 1.25) + 5.0 / 24.0) +
+                         55.0 / 96.0;
+            /* z = 1 - x, 0.5 <= z < 1.5 */
+            weights[3] = z * (z * (z * (5.0 - z) / 6.0 - 1.25) + 5.0 / 24.0) +
+                         55.0 / 96.0;
+            /*
+             * For weights[0] we would normally do:
+             *
+             *   y += 1.0  # y = 2.0 + x, 1.5 <= y < 2.5
+             *   yy = 2.5 - y  # yy = 0.5 - x
+             *  weights[0] = yy**4 / 24.0
+             *
+             * So we set y = 0.5 - x directly instead.
+             */
+            y = 0.5 - x;
+            t = y * y;
+            weights[0] = t * t / 24.0;
+            break;
+        case 5:
+            /* y = x, 0 <= y < 1 */
+            t = y * y;
+            weights[2] = t * (t * (0.25 - y / 12.0) - 0.5) + 0.55;
+            /* z = 1 - x, 0 < z <= 1 */
+            t = z * z;
+            weights[3] = t * (t * (0.25 - z / 12.0) - 0.5) + 0.55;
+            /* y = 1 + x, 1 <= y < 2 */
+            y += 1.0;
+            weights[1] = y * (y * (y * (y * (y / 24.0 - 0.375) + 1.25) - 1.75)
+                              + 0.625) + 0.425;
+            /* z = 2 - x, 1 < z <= 2 */
+            z += 1.0;
+            weights[4] = z * (z * (z * (z * (z / 24.0 - 0.375) + 1.25) - 1.75)
+                              + 0.625) + 0.425;
+            /* For weights[0] we would normally do:
+             *
+             *   y += 1.0  # y = 2.0 + x, 2 <= y < 3
+             *   yy = 3.0 - y  # yy = 1.0 - x
+             *   weights[0] = yy**5 / 120.0
+             *
+             * So we set y = 2.0 - y = 1.0 - x directly instead.
+             */
+            y = 1.0 - x;
+            t = y * y;
+            weights[0] = y * t * t / 120.0;
+            break;
+        default:
+            return 1; /* Unsupported spline order. */
+    }
+
+    /* All interpolation weights add to 1.0, so use it for the last one. */
+    weights[order] = 1.0;
+    for (i = 0; i < order; ++i) {
+        weights[order] -= weights[i];
+    }
+
+    return 0;
+}
+
+
+int
+get_filter_poles(int order, int *npoles, double *poles)
+{
+    *npoles = order / 2;
+    /*
+     * If this assert is triggered, someone added more orders here but
+     * MAX_SPLIINE_FILTER_POLES was not kept in sync.
+     */
+    assert(*npoles <= MAX_SPLINE_FILTER_POLES);
+
+    switch (order) {
+        case 2:
+            /* sqrt(8.0) - 3.0 */
+            poles[0] = -0.171572875253809902396622551580603843;
+            break;
+        case 3:
+            /* sqrt(3.0) - 2.0 */
+            poles[0] = -0.267949192431122706472553658494127633;
+            break;
+        case 4:
+            /* sqrt(664.0 - sqrt(438976.0)) + sqrt(304.0) - 19.0 */
+            poles[0] = -0.361341225900220177092212841325675255;
+            /* sqrt(664.0 + sqrt(438976.0)) - sqrt(304.0) - 19.0 */
+            poles[1] = -0.013725429297339121360331226939128204;
+            break;
+        case 5:
+            /* sqrt(67.5 - sqrt(4436.25)) + sqrt(26.25) - 6.5 */
+            poles[0] = -0.430575347099973791851434783493520110;
+            /* sqrt(67.5 + sqrt(4436.25)) - sqrt(26.25) - 6.5 */
+            poles[1] = -0.043096288203264653822712376822550182;
+            break;
+        default:
+            return 1; /* Unsupported order. */
+    };
+
+    return 0;
+}
+
+
+double
+filter_gain(const double *poles, int npoles)
+{
+    double gain = 1.0;
+
+    while (npoles--) {
+        const double pole = *poles++;
+        gain *= (1.0 - pole) * (1.0 - 1.0 / pole);
+    }
+
+    return gain;
+}
+
+
+void
+apply_gain(double gain, double *coefficients, npy_intp len)
+{
+    while (len--) {
+        *coefficients++ *= gain;
+    }
+}
+
+
+void
+set_initial_causal_coefficient(double *coefficients, npy_intp len,
+                               double pole, double tolerance)
+{
+    int i;
+    int last_coeff = len;
+    double sum = 0.0;
+
+    if (tolerance > 0.0) {
+        last_coeff = ceil(log(tolerance)) / log(fabs(pole));
+    }
+    if (last_coeff < len) {
+        double z_i = pole;
+
+        sum = coefficients[0];
+        for (i = 1; i < last_coeff; ++i) {
+            sum += z_i * coefficients[i];
+            z_i *= pole;
+        }
+    }
+    else {
+        double z_i = pole;
+        const double inv_z = 1.0 / pole;
+        const double z_n_1 = pow(pole, len - 1);
+        double z_2n_2_i = z_n_1 * z_n_1 * inv_z;
+
+        sum = coefficients[0] + coefficients[len - 1] * z_n_1;
+        for (i = 1; i < len - 1; ++i) {
+            sum += (z_i + z_2n_2_i) * coefficients[i];
+            z_i *= pole;
+            z_2n_2_i *= inv_z;
+        }
+        sum /= (1 - z_n_1 * z_n_1);
+    }
+
+    coefficients[0] = sum;
+}
+
+
+void
+set_initial_anticausal_coefficient(double *coefficients, npy_intp len,
+                                   double pole)
+{
+    coefficients[len - 1] = pole / (pole * pole - 1.0) *
+                            (pole * coefficients[len - 2] +
+                             coefficients[len - 1]) ;
+}

--- a/scipy/ndimage/src/ni_splines.h
+++ b/scipy/ndimage/src/ni_splines.h
@@ -1,0 +1,118 @@
+#ifndef NI_SPLINES_H
+#define NI_SPLINES_H
+
+
+/*
+ * For context in the theory behind this code, see:
+ *
+ * M. Unser, A. Aldroubi and M. Eden, "Fast B-spline transforms for
+ * continuous image representation and interpolation," in IEEE
+ * Transactions on Pattern Analysis and Machine Intelligence, vol. 13,
+ * no. 3, pp. 277-285, Mar 1991.
+ *
+ * M. Unser, "Splines: A Perfect Fit for Signal and Image Processing,"
+ * in IEEE Signal Processing Magazine, vol. 16, no. 6, pp. 22-38, 1999.
+ */
+
+/*
+ * Fills `weights` with the interpolation weights for the B-splines at
+ * the `origin + 1` knots closest to the point with coordinate `x`.
+ * Because B-splines are symmetrical, the above turns out to be the
+ * same as computing the values of a B-spline centered at `x` at the
+ * knots.
+ */
+int
+get_spline_interpolation_weights(double x, int order, double *weights);
+
+
+/* The maximum number of poles for supported spline orders. */
+#define MAX_SPLINE_FILTER_POLES 2
+
+/*
+ * Stores in `poles` the values of the poles of a spline filter of the
+ * selected order, and in `npoles` the number of poles written. `poles`
+ * should be at least `MAX_SPLINE_FILTER_POLES` long. Returns 1 if the
+ * order is not supported, 0 on success.
+ */
+int
+get_filter_poles(int order, int *npoles, double *poles);
+
+
+/*
+ * Computes the filter gain for the given poles.
+ */
+double
+filter_gain(const double *poles, int npoles);
+
+
+/*
+ * Multiplies all coefficients in-place by the gain.
+ */
+void
+apply_gain(double gain, double *coefficeints, npy_intp len);
+
+
+/*
+ * Sets the first coefficient to the right value to begin applying a
+ * causal filter for the given pole to the sequence. If tolerance is
+ * zero the calculation will be exact, if non-zero, the series will be
+ * truncated for items  smaller than the tolerance.
+ *
+ * -----
+ *
+ * If s[i] are the values to filter, and z is the pole being considered,
+ * the initial coefficient for the causal filter can be computed as:
+ *
+ *   c[0] = Sum(i=0..inf, s[i] * z**i)
+ *
+ * Since |z| < 1, this can be computed approximately by adding terms
+ * until z**i is below a user defined tolerance.
+ *
+ * It can also be computed exactly by taking into account the boundary
+ * conditions coming from the extend mode. Currently NI_EXTEND_MIRROR
+ * is the only supported mode.
+ *
+ * NI_EXTEND_MIRROR : a b c d | c b a b c d c b ...
+ * The s[i], when extended beyond the given n items, are periodic with
+ * period T, so we can rewrite:
+ *
+ *   c[0] = Sum(k=0..inf, z**(T * k)) * Sum(i=0..T, s[i] * z**i) =
+ *        = 1 / (1 - z**T) * S
+ *
+ * In this case T = 2*n - 2, and c[-k] = c[k], so S can be computed as:
+ *
+ *   S = s[0] + s[n-1] * z**(n-1) +
+ *       Sum(i=1..n-1, s[i]* (z**i + z**(2*n - 2 - i)))
+ *
+ */
+void
+set_initial_causal_coefficient(double *coefficients, npy_intp len,
+                               double pole, double tolerance);
+
+
+/*
+ * Sets the last coefficient to the right value to begin applying an
+ * anticausal filter for the given pole to the sequence.
+ *
+ * -----
+ *
+ * The causal, c+, and anticausal, c-, filter coefficients, and the
+ * filtered sequence, c, are computed from the sequence, s, using the
+ * following recursive relations:
+ *
+ *   c+[i] = s[i] + z * c+[i-1]
+ *   c-[i] = s[i] + z * c-[i+1]
+ *   c[i] = z / (1 - z**2) * (c+[i] + c-[i] - s[i])
+ *
+ * For the anticausal filter, if the extension mode is NI_EXTEND_MIRROR,
+ * we also know that c+[n-1] = c-[n-1], so:
+ *
+ *   c[n-1] = z / (1 - z**2) * (z * c+[n-2] + c+[n-1])
+ *
+ */
+void
+set_initial_anticausal_coefficient(double *coefficients, npy_intp len,
+                                   double pole);
+
+#endif
+

--- a/scipy/ndimage/src/ni_splines.h
+++ b/scipy/ndimage/src/ni_splines.h
@@ -3,7 +3,7 @@
 
 
 /*
- * For context in the theory behind this code, see:
+ * For context on the theory behind this code, see:
  *
  * M. Unser, A. Aldroubi and M. Eden, "Fast B-spline transforms for
  * continuous image representation and interpolation," in IEEE
@@ -27,6 +27,7 @@ get_spline_interpolation_weights(double x, int order, double *weights);
 
 /* The maximum number of poles for supported spline orders. */
 #define MAX_SPLINE_FILTER_POLES 2
+
 
 /*
  * Stores in `poles` the values of the poles of a spline filter of the
@@ -114,5 +115,5 @@ void
 set_initial_anticausal_coefficient(double *coefficients, npy_intp len,
                                    double pole);
 
-#endif
 
+#endif

--- a/scipy/ndimage/tests/test_datatypes.py
+++ b/scipy/ndimage/tests/test_datatypes.py
@@ -5,7 +5,7 @@ from __future__ import division, print_function, absolute_import
 import sys
 
 import numpy as np
-from numpy.testing import assert_array_almost_equal, assert_
+from numpy.testing import assert_array_almost_equal, assert_equal, assert_
 import pytest
 
 from scipy import ndimage
@@ -52,12 +52,17 @@ def test_uint64_max():
     # Test interpolation respects uint64 max.  Reported to fail at least on
     # win32 (due to the 32 bit visual C compiler using signed int64 when
     # converting between uint64 to double) and Debian on s390x.
-    big = 2**64-1
+    # Interpolation is always done in double precision floating point, so we
+    # use the largest uint64 value for which int(float(big)) still fits in
+    # a uint64.
+    big = 2**64-1025
     arr = np.array([big, big, big], dtype=np.uint64)
     # Tests geometric transform (map_coordinates, affine_transform)
     inds = np.indices(arr.shape) - 0.1
     x = ndimage.map_coordinates(arr, inds)
-    assert_(x[1] > (2**63))
+    assert_equal(x[1], int(float(big)))
+    assert_equal(x[2], int(float(big)))
     # Tests zoom / shift
     x = ndimage.shift(arr, 0.1)
-    assert_(x[1] > (2**63))
+    assert_equal(x[1], int(float(big)))
+    assert_equal(x[2], int(float(big)))

--- a/scipy/ndimage/tests/test_splines.py
+++ b/scipy/ndimage/tests/test_splines.py
@@ -1,0 +1,64 @@
+"""Tests for spline filtering."""
+from __future__ import division, print_function, absolute_import
+
+import numpy as np
+import pytest
+
+from numpy.testing import assert_almost_equal
+
+from scipy import ndimage
+
+
+def get_spline_knot_values(order):
+    """Knot values to the right of a B-spline's center."""
+    knot_values = {0: [1],
+                   1: [1],
+                   2: [6, 1],
+                   3: [4, 1],
+                   4: [230, 76, 1],
+                   5: [66, 26, 1]}
+
+    return knot_values[order]
+
+
+def make_spline_knot_matrix(n, order, mode='mirror'):
+    """Matrix to invert to find the spline coefficients."""
+    knot_values = get_spline_knot_values(order)
+
+    matrix = np.zeros((n, n))
+    for diag, knot_value in enumerate(knot_values):
+        indices = np.arange(diag, n)
+        if diag == 0:
+            matrix[indices, indices] = knot_value
+        else:
+            matrix[indices, indices - diag] = knot_value
+            matrix[indices - diag, indices] = knot_value
+
+    knot_values_sum = knot_values[0] + 2 * sum(knot_values[1:])
+
+    if mode == 'mirror':
+        start, step = 1, 1
+    elif mode == 'reflect':
+        start, step = 0, 1
+    elif mode == 'wrap':
+        start, step = -1, -1
+    else:
+        raise ValueError('unsupported mode {}'.format(mode))
+
+    for row in range(len(knot_values) - 1):
+        for idx, knot_value in enumerate(knot_values[row + 1:]):
+            matrix[row, start + step*idx] += knot_value
+            matrix[-row - 1, -start - 1 - step*idx] += knot_value
+
+    return matrix / knot_values_sum
+
+
+@pytest.mark.parametrize('order', [0, 1, 2, 3, 4, 5])
+def test_spline_filter_vs_matrix_solution(order):
+    n = 100
+    eye = np.eye(n, dtype=float)
+    spline_filter_axis_0 = ndimage.spline_filter1d(eye, axis=0, order=order)
+    spline_filter_axis_1 = ndimage.spline_filter1d(eye, axis=1, order=order)
+    matrix = make_spline_knot_matrix(n, order)
+    assert_almost_equal(eye, np.dot(spline_filter_axis_0, matrix))
+    assert_almost_equal(eye, np.dot(spline_filter_axis_1, matrix.T))


### PR DESCRIPTION
This PR moves some of the code in `ndimage/ni_interpolation.c` to a new file `ni_splines.c`. The main purpose of the changes are documentary: the new code is profusely documented, and cites a couple of the original articles on which it is based. This is a first step in finding a path forward for #8465, namely making the code more understandable.

Some of the refactorings may have some marginal performance gains, e.g. the calculation of the spline interpolation weights should be faster, since it has less branches.