### PR TITLE
TST: special: mark a slow test as xslow

### DIFF
--- a/scipy/special/tests/test_precompute_gammainc.py
+++ b/scipy/special/tests/test_precompute_gammainc.py
@@ -99,11 +99,11 @@ def test_gammainc():
                         nan_ok=False, rtol=1e-17, n=50, dps=50)
 
 
+@pytest.mark.xslow
 @check_version(mp, '0.19')
 def test_gammaincc():
-    # Quick check that the gammaincc in
-    # special._precompute.gammainc_data agrees with mpmath's
-    # gammainc.
+    # Check that the gammaincc in special._precompute.gammainc_data
+    # agrees with mpmath's gammainc.
     assert_mpmath_equal(lambda a, x: gammaincc(a, x, dps=1000),
                         lambda a, x: mp.gammainc(a, a=x, regularized=True),
                         [Arg(20, 100), Arg(20, 100)],
@@ -114,4 +114,3 @@ def test_gammaincc():
                         lambda a, x: mp.gammainc(a, a=x, regularized=True),
                         [IntArg(1, 100), Arg(0, 100)],
                         nan_ok=False, rtol=1e-17, n=50, dps=50)
-


### PR DESCRIPTION
The test `test_gammaincc` in `test_precompute_gammainc.py` currently
takes about a minute to run; it appears to have become slower after
the changes to `Arg`. Mark it as xslow since it's not essential for it
to run all the time.