### PR TITLE
ENH: special: improve accuracy of `zetac` for negative arguments

### DIFF
--- a/scipy/special/_precompute/zetac.py
+++ b/scipy/special/_precompute/zetac.py
@@ -1,0 +1,29 @@
+"""Compute the Taylor series for zeta(x) - 1 around x = 0."""
+from __future__ import division, print_function, absolute_import
+
+try:
+    import mpmath
+except ImportError:
+    pass
+
+
+def zetac_series(N):
+    coeffs = []
+    with mpmath.workdps(100):
+        coeffs.append(-1.5)
+        for n in range(1, N):
+            coeff = mpmath.diff(mpmath.zeta, 0, n)/mpmath.factorial(n)
+            coeffs.append(coeff)
+    return coeffs
+
+
+def main():
+    print(__doc__)
+    coeffs = zetac_series(10)
+    coeffs = [mpmath.nstr(x, 20, min_fixed=0, max_fixed=0)
+              for x in coeffs]
+    print("\n".join(coeffs[::-1]))
+
+
+if __name__ == '__main__':
+    main()

--- a/scipy/special/cephes/zetac.c
+++ b/scipy/special/cephes/zetac.c
@@ -56,7 +56,7 @@
 /* Riemann zeta(x) - 1
  * for integer arguments between 0 and 30.
  */
-static double azetac[] = {
+static const double azetac[] = {
     -1.50000000000000000000E0,
     0.0,  /* Not used; zetac(1.0) is infinity. */
     6.44934066848226436472E-1,
@@ -302,7 +302,7 @@ static NPY_INLINE double zetac_reflection(double x)
     /* Group large terms together to prevent overflow */
     s = pow((x + lanczos_g + 0.5) / (2 * NPY_PI * NPY_E), x + 0.5);
     /* Reduce the argument to sine */
-    x_shift = x - 4*floor(x / 4);
+    x_shift = fmod(x, 4);
     s *= -SQRT_2_PI * sin(0.5 * NPY_PI * x_shift);
     s *= lanczos_sum_expg_scaled(x + 1) * zeta(x + 1, 1);
     return s - 1.0;

--- a/scipy/special/cephes/zetac.c
+++ b/scipy/special/cephes/zetac.c
@@ -51,6 +51,7 @@
  */
 
 #include "mconf.h"
+#include "lanczos.h"
 
 /* Riemann zeta(x) - 1
  * for integer arguments between 0 and 30.
@@ -162,37 +163,67 @@ static double S[5] = {
     7.43853965136767874343E4,
 };
 
+static double TAYLOR0[10] = {
+    -1.0000000009110164892,
+    -1.0000000057646759799,
+    -9.9999983138417361078e-1,
+    -1.0000013011460139596,
+    -1.000001940896320456,
+    -9.9987929950057116496e-1,
+    -1.000785194477042408,
+    -1.0031782279542924256,
+    -9.1893853320467274178e-1,
+    -1.5,
+};
+
 #define MAXL2 127
+#define SQRT_2_PI 0.79788456080286535587989
+
+extern double MACHEP;
+
+static double zetac_reflection(double);
+static double zetac_smallneg(double);
+static double zetac_positive(double);
+
 
 /*
  * Riemann zeta function, minus one
  */
-extern double MACHEP;
+double zetac(double x)
+{
+    if (npy_isnan(x)) {
+	return x;
+    }
+    else if (x == -NPY_INFINITY) {
+	return NPY_NAN;
+    }
+    else if (x < 0.0 && x > -0.01) {
+	return zetac_smallneg(x);
+    }
+    else if (x < 0.0) {
+	return zetac_reflection(-x);
+    }
+    else {
+	return zetac_positive(x);
+    }
+}
 
-double zetac(x)
-double x;
+
+/*
+ * Compute zetac for positive arguments
+ */
+static NPY_INLINE double zetac_positive(double x)
 {
     int i;
     double a, b, s, w;
-
-    if (x < 0.0) {
-        if (x < -30.8148) {
-            mtherr("zetac", OVERFLOW);
-            return (NPY_NAN);
-        }
-        s = 1.0 - x;
-        w = zetac(s);
-        b = sin(0.5 * NPY_PI * x) * pow(2.0 * NPY_PI, x) *
-            Gamma(s) * (1.0 + w) / NPY_PI;
-        return (b - 1.0);
-    }
 
     if (x == 1.0) {
         return NPY_INFINITY;
     }
 
     if (x >= MAXL2) {
-        return (0.0);       /* because first term is 2**-x */
+	/* because first term is 2**-x */
+        return 0.0;
     }
 
     /* Tabulated values for integer argument */
@@ -208,31 +239,27 @@ double x;
         }
     }
 
-
     if (x < 1.0) {
         w = 1.0 - x;
         a = polevl(x, R, 5) / (w * p1evl(x, S, 5));
-        return (a);
+        return a;
     }
 
     if (x <= 10.0) {
         b = pow(2.0, x) * (x - 1.0);
         w = 1.0 / x;
         s = (x * polevl(w, P, 8)) / (b * p1evl(w, Q, 8));
-        return (s);
+        return s;
     }
 
     if (x <= 50.0) {
         b = pow(2.0, -x);
         w = polevl(x, A, 10) / p1evl(x, B, 10);
         w = exp(w) + b;
-        return (w);
+        return w;
     }
 
-
     /* Basic sum of inverse powers */
-
-
     s = 0.0;
     a = 1.0;
     do {
@@ -244,5 +271,39 @@ double x;
 
     b = pow(2.0, -x);
     s = (s + b) / (1.0 - b);
-    return (s);
+    return s;
+}
+
+
+/*
+ * Compute zetac for small negative x. We can't use the reflection
+ * formula because to double precision 1 - x = 1 and zetac(1) = inf.
+ */
+static NPY_INLINE double zetac_smallneg(double x)
+{
+    return polevl(x, TAYLOR0, 9);
+}
+
+
+/*
+ * Compute zetac using the reflection formula (see DLMF 25.4.2) plus
+ * the Lanczos approximation for Gamma to avoid overflow.
+ */
+static NPY_INLINE double zetac_reflection(double x)
+{
+    double s, hx, x_shift;
+
+    hx = x / 2;
+    if (hx == floor(hx)) {
+	/* Hit a zero of the sine factor */
+	return -1.0;
+    }
+
+    /* Group large terms together to prevent overflow */
+    s = pow((x + lanczos_g + 0.5) / (2 * NPY_PI * NPY_E), x + 0.5);
+    /* Reduce the argument to sine */
+    x_shift = x - 4*floor(x / 4);
+    s *= -SQRT_2_PI * sin(0.5 * NPY_PI * x_shift);
+    s *= lanczos_sum_expg_scaled(x + 1) * zeta(x + 1, 1);
+    return s - 1.0;
 }

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -944,26 +944,6 @@ class TestCephes(object):
     def _check_yve(self):
         cephes.yve(1,1)
 
-    def test_zeta(self):
-        assert_allclose(zeta(2,2), pi**2/6 - 1, rtol=1e-12)
-
-    def test_zetac(self):
-        assert_equal(cephes.zetac(0), -1.5)
-        assert_equal(cephes.zetac(1.0), np.inf)
-        # Expected values in the following were computed using
-        # Wolfram Alpha `Zeta[x] - 1`:
-        rtol = 1e-12
-        assert_allclose(cephes.zetac(-2.1), -0.9972705002153750, rtol=rtol)
-        assert_allclose(cephes.zetac(0.8), -5.437538415895550, rtol=rtol)
-        assert_allclose(cephes.zetac(0.9999), -10000.42279161673, rtol=rtol)
-        assert_allclose(cephes.zetac(9), 0.002008392826082214, rtol=rtol)
-        assert_allclose(cephes.zetac(50), 8.881784210930816e-16, rtol=rtol)
-        assert_allclose(cephes.zetac(75), 2.646977960169853e-23, rtol=rtol)
-
-    def test_zeta_1arg(self):
-        assert_allclose(zeta(2), pi**2/6, rtol=1e-12)
-        assert_allclose(zeta(4), pi**4/90, rtol=1e-12)
-
     def test_wofz(self):
         z = [complex(624.2,-0.26123), complex(-0.4,3.), complex(0.6,2.),
              complex(-1.,1.), complex(-1.,-9.), complex(-1.,9.),

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -1911,6 +1911,12 @@ class TestSystematic(object):
                             [Arg(a=1, b=1e10, inclusive_a=False),
                              Arg(a=0, inclusive_a=False)])
 
+    def test_zetac(self):
+        assert_mpmath_equal(sc.zetac,
+                            lambda x: mpmath.zeta(x) - 1,
+                            [Arg(-100, 100)],
+                            nan_ok=False, dps=45, rtol=1e-13)
+
     def test_boxcox(self):
 
         def mp_boxcox(x, lmbda):

--- a/scipy/special/tests/test_zeta.py
+++ b/scipy/special/tests/test_zeta.py
@@ -1,0 +1,39 @@
+from __future__ import division, print_function, absolute_import
+
+import scipy.special as sc
+import numpy as np
+from numpy.testing import assert_, assert_equal, assert_allclose
+
+
+def test_zeta():
+    assert_allclose(sc.zeta(2,2), np.pi**2/6 - 1, rtol=1e-12)
+
+
+def test_zeta_1arg():
+    assert_allclose(sc.zeta(2), np.pi**2/6, rtol=1e-12)
+    assert_allclose(sc.zeta(4), np.pi**4/90, rtol=1e-12)
+
+
+def test_zetac():
+    assert_equal(sc.zetac(0), -1.5)
+    assert_equal(sc.zetac(1.0), np.inf)
+    # Expected values in the following were computed using
+    # Wolfram Alpha `Zeta[x] - 1`:
+    rtol = 1e-12
+    assert_allclose(sc.zetac(-2.1), -0.9972705002153750, rtol=rtol)
+    assert_allclose(sc.zetac(0.8), -5.437538415895550, rtol=rtol)
+    assert_allclose(sc.zetac(0.9999), -10000.42279161673, rtol=rtol)
+    assert_allclose(sc.zetac(9), 0.002008392826082214, rtol=rtol)
+    assert_allclose(sc.zetac(50), 8.881784210930816e-16, rtol=rtol)
+    assert_allclose(sc.zetac(75), 2.646977960169853e-23, rtol=rtol)
+
+
+def test_zetac_negative_even():
+    pts = [-2, -50, -100]
+    for p in pts:
+        assert_equal(sc.zetac(p), -1)
+
+
+def test_zetac_inf():
+    assert_equal(sc.zetac(np.inf), 0.0)
+    assert_(np.isnan(sc.zetac(-np.inf)))


### PR DESCRIPTION
Combine the reflection formula for zeta with the Lanczos approximation
for Gamma to prevent overflow. Closes gh-8371.