### PR TITLE
CI: only run slow tests on CI instead of the full test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,13 @@ matrix:
         - NUMPYSPEC="--pre --upgrade --timeout=60 -f $PRE_WHEELS numpy"
     - python: 3.6
       env:
-        - TESTMODE=full
+        - TESTMODE=slow
         - COVERAGE="--coverage --gcov"
         - NUMPYSPEC=numpy
     - python: 3.5
       env:
         - TESTMODE=fast
-        - COVERAGE=
+        - COVERAGE="--coverage --gcov"
         - USE_WHEEL=1
         - REFGUIDE_CHECK=1
     - python: 3.4

--- a/tools/validate_runtests_log.py
+++ b/tools/validate_runtests_log.py
@@ -25,16 +25,17 @@ if __name__ == "__main__":
     # full or fast test suite?
     try:
         testmode = sys.argv[1]
-        if testmode not in ('fast', 'full'):
+        if testmode not in ('fast', 'full', 'slow'):
             raise IndexError
     except IndexError:
-        raise ValueError("Usage: validate.py {full|fast} < logfile.")
+        raise ValueError("Usage: validate.py {full|fast|slow} < logfile.")
 
     # fetch the expected number of tests
     # these numbers are for 10d5dfe8b7
     # XXX: this should probably track the commit hash or commit date
     expected_size = {'full': 11000,
-                     'fast': 10000}
+                     'fast': 10000,
+                     'slow': 300}
 
     # read in the log, parse for the pytest printout
     r1 = re.compile("(?P<num_failed>\d+) failed, (?P<num_passed>\d+) passed,.* in (?P<time>\d+\S+)")


### PR DESCRIPTION
A dumb attempt at fixing https://github.com/scipy/scipy/issues/8518 : instead of running the full test suite, only run slow tests in that CI job.

The  obvious downside is that the coverage metrics is no longer useful.
EDIT: possibly related: https://github.com/travis-ci/travis-ci/issues/7392
