### PR TITLE
TST: Decrease the array sizes for two linalg tests

### DIFF
--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -751,11 +751,10 @@ class TestSolve(object):
         assert_raises(ValueError, solve, 1, 1, assume_a='zxcv')
 
     def test_all_type_size_routine_combinations(self):
-        sizes = [10, 100, 1000]
+        sizes = [10, 100, 700]
         assume_as = ['gen', 'sym', 'pos', 'her']
         dtypes = [np.float32, np.float64, np.complex64, np.complex128]
-        for size, assume_a, dtype in itertools.product(sizes,
-                                                       assume_as,
+        for size, assume_a, dtype in itertools.product(sizes, assume_as,
                                                        dtypes):
             is_complex = dtype in (np.complex64, np.complex128)
             if assume_a == 'her' and not is_complex:
@@ -790,7 +789,8 @@ class TestSolve(object):
                             rtol=tol * size,
                             err_msg=err_msg)
 
-            if assume_a == 'sym' and dtype not in (np.complex64, np.complex128):
+            if assume_a == 'sym' and dtype not in (np.complex64,
+                                                   np.complex128):
                 x = solve(a, b, assume_a=assume_a, transposed=True)
                 assert_allclose(a.dot(x), b,
                                 atol=tol * size,
@@ -1234,44 +1234,40 @@ class TestLstsq(object):
             sup.filter(RuntimeWarning,
                        "internal gelsd driver lwork query error,.*"
                        "Falling back to 'gelss' driver.")
-            for dtype in REAL_DTYPES:
-                a = np.array(((1, 20), (-30, 4)), dtype=dtype)
-                for bt in (((1, 0), (0, 1)), (1, 0),
-                           ((2, 1), (-30, 4))):
-                    for lapack_driver in TestLstsq.lapack_drivers:
-                            for overwrite in (True, False):
-                                for check_finite in (True, False):
-                                    b = np.array(bt, dtype=dtype)
-                                    # Store values in case they are overwritten
-                                    # later
-                                    a1 = a.copy()
-                                    b1 = b.copy()
-                                    try:
-                                        out = lstsq(a1, b1,
-                                                    lapack_driver=lapack_driver,
-                                                    check_finite=check_finite,
-                                                    overwrite_a=overwrite,
-                                                    overwrite_b=overwrite)
-                                    except LstsqLapackError:
-                                        if lapack_driver is None:
-                                            mesg = (
-                                                'LstsqLapackError raised with '
-                                                'lapack_driver being None.')
-                                            raise AssertionError(mesg)
-                                        else:
-                                            # can't proceed,
-                                            # skip to the next iteration
-                                            continue
-                                    x = out[0]
-                                    r = out[2]
-                                    assert_(r == 2,
-                                            'expected efficient rank 2, '
-                                            'got %s' % r)
-                                    assert_allclose(
-                                          dot(a, x), b,
-                                          rtol=25 * _eps_cast(a.dtype),
-                                          atol=25 * _eps_cast(a.dtype),
-                                          err_msg="driver: %s" % lapack_driver)
+
+        at = np.array(((1, 20), (-30, 4)))
+        for dtype, bt, lapack_driver, overwrite, check_finite in \
+            itertools.product(REAL_DTYPES,
+                              (((1, 0), (0, 1)), (1, 0), ((2, 1), (-30, 4))),
+                              TestLstsq.lapack_drivers,
+                              (True, False),
+                              (True, False)):
+
+            a = at.astype(dtype)
+            b = np.array(bt, dtype=dtype)
+            # Store values in case they are overwritten
+            # later
+            a1 = a.copy()
+            b1 = b.copy()
+            try:
+                out = lstsq(a1, b1, lapack_driver=lapack_driver,
+                            check_finite=check_finite, overwrite_a=overwrite,
+                            overwrite_b=overwrite)
+            except LstsqLapackError:
+                if lapack_driver is None:
+                    raise AssertionError('LstsqLapackError raised with '
+                                         '"lapack_driver" being "None".')
+                else:
+                    # can't proceed,
+                    # skip to the next iteration
+                    continue
+            x = out[0]
+            r = out[2]
+            assert_(r == 2, 'expected efficient rank 2, got %s' % r)
+            assert_allclose(dot(a, x), b,
+                            rtol=25 * _eps_cast(a.dtype),
+                            atol=25 * _eps_cast(a.dtype),
+                            err_msg="driver: %s" % lapack_driver)
 
     def test_zero_size(self):
         for a_shape, b_shape in (((0, 2), (0,)),

--- a/scipy/linalg/tests/test_decomp_ldl.py
+++ b/scipy/linalg/tests/test_decomp_ldl.py
@@ -94,7 +94,7 @@ def test_permutations():
 
 def test_ldl_type_size_combinations():
     seed(1234)
-    sizes = [100, 1000]
+    sizes = [30, 750]
     real_dtypes = [float32, float64]
     complex_dtypes = [complex64, complex128]
 


### PR DESCRIPTION
Two tests have 1000 as array sizes but actually they can be smaller to serve the same purpose. 

Also some PEP8 cleanups.