### PR TITLE
ENH: scipy.sparse: add method for (faster) lil matrix vector multiplication

### DIFF
--- a/scipy/sparse/_csparsetools.pyx.in
+++ b/scipy/sparse/_csparsetools.pyx.in
@@ -467,8 +467,8 @@ _fill_dtype_map2(_LIL_FANCY_SET_DISPATCH)
 @cython.wraparound(False)
 def lil_matvec(const cython.integral M,
                const cython.integral N,
-               const cython.integral[:] rows,
-               const cython.numeric[:] data,
+               cnp.ndarray [list] rows,
+               cnp.ndarray [list] data,
                cnp.ndarray[cython.numeric] vec,
                cnp.ndarray[cython.numeric] result):
     """

--- a/scipy/sparse/_csparsetools.pyx.in
+++ b/scipy/sparse/_csparsetools.pyx.in
@@ -463,11 +463,14 @@ _fill_dtype_map(_LIL_FANCY_GET_DISPATCH, np.typecodes['Integer'])
 _fill_dtype_map2(_LIL_FANCY_SET_DISPATCH)
 
 
-def lil_matvec(int M, int N,
-               object[:] rows,
-               object[:] data,
-               cnp.ndarray vec,
-               cnp.ndarray result):
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def lil_matvec(const cython.integral M,
+               const cython.integral N,
+               const cython.integral[:] rows,
+               const cython.numeric[:] data,
+               cnp.ndarray[cython.numeric] vec,
+               cnp.ndarray[cython.numeric] result):
     """
     Compute y = A * x for LIL matrix A and dense vectors x and y.
 
@@ -483,8 +486,10 @@ def lil_matvec(int M, int N,
 
     """
 
+    cdef cython.integral i, k, j
+    cdef cython.numeric result_i
     for i in range(M):
         result_i = 0
-        for (j, A_ij) in zip(rows[i], data[i]):
-            result_i += A_ij * vec[j]
+        for k, j in enumerate(data):
+            result_i = result_i + data[k] * vec[j]
         result[i] = result_i

--- a/scipy/sparse/_csparsetools.pyx.in
+++ b/scipy/sparse/_csparsetools.pyx.in
@@ -490,6 +490,6 @@ def lil_matvec(const cython.integral M,
     cdef cython.numeric result_i
     for i in range(M):
         result_i = 0
-        for k, j in enumerate(data):
+        for k, j in enumerate(rows):
             result_i = result_i + data[k] * vec[j]
         result[i] = result_i

--- a/scipy/sparse/_csparsetools.pyx.in
+++ b/scipy/sparse/_csparsetools.pyx.in
@@ -461,3 +461,30 @@ cdef _fill_dtype_map2(map):
 
 _fill_dtype_map(_LIL_FANCY_GET_DISPATCH, np.typecodes['Integer'])
 _fill_dtype_map2(_LIL_FANCY_SET_DISPATCH)
+
+
+def lil_matvec(int M, int N,
+               object[:] rows,
+               object[:] data,
+               cnp.ndarray vec,
+               cnp.ndarray result):
+    """
+    Compute y = A * x for LIL matrix A and dense vectors x and y.
+
+    Parameters
+    ----------
+    M, N, rows, data
+        The data from the LIL matrix A.
+    vec
+        The vector x as array.
+    res
+        The vector y as array.
+        Must be preallocated to shape `N`!
+
+    """
+
+    for i in range(M):
+        result_i = 0
+        for (j, A_ij) in zip(rows[i], data[i]):
+            result_i += A_ij * vec[j]
+        result[i] = result_i

--- a/scipy/sparse/_csparsetools.pyx.in
+++ b/scipy/sparse/_csparsetools.pyx.in
@@ -463,14 +463,31 @@ _fill_dtype_map(_LIL_FANCY_GET_DISPATCH, np.typecodes['Integer'])
 _fill_dtype_map2(_LIL_FANCY_SET_DISPATCH)
 
 
-@cython.boundscheck(False)
-@cython.wraparound(False)
-def lil_matvec(const cython.integral M,
-               const cython.integral N,
-               cnp.ndarray [list] rows,
-               cnp.ndarray [list] data,
-               cnp.ndarray[cython.numeric] vec,
-               cnp.ndarray[cython.numeric] result):
+ctypedef fused vector_type:
+    cnp.int8_t
+    cnp.int16_t
+    cnp.int32_t
+    cnp.int64_t
+    cnp.float32_t
+    cnp.float64_t
+    cnp.complex64_t
+    cnp.complex128_t
+ctypedef fused result_type:
+    cnp.int8_t
+    cnp.int16_t
+    cnp.int32_t
+    cnp.int64_t
+    cnp.float32_t
+    cnp.float64_t
+    cnp.complex64_t
+    cnp.complex128_t
+
+def lil_matvec(cython.integral M,
+               cython.integral N,
+               cnp.ndarray[list] rows,
+               cnp.ndarray[list] data,
+               cnp.ndarray[vector_type] vector,
+               cnp.ndarray[result_type] result):
     """
     Compute y = A * x for LIL matrix A and dense vectors x and y.
 
@@ -478,7 +495,7 @@ def lil_matvec(const cython.integral M,
     ----------
     M, N, rows, data
         The data from the LIL matrix A.
-    vec
+    vector
         The vector x as array.
     res
         The vector y as array.
@@ -487,9 +504,12 @@ def lil_matvec(const cython.integral M,
     """
 
     cdef cython.integral i, k, j
-    cdef cython.numeric result_i
-    for i in range(M):
+    cdef list row_i, data_i
+    cdef result_type result_i
+
+    for i, row_i in enumerate(rows):
+        data_i = data[i]
         result_i = 0
-        for k, j in enumerate(rows):
-            result_i = result_i + data[k] * vec[j]
+        for k, j in enumerate(row_i):
+            result_i = result_i + data_i[k] * vector[j]
         result[i] = result_i

--- a/scipy/sparse/_csparsetools.pyx.in
+++ b/scipy/sparse/_csparsetools.pyx.in
@@ -482,6 +482,8 @@ ctypedef fused result_type:
     cnp.complex64_t
     cnp.complex128_t
 
+@cython.boundscheck(False)
+@cython.wraparound(False)
 def lil_matvec(cython.integral M,
                cython.integral N,
                cnp.ndarray[list] rows,

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -13,7 +13,7 @@ import numpy as np
 
 from scipy._lib.six import xrange, zip
 from .base import spmatrix, isspmatrix
-from .sputils import (getdtype, isshape, isscalarlike, IndexMixin,
+from .sputils import (getdtype, isshape, isscalarlike, IndexMixin, upcast_char,
                       upcast_scalar, get_index_dtype, isintlike, check_shape,
                       check_reshape_kwargs)
 from . import _csparsetools
@@ -368,6 +368,14 @@ class lil_matrix(spmatrix, IndexMixin):
             for j, rowvals in enumerate(new.data):
                 new.data[j] = [val*other for val in rowvals]
         return new
+
+    def _mul_vector(self, other):
+        M, N = self.shape
+        result = np.empty(M, dtype=upcast_char(self.dtype.char,
+                                               other.dtype.char))
+        _csparsetools.lil_matvec(M, N, self.rows, self.data,
+                                 other, result)
+        return result
 
     def __truediv__(self, other):           # self / other
         if isscalarlike(other):

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -3042,6 +3042,10 @@ class _TestArithmetic(object):
         self.__Asp = self.spmatrix(self.__A)
         self.__Bsp = self.spmatrix(self.__B)
 
+        # vector for matrix vector multiplication
+        self.__x = np.array((1, 0, 2, 3)).reshape(1, -1)
+        self.__y = np.array((4.5, 1.25, 0, 1 + 1j, 1, 2j)).reshape(-1, 1)
+
     def test_add_sub(self):
         self.__arith_init()
 
@@ -3104,6 +3108,14 @@ class _TestArithmetic(object):
                 assert_allclose(S1.todense(), D1,
                                 atol=1e-14*abs(D1).max())
                 assert_equal(S1.dtype,D1.dtype)
+
+    def test_mul_vector(self):
+        self.__arith_init()
+        x = self.__x
+        y = self.__y
+        for A, Asp in ((self.__A, self.__Asp), (self.__B, self.__Bsp)):
+            assert_array_equal(x * Asp, x * A)
+            assert_array_equal(Asp * y, A * y)
 
 
 class _TestMinMax(object):


### PR DESCRIPTION
The `_mul_vector` method of the `lil_matrix` class was implemented using Cython to allow fast matrix vector multiplications with lil matrices. A test for sparse matrix vector multiplication was also added.