### PR TITLE
DOC: Better, shared docstrings in ndimage

### DIFF
--- a/scipy/ndimage/_ni_docstrings.py
+++ b/scipy/ndimage/_ni_docstrings.py
@@ -1,0 +1,130 @@
+"""Docstring components common to several ndimage functions."""
+from __future__ import division, print_function, absolute_import
+
+from scipy.misc import doccer
+
+__all__ = ['docfiller']
+
+
+_input_doc = (
+"""input : array_like
+    The input array.""")
+_axis_doc = (
+"""axis : int, optional
+    The axis of `input` along which to calculate. Default is -1.""")
+_output_doc = (
+"""output : array or dtype, optional
+    The array in which to place the output, or the dtype of the
+    returned array. By default an array of the same dtype as input
+    will be created.""")
+_size_foot_doc = (
+"""size : scalar or tuple, optional
+    See footprint, below
+footprint : array, optional
+    Either `size` or `footprint` must be defined.  `size` gives
+    the shape that is taken from the input array, at every element
+    position, to define the input to the filter function.
+    `footprint` is a boolean array that specifies (implicitly) a
+    shape, but also which of the elements within this shape will get
+    passed to the filter function.  Thus ``size=(n,m)`` is equivalent
+    to ``footprint=np.ones((n,m))``.  We adjust `size` to the number
+    of dimensions of the input array, so that, if the input array is
+    shape (10,10,10), and `size` is 2, then the actual size used is
+    (2,2,2).""")
+_mode_doc = (
+"""mode : {'reflect', 'constant', 'nearest', 'mirror', 'wrap'}, optional
+    The `mode` parameter determines how the input array is extended
+    when the filter overlaps a border. Default is 'reflect'. Behavior
+    for each valid value is as follows:
+
+    'reflect' (`d c b a | a b c d | d c b a`)
+        The input is extended by reflecting about the edge of the last
+        pixel.
+
+    'constant' (`k k k k | a b c d | k k k k`)
+        The input is extended by filling all values beyond the edge with
+        the same constant value, defined by the `cval` parameter.
+
+    'nearest' (`a a a a | a b c d | d d d d`)
+        The input is extended by replicating the last pixel.
+
+    'mirror' (`d c b | a b c d | c b a`)
+        The input is extended by reflecting about the center of the last
+        pixel.
+
+    'wrap' (`a b c d | a b c d | a b c d`)
+        The input is extended by wrapping around to the opposite edge.""")
+_mode_multiple_doc = (
+"""mode : str or sequence, optional
+    The `mode` parameter determines how the input array is extended
+    when the filter overlaps a border. By passing a sequence of modes
+    with length equal to the number of dimensions of the input array,
+    different modes can be specified along each axis. Default value is
+    'reflect'. The valid values and their behavior is as follows:
+
+    'reflect' (`d c b a | a b c d | d c b a`)
+        The input is extended by reflecting about the edge of the last
+        pixel.
+
+    'constant' (`k k k k | a b c d | k k k k`)
+        The input is extended by filling all values beyond the edge with
+        the same constant value, defined by the `cval` parameter.
+
+    'nearest' (`a a a a | a b c d | d d d d`)
+        The input is extended by replicating the last pixel.
+
+    'mirror' (`d c b | a b c d | c b a`)
+        The input is extended by reflecting about the center of the last
+        pixel.
+
+    'wrap' (`a b c d | a b c d | a b c d`)
+        The input is extended by wrapping around to the opposite edge.""")
+_cval_doc = (
+"""cval : scalar, optional
+    Value to fill past edges of input if `mode` is 'constant'. Default
+    is 0.0.""")
+_origin_doc = (
+"""origin : int, optional
+    Controls the placement of the filter on the input array's pixels.
+    A value of 0 (the default) centers the filter over the pixel, with
+    positive values shifting the filter to the left, and negative ones
+    to the right.""")
+_origin_multiple_doc = (
+"""origin : int or sequence, optional
+    Controls the placement of the filter on the input array's pixels.
+    A value of 0 (the default) centers the filter over the pixel, with
+    positive values shifting the filter to the left, and negative ones
+    to the right. By passing a sequence of origins with length equal to
+    the number of dimensions of the input array, different shifts can
+    be specified along each axis.""")
+_extra_arguments_doc = (
+"""extra_arguments : sequence, optional
+    Sequence of extra positional arguments to pass to passed function.""")
+_extra_keywords_doc = (
+"""extra_keywords : dict, optional
+    dict of extra keyword arguments to pass to passed function.""")
+_prefilter_doc = (
+"""prefilter : bool, optional
+    Determines if the input array is prefiltered with `spline_filter`
+    before interpolation. The default is True, which will create a
+    temporary `float64` array of filtered values if `order > 1`. If
+    setting this to False, the output will be slightly blurred if
+    `order > 1`, unless the input is prefiltered, i.e. it is the result
+    of calling `spline_filter` on the original input."""  )
+
+docdict = {
+    'input': _input_doc,
+    'axis': _axis_doc,
+    'output': _output_doc,
+    'size_foot': _size_foot_doc,
+    'mode': _mode_doc,
+    'mode_multiple': _mode_multiple_doc,
+    'cval': _cval_doc,
+    'origin': _origin_doc,
+    'origin_multiple': _origin_multiple_doc,
+    'extra_arguments': _extra_arguments_doc,
+    'extra_keywords': _extra_keywords_doc,
+    'prefilter': _prefilter_doc
+    }
+
+docfiller = doccer.filldoc(docdict)

--- a/scipy/ndimage/filters.py
+++ b/scipy/ndimage/filters.py
@@ -75,25 +75,70 @@ footprint : array, optional
 """
 _mode_doc = \
 """mode : {'reflect', 'constant', 'nearest', 'mirror', 'wrap'}, optional
-    The `mode` parameter determines how the array borders are
-    handled, where `cval` is the value when mode is equal to
-    'constant'. Default is 'reflect'"""
+    The `mode` parameter determines how the input array is extended
+    when the filter overlaps a border. Default is 'reflect'. Behavior
+    for each valid value is as follows:
+
+    'reflect' (`d c b a | a b c d | d c b a`)
+        The input is extended by reflecting about the edge of the last
+        pixel.
+
+    'constant' (`k k k k | a b c d | k k k k`)
+        The input is extended by filling all values beyond the edge with
+        the same constant value, defined by the `cval` parameter.
+
+    'nearest' (`a a a a | a b c d | d d d d`)
+        The input is extended by replicating the last pixel.
+
+    'mirror' (`d c b | a b c d | c b a`)
+        The input is extended by reflecting about the center of the last
+        pixel.
+
+    'wrap' (`a b c d | a b c d | a b c d`)
+        The input is extended by wrapping around to the opposite edge."""
 _mode_multiple_doc = \
 """mode : str or sequence, optional
-    The `mode` parameter determines how the array borders are
-    handled. Valid modes are {'reflect', 'constant', 'nearest',
-    'mirror', 'wrap'}. `cval` is the value used when mode is equal to
-    'constant'. A list of modes with length equal to the number of
-    axes can be provided to specify different modes for different
-    axes. Default is 'reflect'"""
+    The `mode` parameter determines how the input array is extended
+    when the filter overlaps a border. By passing a sequence of modes
+    with length equal to the number of dimensions of the input array,
+    different modes can be specified along each axis. Default value is
+    'reflect'. The valid values and their behavior is as follows:
+
+    'reflect' (`d c b a | a b c d | d c b a`)
+        The input is extended by reflecting about the edge of the last
+        pixel.
+
+    'constant' (`k k k k | a b c d | k k k k`)
+        The input is extended by filling all values beyond the edge with
+        the same constant value, defined by the `cval` parameter.
+
+    'nearest' (`a a a a | a b c d | d d d d`)
+        The input is extended by replicating the last pixel.
+
+    'mirror' (`d c b | a b c d | c b a`)
+        The input is extended by reflecting about the center of the last
+        pixel.
+
+    'wrap' (`a b c d | a b c d | a b c d`)
+        The input is extended by wrapping around to the opposite edge."""
 _cval_doc = \
 """cval : scalar, optional
     Value to fill past edges of input if `mode` is 'constant'. Default
     is 0.0"""
 _origin_doc = \
-"""origin : scalar, optional
-    The `origin` parameter controls the placement of the filter.
-    Default 0.0."""
+"""origin : int, optional
+    Controls the placement of the filter on the input array's pixels.
+    A value of 0 (the default) centers the filter over the pixel, with
+    positive values shifting the filter to the left, and negative ones
+    to the right."""
+_origin_multiple_doc = \
+"""origin : int or sequence, optional
+    Controls the placement of the filter on the input array's pixels.
+    A value of 0 (the default) centers the filter over the pixel, with
+    positive values shifting the filter to the left, and negative ones
+    to the right. By passing a sequence of origins with length equal to
+    the number of dimensions of the input array, different shifts can
+    be specified along each axis."""
 _extra_arguments_doc = \
 """extra_arguments : sequence, optional
     Sequence of extra positional arguments to pass to passed function"""
@@ -110,6 +155,7 @@ docdict = {
     'mode_multiple': _mode_multiple_doc,
     'cval': _cval_doc,
     'origin': _origin_doc,
+    'origin_multiple': _origin_multiple_doc,
     'extra_arguments': _extra_arguments_doc,
     'extra_keywords': _extra_keywords_doc,
     }
@@ -685,24 +731,13 @@ def correlate(input, weights, output=None, mode='reflect', cval=0.0,
 
     Parameters
     ----------
-    input : array-like
-        input array to filter
+    %(input)s
     weights : ndarray
         array of weights, same number of dimensions as input
-    output : array, optional
-        The ``output`` parameter passes an array in which to store the
-        filter output. Output array should have different name as
-        compared to input array to avoid aliasing errors.
-    mode : {'reflect','constant','nearest','mirror', 'wrap'}, optional
-        The ``mode`` parameter determines how the array borders are
-        handled, where ``cval`` is the value when mode is equal to
-        'constant'. Default is 'reflect'
-    cval : scalar, optional
-        Value to fill past edges of input if ``mode`` is 'constant'. Default
-        is 0.0
-    origin : scalar, optional
-        The ``origin`` parameter controls the placement of the filter.
-        Default 0
+    %(output)s
+    %(mode_multiple)s
+    %(cval)s
+    %(origin_multiple)s
 
     See Also
     --------
@@ -722,25 +757,15 @@ def convolve(input, weights, output=None, mode='reflect', cval=0.0,
 
     Parameters
     ----------
-    input : array_like
-        Input array to filter.
+    %(input)s
     weights : array_like
         Array of weights, same number of dimensions as input
-    output : ndarray, optional
-        The `output` parameter passes an array in which to store the
-        filter output. Output array should have different name as
-        compared to input array to avoid aliasing errors.
-    mode : {'reflect','constant','nearest','mirror', 'wrap'}, optional
-        the `mode` parameter determines how the array borders are
-        handled. For 'constant' mode, values beyond borders are set to be
-        `cval`. Default is 'reflect'.
+    %(output)s
+    %(mode_multiple)s
     cval : scalar, optional
         Value to fill past edges of input if `mode` is 'constant'. Default
         is 0.0
-    origin : array_like, optional
-        The `origin` parameter controls the placement of the filter,
-        relative to the centre of the current element of the input.
-        Default of 0 is equivalent to ``(0,)*input.ndim``.
+    %(origin_multiple)s
 
     Returns
     -------
@@ -883,7 +908,7 @@ def uniform_filter(input, size=3, output=None, mode="reflect",
     %(output)s
     %(mode_multiple)s
     %(cval)s
-    %(origin)s
+    %(origin_multiple)s
 
     Returns
     -------
@@ -1116,7 +1141,7 @@ def minimum_filter(input, size=None, footprint=None, output=None,
     %(output)s
     %(mode_multiple)s
     %(cval)s
-    %(origin)s
+    %(origin_multiple)s
 
     Returns
     -------
@@ -1153,7 +1178,7 @@ def maximum_filter(input, size=None, footprint=None, output=None,
     %(output)s
     %(mode_multiple)s
     %(cval)s
-    %(origin)s
+    %(origin_multiple)s
 
     Returns
     -------
@@ -1244,9 +1269,9 @@ def rank_filter(input, rank, size=None, footprint=None, output=None,
         indicates the largest element.
     %(size_foot)s
     %(output)s
-    %(mode)s
+    %(mode_multiple)s
     %(cval)s
-    %(origin)s
+    %(origin_multiple)s
 
     Returns
     -------
@@ -1282,9 +1307,9 @@ def median_filter(input, size=None, footprint=None, output=None,
     %(input)s
     %(size_foot)s
     %(output)s
-    %(mode)s
+    %(mode_multiple)s
     %(cval)s
-    %(origin)s
+    %(origin_multiple)s
 
     Returns
     -------
@@ -1322,9 +1347,9 @@ def percentile_filter(input, percentile, size=None, footprint=None,
         percentile = -20 equals percentile = 80
     %(size_foot)s
     %(output)s
-    %(mode)s
+    %(mode_multiple)s
     %(cval)s
-    %(origin)s
+    %(origin_multiple)s
 
     Returns
     -------
@@ -1449,9 +1474,9 @@ def generic_filter(input, function, size=None, footprint=None,
         Function to apply at each element.
     %(size_foot)s
     %(output)s
-    %(mode)s
+    %(mode_multiple)s
     %(cval)s
-    %(origin)s
+    %(origin_multiple)s
     %(extra_arguments)s
     %(extra_keywords)s
 

--- a/scipy/ndimage/filters.py
+++ b/scipy/ndimage/filters.py
@@ -34,6 +34,7 @@ import math
 import numpy
 from . import _ni_support
 from . import _nd_image
+from . import _ni_docstrings
 from scipy.misc import doccer
 from scipy._lib._version import NumpyVersion
 
@@ -47,123 +48,7 @@ __all__ = ['correlate1d', 'convolve1d', 'gaussian_filter1d', 'gaussian_filter',
            'generic_filter1d', 'generic_filter']
 
 
-_input_doc = \
-"""input : array_like
-    Input array to filter."""
-_axis_doc = \
-"""axis : int, optional
-    The axis of `input` along which to calculate. Default is -1."""
-_output_doc = \
-"""output : array, optional
-    The `output` parameter passes an array in which to store the
-    filter output. Output array should have different name as compared
-    to input array to avoid aliasing errors."""
-_size_foot_doc = \
-"""size : scalar or tuple, optional
-    See footprint, below
-footprint : array, optional
-    Either `size` or `footprint` must be defined.  `size` gives
-    the shape that is taken from the input array, at every element
-    position, to define the input to the filter function.
-    `footprint` is a boolean array that specifies (implicitly) a
-    shape, but also which of the elements within this shape will get
-    passed to the filter function.  Thus ``size=(n,m)`` is equivalent
-    to ``footprint=np.ones((n,m))``.  We adjust `size` to the number
-    of dimensions of the input array, so that, if the input array is
-    shape (10,10,10), and `size` is 2, then the actual size used is
-    (2,2,2).
-"""
-_mode_doc = \
-"""mode : {'reflect', 'constant', 'nearest', 'mirror', 'wrap'}, optional
-    The `mode` parameter determines how the input array is extended
-    when the filter overlaps a border. Default is 'reflect'. Behavior
-    for each valid value is as follows:
-
-    'reflect' (`d c b a | a b c d | d c b a`)
-        The input is extended by reflecting about the edge of the last
-        pixel.
-
-    'constant' (`k k k k | a b c d | k k k k`)
-        The input is extended by filling all values beyond the edge with
-        the same constant value, defined by the `cval` parameter.
-
-    'nearest' (`a a a a | a b c d | d d d d`)
-        The input is extended by replicating the last pixel.
-
-    'mirror' (`d c b | a b c d | c b a`)
-        The input is extended by reflecting about the center of the last
-        pixel.
-
-    'wrap' (`a b c d | a b c d | a b c d`)
-        The input is extended by wrapping around to the opposite edge."""
-_mode_multiple_doc = \
-"""mode : str or sequence, optional
-    The `mode` parameter determines how the input array is extended
-    when the filter overlaps a border. By passing a sequence of modes
-    with length equal to the number of dimensions of the input array,
-    different modes can be specified along each axis. Default value is
-    'reflect'. The valid values and their behavior is as follows:
-
-    'reflect' (`d c b a | a b c d | d c b a`)
-        The input is extended by reflecting about the edge of the last
-        pixel.
-
-    'constant' (`k k k k | a b c d | k k k k`)
-        The input is extended by filling all values beyond the edge with
-        the same constant value, defined by the `cval` parameter.
-
-    'nearest' (`a a a a | a b c d | d d d d`)
-        The input is extended by replicating the last pixel.
-
-    'mirror' (`d c b | a b c d | c b a`)
-        The input is extended by reflecting about the center of the last
-        pixel.
-
-    'wrap' (`a b c d | a b c d | a b c d`)
-        The input is extended by wrapping around to the opposite edge."""
-_cval_doc = \
-"""cval : scalar, optional
-    Value to fill past edges of input if `mode` is 'constant'. Default
-    is 0.0"""
-_origin_doc = \
-"""origin : int, optional
-    Controls the placement of the filter on the input array's pixels.
-    A value of 0 (the default) centers the filter over the pixel, with
-    positive values shifting the filter to the left, and negative ones
-    to the right."""
-_origin_multiple_doc = \
-"""origin : int or sequence, optional
-    Controls the placement of the filter on the input array's pixels.
-    A value of 0 (the default) centers the filter over the pixel, with
-    positive values shifting the filter to the left, and negative ones
-    to the right. By passing a sequence of origins with length equal to
-    the number of dimensions of the input array, different shifts can
-    be specified along each axis."""
-_extra_arguments_doc = \
-"""extra_arguments : sequence, optional
-    Sequence of extra positional arguments to pass to passed function"""
-_extra_keywords_doc = \
-"""extra_keywords : dict, optional
-    dict of extra keyword arguments to pass to passed function"""
-
-docdict = {
-    'input': _input_doc,
-    'axis': _axis_doc,
-    'output': _output_doc,
-    'size_foot': _size_foot_doc,
-    'mode': _mode_doc,
-    'mode_multiple': _mode_multiple_doc,
-    'cval': _cval_doc,
-    'origin': _origin_doc,
-    'origin_multiple': _origin_multiple_doc,
-    'extra_arguments': _extra_arguments_doc,
-    'extra_keywords': _extra_keywords_doc,
-    }
-
-docfiller = doccer.filldoc(docdict)
-
-
-@docfiller
+@_ni_docstrings.docfiller
 def correlate1d(input, weights, axis=-1, output=None, mode="reflect",
                 cval=0.0, origin=0):
     """Calculate a one-dimensional correlation along the given axis.
@@ -207,7 +92,7 @@ def correlate1d(input, weights, axis=-1, output=None, mode="reflect",
     return output
 
 
-@docfiller
+@_ni_docstrings.docfiller
 def convolve1d(input, weights, axis=-1, output=None, mode="reflect",
                cval=0.0, origin=0):
     """Calculate a one-dimensional convolution along the given axis.
@@ -265,7 +150,7 @@ def _gaussian_kernel1d(sigma, order, radius):
     return phi_x
 
 
-@docfiller
+@_ni_docstrings.docfiller
 def gaussian_filter1d(input, sigma, axis=-1, order=0, output=None,
                       mode="reflect", cval=0.0, truncate=4.0):
     """One-dimensional Gaussian filter.
@@ -318,7 +203,7 @@ def gaussian_filter1d(input, sigma, axis=-1, order=0, output=None,
     return correlate1d(input, weights, axis, output, mode, cval, 0)
 
 
-@docfiller
+@_ni_docstrings.docfiller
 def gaussian_filter(input, sigma, order=0, output=None,
                     mode="reflect", cval=0.0, truncate=4.0):
     """Multidimensional Gaussian filter.
@@ -404,7 +289,7 @@ def gaussian_filter(input, sigma, order=0, output=None,
     return output
 
 
-@docfiller
+@_ni_docstrings.docfiller
 def prewitt(input, axis=-1, output=None, mode="reflect", cval=0.0):
     """Calculate a Prewitt filter.
 
@@ -441,7 +326,7 @@ def prewitt(input, axis=-1, output=None, mode="reflect", cval=0.0):
     return output
 
 
-@docfiller
+@_ni_docstrings.docfiller
 def sobel(input, axis=-1, output=None, mode="reflect", cval=0.0):
     """Calculate a Sobel filter.
 
@@ -478,7 +363,7 @@ def sobel(input, axis=-1, output=None, mode="reflect", cval=0.0):
     return output
 
 
-@docfiller
+@_ni_docstrings.docfiller
 def generic_laplace(input, derivative2, output=None, mode="reflect",
                     cval=0.0,
                     extra_arguments=(),
@@ -520,7 +405,7 @@ def generic_laplace(input, derivative2, output=None, mode="reflect",
     return output
 
 
-@docfiller
+@_ni_docstrings.docfiller
 def laplace(input, output=None, mode="reflect", cval=0.0):
     """N-dimensional Laplace filter based on approximate second derivatives.
 
@@ -550,7 +435,7 @@ def laplace(input, output=None, mode="reflect", cval=0.0):
     return generic_laplace(input, derivative2, output, mode, cval)
 
 
-@docfiller
+@_ni_docstrings.docfiller
 def gaussian_laplace(input, sigma, output=None, mode="reflect",
                      cval=0.0, **kwargs):
     """Multidimensional Laplace filter using gaussian second derivatives.
@@ -598,7 +483,7 @@ def gaussian_laplace(input, sigma, output=None, mode="reflect",
                            extra_keywords=kwargs)
 
 
-@docfiller
+@_ni_docstrings.docfiller
 def generic_gradient_magnitude(input, derivative, output=None,
                                mode="reflect", cval=0.0,
                                extra_arguments=(), extra_keywords=None):
@@ -645,7 +530,7 @@ def generic_gradient_magnitude(input, derivative, output=None,
     return output
 
 
-@docfiller
+@_ni_docstrings.docfiller
 def gaussian_gradient_magnitude(input, sigma, output=None,
                                 mode="reflect", cval=0.0, **kwargs):
     """Multidimensional gradient magnitude using Gaussian derivatives.
@@ -721,7 +606,7 @@ def _correlate_or_convolve(input, weights, output, mode, cval, origin,
     return output
 
 
-@docfiller
+@_ni_docstrings.docfiller
 def correlate(input, weights, output=None, mode='reflect', cval=0.0,
               origin=0):
     """
@@ -747,7 +632,7 @@ def correlate(input, weights, output=None, mode='reflect', cval=0.0,
                                   origin, False)
 
 
-@docfiller
+@_ni_docstrings.docfiller
 def convolve(input, weights, output=None, mode='reflect', cval=0.0,
              origin=0):
     """
@@ -853,7 +738,7 @@ def convolve(input, weights, output=None, mode='reflect', cval=0.0,
                                   origin, True)
 
 
-@docfiller
+@_ni_docstrings.docfiller
 def uniform_filter1d(input, size, axis=-1, output=None,
                      mode="reflect", cval=0.0, origin=0):
     """Calculate a one-dimensional uniform filter along the given axis.
@@ -893,7 +778,7 @@ def uniform_filter1d(input, size, axis=-1, output=None,
     return output
 
 
-@docfiller
+@_ni_docstrings.docfiller
 def uniform_filter(input, size=3, output=None, mode="reflect",
                    cval=0.0, origin=0):
     """Multi-dimensional uniform filter.
@@ -955,7 +840,7 @@ def uniform_filter(input, size=3, output=None, mode="reflect",
     return output
 
 
-@docfiller
+@_ni_docstrings.docfiller
 def minimum_filter1d(input, size, axis=-1, output=None,
                      mode="reflect", cval=0.0, origin=0):
     """Calculate a one-dimensional minimum filter along the given axis.
@@ -1007,7 +892,7 @@ def minimum_filter1d(input, size, axis=-1, output=None,
     return output
 
 
-@docfiller
+@_ni_docstrings.docfiller
 def maximum_filter1d(input, size, axis=-1, output=None,
                      mode="reflect", cval=0.0, origin=0):
     """Calculate a one-dimensional maximum filter along the given axis.
@@ -1129,7 +1014,7 @@ def _min_or_max_filter(input, size, footprint, structure, output, mode,
     return output
 
 
-@docfiller
+@_ni_docstrings.docfiller
 def minimum_filter(input, size=None, footprint=None, output=None,
                    mode="reflect", cval=0.0, origin=0):
     """Calculate a multi-dimensional minimum filter.
@@ -1166,7 +1051,7 @@ def minimum_filter(input, size=None, footprint=None, output=None,
                               cval, origin, 1)
 
 
-@docfiller
+@_ni_docstrings.docfiller
 def maximum_filter(input, size=None, footprint=None, output=None,
                    mode="reflect", cval=0.0, origin=0):
     """Calculate a multi-dimensional maximum filter.
@@ -1203,7 +1088,7 @@ def maximum_filter(input, size=None, footprint=None, output=None,
                               cval, origin, 0)
 
 
-@docfiller
+@_ni_docstrings.docfiller
 def _rank_filter(input, rank, size=None, footprint=None, output=None,
                  mode="reflect", cval=0.0, origin=0, operation='rank'):
     input = numpy.asarray(input)
@@ -1256,7 +1141,7 @@ def _rank_filter(input, rank, size=None, footprint=None, output=None,
         return output
 
 
-@docfiller
+@_ni_docstrings.docfiller
 def rank_filter(input, rank, size=None, footprint=None, output=None,
                 mode="reflect", cval=0.0, origin=0):
     """Calculate a multi-dimensional rank filter.
@@ -1296,7 +1181,7 @@ def rank_filter(input, rank, size=None, footprint=None, output=None,
                         origin, 'rank')
 
 
-@docfiller
+@_ni_docstrings.docfiller
 def median_filter(input, size=None, footprint=None, output=None,
                   mode="reflect", cval=0.0, origin=0):
     """
@@ -1334,7 +1219,7 @@ def median_filter(input, size=None, footprint=None, output=None,
                         origin, 'median')
 
 
-@docfiller
+@_ni_docstrings.docfiller
 def percentile_filter(input, percentile, size=None, footprint=None,
                       output=None, mode="reflect", cval=0.0, origin=0):
     """Calculate a multi-dimensional percentile filter.
@@ -1374,7 +1259,7 @@ def percentile_filter(input, percentile, size=None, footprint=None,
                         cval, origin, 'percentile')
 
 
-@docfiller
+@_ni_docstrings.docfiller
 def generic_filter1d(input, function, filter_size, axis=-1,
                      output=None, mode="reflect", cval=0.0, origin=0,
                      extra_arguments=(), extra_keywords=None):
@@ -1457,7 +1342,7 @@ def generic_filter1d(input, function, filter_size, axis=-1,
     return output
 
 
-@docfiller
+@_ni_docstrings.docfiller
 def generic_filter(input, function, size=None, footprint=None,
                    output=None, mode="reflect", cval=0.0, origin=0,
                    extra_arguments=(), extra_keywords=None):

--- a/scipy/ndimage/interpolation.py
+++ b/scipy/ndimage/interpolation.py
@@ -34,6 +34,7 @@ import math
 import numpy
 from . import _ni_support
 from . import _nd_image
+from . import _ni_docstrings
 from functools import wraps
 
 import warnings
@@ -42,6 +43,7 @@ __all__ = ['spline_filter1d', 'spline_filter', 'geometric_transform',
            'map_coordinates', 'affine_transform', 'shift', 'zoom', 'rotate']
 
 
+@_ni_docstrings.docfiller
 def spline_filter1d(input, order=3, axis=-1, output=numpy.float64):
     """
     Calculate a one-dimensional spline filter along the given axis.
@@ -51,8 +53,7 @@ def spline_filter1d(input, order=3, axis=-1, output=numpy.float64):
 
     Parameters
     ----------
-    input : array_like
-        The input array.
+    %(input)s
     order : int, optional
         The order of the spline, default is 3.
     axis : int, optional
@@ -116,6 +117,7 @@ def spline_filter(input, order=3, output=numpy.float64):
     return output
 
 
+@_ni_docstrings.docfiller
 def geometric_transform(input, mapping, output_shape=None,
                         output=None, order=3,
                         mode='constant', cval=0.0, prefilter=True,
@@ -130,32 +132,20 @@ def geometric_transform(input, mapping, output_shape=None,
 
     Parameters
     ----------
-    input : array_like
-        The input array.
+    %(input)s
     mapping : {callable, scipy.LowLevelCallable}
         A callable object that accepts a tuple of length equal to the output
         array rank, and returns the corresponding input coordinates as a tuple
         of length equal to the input array rank.
     output_shape : tuple of ints, optional
         Shape tuple.
-    output : ndarray or dtype, optional
-        The array in which to place the output, or the dtype of the returned
-        array.
+    %(output)s
     order : int, optional
         The order of the spline interpolation, default is 3.
         The order has to be in the range 0-5.
-    mode : str, optional
-        Points outside the boundaries of the input are filled according
-        to the given mode ('constant', 'nearest', 'reflect', 'mirror' or 'wrap').
-        Default is 'constant'.
-    cval : scalar, optional
-        Value used for points outside the boundaries of the input if
-        ``mode='constant'``. Default is 0.0
-    prefilter : bool, optional
-        The parameter prefilter determines if the input is pre-filtered with
-        `spline_filter` before interpolation (necessary for spline
-        interpolation of order > 1).  If False, it is assumed that the input is
-        already filtered. Default is True.
+    %(mode)s
+    %(cval)s
+    %(prefilter)s
     extra_arguments : tuple, optional
         Extra arguments passed to `mapping`.
     extra_keywords : dict, optional
@@ -244,14 +234,14 @@ def geometric_transform(input, mapping, output_shape=None,
         filtered = spline_filter(input, order, output=numpy.float64)
     else:
         filtered = input
-    output = _ni_support._get_output(output, input,
-                                                   shape=output_shape)
+    output = _ni_support._get_output(output, input, shape=output_shape)
     _nd_image.geometric_transform(filtered, mapping, None, None, None, output,
                                   order, mode, cval, extra_arguments,
                                   extra_keywords)
     return output
 
 
+@_ni_docstrings.docfiller
 def map_coordinates(input, coordinates, output=None, order=3,
                     mode='constant', cval=0.0, prefilter=True):
     """
@@ -269,28 +259,16 @@ def map_coordinates(input, coordinates, output=None, order=3,
 
     Parameters
     ----------
-    input : ndarray
-        The input array.
+    %(input)s
     coordinates : array_like
         The coordinates at which `input` is evaluated.
-    output : ndarray or dtype, optional
-        The array in which to place the output, or the dtype of the returned
-        array.
+    %(output)s
     order : int, optional
         The order of the spline interpolation, default is 3.
         The order has to be in the range 0-5.
-    mode : str, optional
-        Points outside the boundaries of the input are filled according
-        to the given mode ('constant', 'nearest', 'reflect', 'mirror' or 'wrap').
-        Default is 'constant'.
-    cval : scalar, optional
-        Value used for points outside the boundaries of the input if
-        ``mode='constant'``. Default is 0.0
-    prefilter : bool, optional
-        The parameter prefilter determines if the input is pre-filtered with
-        `spline_filter` before interpolation (necessary for spline
-        interpolation of order > 1).  If False, it is assumed that the input is
-        already filtered. Default is True.
+    %(mode)s
+    %(cval)s
+    %(prefilter)s
 
     Returns
     -------
@@ -351,6 +329,7 @@ def map_coordinates(input, coordinates, output=None, order=3,
     return output
 
 
+@_ni_docstrings.docfiller
 def affine_transform(input, matrix, offset=0.0, output_shape=None,
                      output=None, order=3,
                      mode='constant', cval=0.0, prefilter=True):
@@ -363,8 +342,7 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None,
 
     Parameters
     ----------
-    input : ndarray
-        The input array.
+    %(input)s
     matrix : ndarray
         The inverse coordinate transformation matrix, mapping output
         coordinates to input coordinates. If ``ndim`` is the number of
@@ -390,25 +368,13 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None,
         contain one value for each axis.
     output_shape : tuple of ints, optional
         Shape tuple.
-    output : ndarray or dtype, optional
-        The array in which to place the output, or the dtype of the returned
-        array.
+    %(output)s
     order : int, optional
         The order of the spline interpolation, default is 3.
         The order has to be in the range 0-5.
-    mode : str, optional
-        Points outside the boundaries of the input are filled according
-        to the given mode ('constant', 'nearest', 'reflect', 'mirror' or
-        'wrap').
-        Default is 'constant'.
-    cval : scalar, optional
-        Value used for points outside the boundaries of the input if
-        ``mode='constant'``. Default is 0.0
-    prefilter : bool, optional
-        The parameter prefilter determines if the input is pre-filtered with
-        `spline_filter` before interpolation (necessary for spline
-        interpolation of order > 1).  If False, it is assumed that the input is
-        already filtered. Default is True.
+    %(mode)s
+    %(cval)s
+    %(prefilter)s
 
     Returns
     -------
@@ -493,6 +459,7 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None,
     return output
 
 
+@_ni_docstrings.docfiller
 def shift(input, shift, output=None, order=3, mode='constant', cval=0.0,
           prefilter=True):
     """
@@ -504,29 +471,17 @@ def shift(input, shift, output=None, order=3, mode='constant', cval=0.0,
 
     Parameters
     ----------
-    input : ndarray
-        The input array.
+    %(input)s
     shift : float or sequence
         The shift along the axes. If a float, `shift` is the same for each
         axis. If a sequence, `shift` should contain one value for each axis.
-    output : ndarray or dtype, optional
-        The array in which to place the output, or the dtype of the returned
-        array.
+    %(output)s
     order : int, optional
         The order of the spline interpolation, default is 3.
         The order has to be in the range 0-5.
-    mode : str, optional
-        Points outside the boundaries of the input are filled according
-        to the given mode ('constant', 'nearest', 'reflect', 'mirror' or 'wrap').
-        Default is 'constant'.
-    cval : scalar, optional
-        Value used for points outside the boundaries of the input if
-        ``mode='constant'``. Default is 0.0
-    prefilter : bool, optional
-        The parameter prefilter determines if the input is pre-filtered with
-        `spline_filter` before interpolation (necessary for spline
-        interpolation of order > 1).  If False, it is assumed that the input is
-        already filtered. Default is True.
+    %(mode)s
+    %(cval)s
+    %(prefilter)s
 
     Returns
     -------
@@ -556,6 +511,7 @@ def shift(input, shift, output=None, order=3, mode='constant', cval=0.0,
     return output
 
 
+@_ni_docstrings.docfiller
 def zoom(input, zoom, output=None, order=3, mode='constant', cval=0.0,
          prefilter=True):
     """
@@ -565,29 +521,17 @@ def zoom(input, zoom, output=None, order=3, mode='constant', cval=0.0,
 
     Parameters
     ----------
-    input : ndarray
-        The input array.
+    %(input)s
     zoom : float or sequence
         The zoom factor along the axes. If a float, `zoom` is the same for each
         axis. If a sequence, `zoom` should contain one value for each axis.
-    output : ndarray or dtype, optional
-        The array in which to place the output, or the dtype of the returned
-        array.
+    %(output)s
     order : int, optional
         The order of the spline interpolation, default is 3.
         The order has to be in the range 0-5.
-    mode : str, optional
-        Points outside the boundaries of the input are filled according
-        to the given mode ('constant', 'nearest', 'reflect', 'mirror' or 'wrap').
-        Default is 'constant'.
-    cval : scalar, optional
-        Value used for points outside the boundaries of the input if
-        ``mode='constant'``. Default is 0.0
-    prefilter : bool, optional
-        The parameter prefilter determines if the input is pre-filtered with
-        `spline_filter` before interpolation (necessary for spline
-        interpolation of order > 1).  If False, it is assumed that the input is
-        already filtered. Default is True.
+    %(mode)s
+    %(cval)s
+    %(prefilter)s
 
     Returns
     -------
@@ -664,8 +608,7 @@ def _minmax(coor, minc, maxc):
     return minc, maxc
 
 
-def rotate(input, angle, axes=(1, 0), reshape=True,
-           output=None, order=3,
+def rotate(input, angle, axes=(1, 0), reshape=True, output=None, order=3,
            mode='constant', cval=0.0, prefilter=True):
     """
     Rotate an array.
@@ -675,8 +618,7 @@ def rotate(input, angle, axes=(1, 0), reshape=True,
 
     Parameters
     ----------
-    input : ndarray
-        The input array.
+    %(input)s
     angle : float
         The rotation angle in degrees.
     axes : tuple of 2 ints, optional
@@ -685,24 +627,13 @@ def rotate(input, angle, axes=(1, 0), reshape=True,
     reshape : bool, optional
         If `reshape` is true, the output shape is adapted so that the input
         array is contained completely in the output. Default is True.
-    output : ndarray or dtype, optional
-        The array in which to place the output, or the dtype of the returned
-        array.
+    %(output)s
     order : int, optional
         The order of the spline interpolation, default is 3.
         The order has to be in the range 0-5.
-    mode : str, optional
-        Points outside the boundaries of the input are filled according
-        to the given mode ('constant', 'nearest', 'reflect', 'mirror' or 'wrap').
-        Default is 'constant'.
-    cval : scalar, optional
-        Value used for points outside the boundaries of the input if
-        ``mode='constant'``. Default is 0.0
-    prefilter : bool, optional
-        The parameter prefilter determines if the input is pre-filtered with
-        `spline_filter` before interpolation (necessary for spline
-        interpolation of order > 1).  If False, it is assumed that the input is
-        already filtered. Default is True.
+    %(mode)s
+    %(cval)s
+    %(prefilter)s
 
     Returns
     -------


### PR DESCRIPTION
This extends some of the docstrings of ndimage functions, namely those related to the extend mode, origin and prefiltering in interpolation.

It also creates a new `_ni_docstrings.py` file, to allow reusing docstring components in all files using doccer.