### PR TITLE
ENH: Implement mode parameter for spline filtering.

### DIFF
--- a/scipy/ndimage/_ni_docstrings.py
+++ b/scipy/ndimage/_ni_docstrings.py
@@ -34,8 +34,8 @@ footprint : array, optional
 _mode_doc = (
 """mode : {'reflect', 'constant', 'nearest', 'mirror', 'wrap'}, optional
     The `mode` parameter determines how the input array is extended
-    when the filter overlaps a border. Default is 'reflect'. Behavior
-    for each valid value is as follows:
+    beyond its boundaries. Default is 'reflect'. Behavior for each valid
+    value is as follows:
 
     'reflect' (`d c b a | a b c d | d c b a`)
         The input is extended by reflecting about the edge of the last

--- a/scipy/ndimage/interpolation.py
+++ b/scipy/ndimage/interpolation.py
@@ -80,15 +80,15 @@ def spline_filter1d(input, order=3, axis=-1, output=numpy.float64,
 
     Notes
     -----
-    All functions in `ndimage.interpolation` internally use a b-spline
-    representation of the input image. Whenever using b-splines of
-    `order > 1`, the input image values have to be converted to b-spline
-    coefficients first, which is done by applying this one-dimensional
-    spline filter sequentially along all axes of the input. All of the
-    functions that require such an input will automatically filter their
-    inputs, a behavior controllable through the `prefilter` keyword
-    argument. For functions that accept a `mode` parameter, the results
-    will only be correct if it matches the `mode` used when filtering.
+    All functions in `ndimage.interpolation` do spline interpolation of
+    the input image. If using b-splines of `order > 1`, the input image
+    values have to be converted to b-spline coefficients first, which is
+    done by applying this one-dimensional filter sequentially along all
+    axes of the input. All functions that require b-spline coefficients
+    will automatically filter their inputs, a behavior controllable with
+    the `prefilter` keyword argument. For functions that accept a `mode`
+    parameter, the result will only be correct if it matches the `mode`
+    used when filtering.
     """
     if order < 0 or order > 5:
         raise RuntimeError('spline order not supported')
@@ -101,7 +101,7 @@ def spline_filter1d(input, order=3, axis=-1, output=numpy.float64,
     else:
         mode = _ni_support._extend_mode_to_code(mode)
         axis = _ni_support._check_axis(axis, input.ndim)
-        _nd_image.spline_filter1d(input, order, axis, mode, output)
+        _nd_image.spline_filter1d(input, order, axis, output, mode)
     return output
 
 

--- a/scipy/ndimage/interpolation.py
+++ b/scipy/ndimage/interpolation.py
@@ -52,7 +52,8 @@ __all__ = ['spline_filter1d', 'spline_filter', 'geometric_transform',
 
 
 @docfiller
-def spline_filter1d(input, order=3, axis=-1, output=numpy.float64):
+def spline_filter1d(input, order=3, axis=-1, output=numpy.float64,
+                    mode='mirror'):
     """
     Calculate a one-dimensional spline filter along the given axis.
 
@@ -70,12 +71,24 @@ def spline_filter1d(input, order=3, axis=-1, output=numpy.float64):
     output : ndarray or dtype, optional
         The array in which to place the output, or the dtype of the returned
         array. Default is `numpy.float64`.
+    %(mode)s
 
     Returns
     -------
     spline_filter1d : ndarray
         The filtered input.
 
+    Notes
+    -----
+    All functions in `ndimage.interpolation` internally use a b-spline
+    representation of the input image. Whenever using b-splines of
+    `order > 1`, the input image values have to be converted to b-spline
+    coefficients first, which is done by applying this one-dimensional
+    spline filter sequentially along all axes of the input. All of the
+    functions that require such an input will automatically filter their
+    inputs, a behavior controllable through the `prefilter` keyword
+    argument. For functions that accept a `mode` parameter, the results
+    will only be correct if it matches the `mode` used when filtering.
     """
     if order < 0 or order > 5:
         raise RuntimeError('spline order not supported')
@@ -86,12 +99,13 @@ def spline_filter1d(input, order=3, axis=-1, output=numpy.float64):
     if order in [0, 1]:
         output[...] = numpy.array(input)
     else:
+        mode = _ni_support._extend_mode_to_code(mode)
         axis = _ni_support._check_axis(axis, input.ndim)
-        _nd_image.spline_filter1d(input, order, axis, output)
+        _nd_image.spline_filter1d(input, order, axis, mode, output)
     return output
 
 
-def spline_filter(input, order=3, output=numpy.float64):
+def spline_filter(input, order=3, output=numpy.float64, mode='mirror'):
     """
     Multi-dimensional spline filter.
 
@@ -118,7 +132,7 @@ def spline_filter(input, order=3, output=numpy.float64):
     output = _ni_support._get_output(output, input)
     if order not in [0, 1] and input.ndim > 0:
         for axis in range(input.ndim):
-            spline_filter1d(input, order, axis, output=output)
+            spline_filter1d(input, order, axis, output=output, mode=mode)
             input = output
     else:
         output[...] = input[...]

--- a/scipy/ndimage/src/nd_image.c
+++ b/scipy/ndimage/src/nd_image.c
@@ -677,10 +677,9 @@ static PyObject *Py_SplineFilter1D(PyObject *obj, PyObject *args)
     PyArrayObject *input = NULL, *output = NULL;
     int axis, order, mode;
 
-    if (!PyArg_ParseTuple(args, "O&iiiO&",
-                          NI_ObjectToInputArray, &input,
-                          &order, &axis, &mode,
-                          NI_ObjectToOutputArray, &output))
+    if (!PyArg_ParseTuple(args, "O&iiO&i",
+                          NI_ObjectToInputArray, &input, &order, &axis,
+                          NI_ObjectToOutputArray, &output, &mode))
         goto exit;
 
     NI_SplineFilter1D(input, order, axis, mode, output);

--- a/scipy/ndimage/src/nd_image.c
+++ b/scipy/ndimage/src/nd_image.c
@@ -675,15 +675,15 @@ exit:
 static PyObject *Py_SplineFilter1D(PyObject *obj, PyObject *args)
 {
     PyArrayObject *input = NULL, *output = NULL;
-    int axis, order;
+    int axis, order, mode;
 
-    if (!PyArg_ParseTuple(args, "O&iiO&",
+    if (!PyArg_ParseTuple(args, "O&iiiO&",
                           NI_ObjectToInputArray, &input,
-                          &order, &axis,
+                          &order, &axis, &mode,
                           NI_ObjectToOutputArray, &output))
         goto exit;
 
-    NI_SplineFilter1D(input, order, axis, output);
+    NI_SplineFilter1D(input, order, axis, mode, output);
     #ifdef HAVE_WRITEBACKIFCOPY
         PyArray_ResolveWritebackIfCopy(output);
     #endif

--- a/scipy/ndimage/src/ni_interpolation.c
+++ b/scipy/ndimage/src/ni_interpolation.c
@@ -129,7 +129,7 @@ map_coordinate(double in, npy_intp len, int mode)
 int NI_SplineFilter1D(PyArrayObject *input, int order, int axis,
                       NI_ExtendMode mode, PyArrayObject *output)
 {
-    int hh, npoles = 0, more;
+    int npoles = 0, more;
     npy_intp kk, lines, len;
     double *buffer = NULL, gain, poles[MAX_SPLINE_FILTER_POLES];
     NI_LineBuffer iline_buffer, oline_buffer;
@@ -173,9 +173,7 @@ int NI_SplineFilter1D(PyArrayObject *input, int order, int axis,
             double *ln = NI_GET_LINE(iline_buffer, kk);
             /* spline filter: */
             if (len > 1) {
-                for(hh = 0; hh < npoles; hh++) {
-                    apply_filter(ln, len, poles[hh], mode);
-                }
+                apply_filter(ln, len, poles, npoles, mode);
             }
         }
 

--- a/scipy/ndimage/src/ni_interpolation.c
+++ b/scipy/ndimage/src/ni_interpolation.c
@@ -127,10 +127,10 @@ map_coordinate(double in, npy_intp len, int mode)
 
 /* one-dimensional spline filter: */
 int NI_SplineFilter1D(PyArrayObject *input, int order, int axis,
-                                            PyArrayObject *output)
+                      NI_ExtendMode mode, PyArrayObject *output)
 {
     int hh, npoles = 0, more;
-    npy_intp kk, ll, lines, len;
+    npy_intp kk, lines, len;
     double *buffer = NULL, gain, poles[MAX_SPLINE_FILTER_POLES];
     NI_LineBuffer iline_buffer, oline_buffer;
     NPY_BEGIN_THREADS_DEF;
@@ -144,21 +144,21 @@ int NI_SplineFilter1D(PyArrayObject *input, int order, int axis,
         goto exit;
     }
 
-    gain = filter_gain(poles, npoles);
-
     /* allocate an initialize the line buffer, only a single one is used,
          because the calculation is in-place: */
     lines = -1;
     if (!NI_AllocateLineBuffer(input, axis, 0, 0, &lines, BUFFER_SIZE,
-                                                         &buffer))
+                               &buffer)) {
         goto exit;
+    }
     if (!NI_InitLineBuffer(input, axis, 0, 0, lines, buffer,
-                                                 NI_EXTEND_DEFAULT, 0.0, &iline_buffer))
+                           NI_EXTEND_DEFAULT, 0.0, &iline_buffer)) {
         goto exit;
+    }
     if (!NI_InitLineBuffer(output, axis, 0, 0, lines, buffer,
-                                                 NI_EXTEND_DEFAULT, 0.0, &oline_buffer))
+                           NI_EXTEND_DEFAULT, 0.0, &oline_buffer)) {
         goto exit;
-
+    }
     NPY_BEGIN_THREADS;
 
     /* iterate over all the array lines: */
@@ -173,17 +173,8 @@ int NI_SplineFilter1D(PyArrayObject *input, int order, int axis,
             double *ln = NI_GET_LINE(iline_buffer, kk);
             /* spline filter: */
             if (len > 1) {
-                apply_gain(gain, ln, len);
                 for(hh = 0; hh < npoles; hh++) {
-                    const double pole = poles[hh];
-                    set_initial_causal_coefficient(ln, len, pole, TOLERANCE);
-                    for(ll = 1; ll < len; ll++) {
-                        ln[ll] += pole * ln[ll - 1];
-                    }
-                    set_initial_anticausal_coefficient(ln, len, pole);
-                    for(ll = len - 2; ll >= 0; ll--) {
-                        ln[ll] = pole * (ln[ll + 1] - ln[ll]);
-                    }
+                    apply_filter(ln, len, poles[hh], mode);
                 }
             }
         }

--- a/scipy/ndimage/src/ni_interpolation.h
+++ b/scipy/ndimage/src/ni_interpolation.h
@@ -32,7 +32,7 @@
 #ifndef NI_INTERPOLATION_H
 #define NI_INTERPOLATION_H
 
-int NI_SplineFilter1D(PyArrayObject*, int, int, PyArrayObject*);
+int NI_SplineFilter1D(PyArrayObject*, int, int, NI_ExtendMode, PyArrayObject*);
 int NI_GeometricTransform(PyArrayObject*, int (*)(npy_intp*, double*, int, int,
                                                     void*), void*, PyArrayObject*, PyArrayObject*,
                                                     PyArrayObject*, PyArrayObject*, int, int,

--- a/scipy/ndimage/src/ni_splines.c
+++ b/scipy/ndimage/src/ni_splines.c
@@ -153,73 +153,145 @@ get_filter_poles(int order, int *npoles, double *poles)
 }
 
 
-double
-filter_gain(const double *poles, int npoles)
+typedef void (init_fn)(npy_double*, const npy_intp, const double);
+
+
+static void
+_init_causal_mirror(double *c, const npy_intp n, const double z)
 {
-    double gain = 1.0;
+    npy_intp i;
+    double z_i = z;
+    const double z_n_1 = pow(z, n - 1);
 
-    while (npoles--) {
-        const double pole = *poles++;
-        gain *= (1.0 - pole) * (1.0 - 1.0 / pole);
+    c[0] = c[0] + z_n_1 * c[n - 1];
+    for (i = 1; i < n - 1; ++i) {
+        c[0] += z_i * (c[i] + z_n_1 * c[n - 1 - i]);
+        z_i *= z;
     }
+    c[0] /= 1 - z_n_1 * z_n_1;
+}
 
-    return gain;
+
+static void
+_init_anticausal_mirror(double *c, const npy_intp n, const double z)
+{
+    c[n - 1] = (z * c[n - 2] + c[n - 1]) * (1 - z) * (1 - z) / (1 - z * z);
+}
+
+
+static void
+_init_causal_wrap(double *c, const npy_intp n, const double z)
+{
+    npy_intp i;
+    double z_i = z;
+
+    for (i = 1; i < n; ++i) {
+        c[0] += z_i * c[n - i];
+        z_i *= z;
+    }
+    c[0] /= 1 - z_i; /* z_i = pow(z, n) */
+}
+
+
+static void
+_init_anticausal_wrap(double *c, const npy_intp n, const double z)
+{
+    npy_intp i;
+    double z_i = z;
+
+    for (i = 0; i < n - 1; ++i) {
+        c[n - 1] += z_i * c[i];
+        z_i *= z;
+    }
+    c[n - 1] *= (1 - z) * (1 - z) / (1 - z_i); /* z_i = pow(z, n) */
+}
+
+
+static void
+_init_causal_reflect(double *c, const npy_intp n, const double z)
+{
+    npy_intp i;
+    double z_i = z;
+    const double z_n = pow(z, n);
+    const double c0 = c[0];
+
+    c[0] = c[0] + z_n * c[n - 1];
+    for (i = 1; i < n; ++i) {
+        c[0] += z_i * (c[i] + z_n * c[n - 1 - i]);
+        z_i *= z;
+    }
+    c[0] *= z / (1 - z_n * z_n);
+    c[0] += c0;
 }
 
 
 void
-apply_gain(double gain, double *coefficients, npy_intp len)
+_init_anticausal_reflect(double *c, const npy_intp n, const double z)
 {
-    while (len--) {
-        *coefficients++ *= gain;
+    c[n - 1] *= 1 - z;
+}
+
+
+/*
+ * The application of the filter is performed in two passes over the
+ * coefficient array, one forward and the other backward. For a
+ * detailed discussion of the method see e.g.:
+ *
+ * Unser, Michael, Akram Aldroubi, and Murray Eden. "Fast B-spline
+ * transforms for continuous image representation and interpolation."
+ * IEEE Transactions on pattern analysis and machine intelligence 13.3
+ * (1991): 277-285.
+ *
+ * A key part of the process is initializing the first coefficient for
+ * each pass, which depends on the boundary conditions chosen to extend
+ * the input image beyond its boundaries. The method to initialize these
+ * values for the NI_EXTEND_MIRROR mode is discussed in the above paper.
+ * For NI_EXTEND_WRAP and NI_EXTEND_REFLECT, the unpublished method was
+ * obtained from a private communication with Dr. Philippe Thévenaz.
+ */
+static void
+_apply_filter(double *c, npy_intp n, double z, init_fn *causal_init,
+              init_fn *anticausal_init)
+{
+    npy_intp i;
+    const double mult = (1 - z) * (1 - z);
+
+    causal_init(c, n, z);
+    for (i = 1; i < n; ++i) {
+        c[i] += z * c[i - 1];
+    }
+    anticausal_init(c, n, z);
+    for (i = n - 2; i >= 0; --i) {
+        c[i] = z * c[i + 1] + mult * c[i];
     }
 }
 
 
 void
-set_initial_causal_coefficient(double *coefficients, npy_intp len,
-                               double pole, double tolerance)
+apply_filter(double *coefficients, const npy_intp len, const double pole,
+             NI_ExtendMode mode)
 {
-    int i;
-    int last_coeff = len;
-    double sum = 0.0;
+    init_fn *causal;
+    init_fn *anticausal;
 
-    if (tolerance > 0.0) {
-        last_coeff = ceil(log(tolerance)) / log(fabs(pole));
-    }
-    if (last_coeff < len) {
-        double z_i = pole;
-
-        sum = coefficients[0];
-        for (i = 1; i < last_coeff; ++i) {
-            sum += z_i * coefficients[i];
-            z_i *= pole;
-        }
-    }
-    else {
-        double z_i = pole;
-        const double inv_z = 1.0 / pole;
-        const double z_n_1 = pow(pole, len - 1);
-        double z_2n_2_i = z_n_1 * z_n_1 * inv_z;
-
-        sum = coefficients[0] + coefficients[len - 1] * z_n_1;
-        for (i = 1; i < len - 1; ++i) {
-            sum += (z_i + z_2n_2_i) * coefficients[i];
-            z_i *= pole;
-            z_2n_2_i *= inv_z;
-        }
-        sum /= (1 - z_n_1 * z_n_1);
+    switch(mode) {
+        case NI_EXTEND_NEAREST:
+        case NI_EXTEND_CONSTANT:
+        case NI_EXTEND_MIRROR:
+            causal = &_init_causal_mirror;
+            anticausal = &_init_anticausal_mirror;
+            break;
+        case NI_EXTEND_WRAP:
+            causal = &_init_causal_wrap;
+            anticausal = &_init_anticausal_wrap;
+            break;
+        case NI_EXTEND_REFLECT:
+            causal = &_init_causal_reflect;
+            anticausal = &_init_anticausal_reflect;
+            break;
+        default:
+            assert(0); /* We should never get here. */
     }
 
-    coefficients[0] = sum;
-}
-
-
-void
-set_initial_anticausal_coefficient(double *coefficients, npy_intp len,
-                                   double pole)
-{
-    coefficients[len - 1] = pole / (pole * pole - 1.0) *
-                            (pole * coefficients[len - 2] +
-                             coefficients[len - 1]) ;
+    _apply_filter(coefficients, len, pole, causal, anticausal);
 }

--- a/scipy/ndimage/src/ni_splines.h
+++ b/scipy/ndimage/src/ni_splines.h
@@ -5,13 +5,8 @@
 /*
  * For context on the theory behind this code, see:
  *
- * M. Unser, A. Aldroubi and M. Eden, "Fast B-spline transforms for
- * continuous image representation and interpolation," in IEEE
- * Transactions on Pattern Analysis and Machine Intelligence, vol. 13,
- * no. 3, pp. 277-285, Mar 1991.
- *
- * M. Unser, "Splines: A Perfect Fit for Signal and Image Processing,"
- * in IEEE Signal Processing Magazine, vol. 16, no. 6, pp. 22-38, 1999.
+ * Unser, Michael. "Splines: A perfect fit for signal and image
+ * processing." IEEE Signal processing magazine 16.6 (1999): 22-38.
  */
 
 /*
@@ -40,80 +35,14 @@ get_filter_poles(int order, int *npoles, double *poles);
 
 
 /*
- * Computes the filter gain for the given poles.
- */
-double
-filter_gain(const double *poles, int npoles);
-
-
-/*
- * Multiplies all coefficients in-place by the gain.
+ * Applies the causal and anticausal filters for a pole to the array of
+ * coefficients. Recursively applying this filter for all poles of a
+ * given order is equivalent to solving the banded linear systems of
+ * equations that computes the spline coefficients for an input array.
  */
 void
-apply_gain(double gain, double *coefficeints, npy_intp len);
-
-
-/*
- * Sets the first coefficient to the right value to begin applying a
- * causal filter for the given pole to the sequence. If tolerance is
- * zero the calculation will be exact, if non-zero, the series will be
- * truncated for items  smaller than the tolerance.
- *
- * -----
- *
- * If s[i] are the values to filter, and z is the pole being considered,
- * the initial coefficient for the causal filter can be computed as:
- *
- *   c[0] = Sum(i=0..inf, s[i] * z**i)
- *
- * Since |z| < 1, this can be computed approximately by adding terms
- * until z**i is below a user defined tolerance.
- *
- * It can also be computed exactly by taking into account the boundary
- * conditions coming from the extend mode. Currently NI_EXTEND_MIRROR
- * is the only supported mode.
- *
- * NI_EXTEND_MIRROR : a b c d | c b a b c d c b ...
- * The s[i], when extended beyond the given n items, are periodic with
- * period T, so we can rewrite:
- *
- *   c[0] = Sum(k=0..inf, z**(T * k)) * Sum(i=0..T, s[i] * z**i) =
- *        = 1 / (1 - z**T) * S
- *
- * In this case T = 2*n - 2, and c[-k] = c[k], so S can be computed as:
- *
- *   S = s[0] + s[n-1] * z**(n-1) +
- *       Sum(i=1..n-1, s[i]* (z**i + z**(2*n - 2 - i)))
- *
- */
-void
-set_initial_causal_coefficient(double *coefficients, npy_intp len,
-                               double pole, double tolerance);
-
-
-/*
- * Sets the last coefficient to the right value to begin applying an
- * anticausal filter for the given pole to the sequence.
- *
- * -----
- *
- * The causal, c+, and anticausal, c-, filter coefficients, and the
- * filtered sequence, c, are computed from the sequence, s, using the
- * following recursive relations:
- *
- *   c+[i] = s[i] + z * c+[i-1]
- *   c-[i] = s[i] + z * c-[i+1]
- *   c[i] = z / (1 - z**2) * (c+[i] + c-[i] - s[i])
- *
- * For the anticausal filter, if the extension mode is NI_EXTEND_MIRROR,
- * we also know that c+[n-1] = c-[n-1], so:
- *
- *   c[n-1] = z / (1 - z**2) * (z * c+[n-2] + c+[n-1])
- *
- */
-void
-set_initial_anticausal_coefficient(double *coefficients, npy_intp len,
-                                   double pole);
+apply_filter(double *coefficients, const npy_intp len, const double pole,
+             NI_ExtendMode mode);
 
 
 #endif

--- a/scipy/ndimage/src/ni_splines.h
+++ b/scipy/ndimage/src/ni_splines.h
@@ -35,14 +35,14 @@ get_filter_poles(int order, int *npoles, double *poles);
 
 
 /*
- * Applies the causal and anticausal filters for a pole to the array of
- * coefficients. Recursively applying this filter for all poles of a
- * given order is equivalent to solving the banded linear systems of
- * equations that computes the spline coefficients for an input array.
+ * Applies the causal and anticausal filters for all poles to the array
+ * of coefficients. This is equivalent to solving the banded linear
+ * system of equations that computes the spline coefficients for an
+ * input array.
  */
 void
-apply_filter(double *coefficients, const npy_intp len, const double pole,
-             NI_ExtendMode mode);
+apply_filter(double *coefficients, const npy_intp len, const double *poles,
+             int npoles, NI_ExtendMode mode);
 
 
 #endif

--- a/scipy/ndimage/tests/test_datatypes.py
+++ b/scipy/ndimage/tests/test_datatypes.py
@@ -5,7 +5,7 @@ from __future__ import division, print_function, absolute_import
 import sys
 
 import numpy as np
-from numpy.testing import assert_array_almost_equal, assert_equal, assert_
+from numpy.testing import assert_array_almost_equal, assert_
 import pytest
 
 from scipy import ndimage
@@ -52,17 +52,17 @@ def test_uint64_max():
     # Test interpolation respects uint64 max.  Reported to fail at least on
     # win32 (due to the 32 bit visual C compiler using signed int64 when
     # converting between uint64 to double) and Debian on s390x.
-    # Interpolation is always done in double precision floating point, so we
-    # use the largest uint64 value for which int(float(big)) still fits in
+    # Interpolation is always done in double precision floating point, so
+    # we use a larges uint64 value for which int(float(big)) still fits in
     # a uint64.
-    big = 2**64-1025
+    big = 2**64 - 3072
     arr = np.array([big, big, big], dtype=np.uint64)
     # Tests geometric transform (map_coordinates, affine_transform)
     inds = np.indices(arr.shape) - 0.1
     x = ndimage.map_coordinates(arr, inds)
-    assert_equal(x[1], int(float(big)))
-    assert_equal(x[2], int(float(big)))
+    assert_(x[1] > 2**63)
+    assert_(x[2] > 2**63)
     # Tests zoom / shift
     x = ndimage.shift(arr, 0.1)
-    assert_equal(x[1], int(float(big)))
-    assert_equal(x[2], int(float(big)))
+    assert_(x[1] > 2**63)
+    assert_(x[2] > 2**63)

--- a/scipy/ndimage/tests/test_datatypes.py
+++ b/scipy/ndimage/tests/test_datatypes.py
@@ -53,16 +53,16 @@ def test_uint64_max():
     # win32 (due to the 32 bit visual C compiler using signed int64 when
     # converting between uint64 to double) and Debian on s390x.
     # Interpolation is always done in double precision floating point, so
-    # we use a larges uint64 value for which int(float(big)) still fits in
-    # a uint64.
-    big = 2**64 - 3072
+    # we use the largest uint64 value for which int(float(big)) still fits
+    # in a uint64.
+    big = 2**64 - 1025
     arr = np.array([big, big, big], dtype=np.uint64)
     # Tests geometric transform (map_coordinates, affine_transform)
     inds = np.indices(arr.shape) - 0.1
     x = ndimage.map_coordinates(arr, inds)
-    assert_(x[1] > 2**63)
-    assert_(x[2] > 2**63)
+    assert_(x[1] == int(float(big)))
+    assert_(x[2] == int(float(big)))
     # Tests zoom / shift
     x = ndimage.shift(arr, 0.1)
-    assert_(x[1] > 2**63)
-    assert_(x[2] > 2**63)
+    assert_(x[1] == int(float(big)))
+    assert_(x[2] == int(float(big)))

--- a/scipy/ndimage/tests/test_splines.py
+++ b/scipy/ndimage/tests/test_splines.py
@@ -54,11 +54,14 @@ def make_spline_knot_matrix(n, order, mode='mirror'):
 
 
 @pytest.mark.parametrize('order', [0, 1, 2, 3, 4, 5])
-def test_spline_filter_vs_matrix_solution(order):
+@pytest.mark.parametrize('mode', ['mirror', 'wrap', 'reflect'])
+def test_spline_filter_vs_matrix_solution(order, mode):
     n = 100
     eye = np.eye(n, dtype=float)
-    spline_filter_axis_0 = ndimage.spline_filter1d(eye, axis=0, order=order)
-    spline_filter_axis_1 = ndimage.spline_filter1d(eye, axis=1, order=order)
-    matrix = make_spline_knot_matrix(n, order)
+    spline_filter_axis_0 = ndimage.spline_filter1d(eye, axis=0, order=order,
+                                                   mode=mode)
+    spline_filter_axis_1 = ndimage.spline_filter1d(eye, axis=1, order=order,
+                                                   mode=mode)
+    matrix = make_spline_knot_matrix(n, order, mode=mode)
     assert_almost_equal(eye, np.dot(spline_filter_axis_0, matrix))
     assert_almost_equal(eye, np.dot(spline_filter_axis_1, matrix.T))


### PR DESCRIPTION
This moves us forward along the lines discussed in #8465. None of the interpolation functions can yet use   an image filtered with any mode other than `'mirror'`, but I think it's better to get this in first. If the interpolation functions have not been changed by the next release, we may want to change the docstring to not mislead users.

This PR implements proper spline coefficient calculations for the `'mirror'`, `'wrap'` and `'reflect'` modes, based on information obtained from Dr. Philippe Thévenaz. For `'nearest'` and `'constant'` methods this PR silently switches them to `'mirror'`: the current implementation of the interpolation functions does a sufficiently good job for those methods, and they have some specific issues, so they didn't seem worth the trouble right now.