### PR TITLE
ENH: interpolate: allow string aliases in make_interp_spline BC

### DIFF
--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -4,6 +4,7 @@ import functools
 import operator
 
 import numpy as np
+from scipy._lib.six import string_types
 from scipy.linalg import (get_lapack_funcs, LinAlgError,
                           cholesky_banded, cho_solve_banded)
 from . import _bspl
@@ -594,6 +595,17 @@ def _augknt(x, k):
     return np.r_[(x[0],)*k, x, (x[-1],)*k]
 
 
+def _convert_string_aliases(deriv, target_shape):
+    if isinstance(deriv, string_types):
+        if deriv == "clamped":
+            deriv = [(1, np.zeros(target_shape))]
+        elif deriv == "natural":
+            deriv = [(2, np.zeros(target_shape))]
+        else:
+            raise ValueError("Unknown boundary condition : %s" % deriv)
+    return deriv
+
+
 def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
                        check_finite=True):
     """Compute the (coefficients of) interpolating B-spline.
@@ -620,6 +632,15 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
         be an iterable of pairs ``(order, value)`` which gives the values of
         derivatives of specified orders at the given edge of the interpolation
         interval.
+        Alternatively, the following string aliases are recognized:
+
+        * ``"clamped"``: The first derivatives at the ends are zero. This is
+           equivalent to ``bc_type=((1, 0.0), (1, 0.0))``.
+        * ``"natural"``: The second derivatives at ends are zero. This is
+          equivalent to ``bc_type=((2, 0.0), (2, 0.0))``.
+        * ``"not-a-knot"`` (default): The first and second segments are the same
+          polynomial. This is equivalent to having ``bc_type=None``.
+
     axis : int, optional
         Interpolation axis. Default is 0.
     check_finite : bool, optional
@@ -657,8 +678,8 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
 
     Here we use a 'natural' spline, with zero 2nd derivatives at edges:
 
-    >>> l, r = [(2, 0)], [(2, 0)]
-    >>> b_n = make_interp_spline(x, y, bc_type=(l, r))
+    >>> l, r = [(2, 0.0)], [(2, 0.0)]
+    >>> b_n = make_interp_spline(x, y, bc_type=(l, r))  # or, bc_type="natural"
     >>> np.allclose(b_n(x), y)
     True
     >>> x0, x1 = x[0], x[-1]
@@ -699,9 +720,13 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
     splrep : a wrapper over FITPACK spline fitting routines
 
     """
-    if bc_type is None:
-        bc_type = (None, None)
-    deriv_l, deriv_r = bc_type
+    # convert string aliases for the boundary conditions
+    if bc_type is None or bc_type == 'not-a-knot':
+        deriv_l, deriv_r = None, None
+    elif isinstance(bc_type, string_types):
+        deriv_l, deriv_r = bc_type, bc_type
+    else:
+        deriv_l, deriv_r = bc_type
 
     # special-case k=0 right away
     if k == 0:
@@ -762,6 +787,7 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
         raise ValueError('Out of bounds w/ x = %s.' % x)
 
     # Here : deriv_l, r = [(nu, value), ...]
+    deriv_l = _convert_string_aliases(deriv_l, y.shape[1:])
     if deriv_l is not None:
         deriv_l_ords, deriv_l_vals = zip(*deriv_l)
     else:
@@ -769,6 +795,7 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
     deriv_l_ords, deriv_l_vals = np.atleast_1d(deriv_l_ords, deriv_l_vals)
     nleft = deriv_l_ords.shape[0]
 
+    deriv_r = _convert_string_aliases(deriv_r, y.shape[1:])
     if deriv_r is not None:
         deriv_r_ords, deriv_r_vals = zip(*deriv_r)
     else:


### PR DESCRIPTION
Make `bc_type="natural"` equivalent to `bc_type=([2, 0.], [2, 0.])` etc