### PR TITLE
DEP: Remove numerical arguments from convolve2d / correlate2d

### DIFF
--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -66,9 +66,8 @@ def _bvalfromboundary(boundary):
     try:
         return _boundarydict[boundary] << 2
     except KeyError:
-        raise ValueError("Acceptable boundary flags are 'fill', 'wrap'"
-                         " (or 'circular'), \n  and 'symm'"
-                         " (or 'symmetric').")
+        raise ValueError("Acceptable boundary flags are 'fill', 'circular' "
+                         "(or 'wrap'), and 'symmetric' (or 'symm').")
 
 
 def _inputs_swap_needed(mode, shape1, shape2):

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -56,25 +56,19 @@ _rfft_lock = threading.Lock()
 
 def _valfrommode(mode):
     try:
-        val = _modedict[mode]
+        return _modedict[mode]
     except KeyError:
-        if mode not in [0, 1, 2]:
-            raise ValueError("Acceptable mode flags are 'valid' (0),"
-                             " 'same' (1), or 'full' (2).")
-        val = mode
-    return val
+        raise ValueError("Acceptable mode flags are 'valid',"
+                         " 'same', or 'full'.")
 
 
 def _bvalfromboundary(boundary):
     try:
-        val = _boundarydict[boundary] << 2
+        return _boundarydict[boundary] << 2
     except KeyError:
-        if val not in [0, 1, 2]:
-            raise ValueError("Acceptable boundary flags are 'fill', 'wrap'"
-                             " (or 'circular'), \n  and 'symm'"
-                             " (or 'symmetric').")
-        val = boundary << 2
-    return val
+        raise ValueError("Acceptable boundary flags are 'fill', 'wrap'"
+                         " (or 'circular'), \n  and 'symm'"
+                         " (or 'symmetric').")
 
 
 def _inputs_swap_needed(mode, shape1, shape2):


### PR DESCRIPTION
As mentioned in https://github.com/scipy/scipy/pull/8413#issuecomment-366580244, it has never actually been possible to set the boundary using an integer, since `_bvalfromboundary` has been broken [since it was created 17 years ago](https://github.com/scipy/scipy/blob/de52369211a15df0eae44a14d2182b35e270f6ca/Lib/signal/signaltools.py#L8), raising `UnboundLocalError: local variable 'val' referenced before assignment`.

The mode argument `_valfrommode` was initially broken the same way, but [fixed shortly afterward ](https://github.com/scipy/scipy/commit/fad9e702a0226be5895a44619f1b64a3c70f1c6f).  

But if no one noticed that it doesn't work for `boundary=` in the last 17 years, it seems like numeric parameters are not commonly used.  Also they are untested, and were [removed from the documentation 8 years ago](https://github.com/scipy/scipy/commit/e80f1d44b63adf7dd4d30785fad54e5623f50f18#diff-97a2088dd3cb8cda2ae551fa9357d5a8R409).

Is there any benefit to supporting them?