### PR TITLE
ENH: New arguments, documentation, and tests for ndimage.binary_opening

### DIFF
--- a/scipy/ndimage/morphology.py
+++ b/scipy/ndimage/morphology.py
@@ -506,7 +506,6 @@ def binary_dilation(input, structure=None, iterations=1, mask=None,
                            output, border_value, origin, 1, brute_force)
 
 
-@_ni_docstrings.docfiller
 def binary_opening(input, structure=None, iterations=1, output=None,
                    origin=0, mask=None, border_value=0, brute_force=False):
     """
@@ -543,9 +542,9 @@ def binary_opening(input, structure=None, iterations=1, output=None,
         Value at the border in the output array.
     brute_force : boolean, optional
 	Memory contition: if False, only the pixels whose value was changed in
-	the last iteration are tracked as candidates to be updated (eroded) in
-	the current iteration; if true all pixels are considered as candidates
-	for erosion, regardless of what happened in the previous iteration.
+	the last iteration are tracked as candidates to be updated in the
+	current iteration; if true all pixels are considered as candidates for
+	update, regardless of what happened in the previous iteration.
 	False by default.
 
     Returns
@@ -618,14 +617,14 @@ def binary_opening(input, structure=None, iterations=1, output=None,
         rank = input.ndim
         structure = generate_binary_structure(rank, 1)
 
-    tmp = binary_erosion(input, structure, iterations, mask, None, border_value,
-                         origin, brute_force)
-    return binary_dilation(tmp, structure, iterations, mask, output, border_value,
-                           origin, brute_force)
+    tmp = binary_erosion(input, structure, iterations, mask, None,
+                        border_value, origin, brute_force)
+    return binary_dilation(tmp, structure, iterations, mask, output,
+                            border_value, origin, brute_force)
 
 
 def binary_closing(input, structure=None, iterations=1, output=None,
-                   origin=0):
+                    origin=0, mask=None, border_value=0, brute_force=False):
     """
     Multi-dimensional binary closing with the given structuring element.
 
@@ -653,6 +652,17 @@ def binary_closing(input, structure=None, iterations=1, output=None,
         By default, a new array is created.
     origin : int or tuple of ints, optional
         Placement of the filter, by default 0.
+    mask : array_like, optional
+        If a mask is given, only those elements with a True value at
+        the corresponding mask element are modified at each iteration.
+    border_value : int (cast to 0 or 1), optional
+        Value at the border in the output array.
+    brute_force : boolean, optional
+        Memory condition: if False, only the pixels whose value was changed in
+        the last iteration are tracked as candidates to be updated in the
+        current iteration; if true al pixels are considered as candidates for
+        update, regardless of what happened in the previous iteration.
+        False by default.
 
     Returns
     -------
@@ -747,10 +757,10 @@ def binary_closing(input, structure=None, iterations=1, output=None,
         rank = input.ndim
         structure = generate_binary_structure(rank, 1)
 
-    tmp = binary_dilation(input, structure, iterations, None, None, 0,
-                          origin)
-    return binary_erosion(tmp, structure, iterations, None, output, 0,
-                          origin)
+    tmp = binary_dilation(input, structure, iterations, mask, None,
+                            border_value, origin, brute_force)
+    return binary_erosion(tmp, structure, iterations, mask, output,
+                            border_value, origin, brute_force)
 
 
 def binary_hit_or_miss(input, structure1=None, structure2=None,

--- a/scipy/ndimage/morphology.py
+++ b/scipy/ndimage/morphology.py
@@ -618,13 +618,13 @@ def binary_opening(input, structure=None, iterations=1, output=None,
         structure = generate_binary_structure(rank, 1)
 
     tmp = binary_erosion(input, structure, iterations, mask, None,
-                        border_value, origin, brute_force)
+                         border_value, origin, brute_force)
     return binary_dilation(tmp, structure, iterations, mask, output,
-                            border_value, origin, brute_force)
+                           border_value, origin, brute_force)
 
 
 def binary_closing(input, structure=None, iterations=1, output=None,
-                    origin=0, mask=None, border_value=0, brute_force=False):
+                   origin=0, mask=None, border_value=0, brute_force=False):
     """
     Multi-dimensional binary closing with the given structuring element.
 
@@ -758,9 +758,9 @@ def binary_closing(input, structure=None, iterations=1, output=None,
         structure = generate_binary_structure(rank, 1)
 
     tmp = binary_dilation(input, structure, iterations, mask, None,
-                            border_value, origin, brute_force)
+                          border_value, origin, brute_force)
     return binary_erosion(tmp, structure, iterations, mask, output,
-                            border_value, origin, brute_force)
+                          border_value, origin, brute_force)
 
 
 def binary_hit_or_miss(input, structure1=None, structure2=None,

--- a/scipy/ndimage/morphology.py
+++ b/scipy/ndimage/morphology.py
@@ -541,11 +541,11 @@ def binary_opening(input, structure=None, iterations=1, output=None,
     border_value : int (cast to 0 or 1), optional
         Value at the border in the output array.
     brute_force : boolean, optional
-	Memory contition: if False, only the pixels whose value was changed in
-	the last iteration are tracked as candidates to be updated in the
-	current iteration; if true all pixels are considered as candidates for
-	update, regardless of what happened in the previous iteration.
-	False by default.
+        Memory condition: if False, only the pixels whose value was changed in
+        the last iteration are tracked as candidates to be updated in the
+        current iteration; if true all pixels are considered as candidates for
+        update, regardless of what happened in the previous iteration.
+        False by default.
 
     Returns
     -------

--- a/scipy/ndimage/morphology.py
+++ b/scipy/ndimage/morphology.py
@@ -506,6 +506,7 @@ def binary_dilation(input, structure=None, iterations=1, mask=None,
                            output, border_value, origin, 1, brute_force)
 
 
+@_ni_docstrings.docfiller
 def binary_opening(input, structure=None, iterations=1, output=None,
                    origin=0, mask=None, border_value=0, brute_force=False):
     """
@@ -541,11 +542,11 @@ def binary_opening(input, structure=None, iterations=1, output=None,
     border_value : int (cast to 0 or 1), optional
         Value at the border in the output array.
     brute_force : boolean, optional
-        Memory condition: if False, only the pixels whose value was changed in
-        the last iteration are tracked as candidates to be updated (eroded) in
-        the current iteration; if true all pixels are considered as candidates
-        for erosion, regardless of what happened in the previous iteration.
-        False by default.
+	Memory contition: if False, only the pixels whose value was changed in
+	the last iteration are tracked as candidates to be updated (eroded) in
+	the current iteration; if true all pixels are considered as candidates
+	for erosion, regardless of what happened in the previous iteration.
+	False by default.
 
     Returns
     -------

--- a/scipy/ndimage/morphology.py
+++ b/scipy/ndimage/morphology.py
@@ -507,7 +507,7 @@ def binary_dilation(input, structure=None, iterations=1, mask=None,
 
 
 def binary_opening(input, structure=None, iterations=1, output=None,
-                   origin=0):
+                   origin=0, mask=None, border_value=0, brute_force=False):
     """
     Multi-dimensional binary opening with the given structuring element.
 
@@ -535,6 +535,17 @@ def binary_opening(input, structure=None, iterations=1, output=None,
         By default, a new array is created.
     origin : int or tuple of ints, optional
         Placement of the filter, by default 0.
+    mask : array_like, optional
+        If a mask is given, only those elements with a True value at
+        the corresponding mask element are modified at each iteration.
+    border_value : int (cast to 0 or 1), optional
+        Value at the border in the output array.
+    brute_force : boolean, optional
+        Memory condition: if False, only the pixels whose value was changed in
+        the last iteration are tracked as candidates to be updated (eroded) in
+        the current iteration; if true all pixels are considered as candidates
+        for erosion, regardless of what happened in the previous iteration.
+        False by default.
 
     Returns
     -------
@@ -606,10 +617,10 @@ def binary_opening(input, structure=None, iterations=1, output=None,
         rank = input.ndim
         structure = generate_binary_structure(rank, 1)
 
-    tmp = binary_erosion(input, structure, iterations, None, None, 0,
-                         origin)
-    return binary_dilation(tmp, structure, iterations, None, output, 0,
-                           origin)
+    tmp = binary_erosion(input, structure, iterations, mask, None, border_value,
+                         origin, brute_force)
+    return binary_dilation(tmp, structure, iterations, mask, output, border_value,
+                           origin, brute_force)
 
 
 def binary_closing(input, structure=None, iterations=1, output=None,

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -4578,7 +4578,7 @@ class TestDilateFix:
         result = ndimage.grey_dilation(self.array, size=3)
         assert_array_almost_equal(result, self.dilated3x3)
 
-class TestBinaryOpening:
+class TestBinaryOpeningClosing:
 
     def setup_method(self):
         a = numpy.zeros((5,5), dtype=bool)
@@ -4587,8 +4587,16 @@ class TestBinaryOpening:
         self.array = a
         self.sq3x3 = numpy.ones((3,3))
         self.opened_old = ndimage.binary_opening(self.array, self.sq3x3,
-                1, None, 0)
+                                                1, None, 0)
+        self.closed_old = ndimage.binary_closing(self.array, self.sq3x3,
+                                                1, None, 0)
 
     def test_opening_new_arguments(self):
-        opened_new = ndimage.binary_opening(self.array, self.sq3x3, 1, None, 0, None, 0, False)
+        opened_new = ndimage.binary_opening(self.array, self.sq3x3, 1, None,
+                                            0, None, 0, False)
         assert_array_equal(opened_new, self.opened_old)
+
+    def test_closing_new_arguments(self):
+        closed_new = ndimage.binary_closing(self.array, self.sq3x3, 1, None,
+                                            0, None, 0, False)
+        assert_array_equal(closed_new, self.closed_old)

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -4578,3 +4578,16 @@ class TestDilateFix:
         result = ndimage.grey_dilation(self.array, size=3)
         assert_array_almost_equal(result, self.dilated3x3)
 
+class TestBinaryOpening:
+
+    def setup_method(self):
+        a = numpy.zeros((5,5), dtype=int)
+        a[1:4, 1:4] = 1
+        a[4,4] = 1
+        self.array = a
+        self.sq3x3 = numpy.ones((3,3))
+        self.opened_old = ndimage.binary_opening(self.array, self.sq3x3, 1, None, 0).astype(int)
+
+    def test_opening_new_arguments(self):
+        opened_new = ndimage.binary_opening(self.array, self.sq3x3, 1, None, 0, None, 0, False).astype(int)
+        assert_array_equal(opened_new, self.opened_old)

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -4587,9 +4587,9 @@ class TestBinaryOpeningClosing:
         self.array = a
         self.sq3x3 = numpy.ones((3,3))
         self.opened_old = ndimage.binary_opening(self.array, self.sq3x3,
-                                                1, None, 0)
+                                                 1, None, 0)
         self.closed_old = ndimage.binary_closing(self.array, self.sq3x3,
-                                                1, None, 0)
+                                                 1, None, 0)
 
     def test_opening_new_arguments(self):
         opened_new = ndimage.binary_opening(self.array, self.sq3x3, 1, None,

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -4581,13 +4581,14 @@ class TestDilateFix:
 class TestBinaryOpening:
 
     def setup_method(self):
-        a = numpy.zeros((5,5), dtype=int)
-        a[1:4, 1:4] = 1
-        a[4,4] = 1
+        a = numpy.zeros((5,5), dtype=bool)
+        a[1:4, 1:4] = True
+        a[4,4] = True
         self.array = a
         self.sq3x3 = numpy.ones((3,3))
-        self.opened_old = ndimage.binary_opening(self.array, self.sq3x3, 1, None, 0).astype(int)
+        self.opened_old = ndimage.binary_opening(self.array, self.sq3x3,
+                1, None, 0)
 
     def test_opening_new_arguments(self):
-        opened_new = ndimage.binary_opening(self.array, self.sq3x3, 1, None, 0, None, 0, False).astype(int)
+        opened_new = ndimage.binary_opening(self.array, self.sq3x3, 1, None, 0, None, 0, False)
         assert_array_equal(opened_new, self.opened_old)


### PR DESCRIPTION
Opening a new pull request with a separate feature branch.
binary_opening function has been extended. New arguments have been added at the end. Created a new test to check backward compatibility.

Fixes #7453