### PR TITLE
Giving both size and input now raises UserWarning (#7334)

### DIFF
--- a/scipy/ndimage/_ni_docstrings.py
+++ b/scipy/ndimage/_ni_docstrings.py
@@ -19,7 +19,7 @@ _output_doc = (
     will be created.""")
 _size_foot_doc = (
 """size : scalar or tuple, optional
-    See footprint, below
+    See footprint, below. Ignored if footprint is given.
 footprint : array, optional
     Either `size` or `footprint` must be defined.  `size` gives
     the shape that is taken from the input array, at every element
@@ -30,7 +30,7 @@ footprint : array, optional
     to ``footprint=np.ones((n,m))``.  We adjust `size` to the number
     of dimensions of the input array, so that, if the input array is
     shape (10,10,10), and `size` is 2, then the actual size used is
-    (2,2,2).""")
+    (2,2,2). When `footprint` is given, `size` is ignored.""")
 _mode_doc = (
 """mode : {'reflect', 'constant', 'nearest', 'mirror', 'wrap'}, optional
     The `mode` parameter determines how the input array is extended

--- a/scipy/ndimage/filters.py
+++ b/scipy/ndimage/filters.py
@@ -29,6 +29,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from __future__ import division, print_function, absolute_import
+import warnings
 
 import math
 import numpy
@@ -951,6 +952,8 @@ def maximum_filter1d(input, size, axis=-1, output=None,
 
 def _min_or_max_filter(input, size, footprint, structure, output, mode,
                        cval, origin, minimum):
+    if (size is not None) and (footprint is not None):
+        warnings.warn("Ignoring size because footprint is set", UserWarning, stacklevel=2)
     if structure is None:
         if footprint is None:
             if size is None:
@@ -1091,6 +1094,8 @@ def maximum_filter(input, size=None, footprint=None, output=None,
 @_ni_docstrings.docfiller
 def _rank_filter(input, rank, size=None, footprint=None, output=None,
                  mode="reflect", cval=0.0, origin=0, operation='rank'):
+    if (size is not None) and (footprint is not None):
+        warnings.warn("Ignoring size because footprint is set", UserWarning, stacklevel=2)
     input = numpy.asarray(input)
     if numpy.iscomplexobj(input):
         raise TypeError('Complex type not supported')
@@ -1396,6 +1401,8 @@ def generic_filter(input, function, size=None, footprint=None,
     not be used in new code.
 
     """
+    if (size is not None) and (footprint is not None):
+        warnings.warn("Ignoring size because footprint is set", UserWarning, stacklevel=1)
     if extra_keywords is None:
         extra_keywords = {}
     input = numpy.asarray(input)

--- a/scipy/ndimage/filters.py
+++ b/scipy/ndimage/filters.py
@@ -953,7 +953,7 @@ def maximum_filter1d(input, size, axis=-1, output=None,
 def _min_or_max_filter(input, size, footprint, structure, output, mode,
                        cval, origin, minimum):
     if (size is not None) and (footprint is not None):
-        warnings.warn("Ignoring size because footprint is set", UserWarning, stacklevel=2)
+        warnings.warn("Ignoring size because footprint is set", UserWarning, stacklevel=3)
     if structure is None:
         if footprint is None:
             if size is None:
@@ -1095,7 +1095,7 @@ def maximum_filter(input, size=None, footprint=None, output=None,
 def _rank_filter(input, rank, size=None, footprint=None, output=None,
                  mode="reflect", cval=0.0, origin=0, operation='rank'):
     if (size is not None) and (footprint is not None):
-        warnings.warn("Ignoring size because footprint is set", UserWarning, stacklevel=2)
+        warnings.warn("Ignoring size because footprint is set", UserWarning, stacklevel=3)
     input = numpy.asarray(input)
     if numpy.iscomplexobj(input):
         raise TypeError('Complex type not supported')
@@ -1402,7 +1402,7 @@ def generic_filter(input, function, size=None, footprint=None,
 
     """
     if (size is not None) and (footprint is not None):
-        warnings.warn("Ignoring size because footprint is set", UserWarning, stacklevel=1)
+        warnings.warn("Ignoring size because footprint is set", UserWarning, stacklevel=2)
     if extra_keywords is None:
         extra_keywords = {}
     input = numpy.asarray(input)

--- a/scipy/ndimage/filters.py
+++ b/scipy/ndimage/filters.py
@@ -953,7 +953,7 @@ def maximum_filter1d(input, size, axis=-1, output=None,
 def _min_or_max_filter(input, size, footprint, structure, output, mode,
                        cval, origin, minimum):
     if (size is not None) and (footprint is not None):
-        warnings.warn("Ignoring size because footprint is set", UserWarning, stacklevel=3)
+        warnings.warn("ignoring size because footprint is set", UserWarning, stacklevel=3)
     if structure is None:
         if footprint is None:
             if size is None:
@@ -1095,7 +1095,7 @@ def maximum_filter(input, size=None, footprint=None, output=None,
 def _rank_filter(input, rank, size=None, footprint=None, output=None,
                  mode="reflect", cval=0.0, origin=0, operation='rank'):
     if (size is not None) and (footprint is not None):
-        warnings.warn("Ignoring size because footprint is set", UserWarning, stacklevel=3)
+        warnings.warn("ignoring size because footprint is set", UserWarning, stacklevel=3)
     input = numpy.asarray(input)
     if numpy.iscomplexobj(input):
         raise TypeError('Complex type not supported')
@@ -1402,7 +1402,7 @@ def generic_filter(input, function, size=None, footprint=None,
 
     """
     if (size is not None) and (footprint is not None):
-        warnings.warn("Ignoring size because footprint is set", UserWarning, stacklevel=2)
+        warnings.warn("ignoring size because footprint is set", UserWarning, stacklevel=2)
     if extra_keywords is None:
         extra_keywords = {}
     input = numpy.asarray(input)

--- a/scipy/ndimage/morphology.py
+++ b/scipy/ndimage/morphology.py
@@ -29,6 +29,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from __future__ import division, print_function, absolute_import
+import warnings
 
 import numpy
 from . import _ni_support

--- a/scipy/ndimage/morphology.py
+++ b/scipy/ndimage/morphology.py
@@ -1399,7 +1399,8 @@ def grey_opening(input, size=None, footprint=None, structure=None,
     >>> # Note that the local maximum a[3,3] has disappeared
 
     """
-    warnings.warn("ignoring size because footprint is set", UserWarning, stacklevel=2)
+    if (size is not None) and (footprint is not None):
+        warnings.warn("ignoring size because footprint is set", UserWarning, stacklevel=2)
     tmp = grey_erosion(input, size, footprint, structure, None, mode,
                        cval, origin)
     return grey_dilation(tmp, size, footprint, structure, output, mode,
@@ -1694,7 +1695,8 @@ def white_tophat(input, size=None, footprint=None, structure=None,
     black_tophat
 
     """
-    warnings.warn("ignoring size because footprint is set", UserWarning, stacklevel=2)
+    if (size is not None) and (footprint is not None):
+        warnings.warn("ignoring size because footprint is set", UserWarning, stacklevel=2)
     tmp = grey_erosion(input, size, footprint, structure, None, mode,
                        cval, origin)
     tmp = grey_dilation(tmp, size, footprint, structure, output, mode,

--- a/scipy/ndimage/morphology.py
+++ b/scipy/ndimage/morphology.py
@@ -1398,6 +1398,7 @@ def grey_opening(input, size=None, footprint=None, structure=None,
     >>> # Note that the local maximum a[3,3] has disappeared
 
     """
+    warnings.warn("ignoring size because footprint is set", UserWarning, stacklevel=2)
     tmp = grey_erosion(input, size, footprint, structure, None, mode,
                        cval, origin)
     return grey_dilation(tmp, size, footprint, structure, output, mode,
@@ -1479,6 +1480,8 @@ def grey_closing(input, size=None, footprint=None, structure=None,
     >>> # Note that the local minimum a[3,3] has disappeared
 
     """
+    if (size is not None) and (footprint is not None):
+        warnings.warn("ignoring size because footprint is set", UserWarning, stacklevel=2)
     tmp = grey_dilation(input, size, footprint, structure, None, mode,
                         cval, origin)
     return grey_erosion(tmp, size, footprint, structure, output, mode,
@@ -1690,6 +1693,7 @@ def white_tophat(input, size=None, footprint=None, structure=None,
     black_tophat
 
     """
+    warnings.warn("ignoring size because footprint is set", UserWarning, stacklevel=2)
     tmp = grey_erosion(input, size, footprint, structure, None, mode,
                        cval, origin)
     tmp = grey_dilation(tmp, size, footprint, structure, output, mode,
@@ -1746,6 +1750,8 @@ def black_tophat(input, size=None, footprint=None,
     white_tophat, grey_opening, grey_closing
 
     """
+    if (size is not None) and (footprint is not None):
+        warnings.warn("ignoring size because footprint is set", UserWarning, stacklevel=2)
     tmp = grey_dilation(input, size, footprint, structure, None, mode,
                         cval, origin)
     tmp = grey_erosion(tmp, size, footprint, structure, output, mode,


### PR DESCRIPTION
Warning with `stacklevel=2` to cover median, rank, minimum, maximum and percentile filters. Generic filter has `stacklevel=1`.

Fixes #7334 