### PR TITLE
MAINT: adjust benchmark config

### DIFF
--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -13,23 +13,23 @@
     // benchmarked
     "repo": "..",
     "dvcs": "git",
-    "branches": ["master", "maintenance/0.15.x", "maintenance/0.14.x"],
+    "branches": ["master"],
 
     // The base URL to "how a commit for the project.
     "show_commit_url": "http://github.com/scipy/scipy/commit/",
 
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.
-    "pythons": ["2.7"],
+    "pythons": ["3.6"],
 
     // The matrix of dependencies to test.  Each key is the name of a
     // package (in PyPI) and the values are version numbers.  An empty
     // list indicates to just test against the default (latest)
     // version.
     "matrix": {
-        "numpy": ["1.8.2"],
-        "Tempita": ["0.5.2"],
-        "Cython": ["0.27.3"],
+        "numpy": [],
+        "Tempita": [],
+        "Cython": [],
         "pytest": [],
         "six": [],
     },

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -29,7 +29,7 @@
     "matrix": {
         "numpy": [],
         "Tempita": [],
-        "Cython": [],
+        "Cython": ["0.27.3"],
         "pytest": [],
         "six": [],
     },


### PR DESCRIPTION
Modifies the asv benchmark config to remove specific versions from the test matrix, and updates the python version from 2.7 to 3.6. Note, one has to have at least one matrix entry to test, which is why I chose py37.