### PR TITLE
[DOC]: fix Nakagami density docstring

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -4485,7 +4485,7 @@ class nakagami_gen(rv_continuous):
 
     .. math::
 
-        f(x, nu) = \frac{2 \nu^\nu}{\gamma(\nu)} x^{2\nu-1} \exp(-\nu x^2)
+        f(x, nu) = \frac{2 \nu^\nu}{\Gamma(\nu)} x^{2\nu-1} \exp(-\nu x^2)
 
     for ``x > 0``, ``nu > 0``.
 


### PR DESCRIPTION
I guess `$\Gamma$` is more often designated to denote the Gamma function than `$\gamma$`. See https://en.wikipedia.org/wiki/Gamma_function, https://docs.scipy.org/doc/scipy/reference/generated/scipy.special.gamma.html#scipy.special.gamma, and https://en.wikipedia.org/wiki/Nakagami_distribution.