### PR TITLE
BUG: fix p-value calc of anderson_ksamp in scipy.stats

### DIFF
--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -1568,7 +1568,8 @@ def anderson_ksamp(samples, midrank=True):
         The critical values for significance levels 25%, 10%, 5%, 2.5%, 1%.
     significance_level : float
         An approximate significance level at which the null hypothesis for the
-        provided samples can be rejected.
+        provided samples can be rejected. The value is floored / capped at
+        1% / 25%.
 
     Raises
     ------
@@ -1621,14 +1622,15 @@ def anderson_ksamp(samples, midrank=True):
 
 
     The null hypothesis cannot be rejected for three samples from an
-    identical distribution. The approximate p-value (87%) has to be
-    computed by extrapolation and may not be very accurate:
+    identical distribution. The reported p-value (25%) has been capped and
+    may not be very accurate (since it corresponds to the value 0.449
+    whereas the statistic is -0.731):
 
     >>> stats.anderson_ksamp([np.random.normal(size=50),
     ... np.random.normal(size=30), np.random.normal(size=20)])
     (-0.73091722665244196,
       array([ 0.44925884,  1.3052767 ,  1.9434184 ,  2.57696569,  3.41634856]),
-      0.8789283903979661)
+      0.25)
 
     """
     k = len(samples)
@@ -1672,13 +1674,19 @@ def anderson_ksamp(samples, midrank=True):
     b1 = np.array([-0.245, 0.25, 0.678, 1.149, 1.822])
     b2 = np.array([-0.105, -0.305, -0.362, -0.391, -0.396])
     critical = b0 + b1 / math.sqrt(m) + b2 / m
-    pf = np.polyfit(critical, log(np.array([0.25, 0.1, 0.05, 0.025, 0.01])), 2)
-    if A2 < critical.min() or A2 > critical.max():
-        warnings.warn("approximate p-value will be computed by extrapolation")
-    try:
+
+    sig = np.array([0.25, 0.1, 0.05, 0.025, 0.01])
+    if A2 < critical.min():
+        p = sig.max()
+        warnings.warn("p-value capped: true value larger than " + str(p))
+    elif A2 > critical.max():
+        p = sig.min()
+        warnings.warn("p-value floored: true value smaller than " + str(p))
+    else:
+        # interpolation of probit of significance level
+        pf = np.polyfit(critical, log(sig), 2)
         p = math.exp(np.polyval(pf, A2))
-    except (OverflowError,):
-        p = float("inf")
+
     return Anderson_ksampResult(A2, critical, p)
 
 

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -1678,10 +1678,12 @@ def anderson_ksamp(samples, midrank=True):
     sig = np.array([0.25, 0.1, 0.05, 0.025, 0.01])
     if A2 < critical.min():
         p = sig.max()
-        warnings.warn("p-value capped: true value larger than " + str(p))
+        warnings.warn("p-value capped: true value larger than {}".format(p),
+                      stacklevel=2)
     elif A2 > critical.max():
         p = sig.min()
-        warnings.warn("p-value floored: true value smaller than " + str(p))
+        warnings.warn("p-value floored: true value smaller than {}".format(p),
+                      stacklevel=2)
     else:
         # interpolation of probit of significance level
         pf = np.polyfit(critical, log(sig), 2)

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -1584,7 +1584,7 @@ def anderson_ksamp(samples, midrank=True):
 
     Notes
     -----
-    [1]_ Defines three versions of the k-sample Anderson-Darling test:
+    [1]_ defines three versions of the k-sample Anderson-Darling test:
     one for continuous distributions and two for discrete
     distributions, in which ties between samples may occur. The
     default of this routine is to compute the version based on the
@@ -1594,6 +1594,11 @@ def anderson_ksamp(samples, midrank=True):
     data. According to [1]_, the two discrete test statistics differ
     only slightly if a few collisions due to round-off errors occur in
     the test not adjusted for ties between samples.
+
+    The critical values are taken from [1]_. p-values are floored / capped
+    at 1% / 25%. Since the range of criticl values might be extended in
+    future releases, it is recommended not to test ``p == 0.01``, but rather
+    ``p <= 0.01`` (analogously for the upper bound).
 
     .. versionadded:: 0.14.0
 

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -391,32 +391,40 @@ class TestAndersonKSamp(object):
         x1 = np.linspace(1, 100, 100)
         # test case: different distributions;p-value floored at 0.01
         # test case for issue #5493 / #8536
-        res = stats.anderson_ksamp([x1, x1 + 40.5], midrank=False)
-        assert_almost_equal(res.statistic, 41.105, 3)
-        assert_equal(res.significance_level, 0.01)
+        with suppress_warnings() as sup:
+            sup.filter(UserWarning, message='p-value floored')
+            s, _, p = stats.anderson_ksamp([x1, x1 + 40.5], midrank=False)
+        assert_almost_equal(s, 41.105, 3)
+        assert_equal(p, 0.01)
 
-        res = stats.anderson_ksamp([x1, x1 + 40.5])
-        assert_almost_equal(res.statistic, 41.235, 3)
-        assert_equal(res.significance_level, 0.01)
+        with suppress_warnings() as sup:
+            sup.filter(UserWarning, message='p-value floored')
+            s, _, p = stats.anderson_ksamp([x1, x1 + 40.5])
+        assert_almost_equal(s, 41.235, 3)
+        assert_equal(p, 0.01)
 
         # test case: similar distributions --> p-value capped at 0.25
-        res = stats.anderson_ksamp([x1, x1 + .5], midrank=False)
-        assert_almost_equal(res.statistic, -1.2824, 4)
-        assert_equal(res.significance_level, 0.25)
+        with suppress_warnings() as sup:
+            sup.filter(UserWarning, message='p-value capped')
+            s, _, p = stats.anderson_ksamp([x1, x1 + .5], midrank=False)
+        assert_almost_equal(s, -1.2824, 4)
+        assert_equal(p, 0.25)
 
-        res = stats.anderson_ksamp([x1, x1 + .5])
-        assert_almost_equal(res.statistic, -1.2944, 4)
-        assert_equal(res.significance_level, 0.25)
+        with suppress_warnings() as sup:
+            sup.filter(UserWarning, message='p-value capped')
+            s, _, p = stats.anderson_ksamp([x1, x1 + .5])
+        assert_almost_equal(s, -1.2944, 4)
+        assert_equal(p, 0.25)
 
         # test case: check interpolated p-value in range [0.01, 0.25] (no ties)
-        res = stats.anderson_ksamp([x1, x1 + 7.5], midrank=False)
-        assert_almost_equal(res.statistic, 1.4923, 4)
-        assert_allclose(res.significance_level, 0.0775, atol=0.005, rtol=0)
+        s, _, p = stats.anderson_ksamp([x1, x1 + 7.5], midrank=False)
+        assert_almost_equal(s, 1.4923, 4)
+        assert_allclose(p, 0.0775, atol=0.005, rtol=0)
 
         # test case: check interpolated p-value in range [0.01, 0.25] (w/ ties)
-        res = stats.anderson_ksamp([x1, x1 + 6])
-        assert_almost_equal(res.statistic, 0.6389, 4)
-        assert_allclose(res.significance_level, 0.1798, atol=0.005, rtol=0)
+        s, _, p = stats.anderson_ksamp([x1, x1 + 6])
+        assert_almost_equal(s, 0.6389, 4)
+        assert_allclose(p, 0.1798, atol=0.005, rtol=0)
 
     def test_not_enough_samples(self):
         assert_raises(ValueError, stats.anderson_ksamp, np.ones(5))

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -270,13 +270,13 @@ class TestAndersonKSamp(object):
         assert_warns(UserWarning, stats.anderson_ksamp, (t1, t2, t3, t4),
                      midrank=False)
         with suppress_warnings() as sup:
-            sup.filter(UserWarning, message='approximate p-value')
+            sup.filter(UserWarning, message='p-value floored')
             Tk, tm, p = stats.anderson_ksamp((t1, t2, t3, t4), midrank=False)
 
         assert_almost_equal(Tk, 4.449, 3)
         assert_array_almost_equal([0.4985, 1.3237, 1.9158, 2.4930, 3.2459],
                                   tm, 4)
-        assert_almost_equal(p, 0.0021, 4)
+        assert_equal(p, 0.01)  # floor at 0.01; in technical report p = 0.0021
 
     def test_example1b(self):
         # Example data from Scholz & Stephens (1987), originally
@@ -288,13 +288,13 @@ class TestAndersonKSamp(object):
         t3 = np.array([34.0, 35.0, 39.0, 40.0, 43.0, 43.0, 44.0, 45.0])
         t4 = np.array([34.0, 34.8, 34.8, 35.4, 37.2, 37.8, 41.2, 42.8])
         with suppress_warnings() as sup:
-            sup.filter(UserWarning, message='approximate p-value')
+            sup.filter(UserWarning, message='p-value floored')
             Tk, tm, p = stats.anderson_ksamp((t1, t2, t3, t4), midrank=True)
 
         assert_almost_equal(Tk, 4.480, 3)
         assert_array_almost_equal([0.4985, 1.3237, 1.9158, 2.4930, 3.2459],
                                   tm, 4)
-        assert_almost_equal(p, 0.0020, 4)
+        assert_equal(p, 0.01)  # floor at 0.01; in technical report p = 0.0020
 
     def test_example2a(self):
         # Example data taken from an earlier technical report of
@@ -320,7 +320,7 @@ class TestAndersonKSamp(object):
         t14 = [102, 209, 14, 57, 54, 32, 67, 59, 134, 152, 27, 14, 230, 66,
                61, 34]
         with suppress_warnings() as sup:
-            sup.filter(UserWarning, message='approximate p-value')
+            sup.filter(UserWarning, message='p-value floored')
             Tk, tm, p = stats.anderson_ksamp((t1, t2, t3, t4, t5, t6, t7, t8,
                                               t9, t10, t11, t12, t13, t14),
                                              midrank=False)
@@ -328,7 +328,7 @@ class TestAndersonKSamp(object):
         assert_almost_equal(Tk, 3.288, 3)
         assert_array_almost_equal([0.5990, 1.3269, 1.8052, 2.2486, 2.8009],
                                   tm, 4)
-        assert_almost_equal(p, 0.0041, 4)
+        assert_equal(p, 0.01)  # floor at 0.01; in technical report p = 0.0041
 
     def test_example2b(self):
         # Example data taken from an earlier technical report of
@@ -353,7 +353,7 @@ class TestAndersonKSamp(object):
         t14 = [102, 209, 14, 57, 54, 32, 67, 59, 134, 152, 27, 14, 230, 66,
                61, 34]
         with suppress_warnings() as sup:
-            sup.filter(UserWarning, message='approximate p-value')
+            sup.filter(UserWarning, message='p-value floored')
             Tk, tm, p = stats.anderson_ksamp((t1, t2, t3, t4, t5, t6, t7, t8,
                                               t9, t10, t11, t12, t13, t14),
                                              midrank=True)
@@ -361,7 +361,62 @@ class TestAndersonKSamp(object):
         assert_almost_equal(Tk, 3.294, 3)
         assert_array_almost_equal([0.5990, 1.3269, 1.8052, 2.2486, 2.8009],
                                   tm, 4)
-        assert_almost_equal(p, 0.0041, 4)
+        assert_equal(p, 0.01)  # floor at 0.01; in technical report p = 0.0041
+
+    def test_R_kSamples(self):
+        # test values generates with R package kSamples
+        # package version 1.2-6 (2017-06-14)
+        # r1 = 1:100
+        # continuous case (no ties) --> version  1
+        # res <- kSamples::ad.test(r1, r1 + 40.5)
+        # res$ad[1, "T.AD"] #  41.105
+        # res$ad[1, " asympt. P-value"] #  5.8399e-18
+        #
+        # discrete case (ties allowed) --> version  2 (here: midrank=True)
+        # res$ad[2, "T.AD"] #  41.235
+        #
+        # res <- kSamples::ad.test(r1, r1 + .5)
+        # res$ad[1, "T.AD"] #  -1.2824
+        # res$ad[1, " asympt. P-value"] #  1
+        # res$ad[2, "T.AD"] #  -1.2944
+        #
+        # res <- kSamples::ad.test(r1, r1 + 7.5)
+        # res$ad[1, "T.AD"] # 1.4923
+        # res$ad[1, " asympt. P-value"] # 0.077501
+        #
+        # res <- kSamples::ad.test(r1, r1 + 6)
+        # res$ad[2, "T.AD"] # 0.63892
+        # res$ad[2, " asympt. P-value"] # 0.17981
+
+        x1 = np.linspace(1, 100, 100)
+        # test case: different distributions;p-value floored at 0.01
+        # test case for issue #5493 / #8536
+        res = stats.anderson_ksamp([x1, x1 + 40.5], midrank=False)
+        assert_almost_equal(res.statistic, 41.105, 3)
+        assert_equal(res.significance_level, 0.01)
+
+        res = stats.anderson_ksamp([x1, x1 + 40.5])
+        assert_almost_equal(res.statistic, 41.235, 3)
+        assert_equal(res.significance_level, 0.01)
+
+        # test case: similar distributions --> p-value capped at 0.25
+        res = stats.anderson_ksamp([x1, x1 + .5], midrank=False)
+        assert_almost_equal(res.statistic, -1.2824, 4)
+        assert_equal(res.significance_level, 0.25)
+
+        res = stats.anderson_ksamp([x1, x1 + .5])
+        assert_almost_equal(res.statistic, -1.2944, 4)
+        assert_equal(res.significance_level, 0.25)
+
+        # test case: check interpolated p-value in range [0.01, 0.25] (no ties)
+        res = stats.anderson_ksamp([x1, x1 + 7.5], midrank=False)
+        assert_almost_equal(res.statistic, 1.4923, 4)
+        assert_allclose(res.significance_level, 0.0775, atol=0.005, rtol=0)
+
+        # test case: check interpolated p-value in range [0.01, 0.25] (w/ ties)
+        res = stats.anderson_ksamp([x1, x1 + 6])
+        assert_almost_equal(res.statistic, 0.6389, 4)
+        assert_allclose(res.significance_level, 0.1798, atol=0.005, rtol=0)
 
     def test_not_enough_samples(self):
         assert_raises(ValueError, stats.anderson_ksamp, np.ones(5))
@@ -384,18 +439,11 @@ class TestAndersonKSamp(object):
         t4 = np.array([34.0, 34.8, 34.8, 35.4, 37.2, 37.8, 41.2, 42.8])
 
         with suppress_warnings() as sup:
-            sup.filter(UserWarning, message='approximate p-value')
+            sup.filter(UserWarning, message='p-value floored')
             res = stats.anderson_ksamp((t1, t2, t3, t4), midrank=False)
 
         attributes = ('statistic', 'critical_values', 'significance_level')
         check_named_results(res, attributes)
-
-    def test_overflow(self):
-        # when significance_level approximation overflows, should still return
-        with suppress_warnings() as sup:
-            sup.filter(UserWarning, message='approximate p-value')
-            res = stats.anderson_ksamp([[-20, -10] * 100, [-10, 40, 12] * 100])
-            assert_almost_equal(res[0], 272.796, 3)
 
 
 class TestAnsari(object):


### PR DESCRIPTION
Appoximation of p-values leads to errors if test statistic lies far outside the range of the known critical values that are used to fit the polynomial. 

Issue described in #5493 and #8536.

Suggestion: better to floor / cap p-values than to report inaccurate / wrong values.
There are also ways to improve the approximation as described in #8536, but in the end, it is unclear how good the result is and this would require more analysis.

added further test cases against results of R package kSamples

@josef-pkt: just to inform you about it, since you have been involved in the discussion.