### PR TITLE
[DOC]: fix gamma density docstring

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -2408,14 +2408,14 @@ class gamma_gen(rv_continuous):
 
     .. math::
 
-        f(x, a) = \frac{x^{a-1} \exp(-x)}{\gamma(a)}
+        f(x, a) = \frac{x^{a-1} \exp(-x)}{\Gamma(a)}
 
-    for :math:`x \ge 0`, :math:`a > 0`. Here :math:`\gamma(a)` refers to the
+    for :math:`x \ge 0`, :math:`a > 0`. Here :math:`\Gamma(a)` refers to the
     gamma function.
 
     `gamma` has a shape parameter `a` which needs to be set explicitly.
 
-    When :math:`a` is an integer, :math:`\gamma` reduces to the Erlang
+    When :math:`a` is an integer, `gamma` reduces to the Erlang
     distribution, and when :math:`a=1` to the exponential distribution.
 
     %(after_notes)s


### PR DESCRIPTION
The proposed changes here follows the same rationale as in https://github.com/scipy/scipy/pull/8557, i.e., `$\Gamma$` is more often used to denote the Gamma function instead of `$\gamma$`. The latter being frequently used to refer to the lower incomplete gamma function (https://en.wikipedia.org/wiki/Incomplete_gamma_function).

One additional proposed change is the following: I believe where it reads
```
When :math:`a` is an integer, :math:`\gamma` reduces to the Erlang distribution
```
should actually read
```
When :math:`a` is an integer, `gamma` reduces to the Erlang distribution
```
just because what reduces to the Erlang distribution is the gamma distribution and not the Gamma function.

Anyways, too many gammas for one to keep track of. ;-)