### PR TITLE
CI: Temporarily pin Cython version to 0.27.3

### DIFF
--- a/tools/ci/appveyor/requirements.txt
+++ b/tools/ci/appveyor/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-cython
+cython==0.27.3
 pytest-timeout
 pytest-xdist
 pytest-env


### PR DESCRIPTION
Cython v0.28 broke the Appveyor tests hence let's see if this is going to turn things back to normal as a temporary fix.

Fixes #8562 

Also opened an issue on Cython repo https://github.com/cython/cython/issues/2154