### PR TITLE
BUG: Fixes Bland's Rule for pivot row/leaving variable, closes #8561

### DIFF
--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -180,6 +180,8 @@ def _pivot_row(T, basis, pivcol, phase, tol=1.0E-12, bland=False):
     ----------
     T : 2D ndarray
         The simplex tableau.
+    basis : array
+        A list of the current basic variables.
     pivcol : int
         The index of the pivot column.
     phase : int
@@ -188,6 +190,9 @@ def _pivot_row(T, basis, pivcol, phase, tol=1.0E-12, bland=False):
         Elements in the pivot column smaller than tol will not be considered
         for pivoting.  Nominally this value is zero, but numerical issues
         cause a tolerance about zero to be necessary.
+    bland : bool
+        If True, use Bland's rule for selection of the row (if more than one
+        row can be used, choose the one with the lowest variable index).
 
     Returns
     -------

--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -171,7 +171,7 @@ def _pivot_col(T, tol=1.0E-12, bland=False):
     return True, np.ma.where(ma == ma.min())[0][0]
 
 
-def _pivot_row(T, pivcol, phase, tol=1.0E-12):
+def _pivot_row(T, basis, pivcol, phase, tol=1.0E-12, bland=False):
     """
     Given a linear programming simplex tableau, determine the row for the
     pivot operation.
@@ -207,7 +207,10 @@ def _pivot_row(T, pivcol, phase, tol=1.0E-12):
         return False, np.nan
     mb = np.ma.masked_where(T[:-k, pivcol] <= tol, T[:-k, -1], copy=False)
     q = mb / ma
-    return True, np.ma.where(q == q.min())[0][0]
+    min_rows = np.ma.where(q == q.min())[0]
+    if bland:
+        return True, min_rows[np.argmin(np.take(basis, min_rows))]
+    return True, min_rows[0]
 
 
 def _solve_simplex(T, n, basis, maxiter=1000, phase=2, callback=None,
@@ -355,7 +358,7 @@ def _solve_simplex(T, n, basis, maxiter=1000, phase=2, callback=None,
             complete = True
         else:
             # Find the pivot row
-            pivrow_found, pivrow = _pivot_row(T, pivcol, phase, tol)
+            pivrow_found, pivrow = _pivot_row(T, basis, pivcol, phase, tol, bland)
             if not pivrow_found:
                 status = 3
                 complete = True

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -240,6 +240,25 @@ class LinprogCommonTests(object):
                           method=self.method)
         _assert_success(res, desired_x=[1, 0, 1, 0])
 
+    def test_linprog_cyclic_bland_bug_8561(self):
+        # Test that pivot row is chosen correctly when using Bland's rule
+        c = np.array([7, 0, -4, 1.5, 1.5])
+        A_ub = np.array([
+            [4, 5.5, 1.5, 1.0, -3.5],
+            [1, -2.5, -2, 2.5, 0.5],
+            [3, -0.5, 4, -12.5, -7],
+            [-1, 4.5, 2, -3.5, -2],
+            [5.5, 2, -4.5, -1, 9.5]])
+        b_ub = np.array([0, 0, 0, 0, 1])
+        if self.method == "simplex":
+            res = linprog(c, A_ub=A_ub, b_ub=b_ub,
+                          options=dict(maxiter=100, bland=True),
+                          method=self.method)
+        else:
+            res = linprog(c, A_ub=A_ub, b_ub=b_ub, options=dict(maxiter=100),
+                          method=self.method)
+        _assert_success(res, desired_x=[0, 0, 19, 16/3, 29/3])
+
     def test_linprog_unbounded(self):
         # Test linprog response to an unbounded problem
         c = np.array([1, 1]) * -1  # maximize


### PR DESCRIPTION
See issue #8561 and my comment to it for further explanation of fix and the previously failing test case.

To summarize, choosing the first of the possible pivot rows (as it does now) is not in accordance with Bland's Rule, since the basis is not sorted by variable index. This results in some inputs cycling/not terminating when Bland's anti-cycling rules are used (see issue). This fix does a lookup in the basis array to make sure the correct row is chosen.

Not sure if "min_rows" breaks the naming conventions. This is my first ever pull request, so let me know if anything is wrong.