### PR TITLE
Backports for 1.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,7 @@ before_install:
       export PATH=/usr/lib/ccache:$PATH
       free -m
     elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      brew cask uninstall oclint
       brew install gcc ccache
       touch config.sh
       git clone https://github.com/matthew-brett/multibuild.git
@@ -102,16 +103,16 @@ before_install:
   - df -h
   - ulimit -a
   - mkdir builds
-  - pushd builds
+  - cd builds
   # Install gmpy2 dependencies
   - mkdir -p $HOME/.local
   - wget ftp://ftp.gnu.org/gnu/mpc/mpc-1.0.2.tar.gz
   - tar xzvf mpc-1.0.2.tar.gz
-  - pushd mpc-1.0.2
+  - cd mpc-1.0.2
   - ./configure --prefix=$HOME/.local
   - make
   - make install
-  - popd
+  - cd ..
   - export CPATH=$HOME/.local/include
   - export LIBRARY_PATH=$HOME/.local/lib
   - export LD_LIBRARY_PATH=$HOME/.local/lib
@@ -130,7 +131,7 @@ before_install:
     fi
   - python -V
   - ccache -s
-  - popd
+  - cd ..
   - set -o pipefail
 script:
   - python -c 'import numpy as np; print("relaxed strides checking:", np.ones((10,1),order="C").flags.f_contiguous)'
@@ -152,14 +153,14 @@ script:
         echo "setup.py sdist"
         python tools/suppress_output.py python setup.py sdist
         # Move out of source directory to avoid finding local scipy
-        pushd dist
+        cd dist
         # Use pip --build option to make ccache work better.
         # However, this option is partially broken
         # (see https://github.com/pypa/pip/issues/4242)
         # and some shenanigans are needed to make it work.
         echo "pip install"
         python ../tools/suppress_output.py pip install --build="$HOME/builds" --upgrade "file://`echo -n $PWD/scipy*`#egg=scipy" -v
-        popd
+        cd ..
         USE_WHEEL_BUILD="--no-build"
     fi
   - export SCIPY_AVAILABLE_MEM=3G
@@ -170,9 +171,9 @@ after_success:
   - ccache -s
   # Upload coverage information
   - if [ "${COVERAGE}" == "--coverage" ]; then
-        pushd build/testenv/lib/python*/site-packages/;
+        cd build/testenv/lib/python*/site-packages/;
         codecov;
-        popd;
+        cd ..;
     fi
 notifications:
   # Perhaps we should have status emails sent to the mailing list, but

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ matrix:
         - COVERAGE=
         - USE_WHEEL=1
         - REFGUIDE_CHECK=1
+        - NUMPYSPEC="numpy==1.13.3"
     - python: 3.4
       env:
         - TESTMODE=fast

--- a/scipy/io/idl.py
+++ b/scipy/io/idl.py
@@ -281,15 +281,15 @@ def _read_array(f, typecode, array_desc):
                 warnings.warn("Not able to verify number of bytes from header")
 
         # Read bytes as numpy array
-        array = np.fromstring(f.read(array_desc['nbytes']),
-                                dtype=DTYPE_DICT[typecode])
+        array = np.frombuffer(f.read(array_desc['nbytes']),
+                              dtype=DTYPE_DICT[typecode])
 
     elif typecode in [2, 12]:
 
         # These are 2 byte types, need to skip every two as they are not packed
 
-        array = np.fromstring(f.read(array_desc['nbytes']*2),
-                                dtype=DTYPE_DICT[typecode])[1::2]
+        array = np.frombuffer(f.read(array_desc['nbytes']*2),
+                              dtype=DTYPE_DICT[typecode])[1::2]
 
     else:
 

--- a/scipy/io/netcdf.py
+++ b/scipy/io/netcdf.py
@@ -45,7 +45,7 @@ import mmap as mm
 
 import numpy as np
 from numpy.compat import asbytes, asstr
-from numpy import fromstring, dtype, empty, array, asarray
+from numpy import frombuffer, dtype, empty, array, asarray
 from numpy import little_endian as LITTLE_ENDIAN
 from functools import reduce
 
@@ -584,7 +584,7 @@ class netcdf_file(object):
         if not magic == b'CDF':
             raise TypeError("Error: %s is not a valid NetCDF 3 file" %
                             self.filename)
-        self.__dict__['version_byte'] = fromstring(self.fp.read(1), '>b')[0]
+        self.__dict__['version_byte'] = frombuffer(self.fp.read(1), '>b')[0]
 
         # Read file headers and set data.
         self._read_numrecs()
@@ -678,7 +678,7 @@ class netcdf_file(object):
                 else:
                     pos = self.fp.tell()
                     self.fp.seek(begin_)
-                    data = fromstring(self.fp.read(a_size), dtype=dtype_)
+                    data = frombuffer(self.fp.read(a_size), dtype=dtype_)
                     data.shape = shape
                     self.fp.seek(pos)
 
@@ -700,7 +700,7 @@ class netcdf_file(object):
             else:
                 pos = self.fp.tell()
                 self.fp.seek(begin)
-                rec_array = fromstring(self.fp.read(self._recs*self._recsize), dtype=dtypes)
+                rec_array = frombuffer(self.fp.read(self._recs*self._recsize), dtype=dtypes)
                 rec_array.shape = (self._recs,)
                 self.fp.seek(pos)
 
@@ -743,7 +743,7 @@ class netcdf_file(object):
         self.fp.read(-count % 4)  # read padding
 
         if typecode is not 'c':
-            values = fromstring(values, dtype='>%s' % typecode)
+            values = frombuffer(values, dtype='>%s' % typecode)
             if values.shape == (1,):
                 values = values[0]
         else:
@@ -761,14 +761,14 @@ class netcdf_file(object):
     _pack_int32 = _pack_int
 
     def _unpack_int(self):
-        return int(fromstring(self.fp.read(4), '>i')[0])
+        return int(frombuffer(self.fp.read(4), '>i')[0])
     _unpack_int32 = _unpack_int
 
     def _pack_int64(self, value):
         self.fp.write(array(value, '>q').tostring())
 
     def _unpack_int64(self):
-        return fromstring(self.fp.read(8), '>q')[0]
+        return frombuffer(self.fp.read(8), '>q')[0]
 
     def _pack_string(self, s):
         count = len(s)

--- a/scipy/io/wavfile.py
+++ b/scipy/io/wavfile.py
@@ -126,7 +126,7 @@ def _read_data_chunk(fid, format_tag, channels, bit_depth, is_big_endian,
         else:
             dtype += 'f%d' % bytes_per_sample
     if not mmap:
-        data = numpy.fromstring(fid.read(size), dtype=dtype)
+        data = numpy.frombuffer(fid.read(size), dtype=dtype)
     else:
         start = fid.tell()
         data = numpy.memmap(fid, dtype=dtype, mode='c', offset=start,

--- a/scipy/linalg/_solvers.py
+++ b/scipy/linalg/_solvers.py
@@ -25,6 +25,7 @@ from .special_matrices import kron, block_diag
 
 __all__ = ['solve_sylvester',
            'solve_continuous_lyapunov', 'solve_discrete_lyapunov',
+           'solve_lyapunov',
            'solve_continuous_are', 'solve_discrete_are']
 
 

--- a/scipy/linalg/flapack.pyf.src
+++ b/scipy/linalg/flapack.pyf.src
@@ -1757,7 +1757,7 @@ interface
      callprotoargument int*,int*,int*,<ctype2c>*,int*,<ctype2c>*,int*,int*,<ctype2>*,int*,<ctype2c>*,int*,<ctype2>*,int*
 
      integer intent(in) :: m
-     integer intent(in)):: n
+     integer intent(in) :: n
      integer intent(hide) :: maxmn = MAX(m,n)
      <ftype2c> intent(hide) :: a
 

--- a/scipy/misc/common.py
+++ b/scipy/misc/common.py
@@ -5,7 +5,7 @@ Functions which are common and require SciPy Base and Level 1 SciPy
 
 from __future__ import division, print_function, absolute_import
 
-from numpy import arange, newaxis, hstack, product, array, fromstring
+from numpy import arange, newaxis, hstack, product, array, frombuffer
 
 __all__ = ['central_diff_weights', 'derivative', 'ascent', 'face']
 
@@ -196,7 +196,7 @@ def face(gray=False):
     with open(os.path.join(os.path.dirname(__file__), 'face.dat'), 'rb') as f:
         rawdata = f.read()
     data = bz2.decompress(rawdata)
-    face = fromstring(data, dtype='uint8')
+    face = frombuffer(data, dtype='uint8')
     face.shape = (768, 1024, 3)
     if gray is True:
         face = (0.21 * face[:,:,0] + 0.71 * face[:,:,1] + 0.07 * face[:,:,2]).astype('uint8')

--- a/scipy/ndimage/src/nd_image.c
+++ b/scipy/ndimage/src/nd_image.c
@@ -45,6 +45,10 @@
 #include "ccallback.h"
 #include "numpy/npy_3kcompat.h"
 
+#if NPY_API_VERSION >= 0x0000000c
+    #define HAVE_WRITEBACKIFCOPY
+#endif
+
 typedef struct {
     PyObject *extra_arguments;
     PyObject *extra_keywords;
@@ -106,7 +110,11 @@ NI_ObjectToOptionalInputArray(PyObject *object, PyArrayObject **array)
 static int
 NI_ObjectToOutputArray(PyObject *object, PyArrayObject **array)
 {
-    int flags = NPY_ARRAY_BEHAVED_NS | NPY_ARRAY_UPDATEIFCOPY;
+    #ifdef HAVE_WRITEBACKIFCOPY
+        int flags = NPY_ARRAY_BEHAVED_NS | NPY_ARRAY_WRITEBACKIFCOPY;
+    #else
+        int flags = NPY_ARRAY_BEHAVED_NS | NPY_ARRAY_UPDATEIFCOPY;
+    #endif
     /*
      * This would also be caught by the PyArray_CheckFromAny call, but
      * we check it explicitly here to provide a saner error message.
@@ -190,6 +198,9 @@ static PyObject *Py_Correlate1D(PyObject *obj, PyObject *args)
 
     NI_Correlate1D(input, weights, axis, output, (NI_ExtendMode)mode, cval,
                    origin);
+    #ifdef HAVE_WRITEBACKIFCOPY
+        PyArray_ResolveWritebackIfCopy(output);
+    #endif
 
 exit:
     Py_XDECREF(input);
@@ -218,6 +229,9 @@ static PyObject *Py_Correlate(PyObject *obj, PyObject *args)
 
     NI_Correlate(input, weights, output, (NI_ExtendMode)mode, cval,
                  origin.ptr);
+    #ifdef HAVE_WRITEBACKIFCOPY
+        PyArray_ResolveWritebackIfCopy(output);
+    #endif
 
 exit:
     Py_XDECREF(input);
@@ -243,6 +257,9 @@ static PyObject *Py_UniformFilter1D(PyObject *obj, PyObject *args)
 
     NI_UniformFilter1D(input, filter_size, axis, output, (NI_ExtendMode)mode,
                        cval, origin);
+    #ifdef HAVE_WRITEBACKIFCOPY
+        PyArray_ResolveWritebackIfCopy(output);
+    #endif
 
 exit:
     Py_XDECREF(input);
@@ -266,6 +283,9 @@ static PyObject *Py_MinOrMaxFilter1D(PyObject *obj, PyObject *args)
 
     NI_MinOrMaxFilter1D(input, filter_size, axis, output, (NI_ExtendMode)mode,
                         cval, origin, minimum);
+    #ifdef HAVE_WRITEBACKIFCOPY
+        PyArray_ResolveWritebackIfCopy(output);
+    #endif
 
 exit:
     Py_XDECREF(input);
@@ -297,6 +317,9 @@ static PyObject *Py_MinOrMaxFilter(PyObject *obj, PyObject *args)
 
     NI_MinOrMaxFilter(input, footprint, structure, output, (NI_ExtendMode)mode,
                       cval, origin.ptr, minimum);
+    #ifdef HAVE_WRITEBACKIFCOPY
+        PyArray_ResolveWritebackIfCopy(output);
+    #endif
 
 exit:
     Py_XDECREF(input);
@@ -328,6 +351,9 @@ static PyObject *Py_RankFilter(PyObject *obj, PyObject *args)
 
     NI_RankFilter(input, rank, footprint, output, (NI_ExtendMode)mode, cval,
                   origin.ptr);
+    #ifdef HAVE_WRITEBACKIFCOPY
+        PyArray_ResolveWritebackIfCopy(output);
+    #endif
 
 exit:
     Py_XDECREF(input);
@@ -453,6 +479,9 @@ static PyObject *Py_GenericFilter1D(PyObject *obj, PyObject *args)
 
     NI_GenericFilter1D(input, func, data, filter_size, axis, output,
                        (NI_ExtendMode)mode, cval, origin);
+    #ifdef HAVE_WRITEBACKIFCOPY
+        PyArray_ResolveWritebackIfCopy(output);
+    #endif
 
 exit:
     if (callback.py_function != NULL || callback.c_function != NULL) {
@@ -577,6 +606,9 @@ static PyObject *Py_GenericFilter(PyObject *obj, PyObject *args)
 
     NI_GenericFilter(input, func, data, footprint, output, (NI_ExtendMode)mode,
                      cval, origin.ptr);
+    #ifdef HAVE_WRITEBACKIFCOPY
+        PyArray_ResolveWritebackIfCopy(output);
+    #endif
 
 exit:
     if (callback.py_function != NULL || callback.c_function != NULL) {
@@ -604,6 +636,9 @@ static PyObject *Py_FourierFilter(PyObject *obj, PyObject *args)
         goto exit;
 
     NI_FourierFilter(input, parameters, n, axis, output, filter_type);
+    #ifdef HAVE_WRITEBACKIFCOPY
+        PyArray_ResolveWritebackIfCopy(output);
+    #endif
 
 exit:
     Py_XDECREF(input);
@@ -626,6 +661,9 @@ static PyObject *Py_FourierShift(PyObject *obj, PyObject *args)
         goto exit;
 
     NI_FourierShift(input, shifts, n, axis, output);
+    #ifdef HAVE_WRITEBACKIFCOPY
+        PyArray_ResolveWritebackIfCopy(output);
+    #endif
 
 exit:
     Py_XDECREF(input);
@@ -646,6 +684,9 @@ static PyObject *Py_SplineFilter1D(PyObject *obj, PyObject *args)
         goto exit;
 
     NI_SplineFilter1D(input, order, axis, output);
+    #ifdef HAVE_WRITEBACKIFCOPY
+        PyArray_ResolveWritebackIfCopy(output);
+    #endif
 
 exit:
     Py_XDECREF(input);
@@ -778,6 +819,9 @@ static PyObject *Py_GeometricTransform(PyObject *obj, PyObject *args)
 
     NI_GeometricTransform(input, func, data, matrix, shift, coordinates,
                           output, order, (NI_ExtendMode)mode, cval);
+    #ifdef HAVE_WRITEBACKIFCOPY
+        PyArray_ResolveWritebackIfCopy(output);
+    #endif
 
 exit:
     if (callback.py_function != NULL || callback.c_function != NULL) {
@@ -807,6 +851,9 @@ static PyObject *Py_ZoomShift(PyObject *obj, PyObject *args)
         goto exit;
 
     NI_ZoomShift(input, zoom, shift, output, order, (NI_ExtendMode)mode, cval);
+    #ifdef HAVE_WRITEBACKIFCOPY
+        PyArray_ResolveWritebackIfCopy(output);
+    #endif
 
 exit:
     Py_XDECREF(input);
@@ -918,6 +965,9 @@ static PyObject *Py_WatershedIFT(PyObject *obj, PyObject *args)
         goto exit;
 
     NI_WatershedIFT(input, markers, strct, output);
+    #ifdef HAVE_WRITEBACKIFCOPY
+        PyArray_ResolveWritebackIfCopy(output);
+    #endif
 
 exit:
     Py_XDECREF(input);
@@ -943,6 +993,9 @@ static PyObject *Py_DistanceTransformBruteForce(PyObject *obj,
         goto exit;
 
     NI_DistanceTransformBruteForce(input, metric, sampling, output, features);
+    #ifdef HAVE_WRITEBACKIFCOPY
+        PyArray_ResolveWritebackIfCopy(output);
+    #endif
 
 exit:
     Py_XDECREF(input);
@@ -1034,6 +1087,10 @@ static PyObject *Py_BinaryErosion(PyObject *obj, PyObject *args)
     if (return_coordinates) {
         cobj = NpyCapsule_FromVoidPtr(coordinate_list, _FreeCoordinateList);
     }
+    #ifdef HAVE_WRITEBACKIFCOPY
+        PyArray_ResolveWritebackIfCopy(output);
+    #endif
+
 exit:
     Py_XDECREF(input);
     Py_XDECREF(strct);

--- a/scipy/ndimage/src/ni_support.c
+++ b/scipy/ndimage/src/ni_support.c
@@ -179,6 +179,12 @@ int NI_InitLineBuffer(PyArrayObject *array, int axis, npy_intp size1,
     buffer->buffer_data = buffer_data;
     buffer->buffer_lines = buffer_lines;
     buffer->array_type = NI_CanonicalType(PyArray_TYPE(array));
+    if (buffer->array_type > 12)
+    {
+        PyErr_Format(PyExc_RuntimeError, "array type %d not supported",
+                    buffer->array_type);
+        return 0;
+    }
     buffer->array_lines = array_lines;
     buffer->next_line = 0;
     buffer->size1 = size1;

--- a/scipy/ndimage/src/ni_support.c
+++ b/scipy/ndimage/src/ni_support.c
@@ -158,6 +158,7 @@ int NI_InitLineBuffer(PyArrayObject *array, int axis, npy_intp size1,
         NI_ExtendMode extend_mode, double extend_value, NI_LineBuffer *buffer)
 {
     npy_intp line_length = 0, array_lines = 0, size;
+    int array_type;
 
     size = PyArray_SIZE(array);
     /* check if the buffer is big enough: */
@@ -165,6 +166,37 @@ int NI_InitLineBuffer(PyArrayObject *array, int axis, npy_intp size1,
         PyErr_SetString(PyExc_RuntimeError, "buffer too small");
         return 0;
     }
+    /*
+     * Check that the data type is supported, against the types listed in
+     * NI_ArrayToLineBuffer
+     */
+    array_type = NI_CanonicalType(PyArray_TYPE(array));
+    switch (array_type) {
+    case NPY_BOOL:
+    case NPY_UBYTE:
+    case NPY_USHORT:
+    case NPY_UINT:
+    case NPY_ULONG:
+    case NPY_ULONGLONG:
+    case NPY_BYTE:
+    case NPY_SHORT:
+    case NPY_INT:
+    case NPY_LONG:
+    case NPY_LONGLONG:
+    case NPY_FLOAT:
+    case NPY_DOUBLE:
+        break;
+    default:
+#if PY_VERSION_HEX >= 0x03040000
+        PyErr_Format(PyExc_RuntimeError, "array type %R not supported",
+                     (PyObject *)PyArray_DTYPE(array));
+#else
+        PyErr_Format(PyExc_RuntimeError, "array type %d not supported",
+                     array_type);
+#endif
+        return 0;
+    }
+
     /* Initialize a line iterator to move over the array: */
     if (!NI_InitPointIterator(array, &(buffer->iterator)))
         return 0;
@@ -178,13 +210,7 @@ int NI_InitLineBuffer(PyArrayObject *array, int axis, npy_intp size1,
     buffer->array_data = (void *)PyArray_DATA(array);
     buffer->buffer_data = buffer_data;
     buffer->buffer_lines = buffer_lines;
-    buffer->array_type = NI_CanonicalType(PyArray_TYPE(array));
-    if (buffer->array_type > 12)
-    {
-        PyErr_Format(PyExc_RuntimeError, "array type %d not supported",
-                    buffer->array_type);
-        return 0;
-    }
+    buffer->array_type = array_type;
     buffer->array_lines = array_lines;
     buffer->next_line = 0;
     buffer->size1 = size1;

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -400,3 +400,11 @@ def test_footprint_all_zeros():
     kernel = np.zeros((3, 3), bool)
     with assert_raises(ValueError):
         sndi.maximum_filter(arr, footprint=kernel)
+
+def test_gaussian_filter():
+    # Test gaussian filter with np.float16
+    # gh-8207
+    data = np.array([1],dtype = np.float16)
+    sigma = 1.0
+    with assert_raises(RuntimeError):
+        sndi.gaussian_filter(data,sigma)

--- a/scipy/optimize/__minpack.h
+++ b/scipy/optimize/__minpack.h
@@ -64,7 +64,7 @@ int raw_multipack_calling_function(int *n, double *x, double *fvec, int *iflag)
 
   PyArrayObject *result_array = NULL;
  
-  result_array = (PyArrayObject *)call_python_function(multipack_python_function, *n, x, multipack_extra_arguments, 1, minpack_error);
+  result_array = (PyArrayObject *)call_python_function(multipack_python_function, *n, x, multipack_extra_arguments, 1, minpack_error, *n);
   if (result_array == NULL) {
     *iflag = -1;
     return -1;
@@ -90,7 +90,7 @@ int jac_multipack_calling_function(int *n, double *x, double *fvec, double *fjac
   PyArrayObject *result_array;
 
   if (*iflag == 1) {
-    result_array = (PyArrayObject *)call_python_function(multipack_python_function, *n, x, multipack_extra_arguments, 1, minpack_error);
+    result_array = (PyArrayObject *)call_python_function(multipack_python_function, *n, x, multipack_extra_arguments, 1, minpack_error, *n);
     if (result_array == NULL) {
       *iflag = -1;
       return -1;
@@ -98,7 +98,7 @@ int jac_multipack_calling_function(int *n, double *x, double *fvec, double *fjac
     memcpy(fvec, PyArray_DATA(result_array), (*n)*sizeof(double));
   }
   else {         /* iflag == 2 */
-    result_array = (PyArrayObject *)call_python_function(multipack_python_jacobian, *n, x, multipack_extra_arguments, 2, minpack_error);
+    result_array = (PyArrayObject *)call_python_function(multipack_python_jacobian, *n, x, multipack_extra_arguments, 2, minpack_error, (*n)*(*ldfjac));
     if (result_array == NULL) {
       *iflag = -1;
       return -1;
@@ -123,7 +123,7 @@ int raw_multipack_lm_function(int *m, int *n, double *x, double *fvec, int *ifla
 
   PyArrayObject *result_array = NULL;
  
-  result_array = (PyArrayObject *)call_python_function(multipack_python_function,*n, x, multipack_extra_arguments, 1, minpack_error);
+  result_array = (PyArrayObject *)call_python_function(multipack_python_function,*n, x, multipack_extra_arguments, 1, minpack_error, *m);
   if (result_array == NULL) {
     *iflag = -1;
     return -1;
@@ -148,7 +148,7 @@ int jac_multipack_lm_function(int *m, int *n, double *x, double *fvec, double *f
   PyArrayObject *result_array;
 
   if (*iflag == 1) {
-    result_array = (PyArrayObject *)call_python_function(multipack_python_function, *n, x, multipack_extra_arguments, 1, minpack_error);
+    result_array = (PyArrayObject *)call_python_function(multipack_python_function, *n, x, multipack_extra_arguments, 1, minpack_error, *m);
     if (result_array == NULL) {
       *iflag = -1;
       return -1;
@@ -156,7 +156,7 @@ int jac_multipack_lm_function(int *m, int *n, double *x, double *fvec, double *f
     memcpy(fvec, PyArray_DATA(result_array), (*m)*sizeof(double));
   }
   else {         /* iflag == 2 */
-    result_array = (PyArrayObject *)call_python_function(multipack_python_jacobian, *n, x, multipack_extra_arguments, 2, minpack_error);
+    result_array = (PyArrayObject *)call_python_function(multipack_python_jacobian, *n, x, multipack_extra_arguments, 2, minpack_error, (*n)*(*ldfjac));
     if (result_array == NULL) {
       *iflag = -1;
       return -1;
@@ -186,7 +186,7 @@ int smjac_multipack_lm_function(int *m, int *n, double *x, double *fvec, double 
   PyArrayObject *result_array;
 
   if (*iflag == 1) {
-    result_array = (PyArrayObject *)call_python_function(multipack_python_function, *n, x, multipack_extra_arguments, 1, minpack_error);
+    result_array = (PyArrayObject *)call_python_function(multipack_python_function, *n, x, multipack_extra_arguments, 1, minpack_error, *m);
     if (result_array == NULL) {
       *iflag = -1;
       return -1;
@@ -209,7 +209,7 @@ int smjac_multipack_lm_function(int *m, int *n, double *x, double *fvec, double 
       return -1;
     }
 
-    result_array = (PyArrayObject *)call_python_function(multipack_python_jacobian, *n, x, newargs, 2, minpack_error);
+    result_array = (PyArrayObject *)call_python_function(multipack_python_jacobian, *n, x, newargs, 2, minpack_error, *n);
     if (result_array == NULL) {
       Py_DECREF(newargs);
       *iflag = -1;
@@ -260,7 +260,7 @@ static PyObject *minpack_hybrd(PyObject *dummy, PyObject *args) {
   if (maxfev < 0) maxfev = 200*(n+1);
 
   /* Setup array to hold the function evaluations */
-  ap_fvec = (PyArrayObject *)call_python_function(fcn, n, x, extra_args, 1, minpack_error);
+  ap_fvec = (PyArrayObject *)call_python_function(fcn, n, x, extra_args, 1, minpack_error, -1);
   if (ap_fvec == NULL) goto fail;
   fvec = (double *) PyArray_DATA(ap_fvec);
   if (PyArray_NDIM(ap_fvec) == 0)
@@ -361,7 +361,7 @@ static PyObject *minpack_hybrj(PyObject *dummy, PyObject *args) {
   if (maxfev < 0) maxfev = 100*(n+1);
 
   /* Setup array to hold the function evaluations */
-  ap_fvec = (PyArrayObject *)call_python_function(fcn, n, x, extra_args, 1, minpack_error);
+  ap_fvec = (PyArrayObject *)call_python_function(fcn, n, x, extra_args, 1, minpack_error, -1);
   if (ap_fvec == NULL) goto fail;
   fvec = (double *) PyArray_DATA(ap_fvec);
   if (PyArray_NDIM(ap_fvec) == 0)
@@ -467,7 +467,7 @@ static PyObject *minpack_lmdif(PyObject *dummy, PyObject *args) {
   if (maxfev < 0) maxfev = 200*(n+1);
 
   /* Setup array to hold the function evaluations and find it's size*/
-  ap_fvec = (PyArrayObject *)call_python_function(fcn, n, x, extra_args, 1, minpack_error);
+  ap_fvec = (PyArrayObject *)call_python_function(fcn, n, x, extra_args, 1, minpack_error, -1);
   if (ap_fvec == NULL) goto fail;
   fvec = (double *) PyArray_DATA(ap_fvec);
   m = (PyArray_NDIM(ap_fvec) > 0 ? PyArray_DIMS(ap_fvec)[0] : 1);
@@ -562,7 +562,7 @@ static PyObject *minpack_lmder(PyObject *dummy, PyObject *args) {
   if (maxfev < 0) maxfev = 100*(n+1);
 
   /* Setup array to hold the function evaluations */
-  ap_fvec = (PyArrayObject *)call_python_function(fcn, n, x, extra_args, 1, minpack_error);
+  ap_fvec = (PyArrayObject *)call_python_function(fcn, n, x, extra_args, 1, minpack_error, -1);
   if (ap_fvec == NULL) goto fail;
   fvec = (double *) PyArray_DATA(ap_fvec);
 

--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -543,6 +543,21 @@ def _presolve(c, A_ub, b_ub, A_eq, b_eq, bounds, rr):
     # identical bounds indicate that variable can be removed
     i_f = np.abs(lb - ub) < tol   # indices of "fixed" variables
     i_nf = np.logical_not(i_f)  # indices of "not fixed" variables
+
+    # test_bounds_equal_but_infeasible
+    if np.all(i_f):  # if bounds define solution, check for consistency
+        residual = b_eq - A_eq.dot(lb)
+        slack = b_ub - A_ub.dot(lb)
+        if ((A_ub.size > 0 and np.any(slack < 0)) or
+                (A_eq.size > 0 and not np.allclose(residual, 0))):
+            status = 2
+            message = ("The problem is (trivially) infeasible because the "
+                       "bounds fix all variables to values inconsistent with "
+                       "the constraints")
+            complete = True
+            return (c, c0, A_ub, b_ub, A_eq, b_eq, bounds,
+                    x, undo, complete, status, message)
+
     if np.any(i_f):
         c0 += c[i_f].dot(lb[i_f])
         b_eq = b_eq - A_eq[:, i_f].dot(lb[i_f])
@@ -562,7 +577,7 @@ def _presolve(c, A_ub, b_ub, A_eq, b_eq, bounds, rr):
         # test_empty_constraint_1
         if c.size == 0:
             status = 0
-            message = ("The solution was determined in presolve as there are"
+            message = ("The solution was determined in presolve as there are "
                        "no non-trivial constraints.")
         elif (np.any(np.logical_and(c < 0, ub == np.inf)) or
                 np.any(np.logical_and(c > 0, lb == -np.inf))):
@@ -570,8 +585,8 @@ def _presolve(c, A_ub, b_ub, A_eq, b_eq, bounds, rr):
             status = 3
             message = ("If feasible, the problem is (trivially) unbounded "
                        "because there are no constraints and at least one "
-                       " element of c is negative. If you wish to check "
-                       " whether the problem is infeasible, turn presolve "
+                       "element of c is negative. If you wish to check "
+                       "whether the problem is infeasible, turn presolve "
                        "off.")
         else:  # test_empty_constraint_2
             status = 0

--- a/scipy/optimize/cobyla.py
+++ b/scipy/optimize/cobyla.py
@@ -196,8 +196,7 @@ def _minimize_cobyla(fun, x0, args=(), constraints=(),
     _check_unknown_options(unknown_options)
     maxfun = maxiter
     rhoend = tol
-    if not disp:
-        iprint = 0
+    iprint = int(bool(disp))
 
     # check constraints
     if isinstance(constraints, dict):

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -1538,6 +1538,7 @@ def _minimize_newtoncg(fun, x0, args=(), jac=None, hess=None, hessp=None,
     if retall:
         allvecs = [xk]
     k = 0
+    gfk = None
     old_fval = f(x0)
     old_old_fval = None
     float64eps = numpy.finfo(numpy.float64).eps

--- a/scipy/optimize/tests/test_cobyla.py
+++ b/scipy/optimize/tests/test_cobyla.py
@@ -25,8 +25,9 @@ class TestCobyla(object):
         return -self.con1(x)
 
     def test_simple(self):
+        # use disp=True as smoke test for gh-8118
         x = fmin_cobyla(self.fun, self.x0, [self.con1, self.con2], rhobeg=1,
-                        rhoend=1e-5, maxfun=100)
+                        rhoend=1e-5, maxfun=100, disp=True)
         assert_allclose(x, self.solution, atol=1e-4)
 
     def test_minimize_simple(self):

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -661,6 +661,24 @@ class TestLinprogSimplex(LinprogCommonTests):
 class BaseTestLinprogIP(LinprogCommonTests):
     method = "interior-point"
 
+    def test_bounds_equal_but_infeasible(self):
+        c = [-4, 1]
+        A_ub = [[7, -2], [0, 1], [2, -2]]
+        b_ub = [14, 0, 3]
+        bounds = [(2, 2), (0, None)]
+        res = linprog(c=c, A_ub=A_ub, b_ub=b_ub, bounds=bounds,
+                      method=self.method)
+        _assert_infeasible(res)
+
+    def test_bounds_equal_but_infeasible2(self):
+        c = [-4, 1]
+        A_eq = [[7, -2], [0, 1], [2, -2]]
+        b_eq = [14, 0, 3]
+        bounds = [(2, 2), (0, None)]
+        res = linprog(c=c, A_eq=A_eq, b_eq=b_eq, bounds=bounds,
+                      method=self.method)
+        _assert_infeasible(res)
+
     def test_magic_square_bug_7044(self):
         # test linprog with a problem with a rank-deficient A_eq matrix
         A, b, c, N = magic_square(3)

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -321,6 +321,14 @@ class CheckOptimizeParameterized(CheckOptimize):
                               full_output=True, disp=False, retall=False,
                               initial_simplex=simplex)
 
+    def test_ncg_negative_maxiter(self):
+        # Regression test for gh-8241
+        opts = {'maxiter': -1}
+        result = optimize.minimize(self.func, self.startparams,
+                                   method='Newton-CG', jac=self.grad,
+                                   args=(), options=opts)
+        assert_(result.status == 1)
+
     def test_ncg(self):
         # line-search Newton conjugate gradient optimization routine
         if self.use_wrapper:

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -551,6 +551,21 @@ class TestMedFilt(object):
         a.strides = 16
         assert_(signal.medfilt(a, 1) == 5.)
 
+    def test_refcounting(self):
+        # Check a refcounting-related crash
+        a = Decimal(123)
+        x = np.array([a, a], dtype=object)
+        if hasattr(sys, 'getrefcount'):
+            n = 2 * sys.getrefcount(a)
+        else:
+            n = 10
+        # Shouldn't segfault:
+        for j in range(n):
+            signal.medfilt(x)
+        if hasattr(sys, 'getrefcount'):
+            assert_(sys.getrefcount(a) < n)
+        assert_equal(x, [a, a])
+
 
 class TestWiener(object):
 

--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -237,6 +237,9 @@ from .construct import *
 from .extract import *
 from ._matrix_io import *
 
+# For backward compatibility with v0.19.
+from . import csgraph
+
 __all__ = [s for s in dir() if not s.startswith('_')]
 
 from scipy._lib._testutils import PytestTester

--- a/scipy/sparse/sparsetools/sparsetools.cxx
+++ b/scipy/sparse/sparsetools/sparsetools.cxx
@@ -41,6 +41,9 @@
 #define PyInt_AsSsize_t PyLong_AsSsize_t
 #define PyInt_FromSsize_t PyLong_FromSsize_t
 #endif
+#if NPY_API_VERSION >= 0x0000000c
+    #define HAVE_WRITEBACKIFCOPY
+#endif
 
 static const int supported_I_typenums[] = {NPY_INT32, NPY_INT64};
 static const int n_supported_I_typenums = sizeof(supported_I_typenums) / sizeof(int);
@@ -444,6 +447,11 @@ fail:
             --j;
             continue;
         }
+        #ifdef HAVE_WRITEBACKIFCOPY
+            if (is_output[j] && arg_arrays[j] != NULL && PyArray_Check(arg_arrays[j])) {
+                PyArray_ResolveWritebackIfCopy((PyArrayObject *)arg_arrays[j]); 
+            }
+        #endif
         Py_XDECREF(arg_arrays[j]);
         if (*p == 'i' && arg_list[j] != NULL) {
             std::free(arg_list[j]);
@@ -578,11 +586,16 @@ static PyObject *c_array_from_object(PyObject *obj, int typenum, int is_output)
         }
     }
     else {
+        #ifdef HAVE_WRITEBACKIFCOPY
+            int flags = NPY_C_CONTIGUOUS|NPY_WRITEABLE|NPY_ARRAY_WRITEBACKIFCOPY|NPY_NOTSWAPPED;
+        #else
+            int flags = NPY_C_CONTIGUOUS|NPY_WRITEABLE|NPY_UPDATEIFCOPY|NPY_NOTSWAPPED;
+        #endif
         if (typenum == -1) {
-            return PyArray_FROM_OF(obj, NPY_C_CONTIGUOUS|NPY_WRITEABLE|NPY_UPDATEIFCOPY|NPY_NOTSWAPPED);
+            return PyArray_FROM_OF(obj, flags);
         }
         else {
-            return PyArray_FROM_OTF(obj, typenum, NPY_C_CONTIGUOUS|NPY_WRITEABLE|NPY_UPDATEIFCOPY|NPY_NOTSWAPPED);
+            return PyArray_FROM_OTF(obj, typenum, flags);
         }
     }
 }

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -275,8 +275,6 @@ def _validate_mahalanobis_kwargs(X, m, n, **kwargs):
 
 
 def _validate_minkowski_kwargs(X, m, n, **kwargs):
-    if 'w' in kwargs:
-        kwargs['w'] = _convert_to_double(kwargs['w'])
     if 'p' not in kwargs:
         kwargs['p'] = 2.
     return kwargs
@@ -327,6 +325,13 @@ def _validate_vector(u, dtype=None):
     if u.ndim > 1:
         raise ValueError("Input vector should be 1-D.")
     return u
+
+
+def _validate_weights(w, dtype=np.double):
+    w = _validate_vector(w, dtype=dtype)
+    if np.any(w < 0):
+        raise ValueError("Input weights should be all non-negative")
+    return w
 
 
 def _validate_wminkowski_kwargs(X, m, n, **kwargs):
@@ -469,7 +474,7 @@ def minkowski(u, v, p=2, w=None):
         raise ValueError("p must be at least 1")
     u_v = u - v
     if w is not None:
-        w = _validate_vector(w)
+        w = _validate_weights(w)
         if p == 1:
             root_w = w
         if p == 2:

--- a/scipy/spatial/qhull.pyx
+++ b/scipy/spatial/qhull.pyx
@@ -2418,7 +2418,7 @@ class Voronoi(_QhullUser):
     Plot it:
 
     >>> import matplotlib.pyplot as plt
-    >>> voronoi_plot_2d(vor)
+    >>> fig = voronoi_plot_2d(vor)
     >>> plt.show()
 
     The Voronoi vertices:

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -1809,6 +1809,18 @@ def test_hamming_string_array():
     assert_allclose(whamming(a, b), desired)
 
 
+def test_minkowski_w():
+    # Regression test for gh-8142.
+    arr_in = np.array([[83.33333333, 100., 83.33333333, 100., 36.,
+                        60., 90., 150., 24., 48.],
+                       [83.33333333, 100., 83.33333333, 100., 36.,
+                        60., 90., 150., 24., 48.]])
+    pdist(arr_in, metric='minkowski', p=1, w=None)
+    cdist(arr_in, arr_in, metric='minkowski', p=1, w=None)
+    pdist(arr_in, metric='minkowski', p=1)
+    cdist(arr_in, arr_in, metric='minkowski', p=1)
+
+
 def test_sqeuclidean_dtypes():
     # Assert that sqeuclidean returns the right types of values.
     # Integer types should be converted to floating for stability.

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -3318,20 +3318,18 @@ class special_ortho_group_gen(multi_rv_generic):
         dim = self._process_parameters(dim)
 
         H = np.eye(dim)
-        D = np.ones((dim,))
-        for n in range(1, dim):
-            x = random_state.normal(size=(dim-n+1,))
-
-            D[n-1] = np.sign(x[0])
-            x[0] -= D[n-1]*np.sqrt((x*x).sum())
+        D = np.empty((dim,))
+        for n in range(dim-1):
+            x = random_state.normal(size=(dim-n,))
+            D[n] = np.sign(x[0]) if x[0] != 0 else 1
+            x[0] += D[n]*np.sqrt((x*x).sum())
             # Householder transformation
-            Hx = (np.eye(dim-n+1)
+            Hx = (np.eye(dim-n)
                   - 2.*np.outer(x, x)/(x*x).sum())
             mat = np.eye(dim)
-            mat[n-1:, n-1:] = Hx
+            mat[n:, n:] = Hx
             H = np.dot(H, mat)
-            # Fix the last sign such that the determinant is 1
-        D[-1] = (-1)**(1-(dim % 2))*D.prod()
+        D[-1] = (-1)**(dim-1)*D[:-1].prod()
         # Equivalent to np.dot(np.diag(D), H) but faster, apparently
         H = (D*H.T).T
         return H
@@ -3458,16 +3456,16 @@ class ortho_group_gen(multi_rv_generic):
         dim = self._process_parameters(dim)
 
         H = np.eye(dim)
-        for n in range(1, dim):
-            x = random_state.normal(size=(dim-n+1,))
+        for n in range(dim):
+            x = random_state.normal(size=(dim-n,))
             # random sign, 50/50, but chosen carefully to avoid roundoff error
-            D = np.sign(x[0])
+            D = np.sign(x[0]) if x[0] != 0 else 1
             x[0] += D*np.sqrt((x*x).sum())
             # Householder transformation
-            Hx = -D*(np.eye(dim-n+1)
+            Hx = -D*(np.eye(dim-n)
                      - 2.*np.outer(x, x)/(x*x).sum())
             mat = np.eye(dim)
-            mat[n-1:, n-1:] = Hx
+            mat[n:, n:] = Hx
             H = np.dot(H, mat)
         return H
 
@@ -3518,7 +3516,6 @@ class random_correlation_gen(multi_rv_generic):
            [-0.20387311,  1.        , -0.24351129,  0.06703474],
            [ 0.18366501, -0.24351129,  1.        ,  0.38530195],
            [-0.04953711,  0.06703474,  0.38530195,  1.        ]])
-
     >>> import scipy.linalg
     >>> e, v = scipy.linalg.eigh(x)
     >>> e

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -3308,14 +3308,14 @@ class special_ortho_group_gen(multi_rv_generic):
             Random size N-dimensional matrices, dimension (size, dim, dim)
 
         """
+        random_state = self._get_random_state(random_state)
+
         size = int(size)
         if size > 1:
             return np.array([self.rvs(dim, size=1, random_state=random_state)
                              for i in range(size)])
 
         dim = self._process_parameters(dim)
-
-        random_state = self._get_random_state(random_state)
 
         H = np.eye(dim)
         D = np.ones((dim,))
@@ -3448,14 +3448,14 @@ class ortho_group_gen(multi_rv_generic):
             Random size N-dimensional matrices, dimension (size, dim, dim)
 
         """
+        random_state = self._get_random_state(random_state)
+
         size = int(size)
         if size > 1:
             return np.array([self.rvs(dim, size=1, random_state=random_state)
                              for i in range(size)])
 
         dim = self._process_parameters(dim)
-
-        random_state = self._get_random_state(random_state)
 
         H = np.eye(dim)
         for n in range(1, dim):
@@ -3735,14 +3735,14 @@ class unitary_group_gen(multi_rv_generic):
             Random size N-dimensional matrices, dimension (size, dim, dim)
 
         """
+        random_state = self._get_random_state(random_state)
+
         size = int(size)
         if size > 1:
             return np.array([self.rvs(dim, size=1, random_state=random_state)
                              for i in range(size)])
 
         dim = self._process_parameters(dim)
-
-        random_state = self._get_random_state(random_state)
 
         z = 1/math.sqrt(2)*(random_state.normal(size=(dim,dim)) +
                             1j*random_state.normal(size=(dim,dim)))

--- a/scipy/stats/tests/test_mstats_extras.py
+++ b/scipy/stats/tests/test_mstats_extras.py
@@ -20,10 +20,10 @@ def test_compare_medians_ms():
 def test_hdmedian():
     # 1-D array
     x = ma.arange(11)
-    assert_equal(ms.hdmedian(x), 5)
+    assert_allclose(ms.hdmedian(x), 5, rtol=1e-14)
     x.mask = ma.make_mask(x)
     x.mask[:7] = False
-    assert_equal(ms.hdmedian(x), 3)
+    assert_allclose(ms.hdmedian(x), 3, rtol=1e-14)
 
     # Check that `var` keyword returns a value.  TODO: check whether returned
     # value is actually correct.

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -1288,9 +1288,9 @@ class TestSpecialOrthoGroup(object):
     def test_reproducibility(self):
         np.random.seed(514)
         x = special_ortho_group.rvs(3)
-        expected = np.array([[0.99394515, -0.04527879, 0.10011432],
-                             [-0.04821555, 0.63900322, 0.76769144],
-                             [-0.09873351, -0.76787024, 0.63295101]])
+        expected = np.array([[-0.99394515, -0.04527879, 0.10011432],
+                             [0.04821555, -0.99846897, 0.02711042],
+                             [0.09873351, 0.03177334, 0.99460653]])
         assert_array_almost_equal(x, expected)
 
         random_state = np.random.RandomState(seed=514)
@@ -1334,7 +1334,7 @@ class TestSpecialOrthoGroup(object):
         # Generate samples
         dim = 5
         samples = 1000  # Not too many, or the test takes too long
-        ks_prob = 0.39  # ...so don't expect much precision
+        ks_prob = .05
         np.random.seed(514)
         xs = special_ortho_group.rvs(dim, size=samples)
 
@@ -1355,16 +1355,16 @@ class TestSpecialOrthoGroup(object):
 
 class TestOrthoGroup(object):
     def test_reproducibility(self):
-        np.random.seed(514)
+        np.random.seed(515)
         x = ortho_group.rvs(3)
-        x2 = ortho_group.rvs(3, random_state=514)
+        x2 = ortho_group.rvs(3, random_state=515)
         # Note this matrix has det -1, distinguishing O(N) from SO(N)
-        expected = np.array([[0.993945, -0.045279, 0.100114],
-                             [-0.048216, -0.998469, 0.02711],
-                             [-0.098734, 0.031773, 0.994607]])
+        assert_almost_equal(np.linalg.det(x), -1)
+        expected = np.array([[0.94449759, -0.21678569, -0.24683651],
+                             [-0.13147569, -0.93800245, 0.3207266],
+                             [0.30106219, 0.27047251, 0.9144431]])
         assert_array_almost_equal(x, expected)
         assert_array_almost_equal(x2, expected)
-        assert_almost_equal(np.linalg.det(x), -1)
 
     def test_invalid_dim(self):
         assert_raises(ValueError, ortho_group.rvs, None)
@@ -1373,18 +1373,25 @@ class TestOrthoGroup(object):
         assert_raises(ValueError, ortho_group.rvs, 2.5)
 
     def test_det_and_ortho(self):
-        xs = [ortho_group.rvs(dim)
-              for dim in range(2,12)
-              for i in range(3)]
+        xs = [[ortho_group.rvs(dim)
+               for i in range(10)]
+              for dim in range(2,12)]
 
-        # Test that determinants are always +1
-        dets = [np.fabs(np.linalg.det(x)) for x in xs]
-        assert_allclose(dets, [1.]*30, rtol=1e-13)
+        # Test that abs determinants are always +1
+        dets = np.array([[np.linalg.det(x) for x in xx] for xx in xs])
+        assert_allclose(np.fabs(dets), np.ones(dets.shape), rtol=1e-13)
+
+        # Test that we get both positive and negative determinants
+        # Check that we have at least one and less than 10 negative dets in a sample of 10. The rest are positive by the previous test.
+        # Test each dimension separately
+        assert_array_less([0]*10, [np.where(d < 0)[0].shape[0] for d in dets])
+        assert_array_less([np.where(d < 0)[0].shape[0] for d in dets], [10]*10)
 
         # Test that these are orthogonal matrices
-        for x in xs:
-            assert_array_almost_equal(np.dot(x, x.T),
-                                      np.eye(x.shape[0]))
+        for xx in xs:
+            for x in xx:
+                assert_array_almost_equal(np.dot(x, x.T),
+                                          np.eye(x.shape[0]))
 
     def test_haar(self):
         # Test that the distribution is constant under rotation
@@ -1394,7 +1401,7 @@ class TestOrthoGroup(object):
         # Generate samples
         dim = 5
         samples = 1000  # Not too many, or the test takes too long
-        ks_prob = 0.39  # ...so don't expect much precision
+        ks_prob = .05
         np.random.seed(518)  # Note that the test is sensitive to seed too
         xs = ortho_group.rvs(dim, size=samples)
 
@@ -1416,6 +1423,7 @@ class TestOrthoGroup(object):
     def test_pairwise_distances(self):
         # Test that the distribution of pairwise distances is close to correct.
         np.random.seed(514)
+
         def random_ortho(dim):
             u, _s, v = np.linalg.svd(np.random.normal(size=(dim, dim)))
             return np.dot(u, v)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -789,11 +789,12 @@ def test_weightedtau():
     # NaNs
     x = [12, 2, 1, 12, 2]
     y = [1, 4, 7, 1, np.nan]
-    tau, p_value = stats.weightedtau(x, y)
-    assert_approx_equal(tau, -0.56694968153682723)
-    x = [12, 2, np.nan, 12, 2]
-    tau, p_value = stats.weightedtau(x, y)
-    assert_approx_equal(tau, -0.56694968153682723)
+    with np.errstate(invalid="ignore"):
+        tau, p_value = stats.weightedtau(x, y)
+        assert_approx_equal(tau, -0.56694968153682723)
+        x = [12, 2, np.nan, 12, 2]
+        tau, p_value = stats.weightedtau(x, y)
+        assert_approx_equal(tau, -0.56694968153682723)
 
 
 def test_weightedtau_vs_quadratic():

--- a/tools/ci/appveyor/requirements.txt
+++ b/tools/ci/appveyor/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-cython
+cython==0.27.3
 pytest-timeout
 pytest-xdist
 pytest-env


### PR DESCRIPTION
Backports for:
- gh-8082 `linalgsolve_lyapunov` not importable
- gh-8144 `optimize.cobyla` fix
- gh-8248 `optimize.ncg` issue
- gh-8530 `linalg.flapack` issue (fix build issue with numpy master)
- gh-8237 `optimize.linprog` issue
- gh-8187 `stats.ortho_group_gen` issue
- gh-8215 `ndimage.gaussian_filter` float16 segfault
- gh-8322 `optimize.root` segfault
- gh-8280 `sparse.csgraph`
- gh-8150 resolve UPDATEIFCOPY deprecation errors 
- gh-8566 pin Cython version in CI to 0.27.3
- gh-8068 fix NumPy 1.14.0 deprecation failures
- gh-8477 fix segfault in `signaltools`
- gh-8197 fix CI issue on macOS
- gh-8334 fix issue with `stats.mstats.hdmedian` test
- gh-8156 fix regression in `spatial.minkowski`