### PR TITLE
Added example to use scipy.linalg.eig() function

### DIFF
--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -184,7 +184,7 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False,
     Examples
     --------
     >>> from scipy import linalg
-    >>> a = np.array([[0., -1.], [1., 0.]])
+    >>>a = np.array([[0., -1.], [1., 0.]])a = np.array([[0., -1.], [1., 0.]])
     >>> linalg.eigvals(a)
     array([0.+1.j, 0.-1.j])
 
@@ -196,6 +196,17 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False,
     >>> linalg.eigvals(a, homogeneous_eigvals=True)
     array([[3.+0.j, 8.+0.j, 7.+0.j],
            [1.+0.j, 1.+0.j, 1.+0.j]])
+
+    >>> a = np.array([[0., -1.], [1., 0.]])
+    >>> linalg.eigvals(a) == linalg.eig(a)[0]
+    array([ True,  True])
+    >>> linalg.eig(a,left=True,right=False)[1] # normalized left eigenvector
+    array([[-0.70710678+0.        j, -0.70710678-0.        j],
+           [ 0.        +0.70710678j,  0.        -0.70710678j]])
+    >>> linalg.eig(a,left=True,right=False)[1] # normalized right eigenvector
+    array([[-0.70710678+0.        j, -0.70710678-0.        j],
+           [ 0.        +0.70710678j,  0.        -0.70710678j]])
+
 
     """
     a1 = _asarray_validated(a, check_finite=check_finite)


### PR DESCRIPTION
```python
    >>> a = np.array([[0., -1.], [1., 0.]])
    >>> linalg.eigvals(a) == linalg.eig(a)[0]
    array([ True,  True])
    >>> linalg.eig(a,left=True,right=False)[1] # normalized left eigenvector
    array([[-0.70710678+0.        j, -0.70710678-0.        j],
           [ 0.        +0.70710678j,  0.        -0.70710678j]])
    >>> linalg.eig(a,left=True,right=False)[1] # normalized right eigenvector
    array([[-0.70710678+0.        j, -0.70710678-0.        j],
           [ 0.        +0.70710678j,  0.        -0.70710678j]])
```