### PR TITLE
filter_design: switch to explicit arguments, keeping None as wrapper for default

### DIFF
--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -100,7 +100,7 @@ def findfreqs(num, den, N, kind='ba'):
     return w
 
 
-def freqs(b, a, worN=None, plot=None):
+def freqs(b, a, worN=200, plot=None):
     """
     Compute frequency response of analog filter.
 
@@ -176,7 +176,7 @@ def freqs(b, a, worN=None, plot=None):
     return w, h
 
 
-def freqs_zpk(z, p, k, worN=None):
+def freqs_zpk(z, p, k, worN=200):
     """
     Compute frequency response of analog filter.
 
@@ -255,7 +255,7 @@ def freqs_zpk(z, p, k, worN=None):
     return w, h
 
 
-def freqz(b, a=1, worN=None, whole=False, plot=None):
+def freqz(b, a=1, worN=512, whole=False, plot=None):
     """
     Compute the frequency response of a digital filter.
 
@@ -281,7 +281,7 @@ def freqz(b, a=1, worN=None, whole=False, plot=None):
         and ``b.shape[1:]``, ``a.shape[1:]``, and the shape of the frequencies
         array must be compatible for broadcasting.
     worN : {None, int, array_like}, optional
-        If None (default), then compute at 512 equally spaced frequencies.
+        If None, then compute at 512 equally spaced frequencies.
         If a single integer, then compute at that many frequencies.  This is
         a convenient alternative to::
 
@@ -450,7 +450,7 @@ def freqz(b, a=1, worN=None, whole=False, plot=None):
     return w, h
 
 
-def freqz_zpk(z, p, k, worN=None, whole=False):
+def freqz_zpk(z, p, k, worN=512, whole=False):
     r"""
     Compute the frequency response of a digital filter in ZPK form.
 
@@ -540,7 +540,7 @@ def freqz_zpk(z, p, k, worN=None, whole=False):
     return w, h
 
 
-def group_delay(system, w=None, whole=False):
+def group_delay(system, w=512, whole=False):
     r"""Compute the group delay of a digital filter.
 
     The group delay measures by how many samples amplitude envelopes of
@@ -556,7 +556,7 @@ def group_delay(system, w=None, whole=False):
     system : tuple of array_like (b, a)
         Numerator and denominator coefficients of a filter transfer function.
     w : {None, int, array-like}, optional
-        If None (default), then compute at 512 frequencies equally spaced
+        If None, then compute at 512 frequencies equally spaced
         around the unit circle.
         If a single integer, then compute at that many frequencies.
         If array, compute the delay at the frequencies given

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -444,6 +444,13 @@ class TestFreqs(object):
                       plot=lambda w, h: 1 / 0)
         freqs([1.0], [1.0], worN=8, plot=plot)
 
+    def test_backward_compat(self):
+        # For backward compatibility, test if None act as a wrapper for default
+        w1, h1 = freqs([1.0],[1.0])
+        w2, h2 = freqs([1.0],[1.0],None)
+        assert_array_almost_equal(w1,w2)
+        assert_array_almost_equal(h1,h2)
+
 
 class TestFreqs_zpk(object):
 
@@ -484,6 +491,12 @@ class TestFreqs_zpk(object):
         assert_allclose(w1, w2)
         assert_allclose(h1, h2, rtol=1e-6)
 
+    def test_backward_compat(self):
+        # For backward compatibility, test if None act as a wrapper for default
+        w1, h1 = freqs_zpk([1.0],[1.0],[1.0])
+        w2, h2 = freqs_zpk([1.0],[1.0],[1.0],None)
+        assert_array_almost_equal(w1,w2)
+        assert_array_almost_equal(h1,h2)
 
 class TestFreqz(object):
 
@@ -670,6 +683,13 @@ class TestFreqz(object):
                     assert_equal(ww, worN.ravel())
                     assert_allclose(hh, h[k, :, :].ravel())
 
+    def test_backward_compat(self):
+        # For backward compatibility, test if None act as a wrapper for default
+        w1, h1 = freqz([1.0], 1)
+        w2, h2 = freqz([1.0], 1, None)
+        assert_array_almost_equal(w1,w2)
+        assert_array_almost_equal(h1,h2)
+
 
 class TestSOSFreqz(object):
 
@@ -834,6 +854,12 @@ class TestFreqz_zpk(object):
         assert_allclose(w1, w2)
         assert_allclose(h1, h2, rtol=1e-6)
 
+    def test_backward_compat(self):
+        # For backward compatibility, test if None act as a wrapper for default
+        w1, h1 = freqz_zpk([0.5], [0.5], 1.0)
+        w2, h2 = freqz_zpk([0.5], [0.5], 1.0, None)
+        assert_array_almost_equal(w1,w2)
+        assert_array_almost_equal(h1,h2)
 
 class TestNormalize(object):
 
@@ -3156,3 +3182,10 @@ class TestGroupDelay(object):
 
         w, gd = assert_warns(UserWarning, group_delay, (b, a), w=w)
         assert_allclose(gd, 0)
+
+    def test_backward_compat(self):
+        # For backward compatibility, test if None act as a wrapper for default
+        w1, gd1 = group_delay((1, 1))
+        w2, gd2 = group_delay((1, 1), None)
+        assert_array_almost_equal(w1,w2)
+        assert_array_almost_equal(h1,h2)

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -446,10 +446,10 @@ class TestFreqs(object):
 
     def test_backward_compat(self):
         # For backward compatibility, test if None act as a wrapper for default
-        w1, h1 = freqs([1.0],[1.0])
-        w2, h2 = freqs([1.0],[1.0],None)
-        assert_array_almost_equal(w1,w2)
-        assert_array_almost_equal(h1,h2)
+        w1, h1 = freqs([1.0], [1.0])
+        w2, h2 = freqs([1.0], [1.0], None)
+        assert_array_almost_equal(w1, w2)
+        assert_array_almost_equal(h1, h2)
 
 
 class TestFreqs_zpk(object):
@@ -493,10 +493,10 @@ class TestFreqs_zpk(object):
 
     def test_backward_compat(self):
         # For backward compatibility, test if None act as a wrapper for default
-        w1, h1 = freqs_zpk([1.0],[1.0],[1.0])
-        w2, h2 = freqs_zpk([1.0],[1.0],[1.0],None)
-        assert_array_almost_equal(w1,w2)
-        assert_array_almost_equal(h1,h2)
+        w1, h1 = freqs_zpk([1.0], [1.0], [1.0])
+        w2, h2 = freqs_zpk([1.0], [1.0], [1.0], None)
+        assert_array_almost_equal(w1, w2)
+        assert_array_almost_equal(h1, h2)
 
 class TestFreqz(object):
 
@@ -687,8 +687,8 @@ class TestFreqz(object):
         # For backward compatibility, test if None act as a wrapper for default
         w1, h1 = freqz([1.0], 1)
         w2, h2 = freqz([1.0], 1, None)
-        assert_array_almost_equal(w1,w2)
-        assert_array_almost_equal(h1,h2)
+        assert_array_almost_equal(w1, w2)
+        assert_array_almost_equal(h1, h2)
 
 
 class TestSOSFreqz(object):
@@ -858,8 +858,8 @@ class TestFreqz_zpk(object):
         # For backward compatibility, test if None act as a wrapper for default
         w1, h1 = freqz_zpk([0.5], [0.5], 1.0)
         w2, h2 = freqz_zpk([0.5], [0.5], 1.0, None)
-        assert_array_almost_equal(w1,w2)
-        assert_array_almost_equal(h1,h2)
+        assert_array_almost_equal(w1, w2)
+        assert_array_almost_equal(h1, h2)
 
 class TestNormalize(object):
 
@@ -3187,5 +3187,5 @@ class TestGroupDelay(object):
         # For backward compatibility, test if None act as a wrapper for default
         w1, gd1 = group_delay((1, 1))
         w2, gd2 = group_delay((1, 1), None)
-        assert_array_almost_equal(w1,w2)
-        assert_array_almost_equal(gd1,gd2)
+        assert_array_almost_equal(w1, w2)
+        assert_array_almost_equal(gd1, gd2)

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -3188,4 +3188,4 @@ class TestGroupDelay(object):
         w1, gd1 = group_delay((1, 1))
         w2, gd2 = group_delay((1, 1), None)
         assert_array_almost_equal(w1,w2)
-        assert_array_almost_equal(h1,h2)
+        assert_array_almost_equal(gd1,gd2)


### PR DESCRIPTION
According to #7788, the function signatures now have explicit arguments, with None effectively meaning the same as default value.