### PR TITLE
MAINT/ENH/BUG/TST: cdf2rdf: Address review comments made after merge

### DIFF
--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -1344,22 +1344,22 @@ def cdf2rdf(w, v):
            [ 0.     ,  2.59153,  3.23942],
            [ 0.     , -3.23942,  2.59153]])
     """
-    w1, v1 = _asarray_validated(w), _asarray_validated(v)
-    if w1.ndim < 1 or w1.ndim > 2:
+    w, v = _asarray_validated(w), _asarray_validated(v)
+    if w.ndim < 1 or w.ndim > 2:
         raise ValueError('expected w to be a one-dimensional array or '
                          'two-dimensional stacked array')
-    if w1.shape[-1] < 2:
+    if w.shape[-1] < 2:
         raise ValueError('expected w array to have 2 or more elements')
-    if v1.ndim < 2 or v1.ndim > 3:
+    if v.ndim < 2 or v.ndim > 3:
         raise ValueError('expected v to be a two-dimensional array or '
                          'three-dimensional stacked array')
-    if v1.shape[-2] != v1.shape[-1] or w1.shape[-1] < 2:
+    if v.shape[-2] != v.shape[-1] or w.shape[-1] < 2:
         raise ValueError('expected v to be a square matrix or stacked square '
-                         'matrices: v1.shape[-2] = v1.shape[-1]')
-    if len(v1.shape) != len(w1.shape) + 1:
+                         'matrices: v.shape[-2] = v.shape[-1]')
+    if len(v.shape) != len(w.shape) + 1:
         raise ValueError('expected eigenvectors array to have exactly one '
                          'dimension more than eigenvalues array')
-    if v1.shape[-1] != w1.shape[-1]:
+    if v.shape[-1] != w.shape[-1]:
         raise ValueError('expected the same number of eigenvalues as '
                          'eigenvectors')
 

--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -1396,7 +1396,8 @@ def cdf2rdf(w, v):
     wr[mat, k, j] = w[mat, k].imag
 
     # compute real eigenvectors associated with real block diagonal eigenvalues
-    u = array([eye(n, n, dtype=numpy.complex128)] * M).reshape(M, n, n)
+    u = zeros((M, n, n), dtype=numpy.cdouble)
+    u[:, di, di] = 1.0
     u[mat, j, j] = 0.5j
     u[mat, j, k] = 0.5
     u[mat, k, j] = -0.5j

--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -1374,10 +1374,12 @@ def cdf2rdf(w, v):
         M, n = w.shape
 
     # get indices for each first pair of complex eigenvalues
-    idx_im = argwhere(iscomplex(w))
+    complex_mask = iscomplex(w)
+    n_complex = complex_mask.sum(axis=-1)
+    idx_im = argwhere(complex_mask)
 
     # check if all complex eigenvalues have conjugate pairs
-    if len(idx_im[::2, 0]) != len(idx_im[1::2, 0]):
+    if not (n_complex % 2 == 0).all():
         raise ValueError('expected complex-conjugate pairs of eigenvalues')
 
     # all eigenvalues to diagonal form

--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -1345,18 +1345,22 @@ def cdf2rdf(w, v):
            [ 0.     , -3.23942,  2.59153]])
     """
     w, v = _asarray_validated(w), _asarray_validated(v)
+
+    # check dimensions
     if w.ndim < 1 or w.ndim > 2:
         raise ValueError('expected w to be a one-dimensional array or '
                          'two-dimensional stacked array')
     if v.ndim < 2 or v.ndim > 3:
         raise ValueError('expected v to be a two-dimensional array or '
                          'three-dimensional stacked array')
+    if v.ndim != w.ndim + 1:
+        raise ValueError('expected eigenvectors array to have exactly one '
+                         'dimension more than eigenvalues array')
+
+    # check shapes
     if v.shape[-2] != v.shape[-1]:
         raise ValueError('expected v to be a square matrix or stacked square '
                          'matrices: v.shape[-2] = v.shape[-1]')
-    if len(v.shape) != len(w.shape) + 1:
-        raise ValueError('expected eigenvectors array to have exactly one '
-                         'dimension more than eigenvalues array')
     if v.shape[-1] != w.shape[-1]:
         raise ValueError('expected the same number of eigenvalues as '
                          'eigenvectors')

--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -1348,12 +1348,10 @@ def cdf2rdf(w, v):
     if w.ndim < 1 or w.ndim > 2:
         raise ValueError('expected w to be a one-dimensional array or '
                          'two-dimensional stacked array')
-    if w.shape[-1] < 2:
-        raise ValueError('expected w array to have 2 or more elements')
     if v.ndim < 2 or v.ndim > 3:
         raise ValueError('expected v to be a two-dimensional array or '
                          'three-dimensional stacked array')
-    if v.shape[-2] != v.shape[-1] or w.shape[-1] < 2:
+    if v.shape[-2] != v.shape[-1]:
         raise ValueError('expected v to be a square matrix or stacked square '
                          'matrices: v.shape[-2] = v.shape[-1]')
     if len(v.shape) != len(w.shape) + 1:

--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -1381,16 +1381,15 @@ def cdf2rdf(w, v):
         raise ValueError('expected complex-conjugate pairs of eigenvalues')
 
     # all eigenvalues to diagonal form
-    w_mat = zeros((M, n, n))
+    wr = zeros((M, n, n), dtype=w.real.dtype)
     di = range(n)
-    w_mat[:, di, di] = w[:, di].real
+    wr[:, di, di] = w[:, di].real
 
     # complex eigenvalues to real block diagonal form
     mat, j = idx_im[::2, 0], idx_im[::2, 1]
     k = j + 1
-    w_mat[mat, j, k] = w[mat, j].imag
-    w_mat[mat, k, j] = w[mat, k].imag
-    wr = w_mat.real
+    wr[mat, j, k] = w[mat, j].imag
+    wr[mat, k, j] = w[mat, k].imag
 
     # compute real eigenvectors associated with real block diagonal eigenvalues
     u = array([eye(n, n, dtype=numpy.complex128)] * M).reshape(M, n, n)

--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -1386,17 +1386,18 @@ def cdf2rdf(w, v):
     w_mat[:, di, di] = w[:, di].real
 
     # complex eigenvalues to real block diagonal form
-    mat, k = idx_im[::2, 0], idx_im[::2, 1]
-    w_mat[mat, k, k+1] = w[mat, k].imag
-    w_mat[mat, k+1, k] = w[mat, k+1].imag
+    mat, j = idx_im[::2, 0], idx_im[::2, 1]
+    k = j + 1
+    w_mat[mat, j, k] = w[mat, j].imag
+    w_mat[mat, k, j] = w[mat, k].imag
     wr = w_mat.real
 
     # compute real eigenvectors associated with real block diagonal eigenvalues
     u = array([eye(n, n, dtype=numpy.complex128)] * M).reshape(M, n, n)
-    u[mat, k, k] = 0.5j
-    u[mat, k, k+1] = 0.5
-    u[mat, k+1, k] = -0.5j
-    u[mat, k+1, k+1] = 0.5
+    u[mat, j, j] = 0.5j
+    u[mat, j, k] = 0.5
+    u[mat, k, j] = -0.5j
+    u[mat, k, k] = 0.5
     # multipy matrices v and u (equivalent to v @ u)
     vr = einsum('bij, bjk -> bik', v, u).real
 

--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -1281,6 +1281,8 @@ def cdf2rdf(w, v):
     continues to hold, where ``X`` is the original array for which ``w`` and
     ``v`` are the eigenvalues and eigenvectors.
 
+    .. versionadded:: 1.1.0
+
     Parameters
     ----------
     w : array_like

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -2725,29 +2725,38 @@ def test_subspace_angles():
 
 class TestCDF2RDF(object):
 
+    def matmul(self, a, b):
+        return np.einsum('...ij,...jk->...ik', a, b)
+
+    def assert_eig_valid(self, w, v, x):
+        assert_array_almost_equal(
+            self.matmul(v, w),
+            self.matmul(x, v)
+        )
+
     def test_single_array2x2_real(self):
         X = np.array([[1, 2], [3, -1]])
         w, v = np.linalg.eig(X)
         wr, vr = cdf2rdf(w, v)
-        assert_array_almost_equal(vr.dot(wr), X.dot(vr))
+        self.assert_eig_valid(wr, vr, X)
 
     def test_single_array2x2_complex(self):
         X = np.array([[1, 2], [-2, 1]])
         w, v = np.linalg.eig(X)
         wr, vr = cdf2rdf(w, v)
-        assert_array_almost_equal(vr.dot(wr), X.dot(vr))
+        self.assert_eig_valid(wr, vr, X)
 
     def test_single_array3x3_real(self):
         X = np.array([[1, 2, 3], [1, 2, 3], [2, 5, 6]])
         w, v = np.linalg.eig(X)
         wr, vr = cdf2rdf(w, v)
-        assert_array_almost_equal(vr.dot(wr), X.dot(vr))
+        self.assert_eig_valid(wr, vr, X)
 
     def test_single_array3x3_complex(self):
         X = np.array([[1, 2, 3], [0, 4, 5], [0, -5, 4]])
         w, v = np.linalg.eig(X)
         wr, vr = cdf2rdf(w, v)
-        assert_array_almost_equal(vr.dot(wr), X.dot(vr))
+        self.assert_eig_valid(wr, vr, X)
 
     def test_random_stacked_arrays(self):
         N = int(1e4)
@@ -2755,8 +2764,7 @@ class TestCDF2RDF(object):
             X = np.random.rand(N, M, M)
             w, v = np.linalg.eig(X)
             wr, vr = cdf2rdf(w, v)
-            assert_array_almost_equal(np.einsum('bij, bjk -> bik', vr, wr),
-                                      np.einsum('bij, bjk -> bik', X, vr))
+            self.assert_eig_valid(wr, vr, X)
 
     def test_empty_array_error(self):
         # Check that passing an empty array raises a ValueError.

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -2784,3 +2784,11 @@ class TestCDF2RDF(object):
         X = np.array([[1, 2, 3], [1, 2, 3], [2, 5, 6+1j]])
         w, v = np.linalg.eig(X)
         assert_raises(ValueError, cdf2rdf, w, v)
+
+        # different arrays in the stack, so not conjugate
+        X = np.array([
+            [[1, 2, 3], [1, 2, 3], [2, 5, 6+1j]],
+            [[1, 2, 3], [1, 2, 3], [2, 5, 6-1j]],
+        ])
+        w, v = np.linalg.eig(X)
+        assert_raises(ValueError, cdf2rdf, w, v)

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -2734,6 +2734,13 @@ class TestCDF2RDF(object):
             self.matmul(x, v)
         )
 
+    def test_single_array0x0real(self):
+        # eig doesn't support 0x0 in old versions of numpy
+        X = np.empty((0, 0))
+        w, v = np.empty(0), np.empty((0, 0))
+        wr, vr = cdf2rdf(w, v)
+        self.assert_eig_valid(wr, vr, X)
+
     def test_single_array2x2_real(self):
         X = np.array([[1, 2], [3, -1]])
         w, v = np.linalg.eig(X)
@@ -2758,10 +2765,10 @@ class TestCDF2RDF(object):
         wr, vr = cdf2rdf(w, v)
         self.assert_eig_valid(wr, vr, X)
 
-    def test_random_stacked_arrays(self):
-        N = int(1e4)
-        for M in range(2, 7):
-            X = np.random.rand(N, M, M)
+    def test_random_1d_stacked_arrays(self):
+        # cannot test M == 0 due to bug in old numpy
+        for M in range(1, 7):
+            X = np.random.rand(10000, M, M)
             w, v = np.linalg.eig(X)
             wr, vr = cdf2rdf(w, v)
             self.assert_eig_valid(wr, vr, X)

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -2768,7 +2768,7 @@ class TestCDF2RDF(object):
     def test_random_1d_stacked_arrays(self):
         # cannot test M == 0 due to bug in old numpy
         for M in range(1, 7):
-            X = np.random.rand(10000, M, M)
+            X = np.random.rand(100, M, M)
             w, v = np.linalg.eig(X)
             wr, vr = cdf2rdf(w, v)
             self.assert_eig_valid(wr, vr, X)
@@ -2776,7 +2776,7 @@ class TestCDF2RDF(object):
     def test_random_2d_stacked_arrays(self):
         # cannot test M == 0 due to bug in old numpy
         for M in range(1, 7):
-            X = np.random.rand(100, 100, M, M)
+            X = np.random.rand(10, 10, M, M)
             w, v = np.linalg.eig(X)
             wr, vr = cdf2rdf(w, v)
             self.assert_eig_valid(wr, vr, X)

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -2773,9 +2773,8 @@ class TestCDF2RDF(object):
             wr, vr = cdf2rdf(w, v)
             self.assert_eig_valid(wr, vr, X)
 
-    def test_empty_array_error(self):
-        # Check that passing an empty array raises a ValueError.
-        w, v = np.array([]), np.array([])
+    def test_low_dimensionality_error(self):
+        w, v = np.empty(()), np.array((2,))
         assert_raises(ValueError, cdf2rdf, w, v)
 
     def test_not_square_error(self):
@@ -2783,14 +2782,14 @@ class TestCDF2RDF(object):
         w, v = np.arange(3), np.arange(6).reshape(3,2)
         assert_raises(ValueError, cdf2rdf, w, v)
 
-    def test_mismatch_error(self):
+    def test_swapped_v_w_error(self):
         # Check that exchanging places of w and v raises ValueError.
         X = np.array([[1, 2, 3], [0, 4, 5], [0, -5, 4]])
         w, v = np.linalg.eig(X)
         assert_raises(ValueError, cdf2rdf, v, w)
 
     def test_non_associated_error(self):
-        # Check that passing non-associated eigenvactors raises a ValueError.
+        # Check that passing non-associated eigenvectors raises a ValueError.
         w, v = np.arange(3), np.arange(16).reshape(4,4)
         assert_raises(ValueError, cdf2rdf, w, v)
 

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -2773,6 +2773,14 @@ class TestCDF2RDF(object):
             wr, vr = cdf2rdf(w, v)
             self.assert_eig_valid(wr, vr, X)
 
+    def test_random_2d_stacked_arrays(self):
+        # cannot test M == 0 due to bug in old numpy
+        for M in range(1, 7):
+            X = np.random.rand(100, 100, M, M)
+            w, v = np.linalg.eig(X)
+            wr, vr = cdf2rdf(w, v)
+            self.assert_eig_valid(wr, vr, X)
+
     def test_low_dimensionality_error(self):
         w, v = np.empty(()), np.array((2,))
         assert_raises(ValueError, cdf2rdf, w, v)


### PR DESCRIPTION
This:
* allows arbitrary dimensions of stacking
* catches issues in stacked matrices with non-even numbers of complex values in each row
* avoids recomputation of k+1
* avoids crashes when called on array_likes that are not arrays

This does not:

* fix `cdf2rdf([1+1j, 2-1j, 1-1j, 2+1j], np.eye(3))`

Follow up from #8550