### PR TITLE
fix_#8589_increase_readability_of_scalar_newton_method

### DIFF
--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -157,26 +157,24 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
         raise ValueError("tol too small (%g <= 0)" % tol)
     if maxiter < 1:
         raise ValueError("maxiter must be greater than 0")
+    p0 = 1.0 * x0
     if fprime is not None:
         # Newton-Rapheson method
         # Multiply by 1.0 to convert to floating point.  We don't use float(x0)
         # so it still works if x0 is complex.
-        p0 = 1.0 * x0
-        fder2 = 0
         for iter in range(maxiter):
-            myargs = (p0,) + args
-            fder = fprime(*myargs)
+            fder = fprime(p0, *args)
             if fder == 0:
                 msg = "derivative was zero."
                 warnings.warn(msg, RuntimeWarning)
                 return p0
-            fval = func(*myargs)
+            fval = func(p0, *args)
             newton_step = fval / fder
             if fprime2 is None:
                 # Newton step
                 p = p0 - newton_step
             else:
-                fder2 = fprime2(*myargs)
+                fder2 = fprime2(p0, *args)
                 # Halley's method
                 p = p0 - newton_step / (1.0 - 0.5 * newton_step * fder2 / fder)
             if abs(p - p0) < tol:
@@ -184,13 +182,12 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
             p0 = p
     else:
         # Secant method
-        p0 = x0
         if x0 >= 0:
             p1 = x0*(1 + 1e-4) + 1e-4
         else:
             p1 = x0*(1 + 1e-4) - 1e-4
-        q0 = func(*((p0,) + args))
-        q1 = func(*((p1,) + args))
+        q0 = func(p0, *args)
+        q1 = func(p1, *args)
         for iter in range(maxiter):
             if q1 == q0:
                 if p1 != p0:
@@ -204,7 +201,7 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
             p0 = p1
             q0 = q1
             p1 = p
-            q1 = func(*((p1,) + args))
+            q1 = func(p1, *args)
     msg = "Failed to converge after %d iterations, value is %s" % (maxiter, p)
     raise RuntimeError(msg)
 

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -157,11 +157,11 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
         raise ValueError("tol too small (%g <= 0)" % tol)
     if maxiter < 1:
         raise ValueError("maxiter must be greater than 0")
+    # Multiply by 1.0 to convert to floating point.  We don't use float(x0)
+    # so it still works if x0 is complex.
     p0 = 1.0 * x0
     if fprime is not None:
         # Newton-Rapheson method
-        # Multiply by 1.0 to convert to floating point.  We don't use float(x0)
-        # so it still works if x0 is complex.
         for iter in range(maxiter):
             fder = fprime(p0, *args)
             if fder == 0:


### PR DESCRIPTION
appropriate readability changes as mentioned in #8589   for the `newton method` in `scipy/scipy/optimize/zeros.py` are made.