### PR TITLE
MAINT: special: improve implementations of `sinpi` and `cospi`

### DIFF
--- a/scipy/special/_trig.pxd
+++ b/scipy/special/_trig.pxd
@@ -3,7 +3,7 @@
 # floating point), it's possible to compute them with greater accuracy
 # than sin(z), cos(z).
 #
-from libc.math cimport sin, cos, sinh, cosh, exp, fabs, ceil, M_PI
+from libc.math cimport sin, cos, sinh, cosh, exp, fabs, fmod, M_PI
 from ._complexstuff cimport number_t, double_complex, zpack
 
 cdef extern from "numpy/npy_math.h":
@@ -16,63 +16,37 @@ DEF TOL = 2.220446049250313e-16
 cdef inline double dsinpi(double x) nogil:
     """Compute sin(pi*x) for real arguments."""
     cdef:
-        double p = ceil(x)
-        double hp = p/2
+        double s = 1.0
+        double r
 
-    # Make p the even integer closest to x
-    if hp != ceil(hp):
-        p -= 1
-    # x is in (-1, 1]
-    x -= p
-    # Reflect x in (0.5, 1] to [0, 0.5).
-    if x > 0.5:
-        x = 1 - x
-    # Reflect x in (-1, -0.5) to (-0.5, 0)
-    if x < -0.5:
-        x = -1 - x
-    return sin(M_PI*x)
+    if x < 0.0:
+        x = -x
+        s = -1.0
 
-
-cdef inline double cospi_taylor(double x) nogil:
-    """
-    Taylor series for cos(pi*x) around x = 0.5. Since the root is
-    exactly representable in double precision we get gains over
-    just using cos(z) here.
-
-    """
-    cdef:
-        int n
-        double xx, term, res
-
-    x = M_PI*(x - 0.5)
-    xx = x*x
-    term = -x
-    res = term
-    for n in range(1, 20):
-        term *= -xx/((2*n + 1)*(2*n))
-        res += term
-        if fabs(term) <= TOL*fabs(res):
-            break
-    return res
+    r = fmod(x, 2.0)
+    if r < 0.5:
+        return s*sin(M_PI*r)
+    elif r > 1.5:
+        return s*sin(M_PI*(r - 2.0))
+    else:
+        return -s*sin(M_PI*(r - 1.0))
 
 
 cdef inline double dcospi(double x) nogil:
     """Compute cos(pi*x) for real arguments."""
-    cdef:
-        double p = ceil(x)
-        double hp = p/2
+    cdef double r
 
-    # Make p the even integer closest to x
-    if hp != ceil(hp):
-        p -= 1
-    # x is in (-1, 1].
-    x -= p
-    if fabs(x - 0.5) < 0.2:
-        return cospi_taylor(x)
-    elif fabs(x + 0.5) < 0.2:
-        return cospi_taylor(-x)
+    if x < 0.0:
+        x = -x
+
+    r = fmod(x, 2.0)
+    if r == 0.5:
+        # We don't want to return -0.0
+        return 0.0
+    if r < 1.0:
+        return -sin(M_PI*(r - 0.5))
     else:
-        return cos(M_PI*x)
+        return sin(M_PI*(r - 1.5))
 
 
 cdef inline double complex csinpi(double complex z) nogil:

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -998,14 +998,10 @@ class TestSystematic(object):
                             rtol=1e-8)
 
     def test_cospi(self):
-        # Without the extra factor of 2 in the relative tolerance as
-        # compared to sinpi there will be one failure at ~0.318 with
-        # an rdiff of ~6e-16. Neither the Taylor series nor the system
-        # cosine are accurate enough here.
         eps = np.finfo(float).eps
         assert_mpmath_equal(_cospi,
                             mpmath.cospi,
-                            [Arg()], nan_ok=False, rtol=4*eps)
+                            [Arg()], nan_ok=False, rtol=eps)
 
     def test_cospi_complex(self):
         assert_mpmath_equal(_cospi,
@@ -1812,7 +1808,7 @@ class TestSystematic(object):
     def test_sinpi(self):
         eps = np.finfo(float).eps
         assert_mpmath_equal(_sinpi, mpmath.sinpi,
-                            [Arg()], nan_ok=False, rtol=2*eps)
+                            [Arg()], nan_ok=False, rtol=eps)
 
     def test_sinpi_complex(self):
         assert_mpmath_equal(_sinpi, mpmath.sinpi,

--- a/scipy/special/tests/test_trig.py
+++ b/scipy/special/tests/test_trig.py
@@ -48,3 +48,17 @@ def test_intermediate_overlow():
     p = complex(0.5 + 1e-14, 227)
     std = complex(-8.113438309924894e+295, -np.inf)
     assert_allclose(cospi(p), std)
+
+
+def test_zero_sign():
+    y = sinpi(-0.0)
+    assert y == 0.0
+    assert np.signbit(y)
+
+    y = sinpi(0.0)
+    assert y == 0.0
+    assert not np.signbit(y)
+
+    y = cospi(0.5)
+    assert y == 0.0
+    assert not np.signbit(y)


### PR DESCRIPTION
The new implementations are simpler and decrease the error for `sinpi`
by a factor of 2 and the error for `cospi` by a factor of 4.