### PR TITLE
MAINT: add 2D benchmarks for convolve

### DIFF
--- a/benchmarks/benchmarks/signal.py
+++ b/benchmarks/benchmarks/signal.py
@@ -101,20 +101,20 @@ class Convolve(Benchmark):
     def setup(self, mode):
         np.random.seed(1234)
         # sample a bunch of pairs of 2d arrays
-        pairs = []
+        pairs = {'1d': [], '2d': []}
         for ma, nb in product((1, 2, 8, 13, 30, 36, 50, 75), repeat=2):
             a = np.random.randn(ma)
             b = np.random.randn(nb)
-            pairs.append((a, b))
+            pairs['1d'].append((a, b))
 
-        for ma, na, mb, nb in product((8, 13, 30), repeat=4):
+        for ma, na, mb, nb in product((8, 13, 35), repeat=4):
             a = np.random.randn(ma, na)
             b = np.random.randn(mb, nb)
-            pairs.append((a, b))
+            pairs['2d'].append((a, b))
         self.pairs = pairs
 
     def time_convolve(self, mode):
-        for a, b in self.pairs:
+        for a, b in self.pairs['1d']:
             if b.shape[0] > a.shape[0]:
                 continue
             if mode == 'valid' and a.ndim == b.ndim == 2:
@@ -122,11 +122,25 @@ class Convolve(Benchmark):
                     continue
             signal.convolve(a, b, mode=mode)
 
+    def time_convolve2d(self, mode):
+        for a, b in self.pairs['2d']:
+            if mode == 'valid' and (b.shape[0] > a.shape[0] or
+                                    b.shape[1] > a.shape[1]):
+                continue
+            signal.convolve(a, b, mode=mode)
+
     def time_correlate(self, mode):
-        for a, b in self.pairs:
+        for a, b in self.pairs['1d']:
             if b.shape[0] > a.shape[0]:
                 continue
             if mode == 'valid' and a.ndim == b.ndim == 2:
+                if b.shape[0] > a.shape[0] or b.shape[1] > a.shape[1]:
+                    continue
+            signal.correlate(a, b, mode=mode)
+
+    def time_correlate2d(self, mode):
+        for a, b in self.pairs['2d']:
+            if mode == 'valid':
                 if b.shape[0] > a.shape[0] or b.shape[1] > a.shape[1]:
                     continue
             signal.correlate(a, b, mode=mode)

--- a/benchmarks/benchmarks/signal.py
+++ b/benchmarks/benchmarks/signal.py
@@ -106,18 +106,29 @@ class Convolve(Benchmark):
             a = np.random.randn(ma)
             b = np.random.randn(nb)
             pairs.append((a, b))
+
+        for ma, na, mb, nb in product((8, 13, 30), repeat=4):
+            a = np.random.randn(ma, na)
+            b = np.random.randn(mb, nb)
+            pairs.append((a, b))
         self.pairs = pairs
 
     def time_convolve(self, mode):
         for a, b in self.pairs:
             if b.shape[0] > a.shape[0]:
                 continue
+            if mode == 'valid' and a.ndim == b.ndim == 2:
+                if b.shape[0] > a.shape[0] or b.shape[1] > a.shape[1]:
+                    continue
             signal.convolve(a, b, mode=mode)
 
     def time_correlate(self, mode):
         for a, b in self.pairs:
             if b.shape[0] > a.shape[0]:
                 continue
+            if mode == 'valid' and a.ndim == b.ndim == 2:
+                if b.shape[0] > a.shape[0] or b.shape[1] > a.shape[1]:
+                    continue
             signal.correlate(a, b, mode=mode)
 
 

--- a/benchmarks/benchmarks/signal.py
+++ b/benchmarks/benchmarks/signal.py
@@ -48,7 +48,7 @@ class Convolve2D(Benchmark):
         np.random.seed(1234)
         # sample a bunch of pairs of 2d arrays
         pairs = []
-        for ma, na, mb, nb in product((1, 2, 8, 13, 30), repeat=4):
+        for ma, na, mb, nb in product((8, 13, 30, 36), repeat=4):
             a = np.random.randn(ma, na)
             b = np.random.randn(mb, nb)
             pairs.append((a, b))
@@ -107,35 +107,30 @@ class Convolve(Benchmark):
             b = np.random.randn(nb)
             pairs['1d'].append((a, b))
 
-        for ma, na, mb, nb in product((8, 13, 35), repeat=4):
-            a = np.random.randn(ma, na)
-            b = np.random.randn(mb, nb)
-            pairs['2d'].append((a, b))
+        for n_image in [256, 512, 1024]:
+            for n_kernel in [3, 5, 7]:
+                x = np.random.randn(n_image, n_image)
+                h = np.random.randn(n_kernel, n_kernel)
+                pairs['2d'].append((x, h))
         self.pairs = pairs
 
     def time_convolve(self, mode):
         for a, b in self.pairs['1d']:
             if b.shape[0] > a.shape[0]:
                 continue
-            if mode == 'valid' and a.ndim == b.ndim == 2:
-                if b.shape[0] > a.shape[0] or b.shape[1] > a.shape[1]:
-                    continue
             signal.convolve(a, b, mode=mode)
 
     def time_convolve2d(self, mode):
         for a, b in self.pairs['2d']:
-            if mode == 'valid' and (b.shape[0] > a.shape[0] or
-                                    b.shape[1] > a.shape[1]):
-                continue
+            if mode == 'valid':
+                if b.shape[0] > a.shape[0] or b.shape[1] > a.shape[1]:
+                    continue
             signal.convolve(a, b, mode=mode)
 
     def time_correlate(self, mode):
         for a, b in self.pairs['1d']:
             if b.shape[0] > a.shape[0]:
                 continue
-            if mode == 'valid' and a.ndim == b.ndim == 2:
-                if b.shape[0] > a.shape[0] or b.shape[1] > a.shape[1]:
-                    continue
             signal.correlate(a, b, mode=mode)
 
     def time_correlate2d(self, mode):


### PR DESCRIPTION
This helps reflects the speed enhancements from #5608. We added a new optional arg, `method`  that chooses between the faster of two methods and it's best shown with 2D. Travis should be happy: this code has been tested with `python run.py -n --bench Convolve`.

I added 2D tests to the `Convolve` benchmark, not `Convolve2D` because `convolve2d` doesn't accept `method` yet.

I added shapes that are found in `Convolve2D` but removed some shapes. Specifically, the tests makes an ndarray with the shape `(m, n) for m, n in product((1, 2, 8, 13, 30))`. I changed it so `(m, n) for m, n in product((8, 13, 30))` which I felt fair for a 2D test (plus, it shows better speed results).
