### PR TITLE
FIX: Fix int check

### DIFF
--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -506,9 +506,10 @@ def _check_select(select, select_range, max_ev, max_len):
             if max_ev == 0:
                 max_ev = max_len
         else:  # 2 (index)
-            if sr.dtype.char.lower() not in 'lih':
+            if sr.dtype.char.lower() not in 'hilqp':
                 raise ValueError('when using select="i", select_range must '
-                                 'contain integers, got dtype %s' % sr.dtype)
+                                 'contain integers, got dtype %s (%s)'
+                                 % (sr.dtype, sr.dtype.char))
             # translate Python (0 ... N-1) into Fortran (1 ... N) with + 1
             il, iu = sr + 1
             if min(il, iu) < 1 or max(il, iu) > max_len:

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -520,7 +520,7 @@ class TestEigBanded(object):
 
         # extracting eigenvalues with respect to an index range
         ind1 = 2
-        ind2 = 6
+        ind2 = np.longlong(6)
         w_sym_ind = eigvals_banded(self.bandmat_sym,
                                     select='i', select_range=(ind1, ind2))
         assert_array_almost_equal(sort(w_sym_ind),


### PR DESCRIPTION
On Windows systems sometimes `c long long` ints are produced, so the int check in `decomp.py` was failing (see https://github.com/mne-tools/mne-python/issues/4843). This generalizes the check, with included failing test.

Ideally this would be backported to 1.0.1 but I think that the window on that is closed.