### PR TITLE
fix typo in doc of signal.peak_widths

### DIFF
--- a/scipy/signal/_peak_finding.py
+++ b/scipy/signal/_peak_finding.py
@@ -412,7 +412,7 @@ def peak_prominences(x, peaks, wlen=None):
 
 def peak_widths(x, peaks, rel_height=0.5, prominence_data=None, wlen=None):
     """
-    Calculate the width of each each peak in a signal.
+    Calculate the width of each peak in a signal.
 
     This function calculates the width of a peak in samples at a relative
     distance to the peak's height and prominence.


### PR DESCRIPTION
Fix a minor typo in the docstring of signal.peak_widths