### PR TITLE
ENH: correct p-values for stats.kendalltau and stats.mstats.kendalltau

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -191,6 +191,7 @@ Jordan Heemskerk for exposing additional windowing functions in scipy.signal.
 Michael Tartre (Two Sigma Investments) for contributions to weighted distance functions.
 Shinya Suzuki for scipy.stats.brunnermunzel
 Graham Clenaghan for bug fixes and optimizations in scipy.stats.
+Konrad Griessinger for the small sample Kendall test
 
 Institutions
 ------------

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -602,7 +602,7 @@ def kendalltau(x, y, use_ties=True, use_missing=False, method='auto'):
                 for k in range(j,c+1):
                     new[k] += new[k-1] - old[k-j]
             prob = 2.0*sum(new)/np.math.factorial(n)
-    else:
+    elif method == 'asymptotic':
         var_s = n*(n-1)*(2*n+5)
         if use_ties:
             var_s -= np.sum(v*k*(k-1)*(2*k+5)*1. for (k,v) in iteritems(xties))
@@ -625,6 +625,8 @@ def kendalltau(x, y, use_ties=True, use_missing=False, method='auto'):
         var_s += (v1 + v2)
         z = (C-D)/np.sqrt(var_s)
         prob = special.erfc(abs(z)/np.sqrt(2))
+    else:
+        raise ValueError("Unknown method "+str(method)+" specified, please use auto, exact or asymptotic.")
     
     return KendalltauResult(tau, prob)
 

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -499,7 +499,7 @@ def spearmanr(x, y, use_ties=True):
 KendalltauResult = namedtuple('KendalltauResult', ('correlation', 'pvalue'))
 
 
-def kendalltau(x, y, use_ties=True, use_missing=False, method='automatic'):
+def kendalltau(x, y, use_ties=True, use_missing=False, method='auto'):
     """
     Computes Kendall's rank correlation tau on two variables *x* and *y*.
 
@@ -514,11 +514,11 @@ def kendalltau(x, y, use_ties=True, use_missing=False, method='automatic'):
     use_missing : {False, True}, optional
         Whether missing data should be allocated a rank of 0 (False) or the
         average rank (True)
-    method: {'automatic', 'asymptotic', 'exact'}, optional
+    method: {'auto', 'asymptotic', 'exact'}, optional
         Defines which method is used to calculate the p-value [1]_. 
         'asymptotic' uses a normal approximation valid for large samples. 
         'exact' computes the exact p-value, but can only be used if no ties 
-        are present. 'automatic' is the default and selects the appropriate 
+        are present. 'auto' is the default and selects the appropriate 
         method based on a trade-off between speed and accuracy.
 
     Returns
@@ -571,7 +571,7 @@ def kendalltau(x, y, use_ties=True, use_missing=False, method='automatic'):
     if method == 'exact' and (xties or yties):
         raise ValueError("Ties found, exact method cannot be used.")
     
-    if method == 'automatic':
+    if method == 'auto':
         if (not xties and not yties) and (n <= 33 or min(C, n*(n-1)/2.0-C) <= 1):
             method = 'exact'
         else:

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -559,8 +559,6 @@ def kendalltau(x, y, use_ties=True, use_missing=False, method='auto'):
     xties = count_tied_groups(x)
     yties = count_tied_groups(y)
     if use_ties:
-        #xties = count_tied_groups(x)
-        #yties = count_tied_groups(y)
         corr_x = np.sum([v*k*(k-1) for (k,v) in iteritems(xties)], dtype=float)
         corr_y = np.sum([v*k*(k-1) for (k,v) in iteritems(yties)], dtype=float)
         denom = ma.sqrt((n*(n-1)-corr_x)/2. * (n*(n-1)-corr_y)/2.)

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3634,12 +3634,14 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate', method='auto'
                     new[k] += new[k-1] - old[k-j]
             pvalue = 2.0*sum(new)/np.math.factorial(size)
 
-    else:
+    elif method == 'asymptotic':
         # con_minus_dis is approx normally distributed with this variance [3]_
         var = (size * (size - 1) * (2.*size + 5) - x1 - y1) / 18. + (
             2. * xtie * ytie) / (size * (size - 1)) + x0 * y0 / (9. *
             size * (size - 1) * (size - 2))
         pvalue = special.erfc(np.abs(con_minus_dis) / np.sqrt(var) / np.sqrt(2))
+    else:
+        raise ValueError("Unknown method "+str(method)+" specified, please use auto, exact or asymptotic.")
 
     return KendalltauResult(tau, pvalue)
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3451,7 +3451,7 @@ def pointbiserialr(x, y):
 KendalltauResult = namedtuple('KendalltauResult', ('correlation', 'pvalue'))
 
 
-def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate', method='automatic'):
+def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate', method='auto'):
     """
     Calculate Kendall's tau, a correlation measure for ordinal data.
 
@@ -3474,11 +3474,11 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate', method='autom
         values. Default is 'propagate'. Note that if the input contains nan
         'omit' delegates to mstats_basic.kendalltau(), which has a different
         implementation.
-    method: {'automatic', 'asymptotic', 'exact'}, optional
+    method: {'auto', 'asymptotic', 'exact'}, optional
         Defines which method is used to calculate the p-value [5]_. 
         'asymptotic' uses a normal approximation valid for large samples. 
         'exact' computes the exact p-value, but can only be used if no ties 
-        are present. 'automatic' is the default and selects the appropriate 
+        are present. 'auto' is the default and selects the appropriate 
         method based on a trade-off between speed and accuracy.
 
     Returns
@@ -3554,7 +3554,7 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate', method='autom
     elif contains_nan and nan_policy == 'omit':
         x = ma.masked_invalid(x)
         y = ma.masked_invalid(y)
-        return mstats_basic.kendalltau(x, y)
+        return mstats_basic.kendalltau(x, y, method=method)
 
     if initial_lexsort is not None:  # deprecate to drop!
         warnings.warn('"initial_lexsort" is gone!')
@@ -3600,7 +3600,7 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate', method='autom
     if method == 'exact' and (xtie != 0 or ytie != 0):
         raise ValueError("Ties found, exact method cannot be used.")
         
-    if method == 'automatic':
+    if method == 'auto':
         if (xtie == 0 and ytie == 0) and (size <= 33 or min(dis, tot-dis) <= 1):
             method = 'exact'
         else:

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3597,11 +3597,11 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate', method='autom
     # Limit range to fix computational errors
     tau = min(1., max(-1., tau))
 
-    if method == 'exact' and ( xtie != 0 or ytie != 0):
+    if method == 'exact' and (xtie != 0 or ytie != 0):
         raise ValueError("Ties found, exact method cannot be used.")
         
     if method == 'automatic':
-        if ( xtie == 0 and ytie == 0 ) and ( size <= 33 or min(dis, tot-dis) <= 1) :
+        if (xtie == 0 and ytie == 0) and (size <= 33 or min(dis, tot-dis) <= 1):
             method = 'exact'
         else:
             method = 'asymptotic'

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -228,18 +228,18 @@ class TestCorr(object):
         assert_almost_equal(np.asarray(mstats.kendalltau(x,y)), expected)
 
         # swap a couple of values
-        b=y[1]
-        y[1]=y[2]
-        y[2]=b
+        b = y[1]
+        y[1] = y[2]
+        y[2] = b
         # Cross-check with exact result from R:
         # cor.test(x,y,method="kendall",exact=1)
         expected = [0.9555555555555556, 5.511463844797e-06]
         assert_almost_equal(np.asarray(mstats.kendalltau(x,y)), expected)
 
         # swap a couple more
-        b=y[5]
-        y[5]=y[6]
-        y[6]=b
+        b = y[5]
+        y[5] = y[6]
+        y[6] = b
         # Cross-check with exact result from R:
         # cor.test(x,y,method="kendall",exact=1)
         expected = [0.9111111111111111, 2.976190476190e-05]
@@ -254,18 +254,18 @@ class TestCorr(object):
         assert_almost_equal(np.asarray(mstats.kendalltau(x,y)), expected)
 
         # swap a couple of values
-        b=y[1]
-        y[1]=y[2]
-        y[2]=b
+        b = y[1]
+        y[1] = y[2]
+        y[2] = b
         # Cross-check with exact result from R:
         # cor.test(x,y,method="kendall",exact=1)
         expected = [-0.9555555555555556, 5.511463844797e-06]
         assert_almost_equal(np.asarray(mstats.kendalltau(x,y)), expected)
 
         # swap a couple more
-        b=y[5]
-        y[5]=y[6]
-        y[6]=b
+        b = y[5]
+        y[5] = y[6]
+        y[6] = b
         # Cross-check with exact result from R:
         # cor.test(x,y,method="kendall",exact=1)
         expected = [-0.9111111111111111, 2.976190476190e-05]

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -219,6 +219,7 @@ class TestCorr(object):
         check_named_results(res, attributes, ma=True)
 
     def test_kendalltau(self):
+        
         # simple case without ties
         x = ma.array(np.arange(10))
         y = ma.array(np.arange(10))
@@ -226,6 +227,9 @@ class TestCorr(object):
         # cor.test(x,y,method="kendall",exact=1)
         expected = [1.0, 5.511463844797e-07]
         assert_almost_equal(np.asarray(mstats.kendalltau(x,y)), expected)
+
+        # check exception in case of invalid method keyword
+        assert_raises(ValueError, mstats.kendalltau, x, y, method='banana')
 
         # swap a couple of values
         b = y[1]

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -219,12 +219,64 @@ class TestCorr(object):
         check_named_results(res, attributes, ma=True)
 
     def test_kendalltau(self):
+        # simple case without ties
+        x = ma.array(np.arange(10))
+        y = ma.array(np.arange(10))
+        # Cross-check with exact result from R:
+        # cor.test(x,y,method="kendall",exact=1)
+        expected = [1.0, 5.511463844797e-07]
+        assert_almost_equal(np.asarray(mstats.kendalltau(x,y)), expected)
+
+        # swap a couple of values
+        b=y[1]
+        y[1]=y[2]
+        y[2]=b
+        # Cross-check with exact result from R:
+        # cor.test(x,y,method="kendall",exact=1)
+        expected = [0.9555555555555556, 5.511463844797e-06]
+        assert_almost_equal(np.asarray(mstats.kendalltau(x,y)), expected)
+
+        # swap a couple more
+        b=y[5]
+        y[5]=y[6]
+        y[6]=b
+        # Cross-check with exact result from R:
+        # cor.test(x,y,method="kendall",exact=1)
+        expected = [0.9111111111111111, 2.976190476190e-05]
+        assert_almost_equal(np.asarray(mstats.kendalltau(x,y)), expected)
+
+        # same in opposite direction
+        x = ma.array(np.arange(10))
+        y = ma.array(np.arange(10)[::-1])
+        # Cross-check with exact result from R:
+        # cor.test(x,y,method="kendall",exact=1)
+        expected = [-1.0, 5.511463844797e-07]
+        assert_almost_equal(np.asarray(mstats.kendalltau(x,y)), expected)
+
+        # swap a couple of values
+        b=y[1]
+        y[1]=y[2]
+        y[2]=b
+        # Cross-check with exact result from R:
+        # cor.test(x,y,method="kendall",exact=1)
+        expected = [-0.9555555555555556, 5.511463844797e-06]
+        assert_almost_equal(np.asarray(mstats.kendalltau(x,y)), expected)
+
+        # swap a couple more
+        b=y[5]
+        y[5]=y[6]
+        y[6]=b
+        # Cross-check with exact result from R:
+        # cor.test(x,y,method="kendall",exact=1)
+        expected = [-0.9111111111111111, 2.976190476190e-05]
+        assert_almost_equal(np.asarray(mstats.kendalltau(x,y)), expected)
+
         # Tests some computations of Kendall's tau
         x = ma.fix_invalid([5.05, 6.75, 3.21, 2.66,np.nan])
         y = ma.fix_invalid([1.65, 26.5, -5.93, 7.96, np.nan])
         z = ma.fix_invalid([1.65, 2.64, 2.64, 6.95, np.nan])
         assert_almost_equal(np.asarray(mstats.kendalltau(x,y)),
-                            [+0.3333333,0.4969059])
+                            [+0.3333333,0.75])
         assert_almost_equal(np.asarray(mstats.kendalltau(x,z)),
                             [-0.5477226,0.2785987])
         #

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -277,6 +277,8 @@ class TestCorr(object):
         z = ma.fix_invalid([1.65, 2.64, 2.64, 6.95, np.nan])
         assert_almost_equal(np.asarray(mstats.kendalltau(x,y)),
                             [+0.3333333,0.75])
+        assert_almost_equal(np.asarray(mstats.kendalltau(x,y, method='asymptotic')),
+                            [+0.3333333,0.4969059])
         assert_almost_equal(np.asarray(mstats.kendalltau(x,z)),
                             [-0.5477226,0.2785987])
         #

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -765,6 +765,8 @@ def test_kendalltau():
     assert_array_equal(stats.kendalltau(x, x), (np.nan, np.nan))
     assert_allclose(stats.kendalltau(x, x, nan_policy='omit'),
                     (1.0, 5.5114638e-6), rtol=1e-06)
+    assert_allclose(stats.kendalltau(x, x, nan_policy='omit', method='asymptotic'),
+                    (1.0, 0.00017455009626808976), rtol=1e-06)
     assert_raises(ValueError, stats.kendalltau, x, x, nan_policy='raise')
     assert_raises(ValueError, stats.kendalltau, x, x, nan_policy='foobar')
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -721,6 +721,9 @@ def test_kendalltau():
     y[2] = y[1]
     assert_raises(ValueError, stats.kendalltau, x, y, method='exact')
 
+    # check exception in case of invalid method keyword
+    assert_raises(ValueError, stats.kendalltau, x, y, method='banana')
+
     # with some ties
     # Cross-check with R:
     # cor.test(c(12,2,1,12,2),c(1,4,7,1,0),method="kendall",exact=FALSE)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -653,6 +653,74 @@ class TestCorrSpearmanrTies(object):
 
 
 def test_kendalltau():
+    # simple case without ties
+    x = np.arange(10)
+    y = np.arange(10)
+    # Cross-check with exact result from R:
+    # cor.test(x,y,method="kendall",exact=1)
+    expected = (1.0, 5.511463844797e-07)
+    res = stats.kendalltau(x, y)
+    assert_approx_equal(res[0], expected[0])
+    assert_approx_equal(res[1], expected[1])
+
+    # swap a couple of values
+    b=y[1]
+    y[1]=y[2]
+    y[2]=b
+    # Cross-check with exact result from R:
+    # cor.test(x,y,method="kendall",exact=1)
+    expected = (0.9555555555555556, 5.511463844797e-06)
+    res = stats.kendalltau(x, y)
+    assert_approx_equal(res[0], expected[0])
+    assert_approx_equal(res[1], expected[1])
+
+    # swap a couple more
+    b=y[5]
+    y[5]=y[6]
+    y[6]=b
+    # Cross-check with exact result from R:
+    # cor.test(x,y,method="kendall",exact=1)
+    expected = (0.9111111111111111, 2.976190476190e-05)
+    res = stats.kendalltau(x, y)
+    assert_approx_equal(res[0], expected[0])
+    assert_approx_equal(res[1], expected[1])
+
+    # same in opposite direction
+    x = np.arange(10)
+    y = np.arange(10)[::-1]
+    # Cross-check with exact result from R:
+    # cor.test(x,y,method="kendall",exact=1)
+    expected = (-1.0, 5.511463844797e-07)
+    res = stats.kendalltau(x, y)
+    assert_approx_equal(res[0], expected[0])
+    assert_approx_equal(res[1], expected[1])
+
+    # swap a couple of values
+    b=y[1]
+    y[1]=y[2]
+    y[2]=b
+    # Cross-check with exact result from R:
+    # cor.test(x,y,method="kendall",exact=1)
+    expected = (-0.9555555555555556, 5.511463844797e-06)
+    res = stats.kendalltau(x, y)
+    assert_approx_equal(res[0], expected[0])
+    assert_approx_equal(res[1], expected[1])
+
+    # swap a couple more
+    b=y[5]
+    y[5]=y[6]
+    y[6]=b
+    # Cross-check with exact result from R:
+    # cor.test(x,y,method="kendall",exact=1)
+    expected = (-0.9111111111111111, 2.976190476190e-05)
+    res = stats.kendalltau(x, y)
+    assert_approx_equal(res[0], expected[0])
+    assert_approx_equal(res[1], expected[1])
+
+    # check exception in case of ties
+    y[2] = y[1]
+    assert_raises(ValueError, stats.kendalltau, x, y, method='exact')
+
     # with some ties
     # Cross-check with R:
     # cor.test(c(12,2,1,12,2),c(1,4,7,1,0),method="kendall",exact=FALSE)
@@ -696,7 +764,7 @@ def test_kendalltau():
     x[9] = np.nan
     assert_array_equal(stats.kendalltau(x, x), (np.nan, np.nan))
     assert_allclose(stats.kendalltau(x, x, nan_policy='omit'),
-                    (1.0, 0.00017455009626808976), rtol=1e-06)
+                    (1.0, 5.5114638e-6), rtol=1e-06)
     assert_raises(ValueError, stats.kendalltau, x, x, nan_policy='raise')
     assert_raises(ValueError, stats.kendalltau, x, x, nan_policy='foobar')
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -664,9 +664,9 @@ def test_kendalltau():
     assert_approx_equal(res[1], expected[1])
 
     # swap a couple of values
-    b=y[1]
-    y[1]=y[2]
-    y[2]=b
+    b = y[1]
+    y[1] = y[2]
+    y[2] = b
     # Cross-check with exact result from R:
     # cor.test(x,y,method="kendall",exact=1)
     expected = (0.9555555555555556, 5.511463844797e-06)
@@ -675,9 +675,9 @@ def test_kendalltau():
     assert_approx_equal(res[1], expected[1])
 
     # swap a couple more
-    b=y[5]
-    y[5]=y[6]
-    y[6]=b
+    b = y[5]
+    y[5] = y[6]
+    y[6] = b
     # Cross-check with exact result from R:
     # cor.test(x,y,method="kendall",exact=1)
     expected = (0.9111111111111111, 2.976190476190e-05)
@@ -696,9 +696,9 @@ def test_kendalltau():
     assert_approx_equal(res[1], expected[1])
 
     # swap a couple of values
-    b=y[1]
-    y[1]=y[2]
-    y[2]=b
+    b = y[1]
+    y[1] = y[2]
+    y[2] = b
     # Cross-check with exact result from R:
     # cor.test(x,y,method="kendall",exact=1)
     expected = (-0.9555555555555556, 5.511463844797e-06)
@@ -707,9 +707,9 @@ def test_kendalltau():
     assert_approx_equal(res[1], expected[1])
 
     # swap a couple more
-    b=y[5]
-    y[5]=y[6]
-    y[6]=b
+    b = y[5]
+    y[5] = y[6]
+    y[6] = b
     # Cross-check with exact result from R:
     # cor.test(x,y,method="kendall",exact=1)
     expected = (-0.9111111111111111, 2.976190476190e-05)


### PR DESCRIPTION
The exact method of computing the p-value is implemented (see #8456).
It is used automatically for small samples or when the user
explicitly demands it. Otherwise the existing asymptotic method
is used.