### PR TITLE
TST: fix failing linalg.qz float32 test by decreasing precision.

### DIFF
--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -2012,10 +2012,10 @@ class TestQZ(object):
         A = random([n,n]).astype(float32)
         B = random([n,n]).astype(float32)
         AA,BB,Q,Z = qz(A,B)
-        assert_array_almost_equal(dot(dot(Q,AA),Z.T), A)
-        assert_array_almost_equal(dot(dot(Q,BB),Z.T), B)
-        assert_array_almost_equal(dot(Q,Q.T), eye(n))
-        assert_array_almost_equal(dot(Z,Z.T), eye(n))
+        assert_array_almost_equal(dot(dot(Q,AA),Z.T), A, decimal=5)
+        assert_array_almost_equal(dot(dot(Q,BB),Z.T), B, decimal=5)
+        assert_array_almost_equal(dot(Q,Q.T), eye(n), decimal=5)
+        assert_array_almost_equal(dot(Z,Z.T), eye(n), decimal=5)
         assert_(all(diag(BB) >= 0))
 
     def test_qz_double(self):


### PR DESCRIPTION
For float32 the default precision of `decimal=6` was too high for my
machine, `decimal=5` seems reasonable.

This was with MKL 2018.01, Python 3.6, NumPy and MKL installed via
Conda.