### PR TITLE
DOC: add note on dtype attribute of aslinearoperator() argument

### DIFF
--- a/scipy/sparse/linalg/interface.py
+++ b/scipy/sparse/linalg/interface.py
@@ -659,13 +659,18 @@ def aslinearoperator(A):
 
     See the LinearOperator documentation for additional information.
 
+    Notes
+    -----
+    If 'A' has no .dtype attribute, the data type is determined by calling
+    :func:`LinearOperator.matvec()` - set the .dtype attribute to prevent this
+    call upon the linear operator creation.
+
     Examples
     --------
     >>> from scipy.sparse.linalg import aslinearoperator
     >>> M = np.array([[1,2,3],[4,5,6]], dtype=np.int32)
     >>> aslinearoperator(M)
     <2x3 MatrixLinearOperator with dtype=int32>
-
     """
     if isinstance(A, LinearOperator):
         return A

--- a/scipy/sparse/linalg/interface.py
+++ b/scipy/sparse/linalg/interface.py
@@ -647,7 +647,7 @@ class IdentityOperator(LinearOperator):
         return self
 
 
-def aslinearoperator(A, dtype=None):
+def aslinearoperator(A):
     """Return A as a LinearOperator.
 
     'A' may be any of the following types:
@@ -658,13 +658,6 @@ def aslinearoperator(A, dtype=None):
      - An object with .shape and .matvec attributes
 
     See the LinearOperator documentation for additional information.
-
-    Parameters
-    ----------
-    A : matrix-like
-        The object implementing the linear operator.
-    dtype : dtype, optional
-        Data type of the operator application result.
 
     Examples
     --------
@@ -689,10 +682,11 @@ def aslinearoperator(A, dtype=None):
     else:
         if hasattr(A, 'shape') and hasattr(A, 'matvec'):
             rmatvec = None
+            dtype = None
 
             if hasattr(A, 'rmatvec'):
                 rmatvec = A.rmatvec
-            if dtype is None and hasattr(A, 'dtype'):
+            if hasattr(A, 'dtype'):
                 dtype = A.dtype
             return LinearOperator(A.shape, A.matvec,
                                   rmatvec=rmatvec, dtype=dtype)

--- a/scipy/sparse/linalg/interface.py
+++ b/scipy/sparse/linalg/interface.py
@@ -647,7 +647,7 @@ class IdentityOperator(LinearOperator):
         return self
 
 
-def aslinearoperator(A):
+def aslinearoperator(A, dtype=None):
     """Return A as a LinearOperator.
 
     'A' may be any of the following types:
@@ -658,6 +658,13 @@ def aslinearoperator(A):
      - An object with .shape and .matvec attributes
 
     See the LinearOperator documentation for additional information.
+
+    Parameters
+    ----------
+    A : matrix-like
+        The object implementing the linear operator.
+    dtype : dtype, optional
+        Data type of the operator application result.
 
     Examples
     --------
@@ -682,11 +689,10 @@ def aslinearoperator(A):
     else:
         if hasattr(A, 'shape') and hasattr(A, 'matvec'):
             rmatvec = None
-            dtype = None
 
             if hasattr(A, 'rmatvec'):
                 rmatvec = A.rmatvec
-            if hasattr(A, 'dtype'):
+            if dtype is None and hasattr(A, 'dtype'):
                 dtype = A.dtype
             return LinearOperator(A.shape, A.matvec,
                                   rmatvec=rmatvec, dtype=dtype)


### PR DESCRIPTION
This PR proposes to add dtype argument to aslinearoperator(), which allows avoiding guessing the dtype in `LinearOperator._init_dtype()` by calling `LinearOperator.self.matvec()` - this can involve a complex setup of the linear operator, so postponing it to a proper call (e.g. in a preconditioner) might save some resources.
