### PR TITLE
Make show_options 'method' case-insensitive and accept Newton-CG (#8576)

### DIFF
--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -3012,6 +3012,7 @@ def show_options(solver=None, method=None, disp=True):
                 text.append(show_options(solver, name, disp=False))
             text = "".join(text)
         else:
+            method = method.lower()
             methods = dict(doc_routines[solver])
             if method not in methods:
                 raise ValueError("Unknown method %r" % (method,))

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -2958,7 +2958,7 @@ def show_options(solver=None, method=None, disp=True):
             ('dogleg', 'scipy.optimize._trustregion_dogleg._minimize_dogleg'),
             ('l-bfgs-b', 'scipy.optimize.lbfgsb._minimize_lbfgsb'),
             ('nelder-mead', 'scipy.optimize.optimize._minimize_neldermead'),
-            ('newtoncg', 'scipy.optimize.optimize._minimize_newtoncg'),
+            ('newton-cg', 'scipy.optimize.optimize._minimize_newtoncg'),
             ('powell', 'scipy.optimize.optimize._minimize_powell'),
             ('slsqp', 'scipy.optimize.slsqp._minimize_slsqp'),
             ('tnc', 'scipy.optimize.tnc._minimize_tnc'),


### PR DESCRIPTION
- Makes the `scipy.optimize.show_options()` `method` parameter case-insensitive. This `method` parameter should accept the same string in both the corresponding solver function and `scipy.optimize.show_options()`. Since each solver function `method` is case-insensitive, it makes sense to make the `scipy.optimize.show_options()` `method` case-insensitive too.
- Fixes `scipy.optimize.show_options()` so that `method='Newton-CG'` rather than `method='newtoncg'` is accepted as a valid `method`, as per documentation. 

Closes https://github.com/scipy/scipy/issues/8576.