### PR TITLE
MAINT: remove spurious warning from (z)vode and lsoda.  Closes gh-7888

### DIFF
--- a/scipy/integrate/odepack/lsoda.f
+++ b/scipy/integrate/odepack/lsoda.f
@@ -1457,11 +1457,8 @@ c counter illin is set to 0.  the optional outputs are loaded into
 c the work arrays before returning.
 c-----------------------------------------------------------------------
 c the maximum number of steps was taken before reaching tout. ----------
- 500  call xerrwv('lsoda--  at current t (=r1), mxstep (=i1) steps   ',
-     1   50, 201, 0, 0, 0, 0, 0, 0.0d0, 0.0d0)
-      call xerrwv('      taken on this call before reaching tout     ',
-     1   50, 201, 0, 1, mxstep, 0, 1, tn, 0.0d0)
-      istate = -1
+c Error message removed, see gh-7888
+ 500  istate = -1
       go to 580
 c ewt(i) .le. 0.0 for some i (not at start of problem). ----------------
  510  ewti = rwork(lewt+i-1)

--- a/scipy/integrate/odepack/vode.f
+++ b/scipy/integrate/odepack/vode.f
@@ -1508,11 +1508,8 @@ C Then Y is loaded from YH, and T is set to TN.
 C The optional output is loaded into the work arrays before returning.
 C-----------------------------------------------------------------------
 C The maximum number of steps was taken before reaching TOUT. ----------
- 500  MSG = 'DVODE--  At current T (=R1), MXSTEP (=I1) steps   '
-      CALL XERRWD (MSG, 50, 201, 1, 0, 0, 0, 0, ZERO, ZERO)
-      MSG = '      taken on this call before reaching TOUT     '
-      CALL XERRWD (MSG, 50, 201, 1, 1, MXSTEP, 0, 1, TN, ZERO)
-      ISTATE = -1
+c Error message removed, see gh-7888
+ 500  ISTATE = -1
       GO TO 580
 C EWT(i) .le. 0.0 for some i (not at start of problem). ----------------
  510  EWTI = RWORK(LEWT+I-1)

--- a/scipy/integrate/odepack/zvode.f
+++ b/scipy/integrate/odepack/zvode.f
@@ -1523,11 +1523,8 @@ C Then Y is loaded from YH, and T is set to TN.
 C The optional output is loaded into the work arrays before returning.
 C-----------------------------------------------------------------------
 C The maximum number of steps was taken before reaching TOUT. ----------
- 500  MSG = 'ZVODE--  At current T (=R1), MXSTEP (=I1) steps   '
-      CALL XERRWD (MSG, 50, 201, 1, 0, 0, 0, 0, ZERO, ZERO)
-      MSG = '      taken on this call before reaching TOUT     '
-      CALL XERRWD (MSG, 50, 201, 1, 1, MXSTEP, 0, 1, TN, ZERO)
-      ISTATE = -1
+C Error message removed, see gh-7888
+ 500  ISTATE = -1
       GO TO 580
 C EWT(i) .le. 0.0 for some i (not at start of problem). ----------------
  510  EWTI = RWORK(LEWT+I-1)


### PR DESCRIPTION
Closes #7888 