### PR TITLE
BUG: sparse.linalg/gcrotmk: avoid rounding error in termination check

### DIFF
--- a/scipy/sparse/linalg/isolve/_gcrotmk.py
+++ b/scipy/sparse/linalg/isolve/_gcrotmk.py
@@ -361,7 +361,14 @@ def gcrotmk(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
         beta = nrm2(r)
 
         # -- check stopping condition
-        if beta <= max(atol, tol * b_norm):
+        beta_tol = max(atol, tol * b_norm)
+
+        if beta <= beta_tol and (j_outer > 0 or CU):
+            # recompute residual to avoid rounding error
+            r = b - matvec(x)
+            beta = nrm2(r)
+
+        if beta <= beta_tol:
             j_outer = -1
             break
 

--- a/scipy/sparse/linalg/isolve/tests/test_gcrotmk.py
+++ b/scipy/sparse/linalg/isolve/tests/test_gcrotmk.py
@@ -54,7 +54,7 @@ class TestGCROTMK(object):
         x0, count_0 = do_solve()
         x1, count_1 = do_solve(M=M)
 
-        assert_equal(count_1, 2)
+        assert_equal(count_1, 3)
         assert_(count_1 < count_0/2)
         assert_(allclose(x1, x0, rtol=1e-14))
 
@@ -144,10 +144,10 @@ class TestGCROTMK(object):
             # should converge immediately
             x1, count_1 = do_solve(CU=CU, discard_C=discard_C)
             if discard_C:
-                assert_equal(count_1, 1 + len(CU))
+                assert_equal(count_1, 2 + len(CU))
             else:
-                assert_equal(count_1, 2)
-            assert_(count_1 < count_0/2)
+                assert_equal(count_1, 3)
+            assert_(count_1 <= count_0/2)
             assert_allclose(x1, x0, atol=1e-14)
 
     def test_denormals(self):


### PR DESCRIPTION
gcrotmk does not recompute the residual vector, so it tends to
accumulate rounding error. Recompute the vector if the termination check
is successful, to avoid exceeding tolerances.

Fixes gh-8629