### PR TITLE
CI: build pdf documentation on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           name: install Debian dependencies
           command: |
             sudo apt-get update
-            sudo apt-get install libatlas-dev libatlas-base-dev liblapack-dev gfortran libgmp-dev libmpfr-dev libfreetype6-dev libpng-dev zlib1g-dev texlive-fonts-recommended
+            sudo apt-get install libatlas-dev libatlas-base-dev liblapack-dev gfortran libgmp-dev libmpfr-dev libfreetype6-dev libpng-dev zlib1g-dev texlive-fonts-recommended texlive-latex-recommended texlive-latex-extra texlive-generic-extra latexmk texlive-xetex
 
       - run:
           name: setup Python venv
@@ -37,7 +37,9 @@ jobs:
           command: |
             . venv/bin/activate
             export SHELL=$(which bash)
-            python -u runtests.py -g --shell -- -c 'make -C doc PYTHON=python html-scipyorg'
+            python -u runtests.py -g --shell -- -c 'make -C doc PYTHON=python html-scipyorg latex'
+            make -C doc/build/latex all-pdf LATEXOPTS="-file-line-error -halt-on-error"
+            cp -f doc/build/latex/scipy-ref.pdf doc/build/html-scipyorg/
 
       - store_artifacts:
           path: doc/build/html-scipyorg

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -53,14 +53,14 @@ INSTALL_DIR = $(CURDIR)/build/inst-dist/
 INSTALL_PPH = $(INSTALL_DIR)/lib/python$(PYVER)/site-packages:$(INSTALL_DIR)/local/lib/python$(PYVER)/site-packages:$(INSTALL_DIR)/lib/python$(PYVER)/dist-packages:$(INSTALL_DIR)/local/lib/python$(PYVER)/dist-packages
 UPLOAD_DIR=/srv/docs_scipy_org/doc/scipy-$(RELEASE)
 
-DIST_VARS=PYTHON="PYTHONPATH=$(INSTALL_PPH):$$PYTHONPATH python$(PYVER)" SPHINXBUILD="LANG=C PYTHONPATH=$(INSTALL_PPH):$$PYTHONPATH python$(PYVER) `which sphinx-build`"
+DIST_VARS=PYTHON="PYTHONPATH=$(INSTALL_PPH):$$PYTHONPATH $(PYTHON)" SPHINXBUILD="PYTHONPATH=$(INSTALL_PPH):$$PYTHONPATH $(SPHINXBUILD)"
 
 dist:
 	make $(DIST_VARS) real-dist
 
 real-dist: dist-build html html-scipyorg
 	test -d build/latex || make latex
-	make -C build/latex all-pdf
+	make -C build/latex all-pdf LATEXOPTS="-halt-on-error"
 	-test -d build/htmlhelp || make htmlhelp-build
 	-rm -rf build/dist
 	mkdir -p build/dist

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -237,9 +237,9 @@ latex_elements = {
 # Intersphinx configuration
 # -----------------------------------------------------------------------------
 intersphinx_mapping = {
-        'python': ('http://docs.python.org/dev', None),
+        'python': ('https://docs.python.org/dev', None),
         'numpy': ('https://docs.scipy.org/doc/numpy', None),
-        'matplotlib': ('http://matplotlib.org', None),
+        'matplotlib': ('https://matplotlib.org', None),
 }
 
 

--- a/scipy/signal/windows/windows.py
+++ b/scipy/signal/windows/windows.py
@@ -1824,7 +1824,7 @@ def dpss(M, NW, Kmax=None, sym=True, norm=None, return_ratios=False):
     >>> fig.tight_layout()
     >>> plt.show()
 
-    Using a standard :math:`l_{$\\infty$}`` norm would produce two unity values
+    Using a standard :math:`l_{\\infty}` norm would produce two unity values
     for even `M`, but only one unity value for odd `M`. This produces uneven
     window power that can be counteracted by the approximate correction
     ``M**2/float(M**2+NW)``, which can be selected by using

--- a/scipy/spatial/__init__.py
+++ b/scipy/spatial/__init__.py
@@ -12,8 +12,9 @@ Nearest-neighbor Queries
 
    KDTree      -- class for efficient nearest-neighbor queries
    cKDTree     -- class for efficient nearest-neighbor queries (faster impl.)
-   distance    -- module containing many different distance measures
    Rectangle
+
+Distance metrics are contained in the :mod:`scipy.spatial.distance` submodule.
 
 Delaunay Triangulation, Convex Hulls and Voronoi Diagrams
 =========================================================

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -54,91 +54,91 @@ docheaders = {'methods': """\nMethods\n-------\n""",
               'examples': """\nExamples\n--------\n"""}
 
 _doc_rvs = """\
-``rvs(%(shapes)s, loc=0, scale=1, size=1, random_state=None)``
+rvs(%(shapes)s, loc=0, scale=1, size=1, random_state=None)
     Random variates.
 """
 _doc_pdf = """\
-``pdf(x, %(shapes)s, loc=0, scale=1)``
+pdf(x, %(shapes)s, loc=0, scale=1)
     Probability density function.
 """
 _doc_logpdf = """\
-``logpdf(x, %(shapes)s, loc=0, scale=1)``
+logpdf(x, %(shapes)s, loc=0, scale=1)
     Log of the probability density function.
 """
 _doc_pmf = """\
-``pmf(k, %(shapes)s, loc=0, scale=1)``
+pmf(k, %(shapes)s, loc=0, scale=1)
     Probability mass function.
 """
 _doc_logpmf = """\
-``logpmf(k, %(shapes)s, loc=0, scale=1)``
+logpmf(k, %(shapes)s, loc=0, scale=1)
     Log of the probability mass function.
 """
 _doc_cdf = """\
-``cdf(x, %(shapes)s, loc=0, scale=1)``
+cdf(x, %(shapes)s, loc=0, scale=1)
     Cumulative distribution function.
 """
 _doc_logcdf = """\
-``logcdf(x, %(shapes)s, loc=0, scale=1)``
+logcdf(x, %(shapes)s, loc=0, scale=1)
     Log of the cumulative distribution function.
 """
 _doc_sf = """\
-``sf(x, %(shapes)s, loc=0, scale=1)``
+sf(x, %(shapes)s, loc=0, scale=1)
     Survival function  (also defined as ``1 - cdf``, but `sf` is sometimes more accurate).
 """
 _doc_logsf = """\
-``logsf(x, %(shapes)s, loc=0, scale=1)``
+logsf(x, %(shapes)s, loc=0, scale=1)
     Log of the survival function.
 """
 _doc_ppf = """\
-``ppf(q, %(shapes)s, loc=0, scale=1)``
+ppf(q, %(shapes)s, loc=0, scale=1)
     Percent point function (inverse of ``cdf`` --- percentiles).
 """
 _doc_isf = """\
-``isf(q, %(shapes)s, loc=0, scale=1)``
+isf(q, %(shapes)s, loc=0, scale=1)
     Inverse survival function (inverse of ``sf``).
 """
 _doc_moment = """\
-``moment(n, %(shapes)s, loc=0, scale=1)``
+moment(n, %(shapes)s, loc=0, scale=1)
     Non-central moment of order n
 """
 _doc_stats = """\
-``stats(%(shapes)s, loc=0, scale=1, moments='mv')``
+stats(%(shapes)s, loc=0, scale=1, moments='mv')
     Mean('m'), variance('v'), skew('s'), and/or kurtosis('k').
 """
 _doc_entropy = """\
-``entropy(%(shapes)s, loc=0, scale=1)``
+entropy(%(shapes)s, loc=0, scale=1)
     (Differential) entropy of the RV.
 """
 _doc_fit = """\
-``fit(data, %(shapes)s, loc=0, scale=1)``
+fit(data, %(shapes)s, loc=0, scale=1)
     Parameter estimates for generic data.
 """
 _doc_expect = """\
-``expect(func, args=(%(shapes_)s), loc=0, scale=1, lb=None, ub=None, conditional=False, **kwds)``
+expect(func, args=(%(shapes_)s), loc=0, scale=1, lb=None, ub=None, conditional=False, **kwds)
     Expected value of a function (of one argument) with respect to the distribution.
 """
 _doc_expect_discrete = """\
-``expect(func, args=(%(shapes_)s), loc=0, lb=None, ub=None, conditional=False)``
+expect(func, args=(%(shapes_)s), loc=0, lb=None, ub=None, conditional=False)
     Expected value of a function (of one argument) with respect to the distribution.
 """
 _doc_median = """\
-``median(%(shapes)s, loc=0, scale=1)``
+median(%(shapes)s, loc=0, scale=1)
     Median of the distribution.
 """
 _doc_mean = """\
-``mean(%(shapes)s, loc=0, scale=1)``
+mean(%(shapes)s, loc=0, scale=1)
     Mean of the distribution.
 """
 _doc_var = """\
-``var(%(shapes)s, loc=0, scale=1)``
+var(%(shapes)s, loc=0, scale=1)
     Variance of the distribution.
 """
 _doc_std = """\
-``std(%(shapes)s, loc=0, scale=1)``
+std(%(shapes)s, loc=0, scale=1)
     Standard deviation of the distribution.
 """
 _doc_interval = """\
-``interval(alpha, %(shapes)s, loc=0, scale=1)``
+interval(alpha, %(shapes)s, loc=0, scale=1)
     Endpoints of the range that contains alpha percent of the distribution
 """
 _doc_allmethods = ''.join([docheaders['methods'], _doc_rvs, _doc_pdf,


### PR DESCRIPTION
Build PDF documentation on CircleCI. This shouldn't increase the build time significantly.

This PR also contains some misc. sphinx/latex markup cleanups.