### PR TITLE
TST: fix special test that was importing `np.testing.utils` (deprecated)

### DIFF
--- a/scipy/special/_testutils.py
+++ b/scipy/special/_testutils.py
@@ -59,8 +59,8 @@ def assert_tol_equal(a, b, rtol=1e-7, atol=0, err_msg='', verbose=True):
         return np.allclose(x, y, rtol=rtol, atol=atol)
     a, b = np.asanyarray(a), np.asanyarray(b)
     header = 'Not equal to tolerance rtol=%g, atol=%g' % (rtol, atol)
-    np.testing.utils.assert_array_compare(compare, a, b, err_msg=str(err_msg),
-                                          verbose=verbose, header=header)
+    np.testing.assert_array_compare(compare, a, b, err_msg=str(err_msg),
+                                    verbose=verbose, header=header)
 
 
 #------------------------------------------------------------------------------

--- a/scipy/special/_testutils.py
+++ b/scipy/special/_testutils.py
@@ -12,8 +12,7 @@ import pytest
 
 import scipy.special as sc
 
-__all__ = ['with_special_errors', 'assert_tol_equal', 'assert_func_equal',
-           'FuncData']
+__all__ = ['with_special_errors', 'assert_func_equal', 'FuncData']
 
 
 #------------------------------------------------------------------------------
@@ -47,20 +46,6 @@ def with_special_errors(func):
             res = func(*a, **kw)
         return res
     return wrapper
-
-
-#------------------------------------------------------------------------------
-# Comparing function values at many data points at once, with helpful
-#------------------------------------------------------------------------------
-
-def assert_tol_equal(a, b, rtol=1e-7, atol=0, err_msg='', verbose=True):
-    """Assert that `a` and `b` are equal to tolerance ``atol + rtol*abs(b)``"""
-    def compare(x, y):
-        return np.allclose(x, y, rtol=rtol, atol=atol)
-    a, b = np.asanyarray(a), np.asanyarray(b)
-    header = 'Not equal to tolerance rtol=%g, atol=%g' % (rtol, atol)
-    np.testing.assert_array_compare(compare, a, b, err_msg=str(err_msg),
-                                    verbose=verbose, header=header)
 
 
 #------------------------------------------------------------------------------

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -38,7 +38,7 @@ from scipy import special
 import scipy.special._ufuncs as cephes
 from scipy.special import ellipk, zeta
 
-from scipy.special._testutils import assert_tol_equal, with_special_errors, \
+from scipy.special._testutils import with_special_errors, \
      assert_func_equal, FuncData
 
 from scipy._lib._numpy_compat import suppress_warnings
@@ -780,7 +780,7 @@ class TestCephes(object):
         assert_approx_equal(cephes.nrdtrimn(0.5,1,1),1.0)
 
     def test_nrdtrisd(self):
-        assert_tol_equal(cephes.nrdtrisd(0.5,0.5,0.5), 0.0,
+        assert_allclose(cephes.nrdtrisd(0.5,0.5,0.5), 0.0,
                          atol=0, rtol=0)
 
     def test_obl_ang1(self):
@@ -1960,7 +1960,7 @@ class TestGamma(object):
         for xp in pts:
             y = special.gammaincinv(.4, xp)
             x = special.gammainc(0.4, y)
-            assert_tol_equal(x, xp, rtol=1e-12)
+            assert_allclose(x, xp, rtol=1e-12)
 
     def test_rgamma(self):
         rgam = special.rgamma(8)
@@ -2298,14 +2298,14 @@ class TestBessel(object):
                                               16.47063]),4)
 
         jn102 = special.jn_zeros(102,5)
-        assert_tol_equal(jn102, array([110.89174935992040343,
+        assert_allclose(jn102, array([110.89174935992040343,
                                        117.83464175788308398,
                                        123.70194191713507279,
                                        129.02417238949092824,
                                        134.00114761868422559]), rtol=1e-13)
 
         jn301 = special.jn_zeros(301,5)
-        assert_tol_equal(jn301, array([313.59097866698830153,
+        assert_allclose(jn301, array([313.59097866698830153,
                                        323.21549776096288280,
                                        331.22338738656748796,
                                        338.39676338872084500,
@@ -2313,17 +2313,17 @@ class TestBessel(object):
 
     def test_jn_zeros_slow(self):
         jn0 = special.jn_zeros(0, 300)
-        assert_tol_equal(jn0[260-1], 816.02884495068867280, rtol=1e-13)
-        assert_tol_equal(jn0[280-1], 878.86068707124422606, rtol=1e-13)
-        assert_tol_equal(jn0[300-1], 941.69253065317954064, rtol=1e-13)
+        assert_allclose(jn0[260-1], 816.02884495068867280, rtol=1e-13)
+        assert_allclose(jn0[280-1], 878.86068707124422606, rtol=1e-13)
+        assert_allclose(jn0[300-1], 941.69253065317954064, rtol=1e-13)
 
         jn10 = special.jn_zeros(10, 300)
-        assert_tol_equal(jn10[260-1], 831.67668514305631151, rtol=1e-13)
-        assert_tol_equal(jn10[280-1], 894.51275095371316931, rtol=1e-13)
-        assert_tol_equal(jn10[300-1], 957.34826370866539775, rtol=1e-13)
+        assert_allclose(jn10[260-1], 831.67668514305631151, rtol=1e-13)
+        assert_allclose(jn10[280-1], 894.51275095371316931, rtol=1e-13)
+        assert_allclose(jn10[300-1], 957.34826370866539775, rtol=1e-13)
 
         jn3010 = special.jn_zeros(3010,5)
-        assert_tol_equal(jn3010, array([3036.86590780927,
+        assert_allclose(jn3010, array([3036.86590780927,
                                         3057.06598526482,
                                         3073.66360690272,
                                         3088.37736494778,
@@ -2352,7 +2352,7 @@ class TestBessel(object):
                                                 11.70600,
                                                 14.86359]),4)
         jnp = special.jnp_zeros(443,5)
-        assert_tol_equal(special.jvp(443, jnp), 0, atol=1e-15)
+        assert_allclose(special.jvp(443, jnp), 0, atol=1e-15)
 
     def test_jnyn_zeros(self):
         jnz = special.jnyn_zeros(1,5)
@@ -2505,7 +2505,7 @@ class TestBessel(object):
         an = special.yn_zeros(4,2)
         assert_array_almost_equal(an,array([5.64515, 9.36162]),5)
         an = special.yn_zeros(443,5)
-        assert_tol_equal(an, [450.13573091578090314, 463.05692376675001542,
+        assert_allclose(an, [450.13573091578090314, 463.05692376675001542,
                               472.80651546418663566, 481.27353184725625838,
                               488.98055964441374646], rtol=1e-15)
 
@@ -2513,13 +2513,13 @@ class TestBessel(object):
         ao = special.ynp_zeros(0,2)
         assert_array_almost_equal(ao,array([2.19714133, 5.42968104]),6)
         ao = special.ynp_zeros(43,5)
-        assert_tol_equal(special.yvp(43, ao), 0, atol=1e-15)
+        assert_allclose(special.yvp(43, ao), 0, atol=1e-15)
         ao = special.ynp_zeros(443,5)
-        assert_tol_equal(special.yvp(443, ao), 0, atol=1e-9)
+        assert_allclose(special.yvp(443, ao), 0, atol=1e-9)
 
     def test_ynp_zeros_large_order(self):
         ao = special.ynp_zeros(443,5)
-        assert_tol_equal(special.yvp(443, ao), 0, atol=1e-14)
+        assert_allclose(special.yvp(443, ao), 0, atol=1e-14)
 
     def test_yn(self):
         yn2n = special.yn(1,.2)
@@ -2571,9 +2571,9 @@ class TestBessel(object):
             elif np.isnan(c1):
                 assert_(c2.imag != 0, (v, z))
             else:
-                assert_tol_equal(c1, c2, err_msg=(v, z), rtol=rtol, atol=atol)
+                assert_allclose(c1, c2, err_msg=(v, z), rtol=rtol, atol=atol)
                 if v == int(v):
-                    assert_tol_equal(c3, c2, err_msg=(v, z),
+                    assert_allclose(c3, c2, err_msg=(v, z),
                                      rtol=rtol, atol=atol)
 
     def test_jv_cephes_vs_amos(self):
@@ -2630,53 +2630,53 @@ class TestBessel(object):
         self.check_cephes_vs_amos(special.kv, special.kv, rtol=1e-9, atol=1e-305)
 
     def test_ticket_623(self):
-        assert_tol_equal(special.jv(3, 4), 0.43017147387562193)
-        assert_tol_equal(special.jv(301, 1300), 0.0183487151115275)
-        assert_tol_equal(special.jv(301, 1296.0682), -0.0224174325312048)
+        assert_allclose(special.jv(3, 4), 0.43017147387562193)
+        assert_allclose(special.jv(301, 1300), 0.0183487151115275)
+        assert_allclose(special.jv(301, 1296.0682), -0.0224174325312048)
 
     def test_ticket_853(self):
         """Negative-order Bessels"""
         # cephes
-        assert_tol_equal(special.jv(-1, 1), -0.4400505857449335)
-        assert_tol_equal(special.jv(-2, 1), 0.1149034849319005)
-        assert_tol_equal(special.yv(-1, 1), 0.7812128213002887)
-        assert_tol_equal(special.yv(-2, 1), -1.650682606816255)
-        assert_tol_equal(special.iv(-1, 1), 0.5651591039924851)
-        assert_tol_equal(special.iv(-2, 1), 0.1357476697670383)
-        assert_tol_equal(special.kv(-1, 1), 0.6019072301972347)
-        assert_tol_equal(special.kv(-2, 1), 1.624838898635178)
-        assert_tol_equal(special.jv(-0.5, 1), 0.43109886801837607952)
-        assert_tol_equal(special.yv(-0.5, 1), 0.6713967071418031)
-        assert_tol_equal(special.iv(-0.5, 1), 1.231200214592967)
-        assert_tol_equal(special.kv(-0.5, 1), 0.4610685044478945)
+        assert_allclose(special.jv(-1, 1), -0.4400505857449335)
+        assert_allclose(special.jv(-2, 1), 0.1149034849319005)
+        assert_allclose(special.yv(-1, 1), 0.7812128213002887)
+        assert_allclose(special.yv(-2, 1), -1.650682606816255)
+        assert_allclose(special.iv(-1, 1), 0.5651591039924851)
+        assert_allclose(special.iv(-2, 1), 0.1357476697670383)
+        assert_allclose(special.kv(-1, 1), 0.6019072301972347)
+        assert_allclose(special.kv(-2, 1), 1.624838898635178)
+        assert_allclose(special.jv(-0.5, 1), 0.43109886801837607952)
+        assert_allclose(special.yv(-0.5, 1), 0.6713967071418031)
+        assert_allclose(special.iv(-0.5, 1), 1.231200214592967)
+        assert_allclose(special.kv(-0.5, 1), 0.4610685044478945)
         # amos
-        assert_tol_equal(special.jv(-1, 1+0j), -0.4400505857449335)
-        assert_tol_equal(special.jv(-2, 1+0j), 0.1149034849319005)
-        assert_tol_equal(special.yv(-1, 1+0j), 0.7812128213002887)
-        assert_tol_equal(special.yv(-2, 1+0j), -1.650682606816255)
+        assert_allclose(special.jv(-1, 1+0j), -0.4400505857449335)
+        assert_allclose(special.jv(-2, 1+0j), 0.1149034849319005)
+        assert_allclose(special.yv(-1, 1+0j), 0.7812128213002887)
+        assert_allclose(special.yv(-2, 1+0j), -1.650682606816255)
 
-        assert_tol_equal(special.iv(-1, 1+0j), 0.5651591039924851)
-        assert_tol_equal(special.iv(-2, 1+0j), 0.1357476697670383)
-        assert_tol_equal(special.kv(-1, 1+0j), 0.6019072301972347)
-        assert_tol_equal(special.kv(-2, 1+0j), 1.624838898635178)
+        assert_allclose(special.iv(-1, 1+0j), 0.5651591039924851)
+        assert_allclose(special.iv(-2, 1+0j), 0.1357476697670383)
+        assert_allclose(special.kv(-1, 1+0j), 0.6019072301972347)
+        assert_allclose(special.kv(-2, 1+0j), 1.624838898635178)
 
-        assert_tol_equal(special.jv(-0.5, 1+0j), 0.43109886801837607952)
-        assert_tol_equal(special.jv(-0.5, 1+1j), 0.2628946385649065-0.827050182040562j)
-        assert_tol_equal(special.yv(-0.5, 1+0j), 0.6713967071418031)
-        assert_tol_equal(special.yv(-0.5, 1+1j), 0.967901282890131+0.0602046062142816j)
+        assert_allclose(special.jv(-0.5, 1+0j), 0.43109886801837607952)
+        assert_allclose(special.jv(-0.5, 1+1j), 0.2628946385649065-0.827050182040562j)
+        assert_allclose(special.yv(-0.5, 1+0j), 0.6713967071418031)
+        assert_allclose(special.yv(-0.5, 1+1j), 0.967901282890131+0.0602046062142816j)
 
-        assert_tol_equal(special.iv(-0.5, 1+0j), 1.231200214592967)
-        assert_tol_equal(special.iv(-0.5, 1+1j), 0.77070737376928+0.39891821043561j)
-        assert_tol_equal(special.kv(-0.5, 1+0j), 0.4610685044478945)
-        assert_tol_equal(special.kv(-0.5, 1+1j), 0.06868578341999-0.38157825981268j)
+        assert_allclose(special.iv(-0.5, 1+0j), 1.231200214592967)
+        assert_allclose(special.iv(-0.5, 1+1j), 0.77070737376928+0.39891821043561j)
+        assert_allclose(special.kv(-0.5, 1+0j), 0.4610685044478945)
+        assert_allclose(special.kv(-0.5, 1+1j), 0.06868578341999-0.38157825981268j)
 
-        assert_tol_equal(special.jve(-0.5,1+0.3j), special.jv(-0.5, 1+0.3j)*exp(-0.3))
-        assert_tol_equal(special.yve(-0.5,1+0.3j), special.yv(-0.5, 1+0.3j)*exp(-0.3))
-        assert_tol_equal(special.ive(-0.5,0.3+1j), special.iv(-0.5, 0.3+1j)*exp(-0.3))
-        assert_tol_equal(special.kve(-0.5,0.3+1j), special.kv(-0.5, 0.3+1j)*exp(0.3+1j))
+        assert_allclose(special.jve(-0.5,1+0.3j), special.jv(-0.5, 1+0.3j)*exp(-0.3))
+        assert_allclose(special.yve(-0.5,1+0.3j), special.yv(-0.5, 1+0.3j)*exp(-0.3))
+        assert_allclose(special.ive(-0.5,0.3+1j), special.iv(-0.5, 0.3+1j)*exp(-0.3))
+        assert_allclose(special.kve(-0.5,0.3+1j), special.kv(-0.5, 0.3+1j)*exp(0.3+1j))
 
-        assert_tol_equal(special.hankel1(-0.5, 1+1j), special.jv(-0.5, 1+1j) + 1j*special.yv(-0.5,1+1j))
-        assert_tol_equal(special.hankel2(-0.5, 1+1j), special.jv(-0.5, 1+1j) - 1j*special.yv(-0.5,1+1j))
+        assert_allclose(special.hankel1(-0.5, 1+1j), special.jv(-0.5, 1+1j) + 1j*special.yv(-0.5,1+1j))
+        assert_allclose(special.hankel2(-0.5, 1+1j), special.jv(-0.5, 1+1j) - 1j*special.yv(-0.5,1+1j))
 
     def test_ticket_854(self):
         """Real-valued Bessel domains"""
@@ -2701,11 +2701,11 @@ class TestBessel(object):
 
     def test_ticket_503(self):
         """Real-valued Bessel I overflow"""
-        assert_tol_equal(special.iv(1, 700), 1.528500390233901e302)
-        assert_tol_equal(special.iv(1000, 1120), 1.301564549405821e301)
+        assert_allclose(special.iv(1, 700), 1.528500390233901e302)
+        assert_allclose(special.iv(1000, 1120), 1.301564549405821e301)
 
     def test_iv_hyperg_poles(self):
-        assert_tol_equal(special.iv(-0.5, 1), 1.231200214592967)
+        assert_allclose(special.iv(-0.5, 1), 1.231200214592967)
 
     def iv_series(self, v, z, n=200):
         k = arange(0, n).astype(float_)
@@ -2718,18 +2718,18 @@ class TestBessel(object):
     def test_i0_series(self):
         for z in [1., 10., 200.5]:
             value, err = self.iv_series(0, z)
-            assert_tol_equal(special.i0(z), value, atol=err, err_msg=z)
+            assert_allclose(special.i0(z), value, atol=err, err_msg=z)
 
     def test_i1_series(self):
         for z in [1., 10., 200.5]:
             value, err = self.iv_series(1, z)
-            assert_tol_equal(special.i1(z), value, atol=err, err_msg=z)
+            assert_allclose(special.i1(z), value, atol=err, err_msg=z)
 
     def test_iv_series(self):
         for v in [-20., -10., -1., 0., 1., 12.49, 120.]:
             for z in [1., 10., 200.5, -1+2j]:
                 value, err = self.iv_series(v, z)
-                assert_tol_equal(special.iv(v, z), value, atol=err, err_msg=(v, z))
+                assert_allclose(special.iv(v, z), value, atol=err, err_msg=(v, z))
 
     def test_i0(self):
         values = [[0.0, 1.0],
@@ -3049,11 +3049,11 @@ class TestParabolicCylinder(object):
         # simple case
         eta = np.linspace(-10, 10, 5)
         z = 2**(eta/2)*np.sqrt(np.pi)/special.gamma(.5-.5*eta)
-        assert_tol_equal(special.pbdv(eta, 0.)[0], z, rtol=1e-14, atol=1e-14)
+        assert_allclose(special.pbdv(eta, 0.)[0], z, rtol=1e-14, atol=1e-14)
 
         # some points
-        assert_tol_equal(special.pbdv(10.34, 20.44)[0], 1.3731383034455e-32, rtol=1e-12)
-        assert_tol_equal(special.pbdv(-9.53, 3.44)[0], 3.166735001119246e-8, rtol=1e-12)
+        assert_allclose(special.pbdv(10.34, 20.44)[0], 1.3731383034455e-32, rtol=1e-12)
+        assert_allclose(special.pbdv(-9.53, 3.44)[0], 3.166735001119246e-8, rtol=1e-12)
 
     def test_pbdv_gradient(self):
         x = np.linspace(-4, 4, 8)[:,None]
@@ -3062,7 +3062,7 @@ class TestParabolicCylinder(object):
         p = special.pbdv(eta, x)
         eps = 1e-7 + 1e-7*abs(x)
         dp = (special.pbdv(eta, x + eps)[0] - special.pbdv(eta, x - eps)[0]) / eps / 2.
-        assert_tol_equal(p[1], dp, rtol=1e-6, atol=1e-6)
+        assert_allclose(p[1], dp, rtol=1e-6, atol=1e-6)
 
     def test_pbvv_gradient(self):
         x = np.linspace(-4, 4, 8)[:,None]
@@ -3071,7 +3071,7 @@ class TestParabolicCylinder(object):
         p = special.pbvv(eta, x)
         eps = 1e-7 + 1e-7*abs(x)
         dp = (special.pbvv(eta, x + eps)[0] - special.pbvv(eta, x - eps)[0]) / eps / 2.
-        assert_tol_equal(p[1], dp, rtol=1e-6, atol=1e-6)
+        assert_allclose(p[1], dp, rtol=1e-6, atol=1e-6)
 
 
 class TestPolygamma(object):
@@ -3212,13 +3212,13 @@ class TestStruve(object):
         for v in [-20, -10, -7.99, -3.4, -1, 0, 1, 3.4, 12.49, 16]:
             for z in [1, 10, 19, 21, 30]:
                 value, err = self._series(v, z)
-                assert_tol_equal(special.struve(v, z), value, rtol=0, atol=err), (v, z)
+                assert_allclose(special.struve(v, z), value, rtol=0, atol=err), (v, z)
 
     def test_some_values(self):
-        assert_tol_equal(special.struve(-7.99, 21), 0.0467547614113, rtol=1e-7)
-        assert_tol_equal(special.struve(-8.01, 21), 0.0398716951023, rtol=1e-8)
-        assert_tol_equal(special.struve(-3.0, 200), 0.0142134427432, rtol=1e-12)
-        assert_tol_equal(special.struve(-8.0, -41), 0.0192469727846, rtol=1e-11)
+        assert_allclose(special.struve(-7.99, 21), 0.0467547614113, rtol=1e-7)
+        assert_allclose(special.struve(-8.01, 21), 0.0398716951023, rtol=1e-8)
+        assert_allclose(special.struve(-3.0, 200), 0.0142134427432, rtol=1e-12)
+        assert_allclose(special.struve(-8.0, -41), 0.0192469727846, rtol=1e-11)
         assert_equal(special.struve(-12, -41), -special.struve(-12, 41))
         assert_equal(special.struve(+12, -41), -special.struve(+12, 41))
         assert_equal(special.struve(-11, -41), +special.struve(-11, 41))
@@ -3229,9 +3229,9 @@ class TestStruve(object):
 
     def test_regression_679(self):
         """Regression test for #679"""
-        assert_tol_equal(special.struve(-1.0, 20 - 1e-8), special.struve(-1.0, 20 + 1e-8))
-        assert_tol_equal(special.struve(-2.0, 20 - 1e-8), special.struve(-2.0, 20 + 1e-8))
-        assert_tol_equal(special.struve(-4.3, 20 - 1e-8), special.struve(-4.3, 20 + 1e-8))
+        assert_allclose(special.struve(-1.0, 20 - 1e-8), special.struve(-1.0, 20 + 1e-8))
+        assert_allclose(special.struve(-2.0, 20 - 1e-8), special.struve(-2.0, 20 + 1e-8))
+        assert_allclose(special.struve(-4.3, 20 - 1e-8), special.struve(-4.3, 20 + 1e-8))
 
 
 def test_chi2_smalldf():


### PR DESCRIPTION
This fixes the CI failures with numpy master.