### PR TITLE
BUG: optimize: fixed sparse redundancy removal bug

### DIFF
--- a/scipy/optimize/_remove_redundancy.py
+++ b/scipy/optimize/_remove_redundancy.py
@@ -329,9 +329,20 @@ def _remove_redundancy_sparse(A, rhs):
         # as any are nonzero). For very large matrices, it might be worth
         # it to compute, say, 100 or 1000 at a time and stop when a nonzero
         # is found.
-        c = abs(A[:, js].transpose().dot(pi))
-        if (c > tolapiv).any():  # independent
-            j = js[np.argmax(c)]  # select very independent column
+
+        c = (np.abs(A[:, js].transpose().dot(pi)) > tolapiv).nonzero()[0]
+        if len(c) > 0:  # independent
+            j = js[c[0]]
+            # in a previous commit, the previous line was changed to choose
+            # index j corresponding with the maximum dot product.
+            # While this avoided issues with almost
+            # singular matrices, it slowed the routine in most NETLIB tests.
+            # I think this is because these columns were denser than the
+            # first column with nonzero dot product (c[0]).
+            # It would be nice to have a heuristic that balances sparsity with
+            # high dot product, but I don't think it's worth the time to
+            # develop one right now. Bartels-Golub update is a much higher
+            # priority.
             b[i] = j  # replace artificial column
         else:
             bibar = pi.T.dot(rhs.reshape(-1, 1))


### PR DESCRIPTION
Commit f2c31e3 "ENH: optimize: enhanced redundancy removal
reliability further" changed _remove_redundancy_sparse to
"choose very independent structural column to enter basis rather
than first one that meets tolerance." In practice, this made most
NETLIB benchmarks much slower. Reverted to original column
selection scheme.