### PR TITLE
DOC: adds SciPy development build videos to Hacking FAQ per #8353

### DIFF
--- a/HACKING.rst.txt
+++ b/HACKING.rst.txt
@@ -380,6 +380,21 @@ test and use your changes (in ``.py`` files), by simply restarting the
 interpreter.
 
 
+*Are there any video examples for installing from source, setting up a 
+development environment, etc...?*
+
+Currently, there are two video demonstrations for macOS:
+
+`Anaconda SciPy Dev Part I (macOS)`_ is a four-minute
+overview of installing Anaconda, building SciPy from source, and testing
+changes made to SciPy from the Spyder IDE.
+
+`Anaconda SciPy Dev Part II (macOS)`_ shows how to use
+a virtual environment to easily switch between the ”pre-built version" of SciPy
+installed with Anaconda and your “source-built version" of SciPy created
+according to Part I.
+
+
 *Can I use a programming language other than Python to speed up my code?*
 
 Yes.  The languages used in SciPy are Python, Cython, C, C++ and Fortran.  All
@@ -489,3 +504,6 @@ suite.
 
 .. _mailing lists: https://www.scipy.org/scipylib/mailing-lists.html
 
+.. _Anaconda SciPy Dev Part I: https://youtu.be/1rPOSNd0ULI
+
+.. _Anaconda SciPy Dev Part II: https://youtu.be/Faz29u5xIZc


### PR DESCRIPTION
See #8353 for discussion. This just adds links to the videos in the [Contributing To SciPy](https://docs.scipy.org/doc/scipy/reference/hacking.html) (hacking.html) FAQ.