### PR TITLE
TST: sparse: skip test_inplace_dense for numpy<1.13

### DIFF
--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2006,6 +2006,8 @@ class _TestCommon(object):
 
 
 class _TestInplaceArithmetic(object):
+    @pytest.mark.skipif(NumpyVersion(np.__version__) < "1.13.0",
+                        reason="numpy version doesn't respect array priority")
     def test_inplace_dense(self):
         a = np.ones((3, 4))
         b = self.spmatrix(a)


### PR DESCRIPTION
Numpy versions < 1.13 don't respect `__array_priority__` for inplace 
operations, so the test does not pass.

Before removal of `spmatrix.__numpy_ufunc__` in 5bb319011bc28081c460, the
test passed also on numpy < 1.13. However, numpy_ufunc is no longer
present in new Numpy versions.

Supporting (ndarray += sparse) for the old-numpy & new-scipy version
combination is not very important, so we just skip the test in this
case.

Closes gh-8604