### PR TITLE
DOC : let PDF be with better bookmarks (and TOC) for Tutorial chapter

### DIFF
--- a/doc/source/tutorial/index.rst
+++ b/doc/source/tutorial/index.rst
@@ -4,6 +4,11 @@ SciPy Tutorial
 
 .. sectionauthor:: Travis E. Oliphant
 
+.. raw:: latex
+
+   \setcounter{tocdepth}{2}% for PDF bookmarks
+   \addtocontents{toc}{\protect\setcounter{tocdepth}{2}}
+
 .. toctree::
    :maxdepth: 1
 
@@ -22,3 +27,8 @@ SciPy Tutorial
    stats
    ndimage
    io
+
+.. raw:: latex
+
+   \setcounter{tocdepth}{1}
+   \addtocontents{toc}{\protect\setcounter{tocdepth}{1}}


### PR DESCRIPTION
This adds to PDF suitable bookmarks for the sections in the tutorial, and also in the main table of contents at start of document.