### PR TITLE
BLD: (DOC) fix LaTeX package expdlist bug causing blank lines in PDF

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -194,6 +194,14 @@ latex_elements = {
 \usepackage{etoolbox}
 \makeatletter
 \patchcmd\@item{{\@breaklabel} }{{\@breaklabel}}{}{}
+% Fix bug in expdlist's way of breaking the line after long item label
+\def\breaklabel{%
+    \def\@breaklabel{%
+        \leavevmode\par
+        % now a hack because Sphinx inserts \leavevmode after term node
+        \def\leavevmode{\def\leavevmode{\unhbox\voidb@x}}%
+    }%
+}
 \makeatother
 
 % Make Examples/etc section headers smaller and more compact


### PR DESCRIPTION
The way the line is broken in case of a long item label is buggy and
this shows in case of nested description lists.

We fix this, but the we then need a hack around Sphinx automatically
inserted ``\leavevmode`` which would again cause an extra blank line
after the long term label.

This suppresses about 2500 extra blank lines in PDF output...

closes #8652