### PR TITLE
Fix some math markup to use LaTeX/AmsMath rather than TeX syntax

### DIFF
--- a/doc/source/tutorial/fftpack.rst
+++ b/doc/source/tutorial/fftpack.rst
@@ -276,7 +276,7 @@ Scipy uses the following definition of the unnormalized DCT-I
 .. math::
 
     y[k] = x_0 + (-1)^k x_{N-1} + 2\sum_{n=1}^{N-2} x[n]
-    \cos\left({\pi nk\over N-1}\right),
+    \cos\left(\frac{\pi nk}{N-1}\right),
     \qquad 0 \le k < N.
 
 Only ``None`` is supported as normalization mode for DCT-I. Note also that the

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -490,7 +490,7 @@ def linkage(y, method='single', metric='euclidean', optimal_ordering=False):
     or a 2d array of observation vectors.
 
     If y is a 1d condensed distance matrix,
-    then y must be a :math:`{n \\choose 2}` sized
+    then y must be a :math:`\\binom{n}{2}` sized
     vector where n is the number of original observations paired
     in the distance matrix. The behavior of this function is very
     similar to the MATLAB linkage function.


### PR DESCRIPTION
Works the same in HTML and avoids warnings in LaTeX log. This is very minor change...