### PR TITLE
Latex reduce left margins

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -187,8 +187,15 @@ latex_elements = {
 \usepackage{expdlist}
 \let\latexdescription=\description
 \let\endlatexdescription=\enddescription
-\renewenvironment{description}%
-{\begin{latexdescription}[\setleftmargin{60pt}\breaklabel\setlabelstyle{\bfseries\itshape}]}%
+\renewenvironment{description}
+{\renewenvironment{description}
+   {\begin{latexdescription}%
+    [\setleftmargin{50pt}\breaklabel\setlabelstyle{\bfseries}]%
+   }%
+   {\end{latexdescription}}%
+ \begin{latexdescription}%
+    [\setleftmargin{15pt}\breaklabel\setlabelstyle{\bfseries\itshape}]%
+}%
 {\end{latexdescription}}
 % Fix bug in expdlist's modified \@item
 \usepackage{etoolbox}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -194,6 +194,14 @@ latex_elements = {
 \usepackage{etoolbox}
 \makeatletter
 \patchcmd\@item{{\@breaklabel} }{{\@breaklabel}}{}{}
+% Fix bug in expdlist's way of breaking the line after long item label
+\def\breaklabel{%
+    \def\@breaklabel{%
+        \leavevmode\par
+        % now a hack because Sphinx inserts \leavevmode after term node
+        \def\leavevmode{\def\leavevmode{\unhbox\voidb@x}}%
+    }%
+}
 \makeatother
 
 % Make Examples/etc section headers smaller and more compact


### PR DESCRIPTION
This builds upon #8654 (else reduced left margin reveals another bug of LaTeX package ``expdlist``, as explained [here](https://github.com/scipy/scipy/pull/8654#issuecomment-377918038)).

The goal is to get deeply nested lists less likely to overflow in right margin. We only reduce slightly from ``60pt`` to ``50pt`` the indentation, except for top level descriptions (whose items are labeled ``Parameters`` etc...) which is set with ``15pt`` indentation.

Additionally, only those items are in bold italic; the parameters are in bold, not italic.

Relates to #8655 (see screenshots there for worst-case scenarii)