### PR TITLE
BLD: (DOC) Let PDF contain maximal depth bookmarks for navigation

### DIFF
--- a/doc/postprocess.py
+++ b/doc/postprocess.py
@@ -39,26 +39,14 @@ def process_html(fn, lines):
 
 def process_tex(lines):
     """
-    Remove unnecessary section titles from the LaTeX file. (not anymore!)
-
-    And fix autosummary LaTeX bug in Sphinx < 1.7.3
+    Fix autosummary LaTeX bug in Sphinx < 1.7.3
     (cf https://github.com/sphinx-doc/sphinx/issues/4790)
+
     """
     new_lines = []
     for line in lines:
-        # line = re.sub(r'^\s*\\strong{See Also:}\s*$', r'\paragraph{See Also}', line)
-
         line = line.replace(r'p{0.5\linewidth}', r'\X{1}{2}')
 
-        # if (line.startswith(r'\section{scipy.')
-        #     or line.startswith(r'\subsection{scipy.')
-        #     or line.startswith(r'\subsubsection{scipy.')
-        #     or line.startswith(r'\paragraph{scipy.')
-        #     or line.startswith(r'\subparagraph{scipy.')
-        #     ):
-        #     pass # skip!
-        # else:
-        #     new_lines.append(line)
         new_lines.append(line)
     return new_lines
 

--- a/doc/postprocess.py
+++ b/doc/postprocess.py
@@ -39,26 +39,27 @@ def process_html(fn, lines):
 
 def process_tex(lines):
     """
-    Remove unnecessary section titles from the LaTeX file.
+    Remove unnecessary section titles from the LaTeX file. (not anymore!)
 
     And fix autosummary LaTeX bug in Sphinx < 1.7.3
     (cf https://github.com/sphinx-doc/sphinx/issues/4790)
     """
     new_lines = []
     for line in lines:
-        line = re.sub(r'^\s*\\strong{See Also:}\s*$', r'\paragraph{See Also}', line)
+        # line = re.sub(r'^\s*\\strong{See Also:}\s*$', r'\paragraph{See Also}', line)
 
         line = line.replace(r'p{0.5\linewidth}', r'\X{1}{2}')
 
-        if (line.startswith(r'\section{scipy.')
-            or line.startswith(r'\subsection{scipy.')
-            or line.startswith(r'\subsubsection{scipy.')
-            or line.startswith(r'\paragraph{scipy.')
-            or line.startswith(r'\subparagraph{scipy.')
-            ):
-            pass # skip!
-        else:
-            new_lines.append(line)
+        # if (line.startswith(r'\section{scipy.')
+        #     or line.startswith(r'\subsection{scipy.')
+        #     or line.startswith(r'\subsubsection{scipy.')
+        #     or line.startswith(r'\paragraph{scipy.')
+        #     or line.startswith(r'\subparagraph{scipy.')
+        #     ):
+        #     pass # skip!
+        # else:
+        #     new_lines.append(line)
+        new_lines.append(line)
     return new_lines
 
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -216,6 +216,14 @@ latex_elements = {
 % Fix: ≠ is unknown to XeLaTeX's default font Latin Modern
 \usepackage{newunicodechar}
 \newunicodechar{≠}{\ensuremath{\neq}}
+% Get PDF to use maximal depth bookmarks
+\hypersetup{bookmarksdepth=subparagraph}
+% reduce hyperref warnings
+\pdfstringdefDisableCommands{%
+  \let\sphinxupquote\empty
+  \let\sphinxstyleliteralintitle\empty
+  \let\sphinxstyleemphasis\empty
+}
 ''',
     # Latex figure (float) alignment
     #

--- a/doc/source/tutorial/index.rst
+++ b/doc/source/tutorial/index.rst
@@ -6,7 +6,6 @@ SciPy Tutorial
 
 .. raw:: latex
 
-   \setcounter{tocdepth}{2}% for PDF bookmarks
    \addtocontents{toc}{\protect\setcounter{tocdepth}{2}}
 
 .. toctree::
@@ -30,5 +29,4 @@ SciPy Tutorial
 
 .. raw:: latex
 
-   \setcounter{tocdepth}{1}
    \addtocontents{toc}{\protect\setcounter{tocdepth}{1}}


### PR DESCRIPTION
For this to work well, the post-processing of tex file is almost
completely canceled. All that remains is a fix to an autosummary bug
which is backported from Sphinx 1.7.3.