### PR TITLE
Fix dblquad and tplquad not accepting float boundaries

### DIFF
--- a/scipy/integrate/quadpack.py
+++ b/scipy/integrate/quadpack.py
@@ -526,11 +526,11 @@ def dblquad(func, a, b, gfun, hfun, args=(), epsabs=1.49e-8, epsrel=1.49e-8):
         first argument and x the second argument.
     a, b : float
         The limits of integration in x: `a` < `b`
-    gfun : callable
+    gfun : callable or float
         The lower boundary curve in y which is a function taking a single
-        floating point argument (x) and returning a floating point result: a
-        lambda function can be useful here.
-    hfun : callable
+        floating point argument (x) and returning a floating point result
+        or a float indicating a constant boundary curve.
+    hfun : callable or float
         The upper boundary curve in y (same requirements as `gfun`).
     args : sequence, optional
         Extra arguments to pass to `func`.
@@ -572,8 +572,11 @@ def dblquad(func, a, b, gfun, hfun, args=(), epsabs=1.49e-8, epsrel=1.49e-8):
         (0.6666666666666667, 7.401486830834377e-15)
 
     """
+    
     def temp_ranges(*args):
-        return [gfun(args[0]), hfun(args[0])]
+        return [gfun(args[0]) if callable(gfun) else gfun,
+                hfun(args[0]) if callable(hfun) else hfun]
+        
     return nquad(func, [temp_ranges, [a, b]], args=args,
             opts={"epsabs": epsabs, "epsrel": epsrel})
 
@@ -593,16 +596,17 @@ def tplquad(func, a, b, gfun, hfun, qfun, rfun, args=(), epsabs=1.49e-8,
         order (z, y, x).
     a, b : float
         The limits of integration in x: `a` < `b`
-    gfun : function
+    gfun : function or float
         The lower boundary curve in y which is a function taking a single
-        floating point argument (x) and returning a floating point result:
-        a lambda function can be useful here.
-    hfun : function
+        floating point argument (x) and returning a floating point result
+        or a float indicating a constant boundary curve.
+    hfun : function or float
         The upper boundary curve in y (same requirements as `gfun`).
-    qfun : function
+    qfun : function or float
         The lower boundary surface in z.  It must be a function that takes
-        two floats in the order (x, y) and returns a float.
-    rfun : function
+        two floats in the order (x, y) and returns a float or a float
+        indicating a constant boundary surface.
+    rfun : function or float
         The upper boundary surface in z. (Same requirements as `qfun`.)
     args : tuple, optional
         Extra arguments to pass to `func`.
@@ -654,10 +658,12 @@ def tplquad(func, a, b, gfun, hfun, qfun, rfun, args=(), epsabs=1.49e-8,
     # Stupid different API...
 
     def ranges0(*args):
-        return [qfun(args[1], args[0]), rfun(args[1], args[0])]
+        return [qfun(args[1], args[0]) if callable(qfun) else qfun,
+                rfun(args[1], args[0]) if callable(rfun) else rfun]
 
     def ranges1(*args):
-        return [gfun(args[0]), hfun(args[0])]
+        return [gfun(args[0]) if callable(gfun) else gfun,
+                hfun(args[0]) if callable(hfun) else hfun]
 
     ranges = [ranges0, ranges1, [a, b]]
     return nquad(func, ranges, args=args,

--- a/scipy/integrate/tests/test_quadpack.py
+++ b/scipy/integrate/tests/test_quadpack.py
@@ -262,6 +262,11 @@ class TestQuad(object):
         args = 1, 2
         assert_quad(dblquad(func, 1, 2, g, h, args=args),35./6 + 9*.5)
 
+    def test_double_integral3(self):
+        def func(x0, x1):
+            return x0 + x1 + 1 + 2
+        assert_quad(dblquad(func, 1, 2, 1, 2),6.)
+        
     def test_triple_integral(self):
         # 9) Triple Integral test
         def simpfunc(z, y, x, t):      # Note order of arguments.


### PR DESCRIPTION
This is a simple fix to make dblquad() and tplquad() functions accept numbers (instead of just functions) as boundaries for the integration. I'm not sure if the previous behaviour was a bug or done like that on purpose, but since nquad() (which dblquad and tplquad use) accepts numbers as boundaries, it seemed inconsistent to me.

I also changed the documentation and added a simple unit test to reflect this change.