### PR TITLE
DOC: Replace deprecated matplotlib kwarg

### DIFF
--- a/scipy/special/_logsumexp.py
+++ b/scipy/special/_logsumexp.py
@@ -5,6 +5,7 @@ from scipy._lib._util import _asarray_validated
 
 __all__ = ["logsumexp"]
 
+
 def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
     """Compute the log of the sum of exponentials of input elements.
 
@@ -35,6 +36,7 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
         as NaN. Default is False (no sign information).
 
         .. versionadded:: 0.16.0
+
     Returns
     -------
     res : ndarray
@@ -91,7 +93,7 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
     """
     a = _asarray_validated(a, check_finite=False)
     if b is not None:
-        a, b = np.broadcast_arrays(a,b)
+        a, b = np.broadcast_arrays(a, b)
         if np.any(b == 0):
             a = a + 0.  # promote to at least float
             a[b == 0] = -np.inf

--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -153,7 +153,7 @@ def binned_statistic(x, values, statistic='mean',
     >>> bin_centers = bin_edges[1:] - bin_width/2
 
     >>> plt.figure()
-    >>> plt.hist(samples, bins=50, normed=True, histtype='stepfilled',
+    >>> plt.hist(samples, bins=50, density=True, histtype='stepfilled',
     ...          alpha=0.2, label='histogram of data')
     >>> plt.plot(x, x_pdf, 'r-', label='analytical pdf')
     >>> plt.hlines(bin_means, bin_edges[:-1], bin_edges[1:], colors='g', lw=2,

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -6609,7 +6609,7 @@ class rv_histogram(rv_continuous):
     >>> import matplotlib.pyplot as plt
     >>> X = np.linspace(-5.0, 5.0, 100)
     >>> plt.title("PDF from Template")
-    >>> plt.hist(data, normed=True, bins=100)
+    >>> plt.hist(data, density=True, bins=100)
     >>> plt.plot(X, hist_dist.pdf(X), label='PDF')
     >>> plt.plot(X, hist_dist.cdf(X), label='CDF')
     >>> plt.show()

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -202,7 +202,7 @@ Generate random numbers:
 
 And compare the histogram:
 
->>> ax.hist(r, normed=True, histtype='stepfilled', alpha=0.2)
+>>> ax.hist(r, density=True, histtype='stepfilled', alpha=0.2)
 >>> ax.legend(loc='best', frameon=False)
 >>> plt.show()
 

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -109,7 +109,7 @@ def bayes_mvs(data, alpha=0.90):
     >>> import matplotlib.pyplot as plt
     >>> fig = plt.figure()
     >>> ax = fig.add_subplot(111)
-    >>> ax.hist(data, bins=100, normed=True, label='Histogram of data')
+    >>> ax.hist(data, bins=100, density=True, label='Histogram of data')
     >>> ax.vlines(res_mean.statistic, 0, 0.5, colors='r', label='Estimated mean')
     >>> ax.axvspan(res_mean.minmax[0],res_mean.minmax[1], facecolor='r',
     ...            alpha=0.2, label=r'Estimated mean (95% limits)')


### PR DESCRIPTION
In the CircleCI output, apart from many many other warnings, matplotlib emits warning about `normed` keyword is deprecated and replaced with `density` keyword. This replaces the keywords.

Also there was an issue with the missing blank line in docstring of special.logsumexp which is handled.