### PR TITLE
BUG: special: Use a stricter tolerance for the chndtr calculation.

### DIFF
--- a/scipy/special/cdflib/cumchn.f
+++ b/scipy/special/cdflib/cumchn.f
@@ -76,7 +76,7 @@ C     .. Statement Functions ..
       LOGICAL qsmall
 C     ..
 C     .. Data statements ..
-      DATA eps/1.0D-5/
+      DATA eps/1.0D-15/
       DATA abstol/1.0D-300/
 C     ..
 C     .. Statement Function definitions ..

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -218,10 +218,28 @@ class TestCephes(object):
 
     def test_chndtr(self):
         assert_equal(cephes.chndtr(0,1,0),0.0)
-        p = cephes.chndtr(np.linspace(20, 25, 5), 2, 1.07458615e+02)
-        assert_allclose(p, [1.21805009e-09, 2.81979982e-09, 6.25652736e-09,
-                            1.33520017e-08, 2.74909967e-08],
-                        rtol=1e-6, atol=0)
+
+        # Each row holds (x, nu, lam, expected_value)
+        # These values were computed using Wolfram Alpha with
+        #     CDF[NoncentralChiSquareDistribution[nu, lam], x]
+        values = np.array([
+            [25.00, 20.0, 400, 4.1210655112396197139e-57],
+            [25.00, 8.00, 250, 2.3988026526832425878e-29],
+            [0.001, 8.00, 40., 5.3761806201366039084e-24],
+            [0.010, 8.00, 40., 5.45396231055999457039e-20],
+            [20.00, 2.00, 107, 1.39390743555819597802e-9],
+            [22.50, 2.00, 107, 7.11803307138105870671e-9],
+            [25.00, 2.00, 107, 3.11041244829864897313e-8],
+            [3.000, 2.00, 1.0, 0.62064365321954362734],
+            [350.0, 300., 10., 0.93880128006276407710],
+            [100.0, 13.5, 10., 0.99999999650104210949],
+            [700.0, 20.0, 400, 0.99999999925680650105],
+            [150.0, 13.5, 10., 0.99999999999999983046],
+            [160.0, 13.5, 10., 0.99999999999999999518],  # 1.0
+        ])
+        cdf = cephes.chndtr(values[:, 0], values[:, 1], values[:, 2])
+        assert_allclose(cdf, values[:, 3], rtol=1e-12)
+
         assert_almost_equal(cephes.chndtr(np.inf, np.inf, 0), 2.0)
         assert_almost_equal(cephes.chndtr(2, 1, np.inf), 0.0)
         assert_(np.isnan(cephes.chndtr(np.nan, 1, 2)))


### PR DESCRIPTION
The relative tolerance for the size of term to be sufficiently small
to stop the sum of the series is decreased from 1e-5 to 1e-15.
The old tolerance of 1e-5 might have been appropriate for single precision
(cf. gh-8398), but we use double precision now.

This change improves the behavior reported in gh-8665, but it is not a
complete fix.  The CDF still has a "plateau", but it is much closer to 1
than it was:

	In [6]: x
	Out[6]: array([ 800,  900, 1000, 1100, 1200, 1300, 1400])

	In [7]: chndtr(x, 20, 500).tolist()
	Out[7]:
	[0.999999985441363,
	 0.9999999999996506,
	 0.9999999999998254,
	 0.9999999999998254,
	 0.9999999999998254,
	 0.9999999999998254,
	 0.9999999999998254]