### PR TITLE
 BUG: optimize: partial fix to linprog fails to detect infeasibility #8664

### DIFF
--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -888,7 +888,6 @@ def _postprocess(
              2 : Problem appears to be infeasible
              3 : Problem appears to be unbounded
              4 : Serious numerical difficulties encountered
-             5 : Other
 
     message : str
         A string descriptor of the exit status of the optimization.
@@ -976,7 +975,7 @@ def _postprocess(
     tol = np.sqrt(tol)  # Somewhat arbitrary, but status 5 is very unusual
     if status == 0 and ((slack < -tol).any() or (np.abs(con) > tol).any() or
                         (x < lb - tol).any() or (x > ub + tol).any()):
-        status = 5
+        status = 4
         message = ("The solution does not satisfy the constraints, yet "
                    "no errors were raised and there is no certificate of "
                    "infeasibility or unboundedness. This is known to occur "
@@ -1265,7 +1264,9 @@ def _get_delta(
                             "approached. However, if you see this frequently, "
                             "your problem may be numerically challenging. "
                             "If you cannot improve the formulation, consider "
-                            "setting 'lstsq' to True.", OptimizeWarning)
+                            "setting 'lstsq' to True. Consider also setting "
+                            "`presolve` to True, if it is not already.",
+                            OptimizeWarning)
                         lstsq = True
                 else:
                     raise e
@@ -1897,7 +1898,6 @@ def _linprog_ip(
                  2 : Problem appears to be infeasible
                  3 : Problem appears to be unbounded
                  4 : Serious numerical difficulties encountered
-                 5 : Other
 
         nit : int
             The number of iterations performed.

--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -1697,9 +1697,11 @@ def _ip_hsd(A, b, c, c0, alpha0, beta, maxiter, disp, tol,
                 x, y, z, tau, kappa = _do_step(
                     x, y, z, tau, kappa, d_x, d_y, d_z, d_tau, d_kappa, alpha)
 
-        except (LinAlgError, FloatingPointError):
+        except (LinAlgError, FloatingPointError,
+                ValueError, ZeroDivisionError):
             # this can happen when sparse solver is used and presolve
-            # is turned off. I've never seen it otherwise.
+            # is turned off. Also observed ValueError in AppVeyor Python 3.6
+            # Win32 build (PR #8676). I've never seen it otherwise.
             status = 4
             message = _get_message(status)
             break

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -963,6 +963,23 @@ class TestLinprogIPSparse(BaseTestLinprogIP):
 class TestLinprogIPDense(BaseTestLinprogIP):
     options = {"sparse": False}
 
+    def test_bug_8664(self):
+        # Very weak test. Ideally should run for all options and should
+        # detect infeasibility for all options.
+        c = [4]
+        A_ub = [[2], [5]]
+        b_ub = [4, 4]
+        A_eq = [[0], [-8], [9]]
+        b_eq = [3, 2, 10]
+        with suppress_warnings() as sup:
+            sup.filter(RuntimeWarning)
+            sup.filter(OptimizeWarning, "Solving system with option...")
+            o = {key: self.options[key] for key in self.options}
+            o["presolve"] = False
+            res = linprog(c, A_ub, b_ub, A_eq, b_eq, options=o,
+                          method=self.method)
+        assert_(not res.success, "incorrectly reported success")
+
 
 class TestLinprogIPSparsePresolve(BaseTestLinprogIP):
     options = {"sparse": True, "_sparse_presolve": True}

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -859,6 +859,22 @@ class BaseTestLinprogIP(LinprogCommonTests):
                       options=o)
         _assert_unbounded(res)
 
+    def test_bug_8664(self):
+        # Weak test. Ideally should _detect infeasibility_ for all options.
+        c = [4]
+        A_ub = [[2], [5]]
+        b_ub = [4, 4]
+        A_eq = [[0], [-8], [9]]
+        b_eq = [3, 2, 10]
+        with suppress_warnings() as sup:
+            sup.filter(RuntimeWarning)
+            sup.filter(OptimizeWarning, "Solving system with option...")
+            o = {key: self.options[key] for key in self.options}
+            o["presolve"] = False
+            res = linprog(c, A_ub, b_ub, A_eq, b_eq, options=o,
+                          method=self.method)
+        assert_(not res.success, "incorrectly reported success")
+
 
 class TestLinprogIPSpecific:
     method = "interior-point"
@@ -962,23 +978,6 @@ class TestLinprogIPSparse(BaseTestLinprogIP):
 
 class TestLinprogIPDense(BaseTestLinprogIP):
     options = {"sparse": False}
-
-    def test_bug_8664(self):
-        # Very weak test. Ideally should run for all options and should
-        # detect infeasibility for all options.
-        c = [4]
-        A_ub = [[2], [5]]
-        b_ub = [4, 4]
-        A_eq = [[0], [-8], [9]]
-        b_eq = [3, 2, 10]
-        with suppress_warnings() as sup:
-            sup.filter(RuntimeWarning)
-            sup.filter(OptimizeWarning, "Solving system with option...")
-            o = {key: self.options[key] for key in self.options}
-            o["presolve"] = False
-            res = linprog(c, A_ub, b_ub, A_eq, b_eq, options=o,
-                          method=self.method)
-        assert_(not res.success, "incorrectly reported success")
 
 
 class TestLinprogIPSparsePresolve(BaseTestLinprogIP):


### PR DESCRIPTION
Commit 87bbd71 is not intended to be part of this. It is part of #8641.
I accidentally branched from my `origin/master` instead of `upstream/master`, and I accidentally added a commit to my `origin/master` previously. Ugh. I'll try not to make this mistake in the future. And next time if it does happen, I'll remove the unwanted commit on my end before pushing. 

In any case, this is a partial fix to #8664. It doesn't actually detect the infeasibility with presolve turned off - but that is what presolve is for. Ideally the solver will give the correct output with presolve off or on, sparse or dense. But for now requiring that the user leave on the default presolve should be sufficient.