### PR TITLE
DOC: Add interp1d-next/previous example to tutorial

### DIFF
--- a/doc/source/tutorial/interpolate.rst
+++ b/doc/source/tutorial/interpolate.rst
@@ -58,7 +58,39 @@ its use, for linear and cubic spline interpolation:
    >>> plt.show()
 
 ..   :caption: One-dimensional interpolation using the
-..             class :obj:`interpolate.interp1d`
+..             class :obj:`interpolate.interp1d` with
+..             kind equals `linear` and `cubic`.
+
+
+Another set of interpolations in `interp1d` is `nearest`, `previous`, and
+`next`, where they return the nearest, previous, or next point along the
+x-axis. Nearest and next can be thought of as a special case of a causal
+interpolating filter. The following example demonstrates their use, using the
+same data as in the previous example:
+
+.. plot::
+
+   >>> from scipy.interpolate import interp1d
+
+   >>> x = np.linspace(0, 10, num=11, endpoint=True)
+   >>> y = np.cos(-x**2/9.0)
+   >>> f = interp1d(x, y)
+   >>> f2 = interp1d(x, y, kind='cubic')
+
+   >>> xnew = np.linspace(0, 10, num=1001, endpoint=True)
+   >>> import matplotlib.pyplot as plt
+   >>> f1 = interp1d(x, y, kind='nearest')
+   >>> f2 = interp1d(x, y, kind='previous')
+   >>> f3 = interp1d(x, y, kind='next')
+   >>> plt.plot(x, y, 'o')
+   >>> plt.plot(xnew, f1(xnew), '-', xnew, f2(xnew), '--', xnew, f3(xnew), ':')
+   >>> plt.legend(['data', 'nearest', 'previous', 'next'], loc='best')
+   >>> plt.show()
+
+..   :caption: One-dimensional interpolation using the
+..             class :obj:`interpolate.interp1d` with
+..             kind equals `nearest`, `previous`, and
+..             `next`.
 
 
 Multivariate data interpolation (:func:`griddata`)

--- a/doc/source/tutorial/interpolate.rst
+++ b/doc/source/tutorial/interpolate.rst
@@ -74,14 +74,12 @@ same data as in the previous example:
 
    >>> x = np.linspace(0, 10, num=11, endpoint=True)
    >>> y = np.cos(-x**2/9.0)
-   >>> f = interp1d(x, y)
-   >>> f2 = interp1d(x, y, kind='cubic')
-
-   >>> xnew = np.linspace(0, 10, num=1001, endpoint=True)
-   >>> import matplotlib.pyplot as plt
    >>> f1 = interp1d(x, y, kind='nearest')
    >>> f2 = interp1d(x, y, kind='previous')
    >>> f3 = interp1d(x, y, kind='next')
+
+   >>> xnew = np.linspace(0, 10, num=1001, endpoint=True)
+   >>> import matplotlib.pyplot as plt
    >>> plt.plot(x, y, 'o')
    >>> plt.plot(xnew, f1(xnew), '-', xnew, f2(xnew), '--', xnew, f3(xnew), ':')
    >>> plt.legend(['data', 'nearest', 'previous', 'next'], loc='best')


### PR DESCRIPTION
Adding an example using `interp1d` with `nearest`, `previous`, and `next` to the tutorial, as suggested by @ev-br in #8572. Using some wording of @Phillip-M-Feldman in said pull request.

I changed it from the original example to use the same example as was already in the tutorial. I think it is more illustrative that way.