### PR TITLE
TST: netcdf: explicit mmap=True in test

### DIFF
--- a/scipy/io/tests/test_netcdf.py
+++ b/scipy/io/tests/test_netcdf.py
@@ -247,7 +247,7 @@ def test_itemset_no_segfault_on_readonly():
     with suppress_warnings() as sup:
         sup.filter(RuntimeWarning,
                    "Cannot close a netcdf_file opened with mmap=True, when netcdf_variables or arrays referring to its data still exist")
-        with netcdf_file(filename, 'r') as f:
+        with netcdf_file(filename, 'r', mmap=True) as f:
             time_var = f.variables['time']
 
     # time_var.assignValue(42) should raise a RuntimeError--not seg. fault!


### PR DESCRIPTION
The mmap= doesn't default to true on pypy.