### PR TITLE
TST: bump tolerances in tests

### DIFF
--- a/scipy/optimize/_trustregion_constr/tests/test_projections.py
+++ b/scipy/optimize/_trustregion_constr/tests/test_projections.py
@@ -49,9 +49,6 @@ class TestProjections(TestCase):
                 x2 = scipy.linalg.lstsq(At_dense, z)[0]
                 assert_array_almost_equal(x, x2)
 
-    @pytest.mark.xfail((sys.platform == "win32" and
-                        platform.architecture()[0] == "32bit"),
-                        reason="Required precision not achieved for win32.")
     def test_iterative_refinements_sparse(self):
         A_dense = np.array([[1, 2, 3, 4, 0, 5, 0, 7],
                             [0, 8, 7, 0, 1, 5, 9, 0],
@@ -67,9 +64,11 @@ class TestProjections(TestCase):
             for z in test_points:
                 # Test if x is in the null_space
                 x = Z.matvec(z)
-                assert_array_almost_equal(A.dot(x), 0, decimal=14)
+                atol = 1e-13 * abs(x).max()
+                err = abs(A.dot(x)).max()
+                assert_allclose(A.dot(x), 0, atol=atol)
                 # Test orthogonality
-                assert_array_almost_equal(orthogonality(A, x), 0, decimal=16)
+                assert_allclose(orthogonality(A, x), 0, atol=1e-13)
 
     def test_rowspace_sparse(self):
         A_dense = np.array([[1, 2, 3, 4, 0, 5, 0, 7],

--- a/scipy/special/tests/test_orthogonal.py
+++ b/scipy/special/tests/test_orthogonal.py
@@ -531,7 +531,7 @@ def test_roots_gegenbauer():
     # to a scaled down copy of T_n(x) there.
     vgq(rootf(0), orth.eval_chebyt, weightf(0), -1., 1., 5)
     vgq(rootf(0), orth.eval_chebyt, weightf(0), -1., 1., 25)
-    vgq(rootf(0), orth.eval_chebyt, weightf(0), -1., 1., 100)
+    vgq(rootf(0), orth.eval_chebyt, weightf(0), -1., 1., 100, atol=1e-12)
 
     x, w = sc.roots_gegenbauer(5, 2, False)
     y, v, m = sc.roots_gegenbauer(5, 2, True)
@@ -549,7 +549,7 @@ def test_roots_chebyt():
     weightf = orth.chebyt(5).weight_func
     verify_gauss_quad(sc.roots_chebyt, orth.eval_chebyt, weightf, -1., 1., 5)
     verify_gauss_quad(sc.roots_chebyt, orth.eval_chebyt, weightf, -1., 1., 25)
-    verify_gauss_quad(sc.roots_chebyt, orth.eval_chebyt, weightf, -1., 1., 100)
+    verify_gauss_quad(sc.roots_chebyt, orth.eval_chebyt, weightf, -1., 1., 100, atol=1e-12)
 
     x, w = sc.roots_chebyt(5, False)
     y, v, m = sc.roots_chebyt(5, True)
@@ -589,7 +589,7 @@ def test_roots_chebyc():
     weightf = orth.chebyc(5).weight_func
     verify_gauss_quad(sc.roots_chebyc, orth.eval_chebyc, weightf, -2., 2., 5)
     verify_gauss_quad(sc.roots_chebyc, orth.eval_chebyc, weightf, -2., 2., 25)
-    verify_gauss_quad(sc.roots_chebyc, orth.eval_chebyc, weightf, -2., 2., 100)
+    verify_gauss_quad(sc.roots_chebyc, orth.eval_chebyc, weightf, -2., 2., 100, atol=1e-12)
 
     x, w = sc.roots_chebyc(5, False)
     y, v, m = sc.roots_chebyc(5, True)


### PR DESCRIPTION
Bump tolerances upward in special/orthogonal and optimize/trustregion-constr tests.

Both of these are currently failing on manylinux docker images, and it looks the required test tolerances are overly strict and can be safely bumped upwards.

cf. gh-8603