### PR TITLE
BLD: special: fix build vs. dd_real.h package

### DIFF
--- a/scipy/special/_round.h
+++ b/scipy/special/_round.h
@@ -7,7 +7,7 @@
 
 #include <numpy/npy_math.h>
 #include "_c99compat.h"
-#include "cephes/dd_real.h"
+#include "cephes/dd_idefs.h"
 
 
 double add_round_up(double a, double b)

--- a/scipy/special/_test_round.pyx
+++ b/scipy/special/_test_round.pyx
@@ -14,18 +14,6 @@ cdef extern from "_round.h":
 cdef extern from "numpy/npy_math.h":
     int npy_isnan(double) nogil
 
-cimport numpy as np
-
-cdef extern from "numpy/ufuncobject.h":
-    int PyUFunc_getfperr() nogil
-
-cdef public int wrap_PyUFunc_getfperr() nogil:
-    """
-    Call PyUFunc_getfperr in a context where PyUFunc_API array is initialized;
-    this avoids messing with the UNIQUE_SYMBOL #defines
-    """
-    return PyUFunc_getfperr()
-
 
 def have_fenv():
     old_round = fegetround()

--- a/scipy/special/setup.py
+++ b/scipy/special/setup.py
@@ -130,11 +130,10 @@ def configuration(parent_package='',top_path=None):
 
     # testing for _round.h
     config.add_extension('_test_round',
-                         sources=['_test_round.c', 'sf_error.c'],
-                         depends=['_round.h'] + cephes_hdr + cephes_src,
+                         sources=['_test_round.c'],
+                         depends=['_round.h', 'cephes/dd_idefs.h'],
                          include_dirs=[numpy.get_include()] + inc_dirs,
-                         extra_info=get_info('npymath'),
-                         libraries=['sc_cephes'])
+                         extra_info=get_info('npymath'))
 
     config.add_data_files('tests/*.py')
     config.add_data_files('tests/data/README')


### PR DESCRIPTION
The header dd_real.h should not be included in _ufuncs_cxx or
_test_round extensions, because it defines extern symbols. 
The header dd_idefs.h OTOH is fine to include.

This PR fixes the build on some platforms (whether the missing symbols
cause problems or not seems to vary).