### PR TITLE
ENH: optimize: call callback with a copy for scipy.optimize

### DIFF
--- a/scipy/optimize/_trustregion.py
+++ b/scipy/optimize/_trustregion.py
@@ -218,9 +218,9 @@ def _minimize_trust_region(fun, x0, args=(), jac=None, hess=None, hessp=None,
 
         # append the best guess, call back, increment the iteration count
         if return_all:
-            allvecs.append(x)
+            allvecs.append(np.copy(x))
         if callback is not None:
-            callback(x)
+            callback(np.copy(x))
         k += 1
 
         # check if the gradient is small enough to stop

--- a/scipy/optimize/_trustregion_constr/minimize_trustregion_constr.py
+++ b/scipy/optimize/_trustregion_constr/minimize_trustregion_constr.py
@@ -415,7 +415,7 @@ def _minimize_trustregion_constr(fun, x0, args, grad,
                                           state.constr_penalty,
                                           state.cg_stop_cond)
             state.status = None
-            if callback is not None and callback(state.x, state):
+            if callback is not None and callback(np.copy(state.x), state):
                 state.status = 3
             elif state.optimality < gtol and state.constr_violation < gtol:
                 state.status = 1
@@ -452,7 +452,7 @@ def _minimize_trustregion_constr(fun, x0, args, grad,
                                          state.barrier_parameter,
                                          state.cg_stop_cond)
             state.status = None
-            if callback is not None and callback(state.x, state):
+            if callback is not None and callback(np.copy(state.x), state):
                 state.status = 3
             elif state.optimality < gtol and state.constr_violation < gtol:
                 state.status = 1

--- a/scipy/optimize/lbfgsb.py
+++ b/scipy/optimize/lbfgsb.py
@@ -337,7 +337,7 @@ def _minimize_lbfgsb(fun, x0, args=(), jac=None, bounds=None,
             # new iteration
             n_iterations += 1
             if callback is not None:
-                callback(x)
+                callback(np.copy(x))
 
             if n_iterations >= maxiter:
                 task[:] = 'STOP: TOTAL NO. of ITERATIONS REACHED LIMIT'

--- a/scipy/optimize/slsqp.py
+++ b/scipy/optimize/slsqp.py
@@ -180,6 +180,7 @@ def fmin_slsqp(func, x0, eqcons=(), f_eqcons=None, ieqcons=(), f_ieqcons=None,
     """
     if disp is not None:
         iprint = disp
+
     opts = {'maxiter': iter,
             'ftol': acc,
             'iprint': iprint,
@@ -426,7 +427,7 @@ def _minimize_slsqp(func, x0, args=(), jac=None, bounds=None,
 
         # call callback if major iteration has incremented
         if callback is not None and majiter > majiter_prev:
-            callback(x)
+            callback(np.copy(x))
 
         # Print the status of the current iterate if iprint > 2 and the
         # major iteration has incremented


### PR DESCRIPTION
Ensure arrays passed to optimizer callback functions are not modified later on by the optimizer.

This was the case for LBFGS and SLSQP.
The trustregion solvers could pass on the same array twice (but didn't modify it).

Supercedes gh-8430
Closes gh-8419