### PR TITLE
DOC: Specify encoding of rst file, remove an ambiguity in an SVD example

### DIFF
--- a/scipy/linalg/decomp_svd.py
+++ b/scipy/linalg/decomp_svd.py
@@ -360,9 +360,9 @@ def null_space(A, rcond=None):
 
     >>> from scipy.linalg import null_space
     >>> A = np.array([[1, 1], [1, 1]])
-    >>> null_space(A)
-    array([[-0.70710678],
-           [ 0.70710678]])
+    >>> null_space(A) * np.sign(A[0,0])  # Remove the sign ambiguity of the vector
+    array([[ 0.70710678],
+           [-0.70710678]])
 
     Two-dimensional null space:
 

--- a/scipy/linalg/decomp_svd.py
+++ b/scipy/linalg/decomp_svd.py
@@ -360,7 +360,8 @@ def null_space(A, rcond=None):
 
     >>> from scipy.linalg import null_space
     >>> A = np.array([[1, 1], [1, 1]])
-    >>> null_space(A) * np.sign(A[0,0])  # Remove the sign ambiguity of the vector
+    >>> ns = null_space(A)
+    >>> ns * np.sign(ns[0,0])  # Remove the sign ambiguity of the vector
     array([[ 0.70710678],
            [-0.70710678]])
 

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -755,7 +755,10 @@ def check_doctests_testfile(fname, verbose, ns=None,
         return results
 
     full_name = fname
-    text = open(fname).read()
+    if sys.version_info.major <= 2:
+        text = open(fname).read()
+    else:
+        text = open(fname, encoding='utf-8').read()
 
     PSEUDOCODE = set(['some_function', 'some_module', 'import example',
                       'ctypes.CDLL',     # likely need compiling, skip it

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -756,9 +756,11 @@ def check_doctests_testfile(fname, verbose, ns=None,
 
     full_name = fname
     if sys.version_info.major <= 2:
-        text = open(fname).read()
+        with open(fname) as f:
+            text = f.read()
     else:
-        text = open(fname, encoding='utf-8').read()
+        with open(fname, encoding='utf-8') as f:
+            text = f.read()
 
     PSEUDOCODE = set(['some_function', 'some_module', 'import example',
                       'ctypes.CDLL',     # likely need compiling, skip it


### PR DESCRIPTION
During execution of `python runtests.py -g --regime-check` open a text file using encoding utf-8 under Python 3, leave as is for Py2.
Multiply a 2x1 matrix by the sign of the first element to remove some ambiguity in a linalg.svd null_space example.

Closes gh-8703.

