### PR TITLE
MAINT: WIP: Add checks for NaN to peak finding functions

### DIFF
--- a/scipy/signal/_peak_finding.py
+++ b/scipy/signal/_peak_finding.py
@@ -3,6 +3,7 @@ Functions for identifying peaks in signals.
 """
 from __future__ import division, print_function, absolute_import
 
+import warnings
 import math
 import numpy as np
 
@@ -375,6 +376,9 @@ def peak_prominences(x, peaks, wlen=None):
     x = np.asarray(x, order='C', dtype=np.float64)
     if x.ndim != 1:
         raise ValueError('`x` must have exactly one dimension')
+    if np.isnan(np.sum(x)):
+        warnings.warn("encountered NaN in `x` which may lead to unexpected "
+                      "results", RuntimeWarning)
 
     peaks = np.asarray(peaks)
     if peaks.size == 0:
@@ -514,6 +518,9 @@ def peak_widths(x, peaks, rel_height=0.5, prominence_data=None, wlen=None):
     x = np.asarray(x, order='C', dtype=np.float64)
     if x.ndim != 1:
         raise ValueError('`x` must have exactly one dimension')
+    if np.isnan(np.sum(x)):
+        warnings.warn("encountered NaN in `x` which may lead to unexpected "
+                      "results", RuntimeWarning)
 
     peaks = np.asarray(peaks)
     if peaks.size == 0:
@@ -857,6 +864,9 @@ def find_peaks(x, height=None, threshold=None, distance=None,
         raise ValueError('`x` must have exactly one dimension')
     if distance is not None and distance < 1:
         raise ValueError('`distance` must be greater or equal to 1')
+    if np.isnan(np.sum(x)):
+        warnings.warn("encountered NaN in `x` which may lead to unexpected "
+                      "results", RuntimeWarning)
 
     peaks = _argmaxima1d(x)
     properties = {}

--- a/scipy/signal/tests/test_peak_finding.py
+++ b/scipy/signal/tests/test_peak_finding.py
@@ -404,6 +404,11 @@ class TestPeakProminences(object):
         with raises(ValueError, match='wlen'):
             peak_prominences(np.arange(10), [3, 5], wlen=1)
 
+    def test_warning(self):
+        with pytest.warns(RuntimeWarning):
+            # Ensure that warning about nan value is raised
+            peak_prominences([0, 1, 0, np.nan], [1])
+
 
 class TestPeakWidths(object):
 
@@ -522,6 +527,12 @@ class TestPeakWidths(object):
         # width_height == x counts as intersection -> nearest 1 is chosen
         assert_allclose(peak_widths(x, peaks=[5], rel_height=2/3),
                         [(4.,), (1.,), (3.,), (7.,)])
+
+    def test_warnings(self):
+        data = peak_prominences([0, 1, 0], [1])
+        with pytest.warns(RuntimeWarning):
+            # Ensure that warning about nan value is raised
+            peak_widths([0, 1, np.nan], [1], prominence_data=data)
 
 
 def test_unpack_condition_args():
@@ -679,6 +690,11 @@ class TestFindPeaks(object):
             find_peaks(np.ones((2, 2)))
         with raises(ValueError, match="distance"):
             find_peaks(np.arange(10), distance=-1)
+
+    def test_warning(self):
+        with pytest.warns(RuntimeWarning):
+            # Ensure that warning about nan value is raised
+            find_peaks([0, 1, np.nan])
 
 
 class TestFindPeaksCwt(object):


### PR DESCRIPTION
As suggested in #8705 this PR adds if statements that check for NaN in the supplied vector `x` and raise a warning if one is found to the functions `find_peaks, peak_widths, peak_prominences` in the signal module.

@larsoner I'm not to happy with this. The simplest  & fastest solution I could think of is to check with `np.isnan(np.sum(x))` for a NaN value. However this adds a noticeable speed penalty (up to ~10%) for in my opinion very little benefit. 
But I will leave this decision to more experienced devs. ;)