### PR TITLE
MAINT: fix an import cycle sparse -> special -> integrate -> optimize -> sparse

### DIFF
--- a/benchmarks/benchmarks/sparse_linalg_onenormest.py
+++ b/benchmarks/benchmarks/sparse_linalg_onenormest.py
@@ -5,8 +5,9 @@ from __future__ import division, print_function, absolute_import
 import numpy as np
 
 try:
-    import scipy.sparse.linalg
     import scipy.sparse
+    import scipy.special  # import cycle workaround for some versions
+    import scipy.sparse.linalg
 except ImportError:
     pass
 

--- a/scipy/_lib/tests/test_import_cycles.py
+++ b/scipy/_lib/tests/test_import_cycles.py
@@ -1,0 +1,52 @@
+from __future__ import division, print_function, absolute_import
+
+import sys
+import subprocess
+
+
+MODULES = [
+    "scipy.cluster",
+    "scipy.cluster.vq",
+    "scipy.cluster.hierarchy",
+    "scipy.constants",
+    "scipy.fftpack",
+    "scipy.integrate",
+    "scipy.interpolate",
+    "scipy.io",
+    "scipy.io.arff",
+    "scipy.io.harwell_boeing",
+    "scipy.io.idl",
+    "scipy.io.matlab",
+    "scipy.io.netcdf",
+    "scipy.io.wavfile",
+    "scipy.linalg",
+    "scipy.linalg.blas",
+    "scipy.linalg.cython_blas",
+    "scipy.linalg.lapack",
+    "scipy.linalg.cython_lapack",
+    "scipy.linalg.interpolative",
+    "scipy.misc",
+    "scipy.ndimage",
+    "scipy.odr",
+    "scipy.optimize",
+    "scipy.signal",
+    "scipy.signal.windows",
+    "scipy.sparse",
+    "scipy.sparse.linalg",
+    "scipy.sparse.csgraph",
+    "scipy.spatial",
+    "scipy.spatial.distance",
+    "scipy.special",
+    "scipy.stats",
+    "scipy.stats.distributions",
+    "scipy.stats.mstats",
+]
+
+
+def test_modules_importable():
+    # Check that all modules are importable in a new Python
+    # process. This is not necessarily true (esp on Python 2) if there
+    # are import cycles present.
+    for module in MODULES:
+        cmd = 'import {}'.format(module)
+        subprocess.check_call([sys.executable, '-c', cmd])

--- a/scipy/special/_ellip_harm_2.pyx
+++ b/scipy/special/_ellip_harm_2.pyx
@@ -4,7 +4,6 @@ import ctypes
 from libc.math cimport sqrt, fabs
 from libc.stdlib cimport free
 from numpy import nan
-import scipy.integrate
 
 cdef extern from "Python.h":
     object PyCapsule_New(void *pointer, char *name, void *destructor)
@@ -107,6 +106,7 @@ cdef double _F_integrand4(double t, void *user_data) nogil:
 
 def _ellipsoid(double h2, double k2, int n, int p, double s):
     import scipy.special._ellip_harm_2 as mod
+    from scipy.integrate import quad
 
     cdef _ellip_data_t data
 
@@ -126,8 +126,8 @@ def _ellipsoid(double h2, double k2, int n, int p, double s):
 
     try:
         capsule = PyCapsule_New(<void*>&data, NULL, NULL)
-        res, err = scipy.integrate.quad(LowLevelCallable.from_cython(mod, "_F_integrand", capsule), 0, 1/s,
-                                        epsabs=1e-300, epsrel=1e-15)
+        res, err = quad(LowLevelCallable.from_cython(mod, "_F_integrand", capsule), 0, 1/s,
+                                                     epsabs=1e-300, epsrel=1e-15)
     finally:
         free(bufferp)
     if err > 1e-10*fabs(res) + 1e-290:
@@ -138,6 +138,7 @@ def _ellipsoid(double h2, double k2, int n, int p, double s):
 
 def _ellipsoid_norm(double h2, double k2, int n, int p):
     import scipy.special._ellip_harm_2 as mod
+    from scipy.integrate import quad
 
     cdef _ellip_data_t data
 
@@ -159,8 +160,6 @@ def _ellipsoid_norm(double h2, double k2, int n, int p):
     k = sqrt(k2)
     try:
         capsule = PyCapsule_New(<void*>&data, NULL, NULL)
-
-        quad = scipy.integrate.quad
 
         wvar = (-0.5, -0.5)
 


### PR DESCRIPTION
The cycle made 'import scipy.sparse.linalg' fail on Python 2 when first
Scipy import.

Break the cycle at special -> integrate dependency.

Add a test that checks all submodules are importable in a new Python
process.

Work around the import cycle in the benchmarks (so that affected versions can 
be benchmarked).