### PR TITLE
ENH: remove an avoidable overflow in scipy.stats.norminvgauss.pdf()

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -3258,7 +3258,9 @@ class norminvgauss_gen(rv_continuous):
     def _pdf(self, x, a, b):
         gamma = np.sqrt(a**2 - b**2)
         fac1 = a / np.pi * np.exp(gamma)
-        sq = np.sqrt(1 + x**2)
+        x = np.asarray(x)
+        one = np.ones_like(x)
+        sq = np.hypot(one, x)  # reduce overflows
         return fac1 * sc.k1e(a * sq) * np.exp(b*x - a*sq) / sq
 
     def _rvs(self, a, b):

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -3258,9 +3258,7 @@ class norminvgauss_gen(rv_continuous):
     def _pdf(self, x, a, b):
         gamma = np.sqrt(a**2 - b**2)
         fac1 = a / np.pi * np.exp(gamma)
-        x = np.asarray(x)
-        one = np.ones_like(x)
-        sq = np.hypot(one, x)  # reduce overflows
+        sq = np.hypot(1, x)  # reduce overflows
         return fac1 * sc.k1e(a * sq) * np.exp(b*x - a*sq) / sq
 
     def _rvs(self, a, b):


### PR DESCRIPTION
Uses `np.hypot()` instead of sqrt-of-sum-of-squares to avoid an overflow in `scipy.stats.norminvgauss.pdf()`.
