### PR TITLE
DEP: deprecate linalg.solve kw "sym_pos"

### DIFF
--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -166,6 +166,10 @@ def solve(a, b, sym_pos=False, lower=False, overwrite_a=False,
 
     # Backwards compatibility - old keyword.
     if sym_pos:
+        warn('Use of the "sym_pos" keyword is deprecated '
+             'and this keyword will be removed in future '
+             'versions of SciPy. Use assume_a="pos" instead.',
+             DeprecationWarning, stacklevel=2)
         assume_a = 'pos'
 
     if assume_a not in ('gen', 'sym', 'her', 'pos'):

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -541,7 +541,7 @@ class TestSolve(object):
         a = [[2, 3], [3, 5]]
         for lower in [0, 1]:
             for b in ([[1, 0], [0, 1]], [1, 0]):
-                x = solve(a, b, sym_pos=1, lower=lower)
+                x = solve(a, b, lower=lower, assume_a='pos')
                 assert_array_almost_equal(dot(a, x), b)
 
     def test_simple_sym_complex(self):
@@ -550,7 +550,7 @@ class TestSolve(object):
                   [[1j, 1j],
                    [0, 2]],
                   ]:
-            x = solve(a, b, sym_pos=1)
+            x = solve(a, b, assume_a='pos')
             assert_array_almost_equal(dot(a, x), b)
 
     def test_simple_complex(self):
@@ -605,7 +605,7 @@ class TestSolve(object):
                 a[i, j] = a[j, i]
         for i in range(4):
             b = random([n])
-            x = solve(a, b, sym_pos=1)
+            x = solve(a, b, assume_a='pos')
             assert_array_almost_equal(dot(a, x), b)
 
     def test_random_sym_complex(self):
@@ -619,7 +619,7 @@ class TestSolve(object):
                 a[i, j] = conjugate(a[j, i])
         b = random([n])+2j*random([n])
         for i in range(2):
-            x = solve(a, b, sym_pos=1)
+            x = solve(a, b, assume_a='pos')
             assert_array_almost_equal(dot(a, x), b)
 
     def test_check_finite(self):

--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -1031,7 +1031,8 @@ def _get_solver(sparse=False, lstsq=False, sym_pos=True, cholesky=True):
             # this seems to cache the matrix factorization, so solving
             # with multiple right hand sides is much faster
             def solve(M, r, sym_pos=sym_pos):
-                return sp.linalg.solve(M, r, sym_pos=sym_pos)
+                solve_kw = 'pos' if sym_pos else 'gen'
+                return sp.linalg.solve(M, r, assume_a=solve_kw)
 
     return solve
 


### PR DESCRIPTION
`sym_pos` keyword functionality is already covered in the more general `assume_a` keyword. Also it only points to a single type of array while the function itself is meant for a more general set of arrays. This PR adds the deprecation warning emitting code.