### PR TITLE
BUG: interpolate: allow list inputs for make_interp_spline(..., k=2)

### DIFF
--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -749,6 +749,10 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
         c = np.ascontiguousarray(c, dtype=_get_dtype(c.dtype))
         return BSpline.construct_fast(t, c, k, axis=axis)
 
+    x = _as_float_array(x, check_finite)
+    y = _as_float_array(y, check_finite)
+    k = int(k)
+
     # come up with a sensible knot vector, if needed
     if t is None:
         if deriv_l is None and deriv_r is None:
@@ -764,10 +768,7 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
         else:
             t = _augknt(x, k)
 
-    x = _as_float_array(x, check_finite)
-    y = _as_float_array(y, check_finite)
     t = _as_float_array(t, check_finite)
-    k = int(k)
 
     axis = axis % y.ndim
     y = np.rollaxis(y, axis)    # now internally interp axis is zero

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -936,6 +936,13 @@ class TestInterp(object):
             y[-1] = z
             assert_raises(ValueError, make_interp_spline, x, y)
 
+    @pytest.mark.parametrize('k', [1, 2, 3, 5])
+    def test_list_input(self, k):
+        # regression test for gh-8714: TypeError for x, y being lists and k=2
+        x = list(range(10))
+        y = [a**2 for a in x]
+        make_interp_spline(x, y, k=k)
+
     def test_multiple_rhs(self):
         yy = np.c_[np.sin(self.xx), np.cos(self.xx)]
         der_l = [(1, [1., 2.])]


### PR DESCRIPTION
Make sure `make_interp_spline` inputs are arrays before doing all-array manipulations with them.

Fixes gh-8714

I'd advocate for backporting to maintenance/1.1.x : this seems mostly harmless. OTOH it's by no means critical.