### PR TITLE
CI: don't use pyproject.toml in the CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,7 +101,7 @@ before_install:
   - cd builds
   - travis_retry pip install --upgrade pip setuptools wheel
   - travis_retry pip install cython==0.25.2
-  - travis_retry pip install $NUMPYSPEC
+  - if [ -n "$NUMPYSPEC" ]; then travis_retry pip install $NUMPYSPEC; fi
   - travis_retry pip install --upgrade pytest pytest-xdist pytest-faulthandler mpmath argparse Pillow codecov
   - travis_retry pip install gmpy2  # speeds up mpmath (scipy.special tests)
   - |
@@ -143,7 +143,7 @@ script:
         echo "setup.py build"
         python tools/suppress_output.py python setup.py build
         echo "pip wheel"
-        python tools/suppress_output.py pip wheel .
+        python tools/suppress_output.py pip wheel --no-build-isolation .
         pip install --no-cache-dir scipy*.whl
         USE_WHEEL_BUILD="--no-build"
     elif [ "${USE_SDIST}" == "1" ]; then
@@ -156,7 +156,7 @@ script:
         # (see https://github.com/pypa/pip/issues/4242)
         # and some shenanigans are needed to make it work.
         echo "pip install"
-        python ../tools/suppress_output.py pip install --no-cache-dir --build="$HOME/builds" --upgrade "file://`echo -n $PWD/scipy*`#egg=scipy" -v
+        python ../tools/suppress_output.py pip install --no-cache-dir --no-build-isolation --build="$HOME/builds" --upgrade "file://`echo -n $PWD/scipy*`#egg=scipy" -v
         cd ..
         USE_WHEEL_BUILD="--no-build"
     fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -159,7 +159,7 @@ build_script:
       $env:Path += ";$MINGW"
       $env:NPY_NUM_BUILD_JOBS = "4"
       mkdir dist
-      pip wheel -v -v -v --wheel-dir=dist .
+      pip wheel --no-build-isolation -v -v -v --wheel-dir=dist .
 
       ls dist -r | Foreach-Object {
           appveyor PushArtifact $_.FullName


### PR DESCRIPTION
Pass on --no-build-isolation to pip, so that it does not break the numpy
version fixing etc. careful environment setup in the CI.

<s>In principle we might want to check the build isolation stuff works in the CI,
but that's for another day.</s>

<s>Make the python 3.5 wheel build use build isolation, the rest of the builds don't.</s>

Trying to use build isolation gives the error (https://travis-ci.org/scipy/scipy/jobs/366522826)
```
pip wheel
Processing /home/travis/build/scipy/scipy
  Could not find a version that satisfies the requirement numpy==1.8.2 (from versions: 1.9.0, 1.9.1, 1.9.2, 1.9.3, 1.10.0, 1.10.1, 1.10.2, 1.10.3, 1.10.4, 1.11.0, 1.11.1rc1, 1.11.1, 1.11.2rc1, 1.11.2, 1.11.3, 1.12.0b1, 1.12.0rc1, 1.12.0rc2, 1.12.0, 1.12.1rc1, 1.12.1, 1.13.0rc1, 1.13.0rc2, 1.13.0, 1.13.1, 1.13.3, 1.14.0rc1, 1.14.0, 1.14.1, 1.14.2)
No matching distribution found for numpy==1.8.2
```
Fixing that probably is for another day...