### PR TITLE
BUG: Fix _get_output in scipy.ndimage to support string

### DIFF
--- a/scipy/ndimage/_ni_support.py
+++ b/scipy/ndimage/_ni_support.py
@@ -75,7 +75,7 @@ def _get_output(output, input, shape=None):
         output = numpy.zeros(shape, dtype=input.dtype.name)
     elif type(output) in [type(type), type(numpy.zeros((4,)).dtype)]:
         output = numpy.zeros(shape, dtype=output)
-    elif type(output) in string_types:
+    elif isinstance(output, string_types):
         output = numpy.typeDict[output]
         output = numpy.zeros(shape, dtype=output)
     elif output.shape != shape:

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -1645,6 +1645,15 @@ class TestNdimage:
             result = out if returned is None else returned
             assert_array_almost_equal(result, [1])
 
+    def test_geometric_transform_with_string_output(self):
+        data = numpy.array([1])
+
+        def mapping(x):
+            return x
+        out = ndimage.geometric_transform(data, mapping, output='f')
+        assert_(out.dtype is numpy.dtype('f'))
+        assert_array_almost_equal(out, [1])
+
     def test_map_coordinates01(self):
         data = numpy.array([[4, 1, 3, 2],
                             [7, 6, 8, 5],
@@ -1700,6 +1709,13 @@ class TestNdimage:
             returned = ndimage.map_coordinates(data, idx, output=out)
             result = out if returned is None else returned
             assert_array_almost_equal(result, expected)
+
+    def test_map_coordinates_with_string_output(self):
+        data = numpy.array([[1]])
+        idx = numpy.indices(data.shape)
+        out = ndimage.map_coordinates(data, idx, output='f')
+        assert_(out.dtype is numpy.dtype('f'))
+        assert_array_almost_equal(out, [[1]])
 
     @pytest.mark.skipif('win32' in sys.platform or numpy.intp(0).itemsize < 8,
                         reason="do not run on 32 bit or windows (no sparse memory)")
@@ -1997,6 +2013,12 @@ class TestNdimage:
             returned = ndimage.affine_transform(data, [[1]], output=out)
             result = out if returned is None else returned
             assert_array_almost_equal(result, [1])
+
+    def test_affine_transform_with_string_output(self):
+        data = numpy.array([1])
+        out = ndimage.affine_transform(data, [[1]], output='f')
+        assert_(out.dtype is numpy.dtype('f'))
+        assert_array_almost_equal(out, [1])
 
     def test_shift01(self):
         data = numpy.array([1])


### PR DESCRIPTION
This PR fixes behavior when `output` is string. Following code works in Python3, but not in Python2.
```
import numpy as np
import scipy.ndimage

a = np.empty((100, 100))
scipy.ndimage.rotate(a, 1, output='f')
```