### PR TITLE
BUG: signal: restore backward-compatible import for hanning

### DIFF
--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -330,12 +330,16 @@ from ._peak_finding import *
 from .windows import get_window  # keep this one in signal namespace
 
 
-# deal with * -> windows.* deprecation
+# deal with * -> windows.* doc-only soft-deprecation
 deprecated_windows = ('boxcar', 'triang', 'parzen', 'bohman', 'blackman',
                       'nuttall', 'blackmanharris', 'flattop', 'bartlett',
                       'barthann', 'hamming', 'kaiser', 'gaussian',
                       'general_gaussian', 'chebwin', 'slepian', 'cosine',
                       'hann', 'exponential', 'tukey')
+
+# backward compatibility imports for actually deprecated windows not
+# in the above list
+from .windows import hanning
 
 
 def deco(name):

--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -350,6 +350,9 @@ def deco(name):
         return f(*args, **kwargs)
 
     wrapped.__name__ = name
+    wrapped.__module__ = 'scipy.signal'
+    if hasattr(f, '__qualname__'):
+        wrapped.__qualname__ = f.__qualname__
 
     if f.__doc__ is not None:
         lines = f.__doc__.splitlines()

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -1,5 +1,7 @@
 from __future__ import division, print_function, absolute_import
 
+import pickle
+
 import numpy as np
 from numpy import array
 from numpy.testing import (assert_array_almost_equal, assert_array_equal,
@@ -631,3 +633,8 @@ def test_deprecation():
     if dep_hann.__doc__ is not None:  # can be None with `-OO` mode
         assert_('signal.hann is deprecated' in dep_hann.__doc__)
         assert_('deprecated' not in windows.hann.__doc__)
+
+
+def test_deprecated_pickleable():
+    dep_hann2 = pickle.loads(pickle.dumps(dep_hann))
+    assert_(dep_hann2 is dep_hann)


### PR DESCRIPTION
Ensure scipy.signal.hanning remains available.

It doesn't need the additional docs-only deprecation since np.deprecate
has already added appropriate deprecation messages.

(This bug my bad, I had misunderstood the scipy.signal window move and soft-deprecation.)