### PR TITLE
MAINT: stats: A bit of clean up.

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -14,13 +14,13 @@ from scipy import optimize
 from scipy import integrate
 import scipy.special as sc
 from scipy._lib._numpy_compat import broadcast_to
+from scipy._lib._util import _lazyselect, _lazywhere
 
 from . import _stats
 from ._tukeylambda_stats import (tukeylambda_variance as _tlvar,
                                  tukeylambda_kurtosis as _tlkurt)
 from ._distn_infrastructure import (get_distribution_names, _kurtosis,
-                                    _lazyselect, _lazywhere, _ncx2_cdf,
-                                    _ncx2_log_pdf, _ncx2_pdf,
+                                    _ncx2_cdf, _ncx2_log_pdf, _ncx2_pdf,
                                     rv_continuous, _skew, valarray)
 from ._constants import _XMIN, _EULER, _ZETA3, _XMAX, _LOGXMAX
 

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -7,13 +7,14 @@ from __future__ import division, print_function, absolute_import
 from scipy import special
 from scipy.special import entr, logsumexp, betaln, gammaln as gamln
 from scipy._lib._numpy_compat import broadcast_to
+from scipy._lib._util import _lazywhere
 
 from numpy import floor, ceil, log, exp, sqrt, log1p, expm1, tanh, cosh, sinh
 
 import numpy as np
 
 from ._distn_infrastructure import (
-        rv_discrete, _lazywhere, _ncx2_pdf, _ncx2_cdf, get_distribution_names)
+        rv_discrete, _ncx2_pdf, _ncx2_cdf, get_distribution_names)
 
 
 class binom_gen(rv_discrete):

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -15,10 +15,10 @@ import warnings
 
 from scipy.misc import doccer
 from ._distr_params import distcont, distdiscrete
-from scipy._lib._util import check_random_state, _lazywhere, _lazyselect
+from scipy._lib._util import check_random_state
 from scipy._lib._util import _valarray as valarray
 
-from scipy.special import (comb, chndtr, entr, rel_entr, kl_div, xlogy, ive)
+from scipy.special import (comb, chndtr, entr, rel_entr, xlogy, ive)
 
 # for root finding for discrete distribution ppf, and max likelihood estimation
 from scipy import optimize
@@ -29,11 +29,9 @@ from scipy import integrate
 # to approximate the pdf of a continuous distribution given its cdf
 from scipy.misc import derivative
 
-from numpy import (arange, putmask, ravel, take, ones, shape, ndarray,
-                   product, reshape, zeros, floor, logical_and, log, sqrt, exp)
-
-from numpy import (place, argsort, argmax, vectorize,
-                   asarray, nan, inf, isinf, NINF, empty)
+from numpy import (arange, putmask, ravel, ones, shape, ndarray, zeros, floor,
+                   logical_and, log, sqrt, place, argmax, vectorize, asarray,
+                   nan, inf, isinf, NINF, empty)
 
 import numpy as np
 
@@ -562,12 +560,12 @@ def _parse_args_stats(self, %(shape_arg_str)s %(locscale_in)s, moments='mv'):
 
 
 # Both the continuous and discrete distributions depend on ncx2.
-# I think the function name ncx2 is an abbreviation for noncentral chi squared.
+# The function name ncx2 is an abbreviation for noncentral chi squared.
 
 def _ncx2_log_pdf(x, df, nc):
-    # We use (xs**2 + ns**2)/2 = (xs - ns)**2/2  + xs*ns, and include the factor
-    # of exp(-xs*ns) into the ive function to improve numerical stability
-    # at large values of xs. See also `rice.pdf`.
+    # We use (xs**2 + ns**2)/2 = (xs - ns)**2/2  + xs*ns, and include the
+    # factor of exp(-xs*ns) into the ive function to improve numerical
+    # stability at large values of xs. See also `rice.pdf`.
     df2 = df/2.0 - 1.0
     xs, ns = np.sqrt(x), np.sqrt(nc)
     res = xlogy(df2/2.0, x/nc) - 0.5*(xs - ns)**2
@@ -738,7 +736,7 @@ class rv_generic(object):
         self.__doc__ = self.__doc__.replace('(, ', '(').replace(', )', ')')
 
     def _construct_default_doc(self, longname=None, extradoc=None,
-                docdict=None, discrete='continuous'):
+                               docdict=None, discrete='continuous'):
         """Construct instance docstring from the default template."""
         if longname is None:
             longname = 'A'
@@ -2247,7 +2245,8 @@ class rv_continuous(rv_generic):
         if support_width <= 0:
             return loc_hat, scale_hat
 
-        # Compute the proposed support according to the loc and scale estimates.
+        # Compute the proposed support according to the loc and scale
+        # estimates.
         a_hat = loc_hat + a * scale_hat
         b_hat = loc_hat + b * scale_hat
 
@@ -2449,10 +2448,6 @@ def _drv2_ppfsingle(self, q, *args):  # Use basic bisection algorithm
         if (qb == q):
             return b
         if b <= a+1:
-            # testcase: return wrong number at lower index
-            # python -c "from scipy.stats import zipf;print zipf.ppf(0.01, 2)" wrong
-            # python -c "from scipy.stats import zipf;print zipf.ppf([0.01, 0.61, 0.77, 0.83], 2)"
-            # python -c "from scipy.stats import logser;print logser.ppf([0.1, 0.66, 0.86, 0.93], 0.6)"
             if qa > q:
                 return a
             else:
@@ -2655,8 +2650,8 @@ class rv_discrete(rv_generic):
 
     """
     def __new__(cls, a=0, b=inf, name=None, badvalue=None,
-                 moment_tol=1e-8, values=None, inc=1, longname=None,
-                 shapes=None, extradoc=None, seed=None):
+                moment_tol=1e-8, values=None, inc=1, longname=None,
+                shapes=None, extradoc=None, seed=None):
 
         if values is not None:
             # dispatch to a subclass
@@ -3178,8 +3173,8 @@ class rv_discrete(rv_generic):
         depending on the function, `func`. If it does exist, but the sum converges
         slowly, the accuracy of the result may be rather low. For instance, for
         ``zipf(4)``, accuracy for mean, variance in example is only 1e-5.
-        increasing `maxcount` and/or `chunksize` may improve the result, but may also
-        make zipf very slow.
+        increasing `maxcount` and/or `chunksize` may improve the result, but may
+        also make zipf very slow.
 
         The function is not vectorized.
 
@@ -3261,7 +3256,8 @@ def _expect(fun, lb, ub, x0, inc, maxcount=1000, tolerance=1e-10,
 def _iter_chunked(x0, x1, chunksize=4, inc=1):
     """Iterate from x0 to x1 in chunks of chunksize and steps inc.
 
-    x0 must be finite, x1 need not be. In the latter case, the iterator is infinite.
+    x0 must be finite, x1 need not be. In the latter case, the iterator is
+    infinite.
     Handles both x0 < x1 and x0 > x1. In the latter case, iterates downwards
     (make sure to set inc < 0.)
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -167,11 +167,11 @@ from numpy import array, asarray, ma, zeros
 
 from scipy._lib.six import callable, string_types
 from scipy._lib._version import NumpyVersion
+from scipy._lib._util import _lazywhere
 import scipy.special as special
 import scipy.linalg as linalg
 from . import distributions
 from . import mstats_basic
-from ._distn_infrastructure import _lazywhere
 from ._stats_mstats_common import _find_repeats, linregress, theilslopes
 from ._stats import _kendall_dis, _toint64, _weightedrankedtau
 


### PR DESCRIPTION
* Import _lazywhere and _lazyselect from their source in scipy._lib._util.
* In _distn_infrastructure.py:
  * Fix a comment about the meaning of 'ncx2'.
  * Remove some old comments about zipf and logser ppf() test cases.
  * Remove unused imports.
  * Some PEP 8 clean up.