### PR TITLE
DOC: use https urls in release documentation

### DIFF
--- a/doc/source/dev/releasing.rst
+++ b/doc/source/dev/releasing.rst
@@ -130,9 +130,12 @@ done in an automated fashion with `terryfy <https://github.com/MacPython/terryfy
 to PyPI step - we want to be able to check the wheels and put their checksums
 into README first)::
 
-  $ python wheel-uploader -n -v -c -w REPO_ROOT/release/installers -t win scipy 0.19.0
-  $ python wheel-uploader -n -v -c -w REPO_ROOT/release/installers -t macosx scipy 0.19.0
-  $ python wheel-uploader -n -v -c -w REPO_ROOT/release/installers -t manylinux1 scipy 0.19.0
+  $ python wheel-uploader -n -v -c -u https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com -w REPO_ROOT/release/installers -t win scipy 0.19.0
+  $ python wheel-uploader -n -v -c -u https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com -w REPO_ROOT/release/installers -t macosx scipy 0.19.0
+  $ python wheel-uploader -n -v -c -u https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com -w REPO_ROOT/release/installers -t manylinux1 scipy 0.19.0
+
+The correct URL to use is shown in https://github.com/MacPython/scipy-wheels
+and should agree with the above one.
 
 After this, we want to regenerate the README file, in order to have the MD5 and SHA256
 checksums of the just downloaded wheels in it.  Run::


### PR DESCRIPTION
Update the release instructions to download over https