### PR TITLE
BF/ENH: make minpack thread safe

### DIFF
--- a/scipy/optimize/minpack/chkder.f
+++ b/scipy/optimize/minpack/chkder.f
@@ -1,4 +1,5 @@
-      subroutine chkder(m,n,x,fvec,fjac,ldfjac,xp,fvecp,mode,err)
+      recursive
+     *subroutine chkder(m,n,x,fvec,fjac,ldfjac,xp,fvecp,mode,err)
       integer m,n,ldfjac,mode
       double precision x(n),fvec(m),fjac(ldfjac,n),xp(n),fvecp(m),
      *                 err(m)

--- a/scipy/optimize/minpack/dogleg.f
+++ b/scipy/optimize/minpack/dogleg.f
@@ -1,4 +1,5 @@
-      subroutine dogleg(n,r,lr,diag,qtb,delta,x,wa1,wa2)
+      recursive
+     *subroutine dogleg(n,r,lr,diag,qtb,delta,x,wa1,wa2)
       integer n,lr
       double precision delta
       double precision r(lr),diag(n),qtb(n),x(n),wa1(n),wa2(n)

--- a/scipy/optimize/minpack/dpmpar.f
+++ b/scipy/optimize/minpack/dpmpar.f
@@ -1,4 +1,5 @@
-      double precision function dpmpar(i)
+      recursive
+     *double precision function dpmpar(i)
       integer i
 c     **********
 c

--- a/scipy/optimize/minpack/enorm.f
+++ b/scipy/optimize/minpack/enorm.f
@@ -1,4 +1,5 @@
-      double precision function enorm(n,x)
+      recursive
+     *double precision function enorm(n,x)
       integer n
       double precision x(n)
 c     **********

--- a/scipy/optimize/minpack/fdjac1.f
+++ b/scipy/optimize/minpack/fdjac1.f
@@ -1,4 +1,5 @@
-      subroutine fdjac1(fcn,n,x,fvec,fjac,ldfjac,iflag,ml,mu,epsfcn,
+      recursive
+     *subroutine fdjac1(fcn,n,x,fvec,fjac,ldfjac,iflag,ml,mu,epsfcn,
      *                  wa1,wa2)
       integer n,ldfjac,iflag,ml,mu
       double precision epsfcn

--- a/scipy/optimize/minpack/fdjac2.f
+++ b/scipy/optimize/minpack/fdjac2.f
@@ -1,4 +1,5 @@
-      subroutine fdjac2(fcn,m,n,x,fvec,fjac,ldfjac,iflag,epsfcn,wa)
+      recursive
+     *subroutine fdjac2(fcn,m,n,x,fvec,fjac,ldfjac,iflag,epsfcn,wa)
       integer m,n,ldfjac,iflag
       double precision epsfcn
       double precision x(n),fvec(m),fjac(ldfjac,n),wa(m)

--- a/scipy/optimize/minpack/hybrd.f
+++ b/scipy/optimize/minpack/hybrd.f
@@ -1,7 +1,7 @@
-      recursive subroutine hybrd(fcn,n,x,fvec,xtol,maxfev,ml,mu,
-     *                           epsfcn,diag,mode,factor,nprint,
-     *                           info,nfev,fjac,ldfjac,r,lr,
-     *                           qtf,wa1,wa2,wa3,wa4)
+      recursive
+     *subroutine hybrd(fcn,n,x,fvec,xtol,maxfev,ml,mu,epsfcn,diag,
+     *                 mode,factor,nprint,info,nfev,fjac,ldfjac,r,lr,
+     *                 qtf,wa1,wa2,wa3,wa4)
       integer n,maxfev,ml,mu,mode,nprint,info,nfev,ldfjac,lr
       double precision xtol,epsfcn,factor
       double precision x(n),fvec(n),diag(n),fjac(ldfjac,n),r(lr),

--- a/scipy/optimize/minpack/hybrd.f
+++ b/scipy/optimize/minpack/hybrd.f
@@ -1,6 +1,7 @@
-      subroutine hybrd(fcn,n,x,fvec,xtol,maxfev,ml,mu,epsfcn,diag,
-     *                 mode,factor,nprint,info,nfev,fjac,ldfjac,r,lr,
-     *                 qtf,wa1,wa2,wa3,wa4)
+      recursive subroutine hybrd(fcn,n,x,fvec,xtol,maxfev,ml,mu,
+     *                           epsfcn,diag,mode,factor,nprint,
+     *                           info,nfev,fjac,ldfjac,r,lr,
+     *                           qtf,wa1,wa2,wa3,wa4)
       integer n,maxfev,ml,mu,mode,nprint,info,nfev,ldfjac,lr
       double precision xtol,epsfcn,factor
       double precision x(n),fvec(n),diag(n),fjac(ldfjac,n),r(lr),

--- a/scipy/optimize/minpack/hybrd1.f
+++ b/scipy/optimize/minpack/hybrd1.f
@@ -1,4 +1,5 @@
-      subroutine hybrd1(fcn,n,x,fvec,tol,info,wa,lwa)
+      recursive
+     *subroutine hybrd1(fcn,n,x,fvec,tol,info,wa,lwa)
       integer n,info,lwa
       double precision tol
       double precision x(n),fvec(n),wa(lwa)

--- a/scipy/optimize/minpack/hybrj.f
+++ b/scipy/optimize/minpack/hybrj.f
@@ -1,6 +1,7 @@
-      subroutine hybrj(fcn,n,x,fvec,fjac,ldfjac,xtol,maxfev,diag,mode,
-     *                 factor,nprint,info,nfev,njev,r,lr,qtf,wa1,wa2,
-     *                 wa3,wa4)
+      recursive subroutine hybrj(fcn,n,x,fvec,fjac,ldfjac,xtol,
+     *                           maxfev,diag,mode,factor,nprint,
+     *                           info,nfev,njev,r,lr,qtf,
+     *                           wa1,wa2,wa3,wa4)
       integer n,ldfjac,maxfev,mode,nprint,info,nfev,njev,lr
       double precision xtol,factor
       double precision x(n),fvec(n),fjac(ldfjac,n),diag(n),r(lr),

--- a/scipy/optimize/minpack/hybrj.f
+++ b/scipy/optimize/minpack/hybrj.f
@@ -1,7 +1,7 @@
-      recursive subroutine hybrj(fcn,n,x,fvec,fjac,ldfjac,xtol,
-     *                           maxfev,diag,mode,factor,nprint,
-     *                           info,nfev,njev,r,lr,qtf,
-     *                           wa1,wa2,wa3,wa4)
+      recursive
+     *subroutine hybrj(fcn,n,x,fvec,fjac,ldfjac,xtol,maxfev,diag,mode,
+     *                 factor,nprint,info,nfev,njev,r,lr,qtf,wa1,wa2,
+     *                 wa3,wa4)
       integer n,ldfjac,maxfev,mode,nprint,info,nfev,njev,lr
       double precision xtol,factor
       double precision x(n),fvec(n),fjac(ldfjac,n),diag(n),r(lr),

--- a/scipy/optimize/minpack/hybrj1.f
+++ b/scipy/optimize/minpack/hybrj1.f
@@ -1,4 +1,5 @@
-      subroutine hybrj1(fcn,n,x,fvec,fjac,ldfjac,tol,info,wa,lwa)
+      recursive
+     *subroutine hybrj1(fcn,n,x,fvec,fjac,ldfjac,tol,info,wa,lwa)
       integer n,ldfjac,info,lwa
       double precision tol
       double precision x(n),fvec(n),fjac(ldfjac,n),wa(lwa)

--- a/scipy/optimize/minpack/lmder.f
+++ b/scipy/optimize/minpack/lmder.f
@@ -1,7 +1,7 @@
-      recursive subroutine lmder(fcn,m,n,x,fvec,fjac,ldfjac,ftol,
-     *                           xtol,gtol,maxfev,diag,mode,factor,
-     *                           nprint,info,nfev,njev,
-     *                           ipvt,qtf,wa1,wa2,wa3,wa4)
+      recursive
+     *subroutine lmder(fcn,m,n,x,fvec,fjac,ldfjac,ftol,xtol,gtol,
+     *                 maxfev,diag,mode,factor,nprint,info,nfev,njev,
+     *                 ipvt,qtf,wa1,wa2,wa3,wa4)
       integer m,n,ldfjac,maxfev,mode,nprint,info,nfev,njev
       integer ipvt(n)
       double precision ftol,xtol,gtol,factor

--- a/scipy/optimize/minpack/lmder.f
+++ b/scipy/optimize/minpack/lmder.f
@@ -1,6 +1,7 @@
-      subroutine lmder(fcn,m,n,x,fvec,fjac,ldfjac,ftol,xtol,gtol,
-     *                 maxfev,diag,mode,factor,nprint,info,nfev,njev,
-     *                 ipvt,qtf,wa1,wa2,wa3,wa4)
+      recursive subroutine lmder(fcn,m,n,x,fvec,fjac,ldfjac,ftol,
+     *                           xtol,gtol,maxfev,diag,mode,factor,
+     *                           nprint,info,nfev,njev,
+     *                           ipvt,qtf,wa1,wa2,wa3,wa4)
       integer m,n,ldfjac,maxfev,mode,nprint,info,nfev,njev
       integer ipvt(n)
       double precision ftol,xtol,gtol,factor

--- a/scipy/optimize/minpack/lmder1.f
+++ b/scipy/optimize/minpack/lmder1.f
@@ -1,4 +1,5 @@
-      subroutine lmder1(fcn,m,n,x,fvec,fjac,ldfjac,tol,info,ipvt,wa,
+      recursive
+     *subroutine lmder1(fcn,m,n,x,fvec,fjac,ldfjac,tol,info,ipvt,wa,
      *                  lwa)
       integer m,n,ldfjac,info,lwa
       integer ipvt(n)

--- a/scipy/optimize/minpack/lmdif.f
+++ b/scipy/optimize/minpack/lmdif.f
@@ -1,6 +1,7 @@
-      subroutine lmdif(fcn,m,n,x,fvec,ftol,xtol,gtol,maxfev,epsfcn,
-     *                 diag,mode,factor,nprint,info,nfev,fjac,ldfjac,
-     *                 ipvt,qtf,wa1,wa2,wa3,wa4)
+      recursive subroutine lmdif(fcn,m,n,x,fvec,ftol,xtol,gtol,
+     *                           maxfev,epsfcn,diag,mode,factor,
+     *                           nprint,info,nfev,fjac,ldfjac,
+     *                           ipvt,qtf,wa1,wa2,wa3,wa4)
       integer m,n,maxfev,mode,nprint,info,nfev,ldfjac
       integer ipvt(n)
       double precision ftol,xtol,gtol,epsfcn,factor

--- a/scipy/optimize/minpack/lmdif.f
+++ b/scipy/optimize/minpack/lmdif.f
@@ -1,7 +1,7 @@
-      recursive subroutine lmdif(fcn,m,n,x,fvec,ftol,xtol,gtol,
-     *                           maxfev,epsfcn,diag,mode,factor,
-     *                           nprint,info,nfev,fjac,ldfjac,
-     *                           ipvt,qtf,wa1,wa2,wa3,wa4)
+      recursive
+     *subroutine lmdif(fcn,m,n,x,fvec,ftol,xtol,gtol,maxfev,epsfcn,
+     *                 diag,mode,factor,nprint,info,nfev,fjac,ldfjac,
+     *                 ipvt,qtf,wa1,wa2,wa3,wa4)
       integer m,n,maxfev,mode,nprint,info,nfev,ldfjac
       integer ipvt(n)
       double precision ftol,xtol,gtol,epsfcn,factor

--- a/scipy/optimize/minpack/lmdif1.f
+++ b/scipy/optimize/minpack/lmdif1.f
@@ -1,4 +1,5 @@
-      subroutine lmdif1(fcn,m,n,x,fvec,tol,info,iwa,wa,lwa)
+      recursive
+     *subroutine lmdif1(fcn,m,n,x,fvec,tol,info,iwa,wa,lwa)
       integer m,n,info,lwa
       integer iwa(n)
       double precision tol

--- a/scipy/optimize/minpack/lmpar.f
+++ b/scipy/optimize/minpack/lmpar.f
@@ -1,4 +1,5 @@
-      subroutine lmpar(n,r,ldr,ipvt,diag,qtb,delta,par,x,sdiag,wa1,
+      recursive
+     *subroutine lmpar(n,r,ldr,ipvt,diag,qtb,delta,par,x,sdiag,wa1,
      *                 wa2)
       integer n,ldr
       integer ipvt(n)

--- a/scipy/optimize/minpack/lmstr.f
+++ b/scipy/optimize/minpack/lmstr.f
@@ -1,4 +1,5 @@
-      subroutine lmstr(fcn,m,n,x,fvec,fjac,ldfjac,ftol,xtol,gtol,
+      recursive
+     *subroutine lmstr(fcn,m,n,x,fvec,fjac,ldfjac,ftol,xtol,gtol,
      *                 maxfev,diag,mode,factor,nprint,info,nfev,njev,
      *                 ipvt,qtf,wa1,wa2,wa3,wa4)
       integer m,n,ldfjac,maxfev,mode,nprint,info,nfev,njev

--- a/scipy/optimize/minpack/lmstr1.f
+++ b/scipy/optimize/minpack/lmstr1.f
@@ -1,4 +1,5 @@
-      subroutine lmstr1(fcn,m,n,x,fvec,fjac,ldfjac,tol,info,ipvt,wa,
+      recursive
+     *subroutine lmstr1(fcn,m,n,x,fvec,fjac,ldfjac,tol,info,ipvt,wa,
      *                  lwa)
       integer m,n,ldfjac,info,lwa
       integer ipvt(n)

--- a/scipy/optimize/minpack/qform.f
+++ b/scipy/optimize/minpack/qform.f
@@ -1,4 +1,5 @@
-      subroutine qform(m,n,q,ldq,wa)
+      recursive
+     *subroutine qform(m,n,q,ldq,wa)
       integer m,n,ldq
       double precision q(ldq,m),wa(m)
 c     **********

--- a/scipy/optimize/minpack/qrfac.f
+++ b/scipy/optimize/minpack/qrfac.f
@@ -1,4 +1,5 @@
-      subroutine qrfac(m,n,a,lda,pivot,ipvt,lipvt,rdiag,acnorm,wa)
+      recursive
+     *subroutine qrfac(m,n,a,lda,pivot,ipvt,lipvt,rdiag,acnorm,wa)
       integer m,n,lda,lipvt
       integer ipvt(lipvt)
       logical pivot

--- a/scipy/optimize/minpack/qrsolv.f
+++ b/scipy/optimize/minpack/qrsolv.f
@@ -1,4 +1,5 @@
-      subroutine qrsolv(n,r,ldr,ipvt,diag,qtb,x,sdiag,wa)
+      recursive
+     *subroutine qrsolv(n,r,ldr,ipvt,diag,qtb,x,sdiag,wa)
       integer n,ldr
       integer ipvt(n)
       double precision r(ldr,n),diag(n),qtb(n),x(n),sdiag(n),wa(n)

--- a/scipy/optimize/minpack/r1mpyq.f
+++ b/scipy/optimize/minpack/r1mpyq.f
@@ -1,4 +1,5 @@
-      subroutine r1mpyq(m,n,a,lda,v,w)
+      recursive
+     *subroutine r1mpyq(m,n,a,lda,v,w)
       integer m,n,lda
       double precision a(lda,n),v(n),w(n)
 c     **********

--- a/scipy/optimize/minpack/r1updt.f
+++ b/scipy/optimize/minpack/r1updt.f
@@ -1,4 +1,5 @@
-      subroutine r1updt(m,n,s,ls,u,v,w,sing)
+      recursive
+     *subroutine r1updt(m,n,s,ls,u,v,w,sing)
       integer m,n,ls
       logical sing
       double precision s(ls),u(m),v(n),w(m)

--- a/scipy/optimize/minpack/rwupdt.f
+++ b/scipy/optimize/minpack/rwupdt.f
@@ -1,4 +1,5 @@
-      subroutine rwupdt(n,r,ldr,w,b,alpha,cos,sin)
+      recursive
+     *subroutine rwupdt(n,r,ldr,w,b,alpha,cos,sin)
       integer n,ldr
       double precision alpha
       double precision r(ldr,n),w(n),b(n),cos(n),sin(n)

--- a/scipy/optimize/setup.py
+++ b/scipy/optimize/setup.py
@@ -1,5 +1,6 @@
 from __future__ import division, print_function, absolute_import
 
+import os.path
 from os.path import join
 
 from scipy._build_utils import numpy_nodepr_api
@@ -8,6 +9,8 @@ def configuration(parent_package='',top_path=None):
     from numpy.distutils.misc_util import Configuration
     from numpy.distutils.system_info import get_info
     config = Configuration('optimize',parent_package, top_path)
+    
+    include_dirs = [join(os.path.dirname(__file__), '..', '_lib', 'src')]
 
     minpack_src = [join('minpack','*f')]
     config.add_library('minpack',sources=minpack_src)
@@ -16,6 +19,7 @@ def configuration(parent_package='',top_path=None):
                          libraries=['minpack'],
                          depends=(["minpack.h","__minpack.h"]
                                   + minpack_src),
+                         include_dirs=include_dirs,
                          **numpy_nodepr_api)
 
     rootfind_src = [join('Zeros','*.c')]

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -162,6 +162,7 @@ class TestFSolve(object):
 
     def test_Dfun_can_raise(self):
         func = lambda x: x - np.array([10])
+
         def deriv_func(*args):
             raise ValueError('I raised')
 
@@ -348,15 +349,16 @@ class TestLeastSq(object):
         def func(*args):
             raise ValueError('I raised')
 
-        with assert_raises(ValueError, matches='I raised'):
+        with assert_raises(ValueError, match='I raised'):
             optimize.leastsq(func, x0=[0])
 
     def test_Dfun_can_raise(self):
         func = lambda x: x - np.array([10])
+
         def deriv_func(*args):
             raise ValueError('I raised')
 
-        with assert_raises(ValueError, matches='I raised'):
+        with assert_raises(ValueError, match='I raised'):
             optimize.leastsq(func, x0=[0], Dfun=deriv_func)
 
     def test_reentrant_func(self):


### PR DESCRIPTION
Replace global variables used to communicate between a minpack invocation and it's callbacks with the standard ccallback mechanism. This means that it is now safe to use minpack+callbacks on multiple threads.

Solves #1240 and #8700.
