### PR TITLE
BUG: Fix division by zero in trust-region optimization methods

### DIFF
--- a/scipy/optimize/_trustregion.py
+++ b/scipy/optimize/_trustregion.py
@@ -178,7 +178,8 @@ def _minimize_trust_region(fun, x0, args=(), jac=None, hess=None, hessp=None,
     k = 0
 
     # search for the function min
-    while True:
+    # do not even start if the gradient is small enough
+    while m.jac_mag >= gtol:
 
         # Solve the sub-problem.
         # This gives us the proposed step relative to the current position

--- a/scipy/optimize/tests/test_trustregion.py
+++ b/scipy/optimize/tests/test_trustregion.py
@@ -85,8 +85,22 @@ class TestTrustRegionSolvers(object):
             assert_(len(r_dogleg['allvecs']) < len(r_ncg['allvecs']))
 
     def test_trust_ncg_hessp(self):
-        for x0 in (self.easy_guess, self.hard_guess):
+        for x0 in (self.easy_guess, self.hard_guess, self.x_opt):
             r = minimize(rosen, x0, jac=rosen_der, hessp=rosen_hess_prod,
                          tol=1e-8, method='trust-ncg')
             assert_allclose(self.x_opt, r['x'])
 
+    def test_trust_ncg_start_in_optimum(self):
+        r = minimize(rosen, x0=self.x_opt, jac=rosen_der, hess=rosen_hess,
+                     tol=1e-8, method='trust-ncg')
+        assert_allclose(self.x_opt, r['x'])
+
+    def test_trust_krylov_start_in_optimum(self):
+        r = minimize(rosen, x0=self.x_opt, jac=rosen_der, hess=rosen_hess,
+                     tol=1e-8, method='trust-krylov')
+        assert_allclose(self.x_opt, r['x'])
+
+    def test_trust_exact_start_in_optimum(self):
+        r = minimize(rosen, x0=self.x_opt, jac=rosen_der, hess=rosen_hess,
+                     tol=1e-8, method='trust-exact')
+        assert_allclose(self.x_opt, r['x'])


### PR DESCRIPTION
Check convergence condition before starting iteration. Solves problem
with division by zero if we have a Jacobian with zero magnitude.
Add corresponding tests.
Fixes #8686.

Work done together @panvaf @lizweer @mezdahun