### PR TITLE
BUG: Handle UTF-8 input files under Py3 in doc postprocessing.

### DIFF
--- a/doc/postprocess.py
+++ b/doc/postprocess.py
@@ -6,6 +6,8 @@ Post-processes HTML and Latex files output by Sphinx.
 MODE is either 'html' or 'tex'.
 
 """
+import sys
+import io
 import re, optparse
 
 def main():
@@ -20,22 +22,29 @@ def main():
     if mode not in ('html', 'tex'):
         p.error('unknown mode %s' % mode)
 
+    def _open(fn, *args, **kwargs):
+        r"""Handle UTF-8 encoding when loading under Py3"""
+        # Issue is that default encoding under Py3 is
+        # locale dependent (might even be ASCII),
+        # so need to specify the encoding.  Py2 doesn't care.
+        if sys.version_info.major < 3:
+            return open(fn, *args, **kwargs)
+        return io.open(fn, *args, encoding='utf-8', **kwargs)
+
     for fn in args:
-        f = open(fn, 'r')
-        try:
+        with _open(fn, 'r') as f:
             if mode == 'html':
                 lines = process_html(fn, f.readlines())
             elif mode == 'tex':
                 lines = process_tex(f.readlines())
-        finally:
-            f.close()
 
-        f = open(fn, 'w')
-        f.write("".join(lines))
-        f.close()
+        with _open(fn, 'w') as f:
+            f.write("".join(lines))
+
 
 def process_html(fn, lines):
     return lines
+
 
 def process_tex(lines):
     """


### PR DESCRIPTION
`postprocessing.py` was opening a file with the default encoding coming from `locale`, which was failing whenever the default encoding was ASCII, as the file was UTF-8.
Use `io.open(fn , encoding='utf-8)` under Py3.
Wrap the file I/O in a `with` block to ensure proper cleanup.
