### PR TITLE
BUG: stats:  boltzmann wasn't setting the upper bound. 

### DIFF
--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -352,9 +352,10 @@ class hypergeom_gen(rv_discrete):
     def _logpmf(self, k, M, n, N):
         tot, good = M, n
         bad = tot - good
-        return betaln(good+1, 1) + betaln(bad+1,1) + betaln(tot-N+1, N+1)\
-            - betaln(k+1, good-k+1) - betaln(N-k+1,bad-N+k+1)\
-            - betaln(tot+1, 1)
+        result = (betaln(good+1, 1) + betaln(bad+1, 1) + betaln(tot-N+1, N+1) -
+                  betaln(k+1, good-k+1) - betaln(N-k+1, bad-N+k+1) -
+                  betaln(tot+1, 1))
+        return result
 
     def _pmf(self, k, M, n, N):
         # same as the following but numerically more precise
@@ -806,8 +807,9 @@ class dlaplace_gen(rv_discrete):
 
     def _ppf(self, q, a):
         const = 1 + exp(a)
-        vals = ceil(np.where(q < 1.0 / (1 + exp(-a)), log(q*const) / a - 1,
-                                                      -log((1-q) * const) / a))
+        vals = ceil(np.where(q < 1.0 / (1 + exp(-a)),
+                             log(q*const) / a - 1,
+                             -log((1-q) * const) / a))
         vals1 = vals - 1
         return np.where(self._cdf(vals1, a) >= q, vals1, vals)
 
@@ -862,16 +864,16 @@ class skellam_gen(rv_discrete):
 
     def _pmf(self, x, mu1, mu2):
         px = np.where(x < 0,
-                _ncx2_pdf(2*mu2, 2*(1-x), 2*mu1)*2,
-                _ncx2_pdf(2*mu1, 2*(1+x), 2*mu2)*2)
+                      _ncx2_pdf(2*mu2, 2*(1-x), 2*mu1)*2,
+                      _ncx2_pdf(2*mu1, 2*(1+x), 2*mu2)*2)
         # ncx2.pdf() returns nan's for extremely low probabilities
         return px
 
     def _cdf(self, x, mu1, mu2):
         x = floor(x)
         px = np.where(x < 0,
-                _ncx2_cdf(2*mu2, -2*x, 2*mu1),
-                1-_ncx2_cdf(2*mu1, 2*(x+1), 2*mu2))
+                      _ncx2_cdf(2*mu2, -2*x, 2*mu1),
+                      1 - _ncx2_cdf(2*mu1, 2*(x+1), 2*mu2))
         return px
 
     def _stats(self, mu1, mu2):

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -606,17 +606,22 @@ class boltzmann_gen(rv_discrete):
 
     .. math::
 
-        f(k) = (1-\exp(-\lambda) \exp(-\lambda k)/(1-\exp(-\lambda N))
+        f(k) = (1-\exp(-\lambda)) \exp(-\lambda k) / (1-\exp(-\lambda N))
 
     for :math:`k = 0,..., N-1`.
 
-    `boltzmann` takes :math:`\lambda` and :math:`N` as shape parameters.
+    `boltzmann` takes :math:`\lambda > 0` and :math:`N > 0` as shape parameters.
 
     %(after_notes)s
 
     %(example)s
 
     """
+    def _argcheck(self, lambda_, N):
+        self.a = 0
+        self.b = N - 1
+        return (lambda_ > 0) & (N > 0)
+
     def _pmf(self, k, lambda_, N):
         # boltzmann.pmf(k) =
         #               (1-exp(-lambda_)*exp(-lambda_*k)/(1-exp(-lambda_*N))
@@ -649,7 +654,7 @@ class boltzmann_gen(rv_discrete):
 
 
 boltzmann = boltzmann_gen(name='boltzmann',
-        longname='A truncated discrete exponential ')
+                          longname='A truncated discrete exponential ')
 
 
 class randint_gen(rv_discrete):

--- a/scipy/stats/tests/test_discrete_distns.py
+++ b/scipy/stats/tests/test_discrete_distns.py
@@ -1,8 +1,8 @@
 from __future__ import division, print_function, absolute_import 
 
-from scipy.stats import hypergeom, bernoulli
+from scipy.stats import hypergeom, bernoulli, boltzmann
 import numpy as np
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_almost_equal, assert_equal, assert_allclose
 
 def test_hypergeom_logpmf():
     # symmetries test
@@ -29,3 +29,21 @@ def test_hypergeom_logpmf():
     bernoulli_logpmf = bernoulli.logpmf(k,K/N)
     assert_almost_equal(hypergeom_logpmf, bernoulli_logpmf, decimal=12)
 
+
+def test_boltzmann_upper_bound():
+    k = np.arange(-3, 5)
+
+    N = 1
+    p = boltzmann.pmf(k, 0.123, N)
+    expected = k == 0
+    assert_equal(p, expected)
+
+    lam = np.log(2)
+    N = 3
+    p = boltzmann.pmf(k, lam, N)
+    expected = [0, 0, 0, 4/7, 2/7, 1/7, 0, 0]
+    assert_allclose(p, expected, rtol=1e-13)
+
+    c = boltzmann.cdf(k, lam, N)
+    expected = [0, 0, 0, 4/7, 6/7, 1, 1, 1]
+    assert_allclose(c, expected, rtol=1e-13)

--- a/scipy/stats/tests/test_discrete_distns.py
+++ b/scipy/stats/tests/test_discrete_distns.py
@@ -1,8 +1,9 @@
-from __future__ import division, print_function, absolute_import 
+from __future__ import division, print_function, absolute_import
 
 from scipy.stats import hypergeom, bernoulli, boltzmann
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_equal, assert_allclose
+
 
 def test_hypergeom_logpmf():
     # symmetries test
@@ -11,10 +12,10 @@ def test_hypergeom_logpmf():
     N = 50
     K = 10
     n = 5
-    logpmf1 = hypergeom.logpmf(k,N,K,n)
-    logpmf2 = hypergeom.logpmf(n-k,N,N-K,n)
-    logpmf3 = hypergeom.logpmf(K-k,N,K,N-n)
-    logpmf4 = hypergeom.logpmf(k,N,n,K)
+    logpmf1 = hypergeom.logpmf(k, N, K, n)
+    logpmf2 = hypergeom.logpmf(n - k, N, N - K, n)
+    logpmf3 = hypergeom.logpmf(K - k, N, K, N - n)
+    logpmf4 = hypergeom.logpmf(k, N, n, K)
     assert_almost_equal(logpmf1, logpmf2, decimal=12)
     assert_almost_equal(logpmf1, logpmf3, decimal=12)
     assert_almost_equal(logpmf1, logpmf4, decimal=12)
@@ -25,8 +26,8 @@ def test_hypergeom_logpmf():
     N = 10
     K = 7
     n = 1
-    hypergeom_logpmf = hypergeom.logpmf(k,N,K,n)
-    bernoulli_logpmf = bernoulli.logpmf(k,K/N)
+    hypergeom_logpmf = hypergeom.logpmf(k, N, K, n)
+    bernoulli_logpmf = bernoulli.logpmf(k, K/N)
     assert_almost_equal(hypergeom_logpmf, bernoulli_logpmf, decimal=12)
 
 


### PR DESCRIPTION
The PMF of the `boltzmann` distribution is nonzero only on the set 0, 1, ... N-1, where N is the second shape parameter.  Before the fix in this pull request, `boltzmann.pmf` incorrectly returns nonzero values for k >= N.  For example,

```
In [10]: k = np.arange(-2, 5)

In [11]: boltzmann.pmf(k, 0.5, 3)
Out[11]: 
array([0.        , 0.        , 0.50648039, 0.30719589, 0.18632372,
       0.11301105, 0.06854467])

In [12]: _.sum()
Out[12]: 1.1815557179455947
```
After:
```
In [2]: k = np.arange(-2, 5)

In [3]: boltzmann.pmf(k, 0.5, 3)
Out[3]: 
array([ 0.        ,  0.        ,  0.50648039,  0.30719589,  0.18632372,
        0.        ,  0.        ])

In [4]: _.sum()
Out[4]: 0.99999999999999989
```