### PR TITLE
ENH: Add Sidi's zero finder as optimize.zeros.sidi

### DIFF
--- a/scipy/optimize/__init__.py
+++ b/scipy/optimize/__init__.py
@@ -162,6 +162,7 @@ Scalar functions
    ridder - Ridder's method
    bisect - Bisection method
    newton - Secant method or Newton's method
+   sidi   - Sidi's method, generalization of Secant
 
 Fixed point finding:
 

--- a/scipy/optimize/_tstutils.py
+++ b/scipy/optimize/_tstutils.py
@@ -55,7 +55,7 @@ bisection in such circumstance, while being faster for smooth
 monotone sorts of functions.
 """
 
-methods = [cc.bisect,cc.ridder,cc.brenth,cc.brentq]
-mstrings = ['cc.bisect','cc.ridder','cc.brenth','cc.brentq']
+methods = [cc.bisect,cc.ridder,cc.brenth,cc.brentq, cc.sidi]
+mstrings = ['cc.bisect','cc.ridder','cc.brenth','cc.brentq', 'cc.sidi']
 functions = [f2,f3,f4,f5,f6]
 fstrings = ['f2','f3','f4','f5','f6']

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -1,6 +1,6 @@
 from __future__ import division, print_function, absolute_import
 
-from math import sqrt, exp, sin, cos
+from math import sqrt, exp, sin, cos, pi, isclose
 
 from numpy.testing import (assert_warns, assert_, 
                            assert_allclose,
@@ -15,17 +15,20 @@ from scipy.optimize._tstutils import functions, fstrings
 
 
 class TestBasic(object):
-    def run_check(self, method, name):
+    def run_check(self, method, name, nToCheck=None, **kwargs):
         a = .5
         b = sqrt(3)
         xtol = 4*finfo(float).eps
         rtol = 4*finfo(float).eps
-        for function, fname in zip(functions, fstrings):
+        for function, fname in zip(functions[:nToCheck], fstrings[:nToCheck]):
             zero, r = method(function, a, b, xtol=xtol, rtol=rtol,
-                             full_output=True)
+                             full_output=True, **kwargs)
             assert_(r.converged)
+            print('%.17e  %.17e' % (zero, zero-1))
+            print(r)
             assert_allclose(zero, 1.0, atol=xtol, rtol=rtol,
-                err_msg='method %s, function %s' % (name, fname))
+                err_msg='method %s, function %s %s' % (
+                    name, fname, (repr(kwargs) if kwargs else '')))
 
     def test_bisect(self):
         self.run_check(cc.bisect, 'bisect')
@@ -38,6 +41,39 @@ class TestBasic(object):
 
     def test_brenth(self):
         self.run_check(cc.brenth, 'brenth')
+
+    def test_sidi_k1(self):
+        self.run_check(cc.sidi, 'sidi', nToCheck=2, k=1)
+
+    def test_sidi_k2(self):
+        self.run_check(cc.sidi, 'sidi', nToCheck=2, k=2)
+
+    def test_sidi_k3(self):
+        self.run_check(cc.sidi, 'sidi', nToCheck=2, k=3)
+
+    def test_sidi(self):
+        f1 = lambda x: x**2 - 2*x - 1
+        f1p = lambda x: 2*x - 2
+        f2 = lambda x: exp(x) - cos(x)
+        f2p = lambda x: exp(x) + sin(x)
+
+        data = [[f1, f1p, 0, 3, sqrt(2)+1],
+                [f2, f2p, -2*pi, 3, -4.72129275884768607e+00 ]
+                ]
+
+        xtol = 4 * finfo(float).eps
+        rtol = 4 * finfo(float).eps
+
+        for f, fp, a, b, r in data:
+            for k in [1, 2, 3]:
+                x, result = zeros.sidi(f, a, b, xtol=xtol, rtol=rtol,
+                                       k=k, full_output=True)
+                fpr = fp(r)
+                print('k=%d, x=%.17e f(x)=%g f(r)=%.17e fp(r)=%f, result=%s' % (
+                    k, x, f(x), f(r), fpr, result))
+                assert_(result.converged)
+                assert_allclose(x, r, atol=xtol, rtol=rtol)
+                assert_allclose(f(x), 0, atol=4*abs(fpr) * xtol, rtol=4*rtol)
 
     def test_newton(self):
         f1 = lambda x: x**2 - 2*x - 1

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -1,6 +1,6 @@
 from __future__ import division, print_function, absolute_import
 
-from math import sqrt, exp, sin, cos, pi, isclose
+from math import sqrt, exp, sin, cos, pi
 
 from numpy.testing import (assert_warns, assert_, 
                            assert_allclose,

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -58,7 +58,7 @@ class TestBasic(object):
         f2p = lambda x: exp(x) + sin(x)
 
         data = [[f1, f1p, 0, 3, sqrt(2)+1],
-                [f2, f2p, -2*pi, 3, -4.72129275884768607e+00 ]
+                [f2, f2p, -2*pi, 3, -4.72129275884768607]
                 ]
 
         xtol = 4 * finfo(float).eps

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -367,8 +367,8 @@ def sidi(f, a, b, args=(), k=2,
     >>> results
           converged: True
                flag: 'converged'
-     function_calls: 10
-         iterations: 8
+     function_calls: 11
+         iterations: 9
                root: 1.0
 
 
@@ -477,7 +477,7 @@ def sidi(f, a, b, args=(), k=2,
         _updateDividedDiffs(xvals, divdiffs, xn, fxn, k)
         _updateBracket(brkt, fbrk, xn, fxn)
 
-        if brkt:
+        if is_bracket:
             # We are in the current bracket and the length of the bracket
             # is small enough to guarantee that np.isclose(xn, r) for any
             # r in the bracket.

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -364,8 +364,8 @@ def sidi(f, a, b, args=(), k=2,
     >>> results
           converged: True
                flag: 'converged'
-     function_calls: 11
-         iterations: 9
+     function_calls: 10
+         iterations: 8
                root: 1.0
 
 

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -354,7 +354,7 @@ def sidi(f, a, b, args=(), k=2,
     k=1 is just the secant method.
     Muller's method use the interpolating polynomial to approximate `f`.
     Sidi's method uses the derivative of the interpolating polynomial to
-    approximate the derivative of `f`.  to find a
+    approximate the derivative of `f`.
 
     Examples
     --------

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -201,9 +201,8 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
             fder = fprime(p0, *args)
             funcalls += 1
             if fder == 0:
-                if disp:
-                    msg = "derivative was zero."
-                    warnings.warn(msg, RuntimeWarning)
+                msg = "derivative was zero."
+                warnings.warn(msg, RuntimeWarning)
                 return _results_select(full_output, (p0, funcalls, itr + 1, _ECONVERR))
             fval = func(p0, *args)
             funcalls += 1
@@ -231,11 +230,10 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
         for itr in range(maxiter):
             if q1 == q0:
                 if p1 != p0:
-                    if disp:
-                        msg = "Tolerance of %s reached" % (p1 - p0)
-                        warnings.warn(msg, RuntimeWarning)
-                    p = (p1 + p0) / 2.0
-                    return _results_select(full_output, (p, funcalls, itr + 1, _ECONVERGED))
+                    msg = "Tolerance of %s reached" % (p1 - p0)
+                    warnings.warn(msg, RuntimeWarning)
+                p = (p1 + p0) / 2.0
+                return _results_select(full_output, (p, funcalls, itr + 1, _ECONVERGED))
             else:
                 p = p1 - q1 * (p1 - p0) / (q1 - q0)
             if abs(p - p1) < tol:


### PR DESCRIPTION
Added a function to optimize.zeros.py
`sidi(f, a, b, args=(), k=2, xtol=_xtol, rtol=_rtol, maxiter=_iter, is_bracket=True, full_output=False, disp=True)`

Sidi's root-finder is a family of generalizations of the secant method using Newton's interpolation formula with divided differences to construct a new approximation to a root of a function.

Muller's method use the interpolating polynomial `p_k` to approximate `f` from `k+1` points.  Sidi's method uses the derivative of the interpolating polynomial `p_k'`  to approximate the derivative `f'` of `f`. The generated approximation is then (reminiscent of Newton-Raphson)
```
        f(x0)
x0 -  --------
       p_k'(x0)
```

For `k=1`, this reduces to the Secant method, with approximate order of convergence `1.618`.
For `k=2, 3,...`, the approximate order of convergence is `1.839, 1.928,...`, a sequence approaching 2, whenever applied to functions with `k+1` continuous derivatives on the interval.

Using divided differences, the method quickly computes ` p_k'(x0)` and only involves evaluation of the function `f` itself, not any derivatives of `f`.
One potential advantage over the Newton-Raphson routine `optimize.newton`, is that it can require fewer evaluations of `f` and `f'`.  One potential advantage over methods such as `optimize.brentq` is that by incorporating 2nd and higher order information it can lead to fewer iterations and function evaluations.

Most of the function's arguments are the same as for `bisect/brentq/ridder`.  There are two additional arguments:
`k`: the order of the interpolating polynomial.  Default is 2.
`is_bracket`: If False, `a` and `b` are just the first two iterates  and not necessarily an interval containing a root.  Similar to Newton-Raphson or Secant, Sidi's method does not require a bracketing interval for operation. If a bracketing interval is provided then it will used to constrain the iterations.

Tests have been updated to include testing of `optimize.sidi`.

I also added keyword args `full_output=False, disp=True` to `optimize.newton(...)` to better match the other zero finders.  The default values preserve the current behavior. 
Setting `full_output=True` causes a `RootResults` object to be returned with information on the total number of function_calls and iterations. 
Setting `disp=False` suppresses the RuntimeError associated with non-convergence, and is likely best combined with `full_output=True`.