### PR TITLE
MAINT: Optimize Cython code in _peak_finding_utils

### DIFF
--- a/scipy/signal/_peak_finding.py
+++ b/scipy/signal/_peak_finding.py
@@ -870,7 +870,7 @@ def find_peaks(x, height=None, threshold=None, distance=None,
     >>> plt.show()
     """
     # _argmaxima1d expects array of dtype 'float64'
-    x = np.asarray(x, dtype=np.float64)
+    x = np.asarray(x, dtype=np.float64, order='C')
     if x.ndim != 1:
         raise ValueError('`x` must have exactly one dimension')
     if distance is not None and distance < 1:


### PR DESCRIPTION
As the title and commit say, these are only minor changes that have (on my machine) small performance improvements and make the code more consistent.

Changes:
- Use `np.intp_t` in favor of `Py_ssize_t`. This type is used internally (as `npy_intp`) by NumPy's array API. I couldn't find any real recommendation in the Cython docs or elsewhere but the fact that methods like `array.shape[0]` return this type are a convincing argument in my book.
- Move common compile directives to header.
- Release GIL in `_argmaxima1d`.
- Input arrays in `_select_by_peak_prominence` can safely be declared as  C-contiguous.
- Favor `np.uint8` as "boolean" type.