### PR TITLE
BLD: remove special/tests/data/local/ from sdist.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -19,6 +19,7 @@ prune benchmarks/html
 prune benchmarks/scipy
 prune scipy/special/tests/data/boost
 prune scipy/special/tests/data/gsl
+prune scipy/special/tests/data/local
 prune doc/build
 prune doc/source/generated
 prune */__pycache__


### PR DESCRIPTION
Same as the `boost` and `gsl` subdirectories it seems, probably a simple oversight that `local` wasn't pruned.