### PR TITLE
DOC: typo fixes

### DIFF
--- a/scipy/interpolate/README
+++ b/scipy/interpolate/README
@@ -42,7 +42,7 @@ A number of other functions and classes are provided, for which README documenta
 Introductions to interpolation and splines can be found online at:
 
 http://en.wikipedia.org/wiki/Interpolation
-	The Wikipedia article on interpolation.  Provides an accesible
+	The Wikipedia article on interpolation.  Provides an accessible
 	overview of major areas of the subject, including spline
 	interpolation.
 http://en.wikipedia.org/wiki/Spline_interpolation

--- a/scipy/ndimage/src/ni_filters.c
+++ b/scipy/ndimage/src/ni_filters.c
@@ -171,7 +171,7 @@ int NI_Correlate(PyArrayObject* input, PyArrayObject* weights,
     int err = 0;
     NPY_BEGIN_THREADS_DEF;
 
-    /* get the the footprint: */
+    /* get the footprint: */
     fsize = PyArray_SIZE(weights);
     pw = (npy_double*)PyArray_DATA(weights);
     pf = malloc(fsize * sizeof(npy_bool));
@@ -542,7 +542,7 @@ int NI_MinOrMaxFilter(PyArrayObject* input, PyArrayObject* footprint,
     npy_double *ps;
     NPY_BEGIN_THREADS_DEF;
 
-    /* get the the footprint: */
+    /* get the footprint: */
     fsize = PyArray_SIZE(footprint);
     pf = (npy_bool*)PyArray_DATA(footprint);
     for(jj = 0; jj < fsize; jj++) {
@@ -735,7 +735,7 @@ int NI_RankFilter(PyArrayObject* input, int rank,
     int err = 0;
     NPY_BEGIN_THREADS_DEF;
 
-    /* get the the footprint: */
+    /* get the footprint: */
     fsize = PyArray_SIZE(footprint);
     pf = (npy_bool*)PyArray_DATA(footprint);
     for(jj = 0; jj < fsize; jj++) {
@@ -947,7 +947,7 @@ int NI_GenericFilter(PyArrayObject* input,
     char *pi, *po;
     double *buffer = NULL;
 
-    /* get the the footprint: */
+    /* get the footprint: */
     fsize = PyArray_SIZE(footprint);
     pf = (npy_bool*)PyArray_DATA(footprint);
     for(jj = 0; jj < fsize; jj++) {

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -4427,7 +4427,7 @@ class TestNdimage:
         array = numpy.eye(5, dtype=numpy.bool_)
         structure = numpy.ones((3, 3), dtype=numpy.bool_)
 
-        # Check that type missmatch is properly handled
+        # Check that type mismatch is properly handled
         output = numpy.empty_like(array, dtype=numpy.float)
         ndimage.white_tophat(array, structure=structure, output=output)
 
@@ -4482,7 +4482,7 @@ class TestNdimage:
         array = numpy.eye(5, dtype=numpy.bool_)
         structure = numpy.ones((3, 3), dtype=numpy.bool_)
 
-        # Check that type missmatch is properly handled
+        # Check that type mismatch is properly handled
         output = numpy.empty_like(array, dtype=numpy.float)
         ndimage.black_tophat(array, structure=structure, output=output)
 

--- a/scipy/optimize/_trustregion_constr/minimize_trustregion_constr.py
+++ b/scipy/optimize/_trustregion_constr/minimize_trustregion_constr.py
@@ -318,7 +318,7 @@ def _minimize_trustregion_constr(fun, x0, args, grad,
     else:
         finite_diff_bounds = (-np.inf, np.inf)
 
-    # Define Objective Funciton
+    # Define Objective Function
     objective = ScalarFunction(fun, x0, args, grad, hess,
                                finite_diff_rel_step, finite_diff_bounds)
 

--- a/scipy/optimize/_trustregion_constr/qp_subproblem.py
+++ b/scipy/optimize/_trustregion_constr/qp_subproblem.py
@@ -566,7 +566,7 @@ def projected_cg(H, c, Z, Y, b, trust_radius=np.inf,
                 # Reinforce variables are inside box constraints.
                 # This is only necessary because of roundoff errors.
                 x = reinforce_box_boundaries(x, lb, ub)
-                # Atribute information
+                # Attribute information
                 stop_cond = 3
                 hits_boundary = True
                 break
@@ -586,7 +586,7 @@ def projected_cg(H, c, Z, Y, b, trust_radius=np.inf,
             # Reinforce variables are inside box constraints.
             # This is only necessary because of roundoff errors.
             x = reinforce_box_boundaries(x, lb, ub)
-            # Atribute information
+            # Attribute information
             stop_cond = 2
             hits_boundary = True
             break

--- a/scipy/optimize/_trustregion_constr/tests/test_qp_subproblem.py
+++ b/scipy/optimize/_trustregion_constr/tests/test_qp_subproblem.py
@@ -276,7 +276,7 @@ class TestBoxSphereBoundariesIntersections(TestCase):
         assert_array_almost_equal([ta, tb], [0, 0.5])
         assert_equal(intersect, True)
 
-        # None of the contraints are active
+        # None of the constraints are active
         ta, tb, intersect = box_sphere_intersections([1, 1], [-1, 1],
                                                      [-1, -3], [1, 3], 10,
                                                      entire_line=False)
@@ -315,7 +315,7 @@ class TestBoxSphereBoundariesIntersections(TestCase):
         assert_array_almost_equal([ta, tb], [0, 0.5])
         assert_equal(intersect, True)
 
-        # None of the contraints are active
+        # None of the constraints are active
         ta, tb, intersect = box_sphere_intersections([1, 1], [-1, 1],
                                                      [-1, -3], [1, 3], 10,
                                                      entire_line=True)
@@ -539,7 +539,7 @@ class TestProjectCG(TestCase):
         assert_equal(info["hits_boundary"], True)
         assert_array_almost_equal(np.linalg.norm(x), trust_radius)
 
-    # The box contraints are inactive at the solution but
+    # The box constraints are inactive at the solution but
     # are active during the iterations.
     def test_inactive_box_constraints(self):
         H = csc_matrix([[6, 2, 1, 3],
@@ -561,7 +561,7 @@ class TestProjectCG(TestCase):
         assert_equal(info["hits_boundary"], False)
         assert_array_almost_equal(x, x_kkt)
 
-    # The box contraints active and the termination is
+    # The box constraints active and the termination is
     # by maximum iterations (infeasible iteraction).
     def test_active_box_constraints_maximum_iterations_reached(self):
         H = csc_matrix([[6, 2, 1, 3],
@@ -583,7 +583,7 @@ class TestProjectCG(TestCase):
         assert_array_almost_equal(A.dot(x), -b)
         assert_array_almost_equal(x[0], 0.8)
 
-    # The box contraints are active and the termination is
+    # The box constraints are active and the termination is
     # because it hits boundary (without infeasible iteraction).
     def test_active_box_constraints_hits_boundaries(self):
         H = csc_matrix([[6, 2, 1, 3],
@@ -605,7 +605,7 @@ class TestProjectCG(TestCase):
         assert_equal(info["hits_boundary"], True)
         assert_array_almost_equal(x[2], 1.6)
 
-    # The box contraints are active and the termination is
+    # The box constraints are active and the termination is
     # because it hits boundary (infeasible iteraction).
     def test_active_box_constraints_hits_boundaries_infeasible_iter(self):
         H = csc_matrix([[6, 2, 1, 3],
@@ -627,7 +627,7 @@ class TestProjectCG(TestCase):
         assert_equal(info["hits_boundary"], True)
         assert_array_almost_equal(x[1], 0.1)
 
-    # The box contraints are active and the termination is
+    # The box constraints are active and the termination is
     # because it hits boundary (no infeasible iteraction).
     def test_active_box_constraints_negative_curvature(self):
         H = csc_matrix([[1, 2, 1, 3],

--- a/scipy/optimize/_trustregion_constr/tr_interior_point.py
+++ b/scipy/optimize/_trustregion_constr/tr_interior_point.py
@@ -118,7 +118,7 @@ class BarrierSubproblem:
     def gradient_and_jacobian(self, z):
         """Returns scaled gradient.
 
-        Return scalled gradient:
+        Return scaled gradient:
             gradient = [             grad(x)             ]
                        [ -barrier_parameter*ones(n_ineq) ]
         and scaled Jacobian Matrix:

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -861,7 +861,7 @@ class TestStateSpace(object):
         assert_allclose(lsim(s1 + 2, U=u, T=t)[1],
                         2 * u + lsim(s1, U=u, T=t)[1])
 
-        # Check for dimension missmatch
+        # Check for dimension mismatch
         with assert_raises(ValueError):
             s1 + np.array([1, 2])
 

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -2340,7 +2340,7 @@ def wilcoxon(x, y=None, zero_method="wilcox", correction=False):
         "wilcox":
             Wilcox treatment: discards all zero-differences
         "zsplit":
-            Zero rank split: just like Pratt, but spliting the zero rank
+            Zero rank split: just like Pratt, but splitting the zero rank
             between positive and negative ones
     correction : bool, optional
         If True, apply continuity correction by adjusting the Wilcoxon rank


### PR DESCRIPTION
doc and source comment typo fixes. Found via `codespell`