### PR TITLE
MAINT: Suppress dd_real unused function compiler warnings.

### DIFF
--- a/scipy/special/cephes/dd_idefs.h
+++ b/scipy/special/cephes/dd_idefs.h
@@ -41,7 +41,7 @@ extern "C" {
 */
 
 /* Computes fl(a+b) and err(a+b).  Assumes |a| >= |b|. */
-static __COMP_NPY_UNUSED double
+static NPY_INLINE double
 quick_two_sum(double a, double b, double *err)
 {
     volatile double s = a + b;
@@ -51,7 +51,7 @@ quick_two_sum(double a, double b, double *err)
 }
 
 /* Computes fl(a-b) and err(a-b).  Assumes |a| >= |b| */
-static __COMP_NPY_UNUSED double
+static NPY_INLINE double
 quick_two_diff(double a, double b, double *err)
 {
     volatile double s = a - b;
@@ -61,7 +61,7 @@ quick_two_diff(double a, double b, double *err)
 }
 
 /* Computes fl(a+b) and err(a+b).  */
-static __COMP_NPY_UNUSED double
+static NPY_INLINE double
 two_sum(double a, double b, double *err)
 {
     volatile double s = a + b;
@@ -73,7 +73,7 @@ two_sum(double a, double b, double *err)
 }
 
 /* Computes fl(a-b) and err(a-b).  */
-static __COMP_NPY_UNUSED double
+static NPY_INLINE double
 two_diff(double a, double b, double *err)
 {
     volatile double s = a - b;
@@ -85,7 +85,7 @@ two_diff(double a, double b, double *err)
 }
 
 /* Computes high word and lo word of a */
-static __COMP_NPY_UNUSED void
+static NPY_INLINE void
 two_split(double a, double *hi, double *lo)
 {
     volatile double temp, tempma;
@@ -107,7 +107,7 @@ two_split(double a, double *hi, double *lo)
 }
 
 /* Computes fl(a*b) and err(a*b). */
-static __COMP_NPY_UNUSED double
+static NPY_INLINE double
 two_prod(double a, double b, double *err)
 {
 #ifdef DD_FMS
@@ -128,7 +128,7 @@ two_prod(double a, double b, double *err)
 }
 
 /* Computes fl(a*a) and err(a*a).  Faster than the above method. */
-static __COMP_NPY_UNUSED double
+static NPY_INLINE double
 two_sqr(double a, double *err)
 {
 #ifdef DD_FMS
@@ -146,7 +146,7 @@ two_sqr(double a, double *err)
 #endif /* DD_FMS */
 }
 
-static __COMP_NPY_UNUSED double
+static NPY_INLINE double
 two_div(double a, double b, double *err)
 {
     volatile double q1, q2;
@@ -167,7 +167,7 @@ two_div(double a, double b, double *err)
 }
 
 /* Computes the nearest integer to d. */
-static __COMP_NPY_UNUSED double
+static NPY_INLINE double
 two_nint(double d)
 {
     if (d == floor(d)) {
@@ -177,7 +177,7 @@ two_nint(double d)
 }
 
 /* Computes the truncated integer. */
-static __COMP_NPY_UNUSED double
+static NPY_INLINE double
 two_aint(double d)
 {
     return (d >= 0.0 ? floor(d) : ceil(d));
@@ -185,7 +185,7 @@ two_aint(double d)
 
 
 /* Compare a and b */
-static __COMP_NPY_UNUSED int
+static NPY_INLINE int
 two_comp(const double a, const double b)
 {
     /* Works for non-NAN inputs */

--- a/scipy/special/cephes/dd_idefs.h
+++ b/scipy/special/cephes/dd_idefs.h
@@ -25,6 +25,8 @@
 #include <limits.h>
 #include <math.h>
 
+#include <numpy/utils.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -39,7 +41,7 @@ extern "C" {
 */
 
 /* Computes fl(a+b) and err(a+b).  Assumes |a| >= |b|. */
-static double
+static __COMP_NPY_UNUSED double
 quick_two_sum(double a, double b, double *err)
 {
     volatile double s = a + b;
@@ -49,7 +51,7 @@ quick_two_sum(double a, double b, double *err)
 }
 
 /* Computes fl(a-b) and err(a-b).  Assumes |a| >= |b| */
-static double
+static __COMP_NPY_UNUSED double
 quick_two_diff(double a, double b, double *err)
 {
     volatile double s = a - b;
@@ -59,7 +61,7 @@ quick_two_diff(double a, double b, double *err)
 }
 
 /* Computes fl(a+b) and err(a+b).  */
-static double
+static __COMP_NPY_UNUSED double
 two_sum(double a, double b, double *err)
 {
     volatile double s = a + b;
@@ -71,7 +73,7 @@ two_sum(double a, double b, double *err)
 }
 
 /* Computes fl(a-b) and err(a-b).  */
-static double
+static __COMP_NPY_UNUSED double
 two_diff(double a, double b, double *err)
 {
     volatile double s = a - b;
@@ -83,7 +85,7 @@ two_diff(double a, double b, double *err)
 }
 
 /* Computes high word and lo word of a */
-static void
+static __COMP_NPY_UNUSED void
 two_split(double a, double *hi, double *lo)
 {
     volatile double temp, tempma;
@@ -105,7 +107,7 @@ two_split(double a, double *hi, double *lo)
 }
 
 /* Computes fl(a*b) and err(a*b). */
-static double
+static __COMP_NPY_UNUSED double
 two_prod(double a, double b, double *err)
 {
 #ifdef DD_FMS
@@ -126,7 +128,7 @@ two_prod(double a, double b, double *err)
 }
 
 /* Computes fl(a*a) and err(a*a).  Faster than the above method. */
-static double
+static __COMP_NPY_UNUSED double
 two_sqr(double a, double *err)
 {
 #ifdef DD_FMS
@@ -144,7 +146,7 @@ two_sqr(double a, double *err)
 #endif /* DD_FMS */
 }
 
-static double
+static __COMP_NPY_UNUSED double
 two_div(double a, double b, double *err)
 {
     volatile double q1, q2;
@@ -165,7 +167,7 @@ two_div(double a, double b, double *err)
 }
 
 /* Computes the nearest integer to d. */
-static double
+static __COMP_NPY_UNUSED double
 two_nint(double d)
 {
     if (d == floor(d)) {
@@ -175,7 +177,7 @@ two_nint(double d)
 }
 
 /* Computes the truncated integer. */
-static double
+static __COMP_NPY_UNUSED double
 two_aint(double d)
 {
     return (d >= 0.0 ? floor(d) : ceil(d));
@@ -183,7 +185,7 @@ two_aint(double d)
 
 
 /* Compare a and b */
-static int
+static __COMP_NPY_UNUSED int
 two_comp(const double a, const double b)
 {
     /* Works for non-NAN inputs */

--- a/scipy/special/cephes/dd_real_idefs.h
+++ b/scipy/special/cephes/dd_real_idefs.h
@@ -37,76 +37,76 @@ extern "C" {
  ************************************************************************
 */
 
-static double
+static __COMP_NPY_UNUSED double
 dd_hi(const double2 a)
 {
     return a.x[0];
 }
 
-static double
+static __COMP_NPY_UNUSED double
 dd_lo(const double2 a)
 {
     return a.x[1];
 }
 
-static int
+static __COMP_NPY_UNUSED int
 dd_isnan(const double2 a)
 {
     return (DD_ISNAN(a.x[0]) || DD_ISNAN(a.x[1]));
 }
 
-static int
+static __COMP_NPY_UNUSED int
 dd_isfinite(const double2 a)
 {
     return DD_ISFINITE(a.x[0]);
 }
 
-static int
+static __COMP_NPY_UNUSED int
 dd_isinf(const double2 a)
 {
     return DD_ISINF(a.x[0]);
 }
 
-static int
+static __COMP_NPY_UNUSED int
 dd_is_zero(const double2 a)
 {
     return (a.x[0] == 0.0);
 }
 
-static int
+static __COMP_NPY_UNUSED int
 dd_is_one(const double2 a)
 {
     return (a.x[0] == 1.0 && a.x[1] == 0.0);
 }
 
-static int
+static __COMP_NPY_UNUSED int
 dd_is_positive(const double2 a)
 {
     return (a.x[0] > 0.0);
 }
 
-static int
+static __COMP_NPY_UNUSED int
 dd_is_negative(const double2 a)
 {
     return (a.x[0] < 0.0);
 }
 
 /* Cast to double. */
-static double
+static __COMP_NPY_UNUSED double
 dd_to_double(const double2 a)
 {
     return a.x[0];
 }
 
 /* Cast to int. */
-static int
+static __COMP_NPY_UNUSED int
 dd_to_int(const double2 a)
 {
     return DD_STATIC_CAST(int, a.x[0]);
 }
 
 /*********** Equality and Other Comparisons ************/
-static int
+static __COMP_NPY_UNUSED int
 dd_comp(const double2 a, const double2 b)
 {
     int cmp = two_comp(a.x[0], b.x[0]);
@@ -116,7 +116,7 @@ dd_comp(const double2 a, const double2 b)
     return cmp;
 }
 
-static int
+static __COMP_NPY_UNUSED int
 dd_comp_dd_d(const double2 a, double b)
 {
     int cmp = two_comp(a.x[0], b);
@@ -126,7 +126,7 @@ dd_comp_dd_d(const double2 a, double b)
     return cmp;
 }
 
-static int
+static __COMP_NPY_UNUSED int
 dd_comp_d_dd(double a, const double2 b)
 {
     int cmp = two_comp(a, b.x[0]);
@@ -138,34 +138,34 @@ dd_comp_d_dd(double a, const double2 b)
 
 
 /*********** Creation ************/
-static double2
+static __COMP_NPY_UNUSED double2
 dd_create(double hi, double lo)
 {
     double2 ret = {{hi, lo}};
     return ret;
 }
 
-static double2
+static __COMP_NPY_UNUSED double2
 dd_zero(void)
 {
     return DD_C_ZERO;
 }
 
-static double2
+static __COMP_NPY_UNUSED double2
 dd_create_d(double hi)
 {
     double2 ret = {{hi, 0.0}};
     return ret;
 }
 
-static double2
+static __COMP_NPY_UNUSED double2
 dd_create_i(int hi)
 {
     double2 ret = {{DD_STATIC_CAST(double, hi), 0.0}};
     return ret;
 }
 
-static double2
+static __COMP_NPY_UNUSED double2
 dd_create_dp(const double *d)
 {
     double2 ret = {{d[0], d[1]}};
@@ -174,7 +174,7 @@ dd_create_dp(const double *d)
 
 
 /*********** Unary Minus ***********/
-static double2
+static __COMP_NPY_UNUSED double2
 dd_neg(const double2 a)
 {
     double2 ret = {{-a.x[0], -a.x[1]}};
@@ -183,7 +183,7 @@ dd_neg(const double2 a)
 
 /*********** Rounding ************/
 /* Round to Nearest integer */
-static double2
+static __COMP_NPY_UNUSED double2
 dd_nint(const double2 a)
 {
     double hi = two_nint(a.x[0]);
@@ -209,7 +209,7 @@ dd_nint(const double2 a)
     return dd_create(hi, lo);
 }
 
-static double2
+static __COMP_NPY_UNUSED double2
 dd_floor(const double2 a)
 {
     double hi = floor(a.x[0]);
@@ -224,7 +224,7 @@ dd_floor(const double2 a)
     return dd_create(hi, lo);
 }
 
-static double2
+static __COMP_NPY_UNUSED double2
 dd_ceil(const double2 a)
 {
     double hi = ceil(a.x[0]);
@@ -239,20 +239,20 @@ dd_ceil(const double2 a)
     return dd_create(hi, lo);
 }
 
-static double2
+static __COMP_NPY_UNUSED double2
 dd_aint(const double2 a)
 {
     return (a.x[0] >= 0.0) ? dd_floor(a) : dd_ceil(a);
 }
 
 /* Absolute value */
-static double2
+static __COMP_NPY_UNUSED double2
 dd_abs(const double2 a)
 {
     return (a.x[0] < 0.0 ? dd_neg(a) : a);
 }
 
-static double2
+static __COMP_NPY_UNUSED double2
 dd_fabs(const double2 a)
 {
     return dd_abs(a);
@@ -261,13 +261,13 @@ dd_fabs(const double2 a)
 
 /*********** Normalizing ***********/
 /* double-double * (2.0 ^ expt) */
-static double2
+static __COMP_NPY_UNUSED double2
 dd_ldexp(const double2 a, int expt)
 {
     return dd_create(ldexp(a.x[0], expt), ldexp(a.x[1], expt));
 }
 
-static double2
+static __COMP_NPY_UNUSED double2
 dd_frexp(const double2 a, int *expt)
 {
 //    r"""return b and l s.t. 0.5<=|b|<1 and 2^l == a
@@ -288,7 +288,7 @@ dd_frexp(const double2 a, int *expt)
 
 
 /*********** Additions ************/
-static double2
+static __COMP_NPY_UNUSED double2
 dd_add_d_d(double a, double b)
 {
     double s, e;
@@ -296,7 +296,7 @@ dd_add_d_d(double a, double b)
     return dd_create(s, e);
 }
 
-static double2
+static __COMP_NPY_UNUSED double2
 dd_add_dd_d(const double2 a, double b)
 {
     double s1, s2;
@@ -306,7 +306,7 @@ dd_add_dd_d(const double2 a, double b)
     return dd_create(s1, s2);
 }
 
-static double2
+static __COMP_NPY_UNUSED double2
 dd_add_d_dd(double a, const double2 b)
 {
     double s1, s2;
@@ -316,7 +316,7 @@ dd_add_d_dd(double a, const double2 b)
     return dd_create(s1, s2);
 }
 
-static double2
+static __COMP_NPY_UNUSED double2
 dd_ieee_add(const double2 a, const double2 b)
 {
     /* This one satisfies IEEE style error bound,
@@ -332,7 +332,7 @@ dd_ieee_add(const double2 a, const double2 b)
     return dd_create(s1, s2);
 }
 
-static double2
+static __COMP_NPY_UNUSED double2
 dd_sloppy_add(const double2 a, const double2 b)
 {
     /* This is the less accurate version ... obeys Cray-style
@@ -345,7 +345,7 @@ dd_sloppy_add(const double2 a, const double2 b)
     return dd_create(s, e);
 }
 
-static double2
+static __COMP_NPY_UNUSED double2
 dd_add(const double2 a, const double2 b)
 {
     /* Always require IEEE-style error bounds */
@@ -354,7 +354,7 @@ dd_add(const double2 a, const double2 b)
 
 /*********** Subtractions ************/
 /* double-double = double - double */
-static double2
+static __COMP_NPY_UNUSED double2
 dd_sub_d_d(double a, double b)
 {
     double s, e;
@@ -362,13 +362,13 @@ dd_sub_d_d(double a, double b)
     return dd_create(s, e);
 }
 
-static double2
+static __COMP_NPY_UNUSED double2
 dd_sub(const double2 a, const double2 b)
 {
     return dd_ieee_add(a, dd_neg(b));
 }
 
-static double2
+static __COMP_NPY_UNUSED double2
 dd_sub_dd_d(const double2 a, double b)
 {
     double s1, s2;
@@ -378,7 +378,7 @@ dd_sub_dd_d(const double2 a, double b)
     return dd_create(s1, s2);
 }
 
-static double2
+static __COMP_NPY_UNUSED double2
 dd_sub_d_dd(double a, const double2 b)
 {
     double s1, s2;
@@ -391,7 +391,7 @@ dd_sub_d_dd(double a, const double2 b)
 
 /*********** Multiplications ************/
 /* double-double = double * double */
-static double2
+static __COMP_NPY_UNUSED double2
 dd_mul_d_d(double a, double b)
 {
     double p, e;
@@ -400,13 +400,13 @@ dd_mul_d_d(double a, double b)
 }
 
 /* double-double * double,  where double is a power of 2. */
-static double2
+static __COMP_NPY_UNUSED double2
 dd_mul_pwr2(const double2 a, double b)
 {
     return dd_create(a.x[0] * b, a.x[1] * b);
 }
 
-static double2
+static __COMP_NPY_UNUSED double2
 dd_mul(const double2 a, const double2 b)
 {
     double p1, p2;
@@ -416,7 +416,7 @@ dd_mul(const double2 a, const double2 b)
     return dd_create(p1, p2);
 }
 
-static double2
+static __COMP_NPY_UNUSED double2
 dd_mul_dd_d(const double2 a, double b)
 {
     double p1, p2, e1, e2;
@@ -426,7 +426,7 @@ dd_mul_dd_d(const double2 a, double b)
     return dd_create(p1, e1);
 }
 
-static double2
+static __COMP_NPY_UNUSED double2
 dd_mul_d_dd(double a, const double2 b)
 {
     double p1, p2, e1, e2;
@@ -438,7 +438,7 @@ dd_mul_d_dd(double a, const double2 b)
 
 
 /*********** Divisions ************/
-static double2
+static __COMP_NPY_UNUSED double2
 dd_sloppy_div(const double2 a, const double2 b)
 {
     double s1, s2;
@@ -461,7 +461,7 @@ dd_sloppy_div(const double2 a, const double2 b)
     return r;
 }
 
-static double2
+static __COMP_NPY_UNUSED double2
 dd_accurate_div(const double2 a, const double2 b)
 {
     double q1, q2, q3;
@@ -481,31 +481,31 @@ dd_accurate_div(const double2 a, const double2 b)
     return r;
 }
 
-static double2
+static __COMP_NPY_UNUSED double2
 dd_div(const double2 a, const double2 b)
 {
     return dd_accurate_div(a, b);
 }
 
-static double2
+static __COMP_NPY_UNUSED double2
 dd_div_d_d(double a, double b)
 {
     return dd_accurate_div(dd_create_d(a), dd_create_d(b));
 }
 
-static double2
+static __COMP_NPY_UNUSED double2
 dd_div_dd_d(const double2 a, double b)
 {
     return dd_accurate_div(a, dd_create_d(b));
 }
 
-static double2
+static __COMP_NPY_UNUSED double2
 dd_div_d_dd(double a, const double2 b)
 {
     return dd_accurate_div(dd_create_d(a), b);
 }
 
-static double2
+static __COMP_NPY_UNUSED double2
 dd_inv(const double2 a)
 {
     return dd_div(DD_C_ONE, a);
@@ -513,14 +513,14 @@ dd_inv(const double2 a)
 
 
 /********** Remainder **********/
-static double2
+static __COMP_NPY_UNUSED double2
 dd_drem(const double2 a, const double2 b)
 {
     double2 n = dd_nint(dd_div(a, b));
     return dd_sub(a, dd_mul(n, b));
 }
 
-static double2
+static __COMP_NPY_UNUSED double2
 dd_divrem(const double2 a, const double2 b, double2 *r)
 {
     double2 n = dd_nint(dd_div(a, b));
@@ -528,7 +528,7 @@ dd_divrem(const double2 a, const double2 b, double2 *r)
     return n;
 }
 
-static double2
+static __COMP_NPY_UNUSED double2
 dd_fmod(const double2 a, const double2 b)
 {
     double2 n = dd_aint(dd_div(a, b));
@@ -536,7 +536,7 @@ dd_fmod(const double2 a, const double2 b)
 }
 
 /*********** Squaring **********/
-static double2
+static __COMP_NPY_UNUSED double2
 dd_sqr(const double2 a)
 {
     double p1, p2;
@@ -548,7 +548,7 @@ dd_sqr(const double2 a)
     return dd_create(s1, s2);
 }
 
-static double2
+static __COMP_NPY_UNUSED double2
 dd_sqr_d(double a)
 {
     double p1, p2;

--- a/scipy/special/cephes/dd_real_idefs.h
+++ b/scipy/special/cephes/dd_real_idefs.h
@@ -37,76 +37,76 @@ extern "C" {
  ************************************************************************
 */
 
-static __COMP_NPY_UNUSED double
+static NPY_INLINE double
 dd_hi(const double2 a)
 {
     return a.x[0];
 }
 
-static __COMP_NPY_UNUSED double
+static NPY_INLINE double
 dd_lo(const double2 a)
 {
     return a.x[1];
 }
 
-static __COMP_NPY_UNUSED int
+static NPY_INLINE int
 dd_isnan(const double2 a)
 {
     return (DD_ISNAN(a.x[0]) || DD_ISNAN(a.x[1]));
 }
 
-static __COMP_NPY_UNUSED int
+static NPY_INLINE int
 dd_isfinite(const double2 a)
 {
     return DD_ISFINITE(a.x[0]);
 }
 
-static __COMP_NPY_UNUSED int
+static NPY_INLINE int
 dd_isinf(const double2 a)
 {
     return DD_ISINF(a.x[0]);
 }
 
-static __COMP_NPY_UNUSED int
+static NPY_INLINE int
 dd_is_zero(const double2 a)
 {
     return (a.x[0] == 0.0);
 }
 
-static __COMP_NPY_UNUSED int
+static NPY_INLINE int
 dd_is_one(const double2 a)
 {
     return (a.x[0] == 1.0 && a.x[1] == 0.0);
 }
 
-static __COMP_NPY_UNUSED int
+static NPY_INLINE int
 dd_is_positive(const double2 a)
 {
     return (a.x[0] > 0.0);
 }
 
-static __COMP_NPY_UNUSED int
+static NPY_INLINE int
 dd_is_negative(const double2 a)
 {
     return (a.x[0] < 0.0);
 }
 
 /* Cast to double. */
-static __COMP_NPY_UNUSED double
+static NPY_INLINE double
 dd_to_double(const double2 a)
 {
     return a.x[0];
 }
 
 /* Cast to int. */
-static __COMP_NPY_UNUSED int
+static NPY_INLINE int
 dd_to_int(const double2 a)
 {
     return DD_STATIC_CAST(int, a.x[0]);
 }
 
 /*********** Equality and Other Comparisons ************/
-static __COMP_NPY_UNUSED int
+static NPY_INLINE int
 dd_comp(const double2 a, const double2 b)
 {
     int cmp = two_comp(a.x[0], b.x[0]);
@@ -116,7 +116,7 @@ dd_comp(const double2 a, const double2 b)
     return cmp;
 }
 
-static __COMP_NPY_UNUSED int
+static NPY_INLINE int
 dd_comp_dd_d(const double2 a, double b)
 {
     int cmp = two_comp(a.x[0], b);
@@ -126,7 +126,7 @@ dd_comp_dd_d(const double2 a, double b)
     return cmp;
 }
 
-static __COMP_NPY_UNUSED int
+static NPY_INLINE int
 dd_comp_d_dd(double a, const double2 b)
 {
     int cmp = two_comp(a, b.x[0]);
@@ -138,34 +138,34 @@ dd_comp_d_dd(double a, const double2 b)
 
 
 /*********** Creation ************/
-static __COMP_NPY_UNUSED double2
+static NPY_INLINE double2
 dd_create(double hi, double lo)
 {
     double2 ret = {{hi, lo}};
     return ret;
 }
 
-static __COMP_NPY_UNUSED double2
+static NPY_INLINE double2
 dd_zero(void)
 {
     return DD_C_ZERO;
 }
 
-static __COMP_NPY_UNUSED double2
+static NPY_INLINE double2
 dd_create_d(double hi)
 {
     double2 ret = {{hi, 0.0}};
     return ret;
 }
 
-static __COMP_NPY_UNUSED double2
+static NPY_INLINE double2
 dd_create_i(int hi)
 {
     double2 ret = {{DD_STATIC_CAST(double, hi), 0.0}};
     return ret;
 }
 
-static __COMP_NPY_UNUSED double2
+static NPY_INLINE double2
 dd_create_dp(const double *d)
 {
     double2 ret = {{d[0], d[1]}};
@@ -174,7 +174,7 @@ dd_create_dp(const double *d)
 
 
 /*********** Unary Minus ***********/
-static __COMP_NPY_UNUSED double2
+static NPY_INLINE double2
 dd_neg(const double2 a)
 {
     double2 ret = {{-a.x[0], -a.x[1]}};
@@ -183,7 +183,7 @@ dd_neg(const double2 a)
 
 /*********** Rounding ************/
 /* Round to Nearest integer */
-static __COMP_NPY_UNUSED double2
+static NPY_INLINE double2
 dd_nint(const double2 a)
 {
     double hi = two_nint(a.x[0]);
@@ -209,7 +209,7 @@ dd_nint(const double2 a)
     return dd_create(hi, lo);
 }
 
-static __COMP_NPY_UNUSED double2
+static NPY_INLINE double2
 dd_floor(const double2 a)
 {
     double hi = floor(a.x[0]);
@@ -224,7 +224,7 @@ dd_floor(const double2 a)
     return dd_create(hi, lo);
 }
 
-static __COMP_NPY_UNUSED double2
+static NPY_INLINE double2
 dd_ceil(const double2 a)
 {
     double hi = ceil(a.x[0]);
@@ -239,20 +239,20 @@ dd_ceil(const double2 a)
     return dd_create(hi, lo);
 }
 
-static __COMP_NPY_UNUSED double2
+static NPY_INLINE double2
 dd_aint(const double2 a)
 {
     return (a.x[0] >= 0.0) ? dd_floor(a) : dd_ceil(a);
 }
 
 /* Absolute value */
-static __COMP_NPY_UNUSED double2
+static NPY_INLINE double2
 dd_abs(const double2 a)
 {
     return (a.x[0] < 0.0 ? dd_neg(a) : a);
 }
 
-static __COMP_NPY_UNUSED double2
+static NPY_INLINE double2
 dd_fabs(const double2 a)
 {
     return dd_abs(a);
@@ -261,13 +261,13 @@ dd_fabs(const double2 a)
 
 /*********** Normalizing ***********/
 /* double-double * (2.0 ^ expt) */
-static __COMP_NPY_UNUSED double2
+static NPY_INLINE double2
 dd_ldexp(const double2 a, int expt)
 {
     return dd_create(ldexp(a.x[0], expt), ldexp(a.x[1], expt));
 }
 
-static __COMP_NPY_UNUSED double2
+static NPY_INLINE double2
 dd_frexp(const double2 a, int *expt)
 {
 //    r"""return b and l s.t. 0.5<=|b|<1 and 2^l == a
@@ -288,7 +288,7 @@ dd_frexp(const double2 a, int *expt)
 
 
 /*********** Additions ************/
-static __COMP_NPY_UNUSED double2
+static NPY_INLINE double2
 dd_add_d_d(double a, double b)
 {
     double s, e;
@@ -296,7 +296,7 @@ dd_add_d_d(double a, double b)
     return dd_create(s, e);
 }
 
-static __COMP_NPY_UNUSED double2
+static NPY_INLINE double2
 dd_add_dd_d(const double2 a, double b)
 {
     double s1, s2;
@@ -306,7 +306,7 @@ dd_add_dd_d(const double2 a, double b)
     return dd_create(s1, s2);
 }
 
-static __COMP_NPY_UNUSED double2
+static NPY_INLINE double2
 dd_add_d_dd(double a, const double2 b)
 {
     double s1, s2;
@@ -316,7 +316,7 @@ dd_add_d_dd(double a, const double2 b)
     return dd_create(s1, s2);
 }
 
-static __COMP_NPY_UNUSED double2
+static NPY_INLINE double2
 dd_ieee_add(const double2 a, const double2 b)
 {
     /* This one satisfies IEEE style error bound,
@@ -332,7 +332,7 @@ dd_ieee_add(const double2 a, const double2 b)
     return dd_create(s1, s2);
 }
 
-static __COMP_NPY_UNUSED double2
+static NPY_INLINE double2
 dd_sloppy_add(const double2 a, const double2 b)
 {
     /* This is the less accurate version ... obeys Cray-style
@@ -345,7 +345,7 @@ dd_sloppy_add(const double2 a, const double2 b)
     return dd_create(s, e);
 }
 
-static __COMP_NPY_UNUSED double2
+static NPY_INLINE double2
 dd_add(const double2 a, const double2 b)
 {
     /* Always require IEEE-style error bounds */
@@ -354,7 +354,7 @@ dd_add(const double2 a, const double2 b)
 
 /*********** Subtractions ************/
 /* double-double = double - double */
-static __COMP_NPY_UNUSED double2
+static NPY_INLINE double2
 dd_sub_d_d(double a, double b)
 {
     double s, e;
@@ -362,13 +362,13 @@ dd_sub_d_d(double a, double b)
     return dd_create(s, e);
 }
 
-static __COMP_NPY_UNUSED double2
+static NPY_INLINE double2
 dd_sub(const double2 a, const double2 b)
 {
     return dd_ieee_add(a, dd_neg(b));
 }
 
-static __COMP_NPY_UNUSED double2
+static NPY_INLINE double2
 dd_sub_dd_d(const double2 a, double b)
 {
     double s1, s2;
@@ -378,7 +378,7 @@ dd_sub_dd_d(const double2 a, double b)
     return dd_create(s1, s2);
 }
 
-static __COMP_NPY_UNUSED double2
+static NPY_INLINE double2
 dd_sub_d_dd(double a, const double2 b)
 {
     double s1, s2;
@@ -391,7 +391,7 @@ dd_sub_d_dd(double a, const double2 b)
 
 /*********** Multiplications ************/
 /* double-double = double * double */
-static __COMP_NPY_UNUSED double2
+static NPY_INLINE double2
 dd_mul_d_d(double a, double b)
 {
     double p, e;
@@ -400,13 +400,13 @@ dd_mul_d_d(double a, double b)
 }
 
 /* double-double * double,  where double is a power of 2. */
-static __COMP_NPY_UNUSED double2
+static NPY_INLINE double2
 dd_mul_pwr2(const double2 a, double b)
 {
     return dd_create(a.x[0] * b, a.x[1] * b);
 }
 
-static __COMP_NPY_UNUSED double2
+static NPY_INLINE double2
 dd_mul(const double2 a, const double2 b)
 {
     double p1, p2;
@@ -416,7 +416,7 @@ dd_mul(const double2 a, const double2 b)
     return dd_create(p1, p2);
 }
 
-static __COMP_NPY_UNUSED double2
+static NPY_INLINE double2
 dd_mul_dd_d(const double2 a, double b)
 {
     double p1, p2, e1, e2;
@@ -426,7 +426,7 @@ dd_mul_dd_d(const double2 a, double b)
     return dd_create(p1, e1);
 }
 
-static __COMP_NPY_UNUSED double2
+static NPY_INLINE double2
 dd_mul_d_dd(double a, const double2 b)
 {
     double p1, p2, e1, e2;
@@ -438,7 +438,7 @@ dd_mul_d_dd(double a, const double2 b)
 
 
 /*********** Divisions ************/
-static __COMP_NPY_UNUSED double2
+static NPY_INLINE double2
 dd_sloppy_div(const double2 a, const double2 b)
 {
     double s1, s2;
@@ -461,7 +461,7 @@ dd_sloppy_div(const double2 a, const double2 b)
     return r;
 }
 
-static __COMP_NPY_UNUSED double2
+static NPY_INLINE double2
 dd_accurate_div(const double2 a, const double2 b)
 {
     double q1, q2, q3;
@@ -481,31 +481,31 @@ dd_accurate_div(const double2 a, const double2 b)
     return r;
 }
 
-static __COMP_NPY_UNUSED double2
+static NPY_INLINE double2
 dd_div(const double2 a, const double2 b)
 {
     return dd_accurate_div(a, b);
 }
 
-static __COMP_NPY_UNUSED double2
+static NPY_INLINE double2
 dd_div_d_d(double a, double b)
 {
     return dd_accurate_div(dd_create_d(a), dd_create_d(b));
 }
 
-static __COMP_NPY_UNUSED double2
+static NPY_INLINE double2
 dd_div_dd_d(const double2 a, double b)
 {
     return dd_accurate_div(a, dd_create_d(b));
 }
 
-static __COMP_NPY_UNUSED double2
+static NPY_INLINE double2
 dd_div_d_dd(double a, const double2 b)
 {
     return dd_accurate_div(dd_create_d(a), b);
 }
 
-static __COMP_NPY_UNUSED double2
+static NPY_INLINE double2
 dd_inv(const double2 a)
 {
     return dd_div(DD_C_ONE, a);
@@ -513,14 +513,14 @@ dd_inv(const double2 a)
 
 
 /********** Remainder **********/
-static __COMP_NPY_UNUSED double2
+static NPY_INLINE double2
 dd_drem(const double2 a, const double2 b)
 {
     double2 n = dd_nint(dd_div(a, b));
     return dd_sub(a, dd_mul(n, b));
 }
 
-static __COMP_NPY_UNUSED double2
+static NPY_INLINE double2
 dd_divrem(const double2 a, const double2 b, double2 *r)
 {
     double2 n = dd_nint(dd_div(a, b));
@@ -528,7 +528,7 @@ dd_divrem(const double2 a, const double2 b, double2 *r)
     return n;
 }
 
-static __COMP_NPY_UNUSED double2
+static NPY_INLINE double2
 dd_fmod(const double2 a, const double2 b)
 {
     double2 n = dd_aint(dd_div(a, b));
@@ -536,7 +536,7 @@ dd_fmod(const double2 a, const double2 b)
 }
 
 /*********** Squaring **********/
-static __COMP_NPY_UNUSED double2
+static NPY_INLINE double2
 dd_sqr(const double2 a)
 {
     double p1, p2;
@@ -548,7 +548,7 @@ dd_sqr(const double2 a)
     return dd_create(s1, s2);
 }
 
-static __COMP_NPY_UNUSED double2
+static NPY_INLINE double2
 dd_sqr_d(double a)
 {
     double p1, p2;


### PR DESCRIPTION
Add the __COMP_NPY_UNUSED attribute to the dd_real inline static functions.