### PR TITLE
MAINT: stats cleanup

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -4777,11 +4777,8 @@ def ks_2samp(data1, data2):
     cdf2 = np.searchsorted(data2, data_all, side='right') / n2
     d = np.max(np.absolute(cdf1 - cdf2))
     # Note: d absolute not signed distance
-    en = np.sqrt(n1 * n2 / float(n1 + n2))
-    try:
-        prob = distributions.kstwobign.sf((en + 0.12 + 0.11 / en) * d)
-    except:
-        prob = 1.0
+    en = np.sqrt(n1 * n2 / (n1 + n2))
+    prob = distributions.kstwobign.sf((en + 0.12 + 0.11 / en) * d)
 
     return Ks_2sampResult(d, prob)
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1310,7 +1310,7 @@ def skewtest(a, axis=0, nan_policy='propagate'):
         a = np.ravel(a)
         axis = 0
     b2 = skew(a, axis)
-    n = float(a.shape[axis])
+    n = a.shape[axis]
     if n < 8:
         raise ValueError(
             "skewtest is not valid with less than 8 samples; %i samples"
@@ -1386,7 +1386,7 @@ def kurtosistest(a, axis=0, nan_policy='propagate'):
         a = ma.masked_invalid(a)
         return mstats_basic.kurtosistest(a, axis)
 
-    n = float(a.shape[axis])
+    n = a.shape[axis]
     if n < 5:
         raise ValueError(
             "kurtosistest requires at least 5 observations; %i observations"
@@ -1532,7 +1532,7 @@ def jarque_bera(x):
 
     """
     x = np.asarray(x)
-    n = float(x.size)
+    n = x.size
     if n == 0:
         raise ValueError('At least one observation is required.')
 
@@ -1799,11 +1799,11 @@ def percentileofscore(a, score, kind='rank'):
         pct = (right + left + (1 if right > left else 0)) * 50.0/n
         return pct
     elif kind == 'strict':
-        return np.count_nonzero(a < score) / float(n) * 100
+        return np.count_nonzero(a < score) / n * 100
     elif kind == 'weak':
-        return np.count_nonzero(a <= score) / float(n) * 100
+        return np.count_nonzero(a <= score) / n * 100
     elif kind == 'mean':
-        pct = (np.count_nonzero(a < score) + np.count_nonzero(a <= score)) / float(n) * 50
+        pct = (np.count_nonzero(a < score) + np.count_nonzero(a <= score)) / n * 50
         return pct
     else:
         raise ValueError("kind can only be 'rank', 'strict', 'weak' or 'mean'")
@@ -2047,7 +2047,7 @@ def relfreq(a, numbins=10, defaultreallimits=None, weights=None):
     """
     a = np.asanyarray(a)
     h, l, b, e = _histogram(a, numbins, defaultreallimits, weights=weights)
-    h = h / float(a.shape[0])
+    h = h / a.shape[0]
 
     return RelfreqResult(h, l, b, e)
 
@@ -2919,19 +2919,19 @@ def f_oneway(*args):
     offset = alldata.mean()
     alldata -= offset
 
-    sstot = _sum_of_squares(alldata) - (_square_of_sums(alldata) / float(bign))
+    sstot = _sum_of_squares(alldata) - (_square_of_sums(alldata) / bign)
     ssbn = 0
     for a in args:
-        ssbn += _square_of_sums(a - offset) / float(len(a))
+        ssbn += _square_of_sums(a - offset) / len(a)
 
     # Naming: variables ending in bn/b are for "between treatments", wn/w are
     # for "within treatments"
-    ssbn -= (_square_of_sums(alldata) / float(bign))
+    ssbn -= _square_of_sums(alldata) / bign
     sswn = sstot - ssbn
     dfbn = num_groups - 1
     dfwn = bign - num_groups
-    msb = ssbn / float(dfbn)
-    msw = sswn / float(dfwn)
+    msb = ssbn / dfbn
+    msw = sswn / dfwn
     f = msb / msw
 
     prob = special.fdtrc(dfbn, dfwn, f)   # equivalent to stats.f.sf
@@ -3097,7 +3097,7 @@ def fisher_exact(table, alternative='two-sided'):
         return np.nan, 1.0
 
     if c[1, 0] > 0 and c[0, 1] > 0:
-        oddsratio = c[0, 0] * c[1, 1] / float(c[1, 0] * c[0, 1])
+        oddsratio = c[0, 0] * c[1, 1] / (c[1, 0] * c[0, 1])
     else:
         oddsratio = np.inf
 
@@ -3152,7 +3152,7 @@ def fisher_exact(table, alternative='two-sided'):
         # Same formula as the 'less' case, but with the second column.
         pvalue = hypergeom.cdf(c[0, 1], n1 + n2, n1, c[0, 1] + c[1, 1])
     elif alternative == 'two-sided':
-        mode = int(float((n + 1) * (n1 + 1)) / (n1 + n2 + 2))
+        mode = int((n + 1) * (n1 + 1) / (n1 + n2 + 2))
         pexact = hypergeom.pmf(c[0, 0], n1 + n2, n1, n)
         pmode = hypergeom.pmf(mode, n1 + n2, n1, n)
 
@@ -3830,7 +3830,7 @@ def ttest_1samp(a, popmean, axis=0, nan_policy='propagate'):
 
     d = np.mean(a, axis) - popmean
     v = np.var(a, axis, ddof=1)
-    denom = np.sqrt(v / float(n))
+    denom = np.sqrt(v / n)
 
     with np.errstate(divide='ignore', invalid='ignore'):
         t = np.divide(d, denom)
@@ -4178,12 +4178,12 @@ def ttest_rel(a, b, axis=0, nan_policy='propagate'):
         return np.nan, np.nan
 
     n = a.shape[axis]
-    df = float(n - 1)
+    df = n - 1
 
     d = (a - b).astype(np.float64)
     v = np.var(d, axis, ddof=1)
     dm = np.mean(d, axis)
-    denom = np.sqrt(v / float(n))
+    denom = np.sqrt(v / n)
 
     with np.errstate(divide='ignore', invalid='ignore'):
         t = np.divide(dm, denom)
@@ -4773,8 +4773,8 @@ def ks_2samp(data1, data2):
     n1 = data1.shape[0]
     n2 = data2.shape[0]
     data_all = np.concatenate([data1, data2])
-    cdf1 = np.searchsorted(data1, data_all, side='right') / (1.0*n1)
-    cdf2 = np.searchsorted(data2, data_all, side='right') / (1.0*n2)
+    cdf1 = np.searchsorted(data1, data_all, side='right') / n1
+    cdf2 = np.searchsorted(data2, data_all, side='right') / n2
     d = np.max(np.absolute(cdf1 - cdf2))
     # Note: d absolute not signed distance
     en = np.sqrt(n1 * n2 / float(n1 + n2))
@@ -5086,7 +5086,7 @@ def kruskal(*args, **kwargs):
     j = np.insert(np.cumsum(n), 0, 0)
     ssbn = 0
     for i in range(num_groups):
-        ssbn += _square_of_sums(ranked[j[i]:j[i+1]]) / float(n[i])
+        ssbn += _square_of_sums(ranked[j[i]:j[i+1]]) / n[i]
 
     totaln = np.sum(n)
     h = 12.0 / (totaln * (totaln + 1)) * ssbn - 3 * (totaln + 1)
@@ -5157,7 +5157,7 @@ def friedmanchisquare(*args):
         replist, repnum = find_repeats(array(data[i]))
         for t in repnum:
             ties += t * (t*t - 1)
-    c = 1 - ties / float(k*(k*k - 1)*n)
+    c = 1 - ties / (k*(k*k - 1)*n)
 
     ssbn = np.sum(data.sum(axis=0)**2)
     chisq = (12.0 / (k*n*(k+1)) * ssbn - 3*n*(k+1)) / c

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -4776,7 +4776,13 @@ def ks_2samp(data1, data2):
     d = np.max(np.absolute(cdf1 - cdf2))
     # Note: d absolute not signed distance
     en = np.sqrt(n1 * n2 / (n1 + n2))
-    prob = distributions.kstwobign.sf((en + 0.12 + 0.11 / en) * d)
+    try:
+        prob = distributions.kstwobign.sf((en + 0.12 + 0.11 / en) * d)
+    except Exception:
+        warnings.warn('This should not happen! Please open an issue at '
+                    'https://github.com/scipy/scipy/issues and provide the code '
+                    'you used to trigger this warning.\n')
+        prob = 1.0
 
     return Ks_2sampResult(d, prob)
 


### PR DESCRIPTION
A minor cleanup prompted by looking at the source of `stats.py`. I've done the following:

* Removed explicit int → float conversion because true division is used anyway.
* Removed an empty except statement. This seems like the only change that may impact anything, but I have been unable to find a case that should be caught there (`ks_2samp` will happily produce nonsense even having complex input!).
* Streamlined some code.

None of the above is particularly valuable, so feel free to reject/close the PR.