### PR TITLE
BUG: ndimage: Fix validation of the origin argument in correlate and convolve.

### DIFF
--- a/scipy/ndimage/filters.py
+++ b/scipy/ndimage/filters.py
@@ -49,6 +49,10 @@ __all__ = ['correlate1d', 'convolve1d', 'gaussian_filter1d', 'gaussian_filter',
            'generic_filter1d', 'generic_filter']
 
 
+def _invalid_origin(origin, lenw):
+    return (origin < -(lenw // 2)) or (origin > (lenw - 1) // 2)
+
+
 @_ni_docstrings.docfiller
 def correlate1d(input, weights, axis=-1, output=None, mode="reflect",
                 cval=0.0, origin=0):
@@ -84,9 +88,10 @@ def correlate1d(input, weights, axis=-1, output=None, mode="reflect",
     if not weights.flags.contiguous:
         weights = weights.copy()
     axis = _ni_support._check_axis(axis, input.ndim)
-    if (len(weights) // 2 + origin < 0) or (len(weights) // 2 +
-                                            origin > len(weights)):
-        raise ValueError('invalid origin')
+    if _invalid_origin(origin, len(weights)):
+        raise ValueError('Invalid origin; origin must satisfy '
+                         '-(len(weights) // 2) <= origin <= '
+                         '(len(weights)-1) // 2')
     mode = _ni_support._extend_mode_to_code(mode)
     _nd_image.correlate1d(input, weights, axis, output, mode, cval,
                           origin)
@@ -597,8 +602,11 @@ def _correlate_or_convolve(input, weights, output, mode, cval, origin,
             if not weights.shape[ii] & 1:
                 origins[ii] -= 1
     for origin, lenw in zip(origins, wshape):
-        if (lenw // 2 + origin < 0) or (lenw // 2 + origin > lenw):
-            raise ValueError('invalid origin')
+        if _invalid_origin(origin, lenw):
+            raise ValueError('Invalid origin; origin must satisfy '
+                             '-(weights.shape[k] // 2) <= origin[k] <= '
+                             '(weights.shape[k]-1) // 2')
+
     if not weights.flags.contiguous:
         weights = weights.copy()
     output = _ni_support._get_output(output, input)

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -101,6 +101,25 @@ def test_valid_origins():
         assert_raises(ValueError, filter, data, 3, origin=2)
 
 
+def test_bad_convolve_and_correlate_origins():
+    """Regression test for gh-822."""
+    # Before gh-822 was fixed, these would generate seg. faults or
+    # other crashes on many system.
+    assert_raises(ValueError, sndi.correlate1d,
+                  [0, 1, 2, 3, 4, 5], [1, 1, 2, 0], origin=2)
+    assert_raises(ValueError, sndi.correlate,
+                  [0, 1, 2, 3, 4, 5], [0, 1, 2], origin=[2])
+    assert_raises(ValueError, sndi.correlate,
+                  np.ones((3, 5)), np.ones((2, 2)), origin=[0, 1])
+
+    assert_raises(ValueError, sndi.convolve1d,
+                  np.arange(10), np.ones(3), origin=-2)
+    assert_raises(ValueError, sndi.convolve,
+                  np.arange(10), np.ones(3), origin=[-2])
+    assert_raises(ValueError, sndi.convolve,
+                  np.ones((3, 5)), np.ones((2, 2)), origin=[0, -2])
+
+
 def test_multiple_modes():
     # Test that the filters with multiple mode cababilities for different
     # dimensions give the same result as applying a single mode.


### PR DESCRIPTION
Closes gh-822.

As discussed in the github issue, the validation of the origin argument of
the functions correlate1d, correlate, convolve1d and convolve was allowing
an invalid value, and that invalid value might result in a seg. fault.
The fix (as suggested in the github issue) was to change an inequality
(`>` to `>=`).  In the actual change, the validation formula has been
moved to a separate function and reformulated slightly, but the net effect
is the same as the inequality change discussed in the github issue.