### PR TITLE
ENH: `spatial.cKDTree.query_ball_point`: allow `r` to be an array

### DIFF
--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -13,7 +13,7 @@ import scipy.sparse
 
 cimport numpy as np
 from numpy.math cimport INFINITY
-
+    
 from cpython.mem cimport PyMem_Malloc, PyMem_Realloc, PyMem_Free
 from libc.string cimport memset, memcpy
 
@@ -27,7 +27,7 @@ cdef extern from "limits.h":
 
 cdef extern from "ckdtree_methods.h":
     int number_of_processors
-
+    
 number_of_processors = cpu_count()
 
 from libcpp.vector cimport vector
@@ -35,19 +35,19 @@ from libc cimport string
 
 __all__ = ['cKDTree']
 
-
+    
 # Borrowed references
 # ===================
 
 cdef extern from *:
-
+    
     struct ckdtree:
         pass
-
+        
     int NPY_LIKELY(int)
     int NPY_UNLIKELY(int)
 
-
+       
 cdef extern from "ckdtree_decl.h":
     struct ckdtreenode:
         np.intp_t split_dim
@@ -59,8 +59,8 @@ cdef extern from "ckdtree_decl.h":
         ckdtreenode *greater
         np.intp_t _less
         np.intp_t _greater
-
-
+    
+    
 # C++ helper functions
 # ====================
 
@@ -79,9 +79,9 @@ cdef extern from "ordered_pair.h":
 
 def new_object(obj):
     return obj.__new__(obj)
-
-cdef extern from "cpp_utils.h":
-    object pickle_tree_buffer(vector[ckdtreenode] *buf)
+ 
+cdef extern from "cpp_utils.h": 
+    object pickle_tree_buffer(vector[ckdtreenode] *buf)    
     object unpickle_tree_buffer(vector[ckdtreenode] *buf, object src)
     ckdtreenode *tree_buffer_root(vector[ckdtreenode] *buf)
     ordered_pair *ordered_pair_vector_buf(vector[ordered_pair] *buf)
@@ -89,7 +89,7 @@ cdef extern from "cpp_utils.h":
     void *tree_buffer_pointer(vector[ckdtreenode] *buf)
     np.intp_t *npy_intp_vector_buf(vector[np.intp_t] *buf)
     np.float64_t *npy_float64_vector_buf(vector[np.float64_t] *buf)
-    ctypedef void *intvector_ptr_t
+    ctypedef void *intvector_ptr_t 
 
 
 
@@ -98,27 +98,27 @@ cdef extern from "cpp_utils.h":
 
 cdef class coo_entries:
 
-    cdef:
+    cdef: 
         readonly object __array_interface__
         vector[coo_entry] *buf
-
-    def __cinit__(coo_entries self):
+        
+    def __cinit__(coo_entries self):    
         self.buf = NULL
 
-    def __init__(coo_entries self):
+    def __init__(coo_entries self):    
         self.buf = new vector[coo_entry]()
-
+        
     def __dealloc__(coo_entries self):
         if self.buf != NULL:
             del self.buf
-
+            
     # The methods ndarray, dict, coo_matrix, and dok_matrix must only
     # be called after the buffer is filled with coo_entry data. This
     # is because std::vector can reallocate its internal buffer when
     # push_back is called.
-
-    def ndarray(coo_entries self):
-        cdef:
+            
+    def ndarray(coo_entries self):    
+        cdef: 
             coo_entry *pr
             np.uintp_t uintptr
             np.intp_t n
@@ -126,9 +126,9 @@ cdef class coo_entries:
         res_dtype = np.dtype(_dtype, align = True)
         n = <np.intp_t> self.buf.size()
         if NPY_LIKELY(n > 0):
-            pr = coo_entry_vector_buf(self.buf)
+            pr = coo_entry_vector_buf(self.buf) 
             uintptr = <np.uintp_t> (<void*> pr)
-            dtype = np.dtype(np.uint8)
+            dtype = np.dtype(np.uint8)               
             self.__array_interface__ = dict(
                 data = (uintptr, False),
                 descr = dtype.descr,
@@ -136,11 +136,11 @@ cdef class coo_entries:
                 strides = (dtype.itemsize,),
                 typestr = dtype.str,
                 version = 3,
-            )
+            ) 
             return np.asarray(self).view(dtype=res_dtype)
         else:
             return np.empty(shape=(0,), dtype=res_dtype)
-
+        
     def dict(coo_entries self):
         cdef:
             np.intp_t i, j, k, n
@@ -149,59 +149,59 @@ cdef class coo_entries:
             dict res_dict
         n = <np.intp_t> self.buf.size()
         if NPY_LIKELY(n > 0):
-            pr = coo_entry_vector_buf(self.buf)
-            res_dict = dict()
-            for k in range(n):
+            pr = coo_entry_vector_buf(self.buf)        
+            res_dict = dict()           
+            for k in range(n):                    
                 i = pr[k].i
                 j = pr[k].j
-                v = pr[k].v
+                v = pr[k].v                    
                 res_dict[(i,j)] = v
             return res_dict
         else:
             return {}
-
+    
     def coo_matrix(coo_entries self, m, n):
         res_arr = self.ndarray()
         return scipy.sparse.coo_matrix(
                        (res_arr['v'], (res_arr['i'], res_arr['j'])),
                                        shape=(m, n))
-
+        
     def dok_matrix(coo_entries self, m, n):
         return self.coo_matrix(m,n).todok()
-
-
+        
+        
 # ordered_pair wrapper
 # ====================
 
 cdef class ordered_pairs:
 
-    cdef:
+    cdef: 
         readonly object __array_interface__
         vector[ordered_pair] *buf
-
+        
     def __cinit__(ordered_pairs self):
         self.buf = NULL
 
     def __init__(ordered_pairs self):
         self.buf = new vector[ordered_pair]()
-
+        
     def __dealloc__(ordered_pairs self):
         if self.buf != NULL:
             del self.buf
-
-    # The methods ndarray and set must only be called after the buffer
+            
+    # The methods ndarray and set must only be called after the buffer 
     # is filled with ordered_pair data.
-
+    
     def ndarray(ordered_pairs self):
-        cdef:
+        cdef: 
             ordered_pair *pr
-            np.uintp_t uintptr
-            np.intp_t n
+            np.uintp_t uintptr 
+            np.intp_t n            
         n = <np.intp_t> self.buf.size()
         if NPY_LIKELY(n > 0):
-            pr = ordered_pair_vector_buf(self.buf)
-            uintptr = <np.uintp_t> (<void*> pr)
-            dtype = np.dtype(np.intp)
+            pr = ordered_pair_vector_buf(self.buf) 
+            uintptr = <np.uintp_t> (<void*> pr)       
+            dtype = np.dtype(np.intp)               
             self.__array_interface__ = dict(
                 data = (uintptr, False),
                 descr = dtype.descr,
@@ -213,9 +213,9 @@ cdef class ordered_pairs:
             return np.asarray(self)
         else:
             return np.empty(shape=(0,2), dtype=np.intp)
-
-    def set(ordered_pairs self):
-        cdef:
+        
+    def set(ordered_pairs self):        
+        cdef: 
             ordered_pair *pair
             np.intp_t i, n
             set results
@@ -226,16 +226,16 @@ cdef class ordered_pairs:
             # Needed for Python 2.x on Win64
             for i in range(n):
                 results.add((int(pair.i), int(pair.j)))
-                pair += 1
+                pair += 1 
         else:
             # other platforms
             for i in range(n):
                 results.add((pair.i, pair.j))
                 pair += 1
         return results
-
-
-
+    
+        
+            
 # Tree structure exposed to Python
 # ================================
 
@@ -244,20 +244,20 @@ cdef class cKDTreeNode:
     class cKDTreeNode
 
     This class exposes a Python view of a node in the cKDTree object.
-
+    
     All attributes are read-only.
-
+    
     Attributes
     ----------
     level : int
         The depth of the node. 0 is the level of the root node.
     split_dim : int
-        The dimension along which this node is split. If this value is -1
+        The dimension along which this node is split. If this value is -1  
         the node is a leafnode in the kd-tree. Leafnodes are not split further
         and scanned by brute force.
     split : float
         The value used to separate split this node. Points with value >= split
-        in the split_dim dimension are sorted to the 'greater' subnode
+        in the split_dim dimension are sorted to the 'greater' subnode 
         whereas those with value < split are sorted to the 'lesser' subnode.
     children : int
         The number of data points sorted to this node.
@@ -283,16 +283,16 @@ cdef class cKDTreeNode:
         ckdtreenode           *_node
         np.ndarray            _data
         np.ndarray            _indices
-
+        
     cdef void _setup(cKDTreeNode self):
         self.split_dim = self._node.split_dim
         self.children = self._node.children
         self.split = self._node.split
-
-    property data_points:
+        
+    property data_points:   
         def __get__(cKDTreeNode self):
             return self._data[self.indices,:]
-
+                     
     property indices:
         def __get__(cKDTreeNode self):
             cdef np.intp_t i, start, stop
@@ -301,9 +301,9 @@ cdef class cKDTreeNode:
                 stop = self._node.end_idx
                 return self._indices[start:stop]
             else:
-                return np.hstack([self.lesser.indices,
+                return np.hstack([self.lesser.indices, 
                            self.greater.indices])
-
+                           
     property lesser:
         def __get__(cKDTreeNode self):
             if self.split_dim == -1:
@@ -316,7 +316,7 @@ cdef class cKDTreeNode:
                 n.level = self.level + 1
                 n._setup()
                 return n
-
+                
     property greater:
         def __get__(cKDTreeNode self):
             if self.split_dim == -1:
@@ -330,7 +330,7 @@ cdef class cKDTreeNode:
                 n._setup()
                 return n
 
-
+    
 # Main cKDTree class
 # ==================
 
@@ -338,36 +338,36 @@ cdef extern from "ckdtree_methods.h":
 
     # External build and query methods in C++. These will internally
     # release the GIL to avoid locking up the interpreter.
-
+    
     int ckdtree_isinf(np.float64_t x)
-
-    object build_ckdtree(ckdtree *self,
-                         np.intp_t start_idx,
+    
+    object build_ckdtree(ckdtree *self, 
+                         np.intp_t start_idx, 
                          np.intp_t end_idx,
-                         np.float64_t *maxes,
-                         np.float64_t *mins,
-                         int _median,
+                         np.float64_t *maxes, 
+                         np.float64_t *mins, 
+                         int _median, 
                          int _compact)
 
-    object build_weights(ckdtree *self,
+    object build_weights(ckdtree *self, 
                          np.float64_t *node_weights,
                          np.float64_t *weights)
-
-    object query_knn(const ckdtree *self,
-                     np.float64_t *dd,
-                     np.intp_t    *ii,
+       
+    object query_knn(const ckdtree *self, 
+                     np.float64_t *dd, 
+                     np.intp_t    *ii, 
                      const np.float64_t *xx,
                      const np.intp_t    n,
-                     const np.intp_t    *k,
-                     const np.intp_t    nk,
-                     const np.intp_t    kmax,
-                     const np.float64_t eps,
-                     const np.float64_t p,
-                     const np.float64_t distance_upper_bound)
-
-    object query_pairs(const ckdtree *self,
-                       const np.float64_t r,
-                       const np.float64_t p,
+                     const np.intp_t    *k, 
+                     const np.intp_t    nk, 
+                     const np.intp_t    kmax, 
+                     const np.float64_t eps, 
+                     const np.float64_t p, 
+                     const np.float64_t distance_upper_bound) 
+                     
+    object query_pairs(const ckdtree *self, 
+                       const np.float64_t r, 
+                       const np.float64_t p, 
                        const np.float64_t eps,
                        vector[ordered_pair] *results)
 
@@ -405,15 +405,15 @@ cdef extern from "ckdtree_methods.h":
                            const np.float64_t r,
                            const np.float64_t p,
                            const np.float64_t eps,
-                           vector[np.intp_t] **results)
-
+                           vector[np.intp_t] **results)                     
+     
     object sparse_distance_matrix(const ckdtree *self,
                                   const ckdtree *other,
                                   const np.float64_t p,
                                   const np.float64_t max_distance,
-                                  vector[coo_entry] *results)
-
-
+                                  vector[coo_entry] *results)                    
+                      
+                      
 cdef public class cKDTree [object ckdtree, type ckdtree_type]:
     """
     cKDTree(data, leafsize=16, compact_nodes=True, copy_data=False,
@@ -423,54 +423,54 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
 
     This class provides an index into a set of k-dimensional points
     which can be used to rapidly look up the nearest neighbors of any
-    point.
+    point. 
 
-    The algorithm used is described in Maneewongvatana and Mount 1999.
-    The general idea is that the kd-tree is a binary trie, each of whose
+    The algorithm used is described in Maneewongvatana and Mount 1999. 
+    The general idea is that the kd-tree is a binary tree, each of whose
     nodes represents an axis-aligned hyperrectangle. Each node specifies
     an axis and splits the set of points based on whether their coordinate
-    along that axis is greater than or less than a particular value.
+    along that axis is greater than or less than a particular value. 
 
-    During construction, the axis and splitting point are chosen by the
+    During construction, the axis and splitting point are chosen by the 
     "sliding midpoint" rule, which ensures that the cells do not all
-    become long and thin.
+    become long and thin. 
 
-    The tree can be queried for the r closest neighbors of any given point
-    (optionally returning only those within some maximum distance of the
-    point). It can also be queried, with a substantial gain in efficiency,
+    The tree can be queried for the r closest neighbors of any given point 
+    (optionally returning only those within some maximum distance of the 
+    point). It can also be queried, with a substantial gain in efficiency, 
     for the r approximate closest neighbors.
 
-    For large dimensions (20 is already large) do not expect this to run
+    For large dimensions (20 is already large) do not expect this to run 
     significantly faster than brute force. High-dimensional nearest-neighbor
     queries are a substantial open problem in computer science.
 
     Parameters
     ----------
     data : array_like, shape (n,m)
-        The n data points of dimension m to be indexed. This array is
-        not copied unless this is necessary to produce a contiguous
-        array of doubles, and so modifying this data will result in
+        The n data points of dimension m to be indexed. This array is 
+        not copied unless this is necessary to produce a contiguous 
+        array of doubles, and so modifying this data will result in 
         bogus results. The data are also copied if the kd-tree is built
         with copy_data=True.
     leafsize : positive int, optional
         The number of points at which the algorithm switches over to
         brute-force. Default: 16.
-    compact_nodes : bool, optional
+    compact_nodes : bool, optional    
         If True, the kd-tree is built to shrink the hyperrectangles to
-        the actual data range. This usually gives a more compact tree that
-        is robust against degenerated input data and gives faster queries
+        the actual data range. This usually gives a more compact tree that 
+        is robust against degenerated input data and gives faster queries 
         at the expense of longer build time. Default: True.
     copy_data : bool, optional
-        If True the data is always copied to protect the kd-tree against
+        If True the data is always copied to protect the kd-tree against 
         data corruption. Default: False.
-    balanced_tree : bool, optional
-        If True, the median is used to split the hyperrectangles instead of
-        the midpoint. This usually gives a more compact tree and
+    balanced_tree : bool, optional    
+        If True, the median is used to split the hyperrectangles instead of 
+        the midpoint. This usually gives a more compact tree and 
         faster queries at the expense of longer build time. Default: True.
     boxsize : array_like or scalar, optional
-        Apply a m-d toroidal topology to the KDTree.. The topology is generated
+        Apply a m-d toroidal topology to the KDTree.. The topology is generated 
         by :math:`x_i + n_i L_i` where :math:`n_i` are integers and :math:`L_i`
-        is the boxsize along i-th dimension. The input data shall be wrapped
+        is the boxsize along i-th dimension. The input data shall be wrapped 
         into :math:`[0, L_i)`. A ValueError is raised if any of the data is
         outside of this bound.
 
@@ -504,8 +504,8 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
     """
     cdef:
         vector[ckdtreenode]      *tree_buffer
-        ckdtreenode              *ctree
-        readonly cKDTreeNode     tree
+        ckdtreenode              *ctree 
+        readonly cKDTreeNode     tree 
         readonly np.ndarray      data
         np.float64_t             *raw_data
         readonly np.intp_t       n, m
@@ -523,9 +523,9 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
         readonly np.intp_t       size
 
     def __cinit__(cKDTree self):
-        self.tree_buffer = NULL
-
-    def __init__(cKDTree self, data, np.intp_t leafsize=16, compact_nodes=True,
+        self.tree_buffer = NULL        
+            
+    def __init__(cKDTree self, data, np.intp_t leafsize=16, compact_nodes=True, 
             copy_data=False, balanced_tree=True, boxsize=None):
         cdef np.ndarray[np.float64_t, ndim=2] data_arr
         cdef np.float64_t *tmp
@@ -569,22 +569,22 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
             self._median_workspace = np.zeros(self.n)
 
         self.tree_buffer = new vector[ckdtreenode]()
-
+        
         try:
             tmp = <np.float64_t*> PyMem_Malloc(self.m*2*sizeof(np.float64_t))
-            if tmp == NULL: raise MemoryError()
+            if tmp == NULL: raise MemoryError()            
             memcpy(tmp, self.raw_maxes, self.m*sizeof(np.float64_t))
             memcpy(tmp + self.m, self.raw_mins, self.m*sizeof(np.float64_t))
-            build_ckdtree(<ckdtree*> self, 0, self.n, tmp, tmp + self.m,
+            build_ckdtree(<ckdtree*> self, 0, self.n, tmp, tmp + self.m, 
                 _median, _compact)
         finally:
             PyMem_Free(tmp)
 
         self._median_workspace = None
-
+        
         # set up the tree structure pointers
         self._post_init()
-
+        
         # make the tree viewable from Python
         self.tree = cKDTreeNode()
         self.tree._node = self.ctree
@@ -605,18 +605,18 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
         if self.boxsize_data is not None:
             self.raw_boxsize_data = <np.float64_t*>np.PyArray_DATA(self.boxsize_data)
 
-        return 0
+        return 0        
 
     cdef int _post_init(cKDTree self) except -1:
         # finalize the tree points, this calls _post_init_traverse
-
+        
         self.ctree = tree_buffer_root(self.tree_buffer)
 
         # set the size attribute after tree_buffer is built
         self.size = self.tree_buffer.size()
 
         return self._post_init_traverse(self.ctree)
-
+         
     cdef int _post_init_traverse(cKDTree self, ckdtreenode *node) except -1:
         # recurse the tree and re-initialize
         # "less" and "greater" fields
@@ -629,9 +629,9 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
             node.greater = self.ctree + node._greater
             self._post_init_traverse(node.less)
             self._post_init_traverse(node.greater)
-
+                
         return 0
-
+        
 
     def __dealloc__(cKDTree self):
         if self.tree_buffer != NULL:
@@ -640,7 +640,7 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
     # -----
     # query
     # -----
-
+    
     @cython.boundscheck(False)
     def query(cKDTree self, object x, object k=1, np.float64_t eps=0,
               np.float64_t p=2, np.float64_t distance_upper_bound=INFINITY,
@@ -655,15 +655,15 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
         x : array_like, last dimension self.m
             An array of points to query.
         k : list of integer or integer
-            The list of k-th nearest neighbors to return. If k is an
+            The list of k-th nearest neighbors to return. If k is an 
             integer it is treated as a list of [1, ... k] (range(1, k+1)).
             Note that the counting starts from 1.
         eps : non-negative float
-            Return approximate nearest neighbors; the k-th returned value
-            is guaranteed to be no further than (1+eps) times the
+            Return approximate nearest neighbors; the k-th returned value 
+            is guaranteed to be no further than (1+eps) times the 
             distance to the real k-th nearest neighbor.
         p : float, 1<=p<=infinity
-            Which Minkowski p-norm to use.
+            Which Minkowski p-norm to use. 
             1 is the sum-of-absolute-values "Manhattan" distance
             2 is the usual Euclidean distance
             infinity is the maximum-coordinate-difference distance
@@ -675,11 +675,11 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
         n_jobs : int, optional
             Number of jobs to schedule for parallel processing. If -1 is given
             all processors are used. Default: 1.
-
+                        
         Returns
         -------
         d : array of floats
-            The distances to the nearest neighbors.
+            The distances to the nearest neighbors. 
             If ``x`` has shape ``tuple+(self.m,)``, then ``d`` has shape ``tuple+(k,)``.
             When k == 1, the last dimension of the output is squeezed.
             Missing neighbors are indicated with infinite distances.
@@ -693,9 +693,9 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
         -----
         If the KD-Tree is periodic, the position ``x`` is wrapped into the
         box.
-
+        
         When the input k is a list, a query for arange(max(k)) is performed, but
-        only columns that store the requested values of k are preserved. This is
+        only columns that store the requested values of k are preserved. This is 
         implemented in a manner that reduces memory usage.
 
         Examples
@@ -745,11 +745,11 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
          [13 12]]
 
         """
-
+        
         cdef:
             np.intp_t n, i, j
             int overflown
-
+        
         x_arr = np.asarray(x, dtype=np.float64)
         if x_arr.ndim == 0 or x_arr.shape[x_arr.ndim - 1] != self.m:
             raise ValueError("x must consist of vectors of length %d but "
@@ -767,7 +767,7 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
             if k == 1:
                 nearest = True
             k = np.arange(1, k + 1)
-
+    
         retshape = np.shape(x)[:-1]
         n = <np.intp_t> np.prod(retshape)
         xx = np.ascontiguousarray(x_arr).reshape(n, self.m)
@@ -778,44 +778,44 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
         dd = np.empty((n,len(k)),dtype=np.float64)
         ii = np.empty((n,len(k)),dtype=np.intp)
 
-        # Do the query in an external C++ function.
+        # Do the query in an external C++ function. 
         # The GIL will be released in the external query function.
         def _thread_func(self, np.intp_t start, np.intp_t stop):
-            cdef:
+            cdef: 
                 np.ndarray[np.intp_t,ndim=2] _ii = ii
                 np.ndarray[np.float64_t,ndim=2] _dd = dd
                 np.ndarray[np.float64_t,ndim=2] _xx = xx
                 np.ndarray[np.intp_t,ndim=1] _k = np.array(k, dtype=np.intp)
-
+            
             kmax = np.max(k)
 
-            query_knn(<ckdtree*>self, &_dd[start,0], &_ii[start,0],
+            query_knn(<ckdtree*>self, &_dd[start,0], &_ii[start,0], 
                 &_xx[start,0], stop-start, &_k[0], len(k), kmax, eps, p, distance_upper_bound)
-
-        if (n_jobs == -1):
+        
+        if (n_jobs == -1): 
             n_jobs = number_of_processors
-
+        
         if n_jobs > 1:
             # static scheduling without load balancing is good enough
-
+                             
             ranges = [(j * n // n_jobs, (j + 1) * n // n_jobs)
                             for j in range(n_jobs)]
-
-            # There might be n_jobs+1 threads spawned here, but only n_jobs of
+            
+            # There might be n_jobs+1 threads spawned here, but only n_jobs of 
             # them will do significant work.
             threads = [threading.Thread(target=_thread_func,
                                 args=(self, start, stop)) for start, stop in ranges]
 
-            # Set the daemon flag so the process can be aborted,
+            # Set the daemon flag so the process can be aborted, 
             # start all threads and wait for completion.
             for t in threads:
                 t.daemon = True
                 t.start()
-            for t in threads:
+            for t in threads: 
                 t.join()
         else:
             _thread_func(self, 0, n)
-
+                
         # massage the output in conformabity to the documented behavior
 
         if sizeof(long) < sizeof(np.intp_t):
@@ -827,7 +827,7 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
                         # C long overlow, return array of dtype=np.int_p
                         overflown = True
                         break
-                if overflown:
+                if overflown: 
                     break
 
             if overflown:
@@ -835,8 +835,8 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
                 iiret = np.reshape(ii,retshape+(len(k),))
             else:
                 ddret = np.reshape(dd,retshape+(len(k),))
-                iiret = np.reshape(ii,retshape+(len(k),)).astype(int)
-
+                iiret = np.reshape(ii,retshape+(len(k),)).astype(int) 
+                        
         else:
             # ... most other platforms
             ddret = np.reshape(dd,retshape+(len(k),))
@@ -849,19 +849,19 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
             if single:
                 ddret = float(ddret)
                 iiret = int(iiret)
-
+            
         return ddret, iiret
 
     # ----------------
     # query_ball_point
     # ----------------
 
-    def query_ball_point(cKDTree self, object x, np.float64_t r,
+    def query_ball_point(cKDTree self, object x, object r,
                          np.float64_t p=2., np.float64_t eps=0, n_jobs=1,
                          return_sorted=None):
         """
         query_ball_point(self, x, r, p=2., eps=0)
-
+        
         Find all points within distance r of point(s) x.
 
         Parameters
@@ -869,8 +869,8 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
         x : array_like, shape tuple + (self.m,)
             The point or points to search for neighbors of.
         r : array_like, shape tuple or positive float
-            The radius of points to return. Can be a scalar or an array matching
-            the points dimensions of x.
+            The radius of points to return. Can be a single scalar or an
+            array with shape matching x.shape[:-1].
         p : float, optional
             Which Minkowski p-norm to use.  Should be in the range [1, inf].
         eps : nonnegative float, optional
@@ -912,7 +912,7 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
         [4, 8, 9, 12]
 
         """
-
+        
         cdef:
             np.ndarray[np.float64_t, ndim=1, mode="c"] xx
             np.ndarray[np.float64_t, ndim=2, mode="c"] vxx
@@ -923,18 +923,18 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
             np.intp_t *cur
             list tmp
             np.intp_t i, j, n, m
-
+        
         vres = NULL
         vvres = NULL
-
+        
         try:
-
+               
             x = np.asarray(x, dtype=np.float64)
             r = np.asarray(r, dtype=np.float64)
             rr_size = r.size
             if x.shape[-1] != self.m:
                 raise ValueError("Searching for a %d-dimensional point in a "
-                                 "%d-dimensional KDTree" %
+                                 "%d-dimensional KDTree" % 
                                      (int(x.shape[-1]), int(self.m)))
             if len(x.shape) == 1:
                 if rr_size != 1:
@@ -955,27 +955,27 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
                             tmp[i] = cur[0]
                         cur += 1
                 result = tmp
-
+            
             else:
                 if r.shape != x.shape[:-1] and rr_size != 1:
                     raise ValueError("r must either be an array of shape "
                                      "x.shape[:-1] or 1.")
                 retshape = x.shape[:-1]
-
+                
                 # allocate an array of std::vector<npy_intp>
                 n = np.prod(retshape)
-                vvres = (<vector[np.intp_t] **>
+                vvres = (<vector[np.intp_t] **> 
                     PyMem_Malloc(n * sizeof(intvector_ptr_t)))
                 if vvres == NULL:
                     raise MemoryError()
-
-                memset(<void*> vvres, 0, n * sizeof(intvector_ptr_t))
-
+                
+                memset(<void*> vvres, 0, n * sizeof(intvector_ptr_t))      
+            
                 for i in range(n):
                     vvres[i] = new vector[np.intp_t]()
-
+                
                 result = np.empty(retshape, dtype=object)
-
+                
                 vxx = np.zeros((n,self.m), dtype=np.float64)
                 if rr_size == 1:
                     rr = np.ascontiguousarray(r, dtype=np.float64)
@@ -987,34 +987,34 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
                     if rr_size != 1:
                         rr[i] = r[c]
                     i += 1
-
+                    
                 # multithreading logic is similar to cKDTree.query
-
-                if (n_jobs == -1):
+                                        
+                if (n_jobs == -1): 
                     n_jobs = number_of_processors
-
+        
                 if n_jobs > 1:
-
+                
                     CHUNK = n//n_jobs if n//n_jobs else n
-
-                    def _thread_func(self, _j, _vxx, _rr, p, eps, _vvres, CHUNK, _size):
-                        cdef:
+                             
+                    def _thread_func(self, _j, _vxx, _rr, p, eps, _vvres, CHUNK, _size): 
+                        cdef: 
                             np.intp_t j = _j
                             np.ndarray[np.float64_t,ndim=2] vxx = _vxx
-                            np.ndarray[np.float64_t,ndim=1] rr = _rr
-                            vector[np.intp_t] **vvres
+                            np.ndarray[np.float64_t,ndim=1] rr = _rr 
+                            vector[np.intp_t] **vvres                   
                             np.intp_t start = j*CHUNK
                             np.intp_t stop = start + CHUNK
                             np.intp_t size = _size
                             np.intp_t start_rr = _size
                         start_rr = min(start, size-1)
                         stop = n if stop > n else stop
-                        vvres = (<vector[np.intp_t] **>
-                                  (<void*> (<np.uintp_t> _vvres)))
+                        vvres = (<vector[np.intp_t] **> 
+                                  (<void*> (<np.uintp_t> _vvres)))                                    
                         if start < n:
-                            query_ball_point(<ckdtree*>self, &vxx[start,0],
+                            query_ball_point(<ckdtree*>self, &vxx[start,0], 
                                 &rr[start_rr], size, p, eps, stop-start, vvres+start)
-
+                                
                     vvres_uintp = <np.uintp_t> (<void*> vvres)
                     threads = [threading.Thread(target=_thread_func,
                                args=(self, j, vxx, rr, p, eps,vvres_uintp,CHUNK, rr_size))
@@ -1022,14 +1022,14 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
                     for t in threads:
                         t.daemon = True
                         t.start()
-                    for t in threads:
+                    for t in threads: 
                         t.join()
-
+                                                                
                 else:
-
-                    query_ball_point(<ckdtree*>self, &vxx[0,0], &rr[0], rr_size, p, eps,
+                
+                    query_ball_point(<ckdtree*>self, &vxx[0,0], &rr[0], rr_size, p, eps, 
                         n, vvres)
-
+                
                 i = 0
                 for c in np.ndindex(retshape):
                     m = <np.intp_t> (vvres[i].size())
@@ -1046,23 +1046,24 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
                     else:
                         result[c] = []
                     i += 1
-
+        
         finally:
-            if vres != NULL:
+            if vres != NULL: 
                 del vres
-
+                
             if vvres != NULL:
                 for i in range(n):
                     if vvres[i] != NULL:
-                        del vvres[i]
+                        del vvres[i]     
                 PyMem_Free(vvres)
-
-        return result
+                
+        return result   
+            
 
     # ---------------
     # query_ball_tree
     # ---------------
-
+    
     def query_ball_tree(cKDTree self, cKDTree other,
                         np.float64_t r, np.float64_t p=2., np.float64_t eps=0):
         """
@@ -1092,8 +1093,8 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
             list of the indices of its neighbors in ``other.data``.
 
         """
-
-        cdef:
+        
+        cdef: 
             vector[np.intp_t] **vvres
             np.intp_t i, j, n, m
             np.intp_t *cur
@@ -1104,46 +1105,46 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
         if self.m != other.m:
             raise ValueError("Trees passed to query_ball_tree have different "
                              "dimensionality")
-
+     
         n = self.n
-
+        
         try:
-
+        
             # allocate an array of std::vector<npy_intp>
-            vvres = (<vector[np.intp_t] **>
+            vvres = (<vector[np.intp_t] **> 
                 PyMem_Malloc(n * sizeof(intvector_ptr_t)))
             if vvres == NULL:
                 raise MemoryError()
-
-            memset(<void*> vvres, 0, n * sizeof(intvector_ptr_t))
-
+                
+            memset(<void*> vvres, 0, n * sizeof(intvector_ptr_t))      
+            
             for i in range(n):
                 vvres[i] = new vector[np.intp_t]()
-
+        
             # query in C++
             # the GIL will be released in the C++ code
             query_ball_tree(
                 <ckdtree*> self, <ckdtree*> other, r, p, eps, vvres)
-
-            # store the results in a list of lists
+                          
+            # store the results in a list of lists                                        
             results = n * [None]
             for i in range(n):
                 m = <np.intp_t> (vvres[i].size())
                 if NPY_LIKELY(m > 0):
                     tmp = m * [None]
-                    cur = npy_intp_vector_buf(vvres[i])
+                    cur = npy_intp_vector_buf(vvres[i]) 
                     for j in range(m):
                         tmp[j] = cur[0]
                         cur += 1
                     results[i] = sorted(tmp)
                 else:
-                    results[i] = []
-
+                    results[i] = []    
+                                  
         finally:
             if vvres != NULL:
                 for i in range(n):
                     if vvres[i] != NULL:
-                        del vvres[i]
+                        del vvres[i]     
                 PyMem_Free(vvres)
 
         return results
@@ -1151,7 +1152,7 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
     # -----------
     # query_pairs
     # -----------
-
+    
     def query_pairs(cKDTree self, np.float64_t r, np.float64_t p=2.,
                     np.float64_t eps=0, output_type='set'):
         """
@@ -1178,22 +1179,22 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
         -------
         results : set or ndarray
             Set of pairs ``(i,j)``, with ``i < j``, for which the corresponding
-            positions are close. If output_type is 'ndarray', an ndarry is
+            positions are close. If output_type is 'ndarray', an ndarry is 
             returned instead of a set.
 
         """
-
+                 
         cdef ordered_pairs results
 
         results = ordered_pairs()
         query_pairs(<ckdtree*> self, r, p, eps, results.buf)
-
+        
         if output_type == 'set':
             return results.set()
         elif output_type == 'ndarray':
             return results.ndarray()
         else:
-            raise ValueError("Invalid output type")
+            raise ValueError("Invalid output type") 
 
     def _build_weights(cKDTree self, object weights):
         """
@@ -1222,7 +1223,7 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
         num_of_nodes = self.tree_buffer.size();
         node_weights = np.empty(num_of_nodes, dtype=np.float64)
 
-        # FIXME: use templates to avoid the type conversion
+        # FIXME: use templates to avoid the type conversion 
         proper_weights = np.ascontiguousarray(weights, dtype=np.float64)
 
         if len(proper_weights) != self.n:
@@ -1238,7 +1239,7 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
     # ---------------
 
     @cython.boundscheck(False)
-    def count_neighbors(cKDTree self, cKDTree other, object r, np.float64_t p=2.,
+    def count_neighbors(cKDTree self, cKDTree other, object r, np.float64_t p=2., 
                         object weights=None, int cumulative=True):
         """
         count_neighbors(self, other, r, p=2., weights=None, cumulative=True)
@@ -1260,17 +1261,17 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
             The other tree to draw points from, can be the same tree as self.
         r : float or one-dimensional array of floats
             The radius to produce a count for. Multiple radii are searched with
-            a single tree traversal.
-            If the count is non-cumulative(``cumulative=False``), ``r`` defines
+            a single tree traversal. 
+            If the count is non-cumulative(``cumulative=False``), ``r`` defines 
             the edges of the bins, and must be non-decreasing.
-        p : float, optional
-            1<=p<=infinity.
+        p : float, optional 
+            1<=p<=infinity. 
             Which Minkowski p-norm to use.
             Default 2.0.
         weights : tuple, array_like, or None, optional
             If None, the pair-counting is unweighted.
             If given as a tuple, weights[0] is the weights of points in ``self``, and
-            weights[1] is the weights of points in ``other``; either can be None to
+            weights[1] is the weights of points in ``other``; either can be None to 
             indicate the points are unweighted.
             If given as an array_like, weights is the weights of points in ``self``
             and ``other``. For this to make sense, ``self`` and ``other`` must be the
@@ -1360,7 +1361,7 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
         .. [5] https://github.com/scipy/scipy/pull/5647#issuecomment-168474926
 
         """
-        cdef:
+        cdef: 
             int r_ndim
             np.intp_t n_queries, i
             np.ndarray[np.float64_t, ndim=1, mode="c"] real_r
@@ -1459,11 +1460,11 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
                 return results[0]
         else:
             return results
-
+    
     # ----------------------
     # sparse_distance_matrix
     # ----------------------
-
+    
     def sparse_distance_matrix(cKDTree self, cKDTree other,
                                np.float64_t max_distance,
                                np.float64_t p=2.,
@@ -1481,10 +1482,10 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
         other : cKDTree
 
         max_distance : positive float
-
+        
         p : float, 1<=p<=infinity
-            Which Minkowski p-norm to use.
-
+            Which Minkowski p-norm to use. 
+        
         output_type : string, optional
             Which container to use for output data. Options: 'dok_matrix',
             'coo_matrix', 'dict', or 'ndarray'. Default: 'dok_matrix'.
@@ -1492,29 +1493,29 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
         Returns
         -------
         result : dok_matrix, coo_matrix, dict or ndarray
-            Sparse matrix representing the results in "dictionary of keys"
+            Sparse matrix representing the results in "dictionary of keys" 
             format. If a dict is returned the keys are (i,j) tuples of indices.
             If output_type is 'ndarray' a record array with fields 'i', 'j',
             and 'k' is returned,
         """
-
+        
         cdef coo_entries res
 
         # Make sure trees are compatible
         if self.m != other.m:
             raise ValueError("Trees passed to sparse_distance_matrix have "
-                             "different dimensionality")
+                             "different dimensionality")                                      
         # do the query
         res = coo_entries()
         sparse_distance_matrix(
                 <ckdtree*> self, <ckdtree*> other, p, max_distance, res.buf)
-
+                
         if output_type == 'dict':
             return res.dict()
         elif output_type == 'ndarray':
             return res.ndarray()
         elif output_type == 'coo_matrix':
-            return res.coo_matrix(self.n, other.n)
+            return res.coo_matrix(self.n, other.n)            
         elif output_type == 'dok_matrix':
             return res.dok_matrix(self.n, other.n)
         else:
@@ -1523,9 +1524,9 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
 
     # ----------------------
     # pickle
-    # ----------------------
+    # ----------------------    
 
-
+        
     def __reduce__(self):
         return (new_object, (cKDTree,), self.__getstate__())
 
@@ -1533,31 +1534,32 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
         cdef object state
         cdef object tree = pickle_tree_buffer(self.tree_buffer)
         state = (tree, self.data.copy(), self.n, self.m, self.leafsize,
-                      self.maxes, self.mins, self.indices.copy(),
+                      self.maxes, self.mins, self.indices.copy(), 
                       self.boxsize, self.boxsize_data)
         return state
-
+            
     def __setstate__(cKDTree self, state):
         cdef object tree
         self.tree_buffer = new vector[ckdtreenode]()
-
+        
         # unpack the state
-        (tree, self.data, self.n, self.m, self.leafsize,
+        (tree, self.data, self.n, self.m, self.leafsize, 
             self.maxes, self.mins, self.indices, self.boxsize, self.boxsize_data) = state
 
         # set raw pointers
         self._pre_init()
-
-        # copy kd-tree buffer
-        unpickle_tree_buffer(self.tree_buffer, tree)
-
+        
+        # copy kd-tree buffer 
+        unpickle_tree_buffer(self.tree_buffer, tree)    
+        
         # set up the tree structure pointers
         self._post_init()
-
+        
         # make the tree viewable from Python
         self.tree = cKDTreeNode()
         self.tree._node = self.ctree
         self.tree._data = self.data
         self.tree._indices = self.indices
         self.tree.level = 0
-        self.tree._setup()
+        self.tree._setup() 
+

--- a/scipy/spatial/ckdtree/src/ckdtree_methods.h
+++ b/scipy/spatial/ckdtree/src/ckdtree_methods.h
@@ -189,7 +189,8 @@ count_neighbors_weighted(const ckdtree *self,
 CKDTREE_EXTERN PyObject*
 query_ball_point(const ckdtree *self,
                  const npy_float64 *x,
-                 const npy_float64 r,
+                 const npy_float64 *r,
+                 const npy_intp n_r,
                  const npy_float64 p,
                  const npy_float64 eps,
                  const npy_intp n_queries,
@@ -212,5 +213,3 @@ sparse_distance_matrix(const ckdtree *self,
 
 
 #endif
-
-

--- a/scipy/spatial/ckdtree/src/ckdtree_methods.h
+++ b/scipy/spatial/ckdtree/src/ckdtree_methods.h
@@ -190,7 +190,7 @@ CKDTREE_EXTERN PyObject*
 query_ball_point(const ckdtree *self,
                  const npy_float64 *x,
                  const npy_float64 *r,
-                 const npy_intp n_r,
+		 const npy_intp n_r,
                  const npy_float64 p,
                  const npy_float64 eps,
                  const npy_intp n_queries,
@@ -213,3 +213,5 @@ sparse_distance_matrix(const ckdtree *self,
 
 
 #endif
+
+

--- a/scipy/spatial/ckdtree/src/query_ball_point.cxx
+++ b/scipy/spatial/ckdtree/src/query_ball_point.cxx
@@ -97,13 +97,12 @@ traverse_checking(const ckdtree *self,
     }
 }
 
-
 inline npy_intp min(npy_intp x, npy_intp y) { return x < y ? x : y; }
 
 extern "C" PyObject*
 query_ball_point(const ckdtree *self, const npy_float64 *x,
                  const npy_float64 *r, const npy_intp n_r,
-                 const npy_float64 p, const npy_float64 eps,
+		 const npy_float64 p, const npy_float64 eps,
                  const npy_intp n_queries, std::vector<npy_intp> **results)
 {
 #define HANDLE(cond, kls) \
@@ -118,7 +117,7 @@ query_ball_point(const ckdtree *self, const npy_float64 *x,
         try {
             for (npy_intp i=0; i < n_queries; ++i) {
                 const npy_intp m = self->m;
-                const npy_float64 rr = r[min(i, n_r-1)];
+		const npy_float64 rr = r[min(i, n_r-1)];
                 Rectangle rect(m, self->raw_mins, self->raw_maxes);
                 if (NPY_LIKELY(self->raw_boxsize_data == NULL)) {
                     Rectangle point(m, x + i * m, x + i * m);

--- a/scipy/spatial/ckdtree/src/query_ball_point.cxx
+++ b/scipy/spatial/ckdtree/src/query_ball_point.cxx
@@ -98,14 +98,17 @@ traverse_checking(const ckdtree *self,
 }
 
 
+inline npy_intp min(npy_intp x, npy_intp y) { return x < y ? x : y; }
+
 extern "C" PyObject*
 query_ball_point(const ckdtree *self, const npy_float64 *x,
-                 const npy_float64 r, const npy_float64 p, const npy_float64 eps,
+                 const npy_float64 *r, const npy_intp n_r,
+                 const npy_float64 p, const npy_float64 eps,
                  const npy_intp n_queries, std::vector<npy_intp> **results)
 {
 #define HANDLE(cond, kls) \
     if(cond) { \
-        RectRectDistanceTracker<kls> tracker(self, point, rect, p, eps, r); \
+        RectRectDistanceTracker<kls> tracker(self, point, rect, p, eps, rr); \
         traverse_checking(self, results[i], self->ctree, &tracker); \
     } else
 
@@ -115,6 +118,7 @@ query_ball_point(const ckdtree *self, const npy_float64 *x,
         try {
             for (npy_intp i=0; i < n_queries; ++i) {
                 const npy_intp m = self->m;
+                const npy_float64 rr = r[min(i, n_r-1)];
                 Rectangle rect(m, self->raw_mins, self->raw_maxes);
                 if (NPY_LIKELY(self->raw_boxsize_data == NULL)) {
                     Rectangle point(m, x + i * m, x + i * m);

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -443,6 +443,11 @@ def test_random_ball_vectorized_compiled():
     assert_equal(r.shape,(2,3))
     assert_(isinstance(r[0,0],list))
 
+    ds = np.ones((2,3))
+    r = T.query_ball_point(np.random.randn(2,3,m),ds)
+    assert_equal(r.shape,(2,3))
+    assert_(isinstance(r[0,0],list))
+
 
 def test_query_ball_point_multithreading():
     np.random.seed(0)
@@ -461,6 +466,17 @@ def test_query_ball_point_multithreading():
     for i in range(n):
         if l1[i] or l3[i]:
             assert_array_equal(l1[i],l3[i])
+
+
+def test_random_ball_vectorized_dist_compiled():
+    n = 20
+    m = 5
+    np.random.seed(1234)
+    T = cKDTree(np.random.randn(n,m))
+    ds = np.ones(7)
+    r0 = T.query_ball_point(np.random.randn(7,m),1)
+    r1 = T.query_ball_point(np.random.randn(7,m),ds)
+    assert_(all([np.allclose(sorted(rx0), sorted(rx1)) for rx0, rx1 in zip(r0, r1)]))
 
 
 class two_trees_consistency:


### PR DESCRIPTION
I'm currently using `cKDTree.query_ball_point` to estimate mutual information (e.g., [this set of algorithms](https://journals.aps.org/pre/abstract/10.1103/PhysRevE.69.066138)). One step of the algorithm is to find all points within a distance r_i of each point x_i. Currently, `cKDTree.query_ball_point` only allows for a single scalar `r`. This PR added the option to have `r` either be a scalar or array with shape equal to the number of samples.

This allows for the application above to take advantage of the multithreaded version.

I don't write cython or c very often, so I'm not sure this is the cleanest way to handle the scalar versus array cases. Feedback is appreciated.

This is intended to be 100% backwards compatible.