### PR TITLE
BUG: integrate: Fix crash with repeated t values in odeint.

### DIFF
--- a/scipy/integrate/odepack.py
+++ b/scipy/integrate/odepack.py
@@ -3,9 +3,11 @@ from __future__ import division, print_function, absolute_import
 
 __all__ = ['odeint']
 
+import numpy as np
 from . import _odepack
 from copy import copy
 import warnings
+
 
 class ODEintWarning(Warning):
     pass
@@ -61,6 +63,8 @@ def odeint(func, y0, t, args=(), Dfun=None, col_deriv=0, full_output=0,
     t : array
         A sequence of time points for which to solve for y.  The initial
         value point should be the first element of this sequence.
+        This sequence must be monotonically increasing or monotonically
+        decreasing; repeated values are allowed.
     args : tuple, optional
         Extra arguments to pass to function.
     Dfun : callable(y, t, ...) or callable(t, y, ...)
@@ -225,6 +229,13 @@ def odeint(func, y0, t, args=(), Dfun=None, col_deriv=0, full_output=0,
         ml = -1  # changed to zero inside function call
     if mu is None:
         mu = -1  # changed to zero inside function call
+
+    dt = np.diff(t)
+    if not((dt >= 0).all() or (dt <= 0).all()):
+        raise ValueError("The values in t must be monotonically increasing "
+                         "or monotonically decreasing; repeated values are "
+                         "allowed.")
+
     t = copy(t)
     y0 = copy(y0)
     output = _odepack.odeint(func, y0, t, args, Dfun, col_deriv, ml, mu,

--- a/scipy/integrate/tests/test_integrate.py
+++ b/scipy/integrate/tests/test_integrate.py
@@ -805,3 +805,31 @@ def test_odeint_bad_shapes():
     # shape of array returned by badjac(x, t) is not correct.
     assert_raises(RuntimeError, odeint, sys1, [10, 10], [0, 1], Dfun=badjac)
 
+
+def test_repeated_t_values():
+    """Regression test for gh-8217."""
+
+    def func(x, t):
+        return -0.25*x
+
+    t = np.zeros(10)
+    sol = odeint(func, [1.], t)
+    assert_array_equal(sol, np.ones((len(t), 1)))
+
+    tau = 4*np.log(2)
+    t = [0]*9 + [tau, 2*tau, 2*tau, 3*tau]
+    sol = odeint(func, [1, 2], t, rtol=1e-12, atol=1e-12)
+    expected_sol = np.array([[1.0, 2.0]]*9 +
+                            [[0.5, 1.0],
+                             [0.25, 0.5],
+                             [0.25, 0.5],
+                             [0.125, 0.25]])
+    assert_allclose(sol, expected_sol)
+
+    # Edge case: empty t sequence.
+    sol = odeint(func, [1.], [])
+    assert_array_equal(sol, np.array([], dtype=np.float64).reshape((0, 1)))
+
+    # t values are not monotonic.
+    assert_raises(ValueError, odeint, func, [1.], [0, 1, 0.5, 0])
+    assert_raises(ValueError, odeint, func, [1, 2, 3], [0, -1, -2, 3])


### PR DESCRIPTION
Two changes to odeint:

* Require `t` to be monotonically increasing or monotonically
  decreasing.  Repeated values are allowed.
* If the initial value in `t` is repeated, don't bother calling
  LSODA for those times.  Just copy the initial condition to the
  output.
  This fixes the problem where an input such as `t = np.zeros(10)`
  would abort the Python interpreter (because of how the Fortran
  subroutine LSODA handled the repeated calls with the same value
  of t).

Closes gh-8217.