### PR TITLE
BUG: sparse.linalg: fix up breakdown detection in cgs/bicg/bicgstab

### DIFF
--- a/scipy/sparse/linalg/isolve/iterative/BiCGREVCOM.f.src
+++ b/scipy/sparse/linalg/isolve/iterative/BiCGREVCOM.f.src
@@ -113,7 +113,8 @@
       <rt>   TOL, RHOTOL, 
      $       <sdsd=s,d,s,d>GETBREAK,  
      $       <rc=ws,d,wsc,dz>NRM2
-      <_t>  ALPHA, BETA, RHO, RHO1, <xdot=wsdot,ddot,wcdotc,wzdotc>
+      <_t>  ALPHA, BETA, RHO, RHO1, <xdot=wsdot,ddot,wcdotc,wzdotc>,
+     $     TMPVAL
 *
 *     indicates where to resume from. Only valid when IJOB = 2!
       INTEGER RLBL
@@ -319,7 +320,13 @@
 *****************
  6       CONTINUE
 *****************
-         ALPHA = RHO / <xdot>( N, WORK(1,PTLD), 1, WORK(1,Q), 1 )
+         TMPVAL = <xdot>( N, WORK(1,PTLD), 1, WORK(1,Q), 1 )
+         IF (TMPVAL.EQ.0) THEN
+*           Breakdown
+            INFO = -11
+            GO TO 20
+         ENDIF
+         ALPHA = RHO / TMPVAL
 *
 *        Compute current solution vector x.
 *

--- a/scipy/sparse/linalg/isolve/iterative/BiCGSTABREVCOM.f.src
+++ b/scipy/sparse/linalg/isolve/iterative/BiCGSTABREVCOM.f.src
@@ -308,7 +308,13 @@
  4    CONTINUE
 *****************
 *
-      ALPHA = RHO / <xdot>( N, WORK(1,RTLD), 1, WORK(1,V), 1 )
+      TMPVAL = <xdot>( N, WORK(1,RTLD), 1, WORK(1,V), 1 )
+      IF (TMPVAL.EQ.0) THEN
+*        Breakdown
+         INFO = -11
+         GO TO 20
+      ENDIF
+      ALPHA = RHO / TMPVAL
 *
 *        Early check for tolerance.
 *

--- a/scipy/sparse/linalg/isolve/iterative/CGSREVCOM.f.src
+++ b/scipy/sparse/linalg/isolve/iterative/CGSREVCOM.f.src
@@ -328,7 +328,13 @@
  4       CONTINUE
 *****************
 *
-         ALPHA = RHO / <xdot>( N, WORK(1,RTLD), 1, WORK(1,VHAT), 1 )
+         TMPVAL = <xdot>( N, WORK(1,RTLD), 1, WORK(1,VHAT), 1 )
+         IF (TMPVAL.EQ.0) THEN
+*           Breakdown
+            INFO = -11
+            GO TO 20
+         ENDIF
+         ALPHA = RHO / TMPVAL
 *
          CALL <_c>COPY( N, WORK(1,U), 1, WORK(1,Q), 1 )
          CALL <_c>AXPY( N, -ALPHA, WORK(1,VHAT), 1, WORK(1,Q), 1 )

--- a/scipy/sparse/linalg/isolve/minres.py
+++ b/scipy/sparse/linalg/isolve/minres.py
@@ -1,6 +1,6 @@
 from __future__ import division, print_function, absolute_import
 
-from numpy import sqrt, inner, finfo, zeros
+from numpy import sqrt, inner, finfo, zeros, inf, finfo
 from numpy.linalg import norm
 
 from .utils import make_system
@@ -159,7 +159,8 @@ def minres(A, b, x0=None, shift=0.0, tol=1e-5, maxiter=None,
     rhs1 = beta1
     rhs2 = 0
     tnorm2 = 0
-    ynorm2 = 0
+    gmax = 0
+    gmin = finfo(xtype).max
     cs = -1
     sn = 0
     w = zeros(n, dtype=xtype)
@@ -198,9 +199,6 @@ def minres(A, b, x0=None, shift=0.0, tol=1e-5, maxiter=None,
         if itn == 1:
             if beta/beta1 <= 10*eps:
                 istop = -1  # Terminate later
-            # tnorm2 = alfa**2 ??
-            gmax = abs(alfa)
-            gmin = gmax
 
         # Apply previous rotation Qk-1 to get
         #   [deltak epslnk+1] = [cs  sn][dbark    0   ]
@@ -236,14 +234,13 @@ def minres(A, b, x0=None, shift=0.0, tol=1e-5, maxiter=None,
         gmax = max(gmax, gamma)
         gmin = min(gmin, gamma)
         z = rhs1 / gamma
-        ynorm2 = z**2 + ynorm2
         rhs1 = rhs2 - delta*z
         rhs2 = - epsln*z
 
         # Estimate various norms and test for convergence.
 
         Anorm = sqrt(tnorm2)
-        ynorm = sqrt(ynorm2)
+        ynorm = norm(x)
         epsa = Anorm * eps
         epsx = Anorm * ynorm * eps
         epsr = Anorm * ynorm * tol
@@ -280,7 +277,7 @@ def minres(A, b, x0=None, shift=0.0, tol=1e-5, maxiter=None,
                 istop = 6
             if Acond >= 0.1/eps:
                 istop = 4
-            if epsx >= beta:
+            if epsx >= beta1:
                 istop = 3
             # if rnorm <= epsx   : istop = 2
             # if rnorm <= epsr   : istop = 1

--- a/scipy/sparse/linalg/isolve/minres.py
+++ b/scipy/sparse/linalg/isolve/minres.py
@@ -251,8 +251,14 @@ def minres(A, b, x0=None, shift=0.0, tol=1e-5, maxiter=None,
 
         qrnorm = phibar
         rnorm = qrnorm
-        test1 = rnorm / (Anorm*ynorm)    # ||r||  / (||A|| ||x||)
-        test2 = root / Anorm            # ||Ar|| / (||A|| ||r||)
+        if ynorm == 0 or Anorm == 0:
+            test1 = inf
+        else:
+            test1 = rnorm / (Anorm*ynorm)    # ||r||  / (||A|| ||x||)
+        if Anorm == 0:
+            test2 = inf
+        else:
+            test2 = root / Anorm            # ||Ar|| / (||A|| ||r||)
 
         # Estimate  cond(A).
         # In this version we look at the diagonals of  R  in the


### PR DESCRIPTION
The cgs/bicg/bicgstab algorithms have the known property that they can run into division by zero, in which case the algorithm cannot continue. In principle, in literature there are variants that can deal with this, but in the meantime change the codes so that the computation stops, instead of continuing until maxiter with vectors containing nans.

Also pick some minres bugfixes from upstream.