### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/doc/source/tutorial/fftpack.rst
+++ b/doc/source/tutorial/fftpack.rst
@@ -498,7 +498,7 @@ References
 
 .. [Mak] J. Makhoul, 1980, 'A Fast Cosine Transform in One and Two Dimensions',
        `IEEE Transactions on acoustics, speech and signal processing`
-       vol. 28(1), pp. 27-34, http://dx.doi.org/10.1109/TASSP.1980.1163351
+       vol. 28(1), pp. 27-34, https://doi.org/10.1109/TASSP.1980.1163351
 
 .. [WPW] http://en.wikipedia.org/wiki/Window_function
 

--- a/doc/source/tutorial/fftpack.rst
+++ b/doc/source/tutorial/fftpack.rst
@@ -498,7 +498,7 @@ References
 
 .. [Mak] J. Makhoul, 1980, 'A Fast Cosine Transform in One and Two Dimensions',
        `IEEE Transactions on acoustics, speech and signal processing`
-       vol. 28(1), pp. 27-34, https://doi.org/10.1109/TASSP.1980.1163351
+       vol. 28(1), pp. 27-34, :doi:`10.1109/TASSP.1980.1163351`
 
 .. [WPW] http://en.wikipedia.org/wiki/Window_function
 

--- a/scipy/cluster/_optimal_leaf_ordering.pyx
+++ b/scipy/cluster/_optimal_leaf_ordering.pyx
@@ -148,8 +148,7 @@ cdef int[:] identify_swaps(int[:, ::1] sorted_Z,
     Implements the Optimal Leaf Ordering algorithm described in 
     "Fast Optimal leaf ordering for hierarchical clustering"
         Ziv Bar-Joseph, David K. Gifford, Tommi S. Jaakkola
-        Bioinformatics, 2001, doi: 10.1093/bioinformatics/17.suppl_1.S22
-        https://doi.org/10.1093/bioinformatics/17.suppl_1.S22
+        Bioinformatics, 2001, :doi:`10.1093/bioinformatics/17.suppl_1.S22`
 
     `sorted_Z` : Linkage list, with 'height' column removed. 
 

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -671,7 +671,7 @@ def linkage(y, method='single', metric='euclidean', optimal_ordering=False):
            algorithms", :arXiv:`1109.2378v1`.
     .. [2] Ziv Bar-Joseph, David K. Gifford, Tommi S. Jaakkola, "Fast optimal
            leaf ordering for hierarchical clustering", 2001. Bioinformatics
-           https://doi.org/10.1093/bioinformatics/17.suppl_1.S22
+           :doi:`10.1093/bioinformatics/17.suppl_1.S22`
 
     Examples
     --------

--- a/scipy/fftpack/realtransforms.py
+++ b/scipy/fftpack/realtransforms.py
@@ -354,7 +354,7 @@ def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
     .. [1] 'A Fast Cosine Transform in One and Two Dimensions', by J.
            Makhoul, `IEEE Transactions on acoustics, speech and signal
            processing` vol. 28(1), pp. 27-34,
-           http://dx.doi.org/10.1109/TASSP.1980.1163351 (1980).
+           https://doi.org/10.1109/TASSP.1980.1163351 (1980).
     .. [2] Wikipedia, "Discrete cosine transform",
            http://en.wikipedia.org/wiki/Discrete_cosine_transform
 

--- a/scipy/fftpack/realtransforms.py
+++ b/scipy/fftpack/realtransforms.py
@@ -354,7 +354,7 @@ def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
     .. [1] 'A Fast Cosine Transform in One and Two Dimensions', by J.
            Makhoul, `IEEE Transactions on acoustics, speech and signal
            processing` vol. 28(1), pp. 27-34,
-           https://doi.org/10.1109/TASSP.1980.1163351 (1980).
+           :doi:`10.1109/TASSP.1980.1163351` (1980).
     .. [2] Wikipedia, "Discrete cosine transform",
            http://en.wikipedia.org/wiki/Discrete_cosine_transform
 

--- a/scipy/linalg/interpolative.py
+++ b/scipy/linalg/interpolative.py
@@ -123,22 +123,22 @@ We advise the user to consult also the `documentation for the ID package
 
 .. [2] H. Cheng, Z. Gimbutas, P.G. Martinsson, V. Rokhlin. "On the
     compression of low rank matrices." *SIAM J. Sci. Comput.* 26 (4): 1389--1404,
-    2005. `doi:10.1137/030602678 <http://dx.doi.org/10.1137/030602678>`_.
+    2005. `doi:10.1137/030602678 <https://doi.org/10.1137/030602678>`_.
 
 .. [3] E. Liberty, F. Woolfe, P.G. Martinsson, V. Rokhlin, M.
     Tygert. "Randomized algorithms for the low-rank approximation of matrices."
     *Proc. Natl. Acad. Sci. U.S.A.* 104 (51): 20167--20172, 2007.
-    `doi:10.1073/pnas.0709640104 <http://dx.doi.org/10.1073/pnas.0709640104>`_.
+    `doi:10.1073/pnas.0709640104 <https://doi.org/10.1073/pnas.0709640104>`_.
 
 .. [4] P.G. Martinsson, V. Rokhlin, M. Tygert. "A randomized
     algorithm for the decomposition of matrices." *Appl. Comput. Harmon. Anal.* 30
     (1): 47--68,  2011. `doi:10.1016/j.acha.2010.02.003
-    <http://dx.doi.org/10.1016/j.acha.2010.02.003>`_.
+    <https://doi.org/10.1016/j.acha.2010.02.003>`_.
 
 .. [5] F. Woolfe, E. Liberty, V. Rokhlin, M. Tygert. "A fast
     randomized algorithm for the approximation of matrices." *Appl. Comput.
     Harmon. Anal.* 25 (3): 335--366, 2008. `doi:10.1016/j.acha.2007.12.002
-    <http://dx.doi.org/10.1016/j.acha.2007.12.002>`_.
+    <https://doi.org/10.1016/j.acha.2007.12.002>`_.
 
 
 Tutorial

--- a/scipy/linalg/interpolative.py
+++ b/scipy/linalg/interpolative.py
@@ -123,22 +123,20 @@ We advise the user to consult also the `documentation for the ID package
 
 .. [2] H. Cheng, Z. Gimbutas, P.G. Martinsson, V. Rokhlin. "On the
     compression of low rank matrices." *SIAM J. Sci. Comput.* 26 (4): 1389--1404,
-    2005. `doi:10.1137/030602678 <https://doi.org/10.1137/030602678>`_.
+    2005. :doi:`10.1137/030602678`.
 
 .. [3] E. Liberty, F. Woolfe, P.G. Martinsson, V. Rokhlin, M.
     Tygert. "Randomized algorithms for the low-rank approximation of matrices."
     *Proc. Natl. Acad. Sci. U.S.A.* 104 (51): 20167--20172, 2007.
-    `doi:10.1073/pnas.0709640104 <https://doi.org/10.1073/pnas.0709640104>`_.
+    :doi:`10.1073/pnas.0709640104`.
 
 .. [4] P.G. Martinsson, V. Rokhlin, M. Tygert. "A randomized
     algorithm for the decomposition of matrices." *Appl. Comput. Harmon. Anal.* 30
-    (1): 47--68,  2011. `doi:10.1016/j.acha.2010.02.003
-    <https://doi.org/10.1016/j.acha.2010.02.003>`_.
+    (1): 47--68,  2011. :doi:`10.1016/j.acha.2010.02.003`.
 
 .. [5] F. Woolfe, E. Liberty, V. Rokhlin, M. Tygert. "A fast
     randomized algorithm for the approximation of matrices." *Appl. Comput.
-    Harmon. Anal.* 25 (3): 335--366, 2008. `doi:10.1016/j.acha.2007.12.002
-    <https://doi.org/10.1016/j.acha.2007.12.002>`_.
+    Harmon. Anal.* 25 (3): 335--366, 2008. :doi:`10.1016/j.acha.2007.12.002`.
 
 
 Tutorial

--- a/scipy/misc/common.py
+++ b/scipy/misc/common.py
@@ -231,12 +231,12 @@ def electrocardiogram():
     ----------
     .. [1] Moody GB, Mark RG. The impact of the MIT-BIH Arrhythmia Database.
            IEEE Eng in Med and Biol 20(3):45-50 (May-June 2001).
-           (PMID: 11446209); https://doi.org/10.13026/C2F305
+           (PMID: 11446209); :doi:`10.13026/C2F305`
     .. [2] Goldberger AL, Amaral LAN, Glass L, Hausdorff JM, Ivanov PCh,
            Mark RG, Mietus JE, Moody GB, Peng C-K, Stanley HE. PhysioBank,
            PhysioToolkit, and PhysioNet: Components of a New Research Resource
            for Complex Physiologic Signals. Circulation 101(23):e215-e220;
-           https://doi.org/10.1161/01.CIR.101.23.e215
+           :doi:`10.1161/01.CIR.101.23.e215`
 
     Examples
     --------

--- a/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
@@ -254,7 +254,7 @@ def lobpcg(A, X,
            Toward the Optimal Preconditioned Eigensolver: Locally Optimal
            Block Preconditioned Conjugate Gradient Method.
            SIAM Journal on Scientific Computing 23, no. 2,
-           pp. 517-541. http://dx.doi.org/10.1137/S1064827500366124
+           pp. 517-541. https://doi.org/10.1137/S1064827500366124
 
     .. [2] A. V. Knyazev, I. Lashuk, M. E. Argentati, and E. Ovchinnikov (2007),
            Block Locally Optimal Preconditioned Eigenvalue Xolvers (BLOPEX)

--- a/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
@@ -254,7 +254,7 @@ def lobpcg(A, X,
            Toward the Optimal Preconditioned Eigensolver: Locally Optimal
            Block Preconditioned Conjugate Gradient Method.
            SIAM Journal on Scientific Computing 23, no. 2,
-           pp. 517-541. https://doi.org/10.1137/S1064827500366124
+           pp. 517-541. :doi:`10.1137/S1064827500366124`
 
     .. [2] A. V. Knyazev, I. Lashuk, M. E. Argentati, and E. Ovchinnikov (2007),
            Block Locally Optimal Preconditioned Eigenvalue Xolvers (BLOPEX)

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -4413,7 +4413,7 @@ class moyal_gen(rv_continuous):
     .. [1] J.E. Moyal, "XXX. Theory of ionization fluctuations",
            The London, Edinburgh, and Dublin Philosophical Magazine
            and Journal of Science, vol 46, 263-280, (1955).
-           https://doi.org/10.1080/14786440308521076 (gated)
+           :doi:`10.1080/14786440308521076` (gated)
     .. [2] G. Cordeiro et al., "The beta Moyal: a useful skew distribution",
            International Journal of Research and Reviews in Applied Sciences,
            vol 10, 171-192, (2012).


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Accordingly, this PR updates all DOI links.

Cheers!