### PR TITLE
DOC: stats: A few tweaks to the linregress docstring.

### DIFF
--- a/scipy/stats/_stats_mstats_common.py
+++ b/scipy/stats/_stats_mstats_common.py
@@ -49,17 +49,25 @@ def linregress(x, y=None):
     --------
     >>> import matplotlib.pyplot as plt
     >>> from scipy import stats
+
+    Generate some data:
+
     >>> np.random.seed(12345678)
     >>> x = np.random.random(10)
-    >>> y = np.random.random(10)
+    >>> y = 1.6*x + np.random.random(10)
+
+    Perform the linear regression:
+
     >>> slope, intercept, r_value, p_value, std_err = stats.linregress(x, y)
+    >>> print("slope: %f    intercept: %f" % (slope, intercept))
+    slope: 1.944864    intercept: 0.268578
 
-    To get coefficient of determination (r_squared)
+    To get coefficient of determination (r_squared):
 
-    >>> print("r-squared:", r_value**2)
-    r-squared: 0.08040226853902833
+    >>> print("r-squared: %f" % r_value**2)
+    r-squared: 0.735498
 
-    Plot the data along with the fitted line
+    Plot the data along with the fitted line:
 
     >>> plt.plot(x, y, 'o', label='original data')
     >>> plt.plot(x, intercept + slope*x, 'r', label='fitted line')


### PR DESCRIPTION
The main reason for this change is to not print r_value**2 with
full precision in the docstring.  There is no guarantee that the
value will be *exactly* the same as the code in scipy evolves,
and as it was, even a change of 1 ULP would cause a doctest to
fail.

I also added a line to print the slope and intercept of the
regression line in the docstring, and modified the sample
data to have a nontrivial slope.