### PR TITLE
BUG: stats: Fix logpdf method of invwishart.

### DIFF
--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -2297,8 +2297,7 @@ def _cho_inv_batch(a, check_finite=True):
 
     potrf, potri = get_lapack_funcs(('potrf', 'potri'), (a1,))
 
-    tril_idx = np.tril_indices(a.shape[-2], k=-1)
-    triu_idx = np.triu_indices(a.shape[-2], k=1)
+    triu_rows, triu_cols = np.triu_indices(a.shape[-2], k=1)
     for index in np.ndindex(a1.shape[:-2]):
 
         # Cholesky decomposition
@@ -2319,7 +2318,7 @@ def _cho_inv_batch(a, check_finite=True):
                              ' potrf' % -info)
 
         # Make symmetric (dpotri only fills in the lower triangle)
-        a1[index][triu_idx] = a1[index][tril_idx]
+        a1[index][triu_rows, triu_cols] = a1[index][triu_cols, triu_rows]
 
     return a1
 

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -17,7 +17,7 @@ import numpy
 import numpy as np
 
 import scipy.linalg
-from scipy.stats._multivariate import _PSD, _lnB
+from scipy.stats._multivariate import _PSD, _lnB, _cho_inv_batch
 from scipy.stats import multivariate_normal
 from scipy.stats import matrix_normal
 from scipy.stats import special_ortho_group, ortho_group
@@ -30,6 +30,7 @@ from scipy.stats import ks_2samp, kstest
 from scipy.stats import binom
 
 from scipy.integrate import romb
+from scipy.special import multigammaln
 
 from .common_tests import check_random_state_property
 
@@ -1294,6 +1295,47 @@ class TestInvwishart(object):
         assert_allclose(frozen_w_rvs, manual_w_rvs)
         assert_allclose(iw_rvs, manual_iw_rvs)
         assert_allclose(frozen_iw_rvs, manual_iw_rvs)
+
+    def test_cho_inv_batch(self):
+        """Regression test for gh-8844."""
+        a0 = np.array([[2, 1, 0, 0.5],
+                       [1, 2, 0.5, 0.5],
+                       [0, 0.5, 3, 1],
+                       [0.5, 0.5, 1, 2]])
+        a1 = np.array([[2, -1, 0, 0.5],
+                       [-1, 2, 0.5, 0.5],
+                       [0, 0.5, 3, 1],
+                       [0.5, 0.5, 1, 4]])
+        a = np.array([a0, a1])
+        ainv = a.copy()
+        _cho_inv_batch(ainv)
+        ident = np.eye(4)
+        assert_allclose(a[0].dot(ainv[0]), ident, atol=1e-15)
+        assert_allclose(a[1].dot(ainv[1]), ident, atol=1e-15)
+
+    def test_logpdf_4x4(self):
+        """Regression test for gh-8844."""
+        X = np.array([[2, 1, 0, 0.5],
+                      [1, 2, 0.5, 0.5],
+                      [0, 0.5, 3, 1],
+                      [0.5, 0.5, 1, 2]])
+        Psi = np.array([[9, 7, 3, 1],
+                        [7, 9, 5, 1],
+                        [3, 5, 8, 2],
+                        [1, 1, 2, 9]])
+        nu = 6
+        prob = invwishart.logpdf(X, nu, Psi)
+        # Explicit calculation from the formula on wikipedia.
+        p = X.shape[0]
+        sig, logdetX = np.linalg.slogdet(X)
+        sig, logdetPsi = np.linalg.slogdet(Psi)
+        M = np.linalg.solve(X, Psi)
+        expected = ((nu/2)*logdetPsi
+                    - (nu*p/2)*np.log(2)
+                    - multigammaln(nu/2, p)
+                    - (nu + p + 1)/2*logdetX
+                    - 0.5*M.trace())
+        assert_allclose(prob, expected)
 
 
 class TestSpecialOrthoGroup(object):


### PR DESCRIPTION
The private function _cho_inv_batch in _multivariate.py computes
the inverse of a sequence of symmetric positive definite matrices
using the Cholesky factorization. There was a bug in this function,
where it didn't correctly copy the lower part of the result to the
upper part to make the resulting inverse(s) symmetric.

Closes gh-8844.