### PR TITLE
reshape yout array

### DIFF
--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -3414,7 +3414,7 @@ def dimpulse(system, x0=None, t=None, n=None):
             yout = yout + (one_output[1],)
 
         tout = one_output[0]
-
+        yout = np.reshape(yout,(n,1))
     return tout, yout
 
 


### PR DESCRIPTION
When I want to plot a impulse response(plt.plot(tout,yout)) , I encounter this error(in 100 samples):
"ValueError: x and y must have the same first dimension, but have shapes (100,) and (1, 100, 1)".
tout and yout must have the same dimensions for plotting the impulse response.