### PR TITLE
FIX: Pin version of pytest != 3.6.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ jobs:
             export PATH=/usr/lib/ccache:$PATH
             # XXX: use "numpy>=1.15.0" when it's released
             pypy3 -mpip install --upgrade pip setuptools wheel
-            pypy3 -mpip install --no-build-isolation --extra-index https://antocuni.github.io/pypy-wheels/ubuntu "pytest<3.6" pytest-xdist Tempita "Cython>=0.28.2" mpmath
+            pypy3 -mpip install --no-build-isolation --extra-index https://antocuni.github.io/pypy-wheels/ubuntu "pytest>=3.5,!=3.6.0" pytest-xdist Tempita "Cython>=0.28.2" mpmath
             pypy3 -mpip install --no-build-isolation git+https://github.com/numpy/numpy.git@db552b5b6b37f2ff085b304751d7a2ebed26adc9
       - run:
           name: build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ jobs:
             export PATH=/usr/lib/ccache:$PATH
             # XXX: use "numpy>=1.15.0" when it's released
             pypy3 -mpip install --upgrade pip setuptools wheel
-            pypy3 -mpip install --no-build-isolation --extra-index https://antocuni.github.io/pypy-wheels/ubuntu pytest<3.6 pytest-xdist Tempita "Cython>=0.28.2" mpmath
+            pypy3 -mpip install --no-build-isolation --extra-index https://antocuni.github.io/pypy-wheels/ubuntu "pytest<3.6" pytest-xdist Tempita "Cython>=0.28.2" mpmath
             pypy3 -mpip install --no-build-isolation git+https://github.com/numpy/numpy.git@db552b5b6b37f2ff085b304751d7a2ebed26adc9
       - run:
           name: build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ jobs:
             export PATH=/usr/lib/ccache:$PATH
             # XXX: use "numpy>=1.15.0" when it's released
             pypy3 -mpip install --upgrade pip setuptools wheel
-            pypy3 -mpip install --no-build-isolation --extra-index https://antocuni.github.io/pypy-wheels/ubuntu pytest pytest-xdist Tempita "Cython>=0.28.2" mpmath
+            pypy3 -mpip install --no-build-isolation --extra-index https://antocuni.github.io/pypy-wheels/ubuntu pytest<3.6 pytest-xdist Tempita "Cython>=0.28.2" mpmath
             pypy3 -mpip install --no-build-isolation git+https://github.com/numpy/numpy.git@db552b5b6b37f2ff085b304751d7a2ebed26adc9
       - run:
           name: build

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,8 @@ before_install:
   - travis_retry pip install --upgrade pip setuptools wheel
   - travis_retry pip install cython==0.25.2
   - if [ -n "$NUMPYSPEC" ]; then travis_retry pip install $NUMPYSPEC; fi
-  - travis_retry pip install --upgrade pytest pytest-xdist pytest-faulthandler mpmath argparse Pillow codecov
+  # For now (2018/05/25) we prevent using pytest 3.6 for all CIs as it has a bug, See gh-8866
+  - travis_retry pip install --upgrade pytest<3.6 pytest-xdist pytest-faulthandler mpmath argparse Pillow codecov
   - travis_retry pip install gmpy2  # speeds up mpmath (scipy.special tests)
   - |
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,7 @@ before_install:
   - travis_retry pip install cython==0.25.2
   - if [ -n "$NUMPYSPEC" ]; then travis_retry pip install $NUMPYSPEC; fi
   # For now (2018/05/25) we prevent using pytest 3.6 for all CIs as it has a bug, See gh-8866
-  - travis_retry pip install --upgrade "pytest<3.6" pytest-xdist pytest-faulthandler mpmath argparse Pillow codecov
+  - travis_retry pip install --upgrade "pytest>=3.5,!=3.6.0" pytest-xdist pytest-faulthandler mpmath argparse Pillow codecov
   - travis_retry pip install gmpy2  # speeds up mpmath (scipy.special tests)
   - |
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,7 @@ before_install:
   - travis_retry pip install cython==0.25.2
   - if [ -n "$NUMPYSPEC" ]; then travis_retry pip install $NUMPYSPEC; fi
   # For now (2018/05/25) we prevent using pytest 3.6 for all CIs as it has a bug, See gh-8866
-  - travis_retry pip install --upgrade pytest<3.6 pytest-xdist pytest-faulthandler mpmath argparse Pillow codecov
+  - travis_retry pip install --upgrade "pytest<3.6" pytest-xdist pytest-faulthandler mpmath argparse Pillow codecov
   - travis_retry pip install gmpy2  # speeds up mpmath (scipy.special tests)
   - |
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then

--- a/tools/ci/appveyor/requirements.txt
+++ b/tools/ci/appveyor/requirements.txt
@@ -1,5 +1,6 @@
 numpy
 cython
+pytest<3.6
 pytest-timeout
 pytest-xdist
 pytest-env

--- a/tools/ci/appveyor/requirements.txt
+++ b/tools/ci/appveyor/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 cython
-pytest<3.6
+pytest>=3.5,!=3.6.0
 pytest-timeout
 pytest-xdist
 pytest-env


### PR DESCRIPTION
Suggested as a temporary workaround in #8866.

Closes #8866.