### PR TITLE
Fixes related to invertibility of STFT

### DIFF
--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -304,6 +304,7 @@ Spectral Analysis
    stft           -- Compute the Short Time Fourier Transform
    istft          -- Compute the Inverse Short Time Fourier Transform
    check_COLA     -- Check the COLA constraint for iSTFT reconstruction
+   check_NOLA     -- Check the NOLA constraint for iSTFT reconstruction
 
 """
 from __future__ import division, print_function, absolute_import

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -14,7 +14,7 @@ import warnings
 from scipy._lib.six import string_types
 
 __all__ = ['periodogram', 'welch', 'lombscargle', 'csd', 'coherence',
-           'spectrogram', 'stft', 'istft', 'check_COLA']
+           'spectrogram', 'stft', 'istft', 'check_COLA', 'check_NOLA']
 
 
 def lombscargle(x,
@@ -26,7 +26,7 @@ def lombscargle(x,
     lombscargle(x, y, freqs)
 
     Computes the Lomb-Scargle periodogram.
-    
+
     The Lomb-Scargle periodogram was developed by Lomb [1]_ and further
     extended by Scargle [2]_ to find, and test the significance of weak
     periodic signals with uneven temporal sampling.
@@ -78,7 +78,7 @@ def lombscargle(x,
     .. [1] N.R. Lomb "Least-squares frequency analysis of unequally spaced
            data", Astrophysics and Space Science, vol 39, pp. 447-462, 1976
 
-    .. [2] J.D. Scargle "Studies in astronomical time series analysis. II - 
+    .. [2] J.D. Scargle "Studies in astronomical time series analysis. II -
            Statistical aspects of spectral analysis of unevenly spaced data",
            The Astrophysical Journal, vol 263, pp. 835-853, 1982
 
@@ -99,21 +99,21 @@ def lombscargle(x,
     >>> nin = 1000
     >>> nout = 100000
     >>> frac_points = 0.9 # Fraction of points to select
-     
+
     Randomly select a fraction of an array with timesteps:
 
     >>> r = np.random.rand(nin)
     >>> x = np.linspace(0.01, 10*np.pi, nin)
     >>> x = x[r >= frac_points]
-     
+
     Plot a sine wave for the selected times:
 
     >>> y = A * np.sin(w*x+phi)
 
     Define the array of frequencies for which to compute the periodogram:
-    
+
     >>> f = np.linspace(0.01, 10, nout)
-     
+
     Calculate Lomb-Scargle periodogram:
 
     >>> import scipy.signal as signal
@@ -749,15 +749,16 @@ def check_COLA(window, nperseg, noverlap, tol=1e-10):
 
     See Also
     --------
+    check_NOLA: Check whether the Nonzero Overlap Add (NOLA) constraint is met
     stft: Short Time Fourier Transform
     istft: Inverse Short Time Fourier Transform
 
     Notes
     -----
     In order to enable inversion of an STFT via the inverse STFT in
-    `istft`, the signal windowing must obey the constraint of "Constant
-    OverLap Add" (COLA). This ensures that every point in the input data
-    is equally weighted, thereby avoiding aliasing and allowing full
+    `istft`, it is sufficient that the signal windowing obeys the constraint of
+    "Constant OverLap Add" (COLA). This ensures that every point in the input
+    data is equally weighted, thereby avoiding aliasing and allowing full
     reconstruction.
 
     Some examples of windows that satisfy COLA:
@@ -844,6 +845,133 @@ def check_COLA(window, nperseg, noverlap, tol=1e-10):
     return np.max(np.abs(deviation)) < tol
 
 
+def check_NOLA(window, nperseg, noverlap, tol=1e-10):
+    r"""
+    Check whether the Nonzero Overlap Add (NOLA) constraint is met
+
+    Parameters
+    ----------
+    window : str or tuple or array_like
+        Desired window to use. If `window` is a string or tuple, it is
+        passed to `get_window` to generate the window values, which are
+        DFT-even by default. See `get_window` for a list of windows and
+        required parameters. If `window` is array_like it will be used
+        directly as the window and its length must be nperseg.
+    nperseg : int
+        Length of each segment.
+    noverlap : int
+        Number of points to overlap between segments.
+    tol : float, optional
+        The allowed variance of a bin's weighted sum from the median bin
+        sum.
+
+    Returns
+    -------
+    verdict : bool
+        `True` if chosen combination satisfies the NOLA constraint within
+        `tol`, `False` otherwise
+
+    See Also
+    --------
+    check_COLA: Check whether the Constant OverLap Add (COLA) constraint is met
+    stft: Short Time Fourier Transform
+    istft: Inverse Short Time Fourier Transform
+
+    Notes
+    -----
+    In order to enable inversion of an STFT via the inverse STFT in
+    `istft`, the signal windowing must obey the constraint of "nonzero
+    overlap add" (NOLA):
+
+    .. math:: \sum_{t}w^{2}[n-tH] \ne 0
+
+    for all :math:`n`, where :math:`w` is the window function, :math:`t` is the
+    frame index, and :math:`H` is the hop size (:math:`H` = `nperseg` -
+    `noverlap`).
+
+    This ensures that the normalization factors in the denominator of the
+    overlap-add inversion equation are not zero. Only very pathological windows
+    will fail the NOLA constraint.
+
+    .. versionadded:: 1.2.0
+
+    References
+    ----------
+    .. [1] Julius O. Smith III, "Spectral Audio Signal Processing", W3K
+           Publishing, 2011,ISBN 978-0-9745607-3-1.
+    .. [2] G. Heinzel, A. Ruediger and R. Schilling, "Spectrum and
+           spectral density estimation by the Discrete Fourier transform
+           (DFT), including a comprehensive list of window functions and
+           some new at-top windows", 2002,
+           http://hdl.handle.net/11858/00-001M-0000-0013-557A-5
+
+    Examples
+    --------
+    >>> from scipy import signal
+
+    Confirm NOLA condition for rectangular window of 75% (3/4) overlap:
+
+    >>> signal.check_NOLA(signal.boxcar(100), 100, 75)
+    True
+
+    NOLA is also true for 25% (1/4) overlap:
+
+    >>> signal.check_NOLA(signal.boxcar(100), 100, 25)
+    True
+
+    "Symmetrical" Hann window (for filter design) is also NOLA:
+
+    >>> signal.check_NOLA(signal.hann(120, sym=True), 120, 60)
+    True
+
+    As long as there is overlap, it takes quite a pathological window to fail
+    NOLA:
+
+    >>> w = np.ones(64, dtype="float")
+    >>> w[::2] = 0
+    >>> signal.check_NOLA(w, 64, 32)
+    False
+
+    If there is not enough overlap, a window with zeros at the ends will not
+    work:
+
+    >>> signal.check_NOLA(signal.hann(64), 64, 0)
+    False
+    >>> signal.check_NOLA(signal.hann(64), 64, 1)
+    False
+    >>> signal.check_NOLA(signal.hann(64), 64, 2)
+    True
+    """
+
+    nperseg = int(nperseg)
+
+    if nperseg < 1:
+        raise ValueError('nperseg must be a positive integer')
+
+    if noverlap >= nperseg:
+        raise ValueError('noverlap must be less than nperseg')
+    if noverlap < 0:
+        raise ValueError('noverlap must be a nonnegative integer')
+    noverlap = int(noverlap)
+
+    if isinstance(window, string_types) or type(window) is tuple:
+        win = get_window(window, nperseg)
+    else:
+        win = np.asarray(window)
+        if len(win.shape) != 1:
+            raise ValueError('window must be 1-D')
+        if win.shape[0] != nperseg:
+            raise ValueError('window must have length of nperseg')
+
+    step = nperseg - noverlap
+    binsums = sum(win[ii*step:(ii+1)*step]**2 for ii in range(nperseg//step))
+
+    if nperseg % step != 0:
+        binsums[:nperseg % step] += win[-(nperseg % step):]**2
+
+    return np.min(binsums) > tol
+
+
 def stft(x, fs=1.0, window='hann', nperseg=256, noverlap=None, nfft=None,
          detrend=False, return_onesided=True, boundary='zeros', padded=True,
          axis=-1):
@@ -921,6 +1049,7 @@ def stft(x, fs=1.0, window='hann', nperseg=256, noverlap=None, nfft=None,
     istft: Inverse Short Time Fourier Transform
     check_COLA: Check whether the Constant OverLap Add (COLA) constraint
                 is met
+    check_NOLA: Check whether the Nonzero Overlap Add (NOLA) constraint is met
     welch: Power spectral density by Welch's method.
     spectrogram: Spectrogram by Welch's method.
     csd: Cross spectral density by Welch's method.
@@ -929,17 +1058,26 @@ def stft(x, fs=1.0, window='hann', nperseg=256, noverlap=None, nfft=None,
     Notes
     -----
     In order to enable inversion of an STFT via the inverse STFT in
-    `istft`, the signal windowing must obey the constraint of "Constant
-    OverLap Add" (COLA), and the input signal must have complete
+    `istft`, the signal windowing must obey the constraint of "Nonzero
+    OverLap Add" (NOLA), and the input signal must have complete
     windowing coverage (i.e. ``(x.shape[axis] - nperseg) %
     (nperseg-noverlap) == 0``). The `padded` argument may be used to
     accomplish this.
 
-    The COLA constraint ensures that every point in the input data is
-    equally weighted, thereby avoiding aliasing and allowing full
-    reconstruction. Whether a choice of `window`, `nperseg`, and
-    `noverlap` satisfy this constraint can be tested with
-    `check_COLA`.
+    Given a time-domain signal :math:`x[n]`, a window :math:`w[n]`, and a hop
+    size :math:`H` = `nperseg - noverlap`, the windowed frame at time index
+    :math:`t` is given by
+
+    .. math:: x_{t}[n]=x[n]w[n-tH]
+
+    The overlap-add (OLA) reconstruction equation is given by
+
+    .. math:: x[n]=\frac{\sum_{t}x_{t}[n]w[n-tH]}{\sum_{t}w^{2}[n-tH]}
+
+    The NOLA constraint ensures that every normalization term that appears
+    in the denomimator of the OLA reconstruction equation is nonzero. Whether a
+    choice of `window`, `nperseg`, and `noverlap` satisfy this constraint can
+    be tested with `check_NOLA`.
 
     .. versionadded:: 0.19.0
 
@@ -947,7 +1085,7 @@ def stft(x, fs=1.0, window='hann', nperseg=256, noverlap=None, nfft=None,
     ----------
     .. [1] Oppenheim, Alan V., Ronald W. Schafer, John R. Buck
            "Discrete-Time Signal Processing", Prentice Hall, 1999.
-    .. [2] Daniel W. Griffin, Jae S. Limdt "Signal Estimation from
+    .. [2] Daniel W. Griffin, Jae S. Lim "Signal Estimation from
            Modified Short Fourier Transform", IEEE 1984,
            10.1109/TASSP.1984.1164317
 
@@ -1062,20 +1200,27 @@ def istft(Zxx, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
     stft: Short Time Fourier Transform
     check_COLA: Check whether the Constant OverLap Add (COLA) constraint
                 is met
+    check_NOLA: Check whether the Nonzero Overlap Add (NOLA) constraint is met
 
     Notes
     -----
     In order to enable inversion of an STFT via the inverse STFT with
-    `istft`, the signal windowing must obey the constraint of "Constant
-    OverLap Add" (COLA). This ensures that every point in the input data
-    is equally weighted, thereby avoiding aliasing and allowing full
-    reconstruction. Whether a choice of `window`, `nperseg`, and
-    `noverlap` satisfy this constraint can be tested with
-    `check_COLA`, by using ``nperseg = Zxx.shape[freq_axis]``.
+    `istft`, the signal windowing must obey the constraint of "nonzero
+    overlap add" (NOLA):
+
+    .. math:: \sum_{t}w^{2}[n-tH] \ne 0
+
+    This ensures that the normalization factors that appear in the denominator
+    of the overlap-add reconstruction equation
+
+    .. math:: x[n]=\frac{\sum_{t}x_{t}[n]w[n-tH]}{\sum_{t}w^{2}[n-tH]}
+
+    are not zero. The NOLA constraint can be checked with the `check_NOLA`
+    function.
 
     An STFT which has been modified (via masking or otherwise) is not
     guaranteed to correspond to a exactly realizible signal. This
-    function implements the iSTFT via the least-squares esimation
+    function implements the iSTFT via the least-squares estimation
     algorithm detailed in [2]_, which produces a signal that minimizes
     the mean squared error between the STFT of the returned signal and
     the modified STFT.
@@ -1196,10 +1341,6 @@ def istft(Zxx, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
         raise ValueError('noverlap must be less than nperseg.')
     nstep = nperseg - noverlap
 
-    if not check_COLA(window, nperseg, noverlap):
-        raise ValueError('Window, STFT shape and noverlap do not satisfy the '
-                         'COLA constraint.')
-
     # Rearrange axes if necessary
     if time_axis != Zxx.ndim-1 or freq_axis != Zxx.ndim-2:
         # Turn negative indices to positive for the call to transpose
@@ -1246,12 +1387,15 @@ def istft(Zxx, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
         x[..., ii*nstep:ii*nstep+nperseg] += xsubs[..., ii] * win
         norm[..., ii*nstep:ii*nstep+nperseg] += win**2
 
-    # Divide out normalization where non-tiny
-    x /= np.where(norm > 1e-10, norm, 1.0)
-
     # Remove extension points
     if boundary:
         x = x[..., nperseg//2:-(nperseg//2)]
+        norm = norm[..., nperseg//2:-(nperseg//2)]
+
+    # Divide out normalization where non-tiny
+    if np.sum(norm > 1e-10) != len(norm):
+        warnings.warn("NOLA condition failed, STFT may not be invertible")
+    x /= np.where(norm > 1e-10, norm, 1.0)
 
     if input_onesided:
         x = x.real

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -10,7 +10,7 @@ from pytest import raises as assert_raises
 from scipy._lib._numpy_compat import suppress_warnings
 from scipy import signal, fftpack
 from scipy.signal import (periodogram, welch, lombscargle, csd, coherence,
-                          spectrogram, stft, istft, check_COLA)
+                          spectrogram, stft, istft, check_COLA, check_NOLA)
 from scipy.signal.spectral import _spectral_helper
 
 
@@ -1067,6 +1067,12 @@ class TestSTFT(object):
         assert_raises(ValueError, check_COLA, np.ones((2,2)), 10, 0)
         assert_raises(ValueError, check_COLA, np.ones(20), 10, 0)
 
+        assert_raises(ValueError, check_NOLA, 'hann', -10, 0)
+        assert_raises(ValueError, check_NOLA, 'hann', 10, 20)
+        assert_raises(ValueError, check_NOLA, np.ones((2,2)), 10, 0)
+        assert_raises(ValueError, check_NOLA, np.ones(20), 10, 0)
+        assert_raises(ValueError, check_NOLA, 'hann', 64, -32)
+
         x = np.empty(1024)
         z = stft(x)
 
@@ -1103,9 +1109,40 @@ class TestSTFT(object):
                     ('hann', 256, 255),
                     ]
 
-        for set in settings:
-            msg = '{0}, {1}, {2}'.format(*set)
-            assert_equal(True, check_COLA(*set), err_msg=msg)
+        for setting in settings:
+            msg = '{0}, {1}, {2}'.format(*setting)
+            assert_equal(True, check_COLA(*setting), err_msg=msg)
+
+    def test_check_NOLA(self):
+        settings_pass = [
+                    ('boxcar', 10, 0),
+                    ('boxcar', 10, 9),
+                    ('boxcar', 10, 7),
+                    ('bartlett', 51, 26),
+                    ('bartlett', 51, 10),
+                    ('hann', 256, 128),
+                    ('hann', 256, 192),
+                    ('hann', 256, 37),
+                    ('blackman', 300, 200),
+                    ('blackman', 300, 123),
+                    (('tukey', 0.5), 256, 64),
+                    (('tukey', 0.5), 256, 38),
+                    ('hann', 256, 255),
+                    ('hann', 256, 39),
+                    ]
+        for setting in settings_pass:
+            msg = '{0}, {1}, {2}'.format(*setting)
+            assert_equal(True, check_NOLA(*setting), err_msg=msg)
+
+        w_fail = np.ones(16)
+        w_fail[::2] = 0
+        settings_fail = [
+                    (w_fail, len(w_fail), len(w_fail) // 2),
+                    ('hann', 64, 0),
+        ]
+        for setting in settings_fail:
+            msg = '{0}, {1}, {2}'.format(*setting)
+            assert_equal(False, check_NOLA(*setting), err_msg=msg)
 
     def test_average_all_segments(self):
         np.random.seed(1234)
@@ -1175,6 +1212,63 @@ class TestSTFT(object):
             msg = '{0}, {1}'.format(window, noverlap)
             assert_allclose(t, tr, err_msg=msg)
             assert_allclose(x, xr, err_msg=msg)
+
+    def test_roundtrip_not_nola(self):
+        np.random.seed(1234)
+
+        w_fail = np.ones(16)
+        w_fail[::2] = 0
+        settings = [
+                    (w_fail, 256, len(w_fail), len(w_fail) // 2),
+                    ('hann', 256, 64, 0),
+        ]
+
+        for window, N, nperseg, noverlap in settings:
+            msg = '{0}, {1}, {2}, {3}'.format(window, N, nperseg, noverlap)
+            assert not check_NOLA(window, nperseg, noverlap), msg
+
+            t = np.arange(N)
+            x = 10 * np.random.randn(t.size)
+
+            _, _, zz = stft(x, nperseg=nperseg, noverlap=noverlap,
+                            window=window, detrend=None, padded=True,
+                            boundary='zeros')
+            with pytest.warns(UserWarning, match='NOLA'):
+                tr, xr = istft(zz, nperseg=nperseg, noverlap=noverlap,
+                               window=window, boundary=True)
+
+            assert np.allclose(t, tr[:len(t)]), msg
+            assert not np.allclose(x, xr[:len(x)]), msg
+
+    def test_roundtrip_nola_not_cola(self):
+        np.random.seed(1234)
+
+        settings = [
+                    ('boxcar', 100, 10, 3),           # NOLA True, COLA False
+                    ('bartlett', 101, 51, 37),        # NOLA True, COLA False
+                    ('hann', 1024, 256, 127),         # NOLA True, COLA False
+                    (('tukey', 0.5), 1152, 256, 14),  # NOLA True, COLA False
+                    ('hann', 1024, 256, 5),           # NOLA True, COLA False
+                    ]
+
+        for window, N, nperseg, noverlap in settings:
+            msg = '{0}, {1}, {2}'.format(window, nperseg, noverlap)
+            assert check_NOLA(window, nperseg, noverlap), msg
+            assert not check_COLA(window, nperseg, noverlap), msg
+
+            t = np.arange(N)
+            x = 10 * np.random.randn(t.size)
+
+            _, _, zz = stft(x, nperseg=nperseg, noverlap=noverlap,
+                            window=window, detrend=None, padded=True,
+                            boundary='zeros')
+
+            tr, xr = istft(zz, nperseg=nperseg, noverlap=noverlap,
+                           window=window, boundary=True)
+
+            msg = '{0}, {1}'.format(window, noverlap)
+            assert_allclose(t, tr[:len(t)], err_msg=msg)
+            assert_allclose(x, xr[:len(x)], err_msg=msg)
 
     @pytest.mark.xfail(reason="Needs complex rfft from fftpack, see gh-2487 + gh-6058")
     def test_roundtrip_float32(self):


### PR DESCRIPTION
**Purpose**

This PR addresses issues related to using `istft` to invert `stft`.

**Overview**

The current code has problems related to the [constant-overlap-add](https://www.dsprelated.com/freebooks/sasp/Overlap_Add_OLA_STFT_Processing.html) (COLA) constraint. The detailed math is available in this [blog post](https://gauss256.github.io/blog/cola.html) but a summary is:

1. The COLA constraint is being enforced by `istft` but that is not necessary and prevents people from using valid windowing configurations.
2. The documentation for `stft` and `istft` suggest that COLA is a necessary condition for invertibility. As the above blog post shows, this is not correct. The necessary and sufficient condition is nonzero-overlap-add (NOLA). This is not a standard term in the field but it is defined in the blog post and in the documentation.
3. A new function `check_NOLA` has been created. It parallels `check_COLA`.
4. Given the availability of `check_NOLA` and because we don't know all the use cases users might have for `istft`, there is now no enforcement of COLA or NOLA in that function.

**Feedback wanted**

1. Is the revised/new documentation of `stft`, `istft`, and `check_COLA` clear and correct?
2. Are the unit tests adequate?
3. The code for `check_NOLA` and `check_COLA` are 95% the same and should probably be refactored. Suggestions for the best way to do this are welcome.
4. Does everyone agree that it is OK to not have checks for COLA or NOLA in `istft`?

Related issue: #8791 