### PR TITLE
correctly iterate pytest mark metadata - addresses #8866

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ jobs:
             export PATH=/usr/lib/ccache:$PATH
             # XXX: use "numpy>=1.15.0" when it's released
             pypy3 -mpip install --upgrade pip setuptools wheel
-            pypy3 -mpip install --no-build-isolation --extra-index https://antocuni.github.io/pypy-wheels/ubuntu "pytest>=3.6" pytest-xdist Tempita "Cython>=0.28.2" mpmath
+            pypy3 -mpip install --no-build-isolation --extra-index https://antocuni.github.io/pypy-wheels/ubuntu pytest pytest-xdist Tempita "Cython>=0.28.2" mpmath
             pypy3 -mpip install --no-build-isolation git+https://github.com/numpy/numpy.git@db552b5b6b37f2ff085b304751d7a2ebed26adc9
       - run:
           name: build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ jobs:
             export PATH=/usr/lib/ccache:$PATH
             # XXX: use "numpy>=1.15.0" when it's released
             pypy3 -mpip install --upgrade pip setuptools wheel
-            pypy3 -mpip install --no-build-isolation --extra-index https://antocuni.github.io/pypy-wheels/ubuntu "pytest>=3.5,!=3.6.0" pytest-xdist Tempita "Cython>=0.28.2" mpmath
+            pypy3 -mpip install --no-build-isolation --extra-index https://antocuni.github.io/pypy-wheels/ubuntu "pytest>=3.6" pytest-xdist Tempita "Cython>=0.28.2" mpmath
             pypy3 -mpip install --no-build-isolation git+https://github.com/numpy/numpy.git@db552b5b6b37f2ff085b304751d7a2ebed26adc9
       - run:
           name: build

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,8 +102,7 @@ before_install:
   - travis_retry pip install --upgrade pip setuptools wheel
   - travis_retry pip install cython==0.25.2
   - if [ -n "$NUMPYSPEC" ]; then travis_retry pip install $NUMPYSPEC; fi
-  # For now (2018/05/25) we prevent using pytest 3.6 for all CIs as it has a bug, See gh-8866
-  - travis_retry pip install --upgrade "pytest>=3.5,!=3.6.0" pytest-xdist pytest-faulthandler mpmath argparse Pillow codecov
+  - travis_retry pip install --upgrade "pytest>=3.6.0" pytest-xdist pytest-faulthandler mpmath argparse Pillow codecov
   - travis_retry pip install gmpy2  # speeds up mpmath (scipy.special tests)
   - |
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,7 @@ before_install:
   - travis_retry pip install --upgrade pip setuptools wheel
   - travis_retry pip install cython==0.25.2
   - if [ -n "$NUMPYSPEC" ]; then travis_retry pip install $NUMPYSPEC; fi
-  - travis_retry pip install --upgrade "pytest>=3.6.0" pytest-xdist pytest-faulthandler mpmath argparse Pillow codecov
+  - travis_retry pip install --upgrade pytest pytest-xdist pytest-faulthandler mpmath argparse Pillow codecov
   - travis_retry pip install gmpy2  # speeds up mpmath (scipy.special tests)
   - |
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -5,12 +5,16 @@ import os
 import pytest
 import warnings
 
+from distutils.version import LooseVersion
 from scipy._lib._fpumode import get_fpu_mode
 from scipy._lib._testutils import FPUModeChangeWarning
 
 
 def pytest_runtest_setup(item):
-    mark = item.get_closest_marker("xslow")
+    if LooseVersion(pytest.__version__) >= LooseVersion("3.6.0"):
+        mark = item.get_closest_marker("xslow")
+    else:
+        mark = item.get_marker("xslow")
     if mark is not None:
         try:
             v = int(os.environ.get('SCIPY_XSLOW', '0'))

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -10,7 +10,7 @@ from scipy._lib._testutils import FPUModeChangeWarning
 
 
 def pytest_runtest_setup(item):
-    mark = item.get_marker("xslow")
+    mark = item.get_closest_marker("xslow")
     if mark is not None:
         try:
             v = int(os.environ.get('SCIPY_XSLOW', '0'))

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -4498,9 +4498,11 @@ def cases_64bit():
                 msg = SKIP_TESTS.get(method_name)
                 if bool(msg):
                     marks += [pytest.mark.skip(reason=msg)]
-                for mname in ['skipif', 'skip', 'xfail', 'xslow']:
-                    if hasattr(method, mname):
-                        marks += [getattr(method, mname)]
+
+                markers = getattr(method, 'pytestmark', [])
+                for mark in markers:
+                    if mark.name in ('skipif', 'skip', 'xfail', 'xslow'):
+                        marks.append(mark)
                 yield pytest.param(cls, method_name, marks=marks)
 
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -22,6 +22,7 @@ Run tests if sparse is not installed:
 import operator
 import contextlib
 import functools
+from distutils.version import LooseVersion
 
 import numpy as np
 from scipy._lib.six import xrange, zip as izip
@@ -4499,10 +4500,16 @@ def cases_64bit():
                 if bool(msg):
                     marks += [pytest.mark.skip(reason=msg)]
 
-                markers = getattr(method, 'pytestmark', [])
-                for mark in markers:
-                    if mark.name in ('skipif', 'skip', 'xfail', 'xslow'):
-                        marks.append(mark)
+                if LooseVersion(pytest.__version__) >= LooseVersion("3.6.0"):
+                    markers = getattr(method, 'pytestmark', [])
+                    for mark in markers:
+                        if mark.name in ('skipif', 'skip', 'xfail', 'xslow'):
+                            marks.append(mark)
+                else:
+                    for mname in ['skipif', 'skip', 'xfail', 'xslow']:
+                        if hasattr(method, mname):
+                            marks += [getattr(method, mname)]
+
                 yield pytest.param(cls, method_name, marks=marks)
 
 

--- a/tools/ci/appveyor/requirements.txt
+++ b/tools/ci/appveyor/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 cython
-pytest>=3.6.0
+pytest
 pytest-timeout
 pytest-xdist
 pytest-env

--- a/tools/ci/appveyor/requirements.txt
+++ b/tools/ci/appveyor/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 cython
-pytest>=3.5,!=3.6.0
+pytest>=3.6.0
 pytest-timeout
 pytest-xdist
 pytest-env


### PR DESCRIPTION
this sorts the scipy part of the issue, instead of marker objects,
markerinfo objects where pushed into the pipeline, this would silently work on older pytest releases
but now breaks due to fixing bugs in markers.

pytest will still need to address better errors when marker api boundaries are violated.
