### PR TITLE
ENH: Added TOMS Algorithm 748 as 1-d root finder; 17 test function families

### DIFF
--- a/scipy/optimize/__init__.py
+++ b/scipy/optimize/__init__.py
@@ -142,12 +142,34 @@ Scalar functions
 .. autosummary::
    :toctree: generated/
 
-   brentq - quadratic interpolation Brent method.
-   brenth - Brent method, modified by Harris with hyperbolic extrapolation.
-   ridder - Ridder's method.
-   bisect - Bisection method.
-   newton - Secant method or Newton's method.
    RootResults - The root finding result returned by some root finders.
+   brentq - quadratic interpolation Brent method
+   brenth - Brent method, modified by Harris with hyperbolic extrapolation
+   ridder - Ridder's method
+   bisect - Bisection method
+   newton - Secant method or Newton's method
+   toms748 - Alefeld, Potra & Shi Algorithm 748
+
+The table below lists situations and appropriate methods, along with *asymptotic* convergence rates
+per iteration (and per function evaluation) for successful convergence to a simple root(*).
+
++-------------+-------------+--------------+---------------+---------------------+-------------+----------------------+
+| Domain of f | Has Bracket | Has `fprime` | Has `fprime2` | Available Functions | Convergence                        |
++             +             +              +               +                     +-------------+----------------------+
+|             |             |              |               |                     | Guaranteed? |  Rate(s)(*)          |
++=============+=============+==============+===============+=====================+=============+======================+
+| `R`         | Yes         | N/A          | N/A           | - bisection         | - Yes       | - 1 "Linear"         |
+|             |             |              |               | - brentq            | - Yes       | - >=1, <= 1.62       |
+|             |             |              |               | - brenth            | - Yes       | - >=1, <= 1.62       |
+|             |             |              |               | - ridder            | - Yes       | - 2.0 (1.41)         |
+|             |             |              |               | - toms748           | - Yes       | - 2.7 (1.65)         |
++-------------+-------------+--------------+---------------+---------------------+-------------+----------------------+
+| `R` or `C`  | No          | No           | No            | newton              | No          | 1.62 (1.62)          |
++-------------+-------------+--------------+---------------+---------------------+-------------+----------------------+
+| `R` or `C`  | No          | Yes          | No            | newton              | No          | 2.00 (1.41)          |
++-------------+-------------+--------------+---------------+---------------------+-------------+----------------------+
+| `R` or `C`  | No          | Yes          | Yes           | newton              | No          | 3.00 (1.44)          |
++-------------+-------------+--------------+---------------+---------------------+-------------+----------------------+
 
 
 Fixed point finding:

--- a/scipy/optimize/__init__.py
+++ b/scipy/optimize/__init__.py
@@ -153,11 +153,11 @@ Scalar functions
 The table below lists situations and appropriate methods, along with
 *asymptotic* convergence rates per iteration (and per function evaluation)
 for successful convergence to a simple root(*).
-Bisection is the slowest of them all, adding one bit of accuracy for each f
-unction evaluation, but is guaranteed to converge.
+Bisection is the slowest of them all, adding one bit of accuracy for each
+function evaluation, but is guaranteed to converge.
 The other bracketing methods all (eventually) increase the number of accurate
 bits by about 50% for every function evaluation.
-The derivative-based methods, all built on newton, can converge quite quickly
+The derivative-based methods, all built on `newton`, can converge quite quickly
 if the initial value is close to the root.  They can also be applied to
 functions defined on (a subset of) the complex plane.
 

--- a/scipy/optimize/__init__.py
+++ b/scipy/optimize/__init__.py
@@ -150,8 +150,16 @@ Scalar functions
    newton - Secant method or Newton's method
    toms748 - Alefeld, Potra & Shi Algorithm 748
 
-The table below lists situations and appropriate methods, along with *asymptotic* convergence rates
-per iteration (and per function evaluation) for successful convergence to a simple root(*).
+The table below lists situations and appropriate methods, along with
+*asymptotic* convergence rates per iteration (and per function evaluation)
+for successful convergence to a simple root(*).
+Bisection is the slowest of them all, adding one bit of accuracy for each f
+unction evaluation, but is guaranteed to converge.
+The other bracketing methods all (eventually) increase the number of accurate
+bits by about 50% for every function evaluation.
+The derivative-based methods, all built on newton, can converge quite quickly
+if the initial value is close to the root.  They can also be applied to
+functions defined on (a subset of) the complex plane.
 
 +-------------+-------------+--------------+---------------+---------------------+-------------+----------------------+
 | Domain of f | Has Bracket | Has `fprime` | Has `fprime2` | Available Functions | Convergence                        |

--- a/scipy/optimize/__init__.py
+++ b/scipy/optimize/__init__.py
@@ -142,13 +142,14 @@ Scalar functions
 .. autosummary::
    :toctree: generated/
 
-   RootResults - The root finding result returned by some root finders.
    brentq - quadratic interpolation Brent method
    brenth - Brent method, modified by Harris with hyperbolic extrapolation
    ridder - Ridder's method
    bisect - Bisection method
    newton - Secant method or Newton's method
    toms748 - Alefeld, Potra & Shi Algorithm 748
+   RootResults - The root finding result returned by some root finders.
+
 
 The table below lists situations and appropriate methods, along with
 *asymptotic* convergence rates per iteration (and per function evaluation)

--- a/scipy/optimize/_tstutils.py
+++ b/scipy/optimize/_tstutils.py
@@ -61,7 +61,7 @@ monotone sorts of functions.
 
 
 def f1(x):
-    r"""f1 is a with roots at 0 and 1"""
+    r"""f1 is a quadratic with roots at 0 and 1"""
     return x * (x - 1.)
 
 
@@ -87,7 +87,7 @@ def f2_fpp(x):
 
 
 def f3(x):
-    r"""A quartic with roots at 0,1, 2 and 3"""
+    r"""A quartic with roots at 0, 1, 2 and 3"""
     return x * (x - 1.) * (x - 2.) * (x - 3.)  # x**4 - 6x**3 + 11x**2 - 6x
 
 

--- a/scipy/optimize/_tstutils.py
+++ b/scipy/optimize/_tstutils.py
@@ -75,7 +75,7 @@ def f1_fpp(x):
 
 def f2(x):
     r"""f2 is a symmetric parabola, x**2 - 1"""
-    return x ** 2 - 1
+    return x**2 - 1
 
 
 def f2_fp(x):
@@ -92,11 +92,11 @@ def f3(x):
 
 
 def f3_fp(x):
-    return 4 * x ** 3 - 18 * x ** 2 + 22 * x - 6
+    return 4 * x**3 - 18 * x**2 + 22 * x - 6
 
 
 def f3_fpp(x):
-    return 12 * x ** 2 - 36 * x + 22
+    return 12 * x**2 - 36 * x + 22
 
 
 def f4(x):
@@ -174,17 +174,17 @@ def aps01_fpp(x):
 def aps02_f(x):
     r"""poles at x=n**2, 1st and 2nd derivatives at root are also close to 0"""
     ii = np.arange(1, 21)
-    return -2 * np.sum((2 * ii - 5) ** 2 / (x - ii ** 2) ** 3)
+    return -2 * np.sum((2 * ii - 5)**2 / (x - ii**2)**3)
 
 
 def aps02_fp(x):
     ii = np.arange(1, 21)
-    return 6 * np.sum((2 * ii - 5) ** 2 / (x - ii ** 2) ** 4)
+    return 6 * np.sum((2 * ii - 5)**2 / (x - ii**2)**4)
 
 
 def aps02_fpp(x):
     ii = np.arange(1, 21)
-    return 24 * np.sum((2 * ii - 5) ** 2 / (x - ii ** 2) ** 5)
+    return 24 * np.sum((2 * ii - 5)**2 / (x - ii**2)**5)
 
 
 def aps03_f(x, a, b):
@@ -202,15 +202,15 @@ def aps03_fpp(x, a, b):
 
 def aps04_f(x, n, a):
     r"""Medium-degree polynomial"""
-    return x ** n - a
+    return x**n - a
 
 
 def aps04_fp(x, n, a):
-    return n * x ** (n - 1)
+    return n * x**(n - 1)
 
 
 def aps04_fpp(x, n, a):
-    return n * (n - 1) * x ** (n - 2)
+    return n * (n - 1) * x**(n - 2)
 
 
 def aps05_f(x):
@@ -241,11 +241,11 @@ def aps06_fpp(x, n):
 
 def aps07_f(x, n):
     r"""Upside down parabola with parametrizable height"""
-    return (1 + (1 - n) ** 2) * x - (1 - n * x) ** 2
+    return (1 + (1 - n)**2) * x - (1 - n * x)**2
 
 
 def aps07_fp(x, n):
-    return (1 + (1 - n) ** 2) + 2 * n * (1 - n * x)
+    return (1 + (1 - n)**2) + 2 * n * (1 - n * x)
 
 
 def aps07_fpp(x, n):
@@ -254,41 +254,41 @@ def aps07_fpp(x, n):
 
 def aps08_f(x, n):
     r"""Degree n polynomial"""
-    return x * x - (1 - x) ** n
+    return x * x - (1 - x)**n
 
 
 def aps08_fp(x, n):
-    return 2 * x + n * (1 - x) ** (n - 1)
+    return 2 * x + n * (1 - x)**(n - 1)
 
 
 def aps08_fpp(x, n):
-    return 2 - n * (n - 1) * (1 - x) ** (n - 2)
+    return 2 - n * (n - 1) * (1 - x)**(n - 2)
 
 
 def aps09_f(x, n):
     r"""Upside down quartic with parametrizable height"""
-    return (1 + (1 - n) ** 4) * x - (1 - n * x) ** 4
+    return (1 + (1 - n)**4) * x - (1 - n * x)**4
 
 
 def aps09_fp(x, n):
-    return (1 + (1 - n) ** 4) + 4 * n * (1 - n * x) ** 3
+    return (1 + (1 - n)**4) + 4 * n * (1 - n * x)**3
 
 
 def aps09_fpp(x, n):
-    return -12 * n * (1 - n * x) ** 2
+    return -12 * n * (1 - n * x)**2
 
 
 def aps10_f(x, n):
     r"""Exponential plus a polynomial"""
-    return np.exp(-n * x) * (x - 1) + x ** n
+    return np.exp(-n * x) * (x - 1) + x**n
 
 
 def aps10_fp(x, n):
-    return np.exp(-n * x) * (-n * (x - 1) + 1) + n * x ** (n - 1)
+    return np.exp(-n * x) * (-n * (x - 1) + 1) + n * x**(n - 1)
 
 
 def aps10_fpp(x, n):
-    return np.exp(-n * x) * (-n * (-n * (x - 1) + 1) + -n * x) + n * (n - 1) * x ** (n - 2)
+    return np.exp(-n * x) * (-n * (-n * (x - 1) + 1) + -n * x) + n * (n - 1) * x**(n - 2)
 
 
 def aps11_f(x, n):
@@ -297,11 +297,11 @@ def aps11_f(x, n):
 
 
 def aps11_fp(x, n):
-    return 1 / (n - 1) / x ** 2
+    return 1 / (n - 1) / x**2
 
 
 def aps11_fpp(x, n):
-    return -2 / (n - 1) / x ** 3
+    return -2 / (n - 1) / x**3
 
 
 def aps12_f(x, n):
@@ -327,7 +327,7 @@ def aps13_f(x):
     # x2 = 1.0/x**2
     # if x2 > 708:
     #     return 0
-    y = 1 / x ** 2
+    y = 1 / x**2
     if y > _MAX_EXPABLE:
         return 0
     return x / np.exp(y)
@@ -336,19 +336,19 @@ def aps13_f(x):
 def aps13_fp(x):
     if x == 0:
         return 0
-    y = 1 / x ** 2
+    y = 1 / x**2
     if y > _MAX_EXPABLE:
         return 0
-    return (1 + 2 / x ** 2) / np.exp(y)
+    return (1 + 2 / x**2) / np.exp(y)
 
 
 def aps13_fpp(x):
     if x == 0:
         return 0
-    y = 1 / x ** 2
+    y = 1 / x**2
     if y > _MAX_EXPABLE:
         return 0
-    return 2 * (2 - x ** 2) / x ** 5 / np.exp(y)
+    return 2 * (2 - x**2) / x**5 / np.exp(y)
 
 
 def aps14_f(x, n):
@@ -573,15 +573,15 @@ _APS_TESTS_DICTS = [dict(zip(_APS_TESTS_KEYS, testcase)) for testcase in _APS_TE
 
 def cplx01_f(z, n, a):
     r"""z**n-a:  Use to find the n-th root of a"""
-    return z ** n - a
+    return z**n - a
 
 
 def cplx01_fp(z, n, a):
-    return n * z ** (n - 1)
+    return n * z**(n - 1)
 
 
 def cplx01_fpp(z, n, a):
-    return n * (n - 1) * z ** (n - 2)
+    return n * (n - 1) * z**(n - 2)
 
 
 def cplx02_f(z, a):

--- a/scipy/optimize/_tstutils.py
+++ b/scipy/optimize/_tstutils.py
@@ -1,47 +1,76 @@
-''' Parameters used in test and benchmark methods '''
 from __future__ import division, print_function, absolute_import
 
+r"""
+Collections of test cases suitable for testing 1-dimensional root-finders
+  'original': The original benchmarking functions.
+     Real-valued functions of real-valued inputs on an interval
+     with a zero.
+     f1, .., f3 are continuous and infinitely differentiable
+     f4 has a left- and right- discontinuity at the root
+     f5 has a root at 1 replacing a 1st order pole
+     f6 is randomly positive on one side of the root,
+     randomly negative on the other.
+     f4 - f6 are not continuous at the root.
+
+  'aps': The test problems in the 1995 paper
+     TOMS "Algorithm 748: Enclosing Zeros of Continuous Functions"
+     by Alefeld, Potra and Shi.  Real-valued functions of
+     real-valued inputs on an interval with a zero.
+     Suitable for methods which start with an enclosing interval, and
+     derivatives up to 2nd order.
+
+  'complex': Some complex-valued functions of complex-valued inputs.
+     No enclosing bracket is provided.
+     Suitable for methods which use one or more starting values, and
+     derivatives up to 2nd order.
+
+  The test cases are provided as a list of dictionaries. The dictionary
+  keys will be a subset of:
+  ["f", "fprime", "fprime2", "args", "bracket", "smoothness",
+   "x0", "x1", "root", "ID"]
+"""
+
+''' Parameters used in test and benchmark methods '''
+
+import collections
+import functools
 from random import random
+
+import numpy as np
 
 from scipy.optimize import zeros as cc
 
-
-def f1(x):
-    return x*(x-1.)
-
-
-def f2(x):
-    return x**2 - 1
-
-
-def f3(x):
-    return x*(x-1.)*(x-2.)*(x-3.)
-
-
-def f4(x):
-    if x > 1:
-        return 1.0 + .1*x
-    if x < 1:
-        return -1.0 + .1*x
-    return 0
-
-
-def f5(x):
-    if x != 1:
-        return 1.0/(1. - x)
-    return 0
-
-
-def f6(x):
-    if x > 1:
-        return random()
-    elif x < 1:
-        return -random()
-    else:
-        return 0
-
-
 description = """
+Collections of test cases suitable for testing 1-dimensional root-finders
+  'original': The original benchmarking functions.
+     Real-valued functions of real-valued inputs on an interval
+     with a zero.
+     f1, .., f3 are continuous and infinitely differentiable
+     f4 has a left- and right- discontinuity at the root
+     f5 has a root at 1 replacing a 1st order pole
+     f6 is randomly positive on one side of the root,
+     randomly negative on the other.
+     f4 - f6 are not continuous at the root.
+
+  'aps': The test problems in the 1995 paper
+     TOMS "Algorithm 748: Enclosing Zeros of Continuous Functions"
+     by Alefeld, Potra and Shi.  Real-valued functions of
+     real-valued inputs on an interval with a zero.
+     Suitable for methods which start with an enclosing interval, and
+     derivatives up to 2nd order.
+
+  'complex': Some complex-valued functions of complex-valued inputs.
+     No enclosing bracket is provided.
+     Suitable for methods which use one or more starting values, and
+     derivatives up to 2nd order.
+
+    The test cases are provided as a list of dictionaries. The dictionary
+    keys will be a subset of:
+    ["f", "fprime", "fprime2", "args", "bracket", "smoothness",
+     "a", "b", "x0", "x1", "root", "ID"]
+"""
+
+_old_description = """
 f2 is a symmetric parabola, x**2 - 1
 f3 is a quartic polynomial with large hump in interval
 f4 is step function with a discontinuity at 1
@@ -55,7 +84,663 @@ bisection in such circumstance, while being faster for smooth
 monotone sorts of functions.
 """
 
-methods = [cc.bisect,cc.ridder,cc.brenth,cc.brentq]
-mstrings = ['cc.bisect','cc.ridder','cc.brenth','cc.brentq']
-functions = [f2,f3,f4,f5,f6]
-fstrings = ['f2','f3','f4','f5','f6']
+
+# Sources:
+#  [1] Alefeld, G. E. and Potra, F. A. and Shi, Yixun,
+#      "Algorithm 748: Enclosing Zeros of Continuous Functions", ACM Trans. Math. Softw. Volume 221(1995)
+#       doi = {10.1145/210089.210111},
+
+# Sources:
+#  [1] Alefeld, G. E. and Potra, F. A. and Shi, Yixun,
+#      "Algorithm 748: Enclosing Zeros of Continuous Functions",
+#      ACM Trans. Math. Softw. Volume 221(1995)
+#       doi = {10.1145/210089.210111},
+
+
+def f1(x):
+    r"""f1 is a with roots at 0 and 1"""
+    return x * (x - 1.)
+
+
+def f1_fp(x):
+    return 2 * x - 1
+
+
+def f1_fpp(x):
+    return 2
+
+
+def f2(x):
+    r"""f2 is a symmetric parabola, x**2 - 1"""
+    return x ** 2 - 1
+
+
+def f2_fp(x):
+    return 2 * x
+
+
+def f2_fpp(x):
+    return 2
+
+
+def f3(x):
+    r"""A quartic with roots at 0,1, 2 and 3"""
+    return x * (x - 1.) * (x - 2.) * (x - 3.)  # x**4 - 6x**3 + 11x**2 - 6x
+
+
+def f3_fp(x):
+    return 4 * x ** 3 - 18 * x ** 2 + 22 * x - 6
+
+
+def f3_fpp(x):
+    return 12 * x ** 2 - 36 * x + 22
+
+
+def f4(x):
+    r"""Piecewise linear, left and right discontinuous at x=1, the root."""
+    if x > 1:
+        return 1.0 + .1 * x
+    if x < 1:
+        return -1.0 + .1 * x
+    return 0
+
+
+def f5(x):
+    r"""Hyperbola with a pole at x=1, but pole replaced with 0.  Not continuous at root."""
+    if x != 1:
+        return 1.0 / (1. - x)
+    return 0
+
+
+# https://wiki.python.org/moin/PythonDecoratorLibrary#Memoize
+class memoized(object):
+    '''Decorator. Caches a function's return value each time it is called.
+   If called later with the same arguments, the cached value is returned
+   (not reevaluated).
+   '''
+
+    def __init__(self, func):
+        self.func = func
+        self.cache = {}
+
+    def __call__(self, *args):
+        if not isinstance(args, collections.Hashable):
+            # uncacheable. a list, for instance.
+            # better to not cache than blow up.
+            return self.func(*args)
+        if args in self.cache:
+            return self.cache[args]
+        else:
+            value = self.func(*args)
+            self.cache[args] = value
+            return value
+
+    def __repr__(self):
+        '''Return the function's docstring.'''
+        return self.func.__doc__
+
+    def __get__(self, obj, objtype):
+        '''Support instance methods.'''
+        return functools.partial(self.__call__, obj)
+
+
+# Without memoization, f6 is random, but also calling twice with the
+# same x returns different values
+@memoized
+def f6(x):
+    if x > 1:
+        return random()
+    elif x < 1:
+        return -random()
+    else:
+        return 0
+
+
+# Each Original test case has
+# - a function and its two derivatives,
+# - additional arguments,
+# - a bracket enclosing a root,
+# - the order of differentiability of the the function on this interval
+# - a starting value for methods which don't require a bracket
+# - the root (inside the bracket)
+# - an Identifier of the test case
+
+_ORIGINAL_TESTS_KEYS = ["f", "fprime", "fprime2", "args", "bracket", "smoothness", "x0", "root", "ID"]
+_ORIGINAL_TESTS = [
+    [f1, f1_fp, f1_fpp, (), [0.5, np.sqrt(3)], np.inf, 0.6, 1.0, "orig.01.00"],
+    [f2, f2_fp, f2_fpp, (), [0.5, np.sqrt(3)], np.inf, 0.6, 1.0, "orig.02.00"],
+    [f3, f3_fp, f3_fpp, (), [0.5, np.sqrt(3)], np.inf, 0.6, 1.0, "orig.03.00"],
+    [f4, None, None, (), [0.5, np.sqrt(3)], -1, 0.6, 1.0, "orig.04.00"],
+    [f5, None, None, (), [0.5, np.sqrt(3)], -1, 0.6, 1.0, "orig.05.00"],
+    [f6, None, None, (), [0.5, np.sqrt(3)], -np.inf, 0.6, 1.0, "orig.05.00"]
+]
+
+_ORIGINAL_TESTS_DICTS = [dict(zip(_ORIGINAL_TESTS_KEYS, testcase)) for testcase in _ORIGINAL_TESTS]
+
+#   ##################
+#   "APS" test cases
+#   Functions and test cases that appear in [1]
+
+_MAX_EXPABLE = np.log(np.finfo(float).max)
+
+
+def aps01_f(x):
+    r"""Straight forward sum of trigonometric function and polynomial"""
+    return np.sin(x) - x / 2
+
+
+def aps01_fp(x):
+    return np.cos(x) - 1.0 / 2
+
+
+def aps01_fpp(x):
+    return -np.sin(x)
+
+
+def aps02_f(x):
+    r"""poles at x=n**2, 1st and 2nd derivatives at root are also close to 0"""
+    ii = np.arange(1, 21)
+    return -2 * np.sum((2 * ii - 5) ** 2 / (x - ii ** 2) ** 3)
+
+
+def aps02_fp(x):
+    ii = np.arange(1, 21)
+    return 6 * np.sum((2 * ii - 5) ** 2 / (x - ii ** 2) ** 4)
+
+
+def aps02_fpp(x):
+    ii = np.arange(1, 21)
+    return 24 * np.sum((2 * ii - 5) ** 2 / (x - ii ** 2) ** 5)
+
+
+def aps03_f(x, a, b):
+    r"""Rapidly changing at the root"""
+    return a * x * np.exp(b * x)
+
+
+def aps03_fp(x, a, b):
+    return a * (b * x + 1) * np.exp(b * x)
+
+
+def aps03_fpp(x, a, b):
+    return a * (b * (b * x + 1) + b) * np.exp(b * x)
+
+
+def aps04_f(x, n, a):
+    r"""Medium-degree polynomial"""
+    return x ** n - a
+
+
+def aps04_fp(x, n, a):
+    return n * x ** (n - 1)
+
+
+def aps04_fpp(x, n, a):
+    return n * (n - 1) * x ** (n - 2)
+
+
+def aps05_f(x):
+    r"""Simple Trigonometric function"""
+    return np.sin(x) - 1.0 / 2
+
+
+def aps05_fp(x):
+    return np.cos(x)
+
+
+def aps05_fpp(x):
+    return -np.sin(x)
+
+
+def aps06_f(x, n):
+    r"""Exponential rapidly changing from -1 to 1 at x=0"""
+    return 2 * x * np.exp(-n) - 2 * np.exp(-n * x) + 1
+
+
+def aps06_fp(x, n):
+    return 2 * np.exp(-n) + 2 * n * np.exp(-n * x)
+
+
+def aps06_fpp(x, n):
+    return -2 * n * n * np.exp(-n * x)
+
+
+def aps07_f(x, n):
+    r"""Upside down parabola with parametrizable height"""
+    return (1 + (1 - n) ** 2) * x - (1 - n * x) ** 2
+
+
+def aps07_fp(x, n):
+    return (1 + (1 - n) ** 2) + 2 * n * (1 - n * x)
+
+
+def aps07_fpp(x, n):
+    return -2 * n * n
+
+
+def aps08_f(x, n):
+    r"""Degree n polynomial"""
+    return x * x - (1 - x) ** n
+
+
+def aps08_fp(x, n):
+    return 2 * x + n * (1 - x) ** (n - 1)
+
+
+def aps08_fpp(x, n):
+    return 2 - n * (n - 1) * (1 - x) ** (n - 2)
+
+
+def aps09_f(x, n):
+    r"""Upside down quartic with parametrizable height"""
+    return (1 + (1 - n) ** 4) * x - (1 - n * x) ** 4
+
+
+def aps09_fp(x, n):
+    return (1 + (1 - n) ** 4) + 4 * n * (1 - n * x) ** 3
+
+
+def aps09_fpp(x, n):
+    return -12 * n * (1 - n * x) ** 2
+
+
+def aps10_f(x, n):
+    r"""Exponential plus a polynomial"""
+    return np.exp(-n * x) * (x - 1) + x ** n
+
+
+def aps10_fp(x, n):
+    return np.exp(-n * x) * (-n * (x - 1) + 1) + n * x ** (n - 1)
+
+
+def aps10_fpp(x, n):
+    return np.exp(-n * x) * (-n * (-n * (x - 1) + 1) + -n * x) + n * (n - 1) * x ** (n - 2)
+
+
+def aps11_f(x, n):
+    r"""Rational function with a zero at x=1/n and a pole at x=0"""
+    return (n * x - 1) / ((n - 1) * x)
+
+
+def aps11_fp(x, n):
+    return 1 / (n - 1) / x ** 2
+
+
+def aps11_fpp(x, n):
+    return -2 / (n - 1) / x ** 3
+
+
+def aps12_f(x, n):
+    r"""n-th root of x, with a zero at x=n"""
+    return np.power(x, 1.0 / n) - np.power(n, 1.0 / n)
+
+
+def aps12_fp(x, n):
+    return np.power(x, (1.0 - n) / n) / n
+
+
+def aps12_fpp(x, n):
+    return np.power(x, (1.0 - 2 * n) / n) * (1.0 / n) * (1.0 - n) / n
+
+
+def aps13_f(x):
+    r"""Function with *all* derivatives 0 at the root"""
+    if x == 0:
+        return 0
+    # x2 = 1.0/x**2
+    # if x2 > 708:
+    #     return 0
+    y = 1 / x ** 2
+    if y > _MAX_EXPABLE:
+        return 0
+    return x / np.exp(y)
+
+
+def aps13_fp(x):
+    if x == 0:
+        return 0
+    y = 1 / x ** 2
+    if y > _MAX_EXPABLE:
+        return 0
+    return (1 + 2 / x ** 2) / np.exp(y)
+
+
+def aps13_fpp(x):
+    if x == 0:
+        return 0
+    y = 1 / x ** 2
+    if y > _MAX_EXPABLE:
+        return 0
+    return 2 * (2 - x ** 2) / x ** 5 / np.exp(y)
+
+
+def aps14_f(x, n):
+    r"""0 for negative x-values, trigonometric+linear for x positive"""
+    if x <= 0:
+        return -n / 20.0
+    return n / 20.0 * (x / 1.5 + np.sin(x) - 1)
+
+
+def aps14_fp(x, n):
+    if x <= 0:
+        return 0
+    return n / 20.0 * (1.0 / 1.5 + np.cos(x))
+
+
+def aps14_fpp(x, n):
+    if x <= 0:
+        return 0
+    return -n / 20.0 * (np.sin(x))
+
+
+def aps15_f(x, n):
+    r"""piecewise linear, constant outside of [0, 0.002/(1+n)]"""
+    if x < 0:
+        return -0.859
+    if x > 2 * 1e-3 / (1 + n):
+        return np.e - 1.859
+    return np.exp((n + 1) * x / 2 * 1000) - 1.859
+
+
+def aps15_fp(x, n):
+    if not 0 <= x <= 2 * 1e-3 / (1 + n):
+        return np.e - 1.859
+    return np.exp((n + 1) * x / 2 * 1000) * (n + 1) / 2 * 1000
+
+
+def aps15_fpp(x, n):
+    if not 0 <= x <= 2 * 1e-3 / (1 + n):
+        return np.e - 1.859
+    return np.exp((n + 1) * x / 2 * 1000) * (n + 1) / 2 * 1000 * (n + 1) / 2 * 1000
+
+
+# Each APS test case has
+# - a function and its two derivatives,
+# - additional arguments,
+# - a bracket enclosing a root,
+# - the order of differentiability of the the function on this interval
+# - a starting value for methods which don't require a bracket
+# - the root (inside the bracket)
+# - an Identifier of the test case
+#
+# Algorithm 748 is a bracketing algorithm so a bracketing interval was provided
+# in [1] for each test case.   Newton and Halley methods need a single
+# starting point x0, which was chosen to be near the middle of the interval,
+# unless that would have made the problem too easy.
+
+_APS_TESTS_KEYS = ["f", "fprime", "fprime2", "args", "bracket", "smoothness", "x0", "root", "ID"]
+_APS_TESTS = [
+    [aps01_f, aps01_fp, aps01_fpp, (), [np.pi / 2, np.pi], np.inf, 3, 1.89549426703398094e+00, "aps.01.00"],
+    [aps02_f, aps02_fp, aps02_fpp, (), [1 + 1e-9, 4 - 1e-9], np.inf, 2, 3.02291534727305677e+00, "aps.02.00"],
+    [aps02_f, aps02_fp, aps02_fpp, (), [4 + 1e-9, 9 - 1e-9], np.inf, 5, 6.68375356080807848e+00, "aps.02.01"],
+    [aps02_f, aps02_fp, aps02_fpp, (), [9 + 1e-9, 16 - 1e-9], np.inf, 10, 1.12387016550022114e+01, "aps.02.02"],
+    [aps02_f, aps02_fp, aps02_fpp, (), [16 + 1e-9, 25 - 1e-9], np.inf, 17, 1.96760000806234103e+01, "aps.02.03"],
+    [aps02_f, aps02_fp, aps02_fpp, (), [25 + 1e-9, 36 - 1e-9], np.inf, 26, 2.98282273265047557e+01, "aps.02.04"],
+    [aps02_f, aps02_fp, aps02_fpp, (), [36 + 1e-9, 49 - 1e-9], np.inf, 37, 4.19061161952894139e+01, "aps.02.05"],
+    [aps02_f, aps02_fp, aps02_fpp, (), [49 + 1e-9, 64 - 1e-9], np.inf, 50, 5.59535958001430913e+01, "aps.02.06"],
+    [aps02_f, aps02_fp, aps02_fpp, (), [64 + 1e-9, 81 - 1e-9], np.inf, 65, 7.19856655865877997e+01, "aps.02.07"],
+    [aps02_f, aps02_fp, aps02_fpp, (), [81 + 1e-9, 100 - 1e-9], np.inf, 82, 9.00088685391666701e+01, "aps.02.08"],
+    [aps02_f, aps02_fp, aps02_fpp, (), [100 + 1e-9, 121 - 1e-9], np.inf, 101, 1.10026532748330197e+02, "aps.02.09"],
+    [aps03_f, aps03_fp, aps03_fpp, (-40, -1), [-9, 31], np.inf, -2, 0, "aps.03.00"],
+    [aps03_f, aps03_fp, aps03_fpp, (-100, -2), [-9, 31], np.inf, -2, 0, "aps.03.01"],
+    [aps03_f, aps03_fp, aps03_fpp, (-200, -3), [-9, 31], np.inf, -2, 0, "aps.03.02"],
+    [aps04_f, aps04_fp, aps04_fpp, (4, 0.2), [0, 5], np.inf, 2.5, 6.68740304976422006e-01, "aps.04.00"],
+    [aps04_f, aps04_fp, aps04_fpp, (6, 0.2), [0, 5], np.inf, 2.5, 7.64724491331730039e-01, "aps.04.01"],
+    [aps04_f, aps04_fp, aps04_fpp, (8, 0.2), [0, 5], np.inf, 2.5, 8.17765433957942545e-01, "aps.04.02"],
+    [aps04_f, aps04_fp, aps04_fpp, (10, 0.2), [0, 5], np.inf, 2.5, 8.51339922520784609e-01, "aps.04.03"],
+    [aps04_f, aps04_fp, aps04_fpp, (12, 0.2), [0, 5], np.inf, 2.5, 8.74485272221167897e-01, "aps.04.04"],
+    [aps04_f, aps04_fp, aps04_fpp, (4, 1), [0, 5], np.inf, 2.5, 1, "aps.04.05"],
+    [aps04_f, aps04_fp, aps04_fpp, (6, 1), [0, 5], np.inf, 2.5, 1, "aps.04.06"],
+    [aps04_f, aps04_fp, aps04_fpp, (8, 1), [0, 5], np.inf, 2.5, 1, "aps.04.07"],
+    [aps04_f, aps04_fp, aps04_fpp, (10, 1), [0, 5], np.inf, 2.5, 1, "aps.04.08"],
+    [aps04_f, aps04_fp, aps04_fpp, (12, 1), [0, 5], np.inf, 2.5, 1, "aps.04.09"],
+    [aps04_f, aps04_fp, aps04_fpp, (8, 1), [-0.95, 4.05], np.inf, 1.5, 1, "aps.04.10"],
+    [aps04_f, aps04_fp, aps04_fpp, (10, 1), [-0.95, 4.05], np.inf, 1.5, 1, "aps.04.11"],
+    [aps04_f, aps04_fp, aps04_fpp, (12, 1), [-0.95, 4.05], np.inf, 1.5, 1, "aps.04.12"],
+    [aps04_f, aps04_fp, aps04_fpp, (14, 1), [-0.95, 4.05], np.inf, 1.5, 1, "aps.04.13"],
+    [aps05_f, aps05_fp, aps05_fpp, (), [0, 1.5], np.inf, 1.3, np.pi / 6, "aps.05.00"],
+    [aps06_f, aps06_fp, aps06_fpp, (1,), [0, 1], np.inf, 0.5, 4.22477709641236709e-01, "aps.06.00"],
+    [aps06_f, aps06_fp, aps06_fpp, (2,), [0, 1], np.inf, 0.5, 3.06699410483203705e-01, "aps.06.01"],
+    [aps06_f, aps06_fp, aps06_fpp, (3,), [0, 1], np.inf, 0.5, 2.23705457654662959e-01, "aps.06.02"],
+    [aps06_f, aps06_fp, aps06_fpp, (4,), [0, 1], np.inf, 0.5, 1.71719147519508369e-01, "aps.06.03"],
+    [aps06_f, aps06_fp, aps06_fpp, (5,), [0, 1], np.inf, 0.4, 1.38257155056824066e-01, "aps.06.04"],
+    [aps06_f, aps06_fp, aps06_fpp, (20,), [0, 1], np.inf, 0.1, 3.46573590208538521e-02, "aps.06.05"],
+    [aps06_f, aps06_fp, aps06_fpp, (40,), [0, 1], np.inf, 5e-02, 1.73286795139986315e-02, "aps.06.06"],
+    [aps06_f, aps06_fp, aps06_fpp, (60,), [0, 1], np.inf, 1.0 / 30, 1.15524530093324210e-02, "aps.06.07"],
+    [aps06_f, aps06_fp, aps06_fpp, (80,), [0, 1], np.inf, 2.5e-02, 8.66433975699931573e-03, "aps.06.08"],
+    [aps06_f, aps06_fp, aps06_fpp, (100,), [0, 1], np.inf, 2e-02, 6.93147180559945415e-03, "aps.06.09"],
+    [aps07_f, aps07_fp, aps07_fpp, (5,), [0, 1], np.inf, 0.4, 3.84025518406218985e-02, "aps.07.00"],
+    [aps07_f, aps07_fp, aps07_fpp, (10,), [0, 1], np.inf, 0.4, 9.90000999800049949e-03, "aps.07.01"],
+    [aps07_f, aps07_fp, aps07_fpp, (20,), [0, 1], np.inf, 0.4, 2.49375003906201174e-03, "aps.07.02"],
+    [aps08_f, aps08_fp, aps08_fpp, (2,), [0, 1], np.inf, 0.9, 0.5, "aps.08.00"],
+    [aps08_f, aps08_fp, aps08_fpp, (5,), [0, 1], np.inf, 0.9, 3.45954815848242059e-01, "aps.08.01"],
+    [aps08_f, aps08_fp, aps08_fpp, (10,), [0, 1], np.inf, 0.9, 2.45122333753307220e-01, "aps.08.02"],
+    [aps08_f, aps08_fp, aps08_fpp, (15,), [0, 1], np.inf, 0.9, 1.95547623536565629e-01, "aps.08.03"],
+    [aps08_f, aps08_fp, aps08_fpp, (20,), [0, 1], np.inf, 0.9, 1.64920957276440960e-01, "aps.08.04"],
+    [aps09_f, aps09_fp, aps09_fpp, (1,), [0, 1], np.inf, 0.5, 2.75508040999484394e-01, "aps.09.00"],
+    [aps09_f, aps09_fp, aps09_fpp, (2,), [0, 1], np.inf, 0.5, 1.37754020499742197e-01, "aps.09.01"],
+    [aps09_f, aps09_fp, aps09_fpp, (4,), [0, 1], np.inf, 0.5, 1.03052837781564422e-02, "aps.09.02"],
+    [aps09_f, aps09_fp, aps09_fpp, (5,), [0, 1], np.inf, 0.5, 3.61710817890406339e-03, "aps.09.03"],
+    [aps09_f, aps09_fp, aps09_fpp, (8,), [0, 1], np.inf, 0.5, 4.10872918496395375e-04, "aps.09.04"],
+    [aps09_f, aps09_fp, aps09_fpp, (15,), [0, 1], np.inf, 0.5, 2.59895758929076292e-05, "aps.09.05"],
+    [aps09_f, aps09_fp, aps09_fpp, (20,), [0, 1], np.inf, 0.5, 7.66859512218533719e-06, "aps.09.06"],
+    [aps10_f, aps10_fp, aps10_fpp, (1,), [0, 1], np.inf, 0.9, 4.01058137541547011e-01, "aps.10.00"],
+    [aps10_f, aps10_fp, aps10_fpp, (5,), [0, 1], np.inf, 0.9, 5.16153518757933583e-01, "aps.10.01"],
+    [aps10_f, aps10_fp, aps10_fpp, (10,), [0, 1], np.inf, 0.9, 5.39522226908415781e-01, "aps.10.02"],
+    [aps10_f, aps10_fp, aps10_fpp, (15,), [0, 1], np.inf, 0.9, 5.48182294340655241e-01, "aps.10.03"],
+    [aps10_f, aps10_fp, aps10_fpp, (20,), [0, 1], np.inf, 0.9, 5.52704666678487833e-01, "aps.10.04"],
+    [aps11_f, aps11_fp, aps11_fpp, (2,), [0.01, 1], np.inf, 1e-02, 1.0 / 2, "aps.11.00"],
+    [aps11_f, aps11_fp, aps11_fpp, (5,), [0.01, 1], np.inf, 1e-02, 1.0 / 5, "aps.11.01"],
+    [aps11_f, aps11_fp, aps11_fpp, (15,), [0.01, 1], np.inf, 1e-02, 1.0 / 15, "aps.11.02"],
+    [aps11_f, aps11_fp, aps11_fpp, (20,), [0.01, 1], np.inf, 1e-02, 1.0 / 20, "aps.11.03"],
+    [aps12_f, aps12_fp, aps12_fpp, (2,), [1, 100], np.inf, 1.1, 2, "aps.12.00"],
+    [aps12_f, aps12_fp, aps12_fpp, (3,), [1, 100], np.inf, 1.1, 3, "aps.12.01"],
+    [aps12_f, aps12_fp, aps12_fpp, (4,), [1, 100], np.inf, 1.1, 4, "aps.12.02"],
+    [aps12_f, aps12_fp, aps12_fpp, (5,), [1, 100], np.inf, 1.1, 5, "aps.12.03"],
+    [aps12_f, aps12_fp, aps12_fpp, (6,), [1, 100], np.inf, 1.1, 6, "aps.12.04"],
+    [aps12_f, aps12_fp, aps12_fpp, (7,), [1, 100], np.inf, 1.1, 7, "aps.12.05"],
+    [aps12_f, aps12_fp, aps12_fpp, (9,), [1, 100], np.inf, 1.1, 9, "aps.12.06"],
+    [aps12_f, aps12_fp, aps12_fpp, (11,), [1, 100], np.inf, 1.1, 11, "aps.12.07"],
+    [aps12_f, aps12_fp, aps12_fpp, (13,), [1, 100], np.inf, 1.1, 13, "aps.12.08"],
+    [aps12_f, aps12_fp, aps12_fpp, (15,), [1, 100], np.inf, 1.1, 15, "aps.12.09"],
+    [aps12_f, aps12_fp, aps12_fpp, (17,), [1, 100], np.inf, 1.1, 17, "aps.12.10"],
+    [aps12_f, aps12_fp, aps12_fpp, (19,), [1, 100], np.inf, 1.1, 19, "aps.12.11"],
+    [aps12_f, aps12_fp, aps12_fpp, (21,), [1, 100], np.inf, 1.1, 21, "aps.12.12"],
+    [aps12_f, aps12_fp, aps12_fpp, (23,), [1, 100], np.inf, 1.1, 23, "aps.12.13"],
+    [aps12_f, aps12_fp, aps12_fpp, (25,), [1, 100], np.inf, 1.1, 25, "aps.12.14"],
+    [aps12_f, aps12_fp, aps12_fpp, (27,), [1, 100], np.inf, 1.1, 27, "aps.12.15"],
+    [aps12_f, aps12_fp, aps12_fpp, (29,), [1, 100], np.inf, 1.1, 29, "aps.12.16"],
+    [aps12_f, aps12_fp, aps12_fpp, (31,), [1, 100], np.inf, 1.1, 31, "aps.12.17"],
+    [aps12_f, aps12_fp, aps12_fpp, (33,), [1, 100], np.inf, 1.1, 33, "aps.12.18"],
+    [aps13_f, aps13_fp, aps13_fpp, (), [-1, 4], np.inf, 1.5, 1.54720911915117165e-02, "aps.13.00"],
+    [aps14_f, aps14_fp, aps14_fpp, (1,), [-1000, np.pi / 2], 0, 1, 6.23806518961612433e-01, "aps.14.00"],
+    [aps14_f, aps14_fp, aps14_fpp, (2,), [-1000, np.pi / 2], 0, 1, 6.23806518961612433e-01, "aps.14.01"],
+    [aps14_f, aps14_fp, aps14_fpp, (3,), [-1000, np.pi / 2], 0, 1, 6.23806518961612433e-01, "aps.14.02"],
+    [aps14_f, aps14_fp, aps14_fpp, (4,), [-1000, np.pi / 2], 0, 1, 6.23806518961612433e-01, "aps.14.03"],
+    [aps14_f, aps14_fp, aps14_fpp, (5,), [-1000, np.pi / 2], 0, 1, 6.23806518961612433e-01, "aps.14.04"],
+    [aps14_f, aps14_fp, aps14_fpp, (6,), [-1000, np.pi / 2], 0, 1, 6.23806518961612433e-01, "aps.14.05"],
+    [aps14_f, aps14_fp, aps14_fpp, (7,), [-1000, np.pi / 2], 0, 1, 6.23806518961612433e-01, "aps.14.06"],
+    [aps14_f, aps14_fp, aps14_fpp, (8,), [-1000, np.pi / 2], 0, 1, 6.23806518961612433e-01, "aps.14.07"],
+    [aps14_f, aps14_fp, aps14_fpp, (9,), [-1000, np.pi / 2], 0, 1, 6.23806518961612433e-01, "aps.14.08"],
+    [aps14_f, aps14_fp, aps14_fpp, (10,), [-1000, np.pi / 2], 0, 1, 6.23806518961612433e-01, "aps.14.09"],
+    [aps14_f, aps14_fp, aps14_fpp, (11,), [-1000, np.pi / 2], 0, 1, 6.23806518961612433e-01, "aps.14.10"],
+    [aps14_f, aps14_fp, aps14_fpp, (12,), [-1000, np.pi / 2], 0, 1, 6.23806518961612433e-01, "aps.14.11"],
+    [aps14_f, aps14_fp, aps14_fpp, (13,), [-1000, np.pi / 2], 0, 1, 6.23806518961612433e-01, "aps.14.12"],
+    [aps14_f, aps14_fp, aps14_fpp, (14,), [-1000, np.pi / 2], 0, 1, 6.23806518961612433e-01, "aps.14.13"],
+    [aps14_f, aps14_fp, aps14_fpp, (15,), [-1000, np.pi / 2], 0, 1, 6.23806518961612433e-01, "aps.14.14"],
+    [aps14_f, aps14_fp, aps14_fpp, (16,), [-1000, np.pi / 2], 0, 1, 6.23806518961612433e-01, "aps.14.15"],
+    [aps14_f, aps14_fp, aps14_fpp, (17,), [-1000, np.pi / 2], 0, 1, 6.23806518961612433e-01, "aps.14.16"],
+    [aps14_f, aps14_fp, aps14_fpp, (18,), [-1000, np.pi / 2], 0, 1, 6.23806518961612433e-01, "aps.14.17"],
+    [aps14_f, aps14_fp, aps14_fpp, (19,), [-1000, np.pi / 2], 0, 1, 6.23806518961612433e-01, "aps.14.18"],
+    [aps14_f, aps14_fp, aps14_fpp, (20,), [-1000, np.pi / 2], 0, 1, 6.23806518961612433e-01, "aps.14.19"],
+    [aps14_f, aps14_fp, aps14_fpp, (21,), [-1000, np.pi / 2], 0, 1, 6.23806518961612433e-01, "aps.14.20"],
+    [aps14_f, aps14_fp, aps14_fpp, (22,), [-1000, np.pi / 2], 0, 1, 6.23806518961612433e-01, "aps.14.21"],
+    [aps14_f, aps14_fp, aps14_fpp, (23,), [-1000, np.pi / 2], 0, 1, 6.23806518961612433e-01, "aps.14.22"],
+    [aps14_f, aps14_fp, aps14_fpp, (24,), [-1000, np.pi / 2], 0, 1, 6.23806518961612433e-01, "aps.14.23"],
+    [aps14_f, aps14_fp, aps14_fpp, (25,), [-1000, np.pi / 2], 0, 1, 6.23806518961612433e-01, "aps.14.24"],
+    [aps14_f, aps14_fp, aps14_fpp, (26,), [-1000, np.pi / 2], 0, 1, 6.23806518961612433e-01, "aps.14.25"],
+    [aps14_f, aps14_fp, aps14_fpp, (27,), [-1000, np.pi / 2], 0, 1, 6.23806518961612433e-01, "aps.14.26"],
+    [aps14_f, aps14_fp, aps14_fpp, (28,), [-1000, np.pi / 2], 0, 1, 6.23806518961612433e-01, "aps.14.27"],
+    [aps14_f, aps14_fp, aps14_fpp, (29,), [-1000, np.pi / 2], 0, 1, 6.23806518961612433e-01, "aps.14.28"],
+    [aps14_f, aps14_fp, aps14_fpp, (30,), [-1000, np.pi / 2], 0, 1, 6.23806518961612433e-01, "aps.14.29"],
+    [aps14_f, aps14_fp, aps14_fpp, (31,), [-1000, np.pi / 2], 0, 1, 6.23806518961612433e-01, "aps.14.30"],
+    [aps14_f, aps14_fp, aps14_fpp, (32,), [-1000, np.pi / 2], 0, 1, 6.23806518961612433e-01, "aps.14.31"],
+    [aps14_f, aps14_fp, aps14_fpp, (33,), [-1000, np.pi / 2], 0, 1, 6.23806518961612433e-01, "aps.14.32"],
+    [aps14_f, aps14_fp, aps14_fpp, (34,), [-1000, np.pi / 2], 0, 1, 6.23806518961612433e-01, "aps.14.33"],
+    [aps14_f, aps14_fp, aps14_fpp, (35,), [-1000, np.pi / 2], 0, 1, 6.23806518961612433e-01, "aps.14.34"],
+    [aps14_f, aps14_fp, aps14_fpp, (36,), [-1000, np.pi / 2], 0, 1, 6.23806518961612433e-01, "aps.14.35"],
+    [aps14_f, aps14_fp, aps14_fpp, (37,), [-1000, np.pi / 2], 0, 1, 6.23806518961612433e-01, "aps.14.36"],
+    [aps14_f, aps14_fp, aps14_fpp, (38,), [-1000, np.pi / 2], 0, 1, 6.23806518961612433e-01, "aps.14.37"],
+    [aps14_f, aps14_fp, aps14_fpp, (39,), [-1000, np.pi / 2], 0, 1, 6.23806518961612433e-01, "aps.14.38"],
+    [aps14_f, aps14_fp, aps14_fpp, (40,), [-1000, np.pi / 2], 0, 1, 6.23806518961612433e-01, "aps.14.39"],
+    [aps15_f, aps15_fp, aps15_fpp, (20,), [-1000, 1e-4], 0, -2, 5.90513055942197166e-05, "aps.15.00"],
+    [aps15_f, aps15_fp, aps15_fpp, (21,), [-1000, 1e-4], 0, -2, 5.63671553399369967e-05, "aps.15.01"],
+    [aps15_f, aps15_fp, aps15_fpp, (22,), [-1000, 1e-4], 0, -2, 5.39164094555919196e-05, "aps.15.02"],
+    [aps15_f, aps15_fp, aps15_fpp, (23,), [-1000, 1e-4], 0, -2, 5.16698923949422470e-05, "aps.15.03"],
+    [aps15_f, aps15_fp, aps15_fpp, (24,), [-1000, 1e-4], 0, -2, 4.96030966991445609e-05, "aps.15.04"],
+    [aps15_f, aps15_fp, aps15_fpp, (25,), [-1000, 1e-4], 0, -2, 4.76952852876389951e-05, "aps.15.05"],
+    [aps15_f, aps15_fp, aps15_fpp, (26,), [-1000, 1e-4], 0, -2, 4.59287932399486662e-05, "aps.15.06"],
+    [aps15_f, aps15_fp, aps15_fpp, (27,), [-1000, 1e-4], 0, -2, 4.42884791956647841e-05, "aps.15.07"],
+    [aps15_f, aps15_fp, aps15_fpp, (28,), [-1000, 1e-4], 0, -2, 4.27612902578832391e-05, "aps.15.08"],
+    [aps15_f, aps15_fp, aps15_fpp, (29,), [-1000, 1e-4], 0, -2, 4.13359139159538030e-05, "aps.15.09"],
+    [aps15_f, aps15_fp, aps15_fpp, (30,), [-1000, 1e-4], 0, -2, 4.00024973380198076e-05, "aps.15.10"],
+    [aps15_f, aps15_fp, aps15_fpp, (31,), [-1000, 1e-4], 0, -2, 3.87524192962066869e-05, "aps.15.11"],
+    [aps15_f, aps15_fp, aps15_fpp, (32,), [-1000, 1e-4], 0, -2, 3.75781035599579910e-05, "aps.15.12"],
+    [aps15_f, aps15_fp, aps15_fpp, (33,), [-1000, 1e-4], 0, -2, 3.64728652199592355e-05, "aps.15.13"],
+    [aps15_f, aps15_fp, aps15_fpp, (34,), [-1000, 1e-4], 0, -2, 3.54307833565318273e-05, "aps.15.14"],
+    [aps15_f, aps15_fp, aps15_fpp, (35,), [-1000, 1e-4], 0, -2, 3.44465949299614980e-05, "aps.15.15"],
+    [aps15_f, aps15_fp, aps15_fpp, (36,), [-1000, 1e-4], 0, -2, 3.35156058778003705e-05, "aps.15.16"],
+    [aps15_f, aps15_fp, aps15_fpp, (37,), [-1000, 1e-4], 0, -2, 3.26336162494372125e-05, "aps.15.17"],
+    [aps15_f, aps15_fp, aps15_fpp, (38,), [-1000, 1e-4], 0, -2, 3.17968568584260013e-05, "aps.15.18"],
+    [aps15_f, aps15_fp, aps15_fpp, (39,), [-1000, 1e-4], 0, -2, 3.10019354369653455e-05, "aps.15.19"],
+    [aps15_f, aps15_fp, aps15_fpp, (40,), [-1000, 1e-4], 0, -2, 3.02457906702100968e-05, "aps.15.20"],
+    [aps15_f, aps15_fp, aps15_fpp, (100,), [-1000, 1e-4], 0, -2, 1.22779942324615231e-05, "aps.15.21"],
+    [aps15_f, aps15_fp, aps15_fpp, (200,), [-1000, 1e-4], 0, -2, 6.16953939044086617e-06, "aps.15.22"],
+    [aps15_f, aps15_fp, aps15_fpp, (300,), [-1000, 1e-4], 0, -2, 4.11985852982928163e-06, "aps.15.23"],
+    [aps15_f, aps15_fp, aps15_fpp, (400,), [-1000, 1e-4], 0, -2, 3.09246238772721682e-06, "aps.15.24"],
+    [aps15_f, aps15_fp, aps15_fpp, (500,), [-1000, 1e-4], 0, -2, 2.47520442610501789e-06, "aps.15.25"],
+    [aps15_f, aps15_fp, aps15_fpp, (600,), [-1000, 1e-4], 0, -2, 2.06335676785127107e-06, "aps.15.26"],
+    [aps15_f, aps15_fp, aps15_fpp, (700,), [-1000, 1e-4], 0, -2, 1.76901200781542651e-06, "aps.15.27"],
+    [aps15_f, aps15_fp, aps15_fpp, (800,), [-1000, 1e-4], 0, -2, 1.54816156988591016e-06, "aps.15.28"],
+    [aps15_f, aps15_fp, aps15_fpp, (900,), [-1000, 1e-4], 0, -2, 1.37633453660223511e-06, "aps.15.29"],
+    [aps15_f, aps15_fp, aps15_fpp, (1000,), [-1000, 1e-4], 0, -2, 1.23883857889971403e-06, "aps.15.30"]
+]
+
+_APS_TESTS_DICTS = [dict(zip(_APS_TESTS_KEYS, testcase)) for testcase in _APS_TESTS]
+for d in _APS_TESTS_DICTS:
+    d['a'] = d['bracket'][0]
+    d['b'] = d['bracket'][0]
+
+
+#   ##################
+#   "complex" test cases
+#   A few simple, complex-valued, functions, defined on the complex plane.
+
+
+def cplx01_f(z, n, a):
+    r"""z**n-a:  Use to find the n-th root of a"""
+    return z ** n - a
+
+
+def cplx01_fp(z, n, a):
+    return n * z ** (n - 1)
+
+
+def cplx01_fpp(z, n, a):
+    return n * (n - 1) * z ** (n - 2)
+
+
+def cplx02_f(z, a):
+    r"""e**z - a: Use to find the log of a"""
+    return np.exp(z) - a
+
+
+def cplx02_fp(z, a):
+    return np.exp(z)
+
+
+def cplx02_fpp(z, a):
+    return np.exp(z)
+
+
+# Each "complex" test case has
+# - a function and its two derivatives,
+# - additional arguments,
+# - the order of differentiability of the the function on this interval
+# - two starting values x0 and x1
+# - the root
+# - an Identifier of the test case
+#
+# Algorithm 748 is a bracketing algorithm so a bracketing interval was provided
+#  in [1] for each test case.   Newton and Halley need a single starting point
+#  x0, which was chosen to be near the middle of the interval, unless that
+# would make the problem too easy.
+
+
+_COMPLEX_TESTS_KEYS = ["f", "fprime", "fprime2", "args", "smoothness", "x0", "x1", "root", "ID"]
+_COMPLEX_TESTS = [
+    [cplx01_f, cplx01_fp, cplx01_fpp, (2, -1), np.inf, (1 + 1j), (0.5 + 0.5j), 1j, "cplx.01.00"],
+    [cplx01_f, cplx01_fp, cplx01_fpp, (3, 1), np.inf, (-1 + 1j), (-0.5 + 2.0j), (-0.5 + np.sqrt(3) / 2 * 1.0j),
+     "cplx.01.01"],
+    [cplx01_f, cplx01_fp, cplx01_fpp, (3, -1), np.inf, 1j, (0.5 + 0.5j), (0.5 + np.sqrt(3) / 2 * 1.0j), "cplx.01.02"],
+    [cplx01_f, cplx01_fp, cplx01_fpp, (3, 8), np.inf, 5, 4, 2, "cplx.01.03"],
+    [cplx02_f, cplx02_fp, cplx02_fpp, (-1,), np.inf, (1 + 2j), (0.5 + 0.5j), np.pi * 1.0j, "cplx.02.00"],
+    [cplx02_f, cplx02_fp, cplx02_fpp, (1j,), np.inf, (1 + 2j), (0.5 + 0.5j), np.pi * 0.5j, "cplx.02.01"],
+]
+
+_COMPLEX_TESTS_DICTS = [dict(zip(_COMPLEX_TESTS_KEYS, testcase)) for testcase in _COMPLEX_TESTS]
+
+
+def _add_a_b(tests):
+    r"""Add "a" and "b" keys ot each test from the "bracket" value"""
+    for d in tests:
+        for k, v in zip(['a', 'b'], d.get('bracket', [])):
+            d[k] = v
+        # if 'bracket' in d:
+        #     d['a'] = d['bracket'][0]
+        #     d['b'] = d['bracket'][1]
+
+
+_add_a_b(_ORIGINAL_TESTS_DICTS)
+_add_a_b(_APS_TESTS_DICTS)
+_add_a_b(_COMPLEX_TESTS_DICTS)
+
+
+def get_tests(collection='original', smoothness=None):
+    r"""Return the requested collection of test cases, as an array of dicts with subset-specific keys
+
+    Allowed values of collection:
+    'original': The original benchmarking functions.
+         Real-valued functions of real-valued inputs on an interval with a zero.
+         f1, .., f3 are continuous and infinitely differentiable
+         f4 has a single discontinuity at the root
+         f5 has a root at 1 replacing a 1st order pole
+         f6 is randomly positive on one side of the root, randomly negative on the other
+    'aps': The test problems in the TOMS "Algorithm 748: Enclosing Zeros of Continuous Functions"
+         paper by Alefeld, Potra and Shi.  Real-valued functions of
+         real-valued inputs on an interval with a zero.
+         Suitable for methods which start with an enclosing interval, and
+         derivatives up to 2nd order.
+    'complex': Some complex-valued functions of complex-valued inputs.
+         No enclosing bracket is provided.
+         Suitable for methods which use one or more starting values, and
+         derivatives up to 2nd order.
+
+    The dictionary keys will be a subset of
+    ["f", "fprime", "fprime2", "args", "bracket", "a", b", "smoothness", "x0", "x1", "root", "ID"]
+     """
+    collection = collection or "original"
+    subsets = {"aps": _APS_TESTS_DICTS,
+               "complex": _COMPLEX_TESTS_DICTS,
+               "original": _ORIGINAL_TESTS_DICTS}
+    testCases = subsets.get(collection, [])
+    if smoothness is not None:
+        testCases = [tc for tc in testCases if tc['smoothness'] >= smoothness]
+    return testCases
+
+
+# Backwards compatibility
+methods = [cc.bisect, cc.ridder, cc.brenth, cc.brentq]
+mstrings = ['cc.bisect', 'cc.ridder', 'cc.brenth', 'cc.brentq']
+functions = [f2, f3, f4, f5, f6]
+fstrings = ['f2', 'f3', 'f4', 'f5', 'f6']

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -7,7 +7,7 @@ from numpy.testing import (assert_warns, assert_,
                            assert_allclose,
                            assert_equal)
 import numpy as np
-from numpy import finfo, power
+from numpy import finfo, power, nan, isclose
 
 
 from scipy.optimize import zeros as cc

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -23,6 +23,7 @@ TOL = 4*np.finfo(float).eps  # tolerance
 
 _FLOAT_EPS = finfo(float).eps
 
+
 class TestBasic(object):
     def run_check(self, method, name):
         a = .5
@@ -114,7 +115,7 @@ class TestBasic(object):
 
     def run_collection(self, collection, method, name, smoothness=None,
                        known_fail=None,
-                       xtol=4 * _FLOAT_EPS, rtol =4 * _FLOAT_EPS,
+                       xtol=4 * _FLOAT_EPS, rtol=4 * _FLOAT_EPS,
                        **kwargs):
         r"""Run a collection of tests using the specified method.
 

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -78,7 +78,7 @@ def results_c(full_output, r):
 
 
 def _results_select(full_output, r):
-    r"""Select from a tuple of (root, funccalls, iterations, flag)"""
+    """Select from a tuple of (root, funccalls, iterations, flag)"""
     x, funcalls, iterations, flag = r
     if full_output:
         results = RootResults(root=x,
@@ -92,7 +92,8 @@ def _results_select(full_output, r):
 def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
            fprime2=None, full_output=False, disp=True):
     """
-    Find a zero of a real or complex function using the Newton-Raphson (or secant or Halley's) method.
+    Find a zero of a real or complex function using the Newton-Raphson
+    (or secant or Halley's) method.
 
     Find a zero of the function `func` given a nearby starting point `x0`.
     The Newton-Raphson method is used if the derivative `fprime` of `func`
@@ -441,9 +442,9 @@ def bisect(f, a, b, args=(),
     f : function
         Python function returning a number.  `f` must be continuous, and
         f(a) and f(b) must have opposite signs.
-    a : number
+    a : scalar
         One end of the bracketing interval [a,b].
-    b : number
+    b : scalar
         The other end of the bracketing interval [a,b].
     xtol : number, optional
         The computed root ``x0`` will satisfy ``np.allclose(x, x0,
@@ -454,7 +455,7 @@ def bisect(f, a, b, args=(),
         atol=xtol, rtol=rtol)``, where ``x`` is the exact root. The
         parameter cannot be smaller than its default value of
         ``4*np.finfo(float).eps``.
-    maxiter : number, optional
+    maxiter : integer, optional
         if convergence is not achieved in `maxiter` iterations, an error is
         raised.  Must be >= 0.
     args : tuple, optional
@@ -466,7 +467,7 @@ def bisect(f, a, b, args=(),
         a `RootResults` object.
     disp : bool, optional
         If True, raise RuntimeError if the algorithm didn't converge.
-        Otherwise the convergence status is recorded in any RootResults
+        Otherwise the convergence status is recorded in a RootResults
         return object.
 
     Returns
@@ -521,9 +522,9 @@ def ridder(f, a, b, args=(),
     f : function
         Python function returning a number.  f must be continuous, and f(a) and
         f(b) must have opposite signs.
-    a : number
+    a : scalar
         One end of the bracketing interval [a,b].
-    b : number
+    b : scalar
         The other end of the bracketing interval [a,b].
     xtol : number, optional
         The computed root ``x0`` will satisfy ``np.allclose(x, x0,
@@ -534,8 +535,8 @@ def ridder(f, a, b, args=(),
         atol=xtol, rtol=rtol)``, where ``x`` is the exact root. The
         parameter cannot be smaller than its default value of
         ``4*np.finfo(float).eps``.
-    maxiter : number, optional
-        if convergence is not achieved in maxiter iterations, an error is
+    maxiter : integer, optional
+        if convergence is not achieved in `maxiter` iterations, an error is
         raised.  Must be >= 0.
     args : tuple, optional
         containing extra arguments for the function `f`.
@@ -573,6 +574,13 @@ def ridder(f, a, b, args=(),
     The routine used here diverges slightly from standard presentations in
     order to be a bit more careful of tolerance.
 
+    References
+    ----------
+    .. [Ridders1979]
+       Ridders, C. F. J. "A New Algorithm for Computing a
+       Single Root of a Real Continuous Function."
+       IEEE Trans. Circuits Systems 26, 979-980, 1979.
+
     Examples
     --------
 
@@ -588,14 +596,6 @@ def ridder(f, a, b, args=(),
     >>> root = optimize.ridder(f, -2, 0)
     >>> root
     -1.0
-
-    References
-    ----------
-    .. [Ridders1979]
-       Ridders, C. F. J. "A New Algorithm for Computing a
-       Single Root of a Real Continuous Function."
-       IEEE Trans. Circuits Systems 26, 979-980, 1979.
-
     """
     if not isinstance(args, tuple):
         args = (args,)
@@ -635,9 +635,9 @@ def brentq(f, a, b, args=(),
         Python function returning a number.  The function :math:`f`
         must be continuous, and :math:`f(a)` and :math:`f(b)` must
         have opposite signs.
-    a : number
+    a : scalar
         One end of the bracketing interval :math:`[a, b]`.
-    b : number
+    b : scalar
         The other end of the bracketing interval :math:`[a, b]`.
     xtol : number, optional
         The computed root ``x0`` will satisfy ``np.allclose(x, x0,
@@ -652,8 +652,8 @@ def brentq(f, a, b, args=(),
         ``4*np.finfo(float).eps``. For nice functions, Brent's
         method will often satisfy the above condition with ``xtol/2``
         and ``rtol/2``. [Brent1973]_
-    maxiter : number, optional
-        if convergence is not achieved in maxiter iterations, an error is
+    maxiter : integer, optional
+        if convergence is not achieved in `maxiter` iterations, an error is
         raised.  Must be >= 0.
     args : tuple, optional
         containing extra arguments for the function `f`.
@@ -698,6 +698,19 @@ def brentq(f, a, b, args=(),
     -----
     `f` must be continuous.  f(a) and f(b) must have opposite signs.
 
+    References
+    ----------
+    .. [Brent1973]
+       Brent, R. P.,
+       *Algorithms for Minimization Without Derivatives*.
+       Englewood Cliffs, NJ: Prentice-Hall, 1973. Ch. 3-4.
+
+    .. [PressEtal1992]
+       Press, W. H.; Flannery, B. P.; Teukolsky, S. A.; and Vetterling, W. T.
+       *Numerical Recipes in FORTRAN: The Art of Scientific Computing*, 2nd ed.
+       Cambridge, England: Cambridge University Press, pp. 352-355, 1992.
+       Section 9.3:  "Van Wijngaarden-Dekker-Brent Method."
+
     Examples
     --------
     >>> def f(x):
@@ -712,20 +725,6 @@ def brentq(f, a, b, args=(),
     >>> root = optimize.brentq(f, 0, 2)
     >>> root
     1.0
-
-    References
-    ----------
-    .. [Brent1973]
-       Brent, R. P.,
-       *Algorithms for Minimization Without Derivatives*.
-       Englewood Cliffs, NJ: Prentice-Hall, 1973. Ch. 3-4.
-
-    .. [PressEtal1992]
-       Press, W. H.; Flannery, B. P.; Teukolsky, S. A.; and Vetterling, W. T.
-       *Numerical Recipes in FORTRAN: The Art of Scientific Computing*, 2nd ed.
-       Cambridge, England: Cambridge University Press, pp. 352-355, 1992.
-       Section 9.3:  "Van Wijngaarden-Dekker-Brent Method."
-
     """
     if not isinstance(args, tuple):
         args = (args,)
@@ -740,7 +739,8 @@ def brentq(f, a, b, args=(),
 def brenth(f, a, b, args=(),
            xtol=_xtol, rtol=_rtol, maxiter=_iter,
            full_output=False, disp=True):
-    """Find a root of a function in a bracketing interval using Brent's method with hyperbolic extrapolation.
+    """Find a root of a function in a bracketing interval using Brent's
+    method with hyperbolic extrapolation.
 
     A variation on the classic Brent routine to find a zero of the function f
     between the arguments a and b that uses hyperbolic extrapolation instead of
@@ -755,9 +755,9 @@ def brenth(f, a, b, args=(),
     f : function
         Python function returning a number.  f must be continuous, and f(a) and
         f(b) must have opposite signs.
-    a : number
+    a : scalar
         One end of the bracketing interval [a,b].
-    b : number
+    b : scalar
         The other end of the bracketing interval [a,b].
     xtol : number, optional
         The computed root ``x0`` will satisfy ``np.allclose(x, x0,
@@ -772,8 +772,8 @@ def brenth(f, a, b, args=(),
         ``4*np.finfo(float).eps``. As with `brentq`, for nice functions
         the method will often satisfy the above condition with
         ``xtol/2`` and ``rtol/2``.
-    maxiter : number, optional
-        if convergence is not achieved in maxiter iterations, an error is
+    maxiter : integer, optional
+        if convergence is not achieved in `maxiter` iterations, an error is
         raised.  Must be >= 0.
     args : tuple, optional
         containing extra arguments for the function `f`.
@@ -856,12 +856,13 @@ def _within_tolerance(x, y, rtol, atol):
 def _notclose(fs, rtol=_rtol, atol=_xtol):
     # Ensure not None, not 0, all finite, and not very close to each other
     notclosefvals = all(fs) and all(isfinite(fs)) and \
-                    not any(any(isclose(_f, fs[i + 1:], rtol=rtol, atol=atol)) for i, _f in enumerate(fs[:-1]))
+                    not any(any(isclose(_f, fs[i + 1:], rtol=rtol, atol=atol))
+                            for i, _f in enumerate(fs[:-1]))
     return notclosefvals
 
 
 def _secant(xvals, fvals):
-    r"""Perform a secant step, taking a little care"""
+    """Perform a secant step, taking a little care"""
     # Secant has many "mathematically" equivalent formulations
     # x2 = x0 - (x1 - x0)/(f1 - f0) * f0
     #    = x1 - (x1 - x0)/(f1 - f0) * f1
@@ -880,8 +881,7 @@ def _secant(xvals, fvals):
 
 
 def _update_bracket(ab, fab, c, fc):
-    r"""Update a bracket given (c, fc) with a < c < b.  Return the discarded endpoint(s)"""
-    a, b = ab
+    """Update a bracket given (c, fc) with a < c < b.  Return the discarded endpoints"""
     fa, fb = fab
     idx = (0 if sign(fa) * sign(fc) > 0 else 1)
     rx, rfx = ab[idx], fab[idx]
@@ -891,11 +891,12 @@ def _update_bracket(ab, fab, c, fc):
 
 
 def _compute_divided_differences(xvals, fvals, N=None, full=True, forward=True):
-    r"""Return a matrix of divided differences for the xvals, fvals pairs
+    """Return a matrix of divided differences for the xvals, fvals pairs
 
     DD[i, j] = f[x_{i-j}, ..., x_i] for 0 <= j <= i
 
-    If full is False, just return the main diagonal(or last row): f[a], f[a, b] and f[a, b, c].
+    If full is False, just return the main diagonal(or last row):
+      f[a], f[a, b] and f[a, b, c].
     If forward is False, return f[c], f[b, c], f[a, b, c]."""
     if full:
         if forward:
@@ -916,13 +917,14 @@ def _compute_divided_differences(xvals, fvals, N=None, full=True, forward=True):
     idx2Use = (0 if forward else -1)
     dd[0] = fvals[idx2Use]
     for i in range(1, len(xvals)):
-        row = npdiff(row)[:] / (xvals[i:i + len(row) - 1] - xvals[:len(row) - 1])
+        denom = xvals[i:i + len(row) - 1] - xvals[:len(row) - 1]
+        row = npdiff(row)[:] / denom
         dd[i] = row[idx2Use]
     return dd
 
 
 def _interpolated_poly(xvals, fvals, x):
-    r"""Compute p(x) for the polynomial passing through the specified locations.
+    """Compute p(x) for the polynomial passing through the specified locations.
 
     Use Neville's algorithm to compute p(x) where p is the minimal degree
     polynomial passing through the points xvals, fvals"""
@@ -942,7 +944,7 @@ def _interpolated_poly(xvals, fvals, x):
 
 
 def _inverse_poly_zero(a, b, c, d, fa, fb, fc, fd):
-    r"""Inverse cubic interpolation f-values -> x-values
+    """Inverse cubic interpolation f-values -> x-values
 
     Given four points (fa, a), (fb, b), (fc, c), (fd, d) with
     fa, fb, fc, fd all distinct, find poly IP(y) through the 4 points
@@ -952,7 +954,7 @@ def _inverse_poly_zero(a, b, c, d, fa, fb, fc, fd):
 
 
 def _newton_quadratic(ab, fab, d, fd, k):
-    """Apply Newton-Raphson like steps, using the divided differences to approximate f'
+    """Apply Newton-Raphson like steps, using divided differences to approximate f'
 
     ab is a real interval [a, b] containing a root,
     fab holds the real values of f(a), f(b)
@@ -961,7 +963,8 @@ def _newton_quadratic(ab, fab, d, fd, k):
     """
     a, b = ab
     fa, fb = fab
-    _, B, A = _compute_divided_differences([a, b, d], [fa, fb, fd], forward=True, full=False)
+    _, B, A = _compute_divided_differences([a, b, d], [fa, fb, fd],
+                                           forward=True, full=False)
 
     # _P  is the quadratic polynomial through the 3 points
     def _P(x):
@@ -986,11 +989,11 @@ def _newton_quadratic(ab, fab, d, fd, k):
 
 
 class TOMS748Solver(object):
-    r"""Solve f(x, *args) == 0 using Algorithm748 of Alefeld, Potro & Shi.
+    """Solve f(x, *args) == 0 using Algorithm748 of Alefeld, Potro & Shi.
     """
     _MU = 0.5
-    _K_MIN = 2
-    _K_MAX = 10
+    _K_MIN = 1
+    _K_MAX = 100  # A very high value for real usage.  Expect 1, 2, maybe 3.
 
     def __init__(self):
         self.f = None
@@ -998,7 +1001,7 @@ class TOMS748Solver(object):
         self.function_calls = 0
         self.iterations = 0
         self.k = 2
-        self.ab = [nan, nan]  # ab is a global interval [a, b] containing a root
+        self.ab = [nan, nan]  # ab=[a,b] is a global interval containing a root
         self.fab = [nan, nan]  # fab is function values at a, b
         self.d = None
         self.fd = None
@@ -1014,10 +1017,16 @@ class TOMS748Solver(object):
         self.xtol = xtol
         self.rtol = rtol
         self.maxiter = maxiter
-        self.k = min(max(k, self._K_MIN), self._K_MAX)
+        # Silently replace a low value of k with 1
+        self.k = max(k, self._K_MIN)
+        # Noisily replace a high value of k with self._K_MAX
+        if self.k > self._K_MAX:
+            msg = "toms748: Overriding k: ->%d" % self._K_MAX
+            warnings.warn(msg, RuntimeWarning)
+            self.k = self._K_MAX
 
     def _callf(self, x, error=True):
-        r"""Call the user-supplied function, update book-keeping"""
+        """Call the user-supplied function, update book-keeping"""
         fx = self.f(x, *self.args)
         self.function_calls += 1
         if not isfinite(fx) and error:
@@ -1054,13 +1063,14 @@ class TOMS748Solver(object):
             return _ECONVERGED, b
 
         if sign(fb) * sign(fa) > 0:
-            raise ValueError("a, b must bracket a root f(%e), f(%e) " % (fa, fb))
+            raise ValueError("a, b must bracket a root f(%e)=%e, f(%e)=%e " %
+                             (a, fa, b, fb))
         self.fab[:] = [fa, fb]
 
         return _EINPROGRESS, sum(self.ab) / 2.0
 
     def get_status(self):
-        # r"""Determine the current status"""
+        # """Determine the current status"""
         a, b = self.ab[:2]
         if _within_tolerance(a, b, self.rtol, self.xtol):
             return _ECONVERGED, sum(self.ab) / 2.0
@@ -1069,9 +1079,9 @@ class TOMS748Solver(object):
         return _EINPROGRESS, sum(self.ab) / 2.0
 
     def iterate(self):
-        r"""Perform one step in the algorithm.
+        """Perform one step in the algorithm.
 
-        Implements Algorithm 4.1(k=2) or 4.2(k=3) in [APS1995]
+        Implements Algorithm 4.1(k=1) or 4.2(k=2) in [APS1995]
         """
         self.iterations += 1
         eps = finfo(float).eps
@@ -1079,17 +1089,17 @@ class TOMS748Solver(object):
         ab_width = self.ab[1] - self.ab[0]  # Need the start width below
         c = None
 
-        for nq_steps in range(2, self.k+1):
+        for nsteps in range(2, self.k+2):
             # If the f-values are sufficiently separated, perform an inverse
-            # polynomial interpolation step.  Otherwise an approximate
-            # Newton-Raphson step.
+            # polynomial interpolation step.  Otherwise nsteps repeats of
+            # an approximate Newton-Raphson step.
             if _notclose(self.fab + [fd, fe], rtol=0, atol=32*eps):
                 c0 = _inverse_poly_zero(self.ab[0], self.ab[1], d, e,
                                         self.fab[0], self.fab[1], fd, fe)
                 if self.ab[0] < c0 < self.ab[1]:
                     c = c0
             if c is None:
-                c = _newton_quadratic(self.ab, self.fab, d, fd, nq_steps)
+                c = _newton_quadratic(self.ab, self.fab, d, fd, nsteps)
 
             fc = self._callf(c)
             if fc == 0:
@@ -1125,6 +1135,7 @@ class TOMS748Solver(object):
                     c = u + adj
                 if not self.ab[0] < c < self.ab[1]:
                     c = sum(self.ab) / 2.0
+
         fc = self._callf(c)
         if fc == 0:
             return _ECONVERGED, c
@@ -1172,45 +1183,48 @@ class TOMS748Solver(object):
             if status == _ECONVERGED:
                 return self.get_result(xn)
             if status == _ECONVERR:
+                fmt = "Failed to converge after %d iterations, bracket is %s"
                 if disp:
-                    msg = "Failed to converge after %d iterations, bracket is %s" % (self.iterations + 1, self.ab)
+                    msg = fmt % (self.iterations + 1, self.ab)
                     raise RuntimeError(msg)
                 return self.get_result(xn, _ECONVERR)
 
 
-def toms748(f, a, b, args=(), k=2,
+def toms748(f, a, b, args=(), k=1,
             xtol=_xtol, rtol=_rtol, maxiter=_iter,
             full_output=False, disp=True):
     """
     Find a zero using TOMS Algorithm 748 method.
 
     Implements the Algorithm 748 method of Alefeld, Potro and Shi to find a
-    zero of the function `f` on the sign changing interval `[a , b]`.
-    It uses a mixture of inverse cubic interpolation with
-    "Newton-quadratic" steps. [APS1995]
-    The R-order is at least 2.7, and with about asymptotically 2 function
-    evaluation per iteration, the efficiency index is approximately 1.65.
+    zero of the function `f` on the interval `[a , b]`, where `f(a)` and
+    `f(b)` must have opposite signs.
+
+    It uses a mixture of inverse cubic interpolation and
+    "Newton-quadratic" steps. [APS1995].
 
     Parameters
     ----------
     f : function
-        Python function returning a number.  The function :math:`f`
+        Python function returning a scalar.  The function :math:`f`
         must be continuous, and :math:`f(a)` and :math:`f(b)`
         have opposite signs.
-    a : number
-    b : number, with b > a and f(b)*f(a) < 0
+    a : scalar, lower boundary of the search interval
+    b : scalar, upper boundary of the search interval
     args : tuple, optional
         containing extra arguments for the function `f`.
         `f` is called by ``f(x, *args)``.
-    xtol : number, optional
+    k : integer, optional
+        The number of Newton quadratic steps to perform each iteration. `k>=1`.
+    xtol : scalar, optional
         The computed root ``x0`` will satisfy ``np.allclose(x, x0,
         atol=xtol, rtol=rtol)``, where ``x`` is the exact root. The
         parameter must be nonnegative.
-    rtol : number, optional
+    rtol : scalar, optional
         The computed root ``x0`` will satisfy ``np.allclose(x, x0,
         atol=xtol, rtol=rtol)``, where ``x`` is the exact root.
-    maxiter : number, optional
-        if convergence is not achieved in maxiter iterations, an error is
+    maxiter : integer, optional
+        if convergence is not achieved in `maxiter` iterations, an error is
         raised.  Must be >= 0.
     full_output : bool, optional
         If `full_output` is False, the root is returned.  If `full_output` is
@@ -1237,10 +1251,34 @@ def toms748(f, a, b, args=(), k=2,
     Notes
     -----
     `f` must be continuous.
+    Algorithm 748 with `k=2` is asymptotically the most efficient
+    algorithm known for finding roots of a four times continuously
+    differentiable function.
+    In contrast with Brent's algorithm, which may only decrease the length of
+    the enclosing bracket on the last step, Algorithm 748 decreases it each
+    iteration with the same asymptotic efficiency as it finds the root.
+
+    For easy statement of efficiency indices, assume that `f` has 4
+    continuouous deriviatives.
+    For `k=1`, the convergence order is at least 2.7, and with about
+    asymptotically 2 function evaluations per iteration, the efficiency
+    index is approximately 1.65.
+    For `k=2`, the order is about 4.6 with asymptotically 3 function
+    evaluations per iteration, and the efficiency index 1.66.
+    For higher values of `k`, the efficiency index approaches
+    the `k`-th root of `(3k-2)`, hence `k=1` or `k=2` are
+    usually appropriate.
+
+    References
+    ----------
+    .. [APS1995]
+       Alefeld, G. E. and Potra, F. A. and Shi, Yixun,
+       *Algorithm 748: Enclosing Zeros of Continuous Functions*,
+       ACM Trans. Math. Softw. Volume 221(1995)
+       doi = {10.1145/210089.210111}
 
     Examples
     --------
-
     >>> def f(x):
     ...     return (x**3 - 1)  # only one real root at x = 1
 
@@ -1254,16 +1292,6 @@ def toms748(f, a, b, args=(), k=2,
      function_calls: 11
          iterations: 5
                root: 1.0
-
-
-    References
-    ----------
-    .. [APS1995]
-       Alefeld, G. E. and Potra, F. A. and Shi, Yixun,
-       *Algorithm 748: Enclosing Zeros of Continuous Functions*,
-       ACM Trans. Math. Softw. Volume 221(1995)
-       doi = {10.1145/210089.210111}
-
     """
     if xtol <= 0:
         raise ValueError("xtol too small (%g <= 0)" % xtol)
@@ -1277,6 +1305,8 @@ def toms748(f, a, b, args=(), k=2,
         raise ValueError("b is not finite %s" % b)
     if a >= b:
         raise ValueError("a and b are not an interval [%d, %d]" % (a, b))
+    if not k >= 1:
+        raise ValueError("k too small (%s < 1)" % k)
 
     if not isinstance(args, tuple):
         args = (args,)

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -9,7 +9,7 @@ _iter = 100
 _xtol = 2e-12
 _rtol = 4 * np.finfo(float).eps
 
-__all__ = ['newton', 'bisect', 'ridder', 'brentq', 'brenth', 'toms748']
+__all__ = ['newton', 'bisect', 'ridder', 'brentq', 'brenth', 'toms748', 'RootResults']
 
 CONVERGED = 'converged'
 SIGNERR = 'sign error'

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -1217,7 +1217,7 @@ def toms748(f, a, b, args=(), k=1,
         containing extra arguments for the function `f`.
         `f` is called by ``f(x, *args)``.
     k : int, optional
-        The number of Newton quadratic steps to perform each iteration. `k>=1`.
+        The number of Newton quadratic steps to perform each iteration. ``k>=1``.
     xtol : scalar, optional
         The computed root ``x0`` will satisfy ``np.allclose(x, x0,
         atol=xtol, rtol=rtol)``, where ``x`` is the exact root. The

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -4,9 +4,6 @@ import warnings
 from collections import namedtuple
 from . import _zeros
 import numpy as np
-from numpy import (finfo, sign, isfinite, abs, asarray, nan, imag, isclose,
-                   frexp, zeros as npzeros, sum as npsum, diff as npdiff,
-                   array as nparray)
 
 _iter = 100
 _xtol = 2e-12
@@ -141,7 +138,7 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
         If True, raise a RuntimeError if the algorithm didn't converge, with
         the error message containing the number of iterations and current
         function value.  Otherwise the convergence status is recorded in a
-        RootResults return object.
+        `RootResults` return object.
         Ignored if `x0` is not scalar.
         *Note: this has little to do with displaying, however
         the `disp` keyword cannot be renamed for backwards compatibility.*
@@ -150,7 +147,7 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
     -------
     root : float, sequence, or ndarray
         Estimated location where function is zero.
-    r : RootResults, optional
+    r : `RootResults`, optional
         Present if ``full_output=True`` and `x0` is scalar.
         Object containing information about the convergence.  In particular,
         ``r.converged`` is True if the routine converged.
@@ -288,10 +285,10 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
                 # opposite direction to Newton.  Doesn't happen if x is close
                 # enough to root.
                 adj = newton_step * fder2 / fder / 2
-                if abs(adj) < 1:
+                if np.abs(adj) < 1:
                     newton_step /= 1.0 - adj
             p = p0 - newton_step
-            if abs(p - p0) < tol:
+            if np.abs(p - p0) < tol:
                 return _results_select(full_output, (p, funcalls, itr + 1, _ECONVERGED))
             p0 = p
     else:
@@ -311,7 +308,7 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
                 return _results_select(full_output, (p, funcalls, itr + 1, _ECONVERGED))
             else:
                 p = p1 - q1 * (p1 - p0) / (q1 - q0)
-            if abs(p - p1) < tol:
+            if np.abs(p - p1) < tol:
                 return _results_select(full_output, (p, funcalls, itr + 1, _ECONVERGED))
             p0 = p1
             q0 = q1
@@ -455,7 +452,7 @@ def bisect(f, a, b, args=(),
         atol=xtol, rtol=rtol)``, where ``x`` is the exact root. The
         parameter cannot be smaller than its default value of
         ``4*np.finfo(float).eps``.
-    maxiter : integer, optional
+    maxiter : int, optional
         if convergence is not achieved in `maxiter` iterations, an error is
         raised.  Must be >= 0.
     args : tuple, optional
@@ -467,14 +464,14 @@ def bisect(f, a, b, args=(),
         a `RootResults` object.
     disp : bool, optional
         If True, raise RuntimeError if the algorithm didn't converge.
-        Otherwise the convergence status is recorded in a RootResults
+        Otherwise the convergence status is recorded in a `RootResults`
         return object.
 
     Returns
     -------
     x0 : float
         Zero of `f` between `a` and `b`.
-    r : RootResults (present if ``full_output = True``)
+    r : `RootResults` (present if ``full_output = True``)
         Object containing information about the convergence.  In particular,
         ``r.converged`` is True if the routine converged.
 
@@ -535,7 +532,7 @@ def ridder(f, a, b, args=(),
         atol=xtol, rtol=rtol)``, where ``x`` is the exact root. The
         parameter cannot be smaller than its default value of
         ``4*np.finfo(float).eps``.
-    maxiter : integer, optional
+    maxiter : int, optional
         if convergence is not achieved in `maxiter` iterations, an error is
         raised.  Must be >= 0.
     args : tuple, optional
@@ -544,17 +541,17 @@ def ridder(f, a, b, args=(),
     full_output : bool, optional
         If `full_output` is False, the root is returned.  If `full_output` is
         True, the return value is ``(x, r)``, where `x` is the root, and `r` is
-        a RootResults object.
+        a `RootResults` object.
     disp : bool, optional
         If True, raise RuntimeError if the algorithm didn't converge.
-        Otherwise the convergence status is recorded in any RootResults
+        Otherwise the convergence status is recorded in any `RootResults`
         return object.
 
     Returns
     -------
     x0 : float
         Zero of `f` between `a` and `b`.
-    r : RootResults (present if ``full_output = True``)
+    r : `RootResults` (present if ``full_output = True``)
         Object containing information about the convergence.
         In particular, ``r.converged`` is True if the routine converged.
 
@@ -652,7 +649,7 @@ def brentq(f, a, b, args=(),
         ``4*np.finfo(float).eps``. For nice functions, Brent's
         method will often satisfy the above condition with ``xtol/2``
         and ``rtol/2``. [Brent1973]_
-    maxiter : integer, optional
+    maxiter : int, optional
         if convergence is not achieved in `maxiter` iterations, an error is
         raised.  Must be >= 0.
     args : tuple, optional
@@ -661,17 +658,17 @@ def brentq(f, a, b, args=(),
     full_output : bool, optional
         If `full_output` is False, the root is returned.  If `full_output` is
         True, the return value is ``(x, r)``, where `x` is the root, and `r` is
-        a RootResults object.
+        a `RootResults` object.
     disp : bool, optional
         If True, raise RuntimeError if the algorithm didn't converge.
-        Otherwise the convergence status is recorded in any RootResults
+        Otherwise the convergence status is recorded in any `RootResults`
         return object.
 
     Returns
     -------
     x0 : float
         Zero of `f` between `a` and `b`.
-    r : RootResults (present if ``full_output = True``)
+    r : `RootResults` (present if ``full_output = True``)
         Object containing information about the convergence.  In particular,
         ``r.converged`` is True if the routine converged.
 
@@ -772,7 +769,7 @@ def brenth(f, a, b, args=(),
         ``4*np.finfo(float).eps``. As with `brentq`, for nice functions
         the method will often satisfy the above condition with
         ``xtol/2`` and ``rtol/2``.
-    maxiter : integer, optional
+    maxiter : int, optional
         if convergence is not achieved in `maxiter` iterations, an error is
         raised.  Must be >= 0.
     args : tuple, optional
@@ -781,17 +778,17 @@ def brenth(f, a, b, args=(),
     full_output : bool, optional
         If `full_output` is False, the root is returned.  If `full_output` is
         True, the return value is ``(x, r)``, where `x` is the root, and `r` is
-        a RootResults object.
+        a `RootResults` object.
     disp : bool, optional
         If True, raise RuntimeError if the algorithm didn't converge.
-        Otherwise the convergence status is recorded in any RootResults
+        Otherwise the convergence status is recorded in any `RootResults`
         return object.
 
     Returns
     -------
     x0 : float
         Zero of `f` between `a` and `b`.
-    r : RootResults (present if ``full_output = True``)
+    r : `RootResults` (present if ``full_output = True``)
         Object containing information about the convergence.  In particular,
         ``r.converged`` is True if the routine converged.
 
@@ -847,16 +844,16 @@ def brenth(f, a, b, args=(),
 
 
 def _within_tolerance(x, y, rtol, atol):
-    diff = abs(x - y)
-    z = abs(y)
+    diff = np.abs(x - y)
+    z = np.abs(y)
     result = (diff <= (atol + rtol * z))
     return result
 
 
 def _notclose(fs, rtol=_rtol, atol=_xtol):
     # Ensure not None, not 0, all finite, and not very close to each other
-    notclosefvals = all(fs) and all(isfinite(fs)) and \
-                    not any(any(isclose(_f, fs[i + 1:], rtol=rtol, atol=atol))
+    notclosefvals = all(fs) and all(np.isfinite(fs)) and \
+                    not any(any(np.isclose(_f, fs[i + 1:], rtol=rtol, atol=atol))
                             for i, _f in enumerate(fs[:-1]))
     return notclosefvals
 
@@ -872,8 +869,8 @@ def _secant(xvals, fvals):
     x0, x1 = xvals[:2]
     f0, f1 = fvals[:2]
     if f0 == f1:
-        return nan
-    if abs(f1) > abs(f0):
+        return np.nan
+    if np.abs(f1) > np.abs(f0):
         x2 = (-f0 / f1 * x1 + x0) / (1 - f0 / f1)
     else:
         x2 = (-f1 / f0 * x0 + x1) / (1 - f1 / f0)
@@ -883,7 +880,7 @@ def _secant(xvals, fvals):
 def _update_bracket(ab, fab, c, fc):
     """Update a bracket given (c, fc) with a < c < b.  Return the discarded endpoints"""
     fa, fb = fab
-    idx = (0 if sign(fa) * sign(fc) > 0 else 1)
+    idx = (0 if np.sign(fa) * np.sign(fc) > 0 else 1)
     rx, rfx = ab[idx], fab[idx]
     fab[idx] = fc
     ab[idx] = c
@@ -900,25 +897,25 @@ def _compute_divided_differences(xvals, fvals, N=None, full=True, forward=True):
     If forward is False, return f[c], f[b, c], f[a, b, c]."""
     if full:
         if forward:
-            xvals = asarray(xvals)
+            xvals = np.asarray(xvals)
         else:
-            xvals = nparray(xvals)[::-1]
+            xvals = np.array(xvals)[::-1]
         M = len(xvals)
         N = M if N is None else min(N, M)
-        DD = npzeros([M, N])
+        DD = np.zeros([M, N])
         DD[:, 0] = fvals[:]
         for i in range(1, N):
-            DD[i:, i] = npdiff(DD[i - 1:, i - 1]) / (xvals[i:] - xvals[:M - i])
+            DD[i:, i] = np.diff(DD[i - 1:, i - 1]) / (xvals[i:] - xvals[:M - i])
         return DD
 
-    xvals = asarray(xvals)
-    dd = nparray(fvals)
-    row = nparray(fvals)
+    xvals = np.asarray(xvals)
+    dd = np.array(fvals)
+    row = np.array(fvals)
     idx2Use = (0 if forward else -1)
     dd[0] = fvals[idx2Use]
     for i in range(1, len(xvals)):
         denom = xvals[i:i + len(row) - 1] - xvals[:len(row) - 1]
-        row = npdiff(row)[:] / denom
+        row = np.diff(row)[:] / denom
         dd[i] = row[idx2Use]
     return dd
 
@@ -928,10 +925,10 @@ def _interpolated_poly(xvals, fvals, x):
 
     Use Neville's algorithm to compute p(x) where p is the minimal degree
     polynomial passing through the points xvals, fvals"""
-    xvals = asarray(xvals)
+    xvals = np.asarray(xvals)
     N = len(xvals)
-    Q = npzeros([N, N])
-    D = npzeros([N, N])
+    Q = np.zeros([N, N])
+    D = np.zeros([N, N])
     Q[:, 0] = fvals[:]
     D[:, 0] = fvals[:]
     for k in range(1, N):
@@ -940,7 +937,7 @@ def _interpolated_poly(xvals, fvals, x):
         Q[k:, k] = (xvals[k:] - x) / diffik * alpha
         D[k:, k] = (xvals[:N - k] - x) / diffik * alpha
     # Expect Q[-1, 1:] to be small relative to Q[-1, 0] as x approaches a root
-    return npsum(Q[-1, 1:]) + Q[-1, 0]
+    return np.sum(Q[-1, 1:]) + Q[-1, 0]
 
 
 def _inverse_poly_zero(a, b, c, d, fa, fb, fc, fd):
@@ -974,7 +971,7 @@ def _newton_quadratic(ab, fab, d, fd, k):
     if A == 0:
         r = a - fa / B
     else:
-        r = (a if sign(A) * sign(fa) > 0 else b)
+        r = (a if np.sign(A) * np.sign(fa) > 0 else b)
     # Apply k Newton-Raphson steps to _P(x), starting from x=r
     for i in range(k):
         r1 = r - _P(r) / (B + A * (2 * r - a - b))
@@ -1001,8 +998,8 @@ class TOMS748Solver(object):
         self.function_calls = 0
         self.iterations = 0
         self.k = 2
-        self.ab = [nan, nan]  # ab=[a,b] is a global interval containing a root
-        self.fab = [nan, nan]  # fab is function values at a, b
+        self.ab = [np.nan, np.nan]  # ab=[a,b] is a global interval containing a root
+        self.fab = [np.nan, np.nan]  # fab is function values at a, b
         self.d = None
         self.fd = None
         self.e = None
@@ -1029,40 +1026,42 @@ class TOMS748Solver(object):
         """Call the user-supplied function, update book-keeping"""
         fx = self.f(x, *self.args)
         self.function_calls += 1
-        if not isfinite(fx) and error:
+        if not np.isfinite(fx) and error:
             raise ValueError("Invalid function value: f(%f) -> %s " % (x, fx))
         return fx
 
     def get_result(self, x, flag=_ECONVERGED):
+        r"""Package the result and statistics into a tuple."""
         return (x, self.function_calls, self.iterations, flag)
 
     def _update_bracket(self, c, fc):
         return _update_bracket(self.ab, self.fab, c, fc)
 
     def start(self, f, a, b, args=()):
+        r"""Prepare for the iterations."""
         self.function_calls = 0
         self.iterations = 0
 
         self.f = f
         self.args = args
         self.ab[:] = [a, b]
-        if not isfinite(a) or imag(a) != 0:
+        if not np.isfinite(a) or np.imag(a) != 0:
             raise ValueError("Invalid x value: %s " % (a))
-        if not isfinite(b) or imag(b) != 0:
+        if not np.isfinite(b) or np.imag(b) != 0:
             raise ValueError("Invalid x value: %s " % (b))
 
         fa = self._callf(a)
-        if not isfinite(fa) or imag(fa) != 0:
+        if not np.isfinite(fa) or np.imag(fa) != 0:
             raise ValueError("Invalid function value: f(%f) -> %s " % (a, fa))
         if fa == 0:
             return _ECONVERGED, a
         fb = self._callf(b)
-        if not isfinite(fb) or imag(fb) != 0:
+        if not np.isfinite(fb) or np.imag(fb) != 0:
             raise ValueError("Invalid function value: f(%f) -> %s " % (b, fb))
         if fb == 0:
             return _ECONVERGED, b
 
-        if sign(fb) * sign(fa) > 0:
+        if np.sign(fb) * np.sign(fa) > 0:
             raise ValueError("a, b must bracket a root f(%e)=%e, f(%e)=%e " %
                              (a, fa, b, fb))
         self.fab[:] = [fa, fb]
@@ -1070,7 +1069,7 @@ class TOMS748Solver(object):
         return _EINPROGRESS, sum(self.ab) / 2.0
 
     def get_status(self):
-        # """Determine the current status"""
+        """Determine the current status."""
         a, b = self.ab[:2]
         if _within_tolerance(a, b, self.rtol, self.xtol):
             return _ECONVERGED, sum(self.ab) / 2.0
@@ -1084,7 +1083,7 @@ class TOMS748Solver(object):
         Implements Algorithm 4.1(k=1) or 4.2(k=2) in [APS1995]
         """
         self.iterations += 1
-        eps = finfo(float).eps
+        eps = np.finfo(float).eps
         d, fd, e, fe = self.d, self.fd, self.e, self.fe
         ab_width = self.ab[1] - self.ab[0]  # Need the start width below
         c = None
@@ -1110,28 +1109,28 @@ class TOMS748Solver(object):
             d, fd = self._update_bracket(c, fc)
 
         # u is the endpoint with the smallest f-value
-        uix = (0 if abs(self.fab[0]) < abs(self.fab[1]) else 1)
+        uix = (0 if np.abs(self.fab[0]) < np.abs(self.fab[1]) else 1)
         u, fu = self.ab[uix], self.fab[uix]
 
         _, A = _compute_divided_differences(self.ab, self.fab,
                                             forward=(uix == 0), full=False)
         c = u - 2 * fu / A
-        if abs(c - u) > 0.5 * (self.ab[1] - self.ab[0]):
+        if np.abs(c - u) > 0.5 * (self.ab[1] - self.ab[0]):
             c = sum(self.ab) / 2.0
         else:
-            if isclose(c, u, rtol=eps, atol=0):
+            if np.isclose(c, u, rtol=eps, atol=0):
                 # c didn't change (much).
                 # Either because the f-values at the endpoints have vastly
                 # differing magnitudes, or because the root is very close to
                 # that endpoint
-                frs = frexp(self.fab)[1]
+                frs = np.frexp(self.fab)[1]
                 if frs[uix] < frs[1 - uix] - 50:  # Differ by more than 2**50
                     c = (31 * self.ab[uix] + self.ab[1 - uix]) / 32
                 else:
                     # Make a bigger adjustment, about the
                     # size of the requested tolerance.
                     mm = (1 if uix == 0 else -1)
-                    adj = mm * abs(c) * self.rtol + mm * self.xtol
+                    adj = mm * np.abs(c) * self.rtol + mm * self.xtol
                     c = u + adj
                 if not self.ab[0] < c < self.ab[1]:
                     c = sum(self.ab) / 2.0
@@ -1161,6 +1160,7 @@ class TOMS748Solver(object):
 
     def solve(self, f, a, b, args=(),
               xtol=_xtol, rtol=_rtol, k=2, maxiter=_iter, disp=True):
+        r"""Solve f(x) = 0 given an interval containing a zero."""
         self.configure(xtol=xtol, rtol=rtol, maxiter=maxiter, disp=disp, k=k)
         status, xn = self.start(f, a, b, args)
         if status == _ECONVERGED:
@@ -1209,12 +1209,14 @@ def toms748(f, a, b, args=(), k=1,
         Python function returning a scalar.  The function :math:`f`
         must be continuous, and :math:`f(a)` and :math:`f(b)`
         have opposite signs.
-    a : scalar, lower boundary of the search interval
-    b : scalar, upper boundary of the search interval
+    a : scalar,
+        lower boundary of the search interval
+    b : scalar,
+        upper boundary of the search interval
     args : tuple, optional
         containing extra arguments for the function `f`.
         `f` is called by ``f(x, *args)``.
-    k : integer, optional
+    k : int, optional
         The number of Newton quadratic steps to perform each iteration. `k>=1`.
     xtol : scalar, optional
         The computed root ``x0`` will satisfy ``np.allclose(x, x0,
@@ -1223,23 +1225,23 @@ def toms748(f, a, b, args=(), k=1,
     rtol : scalar, optional
         The computed root ``x0`` will satisfy ``np.allclose(x, x0,
         atol=xtol, rtol=rtol)``, where ``x`` is the exact root.
-    maxiter : integer, optional
+    maxiter : int, optional
         if convergence is not achieved in `maxiter` iterations, an error is
         raised.  Must be >= 0.
     full_output : bool, optional
         If `full_output` is False, the root is returned.  If `full_output` is
         True, the return value is ``(x, r)``, where `x` is the root, and `r` is
-        a RootResults object.
+        a `RootResults` object.
     disp : bool, optional
         If True, raise RuntimeError if the algorithm didn't converge.
-        Otherwise the convergence status is recorded in the RootResults
+        Otherwise the convergence status is recorded in the `RootResults`
         return object.
 
     Returns
     -------
     x0 : float
         Approximate Zero of `f`
-    r : RootResults (present if ``full_output = True``)
+    r : `RootResults` (present if ``full_output = True``)
         Object containing information about the convergence.  In particular,
         ``r.converged`` is True if the routine converged.
 
@@ -1251,7 +1253,7 @@ def toms748(f, a, b, args=(), k=1,
     Notes
     -----
     `f` must be continuous.
-    Algorithm 748 with `k=2` is asymptotically the most efficient
+    Algorithm 748 with ``k=2`` is asymptotically the most efficient
     algorithm known for finding roots of a four times continuously
     differentiable function.
     In contrast with Brent's algorithm, which may only decrease the length of
@@ -1260,13 +1262,13 @@ def toms748(f, a, b, args=(), k=1,
 
     For easy statement of efficiency indices, assume that `f` has 4
     continuouous deriviatives.
-    For `k=1`, the convergence order is at least 2.7, and with about
+    For ``k=1``, the convergence order is at least 2.7, and with about
     asymptotically 2 function evaluations per iteration, the efficiency
     index is approximately 1.65.
-    For `k=2`, the order is about 4.6 with asymptotically 3 function
+    For ``k=2``, the order is about 4.6 with asymptotically 3 function
     evaluations per iteration, and the efficiency index 1.66.
     For higher values of `k`, the efficiency index approaches
-    the `k`-th root of `(3k-2)`, hence `k=1` or `k=2` are
+    the `k`-th root of ``(3k-2)``, hence ``k=1`` or ``k=2`` are
     usually appropriate.
 
     References
@@ -1299,9 +1301,9 @@ def toms748(f, a, b, args=(), k=1,
         raise ValueError("rtol too small (%g < %g)" % (rtol, _rtol))
     if maxiter < 1:
         raise ValueError("maxiter must be greater than 0")
-    if not isfinite(a):
+    if not np.isfinite(a):
         raise ValueError("a is not finite %s" % a)
-    if not isfinite(b):
+    if not np.isfinite(b):
         raise ValueError("b is not finite %s" % b)
     if a >= b:
         raise ValueError("a and b are not an interval [%d, %d]" % (a, b))


### PR DESCRIPTION
Added `toms748(f, a, b, args=(), k=2, xtol=_xtol, rtol=_rtol, maxiter=_iter, full_output=False, disp=True): ` to `optimize.zeros`.  
`toms748() ` finds a zero of a function inside a bracketing interval.  Algorithm from the 1995 paper by
Alefeld, Potra and Shi, "Algorithm 748: Enclosing Zeros of Continuous Functions", in ACM Trans. Math. Software, hence the name `toms748`.

Added a table showing applicability of each of the 1-d root-finders to `optimize/__init__.py`.

Added 15 test case families from the Alefeld et al paper.
Added 2 test case families for complex-valued functions.
Added `get_tests(collection)` to `optimize._tstutils.py` to return one of 3 collections  `('aps, 'complex', 'original')`, filtered by desired smoothness.
Added generic `TestBasic.run_collection()` to `optimize/tests/test_zeros.py` to allow
testing of any of the 1-dimensional methods with any of the appropriate
collections.
memoized `f6` in `optimize._tstutils.py` so that it is still random but repeatable.  Previously`assert f6(x) == f6(x)` would fail. `f6` was behaving as a random variable, not a random function.