### PR TITLE
ENH: Only use Halley's adjustment to Newton if close enough.

### DIFF
--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -7,9 +7,10 @@ from numpy.testing import (assert_warns, assert_,
                            assert_allclose,
                            assert_equal)
 import numpy as np
+from numpy import finfo, power
 
 from scipy.optimize import zeros as cc
-from scipy.optimize import zeros
+from scipy.optimize import zeros, root_scalar
 
 # Import testing parameters
 from scipy.optimize._tstutils import functions, fstrings
@@ -357,3 +358,29 @@ def test_gh8904_zeroder_at_root_fails():
     r = zeros.newton(f_zeroder_root, x0=[0.5]*10, fprime=fder)
     assert_allclose(r, 0, atol=zeros._xtol, rtol=zeros._rtol)
     # doesn't apply to halley
+
+
+def test_gh_8881():
+    r"""Test that Halley's method realizes that the 2nd order adjustment
+    is too big and drops off to the 1st order adjustment."""
+    n = 9
+
+    def f(x):
+        return power(x, 1.0/n) - power(n, 1.0/n)
+
+    def fp(x):
+        return power(x, (1.0-n)/n)/n
+
+    def fpp(x):
+        return power(x, (1.0-2*n)/n) * (1.0/n) * (1.0-n)/n
+
+    x0 = 0.1
+    # The root is at x=9.
+    # The function has positive slope, x0 < root.
+    # Newton succeeds in 8 iterations
+    r = root_scalar(f, method='newton', x0=x0, fprime=fp)
+    assert(r.converged)
+    # Before the Issue 8881/PR 8882, halley would send x in the wrong direction.
+    # Check that it now succeeds.
+    r = root_scalar(f, method='halley', x0=x0, fprime=fp, fprime2=fpp)
+    assert(r.converged)

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -10,7 +10,7 @@ import numpy as np
 from numpy import finfo, power
 
 from scipy.optimize import zeros as cc
-from scipy.optimize import zeros, root_scalar
+from scipy.optimize import zeros, newton
 
 # Import testing parameters
 from scipy.optimize._tstutils import functions, fstrings
@@ -378,9 +378,9 @@ def test_gh_8881():
     # The root is at x=9.
     # The function has positive slope, x0 < root.
     # Newton succeeds in 8 iterations
-    r = root_scalar(f, method='newton', x0=x0, fprime=fp)
+    rt, r = newton(f, x0, fprime=fp, full_output=True)
     assert(r.converged)
     # Before the Issue 8881/PR 8882, halley would send x in the wrong direction.
     # Check that it now succeeds.
-    r = root_scalar(f, method='halley', x0=x0, fprime=fp, fprime2=fpp)
+    rt, r = newton(f, x0, fprime=fp, fprime2=fpp, full_output=True)
     assert(r.converged)


### PR DESCRIPTION
Closes gh-8881.

Halley's enhancement to the Newton-Raphson rule divides the step by `(1 - 0.5 * f/f' * f''/f')`
If `(1 - 0.5 * f/f' * f''/f')` is not close to 1, then the iteration could easily go in the wrong direction. 
This only happens when the approximation is not that close. See gh-8881.

Algorithm change: If the denominator `(1 - 0.5 * f/f' * f''/f')` in the adjustment is not close to 1, don't use it, as the current approximation is not close enough to the root to guarantee that the necessary assumptions hold.  Just fall-back to a Newton step.

Expected changes in behavior in existing usage:
1. Some convergence failures will be replaced with successes.
2. For an approximation now considered not close enough, the algorithm may take one or more Newton steps until close enough.  This may lead to an increase in the number of iterations, or convergence to a different root.
3. In some cases, `newton(f,...,fprime2=fpp, )` may no longer converge when previously it did. This may occur if the derivative has a zero between the current approximation and the root, or if the sign of `f'(x0)` and `f'(root)` are different.  [E.g `f(x) = 16*x*(x-1)*(x+1)+7`, which has a single real root `-1.17` and is situated on an upward sloping part of the graph.  Starting at `x0` in a positive but downward sloping part of the graph (say between `-0.5 and 0.5`), the algorithm may or may not converge.]
I.e. If Newton's algorithm would be on shaky ground due to the presence of stationary points, then using the modification here may change some previous Halley convergences to failures. And vice-versa.