### PR TITLE
FIX: optimize: make jac and hess truly optional for 'trust-constr'

### DIFF
--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -539,6 +539,8 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
                 jac = fun.derivative
             else:
                 jac = '2-point'
+        elif jac is None:
+            jac = '2-point'
         elif not callable(jac) and jac not in ('2-point', '3-point', 'cs'):
             raise ValueError("Unsupported jac definition.")
     else:

--- a/scipy/optimize/_trustregion_constr/minimize_trustregion_constr.py
+++ b/scipy/optimize/_trustregion_constr/minimize_trustregion_constr.py
@@ -5,6 +5,7 @@ from scipy.sparse.linalg import LinearOperator
 from .._differentiable_functions import VectorFunction
 from .._constraints import (
     NonlinearConstraint, LinearConstraint, PreparedConstraint, strict_bounds)
+from .._hessian_update_strategy import BFGS
 from ..optimize import OptimizeResult
 from .._differentiable_functions import ScalarFunction
 from .equality_constrained_sqp import equality_constrained_sqp
@@ -307,8 +308,11 @@ def _minimize_trustregion_constr(fun, x0, args, grad,
     """
     x0 = np.atleast_1d(x0).astype(float)
     n_vars = np.size(x0)
-    if callable(hessp) and hess is None:
-        hess = HessianLinearOperator(hessp, n_vars)
+    if hess is None:
+        if callable(hessp):
+            hess = HessianLinearOperator(hessp, n_vars)
+        else:
+            hess = BFGS()
     if disp and verbose == 0:
         verbose = 1
 

--- a/scipy/optimize/_trustregion_constr/minimize_trustregion_constr.py
+++ b/scipy/optimize/_trustregion_constr/minimize_trustregion_constr.py
@@ -346,6 +346,8 @@ def _minimize_trustregion_constr(fun, x0, args, grad,
         sparse_jacobian = n_sparse > 0
 
     if bounds is not None:
+        if sparse_jacobian is None:
+            sparse_jacobian = True
         prepared_constraints.append(PreparedConstraint(bounds, x0,
                                                        sparse_jacobian))
 

--- a/scipy/optimize/tests/test_minimize_constrained.py
+++ b/scipy/optimize/tests/test_minimize_constrained.py
@@ -275,6 +275,23 @@ class IneqRosenbrock(Rosenbrock):
         return LinearConstraint(A, -np.inf, b)
 
 
+class BoundedRosenbrock(Rosenbrock):
+    """Rosenbrock subject to inequality constraints.
+
+    The following optimization problem:
+        minimize sum(100.0*(x[1] - x[0]**2)**2.0 + (1 - x[0])**2)
+        subject to:  -2 <= x[0] <= 0
+                      0 <= x[1] <= 2
+
+    Taken from matlab ``fmincon`` documentation.
+    """
+    def __init__(self, random_state=0):
+        Rosenbrock.__init__(self, 2, random_state)
+        self.x0 = [-0.2, 0.2]
+        self.x_opt = None
+        self.bounds = Bounds([-2, 0], [0, 2])
+
+
 class EqIneqRosenbrock(Rosenbrock):
     """Rosenbrock subject to equality and inequality constraints.
 
@@ -444,6 +461,7 @@ class TestTrustRegionConstr(TestCase):
                             Rosenbrock(),
                             IneqRosenbrock(),
                             EqIneqRosenbrock(),
+                            BoundedRosenbrock(),
                             Elec(n_electrons=2),
                             Elec(n_electrons=2, constr_hess='2-point'),
                             Elec(n_electrons=2, constr_hess=SR1()),

--- a/scipy/optimize/tests/test_minimize_constrained.py
+++ b/scipy/optimize/tests/test_minimize_constrained.py
@@ -505,6 +505,20 @@ class TestTrustRegionConstr(TestCase):
                     if result.status in (0, 3):
                         raise RuntimeError("Invalid termination condition.")
 
+    def test_default_jac_and_hess(self):
+        def fun(x):
+            return (x - 1) ** 2
+        bounds = [(-2, 2)]
+        res = minimize(fun, x0=[-1.5], bounds=bounds, method='trust-constr')
+        assert_array_almost_equal(res.x, 1, decimal=5)
+
+    def test_default_hess(self):
+        def fun(x):
+            return (x - 1) ** 2
+        bounds = [(-2, 2)]
+        res = minimize(fun, x0=[-1.5], bounds=bounds, method='trust-constr', jac='2-point')
+        assert_array_almost_equal(res.x, 1, decimal=5)
+
     def test_no_constraints(self):
         prob = Rosenbrock()
         result = minimize(prob.fun, prob.x0,


### PR DESCRIPTION
In this PR I fix the problem described by @mdhaber in #8867. Hence this make the jacobian and hessian truly optional for method 'trust-constr'

I also fix another problem I found: the algorithm was failing when only bound constraints were present.