### PR TITLE
TST: Do not error on warnings raised about non-tuple indexing.

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -6,6 +6,8 @@ markers =
 filterwarnings =
     error
     always::scipy._lib._testutils.FPUModeChangeWarning
+    once:Using a non-tuple sequence for multidimensional indexing.*:FutureWarning
+    once:Using a non-tuple sequence for multidimensional indexing.*:PendingDeprecationWarning
     once:.*LAPACK bug 0038.*:RuntimeWarning
 env =
     PYTHONHASHSEED=0


### PR DESCRIPTION
This avoids having the tests error on the warnings introduced in
https://github.com/numpy/numpy/pull/9686

The change is pretty much verbatim from
https://github.com/scipy/scipy/pull/8879#issuecomment-392721828

This should get the CI tests working until https://github.com/scipy/scipy/pull/8879 can be finished.

