### PR TITLE
FIX: generating random sparse matrix with size > max(int32)

### DIFF
--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -779,9 +779,9 @@ greater than %d - this is not supported on this machine
         ind = np.empty(k, dtype=tp)
         selected = set()
         for i in xrange(k):
-            j = random_state.randint(mn)
+            j = random_state.randint(mn, dtype=tp)
             while j in selected:
-                j = random_state.randint(mn)
+                j = random_state.randint(mn, dtype=tp)
             selected.add(j)
             ind[i] = j
 

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -31,7 +31,8 @@ def _sprandn(m, n, density=0.01, format="coo", dtype=None, random_state=None):
                             random_state, data_rvs)
 
 
-class TestConstructUtils(object):
+class TestConstructUtils(object):      
+        
     def test_spdiags(self):
         diags1 = array([[1, 2, 3, 4, 5]])
         diags2 = array([[1, 2, 3, 4, 5],
@@ -477,4 +478,7 @@ class TestConstructUtils(object):
         # anything that np.dtype can convert to a dtype should be accepted
         # for the dtype
         a = construct.random(10, 10, dtype='d')
-
+    
+    def test_random_large(self):
+        n = 100000
+        x = construct.random(n,n, density=100/n/n);

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -481,4 +481,4 @@ class TestConstructUtils(object):
     
     def test_random_large(self):
         n = 100000
-        x = construct.random(n,n, density=100/n/n);
+        x = construct.random(n,n, density=100/n/n)


### PR DESCRIPTION
This fixes the following bug:
```
from scipy import sparse
N = 46952
x = sparse.random(N,N, density=100/N/N)
```
This occurs because the product of the matrix dimensions is larger than the maximum value of np.int32 and so the the `randint()` call fails. The fix passes the correct type to the `dtype` parameter. The documentation should be updated to mention that the `random_state.randint` function must accept a `dtype` argument.