### PR TITLE
BUG: ENH: Check if guess for newton is already zero before checking derivative

### DIFF
--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -97,7 +97,7 @@ class TestBasic(object):
                     x, r = zeros.newton(f1, x0, maxiter=iters, disp=True, **kwargs)
 
     def test_deriv_zero_warning(self):
-        func = lambda x: x**2
+        func = lambda x: x**2 - 2.0
         dfunc = lambda x: 2*x
         assert_warns(RuntimeWarning, cc.newton, func, 0.0, dfunc)
 

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -171,8 +171,9 @@ def test_complex_halley():
     assert_allclose(f(y, *coeffs), 0, atol=1e-6)
 
 
+@pytest.mark.filterwarnings("error")
 def test_gh8904_zeroder_at_root_fails():
-    """Test that Newton or Halley don't fail if zero derivative at root"""
+    """Test that Newton or Halley don't warn if zero derivative at root"""
 
     # a function that has a zero derivative at it's root
     def f_zeroder_root(x):

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -175,13 +175,15 @@ def test_complex_halley():
 def test_gh8904_zeroder_at_root_fails():
     """Test that Newton or Halley don't warn if zero derivative at root"""
 
+    xtol = finfo(float).eps
+
     # a function that has a zero derivative at it's root
     def f_zeroder_root(x):
         return x ** 3 - x ** 2
 
     # should work with secant
     r = zeros.newton(f_zeroder_root, x0=0)
-    assert_allclose(r, 0, atol=1e-16)
+    assert_allclose(r, 0, atol=xtol)
 
     # 1st derivative
     def fder(x):
@@ -189,10 +191,10 @@ def test_gh8904_zeroder_at_root_fails():
 
     # should work with newton and halley
     r = zeros.newton(f_zeroder_root, x0=0, fprime=fder)
-    assert_allclose(r, 0, atol=1e-16)
+    assert_allclose(r, 0, atol=xtol)
     r = zeros.newton(f_zeroder_root, x0=0, fprime=fder,
                      fprime2=lambda x: 6 * x - 2)
-    assert_allclose(r, 0, atol=1e-16)
+    assert_allclose(r, 0, atol=xtol)
 
     # also test that if a root is found we do not raise RuntimeWarning even if
     # the derivative is zero, EG: at x = 0.5, then fval = -0.125 and
@@ -200,7 +202,7 @@ def test_gh8904_zeroder_at_root_fails():
     # root, but if the solver continued with that guess, then it will calculate
     # a zero derivative, so it should return the root w/o RuntimeWarning
     r = zeros.newton(f_zeroder_root, x0=0.5, fprime=fder)
-    assert_allclose(r, 0, atol=1e-16)
+    assert_allclose(r, 0, atol=xtol)
     r = zeros.newton(f_zeroder_root, x0=0.5, fprime=fder,
                      fprime2=lambda x: 6 * x - 2)
-    assert_allclose(r, 0, atol=1e-16)
+    assert_allclose(r, 0, atol=xtol)

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -191,7 +191,7 @@ def test_gh8904_zeroder_at_root_fails():
     r = zeros.newton(f_zeroder_root, x0=0, fprime=fder)
     assert_allclose(r, 0, atol=zeros._xtol, rtol=zeros._rtol)
     r = zeros.newton(f_zeroder_root, x0=0, fprime=fder,
-                     fprime2=lambda x: 6 * x - 2)
+                     fprime2=lambda x: 6*x - 2)
     assert_allclose(r, 0, atol=zeros._xtol, rtol=zeros._rtol)
 
     # also test that if a root is found we do not raise RuntimeWarning even if

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -169,3 +169,27 @@ def test_complex_halley():
     y = zeros.newton(f, z, args=coeffs, fprime=f_1, fprime2=f_2, tol=1e-6)
     # (-0.75000000000000078+1.1989578808281789j)
     assert_allclose(f(y, *coeffs), 0, atol=1e-6)
+
+
+def test_gh8904_zeroder_at_root_fails():
+    """Test that Newton or Halley don't fail if zero derivative at root"""
+
+    # a function that has a zero derivative at it's root
+    def f_zeroder_root(x):
+        return x ** 3 - x ** 2
+
+    # should work with secant
+    r = zeros.newton(f_zeroder_root, x0=0)
+    assert_allclose(r, 0, atol=1e-16)
+
+    # 1st derivative
+    def fder(x):
+        return 3 * x ** 2 - 2 * x
+
+    # should work with newton and halley
+    r = zeros.newton(f_zeroder_root, x0=0, fprime=fder)
+    assert_allclose(r, 0, atol=1e-16)
+    r = zeros.newton(f_zeroder_root, x0=0, fprime=fder,
+                     fprime2=lambda x: 6 * x - 2)
+    assert_allclose(r, 0, atol=1e-16)
+

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -203,4 +203,4 @@ def test_gh8904_zeroder_at_root_fails():
     assert_allclose(r, 0, atol=zeros._xtol, rtol=zeros._rtol)
     r = zeros.newton(f_zeroder_root, x0=0.5, fprime=fder,
                      fprime2=lambda x: 6 * x - 2)
-    assert_allclose(r, 0, atol=zeros._xtol, rtol=zeros._rtol)
+    assert_allclose(r, 0, atol=1e-6)

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -201,6 +201,4 @@ def test_gh8904_zeroder_at_root_fails():
     # a zero derivative, so it should return the root w/o RuntimeWarning
     r = zeros.newton(f_zeroder_root, x0=0.5, fprime=fder)
     assert_allclose(r, 0, atol=zeros._xtol, rtol=zeros._rtol)
-    r = zeros.newton(f_zeroder_root, x0=0.5, fprime=fder,
-                     fprime2=lambda x: 6 * x - 2)
-    assert_allclose(r, 0, atol=1e-6)
+    # doesn't apply to halley

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -194,3 +194,13 @@ def test_gh8904_zeroder_at_root_fails():
                      fprime2=lambda x: 6 * x - 2)
     assert_allclose(r, 0, atol=1e-16)
 
+    # also test that if a root is found we do not raise RuntimeWarning even if
+    # the derivative is zero, EG: at x = 0.5, then fval = -0.125 and
+    # fder = -0.25 so the next guess is 0.5 - (-0.125/-0.5) = 0 which is the
+    # root, but if the solver continued with that guess, then it will calculate
+    # a zero derivative, so it should return the root w/o RuntimeWarning
+    r = zeros.newton(f_zeroder_root, x0=0.5, fprime=fder)
+    assert_allclose(r, 0, atol=1e-16)
+    r = zeros.newton(f_zeroder_root, x0=0.5, fprime=fder,
+                     fprime2=lambda x: 6 * x - 2)
+    assert_allclose(r, 0, atol=1e-16)

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -171,13 +171,13 @@ def test_complex_halley():
     assert_allclose(f(y, *coeffs), 0, atol=1e-6)
 
 
-@pytest.mark.filterwarnings("error")
+# this test should **not** raise a RuntimeWarning
 def test_gh8904_zeroder_at_root_fails():
     """Test that Newton or Halley don't warn if zero derivative at root"""
 
     # a function that has a zero derivative at it's root
     def f_zeroder_root(x):
-        return x ** 3 - x ** 2
+        return x**3 - x**2
 
     # should work with secant
     r = zeros.newton(f_zeroder_root, x0=0)
@@ -185,7 +185,7 @@ def test_gh8904_zeroder_at_root_fails():
 
     # 1st derivative
     def fder(x):
-        return 3 * x ** 2 - 2 * x
+        return 3 * x**2 - 2 * x
 
     # should work with newton and halley
     r = zeros.newton(f_zeroder_root, x0=0, fprime=fder)

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -175,15 +175,13 @@ def test_complex_halley():
 def test_gh8904_zeroder_at_root_fails():
     """Test that Newton or Halley don't warn if zero derivative at root"""
 
-    xtol = finfo(float).eps
-
     # a function that has a zero derivative at it's root
     def f_zeroder_root(x):
         return x ** 3 - x ** 2
 
     # should work with secant
     r = zeros.newton(f_zeroder_root, x0=0)
-    assert_allclose(r, 0, atol=xtol)
+    assert_allclose(r, 0, atol=zeros._xtol, rtol=zeros._rtol)
 
     # 1st derivative
     def fder(x):
@@ -191,10 +189,10 @@ def test_gh8904_zeroder_at_root_fails():
 
     # should work with newton and halley
     r = zeros.newton(f_zeroder_root, x0=0, fprime=fder)
-    assert_allclose(r, 0, atol=xtol)
+    assert_allclose(r, 0, atol=zeros._xtol, rtol=zeros._rtol)
     r = zeros.newton(f_zeroder_root, x0=0, fprime=fder,
                      fprime2=lambda x: 6 * x - 2)
-    assert_allclose(r, 0, atol=xtol)
+    assert_allclose(r, 0, atol=zeros._xtol, rtol=zeros._rtol)
 
     # also test that if a root is found we do not raise RuntimeWarning even if
     # the derivative is zero, EG: at x = 0.5, then fval = -0.125 and
@@ -202,7 +200,7 @@ def test_gh8904_zeroder_at_root_fails():
     # root, but if the solver continued with that guess, then it will calculate
     # a zero derivative, so it should return the root w/o RuntimeWarning
     r = zeros.newton(f_zeroder_root, x0=0.5, fprime=fder)
-    assert_allclose(r, 0, atol=xtol)
+    assert_allclose(r, 0, atol=zeros._xtol, rtol=zeros._rtol)
     r = zeros.newton(f_zeroder_root, x0=0.5, fprime=fder,
                      fprime2=lambda x: 6 * x - 2)
-    assert_allclose(r, 0, atol=xtol)
+    assert_allclose(r, 0, atol=zeros._xtol, rtol=zeros._rtol)

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -3,7 +3,7 @@ from __future__ import division, print_function, absolute_import
 import warnings
 
 from . import _zeros
-from numpy import finfo, sign, sqrt
+from numpy import finfo
 
 _iter = 100
 _xtol = 2e-12
@@ -195,7 +195,7 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
             fval = func(p0, *args)
             funcalls += 1
             # If a root has been found within some tolerance, then terminate
-            if fval == 0 or abs(fval) < _xtol + _rtol * abs(fval):
+            if fval == 0 or abs(fval) < finfo(float).eps:
                 return _results_select(full_output, (p0, funcalls, itr, _ECONVERGED))
             fder = fprime(p0, *args)
             funcalls += 1

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -195,7 +195,7 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
             fval = func(p0, *args)
             funcalls += 1
             # If a root has been found within some tolerance, then terminate
-            if fval == 0 or abs(fval) < finfo(float).eps:
+            if fval == 0 or abs(fval) < _xtol + _rtol * abs(fval):
                 return _results_select(full_output, (p0, funcalls, itr, _ECONVERGED))
             fder = fprime(p0, *args)
             funcalls += 1

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -187,21 +187,22 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
     # Multiply by 1.0 to convert to floating point.  We don't use float(x0)
     # so it still works if x0 is complex.
     p0 = 1.0 * x0
-    # check if initial guess is the solution
-    if func(p0, *args) == 0:
-        return _results_select(full_output, (p0, 0, 0, _ECONVERGED))
     funcalls = 0
     if fprime is not None:
         # Newton-Raphson method
         for itr in range(maxiter):
+            # first evaluate fval
+            fval = func(p0, *args)
+            funcalls += 1
+            # If a root has been found within some tolerance, then terminate
+            if fval == 0 or abs(fval) < _xtol + _rtol * abs(fval):
+                return _results_select(full_output, (p0, funcalls, itr, _ECONVERGED))
             fder = fprime(p0, *args)
             funcalls += 1
             if fder == 0:
                 msg = "derivative was zero."
                 warnings.warn(msg, RuntimeWarning)
                 return _results_select(full_output, (p0, funcalls, itr + 1, _ECONVERR))
-            fval = func(p0, *args)
-            funcalls += 1
             newton_step = fval / fder
             if fprime2 is None:
                 # Newton step

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -194,8 +194,8 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
             # first evaluate fval
             fval = func(p0, *args)
             funcalls += 1
-            # If a root has been found within some tolerance, then terminate
-            if fval == 0 or abs(fval) < _xtol + _rtol * abs(fval):
+            # If fval is 0, a root has been found, then terminate
+            if fval == 0:
                 return _results_select(full_output, (p0, funcalls, itr, _ECONVERGED))
             fder = fprime(p0, *args)
             funcalls += 1

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -187,6 +187,9 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
     # Multiply by 1.0 to convert to floating point.  We don't use float(x0)
     # so it still works if x0 is complex.
     p0 = 1.0 * x0
+    # check if initial guess is the solution
+    if func(p0, *args) == 0:
+        return _results_select(full_output, (p0, 0, 0, _ECONVERGED))
     funcalls = 0
     if fprime is not None:
         # Newton-Raphson method


### PR DESCRIPTION
* fixes #8904 
* adds a test to see if `RuntimeWarning` is raised for case where `fval(p0)` is already zero where `p0` is the initial guess
* checks in `newton` if `fval(p0)` is already zero, before iterating for any method or evaluating derivatives `fprime` (or `fprime2`) if given, and returns `_ECONVERGED` instead of raising a `RuntimeWarning`
* fails the current test `scipy/optimize/tests/test_zeros.py::TestBasic::test_deriv_zero_warning` since these two are in opposition.
* see [post on SciPy Dev mailing list](https://mail.python.org/pipermail/scipy-dev/2018-June/022861.html) for more info