### PR TITLE
ENH: Make sorting optional for cKDTree.query_ball_point()

### DIFF
--- a/benchmarks/benchmarks/spatial.py
+++ b/benchmarks/benchmarks/spatial.py
@@ -127,6 +127,10 @@ class Radius(LimitedParamBenchmark):
     def time_query_ball_point(self, mnr, p, probe_radius, boxsize, leafsize):
         self.T.query_ball_point(self.queries, probe_radius, p=p)
 
+    def time_query_ball_point_nosort(self, mnr, p, probe_radius, boxsize, leafsize):
+        self.T.query_ball_point(self.queries, probe_radius, p=p,
+                                return_sorted=False)
+
     def time_query_pairs(self, mnr, p, probe_radius, boxsize, leafsize):
         self.T.query_pairs(probe_radius, p=p)
 

--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -885,6 +885,8 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
             multi-point queries which was the behavior before this option
             was added.
 
+            .. versionadded:: 1.2.0
+
         Returns
         -------
         results : list or array of lists

--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -856,7 +856,8 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
     # ----------------
 
     def query_ball_point(cKDTree self, object x, np.float64_t r,
-                         np.float64_t p=2., np.float64_t eps=0, n_jobs=1):
+                         np.float64_t p=2., np.float64_t eps=0, n_jobs=1,
+                         return_sorted=None):
         """
         query_ball_point(self, x, r, p=2., eps=0)
         
@@ -878,6 +879,11 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
         n_jobs : int, optional
             Number of jobs to schedule for parallel processing. If -1 is given
             all processors are used. Default: 1.
+        return_sorted : bool, optional
+            Sorts returned indicies if True and does not sort them if False. If
+            None, does not sort single point queries, but does sort
+            multi-point queries which was the behavior before this option
+            was added.
 
         Returns
         -------
@@ -932,7 +938,10 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
                 if NPY_LIKELY(n > 0):
                     cur = npy_intp_vector_buf(vres)
                     for i in range(n):
-                        tmp[i] = cur[0]
+                        if return_sorted:
+                            tmp[i] = sorted(cur[0])
+                        else:
+                            tmp[i] = cur[0]
                         cur += 1
                 result = tmp
             
@@ -1006,7 +1015,10 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
                         for j in range(m):
                             tmp[j] = cur[0]
                             cur += 1
-                        result[c] = sorted(tmp)
+                        if return_sorted or return_sorted is None:
+                            result[c] = sorted(tmp)
+                        else:
+                            result[c] = tmp
                     else:
                         result[c] = []
                     i += 1

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -1331,7 +1331,7 @@ def test_short_knn():
             [0., 0.01, np.inf, np.inf],
             [0., np.inf, np.inf, np.inf]])
 
-class Test_sorted_query_ball_point:
+class Test_sorted_query_ball_point(object):
 
     def setup_method(self):
         np.random.seed(1234)

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -1330,3 +1330,28 @@ def test_short_knn():
             [0., 0.01, np.inf, np.inf],
             [0., 0.01, np.inf, np.inf],
             [0., np.inf, np.inf, np.inf]])
+
+class Test_sorted_query_ball_point:
+
+    def setup_method(self):
+        np.random.seed(1234)
+        self.x = np.random.randn(100, 1)
+        self.ckdt = cKDTree(self.x)
+
+    def test_return_sorted_True(self):
+        idxs_list = self.ckdt.query_ball_point(self.x, 1., return_sorted=True)
+        for idxs in idxs_list:
+            assert_array_equal(idxs, sorted(idxs))
+
+    def test_return_sorted_None(self):
+        """Previous behavior was to sort the returned indices if there were
+        multiple points per query but not sort them if there was a single point
+        per query."""
+        idxs_list = self.ckdt.query_ball_point(self.x, 1.)
+        for idxs in idxs_list:
+            assert_array_equal(idxs, sorted(idxs))
+
+        idxs_list_single = [self.ckdt.query_ball_point(xi, 1.) for xi in self.x]
+        idxs_list_False = self.ckdt.query_ball_point(self.x, 1., return_sorted=False)
+        for idxs0, idxs1 in zip(idxs_list_False, idxs_list_single):
+            assert_array_equal(idxs0, idxs1)


### PR DESCRIPTION
Previously, `cKDTree.query_ball_point()` would not sort the returned indices for single point queries, but did sort them for multi-point queries.

For multi-point queries with large numbers of returned indices, sorting slowed down `query_ball_point()` significantly.

The PR adds a new optional kwarg which allows the returned indices to be explicitly sorted or not. The default (`None`) has the same inconsistent behavior as before.

Closes #8838 