### PR TITLE
BUG: optimize: fixed issue 8662 for linprog('simplex')

### DIFF
--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -334,7 +334,7 @@ def _solve_simplex(T, n, basis, maxiter=1000, phase=2, callback=None,
         for pivrow in [row for row in range(basis.size)
                        if basis[row] > T.shape[1] - 2]:
             non_zero_row = [col for col in range(T.shape[1] - 1)
-                            if T[pivrow, col] != 0]
+                            if abs(T[pivrow, col]) > tol]
             if len(non_zero_row) > 0:
                 pivcol = non_zero_row[0]
                 # variable represented by pivcol enters

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -687,6 +687,32 @@ class TestLinprogSimplex(LinprogCommonTests):
         assert_(callback_complete[0])
         assert_allclose(last_xk[0], res.x)
 
+    def test_bug_8662(self):
+        # scipy.linprog returns incorrect optimal result for constraints using
+        # default bounds, but, correct if boundary condition as constraint.
+        # https://github.com/scipy/scipy/issues/8662
+        c = [-10, 10, 6, 3]
+        A= [
+            [8, -8, -4, 6],
+            [-8, 8, 4, -6],
+            [-4, 4, 8, -4],
+            [3, -3, -3, -10]
+        ]
+        b = [9, -9, -9, -4]
+        bounds = [(0, None), (0, None), (0, None), (0, None)]
+
+        res1 = linprog(c, A, b, bounds=bounds)
+        _assert_success(res1, 36.0000000000)
+
+        # Set boundary condition as a constraint
+        A.append([0, 0, -1, 0])
+        b.append(0)
+        bounds[2] = (None, None)
+
+        res2 = linprog(c, A, b, bounds=bounds)
+        _assert_success(res2, 36.0000000000)
+        assert_allclose(res1.x, res2.x)
+
 
 class BaseTestLinprogIP(LinprogCommonTests):
     method = "interior-point"

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -689,7 +689,7 @@ class LinprogCommonTests(object):
         desired_fun = 1.730550597
         _assert_success(res, desired_fun=desired_fun)
         assert_allclose(A.dot(res.x), b)
-        assert_array_less(np.zeros(res.x) - 1e-5, res.x)
+        assert_array_less(np.zeros(res.x.size) - 1e-5, res.x)
 
     def test_bug_8662(self):
         # scipy.linprog returns incorrect optimal result for constraints using

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -692,7 +692,7 @@ class TestLinprogSimplex(LinprogCommonTests):
         # default bounds, but, correct if boundary condition as constraint.
         # https://github.com/scipy/scipy/issues/8662
         c = [-10, 10, 6, 3]
-        A= [
+        A = [
             [8, -8, -4, 6],
             [-8, 8, 4, -6],
             [-4, 4, 8, -4],
@@ -728,12 +728,12 @@ class TestLinprogSimplex(LinprogCommonTests):
             [0, 0, 0, 0, 0, 0, 0, -0.25, 0, 0]
         ])
         b_ub = np.array([0.615, 0, 0.172, -0.869, -0.022])
-        bounds =  np.array([
-            [-0.84, -0.97, 0.34, 0.4 , -0.33, -0.74, 0.47, 0.09, -1.45, -0.73],
-            [0.37, 0.02, 2.86, 0.86, 1.18, 0.5 , 1.76, 0.17, 0.32, -0.15]
+        bounds = np.array([
+            [-0.84, -0.97, 0.34, 0.4, -0.33, -0.74, 0.47, 0.09, -1.45, -0.73],
+            [0.37, 0.02, 2.86, 0.86, 1.18, 0.5, 1.76, 0.17, 0.32, -0.15]
         ]).T
         c = np.array(
-            [-1.64, 0.7, 1.8 , -1.06, -1.16,0.26, 2.13, 1.53, 0.66, 0.28]
+            [-1.64, 0.7, 1.8, -1.06, -1.16,0.26, 2.13, 1.53, 0.66, 0.28]
         )
 
         res = linprog(


### PR DESCRIPTION
A bug in phase 2 of the simplex method caused an additional pivot for
the coefficient very close to zero, leading to an incorrect solution.
Fixed by checking whether the coefficient lies within some tolerance
- defined by tol - rather than directly for equality with 0.