### PR TITLE
DOC: sparse.csgraph simple examples.

### DIFF
--- a/scipy/sparse/csgraph/_reordering.pyx
+++ b/scipy/sparse/csgraph/_reordering.pyx
@@ -45,6 +45,28 @@ def reverse_cuthill_mckee(graph, symmetric_mode=False):
     ----------
     E. Cuthill and J. McKee, "Reducing the Bandwidth of Sparse Symmetric Matrices",
     ACM '69 Proceedings of the 1969 24th national conference, (1969).
+
+    Examples
+    --------
+    >>> from scipy.sparse import csr_matrix
+    >>> from scipy.sparse.csgraph import reverse_cuthill_mckee
+
+    >>> graph = [
+    ... [0, 1 , 2, 0],
+    ... [0, 0, 0, 1],
+    ... [2, 0, 0, 3],
+    ... [0, 0, 0, 0]
+    ... ]
+    >>> graph = csr_matrix(graph)
+    >>> print(graph)
+      (0, 1)	1
+      (0, 2)	2
+      (1, 3)	1
+      (2, 0)	2
+      (2, 3)	3
+
+    >>> reverse_cuthill_mckee(graph)
+    array([3, 2, 1, 0], dtype=int32)
     
     """
     if not (isspmatrix_csc(graph) or isspmatrix_csr(graph)):

--- a/scipy/sparse/csgraph/_reordering.pyx
+++ b/scipy/sparse/csgraph/_reordering.pyx
@@ -115,6 +115,31 @@ def maximum_bipartite_matching(graph, perm_type='row'):
     Analysis of Maximum Transversal Algorithms", ACM Trans. Math. Softw.
     38, no. 2, (2011).
 
+    Examples
+    --------
+    >>> from scipy.sparse import csr_matrix
+    >>> from scipy.sparse.csgraph import maximum_bipartite_matching
+
+    >>> graph = [
+    ... [0, 1 , 2, 0],
+    ... [1, 0, 0, 1],
+    ... [2, 0, 0, 3],
+    ... [0, 1, 3, 0]
+    ... ]
+    >>> graph = csr_matrix(graph)
+    >>> print(graph)
+      (0, 1)	1
+      (0, 2)	2
+      (1, 0)	1
+      (1, 3)	1
+      (2, 0)	2
+      (2, 3)	3
+      (3, 1)	1
+      (3, 2)	3
+
+    >>> maximum_bipartite_matching(graph, perm_type='row')
+    array([1, 0, 3, 2], dtype=int32)
+
     """
     cdef np.npy_intp nrows = graph.shape[0]
     if nrows != graph.shape[1]:

--- a/scipy/sparse/csgraph/_reordering.pyx
+++ b/scipy/sparse/csgraph/_reordering.pyx
@@ -334,6 +334,32 @@ def structural_rank(graph):
             Meth., Vol. 7, 594 (1986).
     
     .. [2] http://www.cise.ufl.edu/research/sparse/matrices/legend.html
+
+    Examples
+    --------
+    >>> from scipy.sparse import csr_matrix
+    >>> from scipy.sparse.csgraph import structural_rank
+
+    >>> graph = [
+    ... [0, 1 , 2, 0],
+    ... [1, 0, 0, 1],
+    ... [2, 0, 0, 3],
+    ... [0, 1, 3, 0]
+    ... ]
+    >>> graph = csr_matrix(graph)
+    >>> print(graph)
+      (0, 1)	1
+      (0, 2)	2
+      (1, 0)	1
+      (1, 3)	1
+      (2, 0)	2
+      (2, 3)	3
+      (3, 1)	1
+      (3, 2)	3
+
+    >>> structural_rank(graph)
+    4
+
     """
     if not isspmatrix:
         raise TypeError('Input must be a sparse matrix')

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -147,7 +147,7 @@ def shortest_path(csgraph, method='auto',
 
     >>> dist_matrix, predecessors = shortest_path(csgraph=graph, directed=False, indices=0, return_predecessors=True)
     >>> dist_matrix
-    array([[ 0.,  1.,  2.,  2.])
+    array([ 0.,  1.,  2.,  2.])
     >>> predecessors
     array([-9999,     0,     0,     1], dtype=int32)
 
@@ -1013,7 +1013,7 @@ def johnson(csgraph, directed=True, indices=None,
 
     >>> dist_matrix, predecessors = johnson(csgraph=graph, directed=False, indices=0, return_predecessors=True)
     >>> dist_matrix
-    array([[ 0.,  1.,  2.,  2.])
+    array([ 0.,  1.,  2.,  2.])
     >>> predecessors
     array([-9999,     0,     0,     1], dtype=int32)
 

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -417,6 +417,12 @@ def dijkstra(csgraph, directed=True, indices=None,
       (1, 3)	1
       (2, 3)	3
 
+    >>> dist_matrix, predecessors = dijkstra(csgraph=graph, directed=False, indices=0, return_predecessors=True)
+    >>> dist_matrix
+    array([ 0.,  1.,  2.,  2.])
+    >>> predecessors
+    array([-9999,     0,     0,     1], dtype=int32)
+
     """
     #------------------------------
     # validate csgraph and convert to csr matrix

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -398,6 +398,25 @@ def dijkstra(csgraph, directed=True, indices=None,
     distances.  Negative distances can lead to infinite cycles that must
     be handled by specialized algorithms such as Bellman-Ford's algorithm
     or Johnson's algorithm.
+
+    Examples
+    --------
+    >>> from scipy.sparse import csr_matrix
+    >>> from scipy.sparse.csgraph import dijkstra
+
+    >>> graph = [
+    ... [0, 1 , 2, 0],
+    ... [0, 0, 0, 1],
+    ... [0, 0, 0, 3],
+    ... [0, 0, 0, 0]
+    ... ]
+    >>> graph = csr_matrix(graph)
+    >>> print(graph)
+      (0, 1)	1
+      (0, 2)	2
+      (1, 3)	1
+      (2, 3)	3
+
     """
     #------------------------------
     # validate csgraph and convert to csr matrix

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -729,6 +729,32 @@ def bellman_ford(csgraph, directed=True, indices=None,
     This routine is specially designed for graphs with negative edge weights.
     If all edge weights are positive, then Dijkstra's algorithm is a better
     choice.
+
+    Examples
+    --------
+    >>> from scipy.sparse import csr_matrix
+    >>> from scipy.sparse.csgraph import bellman_ford
+
+    >>> graph = [
+    ... [0, 1 , 2, 0],
+    ... [0, 0, 0, 1],
+    ... [2, 0, 0, 3],
+    ... [0, 0, 0, 0]
+    ... ]
+    >>> graph = csr_matrix(graph)
+    >>> print(graph)
+      (0, 1)	1
+      (0, 2)	2
+      (1, 3)	1
+      (2, 0)	2
+      (2, 3)	3
+
+    >>> dist_matrix, predecessors = bellman_ford(csgraph=graph, directed=False, indices=0, return_predecessors=True)
+    >>> dist_matrix
+    array([ 0.,  1.,  2.,  2.])
+    >>> predecessors
+    array([-9999,     0,     0,     1], dtype=int32)
+
     """
     #------------------------------
     # validate csgraph and convert to csr matrix

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -965,6 +965,32 @@ def johnson(csgraph, directed=True, indices=None,
     This routine is specially designed for graphs with negative edge weights.
     If all edge weights are positive, then Dijkstra's algorithm is a better
     choice.
+
+    Examples
+    --------
+    >>> from scipy.sparse import csr_matrix
+    >>> from scipy.sparse.csgraph import johnson
+
+    >>> graph = [
+    ... [0, 1 , 2, 0],
+    ... [0, 0, 0, 1],
+    ... [2, 0, 0, 3],
+    ... [0, 0, 0, 0]
+    ... ]
+    >>> graph = csr_matrix(graph)
+    >>> print(graph)
+      (0, 1)	1
+      (0, 2)	2
+      (1, 3)	1
+      (2, 0)	2
+      (2, 3)	3
+
+    >>> dist_matrix, predecessors = johnson(csgraph=graph, directed=False, indices=0, return_predecessors=True)
+    >>> dist_matrix
+    array([[ 0.,  1.,  2.,  2.])
+    >>> predecessors
+    array([-9999,     0,     0,     1], dtype=int32)
+
     """
     #------------------------------
     # if unweighted, there are no negative weights: we just use dijkstra

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -125,6 +125,32 @@ def shortest_path(csgraph, method='auto',
     do not work for graphs with direction-dependent distances when
     directed == False.  i.e., if csgraph[i,j] and csgraph[j,i] are non-equal
     edges, method='D' may yield an incorrect result.
+
+    Examples
+    --------
+    >>> from scipy.sparse import csr_matrix
+    >>> from scipy.sparse.csgraph import shortest_path
+
+    >>> graph = [
+    ... [0, 1 , 2, 0],
+    ... [0, 0, 0, 1],
+    ... [2, 0, 0, 3],
+    ... [0, 0, 0, 0]
+    ... ]
+    >>> graph = csr_matrix(graph)
+    >>> print(graph)
+      (0, 1)	1
+      (0, 2)	2
+      (1, 3)	1
+      (2, 0)	2
+      (2, 3)	3
+
+    >>> dist_matrix, predecessors = shortest_path(csgraph=graph, directed=False, indices=0, return_predecessors=True)
+    >>> dist_matrix
+    array([[ 0.,  1.,  2.,  2.])
+    >>> predecessors
+    array([-9999,     0,     0,     1], dtype=int32)
+
     """
     # validate here to catch errors early but don't store the result;
     # we'll validate again later

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -231,6 +231,39 @@ def floyd_warshall(csgraph, directed=True,
     ------
     NegativeCycleError:
         if there are negative cycles in the graph
+
+    Examples
+    --------
+    >>> from scipy.sparse import csr_matrix
+    >>> from scipy.sparse.csgraph import floyd_warshall
+
+    >>> graph = [
+    ... [0, 1 , 2, 0],
+    ... [0, 0, 0, 1],
+    ... [2, 0, 0, 3],
+    ... [0, 0, 0, 0]
+    ... ]
+    >>> graph = csr_matrix(graph)
+    >>> print(graph)
+      (0, 1)	1
+      (0, 2)	2
+      (1, 3)	1
+      (2, 0)	2
+      (2, 3)	3
+
+
+    >>> dist_matrix, predecessors = floyd_warshall(csgraph=graph, directed=False, return_predecessors=True)
+    >>> dist_matrix
+    array([[ 0.,  1.,  2.,  2.],
+           [ 1.,  0.,  3.,  1.],
+           [ 2.,  3.,  0.,  3.],
+           [ 2.,  1.,  3.,  0.]])
+    >>> predecessors
+    array([[-9999,     0,     0,     1],
+           [    1, -9999,     0,     1],
+           [    2,     0, -9999,     2],
+           [    1,     3,     3, -9999]], dtype=int32)
+
     """
     dist_matrix = validate_graph(csgraph, directed, DTYPE,
                                  csr_output=False,

--- a/scipy/sparse/csgraph/_tools.pyx
+++ b/scipy/sparse/csgraph/_tools.pyx
@@ -324,6 +324,34 @@ def reconstruct_path(csgraph, predecessors, directed=True):
     cstree : csr matrix
         The N x N directed compressed-sparse representation of the tree drawn
         from csgraph which is encoded by the predecessor list.
+
+    Examples
+    --------
+    >>> from scipy.sparse import csr_matrix
+    >>> from scipy.sparse.csgraph import reconstruct_path
+
+    >>> graph = [
+    ... [0, 1 , 2, 0],
+    ... [0, 0, 0, 1],
+    ... [0, 0, 0, 3],
+    ... [0, 0, 0, 0]
+    ... ]
+    >>> graph = csr_matrix(graph)
+    >>> print(graph)
+      (0, 1)	1
+      (0, 2)	2
+      (1, 3)	1
+      (2, 3)	3
+
+    >>> pred = np.array([-9999, 0, 0, 1], dtype=np.int32)
+
+    >>> cstree = reconstruct_path(csgraph=graph, predecessors=pred, directed=False)
+    >>> cstree.todense()
+    matrix([[ 0.,  1.,  2.,  0.],
+            [ 0.,  0.,  0.,  1.],
+            [ 0.,  0.,  0.,  0.],
+
+            [ 0.,  0.,  0.,  0.]])
     """
     from ._validation import validate_graph
     csgraph = validate_graph(csgraph, directed, dense_output=False)

--- a/scipy/sparse/csgraph/_tools.pyx
+++ b/scipy/sparse/csgraph/_tools.pyx
@@ -354,6 +354,35 @@ def csgraph_to_masked(csgraph):
     -------
     graph : MaskedArray
         The masked dense representation of the sparse graph.
+
+    Examples
+    --------
+    >>> from scipy.sparse import csr_matrix
+    >>> from scipy.sparse.csgraph import csgraph_to_masked
+
+    >>> graph = csr_matrix( [
+    ... [0, 1 , 2, 0],
+    ... [0, 0, 0, 1],
+    ... [0, 0, 0, 3],
+    ... [0, 0, 0, 0]
+    ... ])
+    >>> graph
+    <4x4 sparse matrix of type '<class 'numpy.int64'>'
+        with 4 stored elements in Compressed Sparse Row format>
+
+    >>> csgraph_to_masked(graph)
+    masked_array(data =
+     [[-- 1.0 2.0 --]
+     [-- -- -- 1.0]
+     [-- -- -- 3.0]
+     [-- -- -- --]],
+                 mask =
+     [[ True False False  True]
+     [ True  True  True False]
+     [ True  True  True False]
+     [ True  True  True  True]],
+           fill_value = 1e+20)
+
     """
     return np.ma.masked_invalid(csgraph_to_dense(csgraph, np.nan))
 

--- a/scipy/sparse/csgraph/_tools.pyx
+++ b/scipy/sparse/csgraph/_tools.pyx
@@ -175,6 +175,22 @@ def csgraph_from_dense(graph,
     -------
     csgraph : csr_matrix
         Compressed sparse representation of graph,
+
+    Examples
+    --------
+    >>> from scipy.sparse.csgraph import csgraph_from_dense
+
+    >>> graph = [
+    ... [0, 1 , 2, 0],
+    ... [0, 0, 0, 1],
+    ... [0, 0, 0, 3],
+    ... [0, 0, 0, 0]
+    ... ]
+
+    >>> csgraph_from_dense(graph)
+    <4x4 sparse matrix of type '<class 'numpy.float64'>'
+        with 4 stored elements in Compressed Sparse Row format>
+
     """
     return csgraph_from_masked(csgraph_masked_from_dense(graph,
                                                          null_value,

--- a/scipy/sparse/csgraph/_tools.pyx
+++ b/scipy/sparse/csgraph/_tools.pyx
@@ -291,6 +291,28 @@ def csgraph_to_dense(csgraph, null_value=0):
     In the first case, the zero-weight edge gets lost in the dense
     representation.  In the second case, we can choose a different null value
     and see the true form of the graph.
+
+    Examples
+    --------
+    >>> from scipy.sparse import csr_matrix
+    >>> from scipy.sparse.csgraph import csgraph_to_dense
+
+    >>> graph = csr_matrix( [
+    ... [0, 1 , 2, 0],
+    ... [0, 0, 0, 1],
+    ... [0, 0, 0, 3],
+    ... [0, 0, 0, 0]
+    ... ])
+    >>> graph
+    <4x4 sparse matrix of type '<class 'numpy.int64'>'
+        with 4 stored elements in Compressed Sparse Row format>
+
+    >>> csgraph_to_dense(graph)
+    array([[ 0.,  1.,  2.,  0.],
+           [ 0.,  0.,  0.,  1.],
+           [ 0.,  0.,  0.,  3.],
+           [ 0.,  0.,  0.,  0.]])
+
     """
     # Allow only csr, lil and csc matrices: other formats when converted to csr
     # combine duplicated edges: we don't want this to happen in the background.

--- a/scipy/sparse/csgraph/_tools.pyx
+++ b/scipy/sparse/csgraph/_tools.pyx
@@ -87,6 +87,31 @@ def csgraph_masked_from_dense(graph,
     -------
     csgraph : MaskedArray
         masked array representation of graph
+
+    Examples
+    --------
+    >>> from scipy.sparse.csgraph import csgraph_masked_from_dense
+
+    >>> graph = [
+    ... [0, 1 , 2, 0],
+    ... [0, 0, 0, 1],
+    ... [0, 0, 0, 3],
+    ... [0, 0, 0, 0]
+    ... ]
+
+    >>> csgraph_masked_from_dense(graph)
+    masked_array(data =
+     [[-- 1 2 --]
+     [-- -- -- 1]
+     [-- -- -- 3]
+     [-- -- -- --]],
+                 mask =
+     [[ True False False  True]
+     [ True  True  True False]
+     [ True  True  True False]
+     [ True  True  True  True]],
+           fill_value = 0)
+
     """
     graph = np.array(graph, copy=copy)
 
@@ -350,8 +375,8 @@ def reconstruct_path(csgraph, predecessors, directed=True):
     matrix([[ 0.,  1.,  2.,  0.],
             [ 0.,  0.,  0.,  1.],
             [ 0.,  0.,  0.,  0.],
-
             [ 0.,  0.,  0.,  0.]])
+
     """
     from ._validation import validate_graph
     csgraph = validate_graph(csgraph, directed, dense_output=False)

--- a/scipy/sparse/csgraph/_tools.pyx
+++ b/scipy/sparse/csgraph/_tools.pyx
@@ -38,7 +38,6 @@ def csgraph_from_masked(graph):
     >>> import numpy as np
     >>> from scipy.sparse.csgraph import csgraph_from_masked
 
-
     >>> graph_masked = np.ma.masked_array(data =[
     ... [0, 1 , 2, 0],
     ... [0, 0, 0, 1],
@@ -123,17 +122,16 @@ def csgraph_masked_from_dense(graph,
     ... ]
 
     >>> csgraph_masked_from_dense(graph)
-    masked_array(data =
-     [[-- 1 2 --]
-     [-- -- -- 1]
-     [-- -- -- 3]
-     [-- -- -- --]],
-                 mask =
-     [[ True False False  True]
-     [ True  True  True False]
-     [ True  True  True False]
-     [ True  True  True  True]],
-           fill_value = 0)
+    masked_array(
+      data=[[--, 1, 2, --],
+            [--, --, --, 1],
+            [--, --, --, 3],
+            [--, --, --, --]],
+      mask=[[ True, False, False,  True],
+            [ True,  True,  True, False],
+            [ True,  True,  True, False],
+            [ True,  True,  True,  True]],
+      fill_value=0)
 
     """
     graph = np.array(graph, copy=copy)
@@ -371,17 +369,16 @@ def csgraph_to_masked(csgraph):
         with 4 stored elements in Compressed Sparse Row format>
 
     >>> csgraph_to_masked(graph)
-    masked_array(data =
-     [[-- 1.0 2.0 --]
-     [-- -- -- 1.0]
-     [-- -- -- 3.0]
-     [-- -- -- --]],
-                 mask =
-     [[ True False False  True]
-     [ True  True  True False]
-     [ True  True  True False]
-     [ True  True  True  True]],
-           fill_value = 1e+20)
+    masked_array(
+      data=[[--, 1.0, 2.0, --],
+            [--, --, --, 1.0],
+            [--, --, --, 3.0],
+            [--, --, --, --]],
+      mask=[[ True, False, False,  True],
+            [ True,  True,  True, False],
+            [ True,  True,  True, False],
+            [ True,  True,  True,  True]],
+      fill_value=1e+20)
 
     """
     return np.ma.masked_invalid(csgraph_to_dense(csgraph, np.nan))

--- a/scipy/sparse/csgraph/_tools.pyx
+++ b/scipy/sparse/csgraph/_tools.pyx
@@ -32,6 +32,29 @@ def csgraph_from_masked(graph):
     -------
     csgraph : csr_matrix
         Compressed sparse representation of graph,
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.sparse.csgraph import csgraph_from_masked
+
+
+    >>> graph_masked = np.ma.masked_array(data =[
+    ... [0, 1 , 2, 0],
+    ... [0, 0, 0, 1],
+    ... [0, 0, 0, 3],
+    ... [0, 0, 0, 0]
+    ...  ],
+    ... mask=[[ True, False, False , True],
+    ... [ True,  True , True, False],
+    ... [ True , True,  True ,False],
+    ... [ True ,True , True , True]],
+    ... fill_value = 0)
+
+    >>> csgraph_from_masked(graph_masked)
+    <4x4 sparse matrix of type '<class 'numpy.float64'>'
+        with 4 stored elements in Compressed Sparse Row format>
+
     """
     # check that graph is a square matrix
     graph = np.ma.asarray(graph)

--- a/scipy/sparse/csgraph/_tools.pyx
+++ b/scipy/sparse/csgraph/_tools.pyx
@@ -398,6 +398,37 @@ def construct_dist_matrix(graph,
     predecessors[i, j] gives the index of the previous node in the path from
     point i to point j.  If no path exists between point i and j, then
     predecessors[i, j] = -9999
+
+    Examples
+    --------
+    >>> from scipy.sparse import csr_matrix
+    >>> from scipy.sparse.csgraph import construct_dist_matrix
+
+    >>> graph = [
+    ... [0, 1 , 2, 0],
+    ... [0, 0, 0, 1],
+    ... [0, 0, 0, 3],
+    ... [0, 0, 0, 0]
+    ... ]
+    >>> graph = csr_matrix(graph)
+    >>> print(graph)
+      (0, 1)	1
+      (0, 2)	2
+      (1, 3)	1
+      (2, 3)	3
+
+    >>> pred = np.array([[-9999, 0, 0, 2],
+    ... [1, -9999, 0, 1],
+    ... [2, 0, -9999, 2],
+    ... [1, 3, 3, -9999]], dtype=np.int32)
+    )
+
+    >>> construct_dist_matrix(graph=graph, predecessors=pred, directed=False)
+    array([[ 0.,  1.,  2.,  5.],
+           [ 1.,  0.,  3.,  1.],
+           [ 2.,  3.,  0.,  3.],
+           [ 2.,  1.,  3.,  0.]])
+
     """
     from ._validation import validate_graph
     graph = validate_graph(graph, directed, dtype=DTYPE,

--- a/scipy/sparse/csgraph/_tools.pyx
+++ b/scipy/sparse/csgraph/_tools.pyx
@@ -564,7 +564,6 @@ def construct_dist_matrix(graph,
     ... [1, -9999, 0, 1],
     ... [2, 0, -9999, 2],
     ... [1, 3, 3, -9999]], dtype=np.int32)
-    )
 
     >>> construct_dist_matrix(graph=graph, predecessors=pred, directed=False)
     array([[ 0.,  1.,  2.,  5.],

--- a/scipy/sparse/csgraph/_traversal.pyx
+++ b/scipy/sparse/csgraph/_traversal.pyx
@@ -304,6 +304,29 @@ cpdef breadth_first_order(csgraph, i_start,
         tree.  If node i is in the tree, then its parent is given by
         predecessors[i]. If node i is not in the tree (and for the parent
         node) then predecessors[i] = -9999.
+
+    Examples
+    --------
+    >>> from scipy.sparse import csr_matrix
+    >>> from scipy.sparse.csgraph import breadth_first_order
+
+    >>> graph = [
+    ... [0, 1 , 2, 0],
+    ... [0, 0, 0, 1],
+    ... [2, 0, 0, 3],
+    ... [0, 0, 0, 0]
+    ... ]
+    >>> graph = csr_matrix(graph)
+    >>> print(graph)
+      (0, 1)    1
+      (0, 2)    2
+      (1, 3)    1
+      (2, 0)    2
+      (2, 3)    3
+
+    >>> breadth_first_order(graph,0)
+    (array([0, 1, 2, 3], dtype=int32), array([-9999,     0,     0,     1], dtype=int32))
+
     """
     csgraph = validate_graph(csgraph, directed, dense_output=False)
     cdef int N = csgraph.shape[0]

--- a/scipy/sparse/csgraph/_traversal.pyx
+++ b/scipy/sparse/csgraph/_traversal.pyx
@@ -62,6 +62,32 @@ def connected_components(csgraph, directed=True, connection='weak',
     .. [1] D. J. Pearce, "An Improved Algorithm for Finding the Strongly
            Connected Components of a Directed Graph", Technical Report, 2005
 
+    Examples
+    --------
+    >>> from scipy.sparse import csr_matrix
+    >>> from scipy.sparse.csgraph import connected_components
+
+    >>> graph = [
+    ... [ 0, 1 , 1, 0 , 0 ],
+    ... [ 0, 0 , 1 , 0 ,0 ],
+    ... [ 0, 0, 0, 0, 0],
+    ... [0, 0 , 0, 0, 1],
+    ... [0, 0, 0, 0, 0]
+    ... ]
+    >>> graph = csr_matrix(graph)
+    >>> print(graph)
+      (0, 1)	1
+      (0, 2)	1
+      (1, 2)	1
+      (3, 4)	1
+
+
+    >>> n_components, labels = connected_components(csgraph=graph, directed=False, return_labels=True)
+    >>> n_components
+    2
+    >>> labels
+    array([0, 0, 0, 1, 1], dtype=int32)
+
     """
     if connection.lower() not in ['weak', 'strong']:
         raise ValueError("connection must be 'weak' or 'strong'")

--- a/scipy/sparse/csgraph/_traversal.pyx
+++ b/scipy/sparse/csgraph/_traversal.pyx
@@ -81,7 +81,6 @@ def connected_components(csgraph, directed=True, connection='weak',
       (1, 2)	1
       (3, 4)	1
 
-
     >>> n_components, labels = connected_components(csgraph=graph, directed=False, return_labels=True)
     >>> n_components
     2

--- a/scipy/sparse/csgraph/_traversal.pyx
+++ b/scipy/sparse/csgraph/_traversal.pyx
@@ -487,6 +487,29 @@ cpdef depth_first_order(csgraph, i_start,
         tree.  If node i is in the tree, then its parent is given by
         predecessors[i]. If node i is not in the tree (and for the parent
         node) then predecessors[i] = -9999.
+
+    Examples
+    --------
+    >>> from scipy.sparse import csr_matrix
+    >>> from scipy.sparse.csgraph import depth_first_order
+
+    >>> graph = [
+    ... [0, 1 , 2, 0],
+    ... [0, 0, 0, 1],
+    ... [2, 0, 0, 3],
+    ... [0, 0, 0, 0]
+    ... ]
+    >>> graph = csr_matrix(graph)
+    >>> print(graph)
+      (0, 1)	1
+      (0, 2)	2
+      (1, 3)	1
+      (2, 0)	2
+      (2, 3)	3
+
+    >>> depth_first_order(graph,0)
+    (array([0, 1, 3, 2], dtype=int32), array([-9999,     0,     0,     1], dtype=int32))
+
     """
     csgraph = validate_graph(csgraph, directed, dense_output=False)
     cdef int N = csgraph.shape[0]


### PR DESCRIPTION
I have created simple  examples for the following sparse.csgraph functions:

sparse.csgraph (18)
    connected_components
    shortest_path
    floyd_warshall
    dijkstra
    bellman_ford
    johnson
    breadth_first_order
    depth_first_order
    reverse_cuthill_mckee
    maximum_bipartite_matching
    structural_rank
    construct_dist_matrix
    reconstruct_path
    csgraph_masked_from_dense
    csgraph_from_dense
    csgraph_from_masked
    csgraph_to_dense
    csgraph_to_masked
