### PR TITLE
MAINT: special: deprecate `hyp2f0`, `hyp1f2`, and `hyp3f0`

### DIFF
--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -650,6 +650,12 @@ from .lambertw import lambertw
 from ._spherical_bessel import (spherical_jn, spherical_yn, spherical_in,
                                 spherical_kn)
 
+from numpy import deprecate
+hyp2f0 = deprecate(hyp2f0, message="hyp2f0 is deprecated in SciPy 1.2")
+hyp1f2 = deprecate(hyp1f2, message="hyp1f2 is deprecated in SciPy 1.2")
+hyp3f0 = deprecate(hyp3f0, message="hyp3f0 is deprecated in SciPy 1.2")
+del deprecate
+
 __all__ = [s for s in dir() if not s.startswith('_')]
 
 from numpy.dual import register_func

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -474,17 +474,8 @@ class TestCephes(object):
         assert_approx_equal(cephes.hyp1f1(3,4,-6), 0.026056422099537251095)
         cephes.hyp1f1(1,1,1)
 
-    def test_hyp1f2(self):
-        cephes.hyp1f2(1,1,1,1)
-
-    def test_hyp2f0(self):
-        cephes.hyp2f0(1,1,1,1)
-
     def test_hyp2f1(self):
         assert_equal(cephes.hyp2f1(1,1,1,0),1.0)
-
-    def test_hyp3f0(self):
-        assert_equal(cephes.hyp3f0(1,1,1,0),(1.0,0.0))
 
     def test_hyperu(self):
         assert_equal(cephes.hyperu(0,1,1),1.0)
@@ -2172,12 +2163,6 @@ class TestHyper(object):
         hyp = special.hyp1f1(0.5, 1.5, -1000)
         assert_almost_equal(hyp, 0.028024956081989643, 12)
 
-    def test_hyp1f2(self):
-        pass
-
-    def test_hyp2f0(self):
-        pass
-
     def test_hyp2f1(self):
         # a collection of special cases taken from AMS 55
         values = [[0.5, 1, 1.5, 0.2**2, 0.5/0.2*log((1+0.2)/(1-0.2))],
@@ -2208,9 +2193,6 @@ class TestHyper(object):
         for i, (a, b, c, x, v) in enumerate(values):
             cv = special.hyp2f1(a, b, c, x)
             assert_almost_equal(cv, v, 8, err_msg='test #%d' % i)
-
-    def test_hyp3f0(self):
-        pass
 
     def test_hyperu(self):
         val1 = special.hyperu(1,0.1,100)
@@ -3317,7 +3299,6 @@ def test_legacy():
         assert_equal(special.bdtr(1, 2, 0.3), special.bdtr(1.8, 2.8, 0.3))
         assert_equal(special.bdtri(1, 2, 0.3), special.bdtri(1.8, 2.8, 0.3))
         assert_equal(special.expn(1, 0.3), special.expn(1.8, 0.3))
-        assert_equal(special.hyp2f0(1, 2, 0.3, 1), special.hyp2f0(1, 2, 0.3, 1.8))
         assert_equal(special.nbdtrc(1, 2, 0.3), special.nbdtrc(1.8, 2.8, 0.3))
         assert_equal(special.nbdtr(1, 2, 0.3), special.nbdtr(1.8, 2.8, 0.3))
         assert_equal(special.nbdtri(1, 2, 0.3), special.nbdtri(1.8, 2.8, 0.3))

--- a/scipy/special/tests/test_cython_special.py
+++ b/scipy/special/tests/test_cython_special.py
@@ -142,10 +142,7 @@ PARAMS = [
     (special.huber, cython_special.huber, ('dd',), None),
     (special.hyp0f1, cython_special.hyp0f1, ('dd', 'dD'), None),
     (special.hyp1f1, cython_special.hyp1f1, ('ddd', 'ddD'), None),
-    (special.hyp1f2, cython_special._hyp1f2_pywrap, ('dddd',), None),
-    (special.hyp2f0, cython_special._hyp2f0_pywrap, ('dddl', 'dddd'), None),
     (special.hyp2f1, cython_special.hyp2f1, ('dddd', 'dddD'), None),
-    (special.hyp3f0, cython_special._hyp3f0_pywrap, ('dddd',), None),
     (special.hyperu, cython_special.hyperu, ('ddd',), None),
     (special.i0, cython_special.i0, ('d',), None),
     (special.i0e, cython_special.i0e, ('d',), None),
@@ -282,10 +279,10 @@ def _generate_test_points(typecodes):
 
 def test_cython_api_completeness():
     # Check that everything is tested
-    skip = []
+    skip = {'hyp2f0', 'hyp1f2', 'hyp3f0'}
     for name in dir(cython_special):
         func = getattr(cython_special, name)
-        if callable(func) and not (name.startswith('_bench') or name in skip):
+        if callable(func) and not (name.startswith('_') or name in skip):
             for _, cyfun, _, _ in PARAMS:
                 if cyfun is func:
                     break

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -1381,36 +1381,6 @@ class TestSystematic(object):
                             [Arg(-1e3, 1e3), Arg(-1e3, 1e3), ComplexArg()],
                             n=2000)
 
-    @pytest.mark.xfail(run=False)
-    def test_hyp1f2(self):
-        def hyp1f2(a, b, c, x):
-            v, err = sc.hyp1f2(a, b, c, x)
-            if abs(err) > max(1, abs(v)) * 1e-7:
-                return np.nan
-            return v
-        assert_mpmath_equal(hyp1f2,
-                            exception_to_nan(lambda a, b, c, x: mpmath.hyp1f2(a, b, c, x, **HYPERKW)),
-                            [Arg(), Arg(), Arg(), Arg()],
-                            n=20000)
-
-    @pytest.mark.xfail(run=False)
-    def test_hyp2f0(self):
-        def hyp2f0(a, b, x):
-            v, err = sc.hyp2f0(a, b, x, 1)
-            if abs(err) > max(1, abs(v)) * 1e-7:
-                return np.nan
-            return v
-        assert_mpmath_equal(hyp2f0,
-                            lambda a, b, x: time_limited(0.1)(exception_to_nan(trace_args(mpmath.hyp2f0)))(
-                                a, b, x, **HYPERKW),
-                            [Arg(), Arg(), Arg()])
-
-    @pytest.mark.xfail(run=False, reason="spurious inf (or inf with wrong sign) for some argument values")
-    def test_hyp2f1(self):
-        assert_mpmath_equal(sc.hyp2f1,
-                            exception_to_nan(lambda a, b, c, x: mpmath.hyp2f1(a, b, c, x, **HYPERKW)),
-                            [Arg(), Arg(), Arg(), Arg()])
-
     @nonfunctional_tooslow
     def test_hyp2f1_complex(self):
         # Scipy's hyp2f1 seems to have performance and accuracy problems

--- a/scipy/special/tests/test_nan_inputs.py
+++ b/scipy/special/tests/test_nan_inputs.py
@@ -13,9 +13,7 @@ from scipy._lib._numpy_compat import suppress_warnings
 
 KNOWNFAILURES = {}
 
-POSTPROCESSING = {
-    sc.hyp2f0: lambda x, y: x  # Second argument is an error estimate
-}
+POSTPROCESSING = {}
 
 
 def _get_ufuncs():


### PR DESCRIPTION
Closes gh-8443. The issue has been open for a while now and nobody objected on the mailing list, so it's time.

This takes the somewhat unusual step of deprecating the functions in `__init__.py`; the issue being that the usual process (change the entry in `functions.json` to an underscored version and then add a wrapper in `basic.py`) would make the functions instantly vanish from `cython_special`, which is no good.