### PR TITLE
MAINT: special: remove `errprint`

### DIFF
--- a/scipy/special/_ufuncs_extra_code.pxi
+++ b/scipy/special/_ufuncs_extra_code.pxi
@@ -65,7 +65,7 @@ def geterr():
     singular: ignore
     slow: ignore
     underflow: ignore
-    
+
     """
     err = {}
     for key, code in _sf_error_code_map.items():
@@ -212,58 +212,9 @@ class errstate(object):
     """
     def __init__(self, **kwargs):
         self.kwargs = kwargs
-    
+
     def __enter__(self):
         self.oldstate = seterr(**self.kwargs)
 
     def __exit__(self, exc_type, exc_value, traceback):
         seterr(**self.oldstate)
-
-
-@np.deprecate(message=("`errprint` is deprecated in SciPy 0.19."
-                       " Use `errstate` instead."))
-def errprint(inflag=None):
-    """
-    errprint(inflag=None)
-
-    Set or return the error printing flag for special functions.
-
-    Parameters
-    ----------
-    inflag : bool, optional
-        Whether warnings concerning evaluation of special functions in
-        ``scipy.special`` are shown. If omitted, no change is made to
-        the current setting.
-
-    Returns
-    -------
-    old_flag : bool
-        Previous value of the error flag
-
-    Examples
-    --------
-    Turn on error printing.
-
-    >>> import warnings
-    >>> import scipy.special as sc
-    >>> sc.bdtr(-1, 10, 0.3)
-    nan
-    >>> sc.errprint(True)
-    False
-    >>> with warnings.catch_warnings(record=True) as w:
-    ...     sc.bdtr(-1, 10, 0.3)
-    ...
-    nan
-    >>> len(w)
-    1
-    >>> w[0].message
-    SpecialFunctionWarning('scipy.special/bdtr: domain error',)
-
-    """
-    allwarn = all([val == 'warn' for val in geterr().values()])
-    if inflag is not None:
-        if bool(inflag):
-            seterr(all='warn')
-        else:
-            seterr(all='ignore')
-    return allwarn

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1675,16 +1675,6 @@ class TestErf(object):
         i = special.erfinv(0)
         assert_equal(i,0)
 
-    def test_errprint(self):
-        with suppress_warnings() as sup:
-            sup.filter(DeprecationWarning, "`errprint` is deprecated!")
-            a = special.errprint()
-            b = 1-a  # a is the state 1-a inverts state
-            c = special.errprint(b)  # returns last state 'a'
-            d = special.errprint(a)  # returns to original state
-        assert_equal(a,c)
-        assert_equal(d,b)  # makes sure state was returned
-
     def test_erf_nan_inf(self):
         vals = [np.nan, -np.inf, np.inf]
         expected = [np.nan, -1, 1]

--- a/scipy/special/tests/test_sf_error.py
+++ b/scipy/special/tests/test_sf_error.py
@@ -113,18 +113,3 @@ def test_errstate_all_but_one():
         with assert_raises(sc.SpecialFunctionError):
             sc.spence(-1.0)
     assert_equal(olderr, sc.geterr())
-
-
-def test_errprint():
-    with suppress_warnings() as sup:
-        sup.filter(DeprecationWarning, "`errprint` is deprecated!")
-        flag = sc.errprint(True)
-
-    try:
-        assert_(isinstance(flag, bool))
-        with pytest.warns(sc.SpecialFunctionWarning):
-            sc.loggamma(0)
-    finally:
-        with suppress_warnings() as sup:
-            sup.filter(DeprecationWarning, "`errprint` is deprecated!")
-            sc.errprint(flag)


### PR DESCRIPTION
It was deprecated in SciPy 0.19, so it's time to remove it.