### PR TITLE
Fix (some) non-tuple index warnings

### DIFF
--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -2070,7 +2070,7 @@ class NdPPoly(object):
         else:
             sl = [slice(None)]*ndim
             sl[axis] = slice(None, -nu, None)
-            c2 = self.c[sl]
+            c2 = self.c[tuple(sl)]
 
         if c2.shape[axis] == 0:
             # derivative of order 0 is zero
@@ -2082,7 +2082,7 @@ class NdPPoly(object):
         factor = spec.poch(np.arange(c2.shape[axis], 0, -1), nu)
         sl = [None]*c2.ndim
         sl[axis] = slice(None)
-        c2 *= factor[sl]
+        c2 *= factor[tuple(sl)]
 
         self.c = c2
 
@@ -2511,7 +2511,7 @@ class RegularGridInterpolator(object):
         idx_res = []
         for i, yi in zip(indices, norm_distances):
             idx_res.append(np.where(yi <= .5, i, i + 1))
-        return self.values[idx_res]
+        return self.values[tuple(idx_res)]
 
     def _find_indices(self, xi):
         # find relevant edges between which xi are situated

--- a/scipy/signal/_arraytools.py
+++ b/scipy/signal/_arraytools.py
@@ -42,7 +42,7 @@ def axis_slice(a, start=None, stop=None, step=None, axis=-1):
     """
     a_slice = [slice(None)] * a.ndim
     a_slice[axis] = slice(start, stop, step)
-    b = a[a_slice]
+    b = a[tuple(a_slice)]
     return b
 
 

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -487,7 +487,7 @@ def _reverse_and_conj(x):
     """
     Reverse array `x` in all dimensions and perform the complex conjugate
     """
-    reverse = [slice(None, None, -1)] * x.ndim
+    reverse = (slice(None, None, -1),) * x.ndim
     return x[reverse].conj()
 
 
@@ -1341,7 +1341,7 @@ def lfilter(b, a, x, axis=-1, zi=None):
             out_full[ind] += zi
 
         ind[axis] = slice(out_full.shape[axis] - len(b) + 1)
-        out = out_full[ind]
+        out = out_full[tuple(ind)]
 
         if zi is None:
             return out
@@ -1590,7 +1590,7 @@ def hilbert(x, N=None, axis=-1):
     if x.ndim > 1:
         ind = [newaxis] * x.ndim
         ind[axis] = slice(None)
-        h = h[ind]
+        h = h[tuple(ind)]
     x = fftpack.ifft(Xf * h, axis=axis)
     return x
 
@@ -2380,7 +2380,7 @@ def resample_poly(x, up, down, axis=0, window=('kaiser', 5.0)):
     y = upfirdn(h, x, up, down, axis=axis)
     keep = [slice(None), ]*x.ndim
     keep[axis] = slice(n_pre_remove, n_pre_remove_end)
-    return y[keep]
+    return y[tuple(keep)]
 
 
 def vectorstrength(events, period):
@@ -3460,4 +3460,4 @@ def decimate(x, q, n=None, ftype='iir', axis=-1, zero_phase=True):
             y = lfilter(b, a, x, axis=axis)
         sl[axis] = slice(None, None, q)
 
-    return y[sl]
+    return y[tuple(sl)]

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -275,7 +275,7 @@ def periodogram(x, fs=1.0, window='boxcar', nfft=None, detrend='constant',
     elif nfft < x.shape[axis]:
         s = [np.s_[:]]*len(x.shape)
         s[axis] = np.s_[:nfft]
-        x = x[s]
+        x = x[tuple(s)]
         nperseg = nfft
         nfft = None
 

--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -603,7 +603,7 @@ def binned_statistic_dd(sample, values, statistic='mean',
     result = result.reshape(np.append(Vdim, nbin))
 
     # Remove outliers (indices 0 and -1 for each bin-dimension).
-    core = [slice(None)] + Ndim * [slice(1, -1)]
+    core = tuple([slice(None)] + Ndim * [slice(1, -1)])
     result = result[core]
 
     # Unravel binnumbers into an ndarray, each row the bins for each dimension

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -2707,7 +2707,7 @@ def trimboth(a, proportiontocut, axis=0):
 
     sl = [slice(None)] * atmp.ndim
     sl[axis] = slice(lowercut, uppercut)
-    return atmp[sl]
+    return atmp[tuple(sl)]
 
 
 def trim1(a, proportiontocut, tail='right', axis=0):
@@ -2830,7 +2830,7 @@ def trim_mean(a, proportiontocut, axis=0):
 
     sl = [slice(None)] * atmp.ndim
     sl[axis] = slice(lowercut, uppercut)
-    return np.mean(atmp[sl], axis=axis)
+    return np.mean(atmp[tuple(sl)], axis=axis)
 
 
 F_onewayResult = namedtuple('F_onewayResult', ('statistic', 'pvalue'))


### PR DESCRIPTION
As a companion to gh-8879, fix the non-tuple index warnings in `signal`, `interpolate` and `stats`.