### PR TITLE
ENH: implement sparse matrix BSR to CSR conversion directly.

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -192,6 +192,7 @@ Michael Tartre (Two Sigma Investments) for contributions to weighted distance fu
 Shinya Suzuki for scipy.stats.brunnermunzel
 Graham Clenaghan for bug fixes and optimizations in scipy.stats.
 Konrad Griessinger for the small sample Kendall test
+Tony Xiang for improvements in scipy.sparse
 
 Institutions
 ------------

--- a/benchmarks/benchmarks/sparse.py
+++ b/benchmarks/benchmarks/sparse.py
@@ -188,8 +188,8 @@ class Construction(Benchmark):
 
 class Conversion(Benchmark):
     params = [
-        ['csr', 'csc', 'coo', 'dia', 'lil', 'dok'],
-        ['csr', 'csc', 'coo', 'dia', 'lil', 'dok'],
+        ['csr', 'csc', 'coo', 'dia', 'lil', 'dok', 'bsr'],
+        ['csr', 'csc', 'coo', 'dia', 'lil', 'dok', 'bsr'],
     ]
     param_names = ['from_format', 'to_format']
 

--- a/scipy/sparse/bsr.py
+++ b/scipy/sparse/bsr.py
@@ -465,7 +465,7 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
     tocsr.__doc__ = spmatrix.tocsr.__doc__
 
     def tocsc(self, copy=False):
-        return self.tocoo(copy=False).tocsc(copy=copy)
+        return self.tocsr(copy=False).tocsc(copy=copy)
 
     tocsc.__doc__ = spmatrix.tocsc.__doc__
 

--- a/scipy/sparse/bsr.py
+++ b/scipy/sparse/bsr.py
@@ -443,17 +443,18 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
     def tocsr(self, copy=False):
         M, N = self.shape
         R, C = self.blocksize
+        nnz = self.nnz
         idx_dtype = get_index_dtype((self.indptr, self.indices),
-                                    maxval=max(self.nnz, N))
+                                    maxval=max(nnz, N))
         indptr = np.empty(M + 1, dtype=idx_dtype)
-        indices = np.empty(self.nnz, dtype=idx_dtype)
-        data = np.empty(self.nnz, dtype=upcast(self.dtype))
+        indices = np.empty(nnz, dtype=idx_dtype)
+        data = np.empty(nnz, dtype=upcast(self.dtype))
 
         bsr_tocsr(M // R,  # n_brow
                   N // C,  # n_bcol
                   R, C,
-                  self.indptr.astype(idx_dtype),
-                  self.indices.astype(idx_dtype),
+                  self.indptr.astype(idx_dtype, copy=False),
+                  self.indices.astype(idx_dtype, copy=False),
                   self.data,
                   indptr,
                   indices,

--- a/scipy/sparse/bsr.py
+++ b/scipy/sparse/bsr.py
@@ -17,7 +17,8 @@ from .sputils import (isshape, getdtype, to_native, upcast, get_index_dtype,
                       check_shape)
 from . import _sparsetools
 from ._sparsetools import (bsr_matvec, bsr_matvecs, csr_matmat_pass1,
-                           bsr_matmat_pass2, bsr_transpose, bsr_sort_indices)
+                           bsr_matmat_pass2, bsr_transpose, bsr_sort_indices,
+                           bsr_tocsr)
 
 
 class bsr_matrix(_cs_matrix, _minmax_mixin):
@@ -440,8 +441,25 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
             return self
 
     def tocsr(self, copy=False):
-        return self.tocoo(copy=False).tocsr(copy=copy)
-        # TODO make this more efficient
+        M, N = self.shape
+        R, C = self.blocksize
+        idx_dtype = get_index_dtype((self.indptr, self.indices),
+                                    maxval=max(self.nnz, N))
+        indptr = np.empty(M + 1, dtype=idx_dtype)
+        indices = np.empty(self.nnz, dtype=idx_dtype)
+        data = np.empty(self.nnz, dtype=upcast(self.dtype))
+
+        bsr_tocsr(M // R,  # n_brow
+                  N // C,  # n_bcol
+                  R, C,
+                  self.indptr.astype(idx_dtype),
+                  self.indices.astype(idx_dtype),
+                  self.data,
+                  indptr,
+                  indices,
+                  data)
+        from .csr import csr_matrix
+        return csr_matrix((data, indices, indptr), shape=self.shape)
 
     tocsr.__doc__ = spmatrix.tocsr.__doc__
 

--- a/scipy/sparse/generate_sparsetools.py
+++ b/scipy/sparse/generate_sparsetools.py
@@ -31,6 +31,7 @@ from distutils.dep_util import newer
 # bsr.h
 BSR_ROUTINES = """
 bsr_diagonal        v iiiiiIIT*T
+bsr_tocsr           v iiiiIIT*I*I*T
 bsr_scale_rows      v iiiiII*TT
 bsr_scale_columns   v iiiiII*TT
 bsr_sort_indices    v iiii*I*I*T

--- a/scipy/sparse/linalg/dsolve/linsolve.py
+++ b/scipy/sparse/linalg/dsolve/linsolve.py
@@ -139,8 +139,7 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
     b_is_vector = ((b.ndim == 1) or (b.ndim == 2 and b.shape[1] == 1))
     
     # sum duplicates for non-canonical format
-    if not A.has_canonical_format:
-        A.sum_duplicates()
+    A.sum_duplicates()
     A = A.asfptype()  # upcast to a floating point format
     result_dtype = np.promote_types(A.dtype, b.dtype)
     if A.dtype != result_dtype:
@@ -297,8 +296,7 @@ def splu(A, permc_spec=None, diag_pivot_thresh=None,
         warn('splu requires CSC matrix format', SparseEfficiencyWarning)
 
     # sum duplicates for non-canonical format
-    if not A.has_canonical_format:
-        A.sum_duplicates()
+    A.sum_duplicates()
     A = A.asfptype()  # upcast to a floating point format
 
     M, N = A.shape
@@ -374,8 +372,7 @@ def spilu(A, drop_tol=None, fill_factor=None, drop_rule=None, permc_spec=None,
         warn('splu requires CSC matrix format', SparseEfficiencyWarning)
 
     # sum duplicates for non-canonical format
-    if not A.has_canonical_format:
-        A.sum_duplicates()
+    A.sum_duplicates()
     A = A.asfptype()  # upcast to a floating point format
 
     M, N = A.shape
@@ -508,10 +505,8 @@ def spsolve_triangular(A, b, lower=True, overwrite_A=False, overwrite_b=False):
         raise ValueError(
             'A must be a square matrix but its shape is {}.'.format(A.shape))
 
-    # A.eliminate_zeros()
     # sum duplicates for non-canonical format
-    if not A.has_canonical_format:
-        A.sum_duplicates()
+    A.sum_duplicates()
 
     b = np.asanyarray(b)
 

--- a/scipy/sparse/linalg/dsolve/linsolve.py
+++ b/scipy/sparse/linalg/dsolve/linsolve.py
@@ -137,8 +137,10 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
     if not b_is_sparse:
         b = asarray(b)
     b_is_vector = ((b.ndim == 1) or (b.ndim == 2 and b.shape[1] == 1))
-
-    A.sort_indices()
+    
+    # sum duplicates for non-canonical format
+    if not A.has_canonical_format:
+        A.sum_duplicates()
     A = A.asfptype()  # upcast to a floating point format
     result_dtype = np.promote_types(A.dtype, b.dtype)
     if A.dtype != result_dtype:
@@ -294,7 +296,9 @@ def splu(A, permc_spec=None, diag_pivot_thresh=None,
         A = csc_matrix(A)
         warn('splu requires CSC matrix format', SparseEfficiencyWarning)
 
-    A.sort_indices()
+    # sum duplicates for non-canonical format
+    if not A.has_canonical_format:
+        A.sum_duplicates()
     A = A.asfptype()  # upcast to a floating point format
 
     M, N = A.shape
@@ -369,7 +373,9 @@ def spilu(A, drop_tol=None, fill_factor=None, drop_rule=None, permc_spec=None,
         A = csc_matrix(A)
         warn('splu requires CSC matrix format', SparseEfficiencyWarning)
 
-    A.sort_indices()
+    # sum duplicates for non-canonical format
+    if not A.has_canonical_format:
+        A.sum_duplicates()
     A = A.asfptype()  # upcast to a floating point format
 
     M, N = A.shape
@@ -502,8 +508,10 @@ def spsolve_triangular(A, b, lower=True, overwrite_A=False, overwrite_b=False):
         raise ValueError(
             'A must be a square matrix but its shape is {}.'.format(A.shape))
 
-    A.eliminate_zeros()
-    A.sort_indices()
+    # A.eliminate_zeros()
+    # sum duplicates for non-canonical format
+    if not A.has_canonical_format:
+        A.sum_duplicates()
 
     b = np.asanyarray(b)
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -4186,6 +4186,28 @@ class TestBSR(sparse_test_class(getset=False,
         indices = np.arange(n, dtype=np.int32)
         bsr_matrix((data, indices, indptr), blocksize=(n, 1), copy=False)
 
+    def test_bsr_tocsr(self):
+        # check native conversion from BSR to CSR
+        indptr = array([0,2,2,4])
+        indices = array([0,2,2,3])
+        data = zeros((4,2,3))
+
+        data[0] = array([[0, 1, 2],
+                         [3, 0, 5]])
+        data[1] = array([[0, 2, 4],
+                         [6, 0, 10]])
+        data[2] = array([[0, 4, 8],
+                         [12, 0, 20]])
+        data[3] = array([[0, 5, 10],
+                         [15, 0, 25]])
+
+        A = kron([[1,0,2,0],[0,0,0,0],[0,0,4,5]], [[0,1,2],[3,0,5]])
+        Absr = bsr_matrix((data,indices,indptr),shape=(6,12))
+        Acsr = Absr.tocsr()
+        Acsr_via_coo = Absr.tocoo().tocsr()
+        assert_equal(Acsr.todense(),A)
+        assert_equal(Acsr.todense(),Acsr_via_coo.todense())
+
     def test_eliminate_zeros(self):
         data = kron([1, 0, 0, 0, 2, 0, 3, 0], [[1,1],[1,1]]).T
         data = data.reshape(-1,2,2)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -4188,9 +4188,9 @@ class TestBSR(sparse_test_class(getset=False,
 
     def test_bsr_tocsr(self):
         # check native conversion from BSR to CSR
-        indptr = array([0,2,2,4])
-        indices = array([0,2,2,3])
-        data = zeros((4,2,3))
+        indptr = array([0, 2, 2, 4])
+        indices = array([0, 2, 2, 3])
+        data = zeros((4, 2, 3))
 
         data[0] = array([[0, 1, 2],
                          [3, 0, 5]])
@@ -4201,12 +4201,13 @@ class TestBSR(sparse_test_class(getset=False,
         data[3] = array([[0, 5, 10],
                          [15, 0, 25]])
 
-        A = kron([[1,0,2,0],[0,0,0,0],[0,0,4,5]], [[0,1,2],[3,0,5]])
-        Absr = bsr_matrix((data,indices,indptr),shape=(6,12))
+        A = kron([[1, 0, 2, 0], [0, 0, 0, 0], [0, 0, 4, 5]],
+                 [[0, 1, 2], [3, 0, 5]])
+        Absr = bsr_matrix((data, indices, indptr), shape=(6, 12))
         Acsr = Absr.tocsr()
         Acsr_via_coo = Absr.tocoo().tocsr()
-        assert_equal(Acsr.todense(),A)
-        assert_equal(Acsr.todense(),Acsr_via_coo.todense())
+        assert_equal(Acsr.todense(), A)
+        assert_equal(Acsr.todense(), Acsr_via_coo.todense())
 
     def test_eliminate_zeros(self):
         data = kron([1, 0, 0, 0, 2, 0, 3, 0], [[1,1],[1,1]]).T


### PR DESCRIPTION
The current implementation of sparse matrix BSR to CSR conversion is to convert to COO first, then to CSR. I noticed that there is a TODO in "scipy/sparse/bsr.py" to make the conversion more efficient. Also there is a half finished function template in "scipy/sparse/sparsetools/bsr.h". I have implemented direct conversion from BSR to CSR instead of converting via COO format. The direct conversion preserves now the (unsorted) block column indices and duplicated block columns.

There is a concern on the data copy of this conversion. Though the current function has a boolean argument to determine if the data are copied or not, the data are actually always copied. Mathematically, from BSR to COO we can avoid copy, but from COO to CSR the copy is almost inevitable, unless the block row size is one. Even in the current version of coo_matrix.tocsr, the data are always copied regardless of the input argument. For the direct conversion I keep the same way: there is a boolean argument, but the data are copied anyway.

P.S. this is the first time I submit a PR. I am not sure if I have done everything correctly, e.g. if the tests were well written and placed in correct position. I apologize for any mistakes.