### PR TITLE
ENH: spatial.transform.Rotation [GSOC2018]

### DIFF
--- a/doc/API.rst.txt
+++ b/doc/API.rst.txt
@@ -130,6 +130,7 @@ change is made.
 * `scipy.spatial`
 
   - `scipy.spatial.distance`
+  - `scipy.spatial.transform`
 
 * `scipy.special`
 
@@ -137,4 +138,3 @@ change is made.
 
   - `scipy.stats.distributions`
   - `scipy.stats.mstats`
-

--- a/doc/source/_templates/autosummary/class.rst
+++ b/doc/source/_templates/autosummary/class.rst
@@ -6,7 +6,7 @@
       .. autosummary::
          :toctree:
       {% for item in all_methods %}
-         {%- if not item.startswith('_') or item in ['__call__'] %}
+         {%- if not item.startswith('_') or item in ['__call__', '__mul__'] %}
          {{ name }}.{{ item }}
          {%- endif -%}
       {%- endfor %}

--- a/doc/source/_templates/autosummary/class.rst
+++ b/doc/source/_templates/autosummary/class.rst
@@ -6,7 +6,7 @@
       .. autosummary::
          :toctree:
       {% for item in all_methods %}
-         {%- if not item.startswith('_') or item in ['__call__', '__mul__', '__getitem__'] %}
+         {%- if not item.startswith('_') or item in ['__call__', '__mul__', '__getitem__', '__len__'] %}
          {{ name }}.{{ item }}
          {%- endif -%}
       {%- endfor %}

--- a/doc/source/_templates/autosummary/class.rst
+++ b/doc/source/_templates/autosummary/class.rst
@@ -6,7 +6,7 @@
       .. autosummary::
          :toctree:
       {% for item in all_methods %}
-         {%- if not item.startswith('_') or item in ['__call__', '__mul__'] %}
+         {%- if not item.startswith('_') or item in ['__call__', '__mul__', '__getitem__'] %}
          {{ name }}.{{ item }}
          {%- endif -%}
       {%- endfor %}

--- a/doc/source/spatial.transform.rst
+++ b/doc/source/spatial.transform.rst
@@ -1,0 +1,1 @@
+.. automodule:: scipy.spatial.transform

--- a/scipy/spatial/__init__.py
+++ b/scipy/spatial/__init__.py
@@ -5,6 +5,10 @@ Spatial algorithms and data structures (:mod:`scipy.spatial`)
 
 .. currentmodule:: scipy.spatial
 
+Spatial Transformations
+=======================
+Contained in the :mod:`scipy.spatial.transform` submodule.
+
 Nearest-neighbor Queries
 ========================
 .. autosummary::
@@ -97,6 +101,7 @@ from .qhull import *
 from ._spherical_voronoi import SphericalVoronoi
 from ._plotutils import *
 from ._procrustes import procrustes
+from . import transform
 
 __all__ = [s for s in dir() if not s.startswith('_')]
 __all__ += ['distance']

--- a/scipy/spatial/__init__.py
+++ b/scipy/spatial/__init__.py
@@ -7,7 +7,7 @@ Spatial algorithms and data structures (:mod:`scipy.spatial`)
 
 Spatial Transformations
 =======================
-Contained in the :mod:`scipy.spatial.transform` submodule.
+Contained in the `scipy.spatial.transform` submodule.
 
 Nearest-neighbor Queries
 ========================

--- a/scipy/spatial/setup.py
+++ b/scipy/spatial/setup.py
@@ -14,6 +14,9 @@ def configuration(parent_package='', top_path=None):
 
     config.add_data_dir('tests')
 
+    # spatial.transform
+    config.add_subpackage('transform')
+
     # qhull
     qhull_src = list(glob.glob(join(dirname(__file__), 'qhull',
                                     'src', '*.c')))

--- a/scipy/spatial/transform/__init__.py
+++ b/scipy/spatial/transform/__init__.py
@@ -1,0 +1,43 @@
+"""
+========================================================
+Spatial Transformations (:mod:`scipy.spatial.transform`)
+========================================================
+
+.. currentmodule:: scipy.spatial.transform
+
+This package implements various spatial transformations. For now,
+only rotations are supported.
+
+Rotations in 3 dimensions
+-------------------------
+This package supports `Rotation` transforms with the following representations
+
+* Quaternions
+* Discrete Cosine Matrices
+* Euler angles
+* Axis angle representation
+
+It also implements some useful algorithms such as
+
+* Quaternion slerp
+* Quaternion spline
+* Rotation estimation (Wahba's problem)
+
+Class Reference
+---------------
+
+.. autosummary::
+    :toctree: generated/
+
+    Rotation
+
+"""
+from __future__ import division, print_function, absolute_import
+
+from .rotation import *
+
+__all__ = [s for s in dir() if not s.startswith('_')]
+
+from scipy._lib._testutils import PytestTester
+test = PytestTester(__name__)
+del PytestTester

--- a/scipy/spatial/transform/__init__.py
+++ b/scipy/spatial/transform/__init__.py
@@ -34,9 +34,9 @@ Class Reference
 """
 from __future__ import division, print_function, absolute_import
 
-from .rotation import *
+from .rotation import Rotation
 
-__all__ = [s for s in dir() if not s.startswith('_')]
+__all__ = ['Rotation']
 
 from scipy._lib._testutils import PytestTester
 test = PytestTester(__name__)

--- a/scipy/spatial/transform/__init__.py
+++ b/scipy/spatial/transform/__init__.py
@@ -10,22 +10,6 @@ only rotations are supported.
 
 Rotations in 3 dimensions
 -------------------------
-This package supports `Rotation` transforms with the following representations
-
-* Quaternions
-* Discrete Cosine Matrices
-* Euler angles
-* Axis angle representation
-
-It also implements some useful algorithms such as
-
-* Quaternion slerp
-* Quaternion spline
-* Rotation estimation (Wahba's problem)
-
-Class Reference
----------------
-
 .. autosummary::
     :toctree: generated/
 

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -662,22 +662,7 @@ class Rotation(object):
     def apply(self, vectors, inverse=False):
         """Apply this rotation on a set of vectors.
 
-        Rotates `vectors` by the rotation(s) represented in the object. In
-        terms of DCMs, this application is the same as
-        `self.as_dcm().dot(vectors)`. Returns a `numpy.ndarray` whose shape
-        depends on the following cases:
-
-            - a single rotation applied on a single vector specified with shape
-              `(3,)`:
-                - output vector has shape `(3,)`.
-            - a single rotation applied on a `P` vectors:
-                - output vectors have shape `(P, 3)`, same as input vectors.
-            - `N` rotations applied on a single vector:
-                - output vectors have shape `(N, 3)`.
-            - `N` rotation applied on `P` vectors:
-                - output has shape `(N, 3)`, where the `ith` rotation is
-                  applied on the `ith` point.
-
+        Rotates `vectors` by the rotation(s) represented in the object.
         If the original frame rotates to the final frame by this rotation, then
         its application to a vector can be seen in two ways:
 
@@ -686,6 +671,18 @@ class Rotation(object):
             - As the physical rotation of a vector being glued to the original
               frame as it rotates. In this case the vector components are
               expressed in the original frame before and after rotation.
+
+        In terms of DCMs, this application is the same as
+        `self.as_dcm().dot(vectors)`.
+
+        The number of rotations and number of vectors given must follow
+        standard numpy broadcasting rules: either one of them equals unity or
+        they both equal each other.
+
+        Returns a `numpy.ndarray` of shape `(3,)` if object contains a single
+        rotation (as opposed to a stack with a single rotation) and a single
+        vector is specified with shape `(3,)`. In all other cases, the returned
+        array has shape `(N, 3)`.
 
         Parameters
         ----------

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -45,10 +45,7 @@ def compute_euler_from_dcm(dcm, seq, extrinsic=False):
     # angle offset is lambda from the paper referenced in [2] from docstring of
     # `as_euler` function
     offset = np.arctan2(sl, cl)
-    c = np.empty((3, 3))
-    c[0] = n2
-    c[1] = np.cross(n1, n2)
-    c[2] = n1
+    c = np.vstack((n2, np.cross(n1, n2), n1))
 
     # Step 3
     rt = np.array([
@@ -56,8 +53,7 @@ def compute_euler_from_dcm(dcm, seq, extrinsic=False):
         [0, cl, -sl],
         [0, sl, cl]
     ])
-    rtc = rt.dot(c)
-    res = np.einsum('...ij,...jk->...ik', rtc, dcm)
+    res = np.einsum('...ij,...jk->...ik', rt.dot(c), dcm)
     dcm_transformed = np.einsum('...ij,...jk->...ik', res, c.T)
 
     # Step 4
@@ -93,7 +89,6 @@ def compute_euler_from_dcm(dcm, seq, extrinsic=False):
     )
 
     # Step 7
-    # python modulo operator works correctly for negative numbers
     if seq[0] == seq[2]:
         # lambda = 0, so we can only ensure angle2 -> [0, pi]
         adjust_mask = np.logical_or(angles[:, 1] < 0, angles[:, 1] > np.pi)
@@ -553,15 +548,13 @@ class Rotation(object):
             - Third angle belongs to [-180, 180] degrees (both inclusive)
             - Second angle belongs to:
 
-                - [-90, 90] degrees if all axes are unique (like xyz)
-                - [0, 180] degrees if first and third axes are same (like zxz)
+                - [-90, 90] degrees if all axes are different (like xyz)
+                - [0, 180] degrees if first and third axes are the same
+                (like zxz)
 
-        Euler angles suffer from the problem of gimbal lock. It occurs when,
-        during the course of the rotation, the initial axis of rotation
-        coincides with the final axis of rotation. As a result, two of the
-        three Euler angles cannot be determined uniquely. In those cases, this
-        function raises a warning. However, the rotation represented by the
-        object is still guaranteed to be correct.
+        Euler angles suffer from the problem of gimbal lock [3]_. In this case,
+        a warning is raised, and the third angle is set to zero. Note however
+        that the returned angles still represent the correct rotation.
 
         Parameters
         ----------
@@ -582,6 +575,8 @@ class Rotation(object):
         .. [2] Malcolm D. Shuster, F. Landis Markley
                 `General Formula for Euler Angles
                 <https://arc.aiaa.org/doi/abs/10.2514/1.16622>`_
+        -- [3] `Gimbal lock
+                <https://en.wikipedia.org/wiki/Gimbal_lock#In_applied_mathematics>`_
         """
         if len(seq) != 3:
             raise ValueError("Expected 3 axes, got {}.".format(seq))

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -257,13 +257,14 @@ class Rotation(object):
     def as_quaternion(self):
         """Return the quaternion representation of the Rotation.
 
-        This function returns a numpy array of shape (4,) or (N x 4) depending
-        on the input that was used to initialize the object.
+        Returns a copy of the quaternions stored internally in a numpy array of
+        shape (4,) or (N x 4) depending on the input that was used to
+        initialize the object.
         """
         if self._single:
-            return self._quat[0]
+            return self._quat[0].copy()
         else:
-            return self._quat
+            return self._quat.copy()
 
     def as_dcm(self):
         """Return the direction cosine matrix representation of the Rotation.

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -18,6 +18,7 @@ class Rotation(object):
     Methods
     -------
     from_quaternion
+    as_quaternion
     """
     def __init__(self, quat, normalized=False):
         self._single = False

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -189,8 +189,9 @@ class Rotation(object):
         quat[ind, 2] = dcm[ind, 1, 0] - dcm[ind, 0, 1]
         quat[ind, 3] = 1 + decision_matrix[ind, -1]
 
+        quat /= np.linalg.norm(quat, axis=1)[:, None]
+
         if is_single:
-            return cls(quat[0] / np.linalg.norm(quat[0]), normalized=True)
+            return cls(quat[0], normalized=True)
         else:
-            return cls(quat / np.linalg.norm(quat, axis=1)[:, None],
-                    normalized=True)
+            return cls(quat, normalized=True)

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -228,10 +228,11 @@ class Rotation(object):
         num_rotations = rotvec.shape[0]
 
         norms = np.linalg.norm(rotvec, axis=1)
-        small_angle = np.nonzero(norms <= 1e-3)[0]
-        large_angle = np.nonzero(norms > 1e-3)[0]
+        small_angle = (norms <= 1e-3)
+        large_angle = ~small_angle
 
         scale = np.empty(num_rotations)
+        # Use the Taylor expansion of sin(x/2) / x for small angles
         scale[small_angle] = (0.5 - norms[small_angle] ** 2 / 48 +
                               norms[small_angle] ** 4 / 3840)
         scale[large_angle] = (np.sin(norms[large_angle] / 2) /

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -137,12 +137,18 @@ class Rotation(object):
 
         This classmethod return a `Rotation` object from the input direction
         cosine matrices. If the input matrix is not orthogonal, this method
-        creates the best approximation of the rotation.
+        creates an approximation using the algorithm described in [1]_.
 
         Parameters
         ----------
         dcm : array_like, shape (N, 3, 3) or (3, 3)
-            Each `dcm[i]` corresponds to a `(3, 3)` direction cosine matrix.
+            A single matrix or a stack of matrices, where `dcm[i]` is the i-th
+            matrix.
+
+        References
+        ----------
+        .. [1] F. Landis Markley, `Unit Quaternion from Rotation Matrix
+               <https://arc.aiaa.org/doi/abs/10.2514/1.31730>`_
         """
         is_single = False
         dcm = np.asarray(dcm, dtype=float)

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -4,14 +4,16 @@ import numpy as np
 import scipy.linalg
 import warnings
 
+
 class Rotation(object):
     """Rotation in 3 dimensions.
 
-    This class will include initializers from different representations, converters
-    and some useful algorithms such as quaternion slerp and rotation estimation.
+    This class will include initializers from different representations,
+    converters and some useful algorithms such as quaternion slerp and
+    rotation estimation.
 
-    For initializing Rotations usage of `from_...` methods such as `from_quaternion`
-    is recommended instead of using `__init__`.
+    For initializing Rotations usage of `from_...` methods such as
+    `from_quaternion` is recommended instead of using `__init__`.
 
     Methods
     -------
@@ -23,7 +25,8 @@ class Rotation(object):
         quat = np.asarray(quat, dtype=float)
 
         if quat.ndim not in [1, 2] or quat.shape[-1] != 4:
-            raise ValueError("`quat` should be of shape (4,) or (N x 4).")
+            raise ValueError(("Expected `quat` to have shape (4,) or (N x 4), "
+                    "got {}.".format(quat.shape)))
 
         # If a single quaternion is given, convert it to a 2D 1 x 4 matrix but
         # set self._single to True so that we can return appropriate objects
@@ -43,7 +46,8 @@ class Rotation(object):
             # which (0,0,0,1) in (x,y,z,w) format
             zero_norms = norms == 0
             if zero_norms.any():
-                warnings.warn("Found zero norm quaternions in input, replacing with identity quaternions.")
+                warnings.warn("""Found zero norm quaternions in input,
+                        replacing with identity quaternions.""")
                 self._quat[zero_norms] = np.array([0, 0, 0, 1])
             # Normalize each quaternion, ensuring norm is broadcasted along
             # each column.
@@ -53,7 +57,7 @@ class Rotation(object):
     def from_quaternion(cls, quat, normalized=False):
         """Initialize Rotation from quaternions.
 
-        This classmethod returns a `Rotation` object from the input quaternions.
+        This classmethod returns a `Rotation` object from the input quaternions
         If `normalized` is `True`, then the quaternions are assumed to have
         unit norm, else the quaternions are normalized before the object is
         created.
@@ -64,8 +68,9 @@ class Rotation(object):
             Each row is a (possibly non-unit norm) quaternion in scalar-last
             (x, y, z, w) format.
         normalized : boolean, optional
-            If this flag is `True`, then it is assumed that the input quaternions
-            all have unit norm and are not normalized again. Default is False.
+            If this flag is `True`, then it is assumed that the input
+            quaternions all have unit norm and are not normalized again.
+            Default is False.
         """
 
         return cls(quat, normalized)

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -25,8 +25,8 @@ class Rotation(object):
         quat = np.asarray(quat, dtype=float)
 
         if quat.ndim not in [1, 2] or quat.shape[-1] != 4:
-            raise ValueError(("Expected `quat` to have shape (4,) or (N x 4), "
-                    "got {}.".format(quat.shape)))
+            raise ValueError("Expected `quat` to have shape (4,) or (N x 4), "
+                             "got {}.".format(quat.shape))
 
         # If a single quaternion is given, convert it to a 2D 1 x 4 matrix but
         # set self._single to True so that we can return appropriate objects
@@ -42,13 +42,11 @@ class Rotation(object):
             # L2 norm of each row
             norms = scipy.linalg.norm(quat, axis=1)
 
-            # Warn user for zero (eps?) norm and set to identity quaternion,
-            # which (0,0,0,1) in (x,y,z,w) format
+            # Raise ValueError for zero (eps?) norm quaternions
             zero_norms = norms == 0
             if zero_norms.any():
-                warnings.warn("""Found zero norm quaternions in input,
-                        replacing with identity quaternions.""")
-                self._quat[zero_norms] = np.array([0, 0, 0, 1])
+                raise ValueError("Found zero norm quaternions in `quat`.")
+
             # Normalize each quaternion, ensuring norm is broadcasted along
             # each column.
             self._quat[~zero_norms] /= norms[~zero_norms][:, None]

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -233,7 +233,7 @@ class Rotation(object):
         return self._quat.shape[0]
 
     @classmethod
-    def from_quaternion(cls, quat, normalized=False, copy=True):
+    def from_quaternion(cls, quat, normalized=False):
         """Initialize Rotation from quaternions.
 
         This classmethod returns a `Rotation` object from the input quaternions
@@ -250,13 +250,9 @@ class Rotation(object):
             If this flag is `True`, then it is assumed that the input
             quaternions all have unit norm and are not normalized again.
             Default is False.
-        copy : boolean, optional
-            Specifies behaviour when `normalized = True`. If `copy = True`, a
-            copy of the input quaternions is stored in the object. If
-            `copy = False`, then the input itself is stored. Default is `True`.
         """
 
-        return cls(quat, normalized, copy)
+        return cls(quat, normalized)
 
     def as_quaternion(self):
         """Return the quaternion representation of the Rotation.

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -193,6 +193,7 @@ class Rotation(object):
     inv
     __mul__
     apply
+    __getitem__
     """
     def __init__(self, quat, normalized=False):
         self._single = False
@@ -725,3 +726,24 @@ class Rotation(object):
             return result[0]
         else:
             return result
+
+    def __getitem__(self, indexer):
+        """Extract rotation at given index(es) from object.
+
+        This function returns a new `Rotation` instance containing:
+
+            - a single rotation, if `indexer` is a single index
+            - a stack of rotation(s), if `indexer` is a slice, or an index
+              array. In cases where a single index is ultimately specified, the
+              stack will contain a single rotation.
+
+        A single indexer must be specified. The semantics for this function are
+        identical to that of numpy arrays and lists.
+
+        Parameters
+        ----------
+        indexer : index, slice, or index array
+            Specifies which rotation(s) to extract.
+        """
+        # __init__ now copies by default
+        return self.__class__(self._quat[indexer], normalized=True)

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -227,13 +227,11 @@ class Rotation(object):
 
         num_rotations = rotvec.shape[0]
 
-
-        scale = np.empty(num_rotations)
-
         norms = np.linalg.norm(rotvec, axis=1)
         small_angle = np.nonzero(norms <= 1e-3)[0]
         large_angle = np.nonzero(norms > 1e-3)[0]
 
+        scale = np.empty(num_rotations)
         scale[small_angle] = (0.5 - norms[small_angle] ** 2 / 48 +
                               norms[small_angle] ** 4 / 3840)
         scale[large_angle] = (np.sin(norms[large_angle] / 2) /

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -198,7 +198,7 @@ class Rotation(object):
             return cls(quat, normalized=True)
 
     @classmethod
-    def from_rotvec(cls, rot_vecs):
+    def from_rotvec(cls, rotvec):
         """Initialize class from rotation vector.
 
         A rotation vector is a 3 dimensional vector which is co-directional to
@@ -207,44 +207,43 @@ class Rotation(object):
 
         Parameters
         ----------
-        rot_vecs : array_like, shape (N, 3) or (3,)
+        rotvec : array_like, shape (N, 3) or (3,)
             A single vector or a stack of vectors, where `rot_vec[i]` gives
             the ith rotation vector.
         """
         is_single = False
-        rot_vecs = np.asarray(rot_vecs, dtype=float)
+        rotvec = np.asarray(rotvec, dtype=float)
 
-        if rot_vecs.ndim not in [1, 2] or rot_vecs.shape[-1] != 3:
+        if rotvec.ndim not in [1, 2] or rotvec.shape[-1] != 3:
             raise ValueError("Expected `rot_vec` to have shape (3,) "
-                             "or (N, 3), got {}".format(rot_vec.shape))
+                             "or (N, 3), got {}".format(rotvec.shape))
 
         # If a single vector is given, convert it to a 2D 1 x 3 matrix but
         # set self._single to True so that we can return appropriate objects
         # in the `as_...` methods
-        if rot_vecs.shape == (3,):
-            rot_vecs = rot_vecs[None, :]
+        if rotvec.shape == (3,):
+            rotvec = rotvec[None, :]
             is_single = True
 
-        num_rotations = rot_vecs.shape[0]
+        num_rotations = rotvec.shape[0]
 
-        norms = np.linalg.norm(rot_vecs, axis=1)[:, None]
+        norms = np.linalg.norm(rotvec, axis=1)
         small_angle = norms <= 1e-3
 
         quat = np.empty((num_rotations, 4))
 
-        zero_norms = np.nonzero(norms == 0)[0]
-        quat[zero_norms, :3] = np.array([0, 0, 0])
+        scale = np.empty(num_rotations)
 
         small_angle = np.nonzero(np.logical_and(
             norms <= 1e-3, norms != 0))[0]
-        quat[small_angle, :3] = (0.5 - np.power(norms[small_angle], 2) /
-                                 48 + np.power(norms[small_angle], 4) /
-                                 3840) * rot_vecs[small_angle]
+        scale[small_angle] = (0.5 - norms[small_angle] ** 2 / 48 +
+                              norms[small_angle] ** 4 / 3840)
 
         large_angle = np.nonzero(norms > 1e-3)[0]
-        quat[large_angle, :3] = (np.sin(norms[large_angle] / 2) /
-                                 norms[large_angle]) * rot_vecs[large_angle]
+        scale[large_angle] = (np.sin(norms[large_angle] / 2) /
+                              norms[large_angle])
 
+        quat[:, :3] = scale[:, None] * rotvec
         quat[:, 3] = np.cos(norms / 2).flatten()
 
         if is_single:

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -567,7 +567,7 @@ class Rotation(object):
 
                 - [-90, 90] degrees if all axes are different (like xyz)
                 - [0, 180] degrees if first and third axes are the same
-                (like zxz)
+                  (like zxz)
 
         Euler angles suffer from the problem of gimbal lock [3]_. In this case,
         a warning is raised, and the third angle is set to zero. Note however
@@ -592,7 +592,7 @@ class Rotation(object):
         .. [2] Malcolm D. Shuster, F. Landis Markley
                 `General Formula for Euler Angles
                 <https://arc.aiaa.org/doi/abs/10.2514/1.16622>`_
-        -- [3] `Gimbal lock
+        .. [3] `Gimbal lock
                 <https://en.wikipedia.org/wiki/Gimbal_lock#In_applied_mathematics>`_
         """
         if len(seq) != 3:

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -227,6 +227,11 @@ class Rotation(object):
             # each column.
             self._quat[~zero_norms] /= norms[~zero_norms][:, None]
 
+    @property
+    def n(self):
+        """Number of rotations contained in object."""
+        return self._quat.shape[0]
+
     @classmethod
     def from_quaternion(cls, quat, normalized=False, copy=True):
         """Initialize Rotation from quaternions.

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -619,15 +619,13 @@ class Rotation(object):
         return angles[0] if self._single else angles
 
     def inv(self):
-        """Returns the inverse of the current rotation
+        """Returns the inverse of the current rotation.
 
         This function returns a new `Rotation` instance containing the inverse
         of all the rotations in the current instance.
         """
         quat = self._quat.copy()
-        # (x,y,z,w) -> (x,y,z,-w)
+        quat[:, -1] *= -1
         if self._single:
-            quat[-1] *= -1
-        else:
-            quat[:, -1] *= -1
+            quat = quat[0]
         return self.__class__(quat, normalized=True)

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -168,10 +168,10 @@ def _elementary_quat_compose(seq, angles, intrinsic=False):
 
 
 class Rotation(object):
-    """Rotation transform in 3 dimensions.
+    """Rotation in 3 dimensions.
 
     This class provides an interface to initialize from and represent rotations
-    using the following:
+    with:
 
         - Quaternions
         - Direction Cosine Matrices
@@ -265,7 +265,7 @@ class Rotation(object):
 
         Returns
         -------
-        output : `Rotation` instance
+        rotation : `Rotation` instance
             Object containing the rotations represented by input quaternions.
 
         References
@@ -281,7 +281,7 @@ class Rotation(object):
         """Initialize Rotation from direction cosine matrix.
 
         Rotations in 3 dimensions can be represented using 3 x 3 proper
-        orthogonal matrices. If the input is not proper orthogonal,
+        orthogonal matrices [2]_. If the input is not proper orthogonal,
         an approximation is created using the method described in [1]_.
 
         Parameters
@@ -292,7 +292,7 @@ class Rotation(object):
 
         Returns
         -------
-        output : `Rotation` instance
+        rotation : `Rotation` instance
             Object containing the rotations represented by the input direction
             cosine matrices.
 
@@ -300,6 +300,8 @@ class Rotation(object):
         ----------
         .. [1] F. Landis Markley, `Unit Quaternion from Rotation Matrix
                <https://arc.aiaa.org/doi/abs/10.2514/1.31730>`_
+        .. [2] `Direction Cosine Matrix
+                <https://en.wikipedia.org/wiki/Rotation_matrix#In_three_dimensions>`_
         """
         is_single = False
         dcm = np.asarray(dcm, dtype=float)
@@ -353,7 +355,7 @@ class Rotation(object):
 
         A rotation vector is a 3 dimensional vector which is co-directional to
         the axis of rotation and whose norm gives the angle of rotation (in
-        radians).
+        radians) [1]_.
 
         Parameters
         ----------
@@ -363,9 +365,14 @@ class Rotation(object):
 
         Returns
         -------
-        output : `Rotation` instance
+        rotation : `Rotation` instance
             Object containing the rotations represented by input rotation
             vectors.
+
+        References
+        ----------
+        .. [1] `Rotation Vectors
+                <https://en.wikipedia.org/wiki/Axis%E2%80%93angle_representation#Rotation_vector>`_
         """
         is_single = False
         rotvec = np.asarray(rotvec, dtype=float)
@@ -447,7 +454,7 @@ class Rotation(object):
 
         Returns
         -------
-        output : `Rotation` instance
+        rotation : `Rotation` instance
             Object containing the rotation represented by the sequence of
             rotations around given axes with given angles.
 
@@ -520,12 +527,12 @@ class Rotation(object):
 
         Rotations in 3 dimensions can be represented using unit norm
         quaternions [1]_. The mapping from quaternions to rotations is
-        two-to-one, i.e. a quaternion and its additive inverse represent the
-        same spatial rotation.
+        two-to-one, i.e. quaternions `q` and `-q`, where `-q` simply reverses
+        the sign of each component, represent the same spatial rotation.
 
         Returns
         -------
-        output : `numpy.ndarray`, shape (4,) or (N, 4)
+        quat : `numpy.ndarray`, shape (4,) or (N, 4)
             Shape depends on shape of inputs used for initialization.
 
         References
@@ -542,12 +549,17 @@ class Rotation(object):
         """Represent rotations as direction cosine matrices.
 
         3D rotations can be represented using direction cosine matrices, which
-        are 3 x 3 real orthogonal matrices with eigenvalue equal to +1.
+        are 3 x 3 real orthogonal matrices with eigenvalue equal to +1 [1]_.
 
         Returns
         -------
-        output : `numpy.ndarray`, shape (3, 3) or (N, 3, 3)
+        dcm : `numpy.ndarray`, shape (3, 3) or (N, 3, 3)
             Shape depends on shape of inputs used for initialization.
+
+        References
+        ----------
+        .. [1] `Direction Cosine Matrix
+                <https://en.wikipedia.org/wiki/Rotation_matrix#In_three_dimensions>`_
         """
 
         x = self._quat[:, 0]
@@ -592,12 +604,17 @@ class Rotation(object):
 
         A rotation vector is a 3 dimensional vector which is co-directional to
         the axis of rotation and whose norm gives the angle of rotation (in
-        radians).
+        radians) [1]_.
 
         Returns
         -------
-        output : `numpy.ndarray`, shape (3,) or (N, 3)
+        rotvec : `numpy.ndarray`, shape (3,) or (N, 3)
             Shape depends on shape of inputs used for initialization.
+
+        References
+        ----------
+        .. [1] `Rotation Vectors
+                <https://en.wikipedia.org/wiki/Axis%E2%80%93angle_representation#Rotation_vector>`_
         """
         quat = self._quat.copy()
         # w > 0 to ensure 0 <= angle <= pi
@@ -731,7 +748,8 @@ class Rotation(object):
 
         Returns
         -------
-        output : `numpy.ndarray`, shape (3,) or (N, 3)
+        outvecs : `numpy.ndarray`, shape (3,) or (N, 3)
+            Result of applying rotation on input vectors.
             Shape depends on the following cases:
 
                 - If object contains a single rotation (as opposed to a stack
@@ -789,7 +807,7 @@ class Rotation(object):
 
         Returns
         -------
-        output : `Rotation` instance
+        rotation : `Rotation` instance
             This function supports composition of multiple rotations at a time.
             The following cases are possible:
 
@@ -820,7 +838,7 @@ class Rotation(object):
 
         Returns
         -------
-        output : `Rotation` instance
+        rotation : `Rotation` instance
             Object containing inverse of the rotations in the current instance.
         """
         quat = self._quat.copy()
@@ -843,7 +861,7 @@ class Rotation(object):
 
         Returns
         -------
-        output : `Rotation` instance
+        rotation : `Rotation` instance
             `output` contains
                 - a single rotation, if `indexer` is a single index
                 - a stack of rotation(s), if `indexer` is a slice, or and index

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -22,23 +22,20 @@ class Rotation(object):
         # Try to convert to numpy array
         quat = np.asarray(quat, dtype=float)
 
-        if quat.ndim not in [1, 2]:
-            raise ValueError("Input quat should be of shape (4,) or (N x 4).")
+        if quat.ndim not in [1, 2] or quat.shape[-1] != 4:
+            raise ValueError("`quat` should be of shape (4,) or (N x 4).")
 
         # If a single quaternion is given, convert it to a 2D 1 x 4 matrix but
         # set self._single to True so that we can return appropriate objects
         # in the `to_...` methods
-        if quat.ndim == 1:
+        if quat.shape == (4,):
             quat = quat[None, :]
             self._single = True
 
-        # Each row should have 4 numbers
-        if quat.shape[1] != 4:
-            raise ValueError("A quaternion should have 4 numbers.")
-
-        self._quat = quat
-
-        if not normalized:
+        if normalized:
+            self._quat = quat
+        else:
+            self._quat = quat.copy()
             # L2 norm of each row
             norms = scipy.linalg.norm(quat, axis=1)
 
@@ -66,7 +63,6 @@ class Rotation(object):
         quat : array_like, shape (N, 4) or (4,)
             Each row is a (possibly non-unit norm) quaternion in scalar-last
             (x, y, z, w) format.
-
         normalized : boolean, optional
             If this flag is `True`, then it is assumed that the input quaternions
             all have unit norm and are not normalized again. Default is False.

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -21,6 +21,7 @@ class Rotation(object):
     as_quaternion
     from_dcm
     as_dcm
+    from_rotvec
     """
     def __init__(self, quat, normalized=False):
         self._single = False

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -89,20 +89,19 @@ class Rotation(object):
     def as_dcm(self):
         """Return the direction cosine matrix representation of the Rotation.
 
-        This function returns a numpy.ndarray of shape (3 x 3) or (N x 3 x 3)
+        This function returns a numpy.ndarray of shape (3, 3) or (N, 3, 3)
         depending on the input that was used to initialize the object.
         """
-        quat = self._quat.copy()
 
-        x = quat[:, 0].reshape(-1, 1)
-        y = quat[:, 1].reshape(-1, 1)
-        z = quat[:, 2].reshape(-1, 1)
-        w = quat[:, 3].reshape(-1, 1)
+        x = self._quat[:, 0]
+        y = self._quat[:, 1]
+        z = self._quat[:, 2]
+        w = self._quat[:, 3]
 
-        x2 = np.power(x, 2)
-        y2 = np.power(y, 2)
-        z2 = np.power(z, 2)
-        w2 = np.power(w, 2)
+        x2 = x * x
+        y2 = y * y
+        z2 = z * z
+        w2 = w * w
 
         xy = x * y
         zw = z * w
@@ -111,13 +110,20 @@ class Rotation(object):
         yz = y * z
         xw = x * w
 
-        d1 = np.concatenate(
-                (x2 - y2 - z2 + w2, 2 * (xy + zw), 2 * (xz - yw)), axis=1)
-        d2 = np.concatenate(
-                (2 * (xy - zw), - x2 + y2 - z2 + w2, 2 * (yz + xw)), axis=1)
-        d3 = np.concatenate(
-                (2 * (xz + yw), 2 * (yz - xw), - x2 - y2 + z2 + w2), axis=1)
-        dcm = np.dstack((d1, d2, d3))
+        num_rotations = self._quat.shape[0]
+        dcm = np.empty((num_rotations, 3, 3))
+
+        dcm[:, 0, 0] = x2 - y2 - z2 + w2
+        dcm[:, 1, 0] = 2 * (xy + zw)
+        dcm[:, 2, 0] = 2 * (xz - yw)
+
+        dcm[:, 0, 1] = 2 * (xy - zw)
+        dcm[:, 1, 1] = - x2 + y2 - z2 + w2
+        dcm[:, 2, 1] = 2 * (yz + xw)
+
+        dcm[:, 0, 2] = 2 * (xz + yw)
+        dcm[:, 1, 2] = 2 * (yz - xw)
+        dcm[:, 2, 2] = - x2 - y2 + z2 + w2
 
         if self._single:
             return dcm[0]

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -195,7 +195,7 @@ class Rotation(object):
     apply
     __getitem__
     """
-    def __init__(self, quat, normalized=False):
+    def __init__(self, quat, normalized=False, copy=True):
         self._single = False
         # Try to convert to numpy array
         quat = np.asarray(quat, dtype=float)
@@ -212,8 +212,8 @@ class Rotation(object):
             self._single = True
 
         if normalized:
-            self._quat = quat
-        else:
+            self._quat = quat.copy() if copy else quat
+        if not normalized:
             self._quat = quat.copy()
             # L2 norm of each row
             norms = scipy.linalg.norm(quat, axis=1)

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -1,0 +1,12 @@
+from __future__ import division, print_function, absolute_import
+
+import numpy as np
+
+class Rotation(object):
+    """Rotation in 3 dimensions.
+
+    This class will include initializers from different representations, converters
+    and some useful algorithms such as quaternion slerp and rotation estimation.
+    """
+    def __init__(self):
+        pass

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -253,7 +253,7 @@ class Rotation(object):
 
     @classmethod
     def from_quat(cls, quat, normalized=False):
-        """Initialize Rotation from quaternions.
+        """Initialize from quaternions.
 
         3D rotations can be represented using unit-norm quaternions [1]_.
 
@@ -282,7 +282,7 @@ class Rotation(object):
 
     @classmethod
     def from_dcm(cls, dcm):
-        """Initialize Rotation from direction cosine matrices.
+        """Initialize from direction cosine matrices.
 
         Rotations in 3 dimensions can be represented using 3 x 3 proper
         orthogonal matrices [1]_. If the input is not proper orthogonal,
@@ -355,7 +355,7 @@ class Rotation(object):
 
     @classmethod
     def from_rotvec(cls, rotvec):
-        """Initialize Rotation from rotation vectors.
+        """Initialize from rotation vectors.
 
         A rotation vector is a 3 dimensional vector which is co-directional to
         the axis of rotation and whose norm gives the angle of rotation (in
@@ -415,7 +415,7 @@ class Rotation(object):
 
     @classmethod
     def from_euler(cls, seq, angles, degrees=False):
-        """Initialize Rotation from Euler angles.
+        """Initialize from Euler angles.
 
         Rotations in 3 dimensions can be represented by a sequece of 3
         rotations around a sequence of axes. In theory, any three axes spanning
@@ -527,7 +527,7 @@ class Rotation(object):
         return cls(quat[0] if is_single else quat, normalized=True, copy=False)
 
     def as_quat(self):
-        """Represent rotations as quaternions.
+        """Represent as quaternions.
 
         Rotations in 3 dimensions can be represented using unit norm
         quaternions [1]_. The mapping from quaternions to rotations is
@@ -550,7 +550,7 @@ class Rotation(object):
             return self._quat.copy()
 
     def as_dcm(self):
-        """Represent rotations as direction cosine matrices.
+        """Represent as direction cosine matrices.
 
         3D rotations can be represented using direction cosine matrices, which
         are 3 x 3 real orthogonal matrices with determinant equal to +1 [1]_.
@@ -604,7 +604,7 @@ class Rotation(object):
             return dcm
 
     def as_rotvec(self):
-        """Represent rotations as rotation vectors.
+        """Represent as rotation vectors.
 
         A rotation vector is a 3 dimensional vector which is co-directional to
         the axis of rotation and whose norm gives the angle of rotation (in
@@ -644,7 +644,7 @@ class Rotation(object):
             return rotvec
 
     def as_euler(self, seq, degrees=False):
-        """Compute Euler angles for rotations with specified axis sequence.
+        """Represent as Euler angles.
 
         Any orientation can be expressed as a composition of 3 elementary
         rotations. Once the axis sequence has been chosen, Euler angles define

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -192,8 +192,8 @@ class Rotation(object):
     Indexing within a rotation is supported since multiple rotation transforms
     can be stored within a single `Rotation` instance.
 
-    Initialization using the `from_...` classmethods such as `from_quat` is
-    recommended over using `__init__`.
+    To create `Rotation` objects use `from_...` classmethods, `__init__` is not
+    supposed to be used directly.
 
     Methods
     -------
@@ -282,11 +282,11 @@ class Rotation(object):
 
     @classmethod
     def from_dcm(cls, dcm):
-        """Initialize Rotation from direction cosine matrix.
+        """Initialize Rotation from direction cosine matrices.
 
         Rotations in 3 dimensions can be represented using 3 x 3 proper
-        orthogonal matrices [2]_. If the input is not proper orthogonal,
-        an approximation is created using the method described in [1]_.
+        orthogonal matrices [1]_. If the input is not proper orthogonal,
+        an approximation is created using the method described in [2]_.
 
         Parameters
         ----------
@@ -302,10 +302,10 @@ class Rotation(object):
 
         References
         ----------
-        .. [1] F. Landis Markley, `Unit Quaternion from Rotation Matrix
-               <https://arc.aiaa.org/doi/abs/10.2514/1.31730>`_
-        .. [2] `Direction Cosine Matrix
+        .. [1] `Direction Cosine Matrix
                 <https://en.wikipedia.org/wiki/Rotation_matrix#In_three_dimensions>`_
+        .. [2] F. Landis Markley, `Unit Quaternion from Rotation Matrix
+               <https://arc.aiaa.org/doi/abs/10.2514/1.31730>`_
         """
         is_single = False
         dcm = np.asarray(dcm, dtype=float)
@@ -355,7 +355,7 @@ class Rotation(object):
 
     @classmethod
     def from_rotvec(cls, rotvec):
-        """Initialize class from rotation vector.
+        """Initialize Rotation from rotation vectors.
 
         A rotation vector is a 3 dimensional vector which is co-directional to
         the axis of rotation and whose norm gives the angle of rotation (in
@@ -415,7 +415,7 @@ class Rotation(object):
 
     @classmethod
     def from_euler(cls, seq, angles, degrees=False):
-        """Initialize rotation from Euler angles.
+        """Initialize Rotation from Euler angles.
 
         Rotations in 3 dimensions can be represented by a sequece of 3
         rotations around a sequence of axes. In theory, any three axes spanning
@@ -553,7 +553,7 @@ class Rotation(object):
         """Represent rotations as direction cosine matrices.
 
         3D rotations can be represented using direction cosine matrices, which
-        are 3 x 3 real orthogonal matrices with eigenvalue equal to +1 [1]_.
+        are 3 x 3 real orthogonal matrices with determinant equal to +1 [1]_.
 
         Returns
         -------
@@ -646,19 +646,16 @@ class Rotation(object):
     def as_euler(self, seq, degrees=False):
         """Compute Euler angles for rotations with specified axis sequence.
 
-        Euler angles can be extracted for any set of 3 mutually perpendicular
-        axes. This paper [2]_ presents such a general algorithm for extracting
-        Euler angles from transformation matrices, as opposed to rotation
-        matrices. Thus, the matrix representation used in the paper is a
-        transpose of the direction cosine matrix representation given by the
-        `as_dcm` function.
+        Any orientation can be expressed as a composition of 3 elementary
+        rotations. Once the axis sequence has been chosen, Euler angles define
+        the angle of rotation around each respective axis [1]_.
 
-        The algorithm has been adapted to use rotation matrices and extended
-        to calculate Euler angles for intrinsic as well as extrinsic rotations.
+        The algorithm from [2]_ has been used to calculate Euler angles for the
+        rotation about a given sequence of axes.
 
         Euler angles suffer from the problem of gimbal lock [3]_, where the
         representation loses a degree of freedom and it is not possible to
-        represent the first and third angles uniquely. In this case,
+        determine the first and third angles uniquely. In this case,
         a warning is raised, and the third angle is set to zero. Note however
         that the returned angles still represent the correct rotation.
 
@@ -722,9 +719,7 @@ class Rotation(object):
         return angles[0] if self._single else angles
 
     def apply(self, vectors, inverse=False):
-        """Apply this rotation on a set of vectors.
-
-        Rotates `vectors` by the rotation(s) represented in the object.
+        """Apply this rotation to a set of vectors.
 
         If the original frame rotates to the final frame by this rotation, then
         its application to a vector can be seen in two ways:
@@ -752,7 +747,7 @@ class Rotation(object):
 
         Returns
         -------
-        outvecs : `numpy.ndarray`, shape (3,) or (N, 3)
+        rotated_vectors : `numpy.ndarray`, shape (3,) or (N, 3)
             Result of applying rotation on input vectors.
             Shape depends on the following cases:
 
@@ -811,7 +806,7 @@ class Rotation(object):
 
         Returns
         -------
-        rotation : `Rotation` instance
+        composition : `Rotation` instance
             This function supports composition of multiple rotations at a time.
             The following cases are possible:
 
@@ -838,11 +833,11 @@ class Rotation(object):
         """Invert this rotation.
 
         Composition of a rotation with its inverse results in an identity
-        rotation, or no rotation.
+        transformation.
 
         Returns
         -------
-        rotation : `Rotation` instance
+        inverse : `Rotation` instance
             Object containing inverse of the rotations in the current instance.
         """
         quat = self._quat.copy()
@@ -866,7 +861,7 @@ class Rotation(object):
         Returns
         -------
         rotation : `Rotation` instance
-            `output` contains
+            Contains
                 - a single rotation, if `indexer` is a single index
                 - a stack of rotation(s), if `indexer` is a slice, or and index
                   array.

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -6,12 +6,12 @@ import numpy as np
 import scipy.linalg
 
 
-AXIS_TO_IND = {'x': 0, 'y': 1, 'z': 2}
+_AXIS_TO_IND = {'x': 0, 'y': 1, 'z': 2}
 
 
 def _elementary_basis_vector(axis):
     b = np.zeros(3)
-    b[AXIS_TO_IND[axis]] = 1
+    b[_AXIS_TO_IND[axis]] = 1
     return b
 
 
@@ -60,8 +60,8 @@ def _compute_euler_from_dcm(dcm, seq, extrinsic=False):
     # Ensure less than unit norm
     positive_unity = dcm_transformed[:, 2, 2] > 1
     negative_unity = dcm_transformed[:, 2, 2] < -1
-    dcm_transformed[positive_unity, 2, 2] = 1.0
-    dcm_transformed[negative_unity, 2, 2] = -1.0
+    dcm_transformed[positive_unity, 2, 2] = 1
+    dcm_transformed[negative_unity, 2, 2] = -1
     angles[:, 1] = np.arccos(dcm_transformed[:, 2, 2])
 
     # Steps 5, 6
@@ -141,11 +141,10 @@ def _compute_euler_from_dcm(dcm, seq, extrinsic=False):
 
 
 def _make_elementary_quat(axis, angles):
-    num_rotations = angles.shape[0]
-    quat = np.zeros((num_rotations, 4))
+    quat = np.zeros((angles.shape[0], 4))
 
     quat[:, 3] = np.cos(angles / 2)
-    quat[:, AXIS_TO_IND[axis]] = np.sin(angles / 2)
+    quat[:, _AXIS_TO_IND[axis]] = np.sin(angles / 2)
     return quat
 
 

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -227,24 +227,21 @@ class Rotation(object):
 
         num_rotations = rotvec.shape[0]
 
-        norms = np.linalg.norm(rotvec, axis=1)
-        small_angle = norms <= 1e-3
-
-        quat = np.empty((num_rotations, 4))
 
         scale = np.empty(num_rotations)
 
-        small_angle = np.nonzero(np.logical_and(
-            norms <= 1e-3, norms != 0))[0]
+        norms = np.linalg.norm(rotvec, axis=1)
+        small_angle = np.nonzero(norms <= 1e-3)[0]
+        large_angle = np.nonzero(norms > 1e-3)[0]
+
         scale[small_angle] = (0.5 - norms[small_angle] ** 2 / 48 +
                               norms[small_angle] ** 4 / 3840)
-
-        large_angle = np.nonzero(norms > 1e-3)[0]
         scale[large_angle] = (np.sin(norms[large_angle] / 2) /
                               norms[large_angle])
 
+        quat = np.empty((num_rotations, 4))
         quat[:, :3] = scale[:, None] * rotvec
-        quat[:, 3] = np.cos(norms / 2).flatten()
+        quat[:, 3] = np.cos(norms / 2)
 
         if is_single:
             return cls(quat[0], normalized=True)

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -1,12 +1,56 @@
 from __future__ import division, print_function, absolute_import
 
+__all__ = ['Rotation']
+
 import numpy as np
+import scipy.linalg
 
 class Rotation(object):
     """Rotation in 3 dimensions.
 
     This class will include initializers from different representations, converters
     and some useful algorithms such as quaternion slerp and rotation estimation.
+
     """
-    def __init__(self):
-        pass
+    def __init__(self, quaternions):
+        """Initialize class from normalized quaternions.
+
+        Parameters
+        ----------
+        quaternions : (N, 4) numpy.array
+                      Each row is a unit-norm quaternion stored in scalar-last
+                      (x, y, z, w) format.
+
+        """
+        self._quat = quaternions
+
+    @classmethod
+    def from_quaternion(cls, quat):
+        """Initialize Rotation from possibly unnormalized quaternions
+
+        This classmethod normalizes the input quaternions and returns a
+        `Rotation` object.
+
+        Parameters
+        ----------
+        quat : (N, 4) or (4,) numpy.array
+               Each row is a (possibly non-unit norm) quaternion in scalar-last
+               (x, y, z, w) format.
+
+        """
+
+        # If a single quaternion is given, convert it to a 2D 1 x 4 matrix
+        if quat.shape == (4,):
+            quat = quat[None, :]
+
+        # Each row should have 4 numbers
+        assert(quat.shape[1] == 4)
+
+        # L2 norm of each row
+        norms = scipy.linalg.norm(quat, axis=1)
+
+        # Divide each row by its norm.
+        # In case quat is [4 x 4], ensure norm is broadcasted along each column
+        normalised_quat = quat / norms[:, None]
+
+        return cls(normalised_quat)

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -160,9 +160,9 @@ class Rotation(object):
 
         num_rotations = dcm.shape[0]
 
-        decision_matrix = np.zeros((num_rotations, 4))
+        decision_matrix = np.empty((num_rotations, 4))
         decision_matrix[:, :3] = dcm.diagonal(axis1=1, axis2=2)
-        decision_matrix[:, -1] = decision_matrix.sum(axis=1)
+        decision_matrix[:, -1] = decision_matrix[:, :3].sum(axis=1)
         choices = decision_matrix.argmax(axis=1)
 
         quat = np.empty((num_rotations, 4))
@@ -184,6 +184,7 @@ class Rotation(object):
         quat[ind, 3] = 1 + decision_matrix[ind, -1]
 
         if is_single:
-            return cls(quat[0])
+            return cls(quat[0] / np.linalg.norm(quat[0]), normalized=True)
         else:
-            return cls(quat)
+            return cls(quat / np.linalg.norm(quat, axis=1)[:, None],
+                    normalized=True)

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -191,6 +191,7 @@ class Rotation(object):
     as_rotvec
     from_euler
     as_euler
+    inv
     """
     def __init__(self, quat, normalized=False):
         self._single = False
@@ -616,3 +617,14 @@ class Rotation(object):
             angles = np.rad2deg(angles)
 
         return angles[0] if self._single else angles
+
+    def inv(self):
+        """Returns the inverse of the current rotation
+
+        This function returns a new `Rotation` instance containing the inverse
+        of all the rotations in the current instance.
+        """
+        quat = self._quat.copy()
+        # (x,y,z,w) -> (x,y,z,-w)
+        quat[:, -1] *= -1
+        return self.__class__(quat, normalized=True)

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -228,7 +228,7 @@ class Rotation(object):
             self._quat[~zero_norms] /= norms[~zero_norms][:, None]
 
     @classmethod
-    def from_quaternion(cls, quat, normalized=False):
+    def from_quaternion(cls, quat, normalized=False, copy=True):
         """Initialize Rotation from quaternions.
 
         This classmethod returns a `Rotation` object from the input quaternions
@@ -245,9 +245,13 @@ class Rotation(object):
             If this flag is `True`, then it is assumed that the input
             quaternions all have unit norm and are not normalized again.
             Default is False.
+        copy : boolean, optional
+            Specifies behaviour when `normalized = True`. If `copy = True`, a
+            copy of the input quaternions is stored in the object. If
+            `copy = False`, then the input itself is stored. Default is `True`.
         """
 
-        return cls(quat, normalized)
+        return cls(quat, normalized, copy)
 
     def as_quaternion(self):
         """Return the quaternion representation of the Rotation.
@@ -365,9 +369,9 @@ class Rotation(object):
         quat /= np.linalg.norm(quat, axis=1)[:, None]
 
         if is_single:
-            return cls(quat[0], normalized=True)
+            return cls(quat[0], normalized=True, copy=False)
         else:
-            return cls(quat, normalized=True)
+            return cls(quat, normalized=True, copy=False)
 
     @classmethod
     def from_rotvec(cls, rotvec):
@@ -415,9 +419,9 @@ class Rotation(object):
         quat[:, 3] = np.cos(norms / 2)
 
         if is_single:
-            return cls(quat[0], normalized=True)
+            return cls(quat[0], normalized=True, copy=False)
         else:
-            return cls(quat, normalized=True)
+            return cls(quat, normalized=True, copy=False)
 
     def as_rotvec(self):
         """Return the rotation vector representation of the Rotation.
@@ -549,7 +553,7 @@ class Rotation(object):
                              "num_axes), got {}.".format(angles.shape))
 
         quat = _elementary_quat_compose(seq, angles, intrinsic)
-        return cls(quat[0] if is_single else quat, normalized=True)
+        return cls(quat[0] if is_single else quat, normalized=True, copy=False)
 
     def as_euler(self, seq, degrees=False):
         """Return the Euler angles representation of the Rotation.
@@ -630,7 +634,7 @@ class Rotation(object):
         quat[:, -1] *= -1
         if self._single:
             quat = quat[0]
-        return self.__class__(quat, normalized=True)
+        return self.__class__(quat, normalized=True, copy=False)
 
     def __mul__(self, other):
         """Compose this rotation with the other.
@@ -658,7 +662,7 @@ class Rotation(object):
         result = _compose_quat(self._quat, other._quat)
         if self._single and other._single:
             result = result[0]
-        return self.__class__(result, normalized=True)
+        return self.__class__(result, normalized=True, copy=False)
 
     def apply(self, vectors, inverse=False):
         """Apply this rotation on a set of vectors.

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -75,18 +75,35 @@ def compute_euler_from_dcm(dcm, seq, extrinsic=False):
     angles[safe_mask, 2] = np.arctan2(dcm_transformed[safe_mask, 0, 2],
                                       dcm_transformed[safe_mask, 1, 2])
 
-    # 6a
-    angles[~safe_mask, 2] = 0
-    # 6b
-    angles[~safe1, 0] = np.arctan2(
-        dcm_transformed[~safe1, 0, 1] - dcm_transformed[~safe1, 1, 0],
-        dcm_transformed[~safe1, 0, 0] + dcm_transformed[~safe1, 1, 1]
-    )
-    # 6c
-    angles[~safe2, 0] = np.arctan2(
-        dcm_transformed[~safe2, 0, 1] + dcm_transformed[~safe2, 1, 0],
-        dcm_transformed[~safe2, 0, 0] - dcm_transformed[~safe2, 1, 1]
-    )
+    if extrinsic:
+        # For extrinsic, set first angle to zero so that after reversal we
+        # ensure that third angle is zero
+        # 6a
+        angles[~safe_mask, 0] = 0
+        # 6b
+        angles[~safe1, 2] = np.arctan2(
+            dcm_transformed[~safe1, 0, 1] - dcm_transformed[~safe1, 1, 0],
+            dcm_transformed[~safe1, 0, 0] + dcm_transformed[~safe1, 1, 1]
+        )
+        # 6c
+        angles[~safe2, 2] = -np.arctan2(
+            dcm_transformed[~safe2, 0, 1] + dcm_transformed[~safe2, 1, 0],
+            dcm_transformed[~safe2, 0, 0] - dcm_transformed[~safe2, 1, 1]
+        )
+    else:
+        # For instrinsic, set third angle to zero
+        # 6a
+        angles[~safe_mask, 2] = 0
+        # 6b
+        angles[~safe1, 0] = np.arctan2(
+            dcm_transformed[~safe1, 0, 1] - dcm_transformed[~safe1, 1, 0],
+            dcm_transformed[~safe1, 0, 0] + dcm_transformed[~safe1, 1, 1]
+        )
+        # 6c
+        angles[~safe2, 0] = np.arctan2(
+            dcm_transformed[~safe2, 0, 1] + dcm_transformed[~safe2, 1, 0],
+            dcm_transformed[~safe2, 0, 0] - dcm_transformed[~safe2, 1, 1]
+        )
 
     # Step 7
     if seq[0] == seq[2]:
@@ -108,14 +125,15 @@ def compute_euler_from_dcm(dcm, seq, extrinsic=False):
     angles[angles > np.pi] -= 2 * np.pi
 
     # Step 8
-    # TODO: if any observability flags are poor, possibly raise a UserWarning?
     if not np.all(safe_mask):
-        warnings.warn("Some angle sequences suffer from gimbal lock. In those "
-                      "cases, it is not possible to determine the angles "
-                      "uniquely.", UserWarning, stacklevel=1)
+        warnings.warn("Gimbal lock detected. Setting third angle to zero since"
+                      " it is not possible to uniquely determine all angles.")
 
-    # Reverse role of extrinsic and intrinsic rotations
-    return angles[:, ::-1] if extrinsic else angles
+    # Reverse role of extrinsic and intrinsic rotations, but let third angle be
+    # zero for gimbal locked cases
+    if extrinsic:
+        angles = angles[:, ::-1]
+    return angles
 
 
 def make_elementary_quat(axis, angles):

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -101,6 +101,10 @@ def compute_euler_from_dcm(dcm, seq, extrinsic=False):
         # lambda = + or - pi/2, so we can ensure angle2 -> [-pi/2, pi/2]
         adjust_mask = np.logical_or(angles[:, 1] < -np.pi / 2,
                                     angles[:, 1] > np.pi / 2)
+
+    # Dont adjust gimbal locked angle sequences
+    adjust_mask = np.logical_and(adjust_mask, safe_mask)
+
     angles[adjust_mask, 0] += np.pi
     angles[adjust_mask, 1] = 2 * offset - angles[adjust_mask, 1]
     angles[adjust_mask, 2] -= np.pi

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -5,7 +5,7 @@ import scipy.linalg
 import re
 
 
-_axis_to_ind = {'x': 0, 'y': 1, 'z': 2}
+AXIS_TO_IND = {'x': 0, 'y': 1, 'z': 2}
 
 
 def _make_elementary_quat(axis, angles):
@@ -13,7 +13,7 @@ def _make_elementary_quat(axis, angles):
     quat = np.zeros((num_rotations, 4))
 
     quat[:, 3] = np.cos(angles / 2)
-    quat[:, _axis_to_ind[axis]] = np.sin(angles / 2)
+    quat[:, AXIS_TO_IND[axis]] = np.sin(angles / 2)
     return quat
 
 
@@ -330,23 +330,23 @@ class Rotation(object):
         ----------
         seq : string
             Up to 3 characters belonging to the set {'X', 'Y', 'Z'} for
-            intrinsic rotations [1]_, or {'x', 'y', 'z'} for extrinsic
-            rotations [2]_. Extrinsic and intrinsic rotations cannot be mixed
+            intrinsic rotations, or {'x', 'y', 'z'} for extrinsic
+            rotations [1]_. Extrinsic and intrinsic rotations cannot be mixed
             in one function call.
-        angles : float or array_like, shape (N, ) or (N, [1 or 2 or 3])
+        angles : float or array_like, shape (N,) or (N, [1 or 2 or 3])
             Euler angles specified in radians (`degrees` is False) or degrees
             (`degrees` is True).
             For a single character `seq`, `angles` can be:
 
                 - a single value
-                - array_like with shape (N, ), where each `angle[i]`
+                - array_like with shape (N,), where each `angle[i]`
                   corresponds to a single rotation
                 - array_like with shape (N, 1), where each `angle[i, 0]`
                   corresponds to a single rotation
 
             For 2- and 3-character wide `seq`, `angles` can be:
 
-                - array_like with shape (W, ) where `W` is the width of
+                - array_like with shape (W,) where `W` is the width of
                   `seq`, which corresponds to a single rotation with `W` axes
                 - array_like with shape (N, W) where each `angle[i]`
                   corresponds to a sequence of Euler angles describing a single
@@ -358,12 +358,8 @@ class Rotation(object):
 
         References
         ----------
-        .. [1] `Intrinsic rotations
-                <https://en.wikipedia.org/wiki/Euler_angles
-                #Definition_by_intrinsic_rotations>`
-        .. [2] `Extrinsic rotations
-                <https://en.wikipedia.org/wiki/Euler_angles
-                #Definition_by_extrinsic_rotations>`
+        .. [1] `Euler angle definitions
+                <https://en.wikipedia.org/wiki/Euler_angles#Definition_by_intrinsic_rotations>`_
         """
         num_axes = len(seq)
         if num_axes < 1 or num_axes > 3:

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -1,9 +1,8 @@
 from __future__ import division, print_function, absolute_import
 
-__all__ = ['Rotation']
-
 import numpy as np
 import scipy.linalg
+import warnings
 
 class Rotation(object):
     """Rotation in 3 dimensions.
@@ -11,46 +10,65 @@ class Rotation(object):
     This class will include initializers from different representations, converters
     and some useful algorithms such as quaternion slerp and rotation estimation.
 
+    For initializing Rotations usage of `from_...` methods such as `from_quaternion`
+    is recommended instead of using `__init__`.
+
+    Methods
+    -------
+    from_quaternion
+
     """
-    def __init__(self, quaternions):
-        """Initialize class from normalized quaternions.
+    def __init__(self, quat, normalized=False):
+        self._single = False
+        # Try to convert to numpy array
+        quat = np.asarray(quat)
 
-        Parameters
-        ----------
-        quaternions : (N, 4) numpy.array
-                      Each row is a unit-norm quaternion stored in scalar-last
-                      (x, y, z, w) format.
+        # If a single quaternion is given, convert it to a 2D 1 x 4 matrix but
+        # set self._single to True so that we can return appropriate objects
+        # in the `to_...` methods
+        if quat.shape == (4,):
+            quat = quat[None, :]
+            self._single = True
 
-        """
-        self._quat = quaternions
+        # Each row should have 4 numbers
+        if quat.shape[1] != 4:
+            raise ValueError("A quaternion should have 4 numbers in (x,y,z,w) format")
+
+        normalized_quat = quat
+        if not normalized:
+            # L2 norm of each row
+            norms = scipy.linalg.norm(quat, axis=1)
+
+            # Warn user for zero (eps?) norm and set to identity quaternion, which
+            # is (0,0,0,1) in (x,y,z,w) format
+            bool_indices = norms == 0
+            if np.any(bool_indices == True):
+                warnings.warn("Found zero norm quaternions in input, replacing with identity quaternions")
+                quat[bool_indices] = np.array([0, 0, 0, 1])
+                norms[bool_indices] = 1.0
+
+            # Normalize each quaternion
+            # In case quat is [4 x 4], ensure norm is broadcasted along each column
+            normalised_quat = quat / norms[:, None]
+        self._quat = normalised_quat
 
     @classmethod
-    def from_quaternion(cls, quat):
-        """Initialize Rotation from possibly unnormalized quaternions
+    def from_quaternion(cls, quat, normalized=False):
+        """Initialize Rotation from possibly unnormalized quaternions.
 
         This classmethod normalizes the input quaternions and returns a
         `Rotation` object.
 
         Parameters
         ----------
-        quat : (N, 4) or (4,) numpy.array
+        quat : array_like, shape (N, 4) or (4,)
                Each row is a (possibly non-unit norm) quaternion in scalar-last
                (x, y, z, w) format.
 
+        normalized : boolean, optional, default = False
+                     If this flag is `True`, then it is assumed that the input
+                     quaternions all have unit norm and are not normalized again.
+
         """
 
-        # If a single quaternion is given, convert it to a 2D 1 x 4 matrix
-        if quat.shape == (4,):
-            quat = quat[None, :]
-
-        # Each row should have 4 numbers
-        assert(quat.shape[1] == 4)
-
-        # L2 norm of each row
-        norms = scipy.linalg.norm(quat, axis=1)
-
-        # Divide each row by its norm.
-        # In case quat is [4 x 4], ensure norm is broadcasted along each column
-        normalised_quat = quat / norms[:, None]
-
-        return cls(normalised_quat)
+        return cls(quat, normalized)

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -8,6 +8,94 @@ import re
 AXIS_TO_IND = {'x': 0, 'y': 1, 'z': 2}
 
 
+def _elementary_basis_vector(char):
+    b = np.zeros(3)
+    b[AXIS_TO_IND[char]] = 1
+    return b
+
+
+def _make_euler_from_dcm(dcm, seq, extrinsic=False):
+    # The algorithm assumes intrinsic frame transformations. Their
+    # ELEMENTARY dcms are transpose of what we return.
+    # Adapt the algorithm for our case by
+    # 1. Transposing our dcm representation
+    # 2. Reversing both axis sequence and angles for extrinsic rotations
+
+    seq = seq[::-1] if extrinsic else seq
+
+    if dcm.ndim == 2:
+        dcm = dcm[None, :, :]
+    num_rotations = dcm.shape[0]
+
+    # Step 0
+    # Algorithms dcms are transpose of ours
+    dcm = np.transpose(dcm, (0, 2, 1))
+    # Algorithm assumes axes as column vectors, here we use 1D vectors
+    n1 = _elementary_basis_vector(seq[0])
+    n2 = _elementary_basis_vector(seq[1])
+    n3 = _elementary_basis_vector(seq[2])
+
+    # Step 2
+    lamb = np.arctan2(np.dot(np.cross(n1, n2), n3), np.dot(n1, n3))
+    c = np.empty((3, 3))
+    c[0] = n2
+    c[1] = np.cross(n1, n2)
+    c[2] = n1
+
+    # Step 3
+    cl = np.cos(lamb)
+    sl = np.sin(lamb)
+    rt = np.array([
+        [1, 0, 0],
+        [0, cl, -sl],
+        [0, sl, cl]
+    ])
+    rtc = rt.dot(c)
+    ct = c.T
+    o = np.empty_like(dcm)
+    for ind in range(num_rotations):
+        o[ind] = rtc.dot(dcm[ind]).dot(ct)
+
+    # Step 4
+    angle2 = lamb + np.arccos(o[:, 2, 2])
+
+    # Steps 5, 6
+    eps = np.finfo(float).resolution  # ~1e-15
+    safe1 = (np.abs(angle2 - lamb) >= eps)
+    safe2 = (np.abs(angle2 - lamb - np.pi) >= eps)
+
+    angle1 = np.empty(num_rotations)
+    angle3 = np.empty(num_rotations)
+
+    # 5b
+    safe_mask = np.logical_and(safe1, safe2)
+    angle1[safe_mask] = np.arctan2(o[safe_mask, 2, 0], -o[safe_mask, 2, 1])
+    angle3[safe_mask] = np.arctan2(o[safe_mask, 0, 2], o[safe_mask, 1, 2])
+
+    # 6a
+    angle3[~safe_mask] = 0
+    # 6b
+    angle1[~safe1] = np.arctan2(o[~safe1, 0, 1] - o[~safe1, 1, 0],
+                                o[~safe1, 0, 0] + o[~safe1, 1, 1])
+    # 6c
+    angle1[~safe2] = np.arctan2(o[~safe2, 0, 1] + o[~safe2, 1, 0],
+                                o[~safe2, 0, 0] - o[~safe2, 1, 1])
+
+    # Step 7
+    # python modulo operator works correctly for negative numbers
+    adjust_mask = np.logical_or(angle2 < 0, angle2 > np.pi)
+    angle1[adjust_mask] = (angle1[adjust_mask] + np.pi) % (2 * np.pi)
+    angle2[adjust_mask] = (2 * lamb - angle2[adjust_mask]) % (2 * np.pi)
+    angle3[adjust_mask] = (angle3[adjust_mask] - np.pi) % (2 * np.pi)
+
+    # Step 8
+    # TODO: if any observability flags are poor, possibly raise a UserWarning?
+
+    # Reverse role of extrinsic and intrinsic rotations
+    return np.column_stack((angle3, angle2, angle1) if extrinsic else
+                           (angle1, angle2, angle3))
+
+
 def _make_elementary_quat(axis, angles):
     num_rotations = angles.shape[0]
     quat = np.zeros((num_rotations, 4))
@@ -419,3 +507,48 @@ class Rotation(object):
 
         quat = _elementary_quat_compose(seq, angles, intrinsic)
         return cls(quat[0] if is_single else quat, normalized=True)
+
+    def as_euler(self, seq, degrees=False):
+        """Return the Euler angles representation of the Rotation.
+
+        This function returns a numpy.ndarray of shape (N, 3) or (3,) depending
+        on how the object was initialized.
+
+        Parameters
+        ----------
+        seq : string, length 3
+            3 characters belonging to the set {'X', 'Y', 'Z'} for intrinsic
+            rotations, or {'x', 'y', 'z'} for extrinsic rotations [1]_.
+            Adjacent axes cannot be the same.
+            Extrinsic and intrinsic rotations cannot be mixed in one function
+            call.
+
+        degrees : boolean, optional
+            Returned angles are in degrees if this flag is True, else they are
+            in radians. Default is False.
+
+        References
+        ----------
+        .. [1] `Euler angle definitions
+                <https://en.wikipedia.org/wiki/Euler_angles#Definition_by_intrinsic_rotations>`_
+        """
+        if len(seq) != 3:
+            raise ValueError("Expected 3 axes, got {}.".format(seq))
+
+        intrinsic = (re.compile('^[XYZ]{1,3}$').match(seq) is not None)
+        extrinsic = (re.compile('^[xyz]{1,3}$').match(seq) is not None)
+        if not (intrinsic or extrinsic):
+            raise ValueError("Expected axes from `seq` to be from ['x', 'y', "
+                             "'z'] or ['X', 'Y', 'Z'], got {}".format(seq))
+
+        if any(seq[i] == seq[i+1] for i in range(2)):
+            raise ValueError("Expected consecutive axes to be different, "
+                             "got {}".format(seq))
+
+        seq = seq.lower()
+
+        angles = _make_euler_from_dcm(self.as_dcm(), seq, extrinsic)
+        if degrees:
+            angles = np.rad2deg(angles)
+
+        return angles[0] if self._single else angles

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -626,5 +626,8 @@ class Rotation(object):
         """
         quat = self._quat.copy()
         # (x,y,z,w) -> (x,y,z,-w)
-        quat[:, -1] *= -1
+        if self._single:
+            quat[-1] *= -1
+        else:
+            quat[:, -1] *= -1
         return self.__class__(quat, normalized=True)

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -552,6 +552,13 @@ class Rotation(object):
                 - [-90, 90] degrees if all axes are unique (like xyz)
                 - [0, 180] degrees if first and third axes are same (like zxz)
 
+        Euler angles suffer from the problem of gimbal lock. It occurs when,
+        during the course of the rotation, the initial axis of rotation
+        coincides with the final axis of rotation. As a result, two of the
+        three Euler angles cannot be determined uniquely. In those cases, this
+        function raises a warning. However, the rotation represented by the
+        object is still guaranteed to be correct.
+
         Parameters
         ----------
         seq : string, length 3

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -631,17 +631,17 @@ class Rotation(object):
         return self.__class__(quat, normalized=True)
 
     def __mul__(self, other):
-        """Returns the composition of the rotations.
+        """Compose this rotation with the other.
 
         If `p` and `q` are two rotations, then the composition of 'q followed
-        by p' is equivalent to `p * q`, which is the same as
-        `p.as_dcm().dot(q.as_dcm())`.
+        by p' is equivalent to `p * q`. In terms of DCMs, the composition can
+        be expressed as `p.as_dcm().dot(q.as_dcm())`.
 
         This function supports composition of multiple rotations at a time:
 
             - Either `p` or `q` contains a single rotation. In this case the
               returned object contains the result of composing each rotation in
-              the other object with the single rotation
+              the other object with the single rotation.
             - Both `p` and `q` contain `N` rotations. In this case each
               rotation `p[i]` is composed with each rotation `q[i]` and the
               returned object contains `N` rotations.

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -16,59 +16,60 @@ class Rotation(object):
     Methods
     -------
     from_quaternion
-
     """
     def __init__(self, quat, normalized=False):
         self._single = False
         # Try to convert to numpy array
-        quat = np.asarray(quat)
+        quat = np.asarray(quat, dtype=float)
+
+        if quat.ndim not in [1, 2]:
+            raise ValueError("Input quat should be of shape (4,) or (N x 4).")
 
         # If a single quaternion is given, convert it to a 2D 1 x 4 matrix but
         # set self._single to True so that we can return appropriate objects
         # in the `to_...` methods
-        if quat.shape == (4,):
+        if quat.ndim == 1:
             quat = quat[None, :]
             self._single = True
 
         # Each row should have 4 numbers
         if quat.shape[1] != 4:
-            raise ValueError("A quaternion should have 4 numbers in (x,y,z,w) format")
+            raise ValueError("A quaternion should have 4 numbers.")
 
-        normalized_quat = quat
+        self._quat = quat
+
         if not normalized:
             # L2 norm of each row
             norms = scipy.linalg.norm(quat, axis=1)
 
-            # Warn user for zero (eps?) norm and set to identity quaternion, which
-            # is (0,0,0,1) in (x,y,z,w) format
-            bool_indices = norms == 0
-            if np.any(bool_indices == True):
-                warnings.warn("Found zero norm quaternions in input, replacing with identity quaternions")
-                quat[bool_indices] = np.array([0, 0, 0, 1])
-                norms[bool_indices] = 1.0
-
-            # Normalize each quaternion
-            # In case quat is [4 x 4], ensure norm is broadcasted along each column
-            normalised_quat = quat / norms[:, None]
-        self._quat = normalised_quat
+            # Warn user for zero (eps?) norm and set to identity quaternion,
+            # which (0,0,0,1) in (x,y,z,w) format
+            zero_norms = norms == 0
+            if zero_norms.any():
+                warnings.warn("Found zero norm quaternions in input, replacing with identity quaternions.")
+                self._quat[zero_norms] = np.array([0, 0, 0, 1])
+            # Normalize each quaternion, ensuring norm is broadcasted along
+            # each column.
+            self._quat[~zero_norms] /= norms[~zero_norms][:, None]
 
     @classmethod
     def from_quaternion(cls, quat, normalized=False):
-        """Initialize Rotation from possibly unnormalized quaternions.
+        """Initialize Rotation from quaternions.
 
-        This classmethod normalizes the input quaternions and returns a
-        `Rotation` object.
+        This classmethod returns a `Rotation` object from the input quaternions.
+        If `normalized` is `True`, then the quaternions are assumed to have
+        unit norm, else the quaternions are normalized before the object is
+        created.
 
         Parameters
         ----------
         quat : array_like, shape (N, 4) or (4,)
-               Each row is a (possibly non-unit norm) quaternion in scalar-last
-               (x, y, z, w) format.
+            Each row is a (possibly non-unit norm) quaternion in scalar-last
+            (x, y, z, w) format.
 
-        normalized : boolean, optional, default = False
-                     If this flag is `True`, then it is assumed that the input
-                     quaternions all have unit norm and are not normalized again.
-
+        normalized : boolean, optional
+            If this flag is `True`, then it is assumed that the input quaternions
+            all have unit norm and are not normalized again. Default is False.
         """
 
         return cls(quat, normalized)

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -680,7 +680,7 @@ class Rotation(object):
               to the original frame.
             - As the physical rotation of a vector being glued to the original
               frame as it rotates. In this case the vector components are
-              expressed in the original frame before and after rotation.
+              expressed in the original frame before and after the rotation.
 
         In terms of DCMs, this application is the same as
         `self.as_dcm().dot(vectors)`.
@@ -692,11 +692,12 @@ class Rotation(object):
         Returns a `numpy.ndarray` of shape `(3,)` if object contains a single
         rotation (as opposed to a stack with a single rotation) and a single
         vector is specified with shape `(3,)`. In all other cases, the returned
-        array has shape `(N, 3)`.
+        array has shape `(N, 3)`, where `N` is either the number of rotations
+        or vectors.
 
         Parameters
         ----------
-        vectors : array_like, shape (3,) or (P, 3)
+        vectors : array_like, shape (3,) or (N, 3)
             Each `vectors[i]` represents a vector in 3D space. A single vector
             can either be specified with shape `(3, )` or `(1, 3)`.
         inverse : boolean, optional

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -60,8 +60,8 @@ def compute_euler_from_dcm(dcm, seq, extrinsic=False):
     rtc = rt.dot(c)
     ct = c.T
     o = np.empty_like(dcm)
-    for ind in range(num_rotations):
-        o[ind] = rtc.dot(dcm[ind]).dot(ct)
+    res = np.einsum('ij,...jk->...ik', rtc, dcm)
+    o = np.einsum('...ij,jk->...ik', res, ct)
 
     # Step 4
     angle2 = lamb + np.arccos(o[:, 2, 2])

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -210,6 +210,143 @@ class Rotation(object):
     __mul__
     inv
     __getitem__
+
+    Examples
+    --------
+    >>> from scipy.spatial.transform import Rotation as R
+
+    A `Rotation` instance can be initialized in any of the above formats and
+    converted to any of the others. The underlying object is independent of the
+    representation used for initialization.
+
+    Consider a counter-clockwise rotation of 90 degrees about the z-axis. This
+    corresponds to the following quaternion (in scalar-last format):
+
+    >>> r = R.from_quat([0, 0, np.sin(np.pi/4), np.cos(np.pi/4)])
+
+    The rotation can be expressed in any of the other formats:
+
+    >>> r.as_dcm()
+    array([[ 2.22044605e-16, -1.00000000e+00,  0.00000000e+00],
+    [ 1.00000000e+00,  2.22044605e-16,  0.00000000e+00],
+    [ 0.00000000e+00,  0.00000000e+00,  1.00000000e+00]])
+    >>> r.as_rotvec()
+    array([0.        , 0.        , 1.57079633])
+    >>> r.as_euler('zyx', degrees=True)
+    array([90.,  0.,  0.])
+
+    The same rotation can be initialized using a direction cosine matrix:
+
+    >>> r = R.from_dcm(np.array([
+    ... [0, -1, 0],
+    ... [1, 0, 0],
+    ... [0, 0, 1]]))
+
+    Representation in other formats:
+
+    >>> r.as_quat()
+    array([0.        , 0.        , 0.70710678, 0.70710678])
+    >>> r.as_rotvec()
+    array([0.        , 0.        , 1.57079633])
+    >>> r.as_euler('zyx', degrees=True)
+    array([90.,  0.,  0.])
+
+    The rotation vector corresponding to this rotation is given by:
+
+    >>> r = R.from_rotvec(np.pi/2 * np.array([0, 0, 1]))
+
+    Representation in other formats:
+
+    >>> r.as_quat()
+    array([0.        , 0.        , 0.70710678, 0.70710678])
+    >>> r.as_dcm()
+    array([[ 2.22044605e-16, -1.00000000e+00,  0.00000000e+00],
+           [ 1.00000000e+00,  2.22044605e-16,  0.00000000e+00],
+           [ 0.00000000e+00,  0.00000000e+00,  1.00000000e+00]])
+    >>> r.as_euler('zyx', degrees=True)
+    array([90.,  0.,  0.])
+
+    The `from_euler` function is quite flexible in the range of input formats
+    it supports. Here we initialize a single rotation about a single axis:
+
+    >>> r = R.from_euler('z', 90, degrees=True)
+
+    Again, the object is representation independent and can be converted to any
+    other format:
+
+    >>> r.as_quat()
+    array([0.        , 0.        , 0.70710678, 0.70710678])
+    >>> r.as_dcm()
+    array([[ 2.22044605e-16, -1.00000000e+00,  0.00000000e+00],
+           [ 1.00000000e+00,  2.22044605e-16,  0.00000000e+00],
+           [ 0.00000000e+00,  0.00000000e+00,  1.00000000e+00]])
+    >>> r.as_rotvec()
+    array([0.        , 0.        , 1.57079633])
+
+    It is also possible to initialize multiple rotations in a single instance
+    using any of the `from_...` functions. Here we initialize a stack of 3
+    rotations using the `from_euler` function:
+
+    >>> r = R.from_euler('zyx', [
+    ... [90, 0, 0],
+    ... [0, 45, 0],
+    ... [45, 60, 30]], degrees=True)
+
+    The other representations also now return a stack of 3 rotations. For
+    example:
+
+    >>> r.as_quat()
+    array([[0.        , 0.        , 0.70710678, 0.70710678],
+           [0.        , 0.38268343, 0.        , 0.92387953],
+           [0.39190384, 0.36042341, 0.43967974, 0.72331741]])
+
+    Applying the above rotations onto a vector:
+
+    >>> v = [1, 2, 3]
+    >>> r.apply(v)
+    array([[-2.        ,  1.        ,  3.        ],
+           [ 2.82842712,  2.        ,  1.41421356],
+           [ 2.24452282,  0.78093109,  2.89002836]])
+
+    A `Rotation` instance can be indexed and sliced as if it were a single
+    1D array or list:
+
+    >>> r.as_quat()
+    array([[0.        , 0.        , 0.70710678, 0.70710678],
+           [0.        , 0.38268343, 0.        , 0.92387953],
+           [0.39190384, 0.36042341, 0.43967974, 0.72331741]])
+    >>> p = r[0]
+    >>> p.as_dcm()
+    array([[ 2.22044605e-16, -1.00000000e+00,  0.00000000e+00],
+           [ 1.00000000e+00,  2.22044605e-16,  0.00000000e+00],
+           [ 0.00000000e+00,  0.00000000e+00,  1.00000000e+00]])
+    >>> q = r[1:3]
+    >>> q.as_quat()
+    array([[0.        , 0.38268343, 0.        , 0.92387953],
+           [0.39190384, 0.36042341, 0.43967974, 0.72331741]])
+
+    Multiple rotations can be composed using the `*` operator:
+
+    >>> r1 = R.from_euler('z', 90, degrees=True)
+    >>> r2 = R.from_rotvec([np.pi/4, 0, 0])
+    >>> v = [1, 2, 3]
+    >>> r2.apply(r1.apply(v))
+    array([-2.        , -1.41421356,  2.82842712])
+    >>> r3 = r2 * r1 # Note the order
+    >>> r3.apply(v)
+    array([-2.        , -1.41421356,  2.82842712])
+
+    Finally, it is also possible to invert rotations:
+
+    >>> r1 = R.from_euler('z', [90, 45], degrees=True)
+    >>> r2 = r.inv()
+    >>> r2.as_euler('zyx', degrees=True)
+    array([[-90.,   0.,   0.],
+           [-45.,   0.,   0.]])
+
+    These examples serve as an overview into the `Rotation` class and highlight
+    major functionalities. For more thorough examples of the range of input and
+    output formats supported, consult the individual method's examples.
     """
     def __init__(self, quat, normalized=False, copy=True):
         self._single = False
@@ -276,6 +413,50 @@ class Rotation(object):
         ----------
         .. [1] `Quaternions and Spatial Rotation
                <https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation>`_
+
+        Examples
+        --------
+        >>> from scipy.spatial.transform import Rotation as R
+
+        Initialize a single rotation:
+
+        >>> r = R.from_quat([1, 0, 0, 0])
+        >>> r.as_quat()
+        array([1., 0., 0., 0.])
+        >>> r.as_quat().shape
+        (4,)
+
+        Initialize multiple rotations in a single object:
+
+        >>> r = R.from_quat([
+        ... [1, 0, 0, 0],
+        ... [0, 0, 0, 1]
+        ... ])
+        >>> r.as_quat()
+        array([[1., 0., 0., 0.],
+               [0., 0., 0., 1.]])
+        >>> r.as_quat().shape
+        (2, 4)
+
+        It is also possible to have a stack of a single rotation:
+
+        >>> r = R.from_quat([[0, 0, 0, 1]])
+        >>> r.as_quat()
+        array([[0., 0., 0., 1.]])
+        >>> r.as_quat().shape
+        (1, 4)
+
+        By default, quaternions are normalized before initialization.
+
+        >>> r = R.from_quat([0, 0, 1, 1])
+        >>> r.as_quat()
+        array([0.        , 0.        , 0.70710678, 0.70710678])
+
+        If unit norms are ensured, skip the normalization step.
+
+        >>> r = R.from_quat([0, 0, 1, 0], normalized=True)
+        >>> r.as_quat()
+        array([0., 0., 1., 0.])
         """
 
         return cls(quat, normalized)
@@ -306,6 +487,65 @@ class Rotation(object):
                 <https://en.wikipedia.org/wiki/Rotation_matrix#In_three_dimensions>`_
         .. [2] F. Landis Markley, `Unit Quaternion from Rotation Matrix
                <https://arc.aiaa.org/doi/abs/10.2514/1.31730>`_
+
+        Examples
+        --------
+        >>> from scipy.spatial.transform import Rotation as R
+
+        Initialize a single rotation:
+
+        >>> r = R.from_dcm([
+        ... [0, -1, 0],
+        ... [1, 0, 0],
+        ... [0, 0, 1]])
+        >>> r.as_dcm().shape
+        (3, 3)
+
+        Initialize multiple rotations in a single object:
+
+        >>> r = R.from_dcm([
+        ... [
+        ...     [0, -1, 0],
+        ...     [1, 0, 0],
+        ...     [0, 0, 1],
+        ... ],
+        ... [
+        ...     [1, 0, 0],
+        ...     [0, 0, -1],
+        ...     [0, 1, 0],
+        ... ]])
+        >>> r.as_dcm().shape
+        (2, 3, 3)
+
+        If input matrices are not special orthogonal (orthogonal with
+        determinant equal to +1), then a special orthogonal estimate is stored:
+
+        >>> a = np.array([
+        ... [0, -0.5, 0],
+        ... [0.5, 0, 0],
+        ... [0, 0, 0.5]])
+        >>> np.linalg.det(a)
+        0.12500000000000003
+        >>> dcm = r.as_dcm()
+        >>> dcm
+        array([[-0.38461538, -0.92307692,  0.        ],
+               [ 0.92307692, -0.38461538,  0.        ],
+               [ 0.        ,  0.        ,  1.        ]])
+        >>> np.linalg.det(dcm)
+        1.0000000000000002
+
+        It is also possible to have a stack containing a single rotation:
+
+        >>> r = R.from_dcm([[
+        ... [0, -1, 0],
+        ... [1, 0, 0],
+        ... [0, 0, 1]]])
+        >>> r.as_dcm()
+        array([[[ 0., -1.,  0.],
+                [ 1.,  0.,  0.],
+                [ 0.,  0.,  1.]]])
+        >>> r.as_dcm().shape
+        (1, 3, 3)
         """
         is_single = False
         dcm = np.asarray(dcm, dtype=float)
@@ -377,6 +617,35 @@ class Rotation(object):
         ----------
         .. [1] `Rotation Vectors
                 <https://en.wikipedia.org/wiki/Axis%E2%80%93angle_representation#Rotation_vector>`_
+
+        Examples
+        --------
+        >>> from scipy.spatial.transform import Rotation as R
+
+        Initialize a single rotation:
+
+        >>> r = R.from_rotvec(np.pi/2 * np.array([0, 0, 1]))
+        >>> r.as_rotvec()
+        array([0.        , 0.        , 1.57079633])
+        >>> r.as_rotvec().shape
+        (3,)
+
+        Initialize multiple rotations in one object:
+
+        >>> r = R.from_rotvec([
+        ... [0, 0, np.pi/2],
+        ... [np.pi/2, 0, 0]])
+        >>> r.as_rotvec()
+        array([[0.        , 0.        , 1.57079633],
+               [1.57079633, 0.        , 0.        ]])
+        >>> r.as_rotvec().shape
+        (2, 3)
+
+        It is also possible to have a stack of a single rotaton:
+
+        >>> r = R.from_rotvec([[0, 0, np.pi/2]])
+        >>> r.as_rotvec().shape
+        (1, 3)
         """
         is_single = False
         rotvec = np.asarray(rotvec, dtype=float)
@@ -466,6 +735,46 @@ class Rotation(object):
         ----------
         .. [1] `Euler angle definitions
                 <https://en.wikipedia.org/wiki/Euler_angles#Definition_by_intrinsic_rotations>`_
+
+        Examples
+        --------
+        >>> from scipy.spatial.transform import Rotation as R
+
+        Initialize a single rotation along a single axis:
+
+        >>> r = R.from_euler('x', 90, degrees=True)
+        >>> r.as_quat().shape
+        (4,)
+
+        Initialize a single rotation with a given axis sequence:
+
+        >>> r = R.from_euler('zyx', [90, 45, 30], degrees=True)
+        >>> r.as_quat().shape
+        (4,)
+
+        Initialize a stack with a single rotation around a single axis:
+
+        >>> r = R.from_euler('x', [90], degrees=True)
+        >>> r.as_quat().shape
+        (1, 4)
+
+        Initialize a stack with a single rotation with an axis sequence:
+
+        >>> r = R.from_euler('zyx', [[90, 45, 30]], degrees=True)
+        >>> r.as_quat().shape
+        (1, 4)
+
+        Initialize multiple elementary rotations in one object:
+
+        >>> r = R.from_euler('x', [90, 45, 30], degrees=True)
+        >>> r.as_quat().shape
+        (3, 4)
+
+        Initialize multiple rotations in one object:
+
+        >>> r = R.from_euler('zyx', [[90, 45, 30], [35, 45, 90]], degrees=True)
+        >>> r.as_quat().shape
+        (2, 4)
         """
         num_axes = len(seq)
         if num_axes < 1 or num_axes > 3:
@@ -543,6 +852,33 @@ class Rotation(object):
         ----------
         .. [1] `Quaternions and Spatial Rotation
                <https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation>`_
+
+        Examples
+        --------
+        >>> from scipy.spatial.transform import Rotation as R
+
+        Represent a single rotation:
+
+        >>> r = R.from_dcm([
+        ... [0, -1, 0],
+        ... [1, 0, 0],
+        ... [0, 0, 1]])
+        >>> r.as_quat()
+        array([0.        , 0.        , 0.70710678, 0.70710678])
+        >>> r.as_quat().shape
+        (4,)
+
+        Represent a stack with a single rotation:
+
+        >>> r = R.from_quat([[0, 0, 0, 1]])
+        >>> r.as_quat().shape
+        (1, 4)
+
+        Represent multiple rotaions in a single object:
+
+        >>> r = R.from_rotvec([[np.pi, 0, 0], [0, 0, np.pi/2]])
+        >>> r.as_quat().shape
+        (2, 4)
         """
         if self._single:
             return self._quat[0].copy()
@@ -564,6 +900,43 @@ class Rotation(object):
         ----------
         .. [1] `Direction Cosine Matrix
                 <https://en.wikipedia.org/wiki/Rotation_matrix#In_three_dimensions>`_
+
+        Examples
+        --------
+        >>> from scipy.spatial.transform import Rotation as R
+
+        Represent a single rotation:
+
+        >>> r = R.from_rotvec([0, 0, np.pi/2])
+        >>> r.as_dcm()
+        array([[ 2.22044605e-16, -1.00000000e+00,  0.00000000e+00],
+               [ 1.00000000e+00,  2.22044605e-16,  0.00000000e+00],
+               [ 0.00000000e+00,  0.00000000e+00,  1.00000000e+00]])
+        >>> r.as_dcm().shape
+        (3, 3)
+
+        Represent a stack with a single rotation:
+
+        >>> r = R.from_quat([[1, 1, 0, 0]])
+        >>> r.as_dcm()
+        array([[[ 0.,  1.,  0.],
+                [ 1.,  0.,  0.],
+                [ 0.,  0., -1.]]])
+        >>> r.as_dcm().shape
+        (1, 3, 3)
+
+        Represent multiple rotations:
+
+        >>> r = R.from_rotvec([[np.pi/2, 0, 0], [0, 0, np.pi/2]])
+        >>> r.as_dcm()
+        array([[[ 1.00000000e+00,  0.00000000e+00,  0.00000000e+00],
+                [ 0.00000000e+00,  2.22044605e-16, -1.00000000e+00],
+                [ 0.00000000e+00,  1.00000000e+00,  2.22044605e-16]],
+               [[ 2.22044605e-16, -1.00000000e+00,  0.00000000e+00],
+                [ 1.00000000e+00,  2.22044605e-16,  0.00000000e+00],
+                [ 0.00000000e+00,  0.00000000e+00,  1.00000000e+00]]])
+        >>> r.as_dcm().shape
+        (2, 3, 3)
         """
 
         x = self._quat[:, 0]
@@ -619,6 +992,35 @@ class Rotation(object):
         ----------
         .. [1] `Rotation Vectors
                 <https://en.wikipedia.org/wiki/Axis%E2%80%93angle_representation#Rotation_vector>`_
+
+        Examples
+        --------
+        >>> from scipy.spatial.transform import Rotation as R
+
+        Represent a single rotation:
+
+        >>> r = R.from_euler('z', 90, degrees=True)
+        >>> r.as_rotvec()
+        array([0.        , 0.        , 1.57079633])
+        >>> r.as_rotvec().shape
+        (3,)
+
+        Represent a stack with a single rotation:
+
+        >>> r = R.from_quat([[0, 0, 1, 1]])
+        >>> r.as_rotvec()
+        array([[0.        , 0.        , 1.57079633]])
+        >>> r.as_rotvec().shape
+        (1, 3)
+
+        Represent multiple rotations in a single object:
+
+        >>> r = R.from_quat([[0, 0, 1, 1], [1, 1, 0, 1]])
+        >>> r.as_rotvec()
+        array([[0.        , 0.        , 1.57079633],
+               [1.35102172, 1.35102172, 0.        ]])
+        >>> r.as_rotvec().shape
+        (2, 3)
         """
         quat = self._quat.copy()
         # w > 0 to ensure 0 <= angle <= pi
@@ -695,6 +1097,39 @@ class Rotation(object):
                 <https://arc.aiaa.org/doi/abs/10.2514/1.16622>`_
         .. [3] `Gimbal lock
                 <https://en.wikipedia.org/wiki/Gimbal_lock#In_applied_mathematics>`_
+
+        Examples
+        --------
+        >>> from scipy.spatial.transform import Rotation as R
+
+        Represent a single rotation:
+
+        >>> r = R.from_rotvec([0, 0, np.pi/2])
+        >>> r.as_euler('zxy', degrees=True)
+        array([90.,  0.,  0.])
+        >>> r.as_euler('zxy', degrees=True).shape
+        (3,)
+
+        Represent a stack of single rotation:
+
+        >>> r = R.from_rotvec([[0, 0, np.pi/2]])
+        >>> r.as_euler('zxy', degrees=True)
+        array([[90.,  0.,  0.]])
+        >>> r.as_euler('zxy', degrees=True).shape
+        (1, 3)
+
+        Represent multiple rotations in a single object:
+
+        >>> r = R.from_rotvec([
+        ... [0, 0, np.pi/2],
+        ... [0, -np.pi/3, 0],
+        ... [np.pi/4, 0, 0]])
+        >>> r.as_euler('zxy', degrees=True)
+        array([[ 90.,   0.,   0.],
+               [  0.,   0., -60.],
+               [  0.,  45.,   0.]])
+        >>> r.as_euler('zxy', degrees=True).shape
+        (3, 3)
         """
         if len(seq) != 3:
             raise ValueError("Expected 3 axes, got {}.".format(seq))
@@ -756,6 +1191,84 @@ class Rotation(object):
                   shape `(3,)`, then `output` has shape `(3,)`.
                 - In all other cases, `output` has shape `(N, 3)`, where `N` is
                   either the number of rotations or vectors.
+
+        Examples
+        --------
+        >>> from scipy.spatial.transform import Rotation as R
+
+        Single rotation applied on a single vector:
+
+        >>> vector = np.array([1, 0, 0])
+        >>> r = R.from_rotvec([0, 0, np.pi/2])
+        >>> r.as_dcm()
+        array([[ 2.22044605e-16, -1.00000000e+00,  0.00000000e+00],
+               [ 1.00000000e+00,  2.22044605e-16,  0.00000000e+00],
+               [ 0.00000000e+00,  0.00000000e+00,  1.00000000e+00]])
+        >>> r.apply(vector)
+        array([2.22044605e-16, 1.00000000e+00, 0.00000000e+00])
+        >>> r.apply(vector).shape
+        (3,)
+
+        Single rotation applied on multiple vectors:
+
+        >>> vectors = np.array([
+        ... [1, 0, 0],
+        ... [1, 2, 3]])
+        >>> r = R.from_rotvec([0, 0, np.pi/4])
+        >>> r.as_dcm()
+        array([[ 0.70710678, -0.70710678,  0.        ],
+               [ 0.70710678,  0.70710678,  0.        ],
+               [ 0.        ,  0.        ,  1.        ]])
+        >>> r.apply(vectors)
+        array([[ 0.70710678,  0.70710678,  0.        ],
+               [-0.70710678,  2.12132034,  3.        ]])
+        >>> r.apply(vectors).shape
+        (2, 3)
+
+        Multiple rotations on a single vector:
+
+        >>> r = R.from_rotvec([[0, 0, np.pi/4], [np.pi/2, 0, 0]])
+        >>> vector = np.array([1,2,3])
+        >>> r.as_dcm()
+        array([[[ 7.07106781e-01, -7.07106781e-01,  0.00000000e+00],
+                [ 7.07106781e-01,  7.07106781e-01,  0.00000000e+00],
+                [ 0.00000000e+00,  0.00000000e+00,  1.00000000e+00]],
+
+               [[ 1.00000000e+00,  0.00000000e+00,  0.00000000e+00],
+                [ 0.00000000e+00,  2.22044605e-16, -1.00000000e+00],
+                [ 0.00000000e+00,  1.00000000e+00,  2.22044605e-16]]])
+        >>> r.apply(vector)
+        array([[-0.70710678,  2.12132034,  3.        ],
+               [ 1.        , -3.        ,  2.        ]])
+        >>> r.apply(vector).shape
+        (2, 3)
+
+        Multiple rotations on multiple vectors. Each rotation is applied on the
+        corresponding vector:
+
+        >>> r = R.from_euler('zxy', [
+        ... [0, 0, 90],
+        ... [45, 30, 60]], degrees=True)
+        >>> vectors = [
+        ... [1, 2, 3],
+        ... [1, 0, -1]]
+        >>> r.apply(vectors)
+        array([[ 3.        ,  2.        , -1.        ],
+               [-0.09026039,  1.11237244, -0.86860844]])
+        >>> r.apply(vectors).shape
+        (2, 3)
+
+        It is also possible to apply the inverse rotation:
+
+        >>> r = R.from_euler('zxy', [
+        ... [0, 0, 90],
+        ... [45, 30, 60]], degrees=True)
+        >>> vectors = [
+        ... [1, 2, 3],
+        ... [1, 0, -1]]
+        >>> r.apply(vectors, inverse=True)
+        array([[-3.        ,  2.        ,  1.        ],
+               [ 1.09533535, -0.8365163 ,  0.3169873 ]])
         """
         vectors = np.asarray(vectors)
         if vectors.ndim > 2 or vectors.shape[-1] != 3:
@@ -816,6 +1329,43 @@ class Rotation(object):
             - Both `p` and `q` contain `N` rotations. In this case each
               rotation `p[i]` is composed with the corresponding rotation
               `q[i]` and `output` contains `N` rotations.
+
+        Examples
+        --------
+        >>> from scipy.spatial.transform import Rotation as R
+
+        Composition of two single rotations:
+
+        >>> p = R.from_quat([0, 0, 1, 1])
+        >>> q = R.from_quat([1, 0, 0, 1])
+        >>> p.as_dcm()
+        array([[ 0., -1.,  0.],
+               [ 1.,  0.,  0.],
+               [ 0.,  0.,  1.]])
+        >>> q.as_dcm()
+        array([[ 1.,  0.,  0.],
+               [ 0.,  0., -1.],
+               [ 0.,  1.,  0.]])
+        >>> r = p * q
+        >>> r.as_dcm()
+        array([[0., 0., 1.],
+               [1., 0., 0.],
+               [0., 1., 0.]])
+
+        Composition of two objects containing equal number of rotations:
+
+        >>> p = R.from_quat([[0, 0, 1, 1], [1, 0, 0, 1]])
+        >>> q = R.from_rotvec([[np.pi/4, 0, 0], [-np.pi/4, 0, np.pi/4]])
+        >>> p.as_quat()
+        array([[0.        , 0.        , 0.70710678, 0.70710678],
+               [0.70710678, 0.        , 0.        , 0.70710678]])
+        >>> q.as_quat()
+        array([[ 0.38268343,  0.        ,  0.        ,  0.92387953],
+               [-0.37282173,  0.        ,  0.37282173,  0.84971049]])
+        >>> r = p * q
+        >>> r.as_quat()
+        array([[ 0.27059805,  0.27059805,  0.65328148,  0.65328148],
+               [ 0.33721128, -0.26362477,  0.26362477,  0.86446082]])
         """
         if not(len(self) == 1 or len(other) == 1 or len(self) == len(other)):
             raise ValueError("Expected equal number of rotations in both "
@@ -838,6 +1388,25 @@ class Rotation(object):
         -------
         inverse : `Rotation` instance
             Object containing inverse of the rotations in the current instance.
+
+        Examples
+        --------
+        >>> from scipy.spatial.transform import Rotation as R
+
+        Inverting a single rotation:
+
+        >>> p = R.from_euler('z', 45, degrees=True)
+        >>> q = p.inv()
+        >>> q.as_euler('zyx', degrees=True)
+        array([-45.,   0.,   0.])
+
+        Inverting multiple rotations:
+
+        >>> p = R.from_rotvec([[0, 0, np.pi/3], [-np.pi/4, 0, 0]])
+        >>> q = p.inv()
+        >>> q.as_rotvec()
+        array([[-0.        , -0.        , -1.04719755],
+               [ 0.78539816, -0.        , -0.        ]])
         """
         quat = self._quat.copy()
         quat[:, -1] *= -1
@@ -864,5 +1433,30 @@ class Rotation(object):
                 - a single rotation, if `indexer` is a single index
                 - a stack of rotation(s), if `indexer` is a slice, or and index
                   array.
+
+        Examples
+        --------
+        >>> from scipy.spatial.transform import Rotation as R
+        >>> r = R.from_quat([
+        ... [1, 1, 0, 0],
+        ... [0, 1, 0, 1],
+        ... [1, 1, -1, 0]])
+        >>> r.as_quat()
+        array([[ 0.70710678,  0.70710678,  0.        ,  0.        ],
+               [ 0.        ,  0.70710678,  0.        ,  0.70710678],
+               [ 0.57735027,  0.57735027, -0.57735027,  0.        ]])
+
+        Indexing using a single index:
+
+        >>> p = r[0]
+        >>> p.as_quat()
+        array([0.70710678, 0.70710678, 0.        , 0.        ])
+
+        Array slicing:
+
+        >>> q = r[1:3]
+        >>> q.as_quat()
+        array([[ 0.        ,  0.70710678,  0.        ,  0.70710678],
+               [ 0.57735027,  0.57735027, -0.57735027,  0.        ]])
         """
         return self.__class__(self._quat[indexer], normalized=True)

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -310,7 +310,7 @@ class Rotation(object):
         is_single = False
         dcm = np.asarray(dcm, dtype=float)
 
-        if dcm.ndim not in [2, 3] or (dcm.shape[-2], dcm.shape[-1]) != (3, 3):
+        if dcm.ndim not in [2, 3] or dcm.shape[-2:] != (3, 3):
             raise ValueError("Expected `dcm` to have shape (3, 3) or "
                              "(N, 3, 3), got {}".format(dcm.shape))
 
@@ -472,8 +472,8 @@ class Rotation(object):
             raise ValueError("Expected axis specification to be a non-empty "
                              "string of upto 3 characters, got {}".format(seq))
 
-        intrinsic = (re.compile('^[XYZ]{1,3}$').match(seq) is not None)
-        extrinsic = (re.compile('^[xyz]{1,3}$').match(seq) is not None)
+        intrinsic = (re.match(r'^[XYZ]{1,3}$', seq) is not None)
+        extrinsic = (re.match(r'^[xyz]{1,3}$', seq) is not None)
         if not (intrinsic or extrinsic):
             raise ValueError("Expected axes from `seq` to be from ['x', 'y', "
                              "'z'] or ['X', 'Y', 'Z'], got {}".format(seq))
@@ -583,7 +583,7 @@ class Rotation(object):
         yz = y * z
         xw = x * w
 
-        num_rotations = self._quat.shape[0]
+        num_rotations = len(self)
         dcm = np.empty((num_rotations, 3, 3))
 
         dcm[:, 0, 0] = x2 - y2 - z2 + w2
@@ -629,7 +629,7 @@ class Rotation(object):
         small_angle = (angle <= 1e-3)
         large_angle = ~small_angle
 
-        num_rotations = quat.shape[0]
+        num_rotations = len(self)
         scale = np.empty(num_rotations)
         scale[small_angle] = (2 + angle[small_angle] ** 2 / 12 +
                               7 * angle[small_angle] ** 4 / 2880)
@@ -699,8 +699,8 @@ class Rotation(object):
         if len(seq) != 3:
             raise ValueError("Expected 3 axes, got {}.".format(seq))
 
-        intrinsic = (re.compile('^[XYZ]{1,3}$').match(seq) is not None)
-        extrinsic = (re.compile('^[xyz]{1,3}$').match(seq) is not None)
+        intrinsic = (re.match(r'^[XYZ]{1,3}$', seq) is not None)
+        extrinsic = (re.match(r'^[xyz]{1,3}$', seq) is not None)
         if not (intrinsic or extrinsic):
             raise ValueError("Expected axes from `seq` to be from "
                              "['x', 'y', 'z'] or ['X', 'Y', 'Z'], "
@@ -817,13 +817,12 @@ class Rotation(object):
               rotation `p[i]` is composed with the corresponding rotation
               `q[i]` and `output` contains `N` rotations.
         """
-        if not(self._quat.shape[0] == 1 or other._quat.shape[0] == 1 or
-               self._quat.shape[0] == other._quat.shape[0]):
+        if not(len(self) == 1 or len(other) == 1 or len(self) == len(other)):
             raise ValueError("Expected equal number of rotations in both "
                              "or a single rotation in either object, "
                              "got {} rotations in first and {} rotations in "
                              "second object.".format(
-                                self._quat.shape[0], other._quat.shape[0]))
+                                len(self), len(other)))
         result = _compose_quat(self._quat, other._quat)
         if self._single and other._single:
             result = result[0]

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -72,3 +72,14 @@ class Rotation(object):
         """
 
         return cls(quat, normalized)
+
+    def as_quaternion(self):
+        """Return the quaternion representation of the Rotation.
+
+        This function returns a numpy array of shape (4,) or (N x 4) depending
+        on the input that was used to initialize the object.
+        """
+        if self._single:
+            return self._quat[0]
+        else:
+            return self._quat

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -213,7 +213,7 @@ class Rotation(object):
 
         if normalized:
             self._quat = quat.copy() if copy else quat
-        if not normalized:
+        else:
             self._quat = quat.copy()
             # L2 norm of each row
             norms = scipy.linalg.norm(quat, axis=1)
@@ -718,7 +718,7 @@ class Rotation(object):
             dcm = dcm[None, :, :]
 
         n_vectors = vectors.shape[0]
-        n_rotations = self._quat.shape[0]
+        n_rotations = self.n
 
         if n_vectors != 1 and n_rotations != 1 and n_vectors != n_rotations:
             raise ValueError("Expected equal numbers of rotations and vectors "
@@ -743,11 +743,10 @@ class Rotation(object):
 
             - a single rotation, if `indexer` is a single index
             - a stack of rotation(s), if `indexer` is a slice, or an index
-              array. In cases where a single index is ultimately specified, the
-              stack will contain a single rotation.
+              array.
 
-        A single indexer must be specified. The semantics for this function are
-        identical to that of numpy arrays and lists.
+        A single indexer must be specified, i.e. as if indexing a 1 dimensional
+        array or list.
 
         Parameters
         ----------

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -57,6 +57,11 @@ def _compute_euler_from_dcm(dcm, seq, extrinsic=False):
 
     # Step 4
     angles = np.empty((num_rotations, 3))
+    # Ensure less than unit norm
+    positive_unity = dcm_transformed[:, 2, 2] > 1
+    negative_unity = dcm_transformed[:, 2, 2] < -1
+    dcm_transformed[positive_unity, 2, 2] = 1.0
+    dcm_transformed[negative_unity, 2, 2] = -1.0
     angles[:, 1] = np.arccos(dcm_transformed[:, 2, 2])
 
     # Steps 5, 6

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -60,8 +60,8 @@ def compute_euler_from_dcm(dcm, seq, extrinsic=False):
     rtc = rt.dot(c)
     ct = c.T
     o = np.empty_like(dcm)
-    res = np.einsum('ij,...jk->...ik', rtc, dcm)
-    o = np.einsum('...ij,jk->...ik', res, ct)
+    res = np.einsum('...ij,...jk->...ik', rtc, dcm)
+    o = np.einsum('...ij,...jk->...ik', res, ct)
 
     # Step 4
     angle2 = lamb + np.arccos(o[:, 2, 2])
@@ -158,6 +158,7 @@ class Rotation(object):
     from_rotvec
     as_rotvec
     from_euler
+    as_euler
     """
     def __init__(self, quat, normalized=False):
         self._single = False
@@ -520,8 +521,11 @@ class Rotation(object):
 
         This function returns a numpy.ndarray of shape (N, 3) or (3,) depending
         on how the object was initialized. The algorithm presented in [2]_ has
-        been adapted for our use to extract Euler angles, keeping in mind the
-        conventions presented in [3]_.
+        been adapted for our use to extract Euler angles. The paper presents an
+        algorithm for extracting Euler angles from transformation matrices, as
+        opposed to rotation matrices. Thus, the matrix representation used in
+        the paper is a transpose of the direction cosine matrix representation
+        returned by the `as_dcm` function.
 
         Parameters
         ----------
@@ -542,8 +546,6 @@ class Rotation(object):
         .. [2] Malcolm D. Shuster, F. Landis Markley
                 `General Formula for Euler Angles
                 <https://arc.aiaa.org/doi/abs/10.2514/1.16622>`_
-        .. [3] Malcolm D. Shuster `A Survey of Attitude Representations
-                <https://www.researchgate.net/publication/253512057_A_Survey_of_Attitude_Representations>`_
         """
         if len(seq) != 3:
             raise ValueError("Expected 3 axes, got {}.".format(seq))

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -227,8 +227,7 @@ class Rotation(object):
             # each column.
             self._quat[~zero_norms] /= norms[~zero_norms][:, None]
 
-    @property
-    def n(self):
+    def __len__(self):
         """Number of rotations contained in object."""
         return self._quat.shape[0]
 
@@ -716,7 +715,7 @@ class Rotation(object):
             dcm = dcm[None, :, :]
 
         n_vectors = vectors.shape[0]
-        n_rotations = self.n
+        n_rotations = len(self)
 
         if n_vectors != 1 and n_rotations != 1 and n_vectors != n_rotations:
             raise ValueError("Expected equal numbers of rotations and vectors "

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -8,20 +8,22 @@ import re
 AXIS_TO_IND = {'x': 0, 'y': 1, 'z': 2}
 
 
-def _elementary_basis_vector(char):
+def elementary_basis_vector(axis):
     b = np.zeros(3)
-    b[AXIS_TO_IND[char]] = 1
+    b[AXIS_TO_IND[axis]] = 1
     return b
 
 
-def _make_euler_from_dcm(dcm, seq, extrinsic=False):
-    # The algorithm assumes intrinsic frame transformations. Their
-    # ELEMENTARY dcms are transpose of what we return.
+def compute_euler_from_dcm(dcm, seq, extrinsic=False):
+    # The algorithm assumes intrinsic frame transformations. For representation
+    # the paper uses transformation matrices, which are transpose of the
+    # direction cosine matrices used by our Rotation class.
     # Adapt the algorithm for our case by
     # 1. Transposing our dcm representation
     # 2. Reversing both axis sequence and angles for extrinsic rotations
 
-    seq = seq[::-1] if extrinsic else seq
+    if extrinsic:
+        seq = seq[::-1]
 
     if dcm.ndim == 2:
         dcm = dcm[None, :, :]
@@ -31,20 +33,25 @@ def _make_euler_from_dcm(dcm, seq, extrinsic=False):
     # Algorithms dcms are transpose of ours
     dcm = np.transpose(dcm, (0, 2, 1))
     # Algorithm assumes axes as column vectors, here we use 1D vectors
-    n1 = _elementary_basis_vector(seq[0])
-    n2 = _elementary_basis_vector(seq[1])
-    n3 = _elementary_basis_vector(seq[2])
+    n1 = elementary_basis_vector(seq[0])
+    n2 = elementary_basis_vector(seq[1])
+    n3 = elementary_basis_vector(seq[2])
 
     # Step 2
-    lamb = np.arctan2(np.dot(np.cross(n1, n2), n3), np.dot(n1, n3))
+    sl = np.dot(np.cross(n1, n2), n3)
+    cl = np.dot(n1, n3)
+
+    norm = sl**2 + cl**2
+    sl /= norm
+    cl /= norm
+
+    lamb = np.arctan2(sl, cl)
     c = np.empty((3, 3))
     c[0] = n2
     c[1] = np.cross(n1, n2)
     c[2] = n1
 
     # Step 3
-    cl = np.cos(lamb)
-    sl = np.sin(lamb)
     rt = np.array([
         [1, 0, 0],
         [0, cl, -sl],
@@ -96,7 +103,7 @@ def _make_euler_from_dcm(dcm, seq, extrinsic=False):
                            (angle1, angle2, angle3))
 
 
-def _make_elementary_quat(axis, angles):
+def make_elementary_quat(axis, angles):
     num_rotations = angles.shape[0]
     quat = np.zeros((num_rotations, 4))
 
@@ -105,7 +112,7 @@ def _make_elementary_quat(axis, angles):
     return quat
 
 
-def _compose_quat(p, q):
+def compose_quat(p, q):
     # p and q should have same shape (N, 4)
     product = np.empty_like(p)
     # Scalar part of result
@@ -116,18 +123,18 @@ def _compose_quat(p, q):
     return product
 
 
-def _elementary_quat_compose(seq, angles, intrinsic=False):
+def elementary_quat_compose(seq, angles, intrinsic=False):
     # Initialize result to first axis
-    result = _make_elementary_quat(seq[0], angles[:, 0])
+    result = make_elementary_quat(seq[0], angles[:, 0])
 
     for idx, axis in enumerate(seq[1:], start=1):
         if intrinsic:
-            result = _compose_quat(
+            result = compose_quat(
                 result,
-                _make_elementary_quat(axis, angles[:, idx]))
+                make_elementary_quat(axis, angles[:, idx]))
         else:
-            result = _compose_quat(
-                _make_elementary_quat(axis, angles[:, idx]),
+            result = compose_quat(
+                make_elementary_quat(axis, angles[:, idx]),
                 result)
     return result
 
@@ -505,14 +512,16 @@ class Rotation(object):
             raise ValueError("Expected angles to have shape (num_rotations, "
                              "num_axes), got {}.".format(angles.shape))
 
-        quat = _elementary_quat_compose(seq, angles, intrinsic)
+        quat = elementary_quat_compose(seq, angles, intrinsic)
         return cls(quat[0] if is_single else quat, normalized=True)
 
     def as_euler(self, seq, degrees=False):
         """Return the Euler angles representation of the Rotation.
 
         This function returns a numpy.ndarray of shape (N, 3) or (3,) depending
-        on how the object was initialized.
+        on how the object was initialized. The algorithm presented in [2]_ has
+        been adapted for our use to extract Euler angles, keeping in mind the
+        conventions presented in [3]_.
 
         Parameters
         ----------
@@ -522,7 +531,6 @@ class Rotation(object):
             Adjacent axes cannot be the same.
             Extrinsic and intrinsic rotations cannot be mixed in one function
             call.
-
         degrees : boolean, optional
             Returned angles are in degrees if this flag is True, else they are
             in radians. Default is False.
@@ -531,6 +539,11 @@ class Rotation(object):
         ----------
         .. [1] `Euler angle definitions
                 <https://en.wikipedia.org/wiki/Euler_angles#Definition_by_intrinsic_rotations>`_
+        .. [2] Malcolm D. Shuster, F. Landis Markley
+                `General Formula for Euler Angles
+                <https://arc.aiaa.org/doi/abs/10.2514/1.16622>`_
+        .. [3] Malcolm D. Shuster `A Survey of Attitude Representations
+                <https://www.researchgate.net/publication/253512057_A_Survey_of_Attitude_Representations>`_
         """
         if len(seq) != 3:
             raise ValueError("Expected 3 axes, got {}.".format(seq))
@@ -547,7 +560,7 @@ class Rotation(object):
 
         seq = seq.lower()
 
-        angles = _make_euler_from_dcm(self.as_dcm(), seq, extrinsic)
+        angles = compute_euler_from_dcm(self.as_dcm(), seq, extrinsic)
         if degrees:
             angles = np.rad2deg(angles)
 

--- a/scipy/spatial/transform/setup.py
+++ b/scipy/spatial/transform/setup.py
@@ -1,5 +1,6 @@
 from __future__ import division, print_function, absolute_import
 
+
 def configuration(parent_package='', top_path=None):
     from numpy.distutils.misc_util import Configuration
 

--- a/scipy/spatial/transform/setup.py
+++ b/scipy/spatial/transform/setup.py
@@ -1,0 +1,10 @@
+from __future__ import division, print_function, absolute_import
+
+def configuration(parent_package='', top_path=None):
+    from numpy.distutils.misc_util import Configuration
+
+    config = Configuration('transform', parent_package, top_path)
+
+    config.add_data_dir('tests')
+
+    return config

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -753,9 +753,7 @@ def test_n_rotations():
     ])
     r = Rotation.from_dcm(dcm)
 
-    assert_equal(r.n, 2)
-    assert_equal(r[0].n, 1)
-    assert_equal(r[1].n, 1)
-    assert_equal(r[:-1].n, 1)
-=======
->>>>>>> 18e780c25... TST: Add test with inverse=True
+    assert_equal(len(r), 2)
+    assert_equal(len(r[0]), 1)
+    assert_equal(len(r[1]), 1)
+    assert_equal(len(r[:-1]), 1)

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -326,3 +326,12 @@ def test_single_intrinsic_extrinsic_rotation():
     ext = Rotation.from_euler('z', 90, degrees=True).as_dcm()
     int = Rotation.from_euler('Z', 90, degrees=True).as_dcm()
     assert_allclose(ext, int)
+
+
+def test_from_euler_rotation_order():
+    np.random.seed(0)
+    a = np.random.randint(low=0, high=180, size=(6, 3))
+    b = a[:, np.argsort([2, 1, 0])]
+    x = Rotation.from_euler('xyz', a, degrees=True).as_quaternion()
+    y = Rotation.from_euler('ZYX', b, degrees=True).as_quaternion()
+    assert_allclose(x, y)

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -502,50 +502,16 @@ def test_as_euler_degenerate_asymmetric_axes():
     angles = np.array([
         [45, 90, 35],
         [90, 35, 20],
-        [35, 60, 90]
+        [35, 60, 90],
+        [0, 15, 60],
+        [35, 0, 75],
+        [65, 85, 0]
         ])
 
-    for seq_tuple in permutations('xyz'):
-        # Extrinsic rotations
-        seq = ''.join(seq_tuple)
-        rotation = Rotation.from_euler(seq, angles, degrees=True)
-        dcm_expected = rotation.as_dcm()
-
-        angle_estimates = rotation.as_euler(seq, degrees=True)
-        dcm_estimated = Rotation.from_euler(
-            seq, angle_estimates, degrees=True
-            ).as_dcm()
-
-        assert_array_almost_equal(dcm_expected, dcm_estimated)
-
-        # Intrinsic rotations
-        seq = seq.upper()
-        rotation = Rotation.from_euler(seq, angles, degrees=True)
-        dcm_expected = rotation.as_dcm()
-
-        angle_estimates = rotation.as_euler(seq, degrees=True)
-        dcm_estimated = Rotation.from_euler(
-            seq, angle_estimates, degrees=True
-            ).as_dcm()
-
-        assert_array_almost_equal(dcm_expected, dcm_estimated)
-
-
-def test_as_euler_degenerate_symmetric_axes():
-    # Since we cannot check for angle equality, we check for dcm equality
-    angles = np.array([
-        [45, 90, 35],
-        [90, 35, 20],
-        [35, 60, 90]
-        ])
-
-    for axis1 in ['x', 'y', 'z']:
-        for axis2 in ['x', 'y', 'z']:
-            if axis1 == axis2:
-                continue
-
+    with pytest.warns(UserWarning, match="gimbal lock"):
+        for seq_tuple in permutations('xyz'):
             # Extrinsic rotations
-            seq = axis1 + axis2 + axis1
+            seq = ''.join(seq_tuple)
             rotation = Rotation.from_euler(seq, angles, degrees=True)
             dcm_expected = rotation.as_dcm()
 
@@ -567,3 +533,45 @@ def test_as_euler_degenerate_symmetric_axes():
                 ).as_dcm()
 
             assert_array_almost_equal(dcm_expected, dcm_estimated)
+
+
+def test_as_euler_degenerate_symmetric_axes():
+    # Since we cannot check for angle equality, we check for dcm equality
+    angles = np.array([
+        [45, 90, 35],
+        [90, 35, 20],
+        [35, 60, 90],
+        [0, 15, 60],
+        [35, 0, 75],
+        [65, 85, 0]
+        ])
+
+    with pytest.warns(UserWarning, match="gimbal lock"):
+        for axis1 in ['x', 'y', 'z']:
+            for axis2 in ['x', 'y', 'z']:
+                if axis1 == axis2:
+                    continue
+
+                # Extrinsic rotations
+                seq = axis1 + axis2 + axis1
+                rotation = Rotation.from_euler(seq, angles, degrees=True)
+                dcm_expected = rotation.as_dcm()
+
+                angle_estimates = rotation.as_euler(seq, degrees=True)
+                dcm_estimated = Rotation.from_euler(
+                    seq, angle_estimates, degrees=True
+                    ).as_dcm()
+
+                assert_array_almost_equal(dcm_expected, dcm_estimated)
+
+                # Intrinsic rotations
+                seq = seq.upper()
+                rotation = Rotation.from_euler(seq, angles, degrees=True)
+                dcm_expected = rotation.as_dcm()
+
+                angle_estimates = rotation.as_euler(seq, degrees=True)
+                dcm_estimated = Rotation.from_euler(
+                    seq, angle_estimates, degrees=True
+                    ).as_dcm()
+
+                assert_array_almost_equal(dcm_expected, dcm_estimated)

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -471,9 +471,9 @@ def test_as_euler_extrinsic_rotation():
 def test_as_euler_intrinsic_rotation():
     np.random.seed(0)
     angles = np.random.uniform(low=-np.pi, high=np.pi, size=(6, 3))
-    rot_obj = Rotation.from_euler('ZXY', angles)
+    rot = Rotation.from_euler('ZXY', angles)
 
-    estimates = rot_obj.as_euler('ZXY')
+    estimates = rot.as_euler('ZXY')
     est_obj = Rotation.from_euler('ZXY', estimates)
 
-    assert_array_almost_equal(rot_obj.as_dcm(), est_obj.as_dcm())
+    assert_array_almost_equal(rot.as_dcm(), est_obj.as_dcm())

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -8,14 +8,14 @@ from scipy.spatial.transform import Rotation
 
 
 def test_generic_quat_matrix():
-    x = np.array([[3,4,0,0], [5, 12, 0, 0]])
+    x = np.array([[3, 4, 0, 0], [5, 12, 0, 0]])
     r = Rotation.from_quaternion(x)
     expected_quat = x / np.array([[5], [13]])
     assert_array_almost_equal(r._quat, expected_quat)
 
 
 def test_from_single_quaternion():
-    x = np.array([3,4,0,0])
+    x = np.array([3, 4, 0, 0])
     r = Rotation.from_quaternion(x)
     expected_quat = x[None, :] / 5
     assert_array_almost_equal(r._quat, expected_quat)
@@ -36,14 +36,14 @@ def test_from_square_quat_matrix():
 
 def test_malformed_1d_from_quaternion():
     with pytest.raises(ValueError):
-        Rotation.from_quaternion(np.array([1,2,3]))
+        Rotation.from_quaternion(np.array([1, 2, 3]))
 
 
 def test_malformed_2d_from_quaternion():
     with pytest.raises(ValueError):
         Rotation.from_quaternion(np.array([
-            [1,2,3,4,5],
-            [4,5,6,7,8]
+            [1, 2, 3, 4, 5],
+            [4, 5, 6, 7, 8]
             ]))
 
 
@@ -53,11 +53,5 @@ def test_zero_norms_from_quaternion():
             [0, 0, 0, 0],
             [5, 0, 12, 0]
             ])
-    with pytest.raises(UserWarning):
+    with pytest.raises(ValueError):
         r = Rotation.from_quaternion(x)
-        expected_quat = np.array([
-            x[0] / 5,
-            [0, 0, 0, 1],
-            x[2] / 13
-            ])
-        assert_array_almost_equal(r, expected_quat)

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -757,3 +757,17 @@ def test_n_rotations():
     assert_equal(len(r[0]), 1)
     assert_equal(len(r[1]), 1)
     assert_equal(len(r[:-1]), 1)
+
+
+def test_quat_ownership():
+    # Ensure that users cannot accidentally corrupt object
+    quat = np.array([
+        [1, 0, 0, 0],
+        [0, 1, 0, 0],
+        [0, 0, 1, 0]
+    ])
+    r = Rotation.from_quaternion(quat, normalized=True)
+    s = r[0:2]
+
+    r._quat[0] = np.array([0, -1, 0, 0])
+    assert_allclose(s._quat[0], np.array([1, 0, 0, 0]))

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -3,7 +3,7 @@ from __future__ import division, print_function, absolute_import
 import pytest
 
 import numpy as np
-from numpy.testing import assert_array_almost_equal
+from numpy.testing import assert_equal, assert_array_almost_equal
 from scipy.spatial.transform import Rotation
 
 
@@ -74,7 +74,7 @@ def test_as_dcm_single_1d_quaternion():
 def test_as_dcm_single_2d_quaternion():
     quat = [[0, 0, 1, 1]]
     mat = Rotation.from_quaternion(quat).as_dcm()
-    assert(mat.shape == (1, 3, 3))
+    assert_equal(mat.shape, (1, 3, 3))
     expected_mat = np.array([
         [0, -1, 0],
         [1, 0, 0],
@@ -91,7 +91,7 @@ def test_as_dcm_from_square_input():
             [0, 0, 0, -1]
             ]
     mat = Rotation.from_quaternion(quats).as_dcm()
-    assert(mat.shape == (4, 3, 3))
+    assert_equal(mat.shape, (4, 3, 3))
 
     expected0 = np.array([
         [0, -1, 0],
@@ -118,7 +118,7 @@ def test_as_dcm_from_generic_input():
             [1, 2, 3, 4]
             ]
     mat = Rotation.from_quaternion(quats).as_dcm()
-    assert(mat.shape == (3, 3, 3))
+    assert_equal(mat.shape, (3, 3, 3))
 
     expected0 = np.array([
         [0, -1, 0],

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -495,3 +495,75 @@ def test_as_euler_symmetric_axes():
             seq = seq.upper()
             assert_allclose(
                 angles, Rotation.from_euler(seq, angles).as_euler(seq))
+
+
+def test_as_euler_degenerate_asymmetric_axes():
+    # Since we cannot check for angle equality, we check for dcm equality
+    angles = np.array([
+        [45, 90, 35],
+        [90, 35, 20],
+        [35, 60, 90]
+        ])
+
+    for seq_tuple in permutations('xyz'):
+        # Extrinsic rotations
+        seq = ''.join(seq_tuple)
+        rotation = Rotation.from_euler(seq, angles, degrees=True)
+        dcm_expected = rotation.as_dcm()
+
+        angle_estimates = rotation.as_euler(seq, degrees=True)
+        dcm_estimated = Rotation.from_euler(
+            seq, angle_estimates, degrees=True
+            ).as_dcm()
+
+        assert_array_almost_equal(dcm_expected, dcm_estimated)
+
+        # Intrinsic rotations
+        seq = seq.upper()
+        rotation = Rotation.from_euler(seq, angles, degrees=True)
+        dcm_expected = rotation.as_dcm()
+
+        angle_estimates = rotation.as_euler(seq, degrees=True)
+        dcm_estimated = Rotation.from_euler(
+            seq, angle_estimates, degrees=True
+            ).as_dcm()
+
+        assert_array_almost_equal(dcm_expected, dcm_estimated)
+
+
+def test_as_euler_degenerate_symmetric_axes():
+    # Since we cannot check for angle equality, we check for dcm equality
+    angles = np.array([
+        [45, 90, 35],
+        [90, 35, 20],
+        [35, 60, 90]
+        ])
+
+    for axis1 in ['x', 'y', 'z']:
+        for axis2 in ['x', 'y', 'z']:
+            if axis1 == axis2:
+                continue
+
+            # Extrinsic rotations
+            seq = axis1 + axis2 + axis1
+            rotation = Rotation.from_euler(seq, angles, degrees=True)
+            dcm_expected = rotation.as_dcm()
+
+            angle_estimates = rotation.as_euler(seq, degrees=True)
+            dcm_estimated = Rotation.from_euler(
+                seq, angle_estimates, degrees=True
+                ).as_dcm()
+
+            assert_array_almost_equal(dcm_expected, dcm_estimated)
+
+            # Intrinsic rotations
+            seq = seq.upper()
+            rotation = Rotation.from_euler(seq, angles, degrees=True)
+            dcm_expected = rotation.as_dcm()
+
+            angle_estimates = rotation.as_euler(seq, degrees=True)
+            dcm_estimated = Rotation.from_euler(
+                seq, angle_estimates, degrees=True
+                ).as_dcm()
+
+            assert_array_almost_equal(dcm_expected, dcm_estimated)

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -259,12 +259,12 @@ def test_from_rotvec_small_angle():
 
 
 def test_malformed_1d_from_rotvec():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='Expected `rot_vec` to have shape'):
         Rotation.from_rotvec([1, 2])
 
 
 def test_malformed_2d_from_rotvec():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='Expected `rot_vec` to have shape'):
         Rotation.from_rotvec([
             [1, 2, 3, 4],
             [5, 6, 7, 8]

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -269,3 +269,48 @@ def test_malformed_2d_from_rotvec():
             [1, 2, 3, 4],
             [5, 6, 7, 8]
             ])
+
+
+def test_as_generic_rotvec():
+    quat = np.array([
+            [1, 2, -1, 0.5],
+            [1, -1, 1, 0.0003],
+            [0, 0, 0, 1]
+            ])
+    quat /= np.linalg.norm(quat, axis=1)[:, None]
+
+    rotvec = Rotation.from_quaternion(quat).as_rotvec()
+    angle = np.linalg.norm(rotvec, axis=1)
+
+    assert_allclose(quat[:, 3], np.cos(angle/2))
+    assert_allclose(np.cross(rotvec, quat[:, :3]), np.zeros((3, 3)))
+
+
+def test_as_rotvec_single_1d_input():
+    quat = np.array([1, 2, -3, 2])
+    expected_rotvec = np.array([0.5772381, 1.1544763, -1.7317144])
+
+    actual_rotvec = Rotation.from_quaternion(quat).as_rotvec()
+
+    assert_equal(actual_rotvec.shape, (3,))
+    assert_allclose(actual_rotvec, expected_rotvec)
+
+
+def test_as_rotvec_single_2d_input():
+    quat = np.array([[1, 2, -3, 2]])
+    expected_rotvec = np.array([[0.5772381, 1.1544763, -1.7317144]])
+
+    actual_rotvec = Rotation.from_quaternion(quat).as_rotvec()
+
+    assert_equal(actual_rotvec.shape, (1, 3))
+    assert_allclose(actual_rotvec, expected_rotvec)
+
+
+def test_rotvec_calc_pipeline():
+    # Include small angles
+    rotvec = np.array([
+        [0, 0, 0],
+        [1, -1, 2],
+        [-3e-4, 3.5e-4, 7.5e-5]
+        ])
+    assert_allclose(Rotation.from_rotvec(rotvec).as_rotvec(), rotvec)

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -622,43 +622,52 @@ def test_inv_single_rotation():
 
 
 def test_apply_single_rotation_single_point():
-    r_1d = Rotation.from_dcm([
+    dcm = np.array([
         [0, -1, 0],
         [1, 0, 0],
         [0, 0, 1]
     ])
-    r_2d = Rotation.from_dcm([[
-        [0, -1, 0],
-        [1, 0, 0],
-        [0, 0, 1]
-    ]])
+    r_1d = Rotation.from_dcm(dcm)
+    r_2d = Rotation.from_dcm(np.expand_dims(dcm, axis=0))
 
     v_1d = np.array([1, 2, 3])
-    v_2d = np.array([[1, 2, 3]])
+    v_2d = np.expand_dims(v_1d, axis=0)
+    v1d_rotated = np.array([-2, 1, 3])
+    v2d_rotated = np.expand_dims(v1d_rotated, axis=0)
 
-    assert_allclose(r_1d.apply(v_1d), np.array([-2, 1, 3]))
-    assert_allclose(r_1d.apply(v_2d), np.array([[-2, 1, 3]]))
-    assert_allclose(r_2d.apply(v_1d), np.array([[-2, 1, 3]]))
-    assert_allclose(r_2d.apply(v_2d), np.array([[-2, 1, 3]]))
+    assert_allclose(r_1d.apply(v_1d), v1d_rotated)
+    assert_allclose(r_1d.apply(v_2d), v2d_rotated)
+    assert_allclose(r_2d.apply(v_1d), v2d_rotated)
+    assert_allclose(r_2d.apply(v_2d), v2d_rotated)
+
+    v1d_inverse = np.array([2, -1, 3])
+    v2d_inverse = np.expand_dims(v1d_inverse, axis=0)
+
+    assert_allclose(r_1d.apply(v_1d, inverse=True), v1d_inverse)
+    assert_allclose(r_1d.apply(v_2d, inverse=True), v2d_inverse)
+    assert_allclose(r_2d.apply(v_1d, inverse=True), v2d_inverse)
+    assert_allclose(r_2d.apply(v_2d, inverse=True), v2d_inverse)
 
 
 def test_apply_single_rotation_multiple_points():
-    r1 = Rotation.from_dcm([
+    dcm = np.array([
         [0, -1, 0],
         [1, 0, 0],
         [0, 0, 1]
     ])
-    r2 = Rotation.from_dcm([[
-            [0, -1, 0],
-            [1, 0, 0],
-            [0, 0, 1]
-        ]])
+    r1 = Rotation.from_dcm(dcm)
+    r2 = Rotation.from_dcm(np.expand_dims(dcm, axis=0))
 
     v = np.array([[1, 2, 3], [4, 5, 6]])
     v_rotated = np.array([[-2, 1, 3], [-5, 4, 6]])
 
     assert_allclose(r1.apply(v), v_rotated)
     assert_allclose(r2.apply(v), v_rotated)
+
+    v_inverse = np.array([[2, -1, 3], [5, -4, 6]])
+
+    assert_allclose(r1.apply(v, inverse=True), v_inverse)
+    assert_allclose(r2.apply(v, inverse=True), v_inverse)
 
 
 def test_apply_multiple_rotations_single_point():
@@ -676,12 +685,17 @@ def test_apply_multiple_rotations_single_point():
     r = Rotation.from_dcm(dcm)
 
     v1 = np.array([1, 2, 3])
-    v2 = np.array([[1, 2, 3]])
+    v2 = np.expand_dims(v1, axis=0)
 
     v_rotated = np.array([[-2, 1, 3], [1, -3, 2]])
 
     assert_allclose(r.apply(v1), v_rotated)
     assert_allclose(r.apply(v2), v_rotated)
+
+    v_inverse = np.array([[2, -1, 3], [1, 3, -2]])
+
+    assert_allclose(r.apply(v1, inverse=True), v_inverse)
+    assert_allclose(r.apply(v2, inverse=True), v_inverse)
 
 
 def test_apply_multiple_rotations_multiple_points():
@@ -700,5 +714,53 @@ def test_apply_multiple_rotations_multiple_points():
 
     v = np.array([[1, 2, 3], [4, 5, 6]])
     v_rotated = np.array([[-2, 1, 3], [4, -6, 5]])
-
     assert_allclose(r.apply(v), v_rotated)
+    v_inverse = np.array([[2, -1, 3], [4, 6, -5]])
+    assert_allclose(r.apply(v, inverse=True), v_inverse)
+
+    v_inverse = np.array([[2, -1, 3], [4, 6, -5]])
+
+    assert_allclose(r.apply(v, inverse=True), v_inverse)
+
+    v_inverse = np.array([[2, -1, 3], [4, 6, -5]])
+
+    assert_allclose(r.apply(v, inverse=True), v_inverse)
+
+
+def test_getitem():
+    dcm = np.empty((2, 3, 3))
+    dcm[0] = np.array([
+        [0, -1, 0],
+        [1, 0, 0],
+        [0, 0, 1]
+    ])
+    dcm[1] = np.array([
+        [1, 0, 0],
+        [0, 0, -1],
+        [0, 1, 0]
+    ])
+    r = Rotation.from_dcm(dcm)
+
+    assert_allclose(r[0].as_dcm(), dcm[0])
+    assert_allclose(r[1].as_dcm(), dcm[1])
+    assert_allclose(r[:-1].as_dcm(), np.expand_dims(dcm[0], axis=0))
+
+
+def test_n_rotations():
+    dcm = np.empty((2, 3, 3))
+    dcm[0] = np.array([
+        [0, -1, 0],
+        [1, 0, 0],
+        [0, 0, 1]
+    ])
+    dcm[1] = np.array([
+        [1, 0, 0],
+        [0, 0, -1],
+        [0, 1, 0]
+    ])
+    r = Rotation.from_dcm(dcm)
+
+    assert_equal(r.n, 2)
+    assert_equal(r[0].n, 1)
+    assert_equal(r[1].n, 1)
+    assert_equal(r[:-1].n, 1)

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -62,3 +62,81 @@ def test_zero_norms_from_quaternion():
             ])
     with pytest.raises(ValueError):
         r = Rotation.from_quaternion(x)
+
+
+def test_as_dcm_single_1d_quaternion():
+    quat = [0, 0, 0, 1]
+    mat = Rotation.from_quaternion(quat).as_dcm()
+    # mat.shape == (3,3) due to 1d input
+    assert_array_almost_equal(mat, np.eye(3))
+
+
+def test_as_dcm_single_2d_quaternion():
+    quat = [[0, 0, 1, 1]]
+    mat = Rotation.from_quaternion(quat).as_dcm()
+    assert(mat.shape == (1, 3, 3))
+    expected_mat = np.array([
+        [0, -1, 0],
+        [1, 0, 0],
+        [0, 0, 1]
+        ])
+    assert_array_almost_equal(mat[0], expected_mat)
+
+
+def test_as_dcm_from_square_input():
+    quats = [
+            [0, 0, 1, 1],
+            [0, 1, 0, 1],
+            [0, 0, 0, 1],
+            [0, 0, 0, -1]
+            ]
+    mat = Rotation.from_quaternion(quats).as_dcm()
+    assert(mat.shape == (4, 3, 3))
+
+    expected0 = np.array([
+        [0, -1, 0],
+        [1, 0, 0],
+        [0, 0, 1]
+        ])
+    assert_array_almost_equal(mat[0], expected0)
+
+    expected1 = np.array([
+        [0, 0, 1],
+        [0, 1, 0],
+        [-1, 0, 0]
+        ])
+    assert_array_almost_equal(mat[1], expected1)
+
+    assert_array_almost_equal(mat[2], np.eye(3))
+    assert_array_almost_equal(mat[3], np.eye(3))
+
+
+def test_as_dcm_from_generic_input():
+    quats = [
+            [0, 0, 1, 1],
+            [0, 1, 0, 1],
+            [1, 2, 3, 4]
+            ]
+    mat = Rotation.from_quaternion(quats).as_dcm()
+    assert(mat.shape == (3, 3, 3))
+
+    expected0 = np.array([
+        [0, -1, 0],
+        [1, 0, 0],
+        [0, 0, 1]
+        ])
+    assert_array_almost_equal(mat[0], expected0)
+
+    expected1 = np.array([
+        [0, 0, 1],
+        [0, 1, 0],
+        [-1, 0, 0]
+        ])
+    assert_array_almost_equal(mat[1], expected1)
+
+    expected2 = np.array([
+        [0.4, -2, 2.2],
+        [2.8, 1, 0.4],
+        [-1, 2, 2]
+        ]) / 3
+    assert_array_almost_equal(mat[2], expected2)

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -234,14 +234,28 @@ def test_from_generic_rotvec():
 
 
 def test_from_rotvec_small_angle():
-    # Small theta
-    rotvec = np.array([1, 0.00001, 0.00001]) * 5e-6
+    rotvec = np.array([
+        [5e-4 / np.sqrt(3), -5e-4 / np.sqrt(3), 5e-4 / np.sqrt(3)],
+        [0.2, 0.3, 0.4],
+        [0, 0, 0]
+        ])
+
     quat = Rotation.from_rotvec(rotvec).as_quaternion()
-    # cos(theta/2) ~~ 1
-    assert_allclose(quat[3], 1)
-    # sin(theta/2) / theta ~~ 0.5
-    assert_allclose(quat[:3], rotvec * 0.5)
-    assert_equal(np.linalg.norm(quat), 1)
+    # cos(theta/2) ~~ 1 for small theta
+    assert_allclose(quat[0, 3], 1)
+    # sin(theta/2) / theta ~~ 0.5 for small theta
+    assert_allclose(quat[0, :3], rotvec[0] * 0.5)
+
+    assert_allclose(quat[1, 3], 0.9639685)
+    assert_allclose(
+            quat[1, :3],
+            np.array([
+                0.09879603932153465,
+                0.14819405898230198,
+                0.19759207864306931
+                ]))
+
+    assert_equal(quat[2], np.array([0, 0, 0, 1]))
 
 
 def test_malformed_1d_from_rotvec():

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -63,7 +63,7 @@ def test_zero_norms_from_quaternion():
             [5, 0, 12, 0]
             ])
     with pytest.raises(ValueError):
-        r = Rotation.from_quaternion(x)
+        Rotation.from_quaternion(x)
 
 
 def test_as_dcm_single_1d_quaternion():
@@ -314,3 +314,15 @@ def test_rotvec_calc_pipeline():
         [-3e-4, 3.5e-4, 7.5e-5]
         ])
     assert_allclose(Rotation.from_rotvec(rotvec).as_rotvec(), rotvec)
+
+
+def test_from_euler_single_rotation():
+    quat = Rotation.from_euler('z', 90, degrees=True).as_quaternion()
+    expected_quat = np.array([0, 0, 1, 1]) / np.sqrt(2)
+    assert_allclose(quat, expected_quat)
+
+
+def test_single_intrinsic_extrinsic_rotation():
+    ext = Rotation.from_euler('z', 90, degrees=True).as_dcm()
+    int = Rotation.from_euler('Z', 90, degrees=True).as_dcm()
+    assert_allclose(ext, int)

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -455,3 +455,25 @@ def test_from_euler_extrinsic_rotation_313():
         [0.91855865, -0.30618622, -0.250000],
         [0.35355339, 0.35355339, 0.8660254]
     ]))
+
+
+def test_as_euler_extrinsic_rotation():
+    np.random.seed(0)
+    angles = np.random.uniform(low=-np.pi, high=np.pi, size=(6, 3))
+    rot_obj = Rotation.from_euler('zxy', angles)
+
+    estimates = rot_obj.as_euler('zxy')
+    est_obj = Rotation.from_euler('zxy', estimates)
+
+    assert_array_almost_equal(rot_obj.as_dcm(), est_obj.as_dcm())
+
+
+def test_as_euler_intrinsic_rotation():
+    np.random.seed(0)
+    angles = np.random.uniform(low=-np.pi, high=np.pi, size=(6, 3))
+    rot_obj = Rotation.from_euler('ZXY', angles)
+
+    estimates = rot_obj.as_euler('ZXY')
+    est_obj = Rotation.from_euler('ZXY', estimates)
+
+    assert_array_almost_equal(rot_obj.as_dcm(), est_obj.as_dcm())

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -1,0 +1,30 @@
+from __future__ import division, print_function, absolute_import
+
+import numpy as np
+from numpy.testing import assert_array_almost_equal
+from scipy.spatial.transform import Rotation
+
+
+def test_generic_quat_matrix():
+    x = np.array([[3,4,0,0], [5, 12, 0, 0]])
+    r = Rotation.from_quaternion(x)
+    expected_quat = x / np.array([[5], [13]])
+    assert_array_almost_equal(r._quat, expected_quat)
+
+def test_from_single_quaternion():
+    x = np.array([3,4,0,0])
+    r = Rotation.from_quaternion(x)
+    expected_quat = x[None, :] / 5
+    assert_array_almost_equal(r._quat, expected_quat)
+
+def test_from_square_quat_matrix():
+    # Ensure proper norm array broadcasting
+    x = np.array([
+        [3, 0, 0, 4],
+        [5, 0, 12, 0],
+        [0, 0, 0, 1],
+        [0, 0, 0, -1]
+        ])
+    r = Rotation.from_quaternion(x)
+    expected_quat = x / np.array([[5], [13], [1], [1]])
+    assert_array_almost_equal(r._quat, expected_quat)

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -477,3 +477,35 @@ def test_as_euler_intrinsic_rotation():
     est_obj = Rotation.from_euler('ZXY', estimates)
 
     assert_array_almost_equal(rot.as_dcm(), est_obj.as_dcm())
+
+
+def test_as_euler_extrinsic_rotation_312():
+    angles = [
+        [45, 30, 60],
+        [30, 60, 15],
+        [35, 20, 65],
+        [25, 45, 20],
+        [45, 30, 20],
+        # [25, 135, 35] -> [-155.,   45., -145.]
+        # In this last case, these are the angles returned by the algorithm
+        # without any adjustment. It looks like we cannot always expect to get
+        # back the original angles. However, the rotation that is represented
+        # is the same.
+        ]
+    estimates = Rotation.from_euler(
+        'zxy', angles, degrees=True).as_euler('zxy', degrees=True)
+    assert_allclose(angles, estimates)
+
+
+def test_as_euler_extrinsic_rotation_313():
+    angles = [
+        [45, 30, 60],
+        [30, 60, 15],
+        [35, 20, 65],
+        [25, 45, 20],
+        [45, 30, 20],
+        [25, 135, 35],
+        ]
+    estimates = Rotation.from_euler(
+        'zxz', angles, degrees=True).as_euler('zxz', degrees=True)
+    assert_allclose(angles, estimates)

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -12,23 +12,23 @@ from itertools import permutations
 
 def test_generic_quat_matrix():
     x = np.array([[3, 4, 0, 0], [5, 12, 0, 0]])
-    r = Rotation.from_quaternion(x)
+    r = Rotation.from_quat(x)
     expected_quat = x / np.array([[5], [13]])
-    assert_array_almost_equal(r.as_quaternion(), expected_quat)
+    assert_array_almost_equal(r.as_quat(), expected_quat)
 
 
 def test_from_single_1d_quaternion():
     x = np.array([3, 4, 0, 0])
-    r = Rotation.from_quaternion(x)
+    r = Rotation.from_quat(x)
     expected_quat = x / 5
-    assert_array_almost_equal(r.as_quaternion(), expected_quat)
+    assert_array_almost_equal(r.as_quat(), expected_quat)
 
 
 def test_from_single_2d_quaternion():
     x = np.array([[3, 4, 0, 0]])
-    r = Rotation.from_quaternion(x)
+    r = Rotation.from_quat(x)
     expected_quat = x / 5
-    assert_array_almost_equal(r.as_quaternion(), expected_quat)
+    assert_array_almost_equal(r.as_quat(), expected_quat)
 
 
 def test_from_square_quat_matrix():
@@ -39,44 +39,44 @@ def test_from_square_quat_matrix():
         [0, 0, 0, 1],
         [0, 0, 0, -1]
         ])
-    r = Rotation.from_quaternion(x)
+    r = Rotation.from_quat(x)
     expected_quat = x / np.array([[5], [13], [1], [1]])
-    assert_array_almost_equal(r.as_quaternion(), expected_quat)
+    assert_array_almost_equal(r.as_quat(), expected_quat)
 
 
-def test_malformed_1d_from_quaternion():
+def test_malformed_1d_from_quat():
     with pytest.raises(ValueError):
-        Rotation.from_quaternion(np.array([1, 2, 3]))
+        Rotation.from_quat(np.array([1, 2, 3]))
 
 
-def test_malformed_2d_from_quaternion():
+def test_malformed_2d_from_quat():
     with pytest.raises(ValueError):
-        Rotation.from_quaternion(np.array([
+        Rotation.from_quat(np.array([
             [1, 2, 3, 4, 5],
             [4, 5, 6, 7, 8]
             ]))
 
 
-def test_zero_norms_from_quaternion():
+def test_zero_norms_from_quat():
     x = np.array([
             [3, 4, 0, 0],
             [0, 0, 0, 0],
             [5, 0, 12, 0]
             ])
     with pytest.raises(ValueError):
-        Rotation.from_quaternion(x)
+        Rotation.from_quat(x)
 
 
 def test_as_dcm_single_1d_quaternion():
     quat = [0, 0, 0, 1]
-    mat = Rotation.from_quaternion(quat).as_dcm()
+    mat = Rotation.from_quat(quat).as_dcm()
     # mat.shape == (3,3) due to 1d input
     assert_array_almost_equal(mat, np.eye(3))
 
 
 def test_as_dcm_single_2d_quaternion():
     quat = [[0, 0, 1, 1]]
-    mat = Rotation.from_quaternion(quat).as_dcm()
+    mat = Rotation.from_quat(quat).as_dcm()
     assert_equal(mat.shape, (1, 3, 3))
     expected_mat = np.array([
         [0, -1, 0],
@@ -93,7 +93,7 @@ def test_as_dcm_from_square_input():
             [0, 0, 0, 1],
             [0, 0, 0, -1]
             ]
-    mat = Rotation.from_quaternion(quats).as_dcm()
+    mat = Rotation.from_quat(quats).as_dcm()
     assert_equal(mat.shape, (4, 3, 3))
 
     expected0 = np.array([
@@ -120,7 +120,7 @@ def test_as_dcm_from_generic_input():
             [0, 1, 0, 1],
             [1, 2, 3, 4]
             ]
-    mat = Rotation.from_quaternion(quats).as_dcm()
+    mat = Rotation.from_quat(quats).as_dcm()
     assert_equal(mat.shape, (3, 3, 3))
 
     expected0 = np.array([
@@ -153,7 +153,7 @@ def test_from_single_2d_dcm():
             ]
     expected_quat = [0.5, 0.5, 0.5, 0.5]
     assert_array_almost_equal(
-            Rotation.from_dcm(dcm).as_quaternion(),
+            Rotation.from_dcm(dcm).as_quat(),
             expected_quat)
 
 
@@ -165,7 +165,7 @@ def test_from_single_3d_dcm():
         ]).reshape((1, 3, 3))
     expected_quat = np.array([0.5, 0.5, 0.5, 0.5]).reshape((1, 4))
     assert_array_almost_equal(
-            Rotation.from_dcm(dcm).as_quaternion(),
+            Rotation.from_dcm(dcm).as_quat(),
             expected_quat)
 
 
@@ -177,10 +177,10 @@ def test_from_dcm_calculation():
             [0.2564103, 0.3589744, 0.8974359]
             ])
     assert_array_almost_equal(
-            Rotation.from_dcm(dcm).as_quaternion(),
+            Rotation.from_dcm(dcm).as_quat(),
             expected_quat)
     assert_array_almost_equal(
-            Rotation.from_dcm(dcm.reshape((1, 3, 3))).as_quaternion(),
+            Rotation.from_dcm(dcm.reshape((1, 3, 3))).as_quat(),
             expected_quat.reshape((1, 4)))
 
 
@@ -208,14 +208,14 @@ def test_from_1d_single_rotvec():
     rotvec = [1, 0, 0]
     expected_quat = np.array([0.4794255, 0, 0, 0.8775826])
     result = Rotation.from_rotvec(rotvec)
-    assert_array_almost_equal(result.as_quaternion(), expected_quat)
+    assert_array_almost_equal(result.as_quat(), expected_quat)
 
 
 def test_from_2d_single_rotvec():
     rotvec = [[1, 0, 0]]
     expected_quat = np.array([[0.4794255, 0, 0, 0.8775826]])
     result = Rotation.from_rotvec(rotvec)
-    assert_array_almost_equal(result.as_quaternion(), expected_quat)
+    assert_array_almost_equal(result.as_quat(), expected_quat)
 
 
 def test_from_generic_rotvec():
@@ -230,7 +230,7 @@ def test_from_generic_rotvec():
         [0, 0, 0, 1]
         ])
     assert_array_almost_equal(
-            Rotation.from_rotvec(rotvec).as_quaternion(),
+            Rotation.from_rotvec(rotvec).as_quat(),
             expected_quat)
 
 
@@ -241,7 +241,7 @@ def test_from_rotvec_small_angle():
         [0, 0, 0]
         ])
 
-    quat = Rotation.from_rotvec(rotvec).as_quaternion()
+    quat = Rotation.from_rotvec(rotvec).as_quat()
     # cos(theta/2) ~~ 1 for small theta
     assert_allclose(quat[0, 3], 1)
     # sin(theta/2) / theta ~~ 0.5 for small theta
@@ -280,7 +280,7 @@ def test_as_generic_rotvec():
             ])
     quat /= np.linalg.norm(quat, axis=1)[:, None]
 
-    rotvec = Rotation.from_quaternion(quat).as_rotvec()
+    rotvec = Rotation.from_quat(quat).as_rotvec()
     angle = np.linalg.norm(rotvec, axis=1)
 
     assert_allclose(quat[:, 3], np.cos(angle/2))
@@ -291,7 +291,7 @@ def test_as_rotvec_single_1d_input():
     quat = np.array([1, 2, -3, 2])
     expected_rotvec = np.array([0.5772381, 1.1544763, -1.7317144])
 
-    actual_rotvec = Rotation.from_quaternion(quat).as_rotvec()
+    actual_rotvec = Rotation.from_quat(quat).as_rotvec()
 
     assert_equal(actual_rotvec.shape, (3,))
     assert_allclose(actual_rotvec, expected_rotvec)
@@ -301,7 +301,7 @@ def test_as_rotvec_single_2d_input():
     quat = np.array([[1, 2, -3, 2]])
     expected_rotvec = np.array([[0.5772381, 1.1544763, -1.7317144]])
 
-    actual_rotvec = Rotation.from_quaternion(quat).as_rotvec()
+    actual_rotvec = Rotation.from_quat(quat).as_rotvec()
 
     assert_equal(actual_rotvec.shape, (1, 3))
     assert_allclose(actual_rotvec, expected_rotvec)
@@ -318,7 +318,7 @@ def test_rotvec_calc_pipeline():
 
 
 def test_from_euler_single_rotation():
-    quat = Rotation.from_euler('z', 90, degrees=True).as_quaternion()
+    quat = Rotation.from_euler('z', 90, degrees=True).as_quat()
     expected_quat = np.array([0, 0, 1, 1]) / np.sqrt(2)
     assert_allclose(quat, expected_quat)
 
@@ -334,8 +334,8 @@ def test_from_euler_rotation_order():
     np.random.seed(0)
     a = np.random.randint(low=0, high=180, size=(6, 3))
     b = a[:, ::-1]
-    x = Rotation.from_euler('xyz', a, degrees=True).as_quaternion()
-    y = Rotation.from_euler('ZYX', b, degrees=True).as_quaternion()
+    x = Rotation.from_euler('xyz', a, degrees=True).as_quat()
+    y = Rotation.from_euler('ZYX', b, degrees=True).as_quat()
     assert_allclose(x, y)
 
 
@@ -576,7 +576,7 @@ def test_as_euler_degenerate_symmetric_axes():
 def test_inv():
     np.random.seed(0)
     n = 10
-    p = Rotation.from_quaternion(np.random.normal(size=(n, 4)))
+    p = Rotation.from_quat(np.random.normal(size=(n, 4)))
     q = p.inv()
 
     p_dcm = p.as_dcm()
@@ -593,7 +593,7 @@ def test_inv():
 
 def test_inv_single_rotation():
     np.random.seed(0)
-    p = Rotation.from_quaternion(np.random.normal(size=(4,)))
+    p = Rotation.from_quat(np.random.normal(size=(4,)))
     q = p.inv()
 
     p_dcm = p.as_dcm()
@@ -606,7 +606,7 @@ def test_inv_single_rotation():
     assert_array_almost_equal(res1, eye)
     assert_array_almost_equal(res2, eye)
 
-    x = Rotation.from_quaternion(np.random.normal(size=(1, 4)))
+    x = Rotation.from_quat(np.random.normal(size=(1, 4)))
     y = x.inv()
 
     x_dcm = x.as_dcm()
@@ -766,7 +766,7 @@ def test_quat_ownership():
         [0, 1, 0, 0],
         [0, 0, 1, 0]
     ])
-    r = Rotation.from_quaternion(quat, normalized=True)
+    r = Rotation.from_quat(quat, normalized=True)
     s = r[0:2]
 
     r._quat[0] = np.array([0, -1, 0, 0])

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -11,14 +11,21 @@ def test_generic_quat_matrix():
     x = np.array([[3, 4, 0, 0], [5, 12, 0, 0]])
     r = Rotation.from_quaternion(x)
     expected_quat = x / np.array([[5], [13]])
-    assert_array_almost_equal(r._quat, expected_quat)
+    assert_array_almost_equal(r.as_quaternion(), expected_quat)
 
 
-def test_from_single_quaternion():
+def test_from_single_1d_quaternion():
     x = np.array([3, 4, 0, 0])
     r = Rotation.from_quaternion(x)
-    expected_quat = x[None, :] / 5
-    assert_array_almost_equal(r._quat, expected_quat)
+    expected_quat = x / 5
+    assert_array_almost_equal(r.as_quaternion(), expected_quat)
+
+
+def test_from_single_2d_quaternion():
+    x = np.array([[3, 4, 0, 0]])
+    r = Rotation.from_quaternion(x)
+    expected_quat = x / 5
+    assert_array_almost_equal(r.as_quaternion(), expected_quat)
 
 
 def test_from_square_quat_matrix():
@@ -31,7 +38,7 @@ def test_from_square_quat_matrix():
         ])
     r = Rotation.from_quaternion(x)
     expected_quat = x / np.array([[5], [13], [1], [1]])
-    assert_array_almost_equal(r._quat, expected_quat)
+    assert_array_almost_equal(r.as_quaternion(), expected_quat)
 
 
 def test_malformed_1d_from_quaternion():

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -323,16 +323,16 @@ def test_from_euler_single_rotation():
 
 
 def test_single_intrinsic_extrinsic_rotation():
-    ext = Rotation.from_euler('z', 90, degrees=True).as_dcm()
-    int = Rotation.from_euler('Z', 90, degrees=True).as_dcm()
-    assert_allclose(ext, int)
+    extrinsic = Rotation.from_euler('z', 90, degrees=True).as_dcm()
+    intrinsic = Rotation.from_euler('Z', 90, degrees=True).as_dcm()
+    assert_allclose(extrinsic, intrinsic)
 
 
 def test_from_euler_rotation_order():
     # Intrinsic rotation is same as extrinsic with order reversed
     np.random.seed(0)
     a = np.random.randint(low=0, high=180, size=(6, 3))
-    b = a[:, np.argsort([2, 1, 0])]
+    b = a[:, ::-1]
     x = Rotation.from_euler('xyz', a, degrees=True).as_quaternion()
     y = Rotation.from_euler('ZYX', b, degrees=True).as_quaternion()
     assert_allclose(x, y)
@@ -347,3 +347,111 @@ def test_from_euler_elementary_extrinsic_rotation():
         [1, 0, 0]
     ])
     assert_array_almost_equal(dcm, expected_dcm)
+
+
+def test_from_euler_intrinsic_rotation_312():
+    angles = [
+        [30, 60, 45],
+        [30, 60, 30],
+        [45, 30, 60]
+        ]
+    dcm = Rotation.from_euler('ZXY', angles, degrees=True).as_dcm()
+
+    assert_array_almost_equal(dcm[0], np.array([
+        [0.3061862, -0.2500000, 0.9185587],
+        [0.8838835, 0.4330127, -0.1767767],
+        [-0.3535534, 0.8660254, 0.3535534]
+    ]))
+
+    assert_array_almost_equal(dcm[1], np.array([
+        [0.5334936, -0.2500000, 0.8080127],
+        [0.8080127, 0.4330127, -0.3995191],
+        [-0.2500000, 0.8660254, 0.4330127]
+    ]))
+
+    assert_array_almost_equal(dcm[2], np.array([
+        [0.0473672, -0.6123725, 0.7891491],
+        [0.6597396, 0.6123725, 0.4355958],
+        [-0.7500000, 0.5000000, 0.4330127]
+    ]))
+
+
+def test_from_euler_intrinsic_rotation_313():
+    angles = [
+        [30, 60, 45],
+        [30, 60, 30],
+        [45, 30, 60]
+        ]
+    dcm = Rotation.from_euler('ZXZ', angles, degrees=True).as_dcm()
+
+    assert_array_almost_equal(dcm[0], np.array([
+        [0.43559574, -0.78914913, 0.4330127],
+        [0.65973961, -0.04736717, -0.750000],
+        [0.61237244, 0.61237244, 0.500000]
+    ]))
+
+    assert_array_almost_equal(dcm[1], np.array([
+        [0.6250000, -0.64951905, 0.4330127],
+        [0.64951905, 0.1250000, -0.750000],
+        [0.4330127, 0.750000, 0.500000]
+    ]))
+
+    assert_array_almost_equal(dcm[2], np.array([
+        [-0.1767767, -0.91855865, 0.35355339],
+        [0.88388348, -0.30618622, -0.35355339],
+        [0.4330127, 0.25000000, 0.8660254]
+    ]))
+
+
+def test_from_euler_extrinsic_rotation_312():
+    angles = [
+        [30, 60, 45],
+        [30, 60, 30],
+        [45, 30, 60]
+        ]
+    dcm = Rotation.from_euler('zxy', angles, degrees=True).as_dcm()
+
+    assert_array_almost_equal(dcm[0], np.array([
+        [0.91855865, 0.1767767, 0.35355339],
+        [0.25000000, 0.4330127, -0.8660254],
+        [-0.30618622, 0.88388348, 0.35355339]
+    ]))
+
+    assert_array_almost_equal(dcm[1], np.array([
+        [0.96650635, -0.0580127, 0.2500000],
+        [0.25000000, 0.4330127, -0.8660254],
+        [-0.0580127, 0.89951905, 0.4330127]
+    ]))
+
+    assert_array_almost_equal(dcm[2], np.array([
+        [0.65973961, -0.04736717, 0.7500000],
+        [0.61237244, 0.61237244, -0.5000000],
+        [-0.43559574, 0.78914913, 0.4330127]
+    ]))
+
+
+def test_from_euler_extrinsic_rotation_313():
+    angles = [
+        [30, 60, 45],
+        [30, 60, 30],
+        [45, 30, 60]
+        ]
+    dcm = Rotation.from_euler('zxz', angles, degrees=True).as_dcm()
+
+    assert_array_almost_equal(dcm[0], np.array([
+        [0.43559574, -0.65973961, 0.61237244],
+        [0.78914913, -0.04736717, -0.61237244],
+        [0.4330127, 0.75000000, 0.500000]
+    ]))
+
+    assert_array_almost_equal(dcm[1], np.array([
+        [0.62500000, -0.64951905, 0.4330127],
+        [0.64951905, 0.12500000, -0.750000],
+        [0.4330127, 0.75000000, 0.500000]
+    ]))
+
+    assert_array_almost_equal(dcm[2], np.array([
+        [-0.1767767, -0.88388348, 0.4330127],
+        [0.91855865, -0.30618622, -0.250000],
+        [0.35355339, 0.35355339, 0.8660254]
+    ]))

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -503,8 +503,6 @@ def test_as_euler_degenerate_asymmetric_axes():
         [45, 90, 35],
         [35, -90, 20],
         [35, 90, 25],
-        [15, 0, 60],
-        [35, 0, 75],
         [25, -90, 15]
         ])
 
@@ -538,12 +536,10 @@ def test_as_euler_degenerate_asymmetric_axes():
 def test_as_euler_degenerate_symmetric_axes():
     # Since we cannot check for angle equality, we check for dcm equality
     angles = np.array([
-        [45, 90, 35],
-        [35, -90, 20],
-        [35, 90, 25],
         [15, 0, 60],
         [35, 0, 75],
-        [25, -90, 15]
+        [60, 180, 35],
+        [15, -180, 25],
         ])
 
     with pytest.warns(UserWarning, match="Gimbal lock"):

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -192,7 +192,11 @@ def test_from_dcm_ortho_output():
     dcm = np.random.random((100, 3, 3))
     ortho_dcm = Rotation.from_dcm(dcm).as_dcm()
 
-    # numpy.__matmul__ was not present in numpy v1.8.2. Avoid use
-    assert_array_almost_equal(
-            np.linalg.inv(ortho_dcm),
+    mult_result = np.einsum('...ij,...jk->...ik', ortho_dcm,
             ortho_dcm.transpose((0, 2, 1)))
+
+    eye3d = np.zeros((100, 3, 3))
+    for i in range(3):
+        eye3d[:, i, i] = 1.0
+
+    assert_array_almost_equal(mult_result, eye3d)

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -193,7 +193,7 @@ def test_from_dcm_ortho_output():
     ortho_dcm = Rotation.from_dcm(dcm).as_dcm()
 
     mult_result = np.einsum('...ij,...jk->...ik', ortho_dcm,
-            ortho_dcm.transpose((0, 2, 1)))
+                            ortho_dcm.transpose((0, 2, 1)))
 
     eye3d = np.zeros((100, 3, 3))
     for i in range(3):

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -200,3 +200,33 @@ def test_from_dcm_ortho_output():
         eye3d[:, i, i] = 1.0
 
     assert_array_almost_equal(mult_result, eye3d)
+
+
+def test_from_1d_single_rotvec():
+    rotvec = [1, 0, 0]
+    expected_quat = np.array([0.4794255, 0, 0, 0.8775826])
+    result = Rotation.from_rotvec(rotvec)
+    assert_equal(result._single, True)
+    assert_array_almost_equal(result._quat[0], expected_quat)
+
+
+def test_from_2d_single_rotvec():
+    rotvec = [[1, 0, 0]]
+    expected_quat = np.array([[0.4794255, 0, 0, 0.8775826]])
+    result = Rotation.from_rotvec(rotvec)
+    assert_equal(result._single, False)
+    assert_array_almost_equal(result._quat, expected_quat)
+
+
+def test_from_generic_rotvec():
+    rotvec = [
+            [1, 2, 2],
+            [1, -1, 0.5]
+            ]
+    expected_quat = np.array([
+        [0.3324983, 0.6649967, 0.6649967, 0.0707372],
+        [0.4544258, -0.4544258, 0.2272129, 0.7316889]
+        ])
+    assert_array_almost_equal(
+            Rotation.from_rotvec(rotvec)._quat,
+            expected_quat)

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -183,11 +183,12 @@ def test_from_dcm_calculation():
 
 
 def test_dcm_calculation_pipeline():
-    dcm = np.array([special_ortho_group.rvs(3) for _ in range(10)])
+    dcm = special_ortho_group.rvs(3, size=10, random_state=0)
     assert_array_almost_equal(Rotation.from_dcm(dcm).as_dcm(), dcm)
 
 
 def test_from_dcm_ortho_output():
+    np.random.seed(0)
     dcm = np.random.random((100, 3, 3))
     ortho_dcm = Rotation.from_dcm(dcm).as_dcm()
 

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -619,3 +619,86 @@ def test_inv_single_rotation():
 
     assert_array_almost_equal(result1, eye3d)
     assert_array_almost_equal(result2, eye3d)
+
+
+def test_apply_single_rotation_single_point():
+    r_1d = Rotation.from_dcm([
+        [0, -1, 0],
+        [1, 0, 0],
+        [0, 0, 1]
+    ])
+    r_2d = Rotation.from_dcm([[
+        [0, -1, 0],
+        [1, 0, 0],
+        [0, 0, 1]
+    ]])
+
+    v_1d = np.array([1, 2, 3])
+    v_2d = np.array([[1, 2, 3]])
+
+    assert_allclose(r_1d.apply(v_1d), np.array([-2, 1, 3]))
+    assert_allclose(r_1d.apply(v_2d), np.array([[-2, 1, 3]]))
+    assert_allclose(r_2d.apply(v_1d), np.array([[-2, 1, 3]]))
+    assert_allclose(r_2d.apply(v_2d), np.array([[-2, 1, 3]]))
+
+
+def test_apply_single_rotation_multiple_points():
+    r1 = Rotation.from_dcm([
+        [0, -1, 0],
+        [1, 0, 0],
+        [0, 0, 1]
+    ])
+    r2 = Rotation.from_dcm([[
+            [0, -1, 0],
+            [1, 0, 0],
+            [0, 0, 1]
+        ]])
+
+    v = np.array([[1, 2, 3], [4, 5, 6]])
+    v_rotated = np.array([[-2, 1, 3], [-5, 4, 6]])
+
+    assert_allclose(r1.apply(v), v_rotated)
+    assert_allclose(r2.apply(v), v_rotated)
+
+
+def test_apply_multiple_rotations_single_point():
+    dcm = np.empty((2, 3, 3))
+    dcm[0] = np.array([
+        [0, -1, 0],
+        [1, 0, 0],
+        [0, 0, 1]
+    ])
+    dcm[1] = np.array([
+        [1, 0, 0],
+        [0, 0, -1],
+        [0, 1, 0]
+    ])
+    r = Rotation.from_dcm(dcm)
+
+    v1 = np.array([1, 2, 3])
+    v2 = np.array([[1, 2, 3]])
+
+    v_rotated = np.array([[-2, 1, 3], [1, -3, 2]])
+
+    assert_allclose(r.apply(v1), v_rotated)
+    assert_allclose(r.apply(v2), v_rotated)
+
+
+def test_apply_multiple_rotations_multiple_points():
+    dcm = np.empty((2, 3, 3))
+    dcm[0] = np.array([
+        [0, -1, 0],
+        [1, 0, 0],
+        [0, 0, 1]
+    ])
+    dcm[1] = np.array([
+        [1, 0, 0],
+        [0, 0, -1],
+        [0, 1, 0]
+    ])
+    r = Rotation.from_dcm(dcm)
+
+    v = np.array([[1, 2, 3], [4, 5, 6]])
+    v_rotated = np.array([[-2, 1, 3], [4, -6, 5]])
+
+    assert_allclose(r.apply(v), v_rotated)

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -460,12 +460,12 @@ def test_from_euler_extrinsic_rotation_313():
 def test_as_euler_extrinsic_rotation():
     np.random.seed(0)
     angles = np.random.uniform(low=-np.pi, high=np.pi, size=(6, 3))
-    rot_obj = Rotation.from_euler('zxy', angles)
+    rotation = Rotation.from_euler('zxy', angles)
 
-    estimates = rot_obj.as_euler('zxy')
-    est_obj = Rotation.from_euler('zxy', estimates)
+    angle_estimates = rotation.as_euler('zxy')
+    estimated = Rotation.from_euler('zxy', angle_estimates)
 
-    assert_array_almost_equal(rot_obj.as_dcm(), est_obj.as_dcm())
+    assert_array_almost_equal(rotation.as_dcm(), estimated.as_dcm())
 
 
 def test_as_euler_intrinsic_rotation():

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -221,11 +221,13 @@ def test_from_2d_single_rotvec():
 def test_from_generic_rotvec():
     rotvec = [
             [1, 2, 2],
-            [1, -1, 0.5]
+            [1, -1, 0.5],
+            [0, 0, 0]
             ]
     expected_quat = np.array([
         [0.3324983, 0.6649967, 0.6649967, 0.0707372],
-        [0.4544258, -0.4544258, 0.2272129, 0.7316889]
+        [0.4544258, -0.4544258, 0.2272129, 0.7316889],
+        [0, 0, 0, 1]
         ])
     assert_array_almost_equal(
             Rotation.from_rotvec(rotvec)._quat,

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -576,8 +576,7 @@ def test_as_euler_degenerate_symmetric_axes():
 def test_inv():
     np.random.seed(0)
     n = 10
-    quat = np.random.normal(size=(n, 4))
-    p = Rotation.from_quaternion(quat)
+    p = Rotation.from_quaternion(np.random.normal(size=(n, 4)))
     q = p.inv()
 
     p_dcm = p.as_dcm()
@@ -585,9 +584,38 @@ def test_inv():
     result1 = np.einsum('...ij,...jk->...ik', p_dcm, q_dcm)
     result2 = np.einsum('...ij,...jk->...ik', q_dcm, p_dcm)
 
-    eye3d = np.zeros((n, 3, 3))
-    for i in range(3):
-        eye3d[:, i, i] = 1
+    eye3d = np.empty((n, 3, 3))
+    eye3d[:] = np.eye(3)
+
+    assert_array_almost_equal(result1, eye3d)
+    assert_array_almost_equal(result2, eye3d)
+
+
+def test_inv_single_rotation():
+    np.random.seed(0)
+    p = Rotation.from_quaternion(np.random.normal(size=(4,)))
+    q = p.inv()
+
+    p_dcm = p.as_dcm()
+    q_dcm = q.as_dcm()
+    res1 = np.dot(p_dcm, q_dcm)
+    res2 = np.dot(q_dcm, p_dcm)
+
+    eye = np.eye(3)
+
+    assert_array_almost_equal(res1, eye)
+    assert_array_almost_equal(res2, eye)
+
+    x = Rotation.from_quaternion(np.random.normal(size=(1, 4)))
+    y = x.inv()
+
+    x_dcm = x.as_dcm()
+    y_dcm = y.as_dcm()
+    result1 = np.einsum('...ij,...jk->...ik', x_dcm, y_dcm)
+    result2 = np.einsum('...ij,...jk->...ik', y_dcm, x_dcm)
+
+    eye3d = np.empty((1, 3, 3))
+    eye3d[:] = np.eye(3)
 
     assert_array_almost_equal(result1, eye3d)
     assert_array_almost_equal(result2, eye3d)

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -1,5 +1,7 @@
 from __future__ import division, print_function, absolute_import
 
+import pytest
+
 import numpy as np
 from numpy.testing import assert_array_almost_equal
 from scipy.spatial.transform import Rotation
@@ -11,11 +13,13 @@ def test_generic_quat_matrix():
     expected_quat = x / np.array([[5], [13]])
     assert_array_almost_equal(r._quat, expected_quat)
 
+
 def test_from_single_quaternion():
     x = np.array([3,4,0,0])
     r = Rotation.from_quaternion(x)
     expected_quat = x[None, :] / 5
     assert_array_almost_equal(r._quat, expected_quat)
+
 
 def test_from_square_quat_matrix():
     # Ensure proper norm array broadcasting
@@ -28,3 +32,32 @@ def test_from_square_quat_matrix():
     r = Rotation.from_quaternion(x)
     expected_quat = x / np.array([[5], [13], [1], [1]])
     assert_array_almost_equal(r._quat, expected_quat)
+
+
+def test_malformed_1d_from_quaternion():
+    with pytest.raises(ValueError):
+        Rotation.from_quaternion(np.array([1,2,3]))
+
+
+def test_malformed_2d_from_quaternion():
+    with pytest.raises(ValueError):
+        Rotation.from_quaternion(np.array([
+            [1,2,3,4,5],
+            [4,5,6,7,8]
+            ]))
+
+
+def test_zero_norms_from_quaternion():
+    x = np.array([
+            [3, 4, 0, 0],
+            [0, 0, 0, 0],
+            [5, 0, 12, 0]
+            ])
+    with pytest.raises(UserWarning):
+        r = Rotation.from_quaternion(x)
+        expected_quat = np.array([
+            x[0] / 5,
+            [0, 0, 0, 1],
+            x[2] / 13
+            ])
+        assert_array_almost_equal(r, expected_quat)

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -501,14 +501,14 @@ def test_as_euler_degenerate_asymmetric_axes():
     # Since we cannot check for angle equality, we check for dcm equality
     angles = np.array([
         [45, 90, 35],
-        [90, 35, 20],
-        [35, 60, 90],
-        [0, 15, 60],
+        [35, -90, 20],
+        [35, 90, 25],
+        [15, 0, 60],
         [35, 0, 75],
-        [65, 85, 0]
+        [25, -90, 15]
         ])
 
-    with pytest.warns(UserWarning, match="gimbal lock"):
+    with pytest.warns(UserWarning, match="Gimbal lock"):
         for seq_tuple in permutations('xyz'):
             # Extrinsic rotations
             seq = ''.join(seq_tuple)
@@ -539,14 +539,14 @@ def test_as_euler_degenerate_symmetric_axes():
     # Since we cannot check for angle equality, we check for dcm equality
     angles = np.array([
         [45, 90, 35],
-        [90, 35, 20],
-        [35, 60, 90],
-        [0, 15, 60],
+        [35, -90, 20],
+        [35, 90, 25],
+        [15, 0, 60],
         [35, 0, 75],
-        [65, 85, 0]
+        [25, -90, 15]
         ])
 
-    with pytest.warns(UserWarning, match="gimbal lock"):
+    with pytest.warns(UserWarning, match="Gimbal lock"):
         for axis1 in ['x', 'y', 'z']:
             for axis2 in ['x', 'y', 'z']:
                 if axis1 == axis2:

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -571,3 +571,23 @@ def test_as_euler_degenerate_symmetric_axes():
                     ).as_dcm()
 
                 assert_array_almost_equal(dcm_expected, dcm_estimated)
+
+
+def test_inv():
+    np.random.seed(0)
+    n = 10
+    quat = np.random.normal(size=(n, 4))
+    p = Rotation.from_quaternion(quat)
+    q = p.inv()
+
+    p_dcm = p.as_dcm()
+    q_dcm = q.as_dcm()
+    result1 = np.einsum('...ij,...jk->...ik', p_dcm, q_dcm)
+    result2 = np.einsum('...ij,...jk->...ik', q_dcm, p_dcm)
+
+    eye3d = np.zeros((n, 3, 3))
+    for i in range(3):
+        eye3d[:, i, i] = 1
+
+    assert_array_almost_equal(result1, eye3d)
+    assert_array_almost_equal(result2, eye3d)

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -329,9 +329,21 @@ def test_single_intrinsic_extrinsic_rotation():
 
 
 def test_from_euler_rotation_order():
+    # Intrinsic rotation is same as extrinsic with order reversed
     np.random.seed(0)
     a = np.random.randint(low=0, high=180, size=(6, 3))
     b = a[:, np.argsort([2, 1, 0])]
     x = Rotation.from_euler('xyz', a, degrees=True).as_quaternion()
     y = Rotation.from_euler('ZYX', b, degrees=True).as_quaternion()
     assert_allclose(x, y)
+
+
+def test_from_euler_elementary_extrinsic_rotation():
+    # Simple test to check if extrinsic rotations are implemented correctly
+    dcm = Rotation.from_euler('zx', [90, 90], degrees=True).as_dcm()
+    expected_dcm = np.array([
+        [0, -1, 0],
+        [0, 0, -1],
+        [1, 0, 0]
+    ])
+    assert_array_almost_equal(dcm, expected_dcm)

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -715,15 +715,8 @@ def test_apply_multiple_rotations_multiple_points():
     v = np.array([[1, 2, 3], [4, 5, 6]])
     v_rotated = np.array([[-2, 1, 3], [4, -6, 5]])
     assert_allclose(r.apply(v), v_rotated)
-    v_inverse = np.array([[2, -1, 3], [4, 6, -5]])
-    assert_allclose(r.apply(v, inverse=True), v_inverse)
 
     v_inverse = np.array([[2, -1, 3], [4, 6, -5]])
-
-    assert_allclose(r.apply(v, inverse=True), v_inverse)
-
-    v_inverse = np.array([[2, -1, 3], [4, 6, -5]])
-
     assert_allclose(r.apply(v, inverse=True), v_inverse)
 
 
@@ -764,3 +757,5 @@ def test_n_rotations():
     assert_equal(r[0].n, 1)
     assert_equal(r[1].n, 1)
     assert_equal(r[:-1].n, 1)
+=======
+>>>>>>> 18e780c25... TST: Add test with inverse=True


### PR DESCRIPTION
This pull request implements, documents, and tests the following features to the `Rotation` class under a new sub-package `scipy.spatial.transform`:
- Initializers from and converters to quaternions, direction cosine matrices, euler angles and rotation vector representations of rotations
- Application of a rotation to vectors
- Inversion and composition of rotations
- Indexing into a `Rotation` object to extract specific rotation(s)