### PR TITLE
Fix rST for the “sparse” module

### DIFF
--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -84,8 +84,8 @@ Submodules
 .. autosummary::
    :toctree: generated/
 
-   csgraph - Compressed sparse graph routines
-   linalg - sparse linear algebra routines
+   csgraph
+   linalg
 
 Exceptions
 ----------


### PR DESCRIPTION
The `sparse` module doesn’t use valid syntax for one autodoc directive:

![image](https://user-images.githubusercontent.com/291575/41647137-d4ecc9be-7475-11e8-88a8-c1cf98b9db21.png)

The lines I deleted belong into the first line of the referenced modules’ docstring.
