### PR TITLE
BUG/ENH: Added possible _transpose into LinearOperator. Fixes #8486

### DIFF
--- a/scipy/sparse/linalg/interface.py
+++ b/scipy/sparse/linalg/interface.py
@@ -428,6 +428,12 @@ class LinearOperator(object):
         return self._adjoint()
 
     H = property(adjoint)
+    
+    def _transpose(self):
+        N,M = self.shape
+        I = np.eye(M, M)
+        X = self.matmat(I)
+        return MatrixLinearOperator(np.transpose(X))
 
     def transpose(self):
         """Transpose this linear operator.


### PR DESCRIPTION
I've submited possible solution to #8486 by adding _transpose funtion into LinearOperator code. It actualy returns MatrixLinearOperator, but it can be easily transformed. Please review this PR and also the idea. Thanks :)