### PR TITLE
BUG: make LinearOperator.matmat interaction with matvec

### DIFF
--- a/scipy/sparse/linalg/interface.py
+++ b/scipy/sparse/linalg/interface.py
@@ -171,7 +171,7 @@ class LinearOperator(object):
         define matrix multiplication (though in a very suboptimal way).
         """
 
-        return np.hstack([self.matvec(col.reshape(-1,1)) for col in X.T])
+        return np.array([self.matvec(col) for col in X])
 
     def _matvec(self, x):
         """Default matrix-vector multiplication handler.

--- a/scipy/sparse/linalg/interface.py
+++ b/scipy/sparse/linalg/interface.py
@@ -428,6 +428,12 @@ class LinearOperator(object):
         return self._adjoint()
 
     H = property(adjoint)
+    
+    def _transpose(self):
+        N,M = self.shape
+        I = np.eye(M, M)
+        X = self.matmat(I)
+        return MatrixLinearOperator(np.transpose(X))
 
     def transpose(self):
         """Transpose this linear operator.


### PR DESCRIPTION
Easy fix in LinearOperator fixing #8444. I have no idea why it was made in the previous way. Now it works. In my opinion this whole code looks pretty strange. Can anybody review my changes?