### PR TITLE
DOC, MAINT: HTTP -> HTTPS, and other linkrot fixes

### DIFF
--- a/HACKING.rst.txt
+++ b/HACKING.rst.txt
@@ -462,27 +462,27 @@ suite.
 
 .. _scikit-image: http://scikit-image.org/
 
-.. _statsmodels: http://statsmodels.sourceforge.net/
+.. _statsmodels: https://www.statsmodels.org/
 
 .. _testing guidelines: https://github.com/numpy/numpy/blob/master/doc/TESTS.rst.txt
 
-.. _formatted correctly: http://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message
+.. _formatted correctly: https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message
 
 .. _how to document: https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt
 
-.. _bug report: http://scipy.org/bug-report.html
+.. _bug report: https://scipy.org/bug-report.html
 
-.. _PEP8: http://www.python.org/dev/peps/pep-0008/
+.. _PEP8: https://www.python.org/dev/peps/pep-0008/
 
-.. _pep8 package: http://pypi.python.org/pypi/pep8
+.. _pep8 package: https://pypi.python.org/pypi/pep8
 
-.. _pyflakes: http://pypi.python.org/pypi/pyflakes
+.. _pyflakes: https://pypi.python.org/pypi/pyflakes
 
 .. _SciPy API: https://docs.scipy.org/doc/scipy/reference/api.html
 
 .. _SciPy Roadmap: https://scipy.github.io/devdocs/roadmap.html
 
-.. _git workflow: http://docs.scipy.org/doc/numpy/dev/gitwash/index.html
+.. _git workflow: https://docs.scipy.org/doc/numpy/dev/gitwash/
 
 .. _Github help pages: https://help.github.com/articles/set-up-git/
 
@@ -492,19 +492,19 @@ suite.
 
 .. _scipy.org: https://scipy.org/
 
-.. _scipy.github.com: http://scipy.github.com/
+.. _scipy.github.com: https://scipy.github.com/
 
 .. _scipy.org-new: https://github.com/scipy/scipy.org-new
 
 .. _documentation wiki: https://docs.scipy.org/scipy/Front%20Page/
 
-.. _SciPy Central: http://scipy-central.org/
+.. _SciPy Central: https://web.archive.org/web/20170520065729/http://central.scipy.org/
 
-.. _doctest: http://www.doughellmann.com/PyMOTW/doctest/
+.. _doctest: https://pymotw.com/3/doctest/
 
-.. _virtualenv: http://www.virtualenv.org/
+.. _virtualenv: https://virtualenv.pypa.io/
 
-.. _virtualenvwrapper: http://www.doughellmann.com/projects/virtualenvwrapper/
+.. _virtualenvwrapper: https://bitbucket.org/dhellmann/virtualenvwrapper/
 
 .. _bsd pitch: http://nipy.sourceforge.net/nipy/stable/faq/johns_bsd_pitch.html
 

--- a/INSTALL.rst.txt
+++ b/INSTALL.rst.txt
@@ -1,7 +1,7 @@
 Building and installing SciPy
 +++++++++++++++++++++++++++++
 
-See https://www.scipy.org/Installing_SciPy/
+See https://www.scipy.org/install.html
 
 .. Contents::
 
@@ -18,12 +18,12 @@ Recommended distributions are:
 
   - Enthought Canopy (https://www.enthought.com/products/canopy/)
   - Anaconda (https://www.anaconda.com)
-  - Python(x,y) (http://python-xy.github.io/)
+  - Python(x,y) (https://python-xy.github.io/)
   - WinPython (https://winpython.github.io/)
 
 The rest of this install documentation summarizes how to build Scipy.  Note
 that more extensive (and possibly more up-to-date) build instructions are
-maintained at http://scipy.org/scipylib/building/index.html
+maintained at https://scipy.github.io/devdocs/building/
 
 
 PREREQUISITES
@@ -33,11 +33,11 @@ SciPy requires the following software installed for your platform:
 
 1) Python__ 2.7 or >= 3.4
 
-__ http://www.python.org
+__ https://www.python.org
 
 2) NumPy__ >= 1.8.2
 
-__ http://www.numpy.org/
+__ https://www.numpy.org/
 
 3) For building from source: setuptools__
 
@@ -45,7 +45,7 @@ __ https://github.com/pypa/setuptools
 
 4) If you want to build the documentation: Sphinx__ >= 1.2.1
 
-__ http://sphinx-doc.org/
+__ http://www.sphinx-doc.org/
 
 5) If you want to build SciPy master or other unreleased version from source
    (Cython-generated C sources are included in official releases):

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ integration, linear algebra, Fourier transforms, signal and image processing,
 ODE solvers, and more.
 
 - **Website (including documentation):** https://www.scipy.org/
-- **Mailing list:** http://scipy.org/scipylib/mailing-lists.html
+- **Mailing list:** https://scipy.org/scipylib/mailing-lists.html
 - **Source:** https://github.com/scipy/scipy
 - **Bug reports:** https://github.com/scipy/scipy/issues
 

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -16,7 +16,7 @@
     "branches": ["master"],
 
     // The base URL to "how a commit for the project.
-    "show_commit_url": "http://github.com/scipy/scipy/commit/",
+    "show_commit_url": "https://github.com/scipy/scipy/commit/",
 
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.

--- a/benchmarks/benchmarks/go_benchmark_functions/__init__.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/__init__.py
@@ -18,20 +18,20 @@ References
 .. [1] Momin Jamil and Xin-She Yang, A literature survey of benchmark
     functions for global optimization problems, Int. Journal of Mathematical
     Modelling and Numerical Optimisation, Vol. 4, No. 2, pp. 150--194 (2013).
-    http://arxiv.org/pdf/1308.4008v1.pdf
+    https://arxiv.org/abs/1308.4008v1
     (and references contained within)
-.. [2] http://infinity77.net/global_optimization/index.html
+.. [2] http://infinity77.net/global_optimization/
 .. [3] S. K. Mishra, Global Optimization By Differential Evolution and
     Particle Swarm Methods: Evaluation On Some Benchmark Functions, Munich
     Research Papers in Economics
 .. [4] E. P. Adorio, U. P. Dilman, MVF - Multivariate Test Function Library
     in C for Unconstrained Global Optimization Methods, [Available Online]:
-    http://www.geocities.ws/eadorio/mvf.pdf
+    https://www.geocities.ws/eadorio/mvf.pdf
 .. [5] S. K. Mishra, Some New Test Functions For Global Optimization And
     Performance of Repulsive Particle Swarm Method, [Available Online]:
-    http://mpra.ub.uni-muenchen.de/2718/
+    https://mpra.ub.uni-muenchen.de/2718/
 .. [6] NIST StRD Nonlinear Regression Problems, retrieved on 1 Oct, 2014
-    http://www.itl.nist.gov/div898/strd/nls/nls_main.shtml
+    https://www.itl.nist.gov/div898/strd/nls/nls_main.shtml
 
 """
 

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_E.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_E.py
@@ -54,7 +54,7 @@ class Eckerle4(Benchmark):
     Eckerle, K., NIST (1979).
     Circular Interference Transmittance Study.
 
-    ..[1] http://www.itl.nist.gov/div898/strd/nls/data/eckerle4.shtml
+    ..[1] https://www.itl.nist.gov/div898/strd/nls/data/eckerle4.shtml
 
     #TODO, this is a NIST regression standard dataset, docstring needs
     improving

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_K.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_K.py
@@ -128,7 +128,7 @@ class Kowalik(Benchmark):
     *Global optimum*: :math:`f(x) = 0.00030748610` for :math:`x = 
     [0.192833, 0.190836, 0.123117, 0.135766]`.
 
-    ..[1] http://www.itl.nist.gov/div898/strd/nls/data/mgh09.shtml
+    ..[1] https://www.itl.nist.gov/div898/strd/nls/data/mgh09.shtml
     """
 
     def __init__(self, dimensions=4):

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_M.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_M.py
@@ -91,7 +91,7 @@ class Meyer(Benchmark):
     r"""
     Meyer [1]_ objective function.
 
-    ..[1] http://www.itl.nist.gov/div898/strd/nls/data/mgh10.shtml
+    ..[1] https://www.itl.nist.gov/div898/strd/nls/data/mgh10.shtml
 
     TODO NIST regression standard
     """

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_R.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_R.py
@@ -96,7 +96,7 @@ class Ratkowsky01(Benchmark):
     """
     Ratkowsky objective function.
 
-    .. [1] http://www.itl.nist.gov/div898/strd/nls/data/ratkowsky3.shtml
+    .. [1] https://www.itl.nist.gov/div898/strd/nls/data/ratkowsky3.shtml
     """
 
     # TODO, this is a NIST regression standard dataset
@@ -148,7 +148,7 @@ class Ratkowsky02(Benchmark):
     *Global optimum*: :math:`f(x) = 8.0565229338` for
     :math:`x = [7.2462237576e1, 2.6180768402, 6.7359200066e-2]`
 
-    .. [1] http://www.itl.nist.gov/div898/strd/nls/data/ratkowsky2.shtml
+    .. [1] https://www.itl.nist.gov/div898/strd/nls/data/ratkowsky2.shtml
     """
 
     def __init__(self, dimensions=3):

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_T.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_T.py
@@ -56,7 +56,7 @@ class Thurber(Benchmark):
     r"""
     Thurber [1]_ objective function.
 
-    .. [1] http://www.itl.nist.gov/div898/strd/nls/data/thurber.shtml
+    .. [1] https://www.itl.nist.gov/div898/strd/nls/data/thurber.shtml
     """
 
     def __init__(self, dimensions=7):

--- a/benchmarks/benchmarks/spatial.py
+++ b/benchmarks/benchmarks/spatial.py
@@ -192,8 +192,8 @@ class CNeighbors(Benchmark):
         self.T1s.count_neighbors(self.T2s, self.r)
 
 def generate_spherical_points(num_points):
-        # generate uniform points on sphere (see:
-        # http://stackoverflow.com/a/23785326/2942522)
+        # generate uniform points on sphere
+        # see: https://stackoverflow.com/a/23785326
         np.random.seed(123)
         points = np.random.normal(size=(num_points, 3))
         points /= np.linalg.norm(points, axis=1)[:, np.newaxis]

--- a/benchmarks/benchmarks/test_functions.py
+++ b/benchmarks/benchmarks/test_functions.py
@@ -45,7 +45,7 @@ class LJ(object):
 
     a mathematically simple model that approximates the interaction between a
     pair of neutral atoms or molecules.
-    http://en.wikipedia.org/wiki/Lennard-Jones_potential
+    https://en.wikipedia.org/wiki/Lennard-Jones_potential
 
     E = sum_ij V(r_ij)
 
@@ -170,9 +170,9 @@ Global Test functions for minimizers.
 
 HolderTable, Ackey and Levi have many competing local minima and are suited
 for global minimizers such as basinhopping or differential_evolution.
-(http://en.wikipedia.org/wiki/Test_functions_for_optimization)
+(https://en.wikipedia.org/wiki/Test_functions_for_optimization)
 
-See also http://mpra.ub.uni-muenchen.de/2718/1/MPRA_paper_2718.pdf
+See also https://mpra.ub.uni-muenchen.de/2718/1/MPRA_paper_2718.pdf
 
 """
 

--- a/doc/release/0.13.0-notes.rst
+++ b/doc/release/0.13.0-notes.rst
@@ -188,7 +188,7 @@ positional parameters in all methods.
 The function `scipy.stats.power_divergence` has been added for the
 Cressie-Read power divergence statistic and goodness of fit test.
 Included in this family of statistics is the "G-test"
-(http://en.wikipedia.org/wiki/G-test).
+(https://en.wikipedia.org/wiki/G-test).
 
 `scipy.stats.mood` now accepts multidimensional input.
 

--- a/doc/release/0.17.0-notes.rst
+++ b/doc/release/0.17.0-notes.rst
@@ -147,7 +147,7 @@ can use a new keyword ``lapack_driver="gelss"`` (allowed values are
 
 ``scipy.sparse`` matrices and linear operators now support the matmul (``@``)
 operator when available (Python 3.5+). See
-[PEP 465](http://legacy.python.org/dev/peps/pep-0465/)
+[PEP 465](https://legacy.python.org/dev/peps/pep-0465/)
 
 A new function `scipy.linalg.ordqz`, for QZ decomposition with reordering, has
 been added.
@@ -227,7 +227,7 @@ automatically rebuilt after every merged pull request.
 `scipy.constants` is updated to the CODATA 2014 recommended values.
 
 Usage of `scipy.fftpack` functions within Scipy has been changed in such a
-way that `PyFFTW <http://hgomersall.github.io/pyFFTW/>`__ can easily replace
+way that `PyFFTW <https://hgomersall.github.io/pyFFTW/>`__ can easily replace
 `scipy.fftpack` functions (with improved performance).  See
 `gh-5295 <https://github.com/scipy/scipy/pull/5295>`__ for details.
 

--- a/doc/release/0.7.0-notes.rst
+++ b/doc/release/0.7.0-notes.rst
@@ -60,7 +60,7 @@ Major documentation improvements
 SciPy documentation is greatly improved; you can view a HTML reference
 manual `online <https://docs.scipy.org/>`__ or download it as a PDF
 file. The new reference guide was built using the popular `Sphinx tool
-<http://sphinx.pocoo.org/>`__.
+<http://www.sphinx-doc.org>`__.
 
 This release also includes an updated tutorial, which hadn't been
 available since SciPy was ported to NumPy in 2005.  Though not
@@ -100,7 +100,7 @@ Building SciPy
 ==============
 
 Support for NumScons has been added. NumScons is a tentative new build
-system for NumPy/SciPy, using `SCons <http://www.scons.org/>`__ at its
+system for NumPy/SciPy, using `SCons <https://www.scons.org/>`__ at its
 core.
 
 SCons is a next-generation build system, intended to replace the

--- a/doc/release/0.7.1-notes.rst
+++ b/doc/release/0.7.1-notes.rst
@@ -38,7 +38,7 @@ Bugs fixed:
 
 - #883: scipy.io.mmread with scipy.sparse.lil_matrix broken
 - lil_matrix and csc_matrix reject now unexpected sequences,
-  cf. http://thread.gmane.org/gmane.comp.python.scientific.user/19996
+  cf. http://thread.gmane.org/gmane.comp.python.scientific.user/19996 (dead link)
 
 scipy.special
 =============

--- a/doc/release/0.8.0-notes.rst
+++ b/doc/release/0.8.0-notes.rst
@@ -124,7 +124,7 @@ Several improvements to the `chirp` function in `scipy.signal` were made:
 
 * The waveform generated when `method="logarithmic"` was corrected; it
   now generates a waveform that is also known as an "exponential" or
-  "geometric" chirp. (See http://en.wikipedia.org/wiki/Chirp.)
+  "geometric" chirp. (See https://en.wikipedia.org/wiki/Chirp.)
 * A new `chirp` method, "hyperbolic", was added.
 * Instead of the keyword `qshape`, `chirp` now uses the keyword
   `vertex_zero`, a boolean.
@@ -155,7 +155,7 @@ New sparse least squares solver
 -------------------------------
 
 The `lsqr` function was added to `scipy.sparse`.  `This routine
-<http://web.stanford.edu/group/SOL/software/lsqr/>`_ finds a
+<https://web.stanford.edu/group/SOL/software/lsqr/>`_ finds a
 least-squares solution to a large, sparse, linear system of equations.
 
 ARPACK-based sparse SVD

--- a/doc/release/0.9.0-notes.rst
+++ b/doc/release/0.9.0-notes.rst
@@ -45,7 +45,7 @@ Soon after this release, Scipy will stop using SVN as the version control
 system, and move to Git. The development source code for Scipy can from then on
 be found at
 
-    http://github.com/scipy/scipy
+    https://github.com/scipy/scipy
 
 
 New features

--- a/doc/source/building/windows.rst
+++ b/doc/source/building/windows.rst
@@ -21,7 +21,7 @@ sure to check up on any of the open source projects mentioned for the most up-to
 information. For more information on all of these projects, the Mingwpy_ website
 is an excellent source of in-depth information than this document will provide.
 
-.. _Mingwpy: http://mingwpy.github.io/
+.. _Mingwpy: https://mingwpy.github.io/
 .. _ATLAS: http://math-atlas.sourceforge.net/
 .. _OpenBLAS: https://github.com/xianyi/OpenBLAS
 .. _LAPACK: http://www.netlib.org/lapack/
@@ -280,7 +280,7 @@ As discussed in the overview, this document is not meant to provide extremely de
 NumPy and SciPy on Windows. This is largely because currently, there is no single superior way to do so
 and because the process for building these libraries on Windows is under development. It is likely that any
 information will go out of date relatively soon. If you wish to receive more assistance, please reach out to the NumPy
-and SciPy mailing lists, which can be found `here <http://www.scipy.org/scipylib/mailing-lists.html>`__.  There are many
+and SciPy mailing lists, which can be found `here <https://www.scipy.org/scipylib/mailing-lists.html>`__.  There are many
 developers out there, working on this issue right now, and they would certainly be happy to help you out!  Google is also
 a good resource, as there are many people out there who use NumPy and SciPy on Windows, so it would not be surprising if
 your question or problem has already been addressed.

--- a/doc/source/dev/distributing.rst
+++ b/doc/source/dev/distributing.rst
@@ -45,7 +45,7 @@ are:
 
 Furthermore of course one needs C, C++ and Fortran compilers to build Scipy,
 but those we don't consider to be dependencies and are therefore not discussed
-here.  For details, see https://scipy.org/scipylib/building/index.html.
+here.  For details, see https://scipy.github.io/devdocs/building/.
 
 When a package provides useful functionality and it's proposed as a new
 dependency, consider also if it makes sense to vendor (i.e. ship a copy of it with
@@ -70,7 +70,7 @@ either 32-bit and 64-bit Windows wheels for Numpy on PyPI or when
 ``pip upgrade`` becomes available (with sane behavior, unlike ``pip install
 -U``, see `this PR
 <https://github.com/pypa/pip/pull/3194>`_).  For more details, see
-`this summary <http://article.gmane.org/gmane.comp.python.distutils.devel/24218>`_.
+`this summary <https://mail.python.org/pipermail/distutils-sig/2015-October/027161.html>`_.
 
 The situation with ``setup_requires`` is even worse; pip_ doesn't handle that
 keyword at all, while ``setuptools`` has issues (here's a `current one
@@ -116,7 +116,7 @@ Building binary installers
 
    This section is only about building Scipy binary installers to *distribute*.
    For info on building Scipy on the same machine as where it will be used, see
-   `this scipy.org page <http://scipy.org/scipylib/building/index.html>`_.
+   `this scipy.org page <https://scipy.github.io/devdocs/building/>`_.
 
 There are a number of things to take into consideration when building binaries
 and distributing them on PyPI or elsewhere.
@@ -143,7 +143,7 @@ and distributing them on PyPI or elsewhere.
   That method will likely be used for Scipy itself once it's clear that the
   maintenance of that toolchain is sustainable long-term.  See the MingwPy_
   project and `this thread
-  <http://article.gmane.org/gmane.comp.python.numeric.general/61727>`_ for
+  <https://mail.scipy.org/pipermail/numpy-discussion/2015-October/074056.html>`_ for
   details.
 - The other way to produce 64-bit Windows installers is with ``icc``, ``ifort``
   plus ``MKL`` (or ``MSVC`` instead of ``icc``).  For Intel toolchain
@@ -180,12 +180,12 @@ would need to be distributed via custom channels, e.g. in a
 Wheelhouse_, see at the wheel_ and Wheelhouse_ docs.
 
 
-.. _Numpy: http://numpy.org
+.. _Numpy: https://numpy.org
 .. _Python: https://python.org
-.. _nose: http://nose.readthedocs.io/en/latest/
-.. _asv: http://asv.readthedocs.org
-.. _matplotlib: http://matplotlib.org
-.. _Pillow: http://pillow.readthedocs.org
+.. _nose: https://nose.readthedocs.io
+.. _asv: https://asv.readthedocs.org
+.. _matplotlib: https://matplotlib.org
+.. _Pillow: https://pillow.readthedocs.org
 .. _scikits.umfpack: https://pypi.python.org/pypi/scikit-umfpack
 .. _mpmath: http://mpmath.org
 .. _Cython: http://cython.org
@@ -195,7 +195,7 @@ Wheelhouse_, see at the wheel_ and Wheelhouse_ docs.
 .. _Python Packaging User Guide: https://packaging.python.org
 .. _Wheelhouse: https://pypi.python.org/pypi/Wheelhouse
 .. _MingwPy: https://mingwpy.github.io
-.. _Sphinx: http://sphinx-doc.org/
+.. _Sphinx: http://www.sphinx-doc.org/
 .. _six: https://pypi.python.org/pypi/six
 .. _decorator: https://github.com/micheles/decorator
 .. _manylinux: https://github.com/pypa/manylinux/

--- a/doc/source/dev/github.rst
+++ b/doc/source/dev/github.rst
@@ -104,4 +104,4 @@ which is about Trac (what we used pre-GitHub) tickets.
 with a three-letter abbreviation like ``ENH:`` or ``BUG:``.  This is useful to
 quickly see what the nature of the commit/PR/issue is.  For the full list of
 abbreviations, see `writing the commit message
-<http://docs.scipy.org/doc/numpy-dev/dev/gitwash/development_workflow.html#writing-the-commit-message>`_.
+<https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message>`_.

--- a/doc/source/dev/versioning.rst
+++ b/doc/source/dev/versioning.rst
@@ -38,4 +38,4 @@ An installed Scipy version contains these version identifiers::
 
 
 .. _PEP 440: https://www.python.org/dev/peps/pep-0440
-.. _PyPI: http://pypi.python.org/
+.. _PyPI: https://pypi.python.org/

--- a/doc/source/tutorial/csgraph.rst
+++ b/doc/source/tutorial/csgraph.rst
@@ -9,7 +9,7 @@ Compressed Sparse Graph Routines (`scipy.sparse.csgraph`)
 Example: Word Ladders
 ---------------------
 
-A `Word Ladder <http://en.wikipedia.org/wiki/Word_ladder>`_ is a word game
+A `Word Ladder <https://en.wikipedia.org/wiki/Word_ladder>`_ is a word game
 invented by Lewis Carroll in which players find paths between words by
 switching one letter at a time.  For example, one can link "ape" and "man"
 in the following way:
@@ -80,7 +80,7 @@ converting each word to a three-dimensional vector:
     (586, 3)    # may vary
 
 Now we'll use the
-`Hamming distance <http://en.wikipedia.org/wiki/Hamming_distance>`_
+`Hamming distance <https://en.wikipedia.org/wiki/Hamming_distance>`_
 between each point to determine which pairs of words are connected.
 The Hamming distance measures the fraction of entries between two vectors
 which differ: any two words with a hamming distance equal to :math:`1/N`,

--- a/doc/source/tutorial/fftpack.rst
+++ b/doc/source/tutorial/fftpack.rst
@@ -500,13 +500,13 @@ References
        `IEEE Transactions on acoustics, speech and signal processing`
        vol. 28(1), pp. 27-34, :doi:`10.1109/TASSP.1980.1163351`
 
-.. [WPW] http://en.wikipedia.org/wiki/Window_function
+.. [WPW] https://en.wikipedia.org/wiki/Window_function
 
-.. [WPC] http://en.wikipedia.org/wiki/Discrete_cosine_transform
+.. [WPC] https://en.wikipedia.org/wiki/Discrete_cosine_transform
 
-.. [WPS] http://en.wikipedia.org/wiki/Discrete_sine_transform
+.. [WPS] https://en.wikipedia.org/wiki/Discrete_sine_transform
 
 
 .. _FFTW: http://www.fftw.org/
-.. _PyFFTW: http://hgomersall.github.io/pyFFTW/index.html
-.. _pyfftw.interfaces: http://hgomersall.github.io/pyFFTW/pyfftw/interfaces/interfaces.html
+.. _PyFFTW: https://hgomersall.github.io/pyFFTW/
+.. _pyfftw.interfaces: https://hgomersall.github.io/pyFFTW/pyfftw/interfaces/interfaces.html

--- a/doc/source/tutorial/io.rst
+++ b/doc/source/tutorial/io.rst
@@ -350,6 +350,6 @@ Netcdf (:mod:`scipy.io.netcdf`)
 
 Allows reading of  NetCDF files (version of pupynere_ package)
 
-.. _pupynere: http://pypi.python.org/pypi/pupynere/
-.. _octave: http://www.gnu.org/software/octave
-.. _matlab: http://www.mathworks.com/
+.. _pupynere: https://pypi.python.org/pypi/pupynere/
+.. _octave: https://www.gnu.org/software/octave
+.. _matlab: https://www.mathworks.com/

--- a/doc/source/tutorial/optimize.rst
+++ b/doc/source/tutorial/optimize.rst
@@ -392,7 +392,7 @@ Hessian product example:
 .. [GLTR]  N. Gould, S. Lucidi, M. Roma, P. Toint: "Solving the
            Trust-Region Subproblem using the Lanczos Method",
            SIAM J. Optim., 9(2), 504--525, (1999).
-           http://epubs.siam.org/doi/abs/10.1137/S1052623497322735
+           https://doi.org/10.1137/S1052623497322735
 
 
 Trust-Region Nearly Exact Algorithm (``method='trust-exact'``)
@@ -818,13 +818,13 @@ Further examples
 Three interactive examples below illustrate usage of :func:`least_squares` in
 greater detail.
 
-1. `Large-scale bundle adjustment in scipy <http://scipy-cookbook.readthedocs.org/items/bundle_adjustment.html>`_
+1. `Large-scale bundle adjustment in scipy <https://scipy-cookbook.readthedocs.io/items/bundle_adjustment.html>`_
    demonstrates large-scale capabilities of :func:`least_squares` and how to
    efficiently compute finite difference approximation of sparse Jacobian.
-2. `Robust nonlinear regression in scipy <http://scipy-cookbook.readthedocs.org/items/robust_regression.html>`_
+2. `Robust nonlinear regression in scipy <https://scipy-cookbook.readthedocs.io/items/robust_regression.html>`_
    shows how to handle outliers with a robust loss function in a nonlinear
    regression.
-3. `Solving a discrete boundary-value problem in scipy <http://scipy-cookbook.readthedocs.org/items/discrete_bvp.html>`_
+3. `Solving a discrete boundary-value problem in scipy <https://scipy-cookbook.readthedocs.io/items/discrete_bvp.html>`_
    examines how to solve a large system of equations and use bounds to achieve
    desired properties of the solution.
 
@@ -1232,8 +1232,8 @@ Some further reading and related software:
 .. [KK] D.A. Knoll and D.E. Keyes, "Jacobian-free Newton-Krylov methods",
         J. Comp. Phys. 193, 357 (2004). doi:10.1016/j.jcp.2003.08.010
 
-.. [PP] PETSc http://www.mcs.anl.gov/petsc/ and its Python bindings
-        http://code.google.com/p/petsc4py/
+.. [PP] PETSc https://www.mcs.anl.gov/petsc/ and its Python bindings
+        https://bitbucket.org/petsc/petsc4py/
 
 .. [AMG] PyAMG (algebraic multigrid preconditioners/solvers)
-         http://code.google.com/p/pyamg/
+         https://github.com/pyamg/pyamg/issues

--- a/doc/source/tutorial/stats/continuous.rst
+++ b/doc/source/tutorial/stats/continuous.rst
@@ -171,10 +171,10 @@ References
 
 -  Documentation to Regress+ by Michael McLaughlin item Engineering and
    Statistics Handbook (NIST),
-   http://www.itl.nist.gov/div898/handbook/index.htm
+   https://www.itl.nist.gov/div898/handbook/
 
 -  Documentation for DATAPLOT from NIST,
-   http://www.itl.nist.gov/div898/software/dataplot/distribu.htm
+   https://www.itl.nist.gov/div898/software/dataplot/distribu.htm
 
 -  Norman Johnson, Samuel Kotz, and N. Balakrishnan Continuous
    Univariate Distributions, second edition, Volumes I and II, Wiley &

--- a/scipy/_lib/_numpy_compat.py
+++ b/scipy/_lib/_numpy_compat.py
@@ -284,7 +284,7 @@ except ImportError:
         ``warnings.catch_warnings``.
 
         However, it also provides a filter mechanism to work around
-        http://bugs.python.org/issue4180.
+        https://bugs.python.org/issue4180.
 
         This bug causes Python before 3.4 to not reliably show warnings again
         after they have been ignored once (even within catch_warnings). It

--- a/scipy/_lib/decorator.py
+++ b/scipy/_lib/decorator.py
@@ -28,7 +28,7 @@
 # DAMAGE.
 
 """
-Decorator module, see http://pypi.python.org/pypi/decorator
+Decorator module, see https://pypi.python.org/pypi/decorator
 for the documentation.
 """
 from __future__ import print_function

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -87,7 +87,7 @@ References
 ----------
 
 .. [1] "Statistics toolbox." API Reference Documentation. The MathWorks.
-   http://www.mathworks.com/access/helpdesk/help/toolbox/stats/.
+   https://www.mathworks.com/access/helpdesk/help/toolbox/stats/.
    Accessed October 1, 2007.
 
 .. [2] "Hierarchical clustering." API Reference Documentation.

--- a/scipy/constants/__init__.py
+++ b/scipy/constants/__init__.py
@@ -312,7 +312,7 @@ References
 .. [CODATA2014] CODATA Recommended Values of the Fundamental
    Physical Constants 2014.
 
-   http://physics.nist.gov/cuu/Constants/index.html
+   https://physics.nist.gov/cuu/Constants/
 
 """
 from __future__ import division, print_function, absolute_import

--- a/scipy/constants/codata.py
+++ b/scipy/constants/codata.py
@@ -37,7 +37,7 @@ all fields of science and technology. The values became available on 25 June
 available through 31 December 2014. The 2014 adjustment was carried out under
 the auspices of the CODATA Task Group on Fundamental Constants. Also available
 is an introduction to the constants for non-experts at
-http://physics.nist.gov/cuu/Constants/introduction.html
+https://physics.nist.gov/cuu/Constants/introduction.html
 
 References
 ----------
@@ -46,7 +46,7 @@ and closely related precision measurements published since the mid 1980s, but
 also including many older papers of particular interest, some of which date
 back to the 1800s. To search bibliography visit
 
-http://physics.nist.gov/cuu/Constants/
+https://physics.nist.gov/cuu/Constants/
 
 """
 from __future__ import division, print_function, absolute_import
@@ -58,7 +58,7 @@ __all__ = ['physical_constants', 'value', 'unit', 'precision', 'find',
            'ConstantWarning']
 
 """
-Source:  http://physics.nist.gov/cuu/Constants/index.html
+Source:  https://physics.nist.gov/cuu/Constants/
 
 The values of the constants provided at the above site are recommended for
 international use by CODATA and are the latest available. Termed the "2006
@@ -70,7 +70,7 @@ the auspices of the CODATA Task Group on Fundamental Constants.
 """
 
 #
-# Source:  http://physics.nist.gov/cuu/Constants/index.html
+# Source:  https://physics.nist.gov/cuu/Constants/
 #
 
 # Quantity                                             Value                 Uncertainty          Unit

--- a/scipy/fftpack/realtransforms.py
+++ b/scipy/fftpack/realtransforms.py
@@ -356,7 +356,7 @@ def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
            processing` vol. 28(1), pp. 27-34,
            :doi:`10.1109/TASSP.1980.1163351` (1980).
     .. [2] Wikipedia, "Discrete cosine transform",
-           http://en.wikipedia.org/wiki/Discrete_cosine_transform
+           https://en.wikipedia.org/wiki/Discrete_cosine_transform
 
     Examples
     --------
@@ -614,7 +614,7 @@ def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
     References
     ----------
     .. [1] Wikipedia, "Discrete sine transform",
-           http://en.wikipedia.org/wiki/Discrete_sine_transform
+           https://en.wikipedia.org/wiki/Discrete_sine_transform
 
     """
     if type == 1 and norm is not None:

--- a/scipy/integrate/quadrature.py
+++ b/scipy/integrate/quadrature.py
@@ -692,7 +692,7 @@ def romberg(function, a, b, args=(), tol=1.48e-8, rtol=1.48e-8, show=False,
 
     References
     ----------
-    .. [1] 'Romberg's method' http://en.wikipedia.org/wiki/Romberg%27s_method
+    .. [1] 'Romberg's method' https://en.wikipedia.org/wiki/Romberg%27s_method
 
     Examples
     --------

--- a/scipy/interpolate/README
+++ b/scipy/interpolate/README
@@ -41,11 +41,11 @@ A number of other functions and classes are provided, for which README documenta
 
 Introductions to interpolation and splines can be found online at:
 
-http://en.wikipedia.org/wiki/Interpolation
+https://en.wikipedia.org/wiki/Interpolation
 	The Wikipedia article on interpolation.  Provides an accessible
 	overview of major areas of the subject, including spline
 	interpolation.
-http://en.wikipedia.org/wiki/Spline_interpolation
+https://en.wikipedia.org/wiki/Spline_interpolation
 	The Wikipedia article on spline interpolation.  It is accessible
 	as a conceptual introduction, and contains links to various
 	algorithms, but discussion is limited to 1D interpolation.

--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -276,7 +276,7 @@ class Akima1DInterpolator(PPoly):
 
     def __init__(self, x, y, axis=0):
         # Original implementation in MATLAB by N. Shamsundar (BSD licensed), see
-        # http://www.mathworks.de/matlabcentral/fileexchange/1814-akima-interpolation
+        # https://www.mathworks.com/matlabcentral/fileexchange/1814-akima-interpolation
         x, y = map(np.asarray, (x, y))
         axis = axis % y.ndim
 
@@ -620,8 +620,8 @@ class CubicSpline(PPoly):
 
                 # Also, due to the periodicity, the system is not tri-diagonal.
                 # We need to compute a "condensed" matrix of shape (n-2, n-2).
-                # See http://www.cfm.brown.edu/people/gk/chap6/node14.html for
-                # more explanations.
+                # See https://web.archive.org/web/20151220180652/http://www.cfm.brown.edu/people/gk/chap6/node14.html
+                # for more explanations.
                 # The condensed matrix is obtained by removing the last column
                 # and last row of the (n-1, n-1) system matrix. The removed
                 # values are saved in scalar variables with the (n-1, n-1)

--- a/scipy/interpolate/_fitpack_impl.py
+++ b/scipy/interpolate/_fitpack_impl.py
@@ -4,9 +4,9 @@ fitpack (dierckx in netlib) --- A Python-C wrapper to FITPACK (by P. Dierckx).
         fitting with splines and tensor product splines.
 
 See
- http://www.cs.kuleuven.ac.be/cwis/research/nalag/research/topics/fitpack.html
+ https://web.archive.org/web/20010524124604/http://www.cs.kuleuven.ac.be:80/cwis/research/nalag/research/topics/fitpack.html
 or
- http://www.netlib.org/dierckx/index.html
+ http://www.netlib.org/dierckx/
 
 Copyright 2002 Pearu Peterson all rights reserved,
 Pearu Peterson <pearu@cens.ioc.ee>

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -476,7 +476,7 @@ class interp1d(_Interpolator1D):
         # Adjust to interpolation kind; store reference to *unbound*
         # interpolation methods, in order to avoid circular references to self
         # stored in the bound instance methods, and therefore delayed garbage
-        # collection.  See: http://docs.python.org/2/reference/datamodel.html
+        # collection.  See: https://docs.python.org/reference/datamodel.html
         if kind in ('linear', 'nearest', 'previous', 'next'):
             # Make a "view" of the y array that is rotated to the interpolation
             # axis.
@@ -1389,7 +1389,7 @@ class BPoly(_PPolyBase):
     Properties of Bernstein polynomials are well documented in the literature.
     Here's a non-exhaustive list:
 
-    .. [1] http://en.wikipedia.org/wiki/Bernstein_polynomial
+    .. [1] https://en.wikipedia.org/wiki/Bernstein_polynomial
 
     .. [2] Kenneth I. Joy, Bernstein polynomials,
       http://www.idav.ucdavis.edu/education/CAGDNotes/Bernstein-Polynomials.pdf
@@ -2390,13 +2390,12 @@ class RegularGridInterpolator(object):
     ----------
     .. [1] Python package *regulargrid* by Johannes Buchner, see
            https://pypi.python.org/pypi/regulargrid/
-    .. [2] Trilinear interpolation. (2013, January 17). In Wikipedia, The Free
-           Encyclopedia. Retrieved 27 Feb 2013 01:28.
-           http://en.wikipedia.org/w/index.php?title=Trilinear_interpolation&oldid=533448871
+    .. [2] Wikipedia, "Trilinear interpolation",
+           https://en.wikipedia.org/wiki/Trilinear_interpolation
     .. [3] Weiser, Alan, and Sergio E. Zarantonello. "A note on piecewise linear
            and multilinear table interpolation in many dimensions." MATH.
            COMPUT. 50.181 (1988): 189-196.
-           http://www.ams.org/journals/mcom/1988-50-181/S0025-5718-1988-0917826-0/S0025-5718-1988-0917826-0.pdf
+           https://www.ams.org/journals/mcom/1988-50-181/S0025-5718-1988-0917826-0/S0025-5718-1988-0917826-0.pdf
 
     """
     # this class is based on code originally programmed by Johannes Buchner,

--- a/scipy/io/matlab/mio5.py
+++ b/scipy/io/matlab/mio5.py
@@ -2,7 +2,7 @@
 
 The matfile specification last found here:
 
-http://www.mathworks.com/access/helpdesk/help/pdf_doc/matlab/matfile_format.pdf
+https://www.mathworks.com/access/helpdesk/help/pdf_doc/matlab/matfile_format.pdf
 
 (as of December 5 2008)
 '''

--- a/scipy/io/matlab/mio5_utils.pyx
+++ b/scipy/io/matlab/mio5_utils.pyx
@@ -797,7 +797,7 @@ cdef class VarReader5:
         else:
             data = self.read_numeric()
         ''' From the matlab (TM) API documentation, last found here:
-        http://www.mathworks.com/access/helpdesk/help/techdoc/matlab_external/
+        https://www.mathworks.com/help/pdf_doc/matlab/apiext.pdf
         rowind are simply the row indices for all the (nnz) non-zero
         entries in the sparse array.  rowind has nzmax entries, so
         may well have more entries than nnz, the actual number of

--- a/scipy/io/matlab/streams.pyx
+++ b/scipy/io/matlab/streams.pyx
@@ -23,7 +23,7 @@ cdef extern from "Python.h":
 
 cdef extern from "py3k.h":
     # From:
-    # http://svn.pyamf.org/pyamf/tags/release-0.4rc2/cpyamf/util.pyx
+    # https://github.com/hydralabs/pyamf/blob/release-0.4rc2/cpyamf/util.pyx
     # (MIT license) - with thanks
     void PycString_IMPORT()
     int StringIO_cread "PycStringIO->cread" (object, char **, Py_ssize_t)
@@ -116,7 +116,7 @@ cdef class ZlibInputStream(GenericStream):
     Some matlab files contain zlib streams without valid Z_STREAM_END
     termination.  To get round this, we use the decompressobj object, that
     allows you to decode an incomplete stream.  See discussion at
-    http://bugs.python.org/issue8672
+    https://bugs.python.org/issue8672
 
     """
 

--- a/scipy/io/tests/test_mmio.py
+++ b/scipy/io/tests/test_mmio.py
@@ -542,7 +542,7 @@ class TestMMIOCoordinate(object):
                         (5, 5, 7, 'coordinate', 'pattern', 'symmetric'))
 
     def test_empty_write_read(self):
-        # http://projects.scipy.org/scipy/ticket/883
+        # https://github.com/scipy/scipy/issues/1410 (Trac #883)
 
         b = scipy.sparse.coo_matrix((10, 10))
         mmwrite(self.fn, b)

--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -660,7 +660,7 @@ def solve_toeplitz(c_or_cr, b, check_finite=True):
     """
     # If numerical stability of this algorithm is a problem, a future
     # developer might consider implementing other O(N^2) Toeplitz solvers,
-    # such as GKO (http://www.jstor.org/stable/2153371) or Bareiss.
+    # such as GKO (https://www.jstor.org/stable/2153371) or Bareiss.
     if isinstance(c_or_cr, tuple):
         c, r = c_or_cr
         c = _asarray_validated(c, check_finite=check_finite).ravel()
@@ -1566,7 +1566,7 @@ def matrix_balance(A, permute=True, scale=True, separate=False,
 
     .. [2] : R. James, J. Langou, B.R. Lowery, "On matrix balancing and
        eigenvector computation", 2014, Available online:
-       http://arxiv.org/abs/1401.5766
+       https://arxiv.org/abs/1401.5766
 
     .. [3] :  D.S. Watkins. A case where balancing is harmful.
        Electron. Trans. Numer. Anal, Vol.23, 2006.

--- a/scipy/linalg/special_matrices.py
+++ b/scipy/linalg/special_matrices.py
@@ -810,7 +810,7 @@ def pascal(n, kind='symmetric', exact=True):
 
     Notes
     -----
-    See http://en.wikipedia.org/wiki/Pascal_matrix for more information
+    See https://en.wikipedia.org/wiki/Pascal_matrix for more information
     about Pascal matrices.
 
     .. versionadded:: 0.11.0
@@ -901,7 +901,7 @@ def invpascal(n, kind='symmetric', exact=True):
 
     References
     ----------
-    .. [1] "Pascal matrix",  http://en.wikipedia.org/wiki/Pascal_matrix
+    .. [1] "Pascal matrix", https://en.wikipedia.org/wiki/Pascal_matrix
     .. [2] Cohen, A. M., "The inverse of a Pascal matrix", Mathematical
            Gazette, 59(408), pp. 111-112, 1975.
 
@@ -1006,7 +1006,7 @@ def dft(n, scale=None):
 
     References
     ----------
-    .. [1] "DFT matrix", http://en.wikipedia.org/wiki/DFT_matrix
+    .. [1] "DFT matrix", https://en.wikipedia.org/wiki/DFT_matrix
 
     Examples
     --------

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -117,7 +117,7 @@ def random_rot(dim):
     matrices with an application to condition estimators', SIAM Journal
     on Numerical Analysis, 17(3), pp. 403-409, 1980.
     For more information see
-    http://en.wikipedia.org/wiki/Orthogonal_matrix#Randomization"""
+    https://en.wikipedia.org/wiki/Orthogonal_matrix#Randomization"""
     H = eye(dim)
     D = ones((dim,))
     for n in range(1, dim):
@@ -285,7 +285,7 @@ class TestEig(object):
     @pytest.mark.xfail(reason="See gh-2254.")
     def test_singular(self):
         # Example taken from
-        # http://www.cs.umu.se/research/nla/singular_pairs/guptri/matlab.html
+        # https://web.archive.org/web/20040903121217/http://www.cs.umu.se/research/nla/singular_pairs/guptri/matlab.html
         A = array(([22,34,31,31,17], [45,45,42,19,29], [39,47,49,26,34],
             [27,31,26,21,15], [38,44,44,24,30]))
         B = array(([13,26,25,17,24], [31,46,40,26,37], [26,40,19,25,25],
@@ -2069,7 +2069,7 @@ class TestQZ(object):
         assert_(all(diag(BB) >= 0))
 
     def test_qz_double_sort(self):
-        # from http://www.nag.com/lapack-ex/node119.html
+        # from https://www.nag.com/lapack-ex/node119.html
         # NOTE: These matrices may be ill-conditioned and lead to a
         # seg fault on certain python versions when compiled with
         # sse2 or sse3 older ATLAS/LAPACK binaries for windows
@@ -2189,7 +2189,7 @@ def _make_pos(X):
 class TestOrdQZ(object):
     @classmethod
     def setup_class(cls):
-        # http://www.nag.com/lapack-ex/node119.html
+        # https://www.nag.com/lapack-ex/node119.html
         A1 = np.array([[-21.10 - 22.50j, 53.5 - 50.5j, -34.5 + 127.5j,
                         7.5 + 0.5j],
                        [-0.46 - 7.78j, -3.5 - 37.5j, -15.5 + 58.5j,
@@ -2204,7 +2204,7 @@ class TestOrdQZ(object):
                        [1.0 + 0.0j, 2.4 + 1.8j, -4 - 5j, 0.0 - 3.0j],
                        [0.0 + 1.0j, -1.8 + 2.4j, 0 - 4j, 4.0 - 5.0j]])
 
-        # http://www.nag.com/numeric/fl/nagdoc_fl23/xhtml/F08/f08yuf.xml
+        # https://www.nag.com/numeric/fl/nagdoc_fl23/xhtml/F08/f08yuf.xml
         A2 = np.array([[3.9, 12.5, -34.5, -0.5],
                        [4.3, 21.5, -47.5, 7.5],
                        [4.3, 21.5, -43.5, 3.5],

--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -260,7 +260,7 @@ class TestSqrtM(object):
                 assert_allclose(M_sqrtm_round_trip, M)
 
     def test_bad(self):
-        # See http://www.maths.man.ac.uk/~nareports/narep336.ps.gz
+        # See https://web.archive.org/web/20051220232650/http://www.maths.man.ac.uk/~nareports/narep336.ps.gz
         e = 2**-5
         se = sqrt(e)
         a = array([[1.0,0,0,1],

--- a/scipy/ndimage/morphology.py
+++ b/scipy/ndimage/morphology.py
@@ -337,8 +337,8 @@ def binary_erosion(input, structure=None, iterations=1, mask=None, output=None,
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/Erosion_%28morphology%29
-    .. [2] http://en.wikipedia.org/wiki/Mathematical_morphology
+    .. [1] https://en.wikipedia.org/wiki/Erosion_%28morphology%29
+    .. [2] https://en.wikipedia.org/wiki/Mathematical_morphology
 
     Examples
     --------
@@ -432,8 +432,8 @@ def binary_dilation(input, structure=None, iterations=1, mask=None,
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/Dilation_%28morphology%29
-    .. [2] http://en.wikipedia.org/wiki/Mathematical_morphology
+    .. [1] https://en.wikipedia.org/wiki/Dilation_%28morphology%29
+    .. [2] https://en.wikipedia.org/wiki/Mathematical_morphology
 
     Examples
     --------
@@ -576,8 +576,8 @@ def binary_opening(input, structure=None, iterations=1, output=None,
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/Opening_%28morphology%29
-    .. [2] http://en.wikipedia.org/wiki/Mathematical_morphology
+    .. [1] https://en.wikipedia.org/wiki/Opening_%28morphology%29
+    .. [2] https://en.wikipedia.org/wiki/Mathematical_morphology
 
     Examples
     --------
@@ -699,8 +699,8 @@ def binary_closing(input, structure=None, iterations=1, output=None,
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/Closing_%28morphology%29
-    .. [2] http://en.wikipedia.org/wiki/Mathematical_morphology
+    .. [1] https://en.wikipedia.org/wiki/Closing_%28morphology%29
+    .. [2] https://en.wikipedia.org/wiki/Mathematical_morphology
 
     Examples
     --------
@@ -819,7 +819,7 @@ def binary_hit_or_miss(input, structure1=None, structure2=None,
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/Hit-or-miss_transform
+    .. [1] https://en.wikipedia.org/wiki/Hit-or-miss_transform
 
     Examples
     --------
@@ -1057,7 +1057,7 @@ def binary_fill_holes(input, structure=None, output=None, origin=0):
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/Mathematical_morphology
+    .. [1] https://en.wikipedia.org/wiki/Mathematical_morphology
 
 
     Examples
@@ -1162,8 +1162,8 @@ def grey_erosion(input, size=None, footprint=None, structure=None,
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/Erosion_%28morphology%29
-    .. [2] http://en.wikipedia.org/wiki/Mathematical_morphology
+    .. [1] https://en.wikipedia.org/wiki/Erosion_%28morphology%29
+    .. [2] https://en.wikipedia.org/wiki/Mathematical_morphology
 
     Examples
     --------
@@ -1272,8 +1272,8 @@ def grey_dilation(input, size=None, footprint=None, structure=None,
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/Dilation_%28morphology%29
-    .. [2] http://en.wikipedia.org/wiki/Mathematical_morphology
+    .. [1] https://en.wikipedia.org/wiki/Dilation_%28morphology%29
+    .. [2] https://en.wikipedia.org/wiki/Mathematical_morphology
 
     Examples
     --------
@@ -1409,7 +1409,7 @@ def grey_opening(input, size=None, footprint=None, structure=None,
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/Mathematical_morphology
+    .. [1] https://en.wikipedia.org/wiki/Mathematical_morphology
 
     Examples
     --------
@@ -1492,7 +1492,7 @@ def grey_closing(input, size=None, footprint=None, structure=None,
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/Mathematical_morphology
+    .. [1] https://en.wikipedia.org/wiki/Mathematical_morphology
 
     Examples
     --------
@@ -1579,7 +1579,7 @@ def morphological_gradient(input, size=None, footprint=None, structure=None,
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/Mathematical_morphology
+    .. [1] https://en.wikipedia.org/wiki/Mathematical_morphology
 
     Examples
     --------

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -190,7 +190,7 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
     (array([1., 1., 1., 1., 1.]), 1.9216496320061384e-19)
 
     Next find the minimum of the Ackley function
-    (http://en.wikipedia.org/wiki/Test_functions_for_optimization).
+    (https://en.wikipedia.org/wiki/Test_functions_for_optimization).
 
     >>> from scipy.optimize import differential_evolution
     >>> import numpy as np
@@ -208,8 +208,8 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
     .. [1] Storn, R and Price, K, Differential Evolution - a Simple and
            Efficient Heuristic for Global Optimization over Continuous Spaces,
            Journal of Global Optimization, 1997, 11, 341 - 359.
-    .. [2] http://www1.icsi.berkeley.edu/~storn/code.html
-    .. [3] http://en.wikipedia.org/wiki/Differential_evolution
+    .. [2] https://www1.icsi.berkeley.edu/~storn/code.html
+    .. [3] https://en.wikipedia.org/wiki/Differential_evolution
     """
 
     solver = DifferentialEvolutionSolver(func, bounds, args=args,

--- a/scipy/optimize/_root.py
+++ b/scipy/optimize/_root.py
@@ -124,7 +124,7 @@ def root(fun, x0, args=(), method='hybr', jac=None, tol=None, callback=None,
        1980. User Guide for MINPACK-1.
     .. [2] C. T. Kelley. 1995. Iterative Methods for Linear and Nonlinear
        Equations. Society for Industrial and Applied Mathematics.
-       <http://www.siam.org/books/kelley/fr16/index.php>
+       <https://archive.siam.org/books/kelley/fr16/>
     .. [3] W. La Cruz, J.M. Martinez, M. Raydan. Math. Comp. 75, 1429 (2006).
 
     Examples

--- a/scipy/optimize/nonlin.py
+++ b/scipy/optimize/nonlin.py
@@ -261,7 +261,7 @@ def nonlin_solve(F, x0, jacobian='krylov', iter=None, verbose=False,
     ----------
     .. [KIM] C. T. Kelley, \"Iterative Methods for Linear and Nonlinear
        Equations\". Society for Industrial and Applied Mathematics. (1995)
-       http://www.siam.org/books/kelley/fr16/index.php
+       https://archive.siam.org/books/kelley/fr16/
 
     """
 
@@ -845,7 +845,7 @@ class LowRankMatrix(object):
            systems of nonlinear equations\". Mathematisch Instituut,
            Universiteit Leiden, The Netherlands (2003).
 
-           http://www.math.leidenuniv.nl/scripties/Rotten.pdf
+           https://web.archive.org/web/20161022015821/http://www.math.leidenuniv.nl/scripties/Rotten.pdf
 
         """
         if self.collapsed is not None:
@@ -939,7 +939,7 @@ class BroydenFirst(GenericBroyden):
        systems of nonlinear equations\". Mathematisch Instituut,
        Universiteit Leiden, The Netherlands (2003).
 
-       http://www.math.leidenuniv.nl/scripties/Rotten.pdf
+       https://web.archive.org/web/20161022015821/http://www.math.leidenuniv.nl/scripties/Rotten.pdf
 
     """
 
@@ -1029,7 +1029,7 @@ class BroydenSecond(BroydenFirst):
        systems of nonlinear equations\". Mathematisch Instituut,
        Universiteit Leiden, The Netherlands (2003).
 
-       http://www.math.leidenuniv.nl/scripties/Rotten.pdf
+       https://web.archive.org/web/20161022015821/http://www.math.leidenuniv.nl/scripties/Rotten.pdf
 
     """
 

--- a/scipy/optimize/slsqp/slsqp_optmz.f
+++ b/scipy/optimize/slsqp/slsqp_optmz.f
@@ -2,10 +2,10 @@ C
 C      ALGORITHM 733, COLLECTED ALGORITHMS FROM ACM.
 C      TRANSACTIONS ON MATHEMATICAL SOFTWARE,
 C      VOL. 20, NO. 3, SEPTEMBER, 1994, PP. 262-281.
-C      http://doi.acm.org/10.1145/192115.192124
+C      https://doi.org/10.1145/192115.192124
 C
 C
-C      http://permalink.gmane.org/gmane.comp.python.scientific.devel/6725
+C      https://web.archive.org/web/20170106155705/http://permalink.gmane.org/gmane.comp.python.scientific.devel/6725
 C      ------
 C      From: Deborah Cotton <cotton@hq.acm.org>
 C      Date: Fri, 14 Sep 2007 12:35:55 -0500

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -201,7 +201,7 @@ class LinprogCommonTests(object):
 
     def test_linprog_mixed_constraints(self):
         # Minimize linear function subject to non-negative variables.
-        #  http://www.statslab.cam.ac.uk/~ff271/teaching/opt/notes/notes8.pdf
+        #  http://www.statslab.cam.ac.uk/~ff271/teaching/opt/notes/notes8.pdf (dead link)
         c = [6, 3]
         A_ub = [[0, 3],
                 [-1, -1],
@@ -213,7 +213,7 @@ class LinprogCommonTests(object):
 
     def test_linprog_cyclic_recovery(self):
         # Test linprogs recovery from cycling using the Klee-Minty problem
-        #  Klee-Minty  http://www.math.ubc.ca/~israel/m340/kleemin3.pdf
+        #  Klee-Minty  https://www.math.ubc.ca/~israel/m340/kleemin3.pdf
         c = np.array([100, 10, 1]) * -1  # maximize
         A_ub = [[1, 0, 0],
                 [20, 1, 0],
@@ -378,7 +378,7 @@ class LinprogCommonTests(object):
         _assert_success(res, desired_fun=14)
 
     def test_simplex_algorithm_wikipedia_example(self):
-        # http://en.wikipedia.org/wiki/Simplex_algorithm#Example
+        # https://en.wikipedia.org/wiki/Simplex_algorithm#Example
         Z = [-2, -3, -4]
         A_ub = [
             [3, 2, 1],
@@ -389,7 +389,7 @@ class LinprogCommonTests(object):
         _assert_success(res, desired_fun=-20)
 
     def test_enzo_example(self):
-        # http://projects.scipy.org/scipy/attachment/ticket/1252/lp2.py
+        # https://github.com/scipy/scipy/issues/1779 lp2.py
         #
         # Translated from Octave code at:
         # http://www.ecs.shimane-u.ac.jp/~kyoshida/lpeng.htm

--- a/scipy/signal/lti_conversion.py
+++ b/scipy/signal/lti_conversion.py
@@ -385,14 +385,14 @@ def cont2discrete(system, dt, method="zoh", alpha=None):
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/Discretization#Discretization_of_linear_state_space_models
+    .. [1] https://en.wikipedia.org/wiki/Discretization#Discretization_of_linear_state_space_models
 
     .. [2] http://techteach.no/publications/discretetime_signals_systems/discrete.pdf
 
     .. [3] G. Zhang, X. Chen, and T. Chen, Digital redesign via the generalized
         bilinear transformation, Int. J. Control, vol. 82, no. 4, pp. 741-754,
         2009.
-        (http://www.mypolyuweb.hk/~magzhang/Research/ZCC09_IJC.pdf)
+        (https://www.mypolyuweb.hk/~magzhang/Research/ZCC09_IJC.pdf)
 
     """
     if len(system) == 1:

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -2488,7 +2488,7 @@ def freqresp(system, w=None, n=10000):
 
 
 # This class will be used by place_poles to return its results
-# see http://code.activestate.com/recipes/52308/
+# see https://code.activestate.com/recipes/52308/
 class Bunch:
     def __init__(self, **kwds):
         self.__dict__.update(kwds)
@@ -2570,7 +2570,7 @@ def _KNV0(B, ker_pole, transfer_matrix, j, poles):
     Algorithm "KNV0" Kautsky et Al. Robust pole
     assignment in linear state feedback, Int journal of Control
     1985, vol 41 p 1129->1155
-    http://la.epfl.ch/files/content/sites/la/files/
+    https://la.epfl.ch/files/content/sites/la/files/
         users/105941/public/KautskyNicholsDooren
 
     """
@@ -2732,7 +2732,7 @@ def _YT_loop(ker_pole, transfer_matrix, poles, B, maxiter, rtol):
     """
     Algorithm "YT" Tits, Yang. Globally Convergent
     Algorithms for Robust Pole Assignment by State Feedback
-    http://drum.lib.umd.edu/handle/1903/5598
+    https://hdl.handle.net/1903/5598
     The poles P have to be sorted accordingly to section 6.2 page 20
 
     """
@@ -2970,7 +2970,7 @@ def place_poles(A, B, poles, method="YT", rtol=1e-3, maxiter=30):
     when ``abs(det(X))`` is used as a robustness indicator.
 
     [2]_ is available as a technical report on the following URL:
-    http://drum.lib.umd.edu/handle/1903/5598
+    https://hdl.handle.net/1903/5598
 
     References
     ----------

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1563,7 +1563,7 @@ def hilbert(x, N=None, axis=-1):
     References
     ----------
     .. [1] Wikipedia, "Analytic signal".
-           http://en.wikipedia.org/wiki/Analytic_signal
+           https://en.wikipedia.org/wiki/Analytic_signal
     .. [2] Leon Cohen, "Time-Frequency Analysis", 1995. Chapter 2.
     .. [3] Alan V. Oppenheim, Ronald W. Schafer. Discrete-Time Signal
            Processing, Third Edition, 2009. Chapter 12.
@@ -1614,7 +1614,7 @@ def hilbert2(x, N=None):
     References
     ----------
     .. [1] Wikipedia, "Analytic signal",
-        http://en.wikipedia.org/wiki/Analytic_signal
+        https://en.wikipedia.org/wiki/Analytic_signal
 
     """
     x = atleast_2d(x)

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -1704,7 +1704,7 @@ def _fft_helper(x, win, detrend_func, nperseg, noverlap, nfft, sides):
     if nperseg == 1 and noverlap == 0:
         result = x[..., np.newaxis]
     else:
-        # http://stackoverflow.com/a/5568169
+        # https://stackoverflow.com/a/5568169
         step = nperseg - noverlap
         shape = x.shape[:-1]+((x.shape[-1]-noverlap)//step, nperseg)
         strides = x.strides[:-1]+(step*x.strides[-1], x.strides[-1])

--- a/scipy/signal/windows/windows.py
+++ b/scipy/signal/windows/windows.py
@@ -664,7 +664,7 @@ def bartlett(M, sym=True):
     .. [3] A.V. Oppenheim and R.W. Schafer, "Discrete-Time Signal
            Processing", Prentice-Hall, 1999, pp. 468-471.
     .. [4] Wikipedia, "Window function",
-           http://en.wikipedia.org/wiki/Window_function
+           https://en.wikipedia.org/wiki/Window_function
     .. [5] W.H. Press,  B.P. Flannery, S.A. Teukolsky, and W.T. Vetterling,
            "Numerical Recipes", Cambridge University Press, 1986, page 429.
 
@@ -753,7 +753,7 @@ def hann(M, sym=True):
     .. [2] E.R. Kanasewich, "Time Sequence Analysis in Geophysics",
            The University of Alberta Press, 1975, pp. 106-108.
     .. [3] Wikipedia, "Window function",
-           http://en.wikipedia.org/wiki/Window_function
+           https://en.wikipedia.org/wiki/Window_function
     .. [4] W.H. Press,  B.P. Flannery, S.A. Teukolsky, and W.T. Vetterling,
            "Numerical Recipes", Cambridge University Press, 1986, page 425.
 
@@ -820,7 +820,7 @@ def tukey(M, alpha=0.5, sym=True):
            Analysis with the Discrete Fourier Transform". Proceedings of the
            IEEE 66 (1): 51-83. :doi:`10.1109/PROC.1978.10837`
     .. [2] Wikipedia, "Window function",
-           http://en.wikipedia.org/wiki/Window_function#Tukey_window
+           https://en.wikipedia.org/wiki/Window_function#Tukey_window
 
     Examples
     --------
@@ -1006,7 +1006,7 @@ def general_hamming(M, alpha, sym=True):
     .. [1] DSPRelated, "Generalized Hamming Window Family",
            https://www.dsprelated.com/freebooks/sasp/Generalized_Hamming_Window_Family.html
     .. [2] Wikipedia, "Window function",
-           http://en.wikipedia.org/wiki/Window_function
+           https://en.wikipedia.org/wiki/Window_function
     .. [3] Riccardo Piantanida ESA, "Sentinel-1 Level 1 Detailed Algorithm
            Definition",
            https://sentinel.esa.int/documents/247904/1877131/Sentinel-1-Level-1-Detailed-Algorithm-Definition
@@ -1061,7 +1061,7 @@ def hamming(M, sym=True):
     .. [2] E.R. Kanasewich, "Time Sequence Analysis in Geophysics", The
            University of Alberta Press, 1975, pp. 109-110.
     .. [3] Wikipedia, "Window function",
-           http://en.wikipedia.org/wiki/Window_function
+           https://en.wikipedia.org/wiki/Window_function
     .. [4] W.H. Press,  B.P. Flannery, S.A. Teukolsky, and W.T. Vetterling,
            "Numerical Recipes", Cambridge University Press, 1986, page 425.
 
@@ -1168,7 +1168,7 @@ def kaiser(M, beta, sym=True):
     .. [2] E.R. Kanasewich, "Time Sequence Analysis in Geophysics", The
            University of Alberta Press, 1975, pp. 177-178.
     .. [3] Wikipedia, "Window function",
-           http://en.wikipedia.org/wiki/Window_function
+           https://en.wikipedia.org/wiki/Window_function
     .. [4] F. J. Harris, "On the use of windows for harmonic analysis with the
            discrete Fourier transform," Proceedings of the IEEE, vol. 66,
            no. 1, pp. 51-83, Jan. 1978. :doi:`10.1109/PROC.1978.10837`.
@@ -1902,7 +1902,7 @@ def dpss(M, NW, Kmax=None, sym=True, norm=None, return_ratios=False):
     # sequences, or discrete prolate spheroidal sequences (DPSS). Only the
     # first K, K = 2NW/dt orders of DPSS will exhibit good spectral
     # concentration
-    # [see http://en.wikipedia.org/wiki/Spectral_concentration_problem]
+    # [see https://en.wikipedia.org/wiki/Spectral_concentration_problem]
 
     # Here we set up an alternative symmetric tri-diagonal eigenvalue
     # problem such that

--- a/scipy/sparse/linalg/dsolve/SuperLU/SRC/colamd.c
+++ b/scipy/sparse/linalg/dsolve/SuperLU/SRC/colamd.c
@@ -35,7 +35,7 @@ at the top-level directory.
 	conventional partial pivoting with row interchanges.  Colamd is the
 	column ordering method used in SuperLU, part of the ScaLAPACK library.
 	It is also available as built-in function in MATLAB Version 6,
-	available from MathWorks, Inc. (http://www.mathworks.com).  This
+	available from MathWorks, Inc. (https://www.mathworks.com).  This
 	routine can be used in place of colmmd in MATLAB.
 
     	Symamd computes a permutation P of a symmetric matrix A such that the
@@ -79,9 +79,9 @@ at the top-level directory.
 
 	The colamd/symamd library is available at
 
-	    http://www.cise.ufl.edu/research/sparse/colamd/
+	    https://web.archive.org/web/20141010162709/http://www.cise.ufl.edu/research/sparse/colamd/
 
-	This is the http://www.cise.ufl.edu/research/sparse/colamd/colamd.c
+	This is the https://web.archive.org/web/20040113022019/http://www.cise.ufl.edu:80/research/sparse/colamd/colamd.c
 	file.  It requires the colamd.h file.  It is required by the colamdmex.c
 	and symamdmex.c files, for the MATLAB interface to colamd and symamd.
 
@@ -349,7 +349,7 @@ at the top-level directory.
 
 	Example:
 	
-	    See http://www.cise.ufl.edu/research/sparse/colamd/example.c
+	    See http://www.cise.ufl.edu/research/sparse/colamd/example.c (dead link)
 	    for a complete example.
 
 	    To order the columns of a 5-by-4 matrix with 11 nonzero entries in

--- a/scipy/sparse/linalg/eigen/arpack/ARPACK/CHANGES
+++ b/scipy/sparse/linalg/eigen/arpack/ARPACK/CHANGES
@@ -40,7 +40,7 @@ arpack-ng - 3.1.5
 arpack-ng - 3.1.4
 
  * libparpack2: missing dependency on MPI:
-   http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=718790
+   https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=718790
 
  * Replace LAPACK second function with ARPACK's own arscnd in PARPACK
 

--- a/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
@@ -227,7 +227,7 @@ def lobpcg(A, X,
     ratio ``n``/``m`` should be large. It you call the LOBPCG code with ``m``=1
     and ``n``=10, it should work, though ``n`` is small. The method is intended
     for extremely large ``n``/``m``, see e.g., reference [28] in
-    http://arxiv.org/abs/0705.2626
+    https://arxiv.org/abs/0705.2626
 
     The convergence speed depends basically on two factors:
 
@@ -258,7 +258,7 @@ def lobpcg(A, X,
 
     .. [2] A. V. Knyazev, I. Lashuk, M. E. Argentati, and E. Ovchinnikov (2007),
            Block Locally Optimal Preconditioned Eigenvalue Xolvers (BLOPEX)
-           in hypre and PETSc.  http://arxiv.org/abs/0705.2626
+           in hypre and PETSc.  https://arxiv.org/abs/0705.2626
 
     .. [3] A. V. Knyazev's C and MATLAB implementations:
            https://bitbucket.org/joseroman/blopex

--- a/scipy/sparse/linalg/eigen/lobpcg/tests/test_lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/tests/test_lobpcg.py
@@ -93,7 +93,7 @@ def test_diagonal():
     # This test was moved from '__main__' in lobpcg.py.
     # Coincidentally or not, this is the same eigensystem
     # required to reproduce arpack bug
-    # http://forge.scilab.org/index.php/p/arpack-ng/issues/1397/
+    # https://forge.scilab.org/p/arpack-ng/issues/1397/
     # even using the same n=100.
 
     np.random.seed(1234)

--- a/scipy/sparse/linalg/isolve/lsmr.py
+++ b/scipy/sparse/linalg/isolve/lsmr.py
@@ -134,8 +134,8 @@ def lsmr(A, b, damp=0.0, atol=1e-6, btol=1e-6, conlim=1e8,
     .. [1] D. C.-L. Fong and M. A. Saunders,
            "LSMR: An iterative algorithm for sparse least-squares problems",
            SIAM J. Sci. Comput., vol. 33, pp. 2950-2971, 2011.
-           http://arxiv.org/abs/1006.0758
-    .. [2] LSMR Software, http://web.stanford.edu/group/SOL/software/lsmr/
+           https://arxiv.org/abs/1006.0758
+    .. [2] LSMR Software, https://web.stanford.edu/group/SOL/software/lsmr/
 
     Examples
     --------

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -717,7 +717,7 @@ class _TestCommon(object):
                                    x.todense().reshape(s, order=order))
 
         # This example is taken from the stackoverflow answer at
-        # http://stackoverflow.com/questions/16511879
+        # https://stackoverflow.com/q/16511879
         x = self.spmatrix([[0, 10, 0, 0], [0, 0, 0, 0], [0, 20, 30, 40]])
         y = x.reshape((2, 6))  # Default order is 'C'
         desired = [[0, 10, 0, 0, 0, 0], [0, 0, 0, 20, 30, 40]]
@@ -2351,7 +2351,7 @@ class _TestSlicing(object):
         assert_equal(A[1:-2].todense(),B[1:-2])
 
         # Check bug reported by Robert Cimrman:
-        # http://thread.gmane.org/gmane.comp.python.scientific.devel/7986
+        # http://thread.gmane.org/gmane.comp.python.scientific.devel/7986 (dead link)
         s = slice(int8(2),int8(4),None)
         assert_equal(A[s,:].todense(), B[2:4,:])
         assert_equal(A[:,s].todense(), B[:,2:4])
@@ -2651,7 +2651,7 @@ class _TestFancyIndexing(object):
         assert_equal(A[:,array([-1,-3])][array([2,-4]),:].todense(), B[:,[-1,-3]][[2,-4],:])
 
         # Check bug reported by Robert Cimrman:
-        # http://thread.gmane.org/gmane.comp.python.scientific.devel/7986
+        # http://thread.gmane.org/gmane.comp.python.scientific.devel/7986 (dead link)
         s = slice(int8(2),int8(4),None)
         assert_equal(A[s,:].todense(), B[2:4,:])
         assert_equal(A[:,s].todense(), B[:,2:4])

--- a/scipy/spatial/qhull/README.txt
+++ b/scipy/spatial/qhull/README.txt
@@ -11,7 +11,7 @@ Convex hull, Delaunay triangulation, Voronoi diagrams, Halfspace intersection
       Available from:
         <http://www.qhull.org>
         <http://www.qhull.org/download>
-        <http://github.com/qhull/qhull> (git@github.com:qhull/qhull.git)
+        <https://github.com/qhull/qhull> (git@github.com:qhull/qhull.git)
  
       News and a paper:
         <http://www.qhull.org/news>
@@ -57,7 +57,7 @@ To cite Qhull, please use
 To modify Qhull, particularly the C++ interface
 
   Qhull is on GitHub 
-     (http://github.com/qhull/qhull, git@github.com:qhull/qhull.git)
+     (https://github.com/qhull/qhull, git@github.com:qhull/qhull.git)
   
   For internal documentation, see html/qh-code.htm
 
@@ -177,7 +177,7 @@ Working with Qhull's C++ interface
 
   Qhull's C++ interface is likely to change.  Stay current with GitHub.
 
-  To clone Qhull's next branch from http://github.com/qhull/qhull
+  To clone Qhull's next branch from https://github.com/qhull/qhull
     git init
     git clone git@github.com:qhull/qhull.git
     cd qhull
@@ -216,7 +216,7 @@ Compiling Qhull with Microsoft Visual C++
   - Download and extract Qhull (either GitHub, .tgz file, or .zip file)
   - Load solution build/qhull-32.sln 
   - Build target 'Win32'
-  - Project qhulltest requires Qt for DevStudio (http://www.qt.io)
+  - Project qhulltest requires Qt for DevStudio (https://www.qt.io)
     Set the QTDIR environment variable to your Qt directory (e.g., c:/qt/5.2.0/5.2.0/msvc2012)
     If QTDIR is incorrect, precompile will fail with 'Can not locate the file specified'
 
@@ -225,7 +225,7 @@ Compiling Qhull with Microsoft Visual C++
   - Download and extract Qhull (either GitHub, .tgz file, or .zip file)
   - Load solution build/qhull-64.sln 
   - Build target 'Win32'
-  - Project qhulltest requires Qt for DevStudio (http://www.qt.io)
+  - Project qhulltest requires Qt for DevStudio (https://www.qt.io)
     Set the QTDIR environment variable to your Qt directory (e.g., c:/qt/5.2.0/5.2.0/msvc2012_64)
     If QTDIR is incorrect, precompile will fail with 'Can not locate the file specified'
   
@@ -233,14 +233,14 @@ Compiling Qhull with Microsoft Visual C++
   - Download and extract Qhull (either GitHub, .tgz file, or .zip file)
   - Load solution build/qhull.sln 
   - Build target 'win32' (not 'x64')
-  - Project qhulltest requires Qt for DevStudio (http://www.qt.io)
+  - Project qhulltest requires Qt for DevStudio (https://www.qt.io)
     Set the QTDIR environment variable to your Qt directory (e.g., c:/qt/4.7.4)
     If QTDIR is incorrect, precompile will fail with 'Can not locate the file specified'
   
 -----------------
 Compiling Qhull with Qt Creator
 
-  Qt (http://www.qt.io) is a C++ framework for Windows, Linux, and Macintosh
+  Qt (https://www.qt.io) is a C++ framework for Windows, Linux, and Macintosh
 
   Qhull uses QTestLib to test qhull's C++ interface (see src/qhulltest/)
   
@@ -267,7 +267,7 @@ Compiling Qhull with cygwin on Windows
 
   To compile Qhull with cygwin
   - Download and extract Qhull (either GitHub, .tgz file, or .zip file)
-  - Install cygwin (http://www.cygwin.com)
+  - Install cygwin (https://www.cygwin.com)
   - Include packages for gcc, make, ar, and ln
   - make
 

--- a/scipy/special/_digamma.pxd
+++ b/scipy/special/_digamma.pxd
@@ -81,7 +81,7 @@ cdef inline double complex cdigamma(double complex z) nogil:
     if z.real < 0 and fabs(z.imag) < smallabsz:
         # Reflection formula for digamma. See
         #
-        # http://dlmf.nist.gov/5.5#E4
+        # https://dlmf.nist.gov/5.5#E4
         #
         res -= M_PI*cospi(z)/sinpi(z)
         z = 1 - z
@@ -120,7 +120,7 @@ cdef inline double complex forward_recurrence(double complex z,
 
     digamma(z + 1) = digamma(z) + 1/z.
 
-    See http://dlmf.nist.gov/5.5#E2
+    See https://dlmf.nist.gov/5.5#E2
 
     """
     cdef:
@@ -155,7 +155,7 @@ cdef inline double complex asymptotic_series(double complex z) nogil:
     """
     Evaluate digamma using an asymptotic series. See
 
-    http://dlmf.nist.gov/5.11#E2
+    https://dlmf.nist.gov/5.11#E2
 
     """
     cdef:

--- a/scipy/special/_ellip_harm.py
+++ b/scipy/special/_ellip_harm.py
@@ -61,7 +61,7 @@ def ellip_harm(h2, k2, n, p, s, signm=1, signn=1):
     References
     ----------
     .. [1] Digital Library of Mathematical Functions 29.12
-       http://dlmf.nist.gov/29.12
+       https://dlmf.nist.gov/29.12
     .. [2] Bardhan and Knepley, "Computational science and
        re-discovery: open-source implementations of
        ellipsoidal harmonics for problems in potential theory",

--- a/scipy/special/_precompute/expn_asy.py
+++ b/scipy/special/_precompute/expn_asy.py
@@ -4,7 +4,7 @@ generalized exponential integral.
 Sources
 -------
 [1] NIST, Digital Library of Mathematical Functions,
-    http://dlmf.nist.gov/8.20#ii
+    https://dlmf.nist.gov/8.20#ii
 
 """
 from __future__ import division, print_function, absolute_import

--- a/scipy/special/_precompute/gammainc_asy.py
+++ b/scipy/special/_precompute/gammainc_asy.py
@@ -5,7 +5,7 @@ This takes about 8 hours to run on a 2.3 GHz Macbook Pro with 4GB ram.
 
 Sources:
 [1] NIST, "Digital Library of Mathematical Functions",
-    http://dlmf.nist.gov/
+    https://dlmf.nist.gov/
 
 """
 from __future__ import division, print_function, absolute_import

--- a/scipy/special/_sici.pxd
+++ b/scipy/special/_sici.pxd
@@ -5,7 +5,7 @@
 #     arbitrary-precision floating-point arithmetic (version 0.19),
 #     December 2013. http://mpmath.org/.
 # [2] NIST, "Digital Library of Mathematical Functions",
-#     http://dlmf.nist.gov/
+#     https://dlmf.nist.gov/
 import cython
 cimport numpy as np
 

--- a/scipy/special/_spherical_bessel.pxd
+++ b/scipy/special/_spherical_bessel.pxd
@@ -118,7 +118,7 @@ cdef inline double complex spherical_jn_complex(long n, double complex z) nogil:
         sf_error.error("spherical_jn", sf_error.DOMAIN, NULL)
         return nan
     if z.real == inf or z.real == -inf:
-        # http://dlmf.nist.gov/10.52.E3
+        # https://dlmf.nist.gov/10.52.E3
         if z.imag == 0:
             return 0
         else:
@@ -182,10 +182,10 @@ cdef inline double complex spherical_yn_complex(long n, double complex z) nogil:
         sf_error.error("spherical_yn", sf_error.DOMAIN, NULL)
         return nan
     if z.real == 0 and z.imag == 0:
-        # http://dlmf.nist.gov/10.52.E2
+        # https://dlmf.nist.gov/10.52.E2
         return nan
     if z.real == inf or z.real == -inf:
-        # http://dlmf.nist.gov/10.52.E3
+        # https://dlmf.nist.gov/10.52.E3
         if z.imag == 0:
             return 0
         else:
@@ -203,13 +203,13 @@ cdef inline double spherical_in_real(long n, double z) nogil:
         sf_error.error("spherical_in", sf_error.DOMAIN, NULL)
         return nan
     if z == 0:
-        # http://dlmf.nist.gov/10.52.E1
+        # https://dlmf.nist.gov/10.52.E1
         if n == 0:
             return 1
         else:
             return 0
     if npy_isinf(z):
-        # http://dlmf.nist.gov/10.49.E8
+        # https://dlmf.nist.gov/10.49.E8
         if z == -inf:
             return (-1)**n*inf
         else:
@@ -228,13 +228,13 @@ cdef inline double complex spherical_in_complex(long n, double complex z) nogil:
         sf_error.error("spherical_in", sf_error.DOMAIN, NULL)
         return nan
     if zabs(z) == 0:
-        # http://dlmf.nist.gov/10.52.E1
+        # https://dlmf.nist.gov/10.52.E1
         if n == 0:
             return 1
         else:
             return 0
     if zisinf(z):
-        # http://dlmf.nist.gov/10.52.E5
+        # https://dlmf.nist.gov/10.52.E5
         if z.imag == 0:
             if z.real == -inf:
                 return (-1)**n*inf
@@ -258,7 +258,7 @@ cdef inline double spherical_kn_real(long n, double z) nogil:
     if z == 0:
         return inf
     if npy_isinf(z):
-        # http://dlmf.nist.gov/10.52.E6
+        # https://dlmf.nist.gov/10.52.E6
         if z == inf:
             return 0
         else:
@@ -278,7 +278,7 @@ cdef inline double complex spherical_kn_complex(long n, double complex z) nogil:
     if zabs(z) == 0:
         return nan
     if zisinf(z):
-        # http://dlmf.nist.gov/10.52.E6
+        # https://dlmf.nist.gov/10.52.E6
         if z.imag == 0:
             if z.real == inf:
                 return 0

--- a/scipy/special/_spherical_bessel.py
+++ b/scipy/special/_spherical_bessel.py
@@ -46,9 +46,9 @@ def spherical_jn(n, z, derivative=False):
 
     References
     ----------
-    .. [1] http://dlmf.nist.gov/10.47.E3
-    .. [2] http://dlmf.nist.gov/10.51.E1
-    .. [3] http://dlmf.nist.gov/10.51.E2
+    .. [1] https://dlmf.nist.gov/10.47.E3
+    .. [2] https://dlmf.nist.gov/10.51.E1
+    .. [3] https://dlmf.nist.gov/10.51.E2
     """
     if derivative:
         return _spherical_jn_d(n, z)
@@ -97,9 +97,9 @@ def spherical_yn(n, z, derivative=False):
 
     References
     ----------
-    .. [1] http://dlmf.nist.gov/10.47.E4
-    .. [2] http://dlmf.nist.gov/10.51.E1
-    .. [3] http://dlmf.nist.gov/10.51.E2
+    .. [1] https://dlmf.nist.gov/10.47.E4
+    .. [2] https://dlmf.nist.gov/10.51.E1
+    .. [3] https://dlmf.nist.gov/10.51.E2
     """
     if derivative:
         return _spherical_yn_d(n, z)
@@ -147,8 +147,8 @@ def spherical_in(n, z, derivative=False):
 
     References
     ----------
-    .. [1] http://dlmf.nist.gov/10.47.E7
-    .. [2] http://dlmf.nist.gov/10.51.E5
+    .. [1] https://dlmf.nist.gov/10.47.E7
+    .. [2] https://dlmf.nist.gov/10.51.E5
     """
     if derivative:
         return _spherical_in_d(n, z)
@@ -196,8 +196,8 @@ def spherical_kn(n, z, derivative=False):
 
     References
     ----------
-    .. [1] http://dlmf.nist.gov/10.47.E9
-    .. [2] http://dlmf.nist.gov/10.51.E5
+    .. [1] https://dlmf.nist.gov/10.47.E9
+    .. [2] https://dlmf.nist.gov/10.51.E5
     """
     if derivative:
         return _spherical_kn_d(n, z)

--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -85,7 +85,7 @@ add_newdoc("scipy.special", "sph_harm",
     References
     ----------
     .. [1] Digital Library of Mathematical Functions, 14.30.
-           http://dlmf.nist.gov/14.30
+           https://dlmf.nist.gov/14.30
     .. [2] https://en.wikipedia.org/wiki/Spherical_harmonics#Condon.E2.80.93Shortley_phase
     """)
 
@@ -260,7 +260,7 @@ add_newdoc("scipy.special", "airy",
     References
     ----------
     .. [1] Cephes Mathematical Functions Library,
-           http://www.netlib.org/cephes/index.html
+           http://www.netlib.org/cephes/
     .. [2] Donald E. Amos, "AMOS, A Portable Package for Bessel Functions
            of a Complex Argument and Nonnegative Order",
            http://netlib.org/amos/
@@ -362,7 +362,7 @@ add_newdoc("scipy.special", "bdtr",
     References
     ----------
     .. [1] Cephes Mathematical Functions Library,
-           http://www.netlib.org/cephes/index.html
+           http://www.netlib.org/cephes/
 
     """)
 
@@ -410,7 +410,7 @@ add_newdoc("scipy.special", "bdtrc",
     References
     ----------
     .. [1] Cephes Mathematical Functions Library,
-           http://www.netlib.org/cephes/index.html
+           http://www.netlib.org/cephes/
 
     """)
 
@@ -456,7 +456,7 @@ add_newdoc("scipy.special", "bdtri",
     References
     ----------
     .. [1] Cephes Mathematical Functions Library,
-           http://www.netlib.org/cephes/index.html
+           http://www.netlib.org/cephes/
     """)
 
 add_newdoc("scipy.special", "bdtrik",
@@ -964,7 +964,7 @@ add_newdoc("scipy.special", "btdtr",
     References
     ----------
     .. [1] Cephes Mathematical Functions Library,
-           http://www.netlib.org/cephes/index.html
+           http://www.netlib.org/cephes/
 
     """)
 
@@ -1009,7 +1009,7 @@ add_newdoc("scipy.special", "btdtri",
     References
     ----------
     .. [1] Cephes Mathematical Functions Library,
-           http://www.netlib.org/cephes/index.html
+           http://www.netlib.org/cephes/
 
     """)
 
@@ -1215,7 +1215,7 @@ add_newdoc("scipy.special", "ellipe",
     References
     ----------
     .. [1] Cephes Mathematical Functions Library,
-           http://www.netlib.org/cephes/index.html
+           http://www.netlib.org/cephes/
     .. [2] Milton Abramowitz and Irene A. Stegun, eds.
            Handbook of Mathematical Functions with Formulas,
            Graphs, and Mathematical Tables. New York: Dover, 1972.
@@ -1266,7 +1266,7 @@ add_newdoc("scipy.special", "ellipeinc",
     References
     ----------
     .. [1] Cephes Mathematical Functions Library,
-           http://www.netlib.org/cephes/index.html
+           http://www.netlib.org/cephes/
     .. [2] Milton Abramowitz and Irene A. Stegun, eds.
            Handbook of Mathematical Functions with Formulas,
            Graphs, and Mathematical Tables. New York: Dover, 1972.
@@ -1320,7 +1320,7 @@ add_newdoc("scipy.special", "ellipj",
     References
     ----------
     .. [1] Cephes Mathematical Functions Library,
-           http://www.netlib.org/cephes/index.html
+           http://www.netlib.org/cephes/
     """)
 
 add_newdoc("scipy.special", "ellipkm1",
@@ -1372,7 +1372,7 @@ add_newdoc("scipy.special", "ellipkm1",
     References
     ----------
     .. [1] Cephes Mathematical Functions Library,
-           http://www.netlib.org/cephes/index.html
+           http://www.netlib.org/cephes/
     """)
 
 add_newdoc("scipy.special", "ellipkinc",
@@ -1421,7 +1421,7 @@ add_newdoc("scipy.special", "ellipkinc",
     References
     ----------
     .. [1] Cephes Mathematical Functions Library,
-           http://www.netlib.org/cephes/index.html
+           http://www.netlib.org/cephes/
     .. [2] Milton Abramowitz and Irene A. Stegun, eds.
            Handbook of Mathematical Functions with Formulas,
            Graphs, and Mathematical Tables. New York: Dover, 1972.
@@ -1486,7 +1486,7 @@ add_newdoc("scipy.special", "erf",
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/Error_function
+    .. [1] https://en.wikipedia.org/wiki/Error_function
     .. [2] Milton Abramowitz and Irene A. Stegun, eds.
         Handbook of Mathematical Functions with Formulas,
         Graphs, and Mathematical Tables. New York: Dover,
@@ -2471,7 +2471,7 @@ add_newdoc("scipy.special", "fdtr",
     References
     ----------
     .. [1] Cephes Mathematical Functions Library,
-           http://www.netlib.org/cephes/index.html
+           http://www.netlib.org/cephes/
 
     """)
 
@@ -2516,7 +2516,7 @@ add_newdoc("scipy.special", "fdtrc",
     References
     ----------
     .. [1] Cephes Mathematical Functions Library,
-           http://www.netlib.org/cephes/index.html
+           http://www.netlib.org/cephes/
     """)
 
 add_newdoc("scipy.special", "fdtri",
@@ -2563,7 +2563,7 @@ add_newdoc("scipy.special", "fdtri",
     References
     ----------
     .. [1] Cephes Mathematical Functions Library,
-           http://www.netlib.org/cephes/index.html
+           http://www.netlib.org/cephes/
 
     """)
 
@@ -2696,7 +2696,7 @@ add_newdoc("scipy.special", "gammainc",
     References
     ----------
     .. [1] Maddock et. al., "Incomplete Gamma Functions",
-       http://www.boost.org/doc/libs/1_61_0/libs/math/doc/html/math_toolkit/sf_gamma/igamma.html
+       https://www.boost.org/doc/libs/1_61_0/libs/math/doc/html/math_toolkit/sf_gamma/igamma.html
     """)
 
 add_newdoc("scipy.special", "gammaincc",
@@ -2728,7 +2728,7 @@ add_newdoc("scipy.special", "gammaincc",
     References
     ----------
     .. [1] Maddock et. al., "Incomplete Gamma Functions",
-       http://www.boost.org/doc/libs/1_61_0/libs/math/doc/html/math_toolkit/sf_gamma/igamma.html
+       https://www.boost.org/doc/libs/1_61_0/libs/math/doc/html/math_toolkit/sf_gamma/igamma.html
     """)
 
 add_newdoc("scipy.special", "gammainccinv",
@@ -2836,7 +2836,7 @@ add_newdoc("scipy.special", "gdtr",
     References
     ----------
     .. [1] Cephes Mathematical Functions Library,
-           http://www.netlib.org/cephes/index.html
+           http://www.netlib.org/cephes/
 
     """)
 
@@ -2886,7 +2886,7 @@ add_newdoc("scipy.special", "gdtrc",
     References
     ----------
     .. [1] Cephes Mathematical Functions Library,
-           http://www.netlib.org/cephes/index.html
+           http://www.netlib.org/cephes/
 
     """)
 
@@ -3401,9 +3401,9 @@ add_newdoc("scipy.special", "hyp2f1",
     ----------
     .. [1] S. Zhang and J.M. Jin, "Computation of Special Functions", Wiley 1996
     .. [2] Cephes Mathematical Functions Library,
-           http://www.netlib.org/cephes/index.html
+           http://www.netlib.org/cephes/
     .. [3] NIST Digital Library of Mathematical Functions
-           http://dlmf.nist.gov/
+           https://dlmf.nist.gov/
 
     """)
 
@@ -3466,7 +3466,7 @@ add_newdoc("scipy.special", "i0",
     References
     ----------
     .. [1] Cephes Mathematical Functions Library,
-           http://www.netlib.org/cephes/index.html
+           http://www.netlib.org/cephes/
     """)
 
 add_newdoc("scipy.special", "i0e",
@@ -3507,7 +3507,7 @@ add_newdoc("scipy.special", "i0e",
     References
     ----------
     .. [1] Cephes Mathematical Functions Library,
-           http://www.netlib.org/cephes/index.html
+           http://www.netlib.org/cephes/
     """)
 
 add_newdoc("scipy.special", "i1",
@@ -3549,7 +3549,7 @@ add_newdoc("scipy.special", "i1",
     References
     ----------
     .. [1] Cephes Mathematical Functions Library,
-           http://www.netlib.org/cephes/index.html
+           http://www.netlib.org/cephes/
     """)
 
 add_newdoc("scipy.special", "i1e",
@@ -3590,7 +3590,7 @@ add_newdoc("scipy.special", "i1e",
     References
     ----------
     .. [1] Cephes Mathematical Functions Library,
-           http://www.netlib.org/cephes/index.html
+           http://www.netlib.org/cephes/
     """)
 
 add_newdoc("scipy.special", "_igam_fac",
@@ -3954,7 +3954,7 @@ add_newdoc("scipy.special", "j0",
     References
     ----------
     .. [1] Cephes Mathematical Functions Library,
-           http://www.netlib.org/cephes/index.html
+           http://www.netlib.org/cephes/
     """)
 
 add_newdoc("scipy.special", "j1",
@@ -3992,7 +3992,7 @@ add_newdoc("scipy.special", "j1",
     References
     ----------
     .. [1] Cephes Mathematical Functions Library,
-           http://www.netlib.org/cephes/index.html
+           http://www.netlib.org/cephes/
 
     """)
 
@@ -4149,7 +4149,7 @@ add_newdoc("scipy.special", "k0",
     References
     ----------
     .. [1] Cephes Mathematical Functions Library,
-           http://www.netlib.org/cephes/index.html
+           http://www.netlib.org/cephes/
     """)
 
 add_newdoc("scipy.special", "k0e",
@@ -4188,7 +4188,7 @@ add_newdoc("scipy.special", "k0e",
     References
     ----------
     .. [1] Cephes Mathematical Functions Library,
-           http://www.netlib.org/cephes/index.html
+           http://www.netlib.org/cephes/
     """)
 
 add_newdoc("scipy.special", "k1",
@@ -4222,7 +4222,7 @@ add_newdoc("scipy.special", "k1",
     References
     ----------
     .. [1] Cephes Mathematical Functions Library,
-           http://www.netlib.org/cephes/index.html
+           http://www.netlib.org/cephes/
     """)
 
 add_newdoc("scipy.special", "k1e",
@@ -4261,7 +4261,7 @@ add_newdoc("scipy.special", "k1e",
     References
     ----------
     .. [1] Cephes Mathematical Functions Library,
-           http://www.netlib.org/cephes/index.html
+           http://www.netlib.org/cephes/
     """)
 
 add_newdoc("scipy.special", "kei",
@@ -4475,7 +4475,7 @@ add_newdoc("scipy.special", "kv",
            functions of a complex argument and nonnegative order", ACM
            TOMS Vol. 12 Issue 3, Sept. 1986, p. 265
     .. [3] NIST Digital Library of Mathematical Functions,
-           Eq. 10.25.E3. http://dlmf.nist.gov/10.25.E3
+           Eq. 10.25.E3. https://dlmf.nist.gov/10.25.E3
 
     Examples
     --------
@@ -4892,7 +4892,7 @@ add_newdoc("scipy.special", "modstruve",
     References
     ----------
     .. [1] NIST Digital Library of Mathematical Functions
-           http://dlmf.nist.gov/11
+           https://dlmf.nist.gov/11
     """)
 
 add_newdoc("scipy.special", "nbdtr",
@@ -4947,7 +4947,7 @@ add_newdoc("scipy.special", "nbdtr",
     References
     ----------
     .. [1] Cephes Mathematical Functions Library,
-           http://www.netlib.org/cephes/index.html
+           http://www.netlib.org/cephes/
 
     """)
 
@@ -4999,7 +4999,7 @@ add_newdoc("scipy.special", "nbdtrc",
     References
     ----------
     .. [1] Cephes Mathematical Functions Library,
-           http://www.netlib.org/cephes/index.html
+           http://www.netlib.org/cephes/
     """)
 
 add_newdoc("scipy.special", "nbdtri",
@@ -5040,7 +5040,7 @@ add_newdoc("scipy.special", "nbdtri",
     References
     ----------
     .. [1] Cephes Mathematical Functions Library,
-           http://www.netlib.org/cephes/index.html
+           http://www.netlib.org/cephes/
 
     """)
 
@@ -5887,7 +5887,7 @@ add_newdoc("scipy.special", "pbwa",
     References
     ----------
     .. [1] Digital Library of Mathematical Functions, 14.30.
-           http://dlmf.nist.gov/14.30
+           https://dlmf.nist.gov/14.30
     .. [2] Zhang, Shanjie and Jin, Jianming. "Computation of Special
            Functions", John Wiley and Sons, 1996.
            https://people.sc.fsu.edu/~jburkardt/f_src/special_functions/special_functions.html
@@ -6155,7 +6155,7 @@ add_newdoc("scipy.special", "psi",
     References
     ----------
     .. [1] NIST Digital Library of Mathematical Functions
-           http://dlmf.nist.gov/5
+           https://dlmf.nist.gov/5
     .. [2] Fredrik Johansson and others.
            "mpmath: a Python library for arbitrary-precision floating-point arithmetic"
            (Version 0.19) http://mpmath.org/
@@ -6271,7 +6271,7 @@ add_newdoc("scipy.special", "shichi",
     References
     ----------
     .. [1] Cephes Mathematical Functions Library,
-           http://www.netlib.org/cephes/index.html
+           http://www.netlib.org/cephes/
     .. [2] Fredrik Johansson and others.
            "mpmath: a Python library for arbitrary-precision floating-point arithmetic"
            (Version 0.19) http://mpmath.org/
@@ -6324,7 +6324,7 @@ add_newdoc("scipy.special", "sici",
     References
     ----------
     .. [1] Cephes Mathematical Functions Library,
-           http://www.netlib.org/cephes/index.html
+           http://www.netlib.org/cephes/
     .. [2] Fredrik Johansson and others.
            "mpmath: a Python library for arbitrary-precision floating-point arithmetic"
            (Version 0.19) http://mpmath.org/
@@ -6474,7 +6474,7 @@ add_newdoc("scipy.special", "struve",
     References
     ----------
     .. [1] NIST Digital Library of Mathematical Functions
-           http://dlmf.nist.gov/11
+           https://dlmf.nist.gov/11
 
     """)
 
@@ -6621,7 +6621,7 @@ add_newdoc("scipy.special", "y0",
     References
     ----------
     .. [1] Cephes Mathematical Functions Library,
-           http://www.netlib.org/cephes/index.html
+           http://www.netlib.org/cephes/
     """)
 
 add_newdoc("scipy.special", "y1",
@@ -6660,7 +6660,7 @@ add_newdoc("scipy.special", "y1",
     References
     ----------
     .. [1] Cephes Mathematical Functions Library,
-           http://www.netlib.org/cephes/index.html
+           http://www.netlib.org/cephes/
     """)
 
 add_newdoc("scipy.special", "yn",
@@ -6696,7 +6696,7 @@ add_newdoc("scipy.special", "yn",
     References
     ----------
     .. [1] Cephes Mathematical Functions Library,
-           http://www.netlib.org/cephes/index.html
+           http://www.netlib.org/cephes/
     """)
 
 add_newdoc("scipy.special", "yv",

--- a/scipy/special/amos_wrappers.c
+++ b/scipy/special/amos_wrappers.c
@@ -666,7 +666,7 @@ double cbesk_wrap_real( double v, double z) {
     return NPY_INFINITY;
   }
   else if (z > 710 * (1 + fabs(v))) {
-      /* Underflow. See uniform expansion http://dlmf.nist.gov/10.41
+      /* Underflow. See uniform expansion https://dlmf.nist.gov/10.41
        * This condition is not a strict bound (it can underflow earlier),
        * rather, we are here working around a restriction in AMOS.
        */

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -455,7 +455,7 @@ def jvp(v, z, n=1):
            Functions", John Wiley and Sons, 1996, chapter 5.
            https://people.sc.fsu.edu/~jburkardt/f_src/special_functions/special_functions.html
     .. [2] NIST Digital Library of Mathematical Functions.
-           http://dlmf.nist.gov/10.6.E7
+           https://dlmf.nist.gov/10.6.E7
 
     """
     n = _nonneg_int_or_fail(n, 'n')
@@ -487,7 +487,7 @@ def yvp(v, z, n=1):
            Functions", John Wiley and Sons, 1996, chapter 5.
            https://people.sc.fsu.edu/~jburkardt/f_src/special_functions/special_functions.html
     .. [2] NIST Digital Library of Mathematical Functions.
-           http://dlmf.nist.gov/10.6.E7
+           https://dlmf.nist.gov/10.6.E7
 
     """
     n = _nonneg_int_or_fail(n, 'n')
@@ -542,7 +542,7 @@ def kvp(v, z, n=1):
            Functions", John Wiley and Sons, 1996, chapter 6.
            https://people.sc.fsu.edu/~jburkardt/f_src/special_functions/special_functions.html
     .. [2] NIST Digital Library of Mathematical Functions.
-           http://dlmf.nist.gov/10.29.E5
+           https://dlmf.nist.gov/10.29.E5
 
     """
     n = _nonneg_int_or_fail(n, 'n')
@@ -575,7 +575,7 @@ def ivp(v, z, n=1):
            Functions", John Wiley and Sons, 1996, chapter 6.
            https://people.sc.fsu.edu/~jburkardt/f_src/special_functions/special_functions.html
     .. [2] NIST Digital Library of Mathematical Functions.
-           http://dlmf.nist.gov/10.29.E5
+           https://dlmf.nist.gov/10.29.E5
 
     """
     n = _nonneg_int_or_fail(n, 'n')
@@ -607,7 +607,7 @@ def h1vp(v, z, n=1):
            Functions", John Wiley and Sons, 1996, chapter 5.
            https://people.sc.fsu.edu/~jburkardt/f_src/special_functions/special_functions.html
     .. [2] NIST Digital Library of Mathematical Functions.
-           http://dlmf.nist.gov/10.6.E7
+           https://dlmf.nist.gov/10.6.E7
 
     """
     n = _nonneg_int_or_fail(n, 'n')
@@ -639,7 +639,7 @@ def h2vp(v, z, n=1):
            Functions", John Wiley and Sons, 1996, chapter 5.
            https://people.sc.fsu.edu/~jburkardt/f_src/special_functions/special_functions.html
     .. [2] NIST Digital Library of Mathematical Functions.
-           http://dlmf.nist.gov/10.6.E7
+           https://dlmf.nist.gov/10.6.E7
 
     """
     n = _nonneg_int_or_fail(n, 'n')
@@ -687,7 +687,7 @@ def riccati_jn(n, x):
            Functions", John Wiley and Sons, 1996.
            https://people.sc.fsu.edu/~jburkardt/f_src/special_functions/special_functions.html
     .. [2] NIST Digital Library of Mathematical Functions.
-           http://dlmf.nist.gov/10.51.E1
+           https://dlmf.nist.gov/10.51.E1
 
     """
     if not (isscalar(n) and isscalar(x)):
@@ -739,7 +739,7 @@ def riccati_yn(n, x):
            Functions", John Wiley and Sons, 1996.
            https://people.sc.fsu.edu/~jburkardt/f_src/special_functions/special_functions.html
     .. [2] NIST Digital Library of Mathematical Functions.
-           http://dlmf.nist.gov/10.51.E1
+           https://dlmf.nist.gov/10.51.E1
 
     """
     if not (isscalar(n) and isscalar(x)):
@@ -907,7 +907,7 @@ def mathieu_even_coef(m, q):
            Functions", John Wiley and Sons, 1996.
            https://people.sc.fsu.edu/~jburkardt/f_src/special_functions/special_functions.html
     .. [2] NIST Digital Library of Mathematical Functions
-           http://dlmf.nist.gov/28.4#i
+           https://dlmf.nist.gov/28.4#i
 
     """
     if not (isscalar(m) and isscalar(q)):
@@ -1036,7 +1036,7 @@ def lpmn(m, n, z):
            Functions", John Wiley and Sons, 1996.
            https://people.sc.fsu.edu/~jburkardt/f_src/special_functions/special_functions.html
     .. [2] NIST Digital Library of Mathematical Functions
-           http://dlmf.nist.gov/14.3
+           https://dlmf.nist.gov/14.3
 
     """
     if not isscalar(m) or (abs(m) > n):
@@ -1119,7 +1119,7 @@ def clpmn(m, n, z, type=3):
            Functions", John Wiley and Sons, 1996.
            https://people.sc.fsu.edu/~jburkardt/f_src/special_functions/special_functions.html
     .. [2] NIST Digital Library of Mathematical Functions
-           http://dlmf.nist.gov/14.21
+           https://dlmf.nist.gov/14.21
 
     """
     if not isscalar(m) or (abs(m) > n):
@@ -1909,7 +1909,7 @@ def perm(N, k, exact=False):
         return vals
 
 
-# http://stackoverflow.com/a/16327037/125507
+# https://stackoverflow.com/a/16327037
 def _range_prod(lo, hi):
     """
     Product of a range of numbers.

--- a/scipy/special/c_misc/struve.c
+++ b/scipy/special/c_misc/struve.c
@@ -46,7 +46,7 @@
  * References
  * ----------
  * [1] NIST Digital Library of Mathematical Functions
- *     http://dlmf.nist.gov/11
+ *     https://dlmf.nist.gov/11
  */
 
 /*
@@ -209,7 +209,7 @@ static double struve_hl(double v, double z, int is_h)
 
 /*
  * Power series for Struve H and L
- * http://dlmf.nist.gov/11.2.1
+ * https://dlmf.nist.gov/11.2.1
  *
  * Starts to converge roughly at |n| > |z|
  */
@@ -288,7 +288,7 @@ double struve_power_series(double v, double z, int is_h, double *err)
 
 /*
  * Bessel series
- * http://dlmf.nist.gov/11.4.19
+ * https://dlmf.nist.gov/11.4.19
  */
 double struve_bessel_series(double v, double z, int is_h, double *err)
 {
@@ -335,7 +335,7 @@ double struve_bessel_series(double v, double z, int is_h, double *err)
 
 /*
  * Large-z expansion for Struve H and L
- * http://dlmf.nist.gov/11.6.1
+ * https://dlmf.nist.gov/11.6.1
  */
 double struve_asymp_large_z(double v, double z, int is_h, double *err)
 {

--- a/scipy/special/cephes/ellie.c
+++ b/scipy/special/cephes/ellie.c
@@ -179,7 +179,7 @@ double ellie(double phi, double m)
  * use the first form, accounting for the smallness of phi.
  * 
  * The algorithm used is described in Carlson, B. C. Numerical computation of
- * real or complex elliptic integrals. (1994) http://arxiv.org/abs/math/9409227
+ * real or complex elliptic integrals. (1994) https://arxiv.org/abs/math/9409227
  * Most variable names reflect Carlson's usage.
  *
  * In this routine, we assume m < 0 and  0 > phi > pi/2.

--- a/scipy/special/cephes/ellik.c
+++ b/scipy/special/cephes/ellik.c
@@ -173,7 +173,7 @@ double ellik(double phi,  double m)
  * use the first form, accounting for the smallness of phi.
  * 
  * The algorithm used is described in Carlson, B. C. Numerical computation of
- * real or complex elliptic integrals. (1994) http://arxiv.org/abs/math/9409227
+ * real or complex elliptic integrals. (1994) https://arxiv.org/abs/math/9409227
  * Most variable names reflect Carlson's usage.
  *
  * In this routine, we assume m < 0 and  0 > phi > pi/2.

--- a/scipy/special/cephes/igam.c
+++ b/scipy/special/cephes/igam.c
@@ -86,7 +86,7 @@
 /* Sources
  * [1] "The Digital Library of Mathematical Functions", dlmf.nist.gov
  * [2] Maddock et. al., "Incomplete Gamma Functions",
- *     http://www.boost.org/doc/libs/1_61_0/libs/math/doc/html/math_toolkit/sf_gamma/igamma.html
+ *     https://www.boost.org/doc/libs/1_61_0/libs/math/doc/html/math_toolkit/sf_gamma/igamma.html
  */
 
 /* Scipy changes:

--- a/scipy/special/cephes/igami.c
+++ b/scipy/special/cephes/igami.c
@@ -2,7 +2,7 @@
  * (C) Copyright John Maddock 2006.
  * Use, modification and distribution are subject to the
  * Boost Software License, Version 1.0. (See accompanying file
- *  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+ *  LICENSE_1_0.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
  */
 #include "mconf.h"
 #include "_c99compat.h"

--- a/scipy/special/cephes/lanczos.c
+++ b/scipy/special/cephes/lanczos.c
@@ -1,7 +1,7 @@
 /*  (C) Copyright John Maddock 2006.
  *  Use, modification and distribution are subject to the
  *  Boost Software License, Version 1.0. (See accompanying file
- *  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+ *  LICENSE_1_0.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
  */
 
 /* Scipy changes:

--- a/scipy/special/cephes/lanczos.h
+++ b/scipy/special/cephes/lanczos.h
@@ -1,7 +1,7 @@
 /*  (C) Copyright John Maddock 2006.
  *  Use, modification and distribution are subject to the
  *  Boost Software License, Version 1.0. (See accompanying file
- *  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+ *  LICENSE_1_0.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
  */
 
 /* Both lanczos.h and lanczos.c were formed from Boost's lanczos.hpp
@@ -14,12 +14,12 @@
 
 /*
  * Optimal values for G for each N are taken from
- * http://web.mala.bc.ca/pughg/phdThesis/phdThesis.pdf,
+ * https://web.viu.ca/pughg/phdThesis/phdThesis.pdf,
  * as are the theoretical error bounds.
  *
  * Constants calculated using the method described by Godfrey
- * http://my.fit.edu/~gabdo/gamma.txt and elaborated by Toth at
- * http://www.rskey.org/gamma.htm using NTL::RR at 1000 bit precision.
+ * https://my.fit.edu/~gabdo/gamma.txt and elaborated by Toth at
+ * https://www.rskey.org/gamma.htm using NTL::RR at 1000 bit precision.
  */
 
 /*

--- a/scipy/special/cephes/owens_t.c
+++ b/scipy/special/cephes/owens_t.c
@@ -2,7 +2,7 @@
  *
  * Use, modification and distribution are subject to the
  * Boost Software License, Version 1.0. (See accompanying file
- * LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+ * LICENSE_1_0.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
  */
 
 /*

--- a/scipy/special/cephes/polevl.h
+++ b/scipy/special/cephes/polevl.h
@@ -51,7 +51,7 @@
 
 /* Sources:
  * [1] Holin et. al., "Polynomial and Rational Function Evaluation",
- *     http://www.boost.org/doc/libs/1_61_0/libs/math/doc/html/math_toolkit/roots/rational.html
+ *     https://www.boost.org/doc/libs/1_61_0/libs/math/doc/html/math_toolkit/roots/rational.html
  */
 
 /* Scipy changes:

--- a/scipy/special/cephes/psi.c
+++ b/scipy/special/cephes/psi.c
@@ -61,7 +61,7 @@
  * (C) Copyright John Maddock 2006.
  * Use, modification and distribution are subject to the
  * Boost Software License, Version 1.0. (See accompanying file
- * LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+ * LICENSE_1_0.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
  */
 
 #include "mconf.h"

--- a/scipy/special/cephes/zeta.c
+++ b/scipy/special/cephes/zeta.c
@@ -112,7 +112,7 @@ double x, q;
     }
 
     /* Asymptotic expansion
-     * http://dlmf.nist.gov/25.11#E43
+     * https://dlmf.nist.gov/25.11#E43
      */
     if (q > 1e8) {
         return (1/(x - 1) + 1/(2*q)) * pow(q, 1 - x);

--- a/scipy/special/lambertw.py
+++ b/scipy/special/lambertw.py
@@ -64,7 +64,7 @@ def lambertw(z, k=0, tol=1e-8):
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/Lambert_W_function
+    .. [1] https://en.wikipedia.org/wiki/Lambert_W_function
     .. [2] Corless et al, "On the Lambert W function", Adv. Comp. Math. 5
        (1996) 329-359.
        http://www.apmaths.uwo.ca/~djeffrey/Offprints/W-adv-cm.pdf

--- a/scipy/special/orthogonal.py
+++ b/scipy/special/orthogonal.py
@@ -905,20 +905,20 @@ def _pbcf(n, theta):
     References
     ----------
     .. [parabolic-asymptotics]
-       http://dlmf.nist.gov/12.10#vii
+       https://dlmf.nist.gov/12.10#vii
     """
     st = sin(theta)
     ct = cos(theta)
-    # http://dlmf.nist.gov/12.10#vii
+    # https://dlmf.nist.gov/12.10#vii
     mu = 2.0*n + 1.0
-    # http://dlmf.nist.gov/12.10#E23
+    # https://dlmf.nist.gov/12.10#E23
     eta = 0.5*theta - 0.5*st*ct
-    # http://dlmf.nist.gov/12.10#E39
+    # https://dlmf.nist.gov/12.10#E39
     zeta = -(3.0*eta/2.0) ** (2.0/3.0)
-    # http://dlmf.nist.gov/12.10#E40
+    # https://dlmf.nist.gov/12.10#E40
     phi = (-zeta / st**2) ** (0.25)
     # Coefficients
-    # http://dlmf.nist.gov/12.10#E43
+    # https://dlmf.nist.gov/12.10#E43
     a0 = 1.0
     a1 = 0.10416666666666666667
     a2 = 0.08355034722222222222
@@ -932,8 +932,8 @@ def _pbcf(n, theta):
     b4 = -0.31722720267841354810
     b5 = -0.94242914795712024914
     # Polynomials
-    # http://dlmf.nist.gov/12.10#E9
-    # http://dlmf.nist.gov/12.10#E10
+    # https://dlmf.nist.gov/12.10#E9
+    # https://dlmf.nist.gov/12.10#E10
     ctp = ct ** arange(16).reshape((-1,1))
     u0 = 1.0
     u1 = (1.0*ctp[3,:] - 6.0*ct) / 24.0
@@ -954,7 +954,7 @@ def _pbcf(n, theta):
     # Prefactor for U
     P = 2.0*sqrt(pi) * mu**(1.0/6.0) * phi
     # Terms for U
-    # http://dlmf.nist.gov/12.10#E42
+    # https://dlmf.nist.gov/12.10#E42
     phip = phi ** arange(6, 31, 6).reshape((-1,1))
     A0 = b0*u0
     A1 = (b2*u0 + phip[0,:]*b1*u1 + phip[1,:]*b0*u2) / zeta**3
@@ -963,13 +963,13 @@ def _pbcf(n, theta):
     B1 = -(a3*u0 + phip[0,:]*a2*u1 + phip[1,:]*a1*u2 + phip[2,:]*a0*u3) / zeta**5
     B2 = -(a5*u0 + phip[0,:]*a4*u1 + phip[1,:]*a3*u2 + phip[2,:]*a2*u3 + phip[3,:]*a1*u4 + phip[4,:]*a0*u5) / zeta**8
     # U
-    # http://dlmf.nist.gov/12.10#E35
+    # https://dlmf.nist.gov/12.10#E35
     U = P * (Ai * (A0 + A1/mu**2.0 + A2/mu**4.0) +
              Aip * (B0 + B1/mu**2.0 + B2/mu**4.0) / mu**(8.0/6.0))
     # Prefactor for derivative of U
     Pd = sqrt(2.0*pi) * mu**(2.0/6.0) / phi
     # Terms for derivative of U
-    # http://dlmf.nist.gov/12.10#E46
+    # https://dlmf.nist.gov/12.10#E46
     C0 = -(b1*v0 + phip[0,:]*b0*v1) / zeta
     C1 = -(b3*v0 + phip[0,:]*b2*v1 + phip[1,:]*b1*v2 + phip[2,:]*b0*v3) / zeta**4
     C2 = -(b5*v0 + phip[0,:]*b4*v1 + phip[1,:]*b3*v2 + phip[2,:]*b2*v3 + phip[3,:]*b1*v4 + phip[4,:]*b0*v5) / zeta**7
@@ -977,7 +977,7 @@ def _pbcf(n, theta):
     D1 = (a2*v0 + phip[0,:]*a1*v1 + phip[1,:]*a0*v2) / zeta**3
     D2 = (a4*v0 + phip[0,:]*a3*v1 + phip[1,:]*a2*v2 + phip[2,:]*a1*v3 + phip[3,:]*a0*v4) / zeta**6
     # Derivative of U
-    # http://dlmf.nist.gov/12.10#E36
+    # https://dlmf.nist.gov/12.10#E36
     Ud = Pd * (Ai * (C0 + C1/mu**2.0 + C2/mu**4.0) / mu**(4.0/6.0) +
                Aip * (D0 + D1/mu**2.0 + D2/mu**4.0))
     return U, Ud

--- a/scipy/special/specfun/specfun.f
+++ b/scipy/special/specfun/specfun.f
@@ -8765,7 +8765,7 @@ C             Careful on the branch cut -- avoid signed zeros
               CE1=-EL-CDLOG(Z)+Z*CE1
            ENDIF
         ELSE
-C          Continued fraction http://dlmf.nist.gov/6.9
+C          Continued fraction https://dlmf.nist.gov/6.9
 C
 C                           1     1     1     2     2     3     3
 C          E1 = exp(-z) * ----- ----- ----- ----- ----- ----- ----- ...

--- a/scipy/special/specfun_wrappers.c
+++ b/scipy/special/specfun_wrappers.c
@@ -418,7 +418,7 @@ double cem_cva_wrap(double m, double q) {
   }
   int_m = (int )m;
   if (q < 0) {
-    /* http://dlmf.nist.gov/28.2#E26 */
+    /* https://dlmf.nist.gov/28.2#E26 */
     if (int_m % 2 == 0) {
       return cem_cva_wrap(m, -q);
     }
@@ -442,7 +442,7 @@ double sem_cva_wrap(double m, double q) {
   }
   int_m = (int)m;
   if (q < 0) {
-    /* http://dlmf.nist.gov/28.2#E26 */
+    /* https://dlmf.nist.gov/28.2#E26 */
     if (int_m % 2 == 0) {
       return sem_cva_wrap(m, -q);
     }
@@ -468,7 +468,7 @@ int cem_wrap(double m, double q, double x, double *csf, double *csd)
   }
   int_m = (int)m;
   if (q < 0) {
-      /* http://dlmf.nist.gov/28.2#E34 */
+      /* https://dlmf.nist.gov/28.2#E34 */
       if (int_m % 2 == 0) {
         sgn = ((int_m/2) % 2 == 0) ? 1 : -1;
         cem_wrap(m, -q, 90 - x, &f, &d);
@@ -505,7 +505,7 @@ int sem_wrap(double m, double q, double x, double *csf, double *csd)
     return 0;
   }
   if (q < 0) {
-      /* http://dlmf.nist.gov/28.2#E34 */
+      /* https://dlmf.nist.gov/28.2#E34 */
       if (int_m % 2 == 0) {
         sgn = ((int_m/2) % 2 == 0) ? -1 : 1;
         sem_wrap(m, -q, 90 - x, &f, &d);

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -2035,7 +2035,7 @@ class TestHyper(object):
         assert_almost_equal(hyp1, 1.3498588075760032,7)
 
         # test contributed by Moritz Deger (2008-05-29)
-        # http://projects.scipy.org/scipy/scipy/ticket/659
+        # https://github.com/scipy/scipy/issues/1186 (Trac #659)
 
         # reference data obtained from mathematica [ a, b, x, m(a,b,x)]:
         # produced with test_hyp1f1.nb
@@ -3131,7 +3131,7 @@ class TestRound(object):
 
 def test_sph_harm():
     # Tests derived from tables in
-    # http://en.wikipedia.org/wiki/Table_of_spherical_harmonics
+    # https://en.wikipedia.org/wiki/Table_of_spherical_harmonics
     sh = special.sph_harm
     pi = np.pi
     exp = np.exp

--- a/scipy/special/tests/test_spherical_bessel.py
+++ b/scipy/special/tests/test_spherical_bessel.py
@@ -15,7 +15,7 @@ from scipy.integrate import quad
 
 class TestSphericalJn:
     def test_spherical_jn_exact(self):
-        # http://dlmf.nist.gov/10.49.E3
+        # https://dlmf.nist.gov/10.49.E3
         # Note: exact expression is numerically stable only for small
         # n or z >> n.
         x = np.array([0.12, 1.23, 12.34, 123.45, 1234.5])
@@ -23,27 +23,27 @@ class TestSphericalJn:
                         (-1/x + 3/x**3)*sin(x) - 3/x**2*cos(x))
 
     def test_spherical_jn_recurrence_complex(self):
-        # http://dlmf.nist.gov/10.51.E1
+        # https://dlmf.nist.gov/10.51.E1
         n = np.array([1, 2, 3, 7, 12])
         x = 1.1 + 1.5j
         assert_allclose(spherical_jn(n - 1, x) + spherical_jn(n + 1, x),
                         (2*n + 1)/x*spherical_jn(n, x))
 
     def test_spherical_jn_recurrence_real(self):
-        # http://dlmf.nist.gov/10.51.E1
+        # https://dlmf.nist.gov/10.51.E1
         n = np.array([1, 2, 3, 7, 12])
         x = 0.12
         assert_allclose(spherical_jn(n - 1, x) + spherical_jn(n + 1,x),
                         (2*n + 1)/x*spherical_jn(n, x))
 
     def test_spherical_jn_inf_real(self):
-        # http://dlmf.nist.gov/10.52.E3
+        # https://dlmf.nist.gov/10.52.E3
         n = 6
         x = np.array([-inf, inf])
         assert_allclose(spherical_jn(n, x), np.array([0, 0]))
 
     def test_spherical_jn_inf_complex(self):
-        # http://dlmf.nist.gov/10.52.E3
+        # https://dlmf.nist.gov/10.52.E3
         n = 7
         x = np.array([-inf + 0j, inf + 0j, inf*(1+1j)])
         assert_allclose(spherical_jn(n, x), np.array([0, 0, inf*(1+1j)]))
@@ -61,7 +61,7 @@ class TestSphericalJn:
         assert_allclose(spherical_jn(2, 10000), 3.0590002633029811e-05)
 
     def test_spherical_jn_at_zero(self):
-        # http://dlmf.nist.gov/10.52.E1
+        # https://dlmf.nist.gov/10.52.E1
         # But note that n = 0 is a special case: j0 = sin(x)/x -> 1
         n = np.array([0, 1, 2, 5, 10, 100])
         x = 0
@@ -70,7 +70,7 @@ class TestSphericalJn:
 
 class TestSphericalYn:
     def test_spherical_yn_exact(self):
-        # http://dlmf.nist.gov/10.49.E5
+        # https://dlmf.nist.gov/10.49.E5
         # Note: exact expression is numerically stable only for small
         # n or z >> n.
         x = np.array([0.12, 1.23, 12.34, 123.45, 1234.5])
@@ -78,33 +78,33 @@ class TestSphericalYn:
                         (1/x - 3/x**3)*cos(x) - 3/x**2*sin(x))
 
     def test_spherical_yn_recurrence_real(self):
-        # http://dlmf.nist.gov/10.51.E1
+        # https://dlmf.nist.gov/10.51.E1
         n = np.array([1, 2, 3, 7, 12])
         x = 0.12
         assert_allclose(spherical_yn(n - 1, x) + spherical_yn(n + 1,x),
                         (2*n + 1)/x*spherical_yn(n, x))
 
     def test_spherical_yn_recurrence_complex(self):
-        # http://dlmf.nist.gov/10.51.E1
+        # https://dlmf.nist.gov/10.51.E1
         n = np.array([1, 2, 3, 7, 12])
         x = 1.1 + 1.5j
         assert_allclose(spherical_yn(n - 1, x) + spherical_yn(n + 1, x),
                         (2*n + 1)/x*spherical_yn(n, x))
 
     def test_spherical_yn_inf_real(self):
-        # http://dlmf.nist.gov/10.52.E3
+        # https://dlmf.nist.gov/10.52.E3
         n = 6
         x = np.array([-inf, inf])
         assert_allclose(spherical_yn(n, x), np.array([0, 0]))
 
     def test_spherical_yn_inf_complex(self):
-        # http://dlmf.nist.gov/10.52.E3
+        # https://dlmf.nist.gov/10.52.E3
         n = 7
         x = np.array([-inf + 0j, inf + 0j, inf*(1+1j)])
         assert_allclose(spherical_yn(n, x), np.array([0, 0, inf*(1+1j)]))
 
     def test_spherical_yn_at_zero(self):
-        # http://dlmf.nist.gov/10.52.E2
+        # https://dlmf.nist.gov/10.52.E2
         n = np.array([0, 1, 2, 5, 10, 100])
         x = 0
         assert_allclose(spherical_yn(n, x), -inf*np.ones(shape=n.shape))
@@ -122,7 +122,7 @@ class TestSphericalYn:
 
 class TestSphericalJnYnCrossProduct:
     def test_spherical_jn_yn_cross_product_1(self):
-        # http://dlmf.nist.gov/10.50.E3
+        # https://dlmf.nist.gov/10.50.E3
         n = np.array([1, 5, 8])
         x = np.array([0.1, 1, 10])
         left = (spherical_jn(n + 1, x) * spherical_yn(n, x) -
@@ -131,7 +131,7 @@ class TestSphericalJnYnCrossProduct:
         assert_allclose(left, right)
 
     def test_spherical_jn_yn_cross_product_2(self):
-        # http://dlmf.nist.gov/10.50.E3
+        # https://dlmf.nist.gov/10.50.E3
         n = np.array([1, 5, 8])
         x = np.array([0.1, 1, 10])
         left = (spherical_jn(n + 2, x) * spherical_yn(n, x) -
@@ -142,33 +142,33 @@ class TestSphericalJnYnCrossProduct:
 
 class TestSphericalIn:
     def test_spherical_in_exact(self):
-        # http://dlmf.nist.gov/10.49.E9
+        # https://dlmf.nist.gov/10.49.E9
         x = np.array([0.12, 1.23, 12.34, 123.45])
         assert_allclose(spherical_in(2, x),
                         (1/x + 3/x**3)*sinh(x) - 3/x**2*cosh(x))
 
     def test_spherical_in_recurrence_real(self):
-        # http://dlmf.nist.gov/10.51.E4
+        # https://dlmf.nist.gov/10.51.E4
         n = np.array([1, 2, 3, 7, 12])
         x = 0.12
         assert_allclose(spherical_in(n - 1, x) - spherical_in(n + 1,x),
                         (2*n + 1)/x*spherical_in(n, x))
 
     def test_spherical_in_recurrence_complex(self):
-        # http://dlmf.nist.gov/10.51.E1
+        # https://dlmf.nist.gov/10.51.E1
         n = np.array([1, 2, 3, 7, 12])
         x = 1.1 + 1.5j
         assert_allclose(spherical_in(n - 1, x) - spherical_in(n + 1,x),
                         (2*n + 1)/x*spherical_in(n, x))
 
     def test_spherical_in_inf_real(self):
-        # http://dlmf.nist.gov/10.52.E3
+        # https://dlmf.nist.gov/10.52.E3
         n = 5
         x = np.array([-inf, inf])
         assert_allclose(spherical_in(n, x), np.array([-inf, inf]))
 
     def test_spherical_in_inf_complex(self):
-        # http://dlmf.nist.gov/10.52.E5
+        # https://dlmf.nist.gov/10.52.E5
         # Ideally, i1n(n, 1j*inf) = 0 and i1n(n, (1+1j)*inf) = (1+1j)*inf, but
         # this appears impossible to achieve because C99 regards any complex
         # value with at least one infinite  part as a complex infinity, so
@@ -179,7 +179,7 @@ class TestSphericalIn:
         assert_allclose(spherical_in(n, x), np.array([-inf, inf, nan]))
 
     def test_spherical_in_at_zero(self):
-        # http://dlmf.nist.gov/10.52.E1
+        # https://dlmf.nist.gov/10.52.E1
         # But note that n = 0 is a special case: i0 = sinh(x)/x -> 1
         n = np.array([0, 1, 2, 5, 10, 100])
         x = 0
@@ -188,33 +188,33 @@ class TestSphericalIn:
 
 class TestSphericalKn:
     def test_spherical_kn_exact(self):
-        # http://dlmf.nist.gov/10.49.E13
+        # https://dlmf.nist.gov/10.49.E13
         x = np.array([0.12, 1.23, 12.34, 123.45])
         assert_allclose(spherical_kn(2, x),
                         pi/2*exp(-x)*(1/x + 3/x**2 + 3/x**3))
 
     def test_spherical_kn_recurrence_real(self):
-        # http://dlmf.nist.gov/10.51.E4
+        # https://dlmf.nist.gov/10.51.E4
         n = np.array([1, 2, 3, 7, 12])
         x = 0.12
         assert_allclose((-1)**(n - 1)*spherical_kn(n - 1, x) - (-1)**(n + 1)*spherical_kn(n + 1,x),
                         (-1)**n*(2*n + 1)/x*spherical_kn(n, x))
 
     def test_spherical_kn_recurrence_complex(self):
-        # http://dlmf.nist.gov/10.51.E4
+        # https://dlmf.nist.gov/10.51.E4
         n = np.array([1, 2, 3, 7, 12])
         x = 1.1 + 1.5j
         assert_allclose((-1)**(n - 1)*spherical_kn(n - 1, x) - (-1)**(n + 1)*spherical_kn(n + 1,x),
                         (-1)**n*(2*n + 1)/x*spherical_kn(n, x))
 
     def test_spherical_kn_inf_real(self):
-        # http://dlmf.nist.gov/10.52.E6
+        # https://dlmf.nist.gov/10.52.E6
         n = 5
         x = np.array([-inf, inf])
         assert_allclose(spherical_kn(n, x), np.array([-inf, 0]))
 
     def test_spherical_kn_inf_complex(self):
-        # http://dlmf.nist.gov/10.52.E6
+        # https://dlmf.nist.gov/10.52.E6
         # The behavior at complex infinity depends on the sign of the real
         # part: if Re(z) >= 0, then the limit is 0; if Re(z) < 0, then it's
         # z*inf.  This distinction cannot be captured, so we return nan.
@@ -223,13 +223,13 @@ class TestSphericalKn:
         assert_allclose(spherical_kn(n, x), np.array([-inf, 0, nan]))
 
     def test_spherical_kn_at_zero(self):
-        # http://dlmf.nist.gov/10.52.E2
+        # https://dlmf.nist.gov/10.52.E2
         n = np.array([0, 1, 2, 5, 10, 100])
         x = 0
         assert_allclose(spherical_kn(n, x), inf*np.ones(shape=n.shape))
 
     def test_spherical_kn_at_zero_complex(self):
-        # http://dlmf.nist.gov/10.52.E2
+        # https://dlmf.nist.gov/10.52.E2
         n = np.array([0, 1, 2, 5, 10, 100])
         x = 0 + 0j
         assert_allclose(spherical_kn(n, x), nan*np.ones(shape=n.shape))

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -754,7 +754,7 @@ class burr12_gen(rv_continuous):
     .. [1] Burr, I. W. "Cumulative frequency functions", Annals of
        Mathematical Statistics, 13(2), pp 215-232 (1942).
 
-    .. [2] http://www.itl.nist.gov/div898/software/dataplot/refman2/auxillar/b12pdf.htm
+    .. [2] https://www.itl.nist.gov/div898/software/dataplot/refman2/auxillar/b12pdf.htm
 
     %(example)s
 
@@ -1299,7 +1299,7 @@ class exponnorm_gen(rv_continuous):
     %(after_notes)s
 
     An alternative parameterization of this distribution (for example, in
-    `Wikipedia <http://en.wikipedia.org/wiki/Exponentially_modified_Gaussian_distribution>`_)
+    `Wikipedia <https://en.wikipedia.org/wiki/Exponentially_modified_Gaussian_distribution>`_)
     involves three parameters, :math:`\mu`, :math:`\lambda` and
     :math:`\sigma`.
     In the present parameterization this corresponds to having ``loc`` and
@@ -1472,7 +1472,7 @@ class fatiguelife_gen(rv_continuous):
     References
     ----------
     .. [1] "Birnbaum-Saunders distribution",
-           http://en.wikipedia.org/wiki/Birnbaum-Saunders_distribution
+           https://en.wikipedia.org/wiki/Birnbaum-Saunders_distribution
 
     %(example)s
 
@@ -1686,7 +1686,7 @@ class foldnorm_gen(rv_continuous):
 
     def _stats(self, c):
         # Regina C. Elandt, Technometrics 3, 551 (1961)
-        # http://www.jstor.org/stable/1266561
+        # https://www.jstor.org/stable/1266561
         #
         c2 = c*c
         expfac = np.exp(-0.5*c2) / np.sqrt(2.*np.pi)
@@ -2803,7 +2803,7 @@ class gumbel_r_gen(rv_continuous):
         return _EULER, np.pi*np.pi/6.0, 12*np.sqrt(6)/np.pi**3 * _ZETA3, 12.0/5
 
     def _entropy(self):
-        # http://en.wikipedia.org/wiki/Gumbel_distribution
+        # https://en.wikipedia.org/wiki/Gumbel_distribution
         return _EULER + 1.
 
 
@@ -3693,7 +3693,7 @@ class logistic_gen(rv_continuous):
         return 0, np.pi*np.pi/3.0, 0, 6.0/5.0
 
     def _entropy(self):
-        # http://en.wikipedia.org/wiki/Logistic_distribution
+        # https://en.wikipedia.org/wiki/Logistic_distribution
         return 2.0
 
 
@@ -4145,7 +4145,7 @@ class kappa4_gen(rv_continuous):
         The "fifth" one is the one kappa4 should match which currently
         isn't implemented in scipy:
         https://en.wikipedia.org/wiki/Talk:Generalized_logistic_distribution
-        http://www.mathwave.com/help/easyfit/html/analyses/distributions/gen_logistic.html
+        https://www.mathwave.com/help/easyfit/html/analyses/distributions/gen_logistic.html
     (2) This distribution is currently not in scipy.
 
     References
@@ -4154,7 +4154,7 @@ class kappa4_gen(rv_continuous):
     to the Kolmogorov-Smirnov Test", A Dissertation Submitted to the Graduate
     Faculty of the Louisiana State University and Agricultural and Mechanical
     College, (August, 2004),
-    http://digitalcommons.lsu.edu/cgi/viewcontent.cgi?article=4671&context=gradschool_dissertations
+    https://digitalcommons.lsu.edu/gradschool_dissertations/3672
 
     J.R.M. Hosking, "The four-parameter kappa distribution". IBM J. Res.
     Develop. 38 (3), 25 1-258 (1994).
@@ -4162,7 +4162,7 @@ class kappa4_gen(rv_continuous):
     B. Kumphon, A. Kaew-Man, P. Seenoi, "A Rainfall Distribution for the Lampao
     Site in the Chi River Basin, Thailand", Journal of Water Resource and
     Protection, vol. 4, 866-869, (2012).
-    http://file.scirp.org/pdf/JWARP20121000009_14676002.pdf
+    https://doi.org/10.4236/jwarp.2012.410101
 
     C. Winchester, "On Estimation of the Four-Parameter Kappa Distribution", A
     Thesis Submitted to Dalhousie University, Halifax, Nova Scotia, (March
@@ -4363,12 +4363,11 @@ class kappa3_gen(rv_continuous):
     P.W. Mielke and E.S. Johnson, "Three-Parameter Kappa Distribution Maximum
     Likelihood and Likelihood Ratio Tests", Methods in Weather Research,
     701-707, (September, 1973),
-    http://docs.lib.noaa.gov/rescue/mwr/101/mwr-101-09-0701.pdf
+    https://doi.org/10.1175/1520-0493(1973)101<0701:TKDMLE>2.3.CO;2
 
     B. Kumphon, "Maximum Entropy and Maximum Likelihood Estimation for the
     Three-Parameter Kappa Distribution", Open Journal of Statistics, vol 2,
-    415-419 (2012)
-    http://file.scirp.org/pdf/OJS20120400011_95789012.pdf
+    415-419 (2012), https://doi.org/10.4236/ojs.2012.24050
 
     %(after_notes)s
 
@@ -4431,7 +4430,7 @@ class moyal_gen(rv_continuous):
     .. [3] C. Walck, "Handbook on Statistical Distributions for
            Experimentalists; International Report SUF-PFY/96-01", Chapter 26,
            University of Stockholm: Stockholm, Sweden, (2007).
-           www.stat.rice.edu/~dobelman/textfiles/DistributionsHandbook.pdf
+           http://www.stat.rice.edu/~dobelman/textfiles/DistributionsHandbook.pdf
 
     .. versionadded:: 1.1.0
 
@@ -4801,7 +4800,7 @@ class nct_gen(rv_continuous):
         # See D. Hogben, R.S. Pinkham, and M.B. Wilk,
         # 'The moments of the non-central t-distribution'
         # Biometrika 48, p. 465 (2961).
-        # e.g. http://www.jstor.org/stable/2332772 (gated)
+        # e.g. https://www.jstor.org/stable/2332772 (gated)
         #
         mu, mu2, g1, g2 = None, None, None, None
 
@@ -5436,7 +5435,7 @@ class rice_gen(rv_continuous):
         return b >= 0
 
     def _rvs(self, b):
-        # http://en.wikipedia.org/wiki/Rice_distribution
+        # https://en.wikipedia.org/wiki/Rice_distribution
         t = b/np.sqrt(2) + self._random_state.standard_normal(size=(2,) +
                                                               self._size)
         return np.sqrt((t*t).sum(axis=0))

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -848,7 +848,7 @@ class skellam_gen(rv_discrete):
 
     Parameters :math:`\mu_1` and :math:`\mu_2` must be strictly positive.
 
-    For details see: http://en.wikipedia.org/wiki/Skellam_distribution
+    For details see: https://en.wikipedia.org/wiki/Skellam_distribution
 
     `skellam` takes :math:`\mu_1` and :math:`\mu_2` as shape parameters.
 

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -3277,7 +3277,7 @@ class special_ortho_group_gen(multi_rv_generic):
     matrices with an application to condition estimators", SIAM Journal
     on Numerical Analysis, 17(3), pp. 403-409, 1980.
     For more information see
-    http://en.wikipedia.org/wiki/Orthogonal_matrix#Randomization
+    https://en.wikipedia.org/wiki/Orthogonal_matrix#Randomization
 
     See also the similar `ortho_group`.
 

--- a/scipy/stats/_tukeylambda_stats.py
+++ b/scipy/stats/_tukeylambda_stats.py
@@ -60,7 +60,7 @@ def tukeylambda_variance(lam):
     -----
     In an interval around lambda=0, this function uses the [4,4] Pade
     approximation to compute the variance.  Otherwise it uses the standard
-    formula (http://en.wikipedia.org/wiki/Tukey_lambda_distribution).  The
+    formula (https://en.wikipedia.org/wiki/Tukey_lambda_distribution).  The
     Pade approximation is used because the standard formula has a removable
     discontinuity at lambda = 0, and does not produce accurate numerical
     results near lambda = 0.

--- a/scipy/stats/contingency.py
+++ b/scipy/stats/contingency.py
@@ -187,9 +187,10 @@ def chi2_contingency(observed, correction=True, lambda_=None):
 
     References
     ----------
-    .. [1] "Contingency table", http://en.wikipedia.org/wiki/Contingency_table
+    .. [1] "Contingency table",
+           https://en.wikipedia.org/wiki/Contingency_table
     .. [2] "Pearson's chi-squared test",
-           http://en.wikipedia.org/wiki/Pearson%27s_chi-squared_test
+           https://en.wikipedia.org/wiki/Pearson%27s_chi-squared_test
     .. [3] Cressie, N. and Read, T. R. C., "Multinomial Goodness-of-Fit
            Tests", J. Royal Stat. Soc. Series B, Vol. 46, No. 3 (1984),
            pp. 440-464.

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -80,7 +80,7 @@ def bayes_mvs(data, alpha=0.90):
     References
     ----------
     T.E. Oliphant, "A Bayesian perspective on estimating mean, variance, and
-    standard-deviation from data", http://scholarsarchive.byu.edu/facpub/278,
+    standard-deviation from data", https://scholarsarchive.byu.edu/facpub/278,
     2006.
 
     Examples
@@ -169,7 +169,7 @@ def mvsdist(data):
     References
     ----------
     T.E. Oliphant, "A Bayesian perspective on estimating mean, variance, and
-    standard-deviation from data", http://scholarsarchive.byu.edu/facpub/278,
+    standard-deviation from data", https://scholarsarchive.byu.edu/facpub/278,
     2006.
 
     Examples
@@ -669,7 +669,7 @@ def ppcc_max(x, brack=(0.0, 1.0), dist='tukeylambda'):
     .. [1] J.J. Filliben, "The Probability Plot Correlation Coefficient Test for
            Normality", Technometrics, Vol. 17, pp. 111-117, 1975.
 
-    .. [2] http://www.itl.nist.gov/div898/handbook/eda/section3/ppccplot.htm
+    .. [2] https://www.itl.nist.gov/div898/handbook/eda/section3/ppccplot.htm
 
     Examples
     --------
@@ -1274,7 +1274,7 @@ def shapiro(x):
 
     References
     ----------
-    .. [1] http://www.itl.nist.gov/div898/handbook/prc/section2/prc213.htm
+    .. [1] https://www.itl.nist.gov/div898/handbook/prc/section2/prc213.htm
     .. [2] Shapiro, S. S. & Wilk, M.B (1965). An analysis of variance test for
            normality (complete samples), Biometrika, Vol. 52, pp. 591-611.
     .. [3] Razali, N. M. & Wah, Y. B. (2011) Power comparisons of Shapiro-Wilk,
@@ -1384,7 +1384,7 @@ def anderson(x, dist='norm'):
 
     References
     ----------
-    .. [1] http://www.itl.nist.gov/div898/handbook/prc/section2/prc213.htm
+    .. [1] https://www.itl.nist.gov/div898/handbook/prc/section2/prc213.htm
     .. [2] Stephens, M. A. (1974). EDF Statistics for Goodness of Fit and
            Some Comparisons, Journal of the American Statistical Association,
            Vol. 69, pp. 730-737.
@@ -1819,7 +1819,7 @@ def bartlett(*args):
 
     References
     ----------
-    .. [1]  http://www.itl.nist.gov/div898/handbook/eda/section3/eda357.htm
+    .. [1]  https://www.itl.nist.gov/div898/handbook/eda/section3/eda357.htm
 
     .. [2]  Snedecor, George W. and Cochran, William G. (1989), Statistical
               Methods, Eighth Edition, Iowa State University Press.
@@ -1900,7 +1900,7 @@ def levene(*args, **kwds):
 
     References
     ----------
-    .. [1]  http://www.itl.nist.gov/div898/handbook/eda/section3/eda35a.htm
+    .. [1]  https://www.itl.nist.gov/div898/handbook/eda/section3/eda35a.htm
     .. [2]   Levene, H. (1960). In Contributions to Probability and Statistics:
                Essays in Honor of Harold Hotelling, I. Olkin et al. eds.,
                Stanford University Press, pp. 278-292.
@@ -2001,7 +2001,7 @@ def binom_test(x, n=None, p=0.5, alternative='two-sided'):
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/Binomial_test
+    .. [1] https://en.wikipedia.org/wiki/Binomial_test
 
     """
     x = atleast_1d(x).astype(np.integer)
@@ -2115,7 +2115,7 @@ def fligner(*args, **kwds):
            Hypothesis Testing based on Quadratic Inference Function. Technical
            Report #99-03, Center for Likelihood Studies, Pennsylvania State
            University.
-           http://cecas.clemson.edu/~cspark/cv/paper/qif/draftqif2.pdf
+           https://cecas.clemson.edu/~cspark/cv/paper/qif/draftqif2.pdf
 
     .. [2] Fligner, M.A. and Killeen, T.J. (1976). Distribution-free two-sample
            tests for scale. 'Journal of the American Statistical Association.'
@@ -2363,7 +2363,7 @@ def wilcoxon(x, y=None, zero_method="wilcox", correction=False):
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/Wilcoxon_signed-rank_test
+    .. [1] https://en.wikipedia.org/wiki/Wilcoxon_signed-rank_test
 
     """
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -872,7 +872,7 @@ def moment(a, moment=1, axis=0, nan_policy='propagate'):
 
     References
     ----------
-    .. [1] http://eli.thegreenplace.net/2009/03/21/efficient-integer-exponentiation-algorithms
+    .. [1] https://eli.thegreenplace.net/2009/03/21/efficient-integer-exponentiation-algorithms
 
     Examples
     --------
@@ -1745,7 +1745,7 @@ def percentileofscore(a, score, kind='rank'):
         - "mean": The average of the "weak" and "strict" scores, often used in
                   testing.  See
 
-                  http://en.wikipedia.org/wiki/Percentile_rank
+                  https://en.wikipedia.org/wiki/Percentile_rank
 
     Returns
     -------
@@ -2877,7 +2877,7 @@ def f_oneway(*args):
     ----------
     .. [1] Lowry, Richard.  "Concepts and Applications of Inferential
            Statistics". Chapter 14.
-           http://faculty.vassar.edu/lowry/ch14pt1.html
+           https://web.archive.org/web/20171027235250/http://vassarstats.net:80/textbook/ch14pt1.html
 
     .. [2] Heiman, G.W.  Research Methods in Statistics. 2002.
 
@@ -3403,7 +3403,9 @@ def pointbiserialr(x, y):
            Variable. Point-Biserial Correlation.", Ann. Math. Statist., Vol. 25,
            np. 3, pp. 603-607, 1954.
 
-    .. [3] http://onlinelibrary.wiley.com/doi/10.1002/9781118445112.stat06227/full
+    .. [3] D. Kornbrot "Point Biserial Correlation", In Wiley StatsRef:
+           Statistics Reference Online (eds N. Balakrishnan, et al.), 2014.
+           https://doi.org/10.1002/9781118445112.stat06227
 
     Examples
     --------
@@ -3927,9 +3929,9 @@ def ttest_ind_from_stats(mean1, std1, nobs1, mean2, std2, nobs2,
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/T-test#Independent_two-sample_t-test
+    .. [1] https://en.wikipedia.org/wiki/T-test#Independent_two-sample_t-test
 
-    .. [2] http://en.wikipedia.org/wiki/Welch%27s_t_test
+    .. [2] https://en.wikipedia.org/wiki/Welch%27s_t-test
 
     Examples
     --------
@@ -4018,9 +4020,9 @@ def ttest_ind(a, b, axis=0, equal_var=True, nan_policy='propagate'):
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/T-test#Independent_two-sample_t-test
+    .. [1] https://en.wikipedia.org/wiki/T-test#Independent_two-sample_t-test
 
-    .. [2] http://en.wikipedia.org/wiki/Welch%27s_t_test
+    .. [2] https://en.wikipedia.org/wiki/Welch%27s_t-test
 
     Examples
     --------
@@ -4464,9 +4466,10 @@ def power_divergence(f_obs, f_exp=None, ddof=0, axis=0, lambda_=None):
     References
     ----------
     .. [1] Lowry, Richard.  "Concepts and Applications of Inferential
-           Statistics". Chapter 8. http://faculty.vassar.edu/lowry/ch8pt1.html
-    .. [2] "Chi-squared test", http://en.wikipedia.org/wiki/Chi-squared_test
-    .. [3] "G-test", http://en.wikipedia.org/wiki/G-test
+           Statistics". Chapter 8.
+           https://web.archive.org/web/20171015035606/http://faculty.vassar.edu/lowry/ch8pt1.html
+    .. [2] "Chi-squared test", https://en.wikipedia.org/wiki/Chi-squared_test
+    .. [3] "G-test", https://en.wikipedia.org/wiki/G-test
     .. [4] Sokal, R. R. and Rohlf, F. J. "Biometry: the principles and
            practice of statistics in biological research", New York: Freeman
            (1981)
@@ -4643,8 +4646,9 @@ def chisquare(f_obs, f_exp=None, ddof=0, axis=0):
     References
     ----------
     .. [1] Lowry, Richard.  "Concepts and Applications of Inferential
-           Statistics". Chapter 8. http://faculty.vassar.edu/lowry/ch8pt1.html
-    .. [2] "Chi-squared test", http://en.wikipedia.org/wiki/Chi-squared_test
+           Statistics". Chapter 8.
+           https://web.archive.org/web/20171022032306/http://vassarstats.net:80/textbook/ch8pt1.html
+    .. [2] "Chi-squared test", https://en.wikipedia.org/wiki/Chi-squared_test
 
     Examples
     --------
@@ -4959,7 +4963,7 @@ def ranksums(x, y):
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/Wilcoxon_rank-sum_test
+    .. [1] https://en.wikipedia.org/wiki/Wilcoxon_rank-sum_test
 
     """
     x, y = map(np.asarray, (x, y))
@@ -5025,7 +5029,7 @@ def kruskal(*args, **kwargs):
     .. [1] W. H. Kruskal & W. W. Wallis, "Use of Ranks in
        One-Criterion Variance Analysis", Journal of the American Statistical
        Association, Vol. 47, Issue 260, pp. 583-621, 1952.
-    .. [2] http://en.wikipedia.org/wiki/Kruskal-Wallis_one-way_analysis_of_variance
+    .. [2] https://en.wikipedia.org/wiki/Kruskal-Wallis_one-way_analysis_of_variance
 
     Examples
     --------
@@ -5133,7 +5137,7 @@ def friedmanchisquare(*args):
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/Friedman_test
+    .. [1] https://en.wikipedia.org/wiki/Friedman_test
 
     """
     k = len(args)
@@ -5348,7 +5352,7 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
     References
     ----------
     .. [1] https://en.wikipedia.org/wiki/Fisher%27s_method
-    .. [2] http://en.wikipedia.org/wiki/Fisher's_method#Relation_to_Stouffer.27s_Z-score_method
+    .. [2] https://en.wikipedia.org/wiki/Fisher%27s_method#Relation_to_Stouffer.27s_Z-score_method
     .. [3] Whitlock, M. C. "Combining probability from independent tests: the
            weighted Z-method is superior to Fisher's approach." Journal of
            Evolutionary Biology 18, no. 5 (2005): 1368-1373.
@@ -5458,7 +5462,7 @@ def wasserstein_distance(u_values, v_values, u_weights=None, v_weights=None):
 
     References
     ----------
-    .. [1] "Wasserstein metric", http://en.wikipedia.org/wiki/Wasserstein_metric
+    .. [1] "Wasserstein metric", https://en.wikipedia.org/wiki/Wasserstein_metric
     .. [2] Ramdas, Garcia, Cuturi "On Wasserstein Two Sample Testing and Related
            Families of Nonparametric Tests" (2015). :arXiv:`1509.02237`.
 
@@ -5826,7 +5830,7 @@ def rankdata(a, method='average'):
 
     References
     ----------
-    .. [1] "Ranking", http://en.wikipedia.org/wiki/Ranking
+    .. [1] "Ranking", https://en.wikipedia.org/wiki/Ranking
 
     Examples
     --------

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2660,7 +2660,7 @@ def test_powerlaw_stats():
     variance:
         sigma**2 = a / ((a + 2) * (a + 1) ** 2)
     skewness:
-        One formula (see http://en.wikipedia.org/wiki/Skewness) is
+        One formula (see https://en.wikipedia.org/wiki/Skewness) is
             gamma_1 = (E[X**3] - 3*mu*E[X**2] + 2*mu**3) / sigma**3
         A short calculation shows that E[X**k] is a / (a + k), so gamma_1
         can be implemented as
@@ -2670,7 +2670,7 @@ def test_powerlaw_stats():
         Either by simplifying, or by a direct calculation of mu_3 / sigma**3,
         one gets the more concise formula:
             gamma_1 = -2.0 * ((a - 1) / (a + 3)) * sqrt((a + 2) / a)
-    kurtosis: (See http://en.wikipedia.org/wiki/Kurtosis)
+    kurtosis: (See https://en.wikipedia.org/wiki/Kurtosis)
         The excess kurtosis is
             gamma_2 = mu_4 / sigma**4 - 3
         A bit of calculus and algebra (sympy helps) shows that

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -356,8 +356,8 @@ class TestMoments(object):
     # note that length(testcase) = 4
     # testmathworks comes from documentation for the
     # Statistics Toolbox for Matlab and can be found at both
-    # http://www.mathworks.com/access/helpdesk/help/toolbox/stats/kurtosis.shtml
-    # http://www.mathworks.com/access/helpdesk/help/toolbox/stats/skewness.shtml
+    # https://www.mathworks.com/help/stats/kurtosis.html
+    # https://www.mathworks.com/help/stats/skewness.html
     # Note that both test cases came from here.
     testcase = [1,2,3,4]
     testmathworks = ma.fix_invalid([1.165, 0.6268, 0.0751, 0.3516, -0.6965,

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2,7 +2,7 @@
 
     WRITTEN BY LOUIS LUANGKESORN <lluang@yahoo.com> FOR THE STATS MODULE
     BASED ON WILKINSON'S STATISTICS QUIZ
-    http://www.stanford.edu/~clint/bench/wilk.txt
+    https://www.stanford.edu/~clint/bench/wilk.txt
 
     Additional tests by a host of SciPy developers.
 """
@@ -1921,8 +1921,8 @@ class TestMoments(object):
         note that length(testcase) = 4
         testmathworks comes from documentation for the
         Statistics Toolbox for Matlab and can be found at both
-        http://www.mathworks.com/access/helpdesk/help/toolbox/stats/kurtosis.shtml
-        http://www.mathworks.com/access/helpdesk/help/toolbox/stats/skewness.shtml
+        https://www.mathworks.com/help/stats/kurtosis.html
+        https://www.mathworks.com/help/stats/skewness.html
         Note that both test cases came from here.
     """
     testcase = [1,2,3,4]
@@ -3407,7 +3407,7 @@ class TestMannWhitneyU(object):
 
 def test_pointbiserial():
     # same as mstats test except for the nan
-    # Test data: http://support.sas.com/ctx/samples/index.jsp?sid=490&tab=output
+    # Test data: https://web.archive.org/web/20060504220742/https://support.sas.com/ctx/samples/index.jsp?sid=490&tab=output
     x = [1,0,1,1,1,1,0,1,0,0,0,1,1,0,0,0,1,1,1,0,0,0,0,0,0,0,0,1,0,
          0,0,0,0,1]
     y = [14.8,13.8,12.4,10.1,7.1,6.1,5.8,4.6,4.3,3.5,3.3,3.2,3.0,
@@ -3936,7 +3936,7 @@ class TestFOneWay(object):
 
     def test_nist(self):
         # These are the nist ANOVA files. They can be found at:
-        # http://www.itl.nist.gov/div898/strd/anova/anova.html
+        # https://www.itl.nist.gov/div898/strd/anova/anova.html
         filenames = ['SiRstv.dat', 'SmLs01.dat', 'SmLs02.dat', 'SmLs03.dat',
                      'AtmWtAg.dat', 'SmLs04.dat', 'SmLs05.dat', 'SmLs06.dat',
                      'SmLs07.dat', 'SmLs08.dat', 'SmLs09.dat']
@@ -4046,7 +4046,7 @@ class TestKruskal(object):
 class TestCombinePvalues(object):
 
     def test_fisher(self):
-        # Example taken from http://en.wikipedia.org/wiki/Fisher's_exact_test#Example
+        # Example taken from https://en.wikipedia.org/wiki/Fisher%27s_exact_test#Example
         xsq, p = stats.combine_pvalues([.01, .2, .3], method='fisher')
         assert_approx_equal(p, 0.02156, significant=4)
 

--- a/site.cfg.example
+++ b/site.cfg.example
@@ -9,7 +9,7 @@
 
 # The format of the file is that of the standard library's ConfigParser module.
 #
-#   http://docs.python.org/3/library/configparser.html
+#   https://docs.python.org/library/configparser.html
 #
 # Each section defines settings that apply to one particular dependency. Some of
 # the settings are general and apply to nearly any section and are defined here.
@@ -123,7 +123,7 @@
 # multiprocessing.
 # (This problem does not exist with multithreaded ATLAS.)
 #
-# http://docs.python.org/3.4/library/multiprocessing.html#contexts-and-start-methods
+# https://docs.python.org/3.4/library/multiprocessing.html#contexts-and-start-methods
 # https://github.com/xianyi/OpenBLAS/issues/294
 #
 # [openblas]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 # 'Tox' is a tool for automating sdist/build/test cycles against
 # multiple Python versions:
-#   http://pypi.python.org/pypi/tox
-#   http://tox.testrun.org/
+#   https://pypi.python.org/pypi/tox
+#   https://tox.readthedocs.io
 
 # Running the command 'tox' while in the root of the scipy source
 # directory will:


### PR DESCRIPTION
Most of the fixes here upgrade from HTTP to HTTPS, particularly for Scipy pages.

Other modifications are to update websites, as they exist today. Some older websites are revived using https://web.archive.org and few others that have no archive were marked with "(dead link)". These should be considered for either removal or replacement.