### PR TITLE
BUG: fftpack: allow next_fast_len(numpy integers)

### DIFF
--- a/scipy/fftpack/helper.py
+++ b/scipy/fftpack/helper.py
@@ -110,6 +110,7 @@ def next_fast_len(target):
             6480, 6561, 6750, 6912, 7200, 7290, 7500, 7680, 7776, 8000, 8100,
             8192, 8640, 8748, 9000, 9216, 9375, 9600, 9720, 10000)
 
+    target = int(target)    # convert e.g. numpy ints to python ints
     if target <= 6:
         return target
 

--- a/scipy/fftpack/tests/test_helper.py
+++ b/scipy/fftpack/tests/test_helper.py
@@ -17,6 +17,7 @@ from scipy.fftpack import fftshift,ifftshift,fftfreq,rfftfreq
 from scipy.fftpack.helper import next_fast_len
 
 from numpy import pi, random
+import numpy as np
 
 
 class TestFFTShift(object):
@@ -158,4 +159,13 @@ class TestNextOptLen(object):
         }
         for x, y in hams.items():
             assert_equal(next_fast_len(x), y)
+
+    def test_np_integers(self):
+        # regression test for gh-8947: next_fast_len(np.int64(27000)) raises
+        # because np.int64 does not have a .bit_length() method
+        ITYPES = [np.int16, np.int32, np.int64, np.uint16, np.uint32, np.uint64]
+        for ityp in ITYPES:
+            x = ityp(27000)
+            nfl = next_fast_len(x)
+            assert_equal(nfl, next_fast_len(int(x)))
 


### PR DESCRIPTION
closes gh-8947
This is a minimal fix: convert numpy integers to python integers right away. Otherwise, there are two issues: 1) numpy integers do not have the `bit_length` method, and 2) `target & (target -1)` fails for unsigned ints because `np.uint32(2700) - 1` is of type `float`  :-).

All in all, it seems easiest to just convert the input to a python int and be done with it.