### PR TITLE
BUG: sparse.linalg: downgrade LinearOperator TypeError to warning

### DIFF
--- a/scipy/sparse/linalg/interface.py
+++ b/scipy/sparse/linalg/interface.py
@@ -42,6 +42,8 @@ Several algorithms in the ``scipy.sparse`` library are able to operate on
 
 from __future__ import division, print_function, absolute_import
 
+import warnings
+
 import numpy as np
 
 from scipy.sparse import isspmatrix
@@ -136,8 +138,9 @@ class LinearOperator(object):
 
             if (type(obj)._matvec == LinearOperator._matvec
                     and type(obj)._matmat == LinearOperator._matmat):
-                raise TypeError("LinearOperator subclass should implement"
-                                " at least one of _matvec and _matmat.")
+                warnings.warn("LinearOperator subclass should implement"
+                              " at least one of _matvec and _matmat.",
+                              category=RuntimeWarning, stacklevel=2)
 
             return obj
 


### PR DESCRIPTION
Raising an error here was a backward compatibility break.

Moreover, subclasses not implementing the _* methods is not necessarily
an error, depending on the intent of the subclass so a warning is
sufficient.