### PR TITLE
Added 'average' keyword for welch/csd to enable median averaging

### DIFF
--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -580,10 +580,14 @@ def csd(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
 
     # Average over windows.
     if len(Pxy.shape) >= 2 and Pxy.size > 0:
-        if Pxy.shape[-1] > 1 and average == 'median':
-            Pxy = np.median(Pxy, axis=-1) / _median_bias(Pxy.shape[-1])
-        elif Pxy.shape[-1] > 1:
-            Pxy = Pxy.mean(axis=-1)
+        if Pxy.shape[-1] > 1:
+            if average == 'median':
+                Pxy = np.median(Pxy, axis=-1) / _median_bias(Pxy.shape[-1])
+            elif average == 'mean':
+                Pxy = Pxy.mean(axis=-1)
+            else:
+                raise ValueError('average must be "median" or "mean", got %s'
+                                 % (average,))
         else:
             Pxy = np.reshape(Pxy, Pxy.shape[:-1])
 

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -286,7 +286,7 @@ def periodogram(x, fs=1.0, window='boxcar', nfft=None, detrend='constant',
 
 def welch(x, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
           detrend='constant', return_onesided=True, scaling='density',
-          average='mean', axis=-1):
+          axis=-1, average='mean'):
     r"""
     Estimate power spectral density using Welch's method.
 
@@ -334,11 +334,13 @@ def welch(x, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
         spectrum ('spectrum') where `Pxx` has units of V**2, if `x`
         is measured in V and `fs` is measured in Hz. Defaults to
         'density'
-    average : { 'mean', 'median' }, optional
-        Method to use when averaging periodograms. Defaults to 'mean'.
     axis : int, optional
         Axis along which the periodogram is computed; the default is
         over the last axis (i.e. ``axis=-1``).
+    average : { 'mean', 'median' }, optional
+        Method to use when averaging periodograms. Defaults to 'mean'.
+
+        .. versionadded:: 1.2.0
 
     Returns
     -------
@@ -427,14 +429,14 @@ def welch(x, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
     freqs, Pxx = csd(x, x, fs=fs, window=window, nperseg=nperseg,
                      noverlap=noverlap, nfft=nfft, detrend=detrend,
                      return_onesided=return_onesided, scaling=scaling,
-                     average=average, axis=axis)
+                     axis=axis, average=average)
 
     return freqs, Pxx.real
 
 
 def csd(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
         detrend='constant', return_onesided=True, scaling='density',
-        average='mean', axis=-1):
+        axis=-1, average='mean'):
     r"""
     Estimate the cross power spectral density, Pxy, using Welch's
     method.
@@ -480,11 +482,13 @@ def csd(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
         where `Pxy` has units of V**2/Hz and computing the cross spectrum
         ('spectrum') where `Pxy` has units of V**2, if `x` and `y` are
         measured in V and `fs` is measured in Hz. Defaults to 'density'
-    average : { 'mean', 'median' }, optional
-        Method to use when averaging periodograms. Defaults to 'mean'.
     axis : int, optional
         Axis along which the CSD is computed for both inputs; the
         default is over the last axis (i.e. ``axis=-1``).
+    average : { 'mean', 'median' }, optional
+        Method to use when averaging periodograms. Defaults to 'mean'.
+
+        .. versionadded:: 1.2.0
 
     Returns
     -------

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -3,7 +3,6 @@
 
 from __future__ import division, print_function, absolute_import
 
-from math import log
 import numpy as np
 from scipy import fftpack
 from . import signaltools
@@ -12,7 +11,7 @@ from ._spectral import _lombscargle
 from ._arraytools import const_ext, even_ext, odd_ext, zero_ext
 import warnings
 
-from scipy._lib.six import (string_types, xrange)
+from scipy._lib.six import string_types
 
 __all__ = ['periodogram', 'welch', 'lombscargle', 'csd', 'coherence',
            'spectrogram', 'stft', 'istft', 'check_COLA']
@@ -1819,9 +1818,5 @@ def _median_bias(n):
     bias : float
         Calculated bias.
     """
-    if n >= 1000:  # large n limit
-        return log(2)
-    bias = 1
-    for i in xrange(1, int((n-1)/2) + 1):
-        bias += 1. / (2 * i + 1) - 1. / (2 * i)
-    return bias
+    ii_2 = 2 * np.arange(1., (n-1) // 2 + 1)
+    return 1 + np.sum(1. / (ii_2 + 1) - 1. / ii_2)

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -280,8 +280,9 @@ def periodogram(x, fs=1.0, window='boxcar', nfft=None, detrend='constant',
         nperseg = nfft
         nfft = None
 
-    return welch(x, fs, window, nperseg, 0, nfft, detrend, return_onesided,
-                 scaling, axis)
+    return welch(x, fs=fs, window=window, nperseg=nperseg, noverlap=0,
+                 nfft=nfft, detrend=detrend, return_onesided=return_onesided,
+                 scaling=scaling, axis=axis)
 
 
 def welch(x, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
@@ -1384,10 +1385,13 @@ def coherence(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
     >>> plt.show()
     """
 
-    freqs, Pxx = welch(x, fs, window, nperseg, noverlap, nfft, detrend,
+    freqs, Pxx = welch(x, fs=fs, window=window, nperseg=nperseg,
+                       noverlap=noverlap, nfft=nfft, detrend=detrend,
                        axis=axis)
-    _, Pyy = welch(y, fs, window, nperseg, noverlap, nfft, detrend, axis=axis)
-    _, Pxy = csd(x, y, fs, window, nperseg, noverlap, nfft, detrend, axis=axis)
+    _, Pyy = welch(y, fs=fs, window=window, nperseg=nperseg, noverlap=noverlap,
+                   nfft=nfft, detrend=detrend, axis=axis)
+    _, Pxy = csd(x, y, fs=fs, window=window, nperseg=nperseg,
+                 noverlap=noverlap, nfft=nfft, detrend=detrend, axis=axis)
 
     Cxy = np.abs(Pxy)**2 / Pxx / Pyy
 

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -424,6 +424,22 @@ def welch(x, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
     >>> np.sqrt(Pxx_spec.max())
     2.0077340678640727
 
+    If we now introduce a discontinuity in the signal, by increasing the
+    amplitude of a small portion of the signal by 50, we can see the
+    corruption of the mean average power spectral density, but using a
+    median average better estimates the normal behaviour.
+
+    >>> x[int(N//2):int(N//2)+10] *= 50.
+    >>> f, Pxx_den = signal.welch(x, fs, nperseg=1024)
+    >>> f_med, Pxx_den_med = signal.welch(x, fs, nperseg=1024, average='median')
+    >>> plt.semilogy(f, Pxx_den, label='mean')
+    >>> plt.semilogy(f_med, Pxx_den_med, label='median')
+    >>> plt.ylim([0.5e-3, 1])
+    >>> plt.xlabel('frequency [Hz]')
+    >>> plt.ylabel('PSD [V**2/Hz]')
+    >>> plt.legend()
+    >>> plt.show()
+
     """
 
     freqs, Pxx = csd(x, x, fs=fs, window=window, nperseg=nperseg,

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -532,7 +532,8 @@ class TestWelch(object):
         q = np.array([.1, .05, 0., 1.54074396e-33, 0.])
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
 
-        assert_raises(ValueError, welch, x, average='unrecognised-average')
+        assert_raises(ValueError, welch, x, nperseg=8,
+                      average='unrecognised-average')
 
 
 class TestCSD:

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -523,6 +523,16 @@ class TestWelch(object):
             assert_equal(p_flat, p_plus.squeeze(), err_msg=a)
             assert_equal(p_flat, p_minus.squeeze(), err_msg=a-x.ndim)
 
+    def test_average(self):
+        x = np.zeros(16)
+        x[0] = 1
+        x[8] = 1
+        f, p = welch(x, nperseg=8, average='median')
+        assert_allclose(f, np.linspace(0, 0.5, 5))
+        q = np.array([.1, .05, 0., 1.54074396e-33, 0.])
+        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
+
+
 class TestCSD:
     def test_pad_shorter_x(self):
         x = np.zeros(8)

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -532,6 +532,8 @@ class TestWelch(object):
         q = np.array([.1, .05, 0., 1.54074396e-33, 0.])
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
 
+        assert_raises(ValueError, welch, x, average='unrecognised-average')
+
 
 class TestCSD:
     def test_pad_shorter_x(self):


### PR DESCRIPTION
This PR adds a keyword `average='mean'` to the `welch()` and `csd()` methods in `scipy/signal/spectral.py` to enable calculating a median average PSD, as opposed to the default mean average.

The median average is used heavily in gravitational-wave astrophysics to minimise the impact of short-duration transients in the estimation of an average PSD. The following example highlights the difference for some LIGO GW detector data that includes a large, short-duration excursion that should only be present in ~2 of the individual periodograms:

```python
import tempfile
from six.moves.urllib import request
from scipy import signal
from matplotlib import pyplot
import h5py

hurl = ("https://losc.ligo.org/s/events/GW170817/"
        "L-L1_LOSC_C00_4_V1-1187006834-4096.hdf5")

with tempfile.NamedTemporaryFile() as local:
    request.urlretrieve(hurl, local.name)
    h5f = h5py.File(local.name)
    dset = h5f['strain/Strain']
    hoft = dset[:]
    fs = 1 / dset.attrs['Xspacing']

nfft = fs
noverlap = fs / 2.

fmean, pmean = signal.welch(hoft, fs=fs, window='hann', nperseg=nfft,
                            noverlap=noverlap, average='mean')
fmedian, pmedian = signal.welch(hoft, fs=fs, window='hann', nperseg=nfft,
                                noverlap=noverlap, average='median')

fig = pyplot.figure()
ax = fig.gca(xscale='log', xlim=(10, 1500), xlabel='Frequency [Hz]',
             yscale='log', ylim=(1e-47, 1e-42),
             ylabel=r'Power spectral density (1/$\sqrt{\mathrm{Hz}}$')
ax.plot(fmean, pmean, label='mean')
ax.plot(fmedian, pmedian, label='median')
ax.legend()
pyplot.show(fig)
```
![scipy-median](https://user-images.githubusercontent.com/1618530/41846595-1185d40e-786f-11e8-9a26-636d52d0f547.png)

In the above, the orange curve more accurately estimates the 'average' PSD.
