### PR TITLE
Better imresize deprecation warning

### DIFF
--- a/scipy/misc/pilutil.py
+++ b/scipy/misc/pilutil.py
@@ -508,8 +508,8 @@ def imshow(arr):
 
 
 @numpy.deprecate(message="`imresize` is deprecated in SciPy 1.0.0, "
-                         "and will be removed in 1.2.0.\n"
-                         "Use ``skimage.transform.resize`` instead.")
+                         "and will be removed in 1.3.0.\n"
+                         "Use Pillow instead: ``numpy.array(Image.fromarray(arr).imresize())``.")
 def imresize(arr, size, interp='bilinear', mode=None):
     """
     Resize an image.


### PR DESCRIPTION
Better deprecation warning, which tells the user how to recover the **same exact output data** when `imresize` will be taken out.