### PR TITLE
MAINT: Switch np.where(c) for np.nonzero(c)

### DIFF
--- a/doc/source/tutorial/csgraph.rst
+++ b/doc/source/tutorial/csgraph.rst
@@ -152,7 +152,7 @@ the list of components::
 There is one large connected set, and 14 smaller ones.  Let's look at the
 words in the smaller ones::
 
-    >>> [list(word_list[np.where(component_list == i)]) for i in range(1, N_components)]
+    >>> [list(word_list[np.nonzero(component_list == i)]) for i in range(1, N_components)]
     [['aha'],    # may vary
      ['chi'],
      ['ebb'],
@@ -185,7 +185,7 @@ we'll need to remove these before finding the maximum::
 So there is at least one pair of words which takes 13 steps to get from one
 to the other!  Let's determine which these are::
 
-    >>> i1, i2 = np.where(distances == max_distance)
+    >>> i1, i2 = np.nonzero(distances == max_distance)
     >>> list(zip(word_list[i1], word_list[i2]))
     [('imp', 'ohm'),    # may vary
      ('imp', 'ohs'),

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -1433,7 +1433,7 @@ def cut_tree(Z, n_clusters=None, height=None):
         this_group[idx] = last_group[idx].min()
         this_group[this_group > last_group[idx].max()] -= 1
         if i + 1 in cols_idx:
-            groups[np.where(i + 1 == cols_idx)[0]] = this_group
+            groups[np.nonzero(i + 1 == cols_idx)[0]] = this_group
         last_group = this_group
 
     return groups.T

--- a/scipy/integrate/_ivp/common.py
+++ b/scipy/integrate/_ivp/common.py
@@ -336,7 +336,7 @@ def _dense_num_jac(fun, t, y, f, h, factor, y_scale):
 
         update = max_diff[ind] * scale_new < max_diff_new * scale[ind]
         if np.any(update):
-            update, = np.where(update)
+            update, = np.nonzero(update)
             update_ind = ind[update]
             factor[update_ind] = new_factor[update]
             h[update_ind] = h_new[update]
@@ -405,7 +405,7 @@ def _sparse_num_jac(fun, t, y, f, h, factor, y_scale, structure, groups):
 
         update = max_diff[ind] * scale_new < max_diff_new * scale[ind]
         if np.any(update):
-            update, = np.where(update)
+            update, = np.nonzero(update)
             update_ind = ind[update]
             factor[update_ind] = new_factor[update]
             h[update_ind] = h_new[update]

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -309,13 +309,13 @@ def test_gaussian_truncate():
 
     # Test gaussian_laplace
     y = sndi.gaussian_laplace(x, sigma=2, truncate=3.5)
-    nonzero_indices = np.where(y != 0)[0]
+    nonzero_indices = np.nonzero(y != 0)[0]
     n = nonzero_indices.ptp() + 1
     assert_equal(n, 15)
 
     # Test gaussian_gradient_magnitude
     y = sndi.gaussian_gradient_magnitude(x, sigma=2, truncate=3.5)
-    nonzero_indices = np.where(y != 0)[0]
+    nonzero_indices = np.nonzero(y != 0)[0]
     n = nonzero_indices.ptp() + 1
     assert_equal(n, 15)
 

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -753,7 +753,7 @@ class DifferentialEvolutionSolver(object):
         """
         make sure the parameters lie between the limits
         """
-        for index in np.where((trial < 0) | (trial > 1))[0]:
+        for index in np.nonzero((trial < 0) | (trial > 1))[0]:
             trial[index] = self.random_number_generator.rand()
 
     def _mutate(self, candidate):

--- a/scipy/optimize/_hungarian.py
+++ b/scipy/optimize/_hungarian.py
@@ -115,7 +115,7 @@ def linear_sum_assignment(cost_matrix):
         marked = state.marked.T
     else:
         marked = state.marked
-    return np.where(marked == 1)
+    return np.nonzero(marked == 1)
 
 
 class _Hungary(object):
@@ -156,7 +156,7 @@ def _step1(state):
     # Step 2: Find a zero (Z) in the resulting matrix. If there is no
     # starred zero in its row or column, star Z. Repeat for each element
     # in the matrix.
-    for i, j in zip(*np.where(state.C == 0)):
+    for i, j in zip(*np.nonzero(state.C == 0)):
         if state.col_uncovered[j] and state.row_uncovered[i]:
             state.marked[i, j] = 1
             state.col_uncovered[j] = False

--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -167,8 +167,8 @@ def _pivot_col(T, tol=1.0E-12, bland=False):
     if ma.count() == 0:
         return False, np.nan
     if bland:
-        return True, np.where(ma.mask == False)[0][0]
-    return True, np.ma.where(ma == ma.min())[0][0]
+        return True, np.nonzero(ma.mask == False)[0][0]
+    return True, np.ma.nonzero(ma == ma.min())[0][0]
 
 
 def _pivot_row(T, basis, pivcol, phase, tol=1.0E-12, bland=False):
@@ -212,7 +212,7 @@ def _pivot_row(T, basis, pivcol, phase, tol=1.0E-12, bland=False):
         return False, np.nan
     mb = np.ma.masked_where(T[:-k, pivcol] <= tol, T[:-k, -1], copy=False)
     q = mb / ma
-    min_rows = np.ma.where(q == q.min())[0]
+    min_rows = np.ma.nonzero(q == q.min())[0]
     if bland:
         return True, min_rows[np.argmin(np.take(basis, min_rows))]
     return True, min_rows[0]

--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -569,7 +569,7 @@ def _presolve(c, A_ub, b_ub, A_eq, b_eq, bounds, rr):
         A_eq = A_eq[:, i_nf]
         A_ub = A_ub[:, i_nf]
         # record of variables to be added back in
-        undo = [np.where(i_f)[0], lb[i_f]]
+        undo = [np.nonzero(i_f)[0], lb[i_f]]
         # don't remove these entries from bounds; they'll be used later.
         # but we _also_ need a version of the bounds with these removed
         lb_mod = lb[i_nf]
@@ -788,7 +788,7 @@ def _get_Abc(
 
     # unbounded below: substitute xi = -xi' (unbounded above)
     l_nolb_someub = np.logical_and(lb_none, ub_some)
-    i_nolb = np.where(l_nolb_someub)[0]
+    i_nolb = np.nonzero(l_nolb_someub)[0]
     lbs[l_nolb_someub], ubs[l_nolb_someub] = (
         -ubs[l_nolb_someub], lbs[l_nolb_someub])
     lb_none = np.equal(lbs, None)
@@ -803,7 +803,7 @@ def _get_Abc(
             A_eq[:, i_nolb] *= -1
 
     # upper bound: add inequality constraint
-    i_newub = np.where(ub_some)[0]
+    i_newub = np.nonzero(ub_some)[0]
     ub_newub = ubs[ub_some]
     n_bounds = np.count_nonzero(ub_some)
     A_ub = vstack((A_ub, zeros((n_bounds, A_ub.shape[1]))))
@@ -817,7 +817,7 @@ def _get_Abc(
 
     # unbounded: substitute xi = xi+ + xi-
     l_free = np.logical_and(lb_none, ub_none)
-    i_free = np.where(l_free)[0]
+    i_free = np.nonzero(l_free)[0]
     n_free = len(i_free)
     A1 = hstack((A1, zeros((A1.shape[0], n_free))))
     c = np.concatenate((c, np.zeros(n_free)))
@@ -830,7 +830,7 @@ def _get_Abc(
 
     # lower bound: substitute xi = xi' + lb
     # now there is a constant term in objective
-    i_shift = np.where(lb_some)[0]
+    i_shift = np.nonzero(lb_some)[0]
     lb_shift = lbs[lb_some].astype(float)
     c0 += np.sum(lb_shift * c[i_shift])
     if sparse:

--- a/scipy/optimize/_lsq/bvls.py
+++ b/scipy/optimize/_lsq/bvls.py
@@ -32,7 +32,7 @@ def bvls(A, b, x_lsq, lb, ub, tol, max_iter, verbose):
 
     free_set = on_bound == 0
     active_set = ~free_set
-    free_set, = np.where(free_set)
+    free_set, = np.nonzero(free_set)
 
     r = A.dot(x) - b
     cost = 0.5 * np.dot(r, r)

--- a/scipy/signal/_peak_finding.py
+++ b/scipy/signal/_peak_finding.py
@@ -243,7 +243,7 @@ def argrelextrema(data, comparator, axis=0, order=1, mode='clip'):
     """
     results = _boolrelextrema(data, comparator,
                               axis, order, mode)
-    return np.where(results)
+    return np.nonzero(results)
 
 
 def peak_prominences(x, peaks, wlen=None):
@@ -986,7 +986,7 @@ def _identify_ridge_lines(matr, max_distances, gap_thresh):
 
     all_max_cols = _boolrelextrema(matr, np.greater, axis=1, order=1)
     # Highest row for which there are any relative maxima
-    has_relmax = np.where(all_max_cols.any(axis=1))[0]
+    has_relmax = np.nonzero(all_max_cols.any(axis=1))[0]
     if(len(has_relmax) == 0):
         return []
     start_row = has_relmax[-1]
@@ -994,7 +994,7 @@ def _identify_ridge_lines(matr, max_distances, gap_thresh):
     # rows, cols,Gap number
     ridge_lines = [[[start_row],
                    [col],
-                   0] for col in np.where(all_max_cols[start_row])[0]]
+                   0] for col in np.nonzero(all_max_cols[start_row])[0]]
     final_lines = []
     rows = np.arange(start_row - 1, -1, -1)
     cols = np.arange(0, matr.shape[1])

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -843,8 +843,8 @@ def _cplxreal(z, tol=None):
     # Find runs of (approximately) the same real part
     same_real = np.diff(zp.real) <= tol * abs(zp[:-1])
     diffs = numpy.diff(concatenate(([0], same_real, [0])))
-    run_starts = numpy.where(diffs > 0)[0]
-    run_stops = numpy.where(diffs < 0)[0]
+    run_starts = numpy.nonzero(diffs > 0)[0]
+    run_stops = numpy.nonzero(diffs < 0)[0]
 
     # Sort each run by their imaginary parts
     for i in range(len(run_starts)):
@@ -1176,7 +1176,7 @@ def _nearest_real_complex_idx(fro, to, which):
     mask = np.isreal(fro[order])
     if which == 'complex':
         mask = ~mask
-    return order[np.where(mask)[0][0]]
+    return order[np.nonzero(mask)[0][0]]
 
 
 def zpk2sos(z, p, k, pairing='nearest'):
@@ -1417,7 +1417,7 @@ def zpk2sos(z, p, k, pairing='nearest'):
                     assert np.isreal(p2)
                 else:  # real pole, real zero
                     # pick the next "worst" pole to use
-                    idx = np.where(np.isreal(p))[0]
+                    idx = np.nonzero(np.isreal(p))[0]
                     assert len(idx) > 0
                     p2_idx = idx[np.argmin(np.abs(np.abs(p[idx]) - 1))]
                     p2 = p[p2_idx]

--- a/scipy/signal/tests/test_peak_finding.py
+++ b/scipy/signal/tests/test_peak_finding.py
@@ -634,7 +634,7 @@ class TestFindPeaks(object):
         x[peaks_true] += offset
         prominences = x[peaks_true] - x[peaks_true + 1]
         interval = (3, 9)
-        keep = np.where(
+        keep = np.nonzero(
             (interval[0] <= prominences) & (prominences <= interval[1]))
 
         peaks_calc, properties = find_peaks(x, prominence=interval)

--- a/scipy/sparse/dia.py
+++ b/scipy/sparse/dia.py
@@ -311,7 +311,7 @@ class dia_matrix(_data_matrix):
         rows, cols = self.shape
         if k <= -rows or k >= cols:
             raise ValueError("k exceeds matrix dimensions")
-        idx, = np.where(self.offsets == k)
+        idx, = np.nonzero(self.offsets == k)
         first_col, last_col = max(0, k), min(rows + k, cols)
         if idx.size == 0:
             return np.zeros(last_col - first_col, dtype=self.data.dtype)

--- a/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
@@ -91,7 +91,7 @@ def generate_matrix(N, complex=False, hermitian=False,
             if sparse:
                 i = np.random.randint(N, size=N * N // 4)
                 j = np.random.randint(N, size=N * N // 4)
-                ind = np.where(i == j)
+                ind = np.nonzero(i == j)
                 j[ind] = (j[ind] + 1) % N
                 M[i,j] = 0
                 M[j,i] = 0

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -177,7 +177,7 @@ def _chk_weights(arrays, weights=None, axis=None,
         raise ValueError("weights cannot be negative")
 
     if pos_only:
-        pos_weights = np.where(weights > 0)[0]
+        pos_weights = np.nonzero(weights > 0)[0]
         if pos_weights.size < weights.size:
             arrays = tuple(np.take(a, pos_weights, axis=axis) for a in arrays)
             weights = weights[pos_weights]

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -1144,8 +1144,8 @@ def test_ckdtree_memuse():
     FILLVAL = 99.
     mask = np.random.randint(0, z.size, np.random.randint(50) + 5)
     z_copy.flat[mask] = FILLVAL
-    igood = np.vstack(np.where(x != FILLVAL)).T
-    ibad = np.vstack(np.where(x == FILLVAL)).T
+    igood = np.vstack(np.nonzero(x != FILLVAL)).T
+    ibad = np.vstack(np.nonzero(x == FILLVAL)).T
     mem_use = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
     # burn-in
     for i in range(10):

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -314,20 +314,20 @@ class TestUtilities(object):
         finally:
             np.seterr(**olderr)
 
-        assert_(ok.all(), "%s %s" % (err_msg, np.where(~ok)))
+        assert_(ok.all(), "%s %s" % (err_msg, np.nonzero(~ok)))
 
         # Invalid simplices must be (nearly) zero volume
         q = vertices[:,:-1,:] - vertices[:,-1,None,:]
         volume = np.array([np.linalg.det(q[k,:,:])
                            for k in range(tri.nsimplex)])
         ok = np.isfinite(tri.transform[:,0,0]) | (volume < np.sqrt(eps))
-        assert_(ok.all(), "%s %s" % (err_msg, np.where(~ok)))
+        assert_(ok.all(), "%s %s" % (err_msg, np.nonzero(~ok)))
 
         # Also, find_simplex for the centroid should end up in some
         # simplex for the non-degenerate cases
         j = tri.find_simplex(centroids)
         ok = (j != -1) | np.isnan(tri.transform[:,0,0])
-        assert_(ok.all(), "%s %s" % (err_msg, np.where(~ok)))
+        assert_(ok.all(), "%s %s" % (err_msg, np.nonzero(~ok)))
 
         if unit_cube:
             # If in unit cube, no interior point should be marked out of hull
@@ -335,7 +335,7 @@ class TestUtilities(object):
             at_boundary |= (centroids >= 1 - unit_cube_tol).any(axis=1)
 
             ok = (j != -1) | at_boundary
-            assert_(ok.all(), "%s %s" % (err_msg, np.where(~ok)))
+            assert_(ok.all(), "%s %s" % (err_msg, np.nonzero(~ok)))
 
     def test_degenerate_barycentric_transforms(self):
         # The triangulation should not produce invalid barycentric
@@ -905,7 +905,7 @@ class Test_HalfspaceIntersection(object):
 
         truths = np.zeros((arr1.shape[0],), dtype=bool)
         for l1 in arr1:
-            indexes = np.where((abs(arr2 - l1) < rtol).all(axis=1))[0]
+            indexes = np.nonzero((abs(arr2 - l1) < rtol).all(axis=1))[0]
             assert_equal(indexes.shape, (1,))
             truths[indexes[0]] = True
         assert_(truths.all())

--- a/scipy/special/_testutils.py
+++ b/scipy/special/_testutils.py
@@ -294,7 +294,7 @@ class FuncData(object):
                 msg.append("Max |rdiff|: %g" % rdiff.max())
                 msg.append("Bad results (%d out of %d) for the following points (in output %d):"
                            % (np.sum(bad_j), point_count, output_num,))
-                for j in np.where(bad_j)[0]:
+                for j in np.nonzero(bad_j)[0]:
                     j = int(j)
                     fmt = lambda x: "%30s" % np.array2string(x[j], precision=18)
                     a = "  ".join(map(fmt, params))

--- a/scipy/stats/contingency.py
+++ b/scipy/stats/contingency.py
@@ -249,7 +249,7 @@ def chi2_contingency(observed, correction=True, lambda_=None):
     if np.any(expected == 0):
         # Include one of the positions where expected is zero in
         # the exception message.
-        zeropos = list(zip(*np.where(expected == 0)))[0]
+        zeropos = list(zip(*np.nonzero(expected == 0)))[0]
         raise ValueError("The internally computed table of expected "
                          "frequencies has a zero element at %s." % (zeropos,))
 

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -2628,7 +2628,7 @@ def median_test(*args, **kwds):
         # is possible that all those values equal the grand median.  If `ties`
         # is "ignore", that would result in a column of zeros in `table`.  We
         # check for that case here.
-        zero_cols = np.where((table == 0).all(axis=0))[0]
+        zero_cols = np.nonzero((table == 0).all(axis=0))[0]
         if len(zero_cols) > 0:
             msg = ("All values in sample %d are equal to the grand "
                    "median (%r), so they are ignored, resulting in an "

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3580,7 +3580,7 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate', method='auto'
     dis = _kendall_dis(x, y)  # discordant pairs
 
     obs = np.r_[True, (x[1:] != x[:-1]) | (y[1:] != y[:-1]), True]
-    cnt = np.diff(np.where(obs)[0]).astype('int64', copy=False)
+    cnt = np.diff(np.nonzero(obs)[0]).astype('int64', copy=False)
 
     ntie = (cnt * (cnt - 1) // 2).sum()  # joint ties
     xtie, x0, x1 = count_rank_tie(x)     # ties in x, stats

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -1438,8 +1438,8 @@ class TestOrthoGroup(object):
         # Test that we get both positive and negative determinants
         # Check that we have at least one and less than 10 negative dets in a sample of 10. The rest are positive by the previous test.
         # Test each dimension separately
-        assert_array_less([0]*10, [np.where(d < 0)[0].shape[0] for d in dets])
-        assert_array_less([np.where(d < 0)[0].shape[0] for d in dets], [10]*10)
+        assert_array_less([0]*10, [np.nonzero(d < 0)[0].shape[0] for d in dets])
+        assert_array_less([np.nonzero(d < 0)[0].shape[0] for d in dets], [10]*10)
 
         # Test that these are orthogonal matrices
         for xx in xs:


### PR DESCRIPTION
Rationale:

* <s>np.nonzero(c) is (negligibly) faster</s>
* np.nonzero(c) has better docs, whereas np.where(c) mixes the docs with the unrelated np.where(c, x, y)
* np.nonzero(c) support duck-types
* There should be one-- and preferably only one --obvious way to do it.
* Rearranges these into a form where `np.flatnonzero` can now obviously be substituted (in a future PR)