### PR TITLE
BUG: sparse.linalg: ensure expm casts integer inputs to float

### DIFF
--- a/scipy/sparse/linalg/matfuncs.py
+++ b/scipy/sparse/linalg/matfuncs.py
@@ -627,6 +627,11 @@ def _expm(A, use_exact_onenorm):
 
         return np.array(out)
 
+    # Ensure input is of float type, to avoid integer overflows etc.
+    if ((isinstance(A, np.ndarray) or isspmatrix(A))
+            and not np.issubdtype(A.dtype, np.inexact)):
+        A = A.astype(float)
+
     # Detect upper triangularity.
     structure = UPPER_TRIANGULAR if _is_upper_triangular(A) else None
 

--- a/scipy/sparse/linalg/tests/test_matfuncs.py
+++ b/scipy/sparse/linalg/tests/test_matfuncs.py
@@ -170,6 +170,17 @@ class TestExpM(object):
             [1, 1, 1, -3]])
         assert_allclose(expm(Q), expm(1.0 * Q))
 
+    def test_integer_matrix_2(self):
+        # Check for integer overflows
+        Q = np.array([[-500, 500, 0, 0],
+                      [0, -550, 360, 190],
+                      [0, 630, -630, 0],
+                      [0, 0, 0, 0]], dtype=np.int16)
+        assert_allclose(expm(Q), expm(1.0 * Q))
+
+        Q = csc_matrix(Q)
+        assert_allclose(expm(Q).A, expm(1.0 * Q).A)
+
     def test_triangularity_perturbation(self):
         # Experiment (1) of
         # Awad H. Al-Mohy and Nicholas J. Higham (2012)


### PR DESCRIPTION
Cast non-float inputs to float in expm, to avoid overflows etc.

Fixes gh-8981