### PR TITLE
BUG: optimize: fixed presolve for no nontrivial constraints (#8973)

### DIFF
--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -585,14 +585,17 @@ def _presolve(c, A_ub, b_ub, A_eq, b_eq, bounds, rr):
             message = ("The solution was determined in presolve as there are "
                        "no non-trivial constraints.")
         elif (np.any(np.logical_and(c < 0, ub_mod == np.inf)) or
-                np.any(np.logical_and(c > 0, lb_mod == -np.inf))):
-                # test_no_constraints()
+              np.any(np.logical_and(c > 0, lb_mod == -np.inf))):
+            # test_no_constraints()
+            # test_unbounded_no_nontrivial_constraints_1
+            # test_unbounded_no_nontrivial_constraints_2
             status = 3
-            message = ("If feasible, the problem is (trivially) unbounded "
-                       "because there are no constraints and at least one "
-                       "element of c is negative. If you wish to check "
-                       "whether the problem is infeasible, turn presolve "
-                       "off.")
+            message = ("The problem is (trivially) unbounded "
+                       "because there are no non-trivial constraints and "
+                       "a) at least one decision variable is unbounded "
+                       "above and its corresponding cost is negative, or "
+                       "b) at least one decision variable is unbounded below "
+                       "and its corresponding cost is positive. ")
         else:  # test_empty_constraint_2
             status = 0
             message = ("The solution was determined in presolve as there are "

--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -584,8 +584,8 @@ def _presolve(c, A_ub, b_ub, A_eq, b_eq, bounds, rr):
             status = 0
             message = ("The solution was determined in presolve as there are "
                        "no non-trivial constraints.")
-        elif (np.any(np.logical_and(c < 0, ub == np.inf)) or
-                np.any(np.logical_and(c > 0, lb == -np.inf))):
+        elif (np.any(np.logical_and(c < 0, ub_mod == np.inf)) or
+                np.any(np.logical_and(c > 0, lb_mod == -np.inf))):
                 # test_no_constraints()
             status = 3
             message = ("If feasible, the problem is (trivially) unbounded "
@@ -600,6 +600,11 @@ def _presolve(c, A_ub, b_ub, A_eq, b_eq, bounds, rr):
         complete = True
         x[c < 0] = ub_mod[c < 0]
         x[c > 0] = lb_mod[c > 0]
+        # where c is zero, set x to a finite bound or zero
+        x_zero_c = ub_mod[c == 0]
+        x_zero_c[np.isinf(x_zero_c)] = ub_mod[c == 0][np.isinf(x_zero_c)]
+        x_zero_c[np.isinf(x_zero_c)] = 0
+        x[c == 0] = x_zero_c
         # if this is not the last step of presolve, should convert bounds back
         # to array and return here
 

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -1001,6 +1001,17 @@ class BaseTestLinprogIP(LinprogCommonTests):
                           method=self.method)
         assert_(not res.success, "incorrectly reported success")
 
+    def test_bug_8973(self):
+        c = np.array([0, 0, 0, 1, -1])
+        A = np.array([[1, 0, 0, 0, 0], [0, 1, 0, 0, 0]])
+        b = np.array([2, -2])
+        bounds = [(None, None), (None, None), (None, None), (-1, 1), (-1, 1)]
+        res = linprog(c, A, b, None, None, bounds, method=self.method,
+                      options=self.options)
+        _assert_success(res,
+                        desired_x=[2, -2, 0, -1, 1],
+                        desired_fun=-2)
+
 
 class TestLinprogIPSpecific:
     method = "interior-point"


### PR DESCRIPTION
Fixes example bug in #8973. The example had no non-trivial constraints. In this case, presolve fixes the solution at either the upper or lower bounds, depending on whether the corresponding elements of `c` are positive or negative. Previously, the case where elements of `c` are zero fell through and the corresponding elements of the solution were left at zero, which may not be feasible. Now, where elements of `c` are zero the corresponding elements of the solution are set to the upper bound if it is finite, the lower bound if it is finite and the upper bound is not, or zero if both bounds are infinite.

@Kai-Striega would you confirm that the new test addresses the case described above? I didn't use the exact example reported in #8973 because that was too specific. But you can see why that one failed - there were provisions in presolve for c < 0 and c > 0 but not c == 0, and this patches that.