### PR TITLE
BUG: optimize/slsqp: do not exit with convergence on steps where SQP is inconsistent

### DIFF
--- a/scipy/optimize/slsqp/slsqp_optmz.f
+++ b/scipy/optimize/slsqp/slsqp_optmz.f
@@ -268,8 +268,8 @@ C        -  L1 - LINE SEARCH,  POSITIVE DEFINITE  BFGS UPDATE  -
 C                      BODY SUBROUTINE FOR SLSQP
 
       INTEGER          iw(*), i, iexact, incons, ireset, iter, itermx,
-     *                 k, j, la, line, m, meq, mode, n, n1, n2, n3,
-     *                 badlin
+     *                 k, j, la, line, m, meq, mode, n, n1, n2, n3
+      LOGICAL          badlin
 
       DOUBLE PRECISION a(la,n+1), c(la), g(n+1), l((n+1)*(n+2)/2),
      *                 mu(la), r(m+n+n+2), s(n+1), u(n+1), v(n+1), w(*),
@@ -291,7 +291,7 @@ c                      with MINEQ = M - MEQ + 2*N1  &  N1 = N+1
 
 C     The badlin flag keeps track whether the SQP problem on the current
 C     iteration was inconsistent or not.
-      badlin = 0
+      badlin = .false.
 
       IF (mode) 260, 100, 220
 
@@ -346,14 +346,14 @@ C   If it turns out that the original SQP problem is inconsistent,
 C   disallow termination with convergence on this iteration,
 C   even if the augmented problem was solved.
 
-      badlin = 0
+      badlin = .false.
       IF (mode.EQ.6) THEN
           IF (n.EQ.meq) THEN
               mode = 4
           ENDIF
       ENDIF
       IF (mode.EQ.4) THEN
-          badlin = 1
+          badlin = .true.
           DO 140 j=1,m
              IF (j.LE.meq) THEN
                  a(j,n1) = -c(j)
@@ -410,7 +410,7 @@ C   UPDATE MULTIPLIERS FOR L1-TEST
 C   CHECK CONVERGENCE
 
       mode = 0
-      IF (h1.LT.acc .AND. h2.LT.acc .AND. badlin .EQ. 0) GO TO 330
+      IF (h1.LT.acc .AND. h2.LT.acc .AND. .NOT. badlin) GO TO 330
       h1 = ZERO
       DO 180 j=1,m
          IF (j.LE.meq) THEN
@@ -482,7 +482,7 @@ C   CHECK CONVERGENCE
          h3 = h3 + MAX(-c(j),h1)
   250 CONTINUE
       IF ((ABS(f-f0).LT.acc .OR. dnrm2_(n,s,1).LT.acc) .AND. h3.LT.acc
-     *     .AND. badlin .EQ. 0)
+     *     .AND. .NOT. badlin)
      *   THEN
             mode = 0
          ELSE
@@ -494,7 +494,7 @@ C   CHECK relaxed CONVERGENCE in case of positive directional derivative
 
   255 CONTINUE
       IF ((ABS(f-f0).LT.tol .OR. dnrm2_(n,s,1).LT.tol) .AND. h3.LT.tol
-     *     .AND. badlin .EQ. 0)
+     *     .AND. .NOT. badlin)
      *   THEN
             mode = 0
          ELSE


### PR DESCRIPTION
Change SLSQP termination conditions so that successful convergence is
signaled only if a feasible solution was sound to the linearized SQP
problem on that iteration.

Otherwise, SLSQP may exit with convergence even if constraints are
grossly violated.

- [x] someone (possibly not me) should check if this causes regressions on some test problem set

Fixes gh-7618