### PR TITLE
Amending CI to accomodate 3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     docker:
       # CircleCI maintains a library of pre-built images
       # documented at https://circleci.com/docs/2.0/circleci-images/
-      - image: circleci/python:3.6.1
+      - image: circleci/python:3.7.0
 
     working_directory: ~/repo
 
@@ -21,14 +21,14 @@ jobs:
           name: install Debian dependencies
           command: |
             sudo apt-get update
-            sudo apt-get install libatlas-dev libatlas-base-dev liblapack-dev gfortran libgmp-dev libmpfr-dev libfreetype6-dev libpng-dev zlib1g-dev texlive-fonts-recommended texlive-latex-recommended texlive-latex-extra texlive-generic-extra latexmk texlive-xetex
+            sudo apt-get install libatlas-dev libatlas-base-dev liblapack-dev gfortran libgmp-dev libmpfr-dev libfreetype6-dev libpng-dev zlib1g zlib1g-dev texlive-fonts-recommended texlive-latex-recommended texlive-latex-extra texlive-generic-extra latexmk texlive-xetex
 
       - run:
           name: setup Python venv
           command: |
             python3 -m venv venv
             . venv/bin/activate
-            pip install --install-option="--no-cython-compile" Cython==0.25
+            pip install --install-option="--no-cython-compile" cython
             pip install numpy
             pip install nose mpmath argparse Pillow codecov matplotlib Sphinx==1.7.2
 
@@ -58,7 +58,7 @@ jobs:
 
   deploy:
     docker:
-      - image: circleci/python:3.6.1
+      - image: circleci/python:3.7.0
 
     working_directory: ~/repo
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,11 @@ matrix:
         - NUMPYSPEC="numpy==1.8.2"
         - USE_SDIST=1
         - OPTIMIZE=-OO
+    - python: 3.4
+      env:
+        - TESTMODE=fast
+        - COVERAGE=
+        - USE_WHEEL=1
     - os: osx
       language: generic
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ matrix:
         - COVERAGE=
         - USE_WHEEL=1
         - REFGUIDE_CHECK=1
+        - NUMPYSPEC=numpy
     - python: 3.5
       env:
         - TESTMODE=fast
@@ -51,6 +52,7 @@ matrix:
         - TESTMODE=fast
         - COVERAGE=
         - USE_WHEEL=1
+        - NUMPYSPEC=numpy
     - os: osx
       language: generic
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,18 +26,20 @@ matrix:
         - TESTMODE=fast
         - COVERAGE=
         - NUMPYSPEC="--pre --upgrade --timeout=60 -f $PRE_WHEELS numpy"
-    - python: 3.6
+    - python: 3.7
+      dist: xenial # travis-ci/travis-ci/issues/9815
+      sudo: true
       env:
         - TESTMODE=full
         - COVERAGE="--coverage --gcov"
         - NUMPYSPEC=numpy
-    - python: 3.5
+    - python: 3.6
       env:
         - TESTMODE=fast
         - COVERAGE=
         - USE_WHEEL=1
         - REFGUIDE_CHECK=1
-    - python: 3.4
+    - python: 3.5
       env:
         - TESTMODE=fast
         - COVERAGE=
@@ -50,7 +52,7 @@ matrix:
         - TESTMODE=fast
         - COVERAGE=
         - NUMPYSPEC=numpy
-        - MB_PYTHON_VERSION=3.6
+        - MB_PYTHON_VERSION=3.7
 addons:
   apt:
     packages:
@@ -130,7 +132,7 @@ before_install:
   - mkdir builds
   - cd builds
   - travis_retry pip install --upgrade pip setuptools wheel
-  - travis_retry pip install cython==0.25.2
+  - travis_retry pip install cython
   - if [ -n "$NUMPYSPEC" ]; then travis_retry pip install $NUMPYSPEC; fi
   - travis_retry pip install --upgrade pytest pytest-xdist pytest-faulthandler mpmath argparse Pillow codecov
   - travis_retry pip install gmpy2  # speeds up mpmath (scipy.special tests)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,15 +31,10 @@ environment:
       PYTHON_ARCH: 64
       TEST_MODE: fast
 
-    - PYTHON: C:\Python34-x64
+    - PYTHON: C:\Python35-x64
       PYTHON_VERSION: 3.5
       PYTHON_ARCH: 64
       TEST_MODE: fast
-
-    - PYTHON: C:\Python36-x64
-      PYTHON_VERSION: 3.6
-      PYTHON_ARCH: 64
-      TEST_MODE: full
 
     - PYTHON: C:\Python37-x64
       PYTHON_VERSION: 3.7

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,12 +32,17 @@ environment:
       TEST_MODE: fast
 
     - PYTHON: C:\Python34-x64
-      PYTHON_VERSION: 3.4
+      PYTHON_VERSION: 3.5
       PYTHON_ARCH: 64
       TEST_MODE: fast
 
     - PYTHON: C:\Python36-x64
       PYTHON_VERSION: 3.6
+      PYTHON_ARCH: 64
+      TEST_MODE: full
+
+    - PYTHON: C:\Python37-x64
+      PYTHON_VERSION: 3.7
       PYTHON_ARCH: 64
       TEST_MODE: full
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,5 +8,6 @@ filterwarnings =
     always::scipy._lib._testutils.FPUModeChangeWarning
     once:.*LAPACK bug 0038.*:RuntimeWarning
     ignore:the matrix subclass is not the recommended way*:PendingDeprecationWarning
+    ignore:Using or importing the ABCs from 'collections'*:DeprecationWarning
 env =
     PYTHONHASHSEED=0


### PR DESCRIPTION
This PR changes the CI configurations to permit testing on Python 3.7.

- Python 3.7 doesn't appear to be available on travis yet, so using 3.7-dev.
- bumped all the travis 3.x versions up by 0.1, i.e. 3.4 becomes 3.5.
- appveyor does not yet accomodate 3.7, according to documentation