### PR TITLE
ENH: Batch differential evolution

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -193,6 +193,7 @@ Shinya Suzuki for scipy.stats.brunnermunzel
 Graham Clenaghan for bug fixes and optimizations in scipy.stats.
 Konrad Griessinger for the small sample Kendall test
 Tony Xiang for improvements in scipy.sparse
+Todd Morse for batch evaluation of differential evolution objective function
 
 Institutions
 ------------

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -749,7 +749,6 @@ class DifferentialEvolutionSolver(object):
             self.scale = (self.random_number_generator.rand()
                           * (self.dither[1] - self.dither[0]) + self.dither[0])
 
-
         parameters_to_evaluate = []
         candidate_trial_solutions = []
         for candidate in range(self.num_population_members):

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -222,8 +222,8 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
 
     >>> from multiprocessing import Pool
     >>> from scipy.optimize import rosen, differential_evolution
-    >>> p = Pool(5)
     >>> def batch_rosen(arr):
+    ...     p = Pool(5)
     ...     return p.map(rosen, arr)
     >>> bounds = [(0,2), (0, 2), (0, 2), (0, 2), (0, 2)]
     >>> result = differential_evolution(None, bounds, batchfunc=batch_rosen)

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -220,10 +220,10 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
     sufficiently time consuming to evaluate to overcome the
     overhead of multiprocessing.
 
-    >>> multiprocessing import Pool
+    >>> from multiprocessing import Pool
     >>> from scipy.optimize import rosen, differential_evolution
+    >>> p = Pool(5)
     >>> def batch_rosen(arr):
-    ...     p = Pool(5)
     ...     return p.map(rosen, arr)
     >>> bounds = [(0,2), (0, 2), (0, 2), (0, 2), (0, 2)]
     >>> result = differential_evolution(None, bounds, batchfunc=batch_rosen)

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -222,8 +222,8 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
 
     >>> multiprocessing import Pool
     >>> from scipy.optimize import rosen, differential_evolution
-    >>> p = Pool(5)
     >>> def batch_rosen(arr):
+    ...     p = Pool(5)
     ...     return p.map(rosen, arr)
     >>> bounds = [(0,2), (0, 2), (0, 2), (0, 2), (0, 2)]
     >>> result = differential_evolution(None, bounds, batchfunc=batch_rosen)

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -431,14 +431,17 @@ class DifferentialEvolutionSolver(object):
         # if a batchfunc is provided and None is explicitly passed,
         # create a func from the batchfunc as is still needed for polishing
         if func is None:
-            self.func = lambda parameters, *passed_args: batchfunc([parameters], *passed_args)[0]
+            self.func = lambda parameters, *passed_args: batchfunc([parameters],
+                                                                   *passed_args)[0]
         else:
             self.func = func
 
         # if no batchfunc is provided
         # then create one that evaluates in sequence to unify implementation
         if batchfunc is None:
-            self.batchfunc = lambda parameter_array, *passed_args: [func(parameter, *passed_args) for parameter in parameter_array]
+            self.batchfunc = lambda parameter_array, *passed_args: [
+                func(parameter, *passed_args) for parameter in parameter_array
+            ]
         else:
             self.batchfunc = batchfunc
 

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -210,26 +210,6 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
     >>> result.x, result.fun
     (array([ 0.,  0.]), 4.4408920985006262e-16)
 
-    When minimizing an objective cost that is very time consuming to
-    evaluate it may be advantageous to run evaluations in parallel within
-    each generation. The ``batchfunc`` parameter allows for arbitrary
-    implementations of parallel computations of batches of function
-    evaluations. Let us consider the problem of minimizing the
-    Rosenbrock again but this time with parallel evaluation
-    using multiprocessing. Note, the objective function must be
-    sufficiently time consuming to evaluate to overcome the
-    overhead of multiprocessing.
-
-    >>> from multiprocessing import Pool
-    >>> from scipy.optimize import rosen, differential_evolution
-    >>> def batch_rosen(arr):
-    ...     p = Pool(5)
-    ...     return p.map(rosen, arr)
-    >>> bounds = [(0,2), (0, 2), (0, 2), (0, 2), (0, 2)]
-    >>> result = differential_evolution(None, bounds, batchfunc=batch_rosen)
-    >>> result.x, result.fun
-    (array([1., 1., 1., 1., 1.]), 1.9216496320061384e-19)
-
     References
     ----------
     .. [1] Storn, R and Price, K, Differential Evolution - a Simple and

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -555,7 +555,7 @@ class TestDifferentialEvolutionSolver(object):
                                              self.bounds,
                                              batchfunc=self.batch_quadradic)
 
-        param_arr = np.random.random((2, 10))
+        param_arr = np.random.random((10, 2))
         func_results = [solver.func(x) for x in param_arr]
         assert_equal(func_results, self.batch_quadradic(param_arr))
 

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -36,11 +36,14 @@ class TestDifferentialEvolutionSolver(object):
     def teardown_method(self):
         np.seterr(**self.old_seterr)
 
-    def quadratic(self, x):
-        return x[0]**2
+    def quadratic(self, x, *args):
+        a = args[0] if args else 1.
+        b = args[1] if len(args) > 1 else 1.
+        c = args[2] if len(args) > 2 else 0.
+        return (a * x**2.) + (b * x) + c
 
-    def batch_quadradic(self, arr):
-        return [x[0]**2 for x in arr]
+    def batch_quadradic(self, arr, *args):
+        return [self.quadratic(x, *args) for x in arr]
 
     def batch_rosen(self, arr):
         return [rosen(x) for x in arr]
@@ -244,14 +247,9 @@ class TestDifferentialEvolutionSolver(object):
     def test_args_tuple_is_passed(self):
         # test that the args tuple is passed to the cost function properly.
         bounds = [(-10, 10)]
-        args = (1., 2., 3.)
+        args = (3., 2., 1.)
 
-        def quadratic(x, *args):
-            if type(args) != tuple:
-                raise ValueError('args should be a tuple')
-            return args[0] + args[1] * x + args[2] * x**2.
-
-        result = differential_evolution(quadratic,
+        result = differential_evolution(self.quadratic,
                                         bounds,
                                         args=args,
                                         polish=True)
@@ -492,24 +490,18 @@ class TestDifferentialEvolutionSolver(object):
     def test_args_tuple_is_passed_with_batchfunc(self):
         # test that the args tuple is passed to a batched cost function properly.
         bounds = [(-10, 10)]
-        args = (1., 2., 3.)
-
-        def batch_quadratic(arr, *args):
-            if type(args) != tuple:
-                raise ValueError('args should be a tuple')
-            return [args[0] + args[1] * x + args[2] * x**2. for x in arr]
+        args = (3., 2., 1.)
 
         result = differential_evolution(None,
                                         bounds,
                                         args=args,
                                         polish=True,
-                                        batchfunc=batch_quadratic)
+                                        batchfunc=self.batch_quadradic)
         assert_almost_equal(result.fun, 2 / 3.)
 
     def test_maxfun_stops_solve_with_batchfunc(self):
         # this is a particularly important test for batchfunc since
         # maintaining maxfun was the biggest implementation challenge
-
 
         # test that if the maximum number of function evaluations is exceeded
         # during initialisation the still solver stops with a batchfunc
@@ -548,10 +540,49 @@ class TestDifferentialEvolutionSolver(object):
                                              self.bounds,
                                              popsize=3,
                                              batchfunc=self.batch_rosen)
-                                             
+
         solver._calculate_population_energies()
 
         assert_equal(np.argmin(solver.population_energies), 0)
 
         # initial calculation of the energies should require 6 nfev.
         assert_equal(solver._nfev, 6)
+
+    def test_create_func_from_batchfunc(self):
+        # test generating an objective function given a
+        # batch objective function
+        solver = DifferentialEvolutionSolver(None,
+                                             self.bounds,
+                                             batchfunc=self.batch_quadradic)
+
+        param_arr = np.random.random((2, 10))
+        func_results = [solver.func(x) for x in param_arr]
+        assert_equal(func_results, self.batch_quadradic(param_arr))
+
+        # same test with additional args
+        solver = DifferentialEvolutionSolver(None,
+                                             self.bounds,
+                                             batchfunc=self.batch_quadradic,
+                                             args=(1))
+
+        param_arr = np.random.random((10, 2))
+        func_results = [solver.func(x, 1) for x in param_arr]
+        assert_equal(func_results, self.batch_quadradic(param_arr, 1))
+
+    def test_create_batchfunc_from_func(self):
+        # test generating a sequential batch objective function
+        # given an objective function
+        solver = DifferentialEvolutionSolver(self.quadratic,
+                                             self.bounds)
+
+        param_arr = np.random.random((2, 10))
+        func_results = [self.quadratic(x) for x in param_arr]
+        assert_equal(func_results, solver.batchfunc(param_arr))
+
+        # same test with additional args
+        solver = DifferentialEvolutionSolver(self.quadratic,
+                                             self.bounds)
+
+        param_arr = np.random.random((10, 2))
+        func_results = [self.quadratic(x, 1) for x in param_arr]
+        assert_equal(func_results, solver.batchfunc(param_arr, 1))


### PR DESCRIPTION
First time contributor so I apologize if this is a bit rough. More than willing to make changes as needed. Thanks for reading!

### Motivation
I was using differential evolution to optimize an objective function that is quite time consuming to evaluate. Unfortunately I couldn't scale up performance with more CPUs because the implementation evaluates the objective function in sequence. Computing the energies for a generation in differential evolution is extremely easy to make parallel so I thought I would add the functionality. 

### API Design
I decided to add an optional `batchfunc` parameter. This parameter takes in an array of parameters and provides an array of energies as a solution. This has a few advantages:

- Leave decisions about parallelism in the hands of the implementer
- Preserve the api
- Unify the implementation of batch and sequence

Some trade offs of doing it this way are:

- Somewhat confusing API since you can technically pass `None` in to the `func` parameter. I don't think this is a huge deal since it needs to be done explicitly so the user would need to really know what they are doing here.
- Repeated work for the implementer needing to implement their own parallelism every time

### Approach

The hardest part of this implementation was retaining the `maxfun` functionality. If we evaluate the entire generation in parallel we may over-evaluate. The way I solved this is by building up an array of which parameters to batch evaluate, preserving the logic of the existing loops, then doing the evaluation in a batch, then going through the rest of the logic in a second loop through the computed energies. This preserves what is already there as much as possible but might be a bit less intuitive than an approach without considering the `maxfun` functionality.

I also decided to do everything in terms of batch functionality. If no `batchfunc` is provided we create one that just does everything in sequence. This allows us to keep a unified implementation of the actual iterations. We still need `func` for polishing, but we can also construct a `func` from a `batchfunc` so we only need one or the other.

### Test Plan

Since the entire implementation uses `batchfunc` the existing tests take us a lot of the way towards coverage. The key piece of the testing is to test the conversion between `func` and `batchfunc`. I tested this conversion in both directions. To write tests of solving with a `batchfunc` I just picked a simple test to test the `batchfunc` conversion functionality, and tried to test a few `batchfunc` pain points like stopping at `maxfun` and passing `args`.

### Usage example

```Python
>>> from multiprocessing import Pool
>>> from scipy.optimize import rosen, differential_evolution
>>> p = Pool(5)
>>> def batch_rosen(arr):
...     return p.map(rosen, arr)
>>> bounds = [(0,2), (0, 2), (0, 2), (0, 2), (0, 2)]
>>> result = differential_evolution(None, bounds, batchfunc=batch_rosen)
>>> result.x, result.fun
(array([1., 1., 1., 1., 1.]), 1.9216496320061384e-19)
```