### PR TITLE
BUG: differential_evolution with inf objective functions

### DIFF
--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -551,6 +551,8 @@ class DifferentialEvolutionSolver(object):
         The standard deviation of the population energies divided by their
         mean.
         """
+        if np.any(np.isinf(self.population_energies)):
+            return np.inf
         return (np.std(self.population_energies) /
                 np.abs(np.mean(self.population_energies) + _MACHEPS))
 
@@ -607,9 +609,12 @@ class DifferentialEvolutionSolver(object):
                                   'by returning True')
                 break
 
-            intol = (np.std(self.population_energies) <=
-                     self.atol +
-                     self.tol * np.abs(np.mean(self.population_energies)))
+            if np.any(np.isinf(self.population_energies)):
+                intol = False
+            else:
+                intol = (np.std(self.population_energies) <=
+                         self.atol +
+                         self.tol * np.abs(np.mean(self.population_energies)))
             if warning_flag or intol:
                 break
 

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -475,3 +475,14 @@ class TestDifferentialEvolutionSolver(object):
                       DifferentialEvolutionSolver,
                       *(rosen, self.bounds),
                       **{'init': population})
+    def test_infinite_objective_function(self):
+        # Test that there are no problems if the objective function
+        # returns inf on some runs
+        def sometimes_inf(x):
+            if x[0] < .5:
+                return np.inf
+            return x[1]
+        bounds = [(0, 1), (0, 1)]
+        x_fit = differential_evolution(sometimes_inf,
+                                       bounds=[(0, 1), (0, 1)],
+                                       disp=False)

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -475,6 +475,7 @@ class TestDifferentialEvolutionSolver(object):
                       DifferentialEvolutionSolver,
                       *(rosen, self.bounds),
                       **{'init': population})
+
     def test_infinite_objective_function(self):
         # Test that there are no problems if the objective function
         # returns inf on some runs


### PR DESCRIPTION
Differential evolution fails after step 1 with objective functions that have at some point returned inf. It throws a "FloatingPointError: invalid value encountered in subtract" when np.seterr(all="throw"), and a warning otherwise.  This is a regression, which worked as expected in 0.15 but stopped working at some point since.