### PR TITLE
BUG: fixed #8446 corner case for asformat(array|dense)

### DIFF
--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -297,20 +297,19 @@ class spmatrix(object):
                         " or shape[0]")
 
     def asformat(self, format, copy=False):
-        """Return this matrix in the passed sparse format.
+        """Return this matrix in the passed format.
 
         Parameters
         ----------
         format : {str, None}
-            The desired sparse matrix format ("csr", "csc", "lil", "dok", ...)
+            The desired matrix format ("csr", "csc", "lil", "dok", "array", ...)
             or None for no conversion.
         copy : bool, optional
             If True, the result is guaranteed to not share data with self.
 
         Returns
         -------
-        A : This matrix in the passed sparse format.
-
+        A : This matrix in the passed format.
         """
         if format is None or format == self.format:
             if copy:
@@ -322,10 +321,12 @@ class spmatrix(object):
                 convert_method = getattr(self, 'to' + format)
             except AttributeError:
                 raise ValueError('Format {} is unknown.'.format(format))
-            else:
-                if format in ['array', 'dense']:
-                    return convert_method()
+
+            # Forward the copy kwarg, if it's accepted.
+            try:
                 return convert_method(copy=copy)
+            except TypeError:
+                return convert_method()
 
     ###################################################################
     #  NOTE: All arithmetic operations use csr_matrix by default.

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -323,6 +323,8 @@ class spmatrix(object):
             except AttributeError:
                 raise ValueError('Format {} is unknown.'.format(format))
             else:
+                if format in ['array', 'dense']:
+                    return convert_method()
                 return convert_method(copy=copy)
 
     ###################################################################

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1701,6 +1701,13 @@ class _TestCommon(object):
             assert_equal(c.format,format)
             assert_array_equal(c.todense(), D)
 
+        for format in ['array', 'dense']:
+            a = A.asformat(format)
+            assert_array_equal(a, D)
+
+            b = self.spmatrix(D+3j).asformat(format)
+            assert_array_equal(b, D+3j)
+
     def test_tobsr(self):
         x = array([[1,0,2,0],[0,0,0,0],[0,0,4,5]])
         y = array([[0,1,2],[3,0,5]])


### PR DESCRIPTION
The PR in #8446 makes a matrix conversion from sparse matrix
to dense arrays using the `asformat` fail because a non-existing
keyword is passed, copy is implicit in the toarray|todense.
Hence they must not be present.
This solution is removing the copy keyword for array|dense conversions.

This commit also adds new tests for these cornercases.