### PR TITLE
MAINT: code cleanup in optimize/linesearch

### DIFF
--- a/scipy/optimize/linesearch.py
+++ b/scipy/optimize/linesearch.py
@@ -480,8 +480,11 @@ def _cubicmin(a, fa, fpa, b, fb, c, fc):
             db = b - a
             dc = c - a
             denom = (db * dc) ** 2 * (db - dc)
-            [A, B] = np.dot(np.array([[dc ** 2,-db ** 2], [-dc ** 3, db ** 3]], dtype=np.float64), 
-                            np.asarray([fb - fa - C * db,fc - fa - C * dc]))
+            [A, B] = np.dot(
+                             np.array([[dc ** 2, -db ** 2], 
+                                       [-dc ** 3, db ** 3]], dtype=np.float64), 
+                             np.array([fb - fa - C * db, fc - fa - C * dc], dtype=np.float64)
+                           )
             A /= denom
             B /= denom
             radical = B * B - 3 * A * C
@@ -491,7 +494,6 @@ def _cubicmin(a, fa, fpa, b, fb, c, fc):
     if not np.isfinite(xmin):
         return None
     return xmin
-
 
 def _quadmin(a, fa, fpa, b, fb):
     """
@@ -598,7 +600,7 @@ def _zoom(a_lo, a_hi, phi_lo, phi_hi, derphi_lo,
 # Armijo line and scalar searches
 #------------------------------------------------------------------------------
 
-def line_search_armijo(f, xk, pk, gfk, old_fval, args=(), c1=1e-4, alpha0=1):
+def line_search_armijo(f, xk, pk, gfk, old_fval=None, args=(), c1=1e-4, alpha0=1):
     """Minimize over alpha, the function ``f(xk+alpha pk)``.
 
     Parameters
@@ -650,7 +652,7 @@ def line_search_armijo(f, xk, pk, gfk, old_fval, args=(), c1=1e-4, alpha0=1):
     return alpha, fc[0], phi1
 
 
-def line_search_BFGS(f, xk, pk, gfk, old_fval, args=(), c1=1e-4, alpha0=1):
+def line_search_BFGS(f, xk, pk, gfk, old_fval=None, args=(), c1=1e-4, alpha0=1):
     """
     Compatibility wrapper for `line_search_armijo`
     """
@@ -679,7 +681,7 @@ def scalar_search_armijo(phi, phi0, derphi0, c1=1e-4, alpha0=1, amin=0):
 
     # Otherwise compute the minimizer of a quadratic interpolant:
 
-    alpha1 = quadmin(0, phi0, derphi0, alpha0, phi_a0)
+    alpha1 = _quadmin(0, phi0, derphi0, alpha0, phi_a0)
     phi_a1 = phi(alpha1)
 
     if (phi_a1 <= phi0 + c1*alpha1*derphi0):
@@ -691,7 +693,7 @@ def scalar_search_armijo(phi, phi0, derphi0, c1=1e-4, alpha0=1, amin=0):
     # condition.
 
     while alpha1 > amin:       # we are assuming alpha>0 is a descent direction
-        alpha2 = cubicmin(0, phi0, derphi0, alpha0, phi_a0, alpha1, phi_a1)
+        alpha2 = _cubicmin(0, phi0, derphi0, alpha0, phi_a0, alpha1, phi_a1)
         phi_a2 = phi(alpha2)
 
         if (phi_a2 <= phi0 + c1*alpha2*derphi0):

--- a/scipy/optimize/linesearch.py
+++ b/scipy/optimize/linesearch.py
@@ -480,13 +480,8 @@ def _cubicmin(a, fa, fpa, b, fb, c, fc):
             db = b - a
             dc = c - a
             denom = (db * dc) ** 2 * (db - dc)
-            d1 = np.empty((2, 2))
-            d1[0, 0] = dc ** 2
-            d1[0, 1] = -db ** 2
-            d1[1, 0] = -dc ** 3
-            d1[1, 1] = db ** 3
-            [A, B] = np.dot(d1, np.asarray([fb - fa - C * db,
-                                            fc - fa - C * dc]).flatten())
+            [A, B] = np.dot(np.array([[dc ** 2,-db ** 2], [-dc ** 3, db ** 3]], dtype=np.float64), 
+                            np.asarray([fb - fa - C * db,fc - fa - C * dc]))
             A /= denom
             B /= denom
             radical = B * B - 3 * A * C
@@ -509,7 +504,7 @@ def _quadmin(a, fa, fpa, b, fb):
         try:
             D = fa
             C = fpa
-            db = b - a * 1.0
+            db = b - a
             B = (fb - D - C * db) / (db * db)
             xmin = a - C / (2.0 * B)
         except ArithmeticError:

--- a/scipy/optimize/linesearch.py
+++ b/scipy/optimize/linesearch.py
@@ -686,12 +686,12 @@ def scalar_search_armijo(phi, phi0, derphi0, c1=1e-4, alpha0=1, amin=0):
     alpha1 = _quadmin(0, phi0, derphi0, alpha0, phi_a0)
    
     if alpha1 is None:
-         alpha1 = alpha0 / 2.0
+        alpha1 = alpha0 / 2.0
     
     phi_a1 = phi(alpha1)
    
     if (phi_a1 <= phi0 + c1*alpha1*derphi0):
-      return alpha1, phi_a1
+        return alpha1, phi_a1
     
     # Otherwise loop with cubic interpolation until we find an alpha which
     # satisfies the Armijo condition
@@ -700,7 +700,7 @@ def scalar_search_armijo(phi, phi0, derphi0, c1=1e-4, alpha0=1, amin=0):
         alpha2 = _cubicmin(0, phi0, derphi0, alpha0, phi_a0, alpha1, phi_a1)
         
         if alpha2 is None:
-         alpha2 = alpha1 / 2.0
+            alpha2 = alpha1 / 2.0
         
         phi_a2 = phi(alpha2)
 

--- a/scipy/optimize/linesearch.py
+++ b/scipy/optimize/linesearch.py
@@ -691,7 +691,7 @@ def scalar_search_armijo(phi, phi0, derphi0, c1=1e-4, alpha0=1, amin=0):
     phi_a1 = phi(alpha1)
    
     if (phi_a1 <= phi0 + c1*alpha1*derphi0):
-         return alpha1, phi_a1
+      return alpha1, phi_a1
     
     # Otherwise loop with cubic interpolation until we find an alpha which
     # satisfies the Armijo condition
@@ -700,7 +700,7 @@ def scalar_search_armijo(phi, phi0, derphi0, c1=1e-4, alpha0=1, amin=0):
         alpha2 = _cubicmin(0, phi0, derphi0, alpha0, phi_a0, alpha1, phi_a1)
         
         if alpha2 is None:
-            alpha2 = alpha1 / 2.0
+         alpha2 = alpha1 / 2.0
         
         phi_a2 = phi(alpha2)
 

--- a/scipy/optimize/linesearch.py
+++ b/scipy/optimize/linesearch.py
@@ -480,11 +480,13 @@ def _cubicmin(a, fa, fpa, b, fb, c, fc):
             db = b - a
             dc = c - a
             denom = (db * dc) ** 2 * (db - dc)
-            [A, B] = np.dot(
-                             np.array([[dc ** 2, -db ** 2], 
-                                       [-dc ** 3, db ** 3]], dtype=np.float64), 
-                             np.array([fb - fa - C * db, fc - fa - C * dc], dtype=np.float64)
-                           )
+            d1 = np.empty((2, 2))
+            d1[0, 0] = dc ** 2
+            d1[0, 1] = -db ** 2
+            d1[1, 0] = -dc ** 3
+            d1[1, 1] = db ** 3
+            [A, B] = np.dot(d1, np.asarray([fb - fa - C * db,
+                                            fc - fa - C * dc]).flatten())
             A /= denom
             B /= denom
             radical = B * B - 3 * A * C

--- a/scipy/optimize/linesearch.py
+++ b/scipy/optimize/linesearch.py
@@ -684,7 +684,7 @@ def scalar_search_armijo(phi, phi0, derphi0, c1=1e-4, alpha0=1, amin=0):
 
     # Otherwise compute the minimizer of a quadratic interpolant:
 
-    alpha1 = -(derphi0) * alpha0**2 / 2.0 / (phi_a0 - phi0 - derphi0 * alpha0)
+    alpha1 = quadmin(0, phi0, derphi0, alpha0, phi_a0)
     phi_a1 = phi(alpha1)
 
     if (phi_a1 <= phi0 + c1*alpha1*derphi0):
@@ -696,15 +696,7 @@ def scalar_search_armijo(phi, phi0, derphi0, c1=1e-4, alpha0=1, amin=0):
     # condition.
 
     while alpha1 > amin:       # we are assuming alpha>0 is a descent direction
-        factor = alpha0**2 * alpha1**2 * (alpha1-alpha0)
-        a = alpha0**2 * (phi_a1 - phi0 - derphi0*alpha1) - \
-            alpha1**2 * (phi_a0 - phi0 - derphi0*alpha0)
-        a = a / factor
-        b = -alpha0**3 * (phi_a1 - phi0 - derphi0*alpha1) + \
-            alpha1**3 * (phi_a0 - phi0 - derphi0*alpha0)
-        b = b / factor
-
-        alpha2 = (-b + np.sqrt(abs(b**2 - 3 * a * derphi0))) / (3.0*a)
+        alpha2 = cubicmin(0, phi0, derphi0, alpha0, phi_a0, alpha1, phi_a1)
         phi_a2 = phi(alpha2)
 
         if (phi_a2 <= phi0 + c1*alpha2*derphi0):

--- a/scipy/optimize/linesearch.py
+++ b/scipy/optimize/linesearch.py
@@ -684,18 +684,24 @@ def scalar_search_armijo(phi, phi0, derphi0, c1=1e-4, alpha0=1, amin=0):
     # Otherwise compute the minimizer of a quadratic interpolant:
 
     alpha1 = _quadmin(0, phi0, derphi0, alpha0, phi_a0)
+   
+    if alpha1 is None:
+         alpha1 = alpha0 / 2.0
+    
     phi_a1 = phi(alpha1)
-
+   
     if (phi_a1 <= phi0 + c1*alpha1*derphi0):
-        return alpha1, phi_a1
-
+         return alpha1, phi_a1
+    
     # Otherwise loop with cubic interpolation until we find an alpha which
-    # satisfies the first Wolfe condition (since we are backtracking, we will
-    # assume that the value of alpha is not too small and satisfies the second
-    # condition.
+    # satisfies the Armijo condition
 
     while alpha1 > amin:       # we are assuming alpha>0 is a descent direction
         alpha2 = _cubicmin(0, phi0, derphi0, alpha0, phi_a0, alpha1, phi_a1)
+        
+        if alpha2 is None:
+            alpha2 = alpha1 / 2.0
+        
         phi_a2 = phi(alpha2)
 
         if (phi_a2 <= phi0 + c1*alpha2*derphi0):


### PR DESCRIPTION
simplify codes and reuse the functions, like `_quadmin` and `_cubicmin`