### PR TITLE
ENH: add rejection direction for wilcoxon

### DIFF
--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -2328,7 +2328,7 @@ def mood(x, y, axis=0):
     return z, pval
 
 
-WilcoxonResult = namedtuple('WilcoxonResult', ('statistic', 'pvalue'))
+WilcoxonResult = namedtuple('WilcoxonResult', ('statistic', 'pvalue', 'rejection_direction'))
 
 
 def wilcoxon(x, y=None, zero_method="wilcox", correction=False):
@@ -2369,6 +2369,8 @@ def wilcoxon(x, y=None, zero_method="wilcox", correction=False):
         is smaller.
     pvalue : float
         The two-sided p-value for the test.
+    rejection_direction : string
+        The difference (or rejection) direction of x-y in case of a one-sided test.
 
     Notes
     -----
@@ -2411,7 +2413,9 @@ def wilcoxon(x, y=None, zero_method="wilcox", correction=False):
         r_plus += r_zero / 2.
         r_minus += r_zero / 2.
 
-    T = min(r_plus, r_minus)
+    rs = [r_plus, r_minus]
+    T = min(rs)
+    rejection_direction = "-" if np.argmin([rs]) == 0 else "+"
     mn = count * (count + 1.) * 0.25
     se = count * (count + 1.) * (2. * count + 1.)
 
@@ -2428,7 +2432,7 @@ def wilcoxon(x, y=None, zero_method="wilcox", correction=False):
     z = (T - mn - correction) / se
     prob = 2. * distributions.norm.sf(abs(z))
 
-    return WilcoxonResult(T, prob)
+    return WilcoxonResult(T, prob, rejection_direction)
 
 
 def median_test(*args, **kwds):

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1344,7 +1344,7 @@ def test_wilcoxon_result_attributes():
     x = np.array([120, 114, 181, 188, 180, 146, 121, 191, 132, 113, 127, 112])
     y = np.array([133, 143, 119, 189, 112, 199, 198, 113, 115, 121, 142, 187])
     res = stats.wilcoxon(x, y, correction=False)
-    attributes = ('statistic', 'pvalue')
+    attributes = ('statistic', 'pvalue', 'rejection_direction')
     check_named_results(res, attributes)
 
 
@@ -1367,6 +1367,17 @@ def test_wilcoxon_tie():
     assert_equal(stat, 0)
     assert_allclose(p, expected_p, rtol=1e-6)
 
+def test_wilcoxon_rejection_direction_x_less():
+    x = np.array([110, 115, 110, 111, 112, 113, 114])
+    y = x + 200
+    res = stats.wilcoxon(x, y, correction=False)
+    assert(res.rejection_direction == "-")
+
+def test_wilcoxon_rejection_direction_y_less():
+    x = np.array([110, 115, 110, 111, 112, 113, 114])
+    y = x - 200
+    res = stats.wilcoxon(x, y, correction=False)
+    assert(res.rejection_direction == "+")
 
 class TestMedianTest(object):
 

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1316,15 +1316,15 @@ def test_accuracy_wilcoxon():
     x = np.concatenate([[u] * v for u, v in zip(nums, freq)])
     y = np.zeros(x.size)
 
-    T, p = stats.wilcoxon(x, y, "pratt")
+    T, p, _ = stats.wilcoxon(x, y, "pratt")
     assert_allclose(T, 423)
     assert_allclose(p, 0.00197547303533107)
 
-    T, p = stats.wilcoxon(x, y, "zsplit")
+    T, p, _ = stats.wilcoxon(x, y, "zsplit")
     assert_allclose(T, 441)
     assert_allclose(p, 0.0032145343172473055)
 
-    T, p = stats.wilcoxon(x, y, "wilcox")
+    T, p, _ = stats.wilcoxon(x, y, "wilcox")
     assert_allclose(T, 327)
     assert_allclose(p, 0.00641346115861)
 
@@ -1332,10 +1332,10 @@ def test_accuracy_wilcoxon():
     # > wilcox.test(x, y, paired=TRUE, exact=FALSE, correct={FALSE,TRUE})
     x = np.array([120, 114, 181, 188, 180, 146, 121, 191, 132, 113, 127, 112])
     y = np.array([133, 143, 119, 189, 112, 199, 198, 113, 115, 121, 142, 187])
-    T, p = stats.wilcoxon(x, y, correction=False)
+    T, p, _ = stats.wilcoxon(x, y, correction=False)
     assert_equal(T, 34)
     assert_allclose(p, 0.6948866, rtol=1e-6)
-    T, p = stats.wilcoxon(x, y, correction=True)
+    T, p, _ = stats.wilcoxon(x, y, correction=True)
     assert_equal(T, 34)
     assert_allclose(p, 0.7240817, rtol=1e-6)
 
@@ -1362,20 +1362,20 @@ def test_wilcoxon_tie():
     assert_equal(stat, 0)
     assert_allclose(p, expected_p, rtol=1e-6)
 
-    stat, p = stats.wilcoxon([0.1] * 10, correction=True)
+    stat, p, _ = stats.wilcoxon([0.1] * 10, correction=True)
     expected_p = 0.001904195
     assert_equal(stat, 0)
     assert_allclose(p, expected_p, rtol=1e-6)
 
 def test_wilcoxon_rejection_direction_x_less():
-    x = np.array([110, 115, 110, 111, 112, 113, 114])
-    y = x + 200
+    x = np.array([120, 114, 181, 188, 180, 146, 121, 191, 132, 113, 127, 112])
+    y = x + 400
     res = stats.wilcoxon(x, y, correction=False)
     assert(res.rejection_direction == "-")
 
 def test_wilcoxon_rejection_direction_y_less():
-    x = np.array([110, 115, 110, 111, 112, 113, 114])
-    y = x - 200
+    x = np.array([120, 114, 181, 188, 180, 146, 121, 191, 132, 113, 127, 112])
+    y = x - 400
     res = stats.wilcoxon(x, y, correction=False)
     assert(res.rejection_direction == "+")
 


### PR DESCRIPTION
This PR is aiming to fix this issue [#9046](https://github.com/scipy/scipy/issues/9046): introduce a rejection direction which is helpful for the one-sided test.