### PR TITLE
ENH: scipy.sparse.random

### DIFF
--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -785,10 +785,11 @@ greater than %d - this is not supported on this machine
             selected.add(j)
             ind[i] = j
 
-    j = np.floor(ind * 1. / m).astype(tp)
-    i = (ind - j * m).astype(tp)
-    vals = data_rvs(k).astype(dtype)
-    return coo_matrix((vals, (i, j)), shape=(m, n)).asformat(format)
+    j = np.floor(ind * 1. / m).astype(tp, copy=False)
+    i = (ind - j * m).astype(tp, copy=False)
+    vals = data_rvs(k).astype(dtype, copy=False)
+    return coo_matrix((vals, (i, j)), shape=(m, n)).asformat(format,
+                                                             copy=False)
 
 
 def rand(m, n, density=0.01, format="coo", dtype=None, random_state=None):

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -773,7 +773,7 @@ greater than %d - this is not supported on this machine
         data_rvs = random_state.rand
 
     # Use the algorithm from python's random.sample for k < mn/3.
-    if mn < 3*k:
+    if mn < 3 * k:
         ind = random_state.choice(mn, size=k, replace=False)
     else:
         ind = np.empty(k, dtype=tp)

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -423,11 +423,12 @@ class TestConstructUtils(object):
     def test_random_sampling(self):
         # Simple sanity checks for sparse random sampling.
         for f in sprand, _sprandn:
-            for t in [np.float32, np.float64, np.longdouble]:
+            for t in [np.float32, np.float64, np.longdouble,
+                      np.int32, np.int64, np.complex64, np.complex128]:
                 x = f(5, 10, density=0.1, dtype=t)
                 assert_equal(x.dtype, t)
                 assert_equal(x.shape, (5, 10))
-                assert_equal(x.nonzero()[0].size, 5)
+                assert_equal(x.nnz, 5)
 
             x1 = f(5, 10, density=0.1, random_state=4321)
             assert_equal(x1.dtype, np.double)

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -432,7 +432,8 @@ class TestConstructUtils(object):
             x1 = f(5, 10, density=0.1, random_state=4321)
             assert_equal(x1.dtype, np.double)
 
-            x2 = f(5, 10, density=0.1, random_state=np.random.RandomState(4321))
+            x2 = f(5, 10, density=0.1,
+                   random_state=np.random.RandomState(4321))
 
             assert_array_equal(x1.data, x2.data)
             assert_array_equal(x1.row, x2.row)


### PR DESCRIPTION
Support for integer and complex values is added to `scipy.sparse.random`. Furthermore the function is faster now because unnecessary copies are avoided.