### PR TITLE
MAINT: spatial: Explicitly initialize LAPACK output parameters.

### DIFF
--- a/scipy/spatial/qhull.pyx
+++ b/scipy/spatial/qhull.pyx
@@ -1071,13 +1071,15 @@ def _get_barycentric_transforms(np.ndarray[np.double_t, ndim=2] points,
     cdef np.ndarray[np.double_t, ndim=2] T
     cdef np.ndarray[np.double_t, ndim=3] Tinvs
     cdef int isimplex
-    cdef int i, j, n, nrhs, lda, ldb, info
+    cdef int i, j, n, nrhs, lda, ldb
+    cdef int info = 0
     cdef int ipiv[NPY_MAXDIMS+1]
     cdef int ndim, nsimplex
     cdef double centroid[NPY_MAXDIMS]
     cdef double c[NPY_MAXDIMS+1]
     cdef double *transform
-    cdef double anorm, rcond
+    cdef double anorm
+    cdef double rcond = 0.0
     cdef double rcond_limit
 
     cdef double work[4*NPY_MAXDIMS]


### PR DESCRIPTION
Prior to this PR, the `info` and `rcond` parameters were not initialized in the .pyx file (and so not in the generated C code).  The SciPy code relied on the invoked LAPACK routines to initialize these parameters.

However, it is not guaranteed that the LAPACK routines will perform the initialization.  For example, [dgecon](http://www.netlib.org/lapack/explore-html/dd/d9a/group__double_g_ecomputational_ga188b8d30443d14b1a3f7f8331d87ae60.html) may return before initializing `rcond`; the [Clang MemorySanitizer](https://clang.llvm.org/docs/MemorySanitizer.html) flags the subsequent use of this variable (line 1124) as `use-of-uninitialized-value`.  Fortunately, in this case there is no bug in behavior, because the LAPACK routine only fails to initialize `rcond` if it sets `info` to a nonzero value.  The end result is that `_get_barycentric_transforms` is guaranteed to return a matrix of NaNs in that case, even though the truth value of the if-statement condition is undefined.  Still, comparisons involving undefined values make the code needlessly fragile.