### PR TITLE
DOC add sections to overview in scipy.stats

### DIFF
--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -160,11 +160,12 @@ Discrete distributions
    skellam           -- Skellam
    zipf              -- Zipf
 
-Statistical functions
-=====================
+In the sequel, an overview of statistical functions is given.
+Several of these functions have a similar version in
+scipy.stats.mstats which work for masked arrays.
 
-Several of these functions have a similar version in scipy.stats.mstats
-which work for masked arrays.
+Summary statistics
+==================
 
 .. autosummary::
    :toctree: generated/
@@ -173,12 +174,9 @@ which work for masked arrays.
    gmean             -- Geometric mean
    hmean             -- Harmonic mean
    kurtosis          -- Fisher or Pearson kurtosis
-   kurtosistest      --
    mode              -- Modal value
    moment            -- Central moment
-   normaltest        --
    skew              -- Skewness
-   skewtest          --
    kstat             --
    kstatvar          --
    tmean             -- Truncated arithmetic mean
@@ -190,6 +188,14 @@ which work for masked arrays.
    variation         -- Coefficient of variation
    find_repeats
    trim_mean
+   iqr
+   sem
+   bayes_mvs
+   mvsdist
+   entropy
+
+Frequency statistics
+====================
 
 .. autosummary::
    :toctree: generated/
@@ -207,23 +213,8 @@ which work for masked arrays.
    binned_statistic_2d  -- Compute a 2-D binned statistic for a set of data.
    binned_statistic_dd  -- Compute a d-D binned statistic for a set of data.
 
-.. autosummary::
-   :toctree: generated/
-
-   obrientransform
-   bayes_mvs
-   mvsdist
-   sem
-   zmap
-   zscore
-   iqr
-
-.. autosummary::
-   :toctree: generated/
-
-   sigmaclip
-   trimboth
-   trim1
+Correlation functions
+=====================
 
 .. autosummary::
    :toctree: generated/
@@ -236,6 +227,9 @@ which work for masked arrays.
    weightedtau
    linregress
    theilslopes
+
+Statistical tests
+=================
 
 .. autosummary::
    :toctree: generated/
@@ -271,7 +265,13 @@ which work for masked arrays.
    binom_test
    fligner
    median_test
-   mood
+   mood   
+   skewtest
+   kurtosistest
+   normaltest
+
+Transformations
+===============
 
 .. autosummary::
    :toctree: generated/
@@ -279,8 +279,15 @@ which work for masked arrays.
    boxcox
    boxcox_normmax
    boxcox_llf
+   obrientransform
+   sigmaclip
+   trimboth
+   trim1   
+   zmap
+   zscore
 
-   entropy
+Statistical distances
+=====================
 
 .. autosummary::
    :toctree: generated/

--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -160,9 +160,9 @@ Discrete distributions
    skellam           -- Skellam
    zipf              -- Zipf
 
-In the sequel, an overview of statistical functions is given.
+An overview of statistical functions is given below.
 Several of these functions have a similar version in
-scipy.stats.mstats which work for masked arrays.
+`scipy.stats.mstats` which work for masked arrays.
 
 Summary statistics
 ==================
@@ -265,7 +265,7 @@ Statistical tests
    binom_test
    fligner
    median_test
-   mood   
+   mood
    skewtest
    kurtosistest
    normaltest
@@ -282,7 +282,7 @@ Transformations
    obrientransform
    sigmaclip
    trimboth
-   trim1   
+   trim1
    zmap
    zscore
 


### PR DESCRIPTION
The overview of the module `scipy.stats` is hard to read in my view: https://docs.scipy.org/doc/scipy/reference/stats.html. 

I tried to group the functions to give a better overview. This is an initial proposal, probably there are a lot of other ways to structure it, feedback welcome.