### PR TITLE
Travis CI: Add Python 3.7 to the testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,13 @@ matrix:
         - TESTMODE=fast
         - COVERAGE=
         - NUMPYSPEC="--pre --upgrade --timeout=60 -f $PRE_WHEELS numpy"
+    - python: 3.7
+      env:
+        - TESTMODE=full
+        - COVERAGE="--coverage --gcov"
+        - NUMPYSPEC=numpy
+      dist: xenial  # Required for Python 3.7
+      sudo: true    # travis-ci/travis-ci#9069
     - python: 3.6
       env:
         - TESTMODE=full

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,6 +21,11 @@ environment:
       TEST_TIMEOUT: 1000
 
   matrix:
+    - PYTHON: C:\Python37
+      PYTHON_VERSION: 3.7
+      PYTHON_ARCH: 32
+      TEST_MODE: fast
+
     - PYTHON: C:\Python36
       PYTHON_VERSION: 3.6
       PYTHON_ARCH: 32
@@ -35,6 +40,11 @@ environment:
       PYTHON_VERSION: 3.4
       PYTHON_ARCH: 64
       TEST_MODE: fast
+
+    - PYTHON: C:\Python37-x64
+      PYTHON_VERSION: 3.7
+      PYTHON_ARCH: 64
+      TEST_MODE: full
 
     - PYTHON: C:\Python36-x64
       PYTHON_VERSION: 3.6


### PR DESCRIPTION
Python 3.7 must run with sudo on xenial travis-ci/travis-ci#9069