### PR TITLE
ENH: spatial.KDTree: add `query_range` method

### DIFF
--- a/scipy/spatial/kdtree.py
+++ b/scipy/spatial/kdtree.py
@@ -757,7 +757,7 @@ class KDTree(object):
                 result[c] = self.__query_range(rng[c])
             return result
         else:
-            raise ValueError("rng must be either 1 or 2dim array, %d dimensional array found." % rng.ndim)
+            raise ValueError("rng must be either 1 or 2 dim array, %d dimensional array found." % rng.ndim)
 
     def query_pairs(self, r, p=2., eps=0):
         """


### PR DESCRIPTION
added a range query method `query_range`  to `scipy.spatial.kdtree` in response to  #7822 

example usage:

```python
>>> from scipy import spatial
>>> x, y = np.mgrid[0:5, 0:5]
>>> points = np.c_[x.ravel(), y.ravel()]
>>> tree = spatial.KDTree(points)
>>> tree.query_range([0,0,2,2])
array([ 0,  1,  2,  5,  6,  7, 10, 11, 12]) 
```
I know we'll want a cKDTree implementation but my cython/c++ chops are << my python abilities so I thought I'd start here and get feedback.  
