### PR TITLE
ENH: Change COO index dtype so reshape will not fail

### DIFF
--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -153,7 +153,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
                     M, N = shape
                     self._shape = check_shape((M, N))
 
-                idx_dtype = get_index_dtype(maxval=max(self.shape))
+                idx_dtype = get_index_dtype(maxval=self.shape[0] * self.shape[1])
                 self.row = np.array(row, copy=copy, dtype=idx_dtype)
                 self.col = np.array(col, copy=copy, dtype=idx_dtype)
                 self.data = np.array(obj, copy=copy)

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -262,7 +262,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
             warn("col index array has non-integer dtype (%s) "
                     % self.col.dtype.name)
 
-        idx_dtype = get_index_dtype(maxval=max(self.shape))
+        idx_dtype = get_index_dtype(maxval=self.shape[0] * self.shape[1])
         self.row = np.asarray(self.row, dtype=idx_dtype)
         self.col = np.asarray(self.col, dtype=idx_dtype)
         self.data = to_native(self.data)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -4520,6 +4520,7 @@ def cases_64bit():
         'test_inv': 'linsolve for 64-bit indices not available',
         'test_solve': 'linsolve for 64-bit indices not available',
         'test_scalar_idx_dtype': 'test implemented in base class',
+        'test_large_dimensions': 'test actually requires 64-bit to work',
     }
 
     for cls in TEST_CLASSES:

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -4080,9 +4080,10 @@ class TestCOO(sparse_test_class(getset=False,
         mat1 = coo_matrix(([1], ([3000000], [1000])), (3000001, 1001))
         mat2 = coo_matrix(([1], ([1000], [3000000])), (1001, 3000001))
 
-        assert_array_equal(mat1.reshape((1001, 3000001), order='C'), mat2)
-        assert_array_equal(mat2.reshape((3000001, 1001), order='F'), mat1)
-
+        # assert_array_equal is slow for big matrices because it expects dense
+        # Using __ne__ and nnz instead
+        assert_((mat1.reshape((1001, 3000001), order='C') != mat2).nnz == 0)
+        assert_((mat2.reshape((3000001, 1001), order='F') != mat1).nnz == 0)
 
 TestCOO.init_class()
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -4074,6 +4074,15 @@ class TestCOO(sparse_test_class(getset=False,
         y = x.reshape(new_shape, copy=True)
         assert_(not np.may_share_memory(y.data, x.data))
 
+    def test_large_dimensions(self):
+        # Test that reshape is immune to integer overflow when number of elements
+        # exceeds 2^31-1
+        mat1 = coo_matrix(([1], ([3000000], [1000])), (3000001, 1001))
+        mat2 = coo_matrix(([1], ([1000], [3000000])), (1001, 3000001))
+
+        assert_array_equal(mat1.reshape((1001, 3000001), order='C'), mat2)
+        assert_array_equal(mat2.reshape((3000001, 1001), order='F'), mat1)
+
 
 TestCOO.init_class()
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -4085,6 +4085,7 @@ class TestCOO(sparse_test_class(getset=False,
         assert_((mat1.reshape((1001, 3000001), order='C') != mat2).nnz == 0)
         assert_((mat2.reshape((3000001, 1001), order='F') != mat1).nnz == 0)
 
+
 TestCOO.init_class()
 
 


### PR DESCRIPTION
This is a new attempt to fix #8912 after my first attempt in #8983 failed.