### PR TITLE
WIP : Remove smirnov entries from special/_legacy.pxd

### DIFF
--- a/scipy/special/_legacy.pxd
+++ b/scipy/special/_legacy.pxd
@@ -129,14 +129,14 @@ cdef inline double yn_unsafe(double n, double x) nogil:
     _legacy_cast_check("yn", n, 0)
     return yn(<int>n, x)
 
-cdef inline double smirnov_unsafe(double n, double e) nogil:
-    if npy_isnan(n):
-        return n
-    _legacy_cast_check("smirnov", n, 0)
-    return smirnov(<int>n, e)
-
-cdef inline double smirnovi_unsafe(double n, double p) nogil:
-    if npy_isnan(n):
-        return n
-    _legacy_cast_check("smirnovi", n, 0)
-    return smirnovi(<int>n, p)
+# cdef inline double smirnov_unsafe(double n, double e) nogil:
+#     if npy_isnan(n):
+#         return n
+#     _legacy_cast_check("smirnov", n, 0)
+#     return smirnov(<int>n, e)
+#
+# cdef inline double smirnovi_unsafe(double n, double p) nogil:
+#     if npy_isnan(n):
+#         return n
+#     _legacy_cast_check("smirnovi", n, 0)
+#     return smirnovi(<int>n, p)

--- a/scipy/special/functions.json
+++ b/scipy/special/functions.json
@@ -1239,17 +1239,11 @@
         }
     },
     "smirnov": {
-        "_legacy.pxd": {
-            "smirnov_unsafe": "dd->d"
-        },
         "cephes.h": {
             "smirnov": "id->d"
         }
     },
     "smirnovi": {
-        "_legacy.pxd": {
-            "smirnovi_unsafe": "dd->d"
-        },
         "cephes.h": {
             "smirnovi": "id->d"
         }

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -249,7 +249,7 @@ def test_rvs_broadcast(dist, shape_args):
     # Generate shape parameter arguments...
     for k in range(nargs):
         shp = (k + 4,) + (1,)*(k + 2)
-        allargs.append(shape_args[k]*np.ones(shp))
+        allargs.append(shape_args[k]*np.ones(shp, dtype=type(shape_args[k])))
         bshape.insert(0, k + 4)
     allargs.extend([loc, scale])
     # bshape holds the expected shape when loc, scale, and the shape


### PR DESCRIPTION
(WIP/Example)
@person142 has noted in https://github.com/scipy/scipy/pull/8737#pullrequestreview-137670398 that adding unsafe versions of functions to `special/_legacy.pxd` is unwanted.
This work/example removes the `smirnov` and `smirnovi` entries to understand the effect.

After removing `smirnov` entries from `_legacy.pxd` and `functions.json`, two tests fail with TypeError Exceptions.

Test Failure 1:
`scipy/stats/tests/test_continuous_basic.py: test_rvs_broadcast` fails as an array constructed from the distribution's shape values is not given the type of the value. `test_rvs_broadcast` is a generic routine used to test 100+ distributions.  It gets the shape parameters from `scipy/stats/_distr_params.py`
I.e. an array of `float` is created even though the first element of the shape maybe an int. Attempting to pass the float into `smirnov(int n, double e)` fails.

This test can be made to pass.  The change to `stats/tests/test_continuous_basic.py` in this PR uses the type of the shape_args element when creating the array of ones. I.e.
`allargs.append(shape_args[k]*np.ones(shp))`
->
`allargs.append(shape_args[k]*np.ones(shp, dtype=type(shape_args[k])))`

This would affect the invocation of `test_rvs_broadcast` for *all*  100_ distributions.  None of the  current list of distributions in `_distr_params.py:distcont` fail.  Any reason to think that this change would not be safe to apply, independent of gh-8737?
