### PR TITLE
DOC: Add link to Spyder when mentioned in SciPy video tutorial so users can more easily follow along

### DIFF
--- a/HACKING.rst.txt
+++ b/HACKING.rst.txt
@@ -387,7 +387,7 @@ test and use your changes (in ``.py`` files), by simply restarting the
 interpreter.
 
 
-*Are there any video examples for installing from source, setting up a 
+*Are there any video examples for installing from source, setting up a
 development environment, etc...?*
 
 Currently, there are two video demonstrations for Anaconda Python on macOS:
@@ -404,7 +404,7 @@ according to Part I.
 
 *Are there any video examples of the basic development workflow?*
 
-`SciPy Development Workflow`_ is a five-minute example of fixing a bug and 
+`SciPy Development Workflow`_ is a five-minute example of fixing a bug and
 submitting a pull request. While it's intended as a followup to
 `Anaconda SciPy Dev Part I (macOS)`_ and `Anaconda SciPy Dev Part II (macOS)`_,
 the process is similar for other development setups.

--- a/HACKING.rst.txt
+++ b/HACKING.rst.txt
@@ -373,7 +373,7 @@ For development, you can set up an in-place build so that changes made to
     $ python setup.py build_ext -i
 
 Then you need to point your PYTHONPATH environment variable to this directory.
-Some IDEs (Spyder for example) have utilities to manage PYTHONPATH.  On Linux
+Some IDEs (`Spyder`_ for example) have utilities to manage PYTHONPATH.  On Linux
 and OSX, you can run the command::
 
     $ export PYTHONPATH=$PWD
@@ -394,7 +394,7 @@ Currently, there are two video demonstrations for Anaconda Python on macOS:
 
 `Anaconda SciPy Dev Part I (macOS)`_ is a four-minute
 overview of installing Anaconda, building SciPy from source, and testing
-changes made to SciPy from the Spyder IDE.
+changes made to SciPy from the `Spyder`_ IDE.
 
 `Anaconda SciPy Dev Part II (macOS)`_ shows how to use
 a virtual environment to easily switch between the "pre-built version" of SciPy
@@ -518,6 +518,8 @@ suite.
 .. _Pytest: https://pytest.org/
 
 .. _mailing lists: https://www.scipy.org/scipylib/mailing-lists.html
+
+.. _Spyder: https://www.spyder-ide.org/
 
 .. _Anaconda SciPy Dev Part I (macOS): https://youtu.be/1rPOSNd0ULI
 


### PR DESCRIPTION
A very small change that simply makes the two existing mentions of the Spyder IDE in ``HACKING.rst.txt`` into a link, like the other packages referred to in the document, so users can find more information about it and download it to follow along with the SciPy video tutorials it is used for. Also did some very minor trailing whitespace cleanup around the lines I modified, since they were the only instances of such in the document.

Part of the broader effort described in spyder-ide/spyder-docs#39 .

I'm a new contributor here, so please let me know what I missed or you want me to change/revert something. Thanks!