### PR TITLE
BUG: Add test for Stackoverflow example from issue 8174.

### DIFF
--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -826,14 +826,12 @@ class LinprogCommonTests(object):
                     c=c, A_ub=A_ub, b_ub=b_ub, A_eq=A_eq, b_eq=b_eq,
                     method=self.method, options=self.options
                 )
-            _assert_success(res, desired_fun=43.3333333331385)
-
         else:
             res = linprog(
                 c=c, A_ub=A_ub, b_ub=b_ub, A_eq=A_eq, b_eq=b_eq,
                 method=self.method, options=self.options
             )
-            _assert_success(res, desired_fun=43.3333333331385)
+        _assert_success(res, desired_fun=43.3333333331385)
 
 
 class TestLinprogSimplex(LinprogCommonTests):

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -802,6 +802,44 @@ class LinprogCommonTests(object):
                     method=self.method, options=self.options)
             _assert_success(res, desired_fun=-106.63507541835018)
 
+    def test_issue_8174_stackoverflow(self):
+        # Test supplementary example from issue 8174.
+        # https://github.com/scipy/scipy/issues/8174
+        # https://stackoverflow.com/questions/47717012/linprog-in-scipy-optimize-checking-solution
+        c = np.array([1, 0, 0, 0, 0, 0, 0])
+        A_ub = -np.identity(7)
+        b_ub = np.array([[-2],[-2],[-2],[-2],[-2],[-2],[-2]])
+        A_eq = np.array([
+            [1, 1, 1, 1, 1, 1, 0],
+            [0.3, 1.3, 0.9, 0, 0, 0, -1],
+            [0.3, 0, 0, 0, 0, 0, -2/3],
+            [0, 0.65, 0, 0, 0, 0, -1/15],
+            [0, 0, 0.3, 0, 0, 0, -1/15]
+        ])
+        b_eq = np.array([[100],[0],[0],[0],[0]])
+
+        shoud_warn_A_not_full_rank = (
+            self.options.get('presolve', True)
+            and self.method == 'interior-point'
+            )
+
+        if shoud_warn_A_not_full_rank:
+            # A is not of full row rank. The expected behaviour is for
+            # the presolve function to warn the user. Currently only
+            # the interior-point method implements presolve.
+            with pytest.warns(OptimizeWarning):
+                res = linprog(
+                    c=c, A_ub=A_ub, b_ub=b_ub, A_eq=A_eq, b_eq=b_eq,
+                    method=self.method, options=self.options
+                )
+        else:
+            res = linprog(
+                c=c, A_ub=A_ub, b_ub=b_ub, A_eq=A_eq, b_eq=b_eq,
+                method=self.method, options=self.options
+            )
+
+        _assert_success(res, desired_fun=43.3333333331385)
+
 
 class TestLinprogSimplex(LinprogCommonTests):
     method = "simplex"

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -797,7 +797,7 @@ class LinprogCommonTests(object):
             with pytest.warns(OptimizeWarning):
                 res = linprog(c, A_ub, b_ub, bounds=bounds,
                     method=self.method, options=self.options)
-        elif self.method == 'interior-point':
+        else:
             res = linprog(c, A_ub, b_ub, bounds=bounds,
                     method=self.method, options=self.options)
             _assert_success(res, desired_fun=-106.63507541835018)
@@ -828,7 +828,7 @@ class LinprogCommonTests(object):
                 )
             _assert_success(res, desired_fun=43.3333333331385)
 
-        elif self.method == 'interior-point':
+        else:
             res = linprog(
                 c=c, A_ub=A_ub, b_ub=b_ub, A_eq=A_eq, b_eq=b_eq,
                 method=self.method, options=self.options

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -818,27 +818,22 @@ class LinprogCommonTests(object):
         ])
         b_eq = np.array([[100],[0],[0],[0],[0]])
 
-        should_warn_A_not_full_rank = (
-            self.options.get('presolve', True)
-            and self.method == 'interior-point'
-            )
-
-        if should_warn_A_not_full_rank:
-            # A is not of full row rank. The expected behaviour is for
-            # the presolve function to warn the user. Currently only
-            # the interior-point method implements presolve.
+        if self.method == 'interior-point':
+            # Warning is raised in presolve method,
+            # which is not yet implemented in the simplex method.
             with pytest.warns(OptimizeWarning):
                 res = linprog(
                     c=c, A_ub=A_ub, b_ub=b_ub, A_eq=A_eq, b_eq=b_eq,
                     method=self.method, options=self.options
                 )
-        else:
+            _assert_success(res, desired_fun=43.3333333331385)
+
+        elif self.method == 'interior-point':
             res = linprog(
                 c=c, A_ub=A_ub, b_ub=b_ub, A_eq=A_eq, b_eq=b_eq,
                 method=self.method, options=self.options
             )
-
-        _assert_success(res, desired_fun=43.3333333331385)
+            _assert_success(res, desired_fun=43.3333333331385)
 
 
 class TestLinprogSimplex(LinprogCommonTests):

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -818,12 +818,12 @@ class LinprogCommonTests(object):
         ])
         b_eq = np.array([[100],[0],[0],[0],[0]])
 
-        shoud_warn_A_not_full_rank = (
+        should_warn_A_not_full_rank = (
             self.options.get('presolve', True)
             and self.method == 'interior-point'
             )
 
-        if shoud_warn_A_not_full_rank:
+        if should_warn_A_not_full_rank:
             # A is not of full row rank. The expected behaviour is for
             # the presolve function to warn the user. Currently only
             # the interior-point method implements presolve.


### PR DESCRIPTION
Test of the [stackoverflow issue](https://stackoverflow.com/questions/47717012/linprog-in-scipy-optimize-checking-solution) in issue #8174 as suggested by @mdhaber. The result returned from `linprog(method='simplex')` now matches that of `linprog(method='interior-point')`:

```python
import numpy as np
from scipy.optimize import linprog
c = np.array([1,0,0,0,0,0,0])
A_ub = np.identity(7)*(-1)
b_ub = np.array([[-2],[-2],[-2],[-2],[-2],[-2],[-2]])
A_eq = np.array([[1,1,1,1,1,1,0],[0.3,1.3,0.9,0,0,0,-1],[0.3,0,0,0,0,0,-2/3],
                 [0,0.65,0,0,0,0,-1/15],[0,0,0.3,0,0,0,-1/15]])
b_eq = np.array([[100],[0],[0],[0],[0]])
res = linprog(c = c, A_ub=A_ub, b_ub=b_ub, A_eq = A_eq, b_eq = b_eq)
print('Simplex method:')
print(res)

print()
print('Interior-Point method')
res_ip = linprog(c = c, A_ub=A_ub, b_ub=b_ub, A_eq = A_eq, b_eq = b_eq, method='interior-point')
print(res_ip)
```

```python
Simplex method:
     fun: 43.33333333333336
 message: 'Optimization terminated successfully.'
     nit: 15
   slack: array([41.33333333,  0.        ,  2.33333333, 44.33333333,  0.        ,
        0.        , 17.5       ])
  status: 0
 success: True
       x: array([43.33333333,  2.        ,  4.33333333, 46.33333333,  2.        ,
        2.        , 19.5       ])

Interior-Point method
     con: array([ 2.79356982e-10, -1.52451385e-11,  3.71258579e-12, -5.92437210e-12,
       -2.36921593e-12])
     fun: 43.33333333313849
 message: 'Optimization terminated successfully.'
     nit: 5
   slack: array([4.13333333e+01, 6.92779167e-13, 2.33333333e+00, 1.47777778e+01,
       1.47777778e+01, 1.47777778e+01, 1.75000000e+01])
  status: 0
 success: True
       x: array([43.33333333,  2.        ,  4.33333333, 16.77777778, 16.77777778,
       16.77777778, 19.5       ])
```