### PR TITLE
allow resample_poly() to output float32 for float32 inputs.

### DIFF
--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2373,7 +2373,8 @@ def resample_poly(x, up, down, axis=0, window=('kaiser', 5.0)):
     while _output_len(len(h) + n_pre_pad + n_post_pad, x.shape[axis],
                       up, down) < n_out + n_pre_remove:
         n_post_pad += 1
-    h = np.concatenate((np.zeros(n_pre_pad), h, np.zeros(n_post_pad)))
+    h = np.concatenate((np.zeros(n_pre_pad, dtype=h.dtype), h,
+                        np.zeros(n_post_pad, dtype=h.dtype)))
     n_pre_remove_end = n_pre_remove + n_out
 
     # filter then remove excess

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -657,6 +657,13 @@ class TestResample(object):
         signal.resample_poly(impulse, 5, 1, window=window)
         assert_array_equal(window, window_orig)
 
+    def test_output_float32(self):
+        # Test that float32 inputs yield a float32 output
+        x = np.arange(10, dtype=np.float32)
+        h = np.array([1,1,1], dtype=np.float32)
+        y = signal.resample_poly(x, 1, 2, window=h)
+        assert_(y.dtype == np.float32)
+
     def _test_data(self, method, ext=False):
         # Test resampling of sinusoids and random noise (1-sec)
         rate = 100


### PR DESCRIPTION
Problem: resample_poly() inadvertently upgrades the user-supplied filter to double precision, such that single precision inputs to resample_poly() yield a double precision output.
See #9104.

Solution: Preserve the filter dtype during zeropadding of the filter