### PR TITLE
interpolative: correctly reconstruct full rank matrices

### DIFF
--- a/scipy/linalg/_interpolative_backend.py
+++ b/scipy/linalg/_interpolative_backend.py
@@ -727,7 +727,7 @@ def iddr_aid(A, k):
     w = iddr_aidi(m, n, k)
     idx, proj = _id.iddr_aid(A, k, w)
     if k == n:
-        proj = np.array([], dtype='float64', order='F')
+        proj = np.empty((k, n-k), dtype='float64', order='F')
     else:
         proj = proj.reshape((k, n-k), order='F')
     return idx, proj
@@ -1523,7 +1523,7 @@ def idzr_aid(A, k):
     w = idzr_aidi(m, n, k)
     idx, proj = _id.idzr_aid(A, k, w)
     if k == n:
-        proj = np.array([], dtype='complex128', order='F')
+        proj = np.empty((k, n-k), dtype='complex128', order='F')
     else:
         proj = proj.reshape((k, n-k), order='F')
     return idx, proj

--- a/scipy/linalg/tests/test_interpolative.py
+++ b/scipy/linalg/tests/test_interpolative.py
@@ -256,3 +256,23 @@ class TestInterpolativeDecomposition(object):
         a = np.ones((4, 3))
         with assert_raises(ValueError):
             pymatrixid.svd(a, 4)
+
+    def test_full_rank(self):
+        eps = 1.0e-12
+
+        # fixed precision
+        A = np.random.rand(16, 8)
+        k, idx, proj = pymatrixid.interp_decomp(A, eps)
+        assert_(k == A.shape[1])
+
+        P = pymatrixid.reconstruct_interp_matrix(idx, proj)
+        B = pymatrixid.reconstruct_skel_matrix(A, k, idx)
+        assert_allclose(A, B.dot(P))
+
+        # fixed rank
+        idx, proj = pymatrixid.interp_decomp(A, k)
+
+        P = pymatrixid.reconstruct_interp_matrix(idx, proj)
+        B = pymatrixid.reconstruct_skel_matrix(A, k, idx)
+        assert_allclose(A, B.dot(P))
+


### PR DESCRIPTION
In the case when `k == rank(A)`, the interpolation matrix returned by `interp_decomp(A, k)` wasn't correctly transformed into the identity by `reconstruct_interp_matrix` (the fixed rank unit test failed).