### PR TITLE
MAINT: Use warnings for unexpected peak properties

### DIFF
--- a/scipy/signal/_peak_finding.py
+++ b/scipy/signal/_peak_finding.py
@@ -263,7 +263,7 @@ def _arg_x_as_expected(value):
     """
     value = np.asarray(value, order='C', dtype=np.float64)
     if value.ndim != 1:
-        raise ValueError('`x` must have exactly one dimension')
+        raise ValueError('`x` must be a 1D array')
     return value
 
 
@@ -287,9 +287,9 @@ def _arg_peaks_as_expected(value):
         value = value.astype(np.intp, order='C', casting='safe',
                              subok=False, copy=False)
     except TypeError:
-        raise TypeError("Cannot safely cast `peaks` to dtype('intp')")
+        raise TypeError("cannot safely cast `peaks` to dtype('intp')")
     if value.ndim != 1:
-        raise ValueError('`peaks` must have exactly one dimension')
+        raise ValueError('`peaks` must be a 1D array')
     return value
 
 
@@ -314,7 +314,7 @@ def _arg_wlen_as_expected(value):
             value = math.ceil(value)
         value = np.intp(value)
     else:
-        raise ValueError('`wlen` must be at larger than 1, was {}'
+        raise ValueError('`wlen` must be larger than 1, was {}'
                          .format(value))
     return value
 

--- a/scipy/signal/_peak_finding.py
+++ b/scipy/signal/_peak_finding.py
@@ -10,8 +10,12 @@ from scipy._lib.six import xrange
 from scipy.signal.wavelets import cwt, ricker
 from scipy.stats import scoreatpercentile
 
-from ._peak_finding_utils import (_argmaxima1d, _select_by_peak_distance,
-                                  _peak_prominences, _peak_widths)
+from ._peak_finding_utils import (
+    _argmaxima1d,
+    _select_by_peak_distance,
+    _peak_prominences,
+    _peak_widths
+)
 
 
 __all__ = ['argrelmin', 'argrelmax', 'argrelextrema', 'peak_prominences',
@@ -277,7 +281,7 @@ def peak_prominences(x, peaks, wlen=None):
     Raises
     ------
     ValueError
-        If an index in `peaks` does not point to a local maximum in `x`.
+        If a value in `peaks` is an invalid index for `x`.
 
     See Also
     --------
@@ -312,6 +316,10 @@ def peak_prominences(x, peaks, wlen=None):
     calculated prominence. In practice this is only relevant for the highest set
     of peaks in `x`. This behavior may even be used intentionally to calculate
     "local" prominences.
+
+    For indices in `peaks` that don't point to valid local maxima in `x` the
+    returned prominence will be 0 and a warning is raised. This also happens
+    if `wlen` is smaller than the plateau size of a peak.
 
     .. warning::
 
@@ -480,6 +488,9 @@ def peak_widths(x, peaks, rel_height=0.5, prominence_data=None, wlen=None):
     As shown above to calculate a peak's width its prominence and bases must be
     known. You can supply these yourself with the argument `prominence_data`.
     Otherwise they are internally calculated (see `peak_prominences`).
+
+    A warning is raised if any calculated width is 0. This may stem from the
+    supplied `prominence_data` or if `rel_height` is set to 0.
 
     .. warning::
 

--- a/scipy/signal/_peak_finding.py
+++ b/scipy/signal/_peak_finding.py
@@ -365,7 +365,7 @@ def peak_prominences(x, peaks, wlen=None):
         A signal with peaks.
     peaks : sequence
         Indices of peaks in `x`.
-    wlen : number, optional
+    wlen : int, optional
         A window length in samples that optionally limits the evaluated area for
         each peak to a subset of `x`. The peak is always placed in the middle of
         the window therefore the given length is rounded up to the next odd
@@ -383,6 +383,18 @@ def peak_prominences(x, peaks, wlen=None):
     ------
     ValueError
         If a value in `peaks` is an invalid index for `x`.
+
+    Warns
+    -----
+    PeakPropertyWarning
+        For indices in `peaks` that don't point to valid local maxima in `x`
+        the returned prominence will be 0 and this warning is raised. This
+        also happens if `wlen` is smaller than the plateau size of a peak.
+
+    Warnings
+    --------
+    This function may return unexpected results for data containing NaNs. To
+    avoid this, NaNs should either be removed or replaced.
 
     See Also
     --------
@@ -417,15 +429,6 @@ def peak_prominences(x, peaks, wlen=None):
     calculated prominence. In practice this is only relevant for the highest set
     of peaks in `x`. This behavior may even be used intentionally to calculate
     "local" prominences.
-
-    For indices in `peaks` that don't point to valid local maxima in `x` the
-    returned prominence will be 0 and a warning is raised. This also happens
-    if `wlen` is smaller than the plateau size of a peak.
-
-    .. warning::
-
-       This function may return unexpected results for data containing NaNs. To
-       avoid this, NaNs should either be removed or replaced.
 
     .. versionadded:: 1.1.0
 
@@ -513,7 +516,7 @@ def peak_widths(x, peaks, rel_height=0.5, prominence_data=None, wlen=None):
         A tuple of three arrays matching the output of `peak_prominences` when
         called with the same arguments `x` and `peaks`. This data is calculated
         internally if not provided.
-    wlen : number, optional
+    wlen : int, optional
         A window length in samples passed to `peak_prominences` as an optional
         argument for internal calculation of `prominence_data`. This argument
         is ignored if `prominence_data` is given.
@@ -535,6 +538,17 @@ def peak_widths(x, peaks, rel_height=0.5, prominence_data=None, wlen=None):
         ``0 <= left_base <= peak <= right_base < x.shape[0]`` for each peak,
         has the wrong dtype, is not C-contiguous or does not have the same
         shape.
+
+    Warns
+    -----
+    PeakPropertyWarning
+        Raised if any calculated width is 0. This may stem from the supplied
+        `prominence_data` or if `rel_height` is set to 0.
+
+    Warnings
+    --------
+    This function may return unexpected results for data containing NaNs. To
+    avoid this, NaNs should either be removed or replaced.
 
     See Also
     --------
@@ -564,14 +578,6 @@ def peak_widths(x, peaks, rel_height=0.5, prominence_data=None, wlen=None):
     As shown above to calculate a peak's width its prominence and bases must be
     known. You can supply these yourself with the argument `prominence_data`.
     Otherwise they are internally calculated (see `peak_prominences`).
-
-    A warning is raised if any calculated width is 0. This may stem from the
-    supplied `prominence_data` or if `rel_height` is set to 0.
-
-    .. warning::
-
-       This function may return unexpected results for data containing NaNs. To
-       avoid this, NaNs should either be removed or replaced.
 
     .. versionadded:: 1.1.0
 
@@ -787,7 +793,7 @@ def find_peaks(x, height=None, threshold=None, distance=None,
         matching `x` or a 2-element sequence of the former. The first
         element is always interpreted as the  minimal and the second, if
         supplied, as the maximal required prominence.
-    wlen : number, optional
+    wlen : int, optional
         Used for calculation of the peaks prominences, thus it is only used if
         one of the arguments `prominence` or `width` is given. See argument
         `wlen` in `peak_prominences` for a full description of its effects.
@@ -820,6 +826,17 @@ def find_peaks(x, height=None, threshold=None, distance=None,
         To calculate and return properties without excluding peaks, provide the
         open interval ``(None, None)`` as a value to the appropriate argument
         (excluding `distance`).
+
+    Warns
+    -----
+    PeakPropertyWarning
+        Raised if a peak's properties have unexpected values (see
+        `peak_prominences` and `peak_widths`).
+
+    Warnings
+    --------
+    This function may return unexpected results for data containing NaNs. To
+    avoid this, NaNs should either be removed or replaced.
 
     See Also
     --------
@@ -862,11 +879,6 @@ def find_peaks(x, height=None, threshold=None, distance=None,
     * Use `wlen` to reduce the time it takes to evaluate the conditions for
       `prominence` or `width` if `x` is large or has many local maxima
       (see `peak_prominences`).
-
-    .. warning::
-
-       This function may return unexpected results for data containing NaNs. To
-       avoid this, NaNs should either be removed or replaced.
 
     .. versionadded:: 1.1.0
 

--- a/scipy/signal/_peak_finding_utils.pyx
+++ b/scipy/signal/_peak_finding_utils.pyx
@@ -249,7 +249,7 @@ def _peak_prominences(np.float64_t[::1] x not None,
 
     if show_warning:
         warnings.warn("some peaks have a prominence of 0",
-                      PeakPropertyWarning)
+                      PeakPropertyWarning, stacklevel=2)
     # Return memoryviews as ndarrays
     return prominences.base, left_bases.base, right_bases.base
 
@@ -360,5 +360,6 @@ def _peak_widths(np.float64_t[::1] x not None,
             right_ips[p] = right_ip
 
     if show_warning:
-        warnings.warn("some peaks have a width of 0", PeakPropertyWarning)
+        warnings.warn("some peaks have a width of 0",
+                      PeakPropertyWarning, stacklevel=2)
     return widths.base, width_heights.base, left_ips.base, right_ips.base

--- a/scipy/signal/_peak_finding_utils.pyx
+++ b/scipy/signal/_peak_finding_utils.pyx
@@ -294,6 +294,7 @@ def _peak_widths(np.float64_t[::1] x not None,
         If the supplied prominence data doesn't satisfy the condition
         ``0 <= left_base <= peak <= right_base < x.shape[0]`` for each peak or
         if `peaks`, `left_bases` and `right_bases` don't share the same shape.
+        Or if `rel_height` is not at least 0.
 
     Warnings
     --------
@@ -312,8 +313,10 @@ def _peak_widths(np.float64_t[::1] x not None,
         np.intp_t p, peak, i, i_max, i_min
         np.uint8_t show_warning
 
-    if not (peaks.shape[0] == prominences.shape[0] == left_bases.shape[0] ==
-            right_bases.shape[0]):
+    if rel_height < 0:
+        raise ValueError('`rel_height` must be greater or equal to 0.0')
+    if not (peaks.shape[0] == prominences.shape[0] == left_bases.shape[0]
+            == right_bases.shape[0]):
         raise ValueError("arrays in `prominence_data` must have the same shape "
                          "as `peaks`")
 

--- a/scipy/signal/_peak_finding_utils.pyx
+++ b/scipy/signal/_peak_finding_utils.pyx
@@ -151,7 +151,7 @@ def _select_by_peak_distance(np.intp_t[::1] peaks not None,
     return keep.base.view(dtype=np.bool)  # Return as boolean array
 
 
-class PeakPropertyWarning(Warning):
+class PeakPropertyWarning(RuntimeWarning):
     """Calculated property of a peak has unexpected value."""
     pass
 

--- a/scipy/signal/_peak_finding_utils.pyx
+++ b/scipy/signal/_peak_finding_utils.pyx
@@ -4,6 +4,8 @@
 
 """Utility functions for finding peaks in signals."""
 
+import warnings
+
 import numpy as np
 
 cimport numpy as np
@@ -149,6 +151,11 @@ def _select_by_peak_distance(np.intp_t[::1] peaks not None,
     return keep.base.view(dtype=np.bool)  # Return as boolean array
 
 
+class PeakPropertyWarning(Warning):
+    """Calculated property of a peak has unexpected value."""
+    pass
+
+
 def _peak_prominences(np.float64_t[::1] x not None,
                       np.intp_t[::1] peaks not None,
                       np.intp_t wlen):
@@ -176,7 +183,12 @@ def _peak_prominences(np.float64_t[::1] x not None,
     Raises
     ------
     ValueError
-        If an index in `peaks` doesn't point to a local maximum in `x`.
+        If a value in `peaks` is an invalid index for `x`.
+
+    Warnings
+    --------
+    PeakPropertyWarning
+        If a prominence of 0 was calculated for any peak.
 
     Notes
     -----
@@ -189,9 +201,9 @@ def _peak_prominences(np.float64_t[::1] x not None,
         np.intp_t[::1] left_bases, right_bases
         np.float64_t left_min, right_min
         np.intp_t peak_nr, peak, i_min, i_max, i
-        np.uint8_t raise_error
+        np.uint8_t show_warning
 
-    raise_error = False
+    show_warning = False
     prominences = np.empty(peaks.shape[0], dtype=np.float64)
     left_bases = np.empty(peaks.shape[0], dtype=np.intp)
     right_bases = np.empty(peaks.shape[0], dtype=np.intp)
@@ -201,6 +213,10 @@ def _peak_prominences(np.float64_t[::1] x not None,
             peak = peaks[peak_nr]
             i_min = 0
             i_max = x.shape[0] - 1
+            if not i_min <= peak <= i_max:
+                with gil:
+                    raise ValueError("peak {} is not a valid index for `x`"
+                                     .format(peak))
 
             if 2 <= wlen:
                 # Adjust window around the evaluated peak (within bounds);
@@ -210,34 +226,30 @@ def _peak_prominences(np.float64_t[::1] x not None,
                 i_max = min(peak + wlen // 2, i_max)
 
             # Find the left base in interval [i_min, peak]
-            i = peak
+            i = left_bases[peak_nr] = peak
             left_min = x[peak]
             while i_min <= i and x[i] <= x[peak]:
                 if x[i] < left_min:
                     left_min = x[i]
                     left_bases[peak_nr] = i
                 i -= 1
-            if not left_min < x[peak]:
-                raise_error = True  # Raise error outside nogil statement
-                break
 
             # Find the right base in interval [peak, i_max]
-            i = peak
+            i = right_bases[peak_nr] = peak
             right_min = x[peak]
             while i <= i_max and x[i] <= x[peak]:
                 if x[i] < right_min:
                     right_min = x[i]
                     right_bases[peak_nr] = i
                 i += 1
-            if not right_min < x[peak]:
-                raise_error = True  # Raise error outside nogil statement
-                break
 
             prominences[peak_nr] = x[peak] - max(left_min, right_min)
+            if prominences[peak_nr] == 0:
+                show_warning = True
 
-    if raise_error:
-        raise ValueError('{} is not a valid peak'.format(peak))
-
+    if show_warning:
+        warnings.warn("some peaks have a prominence of 0",
+                      PeakPropertyWarning)
     # Return memoryviews as ndarrays
     return prominences.base, left_bases.base, right_bases.base
 
@@ -283,6 +295,11 @@ def _peak_widths(np.float64_t[::1] x not None,
         ``0 <= left_base <= peak <= right_base < x.shape[0]`` for each peak or
         if `peaks`, `left_bases` and `right_bases` don't share the same shape.
 
+    Warnings
+    --------
+    PeakPropertyWarning
+        If a width of 0 was calculated for any peak.
+
     Notes
     -----
     This is the inner function to `peak_widths`.
@@ -293,14 +310,14 @@ def _peak_widths(np.float64_t[::1] x not None,
         np.float64_t[::1] widths, width_heights, left_ips, right_ips
         np.float64_t height, left_ip, right_ip
         np.intp_t p, peak, i, i_max, i_min
-        np.uint8_t raise_error
+        np.uint8_t show_warning
 
     if not (peaks.shape[0] == prominences.shape[0] == left_bases.shape[0] ==
             right_bases.shape[0]):
         raise ValueError("arrays in `prominence_data` must have the same shape "
                          "as `peaks`")
 
-    raise_error = False
+    show_warning = False
     widths = np.empty(peaks.shape[0], dtype=np.float64)
     width_heights = np.empty(peaks.shape[0], dtype=np.float64)
     left_ips = np.empty(peaks.shape[0], dtype=np.float64)
@@ -312,9 +329,10 @@ def _peak_widths(np.float64_t[::1] x not None,
             i_max = right_bases[p]
             peak = peaks[p]
             # Validate bounds and order
-            if not 0 <= i_min < peak < i_max < x.shape[0]:
-                raise_error = True
-                break
+            if not 0 <= i_min <= peak <= i_max < x.shape[0]:
+                with gil:
+                    raise ValueError("prominence data is invalid for peak {}"
+                                     .format(peak))
             height = width_heights[p] = x[peak] - prominences[p] * rel_height
 
             # Find intersection point on left side
@@ -336,10 +354,11 @@ def _peak_widths(np.float64_t[::1] x not None,
                 right_ip -= (height - x[i]) / (x[i - 1] - x[i])
 
             widths[p] = right_ip - left_ip
+            if widths[p] == 0:
+                show_warning = True
             left_ips[p] = left_ip
             right_ips[p] = right_ip
 
-    if raise_error:
-        raise ValueError("prominence data is invalid for peak {}".format(peak))
-
+    if show_warning:
+        warnings.warn("some peaks have a width of 0", PeakPropertyWarning)
     return widths.base, width_heights.base, left_ips.base, right_ips.base

--- a/scipy/signal/_peak_finding_utils.pyx
+++ b/scipy/signal/_peak_finding_utils.pyx
@@ -185,8 +185,8 @@ def _peak_prominences(np.float64_t[::1] x not None,
     ValueError
         If a value in `peaks` is an invalid index for `x`.
 
-    Warnings
-    --------
+    Warns
+    -----
     PeakPropertyWarning
         If a prominence of 0 was calculated for any peak.
 

--- a/scipy/signal/tests/test_peak_finding.py
+++ b/scipy/signal/tests/test_peak_finding.py
@@ -502,7 +502,7 @@ class TestPeakWidths(object):
             peak_widths(np.arange(10), [1.1, 2.3])
         with raises(ValueError, match='rel_height'):
             # rel_height is < 0
-            peak_widths(np.arange(10), [1, 2], rel_height=-1)
+            peak_widths([0, 1, 0, 1, 0], [1, 3], rel_height=-1)
         with raises(TypeError, match='None'):
             # prominence data contains None
             peak_widths([1, 2, 1], [1], prominence_data=(None, None, None))

--- a/scipy/signal/tests/test_peak_finding.py
+++ b/scipy/signal/tests/test_peak_finding.py
@@ -704,7 +704,8 @@ class TestFindPeaks(object):
         with raises(ValueError, match="distance"):
             find_peaks(np.arange(10), distance=-1)
 
-    @pytest.mark.filterwarnings("ignore:::scipy.signal._peak_finding")
+    @pytest.mark.filterwarnings("ignore:some peaks have a prominence of 0",
+                                "ignore:some peaks have a width of 0")
     def test_wlen_smaller_plateau(self):
         """
         Test behavior of prominence and width calculation if the given window

--- a/scipy/signal/tests/test_peak_finding.py
+++ b/scipy/signal/tests/test_peak_finding.py
@@ -23,10 +23,7 @@ from scipy.signal._peak_finding import (
     find_peaks_cwt,
     _identify_ridge_lines
 )
-from scipy.signal._peak_finding_utils import (
-    _argmaxima1d,
-    PeakPropertyWarning
-)
+from scipy.signal._peak_finding_utils import _argmaxima1d, PeakPropertyWarning
 
 
 def _gen_gaussians(center_locs, sigmas, total_length):

--- a/scipy/signal/tests/test_peak_finding.py
+++ b/scipy/signal/tests/test_peak_finding.py
@@ -390,16 +390,16 @@ class TestPeakProminences(object):
 
     def test_exceptions(self):
         """
-        Verfiy that exceptions and warnings are raised.
+        Verify that exceptions and warnings are raised.
         """
         # x with dimension > 1
-        with raises(ValueError, match='dimension'):
+        with raises(ValueError, match='1D array'):
             peak_prominences([[0, 1, 1, 0]], [1, 2])
         # peaks with dimension > 1
-        with raises(ValueError, match='dimension'):
+        with raises(ValueError, match='1D array'):
             peak_prominences([0, 1, 1, 0], [[1, 2]])
         # x with dimension < 1
-        with raises(ValueError, match='dimension'):
+        with raises(ValueError, match='1D array'):
             peak_prominences(3, [0,])
 
         # empty x with supplied
@@ -411,7 +411,7 @@ class TestPeakProminences(object):
                 peak_prominences([1, 0, 2], [p])
 
         # peaks is not cast-able to np.intp
-        with raises(TypeError, match='Cannot safely cast'):
+        with raises(TypeError, match='cannot safely cast'):
             peak_prominences([0, 1, 1, 0], [1.1, 2.3])
 
         # wlen < 3
@@ -477,18 +477,18 @@ class TestPeakWidths(object):
 
     def test_exceptions(self):
         """
-        Verfiy that argument validation works as intended.
+        Verify that argument validation works as intended.
         """
-        with raises(ValueError, match='dimension'):
+        with raises(ValueError, match='1D array'):
             # x with dimension > 1
             peak_widths(np.zeros((3, 4)), np.ones(3))
-        with raises(ValueError, match='dimension'):
+        with raises(ValueError, match='1D array'):
             # x with dimension < 1
             peak_widths(3, [0])
-        with raises(ValueError, match='dimension'):
+        with raises(ValueError, match='1D array'):
             # peaks with dimension > 1
             peak_widths(np.arange(10), np.ones((3, 2), dtype=np.intp))
-        with raises(ValueError, match='dimension'):
+        with raises(ValueError, match='1D array'):
             # peaks with dimension < 1
             peak_widths(np.arange(10), 3)
         with raises(ValueError, match='not a valid index'):
@@ -497,7 +497,7 @@ class TestPeakWidths(object):
         with raises(ValueError, match='not a valid index'):
             # empty x with peaks supplied
             peak_widths([], [1, 2])
-        with raises(TypeError, match='Cannot safely cast'):
+        with raises(TypeError, match='cannot safely cast'):
             # peak cannot be safely casted to intp
             peak_widths(np.arange(10), [1.1, 2.3])
         with raises(ValueError, match='rel_height'):
@@ -694,9 +694,9 @@ class TestFindPeaks(object):
         """
         Test exceptions raised by function.
         """
-        with raises(ValueError, match="dimension"):
+        with raises(ValueError, match="1D array"):
             find_peaks(np.array(1))
-        with raises(ValueError, match="dimension"):
+        with raises(ValueError, match="1D array"):
             find_peaks(np.ones((2, 2)))
         with raises(ValueError, match="distance"):
             find_peaks(np.arange(10), distance=-1)

--- a/scipy/signal/tests/test_peak_finding.py
+++ b/scipy/signal/tests/test_peak_finding.py
@@ -418,11 +418,16 @@ class TestPeakProminences(object):
         with raises(ValueError, match='wlen'):
             peak_prominences(np.arange(10), [3, 5], wlen=1)
 
-        # peaks with prominence of 0
+    def test_warnings(self):
+        """
+        Verify that appropriate warnings are raised.
+        """
         msg = "some peaks have a prominence of 0"
         for p in [0, 1, 2]:
             with warns(PeakPropertyWarning, match=msg):
                 peak_prominences([1, 0, 2], [p,])
+        with warns(PeakPropertyWarning, match=msg):
+            peak_prominences([0, 1, 1, 1, 0], [2], wlen=2)
 
 
 class TestPeakWidths(object):
@@ -506,6 +511,23 @@ class TestPeakWidths(object):
         with raises(TypeError, match='None'):
             # prominence data contains None
             peak_widths([1, 2, 1], [1], prominence_data=(None, None, None))
+
+    def test_warnings(self):
+        """
+        Verify that appropriate warnings are raised.
+        """
+        msg = "some peaks have a width of 0"
+        with warns(PeakPropertyWarning, match=msg):
+            # Case: rel_height is 0
+            peak_widths([0, 1, 0], [1], rel_height=0)
+        with warns(PeakPropertyWarning, match=msg):
+            # Case: prominence is 0 and bases are identical
+            peak_widths(
+                [0, 1, 1, 1, 0], [2],
+                prominence_data=(np.array([0.], np.float64),
+                                 np.array([2], np.intp),
+                                 np.array([2], np.intp))
+            )
 
     def test_mismatching_prominence_data(self):
         """Test with mismatching peak and / or prominence data."""


### PR DESCRIPTION
...instead of raising exceptions. The affected functions can deal with a prominence or width of 0 just fine. However these values hint at faulty input or might be unexpected by the user. Therefore the user should still be informed.

Furthermore some bounds checking for the `peaks` argument in _peak_prominences was added. Previously invalid indices weren't caught before indexing `x`!

I took the liberty to reformat some imports to make them (in my opinion) more readable. If this is frowned upon please say so and I'll revert it immediately. :)

I'm not sure whether these "backward compatible" changes require an entry in the release notes...

Closes gh-9110
