### PR TITLE
BUG: Do not catch and silence KeyboardInterrupt

### DIFF
--- a/scipy/integrate/quadrature.py
+++ b/scipy/integrate/quadrature.py
@@ -863,7 +863,7 @@ def newton_cotes(rn, equal=0):
             rn = np.arange(N+1)
         elif np.all(np.diff(rn) == 1):
             equal = 1
-    except:
+    except Exception:
         N = rn
         rn = np.arange(N+1)
         equal = 1

--- a/scipy/interpolate/_fitpack_impl.py
+++ b/scipy/interpolate/_fitpack_impl.py
@@ -581,7 +581,7 @@ def splev(x, tck, der=0, ext=0):
     try:
         c[0][0]
         parametric = True
-    except:
+    except Exception:
         parametric = False
     if parametric:
         return list(map(lambda c, x=x, t=t, k=k, der=der:
@@ -655,7 +655,7 @@ def splint(a, b, tck, full_output=0):
     try:
         c[0][0]
         parametric = True
-    except:
+    except Exception:
         parametric = False
     if parametric:
         return list(map(lambda c, a=a, b=b, t=t, k=k:
@@ -713,7 +713,7 @@ def sproot(tck, mest=10):
     try:
         c[0][0]
         parametric = True
-    except:
+    except Exception:
         parametric = False
     if parametric:
         return list(map(lambda c, t=t, k=k, mest=mest:
@@ -774,7 +774,7 @@ def spalde(x, tck):
     try:
         c[0][0]
         parametric = True
-    except:
+    except Exception:
         parametric = False
     if parametric:
         return list(map(lambda c, x=x, t=t, k=k:
@@ -1129,7 +1129,7 @@ def insert(x, tck, m=1, per=0):
     try:
         c[0][0]
         parametric = True
-    except:
+    except Exception:
         parametric = False
     if parametric:
         cc = []

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -2819,7 +2819,7 @@ def splmake(xk, yk, order=3, kind='smoothest', conds=None):
 
     try:
         func = eval('_find_%s' % kind)
-    except:
+    except Exception:
         raise NotImplementedError
 
     # the constraint matrix

--- a/scipy/misc/pilutil.py
+++ b/scipy/misc/pilutil.py
@@ -493,7 +493,7 @@ def imshow(arr):
     fnum, fname = tempfile.mkstemp('.png')
     try:
         im.save(fname)
-    except:
+    except Exception:
         raise RuntimeError("Error saving temporary image data.")
 
     import os

--- a/scipy/ndimage/morphology.py
+++ b/scipy/ndimage/morphology.py
@@ -1992,7 +1992,7 @@ def distance_transform_cdt(input, metric='chessboard', return_distances=True,
     else:
         try:
             metric = numpy.asarray(metric)
-        except:
+        except Exception:
             raise RuntimeError('invalid metric provided')
         for s in metric.shape:
             if s != 3:

--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -645,7 +645,7 @@ def _presolve(c, A_ub, b_ub, A_eq, b_eq, bounds, rr):
     if rr and A_eq.size > 0:
         try:  # TODO: instead use results of first SVD in _remove_redundancy
             rank = np.linalg.matrix_rank(A_eq)
-        except:  # oh well, we'll have to go with _remove_redundancy_dense
+        except Exception:  # oh well, we'll have to go with _remove_redundancy_dense
             rank = 0
     if rr and A_eq.size > 0 and rank < A_eq.shape[0]:
         warn(redundancy_warning, OptimizeWarning)
@@ -1172,7 +1172,7 @@ def _get_delta(
             #       umfpack and therefore cannot test its performance
             solve = sps.linalg.splu(M, permc_spec=permc_spec).solve
             splu = True
-        except:
+        except Exception:
             lstsq = True
             solve = _get_solver(sparse, lstsq, sym_pos, cholesky)
     else:
@@ -1186,7 +1186,7 @@ def _get_delta(
     if cholesky:
         try:
             L = sp.linalg.cho_factor(M)
-        except:
+        except Exception:
             cholesky = False
             solve = _get_solver(sparse, lstsq, sym_pos, cholesky)
 

--- a/scipy/optimize/_remove_redundancy.py
+++ b/scipy/optimize/_remove_redundancy.py
@@ -191,7 +191,7 @@ def _remove_redundancy_dense(A, rhs):
         try:  # fails for i==0 and any time it gets ill-conditioned
             j = b[i-1]
             lu = bg_update_dense(lu, perm_r, A[:, j], i-1)
-        except:
+        except Exception:
             lu = scipy.linalg.lu_factor(B)
             LU, p = lu
             perm_r = list(range(m))

--- a/scipy/sparse/bsr.py
+++ b/scipy/sparse/bsr.py
@@ -180,7 +180,7 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
             # must be dense
             try:
                 arg1 = np.asarray(arg1)
-            except:
+            except Exception:
                 raise ValueError("unrecognized form for"
                         " %s_matrix constructor" % self.format)
             from .coo import coo_matrix
@@ -195,7 +195,7 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
                 try:
                     M = len(self.indptr) - 1
                     N = self.indices.max() + 1
-                except:
+                except Exception:
                     raise ValueError('unable to infer matrix dimensions')
                 else:
                     R,C = self.blocksize

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -72,7 +72,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             # must be dense
             try:
                 arg1 = np.asarray(arg1)
-            except:
+            except Exception:
                 raise ValueError("unrecognized %s_matrix constructor usage" %
                         self.format)
             from .coo import coo_matrix
@@ -87,7 +87,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                 try:
                     major_dim = len(self.indptr) - 1
                     minor_dim = self.indices.max() + 1
-                except:
+                except Exception:
                     raise ValueError('unable to infer matrix dimensions')
                 else:
                     self._shape = check_shape(self._swap((major_dim,minor_dim)))

--- a/scipy/sparse/csr.py
+++ b/scipy/sparse/csr.py
@@ -242,7 +242,7 @@ class csr_matrix(_cs_matrix, IndexMixin):
                 idx_dtype = get_index_dtype((x,), check_contents=True)
                 if idx_dtype != x.dtype:
                     x = x.astype(idx_dtype)
-            except:
+            except Exception:
                 raise IndexError('invalid index')
             else:
                 return x

--- a/scipy/sparse/dia.py
+++ b/scipy/sparse/dia.py
@@ -104,7 +104,7 @@ class dia_matrix(_data_matrix):
                 try:
                     # Try interpreting it as (data, offsets)
                     data, offsets = arg1
-                except:
+                except Exception:
                     raise ValueError('unrecognized form for dia_matrix constructor')
                 else:
                     if shape is None:
@@ -118,7 +118,7 @@ class dia_matrix(_data_matrix):
             #must be dense, convert to COO first, then to DIA
             try:
                 arg1 = np.asarray(arg1)
-            except:
+            except Exception:
                 raise ValueError("unrecognized form for"
                         " %s_matrix constructor" % self.format)
             from .coo import coo_matrix

--- a/scipy/sparse/dok.py
+++ b/scipy/sparse/dok.py
@@ -101,7 +101,7 @@ class dok_matrix(spmatrix, IndexMixin, dict):
         else:  # Dense ctor
             try:
                 arg1 = np.asarray(arg1)
-            except:
+            except Exception:
                 raise TypeError('Invalid input format.')
 
             if len(arg1.shape) != 2:

--- a/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
@@ -344,7 +344,7 @@ def lobpcg(A, X,
         try:
             # gramYBY is a Cholesky factor from now on...
             gramYBY = cho_factor(gramYBY)
-        except:
+        except Exception:
             raise ValueError('cannot handle linearly dependent constraints')
 
         _applyConstraints(blockVectorX, gramYBY, blockVectorBY, blockVectorY)

--- a/scipy/sparse/sputils.py
+++ b/scipy/sparse/sputils.py
@@ -216,7 +216,7 @@ def isshape(x, nonneg=False):
     try:
         # Assume it's a tuple of matrix dimensions (M, N)
         (M, N) = x
-    except:
+    except Exception:
         return False
     else:
         if isintlike(M) and isintlike(N):

--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -592,7 +592,7 @@ def binned_statistic_dd(sample, values, statistic='mean',
             sup.filter(RuntimeWarning)
             try:
                 null = statistic([])
-            except:
+            except Exception:
                 null = np.nan
         result.fill(null)
         for i in np.unique(binnumbers):

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -463,7 +463,7 @@ def _add_axis_labels_title(plot, xlabel, ylabel, title):
             plot.title(title)
             plot.xlabel(xlabel)
             plot.ylabel(ylabel)
-    except:
+    except Exception:
         # Not an MPL object or something that looks (enough) like it.
         # Don't crash on adding labels or title
         pass


### PR DESCRIPTION
Bare `except`s are only correct when trying to capture and forward exceptions - in all other cases, `except Exception` should be used to avoid catching `KeyboardInterrupt`

This only touches the code that is user-facing, not any of the tooling or tests