### PR TITLE
BUG: sparse: use larger dtype in coo_matrix.reshape when needed

### DIFF
--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -4074,7 +4074,7 @@ class TestCOO(sparse_test_class(getset=False,
         y = x.reshape(new_shape, copy=True)
         assert_(not np.may_share_memory(y.data, x.data))
 
-    def test_large_dimensions(self):
+    def test_large_dimensions_reshape(self):
         # Test that reshape is immune to integer overflow when number of elements
         # exceeds 2^31-1
         mat1 = coo_matrix(([1], ([3000000], [1000])), (3000001, 1001))
@@ -4521,7 +4521,7 @@ def cases_64bit():
         'test_inv': 'linsolve for 64-bit indices not available',
         'test_solve': 'linsolve for 64-bit indices not available',
         'test_scalar_idx_dtype': 'test implemented in base class',
-        'test_large_dimensions': 'test actually requires 64-bit to work',
+        'test_large_dimensions_reshape': 'test actually requires 64-bit to work',
     }
 
     for cls in TEST_CLASSES:


### PR DESCRIPTION
Avoid overflows in coo_matrix.reshape by upcasting to larger integer
dtype as necessary in reshape().  Revert some changes in b8769098 that
are not necessary with this change.

It's better to do the dtype upcasts in reshape() rather than rely
nonlocally on choices made elsewhere --- there are several code paths in
__init__ that could produce matrices with overflow in reshape(), and
this preserves the old 32-bitness rules for coo_matrix. Moreover,
user code in principle can have modified the row/col index dtypes.

Generally, in the sparse matrix classes the design was to allow changing
the index dtype as necessary, so the user perhaps can expect that
`reshape` which is a fairly perturbative operation may also change them 
here.

Follow-up to gh-9087 with different place to do the dtype choice (cf https://github.com/scipy/scipy/pull/9087#issuecomment-412309260)