### PR TITLE
DOC: Add missing word

### DIFF
--- a/doc/source/tutorial/linalg.rst
+++ b/doc/source/tutorial/linalg.rst
@@ -40,9 +40,9 @@ and ``numpy.ndarray`` here.
 
 ``numpy.matrix`` is matrix class that has a more convenient interface
 than ``numpy.ndarray`` for matrix operations. This class supports for
-example MATLAB-like creation syntax via the, has matrix multiplication
-as default for the ``*`` operator, and contains ``I`` and ``T`` members
-that serve as shortcuts for inverse and transpose:
+example MATLAB-like creation syntax via the semicolon, has matrix
+multiplication as default for the ``*`` operator, and contains ``I``
+and ``T`` members that serve as shortcuts for inverse and transpose:
 
     >>> import numpy as np
     >>> A = np.mat('[1 2;3 4]')


### PR DESCRIPTION
I believe the sentence should read "MATLAB-like creation syntax via the semicolon", as in the numpy example `a = np.matrix('1 2; 3 4')`.  

I also re-wrapped the paragraph.  In hindsight that probably should've been a separate commit.  I will change and resubmit if desired.