### PR TITLE
FIX: Make scipy.odr.ODR ifixx equal to its data.fix if given

### DIFF
--- a/scipy/odr/odrpack.py
+++ b/scipy/odr/odrpack.py
@@ -742,6 +742,9 @@ class ODR(object):
         else:
             self.beta0 = _conv(beta0)
 
+        if ifixx is None and data.fix is not None:
+            ifixx = data.fix
+
         self.delta0 = _conv(delta0)
         # These really are 32-bit integers in FORTRAN (gfortran), even on 64-bit
         # platforms.

--- a/scipy/odr/tests/test_odr.py
+++ b/scipy/odr/tests/test_odr.py
@@ -344,3 +344,15 @@ class TestODR(object):
         result = job.run()
         assert_equal(result.info, 2)
 
+    def test_ifixx(self):
+        x1 = [-2.01, -0.99, -0.001, 1.02, 1.98]
+        x2 = [3.98, 1.01, 0.001, 0.998, 4.01]
+        fix = np.vstack((np.zeros_like(x1, dtype=int), np.ones_like(x2, dtype=int)))
+        data = Data(np.vstack((x1, x2)), y=1, fix=fix)
+        model = Model(lambda beta, x: x[1, :] - beta[0] * x[0, :]**2., implicit=True)
+
+        odr1 = ODR(data, model, beta0=np.array([1.]))
+        sol1 = odr1.run()
+        odr2 = ODR(data, model, beta0=np.array([1.]), ifixx=fix)
+        sol2 = odr2.run()
+        assert_equal(sol1.beta, sol2.beta)

--- a/scipy/odr/tests/test_odr.py
+++ b/scipy/odr/tests/test_odr.py
@@ -344,6 +344,8 @@ class TestODR(object):
         result = job.run()
         assert_equal(result.info, 2)
 
+    # Verify fix for gh-9140
+
     def test_ifixx(self):
         x1 = [-2.01, -0.99, -0.001, 1.02, 1.98]
         x2 = [3.98, 1.01, 0.001, 0.998, 4.01]


### PR DESCRIPTION
- `scipy.odr.ODR` objects do not make use of their given `scipy.odr.Data` object's `fix` argument, even when not given an `ifixx`.
- solves this by using `ifixx` when given, and the `data.fix` when not.

Closes #9140.