### PR TITLE
DOC: special: Mention the sigmoid function in the expit docstring.

### DIFF
--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -2263,10 +2263,11 @@ add_newdoc('scipy.special', 'expit',
     """
     expit(x)
 
-    Expit ufunc for ndarrays.
+    Expit (a.k.a. logistic sigmoid) ufunc for ndarrays.
 
-    The expit function, also known as the logistic function, is defined as
-    expit(x) = 1/(1+exp(-x)). It is the inverse of the logit function.
+    The expit function, also known as the logistic sigmoid function, is
+    defined as ``expit(x) = 1/(1+exp(-x))``.  It is the inverse of the
+    logit function.
 
     Parameters
     ----------


### PR DESCRIPTION
This function is not as well known as it should be.  Perhaps including the term "sigmoid function" in the docstring will make it more likely to be found.