### PR TITLE
better description of the hierarchical clustering parameter

### DIFF
--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -2666,8 +2666,10 @@ def fclusterdata(X, t, criterion='inconsistent',
     ----------
     X : (N, M) ndarray
         N by M data matrix with N observations in M dimensions.
-    t : float
+    t : float or int
         The threshold to apply when forming flat clusters.
+        If criterion is 'maxclust' or 'maxclust_monocrit',
+        this would be max number of clusters requested.
     criterion : str, optional
         Specifies the criterion for forming flat clusters.  Valid
         values are 'inconsistent' (default), 'distance', or 'maxclust'

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -2471,8 +2471,11 @@ def fcluster(Z, t, criterion='inconsistent', depth=2, R=None, monocrit=None):
     Z : ndarray
         The hierarchical clustering encoded with the matrix returned
         by the `linkage` function.
-    t : float
-        The threshold to apply when forming flat clusters.
+    t : float or int
+        For criteria 'inconsistent', 'distance' or 'monocrit',
+         this is the threshold to apply when forming flat clusters.
+        For 'maxclust' or 'maxclust_monocrit' criteria,
+         this would be max number of clusters requested.
     criterion : str, optional
         The criterion to use in forming flat clusters. This can
         be any of the following values:

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -2471,7 +2471,7 @@ def fcluster(Z, t, criterion='inconsistent', depth=2, R=None, monocrit=None):
     Z : ndarray
         The hierarchical clustering encoded with the matrix returned
         by the `linkage` function.
-    t : float or int
+    t : scalar
         For criteria 'inconsistent', 'distance' or 'monocrit',
          this is the threshold to apply when forming flat clusters.
         For 'maxclust' or 'maxclust_monocrit' criteria,
@@ -2669,7 +2669,7 @@ def fclusterdata(X, t, criterion='inconsistent',
     ----------
     X : (N, M) ndarray
         N by M data matrix with N observations in M dimensions.
-    t : float or int
+    t : scalar
         For criteria 'inconsistent', 'distance' or 'monocrit',
          this is the threshold to apply when forming flat clusters.
         For 'maxclust' or 'maxclust_monocrit' criteria,

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -2667,9 +2667,10 @@ def fclusterdata(X, t, criterion='inconsistent',
     X : (N, M) ndarray
         N by M data matrix with N observations in M dimensions.
     t : float or int
-        The threshold to apply when forming flat clusters.
-        If criterion is 'maxclust' or 'maxclust_monocrit',
-        this would be max number of clusters requested.
+        For criteria 'inconsistent', 'distance' or 'monocrit',
+         this is the threshold to apply when forming flat clusters.
+        For 'maxclust' or 'maxclust_monocrit' criteria,
+         this would be max number of clusters requested.
     criterion : str, optional
         Specifies the criterion for forming flat clusters.  Valid
         values are 'inconsistent' (default), 'distance', or 'maxclust'


### PR DESCRIPTION
Clarifies that `t` could be an integer specifying the max number of clusters under `maxclust*` criteria