### PR TITLE
domain check for a < b in stats.truncnorm

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -6254,7 +6254,7 @@ class truncnorm_gen(rv_continuous):
                                -(self._sb - self._sa),
                                self._nb - self._na)
         self._logdelta = np.log(self._delta)
-        return np.bitwise_and(np.not_equal(a, b), np.less(a, b))
+        return a < b
 
     def _pdf(self, x, a, b):
         return _norm_pdf(x) / self._delta

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -6254,7 +6254,7 @@ class truncnorm_gen(rv_continuous):
                                -(self._sb - self._sa),
                                self._nb - self._na)
         self._logdelta = np.log(self._delta)
-        return a != b
+        return a != b and a < b
 
     def _pdf(self, x, a, b):
         return _norm_pdf(x) / self._delta

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -6254,7 +6254,7 @@ class truncnorm_gen(rv_continuous):
                                -(self._sb - self._sa),
                                self._nb - self._na)
         self._logdelta = np.log(self._delta)
-        return a != b and a < b
+        return np.bitwise_and(np.not_equal(a, b), np.less(a, b))
 
     def _pdf(self, x, a, b):
         return _norm_pdf(x) / self._delta


### PR DESCRIPTION
I fix and a PR of the bug issued by @chrisb83.
I changed the condition formula for py_test from `a!=b and a<b` to 
`np.bitwise_and(np.not_equal(a, b), np.less(a, b))` in `_argcheck`.

Closes #9169 