### PR TITLE
DOC: correct typo in extending ndimage with C

### DIFF
--- a/doc/source/tutorial/ndimage.rst
+++ b/doc/source/tutorial/ndimage.rst
@@ -1728,7 +1728,7 @@ and now running the script
 
    user_data = ctypes.c_double(shift)
    ptr = ctypes.cast(ctypes.pointer(user_data), ctypes.c_void_p)
-   callback = LowLevelCallable(transform(), ptr)
+   callback = LowLevelCallable(get_transform(), ptr)
    im = np.arange(12).reshape(4, 3).astype(np.float64)
    print(ndimage.geometric_transform(im, callback))
 


### PR DESCRIPTION
* closes #9167 
* `LowLevelCallable` should call `get_transform()` from compiled Python extension `example.c`

Corrected output:
```python
>>> callback = LowLevelCallable(get_transform(), ptr)
>>> im = np.arange(12).reshape(4, 3).astype(np.float64)
>>> print(ndimage.geometric_transform(im, callback))

[[0.     0.     0.    ]
 [0.     1.3625 2.7375]
 [0.     4.8125 6.1875]
 [0.     8.2625 9.6375]]
```

For traceback see related issue.