### PR TITLE
ENH: Support specifying axes for fftconvolve

### DIFF
--- a/scipy/fftpack/helper.py
+++ b/scipy/fftpack/helper.py
@@ -1,7 +1,8 @@
 from __future__ import division, print_function, absolute_import
 
 import operator
-from numpy import arange
+from numpy import (arange, array, asarray, atleast_1d, intc, integer,
+                   isscalar, issubdtype, take, unique, where)
 from numpy.fft.helper import fftshift, ifftshift, fftfreq
 from bisect import bisect_left
 
@@ -151,3 +152,126 @@ def next_fast_len(target):
     if p5 < match:
         match = p5
     return match
+
+
+def _init_nd_shape_and_axes(x, shape, axes):
+    """Handle shape and axes arguments for n-dimensional transforms.
+
+    Returns the shape and axes in a standard form, taking into account negative
+    values and checking for various potential errors.
+
+    Parameters
+    ----------
+    x : array_like
+        The input array.
+    shape : int or array_like of ints or None
+        The shape of the result.  If both `shape` and `axes` (see below) are
+        None, `shape` is ``x.shape``; if `shape` is None but `axes` is
+        not None, then `shape` is ``scipy.take(x.shape, axes, axis=0)``.
+        If `shape` is -1, the size of the corresponding dimension of `x` is
+        used.
+    axes : int or array_like of ints or None
+        Axes along which the calculation is computed.
+        The default is over all axes.
+        Negative indices are automatically converted to their positive
+        counterpart.
+
+    Returns
+    -------
+    shape : array
+        The shape of the result. It is a 1D integer array.
+    axes : array
+        The shape of the result. It is a 1D integer array.
+
+    """
+    x = asarray(x)
+    noshape = shape is None
+    noaxes = axes is None
+
+    if noaxes:
+        axes = arange(x.ndim, dtype=intc)
+    else:
+        axes = atleast_1d(axes)
+
+    if axes.size == 0:
+        axes = axes.astype(intc)
+
+    if not axes.ndim == 1:
+        raise ValueError("when given, axes values must be a scalar or vector")
+    if not issubdtype(axes.dtype, integer):
+        raise ValueError("when given, axes values must be integers")
+
+    axes = where(axes < 0, axes + x.ndim, axes)
+
+    if axes.size != 0 and (axes.max() >= x.ndim or axes.min() < 0):
+        raise ValueError("axes exceeds dimensionality of input")
+    if axes.size != 0 and unique(axes).shape != axes.shape:
+        raise ValueError("all axes must be unique")
+
+    if not noshape:
+        shape = atleast_1d(shape)
+    elif isscalar(x):
+        shape = array([], dtype=intc)
+    elif noaxes:
+        shape = array(x.shape, dtype=intc)
+    else:
+        shape = take(x.shape, axes)
+
+    if shape.size == 0:
+        shape = shape.astype(intc)
+
+    if shape.ndim != 1:
+        raise ValueError("when given, shape values must be a scalar or vector")
+    if not issubdtype(shape.dtype, integer):
+        raise ValueError("when given, shape values must be integers")
+    if axes.shape != shape.shape:
+        raise ValueError("when given, axes and shape arguments"
+                         " have to be of the same length")
+
+    shape = where(shape == -1, array(x.shape)[axes], shape)
+
+    if shape.size != 0 and (shape < 1).any():
+        raise ValueError(
+            "invalid number of data points ({0}) specified".format(shape))
+
+    return shape, axes
+
+
+def _init_nd_shape_and_axes_sorted(x, shape, axes):
+    """Handle and sort shape and axes arguments for n-dimensional transforms.
+
+    This is identical to `_init_nd_shape_and_axes`, except the axes are
+    returned in sorted order and the shape is reordered to match.
+
+    Parameters
+    ----------
+    x : array_like
+        The input array.
+    shape : int or array_like of ints or None
+        The shape of the result.  If both `shape` and `axes` (see below) are
+        None, `shape` is ``x.shape``; if `shape` is None but `axes` is
+        not None, then `shape` is ``scipy.take(x.shape, axes, axis=0)``.
+        If `shape` is -1, the size of the corresponding dimension of `x` is
+        used.
+    axes : int or array_like of ints or None
+        Axes along which the calculation is computed.
+        The default is over all axes.
+        Negative indices are automatically converted to their positive
+        counterpart.
+
+    Returns
+    -------
+    shape : array
+        The shape of the result. It is a 1D integer array.
+    axes : array
+        The shape of the result. It is a 1D integer array.
+
+    """
+    noaxes = axes is None
+    shape, axes = _init_nd_shape_and_axes(x, shape, axes)
+
+    if not noaxes:
+        shape = shape[axes.argsort()]
+        axes.sort()
+
+    return shape, axes

--- a/scipy/fftpack/realtransforms.py
+++ b/scipy/fftpack/realtransforms.py
@@ -9,6 +9,7 @@ __all__ = ['dct', 'idct', 'dst', 'idst', 'dctn', 'idctn', 'dstn', 'idstn']
 import numpy as np
 from scipy.fftpack import _fftpack
 from scipy.fftpack.basic import _datacopied, _fix_shape, _asfarray
+from scipy.fftpack.helper import _init_nd_shape_and_axes
 
 import atexit
 atexit.register(_fftpack.destroy_ddct1_cache)
@@ -24,32 +25,6 @@ atexit.register(_fftpack.destroy_dst1_cache)
 atexit.register(_fftpack.destroy_dst2_cache)
 
 
-def _init_nd_shape_and_axes(x, shape, axes):
-    """Handle shape and axes arguments for dctn, idctn, dstn, idstn."""
-    if shape is None:
-        if axes is None:
-            shape = x.shape
-        else:
-            shape = np.take(x.shape, axes)
-    shape = tuple(shape)
-    for dim in shape:
-        if dim < 1:
-            raise ValueError("Invalid number of DCT data points "
-                             "(%s) specified." % (shape,))
-
-    if axes is None:
-        axes = list(range(-x.ndim, 0))
-    elif np.isscalar(axes):
-        axes = [axes, ]
-    if len(axes) != len(shape):
-        raise ValueError("when given, axes and shape arguments "
-                         "have to be of the same length")
-    if len(np.unique(axes)) != len(axes):
-        raise ValueError("All axes must be unique.")
-
-    return shape, axes
-
-
 def dctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
     """
     Return multidimensional Discrete Cosine Transform along the specified axes.
@@ -60,15 +35,18 @@ def dctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
         The input array.
     type : {1, 2, 3, 4}, optional
         Type of the DCT (see Notes). Default type is 2.
-    shape : tuple of ints, optional
+    shape : int or array_like of ints or None, optional
         The shape of the result.  If both `shape` and `axes` (see below) are
         None, `shape` is ``x.shape``; if `shape` is None but `axes` is
         not None, then `shape` is ``scipy.take(x.shape, axes, axis=0)``.
         If ``shape[i] > x.shape[i]``, the i-th dimension is padded with zeros.
         If ``shape[i] < x.shape[i]``, the i-th dimension is truncated to
         length ``shape[i]``.
-    axes : tuple or None, optional
-        Axes along which the DCT is computed; the default is over all axes.
+        If any element of `shape` is -1, the size of the corresponding
+        dimension of `x` is used.
+    axes : int or array_like of ints or None, optional
+        Axes along which the DCT is computed.
+        The default is over all axes.
     norm : {None, 'ortho'}, optional
         Normalization mode (see Notes). Default is None.
     overwrite_x : bool, optional
@@ -113,15 +91,18 @@ def idctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
         The input array.
     type : {1, 2, 3, 4}, optional
         Type of the DCT (see Notes). Default type is 2.
-    shape : tuple of ints, optional
+    shape : int or array_like of ints or None, optional
         The shape of the result.  If both `shape` and `axes` (see below) are
         None, `shape` is ``x.shape``; if `shape` is None but `axes` is
         not None, then `shape` is ``scipy.take(x.shape, axes, axis=0)``.
         If ``shape[i] > x.shape[i]``, the i-th dimension is padded with zeros.
         If ``shape[i] < x.shape[i]``, the i-th dimension is truncated to
         length ``shape[i]``.
-    axes : tuple or None, optional
-        Axes along which the IDCT is computed; the default is over all axes.
+        If any element of `shape` is -1, the size of the corresponding
+        dimension of `x` is used.
+    axes : int or array_like of ints or None, optional
+        Axes along which the IDCT is computed.
+        The default is over all axes.
     norm : {None, 'ortho'}, optional
         Normalization mode (see Notes). Default is None.
     overwrite_x : bool, optional
@@ -147,6 +128,7 @@ def idctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
     >>> y = np.random.randn(16, 16)
     >>> np.allclose(y, idctn(dctn(y, norm='ortho'), norm='ortho'))
     True
+
     """
     x = np.asanyarray(x)
     shape, axes = _init_nd_shape_and_axes(x, shape, axes)
@@ -166,15 +148,18 @@ def dstn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
         The input array.
     type : {1, 2, 3, 4}, optional
         Type of the DCT (see Notes). Default type is 2.
-    shape : tuple of ints, optional
+    shape : int or array_like of ints or None, optional
         The shape of the result.  If both `shape` and `axes` (see below) are
         None, `shape` is ``x.shape``; if `shape` is None but `axes` is
         not None, then `shape` is ``scipy.take(x.shape, axes, axis=0)``.
         If ``shape[i] > x.shape[i]``, the i-th dimension is padded with zeros.
         If ``shape[i] < x.shape[i]``, the i-th dimension is truncated to
         length ``shape[i]``.
-    axes : tuple or None, optional
-        Axes along which the DCT is computed; the default is over all axes.
+        If any element of `shape` is -1, the size of the corresponding
+        dimension of `x` is used.
+    axes : int or array_like of ints or None, optional
+        Axes along which the DCT is computed.
+        The default is over all axes.
     norm : {None, 'ortho'}, optional
         Normalization mode (see Notes). Default is None.
     overwrite_x : bool, optional
@@ -219,15 +204,18 @@ def idstn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
         The input array.
     type : {1, 2, 3, 4}, optional
         Type of the DCT (see Notes). Default type is 2.
-    shape : tuple of ints, optional
+    shape : int or array_like of ints or None, optional
         The shape of the result.  If both `shape` and `axes` (see below) are
         None, `shape` is ``x.shape``; if `shape` is None but `axes` is
         not None, then `shape` is ``scipy.take(x.shape, axes, axis=0)``.
         If ``shape[i] > x.shape[i]``, the i-th dimension is padded with zeros.
         If ``shape[i] < x.shape[i]``, the i-th dimension is truncated to
         length ``shape[i]``.
-    axes : tuple or None, optional
-        Axes along which the IDCT is computed; the default is over all axes.
+        If any element of `shape` is -1, the size of the corresponding
+        dimension of `x` is used.
+    axes : int or array_like of ints or None, optional
+        Axes along which the IDCT is computed.
+        The default is over all axes.
     norm : {None, 'ortho'}, optional
         Normalization mode (see Notes). Default is None.
     overwrite_x : bool, optional
@@ -253,6 +241,7 @@ def idstn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
     >>> y = np.random.randn(16, 16)
     >>> np.allclose(y, idstn(dstn(y, norm='ortho'), norm='ortho'))
     True
+
     """
     x = np.asanyarray(x)
     shape, axes = _init_nd_shape_and_axes(x, shape, axes)

--- a/scipy/fftpack/tests/test_helper.py
+++ b/scipy/fftpack/tests/test_helper.py
@@ -11,10 +11,12 @@ Run tests if fftpack is not installed:
   python tests/test_helper.py [<level>]
 """
 
-from numpy.testing import (assert_array_almost_equal,
-                           assert_equal, assert_)
+from pytest import raises as assert_raises
+from numpy.testing import assert_array_almost_equal, assert_equal, assert_
 from scipy.fftpack import fftshift,ifftshift,fftfreq,rfftfreq
-from scipy.fftpack.helper import next_fast_len
+from scipy.fftpack.helper import (next_fast_len,
+                                  _init_nd_shape_and_axes,
+                                  _init_nd_shape_and_axes_sorted)
 
 from numpy import pi, random
 import numpy as np
@@ -166,3 +168,249 @@ class TestNextOptLen(object):
         for x, y in hams.items():
             assert_equal(next_fast_len(x), y)
 
+
+class Test_init_nd_shape_and_axes(object):
+
+    def test_py_0d_defaults(self):
+        x = 4
+        shape = None
+        axes = None
+
+        shape_expected = np.array([])
+        axes_expected = np.array([])
+
+        shape_res, axes_res = _init_nd_shape_and_axes(x, shape, axes)
+
+        assert_equal(shape_res, shape_expected)
+        assert_equal(axes_res, axes_expected)
+
+        shape_res, axes_res = _init_nd_shape_and_axes_sorted(x, shape, axes)
+
+        assert_equal(shape_res, shape_expected)
+        assert_equal(axes_res, axes_expected)
+
+    def test_np_0d_defaults(self):
+        x = np.array(7.)
+        shape = None
+        axes = None
+
+        shape_expected = np.array([])
+        axes_expected = np.array([])
+
+        shape_res, axes_res = _init_nd_shape_and_axes(x, shape, axes)
+
+        assert_equal(shape_res, shape_expected)
+        assert_equal(axes_res, axes_expected)
+
+        shape_res, axes_res = _init_nd_shape_and_axes_sorted(x, shape, axes)
+
+        assert_equal(shape_res, shape_expected)
+        assert_equal(axes_res, axes_expected)
+
+    def test_py_1d_defaults(self):
+        x = [1, 2, 3]
+        shape = None
+        axes = None
+
+        shape_expected = np.array([3])
+        axes_expected = np.array([0])
+
+        shape_res, axes_res = _init_nd_shape_and_axes(x, shape, axes)
+
+        assert_equal(shape_res, shape_expected)
+        assert_equal(axes_res, axes_expected)
+
+        shape_res, axes_res = _init_nd_shape_and_axes_sorted(x, shape, axes)
+
+        assert_equal(shape_res, shape_expected)
+        assert_equal(axes_res, axes_expected)
+
+    def test_np_1d_defaults(self):
+        x = np.arange(0, 1, .1)
+        shape = None
+        axes = None
+
+        shape_expected = np.array([10])
+        axes_expected = np.array([0])
+
+        shape_res, axes_res = _init_nd_shape_and_axes(x, shape, axes)
+
+        assert_equal(shape_res, shape_expected)
+        assert_equal(axes_res, axes_expected)
+
+        shape_res, axes_res = _init_nd_shape_and_axes_sorted(x, shape, axes)
+
+        assert_equal(shape_res, shape_expected)
+        assert_equal(axes_res, axes_expected)
+
+    def test_py_2d_defaults(self):
+        x = [[1, 2, 3, 4],
+             [5, 6, 7, 8]]
+        shape = None
+        axes = None
+
+        shape_expected = np.array([2, 4])
+        axes_expected = np.array([0, 1])
+
+        shape_res, axes_res = _init_nd_shape_and_axes(x, shape, axes)
+
+        assert_equal(shape_res, shape_expected)
+        assert_equal(axes_res, axes_expected)
+
+        shape_res, axes_res = _init_nd_shape_and_axes_sorted(x, shape, axes)
+
+        assert_equal(shape_res, shape_expected)
+        assert_equal(axes_res, axes_expected)
+
+    def test_np_2d_defaults(self):
+        x = np.arange(0, 1, .1).reshape(5, 2)
+        shape = None
+        axes = None
+
+        shape_expected = np.array([5, 2])
+        axes_expected = np.array([0, 1])
+
+        shape_res, axes_res = _init_nd_shape_and_axes(x, shape, axes)
+
+        assert_equal(shape_res, shape_expected)
+        assert_equal(axes_res, axes_expected)
+
+        shape_res, axes_res = _init_nd_shape_and_axes_sorted(x, shape, axes)
+
+        assert_equal(shape_res, shape_expected)
+        assert_equal(axes_res, axes_expected)
+
+    def test_np_5d_defaults(self):
+        x = np.zeros([6, 2, 5, 3, 4])
+        shape = None
+        axes = None
+
+        shape_expected = np.array([6, 2, 5, 3, 4])
+        axes_expected = np.array([0, 1, 2, 3, 4])
+
+        shape_res, axes_res = _init_nd_shape_and_axes(x, shape, axes)
+
+        assert_equal(shape_res, shape_expected)
+        assert_equal(axes_res, axes_expected)
+
+        shape_res, axes_res = _init_nd_shape_and_axes_sorted(x, shape, axes)
+
+        assert_equal(shape_res, shape_expected)
+        assert_equal(axes_res, axes_expected)
+
+    def test_np_5d_set_shape(self):
+        x = np.zeros([6, 2, 5, 3, 4])
+        shape = [10, -1, -1, 1, 4]
+        axes = None
+
+        shape_expected = np.array([10, 2, 5, 1, 4])
+        axes_expected = np.array([0, 1, 2, 3, 4])
+
+        shape_res, axes_res = _init_nd_shape_and_axes(x, shape, axes)
+
+        assert_equal(shape_res, shape_expected)
+        assert_equal(axes_res, axes_expected)
+
+        shape_res, axes_res = _init_nd_shape_and_axes_sorted(x, shape, axes)
+
+        assert_equal(shape_res, shape_expected)
+        assert_equal(axes_res, axes_expected)
+
+    def test_np_5d_set_axes(self):
+        x = np.zeros([6, 2, 5, 3, 4])
+        shape = None
+        axes = [4, 1, 2]
+
+        shape_expected = np.array([4, 2, 5])
+        axes_expected = np.array([4, 1, 2])
+
+        shape_res, axes_res = _init_nd_shape_and_axes(x, shape, axes)
+
+        assert_equal(shape_res, shape_expected)
+        assert_equal(axes_res, axes_expected)
+
+    def test_np_5d_set_axes_sorted(self):
+        x = np.zeros([6, 2, 5, 3, 4])
+        shape = None
+        axes = [4, 1, 2]
+
+        shape_expected = np.array([2, 5, 4])
+        axes_expected = np.array([1, 2, 4])
+
+        shape_res, axes_res = _init_nd_shape_and_axes_sorted(x, shape, axes)
+
+        assert_equal(shape_res, shape_expected)
+        assert_equal(axes_res, axes_expected)
+
+    def test_np_5d_set_shape_axes(self):
+        x = np.zeros([6, 2, 5, 3, 4])
+        shape = [10, -1, 2]
+        axes = [1, 0, 3]
+
+        shape_expected = np.array([10, 6, 2])
+        axes_expected = np.array([1, 0, 3])
+
+        shape_res, axes_res = _init_nd_shape_and_axes(x, shape, axes)
+
+        assert_equal(shape_res, shape_expected)
+        assert_equal(axes_res, axes_expected)
+
+    def test_np_5d_set_shape_axes_sorted(self):
+        x = np.zeros([6, 2, 5, 3, 4])
+        shape = [10, -1, 2]
+        axes = [1, 0, 3]
+
+        shape_expected = np.array([6, 10, 2])
+        axes_expected = np.array([0, 1, 3])
+
+        shape_res, axes_res = _init_nd_shape_and_axes_sorted(x, shape, axes)
+
+        assert_equal(shape_res, shape_expected)
+        assert_equal(axes_res, axes_expected)
+
+    def test_errors(self):
+        with assert_raises(ValueError,
+                           match="when given, axes values must be a scalar"
+                           " or vector"):
+            _init_nd_shape_and_axes([0], shape=None, axes=[[1, 2], [3, 4]])
+
+        with assert_raises(ValueError,
+                           match="when given, axes values must be integers"):
+            _init_nd_shape_and_axes([0], shape=None, axes=[1., 2., 3., 4.])
+
+        with assert_raises(ValueError,
+                           match="axes exceeds dimensionality of input"):
+            _init_nd_shape_and_axes([0], shape=None, axes=[1])
+
+        with assert_raises(ValueError,
+                           match="axes exceeds dimensionality of input"):
+            _init_nd_shape_and_axes([0], shape=None, axes=[-2])
+
+        with assert_raises(ValueError,
+                           match="all axes must be unique"):
+            _init_nd_shape_and_axes([0], shape=None, axes=[0, 0])
+
+        with assert_raises(ValueError,
+                           match="when given, shape values must be a scalar "
+                           "or vector"):
+            _init_nd_shape_and_axes([0], shape=[[1, 2], [3, 4]], axes=None)
+
+        with assert_raises(ValueError,
+                           match="when given, shape values must be integers"):
+            _init_nd_shape_and_axes([0], shape=[1., 2., 3., 4.], axes=None)
+
+        with assert_raises(ValueError,
+                           match="when given, axes and shape arguments"
+                           " have to be of the same length"):
+            _init_nd_shape_and_axes(np.zeros([1, 1, 1, 1]),
+                                    shape=[1, 2, 3], axes=[1])
+
+        with assert_raises(ValueError,
+                           match="invalid number of data points"
+                           r" \(\[0\]\) specified"):
+            _init_nd_shape_and_axes([0], shape=[0], axes=None)
+
+        with assert_raises(ValueError,
+                           match="invalid number of data points"
+                           r" \(\[-2\]\) specified"):
+            _init_nd_shape_and_axes([0], shape=-2, axes=None)

--- a/scipy/fftpack/tests/test_real_transforms.py
+++ b/scipy/fftpack/tests/test_real_transforms.py
@@ -4,6 +4,7 @@ from os.path import join, dirname
 
 import numpy as np
 from numpy.testing import assert_array_almost_equal, assert_equal
+import pytest
 from pytest import raises as assert_raises
 
 from scipy.fftpack.realtransforms import (
@@ -51,7 +52,7 @@ def fftw_dst_ref(type, size, dt):
 
 
 def dct_2d_ref(x, **kwargs):
-    """ used as a reference in testing dct2. """
+    """Calculate reference values for testing dct2."""
     x = np.array(x, copy=True)
     for row in range(x.shape[0]):
         x[row, :] = dct(x[row, :], **kwargs)
@@ -61,7 +62,7 @@ def dct_2d_ref(x, **kwargs):
 
 
 def idct_2d_ref(x, **kwargs):
-    """ used as a reference in testing idct2. """
+    """Calculate reference values for testing idct2."""
     x = np.array(x, copy=True)
     for row in range(x.shape[0]):
         x[row, :] = idct(x[row, :], **kwargs)
@@ -71,7 +72,7 @@ def idct_2d_ref(x, **kwargs):
 
 
 def dst_2d_ref(x, **kwargs):
-    """ used as a reference in testing dst2. """
+    """Calculate reference values for testing dst2."""
     x = np.array(x, copy=True)
     for row in range(x.shape[0]):
         x[row, :] = dst(x[row, :], **kwargs)
@@ -81,7 +82,7 @@ def dst_2d_ref(x, **kwargs):
 
 
 def idst_2d_ref(x, **kwargs):
-    """ used as a reference in testing idst2. """
+    """Calculate reference values for testing idst2."""
     x = np.array(x, copy=True)
     for row in range(x.shape[0]):
         x[row, :] = idst(x[row, :], **kwargs)
@@ -89,18 +90,19 @@ def idst_2d_ref(x, **kwargs):
         x[:, col] = idst(x[:, col], **kwargs)
     return x
 
+
 def naive_dct1(x, norm=None):
-    """ textbook definition of DCT-I """
+    """Calculate textbook definition version of DCT-I."""
     x = np.array(x, copy=True)
     N = len(x)
     M = N-1
     y = np.zeros(N)
-    m0,m = 1,2
+    m0, m = 1, 2
     if norm == 'ortho':
         m0 = np.sqrt(1.0/M)
         m = np.sqrt(2.0/M)
     for k in range(N):
-        for n in range(1,N-1):
+        for n in range(1, N-1):
             y[k] += m*x[n]*np.cos(np.pi*n*k/M)
         y[k] += m0 * x[0]
         y[k] += m0 * x[N-1] * (1 if k % 2 == 0 else -1)
@@ -109,8 +111,9 @@ def naive_dct1(x, norm=None):
         y[N-1] *= 1/np.sqrt(2)
     return y
 
+
 def naive_dst1(x, norm=None):
-    """ textbook definition of DST-I """
+    """Calculate textbook definition version  of DST-I."""
     x = np.array(x, copy=True)
     N = len(x)
     M = N+1
@@ -122,8 +125,9 @@ def naive_dst1(x, norm=None):
         y *= np.sqrt(0.5/M)
     return y
 
+
 def naive_dct4(x, norm=None):
-    """ textbook definition of DCT-IV """
+    """Calculate textbook definition version  of DCT-IV."""
     x = np.array(x, copy=True)
     N = len(x)
     y = np.zeros(N)
@@ -136,8 +140,9 @@ def naive_dct4(x, norm=None):
         y *= 2
     return y
 
+
 def naive_dst4(x, norm=None):
-    """ textbook definition of DST-IV """
+    """Calculate textbook definition version  of DST-IV."""
     x = np.array(x, copy=True)
     N = len(x)
     y = np.zeros(N)
@@ -149,6 +154,7 @@ def naive_dst4(x, norm=None):
     else:
         y *= 2
     return y
+
 
 class TestComplex(object):
     def test_dct_complex64(self):
@@ -685,7 +691,7 @@ class TestIDSTIVnt(_TestIDSTBase):
 
 
 class TestOverwrite(object):
-    """Check input overwrite behavior """
+    """Check input overwrite behavior."""
 
     real_dtypes = [np.float32, np.float64]
 
@@ -749,82 +755,75 @@ class TestOverwrite(object):
 
 class Test_DCTN_IDCTN(object):
     dec = 14
-    types = [1, 2, 3, 4]
+    dct_type = [1, 2, 3, 4]
     norms = [None, 'ortho']
     rstate = np.random.RandomState(1234)
     shape = (32, 16)
     data = rstate.randn(*shape)
-    # Sets of functions to test
-    function_sets = [dict(forward=dctn,
-                          inverse=idctn,
-                          forward_ref=dct_2d_ref,
-                          inverse_ref=idct_2d_ref),
-                     dict(forward=dstn,
-                          inverse=idstn,
-                          forward_ref=dst_2d_ref,
-                          inverse_ref=idst_2d_ref), ]
 
-    def test_axes_round_trip(self):
-        norm = 'ortho'
-        for function_set in self.function_sets:
-            fforward = function_set['forward']
-            finverse = function_set['inverse']
-            for axes in [None, (1, ), (0, ), (0, 1), (-2, -1)]:
-                for dct_type in self.types:
-                    tmp = fforward(self.data, type=dct_type, axes=axes,
-                                   norm=norm)
-                    tmp = finverse(tmp, type=dct_type, axes=axes, norm=norm)
-                    assert_array_almost_equal(self.data, tmp, decimal=12)
+    @pytest.mark.parametrize('fforward,finverse', [(dctn, idctn),
+                                                   (dstn, idstn)])
+    @pytest.mark.parametrize('axes', [None,
+                                      1, (1,), [1],
+                                      0, (0,), [0],
+                                      (0, 1), [0, 1],
+                                      (-2, -1), [-2, -1]])
+    @pytest.mark.parametrize('dct_type', dct_type)
+    @pytest.mark.parametrize('norm', ['ortho'])
+    def test_axes_round_trip(self, fforward, finverse, axes, dct_type, norm):
+        tmp = fforward(self.data, type=dct_type, axes=axes, norm=norm)
+        tmp = finverse(tmp, type=dct_type, axes=axes, norm=norm)
+        assert_array_almost_equal(self.data, tmp, decimal=12)
 
-    def test_dctn_vs_2d_reference(self):
-        for function_set in self.function_sets:
-            fforward = function_set['forward']
-            fforward_ref = function_set['forward_ref']
-            for dct_type in self.types:
-                for norm in self.norms:
-                    y1 = fforward(self.data, type=dct_type, axes=None,
-                                  norm=norm)
-                    y2 = fforward_ref(self.data, type=dct_type, norm=norm)
-                    assert_array_almost_equal(y1, y2, decimal=11)
+    @pytest.mark.parametrize('fforward,fforward_ref', [(dctn, dct_2d_ref),
+                                                       (dstn, dst_2d_ref)])
+    @pytest.mark.parametrize('dct_type', dct_type)
+    @pytest.mark.parametrize('norm', norms)
+    def test_dctn_vs_2d_reference(self, fforward, fforward_ref,
+                                  dct_type, norm):
+        y1 = fforward(self.data, type=dct_type, axes=None, norm=norm)
+        y2 = fforward_ref(self.data, type=dct_type, norm=norm)
+        assert_array_almost_equal(y1, y2, decimal=11)
 
-    def test_idctn_vs_2d_reference(self):
-        for function_set in self.function_sets:
-            finverse = function_set['inverse']
-            finverse_ref = function_set['inverse_ref']
-            for dct_type in self.types:
-                for norm in self.norms:
-                    print(function_set, dct_type, norm)
-                    fdata = dctn(self.data, type=dct_type, norm=norm)
-                    y1 = finverse(fdata, type=dct_type, norm=norm)
-                    y2 = finverse_ref(fdata, type=dct_type, norm=norm)
-                    assert_array_almost_equal(y1, y2, decimal=11)
+    @pytest.mark.parametrize('finverse,finverse_ref', [(idctn, idct_2d_ref),
+                                                       (idstn, idst_2d_ref)])
+    @pytest.mark.parametrize('dct_type', dct_type)
+    @pytest.mark.parametrize('norm', [None, 'ortho'])
+    def test_idctn_vs_2d_reference(self, finverse, finverse_ref,
+                                   dct_type, norm):
+        fdata = dctn(self.data, type=dct_type, norm=norm)
+        y1 = finverse(fdata, type=dct_type, norm=norm)
+        y2 = finverse_ref(fdata, type=dct_type, norm=norm)
+        assert_array_almost_equal(y1, y2, decimal=11)
 
-    def test_axes_and_shape(self):
-        for function_set in self.function_sets:
-            fforward = function_set['forward']
-            finverse = function_set['inverse']
+    @pytest.mark.parametrize('fforward,finverse', [(dctn, idctn),
+                                                   (dstn, idstn)])
+    def test_axes_and_shape(self, fforward, finverse):
+        with assert_raises(ValueError,
+                           match="when given, axes and shape arguments"
+                           " have to be of the same length"):
+            fforward(self.data, shape=self.data.shape[0], axes=(0, 1))
 
-            # shape must match the number of axes
-            assert_raises(ValueError, fforward, self.data,
-                          shape=(self.data.shape[0], ),
-                          axes=(0, 1))
-            assert_raises(ValueError, fforward, self.data,
-                          shape=(self.data.shape[0], ),
-                          axes=None)
-            assert_raises(ValueError, fforward, self.data,
-                          shape=self.data.shape,
-                          axes=(0, ))
-            # shape must be a tuple
-            assert_raises(TypeError, fforward, self.data,
-                          shape=self.data.shape[0],
-                          axes=(0, 1))
+        with assert_raises(ValueError,
+                           match="when given, axes and shape arguments"
+                           " have to be of the same length"):
+            fforward(self.data, shape=self.data.shape[0], axes=None)
 
-            # shape=None works with a subset of axes
-            for axes in [(0, ), (1, )]:
-                tmp = fforward(self.data, shape=None, axes=axes, norm='ortho')
-                tmp = finverse(tmp, shape=None, axes=axes, norm='ortho')
-                assert_array_almost_equal(self.data, tmp, decimal=self.dec)
+        with assert_raises(ValueError,
+                           match="when given, axes and shape arguments"
+                           " have to be of the same length"):
+            fforward(self.data, shape=self.data.shape, axes=0)
 
-            # non-default shape
-            tmp = fforward(self.data, shape=(128, 128), axes=None)
-            assert_equal(tmp.shape, (128, 128))
+    @pytest.mark.parametrize('fforward', [dctn, dstn])
+    def test_shape(self, fforward):
+        tmp = fforward(self.data, shape=(128, 128), axes=None)
+        assert_equal(tmp.shape, (128, 128))
+
+    @pytest.mark.parametrize('fforward,finverse', [(dctn, idctn),
+                                                   (dstn, idstn)])
+    @pytest.mark.parametrize('axes', [1, (1,), [1],
+                                      0, (0,), [0]])
+    def test_shape_is_none_with_axes(self, fforward, finverse, axes):
+        tmp = fforward(self.data, shape=None, axes=axes, norm='ortho')
+        tmp = finverse(tmp, shape=None, axes=axes, norm='ortho')
+        assert_array_almost_equal(self.data, tmp, decimal=self.dec)

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -13,6 +13,7 @@ from ._upfirdn import upfirdn, _output_len
 from scipy._lib.six import callable
 from scipy._lib._version import NumpyVersion
 from scipy import fftpack, linalg
+from scipy.fftpack.helper import _init_nd_shape_and_axes_sorted
 from numpy import (allclose, angle, arange, argsort, array, asarray,
                    atleast_1d, atleast_2d, cast, dot, exp, expand_dims,
                    iscomplexobj, mean, ndarray, newaxis, ones, pi,
@@ -278,7 +279,7 @@ def _centered(arr, newshape):
     return arr[tuple(myslice)]
 
 
-def fftconvolve(in1, in2, mode="full"):
+def fftconvolve(in1, in2, mode="full", axes=None):
     """Convolve two N-dimensional arrays using FFT.
 
     Convolve `in1` and `in2` using the fast Fourier transform method, with
@@ -310,6 +311,11 @@ def fftconvolve(in1, in2, mode="full"):
         ``same``
            The output is the same size as `in1`, centered
            with respect to the 'full' output.
+           axis : tuple, optional
+    axes : int or array_like of ints or None, optional
+        Axes over which to compute the convolution.
+        The default is over all axes.
+
 
     Returns
     -------
@@ -360,19 +366,37 @@ def fftconvolve(in1, in2, mode="full"):
     """
     in1 = asarray(in1)
     in2 = asarray(in2)
+    noaxes = axes is None
 
     if in1.ndim == in2.ndim == 0:  # scalar inputs
         return in1 * in2
-    elif not in1.ndim == in2.ndim:
+    elif in1.ndim != in2.ndim:
         raise ValueError("in1 and in2 should have the same dimensionality")
     elif in1.size == 0 or in2.size == 0:  # empty arrays
         return array([])
 
+    _, axes = _init_nd_shape_and_axes_sorted(in1, shape=None, axes=axes)
+
+    if not noaxes and not axes.size:
+        raise ValueError("when provided, axes cannot be empty")
+
+    if noaxes:
+        other_axes = array([], dtype=np.intc)
+    else:
+        other_axes = np.setdiff1d(np.arange(in1.ndim), axes)
+
     s1 = array(in1.shape)
     s2 = array(in2.shape)
-    complex_result = (np.issubdtype(in1.dtype, np.complexfloating) or
-                      np.issubdtype(in2.dtype, np.complexfloating))
-    shape = s1 + s2 - 1
+
+    if not np.all((s1[other_axes] == s2[other_axes])
+                  | (s1[other_axes] == 1) | (s2[other_axes] == 1)):
+        raise ValueError("incompatible shapes for in1 and in2:"
+                         " {0} and {1}".format(in1.shape, in2.shape))
+
+    complex_result = (np.issubdtype(in1.dtype, np.complexfloating)
+                      or np.issubdtype(in2.dtype, np.complexfloating))
+    shape = np.maximum(s1, s2)
+    shape[axes] = s1[axes] + s2[axes] - 1
 
     # Check that input sizes are compatible with 'valid' mode
     if _inputs_swap_needed(mode, s1, s2):
@@ -380,15 +404,15 @@ def fftconvolve(in1, in2, mode="full"):
         in1, s1, in2, s2 = in2, s2, in1, s1
 
     # Speed up FFT by padding to optimal size for FFTPACK
-    fshape = [fftpack.helper.next_fast_len(int(d)) for d in shape]
-    fslice = tuple([slice(0, int(sz)) for sz in shape])
+    fshape = [fftpack.helper.next_fast_len(d) for d in shape[axes]]
+    fslice = tuple([slice(sz) for sz in shape])
     # Pre-1.9 NumPy FFT routines are not threadsafe.  For older NumPys, make
     # sure we only call rfftn/irfftn from one thread at a time.
     if not complex_result and (_rfft_mt_safe or _rfft_lock.acquire(False)):
         try:
-            sp1 = np.fft.rfftn(in1, fshape)
-            sp2 = np.fft.rfftn(in2, fshape)
-            ret = (np.fft.irfftn(sp1 * sp2, fshape)[fslice].copy())
+            sp1 = np.fft.rfftn(in1, fshape, axes=axes)
+            sp2 = np.fft.rfftn(in2, fshape, axes=axes)
+            ret = np.fft.irfftn(sp1 * sp2, fshape, axes=axes)[fslice].copy()
         finally:
             if not _rfft_mt_safe:
                 _rfft_lock.release()
@@ -397,9 +421,9 @@ def fftconvolve(in1, in2, mode="full"):
         # failed to acquire _rfft_lock (meaning rfftn isn't threadsafe and
         # is already in use by another thread).  In either case, use the
         # (threadsafe but slower) SciPy complex-FFT routines instead.
-        sp1 = fftpack.fftn(in1, fshape)
-        sp2 = fftpack.fftn(in2, fshape)
-        ret = fftpack.ifftn(sp1 * sp2)[fslice].copy()
+        sp1 = fftpack.fftn(in1, fshape, axes=axes)
+        sp2 = fftpack.fftn(in2, fshape, axes=axes)
+        ret = fftpack.ifftn(sp1 * sp2, axes=axes)[fslice].copy()
         if not complex_result:
             ret = ret.real
 
@@ -408,10 +432,12 @@ def fftconvolve(in1, in2, mode="full"):
     elif mode == "same":
         return _centered(ret, s1)
     elif mode == "valid":
-        return _centered(ret, s1 - s2 + 1)
+        shape_valid = shape.copy()
+        shape_valid[axes] = s1[axes] - s2[axes] + 1
+        return _centered(ret, shape_valid)
     else:
-        raise ValueError("Acceptable mode flags are 'valid',"
-                         " 'same', or 'full'.")
+        raise ValueError("acceptable mode flags are 'valid',"
+                         " 'same', or 'full'")
 
 
 def _numeric_arrays(arrays, kinds='buifc'):

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -403,77 +403,247 @@ class TestConvolve2d(_TestConvolve2d):
 
 class TestFFTConvolve(object):
 
-    def test_real(self):
-        x = array([1, 2, 3])
-        assert_array_almost_equal(signal.fftconvolve(x, x), [1, 4, 10, 12, 9.])
+    @pytest.mark.parametrize('axes', ['', None, 0, [0], -1, [-1]])
+    def test_real(self, axes):
+        a = array([1, 2, 3])
+        expected = array([1, 4, 10, 12, 9.])
 
-    def test_complex(self):
-        x = array([1 + 1j, 2 + 2j, 3 + 3j])
-        assert_array_almost_equal(signal.fftconvolve(x, x),
-                                  [0 + 2j, 0 + 8j, 0 + 20j, 0 + 24j, 0 + 18j])
+        if axes == '':
+            out = fftconvolve(a, a)
+        else:
+            out = fftconvolve(a, a, axes=axes)
 
-    def test_2d_real_same(self):
-        a = array([[1, 2, 3], [4, 5, 6]])
-        assert_array_almost_equal(signal.fftconvolve(a, a),
-                                  array([[1, 4, 10, 12, 9],
-                                         [8, 26, 56, 54, 36],
-                                         [16, 40, 73, 60, 36]]))
+        assert_array_almost_equal(out, expected)
 
-    def test_2d_complex_same(self):
-        a = array([[1 + 2j, 3 + 4j, 5 + 6j], [2 + 1j, 4 + 3j, 6 + 5j]])
-        c = fftconvolve(a, a)
-        d = array([[-3 + 4j, -10 + 20j, -21 + 56j, -18 + 76j, -11 + 60j],
-                   [10j, 44j, 118j, 156j, 122j],
-                   [3 + 4j, 10 + 20j, 21 + 56j, 18 + 76j, 11 + 60j]])
-        assert_array_almost_equal(c, d)
+    @pytest.mark.parametrize('axes', [1, [1], -1, [-1]])
+    def test_real_axes(self, axes):
+        a = array([1, 2, 3])
+        expected = array([1, 4, 10, 12, 9.])
 
-    def test_real_same_mode(self):
+        a = np.tile(a, [2, 1])
+        expected = np.tile(expected, [2, 1])
+
+        out = fftconvolve(a, a, axes=axes)
+        assert_array_almost_equal(out, expected)
+
+    @pytest.mark.parametrize('axes', ['', None, 0, [0], -1, [-1]])
+    def test_complex(self, axes):
+        a = array([1 + 1j, 2 + 2j, 3 + 3j])
+        expected = array([0 + 2j, 0 + 8j, 0 + 20j, 0 + 24j, 0 + 18j])
+
+        if axes == '':
+            out = fftconvolve(a, a)
+        else:
+            out = fftconvolve(a, a, axes=axes)
+        assert_array_almost_equal(out, expected)
+
+    @pytest.mark.parametrize('axes', [1, [1], -1, [-1]])
+    def test_complex_axes(self, axes):
+        a = array([1 + 1j, 2 + 2j, 3 + 3j])
+        expected = array([0 + 2j, 0 + 8j, 0 + 20j, 0 + 24j, 0 + 18j])
+
+        a = np.tile(a, [2, 1])
+        expected = np.tile(expected, [2, 1])
+
+        out = fftconvolve(a, a, axes=axes)
+        assert_array_almost_equal(out, expected)
+
+    @pytest.mark.parametrize('axes', ['',
+                                      None,
+                                      [0, 1],
+                                      [1, 0],
+                                      [0, -1],
+                                      [-1, 0],
+                                      [-2, 1],
+                                      [1, -2],
+                                      [-2, -1],
+                                      [-1, -2]])
+    def test_2d_real_same(self, axes):
+        a = array([[1, 2, 3],
+                   [4, 5, 6]])
+        expected = array([[1, 4, 10, 12, 9],
+                          [8, 26, 56, 54, 36],
+                          [16, 40, 73, 60, 36]])
+
+        if axes == '':
+            out = fftconvolve(a, a)
+        else:
+            out = fftconvolve(a, a, axes=axes)
+        assert_array_almost_equal(out, expected)
+
+    @pytest.mark.parametrize('axes', [[1, 2],
+                                      [2, 1],
+                                      [1, -1],
+                                      [-1, 1],
+                                      [-2, 2],
+                                      [2, -2],
+                                      [-2, -1],
+                                      [-1, -2]])
+    def test_2d_real_same_axes(self, axes):
+        a = array([[1, 2, 3],
+                   [4, 5, 6]])
+        expected = array([[1, 4, 10, 12, 9],
+                          [8, 26, 56, 54, 36],
+                          [16, 40, 73, 60, 36]])
+
+        a = np.tile(a, [2, 1, 1])
+        expected = np.tile(expected, [2, 1, 1])
+
+        out = fftconvolve(a, a, axes=axes)
+        assert_array_almost_equal(out, expected)
+
+    @pytest.mark.parametrize('axes', ['',
+                                      None,
+                                      [0, 1],
+                                      [1, 0],
+                                      [0, -1],
+                                      [-1, 0],
+                                      [-2, 1],
+                                      [1, -2],
+                                      [-2, -1],
+                                      [-1, -2]])
+    def test_2d_complex_same(self, axes):
+        a = array([[1 + 2j, 3 + 4j, 5 + 6j],
+                   [2 + 1j, 4 + 3j, 6 + 5j]])
+        expected = array([
+            [-3 + 4j, -10 + 20j, -21 + 56j, -18 + 76j, -11 + 60j],
+            [10j, 44j, 118j, 156j, 122j],
+            [3 + 4j, 10 + 20j, 21 + 56j, 18 + 76j, 11 + 60j]
+            ])
+
+        if axes == '':
+            out = fftconvolve(a, a)
+        else:
+            out = fftconvolve(a, a, axes=axes)
+
+        assert_array_almost_equal(out, expected)
+
+    @pytest.mark.parametrize('axes', [[1, 2],
+                                      [2, 1],
+                                      [1, -1],
+                                      [-1, 1],
+                                      [-2, 2],
+                                      [2, -2],
+                                      [-2, -1],
+                                      [-1, -2]])
+    def test_2d_complex_same_axes(self, axes):
+        a = array([[1 + 2j, 3 + 4j, 5 + 6j],
+                   [2 + 1j, 4 + 3j, 6 + 5j]])
+        expected = array([
+            [-3 + 4j, -10 + 20j, -21 + 56j, -18 + 76j, -11 + 60j],
+            [10j, 44j, 118j, 156j, 122j],
+            [3 + 4j, 10 + 20j, 21 + 56j, 18 + 76j, 11 + 60j]
+            ])
+
+        a = np.tile(a, [2, 1, 1])
+        expected = np.tile(expected, [2, 1, 1])
+
+        out = fftconvolve(a, a, axes=axes)
+        assert_array_almost_equal(out, expected)
+
+    @pytest.mark.parametrize('axes', ['', None, 0, [0], -1, [-1]])
+    def test_real_same_mode(self, axes):
         a = array([1, 2, 3])
         b = array([3, 3, 5, 6, 8, 7, 9, 0, 1])
-        c = fftconvolve(a, b, 'same')
-        d = array([35., 41., 47.])
-        assert_array_almost_equal(c, d)
+        expected_1 = array([35., 41., 47.])
+        expected_2 = array([9., 20., 25., 35., 41., 47., 39., 28., 2.])
 
-    def test_real_same_mode2(self):
-        a = array([3, 3, 5, 6, 8, 7, 9, 0, 1])
-        b = array([1, 2, 3])
-        c = fftconvolve(a, b, 'same')
-        d = array([9., 20., 25., 35., 41., 47., 39., 28., 2.])
-        assert_array_almost_equal(c, d)
+        if axes == '':
+            out = fftconvolve(a, b, 'same')
+        else:
+            out = fftconvolve(a, b, 'same', axes=axes)
+        assert_array_almost_equal(out, expected_1)
 
-    def test_valid_mode(self):
+        if axes == '':
+            out = fftconvolve(b, a, 'same')
+        else:
+            out = fftconvolve(b, a, 'same', axes=axes)
+        assert_array_almost_equal(out, expected_2)
+
+    @pytest.mark.parametrize('axes', [1, -1, [1], [-1]])
+    def test_real_same_mode_axes(self, axes):
+        a = array([1, 2, 3])
+        b = array([3, 3, 5, 6, 8, 7, 9, 0, 1])
+        expected_1 = array([35., 41., 47.])
+        expected_2 = array([9., 20., 25., 35., 41., 47., 39., 28., 2.])
+
+        a = np.tile(a, [2, 1])
+        b = np.tile(b, [2, 1])
+        expected_1 = np.tile(expected_1, [2, 1])
+        expected_2 = np.tile(expected_2, [2, 1])
+
+        out = fftconvolve(a, b, 'same', axes=axes)
+        assert_array_almost_equal(out, expected_1)
+
+        out = fftconvolve(b, a, 'same', axes=axes)
+        assert_array_almost_equal(out, expected_2)
+
+    @pytest.mark.parametrize('axes', ['', None, 0, [0], -1, [-1]])
+    def test_valid_mode_real(self, axes):
         # See gh-5897
         a = array([3, 2, 1])
         b = array([3, 3, 5, 6, 8, 7, 9, 0, 1])
         expected = array([24., 31., 41., 43., 49., 25., 12.])
 
-        out = fftconvolve(a, b, 'valid')
+        if axes == '':
+            out = fftconvolve(a, b, 'valid')
+        else:
+            out = fftconvolve(a, b, 'valid', axes=axes)
         assert_array_almost_equal(out, expected)
 
-        out = fftconvolve(b, a, 'valid')
+        if axes == '':
+            out = fftconvolve(b, a, 'valid')
+        else:
+            out = fftconvolve(b, a, 'valid', axes=axes)
         assert_array_almost_equal(out, expected)
 
+    @pytest.mark.parametrize('axes', [1, [1]])
+    def test_valid_mode_real_axes(self, axes):
+        # See gh-5897
+        a = array([3, 2, 1])
+        b = array([3, 3, 5, 6, 8, 7, 9, 0, 1])
+        expected = array([24., 31., 41., 43., 49., 25., 12.])
+
+        a = np.tile(a, [2, 1])
+        b = np.tile(b, [2, 1])
+        expected = np.tile(expected, [2, 1])
+
+        out = fftconvolve(a, b, 'valid', axes=axes)
+        assert_array_almost_equal(out, expected)
+
+    @pytest.mark.parametrize('axes', ['', None, 0, [0], -1, [-1]])
+    def test_valid_mode_complex(self, axes):
         a = array([3 - 1j, 2 + 7j, 1 + 0j])
         b = array([3 + 2j, 3 - 3j, 5 + 0j, 6 - 1j, 8 + 0j])
         expected = array([45. + 12.j, 30. + 23.j, 48 + 32.j])
 
-        out = fftconvolve(a, b, 'valid')
+        if axes == '':
+            out = fftconvolve(a, b, 'valid')
+        else:
+            out = fftconvolve(a, b, 'valid', axes=axes)
         assert_array_almost_equal(out, expected)
 
-        out = fftconvolve(b, a, 'valid')
+        if axes == '':
+            out = fftconvolve(b, a, 'valid')
+        else:
+            out = fftconvolve(b, a, 'valid', axes=axes)
         assert_array_almost_equal(out, expected)
 
-    def test_real_valid_mode(self):
-        a = array([3, 3, 5, 6, 8, 7, 9, 0, 1])
-        b = array([3, 2, 1])
-        d = array([24., 31., 41., 43., 49., 25., 12.])
+    @pytest.mark.parametrize('axes', [1, [1], -1, [-1]])
+    def test_valid_mode_complex_axes(self, axes):
+        a = array([3 - 1j, 2 + 7j, 1 + 0j])
+        b = array([3 + 2j, 3 - 3j, 5 + 0j, 6 - 1j, 8 + 0j])
+        expected = array([45. + 12.j, 30. + 23.j, 48 + 32.j])
 
-        c = fftconvolve(a, b, 'valid')
-        assert_array_almost_equal(c, d)
+        a = np.tile(a, [2, 1])
+        b = np.tile(b, [2, 1])
+        expected = np.tile(expected, [2, 1])
 
-        # See gh-5897
-        c = fftconvolve(b, a, 'valid')
-        assert_array_almost_equal(c, d)
+        out = fftconvolve(a, b, 'valid', axes=axes)
+        assert_array_almost_equal(out, expected)
+
+        out = fftconvolve(b, a, 'valid', axes=axes)
+        assert_array_almost_equal(out, expected)
 
     def test_empty(self):
         # Regression test for #1745: crashes with 0-length input.
@@ -484,63 +654,146 @@ class TestFFTConvolve(object):
     def test_zero_rank(self):
         a = array(4967)
         b = array(3920)
-        c = fftconvolve(a, b)
-        assert_equal(c, a * b)
+        out = fftconvolve(a, b)
+        assert_equal(out, a * b)
 
     def test_single_element(self):
         a = array([4967])
         b = array([3920])
-        c = fftconvolve(a, b)
-        assert_equal(c, a * b)
+        out = fftconvolve(a, b)
+        assert_equal(out, a * b)
 
-    def test_random_data(self):
+    @pytest.mark.parametrize('axes', ['', None, 0, [0], -1, [-1]])
+    def test_random_data(self, axes):
         np.random.seed(1234)
         a = np.random.rand(1233) + 1j * np.random.rand(1233)
         b = np.random.rand(1321) + 1j * np.random.rand(1321)
-        c = fftconvolve(a, b, 'full')
-        d = np.convolve(a, b, 'full')
-        assert_(np.allclose(c, d, rtol=1e-10))
+        expected = np.convolve(a, b, 'full')
+
+        if axes == '':
+            out = fftconvolve(a, b, 'full')
+        else:
+            out = fftconvolve(a, b, 'full', axes=axes)
+        assert_(np.allclose(out, expected, rtol=1e-10))
+
+    @pytest.mark.parametrize('axes', [1, [1], -1, [-1]])
+    def test_random_data_axes(self, axes):
+        np.random.seed(1234)
+        a = np.random.rand(1233) + 1j * np.random.rand(1233)
+        b = np.random.rand(1321) + 1j * np.random.rand(1321)
+        expected = np.convolve(a, b, 'full')
+
+        a = np.tile(a, [2, 1])
+        b = np.tile(b, [2, 1])
+        expected = np.tile(expected, [2, 1])
+
+        out = fftconvolve(a, b, 'full', axes=axes)
+        assert_(np.allclose(out, expected, rtol=1e-10))
+
+    @pytest.mark.parametrize('axes', [[1, 4],
+                                      [4, 1],
+                                      [1, -1],
+                                      [-1, 1],
+                                      [-4, 4],
+                                      [4, -4],
+                                      [-4, -1],
+                                      [-1, -4]])
+    def test_random_data_multidim_axes(self, axes):
+        np.random.seed(1234)
+        a = np.random.rand(123, 222) + 1j * np.random.rand(123, 222)
+        b = np.random.rand(132, 111) + 1j * np.random.rand(132, 111)
+        expected = convolve2d(a, b, 'full')
+
+        a = a[:, :, None, None, None]
+        b = b[:, :, None, None, None]
+        expected = expected[:, :, None, None, None]
+
+        a = np.moveaxis(a, [0, 1], [1, 4])
+        b = np.moveaxis(b, [0, 1], [1, 4])
+        expected = np.moveaxis(expected, [0, 1], [1, 4])
+
+        # use 1 for dimension 2 in a and 3 in b to test broadcasting
+        a = np.tile(a, [2, 1, 3, 1, 1])
+        b = np.tile(b, [2, 1, 1, 4, 1])
+        expected = np.tile(expected, [2, 1, 3, 4, 1])
+
+        out = fftconvolve(a, b, 'full', axes=axes)
+        assert_(np.allclose(out, expected, rtol=1e-10))
 
     @pytest.mark.slow
-    def test_many_sizes(self):
-        np.random.seed(1234)
+    @pytest.mark.parametrize(
+        'n',
+        list(range(1, 100)) +
+        list(range(1000, 1500)) +
+        np.random.RandomState(1234).randint(1001, 10000, 5).tolist())
+    def test_many_sizes(self, n):
+        a = np.random.rand(n) + 1j * np.random.rand(n)
+        b = np.random.rand(n) + 1j * np.random.rand(n)
+        expected = np.convolve(a, b, 'full')
 
-        def ns():
-            for j in range(1, 100):
-                yield j
-            for j in range(1000, 1500):
-                yield j
-            for k in range(50):
-                yield np.random.randint(1001, 10000)
+        out = fftconvolve(a, b, 'full')
+        assert_allclose(out, expected, atol=1e-10)
 
-        for n in ns():
-            msg = 'n=%d' % (n,)
-            a = np.random.rand(n) + 1j * np.random.rand(n)
-            b = np.random.rand(n) + 1j * np.random.rand(n)
-            c = fftconvolve(a, b, 'full')
-            d = np.convolve(a, b, 'full')
-            assert_allclose(c, d, atol=1e-10, err_msg=msg)
+        out = fftconvolve(a, b, 'full', axes=[0])
+        assert_allclose(out, expected, atol=1e-10)
 
     def test_invalid_shapes(self):
-        # By "invalid," we mean that no one
-        # array has dimensions that are all at
-        # least as large as the corresponding
-        # dimensions of the other array. This
-        # setup should throw a ValueError.
         a = np.arange(1, 7).reshape((2, 3))
         b = np.arange(-6, 0).reshape((3, 2))
+        with assert_raises(ValueError,
+                           match="For 'valid' mode, one must be at least "
+                           "as large as the other in every dimension"):
+            fftconvolve(a, b, mode='valid')
 
-        assert_raises(ValueError, fftconvolve, *(a, b), **{'mode': 'valid'})
-        assert_raises(ValueError, fftconvolve, *(b, a), **{'mode': 'valid'})
+    def test_invalid_shapes_axes(self):
+        a = np.zeros([5, 6, 2, 1])
+        b = np.zeros([5, 6, 3, 1])
+        with assert_raises(ValueError,
+                           match=r"incompatible shapes for in1 and in2:"
+                           r" \(5L?, 6L?, 2L?, 1L?\) and"
+                           r" \(5L?, 6L?, 3L?, 1L?\)"):
+            fftconvolve(a, b, axes=[0, 1])
 
-    def test_mismatched_dims(self):
-        assert_raises(ValueError, fftconvolve, [1], 2)
-        assert_raises(ValueError, fftconvolve, 1, [2])
-        assert_raises(ValueError, fftconvolve, [1], [[2]])
-        assert_raises(ValueError, fftconvolve, [3], 2)
+    @pytest.mark.parametrize('a,b',
+                             [([1], 2),
+                              (1, [2]),
+                              ([3], [[2]])])
+    def test_mismatched_dims(self, a, b):
+        with assert_raises(ValueError,
+                           match="in1 and in2 should have the same"
+                           " dimensionality"):
+            fftconvolve(a, b)
 
     def test_invalid_flags(self):
-        assert_raises(ValueError, fftconvolve, [1], [2], mode='chips')
+        with assert_raises(ValueError,
+                           match="acceptable mode flags are 'valid',"
+                           " 'same', or 'full'"):
+            fftconvolve([1], [2], mode='chips')
+
+        with assert_raises(ValueError,
+                           match="when provided, axes cannot be empty"):
+            fftconvolve([1], [2], axes=[])
+
+        with assert_raises(ValueError,
+                           match="when given, axes values must be a scalar"
+                           " or vector"):
+            fftconvolve([1], [2], axes=[[1, 2], [3, 4]])
+
+        with assert_raises(ValueError,
+                           match="when given, axes values must be integers"):
+            fftconvolve([1], [2], axes=[1., 2., 3., 4.])
+
+        with assert_raises(ValueError,
+                           match="axes exceeds dimensionality of input"):
+            fftconvolve([1], [2], axes=[1])
+
+        with assert_raises(ValueError,
+                           match="axes exceeds dimensionality of input"):
+            fftconvolve([1], [2], axes=[-2])
+
+        with assert_raises(ValueError,
+                           match="all axes must be unique"):
+            fftconvolve([1], [2], axes=[0, 0])
 
 
 class TestMedFilt(object):


### PR DESCRIPTION
Allow the user of fftconvolve to specify which axes the convolution should occur over.

Closes #3525.