### PR TITLE
Fix make_interp_spline(..., k=0 or 1, axis<0)

### DIFF
--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -744,6 +744,9 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
         except TypeError:
             raise ValueError("Unknown boundary condition: %s" % bc_type)
 
+    # BSpline requires axis>=0
+    axis = axis % y.ndim
+
     # special-case k=0 right away
     if k == 0:
         if any(_ is not None for _ in (t, deriv_l, deriv_r)):
@@ -786,7 +789,6 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
 
     t = _as_float_array(t, check_finite)
 
-    axis = axis % y.ndim
     y = np.rollaxis(y, axis)    # now internally interp axis is zero
 
     if x.ndim != 1 or np.any(x[1:] <= x[:-1]):

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -192,6 +192,8 @@ class BSpline(object):
 
         n = self.t.shape[0] - self.k - 1
 
+        if axis < 0:
+            axis += self.c.ndim
         if not (0 <= axis < self.c.ndim):
             raise ValueError("%s must be between 0 and %s" % (axis, c.ndim))
 
@@ -744,11 +746,6 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
         except TypeError:
             raise ValueError("Unknown boundary condition: %s" % bc_type)
 
-    if axis < 0:
-        axis += y.ndim
-        if axis < 0:
-            raise ValueError("axis {} is out of bounds".format(axis - y.ndim))
-
     # special-case k=0 right away
     if k == 0:
         if any(_ is not None for _ in (t, deriv_l, deriv_r)):
@@ -973,7 +970,6 @@ def make_lsq_spline(x, y, t, k=3, w=None, axis=0, check_finite=True):
         w = np.ones_like(x)
     k = int(k)
 
-    axis = axis % y.ndim
     y = np.rollaxis(y, axis)    # now internally interp axis is zero
 
     if x.ndim != 1 or np.any(x[1:] - x[:-1] <= 0):

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -744,6 +744,8 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
         except TypeError:
             raise ValueError("Unknown boundary condition: %s" % bc_type)
 
+    y = np.asarray(y)
+
     if not -y.ndim <= axis < y.ndim:
         raise ValueError("axis {} is out of bounds".format(axis))
     if axis < 0:

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -192,8 +192,6 @@ class BSpline(object):
 
         n = self.t.shape[0] - self.k - 1
 
-        if axis < 0:
-            axis += self.c.ndim
         if not (0 <= axis < self.c.ndim):
             raise ValueError("%s must be between 0 and %s" % (axis, c.ndim))
 
@@ -239,7 +237,7 @@ class BSpline(object):
         self = object.__new__(cls)
         self.t, self.c, self.k = t, c, k
         self.extrapolate = extrapolate
-        self.axis = axis if axis >= 0 else axis + self.c.ndim
+        self.axis = axis
         return self
 
     @property
@@ -746,6 +744,11 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
         except TypeError:
             raise ValueError("Unknown boundary condition: %s" % bc_type)
 
+    if not -y.ndim <= axis < y.ndim:
+        raise ValueError("axis {} is out of bounds".format(axis))
+    if axis < 0:
+        axis += y.ndim
+
     # special-case k=0 right away
     if k == 0:
         if any(_ is not None for _ in (t, deriv_l, deriv_r)):
@@ -971,6 +974,11 @@ def make_lsq_spline(x, y, t, k=3, w=None, axis=0, check_finite=True):
     else:
         w = np.ones_like(x)
     k = int(k)
+
+    if not -y.ndim <= axis < y.ndim:
+        raise ValueError("axis {} is out of bounds".format(axis))
+    if axis < 0:
+        axis += y.ndim
 
     y = np.rollaxis(y, axis)    # now internally interp axis is zero
 

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -239,7 +239,7 @@ class BSpline(object):
         self = object.__new__(cls)
         self.t, self.c, self.k = t, c, k
         self.extrapolate = extrapolate
-        self.axis = axis
+        self.axis = axis if axis >= 0 else axis + self.c.ndim
         return self
 
     @property
@@ -512,7 +512,7 @@ class BSpline(object):
                 # (cf _fitpack_impl.splint).
                 t, c, k = self.tck
                 integral, wrk = _dierckx._splint(t, c, k, a, b)
-                return integral * sign 
+                return integral * sign
 
         out = np.empty((2, prod(self.c.shape[1:])), dtype=self.c.dtype)
 

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -744,8 +744,10 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
         except TypeError:
             raise ValueError("Unknown boundary condition: %s" % bc_type)
 
-    # BSpline requires axis>=0
-    axis = axis % y.ndim
+    if axis < 0:
+    axis += y.ndim
+    if axis < 0:
+        raise ValueError("axis {} is out of bounds".format(axis - y.ndim))
 
     # special-case k=0 right away
     if k == 0:

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -754,6 +754,7 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
         x = _as_float_array(x, check_finite)
         t = np.r_[x, x[-1]]
         c = np.asarray(y)
+        c = np.rollaxis(c, axis)
         c = np.ascontiguousarray(c, dtype=_get_dtype(c.dtype))
         return BSpline.construct_fast(t, c, k, axis=axis)
 
@@ -764,6 +765,7 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
         x = _as_float_array(x, check_finite)
         t = np.r_[x[0], x, x[-1]]
         c = np.asarray(y)
+        c = np.rollaxis(c, axis)
         c = np.ascontiguousarray(c, dtype=_get_dtype(c.dtype))
         return BSpline.construct_fast(t, c, k, axis=axis)
 

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -745,9 +745,9 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
             raise ValueError("Unknown boundary condition: %s" % bc_type)
 
     if axis < 0:
-    axis += y.ndim
-    if axis < 0:
-        raise ValueError("axis {} is out of bounds".format(axis - y.ndim))
+        axis += y.ndim
+        if axis < 0:
+            raise ValueError("axis {} is out of bounds".format(axis - y.ndim))
 
     # special-case k=0 right away
     if k == 0:

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -788,9 +788,13 @@ class TestInterp(object):
     def test_order_0(self):
         b = make_interp_spline(self.xx, self.yy, k=0)
         assert_allclose(b(self.xx), self.yy, atol=1e-14, rtol=1e-14)
+        b = make_interp_spline(self.xx, self.yy, k=0, axis=-1)
+        assert_allclose(b(self.xx), self.yy, atol=1e-14, rtol=1e-14)
 
     def test_linear(self):
         b = make_interp_spline(self.xx, self.yy, k=1)
+        assert_allclose(b(self.xx), self.yy, atol=1e-14, rtol=1e-14)
+        b = make_interp_spline(self.xx, self.yy, k=1, axis=-1)
         assert_allclose(b(self.xx), self.yy, atol=1e-14, rtol=1e-14)
 
     def test_not_a_knot(self):

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -405,8 +405,8 @@ class TestBSpline(object):
             assert_equal(b(xp).shape,
                          sh[:axis] + list(xp.shape) + sh[axis+1:])
 
-            #-c.ndim <= axis < c.ndim
-            for ax in [-c.ndim-1, c.ndim]:
+            #0 <= axis < c.ndim
+            for ax in [-1, c.ndim]:
                 assert_raises(ValueError, BSpline, **dict(t=t, c=c, k=k, axis=ax))
 
             # derivative, antiderivative keeps the axis
@@ -886,7 +886,7 @@ class TestInterp(object):
         assert_allclose(b(xx), yy, atol=1e-14, rtol=1e-14)
 
     def test_deriv_spec(self):
-        # If one of the derivatives is omitted, the spline definition is 
+        # If one of the derivatives is omitted, the spline definition is
         # incomplete.
         x = y = [1.0, 2, 3, 4, 5, 6]
 

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -405,8 +405,8 @@ class TestBSpline(object):
             assert_equal(b(xp).shape,
                          sh[:axis] + list(xp.shape) + sh[axis+1:])
 
-            #0 <= axis < c.ndim
-            for ax in [-1, len(sh)+1]:
+            #-c.ndim <= axis < c.ndim
+            for ax in [-c.ndim-1, c.ndim]:
                 assert_raises(ValueError, BSpline, **dict(t=t, c=c, k=k, axis=ax))
 
             # derivative, antiderivative keeps the axis


### PR DESCRIPTION
by moving the modulus operator before the k==0 and k==1 cases, since BSpline needs axis>=0.
This is a minimal fix. A cleaner one seems to be to lift the BSpline constraint
and make it compatible with the numpy convention.