### PR TITLE
MAINT: fix up stats.spearmanr and match mstats.spearmanr with it

### DIFF
--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -435,14 +435,15 @@ def spearmanr(x, y=None, use_ties=True, axis=None, nan_policy='propagate'):
 
     Parameters
     ----------
-    x : array_like
-        The length of `x` must be > 2.
-    y : array_like, optional
-        The length of `y` must be > 2.
+    x, y : 1D or 2D array_like, b is optional
+        One or two 1-D or 2-D arrays containing multiple variables and
+        observations. When these are 1-D, each represents a vector of
+        observations of a single variable. For the behavior in the 2-D case,
+        see under ``axis``, below.
     use_ties : bool, optional
         DO NOT USE.  Does not do anything, keyword is only left in place for
         backwards compatibility reasons.
-   axis : int or None, optional
+    axis : int or None, optional
         If axis=0 (default), then each column represents a variable, with
         observations in the rows. If axis=1, the relationship is transposed:
         each row represents a variable, while the columns contain observations.

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -52,7 +52,7 @@ from ._stats_mstats_common import (
         _find_repeats,
         linregress as stats_linregress,
         theilslopes as stats_theilslopes,
-        siegelslopes as stats_siegelslopes 
+        siegelslopes as stats_siegelslopes
         )
 
 
@@ -88,7 +88,7 @@ def _chk2_asarray(a, b, axis):
     return a, b, outaxis
 
 
-def _chk_size(a,b):
+def _chk_size(a, b):
     a = ma.asanyarray(a)
     b = ma.asanyarray(b)
     (na, nb) = (a.size, b.size)
@@ -411,7 +411,7 @@ def pearsonr(x,y):
 SpearmanrResult = namedtuple('SpearmanrResult', ('correlation', 'pvalue'))
 
 
-def spearmanr(x, y, use_ties=True):
+def spearmanr(x, y=None, use_ties=True, axis=None, nan_policy='propagate'):
     """
     Calculates a Spearman rank-order correlation coefficient and the p-value
     to test for non-correlation.
@@ -437,10 +437,20 @@ def spearmanr(x, y, use_ties=True):
     ----------
     x : array_like
         The length of `x` must be > 2.
-    y : array_like
+    y : array_like, optional
         The length of `y` must be > 2.
     use_ties : bool, optional
-        Whether the correction for ties should be computed.
+        DO NOT USE.  Does not do anything, keyword is only left in place for
+        backwards compatibility reasons.
+   axis : int or None, optional
+        If axis=0 (default), then each column represents a variable, with
+        observations in the rows. If axis=1, the relationship is transposed:
+        each row represents a variable, while the columns contain observations.
+        If axis=None, then both arrays will be raveled.
+    nan_policy : {'propagate', 'raise', 'omit'}, optional
+        Defines how to handle when input contains nan. 'propagate' returns nan,
+        'raise' throws an error, 'omit' performs the calculations ignoring nan
+        values. Default is 'propagate'.
 
     Returns
     -------
@@ -454,48 +464,53 @@ def spearmanr(x, y, use_ties=True):
     [CRCProbStat2000] section 14.7
 
     """
-    (x, y, n) = _chk_size(x, y)
-    (x, y) = (x.ravel(), y.ravel())
+    # Always returns a masked array, raveled if axis=None
+    x, axisout = _chk_asarray(x, axis)
+    if y is not None:
+        # Deal only with 2-D `x` case.
+        y, _ = _chk_asarray(y, axis)
+        if axisout == 0:
+            x = ma.column_stack((x, y))
+        else:
+            x = ma.row_stack((x, y))
 
-    m = ma.mask_or(ma.getmask(x), ma.getmask(y))
-    # need int() here, otherwise numpy defaults to 32 bit
-    # integer on all Windows architectures, causing overflow.
-    # int() will keep it infinite precision.
-    n -= int(m.sum())
-    if m is not nomask:
-        x = ma.array(x, mask=m, copy=True)
-        y = ma.array(y, mask=m, copy=True)
-    df = n-2
-    if df < 0:
+    if nan_policy == 'omit':
+        x = ma.masked_invalid(x)
+
+    # Mask the same observations for all variables, and then drop those
+    # observations (can't leave them masked, rankdata is weird).
+    x = ma.mask_rowcols(x, axis=axisout)
+    if axisout == 0:
+        x = x[~x.mask.any(axis=1), :]
+    else:
+        x = x[:, ~x.mask.any(axis=0)]
+
+    m = ma.getmask(x)
+    n_obs = x.shape[axisout]
+    dof = n_obs - 2 - int(m.sum(axis=axisout)[0])
+    if dof < 0:
         raise ValueError("The input must have at least 3 entries!")
 
     # Gets the ranks and rank differences
-    rankx = rankdata(x)
-    ranky = rankdata(y)
-    dsq = np.add.reduce((rankx-ranky)**2)
-    # Tie correction
-    if use_ties:
-        xties = count_tied_groups(x)
-        yties = count_tied_groups(y)
-        corr_x = sum(v*k*(k**2-1) for (k,v) in iteritems(xties))/12.
-        corr_y = sum(v*k*(k**2-1) for (k,v) in iteritems(yties))/12.
-    else:
-        corr_x = corr_y = 0
+    x_ranked = rankdata(x, axis=axisout)
+    rs = ma.corrcoef(x_ranked, rowvar=axisout).data
 
-    denom = n*(n**2 - 1)/6.
-    if corr_x != 0 or corr_y != 0:
-        rho = denom - dsq - corr_x - corr_y
-        rho /= ma.sqrt((denom-2*corr_x)*(denom-2*corr_y))
-    else:
-        rho = 1. - dsq/denom
+    # rs can have elements equal to 1, so avoid zero division warnings
+    olderr = np.seterr(divide='ignore')
+    try:
+        # clip the small negative values possibly caused by rounding
+        # errors before taking the square root
+        t = rs * np.sqrt((dof / ((rs+1.0) * (1.0-rs))).clip(0))
+    finally:
+        np.seterr(**olderr)
 
-    t = ma.sqrt(ma.divide(df,(rho+1.0)*(1.0-rho))) * rho
-    if t is masked:
-        prob = 0.
-    else:
-        prob = _betai(0.5*df, 0.5, df/(df + t * t))
+    prob = 2 * distributions.t.sf(np.abs(t), dof)
 
-    return SpearmanrResult(rho, prob)
+    # For backwards compatibility, return scalars when comparing 2 colums
+    if rs.shape == (2, 2):
+        return SpearmanrResult(rs[1, 0], prob[1, 0])
+    else:
+        return SpearmanrResult(rs, prob)
 
 
 KendalltauResult = namedtuple('KendalltauResult', ('correlation', 'pvalue'))

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -435,7 +435,7 @@ def spearmanr(x, y=None, use_ties=True, axis=None, nan_policy='propagate'):
 
     Parameters
     ----------
-    x, y : 1D or 2D array_like, b is optional
+    x, y : 1D or 2D array_like, y is optional
         One or two 1-D or 2-D arrays containing multiple variables and
         observations. When these are 1-D, each represents a vector of
         observations of a single variable. For the behavior in the 2-D case,

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -465,6 +465,9 @@ def spearmanr(x, y=None, use_ties=True, axis=None, nan_policy='propagate'):
     [CRCProbStat2000] section 14.7
 
     """
+    if not use_ties:
+        raise ValueError("`use_ties=False` is not supported in SciPy >= 1.2.0")
+
     # Always returns a masked array, raveled if axis=None
     x, axisout = _chk_asarray(x, axis)
     if y is not None:

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3255,15 +3255,11 @@ def spearmanr(a, b=None, axis=0, nan_policy='propagate'):
     correlation : float or ndarray (2-D square)
         Spearman correlation matrix or correlation coefficient (if only 2
         variables are given as parameters. Correlation matrix is square with
-        length equal to total number of variables (columns or rows) in a and b
-        combined.
+        length equal to total number of variables (columns or rows) in ``a``
+        and ``b`` combined.
     pvalue : float
         The two-sided p-value for a hypothesis test whose null hypothesis is
         that two sets of data are uncorrelated, has same dimension as rho.
-
-    Notes
-    -----
-    Changes in scipy 0.8.0: rewrite to add tie-handling, and axis.
 
     References
     ----------
@@ -3313,50 +3309,62 @@ def spearmanr(a, b=None, axis=0, nan_policy='propagate'):
 
     """
     a, axisout = _chk_asarray(a, axis)
+    if a.ndim > 2:
+        raise ValueError("spearmanr only handled 1-D or 2-D arrays")
 
-    a_contains_nan, nan_policy = _contains_nan(a, nan_policy)
+    if b is None:
+        if a.ndim < 2:
+            raise ValueError("`spearmanr` needs at least 2 variables to compare")
+    else:
+        # Concatenate a and b, so that we now only have to handle the case
+        # of a 2-D `a`.
+        b, _ = _chk_asarray(b, axis)
+        if axisout == 0:
+            a = np.column_stack((a, b))
+        else:
+            a = np.row_stack((a, b))
 
-    if a_contains_nan:
-        a = ma.masked_invalid(a)
-
-    if a.size <= 1:
+    n_vars = a.shape[1 - axisout]
+    n_obs = a.shape[axisout]
+    if n_obs <= 1:
+        # Handle empty arrays or single observations.
         return SpearmanrResult(np.nan, np.nan)
 
-    ar = np.apply_along_axis(rankdata, axisout, a)
+    a_contains_nan, nan_policy = _contains_nan(a, nan_policy)
+    variable_has_nan = np.zeros(n_vars, dtype=bool)
+    if a_contains_nan:
+        if nan_policy == 'omit':
+            #a = ma.masked_invalid(a)
+            return mstats_basic.spearmanr(a, axis=axis, nan_policy=nan_policy)
+        elif nan_policy == 'propagate':
+            if a.ndim == 1 or n_vars <= 2:
+                return SpearmanrResult(np.nan, np.nan)
+            else:
+                # Keep track of variables with NaNs, set the outputs to NaN
+                # only for those variables
+                variable_has_nan = np.isnan(x).sum(axis=axisout)
 
-    br = None
-    if b is not None:
-        b, axisout = _chk_asarray(b, axis)
+    a_ranked = np.apply_along_axis(rankdata, axisout, a)
+    rs = np.corrcoef(a_ranked, rowvar=axisout)
+    dof = n_obs - 2  # degrees of freedom
 
-        b_contains_nan, nan_policy = _contains_nan(b, nan_policy)
-
-        if a_contains_nan or b_contains_nan:
-            b = ma.masked_invalid(b)
-
-            if nan_policy == 'propagate':
-                rho, pval = mstats_basic.spearmanr(a, b, use_ties=True)
-                return SpearmanrResult(rho * np.nan, pval * np.nan)
-
-            if nan_policy == 'omit':
-                return mstats_basic.spearmanr(a, b, use_ties=True)
-
-        br = np.apply_along_axis(rankdata, axisout, b)
-    n = a.shape[axisout]
-    rs = np.corrcoef(ar, br, rowvar=axisout)
-
-    olderr = np.seterr(divide='ignore')  # rs can have elements equal to 1
+    # rs can have elements equal to 1, so avoid zero division warnings
+    olderr = np.seterr(divide='ignore')
     try:
         # clip the small negative values possibly caused by rounding
         # errors before taking the square root
-        t = rs * np.sqrt(((n-2)/((rs+1.0)*(1.0-rs))).clip(0))
+        t = rs * np.sqrt((dof/((rs+1.0)*(1.0-rs))).clip(0))
     finally:
         np.seterr(**olderr)
 
-    prob = 2 * distributions.t.sf(np.abs(t), n-2)
+    prob = 2 * distributions.t.sf(np.abs(t), dof)
 
+    # For backwards compatibility, return scalars when comparing 2 colums
     if rs.shape == (2, 2):
         return SpearmanrResult(rs[1, 0], prob[1, 0])
     else:
+        rs[variable_has_nan, :] = np.nan
+        rs[:, variable_has_nan] = np.nan
         return SpearmanrResult(rs, prob)
 
 
@@ -3478,10 +3486,10 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate', method='auto'
         'omit' delegates to mstats_basic.kendalltau(), which has a different
         implementation.
     method: {'auto', 'asymptotic', 'exact'}, optional
-        Defines which method is used to calculate the p-value [5]_. 
-        'asymptotic' uses a normal approximation valid for large samples. 
-        'exact' computes the exact p-value, but can only be used if no ties 
-        are present. 'auto' is the default and selects the appropriate 
+        Defines which method is used to calculate the p-value [5]_.
+        'asymptotic' uses a normal approximation valid for large samples.
+        'exact' computes the exact p-value, but can only be used if no ties
+        are present. 'auto' is the default and selects the appropriate
         method based on a trade-off between speed and accuracy.
 
     Returns
@@ -3520,7 +3528,7 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate', method='auto'
     .. [4] Peter M. Fenwick, "A new data structure for cumulative frequency
            tables", Software: Practice and Experience, Vol. 24, No. 3,
            pp. 327-336, 1994.
-    .. [5] Maurice G. Kendall, "Rank Correlation Methods" (4th Edition), 
+    .. [5] Maurice G. Kendall, "Rank Correlation Methods" (4th Edition),
            Charles Griffin & Co., 1970.
 
     Examples
@@ -3602,13 +3610,13 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate', method='auto'
 
     if method == 'exact' and (xtie != 0 or ytie != 0):
         raise ValueError("Ties found, exact method cannot be used.")
-        
+
     if method == 'auto':
         if (xtie == 0 and ytie == 0) and (size <= 33 or min(dis, tot-dis) <= 1):
             method = 'exact'
         else:
             method = 'asymptotic'
-        
+
     if xtie == 0 and ytie == 0 and method == 'exact':
         # Exact p-value, see Maurice G. Kendall, "Rank Correlation Methods" (4th Edition), Charles Griffin & Co., 1970.
         c = min(dis, tot-dis)

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3334,7 +3334,6 @@ def spearmanr(a, b=None, axis=0, nan_policy='propagate'):
     variable_has_nan = np.zeros(n_vars, dtype=bool)
     if a_contains_nan:
         if nan_policy == 'omit':
-            #a = ma.masked_invalid(a)
             return mstats_basic.spearmanr(a, axis=axis, nan_policy=nan_policy)
         elif nan_policy == 'propagate':
             if a.ndim == 1 or n_vars <= 2:
@@ -3342,7 +3341,7 @@ def spearmanr(a, b=None, axis=0, nan_policy='propagate'):
             else:
                 # Keep track of variables with NaNs, set the outputs to NaN
                 # only for those variables
-                variable_has_nan = np.isnan(x).sum(axis=axisout)
+                variable_has_nan = np.isnan(a).sum(axis=axisout)
 
     a_ranked = np.apply_along_axis(rankdata, axisout, a)
     rs = np.corrcoef(a_ranked, rowvar=axisout)

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3310,7 +3310,7 @@ def spearmanr(a, b=None, axis=0, nan_policy='propagate'):
     """
     a, axisout = _chk_asarray(a, axis)
     if a.ndim > 2:
-        raise ValueError("spearmanr only handled 1-D or 2-D arrays")
+        raise ValueError("spearmanr only handles 1-D or 2-D arrays")
 
     if b is None:
         if a.ndim < 2:

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -219,7 +219,6 @@ class TestCorr(object):
         check_named_results(res, attributes, ma=True)
 
     def test_kendalltau(self):
-        
         # simple case without ties
         x = ma.array(np.arange(10))
         y = ma.array(np.arange(10))
@@ -1099,6 +1098,12 @@ class TestCompareWithStats(object):
             rm, pm = stats.mstats.spearmanr(xm, ym)
             assert_almost_equal(r, rm, 14)
             assert_almost_equal(p, pm, 14)
+
+    def test_spearmanr_backcompat_useties(self):
+        # A regression test to ensure we don't break backwards compat
+        # more than we have to (see gh-9204).
+        x = np.arange(6)
+        assert_raises(ValueError, mstats.spearmanr, x, x, False)
 
     def test_gmean(self):
         for n in self.get_n():

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -596,12 +596,12 @@ class TestCorrSpearmanr(object):
 
     def test_gh_9103(self):
         # Regression test for gh-9103.
-        x = np.array([[np.nan,    3.0, 4.0, 5.0, 5.1, 6.0, 9.2],
-                      [5.0,    np.nan, 4.1, 4.8, 4.9, 5.0, 4.1],
-                      [0.5,       4.0, 7.1, 3.8, 8.0, 5.1, 7.6]]).T
+        x = np.array([[np.nan, 3.0, 4.0, 5.0, 5.1, 6.0, 9.2],
+                      [5.0, np.nan, 4.1, 4.8, 4.9, 5.0, 4.1],
+                      [0.5, 4.0, 7.1, 3.8, 8.0, 5.1, 7.6]]).T
         corr = np.array([[np.nan, np.nan, np.nan],
                          [np.nan, np.nan, np.nan],
-                         [np.nan, np.nan,     1.]])
+                         [np.nan, np.nan, 1.]])
         assert_allclose(stats.spearmanr(x, nan_policy='propagate').correlation,
                         corr)
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -438,9 +438,8 @@ class TestCorrSpearmanr(object):
         x = np.random.randn(4, 3, 2)
         assert_raises(ValueError, stats.spearmanr, x)
         assert_raises(ValueError, stats.spearmanr, x, x)
-        # But should work with axis=None (raveling axes)
-        assert_allclose(stats.spearmanr(x, axis=None),
-                        stats.spearmanr(x.flatten(), axis=0))
+        assert_raises(ValueError, stats.spearmanr, x, None, None)
+        # But should work with axis=None (raveling axes) for two input arrays
         assert_allclose(stats.spearmanr(x, x, axis=None),
                         stats.spearmanr(x.flatten(), x.flatten(), axis=0))
 
@@ -570,7 +569,6 @@ class TestCorrSpearmanr(object):
         res2 = stats.spearmanr(np.asarray([x1, x2]).T)
         assert_allclose(res1, res2)
 
-    @pytest.mark.xfail(reason="Bug: gh-9103")
     def test_1d_vs_2d_nans(self):
         # Now the same with NaNs present.  Regression test for gh-9103.
         for nan_policy in ['propagate', 'omit']:

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -594,6 +594,21 @@ class TestCorrSpearmanr(object):
         assert_allclose(actual.correlation, expected_corr)
         assert_allclose(actual.pvalue, expected_pvalue)
 
+    def test_gh_9103(self):
+        # Regression test for gh-9103.
+        x = np.array([[np.nan,    3.0, 4.0, 5.0, 5.1, 6.0, 9.2],
+                      [5.0,    np.nan, 4.1, 4.8, 4.9, 5.0, 4.1],
+                      [0.5,       4.0, 7.1, 3.8, 8.0, 5.1, 7.6]]).T
+        corr = np.array([[np.nan, np.nan, np.nan],
+                         [np.nan, np.nan, np.nan],
+                         [np.nan, np.nan,     1.]])
+        assert_allclose(stats.spearmanr(x, nan_policy='propagate').correlation,
+                        corr)
+
+        res = stats.spearmanr(x, nan_policy='omit').correlation
+        assert_allclose((res[0][1], res[0][2], res[1][2]),
+                        (0.2051957, 0.4857143, -0.4707919), rtol=1e-6)
+
 
 def test_spearmanr():
     # Cross-check with R:

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -422,6 +422,28 @@ class TestCorrSpearmanr(object):
         assert_raises(ValueError, stats.spearmanr, [1, 2, 1], [8, 9])
         assert_raises(ValueError, stats.spearmanr, [1, 2, 1], 8)
 
+    def test_uneven_2d_shapes(self):
+        # Different number of columns should work - those just get concatenated.
+        np.random.seed(232324)
+        x = np.random.randn(4, 3)
+        y = np.random.randn(4, 2)
+        assert stats.spearmanr(x, y).correlation.shape == (5, 5)
+        assert stats.spearmanr(x.T, y.T, axis=1).pvalue.shape == (5, 5)
+
+        assert_raises(ValueError, stats.spearmanr, x, y, axis=1)
+        assert_raises(ValueError, stats.spearmanr, x.T, y.T)
+
+    def test_ndim_too_high(self):
+        np.random.seed(232324)
+        x = np.random.randn(4, 3, 2)
+        assert_raises(ValueError, stats.spearmanr, x)
+        assert_raises(ValueError, stats.spearmanr, x, x)
+        # But should work with axis=None (raveling axes)
+        assert_allclose(stats.spearmanr(x, axis=None),
+                        stats.spearmanr(x.flatten(), axis=0))
+        assert_allclose(stats.spearmanr(x, x, axis=None),
+                        stats.spearmanr(x.flatten(), x.flatten(), axis=0))
+
     def test_nan_policy(self):
         x = np.arange(10.)
         x[9] = np.nan
@@ -540,6 +562,40 @@ class TestCorrSpearmanr(object):
         res = stats.spearmanr(X, X)
         attributes = ('correlation', 'pvalue')
         check_named_results(res, attributes)
+
+    def test_1d_vs_2d(self):
+        x1 = [1, 2, 3, 4, 5, 6]
+        x2 = [1, 2, 3, 4, 6, 5]
+        res1 = stats.spearmanr(x1, x2)
+        res2 = stats.spearmanr(np.asarray([x1, x2]).T)
+        assert_allclose(res1, res2)
+
+    @pytest.mark.xfail(reason="Bug: gh-9103")
+    def test_1d_vs_2d_nans(self):
+        # Now the same with NaNs present.  Regression test for gh-9103.
+        for nan_policy in ['propagate', 'omit']:
+            x1 = [1, np.nan, 3, 4, 5, 6]
+            x2 = [1, 2, 3, 4, 6, np.nan]
+            res1 = stats.spearmanr(x1, x2)
+            res2 = stats.spearmanr(np.asarray([x1, x2]).T)
+            assert_allclose(res1, res2)
+
+    def test_3cols(self):
+        x1 = np.arange(6)
+        x2 = -x1
+        x3 = np.array([0, 1, 2, 3, 5, 4])
+        x = np.asarray([x1, x2, x3]).T
+        actual = stats.spearmanr(x)
+        expected_corr = np.array([[1, -1, 0.94285714],
+                                  [-1, 1, -0.94285714],
+                                  [0.94285714, -0.94285714, 1]])
+        expected_pvalue = np.zeros((3, 3), dtype=float)
+        expected_pvalue[2, 0:2] = 0.00480466472
+        expected_pvalue[0:2, 2] = 0.00480466472
+
+        assert_allclose(actual.correlation, expected_corr)
+        assert_allclose(actual.pvalue, expected_pvalue)
+
 
 def test_spearmanr():
     # Cross-check with R:


### PR DESCRIPTION
Closes gh-9103.
Closes gh-8111.

Note that this is a backwards compatibility break for `mstats.spearmanr(..., use_ties=False)` - this now raises an error. I think that's okay, `stats.spearmanr` doesn't have it and it doesn't seem very useful. I needed to rewrite the whole function to match `stats` and that was hard enough without supporting `use_ties`.