### PR TITLE
TST: signal: bump bsplines test tolerance for complex data

### DIFF
--- a/scipy/signal/tests/test_bsplines.py
+++ b/scipy/signal/tests/test_bsplines.py
@@ -56,8 +56,11 @@ class TestBSplines(object):
               -9.66586399+0.70250005j, -9.87717438-2.0262239j,
               9.93160629+1.5630846j, 4.71948051-2.22050714j,
               9.49550819+7.8995142j]])
+        # FIXME: for complex types, the computations are done in
+        # single precision (reason unclear). When this is changed,
+        # this test needs updating.
         assert_allclose(bsp.spline_filter(data_array_complex, 0),
-                        result_array_complex)
+                        result_array_complex, rtol=1e-6)
         # Test the real branch
         np.random.seed(12457)
         data_array_real = np.random.rand(12, 12)


### PR DESCRIPTION
For complex inputs, the computations are actually done in single
precision, so use lower precision.

Closes gh-9091  (tested locally)