### PR TITLE
TST: mark tests as slow, fix missing random seed

### DIFF
--- a/scipy/optimize/tests/test__remove_redundancy.py
+++ b/scipy/optimize/tests/test__remove_redundancy.py
@@ -105,6 +105,7 @@ def test_infeasible_m_lt_n():
 
 
 def test_m_gt_n():
+    np.random.seed(2032)
     m, n = 20, 10
     A0 = np.random.rand(m, n)
     b0 = np.random.rand(m)

--- a/scipy/optimize/tests/test_constraint_conversion.py
+++ b/scipy/optimize/tests/test_constraint_conversion.py
@@ -6,6 +6,7 @@ Unit test for constraint conversion
 import numpy as np
 from numpy.testing import (assert_, assert_array_almost_equal,
                            assert_allclose, assert_equal, TestCase)
+import pytest
 from scipy._lib._numpy_compat import suppress_warnings
 from scipy.optimize import (NonlinearConstraint, LinearConstraint, Bounds,
                             OptimizeWarning, minimize, BFGS)
@@ -250,6 +251,7 @@ class TestNewToOldCobyla(object):
                         Elec(n_electrons=4),
                         ]
 
+    @pytest.mark.slow
     def test_list_of_problems(self):
 
         for prob in self.list_of_problems:

--- a/scipy/optimize/tests/test_minimize_constrained.py
+++ b/scipy/optimize/tests/test_minimize_constrained.py
@@ -447,6 +447,7 @@ class Elec:
 
 class TestTrustRegionConstr(TestCase):
 
+    @pytest.mark.slow
     def test_list_of_problems(self):
         list_of_problems = [Maratos(),
                             Maratos(constr_hess='2-point'),

--- a/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
@@ -636,6 +636,7 @@ class TestSplu(object):
         check(np.complex64, True)
         check(np.complex128, True)
 
+    @pytest.mark.slow
     @sup_sparse_efficiency
     def test_threads_parallel(self):
         oks = []
@@ -689,6 +690,7 @@ class TestSpsolveTriangular(object):
             x = spsolve_triangular(matrix_type(A), b, lower=True)
             assert_array_almost_equal(A.dot(x), b)
 
+    @pytest.mark.slow
     @sup_sparse_efficiency
     def test_random(self):
         def random_triangle_matrix(n, lower=True):

--- a/scipy/sparse/tests/test_sparsetools.py
+++ b/scipy/sparse/tests/test_sparsetools.py
@@ -62,6 +62,7 @@ def test_regression_std_vector_dtypes():
         assert_equal(a.getcol(0).todense(), ad[:,0])
 
 
+@pytest.mark.slow
 def test_nnz_overflow():
     # Regression test for gh-7230 / gh-7871, checking that coo_todense
     # with nnz > int32max doesn't overflow.

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -45,6 +45,7 @@ from numpy.linalg import norm
 from numpy.testing import (verbose, assert_,
                            assert_array_equal, assert_equal,
                            assert_almost_equal, assert_allclose)
+import pytest
 from pytest import raises as assert_raises
 
 from scipy._lib._numpy_compat import suppress_warnings
@@ -723,6 +724,7 @@ class TestPdist(object):
         Y_test2 = wpdist_no_const(X, 'test_euclidean')
         _assert_within_tol(Y_test2, Y_right, eps)
 
+    @pytest.mark.slow
     def test_pdist_euclidean_iris_double(self):
         eps = 1e-07
         X = eo['iris']
@@ -730,6 +732,7 @@ class TestPdist(object):
         Y_test1 = wpdist_no_const(X, 'euclidean')
         _assert_within_tol(Y_test1, Y_right, eps)
 
+    @pytest.mark.slow
     def test_pdist_euclidean_iris_float32(self):
         eps = 1e-06
         X = np.float32(eo['iris'])
@@ -737,6 +740,7 @@ class TestPdist(object):
         Y_test1 = wpdist_no_const(X, 'euclidean')
         _assert_within_tol(Y_test1, Y_right, eps, verbose > 2)
 
+    @pytest.mark.slow
     def test_pdist_euclidean_iris_nonC(self):
         # Test pdist(X, 'test_euclidean') [the non-C implementation] on the
         # Iris data set.
@@ -814,6 +818,7 @@ class TestPdist(object):
         Y_test2 = wpdist(X, 'test_cosine')
         _assert_within_tol(Y_test2, Y_right, eps)
 
+    @pytest.mark.slow
     def test_pdist_cosine_iris(self):
         eps = 1e-08
         X = eo['iris']
@@ -821,6 +826,7 @@ class TestPdist(object):
         Y_test1 = wpdist(X, 'cosine')
         _assert_within_tol(Y_test1, Y_right, eps)
 
+    @pytest.mark.slow
     def test_pdist_cosine_iris_float32(self):
         eps = 1e-07
         X = np.float32(eo['iris'])
@@ -828,6 +834,7 @@ class TestPdist(object):
         Y_test1 = wpdist(X, 'cosine')
         _assert_within_tol(Y_test1, Y_right, eps, verbose > 2)
 
+    @pytest.mark.slow
     def test_pdist_cosine_iris_nonC(self):
         eps = 1e-08
         X = eo['iris']
@@ -865,6 +872,7 @@ class TestPdist(object):
         Y_test2 = wpdist_no_const(X, 'test_cityblock')
         _assert_within_tol(Y_test2, Y_right, eps)
 
+    @pytest.mark.slow
     def test_pdist_cityblock_iris(self):
         eps = 1e-14
         X = eo['iris']
@@ -872,6 +880,7 @@ class TestPdist(object):
         Y_test1 = wpdist_no_const(X, 'cityblock')
         _assert_within_tol(Y_test1, Y_right, eps)
 
+    @pytest.mark.slow
     def test_pdist_cityblock_iris_float32(self):
         eps = 1e-06
         X = np.float32(eo['iris'])
@@ -879,6 +888,7 @@ class TestPdist(object):
         Y_test1 = wpdist_no_const(X, 'cityblock')
         _assert_within_tol(Y_test1, Y_right, eps, verbose > 2)
 
+    @pytest.mark.slow
     def test_pdist_cityblock_iris_nonC(self):
         # Test pdist(X, 'test_cityblock') [the non-C implementation] on the
         # Iris data set.
@@ -909,6 +919,7 @@ class TestPdist(object):
         Y_test2 = wpdist(X, 'test_correlation')
         _assert_within_tol(Y_test2, Y_right, eps)
 
+    @pytest.mark.slow
     def test_pdist_correlation_iris(self):
         eps = 1e-08
         X = eo['iris']
@@ -916,6 +927,7 @@ class TestPdist(object):
         Y_test1 = wpdist(X, 'correlation')
         _assert_within_tol(Y_test1, Y_right, eps)
 
+    @pytest.mark.slow
     def test_pdist_correlation_iris_float32(self):
         eps = 1e-07
         X = eo['iris']
@@ -923,6 +935,7 @@ class TestPdist(object):
         Y_test1 = wpdist(X, 'correlation')
         _assert_within_tol(Y_test1, Y_right, eps, verbose > 2)
 
+    @pytest.mark.slow
     def test_pdist_correlation_iris_nonC(self):
         eps = 1e-08
         X = eo['iris']
@@ -951,6 +964,7 @@ class TestPdist(object):
         Y_test2 = wpdist_no_const(X, 'test_minkowski', p=3.2)
         _assert_within_tol(Y_test2, Y_right, eps)
 
+    @pytest.mark.slow
     def test_pdist_minkowski_3_2_iris(self):
         eps = 1e-07
         X = eo['iris']
@@ -958,6 +972,7 @@ class TestPdist(object):
         Y_test1 = wpdist_no_const(X, 'minkowski', p=3.2)
         _assert_within_tol(Y_test1, Y_right, eps)
 
+    @pytest.mark.slow
     def test_pdist_minkowski_3_2_iris_float32(self):
         eps = 1e-06
         X = np.float32(eo['iris'])
@@ -965,6 +980,7 @@ class TestPdist(object):
         Y_test1 = wpdist_no_const(X, 'minkowski', p=3.2)
         _assert_within_tol(Y_test1, Y_right, eps)
 
+    @pytest.mark.slow
     def test_pdist_minkowski_3_2_iris_nonC(self):
         eps = 1e-07
         X = eo['iris']
@@ -972,6 +988,7 @@ class TestPdist(object):
         Y_test2 = wpdist_no_const(X, 'test_minkowski', p=3.2)
         _assert_within_tol(Y_test2, Y_right, eps)
 
+    @pytest.mark.slow
     def test_pdist_minkowski_5_8_iris(self):
         eps = 1e-07
         X = eo['iris']
@@ -979,6 +996,7 @@ class TestPdist(object):
         Y_test1 = wpdist_no_const(X, 'minkowski', p=5.8)
         _assert_within_tol(Y_test1, Y_right, eps)
 
+    @pytest.mark.slow
     def test_pdist_minkowski_5_8_iris_float32(self):
         eps = 1e-06
         X = np.float32(eo['iris'])
@@ -986,6 +1004,7 @@ class TestPdist(object):
         Y_test1 = wpdist_no_const(X, 'minkowski', p=5.8)
         _assert_within_tol(Y_test1, Y_right, eps, verbose > 2)
 
+    @pytest.mark.slow
     def test_pdist_minkowski_5_8_iris_nonC(self):
         eps = 1e-07
         X = eo['iris']
@@ -1270,6 +1289,7 @@ class TestPdist(object):
         assert_allclose(m, 2 / 3, rtol=0, atol=1e-10)
         assert_allclose(m2, 2 / 3, rtol=0, atol=1e-10)
 
+    @pytest.mark.slow
     def test_pdist_canberra_match(self):
         D = eo['iris']
         if verbose > 2:

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -48,7 +48,8 @@ distcont_extra = [
 ]
 
 
-distslow = ['rdist', 'gausshyper', 'recipinvgauss', 'ksone', 'genexpon',
+distslow = ['kappa4', 'crystalball', 'rdist', 'gausshyper',
+            'recipinvgauss', 'ksone', 'genexpon',
             'vonmises', 'vonmises_line', 'mielke', 'semicircular',
             'cosine', 'invweibull', 'powerlognorm', 'johnsonsu', 'kstwobign']
 # distslow are sorted by speed (very slow to slow)

--- a/scipy/stats/tests/test_kdeoth.py
+++ b/scipy/stats/tests/test_kdeoth.py
@@ -4,6 +4,7 @@ from scipy import stats
 import numpy as np
 from numpy.testing import (assert_almost_equal, assert_,
     assert_array_almost_equal, assert_array_almost_equal_nulp)
+import pytest
 from pytest import raises as assert_raises
 
 
@@ -38,6 +39,7 @@ def test_kde_1d():
                         (kdepdf*normpdf).sum()*intervall, decimal=2)
 
 
+@pytest.mark.slow
 def test_kde_2d():
     #some basic tests comparing to normal distribution
     np.random.seed(8765678)

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -9,6 +9,7 @@ import pickle
 from numpy.testing import (assert_allclose, assert_almost_equal,
                            assert_array_almost_equal, assert_equal,
                            assert_array_less, assert_)
+import pytest
 from pytest import raises as assert_raises
 
 from .test_continuous_basic import check_distribution_rvs
@@ -1039,7 +1040,7 @@ class TestMultinomial(object):
 
         vals3 = multinomial.logpmf([3, 4], 0, [-2, 3])
         assert_allclose(vals3, np.NAN, rtol=1e-8)
-        
+
     def test_reduces_binomial(self):
         # test that the multinomial pmf reduces to the binomial pmf in the 2d
         # case
@@ -1092,7 +1093,7 @@ class TestMultinomial(object):
 
         vals4 = multinomial.pmf([1,2], 4, (.3, .7))
         assert_allclose(vals4, 0, rtol=1e-8)
-        
+
         vals5 = multinomial.pmf([3, 3, 0], 6, [2/3.0, 1/3.0, 0])
         assert_allclose(vals5, 0.219478737997, rtol=1e-8)
 
@@ -1474,6 +1475,7 @@ class TestOrthoGroup(object):
         ks_tests = [ks_2samp(proj[p0], proj[p1])[1] for (p0, p1) in pairs]
         assert_array_less([ks_prob]*len(pairs), ks_tests)
 
+    @pytest.mark.slow
     def test_pairwise_distances(self):
         # Test that the distribution of pairwise distances is close to correct.
         np.random.seed(514)


### PR DESCRIPTION
Closes gh-7513. Gives about a 25% speed improvement for `scipy.test()`.

This also fixes the one failure for running tests in parallel with `pytest-xdist` and `scipy.test(extra_argv=['-n', 4])"`. That doesn't scale linearly (there seems to be a lot of scheduling/communication overhead), but for up to 4 cores there's a significant gain. Timings for fast test suite run:
- current master: 280 sec
- this PR: 180 sec
- this PR on 4 cores: 65 sec
- this PR on 16 cores: 50 sec
