### PR TITLE
ENH: add capability to specify orders in pade func

### DIFF
--- a/scipy/interpolate/_pade.py
+++ b/scipy/interpolate/_pade.py
@@ -5,7 +5,7 @@ from scipy import linalg
 
 __all__ = ["pade"]
 
-def pade(an, m):
+def pade(an, m, l=None):
     """
     Return Pade approximation to a polynomial as the ratio of two polynomials.
 
@@ -14,8 +14,11 @@ def pade(an, m):
     an : (N,) array_like
         Taylor series coefficients.
     m : int
-        The order of the returned approximating polynomials.
-
+        The order of the returned approximating polynomial q.
+    l : int, optional
+        The order of the returned approximating polynomial p. By default, 
+        the order is len(an)-m.
+    
     Returns
     -------
     p, q : Polynomial class
@@ -41,11 +44,15 @@ def pade(an, m):
 
     """
     an = asarray(an)
-    N = len(an) - 1
-    n = N - m
-    if n < 0:
+    if l is None:
+        l = len(an) - 1 - m
+    N = m + l
+    if l < 0:
         raise ValueError("Order of q <m> must be smaller than len(an)-1.")
-    Akj = eye(N+1, n+1)
+    if N > len(an)-1:
+        raise ValueError("Order of q+p <m+l> must be smaller than len(an).")
+    an = an[:N+1]
+    Akj = eye(N+1, l+1)
     Bkj = zeros((N+1, m), 'd')
     for row in range(1, m+1):
         Bkj[row,:row] = -(an[:row])[::-1]
@@ -53,7 +60,7 @@ def pade(an, m):
         Bkj[row,:] = -(an[row-m:row])[::-1]
     C = hstack((Akj, Bkj))
     pq = linalg.solve(C, an)
-    p = pq[:n+1]
-    q = r_[1.0, pq[n+1:]]
+    p = pq[:l+1]
+    q = r_[1.0, pq[l+1:]]
     return poly1d(p[::-1]), poly1d(q[::-1])
 

--- a/scipy/interpolate/_pade.py
+++ b/scipy/interpolate/_pade.py
@@ -14,10 +14,10 @@ def pade(an, m, n=None):
     an : (N,) array_like
         Taylor series coefficients.
     m : int
-        The order of the returned approximating polynomial q.
+        The order of the returned approximating polynomial `q`.
     n : int, optional
-        The order of the returned approximating polynomial p. By default, 
-        the order is len(an)-m.
+        The order of the returned approximating polynomial `p`. By default, 
+        the order is ``len(an)-m``.
     
     Returns
     -------

--- a/scipy/interpolate/_pade.py
+++ b/scipy/interpolate/_pade.py
@@ -46,9 +46,11 @@ def pade(an, m, l=None):
     an = asarray(an)
     if l is None:
         l = len(an) - 1 - m
-    N = m + l
+        if l < 0:
+            raise ValueError("Order of q <m> must be smaller than len(an)-1.")
     if l < 0:
-        raise ValueError("Order of q <m> must be smaller than len(an)-1.")
+        raise ValueError("Order of p <l> must be greater than 0.")
+    N = m + l
     if N > len(an)-1:
         raise ValueError("Order of q+p <m+l> must be smaller than len(an).")
     an = an[:N+1]

--- a/scipy/interpolate/_pade.py
+++ b/scipy/interpolate/_pade.py
@@ -5,7 +5,7 @@ from scipy import linalg
 
 __all__ = ["pade"]
 
-def pade(an, m, l=None):
+def pade(an, m, n=None):
     """
     Return Pade approximation to a polynomial as the ratio of two polynomials.
 
@@ -15,7 +15,7 @@ def pade(an, m, l=None):
         Taylor series coefficients.
     m : int
         The order of the returned approximating polynomial q.
-    l : int, optional
+    n : int, optional
         The order of the returned approximating polynomial p. By default, 
         the order is len(an)-m.
     
@@ -44,17 +44,17 @@ def pade(an, m, l=None):
 
     """
     an = asarray(an)
-    if l is None:
-        l = len(an) - 1 - m
-        if l < 0:
+    if n is None:
+        n = len(an) - 1 - m
+        if n < 0:
             raise ValueError("Order of q <m> must be smaller than len(an)-1.")
-    if l < 0:
-        raise ValueError("Order of p <l> must be greater than 0.")
-    N = m + l
+    if n < 0:
+        raise ValueError("Order of p <n> must be greater than 0.")
+    N = m + n
     if N > len(an)-1:
-        raise ValueError("Order of q+p <m+l> must be smaller than len(an).")
+        raise ValueError("Order of q+p <m+n> must be smaller than len(an).")
     an = an[:N+1]
-    Akj = eye(N+1, l+1)
+    Akj = eye(N+1, n+1)
     Bkj = zeros((N+1, m), 'd')
     for row in range(1, m+1):
         Bkj[row,:row] = -(an[:row])[::-1]
@@ -62,7 +62,7 @@ def pade(an, m, l=None):
         Bkj[row,:] = -(an[row-m:row])[::-1]
     C = hstack((Akj, Bkj))
     pq = linalg.solve(C, an)
-    p = pq[:l+1]
-    q = r_[1.0, pq[l+1:]]
+    p = pq[:n+1]
+    q = r_[1.0, pq[n+1:]]
     return poly1d(p[::-1]), poly1d(q[::-1])
 

--- a/scipy/interpolate/tests/test_pade.py
+++ b/scipy/interpolate/tests/test_pade.py
@@ -7,6 +7,10 @@ def test_pade_trivial():
     nump, denomp = pade([1.0], 0)
     assert_array_equal(nump.c, [1.0])
     assert_array_equal(denomp.c, [1.0])
+    
+    nump, denomp = pade([1.0], 0, 0)
+    assert_array_equal(nump.c, [1.0])
+    assert_array_equal(denomp.c, [1.0])
 
 
 def test_pade_4term_exp():
@@ -29,4 +33,34 @@ def test_pade_4term_exp():
     nump, denomp = pade(an, 3)
     assert_array_almost_equal(nump.c, [1.0])
     assert_array_almost_equal(denomp.c, [-1.0/6, 0.5, -1.0, 1.0])
+   
+    # Testing inclusion of optional parameter
+    nump, denomp = pade(an, 0, 3)
+    assert_array_almost_equal(nump.c, [1.0/6, 0.5, 1.0, 1.0])
+    assert_array_almost_equal(denomp.c, [1.0])
+
+    nump, denomp = pade(an, 1, 2)
+    assert_array_almost_equal(nump.c, [1.0/6, 2.0/3, 1.0])
+    assert_array_almost_equal(denomp.c, [-1.0/3, 1.0])
+
+    nump, denomp = pade(an, 2, 1)
+    assert_array_almost_equal(nump.c, [1.0/3, 1.0])
+    assert_array_almost_equal(denomp.c, [1.0/6, -2.0/3, 1.0])
+
+    nump, denomp = pade(an, 3, 0)
+    assert_array_almost_equal(nump.c, [1.0])
+    assert_array_almost_equal(denomp.c, [-1.0/6, 0.5, -1.0, 1.0])
+   
+    # Testing reducing array
+    nump, denomp = pade(an, 0, 2)
+    assert_array_almost_equal(nump.c, [0.5, 1.0, 1.0])
+    assert_array_almost_equal(denomp.c, [1.0])
+
+    nump, denomp = pade(an, 1, 1)
+    assert_array_almost_equal(nump.c, [1.0/2, 1.0])
+    assert_array_almost_equal(denomp.c, [-1.0/2, 1.0])
+
+    nump, denomp = pade(an, 2, 0)
+    assert_array_almost_equal(nump.c, [1.0])
+    assert_array_almost_equal(denomp.c, [1.0/2, -1.0, 1.0])
 


### PR DESCRIPTION
Currently interpolate.pade only takes the order of the denominator <m>
with the order of the numerator assumed from the order of the inputted
array <an>. Added an optional parameter <l> (following standard naming
convention of the pade function) which specifies the order of the
numerator. This is useful if the order of the inputted array returns
a higher order (and computationally more expensive) numerator than needed.
This change does not affect any currently written code.