### PR TITLE
ENH: Rbf interpolation of large multi-dimensional data

### DIFF
--- a/scipy/interpolate/tests/test_rbf.py
+++ b/scipy/interpolate/tests/test_rbf.py
@@ -6,7 +6,7 @@ from __future__ import division, print_function, absolute_import
 import numpy as np
 from numpy.testing import (assert_, assert_array_almost_equal,
                            assert_almost_equal)
-from numpy import linspace, sin, random, exp, allclose
+from numpy import linspace, sin, cos, random, exp, allclose
 from scipy.interpolate.rbf import Rbf
 
 FUNCTIONS = ('multiquadric', 'inverse multiquadric', 'gaussian',
@@ -53,6 +53,52 @@ def test_rbf_interpolation():
         check_rbf3d_interpolation(function)
 
 
+def check_2drbf1d_interpolation(function):
+    # Check that the 2-dim Rbf function interpolates through the nodes (1D)
+    x = linspace(0, 10, 9)
+    y0 = sin(x)
+    y1 = cos(x)
+    y = np.vstack([y0, y1]).T
+    rbf = Rbf(x, y, function=function, mode='N-D')
+    yi = rbf(x)
+    assert_array_almost_equal(y, yi)
+    assert_almost_equal(rbf(float(x[0])), y[0])
+
+
+def check_2drbf2d_interpolation(function):
+    # Check that the 2-dim Rbf function interpolates through the nodes (2D).
+    x = random.rand(50, ) * 4 - 2
+    y = random.rand(50, ) * 4 - 2
+    z0 = x * exp(-x ** 2 - 1j * y ** 2)
+    z1 = y * exp(-y ** 2 - 1j * x ** 2)
+    z = np.vstack([z0, z1]).T
+    rbf = Rbf(x, y, z, epsilon=2, function=function, mode='N-D')
+    zi = rbf(x, y)
+    zi.shape = z.shape
+    assert_array_almost_equal(z, zi)
+
+
+def check_2drbf3d_interpolation(function):
+    # Check that the 2-dim Rbf function interpolates through the nodes (3D).
+    x = random.rand(50, ) * 4 - 2
+    y = random.rand(50, ) * 4 - 2
+    z = random.rand(50, ) * 4 - 2
+    d0 = x * exp(-x ** 2 - y ** 2)
+    d1 = y * exp(-y ** 2 - x ** 2)
+    d = np.vstack([d0, d1]).T
+    rbf = Rbf(x, y, z, d, epsilon=2, function=function, mode='N-D')
+    di = rbf(x, y, z)
+    di.shape = d.shape
+    assert_array_almost_equal(di, d)
+
+
+def test_2drbf_interpolation():
+    for function in FUNCTIONS:
+        check_2drbf1d_interpolation(function)
+        check_2drbf2d_interpolation(function)
+        check_2drbf3d_interpolation(function)
+
+
 def check_rbf1d_regularity(function, atol):
     # Check that the Rbf function approximates a smooth function well away
     # from the nodes.
@@ -83,6 +129,34 @@ def test_rbf_regularity():
     }
     for function in FUNCTIONS:
         check_rbf1d_regularity(function, tolerances.get(function, 1e-2))
+
+
+def check_2drbf1d_regularity(function, atol):
+    # Check that the 2-dim Rbf function approximates a smooth function well away
+    # from the nodes.
+    x = linspace(0, 10, 9)
+    y0 = sin(x)
+    y1 = cos(x)
+    y = np.vstack([y0, y1]).T
+    rbf = Rbf(x, y, function=function, mode='N-D')
+    xi = linspace(0, 10, 100)
+    yi = rbf(xi)
+    msg = "abs-diff: %f" % abs(yi - np.vstack([sin(xi), cos(xi)]).T).max()
+    assert_(allclose(yi, np.vstack([sin(xi), cos(xi)]).T, atol=atol), msg)
+
+
+def test_2drbf_regularity():
+    tolerances = {
+        'multiquadric': 0.1,
+        'inverse multiquadric': 0.15,
+        'gaussian': 0.15,
+        'cubic': 0.15,
+        'quintic': 0.1,
+        'thin-plate': 0.15,
+        'linear': 0.2
+    }
+    for function in FUNCTIONS:
+        check_2drbf1d_regularity(function, tolerances.get(function, 1e-2))
 
 
 def check_rbf1d_stability(function):


### PR DESCRIPTION
So far, scipy.interpolate.Rbf could only be used to interpolate one-dimensional functions, I added the capability to also interpolate multi-dimensional functions.
Furthermore, I changed the way the norm is computed in Rbf to exploit the much faster implementations from scipy.spatial.distance.
Lastly, I also aligned the interface of Rbf to other interpolations in scipy.interpolate such as griddata or LinearNDInterpolator.

Example usage:
```python
>>> from scipy.interpolate import Rbf
>>> x = np.random.rand(50,)*4-2
>>> y = np.random.rand(50,)*4-2
>>> z0 = x*np.exp(-x**2-1j*y**2)
>>> z1 = y*np.exp(-y**2-1j*x**2)
>>> z = np.vstack([z0, z1]).T
>>> rbf = Rbf((x, y), z, epsilon=2)
>>> zi = rbf((x, y))
>>> zi.shape
(50, 2)
```


