### PR TITLE
MAINT: Include ``success`` and ``nit`` in OptimizeResult returned by minimize(method='trust-constr')

### DIFF
--- a/scipy/optimize/_trustregion_constr/minimize_trustregion_constr.py
+++ b/scipy/optimize/_trustregion_constr/minimize_trustregion_constr.py
@@ -59,7 +59,7 @@ class LagrangianHessian(object):
 
 def update_state_sqp(state, x, last_iteration_failed, objective, prepared_constraints,
                      start_time, tr_radius, constr_penalty, cg_info):
-    state.niter += 1
+    state.nit += 1
     state.nfev = objective.nfev
     state.njev = objective.ngev
     state.nhev = objective.nhev
@@ -247,7 +247,7 @@ def _minimize_trustregion_constr(fun, x0, args, grad,
         Gradient of the objective function at the solution.
     lagrangian_grad : ndarray, shape (n,)
         Gradient of the Lagrangian function at the solution.
-    niter : int
+    nit : int
         Total number of iterations.
     nfev : integer
         Number of the objective function evaluations.
@@ -378,7 +378,7 @@ def _minimize_trustregion_constr(fun, x0, args, grad,
 
     # Construct OptimizeResult
     state = OptimizeResult(
-        niter=0, nfev=0, njev=0, nhev=0,
+        nit=0, nfev=0, njev=0, nhev=0,
         cg_niter=0, cg_stop_cond=0,
         fun=objective.f, grad=objective.g,
         lagrangian_grad=np.copy(objective.g),
@@ -403,7 +403,7 @@ def _minimize_trustregion_constr(fun, x0, args, grad,
                                      start_time, tr_radius, constr_penalty,
                                      cg_info)
             if verbose == 2:
-                BasicReport.print_iteration(state.niter,
+                BasicReport.print_iteration(state.nit,
                                             state.nfev,
                                             state.cg_niter,
                                             state.fun,
@@ -411,7 +411,7 @@ def _minimize_trustregion_constr(fun, x0, args, grad,
                                             state.optimality,
                                             state.constr_violation)
             elif verbose > 2:
-                SQPReport.print_iteration(state.niter,
+                SQPReport.print_iteration(state.nit,
                                           state.nfev,
                                           state.cg_niter,
                                           state.fun,
@@ -427,7 +427,7 @@ def _minimize_trustregion_constr(fun, x0, args, grad,
                 state.status = 1
             elif state.tr_radius < xtol:
                 state.status = 2
-            elif state.niter > maxiter:
+            elif state.nit > maxiter:
                 state.status = 0
             return state.status in (0, 1, 2, 3)
     elif method == 'tr_interior_point':
@@ -439,7 +439,7 @@ def _minimize_trustregion_constr(fun, x0, args, grad,
                                     start_time, tr_radius, constr_penalty,
                                     cg_info, barrier_parameter, barrier_tolerance)
             if verbose == 2:
-                BasicReport.print_iteration(state.niter,
+                BasicReport.print_iteration(state.nit,
                                             state.nfev,
                                             state.cg_niter,
                                             state.fun,
@@ -447,7 +447,7 @@ def _minimize_trustregion_constr(fun, x0, args, grad,
                                             state.optimality,
                                             state.constr_violation)
             elif verbose > 2:
-                IPReport.print_iteration(state.niter,
+                IPReport.print_iteration(state.nit,
                                          state.nfev,
                                          state.cg_niter,
                                          state.fun,
@@ -465,7 +465,7 @@ def _minimize_trustregion_constr(fun, x0, args, grad,
             elif (state.tr_radius < xtol
                   and state.barrier_parameter < barrier_tol):
                 state.status = 2
-            elif state.niter > maxiter:
+            elif state.nit > maxiter:
                 state.status = 0
             return state.status in (0, 1, 2, 3)
 
@@ -511,6 +511,9 @@ def _minimize_trustregion_constr(fun, x0, args, grad,
             initial_constr_penalty, initial_tr_radius,
             factorization_method)
 
+    # Status 3 occurs when the callback function requests termination,
+    # this is assumed to not be a success.
+    result.success = True if result.status in (1, 2) else False
     result.message = TERMINATION_MESSAGES[result.status]
 
     if verbose == 2:
@@ -525,7 +528,7 @@ def _minimize_trustregion_constr(fun, x0, args, grad,
         print("Number of iterations: {}, function evaluations: {}, "
               "CG iterations: {}, optimality: {:.2e}, "
               "constraint violation: {:.2e}, execution time: {:4.2} s."
-              .format(result.niter, result.nfev, result.cg_niter,
+              .format(result.nit, result.nfev, result.cg_niter,
                       result.optimality, result.constr_violation,
                       result.execution_time))
     return result

--- a/scipy/optimize/tests/test_minimize_constrained.py
+++ b/scipy/optimize/tests/test_minimize_constrained.py
@@ -4,7 +4,7 @@ import pytest
 from scipy.linalg import block_diag
 from scipy.sparse import csc_matrix
 from numpy.testing import (TestCase, assert_array_almost_equal,
-                           assert_array_less, assert_allclose)
+                           assert_array_less, assert_allclose, assert_)
 from pytest import raises
 from scipy.optimize import (NonlinearConstraint,
                             LinearConstraint,
@@ -585,7 +585,6 @@ class TestTrustRegionConstr(TestCase):
         # xtol
         if result.status == 2:
             assert_array_less(result.tr_radius, 1e-8)
-
             if result.method == "tr_interior_point":
                 assert_array_less(result.barrier_parameter, 1e-8)
         # max iter
@@ -597,3 +596,13 @@ class TestTrustRegionConstr(TestCase):
 
         raises(ValueError, minimize, prob.fun, prob.x0, method='trust-constr',
                jac='2-point', hess='2-point', constraints=prob.constr)
+
+    def test_issue_9044(self):
+        # https://github.com/scipy/scipy/issues/9044
+        # Test the returned `OptimizeResult` contains keys consistent with
+        # other solvers.
+
+        result = minimize(lambda x: x**2, [0], jac=lambda x: 2*x,
+                          hess=lambda x: 2, method='trust-constr')
+        assert_(result.get('success'))
+        assert_(result.get('nit', -1) == 1)


### PR DESCRIPTION
Addresses issue https://github.com/scipy/scipy/issues/9044.

Previously ``minimize(method='trust-constr)`` returns an ``OptimizeResult`` object. The [documentation](https://docs.scipy.org/doc/scipy-0.14.0/reference/generated/scipy.optimize.OptimizeResult.html) states ``OptimizeResult`` contains the keys 

```
success : (bool) Whether or not the optimizer exited successfully.
nit : (int) Number of iterations performed by the optimizer.
```

This PR adds a ``success`` key and renames the ``niter`` field to ``nit``, to better match the documentation.


