### PR TITLE
WIP: Faster distance calculations in 'bounded' scenarios

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -1934,9 +1934,14 @@ def pdist(X, metric='euclidean', *args, **kwargs):
                                                    metric_name, **kwargs)
 
             # get pdist wrapper
+            is_bounded = 'bound' in kwargs
+            bounded_str = '_bounded' if is_bounded else ''
             pdist_fn = getattr(_distance_wrap,
-                               "pdist_%s_%s_wrap" % (metric_name, typ))
-            pdist_fn(X, dm, **kwargs)
+                               "pdist_%s%s_%s_wrap" % (metric_name, bounded_str, typ))
+            if is_bounded:
+                pdist_fn(X, dm, kwargs['bound'], **kwargs)
+            else:
+                pdist_fn(X, dm, **kwargs)
             return dm
 
         elif mstr in ['old_cosine', 'old_cos']:


### PR DESCRIPTION
See discussion in #9205 

Code is nasty at the moment (and not ready for review) - just wanting to prove the concept. Note that this is in part because I'm unfamiliar with the C/Python mixing. On that note, is there a reason we don't use Cython which Just Works and is much easier/cleaner to code (including with Numpy). And, I spent ages trying to figure out an issue with strides, which I discovered where handled further up by copying the array into contiguous formatting (which is an unnecessary slow down?).

Initial results (will update as PR progresses):

```
--------------------------------------------------------------------------------
testing a best-case scenario:
distance.sqeuclidean:                                        0:00:00.088731
unbounded sqeuclidean_bounded_double_wrap                    0:00:00.017311
bounded sqeuclidean_bounded_double_wrap                      0:00:00.000007
--------------------------------------------------------------------------------
testing a best-case nearest search in random data
unbounded sqeuclidean_bounded_double_wrap:                   0:00:00.012723
dynamically bound sqeuclidean_bounded_double_wrap:           0:00:00.000287
--------------------------------------------------------------------------------
testing random pdist
unbounded                                                    0:00:02.567886
bounded                                                      0:00:00.077780
```

In short: it can be a lot faster. Note that it's highly dependent on data structure etc. and I've cherry-picked it.

Uncommented test script if you want to try:

```
from scipy.spatial import distance
import numpy as np
from datetime import datetime

NDIM = int(1e7)

print('-'*80)
print("testing a best-case scenario:")
a = np.arange(NDIM, dtype=np.float64)
b = a + 1
t0 = datetime.now()
_ = distance.sqeuclidean(a,b)
print('distance.sqeuclidean:'.ljust(60), datetime.now() - t0)
t0 = datetime.now()
_ = distance._distance_wrap.sqeuclidean_bounded_double_wrap(a, b, float('Inf'))
print('unbounded sqeuclidean_bounded_double_wrap'.ljust(60), datetime.now() - t0)
t0 = datetime.now()
_ = distance._distance_wrap.sqeuclidean_bounded_double_wrap(a, b, 1.0)
print('bounded sqeuclidean_bounded_double_wrap'.ljust(60), datetime.now() - t0)
del a

print('-'*80)
print("testing a best-case nearest search in random data")
NDIM = int(1e5)
NDATABASE = int(1e2)
b = np.random.normal(size=(NDIM, NDATABASE)).astype(np.float64)
a = b[:, 0]
# a = b[:, 0].copy() # OK, this is weird ... needs to handle stride
t0 = datetime.now()
mind = float('Inf')
for i in range(NDATABASE):
    d = distance._distance_wrap.sqeuclidean_bounded_double_wrap(a, b[:, i], float('Inf'))
    if d < mind:
        mind = d
print('unbounded sqeuclidean_bounded_double_wrap:'.ljust(60), datetime.now() - t0)
t0 = datetime.now()
mind = float('Inf')
for i in range(NDATABASE):
    d = distance._distance_wrap.sqeuclidean_bounded_double_wrap(a, b[:, i], mind)
    if d < mind:
        mind = d
print('dynamically bound sqeuclidean_bounded_double_wrap:'.ljust(60), datetime.now() - t0)
del b

print('-'*80)
print("testing random pdist")
N = 2 * int(1e3)
X = np.random.normal(size=(N, N))
t0 = datetime.now()
_ = distance.pdist(X, 'sqeuclidean')
print('unbounded'.ljust(60), datetime.now() - t0)
t0 = datetime.now()
_ = distance.pdist(X, 'sqeuclidean', bound=10.0)
print('bounded'.ljust(60), datetime.now() - t0)
```

### Questions

For @rgommers ?

- What should the scope of this PR be? Should I just implement these as the C distance functions (e.g. `sqeuclidean_distance_bounded_double`), but not actually used anywhere? Or replace e.g. `distance.squeclidean` with these C versions (including bound and unbound - as above even unbound is 5x faster than the current ones)? Or should I wrap them up into `cdist` and `pdist` as demo'd here? And should I just stick with `squeclidean` for now? My general opinion: I'd prefer a bunch of small-and-sweet PRs as opposed to a big massive one.
- Should I try to handle stride correctly (see commented out code - though I'm not sure it's 100%) or use the current approach (in the python wrapper copy to a new contiguous array)? Or (my preference) can I just use `Cython` to save worrying about this?

### Side note

In some scenarios this can potentially be sped up even further if a principal component analysis is done in advance such that we get the most variability in the early entries - which will hence help us bail out even earlier. I've done this before and, if I remember correctly, it can be e.g. twice as fast (again, highly dependent on data - and probably only makes sense for larger data sets).

