### PR TITLE
MNT: Fix Fourier filter double case

### DIFF
--- a/scipy/ndimage/src/ni_fourier.c
+++ b/scipy/ndimage/src/ni_fourier.c
@@ -424,7 +424,7 @@ int NI_FourierFilter(PyArrayObject *input, PyArrayObject* parameter_array,
             }
             switch (PyArray_TYPE(output)) {
                 CASE_FOURIER_OUT_RR(NPY_FLOAT, npy_float, po, tmp);
-                CASE_FOURIER_OUT_RR(NPY_DOUBLE, npy_float, po, tmp);
+                CASE_FOURIER_OUT_RR(NPY_DOUBLE, npy_double, po, tmp);
                 CASE_FOURIER_OUT_RC(NPY_CFLOAT, npy_cfloat, po, tmp);
                 CASE_FOURIER_OUT_RC(NPY_CDOUBLE, npy_cdouble, po, tmp);
             default:


### PR DESCRIPTION
Fixes https://github.com/scipy/scipy/issues/9194

Seems the case of real double precision input data for a Fourier filter that returns a result was being mishandled accidentally. This fixes that issue by making sure the double precision case has the right type listed.