### PR TITLE
BUG: spatial/distance: fix pdist/cdist performance regression with w=None

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -338,7 +338,7 @@ def _validate_wminkowski_kwargs(X, m, n, **kwargs):
     if w is None:
         raise ValueError('weighted minkowski requires a weight '
                          'vector `w` to be given.')
-    kwargs['w'] = _convert_to_double(w)
+    kwargs['w'] = _validate_weights(w)
     if 'p' not in kwargs:
         kwargs['p'] = 2.
     return kwargs
@@ -1613,7 +1613,7 @@ def _select_weighted_metric(mstr, kwargs, out):
         # w=None is the same as omitting it
         kwargs.pop("w")
 
-    if mstr.startswith("test_"):
+    if mstr.startswith("test_") or mstr in _METRICS['wminkowski'].aka:
         # These support weights
         pass
     elif "w" in kwargs:

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -1889,10 +1889,13 @@ def test_minkowski_w():
                         60., 90., 150., 24., 48.],
                        [83.33333333, 100., 83.33333333, 100., 36.,
                         60., 90., 150., 24., 48.]])
-    pdist(arr_in, metric='minkowski', p=1, w=None)
-    cdist(arr_in, arr_in, metric='minkowski', p=1, w=None)
-    pdist(arr_in, metric='minkowski', p=1)
-    cdist(arr_in, arr_in, metric='minkowski', p=1)
+    p0 = pdist(arr_in, metric='minkowski', p=1, w=None)
+    c0 = cdist(arr_in, arr_in, metric='minkowski', p=1, w=None)
+    p1 = pdist(arr_in, metric='minkowski', p=1)
+    c1 = cdist(arr_in, arr_in, metric='minkowski', p=1)
+
+    assert_allclose(p0, p1, rtol=1e-15)
+    assert_allclose(c0, c1, rtol=1e-15)
 
 
 def test_sqeuclidean_dtypes():


### PR DESCRIPTION
Specifying w=None should be the same as not specifying weights.
Fix the code to respect this, and not select the very much slower
pure-Python code path for w=None.

Fixes the 5000x regressions... https://pv.github.io/scipy-bench/#regressions?sort=3&dir=desc

asv (for one --- running all of them is too slow because the pure-Python code path takes minutes for some inputs, when the C version is done in a few milliseconds):
```
$ python3 runtests.py --bench-compare=master -- 'spatial.Xdist.time_.*cityblock.*'
...
       before           after         ratio
     [10233db2]       [561eb57c]
     <master>         <distance-fix-w>
-       754±100μs       13.7±0.3μs     0.02  spatial.Xdist.time_pdist(10, 'cityblock')
-      1.42±0.2ms         20.9±6μs     0.01  spatial.Xdist.time_cdist(10, 'cityblock')
-        59.9±3ms       30.1±0.3μs     0.00  spatial.Xdist.time_pdist(100, 'cityblock')
-        141±30ms         52.9±9μs     0.00  spatial.Xdist.time_cdist(100, 'cityblock')
-      12.3±0.01s      3.27±0.06ms     0.00  spatial.Xdist.time_cdist(1000, 'cityblock')
```