### PR TITLE
FIX: Proper suppression

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -156,7 +156,10 @@ before_install:
           travis_retry pip uninstall -y numpy
       fi
     fi
-  - if [ "${TESTMODE}" == "full" ]; then pip install pytest-cov coverage; fi
+  - |
+    if [ "${TESTMODE}" == "full" ]; then
+        travis_retry pip install pytest-cov coverage matplotlib
+    fi
   - |
     if [ "${REFGUIDE_CHECK}" == "1" ]; then
         travis_retry pip install matplotlib Sphinx==1.7.2

--- a/scipy/spatial/_plotutils.py
+++ b/scipy/spatial/_plotutils.py
@@ -17,7 +17,7 @@ def _held_figure(func, obj, ax=None, **kw):
 
     # As of matplotlib 2.0, the "hold" mechanism is deprecated.
     # When matplotlib 1.x is no longer supported, this check can be removed.
-    was_held = ax.ishold()
+    was_held = getattr(ax, 'ishold', lambda: True)()
     if was_held:
         return func(obj, ax=ax, **kw)
     try:
@@ -29,8 +29,8 @@ def _held_figure(func, obj, ax=None, **kw):
 
 def _adjust_bounds(ax, points):
     margin = 0.1 * points.ptp(axis=0)
-    xy_min = points.min(axis=0) - margin 
-    xy_max = points.max(axis=0) + margin 
+    xy_min = points.min(axis=0) - margin
+    xy_max = points.max(axis=0) + margin
     ax.set_xlim(xy_min[0], xy_max[0])
     ax.set_ylim(xy_min[1], xy_max[1])
 

--- a/scipy/spatial/tests/test__plotutils.py
+++ b/scipy/spatial/tests/test__plotutils.py
@@ -28,7 +28,7 @@ class TestPlotting:
         fig = plt.figure()
         obj = Delaunay(self.points)
         s_before = obj.simplices.copy()
-        with suppress_warnings as sup:
+        with suppress_warnings() as sup:
             # filter can be removed when matplotlib 1.x is dropped
             sup.filter(message="The ishold function was deprecated in version")
             r = delaunay_plot_2d(obj, ax=fig.gca())
@@ -40,7 +40,7 @@ class TestPlotting:
         # Smoke test
         fig = plt.figure()
         obj = Voronoi(self.points)
-        with suppress_warnings as sup:
+        with suppress_warnings() as sup:
             # filter can be removed when matplotlib 1.x is dropped
             sup.filter(message="The ishold function was deprecated in version")
             r = voronoi_plot_2d(obj, ax=fig.gca())
@@ -52,7 +52,7 @@ class TestPlotting:
         # Smoke test
         fig = plt.figure()
         tri = ConvexHull(self.points)
-        with suppress_warnings as sup:
+        with suppress_warnings() as sup:
             # filter can be removed when matplotlib 1.x is dropped
             sup.filter(message="The ishold function was deprecated in version")
             r = convex_hull_plot_2d(tri, ax=fig.gca())


### PR DESCRIPTION
If you have `matplotlib` installed and run `python runtests.py` you get 3 instances of:
```
self = <scipy.spatial.tests.test__plotutils.TestPlotting object at 0x7f93663c00b8>

    def test_convex_hull(self):
        # Smoke test
        fig = plt.figure()
        tri = ConvexHull(self.points)
>       with suppress_warnings as sup:
E       AttributeError: __enter__

fig        = <Figure size 640x480 with 0 Axes>
self       = <scipy.spatial.tests.test__plotutils.TestPlotting object at 0x7f93663c00b8>
tri        = <scipy.spatial.qhull.ConvexHull object at 0x7f934875ca20>

scipy/spatial/tests/test__plotutils.py:55: AttributeError
```
because `suppress_warnings` is not actually called. This fixes the calling, and installs `matplotlib` in `full` testing mode instead of just `refguide` mode, which would have caught this problem.