### PR TITLE
BENCH: rationalize slow benchmarks + miscellaneous fixes

### DIFF
--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -77,3 +77,16 @@ Some things to consider:
 
 - Use ``run_monitored`` from ``common.py`` if you need to measure memory usage.
 
+- Benchmark versioning: by default ``asv`` invalidates old results
+  when there is any code change in the benchmark routine or in
+  setup/setup_cache.
+
+  This can be controlled manually by setting a fixed benchmark verison
+  number, using the ``version`` attribute. See `ASV documentation`_
+  for details.
+
+  If set manually, the value needs to be changed manually when old
+  results should be invalidated. In case you want to preserve previous
+  benchmark results when the benchmark did not previously have a
+  manual ``version`` attribute, the automatically computed default
+  values can be found in ``results/benchmark.json``.

--- a/benchmarks/benchmarks/fftpack_basic.py
+++ b/benchmarks/benchmarks/fftpack_basic.py
@@ -110,3 +110,6 @@ class Fftn(Benchmark):
             numpy.fft.fftn(self.x)
         else:
             fftn(self.x)
+
+    # Retain old benchmark results (remove this if changing the benchmark)
+    time_fftn.version = "7b630bc6eb41ec0eab713d35b6318dea7a11d785891dae4add928eaac6ed95a4"

--- a/benchmarks/benchmarks/fftpack_basic.py
+++ b/benchmarks/benchmarks/fftpack_basic.py
@@ -98,7 +98,7 @@ class Fftn(Benchmark):
     param_names = ['size', 'type', 'module']
 
     def setup(self, size, cmplx, module):
-        size = map(int, size.split("x"))
+        size = list(map(int, size.split("x")))
 
         if cmplx != 'cmplx':
             self.x = random(size).astype(double)

--- a/benchmarks/benchmarks/io_matlab.py
+++ b/benchmarks/benchmarks/io_matlab.py
@@ -23,7 +23,7 @@ class MemUsage(Benchmark):
 
     @property
     def params(self):
-        return [self._get_sizes().keys(), [True, False]]
+        return [list(self._get_sizes().keys()), [True, False]]
 
     def _get_sizes(self):
         sizes = collections.OrderedDict([

--- a/benchmarks/benchmarks/linalg.py
+++ b/benchmarks/benchmarks/linalg.py
@@ -80,6 +80,13 @@ class Bench(Benchmark):
         else:
             sl.svd(self.a)
 
+    # Retain old benchmark results (remove this if changing the benchmark)
+    time_det.version = "87e530ee50eb6b6c06c7a8abe51c2168e133d5cbd486f4c1c2b9cedc5a078325"
+    time_eigvals.version = "9d68d3a6b473df9bdda3d3fd25c7f9aeea7d5cee869eec730fb2a2bcd1dfb907"
+    time_inv.version = "20beee193c84a5713da9749246a7c40ef21590186c35ed00a4fe854cce9e153b"
+    time_solve.version = "1fe788070f1c9132cbe78a47fdb4cce58266427fc636d2aa9450e3c7d92c644c"
+    time_svd.version = "0ccbda456d096e459d4a6eefc6c674a815179e215f83931a81cfa8c18e39d6e3"
+
 
 class Norm(Benchmark):
     params = [
@@ -165,6 +172,9 @@ class Lstsq(Benchmark):
             sl.lstsq(self.A, self.b, cond=None, overwrite_a=False,
                      overwrite_b=False, check_finite=False,
                      lapack_driver=lapack_driver)
+
+    # Retain old benchmark results (remove this if changing the benchmark)
+    time_lstsq.version = "15ee0be14a0a597c7d1c9a3dab2c39e15c8ac623484410ffefa406bf6b596ebe"
 
 
 class SpecialMatrices(Benchmark):

--- a/benchmarks/benchmarks/linalg.py
+++ b/benchmarks/benchmarks/linalg.py
@@ -28,7 +28,15 @@ class Bench(Benchmark):
     ]
     param_names = ['size', 'contiguous', 'module']
 
+    def __init__(self):
+        # likely not useful to benchmark svd for large sizes
+        self.time_svd.__func__.params = [[20, 100, 500]] + self.params[1:]
+
     def setup(self, size, contig, module):
+        if module == 'numpy' and size >= 200:
+            # skip: slow, and not useful to benchmark numpy
+            raise NotImplementedError()
+
         a = random([size,size])
         # larger diagonal ensures non-singularity:
         for i in range(size):
@@ -125,6 +133,10 @@ class Lstsq(Benchmark):
     ]
 
     def setup(self, dtype, size, lapack_driver):
+        if lapack_driver == 'numpy' and size >= 200:
+            # skip: slow, and not useful to benchmark numpy
+            raise NotImplementedError()
+
         np.random.seed(1234)
         n = math.ceil(2./3. * size)
         k = math.ceil(1./2. * size)

--- a/benchmarks/benchmarks/sparse.py
+++ b/benchmarks/benchmarks/sparse.py
@@ -152,14 +152,15 @@ class Matmul(Benchmark):
 
         random.seed(0)
 
-        matrix1 = lil_matrix(zeros((H1, W1)))
-        matrix2 = lil_matrix(zeros((H2, W2)))
-        for i in range(C1):
-            matrix1[random.randint(H1), random.randint(W1)] = random.rand()
-        for i in range(C2):
-            matrix2[random.randint(H2), random.randint(W2)] = random.rand()
-        self.matrix1 = matrix1.tocsr()
-        self.matrix2 = matrix2.tocsr()
+        i = random.randint(H1, size=C1)
+        j = random.randint(W1, size=C1)
+        data = random.rand(C1)
+        self.matrix1 = coo_matrix((data, (i, j)), shape=(H1, W1)).tocsr()
+
+        i = random.randint(H2, size=C2)
+        j = random.randint(W2, size=C2)
+        data = random.rand(C2)
+        self.matrix2 = coo_matrix((data, (i, j)), shape=(H2, W2)).tocsr()
 
     def time_large(self):
         for i in range(100):

--- a/benchmarks/benchmarks/sparse.py
+++ b/benchmarks/benchmarks/sparse.py
@@ -343,6 +343,8 @@ class Diagonal(Benchmark):
         if format == 'dok' and n * density >= 500:
             raise NotImplementedError()
 
+        warnings.simplefilter('ignore', SparseEfficiencyWarning)
+
         self.X = sparse.rand(n, n, format=format, density=density)
 
     def time_diagonal(self, density, format):
@@ -358,6 +360,7 @@ class Sum(Benchmark):
         if format == 'dok' and n * density >= 500:
             raise NotImplementedError()
 
+        warnings.simplefilter('ignore', SparseEfficiencyWarning)
         self.X = sparse.rand(n, n, format=format, density=density)
 
     def time_sum(self, density, format):
@@ -392,6 +395,7 @@ class Densify(Benchmark):
     param_names = ['format', 'order']
 
     def setup(self, format, order):
+        warnings.simplefilter('ignore', SparseEfficiencyWarning)
         self.X = sparse.rand(1000, 1000, format=format, density=0.01)
 
     def time_toarray(self, format, order):

--- a/benchmarks/benchmarks/sparse.py
+++ b/benchmarks/benchmarks/sparse.py
@@ -166,6 +166,9 @@ class Matmul(Benchmark):
         for i in range(100):
             self.matrix1 * self.matrix2
 
+    # Retain old benchmark results (remove this if changing the benchmark)
+    time_large.version = "33aee08539377a7cb0fabaf0d9ff9d6d80079a428873f451b378c39f6ead48cb"
+
 
 class Construction(Benchmark):
     params = [
@@ -334,6 +337,14 @@ class NullSlice(Benchmark):
     def time_100_cols(self, density, format):
         self.X[:, np.arange(100)]
 
+    # Retain old benchmark results (remove this if changing the benchmark)
+    time_10000_rows.version = "dc19210b894d5fd41d4563f85b7459ef5836cddaf77154b539df3ea91c5d5c1c"
+    time_100_cols.version = "8d43ed52084cdab150018eedb289a749a39f35d4dfa31f53280f1ef286a23046"
+    time_3_cols.version = "93e5123910772d62b3f72abff56c2732f83d217221bce409b70e77b89c311d26"
+    time_3_rows.version = "a9eac80863a0b2f4b510269955041930e5fdd15607238257eb78244f891ebfe6"
+    time_getcol.version = "291388763b355f0f3935db9272a29965d14fa3f305d3306059381e15300e638b"
+    time_getrow.version = "edb9e4291560d6ba8dd58ef371b3a343a333bc10744496adb3ff964762d33c68"
+
 
 class Diagonal(Benchmark):
     params = [[0.01, 0.1, 0.5], ['csr', 'csc', 'coo', 'lil', 'dok', 'dia']]
@@ -350,6 +361,9 @@ class Diagonal(Benchmark):
 
     def time_diagonal(self, density, format):
         self.X.diagonal()
+
+    # Retain old benchmark results (remove this if changing the benchmark)
+    time_diagonal.version = "d84f53fdc6abc208136c8ce48ca156370f6803562f6908eb6bd1424f50310cf1"
 
 
 class Sum(Benchmark):
@@ -372,6 +386,11 @@ class Sum(Benchmark):
 
     def time_sum_axis1(self, density, format):
         self.X.sum(axis=1)
+
+    # Retain old benchmark results (remove this if changing the benchmark)
+    time_sum.version = "05c305857e771024535e546360203b17f5aca2b39b023a49ab296bd746d6cdd3"
+    time_sum_axis0.version = "8aca682fd69aa140c69c028679826bdf43c717589b1961b4702d744ed72effc6"
+    time_sum_axis1.version = "1a6e05244b77f857c61f8ee09ca3abd006a10ba07eff10b1c5f9e0ac20f331b2"
 
 
 class Iteration(Benchmark):
@@ -402,3 +421,5 @@ class Densify(Benchmark):
     def time_toarray(self, format, order):
         self.X.toarray(order=order)
 
+    # Retain old benchmark results (remove this if changing the benchmark)
+    time_toarray.version = "2fbf492ec800b982946a62785beda803460b913cc80080043a5d407025893b2b"

--- a/benchmarks/benchmarks/sparse_linalg_expm.py
+++ b/benchmarks/benchmarks/sparse_linalg_expm.py
@@ -35,28 +35,19 @@ def random_sparse_csc(m, n, nnz_per_row):
 
 
 class ExpmMultiply(Benchmark):
-    params = [['sparse', 'full']]
-    param_names = ['run format']
-
-    def setup(self, *args):
+    def setup(self):
         self.n = 2000
         self.i = 100
         self.j = 200
         nnz_per_row = 25
         self.A = random_sparse_csr(self.n, self.n, nnz_per_row)
-        self.A_dense = self.A.toarray()
 
-    def time_expm_multiply(self, format):
-        if format == 'full':
-            # computing full expm of the dense array...
-            A_expm = scipy.linalg.expm(self.A_dense)
-            A_expm[self.i, self.j]
-        else:
-            # computing only column', j, 'of expm of the sparse matrix...
-            v = np.zeros(self.n, dtype=float)
-            v[self.j] = 1
-            A_expm_col_j = expm_multiply(self.A, v)
-            A_expm_col_j[self.i]
+    def time_expm_multiply(self):
+        # computing only column', j, 'of expm of the sparse matrix
+        v = np.zeros(self.n, dtype=float)
+        v[self.j] = 1
+        A_expm_col_j = expm_multiply(self.A, v)
+        A_expm_col_j[self.i]
 
 
 class Expm(Benchmark):

--- a/benchmarks/benchmarks/sparse_linalg_lobpcg.py
+++ b/benchmarks/benchmarks/sparse_linalg_lobpcg.py
@@ -110,3 +110,7 @@ class Bench(Benchmark):
                                        retResidualNormsHistory=1)
         else:
             eigh(self.A_dense, self.B_dense, eigvals_only=True, eigvals=(0, m - 1))
+
+    # Retain old benchmark results (remove this if changing the benchmark)
+    time_mikota.version = "a1fb679758f7e5cf79d18cc4930afdff999fccc142fe7a4f63e73b39ab1f58bb"
+    time_sakurai.version = "7c38d449924fb71f777bd408072ecc883b8b05e53a6544e97da3887fbc10b235"

--- a/benchmarks/benchmarks/sparse_linalg_lobpcg.py
+++ b/benchmarks/benchmarks/sparse_linalg_lobpcg.py
@@ -79,6 +79,10 @@ class Bench(Benchmark):
         self.shape = (n, n)
         self.A, self.B = _mikota_pair(n)
 
+        if solver == 'eigh' and n >= 512:
+            # skip: slow, and not useful to benchmark
+            raise NotImplementedError()
+
     def setup_sakurai(self, n, solver):
         self.shape = (n, n)
         self.A, self.B, all_eigenvalues = _sakurai(n)

--- a/benchmarks/benchmarks/sparse_linalg_lobpcg.py
+++ b/benchmarks/benchmarks/sparse_linalg_lobpcg.py
@@ -72,7 +72,7 @@ class Bench(Benchmark):
         self.time_mikota.__func__.setup = self.setup_mikota
 
         self.time_sakurai.__func__.params = list(self.params)
-        self.time_sakurai.__func__.params[0] = [50, 400, 2400]
+        self.time_sakurai.__func__.params[0] = [50, 400]
         self.time_sakurai.__func__.setup = self.setup_sakurai
 
     def setup_mikota(self, n, solver):

--- a/benchmarks/benchmarks/sparse_linalg_onenormest.py
+++ b/benchmarks/benchmarks/sparse_linalg_onenormest.py
@@ -24,7 +24,7 @@ class BenchmarkOneNormEst(Benchmark):
     def setup(self, n, solver):
         np.random.seed(1234)
         nrepeats = 100
-        shape = (n, n)
+        shape = (int(n), int(n))
 
         if n <= 1000:
             # Sample the matrices.

--- a/benchmarks/benchmarks/sparse_linalg_onenormest.py
+++ b/benchmarks/benchmarks/sparse_linalg_onenormest.py
@@ -26,6 +26,10 @@ class BenchmarkOneNormEst(Benchmark):
         nrepeats = 100
         shape = (int(n), int(n))
 
+        if solver == 'exact' and n >= 300:
+            # skip: slow, and not useful to benchmark
+            raise NotImplementedError()
+
         if n <= 1000:
             # Sample the matrices.
             self.matrices = []
@@ -33,9 +37,6 @@ class BenchmarkOneNormEst(Benchmark):
                 M = np.random.randn(*shape)
                 self.matrices.append(M)
         else:
-            if solver == 'exact':
-                raise NotImplementedError()
-
             max_nnz = 100000
             nrepeats = 1
 

--- a/benchmarks/benchmarks/sparse_linalg_onenormest.py
+++ b/benchmarks/benchmarks/sparse_linalg_onenormest.py
@@ -55,3 +55,6 @@ class BenchmarkOneNormEst(Benchmark):
             # Get the estimates of one-norms of squares.
             for M in self.matrices:
                 scipy.sparse.linalg.matfuncs._onenormest_matrix_power(M, 2)
+
+    # Retain old benchmark results (remove this if changing the benchmark)
+    time_onenormest.version = "f7b31b4bf5caa50d435465e78dab6e133f3c263a52c4523eec785446185fdb6f"

--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -93,6 +93,9 @@ class Distribution(Benchmark):
             elif properties == 'fit':
                 stats.beta.fit(self.x, loc=4, scale=10)
 
+    # Retain old benchmark results (remove this if changing the benchmark)
+    time_distribution.version = "fb22ae5386501008d945783921fe44aef3f82c1dafc40cddfaccaeec38b792b0"
+
 
 class DescriptiveStats(Benchmark):
     param_names = ['n_levels']

--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -73,7 +73,7 @@ class Distribution(Benchmark):
             elif properties == 'rvs':
                 stats.gamma.rvs(size=1000, a=5, loc=4, scale=10)
             elif properties == 'fit':
-                stats.gamma.fit(self.x, a=5, loc=4, scale=10)
+                stats.gamma.fit(self.x, loc=4, scale=10)
         elif distribution == 'cauchy':
             if properties == 'pdf':
                 stats.cauchy.pdf(self.x, loc=4, scale=10)
@@ -91,7 +91,7 @@ class Distribution(Benchmark):
             elif properties == 'rvs':
                 stats.beta.rvs(size=1000, a=5, b=3, loc=4, scale=10)
             elif properties == 'fit':
-                stats.beta.fit(self.x, a=5, b=3, loc=4, scale=10)
+                stats.beta.fit(self.x, loc=4, scale=10)
 
 
 class DescriptiveStats(Benchmark):


### PR DESCRIPTION
Fix Python 3 bugs.
Skip slowest "comparison" benchmarks, which e.g. benchmark numpy routines or non-relevant scipy routines.
Limit the problem sizes for which some benchmarks are run, in order to reduce runtime.
Rewrite benchmarks/sparse.NullSlice setup() in a faster way.
Fix bugs in benchmark code.

Set [benchmark version numbers](https://asv.readthedocs.io/en/latest/benchmarks.html#general), so that the changes won't invalidate old results. They don't need to be kept in sync with anything or updated in the future. (asv only looks if the `.version` attribute changes, it doesn't care what is in it. The values here are copypasted from results/benchmarks.json --- they come from the default behavior of hashing the source code for setup() and time_*().)

I didn't look here at benchmarks/spatial.py, maybe there's something to fix also there.

First look at gh-9225, trying to fix the worst offenders...

[no ci] / canceled manually