### PR TITLE
ENH: Evaluate plateau size during peak finding

### DIFF
--- a/scipy/signal/tests/test_peak_finding.py
+++ b/scipy/signal/tests/test_peak_finding.py
@@ -23,7 +23,7 @@ from scipy.signal._peak_finding import (
     find_peaks_cwt,
     _identify_ridge_lines
 )
-from scipy.signal._peak_finding_utils import _argmaxima1d, PeakPropertyWarning
+from scipy.signal._peak_finding_utils import _local_maxima_1d, PeakPropertyWarning
 
 
 def _gen_gaussians(center_locs, sigmas, total_length):
@@ -86,56 +86,63 @@ def _gen_ridge_line(start_locs, max_locs, length, distances, gaps):
     return [locs[:, 0], locs[:, 1]]
 
 
-class TestArgmaxima1d(object):
+class TestLocalMaxima1d(object):
 
     def test_empty(self):
         """Test with empty signal."""
         x = np.array([], dtype=np.float64)
-        maxima = _argmaxima1d(x)
-        assert_equal(maxima, np.array([]))
-        assert_(maxima.base is None)
+        for array in _local_maxima_1d(x):
+            assert_equal(array, np.array([]))
+            assert_(array.base is None)
 
     def test_linear(self):
         """Test with linear signal."""
         x = np.linspace(0, 100)
-        maxima = _argmaxima1d(x)
-        assert_equal(maxima, np.array([]))
-        assert_(maxima.base is None)
+        for array in _local_maxima_1d(x):
+            assert_equal(array, np.array([]))
+            assert_(array.base is None)
 
     def test_simple(self):
         """Test with simple signal."""
         x = np.linspace(-10, 10, 50)
         x[2::3] += 1
-        maxima = _argmaxima1d(x)
-        assert_equal(maxima, np.arange(2, 50, 3))
-        assert_(maxima.base is None)
+        expected = np.arange(2, 50, 3)
+        for array in _local_maxima_1d(x):
+            # For plateaus of size 1, the edges are identical with the
+            # midpoints
+            assert_equal(array, expected)
+            assert_(array.base is None)
 
     def test_flat_maxima(self):
         """Test if flat maxima are detected correctly."""
-        x = np.array([-1.3, 0, 1, 0, 2, 2, 0, 3, 3, 3, 0, 4, 4, 4, 4, 0, 5])
-        maxima = _argmaxima1d(x)
-        assert_equal(maxima, np.array([2, 4, 8, 12]))
-        assert_(maxima.base is None)
+        x = np.array([-1.3, 0, 1, 0, 2, 2, 0, 3, 3, 3, 2.99, 4, 4, 4, 4, -10,
+                      -5, -5, -5, -5, -5, -10])
+        midpoints, left_edges, right_edges = _local_maxima_1d(x)
+        assert_equal(midpoints, np.array([2, 4, 8, 12, 18]))
+        assert_equal(left_edges, np.array([2, 4, 7, 11, 16]))
+        assert_equal(right_edges, np.array([2, 5, 9, 14, 20]))
 
-    @pytest.mark.parametrize(
-        'x', [np.array([1., 0, 2]), np.array([3., 3, 0, 4, 4]),
-              np.array([5., 5, 5, 0, 6, 6, 6])])
+    @pytest.mark.parametrize('x', [
+        np.array([1., 0, 2]),
+        np.array([3., 3, 0, 4, 4]),
+        np.array([5., 5, 5, 0, 6, 6, 6]),
+    ])
     def test_signal_edges(self, x):
-        """Test if correct behavior on signal edges."""
-        maxima = _argmaxima1d(x)
-        assert_equal(maxima, np.array([]))
-        assert_(maxima.base is None)
+        """Test if behavior on signal edges is correct."""
+        for array in _local_maxima_1d(x):
+            assert_equal(array, np.array([]))
+            assert_(array.base is None)
 
     def test_exceptions(self):
         """Test input validation and raised exceptions."""
         with raises(ValueError, match="wrong number of dimensions"):
-            _argmaxima1d(np.ones((1, 1)))
+            _local_maxima_1d(np.ones((1, 1)))
         with raises(ValueError, match="expected 'float64_t'"):
-            _argmaxima1d(np.ones(1, dtype=int))
+            _local_maxima_1d(np.ones(1, dtype=int))
         with raises(TypeError, match="list"):
-            _argmaxima1d([1., 2.])
+            _local_maxima_1d([1., 2.])
         with raises(TypeError, match="'x' must not be None"):
-            _argmaxima1d(None)
+            _local_maxima_1d(None)
 
 
 class TestRidgeLines(object):
@@ -613,6 +620,30 @@ class TestFindPeaks(object):
         assert_(peaks.size == 0)
         for key in self.property_keys:
             assert_(props[key].size == 0)
+
+    def test_plateau_size(self):
+        """
+        Test plateau size condition for peaks.
+        """
+        # Prepare signal with peaks with peak_height == plateau_size
+        plateau_sizes = np.array([1, 2, 3, 4, 8, 20, 111])
+        x = np.zeros(plateau_sizes.size * 2 + 1)
+        x[1::2] = plateau_sizes
+        repeats = np.ones(x.size, dtype=int)
+        repeats[1::2] = x[1::2]
+        x = np.repeat(x, repeats)
+
+        # Test full output
+        peaks, props = find_peaks(x, plateau_size=(None, None))
+        assert_equal(peaks, [1, 3, 7, 11, 18, 33, 100])
+        assert_equal(props["plateau_sizes"], plateau_sizes)
+        assert_equal(props["left_edges"], peaks - (plateau_sizes - 1) // 2)
+        assert_equal(props["right_edges"], peaks + plateau_sizes // 2)
+
+        # Test conditions
+        assert_equal(find_peaks(x, plateau_size=4)[0], [11, 18, 33, 100])
+        assert_equal(find_peaks(x, plateau_size=(None, 3.5))[0], [1, 3, 7])
+        assert_equal(find_peaks(x, plateau_size=(5, 50))[0], [18, 33])
 
     def test_height_condition(self):
         """


### PR DESCRIPTION
gh-9110 got me thinking that it might be useful to provide a new condition argument to [find_peaks](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.find_peaks.html) which deals with a peak's plateau size (length of the flat top of a peak in samples). This PR implements the new keyword argument `plateau_size` and if given adds 3 new peak properties to the functions second return argument.

I did a quick comparison of the affected benchmarks on my machine as well.:
```
    before     after       ratio
  [cc75a833] [46195cc3]
     1.58ms     1.51ms      0.96  peak_finding.FindPeaks.time_find_peaks(4096)
     1.59ms     1.49ms      0.94  peak_finding.FindPeaks.time_find_peaks(512)
     1.65ms     1.56ms      0.94  peak_finding.FindPeaks.time_find_peaks(64)
     1.90ms     1.75ms      0.92  peak_finding.FindPeaks.time_find_peaks(8)
   622.96μs   535.90μs      0.86  peak_finding.FindPeaks.time_find_peaks(None)
```

cc @larsoner, @ilayn