### PR TITLE
DOC: Properly render versionadded directive in HTML documentation

### DIFF
--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -1523,8 +1523,6 @@ def matrix_balance(A, permute=True, scale=True, separate=False,
         ``T`` above, the scaling and the permutation vectors are given
         separately as a tuple without allocating the full array ``T``.
 
-    .. versionadded:: 0.19.0
-
     Notes
     -----
 
@@ -1540,6 +1538,8 @@ def matrix_balance(A, permute=True, scale=True, separate=False,
 
     The code is a wrapper around LAPACK's xGEBAL routine family for matrix
     balancing.
+
+    .. versionadded:: 0.19.0
 
     Examples
     --------

--- a/scipy/optimize/_trustregion_krylov.py
+++ b/scipy/optimize/_trustregion_krylov.py
@@ -10,13 +10,13 @@ def _minimize_trust_krylov(fun, x0, args=(), jac=None, hess=None, hessp=None,
     a nearly exact trust-region algorithm that only requires matrix
     vector products with the hessian matrix.
 
+    .. versionadded:: 1.0.0
+
     Options
     -------
     inexact : bool, optional
         Accuracy to solve subproblems. If True requires less nonlinear
         iterations, but more vector products.
-
-    .. versionadded:: 1.0.0
     """
 
     if jac is None:

--- a/scipy/sparse/csgraph/_reordering.pyx
+++ b/scipy/sparse/csgraph/_reordering.pyx
@@ -316,6 +316,8 @@ def structural_rank(graph):
     on the numerical rank of the matrix. A graph has full structural rank 
     if it is possible to permute the elements to make the diagonal zero-free.
 
+    .. versionadded:: 0.19.0
+
     Parameters
     ----------
     graph : sparse matrix
@@ -325,8 +327,6 @@ def structural_rank(graph):
     -------
     rank : int
         The structural rank of the sparse graph.
-
-    .. versionadded:: 0.19.0
     
     References
     ----------

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -993,6 +993,7 @@ def ttest_ind(a, b, axis=0, equal_var=True):
         population variances.
         If False, perform Welch's t-test, which does not assume equal population
         variance.
+
         .. versionadded:: 0.17.0
 
     Returns


### PR DESCRIPTION
It seems like the versionadded directive is not properly replaced with "New in Version ..." when it is not prefixed with an empty line. Furthermore it seems that it can't be placed directly after the "Returns" or "Options" sections. 

Found by searching https://scipy.github.io/devdocs/ for `.. versionadded::`.