### PR TITLE
DOC: Update _ni_docstrings.py

### DIFF
--- a/scipy/ndimage/_ni_docstrings.py
+++ b/scipy/ndimage/_ni_docstrings.py
@@ -34,7 +34,7 @@ footprint : array, optional
 _mode_doc = (
 """mode : {'reflect', 'constant', 'nearest', 'mirror', 'wrap'}, optional
     The `mode` parameter determines how the input array is extended
-    when the filter overlaps a border. Default is 'reflect'. Behavior
+    when the filter overlaps a border. Default is 'constant'. Behavior
     for each valid value is as follows:
 
     'reflect' (`d c b a | a b c d | d c b a`)


### PR DESCRIPTION
the default value of mode in the doc is 'reflect' but in the interpolation.py code is 'constant'. So I decide to fix the doc.