### PR TITLE
TST Use assert_raises "match" parameter instead of the "message" parameter.

### DIFF
--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -626,9 +626,9 @@ class TestInterop(object):
             _impl.splrep(x, y2)
 
         # input below minimum size
-        with assert_raises(TypeError, message="m > k must hold"):
+        with assert_raises(TypeError, match="m > k must hold"):
             splrep(x[:3], y[:3])
-        with assert_raises(TypeError, message="m > k must hold"):
+        with assert_raises(TypeError, match="m > k must hold"):
             _impl.splrep(x[:3], y[:3])
 
     def test_splprep(self):
@@ -649,30 +649,30 @@ class TestInterop(object):
     def test_splprep_errors(self):
         # test that both "old" and "new" code paths raise for x.ndim > 2
         x = np.arange(3*4*5).reshape((3, 4, 5))
-        with assert_raises(ValueError, message="too many values to unpack"):
+        with assert_raises(ValueError, match="too many values to unpack"):
             splprep(x)
-        with assert_raises(ValueError, message="too many values to unpack"):
+        with assert_raises(ValueError, match="too many values to unpack"):
             _impl.splprep(x)
 
         # input below minimum size
         x = np.linspace(0, 40, num=3)
-        with assert_raises(TypeError, message="m > k must hold"):
+        with assert_raises(TypeError, match="m > k must hold"):
             splprep([x])
-        with assert_raises(TypeError, message="m > k must hold"):
+        with assert_raises(TypeError, match="m > k must hold"):
             _impl.splprep([x])
 
         # automatically calculated parameters are non-increasing
         # see gh-7589
         x = [-50.49072266, -50.49072266, -54.49072266, -54.49072266]
-        with assert_raises(ValueError, message="Invalid inputs"):
+        with assert_raises(ValueError, match="Invalid inputs"):
             splprep([x])
-        with assert_raises(ValueError, message="Invalid inputs"):
+        with assert_raises(ValueError, match="Invalid inputs"):
             _impl.splprep([x])
 
         # given non-increasing parameter values u
         x = [1, 3, 2, 4]
         u = [0, 0.3, 0.2, 1]
-        with assert_raises(ValueError, message="Invalid inputs"):
+        with assert_raises(ValueError, match="Invalid inputs"):
             splprep(*[[x], None, u])
 
     def test_sproot(self):

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -1007,11 +1007,8 @@ class TestOptimizeScalar(object):
         assert_raises(ValueError, optimize.fminbound, self.fun, 5, 1)
 
     def test_fminbound_scalar(self):
-        try:
+        with pytest.raises(ValueError, match='.*must be scalar.*'):
             optimize.fminbound(self.fun, np.zeros((1, 2)), 1)
-            self.fail("exception not raised")
-        except ValueError as e:
-            assert_('must be scalar' in str(e))
 
         x = optimize.fminbound(self.fun, 1, np.array(5))
         assert_allclose(x, self.solution, atol=1e-6)

--- a/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
@@ -66,7 +66,7 @@ class TestFactorized(object):
 
     def test_singular_without_umfpack(self):
         use_solver(useUmfpack=False)
-        with assert_raises(RuntimeError, message="Factor is exactly singular"):
+        with assert_raises(RuntimeError, match="Factor is exactly singular"):
             self._check_singular()
 
     @pytest.mark.skipif(not has_umfpack, reason="umfpack not available")
@@ -88,7 +88,7 @@ class TestFactorized(object):
     def test_cannot_factorize_nonsquare_matrix_without_umfpack(self):
         use_solver(useUmfpack=False)
         msg = "can only factor square matrices"
-        with assert_raises(ValueError, message=msg):
+        with assert_raises(ValueError, match=msg):
             factorized(self.A[:, :4])
 
     @pytest.mark.skipif(not has_umfpack, reason="umfpack not available")
@@ -104,12 +104,12 @@ class TestFactorized(object):
         B = random.rand(4, 3)
         BB = random.rand(self.n, 3, 9)
 
-        with assert_raises(ValueError, message="is of incompatible size"):
+        with assert_raises(ValueError, match="is of incompatible size"):
             solve(b)
-        with assert_raises(ValueError, message="is of incompatible size"):
+        with assert_raises(ValueError, match="is of incompatible size"):
             solve(B)
         with assert_raises(ValueError,
-                           message="object too deep for desired array"):
+                           match="object too deep for desired array"):
             solve(BB)
 
     @pytest.mark.skipif(not has_umfpack, reason="umfpack not available")
@@ -123,9 +123,9 @@ class TestFactorized(object):
         # does not raise
         solve(b)
         msg = "object too deep for desired array"
-        with assert_raises(ValueError, message=msg):
+        with assert_raises(ValueError, match=msg):
             solve(B)
-        with assert_raises(ValueError, message=msg):
+        with assert_raises(ValueError, match=msg):
             solve(BB)
 
     def test_call_with_cast_to_complex_without_umfpack(self):
@@ -133,7 +133,7 @@ class TestFactorized(object):
         solve = factorized(self.A)
         b = random.rand(4)
         for t in [np.complex64, np.complex128]:
-            with assert_raises(TypeError, message="Cannot cast array data"):
+            with assert_raises(TypeError, match="Cannot cast array data"):
                 solve(b.astype(t))
 
     @pytest.mark.skipif(not has_umfpack, reason="umfpack not available")
@@ -156,7 +156,7 @@ class TestFactorized(object):
         # should raise when incorrectly assuming indices are sorted
         use_solver(useUmfpack=True, assumeSortedIndices=True)
         with assert_raises(RuntimeError,
-                           message="UMFPACK_ERROR_invalid_matrix"):
+                           match="UMFPACK_ERROR_invalid_matrix"):
             factorized(A)
 
         # should sort indices and succeed when not assuming indices are sorted

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3243,12 +3243,7 @@ class TestSubclassingNoShapes(object):
 
     def test_signature_inspection_2args_incorrect_shapes(self):
         # both _pdf and _cdf defined, but shapes are inconsistent: raises
-        try:
-            _distr3_gen(name='dummy')
-        except TypeError:
-            pass
-        else:
-            raise AssertionError('TypeError not raised.')
+        assert_raises(TypeError, _distr3_gen, **dict(name='dummy'))
 
     def test_defaults_raise(self):
         # default arguments should raise

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3243,7 +3243,7 @@ class TestSubclassingNoShapes(object):
 
     def test_signature_inspection_2args_incorrect_shapes(self):
         # both _pdf and _cdf defined, but shapes are inconsistent: raises
-        assert_raises(TypeError, _distr3_gen, **dict(name='dummy'))
+        assert_raises(TypeError, _distr3_gen, name='dummy')
 
     def test_defaults_raise(self):
         # default arguments should raise

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -103,7 +103,7 @@ class TestTrimmedStats(object):
             assert_raises(ValueError, stats.tmin, x, nan_policy='raise')
             assert_raises(ValueError, stats.tmin, x, nan_policy='foobar')
             msg = "'propagate', 'raise', 'omit'"
-            with assert_raises(ValueError, message=msg):
+            with assert_raises(ValueError, match=msg):
                 stats.tmin(x, nan_policy='foo')
 
     def test_tmax(self):


### PR DESCRIPTION
It appears there are several occurrences in tests where the `match` parameter should have been used in `pytest.raises` instead of the `message` parameter.

The former checks the obtained exception message against a pattern, while the latter is the message printed on failure.

The consequence is that these tests could have been passing while they shouldn't have. Will open an issue about this confusing terminology in pytest.

This also refactors a few tests to use `assert_raises` instead of more complicated constructions and removes one outdated call to `unittest.TestCase.fail` which is no longer used as a base class for tests.
