### PR TITLE
DOC: Add description of default bounds to linprog

### DIFF
--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -312,8 +312,7 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
     less accurate than that of the simplex method and may not correspond with a
     vertex of the polytope defined by the constraints.
 
-    Before applying either method a presolve procedure based on [8]_ and
-    converted attempts to standard form. The presolve procedure attempts to
+    Before applying either method a presolve procedure based on [8]_ attempts to
     identify trivial infeasibilities, trivial unboundedness, and potential
     problem simplifications. Specifically, it checks for:
 
@@ -340,7 +339,7 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
     of the ``A_eq`` matrix are removed, (unless they represent an
     infeasibility) to avoid numerical difficulties in the primary solve
     routine. Note that rows that are nearly linearly dependent (within a
-    prescibed tolerance) may also be removed, which can change the optimal
+    prescribed tolerance) may also be removed, which can change the optimal
     solution in rare cases. If this is a concern, eliminate redundancy from
     your problem formulation and run with option ``rr=False`` or
     ``presolve=False``.

--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -165,10 +165,13 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
 
     Linear Programming is intended to solve the following problem form::
 
-        Minimize:     c^T * x
+        Minimize:     c^T @ x
 
-        Subject to:   A_ub * x <= b_ub
-                      A_eq * x == b_eq
+        Subject to:   A_ub @ x <= b_ub
+                      A_eq @ x == b_eq
+                      lb <= x <= ub
+
+        Where ``lb = 0`` and ``ub = np.inf`` unless set in ``bounds``.
 
     Parameters
     ----------

--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -125,8 +125,8 @@ def linprog_terse_callback(res):
         success : bool
             True if the algorithm succeeded in finding an optimal solution.
         slack : 1D array
-            The values of the slack variables.  Each slack variable corresponds
-            to an inequality constraint.  If the slack is zero, then the
+            The values of the slack variables. Each slack variable corresponds
+            to an inequality constraint. If the slack is zero, then the
             corresponding constraint is active.
         phase : int
             The phase of the optimization being executed. In phase 1 a basic
@@ -230,9 +230,7 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
                      1 : Iteration limit reached
                      2 : Problem appears to be infeasible
                      3 : Problem appears to be unbounded
-                     4 : Serious numerical difficulties which could not resolved
-                         using a more robust, albeit less efficient, solver
-                         encountered
+                     4 : Serious numerical difficulties encountered
 
             nit : int
                 The number of iterations performed.
@@ -273,8 +271,7 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
                  1 : Iteration limit reached
                  2 : Problem appears to be infeasible
                  3 : Problem appears to be unbounded
-                 4 : Serious numerical difficulties which could not resolved using
-                     a more robust, albeit less efficient, solver encountered
+                 4 : Serious numerical difficulties encountered
 
         nit : int
             The number of iterations performed.
@@ -392,13 +389,12 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
         -3x[0] + 1x[1] <= 6
          1x[0] + 2x[1] <= 4
                   x[1] >= -3
-
-    where:  -inf <= x[0] <= inf
+          -inf <= x[0] <= inf
 
     This problem deviates from the standard linear programming problem.
     In standard form, linear programming problems assume the variables x are
-    non-negative.  Since the variables don't have standard bounds where
-    0 <= x <= inf, the bounds of the variables must be explicitly set.
+    non-negative. Since the problem variables don't have the standard bounds of
+    ``(0, None)``, the variable bounds must be set using ``bounds`` explicitly.
 
     There are two upper-bound constraints, which can be expressed as
 
@@ -426,9 +422,6 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
       status: 0
      success: True
            x: array([10., -3.])
-
-    Note the actual objective value is -22.0. In this case we minimized
-    the negative of the objective function.
 
     """
     meth = method.lower()

--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -163,13 +163,13 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
     Minimize a linear objective function subject to linear
     equality and inequality constraints.
 
-    Linear Programming is intended to solve the following problem form:
+    Linear Programming is intended to solve the following problem form::
 
         Minimize:     c^T @ x
 
         Subject to:   A_ub @ x <= b_ub
                       A_eq @ x == b_eq
-                      lb <= x <= ub
+                       lb <= x <= ub
 
     where ``lb = 0`` and ``ub = np.inf`` unless set in ``bounds``.
 

--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -54,7 +54,7 @@ def linprog_verbose_callback(res):
             corresponding constraint is active.
         con : 1D array
             The (nominally zero) residuals of the equality constraints, that is,
-            ``b - A_eq * x``
+            ``b - A_eq @ x``
         phase : int
             The phase of the optimization being executed. In phase 1 a basic
             feasible solution is sought and the T has an additional row
@@ -132,7 +132,7 @@ def linprog_terse_callback(res):
             corresponding constraint is active.
         con : 1D array
             The (nominally zero) residuals of the equality constraints, that is,
-            ``b - A_eq * x``
+            ``b - A_eq @ x``
         phase : int
             The phase of the optimization being executed. In phase 1 a basic
             feasible solution is sought and the T has an additional row
@@ -224,8 +224,8 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
                 corresponds to an inequality constraint. If the slack is zero,
                 the corresponding constraint is active.
             con : 1D array
-                The (nominally zero) residuals of the equality constraints, that is,
-                ``b - A_eq * x``
+                The (nominally zero) residuals of the equality constraints
+                that is, ``b - A_eq @ x``
             phase : int
                 The phase of the optimization being executed. In phase 1 a basic
                 feasible solution is sought and the T has an additional row
@@ -243,6 +243,7 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
                 The number of iterations performed.
             message : str
                 A string descriptor of the exit status of the optimization.
+
     options : dict, optional
         A dictionary of solver options. All methods accept the following
         generic options:
@@ -267,6 +268,9 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
             The values of the slack variables. Each slack variable corresponds
             to an inequality constraint.  If the slack is zero, then the
             corresponding constraint is active.
+        con : 1D array
+            The (nominally zero) residuals of the equality constraints, that is,
+            ``b - A_eq @ x``
         success : bool
             Returns True if the algorithm succeeded in finding an optimal
             solution.

--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -52,6 +52,9 @@ def linprog_verbose_callback(res):
             The values of the slack variables.  Each slack variable corresponds
             to an inequality constraint.  If the slack is zero, then the
             corresponding constraint is active.
+        con : 1D array
+            The (nominally zero) residuals of the equality constraints, that is,
+            ``b - A_eq * x``
         phase : int
             The phase of the optimization being executed. In phase 1 a basic
             feasible solution is sought and the T has an additional row
@@ -63,8 +66,7 @@ def linprog_verbose_callback(res):
                  1 : Iteration limit reached
                  2 : Problem appears to be infeasible
                  3 : Problem appears to be unbounded
-                 4 : Serious numerical difficulties which could not resolved using
-                     a more robust, albeit less efficient, solver encountered
+                 4 : Serious numerical difficulties encountered
 
         nit : int
             The number of iterations performed.
@@ -128,6 +130,9 @@ def linprog_terse_callback(res):
             The values of the slack variables. Each slack variable corresponds
             to an inequality constraint. If the slack is zero, then the
             corresponding constraint is active.
+        con : 1D array
+            The (nominally zero) residuals of the equality constraints, that is,
+            ``b - A_eq * x``
         phase : int
             The phase of the optimization being executed. In phase 1 a basic
             feasible solution is sought and the T has an additional row
@@ -139,8 +144,7 @@ def linprog_terse_callback(res):
                  1 : Iteration limit reached
                  2 : Problem appears to be infeasible
                  3 : Problem appears to be unbounded
-                 4 : Serious numerical difficulties which could not be resolved
-                     using a more robust, albeit less efficient, solver.
+                 4 : Serious numerical difficulties encountered
 
         nit : int
             The number of iterations performed.
@@ -166,7 +170,7 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
 
     Minimize::
 
-        cT @ x
+        c @ x
 
     Subject to::
 
@@ -196,7 +200,7 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
         ``(min, max)`` pairs for each element in ``x``, defining
         the bounds on that parameter. Use None for one of ``min`` or
         ``max`` when there is no bound in that direction. By default
-        bounds are ``(0, None)`` (non-negative)
+        bounds are ``(0, None)`` (non-negative).
         If a sequence containing a single tuple is provided, then ``min`` and
         ``max`` will be applied to all variables in the problem.
     method : str, optional
@@ -219,6 +223,9 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
                 The values of the slack variables. Each slack variable
                 corresponds to an inequality constraint. If the slack is zero,
                 the corresponding constraint is active.
+            con : 1D array
+                The (nominally zero) residuals of the equality constraints, that is,
+                ``b - A_eq * x``
             phase : int
                 The phase of the optimization being executed. In phase 1 a basic
                 feasible solution is sought and the T has an additional row
@@ -236,7 +243,6 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
                 The number of iterations performed.
             message : str
                 A string descriptor of the exit status of the optimization.
-
     options : dict, optional
         A dictionary of solver options. All methods accept the following
         generic options:
@@ -302,9 +308,10 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
     less accurate than that of the simplex method and may not correspond with a
     vertex of the polytope defined by the constraints.
 
-    Both methods apply a presolve procedure based on [8]_ attempts to identify
-    trivial infeasibilities, trivial unboundedness, and potential problem
-    simplifications. Specifically, it checks for:
+    Before applying either method a presolve procedure based on [8]_ and
+    converted attempts to standard form. The presolve procedure attempts to
+    identify trivial infeasibilities, trivial unboundedness, and potential
+    problem simplifications. Specifically, it checks for:
 
     - rows of zeros in ``A_eq`` or ``A_ub``, representing trivial constraints;
     - columns of zeros in ``A_eq`` `and` ``A_ub``, representing unconstrained

--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -163,7 +163,7 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
     Minimize a linear objective function subject to linear
     equality and inequality constraints.
 
-    Linear Programming is intended to solve the following problem form::
+    Linear Programming is intended to solve the following problem form:
 
         Minimize:     c^T @ x
 
@@ -171,7 +171,7 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
                       A_eq @ x == b_eq
                       lb <= x <= ub
 
-        Where ``lb = 0`` and ``ub = np.inf`` unless set in ``bounds``.
+    where ``lb = 0`` and ``ub = np.inf`` unless set in ``bounds``.
 
     Parameters
     ----------

--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -166,7 +166,7 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
 
     Minimize::
 
-        c^T @ x
+        cT @ x
 
     Subject to::
 
@@ -174,7 +174,7 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
         A_eq @ x == b_eq
          lb <= x <= ub
 
-    where ``lb = 0`` and ``ub = np.inf`` unless set in ``bounds``.
+    where ``lb = 0`` and ``ub = None`` unless set in ``bounds``.
 
     Parameters
     ----------
@@ -383,11 +383,15 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
     --------
     Consider the following problem:
 
-    Minimize: f = -1*x[0] + 4*x[1]
+    Minimize::
 
-    Subject to: -3*x[0] + 1*x[1] <= 6
-                 1*x[0] + 2*x[1] <= 4
-                            x[1] >= -3
+        f = -1x[0] + 4x[1]
+
+    Subject to::
+
+        -3x[0] + 1x[1] <= 6
+         1x[0] + 2x[1] <= 4
+                  x[1] >= -3
 
     where:  -inf <= x[0] <= inf
 

--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -161,15 +161,18 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
             options=None):
     """
     Minimize a linear objective function subject to linear
-    equality and inequality constraints.
+    equality and inequality constraints. Linear Programming is intended to
+    solve the following problem form:
 
-    Linear Programming is intended to solve the following problem form::
+    Minimize::
 
-        Minimize:     c^T @ x
+        c^T @ x
 
-        Subject to:   A_ub @ x <= b_ub
-                      A_eq @ x == b_eq
-                       lb <= x <= ub
+    Subject to::
+
+        A_ub @ x <= b_ub
+        A_eq @ x == b_eq
+         lb <= x <= ub
 
     where ``lb = 0`` and ``ub = np.inf`` unless set in ``bounds``.
 

--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -776,14 +776,17 @@ def _linprog_ip(
     r"""
     Minimize a linear objective function subject to linear
     equality constraints, linear inequality constraints, and simple bounds
-    using the interior point method of [4]_.
+    using the interior point method of [4]_. Linear programming is intended to
+    solve problems of the following form:
 
-    Linear programming is intended to solve problems of the following form::
+    Minimize::
 
-        Minimize:     c^T @ x
+        c^T @ x
 
-        Subject to:      A @ x == b
-                             0 >= x
+    Subject to::
+
+        A @ x == b
+            x >= 0
 
     Parameters
     ----------

--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -886,7 +886,6 @@ def _linprog_ip(
 
     Notes
     -----
-
     This method implements the algorithm outlined in [4]_ with ideas from [8]_
     and a structure inspired by the simpler methods of [6]_ and [4]_.
 
@@ -959,12 +958,44 @@ def _linprog_ip(
     unboundedness, or infeasibility is detected, the solve procedure
     terminates; otherwise it repeats.
 
-    If optimality is achieved, a postsolve procedure undoes transformations
-    associated with presolve and converting to standard form. It then
-    calculates the residuals (equality constraint violations, which should
-    be very small) and slacks (difference between the left and right hand
-    sides of the upper bound constraints) of the original problem, which are
-    returned with the solution in an ``OptimizeResult`` object.
+    The expected problem formulation differs between the top level ``linprog``
+    module and the method specific solvers. The method specific solvers expect a
+    problem in standard form:
+
+    Minimize::
+
+        c @ x
+
+    Subject to::
+
+        A @ x == b
+            x >= 0
+
+    Whereas the top level ``linprog`` module expects a problem of form:
+
+    Minimize::
+
+        c @ x
+
+    Subject to::
+
+        A_ub @ x <= b_ub
+        A_eq @ x == b_eq
+         lb <= x <= ub
+
+    where ``lb = 0`` and ``ub = None`` unless set in ``bounds``.
+
+    Note the equality constraints and non-negativity constraints in the method
+    specific solvers.
+
+    Note the original problem contains equality, upper-bound and variable
+    constraints whereas the method specific solver requires equality constraints
+    and variable non-negativity only. The top level ``linprog`` module
+    converts the original problem to standard form by converting the simple
+    bounds to upper bound constraints, introducing non-negative slack variables
+    for inequality constraints, and expressing unbounded variables as the
+    difference between two non-negative variables.
+
 
     References
     ----------

--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -371,8 +371,7 @@ def _get_message(status):
          1 : Iteration limit reached
          2 : Problem appears to be infeasible
          3 : Problem appears to be unbounded
-         4 : Serious numerical difficulties which could not resolved using
-             a more robust, albeit less efficient, solver encountered
+         4 : Serious numerical difficulties encountered
 
     Returns
     -------
@@ -539,10 +538,14 @@ def _ip_hsd(A, b, c, c0, alpha0, beta, maxiter, disp, tol,
     r"""
     Solve a linear programming problem in standard form:
 
-    minimize:     c'^T @ x'
+    Minimize::
 
-    subject to:   A @ x' == b
-                      x' >= 0
+        c @ x
+
+    Subject to::
+
+        A @ x == b
+            x >= 0
 
     using the interior point method of [4].
 
@@ -622,8 +625,7 @@ def _ip_hsd(A, b, c, c0, alpha0, beta, maxiter, disp, tol,
          1 : Iteration limit reached
          2 : Problem appears to be infeasible
          3 : Problem appears to be unbounded
-         4 : Serious numerical difficulties, that could not be resolved
-             using a more robust solver encountered
+         4 : Serious numerical difficulties encountered
 
     message : str
         A string descriptor of the exit status of the optimization.
@@ -775,13 +777,13 @@ def _linprog_ip(
         **unknown_options):
     r"""
     Minimize a linear objective function subject to linear
-    equality constraints, linear inequality constraints, and simple bounds
-    using the interior point method of [4]_. Linear programming is intended to
-    solve problems of the following form:
+    equality and non-negativity constraints using the interior point method
+    of [4]_. Linear programming is intended to solve problems
+    of the following form:
 
     Minimize::
 
-        cT @ x
+        c @ x
 
     Subject to::
 
@@ -875,8 +877,7 @@ def _linprog_ip(
          1 : Iteration limit reached
          2 : Problem appears to be infeasible
          3 : Problem appears to be unbounded
-         4 : Serious numerical difficulties not resolved using a more robust,
-             yet less efficient, solver encountered
+         4 : Serious numerical difficulties encountered
 
     message : str
         A string descriptor of the exit status of the optimization.

--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -781,7 +781,7 @@ def _linprog_ip(
 
     Minimize::
 
-        c^T @ x
+        cT @ x
 
     Subject to::
 

--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -985,16 +985,14 @@ def _linprog_ip(
 
     where ``lb = 0`` and ``ub = None`` unless set in ``bounds``.
 
-    Note the equality constraints and non-negativity constraints in the method
-    specific solvers.
+    The original problem contains equality, upper-bound and variable constraints
+    whereas the method specific solver requires equality constraints and
+    variable non-negativity.
 
-    Note the original problem contains equality, upper-bound and variable
-    constraints whereas the method specific solver requires equality constraints
-    and variable non-negativity only. The top level ``linprog`` module
-    converts the original problem to standard form by converting the simple
-    bounds to upper bound constraints, introducing non-negative slack variables
-    for inequality constraints, and expressing unbounded variables as the
-    difference between two non-negative variables.
+    ``linprog`` module converts the original problem to standard form by
+    converting the simple bounds to upper bound constraints, introducing
+    non-negative slack variables for inequality constraints, and expressing
+    unbounded variables as the difference between two non-negative variables.
 
 
     References

--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -9,7 +9,7 @@ import scipy as sp
 import scipy.sparse as sps
 from warnings import warn
 from scipy.linalg import LinAlgError
-from .optimize import OptimizeResult, OptimizeWarning, _check_unknown_options
+from .optimize import OptimizeWarning, _check_unknown_options
 
 
 def _get_solver(sparse=False, lstsq=False, sym_pos=True, cholesky=True):

--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -542,7 +542,7 @@ def _ip_hsd(A, b, c, c0, alpha0, beta, maxiter, disp, tol,
     minimize:     c'^T @ x'
 
     subject to:   A @ x' == b
-                  0 < x' < oo
+                      x' >= 0
 
     using the interior point method of [4].
 

--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -539,9 +539,9 @@ def _ip_hsd(A, b, c, c0, alpha0, beta, maxiter, disp, tol,
     r"""
     Solve a linear programming problem in standard form:
 
-    minimize:     c'^T * x'
+    minimize:     c'^T @ x'
 
-    subject to:   A * x' == b
+    subject to:   A @ x' == b
                   0 < x' < oo
 
     using the interior point method of [4].
@@ -780,9 +780,9 @@ def _linprog_ip(
 
     Linear programming is intended to solve problems of the following form::
 
-        Minimize:     c^T * x
+        Minimize:     c^T @ x
 
-        Subject to:      A * x == b
+        Subject to:      A @ x == b
                          0 <= x < oo
 
     Parameters

--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -783,7 +783,7 @@ def _linprog_ip(
         Minimize:     c^T @ x
 
         Subject to:      A @ x == b
-                         0 <= x < oo
+                             0 >= x
 
     Parameters
     ----------

--- a/scipy/optimize/_linprog_simplex.py
+++ b/scipy/optimize/_linprog_simplex.py
@@ -135,7 +135,7 @@ def _solve_simplex(T, n, basis, maxiter=1000, phase=2, status=0, message='',
     """
     Solve a linear programming problem in "standard maximization form" using
     the Simplex Method. Linear Programming is intended to solve the following
-    problem form::
+    problem form:
 
     Minimize::
 
@@ -145,7 +145,6 @@ def _solve_simplex(T, n, basis, maxiter=1000, phase=2, status=0, message='',
 
         A @ x == b
             x >= 0
-
 
     Parameters
     ----------

--- a/scipy/optimize/_linprog_simplex.py
+++ b/scipy/optimize/_linprog_simplex.py
@@ -337,8 +337,6 @@ def _linprog_simplex(c, c0, A, b, maxiter=1000, disp=False, callback=None,
     non-negativity constraints using the two phase simplex method.
     Linear programming is intended to solve problems of the following form:
 
-    The  of the form:
-
     Minimize::
 
         c @ x
@@ -497,7 +495,7 @@ def _linprog_simplex(c, c0, A, b, maxiter=1000, disp=False, callback=None,
     A[is_negative_constraint] *= -1
     b[is_negative_constraint] *= -1
 
-    # As all constraints are equality constraints the artifical variables
+    # As all constraints are equality constraints the artificial variables
     # will also be basic variables.
     av = np.arange(n) + m
     basis = av.copy()

--- a/scipy/optimize/_linprog_simplex.py
+++ b/scipy/optimize/_linprog_simplex.py
@@ -333,8 +333,11 @@ def _solve_simplex(T, n, basis, maxiter=1000, phase=2, status=0, message='',
 def _linprog_simplex(c, c0, A, b, maxiter=1000, disp=False, callback=None,
                      tol=1.0E-12, bland=False, _T_o=None, **unknown_options):
     """
-    Solve the following linear programming problem via a two-phase
-    simplex algorithm of the form:
+    Minimize a linear objective function subject to linear equality and
+    non-negativity constraints using the two phase simplex method.
+    Linear programming is intended to solve problems of the following form:
+
+    The  of the form:
 
     Minimize::
 
@@ -468,13 +471,14 @@ def _linprog_simplex(c, c0, A, b, maxiter=1000, disp=False, callback=None,
 
     where ``lb = 0`` and ``ub = None`` unless set in ``bounds``.
 
-    Note the original problem contains equality, upper-bound and variable
-    constraints whereas the method specific solver requires equality constraints
-    and variable non-negativity only. The top level ``linprog`` module
-    converts the original problem to standard form by converting the simple
-    bounds to upper bound constraints, introducing non-negative slack variables
-    for inequality constraints, and expressing unbounded variables as the
-    difference between two non-negative variables.
+    The original problem contains equality, upper-bound and variable constraints
+    whereas the method specific solver requires equality constraints and
+    variable non-negativity.
+
+    ``linprog`` module converts the original problem to standard form by
+    converting the simple bounds to upper bound constraints, introducing
+    non-negative slack variables for inequality constraints, and expressing
+    unbounded variables as the difference between two non-negative variables.
     """
     _check_unknown_options(unknown_options)
 

--- a/scipy/optimize/_linprog_simplex.py
+++ b/scipy/optimize/_linprog_simplex.py
@@ -137,10 +137,15 @@ def _solve_simplex(T, n, basis, maxiter=1000, phase=2, status=0, message='',
     the Simplex Method. Linear Programming is intended to solve the following
     problem form::
 
-        minimize:     c'^T @ x'
+    Minimize::
 
-        subject to:   A @ x' == b
-                          x' >= 0
+        c^T @ x
+
+    Subject to::
+
+        A @ x == b
+            x >= 0
+
 
     Parameters
     ----------

--- a/scipy/optimize/_linprog_simplex.py
+++ b/scipy/optimize/_linprog_simplex.py
@@ -204,7 +204,7 @@ def _solve_simplex(T, n, basis, maxiter=1000, phase=2, status=0, message='',
                 the corresponding constraint is active.
             con : 1D array
                 The (nominally zero) residuals of the equality constraints,
-                that is, ``b - A_eq * x``
+                that is, ``b - A_eq @ x``
             phase : int
                 The phase of the optimization being executed. In phase 1 a basic
                 feasible solution is sought and the T has an additional row
@@ -376,7 +376,7 @@ def _linprog_simplex(c, c0, A, b, maxiter=1000, disp=False, callback=None,
                 the corresponding constraint is active.
             con : 1D array
                 The (nominally zero) residuals of the equality constraints, that
-                is, ``b - A_eq * x``
+                is, ``b - A_eq @ x``
             phase : int
                 The phase of the optimization being executed. In phase 1 a basic
                 feasible solution is sought and the T has an additional row

--- a/scipy/optimize/_linprog_simplex.py
+++ b/scipy/optimize/_linprog_simplex.py
@@ -18,7 +18,7 @@ def _pivot_col(T, tol=1.0E-12, bland=False):
         The simplex tableau.
     tol : float
         Elements in the objective row larger than -tol will not be considered
-        for pivoting.  Nominally this value is zero, but numerical issues
+        for pivoting. Nominally this value is zero, but numerical issues
         cause a tolerance about zero to be necessary.
     bland : bool
         If True, use Bland's rule for selection of the column (select the
@@ -60,7 +60,7 @@ def _pivot_row(T, basis, pivcol, phase, tol=1.0E-12, bland=False):
         The phase of the simplex algorithm (1 or 2).
     tol : float
         Elements in the pivot column smaller than tol will not be considered
-        for pivoting.  Nominally this value is zero, but numerical issues
+        for pivoting. Nominally this value is zero, but numerical issues
         cause a tolerance about zero to be necessary.
     bland : bool
         If True, use Bland's rule for selection of the row (if more than one
@@ -69,10 +69,10 @@ def _pivot_row(T, basis, pivcol, phase, tol=1.0E-12, bland=False):
     Returns
     -------
     status: bool
-        True if a suitable pivot row was found, otherwise False.  A return
+        True if a suitable pivot row was found, otherwise False. A return
         of False indicates that the linear programming problem is unbounded.
     row: int
-        The index of the row of the pivot element.  If status is False, row
+        The index of the row of the pivot element. If status is False, row
         will be returned as nan.
     """
     if phase == 1:
@@ -150,7 +150,7 @@ def _solve_simplex(T, n, basis, maxiter=1000, phase=2, status=0, message='',
     ----------
     T : 2D array
         A 2D array representing the simplex T corresponding to the
-        maximization problem.  It should have the form:
+        maximization problem. It should have the form:
 
         [[A[0, 0], A[0, 1], ..., A[0, n_total], b[0]],
          [A[1, 0], A[1, 1], ..., A[1, n_total], b[1]],
@@ -172,7 +172,7 @@ def _solve_simplex(T, n, basis, maxiter=1000, phase=2, status=0, message='',
          [c'[0],  c'[1], ...,  c'[n_total],  0]]
 
          for a Phase 1 problem (a Problem in which a basic feasible solution is
-         sought prior to maximizing the actual objective.  T is modified in
+         sought prior to maximizing the actual objective. T is modified in
          place by _solve_simplex.
     n : int
         The number of true variables in the problem.
@@ -205,7 +205,7 @@ def _solve_simplex(T, n, basis, maxiter=1000, phase=2, status=0, message='',
         The initial iteration number used to keep an accurate iteration total
         in a two-phase problem.
     bland : bool
-        If True, choose pivots using Bland's rule [3]_.  In problems which
+        If True, choose pivots using Bland's rule [3]_. In problems which
         fail to converge due to cycling, using Bland's rule can provide
         convergence at the expense of a less optimal path about the simplex.
 
@@ -347,7 +347,7 @@ def _linprog_simplex(c, c0, A, b, maxiter=1000, disp=False, callback=None,
             success : bool
                 True if the algorithm succeeded in finding an optimal solution.
             slack : 1D array
-                The values of the slack variables.  Each slack variable
+                The values of the slack variables. Each slack variable
                 corresponds to an inequality constraint. If the slack is zero,
                 the corresponding constraint is active.
             phase : int
@@ -361,9 +361,7 @@ def _linprog_simplex(c, c0, A, b, maxiter=1000, disp=False, callback=None,
                      1 : Iteration limit reached
                      2 : Problem appears to be infeasible
                      3 : Problem appears to be unbounded
-                     4 : Serious numerical difficulties which could not resolved
-                         using a more robust, albeit less efficient, solver
-                         encountered
+                     4 : Serious numerical difficulties encountered
 
             nit : int
                 The number of iterations performed.
@@ -381,8 +379,8 @@ def _linprog_simplex(c, c0, A, b, maxiter=1000, disp=False, callback=None,
         enough to positive to serve as an optimal solution.
     bland : bool
         If True, use Bland's anti-cycling rule [3]_ to choose pivots to
-        prevent cycling.  If False, choose pivots which should lead to a
-        converged solution more quickly.  The latter method is subject to
+        prevent cycling. If False, choose pivots which should lead to a
+        converged solution more quickly. The latter method is subject to
         cycling (non-convergence) in rare instances.
 
     Returns
@@ -396,56 +394,12 @@ def _linprog_simplex(c, c0, A, b, maxiter=1000, disp=False, callback=None,
          1 : Iteration limit reached
          2 : Problem appears to be infeasible
          3 : Problem appears to be unbounded
-         4 : Serious numerical difficulties which could not resolved using
-             a more robust, albeit less efficient, solver encountered
+         4 : Serious numerical difficulties encountered
 
     message : str
         A string descriptor of the exit status of the optimization.
     iteration : int
         The number of iterations taken to solve the problem.
-
-    Examples
-    --------
-    Consider the following problem:
-
-    Minimize::
-
-        f = -1x[0] + 4x[1]
-
-    Subject to::
-
-        -3x[0] + 1x[1] <= 6
-         1x[0] + 2x[1] <= 4
-                  x[1] >= -3
-
-    where:  -inf <= x[0] <= inf
-
-    This problem deviates from the standard linear programming problem.  In
-    standard form, linear programming problems assume the variables x are
-    non-negative.  Since the variables don't have standard bounds where
-    0 <= x <= inf, the bounds of the variables must be explicitly set.
-
-    There are two upper-bound constraints, which can be expressed as
-
-    dot(A_ub, x) <= b_ub
-
-    The input for this problem is as follows:
-
-    >>> from scipy.optimize import linprog
-    >>> c = [-1, 4]
-    >>> A = [[-3, 1], [1, 2]]
-    >>> b = [6, 4]
-    >>> x0_bnds = (None, None)
-    >>> x1_bnds = (-3, None)
-    >>> res = linprog(c, A, b, bounds=(x0_bnds, x1_bnds))
-    >>> print(res)
-         fun: -22.0
-     message: 'Optimization terminated successfully.'
-         nit: 1
-       slack: array([ 39.,   0.])
-      status: 0
-     success: True
-           x: array([ 10.,  -3.])
 
     References
     ----------

--- a/scipy/optimize/_linprog_simplex.py
+++ b/scipy/optimize/_linprog_simplex.py
@@ -139,7 +139,7 @@ def _solve_simplex(T, n, basis, maxiter=1000, phase=2, status=0, message='',
 
     Minimize::
 
-        c^T @ x
+        cT @ x
 
     Subject to::
 
@@ -205,7 +205,7 @@ def _solve_simplex(T, n, basis, maxiter=1000, phase=2, status=0, message='',
         The initial iteration number used to keep an accurate iteration total
         in a two-phase problem.
     bland : bool
-        If True, choose pivots using Bland's rule [3].  In problems which
+        If True, choose pivots using Bland's rule [3]_.  In problems which
         fail to converge due to cycling, using Bland's rule can provide
         convergence at the expense of a less optimal path about the simplex.
 
@@ -310,12 +310,16 @@ def _linprog_simplex(c, c0, A, b, maxiter=1000, disp=False, callback=None,
                      tol=1.0E-12, bland=False, _T_o=None, **unknown_options):
     """
     Solve the following linear programming problem via a two-phase
-    simplex algorithm of the form::
+    simplex algorithm of the form:
 
-        Minimize: c^T @ x
+    Minimize::
 
-        Subject to: A @ x == b
-                        0 >= x
+        cT @ x
+
+    Subject to::
+
+        A @ x == b
+            x >= 0
 
     Parameters
     ----------
@@ -376,7 +380,7 @@ def _linprog_simplex(c, c0, A, b, maxiter=1000, disp=False, callback=None,
         zero in Phase 1 to be considered a basic feasible solution or close
         enough to positive to serve as an optimal solution.
     bland : bool
-        If True, use Bland's anti-cycling rule [3] to choose pivots to
+        If True, use Bland's anti-cycling rule [3]_ to choose pivots to
         prevent cycling.  If False, choose pivots which should lead to a
         converged solution more quickly.  The latter method is subject to
         cycling (non-convergence) in rare instances.
@@ -404,11 +408,15 @@ def _linprog_simplex(c, c0, A, b, maxiter=1000, disp=False, callback=None,
     --------
     Consider the following problem:
 
-    Minimize: f = -1*x[0] + 4*x[1]
+    Minimize::
 
-    Subject to: -3*x[0] + 1*x[1] <= 6
-                 1*x[0] + 2*x[1] <= 4
-                            x[1] >= -3
+        f = -1x[0] + 4x[1]
+
+    Subject to::
+
+        -3x[0] + 1x[1] <= 6
+         1x[0] + 2x[1] <= 4
+                  x[1] >= -3
 
     where:  -inf <= x[0] <= inf
 

--- a/scipy/optimize/_linprog_simplex.py
+++ b/scipy/optimize/_linprog_simplex.py
@@ -140,7 +140,7 @@ def _solve_simplex(T, n, basis, maxiter=1000, phase=2, status=0, message='',
         minimize:     c'^T @ x'
 
         subject to:   A @ x' == b
-                      0 < x' < oo
+                          x' >= 0
 
     Parameters
     ----------
@@ -311,7 +311,7 @@ def _linprog_simplex(c, c0, A, b, maxiter=1000, disp=False, callback=None,
         minimize:     c'^T @ x'
 
         subject to:   A @ x' == b
-                      0 < x' < oo
+                          x' >= 0
 
     Parameters
     ----------

--- a/scipy/optimize/_linprog_simplex.py
+++ b/scipy/optimize/_linprog_simplex.py
@@ -134,17 +134,13 @@ def _solve_simplex(T, n, basis, maxiter=1000, phase=2, status=0, message='',
                    callback=None, tol=1.0E-12, nit0=0, bland=False, _T_o=None):
     """
     Solve a linear programming problem in "standard maximization form" using
-    the Simplex Method.
+    the Simplex Method. Linear Programming is intended to solve the following
+    problem form::
 
-    Minimize :math:`f = c^T x`
+        minimize:     c'^T @ x'
 
-    subject to
-
-    .. math::
-
-        Ax = b
-        x_i >= 0
-        b_j >= 0
+        subject to:   A @ x' == b
+                      0 < x' < oo
 
     Parameters
     ----------
@@ -310,12 +306,12 @@ def _linprog_simplex(c, c0, A, b, maxiter=1000, disp=False, callback=None,
                      tol=1.0E-12, bland=False, _T_o=None, **unknown_options):
     """
     Solve the following linear programming problem via a two-phase
-    simplex algorithm.::
+    simplex algorithm.
 
-        minimize:     c^T * x
+        minimize:     c'^T @ x'
 
-        subject to:  A * x == b
-                    0 <= x < oo
+        subject to:   A @ x' == b
+                      0 < x' < oo
 
     Parameters
     ----------

--- a/scipy/optimize/_linprog_simplex.py
+++ b/scipy/optimize/_linprog_simplex.py
@@ -437,6 +437,44 @@ def _linprog_simplex(c, c0, A, b, maxiter=1000, disp=False, callback=None,
            Mathematical Programming", McGraw-Hill, Chapter 4.
     .. [3] Bland, Robert G. New finite pivoting rules for the simplex method.
            Mathematics of Operations Research (2), 1977: pp. 103-107.
+
+
+    Notes
+    -----
+    The expected problem formulation differs between the top level ``linprog``
+    module and the method specific solvers. The method specific solvers expect a
+    problem in standard form:
+
+    Minimize::
+
+        c @ x
+
+    Subject to::
+
+        A @ x == b
+            x >= 0
+
+    Whereas the top level ``linprog`` module expects a problem of form:
+
+    Minimize::
+
+        c @ x
+
+    Subject to::
+
+        A_ub @ x <= b_ub
+        A_eq @ x == b_eq
+         lb <= x <= ub
+
+    where ``lb = 0`` and ``ub = None`` unless set in ``bounds``.
+
+    Note the original problem contains equality, upper-bound and variable
+    constraints whereas the method specific solver requires equality constraints
+    and variable non-negativity only. The top level ``linprog`` module
+    converts the original problem to standard form by converting the simple
+    bounds to upper bound constraints, introducing non-negative slack variables
+    for inequality constraints, and expressing unbounded variables as the
+    difference between two non-negative variables.
     """
     _check_unknown_options(unknown_options)
 

--- a/scipy/optimize/_linprog_simplex.py
+++ b/scipy/optimize/_linprog_simplex.py
@@ -306,12 +306,12 @@ def _linprog_simplex(c, c0, A, b, maxiter=1000, disp=False, callback=None,
                      tol=1.0E-12, bland=False, _T_o=None, **unknown_options):
     """
     Solve the following linear programming problem via a two-phase
-    simplex algorithm.
+    simplex algorithm of the form::
 
-        minimize:     c'^T @ x'
+        Minimize: c^T @ x
 
-        subject to:   A @ x' == b
-                          x' >= 0
+        Subject to: A @ x == b
+                        0 >= x
 
     Parameters
     ----------

--- a/scipy/optimize/_linprog_util.py
+++ b/scipy/optimize/_linprog_util.py
@@ -95,7 +95,7 @@ def _clean_inputs(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None, bounds=None):
         ``(min, max)`` pairs for each element in ``x``, defining
         the bounds on that parameter. Use None for one of ``min`` or
         ``max`` when there is no bound in that direction. By default
-        bounds are ``(0, None)`` (non-negative)
+        bounds are ``(0, None)`` (non-negative).
         If a sequence containing a single tuple is provided, then ``min`` and
         ``max`` will be applied to all variables in the problem.
 
@@ -119,7 +119,7 @@ def _clean_inputs(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None, bounds=None):
         ``(min, max)`` pairs for each element in ``x``, defining
         the bounds on that parameter. Use None for each of ``min`` or
         ``max`` when there is no bound in that direction. By default
-        bounds are ``(0, None)`` (non-negative)
+        bounds are ``(0, None)`` (non-negative).
 
     """
 
@@ -364,6 +364,14 @@ def _presolve(c, A_ub, b_ub, A_eq, b_eq, bounds, rr, tol=1e-9):
         ``(min, max)`` pairs for each element in ``x``, defining
         the bounds on that parameter. Use None for each of ``min`` or
         ``max`` when there is no bound in that direction.
+    rr : bool
+        If ``True`` attempts to eliminate any redundant rows in ``A_eq``.
+        Set False if ``A_eq`` is known to be of full row rank, or if you are
+        looking for a potential speedup (at the expense of reliability).
+    tol : float
+        The tolerance which determines when a solution is "close enough" to
+        zero in Phase 1 to be considered a basic feasible solution or close
+        enough to positive to serve as an optimal solution.
 
     Returns
     -------
@@ -407,6 +415,7 @@ def _presolve(c, A_ub, b_ub, A_eq, b_eq, bounds, rr, tol=1e-9):
          1 : Iteration limit reached
          2 : Problem appears to be infeasible
          3 : Problem appears to be unbounded
+         4 : Serious numerical difficulties encountered
 
     message : str
         A string descriptor of the exit status of the optimization.
@@ -747,9 +756,9 @@ def _parse_linprog(c, A_ub, b_ub, A_eq, b_eq, bounds, options):
         ``(min, max)`` pairs for each element in ``x``, defining
         the bounds on that parameter. Use None for one of ``min`` or
         ``max`` when there is no bound in that direction. By default
-        bounds are ``(0, None)`` (non-negative)
-        If a sequence containing a single tuple is provided, then ``min`` and
-        ``max`` will be applied to all variables in the problem.
+        bounds are ``(0, None)`` (non-negative). If a sequence containing a
+        single tuple is provided, then ``min`` and ``max`` will be applied to
+        all variables in the problem.
     options : dict
         A dictionary of solver options. All methods accept the following
         generic options:
@@ -781,7 +790,7 @@ def _parse_linprog(c, A_ub, b_ub, A_eq, b_eq, bounds, options):
         ``(min, max)`` pairs for each element in ``x``, defining
         the bounds on that parameter. Use None for one of ``min`` or
         ``max`` when there is no bound in that direction. By default
-        bounds are ``(0, None)`` (non-negative)
+        bounds are ``(0, None)`` (non-negative).
         If a sequence containing a single tuple is provided, then ``min`` and
         ``max`` will be applied to all variables in the problem.
     options : dict, optional
@@ -812,17 +821,28 @@ def _get_Abc(c, c0=0, A_ub=None, b_ub=None, A_eq=None, b_eq=None, bounds=None,
     """
     Given a linear programming problem of the form:
 
-    minimize:     c^T * x
+    Minimize::
 
-    subject to:   A_ub * x <= b_ub
-                  A_eq * x == b_eq
-                  bounds[i][0] < x_i < bounds[i][1]
+        c @ x
 
-    return the problem in standard form:
-    minimize:     c'^T * x'
+    Subject to::
 
-    subject to:   A * x' == b
-                  0 < x' < oo
+        A_ub @ x <= b_ub
+        A_eq @ x == b_eq
+         lb <= x <= ub
+
+    where ``lb = 0`` and ``ub = None`` unless set in ``bounds``.
+
+    Return the problem in standard form:
+
+    Minimize::
+
+        c @ x
+
+    Subject to::
+
+        A @ x == b
+            x >= 0
 
     by adding slack variables and making variable substitutions as necessary.
 
@@ -986,7 +1006,7 @@ def _get_Abc(c, c0=0, A_ub=None, b_ub=None, A_eq=None, b_eq=None, bounds=None,
 
 def _display_summary(message, status, fun, iteration):
     """
-    Print termination summary of the linear progam
+    Print the termination summary of the linear program
 
     Parameters
     ----------
@@ -999,8 +1019,7 @@ def _display_summary(message, status, fun, iteration):
                 1 : Iteration limit reached
                 2 : Problem appears to be infeasible
                 3 : Problem appears to be unbounded
-                4 : Serious numerical difficulties which could not resolved using
-                    a more robust, albeit less efficient, solver encountered
+                4 : Serious numerical difficulties encountered
 
     fun : float
         Value of the objective function.
@@ -1058,6 +1077,10 @@ def _postsolve(x, c, A_ub=None, b_ub=None, A_eq=None, b_eq=None, bounds=None,
     con : 1D array
         The (nominally zero) residuals of the equality constraints, that is,
         ``b - A_eq * x``
+    lb : 1D array
+        The lower bound constraints on the original variables
+    ub: 1D array
+        The upper bound constraints on the original variables
     """
     # note that all the inputs are the ORIGINAL, unmodified versions
     # no rows, columns have been removed
@@ -1138,8 +1161,7 @@ def _check_result(x, fun, status, slack, con, lb, ub, tol, message):
              1 : Iteration limit reached
              2 : Problem appears to be infeasible
              3 : Problem appears to be unbounded
-             4 : Serious numerical difficulties which could not resolved using
-                 a more robust, albeit less efficient, solver encountered
+             4 : Serious numerical difficulties encountered
 
     slack: 1D array
         The (non-negative) slack in the upper bound constraints, that is,
@@ -1147,6 +1169,10 @@ def _check_result(x, fun, status, slack, con, lb, ub, tol, message):
     con : 1D array
         The (nominally zero) residuals of the equality constraints, that is,
         ``b - A_eq * x``
+    lb : 1D array
+        The lower bound constraints on the original variables
+    ub: 1D array
+        The upper bound constraints on the original variables
     message : str
         A string descriptor of the exit status of the optimization.
     tol : float
@@ -1161,8 +1187,7 @@ def _check_result(x, fun, status, slack, con, lb, ub, tol, message):
              1 : Iteration limit reached
              2 : Problem appears to be infeasible
              3 : Problem appears to be unbounded
-             4 : Serious numerical difficulties which could not resolved using
-                 a more robust, albeit less efficient, solver encountered
+             4 : Serious numerical difficulties encountered
 
     message : str
         A string descriptor of the exit status of the optimization.
@@ -1250,8 +1275,7 @@ def _postprocess(x, c, A_ub=None, b_ub=None, A_eq=None, b_eq=None, bounds=None,
              1 : Iteration limit reached
              2 : Problem appears to be infeasible
              3 : Problem appears to be unbounded
-             4 : Serious numerical difficulties which could not resolved using
-                 a more robust, albeit less efficient, solver encountered
+             4 : Serious numerical difficulties encountered
 
     message : str
         A string descriptor of the exit status of the optimization.
@@ -1277,8 +1301,7 @@ def _postprocess(x, c, A_ub=None, b_ub=None, A_eq=None, b_eq=None, bounds=None,
              1 : Iteration limit reached
              2 : Problem appears to be infeasible
              3 : Problem appears to be unbounded
-             4 : Serious numerical difficulties which could not resolved using
-                 a more robust, albeit less efficient, solver encountered
+             4 : Serious numerical difficulties encountered
 
     message : str
         A string descriptor of the exit status of the optimization.

--- a/scipy/optimize/_linprog_util.py
+++ b/scipy/optimize/_linprog_util.py
@@ -1071,12 +1071,12 @@ def _postsolve(x, c, A_ub=None, b_ub=None, A_eq=None, b_eq=None, bounds=None,
         Solution vector to original linear programming problem
     fun: float
         optimal objective value for original problem
-    slack: 1D array
+    slack : 1D array
         The (non-negative) slack in the upper bound constraints, that is,
-        ``b_ub - A_ub * x``
+        ``b_ub - A_ub @ x``
     con : 1D array
         The (nominally zero) residuals of the equality constraints, that is,
-        ``b - A_eq * x``
+        ``b - A_eq @ x``
     lb : 1D array
         The lower bound constraints on the original variables
     ub: 1D array
@@ -1163,12 +1163,12 @@ def _check_result(x, fun, status, slack, con, lb, ub, tol, message):
              3 : Problem appears to be unbounded
              4 : Serious numerical difficulties encountered
 
-    slack: 1D array
+    slack : 1D array
         The (non-negative) slack in the upper bound constraints, that is,
-        ``b_ub - A_ub * x``
+        ``b_ub - A_ub @ x``
     con : 1D array
         The (nominally zero) residuals of the equality constraints, that is,
-        ``b - A_eq * x``
+        ``b - A_eq @ x``
     lb : 1D array
         The lower bound constraints on the original variables
     ub: 1D array
@@ -1288,12 +1288,12 @@ def _postprocess(x, c, A_ub=None, b_ub=None, A_eq=None, b_eq=None, bounds=None,
         Solution vector to original linear programming problem
     fun: float
         optimal objective value for original problem
-    slack: 1D array
+    slack : 1D array
         The (non-negative) slack in the upper bound constraints, that is,
-        ``b_ub - A_ub * x``
+        ``b_ub - A_ub @ x``
     con : 1D array
         The (nominally zero) residuals of the equality constraints, that is,
-        ``b - A_eq * x``
+        ``b - A_eq @ x``
     status : int
         An integer representing the exit status of the optimization::
 


### PR DESCRIPTION
closes #6139 

By default linear programming bounds variables to be non-negative causing some confusion for users not familiar with LP. This PR explicitly states the default bounds (``lb = 0``, ``ub = np.inf``) and that they may be set by using the ``bounds`` parameter.

@mdhaber @ilayn