### PR TITLE
MAINT: sparse/linalg: make test deterministic

### DIFF
--- a/scipy/sparse/linalg/isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/isolve/tests/test_iterative.py
@@ -590,7 +590,8 @@ class TestGMRES(object):
             assert_(np.linalg.norm(A.dot(x) - b) <= 1e-5*np.linalg.norm(b))
             assert_allclose(x, b, atol=0, rtol=1e-8)
 
-            A = np.random.rand(30, 30)
+            rndm = np.random.RandomState(12345)
+            A = rndm.rand(30, 30)
             b = 1e-6 * ones(30)
             x, info = gmres(A, b, tol=1e-7, restart=20)
             assert_(np.linalg.norm(A.dot(x) - b) > 1e-7)


### PR DESCRIPTION
To make the test deterministic, seed the random number generator. 

This test fails intermittently on some recent PRs (https://github.com/scipy/scipy/pull/9272, https://github.com/scipy/scipy/pull/9262, https://github.com/scipy/scipy/pull/9264). 
