### PR TITLE
Run distance_transform_edt tests on all types

### DIFF
--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -2868,17 +2868,17 @@ class TestNdimage:
                                 [0, 0, 0, 1, 1, 1, 0, 0, 0],
                                 [0, 0, 0, 0, 0, 0, 0, 0, 0],
                                 [0, 0, 0, 0, 0, 0, 0, 0, 0]], type_)
-        out, ft = ndimage.distance_transform_edt(data, return_indices=True)
-        bf = ndimage.distance_transform_bf(data, 'euclidean')
-        assert_array_almost_equal(bf, out)
+            out, ft = ndimage.distance_transform_edt(data, return_indices=True)
+            bf = ndimage.distance_transform_bf(data, 'euclidean')
+            assert_array_almost_equal(bf, out)
 
-        dt = ft - numpy.indices(ft.shape[1:], dtype=ft.dtype)
-        dt = dt.astype(numpy.float64)
-        numpy.multiply(dt, dt, dt)
-        dt = numpy.add.reduce(dt, axis=0)
-        numpy.sqrt(dt, dt)
+            dt = ft - numpy.indices(ft.shape[1:], dtype=ft.dtype)
+            dt = dt.astype(numpy.float64)
+            numpy.multiply(dt, dt, dt)
+            dt = numpy.add.reduce(dt, axis=0)
+            numpy.sqrt(dt, dt)
 
-        assert_array_almost_equal(bf, dt)
+            assert_array_almost_equal(bf, dt)
 
     def test_distance_transform_edt02(self):
         for type_ in self.types:
@@ -2891,43 +2891,43 @@ class TestNdimage:
                                 [0, 0, 0, 1, 1, 1, 0, 0, 0],
                                 [0, 0, 0, 0, 0, 0, 0, 0, 0],
                                 [0, 0, 0, 0, 0, 0, 0, 0, 0]], type_)
-        tdt, tft = ndimage.distance_transform_edt(data, return_indices=True)
-        dts = []
-        fts = []
-        dt = numpy.zeros(data.shape, dtype=numpy.float64)
-        ndimage.distance_transform_edt(data, distances=dt)
-        dts.append(dt)
-        ft = ndimage.distance_transform_edt(
-            data, return_distances=0, return_indices=True)
-        fts.append(ft)
-        ft = numpy.indices(data.shape, dtype=numpy.int32)
-        ndimage.distance_transform_edt(
-            data, return_distances=False, return_indices=True, indices=ft)
-        fts.append(ft)
-        dt, ft = ndimage.distance_transform_edt(
-            data, return_indices=True)
-        dts.append(dt)
-        fts.append(ft)
-        dt = numpy.zeros(data.shape, dtype=numpy.float64)
-        ft = ndimage.distance_transform_edt(
-            data, distances=dt, return_indices=True)
-        dts.append(dt)
-        fts.append(ft)
-        ft = numpy.indices(data.shape, dtype=numpy.int32)
-        dt = ndimage.distance_transform_edt(
-            data, return_indices=True, indices=ft)
-        dts.append(dt)
-        fts.append(ft)
-        dt = numpy.zeros(data.shape, dtype=numpy.float64)
-        ft = numpy.indices(data.shape, dtype=numpy.int32)
-        ndimage.distance_transform_edt(
-            data, distances=dt, return_indices=True, indices=ft)
-        dts.append(dt)
-        fts.append(ft)
-        for dt in dts:
-            assert_array_almost_equal(tdt, dt)
-        for ft in fts:
-            assert_array_almost_equal(tft, ft)
+            tdt, tft = ndimage.distance_transform_edt(data, return_indices=True)
+            dts = []
+            fts = []
+            dt = numpy.zeros(data.shape, dtype=numpy.float64)
+            ndimage.distance_transform_edt(data, distances=dt)
+            dts.append(dt)
+            ft = ndimage.distance_transform_edt(
+                data, return_distances=0, return_indices=True)
+            fts.append(ft)
+            ft = numpy.indices(data.shape, dtype=numpy.int32)
+            ndimage.distance_transform_edt(
+                data, return_distances=False, return_indices=True, indices=ft)
+            fts.append(ft)
+            dt, ft = ndimage.distance_transform_edt(
+                data, return_indices=True)
+            dts.append(dt)
+            fts.append(ft)
+            dt = numpy.zeros(data.shape, dtype=numpy.float64)
+            ft = ndimage.distance_transform_edt(
+                data, distances=dt, return_indices=True)
+            dts.append(dt)
+            fts.append(ft)
+            ft = numpy.indices(data.shape, dtype=numpy.int32)
+            dt = ndimage.distance_transform_edt(
+                data, return_indices=True, indices=ft)
+            dts.append(dt)
+            fts.append(ft)
+            dt = numpy.zeros(data.shape, dtype=numpy.float64)
+            ft = numpy.indices(data.shape, dtype=numpy.int32)
+            ndimage.distance_transform_edt(
+                data, distances=dt, return_indices=True, indices=ft)
+            dts.append(dt)
+            fts.append(ft)
+            for dt in dts:
+                assert_array_almost_equal(tdt, dt)
+            for ft in fts:
+                assert_array_almost_equal(tft, ft)
 
     def test_distance_transform_edt03(self):
         for type_ in self.types:
@@ -2940,9 +2940,9 @@ class TestNdimage:
                                 [0, 0, 0, 1, 1, 1, 0, 0, 0],
                                 [0, 0, 0, 0, 0, 0, 0, 0, 0],
                                 [0, 0, 0, 0, 0, 0, 0, 0, 0]], type_)
-        ref = ndimage.distance_transform_bf(data, 'euclidean', sampling=[2, 2])
-        out = ndimage.distance_transform_edt(data, sampling=[2, 2])
-        assert_array_almost_equal(ref, out)
+            ref = ndimage.distance_transform_bf(data, 'euclidean', sampling=[2, 2])
+            out = ndimage.distance_transform_edt(data, sampling=[2, 2])
+            assert_array_almost_equal(ref, out)
 
     def test_distance_transform_edt4(self):
         for type_ in self.types:
@@ -2955,9 +2955,9 @@ class TestNdimage:
                                 [0, 0, 0, 1, 1, 1, 0, 0, 0],
                                 [0, 0, 0, 0, 0, 0, 0, 0, 0],
                                 [0, 0, 0, 0, 0, 0, 0, 0, 0]], type_)
-        ref = ndimage.distance_transform_bf(data, 'euclidean', sampling=[2, 1])
-        out = ndimage.distance_transform_edt(data, sampling=[2, 1])
-        assert_array_almost_equal(ref, out)
+            ref = ndimage.distance_transform_bf(data, 'euclidean', sampling=[2, 1])
+            out = ndimage.distance_transform_edt(data, sampling=[2, 1])
+            assert_array_almost_equal(ref, out)
 
     def test_distance_transform_edt5(self):
         # Ticket #954 regression test


### PR DESCRIPTION
The existing tests for `distance_transform_edt` only test the function using `numpy.float64` input arrays. 

The arrays for other numeric types are being created in the tests, but are never passed to `distance_transform_edt` due to the lack of indentation after the for loops. This PR adds indentation so that `distance_transform_edt` is tested with all of the defined numerical types in `self.types`.