### PR TITLE
Fix slow stats.fisher_exact(x) (#9231)

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3158,17 +3158,19 @@ def fisher_exact(table, alternative='two-sided'):
         if guess == -1:
             guess = minval
             
-        if not np.isclose(pexact, 0.0, atol=np.finfo(np.float64).eps):
-            if side == "upper":
-                while guess > 0 and hypergeom.pmf(guess, n1 + n2, n1, n) < pexact * epsilon:
-                    guess -= 1
-                while hypergeom.pmf(guess, n1 + n2, n1, n) > pexact / epsilon:
-                    guess += 1
-            else:
-                while hypergeom.pmf(guess, n1 + n2, n1, n) < pexact * epsilon:
-                    guess += 1
-                while guess > 0 and hypergeom.pmf(guess, n1 + n2, n1, n) > pexact / epsilon:
-                    guess -= 1
+        if np.abs(pexact) < np.spacing(1.0):
+            return guess
+        
+        if side == "upper":
+            while guess > 0 and hypergeom.pmf(guess, n1 + n2, n1, n) < pexact * epsilon:
+                guess -= 1
+            while hypergeom.pmf(guess, n1 + n2, n1, n) > pexact / epsilon:
+                guess += 1
+        else:
+            while hypergeom.pmf(guess, n1 + n2, n1, n) < pexact * epsilon:
+                guess += 1
+            while guess > 0 and hypergeom.pmf(guess, n1 + n2, n1, n) > pexact / epsilon:
+                guess -= 1
         return guess
 
     if alternative == 'less':

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3157,16 +3157,18 @@ def fisher_exact(table, alternative='two-sided'):
                 minval = guess
         if guess == -1:
             guess = minval
-        if side == "upper":
-            while guess > 0 and hypergeom.pmf(guess, n1 + n2, n1, n) < pexact * epsilon:
-                guess -= 1
-            while hypergeom.pmf(guess, n1 + n2, n1, n) > pexact / epsilon:
-                guess += 1
-        else:
-            while hypergeom.pmf(guess, n1 + n2, n1, n) < pexact * epsilon:
-                guess += 1
-            while guess > 0 and hypergeom.pmf(guess, n1 + n2, n1, n) > pexact / epsilon:
-                guess -= 1
+            
+        if not np.isclose(pexact, 0.0, atol=np.finfo(np.float64).eps):
+            if side == "upper":
+                while guess > 0 and hypergeom.pmf(guess, n1 + n2, n1, n) < pexact * epsilon:
+                    guess -= 1
+                while hypergeom.pmf(guess, n1 + n2, n1, n) > pexact / epsilon:
+                    guess += 1
+            else:
+                while hypergeom.pmf(guess, n1 + n2, n1, n) < pexact * epsilon:
+                    guess += 1
+                while guess > 0 and hypergeom.pmf(guess, n1 + n2, n1, n) > pexact / epsilon:
+                    guess -= 1
         return guess
 
     if alternative == 'less':

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -292,6 +292,8 @@ class TestFisherExact(object):
     def test_basic(self):
         fisher_exact = stats.fisher_exact
 
+        res = fisher_exact([[5829225, 5692693], [5760959, 5760959]])[1]
+        assert_approx_equal(res, 3.06311e-178, significant=4)
         res = fisher_exact([[14500, 20000], [30000, 40000]])[1]
         assert_approx_equal(res, 0.01106, significant=4)
         res = fisher_exact([[100, 2], [1000, 5]])[1]


### PR DESCRIPTION
#9231 
It is the PR for the problem that the computation time is long in the situation where x = [[5829225, 5692693], [5760959, 5760959]].

If the value of `pexact` is very small(`np.finfo(np.float64).eps`), the `binary_search()` function is skipped.