### PR TITLE
MAINT: optimize/trust-constr: restore .niter attribute for backward-compat

### DIFF
--- a/scipy/optimize/_trustregion_constr/minimize_trustregion_constr.py
+++ b/scipy/optimize/_trustregion_constr/minimize_trustregion_constr.py
@@ -421,6 +421,7 @@ def _minimize_trustregion_constr(fun, x0, args, grad,
                                           state.constr_penalty,
                                           state.cg_stop_cond)
             state.status = None
+            state.niter = state.nit  # Alias for callback (backward-compatibility)
             if callback is not None and callback(np.copy(state.x), state):
                 state.status = 3
             elif state.optimality < gtol and state.constr_violation < gtol:
@@ -458,6 +459,7 @@ def _minimize_trustregion_constr(fun, x0, args, grad,
                                          state.barrier_parameter,
                                          state.cg_stop_cond)
             state.status = None
+            state.niter = state.nit  # Alias for callback (backward-compatibility)
             if callback is not None and callback(np.copy(state.x), state):
                 state.status = 3
             elif state.optimality < gtol and state.constr_violation < gtol:
@@ -515,6 +517,9 @@ def _minimize_trustregion_constr(fun, x0, args, grad,
     # this is assumed to not be a success.
     result.success = True if result.status in (1, 2) else False
     result.message = TERMINATION_MESSAGES[result.status]
+
+    # Alias (for backward compatibility with 1.1.0)
+    result.niter = result.nit
 
     if verbose == 2:
         BasicReport.print_footer()

--- a/scipy/optimize/tests/test_minimize_constrained.py
+++ b/scipy/optimize/tests/test_minimize_constrained.py
@@ -602,7 +602,16 @@ class TestTrustRegionConstr(TestCase):
         # Test the returned `OptimizeResult` contains keys consistent with
         # other solvers.
 
+        def callback(x, info):
+            assert_('nit' in info)
+            assert_('niter' in info)
+
         result = minimize(lambda x: x**2, [0], jac=lambda x: 2*x,
-                          hess=lambda x: 2, method='trust-constr')
+                          hess=lambda x: 2, callback=callback,
+                          method='trust-constr')
         assert_(result.get('success'))
         assert_(result.get('nit', -1) == 1)
+
+        # Also check existence of the 'niter' attribute, for backward
+        # compatibility
+        assert_(result.get('niter', -1) == 1)


### PR DESCRIPTION
Add back the OptimizeResult.niter (alias for .nit) attribute in trust-constr solver, for backward compatibility.

This was removed in gh-9217 when the attribute was renamed to conform with the other solvers, but removing it is a small backward-compatibility break.