### PR TITLE
MAINT: removed unused import sys

### DIFF
--- a/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
@@ -11,9 +11,6 @@ Examples in tests directory contributed by Nils Wagner.
 """
 
 from __future__ import division, print_function, absolute_import
-
-import sys
-
 import numpy as np
 from numpy.testing import assert_allclose
 from scipy._lib.six import xrange


### PR DESCRIPTION
sys module was imported but not used in
https://github.com/scipy/scipy/blob/74f4e5a0b67817946528c5cf9cbe7d8a21f3b1be/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py#L15

