### PR TITLE
ENH: WIP Add support for LowLevelCallable to optimize.zeros.brenth et al

### DIFF
--- a/scipy/_lib/src/ccallback.h
+++ b/scipy/_lib/src/ccallback.h
@@ -280,7 +280,7 @@ fail:
  *     !=NULL if success, ==NULL on failure.
  *
  */
- static PyTypeObject * get_lowlevelcallable_type() {
+ static PyTypeObject * ccallback__get_lowlevelcallable_type() {
     static PyTypeObject *lowlevelcallable_type = NULL;
     if (lowlevelcallable_type == NULL) {
         PyObject *module;
@@ -312,10 +312,10 @@ fail:
  *     0 if success, != 0 on failure.
  *
  */
-static int is_lowlevelcallable(PyObject *callback_obj)
+static int ccallback_is_lowlevelcallable(PyObject *callback_obj)
 {
-    PyTypeObject *lowlevelcallable_type = get_lowlevelcallable_type();
-    if (lowlevelcallable_type == NULL || callback_obj== NULL) {
+    PyTypeObject *lowlevelcallable_type = ccallback__get_lowlevelcallable_type();
+    if (lowlevelcallable_type == NULL || callback_obj == NULL) {
         return 0;
     }
     return (PyObject_TypeCheck(callback_obj, lowlevelcallable_type));
@@ -353,7 +353,7 @@ static int ccallback_prepare(ccallback_t *callback, ccallback_signature_t *signa
     PyObject *callback_obj2 = NULL;
     PyObject *capsule = NULL;
 
-    lowlevelcallable_type = get_lowlevelcallable_type();
+    lowlevelcallable_type = ccallback__get_lowlevelcallable_type();
 
     if (lowlevelcallable_type == NULL) {
         goto error;

--- a/scipy/optimize/Zeros/bisect.c
+++ b/scipy/optimize/Zeros/bisect.c
@@ -5,16 +5,16 @@
 
 double
 bisect(callback_type f, double xa, double xb, double xtol, double rtol,
-       int iter, default_parameters *params)
+       int iter, void *func_data, scipy_zeros_info *solver_stats)
 {
     int i;
     double dm,xm,fm,fa,fb;
 
-    fa = (*f)(xa,params);
-    fb = (*f)(xb,params);
-    params->funcalls = 2;
+    fa = (*f)(xa, func_data);
+    fb = (*f)(xb, func_data);
+    solver_stats->funcalls = 2;
     if (fa*fb > 0) {
-        params->error_num = SIGNERR;
+        solver_stats->error_num = SIGNERR;
         return 0.;
     }
     if (fa == 0) {
@@ -24,13 +24,13 @@ bisect(callback_type f, double xa, double xb, double xtol, double rtol,
         return xb;
     }
     dm = xb - xa;
-    params->iterations = 0;
+    solver_stats->iterations = 0;
     for (i=0; i<iter; i++) {
-        params->iterations++;
+        solver_stats->iterations++;
         dm *= .5;
         xm = xa + dm;
-        fm = (*f)(xm,params);
-        params->funcalls++;
+        fm = (*f)(xm, func_data);
+        solver_stats->funcalls++;
         if (fm*fa >= 0) {
             xa = xm;
         }
@@ -38,6 +38,6 @@ bisect(callback_type f, double xa, double xb, double xtol, double rtol,
             return xm;
         }
     }
-    params->error_num = CONVERR;
+    solver_stats->error_num = CONVERR;
     return xa;
 }

--- a/scipy/optimize/Zeros/bisect.c
+++ b/scipy/optimize/Zeros/bisect.c
@@ -9,6 +9,7 @@ bisect(callback_type f, double xa, double xb, double xtol, double rtol,
 {
     int i;
     double dm,xm,fm,fa,fb;
+    solver_stats->error_num = INPROGRESS;
 
     fa = (*f)(xa, func_data);
     fb = (*f)(xb, func_data);
@@ -17,11 +18,12 @@ bisect(callback_type f, double xa, double xb, double xtol, double rtol,
         solver_stats->error_num = SIGNERR;
         return 0.;
     }
-    solver_stats->error_num = CONVERGED;
     if (fa == 0) {
+        solver_stats->error_num = CONVERGED;
         return xa;
     }
     if (fb == 0) {
+        solver_stats->error_num = CONVERGED;
         return xb;
     }
     dm = xb - xa;
@@ -36,6 +38,7 @@ bisect(callback_type f, double xa, double xb, double xtol, double rtol,
             xa = xm;
         }
         if (fm == 0 || fabs(dm) < xtol + rtol*fabs(xm)) {
+            solver_stats->error_num = CONVERGED;
             return xm;
         }
     }

--- a/scipy/optimize/Zeros/bisect.c
+++ b/scipy/optimize/Zeros/bisect.c
@@ -2,6 +2,9 @@
 
 #include <math.h>
 #include "zeros.h"
+#include <stdio.h>
+
+#define OFILE stdout
 
 double
 bisect(callback_type f, double xa, double xb, double xtol, double rtol,
@@ -9,6 +12,10 @@ bisect(callback_type f, double xa, double xb, double xtol, double rtol,
 {
     int i;
     double dm,xm,fm,fa,fb;
+    fprintf(OFILE, "BISECT:Start\n");
+    fprintf(OFILE, "a=%f b=%f\n", xa, xb);
+    fprintf(OFILE, "f=%p func_data=%p\n", (void *)f, func_data);
+    fflush(OFILE);
 
     fa = (*f)(xa, func_data);
     fb = (*f)(xb, func_data);
@@ -17,6 +24,7 @@ bisect(callback_type f, double xa, double xb, double xtol, double rtol,
         solver_stats->error_num = SIGNERR;
         return 0.;
     }
+    solver_stats->error_num = CONVERGED;
     if (fa == 0) {
         return xa;
     }
@@ -35,9 +43,12 @@ bisect(callback_type f, double xa, double xb, double xtol, double rtol,
             xa = xm;
         }
         if (fm == 0 || fabs(dm) < xtol + rtol*fabs(xm)) {
+            fprintf(OFILE, "Converged!\n"); fflush(OFILE);
             return xm;
         }
+        fprintf(OFILE, "Still working: i=%2d: xa=%f, xm=%f fm=%f\n", i, xa, xm, fm); fflush(OFILE);
     }
+    fprintf(OFILE, "FAIL: Not converged!\n"); fflush(OFILE);
     solver_stats->error_num = CONVERR;
     return xa;
 }

--- a/scipy/optimize/Zeros/bisect.c
+++ b/scipy/optimize/Zeros/bisect.c
@@ -4,18 +4,12 @@
 #include "zeros.h"
 #include <stdio.h>
 
-#define OFILE stdout
-
 double
 bisect(callback_type f, double xa, double xb, double xtol, double rtol,
        int iter, void *func_data, scipy_zeros_info *solver_stats)
 {
     int i;
     double dm,xm,fm,fa,fb;
-    fprintf(OFILE, "BISECT:Start\n");
-    fprintf(OFILE, "a=%f b=%f\n", xa, xb);
-    fprintf(OFILE, "f=%p func_data=%p\n", (void *)f, func_data);
-    fflush(OFILE);
 
     fa = (*f)(xa, func_data);
     fb = (*f)(xb, func_data);
@@ -43,12 +37,9 @@ bisect(callback_type f, double xa, double xb, double xtol, double rtol,
             xa = xm;
         }
         if (fm == 0 || fabs(dm) < xtol + rtol*fabs(xm)) {
-            fprintf(OFILE, "Converged!\n"); fflush(OFILE);
             return xm;
         }
-        fprintf(OFILE, "Still working: i=%2d: xa=%f, xm=%f fm=%f\n", i, xa, xm, fm); fflush(OFILE);
     }
-    fprintf(OFILE, "FAIL: Not converged!\n"); fflush(OFILE);
     solver_stats->error_num = CONVERR;
     return xa;
 }

--- a/scipy/optimize/Zeros/bisect.c
+++ b/scipy/optimize/Zeros/bisect.c
@@ -2,7 +2,6 @@
 
 #include <math.h>
 #include "zeros.h"
-#include <stdio.h>
 
 double
 bisect(callback_type f, double xa, double xb, double xtol, double rtol,

--- a/scipy/optimize/Zeros/brenth.c
+++ b/scipy/optimize/Zeros/brenth.c
@@ -36,7 +36,7 @@
 
 double
 brenth(callback_type f, double xa, double xb, double xtol, double rtol,
-       int iter, default_parameters *params)
+       int iter, void *func_data, scipy_zeros_info *solver_stats)
 {
     double xpre = xa, xcur = xb;
     double xblk = 0., fpre, fcur, fblk = 0., spre = 0., scur = 0., sbis;
@@ -45,11 +45,11 @@ brenth(callback_type f, double xa, double xb, double xtol, double rtol,
     double stry, dpre, dblk;
     int i;
 
-    fpre = (*f)(xpre,params);
-    fcur = (*f)(xcur,params);
-    params->funcalls = 2;
+    fpre = (*f)(xpre,func_data);
+    fcur = (*f)(xcur,func_data);
+    solver_stats->funcalls = 2;
     if (fpre*fcur > 0) {
-        params->error_num = SIGNERR;
+        solver_stats->error_num = SIGNERR;
         return 0.;
     }
     if (fpre == 0) {
@@ -58,9 +58,9 @@ brenth(callback_type f, double xa, double xb, double xtol, double rtol,
     if (fcur == 0) {
         return xcur;
     }
-    params->iterations = 0;
+    solver_stats->iterations = 0;
     for (i = 0; i < iter; i++) {
-        params->iterations++;
+        solver_stats->iterations++;
         if (fpre*fcur < 0) {
             xblk = xpre;
             fblk = fpre;
@@ -120,9 +120,9 @@ brenth(callback_type f, double xa, double xb, double xtol, double rtol,
             xcur += (sbis > 0 ? delta : -delta);
         }
 
-        fcur = (*f)(xcur, params);
-        params->funcalls++;
+        fcur = (*f)(xcur, func_data);
+        solver_stats->funcalls++;
     }
-    params->error_num = CONVERR;
+    solver_stats->error_num = CONVERR;
     return xcur;
 }

--- a/scipy/optimize/Zeros/brenth.c
+++ b/scipy/optimize/Zeros/brenth.c
@@ -44,6 +44,7 @@ brenth(callback_type f, double xa, double xb, double xtol, double rtol,
     double delta;
     double stry, dpre, dblk;
     int i;
+    solver_stats->error_num = INPROGRESS;
 
     fpre = (*f)(xpre,func_data);
     fcur = (*f)(xcur,func_data);
@@ -53,9 +54,11 @@ brenth(callback_type f, double xa, double xb, double xtol, double rtol,
         return 0.;
     }
     if (fpre == 0) {
+        solver_stats->error_num = CONVERGED;
         return xpre;
     }
     if (fcur == 0) {
+        solver_stats->error_num = CONVERGED;
         return xcur;
     }
     solver_stats->iterations = 0;
@@ -79,6 +82,7 @@ brenth(callback_type f, double xa, double xb, double xtol, double rtol,
         delta = (xtol + rtol*fabs(xcur))/2;
         sbis = (xblk - xcur)/2;
         if (fcur == 0 || fabs(sbis) < delta) {
+            solver_stats->error_num = CONVERGED;
             return xcur;
         }
 

--- a/scipy/optimize/Zeros/brentq.c
+++ b/scipy/optimize/Zeros/brentq.c
@@ -35,7 +35,7 @@
 
 double
 brentq(callback_type f, double xa, double xb, double xtol, double rtol,
-       int iter, default_parameters *params)
+       int iter, void *func_data, scipy_zeros_info *solver_stats)
 {
     double xpre = xa, xcur = xb;
     double xblk = 0., fpre, fcur, fblk = 0., spre = 0., scur = 0., sbis;
@@ -44,11 +44,11 @@ brentq(callback_type f, double xa, double xb, double xtol, double rtol,
     double stry, dpre, dblk;
     int i;
 
-    fpre = (*f)(xpre, params);
-    fcur = (*f)(xcur, params);
-    params->funcalls = 2;
+    fpre = (*f)(xpre, func_data);
+    fcur = (*f)(xcur, func_data);
+    solver_stats->funcalls = 2;
     if (fpre*fcur > 0) {
-        params->error_num = SIGNERR;
+        solver_stats->error_num = SIGNERR;
         return 0.;
     }
     if (fpre == 0) {
@@ -58,9 +58,9 @@ brentq(callback_type f, double xa, double xb, double xtol, double rtol,
         return xcur;
     }
 
-    params->iterations = 0;
+    solver_stats->iterations = 0;
     for (i = 0; i < iter; i++) {
-        params->iterations++;
+        solver_stats->iterations++;
         if (fpre*fcur < 0) {
             xblk = xpre;
             fblk = fpre;
@@ -118,9 +118,9 @@ brentq(callback_type f, double xa, double xb, double xtol, double rtol,
             xcur += (sbis > 0 ? delta : -delta);
         }
 
-        fcur = (*f)(xcur, params);
-        params->funcalls++;
+        fcur = (*f)(xcur, func_data);
+        solver_stats->funcalls++;
     }
-    params->error_num = CONVERR;
+    solver_stats->error_num = CONVERR;
     return xcur;
 }

--- a/scipy/optimize/Zeros/brentq.c
+++ b/scipy/optimize/Zeros/brentq.c
@@ -43,6 +43,7 @@ brentq(callback_type f, double xa, double xb, double xtol, double rtol,
     double delta;
     double stry, dpre, dblk;
     int i;
+    solver_stats->error_num = INPROGRESS;
 
     fpre = (*f)(xpre, func_data);
     fcur = (*f)(xcur, func_data);
@@ -52,9 +53,11 @@ brentq(callback_type f, double xa, double xb, double xtol, double rtol,
         return 0.;
     }
     if (fpre == 0) {
+        solver_stats->error_num = CONVERGED;
         return xpre;
     }
     if (fcur == 0) {
+        solver_stats->error_num = CONVERGED;
         return xcur;
     }
 
@@ -79,6 +82,7 @@ brentq(callback_type f, double xa, double xb, double xtol, double rtol,
         delta = (xtol + rtol*fabs(xcur))/2;
         sbis = (xblk - xcur)/2;
         if (fcur == 0 || fabs(sbis) < delta) {
+            solver_stats->error_num = CONVERGED;
             return xcur;
         }
 

--- a/scipy/optimize/Zeros/ridder.c
+++ b/scipy/optimize/Zeros/ridder.c
@@ -20,6 +20,7 @@ ridder(callback_type f, double xa, double xb, double xtol, double rtol,
 {
     int i;
     double dm,dn,xm,xn=0.0,fn,fm,fa,fb,tol;
+    solver_stats->error_num = INPROGRESS;
 
     tol = xtol + rtol*MIN(fabs(xa), fabs(xb));
     fa = (*f)(xa, func_data);
@@ -30,9 +31,11 @@ ridder(callback_type f, double xa, double xb, double xtol, double rtol,
         return 0.;
     }
     if (fa == 0) {
+        solver_stats->error_num = CONVERGED;
         return xa;
     }
     if (fb == 0) {
+        solver_stats->error_num = CONVERGED;
         return xb;
     }
 
@@ -57,6 +60,7 @@ ridder(callback_type f, double xa, double xb, double xtol, double rtol,
         }
         tol = xtol + rtol*xn;
         if (fn == 0.0 || fabs(xb - xa) < tol) {
+            solver_stats->error_num = CONVERGED;
             return xn;
         }
     }

--- a/scipy/optimize/Zeros/ridder.c
+++ b/scipy/optimize/Zeros/ridder.c
@@ -9,23 +9,24 @@
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 #define SIGN(a) ((a) > 0. ? 1. : -1.)
 
-/* Sets params->error_num SIGNERR for sign_error;
-                         CONVERR for convergence_error;
+/* Sets solver_stats->error_num
+    SIGNERR for sign_error;
+    CONVERR for convergence_error;
 */
 
 double
 ridder(callback_type f, double xa, double xb, double xtol, double rtol,
-       int iter, default_parameters *params)
+       int iter, void *func_data, scipy_zeros_info *solver_stats)
 {
     int i;
     double dm,dn,xm,xn=0.0,fn,fm,fa,fb,tol;
 
     tol = xtol + rtol*MIN(fabs(xa), fabs(xb));
-    fa = (*f)(xa,params);
-    fb = (*f)(xb,params);
-    params->funcalls = 2;
+    fa = (*f)(xa, func_data);
+    fb = (*f)(xb, func_data);
+    solver_stats->funcalls = 2;
     if (fa*fb > 0) {
-        params->error_num = SIGNERR;
+        solver_stats->error_num = SIGNERR;
         return 0.;
     }
     if (fa == 0) {
@@ -35,16 +36,16 @@ ridder(callback_type f, double xa, double xb, double xtol, double rtol,
         return xb;
     }
 
-    params->iterations=0;
+    solver_stats->iterations=0;
     for (i=0; i<iter; i++) {
-        params->iterations++;
+        solver_stats->iterations++;
         dm = 0.5*(xb - xa);
         xm = xa + dm;
-        fm = (*f)(xm,params);
+        fm = (*f)(xm, func_data);
         dn = SIGN(fb - fa)*dm*fm/sqrt(fm*fm - fa*fb);
         xn = xm - SIGN(dn) * MIN(fabs(dn), fabs(dm) - .5*tol);
-        fn = (*f)(xn,params);
-        params->funcalls += 2;
+        fn = (*f)(xn, func_data);
+        solver_stats->funcalls += 2;
         if (fn*fm < 0.0) {
             xa = xn; fa = fn; xb = xm; fb = fm;
         }
@@ -59,6 +60,6 @@ ridder(callback_type f, double xa, double xb, double xtol, double rtol,
             return xn;
         }
     }
-    params->error_num = CONVERR;
+    solver_stats->error_num = CONVERR;
     return xn;
 }

--- a/scipy/optimize/Zeros/zeros.h
+++ b/scipy/optimize/Zeros/zeros.h
@@ -10,17 +10,21 @@ typedef struct {
     int funcalls;
     int iterations;
     int error_num;
-} default_parameters;
+} scipy_zeros_info;
 
+
+/* Must agree with _ECONVERGED, _ESIGNERR, _ECONVERR  in zeros.py */
+#define CONVERGED 0
 #define SIGNERR -1
 #define CONVERR -2
+#define EVALUEERR -3
 
 typedef double (*callback_type)(double,void*);
-typedef double (*solver_type)(callback_type, double, double, double, double, int,default_parameters*);
+typedef double (*solver_type)(callback_type, double, double, double, double, int,void *, scipy_zeros_info*);
 
-extern double bisect(callback_type f, double xa, double xb, double xtol, double rtol, int iter, default_parameters *params);
-extern double ridder(callback_type f, double xa, double xb, double xtol, double rtol, int iter, default_parameters *params);
-extern double brenth(callback_type f, double xa, double xb, double xtol, double rtol, int iter, default_parameters *params);
-extern double brentq(callback_type f, double xa, double xb, double xtol, double rtol, int iter, default_parameters *params);
+extern double bisect(callback_type f, double xa, double xb, double xtol, double rtol, int iter, void *func_data, scipy_zeros_info *solver_stats);
+extern double ridder(callback_type f, double xa, double xb, double xtol, double rtol, int iter, void *func_data, scipy_zeros_info *solver_stats);
+extern double brenth(callback_type f, double xa, double xb, double xtol, double rtol, int iter, void *func_data, scipy_zeros_info *solver_stats);
+extern double brentq(callback_type f, double xa, double xb, double xtol, double rtol, int iter, void *func_data, scipy_zeros_info *solver_stats);
 
 #endif

--- a/scipy/optimize/Zeros/zeros.h
+++ b/scipy/optimize/Zeros/zeros.h
@@ -18,6 +18,7 @@ typedef struct {
 #define SIGNERR -1
 #define CONVERR -2
 #define EVALUEERR -3
+#define INPROGRESS 1
 
 typedef double (*callback_type)(double,void*);
 typedef double (*solver_type)(callback_type, double, double, double, double, int,void *, scipy_zeros_info*);

--- a/scipy/optimize/Zeros/zeros.h
+++ b/scipy/optimize/Zeros/zeros.h
@@ -21,11 +21,20 @@ typedef struct {
 #define INPROGRESS 1
 
 typedef double (*callback_type)(double,void*);
-typedef double (*solver_type)(callback_type, double, double, double, double, int,void *, scipy_zeros_info*);
+typedef double (*solver_type)(callback_type, double, double, double, double,
+                              int, void *, scipy_zeros_info*);
 
-extern double bisect(callback_type f, double xa, double xb, double xtol, double rtol, int iter, void *func_data, scipy_zeros_info *solver_stats);
-extern double ridder(callback_type f, double xa, double xb, double xtol, double rtol, int iter, void *func_data, scipy_zeros_info *solver_stats);
-extern double brenth(callback_type f, double xa, double xb, double xtol, double rtol, int iter, void *func_data, scipy_zeros_info *solver_stats);
-extern double brentq(callback_type f, double xa, double xb, double xtol, double rtol, int iter, void *func_data, scipy_zeros_info *solver_stats);
+extern double bisect(callback_type f, double xa, double xb, double xtol,
+                     double rtol, int iter, void *func_data,
+                     scipy_zeros_info *solver_stats);
+extern double ridder(callback_type f, double xa, double xb, double xtol,
+                     double rtol, int iter, void *func_data,
+                     scipy_zeros_info *solver_stats);
+extern double brenth(callback_type f, double xa, double xb, double xtol,
+                     double rtol, int iter, void *func_data,
+                     scipy_zeros_info *solver_stats);
+extern double brentq(callback_type f, double xa, double xb, double xtol,
+                     double rtol, int iter, void *func_data,
+                     scipy_zeros_info *solver_stats);
 
 #endif

--- a/scipy/optimize/_tstutils_zerofuncs.pxd
+++ b/scipy/optimize/_tstutils_zerofuncs.pxd
@@ -4,4 +4,5 @@
 
 cdef double xcubed_minus_2(double x) nogil
 cdef double x_to_the_n_minus_2(double x, double n) nogil
+cdef double x_to_the_3_minus_a(double x, const void *user_data) nogil
 cdef double x_to_the_n_minus_a(double x, const void *user_data) nogil

--- a/scipy/optimize/_tstutils_zerofuncs.pxd
+++ b/scipy/optimize/_tstutils_zerofuncs.pxd
@@ -3,6 +3,6 @@
 #
 
 cdef double xcubed_minus_2(double x) nogil
-cdef double x_to_the_n_minus_2(double x, double n) nogil
+cdef double x_to_the_n_minus_2(double x, const void *user_data) nogil
 cdef double x_to_the_3_minus_a(double x, const void *user_data) nogil
 cdef double x_to_the_n_minus_a(double x, const void *user_data) nogil

--- a/scipy/optimize/_tstutils_zerofuncs.pxd
+++ b/scipy/optimize/_tstutils_zerofuncs.pxd
@@ -1,0 +1,7 @@
+#
+# Exports for _tstutils_zerofuncs
+#
+
+cdef double xcubed_minus_2(double x) nogil
+cdef double x_to_the_n_minus_2(double x, double n) nogil
+cdef double x_to_the_n_minus_a(double x, const void *user_data) nogil

--- a/scipy/optimize/_tstutils_zerofuncs.pyx
+++ b/scipy/optimize/_tstutils_zerofuncs.pyx
@@ -1,0 +1,41 @@
+"""
+Test functions for optimize.zeros LowLevelCallable code
+"""
+
+from __future__ import absolute_import
+cimport cython
+from libc.math cimport pow
+
+# 3 functions of increasing generality used to compute x^3 - 2,
+# x**3 - 2
+# x**n - 2
+# x**n - a
+
+# Function 1: Most specialized
+cdef double xcubed_minus_2(double x) nogil:
+    return x*x*x - 2
+
+
+# Function 2: The exponent is specified at run-time
+cdef double x_to_the_n_minus_2(double x, double n) nogil:
+    cdef int ni = <int>n
+    return pow(x, ni) - 2.0
+
+
+# Function 3: The exponent and subtractand are specified at run-time via user_data
+# First a struct to hold n, a
+ctypedef struct _x_to_the_n_minus_a_data_t:
+    double a
+    int n
+
+# Now the function to compute x**n-a
+cdef double x_to_the_n_minus_a(double x, const void *user_data) nogil:
+    cdef _x_to_the_n_minus_a_data_t *data = <_x_to_the_n_minus_a_data_t *>user_data
+    cdef int n
+    cdef double a
+    cdef double result
+    n = data[0].n
+    a = data[0].a
+    result = pow(x, n)
+    result = result - a
+    return result

--- a/scipy/optimize/_tstutils_zerofuncs.pyx
+++ b/scipy/optimize/_tstutils_zerofuncs.pyx
@@ -9,6 +9,7 @@ from libc.math cimport pow
 # 3 functions of increasing generality used to compute x^3 - 2,
 # x**3 - 2
 # x**n - 2
+# x**3 - a
 # x**n - a
 
 # Function 1: Most specialized
@@ -17,36 +18,31 @@ cdef double xcubed_minus_2(double x) nogil:
 
 
 # Function 2: The exponent is specified at run-time
-cdef double x_to_the_n_minus_2(double x, double n) nogil:
-    cdef int ni = <int>n
+cdef double x_to_the_n_minus_2(double x, const void *user_data) nogil:
+    cdef int ni = (<int *>user_data)[0]
     return pow(x, ni) - 2.0
+
 
 # Now the function to compute x**n-a
 cdef double x_to_the_3_minus_a(double x, const void *user_data) nogil:
     cdef double a = (<double *>user_data)[0]
     cdef double result
-    result = pow(x, 3)
-    result = result - a
-    with gil:
-        print('x=', x, 'a=', a, 'result=', result)
+    result = pow(x, 3) - a
     return result
 
-# Function 3: The exponent and subtractand are specified at run-time via user_data
+
+# Function 4:  Now the function to compute x**n-a
+# The exponent and subtractand are specified at run-time via user_data
 # First a struct to hold n, a
 ctypedef struct _x_to_the_n_minus_a_data_t:
     double a
     int n
 
-# Now the function to compute x**n-a
 cdef double x_to_the_n_minus_a(double x, const void *user_data) nogil:
     cdef _x_to_the_n_minus_a_data_t *data = <_x_to_the_n_minus_a_data_t *>user_data
     cdef int n
-    cdef double a
-    cdef double result
+    cdef double a, result
     n = data[0].n
     a = data[0].a
-    result = pow(x, n)
-    result = result - a
-    with gil:
-        print('user_data=', <long>user_data, '%x' % (<long>user_data), 'x=', x, 'a=', a, 'n=', n, 'result=', result)
+    result = pow(x, n) - a
     return result

--- a/scipy/optimize/_tstutils_zerofuncs.pyx
+++ b/scipy/optimize/_tstutils_zerofuncs.pyx
@@ -21,6 +21,15 @@ cdef double x_to_the_n_minus_2(double x, double n) nogil:
     cdef int ni = <int>n
     return pow(x, ni) - 2.0
 
+# Now the function to compute x**n-a
+cdef double x_to_the_3_minus_a(double x, const void *user_data) nogil:
+    cdef double a = (<double *>user_data)[0]
+    cdef double result
+    result = pow(x, 3)
+    result = result - a
+    with gil:
+        print('x=', x, 'a=', a, 'result=', result)
+    return result
 
 # Function 3: The exponent and subtractand are specified at run-time via user_data
 # First a struct to hold n, a
@@ -38,4 +47,6 @@ cdef double x_to_the_n_minus_a(double x, const void *user_data) nogil:
     a = data[0].a
     result = pow(x, n)
     result = result - a
+    with gil:
+        print('user_data=', <long>user_data, '%x' % (<long>user_data), 'x=', x, 'a=', a, 'n=', n, 'result=', result)
     return result

--- a/scipy/optimize/setup.py
+++ b/scipy/optimize/setup.py
@@ -33,6 +33,7 @@ def configuration(parent_package='',top_path=None):
                          sources=['zeros.c'],
                          libraries=['rootfind'],
                          depends=(rootfind_src + rootfind_hdr),
+                         include_dirs=include_dirs,
                          **numpy_nodepr_api)
 
     lapack = get_info('lapack_opt')
@@ -73,6 +74,8 @@ def configuration(parent_package='',top_path=None):
                          **numpy_nodepr_api)
 
     config.add_extension('_group_columns', sources=['_group_columns.c'],)
+
+    config.add_extension('_tstutils_zerofuncs', sources=['_tstutils_zerofuncs.c'],)
 
     config.add_subpackage('_lsq')
 

--- a/scipy/optimize/setup.py
+++ b/scipy/optimize/setup.py
@@ -10,7 +10,8 @@ def configuration(parent_package='',top_path=None):
     from scipy._build_utils.system_info import get_info
     config = Configuration('optimize',parent_package, top_path)
 
-    include_dirs = [join(os.path.dirname(__file__), '..', '_lib', 'src')]
+    include_dir = join(os.path.dirname(__file__), '..', '_lib', 'src')
+    include_dirs = [include_dir]
 
     minpack_src = [join('minpack','*f')]
     config.add_library('minpack',sources=minpack_src)
@@ -35,6 +36,12 @@ def configuration(parent_package='',top_path=None):
                          depends=(rootfind_src + rootfind_hdr),
                          include_dirs=include_dirs,
                          **numpy_nodepr_api)
+
+    if 0:
+        config.add_extension("_zero_thunk",
+                         sources=["_zero_thunk.c"],
+                         depends=[os.path.join(include_dir, 'ccallback.h')],
+                         include_dirs=include_dirs)
 
     lapack = get_info('lapack_opt')
     if 'define_macros' in numpy_nodepr_api:

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -382,7 +382,7 @@ class TestLowLevelCallable(object):
         cls.setup_basic()
         cls.setup_userdata_double()
         cls.setup_userdata_struct()
-        cls.setup_arg_struct()
+        # cls.setup_arg_struct()
 
     def run_check(self, method, name):
         cuberoot3 = np.power(2, 1.0/3)

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -74,7 +74,7 @@ class TestBasic(object):
         # The methods have one of two base signatures:
         # (f, a, b, **kwargs)  # newton
         # (func, x0, **kwargs)  # bisect/brentq/...
-        sig = _getargspec(method)  # ArgSpec with args, varargs, varkw, defaults
+        sig = _getargspec(method)  # ArgSpec with args varargs varkw defaults
         nDefaults = len(sig[3])
         nRequired = len(sig[0]) - nDefaults
         sig_args_keys = sig[0][:nRequired]
@@ -109,9 +109,9 @@ class TestBasic(object):
         cvgd = [elt for elt in results if elt[1].converged]
         approx = [elt[1].root for elt in cvgd]
         correct = [elt[0] for elt in cvgd]
-        notclose = [[a] + elt for a, c, elt in zip(approx, correct, cvgd) if
-                    not isclose(a, c, rtol=rtol, atol=atol)
-                    and elt[-1]['ID'] not in known_fail]
+        notclose = [[a] + elt for a, c, elt in zip(approx, correct, cvgd)
+                    if (not isclose(a, c, rtol=rtol, atol=atol) and
+                        elt[-1]['ID'] not in known_fail)]
         # Evaluate the function and see if is 0 at the purported root
         fvs = [tc['f'](aroot, *(tc['args']))
                for aroot, c, fullout, tc in notclose]
@@ -336,7 +336,9 @@ class TestLowLevelCallable(object):
     def setup_no_args(cls):
         func_names_plus_args = [['xcubed_minus_2', ()]]
         for fn, args in func_names_plus_args:
-            cls._add_test(LowLevelCallable.from_cython(_tstutils_zerofuncs, fn), args, fn)
+            cls._add_test(
+                LowLevelCallable.from_cython(_tstutils_zerofuncs, fn),
+                args, fn)
 
     @classmethod
     def setup_userdata_int(cls):
@@ -347,7 +349,7 @@ class TestLowLevelCallable(object):
         cls.c_a = ctypes.pointer(cls.n)
         cls.llc3 = LowLevelCallable.from_cython(
             _tstutils_zerofuncs, "x_to_the_n_minus_2",
-            user_data = ctypes.cast(cls.c_a, ctypes.c_voidp)
+            user_data=ctypes.cast(cls.c_a, ctypes.c_voidp)
         )
         cls._add_test(cls.llc3, tuple(), "x_to_the_n_minus_2 (int *)")
 
@@ -360,7 +362,7 @@ class TestLowLevelCallable(object):
         cls.c_a = ctypes.pointer(cls.a)
         cls.llc3 = LowLevelCallable.from_cython(
             _tstutils_zerofuncs, "x_to_the_3_minus_a",
-            user_data = ctypes.cast(cls.c_a, ctypes.c_voidp)
+            user_data=ctypes.cast(cls.c_a, ctypes.c_voidp)
         )
         cls._add_test(cls.llc3, tuple(), "x_to_the_3_minus_a (double *)")
 
@@ -383,7 +385,8 @@ class TestLowLevelCallable(object):
         cls.llc_voidstar = LowLevelCallable.from_cython(
             _tstutils_zerofuncs, "x_to_the_n_minus_a")
         voidstar = ctypes.cast(cls.n_and_a_ptr, ctypes.c_void_p)
-        cls._add_test(cls.llc_voidstar, (voidstar,), "x_to_the_n_minus_a  (void *)")
+        cls._add_test(cls.llc_voidstar, (voidstar,),
+                      "x_to_the_n_minus_a  (void *)")
 
     @classmethod
     def setup_class(cls):
@@ -396,12 +399,16 @@ class TestLowLevelCallable(object):
         cls.setup_userdata_double()
         cls.setup_userdata_struct()
 
-    def run_check(self, method, name):
+    def run_check(self, method, name, index=None):
         cuberoot3 = np.power(2, 1.0/3)
         a = .5
         b = sqrt(10)
         xtol = rtol = TOL
         tests = self.func_plus_args
+        if index:
+            if index < 0 or index >= len(tests):
+                return
+            tests = tests[index:index+1]
         for function, args, fname in tests:
             zero, r = method(function, a, b, xtol=xtol, rtol=rtol,
                              args=args, full_output=True)
@@ -429,17 +436,65 @@ class TestLowLevelCallable(object):
             assert(r.iterations <= 11), str(
                     [r.converged, r.iterations, r.function_calls])
 
-    def test_bisect(self):
-        self.run_check(cc.bisect, 'bisect')
+    def test_bisect0(self):
+        self.run_check(cc.bisect, 'bisect', 0)
 
-    def test_brentq(self):
-        self.run_check(cc.brentq, 'brentq')
+    def test_bisect1(self):
+        self.run_check(cc.bisect, 'bisect', 1)
 
-    def test_brenth(self):
-        self.run_check(cc.brenth, 'brenth')
+    def test_bisect2(self):
+        self.run_check(cc.bisect, 'bisect', 2)
 
-    def test_ridder(self):
-        self.run_check(cc.ridder, 'ridder')
+    def test_bisect3(self):
+        self.run_check(cc.bisect, 'bisect', 3)
+
+    def test_brentq0(self):
+        self.run_check(cc.brentq, 'brentq', 0)
+
+    def test_brentq1(self):
+        self.run_check(cc.brentq, 'brentq', 1)
+
+    def test_brentq2(self):
+        self.run_check(cc.brentq, 'brentq', 2)
+
+    def test_brentq3(self):
+        self.run_check(cc.brentq, 'brentq', 3)
+
+    def test_brenth0(self):
+        self.run_check(cc.brenth, 'brenth', 0)
+
+    def test_brenth1(self):
+        self.run_check(cc.brenth, 'brenth', 1)
+
+    def test_brenth2(self):
+        self.run_check(cc.brenth, 'brenth', 2)
+
+    def test_brenth3(self):
+        self.run_check(cc.brenth, 'brenth', 3)
+
+    def test_ridder0(self):
+        self.run_check(cc.ridder, 'ridder', 0)
+
+    def test_ridder1(self):
+        self.run_check(cc.ridder, 'ridder', 1)
+
+    def test_ridder2(self):
+        self.run_check(cc.ridder, 'ridder', 2)
+
+    def test_ridder3(self):
+        self.run_check(cc.ridder, 'ridder', 3)
+
+    # def test_bisect(self):
+    #     self.run_check(cc.bisect, 'bisect')
+    #
+    # def test_brentq(self):
+    #     self.run_check(cc.brentq, 'brentq')
+    #
+    # def test_brenth(self):
+    #     self.run_check(cc.brenth, 'brenth')
+    #
+    # def test_ridder(self):
+    #     self.run_check(cc.ridder, 'ridder')
 
     # def test_newton(self):
     #     self.run_secant_check(cc.newton, 'newton')

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -325,13 +325,14 @@ class TestLowLevelCallable(object):
         else:
             class N_AND_A(ctypes.Structure):
                 _fields_ = ("a", ctypes.c_double), ("n", ctypes.c_int)
+                
                 def __init__(self, n, a):
                     self.n = n
                     self.a = a
 
             n_and_a = N_AND_A(3, 2.0)
             c_n_and_a = ctypes.pointer(n_and_a)
-            c_n_and_a = ctypes.cast(c_n_and_a, c_void_p)
+            c_n_and_a = ctypes.cast(c_n_and_a, ctypes.c_void_p)
             llc_with_data = LowLevelCallable.from_cython(_tstutils_zerofuncs, "x_to_the_n_minus_a", c_n_and_a)
             print("llc_with_data", llc_with_data)
             self.func_plus_args_user_data = [llc_with_data, (), '_x_to_the_n_minus_a']

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -21,8 +21,6 @@ from scipy._lib._numpy_compat import suppress_warnings
 
 from scipy._lib._ccallback import LowLevelCallable
 from scipy.optimize import _tstutils_zerofuncs
-from scipy.optimize._tstutils_zerofuncs import get_x_to_the_n_minus_a
-# from ctypes import *  # Structure, c_int, c_double, pointer
 import ctypes
 
 TOL = 4*np.finfo(float).eps  # tolerance
@@ -318,24 +316,19 @@ class TestLowLevelCallable(object):
         self.func_plus_args = [
             [LowLevelCallable.from_cython(_tstutils_zerofuncs, fn), args, fn]
             for fn, args in func_names_plus_args]
-        if 0:
-            llc_with_data = get_x_to_the_n_minus_a(3, 2)
-            print("llc_with_data", llc_with_data)
-            self.func_plus_args_user_data = [llc_with_data, (), '_x_to_the_n_minus_a']
-        else:
-            class N_AND_A(ctypes.Structure):
-                _fields_ = ("a", ctypes.c_double), ("n", ctypes.c_int)
-                
-                def __init__(self, n, a):
-                    self.n = n
-                    self.a = a
 
-            n_and_a = N_AND_A(3, 2.0)
-            c_n_and_a = ctypes.pointer(n_and_a)
-            c_n_and_a = ctypes.cast(c_n_and_a, ctypes.c_void_p)
-            llc_with_data = LowLevelCallable.from_cython(_tstutils_zerofuncs, "x_to_the_n_minus_a", c_n_and_a)
-            print("llc_with_data", llc_with_data)
-            self.func_plus_args_user_data = [llc_with_data, (), '_x_to_the_n_minus_a']
+        class N_AND_A(ctypes.Structure):
+            _fields_ = ("a", ctypes.c_double), ("n", ctypes.c_int)
+
+            def __init__(self, n, a):
+                self.n = n
+                self.a = a
+
+        n_and_a = N_AND_A(3, 2.0)
+        c_n_and_a = ctypes.pointer(n_and_a)
+        c_n_and_a = ctypes.cast(c_n_and_a, ctypes.c_void_p)
+        llc_with_data = LowLevelCallable.from_cython(_tstutils_zerofuncs, "x_to_the_n_minus_a", c_n_and_a)
+        self.func_plus_args_user_data = [llc_with_data, (), '_x_to_the_n_minus_a']
 
     def run_check(self, method, name, test_user_data=False):
         cuberoot3 = np.power(2, 1.0/3)
@@ -344,7 +337,7 @@ class TestLowLevelCallable(object):
         xtol = rtol = TOL
         tests = self.func_plus_args
         if test_user_data:
-            tests = self.func_plus_args_user_data
+            tests += self.func_plus_args_user_data
         for function, args, fname in tests:
             zero, r = method(function, a, b, xtol=xtol, rtol=rtol,
                              args=args, full_output=True)

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -333,9 +333,7 @@ class TestLowLevelCallable(object):
         cls.func_plus_args.append([llc, args, name])
 
     @classmethod
-    def setup_basic(cls):
-        # func_names_plus_args = [['xcubed_minus_2', ()],
-        #                         ['x_to_the_n_minus_2', (3)]]
+    def setup_no_args(cls):
         func_names_plus_args = [['xcubed_minus_2', ()]]
         for fn, args in func_names_plus_args:
             cls._add_test(LowLevelCallable.from_cython(_tstutils_zerofuncs, fn), args, fn)
@@ -381,7 +379,7 @@ class TestLowLevelCallable(object):
     def setup_arg_struct(cls):
         # f(x, n, a) = x**n - a
         # Create a c_void_p for the values of n(=3) and a(=2.0)
-        # Create LowLevelCallable for just f, and pass in c_void_p as an arg
+        # Create LowLevelCallable with that c_void_p as user_data.
         cls.llc_voidstar = LowLevelCallable.from_cython(
             _tstutils_zerofuncs, "x_to_the_n_minus_a")
         voidstar = ctypes.cast(cls.n_and_a_ptr, ctypes.c_void_p)
@@ -393,11 +391,10 @@ class TestLowLevelCallable(object):
         cls.n_and_a = TestLowLevelCallable.N_AND_A(3, 2.0)  # x**3 - 2.0
         cls.n_and_a_ptr = ctypes.pointer(cls.n_and_a)
 
-        cls.setup_basic()
+        cls.setup_no_args()
         cls.setup_userdata_int()
         cls.setup_userdata_double()
         cls.setup_userdata_struct()
-        # cls.setup_arg_struct()
 
     def run_check(self, method, name):
         cuberoot3 = np.power(2, 1.0/3)
@@ -408,8 +405,6 @@ class TestLowLevelCallable(object):
         for function, args, fname in tests:
             zero, r = method(function, a, b, xtol=xtol, rtol=rtol,
                              args=args, full_output=True)
-            # zero, r = method(function, a, b, xtol=xtol, rtol=rtol,
-            #                  args=args, full_output=True)
             assert_(r.converged)
             assert_allclose(zero, cuberoot3, atol=xtol, rtol=rtol,
                             err_msg='method %s, function %s' % (name, fname))

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -329,72 +329,61 @@ class TestLowLevelCallable(object):
             return ('N_AND_A(%d, %s)' % (self.n, str(self.a)))
 
     @classmethod
-    def setup_doublestar(cls):
-        # It should be possible to create a LowLevelCallable and
-        # use double * as a void *
-        if 1:
-            cls.a = ctypes.c_double(2.0)
-            cls.c_a = ctypes.byref(cls.a)
-            cls.llc3 = LowLevelCallable.from_cython(
-                _tstutils_zerofuncs, "x_to_the_3_minus_a",
-                user_data=ctypes.cast(cls.c_a, ctypes.c_voidp))
-            cls.func_plus_args += [
-                [cls.llc3, tuple(), "x_to_the_3_minus_a (double *)"]]
-            print("setup_doublestar:", cls.a, cls.c_a, cls.llc3)
+    def _add_test(cls, llc, args, name):
+        cls.func_plus_args.append([llc, args, name])
 
     @classmethod
-    def setup_voidstar(cls):
-        # It should be possible to create a LowLevelCallable and
-        # use cls.n_and_a as a void *
-        if 1:
-            cls.c_n_and_a = ctypes.byref(cls.n_and_a)
-            cls.c_n_and_a = ctypes.pointer(cls.n_and_a)
-            cls.llc_voidstar = LowLevelCallable.from_cython(
-                _tstutils_zerofuncs, "x_to_the_n_minus_a")
-            # cls.func_plus_args += [
-            #     [cls.llc, tuple([cls.c_n_and_a]), "x_to_the_n_minus_a"]]
-            voidstar = ctypes.cast(cls.c_n_and_a, ctypes.c_void_p)
-            cls.func_plus_args += [
-                [cls.llc_voidstar, tuple([voidstar]), "x_to_the_n_minus_a  (void *)"]]
-            print("setup_voidstar:", cls.c_n_and_a, cls.llc_voidstar, voidstar)
-            print("setup_voidstar:pt1 ", cls.c_n_and_a[0])
-            print("setup_voidstar:pt2", dir(cls.c_n_and_a))
-            print("setup_voidstar:pt3", cls.c_n_and_a.contents)
-            # print("setup_voidstar:pt2 ", ctypes.cast(cls.c_n_and_a, TestLowLevelCallable.N_AND_A))
-
+    def setup_basic(cls):
+        func_names_plus_args = [['xcubed_minus_2', ()],
+                                ['x_to_the_n_minus_2', (3)]]
+        for fn, args in func_names_plus_args:
+            cls._add_test(LowLevelCallable.from_cython(_tstutils_zerofuncs, fn), args, fn)
 
     @classmethod
-    def setup_userdata(cls):
-        # It should be possible to create a LowLevelCallable and
-        # use cls.n_and_a as user_data
-        if 1:
-            # cls.c_n_and_a_ud = ctypes.byref(cls.n_and_a)
-            udata = ctypes.cast(
-                ctypes.byref(cls.n_and_a), ctypes.c_void_p)
-            cls.llc_with_data = LowLevelCallable.from_cython(
-                _tstutils_zerofuncs, "x_to_the_n_minus_a",
-                user_data=udata)
-            cls.func_plus_args += [
-                [cls.llc_with_data, (), '_x_to_the_n_minus_a (userdata)']]
-            print("setup_userdata:", cls.n_and_a, cls.llc_with_data, udata)
+    def setup_userdata_double(cls):
+        # f(x, a) = x**3 - a
+        # Create user_data for the value of a(=2.0)
+        # Create LowLevelCallable with that user_data
+        cls.a = ctypes.c_double(2.0)
+        cls.c_a = ctypes.pointer(cls.a)
+        cls.llc3 = LowLevelCallable.from_cython(
+            _tstutils_zerofuncs, "x_to_the_3_minus_a",
+            user_data = ctypes.cast(cls.c_a, ctypes.c_voidp)
+        )
+        cls._add_test(cls.llc3, tuple(), "x_to_the_3_minus_a (double *)")
+
+    @classmethod
+    def setup_userdata_struct(cls):
+        # f(x, n, a) = x**n - a
+        # Create user_data for the value of n(=3) and a(=2.0)
+        # Create LowLevelCallable with that user_data
+        user_data = ctypes.cast(cls.n_and_a_ptr, ctypes.c_void_p)
+        cls.llc_with_data = LowLevelCallable.from_cython(
+            _tstutils_zerofuncs, "x_to_the_n_minus_a",
+            user_data=user_data)
+        cls._add_test(cls.llc_with_data, (),  '_x_to_the_n_minus_a (userdata)')
+
+    @classmethod
+    def setup_arg_struct(cls):
+        # f(x, n, a) = x**n - a
+        # Create a c_void_p for the values of n(=3) and a(=2.0)
+        # Create LowLevelCallable for just f, and pass in c_void_p as an arg
+        cls.llc_voidstar = LowLevelCallable.from_cython(
+            _tstutils_zerofuncs, "x_to_the_n_minus_a")
+        voidstar = ctypes.cast(cls.n_and_a_ptr, ctypes.c_void_p)
+        cls._add_test(cls.llc_voidstar, (voidstar,), "x_to_the_n_minus_a  (void *)")
 
     @classmethod
     def setup_class(cls):
-        func_names_plus_args = [['xcubed_minus_2', ()],
-                                ['x_to_the_n_minus_2', (3)]]
         cls.func_plus_args = []
-        cls.func_plus_args_user_data = []
-        for fn, args in func_names_plus_args:
-            cls.func_plus_args.append([
-                LowLevelCallable.from_cython(_tstutils_zerofuncs, fn), args, fn])
-        cls.llc = LowLevelCallable.from_cython(_tstutils_zerofuncs, "x_to_the_n_minus_a")
         cls.n_and_a = TestLowLevelCallable.N_AND_A(3, 2.0)  # x**3 - 2.0
+        cls.n_and_a_ptr = ctypes.pointer(cls.n_and_a)
 
-        cls.setup_doublestar()
-        cls.setup_userdata()
-        cls.setup_voidstar()
-        import pprint
-        print("setup_class:", pprint.pformat(cls.func_plus_args))
+        cls.setup_basic()
+        cls.setup_userdata_double()
+        cls.setup_userdata_struct()
+        cls.setup_arg_struct()
+
 
     def run_check(self, method, name):
         cuberoot3 = np.power(2, 1.0/3)
@@ -436,14 +425,14 @@ class TestLowLevelCallable(object):
     def test_bisect(self):
         self.run_check(cc.bisect, 'bisect')
 
-    # def test_brentq(self):
-    #     self.run_check(cc.brentq, 'brentq')
-    #
-    # def test_brenth(self):
-    #     self.run_check(cc.brenth, 'brenth')
-    #
-    # def test_ridder(self):
-    #     self.run_check(cc.ridder, 'ridder')
+    def test_brentq(self):
+        self.run_check(cc.brentq, 'brentq')
+
+    def test_brenth(self):
+        self.run_check(cc.brenth, 'brenth')
+
+    def test_ridder(self):
+        self.run_check(cc.ridder, 'ridder')
 
     # def test_newton(self):
     #     self.run_secant_check(cc.newton, 'newton')

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -113,7 +113,8 @@ class TestBasic(object):
                     not isclose(a, c, rtol=rtol, atol=atol)
                     and elt[-1]['ID'] not in known_fail]
         # Evaluate the function and see if is 0 at the purported root
-        fvs = [tc['f'](aroot, *(tc['args'])) for aroot, c, fullout, tc in notclose]
+        fvs = [tc['f'](aroot, *(tc['args']))
+               for aroot, c, fullout, tc in notclose]
         notclose = [[fv] + elt for fv, elt in zip(fvs, notclose) if fv != 0]
         assert_equal([notclose, len(notclose)], [[], 0])
 
@@ -155,7 +156,8 @@ class TestBasic(object):
         known_fail = ['aps.13.00']
         known_fail += ['aps.12.05', 'aps.12.17']  # fails under Windows Py27
         for collection in ['aps', 'complex']:
-            self.run_collection(collection, cc.newton, 'newton', smoothness=2, known_fail=known_fail)
+            self.run_collection(collection, cc.newton, 'newton', smoothness=2,
+                                known_fail=known_fail)
 
     def test_halley_collections(self):
         known_fail = ['aps.12.06', 'aps.12.07', 'aps.12.08', 'aps.12.09',
@@ -163,7 +165,8 @@ class TestBasic(object):
                       'aps.12.14', 'aps.12.15', 'aps.12.16', 'aps.12.17',
                       'aps.12.18', 'aps.13.00']
         for collection in ['aps', 'complex']:
-            self.run_collection(collection, cc.newton, 'halley', smoothness=2, known_fail=known_fail)
+            self.run_collection(collection, cc.newton, 'halley', smoothness=2,
+                                known_fail=known_fail)
 
     @staticmethod
     def f1(x):
@@ -190,7 +193,8 @@ class TestBasic(object):
         return exp(x) + cos(x)
 
     def test_newton(self):
-        for f, f_1, f_2 in [(self.f1, self.f1_1, self.f1_2), (self.f2, self.f2_1, self.f2_2)]:
+        for f, f_1, f_2 in [(self.f1, self.f1_1, self.f1_2),
+                            (self.f2, self.f2_1, self.f2_2)]:
             x = zeros.newton(f, 3, tol=1e-6)
             assert_allclose(f(x), 0, atol=1e-6)
             x = zeros.newton(f, 3, fprime=f_1, tol=1e-6)
@@ -287,7 +291,8 @@ class TestBasic(object):
             else:
                 assert_equal(r.function_calls, (derivs + 1) * r.iterations)
 
-            # Now repeat, allowing one fewer iteration to force convergence failure
+            # Now repeat, allowing one fewer iteration in order to force
+            #  convergence failure
             iters = r.iterations - 1
             x, r = zeros.newton(self.f1, x0, maxiter=iters, disp=False, **kwargs)
             assert_(not r.converged)
@@ -312,10 +317,10 @@ class TestBasic(object):
 
 class TestLowLevelCallable(object):
     def setUp(self):
-        func_names_plus_args = [['xcubed_minus_2', ()], ['x_to_the_n_minus_2', (3)]]
+        self.func_names_plus_args = [['xcubed_minus_2', ()], ['x_to_the_n_minus_2', (3)]]
         self.func_plus_args = [
             [LowLevelCallable.from_cython(_tstutils_zerofuncs, fn), args, fn]
-            for fn, args in func_names_plus_args]
+            for fn, args in self.func_names_plus_args]
 
         class N_AND_A(ctypes.Structure):
             _fields_ = ("a", ctypes.c_double), ("n", ctypes.c_int)
@@ -324,11 +329,13 @@ class TestLowLevelCallable(object):
                 self.n = n
                 self.a = a
 
-        n_and_a = N_AND_A(3, 2.0)
+        n_and_a = N_AND_A(3, 2.0)  # x**3 - 2.0
         c_n_and_a = ctypes.pointer(n_and_a)
         c_n_and_a = ctypes.cast(c_n_and_a, ctypes.c_void_p)
-        llc_with_data = LowLevelCallable.from_cython(_tstutils_zerofuncs, "x_to_the_n_minus_a", c_n_and_a)
-        self.func_plus_args_user_data = [llc_with_data, (), '_x_to_the_n_minus_a']
+        llc_with_data = LowLevelCallable.from_cython(
+            _tstutils_zerofuncs, "x_to_the_n_minus_a", c_n_and_a)
+        self.func_plus_args_user_data = [
+            llc_with_data, (), '_x_to_the_n_minus_a']
 
     def run_check(self, method, name, test_user_data=False):
         cuberoot3 = np.power(2, 1.0/3)

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -278,7 +278,8 @@ class TestBasic(object):
 
         for derivs in range(3):
             kwargs = {'tol': 1e-6, 'full_output': True, }
-            for k, v in [['fprime', self.f1_1], ['fprime2', self.f1_2]][:derivs]:
+            for k, v in [['fprime', self.f1_1],
+                         ['fprime2', self.f1_2]][:derivs]:
                 kwargs[k] = v
 
             x, r = zeros.newton(self.f1, x0, disp=False, **kwargs)
@@ -294,7 +295,8 @@ class TestBasic(object):
             # Now repeat, allowing one fewer iteration in order to force
             #  convergence failure
             iters = r.iterations - 1
-            x, r = zeros.newton(self.f1, x0, maxiter=iters, disp=False, **kwargs)
+            x, r = zeros.newton(self.f1, x0, maxiter=iters, disp=False,
+                                **kwargs)
             assert_(not r.converged)
             assert_equal(x, r.root)
             assert_equal(r.iterations, iters)
@@ -316,11 +318,13 @@ class TestBasic(object):
 
 
 class TestLowLevelCallable(object):
-    def setUp(self):
-        self.func_names_plus_args = [['xcubed_minus_2', ()], ['x_to_the_n_minus_2', (3)]]
-        self.func_plus_args = [
+    @classmethod
+    def setup_class(cls):
+        func_names_plus_args = [['xcubed_minus_2', ()],
+                                    ['x_to_the_n_minus_2', (3)]]
+        cls.func_plus_args = [
             [LowLevelCallable.from_cython(_tstutils_zerofuncs, fn), args, fn]
-            for fn, args in self.func_names_plus_args]
+            for fn, args in func_names_plus_args]
 
         class N_AND_A(ctypes.Structure):
             _fields_ = ("a", ctypes.c_double), ("n", ctypes.c_int)
@@ -334,7 +338,7 @@ class TestLowLevelCallable(object):
         c_n_and_a = ctypes.cast(c_n_and_a, ctypes.c_void_p)
         llc_with_data = LowLevelCallable.from_cython(
             _tstutils_zerofuncs, "x_to_the_n_minus_a", c_n_and_a)
-        self.func_plus_args_user_data = [
+        cls.func_plus_args_user_data = [
             llc_with_data, (), '_x_to_the_n_minus_a']
 
     def run_check(self, method, name, test_user_data=False):

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -334,10 +334,24 @@ class TestLowLevelCallable(object):
 
     @classmethod
     def setup_basic(cls):
-        func_names_plus_args = [['xcubed_minus_2', ()],
-                                ['x_to_the_n_minus_2', (3)]]
+        # func_names_plus_args = [['xcubed_minus_2', ()],
+        #                         ['x_to_the_n_minus_2', (3)]]
+        func_names_plus_args = [['xcubed_minus_2', ()]]
         for fn, args in func_names_plus_args:
             cls._add_test(LowLevelCallable.from_cython(_tstutils_zerofuncs, fn), args, fn)
+
+    @classmethod
+    def setup_userdata_int(cls):
+        # f(x, a) = x**n - 2
+        # Create user_data for the value of n(=3)
+        # Create LowLevelCallable with that user_data
+        cls.n = ctypes.c_int(3)
+        cls.c_a = ctypes.pointer(cls.n)
+        cls.llc3 = LowLevelCallable.from_cython(
+            _tstutils_zerofuncs, "x_to_the_n_minus_2",
+            user_data = ctypes.cast(cls.c_a, ctypes.c_voidp)
+        )
+        cls._add_test(cls.llc3, tuple(), "x_to_the_n_minus_2 (int *)")
 
     @classmethod
     def setup_userdata_double(cls):
@@ -380,6 +394,7 @@ class TestLowLevelCallable(object):
         cls.n_and_a_ptr = ctypes.pointer(cls.n_and_a)
 
         cls.setup_basic()
+        cls.setup_userdata_int()
         cls.setup_userdata_double()
         cls.setup_userdata_struct()
         # cls.setup_arg_struct()
@@ -391,7 +406,6 @@ class TestLowLevelCallable(object):
         xtol = rtol = TOL
         tests = self.func_plus_args
         for function, args, fname in tests:
-            print("START run_check", function, fname)
             zero, r = method(function, a, b, xtol=xtol, rtol=rtol,
                              args=args, full_output=True)
             # zero, r = method(function, a, b, xtol=xtol, rtol=rtol,
@@ -412,7 +426,6 @@ class TestLowLevelCallable(object):
         xtol = rtol = TOL
         tests = self.func_plus_args
         for function, args, fname in tests:
-            print("Start run_check", function, fname)
             zero, r = method(function, a, tol=xtol,
                              args=args, full_output=True)
             assert_(r.converged)

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -361,7 +361,7 @@ class TestLowLevelCallable(object):
         cls.llc_with_data = LowLevelCallable.from_cython(
             _tstutils_zerofuncs, "x_to_the_n_minus_a",
             user_data=user_data)
-        cls._add_test(cls.llc_with_data, (),  '_x_to_the_n_minus_a (userdata)')
+        cls._add_test(cls.llc_with_data, (), '_x_to_the_n_minus_a (userdata)')
 
     @classmethod
     def setup_arg_struct(cls):
@@ -383,7 +383,6 @@ class TestLowLevelCallable(object):
         cls.setup_userdata_double()
         cls.setup_userdata_struct()
         cls.setup_arg_struct()
-
 
     def run_check(self, method, name):
         cuberoot3 = np.power(2, 1.0/3)

--- a/scipy/optimize/zeros.c
+++ b/scipy/optimize/zeros.c
@@ -162,7 +162,6 @@ init_func_extra_args(ccallback_t *callback, PyObject *extra_arguments)
 
 static int fill_in_ccallback(PyObject *f, PyObject *xargs, ccallback_t *pcallback)
 {
-    int ret;
     int use_ccallback = FALSE;
     pcallback->info_p = NULL;
 
@@ -188,14 +187,12 @@ static int fill_in_ccallback(PyObject *f, PyObject *xargs, ccallback_t *pcallbac
             int inited = init_func_extra_args(pcallback, xargs);
             if (!inited) {
                 /* Check for a single argument */
-                if (pcallback->info == 1) {
+                if (pcallback->info != 1) {
+                    PyErr_SetString(PyExc_ValueError,
+                        "Wrong number of extra arguments.");
+                } else {
                     use_ccallback = TRUE;
                 }
-            } else {
-                PyObject *ptype, *pvalue, *ptraceback;
-                PyErr_Fetch(&ptype, &pvalue, &ptraceback);
-                char *pStrErrorMessage = PyString_AsString(pvalue);
-                return FALSE;
             }
             break;
         }
@@ -243,7 +240,7 @@ call_solver(solver_type solver, PyObject *self, PyObject *args)
     ccallback_t callback;
     memset(&callback, sizeof(callback), '\0');
     callback.info_p = NULL;
-    int isllc = is_lowlevelcallable(f);
+    int isllc = ccallback_is_lowlevelcallable(f);
     if (isllc) {
         use_ccallback = fill_in_ccallback(f, xargs, &callback);
         /* error message already set inside ccallback_prepare */

--- a/scipy/optimize/zeros.c
+++ b/scipy/optimize/zeros.c
@@ -7,6 +7,46 @@
 #include "Python.h"
 #include <setjmp.h>
 
+//#include <stdio.h>
+#if PY_VERSION_HEX >= 0x03000000
+    #define PyString_FromString PyBytes_FromString
+    #define PyString_Concat PyBytes_Concat
+    #define PyString_AsString PyBytes_AsString
+    #define PyInt_FromLong PyLong_FromLong
+    #define PyInt_AsLong PyLong_AsLong
+#endif
+
+#ifndef FALSE
+#define FALSE 0
+#endif /* FALSE */
+#ifndef TRUE
+#define TRUE 1
+#endif /* TRUE */
+
+#include "ccallback.h"
+#include "Zeros/zeros.h"
+
+/*
+ * Caller entry point functions
+ */
+
+typedef enum {
+    CB_D = 1,         // f(x)
+    CB_D_D = 2,       // f(x, double)
+    CB_D_I_ND = 10,   // f(x, int n, double *)   I.e. pointer to n doubles
+    CB_D_UD = 100     // f(x, void *) or f(x, const void *)
+} zeros_signature_t;
+
+static ccallback_signature_t signatures[] = {
+    {"double (double)", CB_D},
+    {"double (double, double)", CB_D_D},
+    {"double (double, int, double *)", CB_D_I_ND},
+    {"double (double, void const *)", CB_D_UD},
+    {"double (double, void *)", CB_D_UD},
+    {NULL}
+};
+
+
 #ifdef PYPY_VERSION
     /*
      * As described in http://doc.pypy.org/en/latest/cpython_differences.html#c-api-differences,
@@ -19,24 +59,47 @@
     #define PyArgs(Operation) PyTuple_##Operation
 #endif
 
+
 typedef struct {
-    int funcalls;
-    int iterations;
-    int error_num;
     PyObject *function;
     PyObject *args;
     jmp_buf env;
 } scipy_zeros_parameters;
 
-/*
- * Storage for the relative precision of doubles. This is computed when the module
- * is initialized.
- */
 
-#include "Zeros/zeros.h"
+static double
+scipy_zeros_functions_lowlevelfunc(double x, void *func_data)
+{
+    double result;
+    zeros_signature_t sigval;
+    ccallback_t *callback = (ccallback_t*)func_data;
+    assert(callback->c_function != NULL);
+    assert(callback->signature != NULL);
+    assert(callback->signature->value == CB_D || callback->info_p != NULL);
+    sigval = callback->signature->value;
+    switch (sigval) {
+      case CB_D:
+        result = ((double(*)(double))callback->c_function)(x);
+        break;
+      case CB_D_D:
+        result = ((double(*)(double, double))callback->c_function)(
+            x, *(double *)(callback->info_p));
+        break;
+      case CB_D_I_ND:
+        result = ((double(*)(double, int, double *))callback->c_function)(
+             x, callback->info, (double *)(callback->info_p));
+        break;
+      case CB_D_UD:
+        result = ((double(*)(double, const void *))callback->c_function)(
+            x, (const void *)(callback->user_data));
+        break;
 
-#define SIGNERR -1
-#define CONVERR -2
+      default:
+         result = NAN;
+         break;
+    }
+    return result;
+}
 
 static double
 scipy_zeros_functions_func(double x, void *params)
@@ -48,7 +111,7 @@ scipy_zeros_functions_func(double x, void *params)
     args = myparams->args;
     f = myparams->function;
     PyArgs(SetItem)(args, 0, Py_BuildValue("d",x));
-    retval=PyObject_CallObject(f,args);
+    retval = PyObject_CallObject(f,args);
     if (retval == NULL) {
         longjmp(myparams->env, 1);
     }
@@ -57,22 +120,113 @@ scipy_zeros_functions_func(double x, void *params)
     return val;
 }
 
+
 /*
  * Helper function that calls a Python function with extended arguments
  */
 
+static int
+init_func_extra_args(ccallback_t *callback, PyObject *extra_arguments)
+{
+    double *p;
+    Py_ssize_t i;
+    int num_xargs;
+
+    callback->info_p = NULL;
+
+    if (!PyTuple_Check(extra_arguments)) {
+        return -1;
+    }
+    num_xargs = PyTuple_GET_SIZE(extra_arguments);
+
+    p = calloc(num_xargs, sizeof(double));
+    if (p == NULL) {
+        PyErr_SetString(PyExc_MemoryError, "failed to allocate memory");
+        return -1;
+    }
+
+    for (i = 0; i < num_xargs; ++i) {
+        PyObject *item = PyTuple_GET_ITEM(extra_arguments, i);
+        p[i] = PyFloat_AsDouble(item);
+        if (PyErr_Occurred()) {
+            free(p);
+            return -1;
+        }
+    }
+
+    callback->info_p = (void *)p;
+    callback->info = num_xargs;
+    return 0;
+}
+
+
+static int fill_in_ccallback(PyObject *f, PyObject *xargs, ccallback_t *pcallback)
+{
+    int ret;
+    int use_ccallback = FALSE;
+    pcallback->info_p = NULL;
+
+    /* f was filled in previously by PyArg_ParseTuple */
+    if (ccallback_prepare(pcallback, signatures, f, CCALLBACK_DEFAULTS)) {
+        return FALSE;
+    }
+
+    if (pcallback->signature == NULL) {
+        /* pure-Python */
+        /* For now, just break */
+        return FALSE;
+    }
+    switch(pcallback->signature->value) {
+        case CB_D:
+            /* extra_arguments is just ignored */
+            pcallback->info_p = NULL;
+            use_ccallback = TRUE;
+            break;
+
+        case CB_D_D:
+        {
+            int inited = init_func_extra_args(pcallback, xargs);
+            if (!inited) {
+                /* Check for a single argument */
+                if (pcallback->info == 1) {
+                    use_ccallback = TRUE;
+                }
+            } else {
+                PyObject *ptype, *pvalue, *ptraceback;
+                PyErr_Fetch(&ptype, &pvalue, &ptraceback);
+                char *pStrErrorMessage = PyString_AsString(pvalue);
+                return FALSE;
+            }
+            break;
+        }
+
+        case CB_D_I_ND:
+            if (init_func_extra_args(pcallback, xargs) == 0) {
+                use_ccallback = TRUE;
+            }
+            break;
+
+        case CB_D_UD:
+            use_ccallback = TRUE;
+            break;
+
+        default:
+            break;
+    }
+    return use_ccallback;
+}
+
 static PyObject *
 call_solver(solver_type solver, PyObject *self, PyObject *args)
 {
-    double a,b,xtol,rtol,zero;
+    double a, b, xtol, rtol, zero;
     int iter,i, len, fulloutput, disp=1, flag=0;
     scipy_zeros_parameters params;
-    jmp_buf env;
-    PyObject *f, *xargs, *item, *fargs=NULL;
-
+    scipy_zeros_info solver_stats;
+    PyObject *f, *xargs, *item;
+    volatile PyObject *fargs = NULL;
     if (!PyArg_ParseTuple(args, "OddddiOi|i",
-                &f, &a, &b, &xtol, &rtol, &iter, &xargs, &fulloutput, &disp))
-        {
+                &f, &a, &b, &xtol, &rtol, &iter, &xargs, &fulloutput, &disp)) {
             PyErr_SetString(PyExc_RuntimeError, "Unable to parse arguments");
             return NULL;
         }
@@ -85,65 +239,88 @@ call_solver(solver_type solver, PyObject *self, PyObject *args)
         return NULL;
     }
 
-    len = PyTuple_Size(xargs);
-    /* Make room for the double as first argument */
-    fargs = PyArgs(New)(len + 1);
-    if (fargs == NULL) {
-        PyErr_SetString(PyExc_RuntimeError,
-                "Failed to allocate arguments");
-        return NULL;
+    int use_ccallback = FALSE;
+    ccallback_t callback;
+    memset(&callback, sizeof(callback), '\0');
+    callback.info_p = NULL;
+    int isllc = is_lowlevelcallable(f);
+    if (isllc) {
+        use_ccallback = fill_in_ccallback(f, xargs, &callback);
+        /* error message already set inside ccallback_prepare */
+        if (!use_ccallback) {
+            return NULL;
+        }
     }
 
-    for (i = 0; i < len; i++) {
-        item = PyTuple_GetItem(xargs, i);
-        if (item == NULL) {
+    if (use_ccallback) {
+        solver_stats.error_num = 0;
+        zero = solver(scipy_zeros_functions_lowlevelfunc, a, b,
+                      xtol, rtol, iter, (void*)&callback, &solver_stats);
+        free(callback.info_p);
+        callback.info_p = NULL;
+    }
+    else if (!PyCallable_Check(f)) {
+        PyErr_SetString(PyExc_RuntimeError, "Is not callable");
+        return NULL;
+    } else {
+        len = PyTuple_Size(xargs);
+        /* Make room for the double as first argument */
+        fargs = PyArgs(New)(len + 1);
+        if (fargs == NULL) {
+            PyErr_SetString(PyExc_RuntimeError, "Failed to allocate arguments");
+            return NULL;
+        }
+
+        for (i = 0; i < len; i++) {
+            item = PyTuple_GetItem(xargs, i);
+            if (item == NULL) {
+                Py_DECREF(fargs);
+                return NULL;
+            }
+            Py_INCREF(item);
+            PyArgs(SET_ITEM)(fargs, i+1, item);
+        }
+
+        params.function = f;
+        params.args = (PyObject *)fargs;  /* Discard the volatile attribute */
+
+        if (!setjmp(params.env)) {
+            /* direct return */
+            solver_stats.error_num = 0;
+            zero = solver(scipy_zeros_functions_func, a, b, xtol, rtol,
+                          iter, (void*)&params, &solver_stats);
+            Py_DECREF(fargs);
+            fargs = NULL;
+        } else {
+            /* error return from Python function */
             Py_DECREF(fargs);
             return NULL;
         }
-        Py_INCREF(item);
-        PyArgs(SET_ITEM)(fargs, i+1, item);
     }
-
-    params.function = f;
-    params.args = fargs;
-
-    if (!setjmp(env)) {
-        /* direct return */
-        memcpy(params.env, env, sizeof(jmp_buf));
-        params.error_num = 0;
-        zero = solver(scipy_zeros_functions_func, a, b,
-                xtol, rtol, iter, (default_parameters*)&params);
-        Py_DECREF(fargs);
-        if (params.error_num != 0) {
-            if (params.error_num == SIGNERR) {
-                PyErr_SetString(PyExc_ValueError,
-                        "f(a) and f(b) must have different signs");
+    if (solver_stats.error_num != 0) {
+        if (solver_stats.error_num == SIGNERR) {
+            PyErr_SetString(PyExc_ValueError,
+                    "f(a) and f(b) must have different signs");
+            return NULL;
+        }
+        if (solver_stats.error_num == CONVERR) {
+            if (disp) {
+                char msg[100];
+                PyOS_snprintf(msg, sizeof(msg),
+                        "Failed to converge after %d iterations.",
+                        solver_stats.iterations);
+                PyErr_SetString(PyExc_RuntimeError, msg);
+                flag = 1;
                 return NULL;
             }
-            if (params.error_num == CONVERR) {
-                if (disp) {
-                    char msg[100];
-                    PyOS_snprintf(msg, sizeof(msg),
-                            "Failed to converge after %d iterations.",
-                            params.iterations);
-                    PyErr_SetString(PyExc_RuntimeError, msg);
-                    flag = 1;
-                    return NULL;
-                }
-            }
-        }
-        if (fulloutput) {
-            return Py_BuildValue("diii",
-                    zero, params.funcalls, params.iterations, flag);
-        }
-        else {
-            return Py_BuildValue("d", zero);
         }
     }
+    if (fulloutput) {
+        return Py_BuildValue("diii",
+                zero, solver_stats.funcalls, solver_stats.iterations, flag);
+    }
     else {
-        /* error return from Python function */
-        Py_DECREF(fargs);
-        return NULL;
+        return Py_BuildValue("d", zero);
     }
 }
 

--- a/scipy/optimize/zeros.c
+++ b/scipy/optimize/zeros.c
@@ -8,7 +8,9 @@
 #include <setjmp.h>
 #include <numpy/npy_math.h>
 
-//#include <stdio.h>
+#include <stdio.h>
+#define OFILE stdout
+
 #if PY_VERSION_HEX >= 0x03000000
     #define PyString_FromString PyBytes_FromString
     #define PyString_Concat PyBytes_Concat
@@ -16,6 +18,71 @@
     #define PyInt_FromLong PyLong_FromLong
     #define PyInt_AsLong PyLong_AsLong
 #endif
+
+//union value {
+//                char c[16];
+//                short s;
+//                int i;
+//                long l;
+//                float f;
+//                double d;
+//                long long ll;
+//                long double D;
+//};
+
+///*
+//  Hm. Are there CDataObject's which do not need the b_objects member?  In
+//  this case we probably should introduce b_flags to mark it as present...  If
+//  b_objects is not present/unused b_length is unneeded as well.
+//*/
+//typedef struct tagCDataObject CDataObject;
+//
+//struct tagCDataObject {
+//    PyObject_HEAD
+//    char *b_ptr;                /* pointer to memory block */
+//    int  b_needsfree;           /* need _we_ free the memory? */
+//    CDataObject *b_base;        /* pointer to base object or NULL */
+//    Py_ssize_t b_size;          /* size of memory block in bytes */
+//    Py_ssize_t b_length;        /* number of references we need */
+//    Py_ssize_t b_index;         /* index of this object into base's
+//                               b_object list */
+//    PyObject *b_objects;        /* dictionary of references we need to keep, or Py_None */
+//    union value b_value;
+//};
+//
+//
+//extern PyTypeObject PyCPointer_Type;
+//extern PyTypeObject PyCData_Type;
+//#define PointerObject_Check(v)        PyObject_TypeCheck(v, &PyCPointer_Type)
+//#define PointerObject_CheckExact(v)   ((v)->ob_type == &PyCPointer_Type)
+//#define CDataObject_Check(v)          PyObject_TypeCheck(v, &PyCData_Type)
+//#define CDataObject_CheckExact(v)     ((v)->ob_type == &PyCData_Type)
+//// ((v)->ob_type == &PyCArg_Type)
+//
+//typedef struct tagPyCArgObject PyCArgObject;
+//struct tagPyCArgObject {
+//    PyObject_HEAD
+////    ffi_type *pffi_type;
+//    void *pffi_type;
+//    char tag;
+//    union {
+//        char c;
+//        char b;
+//        short h;
+//        int i;
+//        long l;
+//        long long q;
+//        long double D;
+//        double d;
+//        float f;
+//        void *p;
+//    } value;
+//    PyObject *obj;
+//    Py_ssize_t size; /* for the 'V' tag */
+//};
+//extern PyTypeObject PyCArg_Type;
+//#define PyCArg_Check(v)          PyObject_TypeCheck(v, &PyCArg_Type)
+//#define PyCArg_CheckExact(v)        ((v)->ob_type == &PyCArg_Type)
 
 #ifndef FALSE
 #define FALSE 0
@@ -39,12 +106,18 @@ typedef enum {
     CB_D_USERDATA = 1001     // f(x, void *) or f(x, const void *) using UserData
 } zeros_signature_t;
 
-static ccallback_signature_t signatures[] = {
-    {"double (double)", CB_D},
+static const ccallback_signature_t signatures_with_args[] = {
+//    {"double (double)", CB_D},
     {"double (double, double)", CB_D_D},
-    {"double (double, int, double *)", CB_D_I_ND},
     {"double (double, void const *)", CB_D_VOIDSTAR},
     {"double (double, void *)", CB_D_VOIDSTAR},
+    {NULL}
+};
+
+static const ccallback_signature_t signatures_no_args[] = {
+    {"double (double)", CB_D},
+    {"double (double, void const *)", CB_D_USERDATA},
+    {"double (double, void *)", CB_D_USERDATA},
     {NULL}
 };
 
@@ -100,6 +173,8 @@ scipy_zeros_functions_lowlevelfunc(double x, void *func_data)
       case CB_D_VOIDSTAR:
         result = ((double(*)(double, const void *))callback->c_function)(
             x, *(const void **)(callback->info_p));
+//        result = ((double(*)(double, const void *))callback->c_function)(
+//            x, (const void *)(callback->info_p));
         break;
 
       case CB_D_USERDATA:
@@ -177,15 +252,29 @@ static int fill_in_ccallback(PyObject *f, PyObject *xargs, ccallback_t *pcallbac
     int use_ccallback = FALSE;
     pcallback->info_p = NULL;
 
+    int bHasArgs = (xargs && PyTuple_Check(xargs) && PyTuple_GET_SIZE(xargs) > 0);
+
     /* f was filled in previously by PyArg_ParseTuple */
-    if (ccallback_prepare(pcallback, signatures, f, CCALLBACK_DEFAULTS)) {
+    if (ccallback_prepare(pcallback, (bHasArgs ? signatures_with_args : signatures_no_args),
+                          f, CCALLBACK_DEFAULTS)) {
+        // fprintf(OFILE,"ccallback_prepare != 0\n"); fflush(OFILE);
         return FALSE;
     }
 
     if (pcallback->signature == NULL) {
         /* pure-Python */
         /* For now, just break */
+        // fprintf(OFILE,"pcallback->signature == NULL\n"); fflush(OFILE);
+        PyErr_SetString(PyExc_ValueError,
+                        "Python call, not LowLevalCallable.");
         return FALSE;
+    }
+    fprintf(OFILE, "FIC: sig->value=%d\n", pcallback->signature->value); fflush(OFILE);
+    if (xargs) {
+         fprintf(OFILE,"XT: xargs is tuple?: %d\n", PyTuple_Check(xargs) ); fflush(OFILE);
+         if (PyTuple_Check(xargs)) {
+             fprintf(OFILE,"XT: len(xargs) = %d\n", PyTuple_GET_SIZE(xargs) ); fflush(OFILE);
+        }
     }
     switch(pcallback->signature->value) {
         case CB_D:
@@ -205,38 +294,82 @@ static int fill_in_ccallback(PyObject *f, PyObject *xargs, ccallback_t *pcallbac
                 } else {
                     use_ccallback = TRUE;
                 }
+            } else {
+                PyErr_SetString(PyExc_ValueError,
+                    "Unable to parse xargs as a double.");
             }
             break;
         }
 
         case CB_D_I_ND:
-            if (init_func_extra_args(pcallback, xargs) == 0) {
+        {
+            int initerr = init_func_extra_args(pcallback, xargs);
+            if (!initerr) {
+                PyErr_SetString(PyExc_ValueError,
+                    "Unable to parse xargs as a tuple of doubles.");
+                // fprintf(OFILE,"init_func_extra_args != 0\n"); fflush(OFILE);
+            } else {
                 use_ccallback = TRUE;
             }
             break;
+        }
 
         case CB_D_VOIDSTAR:
             // Is the data passed in, or stored in user_data?
-            if (xargs) {
-                if (PyTuple_Check(xargs) && PyTuple_GET_SIZE(xargs)==1)  {
+            fprintf(OFILE,"XT:  CB_D_VOIDSTAR\n"); fflush(OFILE);
+            if (xargs && PyTuple_Check(xargs) && PyTuple_GET_SIZE(xargs) > 0) {
+                fprintf(OFILE,"XT:  Checks OK\n"); fflush(OFILE);
+                if (PyTuple_GET_SIZE(xargs) == 1)
+                {
                     PyObject *item = PyTuple_GET_ITEM(xargs, 0);
-                    void **p = malloc(sizeof(void *));
-                    *p = (void *)item;
-                    pcallback->info_p = p;
+                    PyObject * p2 = NULL;
+                    // Expecting an object created by ctypes.pointer(E.g. gives a CDataObject) or
+                    // ctypes.byref(gives a CArgObject)
+                    // First check if a CDataObject
+                    p2 = PyObject_GetAttrString(item, "value");
+                    fprintf(OFILE, "CB_D_VOIDSTAR: p2 is %p: ", p2); PyObject_Print(p2, OFILE, 0); fprintf(OFILE, "\n"); fflush(OFILE);
                     pcallback->info = 1;
-                    use_ccallback = TRUE;
+                    if (p2) {
+                        int overflow;
+                        long long value;
+                        void **p = malloc(sizeof(void *));
+                        value = PyLong_AsLongLongAndOverflow(p2, &overflow);
+                        *p = (void *)value;
+//                        *p = *(void **)value;
+                        pcallback->info_p = p;
+                        use_ccallback = TRUE;
+                        fprintf(OFILE, "CB_D_VOIDSTAR: p is %p(%lld), pc->ip=%p, value=%lld\n", p, *(void **)p, pcallback->info_p, value); fflush(OFILE);
+                    } else {
+                        PyErr_SetString(PyExc_ValueError,
+                            "Unable to Extract value fronm xargs.");
+                        use_ccallback = FALSE;
+                    }
                 } else {
                     PyErr_SetString(PyExc_ValueError,
                         "Wrong number of extra arguments for void *.");
                 }
             } else {
-               // Update the signature enum
-                pcallback->signature->value = CB_D_USERDATA;
+                fprintf(OFILE,"XT:  Checks NOT OK\n"); fflush(OFILE);
+                PyErr_SetString(PyExc_ValueError,
+                    "Wrong number of extra arguments for void *.");
+            }
+            break;
+
+        case CB_D_USERDATA:
+            fprintf(OFILE,"XT:  CB_D_USERDATA\n"); fflush(OFILE);
+            // Is the data passed in, or stored in user_data?
+            if (xargs && PyTuple_Check(xargs) && PyTuple_GET_SIZE(xargs) > 0) {
+                PyErr_SetString(PyExc_ValueError,
+                        "Wrong number of extra arguments for user_data.");
+            } else {
+//                PyObject *item = (PyObject *)pcallback->user_data;
+//                fprintf(OFILE, "CB_D_USERDATA: item is %p: ", item); PyObject_Print(item, OFILE, 0); fprintf(OFILE, "\n"); fflush(OFILE);
                 use_ccallback = TRUE;
             }
             break;
 
         default:
+            // fprintf(OFILE,"Unknown sig->value %d\n", pcallback->signature->value); fflush(OFILE);
             break;
     }
     return use_ccallback;
@@ -254,9 +387,12 @@ call_solver(solver_type solver, PyObject *self, PyObject *args)
     volatile PyObject *fargs = NULL;
     int use_ccallback = FALSE, isllc = FALSE;
     ccallback_t callback;
+    // fprintf(OFILE,"solver %p\n", (void *)solver); fflush(OFILE);
+
     if (!PyArg_ParseTuple(args, "OddddiOi|i",
                 &f, &a, &b, &xtol, &rtol, &iter, &xargs, &fulloutput, &disp)) {
         PyErr_SetString(PyExc_RuntimeError, "Unable to parse arguments");
+        // fprintf(OFILE,"No parse\n"); fflush(OFILE);
         return NULL;
     }
     if (xtol < 0) {
@@ -267,23 +403,31 @@ call_solver(solver_type solver, PyObject *self, PyObject *args)
         PyErr_SetString(PyExc_ValueError, "maxiter should be > 0");
         return NULL;
     }
+    // fprintf(OFILE,"Past checks.\n"); fflush(OFILE);
 
     memset(&callback, sizeof(callback), '\0');
     callback.info_p = NULL;
     isllc = ccallback_is_lowlevelcallable(f);
+    // fprintf(OFILE,"isllc %d\n", isllc); fflush(OFILE);
     use_ccallback = fill_in_ccallback(f, xargs, &callback);
+    // fprintf(OFILE,"use_ccallback %d\n", use_ccallback); fflush(OFILE);
     if (isllc) {
         /* error message already set inside ccallback_prepare */
         if (!use_ccallback) {
+//            PyErr_SetString(PyExc_RuntimeError, "Not a matching callback");
             return NULL;
         }
     }
 
     if (use_ccallback) {
         solver_stats.error_num = 0;
+        // fprintf(OFILE,"ll start!\n"); fflush(OFILE);
         zero = solver(scipy_zeros_functions_lowlevelfunc, a, b,
                       xtol, rtol, iter, (void*)&callback, &solver_stats);
-        free(callback.info_p);
+        // fprintf(OFILE,"ll return!\n"); fflush(OFILE);
+        if (1) {
+            free(callback.info_p);
+        }
         callback.info_p = NULL;
         ccallback_release(&callback);
     }
@@ -321,6 +465,7 @@ call_solver(solver_type solver, PyObject *self, PyObject *args)
             fargs = NULL;
         } else {
             /* error return from Python function */
+            // fprintf(OFILE,"longjmp return\n"); fflush(OFILE);
             Py_DECREF(fargs);
             return NULL;
         }

--- a/scipy/optimize/zeros.c
+++ b/scipy/optimize/zeros.c
@@ -169,7 +169,7 @@ init_func_extra_args(ccallback_t *callback, PyObject *extra_arguments)
     }
 
     callback->info_p = (void *)p;
-    callback->info = num_xargs;
+    callback->info = (int)num_xargs;
     return 0;
 }
 
@@ -177,21 +177,19 @@ init_func_extra_args(ccallback_t *callback, PyObject *extra_arguments)
 static int fill_in_ccallback(PyObject *f, PyObject *xargs, ccallback_t *pcallback)
 {
     int use_ccallback = FALSE;
-    pcallback->info_p = NULL;
-
     int bHasArgs = (xargs && PyTuple_Check(xargs) && PyTuple_GET_SIZE(xargs) > 0);
 
     /* f was filled in previously by PyArg_ParseTuple */
-    const ccallback_signature_t *sigs =  (bHasArgs ? signatures_with_args : signatures_no_args);
-    if (ccallback_prepare(pcallback, (ccallback_signature_t *)sigs, f, CCALLBACK_DEFAULTS)) {
+    const ccallback_signature_t *sigs =  (
+        bHasArgs ? signatures_with_args : signatures_no_args);
+    if (ccallback_prepare(pcallback, (ccallback_signature_t *)sigs,
+                          f, CCALLBACK_DEFAULTS)) {
         return FALSE;
     }
 
+    pcallback->info_p = NULL;
     if (pcallback->signature == NULL) {
         /* pure-Python */
-        /* For now, just break */
-//        PyErr_SetString(PyExc_ValueError,
-//                        "Python call, not LowLevelCallable.");
         return FALSE;
     }
     switch(pcallback->signature->value) {

--- a/scipy/optimize/zeros.c
+++ b/scipy/optimize/zeros.c
@@ -8,8 +8,6 @@
 #include <setjmp.h>
 #include <numpy/npy_math.h>
 
-#include <stdio.h>
-
 #if PY_VERSION_HEX >= 0x03000000
     #define PyString_FromString PyBytes_FromString
     #define PyString_Concat PyBytes_Concat

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -9,7 +9,8 @@ _iter = 100
 _xtol = 2e-12
 _rtol = 4 * np.finfo(float).eps
 
-__all__ = ['newton', 'bisect', 'ridder', 'brentq', 'brenth', 'toms748', 'RootResults']
+__all__ = ['newton', 'bisect', 'ridder', 'brentq', 'brenth', 'toms748',
+           'RootResults']
 
 # Must agree with CONVERGED, SIGNERR, CONVERR, ...  in zeros.h
 CONVERGED = 'converged'
@@ -627,8 +628,8 @@ def brentq(f, a, b, args=(),
     claims convergence is guaranteed for functions computable within [a,b].
 
     [Brent1973]_ provides the classic description of the algorithm.  Another
-    description can be found in a recent edition of Numerical Recipes, including
-    [PressEtal1992]_.  Another description is at
+    description can be found in a recent edition of Numerical Recipes,
+    including [PressEtal1992]_.  Another description is at
     http://mathworld.wolfram.com/BrentsMethod.html.  It should be easy to
     understand the algorithm just by reading our code.  Our code diverges a bit
     from standard presentations: we choose a different formula for the
@@ -860,9 +861,10 @@ def _within_tolerance(x, y, rtol, atol):
 
 def _notclose(fs, rtol=_rtol, atol=_xtol):
     # Ensure not None, not 0, all finite, and not very close to each other
-    notclosefvals = all(fs) and all(np.isfinite(fs)) and \
-                    not any(any(np.isclose(_f, fs[i + 1:], rtol=rtol, atol=atol))
-                            for i, _f in enumerate(fs[:-1]))
+    notclosefvals = (
+            all(fs) and all(np.isfinite(fs)) and
+            not any(any(np.isclose(_f, fs[i + 1:], rtol=rtol, atol=atol))
+                    for i, _f in enumerate(fs[:-1])))
     return notclosefvals
 
 
@@ -886,7 +888,9 @@ def _secant(xvals, fvals):
 
 
 def _update_bracket(ab, fab, c, fc):
-    """Update a bracket given (c, fc) with a < c < b.  Return the discarded endpoints"""
+    """Update a bracket from (c, fc), return the discarded endpoints.
+
+    c must be an interior point of the interval [a, b]."""
     fa, fb = fab
     idx = (0 if np.sign(fa) * np.sign(fc) > 0 else 1)
     rx, rfx = ab[idx], fab[idx]
@@ -895,7 +899,8 @@ def _update_bracket(ab, fab, c, fc):
     return rx, rfx
 
 
-def _compute_divided_differences(xvals, fvals, N=None, full=True, forward=True):
+def _compute_divided_differences(xvals, fvals, N=None, full=True,
+                                 forward=True):
     """Return a matrix of divided differences for the xvals, fvals pairs
 
     DD[i, j] = f[x_{i-j}, ..., x_i] for 0 <= j <= i
@@ -1006,8 +1011,10 @@ class TOMS748Solver(object):
         self.function_calls = 0
         self.iterations = 0
         self.k = 2
-        self.ab = [np.nan, np.nan]  # ab=[a,b] is a global interval containing a root
-        self.fab = [np.nan, np.nan]  # fab is function values at a, b
+        # ab=[a,b] is a global interval containing a root
+        self.ab = [np.nan, np.nan]
+        # fab is function values at a, b
+        self.fab = [np.nan, np.nan]
         self.d = None
         self.fd = None
         self.e = None
@@ -1225,7 +1232,8 @@ def toms748(f, a, b, args=(), k=1,
         containing extra arguments for the function `f`.
         `f` is called by ``f(x, *args)``.
     k : int, optional
-        The number of Newton quadratic steps to perform each iteration. ``k>=1``.
+        The number of Newton quadratic steps to perform during each each
+        iteration. ``k>=1``.
     xtol : scalar, optional
         The computed root ``x0`` will satisfy ``np.allclose(x, x0,
         atol=xtol, rtol=rtol)``, where ``x`` is the exact root. The

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -2,8 +2,14 @@ from __future__ import division, print_function, absolute_import
 
 import warnings
 from collections import namedtuple
-from . import _zeros
 import numpy as np
+from . import _zeros
+from scipy._lib._ccallback import LowLevelCallable
+
+# from ._zero_thunk import call_thunk_real_call_llc
+# from . import _zero_thunk
+# print(dir(_zero_thunk))
+# _call_thunk_real_call_llc = _zero_thunk.call_thunk_real_call_llc
 
 _iter = 100
 _xtol = 2e-12
@@ -261,6 +267,11 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
     # Convert to float (don't use float(x0); this works also for complex x0)
     p0 = 1.0 * x0
     funcalls = 0
+
+    if 0 and isinstance(func, LowLevelCallable):
+        args = tuple([func])
+        func = call_thunk_real_call_llc
+
     if fprime is not None:
         # Newton-Raphson method
         for itr in range(maxiter):
@@ -513,7 +524,9 @@ def bisect(f, a, b, args=(),
         raise ValueError("xtol too small (%g <= 0)" % xtol)
     if rtol < _rtol:
         raise ValueError("rtol too small (%g < %g)" % (rtol, _rtol))
+    print("zeros.py:bisect:", f, a, b, args)
     r = _zeros._bisect(f, a, b, xtol, rtol, maxiter, args, full_output, disp)
+    print("zeros.py:bisect: returned", r)
     return results_c(full_output, r)
 
 

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -514,9 +514,7 @@ def bisect(f, a, b, args=(),
         raise ValueError("xtol too small (%g <= 0)" % xtol)
     if rtol < _rtol:
         raise ValueError("rtol too small (%g < %g)" % (rtol, _rtol))
-    print("zeros.py:bisect:", f, a, b, args)
     r = _zeros._bisect(f, a, b, xtol, rtol, maxiter, args, full_output, disp)
-    print("zeros.py:bisect: returned", r)
     return results_c(full_output, r)
 
 

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -919,7 +919,8 @@ def _compute_divided_differences(xvals, fvals, N=None, full=True,
         DD = np.zeros([M, N])
         DD[:, 0] = fvals[:]
         for i in range(1, N):
-            DD[i:, i] = np.diff(DD[i - 1:, i - 1]) / (xvals[i:] - xvals[:M - i])
+            DD[i:, i] = (np.diff(DD[i - 1:, i - 1]) /
+                         (xvals[i:] - xvals[:M - i]))
         return DD
 
     xvals = np.asarray(xvals)

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -4,12 +4,6 @@ import warnings
 from collections import namedtuple
 import numpy as np
 from . import _zeros
-from scipy._lib._ccallback import LowLevelCallable
-
-# from ._zero_thunk import call_thunk_real_call_llc
-# from . import _zero_thunk
-# print(dir(_zero_thunk))
-# _call_thunk_real_call_llc = _zero_thunk.call_thunk_real_call_llc
 
 _iter = 100
 _xtol = 2e-12
@@ -267,10 +261,6 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
     # Convert to float (don't use float(x0); this works also for complex x0)
     p0 = 1.0 * x0
     funcalls = 0
-
-    if 0 and isinstance(func, LowLevelCallable):
-        args = tuple([func])
-        func = call_thunk_real_call_llc
 
     if fprime is not None:
         # Newton-Raphson method

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -11,6 +11,7 @@ _rtol = 4 * np.finfo(float).eps
 
 __all__ = ['newton', 'bisect', 'ridder', 'brentq', 'brenth', 'toms748', 'RootResults']
 
+# Must agree with CONVERGED, SIGNERR, CONVERR, ...  in zeros.h
 CONVERGED = 'converged'
 SIGNERR = 'sign error'
 CONVERR = 'convergence error'
@@ -267,13 +268,15 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
             funcalls += 1
             # If fval is 0, a root has been found, then terminate
             if fval == 0:
-                return _results_select(full_output, (p0, funcalls, itr, _ECONVERGED))
+                return _results_select(
+                    full_output, (p0, funcalls, itr, _ECONVERGED))
             fder = fprime(p0, *args)
             funcalls += 1
             if fder == 0:
                 msg = "derivative was zero."
                 warnings.warn(msg, RuntimeWarning)
-                return _results_select(full_output, (p0, funcalls, itr + 1, _ECONVERR))
+                return _results_select(
+                    full_output, (p0, funcalls, itr + 1, _ECONVERR))
             newton_step = fval / fder
             if fprime2:
                 fder2 = fprime2(p0, *args)
@@ -289,7 +292,8 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
                     newton_step /= 1.0 - adj
             p = p0 - newton_step
             if np.abs(p - p0) < tol:
-                return _results_select(full_output, (p, funcalls, itr + 1, _ECONVERGED))
+                return _results_select(
+                    full_output, (p, funcalls, itr + 1, _ECONVERGED))
             p0 = p
     else:
         # Secant method
@@ -305,11 +309,13 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
                     msg = "Tolerance of %s reached" % (p1 - p0)
                     warnings.warn(msg, RuntimeWarning)
                 p = (p1 + p0) / 2.0
-                return _results_select(full_output, (p, funcalls, itr + 1, _ECONVERGED))
+                return _results_select(
+                    full_output, (p, funcalls, itr + 1, _ECONVERGED))
             else:
                 p = p1 - q1 * (p1 - p0) / (q1 - q0)
             if np.abs(p - p1) < tol:
-                return _results_select(full_output, (p, funcalls, itr + 1, _ECONVERGED))
+                return _results_select(
+                    full_output, (p, funcalls, itr + 1, _ECONVERGED))
             p0 = p1
             q0 = q1
             p1 = p
@@ -317,7 +323,8 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
             funcalls += 1
 
     if disp:
-        msg = "Failed to converge after %d iterations, value is %s" % (itr + 1, p)
+        msg = "Failed to converge after %d iterations, value is %s" % (
+            itr + 1, p)
         raise RuntimeError(msg)
 
     return _results_select(full_output, (p, funcalls, itr + 1, _ECONVERR))
@@ -402,7 +409,8 @@ def _array_newton(func, x0, fprime, args, tol, maxiter, fprime2, full_output):
                 rms = np.sqrt(
                     sum((p1[zero_der_nz_dp] - p[zero_der_nz_dp]) ** 2)
                 )
-                warnings.warn('RMS of {:g} reached'.format(rms), RuntimeWarning)
+                warnings.warn(
+                    'RMS of {:g} reached'.format(rms), RuntimeWarning)
         # Newton or Halley warnings
         else:
             all_or_some = 'all' if zero_der.all() else 'some'


### PR DESCRIPTION
Added support for the function passed to `optimize.zeros.{bisect|brenth|brentq|ridder}(func, a, b)` to be a `LowLevelCallable`.  This allows for speedups in root-finding by staying within C, and not jumping back and-forth between C and Python.
It is an alternate approach to that of gh-8431, which augments the C implementations of `brenth|brentq|ridder|bisect` with Cython versions in a sub package of `zeros` and allows the user to pass in Cython functions.

Two new files are added with Cython functions for testing purposes: `optimize/_tstutils_zerofuncs.pxy` and `optimize/_tstutils_zerofuncs.pxd`.

Some caveats:
* This PR does not extend support for `LowLevelCallables` to the `toms748` root finder --- that routine is currently written in Python and would require additional modifications.
* This PR does not extend support for LowLevelCallables to the `newton` (or `secant`, `halley`) root finder(s) --- that routine is written in Python, and it supports both real and complex-valued functions, and would require additional modifications.

Some cleanup along the way:
* Separated the constant parts (`function`, `args` and `jmp_buf`) from the changeable parts (`funccalls`, `iterations`, `error_num`) of the `default_parameters` struct into two separate structs.
* Removed an unneeded copy of the `jmp_buf` on the stack of `zeros.c:call_solver`.
* Added `volatile` to the declaration of a variable needed after a `longjmp` returns.
* Split some functionality in `_lib/src/ccallback.h` into multiple functions to enable reuse.