### PR TITLE
Nested SLSQP bug fix.

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -197,6 +197,7 @@ Roy Zywina for contributions to scipy.fftpack.
 Christian H. Meyer for bug fixes in subspace_angles.
 Kai Striega for improvements to the scipy.optimize.linprog simplex method.
 Josua Sassen for improvements to scipy.interpolate.Rbf
+Stiaan Gerber for a bug fix in scipy.optimize.
 
 Institutions
 ------------

--- a/scipy/optimize/slsqp.py
+++ b/scipy/optimize/slsqp.py
@@ -367,6 +367,26 @@ def _minimize_slsqp(func, x0, args=(), jac=None, bounds=None,
     majiter = array(iter, int)
     majiter_prev = 0
 
+    # Initialize internal SLSQP state variables
+    alpha = array(0, float)
+    f0 = array(0, float)
+    gs = array(0, float)
+    h1 = array(0, float)
+    h2 = array(0, float)
+    h3 = array(0, float)
+    h4 = array(0, float)
+    t = array(0, float)
+    t0 = array(0, float)
+    tol = array(0, float)
+    iexact = array(0, int)
+    incons = array(0, int)
+    ireset = array(0, int)
+    itermx = array(0, int)
+    line = array(0, int)
+    n1 = array(0, int)
+    n2 = array(0, int)
+    n3 = array(0, int)
+
     # Print the header if iprint >= 2
     if iprint >= 2:
         print("%5s %5s %16s %16s" % ("NIT", "FC", "OBJFUN", "GNORM"))
@@ -423,7 +443,10 @@ def _minimize_slsqp(func, x0, args=(), jac=None, bounds=None,
             a = concatenate((a, zeros([la, 1])), 1)
 
         # Call SLSQP
-        slsqp(m, meq, x, xl, xu, fx, c, g, a, acc, majiter, mode, w, jw)
+        slsqp(m, meq, x, xl, xu, fx, c, g, a, acc, majiter, mode, w, jw,
+              alpha, f0, gs, h1, h2, h3, h4, t, t0, tol,
+              iexact, incons, ireset, itermx, line, 
+              n1, n2, n3)
 
         # call callback if major iteration has incremented
         if callback is not None and majiter > majiter_prev:

--- a/scipy/optimize/slsqp/slsqp.pyf
+++ b/scipy/optimize/slsqp/slsqp.pyf
@@ -3,7 +3,7 @@
 
 python module _slsqp ! in 
     interface  ! in :slsqp
-        subroutine slsqp(m,meq,la,n,x,xl,xu,f,c,g,a,acc,iter,mode,w,l_w,jw,l_jw) ! in :slsqp:slsqp_optmz.f
+        subroutine slsqp(m,meq,la,n,x,xl,xu,f,c,g,a,acc,iter,mode,w,l_w,jw,l_jw,alpha,f0,gs,h1,h2,h3,h4,t,t0,tol,iexact,incons,ireset,itermx,line,n1,n2,n3) ! in :slsqp:slsqp_optmz.f
             integer :: m
             integer :: meq
             integer optional,check(len(c)>=la),depend(c) :: la=len(c)
@@ -22,9 +22,27 @@ python module _slsqp ! in
             integer optional,check(len(w)>=l_w),depend(w) :: l_w=len(w)
             integer dimension(l_jw) :: jw
             integer optional,check(len(jw)>=l_jw),depend(jw) :: l_jw=len(jw)
+            double precision, intent(inout) :: alpha
+            double precision, intent(inout) :: f0
+            double precision, intent(inout) :: gs
+            double precision, intent(inout) :: h1
+            double precision, intent(inout) :: h2
+            double precision, intent(inout) :: h3
+            double precision, intent(inout) :: h4
+            double precision, intent(inout) :: t
+            double precision, intent(inout) :: t0
+            double precision, intent(inout) :: tol
+            integer, intent(inout) :: iexact
+            integer, intent(inout) :: incons
+            integer, intent(inout) :: ireset
+            integer, intent(inout) :: itermx
+            integer, intent(inout) :: line
+            integer, intent(inout) :: n1
+            integer, intent(inout) :: n2
+            integer, intent(inout) :: n3
         end subroutine slsqp
     end interface 
 end python module slsqp
 
-! This file was auto-generated with f2py (version:2_3844).
+! This file was auto-generated with f2py (version:2).
 ! See http://cens.ioc.ee/projects/f2py2e/

--- a/scipy/optimize/slsqp/slsqp_optmz.f
+++ b/scipy/optimize/slsqp/slsqp_optmz.f
@@ -35,7 +35,10 @@ C
 ************************************************************************
 
       SUBROUTINE slsqp (m, meq, la, n, x, xl, xu, f, c, g, a,
-     *                  acc, iter, mode, w, l_w, jw, l_jw)
+     *                  acc, iter, mode, w, l_w, jw, l_jw,
+     *                  alpha, f0, gs, h1, h2, h3, h4, t, t0, tol,
+     *                  iexact, incons, ireset, itermx, line, 
+     *                  n1, n2, n3)
 
 C   SLSQP       S EQUENTIAL  L EAST  SQ UARES  P ROGRAMMING
 C            TO SOLVE GENERAL NONLINEAR OPTIMIZATION PROBLEMS
@@ -214,10 +217,14 @@ C*                                                                     *
 C***********************************************************************
 
       INTEGER          il, im, ir, is, iter, iu, iv, iw, ix, l_w, l_jw,
-     *                 jw(l_jw), la, m, meq, mineq, mode, n, n1
+     *                 jw(l_jw), la, m, meq, mineq, mode, n
 
       DOUBLE PRECISION acc, a(la,n+1), c(la), f, g(n+1),
      *                 x(n), xl(n), xu(n), w(l_w)
+
+      INTEGER          iexact, incons, ireset, itermx, line, n1, n2, n3
+
+      DOUBLE PRECISION alpha, f0, gs, h1, h2, h3, h4, t, t0, tol
 
 c     dim(W) =         N1*(N1+1) + MEQ*(N1+1) + MINEQ*(N1+1)  for LSQ
 c                    +(N1-MEQ+1)*(MINEQ+2) + 2*MINEQ          for LSI
@@ -254,12 +261,18 @@ C   PREPARE DATA FOR CALLING SQPBDY  -  INITIAL ADDRESSES IN W
       iw = iv + n1
 
       CALL slsqpb  (m, meq, la, n, x, xl, xu, f, c, g, a, acc, iter,
-     * mode, w(ir), w(il), w(ix), w(im), w(is), w(iu), w(iv), w(iw), jw)
-
+     * mode, w(ir), w(il), w(ix), w(im), w(is), w(iu), w(iv), w(iw), jw,
+     * alpha, f0, gs, h1, h2, h3, h4, t, t0, tol,
+     * iexact, incons, ireset, itermx, line, 
+     * n1, n2, n3)
+ 
       END
 
       SUBROUTINE slsqpb (m, meq, la, n, x, xl, xu, f, c, g, a, acc,
-     *                   iter, mode, r, l, x0, mu, s, u, v, w, iw)
+     *                   iter, mode, r, l, x0, mu, s, u, v, w, iw,
+     *                   alpha, f0, gs, h1, h2, h3, h4, t, t0, tol,
+     *                   iexact, incons, ireset, itermx, line, 
+     *                   n1, n2, n3)
 
 C   NONLINEAR PROGRAMMING BY SOLVING SEQUENTIALLY QUADRATIC PROGRAMS
 
@@ -282,9 +295,6 @@ c     dim(W) =         N1*(N1+1) + MEQ*(N1+1) + MINEQ*(N1+1)  for LSQ
 c                     +(N1-MEQ+1)*(MINEQ+2) + 2*MINEQ
 c                     +(N1+MINEQ)*(N1-MEQ) + 2*MEQ + N1       for LSEI
 c                      with MINEQ = M - MEQ + 2*N1  &  N1 = N+1
-
-      SAVE             alpha, f0, gs, h1, h2, h3, h4, t, t0, tol,
-     *                 iexact, incons, ireset, itermx, line, n1, n2, n3
 
       DATA             ZERO /0.0d0/, one /1.0d0/, alfmin /1.0d-1/,
      *                 hun /1.0d+2/, ten /1.0d+1/, two /2.0d0/


### PR DESCRIPTION
First time contributor here. I came across a problem with nested optimization using the SLSQP method in scipy.optimize (Issue #9316) I added a test demonstrating the problem and managed to fix the problem by storing additional information about the internal state of the SLSQP optimization process in _minimize_slsqp(). Seems to be working fine on my side.