### PR TITLE
Fix for error while using PIL with scipy

### DIFF
--- a/scipy/misc/pilutil.py
+++ b/scipy/misc/pilutil.py
@@ -94,14 +94,14 @@ def bytescale(data, cmin=None, cmax=None, high=255, low=0):
     if cmax is None:
         cmax = data.max()
 
-    cscale = cmax - cmin
+    cscale = numpy.subtract(cmax, cmin, dtype=numpy.float32)
     if cscale < 0:
         raise ValueError("`cmax` should be larger than `cmin`.")
     elif cscale == 0:
         cscale = 1
 
     scale = float(high - low) / cscale
-    bytedata = (data - cmin) * scale + low
+    bytedata = numpy.subtract(data, cmin, dtype=numpy.float32) * scale + low
     return (bytedata.clip(low, high) + 0.5).astype(uint8)
 
 


### PR DESCRIPTION
python3.6/site-packages/scipy/misc/pilutil.py", line 97, in bytescale
    cscale = cmax - cmin
TypeError: numpy boolean subtract, the `-` operator, is deprecated, use the bitwise_xor, the `^` operator, or the logical_xor function instead.


lib/python3.6/site-packages/scipy/misc/pilutil.py", line 105, in bytescale
    bytedata = (data - cmin) * scale + low