### PR TITLE
MAINT: Convert instructions to hidden HTML comment

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,20 +1,39 @@
 
-<<Please describe the issue in detail here, and for bug reports fill in the fields below.>>
+<!-- 
+Thank you for taking the time to report a SciPy issue.
+Please describe the issue in detail, and for bug reports
+fill in the fields below. You can delete the sections that 
+don't apply to your issue. You can view the final output
+by clicking the preview button above.
+-->
 
-
+My issue is about ...
 
 ### Reproducing code example:
+<!-- 
+If you place your code between the triple backticks below, 
+it will be marked as a code block automatically 
+-->
+
+
 ```
-<<A short code example that reproduces the problem. It should be self-contained, i.e., possible to run as-is via 'python myproblem.py'>>
+Sample code to reproduce the problem
 ```
 
 ### Error message:
+<!-- If any, paste the *full* error message inside a code block
+as above (starting from line Traceback)
+-->
+
 ```
-<<Full error message, if any (starting from line Traceback: ...)>>
+Traceback (most recent call last):
+  File "<stdin>", line 1, in <module>
+  ...
 ```
 
 ### Scipy/Numpy/Python version information:
+<!-- You can simply run the following and paste the result in a code block
 ```
-<<Output from 'import sys, scipy, numpy; print(scipy.__version__, numpy.__version__, sys.version_info)'>>
+import sys, scipy, numpy; print(scipy.__version__, numpy.__version__, sys.version_info)
 ```
-
+-->

--- a/doc/source/tutorial/arpack.rst
+++ b/doc/source/tutorial/arpack.rst
@@ -162,7 +162,7 @@ non-external eigenvalues: *shift-invert mode*.  As mentioned above, this
 mode involves transforming the eigenvalue problem to an equivalent problem
 with different eigenvalues.  In this case, we hope to find eigenvalues near
 zero, so we'll choose ``sigma = 0``.  The transformed eigenvalues will
-then satisfy :math:`\nu = 1/(\sigma - \lambda) = 1/\lambda`, so our
+then satisfy :math:`\nu = 1/(\lambda - \sigma) = 1/\lambda`, so our
 small eigenvalues :math:`\lambda` become large eigenvalues :math:`\nu`.
 
     >>> evals_small, evecs_small = eigsh(X, 3, sigma=0, which='LM')


### PR DESCRIPTION
As often seen in the issue reports, it seems that folks don't remove the parts that are already in the issue template which causes extra clutter. I've converted the instructions to HTML comments so even if they are kept, they don't show up in the output.