### PR TITLE
Sort file lists

### DIFF
--- a/scipy/_build_utils/_fortran.py
+++ b/scipy/_build_utils/_fortran.py
@@ -112,7 +112,7 @@ def split_fortran_files(source_dir, subroutines=None):
         return new_fnames
 
     exclude_pattern = re.compile('_subr_[0-9]')
-    source_fnames = [f for f in glob.glob(os.path.join(source_dir, '*.f'))
+    source_fnames = [f for f in sorted(glob.glob(os.path.join(source_dir, '*.f')))
                              if not exclude_pattern.search(os.path.basename(f))]
     fnames = []
     for source_fname in source_fnames:

--- a/scipy/linalg/_cython_signature_generator.py
+++ b/scipy/linalg/_cython_signature_generator.py
@@ -55,7 +55,7 @@ def get_sig_name(line):
 def sigs_from_dir(directory, outfile, manual_wrappers=None, exclusions=None):
     if directory[-1] in ['/', '\\']:
         directory = directory[:-1]
-    files = glob.glob(directory + '/*.f*')
+    files = sorted(glob.glob(directory + '/*.f*'))
     if exclusions is None:
         exclusions = []
     if manual_wrappers is not None:

--- a/scipy/sparse/linalg/dsolve/setup.py
+++ b/scipy/sparse/linalg/dsolve/setup.py
@@ -23,7 +23,7 @@ def configuration(parent_package='',top_path=None):
 
     superlu_src = join(dirname(__file__), 'SuperLU', 'SRC')
 
-    sources = list(glob.glob(join(superlu_src, '*.c')))
+    sources = sorted(glob.glob(join(superlu_src, '*.c')))
     headers = list(glob.glob(join(superlu_src, '*.h')))
 
     config.add_library('superlu_src',

--- a/scipy/spatial/setup.py
+++ b/scipy/spatial/setup.py
@@ -18,7 +18,7 @@ def configuration(parent_package='', top_path=None):
     config.add_subpackage('transform')
 
     # qhull
-    qhull_src = list(glob.glob(join(dirname(__file__), 'qhull_src',
+    qhull_src = sorted(glob.glob(join(dirname(__file__), 'qhull_src',
                                     'src', '*.c')))
 
     inc_dirs = [get_python_inc()]


### PR DESCRIPTION
(because linkers take input file order into account)
to generate reproducible binaries
in spite of indeterministic filesystem readdir order
and http://bugs.python.org/issue30461

See https://reproducible-builds.org/ for why this matters.


Note: For fully reproducible output, [numpy>=1.15](https://github.com/numpy/numpy/pull/11163) is also needed.