### PR TITLE
 Add a custom query to be run at LGTM.com

### DIFF
--- a/.lgtm/python-queries/Pythagorean.ql
+++ b/.lgtm/python-queries/Pythagorean.ql
@@ -4,7 +4,6 @@
  * @kind problem
  * @tags accuracy
  * @problem.severity warning
- * @sub-severity low
  * @precision high
  * @id py/pythagorean
  */

--- a/.lgtm/python-queries/Pythagorean.ql
+++ b/.lgtm/python-queries/Pythagorean.ql
@@ -1,0 +1,48 @@
+/**
+ * @name Pythagorean calculation with sub-optimal numerics
+ * @description Calculating the length of the hypotenuse using the standard formula may lead to overflow.
+ * @kind problem
+ * @tags accuracy
+ * @problem.severity warning
+ * @sub-severity low
+ * @precision medium
+ * @id py/pythagorean
+ */
+
+import python
+
+predicate squareOp(BinaryExpr e) {
+  e.getOp() instanceof Pow and e.getRight().(IntegerLiteral).getN() = "2"
+}
+
+predicate squareMul(BinaryExpr e) {
+  e.getOp() instanceof Mult and e.getRight().(Name).getId() = e.getLeft().(Name).getId()
+}
+
+predicate squareRef(Name e) {
+  e.isUse() and
+  exists(SsaVariable v, Expr s |
+    v.getVariable() = e.getVariable() |
+    s = v.getDefinition().getNode().getParentNode().(AssignStmt).getValue() and
+    square(s)
+  )
+}
+
+predicate square(Expr e) {
+  squareOp(e)
+  or
+  squareMul(e)
+  or
+  squareRef(e)
+}
+
+from
+  Call c,
+  BinaryExpr s
+where
+  c.getFunc().toString() = "sqrt" and
+  c.getArg(0) = s and
+  s.getOp() instanceof Add and
+  square(s.getLeft()) and square(s.getRight())
+select
+  c, "Pythagorean calculation with sub-optimal numerics"

--- a/.lgtm/python-queries/Pythagorean.ql
+++ b/.lgtm/python-queries/Pythagorean.ql
@@ -51,16 +51,8 @@ predicate hypot(Call c) {
   )
 }
 
-// inside tests is less interesting
-predicate inTest(Call c) {
-  c.getLocation().getFile().toString().prefix(19) = "/opt/src/benchmarks"
-  or
-  c.getLocation().getFile().getShortName().prefix(4) = "test"
-}
-
 from Call c
 where
-  hypot(c) and not inTest(c)
+  hypot(c)
 select
   c, "Pythagorean calculation with sub-optimal numerics"
-  

--- a/.lgtm/python-queries/Pythagorean.ql
+++ b/.lgtm/python-queries/Pythagorean.ql
@@ -5,7 +5,7 @@
  * @tags accuracy
  * @problem.severity warning
  * @sub-severity low
- * @precision medium
+ * @precision high
  * @id py/pythagorean
  */
 


### PR DESCRIPTION
I had the idea to define a number of queries that look for problematic numerical calculations. This one looks for `sqrt(a**2 + b**2)` which could be replaced with `hypot(a, b)`.
A run against a recent snapshot can be seen here: https://lgtm.com/query/1506571736017/

Some of the results appear to be in test files, it is possible to exclude those.

If the results seem like noise to you or if you have suggestions for more important numerical errors to look for, I am quite interested to hear about it.