### PR TITLE
MAINT Use np.full when possible

### DIFF
--- a/scipy/integrate/_ivp/common.py
+++ b/scipy/integrate/_ivp/common.py
@@ -285,7 +285,7 @@ def num_jac(fun, t, y, f, threshold, factor, sparsity=None):
         return np.empty((0, 0)), factor
 
     if factor is None:
-        factor = np.ones(n) * EPS ** 0.5
+        factor = np.full(n, EPS ** 0.5)
     else:
         factor = factor.copy()
 

--- a/scipy/integrate/quadrature.py
+++ b/scipy/integrate/quadrature.py
@@ -294,7 +294,7 @@ def cumtrapz(y, x=None, dx=1.0, axis=-1, initial=None):
 
         shape = list(res.shape)
         shape[axis] = 1
-        res = np.concatenate([np.ones(shape, dtype=res.dtype) * initial, res],
+        res = np.concatenate([np.full(shape, initial, dtype=res.dtype), res],
                              axis=axis)
 
     return res

--- a/scipy/linalg/_decomp_update.pyx.in
+++ b/scipy/linalg/_decomp_update.pyx.in
@@ -1938,7 +1938,7 @@ cdef qr_insert_col(Q, R, u, int k, rcond, bint overwrite_qru, bint check_finite)
     # special case 1xN
     # if m == 1, Q is always 1x1 and abs(Q[0,0]) == 1.0
     if m == 1:
-        rnew = np.insert(r1, k*np.ones(p, np.intp), q1.conjugate()*u1, 1)
+        rnew = np.insert(r1, np.full(p, k, np.intp), q1.conjugate()*u1, 1)
         return q1.copy(), rnew
 
     if economic:

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -476,8 +476,8 @@ class DifferentialEvolutionSolver(object):
             self.population[:, j] = samples[order, j]
 
         # reset population energies
-        self.population_energies = (np.ones(self.num_population_members) *
-                                    np.inf)
+        self.population_energies = np.full(self.num_population_members,
+                                           np.inf)
 
         # reset number of function evaluations counter
         self._nfev = 0
@@ -491,8 +491,8 @@ class DifferentialEvolutionSolver(object):
         self.population = rng.random_sample(self.population_shape)
 
         # reset population energies
-        self.population_energies = (np.ones(self.num_population_members) *
-                                    np.inf)
+        self.population_energies = np.full(self.num_population_members,
+                                           np.inf)
 
         # reset number of function evaluations counter
         self._nfev = 0

--- a/scipy/optimize/_group_columns.pyx
+++ b/scipy/optimize/_group_columns.pyx
@@ -18,7 +18,7 @@ from cpython cimport bool
 def group_dense(int m, int n, int [:, :] A):
     cdef int [:, :] B = A.T  # Transposed view for convenience.
 
-    cdef int [:] groups = -np.ones(n, dtype=np.int32)
+    cdef int [:] groups = np.full(n, -1, dtype=np.int32)
     cdef int current_group = 0
 
     cdef int i, j, k
@@ -64,7 +64,7 @@ def group_dense(int m, int n, int [:, :] A):
 
 @cython.wraparound(False)
 def group_sparse(int m, int n, int [:] indices, int [:] indptr):
-    cdef int [:] groups = -np.ones(n, dtype=np.int32)
+    cdef int [:] groups = np.full(n, -1, dtype=np.int32)
     cdef int current_group = 0
 
     cdef int i, j, k

--- a/scipy/optimize/nonlin.py
+++ b/scipy/optimize/nonlin.py
@@ -1262,7 +1262,7 @@ class LinearMixing(GenericBroyden):
         return -f/np.conj(self.alpha)
 
     def todense(self):
-        return np.diag(-np.ones(self.shape[0])/self.alpha)
+        return np.diag(np.full(self.shape[0], -1/self.alpha))
 
     def _update(self, x, f, dx, df, dx_norm, df_norm):
         pass
@@ -1298,7 +1298,7 @@ class ExcitingMixing(GenericBroyden):
 
     def setup(self, x, F, func):
         GenericBroyden.setup(self, x, F, func)
-        self.beta = self.alpha * np.ones((self.shape[0],), dtype=self.dtype)
+        self.beta = np.full((self.shape[0],), self.alpha, dtype=self.dtype)
 
     def solve(self, f, tol=0):
         return -f*self.beta

--- a/scipy/sparse/linalg/dsolve/linsolve.py
+++ b/scipy/sparse/linalg/dsolve/linsolve.py
@@ -214,7 +214,7 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
                 w = np.flatnonzero(xj)
                 segment_length = w.shape[0]
                 row_segs.append(w)
-                col_segs.append(np.ones(segment_length, dtype=int)*j)
+                col_segs.append(np.full(segment_length, j, dtype=int))
                 data_segs.append(np.asarray(xj[w], dtype=A.dtype))
             sparse_data = np.concatenate(data_segs)
             sparse_row = np.concatenate(row_segs)

--- a/scipy/special/tests/test_logsumexp.py
+++ b/scipy/special/tests/test_logsumexp.py
@@ -19,7 +19,7 @@ def test_logsumexp():
     assert_almost_equal(logsumexp(b), desired)
 
     n = 1000
-    b = np.full(n, 10000)
+    b = np.full(n, 10000, dtype='float64')
     desired = 10000.0 + np.log(n)
     assert_almost_equal(logsumexp(b), desired)
 

--- a/scipy/special/tests/test_logsumexp.py
+++ b/scipy/special/tests/test_logsumexp.py
@@ -19,7 +19,7 @@ def test_logsumexp():
     assert_almost_equal(logsumexp(b), desired)
 
     n = 1000
-    b = np.ones(n) * 10000
+    b = np.full(n, 10000)
     desired = 10000.0 + np.log(n)
     assert_almost_equal(logsumexp(b), desired)
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -917,7 +917,7 @@ def moment(a, moment=1, axis=0, nan_policy='propagate'):
         if np.isscalar(moment):
             return np.nan
         else:
-            return np.ones(np.asarray(moment).shape, dtype=np.float64) * np.nan
+            return np.full(np.asarray(moment).shape, np.nan, dtype=np.float64)
 
     # for array_like moment input, return a value for each.
     if not np.isscalar(moment):
@@ -1683,7 +1683,7 @@ def scoreatpercentile(a, per, limit=(), interpolation_method='fraction',
         if np.isscalar(per):
             return np.nan
         else:
-            return np.ones(np.asarray(per).shape, dtype=np.float64) * np.nan
+            return np.full(np.asarray(per).shape, np.nan, dtype=np.float64)
 
     if limit:
         a = a[(limit[0] <= a) & (a <= limit[1])]


### PR DESCRIPTION
This PR makes use of `np.full` in places where `cst * np.ones` etc was previously used. The former makes less memory copies and is significantly faster,
```
In [2]: %timeit 2*np.ones(1000)
4.7 µs ± 48.6 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
In [3]: %timeit np.full(1000, 2)
2.83 µs ± 10.1 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
In [4]: %timeit - np.ones(1000)
4.03 µs ± 28.7 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```
the changes are not exhaustive, and were only applied when they could have a chance to impact run time (e.g. array size could be big enough).

`np.full` is available since numpy 1.8.