### PR TITLE
 DOC: Fix import of scipy.sparse.linalg in example (#9345)

### DIFF
--- a/scipy/sparse/linalg/eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/arpack.py
@@ -1224,9 +1224,9 @@ def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
     --------
     Find 6 eigenvectors of the identity matrix:
 
-    >>> import scipy.sparse.linalg as linalg
+    >>> from scipy.sparse.linalg import eigs
     >>> id = np.eye(13)
-    >>> vals, vecs = linalg.eigs(id, k=6)
+    >>> vals, vecs = eigs(id, k=6)
     >>> vals
     array([ 1.+0.j,  1.+0.j,  1.+0.j,  1.+0.j,  1.+0.j,  1.+0.j])
     >>> vecs.shape

--- a/scipy/sparse/linalg/eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/arpack.py
@@ -1224,9 +1224,9 @@ def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
     --------
     Find 6 eigenvectors of the identity matrix:
 
-    >>> import scipy.sparse as sparse
+    >>> import scipy.sparse.linalg as linalg
     >>> id = np.eye(13)
-    >>> vals, vecs = sparse.linalg.eigs(id, k=6)
+    >>> vals, vecs = linalg.eigs(id, k=6)
     >>> vals
     array([ 1.+0.j,  1.+0.j,  1.+0.j,  1.+0.j,  1.+0.j,  1.+0.j])
     >>> vecs.shape


### PR DESCRIPTION
Closes #9345. 

Updated documentation to import the function directly