### PR TITLE
Fix interpolate read only

### DIFF
--- a/scipy/interpolate/_bspl.pyx
+++ b/scipy/interpolate/_bspl.pyx
@@ -29,7 +29,7 @@ ctypedef fused double_or_complex:
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-cdef inline int find_interval(double[::1] t,
+cdef inline int find_interval(const double[::1] t,
                        int k,
                        double xval,
                        int prev_l,
@@ -89,10 +89,10 @@ cdef inline int find_interval(double[::1] t,
 @cython.wraparound(False)
 @cython.boundscheck(False)
 @cython.cdivision(True)
-def evaluate_spline(double[::1] t,
+def evaluate_spline(const double[::1] t,
              double_or_complex[:, ::1] c,
              int k,
-             double[::1] xp,
+             const double[::1] xp,
              int nu,
              bint extrapolate,
              double_or_complex[:, ::1] out):
@@ -160,7 +160,7 @@ def evaluate_spline(double[::1] t,
                     out[ip, jp] = out[ip, jp] + c[interval + a - k, jp] * work[a]
 
 
-def evaluate_all_bspl(double[::1] t, int k, double xval, int m, int nu=0):
+def evaluate_all_bspl(const double[::1] t, int k, double xval, int m, int nu=0):
     """Evaluate the ``k+1`` B-splines which are non-zero on interval ``m``.
 
     Parameters
@@ -224,7 +224,8 @@ def evaluate_all_bspl(double[::1] t, int k, double xval, int m, int nu=0):
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def _colloc(double[::1] x, double[::1] t, int k, double[::1, :] ab, int offset=0):
+def _colloc(const double[::1] x, const double[::1] t, int k, double[::1, :] ab,
+            int offset=0):
     """Build the B-spline collocation matrix.
 
     The collocation matrix is defined as :math:`B_{j,l} = B_l(x_j)`,
@@ -285,10 +286,10 @@ def _colloc(double[::1] x, double[::1] t, int k, double[::1, :] ab, int offset=0
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def _handle_lhs_derivatives(double[::1]t, int k, double xval,
+def _handle_lhs_derivatives(const double[::1]t, int k, double xval,
                             double[::1, :] ab,
                             int kl, int ku,
-                            cnp.int_t[::1] deriv_ords,
+                            const cnp.int_t[::1] deriv_ords,
                             int offset=0):
     """ Fill in the entries of the collocation matrix corresponding to known
     derivatives at xval.
@@ -336,11 +337,11 @@ def _handle_lhs_derivatives(double[::1]t, int k, double xval,
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def _norm_eq_lsq(double[::1] x,
-                 double[::1] t,
+def _norm_eq_lsq(const double[::1] x,
+                 const double[::1] t,
                  int k,
                  double_or_complex[:, ::1] y,
-                 double[::1] w,
+                 const double[::1] w,
                  double[::1, :] ab,
                  double_or_complex[::1, :] rhs):
     """Construct the normal equations for the B-spline LSQ problem.

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -698,6 +698,19 @@ class TestInterp1D(object):
                 assert_(np.isnan(outn).all())
                 assert_equal(out.shape, outn.shape)
 
+    def test_read_only(self):
+        x = np.arange(0, 10)
+        y = np.exp(-x / 3.0)
+        xnew = np.arange(0, 9, 0.1)
+        # Check both read-only and not read-only:
+        for writeable in (True, False):
+            xnew.flags.writeable = writeable
+            for kind in ('linear', 'nearest', 'zero', 'slinear', 'quadratic',
+                         'cubic'):
+                f = interp1d(x, y, kind=kind)
+                vals = f(xnew)
+                assert_(np.isfinite(vals).all())
+
 
 class TestLagrange(object):
 


### PR DESCRIPTION
This attempts to fix issue #9331 where the read-only array would raise an exception.  I tried to put in const for arrays that are read-only in nature.  However, due to the lack of fused type support for const in cython some arguments are not marked as const so it is not a complete yet. 