### PR TITLE
DOC: improve doc for ksone and kstwobign in scipy.stats

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -46,7 +46,7 @@ class ksone_gen(rv_continuous):
 
     Notes
     -----
-    The :math:`\sqrt{n} D_n^+` and :math:`\sqrt{n} D_n^-` are given by
+    :math:`\sqrt{n} D_n^+` and :math:`\sqrt{n} D_n^-` are given by
 
     .. math::
 
@@ -63,6 +63,12 @@ class ksone_gen(rv_continuous):
     See Also
     --------
     kstwobign, kstest
+
+    References
+    ----------
+    .. [1] Birnbaum, Z. W. and Tingey, F.H. "One-sided confidence contours
+       for probability distribution functions", The Annals of Mathematical
+       Statistics, 22(4), pp 592-596 (1951).
 
     %(example)s
 
@@ -81,14 +87,14 @@ class kstwobign_gen(rv_continuous):
     """Kolmogorov-Smirnov two-sided test for large N.
 
     This is the asymptotic distribution of the two-sided Kolmogorov-Smirnov
-    statistic :math:`\sqrt{n} D_n` that measures the maximum of absolute
+    statistic :math:`\sqrt{n} D_n` that measures the maximum absolute
     distance of the theoretical CDF from the empirical CDF (see `kstest`).
 
     %(before_notes)s
 
     Notes
     -----
-    The :math:`\sqrt{n} D_n` is given by
+    :math:`\sqrt{n} D_n` is given by
 
     .. math::
 
@@ -104,6 +110,11 @@ class kstwobign_gen(rv_continuous):
     See Also
     --------
     ksone, kstest
+
+    References
+    ----------
+    .. [1] Marsaglia, G. et al. "Evaluating Kolmogorov's distribution",
+       Journal of Statistical Software, 8(18), 2003.
 
     %(example)s
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -36,7 +36,7 @@ except AttributeError:
 
 ## Kolmogorov-Smirnov one-sided and two-sided test statistics
 class ksone_gen(rv_continuous):
-    """General Kolmogorov-Smirnov one-sided test.
+    r"""General Kolmogorov-Smirnov one-sided test.
 
     This is the distribution of the one-sided Kolmogorov-Smirnov (KS)
     statistics :math:`\sqrt{n} D_n^+` and :math:`\sqrt{n} D_n^-`
@@ -50,8 +50,8 @@ class ksone_gen(rv_continuous):
 
     .. math::
 
-        D_n^+ &= \sup_x (F_n(x) - F(x)),\\
-        D_n^- &= \sup_x (F(x) - F_n(x)),\\
+        D_n^+ &= \text{sup}_x (F_n(x) - F(x)),\\
+        D_n^- &= \text{sup}_x (F(x) - F_n(x)),\\
 
     where :math:`F` is a CDF and :math:`F_n` is an empirical CDF. `ksone`
     describes the distribution under the null hypothesis of the KS test
@@ -84,7 +84,7 @@ ksone = ksone_gen(a=0.0, name='ksone')
 
 
 class kstwobign_gen(rv_continuous):
-    """Kolmogorov-Smirnov two-sided test for large N.
+    r"""Kolmogorov-Smirnov two-sided test for large N.
 
     This is the asymptotic distribution of the two-sided Kolmogorov-Smirnov
     statistic :math:`\sqrt{n} D_n` that measures the maximum absolute
@@ -98,12 +98,12 @@ class kstwobign_gen(rv_continuous):
 
     .. math::
 
-        D_n = \sup_x \abs{F_n(x) - F(x)}
+        D_n = \text{sup}_x |F_n(x) - F(x)|
 
     where :math:`F` is a CDF and :math:`F_n` is an empirical CDF. `kstwobign`
-    describes the asymptotic distribution (i.e. :math:`\lim_n \sqrt{n} D_n`
-    under the null hypothesis of the KS test that the empirical CDF
-    corresponds to i.i.d. random variates with CDF :math:`F`.
+    describes the asymptotic distribution (i.e. the limit of
+    :math:`\sqrt{n} D_n`) under the null hypothesis of the KS test that the
+    empirical CDF corresponds to i.i.d. random variates with CDF :math:`F`.
 
     %(after_notes)s
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -38,7 +38,33 @@ except AttributeError:
 class ksone_gen(rv_continuous):
     """General Kolmogorov-Smirnov one-sided test.
 
-    %(default)s
+    This is the distribution of the one-sided Kolmogorov-Smirnov (KS)
+    statistics :math:`\sqrt{n} D_n^+` and :math:`\sqrt{n} D_n^-`
+    for a finite sample size ``n`` (the shape parameter).
+
+    %(before_notes)s
+
+    Notes
+    -----
+    The :math:`\sqrt{n} D_n^+` and :math:`\sqrt{n} D_n^-` are given by
+
+    .. math::
+
+        D_n^+ &= \sup_x (F_n(x) - F(x)),\\
+        D_n^- &= \sup_x (F(x) - F_n(x)),\\
+
+    where :math:`F` is a CDF and :math:`F_n` is an empirical CDF. `ksone`
+    describes the distribution under the null hypothesis of the KS test
+    that the empirical CDF corresponds to :math:`n` i.i.d. random variates
+    with CDF :math:`F`.
+
+    %(after_notes)s
+
+    See Also
+    --------
+    kstwobign, kstest
+
+    %(example)s
 
     """
     def _cdf(self, x, n):
@@ -54,7 +80,32 @@ ksone = ksone_gen(a=0.0, name='ksone')
 class kstwobign_gen(rv_continuous):
     """Kolmogorov-Smirnov two-sided test for large N.
 
-    %(default)s
+    This is the asymptotic distribution of the two-sided Kolmogorov-Smirnov
+    statistic :math:`\sqrt{n} D_n` that measures the maximum of absolute
+    distance of the theoretical CDF from the empirical CDF (see `kstest`).
+
+    %(before_notes)s
+
+    Notes
+    -----
+    The :math:`\sqrt{n} D_n` is given by
+
+    .. math::
+
+        D_n = \sup_x \abs{F_n(x) - F(x)}
+
+    where :math:`F` is a CDF and :math:`F_n` is an empirical CDF. `kstwobign`
+    describes the asymptotic distribution (i.e. :math:`\lim_n \sqrt{n} D_n`
+    under the null hypothesis of the KS test that the empirical CDF
+    corresponds to i.i.d. random variates with CDF :math:`F`.
+
+    %(after_notes)s
+
+    See Also
+    --------
+    ksone, kstest
+
+    %(example)s
 
     """
     def _cdf(self, x):
@@ -114,8 +165,8 @@ def _norm_isf(q):
 class norm_gen(rv_continuous):
     r"""A normal continuous random variable.
 
-    The location (loc) keyword specifies the mean.
-    The scale (scale) keyword specifies the standard deviation.
+    The location (``loc``) keyword specifies the mean.
+    The scale (``scale``) keyword specifies the standard deviation.
 
     %(before_notes)s
 
@@ -215,9 +266,9 @@ class alpha_gen(rv_continuous):
         f(x, a) = \frac{1}{x^2 \Phi(a) \sqrt{2\pi}} *
                   \exp(-\frac{1}{2} (a-1/x)^2)
 
-    where :math:`\Phi(a)` is the normal CDF, :math:`x > 0`, and :math:`a > 0`.
+    where :math:`\Phi` is the normal CDF, :math:`x > 0`, and :math:`a > 0`.
 
-    `alpha` takes ``a`` as a shape parameter for :math:`a`.
+    `alpha` takes ``a`` as a shape parameter.
 
     %(after_notes)s
 

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -554,14 +554,10 @@ class planck_gen(rv_discrete):
 
     """
     def _argcheck(self, lambda_):
-        self.a = np.where(lambda_ > 0, 0, -np.inf)
-        self.b = np.where(lambda_ > 0, np.inf, 0)
-        return lambda_ != 0
+        return lambda_ > 0
 
     def _pmf(self, k, lambda_):
-        # planck.pmf(k) = (1-exp(-lambda_))*exp(-lambda_*k)
-        fact = (1-exp(-lambda_))
-        return fact*exp(-lambda_*k)
+        return (1-exp(-lambda_))*exp(-lambda_*k)
 
     def _cdf(self, x, lambda_):
         k = floor(x)
@@ -593,7 +589,7 @@ class planck_gen(rv_discrete):
         return l*exp(-l)/C - log(C)
 
 
-planck = planck_gen(name='planck', longname='A discrete exponential ')
+planck = planck_gen(a=0, name='planck', longname='A discrete exponential ')
 
 
 class boltzmann_gen(rv_discrete):

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -544,7 +544,7 @@ class planck_gen(rv_discrete):
 
         f(k) = (1-\exp(-\lambda)) \exp(-\lambda k)
 
-    for :math:`k \lambda \ge 0`.
+    for :math:`k \ge 0` and :math:`\lambda > 0`.
 
     `planck` takes :math:`\lambda` as shape parameter.
 
@@ -745,7 +745,8 @@ class zipf_gen(rv_discrete):
 
     for :math:`k \ge 1`.
 
-    `zipf` takes :math:`a` as shape parameter.
+    `zipf` takes :math:`a` as shape parameter. :math:`\zeta` is the 
+    Riemann zeta function (`scipy.special.zeta`)
 
     %(after_notes)s
 
@@ -786,7 +787,7 @@ class dlaplace_gen(rv_discrete):
 
         f(k) = \tanh(a/2) \exp(-a |k|)
 
-    for :math:`a > 0`.
+    for integers :math:`k` and :math:`a > 0`.
 
     `dlaplace` takes :math:`a` as shape parameter.
 
@@ -838,8 +839,8 @@ class skellam_gen(rv_discrete):
     uncorrelated Poisson random variables.
 
     Let :math:`k_1` and :math:`k_2` be two Poisson-distributed r.v. with
-    expected values lam1 and lam2. Then, :math:`k_1 - k_2` follows a Skellam
-    distribution with parameters
+    expected values :math:`\lambda_1` and :math:`\lambda_2`. Then,
+    :math:`k_1 - k_2` follows a Skellam distribution with parameters
     :math:`\mu_1 = \lambda_1 - \rho \sqrt{\lambda_1 \lambda_2}` and
     :math:`\mu_2 = \lambda_2 - \rho \sqrt{\lambda_1 \lambda_2}`, where
     :math:`\rho` is the correlation coefficient between :math:`k_1` and


### PR DESCRIPTION
Also fixed a few other doc issues + minor code change / bug fix for discrete distribution `planck`: it was defined on `x <= 0` for `lambda < 0` but then `pmf(x) = (1-exp(-lambda))*exp(-lambda*x) < 0` for `x < 0`.