### PR TITLE
DOC: Change datatypes of A matrices in linprog

### DIFF
--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -185,7 +185,7 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
     c : 1D array
         Coefficients of the linear objective function to be minimized.
     A_ub : 2D array, optional
-        2D array such that ``A_ub`` @ ``x`` gives the values of the upper-bound
+        2D array such that ``A_ub @ x`` gives the values of the upper-bound
         inequality constraints at ``x``.
     b_ub : 1D array, optional
         1D array of values representing the upper-bound of each inequality

--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -49,8 +49,8 @@ def linprog_verbose_callback(res):
         success : bool
             True if the algorithm succeeded in finding an optimal solution.
         slack : 1D array
-            The values of the slack variables.  Each slack variable corresponds
-            to an inequality constraint.  If the slack is zero, then the
+            The values of the slack variables. Each slack variable corresponds
+            to an inequality constraint. If the slack is zero, then the
             corresponding constraint is active.
         con : 1D array
             The (nominally zero) residuals of the equality constraints, that is,
@@ -184,16 +184,16 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
     ----------
     c : 1D array
         Coefficients of the linear objective function to be minimized.
-    A_ub : 1D array, optional
-        2D array which, when matrix-multiplied by ``x``, gives the values of
-        the upper-bound inequality constraints at ``x``.
+    A_ub : 2D array, optional
+        2D array such that ``A_ub`` @ ``x`` gives the values of the upper-bound
+        inequality constraints at ``x``.
     b_ub : 1D array, optional
         1D array of values representing the upper-bound of each inequality
         constraint (row) in ``A_ub``.
-    A_eq : array_like, optional
-        2D array which, when matrix-multiplied by ``x``, gives the values of
-        the equality constraints at ``x``.
-    b_eq : array_like, optional
+    A_eq : 2D, optional
+        2D array such that ``A_eq`` @ ``x`` gives the values of the equality
+        constraints at ``x``.
+    b_eq : 1D array, optional
         1D array of values representing the RHS of each equality constraint
         (row) in ``A_eq``.
     bounds : sequence, optional
@@ -266,7 +266,7 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
             Value of the objective function.
         slack : 1D array
             The values of the slack variables. Each slack variable corresponds
-            to an inequality constraint.  If the slack is zero, then the
+            to an inequality constraint. If the slack is zero, then the
             corresponding constraint is active.
         con : 1D array
             The (nominally zero) residuals of the equality constraints, that is,

--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -257,36 +257,37 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
 
     Returns
     -------
-    A `scipy.optimize.OptimizeResult` consisting of the following fields:
+    res : OptimizeResult
+        A :class:`scipy.optimize.OptimizeResult` consisting of the fields:
 
-        x : 1D array
-            The independent variable vector which optimizes the linear
-            programming problem.
-        fun : float
-            Value of the objective function.
-        slack : 1D array
-            The values of the slack variables. Each slack variable corresponds
-            to an inequality constraint. If the slack is zero, then the
-            corresponding constraint is active.
-        con : 1D array
-            The (nominally zero) residuals of the equality constraints, that is,
-            ``b - A_eq @ x``
-        success : bool
-            Returns True if the algorithm succeeded in finding an optimal
-            solution.
-        status : int
-            An integer representing the exit status of the optimization::
+            x : 1D array
+                The independent variable vector which optimizes the linear
+                programming problem.
+            fun : float
+                Value of the objective function.
+            slack : 1D array
+                The values of the slack variables. Each slack variable
+                corresponds to an inequality constraint. If the slack is zero,
+                then the corresponding constraint is active.
+            con : 1D array
+                The (nominally zero) residuals of the equality constraints,
+                that is, ``b - A_eq @ x``
+            success : bool
+                Returns True if the algorithm succeeded in finding an optimal
+                solution.
+            status : int
+                An integer representing the exit status of the optimization::
 
-                 0 : Optimization terminated successfully
-                 1 : Iteration limit reached
-                 2 : Problem appears to be infeasible
-                 3 : Problem appears to be unbounded
-                 4 : Serious numerical difficulties encountered
+                     0 : Optimization terminated successfully
+                     1 : Iteration limit reached
+                     2 : Problem appears to be infeasible
+                     3 : Problem appears to be unbounded
+                     4 : Serious numerical difficulties encountered
 
-        nit : int
-            The number of iterations performed.
-        message : str
-            A string descriptor of the exit status of the optimization.
+            nit : int
+                The number of iterations performed.
+            message : str
+                A string descriptor of the exit status of the optimization.
 
     See Also
     --------

--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -191,7 +191,7 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
         1D array of values representing the upper-bound of each inequality
         constraint (row) in ``A_ub``.
     A_eq : 2D, optional
-        2D array such that ``A_eq`` @ ``x`` gives the values of the equality
+        2D array such that ``A_eq @ x`` gives the values of the equality
         constraints at ``x``.
     b_eq : 1D array, optional
         1D array of values representing the RHS of each equality constraint

--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -552,7 +552,7 @@ def _ip_hsd(A, b, c, c0, alpha0, beta, maxiter, disp, tol,
     Parameters
     ----------
     A : 2D array
-        2D array such that ``A`` @ ``x``, gives the values of the equality
+        2D array such that ``A @ x``, gives the values of the equality
         constraints at ``x``.
     b : 1D array
         1D array of values representing the RHS of each equality constraint
@@ -798,7 +798,7 @@ def _linprog_ip(
         Constant term in objective function due to fixed (and eliminated)
         variables. (Purely for display.)
     A : 2D array
-        2D array such that ``A`` @ ``x``, gives the values of the equality
+        2D array such that ``A @ x``, gives the values of the equality
         constraints at ``x``.
     b : 1D array
         1D array of values representing the right hand side of each equality

--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -552,8 +552,8 @@ def _ip_hsd(A, b, c, c0, alpha0, beta, maxiter, disp, tol,
     Parameters
     ----------
     A : 2D array
-        2D array which, when matrix-multiplied by ``x``, gives the values of
-        the equality constraints at ``x`` (for standard form problem).
+        2D array such that ``A`` @ ``x``, gives the values of the equality
+        constraints at ``x``.
     b : 1D array
         1D array of values representing the RHS of each equality constraint
         (row) in ``A`` (for standard form problem).
@@ -798,8 +798,8 @@ def _linprog_ip(
         Constant term in objective function due to fixed (and eliminated)
         variables. (Purely for display.)
     A : 2D array
-        2D array which, when matrix-multiplied by ``x``, gives the values of
-        the equality constraints at ``x``.
+        2D array such that ``A`` @ ``x``, gives the values of the equality
+        constraints at ``x``.
     b : 1D array
         1D array of values representing the right hand side of each equality
         constraint (row) in ``A``.

--- a/scipy/optimize/_linprog_simplex.py
+++ b/scipy/optimize/_linprog_simplex.py
@@ -15,7 +15,31 @@ def _pivot_col(T, tol=1.0E-12, bland=False):
     Parameters
     ----------
     T : 2D array
-        The simplex tableau.
+        A 2D array representing the simplex tableau, T, corresponding to the
+        linear programming problem. It should have the form:
+
+        [[A[0, 0], A[0, 1], ..., A[0, n_total], b[0]],
+         [A[1, 0], A[1, 1], ..., A[1, n_total], b[1]],
+         .
+         .
+         .
+         [A[m, 0], A[m, 1], ..., A[m, n_total], b[m]],
+         [c[0],   c[1], ...,   c[n_total],    0]]
+
+        for a Phase 2 problem, or the form:
+
+        [[A[0, 0], A[0, 1], ..., A[0, n_total], b[0]],
+         [A[1, 0], A[1, 1], ..., A[1, n_total], b[1]],
+         .
+         .
+         .
+         [A[m, 0], A[m, 1], ..., A[m, n_total], b[m]],
+         [c[0],   c[1], ...,   c[n_total],   0],
+         [c'[0],  c'[1], ...,  c'[n_total],  0]]
+
+         for a Phase 1 problem (a problem in which a basic feasible solution is
+         sought prior to maximizing the actual objective. ``T`` is modified in
+         place by ``_solve_simplex``.
     tol : float
         Elements in the objective row larger than -tol will not be considered
         for pivoting. Nominally this value is zero, but numerical issues
@@ -51,7 +75,31 @@ def _pivot_row(T, basis, pivcol, phase, tol=1.0E-12, bland=False):
     Parameters
     ----------
     T : 2D array
-        The simplex tableau.
+        A 2D array representing the simplex tableau, T, corresponding to the
+        linear programming problem. It should have the form:
+
+        [[A[0, 0], A[0, 1], ..., A[0, n_total], b[0]],
+         [A[1, 0], A[1, 1], ..., A[1, n_total], b[1]],
+         .
+         .
+         .
+         [A[m, 0], A[m, 1], ..., A[m, n_total], b[m]],
+         [c[0],   c[1], ...,   c[n_total],    0]]
+
+        for a Phase 2 problem, or the form:
+
+        [[A[0, 0], A[0, 1], ..., A[0, n_total], b[0]],
+         [A[1, 0], A[1, 1], ..., A[1, n_total], b[1]],
+         .
+         .
+         .
+         [A[m, 0], A[m, 1], ..., A[m, n_total], b[m]],
+         [c[0],   c[1], ...,   c[n_total],   0],
+         [c'[0],  c'[1], ...,  c'[n_total],  0]]
+
+         for a Phase 1 problem (a Problem in which a basic feasible solution is
+         sought prior to maximizing the actual objective. ``T`` is modified in
+         place by ``_solve_simplex``.
     basis : array
         A list of the current basic variables.
     pivcol : int
@@ -99,8 +147,31 @@ def _apply_pivot(T, basis, pivrow, pivcol, tol=1e-12):
     Parameters
     ----------
     T : 2D array
-        A 2D numpy array representing the simplex T to the corresponding
-        maximization problem.
+        A 2D array representing the simplex tableau, T, corresponding to the
+        linear programming problem. It should have the form:
+
+        [[A[0, 0], A[0, 1], ..., A[0, n_total], b[0]],
+         [A[1, 0], A[1, 1], ..., A[1, n_total], b[1]],
+         .
+         .
+         .
+         [A[m, 0], A[m, 1], ..., A[m, n_total], b[m]],
+         [c[0],   c[1], ...,   c[n_total],    0]]
+
+        for a Phase 2 problem, or the form:
+
+        [[A[0, 0], A[0, 1], ..., A[0, n_total], b[0]],
+         [A[1, 0], A[1, 1], ..., A[1, n_total], b[1]],
+         .
+         .
+         .
+         [A[m, 0], A[m, 1], ..., A[m, n_total], b[m]],
+         [c[0],   c[1], ...,   c[n_total],   0],
+         [c'[0],  c'[1], ...,  c'[n_total],  0]]
+
+         for a Phase 1 problem (a problem in which a basic feasible solution is
+         sought prior to maximizing the actual objective. ``T`` is modified in
+         place by ``_solve_simplex``.
     basis : 1D array
         An array of the indices of the basic variables, such that basis[i]
         contains the column corresponding to the basic variable for row i.
@@ -170,7 +241,7 @@ def _solve_simplex(T, n, basis, maxiter=1000, phase=2, status=0, message='',
          [c[0],   c[1], ...,   c[n_total],   0],
          [c'[0],  c'[1], ...,  c'[n_total],  0]]
 
-         for a Phase 1 problem (a Problem in which a basic feasible solution is
+         for a Phase 1 problem (a problem in which a basic feasible solution is
          sought prior to maximizing the actual objective. ``T`` is modified in
          place by ``_solve_simplex``.
     n : int
@@ -354,11 +425,11 @@ def _linprog_simplex(c, c0, A, b, maxiter=1000, disp=False, callback=None,
         Constant term in objective function due to fixed (and eliminated)
         variables. (Purely for display.)
     A : 2D array
-        2D array which, when matrix-multiplied by ``x``, gives the values of
-        the equality constraints at ``x``.
+        2D array such that ``A`` @ ``x``, gives the values of the equality
+        constraints at ``x``.
     b : 1D array
-        1D array of values representing the RHS of each equality constraint
-        (row) in ``A_eq``.
+        1D array of values representing the right hand side of each equality
+        constraint (row) in ``A``.
     callback : callable, optional (simplex only)
         If a callback function is provided, it will be called within each
         iteration of the simplex algorithm. The callback must require a

--- a/scipy/optimize/_linprog_simplex.py
+++ b/scipy/optimize/_linprog_simplex.py
@@ -425,7 +425,7 @@ def _linprog_simplex(c, c0, A, b, maxiter=1000, disp=False, callback=None,
         Constant term in objective function due to fixed (and eliminated)
         variables. (Purely for display.)
     A : 2D array
-        2D array such that ``A`` @ ``x``, gives the values of the equality
+        2D array such that ``A @ x``, gives the values of the equality
         constraints at ``x``.
     b : 1D array
         1D array of values representing the right hand side of each equality

--- a/scipy/optimize/_linprog_util.py
+++ b/scipy/optimize/_linprog_util.py
@@ -19,11 +19,11 @@ def _check_sparse_inputs(options, A_ub, A_eq):
     Parameters
     ----------
     A_ub : 2D array, optional
-        2D array which, when matrix-multiplied by ``x``, gives the values of
-        the upper-bound inequality constraints at ``x``.
-    A_eq : array_like, optional
-        2D array which, when matrix-multiplied by ``x``, gives the values of
-        the equality constraints at ``x``.
+        2D array such that ``A_ub`` @ ``x`` gives the values of the upper-bound
+        inequality constraints at ``x``.
+    A_eq : 2D array, optional
+        2D array such that ``A_eq`` @ ``x`` gives the values of the equality
+        constraints at ``x``.
     options : dict
         A dictionary of solver options. All methods accept the following
         generic options:
@@ -37,12 +37,12 @@ def _check_sparse_inputs(options, A_ub, A_eq):
 
     Returns
     -------
-    A_ub : 2D array
-        2D array which, when matrix-multiplied by ``x``, gives the values of
-        the upper-bound inequality constraints at ``x``.
-    A_eq : array_like
-        2D array which, when matrix-multiplied by ``x``, gives the values of
-        the equality constraints at ``x``.
+    A_ub : 2D array, optional
+        2D array such that ``A_ub`` @ ``x`` gives the values of the upper-bound
+        inequality constraints at ``x``.
+    A_eq : 2D array, optional
+        2D array such that ``A_eq`` @ ``x`` gives the values of the equality
+        constraints at ``x``.
     options : dict
         A dictionary of solver options. All methods accept the following
         generic options:
@@ -80,15 +80,15 @@ def _clean_inputs(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None, bounds=None):
     c : 1D array
         Coefficients of the linear objective function to be minimized.
     A_ub : 2D array, optional
-        2D array which, when matrix-multiplied by ``x``, gives the values of
-        the upper-bound inequality constraints at ``x``.
+        2D array such that ``A_ub`` @ ``x`` gives the values of the upper-bound
+        inequality constraints at ``x``.
     b_ub : 1D array, optional
         1D array of values representing the upper-bound of each inequality
         constraint (row) in ``A_ub``.
-    A_eq : array_like, optional
-        2D array which, when matrix-multiplied by ``x``, gives the values of
-        the equality constraints at ``x``.
-    b_eq : array_like, optional
+    A_eq : 2D array, optional
+        2D array such that ``A_eq`` @ ``x`` gives the values of the equality
+        constraints at ``x``.
+    b_eq : 1D array, optional
         1D array of values representing the RHS of each equality constraint
         (row) in ``A_eq``.
     bounds : sequence, optional
@@ -103,16 +103,16 @@ def _clean_inputs(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None, bounds=None):
     -------
     c : 1D array
         Coefficients of the linear objective function to be minimized.
-    A_ub : 2D array
-        2D array which, when matrix-multiplied by ``x``, gives the values of
-        the upper-bound inequality constraints at ``x``.
-    b_ub : 1D array
+    A_ub : 2D array, optional
+        2D array such that ``A_ub`` @ ``x`` gives the values of the upper-bound
+        inequality constraints at ``x``.
+    b_ub : 1D array, optional
         1D array of values representing the upper-bound of each inequality
         constraint (row) in ``A_ub``.
-    A_eq : 2D array
-        2D array which, when matrix-multiplied by ``x``, gives the values of
-        the equality constraints at ``x``.
-    b_eq : 1D array
+    A_eq : 2D array, optional
+        2D array such that ``A_eq`` @ ``x`` gives the values of the equality
+        constraints at ``x``.
+    b_eq : 1D array, optional
         1D array of values representing the RHS of each equality constraint
         (row) in ``A_eq``.
     bounds : sequence of tuples
@@ -348,16 +348,16 @@ def _presolve(c, A_ub, b_ub, A_eq, b_eq, bounds, rr, tol=1e-9):
     ----------
     c : 1D array
         Coefficients of the linear objective function to be minimized.
-    A_ub : 2D array
-        2D array which, when matrix-multiplied by ``x``, gives the values of
-        the upper-bound inequality constraints at ``x``.
-    b_ub : 1D array
+    A_ub : 2D array, optional
+        2D array such that ``A_ub`` @ ``x`` gives the values of the upper-bound
+        inequality constraints at ``x``.
+    b_ub : 1D array, optional
         1D array of values representing the upper-bound of each inequality
         constraint (row) in ``A_ub``.
-    A_eq : 2D array
-        2D array which, when matrix-multiplied by ``x``, gives the values of
-        the equality constraints at ``x``.
-    b_eq : 1D array
+    A_eq : 2D array, optional
+        2D array such that ``A_eq`` @ ``x`` gives the values of the equality
+        constraints at ``x``.
+    b_eq : 1D array, optional
         1D array of values representing the RHS of each equality constraint
         (row) in ``A_eq``.
     bounds : sequence of tuples
@@ -380,20 +380,18 @@ def _presolve(c, A_ub, b_ub, A_eq, b_eq, bounds, rr, tol=1e-9):
     c0 : 1D array
         Constant term in objective function due to fixed (and eliminated)
         variables.
-    A_ub : 2D array
-        2D array which, when matrix-multiplied by ``x``, gives the values of
-        the upper-bound inequality constraints at ``x``. Unnecessary
-        rows/columns have been removed.
-    b_ub : 1D array
+    A_ub : 2D array, optional
+        2D array such that ``A_ub`` @ ``x`` gives the values of the upper-bound
+        inequality constraints at ``x``.
+    b_ub : 1D array, optional
         1D array of values representing the upper-bound of each inequality
-        constraint (row) in ``A_ub``. Unnecessary elements have been removed.
-    A_eq : 2D array
-        2D array which, when matrix-multiplied by ``x``, gives the values of
-        the equality constraints at ``x``. Unnecessary rows/columns have been
-        removed.
-    b_eq : 1D array
+        constraint (row) in ``A_ub``.
+    A_eq : 2D array, optional
+        2D array such that ``A_eq`` @ ``x`` gives the values of the equality
+        constraints at ``x``.
+    b_eq : 1D array, optional
         1D array of values representing the RHS of each equality constraint
-        (row) in ``A_eq``. Unnecessary elements have been removed.
+        (row) in ``A_eq``.
     bounds : sequence of tuples
         ``(min, max)`` pairs for each element in ``x``, defining
         the bounds on that parameter. Use None for each of ``min`` or
@@ -740,16 +738,16 @@ def _parse_linprog(c, A_ub, b_ub, A_eq, b_eq, bounds, options):
     ----------
     c : 1D array
         Coefficients of the linear objective function to be minimized.
-    A_ub : 2D array
-        2D array which, when matrix-multiplied by ``x``, gives the values of
-        the upper-bound inequality constraints at ``x``.
-    b_ub : 1D array
+    A_ub : 2D array, optional
+        2D array such that ``A_ub`` @ ``x`` gives the values of the upper-bound
+        inequality constraints at ``x``.
+    b_ub : 1D array, optional
         1D array of values representing the upper-bound of each inequality
         constraint (row) in ``A_ub``.
-    A_eq : array_like
-        2D array which, when matrix-multiplied by ``x``, gives the values of
-        the equality constraints at ``x``.
-    b_eq : array_like
+    A_eq : 2D array, optional
+        2D array such that ``A_eq`` @ ``x`` gives the values of the equality
+        constraints at ``x``.
+    b_eq : 1D array, optional
         1D array of values representing the RHS of each equality constraint
         (row) in ``A_eq``.
     bounds : sequence
@@ -774,16 +772,16 @@ def _parse_linprog(c, A_ub, b_ub, A_eq, b_eq, bounds, options):
     -------
     c : 1D array
         Coefficients of the linear objective function to be minimized.
-    A_ub : 1D array, optional
-        2D array which, when matrix-multiplied by ``x``, gives the values of
-        the upper-bound inequality constraints at ``x``.
+    A_ub : 2D array, optional
+        2D array such that ``A_ub`` @ ``x`` gives the values of the upper-bound
+        inequality constraints at ``x``.
     b_ub : 1D array, optional
         1D array of values representing the upper-bound of each inequality
         constraint (row) in ``A_ub``.
-    A_eq : array_like, optional
-        2D array which, when matrix-multiplied by ``x``, gives the values of
-        the equality constraints at ``x``.
-    b_eq : array_like, optional
+    A_eq : 2D array, optional
+        2D array such that ``A_eq`` @ ``x`` gives the values of the equality
+        constraints at ``x``.
+    b_eq : 1D array, optional
         1D array of values representing the RHS of each equality constraint
         (row) in ``A_eq``.
     bounds : sequence, optional
@@ -854,20 +852,18 @@ def _get_Abc(c, c0=0, A_ub=None, b_ub=None, A_eq=None, b_eq=None, bounds=None,
     c0 : float
         Constant term in objective function due to fixed (and eliminated)
         variables.
-    A_ub : 2D array
-        2D array which, when matrix-multiplied by ``x``, gives the values of
-        the upper-bound inequality constraints at ``x``. Unnecessary
-        rows/columns have been removed.
-    b_ub : 1D array
+    A_ub : 2D array, optional
+        2D array such that ``A_ub`` @ ``x`` gives the values of the upper-bound
+        inequality constraints at ``x``.
+    b_ub : 1D array, optional
         1D array of values representing the upper-bound of each inequality
-        constraint (row) in ``A_ub``. Unnecessary elements have been removed.
-    A_eq : 2D array
-        2D array which, when matrix-multiplied by ``x``, gives the values of
-        the equality constraints at ``x``. Unnecessary rows/columns have been
-        removed.
-    b_eq : 1D array
+        constraint (row) in ``A_ub``.
+    A_eq : 2D array, optional
+        2D array such that ``A_eq`` @ ``x`` gives the values of the equality
+        constraints at ``x``.
+    b_eq : 1D array, optional
         1D array of values representing the RHS of each equality constraint
-        (row) in ``A_eq``. Unnecessary elements have been removed.
+        (row) in ``A_eq``.
     bounds : sequence of tuples
         ``(min, max)`` pairs for each element in ``x``, defining
         the bounds on that parameter. Use None for each of ``min`` or
@@ -880,8 +876,8 @@ def _get_Abc(c, c0=0, A_ub=None, b_ub=None, A_eq=None, b_eq=None, bounds=None,
     Returns
     -------
     A : 2D array
-        2D array which, when matrix-multiplied by x, gives the values of the
-        equality constraints at x (for standard form problem).
+        2D array such that ``A`` @ ``x``, gives the values of the equality
+        constraints at ``x``.
     b : 1D array
         1D array of values representing the RHS of each equality constraint
         (row) in A (for standard form problem).
@@ -1047,14 +1043,18 @@ def _postsolve(x, c, A_ub=None, b_ub=None, A_eq=None, b_eq=None, bounds=None,
         Solution vector to the standard-form problem.
     c : 1D array
         Original coefficients of the linear objective function to be minimized.
-    A_ub : 2D array
-        Original upper bound constraint matrix.
-    b_ub : 1D array
-        Original upper bound constraint vector.
-    A_eq : 2D array
-        Original equality constraint matrix.
-    b_eq : 1D array
-        Original equality constraint vector.
+    A_ub : 2D array, optional
+        2D array such that ``A_ub`` @ ``x`` gives the values of the upper-bound
+        inequality constraints at ``x``.
+    b_ub : 1D array, optional
+        1D array of values representing the upper-bound of each inequality
+        constraint (row) in ``A_ub``.
+    A_eq : 2D array, optional
+        2D array such that ``A_eq`` @ ``x`` gives the values of the equality
+        constraints at ``x``.
+    b_eq : 1D array, optional
+        1D array of values representing the RHS of each equality constraint
+        (row) in ``A_eq``.
     bounds : sequence of tuples
         Bounds, as modified in presolve
     complete : bool
@@ -1253,14 +1253,18 @@ def _postprocess(x, c, A_ub=None, b_ub=None, A_eq=None, b_eq=None, bounds=None,
         Solution vector to the standard-form problem.
     c : 1D array
         Original coefficients of the linear objective function to be minimized.
-    A_ub : 2D array
-        Original upper bound constraint matrix.
-    b_ub : 1D array
-        Original upper bound constraint vector.
-    A_eq : 2D array
-        Original equality constraint matrix.
-    b_eq : 1D array
-        Original equality constraint vector.
+    A_ub : 2D array, optional
+        2D array such that ``A_ub`` @ ``x`` gives the values of the upper-bound
+        inequality constraints at ``x``.
+    b_ub : 1D array, optional
+        1D array of values representing the upper-bound of each inequality
+        constraint (row) in ``A_ub``.
+    A_eq : 2D array, optional
+        2D array such that ``A_eq`` @ ``x`` gives the values of the equality
+        constraints at ``x``.
+    b_eq : 1D array, optional
+        1D array of values representing the RHS of each equality constraint
+        (row) in ``A_eq``.
     bounds : sequence of tuples
         Bounds, as modified in presolve
     complete : bool

--- a/scipy/optimize/_linprog_util.py
+++ b/scipy/optimize/_linprog_util.py
@@ -22,7 +22,7 @@ def _check_sparse_inputs(options, A_ub, A_eq):
         2D array such that ``A_ub @ x`` gives the values of the upper-bound
         inequality constraints at ``x``.
     A_eq : 2D array, optional
-        2D array such that ``A_eq`` @ ``x`` gives the values of the equality
+        2D array such that ``A_eq @ x`` gives the values of the equality
         constraints at ``x``.
     options : dict
         A dictionary of solver options. All methods accept the following
@@ -41,7 +41,7 @@ def _check_sparse_inputs(options, A_ub, A_eq):
         2D array such that ``A_ub @ x`` gives the values of the upper-bound
         inequality constraints at ``x``.
     A_eq : 2D array, optional
-        2D array such that ``A_eq`` @ ``x`` gives the values of the equality
+        2D array such that ``A_eq @ x`` gives the values of the equality
         constraints at ``x``.
     options : dict
         A dictionary of solver options. All methods accept the following
@@ -86,7 +86,7 @@ def _clean_inputs(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None, bounds=None):
         1D array of values representing the upper-bound of each inequality
         constraint (row) in ``A_ub``.
     A_eq : 2D array, optional
-        2D array such that ``A_eq`` @ ``x`` gives the values of the equality
+        2D array such that ``A_eq @ x`` gives the values of the equality
         constraints at ``x``.
     b_eq : 1D array, optional
         1D array of values representing the RHS of each equality constraint
@@ -110,7 +110,7 @@ def _clean_inputs(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None, bounds=None):
         1D array of values representing the upper-bound of each inequality
         constraint (row) in ``A_ub``.
     A_eq : 2D array, optional
-        2D array such that ``A_eq`` @ ``x`` gives the values of the equality
+        2D array such that ``A_eq @ x`` gives the values of the equality
         constraints at ``x``.
     b_eq : 1D array, optional
         1D array of values representing the RHS of each equality constraint
@@ -355,7 +355,7 @@ def _presolve(c, A_ub, b_ub, A_eq, b_eq, bounds, rr, tol=1e-9):
         1D array of values representing the upper-bound of each inequality
         constraint (row) in ``A_ub``.
     A_eq : 2D array, optional
-        2D array such that ``A_eq`` @ ``x`` gives the values of the equality
+        2D array such that ``A_eq @ x`` gives the values of the equality
         constraints at ``x``.
     b_eq : 1D array, optional
         1D array of values representing the RHS of each equality constraint
@@ -387,7 +387,7 @@ def _presolve(c, A_ub, b_ub, A_eq, b_eq, bounds, rr, tol=1e-9):
         1D array of values representing the upper-bound of each inequality
         constraint (row) in ``A_ub``.
     A_eq : 2D array, optional
-        2D array such that ``A_eq`` @ ``x`` gives the values of the equality
+        2D array such that ``A_eq @ x`` gives the values of the equality
         constraints at ``x``.
     b_eq : 1D array, optional
         1D array of values representing the RHS of each equality constraint
@@ -745,7 +745,7 @@ def _parse_linprog(c, A_ub, b_ub, A_eq, b_eq, bounds, options):
         1D array of values representing the upper-bound of each inequality
         constraint (row) in ``A_ub``.
     A_eq : 2D array, optional
-        2D array such that ``A_eq`` @ ``x`` gives the values of the equality
+        2D array such that ``A_eq @ x`` gives the values of the equality
         constraints at ``x``.
     b_eq : 1D array, optional
         1D array of values representing the RHS of each equality constraint
@@ -779,7 +779,7 @@ def _parse_linprog(c, A_ub, b_ub, A_eq, b_eq, bounds, options):
         1D array of values representing the upper-bound of each inequality
         constraint (row) in ``A_ub``.
     A_eq : 2D array, optional
-        2D array such that ``A_eq`` @ ``x`` gives the values of the equality
+        2D array such that ``A_eq @ x`` gives the values of the equality
         constraints at ``x``.
     b_eq : 1D array, optional
         1D array of values representing the RHS of each equality constraint
@@ -859,7 +859,7 @@ def _get_Abc(c, c0=0, A_ub=None, b_ub=None, A_eq=None, b_eq=None, bounds=None,
         1D array of values representing the upper-bound of each inequality
         constraint (row) in ``A_ub``.
     A_eq : 2D array, optional
-        2D array such that ``A_eq`` @ ``x`` gives the values of the equality
+        2D array such that ``A_eq @ x`` gives the values of the equality
         constraints at ``x``.
     b_eq : 1D array, optional
         1D array of values representing the RHS of each equality constraint
@@ -1050,7 +1050,7 @@ def _postsolve(x, c, A_ub=None, b_ub=None, A_eq=None, b_eq=None, bounds=None,
         1D array of values representing the upper-bound of each inequality
         constraint (row) in ``A_ub``.
     A_eq : 2D array, optional
-        2D array such that ``A_eq`` @ ``x`` gives the values of the equality
+        2D array such that ``A_eq @ x`` gives the values of the equality
         constraints at ``x``.
     b_eq : 1D array, optional
         1D array of values representing the RHS of each equality constraint
@@ -1260,7 +1260,7 @@ def _postprocess(x, c, A_ub=None, b_ub=None, A_eq=None, b_eq=None, bounds=None,
         1D array of values representing the upper-bound of each inequality
         constraint (row) in ``A_ub``.
     A_eq : 2D array, optional
-        2D array such that ``A_eq`` @ ``x`` gives the values of the equality
+        2D array such that ``A_eq @ x`` gives the values of the equality
         constraints at ``x``.
     b_eq : 1D array, optional
         1D array of values representing the RHS of each equality constraint

--- a/scipy/optimize/_linprog_util.py
+++ b/scipy/optimize/_linprog_util.py
@@ -19,7 +19,7 @@ def _check_sparse_inputs(options, A_ub, A_eq):
     Parameters
     ----------
     A_ub : 2D array, optional
-        2D array such that ``A_ub`` @ ``x`` gives the values of the upper-bound
+        2D array such that ``A_ub @ x`` gives the values of the upper-bound
         inequality constraints at ``x``.
     A_eq : 2D array, optional
         2D array such that ``A_eq`` @ ``x`` gives the values of the equality
@@ -38,7 +38,7 @@ def _check_sparse_inputs(options, A_ub, A_eq):
     Returns
     -------
     A_ub : 2D array, optional
-        2D array such that ``A_ub`` @ ``x`` gives the values of the upper-bound
+        2D array such that ``A_ub @ x`` gives the values of the upper-bound
         inequality constraints at ``x``.
     A_eq : 2D array, optional
         2D array such that ``A_eq`` @ ``x`` gives the values of the equality
@@ -80,7 +80,7 @@ def _clean_inputs(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None, bounds=None):
     c : 1D array
         Coefficients of the linear objective function to be minimized.
     A_ub : 2D array, optional
-        2D array such that ``A_ub`` @ ``x`` gives the values of the upper-bound
+        2D array such that ``A_ub @ x`` gives the values of the upper-bound
         inequality constraints at ``x``.
     b_ub : 1D array, optional
         1D array of values representing the upper-bound of each inequality
@@ -104,7 +104,7 @@ def _clean_inputs(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None, bounds=None):
     c : 1D array
         Coefficients of the linear objective function to be minimized.
     A_ub : 2D array, optional
-        2D array such that ``A_ub`` @ ``x`` gives the values of the upper-bound
+        2D array such that ``A_ub @ x`` gives the values of the upper-bound
         inequality constraints at ``x``.
     b_ub : 1D array, optional
         1D array of values representing the upper-bound of each inequality
@@ -349,7 +349,7 @@ def _presolve(c, A_ub, b_ub, A_eq, b_eq, bounds, rr, tol=1e-9):
     c : 1D array
         Coefficients of the linear objective function to be minimized.
     A_ub : 2D array, optional
-        2D array such that ``A_ub`` @ ``x`` gives the values of the upper-bound
+        2D array such that ``A_ub @ x`` gives the values of the upper-bound
         inequality constraints at ``x``.
     b_ub : 1D array, optional
         1D array of values representing the upper-bound of each inequality
@@ -381,7 +381,7 @@ def _presolve(c, A_ub, b_ub, A_eq, b_eq, bounds, rr, tol=1e-9):
         Constant term in objective function due to fixed (and eliminated)
         variables.
     A_ub : 2D array, optional
-        2D array such that ``A_ub`` @ ``x`` gives the values of the upper-bound
+        2D array such that ``A_ub @ x`` gives the values of the upper-bound
         inequality constraints at ``x``.
     b_ub : 1D array, optional
         1D array of values representing the upper-bound of each inequality
@@ -739,7 +739,7 @@ def _parse_linprog(c, A_ub, b_ub, A_eq, b_eq, bounds, options):
     c : 1D array
         Coefficients of the linear objective function to be minimized.
     A_ub : 2D array, optional
-        2D array such that ``A_ub`` @ ``x`` gives the values of the upper-bound
+        2D array such that ``A_ub @ x`` gives the values of the upper-bound
         inequality constraints at ``x``.
     b_ub : 1D array, optional
         1D array of values representing the upper-bound of each inequality
@@ -773,7 +773,7 @@ def _parse_linprog(c, A_ub, b_ub, A_eq, b_eq, bounds, options):
     c : 1D array
         Coefficients of the linear objective function to be minimized.
     A_ub : 2D array, optional
-        2D array such that ``A_ub`` @ ``x`` gives the values of the upper-bound
+        2D array such that ``A_ub @ x`` gives the values of the upper-bound
         inequality constraints at ``x``.
     b_ub : 1D array, optional
         1D array of values representing the upper-bound of each inequality
@@ -853,7 +853,7 @@ def _get_Abc(c, c0=0, A_ub=None, b_ub=None, A_eq=None, b_eq=None, bounds=None,
         Constant term in objective function due to fixed (and eliminated)
         variables.
     A_ub : 2D array, optional
-        2D array such that ``A_ub`` @ ``x`` gives the values of the upper-bound
+        2D array such that ``A_ub @ x`` gives the values of the upper-bound
         inequality constraints at ``x``.
     b_ub : 1D array, optional
         1D array of values representing the upper-bound of each inequality
@@ -1044,7 +1044,7 @@ def _postsolve(x, c, A_ub=None, b_ub=None, A_eq=None, b_eq=None, bounds=None,
     c : 1D array
         Original coefficients of the linear objective function to be minimized.
     A_ub : 2D array, optional
-        2D array such that ``A_ub`` @ ``x`` gives the values of the upper-bound
+        2D array such that ``A_ub @ x`` gives the values of the upper-bound
         inequality constraints at ``x``.
     b_ub : 1D array, optional
         1D array of values representing the upper-bound of each inequality
@@ -1254,7 +1254,7 @@ def _postprocess(x, c, A_ub=None, b_ub=None, A_eq=None, b_eq=None, bounds=None,
     c : 1D array
         Original coefficients of the linear objective function to be minimized.
     A_ub : 2D array, optional
-        2D array such that ``A_ub`` @ ``x`` gives the values of the upper-bound
+        2D array such that ``A_ub @ x`` gives the values of the upper-bound
         inequality constraints at ``x``.
     b_ub : 1D array, optional
         1D array of values representing the upper-bound of each inequality


### PR DESCRIPTION
closes #9323 

* Change datatype of ``A_ub`` from ``1D array`` to ``2D array``
* Change dataype of ``A_eq`` from ``array_like`` to ``2D array``
* Add full description of tableau ``T`` in simplex method
* Shorten descriptions of ``A_ub``, ``A_eq`` and ``A``