### PR TITLE
ENH+BUG: Add first_step functionality to all solve_ivp methods and fix lsoda first_step for backwards case (fixes #9366)

### DIFF
--- a/scipy/integrate/_ivp/bdf.py
+++ b/scipy/integrate/_ivp/bdf.py
@@ -100,6 +100,9 @@ class BDF(OdeSolver):
     t_bound : float
         Boundary time - the integration won't continue beyond it. It also
         determines the direction of the integration.
+    first_step : float or None, optional
+        Initial step size. Default is ``None`` which means that the algorithm
+        should choose.
     max_step : float, optional
         Maximum allowed step size. Default is np.inf, i.e. the step size is not
         bounded and determined solely by the solver.

--- a/scipy/integrate/_ivp/bdf.py
+++ b/scipy/integrate/_ivp/bdf.py
@@ -100,6 +100,10 @@ class BDF(OdeSolver):
     t_bound : float
         Boundary time - the integration won't continue beyond it. It also
         determines the direction of the integration.
+    first_step : float or None, optional
+        Initial step size. Default is ``None`` which means that the algorith
+m
+        should choose.
     max_step : float, optional
         Maximum allowed step size. Default is np.inf, i.e. the step size is not
         bounded and determined solely by the solver.

--- a/scipy/integrate/_ivp/bdf.py
+++ b/scipy/integrate/_ivp/bdf.py
@@ -5,7 +5,8 @@ from scipy.sparse import issparse, csc_matrix, eye
 from scipy.sparse.linalg import splu
 from scipy.optimize._numdiff import group_columns
 from .common import (validate_max_step, validate_tol, select_initial_step,
-                     norm, EPS, num_jac, warn_extraneous)
+                     norm, EPS, num_jac, validate_first_step,
+                     warn_extraneous)
 from .base import OdeSolver, DenseOutput
 
 
@@ -180,16 +181,19 @@ class BDF(OdeSolver):
     """
     def __init__(self, fun, t0, y0, t_bound, max_step=np.inf,
                  rtol=1e-3, atol=1e-6, jac=None, jac_sparsity=None,
-                 vectorized=False, **extraneous):
+                 vectorized=False, first_step=None, **extraneous):
         warn_extraneous(extraneous)
         super(BDF, self).__init__(fun, t0, y0, t_bound, vectorized,
                                   support_complex=True)
         self.max_step = validate_max_step(max_step)
         self.rtol, self.atol = validate_tol(rtol, atol, self.n)
         f = self.fun(self.t, self.y)
-        self.h_abs = select_initial_step(self.fun, self.t, self.y, f,
-                                         self.direction, 1,
-                                         self.rtol, self.atol)
+        if first_step is None:
+            self.h_abs = select_initial_step(self.fun, self.t, self.y, f,
+                                             self.direction, 1,
+                                             self.rtol, self.atol)
+        else:
+            self.h_abs = validate_first_step(first_step)
         self.h_abs_old = None
         self.error_norm_old = None
 

--- a/scipy/integrate/_ivp/bdf.py
+++ b/scipy/integrate/_ivp/bdf.py
@@ -196,7 +196,7 @@ class BDF(OdeSolver):
                                              self.direction, 1,
                                              self.rtol, self.atol)
         else:
-            self.h_abs = validate_first_step(first_step)
+            self.h_abs = validate_first_step(first_step, t_bound, t0)
         self.h_abs_old = None
         self.error_norm_old = None
 

--- a/scipy/integrate/_ivp/bdf.py
+++ b/scipy/integrate/_ivp/bdf.py
@@ -100,10 +100,6 @@ class BDF(OdeSolver):
     t_bound : float
         Boundary time - the integration won't continue beyond it. It also
         determines the direction of the integration.
-    first_step : float or None, optional
-        Initial step size. Default is ``None`` which means that the algorith
-m
-        should choose.
     max_step : float, optional
         Maximum allowed step size. Default is np.inf, i.e. the step size is not
         bounded and determined solely by the solver.

--- a/scipy/integrate/_ivp/bdf.py
+++ b/scipy/integrate/_ivp/bdf.py
@@ -196,7 +196,7 @@ class BDF(OdeSolver):
                                              self.direction, 1,
                                              self.rtol, self.atol)
         else:
-            self.h_abs = validate_first_step(first_step, t_bound, t0)
+            self.h_abs = validate_first_step(first_step, t0, t_bound)
         self.h_abs_old = None
         self.error_norm_old = None
 

--- a/scipy/integrate/_ivp/common.py
+++ b/scipy/integrate/_ivp/common.py
@@ -8,10 +8,12 @@ from scipy.sparse import find, coo_matrix
 EPS = np.finfo(float).eps
 
 
-def validate_first_step(first_step):
+def validate_first_step(first_step, t_bound, t0):
     """Assert that first_step is valid and return it."""
     if first_step <= 0:
         raise ValueError("`first_step` must be positive.")
+    if first_step > np.abs(t_bound - t0):
+        raise ValueError("`first_step` too large.")
     return first_step
 
 

--- a/scipy/integrate/_ivp/common.py
+++ b/scipy/integrate/_ivp/common.py
@@ -8,6 +8,13 @@ from scipy.sparse import find, coo_matrix
 EPS = np.finfo(float).eps
 
 
+def validate_first_step(first_step):
+    """Assert that first_step is valid and return it."""
+    if first_step <= 0:
+        raise ValueError("`first_step` must be positive.")
+    return first_step
+
+
 def validate_max_step(max_step):
     """Assert that max_Step is valid and return it."""
     if max_step <= 0:

--- a/scipy/integrate/_ivp/common.py
+++ b/scipy/integrate/_ivp/common.py
@@ -13,7 +13,7 @@ def validate_first_step(first_step, t0, t_bound):
     if first_step <= 0:
         raise ValueError("`first_step` must be positive.")
     if first_step > np.abs(t_bound - t0):
-        raise ValueError("`first_step` too large.")
+        raise ValueError("`first_step` exceeds bounds.")
     return first_step
 
 

--- a/scipy/integrate/_ivp/common.py
+++ b/scipy/integrate/_ivp/common.py
@@ -8,7 +8,7 @@ from scipy.sparse import find, coo_matrix
 EPS = np.finfo(float).eps
 
 
-def validate_first_step(first_step, t_bound, t0):
+def validate_first_step(first_step, t0, t_bound):
     """Assert that first_step is valid and return it."""
     if first_step <= 0:
         raise ValueError("`first_step` must be positive.")

--- a/scipy/integrate/_ivp/ivp.py
+++ b/scipy/integrate/_ivp/ivp.py
@@ -217,7 +217,7 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
               in [6]_. A quasi-constant step scheme is used and accuracy is
               enhanced using the NDF modification. Can be applied in the complex
               domain.
-            * 'LSODA': Adams/BDF method with automatic stiffness detection and
+            * 'LSODA': Adams/BDF method with automatic stiffness detection a👌nd
               switching [7]_, [8]_. This is a wrapper of the Fortran solver
               from ODEPACK.
 
@@ -257,7 +257,11 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
     options
         Options passed to a chosen solver. All options available for already
         implemented solvers are listed below.
-    max_step : float, optional
+    first_step : float or None, optional
+        Initial step size. Default is ``None`` which means that the algorith
+m
+        should choose.
+    👌max_step : float, optional
         Maximum allowed step size. Default is np.inf, i.e. the step size is not
         bounded and determined solely by the solver.
     rtol, atol : float and array_like, optional
@@ -306,10 +310,9 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
         in `scipy.linalg.solve_banded` (check for an illustration).
         These parameters can be also used with ``jac=None`` to reduce the
         number of Jacobian elements estimated by finite differences.
-    min_step, first_step : float, optional
-        The minimum allowed step size and the initial step size respectively
-        for 'LSODA' method. By default `min_step` is zero and `first_step` is
-        selected automatically.
+    min_step : float, optional
+        The minimum allowed step size for 'LSODA' method. 
+        By default `min_step` is zero.
 
     Returns
     -------

--- a/scipy/integrate/_ivp/ivp.py
+++ b/scipy/integrate/_ivp/ivp.py
@@ -309,10 +309,9 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
         in `scipy.linalg.solve_banded` (check for an illustration).
         These parameters can be also used with ``jac=None`` to reduce the
         number of Jacobian elements estimated by finite differences.
-    min_step, first_step : float, optional
-        The minimum allowed step size and the initial step size respectively
-        for 'LSODA' method. By default `min_step` is zero and `first_step` is
-        selected automatically.
+    min_step : float, optional
+        The minimum allowed step size for 'LSODA' method. 
+        By default `min_step` is zero.
 
     Returns
     -------

--- a/scipy/integrate/_ivp/ivp.py
+++ b/scipy/integrate/_ivp/ivp.py
@@ -217,7 +217,7 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
               in [6]_. A quasi-constant step scheme is used and accuracy is
               enhanced using the NDF modification. Can be applied in the complex
               domain.
-            * 'LSODA': Adams/BDF method with automatic stiffness detection a👌nd
+            * 'LSODA': Adams/BDF method with automatic stiffness detection and
               switching [7]_, [8]_. This is a wrapper of the Fortran solver
               from ODEPACK.
 
@@ -257,11 +257,7 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
     options
         Options passed to a chosen solver. All options available for already
         implemented solvers are listed below.
-    first_step : float or None, optional
-        Initial step size. Default is ``None`` which means that the algorith
-m
-        should choose.
-    👌max_step : float, optional
+    max_step : float, optional
         Maximum allowed step size. Default is np.inf, i.e. the step size is not
         bounded and determined solely by the solver.
     rtol, atol : float and array_like, optional
@@ -310,9 +306,10 @@ m
         in `scipy.linalg.solve_banded` (check for an illustration).
         These parameters can be also used with ``jac=None`` to reduce the
         number of Jacobian elements estimated by finite differences.
-    min_step : float, optional
-        The minimum allowed step size for 'LSODA' method. 
-        By default `min_step` is zero.
+    min_step, first_step : float, optional
+        The minimum allowed step size and the initial step size respectively
+        for 'LSODA' method. By default `min_step` is zero and `first_step` is
+        selected automatically.
 
     Returns
     -------

--- a/scipy/integrate/_ivp/ivp.py
+++ b/scipy/integrate/_ivp/ivp.py
@@ -257,6 +257,9 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
     options
         Options passed to a chosen solver. All options available for already
         implemented solvers are listed below.
+    first_step : float or None, optional
+        Initial step size. Default is ``None`` which means that the algorithm
+        should choose.
     max_step : float, optional
         Maximum allowed step size. Default is np.inf, i.e. the step size is not
         bounded and determined solely by the solver.

--- a/scipy/integrate/_ivp/lsoda.py
+++ b/scipy/integrate/_ivp/lsoda.py
@@ -110,8 +110,8 @@ class LSODA(OdeSolver):
 
         if first_step is None:
             first_step = 0  # LSODA value for automatic selection.
-        elif first_step <= 0:
-            raise ValueError("`first_step` must be positive or None.")
+        else:
+            first_step = validate_first_step(first_step, t_bound, t0)
 
         if t_bound - t0 < 0 and first_step is not None:
             first_step *= -1

--- a/scipy/integrate/_ivp/lsoda.py
+++ b/scipy/integrate/_ivp/lsoda.py
@@ -113,8 +113,7 @@ class LSODA(OdeSolver):
         else:
             first_step = validate_first_step(first_step, t0, t_bound)
 
-        if t_bound - t0 < 0 and first_step is not None:
-            first_step *= -1
+        first_step *= self.direction
 
         if max_step == np.inf:
             max_step = 0  # LSODA value for infinity.

--- a/scipy/integrate/_ivp/lsoda.py
+++ b/scipy/integrate/_ivp/lsoda.py
@@ -113,6 +113,9 @@ class LSODA(OdeSolver):
         elif first_step <= 0:
             raise ValueError("`first_step` must be positive or None.")
 
+        if t_bound - t0 < 0 and first_step is not None:
+            first_step *= -1
+
         if max_step == np.inf:
             max_step = 0  # LSODA value for infinity.
         elif max_step <= 0:

--- a/scipy/integrate/_ivp/lsoda.py
+++ b/scipy/integrate/_ivp/lsoda.py
@@ -111,7 +111,7 @@ class LSODA(OdeSolver):
         if first_step is None:
             first_step = 0  # LSODA value for automatic selection.
         else:
-            first_step = validate_first_step(first_step, t_bound, t0)
+            first_step = validate_first_step(first_step, t0, t_bound)
 
         if t_bound - t0 < 0 and first_step is not None:
             first_step *= -1

--- a/scipy/integrate/_ivp/lsoda.py
+++ b/scipy/integrate/_ivp/lsoda.py
@@ -1,6 +1,6 @@
 import numpy as np
 from scipy.integrate import ode
-from .common import validate_tol, warn_extraneous
+from .common import validate_tol, validate_first_step, warn_extraneous
 from .base import OdeSolver, DenseOutput
 
 

--- a/scipy/integrate/_ivp/radau.py
+++ b/scipy/integrate/_ivp/radau.py
@@ -204,6 +204,9 @@ class Radau(OdeSolver):
     t_bound : float
         Boundary time - the integration won't continue beyond it. It also
         determines the direction of the integration.
+    first_step : float or None, optional
+        Initial step size. Default is ``None`` which means that the algorithm
+        should choose.
     max_step : float, optional
         Maximum allowed step size. Default is np.inf, i.e. the step size is not
         bounded and determined solely by the solver.

--- a/scipy/integrate/_ivp/radau.py
+++ b/scipy/integrate/_ivp/radau.py
@@ -297,7 +297,7 @@ class Radau(OdeSolver):
                 self.fun, self.t, self.y, self.f, self.direction,
                 3, self.rtol, self.atol)
         else:
-            self.h_abs = validate_first_step(first_step, t_bound, t0)
+            self.h_abs = validate_first_step(first_step, t0, t_bound)
         self.h_abs_old = None
         self.error_norm_old = None
 

--- a/scipy/integrate/_ivp/radau.py
+++ b/scipy/integrate/_ivp/radau.py
@@ -297,7 +297,7 @@ class Radau(OdeSolver):
                 self.fun, self.t, self.y, self.f, self.direction,
                 3, self.rtol, self.atol)
         else:
-            self.h_abs = validate_first_step(first_step)
+            self.h_abs = validate_first_step(first_step, t_bound, t0)
         self.h_abs_old = None
         self.error_norm_old = None
 

--- a/scipy/integrate/_ivp/radau.py
+++ b/scipy/integrate/_ivp/radau.py
@@ -204,10 +204,6 @@ class Radau(OdeSolver):
     t_bound : float
         Boundary time - the integration won't continue beyond it. It also
         determines the direction of the integration.
-    first_step : float or None, optional
-        Initial step size. Default is ``None`` which means that the algorith
-m
-        should choose.
     max_step : float, optional
         Maximum allowed step size. Default is np.inf, i.e. the step size is not
         bounded and determined solely by the solver.

--- a/scipy/integrate/_ivp/radau.py
+++ b/scipy/integrate/_ivp/radau.py
@@ -204,6 +204,10 @@ class Radau(OdeSolver):
     t_bound : float
         Boundary time - the integration won't continue beyond it. It also
         determines the direction of the integration.
+    first_step : float or None, optional
+        Initial step size. Default is ``None`` which means that the algorith
+m
+        should choose.
     max_step : float, optional
         Maximum allowed step size. Default is np.inf, i.e. the step size is not
         bounded and determined solely by the solver.

--- a/scipy/integrate/_ivp/rk.py
+++ b/scipy/integrate/_ivp/rk.py
@@ -103,7 +103,7 @@ class RungeKutta(OdeSolver):
                 self.fun, self.t, self.y, self.f, self.direction,
                 self.order, self.rtol, self.atol)
         else:
-            self.h_abs = validate_first_step(first_step, t_bound, t0)
+            self.h_abs = validate_first_step(first_step, t0, t_bound)
         self.K = np.empty((self.n_stages + 1, self.n), dtype=self.y.dtype)
 
     def _step_impl(self):

--- a/scipy/integrate/_ivp/rk.py
+++ b/scipy/integrate/_ivp/rk.py
@@ -197,6 +197,10 @@ class RK23(RungeKutta):
     t_bound : float
         Boundary time - the integration won't continue beyond it. It also
         determines the direction of the integration.
+    first_step : float or None, optional
+        Initial step size. Default is ``None`` which means that the algorith
+m
+        should choose.
     max_step : float, optional
         Maximum allowed step size. Default is np.inf, i.e. the step size is not
         bounded and determined solely by the solver.
@@ -283,6 +287,10 @@ class RK45(RungeKutta):
     t_bound : float
         Boundary time - the integration won't continue beyond it. It also
         determines the direction of the integration.
+    first_step : float or None, optional
+        Initial step size. Default is ``None`` which means that the algorith
+m
+        should choose.
     max_step : float, optional
         Maximum allowed step size. Default is np.inf, i.e. the step size is not
         bounded and determined solely by the solver.

--- a/scipy/integrate/_ivp/rk.py
+++ b/scipy/integrate/_ivp/rk.py
@@ -197,10 +197,6 @@ class RK23(RungeKutta):
     t_bound : float
         Boundary time - the integration won't continue beyond it. It also
         determines the direction of the integration.
-    first_step : float or None, optional
-        Initial step size. Default is ``None`` which means that the algorith
-m
-        should choose.
     max_step : float, optional
         Maximum allowed step size. Default is np.inf, i.e. the step size is not
         bounded and determined solely by the solver.
@@ -287,10 +283,6 @@ class RK45(RungeKutta):
     t_bound : float
         Boundary time - the integration won't continue beyond it. It also
         determines the direction of the integration.
-    first_step : float or None, optional
-        Initial step size. Default is ``None`` which means that the algorith
-m
-        should choose.
     max_step : float, optional
         Maximum allowed step size. Default is np.inf, i.e. the step size is not
         bounded and determined solely by the solver.

--- a/scipy/integrate/_ivp/rk.py
+++ b/scipy/integrate/_ivp/rk.py
@@ -103,7 +103,7 @@ class RungeKutta(OdeSolver):
                 self.fun, self.t, self.y, self.f, self.direction,
                 self.order, self.rtol, self.atol)
         else:
-            self.h_abs = validate_first_step(first_step)
+            self.h_abs = validate_first_step(first_step, t_bound, t0)
         self.K = np.empty((self.n_stages + 1, self.n), dtype=self.y.dtype)
 
     def _step_impl(self):

--- a/scipy/integrate/_ivp/rk.py
+++ b/scipy/integrate/_ivp/rk.py
@@ -197,6 +197,9 @@ class RK23(RungeKutta):
     t_bound : float
         Boundary time - the integration won't continue beyond it. It also
         determines the direction of the integration.
+    first_step : float or None, optional
+        Initial step size. Default is ``None`` which means that the algorithm
+        should choose.
     max_step : float, optional
         Maximum allowed step size. Default is np.inf, i.e. the step size is not
         bounded and determined solely by the solver.
@@ -283,6 +286,9 @@ class RK45(RungeKutta):
     t_bound : float
         Boundary time - the integration won't continue beyond it. It also
         determines the direction of the integration.
+    first_step : float or None, optional
+        Initial step size. Default is ``None`` which means that the algorithm
+        should choose.
     max_step : float, optional
         Maximum allowed step size. Default is np.inf, i.e. the step size is not
         bounded and determined solely by the solver.

--- a/scipy/integrate/tests/test_ivp.py
+++ b/scipy/integrate/tests/test_ivp.py
@@ -491,7 +491,9 @@ def test_first_step():
 
             assert_raises(ValueError, method, fun_rational, t_span[0], y0,
                           t_span[1], first_step=-1)
-                
+            assert_raises(ValueError, method, fun_rational, t_span[0], y0,
+                          t_span[1], first_step=5)
+    
 
 def test_t_eval():
     rtol = 1e-3

--- a/scipy/integrate/tests/test_ivp.py
+++ b/scipy/integrate/tests/test_ivp.py
@@ -456,6 +456,45 @@ def test_max_step():
                 assert_raises(RuntimeError, solver.step)
 
 
+def test_first_step():
+    rtol = 1e-3
+    atol = 1e-6
+    y0 = [1/3, 2/9]
+    first_step = 0.1
+    for method in [RK23, RK45, Radau, BDF, LSODA]:
+        for t_span in ([5, 9], [5, 1]):
+            res = solve_ivp(fun_rational, t_span, y0, rtol=rtol,
+                            max_step=0.5, atol=atol, method=method,
+                            dense_output=True, first_step=first_step)
+
+            print(method, res)
+            assert_equal(res.t[0], t_span[0])
+            assert_equal(res.t[-1], t_span[-1])
+            assert_allclose(first_step, np.abs(res.t[1] - 5))
+            assert_(res.t_events is None)
+            assert_(res.success)
+            assert_equal(res.status, 0)
+
+            y_true = sol_rational(res.t)
+            e = compute_error(res.y, y_true, rtol, atol)
+            assert_(np.all(e < 5))
+
+            tc = np.linspace(*t_span)
+            yc_true = sol_rational(tc)
+            yc = res.sol(tc)
+
+            e = compute_error(yc, yc_true, rtol, atol)
+            assert_(np.all(e < 5))
+
+            # See comment in test_integration.
+            if method is not LSODA:
+                assert_allclose(res.sol(res.t), res.y, rtol=1e-15, atol=1e-15)
+
+            assert_raises(ValueError, method, fun_rational, t_span[0], y0,
+                          t_span[1], first_step=-1)
+
+                
+
 def test_t_eval():
     rtol = 1e-3
     atol = 1e-6

--- a/scipy/integrate/tests/test_ivp.py
+++ b/scipy/integrate/tests/test_ivp.py
@@ -467,7 +467,6 @@ def test_first_step():
                             max_step=0.5, atol=atol, method=method,
                             dense_output=True, first_step=first_step)
 
-            print(method, res)
             assert_equal(res.t[0], t_span[0])
             assert_equal(res.t[-1], t_span[-1])
             assert_allclose(first_step, np.abs(res.t[1] - 5))
@@ -492,7 +491,6 @@ def test_first_step():
 
             assert_raises(ValueError, method, fun_rational, t_span[0], y0,
                           t_span[1], first_step=-1)
-
                 
 
 def test_t_eval():


### PR DESCRIPTION
This adds functionality to be able to specify first_step to any currently implemented solve_ivp solver.   

This fixes #9366, which was uncovered in developing this functionality. If it is preferred to fix this independently, the changes to lsoda.py file are the only additions needed.  The test would have to be rewritten only slightly to just use LSODA method in this case

This also partially addresses #9198 as well.  
