### PR TITLE
Fix exception if python is called with -OO option

### DIFF
--- a/scipy/misc/doccer.py
+++ b/scipy/misc/doccer.py
@@ -134,6 +134,10 @@ def extend_notes_in_docstring(cls, notes):
     """
     def _doc(func):
         cls_docstring = getattr(cls, func.__name__).__doc__
+        # If python is called with -OO option,
+        # there is no docstring
+        if cls_docstring is None:
+            return func
         end_of_notes = cls_docstring.find('        References\n')
         if end_of_notes == -1:
             end_of_notes = cls_docstring.find('        Examples\n')
@@ -155,7 +159,10 @@ def replace_notes_in_docstring(cls, notes):
     def _doc(func):
         cls_docstring = getattr(cls, func.__name__).__doc__
         notes_header = '        Notes\n        -----\n'
-        # XXX The following assumes that there is a Notes section.
+        # If python is called with -OO option,
+        # there is no docstring
+        if cls_docstring is None:
+            return func
         start_of_notes = cls_docstring.find(notes_header)
         end_of_notes = cls_docstring.find('        References\n')
         if end_of_notes == -1:


### PR DESCRIPTION
Minimal way to reproduce:
```python -OO -c 'from scipy.signal import fftconvolve'```

Traceback:

```
../../../venv/lib/python3.7/site-packages/scipy/signal/__init__.py:329: in <module>
    from ._peak_finding import *
../../../venv/lib/python3.7/site-packages/scipy/signal/_peak_finding.py:11: in <module>
    from scipy.stats import scoreatpercentile
../../../venv/lib/python3.7/site-packages/scipy/stats/__init__.py:345: in <module>
    from .stats import *
../../../venv/lib/python3.7/site-packages/scipy/stats/stats.py:171: in <module>
    from . import distributions
../../../venv/lib/python3.7/site-packages/scipy/stats/distributions.py:13: in <module>
    from . import _continuous_distns
../../../venv/lib/python3.7/site-packages/scipy/stats/_continuous_distns.py:113: in <module>
    class norm_gen(rv_continuous):
../../../venv/lib/python3.7/site-packages/scipy/stats/_continuous_distns.py:175: in norm_gen
    `optimizer` argument is ignored.\n\n""")
../../../venv/lib/python3.7/site-packages/scipy/misc/doccer.py:159: in _doc
    start_of_notes = cls_docstring.find(notes_header)
E   AttributeError: 'NoneType' object has no attribute 'find'

```

Long story short, we encountered the bug in [scikit-image](https://github.com/scikit-image/scikit-image/pull/3470). 
xref from scipy #7914 

The patch fixes it, but I'm not sure whether it is well done. Eventually, -OO build could be added to your travis array.