### PR TITLE
FIX: AIX compilation issue with NAN and INFINITY

### DIFF
--- a/scipy/special/cephes/dd_real.h
+++ b/scipy/special/cephes/dd_real.h
@@ -105,7 +105,7 @@ extern const double2 DD_C_LOG10;
 extern const double2 DD_C_ZERO;
 extern const double2 DD_C_ONE;
 
-#if defined(__STDC__) && defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) && defined(NAN)
+#if defined(__STDC__) && defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) && defined(NAN) && !defined(_AIX)
 #define DD_C_NAN_IS_CONST
 extern const double2 DD_C_NAN;
 extern const double2 DD_C_INF;

--- a/scipy/special/cephes/dd_real.h
+++ b/scipy/special/cephes/dd_real.h
@@ -105,6 +105,7 @@ extern const double2 DD_C_LOG10;
 extern const double2 DD_C_ZERO;
 extern const double2 DD_C_ONE;
 
+/* NAN definition in AIX's math.h doesn't make it qualify as constant literal. */
 #if defined(__STDC__) && defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) && defined(NAN) && !defined(_AIX)
 #define DD_C_NAN_IS_CONST
 extern const double2 DD_C_NAN;


### PR DESCRIPTION
The definition of NAN and INFINITY in AIX doesn't make it qualify as constant literals.
After the preprocessing step, the definitions are

NAN ---> (*((float )(&_SQNAN)))
INFINITY ----> (((float *)(&_SINFINITY)))

Because of this, the compilation fails
scipy/special/cephes/dd_real.c:70:40: error: initializer element is not constant
     const double2 DD_C_NAN = _DD_REAL_INIT(NAN, NAN);
                                                                             ^
    scipy/special/cephes/dd_real.c:33:32: note: in definition of macro '_DD_REAL_INIT'
     #define _DD_REAL_INIT(A, B)  {{A, B}}
                                                       ^
scipy/special/cephes/dd_real.c:71:40: error: initializer element is not constant
     const double2 DD_C_INF = _DD_REAL_INIT(INFINITY, INFINITY);
                                                                           ^
    scipy/special/cephes/dd_real.c:33:32: note: in definition of macro '_DD_REAL_INIT'
     #define _DD_REAL_INIT(A, B)  {{A, B}}
                                                       ^
