### PR TITLE
MAINT: TST: Make tests NumPy 1.8 compatible

### DIFF
--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -9,7 +9,7 @@ from scipy.optimize import rosen
 from numpy.testing import (assert_equal, assert_allclose,
                            assert_almost_equal,
                            assert_string_equal, assert_)
-from pytest import raises as assert_raises
+from pytest import raises as assert_raises, warns
 
 
 class TestDifferentialEvolutionSolver(object):
@@ -520,7 +520,7 @@ class TestDifferentialEvolutionSolver(object):
 
         # should raise a UserWarning because the updating='immediate'
         # is being overriden by the workers keyword
-        with np.testing.assert_warns(UserWarning):
+        with warns(UserWarning):
             solver = DifferentialEvolutionSolver(rosen, bounds, workers=2)
             assert_(solver._updating == 'deferred')
 

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -520,7 +520,7 @@ class TestDifferentialEvolutionSolver(object):
 
         # should raise a UserWarning because the updating='immediate'
         # is being overriden by the workers keyword
-        with np.testing.assert_warns(UserWarning):
+        with pytest.warns(UserWarning):
             solver = DifferentialEvolutionSolver(rosen, bounds, workers=2)
             assert_(solver._updating == 'deferred')
 

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -708,9 +708,9 @@ class TestFFTConvolve(object):
         b = b[:, :, None, None, None]
         expected = expected[:, :, None, None, None]
 
-        a = np.moveaxis(a, [0, 1], [1, 4])
-        b = np.moveaxis(b, [0, 1], [1, 4])
-        expected = np.moveaxis(expected, [0, 1], [1, 4])
+        a = np.rollaxis(a.swapaxes(0, 2), 1, 5)
+        b = np.rollaxis(b.swapaxes(0, 2), 1, 5)
+        expected = np.rollaxis(expected.swapaxes(0, 2), 1, 5)
 
         # use 1 for dimension 2 in a and 3 in b to test broadcasting
         a = np.tile(a, [2, 1, 3, 1, 1])


### PR DESCRIPTION
In #9190 and #8259 , the tests involve the usage of `np.moveaxis` and `np.testing.assert_warns` which are introduced in NumPy 1.11 but we still support 1.8. 

And for some reason it has not failed in the original PRs but started to fail recently. I have converted to 1.8.2 compatible syntax without changing the logic.