### PR TITLE
CI: On Travis matrix "OPTIMIZE=-OO" flag ignored

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ matrix:
         - COVERAGE=
         - NUMPYSPEC="numpy==1.8.2"
         - USE_SDIST=1
-        - OPTIMIZE=-OO
+        - OPTIMIZE="-OO"
     - python: 3.4
       env:
         - TESTMODE=fast


### PR DESCRIPTION
In order to address #9373, we need a working (in this case failing) build however Travis doesn't seem to enable the `-OO` flag. This PR is for testing different options in the yaml file.