### PR TITLE
MAINT: (WIP) Review and strengthen tests for linprog(method='simplex')

### DIFF
--- a/scipy/optimize/_linprog_util.py
+++ b/scipy/optimize/_linprog_util.py
@@ -1231,8 +1231,8 @@ def _check_result(x, fun, status, slack, con, lb, ub, tol, message):
     elif status == 2 and is_feasible:
         # Occurs if the simplex method exits after phase one with a very
         # nearly basic feasible solution. Postsolving can make the solution
-        #basic, however, this solution is NOT optimal
-        raise ValueError(message)
+        # basic, however, this solution is NOT optimal
+        status = 4
 
     return status, message
 


### PR DESCRIPTION
closes #9268

This PR reviews the tests of recent bug fixes in ``linprog(method='simplex')``. 

Further the PR alters the error checking such that the ``status=4`` (numerical difficulties encountered) instead of raising a `ValueError` when ``status == 2 and is_feasible``. The choice of status is ambiguous and I'd like someone with a little more experience to consider how to handle it (@mdhaber @ilayn @rgommers)

Phase one of the simplex method fails to find the basic feasible solution if the pseudo-objective function is very slightly greater than `tol`, this isn't really a bug but an issue with the default tolerance (see: #8958). During the conversion back to the original problem via ``_post_solve(...)`` the problem may become feasible again. The resultant solution is sometimes, but not necessarily, optimal.

My rational  for choosing ``status=4`` is to be conservative when claiming a successful result. For all cases where this occurs a ``OptimizeWarning`` is raised in ``_apply_pivot(...)`` (see: #9081). Maybe returning a status of 0 (Optimization terminated successfully), with a warning of possible numerical errors is more relevant?

An example of this ``TestLinprogSimplexNoPresolve.test_issue_6139`` The pseudo objective function evaluates to ``5.1e-10`` with the tolerance of ``1e-12`` and is therefore not considered close enough to zero to find a basic feasible solution. This is explained in the exit message: 

https://github.com/scipy/scipy/blob/1ec1c8ab24d57a5c46adf68b8f6cdae2faa975da/scipy/optimize/_linprog_simplex.py#L595-L603

The other failing test  is ``TestLinprogSimplexBland.test_issue_8174``. The test returns a status of 0 and ``success=True``, with the wrong result. A basic feasible solution is correctly found at the end of phase one, however in phase two division by a small pivot value leads to the simplex method "exploding".  The pivot value is small enough that a warning is issued:

https://github.com/scipy/scipy/blob/1ec1c8ab24d57a5c46adf68b8f6cdae2faa975da/scipy/optimize/_linprog_simplex.py#L194-L201

I'm also not quite sure how this should be handled; the test returns the wrong result while claiming it is correct, however a warning is issued notifying the user the solution may be wrong.