### PR TITLE
BUG: rank has to be integer in rank_filter: fixed issue 9388

### DIFF
--- a/scipy/ndimage/filters.py
+++ b/scipy/ndimage/filters.py
@@ -32,6 +32,7 @@ from __future__ import division, print_function, absolute_import
 import warnings
 import numbers
 import numpy
+import operator
 from . import _ni_support
 from . import _nd_image
 from . import _ni_docstrings
@@ -1187,8 +1188,7 @@ def rank_filter(input, rank, size=None, footprint=None, output=None,
     >>> ax2.imshow(result)
     >>> plt.show()
     """
-    if not isinstance(rank, numbers.Integral):
-        raise ValueError('Input rank needs to be integer')
+    rank = operator.index(rank)
     return _rank_filter(input, rank, size, footprint, output, mode, cval,
                         origin, 'rank')
 

--- a/scipy/ndimage/filters.py
+++ b/scipy/ndimage/filters.py
@@ -30,7 +30,7 @@
 
 from __future__ import division, print_function, absolute_import
 import warnings
-
+import numbers
 import numpy
 from . import _ni_support
 from . import _nd_image

--- a/scipy/ndimage/filters.py
+++ b/scipy/ndimage/filters.py
@@ -1188,7 +1188,7 @@ def rank_filter(input, rank, size=None, footprint=None, output=None,
     >>> plt.show()
     """
     if not isinstance(rank, numbers.Integral):
-        raise TypeError('Input rank needs to be integer')
+        raise ValueError('Input rank needs to be integer')
     return _rank_filter(input, rank, size, footprint, output, mode, cval,
                         origin, 'rank')
 

--- a/scipy/ndimage/filters.py
+++ b/scipy/ndimage/filters.py
@@ -1187,6 +1187,9 @@ def rank_filter(input, rank, size=None, footprint=None, output=None,
     >>> ax2.imshow(result)
     >>> plt.show()
     """
+    if not isinstance(rank, int):
+        raise TypeError('Input rank needs to be integer')
+        return None
     return _rank_filter(input, rank, size, footprint, output, mode, cval,
                         origin, 'rank')
 

--- a/scipy/ndimage/filters.py
+++ b/scipy/ndimage/filters.py
@@ -1187,9 +1187,8 @@ def rank_filter(input, rank, size=None, footprint=None, output=None,
     >>> ax2.imshow(result)
     >>> plt.show()
     """
-    if not isinstance(rank, int):
+    if not isinstance(rank, numbers.Integral):
         raise TypeError('Input rank needs to be integer')
-        return None
     return _rank_filter(input, rank, size, footprint, output, mode, cval,
                         origin, 'rank')
 

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -10,7 +10,7 @@ from pytest import raises as assert_raises
 
 import scipy.ndimage as sndi
 from scipy.ndimage.filters import _gaussian_kernel1d, rank_filter
-
+from scipy._lib._numpy_compat import suppress_warnings
 
 def test_ticket_701():
     # Test generic filter sizes
@@ -435,3 +435,13 @@ def test_rank_filter_noninteger_rank():
     arr = np.random.random((10, 20, 30))
     assert_raises(ValueError, rank_filter, arr, 0.5, footprint=np.ones((1, 1, 10),
                   dtype=bool))
+    
+
+def test_size_footprint_both_set():
+    # test for input validation, expect user warning when
+    # size and footprint is set
+    with suppress_warnings() as sup:
+        sup.filter(UserWarning,
+                   "ignoring size because footprint is set")
+        arr = np.random.random((10, 20, 30))
+        rank_filter(arr, 5, size=2, footprint=np.ones((1, 1, 10), dtype=bool))

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -9,7 +9,7 @@ from numpy.testing import (assert_equal, assert_allclose,
 from pytest import raises as assert_raises
 
 import scipy.ndimage as sndi
-from scipy.ndimage.filters import _gaussian_kernel1d
+from scipy.ndimage.filters import _gaussian_kernel1d, rank_filter
 
 
 def test_ticket_701():
@@ -427,3 +427,11 @@ def test_gaussian_filter():
     sigma = 1.0
     with assert_raises(RuntimeError):
         sndi.gaussian_filter(data,sigma)
+
+
+def test_rank_filter_noninteger_rank():
+    # regression test for issue 9388: ValueError for
+    # non integer rank when performing rank_filter
+    arr = np.random.random((10, 20, 30))
+    assert_raises(ValueError, rank_filter, arr, 0.5, footprint=np.ones((1, 1, 10),
+                  dtype=bool))

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -433,9 +433,9 @@ def test_rank_filter_noninteger_rank():
     # regression test for issue 9388: ValueError for
     # non integer rank when performing rank_filter
     arr = np.random.random((10, 20, 30))
-    assert_raises(ValueError, rank_filter, arr, 0.5, footprint=np.ones((1, 1, 10),
-                  dtype=bool))
-    
+    assert_raises(ValueError, rank_filter, arr, 0.5,
+                  footprint=np.ones((1, 1, 10), dtype=bool))
+
 
 def test_size_footprint_both_set():
     # test for input validation, expect user warning when

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -433,7 +433,7 @@ def test_rank_filter_noninteger_rank():
     # regression test for issue 9388: ValueError for
     # non integer rank when performing rank_filter
     arr = np.random.random((10, 20, 30))
-    assert_raises(ValueError, rank_filter, arr, 0.5,
+    assert_raises(TypeError, rank_filter, arr, 0.5,
                   footprint=np.ones((1, 1, 10), dtype=bool))
 
 


### PR DESCRIPTION
Fixes #9388
Call to `rank_filter` with a non integer value of rank causes a malloc memory corruption. Hence added input validation to return `TypeError` for that scenario