### PR TITLE
TST: stats: Fix the expected r-value of a linregress test.

### DIFF
--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1163,13 +1163,13 @@ class TestRegression(object):
         # Expected values
         exp_slope = 1.00211681802045
         exp_intercept = -0.262323073774029
-        exp_rvalue = 0.999993745883712
+        exp_rsquared = 0.999993745883712
 
         actual = stats.linregress(x, y)
 
         assert_almost_equal(actual.slope, exp_slope)
         assert_almost_equal(actual.intercept, exp_intercept)
-        assert_almost_equal(actual.rvalue, exp_rvalue, decimal=5)
+        assert_almost_equal(actual.rvalue**2, exp_rsquared)
 
     def test_empty_input(self):
         assert_raises(ValueError, stats.linregress, [], [])


### PR DESCRIPTION
The test TestRegression.test_nist_norris() in stats/test_stats.py
uses the "Norris" data set from

    https://www.itl.nist.gov/div898/strd/lls/data/Norris.shtml

The certified r-squared value is 0.999993745883712.  `stats.linregress`
returns the r-value (not squared), so we must square it before comparing
it to the certified value.