### PR TITLE
BUG: np.hstack does not accept generator expressions

### DIFF
--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -690,9 +690,8 @@ def solve_toeplitz(c_or_cr, b, check_finite=True):
     else:
         b_shape = b.shape
         b = b.reshape(b.shape[0], -1)
-        x = np.column_stack(
-            (levinson(vals, np.ascontiguousarray(b[:, i]))[0])
-            for i in range(b.shape[1]))
+        x = np.column_stack([levinson(vals, np.ascontiguousarray(b[:, i]))[0]
+                             for i in range(b.shape[1])])
         x = x.reshape(*b_shape)
 
     return x

--- a/scipy/optimize/_trustregion_constr/canonical_constraint.py
+++ b/scipy/optimize/_trustregion_constr/canonical_constraint.py
@@ -144,8 +144,8 @@ class CanonicalConstraint(object):
 
         n_eq = sum(c.n_eq for c in canonical_constraints)
         n_ineq = sum(c.n_ineq for c in canonical_constraints)
-        keep_feasible = np.array(np.hstack((
-            c.keep_feasible for c in canonical_constraints)), dtype=bool)
+        keep_feasible = np.hstack([c.keep_feasible for c in
+                                   canonical_constraints])
 
         return cls(n_eq, n_ineq, fun, jac, hess, keep_feasible)
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -183,7 +183,7 @@ class TestRandInt(object):
         assert_array_almost_equal(vals, out)
 
     def test_cdf(self):
-        x = numpy.r_[0:36:100j]
+        x = np.linspace(0,36,100)
         k = numpy.floor(x)
         out = numpy.select([k >= 30, k >= 5], [1.0, (k-5.0+1)/(30-5.0)], 0)
         vals = stats.randint.cdf(x, 5, 30)

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -1632,7 +1632,7 @@ class TestUnitaryGroup(object):
 
         # The angles "x" of the eigenvalues should be uniformly distributed
         # Overall this seems to be a necessary but weak test of the distribution.
-        eigs = np.vstack(scipy.linalg.eigvals(x) for x in xs)
+        eigs = np.vstack([scipy.linalg.eigvals(x) for x in xs])
         x = np.arctan2(eigs.imag, eigs.real)
         res = kstest(x.ravel(), uniform(-np.pi, 2*np.pi).cdf)
         assert_(res.pvalue > 0.05)


### PR DESCRIPTION
Lately SciPy tests fail on the upstream NumPy branch. Judging by the fix that made the tests passed locally, it looks like numpy.hstack behavior changed.

Converted to list comprehension with this PR.