### PR TITLE
ENH: linalg: Shorter ill-conditioned warning message

### DIFF
--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -34,9 +34,9 @@ def _solve_check(n, info, lamch=None, rcond=None):
         return
     E = lamch('E')
     if rcond < E:
-        warn('scipy.linalg.solve\nIll-conditioned matrix detected. Result '
-             'is not guaranteed to be accurate.\nReciprocal condition '
-             'number{:.6e}'.format(rcond), LinAlgWarning, stacklevel=3)
+        warn('Ill-conditioned matrix (rcond={:.6g}): '
+             'result may not be accurate.'.format(rcond),
+             LinAlgWarning, stacklevel=3)
 
 
 def solve(a, b, sym_pos=False, lower=False, overwrite_a=False,

--- a/scipy/sparse/linalg/tests/test_matfuncs.py
+++ b/scipy/sparse/linalg/tests/test_matfuncs.py
@@ -211,8 +211,7 @@ class TestExpM(object):
         A_logm_perturbed = A_logm.copy()
         A_logm_perturbed[1, 0] = tiny
         with suppress_warnings() as sup:
-            sup.filter(RuntimeWarning,
-                       "scipy.linalg.solve\nIll-conditioned.*")
+            sup.filter(RuntimeWarning, "Ill-conditioned.*")
             A_expm_logm_perturbed = expm(A_logm_perturbed)
         rtol = 1e-4
         atol = 100 * tiny


### PR DESCRIPTION
Make the ill-conditioned matrix warning one-liner.  Fix the missing
space between the number and text.

Previously, the warning read
```
__main__:1: LinAlgWarning: scipy.linalg.solve
Ill-conditioned matrix detected. Result is not guaranteed to be accurate.
Reciprocal condition number1.000000e-19
```
Some issues that are addressed here: there's no space before condition number, the message is quite long, usually the warnings don't contain the function name, and usually they don't contain newlines.