### PR TITLE
NaN handling in pearsonr

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -2980,6 +2980,8 @@ def pearsonr(x, y):
     producing datasets that have a Pearson correlation at least as extreme
     as the one computed from these datasets. The p-values are not entirely
     reliable but are probably reasonable for datasets larger than 500 or so.
+    If either input dataset has zero variance then the correlation is nan
+    and the p-value returned will be nan as well.
 
     Parameters
     ----------

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3033,13 +3033,18 @@ def pearsonr(x, y):
     xm, ym = x - mx, y - my
     r_num = np.add.reduce(xm * ym)
     r_den = np.sqrt(_sum_of_squares(xm) * _sum_of_squares(ym))
-    r = r_num / r_den
+    try:
+        r = r_num / r_den
+    except ZeroDivisionError:
+        r = np.nan
 
     # Presumably, if abs(r) > 1, then it is only some small artifact of
     # floating point arithmetic.
     r = max(min(r, 1.0), -1.0)
     df = n - 2
-    if abs(r) == 1.0:
+    if np.isnan(r):
+        prob = np.nan
+    elif abs(r) == 1.0:
         prob = 0.0
     else:
         t_squared = r**2 * (df / ((1.0 - r) * (1.0 + r)))

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3041,10 +3041,14 @@ def pearsonr(x, y):
         r = np.nan
 
     # Presumably, if abs(r) > 1, then it is only some small artifact of
-    # floating point arithmetic.
-    r = max(min(r, 1.0), -1.0)
+    # floating point arithmetic, except if np.inf
+    if r != np.inf:
+        r = max(min(r, 1.0), -1.0)
+    else:
+        r = np.inf
+
     df = n - 2
-    if np.isnan(r):
+    if np.isnan(r) or np.isinf(r):
         prob = np.nan
     elif abs(r) == 1.0:
         prob = 0.0


### PR DESCRIPTION
maybe fixes issue #9406 ?

 In my dev-env, the change fixes the return tuple to be (nan, nan) for pearsonr, but does not fix the first occurrence of the runtime warning in #9406. 

```
>>> from scipy.stats import pearsonr
>>> pearsonr([1, 1, 1], [2, 2, 2])
/Users/rlucas/scipy-dev/scipy/scipy/stats/stats.py:3039: RuntimeWarning: invalid value encountered in double_scalars
  r = r_num / r_den
(nan, nan)
>>> pearsonr([1, 1, 1], [2, 2, 2])
(nan, nan)

```