### PR TITLE
DOC: Add an example to integrate.newton_cotes

### DIFF
--- a/scipy/integrate/quadrature.py
+++ b/scipy/integrate/quadrature.py
@@ -883,6 +883,29 @@ def newton_cotes(rn, equal=0):
     B : float
         Error coefficient.
 
+    Examples
+    --------
+    Compute the integral of sin(x) in [0, :math:`\pi`]:
+
+    >>> def f(x):
+    ...     return np.sin(x)
+    >>> a = 0
+    >>> b = np.pi
+    >>> exact = 2
+    >>> for N in [2, 4, 6, 8, 10]:
+    ...     x = np.linspace(a, b, N + 1)
+    ...     an, B = newton_cotes(N, 1)
+    ...     dx = (b - a) / N
+    ...     quad = dx * np.sum(an * f(x))
+    ...     error = abs(quad - exact)
+    ...     print(N, '\\t', quad, '\\t', error)
+    ... 
+    2 	 2.0943951023931953 	 0.09439510239319526
+    4 	 1.9985707318238355 	 0.001429268176164511
+    6 	 2.000017813636656 	 1.7813636655983345e-05
+    8 	 1.9999998352747237 	 1.6472527630817524e-07
+    10 	 2.000000001146774 	 1.146773787041866e-09
+
     Notes
     -----
     Normally, the Newton-Cotes rules are used on smaller integration

--- a/scipy/integrate/quadrature.py
+++ b/scipy/integrate/quadrature.py
@@ -850,21 +850,21 @@ _builtincoeffs = {
 
 
 def newton_cotes(rn, equal=0):
-    """
+    r"""
     Return weights and error coefficient for Newton-Cotes integration.
 
     Suppose we have (N+1) samples of f at the positions
     x_0, x_1, ..., x_N.  Then an N-point Newton-Cotes formula for the
     integral between x_0 and x_N is:
 
-    :math:`\\int_{x_0}^{x_N} f(x)dx = \\Delta x \\sum_{i=0}^{N} a_i f(x_i)
-    + B_N (\\Delta x)^{N+2} f^{N+1} (\\xi)`
+    :math:`\int_{x_0}^{x_N} f(x)dx = \Delta x \sum_{i=0}^{N} a_i f(x_i)
+    + B_N (\Delta x)^{N+2} f^{N+1} (\xi)`
 
-    where :math:`\\xi \\in [x_0,x_N]`
-    and :math:`\\Delta x = \\frac{x_N-x_0}{N}` is the average samples spacing.
+    where :math:`\xi \in [x_0,x_N]`
+    and :math:`\Delta x = \frac{x_N-x_0}{N}` is the average samples spacing.
 
     If the samples are equally-spaced and N is even, then the error
-    term is :math:`B_N (\\Delta x)^{N+3} f^{N+2}(\\xi)`.
+    term is :math:`B_N (\Delta x)^{N+3} f^{N+2}(\xi)`.
 
     Parameters
     ----------
@@ -899,14 +899,13 @@ def newton_cotes(rn, equal=0):
     ...     dx = (b - a) / N
     ...     quad = dx * np.sum(an * f(x))
     ...     error = abs(quad - exact)
-    ...     print(N, '\\t', quad, '\\t', error)
-    ... 
-    2 	 2.0943951023931953 	 0.09439510239319526
-    4 	 1.9985707318238355 	 0.001429268176164511
-    6 	 2.000017813636656 	 1.7813636655983345e-05
-    8 	 1.9999998352747237 	 1.6472527630817524e-07
-    10 	 2.000000001146774 	 1.146773787041866e-09
-
+    ...     print('{:2d}  {:10.9f}  {:.5e}'.format(N, quad, error))
+    ...
+     2   2.094395102   9.43951e-02
+     4   1.998570732   1.42927e-03
+     6   2.000017814   1.78136e-05
+     8   1.999999835   1.64725e-07
+    10   2.000000001   1.14677e-09
     Notes
     -----
     Normally, the Newton-Cotes rules are used on smaller integration

--- a/scipy/integrate/quadrature.py
+++ b/scipy/integrate/quadrature.py
@@ -906,6 +906,7 @@ def newton_cotes(rn, equal=0):
      6   2.000017814   1.78136e-05
      8   1.999999835   1.64725e-07
     10   2.000000001   1.14677e-09
+
     Notes
     -----
     Normally, the Newton-Cotes rules are used on smaller integration

--- a/scipy/integrate/quadrature.py
+++ b/scipy/integrate/quadrature.py
@@ -887,6 +887,7 @@ def newton_cotes(rn, equal=0):
     --------
     Compute the integral of sin(x) in [0, :math:`\pi`]:
 
+    >>> from scipy.integrate import newton_cotes
     >>> def f(x):
     ...     return np.sin(x)
     >>> a = 0


### PR DESCRIPTION
Added an example to `scipy.integrate.newton_cotes`. 

`quad_explain` is still missing an example but I am not sure what should be done on that one.

Reference https://github.com/scipy/scipy/issues/7168