### PR TITLE
BENCH: Add dual annealing to scipy benchmark (see #9415)

### DIFF
--- a/benchmarks/benchmarks/optimize.py
+++ b/benchmarks/benchmarks/optimize.py
@@ -13,7 +13,7 @@ try:
     import scipy.optimize
     from scipy.optimize.optimize import rosen, rosen_der, rosen_hess
     from scipy.optimize import (leastsq, basinhopping, differential_evolution,
-                                OptimizeResult)
+                                dual_annealing, OptimizeResult)
 except ImportError:
     pass
 
@@ -187,16 +187,34 @@ class _BenchOptimizers(Benchmark):
         res.nfev = self.function.nfev
         self.add_result(res, t1 - t0, 'DE')
 
+    def run_dualannealing(self):
+        """
+        Do an optimization run for dual_annealing
+        """
+        self.function.nfev = 0
+
+        t0 = time.time()
+
+        res = dual_annealing(self.fun,
+                             None,
+                             self.bounds)
+
+        t1 = time.time()
+        res.success = self.function.success(res.x)
+        res.nfev = self.function.nfev
+        self.add_result(res, t1 - t0, 'DA')
+
     def bench_run_global(self, numtrials=50, methods=None):
         """
         Run the optimization tests for the required minimizers.
         """
 
         if methods is None:
-            methods = ['DE', 'basinh.']
+            methods = ['DE', 'basinh.', 'DA']
 
         method_fun = {'DE': self.run_differentialevolution,
-                      'basinh.': self.run_basinhopping}
+                      'basinh.': self.run_basinhopping,
+                      'DA': self.run_dualannealing,}
 
         for i in range(numtrials):
             for m in methods:
@@ -447,7 +465,7 @@ class BenchGlobal(Benchmark):
     params = [
         list(_functions.keys()),
         ["success%", "<nfev>"],
-        ['DE', 'basinh.'],
+        ['DE', 'basinh.', 'DA'],
     ]
     param_names = ["test function", "result type", "solver"]
 


### PR DESCRIPTION
@rgommers, thanks for the merging. This PR is for adding `optimize.dual_annealing` into the scipy optimize benchmark. I ran:
```bash
python runtests.py --bench -s optimize
```
with ``SCIPY_XSLOW=5`` env var exported to test if what I added in benchmarks/benchmarks/optimize.py was ok.
This was to address #9415.