### PR TITLE
BUG: Initialize coo matrix with size_t indexes

### DIFF
--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -18,6 +18,8 @@ from .sputils import (upcast, upcast_char, to_native, isshape, getdtype,
                       get_index_dtype, downcast_intp_index, check_shape,
                       check_reshape_kwargs)
 
+import operator
+
 
 class coo_matrix(_data_matrix, _minmax_mixin):
     """
@@ -145,8 +147,8 @@ class coo_matrix(_data_matrix, _minmax_mixin):
                     if len(row) == 0 or len(col) == 0:
                         raise ValueError('cannot infer dimensions from zero '
                                          'sized index arrays')
-                    M = np.max(row) + 1
-                    N = np.max(col) + 1
+                    M = operator.index(np.max(row)) + 1
+                    N = operator.index(np.max(col)) + 1
                     self._shape = check_shape((M, N))
                 else:
                     # Use 2 steps to ensure shape has length 2.


### PR DESCRIPTION
Fixes #9437 

It seems that trying to construct a `coo_matrix` from row and column indexes of `size_t` type without shape will fail because it takes the max of them and interprets it as a float rather than integer. This small change fixes that.