### PR TITLE
MAINT: interpolate: use operator.index for checking/coercing to integers

### DIFF
--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -181,7 +181,7 @@ class BSpline(object):
     def __init__(self, t, c, k, extrapolate=True, axis=0):
         super(BSpline, self).__init__()
 
-        self.k = int(k)
+        self.k = operator.index(k)
         self.c = np.asarray(c)
         self.t = np.ascontiguousarray(t, dtype=np.float64)
 
@@ -206,8 +206,6 @@ class BSpline(object):
 
         if k < 0:
             raise ValueError("Spline order cannot be negative.")
-        if int(k) != k:
-            raise ValueError("Spline order must be integer.")
         if self.t.ndim != 1:
             raise ValueError("Knot vector must be one-dimensional.")
         if n < self.k + 1:
@@ -776,7 +774,7 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
 
     x = _as_float_array(x, check_finite)
     y = _as_float_array(y, check_finite)
-    k = int(k)
+    k = operator.index(k)
 
     # come up with a sensible knot vector, if needed
     if t is None:
@@ -975,7 +973,7 @@ def make_lsq_spline(x, y, t, k=3, w=None, axis=0, check_finite=True):
         w = _as_float_array(w, check_finite)
     else:
         w = np.ones_like(x)
-    k = int(k)
+    k = operator.index(k)
 
     if not -y.ndim <= axis < y.ndim:
         raise ValueError("axis {} is out of bounds".format(axis))

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -34,9 +34,9 @@ class TestBSpline(object):
                 **dict(t=[0, 1, 2, 3, 4], c=[1., 1.], k=2))
 
         # non-integer orders
-        assert_raises(ValueError, BSpline,
+        assert_raises(TypeError, BSpline,
                 **dict(t=[0., 0., 1., 2., 3., 4.], c=[1., 1., 1.], k="cubic"))
-        assert_raises(ValueError, BSpline,
+        assert_raises(TypeError, BSpline,
                 **dict(t=[0., 0., 1., 2., 3., 4.], c=[1., 1., 1.], k=2.5))
 
         # basic interval cannot have measure zero (here: [1..1])
@@ -784,6 +784,10 @@ class TestInterp(object):
     #
     xx = np.linspace(0., 2.*np.pi)
     yy = np.sin(xx)
+
+    def test_non_int_order(self):
+        with assert_raises(TypeError):
+            make_interp_spline(self.xx, self.yy, k=2.5)
 
     def test_order_0(self):
         b = make_interp_spline(self.xx, self.yy, k=0)


### PR DESCRIPTION
Use the recommended idiom for checking integer inputs.
Strictly speaking, this is a backcompat break since some ValueErrors become TypeErrors, but I believe this is harmless (can't see any reason to catch these errors in library or user code).