### PR TITLE
MAINT: Speed up get_(lapack,blas)_func

### DIFF
--- a/benchmarks/benchmarks/blas_lapack.py
+++ b/benchmarks/benchmarks/blas_lapack.py
@@ -1,0 +1,38 @@
+from __future__ import division, absolute_import, print_function
+
+import numpy as np
+
+try:
+    import scipy.linalg.lapack as la
+    import scipy.linalg.blas as bla
+except ImportError:
+    pass
+
+from .common import Benchmark
+
+
+class GetBlasLapackFuncs(Benchmark):
+    """
+    Test the speed of grabbing the correct BLAS/LAPACK routine flavor.
+
+    In particular, upon receiving strange dtype arrays the results shouldn't
+    diverge too much. Hence the results here should be comparable
+    """
+
+    param_names = ['dtype1', 'dtype2',
+                   'dtype1_ord', 'dtype2_ord',
+                   'size']
+    params = [
+        ['b', 'G', 'd'],
+        ['d', 'F', '?']
+        ['C', 'F'],
+        ['C', 'F'],
+        [10, 100, 1000]
+    ]
+
+    def setup(self, dtype1, dtype2, dtype1_ord, dtype2_ord, size):
+        self.arr1 = np.empty(size, dtype=dtype1, order=dtype1_ord)
+        self.arr2 = np.empty(size, dtype=dtype2, order=dtype2_ord)
+
+    def time_find_best_blas_type(self, arr1, arr2):
+        prefix, dtype, prefer_fortran = bla.find_best_blas_type((arr1, arr2))

--- a/scipy/linalg/blas.py
+++ b/scipy/linalg/blas.py
@@ -206,6 +206,7 @@ BLAS Level 3 functions
 #
 
 from __future__ import division, print_function, absolute_import
+
 __all__ = ['get_blas_funcs', 'find_best_blas_type']
 
 import numpy as _np
@@ -283,6 +284,8 @@ def find_best_blas_type(arrays=(), dtype=None):
     prefer_fortran : bool
         Whether to prefer Fortran order routines over C order.
 
+    .. versionchanged:: 1.2.0
+
     Examples
     --------
     >>> import scipy.linalg.blas as bla
@@ -345,7 +348,7 @@ def _get_funcs(names, arrays, dtype,
     if prefer_fortran:
         module1, module2 = module2, module1
 
-    for i, name in enumerate(names):
+    for name in names:
         func_name = prefix + name
         func_name = alias.get(func_name, func_name)
         func = getattr(module1[0], func_name, None)

--- a/scipy/linalg/blas.py
+++ b/scipy/linalg/blas.py
@@ -224,27 +224,16 @@ del empty_module
 
 # all numeric dtypes '?bBhHiIlLqQefdgFDGO' that are safe to be converted to
 
-# single precision float
-# WIN : '?bBhH!!!!!!ef!!!!!!'
-# NIX : '?bBhH!!!!!!ef!!!!!!'
-
-# double precision float
-# WIN : '?bBhHiIlLqQefdg!!!!'
-# NIX : '?bBhHiIlLqQefd!!!!!'
-
-# single precision complex
-# WIN : '?bBhH!!!!!!ef!!F!!!'
-# NIX : '?bBhH!!!!!!ef!!F!!!'
-
-# double precision complex
-# WIN : '?bBhHiIlLqQefdgFDG!'
-# NIX : '?bBhHiIlLqQefd!FD!!'
+# single precision float   : '?bBhH!!!!!!ef!!!!!!'
+# double precision float   : '?bBhHiIlLqQefdg!!!!'
+# single precision complex : '?bBhH!!!!!!ef!!F!!!'
+# double precision complex : '?bBhHiIlLqQefdgFDG!'
 
 _type_score = {x: 1 for x in '?bBhHef'}
 _type_score.update({x: 2 for x in 'iIlLqQd'})
 
-# Handle float128 and complex256 separately for non-windows systems
-# otherwise it will overwrite the same key with same value
+# Handle float128(g) and complex256(G) separately in case non-windows systems.
+# On windows, the values will be rewritten to the same key with the same value.
 _type_score.update({'F': 3, 'D': 4, 'g': 2, 'G': 4})
 
 # Final mapping to the actual prefixes and dtypes
@@ -283,8 +272,6 @@ def find_best_blas_type(arrays=(), dtype=None):
         Inferred Numpy data type.
     prefer_fortran : bool
         Whether to prefer Fortran order routines over C order.
-
-    .. versionchanged:: 1.3.0
 
     Examples
     --------


### PR DESCRIPTION
Closes #6782

The main overhead of `get_lapack_func` comes from the NumPy call to `can_coerce_all` function which searches for the next best dtype. Here we only need to map it to one of the canonical LAPACK types hence the search can be reduced significantly. 

In the linked issue I have gained ~50% time reduction with this simple score based evaluation. 