### PR TITLE
TST: test_eigs_consistency() now sorts output

### DIFF
--- a/scipy/sparse/linalg/eigen/lobpcg/tests/test_lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/tests/test_lobpcg.py
@@ -243,7 +243,7 @@ def test_eigs_consistency(n, atol):
     vals, vecs = eigs(A, k=2)
 
     _check_eigen(A, lvals, lvecs, atol=atol, rtol=0)
-    assert_allclose(vals, lvals, atol=1e-14)
+    assert_allclose(np.sort(vals), np.sort(lvals), atol=1e-14)
 
 def test_verbosity():
     """Check that nonzero verbosity level code runs.


### PR DESCRIPTION
Fixes #9453 

@lobpcg confirmed the mathematical equivalence of the differently sorted values (and complex or not), but the assertion does not pass in the stochastic cases where the sorting doesn't match between actual and expected values.

So, sorting is now enforced even though the mathematically correct result was already produced, to alleviate the unit test failure.

To confirm locally, due to the difficulty with reproduction, I initially looped the test 500 times, and this made it much easier to detect and confirm a likely fix.