### PR TITLE
BUG: Check parameter values' type

### DIFF
--- a/scipy/interpolate/ndgriddata.py
+++ b/scipy/interpolate/ndgriddata.py
@@ -192,7 +192,7 @@ def griddata(points, values, xi, method='linear', fill_value=np.nan,
     """
 
     if type(values) != np.ndarray:
-          raise TypeError('Invalid type of values, values must be type of ndarray.')
+          values = np.array(values)
 
     points = _ndim_coords_from_arrays(points)
 

--- a/scipy/interpolate/ndgriddata.py
+++ b/scipy/interpolate/ndgriddata.py
@@ -191,6 +191,9 @@ def griddata(points, values, xi, method='linear', fill_value=np.nan,
 
     """
 
+    if type(values) != np.ndarray:
+          raise TypeError('Invalid type of values, values must be type of ndarray.')
+
     points = _ndim_coords_from_arrays(points)
 
     if points.ndim < 2:


### PR DESCRIPTION
convert other types to ndarray automatically when the parameter values is not ndarray. 
Making this change is because the issue scipy#9433 .