### PR TITLE
Cythonize ks_2samp.

### DIFF
--- a/doc/release/1.2.0-notes.rst
+++ b/doc/release/1.2.0-notes.rst
@@ -26,6 +26,12 @@ New features
 
 The function `softmax` was added to `scipy.special`.
 
+`scipy.stats`
+-------------
+
+``stats.ks_2samp`` used to return nonsensical values if the input was
+not real or contained nans.  It now raises an exception for such inputs.
+
 Deprecated features
 ===================
 

--- a/scipy/stats/_stats.pyx
+++ b/scipy/stats/_stats.pyx
@@ -296,3 +296,41 @@ def _weightedrankedtau(ordered[:] x, ordered[:] y, intp_t[:] rank, weigher, bool
     tau = ((tot - (v + u - t)) - 2. * exchanges_weight[0]
            ) / np.sqrt(tot - u) / np.sqrt(tot - v)
     return min(1., max(-1., tau))
+
+
+ctypedef fused dtype:
+    np.uint8_t
+    np.uint16_t
+    np.uint32_t
+    np.uint64_t
+    np.int8_t
+    np.int16_t
+    np.int32_t
+    np.int64_t
+    np.float32_t
+    np.float64_t
+    np.longdouble_t
+
+
+@cython.boundscheck(False)
+@cython.nonecheck(False)
+@cython.wraparound(False)
+@cython.cdivision(True)
+cpdef double ks_2samp(dtype[:] data1, dtype[:] data2):
+    cdef:
+        size_t i = 0, j = 0, n1 = data1.shape[0], n2 = data2.shape[0]
+        dtype d1i, d2j
+        double d = 0, maxd = 0, inv_n1 = 1. / n1, inv_n2 = 1. / n2
+    while i < n1 and j < n2:
+        d1i = data1[i]
+        d2j = data2[j]
+        if d1i <= d2j:
+            while i < n1 and data1[i] == d1i:
+                d += inv_n1
+                i += 1
+        if d1i >= d2j:
+            while j < n2 and data2[j] == d2j:
+                d -= inv_n2
+                j += 1
+        maxd = max(maxd, math.fabs(d))
+    return maxd


### PR DESCRIPTION
A redo of #5938, but with proper handling of ties (lack of handling of ties (#6435) led to a revert of the original PR in #6545); this PR computes the "correct" values in for the inputs provided in #6435).

On the sample code

    from time import perf_counter
    import numpy as np
    from scipy.stats import ks_2samp

    N = 10000

    start = perf_counter()
    for _ in range(100):
        x, y = np.random.random((2, N))
    generation_time = perf_counter() - start

    start = perf_counter()
    for _ in range(100):
        x, y = np.random.random((2, N))
        ks_2samp(x, y)
    print(perf_counter() - start - generation_time)

this results in a ~35% speedup at N=1e4 and ~45% at N=1e5.