### PR TITLE
MAINT: Clean up optimize.zeros C solvers interfaces/code.

### DIFF
--- a/scipy/optimize/Zeros/bisect.c
+++ b/scipy/optimize/Zeros/bisect.c
@@ -5,39 +5,43 @@
 
 double
 bisect(callback_type f, double xa, double xb, double xtol, double rtol,
-       int iter, default_parameters *params)
+       int iter, void *func_data, scipy_zeros_info *solver_stats)
 {
     int i;
     double dm,xm,fm,fa,fb;
+    solver_stats->error_num = INPROGRESS;
 
-    fa = (*f)(xa,params);
-    fb = (*f)(xb,params);
-    params->funcalls = 2;
+    fa = (*f)(xa, func_data);
+    fb = (*f)(xb, func_data);
+    solver_stats->funcalls = 2;
     if (fa*fb > 0) {
-        params->error_num = SIGNERR;
+        solver_stats->error_num = SIGNERR;
         return 0.;
     }
     if (fa == 0) {
+        solver_stats->error_num = CONVERGED;
         return xa;
     }
     if (fb == 0) {
+        solver_stats->error_num = CONVERGED;
         return xb;
     }
     dm = xb - xa;
-    params->iterations = 0;
+    solver_stats->iterations = 0;
     for (i=0; i<iter; i++) {
-        params->iterations++;
+        solver_stats->iterations++;
         dm *= .5;
         xm = xa + dm;
-        fm = (*f)(xm,params);
-        params->funcalls++;
+        fm = (*f)(xm, func_data);
+        solver_stats->funcalls++;
         if (fm*fa >= 0) {
             xa = xm;
         }
         if (fm == 0 || fabs(dm) < xtol + rtol*fabs(xm)) {
+            solver_stats->error_num = CONVERGED;
             return xm;
         }
     }
-    params->error_num = CONVERR;
+    solver_stats->error_num = CONVERR;
     return xa;
 }

--- a/scipy/optimize/Zeros/brenth.c
+++ b/scipy/optimize/Zeros/brenth.c
@@ -36,7 +36,7 @@
 
 double
 brenth(callback_type f, double xa, double xb, double xtol, double rtol,
-       int iter, default_parameters *params)
+       int iter, void *func_data, scipy_zeros_info *solver_stats)
 {
     double xpre = xa, xcur = xb;
     double xblk = 0., fpre, fcur, fblk = 0., spre = 0., scur = 0., sbis;
@@ -44,23 +44,26 @@ brenth(callback_type f, double xa, double xb, double xtol, double rtol,
     double delta;
     double stry, dpre, dblk;
     int i;
+    solver_stats->error_num = INPROGRESS;
 
-    fpre = (*f)(xpre,params);
-    fcur = (*f)(xcur,params);
-    params->funcalls = 2;
+    fpre = (*f)(xpre,func_data);
+    fcur = (*f)(xcur,func_data);
+    solver_stats->funcalls = 2;
     if (fpre*fcur > 0) {
-        params->error_num = SIGNERR;
+        solver_stats->error_num = SIGNERR;
         return 0.;
     }
     if (fpre == 0) {
+        solver_stats->error_num = CONVERGED;
         return xpre;
     }
     if (fcur == 0) {
+        solver_stats->error_num = CONVERGED;
         return xcur;
     }
-    params->iterations = 0;
+    solver_stats->iterations = 0;
     for (i = 0; i < iter; i++) {
-        params->iterations++;
+        solver_stats->iterations++;
         if (fpre*fcur < 0) {
             xblk = xpre;
             fblk = fpre;
@@ -79,6 +82,7 @@ brenth(callback_type f, double xa, double xb, double xtol, double rtol,
         delta = (xtol + rtol*fabs(xcur))/2;
         sbis = (xblk - xcur)/2;
         if (fcur == 0 || fabs(sbis) < delta) {
+            solver_stats->error_num = CONVERGED;
             return xcur;
         }
 
@@ -120,9 +124,9 @@ brenth(callback_type f, double xa, double xb, double xtol, double rtol,
             xcur += (sbis > 0 ? delta : -delta);
         }
 
-        fcur = (*f)(xcur, params);
-        params->funcalls++;
+        fcur = (*f)(xcur, func_data);
+        solver_stats->funcalls++;
     }
-    params->error_num = CONVERR;
+    solver_stats->error_num = CONVERR;
     return xcur;
 }

--- a/scipy/optimize/Zeros/ridder.c
+++ b/scipy/optimize/Zeros/ridder.c
@@ -9,42 +9,46 @@
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 #define SIGN(a) ((a) > 0. ? 1. : -1.)
 
-/* Sets params->error_num SIGNERR for sign_error;
-                         CONVERR for convergence_error;
+/* Sets solver_stats->error_num
+    SIGNERR for sign_error;
+    CONVERR for convergence_error;
 */
 
 double
 ridder(callback_type f, double xa, double xb, double xtol, double rtol,
-       int iter, default_parameters *params)
+       int iter, void *func_data, scipy_zeros_info *solver_stats)
 {
     int i;
     double dm,dn,xm,xn=0.0,fn,fm,fa,fb,tol;
+    solver_stats->error_num = INPROGRESS;
 
     tol = xtol + rtol*MIN(fabs(xa), fabs(xb));
-    fa = (*f)(xa,params);
-    fb = (*f)(xb,params);
-    params->funcalls = 2;
+    fa = (*f)(xa, func_data);
+    fb = (*f)(xb, func_data);
+    solver_stats->funcalls = 2;
     if (fa*fb > 0) {
-        params->error_num = SIGNERR;
+        solver_stats->error_num = SIGNERR;
         return 0.;
     }
     if (fa == 0) {
+        solver_stats->error_num = CONVERGED;
         return xa;
     }
     if (fb == 0) {
+        solver_stats->error_num = CONVERGED;
         return xb;
     }
 
-    params->iterations=0;
+    solver_stats->iterations=0;
     for (i=0; i<iter; i++) {
-        params->iterations++;
+        solver_stats->iterations++;
         dm = 0.5*(xb - xa);
         xm = xa + dm;
-        fm = (*f)(xm,params);
+        fm = (*f)(xm, func_data);
         dn = SIGN(fb - fa)*dm*fm/sqrt(fm*fm - fa*fb);
         xn = xm - SIGN(dn) * MIN(fabs(dn), fabs(dm) - .5*tol);
-        fn = (*f)(xn,params);
-        params->funcalls += 2;
+        fn = (*f)(xn, func_data);
+        solver_stats->funcalls += 2;
         if (fn*fm < 0.0) {
             xa = xn; fa = fn; xb = xm; fb = fm;
         }
@@ -56,9 +60,10 @@ ridder(callback_type f, double xa, double xb, double xtol, double rtol,
         }
         tol = xtol + rtol*xn;
         if (fn == 0.0 || fabs(xb - xa) < tol) {
+            solver_stats->error_num = CONVERGED;
             return xn;
         }
     }
-    params->error_num = CONVERR;
+    solver_stats->error_num = CONVERR;
     return xn;
 }

--- a/scipy/optimize/Zeros/zeros.h
+++ b/scipy/optimize/Zeros/zeros.h
@@ -10,17 +10,31 @@ typedef struct {
     int funcalls;
     int iterations;
     int error_num;
-} default_parameters;
+} scipy_zeros_info;
 
+
+/* Must agree with _ECONVERGED, _ESIGNERR, _ECONVERR  in zeros.py */
+#define CONVERGED 0
 #define SIGNERR -1
 #define CONVERR -2
+#define EVALUEERR -3
+#define INPROGRESS 1
 
 typedef double (*callback_type)(double,void*);
-typedef double (*solver_type)(callback_type, double, double, double, double, int,default_parameters*);
+typedef double (*solver_type)(callback_type, double, double, double, double,
+                              int, void *, scipy_zeros_info*);
 
-extern double bisect(callback_type f, double xa, double xb, double xtol, double rtol, int iter, default_parameters *params);
-extern double ridder(callback_type f, double xa, double xb, double xtol, double rtol, int iter, default_parameters *params);
-extern double brenth(callback_type f, double xa, double xb, double xtol, double rtol, int iter, default_parameters *params);
-extern double brentq(callback_type f, double xa, double xb, double xtol, double rtol, int iter, default_parameters *params);
+extern double bisect(callback_type f, double xa, double xb, double xtol,
+                     double rtol, int iter, void *func_data,
+                     scipy_zeros_info *solver_stats);
+extern double ridder(callback_type f, double xa, double xb, double xtol,
+                     double rtol, int iter, void *func_data,
+                     scipy_zeros_info *solver_stats);
+extern double brenth(callback_type f, double xa, double xb, double xtol,
+                     double rtol, int iter, void *func_data,
+                     scipy_zeros_info *solver_stats);
+extern double brentq(callback_type f, double xa, double xb, double xtol,
+                     double rtol, int iter, void *func_data,
+                     scipy_zeros_info *solver_stats);
 
 #endif

--- a/scipy/optimize/zeros.c
+++ b/scipy/optimize/zeros.c
@@ -6,6 +6,12 @@
 
 #include "Python.h"
 #include <setjmp.h>
+#include <numpy/npy_math.h>
+#include "Zeros/zeros.h"
+
+/*
+ * Caller entry point functions
+ */
 
 #ifdef PYPY_VERSION
     /*
@@ -20,23 +26,12 @@
 #endif
 
 typedef struct {
-    int funcalls;
-    int iterations;
-    int error_num;
     PyObject *function;
     PyObject *args;
     jmp_buf env;
 } scipy_zeros_parameters;
 
-/*
- * Storage for the relative precision of doubles. This is computed when the module
- * is initialized.
- */
 
-#include "Zeros/zeros.h"
-
-#define SIGNERR -1
-#define CONVERR -2
 
 static double
 scipy_zeros_functions_func(double x, void *params)
@@ -48,7 +43,7 @@ scipy_zeros_functions_func(double x, void *params)
     args = myparams->args;
     f = myparams->function;
     PyArgs(SetItem)(args, 0, Py_BuildValue("d",x));
-    retval=PyObject_CallObject(f,args);
+    retval = PyObject_CallObject(f,args);
     if (retval == NULL) {
         longjmp(myparams->env, 1);
     }
@@ -57,6 +52,7 @@ scipy_zeros_functions_func(double x, void *params)
     return val;
 }
 
+
 /*
  * Helper function that calls a Python function with extended arguments
  */
@@ -64,18 +60,19 @@ scipy_zeros_functions_func(double x, void *params)
 static PyObject *
 call_solver(solver_type solver, PyObject *self, PyObject *args)
 {
-    double a,b,xtol,rtol,zero;
-    int iter,i, len, fulloutput, disp=1, flag=0;
+    double a, b, xtol, rtol, zero;
+    Py_ssize_t len;
+    int iter, i, fulloutput, disp=1, flag=0;
     scipy_zeros_parameters params;
-    jmp_buf env;
-    PyObject *f, *xargs, *item, *fargs=NULL;
+    scipy_zeros_info solver_stats;
+    PyObject *f, *xargs, *item;
+    volatile PyObject *fargs = NULL;
 
     if (!PyArg_ParseTuple(args, "OddddiOi|i",
-                &f, &a, &b, &xtol, &rtol, &iter, &xargs, &fulloutput, &disp))
-        {
-            PyErr_SetString(PyExc_RuntimeError, "Unable to parse arguments");
-            return NULL;
-        }
+                &f, &a, &b, &xtol, &rtol, &iter, &xargs, &fulloutput, &disp)) {
+        PyErr_SetString(PyExc_RuntimeError, "Unable to parse arguments");
+        return NULL;
+    }
     if (xtol < 0) {
         PyErr_SetString(PyExc_ValueError, "xtol must be >= 0");
         return NULL;
@@ -89,8 +86,7 @@ call_solver(solver_type solver, PyObject *self, PyObject *args)
     /* Make room for the double as first argument */
     fargs = PyArgs(New)(len + 1);
     if (fargs == NULL) {
-        PyErr_SetString(PyExc_RuntimeError,
-                "Failed to allocate arguments");
+        PyErr_SetString(PyExc_RuntimeError, "Failed to allocate arguments");
         return NULL;
     }
 
@@ -105,45 +101,45 @@ call_solver(solver_type solver, PyObject *self, PyObject *args)
     }
 
     params.function = f;
-    params.args = fargs;
+    params.args = (PyObject *)fargs;  /* Discard the volatile attribute */
 
-    if (!setjmp(env)) {
+    if (!setjmp(params.env)) {
         /* direct return */
-        memcpy(params.env, env, sizeof(jmp_buf));
-        params.error_num = 0;
-        zero = solver(scipy_zeros_functions_func, a, b,
-                xtol, rtol, iter, (default_parameters*)&params);
+        solver_stats.error_num = 0;
+        zero = solver(scipy_zeros_functions_func, a, b, xtol, rtol,
+                      iter, (void*)&params, &solver_stats);
         Py_DECREF(fargs);
-        if (params.error_num != 0) {
-            if (params.error_num == SIGNERR) {
-                PyErr_SetString(PyExc_ValueError,
-                        "f(a) and f(b) must have different signs");
-                return NULL;
-            }
-            if (params.error_num == CONVERR) {
-                if (disp) {
-                    char msg[100];
-                    PyOS_snprintf(msg, sizeof(msg),
-                            "Failed to converge after %d iterations.",
-                            params.iterations);
-                    PyErr_SetString(PyExc_RuntimeError, msg);
-                    flag = 1;
-                    return NULL;
-                }
-            }
-        }
-        if (fulloutput) {
-            return Py_BuildValue("diii",
-                    zero, params.funcalls, params.iterations, flag);
-        }
-        else {
-            return Py_BuildValue("d", zero);
-        }
-    }
-    else {
+        fargs = NULL;
+    } else {
         /* error return from Python function */
         Py_DECREF(fargs);
         return NULL;
+    }
+
+    if (solver_stats.error_num != 0) {
+        if (solver_stats.error_num == SIGNERR) {
+            PyErr_SetString(PyExc_ValueError,
+                    "f(a) and f(b) must have different signs");
+            return NULL;
+        }
+        if (solver_stats.error_num == CONVERR) {
+            if (disp) {
+                char msg[100];
+                PyOS_snprintf(msg, sizeof(msg),
+                        "Failed to converge after %d iterations.",
+                        solver_stats.iterations);
+                PyErr_SetString(PyExc_RuntimeError, msg);
+                flag = 1;
+                return NULL;
+            }
+        }
+    }
+    if (fulloutput) {
+        return Py_BuildValue("diii",
+                zero, solver_stats.funcalls, solver_stats.iterations, flag);
+    }
+    else {
+        return Py_BuildValue("d", zero);
     }
 }
 


### PR DESCRIPTION
Split data being passed to zeros C solvers into const/modifiable parts.
Refactored to remove an unneeded jmp_buf object.
Added volatile qualifier to a object used after a longjmp() return.

In optimize.zeros, the C solvers were being passed a scipy_zeros_parameters
struct disguised as a default_parameters struct.  The initial elements of the
scipy_zeros_parameters contained the same elements as the default_parameters,
and pointers to default_parameters were being upcast to scipy_zeros_parameters.
However these two structs were not linked either in code or documentation.
This change separates the data needed to evaluate the function from the
statistics collected during the solving of the equation.  This also makes for
easier initialization and cleaner separation of input and output data.
Ensure the solver_stats->error_num is set for all return paths.
The jmp_buf does not need to be copied if it is constructed in place.
A PyTuple is being created and then destroyed in both branches after a
setjmp() return, hence needs a volatile qualifier.