### PR TITLE
DOC: linalg: fix lstsq docstring on residues shape

### DIFF
--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -1084,7 +1084,7 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
         Least-squares solution.  Return shape matches shape of `b`.
     residues : (0,) or () or (K,) ndarray
         Sums of residues, squared 2-norm for each column in ``b - a x``.
-        If rank of matrix a is ``< N`` or ``N > M``, or ``'gelsy'`` is used,
+        If rank of matrix a is ``< N`` or ``N >= M``, or ``'gelsy'`` is used,
         this is a length zero array. If b was 1-D, this is a () shape array
         (numpy scalar), otherwise the shape is (K,).
     rank : int


### PR DESCRIPTION
```python
>>> import scipy.linalg
>>> scipy.linalg.lstsq([[1]], [1])[1].shape
(0,)
```

See also: https://github.com/scipy/scipy/blob/0a9e93e23453cce2f5e861bf6dc4168d788fdb51/scipy/linalg/basic.py#L1245-L1251