### PR TITLE
BUG: fix sparse random int handling

### DIFF
--- a/scipy/_lib/_numpy_compat.py
+++ b/scipy/_lib/_numpy_compat.py
@@ -94,30 +94,10 @@ else:
     # In NumPy versions previous to 1.11.0 the randint funtion and the randint
     # method of RandomState does only work with int32 values.
     def get_randint(random_state):
-        def randint_patched(*args, **kwargs):
-            try:
-                low = args[0]
-            except IndexError:
-                low = None
-            high = kwargs.pop('high', None)
-            dtype = kwargs.pop('dtype', None)
-
-            if high is None:
-                high = low
-                low = 0
-
-            low_min = np.iinfo(np.int32).min
-            if low is None:
-                low = low_min
-            else:
-                low = max(low, low_min)
-            high_max = np.iinfo(np.int32).max
-            if high is None:
-                high = high_max
-            else:
-                high = min(high, high_max)
-
-            integers = random_state.randint(low, high=high, **kwargs)
+        def randint_patched(low, high, size, dtype=np.int32):
+            low = max(low, np.iinfo(dtype).min)
+            high = min(high, np.iinfo(dtype).max)
+            integers = random_state.randint(low, high=high, size=size)
             return integers.astype(dtype, copy=False)
         return randint_patched
 


### PR DESCRIPTION
SciPy wheel builds have been failing for [the last ten weeks](https://travis-ci.org/MacPython/scipy-wheels/builds), which has caused a number of issues to fly under the radar until my attempt to start the wheel build process for `1.2.0rc1` as described in https://github.com/MacPython/scipy-wheels/pull/37.

This PR targets perhaps the most worrisome of the failures, in `scipy.sparse.tests.test_construct::TestConstructUtils::test_random_sampling`.

I was able to reproduce one of the several failing wheel build matrix entries locally by using `numpy==1.8.2`, `Cython==0.29.0`, `Python==2.7`, and SciPy master branch.

The changes made in this PR were sufficient to patch that specific test failure locally, but that doesn't mean we actually want to fix it this way, and I'm not sure how imposing this fix is after the branch has happened--maybe not too cumbersome yet without a tag having been pushed.

The original compatibility layer addition was quite recent -- #9048 by @jor-.
