### PR TITLE
TST: 32-bit test_distance.py now passes

### DIFF
--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -1157,7 +1157,7 @@ class TestPdist(object):
         _assert_within_tol(Y_test1, Y_right, eps, verbose > 2)
 
     def test_pdist_jensenshannon_iris_nonC(self):
-        eps = 5e-13
+        eps = 5e-12
         X = eo['iris']
         Y_right = eo['pdist-jensenshannon-iris']
         Y_test2 = pdist(X, 'test_jensenshannon')


### PR DESCRIPTION
As [discussed](https://github.com/MacPython/scipy-wheels/pull/37#issuecomment-439281762) for SciPy wheel building related to `1.2.x`, there was a [test failure with 32-bit Python interpreters](https://travis-ci.org/MacPython/scipy-wheels/jobs/455687598) in our wheel build matrix in `scipy/spatial/tests/test_distance.py::TestPdist::test_pdist_jensenshannon_iris_nonC`

I've reduced the stringency of the test a bit so that it can pass with a 32-bit interpreter. This isn't caught by our current test matrix (wheel matrix only), but I did reproduce locally using an i386 Ubuntu docker container -- I'll put the sequence of commands used below in case a reviewer wants to check (I should probably just upload an image / dockerfile I suppose):

<details>

- `docker pull i386/ubuntu`
- `docker run -it i386/ubuntu`
- `apt-get update`
- `apt-get install python2.7-dev`
- `apt-get install python-pip`
- `pip2 install cython==0.29.0 numpy==1.8.2`
- `apt-get install git`
- `git clone https://github.com/scipy/scipy.git`
- `apt-get install libopenblas-dev`
- `apt-get install gfortran`
- `pip2 install pytest`
- `apt-get install vim`
- in scipy repo on master at hash 3651d2d7  again:
- `python setup.py install`
- `python runtests.py -t "scipy/spatial/tests/test_distance.py::TestPdist::test_pdist_jensenshannon_iris_nonC"`
  - fails without patch here
</details>