### PR TITLE
TST: test_kolmogorov xfail 32-bit

### DIFF
--- a/scipy/special/tests/test_kolmogorov.py
+++ b/scipy/special/tests/test_kolmogorov.py
@@ -1,6 +1,8 @@
 from __future__ import division, print_function, absolute_import
 
 import itertools
+import sys
+import pytest
 
 import numpy as np
 from numpy.testing import assert_
@@ -228,6 +230,8 @@ class TestSmirnovp(object):
         dataset0 = np.column_stack([n, x, pp])
         FuncData(_smirnovp, dataset0, (0, 1), 2, rtol=_rtol).check(dtypes=[int, float, float])
 
+    @pytest.mark.xfail(sys.maxsize <= 2**32,
+                       reason="requires 64-bit platform")
     def test_oneovernclose(self):
         # Check derivative at x=1/n  (Discontinuous at x=1/n, test on either side: x=1/n +/- 2epsilon)
         n = np.arange(3, 20)


### PR DESCRIPTION
Another patch aimed at fixing 32-bit wheel build issues described in https://github.com/MacPython/scipy-wheels/pull/37 & ~with local verification of fix using an i386 docker container as described in #9493.~

~`test_oneovernclose()` seemed to need two "fixes" to pass:~

~1. use a sized (`np.float32`) type since `float` is apparently a C double (`float64`) in an i386 Python interpreter on 64-bit architecture~
~2. reduce the tolerance stringency to something more suitable to single precision~

~That said, the above fix is only necessary for one of the two tests of this type & even better may be to robustly & portably detect interpreter architecture & dispatch the test stringency from there, maybe. Not sure if that is in scope for this fix / for now.~