### PR TITLE
MAINT: Bump the numpy and cython versions for pypy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,10 +112,9 @@ jobs:
             export CCACHE_COMPRESS=1
             export NPY_NUM_BUILD_JOBS=`pypy3 -c 'import multiprocessing as mp; print(mp.cpu_count())'`
             export PATH=/usr/lib/ccache:$PATH
-            # XXX: use "numpy>=1.15.0" when it's released
             pypy3 -mpip install --upgrade pip setuptools wheel
-            pypy3 -mpip install --no-build-isolation --extra-index https://antocuni.github.io/pypy-wheels/ubuntu pytest pytest-xdist Tempita "Cython>=0.28.2" mpmath
-            pypy3 -mpip install --no-build-isolation git+https://github.com/numpy/numpy.git@db552b5b6b37f2ff085b304751d7a2ebed26adc9
+            pypy3 -mpip install --no-build-isolation --extra-index https://antocuni.github.io/pypy-wheels/ubuntu pytest pytest-xdist Tempita "Cython>=0.28.5" mpmath
+            pypy3 -mpip install --no-build-isolation numpy>=1.15.0
       - run:
           name: build
           command: |


### PR DESCRIPTION
Currently two tests are failing sporadically on the PRs and it seems like there were no related changes. This is to test whether bumping the versions that are known problematic would fix the issues.