### PR TITLE
DOC: Replace "Scipy" with "SciPy" in the .rst doc files for consistency.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -2,7 +2,7 @@
 SciPy pull request guidelines
 =============================
 
-Pull requests are always welcome, and the Scipy community appreciates
+Pull requests are always welcome, and the SciPy community appreciates
 any help you give. Note that a code of conduct applies to all spaces
 managed by the SciPy project, including issues and pull requests:
 https://github.com/scipy/scipy/blob/master/doc/source/dev/conduct/code_of_conduct.rst.

--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -4,7 +4,7 @@
 SciPy benchmarks
 ================
 
-Benchmarking Scipy with Airspeed Velocity.
+Benchmarking SciPy with Airspeed Velocity.
 
 
 Usage
@@ -12,11 +12,11 @@ Usage
 
 Airspeed Velocity manages building and Python virtualenvs by itself,
 unless told otherwise. Some of the benchmarking features in
-``runtests.py`` also tell ASV to use the Scipy compiled by
+``runtests.py`` also tell ASV to use the SciPy compiled by
 ``runtests.py``. To run the benchmarks, you do not need to install a
-development version of Scipy to your current Python environment.
+development version of SciPy to your current Python environment.
 
-Run a benchmark against currently checked out Scipy version (don't record the
+Run a benchmark against currently checked out SciPy version (don't record the
 result)::
 
     python runtests.py --bench sparse.Arithmetic
@@ -54,7 +54,7 @@ See `ASV documentation`_ for basics on how to write benchmarks.
 
 Some things to consider:
 
-- When importing things from Scipy on the top of the test files, do it as::
+- When importing things from SciPy on the top of the test files, do it as::
 
       try:
           from scipy.sparse.linalg import onenormest
@@ -62,7 +62,7 @@ Some things to consider:
           pass
 
   The benchmark files need to be importable also when benchmarking old versions
-  of Scipy. The benchmarks themselves don't need any guarding against missing
+  of SciPy. The benchmarks themselves don't need any guarding against missing
   features --- only the top-level imports.
 
 - Try to keep the runtime of the benchmark reasonable.

--- a/doc/source/building/macosx.rst
+++ b/doc/source/building/macosx.rst
@@ -44,7 +44,7 @@ You will also need to install a library providing the BLAS and LAPACK
 interfaces. ATLAS, OpenBLAS, and MKL all work. OpenBLAS can be installed
 via `Homebrew <https://brew.sh/>`.
 
-As of Scipy version 1.2.0, we do not support compiling against the system
+As of SciPy version 1.2.0, we do not support compiling against the system
 Accelerate library for BLAS and LAPACK. It does not support a sufficiently
 recent LAPACK interface.
 

--- a/doc/source/ccallback.rst
+++ b/doc/source/ccallback.rst
@@ -9,7 +9,7 @@ can either be python callables or low-level compiled functions.  Using
 compiled callback functions can improve performance somewhat by
 avoiding wrapping data in Python objects.
 
-Such low-level functions in Scipy are wrapped in `LowLevelCallable`
+Such low-level functions in SciPy are wrapped in `LowLevelCallable`
 objects, which can be constructed from function pointers obtained from
 ctypes, cffi, Cython, or contained in Python `PyCapsule` objects.
 

--- a/doc/source/dev/deprecations.rst
+++ b/doc/source/dev/deprecations.rst
@@ -3,7 +3,7 @@ Deprecations
 
 There are various reasons for wanting to remove existing functionality: it's
 buggy, the API isn't understandable, it's superseded by functionality with
-better performance, it needs to be moved to another Scipy submodule, etc.
+better performance, it needs to be moved to another SciPy submodule, etc.
 
 In general it's not a good idea to remove something without warning users about
 that removal first.  Therefore this is what should be done before removing

--- a/doc/source/dev/distributing.rst
+++ b/doc/source/dev/distributing.rst
@@ -2,16 +2,16 @@ Distributing
 ============
 
 Distributing Python packages is nontrivial - especially for a package with
-complex build requirements like Scipy - and subject to change.  For an up-to-date
+complex build requirements like SciPy - and subject to change.  For an up-to-date
 overview of recommended tools and techniques, see the `Python Packaging User
 Guide`_.  This document discusses some of the main issues and considerations for
-Scipy.
+SciPy.
 
 Dependencies
 ------------
 Dependencies are things that a user has to install in order to use (or
 build/test) a package.  They usually cause trouble, especially if they're not
-optional.  Scipy tries to keep its dependencies to a minimum; currently they
+optional.  SciPy tries to keep its dependencies to a minimum; currently they
 are:
 
 *Unconditional run-time dependencies:*
@@ -43,7 +43,7 @@ are:
 - LaTeX (pdf docs)
 - Pillow_ (docs)
 
-Furthermore of course one needs C, C++ and Fortran compilers to build Scipy,
+Furthermore of course one needs C, C++ and Fortran compilers to build SciPy,
 but those we don't consider to be dependencies and are therefore not discussed
 here.  For details, see https://scipy.github.io/devdocs/building/.
 
@@ -53,18 +53,18 @@ scipy) the package instead.  For example, six_ and decorator_ are vendored in
 ``scipy._lib``.
 
 The only dependency that is reported to pip_  is Numpy_, see
-``install_requires`` in Scipy's main ``setup.py``.  The other dependencies
-aren't needed for Scipy to function correctly, and the one unconditional build
+``install_requires`` in SciPy's main ``setup.py``.  The other dependencies
+aren't needed for SciPy to function correctly, and the one unconditional build
 dependency that pip_ knows how to install (Cython_) we prefer to treat like a
 compiler rather than a Python package that pip_ is allowed to upgrade.
 
 Issues with dependency handling
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 There are some serious issues with how Python packaging tools handle
-dependencies reported by projects.  Because Scipy gets regular bug reports
+dependencies reported by projects.  Because SciPy gets regular bug reports
 about this, we go in a bit of detail here.
 
-Scipy only reports its dependency on Numpy via ``install_requires`` if Numpy
+SciPy only reports its dependency on Numpy via ``install_requires`` if Numpy
 isn't installed at all on a system.  This will only change when there are
 either 32-bit and 64-bit Windows wheels for Numpy on PyPI or when
 ``pip upgrade`` becomes available (with sane behavior, unlike ``pip install
@@ -75,7 +75,7 @@ either 32-bit and 64-bit Windows wheels for Numpy on PyPI or when
 The situation with ``setup_requires`` is even worse; pip_ doesn't handle that
 keyword at all, while ``setuptools`` has issues (here's a `current one
 <https://bitbucket.org/pypa/setuptools/issues/391>`_) and invokes
-``easy_install`` which comes with its own set of problems (note that Scipy doesn't
+``easy_install`` which comes with its own set of problems (note that SciPy doesn't
 support ``easy_install`` at all anymore; issues specific to it will be closed
 as "wontfix").
 
@@ -84,19 +84,19 @@ as "wontfix").
 
 Supported Python and Numpy versions
 -----------------------------------
-The Python_ versions that Scipy supports are listed in the list of PyPI
+The Python_ versions that SciPy supports are listed in the list of PyPI
 classifiers in ``setup.py``, and mentioned in the release notes for each
 release.  All newly released Python versions will be supported as soon as
 possible.  The general policy on dropping support for a Python version is that
 (a) usage of that version has to be quite low (say <5% of users) and (b) the
 version isn't included in an active long-term support release of one of the
-main Linux distributions anymore.  Scipy typically follows Numpy, which has a
+main Linux distributions anymore.  SciPy typically follows Numpy, which has a
 similar policy.  The final decision on dropping support is always taken on the
 scipy-dev mailing list.
 
-The lowest supported Numpy_ version for a Scipy version is mentioned in the
+The lowest supported Numpy_ version for a SciPy version is mentioned in the
 release notes and is encoded in ``scipy/__init__.py`` and the
-``install_requires`` field of ``setup.py``.  Typically the latest Scipy release
+``install_requires`` field of ``setup.py``.  Typically the latest SciPy release
 supports 3 or 4 minor versions of Numpy.  That may become more if the frequency
 of Numpy releases increases (it's about 1x/year at the time of writing).
 Support for a particular Numpy version is typically dropped if (a) that Numpy
@@ -105,7 +105,7 @@ is starting to outweigh the benefits.  The final decision on dropping support
 is always taken on the scipy-dev mailing list.
 
 Supported versions of optional dependencies and compilers is less clearly
-documented, and also isn't tested well or at all by Scipy's Continuous
+documented, and also isn't tested well or at all by SciPy's Continuous
 Integration setup.  Issues regarding this are dealt with as they come up in the
 issue tracker or mailing list.
 
@@ -114,8 +114,8 @@ Building binary installers
 --------------------------
 .. note::
 
-   This section is only about building Scipy binary installers to *distribute*.
-   For info on building Scipy on the same machine as where it will be used, see
+   This section is only about building SciPy binary installers to *distribute*.
+   For info on building SciPy on the same machine as where it will be used, see
    `this scipy.org page <https://scipy.github.io/devdocs/building/>`_.
 
 There are a number of things to take into consideration when building binaries
@@ -132,7 +132,7 @@ and distributing them on PyPI or elsewhere.
 **Windows**
 
 - The currently most easily available toolchain for building
-  Python.org compatible binaries for Scipy is installing MSVC (see
+  Python.org compatible binaries for SciPy is installing MSVC (see
   https://wiki.python.org/moin/WindowsCompilers) and mingw64-gfortran.
   Support for this configuration requires numpy.distutils from
   Numpy >= 1.14.dev and a gcc/gfortran-compiled static ``openblas.a``.
@@ -140,7 +140,7 @@ and distributing them on PyPI or elsewhere.
   https://github.com/MacPython/scipy-wheels
 - For 64-bit Windows installers built with a free toolchain, use the method
   documented at https://github.com/numpy/numpy/wiki/Mingw-static-toolchain.
-  That method will likely be used for Scipy itself once it's clear that the
+  That method will likely be used for SciPy itself once it's clear that the
   maintenance of that toolchain is sustainable long-term.  See the MingwPy_
   project and `this thread
   <https://mail.scipy.org/pipermail/numpy-discussion/2015-October/074056.html>`_ for
@@ -151,13 +151,13 @@ and distributing them on PyPI or elsewhere.
   `this article <https://software.intel.com/en-us/articles/numpyscipy-with-intel-mkl>`_
   and for (partial) MSVC instructions see
   `this wiki page <https://github.com/numpy/numpy/wiki/Building-with-MSVC>`_.
-- Older Scipy releases contained a .exe "superpack" installer.  Those contain
+- Older SciPy releases contained a .exe "superpack" installer.  Those contain
   3 complete builds (no SSE, SSE2, SSE3), and were built with
   https://github.com/numpy/numpy-vendor.  That build setup is known to not work
   well anymore and is no longer supported.  It used g77 instead of gfortran,
   due to complex DLL distribution issues (see `gh-2829
   <https://github.com/scipy/scipy/issues/2829>`_).  Because the toolchain is no
-  longer supported, g77 support isn't needed anymore and Scipy can now include
+  longer supported, g77 support isn't needed anymore and SciPy can now include
   Fortran 90/95 code.
 
 **OS X**
@@ -166,13 +166,13 @@ and distributing them on PyPI or elsewhere.
   python.org, Homebrew, MacPython), use the build method provided by
   https://github.com/MacPython/scipy-wheels.
 - DMG installers for the Python from python.org on OS X can still be produced
-  by ``tools/scipy-macosx-installer/``.  Scipy doesn't distribute those
+  by ``tools/scipy-macosx-installer/``.  SciPy doesn't distribute those
   installers anymore though, now that there are binary wheels on PyPi.
 
 **Linux**
 
 - PyPi-compatible Linux wheels can be produced via the manylinux_ project.
-  The corresponding build setup for TravisCI for Scipy is set up in
+  The corresponding build setup for TravisCI for SciPy is set up in
   https://github.com/MacPython/scipy-wheels.
 
 Other Linux build-setups result to PyPi incompatible wheels, which

--- a/doc/source/dev/github.rst
+++ b/doc/source/dev/github.rst
@@ -51,7 +51,7 @@ Dealing with pull requests
 - Make sure that the labels and milestone on a merged PR are set correctly.
 - When you want to reject a PR: if it's very obvious you can just close it and
   explain why, if not obvious then it's a good idea to first explain why you
-  think the PR is not suitable for inclusion in Scipy and then let a second
+  think the PR is not suitable for inclusion in SciPy and then let a second
   committer comment or close.
 
 

--- a/doc/source/dev/licensing.rst
+++ b/doc/source/dev/licensing.rst
@@ -1,18 +1,18 @@
 Licensing
 =========
-Scipy is distributed under the modified (3-clause) BSD license.  All code,
-documentation and other files added to Scipy by contributors is licensed under
+SciPy is distributed under the modified (3-clause) BSD license.  All code,
+documentation and other files added to SciPy by contributors is licensed under
 this license, unless another license is explicitly specified in the source
 code.  Contributors keep the copyright for code they wrote and submit for
-inclusion to Scipy.
+inclusion to SciPy.
 
-Other licenses that are compatible with the modified BSD license that Scipy
+Other licenses that are compatible with the modified BSD license that SciPy
 uses are 2-clause BSD, MIT and PSF.  Incompatible licenses are GPL, Apache and
 custom licenses that require attribution/citation or prohibit use for
 commercial purposes.
 
 It regularly happens that PRs are submitted with content copied or derived from
-unlicensed code.  Such contributions cannot be accepted for inclusion in Scipy.
+unlicensed code.  Such contributions cannot be accepted for inclusion in SciPy.
 What is needed in such cases is to contact the original author and ask him to
 relicense his code under the modified BSD (or a compatible) license.  If the
 original author agrees to this, add a comment saying so to the source files and
@@ -20,6 +20,6 @@ forward the relevant email to the scipy-dev mailing list.
 
 What also regularly happens is that code is translated or derived from code in
 R, Octave (both GPL-licensed) or a commercial application.  Such code also
-cannot be included in Scipy.  Simply implementing functionality with the same
+cannot be included in SciPy.  Simply implementing functionality with the same
 API as found in R/Octave/... is fine though, as long as the author doesn't look
 at the original incompatibly-licensed source code.

--- a/doc/source/dev/releasing.rst
+++ b/doc/source/dev/releasing.rst
@@ -4,7 +4,7 @@ Making a SciPy release
 ======================
 
 At the highest level, this is what the release manager does to release a new
-Scipy version:
+SciPy version:
 
 #. Propose a release schedule on the scipy-dev mailing list.
 #. Create the maintenance branch for the release.
@@ -85,7 +85,7 @@ and that the release notes are up-to-date and included in the html docs.
 
 Then edit ``setup.py`` to get the correct version number (set
 ``ISRELEASED = True``) and commit it with a message like ``REL: set version to
-<version-number>``.  Don't push this commit to the Scipy repo yet.
+<version-number>``.  Don't push this commit to the SciPy repo yet.
 
 Finally tag the release locally with ``git tag -s <v1.x.y>`` (the ``-s`` ensures
 the tag is signed).  Continue with building release artifacts (next section).
@@ -179,7 +179,7 @@ doc server is needed; ask @pv (server admin) or @rgommers (can upload) if you
 don't have that.
 
 The sources for the website itself are maintained in
-https://github.com/scipy/docs.scipy.org/.  Add the new Scipy version in the
+https://github.com/scipy/docs.scipy.org/.  Add the new SciPy version in the
 table of releases in ``index.rst``.  Push that commit, then do ``make upload
 USERNAME=yourusername``.
 

--- a/doc/source/dev/versioning.rst
+++ b/doc/source/dev/versioning.rst
@@ -1,6 +1,6 @@
 Version numbering
 =================
-Scipy version numbering complies to `PEP 440`_.  Released final versions, which
+SciPy version numbering complies to `PEP 440`_.  Released final versions, which
 are the only versions appearing on `PyPI`_, are numbered ``MAJOR.MINOR.MICRO``
 where:
 
@@ -18,7 +18,7 @@ Released alpha, beta and rc (release candidate) versions are numbered
 like final versions but with postfixes ``a#``, ``b#`` and ``rc#`` respectively,
 with ``#`` an integer.  Development versions are postfixed with ``.dev0+<git-commit-hash>``.
 
-Examples of valid Scipy version strings are::
+Examples of valid SciPy version strings are::
 
     0.16.0
     0.15.1
@@ -27,7 +27,7 @@ Examples of valid Scipy version strings are::
     0.14.0rc1
     0.17.0.dev0+ac53f09
 
-An installed Scipy version contains these version identifiers::
+An installed SciPy version contains these version identifiers::
 
     scipy.__version__            # complete version string, including git commit hash for dev versions
     scipy.version.short_version  # string, only major.minor.micro

--- a/doc/source/tutorial/basic.rst
+++ b/doc/source/tutorial/basic.rst
@@ -10,7 +10,7 @@ Basic functions
 Interaction with Numpy
 ----------------------
 
-Scipy builds on Numpy, and for all basic array handling needs you can
+SciPy builds on Numpy, and for all basic array handling needs you can
 use Numpy functions:
 
     >>> import numpy as np
@@ -22,7 +22,7 @@ Rather than giving a detailed description of each of these functions
 will discuss some of the more useful commands which require a little
 introduction to use to their full potential.
 
-To use functions from some of the Scipy modules, you can do:
+To use functions from some of the SciPy modules, you can do:
 
     >>> from scipy import some_module
     >>> some_module.some_function()

--- a/doc/source/tutorial/fftpack.rst
+++ b/doc/source/tutorial/fftpack.rst
@@ -1,7 +1,7 @@
 Fourier Transforms (:mod:`scipy.fftpack`)
 =========================================
 
-.. sectionauthor:: Scipy Developers
+.. sectionauthor:: SciPy Developers
 
 .. currentmodule:: scipy.fftpack
 
@@ -23,7 +23,7 @@ Fourier analysis and its applications.
    PyFFTW_ provides a way to replace a number of functions in `scipy.fftpack`
    with its own functions, which are usually significantly faster, via
    pyfftw.interfaces_.  Because PyFFTW_ relies on the GPL-licensed FFTW_ it
-   cannot be included in Scipy.  Users for whom the speed of FFT routines is
+   cannot be included in SciPy.  Users for whom the speed of FFT routines is
    critical should consider installing PyFFTW_.
 
 
@@ -255,7 +255,7 @@ arrays in frequency domain.
 Discrete Cosine Transforms
 --------------------------
 
-Scipy provides a DCT with the function :func:`dct` and a corresponding IDCT
+SciPy provides a DCT with the function :func:`dct` and a corresponding IDCT
 with the function :func:`idct`. There are 8 types of the DCT [WPC]_, [Mak]_;
 however, only the first 3 types are implemented in scipy. "The" DCT generally
 refers to DCT type 2, and "the" Inverse DCT generally refers to DCT type 3. In
@@ -270,7 +270,7 @@ MATLAB dct(x).
 Type I DCT
 __________
 
-Scipy uses the following definition of the unnormalized DCT-I
+SciPy uses the following definition of the unnormalized DCT-I
 (``norm='None'``):
 
 .. math::
@@ -285,7 +285,7 @@ DCT-I is only supported for input size > 1
 Type II DCT
 ___________
 
-Scipy uses the following definition of the unnormalized DCT-II
+SciPy uses the following definition of the unnormalized DCT-II
 (``norm='None'``):
 
 .. math::
@@ -312,7 +312,7 @@ In this case, the DCT "base functions" :math:`\phi_k[n] = 2 f \cos
 Type III DCT
 ____________
 
-Scipy uses the following definition of the unnormalized DCT-III
+SciPy uses the following definition of the unnormalized DCT-III
 (``norm='None'``):
 
 .. math::
@@ -403,7 +403,7 @@ provides a five-fold compression rate.
 Discrete Sine Transforms
 ------------------------
 
-Scipy provides a DST [Mak]_ with the function :func:`dst` and a corresponding IDST
+SciPy provides a DST [Mak]_ with the function :func:`dst` and a corresponding IDST
 with the function :func:`idst`.
 
 There are theoretically 8 types of the DST for different combinations of
@@ -413,7 +413,7 @@ types are implemented in scipy.
 Type I DST
 __________
 
-DST-I assumes the input is odd around n=-1 and n=N. Scipy uses the following
+DST-I assumes the input is odd around n=-1 and n=N. SciPy uses the following
 definition of the unnormalized DST-I (``norm='None'``):
 
 .. math::
@@ -428,7 +428,7 @@ own inverse, up to a factor `2(N+1)`.
 Type II DST
 ___________
 
-DST-II assumes the input is odd around n=-1/2 and even around n=N. Scipy uses
+DST-II assumes the input is odd around n=-1/2 and even around n=N. SciPy uses
 the following definition of the unnormalized DST-II (``norm='None'``):
 
 .. math::
@@ -439,7 +439,7 @@ the following definition of the unnormalized DST-II (``norm='None'``):
 Type III DST
 ____________
 
-DST-III assumes the input is odd around n=-1 and even around n=N-1. Scipy uses
+DST-III assumes the input is odd around n=-1 and even around n=N-1. SciPy uses
 the following definition of the unnormalized DST-III (``norm='None'``):
 
 .. math::

--- a/doc/source/tutorial/general.rst
+++ b/doc/source/tutorial/general.rst
@@ -69,7 +69,7 @@ Subpackage          Description
 :mod:`stats`        Statistical distributions and functions
 ==================  ======================================================
 
-Scipy sub-packages need to be imported separately, for example::
+SciPy sub-packages need to be imported separately, for example::
 
     >>> from scipy import linalg, optimize
 

--- a/doc/source/tutorial/integrate.rst
+++ b/doc/source/tutorial/integrate.rst
@@ -356,7 +356,7 @@ different file extension. A library has now been created that can be loaded
 into Python with `ctypes`.
 
 3.) Load shared library into Python using `ctypes` and set ``restypes`` and
-``argtypes`` - this allows Scipy to interpret the function correctly:
+``argtypes`` - this allows SciPy to interpret the function correctly:
 
 .. code:: python
 

--- a/doc/source/tutorial/io.rst
+++ b/doc/source/tutorial/io.rst
@@ -44,8 +44,8 @@ From time to time you may find yourself re-using this machinery.
 How do I start?
 ```````````````
 
-You may have a ``.mat`` file that you want to read into Scipy.  Or, you
-want to pass some variables from Scipy / Numpy into MATLAB.
+You may have a ``.mat`` file that you want to read into SciPy.  Or, you
+want to pass some variables from SciPy / Numpy into MATLAB.
 
 To save us using a MATLAB license, let's start in Octave_.  Octave has
 MATLAB-compatible save and load functions.  Start Octave (``octave`` at
@@ -171,7 +171,7 @@ We can load this in Python:
    >>> val.dtype
    dtype([('field1', 'O'), ('field2', 'O')])
 
-In versions of Scipy from 0.12.0, MATLAB structs come back as numpy
+In versions of SciPy from 0.12.0, MATLAB structs come back as numpy
 structured arrays, with fields named for the struct fields.  You can see
 the field names in the ``dtype`` output above.  Note also:
 
@@ -187,7 +187,7 @@ and:
      1   1
 
 So, in MATLAB, the struct array must be at least 2D, and we replicate
-that when we read into Scipy.  If you want all length 1 dimensions
+that when we read into SciPy.  If you want all length 1 dimensions
 squeezed out, try this:
 
    >>> mat_contents = sio.loadmat('octave_struct.mat', squeeze_me=True)

--- a/doc/source/tutorial/signal.rst
+++ b/doc/source/tutorial/signal.rst
@@ -512,7 +512,7 @@ Filter Design
 
 Time-discrete filters can be classified into finite response (FIR) filters and
 infinite response (IIR) filters. FIR filters can provide a linear phase
-response, whereas IIR filters cannot. Scipy provides functions
+response, whereas IIR filters cannot. SciPy provides functions
 for designing both types of filters.
 
 FIR Filter
@@ -579,7 +579,7 @@ Nyquist frequency in :func:`firwin2` and :func:`freqz` (as explained above).
 IIR Filter
 """"""""""
 
-Scipy provides two functions to directly design IIR :func:`iirdesign` and
+SciPy provides two functions to directly design IIR :func:`iirdesign` and
 :func:`iirfilter` where the filter type (e.g. elliptic) is passed as an
 argument and several more filter design functions for specific filter types;
 e.g. :func:`ellip`.
@@ -1044,7 +1044,7 @@ implementation.
 Detrend
 -------
 
-Scipy provides the function :func:`detrend` to remove a constant or linear
+SciPy provides the function :func:`detrend` to remove a constant or linear
 trend in a data series in order to see effect of higher order.
 
 The example below removes the constant and linear trend of a 2-nd order

--- a/doc/source/tutorial/special.rst
+++ b/doc/source/tutorial/special.rst
@@ -66,7 +66,7 @@ Cython Bindings for Special Functions (:mod:`scipy.special.cython_special`)
 
 .. highlight:: cython
 
-Scipy also offers Cython bindings for scalar, typed versions of many
+SciPy also offers Cython bindings for scalar, typed versions of many
 of the functions in special. The following Cython code gives a simple
 example of how to use these functions::
 


### PR DESCRIPTION
Many rst files use the terms "SciPy" in one part of the document and "Scipy"
in a later. Change all "Scipy" to "SciPy".