### PR TITLE
DOC: Replace "Scipy" with "SciPy" in .py and .txt doc files for consistency

### DIFF
--- a/doc/API.rst.txt
+++ b/doc/API.rst.txt
@@ -1,4 +1,4 @@
-API - importing from Scipy
+API - importing from SciPy
 ==========================
 
 In Python the distinction between what is the public API of a library and what
@@ -25,12 +25,12 @@ rules for what is and isn't public in Python are:
           case; the presence of underscores do mark something as private, but
           the absence of underscores do not mark something as public.
 
-In Scipy there are modules whose names don't start with an underscore, but that
+In SciPy there are modules whose names don't start with an underscore, but that
 should be considered private.  To clarify which modules these are we define
-below what the public API is for Scipy, and give some recommendations for how
-to import modules/functions/objects from Scipy.
+below what the public API is for SciPy, and give some recommendations for how
+to import modules/functions/objects from SciPy.
 
-Guidelines for importing functions from Scipy
+Guidelines for importing functions from SciPy
 ---------------------------------------------
 
 The scipy namespace itself only contains functions imported from numpy.  These
@@ -77,7 +77,7 @@ API definition
 
 Every submodule listed below is public.  That means that these submodules are
 unlikely to be renamed or changed in an incompatible way, and if that is
-necessary a deprecation warning will be raised for one Scipy release before the
+necessary a deprecation warning will be raised for one SciPy release before the
 change is made.
 
 * `scipy.cluster`

--- a/doc/README.txt
+++ b/doc/README.txt
@@ -7,7 +7,7 @@ The easy way to build the documentation is to run
 
     python setup.py build_sphinx
 
-This will first build Scipy in-place, and then generate documentation for it.
+This will first build SciPy in-place, and then generate documentation for it.
 
 Another way
 -----------
@@ -16,5 +16,5 @@ Another way
 2. Run ``make html`` or ``make dist``
 
 Note that ``make html`` builds the documentation for the currently installed
-version of Scipy, not the one corresponding to the source code here.
+version of SciPy, not the one corresponding to the source code here.
 

--- a/doc/ROADMAP.rst.txt
+++ b/doc/ROADMAP.rst.txt
@@ -341,7 +341,7 @@ New modules under discussion
 
 diff
 ````
-Currently Scipy doesn't provide much support for numerical differentiation.
+Currently SciPy doesn't provide much support for numerical differentiation.
 A new ``scipy.diff`` module for that is discussed in
 https://github.com/scipy/scipy/issues/2035.  There's also a fairly detailed
 GSoC proposal to build on, see `here <https://github.com/scipy/scipy/wiki/Proposal:-add-finite-difference-numerical-derivatives-as-scipy.diff>`_.

--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -51,7 +51,7 @@ Utility tools
  test              --- Run scipy unittests
  show_config       --- Show scipy build configuration
  show_numpy_config --- Show numpy build configuration
- __version__       --- Scipy version string
+ __version__       --- SciPy version string
  __numpy_version__ --- Numpy version string
 
 """

--- a/scipy/_build_utils/__init__.py
+++ b/scipy/_build_utils/__init__.py
@@ -4,7 +4,7 @@ from scipy._lib._version import NumpyVersion
 
 
 # Don't use deprecated Numpy C API.  Define this to a fixed version instead of
-# NPY_API_VERSION in order not to break compilation for released Scipy versions
+# NPY_API_VERSION in order not to break compilation for released SciPy versions
 # when Numpy introduces a new deprecation.  Use in setup.py::
 #
 #   config.add_extension('_name', sources=['source_fname'], **numpy_nodepr_api)

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -1852,7 +1852,7 @@ def from_mlab_linkage(Z):
     See Also
     --------
     linkage: for a description of what a linkage matrix is.
-    to_mlab_linkage: transform from Scipy to MATLAB format.
+    to_mlab_linkage: transform from SciPy to MATLAB format.
 
     Examples
     --------
@@ -1861,7 +1861,7 @@ def from_mlab_linkage(Z):
 
     Given a linkage matrix in MATLAB format ``mZ``, we can use
     `scipy.cluster.hierarchy.from_mlab_linkage` to import
-    it into Scipy format:
+    it into SciPy format:
 
     >>> mZ = np.array([[1, 2, 1], [4, 5, 1], [7, 8, 1],
     ...                [10, 11, 1], [3, 13, 1.29099445],
@@ -1889,7 +1889,7 @@ def from_mlab_linkage(Z):
     As expected, the linkage matrix ``Z`` returned includes an
     additional column counting the number of original samples in
     each cluster. Also, all cluster indexes are reduced by 1
-    (MATLAB format uses 1-indexing, whereas Scipy uses 0-indexing).
+    (MATLAB format uses 1-indexing, whereas SciPy uses 0-indexing).
 
     """
     Z = np.asarray(Z, dtype=np.double, order='c')
@@ -1942,7 +1942,7 @@ def to_mlab_linkage(Z):
     See Also
     --------
     linkage: for a description of what a linkage matrix is.
-    from_mlab_linkage: transform from Matlab to Scipy format.
+    from_mlab_linkage: transform from Matlab to SciPy format.
 
     Examples
     --------
@@ -2712,7 +2712,7 @@ def fclusterdata(X, t, criterion='inconsistent',
     >>> from scipy.cluster.hierarchy import fclusterdata
 
     This is a convenience method that abstracts all the steps to perform in a
-    typical Scipy's hierarchical clustering workflow.
+    typical SciPy's hierarchical clustering workflow.
 
     * Transform the input data into a condensed matrix with `scipy.spatial.distance.pdist`.
 
@@ -3015,7 +3015,7 @@ def set_link_color_palette(palette):
 
     Notes
     -----
-    Ability to reset the palette with ``None`` added in Scipy 0.17.0.
+    Ability to reset the palette with ``None`` added in SciPy 0.17.0.
 
     Examples
     --------

--- a/scipy/io/matlab/mio4.py
+++ b/scipy/io/matlab/mio4.py
@@ -253,7 +253,7 @@ class VarReader4(object):
         '''
         res = self.read_sub_array(hdr)
         tmp = res[:-1,:]
-        # All numbers are float64 in Matlab, but Scipy sparse expects int shape
+        # All numbers are float64 in Matlab, but SciPy sparse expects int shape
         dims = (int(res[-1,0]), int(res[-1,1]))
         I = np.ascontiguousarray(tmp[:,0],dtype='intc')  # fixes byte order also
         J = np.ascontiguousarray(tmp[:,1],dtype='intc')

--- a/scipy/linalg/decomp_lu.py
+++ b/scipy/linalg/decomp_lu.py
@@ -196,7 +196,7 @@ def lu(a, permute_l=False, overwrite_a=False, check_finite=True):
 
     Notes
     -----
-    This is a LU factorization routine written for Scipy.
+    This is a LU factorization routine written for SciPy.
 
     Examples
     --------

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -46,7 +46,7 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False,
         Determines what information is to be returned: either both Q and R
         ('full', default), only R ('r') or both Q and R but computed in
         economy-size ('economic', see Notes). The final option 'raw'
-        (added in Scipy 0.11) makes the function return two matrices
+        (added in SciPy 0.11) makes the function return two matrices
         (Q, TAU) in the internal format used by LAPACK.
     pivoting : bool, optional
         Whether or not factorization should include pivoting for rank-revealing

--- a/scipy/odr/tests/test_odr.py
+++ b/scipy/odr/tests/test_odr.py
@@ -1,6 +1,6 @@
 from __future__ import division, print_function, absolute_import
 
-# Scipy imports.
+# SciPy imports.
 import numpy as np
 from numpy import pi
 from numpy.testing import (assert_array_almost_equal,

--- a/scipy/optimize/_remove_redundancy.py
+++ b/scipy/optimize/_remove_redundancy.py
@@ -309,7 +309,7 @@ def _remove_redundancy_sparse(A, rhs):
     # I tried and tried and tried to improve performance using the
     # Bartels-Golub update. It works, but it's only practical if the LU
     # factorization can be specialized as described, and that is not possible
-    # until the Scipy SuperLU interface permits control over column
+    # until the SciPy SuperLU interface permits control over column
     # permutation - see issue #7700.
 
     for i in v:

--- a/scipy/optimize/_trustregion_exact.py
+++ b/scipy/optimize/_trustregion_exact.py
@@ -236,7 +236,7 @@ class IterativeSubproblem(BaseQuadraticSubproblem):
         self.k_hard = k_hard
 
         # Get Lapack function for cholesky decomposition.
-        # The implemented Scipy wrapper does not return
+        # The implemented SciPy wrapper does not return
         # the incomplete factorization needed by the method.
         self.cholesky, = get_lapack_funcs(('potrf',), (self.hess,))
 

--- a/scipy/optimize/nonlin.py
+++ b/scipy/optimize/nonlin.py
@@ -105,7 +105,7 @@ The solution can be found using the `newton_krylov` solver:
 
 """
 # Copyright (C) 2009, Pauli Virtanen <pav@iki.fi>
-# Distributed under the same license as Scipy.
+# Distributed under the same license as SciPy.
 
 from __future__ import division, print_function, absolute_import
 
@@ -465,7 +465,7 @@ class TerminationCondition(object):
             return 1
 
         if self.iter is not None:
-            # backwards compatibility with Scipy 0.6.0
+            # backwards compatibility with SciPy 0.6.0
             return 2 * (self.iteration > self.iter)
 
         # NB: condition must succeed for rtol=inf even if norm == 0
@@ -1381,7 +1381,7 @@ class KrylovJacobian(Jacobian):
     Due to the use of iterative matrix inverses, these methods can
     deal with large nonlinear problems.
 
-    Scipy's `scipy.sparse.linalg` module offers a selection of Krylov
+    SciPy's `scipy.sparse.linalg` module offers a selection of Krylov
     solvers to choose from. The default here is `lgmres`, which is a
     variant of restarted GMRES iteration that reuses some of the
     information obtained in the previous Newton steps to invert

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -138,7 +138,7 @@ def _check_unknown_options(unknown_options):
     if unknown_options:
         msg = ", ".join(map(str, unknown_options.keys()))
         # Stack level 4: this is called from _minimize_*, which is
-        # called from another function in Scipy. Level 4 is the first
+        # called from another function in SciPy. Level 4 is the first
         # level in user code.
         warnings.warn("Unknown solver options: %s" % msg, OptimizeWarning, 4)
 

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -114,11 +114,11 @@ class CheckOptimizeParameterized(CheckOptimize):
                         atol=1e-6)
 
         # Ensure that function call counts are 'known good'; these are from
-        # Scipy 0.7.0. Don't allow them to increase.
+        # SciPy 0.7.0. Don't allow them to increase.
         assert_(self.funccalls == 9, self.funccalls)
         assert_(self.gradcalls == 7, self.gradcalls)
 
-        # Ensure that the function behaves the same; this is from Scipy 0.7.0
+        # Ensure that the function behaves the same; this is from SciPy 0.7.0
         assert_allclose(self.trace[2:4],
                         [[0, -0.5, 0.5],
                          [0, -5.05700028e-01, 4.95985862e-01]],
@@ -158,11 +158,11 @@ class CheckOptimizeParameterized(CheckOptimize):
                         atol=1e-6)
 
         # Ensure that function call counts are 'known good'; these are from
-        # Scipy 0.7.0. Don't allow them to increase.
+        # SciPy 0.7.0. Don't allow them to increase.
         assert_(self.funccalls == 10, self.funccalls)
         assert_(self.gradcalls == 8, self.gradcalls)
 
-        # Ensure that the function behaves the same; this is from Scipy 0.7.0
+        # Ensure that the function behaves the same; this is from SciPy 0.7.0
         assert_allclose(self.trace[6:8],
                         [[0, -5.25060743e-01, 4.87748473e-01],
                          [0, -5.24885582e-01, 4.87530347e-01]],
@@ -206,7 +206,7 @@ class CheckOptimizeParameterized(CheckOptimize):
                         atol=1e-6)
 
         # Ensure that function call counts are 'known good'; these are from
-        # Scipy 0.7.0. Don't allow them to increase.
+        # SciPy 0.7.0. Don't allow them to increase.
         #
         # However, some leeway must be added: the exact evaluation
         # count is sensitive to numerical error, and floating-point
@@ -217,7 +217,7 @@ class CheckOptimizeParameterized(CheckOptimize):
         assert_(self.funccalls <= 116 + 20, self.funccalls)
         assert_(self.gradcalls == 0, self.gradcalls)
 
-        # Ensure that the function behaves the same; this is from Scipy 0.7.0
+        # Ensure that the function behaves the same; this is from SciPy 0.7.0
         assert_allclose(self.trace[34:39],
                         [[0.72949016, -0.44156936, 0.47100962],
                          [0.72949016, -0.44156936, 0.48052496],
@@ -247,11 +247,11 @@ class CheckOptimizeParameterized(CheckOptimize):
                         atol=1e-6)
 
         # Ensure that function call counts are 'known good'; these are from
-        # Scipy 0.7.0. Don't allow them to increase.
+        # SciPy 0.7.0. Don't allow them to increase.
         assert_(self.funccalls == 167, self.funccalls)
         assert_(self.gradcalls == 0, self.gradcalls)
 
-        # Ensure that the function behaves the same; this is from Scipy 0.7.0
+        # Ensure that the function behaves the same; this is from SciPy 0.7.0
         assert_allclose(self.trace[76:78],
                         [[0.1928968, -0.62780447, 0.35166118],
                          [0.19572515, -0.63648426, 0.35838135]],
@@ -285,11 +285,11 @@ class CheckOptimizeParameterized(CheckOptimize):
                         atol=1e-6)
 
         # Ensure that function call counts are 'known good'; these are from
-        # Scipy 0.17.0. Don't allow them to increase.
+        # SciPy 0.17.0. Don't allow them to increase.
         assert_(self.funccalls == 100, self.funccalls)
         assert_(self.gradcalls == 0, self.gradcalls)
 
-        # Ensure that the function behaves the same; this is from Scipy 0.15.0
+        # Ensure that the function behaves the same; this is from SciPy 0.15.0
         assert_allclose(self.trace[50:52],
                         [[0.14687474, -0.5103282, 0.48252111],
                          [0.14474003, -0.5282084, 0.48743951]],
@@ -349,14 +349,14 @@ class CheckOptimizeParameterized(CheckOptimize):
                         atol=1e-6)
 
         # Ensure that function call counts are 'known good'; these are from
-        # Scipy 0.7.0. Don't allow them to increase.
+        # SciPy 0.7.0. Don't allow them to increase.
         assert_(self.funccalls == 7, self.funccalls)
         assert_(self.gradcalls <= 22, self.gradcalls)  # 0.13.0
         #assert_(self.gradcalls <= 18, self.gradcalls) # 0.9.0
         #assert_(self.gradcalls == 18, self.gradcalls) # 0.8.0
         #assert_(self.gradcalls == 22, self.gradcalls) # 0.7.0
 
-        # Ensure that the function behaves the same; this is from Scipy 0.7.0
+        # Ensure that the function behaves the same; this is from SciPy 0.7.0
         assert_allclose(self.trace[3:5],
                         [[-4.35700753e-07, -5.24869435e-01, 4.87527480e-01],
                          [-4.35700753e-07, -5.24869401e-01, 4.87527774e-01]],
@@ -384,13 +384,13 @@ class CheckOptimizeParameterized(CheckOptimize):
                         atol=1e-6)
 
         # Ensure that function call counts are 'known good'; these are from
-        # Scipy 0.7.0. Don't allow them to increase.
+        # SciPy 0.7.0. Don't allow them to increase.
         assert_(self.funccalls == 7, self.funccalls)
         assert_(self.gradcalls <= 18, self.gradcalls)  # 0.9.0
         # assert_(self.gradcalls == 18, self.gradcalls) # 0.8.0
         # assert_(self.gradcalls == 22, self.gradcalls) # 0.7.0
 
-        # Ensure that the function behaves the same; this is from Scipy 0.7.0
+        # Ensure that the function behaves the same; this is from SciPy 0.7.0
         assert_allclose(self.trace[3:5],
                         [[-4.35700753e-07, -5.24869435e-01, 4.87527480e-01],
                          [-4.35700753e-07, -5.24869401e-01, 4.87527774e-01]],
@@ -418,13 +418,13 @@ class CheckOptimizeParameterized(CheckOptimize):
                         atol=1e-6)
 
         # Ensure that function call counts are 'known good'; these are from
-        # Scipy 0.7.0. Don't allow them to increase.
+        # SciPy 0.7.0. Don't allow them to increase.
         assert_(self.funccalls == 7, self.funccalls)
         assert_(self.gradcalls <= 18, self.gradcalls)  # 0.9.0
         # assert_(self.gradcalls == 18, self.gradcalls) # 0.8.0
         # assert_(self.gradcalls == 22, self.gradcalls) # 0.7.0
 
-        # Ensure that the function behaves the same; this is from Scipy 0.7.0
+        # Ensure that the function behaves the same; this is from SciPy 0.7.0
         assert_allclose(self.trace[3:5],
                         [[-4.35700753e-07, -5.24869435e-01, 4.87527480e-01],
                          [-4.35700753e-07, -5.24869401e-01, 4.87527774e-01]],
@@ -539,11 +539,11 @@ class TestOptimizeSimple(CheckOptimize):
                         atol=1e-6)
 
         # Ensure that function call counts are 'known good'; these are from
-        # Scipy 0.7.0. Don't allow them to increase.
+        # SciPy 0.7.0. Don't allow them to increase.
         assert_(self.funccalls == 7, self.funccalls)
         assert_(self.gradcalls == 5, self.gradcalls)
 
-        # Ensure that the function behaves the same; this is from Scipy 0.7.0
+        # Ensure that the function behaves the same; this is from SciPy 0.7.0
         assert_allclose(self.trace[3:5],
                         [[0., -0.52489628, 0.48753042],
                          [0., -0.52489628, 0.48753042]],

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -521,7 +521,7 @@ def _np_conv_ok(volume, kernel, mode):
     """
     See if numpy supports convolution of `volume` and `kernel` (i.e. both are
     1D ndarrays and of the appropriate shape).  Numpy's 'same' mode uses the
-    size of the larger input, while Scipy's uses the size of the first input.
+    size of the larger input, while SciPy's uses the size of the first input.
 
     Invalid mode strings will return False and be caught by the calling func.
     """

--- a/scipy/sparse/_matrix_io.py
+++ b/scipy/sparse/_matrix_io.py
@@ -138,7 +138,7 @@ def load_npz(file):
 
         if sys.version_info[0] >= 3 and not isinstance(matrix_format, str):
             # Play safe with Python 2 vs 3 backward compatibility;
-            # files saved with Scipy < 1.0.0 may contain unicode or bytes.
+            # files saved with SciPy < 1.0.0 may contain unicode or bytes.
             matrix_format = matrix_format.decode('ascii')
 
         try:

--- a/scipy/sparse/linalg/isolve/_gcrotmk.py
+++ b/scipy/sparse/linalg/isolve/_gcrotmk.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2015, Pauli Virtanen <pav@iki.fi>
-# Distributed under the same license as Scipy.
+# Distributed under the same license as SciPy.
 
 from __future__ import division, print_function, absolute_import
 

--- a/scipy/sparse/linalg/isolve/lgmres.py
+++ b/scipy/sparse/linalg/isolve/lgmres.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2009, Pauli Virtanen <pav@iki.fi>
-# Distributed under the same license as Scipy.
+# Distributed under the same license as SciPy.
 
 from __future__ import division, print_function, absolute_import
 

--- a/scipy/sparse/linalg/isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/isolve/tests/test_iterative.py
@@ -544,7 +544,7 @@ class TestGMRES(object):
             sup.filter(DeprecationWarning, ".*called without specifying.*")
             x,flag = gmres(A, b, x0=zeros(A.shape[0]), tol=1e-16, maxiter=maxiter, callback=callback)
 
-        # Expected output from Scipy 1.0.0
+        # Expected output from SciPy 1.0.0
         assert_allclose(rvec, array([1.0, 0.81649658092772603]), rtol=1e-10)
 
         # Test preconditioned callback
@@ -555,7 +555,7 @@ class TestGMRES(object):
             sup.filter(DeprecationWarning, ".*called without specifying.*")
             x, flag = gmres(A, b, M=M, tol=1e-16, maxiter=maxiter, callback=callback)
 
-        # Expected output from Scipy 1.0.0 (callback has preconditioned residual!)
+        # Expected output from SciPy 1.0.0 (callback has preconditioned residual!)
         assert_allclose(rvec, array([1.0, 1e-3 * 0.81649658092772603]), rtol=1e-10)
 
     def test_abi(self):

--- a/scipy/sparse/linalg/isolve/tests/test_lsmr.py
+++ b/scipy/sparse/linalg/isolve/tests/test_lsmr.py
@@ -1,6 +1,6 @@
 """
 Copyright (C) 2010 David Fong and Michael Saunders
-Distributed under the same license as Scipy
+Distributed under the same license as SciPy
 
 Testing Code for LSMR.
 

--- a/scipy/sparse/sparsetools.py
+++ b/scipy/sparse/sparsetools.py
@@ -4,7 +4,7 @@ for backward compatibility if someone happens to use it.
 """
 from numpy import deprecate
 
-# This file shouldn't be imported by scipy --- Scipy code should use
+# This file shouldn't be imported by scipy --- SciPy code should use
 # internally scipy.sparse._sparsetools
 
 

--- a/scipy/sparse/tests/test_matrix_io.py
+++ b/scipy/sparse/tests/test_matrix_io.py
@@ -73,7 +73,7 @@ def test_malicious_load():
 
 def test_py23_compatibility():
     # Try loading files saved on Python 2 and Python 3.  They are not
-    # the same, since files saved with Scipy versions < 1.0.0 may
+    # the same, since files saved with SciPy versions < 1.0.0 may
     # contain unicode.
 
     a = load_npz(os.path.join(DATA_DIR, 'csc_py2.npz'))

--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -8,7 +8,7 @@ Spherical Voronoi Code
 # Copyright (C)  Tyler Reddy, Ross Hemsley, Edd Edmondson,
 #                Nikolai Nowaczyk, Joe Pitt-Francis, 2015.
 #
-# Distributed under the same BSD license as Scipy.
+# Distributed under the same BSD license as SciPy.
 #
 
 import numpy as np

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -2122,7 +2122,7 @@ def squareform(X, force="no", checks=True):
       :math:`v[{n \\choose 2}-{n-i \\choose 2} + (j-i-1)]` and all
       diagonal elements are zero.
 
-    In Scipy 0.19.0, ``squareform`` stopped casting all input types to
+    In SciPy 0.19.0, ``squareform`` stopped casting all input types to
     float64, and started returning arrays of the same dtype as the input.
 
     """

--- a/scipy/special/orthogonal.py
+++ b/scipy/special/orthogonal.py
@@ -76,7 +76,7 @@ References
 
 from __future__ import division, print_function, absolute_import
 
-# Scipy imports.
+# SciPy imports.
 import numpy as np
 from numpy import (exp, inf, pi, sqrt, floor, sin, cos, around, int,
                    hstack, arccos, arange)

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -1,5 +1,5 @@
 """
-Test Scipy functions versus mpmath, if available.
+Test SciPy functions versus mpmath, if available.
 
 """
 from __future__ import division, print_function, absolute_import
@@ -1383,7 +1383,7 @@ class TestSystematic(object):
 
     @nonfunctional_tooslow
     def test_hyp2f1_complex(self):
-        # Scipy's hyp2f1 seems to have performance and accuracy problems
+        # SciPy's hyp2f1 seems to have performance and accuracy problems
         assert_mpmath_equal(lambda a, b, c, x: sc.hyp2f1(a.real, b.real, c.real, x),
                             exception_to_nan(lambda a, b, c, x: mpmath.hyp2f1(a, b, c, x, **HYPERKW)),
                             [Arg(-1e2, 1e2), Arg(-1e2, 1e2), Arg(-1e2, 1e2), ComplexArg()],

--- a/scipy/stats/kde.py
+++ b/scipy/stats/kde.py
@@ -9,7 +9,7 @@
 #  Date: 2004-08-09
 #
 #  Modified: 2005-02-10 by Robert Kern.
-#              Contributed to Scipy
+#              Contributed to SciPy
 #            2005-10-07 by Robert Kern.
 #              Some fixes to match the new scipy_core
 #
@@ -22,7 +22,7 @@ from __future__ import division, print_function, absolute_import
 # Standard library imports.
 import warnings
 
-# Scipy imports.
+# SciPy imports.
 from scipy._lib.six import callable, string_types
 from scipy import linalg, special
 from scipy.special import logsumexp

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -284,7 +284,7 @@ class TestFisherExact(object):
     Note that in SciPy 0.9.0 this was not working well for large numbers due to
     inaccuracy of the hypergeom distribution (see #1218). Fixed now.
 
-    Also note that R and Scipy have different argument formats for their
+    Also note that R and SciPy have different argument formats for their
     hypergeometric distribution functions.
 
     R:


### PR DESCRIPTION
[Followon from gh-9499.]
Some documentation in .txt and .py files use the terms "SciPy" in one part of the document and "Scipy" in a later part. Change all "Scipy" to "SciPy".

Explicitly excluded are the old release notes `doc/release/*-notes.rst` which have been left alone.