### PR TITLE
DOC: specify which definition of skewness is used

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1072,7 +1072,7 @@ def skew(a, axis=0, bias=True, nan_policy='propagate'):
     adjusted Fisher-Pearson standardized moment coefficient, i.e. 
     
     .. math:: G_1=\\frac{k_3}{k_2^{3/2}}=
-                  \\frac{\\sqrt{n(n-1)}}{n-2}\\frac{m_3}{m_2^{3/2}}.
+                  \\frac{\\sqrt{N(N-1)}}{N-2}\\frac{m_3}{m_2^{3/2}}.
 
     References
     ----------

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1027,7 +1027,7 @@ def variation(a, axis=0, nan_policy='propagate'):
 
 def skew(a, axis=0, bias=True, nan_policy='propagate'):
     """
-    Compute the skewness of a data set.
+    Compute the sample skewness of a data set.
 
     For normally distributed data, the skewness should be about 0. For
     unimodal continuous distributions, a skewness value > 0 means that
@@ -1062,12 +1062,17 @@ def skew(a, axis=0, bias=True, nan_policy='propagate'):
     
     .. math:: g_1=\\frac{m_3}{m_2^{3/2}}
 
-    If ``bias`` is False, the calculations are corrected for bias and the
-    value computed is the adjusted Fisher-Pearson standardized moment
-    coefficient, i.e. 
+    where
+
+    .. math:: m_i=\\frac{1}{N}\\sum_{n=1}^N(x[n]-\\bar{x})^i
+
+    is the biased sample :math:`i^\\texttt{th}` central moment, and
+    :math:`\\bar{x}` is the sample mean.  If ``bias`` is False, the
+    calculations are corrected for bias and the value computed is the
+    adjusted Fisher-Pearson standardized moment coefficient, i.e. 
     
     .. math:: G_1=\\frac{k_3}{k_2^{3/2}}=
-                  \\frac{\\sqrt{n(n-1)}}{n-2}\\frac{m_3}{m_2^{3/2}}`.
+                  \\frac{\\sqrt{n(n-1)}}{n-2}\\frac{m_3}{m_2^{3/2}}.
 
     References
     ----------

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1029,9 +1029,6 @@ def skew(a, axis=0, bias=True, nan_policy='propagate'):
     """
     Compute the skewness of a data set.
 
-    The sample skewness is defined as the adjusted Fisher-Pearson
-    standardized moment coefficient.
-
     For normally distributed data, the skewness should be about 0. For
     unimodal continuous distributions, a skewness value > 0 means that
     there is more weight in the right tail of the distribution. The
@@ -1057,6 +1054,20 @@ def skew(a, axis=0, bias=True, nan_policy='propagate'):
     skewness : ndarray
         The skewness of values along an axis, returning 0 where all values are
         equal.
+
+    Notes
+    -----
+    The sample skewness is computed as the Fisher-Pearson coefficicient
+    of skewness, i.e.
+    
+    .. math:: g_1=\\frac{m_3}{m_2^{3/2}}
+
+    If ``bias`` is False, the calculations are corrected for bias and the
+    value computed is the adjusted Fisher-Pearson standardized moment
+    coefficient, i.e. 
+    
+    .. math:: G_1=\\frac{k_3}{k_2^{3/2}}=
+                  \\frac{\\sqrt{n(n-1)}}{n-2}\\frac{m_3}{m_2^{3/2}}`.
 
     References
     ----------

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1029,6 +1029,9 @@ def skew(a, axis=0, bias=True, nan_policy='propagate'):
     """
     Compute the skewness of a data set.
 
+    The sample skewness is defined as the adjusted Fisher-Pearson
+    standardized moment coefficient.
+
     For normally distributed data, the skewness should be about 0. For
     unimodal continuous distributions, a skewness value > 0 means that
     there is more weight in the right tail of the distribution. The

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1066,10 +1066,10 @@ def skew(a, axis=0, bias=True, nan_policy='propagate'):
 
     .. math:: m_i=\\frac{1}{N}\\sum_{n=1}^N(x[n]-\\bar{x})^i
 
-    is the biased sample :math:`i^\\texttt{th}` central moment, and
-    :math:`\\bar{x}` is the sample mean.  If ``bias`` is False, the
-    calculations are corrected for bias and the value computed is the
-    adjusted Fisher-Pearson standardized moment coefficient, i.e. 
+    is the biased sample :math:`i\\texttt{th}` central moment, and :math:`\\bar{x}` is
+    the sample mean.  If ``bias`` is False, the calculations are
+    corrected for bias and the value computed is the adjusted
+    Fisher-Pearson standardized moment coefficient, i.e. 
     
     .. math:: G_1=\\frac{k_3}{k_2^{3/2}}=
                   \\frac{\\sqrt{N(N-1)}}{N-2}\\frac{m_3}{m_2^{3/2}}.


### PR DESCRIPTION
Since there are a few ways of estimating skewness, it would be helpful to specify which definition is used by scipy in the docstring of scipy.stats.skew.