### PR TITLE
CI: MAINT: Skip a ckdtree test on pypy

### DIFF
--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -3,10 +3,11 @@
 
 from __future__ import division, print_function, absolute_import
 
-from numpy.testing import (assert_equal, assert_array_equal,
-    assert_almost_equal, assert_array_almost_equal, assert_)
+from numpy.testing import (assert_equal, assert_array_equal, assert_,
+                           assert_almost_equal, assert_array_almost_equal)
 from pytest import raises as assert_raises
-
+import pytest
+from platform import python_implementation
 import numpy as np
 from scipy.spatial import KDTree, Rectangle, distance_matrix, cKDTree
 from scipy.spatial.ckdtree import cKDTreeNode
@@ -441,8 +442,8 @@ def test_random_ball_vectorized_compiled():
     r = T.query_ball_point(np.random.randn(2,3,m),1)
     assert_equal(r.shape,(2,3))
     assert_(isinstance(r[0,0],list))
-    
-    
+
+
 def test_query_ball_point_multithreading():
     np.random.seed(0)
     n = 5000
@@ -452,15 +453,15 @@ def test_query_ball_point_multithreading():
     l1 = T.query_ball_point(points,0.003,n_jobs=1)
     l2 = T.query_ball_point(points,0.003,n_jobs=64)
     l3 = T.query_ball_point(points,0.003,n_jobs=-1)
-    
+
     for i in range(n):
         if l1[i] or l2[i]:
             assert_array_equal(l1[i],l2[i])
-        
+
     for i in range(n):
         if l1[i] or l3[i]:
             assert_array_equal(l1[i],l3[i])
-         
+
 
 class two_trees_consistency:
 
@@ -714,7 +715,7 @@ class Test_sparse_distance_matrix_compiled(sparse_distance_matrix_consistency):
         M1 = self.T1.sparse_distance_matrix(self.T2, self.r)
         M2 = self.ref_T1.sparse_distance_matrix(self.ref_T2, self.r)
         assert_array_almost_equal(M1.todense(), M2.todense(), decimal=14)
-        
+
     def test_against_logic_error_regression(self):
         # regression test for gh-5077 logic error
         np.random.seed(0)
@@ -730,7 +731,7 @@ class Test_sparse_distance_matrix_compiled(sparse_distance_matrix_consistency):
             for j in range(self.n):
                 v = self.data1[i,:] - self.data2[j,:]
                 ref[i,j] = np.dot(v,v)
-        ref = np.sqrt(ref)    
+        ref = np.sqrt(ref)
         ref[ref > self.r] = 0.
         # test return type 'dict'
         dist = np.zeros((self.n,self.n))
@@ -740,7 +741,7 @@ class Test_sparse_distance_matrix_compiled(sparse_distance_matrix_consistency):
         assert_array_almost_equal(ref, dist, decimal=14)
         # test return type 'ndarray'
         dist = np.zeros((self.n,self.n))
-        r = self.T1.sparse_distance_matrix(self.T2, self.r, 
+        r = self.T1.sparse_distance_matrix(self.T2, self.r,
             output_type='ndarray')
         for k in range(r.shape[0]):
             i = r['i'][k]
@@ -749,11 +750,11 @@ class Test_sparse_distance_matrix_compiled(sparse_distance_matrix_consistency):
             dist[i,j] = v
         assert_array_almost_equal(ref, dist, decimal=14)
         # test return type 'dok_matrix'
-        r = self.T1.sparse_distance_matrix(self.T2, self.r, 
+        r = self.T1.sparse_distance_matrix(self.T2, self.r,
             output_type='dok_matrix')
         assert_array_almost_equal(ref, r.todense(), decimal=14)
         # test return type 'coo_matrix'
-        r = self.T1.sparse_distance_matrix(self.T2, self.r, 
+        r = self.T1.sparse_distance_matrix(self.T2, self.r,
             output_type='coo_matrix')
         assert_array_almost_equal(ref, r.todense(), decimal=14)
 
@@ -858,11 +859,11 @@ def test_ckdtree_query_pairs():
     l0 = sorted(brute)
     # test default return type
     s = T.query_pairs(r)
-    l1 = sorted(s)    
+    l1 = sorted(s)
     assert_array_equal(l0,l1)
     # test return type 'set'
     s = T.query_pairs(r, output_type='set')
-    l1 = sorted(s)    
+    l1 = sorted(s)
     assert_array_equal(l0,l1)
     # test return type 'ndarray'
     s = set()
@@ -871,8 +872,8 @@ def test_ckdtree_query_pairs():
         s.add((int(arr[i,0]),int(arr[i,1])))
     l2 = sorted(s)
     assert_array_equal(l0,l2)
-    
-    
+
+
 def test_ball_point_ints():
     # Regression test for #1373.
     x, y = np.mgrid[0:4, 0:4]
@@ -942,10 +943,10 @@ def test_ckdtree_pickle_boxsize():
     T1 = T1.query(points, k=5)[-1]
     T2 = T2.query(points, k=5)[-1]
     assert_array_equal(T1, T2)
-    
+
 def test_ckdtree_copy_data():
     # check if copy_data=True makes the kd-tree
-    # impervious to data corruption by modification of 
+    # impervious to data corruption by modification of
     # the data arrray
     np.random.seed(0)
     n = 5000
@@ -957,7 +958,7 @@ def test_ckdtree_copy_data():
     points[...] = np.random.randn(n, k)
     T2 = T.query(q, k=5)[-1]
     assert_array_equal(T1, T2)
-    
+
 def test_ckdtree_parallel():
     # check if parallel=True also generates correct
     # query results
@@ -972,7 +973,7 @@ def test_ckdtree_parallel():
     assert_array_equal(T1, T2)
     assert_array_equal(T1, T3)
 
-def test_ckdtree_view():        
+def test_ckdtree_view():
     # Check that the nodes can be correctly viewed from Python.
     # This test also sanity checks each node in the cKDTree, and
     # thus verifies the internal structure of the kd-tree.
@@ -981,11 +982,11 @@ def test_ckdtree_view():
     k = 4
     points = np.random.randn(n, k)
     kdtree = cKDTree(points)
-    
+
     # walk the whole kd-tree and sanity check each node
     def recurse_tree(n):
-        assert_(isinstance(n, cKDTreeNode)) 
-        if n.split_dim == -1: 
+        assert_(isinstance(n, cKDTreeNode))
+        if n.split_dim == -1:
             assert_(n.lesser is None)
             assert_(n.greater is None)
             assert_(n.indices.shape[0] <= kdtree.leafsize)
@@ -995,7 +996,7 @@ def test_ckdtree_view():
             x = n.lesser.data_points[:, n.split_dim]
             y = n.greater.data_points[:, n.split_dim]
             assert_(x.max() < y.min())
-    
+
     recurse_tree(kdtree.tree)
     # check that indices are correctly retrieved
     n = kdtree.tree
@@ -1058,7 +1059,7 @@ def test_ckdtree_box():
         dd1, ii1 = kdtree.query(data + 1.0, k, p=p)
         assert_almost_equal(dd, dd1)
         assert_equal(ii, ii1)
-        
+
         dd1, ii1 = kdtree.query(data - 1.0, k, p=p)
         assert_almost_equal(dd, dd1)
         assert_equal(ii, ii1)
@@ -1121,7 +1122,10 @@ def simulate_periodic_box(kdtree, data, k, boxsize, p):
     result['dd'][:] = dd
     result.sort(order='dd')
     return result['dd'][:, :k], result['ii'][:,:k]
-    
+
+
+@pytest.mark.skipif(python_implementation() == 'PyPy',
+                    reason="Fails on PyPy CI runs. See #9455")
 def test_ckdtree_memuse():
     # unit test adaptation of gh-5630
 
@@ -1177,13 +1181,13 @@ def test_ckdtree_weights():
     for i in range(10):
         # since weights are uniform, these shall agree:
         c1 = tree1.count_neighbors(tree1, np.linspace(0, 10, i))
-        c2 = tree1.count_neighbors(tree1, np.linspace(0, 10, i), 
+        c2 = tree1.count_neighbors(tree1, np.linspace(0, 10, i),
                 weights=(weights, weights))
-        c3 = tree1.count_neighbors(tree1, np.linspace(0, 10, i), 
+        c3 = tree1.count_neighbors(tree1, np.linspace(0, 10, i),
                 weights=(weights, None))
-        c4 = tree1.count_neighbors(tree1, np.linspace(0, 10, i), 
+        c4 = tree1.count_neighbors(tree1, np.linspace(0, 10, i),
                 weights=(None, weights))
-        c5 = tree1.count_neighbors(tree1, np.linspace(0, 10, i), 
+        c5 = tree1.count_neighbors(tree1, np.linspace(0, 10, i),
                 weights=weights)
 
         assert_array_equal(c1, c2)
@@ -1222,12 +1226,12 @@ def test_ckdtree_count_neighbous_multiple_r():
     nnc = kdtree.count_neighbors(kdtree, r0, cumulative=False)
     assert_equal(n0, nnc.cumsum())
 
-    for i, r in zip(itertools.permutations(i0), 
+    for i, r in zip(itertools.permutations(i0),
                     itertools.permutations(r0)):
-        # permute n0 by i and it shall agree 
+        # permute n0 by i and it shall agree
         n = kdtree.count_neighbors(kdtree, r)
         assert_array_equal(n, n0[list(i)])
-    
+
 def test_len0_arrays():
     # make sure len-0 arrays are handled correctly
     # in range queries (gh-5639)
@@ -1276,7 +1280,7 @@ def test_len0_arrays():
 
 def test_ckdtree_duplicated_inputs():
     # check ckdtree with duplicated inputs
-    n = 1024 
+    n = 1024
     for m in range(1, 8):
         data = np.concatenate([
             np.ones((n // 2, m)) * 1,

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -1125,7 +1125,7 @@ def simulate_periodic_box(kdtree, data, k, boxsize, p):
 
 
 @pytest.mark.skipif(python_implementation() == 'PyPy',
-                    reason="Fails on PyPy CI runs. See #9455")
+                    reason="Fails on PyPy CI runs. See #9507")
 def test_ckdtree_memuse():
     # unit test adaptation of gh-5630
 


### PR DESCRIPTION
As per discussion on #9455, one of the ckdtree tests are skipped. The PR became noisy after auto-removal of the spurious spaces. The change is around line no.1127