### PR TITLE
TST: test_random_sampling 32-bit handling

### DIFF
--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -2,6 +2,7 @@
 
 from __future__ import division, print_function, absolute_import
 
+import sys
 import numpy as np
 from numpy import array, matrix
 from numpy.testing import (assert_equal, assert_,
@@ -9,6 +10,7 @@ from numpy.testing import (assert_equal, assert_,
 import pytest
 from pytest import raises as assert_raises
 from scipy._lib._testutils import check_free_memory
+from scipy._lib._version import NumpyVersion
 
 from scipy.sparse import csr_matrix, coo_matrix
 
@@ -420,6 +422,9 @@ class TestConstructUtils(object):
         assert_equal(construct.block_diag([1]).todense(),
                      matrix([[1]]))
 
+    @pytest.mark.xfail((NumpyVersion(np.__version__) < "1.11.0" and
+                        sys.maxsize <= 2**32),
+                       reason="randint not compatible")
     def test_random_sampling(self):
         # Simple sanity checks for sparse random sampling.
         for f in sprand, _sprandn:


### PR DESCRIPTION
The 6 master branch wheel build failures [observed on Travis CI](https://travis-ci.org/MacPython/scipy-wheels/builds/458048253) fall into two categories:

1. `test_random_sampling` fails on 32-bit interpreter with NumPy `1.8.2.`
2.  `wheelhouse_uploader` seems to take too long, but all unit tests pass

The objective of this PR is to address the first point above, on the assumption that the second is out of our control, to get the Travis wheel builds green for SciPy master.

Note that a local build with NumPy `1.8.2` allows the test to pass with 64-bit interpreter, so 32-bit interpreter only with really old NumPy versions doesn't seem like too serious an xfail.