### PR TITLE
BUG: improve error handling in stats.iqr

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -2483,6 +2483,9 @@ def iqr(x, axis=None, rng=(25, 75), scale='raw', nan_policy='propagate',
     if len(rng) != 2:
         raise TypeError("quantile range must be two element sequence")
 
+    if np.isnan(rng).any():
+        raise ValueError("range must not contain NaNs")
+
     rng = sorted(rng)
     pct = percentile_func(x, rng, axis=axis, interpolation=interpolation,
                           keepdims=keepdims, contains_nan=contains_nan)


### PR DESCRIPTION
Add missing check for NaNs in rng which is expected by TestIQR.test_rng
test.

Closes #9516.