### PR TITLE
BUG: SuperLU 'NATURAL' order applies a column permutation

### DIFF
--- a/scipy/sparse/linalg/dsolve/linsolve.py
+++ b/scipy/sparse/linalg/dsolve/linsolve.py
@@ -321,6 +321,11 @@ def splu(A, permc_spec=None, diag_pivot_thresh=None,
                     PanelSize=panel_size, Relax=relax)
     if options is not None:
         _options.update(options)
+
+    # Ensure no column permutations applied
+    if (_options["ColPerm"] == "NATURAL"):
+        _options["SymmetricMode"] = True
+
     return _superlu.gstrf(N, A.nnz, A.data, A.indices, A.indptr,
                           csc_construct_func=csc_construct_func,
                           ilu=False, options=_options)
@@ -407,6 +412,11 @@ def spilu(A, drop_tol=None, fill_factor=None, drop_rule=None, permc_spec=None,
                     PanelSize=panel_size, Relax=relax)
     if options is not None:
         _options.update(options)
+
+    # Ensure no column permutations applied
+    if (_options["ColPerm"] == "NATURAL"):
+        _options["SymmetricMode"] = True
+
     return _superlu.gstrf(N, A.nnz, A.data, A.indices, A.indptr,
                           csc_construct_func=csc_construct_func,
                           ilu=True, options=_options)

--- a/scipy/sparse/linalg/dsolve/linsolve.py
+++ b/scipy/sparse/linalg/dsolve/linsolve.py
@@ -322,7 +322,7 @@ def splu(A, permc_spec=None, diag_pivot_thresh=None,
     if options is not None:
         _options.update(options)
 
-    # Ensure no column permutations applied
+    # Ensure that no column permutations are applied
     if (_options["ColPerm"] == "NATURAL"):
         _options["SymmetricMode"] = True
 

--- a/scipy/sparse/linalg/dsolve/linsolve.py
+++ b/scipy/sparse/linalg/dsolve/linsolve.py
@@ -413,7 +413,7 @@ def spilu(A, drop_tol=None, fill_factor=None, drop_rule=None, permc_spec=None,
     if options is not None:
         _options.update(options)
 
-    # Ensure no column permutations applied
+    # Ensure that no column permutations are applied
     if (_options["ColPerm"] == "NATURAL"):
         _options["SymmetricMode"] = True
 

--- a/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
@@ -547,29 +547,30 @@ class TestSplu(object):
         lu = splu(a_)
         assert_array_equal(lu.perm_r, lu.perm_c)
 
-    def test_splu_natural_permc(self):
+    @pytest.mark.parametrize("splu_fun, rtol", [(splu, 1e-7), (spilu, 1e-1)])
+    def test_natural_permc(self, splu_fun, rtol):
         # Test that the "NATURAL" permc_spec does not permute the matrix
-        n = 1000
+        np.random.seed(42)
+        n = 500
         p = 0.01
-        a = scipy.sparse.random(n,n,p)
-        # Make a diagonal dominant, to make sure it is not singular
-        a += (n+1)*scipy.sparse.identity(n)
-        a_ = csc_matrix(a)
-        lu = splu(a_, permc_spec = "NATURAL")
-        # Assert that output col permutations are sequential ordering
-        assert_(np.all(lu.perm_c == np.arange(n)))
+        A = scipy.sparse.random(n, n, p)
+        x = np.random.rand(n)
+        # Make A diagonal dominant to make sure it is not singular
+        A += (n+1)*scipy.sparse.identity(n)
+        A_ = csc_matrix(A)
+        b = A_ @ x
 
-    def test_spilu_natural_permc(self):
-        # Test that the "NATURAL" permc_spec does not permute the matrix
-        n = 1000
-        p = 0.01
-        a = scipy.sparse.random(n,n,p)
-        # Make a diagonal dominant, to make sure it is not singular
-        a += (n+1)*scipy.sparse.identity(n)
-        a_ = csc_matrix(a)
-        lu = spilu(a_, permc_spec = "NATURAL")
-        # Assert that output col permutations are sequential ordering
-        assert_(np.all(lu.perm_c == np.arange(n)))
+        # without permc_spec, permutation is not identity
+        lu = splu_fun(A_)
+        assert_(np.any(lu.perm_c != np.arange(n)))
+
+        # with permc_spec="NATURAL", permutation is identity
+        lu = splu_fun(A_, permc_spec="NATURAL")
+        assert_array_equal(lu.perm_c, np.arange(n))
+
+        # Also, lu decomposition is valid
+        x2 = lu.solve(b)
+        assert_allclose(x, x2, rtol=rtol)
 
     @pytest.mark.skipif(not hasattr(sys, 'getrefcount'), reason="no sys.getrefcount")
     def test_lu_refcount(self):

--- a/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
@@ -557,7 +557,7 @@ class TestSplu(object):
         a_ = csc_matrix(a)
         lu = splu(a_, permc_spec = "NATURAL")
         # Assert that output col permutations are sequential ordering
-        assert_(np.all(lu.perm_c==np.arange(n)))
+        assert_(np.all(lu.perm_c == np.arange(n)))
 
     def test_spilu_natural_permc(self):
         # Test that the "NATURAL" permc_spec does not permute the matrix
@@ -569,7 +569,7 @@ class TestSplu(object):
         a_ = csc_matrix(a)
         lu = spilu(a_, permc_spec = "NATURAL")
         # Assert that output col permutations are sequential ordering
-        assert_(np.all(lu.perm_c==np.arange(n)))
+        assert_(np.all(lu.perm_c == np.arange(n)))
 
     @pytest.mark.skipif(not hasattr(sys, 'getrefcount'), reason="no sys.getrefcount")
     def test_lu_refcount(self):

--- a/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
@@ -547,6 +547,30 @@ class TestSplu(object):
         lu = splu(a_)
         assert_array_equal(lu.perm_r, lu.perm_c)
 
+    def test_splu_natural_permc(self):
+        # Test that the "NATURAL" permc_spec does not permute the matrix
+        n = 1000
+        p = 0.01
+        a = scipy.sparse.random(n,n,p)
+        # Make a diagonal dominant, to make sure it is not singular
+        a += (n+1)*scipy.sparse.identity(n)
+        a_ = csc_matrix(a)
+        lu = splu(a_, permc_spec = "NATURAL")
+        # Assert that output col permutations are sequential ordering
+        assert_(np.all(lu.perm_c==np.arange(n)))
+
+    def test_spilu_natural_permc(self):
+        # Test that the "NATURAL" permc_spec does not permute the matrix
+        n = 1000
+        p = 0.01
+        a = scipy.sparse.random(n,n,p)
+        # Make a diagonal dominant, to make sure it is not singular
+        a += (n+1)*scipy.sparse.identity(n)
+        a_ = csc_matrix(a)
+        lu = spilu(a_, permc_spec = "NATURAL")
+        # Assert that output col permutations are sequential ordering
+        assert_(np.all(lu.perm_c==np.arange(n)))
+
     @pytest.mark.skipif(not hasattr(sys, 'getrefcount'), reason="no sys.getrefcount")
     def test_lu_refcount(self):
         # Test that we are keeping track of the reference count with splu.


### PR DESCRIPTION
When using perm_c="NATURAL" in splu and spilu, the column ordering of a SuperLU
factorization is not preserved. This patch sets appropriate options to pass
into SuperLU so that the column ordering is preserved.

Row permutations for partial pivoting can still be performed.

Fix #7700, #8795