### PR TITLE
DOC: fix missing random seed in optimize.newton example

### DIFF
--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -230,6 +230,7 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
 
     >>> f = lambda x, a: x**3 - a
     >>> fder = lambda x, a: 3 * x**2
+    >>> np.random.seed(4321)
     >>> x = np.random.randn(100)
     >>> a = np.arange(-50, 50)
     >>> vec_res = optimize.newton(f, x, fprime=fder, args=(a, ))


### PR DESCRIPTION
This was giving occasional CI failures (e.g. https://travis-ci.org/scipy/scipy/jobs/458735190) in the refguide check that looked like:

```
scipy.optimize.newton
---------------------
/home/travis/build/scipy/scipy/build/testenv/lib/python3.6/site-packages/scipy/optimize/zeros.py:439: RuntimeWarning: some failed to converge after 50 iterations
  warnings.warn(msg, RuntimeWarning)
File "build/testenv/lib/python3.6/site-packages/scipy/optimize/zeros.py", line 242, in newton
Failed example:
    np.allclose(vec_res, loop_res)
Expected:
    True
Got:
    False
```