### PR TITLE
MAINT Use set literals

### DIFF
--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -2348,7 +2348,7 @@ def _check_hierarchy_uses_cluster_before_formed(Z):
 
 def _check_hierarchy_uses_cluster_more_than_once(Z):
     n = Z.shape[0] + 1
-    chosen = set([])
+    chosen = set()
     for i in xrange(0, n - 1):
         if (Z[i, 0] in chosen) or (Z[i, 1] in chosen) or Z[i, 0] == Z[i, 1]:
             return True
@@ -2359,7 +2359,7 @@ def _check_hierarchy_uses_cluster_more_than_once(Z):
 
 def _check_hierarchy_not_all_clusters_used(Z):
     n = Z.shape[0] + 1
-    chosen = set([])
+    chosen = set()
     for i in xrange(0, n - 1):
         chosen.add(int(Z[i, 0]))
         chosen.add(int(Z[i, 1]))
@@ -2826,7 +2826,7 @@ def _remove_dups(L):
 
     The set class is not guaranteed to do this.
     """
-    seen_before = set([])
+    seen_before = set()
     L2 = []
     for i in L:
         if i not in seen_before:

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -569,7 +569,7 @@ def test_save_dict():
         savemat(stream, {'dict': d})
         stream.seek(0)
         vals = loadmat(stream)['dict']
-        assert_equal(set(vals.dtype.names), set(['a', 'b']))
+        assert_equal(set(vals.dtype.names), {'a', 'b'})
         if is_ordered:  # Input was ordered, output in ab order
             assert_array_equal(vals, ab_exp)
         else:  # Not ordered input, either order output

--- a/scipy/io/matlab/tests/test_pathological.py
+++ b/scipy/io/matlab/tests/test_pathological.py
@@ -20,8 +20,8 @@ def test_multiple_fieldnames():
     multi_fname = pjoin(TEST_DATA_PATH, 'nasty_duplicate_fieldnames.mat')
     vars = loadmat(multi_fname)
     funny_names = vars['Summary'].dtype.names
-    assert_(set(['_1_Station_Q', '_2_Station_Q',
-                     '_3_Station_Q']).issubset(funny_names))
+    assert_({'_1_Station_Q', '_2_Station_Q',
+             '_3_Station_Q'}.issubset(funny_names))
 
 
 def test_malformed1():

--- a/scipy/ndimage/src/_ni_label.pyx
+++ b/scipy/ndimage/src/_ni_label.pyx
@@ -218,7 +218,7 @@ cpdef _label(np.ndarray input,
          "{:d} != {:d}".format(input.ndim, structure.ndim))
 
     # Check that structuring element is of size 3 in every dimension
-    assert set((<object> structure).shape) <= set([3]), \
+    assert set((<object> structure).shape) <= {3}, \
         ("Structuring element must be size 3 in every dimension, "
          "was {}".format((<object> structure).shape))
 

--- a/scipy/ndimage/utils/generate_label_testvectors.py
+++ b/scipy/ndimage/utils/generate_label_testvectors.py
@@ -32,7 +32,7 @@ def generate_test_vecs(infile, strelfile, resultfile):
     strels = strels + [np.flipud(s) for s in strels]
     strels = strels + [np.rot90(s) for s in strels]
     strels = [np.fromstring(s, dtype=int).reshape((3, 3))
-              for s in set(t.astype(int).tostring() for t in strels)]
+              for s in {t.astype(int).tostring() for t in strels}]
     inputs = np.vstack(data)
     results = np.vstack([label(d, s)[0] for d in data for s in strels])
     strels = np.vstack(strels)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -831,8 +831,8 @@ class _TestCommon(object):
         A = array([[1, 0, 1],[0, 1, 1],[0, 0, 1]])
         Asp = self.spmatrix(A)
 
-        A_nz = set([tuple(ij) for ij in transpose(A.nonzero())])
-        Asp_nz = set([tuple(ij) for ij in transpose(Asp.nonzero())])
+        A_nz = {tuple(ij) for ij in transpose(A.nonzero())}
+        Asp_nz = {tuple(ij) for ij in transpose(Asp.nonzero())}
 
         assert_equal(A_nz, Asp_nz)
 
@@ -841,8 +841,8 @@ class _TestCommon(object):
         A = array([[1, 0, 1], [0, 1, 1], [0, 0, 1]])
         Asp = self.spmatrix(A)
 
-        A_nz = set([tuple(ij) for ij in transpose(np.nonzero(A))])
-        Asp_nz = set([tuple(ij) for ij in transpose(np.nonzero(Asp))])
+        A_nz = {tuple(ij) for ij in transpose(np.nonzero(A))}
+        Asp_nz = {tuple(ij) for ij in transpose(np.nonzero(Asp))}
 
         assert_equal(A_nz, Asp_nz)
 

--- a/scipy/spatial/qhull.pyx
+++ b/scipy/spatial/qhull.pyx
@@ -294,7 +294,7 @@ cdef class _Qhull:
             option_set.update(required_option_set)
 
         if incremental:
-            incremental_bad_ops = set([b'Qbb', b'Qbk', b'QBk', b'QbB', b'Qz'])
+            incremental_bad_ops = {b'Qbb', b'Qbk', b'QBk', b'QbB', b'Qz'}
             bad_opts = []
             for bad_opt in incremental_bad_ops:
                 if bad_opt in options:

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -1672,7 +1672,7 @@ class TestNumObsY(object):
     def test_num_obs_y_2_100(self):
         # Tests num_obs_y(y) on 100 improper condensed distance matrices.
         # Expecting exception.
-        a = set([])
+        a = set()
         for n in xrange(2, 16):
             a.add(n * (n - 1) / 2)
         for i in xrange(5, 105):

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -871,7 +871,7 @@ class TestVoronoi:
 
             def remap(x):
                 if hasattr(x, '__len__'):
-                    return tuple(set([remap(y) for y in x]))
+                    return tuple({remap(y) for y in x})
                 try:
                     return vertex_map[x]
                 except KeyError:

--- a/scipy/special/_generate_pyx.py
+++ b/scipy/special/_generate_pyx.py
@@ -215,7 +215,7 @@ def cast_order(c):
 
 # These downcasts will cause the function to return NaNs, unless the
 # values happen to coincide exactly.
-DANGEROUS_DOWNCAST = set([
+DANGEROUS_DOWNCAST = {
     ('F', 'i'), ('F', 'l'), ('F', 'f'), ('F', 'd'), ('F', 'g'),
     ('D', 'i'), ('D', 'l'), ('D', 'f'), ('D', 'd'), ('D', 'g'),
     ('G', 'i'), ('G', 'l'), ('G', 'f'), ('G', 'd'), ('G', 'g'),
@@ -223,7 +223,7 @@ DANGEROUS_DOWNCAST = set([
     ('d', 'i'), ('d', 'l'),
     ('g', 'i'), ('g', 'l'),
     ('l', 'i'),
-])
+}
 
 NAN_VALUE = {
     'f': 'NPY_NAN',

--- a/scipy/special/utils/makenpz.py
+++ b/scipy/special/utils/makenpz.py
@@ -43,7 +43,7 @@ def main():
         try:
             old_data = np.load(outp)
             try:
-                changed = set(old_data.keys()) != set(key for key, _ in files)
+                changed = set(old_data.keys()) != {key for key, _ in files}
             finally:
                 old_data.close()
         except (IOError, OSError):

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -59,13 +59,13 @@ distslow = ['kappa4', 'rdist', 'gausshyper',
 # Here 'fail' mean produce wrong results and/or raise exceptions, depending
 # on the implementation details of corresponding special functions.
 # cf https://github.com/scipy/scipy/pull/4979 for a discussion.
-fails_cmplx = set(['beta', 'betaprime', 'chi', 'chi2', 'dgamma', 'dweibull',
-                   'erlang', 'f', 'gamma', 'gausshyper', 'gengamma',
-                   'gennorm', 'genpareto', 'halfgennorm', 'invgamma',
-                   'ksone', 'kstwobign', 'levy_l', 'loggamma', 'logistic',
-                   'maxwell', 'nakagami', 'ncf', 'nct', 'ncx2', 'norminvgauss',
-                   'pearson3', 'rice', 't', 'skewnorm', 'tukeylambda',
-                   'vonmises', 'vonmises_line', 'rv_histogram_instance'])
+fails_cmplx = {'beta', 'betaprime', 'chi', 'chi2', 'dgamma', 'dweibull',
+               'erlang', 'f', 'gamma', 'gausshyper', 'gengamma',
+               'gennorm', 'genpareto', 'halfgennorm', 'invgamma',
+               'ksone', 'kstwobign', 'levy_l', 'loggamma', 'logistic',
+               'maxwell', 'nakagami', 'ncf', 'nct', 'ncx2', 'norminvgauss',
+               'pearson3', 'rice', 't', 'skewnorm', 'tukeylambda',
+               'vonmises', 'vonmises_line', 'rv_histogram_instance'}
 
 _h = np.histogram([1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5, 6,
                    6, 6, 6, 7, 7, 7, 8, 8, 9], bins=8)
@@ -172,8 +172,8 @@ def test_levy_stable_random_state_property():
 
 
 def cases_test_moments():
-    fail_normalization = set(['vonmises', 'ksone'])
-    fail_higher = set(['vonmises', 'ksone', 'ncf'])
+    fail_normalization = {'vonmises', 'ksone'}
+    fail_higher = {'vonmises', 'ksone', 'ncf'}
 
     for distname, arg in distcont[:] + [(histogram_test_instance, tuple())]:
         if distname == 'levy_stable':

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -107,13 +107,13 @@ OTHER_MODULE_DOCS = {
 
 # these names are known to fail doctesting and we like to keep it that way
 # e.g. sometimes pseudocode is acceptable etc
-DOCTEST_SKIPLIST = set([
+DOCTEST_SKIPLIST = {
     'scipy.stats.kstwobign', # inaccurate cdf or ppf
     'scipy.stats.levy_stable',
     'scipy.special.sinc', # comes from numpy
     'scipy.misc.who', # comes from numpy
     'io.rst',   # XXX: need to figure out how to deal w/ mat files
-])
+}
 
 # these names are not required to be present in ALL despite being in
 # autosummary:: listing
@@ -320,12 +320,12 @@ def validate_rst_syntax(text, name, dots=True):
             output_dot('E')
         return False, "ERROR: %s: no documentation" % (name,)
 
-    ok_unknown_items = set([
+    ok_unknown_items = {
         'mod', 'currentmodule', 'autosummary', 'data',
         'obj', 'versionadded', 'versionchanged', 'module', 'class',
         'ref', 'func', 'toctree', 'moduleauthor',
         'sectionauthor', 'codeauthor', 'eq', 'doi', 'DOI', 'arXiv', 'arxiv'
-    ])
+    }
 
     # Run through docutils
     error_stream = io.StringIO()
@@ -783,10 +783,10 @@ def check_doctests_testfile(fname, verbose, ns=None,
         with open(fname, encoding='utf-8') as f:
             text = f.read()
 
-    PSEUDOCODE = set(['some_function', 'some_module', 'import example',
-                      'ctypes.CDLL',     # likely need compiling, skip it
-                      'integrate.nquad(func,'  # ctypes integrate tutotial
-    ])
+    PSEUDOCODE = {'some_function', 'some_module', 'import example',
+                  'ctypes.CDLL',     # likely need compiling, skip it
+                  'integrate.nquad(func,'  # ctypes integrate tutotial
+    }
 
     # split the text into "blocks" and try to detect and omit pseudocode blocks.
     parser = doctest.DocTestParser()


### PR DESCRIPTION
Set literals (and set comprehension) were added in Python 2.7. They are a bit more readable and [faster](https://renzo.lucioni.xyz/pythons-set-literals/) than alternative methods for `set` creation. This uses them when possible.