### PR TITLE
TST: backport gh-9493 to 1.2.x branch

### DIFF
--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -1157,7 +1157,7 @@ class TestPdist(object):
         _assert_within_tol(Y_test1, Y_right, eps, verbose > 2)
 
     def test_pdist_jensenshannon_iris_nonC(self):
-        eps = 5e-13
+        eps = 5e-12
         X = eo['iris']
         Y_right = eo['pdist-jensenshannon-iris']
         Y_test2 = pdist(X, 'test_jensenshannon')


### PR DESCRIPTION
Backport gh-9493

With both [Travis](https://travis-ci.org/MacPython/scipy-wheels/builds/458994594) and [Appveyor](https://ci.appveyor.com/project/scipy/scipy-wheels/builds/20519928) wheel build CI runs now finally green (for the first time in 2+ months) on the master branch after a set of PRs, this is the first of a few backport PRs to enable the same wheel building fixes in the `1.2.x` maintenance branch, so that I may eventually proceed with the somewhat-delayed release candidate process.