### PR TITLE
MAINT: Use list comprehension when possible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
         - NUMPYSPEC="--upgrade numpy"
       before_install:
         - pip install pycodestyle==2.3.1
-        - pip install pyflakes==2.0.0
+        - pip install pyflakes==1.1.0
       script:
         - PYFLAKES_NODOCTEST=1 pyflakes scipy benchmarks/benchmarks | grep -E -v 'unable to detect undefined names|assigned to but never used|imported but unused|redefinition of unused|may be undefined, or defined from star imports' > test.out; cat test.out; test \! -s test.out
         - pycodestyle scipy benchmarks/benchmarks

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
         - NUMPYSPEC="--upgrade numpy"
       before_install:
         - pip install pycodestyle==2.3.1
-        - pip install pyflakes==1.1.0
+        - pip install pyflakes==2.0.0
       script:
         - PYFLAKES_NODOCTEST=1 pyflakes scipy benchmarks/benchmarks | grep -E -v 'unable to detect undefined names|assigned to but never used|imported but unused|redefinition of unused|may be undefined, or defined from star imports' > test.out; cat test.out; test \! -s test.out
         - pycodestyle scipy benchmarks/benchmarks

--- a/scipy/_lib/decorator.py
+++ b/scipy/_lib/decorator.py
@@ -392,9 +392,8 @@ def dispatch_on(*dispatch_args):
             An utility to introspect the dispatch algorithm
             """
             check(types)
-            lst = []
-            for anc in itertools.product(*ancestors(*types)):
-                lst.append(tuple(a.__name__ for a in anc))
+            lst = [tuple(a.__name__ for a in anc)
+                   for anc in itertools.product(*ancestors(*types))]
             return lst
 
         def _dispatch(dispatch_args, *args, **kw):

--- a/scipy/integrate/_ivp/ivp.py
+++ b/scipy/integrate/_ivp/ivp.py
@@ -105,9 +105,8 @@ def handle_events(sol, events, active_events, is_terminal, t_old, t):
     terminate : bool
         Whether a terminal event occurred.
     """
-    roots = []
-    for event_index in active_events:
-        roots.append(solve_event_equation(events[event_index], sol, t_old, t))
+    roots = [solve_event_equation(events[event_index], sol, t_old, t)
+             for event_index in active_events]
 
     roots = np.asarray(roots)
 

--- a/scipy/integrate/tests/test_banded_ode_solvers.py
+++ b/scipy/integrate/tests/test_banded_ode_solvers.py
@@ -36,9 +36,7 @@ def _linear_jac(t, y, a):
 def _linear_banded_jac(t, y, a):
     """Banded Jacobian."""
     ml, mu = _band_count(a)
-    bjac = []
-    for k in range(mu, 0, -1):
-        bjac.append(np.r_[[0] * k, np.diag(a, k)])
+    bjac = [np.r_[[0] * k, np.diag(a, k)] for k in range(mu, 0, -1)]
     bjac.append(np.diag(a))
     for k in range(-1, -ml-1, -1):
         bjac.append(np.r_[np.diag(a, k), [0] * (-k)])

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -2501,9 +2501,8 @@ class RegularGridInterpolator(object):
         return values
 
     def _evaluate_nearest(self, indices, norm_distances, out_of_bounds):
-        idx_res = []
-        for i, yi in zip(indices, norm_distances):
-            idx_res.append(np.where(yi <= .5, i, i + 1))
+        idx_res = [np.where(yi <= .5, i, i + 1)
+                   for i, yi in zip(indices, norm_distances)]
         return self.values[tuple(idx_res)]
 
     def _find_indices(self, xi):

--- a/scipy/io/idl.py
+++ b/scipy/io/idl.py
@@ -395,17 +395,13 @@ def _read_record(f):
     elif record['rectype'] == "HEAP_HEADER":
 
         record['nvalues'] = _read_long(f)
-        record['indices'] = []
-        for i in range(record['nvalues']):
-            record['indices'].append(_read_long(f))
+        record['indices'] = [_read_long(f) for i in range(record['nvalues'])]
 
     elif record['rectype'] == "COMMONBLOCK":
 
         record['nvars'] = _read_long(f)
         record['name'] = _read_string(f)
-        record['varnames'] = []
-        for i in range(record['nvars']):
-            record['varnames'].append(_read_string(f))
+        record['varnames'] = [_read_string(f) for i in range(record['nvars'])]
 
     elif record['rectype'] == "END_MARKER":
 
@@ -466,9 +462,7 @@ def _read_arraydesc(f):
 
         arraydesc['nmax'] = _read_long(f)
 
-        arraydesc['dims'] = []
-        for d in range(arraydesc['nmax']):
-            arraydesc['dims'].append(_read_long(f))
+        arraydesc['dims'] = [_read_long(f) for d in range(arraydesc['nmax'])]
 
     elif arraydesc['arrstart'] == 18:
 
@@ -518,32 +512,27 @@ def _read_structdesc(f):
 
     if not structdesc['predef']:
 
-        structdesc['tagtable'] = []
-        for t in range(structdesc['ntags']):
-            structdesc['tagtable'].append(_read_tagdesc(f))
+        structdesc['tagtable'] = [_read_tagdesc(f)
+                                  for t in range(structdesc['ntags'])]
 
         for tag in structdesc['tagtable']:
             tag['name'] = _read_string(f)
 
-        structdesc['arrtable'] = {}
-        for tag in structdesc['tagtable']:
-            if tag['array']:
-                structdesc['arrtable'][tag['name']] = _read_arraydesc(f)
+        structdesc['arrtable'] = {tag['name']: _read_arraydesc(f)
+                                  for tag in structdesc['tagtable']
+                                  if tag['array']}
 
-        structdesc['structtable'] = {}
-        for tag in structdesc['tagtable']:
-            if tag['structure']:
-                structdesc['structtable'][tag['name']] = _read_structdesc(f)
+        structdesc['structtable'] = {tag['name']: _read_structdesc(f)
+                                     for tag in structdesc['tagtable']
+                                     if tag['structure']}
 
         if structdesc['inherits'] or structdesc['is_super']:
             structdesc['classname'] = _read_string(f)
             structdesc['nsupclasses'] = _read_long(f)
-            structdesc['supclassnames'] = []
-            for s in range(structdesc['nsupclasses']):
-                structdesc['supclassnames'].append(_read_string(f))
-            structdesc['supclasstable'] = []
-            for s in range(structdesc['nsupclasses']):
-                structdesc['supclasstable'].append(_read_structdesc(f))
+            structdesc['supclassnames'] = [
+                _read_string(f) for s in range(structdesc['nsupclasses'])]
+            structdesc['supclasstable'] = [
+                _read_structdesc(f) for s in range(structdesc['nsupclasses'])]
 
         STRUCT_DICT[structdesc['name']] = structdesc
 

--- a/scipy/io/idl.py
+++ b/scipy/io/idl.py
@@ -395,13 +395,13 @@ def _read_record(f):
     elif record['rectype'] == "HEAP_HEADER":
 
         record['nvalues'] = _read_long(f)
-        record['indices'] = [_read_long(f) for i in range(record['nvalues'])]
+        record['indices'] = [_read_long(f) for _ in range(record['nvalues'])]
 
     elif record['rectype'] == "COMMONBLOCK":
 
         record['nvars'] = _read_long(f)
         record['name'] = _read_string(f)
-        record['varnames'] = [_read_string(f) for i in range(record['nvars'])]
+        record['varnames'] = [_read_string(f) for _ in range(record['nvars'])]
 
     elif record['rectype'] == "END_MARKER":
 
@@ -462,7 +462,7 @@ def _read_arraydesc(f):
 
         arraydesc['nmax'] = _read_long(f)
 
-        arraydesc['dims'] = [_read_long(f) for d in range(arraydesc['nmax'])]
+        arraydesc['dims'] = [_read_long(f) for _ in range(arraydesc['nmax'])]
 
     elif arraydesc['arrstart'] == 18:
 
@@ -513,7 +513,7 @@ def _read_structdesc(f):
     if not structdesc['predef']:
 
         structdesc['tagtable'] = [_read_tagdesc(f)
-                                  for t in range(structdesc['ntags'])]
+                                  for _ in range(structdesc['ntags'])]
 
         for tag in structdesc['tagtable']:
             tag['name'] = _read_string(f)
@@ -530,9 +530,9 @@ def _read_structdesc(f):
             structdesc['classname'] = _read_string(f)
             structdesc['nsupclasses'] = _read_long(f)
             structdesc['supclassnames'] = [
-                _read_string(f) for s in range(structdesc['nsupclasses'])]
+                _read_string(f) for _ in range(structdesc['nsupclasses'])]
             structdesc['supclasstable'] = [
-                _read_structdesc(f) for s in range(structdesc['nsupclasses'])]
+                _read_structdesc(f) for _ in range(structdesc['nsupclasses'])]
 
         STRUCT_DICT[structdesc['name']] = structdesc
 

--- a/scipy/io/matlab/mio5_utils.pyx
+++ b/scipy/io/matlab/mio5_utils.pyx
@@ -611,9 +611,7 @@ cdef class VarReader5:
             raise ValueError('Too many dimensions (%d) for numpy arrays'
                              % header.n_dims)
         # convert dims to list
-        header.dims = []
-        for i in range(header.n_dims):
-            header.dims.append(header.dims_ptr[i])
+        header.dims = [header.dims_ptr[i] for i in range(header.n_dims)]
         header.name = self.read_int8_string()
         return header
 

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -311,9 +311,8 @@ def _whos_check_case(name, files, case, classes):
 
         whos = whosmat(file_name)
 
-        expected_whos = []
-        for k, expected in case.items():
-            expected_whos.append((k, expected.shape, classes[k]))
+        expected_whos = [
+            (k, expected.shape, classes[k]) for k, expected in case.items()]
 
         whos.sort()
         expected_whos.sort()

--- a/scipy/linalg/tests/test_decomp_update.py
+++ b/scipy/linalg/tests/test_decomp_update.py
@@ -81,11 +81,10 @@ def nonitemsize_strides(arrs):
         out.append(c)
     return out
 
+
 def make_nonnative(arrs):
-    out = []
-    for a in arrs:
-        out.append(a.astype(a.dtype.newbyteorder()))
-    return out
+    return [a.astype(a.dtype.newbyteorder()) for a in arrs]
+
 
 class BaseQRdeltas(object):
     def setup_method(self):

--- a/scipy/optimize/_shgo.py
+++ b/scipy/optimize/_shgo.py
@@ -1097,9 +1097,7 @@ class SHGO(object):
         cbounds : list of lists
             List of size dim with length-2 list of bounds for each dimension
         """
-        cbounds = []
-        for x_b_i in self.bounds:
-            cbounds.append([x_b_i[0], x_b_i[1]])
+        cbounds = [[x_b_i[0], x_b_i[1]] for x_b_i in self.bounds]
 
         return cbounds
 

--- a/scipy/optimize/_trustregion_constr/canonical_constraint.py
+++ b/scipy/optimize/_trustregion_constr/canonical_constraint.py
@@ -99,8 +99,7 @@ class CanonicalConstraint(object):
         must have their Jacobians in the same format.
         """
         def fun(x):
-            eq_all, ineq_all = zip(
-                    *[c.fun(x) for c in canonical_constraints])
+            eq_all, ineq_all = zip(*[c.fun(x) for c in canonical_constraints])
 
             return np.hstack(eq_all), np.hstack(ineq_all)
 
@@ -110,8 +109,7 @@ class CanonicalConstraint(object):
             vstack = np.vstack
 
         def jac(x):
-            eq_all, ineq_all = zip(
-                    *[c.jac(x) for c in canonical_constraints])
+            eq_all, ineq_all = zip(*[c.jac(x) for c in canonical_constraints])
             return vstack(eq_all), vstack(ineq_all)
 
         def hess(x, v_eq, v_ineq):

--- a/scipy/optimize/_trustregion_constr/canonical_constraint.py
+++ b/scipy/optimize/_trustregion_constr/canonical_constraint.py
@@ -99,7 +99,11 @@ class CanonicalConstraint(object):
         must have their Jacobians in the same format.
         """
         def fun(x):
-            eq_all, ineq_all = zip(*[c.fun(x) for c in canonical_constraints])
+            if canonical_constraints:
+                eq_all, ineq_all = zip(
+                        *[c.fun(x) for c in canonical_constraints])
+            else:
+                eq_all, ineq_all = [], []
 
             return np.hstack(eq_all), np.hstack(ineq_all)
 
@@ -109,7 +113,12 @@ class CanonicalConstraint(object):
             vstack = np.vstack
 
         def jac(x):
-            eq_all, ineq_all = zip(*[c.jac(x) for c in canonical_constraints])
+            if canonical_constraints:
+                eq_all, ineq_all = zip(
+                        *[c.jac(x) for c in canonical_constraints])
+            else:
+                eq_all, ineq_all = [], []
+
             return vstack(eq_all), vstack(ineq_all)
 
         def hess(x, v_eq, v_ineq):

--- a/scipy/optimize/_trustregion_constr/canonical_constraint.py
+++ b/scipy/optimize/_trustregion_constr/canonical_constraint.py
@@ -99,12 +99,8 @@ class CanonicalConstraint(object):
         must have their Jacobians in the same format.
         """
         def fun(x):
-            eq_all = []
-            ineq_all = []
-            for c in canonical_constraints:
-                eq, ineq = c.fun(x)
-                eq_all.append(eq)
-                ineq_all.append(ineq)
+            eq_all, ineq_all = zip(
+                    *[c.fun(x) for c in canonical_constraints])
 
             return np.hstack(eq_all), np.hstack(ineq_all)
 
@@ -114,12 +110,8 @@ class CanonicalConstraint(object):
             vstack = np.vstack
 
         def jac(x):
-            eq_all = []
-            ineq_all = []
-            for c in canonical_constraints:
-                eq, ineq = c.jac(x)
-                eq_all.append(eq)
-                ineq_all.append(ineq)
+            eq_all, ineq_all = zip(
+                    *[c.jac(x) for c in canonical_constraints])
             return vstack(eq_all), vstack(ineq_all)
 
         def hess(x, v_eq, v_ineq):

--- a/scipy/signal/tests/mpsig.py
+++ b/scipy/signal/tests/mpsig.py
@@ -78,9 +78,7 @@ def _butter_analog_poles(n):
     scipy.signal.butter(n, 1, analog=True, output='zpk'), but mpmath is used,
     and only the poles are returned.
     """
-    poles = []
-    for k in range(-n+1, n, 2):
-        poles.append(-mpmath.exp(1j*mpmath.pi*k/(2*n)))
+    poles = [-mpmath.exp(1j*mpmath.pi*k/(2*n)) for k in range(-n+1, n, 2)]
     return poles
 
 

--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -304,10 +304,9 @@ class SphericalVoronoi:
 
         # group by generator indices to produce
         # unsorted regions in nested list
-        groups = []
-        for k, g in itertools.groupby(array_associations,
-                                      lambda t: t[0]):
-            groups.append(list(list(zip(*list(g)))[1]))
+        groups = [list(list(zip(*list(g)))[1])
+                  for k, g in itertools.groupby(array_associations,
+                                                lambda t: t[0])]
 
         self.regions = groups
 

--- a/scipy/spatial/qhull.pyx
+++ b/scipy/spatial/qhull.pyx
@@ -1007,8 +1007,10 @@ cdef void _visit_voronoi(qhT *_qh, void *ptr, vertexT *vertex, vertexT *vertexA,
     p[2*qh._nridges + 1] = point_2
 
     # Record which voronoi vertices constitute the ridge
-    cur_vertices = [(<facetT*>centers.e[i].p).visitid - 1
-                    for i in xrange(qh_setsize(_qh, centers))]
+    cur_vertices = []
+    for i in xrange(qh_setsize(_qh, centers)):
+        ix = (<facetT*>centers.e[i].p).visitid - 1
+        cur_vertices.append(ix)
     qh._ridge_vertices.append(cur_vertices)
 
     qh._nridges += 1

--- a/scipy/spatial/qhull.pyx
+++ b/scipy/spatial/qhull.pyx
@@ -295,10 +295,8 @@ cdef class _Qhull:
 
         if incremental:
             incremental_bad_ops = set([b'Qbb', b'Qbk', b'QBk', b'QbB', b'Qz'])
-            bad_opts = []
-            for bad_opt in incremental_bad_ops:
-                if bad_opt in options:
-                    bad_opts.append(bad_opt)
+            bad_opts = [bad_opt for bad_opt in incremental_bad_ops
+                        if bad_opt in options]
             if bad_opts:
                 raise ValueError("Qhull options %r are incompatible "
                                  "with incremental mode" % (bad_opts,))
@@ -1009,10 +1007,8 @@ cdef void _visit_voronoi(qhT *_qh, void *ptr, vertexT *vertex, vertexT *vertexA,
     p[2*qh._nridges + 1] = point_2
 
     # Record which voronoi vertices constitute the ridge
-    cur_vertices = []
-    for i in xrange(qh_setsize(_qh, centers)):
-        ix = (<facetT*>centers.e[i].p).visitid - 1
-        cur_vertices.append(ix)
+    cur_vertices = [(<facetT*>centers.e[i].p).visitid - 1
+                    for i in xrange(qh_setsize(_qh, centers))]
     qh._ridge_vertices.append(cur_vertices)
 
     qh._nridges += 1

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -427,9 +427,8 @@ class TestVertexNeighborVertices(object):
 
         indptr, indices = tri.vertex_neighbor_vertices
 
-        got = []
-        for j in range(tri.points.shape[0]):
-            got.append(set(map(int, indices[indptr[j]:indptr[j+1]])))
+        got = [set(map(int, indices[indptr[j]:indptr[j+1]]))
+               for j in range(tri.points.shape[0])]
 
         assert_equal(got, expected, err_msg="%r != %r" % (got, expected))
 

--- a/scipy/special/_generate_pyx.py
+++ b/scipy/special/_generate_pyx.py
@@ -838,7 +838,7 @@ class FusedFunc(Func):
             return lines
 
         # Set fused-type variables to nan
-        all_codes = tuple([codes for _, codes in fused_types])  # noqa
+        all_codes = tuple([codes for _unused, codes in fused_types])
 
         codelens = list(map(lambda x: len(x), all_codes))
         last = numpy.product(codelens) - 1

--- a/scipy/special/_generate_pyx.py
+++ b/scipy/special/_generate_pyx.py
@@ -838,7 +838,7 @@ class FusedFunc(Func):
             return lines
 
         # Set fused-type variables to nan
-        all_codes = tuple([codes for _, codes in fused_types])
+        all_codes = tuple([codes for _, codes in fused_types])  # noqa
 
         codelens = list(map(lambda x: len(x), all_codes))
         last = numpy.product(codelens) - 1

--- a/scipy/special/_generate_pyx.py
+++ b/scipy/special/_generate_pyx.py
@@ -756,12 +756,8 @@ class FusedFunc(Func):
         return all_types, fused_types
 
     def _get_vars(self):
-        invars = []
-        for n in range(len(self.intypes)):
-            invars.append("x{}".format(n))
-        outvars = []
-        for n in range(len(self.outtypes)):
-            outvars.append("y{}".format(n))
+        invars = ["x{}".format(n) for n in range(len(self.intypes))]
+        outvars = ["y{}".format(n) for n in range(len(self.outtypes))]
         return invars, outvars
 
     def _get_conditional(self, types, codes, adverb):
@@ -842,11 +838,7 @@ class FusedFunc(Func):
             return lines
 
         # Set fused-type variables to nan
-        all_codes = []
-        for fused_type in fused_types:
-            _, codes = fused_type
-            all_codes.append(codes)
-        all_codes = tuple(all_codes)
+        all_codes = tuple([codes for _, codes in fused_types])
 
         codelens = list(map(lambda x: len(x), all_codes))
         last = numpy.product(codelens) - 1
@@ -878,10 +870,8 @@ class FusedFunc(Func):
         tab = " "*4
         tmpvars = list(all_tmpvars)
         tmpvars.sort()
-        tmpdecs = []
-        for tmpvar in tmpvars:
-            line = "cdef npy_cdouble {}".format(tmpvar)
-            tmpdecs.append(tab + line)
+        tmpdecs = [tab + "cdef npy_cdouble {}".format(tmpvar)
+                   for tmpvar in tmpvars]
         return tmpdecs
 
     def _get_python_wrap(self):

--- a/scipy/special/_mptestutils.py
+++ b/scipy/special/_mptestutils.py
@@ -173,9 +173,7 @@ def get_args(argspec, n):
         ms = np.asarray([1.5 if isinstance(spec, ComplexArg) else 1.0 for spec in argspec])
         ms = (n**(ms/sum(ms))).astype(int) + 1
 
-        args = []
-        for spec, m in zip(argspec, ms):
-            args.append(spec.values(m))
+        args = [spec.values(m) for spec, m in zip(argspec, ms)]
         args = np.array(np.broadcast_arrays(*np.ix_(*args))).reshape(nargs, -1).T
 
     return args

--- a/scipy/special/_precompute/gammainc_asy.py
+++ b/scipy/special/_precompute/gammainc_asy.py
@@ -34,9 +34,7 @@ def compute_a(n):
 def compute_g(n):
     """g_k from DLMF 5.11.3/5.11.5"""
     a = compute_a(2*n)
-    g = []
-    for k in range(n):
-        g.append(mp.sqrt(2)*mp.rf(0.5, k)*a[2*k])
+    g = [mp.sqrt(2)*mp.rf(0.5, k)*a[2*k] for k in range(n)]
     return g
 
 

--- a/scipy/special/_precompute/lambertw.py
+++ b/scipy/special/_precompute/lambertw.py
@@ -15,9 +15,7 @@ except ImportError:
 
 
 def lambertw_pade():
-    derivs = []
-    for n in range(6):
-        derivs.append(mpmath.diff(mpmath.lambertw, 0, n=n))
+    derivs = [mpmath.diff(mpmath.lambertw, 0, n=n) for n in range(6)]
     p, q = mpmath.pade(derivs, 3, 2)
     return p, q
 

--- a/scipy/special/_precompute/loggamma.py
+++ b/scipy/special/_precompute/loggamma.py
@@ -8,10 +8,9 @@ except ImportError:
 
 
 def stirling_series(N):
-    coeffs = []
     with mpmath.workdps(100):
-        for n in range(1, N + 1):
-            coeffs.append(mpmath.bernoulli(2*n)/(2*n*(2*n - 1)))
+        coeffs = [mpmath.bernoulli(2*n)/(2*n*(2*n - 1))
+                  for n in range(1, N + 1)]
     return coeffs
 
 

--- a/scipy/special/tests/test_cython_special.py
+++ b/scipy/special/tests/test_cython_special.py
@@ -313,10 +313,9 @@ def test_cython_api(param):
     # Check results
     for typecodes in specializations:
         # Pick the correct specialized function
-        signature = []
-        for j, code in enumerate(typecodes):
-            if is_fused_code[j]:
-                signature.append(CYTHON_SIGNATURE_MAP[code])
+        signature = [CYTHON_SIGNATURE_MAP[code]
+                     for j, code in enumerate(typecodes)
+                     if is_fused_code[j]]
 
         if signature:
             cy_spec_func = cyfunc[tuple(signature)]

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -365,9 +365,7 @@ def test_loggamma_taylor_transition():
     dz = r*np.exp(1j*theta)
     z = np.r_[1 + dz, 2 + dz].flatten()
 
-    dataset = []
-    for z0 in z:
-        dataset.append((z0, complex(mpmath.loggamma(z0))))
+    dataset = [(z0, complex(mpmath.loggamma(z0))) for z0 in z]
     dataset = np.array(dataset)
 
     FuncData(sc.loggamma, dataset, 0, 1, rtol=5e-14).check()
@@ -383,9 +381,7 @@ def test_loggamma_taylor():
     dz = r*np.exp(1j*theta)
     z = np.r_[1 + dz, 2 + dz].flatten()
 
-    dataset = []
-    for z0 in z:
-        dataset.append((z0, complex(mpmath.loggamma(z0))))
+    dataset = [(z0, complex(mpmath.loggamma(z0))) for z0 in z]
     dataset = np.array(dataset)
 
     FuncData(sc.loggamma, dataset, 0, 1, rtol=5e-14).check()
@@ -409,10 +405,8 @@ def test_rgamma_zeros():
     dz = dx + 1j*dy
     zeros = np.arange(0, -170, -1).reshape(1, 1, -1)
     z = (zeros + np.dstack((dz,)*zeros.size)).flatten()
-    dataset = []
     with mpmath.workdps(100):
-        for z0 in z:
-            dataset.append((z0, complex(mpmath.rgamma(z0))))
+        dataset = [(z0, complex(mpmath.rgamma(z0))) for z0 in z]
 
     dataset = np.array(dataset)
     FuncData(sc.rgamma, dataset, 0, 1, rtol=1e-12).check()
@@ -438,10 +432,8 @@ def test_digamma_roots():
     dx, dy = np.meshgrid(dx, dy)
     dz = dx + 1j*dy
     z = (roots + np.dstack((dz,)*roots.size)).flatten()
-    dataset = []
     with mpmath.workdps(30):
-        for z0 in z:
-            dataset.append((z0, complex(mpmath.digamma(z0))))
+        dataset = [(z0, complex(mpmath.digamma(z0))) for z0 in z]
 
     dataset = np.array(dataset)
     FuncData(sc.digamma, dataset, 0, 1, rtol=1e-14).check()
@@ -460,11 +452,8 @@ def test_digamma_negreal():
     x, y = np.meshgrid(x, y)
     z = (x + 1j*y).flatten()
 
-    dataset = []
     with mpmath.workdps(40):
-        for z0 in z:
-            res = digamma(z0)
-            dataset.append((z0, complex(res)))
+        dataset = [(z0, complex(digamma(z0))) for z0 in z]
     dataset = np.asarray(dataset)
 
     FuncData(sc.digamma, dataset, 0, 1, rtol=1e-13).check()
@@ -480,11 +469,8 @@ def test_digamma_boundary():
     x, y = np.meshgrid(x, y)
     z = (x + 1j*y).flatten()
 
-    dataset = []
     with mpmath.workdps(30):
-        for z0 in z:
-            res = mpmath.digamma(z0)
-            dataset.append((z0, complex(res)))
+        dataset = [(z0, complex(mpmath.digamma(z0))) for z0 in z]
     dataset = np.asarray(dataset)
 
     FuncData(sc.digamma, dataset, 0, 1, rtol=1e-13).check()
@@ -503,10 +489,9 @@ def test_gammainc_boundary():
     x = a.copy()
     a, x = np.meshgrid(a, x)
     a, x = a.flatten(), x.flatten()
-    dataset = []
     with mpmath.workdps(100):
-        for a0, x0 in zip(a, x):
-            dataset.append((a0, x0, float(mpmath.gammainc(a0, b=x0, regularized=True))))
+        dataset = [(a0, x0, float(mpmath.gammainc(a0, b=x0, regularized=True)))
+                   for a0, x0 in zip(a, x)]
     dataset = np.array(dataset)
 
     FuncData(sc.gammainc, dataset, (0, 1), 2, rtol=1e-12).check()
@@ -528,11 +513,8 @@ def test_spence_circle():
     r = np.linspace(0.5, 1.5)
     theta = np.linspace(0, 2*pi)
     z = (1 + np.outer(r, np.exp(1j*theta))).flatten()
-    dataset = []
-    for z0 in z:
-        dataset.append((z0, spence(z0)))
+    dataset = np.asarray([(z0, spence(z0)) for z0 in z])
 
-    dataset = np.array(dataset)
     FuncData(sc.spence, dataset, 0, 1, rtol=1e-14).check()
 
 
@@ -549,11 +531,8 @@ def test_sinpi_zeros():
     dz = dx + 1j*dy
     zeros = np.arange(-100, 100, 1).reshape(1, 1, -1)
     z = (zeros + np.dstack((dz,)*zeros.size)).flatten()
-    dataset = []
-    for z0 in z:
-        dataset.append((z0, complex(mpmath.sinpi(z0))))
-
-    dataset = np.array(dataset)
+    dataset = np.asarray([(z0, complex(mpmath.sinpi(z0)))
+                          for z0 in z])
     FuncData(_sinpi, dataset, 0, 1, rtol=2*eps).check()
 
 
@@ -566,11 +545,9 @@ def test_cospi_zeros():
     dz = dx + 1j*dy
     zeros = (np.arange(-100, 100, 1) + 0.5).reshape(1, 1, -1)
     z = (zeros + np.dstack((dz,)*zeros.size)).flatten()
-    dataset = []
-    for z0 in z:
-        dataset.append((z0, complex(mpmath.cospi(z0))))
+    dataset = np.asarray([(z0, complex(mpmath.cospi(z0)))
+                          for z0 in z])
 
-    dataset = np.array(dataset)
     FuncData(_cospi, dataset, 0, 1, rtol=2*eps).check()
 
 
@@ -628,10 +605,8 @@ def test_wrightomega_branch():
     x, y = np.meshgrid(x, y)
     z = (x + 1j*y).flatten()
 
-    dataset = []
-    for z0 in z:
-        dataset.append((z0, complex(_mpmath_wrightomega(z0, 25))))
-    dataset = np.asarray(dataset)
+    dataset = np.asarray([(z0, complex(_mpmath_wrightomega(z0, 25)))
+                          for z0 in z])
 
     FuncData(sc.wrightomega, dataset, 0, 1, rtol=1e-8).check()
 
@@ -645,10 +620,8 @@ def test_wrightomega_region1():
     x, y = np.meshgrid(x, y)
     z = (x + 1j*y).flatten()
 
-    dataset = []
-    for z0 in z:
-        dataset.append((z0, complex(_mpmath_wrightomega(z0, 25))))
-    dataset = np.asarray(dataset)
+    dataset = np.asarray([(z0, complex(_mpmath_wrightomega(z0, 25)))
+                          for z0 in z])
 
     FuncData(sc.wrightomega, dataset, 0, 1, rtol=1e-15).check()
 
@@ -662,10 +635,8 @@ def test_wrightomega_region2():
     x, y = np.meshgrid(x, y)
     z = (x + 1j*y).flatten()
 
-    dataset = []
-    for z0 in z:
-        dataset.append((z0, complex(_mpmath_wrightomega(z0, 25))))
-    dataset = np.asarray(dataset)
+    dataset = np.asarray([(z0, complex(_mpmath_wrightomega(z0, 25)))
+                          for z0 in z])
 
     FuncData(sc.wrightomega, dataset, 0, 1, rtol=1e-15).check()
 
@@ -681,10 +652,8 @@ def test_lambertw_smallz():
     x, y = np.meshgrid(x, y)
     z = (x + 1j*y).flatten()
 
-    dataset = []
-    for z0 in z:
-        dataset.append((z0, complex(mpmath.lambertw(z0))))
-    dataset = np.asarray(dataset)
+    dataset = np.asarray([(z0, complex(mpmath.lambertw(z0)))
+                          for z0 in z])
 
     FuncData(sc.lambertw, dataset, 0, 1, rtol=1e-13).check()
 

--- a/scipy/special/tests/test_precompute_gammainc.py
+++ b/scipy/special/tests/test_precompute_gammainc.py
@@ -81,9 +81,7 @@ def test_d():
                    (9, 0, -mp.mpf('0.596761290192746250124390067179e-3')),
                    (9, 12, mp.mpf('0.870823417786464116761231237189e-6'))]
         d = compute_d(10, 13)
-        res = []
-        for k, n, std in dataset:
-            res.append(d[k][n])
+        res = [d[k][n] for k, n, std in dataset]
         std = map(lambda x: x[2], dataset)
         mp_assert_allclose(res, std)
 

--- a/scipy/special/utils/datafunc.py
+++ b/scipy/special/utils/datafunc.py
@@ -9,9 +9,7 @@ def parse_txt_data(filename):
     f = open(filename)
     try:
         reader = csv.reader(f, delimiter=',')
-        data = []
-        for row in reader:
-            data.append(list(map(float, row)))
+        data = [list(map(float, row)) for row in reader]
         nc = len(data[0])
         for i in data:
             if not nc == len(i):
@@ -48,11 +46,7 @@ def run_test(filename, funcs, args=[0]):
         x = [data[args[i]] for i in nargs]
         return f(*x)
     else:
-        y = []
-        i = 1
-        for f in funcs:
-            y.append(f(data[:, 0]) - data[:, i])
-            i += 1
+        y = [f(data[:, 0]) - data[:, idx + 1] for idx, f in enumerate(funcs)]
 
         return data[:, 0], y
 

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -1074,10 +1074,7 @@ class rv_generic(object):
                 place(out0, cond, g2)
                 output.append(out0)
         else:  # no valid args
-            output = []
-            for _ in moments:
-                out0 = default.copy()
-                output.append(out0)
+            output = [default.copy() for _ in moments]
 
         if len(output) == 1:
             return output[0]

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -2446,9 +2446,7 @@ def _apply_func(x, g, func):
     #  separating x into different groups
     #  func should be applied over the groups
     g = unique(r_[0, g, len(x)])
-    output = []
-    for k in range(len(g) - 1):
-        output.append(func(x[g[k]:g[k+1]]))
+    output = [func(x[g[k]:g[k+1]]) for k in range(len(g) - 1)]
 
     return asarray(output)
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -535,10 +535,8 @@ class TestHypergeom(object):
         pears = 1.1e5
         fruits_eaten = np.array([3, 3.8, 3.9, 4, 4.1, 4.2, 5]) * 1e4
         quantile = 2e4
-        res = []
-        for eaten in fruits_eaten:
-            res.append(stats.hypergeom.sf(quantile, oranges + pears, oranges,
-                                          eaten))
+        res = [stats.hypergeom.sf(quantile, oranges + pears, oranges, eaten)
+               for eaten in fruits_eaten]
         expected = np.array([0, 1.904153e-114, 2.752693e-66, 4.931217e-32,
                              8.265601e-11, 0.1237904, 1])
         assert_allclose(res, expected, atol=0, rtol=5e-7)

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -924,9 +924,7 @@ class TestKstat(object):
     def test_moments_normal_distribution(self):
         np.random.seed(32149)
         data = np.random.randn(12345)
-        moments = []
-        for n in [1, 2, 3, 4]:
-            moments.append(stats.kstat(data, n))
+        moments = [stats.kstat(data, n) for n in [1, 2, 3, 4]]
 
         expected = [0.011315, 1.017931, 0.05811052, 0.0754134]
         assert_allclose(moments, expected, rtol=1e-4)


### PR DESCRIPTION
This uses list comprehension when possible, instead of creating a list by appending to it in a for loop, which is faster and less verbose.

Tried to only make the changes in some simple cases when it doesn't hurt readability