### PR TITLE
DOC: Replace "Numpy" with "NumPy" in .py, .rst and .txt doc files for consistency

### DIFF
--- a/HACKING.rst.txt
+++ b/HACKING.rst.txt
@@ -261,7 +261,7 @@ following, a *SciPy module* is defined as a Python package, say
   for instance ``yyy/_somemodule.py``.
 
 * User-visible functions should have good documentation following
-  the Numpy documentation style, see `how to document`_
+  the NumPy documentation style, see `how to document`_
 
 * The ``__init__.py`` of the module should contain the main reference
   documentation in its docstring. This is connected to the Sphinx
@@ -277,7 +277,7 @@ following, a *SciPy module* is defined as a Python package, say
 
 See the existing Scipy submodules for guidance.
 
-For further details on Numpy distutils, see:
+For further details on NumPy distutils, see:
 
   https://github.com/numpy/numpy/blob/master/doc/DISTUTILS.rst.txt
 
@@ -356,7 +356,7 @@ command ``source scipy-dev/bin/activate``, and ``deactivate`` to exit from the
 virtual environment and back to your previous shell.  With scipy-dev
 activated, install first Scipy's dependencies::
 
-    $ pip install Numpy pytest Cython
+    $ pip install NumPy pytest Cython
 
 After that, you can install a development version of Scipy, for example via::
 

--- a/THANKS.txt
+++ b/THANKS.txt
@@ -80,7 +80,7 @@ Martin Teichmann for improving scipy.special.ellipk & agm accuracy,
     and for linalg.qr_multiply.
 Jeff Armstrong for discrete state-space and linear time-invariant functionality
     in scipy.signal, and sylvester/riccati/lyapunov solvers in scipy.linalg.
-Mark Wiebe for fixing type casting after changes in Numpy.
+Mark Wiebe for fixing type casting after changes in NumPy.
 Andrey Smirnov for improvements to FIR filter design.
 Anthony Scopatz for help with code review and merging.
 Lars Buitinck for improvements to scipy.sparse and various other modules.

--- a/doc/source/building/windows.rst
+++ b/doc/source/building/windows.rst
@@ -229,7 +229,7 @@ not be used. Attempting to build with the MSYS2 Python will not work correctly.*
 
 Please note that this is a simpler procedure than what is used for the official binaries.
 **Your binaries will only work with the latest NumPy (v1.14.0dev and higher)**. For
-building against older Numpy versions, see `Building Against an Older Numpy Version`_. 
+building against older NumPy versions, see `Building Against an Older NumPy Version`_.
 Make sure that you are in the same directory where  ``setup.py`` is (you should be if you 
 have not changed directories):
 
@@ -257,13 +257,13 @@ Congratulatations, you've built SciPy!
 .. _`pre-built zip files`: https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/
 .. _WindowsCompilers: https://wiki.python.org/moin/WindowsCompilers
 
-Building Against an Older Numpy Version
+Building Against an Older NumPy Version
 ---------------------------------------
 
 If you want to build SciPy to work with an older numpy version, then you will need 
-to replace the Numpy "distutils" folder with the folder from the latest numpy.
-The following powershell snippet can upgrade Numpy distutils while retaining an older
-Numpy ABI_.
+to replace the NumPy "distutils" folder with the folder from the latest numpy.
+The following powershell snippet can upgrade NumPy distutils while retaining an older
+NumPy ABI_.
 
 .. code:: shell
 

--- a/doc/source/dev/distributing.rst
+++ b/doc/source/dev/distributing.rst
@@ -64,9 +64,9 @@ There are some serious issues with how Python packaging tools handle
 dependencies reported by projects.  Because SciPy gets regular bug reports
 about this, we go in a bit of detail here.
 
-SciPy only reports its dependency on Numpy via ``install_requires`` if Numpy
+SciPy only reports its dependency on NumPy via ``install_requires`` if NumPy
 isn't installed at all on a system.  This will only change when there are
-either 32-bit and 64-bit Windows wheels for Numpy on PyPI or when
+either 32-bit and 64-bit Windows wheels for NumPy on PyPI or when
 ``pip upgrade`` becomes available (with sane behavior, unlike ``pip install
 -U``, see `this PR
 <https://github.com/pypa/pip/pull/3194>`_).  For more details, see
@@ -82,7 +82,7 @@ as "wontfix").
 
 .. _supported-py-numpy-versions:
 
-Supported Python and Numpy versions
+Supported Python and NumPy versions
 -----------------------------------
 The Python_ versions that SciPy supports are listed in the list of PyPI
 classifiers in ``setup.py``, and mentioned in the release notes for each
@@ -90,16 +90,16 @@ release.  All newly released Python versions will be supported as soon as
 possible.  The general policy on dropping support for a Python version is that
 (a) usage of that version has to be quite low (say <5% of users) and (b) the
 version isn't included in an active long-term support release of one of the
-main Linux distributions anymore.  SciPy typically follows Numpy, which has a
+main Linux distributions anymore.  SciPy typically follows NumPy, which has a
 similar policy.  The final decision on dropping support is always taken on the
 scipy-dev mailing list.
 
 The lowest supported Numpy_ version for a SciPy version is mentioned in the
 release notes and is encoded in ``scipy/__init__.py`` and the
 ``install_requires`` field of ``setup.py``.  Typically the latest SciPy release
-supports 3 or 4 minor versions of Numpy.  That may become more if the frequency
-of Numpy releases increases (it's about 1x/year at the time of writing).
-Support for a particular Numpy version is typically dropped if (a) that Numpy
+supports 3 or 4 minor versions of NumPy.  That may become more if the frequency
+of NumPy releases increases (it's about 1x/year at the time of writing).
+Support for a particular NumPy version is typically dropped if (a) that NumPy
 version is several years old, and (b) the maintenance cost of keeping support
 is starting to outweigh the benefits.  The final decision on dropping support
 is always taken on the scipy-dev mailing list.
@@ -125,8 +125,8 @@ and distributing them on PyPI or elsewhere.
 
 - A binary is specific for a single Python version (because different Python
   versions aren't ABI-compatible, at least up to Python 3.4).
-- Build against the lowest Numpy version that you need to support, then it will
-  work for all Numpy versions with the same major version number (Numpy does
+- Build against the lowest NumPy version that you need to support, then it will
+  work for all NumPy versions with the same major version number (NumPy does
   maintain backwards ABI compatibility).
 
 **Windows**
@@ -135,7 +135,7 @@ and distributing them on PyPI or elsewhere.
   Python.org compatible binaries for SciPy is installing MSVC (see
   https://wiki.python.org/moin/WindowsCompilers) and mingw64-gfortran.
   Support for this configuration requires numpy.distutils from
-  Numpy >= 1.14.dev and a gcc/gfortran-compiled static ``openblas.a``.
+  NumPy >= 1.14.dev and a gcc/gfortran-compiled static ``openblas.a``.
   This configuration is currently used in the Appveyor configuration for
   https://github.com/MacPython/scipy-wheels
 - For 64-bit Windows installers built with a free toolchain, use the method

--- a/doc/source/dev/releasing.rst
+++ b/doc/source/dev/releasing.rst
@@ -117,8 +117,8 @@ commit (not the tag, see section above) to the scipy repo.
 To build wheels, push a commit to the master branch of
 https://github.com/MacPython/scipy-wheels .  This triggers builds for all needed
 Python versions on TravisCI.  Update and check the ``.travis.yml`` and ``appveyor.yml``
-config files what commit to build, and what Python and Numpy are used for the
-builds (it needs to be the lowest supported Numpy version for each Python
+config files what commit to build, and what Python and NumPy are used for the
+builds (it needs to be the lowest supported NumPy version for each Python
 version).  See the README file in the scipy-wheels repo for more details.
 
 The TravisCI and Appveyor builds run the tests from the built wheels and if they pass,

--- a/doc/source/tutorial/basic.rst
+++ b/doc/source/tutorial/basic.rst
@@ -7,17 +7,17 @@ Basic functions
 
 .. contents::
 
-Interaction with Numpy
+Interaction with NumPy
 ----------------------
 
-SciPy builds on Numpy, and for all basic array handling needs you can
-use Numpy functions:
+SciPy builds on NumPy, and for all basic array handling needs you can
+use NumPy functions:
 
     >>> import numpy as np
     >>> np.some_function()
 
 Rather than giving a detailed description of each of these functions
-(which is available in the Numpy Reference Guide or by using the
+(which is available in the NumPy Reference Guide or by using the
 :func:`help`, :func:`info` and :func:`source` commands), this tutorial
 will discuss some of the more useful commands which require a little
 introduction to use to their full potential.
@@ -99,7 +99,7 @@ usage:
 
 Having meshed arrays like this is sometimes very useful. However, it
 is not always needed just to evaluate some N-dimensional function over
-a grid due to the array-broadcasting rules of Numpy and SciPy. If this
+a grid due to the array-broadcasting rules of NumPy and SciPy. If this
 is the only purpose for generating a meshgrid, you should instead use
 the function :obj:`ogrid` which generates an "open" grid using :obj:`newaxis`
 judiciously to create N, N-d arrays where only one dimension in each
@@ -123,7 +123,7 @@ Polynomials
 ^^^^^^^^^^^
 
 There are two (interchangeable) ways to deal with 1-d polynomials in
-SciPy. The first is to use the :class:`poly1d` class from Numpy. This
+SciPy. The first is to use the :class:`poly1d` class from NumPy. This
 class accepts coefficients or polynomial roots to initialize a
 polynomial. The polynomial object can then be manipulated in algebraic
 expressions, integrated, differentiated, and evaluated. It even prints
@@ -158,7 +158,7 @@ Vectorizing functions (vectorize)
 One of the features that NumPy provides is a class :obj:`vectorize` to
 convert an ordinary Python function which accepts scalars and returns
 scalars into a "vectorized-function" with the same broadcasting rules
-as other Numpy functions (*i.e.* the Universal functions, or
+as other NumPy functions (*i.e.* the Universal functions, or
 ufuncs). For example, suppose you have a Python function named
 :obj:`addsubtract` defined as:
 
@@ -198,7 +198,7 @@ complex number. While complex numbers and arrays have attributes that
 return those values, if one is not sure whether or not the object will
 be complex-valued, it is better to use the functional forms
 :func:`np.real` and :func:`np.imag` . These functions succeed for anything
-that can be turned into a Numpy array. Consider also the function
+that can be turned into a NumPy array. Consider also the function
 :func:`np.real_if_close` which transforms a complex-valued number with
 tiny imaginary part into a real number.
 
@@ -207,7 +207,7 @@ Occasionally the need to check whether or not a number is a scalar
 occurs in coding. This functionality is provided in the convenient
 function :func:`np.isscalar` which returns a 1 or a 0.
 
-Finally, ensuring that objects are a certain Numpy type occurs often
+Finally, ensuring that objects are a certain NumPy type occurs often
 enough that it has been given a convenient interface in SciPy through
 the use of the :obj:`np.cast` dictionary. The dictionary is keyed by the
 type it is desired to cast to and the dictionary stores functions to
@@ -227,7 +227,7 @@ mentioned. For doing phase processing, the functions :func:`angle`,
 and :obj:`unwrap` are useful. Also, the :obj:`linspace` and
 :obj:`logspace` functions return equally spaced samples in a linear or
 log scale.  Finally, it's useful to be aware of the indexing
-capabilities of Numpy. Mention should be made of the function
+capabilities of NumPy. Mention should be made of the function
 :obj:`select` which extends the functionality of :obj:`where` to
 include multiple conditions and multiple choices. The calling
 convention is ``select(condlist,choicelist,default=0).`` :obj:`select`

--- a/doc/source/tutorial/general.rst
+++ b/doc/source/tutorial/general.rst
@@ -5,7 +5,7 @@ Introduction
 .. contents::
 
 SciPy is a collection of mathematical algorithms and convenience
-functions built on the Numpy extension of Python. It adds
+functions built on the NumPy extension of Python. It adds
 significant power to the interactive Python session by providing the
 user with high-level commands and classes for manipulating and
 visualizing data. With SciPy an interactive Python session
@@ -26,7 +26,7 @@ This tutorial will acquaint the first-time user of SciPy with some of its most
 important features. It assumes that the user has already installed the SciPy
 package. Some general Python facility is also assumed, such as could be
 acquired by working through the Python distribution's Tutorial. For further
-introductory help the user is directed to the Numpy documentation.
+introductory help the user is directed to the NumPy documentation.
 
 For brevity and convenience, we will often assume that the main
 packages (numpy, scipy, and matplotlib) have been imported as::

--- a/doc/source/tutorial/io.rst
+++ b/doc/source/tutorial/io.rst
@@ -45,7 +45,7 @@ How do I start?
 ```````````````
 
 You may have a ``.mat`` file that you want to read into SciPy.  Or, you
-want to pass some variables from SciPy / Numpy into MATLAB.
+want to pass some variables from SciPy / NumPy into MATLAB.
 
 To save us using a MATLAB license, let's start in Octave_.  Octave has
 MATLAB-compatible save and load functions.  Start Octave (``octave`` at

--- a/doc/source/tutorial/linalg.rst
+++ b/doc/source/tutorial/linalg.rst
@@ -111,7 +111,7 @@ The inverse of a matrix :math:`\mathbf{A}` is the matrix
 :math:`\mathbf{I}` is the identity matrix consisting of ones down the
 main diagonal.  Usually :math:`\mathbf{B}` is denoted
 :math:`\mathbf{B}=\mathbf{A}^{-1}` . In SciPy, the matrix inverse of
-the Numpy array, A, is obtained using :obj:`linalg.inv` ``(A)`` , or
+the NumPy array, A, is obtained using :obj:`linalg.inv` ``(A)`` , or
 using ``A.I`` if ``A`` is a Matrix. For example, let
 
 .. math::

--- a/doc/source/tutorial/signal.rst
+++ b/doc/source/tutorial/signal.rst
@@ -151,17 +151,17 @@ Filtering
 ---------
 
 Filtering is a generic name for any system that modifies an input
-signal in some way. In SciPy a signal can be thought of as a Numpy
+signal in some way. In SciPy a signal can be thought of as a NumPy
 array. There are different kinds of filters for different kinds of
 operations. There are two broad kinds of filtering operations: linear
 and non-linear. Linear filters can always be reduced to multiplication
-of the flattened Numpy array by an appropriate matrix resulting in
-another flattened Numpy array. Of course, this is not usually the best
+of the flattened NumPy array by an appropriate matrix resulting in
+another flattened NumPy array. Of course, this is not usually the best
 way to compute the filter as the matrices and vectors involved may be
 huge. For example filtering a :math:`512 \times 512` image with this
 method would require multiplication of a :math:`512^2 \times 512^2`
 matrix with a :math:`512^2` vector. Just trying to store the
-:math:`512^2 \times 512^2` matrix using a standard Numpy array would
+:math:`512^2 \times 512^2` matrix using a standard NumPy array would
 require :math:`68,719,476,736` elements. At 4 bytes per element this
 would require :math:`256\textrm{GB}` of memory. In most applications
 most of the elements of this matrix are zero and a different method

--- a/runtests.py
+++ b/runtests.py
@@ -26,7 +26,7 @@ Generate C code coverage listing under build/lcov/:
 """
 
 #
-# This is a generic test runner script for projects using Numpy's test
+# This is a generic test runner script for projects using NumPy's test
 # framework. Change the following values to adapt to your project:
 #
 
@@ -106,7 +106,7 @@ def main(argv):
                         help="Debug build")
     parser.add_argument("--parallel", "-j", type=int, default=1,
                         help="Number of parallel jobs during build (requires "
-                             "Numpy 1.10 or greater).")
+                             "NumPy 1.10 or greater).")
     parser.add_argument("--show-build-log", action="store_true",
                         help="Show build output rather than using a log file")
     parser.add_argument("--bench", action="store_true",

--- a/scipy/linalg/_solvers.py
+++ b/scipy/linalg/_solvers.py
@@ -784,7 +784,7 @@ def _are_validate_args(a, b, q, r, e, s, eq_type='care'):
     q = np.atleast_2d(_asarray_validated(q, check_finite=True))
     r = np.atleast_2d(_asarray_validated(r, check_finite=True))
 
-    # Get the correct data types otherwise Numpy complains
+    # Get the correct data types otherwise NumPy complains
     # about pushing complex numbers into real arrays.
     r_or_c = complex if np.iscomplexobj(b) else float
 

--- a/scipy/ndimage/measurements.py
+++ b/scipy/ndimage/measurements.py
@@ -888,7 +888,7 @@ def minimum(input, labels=None, index=None):
 
     Notes
     -----
-    The function returns a Python list and not a Numpy array, use
+    The function returns a Python list and not a NumPy array, use
     `np.array` to convert the list to an array.
 
     Examples
@@ -950,7 +950,7 @@ def maximum(input, labels=None, index=None):
 
     Notes
     -----
-    The function returns a Python list and not a Numpy array, use
+    The function returns a Python list and not a NumPy array, use
     `np.array` to convert the list to an array.
 
     Examples
@@ -1028,7 +1028,7 @@ def median(input, labels=None, index=None):
 
     Notes
     -----
-    The function returns a Python list and not a Numpy array, use
+    The function returns a Python list and not a NumPy array, use
     `np.array` to convert the list to an array.
 
     Examples

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -1294,7 +1294,7 @@ class StateSpace(LinearTimeInvariant):
 
     """
 
-    # Override Numpy binary operations and ufuncs
+    # Override NumPy binary operations and ufuncs
     __array_priority__ = 100.0
     __array_ufunc__ = None
 

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -520,7 +520,7 @@ def _reverse_and_conj(x):
 def _np_conv_ok(volume, kernel, mode):
     """
     See if numpy supports convolution of `volume` and `kernel` (i.e. both are
-    1D ndarrays and of the appropriate shape).  Numpy's 'same' mode uses the
+    1D ndarrays and of the appropriate shape).  NumPy's 'same' mode uses the
     size of the larger input, while SciPy's uses the size of the first input.
 
     Invalid mode strings will return False and be caught by the calling func.

--- a/scipy/sparse/dok.py
+++ b/scipy/sparse/dok.py
@@ -235,7 +235,7 @@ class dok_matrix(spmatrix, IndexMixin, dict):
         return newdok
 
     def _getitem_ranges(self, i_indices, j_indices, shape):
-        # performance golf: we don't want Numpy scalars here, they are slow
+        # performance golf: we don't want NumPy scalars here, they are slow
         i_start, i_stop, i_stride = map(int, i_indices)
         j_start, j_stop, j_stride = map(int, j_indices)
 

--- a/scipy/sparse/sparsetools.py
+++ b/scipy/sparse/sparsetools.py
@@ -21,7 +21,7 @@ try:
     _deprecated()
 except DeprecationWarning as e:
     # don't fail import if DeprecationWarnings raise error -- works around
-    # the situation with Numpy's test framework
+    # the situation with NumPy's test framework
     pass
 
 from ._sparsetools import *

--- a/scipy/special/_generate_pyx.py
+++ b/scipy/special/_generate_pyx.py
@@ -490,7 +490,7 @@ def iter_variants(inputs, outputs):
         # can lead to incorrect dtype selection if the integer arguments are
         # arrays, but float arguments are scalars.
         # For instance sph_harm(0,[0],0,0).dtype == complex64
-        # This may be a Numpy bug, but we need to work around it.
+        # This may be a NumPy bug, but we need to work around it.
         # cf. gh-4895, https://github.com/numpy/numpy/issues/5895
         maps = maps + [(a + 'dD', b + 'fF') for a, b in maps]
 

--- a/scipy/special/_logsumexp.py
+++ b/scipy/special/_logsumexp.py
@@ -54,7 +54,7 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
 
     Notes
     -----
-    Numpy has a logaddexp function which is very similar to `logsumexp`, but
+    NumPy has a logaddexp function which is very similar to `logsumexp`, but
     only handles two arguments. `logaddexp.reduce` is similar to this
     function, but may be less stable.
 

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -708,7 +708,7 @@ class randint_gen(rv_discrete):
     def _rvs(self, low, high):
         """An array of *size* random integers >= ``low`` and < ``high``."""
         if self._size is not None:
-            # Numpy's RandomState.randint() doesn't broadcast its arguments.
+            # NumPy's RandomState.randint() doesn't broadcast its arguments.
             # Use `broadcast_to()` to extend the shapes of low and high
             # up to self._size.  Then we can use the numpy.vectorize'd
             # randint without needing to pass it a `size` argument.

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1664,7 +1664,7 @@ def scoreatpercentile(a, per, limit=(), interpolation_method='fraction',
     Notes
     -----
     This function will become obsolete in the future.
-    For Numpy 1.9 and higher, `numpy.percentile` provides all the functionality
+    For NumPy 1.9 and higher, `numpy.percentile` provides all the functionality
     that `scoreatpercentile` provides.  And it's significantly faster.
     Therefore it's recommended to use `numpy.percentile` for users that have
     numpy >= 1.9.

--- a/setup.py
+++ b/setup.py
@@ -478,8 +478,8 @@ def setup_package():
         metadata['configuration'] = configuration
     else:
         # Don't import numpy here - non-build actions are required to succeed
-        # without Numpy for example when pip is used to install Scipy when
-        # Numpy is not yet present in the system.
+        # without NumPy for example when pip is used to install Scipy when
+        # NumPy is not yet present in the system.
 
         # Version number is added to metadata inside configuration() if build
         # is run.


### PR DESCRIPTION
[Followon from gh-9499 and gh-9504.]
Some documentation in .txt and .py files use the terms "NumPy" in one part of the document and "Numpy" in a later part. Change all "Numpy" to "NumPy".

Explicitly excluded are the old release notes doc/release/*-notes.rst which have been left alone.