### PR TITLE
TST: add Windows Azure CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,110 @@
+trigger:
+  # start a new build for every push
+  batch: False
+  branches:
+    include:
+      - master
+      - maintenance/*
+
+jobs:
+- job: Windows
+  pool:
+    vmIMage: 'VS2017-Win2016'
+  variables:
+      OPENBLAS_32: https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-5f998ef_gcc7_1_0_win32.zip
+      OPENBLAS_64: https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-5f998ef_gcc7_1_0_win64.zip
+  strategy:
+    maxParallel: 4
+    matrix:
+        Python36-32bit-full:
+          PYTHON_VERSION: '3.6'
+          PYTHON_ARCH: 'x86'
+          TEST_MODE: full
+          OPENBLAS: $(OPENBLAS_32)
+          BITS: 32
+        Python35-64bit-full:
+          PYTHON_VERSION: '3.5'
+          PYTHON_ARCH: 'x64'
+          TEST_MODE: full
+          OPENBLAS: $(OPENBLAS_64)
+          BITS: 64
+        Python36-64bit-full:
+          PYTHON_VERSION: '3.6'
+          PYTHON_ARCH: 'x64'
+          TEST_MODE: full
+          OPENBLAS: $(OPENBLAS_64)
+          BITS: 64
+        Python37-64bit-full:
+          PYTHON_VERSION: '3.7'
+          PYTHON_ARCH: 'x64'
+          TEST_MODE: full
+          OPENBLAS: $(OPENBLAS_64)
+          BITS: 64
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: $(PYTHON_VERSION)
+      addToPath: true
+      architecture: $(PYTHON_ARCH)
+  # as noted by numba project, currently need
+  # specific VC install for Python 2.7
+  - powershell: |
+      $wc = New-Object net.webclient
+      $wc.Downloadfile("https://download.microsoft.com/download/7/9/6/796EF2E4-801B-4FC4-AB28-B59FBF6D907B/VCForPython27.msi", "VCForPython27.msi")
+      Start-Process "VCForPython27.msi" /qn -Wait
+    displayName: 'Install VC 9.0'
+    condition: eq(variables['PYTHON_VERSION'], '2.7')
+  - script: python -m pip install --upgrade pip setuptools wheel
+    displayName: 'Install tools'
+  - powershell: |
+      $wc = New-Object net.webclient;
+      $wc.Downloadfile("$(OPENBLAS)", "openblas.zip")
+      $tmpdir = New-TemporaryFile | %{ rm $_; mkdir $_ }
+      Expand-Archive "openblas.zip" $tmpdir
+      $pyversion = python -c "from __future__ import print_function; import sys; print(sys.version.split()[0])"
+      Write-Host "Python Version: $pyversion"
+      $target = "C:\\hostedtoolcache\\windows\\Python\\$pyversion\\$(PYTHON_ARCH)\\lib\\openblas.a"
+      Write-Host "target path: $target"
+      cp $tmpdir\$(BITS)\lib\libopenblas_5f998ef_gcc7_1_0.a $target
+    displayName: 'Download / Install OpenBLAS'
+  - powershell: |
+      # NOTE: can probably (eventually) abstract this 
+      # upstream in Microsoft repo to support x86 natively
+      choco install -y mingw --forcex86 --force
+    displayName: 'Install 32-bit mingw for 32-bit builds'
+    condition: eq(variables['BITS'], 32)
+  - script: python -m pip install numpy cython==0.28.5 pytest pytest-timeout pytest-xdist pytest-env pytest-faulthandler Pillow mpmath matplotlib
+    displayName: 'Install dependencies'
+  - powershell: |
+      # need a version of NumPy distutils that can build
+      # with msvc + mingw-gfortran
+      $NumpyDir = $((python -c 'import os; import numpy; print(os.path.dirname(numpy.__file__))') | Out-String).Trim()
+      rm -r -Force "$NumpyDir\distutils"
+      $tmpdir = New-TemporaryFile | %{ rm $_; mkdir $_ }
+      git clone -q --depth=1 -b master https://github.com/numpy/numpy.git $tmpdir
+      mv $tmpdir\numpy\distutils $NumpyDir
+    displayName: 'Replace NumPy distutils'
+  - powershell: |
+      If ($(BITS) -eq 32) {
+          # 32-bit build requires careful adjustments
+          # until Microsoft has a switch we can use
+          # directly for i686 mingw
+          $env:NPY_DISTUTILS_APPEND_FLAGS = 1
+          $env:CFLAGS = "-m32"
+          $env:LDFLAGS = "-m32"
+          $env:PATH = "C:\\tools\\mingw32\\bin;" + $env:PATH
+          refreshenv
+      }
+
+      mkdir dist
+      pip wheel --no-build-isolation -v -v -v --wheel-dir=dist .
+      ls dist -r | Foreach-Object {
+          pip install $_.FullName
+      }
+    displayName: 'Build SciPy'
+  - script: python runtests.py -n --mode=$(TEST_MODE) -- -n auto -rsx --junitxml=junit/test-results.xml
+    displayName: 'Run SciPy Test Suite'
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFiles: '**/test-*.xml'
+      testRunTitle: 'Publish test results for Python $(python.version)'


### PR DESCRIPTION
Closes #9471.

**Objective**: Faster windows CI test runs & replicate Appveyor as closely as possible initially, to prevent allowing new issues through.

Full Azure matrix [now passing in my fork](https://github.com/tylerjereddy/scipy/pull/20) for this commit.

For reviewers:

- [x] confirm exclusion of Python 3.4 from original Appveyor matrix is "ok" (otherwise we need to awkwardly install VC 10.0 I think)
- [x] carefully check the i686 (32-bit) vs. 64-bit configs -- the latter is pre-installed mingw, but 32-bit mingw compiler toolchain is manually installed using the chocolatey package manger, for now
- [x] could maybe speed up build / testing a little by using more "processes;" not sure if we can leverage the `build -j` parallelism possible with `python setup.py` using some kind of equivalent in `pip`, but `pip` seems absolutely required for the Windows stuff
- [x] spot check comparison test results with Appveyor (7 / 8 matrix entries should have matching test results, with 3.4 excluded as noted above)
- [x] The Azure app should be added from github marketplace by a repo owner (probably @rgommers I guess) & the best option may be to just merge this on the basis of a mirroring fork run initially to get it going once reviewers are happy. We will also have to set up the web interface with some admins, etc., which is a little annoying.