### PR TITLE
BUG: scipy/_lib/_numpy_compat: get_randint

### DIFF
--- a/scipy/_lib/_numpy_compat.py
+++ b/scipy/_lib/_numpy_compat.py
@@ -95,8 +95,8 @@ else:
     # method of RandomState does only work with int32 values.
     def get_randint(random_state):
         def randint_patched(low, high, size, dtype=np.int32):
-            low = max(low, np.iinfo(dtype).min)
-            high = min(high, np.iinfo(dtype).max)
+            low = max(low, np.iinfo(dtype).min, np.iinfo(np.int32).min)
+            high = min(high, np.iinfo(dtype).max, np.iinfo(np.int32).max)
             integers = random_state.randint(low, high=high, size=size)
             return integers.astype(dtype, copy=False)
         return randint_patched
@@ -779,6 +779,3 @@ else:
         c = dot(X, X_T.conj())
         c *= 1. / np.float64(fact)
         return c.squeeze()
-
-
-

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -2,7 +2,6 @@
 
 from __future__ import division, print_function, absolute_import
 
-import sys
 import numpy as np
 from numpy import array, matrix
 from numpy.testing import (assert_equal, assert_,
@@ -10,7 +9,6 @@ from numpy.testing import (assert_equal, assert_,
 import pytest
 from pytest import raises as assert_raises
 from scipy._lib._testutils import check_free_memory
-from scipy._lib._version import NumpyVersion
 
 from scipy.sparse import csr_matrix, coo_matrix
 
@@ -422,9 +420,6 @@ class TestConstructUtils(object):
         assert_equal(construct.block_diag([1]).todense(),
                      matrix([[1]]))
 
-    @pytest.mark.xfail((NumpyVersion(np.__version__) < "1.11.0" and
-                        sys.maxsize <= 2**32),
-                       reason="randint not compatible")
     def test_random_sampling(self):
         # Simple sanity checks for sparse random sampling.
         for f in sprand, _sprandn:


### PR DESCRIPTION
Fix for problem mentioned in #9486. The `low` and `high` values might be chosen in some cases out of the integer type range. This is fixed.