### PR TITLE
CI: run PyPy tests on CircleCI with single-threaded OpenBLAS.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,6 +137,9 @@ jobs:
           command: |
             # CircleCI has 4G memory limit, play it safe
             export SCIPY_AVAILABLE_MEM=1G
+            # Limit OpenBLAS to 1 thread, PyPy crashes otherwise (at least for
+            # OpenBLAS v0.3.0), see gh-9530.
+            export OPENBLAS_NUM_THREADS=1
             pypy3 runtests.py -- -rfEX -n 3 --durations=30
 
 


### PR DESCRIPTION
Closes gh-9530.  Closes gh-9508.

Skip TravisCI tests:
[ci skip]

Let's see if this turns green ...

Note that the `OPENBLAS_NUM_THREADS` only works if OpenBLAS was compiled with `OPENMP=0`. That is the case, see https://github.com/MacPython/openblas-libs