### PR TITLE
ENH: remove noprefix.h, change code appropriately

### DIFF
--- a/scipy/signal/S_bspline_util.c
+++ b/scipy/signal/S_bspline_util.c
@@ -5,7 +5,7 @@
 #include <string.h>
 #include <stdio.h>
 #define NO_IMPORT_ARRAY
-#include "numpy/noprefix.h"
+#include "numpy/ndarrayobject.h"
 
 void compute_root_from_lambda(double, double *, double *);
 
@@ -21,10 +21,11 @@ void S_IIR_order2(float,float,float,float*,float*,int,int,int);
 void S_IIR_order2_cascade(float,float,float,float,float*,float*,int,int,int);
 int S_IIR_forback1(float,float,float*,float*,int,int,int,float);
 void S_FIR_mirror_symmetric(float*,float*,int,float*,int,int,int);
-int S_separable_2Dconvolve_mirror(float*,float*,int,int,float*,float*,int,int,intp*,intp*);
+int S_separable_2Dconvolve_mirror(float*,float*,int,int,float*,float*,int,int,
+                                  npy_intp*,npy_intp*);
 int S_IIR_forback2(double,double,float*,float*,int,int,int,float); 
-int S_cubic_spline2D(float*,float*,int,int,double,intp*,intp*,float);
-int S_quadratic_spline2D(float*,float*,int,int,double,intp*,intp*,float);
+int S_cubic_spline2D(float*,float*,int,int,double,npy_intp*,npy_intp*,float);
+int S_quadratic_spline2D(float*,float*,int,int,double,npy_intp*,npy_intp*,float);
 
 /* Implement the following difference equation */
 /* y[n] = a1 * x[n] + a2 * y[n-1]  */
@@ -235,7 +236,7 @@ S_FIR_mirror_symmetric (float *in, float *out, int N, float *h, int Nh,
 int
 S_separable_2Dconvolve_mirror(float *in, float *out, int M, int N, 
 			      float *hr, float *hc, int Nhr, 
-			      int Nhc, intp *instrides, intp *outstrides) {
+			      int Nhc, npy_intp *instrides, npy_intp *outstrides) {
     int m, n;
     float *tmpmem;
     float *inptr=NULL, *outptr=NULL;
@@ -458,7 +459,7 @@ S_IIR_forback2 (double r, double omega, float *x, float *y,
 
 int 
 S_cubic_spline2D(float *image, float *coeffs, int M, int N, double lambda,
-		 intp *strides, intp *cstrides, float precision) {    
+		 npy_intp *strides, npy_intp *cstrides, float precision) {    
     double r, omega;
     float *inptr;
     float *coptr;
@@ -545,7 +546,7 @@ S_cubic_spline2D(float *image, float *coeffs, int M, int N, double lambda,
 
 int 
 S_quadratic_spline2D(float *image, float *coeffs, int M, int N, double lambda,
-		     intp *strides, intp *cstrides, float precision) {    
+		     npy_intp *strides, npy_intp *cstrides, float precision) {    
     double r;
     float *inptr;
     float *coptr;

--- a/scipy/signal/correlate_nd.c.src
+++ b/scipy/signal/correlate_nd.c.src
@@ -5,8 +5,7 @@
 #include <Python.h>
 #define PY_ARRAY_UNIQUE_SYMBOL _scipy_signal_ARRAY_API
 #define NO_IMPORT_ARRAY
-#include <numpy/noprefix.h>
-
+#include "numpy/ndarrayobject.h"
 #include "sigtools.h"
 
 enum {
@@ -107,10 +106,10 @@ clean_ax:
  */
 
 /**begin repeat
- * #fsuf = ubyte, byte, ushort, short, uint, int, ulong, long, ulonglong,
- *         longlong, float, double, longdouble#
- * #type = ubyte, byte, ushort, short, uint, int, ulong, long, ulonglong,
- *         longlong, float, double, npy_longdouble#
+ * #fsuf = ubyte, byte, ushort, short, uint, int, ulong,
+ *         long, ulonglong, longlong, float, double, longdouble#
+ * #type = npy_ubyte, npy_byte, npy_ushort, short, npy_uint, int, npy_ulong,
+ *         long, npy_ulonglong, npy_longlong, float, double, npy_longdouble#
  */
 
 static int _imp_correlate_nd_@fsuf@(PyArrayNeighborhoodIterObject *curx,

--- a/scipy/signal/firfilter.c
+++ b/scipy/signal/firfilter.c
@@ -65,7 +65,7 @@ static void fname ## _onemultadd2(char *sum, char *term1, char *term2) { \
   return; }
 
 #define MAKE_C_ONEMULTADD2(fname, type) \
-static void fname ## _onemultadd(char *sum, char *term1, npy_intp str,
+static void fname ## _onemultadd(char *sum, char *term1, npy_intp str, \
                                  char **pvals, npy_intp n) { \
         npy_intp k; \
         for (k=0; k < n; k++) { \

--- a/scipy/signal/firfilter.c
+++ b/scipy/signal/firfilter.c
@@ -1,31 +1,32 @@
 #define NO_IMPORT_ARRAY
+#include "numpy/ndarrayobject.h"
 #include "sigtools.h"
 
-static int elsizes[] = {sizeof(Bool),
-			sizeof(byte),
-                        sizeof(ubyte),
-                        sizeof(short),
-                        sizeof(ushort),
+static int elsizes[] = {sizeof(npy_bool),
+			            sizeof(npy_byte),
+                        sizeof(npy_ubyte),
+                        sizeof(npy_short),
+                        sizeof(npy_ushort),
                         sizeof(int),
-			sizeof(uint),
-			sizeof(long),
-                        sizeof(ulong),
-                        sizeof(longlong),
-			sizeof(ulonglong),
+                        sizeof(npy_uint),
+                        sizeof(long),
+                        sizeof(npy_ulong),
+                        sizeof(npy_longlong),
+                        sizeof(npy_ulonglong),
                         sizeof(float),
                         sizeof(double),
-			sizeof(longdouble),
-                        sizeof(cfloat),
-                        sizeof(cdouble),
-			sizeof(clongdouble),
+                        sizeof(npy_longdouble),
+                        sizeof(npy_cfloat),
+                        sizeof(npy_cdouble),
+                        sizeof(npy_clongdouble),
                         sizeof(void *),
 			0,0,0,0};
 
-typedef void (OneMultAddFunction) (char *, char *, intp, char **, intp);
+typedef void (OneMultAddFunction) (char *, char *, npy_intp, char **, npy_intp);
 
 #define MAKE_ONEMULTADD(fname, type) \
-static void fname ## _onemultadd(char *sum, char *term1, intp str, char **pvals, intp n) { \
-        intp k; \
+static void fname ## _onemultadd(char *sum, char *term1, npy_intp str, char **pvals, npy_intp n) { \
+        npy_intp k; \
         type dsum = *(type*)sum; \
         for (k=0; k < n; k++) { \
           type tmp = *(type*)(term1 + k * str); \
@@ -34,21 +35,21 @@ static void fname ## _onemultadd(char *sum, char *term1, intp str, char **pvals,
         *(type*)(sum) = dsum; \
 }
 
-MAKE_ONEMULTADD(UBYTE, ubyte)
-MAKE_ONEMULTADD(USHORT, ushort)
-MAKE_ONEMULTADD(UINT, uint)
-MAKE_ONEMULTADD(ULONG, ulong)
-MAKE_ONEMULTADD(ULONGLONG, ulonglong)
+MAKE_ONEMULTADD(UBYTE, npy_ubyte)
+MAKE_ONEMULTADD(USHORT, npy_ushort)
+MAKE_ONEMULTADD(UINT, npy_uint)
+MAKE_ONEMULTADD(ULONG, npy_ulong)
+MAKE_ONEMULTADD(ULONGLONG, npy_ulonglong)
 
-MAKE_ONEMULTADD(BYTE, byte)
+MAKE_ONEMULTADD(BYTE, npy_byte)
 MAKE_ONEMULTADD(SHORT, short)
 MAKE_ONEMULTADD(INT, int)
 MAKE_ONEMULTADD(LONG, long)
-MAKE_ONEMULTADD(LONGLONG, longlong)
+MAKE_ONEMULTADD(LONGLONG, npy_longlong)
 
 MAKE_ONEMULTADD(FLOAT, float)
 MAKE_ONEMULTADD(DOUBLE, double)
-MAKE_ONEMULTADD(LONGDOUBLE, longdouble)
+MAKE_ONEMULTADD(LONGDOUBLE, npy_longdouble)
  
 #ifdef __GNUC__
 MAKE_ONEMULTADD(CFLOAT, __complex__ float)
@@ -64,18 +65,19 @@ static void fname ## _onemultadd2(char *sum, char *term1, char *term2) { \
   return; }
 
 #define MAKE_C_ONEMULTADD2(fname, type) \
-static void fname ## _onemultadd(char *sum, char *term1, intp str, char **pvals, intp n) { \
-        intp k; \
+static void fname ## _onemultadd(char *sum, char *term1, npy_intp str,
+                                 char **pvals, npy_intp n) { \
+        npy_intp k; \
         for (k=0; k < n; k++) { \
           fname ## _onemultadd2(sum, term1 + k * str, pvals[k]); \
         } \
 }
 MAKE_C_ONEMULTADD(CFLOAT, float)
 MAKE_C_ONEMULTADD(CDOUBLE, double)
-MAKE_C_ONEMULTADD(CLONGDOUBLE, longdouble)
+MAKE_C_ONEMULTADD(CLONGDOUBLE, npy_longdouble)
 MAKE_C_ONEMULTADD2(CFLOAT, float)
 MAKE_C_ONEMULTADD2(CDOUBLE, double)
-MAKE_C_ONEMULTADD2(CLONGDOUBLE, longdouble)
+MAKE_C_ONEMULTADD2(CLONGDOUBLE, npy_longdouble)
 #endif /* __GNUC__ */
 
 static OneMultAddFunction *OneMultAdd[]={NULL,
@@ -102,13 +104,13 @@ static OneMultAddFunction *OneMultAdd[]={NULL,
 
 
 int pylab_convolve_2d (char  *in,        /* Input data Ns[0] x Ns[1] */
-		       intp   *instr,     /* Input strides */
+		       npy_intp   *instr,     /* Input strides */
 		       char  *out,       /* Output data */
-		       intp   *outstr,    /* Output strides */
+		       npy_intp   *outstr,    /* Output strides */
 		       char  *hvals,     /* coefficients in filter */
-		       intp   *hstr,      /* coefficients strides */ 
-		       intp   *Nwin,     /* Size of kernel Nwin[0] x Nwin[1] */
-		       intp   *Ns,        /* Size of image Ns[0] x Ns[1] */
+		       npy_intp   *hstr,      /* coefficients strides */ 
+		       npy_intp   *Nwin,     /* Size of kernel Nwin[0] x Nwin[1] */
+		       npy_intp   *Ns,        /* Size of image Ns[0] x Ns[1] */
 		       int   flag,       /* convolution parameters */
 		       char  *fillvalue) /* fill value */
 {
@@ -180,13 +182,13 @@ int pylab_convolve_2d (char  *in,        /* Input data Ns[0] x Ns[1] */
 	if (!bounds_pad_flag) ind0_memory = ind0*instr[0];
 
         if (bounds_pad_flag) {
-          intp k;
+          npy_intp k;
           for (k=0; k < Nwin[1]; k++) {
               indices[k] = fillvalue;
           }
         }
         else  {
-          intp k;
+          npy_intp k;
 	  for (k=0; k < Nwin[1]; k++) {
 	    ind1 = convolve ? (new_n-k) : (new_n+k);
 	    if (ind1 < 0) {

--- a/scipy/signal/lfilter.c.src
+++ b/scipy/signal/lfilter.c.src
@@ -5,7 +5,7 @@
 #include <Python.h>
 #define PY_ARRAY_UNIQUE_SYMBOL _scipy_signal_ARRAY_API
 #define NO_IMPORT_ARRAY
-#include <numpy/noprefix.h>
+#include <numpy/ndarrayobject.h>
 #include <numpy/npy_3kcompat.h>
 
 #if PY_VERSION_HEX >= 0x03000000
@@ -15,28 +15,29 @@
 #include "sigtools.h"
 
 static void FLOAT_filt(char *b, char *a, char *x, char *y, char *Z,
-                       intp len_b, uintp len_x, intp stride_X,
-                       intp stride_Y);
+                       npy_intp len_b, npy_uintp len_x, npy_intp stride_X,
+                       npy_intp stride_Y);
 static void DOUBLE_filt(char *b, char *a, char *x, char *y, char *Z,
-                        intp len_b, uintp len_x, intp stride_X,
-                        intp stride_Y);
+                        npy_intp len_b, npy_uintp len_x, npy_intp stride_X,
+                        npy_intp stride_Y);
 static void EXTENDED_filt(char *b, char *a, char *x, char *y, char *Z,
-                        intp len_b, uintp len_x, intp stride_X,
-                        intp stride_Y);
+                        npy_intp len_b, npy_uintp len_x, npy_intp stride_X,
+                        npy_intp stride_Y);
 static void CFLOAT_filt(char *b, char *a, char *x, char *y, char *Z,
-                        intp len_b, uintp len_x, intp stride_X,
-                        intp stride_Y);
+                        npy_intp len_b, npy_uintp len_x, npy_intp stride_X,
+                        npy_intp stride_Y);
 static void CDOUBLE_filt(char *b, char *a, char *x, char *y, char *Z,
-                         intp len_b, uintp len_x, intp stride_X,
-                         intp stride_Y);
+                         npy_intp len_b, npy_uintp len_x, npy_intp stride_X,
+                         npy_intp stride_Y);
 static void CEXTENDED_filt(char *b, char *a, char *x, char *y, char *Z,
-                         intp len_b, uintp len_x, intp stride_X,
-                         intp stride_Y);
+                         npy_intp len_b, npy_uintp len_x, npy_intp stride_X,
+                         npy_intp stride_Y);
 static void OBJECT_filt(char *b, char *a, char *x, char *y, char *Z,
-                        intp len_b, uintp len_x, intp stride_X,
-                        intp stride_Y);
+                        npy_intp len_b, npy_uintp len_x, npy_intp stride_X,
+                        npy_intp stride_Y);
 
-typedef void (BasicFilterFunction) (char *, char *,  char *, char *, char *, intp, uintp, intp, intp);
+typedef void (BasicFilterFunction) (char *, char *,  char *, char *, char *,
+                                    npy_intp, npy_uintp, npy_intp, npy_intp);
 
 static BasicFilterFunction *BasicFilterFunctions[256];
 
@@ -65,9 +66,10 @@ RawFilter(const PyArrayObject * b, const PyArrayObject * a,
           BasicFilterFunction * filter_func);
 
 PyObject*
-convert_shape_to_errmsg(intp ndim, intp *Xshape, intp *Vishape, intp theaxis, intp val)
+convert_shape_to_errmsg(npy_intp ndim, npy_intp *Xshape, npy_intp *Vishape,
+                        npy_intp theaxis, npy_intp val)
 {
-    intp j, expect_size;
+    npy_intp j, expect_size;
     PyObject *msg, *tmp, *msg1, *tmp1;
 
     if (ndim == 1) {
@@ -133,8 +135,8 @@ scipy_signal_sigtools_linear_filter(PyObject * NPY_UNUSED(dummy), PyObject * arg
     PyArrayObject *arY, *arb, *ara, *arX, *arVi, *arVf;
     int axis, typenum, theaxis, st, Vi_needs_broadcasted = 0;
     char *ara_ptr, input_flag = 0, *azero;
-    intp na, nb, nal, zi_size;
-    intp zf_shape[NPY_MAXDIMS];
+    npy_intp na, nb, nal, zi_size;
+    npy_intp zf_shape[NPY_MAXDIMS];
     BasicFilterFunction *basic_filter;
 
     axis = -1;
@@ -229,7 +231,7 @@ scipy_signal_sigtools_linear_filter(PyObject * NPY_UNUSED(dummy), PyObject * arg
     nb = PyArray_SIZE(arb);
     zi_size = (na > nb ? na : nb) - 1;
     if (input_flag) {
-        intp k, Vik, Xk;
+        npy_intp k, Vik, Xk;
         for (k = 0; k < PyArray_NDIM(arX); ++k) {
             Vik = PyArray_DIM(arVi, k);
             Xk = PyArray_DIM(arX, k);
@@ -345,10 +347,10 @@ scipy_signal_sigtools_linear_filter(PyObject * NPY_UNUSED(dummy), PyObject * arg
  * 0s
  */
 static int
-zfill(const PyArrayObject * x, intp nx, char *xzfilled, intp nxzfilled)
+zfill(const PyArrayObject * x, npy_intp nx, char *xzfilled, npy_intp nxzfilled)
 {
     char *xzero;
-    intp i, nxl;
+    npy_intp i, nxl;
     PyArray_CopySwapFunc *copyswap = PyArray_DESCR((PyArrayObject *)x)->f->copyswap;
 
     nxl = PyArray_ITEMSIZE(x);
@@ -389,9 +391,9 @@ RawFilter(const PyArrayObject * b, const PyArrayObject * a,
           BasicFilterFunction * filter_func)
 {
     PyArrayIterObject *itx, *ity, *itzi = NULL, *itzf = NULL;
-    intp nitx, i, nxl, nzfl, j;
-    intp na, nb, nal, nbl;
-    intp nfilt;
+    npy_intp nitx, i, nxl, nzfl, j;
+    npy_intp na, nb, nal, nbl;
+    npy_intp nfilt;
     char *azfilled, *bzfilled, *zfzfilled, *yoyo;
     PyArray_CopySwapFunc *copyswap = PyArray_DESCR((PyArrayObject *)x)->f->copyswap;
 
@@ -552,8 +554,8 @@ fail:
  * #NAME = FLOAT, DOUBLE, EXTENDED#
  */
 static void @NAME@_filt(char *b, char *a, char *x, char *y, char *Z,
-                       intp len_b, uintp len_x, intp stride_X,
-                       intp stride_Y)
+                       npy_intp len_b, npy_uintp len_x, npy_intp stride_X,
+                       npy_intp stride_Y)
 {
     char *ptr_x = x, *ptr_y = y;
     @type@ *ptr_Z;
@@ -561,8 +563,8 @@ static void @NAME@_filt(char *b, char *a, char *x, char *y, char *Z,
     @type@ *ptr_a = (@type@*)a;
     @type@ *xn, *yn;
     const @type@ a0 = *((@type@ *) a);
-    intp n;
-    uintp k;
+    npy_intp n;
+    npy_uintp k;
 
     /* normalize the filter coefs only once. */
     for (n = 0; n < len_b; ++n) {
@@ -600,8 +602,8 @@ static void @NAME@_filt(char *b, char *a, char *x, char *y, char *Z,
 }
 
 static void C@NAME@_filt(char *b, char *a, char *x, char *y, char *Z,
-                        intp len_b, uintp len_x, intp stride_X,
-                        intp stride_Y)
+                        npy_intp len_b, npy_uintp len_x, npy_intp stride_X,
+                        npy_intp stride_Y)
 {
     char *ptr_x = x, *ptr_y = y;
     @type@ *ptr_Z, *ptr_b;
@@ -610,8 +612,8 @@ static void C@NAME@_filt(char *b, char *a, char *x, char *y, char *Z,
     @type@ a0r = ((@type@ *) a)[0];
     @type@ a0i = ((@type@ *) a)[1];
     @type@ a0_mag, tmpr, tmpi;
-    intp n;
-    uintp k;
+    npy_intp n;
+    npy_uintp k;
 
     a0_mag = a0r * a0r + a0i * a0i;
     for (k = 0; k < len_x; k++) {
@@ -669,8 +671,8 @@ static void C@NAME@_filt(char *b, char *a, char *x, char *y, char *Z,
 /**end repeat**/
 
 static void OBJECT_filt(char *b, char *a, char *x, char *y, char *Z,
-                        intp len_b, uintp len_x, intp stride_X,
-                        intp stride_Y)
+                        npy_intp len_b, npy_uintp len_x, npy_intp stride_X,
+                        npy_intp stride_Y)
 {
     char *ptr_x = x, *ptr_y = y;
     PyObject **ptr_Z, **ptr_b;
@@ -678,8 +680,8 @@ static void OBJECT_filt(char *b, char *a, char *x, char *y, char *Z,
     PyObject **xn, **yn;
     PyObject **a0 = (PyObject **) a;
     PyObject *tmp1, *tmp2, *tmp3;
-    intp n;
-    uintp k;
+    npy_intp n;
+    npy_uintp k;
 
     /* My reference counting might not be right */
     for (k = 0; k < len_x; k++) {

--- a/scipy/signal/medianfilter.c
+++ b/scipy/signal/medianfilter.c
@@ -3,13 +3,13 @@
 
 #include "Python.h"
 #define NO_IMPORT_ARRAY
-#include "numpy/noprefix.h"
+#include "numpy/ndarrayobject.h"
 
 
 /* defined below */
-void f_medfilt2(float*,float*,intp*,intp*);
-void d_medfilt2(double*,double*,intp*,intp*);
-void b_medfilt2(unsigned char*,unsigned char*,intp*,intp*);
+void f_medfilt2(float*,float*,npy_intp*,npy_intp*);
+void d_medfilt2(double*,double*,npy_intp*,npy_intp*);
+void b_medfilt2(unsigned char*,unsigned char*,npy_intp*,npy_intp*);
 extern char *check_malloc (int);
 
 
@@ -72,7 +72,7 @@ TYPE NAME(TYPE arr[], int n)                                            \
 
 /* 2-D median filter with zero-padding on edges. */
 #define MEDIAN_FILTER_2D(NAME, TYPE, SELECT)                            \
-void NAME(TYPE* in, TYPE* out, intp* Nwin, intp* Ns)                    \
+void NAME(TYPE* in, TYPE* out, npy_intp* Nwin, npy_intp* Ns)                    \
 {                                                                       \
     int nx, ny, hN[2];                                                  \
     int pre_x, pre_y, pos_x, pos_y;                                     \

--- a/scipy/signal/sigtools.h
+++ b/scipy/signal/sigtools.h
@@ -2,7 +2,6 @@
 #define _SCIPY_PRIVATE_SIGNAL_SIGTOOLS_H_
 
 #include "Python.h"
-#include "numpy/noprefix.h"
 
 #define BOUNDARY_MASK 12
 #define OUTSIZE_MASK 3
@@ -33,7 +32,7 @@ typedef struct {
 
 typedef struct {
   char *data;
-  intp numels;
+  npy_intp numels;
   int elsize;
   char *zero;        /* Pointer to Representation of zero */
 } Generic_Vector;
@@ -41,13 +40,15 @@ typedef struct {
 typedef struct {
   char *data;
   int  nd;
-  intp  *dimensions;
+  npy_intp  *dimensions;
   int  elsize;
-  intp  *strides;
+  npy_intp  *strides;
   char *zero;         /* Pointer to Representation of zero */
 } Generic_Array;
 
-typedef void (MultAddFunction) (char *, intp, char *, intp, char *, intp *, intp *, int, intp, int, intp *, intp *, uintp *);
+typedef void (MultAddFunction) (char *, npy_intp, char *, npy_intp, char *,
+                                npy_intp *, npy_intp *, int, npy_intp, int,
+                                npy_intp *, npy_intp *, npy_uintp *);
 
 PyObject*
 scipy_signal_sigtools_linear_filter(PyObject * NPY_UNUSED(dummy), PyObject * args);


### PR DESCRIPTION
It seems SciPy is still old NumPy names, and including a header that redefines the old names to the new ones. This PR removes the header and adjusts the code accordingly.