### PR TITLE
BUG: white/black_tophat behavior fixes

### DIFF
--- a/scipy/ndimage/morphology.py
+++ b/scipy/ndimage/morphology.py
@@ -1733,8 +1733,14 @@ def white_tophat(input, size=None, footprint=None, structure=None,
         warnings.warn("ignoring size because footprint is set", UserWarning, stacklevel=2)
     tmp = grey_erosion(input, size, footprint, structure, None, mode,
                        cval, origin)
-    tmp = grey_dilation(tmp, size, footprint, structure, output, mode,
-                        cval, origin)
+
+    if numpy.array_equal(input, output):
+        tmp = grey_dilation(tmp, size, footprint, structure, None, mode,
+                           cval, origin)
+    else:
+        tmp = grey_dilation(tmp, size, footprint, structure, output, mode,
+                           cval, origin)
+
     if tmp is None:
         tmp = output
 
@@ -1791,8 +1797,14 @@ def black_tophat(input, size=None, footprint=None,
         warnings.warn("ignoring size because footprint is set", UserWarning, stacklevel=2)
     tmp = grey_dilation(input, size, footprint, structure, None, mode,
                         cval, origin)
-    tmp = grey_erosion(tmp, size, footprint, structure, output, mode,
-                       cval, origin)
+
+    if numpy.array_equal(input, output):
+        tmp = grey_erosion(tmp, size, footprint, structure, None, mode,
+                           cval, origin)
+    else:
+        tmp = grey_erosion(tmp, size, footprint, structure, output, mode,
+                           cval, origin)
+
     if tmp is None:
         tmp = output
 

--- a/scipy/ndimage/morphology.py
+++ b/scipy/ndimage/morphology.py
@@ -1748,6 +1748,10 @@ def white_tophat(input, size=None, footprint=None, structure=None,
         numpy.bitwise_xor(input, tmp, out=tmp)
     else:
         numpy.subtract(input, tmp, out=tmp)
+
+    if numpy.array_equal(input, output):
+        output=tmp
+
     return tmp
 
 
@@ -1812,6 +1816,9 @@ def black_tophat(input, size=None, footprint=None,
         numpy.bitwise_xor(tmp, input, out=tmp)
     else:
         numpy.subtract(tmp, input, out=tmp)
+
+    if numpy.array_equal(input, output):
+        output=tmp
     return tmp
 
 

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -4456,7 +4456,7 @@ class TestNdimage:
     def test_white_tophat05(self):
         array = numpy.ones((3, 3))
         array[1,1] = 0.0
-        ndimage.white_tophat(array, size=3, output=array)
+        array = ndimage.white_tophat(array, size=3, output=array)
         expected = numpy.array([[1., 1., 1.],
                                 [1., 0., 1.],
                                 [1., 1., 1.]])
@@ -4520,10 +4520,10 @@ class TestNdimage:
     def test_black_tophat05(self):
         array = numpy.ones((3, 3))
         array[1, 1] = 0.0
-        ndimage.black_tophat(array, size=3, output=array)
-        expected = numpy.array([[1., 1., 1.],
-                                [1., 0., 1.],
-                                [1., 1., 1.]])
+        array = ndimage.black_tophat(array, size=3, output=array)
+        expected = numpy.array([[0., 0., 0.],
+                                [0., 1., 0.],
+                                [0., 0., 0.]])
         assert_array_equal(array, expected)
 
     def test_hit_or_miss01(self):

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -4453,6 +4453,15 @@ class TestNdimage:
         output = numpy.empty_like(array, dtype=numpy.float)
         ndimage.white_tophat(array, structure=structure, output=output)
 
+    def test_white_tophat05(self):
+        array = numpy.ones((3, 3))
+        array[1,1] = 0.0
+        ndimage.white_tophat(array, size=3, output=array)
+        expected = numpy.array([[1., 1., 1.],
+                                [1., 0., 1.],
+                                [1., 1., 1.]])
+        assert_array_equal(array, expected)
+
     def test_black_tophat01(self):
         array = numpy.array([[3, 2, 5, 1, 4],
                              [7, 6, 9, 3, 5],
@@ -4507,6 +4516,15 @@ class TestNdimage:
         # Check that type mismatch is properly handled
         output = numpy.empty_like(array, dtype=numpy.float)
         ndimage.black_tophat(array, structure=structure, output=output)
+
+    def test_black_tophat05(self):
+        array = numpy.ones((3, 3))
+        array[1, 1] = 0.0
+        ndimage.black_tophat(array, size=3, output=array)
+        expected = numpy.array([[1., 1., 1.],
+                                [1., 0., 1.],
+                                [1., 1., 1.]])
+        assert_array_equal(array, expected)
 
     def test_hit_or_miss01(self):
         struct = [[0, 1, 0],


### PR DESCRIPTION
closes #9553 

When the name of input parameter and output parameter is same in `ndimage.white_tophat()`/`ndimage.black_tophat()`, they gives zero.

I have designed the solution by comparing input and output.
