### PR TITLE
REV: restore noprefix.h

### DIFF
--- a/scipy/signal/S_bspline_util.c
+++ b/scipy/signal/S_bspline_util.c
@@ -5,7 +5,7 @@
 #include <string.h>
 #include <stdio.h>
 #define NO_IMPORT_ARRAY
-#include "numpy/ndarrayobject.h"
+#include "numpy/noprefix.h"
 
 void compute_root_from_lambda(double, double *, double *);
 
@@ -21,11 +21,10 @@ void S_IIR_order2(float,float,float,float*,float*,int,int,int);
 void S_IIR_order2_cascade(float,float,float,float,float*,float*,int,int,int);
 int S_IIR_forback1(float,float,float*,float*,int,int,int,float);
 void S_FIR_mirror_symmetric(float*,float*,int,float*,int,int,int);
-int S_separable_2Dconvolve_mirror(float*,float*,int,int,float*,float*,int,int,
-                                  npy_intp*,npy_intp*);
+int S_separable_2Dconvolve_mirror(float*,float*,int,int,float*,float*,int,int,intp*,intp*);
 int S_IIR_forback2(double,double,float*,float*,int,int,int,float); 
-int S_cubic_spline2D(float*,float*,int,int,double,npy_intp*,npy_intp*,float);
-int S_quadratic_spline2D(float*,float*,int,int,double,npy_intp*,npy_intp*,float);
+int S_cubic_spline2D(float*,float*,int,int,double,intp*,intp*,float);
+int S_quadratic_spline2D(float*,float*,int,int,double,intp*,intp*,float);
 
 /* Implement the following difference equation */
 /* y[n] = a1 * x[n] + a2 * y[n-1]  */
@@ -236,7 +235,7 @@ S_FIR_mirror_symmetric (float *in, float *out, int N, float *h, int Nh,
 int
 S_separable_2Dconvolve_mirror(float *in, float *out, int M, int N, 
 			      float *hr, float *hc, int Nhr, 
-			      int Nhc, npy_intp *instrides, npy_intp *outstrides) {
+			      int Nhc, intp *instrides, intp *outstrides) {
     int m, n;
     float *tmpmem;
     float *inptr=NULL, *outptr=NULL;
@@ -459,7 +458,7 @@ S_IIR_forback2 (double r, double omega, float *x, float *y,
 
 int 
 S_cubic_spline2D(float *image, float *coeffs, int M, int N, double lambda,
-		 npy_intp *strides, npy_intp *cstrides, float precision) {    
+		 intp *strides, intp *cstrides, float precision) {    
     double r, omega;
     float *inptr;
     float *coptr;
@@ -546,7 +545,7 @@ S_cubic_spline2D(float *image, float *coeffs, int M, int N, double lambda,
 
 int 
 S_quadratic_spline2D(float *image, float *coeffs, int M, int N, double lambda,
-		     npy_intp *strides, npy_intp *cstrides, float precision) {    
+		     intp *strides, intp *cstrides, float precision) {    
     double r;
     float *inptr;
     float *coptr;

--- a/scipy/signal/correlate_nd.c.src
+++ b/scipy/signal/correlate_nd.c.src
@@ -5,7 +5,8 @@
 #include <Python.h>
 #define PY_ARRAY_UNIQUE_SYMBOL _scipy_signal_ARRAY_API
 #define NO_IMPORT_ARRAY
-#include "numpy/ndarrayobject.h"
+#include <numpy/noprefix.h>
+
 #include "sigtools.h"
 
 enum {
@@ -106,10 +107,10 @@ clean_ax:
  */
 
 /**begin repeat
- * #fsuf = ubyte, byte, ushort, short, uint, int, ulong,
- *         long, ulonglong, longlong, float, double, longdouble#
- * #type = npy_ubyte, npy_byte, npy_ushort, short, npy_uint, int, npy_ulong,
- *         long, npy_ulonglong, npy_longlong, float, double, npy_longdouble#
+ * #fsuf = ubyte, byte, ushort, short, uint, int, ulong, long, ulonglong,
+ *         longlong, float, double, longdouble#
+ * #type = ubyte, byte, ushort, short, uint, int, ulong, long, ulonglong,
+ *         longlong, float, double, npy_longdouble#
  */
 
 static int _imp_correlate_nd_@fsuf@(PyArrayNeighborhoodIterObject *curx,

--- a/scipy/signal/firfilter.c
+++ b/scipy/signal/firfilter.c
@@ -1,32 +1,31 @@
 #define NO_IMPORT_ARRAY
-#include "numpy/ndarrayobject.h"
 #include "sigtools.h"
 
-static int elsizes[] = {sizeof(npy_bool),
-			            sizeof(npy_byte),
-                        sizeof(npy_ubyte),
-                        sizeof(npy_short),
-                        sizeof(npy_ushort),
+static int elsizes[] = {sizeof(Bool),
+			sizeof(byte),
+                        sizeof(ubyte),
+                        sizeof(short),
+                        sizeof(ushort),
                         sizeof(int),
-                        sizeof(npy_uint),
-                        sizeof(long),
-                        sizeof(npy_ulong),
-                        sizeof(npy_longlong),
-                        sizeof(npy_ulonglong),
+			sizeof(uint),
+			sizeof(long),
+                        sizeof(ulong),
+                        sizeof(longlong),
+			sizeof(ulonglong),
                         sizeof(float),
                         sizeof(double),
-                        sizeof(npy_longdouble),
-                        sizeof(npy_cfloat),
-                        sizeof(npy_cdouble),
-                        sizeof(npy_clongdouble),
+			sizeof(longdouble),
+                        sizeof(cfloat),
+                        sizeof(cdouble),
+			sizeof(clongdouble),
                         sizeof(void *),
 			0,0,0,0};
 
-typedef void (OneMultAddFunction) (char *, char *, npy_intp, char **, npy_intp);
+typedef void (OneMultAddFunction) (char *, char *, intp, char **, intp);
 
 #define MAKE_ONEMULTADD(fname, type) \
-static void fname ## _onemultadd(char *sum, char *term1, npy_intp str, char **pvals, npy_intp n) { \
-        npy_intp k; \
+static void fname ## _onemultadd(char *sum, char *term1, intp str, char **pvals, intp n) { \
+        intp k; \
         type dsum = *(type*)sum; \
         for (k=0; k < n; k++) { \
           type tmp = *(type*)(term1 + k * str); \
@@ -35,21 +34,21 @@ static void fname ## _onemultadd(char *sum, char *term1, npy_intp str, char **pv
         *(type*)(sum) = dsum; \
 }
 
-MAKE_ONEMULTADD(UBYTE, npy_ubyte)
-MAKE_ONEMULTADD(USHORT, npy_ushort)
-MAKE_ONEMULTADD(UINT, npy_uint)
-MAKE_ONEMULTADD(ULONG, npy_ulong)
-MAKE_ONEMULTADD(ULONGLONG, npy_ulonglong)
+MAKE_ONEMULTADD(UBYTE, ubyte)
+MAKE_ONEMULTADD(USHORT, ushort)
+MAKE_ONEMULTADD(UINT, uint)
+MAKE_ONEMULTADD(ULONG, ulong)
+MAKE_ONEMULTADD(ULONGLONG, ulonglong)
 
-MAKE_ONEMULTADD(BYTE, npy_byte)
+MAKE_ONEMULTADD(BYTE, byte)
 MAKE_ONEMULTADD(SHORT, short)
 MAKE_ONEMULTADD(INT, int)
 MAKE_ONEMULTADD(LONG, long)
-MAKE_ONEMULTADD(LONGLONG, npy_longlong)
+MAKE_ONEMULTADD(LONGLONG, longlong)
 
 MAKE_ONEMULTADD(FLOAT, float)
 MAKE_ONEMULTADD(DOUBLE, double)
-MAKE_ONEMULTADD(LONGDOUBLE, npy_longdouble)
+MAKE_ONEMULTADD(LONGDOUBLE, longdouble)
  
 #ifdef __GNUC__
 MAKE_ONEMULTADD(CFLOAT, __complex__ float)
@@ -65,19 +64,18 @@ static void fname ## _onemultadd2(char *sum, char *term1, char *term2) { \
   return; }
 
 #define MAKE_C_ONEMULTADD2(fname, type) \
-static void fname ## _onemultadd(char *sum, char *term1, npy_intp str, \
-                                 char **pvals, npy_intp n) { \
-        npy_intp k; \
+static void fname ## _onemultadd(char *sum, char *term1, intp str, char **pvals, intp n) { \
+        intp k; \
         for (k=0; k < n; k++) { \
           fname ## _onemultadd2(sum, term1 + k * str, pvals[k]); \
         } \
 }
 MAKE_C_ONEMULTADD(CFLOAT, float)
 MAKE_C_ONEMULTADD(CDOUBLE, double)
-MAKE_C_ONEMULTADD(CLONGDOUBLE, npy_longdouble)
+MAKE_C_ONEMULTADD(CLONGDOUBLE, longdouble)
 MAKE_C_ONEMULTADD2(CFLOAT, float)
 MAKE_C_ONEMULTADD2(CDOUBLE, double)
-MAKE_C_ONEMULTADD2(CLONGDOUBLE, npy_longdouble)
+MAKE_C_ONEMULTADD2(CLONGDOUBLE, longdouble)
 #endif /* __GNUC__ */
 
 static OneMultAddFunction *OneMultAdd[]={NULL,
@@ -104,13 +102,13 @@ static OneMultAddFunction *OneMultAdd[]={NULL,
 
 
 int pylab_convolve_2d (char  *in,        /* Input data Ns[0] x Ns[1] */
-		       npy_intp   *instr,     /* Input strides */
+		       intp   *instr,     /* Input strides */
 		       char  *out,       /* Output data */
-		       npy_intp   *outstr,    /* Output strides */
+		       intp   *outstr,    /* Output strides */
 		       char  *hvals,     /* coefficients in filter */
-		       npy_intp   *hstr,      /* coefficients strides */ 
-		       npy_intp   *Nwin,     /* Size of kernel Nwin[0] x Nwin[1] */
-		       npy_intp   *Ns,        /* Size of image Ns[0] x Ns[1] */
+		       intp   *hstr,      /* coefficients strides */ 
+		       intp   *Nwin,     /* Size of kernel Nwin[0] x Nwin[1] */
+		       intp   *Ns,        /* Size of image Ns[0] x Ns[1] */
 		       int   flag,       /* convolution parameters */
 		       char  *fillvalue) /* fill value */
 {
@@ -182,13 +180,13 @@ int pylab_convolve_2d (char  *in,        /* Input data Ns[0] x Ns[1] */
 	if (!bounds_pad_flag) ind0_memory = ind0*instr[0];
 
         if (bounds_pad_flag) {
-          npy_intp k;
+          intp k;
           for (k=0; k < Nwin[1]; k++) {
               indices[k] = fillvalue;
           }
         }
         else  {
-          npy_intp k;
+          intp k;
 	  for (k=0; k < Nwin[1]; k++) {
 	    ind1 = convolve ? (new_n-k) : (new_n+k);
 	    if (ind1 < 0) {

--- a/scipy/signal/lfilter.c.src
+++ b/scipy/signal/lfilter.c.src
@@ -5,7 +5,7 @@
 #include <Python.h>
 #define PY_ARRAY_UNIQUE_SYMBOL _scipy_signal_ARRAY_API
 #define NO_IMPORT_ARRAY
-#include <numpy/ndarrayobject.h>
+#include <numpy/noprefix.h>
 #include <numpy/npy_3kcompat.h>
 
 #if PY_VERSION_HEX >= 0x03000000
@@ -15,29 +15,28 @@
 #include "sigtools.h"
 
 static void FLOAT_filt(char *b, char *a, char *x, char *y, char *Z,
-                       npy_intp len_b, npy_uintp len_x, npy_intp stride_X,
-                       npy_intp stride_Y);
+                       intp len_b, uintp len_x, intp stride_X,
+                       intp stride_Y);
 static void DOUBLE_filt(char *b, char *a, char *x, char *y, char *Z,
-                        npy_intp len_b, npy_uintp len_x, npy_intp stride_X,
-                        npy_intp stride_Y);
+                        intp len_b, uintp len_x, intp stride_X,
+                        intp stride_Y);
 static void EXTENDED_filt(char *b, char *a, char *x, char *y, char *Z,
-                        npy_intp len_b, npy_uintp len_x, npy_intp stride_X,
-                        npy_intp stride_Y);
+                        intp len_b, uintp len_x, intp stride_X,
+                        intp stride_Y);
 static void CFLOAT_filt(char *b, char *a, char *x, char *y, char *Z,
-                        npy_intp len_b, npy_uintp len_x, npy_intp stride_X,
-                        npy_intp stride_Y);
+                        intp len_b, uintp len_x, intp stride_X,
+                        intp stride_Y);
 static void CDOUBLE_filt(char *b, char *a, char *x, char *y, char *Z,
-                         npy_intp len_b, npy_uintp len_x, npy_intp stride_X,
-                         npy_intp stride_Y);
+                         intp len_b, uintp len_x, intp stride_X,
+                         intp stride_Y);
 static void CEXTENDED_filt(char *b, char *a, char *x, char *y, char *Z,
-                         npy_intp len_b, npy_uintp len_x, npy_intp stride_X,
-                         npy_intp stride_Y);
+                         intp len_b, uintp len_x, intp stride_X,
+                         intp stride_Y);
 static void OBJECT_filt(char *b, char *a, char *x, char *y, char *Z,
-                        npy_intp len_b, npy_uintp len_x, npy_intp stride_X,
-                        npy_intp stride_Y);
+                        intp len_b, uintp len_x, intp stride_X,
+                        intp stride_Y);
 
-typedef void (BasicFilterFunction) (char *, char *,  char *, char *, char *,
-                                    npy_intp, npy_uintp, npy_intp, npy_intp);
+typedef void (BasicFilterFunction) (char *, char *,  char *, char *, char *, intp, uintp, intp, intp);
 
 static BasicFilterFunction *BasicFilterFunctions[256];
 
@@ -66,10 +65,9 @@ RawFilter(const PyArrayObject * b, const PyArrayObject * a,
           BasicFilterFunction * filter_func);
 
 PyObject*
-convert_shape_to_errmsg(npy_intp ndim, npy_intp *Xshape, npy_intp *Vishape,
-                        npy_intp theaxis, npy_intp val)
+convert_shape_to_errmsg(intp ndim, intp *Xshape, intp *Vishape, intp theaxis, intp val)
 {
-    npy_intp j, expect_size;
+    intp j, expect_size;
     PyObject *msg, *tmp, *msg1, *tmp1;
 
     if (ndim == 1) {
@@ -135,8 +133,8 @@ scipy_signal_sigtools_linear_filter(PyObject * NPY_UNUSED(dummy), PyObject * arg
     PyArrayObject *arY, *arb, *ara, *arX, *arVi, *arVf;
     int axis, typenum, theaxis, st, Vi_needs_broadcasted = 0;
     char *ara_ptr, input_flag = 0, *azero;
-    npy_intp na, nb, nal, zi_size;
-    npy_intp zf_shape[NPY_MAXDIMS];
+    intp na, nb, nal, zi_size;
+    intp zf_shape[NPY_MAXDIMS];
     BasicFilterFunction *basic_filter;
 
     axis = -1;
@@ -231,7 +229,7 @@ scipy_signal_sigtools_linear_filter(PyObject * NPY_UNUSED(dummy), PyObject * arg
     nb = PyArray_SIZE(arb);
     zi_size = (na > nb ? na : nb) - 1;
     if (input_flag) {
-        npy_intp k, Vik, Xk;
+        intp k, Vik, Xk;
         for (k = 0; k < PyArray_NDIM(arX); ++k) {
             Vik = PyArray_DIM(arVi, k);
             Xk = PyArray_DIM(arX, k);
@@ -347,10 +345,10 @@ scipy_signal_sigtools_linear_filter(PyObject * NPY_UNUSED(dummy), PyObject * arg
  * 0s
  */
 static int
-zfill(const PyArrayObject * x, npy_intp nx, char *xzfilled, npy_intp nxzfilled)
+zfill(const PyArrayObject * x, intp nx, char *xzfilled, intp nxzfilled)
 {
     char *xzero;
-    npy_intp i, nxl;
+    intp i, nxl;
     PyArray_CopySwapFunc *copyswap = PyArray_DESCR((PyArrayObject *)x)->f->copyswap;
 
     nxl = PyArray_ITEMSIZE(x);
@@ -391,9 +389,9 @@ RawFilter(const PyArrayObject * b, const PyArrayObject * a,
           BasicFilterFunction * filter_func)
 {
     PyArrayIterObject *itx, *ity, *itzi = NULL, *itzf = NULL;
-    npy_intp nitx, i, nxl, nzfl, j;
-    npy_intp na, nb, nal, nbl;
-    npy_intp nfilt;
+    intp nitx, i, nxl, nzfl, j;
+    intp na, nb, nal, nbl;
+    intp nfilt;
     char *azfilled, *bzfilled, *zfzfilled, *yoyo;
     PyArray_CopySwapFunc *copyswap = PyArray_DESCR((PyArrayObject *)x)->f->copyswap;
 
@@ -554,8 +552,8 @@ fail:
  * #NAME = FLOAT, DOUBLE, EXTENDED#
  */
 static void @NAME@_filt(char *b, char *a, char *x, char *y, char *Z,
-                       npy_intp len_b, npy_uintp len_x, npy_intp stride_X,
-                       npy_intp stride_Y)
+                       intp len_b, uintp len_x, intp stride_X,
+                       intp stride_Y)
 {
     char *ptr_x = x, *ptr_y = y;
     @type@ *ptr_Z;
@@ -563,8 +561,8 @@ static void @NAME@_filt(char *b, char *a, char *x, char *y, char *Z,
     @type@ *ptr_a = (@type@*)a;
     @type@ *xn, *yn;
     const @type@ a0 = *((@type@ *) a);
-    npy_intp n;
-    npy_uintp k;
+    intp n;
+    uintp k;
 
     /* normalize the filter coefs only once. */
     for (n = 0; n < len_b; ++n) {
@@ -602,8 +600,8 @@ static void @NAME@_filt(char *b, char *a, char *x, char *y, char *Z,
 }
 
 static void C@NAME@_filt(char *b, char *a, char *x, char *y, char *Z,
-                        npy_intp len_b, npy_uintp len_x, npy_intp stride_X,
-                        npy_intp stride_Y)
+                        intp len_b, uintp len_x, intp stride_X,
+                        intp stride_Y)
 {
     char *ptr_x = x, *ptr_y = y;
     @type@ *ptr_Z, *ptr_b;
@@ -612,8 +610,8 @@ static void C@NAME@_filt(char *b, char *a, char *x, char *y, char *Z,
     @type@ a0r = ((@type@ *) a)[0];
     @type@ a0i = ((@type@ *) a)[1];
     @type@ a0_mag, tmpr, tmpi;
-    npy_intp n;
-    npy_uintp k;
+    intp n;
+    uintp k;
 
     a0_mag = a0r * a0r + a0i * a0i;
     for (k = 0; k < len_x; k++) {
@@ -671,8 +669,8 @@ static void C@NAME@_filt(char *b, char *a, char *x, char *y, char *Z,
 /**end repeat**/
 
 static void OBJECT_filt(char *b, char *a, char *x, char *y, char *Z,
-                        npy_intp len_b, npy_uintp len_x, npy_intp stride_X,
-                        npy_intp stride_Y)
+                        intp len_b, uintp len_x, intp stride_X,
+                        intp stride_Y)
 {
     char *ptr_x = x, *ptr_y = y;
     PyObject **ptr_Z, **ptr_b;
@@ -680,8 +678,8 @@ static void OBJECT_filt(char *b, char *a, char *x, char *y, char *Z,
     PyObject **xn, **yn;
     PyObject **a0 = (PyObject **) a;
     PyObject *tmp1, *tmp2, *tmp3;
-    npy_intp n;
-    npy_uintp k;
+    intp n;
+    uintp k;
 
     /* My reference counting might not be right */
     for (k = 0; k < len_x; k++) {

--- a/scipy/signal/medianfilter.c
+++ b/scipy/signal/medianfilter.c
@@ -3,13 +3,13 @@
 
 #include "Python.h"
 #define NO_IMPORT_ARRAY
-#include "numpy/ndarrayobject.h"
+#include "numpy/noprefix.h"
 
 
 /* defined below */
-void f_medfilt2(float*,float*,npy_intp*,npy_intp*);
-void d_medfilt2(double*,double*,npy_intp*,npy_intp*);
-void b_medfilt2(unsigned char*,unsigned char*,npy_intp*,npy_intp*);
+void f_medfilt2(float*,float*,intp*,intp*);
+void d_medfilt2(double*,double*,intp*,intp*);
+void b_medfilt2(unsigned char*,unsigned char*,intp*,intp*);
 extern char *check_malloc (int);
 
 
@@ -72,7 +72,7 @@ TYPE NAME(TYPE arr[], int n)                                            \
 
 /* 2-D median filter with zero-padding on edges. */
 #define MEDIAN_FILTER_2D(NAME, TYPE, SELECT)                            \
-void NAME(TYPE* in, TYPE* out, npy_intp* Nwin, npy_intp* Ns)                    \
+void NAME(TYPE* in, TYPE* out, intp* Nwin, intp* Ns)                    \
 {                                                                       \
     int nx, ny, hN[2];                                                  \
     int pre_x, pre_y, pos_x, pos_y;                                     \

--- a/scipy/signal/sigtools.h
+++ b/scipy/signal/sigtools.h
@@ -2,6 +2,7 @@
 #define _SCIPY_PRIVATE_SIGNAL_SIGTOOLS_H_
 
 #include "Python.h"
+#include "numpy/noprefix.h"
 
 #define BOUNDARY_MASK 12
 #define OUTSIZE_MASK 3
@@ -32,7 +33,7 @@ typedef struct {
 
 typedef struct {
   char *data;
-  npy_intp numels;
+  intp numels;
   int elsize;
   char *zero;        /* Pointer to Representation of zero */
 } Generic_Vector;
@@ -40,15 +41,13 @@ typedef struct {
 typedef struct {
   char *data;
   int  nd;
-  npy_intp  *dimensions;
+  intp  *dimensions;
   int  elsize;
-  npy_intp  *strides;
+  intp  *strides;
   char *zero;         /* Pointer to Representation of zero */
 } Generic_Array;
 
-typedef void (MultAddFunction) (char *, npy_intp, char *, npy_intp, char *,
-                                npy_intp *, npy_intp *, int, npy_intp, int,
-                                npy_intp *, npy_intp *, npy_uintp *);
+typedef void (MultAddFunction) (char *, intp, char *, intp, char *, intp *, intp *, int, intp, int, intp *, intp *, uintp *);
 
 PyObject*
 scipy_signal_sigtools_linear_filter(PyObject * NPY_UNUSED(dummy), PyObject * args);

--- a/scipy/signal/sigtoolsmodule.c
+++ b/scipy/signal/sigtoolsmodule.c
@@ -5,8 +5,9 @@ Permission to use, copy, modify, and distribute this software without fee
 is granted under the SciPy License.
 */
 #include <Python.h>
+
 #define PY_ARRAY_UNIQUE_SYMBOL _scipy_signal_ARRAY_API
-#include "numpy/ndarrayobject.h"
+#include <numpy/noprefix.h>
 
 #include "sigtools.h"
 #include <setjmp.h>
@@ -38,7 +39,7 @@ order filtering, however uses python-specific constructs in its guts
 and is therefore Python dependent.  This could be changed in a 
 straightforward way but I haven't done it for lack of time.*/
 
-static int index_out_of_bounds(npy_intp *indices, npy_intp *max_indices, int ndims) {
+static int index_out_of_bounds(intp *indices, intp *max_indices, int ndims) {
   int bad_index = 0, k = 0;
 
   while (!bad_index && (k++ < ndims)) {
@@ -55,11 +56,11 @@ static int index_out_of_bounds(npy_intp *indices, npy_intp *max_indices, int ndi
  * but probably with dim1 being the size of the "original, unsliced" array
  */
 
-static npy_intp compute_offsets (npy_uintp *offsets, npy_intp *offsets2, npy_intp *dim1,
-                             npy_intp *dim2, npy_intp *dim3, npy_intp *mode_dep,
+static intp compute_offsets (uintp *offsets, intp *offsets2, intp *dim1,
+                             intp *dim2, intp *dim3, intp *mode_dep,
                              int nd) {
   int k,i;
-  npy_intp init_offset = 0;
+  intp init_offset = 0;
 
   for (k = 0; k < nd - 1; k++) 
     {
@@ -92,7 +93,7 @@ static npy_intp compute_offsets (npy_uintp *offsets, npy_intp *offsets2, npy_int
 
 /* increment by 1 the index into an N-D array, doing the necessary
    carrying when the index reaches the dimension along that axis */ 
-static int increment(npy_intp *ret_ind, int nd, npy_intp *max_ind) {    
+static int increment(intp *ret_ind, int nd, intp *max_ind) {    
     int k, incr = 1;
     
     k = nd - 1;
@@ -767,13 +768,13 @@ static int pre_remez(double *h2, int numtaps, int numbands, double *bands,
 
 static void fill_buffer(char *ip1, PyArrayObject *ap1, PyArrayObject *ap2,
                         char *sort_buffer, int nels2, int check,
-                        npy_intp *loop_ind, npy_intp *temp_ind, npy_uintp *offset){ 
+                        intp *loop_ind, intp *temp_ind, uintp *offset){ 
   int i, k, incr = 1;
   int ndims = PyArray_NDIM(ap1);
-  npy_intp *dims2 = PyArray_DIMS(ap2);
-  npy_intp *dims1 = PyArray_DIMS(ap1);
-  npy_intp is1 = PyArray_ITEMSIZE(ap1);
-  npy_intp is2 = PyArray_ITEMSIZE(ap2);
+  intp *dims2 = PyArray_DIMS(ap2);
+  intp *dims1 = PyArray_DIMS(ap1);
+  intp is1 = PyArray_ITEMSIZE(ap1);
+  intp is2 = PyArray_ITEMSIZE(ap2);
   char *ip2 = PyArray_DATA(ap2);
   int elsize = PyArray_ITEMSIZE(ap1);
   char *ptr;
@@ -810,17 +811,17 @@ int fname(type *ip1, type *ip2) { return *ip1 < *ip2 ? -1 : *ip1 == *ip2 ? 0 : 1
 
 COMPARE(DOUBLE_compare, double)
 COMPARE(FLOAT_compare, float)
-COMPARE(LONGDOUBLE_compare, npy_longdouble)
-COMPARE(BYTE_compare, npy_byte)
+COMPARE(LONGDOUBLE_compare, longdouble)
+COMPARE(BYTE_compare, byte)
 COMPARE(SHORT_compare, short)
 COMPARE(INT_compare, int)
 COMPARE(LONG_compare, long)
-COMPARE(LONGLONG_compare, npy_longlong)
-COMPARE(UBYTE_compare, npy_ubyte)
-COMPARE(USHORT_compare, npy_ushort)
-COMPARE(UINT_compare, npy_uint)
-COMPARE(ULONG_compare, npy_ulong)
-COMPARE(ULONGLONG_compare, npy_ulonglong)
+COMPARE(LONGLONG_compare, longlong)
+COMPARE(UBYTE_compare, ubyte)
+COMPARE(USHORT_compare, ushort)
+COMPARE(UINT_compare, uint)
+COMPARE(ULONG_compare, ulong)
+COMPARE(ULONGLONG_compare, ulonglong)
 
 
 int OBJECT_compare(PyObject **ip1, PyObject **ip2) {
@@ -842,14 +843,14 @@ CompareFunction compare_functions[] = \
 
 PyObject *PyArray_OrderFilterND(PyObject *op1, PyObject *op2, int order) {
 	PyArrayObject *ap1=NULL, *ap2=NULL, *ret=NULL;
-	npy_intp *a_ind, *b_ind, *temp_ind, *mode_dep, *check_ind;
-	npy_uintp *offsets, offset1;
-	npy_intp *offsets2;
+	intp *a_ind, *b_ind, *temp_ind, *mode_dep, *check_ind;
+	uintp *offsets, offset1;
+	intp *offsets2;
 	int i, n2, n2_nonzero, k, check, incr = 1;
 	int typenum, bytes_in_array;
 	int is1, os;
 	char *op, *ap1_ptr, *ap2_ptr, *sort_buffer;
-	npy_intp *ret_ind;
+	intp *ret_ind;
 	CompareFunction compare_func;
 	char *zptr=NULL;
 	PyArray_CopySwapFunc *copyswap;
@@ -910,21 +911,21 @@ PyObject *PyArray_OrderFilterND(PyObject *op1, PyObject *op2, int order) {
 
 	copyswap = PyArray_DESCR(ret)->f->copyswap;
 
-	bytes_in_array = PyArray_NDIM(ap1)*sizeof(npy_intp);
+	bytes_in_array = PyArray_NDIM(ap1)*sizeof(intp);
 	mode_dep = malloc(bytes_in_array);
 	for (k = 0; k < PyArray_NDIM(ap1); k++) { 
 	  mode_dep[k] = -((PyArray_DIMS(ap2)[k]-1) >> 1);
 	}	
 
-	b_ind = (npy_intp *)malloc(bytes_in_array);  /* loop variables */
+	b_ind = (intp *)malloc(bytes_in_array);  /* loop variables */
 	memset(b_ind,0,bytes_in_array);
-	a_ind = (npy_intp *)malloc(bytes_in_array);
-	ret_ind = (npy_intp *)malloc(bytes_in_array);
+	a_ind = (intp *)malloc(bytes_in_array);
+	ret_ind = (intp *)malloc(bytes_in_array);
 	memset(ret_ind,0,bytes_in_array);
-	temp_ind = (npy_intp *)malloc(bytes_in_array);
-	check_ind = (npy_intp*)malloc(bytes_in_array);
-	offsets = (npy_uintp *)malloc(PyArray_NDIM(ap1)*sizeof(npy_uintp));
-	offsets2 = (npy_intp *)malloc(PyArray_NDIM(ap1)*sizeof(npy_intp));
+	temp_ind = (intp *)malloc(bytes_in_array);
+	check_ind = (intp*)malloc(bytes_in_array);
+	offsets = (uintp *)malloc(PyArray_NDIM(ap1)*sizeof(uintp));
+	offsets2 = (intp *)malloc(PyArray_NDIM(ap1)*sizeof(intp));
 	offset1 = compute_offsets(offsets, offsets2, PyArray_DIMS(ap1),
                                   PyArray_DIMS(ap2), PyArray_DIMS(ret),
                                   mode_dep, PyArray_NDIM(ap1));
@@ -1026,14 +1027,14 @@ static char doc_correlateND[] = "out = _correlateND(a,kernel,mode) \n\n   mode =
 
 static char doc_convolve2d[] = "out = _convolve2d(in1, in2, flip, mode, boundary, fillvalue)";
 
-extern int pylab_convolve_2d(char*, npy_intp*, char*, npy_intp*, char*,
-                             npy_intp*, npy_intp*, npy_intp*, int, char*);
+extern int pylab_convolve_2d(char*, intp*, char*, intp*, char*, intp*, intp*,
+                             intp*, int, char*);
 
 static PyObject *sigtools_convolve2d(PyObject *NPY_UNUSED(dummy), PyObject *args) {
 
     PyObject *in1=NULL, *in2=NULL, *fill_value=NULL;
     int mode=2, boundary=0, typenum, flag, flip=1, ret;
-    npy_intp *aout_dimens=NULL;
+    intp *aout_dimens=NULL;
     int i;
     PyArrayObject *ain1=NULL, *ain2=NULL, *aout=NULL;
     PyArrayObject *afill=NULL;
@@ -1093,7 +1094,7 @@ static PyObject *sigtools_convolve2d(PyObject *NPY_UNUSED(dummy), PyObject *args
         if (afill == NULL) goto fail;
     }
 
-    aout_dimens = malloc(PyArray_NDIM(ain1)*sizeof(npy_intp));
+    aout_dimens = malloc(PyArray_NDIM(ain1)*sizeof(intp));
     switch(mode & OUTSIZE_MASK) {
     case VALID:
 	for (i = 0; i < PyArray_NDIM(ain1); i++) { 
@@ -1205,7 +1206,7 @@ static PyObject *sigtools_remez(PyObject *NPY_UNUSED(dummy), PyObject *args)
     int k, numtaps, numbands, type = BANDPASS, err; 
     PyArrayObject *a_bands=NULL, *a_des=NULL, *a_weight=NULL;
     PyArrayObject *h=NULL;
-    npy_intp ret_dimens; int maxiter = 25, grid_density = 16;
+    intp ret_dimens; int maxiter = 25, grid_density = 16;
     double oldvalue, *dptr, fs = 1.0;
     char mystr[255];
     int niter = -1;
@@ -1302,9 +1303,9 @@ fail:
 
 static char doc_median2d[] = "filt = _median2d(data, size)";
 
-extern void f_medfilt2(float*,float*,npy_intp*,npy_intp*);
-extern void d_medfilt2(double*,double*,npy_intp*,npy_intp*);
-extern void b_medfilt2(unsigned char*,unsigned char*,npy_intp*,npy_intp*);
+extern void f_medfilt2(float*,float*,intp*,intp*);
+extern void d_medfilt2(double*,double*,intp*,intp*);
+extern void b_medfilt2(unsigned char*,unsigned char*,intp*,intp*);
 
 static PyObject *sigtools_median2d(PyObject *NPY_UNUSED(dummy), PyObject *args)
 {
@@ -1312,7 +1313,7 @@ static PyObject *sigtools_median2d(PyObject *NPY_UNUSED(dummy), PyObject *args)
     int typenum;
     PyArrayObject *a_image=NULL, *a_size=NULL;
     PyArrayObject *a_out=NULL;
-    npy_intp Nwin[2] = {3,3};
+    intp Nwin[2] = {3,3};
 
     if (!PyArg_ParseTuple(args, "O|O", &image, &size)) return NULL;
 
@@ -1325,8 +1326,8 @@ static PyObject *sigtools_median2d(PyObject *NPY_UNUSED(dummy), PyObject *args)
 	if (a_size == NULL) goto fail;
 	if ((PyArray_NDIM(a_size) != 1) || (PyArray_DIMS(a_size)[0] < 2)) 
 	    PYERR("Size must be a length two sequence");
-	Nwin[0] = ((npy_intp *)PyArray_DATA(a_size))[0];
-	Nwin[1] = ((npy_intp *)PyArray_DATA(a_size))[1];
+	Nwin[0] = ((intp *)PyArray_DATA(a_size))[0];
+	Nwin[1] = ((intp *)PyArray_DATA(a_size))[1];
     }  
 
     a_out = (PyArrayObject *)PyArray_SimpleNew(2, PyArray_DIMS(a_image), typenum);


### PR DESCRIPTION
Revert gh-9561, which is likely causing wheel build failures and is far too tricky to debug this close to the `1.2.0` release.

Since my most recent backport PR squashed history and I'm working on a different machine at the moment I generated the reversion manually for the 7 files involved using the master branch commit that preceded the changes in that PR with:

```git
git checkout ef3d4df -- scipy/signal/S_bspline_util.c scipy/signal/correlate_nd.c.src scipy/signal/firfilter.c scipy/signal/lfilter.c.src scipy/signal/medianfilter.c scipy/signal/sigtools.h scipy/signal/sigtoolsmodule.c
```