### PR TITLE
TST: fix minor issue in a signal.stft test.

### DIFF
--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -1086,7 +1086,7 @@ class TestSTFT(object):
         assert_raises(ValueError, check_NOLA, np.ones(20), 10, 0)
         assert_raises(ValueError, check_NOLA, 'hann', 64, -32)
 
-        x = np.empty(1024)
+        x = np.zeros(1024)
         z = stft(x)
 
         assert_raises(ValueError, stft, x, window=np.ones((2,2)))


### PR DESCRIPTION
The use of np.empty caused a spurious RuntimeWarning in CI, see
e.g. https://circleci.com/gh/scipy/scipy/10288?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link