### PR TITLE
TST: Add 32-bit testing to CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,6 +7,30 @@ trigger:
       - maintenance/*
 
 jobs:
+- job: Linux_Python_36_32bit_full
+  pool:
+    vmIMage: 'ubuntu-16.04'
+  steps:
+  - script: |
+           docker pull i386/ubuntu:bionic
+           docker run -v $(pwd):/scipy i386/ubuntu:bionic /bin/bash -c "cd scipy && \
+           apt-get -y update && \
+           apt-get -y install python3.6-dev python3-pip pkg-config libpng-dev libjpeg8-dev libfreetype6-dev && \
+           pip3 install setuptools wheel numpy cython==0.29 pytest pytest-timeout pytest-xdist pytest-env pytest-faulthandler Pillow mpmath matplotlib && \
+           apt-get -y install gfortran-5 wget && \
+           cd .. && \
+           mkdir openblas && cd openblas && \
+           wget https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-0.3.0-Linux-i686.tar.gz && \
+           tar zxvf openblas-0.3.0-Linux-i686.tar.gz && \
+           cp -r ./usr/local/lib/* /usr/lib && \
+           cp ./usr/local/include/* /usr/include && \
+           cd ../scipy && \
+           F77=gfortran-5 F90=gfortran-5 python3 runtests.py --mode=full -- -n auto -rsx --junitxml=junit/test-results.xml"
+    displayName: 'Run 32-bit Ubuntu Docker Build / Tests'
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFiles: '**/test-*.xml'
+      testRunTitle: 'Publish test results for Python 3.6-32 bit full Linux'
 - job: Windows
   pool:
     vmIMage: 'VS2017-Win2016'


### PR DESCRIPTION
As [recently noted](https://github.com/scipy/scipy/pull/9542#issuecomment-443401956), it has been ages (or never?) since SciPy has had 32-bit testing in its development CI, and Ralf (and more recently I) have been doing this manually, especially when there are wheels issues.

I've added 32-bit Linux testing using Azure and the base approach is the Docker approach used by NumPy for the same purpose. However, SciPy proved more sensitive to the exact version of openblas, so I was forced to use the same pre-built openblas binary we use for 32-bit Linux wheels at the moment along with an older version of gfortran. I think that's a good thing in the end as it better matches wheels workflow.

This should help close one of the major sources of dissonance with our wheels testing, which has many 32-bit matrix entries. I'm not claiming that this build is identical to what we do for wheels just yet (I'm not building a wheel in this new job just yet), but the linked openblas should match and the gfortran should be very similar.

This may be useful to backport to the 1.2.x branch along with the original Azure PR to reduce the likelihood of undetected 32-bit breaks seeping through to the wheels on that LTS branch.

My other idea is that this approach will eventually be augmented with post-mortem openblas build version confirmation using the machinery from https://github.com/numpy/numpy/pull/12523 when it is ready / merged. Likewise, NumPy should be able to benefit from the approach used here to better match wheels instead of using `apt-get` version of openblas on Linux Azure. So the projects can continue to build each other up.