### PR TITLE
DOC: Replace cumulative density with cumulative distribution

### DIFF
--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -199,7 +199,7 @@ Raw Statistical Functions
    bdtri        -- Inverse function to `bdtr` with respect to `p`.
    bdtrik       -- Inverse function to `bdtr` with respect to `k`.
    bdtrin       -- Inverse function to `bdtr` with respect to `n`.
-   btdtr        -- Cumulative density function of the beta distribution.
+   btdtr        -- Cumulative distribution function of the beta distribution.
    btdtri       -- The `p`-th quantile of the beta distribution.
    btdtria      -- Inverse of `btdtr` with respect to `a`.
    btdtrib      -- btdtria(a, p, x)
@@ -207,7 +207,7 @@ Raw Statistical Functions
    fdtrc        -- F survival function.
    fdtri        -- The `p`-th quantile of the F-distribution.
    fdtridfd     -- Inverse to `fdtr` vs dfd
-   gdtr         -- Gamma distribution cumulative density function.
+   gdtr         -- Gamma distribution cumulative distribution function.
    gdtrc        -- Gamma distribution survival function.
    gdtria       -- Inverse of `gdtr` vs a.
    gdtrib       -- Inverse of `gdtr` vs b.
@@ -232,7 +232,7 @@ Raw Statistical Functions
    pdtrc        -- Poisson survival function
    pdtri        -- Inverse to `pdtr` vs m
    pdtrik       -- Inverse to `pdtr` vs k
-   stdtr        -- Student t distribution cumulative density function
+   stdtr        -- Student t distribution cumulative distribution function
    stdtridf     -- Inverse of `stdtr` vs df
    stdtrit      -- Inverse of `stdtr` vs `t`
    chdtr        -- Chi square cumulative distribution function

--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -599,7 +599,7 @@ add_newdoc("scipy.special", "btdtria",
 
     See Also
     --------
-    btdtr : Cumulative density function of the beta distribution.
+    btdtr : Cumulative distribution function of the beta distribution.
     btdtri : Inverse with respect to `x`.
     btdtrib : Inverse with respect to `b`.
 
@@ -652,7 +652,7 @@ add_newdoc("scipy.special", "btdtrib",
 
     See Also
     --------
-    btdtr : Cumulative density function of the beta distribution.
+    btdtr : Cumulative distribution function of the beta distribution.
     btdtri : Inverse with respect to `x`.
     btdtria : Inverse with respect to `a`.
 
@@ -925,7 +925,7 @@ add_newdoc("scipy.special", "btdtr",
     r"""
     btdtr(a, b, x)
 
-    Cumulative density function of the beta distribution.
+    Cumulative distribution function of the beta distribution.
 
     Returns the integral from zero to `x` of the beta probability density
     function,
@@ -947,8 +947,8 @@ add_newdoc("scipy.special", "btdtr",
     Returns
     -------
     I : ndarray
-        Cumulative density function of the beta distribution with parameters
-        `a` and `b` at `x`.
+        Cumulative distribution function of the beta distribution with
+        parameters `a` and `b` at `x`.
 
     See Also
     --------
@@ -2431,7 +2431,7 @@ add_newdoc("scipy.special", "fdtr",
 
     F cumulative distribution function.
 
-    Returns the value of the cumulative density function of the
+    Returns the value of the cumulative distribution function of the
     F-distribution, also known as Snedecor's F-distribution or the
     Fisher-Snedecor distribution.
 
@@ -2794,7 +2794,7 @@ add_newdoc("scipy.special", "gdtr",
     r"""
     gdtr(a, b, x)
 
-    Gamma distribution cumulative density function.
+    Gamma distribution cumulative distribution function.
 
     Returns the integral from zero to `x` of the gamma probability density
     function,
@@ -4489,7 +4489,7 @@ add_newdoc("scipy.special", "kolmogorov",
     Show the probability of a gap at least as big as 0, 0.5 and 1.0.
 
     >>> from scipy.special import kolmogorov
-    >>> from scipy.stats import kstwobign 
+    >>> from scipy.stats import kstwobign
     >>> kolmogorov([0, 0.5, 1.0])
     array([ 1.        ,  0.96394524,  0.26999967])
 
@@ -6654,7 +6654,7 @@ add_newdoc("scipy.special", "stdtr",
     """
     stdtr(df, t)
 
-    Student t distribution cumulative density function
+    Student t distribution cumulative distribution function
 
     Returns the integral from minus infinity to t of the Student t
     distribution with df > 0 degrees of freedom::

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -4002,9 +4002,10 @@ class levy_stable_gen(rv_continuous):
                 data_out[data_mask] = np.array([levy_stable._cdf_single_value_zolotarev(_x, _alpha, _beta)
                             for _x, _alpha, _beta in data_subset]).reshape(len(data_subset), 1)
             else:
-                warnings.warn('Cumulative distribution function calculations' +
-                              ' experimental for FFT method.' +
-                              ' Use zolatarev method instead.', RuntimeWarning)
+                warnings.warn('FFT method is considered experimental for ' +
+                              'cumulative distribution function ' +
+                              'evaluations. Use Zolotarev’s method instead).',
+                              RuntimeWarning)
                 _alpha, _beta = pair
                 _x = data_subset[:,(0,)]
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -4002,7 +4002,8 @@ class levy_stable_gen(rv_continuous):
                 data_out[data_mask] = np.array([levy_stable._cdf_single_value_zolotarev(_x, _alpha, _beta)
                             for _x, _alpha, _beta in data_subset]).reshape(len(data_subset), 1)
             else:
-                warnings.warn('Cumulative density calculations experimental for FFT method.' +
+                warnings.warn('Cumulative distribution function calculations' +
+                              ' experimental for FFT method.' +
                               ' Use zolatarev method instead.', RuntimeWarning)
                 _alpha, _beta = pair
                 _x = data_subset[:,(0,)]

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1600,7 +1600,7 @@ class TestLevyStable(object):
             stats.levy_stable.pdf_fft_min_points_threshold = fft_min_points
             subdata = data[filter_func(data)] if filter_func is not None else data
             with suppress_warnings() as sup:
-                sup.record(RuntimeWarning, "Cumulative density calculations experimental for FFT method.*")
+                sup.record(RuntimeWarning, "Cumulative distribution function calculations experimental for FFT method.*")
                 p = stats.levy_stable.cdf(subdata['x'], subdata['alpha'], subdata['beta'], scale=1, loc=0)
                 subdata2 = rec_append_fields(subdata, 'calc', p)
                 failures = subdata2[(np.abs(p-subdata['p']) >= 1.5*10.**(-decimal_places)) | np.isnan(p)]

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1600,7 +1600,7 @@ class TestLevyStable(object):
             stats.levy_stable.pdf_fft_min_points_threshold = fft_min_points
             subdata = data[filter_func(data)] if filter_func is not None else data
             with suppress_warnings() as sup:
-                sup.record(RuntimeWarning, 'The FFT method is considered ' +
+                sup.record(RuntimeWarning, 'FFT method is considered ' +
                            'experimental for cumulative distribution ' +
                            'function evaluations.*')
                 p = stats.levy_stable.cdf(subdata['x'], subdata['alpha'], subdata['beta'], scale=1, loc=0)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1600,7 +1600,9 @@ class TestLevyStable(object):
             stats.levy_stable.pdf_fft_min_points_threshold = fft_min_points
             subdata = data[filter_func(data)] if filter_func is not None else data
             with suppress_warnings() as sup:
-                sup.record(RuntimeWarning, "Cumulative distribution function calculations experimental for FFT method.*")
+                sup.record(RuntimeWarning, 'The FFT method is considered ' +
+                           'experimental for cumulative distribution ' +
+                           'function evaluations.*')
                 p = stats.levy_stable.cdf(subdata['x'], subdata['alpha'], subdata['beta'], scale=1, loc=0)
                 subdata2 = rec_append_fields(subdata, 'calc', p)
                 failures = subdata2[(np.abs(p-subdata['p']) >= 1.5*10.**(-decimal_places)) | np.isnan(p)]


### PR DESCRIPTION
Fixes #9589

"Cumulative density" is not correct: "cumulative distribution" should be used instead.