### PR TITLE
TST: remove VC 9.0 from Azure CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,14 +70,6 @@ jobs:
       versionSpec: $(PYTHON_VERSION)
       addToPath: true
       architecture: $(PYTHON_ARCH)
-  # as noted by numba project, currently need
-  # specific VC install for Python 2.7
-  - powershell: |
-      $wc = New-Object net.webclient
-      $wc.Downloadfile("https://download.microsoft.com/download/7/9/6/796EF2E4-801B-4FC4-AB28-B59FBF6D907B/VCForPython27.msi", "VCForPython27.msi")
-      Start-Process "VCForPython27.msi" /qn -Wait
-    displayName: 'Install VC 9.0'
-    condition: eq(variables['PYTHON_VERSION'], '2.7')
   - script: python -m pip install --upgrade pip setuptools wheel
     displayName: 'Install tools'
   - powershell: |


### PR DESCRIPTION
* master branch no longer supports /
tests Python 2.7, so we can now
safely remove the older VC 9.0 compiler
from Windows Azure CI

This was one of the things shackling us to C89 standard, although I think there are still some other ecosystem things to be cautious of for > C89 standard.

It was convenient to have this in the initial PR for Azure that we merged because I can now use that to more easily restore 2.7 on the maintenance backport.