### PR TITLE
MAINT: backports for 1.2.x branch -- mostly CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,6 +7,30 @@ trigger:
       - maintenance/*
 
 jobs:
+- job: Linux_Python_36_32bit_full
+  pool:
+    vmIMage: 'ubuntu-16.04'
+  steps:
+  - script: |
+           docker pull i386/ubuntu:bionic
+           docker run -v $(pwd):/scipy i386/ubuntu:bionic /bin/bash -c "cd scipy && \
+           apt-get -y update && \
+           apt-get -y install python3.6-dev python3-pip pkg-config libpng-dev libjpeg8-dev libfreetype6-dev && \
+           pip3 install setuptools wheel numpy cython==0.29 pytest pytest-timeout pytest-xdist pytest-env pytest-faulthandler Pillow mpmath matplotlib && \
+           apt-get -y install gfortran-5 wget && \
+           cd .. && \
+           mkdir openblas && cd openblas && \
+           wget https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-0.3.0-Linux-i686.tar.gz && \
+           tar zxvf openblas-0.3.0-Linux-i686.tar.gz && \
+           cp -r ./usr/local/lib/* /usr/lib && \
+           cp ./usr/local/include/* /usr/include && \
+           cd ../scipy && \
+           F77=gfortran-5 F90=gfortran-5 python3 runtests.py --mode=full -- -n auto -rsx --junitxml=junit/test-results.xml"
+    displayName: 'Run 32-bit Ubuntu Docker Build / Tests'
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFiles: '**/test-*.xml'
+      testRunTitle: 'Publish test results for Python 3.6-32 bit full Linux'
 - job: Windows
   pool:
     vmIMage: 'VS2017-Win2016'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,110 @@
+trigger:
+  # start a new build for every push
+  batch: False
+  branches:
+    include:
+      - master
+      - maintenance/*
+
+jobs:
+- job: Windows
+  pool:
+    vmIMage: 'VS2017-Win2016'
+  variables:
+      OPENBLAS_32: https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-5f998ef_gcc7_1_0_win32.zip
+      OPENBLAS_64: https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-5f998ef_gcc7_1_0_win64.zip
+  strategy:
+    maxParallel: 4
+    matrix:
+        Python36-32bit-full:
+          PYTHON_VERSION: '3.6'
+          PYTHON_ARCH: 'x86'
+          TEST_MODE: full
+          OPENBLAS: $(OPENBLAS_32)
+          BITS: 32
+        Python35-64bit-full:
+          PYTHON_VERSION: '3.5'
+          PYTHON_ARCH: 'x64'
+          TEST_MODE: full
+          OPENBLAS: $(OPENBLAS_64)
+          BITS: 64
+        Python36-64bit-full:
+          PYTHON_VERSION: '3.6'
+          PYTHON_ARCH: 'x64'
+          TEST_MODE: full
+          OPENBLAS: $(OPENBLAS_64)
+          BITS: 64
+        Python37-64bit-full:
+          PYTHON_VERSION: '3.7'
+          PYTHON_ARCH: 'x64'
+          TEST_MODE: full
+          OPENBLAS: $(OPENBLAS_64)
+          BITS: 64
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: $(PYTHON_VERSION)
+      addToPath: true
+      architecture: $(PYTHON_ARCH)
+  # as noted by numba project, currently need
+  # specific VC install for Python 2.7
+  - powershell: |
+      $wc = New-Object net.webclient
+      $wc.Downloadfile("https://download.microsoft.com/download/7/9/6/796EF2E4-801B-4FC4-AB28-B59FBF6D907B/VCForPython27.msi", "VCForPython27.msi")
+      Start-Process "VCForPython27.msi" /qn -Wait
+    displayName: 'Install VC 9.0'
+    condition: eq(variables['PYTHON_VERSION'], '2.7')
+  - script: python -m pip install --upgrade pip setuptools wheel
+    displayName: 'Install tools'
+  - powershell: |
+      $wc = New-Object net.webclient;
+      $wc.Downloadfile("$(OPENBLAS)", "openblas.zip")
+      $tmpdir = New-TemporaryFile | %{ rm $_; mkdir $_ }
+      Expand-Archive "openblas.zip" $tmpdir
+      $pyversion = python -c "from __future__ import print_function; import sys; print(sys.version.split()[0])"
+      Write-Host "Python Version: $pyversion"
+      $target = "C:\\hostedtoolcache\\windows\\Python\\$pyversion\\$(PYTHON_ARCH)\\lib\\openblas.a"
+      Write-Host "target path: $target"
+      cp $tmpdir\$(BITS)\lib\libopenblas_5f998ef_gcc7_1_0.a $target
+    displayName: 'Download / Install OpenBLAS'
+  - powershell: |
+      # NOTE: can probably (eventually) abstract this 
+      # upstream in Microsoft repo to support x86 natively
+      choco install -y mingw --forcex86 --force
+    displayName: 'Install 32-bit mingw for 32-bit builds'
+    condition: eq(variables['BITS'], 32)
+  - script: python -m pip install numpy cython==0.28.5 pytest pytest-timeout pytest-xdist pytest-env pytest-faulthandler Pillow mpmath matplotlib
+    displayName: 'Install dependencies'
+  - powershell: |
+      # need a version of NumPy distutils that can build
+      # with msvc + mingw-gfortran
+      $NumpyDir = $((python -c 'import os; import numpy; print(os.path.dirname(numpy.__file__))') | Out-String).Trim()
+      rm -r -Force "$NumpyDir\distutils"
+      $tmpdir = New-TemporaryFile | %{ rm $_; mkdir $_ }
+      git clone -q --depth=1 -b master https://github.com/numpy/numpy.git $tmpdir
+      mv $tmpdir\numpy\distutils $NumpyDir
+    displayName: 'Replace NumPy distutils'
+  - powershell: |
+      If ($(BITS) -eq 32) {
+          # 32-bit build requires careful adjustments
+          # until Microsoft has a switch we can use
+          # directly for i686 mingw
+          $env:NPY_DISTUTILS_APPEND_FLAGS = 1
+          $env:CFLAGS = "-m32"
+          $env:LDFLAGS = "-m32"
+          $env:PATH = "C:\\tools\\mingw32\\bin;" + $env:PATH
+          refreshenv
+      }
+
+      mkdir dist
+      pip wheel --no-build-isolation -v -v -v --wheel-dir=dist .
+      ls dist -r | Foreach-Object {
+          pip install $_.FullName
+      }
+    displayName: 'Build SciPy'
+  - script: python runtests.py -n --mode=$(TEST_MODE) -- -n auto -rsx --junitxml=junit/test-results.xml
+    displayName: 'Run SciPy Test Suite'
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFiles: '**/test-*.xml'
+      testRunTitle: 'Publish test results for Python $(python.version)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,6 +40,12 @@ jobs:
   strategy:
     maxParallel: 4
     matrix:
+        Python27-64bit-full:
+          PYTHON_VERSION: '2.7'
+          PYTHON_ARCH: 'x64'
+          TEST_MODE: full
+          OPENBLAS: $(OPENBLAS_64)
+          BITS: 64
         Python36-32bit-full:
           PYTHON_VERSION: '3.6'
           PYTHON_ARCH: 'x86'

--- a/setup.py
+++ b/setup.py
@@ -59,8 +59,8 @@ Operating System :: MacOS
 MAJOR = 1
 MINOR = 2
 MICRO = 0
-ISRELEASED = True
-VERSION = '%d.%d.%drc2' % (MAJOR, MINOR, MICRO)
+ISRELEASED = False
+VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
 
 # Return the git revision as a string


### PR DESCRIPTION
This backport PR aims to do a few things:

- remove "rc" from the version number & set status to unreleased until the release commit proper for `1.2.0`
- backport Windows Azure CI testing in case we disable Appveyor web hooks eventually & still need to make changes on this LTS branch
- backport 32-bit Linux testing Azure CI because this can be very helpful to prevent issues seeping through to 32-bit wheel builds
- manually restore 64-bit Python 2.7 Windows testing on Azure because this is an LTS release branch with Python 2.7 bugfix support

Other notes:
- I didn't update the release notes for this backport PR because none of the testing / maintenance matters above are user-facing
- pytext-xdist looks a little flaky for Windows Python 2.7 Azure, but still passes full suite (you can see some thread warning in there 3/4 of the way through, but seems to handle gracefully)
- I didn't try to manually add Python 3.4 to Windows Azure CI -- I've not seen this done and it would require an older / exotic version of VC that I'd prefer to avoid if possible