### PR TITLE
TST: reduce max memory usage for sparse.linalg.gcrotmk test.

### DIFF
--- a/scipy/sparse/linalg/isolve/tests/test_gcrotmk.py
+++ b/scipy/sparse/linalg/isolve/tests/test_gcrotmk.py
@@ -61,8 +61,8 @@ class TestGCROTMK(object):
     def test_arnoldi(self):
         np.random.rand(1234)
 
-        A = eye(10000) + rand(10000,10000,density=1e-4)
-        b = np.random.rand(10000)
+        A = eye(2000) + rand(2000, 2000, density=5e-4)
+        b = np.random.rand(2000)
 
         # The inner arnoldi should be equivalent to gmres
         with suppress_warnings() as sup:


### PR DESCRIPTION
Closes gh-9595

This test calls `np.random.choice` with a large sparse array of shape
(10000, 10000). Under the hood, `choice` ends up constructing a dense
array of the same size explicitly, in `np.random.permutation`. That
takes 0.8 GB for int64. That then goes on to `np.random.shuffle`, which
creates some extra buffers. The `MemoryError` seems to be simply because
we're pushing the 2 GB limit on 32-bit Python.