### PR TITLE
DOC: update release process documentation

### DIFF
--- a/doc/source/dev/github.rst
+++ b/doc/source/dev/github.rst
@@ -69,6 +69,12 @@ Typically, the developer who merges an important bugfix adds the
 whether and when the backport is done.  After the backport is completed, the
 ``backport-candidate`` label has to be removed again.
 
+A good strategy for a backport pull request is to combine several master
+branch pull requests, to reduce the burden on continuous integration tests
+and to reduce the merge commit cluttering of maintenance branch history. It
+is generally best to have a single commit for each of the master branch pull
+requests represented in the backport pull request. This way, history is clear
+and can be reverted in a straightforward manner if needed.
 
 Release notes
 -------------


### PR DESCRIPTION
Add some minor adjustments to SciPy release process documentation after the recent release. The main idea is to cover a few points that are obvious to the *usual suspects*, but maybe less so to newer release managers.

That said, there's always the tradeoff with verbosity, so I'll let others judge if this is too much expansion.