### PR TITLE
bugfix in rv_sample in scipy.stats

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -2579,6 +2579,7 @@ class rv_discrete(rv_generic):
     values : tuple of two array_like, optional
         ``(xk, pk)`` where ``xk`` are integers with non-zero
         probabilities ``pk``  with ``sum(pk) = 1``.
+        ``xk`` and ``pk`` must have the same shape.
     inc : integer, optional
         Increment for the support of the distribution.
         Default is 1. (other values have not been tested)
@@ -3360,8 +3361,8 @@ class rv_sample(rv_discrete):
 
         xk, pk = values
 
-        if len(xk) != len(pk):
-            raise ValueError("xk and pk need to have the same length.")
+        if np.shape(xk) != np.shape(pk):
+            raise ValueError("xk and pk must have the same shape.")
         if not np.allclose(np.sum(pk), 1):
             raise ValueError("The sum of provided pk is not 1.")
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1216,7 +1216,7 @@ class TestRvDiscrete(object):
 
         # same shapes => no error
         xk, pk = np.arange(6).reshape((3, 2)), np.ones((3, 2)) / 6
-        assert_raises(ValueError, stats.rv_discrete, **dict(values=(xk, pk)))
+        assert_equal(stats.rv_discrete(values=(xk, pk)).pmf(0), 1/6)
 
 
 class TestSkewNorm(object):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1203,6 +1203,21 @@ class TestRvDiscrete(object):
         pk = [1, 2, 3]
         assert_raises(ValueError, stats.rv_discrete, **dict(values=(xk, pk)))
 
+    def test_shape_rv_sample():
+        # tests added for gh-9565
+
+        # mismatch of 2d inputs
+        xk, pk = np.arange(4).reshape((2, 2)), np.ones((2, 3)) / 6
+        assert_raises(ValueError, stats.rv_discrete, **dict(values=(xk, pk)))
+
+        # same number of elements, but shapes not compatible
+        xk, pk = np.arange(6).reshape((3, 2)), np.ones((2, 3)) / 6
+        assert_raises(ValueError, stats.rv_discrete, **dict(values=(xk, pk)))
+
+        # same shapes => no error
+        xk, pk = np.arange(6).reshape((3, 2)), np.ones((3, 2)) / 6
+        assert_raises(ValueError, stats.rv_discrete, **dict(values=(xk, pk)))
+
 
 class TestSkewNorm(object):
     def setup_method(self):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1203,7 +1203,7 @@ class TestRvDiscrete(object):
         pk = [1, 2, 3]
         assert_raises(ValueError, stats.rv_discrete, **dict(values=(xk, pk)))
 
-    def test_shape_rv_sample():
+    def test_shape_rv_sample(self):
         # tests added for gh-9565
 
         # mismatch of 2d inputs


### PR DESCRIPTION
Closes #9565 

xk and pk in rv_discrete should have the same size, After that check they are ravelled. One could also test the size but I think it is better to enforce the same shape, otherwise matching of elements in pk and xk depends on the order used to ravel the Vector.