### PR TITLE
MAINT: Raise error in directed_hausdorff distance

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -375,6 +375,12 @@ def directed_hausdorff(u, v, seed=0):
     index_2 : int
         index of point contributing to Hausdorff pair in `v`
 
+    Raises
+    ------
+    ValueError
+        An exception is thrown if `u` and `v` do not have
+        the same number of columns.
+
     Notes
     -----
     Uses the early break technique and the random sampling approach
@@ -435,6 +441,9 @@ def directed_hausdorff(u, v, seed=0):
     """
     u = np.asarray(u, dtype=np.float64, order='c')
     v = np.asarray(v, dtype=np.float64, order='c')
+    if u.shape[1] != v.shape[1]:
+        raise ValueError('u and v need to have the same '
+                         'number of columns')
     result = _hausdorff.directed_hausdorff(u, v, seed)
     return result
 

--- a/scipy/spatial/tests/test_hausdorff.py
+++ b/scipy/spatial/tests/test_hausdorff.py
@@ -5,6 +5,7 @@ from numpy.testing import (assert_almost_equal,
                            assert_array_equal,
                            assert_equal,
                            assert_)
+import pytest
 from scipy.spatial.distance import directed_hausdorff
 from scipy.spatial import distance
 from scipy._lib._util import check_random_state
@@ -113,3 +114,12 @@ class TestHausdorff(object):
             rs2 = check_random_state(None)
             new_global_state = rs2.get_state()
             assert_equal(new_global_state, old_global_state)
+
+    def test_invalid_dimensions(self):
+        # Ensure that a ValueError is raised when the number of columns
+        # is not the same
+        np.random.seed(1234)
+        A = np.random.rand(3, 2)
+        B = np.random.rand(4, 5)
+        with pytest.raises(ValueError):
+            directed_hausdorff(A, B)


### PR DESCRIPTION
As documented in the current release, the arrays `u` and `v` should have the same number of columns, otherwise computing a distance does not seem to make sense. However, the current version 
happily accepts any 2-D arrays and computes some distance, see the example below.

```
from scipy.spatial.distance import directed_hausdorff
import numpy as np

A = np.random.rand(3,2)
B = np.random.rand(4,5)

print(directed_hausdorff(A, B))  # This should not work
```

This PR addresses this and raises an error, if preferred this could also be turned into a deprecation warning.