### PR TITLE
Return the number of calls to 'hessp' (not just 'hess') in trust region methods.

### DIFF
--- a/scipy/optimize/_trustregion.py
+++ b/scipy/optimize/_trustregion.py
@@ -250,7 +250,7 @@ def _minimize_trust_region(fun, x0, args=(), jac=None, hess=None, hessp=None,
         print("         Iterations: %d" % k)
         print("         Function evaluations: %d" % nfun[0])
         print("         Gradient evaluations: %d" % njac[0])
-        print("         Hessian evaluations: %d" % nhess[0] + nhessp[0])
+        print("         Hessian evaluations: %d" % (nhess[0] + nhessp[0]))
 
     result = OptimizeResult(x=x, success=(warnflag == 0), status=warnflag,
                             fun=m.fun, jac=m.jac, nfev=nfun[0], njev=njac[0],

--- a/scipy/optimize/_trustregion.py
+++ b/scipy/optimize/_trustregion.py
@@ -250,11 +250,11 @@ def _minimize_trust_region(fun, x0, args=(), jac=None, hess=None, hessp=None,
         print("         Iterations: %d" % k)
         print("         Function evaluations: %d" % nfun[0])
         print("         Gradient evaluations: %d" % njac[0])
-        print("         Hessian evaluations: %d" % nhess[0])
+        print("         Hessian evaluations: %d" % nhess[0] + nhessp[0])
 
     result = OptimizeResult(x=x, success=(warnflag == 0), status=warnflag,
                             fun=m.fun, jac=m.jac, nfev=nfun[0], njev=njac[0],
-                            nhev=nhess[0], nit=k,
+                            nhev=nhess[0] + nhessp[0], nit=k,
                             message=status_messages[warnflag])
 
     if hess is not None:


### PR DESCRIPTION
Currently, the output (OptimizationResult class) of trust region methods set 'nhev' (the number of hessian evaluations) to be 0 if 'hessp' is given as an argument instead of 'hess'. I think a reasonable behavior, which most of the users would expect, is to return the number of calls to 'hessp' if that's the argument given to sp.optimize.minimize. Also, that is indeed what the 'Newton-CG' method does.

The code below illustrates the described behavior of sp.optimize.minimize.
```
import numpy as np
import scipy as sp

f = lambda x: np.inner(x, x) / 2
jac = lambda x: x
hess = lambda x: np.eye(len(x))
def hessp(x, v):
    return v
x0 = np.random.randn(100)

optim_result = sp.optimize.minimize(
    f, x0, method='trust-ncg', jac=jac, hessp=hessp
)
print(optim_result['nhev']) # Used to return 0, but now returns the number of calls to 'hessp'.


"""
Newton-CG already returns the number of calls to 'hessp' when this argument is 
provided instead of 'hess'.
"""
optim_result = sp.optimize.minimize(
    f, x0, method='Newton-CG', jac=jac, hessp=hessp
)
print(optim_result['nhev']) 
```