### PR TITLE
BUG: ignore empty lines in mmio

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -199,6 +199,7 @@ Kai Striega for improvements to the scipy.optimize.linprog simplex method.
 Josua Sassen for improvements to scipy.interpolate.Rbf
 Stiaan Gerber for a bug fix in scipy.optimize.
 Nicolas Hug for the Yeo-Johnson transformation.
+Petar Mlinarić for a bug fix in scipy.io.mmio.
 
 Institutions
 ------------

--- a/scipy/io/mmio.py
+++ b/scipy/io/mmio.py
@@ -246,6 +246,10 @@ class MMFile (object):
             while line.startswith(b'%'):
                 line = stream.readline()
 
+            # skip empty lines
+            while not line.strip():
+                line = stream.readline()
+
             line = line.split()
             if format == self.FORMAT_ARRAY:
                 if not len(line) == 2:
@@ -512,7 +516,7 @@ class MMFile (object):
                     i += 1
             while line:
                 line = stream.readline()
-                if not line or line.startswith(b'%'):
+                if not line or line.startswith(b'%') or not line.strip():
                     continue
                 if is_integer:
                     aij = int(line)
@@ -557,7 +561,7 @@ class MMFile (object):
             k = 0
             while line:
                 line = stream.readline()
-                if not line or line.startswith(b'%'):
+                if not line or line.startswith(b'%') or not line.strip():
                     continue
                 l = line.split()
                 i, j = map(int, l[:2])
@@ -604,7 +608,7 @@ class MMFile (object):
 
             entry_number = 0
             for line in stream:
-                if not line or line.startswith(b'%'):
+                if not line or line.startswith(b'%') or not line.strip():
                     continue
 
                 if entry_number+1 > entries:

--- a/scipy/io/tests/test_mmio.py
+++ b/scipy/io/tests/test_mmio.py
@@ -479,6 +479,24 @@ _symmetric_pattern_example = '''\
     5     4
 '''
 
+# example (without comment lines) from Figure 1 in
+# https://math.nist.gov/MatrixMarket/reports/MMformat.ps
+_empty_lines_example = '''\
+%%MatrixMarket  MATRIX    Coordinate    Real General
+
+   5  5         8
+
+1 1  1.0
+2 2       10.5
+3 3             1.5e-2
+4 4                     -2.8E2
+5 5                              12.
+     1      4      6
+     4      2      250.5
+     4      5      33.32
+
+'''
+
 
 class TestMMIOCoordinate(object):
     def setup_method(self):
@@ -540,6 +558,15 @@ class TestMMIOCoordinate(object):
              [0, 0, 0, 1, 1]]
         self.check_read(_symmetric_pattern_example, a,
                         (5, 5, 7, 'coordinate', 'pattern', 'symmetric'))
+
+    def test_read_empty_lines(self):
+        a = [[1, 0, 0, 6, 0],
+             [0, 10.5, 0, 0, 0],
+             [0, 0, .015, 0, 0],
+             [0, 250.5, 0, -280, 33.32],
+             [0, 0, 0, 0, 12]]
+        self.check_read(_empty_lines_example, a,
+                        (5, 5, 8, 'coordinate', 'real', 'general'))
 
     def test_empty_write_read(self):
         # https://github.com/scipy/scipy/issues/1410 (Trac #883)


### PR DESCRIPTION
Hi, this is my first PR, I hope I didn't do something horribly wrong.

From time to time, I encounter Matrix Market format files containing empty lines, so it would be nice if I didn't have to delete those manually before using `scipy.io.mmread`. Also, the documentation of the MM format [1] and the Matlab `mmread` function [2] both allow empty lines. Here is the example from Figure 1 in [1] (without comment lines):
```
%%MatrixMarket  MATRIX    Coordinate    Real General

   5  5         8

1 1  1.0
2 2       10.5
3 3             1.5e-2
4 4                     -2.8E2
5 5                              12.
     1      4      6
     4      2      250.5
     4      5      33.32

```
Notice that there are three empty lines in this example (one is at the end of the file).

I've added this example to `scipy/io/tests/test_mmio.py` and made changes in `scipy/io/mmio.py` which makes this test pass.

[1] https://math.nist.gov/MatrixMarket/reports/MMformat.ps (available from https://math.nist.gov/MatrixMarket/formats.html)
[2] https://math.nist.gov/MatrixMarket/mmio/matlab/mmiomatlab.html

(https://math.nist.gov seems to be down at the moment...)
