### PR TITLE
DOC: fill_value is None by default, not nan

### DIFF
--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -101,7 +101,7 @@ def lagrange(x, w):
 class interp2d(object):
     """
     interp2d(x, y, z, kind='linear', copy=True, bounds_error=False,
-             fill_value=nan)
+             fill_value=None)
 
     Interpolate over a 2-D grid.
 


### PR DESCRIPTION
Little fix about the documentation of fill_value paramter of interp2d.