### PR TITLE
Add the number of Jacobian evaluations to the output of L-BFGS-B.

### DIFF
--- a/scipy/optimize/lbfgsb.py
+++ b/scipy/optimize/lbfgsb.py
@@ -275,6 +275,7 @@ def _minimize_lbfgsb(fun, x0, args=(), jac=None, bounds=None,
             iprint = disp
 
     n_function_evals, fun = wrap_function(fun, ())
+    n_jac_evals, jac = wrap_function(jac, ())
     if jac is None:
         def func_and_grad(x):
             f = fun(x, *args)
@@ -368,6 +369,7 @@ def _minimize_lbfgsb(fun, x0, args=(), jac=None, bounds=None,
     hess_inv = LbfgsInvHessProduct(s[:n_corrs], y[:n_corrs])
 
     return OptimizeResult(fun=f, jac=g, nfev=n_function_evals[0],
+                          njev=n_jac_evals[0],
                           nit=n_iterations, status=warnflag, message=task_str,
                           x=x, success=(warnflag == 0), hess_inv=hess_inv)
 


### PR DESCRIPTION
I guess the number of Jacobian evaluations should be equal to that of the function evaluations for BFGS, but I think it is still better for the output (OptimizationResult class) to have the attribute 'njev' with the actual number of calls to the 'jac' function.

The code below illustrates the behavior of sp.optimize.minimize with and without the proposed change.
```python
import numpy as np
import scipy as sp
import scipy.optimize

f = lambda x: np.inner(x, x) / 2
jac = lambda x: x
hess = lambda x: np.eye(len(x))
def hessp(x, v):
    return v
x0 = np.random.randn(100)

optim_result = sp.optimize.minimize(
    f, x0, method='L-BFGS-B', jac=jac, hessp=hessp
)

optim_result.njev # Used to throw an error, now returns the number of calls to 'jac.'
```