### PR TITLE
ENH: integrate: quad() for vector-valued functions

### DIFF
--- a/scipy/integrate/__init__.py
+++ b/scipy/integrate/__init__.py
@@ -12,6 +12,7 @@ Integrating functions, given function object
    :toctree: generated/
 
    quad          -- General purpose integration
+   quad_vec      -- General purpose integration of vector-valued functions
    dblquad       -- General purpose double integration
    tplquad       -- General purpose triple integration
    nquad         -- General purpose n-dimensional integration
@@ -93,6 +94,7 @@ from ._ode import *
 from ._bvp import solve_bvp
 from ._ivp import (solve_ivp, OdeSolution, DenseOutput,
                    OdeSolver, RK23, RK45, Radau, BDF, LSODA)
+from ._quad_vec import quad_vec
 
 __all__ = [s for s in dir() if not s.startswith('_')]
 

--- a/scipy/integrate/_quad_vec.py
+++ b/scipy/integrate/_quad_vec.py
@@ -301,11 +301,13 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6, li
     CONVERGED = 0
     NOT_CONVERGED = 1
     ROUNDING_ERROR = 2
+    NOT_A_NUMBER = 3
 
     status_msg = {
         CONVERGED: "Target precision reached.",
         NOT_CONVERGED: "Target precision not reached.",
-        ROUNDING_ERROR: "Target precision could not be reached due to rounding error."
+        ROUNDING_ERROR: "Target precision could not be reached due to rounding error.",
+        NOT_A_NUMBER: "Non-finite values encountered."
     }
 
     # Process intervals
@@ -351,6 +353,10 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6, li
                 if global_error < rounding_error:
                     ier = ROUNDING_ERROR
                     break
+
+            if not (np.isfinite(global_error) and np.isfinite(rounding_error)):
+                ier = NOT_A_NUMBER
+                break
 
     res = global_integral
     err = global_error + rounding_error

--- a/scipy/integrate/_quad_vec.py
+++ b/scipy/integrate/_quad_vec.py
@@ -117,7 +117,7 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6, li
     norm : {'max', '2'}, optional
         Vector norm to use for error estimation.
     cache_size : int, optional
-        Number bytes to use for memoization.
+        Number of bytes to use for memoization.
     workers : int or map-like callable, optional
         If `workers` is an integer, part of the computation is done in
         parallel subdivided to this many tasks (using `multiprocessing.Pool`).
@@ -127,7 +127,7 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6, li
         This evaluation is carried out as ``workers(func, iterable)``.
     points : list, optional
         List of additional breakpoints.
-    quardarture : {'gk21', 'gk15', 'trapz'}, optional
+    quadrature : {'gk21', 'gk15', 'trapz'}, optional
         Quadrature rule to use on subintervals.
         Options: 'gk21' (Gauss-Kronrod 21-point rule),
         'gk15' (Gauss-Kronrod 15-point rule),

--- a/scipy/integrate/_quad_vec.py
+++ b/scipy/integrate/_quad_vec.py
@@ -93,6 +93,7 @@ class _Bunch(object):
     def __init__(self, **kwargs):
         self.__keys = kwargs.keys()
         self.__dict__.update(**kwargs)
+
     def __repr__(self):
         return "_Bunch({})".format(", ".join("{}={}".format(k, repr(self.__dict__[k]))
                                              for k in self.__keys))

--- a/scipy/integrate/_quad_vec.py
+++ b/scipy/integrate/_quad_vec.py
@@ -1,0 +1,494 @@
+from __future__ import division, print_function, absolute_import
+
+import sys
+import copy
+import heapq
+import collections
+import functools
+
+import numpy as np
+
+from scipy._lib._util import MapWrapper
+
+
+class LRUDict(collections.OrderedDict):
+    def __init__(self, max_size):
+        self.__max_size = max_size
+
+    def __setitem__(self, key, value):
+        existing_key = (key in self)
+        super(LRUDict, self).__setitem__(key, value)
+        if existing_key:
+            self.move_to_end(key)
+        elif len(self) > self.__max_size:
+            self.popitem(last=False)
+
+    def update(self, other):
+        # Not needed below
+        raise NotImplementedError()
+
+
+class SemiInfiniteFunc(object):
+    """
+    Argument transform from (start, +-oo) to (0, 1)
+    """
+    def __init__(self, func, start, infty):
+        self._func = func
+        self._start = start
+        self._sgn = -1 if infty < 0 else 1
+
+        # Overflow threshold for the 1/t**2 factor
+        self._tmin = sys.float_info.min**0.5
+
+    def get_t(self, x):
+        return 1 / (self._sgn * (x - self._start) + 1)
+
+    def __call__(self, t):
+        if t < self._tmin:
+            return 0.0
+        else:
+            x = self._start + self._sgn * (1 - t) / t
+            f = self._func(x)
+            return self._sgn * (f / t) / t
+
+
+class DoubleInfiniteFunc(object):
+    """
+    Argument transform from (-oo, oo) to (-1, 1)
+    """
+    def __init__(self, func):
+        self._func = func
+
+        # Overflow threshold for the 1/t**2 factor
+        self._tmin = sys.float_info.min**0.5
+
+    def get_t(self, x):
+        s = -1 if x < 0 else 1
+        return s / (abs(x) + 1)
+
+    def __call__(self, t):
+        if abs(t) < self._tmin:
+            return 0.0
+        else:
+            x = (1 - abs(t)) / t
+            f = self._func(x)
+            return (f / t) / t
+
+
+def _max_norm(x):
+    return np.amax(abs(x))
+
+
+def _get_sizeof(obj):
+    try:
+        return sys.getsizeof(obj)
+    except TypeError:
+        # occurs on pypy
+        if hasattr(obj, '__sizeof__'):
+            return int(obj.__sizeof__())
+        return 64
+
+
+def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6, limit=10000,
+             workers=1, points=None, quadrature='gk21', full_output=False):
+    """Adaptive integration of a vector-valued function.
+
+    Parameters
+    ----------
+    f : callable
+        Vector-valued function f(x) to integrate.
+    a : float
+        Initial point.
+    b : float
+        Final point.
+    epsabs : float, optional
+        Absolute tolerance.
+    epsrel : float, optional
+        Relative tolerance.
+    norm : {'max', '2'}, optional
+        Vector norm to use for error estimation.
+    cache_size : int, optional
+        Number bytes to use for memoization.
+    workers : int or map-like callable, optional
+        If `workers` is an integer, part of the computation is done in
+        parallel subdivided to this many tasks (using `multiprocessing.Pool`).
+        Supply `-1` to use all cores available to the Process.
+        Alternatively, supply a map-like callable, such as
+        `multiprocessing.Pool.map` for evaluating the population in parallel.
+        This evaluation is carried out as ``workers(func, iterable)``.
+    points : list, optional
+        List of additional breakpoints.
+    quardarture : {'gk21', 'trapz'}, optional
+        Quadrature rule to use on subintervals.
+        Options: 'gk21' (Gauss-Kronrod 21-point rule),
+        'trapz' (composite trapezoid rule).
+    full_output : bool, optional
+        If true, populate ``info`` return value with "alist", "blist",
+        "rlist", "elist", "iord" keys.
+
+    Returns
+    -------
+    res : {float, array-like}
+        Estimate for the result
+    err : float
+        Error estimate for the result in the given norm
+    info : dict
+        Info dictionary. Has always the keys "neval" and "last"
+    ier : int
+        Result code
+
+    Notes
+    -----
+    The algorithm mainly follows the implementation of QUADPACK's
+    DQAG* algorithms, implementing global error control and adaptive
+    subdivision.
+
+    The algorithm here has some differences to the QUADPACK approach:
+
+    Instead of subdividing one interval at a time, the algorithm
+    subdivides N intervals with largest errors at once. This enables
+    (partial) parallelization of the integration.
+
+    The logic of subdividing "next largest" intervals first is then
+    not implemented, and we rely on the above extension to avoid
+    concentrating on "small" intervals only.
+
+    The Wynn epsilon table extrapolation is not used (QUADPACK uses it
+    for infinite intervals). This is because the algorithm here is
+    supposed to work on vector-valued functions, in an user-specified
+    norm, and the extension of the epsilon algorithm to this case does
+    not appear to be widely agreed.  For max-norm, using elementwise
+    Wynn epsilon could be possible, but we do not do this here with
+    the hope that the epsilon extrapolation is mainly useful in
+    special cases.
+
+    References
+    ----------
+    [1] R. Piessens, E. de Doncker, QUADPACK (1983).
+
+    """
+    a = float(a)
+    b = float(b)
+
+    # Use simple transformations to deal with integrals over infinite
+    # intervals.
+    args = (epsabs, epsrel, norm, cache_size, limit, workers, points, quadrature, full_output)
+    if np.isfinite(a) and np.isinf(b):
+        f2 = SemiInfiniteFunc(f, start=a, infty=b)
+        if points is not None:
+            points = tuple(f2.get_t(xp) for xp in points)
+        return quad_vec(f2, 0, 1, *args)
+    elif np.isfinite(b) and np.isinf(a):
+        f2 = SemiInfiniteFunc(f, start=b, infty=a)
+        if points is not None:
+            points = tuple(f2.get_t(xp) for xp in points)
+        res = quad_vec(f2, 0, 1, *args)
+        return (-res[0],) + res[1:]
+    elif np.isinf(a) and np.isinf(b):
+        sgn = -1 if b < a else 1
+
+        # NB. first interval split occurs at t=0, which separates
+        # positive and negative sides of the integral
+        f2 = DoubleInfiniteFunc(f)
+        if points is not None:
+            points = tuple(f2.get_t(xp) for xp in points)
+        if a != b:
+            res = quad_vec(f2, -1, 1, *args)
+        else:
+            res = quad_vec(f2, 1, 1, *args)
+        return (res[0]*sgn,) + res[1:]
+    elif not (np.isfinite(a) and np.isfinite(b)):
+        raise ValueError("invalid integration bounds a={}, b={}".format(a, b))
+
+    norm_funcs = {
+        None: _max_norm,
+        'max': _max_norm,
+        '2': np.linalg.norm
+    }
+    if callable(norm):
+        norm_func = norm
+    else:
+        norm_func = norm_funcs[norm]
+
+    mapwrapper = MapWrapper(workers)
+
+    parallel_count = 8
+    min_intervals = 2
+
+    try:
+        _quadrature = {None: _quadrature_gk21,
+                       'gk21': _quadrature_gk21,
+                       'trapz': _quadrature_trapz}[quadrature]
+    except KeyError:
+        raise ValueError("unknown quadrature {!r}".format(quadrature))
+
+    # Initial interval set
+    if points is None:
+        initial_intervals = [(a, b)]
+    else:
+        prev = a
+        initial_intervals = []
+        for p in sorted(points):
+            p = float(p)
+            if p <= a or p >= b or p == prev:
+                continue
+            initial_intervals.append((prev, p))
+            prev = p
+        initial_intervals.append((prev, b))
+
+    global_integral = None
+    global_error = None
+    rounding_error = None
+    interval_cache = None
+    intervals = []
+    neval = 0
+
+    for x1, x2 in initial_intervals:
+        ig, err, rnd = _quadrature(x1, x2, f, norm_func)
+        neval += _quadrature.num_eval
+
+        if global_integral is None:
+            if isinstance(ig, (float, complex)):
+                # Specialize for scalars
+                if norm_func in (_max_norm, np.linalg.norm):
+                    norm_func = abs
+
+            global_integral = ig
+            global_error = float(err)
+            rounding_error = float(rnd)
+
+            cache_count = cache_size // _get_sizeof(ig)
+            interval_cache = LRUDict(cache_count)
+        else:
+            global_integral += ig
+            global_error += err
+            rounding_error += rnd
+
+        interval_cache[(x1, x2)] = copy.copy(ig)
+        intervals.append((-err, x1, x2))
+
+    heapq.heapify(intervals)
+
+    # Process intervals
+    with mapwrapper:
+        ier = 1
+
+        while intervals and len(intervals) < limit:
+            # Select intervals with largest errors for subdivision
+            tol = max(epsabs, epsrel*norm_func(global_integral))
+
+            to_process = []
+            for j in range(parallel_count):
+                if not intervals:
+                    break
+
+                if j > 0 and abs(intervals[0][0]) * len(intervals) < 0.5*tol:
+                    # avoid unnecessary parallel splitting
+                    break
+
+                interval = heapq.heappop(intervals)
+
+                neg_old_err, a, b = interval
+                old_int = interval_cache.pop((a, b), None)
+                to_process.append(((-neg_old_err, a, b, old_int), f, norm_func, _quadrature))
+
+            # Subdivide intervals
+            for dint, derr, dround_err, subint, dneval in mapwrapper(_subdivide_interval, to_process):
+                neval += dneval
+                global_integral += dint
+                global_error += derr
+                rounding_error += dround_err
+                for x in subint:
+                    x1, x2, ig, err = x
+                    interval_cache[(x1, x2)] = ig
+                    heapq.heappush(intervals, (-err, x1, x2))
+
+            # Termination check
+            if len(intervals) >= min_intervals:
+                tol = max(epsabs, epsrel*norm_func(global_integral))
+                if global_error < tol/8:
+                    ier = 0
+                    break
+                if global_error < rounding_error:
+                    ier = 2
+                    break
+
+    res = global_integral
+    err = global_error + rounding_error
+    info = dict(neval=neval,
+                last=len(intervals))
+    if full_output:
+        info['alist'] = np.array([z[1] for z in intervals])
+        info['blist'] = np.array([z[2] for z in intervals])
+        res_arr = np.asarray(res)
+        dummy = np.full(res_arr.shape, np.nan, dtype=res_arr.dtype)
+        info['rlist'] = np.array([interval_cache.get((z[1], z[2]), dummy)
+                                  for z in intervals], dtype=res_arr.dtype)
+        info['elist'] = np.array([-z[0] for z in intervals])
+        info['iord'] = np.argsort(-info['elist'])
+
+    return (res, err, info, ier)
+
+
+def _subdivide_interval(args):
+    interval, f, norm_func, _quadrature = args
+    old_err, a, b, old_int = interval
+
+    c = 0.5 * (a + b)
+
+    # Left-hand side
+    if getattr(_quadrature, 'cache_size', 0) > 0:
+        f = functools.lru_cache(_quadrature.cache_size)(f)
+
+    s1, err1, round1 = _quadrature(a, c, f, norm_func)
+    dneval = _quadrature.num_eval
+    s2, err2, round2 = _quadrature(c, b, f, norm_func)
+    dneval += _quadrature.num_eval
+    if old_int is None:
+        old_int, _, _ = _quadrature(a, b, f, norm_func)
+        dneval += _quadrature.num_eval
+
+    if getattr(_quadrature, 'cache_size', 0) > 0:
+        dneval = f.cache_info().misses
+
+    dint = s1 + s2 - old_int
+    derr = err1 + err2 - old_err
+    dround_err = round1 + round2
+
+    subintervals = ((a, c, s1, err1), (c, b, s2, err2))
+    return dint, derr, dround_err, subintervals, dneval
+
+
+def _quadrature_trapz(x1, x2, f, norm_func):
+    """
+    Composite trapezoid quadrature
+    """
+    x3 = 0.5*(x1 + x2)
+    f1 = f(x1)
+    f2 = f(x2)
+    f3 = f(x3)
+
+    s2 = 0.25 * (x2 - x1) * (f1 + 2*f3 + f2)
+
+    round_err = 0.25 * abs(x2 - x1) * (float(norm_func(f1))
+                                       + 2*float(norm_func(f3))
+                                       + float(norm_func(f2))) * 2e-16
+
+    s1 = 0.5 * (x2 - x1) * (f1 + f2)
+    err = 1/3 * float(norm_func(s1 - s2))
+    return s2, err, round_err
+
+
+_quadrature_trapz.cache_size = 3 * 3
+_quadrature_trapz.num_eval = 3
+
+
+def _quadrature_gk21(a, b, f, norm_func):
+    """
+    Gauss-Kronrod 21 quadrature with error estimate
+    """
+    # Gauss-Kronrod points
+    x = (0.995657163025808080735527280689003,
+         0.973906528517171720077964012084452,
+         0.930157491355708226001207180059508,
+         0.865063366688984510732096688423493,
+         0.780817726586416897063717578345042,
+         0.679409568299024406234327365114874,
+         0.562757134668604683339000099272694,
+         0.433395394129247190799265943165784,
+         0.294392862701460198131126603103866,
+         0.148874338981631210884826001129720,
+         0,
+         -0.148874338981631210884826001129720,
+         -0.294392862701460198131126603103866,
+         -0.433395394129247190799265943165784,
+         -0.562757134668604683339000099272694,
+         -0.679409568299024406234327365114874,
+         -0.780817726586416897063717578345042,
+         -0.865063366688984510732096688423493,
+         -0.930157491355708226001207180059508,
+         -0.973906528517171720077964012084452,
+         -0.995657163025808080735527280689003)
+
+    # 10-point weights
+    w = (0.066671344308688137593568809893332,
+         0.149451349150580593145776339657697,
+         0.219086362515982043995534934228163,
+         0.269266719309996355091226921569469,
+         0.295524224714752870173892994651338,
+         0.295524224714752870173892994651338,
+         0.269266719309996355091226921569469,
+         0.219086362515982043995534934228163,
+         0.149451349150580593145776339657697,
+         0.066671344308688137593568809893332)
+
+    # 21-point weights
+    v = (0.011694638867371874278064396062192,
+         0.032558162307964727478818972459390,
+         0.054755896574351996031381300244580,
+         0.075039674810919952767043140916190,
+         0.093125454583697605535065465083366,
+         0.109387158802297641899210590325805,
+         0.123491976262065851077958109831074,
+         0.134709217311473325928054001771707,
+         0.142775938577060080797094273138717,
+         0.147739104901338491374841515972068,
+         0.149445554002916905664936468389821,
+         0.147739104901338491374841515972068,
+         0.142775938577060080797094273138717,
+         0.134709217311473325928054001771707,
+         0.123491976262065851077958109831074,
+         0.109387158802297641899210590325805,
+         0.093125454583697605535065465083366,
+         0.075039674810919952767043140916190,
+         0.054755896574351996031381300244580,
+         0.032558162307964727478818972459390,
+         0.011694638867371874278064396062192)
+
+    fv = [0.0]*21
+
+    c = 0.5 * (a + b)
+    h = 0.5 * (b - a)
+
+    # 21-point Gauss-Kronrod
+    s_k = 0.0
+    s_k_abs = 0.0
+    for i in range(21):
+        ff = f(c + h*x[i])
+        fv[i] = ff
+
+        vv = v[i]
+
+        # \int f(x)
+        s_k += vv * ff
+        # \int |f(x)|
+        s_k_abs += vv * abs(ff)
+
+    # 10-point Gauss
+    s_g = 0.0
+    for i in range(10):
+        s_g += w[i] * fv[2*i + 1]
+
+    # Quadrature of abs-deviation from average
+    s_k_dabs = 0.0
+    y0 = s_k / 2.0
+    for i in range(21):
+        # \int |f(x) - y0|
+        s_k_dabs += v[i] * abs(fv[i] - y0)
+
+    # Use similar error estimation as quadpack
+    err = float(norm_func((s_k - s_g) * h))
+    dabs = float(norm_func(s_k_dabs * h))
+    if dabs != 0 and err != 0:
+        err = dabs * min(1.0, (200 * err / dabs)**1.5)
+
+    eps = sys.float_info.epsilon
+    round_err = float(norm_func(50 * eps * h * s_k_abs))
+
+    if round_err > sys.float_info.min:
+        err = max(err, round_err)
+
+    return h * s_k, err, round_err
+
+
+_quadrature_gk21.num_eval = 21

--- a/scipy/integrate/quadpack.py
+++ b/scipy/integrate/quadpack.py
@@ -6,7 +6,7 @@ import sys
 import warnings
 from functools import partial
 
-from . import _quadpack, _quad_vec
+from . import _quadpack
 import numpy
 from numpy import Inf
 
@@ -43,8 +43,9 @@ def quad_explain(output=sys.stdout):
 
 def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
          limit=50, points=None, weight=None, wvar=None, wopts=None, maxp1=50,
-         limlst=50, vectorized=False, norm=None, quadrature=None, workers=1):
-    """Compute a definite integral.
+         limlst=50):
+    """
+    Compute a definite integral.
 
     Integrate func from `a` to `b` (possibly infinite interval) using a
     technique from the Fortran library QUADPACK.
@@ -81,9 +82,6 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
         Non-zero to return a dictionary of integration information.
         If non-zero, warning messages are also suppressed and the
         message is appended to the output tuple.
-    vectorized : bool, optional
-        Whether the function is vector-valued.
-        If yes, a slightly different integration algorithm is used.
 
     Returns
     -------
@@ -117,8 +115,7 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
         to be sorted.
     weight : float or int, optional
         String indicating weighting function. Full explanation for this
-        and the following four arguments can be found below.
-        Not available for ``vectorized=True``.
+        and the remaining arguments can be found below.
     wvar : optional
         Variables for use with weighting functions.
     wopts : optional
@@ -128,23 +125,6 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
     limlst : int, optional
         Upper bound on the number of cycles (>=3) for use with a sinusoidal
         weighting and an infinite end-point.
-    norm : {'max', '2'}, optional
-        Available only for ``vectorized=True``.
-        Vector norm to use for error estimation.
-    quadrature : {'gk21', 'trapz'}, optional
-        Available only for ``vectorized=True``.
-        Quadrature rule to use on subintervals.
-        Options: 'gk21' (Gauss-Kronrod 21-point rule),
-        'trapz' (composite trapezoid rule).
-    workers : int or map-like callable, optional
-        Available only for ``vectorized=True``.
-        If `workers` is an integer, part of the computation is done in
-        parallel subdivided to this many tasks (using `multiprocessing.Pool`).
-        Supply `-1` to use all cores available to the Process.
-        Alternatively, supply a map-like callable, such as
-        `multiprocessing.Pool.map` for evaluating the population in parallel.
-        This evaluation is carried out as ``workers(func, iterable)``.
-        
 
     See Also
     --------
@@ -185,8 +165,6 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
     'rlist'
         A rank-1 array of length M, the first K elements of which are the
         integral approximations on the subintervals.
-        For ``vectorized=True`` the integrator does not retain all
-        of the data. In this case, missing data is indicated with NaN values.
     'elist'
         A rank-1 array of length M, the first K elements of which are the
         moduli of the absolute error estimates on the subintervals.
@@ -201,7 +179,6 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
     If the input argument points is provided (i.e. it is not None),
     the following additional outputs are placed in the output
     dictionary.  Assume the points sequence is of length P.
-    The keys below are not present when ``vectorized=True``.
 
     'pts'
         A rank-1 array of length P+2 containing the integration limits
@@ -293,36 +270,6 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
         ``infodict['rslist']``.  See the explanation dictionary (last entry
         in the output tuple) for the meaning of the codes.
 
-    **Vector-valued integration**
-
-    The algorithm used for ``vectorized=True`` mainly follows the
-    implementation of QUADPACK's DQAG* algorithms (which are used for
-    ``vectorized=False``), implementing global error control and
-    adaptive subdivision.
-
-    The algorithm has some differences to the QUADPACK approach:
-
-    Instead of subdividing one interval at a time, the algorithm
-    subdivides N intervals with largest errors at once. This enables
-    (partial) parallelization of the integration.
-
-    The logic of subdividing "next largest" intervals first is then
-    not implemented, and we rely on the above extension to avoid
-    concentrating on "small" intervals only.
-
-    The Wynn epsilon table extrapolation is not used (QUADPACK uses it
-    for infinite intervals). This is because the algorithm here is
-    supposed to work on vector-valued functions, in an user-specified
-    norm, and the extension of the epsilon algorithm to this case does
-    not appear to be widely agreed.  For max-norm, using elementwise
-    Wynn epsilon could be possible, but we do not do this here with
-    the hope that the epsilon extrapolation is mainly useful in
-    special cases.
-
-    References
-    ----------
-    [1] R. Piessens, E. de Doncker, QUADPACK (1983).
-
     Examples
     --------
     Calculate :math:`\\int^4_0 x^2 dx` and compare with an analytic result
@@ -386,39 +333,15 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
     if not isinstance(args, tuple):
         args = (args,)
 
-    if not vectorized:
-        if norm is not None:
-            raise ValueError("Option 'norm' not available when vectorized=False")
-        if quadrature is not None:
-            raise ValueError("Option 'quadrature' not available when vectorized=False")
-        if workers != 1:
-            raise ValueError("Option 'workers' not available when vectorized=False")
+    # check the limits of integration: \int_a^b, expect a < b
+    flip, a, b = b < a, min(a, b), max(a, b)
 
-        # check the limits of integration: \int_a^b, expect a < b
-        flip, a, b = b < a, min(a, b), max(a, b)
-
-        if weight is None:
-            retval = _quad(func, a, b, args, full_output, epsabs, epsrel, limit,
-                           points)
-        else:
-            retval = _quad_weight(func, a, b, args, full_output, epsabs, epsrel,
-                                  limlst, limit, maxp1, weight, wvar, wopts)
+    if weight is None:
+        retval = _quad(func, a, b, args, full_output, epsabs, epsrel, limit,
+                       points)
     else:
-        if weight is not None:
-            raise ValueError("Option 'weight' not supported when vectorized=True")
-        if args:
-            f = lambda t: func(t, *args)
-        else:
-            f = func
-        res, err, info, ier = _quad_vec.quad_vec(f, a, b, epsabs=epsabs, epsrel=epsrel, norm=norm,
-                                                 limit=limit, workers=workers,
-                                                 full_output=full_output,
-                                                 points=points, quadrature=quadrature)
-        flip = False
-        if full_output:
-            retval = (res, err, info, ier)
-        else:
-            retval = (res, err, ier)
+        retval = _quad_weight(func, a, b, args, full_output, epsabs, epsrel,
+                              limlst, limit, maxp1, weight, wvar, wopts)
 
     if flip:
         retval = (-retval[0],) + retval[1:]

--- a/scipy/integrate/tests/test__quad_vec.py
+++ b/scipy/integrate/tests/test__quad_vec.py
@@ -1,0 +1,97 @@
+from __future__ import division, print_function, absolute_import
+
+import numpy as np
+from numpy.testing import assert_allclose, assert_equal
+
+from scipy.integrate import quad
+from scipy.integrate._quad_vec import quad_vec
+
+
+def test_quad_vec_simple():
+    n = np.arange(10)
+    f = lambda x: x**n
+    for epsabs in [0.1, 1e-3, 1e-6]:
+        exact = 2**(n+1)/(n + 1)
+
+        res, err = quad(f, 0, 2, vectorized=True, norm='max', epsabs=epsabs)
+        assert_allclose(res, exact, rtol=0, atol=epsabs)
+
+        res, err = quad(f, 0, 2, vectorized=True, norm='2', epsabs=epsabs)
+        assert np.linalg.norm(res - exact) < epsabs
+
+        res, err = quad(f, 0, 2, vectorized=True, norm='max', epsabs=epsabs, points=(0.5, 1.0))
+        assert_allclose(res, exact, rtol=0, atol=epsabs)
+
+        res, err, *rest = quad(f, 0, 2, vectorized=True, norm='max',
+                               epsrel=1e-8, epsabs=epsabs,
+                               full_output=True,
+                               limit=10000, quadrature='trapz')
+        assert_allclose(res, exact, rtol=0, atol=epsabs)
+
+
+def test_quad_vec_simple_inf():
+    f = lambda x: 1 / (1 + np.float64(x)**2)
+
+    for epsabs in [0.1, 1e-3, 1e-6]:
+        res, err = quad(f, 0, np.inf, vectorized=True, norm='max', epsabs=epsabs)
+        assert_allclose(res, np.pi/2, rtol=0, atol=max(epsabs, err))
+
+        res, err = quad(f, 0, -np.inf, vectorized=True, norm='max', epsabs=epsabs)
+        assert_allclose(res, -np.pi/2, rtol=0, atol=max(epsabs, err))
+
+        res, err = quad(f, -np.inf, 0, vectorized=True, norm='max', epsabs=epsabs)
+        assert_allclose(res, np.pi/2, rtol=0, atol=max(epsabs, err))
+
+        res, err = quad(f, np.inf, 0, vectorized=True, norm='max', epsabs=epsabs)
+        assert_allclose(res, -np.pi/2, rtol=0, atol=max(epsabs, err))
+
+        res, err = quad(f, -np.inf, np.inf, vectorized=True, norm='max', epsabs=epsabs)
+        assert_allclose(res, np.pi, rtol=0, atol=max(epsabs, err))
+
+        res, err = quad(f, np.inf, -np.inf, vectorized=True, norm='max', epsabs=epsabs)
+        assert_allclose(res, -np.pi, rtol=0, atol=max(epsabs, err))
+
+        res, err = quad(f, np.inf, np.inf, vectorized=True, norm='max', epsabs=epsabs)
+        assert_allclose(res, 0, rtol=0, atol=max(epsabs, err))
+
+        res, err = quad(f, -np.inf, -np.inf, vectorized=True, norm='max', epsabs=epsabs)
+        assert_allclose(res, 0, rtol=0, atol=max(epsabs, err))
+
+        res, err = quad(f, 0, np.inf, vectorized=True, norm='max', epsabs=epsabs, points=(1.0, 2.0))
+        assert_allclose(res, np.pi/2, rtol=0, atol=max(epsabs, err))
+
+    f = lambda x: np.sin(x + 2) / (1 + x**2)
+    exact = np.pi / np.e * np.sin(2)
+    epsabs = 1e-5
+
+    res, err, info, ier = quad(f, -np.inf, np.inf, vectorized=True, limit=1000, norm='max', epsabs=epsabs,
+                               full_output=True)
+    assert_allclose(res, exact, rtol=0, atol=max(epsabs, err))
+
+
+def _lorenzian(x):
+    return 1 / (1 + x**2)
+
+
+def test_quad_vec_pool():
+    from multiprocessing.dummy import Pool
+
+    f = _lorenzian
+    res, err = quad(f, -np.inf, np.inf, vectorized=True, norm='max', epsabs=1e-4, workers=4)
+    assert_allclose(res, np.pi, rtol=0, atol=1e-4)
+
+    with Pool(10) as pool:
+        f = lambda x: 1 / (1 + x**2)
+        res, err = quad(f, -np.inf, np.inf, vectorized=True, norm='max', epsabs=1e-4, workers=pool.map)
+        assert_allclose(res, np.pi, rtol=0, atol=1e-4)
+
+
+def test_num_eval():
+    def f(x):
+        count[0] += 1
+        return x**5
+
+    for q in ['gk21', 'trapz']:
+        count = [0]
+        res = quad(f, 0, 1, vectorized=True, norm='max', full_output=True, quadrature=q)
+        assert res[2]['neval'] == count[0]

--- a/scipy/integrate/tests/test__quad_vec.py
+++ b/scipy/integrate/tests/test__quad_vec.py
@@ -3,8 +3,7 @@ from __future__ import division, print_function, absolute_import
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 
-from scipy.integrate import quad
-from scipy.integrate._quad_vec import quad_vec
+from scipy.integrate import quad_vec
 
 
 def test_quad_vec_simple():
@@ -13,19 +12,19 @@ def test_quad_vec_simple():
     for epsabs in [0.1, 1e-3, 1e-6]:
         exact = 2**(n+1)/(n + 1)
 
-        res, err = quad(f, 0, 2, vectorized=True, norm='max', epsabs=epsabs)
+        res, err = quad_vec(f, 0, 2, norm='max', epsabs=epsabs)
         assert_allclose(res, exact, rtol=0, atol=epsabs)
 
-        res, err = quad(f, 0, 2, vectorized=True, norm='2', epsabs=epsabs)
+        res, err = quad_vec(f, 0, 2, norm='2', epsabs=epsabs)
         assert np.linalg.norm(res - exact) < epsabs
 
-        res, err = quad(f, 0, 2, vectorized=True, norm='max', epsabs=epsabs, points=(0.5, 1.0))
+        res, err = quad_vec(f, 0, 2, norm='max', epsabs=epsabs, points=(0.5, 1.0))
         assert_allclose(res, exact, rtol=0, atol=epsabs)
 
-        res, err, *rest = quad(f, 0, 2, vectorized=True, norm='max',
-                               epsrel=1e-8, epsabs=epsabs,
-                               full_output=True,
-                               limit=10000, quadrature='trapz')
+        res, err, *rest = quad_vec(f, 0, 2, norm='max',
+                                   epsrel=1e-8, epsabs=epsabs,
+                                   full_output=True,
+                                   limit=10000, quadrature='trapz')
         assert_allclose(res, exact, rtol=0, atol=epsabs)
 
 
@@ -33,39 +32,39 @@ def test_quad_vec_simple_inf():
     f = lambda x: 1 / (1 + np.float64(x)**2)
 
     for epsabs in [0.1, 1e-3, 1e-6]:
-        res, err = quad(f, 0, np.inf, vectorized=True, norm='max', epsabs=epsabs)
+        res, err = quad_vec(f, 0, np.inf, norm='max', epsabs=epsabs)
         assert_allclose(res, np.pi/2, rtol=0, atol=max(epsabs, err))
 
-        res, err = quad(f, 0, -np.inf, vectorized=True, norm='max', epsabs=epsabs)
+        res, err = quad_vec(f, 0, -np.inf, norm='max', epsabs=epsabs)
         assert_allclose(res, -np.pi/2, rtol=0, atol=max(epsabs, err))
 
-        res, err = quad(f, -np.inf, 0, vectorized=True, norm='max', epsabs=epsabs)
+        res, err = quad_vec(f, -np.inf, 0, norm='max', epsabs=epsabs)
         assert_allclose(res, np.pi/2, rtol=0, atol=max(epsabs, err))
 
-        res, err = quad(f, np.inf, 0, vectorized=True, norm='max', epsabs=epsabs)
+        res, err = quad_vec(f, np.inf, 0, norm='max', epsabs=epsabs)
         assert_allclose(res, -np.pi/2, rtol=0, atol=max(epsabs, err))
 
-        res, err = quad(f, -np.inf, np.inf, vectorized=True, norm='max', epsabs=epsabs)
+        res, err = quad_vec(f, -np.inf, np.inf, norm='max', epsabs=epsabs)
         assert_allclose(res, np.pi, rtol=0, atol=max(epsabs, err))
 
-        res, err = quad(f, np.inf, -np.inf, vectorized=True, norm='max', epsabs=epsabs)
+        res, err = quad_vec(f, np.inf, -np.inf, norm='max', epsabs=epsabs)
         assert_allclose(res, -np.pi, rtol=0, atol=max(epsabs, err))
 
-        res, err = quad(f, np.inf, np.inf, vectorized=True, norm='max', epsabs=epsabs)
+        res, err = quad_vec(f, np.inf, np.inf, norm='max', epsabs=epsabs)
         assert_allclose(res, 0, rtol=0, atol=max(epsabs, err))
 
-        res, err = quad(f, -np.inf, -np.inf, vectorized=True, norm='max', epsabs=epsabs)
+        res, err = quad_vec(f, -np.inf, -np.inf, norm='max', epsabs=epsabs)
         assert_allclose(res, 0, rtol=0, atol=max(epsabs, err))
 
-        res, err = quad(f, 0, np.inf, vectorized=True, norm='max', epsabs=epsabs, points=(1.0, 2.0))
+        res, err = quad_vec(f, 0, np.inf, norm='max', epsabs=epsabs, points=(1.0, 2.0))
         assert_allclose(res, np.pi/2, rtol=0, atol=max(epsabs, err))
 
     f = lambda x: np.sin(x + 2) / (1 + x**2)
     exact = np.pi / np.e * np.sin(2)
     epsabs = 1e-5
 
-    res, err, info, ier = quad(f, -np.inf, np.inf, vectorized=True, limit=1000, norm='max', epsabs=epsabs,
-                               full_output=True)
+    res, err, info = quad_vec(f, -np.inf, np.inf, limit=1000, norm='max', epsabs=epsabs,
+                              full_output=True)
     assert_allclose(res, exact, rtol=0, atol=max(epsabs, err))
 
 
@@ -77,12 +76,12 @@ def test_quad_vec_pool():
     from multiprocessing.dummy import Pool
 
     f = _lorenzian
-    res, err = quad(f, -np.inf, np.inf, vectorized=True, norm='max', epsabs=1e-4, workers=4)
+    res, err = quad_vec(f, -np.inf, np.inf, norm='max', epsabs=1e-4, workers=4)
     assert_allclose(res, np.pi, rtol=0, atol=1e-4)
 
     with Pool(10) as pool:
         f = lambda x: 1 / (1 + x**2)
-        res, err = quad(f, -np.inf, np.inf, vectorized=True, norm='max', epsabs=1e-4, workers=pool.map)
+        res, err = quad_vec(f, -np.inf, np.inf, norm='max', epsabs=1e-4, workers=pool.map)
         assert_allclose(res, np.pi, rtol=0, atol=1e-4)
 
 
@@ -93,5 +92,20 @@ def test_num_eval():
 
     for q in ['gk21', 'trapz']:
         count = [0]
-        res = quad(f, 0, 1, vectorized=True, norm='max', full_output=True, quadrature=q)
-        assert res[2]['neval'] == count[0]
+        res = quad_vec(f, 0, 1, norm='max', full_output=True, quadrature=q)
+        assert res[2].neval == count[0]
+
+
+def test_info():
+    def f(x):
+        return np.ones((3, 2, 1))
+
+    res, err, info = quad_vec(f, 0, 1, norm='max', full_output=True)
+
+    assert info.success == True
+    assert info.status == 0
+    assert info.message == 'Target precision reached.'
+    assert info.neval > 0
+    assert info.intervals.shape[1] == 2
+    assert info.integrals.shape == (info.intervals.shape[0], 3, 2, 1)
+    assert info.errors.shape == (info.intervals.shape[0],)

--- a/scipy/integrate/tests/test__quad_vec.py
+++ b/scipy/integrate/tests/test__quad_vec.py
@@ -109,3 +109,17 @@ def test_info():
     assert info.intervals.shape[1] == 2
     assert info.integrals.shape == (info.intervals.shape[0], 3, 2, 1)
     assert info.errors.shape == (info.intervals.shape[0],)
+
+
+def test_nan_inf():
+    def f_nan(x):
+        return np.nan
+
+    def f_inf(x):
+        return np.inf if x < 0.1 else 1/x
+
+    res, err, info = quad_vec(f_nan, 0, 1, full_output=True)
+    assert info.status == 3
+
+    res, err, info = quad_vec(f_inf, 0, 1, full_output=True)
+    assert info.status == 3


### PR DESCRIPTION
Implement a variant of the QUADPACK integration algorithm in Python, and
use it for integrating vector-valued functions.

This is useful in cases in which the function is not easy to calculate
elementwise, or a different norm than the max-norm is wanted for error
estimation, in which cases running quad() separately for each element is
not optimal.

The vectorized algorithm also allows for some degree of parallelization.

Example case:
```python
import time
import numpy as np

from scipy.integrate import quad, solve_ivp

t = np.linspace(0, 10, 200)

def f(x):
    sol = solve_ivp(lambda t, y: [x - y[1], x + y[0]], (0, 10), [1, 0], t_eval=t)
    return sol.y[0]

start = time.monotonic()
res = quad(f, -1, 1, vectorized=True, epsrel=1e-3)[0]
print("vec:", time.monotonic() - start)

start = time.monotonic()
res2 = np.array([quad(lambda x: f(x)[j], -1, 1, epsrel=1e-3)[0] for j in range(len(t))])
print("novec:", time.monotonic() - start)

import matplotlib.pyplot as plt
plt.plot(t, res, '-', t, res2, '--')
plt.show()
```
The vectorized=True scales linearly with `len(t)`, vectorized=False quadratically.
For scalar problems, there's more Python overhead:
```
In [5]: %timeit quad(np.sin, 0, 3, vectorized=True)
212 µs ± 48.5 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
In [6]: %timeit quad(np.sin, 0, 3, vectorized=False)
17.3 µs ± 2.21 µs per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```
On pypy, it goes the other way for pure-Python code:
```
[PyPy 6.0.0 with GCC 8.0.1 20180324 (Red Hat 8.0.1-0.20)] on linux
In [5]: %timeit quad(lambda x: 1/(1 + x**2), 0, 3, vectorized=True)                            
43 µs ± 3.49 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
In [6]: %timeit quad(lambda x: 1/(1 + x**2), 0, 3, vectorized=False)                           
103 µs ± 5.26 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```
Evaluation counts are similar in most cases:
```
In [20]: quad(lambda x: 1/(1 + x**2), 0, 3, vectorized=False, full_output=True)[2]['neval']    
63
In [21]: quad(lambda x: 1/(1 + x**2), 0, 3, vectorized=True, full_output=True)[2]['neval']     
63
```