### PR TITLE
DEP: deprecate planck distribution in scipy.stats

### DIFF
--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -531,6 +531,11 @@ class poisson_gen(rv_discrete):
 poisson = poisson_gen(name="poisson", longname='A Poisson')
 
 
+_planck_deprec_msg = """\
+The distribution `planck` is a special case of `geom` with suitable
+parameters; `planck` is therefore deprecated. Please use `scipy.stats.geom`."""
+
+
 class planck_gen(rv_discrete):
     r"""A Planck discrete exponential random variable.
 
@@ -556,26 +561,32 @@ class planck_gen(rv_discrete):
     def _argcheck(self, lambda_):
         return lambda_ > 0
 
+    @np.deprecate(old_name='planck', message=_planck_deprec_msg)
     def _pmf(self, k, lambda_):
         return (1-exp(-lambda_))*exp(-lambda_*k)
 
+    @np.deprecate(old_name='planck', message=_planck_deprec_msg)
     def _cdf(self, x, lambda_):
         k = floor(x)
         return 1-exp(-lambda_*(k+1))
 
+    @np.deprecate(old_name='planck', message=_planck_deprec_msg)
     def _sf(self, x, lambda_):
         return np.exp(self._logsf(x, lambda_))
 
+    @np.deprecate(old_name='planck', message=_planck_deprec_msg)
     def _logsf(self, x, lambda_):
         k = floor(x)
         return -lambda_*(k+1)
 
+    @np.deprecate(old_name='planck', message=_planck_deprec_msg)
     def _ppf(self, q, lambda_):
         vals = ceil(-1.0/lambda_ * log1p(-q)-1)
         vals1 = (vals-1).clip(self.a, np.inf)
         temp = self._cdf(vals1, lambda_)
         return np.where(temp >= q, vals1, vals)
 
+    @np.deprecate(old_name='planck', message=_planck_deprec_msg)
     def _stats(self, lambda_):
         mu = 1/(exp(lambda_)-1)
         var = exp(-lambda_)/(expm1(-lambda_))**2
@@ -583,6 +594,7 @@ class planck_gen(rv_discrete):
         g2 = 4+2*cosh(lambda_)
         return mu, var, g1, g2
 
+    @np.deprecate(old_name='planck', message=_planck_deprec_msg)
     def _entropy(self, lambda_):
         l = lambda_
         C = (1-exp(-l))

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -392,23 +392,6 @@ class TestGeom(object):
         assert_allclose(stats.geom.ppf(1e-20, 1e-20), 1.0, atol=1e-14)
 
 
-class TestPlanck(object):
-    def setup_method(self):
-        np.random.seed(1234)
-
-    def test_sf(self):
-        vals = stats.planck.sf([1, 2, 3], 5.)
-        expected = array([4.5399929762484854e-05,
-                          3.0590232050182579e-07,
-                          2.0611536224385579e-09])
-        assert_array_almost_equal(vals, expected)
-
-    def test_logsf(self):
-        vals = stats.planck.logsf([1000., 2000., 3000.], 1000.)
-        expected = array([-1001000., -2001000., -3001000.])
-        assert_array_almost_equal(vals, expected)
-
-
 class TestGennorm(object):
     def test_laplace(self):
         # test against Laplace (special case for beta=1)


### PR DESCRIPTION
Closes #9359 

Probably the standards tests of the distributions still need to be adjusted to handle the deprecation warning.