### PR TITLE
BUG: stats: mode for objects w/ndim > 1

### DIFF
--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1430,12 +1430,7 @@ class TestMode(object):
 
     def test_strings(self):
         data1 = ['rain', 'showers', 'showers']
-
-        with suppress_warnings() as sup:
-            r = sup.record(RuntimeWarning, ".*checked for nan values")
-            vals = stats.mode(data1)
-            assert_equal(len(r), 1)
-
+        vals = stats.mode(data1)
         assert_equal(vals[0][0], 'showers')
         assert_equal(vals[1][0], 2)
 
@@ -1443,10 +1438,7 @@ class TestMode(object):
         objects = [10, True, np.nan, 'hello', 10]
         arr = np.empty((5,), dtype=object)
         arr[:] = objects
-        with suppress_warnings() as sup:
-            r = sup.record(RuntimeWarning, ".*checked for nan values")
-            vals = stats.mode(arr)
-            assert_equal(len(r), 1)
+        vals = stats.mode(arr)
         assert_equal(vals[0][0], 10)
         assert_equal(vals[1][0], 2)
 
@@ -1474,10 +1466,7 @@ class TestMode(object):
         arr[:] = points
         assert_(len(set(points)) == 4)
         assert_equal(np.unique(arr).shape, (4,))
-        with suppress_warnings() as sup:
-            r = sup.record(RuntimeWarning, ".*checked for nan values")
-            vals = stats.mode(arr)
-            assert_equal(len(r), 1)
+        vals = stats.mode(arr)
 
         assert_equal(vals[0][0], Point(2))
         assert_equal(vals[1][0], 4)
@@ -1510,6 +1499,20 @@ class TestMode(object):
     def test_smallest_equal(self, data):
         result = stats.mode(data, nan_policy='omit')
         assert_equal(result[0][0], 1)
+
+    def test_obj_arrays_ndim(self):
+        # regression test for gh-9645: `mode` fails for object arrays w/ndim > 1
+        data = [['Oxidation'], ['Oxidation'], ['Polymerization'], ['Reduction']]
+        ar = np.array(data, dtype=object)
+        m = stats.mode(ar, axis=0)
+        assert np.all(m.mode == 'Oxidation') and m.mode.shape == (1, 1)
+        assert np.all(m.count == 2) and m.count.shape == (1, 1)
+
+        data1 = data + [[np.nan]]
+        ar1 = np.array(data1, dtype=object)
+        m = stats.mode(ar1, axis=0)
+        assert np.all(m.mode == 'Oxidation') and m.mode.shape == (1, 1)
+        assert np.all(m.count == 2) and m.count.shape == (1, 1)
 
 
 class TestVariability(object):


### PR DESCRIPTION
Fix the nan check for the edge case of object arrays with ndim > 1, and possibly string values.

closes gh-9645