### PR TITLE
MAINT: signal: avoid compiler warnings in lfilter.c.src

### DIFF
--- a/scipy/signal/lfilter.c.src
+++ b/scipy/signal/lfilter.c.src
@@ -189,7 +189,6 @@ scipy_signal_sigtools_linear_filter(PyObject * NPY_UNUSED(dummy), PyObject * arg
     }
     if (basic_filter == NULL) {
         PyObject *msg, *str;
-        char *s;
 
         str = PyObject_Str((PyObject*)PyArray_DESCR(arX));
         if (str == NULL) {
@@ -199,6 +198,7 @@ scipy_signal_sigtools_linear_filter(PyObject * NPY_UNUSED(dummy), PyObject * arg
         msg = PyUnicode_FromFormat(
                         "input type '%U' not supported\n", str);
 #else
+        char *s;
         s = PyString_AsString(str);
         msg = PyString_FromFormat(
                         "input type '%s' not supported\n", s);
@@ -290,7 +290,7 @@ scipy_signal_sigtools_linear_filter(PyObject * NPY_UNUSED(dummy), PyObject * arg
             }
             /* Give our reference to arVi to arVi_view */
 #if NPY_API_VERSION >= 0x00000007
-            if (PyArray_SetBaseObject(arVi_view, arVi) == -1) {
+            if (PyArray_SetBaseObject(arVi_view, (PyObject *)arVi) == -1) {
                 Py_DECREF(arVi_view);
                 goto fail;
             }


### PR DESCRIPTION
Trivial cleanup: move a variable declaration (we're OK with C99 declaration-after-statement now, are we?), and cast the array to PyObject since `PyArray_SetBaseObject` is documented to receive a PyObject, not a PyArrayObject. 