### PR TITLE
Add `stats.contingency` to refguide-check

### DIFF
--- a/scipy/stats/contingency.py
+++ b/scipy/stats/contingency.py
@@ -34,6 +34,7 @@ def margins(a):
     >>> a
     array([[ 0,  1,  2,  3,  4,  5],
            [ 6,  7,  8,  9, 10, 11]])
+    >>> from scipy.stats.contingency import margins
     >>> m0, m1 = margins(a)
     >>> m0
     array([[15],

--- a/scipy/stats/contingency.py
+++ b/scipy/stats/contingency.py
@@ -86,7 +86,7 @@ def expected_freq(observed):
     Examples
     --------
     >>> observed = np.array([[10, 10, 20],[20, 20, 20]])
-    >>> from scipy.stats import expected_freq
+    >>> from scipy.stats.contingency import expected_freq
     >>> expected_freq(observed)
     array([[ 12.,  12.,  16.],
            [ 18.,  18.,  24.]])

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -96,6 +96,7 @@ PUBLIC_SUBMODULES = [
     'special',
     'stats',
     'stats.mstats',
+    'stats.contingency',
 ]
 
 # Docs for these modules are included in the parent module
@@ -131,6 +132,9 @@ REFGUIDE_AUTOSUMMARY_SKIPLIST = [
     r'scipy\.special\..*_roots',  # old aliases for scipy.special.*_roots
     r'scipy\.special\.jn',  # alias for jv
     r'scipy\.linalg\.solve_lyapunov',  # deprecated name
+    r'scipy\.stats\.contingency\.chi2_contingency',
+    r'scipy\.stats\.contingency\.expected_freq',
+    r'scipy\.stats\.contingency\.margins',
 ]
 # deprecated windows in scipy.signal namespace
 for name in ('barthann', 'bartlett', 'blackmanharris', 'blackman', 'bohman',


### PR DESCRIPTION
Apparently, `stats.contingency` is a semi-public submodule: `chi2_contingency` is exported via the main scipy.stats namespace, but `expected_freq` and `margins` are not. They are instead listed in the docs
(https://docs.scipy.org/doc/scipy/reference/stats.html)
with explicit `contingency` namespace.

We probably do not want to either expand the surface area of scipy.stats with these two names, or advertise `stats.contingency` more by giving it a separate subheading in the main stats refguide.

So this PR simply switches the refguide-check for these functions, and lists them as exceptions for the consistency between refguide and `__all__`. 

@JacobBlomgren I cherry-picked your commit from https://github.com/scipy/scipy/pull/9624
(authorship's preserved).

supersedes and closes gh-9624

