### PR TITLE
Move misc.doccer to _lib.doccer

### DIFF
--- a/scipy/_lib/doccer.py
+++ b/scipy/_lib/doccer.py
@@ -1,0 +1,250 @@
+''' Utilities to allow inserting docstring fragments for common
+parameters into function and method docstrings'''
+
+from __future__ import division, print_function, absolute_import
+
+import sys
+
+__all__ = ['docformat', 'inherit_docstring_from', 'indentcount_lines',
+           'filldoc', 'unindent_dict', 'unindent_string']
+
+
+def docformat(docstring, docdict=None):
+    ''' Fill a function docstring from variables in dictionary
+
+    Adapt the indent of the inserted docs
+
+    Parameters
+    ----------
+    docstring : string
+        docstring from function, possibly with dict formatting strings
+    docdict : dict, optional
+        dictionary with keys that match the dict formatting strings
+        and values that are docstring fragments to be inserted.  The
+        indentation of the inserted docstrings is set to match the
+        minimum indentation of the ``docstring`` by adding this
+        indentation to all lines of the inserted string, except the
+        first
+
+    Returns
+    -------
+    outstring : string
+        string with requested ``docdict`` strings inserted
+
+    Examples
+    --------
+    >>> docformat(' Test string with %(value)s', {'value':'inserted value'})
+    ' Test string with inserted value'
+    >>> docstring = 'First line\\n    Second line\\n    %(value)s'
+    >>> inserted_string = "indented\\nstring"
+    >>> docdict = {'value': inserted_string}
+    >>> docformat(docstring, docdict)
+    'First line\\n    Second line\\n    indented\\n    string'
+    '''
+    if not docstring:
+        return docstring
+    if docdict is None:
+        docdict = {}
+    if not docdict:
+        return docstring
+    lines = docstring.expandtabs().splitlines()
+    # Find the minimum indent of the main docstring, after first line
+    if len(lines) < 2:
+        icount = 0
+    else:
+        icount = indentcount_lines(lines[1:])
+    indent = ' ' * icount
+    # Insert this indent to dictionary docstrings
+    indented = {}
+    for name, dstr in docdict.items():
+        lines = dstr.expandtabs().splitlines()
+        try:
+            newlines = [lines[0]]
+            for line in lines[1:]:
+                newlines.append(indent+line)
+            indented[name] = '\n'.join(newlines)
+        except IndexError:
+            indented[name] = dstr
+    return docstring % indented
+
+
+def inherit_docstring_from(cls):
+    """
+    This decorator modifies the decorated function's docstring by
+    replacing occurrences of '%(super)s' with the docstring of the
+    method of the same name from the class `cls`.
+
+    If the decorated method has no docstring, it is simply given the
+    docstring of `cls`s method.
+
+    Parameters
+    ----------
+    cls : Python class or instance
+        A class with a method with the same name as the decorated method.
+        The docstring of the method in this class replaces '%(super)s' in the
+        docstring of the decorated method.
+
+    Returns
+    -------
+    f : function
+        The decorator function that modifies the __doc__ attribute
+        of its argument.
+
+    Examples
+    --------
+    In the following, the docstring for Bar.func created using the
+    docstring of `Foo.func`.
+
+    >>> class Foo(object):
+    ...     def func(self):
+    ...         '''Do something useful.'''
+    ...         return
+    ...
+    >>> class Bar(Foo):
+    ...     @inherit_docstring_from(Foo)
+    ...     def func(self):
+    ...         '''%(super)s
+    ...         Do it fast.
+    ...         '''
+    ...         return
+    ...
+    >>> b = Bar()
+    >>> b.func.__doc__
+    'Do something useful.\n        Do it fast.\n        '
+
+    """
+    def _doc(func):
+        cls_docstring = getattr(cls, func.__name__).__doc__
+        func_docstring = func.__doc__
+        if func_docstring is None:
+            func.__doc__ = cls_docstring
+        else:
+            new_docstring = func_docstring % dict(super=cls_docstring)
+            func.__doc__ = new_docstring
+        return func
+    return _doc
+
+
+def extend_notes_in_docstring(cls, notes):
+    """
+    This decorator replaces the decorated function's docstring
+    with the docstring from corresponding method in `cls`.
+    It extends the 'Notes' section of that docstring to include
+    the given `notes`.
+    """
+    def _doc(func):
+        cls_docstring = getattr(cls, func.__name__).__doc__
+        # If python is called with -OO option,
+        # there is no docstring
+        if cls_docstring is None:
+            return func
+        end_of_notes = cls_docstring.find('        References\n')
+        if end_of_notes == -1:
+            end_of_notes = cls_docstring.find('        Examples\n')
+            if end_of_notes == -1:
+                end_of_notes = len(cls_docstring)
+        func.__doc__ = (cls_docstring[:end_of_notes] + notes +
+                        cls_docstring[end_of_notes:])
+        return func
+    return _doc
+
+
+def replace_notes_in_docstring(cls, notes):
+    """
+    This decorator replaces the decorated function's docstring
+    with the docstring from corresponding method in `cls`.
+    It replaces the 'Notes' section of that docstring with
+    the given `notes`.
+    """
+    def _doc(func):
+        cls_docstring = getattr(cls, func.__name__).__doc__
+        notes_header = '        Notes\n        -----\n'
+        # If python is called with -OO option,
+        # there is no docstring
+        if cls_docstring is None:
+            return func
+        start_of_notes = cls_docstring.find(notes_header)
+        end_of_notes = cls_docstring.find('        References\n')
+        if end_of_notes == -1:
+            end_of_notes = cls_docstring.find('        Examples\n')
+            if end_of_notes == -1:
+                end_of_notes = len(cls_docstring)
+        func.__doc__ = (cls_docstring[:start_of_notes + len(notes_header)] +
+                        notes +
+                        cls_docstring[end_of_notes:])
+        return func
+    return _doc
+
+
+def indentcount_lines(lines):
+    ''' Minimum indent for all lines in line list
+
+    >>> lines = [' one', '  two', '   three']
+    >>> indentcount_lines(lines)
+    1
+    >>> lines = []
+    >>> indentcount_lines(lines)
+    0
+    >>> lines = [' one']
+    >>> indentcount_lines(lines)
+    1
+    >>> indentcount_lines(['    '])
+    0
+    '''
+    indentno = sys.maxsize
+    for line in lines:
+        stripped = line.lstrip()
+        if stripped:
+            indentno = min(indentno, len(line) - len(stripped))
+    if indentno == sys.maxsize:
+        return 0
+    return indentno
+
+
+def filldoc(docdict, unindent_params=True):
+    ''' Return docstring decorator using docdict variable dictionary
+
+    Parameters
+    ----------
+    docdict : dictionary
+        dictionary containing name, docstring fragment pairs
+    unindent_params : {False, True}, boolean, optional
+        If True, strip common indentation from all parameters in
+        docdict
+
+    Returns
+    -------
+    decfunc : function
+        decorator that applies dictionary to input function docstring
+
+    '''
+    if unindent_params:
+        docdict = unindent_dict(docdict)
+
+    def decorate(f):
+        f.__doc__ = docformat(f.__doc__, docdict)
+        return f
+    return decorate
+
+
+def unindent_dict(docdict):
+    ''' Unindent all strings in a docdict '''
+    can_dict = {}
+    for name, dstr in docdict.items():
+        can_dict[name] = unindent_string(dstr)
+    return can_dict
+
+
+def unindent_string(docstring):
+    ''' Set docstring to minimum indent for all lines, including first
+
+    >>> unindent_string(' two')
+    'two'
+    >>> unindent_string('  two\\n   three')
+    'two\\n three'
+    '''
+    lines = docstring.expandtabs().splitlines()
+    icount = indentcount_lines(lines)
+    if icount == 0:
+        return docstring
+    return '\n'.join([line[icount:] for line in lines])

--- a/scipy/io/matlab/miobase.py
+++ b/scipy/io/matlab/miobase.py
@@ -19,7 +19,7 @@ if sys.version_info[0] >= 3:
 else:
     byteord = ord
 
-from scipy.misc import doccer
+from scipy._lib import doccer
 
 from . import byteordercodes as boc
 

--- a/scipy/misc/doccer.py
+++ b/scipy/misc/doccer.py
@@ -4,247 +4,51 @@ parameters into function and method docstrings'''
 from __future__ import division, print_function, absolute_import
 
 import sys
+import numpy as np
+from .._lib import doccer as _ld
 
 __all__ = ['docformat', 'inherit_docstring_from', 'indentcount_lines',
            'filldoc', 'unindent_dict', 'unindent_string']
 
-
+@np.deprecate(message="scipy.misc.docformat is deprecated in Scipy 1.3.0")
 def docformat(docstring, docdict=None):
-    ''' Fill a function docstring from variables in dictionary
-
-    Adapt the indent of the inserted docs
-
-    Parameters
-    ----------
-    docstring : string
-        docstring from function, possibly with dict formatting strings
-    docdict : dict, optional
-        dictionary with keys that match the dict formatting strings
-        and values that are docstring fragments to be inserted.  The
-        indentation of the inserted docstrings is set to match the
-        minimum indentation of the ``docstring`` by adding this
-        indentation to all lines of the inserted string, except the
-        first
-
-    Returns
-    -------
-    outstring : string
-        string with requested ``docdict`` strings inserted
-
-    Examples
-    --------
-    >>> docformat(' Test string with %(value)s', {'value':'inserted value'})
-    ' Test string with inserted value'
-    >>> docstring = 'First line\\n    Second line\\n    %(value)s'
-    >>> inserted_string = "indented\\nstring"
-    >>> docdict = {'value': inserted_string}
-    >>> docformat(docstring, docdict)
-    'First line\\n    Second line\\n    indented\\n    string'
-    '''
-    if not docstring:
-        return docstring
-    if docdict is None:
-        docdict = {}
-    if not docdict:
-        return docstring
-    lines = docstring.expandtabs().splitlines()
-    # Find the minimum indent of the main docstring, after first line
-    if len(lines) < 2:
-        icount = 0
-    else:
-        icount = indentcount_lines(lines[1:])
-    indent = ' ' * icount
-    # Insert this indent to dictionary docstrings
-    indented = {}
-    for name, dstr in docdict.items():
-        lines = dstr.expandtabs().splitlines()
-        try:
-            newlines = [lines[0]]
-            for line in lines[1:]:
-                newlines.append(indent+line)
-            indented[name] = '\n'.join(newlines)
-        except IndexError:
-            indented[name] = dstr
-    return docstring % indented
+    return _ld.docformat(docstring, docdict)
 
 
+@np.deprecate(message="scipy.misc.inherit_docstring_from is deprecated "
+                      "in Scipy 1.3.0")
 def inherit_docstring_from(cls):
-    """
-    This decorator modifies the decorated function's docstring by
-    replacing occurrences of '%(super)s' with the docstring of the
-    method of the same name from the class `cls`.
-
-    If the decorated method has no docstring, it is simply given the
-    docstring of `cls`s method.
-
-    Parameters
-    ----------
-    cls : Python class or instance
-        A class with a method with the same name as the decorated method.
-        The docstring of the method in this class replaces '%(super)s' in the
-        docstring of the decorated method.
-
-    Returns
-    -------
-    f : function
-        The decorator function that modifies the __doc__ attribute
-        of its argument.
-
-    Examples
-    --------
-    In the following, the docstring for Bar.func created using the
-    docstring of `Foo.func`.
-
-    >>> class Foo(object):
-    ...     def func(self):
-    ...         '''Do something useful.'''
-    ...         return
-    ...
-    >>> class Bar(Foo):
-    ...     @inherit_docstring_from(Foo)
-    ...     def func(self):
-    ...         '''%(super)s
-    ...         Do it fast.
-    ...         '''
-    ...         return
-    ...
-    >>> b = Bar()
-    >>> b.func.__doc__
-    'Do something useful.\n        Do it fast.\n        '
-
-    """
-    def _doc(func):
-        cls_docstring = getattr(cls, func.__name__).__doc__
-        func_docstring = func.__doc__
-        if func_docstring is None:
-            func.__doc__ = cls_docstring
-        else:
-            new_docstring = func_docstring % dict(super=cls_docstring)
-            func.__doc__ = new_docstring
-        return func
-    return _doc
+    return _ld.inherit_docstring_from(cls)
 
 
+@np.deprecate(message="scipy.misc.extend_notes_in_docstring is deprecated "
+                      "in Scipy 1.3.0")
 def extend_notes_in_docstring(cls, notes):
-    """
-    This decorator replaces the decorated function's docstring
-    with the docstring from corresponding method in `cls`.
-    It extends the 'Notes' section of that docstring to include
-    the given `notes`.
-    """
-    def _doc(func):
-        cls_docstring = getattr(cls, func.__name__).__doc__
-        # If python is called with -OO option,
-        # there is no docstring
-        if cls_docstring is None:
-            return func
-        end_of_notes = cls_docstring.find('        References\n')
-        if end_of_notes == -1:
-            end_of_notes = cls_docstring.find('        Examples\n')
-            if end_of_notes == -1:
-                end_of_notes = len(cls_docstring)
-        func.__doc__ = (cls_docstring[:end_of_notes] + notes +
-                        cls_docstring[end_of_notes:])
-        return func
-    return _doc
+    return _ld.extend_notes_in_docstring(cls, notes)
 
 
+@np.deprecate(message="scipy.misc.replace_notes_in_docstring is deprecated "
+                      "in Scipy 1.3.0")
 def replace_notes_in_docstring(cls, notes):
-    """
-    This decorator replaces the decorated function's docstring
-    with the docstring from corresponding method in `cls`.
-    It replaces the 'Notes' section of that docstring with
-    the given `notes`.
-    """
-    def _doc(func):
-        cls_docstring = getattr(cls, func.__name__).__doc__
-        notes_header = '        Notes\n        -----\n'
-        # If python is called with -OO option,
-        # there is no docstring
-        if cls_docstring is None:
-            return func
-        start_of_notes = cls_docstring.find(notes_header)
-        end_of_notes = cls_docstring.find('        References\n')
-        if end_of_notes == -1:
-            end_of_notes = cls_docstring.find('        Examples\n')
-            if end_of_notes == -1:
-                end_of_notes = len(cls_docstring)
-        func.__doc__ = (cls_docstring[:start_of_notes + len(notes_header)] +
-                        notes +
-                        cls_docstring[end_of_notes:])
-        return func
-    return _doc
+    return _ld.replace_notes_in_docstring(cls, notes)
 
 
+@np.deprecate(message="scipy.misc.indentcount_lines is deprecated "
+                      "in Scipy 1.3.0")
 def indentcount_lines(lines):
-    ''' Minimum indent for all lines in line list
-
-    >>> lines = [' one', '  two', '   three']
-    >>> indentcount_lines(lines)
-    1
-    >>> lines = []
-    >>> indentcount_lines(lines)
-    0
-    >>> lines = [' one']
-    >>> indentcount_lines(lines)
-    1
-    >>> indentcount_lines(['    '])
-    0
-    '''
-    indentno = sys.maxsize
-    for line in lines:
-        stripped = line.lstrip()
-        if stripped:
-            indentno = min(indentno, len(line) - len(stripped))
-    if indentno == sys.maxsize:
-        return 0
-    return indentno
+    return _ld.indentcount_lines(lines)
 
 
+@np.deprecate(message="scipy.misc.filldoc is deprecated in Scipy 1.3.0")
 def filldoc(docdict, unindent_params=True):
-    ''' Return docstring decorator using docdict variable dictionary
-
-    Parameters
-    ----------
-    docdict : dictionary
-        dictionary containing name, docstring fragment pairs
-    unindent_params : {False, True}, boolean, optional
-        If True, strip common indentation from all parameters in
-        docdict
-
-    Returns
-    -------
-    decfunc : function
-        decorator that applies dictionary to input function docstring
-
-    '''
-    if unindent_params:
-        docdict = unindent_dict(docdict)
-
-    def decorate(f):
-        f.__doc__ = docformat(f.__doc__, docdict)
-        return f
-    return decorate
+    return _ld.filldoc(docdict, unindent_params)
 
 
+@np.deprecate(message="scipy.misc.unindent_dict is deprecated in Scipy 1.3.0")
 def unindent_dict(docdict):
-    ''' Unindent all strings in a docdict '''
-    can_dict = {}
-    for name, dstr in docdict.items():
-        can_dict[name] = unindent_string(dstr)
-    return can_dict
+    return _ld.unindent_dict(docdict)
 
 
+@np.deprecate(message="scipy.misc.unindent_string is deprecated in Scipy 1.3.0")
 def unindent_string(docstring):
-    ''' Set docstring to minimum indent for all lines, including first
-
-    >>> unindent_string(' two')
-    'two'
-    >>> unindent_string('  two\\n   three')
-    'two\\n three'
-    '''
-    lines = docstring.expandtabs().splitlines()
-    icount = indentcount_lines(lines)
-    if icount == 0:
-        return docstring
-    return '\n'.join([line[icount:] for line in lines])
+    return _ld.unindent_string(docstring)

--- a/scipy/ndimage/_ni_docstrings.py
+++ b/scipy/ndimage/_ni_docstrings.py
@@ -1,7 +1,7 @@
 """Docstring components common to several ndimage functions."""
 from __future__ import division, print_function, absolute_import
 
-from scipy.misc import doccer
+from scipy._lib import doccer
 
 __all__ = ['docfiller']
 

--- a/scipy/ndimage/interpolation.py
+++ b/scipy/ndimage/interpolation.py
@@ -37,7 +37,7 @@ import warnings
 from . import _ni_support
 from . import _nd_image
 from ._ni_docstrings import docdict
-from scipy.misc import doccer
+from scipy._lib import doccer
 
 # Change the default 'reflect' to 'constant' via modifying a copy of docdict
 docdict_copy = docdict.copy()

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -9,7 +9,7 @@ import warnings
 
 import numpy as np
 
-from scipy.misc.doccer import (extend_notes_in_docstring,
+from scipy._lib.doccer import (extend_notes_in_docstring,
                                replace_notes_in_docstring)
 from scipy import optimize
 from scipy import integrate

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -13,7 +13,7 @@ import re
 import types
 import warnings
 
-from scipy.misc import doccer
+from scipy._lib import doccer
 from ._distr_params import distcont, distdiscrete
 from scipy._lib._util import check_random_state
 from scipy._lib._util import _valarray as valarray

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -7,7 +7,7 @@ import math
 import numpy as np
 from numpy import asarray_chkfinite, asarray
 import scipy.linalg
-from scipy.misc import doccer
+from scipy._lib import doccer
 from scipy.special import gammaln, psi, multigammaln, xlogy, entr
 from scipy._lib._util import check_random_state
 from scipy.linalg.blas import drot


### PR DESCRIPTION
Make functions from misc.doccer emit deprecation warnings, and change internal uses to `from scipy._lib import doccer`.