### PR TITLE
ENH: add pearson, tippett, and mudholkar-george to combine_pvalues

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5432,8 +5432,8 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
           complement of the p-values inside the logarithms).
         - "tippett": Tippett's method (minimum of p-values).
         - "stouffer": Stouffer's Z-score method.
-        - "mudholkar_george": the difference of Fisher's and Pearson's methods.
-          Uses a t-distribution approximation to the logistic [7]_.
+        - "mudholkar_george": the difference of Fisher's and Pearson's methods
+           divided by 2.
     weights : array_like, 1-D, optional
         Optional array of weights used only for Stouffer's Z-score method.
 
@@ -5451,14 +5451,17 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
     Stouffer's Z-score method [2]_ uses Z-scores rather than p-values. The
     advantage of Stouffer's method is that it is straightforward to introduce
     weights, which can make Stouffer's method more powerful than Fisher's
-    method when the p-values are from studies of different size [3]_ [4]_.
+    method when the p-values are from studies of different size [6]_ [7]_.
     The Pearson's method uses :math:`log(1-p_i)` inside the sum whereas Fisher's
-    method uses :math:`log(p_i)` [6]_. For Fisher's and Pearson's method, the
+    method uses :math:`log(p_i)` [4]_. For Fisher's and Pearson's method, the
     sum of the logarithms is multiplied by -2 in the implementation. This
     quantity has a chisquare distribution that determines the p-value. The
     `mudholkar_george` method is the difference of the Fisher's and Pearson's
-    test statistics, each of which include the -2 factor [7]_. However, the
-    `mudholkar_george` method does not include these -2 factors.
+    test statistics, each of which include the -2 factor [4]_. However, the
+    `mudholkar_george` method does not include these -2 factors. The test
+    statistic of `mudholkar_george` is the sum of logisitic random variables and
+    equation 3.6 in [3]_ is used to approximate the p-value based on Student's
+    t-distribution.
 
     Fisher's method may be extended to combine p-values from dependent tests
     [5]_. Extensions such as Brown's method and Kost's method are not currently
@@ -5470,17 +5473,17 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
     ----------
     .. [1] https://en.wikipedia.org/wiki/Fisher%27s_method
     .. [2] https://en.wikipedia.org/wiki/Fisher%27s_method#Relation_to_Stouffer.27s_Z-score_method
-    .. [3] Whitlock, M. C. "Combining probability from independent tests: the
+    .. [3] George, E. O., and G. S. Mudholkar. "On the convolution of logistic
+           random variables." Metrika 30.1 (1983): 1-13.
+    .. [4] Heard, N. and Rubin-Delanchey, P. "Choosing between methods of
+           combining p-values."  Biometrika 105.1 (2018): 239-246.
+    .. [5] Whitlock, M. C. "Combining probability from independent tests: the
            weighted Z-method is superior to Fisher's approach." Journal of
            Evolutionary Biology 18, no. 5 (2005): 1368-1373.
-    .. [4] Zaykin, Dmitri V. "Optimally weighted Z-test is a powerful method
+    .. [6] Zaykin, Dmitri V. "Optimally weighted Z-test is a powerful method
            for combining probabilities in meta-analysis." Journal of
            Evolutionary Biology 24, no. 8 (2011): 1836-1841.
-    .. [5] https://en.wikipedia.org/wiki/Extensions_of_Fisher%27s_method
-    .. [6] Heard, N. and Rubin-Delanchey, P. "Choosing between methods of
-           combining p-values."  Biometrika 105.1 (2018): 239-246.
-    .. [7] George, E. O., and G. S. Mudholkar. "On the convolution of logistic
-           random variables." Metrika 30.1 (1983): 1-13.
+    .. [7] https://en.wikipedia.org/wiki/Extensions_of_Fisher%27s_method
 
     """
     pvalues = np.asarray(pvalues)

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5427,12 +5427,12 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
         available:
 
         - "fisher": Fisher's method (Fisher's combined probability test),
-          the default.
+          the default, the sum of the logarithm of the p-values.
         - "pearson": Pearson's method (similar to Fisher's but uses 1-p
           inside the logarithms).
-        - "tippett": Tippett's nethd=od (minimum of pvalues).
+        - "tippett": Tippett's method (minimum of p-values).
         - "stouffer": Stouffer's Z-score method.
-        - "mudholkar-george": a sum of fisher and pearson methods.
+        - "mudholkar-george": a sum of Fisher's and Pearson's methods.
     weights : array_like, 1-D, optional
         Optional array of weights used only for Stouffer's Z-score method.
 
@@ -5456,9 +5456,9 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
     advantage of Stouffer's method is that it is straightforward to introduce
     weights, which can make Stouffer's method more powerful than Fisher's
     method when the p-values are from studies of different size [3]_ [4]_.
-    The Pearson method uses :math:`log(1-p_i)` inside the sum whereas Fisher's
+    The Pearson's method uses :math:`log(1-p_i)` inside the sum whereas Fisher's
     method uses :math:`log(p_i)` [6]_. The `mudholkar-george` method is the
-    sum of the fisher and the pearson test statistics.
+    sum of the Fisher's and Pearson's test statistics.
 
     Fisher's method may be extended to combine p-values from dependent tests
     [5]_. Extensions such as Brown's method and Kost's method are not currently
@@ -5494,14 +5494,14 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
         pval = distributions.chi2.sf(Xsq, 2 * len(pvalues))
         return (Xsq, pval)
     elif method == 'mudholkar_george':
-        Sg = -2 * np.sum(np.log(pvalues)) + 2 * np.sum(np.log(1-pvalues))
+        Sg = -2 * np.sum(np.log(pvalues)) + 2 * np.sum(np.log1p(-pvalues))
         nu = 5 * len(pvalues) + 4
         approx_factor = np.sqrt(nu / (nu - 2))
         pval = distributions.t.sf(Sg * approx_factor, nu)
         return (Sg, pval)
     elif method == 'tippett':
         St = np.min(pvalues)
-        pval = distributions.beta.sf(St,1, len(pvalues))
+        pval = distributions.beta.sf(St, 1, len(pvalues))
         return (St, pval)
     elif method == 'stouffer':
         if weights is None:

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5432,7 +5432,7 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
           complement of the p-values inside the logarithms).
         - "tippett": Tippett's method (minimum of p-values).
         - "stouffer": Stouffer's Z-score method.
-        - "mudholkar_george": a sum of Fisher's and Pearson's methods.
+        - "mudholkar_george": the difference of Fisher's and Pearson's methods.
     weights : array_like, 1-D, optional
         Optional array of weights used only for Stouffer's Z-score method.
 
@@ -5453,7 +5453,7 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
     method when the p-values are from studies of different size [3]_ [4]_.
     The Pearson's method uses :math:`log(1-p_i)` inside the sum whereas Fisher's
     method uses :math:`log(p_i)` [6]_. The `mudholkar_george` method is the
-    sum of the Fisher's and Pearson's test statistics.
+    difference of the Fisher's and Pearson's test statistics.
 
     Fisher's method may be extended to combine p-values from dependent tests
     [5]_. Extensions such as Brown's method and Kost's method are not currently

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5433,6 +5433,7 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
         - "tippett": Tippett's method (minimum of p-values).
         - "stouffer": Stouffer's Z-score method.
         - "mudholkar_george": the difference of Fisher's and Pearson's methods.
+          Uses a t-distribution approximation to the logistic [7]_.
     weights : array_like, 1-D, optional
         Optional array of weights used only for Stouffer's Z-score method.
 
@@ -5452,8 +5453,10 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
     weights, which can make Stouffer's method more powerful than Fisher's
     method when the p-values are from studies of different size [3]_ [4]_.
     The Pearson's method uses :math:`log(1-p_i)` inside the sum whereas Fisher's
-    method uses :math:`log(p_i)` [6]_. The `mudholkar_george` method is the
-    difference of the Fisher's and Pearson's test statistics.
+    method uses :math:`log(p_i)` [6]_. Fisher's and Pearson's methods each
+    multiply the sum of the logged p-values quantity by `-2`. The
+    `mudholkar_george` method is the difference of the Fisher's and Pearson's
+    test statistics [7]_.
 
     Fisher's method may be extended to combine p-values from dependent tests
     [5]_. Extensions such as Brown's method and Kost's method are not currently
@@ -5474,6 +5477,8 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
     .. [5] https://en.wikipedia.org/wiki/Extensions_of_Fisher%27s_method
     .. [6] Heard, N. and Rubin-Delanchey, P. "Choosing between methods of
            combining p-values."  Biometrika 105.1 (2018): 239-246.
+    .. [7] George, E. O., and G. S. Mudholkar. "On the convolution of logistic
+           random variables." Metrika 30.1 (1983): 1-13.
 
     """
     pvalues = np.asarray(pvalues)

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5421,7 +5421,7 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
     ----------
     pvalues : array_like, 1-D
         Array of p-values assumed to come from independent tests.
-    method : {'fisher', 'pearson', 'tippett', 'stouffer', 'mudholkar-george'},
+    method : {'fisher', 'pearson', 'tippett', 'stouffer', 'mudholkar_george'},
     optional.
         Name of method to use to combine p-values. The following methods are
         available:
@@ -5432,7 +5432,7 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
           complement of the p-values inside the logarithms).
         - "tippett": Tippett's method (minimum of p-values).
         - "stouffer": Stouffer's Z-score method.
-        - "mudholkar-george": a sum of Fisher's and Pearson's methods.
+        - "mudholkar_george": a sum of Fisher's and Pearson's methods.
     weights : array_like, 1-D, optional
         Optional array of weights used only for Stouffer's Z-score method.
 
@@ -5444,7 +5444,7 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
         - "pearson": Similar to Fisher but using complementary pval
         - "tippett": smallest p-value
         - "stouffer": The Z-score
-        - "mudholkar-george": The sum of fisher and pearson methods
+        - "mudholkar_george": The sum of fisher and pearson methods
     pval: float
         The combined p-value.
 
@@ -5457,7 +5457,7 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
     weights, which can make Stouffer's method more powerful than Fisher's
     method when the p-values are from studies of different size [3]_ [4]_.
     The Pearson's method uses :math:`log(1-p_i)` inside the sum whereas Fisher's
-    method uses :math:`log(p_i)` [6]_. The `mudholkar-george` method is the
+    method uses :math:`log(p_i)` [6]_. The `mudholkar_george` method is the
     sum of the Fisher's and Pearson's test statistics.
 
     Fisher's method may be extended to combine p-values from dependent tests

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5457,7 +5457,8 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
     sum of the logarithms is multiplied by -2 in the implementation. This
     quantity has a chisquare distribution that determines the p-value. The
     `mudholkar_george` method is the difference of the Fisher's and Pearson's
-    test statistics, each of which include the -2 factor [7]_.
+    test statistics, each of which include the -2 factor [7]_. However, the
+    `mudholkar_george` method does not include these -2 factors.
 
     Fisher's method may be extended to combine p-values from dependent tests
     [5]_. Extensions such as Brown's method and Kost's method are not currently
@@ -5493,7 +5494,7 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
         statistic = -2 * np.sum(np.log1p(-pvalues))
         pval = distributions.chi2.sf(statistic, 2 * len(pvalues))
     elif method == 'mudholkar_george':
-        statistic = -2 * np.sum(np.log(pvalues)) + 2 * np.sum(np.log1p(-pvalues))
+        statistic = -np.sum(np.log(pvalues)) + np.sum(np.log1p(-pvalues))
         nu = 5 * len(pvalues) + 4
         approx_factor = np.sqrt(nu / (nu - 2))
         pval = distributions.t.sf(statistic * approx_factor, nu)

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5453,10 +5453,11 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
     weights, which can make Stouffer's method more powerful than Fisher's
     method when the p-values are from studies of different size [3]_ [4]_.
     The Pearson's method uses :math:`log(1-p_i)` inside the sum whereas Fisher's
-    method uses :math:`log(p_i)` [6]_. Fisher's and Pearson's methods each
-    multiply the sum of the logged p-values quantity by `-2`. The
+    method uses :math:`log(p_i)` [6]_. For Fisher's and Pearson's method, the
+    sum of the logarithms is multiplied by -2 in the implementation. This
+    quantity has a chisquare distribution that determines the p-value. The
     `mudholkar_george` method is the difference of the Fisher's and Pearson's
-    test statistics [7]_.
+    test statistics, each of which include the -2 factor [7]_.
 
     Fisher's method may be extended to combine p-values from dependent tests
     [5]_. Extensions such as Brown's method and Kost's method are not currently

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5486,19 +5486,19 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
         raise ValueError("pvalues is not 1-D")
 
     if method == 'fisher':
-        Xsq = -2 * np.sum(np.log(pvalues))
-        pval = distributions.chi2.sf(Xsq, 2 * len(pvalues))
+        statistic = -2 * np.sum(np.log(pvalues))
+        pval = distributions.chi2.sf(statistic, 2 * len(pvalues))
     elif method == 'pearson':
-        Xsq = -2 * np.sum(np.log(1 - pvalues))
-        pval = distributions.chi2.sf(Xsq, 2 * len(pvalues))
+        statistic = -2 * np.sum(np.log1p(-pvalues))
+        pval = distributions.chi2.sf(statistic, 2 * len(pvalues))
     elif method == 'mudholkar_george':
-        Xsq = -2 * np.sum(np.log(pvalues)) + 2 * np.sum(np.log1p(-pvalues))
+        statistic = -2 * np.sum(np.log(pvalues)) + 2 * np.sum(np.log1p(-pvalues))
         nu = 5 * len(pvalues) + 4
         approx_factor = np.sqrt(nu / (nu - 2))
-        pval = distributions.t.sf(Sg * approx_factor, nu)
+        pval = distributions.t.sf(statistic * approx_factor, nu)
     elif method == 'tippett':
-        Xsq = np.min(pvalues)
-        pval = distributions.beta.sf(St, 1, len(pvalues))
+        statistic = np.min(pvalues)
+        pval = distributions.beta.sf(statistic, 1, len(pvalues))
     elif method == 'stouffer':
         if weights is None:
             weights = np.ones_like(pvalues)
@@ -5510,15 +5510,15 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
             raise ValueError("weights is not 1-D")
 
         Zi = distributions.norm.isf(pvalues)
-        Xsq = np.dot(weights, Zi) / np.linalg.norm(weights)
-        pval = distributions.norm.sf(Xsq)
+        statistic = np.dot(weights, Zi) / np.linalg.norm(weights)
+        pval = distributions.norm.sf(statistic)
 
     else:
         raise ValueError(
             "Invalid method '%s'. Options are 'fisher', 'pearson', \
             'mudholkar_george', 'tippett', 'or 'stouffer'", method)
 
-    return (Xsq, pval)
+    return (statistic, pval)
 
 
 #####################################

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5439,12 +5439,7 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
     Returns
     -------
     statistic: float
-        The statistic calculated by the specified method:
-        - "fisher": The chi-squared statistic
-        - "pearson": Similar to Fisher but using complementary pval
-        - "tippett": smallest p-value
-        - "stouffer": The Z-score
-        - "mudholkar_george": The sum of fisher and pearson methods
+        The statistic calculated by the specified method.
     pval: float
         The combined p-value.
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4154,7 +4154,7 @@ class TestCombinePvalues(object):
         Z, p = stats.combine_pvalues([.01, .2, .3], method='mudholkar_george')
         assert_approx_equal(p, 5.373858588862369e-12, significant=4)
 
-    def test_mudholkar_george_equal_fisher_plus_pearson(self):
+    def test_mudholkar_george_equal_fisher_minus_pearson(self):
         Z, p = stats.combine_pvalues([.01, .2, .3], method='mudholkar_george')
         Z_f, p_f = stats.combine_pvalues([.01, .2, .3], method='fisher')
         Z_p, p_p = stats.combine_pvalues([.01, .2, .3], method='pearson')

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4152,13 +4152,13 @@ class TestCombinePvalues(object):
 
     def test_mudholkar_george(self):
         Z, p = stats.combine_pvalues([.01, .2, .3], method='mudholkar_george')
-        assert_approx_equal(p, 5.373858588862369e-12, significant=4)
+        assert_approx_equal(p, 3.7191571041915e-07, significant=4)
 
     def test_mudholkar_george_equal_fisher_minus_pearson(self):
         Z, p = stats.combine_pvalues([.01, .2, .3], method='mudholkar_george')
         Z_f, p_f = stats.combine_pvalues([.01, .2, .3], method='fisher')
         Z_p, p_p = stats.combine_pvalues([.01, .2, .3], method='pearson')
-        assert_approx_equal(Z_f-Z_p, Z, significant=4)
+        assert_approx_equal(0.5 * (Z_f-Z_p), Z, significant=4)
 
 
 class TestCdfDistanceValidation(object):

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4142,6 +4142,18 @@ class TestCombinePvalues(object):
                                      weights=np.array((1, 4, 9)))
         assert_approx_equal(p, 0.1464, significant=4)
 
+    def test_pearson(self):
+        Z, p = stats.combine_pvalues([.01, .2, .3], method='pearson')
+        assert_approx_equal(p, 0.97787, significant=4)
+
+    def test_tippett(self):
+        Z, p = stats.combine_pvalues([.01, .2, .3], method='tippett')
+        assert_approx_equal(p, 0.970299, significant=4)
+
+    def test_mudholkar_george(self):
+        Z, p = stats.combine_pvalues([.01, .2, .3], method='mudholkar_george')
+        assert_approx_equal(p, 5.373858588862369e-12, significant=4)
+
 
 class TestCdfDistanceValidation(object):
     """

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4158,6 +4158,7 @@ class TestCombinePvalues(object):
         Z, p = stats.combine_pvalues([.01, .2, .3], method='mudholkar_george')
         Z_f, p_f = stats.combine_pvalues([.01, .2, .3], method='fisher')
         Z_p, p_p = stats.combine_pvalues([.01, .2, .3], method='pearson')
+        # 0.5 here is because logistic = log(u) - log(1-u), i.e. no 2 factors
         assert_approx_equal(0.5 * (Z_f-Z_p), Z, significant=4)
 
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4154,6 +4154,12 @@ class TestCombinePvalues(object):
         Z, p = stats.combine_pvalues([.01, .2, .3], method='mudholkar_george')
         assert_approx_equal(p, 5.373858588862369e-12, significant=4)
 
+    def test_mudholkar_george_equal_fisher_plus_pearson(self):
+        Z, p = stats.combine_pvalues([.01, .2, .3], method='mudholkar_george')
+        Z_f, p_f = stats.combine_pvalues([.01, .2, .3], method='fisher')
+        Z_p, p_p = stats.combine_pvalues([.01, .2, .3], method='pearson')
+        assert_approx_equal(Z_f-Z_p, Z, significant=4)
+
 
 class TestCdfDistanceValidation(object):
     """


### PR DESCRIPTION
This PR adds pearson, tippett, and mudholkar-george methods to combine_pvalues funtion in the stats submodule. These methods use the nomenclature from https://arxiv.org/pdf/1707.06897.pdf 
While this paper is recent (reviewed in 2018) the added methods from the paper date to at least 1978 or earlier so nothing that hasn't been extensively used already in meta-analysis is being added. 
One omission-if you read the Heard and Rubin-Delanchey paper is the Edington method (raw sum of p-values). I started to implement the Edington method but that requires an implementation of the Irwin Hall distribution. That made the PR too big so I decided to parse them out as 2 separate PRs. I will post the second PR once I finish implementing the Irwin-Hall ( https://en.wikipedia.org/wiki/Irwin%E2%80%93Hall_distribution ). This also makes the 2 PRs smaller and require smaller time to code review. 

For the `mudholkar-george` method I use the approximation from the original paper using a t-distribution. Gist is here:

https://gist.github.com/rlucas7/53ceae3b0ebbb1662892246d58f6a70a

The values are slightly different in my version than in their table but mostly agree on magnitudes and first digit in the approximation errors. The largest error in this approximation is 0.001. Given that p-values are usually made at the 0.01 and 0.05 level this seems reasonable, and there doesn't appear to be a better approximation without resorting to some very complicated truncation of infinite series approximations (see Mudholkar and George for these equations). 
 