### PR TITLE
BUG: Fix ksone right-hand endpoint, documentation and tests.

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -41,14 +41,14 @@ class ksone_gen(rv_continuous):
     r"""General Kolmogorov-Smirnov one-sided test.
 
     This is the distribution of the one-sided Kolmogorov-Smirnov (KS)
-    statistics :math:`\sqrt{n} D_n^+` and :math:`\sqrt{n} D_n^-`
+    statistics :math:`D_n^+` and :math:`D_n^-`
     for a finite sample size ``n`` (the shape parameter).
 
     %(before_notes)s
 
     Notes
     -----
-    :math:`\sqrt{n} D_n^+` and :math:`\sqrt{n} D_n^-` are given by
+    :math:`D_n^+` and :math:`D_n^-` are given by
 
     .. math::
 
@@ -91,7 +91,7 @@ class ksone_gen(rv_continuous):
         return sc.smirnovi(n, q)
 
 
-ksone = ksone_gen(a=0.0, name='ksone')
+ksone = ksone_gen(a=0.0, b=1.0, name='ksone')
 
 
 class kstwobign_gen(rv_continuous):

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -49,7 +49,7 @@ distcont_extra = [
 
 
 distslow = ['kappa4', 'rdist', 'gausshyper',
-            'recipinvgauss', 'ksone', 'genexpon',
+            'recipinvgauss', 'genexpon',
             'vonmises', 'vonmises_line', 'mielke', 'semicircular',
             'cosine', 'invweibull', 'powerlognorm', 'johnsonsu', 'kstwobign']
 # distslow are sorted by speed (very slow to slow)
@@ -136,7 +136,7 @@ def test_cont_basic(distname, arg):
         check_pickling(distfn, arg)
 
         # Entropy
-        if distname not in ['ksone', 'kstwobign']:
+        if distname not in ['kstwobign']:
             check_entropy(distfn, arg, distname)
 
         if distfn.numargs == 0:
@@ -172,8 +172,8 @@ def test_levy_stable_random_state_property():
 
 
 def cases_test_moments():
-    fail_normalization = set(['vonmises', 'ksone'])
-    fail_higher = set(['vonmises', 'ksone', 'ncf'])
+    fail_normalization = set(['vonmises'])
+    fail_higher = set(['vonmises', 'ncf'])
 
     for distname, arg in distcont[:] + [(histogram_test_instance, tuple())]:
         if distname == 'levy_stable':


### PR DESCRIPTION
The right-hand endpoint for `ksone` is 1.0, not the default +infinity. (This
appeared to contribute to some of the test xfailures.)
The docstring had incorrect `sqrt(n)` multipliers in places.
As of this PR and gh-8737, `ksone` no longer fails the `check_entropy()` test so
remove it from the list of exclusions.  Nor does it fail the normalization and
higher conditions in `cases_test_moments()`.  Removed from the list of slow
distributions as it takes about the same time as some of the other non-slow
dists.