### PR TITLE
DOC: add dev setup description for PRs to local repo

### DIFF
--- a/HACKING.rst.txt
+++ b/HACKING.rst.txt
@@ -212,8 +212,19 @@ account and then create your local repository via::
     $ git remote add upstream git://github.com/scipy/scipy.git
 
 Second to code review pull requests it is helpful to have a local copy of the
-code changes in the pull request. To ensure you have the pull request code in
-you local repository at the top level of your scipy repository open the file::
+code changes in the pull request. The preferred method to bring a PR from the
+github repository to your local repo in a new branch::
+
+    $ git fetch upstream pull/PULL_REQUEST_ID/head:NEW_BRANCH_NAME
+
+The value of `PULL_REQUEST_ID` will be the PR number and the `NEW_BRANCH_NAME`
+will be the name of the branch in your local repository where the diffs will
+reside.
+
+An alternate option is to ensure you have all the pull requests in you local
+repository. To configure your repository to grab all the updated PR data when
+you fetch from upstream first navigate to the top level of your scipy
+repository open the file::
 
     $ .git/config
 
@@ -228,6 +239,10 @@ After the `fetch` line you will add another line that reads::
     $ fetch = +refs/pull/*/head:refs/remotes/upstream/pr/*
 
 Save the config file in the same place with no other changes.
+Alternately, you can add this in directly from the command line via::
+
+    $ git config --local --add remote.upstream.fetch '+refs/pull/*/head:refs/remotes/upstream/pr/*'
+
 Now execute the command::
 
     $ git fetch upstream pr

--- a/HACKING.rst.txt
+++ b/HACKING.rst.txt
@@ -211,6 +211,36 @@ account and then create your local repository via::
     $ cd scipy
     $ git remote add upstream git://github.com/scipy/scipy.git
 
+Second to code review pull requests it is helpful to have a local copy of the
+code changes in the pull request. To ensure you have the pull request code in
+you local repository at the top level of your scipy repository open the file
+
+    $ .git/config
+
+When you open the file you should see 3 lines that look like this:
+
+    $ [remote "upstream"]
+    $         url = git://github.com/scipy/scipy.git
+    $         fetch = +refs/heads/*:refs/remotes/upstream/*
+
+After the `fetch` line you will add another line that reads:
+
+    $ fetch = +refs/pull/*/head:refs/remotes/upstream/pr/*
+
+Save the config file in the same place with no other changes.
+Now execute the command:
+
+    $ git fetch upstream pr
+
+This will bring all the pull requests to you local repository, including merged
+and closed pull requests. To investigate the pull request you will need to
+create a branch. For example to examine the code changes in pull request 1 you
+would create a branch via:
+
+    $ git checkout pr/1
+
+Now you have a branch in your local development area to execute test in python.
+
 To build the development version of Scipy and run tests, spawn
 interactive shells with the Python import paths properly set up etc.,
 do one of::

--- a/HACKING.rst.txt
+++ b/HACKING.rst.txt
@@ -213,29 +213,29 @@ account and then create your local repository via::
 
 Second to code review pull requests it is helpful to have a local copy of the
 code changes in the pull request. To ensure you have the pull request code in
-you local repository at the top level of your scipy repository open the file
+you local repository at the top level of your scipy repository open the file::
 
     $ .git/config
 
-When you open the file you should see 3 lines that look like this:
+When you open the file you should see 3 lines that look like this::
 
     $ [remote "upstream"]
     $         url = git://github.com/scipy/scipy.git
     $         fetch = +refs/heads/*:refs/remotes/upstream/*
 
-After the `fetch` line you will add another line that reads:
+After the `fetch` line you will add another line that reads::
 
     $ fetch = +refs/pull/*/head:refs/remotes/upstream/pr/*
 
 Save the config file in the same place with no other changes.
-Now execute the command:
+Now execute the command::
 
     $ git fetch upstream pr
 
 This will bring all the pull requests to you local repository, including merged
 and closed pull requests. To investigate the pull request you will need to
 create a branch. For example to examine the code changes in pull request 1 you
-would create a branch via:
+would create a branch via::
 
     $ git checkout pr/1
 

--- a/HACKING.rst.txt
+++ b/HACKING.rst.txt
@@ -221,40 +221,7 @@ The value of `PULL_REQUEST_ID` will be the PR number and the `NEW_BRANCH_NAME`
 will be the name of the branch in your local repository where the diffs will
 reside.
 
-An alternate option is to ensure you have all the pull requests in you local
-repository. To configure your repository to grab all the updated PR data when
-you fetch from upstream first navigate to the top level of your scipy
-repository open the file::
-
-    $ .git/config
-
-When you open the file you should see 3 lines that look like this::
-
-    $ [remote "upstream"]
-    $         url = git://github.com/scipy/scipy.git
-    $         fetch = +refs/heads/*:refs/remotes/upstream/*
-
-After the `fetch` line you will add another line that reads::
-
-    $ fetch = +refs/pull/*/head:refs/remotes/upstream/pr/*
-
-Save the config file in the same place with no other changes.
-Alternately, you can add this in directly from the command line via::
-
-    $ git config --local --add remote.upstream.fetch '+refs/pull/*/head:refs/remotes/upstream/pr/*'
-
-Now execute the command::
-
-    $ git fetch upstream pr
-
-This will bring all the pull requests to you local repository, including merged
-and closed pull requests. To investigate the pull request you will need to
-create a branch. For example to examine the code changes in pull request 1 you
-would create a branch via::
-
-    $ git checkout pr/1
-
-Now you have a branch in your local development area to execute test in python.
+Now you have a branch in your local development area to code review in python.
 
 To build the development version of Scipy and run tests, spawn
 interactive shells with the Python import paths properly set up etc.,


### PR DESCRIPTION
This PR adds a few lines to the development setup to describe how to setup the configuration of git so that you grab the pull requests from github when you run:

`git fetch upstream`

and stores them in your local repository. This is helpful if you want to test out the code that someone has in a PR in an easy way. If the pull request is recent then you will need to re-fetch and then create a branch e.g. 

`git checkout pr/123`

