### PR TITLE
DOC: expand docstring of exponweib distribution

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -1555,13 +1555,31 @@ class exponweib_gen(rv_continuous):
 
     .. math::
 
-        f(x, a, c) = a c (1-\exp(-x^c))^{a-1} \exp(-x^c) x^{c-1}
+        f(x, a, c) = a c [1-\exp(-x^c)]^{a-1} \exp(-x^c) x^{c-1}
 
-    for :math:`x >= 0`, :math:`a > 0`, :math:`c > 0`.
+    and its cumulative distribution function is:
 
-    `exponweib` takes :math:`a` and :math:`c` as shape parameters.
+    .. math::
+
+        F(x, a, c) = [1-\exp(-x^c)]^a
+
+    for :math:`x > 0`, :math:`a > 0`, :math:`c > 0`.
+
+    `exponweib` takes :math:`a` and :math:`c` as shape parameters:
+
+    * :math:`a` is the exponentiation parameter,
+      with the special case :math:`a=1` corresponding to the usual
+      (non-exponentiated) Weibull distribution.
+    * :math:`c` is the shape parameter of the usual Weibull law
+      (often named :math:`k`, but named :math:`a` in `numpy.random.weibull`).
+      Special values are :math:`c=1` and :math:`c=2` where Weibull distribution
+      reduces to the `expon` and `rayleigh` distributions respectively.
 
     %(after_notes)s
+
+    References
+    ----------
+    https://en.wikipedia.org/wiki/Exponentiated_Weibull_distribution
 
     %(example)s
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -1551,7 +1551,7 @@ class exponweib_gen(rv_continuous):
 
     See Also
     --------
-    weibull_min, numpy.random.weibull
+    weibull_min, numpy.random.mtrand.RandomState.weibull
 
     Notes
     -----
@@ -1572,7 +1572,7 @@ class exponweib_gen(rv_continuous):
     `exponweib` takes :math:`a` and :math:`c` as shape parameters:
 
     * :math:`a` is the exponentiation parameter,
-      with the special case :math:`a=1` corresponding to the usual
+      with the special case :math:`a=1` corresponding to the
       (non-exponentiated) Weibull distribution `weibull_min`.
     * :math:`c` is the shape parameter of the non-exponentiated Weibull law.
 
@@ -1928,7 +1928,7 @@ class weibull_min_gen(rv_continuous):
 
     See Also
     --------
-    weibull_max, numpy.random.weibull, exponweib
+    weibull_max, numpy.random.mtrand.RandomState.weibull, exponweib
 
     Notes
     -----
@@ -1941,9 +1941,10 @@ class weibull_min_gen(rv_continuous):
     for :math:`x >= 0`, :math:`c > 0`.
 
     `weibull_min` takes ``c`` as a shape parameter for :math:`c`.
-    (named :math:`k` in Wikipedia article and :math:`a` in `numpy.random.weibull`)
-    Special shape values are :math:`c=1` and :math:`c=2` where Weibull distribution
-    reduces to the `expon` and `rayleigh` distributions respectively.
+    (named :math:`k` in Wikipedia article and :math:`a` in
+    ``numpy.random.weibull``).  Special shape values are :math:`c=1` and
+    :math:`c=2` where Weibull distribution reduces to the `expon` and
+    `rayleigh` distributions respectively.
 
     %(after_notes)s
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -1549,6 +1549,10 @@ class exponweib_gen(rv_continuous):
 
     %(before_notes)s
 
+    See Also
+    --------
+    weibull_min, numpy.random.weibull
+
     Notes
     -----
     The probability density function for `exponweib` is:
@@ -1569,11 +1573,8 @@ class exponweib_gen(rv_continuous):
 
     * :math:`a` is the exponentiation parameter,
       with the special case :math:`a=1` corresponding to the usual
-      (non-exponentiated) Weibull distribution.
-    * :math:`c` is the shape parameter of the usual Weibull law
-      (often named :math:`k`, but named :math:`a` in `numpy.random.weibull`).
-      Special values are :math:`c=1` and :math:`c=2` where Weibull distribution
-      reduces to the `expon` and `rayleigh` distributions respectively.
+      (non-exponentiated) Weibull distribution `weibull_min`.
+    * :math:`c` is the shape parameter of the non-exponentiated Weibull law.
 
     %(after_notes)s
 
@@ -1920,11 +1921,14 @@ foldnorm = foldnorm_gen(a=0.0, name='foldnorm')
 class weibull_min_gen(rv_continuous):
     r"""Weibull minimum continuous random variable.
 
+    The Weibull Minimum Extreme Value distribution, from extreme value theory,
+    is also often simply called the Weibull distribution.
+
     %(before_notes)s
 
     See Also
     --------
-    weibull_max
+    weibull_max, numpy.random.weibull, exponweib
 
     Notes
     -----
@@ -1937,8 +1941,15 @@ class weibull_min_gen(rv_continuous):
     for :math:`x >= 0`, :math:`c > 0`.
 
     `weibull_min` takes ``c`` as a shape parameter for :math:`c`.
+    (named :math:`k` in Wikipedia article and :math:`a` in `numpy.random.weibull`)
+    Special shape values are :math:`c=1` and :math:`c=2` where Weibull distribution
+    reduces to the `expon` and `rayleigh` distributions respectively.
 
     %(after_notes)s
+
+    References
+    ----------
+    https://en.wikipedia.org/wiki/Weibull_distribution
 
     %(example)s
 


### PR DESCRIPTION
Hi, this is a small expansion to the docstring of the exponweib distribution. Indeed, it seems for 2 SO questions [1][2] that the meaning of the shape parameters is not obvious and doesn't match some classical definitions.

Also, it may be useful to add a "see also" section in `exponweib` pointing to `weibull_min` which seems to corresponds to the usual Weibull distribution, however its docstring doesn't say it explicitely (in fact, I find no references on the web for weibull_min and weibull_max except in scipy!). What do you think?

[1] https://stackoverflow.com/questions/17481672/fitting-a-weibull-distribution-using-scipy
[2] https://stackoverflow.com/questions/38287971/scipy-how-to-fit-weibull-distribution