### PR TITLE
BUG: Fix failing stats tests

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -3995,7 +3995,8 @@ class levy_stable_gen(rv_continuous):
         fft_n_points_two_power = getattr(self, 'pdf_fft_n_points_two_power', None)
 
         # group data in unique arrays of alpha, beta pairs
-        uniq_param_pairs = np.vstack({tuple(row) for row in data_in[:,1:]})
+        uniq_param_pairs = np.vstack(
+            list({tuple(row) for row in data_in[:,1:]}))
         for pair in uniq_param_pairs:
             data_mask = np.all(data_in[:,1:] == pair, axis=-1)
             data_subset = data_in[data_mask]

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1057,9 +1057,9 @@ def skew(a, axis=0, bias=True, nan_policy='propagate'):
 
     Notes
     -----
-    The sample skewness is computed as the Fisher-Pearson coefficicient
+    The sample skewness is computed as the Fisher-Pearson coefficient
     of skewness, i.e.
-    
+
     .. math:: g_1=\\frac{m_3}{m_2^{3/2}}
 
     where
@@ -1069,8 +1069,8 @@ def skew(a, axis=0, bias=True, nan_policy='propagate'):
     is the biased sample :math:`i\\texttt{th}` central moment, and :math:`\\bar{x}` is
     the sample mean.  If ``bias`` is False, the calculations are
     corrected for bias and the value computed is the adjusted
-    Fisher-Pearson standardized moment coefficient, i.e. 
-    
+    Fisher-Pearson standardized moment coefficient, i.e.
+
     .. math:: G_1=\\frac{k_3}{k_2^{3/2}}=
                   \\frac{\\sqrt{N(N-1)}}{N-2}\\frac{m_3}{m_2^{3/2}}.
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1983,7 +1983,9 @@ class TestIQR(object):
                                     np.array([2, np.nan, 2]) / 1.3489795)
                 assert_equal(stats.iqr(x, axis=1, scale=2.0, nan_policy='propagate'),
                              [1, np.nan, 1])
-                _check_warnings(w, RuntimeWarning, 6)
+                # Since NumPy 1.17.0.dev, warnings are no longer emitted by
+                # np.percentile with nans, so we don't check the number of
+                # warnings here. See https://github.com/numpy/numpy/pull/12679.
 
         if numpy_version < '1.9.0a':
             with warnings.catch_warnings(record=True) as w:


### PR DESCRIPTION
Pending the result of the related NumPy issue

https://github.com/numpy/numpy/issues/12737

This might not be the right fix. But in the meantime this should get Travis happy again, so probably worth merging and following up on later if necessary.

The `list({...})` change fixes a bug that I see locally using latest `numpy` where `np.vstack` gives:

> E           FutureWarning: arrays to stack must be passed as a "sequence" type such as list or tuple. Support for non-sequence iterables such as generators is deprecated as of NumPy 1.16 and will raise an error in the future.
