### PR TITLE
Added reference to ndimage.filters.median_filter

### DIFF
--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -899,14 +899,15 @@ def medfilt(volume, kernel_size=None):
     out : ndarray
         An array the same size as input containing the median filtered
         result.
-        
+
     See also
     --------
     ndimage.filters.median_filter
-    
+
     Notes
     -------
-    The more general function `ndimage.filters.median_filter` has a more efficient implementation of a median filter and therefore runs much faster.
+    The more general function `ndimage.filters.median_filter` has a more
+    efficient implementation of a median filter and therefore runs much faster.
     """
     volume = atleast_1d(volume)
     if kernel_size is None:
@@ -1166,7 +1167,8 @@ def medfilt2d(input, kernel_size=3):
     Median filter a 2-dimensional array.
 
     Apply a median filter to the `input` array using a local window-size
-    given by `kernel_size` (must be odd). The array is zero-padded automatically.
+    given by `kernel_size` (must be odd). The array is zero-padded
+    automatically.
 
     Parameters
     ----------
@@ -1184,14 +1186,15 @@ def medfilt2d(input, kernel_size=3):
     out : ndarray
         An array the same size as input containing the median filtered
         result.
-        
+
     See also
     --------
     ndimage.filters.median_filter
-    
+
     Notes
     -------
-    The more general function `ndimage.filters.median_filter` has a more efficient implementation of a median filter and therefore runs much faster.
+    The more general function `ndimage.filters.median_filter` has a more
+    efficient implementation of a median filter and therefore runs much faster.
     """
     image = asarray(input)
     if kernel_size is None:

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -882,7 +882,7 @@ def medfilt(volume, kernel_size=None):
     Perform a median filter on an N-dimensional array.
 
     Apply a median filter to the input array using a local window-size
-    given by `kernel_size`.
+    given by `kernel_size`. The array will automatically be zero-padded.
 
     Parameters
     ----------
@@ -899,7 +899,14 @@ def medfilt(volume, kernel_size=None):
     out : ndarray
         An array the same size as input containing the median filtered
         result.
-
+        
+    See also
+    --------
+    ndimage.filters.median_filter
+    
+    Notes
+    -------
+    The more general function `ndimage.filters.median_filter` has a more efficient implementation of a median filter and therefore runs much faster.
     """
     volume = atleast_1d(volume)
     if kernel_size is None:
@@ -1159,7 +1166,7 @@ def medfilt2d(input, kernel_size=3):
     Median filter a 2-dimensional array.
 
     Apply a median filter to the `input` array using a local window-size
-    given by `kernel_size` (must be odd).
+    given by `kernel_size` (must be odd). The array is zero-padded automatically.
 
     Parameters
     ----------
@@ -1177,7 +1184,14 @@ def medfilt2d(input, kernel_size=3):
     out : ndarray
         An array the same size as input containing the median filtered
         result.
-
+        
+    See also
+    --------
+    ndimage.filters.median_filter
+    
+    Notes
+    -------
+    The more general function `ndimage.filters.median_filter` has a more efficient implementation of a median filter and therefore runs much faster.
     """
     image = asarray(input)
     if kernel_size is None:


### PR DESCRIPTION
As suggested in #9680 I've added a note to `signal.medfilt` and `signal.medfilt2d` that the `ndimage.filters.median_filter` function is magnitudes faster.

Additionally, I've added that `medfilt` uses zero padding as a standard, as suggested in #3771