### PR TITLE
Fix coefficients in expm helper function

### DIFF
--- a/scipy/sparse/linalg/matfuncs.py
+++ b/scipy/sparse/linalg/matfuncs.py
@@ -844,19 +844,17 @@ def _ell(A, m):
     if len(A.shape) != 2 or A.shape[0] != A.shape[1]:
         raise ValueError('expected A to be like a square matrix')
 
-    p = 2*m + 1
-
     # The c_i are explained in (2.2) and (2.6) of the 2005 expm paper.
     # They are coefficients of terms of a generating function series expansion.
-    choose_2p_p = scipy.special.comb(2*p, p, exact=True)
-    abs_c_recip = float(choose_2p_p * math.factorial(2*p + 1))
+    choose_2m_m = scipy.special.comb(2*m, m, exact=True)
+    abs_c_recip = float(choose_2m_m * math.factorial(2*m + 1))
 
     # This is explained after Eq. (1.2) of the 2009 expm paper.
     # It is the "unit roundoff" of IEEE double precision arithmetic.
     u = 2**-53
 
     # Compute the one-norm of matrix power p of abs(A).
-    A_abs_onenorm = _onenorm_matrix_power_nnm(abs(A), p)
+    A_abs_onenorm = _onenorm_matrix_power_nnm(abs(A), 2*m + 1)
 
     # Treat zero norm as a special case.
     if not A_abs_onenorm:


### PR DESCRIPTION
According to [Higham 2005], the leading term of the backward error function of the [m/m] Padé approximant of the exponential function is `x^{2m+1}`. Its corresponding coefficient is `C_{2m+1} = (m!)^2 / ( (2m)! * (2m+1)!)`, cf. Equations (2.2) and (2.6) in said reference.

So far, the code didn't compute `C_{2m+1}`, but replaced `m <- 2m + 1`, which is probably due to the literature's somewhat surprising notation (cf. the index `i = 2m + 1` in Equation (2.6)).

[Al-Mohy and Higham 2009] actually have a [Matlab reference implementation] available, where they hard-code the cofficients, which are reproduced verbatim below. Using m instead of `m <- 2m + 1`, as is currently done, exactly reproduces these coefficients:

```matlab
% Coefficients of leading terms in the backward error functions h_{2m+1}.
Coeff = [1/100800, 1/10059033600, 1/4487938430976000,...
         1/5914384781877411840000, 1/113250775606021113483283660800000000];
```

[Higham 2005]: https://doi.org/10.1137/04061101X
[Al-Mohy and Higham 2009]: https://doi.org/10.1137/09074721X
[Matlab reference implementation]: http://eprints.ma.man.ac.uk/1442/03/expm_new.zip