### PR TITLE
DOC: Fix DCT vs DST in docstring for idstn

### DIFF
--- a/scipy/fftpack/realtransforms.py
+++ b/scipy/fftpack/realtransforms.py
@@ -203,7 +203,7 @@ def idstn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
     x : array_like
         The input array.
     type : {1, 2, 3, 4}, optional
-        Type of the DCT (see Notes). Default type is 2.
+        Type of the DST (see Notes). Default type is 2.
     shape : int or array_like of ints or None, optional
         The shape of the result.  If both `shape` and `axes` (see below) are
         None, `shape` is ``x.shape``; if `shape` is None but `axes` is
@@ -214,7 +214,7 @@ def idstn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
         If any element of `shape` is -1, the size of the corresponding
         dimension of `x` is used.
     axes : int or array_like of ints or None, optional
-        Axes along which the IDCT is computed.
+        Axes along which the IDST is computed.
         The default is over all axes.
     norm : {None, 'ortho'}, optional
         Normalization mode (see Notes). Default is None.
@@ -228,7 +228,7 @@ def idstn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
 
     See Also
     --------
-    dctn : multidimensional DST
+    dstn : multidimensional DST
 
     Notes
     -----


### PR DESCRIPTION
Typo fixes for the idstn docstring