### PR TITLE
Release the GIL during sosfilt processing for simple types

### DIFF
--- a/benchmarks/benchmarks/signal_filtering.py
+++ b/benchmarks/benchmarks/signal_filtering.py
@@ -1,9 +1,11 @@
 from __future__ import division, absolute_import, print_function
 
 import numpy as np
+import timeit
+from concurrent.futures import ThreadPoolExecutor, wait
 
 try:
-    from scipy.signal import lfilter, firwin, decimate
+    from scipy.signal import lfilter, firwin, decimate, butter, sosfilt
 except ImportError:
     pass
 
@@ -45,3 +47,26 @@ class Lfilter(Benchmark):
 
     def time_lfilter(self, n_samples, numtaps):
         lfilter(self.coeff, 1.0, self.sig)
+
+class ParallelSosfilt(Benchmark):
+    timeout = 100
+    timer = timeit.default_timer
+
+    param_names = ['n_samples', 'threads']
+    params = [
+        [1e3, 10e3],
+        [1, 2, 4]
+    ]
+
+    def setup(self, n_samples, threads):
+        self.filt = butter(8, 8e-6, "lowpass", output="sos")
+        self.data = np.arange(int(n_samples) * 3000).reshape(int(n_samples), 3000)
+        self.chunks = np.array_split(self.data, threads)
+
+    def time_sosfilt(self, n_samples, threads):
+        pool = ThreadPoolExecutor(max_workers=threads)
+        futures = []
+        for i in range(threads):
+            futures.append(pool.submit(sosfilt, self.filt, self.chunks[i]))
+
+        wait(futures)

--- a/scipy/signal/lfilter.c.src
+++ b/scipy/signal/lfilter.c.src
@@ -557,6 +557,7 @@ static void @NAME@_filt(char *b, char *a, char *x, char *y, char *Z,
                        npy_intp len_b, npy_uintp len_x, npy_intp stride_X,
                        npy_intp stride_Y)
 {
+    Py_BEGIN_ALLOW_THREADS
     char *ptr_x = x, *ptr_y = y;
     @type@ *ptr_Z;
     @type@ *ptr_b = (@type@*)b;
@@ -599,12 +600,14 @@ static void @NAME@_filt(char *b, char *a, char *x, char *y, char *Z,
         ptr_y += stride_Y;      /* Move to next input/output point */
         ptr_x += stride_X;
     }
+    Py_END_ALLOW_THREADS
 }
 
 static void C@NAME@_filt(char *b, char *a, char *x, char *y, char *Z,
                         npy_intp len_b, npy_uintp len_x, npy_intp stride_X,
                         npy_intp stride_Y)
 {
+    Py_BEGIN_ALLOW_THREADS
     char *ptr_x = x, *ptr_y = y;
     @type@ *ptr_Z, *ptr_b;
     @type@ *ptr_a;
@@ -667,6 +670,7 @@ static void C@NAME@_filt(char *b, char *a, char *x, char *y, char *Z,
         ptr_x += stride_X;
 
     }
+    Py_END_ALLOW_THREADS
 }
 /**end repeat**/
 


### PR DESCRIPTION
We noticed that despite using numpy sosfilt actually keeps the GIL which prevents us from using sosfilt in parallel. At least for the two cases that I have changed it seems safe to drop the GIL.

With the change the time the GIL is held during sosfilt drops from more than 85% to less than 5% for our workloads.