### PR TITLE
ENH: Convexhull visiblefacets

### DIFF
--- a/scipy/spatial/qhull.pyx
+++ b/scipy/spatial/qhull.pyx
@@ -1718,8 +1718,6 @@ class Delaunay(_QhullUser):
     vertex_neighbor_vertices : tuple of two ndarrays of int; (indptr, indices)
         Neighboring vertices of vertices. The indices of neighboring
         vertices of vertex `k` are ``indices[indptr[k]:indptr[k+1]]``.
-    furthest_site
-        True if this was a furthest site triangulation and False if not.
 
     Raises
     ------
@@ -1834,8 +1832,6 @@ class Delaunay(_QhullUser):
         qhull = _Qhull(b"d", points, qhull_options, required_options=b"Qt",
                        furthest_site=furthest_site, incremental=incremental)
         _QhullUser.__init__(self, qhull, incremental=incremental)
-
-        self.furthest_site = furthest_site
 
     def _update(self, qhull):
         qhull.triangulate()
@@ -2448,8 +2444,6 @@ class Voronoi(_QhullUser):
         Index of the Voronoi region for each input point.
         If qhull option "Qc" was not specified, the list will contain -1
         for points that are not associated with a Voronoi region.
-    furthest_site
-        True if this was a furthest site triangulation and False if not.
 
     Raises
     ------
@@ -2533,8 +2527,6 @@ class Voronoi(_QhullUser):
         qhull = _Qhull(b"v", points, qhull_options, furthest_site=furthest_site,
                        incremental=incremental)
         _QhullUser.__init__(self, qhull, incremental=incremental)
-
-        self.furthest_site = furthest_site
 
     def _update(self, qhull):
         self.vertices, self.ridge_points, self.ridge_vertices, \

--- a/scipy/spatial/qhull.pyx
+++ b/scipy/spatial/qhull.pyx
@@ -2487,7 +2487,7 @@ class Voronoi(_QhullUser):
            [ 0.5,  1.5],
            [ 1.5,  1.5]])
 
-    There is a single finite Voronoi region, and four finite Voronoi
+    There is a single finite Voronoi region, and eight infinite Voronoi
     ridges:
 
     >>> vor.regions

--- a/scipy/spatial/qhull.pyx
+++ b/scipy/spatial/qhull.pyx
@@ -1718,6 +1718,8 @@ class Delaunay(_QhullUser):
     vertex_neighbor_vertices : tuple of two ndarrays of int; (indptr, indices)
         Neighboring vertices of vertices. The indices of neighboring
         vertices of vertex `k` are ``indices[indptr[k]:indptr[k+1]]``.
+    furthest_site
+        True if this was a furthest site triangulation and False if not.
 
     Raises
     ------
@@ -1832,6 +1834,8 @@ class Delaunay(_QhullUser):
         qhull = _Qhull(b"d", points, qhull_options, required_options=b"Qt",
                        furthest_site=furthest_site, incremental=incremental)
         _QhullUser.__init__(self, qhull, incremental=incremental)
+
+        self.furthest_site = furthest_site
 
     def _update(self, qhull):
         qhull.triangulate()
@@ -2444,6 +2448,8 @@ class Voronoi(_QhullUser):
         Index of the Voronoi region for each input point.
         If qhull option "Qc" was not specified, the list will contain -1
         for points that are not associated with a Voronoi region.
+    furthest_site
+        True if this was a furthest site triangulation and False if not.
 
     Raises
     ------
@@ -2527,6 +2533,8 @@ class Voronoi(_QhullUser):
         qhull = _Qhull(b"v", points, qhull_options, furthest_site=furthest_site,
                        incremental=incremental)
         _QhullUser.__init__(self, qhull, incremental=incremental)
+
+        self.furthest_site = furthest_site
 
     def _update(self, qhull):
         self.vertices, self.ridge_points, self.ridge_vertices, \

--- a/scipy/spatial/qhull.pyx
+++ b/scipy/spatial/qhull.pyx
@@ -2487,7 +2487,7 @@ class Voronoi(_QhullUser):
            [ 0.5,  1.5],
            [ 1.5,  1.5]])
 
-    There is a single finite Voronoi region, and eight infinite Voronoi
+    There is a single finite Voronoi region, and four finite Voronoi
     ridges:
 
     >>> vor.regions

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -701,6 +701,43 @@ class TestConvexHull:
         assert_allclose(tri.volume, 1., rtol=1e-14)
         assert_allclose(tri.area, 6., rtol=1e-14)
 
+    def test_good2d(self):
+        # Make sure the QGn option gives the correct value of "good".
+        points = np.array([[0.2, 0.2],
+                           [0.2, 0.4],
+                           [0.4, 0.4],
+                           [0.4, 0.2],
+                           [0.3, 0.6]])
+        hull = ConvexHull(points=points, qhull_options='QG4')
+        expected = np.array([False, True, False, False], dtype=bool)
+        actual = hull.good
+        assert_equal(actual, expected)
+
+    def test_good2d_inside(self):
+        # Make sure the QGn option gives the correct value of "good".
+        # When point n is inside the convex hull of the rest, good i
+        # all False.
+        points = np.array([[0.2, 0.2],
+                           [0.2, 0.4],
+                           [0.4, 0.4],
+                           [0.4, 0.2],
+                           [0.3, 0.3]])
+        hull = ConvexHull(points=points, qhull_options='QG4')
+        expected = np.array([False, False, False, False], dtype=bool)
+        actual = hull.good
+        assert_equal(actual, expected)
+
+    def test_good3d(self):
+        # Make sure the QGn option gives the correct value of "good"
+        # for a 3d figure..
+         points = np.array([[0.0,         0.0,         0.0       ],
+                            [0.90029516, -0.39187448,  0.18948093],
+                            [0.48676420, -0.72627633,  0.48536925],
+                            [0.57651530, -0.81179274, -0.09285832],
+                            [0.67846893, -0.71119562,  0.18406710]])
+         hull = ConvexHull(points=points, qhull_options='QG0')
+         expected = np.array([True, False, False, False], dtype=bool)
+         assert_equal(hull.good, expected)
 
 class TestVoronoi:
     def test_masked_array_fails(self):

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -701,43 +701,124 @@ class TestConvexHull:
         assert_allclose(tri.volume, 1., rtol=1e-14)
         assert_allclose(tri.area, 6., rtol=1e-14)
 
-    def test_good2d(self):
+    @pytest.mark.parametrize("incremental", [False, True])
+    def test_good2d(self, incremental):
         # Make sure the QGn option gives the correct value of "good".
         points = np.array([[0.2, 0.2],
                            [0.2, 0.4],
                            [0.4, 0.4],
                            [0.4, 0.2],
                            [0.3, 0.6]])
-        hull = ConvexHull(points=points, qhull_options='QG4')
+        hull = qhull.ConvexHull(points=points,
+                                incremental=incremental,
+                                qhull_options='QG4')
         expected = np.array([False, True, False, False], dtype=bool)
         actual = hull.good
         assert_equal(actual, expected)
 
-    def test_good2d_inside(self):
+    @pytest.mark.parametrize("visibility", [
+                              "QG4",  # visible=True
+                              "QG-4",  # visible=False
+                              ])
+    @pytest.mark.parametrize("new_gen, expected", [
+        # add generator that places QG4 inside hull
+        # so all facets are invisible
+        (np.array([[0.3, 0.7]]),
+         np.array([False, False, False, False, False], dtype=bool)),
+        # adding a generator on the opposite side of the square
+        # should preserve the single visible facet & add one invisible
+        # facet
+        (np.array([[0.3, -0.7]]),
+         np.array([False, True, False, False, False], dtype=bool)),
+        # split the visible facet on top of the square into two
+        # visible facets, with visibility at the end of the array
+        # because add_points concatenates
+        (np.array([[0.3, 0.41]]),
+         np.array([False, False, False, True, True], dtype=bool)),
+        # with our current Qhull options, coplanarity will not count
+        # for visibility; this case shifts one visible & one invisible
+        # facet & adds a coplanar facet
+        # simplex at index position 2 is the shifted visible facet
+        # the final simplex is the coplanar facet
+        (np.array([[0.5, 0.6], [0.6, 0.6]]),
+         np.array([False, False, True, False, False], dtype=bool)),
+        # place the new generator such that it envelops the query
+        # point within the convex hull, but only just barely within
+        # the double precision limit
+        # NOTE: testing exact degeneracy is less predictable than this
+        # scenario, perhaps because of the default Qt option we have
+        # enabled for Qhull to handle precision matters
+        (np.array([[0.3, 0.6 + 1e-16]]),
+         np.array([False, False, False, False, False], dtype=bool)),
+        ])
+    def test_good2d_incremental_changes(self, new_gen, expected,
+                                        visibility):
+        # use the usual square convex hull
+        # generators from test_good2d
+        points = np.array([[0.2, 0.2],
+                           [0.2, 0.4],
+                           [0.4, 0.4],
+                           [0.4, 0.2],
+                           [0.3, 0.6]])
+        hull = qhull.ConvexHull(points=points,
+                                incremental=True,
+                                qhull_options=visibility)
+        hull.add_points(new_gen)
+        actual = hull.good
+        if '-' in visibility:
+            expected = np.invert(expected)
+        assert_equal(actual, expected)
+
+    @pytest.mark.parametrize("incremental", [False, True])
+    def test_good2d_no_option(self, incremental):
+        # handle case where good attribue doesn't exist
+        # because Qgn or Qg-n wasn't specified
+        points = np.array([[0.2, 0.2],
+                           [0.2, 0.4],
+                           [0.4, 0.4],
+                           [0.4, 0.2],
+                           [0.3, 0.6]])
+        hull = qhull.ConvexHull(points=points,
+                                incremental=incremental)
+        actual = hull.good
+        assert actual is None
+        # preserve None after incremental addition
+        if incremental:
+            hull.add_points(np.zeros((1, 2)))
+            actual = hull.good
+            assert actual is None
+
+    @pytest.mark.parametrize("incremental", [False, True])
+    def test_good2d_inside(self, incremental):
         # Make sure the QGn option gives the correct value of "good".
-        # When point n is inside the convex hull of the rest, good i
+        # When point n is inside the convex hull of the rest, good is
         # all False.
         points = np.array([[0.2, 0.2],
                            [0.2, 0.4],
                            [0.4, 0.4],
                            [0.4, 0.2],
                            [0.3, 0.3]])
-        hull = ConvexHull(points=points, qhull_options='QG4')
+        hull = qhull.ConvexHull(points=points,
+                                incremental=incremental,
+                                qhull_options='QG4')
         expected = np.array([False, False, False, False], dtype=bool)
         actual = hull.good
         assert_equal(actual, expected)
 
-    def test_good3d(self):
+    @pytest.mark.parametrize("incremental", [False, True])
+    def test_good3d(self, incremental):
         # Make sure the QGn option gives the correct value of "good"
-        # for a 3d figure..
-         points = np.array([[0.0,         0.0,         0.0       ],
-                            [0.90029516, -0.39187448,  0.18948093],
-                            [0.48676420, -0.72627633,  0.48536925],
-                            [0.57651530, -0.81179274, -0.09285832],
-                            [0.67846893, -0.71119562,  0.18406710]])
-         hull = ConvexHull(points=points, qhull_options='QG0')
-         expected = np.array([True, False, False, False], dtype=bool)
-         assert_equal(hull.good, expected)
+        # for a 3d figure
+        points = np.array([[0.0, 0.0, 0.0],
+                           [0.90029516, -0.39187448, 0.18948093],
+                           [0.48676420, -0.72627633, 0.48536925],
+                           [0.57651530, -0.81179274, -0.09285832],
+                           [0.67846893, -0.71119562, 0.18406710]])
+        hull = qhull.ConvexHull(points=points,
+                                incremental=incremental,
+                                qhull_options='QG0')
+        expected = np.array([True, False, False, False], dtype=bool)
+        assert_equal(hull.good, expected)
 
 class TestVoronoi:
     def test_masked_array_fails(self):


### PR DESCRIPTION
This pull request has three unrelated changes to qhull interface.

1.  The important change.  Qhull has the ability to create a list of facets in the convex hull that are visible from a point via the QGn and QG-n flags.  The current qhull.pyx allows the user to use the options but doesn't provide enough information to actually extract the visible info.  The qhull library returns a list of facets and each facet has a "good" flag.  All this modification does is return the "good" flag for each facet in an array called good.

I am working up some unit tests, but there are some test programs in https://github.com/rtshort/spatial.git.

2.  In both the Delaunay and Voronoi classes I added a flag to the class that indicates whether this was a furthest site diagram or not.  I did this because carrying the input flag furthest_site along into the downstream processing (e.g. plotting or pole of inaccessibility computations) was error prone and clunky.  This is not terribly important, just a convenience.

3.  There seems to be an error in the docstrings for Voronoi - the docs said 1 finite and 4 finite ridges.  I believe I corrected this.

