### PR TITLE
BLD: Modify rv_generic._construct_doc to print out failing distribution name

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -725,7 +725,10 @@ class rv_generic(object):
             if self.shapes is None:
                 # necessary because we use %(shapes)s in two forms (w w/o ", ")
                 self.__doc__ = self.__doc__.replace("%(shapes)s, ", "")
-            self.__doc__ = doccer.docformat(self.__doc__, tempdict)
+            try:
+                self.__doc__ = doccer.docformat(self.__doc__, tempdict)
+            except TypeError as e:
+                raise Exception("Unable to construct docstring for distribution \"%s\": %s" % (self.name, repr(e)))
 
         # correct for empty shapes
         self.__doc__ = self.__doc__.replace('(, ', '(').replace(', )', ')')


### PR DESCRIPTION
When a `scipy.stats` distribution's docstring fails to build, either when building the
refguide or during import of `scipy.stats`, a TypeError is thrown without
any indication of the offending distribution.
The failure can be triggered by placing %-signs in an distribution's class
docstring, perhaps as part of an Example, and these do not get handled by
`doccer.docformat(docstring, docdict)`.
This change replaces the original Exception with a new one whose message is
"Unable to construct docstring for distribution <NAME>:  TypeError('not ...')"
which gives enough information to diagnose the problem.