### PR TITLE
TST: pin mingw for Azure Win CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -86,7 +86,7 @@ jobs:
   - powershell: |
       # NOTE: can probably (eventually) abstract this 
       # upstream in Microsoft repo to support x86 natively
-      choco install -y mingw --forcex86 --force
+      choco install -y mingw --forcex86 --force --version=5.3.0
     displayName: 'Install 32-bit mingw for 32-bit builds'
     condition: eq(variables['BITS'], 32)
   - script: python -m pip install numpy cython==0.28.5 pytest pytest-timeout pytest-xdist pytest-env pytest-faulthandler Pillow mpmath matplotlib


### PR DESCRIPTION
Fixes #9724 

Our build toolchain can't use the newer compilers yet (similar to NumPy). 

I used very similar code for the NumPy Azure CI and SciPy Azure CI so this is likely to work the same as in https://github.com/numpy/numpy/pull/12863.