### PR TITLE
BUG: Typecheck iterations for binary image operations

### DIFF
--- a/scipy/ndimage/morphology.py
+++ b/scipy/ndimage/morphology.py
@@ -30,6 +30,7 @@
 
 from __future__ import division, print_function, absolute_import
 import warnings
+import operator
 
 import numpy
 from . import _ni_support
@@ -240,8 +241,7 @@ def _binary_erosion(input, structure, iterations, mask, output,
         output = bool
     output = _ni_support._get_output(output, input)
 
-    if not isinstance(iterations, int):
-        raise RuntimeError('must run for an integer number of iterations')
+    iterations = operator.index(iterations)
     if iterations == 1:
         _nd_image.binary_erosion(input, structure, mask, output,
                                  border_value, origin, invert, cit, 0)

--- a/scipy/ndimage/morphology.py
+++ b/scipy/ndimage/morphology.py
@@ -240,6 +240,8 @@ def _binary_erosion(input, structure, iterations, mask, output,
         output = bool
     output = _ni_support._get_output(output, input)
 
+    if not isinstance(iterations, int):
+        raise RuntimeError('must run for an integer number of iterations')
     if iterations == 1:
         _nd_image.binary_erosion(input, structure, mask, output,
                                  border_value, origin, invert, cit, 0)

--- a/scipy/ndimage/morphology.py
+++ b/scipy/ndimage/morphology.py
@@ -298,7 +298,7 @@ def binary_erosion(input, structure=None, iterations=1, mask=None, output=None,
         Structuring element used for the erosion. Non-zero elements are
         considered True. If no structuring element is provided, an element
         is generated with a square connectivity equal to one.
-    iterations : {int, float}, optional
+    iterations : int, optional
         The erosion is repeated `iterations` times (one, by default).
         If iterations is less than 1, the erosion is repeated until the
         result does not change anymore.
@@ -393,7 +393,7 @@ def binary_dilation(input, structure=None, iterations=1, mask=None,
         Structuring element used for the dilation. Non-zero elements are
         considered True. If no structuring element is provided an element
         is generated with a square connectivity equal to one.
-    iterations : {int, float}, optional
+    iterations : int, optional
         The dilation is repeated `iterations` times (one, by default).
         If iterations is less than 1, the dilation is repeated until the
         result does not change anymore.
@@ -651,7 +651,7 @@ def binary_closing(input, structure=None, iterations=1, output=None,
         is generated with a square connectivity equal to one (i.e., only
         nearest neighbors are connected to the center, diagonally-connected
         elements are not considered neighbors).
-    iterations : {int, float}, optional
+    iterations : int, optional
         The dilation step of the closing, then the erosion step are each
         repeated `iterations` times (one, by default). If iterations is
         less than 1, each operations is repeated until the result does

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -3559,8 +3559,56 @@ class TestNdimage:
                            [0, 1, 0],
                            [1, 0, 1]], dtype=bool)
         iterations = 2.0
-        with assert_raises(RuntimeError):
+        with assert_raises(TypeError):
             out = ndimage.binary_erosion(data, iterations=iterations)
+
+    def test_binary_erosion39(self):
+        iterations = numpy.int32(3)
+        struct = [[0, 1, 0],
+                  [1, 1, 1],
+                  [0, 1, 0]]
+        expected = [[0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 1, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0]]
+        data = numpy.array([[0, 0, 0, 1, 0, 0, 0],
+                            [0, 0, 1, 1, 1, 0, 0],
+                            [0, 1, 1, 1, 1, 1, 0],
+                            [1, 1, 1, 1, 1, 1, 1],
+                            [0, 1, 1, 1, 1, 1, 0],
+                            [0, 0, 1, 1, 1, 0, 0],
+                            [0, 0, 0, 1, 0, 0, 0]], bool)
+        out = numpy.zeros(data.shape, bool)
+        ndimage.binary_erosion(data, struct, border_value=1,
+                               iterations=iterations, output=out)
+        assert_array_almost_equal(out, expected)
+
+    def test_binary_erosion40(self):
+        iterations = numpy.int64(3)
+        struct = [[0, 1, 0],
+                  [1, 1, 1],
+                  [0, 1, 0]]
+        expected = [[0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 1, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0]]
+        data = numpy.array([[0, 0, 0, 1, 0, 0, 0],
+                            [0, 0, 1, 1, 1, 0, 0],
+                            [0, 1, 1, 1, 1, 1, 0],
+                            [1, 1, 1, 1, 1, 1, 1],
+                            [0, 1, 1, 1, 1, 1, 0],
+                            [0, 0, 1, 1, 1, 0, 0],
+                            [0, 0, 0, 1, 0, 0, 0]], bool)
+        out = numpy.zeros(data.shape, bool)
+        ndimage.binary_erosion(data, struct, border_value=1,
+                               iterations=iterations, output=out)
+        assert_array_almost_equal(out, expected)
 
     def test_binary_dilation01(self):
         for type_ in self.types:

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -3554,6 +3554,14 @@ class TestNdimage:
                                    border_value=True),
             b)
 
+    def test_binary_erosion38(self):
+        data = numpy.array([[1, 0, 1],
+                           [0, 1, 0],
+                           [1, 0, 1]], dtype=bool)
+        iterations = 2.0
+        with assert_raises(RuntimeError):
+            out = ndimage.binary_erosion(data, iterations=iterations)
+
     def test_binary_dilation01(self):
         for type_ in self.types:
             data = numpy.ones([], type_)


### PR DESCRIPTION
Hi,

This is a tiny PR which added type-restricting the `iterations` parameter in `scipy.ndimage.morphology._binary_erosion` method to be an `int`, effectively adding this to `binary_erosion`, `binary_dilation`, and `binary_closing`.

I kept getting a segmentation fault when accidentally passing a float (`np.floor` returns a float, who knew!), so this now gives a runtime error instead of seg faulting if a float is provided.

Conceptual question: I noticed that the docstrings explicitly stated a `float` could be provided for this parameter previously, but don't know how that could be performed (what is half an iteration of a dilation?), so I updated those to also now only say that integers are supported. I note that the mode for repetition until no more changes occur suggests "`using a number less than 1`," which can still be accomplished when the parameter is an integer, using `0` or a negative number.

Previous behaviour:
```
>> import numpy as np
>> from scipy import ndimage
>> data = np.random.random((5, 5))
>> iterations = 3.0
>> output = ndimage.binary_erosion(data, iterations=iterations)
python(6180,0x7fffec7713c0) malloc: *** error for object 0x7f89a881c068: pointer being freed was not allocated
*** set a breakpoint in malloc_error_break to debug
Abort trap: 6
```

Current behaviour:
```
>> output = ndimage.binary_erosion(data, iterations=iterations)
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/greg/code/gkiar/scipy/scipy/ndimage/morphology.py", line 378, in binary_erosion
    output, border_value, origin, 0, brute_force)
  File "/Users/greg/code/gkiar/scipy/scipy/ndimage/morphology.py", line 244, in _binary_erosion
    raise RuntimeError('must run for an integer number of iterations')
RuntimeError: must run for an integer number of iterations
```

P.s. I wasn't sure what branch you'd want this PR to, so please let me know and I can update the destination, if it's worth merging.