### PR TITLE
ENH: reduce sizeof(NI_WatershedElement) by 20%

### DIFF
--- a/scipy/ndimage/src/ni_measure.c
+++ b/scipy/ndimage/src/ni_measure.c
@@ -203,9 +203,9 @@ break
 
 typedef struct {
     npy_intp index;
-    npy_uint8 cost;
     void *next, *prev;
     npy_uint16 done;
+    npy_uint8 cost;
 } NI_WatershedElement;
 
 int NI_WatershedIFT(PyArrayObject* input, PyArrayObject* markers,


### PR DESCRIPTION
On 64-bit platform, the NI_WatershedElement structure size can be reduced from 40 to 32 bytes by rearranging the fields according to their sizes in decreasing order.

See https://www.viva64.com/en/w/v802/