### PR TITLE
ENH: remove suspicious sequence of type castings

### DIFF
--- a/scipy/ndimage/src/ni_interpolation.c
+++ b/scipy/ndimage/src/ni_interpolation.c
@@ -429,10 +429,10 @@ NI_GeometricTransform(PyArrayObject *input, int (*map)(npy_intp*, double*,
                         } else {
                             npy_intp s2 = 2 * len - 2;
                             if (idx < 0) {
-                                idx = s2 * (int)(-idx / s2) + idx;
+                                idx = s2 * (-idx / s2) + idx;
                                 idx = idx <= 1 - len ? idx + s2 : -idx;
                             } else if (idx >= len) {
-                                idx -= s2 * (int)(idx / s2);
+                                idx -= s2 * (idx / s2);
                                 if (idx >= len)
                                     idx = s2 - idx;
                             }


### PR DESCRIPTION
See [V220. Suspicious sequence of types castings: memsize -> 32-bit integer -> memsize](https://www.viva64.com/en/w/v220/).