### PR TITLE
BUG: qr_updates fails if u is exactly in span Q

### DIFF
--- a/scipy/linalg/_decomp_update.pyx.in
+++ b/scipy/linalg/_decomp_update.pyx.in
@@ -268,6 +268,12 @@ cdef bint blas_t_less_than(blas_t x, blas_t y) nogil:
     else:
         return x.real < y.real
 
+cdef bint blas_t_less_equal(blas_t x, blas_t y) nogil:
+    if blas_t is float or blas_t is double:
+        return x <= y
+    else:
+        return x.real <= y.real
+
 cdef int to_lwork(blas_t a, blas_t b) nogil:
     cdef int ai, bi
     if blas_t is float or blas_t is double:
@@ -1133,7 +1139,7 @@ cdef int reorth(int m, int n, blas_t* q, int* qs, bint qisF, blas_t* u,
 
     wpnorm = nrm2(m, u, us[0])
 
-    if blas_t_less_than(wpnorm, wnorm*inv_root2): # u lies in span(q)
+    if blas_t_less_equal(wpnorm, wnorm*inv_root2): # u lies in span(q)
         scal(m, 0, u, us[0])
         axpy(n, 1, s, 1, s+n, 1)
         scal(n, unorm, s, 1)

--- a/scipy/linalg/tests/test_decomp_update.py
+++ b/scipy/linalg/tests/test_decomp_update.py
@@ -1616,6 +1616,15 @@ class BaseQRupdate(BaseQRdeltas):
         assert_raises(ValueError, qr_update, q0, r0, u[:,0], v[:,0])
         assert_raises(ValueError, qr_update, q0, r0, u, v)
 
+    def test_u_exactly_in_span_q(self):
+        q = np.array([[0, 0], [0, 0], [1, 0], [0, 1]], self.dtype)
+        r = np.array([[1, 0], [0, 1]], self.dtype)
+        u = np.array([0, 0, 0, -1], self.dtype)
+        v = np.array([1, 2], self.dtype)
+        q1, r1 = qr_update(q, r, u, v)
+        a1 = np.dot(q, r) + np.outer(u, v.conj())
+        check_qr(q1, r1, a1, self.rtol, self.atol, False)
+
 class TestQRupdate_f(BaseQRupdate):
     dtype = np.dtype('f')
 


### PR DESCRIPTION
This change (from < to <=) is in Riechel's paper and was missed when the code was first written.

closes gh-9733