### PR TITLE
MAINT: a few backports as 1.2.1 approaches

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ trigger:
 jobs:
 - job: Linux_Python_36_32bit_full
   pool:
-    vmIMage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-16.04'
   steps:
   - script: |
            docker pull i386/ubuntu:bionic
@@ -33,7 +33,7 @@ jobs:
       testRunTitle: 'Publish test results for Python 3.6-32 bit full Linux'
 - job: Windows
   pool:
-    vmIMage: 'VS2017-Win2016'
+    vmImage: 'VS2017-Win2016'
   variables:
       OPENBLAS_32: https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-5f998ef_gcc7_1_0_win32.zip
       OPENBLAS_64: https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-5f998ef_gcc7_1_0_win64.zip

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -100,7 +100,7 @@ jobs:
   - powershell: |
       # NOTE: can probably (eventually) abstract this 
       # upstream in Microsoft repo to support x86 natively
-      choco install -y mingw --forcex86 --force
+      choco install -y mingw --forcex86 --force --version=5.3.0
     displayName: 'Install 32-bit mingw for 32-bit builds'
     condition: eq(variables['BITS'], 32)
   - script: python -m pip install numpy cython==0.28.5 pytest pytest-timeout pytest-xdist pytest-env pytest-faulthandler Pillow mpmath matplotlib

--- a/scipy/stats/kde.py
+++ b/scipy/stats/kde.py
@@ -197,7 +197,7 @@ class gaussian_kde(object):
         self.d, self.n = self.dataset.shape
 
         if weights is not None:
-            self._weights = atleast_1d(weights)
+            self._weights = atleast_1d(weights).astype(float)
             self._weights /= sum(self._weights)
             if self.weights.ndim != 1:
                 raise ValueError("`weights` input should be one-dimensional.")

--- a/scipy/stats/tests/test_kdeoth.py
+++ b/scipy/stats/tests/test_kdeoth.py
@@ -3,7 +3,7 @@ from __future__ import division, print_function, absolute_import
 from scipy import stats
 import numpy as np
 from numpy.testing import (assert_almost_equal, assert_,
-    assert_array_almost_equal, assert_array_almost_equal_nulp)
+    assert_array_almost_equal, assert_array_almost_equal_nulp, assert_allclose)
 import pytest
 from pytest import raises as assert_raises
 
@@ -366,3 +366,28 @@ def test_pdf_logpdf_weighted():
     pdf = np.log(gkde.evaluate(xn))
     pdf2 = gkde.logpdf(xn)
     assert_almost_equal(pdf, pdf2, decimal=12)
+
+
+def test_weights_intact():
+    # regression test for gh-9709: weights are not modified
+    np.random.seed(12345)
+    vals = np.random.lognormal(size=100)
+    weights = np.random.choice([1.0, 10.0, 100], size=vals.size)
+    orig_weights = weights.copy()
+
+    stats.gaussian_kde(np.log10(vals), weights=weights)
+    assert_allclose(weights, orig_weights, atol=1e-14, rtol=1e-14)
+
+
+def test_weights_integer():
+    # integer weights are OK, cf gh-9709 (comment)
+    np.random.seed(12345)
+    values = [0.2, 13.5, 21.0, 75.0, 99.0]
+    weights = [1, 2, 4, 8, 16]  # a list of integers
+    pdf_i = stats.gaussian_kde(values, weights=weights)
+    pdf_f = stats.gaussian_kde(values, weights=np.float64(weights))
+
+    xn = [0.3, 11, 88]
+    assert_allclose(pdf_i.evaluate(xn),
+                    pdf_f.evaluate(xn), atol=1e-14, rtol=1e-14)
+


### PR DESCRIPTION
Cherry-picked commits from the following single-commit PRs with backport labels:

#9725 
#9736 
#9720 