### PR TITLE
BUG: MapWrapper.__exit__ should terminate

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -387,6 +387,7 @@ class MapWrapper(object):
 
     def __del__(self):
         self.close()
+        self.terminate()
 
     def terminate(self):
         if self._own_pool:
@@ -402,11 +403,8 @@ class MapWrapper(object):
 
     def __exit__(self, exc_type, exc_value, traceback):
         if self._own_pool:
-            if exc_type is None:
-                self.pool.close()
-                self.pool.join()
-            else:
-                self.pool.terminate()
+            self.pool.close()
+            self.pool.terminate()
 
     def __call__(self, func, iterable):
         # only accept one iterable because that's all Pool.map accepts

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -804,10 +804,12 @@ class DifferentialEvolutionSolver(object):
     def __exit__(self, *args):
         # to make sure resources are closed down
         self._mapwrapper.close()
+        self._mapwrapper.terminate()
 
     def __del__(self):
         # to make sure resources are closed down
         self._mapwrapper.close()
+        self._mapwrapper.terminate()
 
     def __next__(self):
         """

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -1,6 +1,8 @@
 """
 Unit tests for the differential global minimization algorithm.
 """
+import multiprocessing
+
 from scipy.optimize import _differentialevolution
 from scipy.optimize._differentialevolution import DifferentialEvolutionSolver
 from scipy.optimize import differential_evolution
@@ -536,8 +538,13 @@ class TestDifferentialEvolutionSolver(object):
     def test_parallel(self):
         # smoke test for parallelisation with deferred updating
         bounds = [(0., 2.), (0., 2.)]
-        with DifferentialEvolutionSolver(rosen, bounds,
-                                         updating='deferred',
+        with multiprocessing.Pool(2) as p, DifferentialEvolutionSolver(rosen, bounds,
+             updating='deferred', workers=p.map) as solver:
+                assert_(solver._mapwrapper.pool is not None)
+                assert_(solver._updating == 'deferred')
+                solver.solve()
+
+        with DifferentialEvolutionSolver(rosen, bounds, updating='deferred',
                                          workers=2) as solver:
             assert_(solver._mapwrapper.pool is not None)
             assert_(solver._updating == 'deferred')


### PR DESCRIPTION
I'm trying to use `differential_evolution` with `workers=-1` (i.e. multiprocessing) via PyCharm. I am getting the issue below, which is causing my GUI program to crash. The issue I'm experiencing is fixed by this PR, asking the `_mapwrapper` pool to `terminate` in both the `DifferentialEvolutionSolver.__exit__` and `__del__` methods. I also added the `terminate` to the `__del__` method in `scipy._lib._util.MapWrapper`. These additions are based on the `multiprocessing` documentation:

> When the pool object is garbage collected `terminate()` will be called immediately.

i.e. `terminate` could/should be added to `__del__`

and

>  `__enter__()` returns the pool object, and `__exit__()` calls terminate().

i.e. `terminate` could/should be added to `__exit__`.

I think this is a reasonable back candidate for backporting to 1.2 (@tylerjereddy)?
@pv what are your thoughts?

```
  File "/Users/andrew/miniconda3/envs/dev3/lib/python3.7/site-packages/scipy/optimize/_differentialevolution.py", line 273, in differential_evolution
    ret = solver.solve()
  File "/Users/andrew/miniconda3/envs/dev3/lib/python3.7/site-packages/scipy/optimize/_differentialevolution.py", line 676, in solve
    self.population)
  File "/Users/andrew/miniconda3/envs/dev3/lib/python3.7/site-packages/scipy/optimize/_differentialevolution.py", line 777, in _calculate_population_energies
    parameters_pop[0:nfevs]))
  File "/Users/andrew/miniconda3/envs/dev3/lib/python3.7/site-packages/scipy/_lib/_util.py", line 414, in __call__
    return self._mapfunc(func, iterable)
  File "/Users/andrew/miniconda3/envs/dev3/lib/python3.7/multiprocessing/pool.py", line 268, in map
    return self._map_async(func, iterable, mapstar, chunksize).get()
  File "/Users/andrew/miniconda3/envs/dev3/lib/python3.7/multiprocessing/pool.py", line 651, in get
    self.wait(timeout)
  File "/Users/andrew/miniconda3/envs/dev3/lib/python3.7/multiprocessing/pool.py", line 648, in wait
    self._event.wait(timeout)
  File "/Users/andrew/miniconda3/envs/dev3/lib/python3.7/threading.py", line 552, in wait
    signaled = self._cond.wait(timeout)
  File "/Users/andrew/miniconda3/envs/dev3/lib/python3.7/threading.py", line 296, in wait
    waiter.acquire()
KeyboardInterrupt

Process finished with exit code 134 (interrupted by signal 6: SIGABRT)
```