### PR TITLE
ENH: Added exact computation for Kolmogorov-Smirnov two-sample test.

### DIFF
--- a/doc/source/tutorial/stats.rst
+++ b/doc/source/tutorial/stats.rst
@@ -889,13 +889,13 @@ For the example where both samples are drawn from the same distribution,
 we cannot reject the null hypothesis since the pvalue is high
 
     >>> stats.ks_2samp(rvs1, rvs2)
-    Ks_2sampResult(statistic=0.025999999999999995, pvalue=0.9954119517306488)
+    Ks_2sampResult(statistic=0.026, pvalue=0.9959527565364388)
 
 In the second example, with different location, i.e. means, we can
 reject the null hypothesis since the pvalue is below 1%
 
     >>> stats.ks_2samp(rvs1, rvs3)
-    Ks_2sampResult(statistic=0.11399999999999999, pvalue=0.002713210366128314)
+    Ks_2sampResult(statistic=0.114, pvalue=0.00299005061044668)
 
 Kernel Density Estimation
 -------------------------

--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -4456,7 +4456,7 @@ add_newdoc("scipy.special", "kolmogi",
     Kolmogorov-Smirnov Goodness of Fit test. For historial reasons this
     function is exposed in `scpy.special`, but the recommended way to achieve
     the most accurate CDF/SF/PDF/PPF/ISF computations is to use the
-    `stats.kstwobign` distrubution.
+    `stats.kstwobign` distribution.
 
     See Also
     --------

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5272,7 +5272,7 @@ def ks_2samp(data1, data2, alternative='two-sided', mode='auto'):
     alternative : {'two-sided', 'less','greater'}, optional
         Defines the alternative hypothesis (see explanation above).
         Default is 'two-sided'.
-    mode : 'auto' (default), 'approx' or 'asymp', optional
+    mode : 'auto' (default), 'exact' or 'asymp', optional
         Defines the method used for calculating the p-value.
 
           - 'exact' : use approximation to exact distribution of test statistic

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5308,7 +5308,7 @@ def ks_2samp(data1, data2, alternative='two-sided', mode='auto'):
     less than 10000.  For larger sizes, the computation uses the
     Kolmogorov-Smirnov distributions to compute an approximate value.
 
-    We generally follow Hodges'[1] treatment of Drion/Gnedenko/Korolyuk.
+    We generally follow Hodges' treatment of Drion/Gnedenko/Korolyuk [1]_.
 
     References
     ----------

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5274,11 +5274,11 @@ def ks_2samp(data1, data2, alternative='two-sided', mode='auto'):
         Default is 'two-sided'.
     mode : {'auto', 'exact', 'asymp'}, optional
         Defines the method used for calculating the p-value.
+        Default is 'auto'.
 
         - 'exact' : use approximation to exact distribution of test statistic
         - 'asymp' : use asymptotic distribution of test statistic
         - 'auto' : use 'exact' for small size arrays, 'asymp' for large.
-        Default is 'auto'.
 
     Returns
     -------

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -4552,9 +4552,9 @@ def kstest(rvs, cdf, args=(), N=20, alternative='two-sided', mode='approx'):
     """
     Perform the Kolmogorov-Smirnov test for goodness of fit.
 
-    This performs a test of the distribution G(x) of an observed
-    random variable against a given distribution F(x). Under the null
-    hypothesis the two distributions are identical, G(x)=F(x). The
+    This performs a test of the distribution F(x) of an observed
+    random variable against a given distribution G(x). Under the null
+    hypothesis the two distributions are identical, F(x)=G(x). The
     alternative hypothesis can be either 'two-sided' (default), 'less'
     or 'greater'. The KS test is only valid for continuous distributions.
 
@@ -4594,8 +4594,8 @@ def kstest(rvs, cdf, args=(), N=20, alternative='two-sided', mode='approx'):
     -----
     In the one-sided test, the alternative is that the empirical
     cumulative distribution function of the random variable is "less"
-    or "greater" than the cumulative distribution function F(x) of the
-    hypothesis, ``G(x)<=F(x)``, resp. ``G(x)>=F(x)``.
+    or "greater" than the cumulative distribution function G(x) of the
+    hypothesis, ``F(x)<=G(x)``, resp. ``F(x)>=G(x)``.
 
     Examples
     --------
@@ -5269,15 +5269,16 @@ def ks_2samp(data1, data2, alternative='two-sided', mode='auto'):
     data1, data2 : sequence of 1-D ndarrays
         Two arrays of sample observations assumed to be drawn from a continuous
         distribution, sample sizes can be different.
-    alternative : {'two-sided', 'less','greater'}, optional
+    alternative : {'two-sided', 'less', 'greater'}, optional
         Defines the alternative hypothesis (see explanation above).
         Default is 'two-sided'.
-    mode : 'auto' (default), 'exact' or 'asymp', optional
+    mode : {'auto', 'exact', 'asymp'}, optional
         Defines the method used for calculating the p-value.
 
         - 'exact' : use approximation to exact distribution of test statistic
         - 'asymp' : use asymptotic distribution of test statistic
         - 'auto' : use 'exact' for small size arrays, 'asymp' for large.
+        Default is 'auto'.
 
     Returns
     -------
@@ -5293,18 +5294,17 @@ def ks_2samp(data1, data2, alternative='two-sided', mode='auto'):
     assumed to be continuous.
 
     In the one-sided test, the alternative is that the empirical
-    cumulative distribution function G(x) of the data1 variable is "less"
-    or "greater" than the empirical cumulative distribution function F(x)
-    of the data2 variable, ``G(x)<=F(x)``, resp. ``G(x)>=F(x)``.
+    cumulative distribution function F(x) of the data1 variable is "less"
+    or "greater" than the empirical cumulative distribution function G(x)
+    of the data2 variable, ``F(x)<=G(x)``, resp. ``F(x)>=G(x)``.
 
     If the K-S statistic is small or the p-value is high, then we cannot
     reject the hypothesis that the distributions of the two samples
     are the same.
 
-    If the mode is 'auto', the computation is exact for small enough
-    sample sizes.  For larger sizes, the computation uses the
+    If the mode is 'auto', the computation is exact if the sample sizes are
+    less than 10000.  For larger sizes, the computation uses the
     Kolmogorov-Smirnov distributions to compute an approximate value.
-
 
     Examples
     --------

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5391,7 +5391,7 @@ def ks_2samp(data1, data2, alternative='two-sided', mode='auto'):
                     try:
                         num_paths = _count_paths_outside_method(n1, n2, g, h)
                         bin = special.binom(n1 + n2, n1)
-                        if not np.isfinite(bin) or  not np.isfinite(num_paths) or num_paths > bin:
+                        if not np.isfinite(bin) or not np.isfinite(num_paths) or num_paths > bin:
                             raise FloatingPointError()
                         prob = num_paths / bin
                     except FloatingPointError:

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2803,10 +2803,10 @@ def test_kstest():
 
 
 class TestKSTwoSamples(object):
-    def _testOne(self, x1, x2, alternative, expected_statistic, expected_prob):
-        result = stats.ks_2samp(x1, x2, alternative)
+    def _testOne(self, x1, x2, alternative, expected_statistic, expected_prob, mode='auto'):
+        result = stats.ks_2samp(x1, x2, alternative, mode=mode)
         expected = np.array([expected_statistic, expected_prob])
-        # print('%.16f' % result.statistic, '%.16e' % result.pvalue, result.statistic*10000*11000)
+        # print('%.16f' % result.statistic, '%.16e' % result.pvalue, result.statistic*500*600)
         assert_array_almost_equal(np.array(result), expected)
 
     def testSmall(self):
@@ -2881,6 +2881,30 @@ class TestKSTwoSamples(object):
         self._testOne(data2, data2+1, 'greater', 1.0/3, 0.75)
         self._testOne(data2, data2+1, 'less', 0.0/3, 1.)
 
+    def testMiddlingBoth(self):
+        x500 = np.linspace(1, 200, 500)
+        x600 = np.linspace(2, 200, 600)
+        n1, n2 = len(x500), len(x600)
+        # 500, 600
+        self._testOne(x500, x600, 'two-sided', 2000.0 / n1 / n2, 1.0, mode='auto')
+        self._testOne(x500, x600, 'two-sided', 2000.0 / n1 / n2, 1.0, mode='asymp')
+        self._testOne(x500, x600, 'greater', 2000.0 / n1 / n2,  0.87721554018921577, mode='exact')
+        self._testOne(x500, x600, 'greater', 2000.0 / n1 / n2,  0.87721554018921566, mode='asymp')
+        self._testOne(x500, x600, 'less', 500.0 / n1 / n2, 0.97218887049883673, mode='exact')
+        self._testOne(x500, x600, 'less', 500.0 / n1 / n2, 0.97218887049883673, mode='asymp')
+
+    def testMediumBoth(self):
+        x1000 = np.linspace(1, 200, 1000)
+        x1100 = np.linspace(2, 200, 1100)
+        n1, n2 = len(x1000), len(x1100)
+        # 1000, 1100
+        self._testOne(x1000, x1100, 'two-sided', 6600.0 / n1 / n2, 1.0, mode='asymp')
+        self._testOne(x1000, x1100, 'two-sided', 6600.0 / n1 / n2, 1.0, mode='auto')
+        self._testOne(x1000, x1100, 'greater', 6600.0 / n1 / n2,  0.84125883587707861, mode='exact')
+        self._testOne(x1000, x1100, 'greater', 6600.0 / n1 / n2,  0.84125883587707861, mode='asymp')
+        self._testOne(x1000, x1100, 'less', 1000.0 /  n1 / n2, 0.97888432252447422, mode='exact')
+        self._testOne(x1000, x1100, 'less', 1000.0 /  n1 / n2, 0.97888432252447422, mode='asymp')
+
     def testLarge(self):
         x10000 = np.linspace(1, 200, 10000)
         x110 = np.linspace(2, 100, 110)
@@ -2889,13 +2913,17 @@ class TestKSTwoSamples(object):
         self._testOne(x10000, x110, 'greater', 561.0 / 10000 / 11, 0.99115454582047591)
         self._testOne(x10000, x110, 'less', 55275.0 / 10000 / 11, 3.1317328311518713e-26)
 
+    @pytest.mark.slow
     def testLargeBoth(self):
         x10000 = np.linspace(1, 200, 10000)
         x11000 = np.linspace(2, 200, 11000)
         # 10000, 11000
-        self._testOne(x10000, x11000, 'two-sided', 563.0 / 10000 / 11, 0.99915729949018561)
-        self._testOne(x10000, x11000, 'greater', 563.0 / 10000 / 11, 0.99264586027885104)
-        self._testOne(x10000, x11000, 'less', 10.0 / 10000 / 11, 0.99990850226130423)
+        self._testOne(x10000, x11000, 'two-sided', 563.0 / 10000 / 11, 0.99915729949018561, mode='asymp')
+        self._testOne(x10000, x11000, 'two-sided', 563.0 / 10000 / 11, 1.0, mode='auto')
+        self._testOne(x10000, x11000, 'greater', 563.0 / 10000 / 11, 0.5278310390162617, mode='exact')
+        self._testOne(x10000, x11000, 'greater', 563.0 / 10000 / 11, 0.5278310390162617)
+        self._testOne(x10000, x11000, 'less', 10.0 / 10000 / 11, 0.9934598204248157, mode='exact')
+        self._testOne(x10000, x11000, 'less', 10.0 / 10000 / 11, 0.9934598204248157)
 
     def testNamedAtributes(self):
         # test for namedtuple attribute results

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2888,8 +2888,8 @@ class TestKSTwoSamples(object):
         # 500, 600
         self._testOne(x500, x600, 'two-sided', 2000.0 / n1 / n2, 1.0, mode='auto')
         self._testOne(x500, x600, 'two-sided', 2000.0 / n1 / n2, 1.0, mode='asymp')
-        self._testOne(x500, x600, 'greater', 2000.0 / n1 / n2,  0.87721554018921577, mode='exact')
-        self._testOne(x500, x600, 'greater', 2000.0 / n1 / n2,  0.87721554018921566, mode='asymp')
+        self._testOne(x500, x600, 'greater', 2000.0 / n1 / n2, 0.87721554018921577, mode='exact')
+        self._testOne(x500, x600, 'greater', 2000.0 / n1 / n2, 0.87721554018921566, mode='asymp')
         self._testOne(x500, x600, 'less', 500.0 / n1 / n2, 0.97218887049883673, mode='exact')
         self._testOne(x500, x600, 'less', 500.0 / n1 / n2, 0.97218887049883673, mode='asymp')
 
@@ -2900,10 +2900,10 @@ class TestKSTwoSamples(object):
         # 1000, 1100
         self._testOne(x1000, x1100, 'two-sided', 6600.0 / n1 / n2, 1.0, mode='asymp')
         self._testOne(x1000, x1100, 'two-sided', 6600.0 / n1 / n2, 1.0, mode='auto')
-        self._testOne(x1000, x1100, 'greater', 6600.0 / n1 / n2,  0.84125883587707861, mode='exact')
-        self._testOne(x1000, x1100, 'greater', 6600.0 / n1 / n2,  0.84125883587707861, mode='asymp')
-        self._testOne(x1000, x1100, 'less', 1000.0 /  n1 / n2, 0.97888432252447422, mode='exact')
-        self._testOne(x1000, x1100, 'less', 1000.0 /  n1 / n2, 0.97888432252447422, mode='asymp')
+        self._testOne(x1000, x1100, 'greater', 6600.0 / n1 / n2, 0.84125883587707861, mode='exact')
+        self._testOne(x1000, x1100, 'greater', 6600.0 / n1 / n2, 0.84125883587707861, mode='asymp')
+        self._testOne(x1000, x1100, 'less', 1000.0 / n1 / n2, 0.97888432252447422, mode='exact')
+        self._testOne(x1000, x1100, 'less', 1000.0 / n1 / n2, 0.97888432252447422, mode='asymp')
 
     def testLarge(self):
         x10000 = np.linspace(1, 200, 10000)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2879,66 +2879,80 @@ class TestKSTwoSamples(object):
         self._testOne(data2, data2+1, 'two-sided', 1.0/3, 1.0)
         self._testOne(data2, data2+1, 'greater', 1.0/3, 0.75)
         self._testOne(data2, data2+1, 'less', 0.0/3, 1.)
+        self._testOne(data2, data2+0.5, 'two-sided', 1.0/3, 1.0)
+        self._testOne(data2, data2+0.5, 'greater', 1.0/3, 0.75)
+        self._testOne(data2, data2+0.5, 'less', 0.0/3, 1.)
+        self._testOne(data2, data2-0.5, 'two-sided', 1.0/3, 1.0)
+        self._testOne(data2, data2-0.5, 'greater', 0.0/3, 1.0)
+        self._testOne(data2, data2-0.5, 'less', 1.0/3, 0.75)
 
     def testMiddlingBoth(self):
-        x500 = np.linspace(1, 200, 500)
-        x600 = np.linspace(2, 200, 600)
-        n1, n2 = len(x500), len(x600)
         # 500, 600
-        self._testOne(x500, x600, 'two-sided', 2000.0 / n1 / n2, 1.0, mode='auto')
-        self._testOne(x500, x600, 'two-sided', 2000.0 / n1 / n2, 1.0, mode='asymp')
-        self._testOne(x500, x600, 'greater', 2000.0 / n1 / n2, 0.9697596024683929, mode='asymp')
-        self._testOne(x500, x600, 'less', 500.0 / n1 / n2, 0.9968735843165021, mode='asymp')
+        n1, n2 = 500, 600
+        delta = 1.0/n1/n2/2/2
+        x = np.linspace(1, 200, n1) - delta
+        y = np.linspace(2, 200, n2)
+        self._testOne(x, y, 'two-sided', 2000.0 / n1 / n2, 1.0, mode='auto')
+        self._testOne(x, y, 'two-sided', 2000.0 / n1 / n2, 1.0, mode='asymp')
+        self._testOne(x, y, 'greater', 2000.0 / n1 / n2, 0.9697596024683929, mode='asymp')
+        self._testOne(x, y, 'less', 500.0 / n1 / n2, 0.9968735843165021, mode='asymp')
         with suppress_warnings() as sup:
             sup.filter(RuntimeWarning, "ks_2samp: Exact calculation overflowed. Switching to mode=asymp")
-            self._testOne(x500, x600, 'greater', 2000.0 / n1 / n2, 0.9697596024683929, mode='exact')
-            self._testOne(x500, x600, 'less', 500.0 / n1 / n2, 0.9968735843165021, mode='exact')
+            self._testOne(x, y, 'greater', 2000.0 / n1 / n2, 0.9697596024683929, mode='exact')
+            self._testOne(x, y, 'less', 500.0 / n1 / n2, 0.9968735843165021, mode='exact')
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            self._testOne(x500, x600, 'less', 500.0 / n1 / n2, 0.9968735843165021, mode='exact')
+            self._testOne(x, y, 'less', 500.0 / n1 / n2, 0.9968735843165021, mode='exact')
             _check_warnings(w, RuntimeWarning, 1)
 
     def testMediumBoth(self):
-        x1000 = np.linspace(1, 200, 1000)
-        x1100 = np.linspace(2, 200, 1100)
-        n1, n2 = len(x1000), len(x1100)
         # 1000, 1100
-        self._testOne(x1000, x1100, 'two-sided', 6600.0 / n1 / n2, 1.0, mode='asymp')
-        self._testOne(x1000, x1100, 'two-sided', 6600.0 / n1 / n2, 1.0, mode='auto')
-        self._testOne(x1000, x1100, 'greater', 6600.0 / n1 / n2, 0.9573185808092622, mode='asymp')
-        self._testOne(x1000, x1100, 'less', 1000.0 / n1 / n2, 0.9982410869433984, mode='asymp')
+        n1, n2 = 1000, 1100
+        delta = 1.0/n1/n2/2/2
+        x = np.linspace(1, 200, n1) - delta
+        y = np.linspace(2, 200, n2)
+        self._testOne(x, y, 'two-sided', 6600.0 / n1 / n2, 1.0, mode='asymp')
+        self._testOne(x, y, 'two-sided', 6600.0 / n1 / n2, 1.0, mode='auto')
+        self._testOne(x, y, 'greater', 6600.0 / n1 / n2, 0.9573185808092622, mode='asymp')
+        self._testOne(x, y, 'less', 1000.0 / n1 / n2, 0.9982410869433984, mode='asymp')
 
         with suppress_warnings() as sup:
             sup.filter(RuntimeWarning, "ks_2samp: Exact calculation overflowed. Switching to mode=asymp")
-            self._testOne(x1000, x1100, 'greater', 6600.0 / n1 / n2, 0.9573185808092622, mode='exact')
-            self._testOne(x1000, x1100, 'less', 1000.0 / n1 / n2, 0.9982410869433984, mode='exact')
+            self._testOne(x, y, 'greater', 6600.0 / n1 / n2, 0.9573185808092622, mode='exact')
+            self._testOne(x, y, 'less', 1000.0 / n1 / n2, 0.9982410869433984, mode='exact')
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            self._testOne(x1000, x1100, 'less', 1000.0 / n1 / n2, 0.9982410869433984, mode='exact')
+            self._testOne(x, y, 'less', 1000.0 / n1 / n2, 0.9982410869433984, mode='exact')
             _check_warnings(w, RuntimeWarning, 1)
 
     def testLarge(self):
-        x10000 = np.linspace(1, 200, 10000)
-        x110 = np.linspace(2, 100, 110)
         # 10000, 110
-        self._testOne(x10000, x110, 'two-sided', 55275.0 / 10000 / 11, 4.2188474935755949e-15)
-        self._testOne(x10000, x110, 'greater', 561.0 / 10000 / 11, 0.99115454582047591)
-        self._testOne(x10000, x110, 'less', 55275.0 / 10000 / 11, 3.1317328311518713e-26)
+        n1, n2 = 10000, 110
+        lcm = n1*11.0
+        delta = 1.0/n1/n2/2/2
+        x = np.linspace(1, 200, n1) - delta
+        y = np.linspace(2, 100, n2)
+        self._testOne(x, y, 'two-sided', 55275.0 / lcm, 4.2188474935755949e-15)
+        self._testOne(x, y, 'greater', 561.0 / lcm, 0.99115454582047591)
+        self._testOne(x, y, 'less', 55275.0 / lcm, 3.1317328311518713e-26)
 
     @pytest.mark.slow
     def testLargeBoth(self):
-        x10000 = np.linspace(1, 200, 10000)
-        x11000 = np.linspace(2, 200, 11000)
         # 10000, 11000
-        self._testOne(x10000, x11000, 'two-sided', 563.0 / 10000 / 11, 0.99915729949018561, mode='asymp')
-        self._testOne(x10000, x11000, 'two-sided', 563.0 / 10000 / 11, 1.0, mode='exact')
-        self._testOne(x10000, x11000, 'two-sided', 563.0 / 10000 / 11, 0.99915729949018561, mode='auto')
-        self._testOne(x10000, x11000, 'greater', 563.0 / 10000 / 11, 0.5278310390162617)
-        self._testOne(x10000, x11000, 'less', 10.0 / 10000 / 11, 0.9934598204248157)
+        n1, n2 = 10000, 11000
+        lcm = n1*11.0
+        delta = 1.0/n1/n2/2/2
+        x = np.linspace(1, 200, n1) - delta
+        y = np.linspace(2, 200, n2)
+        self._testOne(x, y, 'two-sided', 563.0 / lcm, 0.99915729949018561, mode='asymp')
+        self._testOne(x, y, 'two-sided', 563.0 / lcm, 1.0, mode='exact')
+        self._testOne(x, y, 'two-sided', 563.0 / lcm, 0.99915729949018561, mode='auto')
+        self._testOne(x, y, 'greater', 563.0 / lcm, 0.7561851877420673)
+        self._testOne(x, y, 'less', 10.0 / lcm, 0.9998239693191724)
         with suppress_warnings() as sup:
             sup.filter(RuntimeWarning, "ks_2samp: Exact calculation overflowed. Switching to mode=asymp")
-            self._testOne(x10000, x11000, 'greater', 563.0 / 10000 / 11, 0.5278310390162617, mode='exact')
-            self._testOne(x10000, x11000, 'less', 10.0 / 10000 / 11, 0.9934598204248157, mode='exact')
+            self._testOne(x, y, 'greater', 563.0 / lcm, 0.7561851877420673, mode='exact')
+            self._testOne(x, y, 'less', 10.0 / lcm, 0.9998239693191724, mode='exact')
 
     def testNamedAtributes(self):
         # test for namedtuple attribute results

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2812,6 +2812,9 @@ class TestKSTwoSamples(object):
         self._testOne([0], [1], 'two-sided', 1.0/1, 1.0)
         self._testOne([0], [1], 'greater', 1.0/1, 0.5)
         self._testOne([0], [1], 'less', 0.0/1, 1.0)
+        self._testOne([1], [0], 'two-sided', 1.0/1, 1.0)
+        self._testOne([1], [0], 'greater', 0.0/1, 1.0)
+        self._testOne([1], [0], 'less', 1.0/1, 0.5)
 
     def testTwoVsThree(self):
         data1 = np.array([1.0, 2.0])
@@ -2959,6 +2962,22 @@ class TestKSTwoSamples(object):
         attributes = ('statistic', 'pvalue')
         res = stats.ks_2samp([1, 2], [3])
         check_named_results(res, attributes)
+
+    def test_some_code_paths(self):
+        # Check that some code paths are executed
+        from scipy.stats.stats import _count_paths_outside_method, _compute_prob_inside_method
+
+        _compute_prob_inside_method(1, 1, 1, 1)
+        _count_paths_outside_method(1000, 1, 1, 1001)
+
+        assert_raises(FloatingPointError, _count_paths_outside_method, 1100, 1099, 1, 1)
+        assert_raises(FloatingPointError, _count_paths_outside_method, 2000, 1000, 1, 1)
+
+    def test_argument_checking(self):
+        # Check that an empty array causes a ValueError
+        assert_raises(ValueError, stats.ks_2samp, [], [1])
+        assert_raises(ValueError, stats.ks_2samp, [1], [])
+        assert_raises(ValueError, stats.ks_2samp, [], [])
 
 
 def test_ttest_rel():

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2888,10 +2888,16 @@ class TestKSTwoSamples(object):
         # 500, 600
         self._testOne(x500, x600, 'two-sided', 2000.0 / n1 / n2, 1.0, mode='auto')
         self._testOne(x500, x600, 'two-sided', 2000.0 / n1 / n2, 1.0, mode='asymp')
-        self._testOne(x500, x600, 'greater', 2000.0 / n1 / n2, 0.87721554018921577, mode='exact')
         self._testOne(x500, x600, 'greater', 2000.0 / n1 / n2, 0.87721554018921566, mode='asymp')
-        self._testOne(x500, x600, 'less', 500.0 / n1 / n2, 0.97218887049883673, mode='exact')
         self._testOne(x500, x600, 'less', 500.0 / n1 / n2, 0.97218887049883673, mode='asymp')
+        with suppress_warnings() as sup:
+            sup.filter(RuntimeWarning, "ks_2samp: Exact calculation overflowed. Switching to mode=asymp")
+            self._testOne(x500, x600, 'greater', 2000.0 / n1 / n2, 0.87721554018921577, mode='exact')
+            self._testOne(x500, x600, 'less', 500.0 / n1 / n2, 0.97218887049883673, mode='exact')
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            self._testOne(x500, x600, 'less', 500.0 / n1 / n2, 0.97218887049883673, mode='exact')
+            _check_warnings(w, RuntimeWarning, 1)
 
     def testMediumBoth(self):
         x1000 = np.linspace(1, 200, 1000)
@@ -2900,10 +2906,17 @@ class TestKSTwoSamples(object):
         # 1000, 1100
         self._testOne(x1000, x1100, 'two-sided', 6600.0 / n1 / n2, 1.0, mode='asymp')
         self._testOne(x1000, x1100, 'two-sided', 6600.0 / n1 / n2, 1.0, mode='auto')
-        self._testOne(x1000, x1100, 'greater', 6600.0 / n1 / n2, 0.84125883587707861, mode='exact')
         self._testOne(x1000, x1100, 'greater', 6600.0 / n1 / n2, 0.84125883587707861, mode='asymp')
-        self._testOne(x1000, x1100, 'less', 1000.0 / n1 / n2, 0.97888432252447422, mode='exact')
         self._testOne(x1000, x1100, 'less', 1000.0 / n1 / n2, 0.97888432252447422, mode='asymp')
+
+        with suppress_warnings() as sup:
+            sup.filter(RuntimeWarning, "ks_2samp: Exact calculation overflowed. Switching to mode=asymp")
+            self._testOne(x1000, x1100, 'greater', 6600.0 / n1 / n2, 0.84125883587707861, mode='exact')
+            self._testOne(x1000, x1100, 'less', 1000.0 / n1 / n2, 0.97888432252447422, mode='exact')
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            self._testOne(x1000, x1100, 'less', 1000.0 / n1 / n2, 0.97888432252447422, mode='exact')
+            _check_warnings(w, RuntimeWarning, 1)
 
     def testLarge(self):
         x10000 = np.linspace(1, 200, 10000)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2806,7 +2806,6 @@ class TestKSTwoSamples(object):
     def _testOne(self, x1, x2, alternative, expected_statistic, expected_prob, mode='auto'):
         result = stats.ks_2samp(x1, x2, alternative, mode=mode)
         expected = np.array([expected_statistic, expected_prob])
-        # print('%.16f' % result.statistic, '%.16e' % result.pvalue, result.statistic*500*600)
         assert_array_almost_equal(np.array(result), expected)
 
     def testSmall(self):
@@ -2888,15 +2887,15 @@ class TestKSTwoSamples(object):
         # 500, 600
         self._testOne(x500, x600, 'two-sided', 2000.0 / n1 / n2, 1.0, mode='auto')
         self._testOne(x500, x600, 'two-sided', 2000.0 / n1 / n2, 1.0, mode='asymp')
-        self._testOne(x500, x600, 'greater', 2000.0 / n1 / n2, 0.87721554018921566, mode='asymp')
-        self._testOne(x500, x600, 'less', 500.0 / n1 / n2, 0.97218887049883673, mode='asymp')
+        self._testOne(x500, x600, 'greater', 2000.0 / n1 / n2, 0.9697596024683929, mode='asymp')
+        self._testOne(x500, x600, 'less', 500.0 / n1 / n2, 0.9968735843165021, mode='asymp')
         with suppress_warnings() as sup:
             sup.filter(RuntimeWarning, "ks_2samp: Exact calculation overflowed. Switching to mode=asymp")
-            self._testOne(x500, x600, 'greater', 2000.0 / n1 / n2, 0.87721554018921577, mode='exact')
-            self._testOne(x500, x600, 'less', 500.0 / n1 / n2, 0.97218887049883673, mode='exact')
+            self._testOne(x500, x600, 'greater', 2000.0 / n1 / n2, 0.9697596024683929, mode='exact')
+            self._testOne(x500, x600, 'less', 500.0 / n1 / n2, 0.9968735843165021, mode='exact')
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            self._testOne(x500, x600, 'less', 500.0 / n1 / n2, 0.97218887049883673, mode='exact')
+            self._testOne(x500, x600, 'less', 500.0 / n1 / n2, 0.9968735843165021, mode='exact')
             _check_warnings(w, RuntimeWarning, 1)
 
     def testMediumBoth(self):
@@ -2906,16 +2905,16 @@ class TestKSTwoSamples(object):
         # 1000, 1100
         self._testOne(x1000, x1100, 'two-sided', 6600.0 / n1 / n2, 1.0, mode='asymp')
         self._testOne(x1000, x1100, 'two-sided', 6600.0 / n1 / n2, 1.0, mode='auto')
-        self._testOne(x1000, x1100, 'greater', 6600.0 / n1 / n2, 0.84125883587707861, mode='asymp')
-        self._testOne(x1000, x1100, 'less', 1000.0 / n1 / n2, 0.97888432252447422, mode='asymp')
+        self._testOne(x1000, x1100, 'greater', 6600.0 / n1 / n2, 0.9573185808092622, mode='asymp')
+        self._testOne(x1000, x1100, 'less', 1000.0 / n1 / n2, 0.9982410869433984, mode='asymp')
 
         with suppress_warnings() as sup:
             sup.filter(RuntimeWarning, "ks_2samp: Exact calculation overflowed. Switching to mode=asymp")
-            self._testOne(x1000, x1100, 'greater', 6600.0 / n1 / n2, 0.84125883587707861, mode='exact')
-            self._testOne(x1000, x1100, 'less', 1000.0 / n1 / n2, 0.97888432252447422, mode='exact')
+            self._testOne(x1000, x1100, 'greater', 6600.0 / n1 / n2, 0.9573185808092622, mode='exact')
+            self._testOne(x1000, x1100, 'less', 1000.0 / n1 / n2, 0.9982410869433984, mode='exact')
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            self._testOne(x1000, x1100, 'less', 1000.0 / n1 / n2, 0.97888432252447422, mode='exact')
+            self._testOne(x1000, x1100, 'less', 1000.0 / n1 / n2, 0.9982410869433984, mode='exact')
             _check_warnings(w, RuntimeWarning, 1)
 
     def testLarge(self):

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2932,11 +2932,14 @@ class TestKSTwoSamples(object):
         x11000 = np.linspace(2, 200, 11000)
         # 10000, 11000
         self._testOne(x10000, x11000, 'two-sided', 563.0 / 10000 / 11, 0.99915729949018561, mode='asymp')
-        self._testOne(x10000, x11000, 'two-sided', 563.0 / 10000 / 11, 1.0, mode='auto')
-        self._testOne(x10000, x11000, 'greater', 563.0 / 10000 / 11, 0.5278310390162617, mode='exact')
+        self._testOne(x10000, x11000, 'two-sided', 563.0 / 10000 / 11, 1.0, mode='exact')
+        self._testOne(x10000, x11000, 'two-sided', 563.0 / 10000 / 11, 0.99915729949018561, mode='auto')
         self._testOne(x10000, x11000, 'greater', 563.0 / 10000 / 11, 0.5278310390162617)
-        self._testOne(x10000, x11000, 'less', 10.0 / 10000 / 11, 0.9934598204248157, mode='exact')
         self._testOne(x10000, x11000, 'less', 10.0 / 10000 / 11, 0.9934598204248157)
+        with suppress_warnings() as sup:
+            sup.filter(RuntimeWarning, "ks_2samp: Exact calculation overflowed. Switching to mode=asymp")
+            self._testOne(x10000, x11000, 'greater', 563.0 / 10000 / 11, 0.5278310390162617, mode='exact')
+            self._testOne(x10000, x11000, 'less', 10.0 / 10000 / 11, 0.9934598204248157, mode='exact')
 
     def testNamedAtributes(self):
         # test for namedtuple attribute results


### PR DESCRIPTION
Replaced approximation with exact computation for two-sided test `stats.ks_2samp`. 
Added a one-sided, two-sample KS test. 
Added a keyword `alternative` to `stats.ks_2samp`. so the signature becomes
```
stats.ks_2samp(data1, data2, alternative='two-sided')
```
Slightly increase accuracy of the test statistic.
Added test cases.
Updated the stats tutorial with slightly changed probabilities.

**WARNING: This PR changes returned results.**.  
An extreme example occurs when comparing two samples of length 1, `[X0]` and `[Y0]`  
The computed test statistic is `1.0`, and the returned probability changes from `0.289` to `1.0`(!) 
[0.289 came from using the Smirnov approximation suitable for large `n`, even though `n=1` and is not large.  
Then probability 1.0 arises because when comparing two size 1 samples, the smallest Empirical CDF gap is 1.0 (as the distributions are continuous so no common values), hence `Pr(Dn,m >= 1.0) = 1`. So the new exactly computed value is much more accurate for n small and moderate sized n.

This is the second of 3 planned PRs for (the first is gh-9719).  The 3rd will be a smaller one switching which functions are called inside `stats.{kstest/ks_2samp}` with an indication of what results may change.
