### PR TITLE
ENH: Allow pass_zero to act like btype

### DIFF
--- a/scipy/signal/fir_filter_design.py
+++ b/scipy/signal/fir_filter_design.py
@@ -3,6 +3,7 @@
 from __future__ import division, print_function, absolute_import
 
 from math import ceil, log
+import operator
 import warnings
 
 import numpy as np
@@ -292,9 +293,13 @@ def firwin(numtaps, cutoff, width=None, window='hamming', pass_zero=True,
     window : string or tuple of string and parameter values, optional
         Desired window to use. See `scipy.signal.get_window` for a list
         of windows and required parameters.
-    pass_zero : bool, optional
+    pass_zero : {True, False, 'bandpass', 'lowpass', 'highpass', 'bandstop'}, optional
         If True, the gain at the frequency 0 (i.e. the "DC gain") is 1.
-        Otherwise the DC gain is 0.
+        If False, the DC gain is 0. Can also be a string argument for the
+        desired filter type (equivalent to ``btype`` in IIR design functions).
+
+        .. versionadded:: 1.3.0
+           Support for string arguments.
     scale : bool, optional
         Set to True to scale the coefficients so that the frequency
         response is exactly unity at a certain frequency.
@@ -376,7 +381,7 @@ def firwin(numtaps, cutoff, width=None, window='hamming', pass_zero=True,
     >>> signal.firwin(numtaps, [f1, f2, f3, f4], pass_zero=False)
     array([ 0.04890915,  0.91284326,  0.04890915])
 
-    """
+    """  # noqa: E501
     # The major enhancements to this function added in November 2010 were
     # developed by Tom Krauss (see ticket #902).
 
@@ -403,6 +408,29 @@ def firwin(numtaps, cutoff, width=None, window='hamming', pass_zero=True,
         atten = kaiser_atten(numtaps, float(width) / nyq)
         beta = kaiser_beta(atten)
         window = ('kaiser', beta)
+
+    if isinstance(pass_zero, str):
+        if pass_zero == 'bandstop':
+            pass_zero = True
+        elif pass_zero == 'lowpass':
+            if cutoff.size != 1:
+                raise ValueError('cutoff must be shape (1,) if '
+                                 'pass_zero=="lowpass", got %s'
+                                 % (cutoff.shape,))
+            pass_zero = True
+        elif pass_zero == 'bandpass':
+            pass_zero = False
+        else:
+            if pass_zero != 'highpass':
+                raise ValueError('pass_zero must be True, False, "bandpass", '
+                                 '"lowpass", "highpass", or "bandstop", got '
+                                 '%s' % (pass_zero,))
+            if cutoff.size != 1:
+                raise ValueError('cutoff must be shape (1,) if '
+                                 'pass_zero=="highpass", got %s'
+                                 % (cutoff.shape,))
+            pass_zero = False
+    pass_zero = bool(operator.index(pass_zero))  # ensure bool-like
 
     pass_nyquist = bool(cutoff.size & 1) ^ pass_zero
     if pass_nyquist and numtaps % 2 == 0:

--- a/scipy/signal/fir_filter_design.py
+++ b/scipy/signal/fir_filter_design.py
@@ -410,26 +410,32 @@ def firwin(numtaps, cutoff, width=None, window='hamming', pass_zero=True,
         window = ('kaiser', beta)
 
     if isinstance(pass_zero, str):
-        if pass_zero == 'bandstop':
-            pass_zero = True
-        elif pass_zero == 'lowpass':
-            if cutoff.size != 1:
-                raise ValueError('cutoff must be shape (1,) if '
-                                 'pass_zero=="lowpass", got %s'
+        if pass_zero in ('bandstop', 'lowpass'):
+            if pass_zero == 'lowpass':
+                if cutoff.size != 1:
+                    raise ValueError('cutoff must have one element if '
+                                     'pass_zero=="lowpass", got %s'
+                                     % (cutoff.shape,))
+            elif cutoff.size <= 1:
+                raise ValueError('cutoff must have at least two elements if '
+                                 'pass_zero=="bandstop", got %s'
                                  % (cutoff.shape,))
             pass_zero = True
-        elif pass_zero == 'bandpass':
+        elif pass_zero in ('bandpass', 'highpass'):
+            if pass_zero == 'highpass':
+                if cutoff.size != 1:
+                    raise ValueError('cutoff must have one element if '
+                                     'pass_zero=="highpass", got %s'
+                                     % (cutoff.shape,))
+            elif cutoff.size <= 1:
+                raise ValueError('cutoff must have at least two elements if '
+                                 'pass_zero=="bandpass", got %s'
+                                 % (cutoff.shape,))
             pass_zero = False
         else:
-            if pass_zero != 'highpass':
-                raise ValueError('pass_zero must be True, False, "bandpass", '
-                                 '"lowpass", "highpass", or "bandstop", got '
-                                 '%s' % (pass_zero,))
-            if cutoff.size != 1:
-                raise ValueError('cutoff must be shape (1,) if '
-                                 'pass_zero=="highpass", got %s'
-                                 % (cutoff.shape,))
-            pass_zero = False
+            raise ValueError('pass_zero must be True, False, "bandpass", '
+                             '"lowpass", "highpass", or "bandstop", got '
+                             '%s' % (pass_zero,))
     pass_zero = bool(operator.index(pass_zero))  # ensure bool-like
 
     pass_nyquist = bool(cutoff.size & 1) ^ pass_zero

--- a/scipy/signal/tests/test_fir_filter_design.py
+++ b/scipy/signal/tests/test_fir_filter_design.py
@@ -265,10 +265,12 @@ class TestFirWinMore(object):
             firwin(41, 0.5, pass_zero='foo')
         with assert_raises(TypeError, match='cannot be interpreted'):
             firwin(41, 0.5, pass_zero=1.)
-        with assert_raises(ValueError, match='cutoff must be shape'):
-            firwin(41, [0.5, 0.6], pass_zero='lowpass')
-        with assert_raises(ValueError, match='cutoff must be shape'):
-            firwin(41, [0.5, 0.6], pass_zero='highpass')
+        for pass_zero in ('lowpass', 'highpass'):
+            with assert_raises(ValueError, match='cutoff must have one'):
+                firwin(41, [0.5, 0.6], pass_zero=pass_zero)
+        for pass_zero in ('bandpass', 'bandstop'):
+            with assert_raises(ValueError, match='must have at least two'):
+                firwin(41, [0.5], pass_zero=pass_zero)
 
 
 class TestFirwin2(object):

--- a/scipy/signal/tests/test_fir_filter_design.py
+++ b/scipy/signal/tests/test_fir_filter_design.py
@@ -131,7 +131,8 @@ class TestFirWinMore(object):
     def test_lowpass(self):
         width = 0.04
         ntaps, beta = kaiserord(120, width)
-        taps = firwin(ntaps, cutoff=0.5, window=('kaiser', beta), scale=False)
+        kwargs = dict(cutoff=0.5, window=('kaiser', beta), scale=False)
+        taps = firwin(ntaps, **kwargs)
 
         # Check the symmetry of taps.
         assert_array_almost_equal(taps[:ntaps//2], taps[ntaps:ntaps-ntaps//2-1:-1])
@@ -142,6 +143,9 @@ class TestFirWinMore(object):
         assert_array_almost_equal(np.abs(response),
                                     [1.0, 1.0, 1.0, 0.0, 0.0, 0.0], decimal=5)
 
+        taps_str = firwin(ntaps, pass_zero='lowpass', **kwargs)
+        assert_allclose(taps, taps_str)
+
     def test_highpass(self):
         width = 0.04
         ntaps, beta = kaiserord(120, width)
@@ -149,8 +153,8 @@ class TestFirWinMore(object):
         # Ensure that ntaps is odd.
         ntaps |= 1
 
-        taps = firwin(ntaps, cutoff=0.5, window=('kaiser', beta),
-                        pass_zero=False, scale=False)
+        kwargs = dict(cutoff=0.5, window=('kaiser', beta), scale=False)
+        taps = firwin(ntaps, pass_zero=False, **kwargs)
 
         # Check the symmetry of taps.
         assert_array_almost_equal(taps[:ntaps//2], taps[ntaps:ntaps-ntaps//2-1:-1])
@@ -161,11 +165,14 @@ class TestFirWinMore(object):
         assert_array_almost_equal(np.abs(response),
                                     [0.0, 0.0, 0.0, 1.0, 1.0, 1.0], decimal=5)
 
+        taps_str = firwin(ntaps, pass_zero='highpass', **kwargs)
+        assert_allclose(taps, taps_str)
+
     def test_bandpass(self):
         width = 0.04
         ntaps, beta = kaiserord(120, width)
-        taps = firwin(ntaps, cutoff=[0.3, 0.7], window=('kaiser', beta),
-                        pass_zero=False, scale=False)
+        kwargs = dict(cutoff=[0.3, 0.7], window=('kaiser', beta), scale=False)
+        taps = firwin(ntaps, pass_zero=False, **kwargs)
 
         # Check the symmetry of taps.
         assert_array_almost_equal(taps[:ntaps//2], taps[ntaps:ntaps-ntaps//2-1:-1])
@@ -177,11 +184,15 @@ class TestFirWinMore(object):
         assert_array_almost_equal(np.abs(response),
                 [0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0], decimal=5)
 
-    def test_multi(self):
+        taps_str = firwin(ntaps, pass_zero='bandpass', **kwargs)
+        assert_allclose(taps, taps_str)
+
+    def test_bandstop_multi(self):
         width = 0.04
         ntaps, beta = kaiserord(120, width)
-        taps = firwin(ntaps, cutoff=[0.2, 0.5, 0.8], window=('kaiser', beta),
-                        pass_zero=True, scale=False)
+        kwargs = dict(cutoff=[0.2, 0.5, 0.8], window=('kaiser', beta),
+                      scale=False)
+        taps = firwin(ntaps, **kwargs)
 
         # Check the symmetry of taps.
         assert_array_almost_equal(taps[:ntaps//2], taps[ntaps:ntaps-ntaps//2-1:-1])
@@ -194,6 +205,9 @@ class TestFirWinMore(object):
         assert_array_almost_equal(np.abs(response),
                 [1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0],
                 decimal=5)
+
+        taps_str = firwin(ntaps, pass_zero='bandstop', **kwargs)
+        assert_allclose(taps, taps_str)
 
     def test_fs_nyq(self):
         """Test the fs and nyq keywords."""
@@ -244,6 +258,17 @@ class TestFirWinMore(object):
         of taps raises a ValueError exception."""
         assert_raises(ValueError, firwin, 40, 0.5, pass_zero=False)
         assert_raises(ValueError, firwin, 40, [.25, 0.5])
+
+    def test_bad_pass_zero(self):
+        """Test degenerate pass_zero cases."""
+        with assert_raises(ValueError, match='pass_zero must be'):
+            firwin(41, 0.5, pass_zero='foo')
+        with assert_raises(TypeError, match='cannot be interpreted'):
+            firwin(41, 0.5, pass_zero=1.)
+        with assert_raises(ValueError, match='cutoff must be shape'):
+            firwin(41, [0.5, 0.6], pass_zero='lowpass')
+        with assert_raises(ValueError, match='cutoff must be shape'):
+            firwin(41, [0.5, 0.6], pass_zero='highpass')
 
 
 class TestFirwin2(object):


### PR DESCRIPTION
This addresses a user-requested feature to be able to specify the design type of `firwin` using a string argument instead of whether or not DC gets passed by the filter.

Closes #8033.