### PR TITLE
BUG: Catch internal warnings for matrix

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -7,7 +7,6 @@ filterwarnings =
     error
     always::scipy._lib._testutils.FPUModeChangeWarning
     once:.*LAPACK bug 0038.*:RuntimeWarning
-    ignore:the matrix subclass is not the recommended way*:PendingDeprecationWarning
     ignore:Using or importing the ABCs from 'collections'*:DeprecationWarning
     ignore:can't resolve package from __spec__ or __package__, falling back on __name__ and __path__:ImportWarning
 env =

--- a/scipy/_lib/tests/test_warnings.py
+++ b/scipy/_lib/tests/test_warnings.py
@@ -70,7 +70,7 @@ def warning_calls():
 
     bad_filters = []
     bad_stacklevels = []
-    
+
     for path in base.rglob("*.py"):
         # use tokenize to auto-detect encoding on systems where no
         # default encoding is defined (e.g. LANG='C')
@@ -92,9 +92,10 @@ def test_warning_calls_filters(warning_calls):
     # There is still one simplefilter occurrence in optimize.py that could be removed.
     bad_filters = [item for item in bad_filters
                    if 'optimize.py' not in item]
-    # The filterwarnings call in sparse/__init__.py is needed.
+    # The filterwarnings calls in sparse are needed.
     bad_filters = [item for item in bad_filters
-                   if os.path.join('sparse', '__init__.py') not in item]
+                   if os.path.join('sparse', '__init__.py') not in item
+                   and os.path.join('sparse', 'sputils.py') not in item]
 
     if bad_filters:
         raise AssertionError(

--- a/scipy/cluster/tests/test_vq.py
+++ b/scipy/cluster/tests/test_vq.py
@@ -14,6 +14,7 @@ from pytest import raises as assert_raises
 from scipy.cluster.vq import (kmeans, kmeans2, py_vq, vq, whiten,
                               ClusterError, _krandinit)
 from scipy.cluster import _vq
+from scipy.sparse.sputils import matrix
 
 
 TESTDATA_2D = np.array([
@@ -79,7 +80,7 @@ class TestWhiten(object):
                             [4.51041982, 0.02640918],
                             [4.38567074, 0.95120889],
                             [2.32191480, 1.63195503]])
-        for tp in np.array, np.matrix:
+        for tp in np.array, matrix:
             obs = tp([[0.98744510, 0.82766775],
                       [0.62093317, 0.19406729],
                       [0.87545741, 0.00735733],
@@ -91,7 +92,7 @@ class TestWhiten(object):
         desired = np.array([[0., 1.0, 2.86666544],
                             [0., 1.0, 1.32460034],
                             [0., 1.0, 3.74382172]])
-        for tp in np.array, np.matrix:
+        for tp in np.array, matrix:
             obs = tp([[0., 1., 0.74109533],
                       [0., 1., 0.34243798],
                       [0., 1., 0.96785929]])
@@ -102,7 +103,7 @@ class TestWhiten(object):
                 assert_(issubclass(w[-1].category, RuntimeWarning))
 
     def test_whiten_not_finite(self):
-        for tp in np.array, np.matrix:
+        for tp in np.array, matrix:
             for bad_value in np.nan, np.inf, -np.inf:
                 obs = tp([[0.98744510, bad_value],
                           [0.62093317, 0.19406729],
@@ -115,13 +116,13 @@ class TestWhiten(object):
 class TestVq(object):
     def test_py_vq(self):
         initc = np.concatenate(([[X[0]], [X[1]], [X[2]]]))
-        for tp in np.array, np.matrix:
+        for tp in np.array, matrix:
             label1 = py_vq(tp(X), tp(initc))[0]
             assert_array_equal(label1, LABEL1)
 
     def test_vq(self):
         initc = np.concatenate(([[X[0]], [X[1]], [X[2]]]))
-        for tp in np.array, np.matrix:
+        for tp in np.array, matrix:
             label1, dist = _vq.vq(tp(X), tp(initc))
             assert_array_equal(label1, LABEL1)
             tlabel1, tdist = vq(tp(X), tp(initc))
@@ -192,7 +193,7 @@ class TestKMean(object):
     def test_kmeans_simple(self):
         np.random.seed(54321)
         initc = np.concatenate(([[X[0]], [X[1]], [X[2]]]))
-        for tp in np.array, np.matrix:
+        for tp in np.array, matrix:
             code1 = kmeans(tp(X), tp(initc), iter=1)[0]
             assert_array_almost_equal(code1, CODET2)
 
@@ -215,7 +216,7 @@ class TestKMean(object):
     def test_kmeans2_simple(self):
         np.random.seed(12345678)
         initc = np.concatenate(([[X[0]], [X[1]], [X[2]]]))
-        for tp in np.array, np.matrix:
+        for tp in np.array, matrix:
             code1 = kmeans2(tp(X), tp(initc), iter=1)[0]
             code2 = kmeans2(tp(X), tp(initc), iter=2)[0]
 

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -29,6 +29,8 @@ from scipy.integrate import nquad
 
 from scipy.special import binom
 
+from scipy.sparse.sputils import matrix
+
 
 class TestInterp2D(object):
     def test_interp2d(self):
@@ -2783,11 +2785,11 @@ class TestInterpN(object):
         x = np.linspace(0, 2, 5)
         y = np.linspace(0, 1, 7)
 
-        values = np.matrix(np.random.rand(5, 7))
+        values = matrix(np.random.rand(5, 7))
 
         sample = np.random.rand(3, 7, 2)
 
         for method in ('nearest', 'linear', 'splinef2d'):
             v1 = interpn((x, y), values, sample, method=method)
             v2 = interpn((x, y), np.asarray(values), sample, method=method)
-            assert_allclose(v1, np.asmatrix(v2))
+            assert_allclose(v1, v2)

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -33,13 +33,14 @@ from scipy.linalg._decomp_qz import _select_function
 
 from numpy import array, transpose, sometrue, diag, ones, linalg, \
      argsort, zeros, arange, float32, complex64, dot, conj, identity, \
-     ravel, sqrt, iscomplex, shape, sort, conjugate, bmat, sign, \
-     asarray, matrix, isfinite, all, ndarray, outer, eye, dtype, empty,\
+     ravel, sqrt, iscomplex, shape, sort, conjugate, sign, \
+     asarray, isfinite, all, ndarray, outer, eye, dtype, empty,\
      triu, tril
 
 from numpy.random import normal, seed, random
 
 from scipy.linalg._testutils import assert_no_overwrite
+from scipy.sparse.sputils import bmat, matrix
 
 # digit precision to use in asserts for different types
 DIGITS = {'d':11, 'D':11, 'f':4, 'F':4}

--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -10,18 +10,18 @@ import random
 import functools
 
 import numpy as np
-from numpy import array, matrix, identity, dot, sqrt, double
+from numpy import array, identity, dot, sqrt
 from numpy.testing import (
         assert_array_equal, assert_array_less, assert_equal,
-        assert_array_almost_equal, assert_array_almost_equal_nulp,
+        assert_array_almost_equal,
         assert_allclose, assert_)
 import pytest
 
-from scipy._lib._numpy_compat import _assert_warns, suppress_warnings
+from scipy._lib._numpy_compat import _assert_warns
 
 import scipy.linalg
 from scipy.linalg import (funm, signm, logm, sqrtm, fractional_matrix_power,
-        expm, expm_frechet, expm_cond, norm)
+                          expm, expm_frechet, expm_cond, norm)
 from scipy.linalg import _matfuncs_inv_ssq
 import scipy.linalg._expm_frechet
 

--- a/scipy/linalg/tests/test_procrustes.py
+++ b/scipy/linalg/tests/test_procrustes.py
@@ -6,6 +6,7 @@ from pytest import raises as assert_raises
 
 from scipy.linalg import inv, eigh, norm
 from scipy.linalg import orthogonal_procrustes
+from scipy.sparse.sputils import matrix
 
 
 def test_orthogonal_procrustes_ndim_too_large():
@@ -63,8 +64,8 @@ def test_orthogonal_procrustes_array_conversion():
     for m, n in ((6, 4), (4, 4), (4, 6)):
         A_arr = np.random.randn(m, n)
         B_arr = np.random.randn(m, n)
-        As = (A_arr, A_arr.tolist(), np.matrix(A_arr))
-        Bs = (B_arr, B_arr.tolist(), np.matrix(B_arr))
+        As = (A_arr, A_arr.tolist(), matrix(A_arr))
+        Bs = (B_arr, B_arr.tolist(), matrix(B_arr))
         R_arr, s = orthogonal_procrustes(A_arr, B_arr)
         AR_arr = A_arr.dot(R_arr)
         for A, B in product(As, Bs):

--- a/scipy/linalg/tests/test_solvers.py
+++ b/scipy/linalg/tests/test_solvers.py
@@ -11,6 +11,7 @@ from scipy.linalg import solve_sylvester
 from scipy.linalg import solve_continuous_lyapunov, solve_discrete_lyapunov
 from scipy.linalg import solve_continuous_are, solve_discrete_are
 from scipy.linalg import block_diag, solve, LinAlgError
+from scipy.sparse.sputils import matrix
 
 
 def _load_data(name):
@@ -79,11 +80,11 @@ class TestSolveLyapunov(object):
                     0.000+0.j]]),
          np.eye(11)),
         # https://github.com/scipy/scipy/issues/4176
-        (np.matrix([[0, 1], [-1/2, -1]]),
-         (np.matrix([0, 3]).T * np.matrix([0, 3]).T.T)),
+        (matrix([[0, 1], [-1/2, -1]]),
+         (matrix([0, 3]).T * matrix([0, 3]).T.T)),
         # https://github.com/scipy/scipy/issues/4176
-        (np.matrix([[0, 1], [-1/2, -1]]),
-         (np.array(np.matrix([0, 3]).T * np.matrix([0, 3]).T.T))),
+        (matrix([[0, 1], [-1/2, -1]]),
+         (np.array(matrix([0, 3]).T * matrix([0, 3]).T.T))),
         ]
 
     def test_continuous_squareness_and_shape(self):

--- a/scipy/optimize/_trustregion_constr/tr_interior_point.py
+++ b/scipy/optimize/_trustregion_constr/tr_interior_point.py
@@ -160,8 +160,8 @@ class BarrierSubproblem:
                 if sps.issparse(J_eq):
                     J_eq = J_eq.toarray()
                 # Concatenate matrices
-                return np.asarray(np.bmat([[J_eq, zeros],
-                                           [J_ineq, S]]))
+                return np.block([[J_eq, zeros],
+                                 [J_ineq, S]])
 
     def _assemble_sparse_jacobian(self, J_eq, J_ineq, s):
         """Assemble sparse jacobian given its components.
@@ -250,7 +250,7 @@ class BarrierSubproblem:
         """
         x = self.get_variables(z)
         if self.global_stop_criteria(state, x,
-                                     last_iteration_failed, 
+                                     last_iteration_failed,
                                      trust_radius, penalty,
                                      cg_info,
                                      self.barrier_parameter,

--- a/scipy/optimize/tests/test_hungarian.py
+++ b/scipy/optimize/tests/test_hungarian.py
@@ -7,6 +7,7 @@ from pytest import raises as assert_raises
 import numpy as np
 
 from scipy.optimize import linear_sum_assignment
+from scipy.sparse.sputils import matrix
 
 
 def test_linear_sum_assignment():
@@ -59,7 +60,7 @@ def test_linear_sum_assignment_input_validation():
     assert_array_equal(linear_sum_assignment(C),
                        linear_sum_assignment(np.asarray(C)))
     assert_array_equal(linear_sum_assignment(C),
-                       linear_sum_assignment(np.matrix(C)))
+                       linear_sum_assignment(matrix(C)))
 
     I = np.identity(3)
     assert_array_equal(linear_sum_assignment(I.astype(np.bool)),

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -4,10 +4,10 @@ Unit tests for optimization routines from minpack.py.
 from __future__ import division, print_function, absolute_import
 
 from numpy.testing import (assert_, assert_almost_equal, assert_array_equal,
-        assert_array_almost_equal, assert_allclose)
+                           assert_array_almost_equal, assert_allclose)
 from pytest import raises as assert_raises
 import numpy as np
-from numpy import array, float64, matrix
+from numpy import array, float64
 from multiprocessing.pool import ThreadPool
 
 from scipy import optimize
@@ -224,7 +224,7 @@ class TestRootHybr(object):
         # root/hybr with gradient, equal pipes -> equal flows
         k = np.ones(4) * 0.5
         Qtot = 4
-        initial_guess = matrix([2., 0., 2., 0.])
+        initial_guess = array([[2., 0., 2., 0.]])
         final_flows = optimize.root(pressure_network, initial_guess,
                                     args=(Qtot, k), method='hybr',
                                     jac=pressure_network_jacobian).x
@@ -289,7 +289,7 @@ class TestLeastSq(object):
         assert_array_almost_equal(params_fit, self.abc, decimal=2)
 
     def test_full_output(self):
-        p0 = matrix([0,0,0])
+        p0 = array([[0,0,0]])
         full_output = leastsq(self.residuals, p0,
                               args=(self.y_meas, self.x),
                               full_output=True)

--- a/scipy/optimize/tests/test_nonlin.py
+++ b/scipy/optimize/tests/test_nonlin.py
@@ -9,7 +9,7 @@ import pytest
 
 from scipy._lib.six import xrange
 from scipy.optimize import nonlin, root
-from numpy import matrix, diag, dot
+from numpy import diag, dot
 from numpy.linalg import inv
 import numpy as np
 
@@ -28,10 +28,10 @@ MUST_WORK = {'anderson': nonlin.anderson, 'broyden1': nonlin.broyden1,
 
 
 def F(x):
-    x = np.asmatrix(x).T
-    d = matrix(diag([3,2,1.5,1,0.5]))
+    x = np.asarray(x).T
+    d = diag([3,2,1.5,1,0.5])
     c = 0.01
-    f = -d*x - c*float(x.T*x)*x
+    f = -d @ x - c * float(x.T @ x) * x
     return f
 
 
@@ -57,9 +57,9 @@ F2_lucky.KNOWN_BAD = {}
 
 
 def F3(x):
-    A = np.mat('-2 1 0; 1 -2 1; 0 1 -2')
-    b = np.mat('1 2 3')
-    return np.dot(A, x) - b
+    A = np.array([[-2, 1, 0.], [1, -2, 1], [0, 1, -2]])
+    b = np.array([1, 2, 3.])
+    return A @ x - b
 
 
 F3.xin = [1,2,3]

--- a/scipy/optimize/tests/test_tnc.py
+++ b/scipy/optimize/tests/test_tnc.py
@@ -4,9 +4,11 @@ Unit tests for TNC optimization routine from tnc.py
 
 from numpy.testing import assert_allclose, assert_equal
 
-from scipy import optimize
 import numpy as np
 from math import pow
+
+from scipy import optimize
+from scipy.sparse.sputils import matrix
 
 
 class TestTnc(object):
@@ -126,7 +128,7 @@ class TestTnc(object):
         assert_equal(len(iterx), res.nit)
 
     def test_minimize_tnc1b(self):
-        x0, bnds = np.matrix([-2, 1]), ([-np.inf, None],[-1.5, None])
+        x0, bnds = matrix([-2, 1]), ([-np.inf, None],[-1.5, None])
         xopt = [1, 1]
         x = optimize.minimize(self.f1, x0, method='TNC',
                               bounds=bnds, options=self.opts).x

--- a/scipy/signal/tests/test_dltisys.py
+++ b/scipy/signal/tests/test_dltisys.py
@@ -26,17 +26,17 @@ class TestDLTI(object):
 
         # Create an input matrix with inputs down the columns (3 cols) and its
         # respective time input vector
-        u = np.hstack((np.asmatrix(np.linspace(0, 4.0, num=5)).transpose(),
+        u = np.hstack((np.linspace(0, 4.0, num=5)[:, np.newaxis],
                        0.01 * np.ones((5, 1)),
                        -0.002 * np.ones((5, 1))))
         t_in = np.linspace(0, 2.0, num=5)
 
         # Define the known result
-        yout_truth = np.asmatrix([-0.001,
-                                  -0.00073,
-                                  0.039446,
-                                  0.0915387,
-                                  0.13195948]).transpose()
+        yout_truth = np.array([[-0.001,
+                                -0.00073,
+                                0.039446,
+                                0.0915387,
+                                0.13195948]]).T
         xout_truth = np.asarray([[0, 0],
                                  [0.0012, 0.0005],
                                  [0.40233, 0.00071],
@@ -66,11 +66,11 @@ class TestDLTI(object):
         # Transfer functions (assume dt = 0.5)
         num = np.asarray([1.0, -0.1])
         den = np.asarray([0.3, 1.0, 0.2])
-        yout_truth = np.asmatrix([0.0,
-                                  0.0,
-                                  3.33333333333333,
-                                  -4.77777777777778,
-                                  23.0370370370370]).transpose()
+        yout_truth = np.array([[0.0,
+                                0.0,
+                                3.33333333333333,
+                                -4.77777777777778,
+                                23.0370370370370]]).T
 
         # Assume use of the first column of the control input built earlier
         tout, yout = dlsim((num, den, 0.5), u[:, 0], t_in)
@@ -90,7 +90,7 @@ class TestDLTI(object):
         zd = np.array([0.5, -0.5])
         pd = np.array([1.j / np.sqrt(2), -1.j / np.sqrt(2)])
         k = 1.0
-        yout_truth = np.asmatrix([0.0, 1.0, 2.0, 2.25, 2.5]).transpose()
+        yout_truth = np.array([[0.0, 1.0, 2.0, 2.25, 2.5]]).T
 
         tout, yout = dlsim((zd, pd, k, 0.5), u[:, 0], t_in)
 

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -14,6 +14,7 @@ from scipy.signal import (ss2tf, tf2ss, lsim2, impulse2, step2, lti,
                           TransferFunction, StateSpace, ZerosPolesGain)
 from scipy.signal.filter_design import BadCoefficients
 import scipy.linalg as linalg
+from scipy.sparse.sputils import matrix
 
 import scipy._lib.six as six
 
@@ -422,9 +423,9 @@ class TestLsim(object):
 
     def test_double_integrator(self):
         # double integrator: y'' = 2u
-        A = np.mat("0. 1.; 0. 0.")
-        B = np.mat("0.; 1.")
-        C = np.mat("2. 0.")
+        A = matrix("0. 1.; 0. 0.")
+        B = matrix("0.; 1.")
+        C = matrix("2. 0.")
         system = self.lti_nowarn(A, B, C, 0.)
         t = np.linspace(0,5)
         u = np.ones_like(t)
@@ -440,9 +441,9 @@ class TestLsim(object):
         #   x2' + x2 = u
         #   y = x1
         # Exact solution with u = 0 is y(t) = t exp(-t)
-        A = np.mat("-1. 1.; 0. -1.")
-        B = np.mat("0.; 1.")
-        C = np.mat("1. 0.")
+        A = matrix("-1. 1.; 0. -1.")
+        B = matrix("0.; 1.")
+        C = matrix("1. 0.")
         system = self.lti_nowarn(A, B, C, 0.)
         t = np.linspace(0,5)
         u = np.zeros_like(t)

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -1,15 +1,13 @@
 """Base class for sparse matrices"""
 from __future__ import division, print_function, absolute_import
 
-import sys
-
 import numpy as np
 
 from scipy._lib.six import xrange
 from scipy._lib._numpy_compat import broadcast_to
 from .sputils import (isdense, isscalarlike, isintlike,
                       get_sum_dtype, validateaxis, check_reshape_kwargs,
-                      check_shape)
+                      check_shape, asmatrix)
 
 __all__ = ['spmatrix', 'isspmatrix', 'issparse',
            'SparseWarning', 'SparseEfficiencyWarning']
@@ -503,7 +501,7 @@ class spmatrix(object):
             result = self._mul_vector(np.ravel(other))
 
             if isinstance(other, np.matrix):
-                result = np.asmatrix(result)
+                result = asmatrix(result)
 
             if other.ndim == 2 and other.shape[1] == 1:
                 # If 'other' was an (nx1) column vector, reshape the result
@@ -521,7 +519,7 @@ class spmatrix(object):
             result = self._mul_multivector(np.asarray(other))
 
             if isinstance(other, np.matrix):
-                result = np.asmatrix(result)
+                result = asmatrix(result)
 
             return result
 
@@ -847,7 +845,7 @@ class spmatrix(object):
             with the appropriate values and returned wrapped in a
             `numpy.matrix` object that shares the same memory.
         """
-        return np.asmatrix(self.toarray(order=order, out=out))
+        return asmatrix(self.toarray(order=order, out=out))
 
     def toarray(self, order=None, out=None):
         """
@@ -1001,7 +999,7 @@ class spmatrix(object):
 
         if axis is None:
             # sum over rows and columns
-            return (self * np.asmatrix(np.ones(
+            return (self * asmatrix(np.ones(
                 (n, 1), dtype=res_dtype))).sum(
                 dtype=dtype, out=out)
 
@@ -1011,11 +1009,11 @@ class spmatrix(object):
         # axis = 0 or 1 now
         if axis == 0:
             # sum over columns
-            ret = np.asmatrix(np.ones(
+            ret = asmatrix(np.ones(
                 (1, m), dtype=res_dtype)) * self
         else:
             # sum over rows
-            ret = self * np.asmatrix(
+            ret = self * asmatrix(
                 np.ones((n, 1), dtype=res_dtype))
 
         if out is not None and out.shape != ret.shape:

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -20,7 +20,8 @@ from ._sparsetools import (get_csr_submatrix, csr_sample_offsets, csr_todense,
 from ._index import IndexMixin
 from .sputils import (upcast, upcast_char, to_native, isdense, isshape,
                       getdtype, isscalarlike, isintlike, get_index_dtype,
-                      downcast_intp_index, get_sum_dtype, check_shape)
+                      downcast_intp_index, get_sum_dtype, check_shape,
+                      matrix, asmatrix)
 
 
 class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
@@ -348,7 +349,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         M, N = self._swap(self.shape)
         y = result if result.flags.c_contiguous else result.T
         csr_todense(M, N, self.indptr, self.indices, self.data, y)
-        return np.matrix(result, copy=False)
+        return matrix(result, copy=False)
 
     def _add_sparse(self, other):
         return self._binopt(other, '_plus_')
@@ -596,7 +597,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
 
             major_index, value = self._minor_reduce(np.add)
             ret[major_index] = value
-            ret = np.asmatrix(ret)
+            ret = asmatrix(ret)
             if axis % 2 == 1:
                 ret = ret.T
 
@@ -663,7 +664,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         csr_sample_values(M, N, self.indptr, self.indices, self.data,
                           major.size, major.ravel(), minor.ravel(), val)
         if major.ndim == 1:
-            return np.asmatrix(val)
+            return asmatrix(val)
         return self.__class__(val.reshape(major.shape))
 
     def _get_columnXarray(self, row, col):
@@ -1259,7 +1260,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             out[row, col] = 0
             r = r.tocoo()
             out[r.row, r.col] = r.data
-            out = np.matrix(out)
+            out = matrix(out)
         else:
             # integers types go with nan <-> 0
             out = r

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -16,7 +16,7 @@ from .base import isspmatrix, SparseEfficiencyWarning, spmatrix
 from .data import _data_matrix, _minmax_mixin
 from .sputils import (upcast, upcast_char, to_native, isshape, getdtype,
                       get_index_dtype, downcast_intp_index, check_shape,
-                      check_reshape_kwargs)
+                      check_reshape_kwargs, matrix)
 
 
 class coo_matrix(_data_matrix, _minmax_mixin):
@@ -88,7 +88,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
 
     Examples
     --------
-    
+
     >>> # Constructing an empty matrix
     >>> from scipy.sparse import coo_matrix
     >>> coo_matrix((3, 4), dtype=np.int8).toarray()
@@ -570,7 +570,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
         M, N = self.shape
         coo_todense(M, N, self.nnz, self.row, self.col, self.data,
                     result.ravel('A'), fortran)
-        return np.matrix(result, copy=False)
+        return matrix(result, copy=False)
 
     def _mul_vector(self, other):
         #output array

--- a/scipy/sparse/data.py
+++ b/scipy/sparse/data.py
@@ -11,7 +11,7 @@ from __future__ import division, print_function, absolute_import
 import numpy as np
 
 from .base import spmatrix, _ufuncs_with_fixed_point_at_zero
-from .sputils import isscalarlike, validateaxis
+from .sputils import isscalarlike, validateaxis, matrix
 
 __all__ = []
 
@@ -246,7 +246,7 @@ class _minmax_mixin(object):
         if axis == 1:
             ret = ret.reshape(-1, 1)
 
-        return np.asmatrix(ret)
+        return matrix(ret)
 
     def _arg_min_or_max(self, axis, out, op, compare):
         if out is not None:

--- a/scipy/sparse/dia.py
+++ b/scipy/sparse/dia.py
@@ -11,7 +11,7 @@ import numpy as np
 from .base import isspmatrix, _formats, spmatrix
 from .data import _data_matrix
 from .sputils import (isshape, upcast_char, getdtype, get_index_dtype,
-                      get_sum_dtype, validateaxis, check_shape)
+                      get_sum_dtype, validateaxis, check_shape, matrix)
 from ._sparsetools import dia_matvec
 
 
@@ -201,7 +201,7 @@ class dia_matrix(_data_matrix):
             else:
                 res = np.zeros(num_cols, dtype=x.dtype)
                 res[:x.shape[0]] = x
-            ret = np.matrix(res, dtype=res_dtype)
+            ret = matrix(res, dtype=res_dtype)
 
         else:
             row_sums = np.zeros(num_rows, dtype=res_dtype)
@@ -209,7 +209,7 @@ class dia_matrix(_data_matrix):
             dia_matvec(num_rows, num_cols, len(self.offsets),
                        self.data.shape[1], self.offsets, self.data, one, row_sums)
 
-            row_sums = np.matrix(row_sums)
+            row_sums = matrix(row_sums)
 
             if axis is None:
                 return row_sums.sum(dtype=dtype, out=out)
@@ -217,7 +217,7 @@ class dia_matrix(_data_matrix):
             if axis is not None:
                 row_sums = row_sums.T
 
-            ret = np.matrix(row_sums.sum(axis=axis))
+            ret = matrix(row_sums.sum(axis=axis))
 
         if out is not None and out.shape != ret.shape:
             raise ValueError("dimensions do not match")

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -5,7 +5,7 @@ from __future__ import division, print_function, absolute_import
 
 __docformat__ = "restructuredtext en"
 
-__all__ = ['lil_matrix','isspmatrix_lil']
+__all__ = ['lil_matrix', 'isspmatrix_lil']
 
 from bisect import bisect_left
 
@@ -15,7 +15,8 @@ from scipy._lib.six import xrange, zip
 from .base import spmatrix, isspmatrix
 from ._index import IndexMixin, INT_TYPES
 from .sputils import (getdtype, isshape, isscalarlike, upcast_scalar,
-                      get_index_dtype, check_shape, check_reshape_kwargs)
+                      get_index_dtype, check_shape, check_reshape_kwargs,
+                      asmatrix)
 from . import _csparsetools
 
 
@@ -118,7 +119,7 @@ class lil_matrix(spmatrix, IndexMixin):
         else:
             # assume A is dense
             try:
-                A = np.asmatrix(arg1)
+                A = asmatrix(arg1)
             except TypeError:
                 raise TypeError('unsupported matrix type')
             else:

--- a/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
@@ -4,7 +4,7 @@ import sys
 import threading
 
 import numpy as np
-from numpy import array, finfo, arange, eye, all, unique, ones, dot, matrix
+from numpy import array, finfo, arange, eye, all, unique, ones, dot
 import numpy.random as random
 from numpy.testing import (
         assert_array_almost_equal, assert_almost_equal,
@@ -215,9 +215,9 @@ class TestLinsolve(object):
                 assert_(norm(b - Asp*x) < 10 * cond_A * eps)
 
     def test_bvector_smoketest(self):
-        Adense = matrix([[0., 1., 1.],
-                         [1., 0., 1.],
-                         [0., 0., 1.]])
+        Adense = array([[0., 1., 1.],
+                        [1., 0., 1.],
+                        [0., 0., 1.]])
         As = csc_matrix(Adense)
         random.seed(1234)
         x = random.randn(3)
@@ -227,9 +227,9 @@ class TestLinsolve(object):
         assert_array_almost_equal(x, x2)
 
     def test_bmatrix_smoketest(self):
-        Adense = matrix([[0., 1., 1.],
-                         [1., 0., 1.],
-                         [0., 0., 1.]])
+        Adense = array([[0., 1., 1.],
+                        [1., 0., 1.],
+                        [0., 0., 1.]])
         As = csc_matrix(Adense)
         random.seed(1234)
         x = random.randn(3, 4)

--- a/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
@@ -22,6 +22,7 @@ import numpy as np
 from scipy.linalg import (inv, eigh, cho_factor, cho_solve, cholesky,
                           LinAlgError)
 from scipy.sparse.linalg import aslinearoperator
+from scipy.sparse.sputils import bmat
 
 __all__ = ['lobpcg']
 
@@ -492,18 +493,18 @@ def lobpcg(A, X,
                 xbp = np.dot(blockVectorX.T.conj(), activeBlockVectorBP)
                 wbp = np.dot(activeBlockVectorR.T.conj(), activeBlockVectorBP)
 
-                gramA = np.bmat([[np.diag(_lambda), xaw, xap],
-                                [xaw.T.conj(), waw, wap],
-                                [xap.T.conj(), wap.T.conj(), pap]])
+                gramA = bmat([[np.diag(_lambda), xaw, xap],
+                              [xaw.T.conj(), waw, wap],
+                              [xap.T.conj(), wap.T.conj(), pap]])
 
-                gramB = np.bmat([[ident0, xbw, xbp],
-                                [xbw.T.conj(), ident, wbp],
-                                [xbp.T.conj(), wbp.T.conj(), ident]])
+                gramB = bmat([[ident0, xbw, xbp],
+                              [xbw.T.conj(), ident, wbp],
+                              [xbp.T.conj(), wbp.T.conj(), ident]])
             else:
-                gramA = np.bmat([[np.diag(_lambda), xaw],
-                                [xaw.T.conj(), waw]])
-                gramB = np.bmat([[ident0, xbw],
-                                [xbw.T.conj(), ident]])
+                gramA = bmat([[np.diag(_lambda), xaw],
+                              [xaw.T.conj(), waw]])
+                gramB = bmat([[ident0, xbw],
+                              [xbw.T.conj(), ident]])
 
         else:
             xaw = np.dot(blockVectorX.T.conj(), activeBlockVectorAR)
@@ -517,18 +518,18 @@ def lobpcg(A, X,
                 xbp = np.dot(blockVectorX.T.conj(), activeBlockVectorP)
                 wbp = np.dot(activeBlockVectorR.T.conj(), activeBlockVectorP)
 
-                gramA = np.bmat([[np.diag(_lambda), xaw, xap],
-                                 [xaw.T.conj(), waw, wap],
-                                 [xap.T.conj(), wap.T.conj(), pap]])
+                gramA = bmat([[np.diag(_lambda), xaw, xap],
+                              [xaw.T.conj(), waw, wap],
+                              [xap.T.conj(), wap.T.conj(), pap]])
 
-                gramB = np.bmat([[ident0, xbw, xbp],
-                                 [xbw.T.conj(), ident, wbp],
-                                 [xbp.T.conj(), wbp.T.conj(), ident]])
+                gramB = bmat([[ident0, xbw, xbp],
+                              [xbw.T.conj(), ident, wbp],
+                              [xbp.T.conj(), wbp.T.conj(), ident]])
             else:
-                gramA = np.bmat([[np.diag(_lambda), xaw],
-                                 [xaw.T.conj(), waw]])
-                gramB = np.bmat([[ident0, xbw],
-                                 [xbw.T.conj(), ident]])
+                gramA = bmat([[np.diag(_lambda), xaw],
+                              [xaw.T.conj(), waw]])
+                gramB = bmat([[ident0, xbw],
+                              [xbw.T.conj(), ident]])
 
         if verbosityLevel > 0:
             _report_nonhermitian(gramA, 3, -1, 'gramA')

--- a/scipy/sparse/linalg/interface.py
+++ b/scipy/sparse/linalg/interface.py
@@ -47,7 +47,7 @@ import warnings
 import numpy as np
 
 from scipy.sparse import isspmatrix
-from scipy.sparse.sputils import isshape, isintlike
+from scipy.sparse.sputils import isshape, isintlike, asmatrix
 
 __all__ = ['LinearOperator', 'aslinearoperator']
 
@@ -227,7 +227,7 @@ class LinearOperator(object):
         y = self._matvec(x)
 
         if isinstance(x, np.matrix):
-            y = np.asmatrix(y)
+            y = asmatrix(y)
         else:
             y = np.asarray(y)
 
@@ -274,7 +274,7 @@ class LinearOperator(object):
         y = self._rmatvec(x)
 
         if isinstance(x, np.matrix):
-            y = np.asmatrix(y)
+            y = asmatrix(y)
         else:
             y = np.asarray(y)
 
@@ -334,7 +334,7 @@ class LinearOperator(object):
         Y = self._matmat(X)
 
         if isinstance(Y, np.matrix):
-            Y = np.asmatrix(Y)
+            Y = asmatrix(Y)
 
         return Y
 

--- a/scipy/sparse/linalg/isolve/utils.py
+++ b/scipy/sparse/linalg/isolve/utils.py
@@ -5,7 +5,8 @@ __docformat__ = "restructuredtext en"
 __all__ = []
 
 
-from numpy import asanyarray, asarray, asmatrix, array, matrix, zeros
+from numpy import asanyarray, asarray, array, matrix, zeros
+from scipy.sparse.sputils import asmatrix
 
 from scipy.sparse.linalg.interface import aslinearoperator, LinearOperator, \
      IdentityOperator

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -14,6 +14,7 @@ import numpy as np
 import scipy.sparse as sparse
 
 from scipy.sparse.linalg import interface
+from scipy.sparse.sputils import matrix
 
 
 # Only test matmul operator (A @ B) when available (Python 3.5+)
@@ -57,9 +58,9 @@ class TestLinearOperator(object):
             assert_equal(A.dot(np.array([1,2,3])), [14,32])
             assert_equal(A.dot(np.array([[1],[2],[3]])), [[14],[32]])
 
-            assert_equal(A.matvec(np.matrix([[1],[2],[3]])), [[14],[32]])
-            assert_equal(A * np.matrix([[1],[2],[3]]), [[14],[32]])
-            assert_equal(A.dot(np.matrix([[1],[2],[3]])), [[14],[32]])
+            assert_equal(A.matvec(matrix([[1],[2],[3]])), [[14],[32]])
+            assert_equal(A * matrix([[1],[2],[3]]), [[14],[32]])
+            assert_equal(A.dot(matrix([[1],[2],[3]])), [[14],[32]])
 
             assert_equal((2*A)*[1,1,1], [12,30])
             assert_equal((2*A).rmatvec([1,1]), [10, 14, 18])
@@ -91,9 +92,9 @@ class TestLinearOperator(object):
             assert_(isinstance(A.dot(np.array([1,2,3])), np.ndarray))
             assert_(isinstance(A.dot(np.array([[1],[2],[3]])), np.ndarray))
 
-            assert_(isinstance(A.matvec(np.matrix([[1],[2],[3]])), np.ndarray))
-            assert_(isinstance(A * np.matrix([[1],[2],[3]]), np.ndarray))
-            assert_(isinstance(A.dot(np.matrix([[1],[2],[3]])), np.ndarray))
+            assert_(isinstance(A.matvec(matrix([[1],[2],[3]])), np.ndarray))
+            assert_(isinstance(A * matrix([[1],[2],[3]]), np.ndarray))
+            assert_(isinstance(A.dot(matrix([[1],[2],[3]])), np.ndarray))
 
             assert_(isinstance(2*A, interface._ScaledLinearOperator))
             assert_(isinstance(2j*A, interface._ScaledLinearOperator))
@@ -167,7 +168,7 @@ class TestAsLinearOperator(object):
         self.cases = []
 
         def make_cases(dtype):
-            self.cases.append(np.matrix([[1,2,3],[4,5,6]], dtype=dtype))
+            self.cases.append(matrix([[1,2,3],[4,5,6]], dtype=dtype))
             self.cases.append(np.array([[1,2,3],[4,5,6]], dtype=dtype))
             self.cases.append(sparse.csr_matrix([[1,2,3],[4,5,6]], dtype=dtype))
 

--- a/scipy/sparse/linalg/tests/test_matfuncs.py
+++ b/scipy/sparse/linalg/tests/test_matfuncs.py
@@ -21,6 +21,7 @@ from scipy.sparse.construct import eye as speye
 from scipy.sparse.linalg.matfuncs import (expm, _expm,
         ProductOperator, MatrixPowerOperator,
         _onenorm_matrix_power_nnm)
+from scipy.sparse.sputils import matrix
 from scipy.linalg import logm
 from scipy.special import factorial, binom
 import scipy.sparse
@@ -80,20 +81,20 @@ class TestExpM(object):
         assert_array_almost_equal(expm(a).toarray(),[[1,0],[0,1]])
 
     def test_zero_matrix(self):
-        a = np.matrix([[0.,0],[0,0]])
+        a = matrix([[0.,0],[0,0]])
         assert_array_almost_equal(expm(a),[[1,0],[0,1]])
 
     def test_misc_types(self):
         A = expm(np.array([[1]]))
         assert_allclose(expm(((1,),)), A)
         assert_allclose(expm([[1]]), A)
-        assert_allclose(expm(np.matrix([[1]])), A)
+        assert_allclose(expm(matrix([[1]])), A)
         assert_allclose(expm(np.array([[1]])), A)
         assert_allclose(expm(csc_matrix([[1]])).A, A)
         B = expm(np.array([[1j]]))
         assert_allclose(expm(((1j,),)), B)
         assert_allclose(expm([[1j]]), B)
-        assert_allclose(expm(np.matrix([[1j]])), B)
+        assert_allclose(expm(matrix([[1j]])), B)
         assert_allclose(expm(csc_matrix([[1j]])).A, B)
 
     def test_bidiagonal_sparse(self):

--- a/scipy/sparse/sputils.py
+++ b/scipy/sparse/sputils.py
@@ -338,3 +338,26 @@ def check_reshape_kwargs(kwargs):
                         .format(', '.join(kwargs.keys())))
     return order, copy
 
+
+###############################################################################
+# Wrappers for NumPy types that are deprecated
+
+def matrix(*args, **kwargs):
+    with warnings.catch_warnings(record=True):
+        warnings.filterwarnings(
+            'ignore', '.*the matrix subclass is not the recommended way.*')
+        return np.matrix(*args, **kwargs)
+
+
+def asmatrix(*args, **kwargs):
+    with warnings.catch_warnings(record=True):
+        warnings.filterwarnings(
+            'ignore', '.*the matrix subclass is not the recommended way.*')
+        return np.asmatrix(*args, **kwargs)
+
+
+def bmat(*args, **kwargs):
+    with warnings.catch_warnings(record=True):
+        warnings.filterwarnings(
+            'ignore', '.*the matrix subclass is not the recommended way.*')
+        return np.bmat(*args, **kwargs)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -26,7 +26,7 @@ from distutils.version import LooseVersion
 
 import numpy as np
 from scipy._lib.six import xrange, zip as izip
-from numpy import (arange, zeros, array, dot, matrix, asmatrix, asarray,
+from numpy import (arange, zeros, array, dot, asarray,
                    vstack, ndarray, transpose, diag, kron, inf, conjugate,
                    int8, ComplexWarning)
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -43,7 +43,8 @@ import scipy.sparse as sparse
 from scipy.sparse import (csc_matrix, csr_matrix, dok_matrix,
         coo_matrix, lil_matrix, dia_matrix, bsr_matrix,
         eye, isspmatrix, SparseEfficiencyWarning, issparse)
-from scipy.sparse.sputils import supported_dtypes, isscalarlike, get_index_dtype
+from scipy.sparse.sputils import (supported_dtypes, isscalarlike,
+                                  get_index_dtype, asmatrix, matrix)
 from scipy.sparse.linalg import splu, expm, inv
 
 from scipy._lib._version import NumpyVersion
@@ -266,7 +267,7 @@ class _TestCommon(object):
     def test_bool_rollover(self):
         # bool's underlying dtype is 1 byte, check that it does not
         # rollover True -> False at 256.
-        dat = np.matrix([[True, False]])
+        dat = matrix([[True, False]])
         datsp = self.spmatrix(dat)
 
         for _ in range(10):
@@ -856,9 +857,9 @@ class _TestCommon(object):
 
     def test_sum(self):
         np.random.seed(1234)
-        dat_1 = np.matrix([[0, 1, 2],
-                           [3, -4, 5],
-                           [-6, 7, 9]])
+        dat_1 = matrix([[0, 1, 2],
+                        [3, -4, 5],
+                        [-6, 7, 9]])
         dat_2 = np.random.rand(5, 5)
         dat_3 = np.array([[]])
         dat_4 = np.zeros((40, 40))
@@ -866,7 +867,7 @@ class _TestCommon(object):
         matrices = [dat_1, dat_2, dat_3, dat_4, dat_5]
 
         def check(dtype, j):
-            dat = np.matrix(matrices[j], dtype=dtype)
+            dat = matrix(matrices[j], dtype=dtype)
             datsp = self.spmatrix(dat, dtype=dtype)
             with np.errstate(over='ignore'):
                 assert_array_almost_equal(dat.sum(), datsp.sum())
@@ -890,10 +891,10 @@ class _TestCommon(object):
                 check(dtype, j)
 
     def test_sum_invalid_params(self):
-        out = np.asmatrix(np.zeros((1, 3)))
-        dat = np.matrix([[0, 1, 2],
-                         [3, -4, 5],
-                         [-6, 7, 9]])
+        out = asmatrix(np.zeros((1, 3)))
+        dat = matrix([[0, 1, 2],
+                      [3, -4, 5],
+                      [-6, 7, 9]])
         datsp = self.spmatrix(dat)
 
         assert_raises(ValueError, datsp.sum, axis=3)
@@ -902,9 +903,9 @@ class _TestCommon(object):
         assert_raises(ValueError, datsp.sum, axis=1, out=out)
 
     def test_sum_dtype(self):
-        dat = np.matrix([[0, 1, 2],
-                         [3, -4, 5],
-                         [-6, 7, 9]])
+        dat = matrix([[0, 1, 2],
+                      [3, -4, 5],
+                      [-6, 7, 9]])
         datsp = self.spmatrix(dat)
 
         def check(dtype):
@@ -918,20 +919,20 @@ class _TestCommon(object):
             check(dtype)
 
     def test_sum_out(self):
-        dat = np.matrix([[0, 1, 2],
-                         [3, -4, 5],
-                         [-6, 7, 9]])
+        dat = matrix([[0, 1, 2],
+                      [3, -4, 5],
+                      [-6, 7, 9]])
         datsp = self.spmatrix(dat)
 
-        dat_out = np.matrix(0)
-        datsp_out = np.matrix(0)
+        dat_out = matrix(0)
+        datsp_out = matrix(0)
 
         dat.sum(out=dat_out)
         datsp.sum(out=datsp_out)
         assert_array_almost_equal(dat_out, datsp_out)
 
-        dat_out = np.asmatrix(np.zeros((3, 1)))
-        datsp_out = np.asmatrix(np.zeros((3, 1)))
+        dat_out = asmatrix(np.zeros((3, 1)))
+        datsp_out = asmatrix(np.zeros((3, 1)))
 
         dat.sum(axis=1, out=dat_out)
         datsp.sum(axis=1, out=datsp_out)
@@ -939,9 +940,9 @@ class _TestCommon(object):
 
     def test_numpy_sum(self):
         # See gh-5987
-        dat = np.matrix([[0, 1, 2],
-                         [3, -4, 5],
-                         [-6, 7, 9]])
+        dat = matrix([[0, 1, 2],
+                      [3, -4, 5],
+                      [-6, 7, 9]])
         datsp = self.spmatrix(dat)
 
         dat_mean = np.sum(dat)
@@ -952,9 +953,9 @@ class _TestCommon(object):
 
     def test_mean(self):
         def check(dtype):
-            dat = np.matrix([[0, 1, 2],
-                            [3, -4, 5],
-                            [-6, 7, 9]], dtype=dtype)
+            dat = matrix([[0, 1, 2],
+                          [3, -4, 5],
+                          [-6, 7, 9]], dtype=dtype)
             datsp = self.spmatrix(dat, dtype=dtype)
 
             assert_array_almost_equal(dat.mean(), datsp.mean())
@@ -975,10 +976,10 @@ class _TestCommon(object):
             check(dtype)
 
     def test_mean_invalid_params(self):
-        out = np.asmatrix(np.zeros((1, 3)))
-        dat = np.matrix([[0, 1, 2],
-                         [3, -4, 5],
-                         [-6, 7, 9]])
+        out = asmatrix(np.zeros((1, 3)))
+        dat = matrix([[0, 1, 2],
+                      [3, -4, 5],
+                      [-6, 7, 9]])
         datsp = self.spmatrix(dat)
 
         assert_raises(ValueError, datsp.mean, axis=3)
@@ -987,9 +988,9 @@ class _TestCommon(object):
         assert_raises(ValueError, datsp.mean, axis=1, out=out)
 
     def test_mean_dtype(self):
-        dat = np.matrix([[0, 1, 2],
-                         [3, -4, 5],
-                         [-6, 7, 9]])
+        dat = matrix([[0, 1, 2],
+                      [3, -4, 5],
+                      [-6, 7, 9]])
         datsp = self.spmatrix(dat)
 
         def check(dtype):
@@ -1003,20 +1004,20 @@ class _TestCommon(object):
             check(dtype)
 
     def test_mean_out(self):
-        dat = np.matrix([[0, 1, 2],
-                         [3, -4, 5],
-                         [-6, 7, 9]])
+        dat = matrix([[0, 1, 2],
+                      [3, -4, 5],
+                      [-6, 7, 9]])
         datsp = self.spmatrix(dat)
 
-        dat_out = np.matrix(0)
-        datsp_out = np.matrix(0)
+        dat_out = matrix(0)
+        datsp_out = matrix(0)
 
         dat.mean(out=dat_out)
         datsp.mean(out=datsp_out)
         assert_array_almost_equal(dat_out, datsp_out)
 
-        dat_out = np.asmatrix(np.zeros((3, 1)))
-        datsp_out = np.asmatrix(np.zeros((3, 1)))
+        dat_out = asmatrix(np.zeros((3, 1)))
+        datsp_out = asmatrix(np.zeros((3, 1)))
 
         dat.mean(axis=1, out=dat_out)
         datsp.mean(axis=1, out=datsp_out)
@@ -1024,9 +1025,9 @@ class _TestCommon(object):
 
     def test_numpy_mean(self):
         # See gh-5987
-        dat = np.matrix([[0, 1, 2],
-                         [3, -4, 5],
-                         [-6, 7, 9]])
+        dat = matrix([[0, 1, 2],
+                      [3, -4, 5],
+                      [-6, 7, 9]])
         datsp = self.spmatrix(dat)
 
         dat_mean = np.mean(dat)
@@ -1150,18 +1151,18 @@ class _TestCommon(object):
         assert_array_equal(self.dat, chk)
         assert_(chk.base is out)
         # Check with out array (matrix).
-        out = np.asmatrix(np.zeros(self.datsp.shape, dtype=self.datsp.dtype))
+        out = asmatrix(np.zeros(self.datsp.shape, dtype=self.datsp.dtype))
         chk = self.datsp.todense(out=out)
         assert_array_equal(self.dat, out)
         assert_array_equal(self.dat, chk)
         assert_(chk is out)
-        a = matrix([1.,2.,3.])
-        dense_dot_dense = a * self.dat
+        a = array([[1.,2.,3.]])
+        dense_dot_dense = a @ self.dat
         check = a * self.datsp.todense()
         assert_array_equal(dense_dot_dense, check)
-        b = matrix([1.,2.,3.,4.]).T
-        dense_dot_dense = self.dat * b
-        check2 = self.datsp.todense() * b
+        b = array([[1.,2.,3.,4.]]).T
+        dense_dot_dense = self.dat @ b
+        check2 = self.datsp.todense() @ b
         assert_array_equal(dense_dot_dense, check2)
         # Check bool data works.
         spbool = self.spmatrix(self.dat, dtype=bool)
@@ -1508,8 +1509,8 @@ class _TestCommon(object):
     def test_rmatvec(self):
         M = self.spmatrix(matrix([[3,0,0],[0,1,0],[2,0,3.0],[2,3,0]]))
         assert_array_almost_equal([1,2,3,4]*M, dot([1,2,3,4], M.toarray()))
-        row = matrix([[1,2,3,4]])
-        assert_array_almost_equal(row*M, row*M.todense())
+        row = array([[1,2,3,4]])
+        assert_array_almost_equal(row * M, row @ M.todense())
 
     def test_small_multiplication(self):
         # test that A*x works for x with shape () (1,) (1,1) and (1,0)
@@ -1557,13 +1558,13 @@ class _TestCommon(object):
         if not TEST_MATMUL:
             pytest.skip("matmul is only tested in Python 3.5+")
 
-        M = self.spmatrix(matrix([[3,0,0],[0,1,0],[2,0,3.0],[2,3,0]]))
-        B = self.spmatrix(matrix([[0,1],[1,0],[0,2]],'d'))
-        col = matrix([1,2,3]).T
+        M = self.spmatrix(array([[3,0,0],[0,1,0],[2,0,3.0],[2,3,0]]))
+        B = self.spmatrix(array([[0,1],[1,0],[0,2]],'d'))
+        col = array([[1,2,3]]).T
 
         # check matrix-vector
         assert_array_almost_equal(operator.matmul(M, col),
-                                  M.todense() * col)
+                                  M.todense() @ col)
 
         # check matrix-matrix
         assert_array_almost_equal(operator.matmul(M, B).todense(),
@@ -1579,8 +1580,8 @@ class _TestCommon(object):
 
     def test_matvec(self):
         M = self.spmatrix(matrix([[3,0,0],[0,1,0],[2,0,3.0],[2,3,0]]))
-        col = matrix([1,2,3]).T
-        assert_array_almost_equal(M * col, M.todense() * col)
+        col = array([[1,2,3]]).T
+        assert_array_almost_equal(M * col, M.todense() @ col)
 
         # check result dimensions (ticket #514)
         assert_equal((M * array([1,2,3])).shape,(4,))
@@ -1589,7 +1590,7 @@ class _TestCommon(object):
 
         # check result type
         assert_(isinstance(M * array([1,2,3]), ndarray))
-        assert_(isinstance(M * matrix([1,2,3]).T, matrix))
+        assert_(isinstance(M * matrix([1,2,3]).T, np.matrix))
 
         # ensure exception is raised for improper dimensions
         bad_vecs = [array([1,2]), array([1,2,3,4]), array([[1],[2]]),
@@ -1623,31 +1624,32 @@ class _TestCommon(object):
         b = matrix([[0,1],[1,0],[0,2]],'d')
         asp = self.spmatrix(a)
         bsp = self.spmatrix(b)
-        assert_array_almost_equal((asp*bsp).todense(), a*b)
-        assert_array_almost_equal(asp*b, a*b)
-        assert_array_almost_equal(a*bsp, a*b)
-        assert_array_almost_equal(a2*bsp, a*b)
+        assert_array_almost_equal((asp*bsp).todense(), a@b)
+        assert_array_almost_equal(asp*b, a@b)
+        assert_array_almost_equal(a*bsp, a@b)
+        assert_array_almost_equal(a2*bsp, a@b)
 
         # Now try performing cross-type multplication:
         csp = bsp.tocsc()
         c = b
-        assert_array_almost_equal((asp*csp).todense(), a*c)
-        assert_array_almost_equal(asp*c, a*c)
+        want = a@c
+        assert_array_almost_equal((asp*csp).todense(), want)
+        assert_array_almost_equal(asp*c, want)
 
-        assert_array_almost_equal(a*csp, a*c)
-        assert_array_almost_equal(a2*csp, a*c)
+        assert_array_almost_equal(a*csp, want)
+        assert_array_almost_equal(a2*csp, want)
         csp = bsp.tocsr()
-        assert_array_almost_equal((asp*csp).todense(), a*c)
-        assert_array_almost_equal(asp*c, a*c)
+        assert_array_almost_equal((asp*csp).todense(), want)
+        assert_array_almost_equal(asp*c, want)
 
-        assert_array_almost_equal(a*csp, a*c)
-        assert_array_almost_equal(a2*csp, a*c)
+        assert_array_almost_equal(a*csp, want)
+        assert_array_almost_equal(a2*csp, want)
         csp = bsp.tocoo()
-        assert_array_almost_equal((asp*csp).todense(), a*c)
-        assert_array_almost_equal(asp*c, a*c)
+        assert_array_almost_equal((asp*csp).todense(), want)
+        assert_array_almost_equal(asp*c, want)
 
-        assert_array_almost_equal(a*csp, a*c)
-        assert_array_almost_equal(a2*csp, a*c)
+        assert_array_almost_equal(a*csp, want)
+        assert_array_almost_equal(a2*csp, want)
 
         # Test provided by Andy Fraser, 2006-03-26
         L = 30
@@ -1662,8 +1664,8 @@ class _TestCommon(object):
 
         A = self.spmatrix(A)
         B = A*A.T
-        assert_array_almost_equal(B.todense(), A.todense() * A.T.todense())
-        assert_array_almost_equal(B.todense(), A.todense() * A.todense().T)
+        assert_array_almost_equal(B.todense(), A.todense() @ A.T.todense())
+        assert_array_almost_equal(B.todense(), A.todense() @ A.todense().T)
 
         # check dimension mismatch 2x2 times 3x2
         A = self.spmatrix([[1,2],[3,4]])
@@ -1726,7 +1728,7 @@ class _TestCommon(object):
         matrices = [dat_1, dat_2]
 
         def check(dtype, j):
-            dat = np.matrix(matrices[j], dtype=dtype)
+            dat = matrix(matrices[j], dtype=dtype)
             datsp = self.spmatrix(dat)
 
             a = datsp.transpose()
@@ -1869,7 +1871,7 @@ class _TestCommon(object):
 
     # test that __iter__ is compatible with NumPy matrix
     def test_iterator(self):
-        B = np.matrix(np.arange(50).reshape(5, 10))
+        B = matrix(np.arange(50).reshape(5, 10))
         A = self.spmatrix(B)
 
         for x, y in zip(A, B):
@@ -1878,13 +1880,13 @@ class _TestCommon(object):
     def test_size_zero_matrix_arithmetic(self):
         # Test basic matrix arithmetic with shapes like (0,0), (10,0),
         # (0, 3), etc.
-        mat = np.matrix([])
+        mat = matrix([])
         a = mat.reshape((0, 0))
         b = mat.reshape((0, 1))
         c = mat.reshape((0, 5))
         d = mat.reshape((1, 0))
         e = mat.reshape((5, 0))
-        f = np.matrix(np.ones([5, 5]))
+        f = matrix(np.ones([5, 5]))
 
         asp = self.spmatrix(a)
         bsp = self.spmatrix(b)
@@ -1934,7 +1936,7 @@ class _TestCommon(object):
         assert_raises(ValueError, bsp.__add__, asp)
 
     def test_size_zero_conversions(self):
-        mat = np.matrix([])
+        mat = matrix([])
         a = mat.reshape((0, 0))
         b = mat.reshape((0, 5))
         c = mat.reshape((5, 0))
@@ -2677,7 +2679,7 @@ class _TestFancyIndexing(object):
         M = 6
         N = 4
 
-        D = np.asmatrix(np.random.rand(M,N))
+        D = asmatrix(np.random.rand(M,N))
         D = np.multiply(D, D > 0.5)
 
         I = np.random.randint(-M + 1, M, size=NUM_SAMPLES)
@@ -2921,7 +2923,7 @@ class _TestFancyMultidim(object):
 
         for I, J in sets:
             np.random.seed(1234)
-            D = np.asmatrix(np.random.rand(5, 7))
+            D = asmatrix(np.random.rand(5, 7))
             S = self.spmatrix(D)
 
             SIJ = S[I,J]
@@ -2944,7 +2946,7 @@ class _TestFancyMultidimAssign(object):
     def test_fancy_assign_ndarray(self):
         np.random.seed(1234)
 
-        D = np.asmatrix(np.random.rand(5, 7))
+        D = asmatrix(np.random.rand(5, 7))
         S = self.spmatrix(D)
         X = np.random.rand(2, 3)
 
@@ -2995,7 +2997,7 @@ class _TestFancyMultidimAssign(object):
     def test_fancy_assign_list(self):
         np.random.seed(1234)
 
-        D = np.asmatrix(np.random.rand(5, 7))
+        D = asmatrix(np.random.rand(5, 7))
         S = self.spmatrix(D)
         X = np.random.rand(2, 3)
 
@@ -3024,7 +3026,7 @@ class _TestFancyMultidimAssign(object):
     def test_fancy_assign_slice(self):
         np.random.seed(1234)
 
-        D = np.asmatrix(np.random.rand(5, 7))
+        D = asmatrix(np.random.rand(5, 7))
         S = self.spmatrix(D)
 
         I = [1, 2, 3, 3, 4, 2]
@@ -3110,7 +3112,8 @@ class _TestArithmetic(object):
         self.__arith_init()
 
         # basic tests
-        assert_array_equal((self.__Asp*self.__Bsp.T).todense(),self.__A*self.__B.T)
+        assert_array_equal((self.__Asp*self.__Bsp.T).todense(),
+                           self.__A @ self.__B.T)
 
         for x in supported_dtypes:
             A = self.__A.astype(x)
@@ -3122,7 +3125,7 @@ class _TestArithmetic(object):
                     B = self.__B.real.astype(y)
                 Bsp = self.spmatrix(B)
 
-                D1 = A * B.T
+                D1 = A @ B.T
                 S1 = Asp * Bsp.T
 
                 assert_allclose(S1.todense(), D1,
@@ -3179,7 +3182,7 @@ class _TestMinMax(object):
             assert_raises(ValueError, X.max)
 
     def test_minmax_axis(self):
-        D = np.matrix(np.arange(50).reshape(5,10))
+        D = matrix(np.arange(50).reshape(5,10))
         # completely empty rows, leaving some completely full:
         D[1, :] = 0
         # empty at end for reduceat:
@@ -3196,14 +3199,14 @@ class _TestMinMax(object):
             assert_array_equal(X.min(axis=axis).A, D.min(axis=axis).A)
 
         # full matrix
-        D = np.matrix(np.arange(1, 51).reshape(10, 5))
+        D = matrix(np.arange(1, 51).reshape(10, 5))
         X = self.spmatrix(D)
         for axis in axes:
             assert_array_equal(X.max(axis=axis).A, D.max(axis=axis).A)
             assert_array_equal(X.min(axis=axis).A, D.min(axis=axis).A)
 
         # empty matrix
-        D = np.matrix(np.zeros((10, 5)))
+        D = matrix(np.zeros((10, 5)))
         X = self.spmatrix(D)
         for axis in axes:
             assert_array_equal(X.max(axis=axis).A, D.max(axis=axis).A)
@@ -3232,9 +3235,9 @@ class _TestMinMax(object):
             assert_array_equal(np.zeros((1, 0)), X.max(axis=axis).A)
 
     def test_minmax_invalid_params(self):
-        dat = np.matrix([[0, 1, 2],
-                         [3, -4, 5],
-                         [-6, 7, 9]])
+        dat = matrix([[0, 1, 2],
+                      [3, -4, 5],
+                      [-6, 7, 9]])
         datsp = self.spmatrix(dat)
 
         for fname in ('min', 'max'):
@@ -3249,9 +3252,9 @@ class _TestMinMax(object):
         # xref gh-7460 in 'numpy'
         from scipy.sparse import data
 
-        dat = np.matrix([[0, 1, 2],
-                         [3, -4, 5],
-                         [-6, 7, 9]])
+        dat = matrix([[0, 1, 2],
+                      [3, -4, 5],
+                      [-6, 7, 9]])
         datsp = self.spmatrix(dat)
 
         # We are only testing sparse matrices who have
@@ -3279,14 +3282,14 @@ class _TestMinMax(object):
             assert_equal(mat.argmin(), np.argmin(D))
 
             assert_equal(mat.argmax(axis=0),
-                         np.asmatrix(np.argmax(D, axis=0)))
+                         asmatrix(np.argmax(D, axis=0)))
             assert_equal(mat.argmin(axis=0),
-                         np.asmatrix(np.argmin(D, axis=0)))
+                         asmatrix(np.argmin(D, axis=0)))
 
             assert_equal(mat.argmax(axis=1),
-                         np.asmatrix(np.argmax(D, axis=1).reshape(-1, 1)))
+                         asmatrix(np.argmax(D, axis=1).reshape(-1, 1)))
             assert_equal(mat.argmin(axis=1),
-                         np.asmatrix(np.argmin(D, axis=1).reshape(-1, 1)))
+                         asmatrix(np.argmin(D, axis=1).reshape(-1, 1)))
 
         D1 = np.empty((0, 5))
         D2 = np.empty((5, 0))
@@ -3304,9 +3307,9 @@ class _TestMinMax(object):
 
 class _TestGetNnzAxis(object):
     def test_getnnz_axis(self):
-        dat = np.matrix([[0, 2],
-                        [3, 5],
-                        [-6, 9]])
+        dat = matrix([[0, 2],
+                     [3, 5],
+                     [-6, 9]])
         bool_dat = dat.astype(bool).A
         datsp = self.spmatrix(dat)
 
@@ -3537,7 +3540,7 @@ class TestCSR(sparse_test_class()):
         J = np.array([3, 4, 2])
 
         np.random.seed(1234)
-        D = np.asmatrix(np.random.rand(5, 7))
+        D = asmatrix(np.random.rand(5, 7))
         S = self.spmatrix(D)
 
         SIJ = S[I,J]
@@ -3740,7 +3743,7 @@ class TestCSC(sparse_test_class()):
         J = np.array([3, 4, 2])
 
         np.random.seed(1234)
-        D = np.asmatrix(np.random.rand(5, 7))
+        D = asmatrix(np.random.rand(5, 7))
         S = self.spmatrix(D)
 
         SIJ = S[I,J]
@@ -3882,15 +3885,15 @@ class TestLIL(sparse_test_class(minmax=False)):
     math_dtypes = [np.int_, np.float_, np.complex_]
 
     def test_dot(self):
-        A = matrix(zeros((10,10)))
+        A = zeros((10,10), np.complex)
         A[0,3] = 10
-        A[5,6] = 20
+        A[5,6] = 20j
 
-        B = lil_matrix((10,10))
+        B = lil_matrix((10,10), dtype=np.complex)
         B[0,3] = 10
-        B[5,6] = 20
-        assert_array_equal(A * A.T, (B * B.T).todense())
-        assert_array_equal(A * A.H, (B * B.H).todense())
+        B[5,6] = 20j
+        assert_array_equal(A @ A.T, (B * B.T).todense())
+        assert_array_equal(A @ A.conjugate().T, (B * B.H).todense())
 
     def test_scalar_mul(self):
         x = lil_matrix((3,3))
@@ -4266,12 +4269,12 @@ class TestBSR(sparse_test_class(getset=False,
     def test_bsr_matvec(self):
         A = bsr_matrix(arange(2*3*4*5).reshape(2*4,3*5), blocksize=(4,5))
         x = arange(A.shape[1]).reshape(-1,1)
-        assert_equal(A*x, A.todense()*x)
+        assert_equal(A*x, A.todense() @ x)
 
     def test_bsr_matvecs(self):
         A = bsr_matrix(arange(2*3*4*5).reshape(2*4,3*5), blocksize=(4,5))
         x = arange(A.shape[1]*6).reshape(-1,6)
-        assert_equal(A*x, A.todense()*x)
+        assert_equal(A*x, A.todense() @ x)
 
     @pytest.mark.xfail(run=False, reason='BSR does not have a __getitem__')
     def test_iterator(self):

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -3,17 +3,16 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy import array, matrix
+from numpy import array
 from numpy.testing import (assert_equal, assert_,
         assert_array_equal, assert_array_almost_equal_nulp)
 import pytest
 from pytest import raises as assert_raises
 from scipy._lib._testutils import check_free_memory
 
-from scipy.sparse import csr_matrix, coo_matrix
-
-from scipy.sparse import construct
+from scipy.sparse import csr_matrix, coo_matrix, construct
 from scipy.sparse.construct import rand as sprand
+from scipy.sparse.sputils import matrix
 
 sparse_formats = ['csr','csc','coo','bsr','dia','lil','dok']
 

--- a/scipy/sparse/tests/test_sparsetools.py
+++ b/scipy/sparse/tests/test_sparsetools.py
@@ -3,18 +3,18 @@ from __future__ import division, print_function, absolute_import
 import sys
 import os
 import gc
-import re
 import threading
 
 import numpy as np
 from numpy.testing import assert_equal, assert_, assert_allclose
 from scipy.sparse import (_sparsetools, coo_matrix, csr_matrix, csc_matrix,
                           bsr_matrix, dia_matrix)
-from scipy.sparse.sputils import supported_dtypes
+from scipy.sparse.sputils import supported_dtypes, matrix
 from scipy._lib._testutils import check_free_memory
 
 import pytest
 from pytest import raises as assert_raises
+
 
 def test_exception():
     assert_raises(MemoryError, _sparsetools.test_throw_error)
@@ -55,7 +55,7 @@ def test_regression_std_vector_dtypes():
     # Regression test for gh-3780, checking the std::vector typemaps
     # in sparsetools.cxx are complete.
     for dtype in supported_dtypes:
-        ad = np.matrix([[1, 2], [3, 4]]).astype(dtype)
+        ad = matrix([[1, 2], [3, 4]]).astype(dtype)
         a = csr_matrix(ad, dtype=dtype)
 
         # getcol is one function using std::vector typemaps, and should not fail

--- a/scipy/sparse/tests/test_spfuncs.py
+++ b/scipy/sparse/tests/test_spfuncs.py
@@ -1,12 +1,13 @@
 from __future__ import division, print_function, absolute_import
 
-from numpy import array, kron, matrix, diag
+from numpy import array, kron, diag
 from numpy.testing import assert_, assert_equal
 
 from scipy.sparse import spfuncs
 from scipy.sparse import csr_matrix, csc_matrix, bsr_matrix
 from scipy.sparse._sparsetools import (csr_scale_rows, csr_scale_columns,
                                        bsr_scale_rows, bsr_scale_columns)
+from scipy.sparse.sputils import matrix
 
 
 class TestSparseFunctions(object):
@@ -24,30 +25,30 @@ class TestSparseFunctions(object):
         S = csr_matrix(D)
         v = array([1,2,3,4,5])
         csr_scale_columns(3,5,S.indptr,S.indices,S.data,v)
-        assert_equal(S.todense(), D*diag(v))
+        assert_equal(S.todense(), D@diag(v))
 
         # blocks
         E = kron(D,[[1,2],[3,4]])
         S = bsr_matrix(E,blocksize=(2,2))
         v = array([1,2,3,4,5,6])
         bsr_scale_rows(3,5,2,2,S.indptr,S.indices,S.data,v)
-        assert_equal(S.todense(), diag(v)*E)
+        assert_equal(S.todense(), diag(v)@E)
 
         S = bsr_matrix(E,blocksize=(2,2))
         v = array([1,2,3,4,5,6,7,8,9,10])
         bsr_scale_columns(3,5,2,2,S.indptr,S.indices,S.data,v)
-        assert_equal(S.todense(), E*diag(v))
+        assert_equal(S.todense(), E@diag(v))
 
         E = kron(D,[[1,2,3],[4,5,6]])
         S = bsr_matrix(E,blocksize=(2,3))
         v = array([1,2,3,4,5,6])
         bsr_scale_rows(3,5,2,3,S.indptr,S.indices,S.data,v)
-        assert_equal(S.todense(), diag(v)*E)
+        assert_equal(S.todense(), diag(v)@E)
 
         S = bsr_matrix(E,blocksize=(2,3))
         v = array([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15])
         bsr_scale_columns(3,5,2,3,S.indptr,S.indices,S.data,v)
-        assert_equal(S.todense(), E*diag(v))
+        assert_equal(S.todense(), E@diag(v))
 
     def test_estimate_blocksize(self):
         mats = []

--- a/scipy/sparse/tests/test_sputils.py
+++ b/scipy/sparse/tests/test_sputils.py
@@ -3,9 +3,10 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import assert_equal, assert_raises
+from numpy.testing import assert_equal
 from pytest import raises as assert_raises
 from scipy.sparse import sputils
+from scipy.sparse.sputils import matrix
 from scipy._lib._numpy_compat import suppress_warnings
 
 
@@ -84,7 +85,7 @@ class TestSparseUtils(object):
 
     def test_isdense(self):
         assert_equal(sputils.isdense(np.array([1])), True)
-        assert_equal(sputils.isdense(np.matrix([1])), True)
+        assert_equal(sputils.isdense(matrix([1])), True)
 
     def test_validateaxis(self):
         assert_raises(TypeError, sputils.validateaxis, (0, 1))

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -31,6 +31,7 @@ from scipy._lib._version import NumpyVersion
 from scipy._lib.six import xrange
 from .common_tests import check_named_results
 from scipy.special import kv
+from scipy.sparse.sputils import matrix
 from scipy.integrate import quad
 
 """ Numbers in docstrings beginning with 'W' refer to the section numbers
@@ -3621,14 +3622,14 @@ class TestHarMean(object):
     def test_2d_matrix_axis0(self):
         #  Test a 2d list with axis=0
         a = [[10, 20, 30, 40], [50, 60, 70, 80], [90, 100, 110, 120]]
-        desired = np.matrix([[22.88135593, 39.13043478, 52.90076336, 65.45454545]])
-        check_equal_hmean(np.matrix(a), desired, axis=0)
+        desired = matrix([[22.88135593, 39.13043478, 52.90076336, 65.45454545]])
+        check_equal_hmean(matrix(a), desired, axis=0)
 
     def test_2d_matrix_axis1(self):
         #  Test a 2d list with axis=1
         a = [[10, 20, 30, 40], [50, 60, 70, 80], [90, 100, 110, 120]]
-        desired = np.matrix([[19.2, 63.03939962, 103.80078637]]).T
-        check_equal_hmean(np.matrix(a), desired, axis=1)
+        desired = matrix([[19.2, 63.03939962, 103.80078637]]).T
+        check_equal_hmean(matrix(a), desired, axis=1)
 
 
 class TestGeoMean(object):
@@ -3689,27 +3690,27 @@ class TestGeoMean(object):
     def test_2d_matrix_axis0(self):
         #  Test a 2d list with axis=0
         a = [[10, 20, 30, 40], [50, 60, 70, 80], [90, 100, 110, 120]]
-        desired = np.matrix([[35.56893304, 49.32424149, 61.3579244, 72.68482371]])
-        check_equal_gmean(np.matrix(a), desired, axis=0)
+        desired = matrix([[35.56893304, 49.32424149, 61.3579244, 72.68482371]])
+        check_equal_gmean(matrix(a), desired, axis=0)
 
         a = array([[1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4]])
-        desired = np.matrix([1, 2, 3, 4])
-        check_equal_gmean(np.matrix(a), desired, axis=0, rtol=1e-14)
+        desired = matrix([1, 2, 3, 4])
+        check_equal_gmean(matrix(a), desired, axis=0, rtol=1e-14)
 
         a = array([[1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4]])
-        desired = np.matrix(stats.gmean(a, axis=0))
-        check_equal_gmean(np.matrix(a), desired, axis=0, rtol=1e-14)
+        desired = matrix(stats.gmean(a, axis=0))
+        check_equal_gmean(matrix(a), desired, axis=0, rtol=1e-14)
 
     def test_2d_matrix_axis1(self):
         #  Test a 2d list with axis=1
         a = [[10, 20, 30, 40], [50, 60, 70, 80], [90, 100, 110, 120]]
-        desired = np.matrix([[22.13363839, 64.02171746, 104.40086817]]).T
-        check_equal_gmean(np.matrix(a), desired, axis=1)
+        desired = matrix([[22.13363839, 64.02171746, 104.40086817]]).T
+        check_equal_gmean(matrix(a), desired, axis=1)
 
         a = array([[1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4]])
         v = power(1 * 2 * 3 * 4, 1. / 4.)
-        desired = np.matrix([[v], [v], [v]])
-        check_equal_gmean(np.matrix(a), desired, axis=1, rtol=1e-14)
+        desired = matrix([[v], [v], [v]])
+        check_equal_gmean(matrix(a), desired, axis=1, rtol=1e-14)
 
     def test_large_values(self):
         a = array([1e100, 1e200, 1e300])


### PR DESCRIPTION
If we know we are going to fix the `np.matrix` PendingDeprecationWarning, then our users should not need to see it. This PR:

1. Makes internal `matrix`, `asmatrix`, and `bmat` functions in `scipy.sparse.sputils` that wrap to NumPy calls, but do so while catching the PendingDeprecationWarning.
2. Eliminates a few uses of `matrix` in tests where they were not necessary.
3. Translates other uses of `matrix` where they might have been necessary (I tried to be conservative and not guess too much) to use `scipy.sparse.sputils.matrix`.
4. Removes the `filterwarnings` from our `pytest.ini`.

This approach also has the advantage that we can easily in the future see everywhere we use `np.matrix` by doing a suitable grep for `from scipy.sparse.sputils import .*matrix.*` or so.

Closes #9734.