### PR TITLE
TST: bump Azure CI OpenBLAS version to match wheels

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,6 +6,10 @@ trigger:
       - master
       - maintenance/*
 
+# the version of OpenBLAS used is currently 0.3.5.dev
+# despite the numbering on the downloaded files
+# and should be updated to match scipy-wheels as appropriate
+
 jobs:
 - job: Linux_Python_36_32bit_full
   pool:
@@ -23,8 +27,8 @@ jobs:
            apt-get -y install gfortran-5 wget && \
            cd .. && \
            mkdir openblas && cd openblas && \
-           wget https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-0.3.0-Linux-i686.tar.gz && \
-           tar zxvf openblas-0.3.0-Linux-i686.tar.gz && \
+           wget https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.3-186-g701ea883-manylinux1_i686.tar.gz && \
+           tar zxvf openblas-v0.3.3-186-g701ea883-manylinux1_i686.tar.gz && \
            cp -r ./usr/local/lib/* /usr/lib && \
            cp ./usr/local/include/* /usr/include && \
            cd ../scipy && \
@@ -38,8 +42,8 @@ jobs:
   pool:
     vmImage: 'VS2017-Win2016'
   variables:
-      OPENBLAS_32: https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-5f998ef_gcc7_1_0_win32.zip
-      OPENBLAS_64: https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-5f998ef_gcc7_1_0_win64.zip
+      OPENBLAS_32: https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.3-186-g701ea883-win32-gcc_7_1_0.zip
+      OPENBLAS_64: https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.3-186-g701ea883-win_amd64-gcc_7_1_0.zip
   strategy:
     maxParallel: 4
     matrix:
@@ -84,14 +88,18 @@ jobs:
       Write-Host "Python Version: $pyversion"
       $target = "C:\\hostedtoolcache\\windows\\Python\\$pyversion\\$(PYTHON_ARCH)\\lib\\openblas.a"
       Write-Host "target path: $target"
-      cp $tmpdir\$(BITS)\lib\libopenblas_5f998ef_gcc7_1_0.a $target
+      cp $tmpdir\$(BITS)\lib\libopenblas_v0.3.3-186-g701ea883-gcc_7_1_0.a $target
     displayName: 'Download / Install OpenBLAS'
   - powershell: |
-      # NOTE: can probably (eventually) abstract this 
-      # upstream in Microsoft repo to support x86 natively
-      choco install -y mingw --forcex86 --force --version=5.3.0
+      # wheels appear to use mingw64 version 6.3.0, but 6.4.0
+      # is the closest match available from choco package manager
+      choco install -y mingw --forcex86 --force --version=6.4.0
     displayName: 'Install 32-bit mingw for 32-bit builds'
     condition: eq(variables['BITS'], 32)
+  - powershell: |
+      choco install -y mingw --force --version=6.4.0
+    displayName: 'Install 64-bit mingw for 64-bit builds'
+    condition: eq(variables['BITS'], 64)
   - script: python -m pip install numpy cython==0.29.2 pytest pytest-timeout pytest-xdist pytest-env pytest-faulthandler Pillow mpmath matplotlib
     displayName: 'Install dependencies'
   - powershell: |
@@ -102,9 +110,9 @@ jobs:
           $env:NPY_DISTUTILS_APPEND_FLAGS = 1
           $env:CFLAGS = "-m32"
           $env:LDFLAGS = "-m32"
-          $env:PATH = "C:\\tools\\mingw32\\bin;" + $env:PATH
           refreshenv
       }
+      $env:PATH = "C:\\ProgramData\\chocolatey\\lib\\mingw\\tools\\install\\mingw$(BITS)\\bin;" + $env:PATH
 
       mkdir dist
       pip wheel --no-build-isolation -v -v -v --wheel-dir=dist .
@@ -112,7 +120,9 @@ jobs:
           pip install $_.FullName
       }
     displayName: 'Build SciPy'
-  - script: python runtests.py -n --mode=$(TEST_MODE) -- -n auto -rsx --junitxml=junit/test-results.xml
+  - powershell: |
+      $env:PATH = "C:\\ProgramData\\chocolatey\\lib\\mingw\\tools\\install\\mingw$(BITS)\\bin;" + $env:PATH
+      python runtests.py -n --mode=$(TEST_MODE) -- -n auto -rsx --junitxml=junit/test-results.xml
     displayName: 'Run SciPy Test Suite'
   - task: PublishTestResults@2
     inputs:


### PR DESCRIPTION
Bump development OpenBLAS Azure CI versions to reduce dissonance with the wheel builds. The wheels were recently bumped to OpenBLAS version `0.3.5.dev`.

The version numbers on the files themselves can be a little deceptive--there's a separate effort in NumPy to get the true OpenBLAS version numbers accessible from numpy-distutils, but it isn't ready just yet.