### PR TITLE
DOC: Improve clarity of cov_x documentation for scipy.optimize.leastsq

### DIFF
--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -323,7 +323,7 @@ def leastsq(func, x0, args=(), Dfun=None, full_output=0,
     cov_x : ndarray
         The inverse of the Hessian. fjac and ipvt are used to construct an
         estimate of the Hessian. A value of None indicates a singular matrix,
-        which may indicate very flat curvature in parameters x. To obtain
+        which means the curvature in parameters x is numerically flat. To obtain
         the covariance matrix of the parameters x, cov_x must be multiplied
         by the variance of the residuals -- see curve_fit.
     infodict : dict

--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -321,11 +321,11 @@ def leastsq(func, x0, args=(), Dfun=None, full_output=0,
         The solution (or the result of the last iteration for an unsuccessful
         call).
     cov_x : ndarray
-        The inverse of the Hessian. fjac and ipvt are used to construct an
+        The inverse of the Hessian. `fjac` and `ipvt` are used to construct an
         estimate of the Hessian. A value of None indicates a singular matrix,
-        which means the curvature in parameters x is numerically flat. To obtain
-        the covariance matrix of the parameters x, cov_x must be multiplied
-        by the variance of the residuals -- see curve_fit.
+        which means the curvature in parameters `x` is numerically flat. To
+        obtain the covariance matrix of the parameters `x`, `cov_x` must be
+        multiplied by the variance of the residuals -- see curve_fit.
     infodict : dict
         a dictionary of optional outputs with the keys:
 

--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -321,14 +321,13 @@ def leastsq(func, x0, args=(), Dfun=None, full_output=0,
         The solution (or the result of the last iteration for an unsuccessful
         call).
     cov_x : ndarray
-        Uses the fjac and ipvt optional outputs to construct an
-        estimate of the jacobian around the solution. None if a
-        singular matrix encountered (indicates very flat curvature in
-        some direction).  This matrix must be multiplied by the
-        residual variance to get the covariance of the
-        parameter estimates -- see curve_fit.
+        The inverse of the Hessian. fjac and ipvt are used to construct an
+        estimate of the Hessian. A value of None indicates a singular matrix,
+        which may indicate very flat curvature in parameters x. To obtain
+        the covariance matrix of the parameters x, cov_x must be multiplied
+        by the variance of the residuals -- see curve_fit.
     infodict : dict
-        a dictionary of optional outputs with the key s:
+        a dictionary of optional outputs with the keys:
 
         ``nfev``
             The number of function calls


### PR DESCRIPTION
Updated the documentation for `cov_x` to clarify what `cov_x` is. The existing docstring for `cov_x` was a bit unclear and didn't use common terminology. Updated docstring is more explicit and clear.