### PR TITLE
MAINT: Skip parallel tests on PyPy

### DIFF
--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -3,7 +3,6 @@ Unit tests for the differential global minimization algorithm.
 """
 import sys
 
-from scipy.optimize import _differentialevolution
 from scipy.optimize._differentialevolution import DifferentialEvolutionSolver
 from scipy.optimize import differential_evolution
 import numpy as np
@@ -12,6 +11,7 @@ from numpy.testing import (assert_equal, assert_allclose,
                            assert_almost_equal,
                            assert_string_equal, assert_)
 from pytest import raises as assert_raises, warns
+import pytest
 
 IS_PYPY = '__pypy__' in sys.modules
 

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -1,6 +1,8 @@
 """
 Unit tests for the differential global minimization algorithm.
 """
+import sys
+
 from scipy.optimize import _differentialevolution
 from scipy.optimize._differentialevolution import DifferentialEvolutionSolver
 from scipy.optimize import differential_evolution
@@ -10,6 +12,8 @@ from numpy.testing import (assert_equal, assert_allclose,
                            assert_almost_equal,
                            assert_string_equal, assert_)
 from pytest import raises as assert_raises, warns
+
+IS_PYPY = '__pypy__' in sys.modules
 
 
 class TestDifferentialEvolutionSolver(object):
@@ -512,6 +516,8 @@ class TestDifferentialEvolutionSolver(object):
         assert_(solver._mapwrapper._mapfunc is map)
         solver.solve()
 
+    @pytest.mark.skipif(IS_PYPY,
+                        reason="Parallel test might not be stable on PyPy")
     def test_immediate_updating(self):
         # check setting of immediate updating, with default workers
         bounds = [(0., 2.), (0., 2.)]
@@ -524,6 +530,8 @@ class TestDifferentialEvolutionSolver(object):
             solver = DifferentialEvolutionSolver(rosen, bounds, workers=2)
             assert_(solver._updating == 'deferred')
 
+    @pytest.mark.skipif(IS_PYPY,
+                        reason="Parallel test might not be stable on PyPy")
     def test_parallel(self):
         # smoke test for parallelisation with deferred updating
         bounds = [(0., 2.), (0., 2.)]

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -1,6 +1,7 @@
 """
 Unit tests for the differential global minimization algorithm.
 """
+import multiprocessing
 import sys
 
 from scipy.optimize._differentialevolution import DifferentialEvolutionSolver
@@ -541,6 +542,17 @@ class TestDifferentialEvolutionSolver(object):
             assert_(solver._mapwrapper.pool is not None)
             assert_(solver._updating == 'deferred')
             solver.solve()
+
+    def test_parallel_pool(self):
+        # parallelisation test with Pool, which might work better with pypy
+        bounds = [(0., 2.), (0., 2.)]
+        with multiprocessing.Pool(2) as p:
+            with DifferentialEvolutionSolver(rosen, bounds,
+                                             updating='deferred',
+                                             workers=p.map) as solver:
+                assert solver._mapwrapper.pool is not None
+                assert solver._updating == 'deferred'
+                solver.solve()
 
     def test_converged(self):
         solver = DifferentialEvolutionSolver(rosen, [(0, 2), (0, 2)])

--- a/scipy/optimize/tests/test__dual_annealing.py
+++ b/scipy/optimize/tests/test__dual_annealing.py
@@ -248,7 +248,8 @@ class TestDualAnnealing(TestCase):
             'method': 'SLSQP',
         }
         ret = dual_annealing(self.func, self.ld_bounds,
-                             local_search_options=minimizer_opts)
+                             local_search_options=minimizer_opts,
+                             seed=self.seed)
         assert_allclose(ret.fun, 0., atol=1e-7)
 
     def test_wrong_restart_temp(self):


### PR DESCRIPTION
A variant of the fix suggested by @andyfaff in #9763 to work around the PyPy timeout failures.