### PR TITLE
TEST: limit pypy to 2 verbose runners, fix numpy install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,8 +132,7 @@ jobs:
             export NPY_NUM_BUILD_JOBS=`pypy3 -c 'import multiprocessing as mp; print(mp.cpu_count())'`
             pypy3 -mpip install --upgrade pip setuptools wheel
             pypy3 -mpip install Cython>=0.28.5
-            pypy3 -mpip install numpy>=1.15.0
-            pypy3 -mpip install --no-build-isolation --extra-index https://antocuni.github.io/pypy-wheels/ubuntu pytest pytest-xdist pytest-timeout Tempita mpmath
+            pypy3 -mpip install --no-build-isolation --extra-index https://antocuni.github.io/pypy-wheels/ubuntu pytest pytest-xdist pytest-timeout Tempita mpmath numpy>=1.15.0
       - run:
           name: build SciPy
           command: |
@@ -155,7 +154,7 @@ jobs:
             export SCIPY_AVAILABLE_MEM=1G
             # Try to limit per-process GC memory usage
             export PYPY_GC_MAX=900MB
-            pypy3 runtests.py -- -rfEX -n 3 --durations=30 --timeout=45 --timeout-method=thread
+            pypy3 runtests.py -- -rfEX -n 2 --durations=30 --timeout=45 --timeout-method=thread -v
 
 
 workflows:


### PR DESCRIPTION
PyPy seems to run 92% of the tests and randomly fail. I cannot reproduce this locally. The circleCI instances are limited to 4GB. This PR 
- reduces the number of parallel test runs to 2 in the hope that the crashes are due to MemoryError
- adds `-v` to hpoefully output more information about why the crash, and
- moves the numpy pip install to the line with the PyPI repo for the numpy wheels, so installating numpy from the wheels not from source