### PR TITLE
TST: xfail problematic test for 1.2.x LTS branch

### DIFF
--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -10,6 +10,7 @@ from scipy.interpolate import (BSpline, BPoly, PPoly, make_interp_spline,
         make_lsq_spline, _bspl, splev, splrep, splprep, splder, splantider,
          sproot, splint, insert)
 import scipy.linalg as sl
+from scipy._lib._version import NumpyVersion
 
 from scipy.interpolate._bsplines import _not_a_knot, _augknt
 import scipy.interpolate._fitpack_impl as _impl
@@ -614,6 +615,8 @@ class TestInterop(object):
         b = BSpline(*tck)
         assert_allclose(y, b(x), atol=1e-15)
 
+    @pytest.mark.xfail(NumpyVersion(np.__version__) < '1.14.0',
+                       reason='requires NumPy >= 1.14.0')
     def test_splrep_errors(self):
         # test that both "old" and "new" splrep raise for an n-D ``y`` array
         # with n > 1


### PR DESCRIPTION
Related to #9777, but I'll want to keep that issue open for now for a more detailed fix / consideration on master branch.

This is the only failing test both locally and in wheel builds when `1.2.1` is built with NumPy < `1.14.0`. The bisection of NumPy hashes / analysis is available in the linked issue.