### PR TITLE
TST, BUG: f2py-related issues with NumPy < 1.14.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -152,21 +152,8 @@ before_install:
   - travis_retry pip install --upgrade pytest pytest-xdist pytest-faulthandler mpmath argparse Pillow codecov
   - travis_retry pip install gmpy2  # speeds up mpmath (scipy.special tests)
   - |
-    if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      # optional sparse.linalg dependency (test linux only, no suitesparse installed on osx)
-      if [ -z "$NUMPYSPEC" ]; then
-          # numpy must be installed to build scikit-umfpack
-          travis_retry pip install numpy
-      fi
-      travis_retry pip install scikit-umfpack
-      if [ -z "$NUMPYSPEC" ]; then
-          # cleanup after ourselves
-          travis_retry pip uninstall -y numpy
-      fi
-    fi
-  - |
     if [ "${TESTMODE}" == "full" ]; then
-        travis_retry pip install pytest-cov coverage matplotlib
+        travis_retry pip install pytest-cov coverage matplotlib scikit-umfpack
     fi
   - |
     if [ "${REFGUIDE_CHECK}" == "1" ]; then

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -10,6 +10,7 @@ from scipy.interpolate import (BSpline, BPoly, PPoly, make_interp_spline,
         make_lsq_spline, _bspl, splev, splrep, splprep, splder, splantider,
          sproot, splint, insert)
 import scipy.linalg as sl
+from scipy._lib._version import NumpyVersion
 
 from scipy.interpolate._bsplines import _not_a_knot, _augknt
 import scipy.interpolate._fitpack_impl as _impl
@@ -614,6 +615,8 @@ class TestInterop(object):
         b = BSpline(*tck)
         assert_allclose(y, b(x), atol=1e-15)
 
+    @pytest.mark.xfail(NumpyVersion(np.__version__) < '1.14.0',
+                       reason='requires NumPy >= 1.14.0')
     def test_splrep_errors(self):
         # test that both "old" and "new" splrep raise for an n-D ``y`` array
         # with n > 1


### PR DESCRIPTION
Related to #9777 & #9784.

~Definitely a WIP. Just adds an older NumPy build to the Azure matrix at the moment, but I should probably swap that to 64-bit and use a sub-matrix entry or something. The 32-bit addition here also updates openblas to the most recent for that job, and seems to only show the original failure reported for the LTS branch.~

~Maybe the damage is minimized somewhat with the older gfortran & wheel-matched openblas vs. what I may use locally and / or the 64 vs. 32-bit.~

Anyway, this should show some kind of failure on CI related to the older NumPy for initial demo.