### PR TITLE
TST: close mat file, avoiding ResourceWarning

### DIFF
--- a/scipy/io/matlab/mio.py
+++ b/scipy/io/matlab/mio.py
@@ -29,7 +29,9 @@ def _open_file(file_like, appendmat, mode='rb'):
     to open(). If that fails, and `file_like` is a string, and `appendmat` is true,
     append '.mat' and try again.
     """
-    if hasattr(file_like, 'read') and hasattr(file_like, 'write'):
+    if hasattr(file_like, 'read'):
+        if 'w' in mode and hasattr(file_like, 'write') is False:
+            raise IOError("The file-like object does not have a write attribute")
         return file_like, False
 
     try:

--- a/scipy/io/matlab/mio.py
+++ b/scipy/io/matlab/mio.py
@@ -29,9 +29,10 @@ def _open_file(file_like, appendmat, mode='rb'):
     to open(). If that fails, and `file_like` is a string, and `appendmat` is true,
     append '.mat' and try again.
     """
-    if hasattr(file_like, 'read'):
-        if 'w' in mode and hasattr(file_like, 'write') is False:
-            raise IOError("The file-like object does not have a write attribute")
+    reqs = {'read'} if set(mode) & set('r+') else set()
+    if set(mode) & set('wax+'):
+        reqs.add('write')
+    if reqs.issubset(dir(file_like)):
         return file_like, False
 
     try:

--- a/scipy/io/matlab/mio.py
+++ b/scipy/io/matlab/mio.py
@@ -30,10 +30,6 @@ def _open_file(file_like, appendmat, mode='rb'):
     append '.mat' and try again.
     """
     if hasattr(file_like, 'read') and hasattr(file_like, 'write'):
-        # can't use file_like.read(0) to see if something is a file-like
-        # this is now being used to open a file for writing ('wb') and
-        # the resulting file may be write only.
-        # file_like.read(0)
         return file_like, False
 
     try:

--- a/scipy/io/matlab/mio.py
+++ b/scipy/io/matlab/mio.py
@@ -29,15 +29,12 @@ def _open_file(file_like, appendmat, mode='rb'):
     to open(). If that fails, and `file_like` is a string, and `appendmat` is true,
     append '.mat' and try again.
     """
-    try:
-        if hasattr(file_like, 'read') and hasattr(file_like, 'write'):
-            # can't use file_like.read(0) to see if something is a file-like
-            # this is now being used to open a file for writing ('wb') and
-            # the resulting file may be write only.
-            # file_like.read(0)
-            return file_like, False
-    except AttributeError:
-        pass
+    if hasattr(file_like, 'read') and hasattr(file_like, 'write'):
+        # can't use file_like.read(0) to see if something is a file-like
+        # this is now being used to open a file for writing ('wb') and
+        # the resulting file may be write only.
+        # file_like.read(0)
+        return file_like, False
 
     try:
         return open(file_like, mode), True

--- a/scipy/io/matlab/mio.py
+++ b/scipy/io/matlab/mio.py
@@ -4,7 +4,7 @@ Module for reading and writing matlab (TM) .mat files
 # Authors: Travis Oliphant, Matthew Brett
 
 from __future__ import division, print_function, absolute_import
-
+from contextlib import contextmanager
 from scipy._lib.six import string_types
 
 from .miobase import get_matfile_version, docfiller
@@ -14,7 +14,15 @@ from .mio5 import MatFile5Reader, MatFile5Writer
 __all__ = ['mat_reader_factory', 'loadmat', 'savemat', 'whosmat']
 
 
-def _open_file(file_like, appendmat):
+@contextmanager
+def _open_file_context(file_like, appendmat, mode='rb'):
+    f, opened = _open_file(file_like, appendmat, mode)
+    yield f
+    if opened:
+        f.close()
+
+
+def _open_file(file_like, appendmat, mode='rb'):
     """
     Open `file_like` and return as file-like object. First, check if object is
     already file-like; if so, return it as-is. Otherwise, try to pass it
@@ -22,21 +30,26 @@ def _open_file(file_like, appendmat):
     append '.mat' and try again.
     """
     try:
-        file_like.read(0)
-        return file_like, False
+        if hasattr(file_like, 'read') and hasattr(file_like, 'write'):
+            # can't use file_like.read(0) to see if something is a file-like
+            # this is now being used to open a file for writing ('wb') and
+            # the resulting file may be write only.
+            # file_like.read(0)
+            return file_like, False
     except AttributeError:
         pass
 
     try:
-        return open(file_like, 'rb'), True
+        return open(file_like, mode), True
     except IOError:
         # Probably "not found"
         if isinstance(file_like, string_types):
             if appendmat and not file_like.endswith('.mat'):
                 file_like += '.mat'
-            return open(file_like, 'rb'), True
+            return open(file_like, mode), True
         else:
             raise IOError('Reader needs file name or open file-like object')
+
 
 @docfiller
 def mat_reader_factory(file_name, appendmat=True, **kwargs):
@@ -204,14 +217,15 @@ def loadmat(file_name, mdict=None, appendmat=True, **kwargs):
         3.14159265+3.14159265j])
     """
     variable_names = kwargs.pop('variable_names', None)
-    MR, file_opened = mat_reader_factory(file_name, appendmat, **kwargs)
-    matfile_dict = MR.get_variables(variable_names)
+    with _open_file_context(file_name, appendmat) as f:
+        MR, _ = mat_reader_factory(f, **kwargs)
+        matfile_dict = MR.get_variables(variable_names)
+
     if mdict is not None:
         mdict.update(matfile_dict)
     else:
         mdict = matfile_dict
-    if file_opened:
-        MR.mat_stream.close()
+
     return mdict
 
 
@@ -253,33 +267,20 @@ def savemat(file_name, mdict,
         If 'column', write 1-D numpy arrays as column vectors.
         If 'row', write 1-D numpy arrays as row vectors.
     """
-    file_opened = False
-    if hasattr(file_name, 'write'):
-        # File-like object already; use as-is
-        file_stream = file_name
-    else:
-        if isinstance(file_name, string_types):
-            if appendmat and not file_name.endswith('.mat'):
-                file_name = file_name + ".mat"
-
-        file_stream = open(file_name, 'wb')
-        file_opened = True
-
-    if format == '4':
-        if long_field_names:
-            raise ValueError("Long field names are not available for version 4 files")
-        MW = MatFile4Writer(file_stream, oned_as)
-    elif format == '5':
-        MW = MatFile5Writer(file_stream,
-                            do_compression=do_compression,
-                            unicode_strings=True,
-                            long_field_names=long_field_names,
-                            oned_as=oned_as)
-    else:
-        raise ValueError("Format should be '4' or '5'")
-    MW.put_variables(mdict)
-    if file_opened:
-        file_stream.close()
+    with _open_file_context(file_name, appendmat, 'wb') as file_stream:
+        if format == '4':
+            if long_field_names:
+                raise ValueError("Long field names are not available for version 4 files")
+            MW = MatFile4Writer(file_stream, oned_as)
+        elif format == '5':
+            MW = MatFile5Writer(file_stream,
+                                do_compression=do_compression,
+                                unicode_strings=True,
+                                long_field_names=long_field_names,
+                                oned_as=oned_as)
+        else:
+            raise ValueError("Format should be '4' or '5'")
+        MW.put_variables(mdict)
 
 
 @docfiller
@@ -314,8 +315,7 @@ def whosmat(file_name, appendmat=True, **kwargs):
     .. versionadded:: 0.12.0
 
     """
-    ML, file_opened = mat_reader_factory(file_name, **kwargs)
-    variables = ML.list_variables()
-    if file_opened:
-        ML.mat_stream.close()
+    with _open_file_context(file_name, appendmat) as f:
+        ML, file_opened = mat_reader_factory(f, **kwargs)
+        variables = ML.list_variables()
     return variables

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -377,11 +377,11 @@ def test_gzip_simple():
     tmpdir = mkdtemp()
     try:
         fname = pjoin(tmpdir,name)
-        mat_stream = gzip.open(fname,mode='wb')
+        mat_stream = gzip.open(fname, mode='wb')
         savemat(mat_stream, expected, format=format)
         mat_stream.close()
 
-        mat_stream = gzip.open(fname,mode='rb')
+        mat_stream = gzip.open(fname, mode='rb')
         actual = loadmat(mat_stream, struct_as_record=True)
         mat_stream.close()
     finally:
@@ -1200,8 +1200,8 @@ def test_miuint32_compromise():
     assert_equal(res['an_array'], np.arange(10)[None, :])
     # mat file with miUINT32 for miINT32, with negative value
     filename = pjoin(test_data_path, 'bad_miuint32.mat')
-    with assert_raises(ValueError), open(filename, 'rb') as f:
-        loadmat(f)
+    with assert_raises(ValueError):
+        loadmat(filename)
 
 
 def test_miutf8_for_miint8_compromise():
@@ -1211,8 +1211,8 @@ def test_miutf8_for_miint8_compromise():
     assert_equal(res['array_name'], [[1]])
     # mat file with non-ascii utf8 name raises error
     filename = pjoin(test_data_path, 'bad_miutf8_array_name.mat')
-    with assert_raises(ValueError), open(filename, 'rb') as f:
-        loadmat(f)
+    with assert_raises(ValueError):
+        loadmat(filename)
 
 
 def test_bad_utf8():

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -1212,9 +1212,8 @@ def test_miutf8_for_miint8_compromise():
     assert_equal(res['array_name'], [[1]])
     # mat file with non-ascii utf8 name raises error
     filename = pjoin(test_data_path, 'bad_miutf8_array_name.mat')
-    with suppress_warnings() as sup:
-        sup.filter(message="unclosed file")  # Py3k ResourceWarning
-        assert_raises(ValueError, loadmat, filename)
+    with assert_raises(ValueError), open(filename, 'rb') as f:
+        loadmat(f)
 
 
 def test_bad_utf8():

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -1200,9 +1200,8 @@ def test_miuint32_compromise():
     assert_equal(res['an_array'], np.arange(10)[None, :])
     # mat file with miUINT32 for miINT32, with negative value
     filename = pjoin(test_data_path, 'bad_miuint32.mat')
-    with suppress_warnings() as sup:
-        sup.filter(message="unclosed file")  # Py3k ResourceWarning
-        assert_raises(ValueError, loadmat, filename)
+    with assert_raises(ValueError), open(filename, 'rb') as f:
+        loadmat(f)
 
 
 def test_miutf8_for_miint8_compromise():


### PR DESCRIPTION
https://circleci.com/gh/scipy/scipy/11263 has a warning that a file is not being closed properly. The warning was supposed to be filtered (but it's not always the case, as shown in the CI output). This PR closes the file properly.