### PR TITLE
BUG: fix amax constraint not enforced in scalar_search_wolfe2

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -201,6 +201,7 @@ Stiaan Gerber for a bug fix in scipy.optimize.
 Nicolas Hug for the Yeo-Johnson transformation.
 Petar Mlinarić for a bug fix in scipy.io.mmio.
 Franz Forstmayr for documentation in scipy.signal
+Vega Theil Carstensen for a bug fix in scipy.optimize.linesearch.
 
 Institutions
 ------------

--- a/scipy/optimize/linesearch.py
+++ b/scipy/optimize/linesearch.py
@@ -396,6 +396,9 @@ def scalar_search_wolfe2(phi, derphi, phi0=None,
     if alpha1 < 0:
         alpha1 = 1.0
 
+    if amax is not None:
+        alpha1 = min(alpha1, amax)
+
     phi_a1 = phi(alpha1)
     #derphi_a1 = derphi(alpha1)  evaluated below
 

--- a/scipy/optimize/tests/test_linesearch.py
+++ b/scipy/optimize/tests/test_linesearch.py
@@ -154,6 +154,16 @@ class TestLineSearch(object):
                 assert_fp_equal(derphi1, derphi(s), name)
             assert_wolfe(s, phi, derphi, err_msg="%s %g" % (name, old_phi0))
 
+    def test_scalar_search_wolfe2_with_low_amax(self):
+        def phi(alpha):
+            return (alpha - 5) ** 2
+
+        def derphi(alpha):
+            return 2 * (alpha - 5)
+
+        alpha_star, _, _, _ = ls.scalar_search_wolfe2(phi, derphi, amax=0.001)
+        assert_(alpha_star is None)
+
     def test_scalar_search_armijo(self):
         for name, phi, derphi, old_phi0 in self.scalar_iter():
             s, phi1 = ls.scalar_search_armijo(phi, phi(0), derphi(0))

--- a/scipy/optimize/tests/test_linesearch.py
+++ b/scipy/optimize/tests/test_linesearch.py
@@ -161,8 +161,9 @@ class TestLineSearch(object):
         def derphi(alpha):
             return 2 * (alpha - 5)
 
-        alpha_star, _, _, _ = ls.scalar_search_wolfe2(phi, derphi, amax=0.001)
-        assert_(alpha_star is None)
+        s, _, _, _ = assert_warns(LineSearchWarning,
+                                  ls.scalar_search_wolfe2, phi, derphi, amax=0.001)
+        assert_(s is None)
 
     def test_scalar_search_armijo(self):
         for name, phi, derphi, old_phi0 in self.scalar_iter():


### PR DESCRIPTION
Fixing the error indicated by [this question](https://stackoverflow.com/questions/47698022/interpreting-the-amax-parameter-in-scipys-line-search).