### PR TITLE
MAINT: Allow None tolerances in least_squares

### DIFF
--- a/doc/source/tutorial/optimize.rst
+++ b/doc/source/tutorial/optimize.rst
@@ -795,6 +795,7 @@ finally plots the original data and the fitted model function:
     ...               4.56e-2, 3.42e-2, 3.23e-2, 2.35e-2, 2.46e-2])
     >>> x0 = np.array([2.5, 3.9, 4.15, 3.9])
     >>> res = least_squares(fun, x0, jac=jac, bounds=(0, 100), args=(u, y), verbose=1)
+    # may vary
     `ftol` termination condition is satisfied.
     Function evaluations 130, initial cost 4.4383e+00, final cost 1.5375e-04, first-order optimality 4.92e-08.
     >>> res.x

--- a/scipy/optimize/_lsq/common.py
+++ b/scipy/optimize/_lsq/common.py
@@ -230,11 +230,12 @@ def update_tr_radius(Delta, actual_reduction, predicted_reduction,
     Delta : float
         New radius.
     ratio : float
-        Ratio between actual and predicted reductions. Zero if predicted
-        reduction is zero.
+        Ratio between actual and predicted reductions.
     """
     if predicted_reduction > 0:
         ratio = actual_reduction / predicted_reduction
+    elif predicted_reduction == actual_reduction == 0:
+        ratio = 1
     else:
         ratio = 0
 

--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -115,7 +115,15 @@ def check_tolerance(ftol, xtol, gtol):
                  .format(name, EPS))
         return tol
 
-    return check(ftol, "ftol"), check(xtol, "xtol"), check(gtol, "gtol")
+    ftol = check(ftol, "ftol")
+    xtol = check(xtol, "xtol")
+    gtol = check(gtol, "gtol")
+
+    if ftol < EPS and xtol < EPS and gtol < EPS:
+        raise ValueError("At least one of the tolerances must be higher than "
+                         "machine epsilon ({:.2e}).".format(EPS))
+
+    return ftol, xtol, gtol
 
 
 def check_x_scale(x_scale, x0):

--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -111,7 +111,7 @@ def check_tolerance(ftol, xtol, gtol):
             tol = 0
         elif tol < EPS:
             warn("Setting `{}` below the machine epsilon ({:.2e}) effectively "
-                 "disables the corresponding termination condtion."
+                 "disables the corresponding termination condition."
                  .format(name, EPS))
         return tol
 

--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -106,18 +106,16 @@ def prepare_bounds(bounds, n):
 
 
 def check_tolerance(ftol, xtol, gtol):
-    message = "{} is too low, setting to machine epsilon {}."
-    if ftol < EPS:
-        warn(message.format("`ftol`", EPS))
-        ftol = EPS
-    if xtol < EPS:
-        warn(message.format("`xtol`", EPS))
-        xtol = EPS
-    if gtol < EPS:
-        warn(message.format("`gtol`", EPS))
-        gtol = EPS
+    def check(tol, name):
+        if tol is None:
+            tol = 0
+        elif tol < EPS:
+            warn("Setting `{}` below the machine epsilon ({:.2e}) effectively "
+                 "disables the corresponding termination condtion."
+                 .format(name, EPS))
+        return tol
 
-    return ftol, xtol, gtol
+    return check(ftol, "ftol"), check(xtol, "xtol"), check(gtol, "gtol")
 
 
 def check_x_scale(x_scale, x0):
@@ -293,12 +291,13 @@ def least_squares(
               efficient method for small unconstrained problems.
 
         Default is 'trf'. See Notes for more information.
-    ftol : float, optional
+    ftol : float or None, optional
         Tolerance for termination by the change of the cost function. Default
         is 1e-8. The optimization process is stopped when  ``dF < ftol * F``,
         and there was an adequate agreement between a local quadratic model and
-        the true model in the last step.
-    xtol : float, optional
+        the true model in the last step. If None, the termination by this
+        condition is disabled.
+    xtol : float or None, optional
         Tolerance for termination by the change of the independent variables.
         Default is 1e-8. The exact condition depends on the `method` used:
 
@@ -307,7 +306,8 @@ def least_squares(
               a trust-region radius and ``xs`` is the value of ``x``
               scaled according to `x_scale` parameter (see below).
 
-    gtol : float, optional
+        If None, the termination by this condition is disabled.
+    gtol : float or None, optional
         Tolerance for termination by the norm of the gradient. Default is 1e-8.
         The exact condition depends on a `method` used:
 
@@ -321,6 +321,7 @@ def least_squares(
               between columns of the Jacobian and the residual vector is less
               than `gtol`, or the residual vector is zero.
 
+        If None, the termination by this condition is disabled.
     x_scale : array_like or 'jac', optional
         Characteristic scale of each variable. Setting `x_scale` is equivalent
         to reformulating the problem in scaled variables ``xs = x / x_scale``.

--- a/scipy/optimize/_lsq/trf.py
+++ b/scipy/optimize/_lsq/trf.py
@@ -358,18 +358,17 @@ def trf_bounds(fun, jac, x0, f0, J0, lb, ub, ftol, xtol, gtol, max_nfev,
             correction = 0.5 * np.dot(step_h * diag_h, step_h)
 
             Delta_new, ratio = update_tr_radius(
-                Delta, actual_reduction - correction, predicted_reduction,
-                step_h_norm, step_h_norm > 0.95 * Delta
-            )
-            alpha *= Delta / Delta_new
-            Delta = Delta_new
+                Delta, actual_reduction, predicted_reduction,
+                step_h_norm, step_h_norm > 0.95 * Delta)
 
             step_norm = norm(step)
             termination_status = check_termination(
                 actual_reduction, cost, step_norm, norm(x), ratio, ftol, xtol)
-
             if termination_status is not None:
                 break
+
+            alpha *= Delta / Delta_new
+            Delta = Delta_new
 
         if actual_reduction > 0:
             x = x_new
@@ -523,15 +522,15 @@ def trf_no_bounds(fun, jac, x0, f0, J0, ftol, xtol, gtol, max_nfev,
             Delta_new, ratio = update_tr_radius(
                 Delta, actual_reduction, predicted_reduction,
                 step_h_norm, step_h_norm > 0.95 * Delta)
-            alpha *= Delta / Delta_new
-            Delta = Delta_new
 
             step_norm = norm(step)
             termination_status = check_termination(
                 actual_reduction, cost, step_norm, norm(x), ratio, ftol, xtol)
-
             if termination_status is not None:
                 break
+
+            alpha *= Delta / Delta_new
+            Delta = Delta_new
 
         if actual_reduction > 0:
             x = x_new

--- a/scipy/optimize/tests/test_least_squares.py
+++ b/scipy/optimize/tests/test_least_squares.py
@@ -367,6 +367,13 @@ class BaseMixin(object):
         assert_(res.nfev < max_nfev)
         assert_(res.cost < 0.5)
 
+    def test_none_tolerance(self):
+        # Test that all options are None the algorithm terminates by the
+        # maximum number of function evaluations.
+        res = least_squares(fun_trivial, 2., method=self.method,
+                            ftol=None, xtol=None, gtol=None, max_nfev=10)
+        assert_equal(res.nfev, 10)
+
 
 class BoundsMixin(object):
     def test_inconsistent(self):

--- a/scipy/optimize/tests/test_least_squares.py
+++ b/scipy/optimize/tests/test_least_squares.py
@@ -367,12 +367,21 @@ class BaseMixin(object):
         assert_(res.nfev < max_nfev)
         assert_(res.cost < 0.5)
 
-    def test_none_tolerance(self):
-        # Test that all options are None the algorithm terminates by the
-        # maximum number of function evaluations.
-        res = least_squares(fun_trivial, 2., method=self.method,
-                            ftol=None, xtol=None, gtol=None, max_nfev=10)
-        assert_equal(res.nfev, 10)
+    def test_error_raised_when_all_tolerances_below_eps(self):
+        # Test that all 0 tolerances are not allowed.
+        assert_raises(ValueError, least_squares, fun_trivial, 2.0,
+                      method=self.method, ftol=None, xtol=None, gtol=None)
+
+    def test_convergence_with_only_one_tolerance_enabled(self):
+        x0 = [-2, 1]
+        x_opt = [1, 1]
+        for ftol, xtol, gtol in [(1e-8, None, None),
+                                  (None, 1e-8, None),
+                                  (None, None, 1e-8)]:
+            res = least_squares(fun_rosenbrock, x0, jac=jac_rosenbrock,
+                                ftol=ftol, gtol=gtol, xtol=xtol,
+                                method=self.method)
+            assert_allclose(res.x, x_opt)
 
 
 class BoundsMixin(object):
@@ -739,4 +748,3 @@ def test_basic():
     # test that 'method' arg is really optional
     res = least_squares(fun_trivial, 2.0)
     assert_allclose(res.x, 0, atol=1e-10)
-


### PR DESCRIPTION
Fixes #7632

The tolerance logic was changes as follows:

1. `None` is accepted and it is converted to 0.
2. Tolerances are not bounded by `EPS`. But a warning is issued when it is less that `EPS`, unless `None` was passed (we consider this as a clear intent and don't warn about disabled tolerance check).