### PR TITLE
Fix PPoly integrate and test for CubicSpline

### DIFF
--- a/scipy/interpolate/_ppoly.pyx
+++ b/scipy/interpolate/_ppoly.pyx
@@ -332,7 +332,7 @@ def fix_continuity(double_or_complex[:,:,::1] c,
 @cython.boundscheck(False)
 @cython.cdivision(True)
 def integrate(double_or_complex[:,:,::1] c,
-              double[::1] x,
+              const double[::1] x,
               double a,
               double b,
               bint extrapolate,

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -703,8 +703,9 @@ class TestInterp1D(object):
         y = np.exp(-x / 3.0)
         xnew = np.arange(0, 9, 0.1)
         # Check both read-only and not read-only:
-        for writeable in (True, False):
-            xnew.flags.writeable = writeable
+        for xnew_writeable in (True, False):
+            xnew.flags.writeable = xnew_writeable
+            x.flags.writeable = False
             for kind in ('linear', 'nearest', 'zero', 'slinear', 'quadratic',
                          'cubic'):
                 f = interp1d(x, y, kind=kind)
@@ -1287,9 +1288,8 @@ class TestPPoly(object):
             x.flags.writeable = writeable
 
             P = PPoly(c, x)
-            I = P.antiderivative()
+            vals = P.integrate(1, 4)
 
-            vals = I(4) - I(1)
             assert_(np.isfinite(vals).all())
 
     def test_integrate_periodic(self):

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -1012,7 +1012,7 @@ class TestPPoly(object):
         p = PPoly(c, x, extrapolate='periodic')
 
         for writeable in (True, False):
-            xnew.flags.writeable = writeable
+            x.flags.writeable = writeable
             f = PPoly(c, x)
             vals = f(xnew)
             assert_(np.isfinite(vals).all())
@@ -1278,6 +1278,19 @@ class TestPPoly(object):
         assert_allclose(ig, ipp(b) - ipp(a))
 
         assert_(np.isnan(pp.integrate(a, b, extrapolate=False)).all())
+
+    def test_integrate_readonly(self):
+        x = np.array([1, 2, 4])
+        c = np.array([[0., 0.], [-1., -1.], [2., -0.], [1., 2.]])
+
+        for writeable in (True, False):
+            x.flags.writeable = writeable
+
+            P = PPoly(c, x)
+            I = P.antiderivative()
+
+            vals = I(4) - I(1)
+            assert_(np.isfinite(vals).all())
 
     def test_integrate_periodic(self):
         x = np.array([1, 2, 4])


### PR DESCRIPTION
Fixes which variable should become readonly.

Also fixes read only issues with `PPoly.integrate` @ev-br 