### PR TITLE
DOC: Include Numba in list of non-C ndimage examples

### DIFF
--- a/doc/source/tutorial/ndimage.rst
+++ b/doc/source/tutorial/ndimage.rst
@@ -1772,9 +1772,10 @@ callback function and gives the prototype of the function.
 
    `generic_filter`, `generic_filter1d`, `geometric_transform`
 
-Below, we show alternative ways to write the code, using Cython_,
+Below, we show alternative ways to write the code, using Numba_, Cython_,
 ctypes_, or cffi_ instead of writing wrapper code in C.
 
+.. _Numba: https://numba.pydata.org/
 .. _Cython: https://cython.org/
 .. _ctypes: https://docs.python.org/3/library/ctypes.html
 .. _cffi: https://cffi.readthedocs.io/

--- a/doc/source/tutorial/ndimage.rst
+++ b/doc/source/tutorial/ndimage.rst
@@ -1775,7 +1775,7 @@ callback function and gives the prototype of the function.
 Below, we show alternative ways to write the code, using Cython_,
 ctypes_, or cffi_ instead of writing wrapper code in C.
 
-.. _Cython: http://cython.org/
+.. _Cython: https://cython.org/
 .. _ctypes: https://docs.python.org/3/library/ctypes.html
 .. _cffi: https://cffi.readthedocs.io/
 


### PR DESCRIPTION
Numba is shown as the first example after this list, but was not included in this list. Hence we add it to the list.