### PR TITLE
ENH: Use faster solvers for firls

### DIFF
--- a/benchmarks/benchmarks/signal.py
+++ b/benchmarks/benchmarks/signal.py
@@ -210,3 +210,14 @@ class Upfirdn2D(Benchmark):
     def time_upfirdn2d(self, up, down, axis):
         for h, x in self.pairs:
             signal.upfirdn(h, x, up=up, down=down, axis=axis)
+
+
+class FIRLS(Benchmark):
+    param_names = ['n', 'edges']
+    params = [
+        [21, 101, 1001, 2001],
+        [(0.1, 0.9), (0.01, 0.99)],
+        ]
+
+    def time_firls(self, n, edges):
+        signal.firls(n, (0,) + edges + (1,), [1, 1, 0, 0])

--- a/scipy/signal/fir_filter_design.py
+++ b/scipy/signal/fir_filter_design.py
@@ -1045,7 +1045,10 @@ def firls(numtaps, bands, desired, weight=None, nyq=None, fs=None):
                     str(ww.message).startswith('Ill-conditioned matrix'):
                 raise LinAlgError(str(ww.message))
     except LinAlgError:  # in case Q is rank deficient
-        a = lstsq(Q, b, lapack_driver='gelsy')
+        # This is faster than pinvh, even though we don't explicitly use
+        # the symmetry here. gelsy was faster than gelsd and gelss in
+        # some non-exhaustive tests.
+        a = lstsq(Q, b, lapack_driver='gelsy')[0]
 
     # make coefficients symmetric (linear phase)
     coeffs = np.hstack((a[:0:-1], 2 * a[0], a[1:]))

--- a/scipy/signal/fir_filter_design.py
+++ b/scipy/signal/fir_filter_design.py
@@ -9,7 +9,7 @@ import warnings
 import numpy as np
 from numpy.fft import irfft, fft, ifft
 from scipy.special import sinc
-from scipy.linalg import toeplitz, hankel, pinv
+from scipy.linalg import toeplitz, hankel, solve, pinvh, LinAlgError
 from scipy._lib.six import string_types
 
 from . import sigtools
@@ -965,6 +965,8 @@ def firls(numtaps, bands, desired, weight=None, nyq=None, fs=None):
     bands = np.asarray(bands).flatten() / nyq
     if len(bands) % 2 != 0:
         raise ValueError("bands must contain frequency pairs.")
+    if (bands < 0).any() or (bands > 1).any():
+        raise ValueError("bands must be between 0 and 1 relative to Nyquist")
     bands.shape = (-1, 2)
 
     # check remaining params
@@ -1032,8 +1034,11 @@ def firls(numtaps, bands, desired, weight=None, nyq=None, fs=None):
     b[1:] += m * np.cos(n[1:] * np.pi * bands) / (np.pi * n[1:]) ** 2
     b = np.dot(np.diff(b, axis=2)[:, :, 0], weight)
 
-    # Now we can solve the equation (use pinv because Q can be rank deficient)
-    a = np.dot(pinv(Q), b)
+    # Now we can solve the equation
+    try:  # try the fast way
+        a = solve(Q, b, sym_pos=True, check_finite=False)
+    except LinAlgError:  # in case Q is rank deficient
+        a = np.dot(pinvh(Q, check_finite=False), b)
 
     # make coefficients symmetric (linear phase)
     coeffs = np.hstack((a[:0:-1], 2 * a[0], a[1:]))

--- a/scipy/signal/fir_filter_design.py
+++ b/scipy/signal/fir_filter_design.py
@@ -1041,8 +1041,8 @@ def firls(numtaps, bands, desired, weight=None, nyq=None, fs=None):
             warnings.simplefilter('always')
             a = solve(Q, b, sym_pos=True, check_finite=False)
         for ww in w:
-            if ww.category == LinAlgWarning and \
-                    str(ww.message).startswith('Ill-conditioned matrix'):
+            if (ww.category == LinAlgWarning and
+                    str(ww.message).startswith('Ill-conditioned matrix')):
                 raise LinAlgError(str(ww.message))
     except LinAlgError:  # in case Q is rank deficient
         # This is faster than pinvh, even though we don't explicitly use

--- a/scipy/signal/tests/test_fir_filter_design.py
+++ b/scipy/signal/tests/test_fir_filter_design.py
@@ -541,9 +541,10 @@ class TestFirls(object):
             firls(7, [0, 1], [0, 1], nyq=0.5)
 
     def test_rank_deficient(self):
-        # solve() runs but warns
-        with pytest.warns(LinAlgWarning, match='Ill-conditioned'):
+        # solve() runs but warns (only sometimes, so here we don't use match)
+        with pytest.warns(None) as warnings_:
             x = firls(21, [0, 0.1, 0.9, 1], [1, 1, 0, 0])
+        assert all('Ill-conditioned' in str(ww) for ww in warnings_)
         w, h = freqz(x, fs=2.)
         assert_allclose(np.abs(h[:2]), 1.)
         assert_allclose(np.abs(h[-2:]), 0., atol=1e-7)

--- a/scipy/signal/tests/test_fir_filter_design.py
+++ b/scipy/signal/tests/test_fir_filter_design.py
@@ -542,12 +542,10 @@ class TestFirls(object):
 
     def test_rank_deficient(self):
         # solve() runs but warns (only sometimes, so here we don't use match)
-        with pytest.warns(None) as warnings_:
-            x = firls(21, [0, 0.1, 0.9, 1], [1, 1, 0, 0])
-        assert all('Ill-conditioned' in str(ww) for ww in warnings_)
+        x = firls(21, [0, 0.1, 0.9, 1], [1, 1, 0, 0])
         w, h = freqz(x, fs=2.)
-        assert_allclose(np.abs(h[:2]), 1.)
-        assert_allclose(np.abs(h[-2:]), 0., atol=1e-7)
+        assert_allclose(np.abs(h[:2]), 1., atol=1e-5)
+        assert_allclose(np.abs(h[-2:]), 0., atol=1e-6)
         # switch to pinvh (tolerances could be higher with longer
         # filters, but using shorter ones is faster computationally and
         # the idea is the same)

--- a/scipy/signal/tests/test_fir_filter_design.py
+++ b/scipy/signal/tests/test_fir_filter_design.py
@@ -5,9 +5,10 @@ from numpy.testing import (assert_almost_equal, assert_array_almost_equal,
                            assert_equal, assert_,
                            assert_allclose, assert_warns)
 from pytest import raises as assert_raises
+import pytest
 
+from scipy.linalg import LinAlgWarning
 from scipy.special import sinc
-
 from scipy.signal import kaiser_beta, kaiser_atten, kaiserord, \
         firwin, firwin2, freqz, remez, firls, minimum_phase
 
@@ -535,6 +536,28 @@ class TestFirls(object):
 
         taps = firls(7, (0, 1, 2, 3, 4, 5), [1, 0, 0, 1, 1, 0], nyq=10)
         assert_allclose(taps, known_taps)
+
+        with pytest.raises(ValueError, match='between 0 and 1'):
+            firls(7, [0, 1], [0, 1], nyq=0.5)
+
+    def test_rank_deficient(self):
+        # solve() runs but warns
+        with pytest.warns(LinAlgWarning, match='Ill-conditioned'):
+            x = firls(21, [0, 0.1, 0.9, 1], [1, 1, 0, 0])
+        w, h = freqz(x, fs=2.)
+        assert_allclose(np.abs(h[:2]), 1.)
+        assert_allclose(np.abs(h[-2:]), 0., atol=1e-7)
+        # switch to pinvh (tolerances could be higher with longer
+        # filters, but using shorter ones is faster computationally and
+        # the idea is the same)
+        x = firls(101, [0, 0.01, 0.99, 1], [1, 1, 0, 0])
+        w, h = freqz(x, fs=2.)
+        mask = w < 0.01
+        assert mask.sum() > 3
+        assert_allclose(np.abs(h[mask]), 1., atol=1e-4)
+        mask = w > 0.99
+        assert mask.sum() > 3
+        assert_allclose(np.abs(h[mask]), 0., atol=1e-4)
 
 
 class TestMinimumPhase(object):


### PR DESCRIPTION
`Q` is symmetric, so we should use that to speed up solving. Also, we can try using `linalg.solve` first, and fall back to a `pinvh` if necessary.

I'm not 100% sure that it's okay to use `solve` in cases where it warns about rank deficiency. It seems to produce okay results in my tests, but if someone thinks it's better to catch the emitted warning and use `pinvh` in that case, too, I can change it to do so.

Closes #9835.