### PR TITLE
ENH: scipy.optimize.minimize with method=SLSQP returns KKT multipliers

### DIFF
--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -102,6 +102,9 @@ class OptimizeResult(dict):
         Number of iterations performed by the optimizer.
     maxcv : float
         The maximum constraint violation.
+    kkt : list
+        The kkt multipliers associated with constraint functions returned as
+        a list of ndarrays. Not available for all solvers.
 
     Notes
     -----

--- a/scipy/optimize/slsqp.py
+++ b/scipy/optimize/slsqp.py
@@ -212,6 +212,38 @@ def fmin_slsqp(func, x0, eqcons=(), f_eqcons=None, ieqcons=(), f_ieqcons=None,
         return res['x']
 
 
+class KKT(dict):
+    """ Represents the KKT multipliers from an optimization result.
+
+    Attributes
+    ----------
+    equality : ndarray
+        KKT multipliers associated with the equality constraints.
+    inequality : ndarray
+        KKT multipliers associated with the inequality constraints.
+
+    """
+    def __getattr__(self, name):
+        try:
+            return self[name]
+        except KeyError:
+            raise AttributeError(name)
+
+    __setattr__ = dict.__setitem__
+    __delattr__ = dict.__delitem__
+
+    def __repr__(self):
+        if self.keys():
+            m = max(map(len, list(self.keys()))) + 1
+            return ''.join([k.rjust(m) + ': ' + repr(v)
+                              for k, v in sorted(self.items())])
+        else:
+            return self.__class__.__name__ + "()"
+
+    def __dir__(self):
+        return list(self.keys())
+
+
 def _minimize_slsqp(func, x0, args=(), jac=None, bounds=None,
                     constraints=(),
                     maxiter=100, ftol=1.0E-6, iprint=1, disp=False,
@@ -474,7 +506,8 @@ def _minimize_slsqp(func, x0, args=(), jac=None, bounds=None,
 
     return OptimizeResult(x=x, fun=fx, jac=g[:-1], nit=int(majiter),
                           nfev=feval[0], njev=geval[0], status=int(mode),
-                          message=exit_modes[int(mode)], success=(mode == 0))
+                          message=exit_modes[int(mode)], success=(mode == 0),
+                          kkt=KKT(equality=w[:meq], inequality=w[meq:meq+mieq]))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
See issue #9827.

I added a `KKT` dictionary, which behaves almost identical to `OptimizeResult`, whose role is to store the KKT multipliers in two separate fields, `equality` and `inequality`. This is consistent with how results are returned from scipy optimizers, but there may be a better way to do this. Since the user enters in constraints as a list of equality and inequality constraints, should we do the same for the output of kkts?

The only change to `_minimize_slsqp` was that we grab the kkt multipliers from the `w` variable output by the SLSQP FORTRAN code. I don't think any changes are necessary to the documentation or test cases.