### PR TITLE
TST: reduce Appveyor CI load

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,31 +21,9 @@ environment:
       TEST_TIMEOUT: 1000
 
   matrix:
-    - PYTHON: C:\Python36
-      PYTHON_VERSION: 3.6
-      PYTHON_ARCH: 32
-      TEST_MODE: fast
-
-    - PYTHON: C:\Python35-x64
-      PYTHON_VERSION: 3.5
-      PYTHON_ARCH: 64
-      TEST_MODE: fast
-
     - PYTHON: C:\Python37-x64
       PYTHON_VERSION: 3.7
       PYTHON_ARCH: 64
-      TEST_MODE: full
-
-    - PYTHON: C:\Python35-x64
-      PYTHON_VERSION: 3.5
-      PYTHON_ARCH: 64
-      SKIP_NOTAG: true
-      TEST_MODE: full
-
-    - PYTHON: C:\Python35
-      PYTHON_VERSION: 3.5
-      PYTHON_ARCH: 32
-      SKIP_NOTAG: true
       TEST_MODE: full
 
 init:


### PR DESCRIPTION
As [noted](https://github.com/scipy/scipy/pull/9542#issuecomment-466097045), we may wish to consider slimming down our Appveyor CI load given the lower free parallel offering there & the continued solid Windows CI performance from Azure.

I thought it might make sense to keep just 1 full suite run in Appveyor matrix in case  they up their offerings in the future and we want to maintain a low barrier to re-adoption so we can redistribute CI load in the future.