### PR TITLE
BUG: Fix divide by zero warnings caused by error_norms=0 in bdf.py

### DIFF
--- a/scipy/integrate/_ivp/bdf.py
+++ b/scipy/integrate/_ivp/bdf.py
@@ -422,7 +422,8 @@ class BDF(OdeSolver):
             error_p_norm = np.inf
 
         error_norms = np.array([error_m_norm, error_norm, error_p_norm])
-        factors = error_norms ** (-1 / np.arange(order, order + 3))
+        with np.errstate(divide='ignore'): 
+            factors = error_norms ** (-1 / np.arange(order, order + 3))
 
         delta_order = np.argmax(factors) - 1
         order += delta_order


### PR DESCRIPTION
I cannot come up with a small reproducible code example, but I occasionally get warnings from bdf.py like below.  This is caused by at least one element of `error_norms` = 0.  In my case, it was the first two elements.  This fix clips the lower bound to be `np.finfo(float).eps`, and I no longer get the same warnings.

`
RuntimeWarning: divide by zero encountered in power
    factors = error_norms ** (-1 / np.arange(order, order + 3))
`

@nmayorov since you authored 99.9% of this file, can you review that it doesn't break some logic?  Each element is a norm, so they should be greater than or equal to zero, and after this change, only greater than zero.