### PR TITLE
BUG: fixed parenthesis in spatial.rotation

### DIFF
--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -826,8 +826,8 @@ class Rotation(object):
             if angles.ndim not in [1, 2] or angles.shape[-1] != num_axes:
                 raise ValueError("Expected `angles` to be at most "
                                  "2-dimensional with width equal to number "
-                                 "of axes specified, got {} for shape").format(
-                                 angles.shape)
+                                 "of axes specified, got {} for shape".format(
+                                 angles.shape))
 
             if angles.ndim == 1:
                 # (1, num_axes)


### PR DESCRIPTION
As stated in #9882, there is a small formatting error.

