### PR TITLE
ENH: Use Sparsity in Clarkson-Woodruff Sketch

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -202,7 +202,7 @@ Nicolas Hug for the Yeo-Johnson transformation.
 Petar Mlinarić for a bug fix in scipy.io.mmio.
 Franz Forstmayr for documentation in scipy.signal
 Jordi Montes for initial contribution of the Clarkson-Woodruff sketch.
-William Conner DiPaolo for improvements to randomized numerical linear algebra methods.
+William Conner DiPaolo for improvements to the Clarkson-Woodruff transform.
 
 Institutions
 ------------

--- a/THANKS.txt
+++ b/THANKS.txt
@@ -201,6 +201,8 @@ Stiaan Gerber for a bug fix in scipy.optimize.
 Nicolas Hug for the Yeo-Johnson transformation.
 Petar Mlinarić for a bug fix in scipy.io.mmio.
 Franz Forstmayr for documentation in scipy.signal
+Jordi Montes for initial contribution of the Clarkson-Woodruff sketch.
+William Conner DiPaolo for improvements to randomized numerical linear algebra methods.
 
 Institutions
 ------------

--- a/scipy/linalg/_sketches.py
+++ b/scipy/linalg/_sketches.py
@@ -114,10 +114,10 @@ def clarkson_woodruff_transform(input_matrix, sketch_size, seed=None):
     >>> B = sparse.rand(n_rows, n_columns, density=density, format='csr')
     >>> C = sparse.rand(n_rows, n_columns, density=density, format='coo')
     >>> D = np.random.randn(n_rows,n_columns)
-    >>> linalg.clarkson_woodruff_transform(A,sketch_n_rows) # fastest
-    >>> linalg.clarkson_woodruff_transform(B,sketch_n_rows) # fast
-    >>> linalg.clarkson_woodruff_transform(C,sketch_n_rows) # slower
-    >>> linalg.clarkson_woodruff_transform(D,sketch_n_rows) # slowest
+    >>> SA = linalg.clarkson_woodruff_transform(A,sketch_n_rows) # fastest
+    >>> SB = linalg.clarkson_woodruff_transform(B,sketch_n_rows) # fast
+    >>> SC = linalg.clarkson_woodruff_transform(C,sketch_n_rows) # slower
+    >>> SD = linalg.clarkson_woodruff_transform(D,sketch_n_rows) # slowest
 
     That said, this method does perform well on dense inputs, just slower
     on a relative scale.
@@ -131,7 +131,7 @@ def clarkson_woodruff_transform(input_matrix, sketch_size, seed=None):
     >>> A = np.random.randn(n_rows, n_columns)
     >>> sketch = linalg.clarkson_woodruff_transform(A,sketch_n_rows)
     >>> sketch.shape
-    (150, 100)
+    (200, 100)
     >>> norm_A = np.linalg.norm(A)
     >>> norm_sketch = np.linalg.norm(sketch)
 

--- a/scipy/linalg/_sketches.py
+++ b/scipy/linalg/_sketches.py
@@ -1,24 +1,22 @@
 """ Sketching-based Matrix Computations """
-
-# Author: Jordi Montes <jomsdev@gmail.com>
-# August 28, 2017
-
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
 
 from scipy._lib._util import check_random_state
+from scipy.sparse import coo_matrix
 
 __all__ = ['clarkson_woodruff_transform']
 
 
 def cwt_matrix(n_rows, n_columns, seed=None):
     r""""
-    Generate a matrix S for the Clarkson-Woodruff sketch.
+    Generate a matrix S which represents a Clarkson-Woodruff transform.
 
     Given the desired size of matrix, the method returns a matrix S of size
-    (n_rows, n_columns) where each column has all the entries set to 0 less one
-    position which has been randomly set to +1 or -1 with equal probability.
+    (n_rows, n_columns) where each column has all the entries set to 0
+    except for one position which has been randomly set to +1 or -1 with
+    equal probability.
 
     Parameters
     ----------
@@ -35,42 +33,36 @@ def cwt_matrix(n_rows, n_columns, seed=None):
 
     Returns
     -------
-    S : (n_rows, n_columns) array_like
+    S : (n_rows, n_columns) csc_matrix
+        The returned matrix has ``n_columns'' nonzero entries.
 
     Notes
     -----
     Given a matrix A, with probability at least 9/10,
-    .. math:: ||SA|| == (1 \pm \epsilon)||A||
-    Where epsilon is related to the size of S
+    .. math:: \|SA\| = (1 \pm \epsilon)\|A\|
+    Where the error epsilon is related to the size of S
     """
-    S = np.zeros((n_rows, n_columns))
-    nz_positions = np.random.randint(0, n_rows, n_columns)
     rng = check_random_state(seed)
-    values = rng.choice([1, -1], n_columns)
-    for i in range(n_columns):
-        S[nz_positions[i]][i] = values[i]
-
-    return S
+    rows = rng.randint(0,n_rows,n_columns)
+    cols = np.arange(n_columns)
+    signs = rng.choice([1, -1], n_columns)
+    S = coo_matrix((signs,(rows,cols)),shape=(n_rows,n_columns))
+    return S.tocsc()
 
 
 def clarkson_woodruff_transform(input_matrix, sketch_size, seed=None):
     r""""
-    Find low-rank matrix approximation via the Clarkson-Woodruff Transform.
+    Applies a Clarkson-Woodruff Transform/sketch to the input matrix.
 
     Given an input_matrix ``A`` of size ``(n, d)``, compute a matrix ``A'`` of
-    size (sketch_size, d) which holds:
-
-    .. math:: ||Ax|| = (1 \pm \epsilon)||A'x||
-
-    with high probability.
-
-    The error is related to the number of rows of the sketch and it is bounded
-
-    .. math:: poly(r(\epsilon^{-1}))
+    size (sketch_size, d) so that
+    .. math:: \|Ax\| \approx \|A'x\|
+    with high probability via the Clarkson-Woodruff Transform, otherwise
+    known as the CountSketch matrix.
 
     Parameters
     ----------
-    input_matrix: array_like
+    input_matrix: array_like or `scipy.sparse.spmatrix'.
         Input matrix, of shape ``(n, d)``.
     sketch_size: int
         Number of rows for the sketch.
@@ -88,34 +80,73 @@ def clarkson_woodruff_transform(input_matrix, sketch_size, seed=None):
 
     Notes
     -----
-    This is an implementation of the Clarkson-Woodruff Transform (CountSketch).
-    ``A'`` can be computed in principle in ``O(nnz(A))`` (with ``nnz`` meaning
-    the number of nonzero entries), however we don't take advantage of sparse
-    matrices in this implementation.
+    To make the statement
+    .. math:: \|Ax\| \approx \|A'x\|
+    precise, observe the following result which is adapted from the
+    proof of Theorem 14 of [2] via Markov's Inequality. If we have
+    a sketch size ``sketch_size=k'' which is at least
+    
+    .. math:: k \geq \frac{2}{\epsilon^2\delta}
+
+    Then for any fixed vector ``x'',
+    .. math:: \|Ax\| = (1\pm\epsilon)\|A'x\|
+    with probability at least one minus delta.
+
+    This implementation takes advantage of sparsity: computing
+    a sketch takes time proportional to ``A.nnz''. Data ``A'' which
+    is in ``scipy.sparse.csc_matrix'' format gives the quickest
+    computation time for sparse input.
+
+    >>> from scipy import sparse
+    >>> n_rows, n_columns, density, sketch_n_rows = 15000, 100, 0.01, 200
+    >>> A = sparse.rand(n_rows, n_columns, density=density, format='csc')
+    >>> B = sparse.rand(n_rows, n_columns, density=density, format='csr')
+    >>> C = sparse.rand(n_rows, n_columns, density=density, format='coo')
+    >>> D = np.random.randn(n_rows,n_columns)
+    >>> clarkson_woodruff_transform(A) # fastest
+    >>> clarkson_woodruff_transform(B) # fast
+    >>> clarkson_woodruff_transform(C) # slower
+    >>> clarkson_woodruff_transform(D) # slowest
 
     Examples
     --------
     Given a big dense matrix ``A``:
 
-    >>> from scipy import linalg
-    >>> n_rows, n_columns, sketch_n_rows = (2000, 100, 100)
-    >>> threshold = 0.1
-    >>> tmp = np.random.normal(0, 0.1, n_rows*n_columns)
-    >>> A = np.reshape(tmp, (n_rows, n_columns))
-    >>> sketch = linalg.clarkson_woodruff_transform(A, sketch_n_rows)
+    >>> n_rows, n_columns, sketch_n_rows = 15000, 100, 200
+    >>> A = np.random.randn(n_rows, n_columns)
+    >>> sketch = clarkson_woodruff_transform(A, sketch_n_rows)
     >>> sketch.shape
-    (100, 100)
-    >>> normA = linalg.norm(A)
-    >>> norm_sketch = linalg.norm(sketch)
+    (150, 100)
+    >>> norm_A = np.linalg.norm(A)
+    >>> norm_sketch = np.linalg.norm(sketch)
 
-    Now with high probability, the condition ``abs(normA-normSketch) <
-    threshold`` holds.
+    Now with high probability, thee true norm ``norm_A'' is close to
+    the sketched norm ``norm_sketch'' in absolute value.
+
+    Similarly, applying our sketch preserves the solution to a linear
+    regression of ``min ||Ax - b||''.
+
+    >>> n_rows, n_columns, sketch_n_rows = 15000, 100, 200
+    >>> A = np.random.randn(n_rows,n_columns)
+    >>> b = np.random.randn(n_rows)
+    >>> x = np.linalg.lstsq(A,b)
+    >>> Ab = np.hstack((A,b.reshape(-1,1)))
+    >>> SAb = clarkson_woodruff_transform(Ab, sketch_size=sketch_n_rows)
+    >>> SA, Sb = SAb[:,:-1], SAb[:,-1]
+    >>> x_sketched = np.linalg.lstsq(SA,Sb)
+
+    As with the matrix norm example, ``np.linalg.norm(A @ x - b)''
+    is close to ``np.linalg.norm(A @ x_sketched - b)'' with high
+    probability.
 
     References
     ----------
     .. [1] Kenneth L. Clarkson and David P. Woodruff. Low rank approximation and
            regression in input sparsity time. In STOC, 2013.
 
+    .. [2] David P. Woodruff. Sketching as a tool for numerical linear algebra.
+           In Foundations and Trends in Theoretical Computer Science, 2014.
+
     """
     S = cwt_matrix(sketch_size, input_matrix.shape[0], seed)
-    return np.dot(S, input_matrix)
+    return S.dot(input_matrix)

--- a/scipy/linalg/_sketches.py
+++ b/scipy/linalg/_sketches.py
@@ -68,7 +68,7 @@ def clarkson_woodruff_transform(input_matrix, sketch_size, seed=None):
 
     Parameters
     ----------
-    input_matrix: array_like or `scipy.sparse.spmatrix'.
+    input_matrix: array_like
         Input matrix, of shape ``(n, d)``.
     sketch_size: int
         Number of rows for the sketch.
@@ -91,7 +91,7 @@ def clarkson_woodruff_transform(input_matrix, sketch_size, seed=None):
     .. math:: \|Ax\| \approx \|A'x\|
 
     precise, observe the following result which is adapted from the
-    proof of Theorem 14 of [2] via Markov's Inequality. If we have
+    proof of Theorem 14 of [2]_ via Markov's Inequality. If we have
     a sketch size ``sketch_size=k`` which is at least
     
     .. math:: k \geq \frac{2}{\epsilon^2\delta}

--- a/scipy/linalg/_sketches.py
+++ b/scipy/linalg/_sketches.py
@@ -1,4 +1,8 @@
 """ Sketching-based Matrix Computations """
+
+# Author: Jordi Montes <jomsdev@gmail.com>	
+# August 28, 2017	
+
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
@@ -34,7 +38,7 @@ def cwt_matrix(n_rows, n_columns, seed=None):
     Returns
     -------
     S : (n_rows, n_columns) csc_matrix
-        The returned matrix has ``n_columns'' nonzero entries.
+        The returned matrix has ``n_columns`` nonzero entries.
 
     Notes
     -----
@@ -84,19 +88,20 @@ def clarkson_woodruff_transform(input_matrix, sketch_size, seed=None):
     .. math:: \|Ax\| \approx \|A'x\|
     precise, observe the following result which is adapted from the
     proof of Theorem 14 of [2] via Markov's Inequality. If we have
-    a sketch size ``sketch_size=k'' which is at least
+    a sketch size ``sketch_size=k`` which is at least
     
     .. math:: k \geq \frac{2}{\epsilon^2\delta}
 
-    Then for any fixed vector ``x'',
+    Then for any fixed vector ``x``,
     .. math:: \|Ax\| = (1\pm\epsilon)\|A'x\|
     with probability at least one minus delta.
 
     This implementation takes advantage of sparsity: computing
-    a sketch takes time proportional to ``A.nnz''. Data ``A'' which
-    is in ``scipy.sparse.csc_matrix'' format gives the quickest
+    a sketch takes time proportional to ``A.nnz``. Data ``A`` which
+    is in ``scipy.sparse.csc_matrix`` format gives the quickest
     computation time for sparse input.
 
+    >>> from scipy.linalg import clarkson_woodruff_transform
     >>> from scipy import sparse
     >>> n_rows, n_columns, density, sketch_n_rows = 15000, 100, 0.01, 200
     >>> A = sparse.rand(n_rows, n_columns, density=density, format='csc')
@@ -120,12 +125,13 @@ def clarkson_woodruff_transform(input_matrix, sketch_size, seed=None):
     >>> norm_A = np.linalg.norm(A)
     >>> norm_sketch = np.linalg.norm(sketch)
 
-    Now with high probability, thee true norm ``norm_A'' is close to
-    the sketched norm ``norm_sketch'' in absolute value.
+    Now with high probability, the true norm ``norm_A`` is close to
+    the sketched norm ``norm_sketch`` in absolute value.
 
     Similarly, applying our sketch preserves the solution to a linear
-    regression of ``min ||Ax - b||''.
+    regression of ``min ||Ax - b||``.
 
+    >>> from scipy.linalg import clarkson_woodruff_transform
     >>> n_rows, n_columns, sketch_n_rows = 15000, 100, 200
     >>> A = np.random.randn(n_rows,n_columns)
     >>> b = np.random.randn(n_rows)
@@ -133,10 +139,10 @@ def clarkson_woodruff_transform(input_matrix, sketch_size, seed=None):
     >>> Ab = np.hstack((A,b.reshape(-1,1)))
     >>> SAb = clarkson_woodruff_transform(Ab, sketch_size=sketch_n_rows)
     >>> SA, Sb = SAb[:,:-1], SAb[:,-1]
-    >>> x_sketched = np.linalg.lstsq(SA,Sb)
+    >>> x_sketched = np.linalg.lstsq(SA,Sb,rcond=None)
 
-    As with the matrix norm example, ``np.linalg.norm(A @ x - b)''
-    is close to ``np.linalg.norm(A @ x_sketched - b)'' with high
+    As with the matrix norm example, ``np.linalg.norm(A @ x - b)``
+    is close to ``np.linalg.norm(A @ x_sketched - b)`` with high
     probability.
 
     References

--- a/scipy/linalg/_sketches.py
+++ b/scipy/linalg/_sketches.py
@@ -8,7 +8,7 @@ from __future__ import division, print_function, absolute_import
 import numpy as np
 
 from scipy._lib._util import check_random_state
-from scipy.sparse import coo_matrix
+from scipy.sparse import csc_matrix
 
 __all__ = ['clarkson_woodruff_transform']
 
@@ -48,10 +48,10 @@ def cwt_matrix(n_rows, n_columns, seed=None):
     """
     rng = check_random_state(seed)
     rows = rng.randint(0, n_rows, n_columns)
-    cols = np.arange(n_columns)
+    cols = np.arange(n_columns+1)
     signs = rng.choice([1, -1], n_columns)
-    S = coo_matrix((signs, (rows, cols)),shape=(n_rows, n_columns))
-    return S.tocsc()
+    S = csc_matrix((signs, rows, cols),shape=(n_rows, n_columns))
+    return S
 
 
 def clarkson_woodruff_transform(input_matrix, sketch_size, seed=None):

--- a/scipy/linalg/_sketches.py
+++ b/scipy/linalg/_sketches.py
@@ -114,18 +114,22 @@ def clarkson_woodruff_transform(input_matrix, sketch_size, seed=None):
     >>> B = sparse.rand(n_rows, n_columns, density=density, format='csr')
     >>> C = sparse.rand(n_rows, n_columns, density=density, format='coo')
     >>> D = np.random.randn(n_rows,n_columns)
-    >>> linalg.clarkson_woodruff_transform(A) # fastest
-    >>> linalg.clarkson_woodruff_transform(B) # fast
-    >>> linalg.clarkson_woodruff_transform(C) # slower
-    >>> linalg.clarkson_woodruff_transform(D) # slowest
+    >>> linalg.clarkson_woodruff_transform(A,sketch_n_rows) # fastest
+    >>> linalg.clarkson_woodruff_transform(B,sketch_n_rows) # fast
+    >>> linalg.clarkson_woodruff_transform(C,sketch_n_rows) # slower
+    >>> linalg.clarkson_woodruff_transform(D,sketch_n_rows) # slowest
+
+    That said, this method does perform well on dense inputs, just slower
+    on a relative scale.
 
     Examples
     --------
     Given a big dense matrix ``A``:
 
+    >>> from scipy import linalg
     >>> n_rows, n_columns, sketch_n_rows = 15000, 100, 200
     >>> A = np.random.randn(n_rows, n_columns)
-    >>> sketch = clarkson_woodruff_transform(A, sketch_n_rows)
+    >>> sketch = linalg.clarkson_woodruff_transform(A,sketch_n_rows)
     >>> sketch.shape
     (150, 100)
     >>> norm_A = np.linalg.norm(A)
@@ -141,9 +145,9 @@ def clarkson_woodruff_transform(input_matrix, sketch_size, seed=None):
     >>> n_rows, n_columns, sketch_n_rows = 15000, 100, 200
     >>> A = np.random.randn(n_rows,n_columns)
     >>> b = np.random.randn(n_rows)
-    >>> x = np.linalg.lstsq(A,b)
+    >>> x = np.linalg.lstsq(A,b,rcond=None)
     >>> Ab = np.hstack((A,b.reshape(-1,1)))
-    >>> SAb = linalg.clarkson_woodruff_transform(Ab, sketch_size=sketch_n_rows)
+    >>> SAb = linalg.clarkson_woodruff_transform(Ab,sketch_n_rows)
     >>> SA, Sb = SAb[:,:-1], SAb[:,-1]
     >>> x_sketched = np.linalg.lstsq(SA,Sb,rcond=None)
 

--- a/scipy/linalg/_sketches.py
+++ b/scipy/linalg/_sketches.py
@@ -44,13 +44,13 @@ def cwt_matrix(n_rows, n_columns, seed=None):
     -----
     Given a matrix A, with probability at least 9/10,
     .. math:: \|SA\| = (1 \pm \epsilon)\|A\|
-    Where the error epsilon is related to the size of S
+    Where the error epsilon is related to the size of S.
     """
     rng = check_random_state(seed)
-    rows = rng.randint(0,n_rows,n_columns)
+    rows = rng.randint(0, n_rows, n_columns)
     cols = np.arange(n_columns)
     signs = rng.choice([1, -1], n_columns)
-    S = coo_matrix((signs,(rows,cols)),shape=(n_rows,n_columns))
+    S = coo_matrix((signs, (rows, cols)),shape=(n_rows, n_columns))
     return S.tocsc()
 
 
@@ -113,11 +113,11 @@ def clarkson_woodruff_transform(input_matrix, sketch_size, seed=None):
     >>> A = sparse.rand(n_rows, n_columns, density=density, format='csc')
     >>> B = sparse.rand(n_rows, n_columns, density=density, format='csr')
     >>> C = sparse.rand(n_rows, n_columns, density=density, format='coo')
-    >>> D = np.random.randn(n_rows,n_columns)
-    >>> SA = linalg.clarkson_woodruff_transform(A,sketch_n_rows) # fastest
-    >>> SB = linalg.clarkson_woodruff_transform(B,sketch_n_rows) # fast
-    >>> SC = linalg.clarkson_woodruff_transform(C,sketch_n_rows) # slower
-    >>> SD = linalg.clarkson_woodruff_transform(D,sketch_n_rows) # slowest
+    >>> D = np.random.randn(n_rows, n_columns)
+    >>> SA = linalg.clarkson_woodruff_transform(A, sketch_n_rows) # fastest
+    >>> SB = linalg.clarkson_woodruff_transform(B, sketch_n_rows) # fast
+    >>> SC = linalg.clarkson_woodruff_transform(C, sketch_n_rows) # slower
+    >>> SD = linalg.clarkson_woodruff_transform(D, sketch_n_rows) # slowest
 
     That said, this method does perform well on dense inputs, just slower
     on a relative scale.
@@ -129,7 +129,7 @@ def clarkson_woodruff_transform(input_matrix, sketch_size, seed=None):
     >>> from scipy import linalg
     >>> n_rows, n_columns, sketch_n_rows = 15000, 100, 200
     >>> A = np.random.randn(n_rows, n_columns)
-    >>> sketch = linalg.clarkson_woodruff_transform(A,sketch_n_rows)
+    >>> sketch = linalg.clarkson_woodruff_transform(A, sketch_n_rows)
     >>> sketch.shape
     (200, 100)
     >>> norm_A = np.linalg.norm(A)
@@ -143,13 +143,13 @@ def clarkson_woodruff_transform(input_matrix, sketch_size, seed=None):
 
     >>> from scipy import linalg
     >>> n_rows, n_columns, sketch_n_rows = 15000, 100, 200
-    >>> A = np.random.randn(n_rows,n_columns)
+    >>> A = np.random.randn(n_rows, n_columns)
     >>> b = np.random.randn(n_rows)
-    >>> x = np.linalg.lstsq(A,b,rcond=None)
-    >>> Ab = np.hstack((A,b.reshape(-1,1)))
-    >>> SAb = linalg.clarkson_woodruff_transform(Ab,sketch_n_rows)
+    >>> x = np.linalg.lstsq(A, b, rcond=None)
+    >>> Ab = np.hstack((A, b.reshape(-1,1)))
+    >>> SAb = linalg.clarkson_woodruff_transform(Ab, sketch_n_rows)
     >>> SA, Sb = SAb[:,:-1], SAb[:,-1]
-    >>> x_sketched = np.linalg.lstsq(SA,Sb,rcond=None)
+    >>> x_sketched = np.linalg.lstsq(SA, Sb, rcond=None)
 
     As with the matrix norm example, ``np.linalg.norm(A @ x - b)``
     is close to ``np.linalg.norm(A @ x_sketched - b)`` with high

--- a/scipy/linalg/_sketches.py
+++ b/scipy/linalg/_sketches.py
@@ -1,7 +1,7 @@
 """ Sketching-based Matrix Computations """
 
-# Author: Jordi Montes <jomsdev@gmail.com>	
-# August 28, 2017	
+# Author: Jordi Montes <jomsdev@gmail.com>
+# August 28, 2017
 
 from __future__ import division, print_function, absolute_import
 
@@ -60,7 +60,9 @@ def clarkson_woodruff_transform(input_matrix, sketch_size, seed=None):
 
     Given an input_matrix ``A`` of size ``(n, d)``, compute a matrix ``A'`` of
     size (sketch_size, d) so that
+
     .. math:: \|Ax\| \approx \|A'x\|
+
     with high probability via the Clarkson-Woodruff Transform, otherwise
     known as the CountSketch matrix.
 
@@ -85,7 +87,9 @@ def clarkson_woodruff_transform(input_matrix, sketch_size, seed=None):
     Notes
     -----
     To make the statement
+
     .. math:: \|Ax\| \approx \|A'x\|
+
     precise, observe the following result which is adapted from the
     proof of Theorem 14 of [2] via Markov's Inequality. If we have
     a sketch size ``sketch_size=k`` which is at least
@@ -93,7 +97,9 @@ def clarkson_woodruff_transform(input_matrix, sketch_size, seed=None):
     .. math:: k \geq \frac{2}{\epsilon^2\delta}
 
     Then for any fixed vector ``x``,
+
     .. math:: \|Ax\| = (1\pm\epsilon)\|A'x\|
+
     with probability at least one minus delta.
 
     This implementation takes advantage of sparsity: computing
@@ -101,17 +107,17 @@ def clarkson_woodruff_transform(input_matrix, sketch_size, seed=None):
     is in ``scipy.sparse.csc_matrix`` format gives the quickest
     computation time for sparse input.
 
-    >>> from scipy.linalg import clarkson_woodruff_transform
+    >>> from scipy import linalg
     >>> from scipy import sparse
     >>> n_rows, n_columns, density, sketch_n_rows = 15000, 100, 0.01, 200
     >>> A = sparse.rand(n_rows, n_columns, density=density, format='csc')
     >>> B = sparse.rand(n_rows, n_columns, density=density, format='csr')
     >>> C = sparse.rand(n_rows, n_columns, density=density, format='coo')
     >>> D = np.random.randn(n_rows,n_columns)
-    >>> clarkson_woodruff_transform(A) # fastest
-    >>> clarkson_woodruff_transform(B) # fast
-    >>> clarkson_woodruff_transform(C) # slower
-    >>> clarkson_woodruff_transform(D) # slowest
+    >>> linalg.clarkson_woodruff_transform(A) # fastest
+    >>> linalg.clarkson_woodruff_transform(B) # fast
+    >>> linalg.clarkson_woodruff_transform(C) # slower
+    >>> linalg.clarkson_woodruff_transform(D) # slowest
 
     Examples
     --------
@@ -129,15 +135,15 @@ def clarkson_woodruff_transform(input_matrix, sketch_size, seed=None):
     the sketched norm ``norm_sketch`` in absolute value.
 
     Similarly, applying our sketch preserves the solution to a linear
-    regression of ``min ||Ax - b||``.
+    regression of :math:`\min \|Ax - b\|`.
 
-    >>> from scipy.linalg import clarkson_woodruff_transform
+    >>> from scipy import linalg
     >>> n_rows, n_columns, sketch_n_rows = 15000, 100, 200
     >>> A = np.random.randn(n_rows,n_columns)
     >>> b = np.random.randn(n_rows)
     >>> x = np.linalg.lstsq(A,b)
     >>> Ab = np.hstack((A,b.reshape(-1,1)))
-    >>> SAb = clarkson_woodruff_transform(Ab, sketch_size=sketch_n_rows)
+    >>> SAb = linalg.clarkson_woodruff_transform(Ab, sketch_size=sketch_n_rows)
     >>> SA, Sb = SAb[:,:-1], SAb[:,-1]
     >>> x_sketched = np.linalg.lstsq(SA,Sb,rcond=None)
 

--- a/scipy/linalg/tests/test_sketches.py
+++ b/scipy/linalg/tests/test_sketches.py
@@ -88,14 +88,18 @@ class TestClarksonWoodruffTransform(object):
         # we pass all/almost all the tries.
         n_errors = 0
         for A in self.test_matrices:
-            true_norm = norm(A) if issparse(A) \
-                        else np.linalg.norm(A)
+            if issparse(A):
+                true_norm = norm(A)
+            else:
+                true_norm = np.linalg.norm(A)
             for seed in self.seeds:
                 sketch = clarkson_woodruff_transform(
                     A, self.n_sketch_rows, seed=seed,
                 )
-                sketch_norm = norm(sketch) if issparse(sketch) \
-                              else np.linalg.norm(sketch)
+                if issparse(sketch):
+                    sketch_norm = norm(sketch)
+                else:
+                    sketch_norm = np.linalg.norm(sketch)
 
                 if np.abs(true_norm - sketch_norm) > 0.1 * true_norm:
                     n_errors += 1
@@ -114,7 +118,3 @@ class TestClarksonWoodruffTransform(object):
             if np.abs(true_norm - sketch_norm) > 0.5 * true_norm:
                 n_errors += 1
         assert_(n_errors == 0)
-
-
-if __name__ == "__main__":
-    np.testing.run_module_suite()

--- a/scipy/linalg/tests/test_sketches.py
+++ b/scipy/linalg/tests/test_sketches.py
@@ -29,7 +29,7 @@ class TestClarksonWoodruffTransform(object):
     seeds = [1755490010, 934377150, 1391612830, 1752708722, 2008891431,
              1302443994, 1521083269, 1501189312, 1126232505, 1533465685]
 
-    A_dense = rng.randn(n_rows,n_cols)
+    A_dense = rng.randn(n_rows, n_cols)
     A_csc = rand(
         n_rows, n_cols, density=density, format='csc', random_state=rng,
     )
@@ -46,7 +46,7 @@ class TestClarksonWoodruffTransform(object):
     ]
 
     # Test vector with norm ~1
-    x = rng.randn(n_rows,1) / np.sqrt(n_rows)
+    x = rng.randn(n_rows, 1) / np.sqrt(n_rows)
 
     def test_sketch_dimensions(self):
         for A in self.test_matrices:
@@ -54,7 +54,7 @@ class TestClarksonWoodruffTransform(object):
                 sketch = clarkson_woodruff_transform(
                     A, self.n_sketch_rows, seed=seed
                 )
-                assert_(sketch.shape == (self.n_sketch_rows,self.n_cols))
+                assert_(sketch.shape == (self.n_sketch_rows, self.n_cols))
 
     def test_seed_returns_identical_transform_matrix(self):
         for A in self.test_matrices:
@@ -65,7 +65,7 @@ class TestClarksonWoodruffTransform(object):
                 S2 = cwt_matrix(
                     self.n_sketch_rows, self.n_rows, seed=seed
                 ).todense()
-                assert_equal(S1,S2)
+                assert_equal(S1, S2)
 
     def test_seed_returns_identically(self):
         for A in self.test_matrices:
@@ -80,7 +80,7 @@ class TestClarksonWoodruffTransform(object):
                     sketch1 = sketch1.todense()
                 if issparse(sketch2):
                     sketch2 = sketch2.todense()
-                assert_equal(sketch1,sketch2)
+                assert_equal(sketch1, sketch2)
 
     def test_sketch_preserves_frobenius_norm(self):
         # Given the probabilistic nature of the sketches

--- a/scipy/linalg/tests/test_sketches.py
+++ b/scipy/linalg/tests/test_sketches.py
@@ -76,8 +76,10 @@ class TestClarksonWoodruffTransform(object):
                 sketch2 = clarkson_woodruff_transform(
                     A, self.n_sketch_rows, seed=seed
                 )
-                if issparse(sketch1): sketch1 = sketch1.todense()
-                if issparse(sketch2): sketch2 = sketch2.todense()
+                if issparse(sketch1):
+                    sketch1 = sketch1.todense()
+                if issparse(sketch2):
+                    sketch2 = sketch2.todense()
                 assert_equal(sketch1,sketch2)
 
     def test_sketch_preserves_frobenius_norm(self):
@@ -100,16 +102,8 @@ class TestClarksonWoodruffTransform(object):
         assert_(n_errors == 0)
 
     def test_sketch_preserves_vector_norm(self):
-        # Testing that the with-high-probability bound presented
-        # in the documentation is right. In particular, sketch
-        # dimension >= 2 / (delta * eps**2) should ensure that
-        # the Euclidean norm of a sketched vector ought to be
-        # within an epsilon multiplicative factor of the original.
-        # Here, we try eps=0.5 and delta=0.01 so that over
-        # all our seeds this norm should be presered to a 0.5
-        # factor.
         n_errors = 0
-        n_sketch_rows = int(np.ceil(2. / (0.01 * 0.5**2))) # = 800
+        n_sketch_rows = int(np.ceil(2. / (0.01 * 0.5**2)))
         true_norm = np.linalg.norm(self.x)
         for seed in self.seeds:
             sketch = clarkson_woodruff_transform(

--- a/scipy/linalg/tests/test_sketches.py
+++ b/scipy/linalg/tests/test_sketches.py
@@ -1,61 +1,126 @@
 """Tests for _sketches.py."""
 
 from __future__ import division, print_function, absolute_import
+
 import numpy as np
+from numpy.testing import assert_, assert_equal
 from scipy.linalg import clarkson_woodruff_transform
-
-from numpy.testing import assert_
-
-
-def make_random_dense_gaussian_matrix(n_rows, n_columns, mu=0, sigma=0.01):
-    """
-    Make some random data with Gaussian distributed values
-    """
-    np.random.seed(142352345)
-    res = np.random.normal(mu, sigma, n_rows*n_columns)
-    return np.reshape(res, (n_rows, n_columns))
+from scipy.linalg._sketches import cwt_matrix
+from scipy.sparse import issparse, rand
+from scipy.sparse.linalg import norm
 
 
 class TestClarksonWoodruffTransform(object):
     """
     Testing the Clarkson Woodruff Transform
     """
-    # Big dense matrix dimensions
-    n_matrix_rows = 2000
-    n_matrix_columns = 100
+    # set seed for generating test matrices
+    rng = np.random.RandomState(seed=1179103485)
+
+    # Test matrix parameters
+    n_rows = 2000
+    n_cols = 100
+    density = 0.1
 
     # Sketch matrix dimensions
-    n_sketch_rows = 100
+    n_sketch_rows = 200
 
-    # Error threshold
-    threshold = 0.1
+    # Seeds to test with
+    seeds = [1755490010, 934377150, 1391612830, 1752708722, 2008891431,
+             1302443994, 1521083269, 1501189312, 1126232505, 1533465685]
 
-    dense_big_matrix = make_random_dense_gaussian_matrix(n_matrix_rows,
-                                                         n_matrix_columns)
+    A_dense = rng.randn(n_rows,n_cols)
+    A_csc = rand(
+        n_rows, n_cols, density=density, format='csc', random_state=rng,
+    )
+    A_csr = rand(
+        n_rows, n_cols, density=density, format='csr', random_state=rng,
+    )
+    A_coo = rand(
+        n_rows, n_cols, density=density, format='coo', random_state=rng,
+    )
+
+    # Collect the test matrices
+    test_matrices = [
+        A_dense, A_csc, A_csr, A_coo,
+    ]
+
+    # Test vector with norm ~1
+    x = rng.randn(n_rows,1) / np.sqrt(n_rows)
 
     def test_sketch_dimensions(self):
-        sketch = clarkson_woodruff_transform(self.dense_big_matrix,
-                                             self.n_sketch_rows)
+        for A in self.test_matrices:
+            for seed in self.seeds:
+                sketch = clarkson_woodruff_transform(
+                    A, self.n_sketch_rows, seed=seed
+                )
+                assert_(sketch.shape == (self.n_sketch_rows,self.n_cols))
 
-        assert_(sketch.shape == (self.n_sketch_rows,
-                                 self.dense_big_matrix.shape[1]))
+    def test_seed_returns_identical_transform_matrix(self):
+        for A in self.test_matrices:
+            for seed in self.seeds:
+                S1 = cwt_matrix(
+                    self.n_sketch_rows, self.n_rows, seed=seed
+                ).todense()
+                S2 = cwt_matrix(
+                    self.n_sketch_rows, self.n_rows, seed=seed
+                ).todense()
+                assert_equal(S1,S2)
 
-    def test_sketch_rows_norm(self):
+    def test_seed_returns_identically(self):
+        for A in self.test_matrices:
+            for seed in self.seeds:
+                sketch1 = clarkson_woodruff_transform(
+                    A, self.n_sketch_rows, seed=seed
+                )
+                sketch2 = clarkson_woodruff_transform(
+                    A, self.n_sketch_rows, seed=seed
+                )
+                if issparse(sketch1): sketch1 = sketch1.todense()
+                if issparse(sketch2): sketch2 = sketch2.todense()
+                assert_equal(sketch1,sketch2)
+
+    def test_sketch_preserves_frobenius_norm(self):
         # Given the probabilistic nature of the sketches
-        # we run the 'test' multiple times and check that
-        # we pass all/almost all the tries
+        # we run the test multiple times and check that
+        # we pass all/almost all the tries.
         n_errors = 0
+        for A in self.test_matrices:
+            true_norm = norm(A) if issparse(A) \
+                        else np.linalg.norm(A)
+            for seed in self.seeds:
+                sketch = clarkson_woodruff_transform(
+                    A, self.n_sketch_rows, seed=seed,
+                )
+                sketch_norm = norm(sketch) if issparse(sketch) \
+                              else np.linalg.norm(sketch)
 
-        seeds = [1755490010, 934377150, 1391612830, 1752708722, 2008891431,
-                 1302443994, 1521083269, 1501189312, 1126232505, 1533465685]
-
-        for seed_ in seeds:
-            sketch = clarkson_woodruff_transform(self.dense_big_matrix,
-                                                 self.n_sketch_rows, seed_)
-
-            # We could use other norms (like L2)
-            err = np.linalg.norm(self.dense_big_matrix) - np.linalg.norm(sketch)
-            if err > self.threshold:
-                n_errors += 1
-
+                if np.abs(true_norm - sketch_norm) > 0.1 * true_norm:
+                    n_errors += 1
         assert_(n_errors == 0)
+
+    def test_sketch_preserves_vector_norm(self):
+        # Testing that the with-high-probability bound presented
+        # in the documentation is right. In particular, sketch
+        # dimension >= 2 / (delta * eps**2) should ensure that
+        # the Euclidean norm of a sketched vector ought to be
+        # within an epsilon multiplicative factor of the original.
+        # Here, we try eps=0.5 and delta=0.01 so that over
+        # all our seeds this norm should be presered to a 0.5
+        # factor.
+        n_errors = 0
+        n_sketch_rows = int(np.ceil(2. / (0.01 * 0.5**2))) # = 800
+        true_norm = np.linalg.norm(self.x)
+        for seed in self.seeds:
+            sketch = clarkson_woodruff_transform(
+                self.x, n_sketch_rows, seed=seed,
+            )
+            sketch_norm = np.linalg.norm(sketch)
+
+            if np.abs(true_norm - sketch_norm) > 0.5 * true_norm:
+                n_errors += 1
+        assert_(n_errors == 0)
+
+
+if __name__ == "__main__":
+    np.testing.run_module_suite()


### PR DESCRIPTION
(See #9816, #7122, #7809, #8498 for all relevant background.)

This PR takes advantage of sparsity when computing the Clarkson-Woodruff transform. The code change is quite small on it's own, but gives a ~60-90% time speedup for _dense_ input matrices on a small benchmark I just ran and a much larger performance boost for truly sparse input matrices, as the algorithm now correctly runs in ``O(nnz(A))`` time.

In addition, I
- Expanded on the documentation to be a bit more concrete about sketch size choices, and
- Fixed a small bug with the current implementation where the same seed would give different sketches (see [this line of code](https://github.com/scipy/scipy/blob/e63d275e097c007d5711f8f200edc30f3b0f72c5/scipy/linalg/_sketches.py#L42) for the reason.) The tests have been expanded as well to catch issues like this.

Let me know if there's anything that needs to be changed on my end, or any more numerical verification to validate the improvement; I'd love to see this be a help to the community. 😊