### PR TITLE
BUG: interp1d: do not allow duplicate `x` values

### DIFF
--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -453,6 +453,8 @@ class interp1d(_Interpolator1D):
 
         if x.ndim != 1:
             raise ValueError("the x array must have exactly one dimension.")
+        if not (np.all(x[1:] - x[:-1] > 0) or np.all(x[1:] - x[:-1] < 0)):
+            raise ValueError("Expect x to be a 1-D sorted array_like.")
         if y.ndim == 0:
             raise ValueError("the y array must have at least one dimension.")
 

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -714,6 +714,16 @@ class TestInterp1D(object):
                 vals = f(xnew)
                 assert_(np.isfinite(vals).all())
 
+    def test_duplicate_x(self):
+        # gh-9886: duplicate values of `x` are not allowed
+        x = np.array([0, 1, 1])
+        y = np.array([0, 1, 0])
+        kinds = ['nearest', 'linear', 'previous', 'next']
+
+        for kind in kinds:
+            with assert_raises(ValueError):
+                interp1d(x,y,kind=kind)
+
 
 class TestLagrange(object):
 


### PR DESCRIPTION
Make `interp1d` raise ValueError for duplicate `x` values. Previously, kinds=`cubic` and `quadratic` raised, but `linear` and `nearest` returned some nonsense instead. 

closes gh-9886