### PR TITLE
MAINT: Replace NumPy aliased functions

### DIFF
--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -23,7 +23,7 @@ __all__ = [
 
 import warnings
 
-from numpy import zeros, concatenate, ravel, all, diff, array, ones
+from numpy import zeros, concatenate, ravel, diff, array, ones
 import numpy as np
 
 from . import fitpack
@@ -173,7 +173,7 @@ class UnivariateSpline(object):
                     not w_finite):
                 raise ValueError("x and y array must not contain "
                                  "NaNs or infs.")
-        if not all(diff(x) > 0.0):
+        if not np.all(diff(x) > 0.0):
             raise ValueError('x must be strictly increasing')
 
         # _data == x,y,w,xb,xe,k,s,n,t,c,fp,fpint,nrdata,ier
@@ -597,7 +597,7 @@ class InterpolatedUnivariateSpline(UnivariateSpline):
             if (not np.isfinite(x).all() or not np.isfinite(y).all() or
                     not w_finite):
                 raise ValueError("Input must not contain NaNs or infs.")
-        if not all(diff(x) > 0.0):
+        if not np.all(diff(x) > 0.0):
             raise ValueError('x must be strictly increasing')
 
         # _data == x,y,w,xb,xe,k,s,n,t,c,fp,fpint,nrdata,ier
@@ -736,7 +736,7 @@ class LSQUnivariateSpline(UnivariateSpline):
             if (not np.isfinite(x).all() or not np.isfinite(y).all() or
                     not w_finite or not np.isfinite(t).all()):
                 raise ValueError("Input(s) must not contain NaNs or infs.")
-        if not all(diff(x) > 0.0):
+        if not np.all(diff(x) > 0.0):
             raise ValueError('x must be strictly increasing')
 
         # _data == x,y,w,xb,xe,k,s,n,t,c,fp,fpint,nrdata,ier
@@ -748,7 +748,7 @@ class LSQUnivariateSpline(UnivariateSpline):
             xe = x[-1]
         t = concatenate(([xb]*(k+1), t, [xe]*(k+1)))
         n = len(t)
-        if not all(t[k+1:n-k]-t[k:n-k-1] > 0, axis=0):
+        if not np.all(t[k+1:n-k]-t[k:n-k-1] > 0, axis=0):
             raise ValueError('Interior knots t must satisfy '
                              'Schoenberg-Whitney conditions')
         if not dfitpack.fpchec(x, t, k) == 0:
@@ -1163,9 +1163,9 @@ class RectBivariateSpline(BivariateSpline):
 
     def __init__(self, x, y, z, bbox=[None] * 4, kx=3, ky=3, s=0):
         x, y = ravel(x), ravel(y)
-        if not all(diff(x) > 0.0):
+        if not np.all(diff(x) > 0.0):
             raise ValueError('x must be strictly increasing')
-        if not all(diff(y) > 0.0):
+        if not np.all(diff(y) > 0.0):
             raise ValueError('y must be strictly increasing')
         if not ((x.min() == x[0]) and (x.max() == x[-1])):
             raise ValueError('x must be strictly ascending')

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -23,7 +23,7 @@ __all__ = [
 
 import warnings
 
-from numpy import zeros, concatenate, alltrue, ravel, all, diff, array, ones
+from numpy import zeros, concatenate, ravel, all, diff, array, ones
 import numpy as np
 
 from . import fitpack
@@ -748,7 +748,7 @@ class LSQUnivariateSpline(UnivariateSpline):
             xe = x[-1]
         t = concatenate(([xb]*(k+1), t, [xe]*(k+1)))
         n = len(t)
-        if not alltrue(t[k+1:n-k]-t[k:n-k-1] > 0, axis=0):
+        if not all(t[k+1:n-k]-t[k:n-k-1] > 0, axis=0):
             raise ValueError('Interior knots t must satisfy '
                              'Schoenberg-Whitney conditions')
         if not dfitpack.fpchec(x, t, k) == 0:

--- a/scipy/io/matlab/mio4.py
+++ b/scipy/io/matlab/mio4.py
@@ -551,7 +551,7 @@ class VarWriter4(object):
             T=mxCHAR_CLASS)
         if arr.dtype.kind == 'U':
             # Recode unicode to latin1
-            n_chars = np.product(dims)
+            n_chars = np.prod(dims)
             st_arr = np.ndarray(shape=(),
                                 dtype=arr_dtype_number(arr, n_chars),
                                 buffer=arr)

--- a/scipy/io/matlab/mio5.py
+++ b/scipy/io/matlab/mio5.py
@@ -685,7 +685,7 @@ class VarWriter5(object):
             # transpose here, because we're flattening the array, before
             # we write the bytes.  The bytes have to be written in
             # Fortran order.
-            n_chars = np.product(shape)
+            n_chars = np.prod(shape)
             st_arr = np.ndarray(shape=(),
                                 dtype=arr_dtype_number(arr, n_chars),
                                 buffer=arr.T.copy())  # Fortran order

--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -1079,7 +1079,7 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
         Least-squares solution.  Return shape matches shape of `b`.
     residues : (K,) ndarray or float
         Square of the 2-norm for each column in ``b - a x``, if ``M > N`` and
-        ``rank(A) == n`` (returns a scalar if b is 1-D). Otherwise a
+        ``ndim(A) == n`` (returns a scalar if b is 1-D). Otherwise a
         (0,)-shaped array is returned.
     rank : int
         Effective rank of `a`.

--- a/scipy/linalg/matfuncs.py
+++ b/scipy/linalg/matfuncs.py
@@ -8,7 +8,7 @@ __all__ = ['expm','cosm','sinm','tanm','coshm','sinhm',
            'tanhm','logm','funm','signm','sqrtm',
            'expm_frechet', 'expm_cond', 'fractional_matrix_power']
 
-from numpy import (Inf, dot, diag, product, logical_not, ravel,
+from numpy import (Inf, dot, diag, prod, logical_not, ravel,
         transpose, conjugate, absolute, amax, sign, isfinite, single)
 import numpy as np
 
@@ -580,7 +580,7 @@ def funm(A, func, disp=True):
     if minden == 0.0:
         minden = tol
     err = min(1, max(tol,(tol/minden)*norm(triu(T,1),1)))
-    if product(ravel(logical_not(isfinite(F))),axis=0):
+    if prod(ravel(logical_not(isfinite(F))),axis=0):
         err = Inf
     if disp:
         if err > 1000*tol:

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -31,10 +31,10 @@ from scipy.linalg.lapack import dgbtrf, dgbtrs, zgbtrf, zgbtrs, \
 from scipy.linalg.misc import norm
 from scipy.linalg._decomp_qz import _select_function
 
-from numpy import array, transpose, any, diag, ones, linalg, \
+from numpy import array, transpose, diag, ones, linalg, \
      argsort, zeros, arange, float32, complex64, dot, conj, identity, \
      ravel, sqrt, iscomplex, shape, sort, conjugate, sign, \
-     asarray, isfinite, all, ndarray, outer, eye, dtype, empty,\
+     asarray, isfinite, ndarray, outer, eye, dtype, empty,\
      triu, tril
 
 from numpy.random import normal, seed, random
@@ -265,7 +265,7 @@ class TestEig(object):
         val2 = dot(B, vr) * w
         res = val1 - val2
         for i in range(res.shape[1]):
-            if all(isfinite(res[:,i])):
+            if np.all(isfinite(res[:,i])):
                 assert_allclose(res[:,i], 0, rtol=1e-13, atol=1e-13, err_msg=msg)
 
         w_fin = w[isfinite(w)]
@@ -1222,7 +1222,7 @@ class TestQR(object):
         a = np.asarray([[8,2,3],[2,9,3],[5,3,6]])
         q,r,p = qr(a, pivoting=True)
         d = abs(diag(r))
-        assert_(all(d[1:] <= d[:-1]))
+        assert_(np.all(d[1:] <= d[:-1]))
         assert_array_almost_equal(dot(transpose(q),q),identity(3))
         assert_array_almost_equal(dot(q,r),a[:,p])
         q2,r2 = qr(a[:,p])
@@ -1253,7 +1253,7 @@ class TestQR(object):
         a = np.asarray([[8,2,3],[2,9,3]])
         q,r,p = qr(a, pivoting=True)
         d = abs(diag(r))
-        assert_(all(d[1:] <= d[:-1]))
+        assert_(np.all(d[1:] <= d[:-1]))
         assert_array_almost_equal(dot(transpose(q),q),identity(2))
         assert_array_almost_equal(dot(q,r),a[:,p])
         q2,r2 = qr(a[:,p])
@@ -1272,7 +1272,7 @@ class TestQR(object):
         a = np.asarray([[8,2],[2,9],[5,3]])
         q,r,p = qr(a, pivoting=True)
         d = abs(diag(r))
-        assert_(all(d[1:] <= d[:-1]))
+        assert_(np.all(d[1:] <= d[:-1]))
         assert_array_almost_equal(dot(transpose(q),q),identity(3))
         assert_array_almost_equal(dot(q,r),a[:,p])
         q2,r2 = qr(a[:,p])
@@ -1293,7 +1293,7 @@ class TestQR(object):
         a = np.asarray([[8,2],[2,9],[5,3]])
         q,r,p = qr(a, pivoting=True, mode='economic')
         d = abs(diag(r))
-        assert_(all(d[1:] <= d[:-1]))
+        assert_(np.all(d[1:] <= d[:-1]))
         assert_array_almost_equal(dot(transpose(q),q),identity(2))
         assert_array_almost_equal(dot(q,r),a[:,p])
         q2,r2 = qr(a[:,p], mode='economic')
@@ -1356,7 +1356,7 @@ class TestQR(object):
         a = np.asarray([[8,2,5],[2,9,3]])
         q,r,p = qr(a, pivoting=True)
         d = abs(diag(r))
-        assert_(all(d[1:] <= d[:-1]))
+        assert_(np.all(d[1:] <= d[:-1]))
         assert_array_almost_equal(dot(transpose(q),q),identity(2))
         assert_array_almost_equal(dot(q,r),a[:,p])
         assert_equal(q.shape, (2,2))
@@ -1379,7 +1379,7 @@ class TestQR(object):
         a = np.asarray([[8,2,3],[2,9,5]])
         q,r,p = qr(a, pivoting=True, mode='economic')
         d = abs(diag(r))
-        assert_(all(d[1:] <= d[:-1]))
+        assert_(np.all(d[1:] <= d[:-1]))
         assert_array_almost_equal(dot(transpose(q),q),identity(2))
         assert_array_almost_equal(dot(q,r),a[:,p])
         assert_equal(q.shape, (2,2))
@@ -1488,7 +1488,7 @@ class TestQR(object):
         a = np.asarray([[3,3+4j,5],[5,2,2+7j],[3,2,7]])
         q,r,p = qr(a, pivoting=True)
         d = abs(diag(r))
-        assert_(all(d[1:] <= d[:-1]))
+        assert_(np.all(d[1:] <= d[:-1]))
         assert_array_almost_equal(dot(conj(transpose(q)),q),identity(3))
         assert_array_almost_equal(dot(q,r),a[:,p])
         q2,r2 = qr(a[:,p])
@@ -1545,7 +1545,7 @@ class TestQR(object):
             a = random([n,n])
             q,r,p = qr(a, pivoting=True)
             d = abs(diag(r))
-            assert_(all(d[1:] <= d[:-1]))
+            assert_(np.all(d[1:] <= d[:-1]))
             assert_array_almost_equal(dot(transpose(q),q),identity(n))
             assert_array_almost_equal(dot(q,r),a[:,p])
             q2,r2 = qr(a[:,p])
@@ -1596,7 +1596,7 @@ class TestQR(object):
             a = random([m,n])
             q,r,p = qr(a, pivoting=True)
             d = abs(diag(r))
-            assert_(all(d[1:] <= d[:-1]))
+            assert_(np.all(d[1:] <= d[:-1]))
             assert_array_almost_equal(dot(transpose(q),q),identity(m))
             assert_array_almost_equal(dot(q,r),a[:,p])
             q2,r2 = qr(a[:,p])
@@ -1623,7 +1623,7 @@ class TestQR(object):
             a = random([m,n])
             q,r,p = qr(a, pivoting=True, mode='economic')
             d = abs(diag(r))
-            assert_(all(d[1:] <= d[:-1]))
+            assert_(np.all(d[1:] <= d[:-1]))
             assert_array_almost_equal(dot(transpose(q),q),identity(n))
             assert_array_almost_equal(dot(q,r),a[:,p])
             assert_equal(q.shape, (m,n))
@@ -1648,7 +1648,7 @@ class TestQR(object):
             a = random([m,n])
             q,r,p = qr(a, pivoting=True)
             d = abs(diag(r))
-            assert_(all(d[1:] <= d[:-1]))
+            assert_(np.all(d[1:] <= d[:-1]))
             assert_array_almost_equal(dot(transpose(q),q),identity(m))
             assert_array_almost_equal(dot(q,r),a[:,p])
             q2,r2 = qr(a[:,p])
@@ -1691,7 +1691,7 @@ class TestQR(object):
             a = random([n,n])+1j*random([n,n])
             q,r,p = qr(a, pivoting=True)
             d = abs(diag(r))
-            assert_(all(d[1:] <= d[:-1]))
+            assert_(np.all(d[1:] <= d[:-1]))
             assert_array_almost_equal(dot(conj(transpose(q)),q),identity(n))
             assert_array_almost_equal(dot(q,r),a[:,p])
             q2,r2 = qr(a[:,p])
@@ -1842,7 +1842,7 @@ class TestSchur(object):
         t,z = schur(a)
         assert_array_almost_equal(dot(dot(z,t),transp(conj(z))),a)
         tc,zc = schur(a,'complex')
-        assert_(any(ravel(iscomplex(zc))) and any(ravel(iscomplex(tc))))
+        assert_(np.any(ravel(iscomplex(zc))) and np.any(ravel(iscomplex(tc))))
         assert_array_almost_equal(dot(dot(zc,tc),transp(conj(zc))),a)
         tc2,zc2 = rsf2csf(tc,zc)
         assert_array_almost_equal(dot(dot(zc2,tc2),transp(conj(zc2))),a)
@@ -2016,7 +2016,7 @@ class TestQZ(object):
         assert_array_almost_equal(dot(dot(Q,BB),Z.T), B, decimal=5)
         assert_array_almost_equal(dot(Q,Q.T), eye(n), decimal=5)
         assert_array_almost_equal(dot(Z,Z.T), eye(n), decimal=5)
-        assert_(all(diag(BB) >= 0))
+        assert_(np.all(diag(BB) >= 0))
 
     def test_qz_double(self):
         n = 5
@@ -2027,7 +2027,7 @@ class TestQZ(object):
         assert_array_almost_equal(dot(dot(Q,BB),Z.T), B)
         assert_array_almost_equal(dot(Q,Q.T), eye(n))
         assert_array_almost_equal(dot(Z,Z.T), eye(n))
-        assert_(all(diag(BB) >= 0))
+        assert_(np.all(diag(BB) >= 0))
 
     def test_qz_complex(self):
         n = 5
@@ -2038,8 +2038,8 @@ class TestQZ(object):
         assert_array_almost_equal(dot(dot(Q,BB),Z.conjugate().T), B)
         assert_array_almost_equal(dot(Q,Q.conjugate().T), eye(n))
         assert_array_almost_equal(dot(Z,Z.conjugate().T), eye(n))
-        assert_(all(diag(BB) >= 0))
-        assert_(all(diag(BB).imag == 0))
+        assert_(np.all(diag(BB) >= 0))
+        assert_(np.all(diag(BB).imag == 0))
 
     def test_qz_complex64(self):
         n = 5
@@ -2050,8 +2050,8 @@ class TestQZ(object):
         assert_array_almost_equal(dot(dot(Q,BB),Z.conjugate().T), B, decimal=5)
         assert_array_almost_equal(dot(Q,Q.conjugate().T), eye(n), decimal=5)
         assert_array_almost_equal(dot(Z,Z.conjugate().T), eye(n), decimal=5)
-        assert_(all(diag(BB) >= 0))
-        assert_(all(diag(BB).imag == 0))
+        assert_(np.all(diag(BB) >= 0))
+        assert_(np.all(diag(BB).imag == 0))
 
     def test_qz_double_complex(self):
         n = 5
@@ -2066,7 +2066,7 @@ class TestQZ(object):
         assert_array_almost_equal(bb.imag, 0)
         assert_array_almost_equal(dot(Q,Q.conjugate().T), eye(n))
         assert_array_almost_equal(dot(Z,Z.conjugate().T), eye(n))
-        assert_(all(diag(BB) >= 0))
+        assert_(np.all(diag(BB) >= 0))
 
     def test_qz_double_sort(self):
         # from https://www.nag.com/lapack-ex/node119.html
@@ -2166,8 +2166,8 @@ class TestQZ(object):
     #    AAS,BBS,QS,ZS,sdim = qz(cA,cB,sort='lhp')
 
     #    eigenvalues = diag(AAS)/diag(BBS)
-    #    assert_(all(np.real(eigenvalues[:sdim] < 0)))
-    #    assert_(all(np.real(eigenvalues[sdim:] > 0)))
+    #    assert_(np.all(np.real(eigenvalues[:sdim] < 0)))
+    #    assert_(np.all(np.real(eigenvalues[sdim:] > 0)))
 
     def test_check_finite(self):
         n = 5
@@ -2178,7 +2178,7 @@ class TestQZ(object):
         assert_array_almost_equal(dot(dot(Q,BB),Z.T), B)
         assert_array_almost_equal(dot(Q,Q.T), eye(n))
         assert_array_almost_equal(dot(Z,Z.T), eye(n))
-        assert_(all(diag(BB) >= 0))
+        assert_(np.all(diag(BB) >= 0))
 
 
 def _make_pos(X):

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -31,7 +31,7 @@ from scipy.linalg.lapack import dgbtrf, dgbtrs, zgbtrf, zgbtrs, \
 from scipy.linalg.misc import norm
 from scipy.linalg._decomp_qz import _select_function
 
-from numpy import array, transpose, sometrue, diag, ones, linalg, \
+from numpy import array, transpose, any, diag, ones, linalg, \
      argsort, zeros, arange, float32, complex64, dot, conj, identity, \
      ravel, sqrt, iscomplex, shape, sort, conjugate, sign, \
      asarray, isfinite, all, ndarray, outer, eye, dtype, empty,\
@@ -1833,7 +1833,6 @@ class TestRQ(object):
 
 
 transp = transpose
-any = sometrue
 
 
 class TestSchur(object):

--- a/scipy/misc/common.py
+++ b/scipy/misc/common.py
@@ -5,7 +5,7 @@ Functions which are common and require SciPy Base and Level 1 SciPy
 
 from __future__ import division, print_function, absolute_import
 
-from numpy import arange, newaxis, hstack, product, array, frombuffer, load
+from numpy import arange, newaxis, hstack, prod, array, frombuffer, load
 
 __all__ = ['central_diff_weights', 'derivative', 'ascent', 'face',
            'electrocardiogram']
@@ -43,7 +43,7 @@ def central_diff_weights(Np, ndiv=1):
     X = x**0.0
     for k in range(1,Np):
         X = hstack([X,x**k])
-    w = product(arange(1,ndiv+1),axis=0)*linalg.inv(X)[ndiv]
+    w = prod(arange(1,ndiv+1),axis=0)*linalg.inv(X)[ndiv]
     return w
 
 
@@ -117,7 +117,7 @@ def derivative(func, x0, dx=1.0, n=1, args=(), order=3):
     ho = order >> 1
     for k in range(order):
         val += weights[k]*func(x0+(k-ho)*dx,*args)
-    return val / product((dx,)*n,axis=0)
+    return val / prod((dx,)*n,axis=0)
 
 
 def ascent():

--- a/scipy/ndimage/interpolation.py
+++ b/scipy/ndimage/interpolation.py
@@ -719,7 +719,7 @@ def rotate(input, angle, axes=(1, 0), reshape=True, output=None, order=3,
                          order, mode, cval, prefilter)
     else:
         coordinates = []
-        size = numpy.product(input.shape, axis=0)
+        size = numpy.prod(input.shape, axis=0)
         size //= input.shape[axes[0]]
         size //= input.shape[axes[1]]
         for ii in range(input.ndim):

--- a/scipy/ndimage/morphology.py
+++ b/scipy/ndimage/morphology.py
@@ -226,7 +226,7 @@ def _binary_erosion(input, structure, iterations, mask, output,
         raise RuntimeError('structure and input must have same dimensionality')
     if not structure.flags.contiguous:
         structure = structure.copy()
-    if numpy.product(structure.shape, axis=0) < 1:
+    if numpy.prod(structure.shape, axis=0) < 1:
         raise RuntimeError('structure must not be empty')
     if mask is not None:
         mask = numpy.asarray(mask)
@@ -2014,7 +2014,7 @@ def distance_transform_cdt(input, metric='chessboard', return_distances=True,
 
     rank = dt.ndim
     if return_indices:
-        sz = numpy.product(dt.shape, axis=0)
+        sz = numpy.prod(dt.shape, axis=0)
         ft = numpy.arange(sz, dtype=numpy.int32)
         ft.shape = dt.shape
     else:

--- a/scipy/ndimage/tests/test_regression.py
+++ b/scipy/ndimage/tests/test_regression.py
@@ -31,7 +31,7 @@ def test_ticket_742():
 
     if np.dtype(np.intp) != np.dtype('i'):
         shape = (3,1240,1240)
-        a = np.random.rand(np.product(shape)).reshape(shape)
+        a = np.random.rand(np.prod(shape)).reshape(shape)
         # shouldn't crash
         SE(a)
 

--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -6,7 +6,7 @@ from . import _minpack
 
 import numpy as np
 from numpy import (atleast_1d, dot, take, triu, shape, eye,
-                   transpose, zeros, product, greater, array,
+                   transpose, zeros, prod, greater, array,
                    all, where, isscalar, asarray, inf, abs,
                    finfo, inexact, issubdtype, dtype)
 from scipy.linalg import svd, cholesky, solve_triangular, LinAlgError
@@ -818,7 +818,7 @@ def check_gradient(fcn, Dfcn, x0, args=(), col_deriv=0):
     fvecp = fvecp.reshape((m,))
     _minpack._chkder(m, n, x, fvec, fjac, ldfjac, xp, fvecp, 2, err)
 
-    good = (product(greater(err, 0.5), axis=0))
+    good = (prod(greater(err, 0.5), axis=0))
 
     return (good, err)
 

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -66,7 +66,7 @@ class MemoizeJac(object):
         return fg[0]
 
     def derivative(self, x, *args):
-        if self.jac is not None and numpy.alltrue(x == self.x):
+        if self.jac is not None and numpy.all(x == self.x):
             return self.jac
         else:
             self(x, *args)

--- a/scipy/signal/lti_conversion.py
+++ b/scipy/signal/lti_conversion.py
@@ -7,7 +7,7 @@ from __future__ import division, print_function, absolute_import
 import numpy
 import numpy as np
 from numpy import (r_, eye, atleast_2d, poly, dot,
-                   asarray, product, zeros, array, outer)
+                   asarray, prod, zeros, array, outer)
 from scipy import linalg
 
 from .filter_design import tf2zpk, zpk2tf, normalize
@@ -268,9 +268,9 @@ def ss2tf(A, B, C, D, input=0):
     except ValueError:
         den = 1
 
-    if (product(B.shape, axis=0) == 0) and (product(C.shape, axis=0) == 0):
+    if (prod(B.shape, axis=0) == 0) and (prod(C.shape, axis=0) == 0):
         num = numpy.ravel(D)
-        if (product(D.shape, axis=0) == 0) and (product(A.shape, axis=0) == 0):
+        if (prod(D.shape, axis=0) == 0) and (prod(A.shape, axis=0) == 0):
             den = []
         return num, den
 

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -18,7 +18,7 @@ from numpy import (allclose, angle, arange, argsort, array, asarray,
                    atleast_1d, atleast_2d, cast, dot, exp, expand_dims,
                    iscomplexobj, mean, ndarray, newaxis, ones, pi,
                    poly, polyadd, polyder, polydiv, polymul, polysub, polyval,
-                   product, r_, ravel, real_if_close, reshape,
+                   prod, r_, ravel, real_if_close, reshape,
                    roots, sort, take, transpose, unique, where, zeros,
                    zeros_like)
 import numpy as np
@@ -922,7 +922,7 @@ def medfilt(volume, kernel_size=None):
 
     domain = ones(kernel_size)
 
-    numels = product(kernel_size, axis=0)
+    numels = prod(kernel_size, axis=0)
     order = numels // 2
     return sigtools._order_filterND(volume, domain, order)
 
@@ -960,11 +960,11 @@ def wiener(im, mysize=None, noise=None):
         mysize = np.repeat(mysize.item(), im.ndim)
 
     # Estimate the local mean
-    lMean = correlate(im, ones(mysize), 'same') / product(mysize, axis=0)
+    lMean = correlate(im, ones(mysize), 'same') / prod(mysize, axis=0)
 
     # Estimate the local variance
     lVar = (correlate(im ** 2, ones(mysize), 'same') /
-            product(mysize, axis=0) - lMean ** 2)
+            prod(mysize, axis=0) - lMean ** 2)
 
     # Estimate the noise power if needed.
     if noise is None:

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -212,7 +212,7 @@ class TestPlacePoles(object):
         assert_raises(ValueError, place_poles, A, B, (-2.1,-2.2,-2.3,-2.4),
                       maxiter=-42)
 
-        # should fail as rank(B) is two
+        # should fail as ndim(B) is two
         assert_raises(ValueError, place_poles, A, B, (-2,-2,-2,-2))
 
         #unctrollable system

--- a/scipy/sparse/data.py
+++ b/scipy/sparse/data.py
@@ -199,7 +199,7 @@ class _minmax_mixin(object):
             if self.nnz == 0:
                 return zero
             m = min_or_max.reduce(self._deduped_data().ravel())
-            if self.nnz != np.product(self.shape):
+            if self.nnz != np.prod(self.shape):
                 m = min_or_max(zero, m)
             return m
 
@@ -272,7 +272,7 @@ class _minmax_mixin(object):
                 if compare(m, zero):
                     return mat.row[am] * mat.shape[1] + mat.col[am]
                 else:
-                    size = np.product(mat.shape)
+                    size = np.prod(mat.shape)
                     if size == mat.nnz:
                         return am
                     else:

--- a/scipy/special/_generate_pyx.py
+++ b/scipy/special/_generate_pyx.py
@@ -840,7 +840,7 @@ class FusedFunc(Func):
         all_codes = tuple([codes for _unused, codes in fused_types])
 
         codelens = list(map(lambda x: len(x), all_codes))
-        last = numpy.product(codelens) - 1
+        last = numpy.prod(codelens) - 1
         for m, codes in enumerate(itertools.product(*all_codes)):
             fused_codes, decs = [], []
             for n, fused_type in enumerate(fused_types):


### PR DESCRIPTION
In https://github.com/numpy/numpy/pull/10653, NumPy has replaced duplicate
implementations by aliased functions. Such aliases may not be available in other
NumPy-like libraries (e.g., CuPy), thus breaking compatibility after the
introduction of __array_function__, as described in NEP-18 [1].

[1] https://www.numpy.org/neps/nep-0018-array-function-protocol.html

cc @mrocklin