### PR TITLE
BUG: Fix 9890 query_ball_point returns wrong result when p is large.

### DIFF
--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -666,6 +666,7 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
             1 is the sum-of-absolute-values "Manhattan" distance
             2 is the usual Euclidean distance
             infinity is the maximum-coordinate-difference distance
+            A finite large p may cause a ValueError if overflow can occur.
         distance_upper_bound : nonnegative float
             Return only neighbors within this distance.  This is used to prune
             tree searches, so if you are doing a series of nearest-neighbor
@@ -871,6 +872,7 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
             The radius of points to return.
         p : float, optional
             Which Minkowski p-norm to use.  Should be in the range [1, inf].
+            A finite large p may cause a ValueError if overflow can occur.
         eps : nonnegative float, optional
             Approximate search. Branches of the tree are not explored if their
             nearest points are further than ``r / (1 + eps)``, and branches are
@@ -1058,6 +1060,7 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
         p : float, optional
             Which Minkowski norm to use.  `p` has to meet the condition
             ``1 <= p <= infinity``.
+            A finite large p may cause a ValueError if overflow can occur.
         eps : float, optional
             Approximate search.  Branches of the tree are not explored
             if their nearest points are further than ``r/(1+eps)``, and
@@ -1145,6 +1148,7 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
         p : float, optional
             Which Minkowski norm to use.  ``p`` has to meet the condition
             ``1 <= p <= infinity``.
+            A finite large p may cause a ValueError if overflow can occur.
         eps : float, optional
             Approximate search.  Branches of the tree are not explored
             if their nearest points are further than ``r/(1+eps)``, and
@@ -1246,6 +1250,7 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
             1<=p<=infinity. 
             Which Minkowski p-norm to use.
             Default 2.0.
+            A finite large p may cause a ValueError if overflow can occur.
         weights : tuple, array_like, or None, optional
             If None, the pair-counting is unweighted.
             If given as a tuple, weights[0] is the weights of points in ``self``, and
@@ -1462,7 +1467,8 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
         max_distance : positive float
         
         p : float, 1<=p<=infinity
-            Which Minkowski p-norm to use. 
+            Which Minkowski p-norm to use.
+            A finite large p may cause a ValueError if overflow can occur.
         
         output_type : string, optional
             Which container to use for output data. Options: 'dok_matrix',

--- a/scipy/spatial/ckdtree/src/query_ball_point.cxx
+++ b/scipy/spatial/ckdtree/src/query_ball_point.cxx
@@ -33,8 +33,9 @@ traverse_no_checking(const ckdtree *self,
         lnode = node;
         const npy_intp start = lnode->start_idx;
         const npy_intp end = lnode->end_idx;
-        for (i = start; i < end; ++i)
+        for (i = start; i < end; ++i) {
             results->push_back(indices[i]);
+        }
     }
     else {
         traverse_no_checking(self, results, node->less);
@@ -53,10 +54,12 @@ traverse_checking(const ckdtree *self,
     npy_float64 d;
     npy_intp i;
 
-    if (tracker->min_distance > tracker->upper_bound * tracker->epsfac)
+    if (tracker->min_distance > tracker->upper_bound * tracker->epsfac) {
         return;
-    else if (tracker->max_distance < tracker->upper_bound / tracker->epsfac)
+    }
+    else if (tracker->max_distance < tracker->upper_bound / tracker->epsfac) {
         traverse_no_checking(self, results, node);
+    }
     else if (node->split_dim == -1)  { /* leaf node */
 
         /* brute-force */

--- a/scipy/spatial/ckdtree/src/rectangle.h
+++ b/scipy/spatial/ckdtree/src/rectangle.h
@@ -114,6 +114,10 @@ template<typename MinMaxDist>
     std::vector<RR_stack_item> stack_arr;
     RR_stack_item *stack;
 
+    /* if min/max distance / adjustment is less than this,
+     * we believe the incremental tracking is inaccurate */
+    npy_float64 inaccurate_distance_limit;
+
     void _resize_stack(const npy_intp new_max_size) {
         stack_arr.resize(new_max_size);
         stack = &stack_arr[0];
@@ -160,6 +164,7 @@ template<typename MinMaxDist>
         /* Compute initial min and max distances */
         MinMaxDist::rect_rect_p(tree, rect1, rect2, p, &min_distance, &max_distance);
 
+        inaccurate_distance_limit = max_distance;
     };
 
 
@@ -194,29 +199,30 @@ template<typename MinMaxDist>
         item->max_along_dim = rect->maxes()[split_dim];
 
         /* update min/max distances */
-        npy_float64 min, max;
+        npy_float64 min1, max1;
+        npy_float64 min2, max2;
 
-        MinMaxDist::interval_interval_p(tree, rect1, rect2, split_dim, p, &min, &max);
-
-        subnomial = subnomial || (min < min_distance * 1e-7 || max < max_distance * 1e-7);
-
-        min_distance -= min;
-        max_distance -= max;
+        MinMaxDist::interval_interval_p(tree, rect1, rect2, split_dim, p, &min1, &max1);
 
         if (direction == LESS)
             rect->maxes()[split_dim] = split_val;
         else
             rect->mins()[split_dim] = split_val;
 
-        MinMaxDist::interval_interval_p(tree, rect1, rect2, split_dim, p, &min, &max);
+        MinMaxDist::interval_interval_p(tree, rect1, rect2, split_dim, p, &min2, &max2);
 
-        min_distance += min;
-        max_distance += max;
+        subnomial = subnomial || (min_distance < inaccurate_distance_limit || max_distance < inaccurate_distance_limit);
 
-        subnomial = subnomial || (min < min_distance * 1e-7 || max < max_distance * 1e-7);
+        subnomial = subnomial || ((min1 != 0 && min1 < inaccurate_distance_limit) || max1 < inaccurate_distance_limit);
+        subnomial = subnomial || ((min2 != 0 && min2 < inaccurate_distance_limit) || max2 < inaccurate_distance_limit);
+        subnomial = subnomial || (min_distance < inaccurate_distance_limit || max_distance < inaccurate_distance_limit);
 
-        if (subnomial)
+        if (NPY_UNLIKELY(subnomial)) {
             MinMaxDist::rect_rect_p(tree, rect1, rect2, p, &min_distance, &max_distance);
+        } else {
+            min_distance += (min2 - min1);
+            max_distance += (max2 - max1);
+        }
     };
 
     inline void push_less_of(const npy_intp which,

--- a/scipy/spatial/ckdtree/src/rectangle.h
+++ b/scipy/spatial/ckdtree/src/rectangle.h
@@ -164,7 +164,9 @@ template<typename MinMaxDist>
         /* Compute initial min and max distances */
         MinMaxDist::rect_rect_p(tree, rect1, rect2, p, &min_distance, &max_distance);
         if(ckdtree_isinf(max_distance)) {
-            const char *msg = "floating point overlow error. The value of p is too high for this dataset.";
+            const char *msg = "Encountering floating point overflow. "
+                              "The value of p too large for this dataset; "
+                              "For such large p, consider using the special case p=np.inf . ";
             throw std::invalid_argument(msg); // raises ValueError
         }
         inaccurate_distance_limit = max_distance;

--- a/scipy/spatial/ckdtree/src/rectangle.h
+++ b/scipy/spatial/ckdtree/src/rectangle.h
@@ -163,7 +163,10 @@ template<typename MinMaxDist>
 
         /* Compute initial min and max distances */
         MinMaxDist::rect_rect_p(tree, rect1, rect2, p, &min_distance, &max_distance);
-
+        if(ckdtree_isinf(max_distance)) {
+            const char *msg = "floating point overlow error. The value of p is too high for this dataset.";
+            throw std::invalid_argument(msg); // raises ValueError
+        }
         inaccurate_distance_limit = max_distance;
     };
 

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -357,13 +357,13 @@ class Test_random_ball_compiled_largep_issue9890(ball_consistency):
     def setup_method(self):
         n = 1000
         m = 2
-        np.random.seed(1234)
-        self.data = np.random.randn(n,m) * 1000
-        self.T = cKDTree(self.data,leafsize=2)
-        self.x = np.random.randn(m)
-        self.p = 13.2
+        np.random.seed(123)
+        self.data = np.random.randint(100, 1000, size=(n, m))
+        self.T = cKDTree(self.data)
+        self.x = self.data#[3] #np.random.randn(m)
+        self.p = 15.0
         self.eps = 0
-        self.d = 100
+        self.d = 10
 
 class Test_random_ball_approx(Test_random_ball):
 

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -348,6 +348,19 @@ class Test_random_ball_compiled_periodic(ball_consistency):
         c[l] = False
         assert_(np.all(self.distance(self.data[c],self.x,self.p) >= self.d/(1.+self.eps)))
 
+class Test_random_ball_compiled_largep_issue9890(ball_consistency):
+
+    def setup_method(self):
+        n = 1000
+        m = 2
+        np.random.seed(1234)
+        self.data = np.random.randn(n,m) * 1000
+        self.T = cKDTree(self.data,leafsize=2)
+        self.x = np.random.randn(m)
+        self.p = 13.2
+        self.eps = 0
+        self.d = 100
+
 class Test_random_ball_approx(Test_random_ball):
 
     def setup_method(self):

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -359,14 +359,15 @@ class Test_random_ball_compiled_periodic(ball_consistency):
 
 class Test_random_ball_compiled_largep_issue9890(ball_consistency):
 
+    tol = 1e-13 # allow some roundoff errors due to numerical issues
     def setup_method(self):
         n = 1000
         m = 2
         np.random.seed(123)
         self.data = np.random.randint(100, 1000, size=(n, m))
         self.T = cKDTree(self.data)
-        self.x = self.data#[3] #np.random.randn(m)
-        self.p = 15.0
+        self.x = self.data
+        self.p = 100
         self.eps = 0
         self.d = 10
 

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -277,16 +277,20 @@ class ball_consistency:
         return minkowski_distance(a, b, p)
 
     def test_in_ball(self):
-        l = self.T.query_ball_point(self.x, self.d, p=self.p, eps=self.eps)
-        for i in l:
-            assert_(self.distance(self.data[i],self.x,self.p) <= self.d*(1.+self.eps))
+        x = np.atleast_2d(self.x)
+        d = np.broadcast_to(self.d, x.shape[:-1])
+        l = self.T.query_ball_point(x, self.d, p=self.p, eps=self.eps)
+        for i, ind in enumerate(l):
+            assert_(np.all(self.distance(self.data[ind], x[i],self.p) <= d[i]*(1.+self.eps)))
 
     def test_found_all(self):
-        c = np.ones(self.T.n,dtype=bool)
-        l = self.T.query_ball_point(self.x, self.d, p=self.p, eps=self.eps)
-        c[l] = False
-        assert_(np.all(self.distance(self.data[c],self.x,self.p) >= self.d/(1.+self.eps)))
-
+        x = np.atleast_2d(self.x)
+        d = np.broadcast_to(self.d, x.shape[:-1])
+        l = self.T.query_ball_point(x, self.d, p=self.p, eps=self.eps)
+        for i, ind in enumerate(l):
+            c = np.ones(self.T.n, dtype=bool)
+            c[ind] = False
+            assert_(np.all(self.distance(self.data[c], x[i],self.p) >= d[i]/(1.+self.eps)))
 
 class Test_random_ball(ball_consistency):
 

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -284,7 +284,7 @@ class ball_consistency:
         for i, ind in enumerate(l):
             dist = self.distance(self.data[ind], x[i],self.p) - d[i]*(1.+self.eps)
             norm = self.distance(self.data[ind], x[i],self.p) + d[i]*(1.+self.eps)
-            assert_array_equal(dist < self.tol * norm, True )
+            assert_array_equal(dist < self.tol * norm, True)
 
     def test_found_all(self):
         x = np.atleast_2d(self.x)
@@ -359,7 +359,9 @@ class Test_random_ball_compiled_periodic(ball_consistency):
 
 class Test_random_ball_compiled_largep_issue9890(ball_consistency):
 
-    tol = 1e-13 # allow some roundoff errors due to numerical issues
+    # allow some roundoff errors due to numerical issues
+    tol = 1e-13
+
     def setup_method(self):
         n = 1000
         m = 2


### PR DESCRIPTION
We use incremental distance tracking during tree walk to avoid the relatively expensive recalculation of the min, max distance.

This is OK when the distance contribution from any split is not significantly smaller than others. But when the dynamic range is large, the tracking will be buried under round off errors, and our estimate of the min, max distances are completely wrong.

When p is large the dynamic range if distances is indeed large. Therefore we encounter 9890.
The solution here adds a heuristics to detect if round-off error may occur, and recalculates the min, max distance if that does occur.

Closes #9890