### PR TITLE
BUG: curve_fit doesn't check for empty input if called with bounds

### DIFF
--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -382,6 +382,7 @@ def leastsq(func, x0, args=(), Dfun=None, full_output=0,
         args = (args,)
     shape, dtype = _check_func('leastsq', 'func', func, x0, args, n)
     m = shape[0]
+
     if n > m:
         raise TypeError('Improper input: N=%s must not exceed M=%s' % (n, m))
     if epsfcn is None:
@@ -671,6 +672,10 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
     >>> plt.show()
 
     """
+    
+    if len(xdata) == 0 or len(ydata) == 0:
+        raise ValueError("Improper input: N=1 must not exceed M=0")
+        
     if p0 is None:
         # determine number of parameters by inspecting the function
         from scipy._lib._util import getargspec_no_self as _getargspec

--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -385,8 +385,10 @@ def leastsq(func, x0, args=(), Dfun=None, full_output=0,
 
     if n > m:
         raise TypeError('Improper input: N=%s must not exceed M=%s' % (n, m))
+
     if epsfcn is None:
         epsfcn = finfo(dtype).eps
+
     if Dfun is None:
         if maxfev == 0:
             maxfev = 200*(n + 1)
@@ -515,15 +517,17 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
         The model function, f(x, ...).  It must take the independent
         variable as the first argument and the parameters to fit as
         separate remaining arguments.
-    xdata : An M-length sequence or an (k,M)-shaped array for functions with k predictors
+    xdata : array_like
         The independent variable where the data is measured.
-    ydata : M-length sequence
-        The dependent data --- nominally f(xdata, ...)
-    p0 : None, scalar, or N-length sequence, optional
-        Initial guess for the parameters.  If None, then the initial
-        values will all be 1 (if the number of parameters for the function
-        can be determined using introspection, otherwise a ValueError
-        is raised).
+        Must be an M-length sequence or an (k,M)-shaped array for functions
+        with k predictors.
+    ydata : array_like
+        The dependent data, a length M array - nominally ``f(xdata, ...)``.
+    p0 : array_like, optional
+        Initial guess for the parameters (length N).  If None, then the
+        initial values will all be 1 (if the number of parameters for the
+        function can be determined using introspection, otherwise a
+        ValueError is raised).
     sigma : None or M-length sequence or MxM array, optional
         Determines the uncertainty in `ydata`. If we define residuals as
         ``r = ydata - f(xdata, *popt)``, then the interpretation of `sigma`
@@ -633,7 +637,6 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
 
     Examples
     --------
-    >>> import numpy as np
     >>> import matplotlib.pyplot as plt
     >>> from scipy.optimize import curve_fit
 
@@ -672,10 +675,6 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
     >>> plt.show()
 
     """
-    
-    if len(xdata) == 0 or len(ydata) == 0:
-        raise ValueError("Improper input: N=1 must not exceed M=0")
-        
     if p0 is None:
         # determine number of parameters by inspecting the function
         from scipy._lib._util import getargspec_no_self as _getargspec
@@ -715,6 +714,11 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
             xdata = np.asarray_chkfinite(xdata)
         else:
             xdata = np.asarray(xdata)
+
+    if xdata.size == 0:
+        raise ValueError("`xdata` must not be empty!")
+    if ydata.size == 0:
+        raise ValueError("`ydata` must not be empty!")
 
     # Determine type of sigma
     if sigma is not None:

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -394,6 +394,13 @@ class TestLeastSq(object):
 
 
 class TestCurveFit(object):
+    def test_empty_array_with_bounds(self):
+        # This test is regarding the issue #9864
+        # Test that Curve_fit checks for empty input data
+        # if called with bounds
+        # Calling this function will produce a meaningful error message.
+        assert_raises(ValueError, curve_fit, lambda x, a: a*x, [], [], bounds=(1, 2))
+
     def setup_method(self):
         self.y = array([1.0, 3.2, 9.5, 13.7])
         self.x = array([1.0, 2.0, 3.0, 4.0])
@@ -707,7 +714,6 @@ class TestCurveFit(object):
                 assert_allclose(popt1, popt2, atol=1e-14)
                 assert_allclose(pcov1, pcov2, atol=1e-14)
 
-
 class TestFixedPoint(object):
 
     def test_scalar_trivial(self):
@@ -787,4 +793,3 @@ class TestFixedPoint(object):
 
         n = fixed_point(func, n0, method='iteration')
         assert_allclose(n, m)
-

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -394,13 +394,6 @@ class TestLeastSq(object):
 
 
 class TestCurveFit(object):
-    def test_empty_array_with_bounds(self):
-        # This test is regarding the issue #9864
-        # Test that Curve_fit checks for empty input data
-        # if called with bounds
-        # Calling this function will produce a meaningful error message.
-        assert_raises(ValueError, curve_fit, lambda x, a: a*x, [], [], bounds=(1, 2))
-
     def setup_method(self):
         self.y = array([1.0, 3.2, 9.5, 13.7])
         self.x = array([1.0, 2.0, 3.0, 4.0])
@@ -541,6 +534,19 @@ class TestCurveFit(object):
 
         assert_raises(ValueError, curve_fit, lambda x, a, b: a*x + b,
                       xdata, ydata, **{"check_finite": True})
+
+    def test_empty_inputs(self):
+        # Test both with and without bounds (regression test for gh-9864)
+        assert_raises(ValueError, curve_fit, lambda x, a: a*x, [], [])
+        assert_raises(ValueError, curve_fit, lambda x, a: a*x, [], [],
+                      bounds=(1, 2))
+        assert_raises(ValueError, curve_fit, lambda x, a: a*x, [1], [])
+        assert_raises(ValueError, curve_fit, lambda x, a: a*x, [2], [],
+                      bounds=(1, 2))
+
+    def test_function_zero_params(self):
+        # Fit args is zero, so "Unable to determine number of fit parameters."
+        assert_raises(ValueError, curve_fit, lambda x: x, [1, 2], [3, 4])
 
     def test_method_argument(self):
         def f(x, a, b):
@@ -713,6 +719,7 @@ class TestCurveFit(object):
 
                 assert_allclose(popt1, popt2, atol=1e-14)
                 assert_allclose(pcov1, pcov2, atol=1e-14)
+
 
 class TestFixedPoint(object):
 


### PR DESCRIPTION
I have added a function to check the length so now when` scipy.optimize.curve_fit` is called with the `bounds `keyword, the input data is being checked, if it is empty it is showing error.

closes gh-9864