### PR TITLE
BUG: Restrict rv_generic._argcheck() and its overrides from setting members.

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -2238,11 +2238,15 @@ class genpareto_gen(rv_continuous):
 
     """
     def _argcheck(self, c):
+        return np.isfinite(c)
+
+    def _get_support(self, c):
         c = np.asarray(c)
-        self.b = _lazywhere(c < 0, (c,),
-                            lambda c: -1. / c,
-                            np.inf)
-        return True
+        b = _lazywhere(c < 0, (c,),
+                       lambda c: -1. / c,
+                       np.inf)
+        a = np.where(c >= 0, self.a, self.a)
+        return a, b
 
     def _pdf(self, x, c):
         # genpareto.pdf(x, c) = (1 + c * x)**(-1 - 1/c)
@@ -2803,8 +2807,10 @@ class genhalflogistic_gen(rv_continuous):
 
     """
     def _argcheck(self, c):
-        self.b = 1.0 / c
         return c > 0
+
+    def _get_support(self, c):
+        return self.a, 1.0/c
 
     def _pdf(self, x, c):
         # genhalflogistic.pdf(x, c) =
@@ -5918,9 +5924,6 @@ class reciprocal_gen(rv_continuous):
 
     """
     def _argcheck(self, a, b):
-        self.a = a
-        self.b = b
-        self.d = np.log(b*1.0 / a)
         return (a > 0) & (b > a)
 
     def _get_support(self, a, b):
@@ -5940,7 +5943,7 @@ class reciprocal_gen(rv_continuous):
         return a*pow(b*1.0/a, q)
 
     def _munp(self, n, a, b):
-        return 1.0/self.d / n * (pow(b*1.0, n) - pow(a*1.0, n))
+        return 1.0/np.log(b*1.0/a) / n * (pow(b*1.0, n) - pow(a*1.0, n))
 
     def _entropy(self, a, b):
         return 0.5*np.log(a*b)+np.log(np.log(b*1.0/a))

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -7286,8 +7286,8 @@ class rv_histogram(rv_continuous):
         self._hpdf = np.hstack([0.0, self._hpdf, 0.0])
         self._hcdf = np.hstack([0.0, self._hcdf])
         # Set support
-        kwargs['a'] = self._hbins[0]
-        kwargs['b'] = self._hbins[-1]
+        kwargs['a'] = self.a = self._hbins[0]
+        kwargs['b'] = self.b = self._hbins[-1]
         super(rv_histogram, self).__init__(*args, **kwargs)
 
     def _pdf(self, x):

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -2369,9 +2369,12 @@ class genextreme_gen(rv_continuous):
 
     """
     def _argcheck(self, c):
-        self.b = np.where(c > 0, 1.0 / np.maximum(c, _XMIN), np.inf)
-        self.a = np.where(c < 0, 1.0 / np.minimum(c, -_XMIN), -np.inf)
         return np.where(abs(c) == np.inf, 0, 1)
+
+    def _get_support(self, c):
+        _b = np.where(c > 0, 1.0 / np.maximum(c, _XMIN), np.inf)
+        _a = np.where(c < 0, 1.0 / np.minimum(c, -_XMIN), -np.inf)
+        return _a, _b
 
     def _loglogcdf(self, x, c):
         return _lazywhere((x == x) & (c != 0), (x, c),
@@ -4714,6 +4717,9 @@ class kappa4_gen(rv_continuous):
 
     """
     def _argcheck(self, h, k):
+        return h == h
+
+    def _get_support(self, h, k):
         condlist = [np.logical_and(h > 0, k > 0),
                     np.logical_and(h > 0, k == 0),
                     np.logical_and(h > 0, k < 0),
@@ -4735,7 +4741,7 @@ class kappa4_gen(rv_continuous):
         def f5(h, k):
             return 1.0/k
 
-        self.a = _lazyselect(condlist,
+        _a = _lazyselect(condlist,
                              [f0, f1, f0, f3, f3, f5],
                              [h, k],
                              default=np.nan)
@@ -4748,11 +4754,11 @@ class kappa4_gen(rv_continuous):
             a[:] = np.inf
             return a
 
-        self.b = _lazyselect(condlist,
+        _b = _lazyselect(condlist,
                              [f0, f1, f1, f0, f1, f1],
                              [h, k],
                              default=np.nan)
-        return h == h
+        return _a, _b
 
     def _pdf(self, x, h, k):
         # kappa4.pdf(x, h, k) = (1.0 - k*x)**(1.0/k - 1.0)*
@@ -5917,15 +5923,18 @@ class reciprocal_gen(rv_continuous):
         self.d = np.log(b*1.0 / a)
         return (a > 0) & (b > a)
 
+    def _get_support(self, a, b):
+        return a, b
+
     def _pdf(self, x, a, b):
         # reciprocal.pdf(x, a, b) = 1 / (x*log(b/a))
-        return 1.0 / (x * self.d)
+        return 1.0 / (x * np.log(b * 1.0 / a))
 
     def _logpdf(self, x, a, b):
-        return -np.log(x) - np.log(self.d)
+        return -np.log(x) - np.log(np.log(b * 1.0 / a))
 
     def _cdf(self, x, a, b):
-        return (np.log(x)-np.log(a)) / self.d
+        return (np.log(x)-np.log(a)) / np.log(b * 1.0 / a)
 
     def _ppf(self, q, a, b):
         return a*pow(b*1.0/a, q)
@@ -5934,7 +5943,7 @@ class reciprocal_gen(rv_continuous):
         return 1.0/self.d / n * (pow(b*1.0, n) - pow(a*1.0, n))
 
     def _entropy(self, a, b):
-        return 0.5*np.log(a*b)+np.log(np.log(b/a))
+        return 0.5*np.log(a*b)+np.log(np.log(b*1.0/a))
 
 
 reciprocal = reciprocal_gen(name="reciprocal")
@@ -6120,10 +6129,11 @@ class skew_norm_gen(rv_continuous):
         return 2.*_norm_pdf(x)*_norm_cdf(a*x)
 
     def _cdf_single(self, x, *args):
+        _a, _b = self._get_support(*args)
         if x <= 0:
-            cdf = integrate.quad(self._pdf, self.a, x, args=args)[0]
+            cdf = integrate.quad(self._pdf, _a, x, args=args)[0]
         else:
-            t1 = integrate.quad(self._pdf, self.a, 0, args=args)[0]
+            t1 = integrate.quad(self._pdf, _a, 0, args=args)[0]
             t2 = integrate.quad(self._pdf, 0, x, args=args)[0]
             cdf = t1 + t2
         if cdf > 1:
@@ -6314,8 +6324,10 @@ class truncexpon_gen(rv_continuous):
 
     """
     def _argcheck(self, b):
-        self.b = b
         return b > 0
+
+    def _get_support(self, b):
+        return self.a, b
 
     def _pdf(self, x, b):
         # truncexpon.pdf(x, b) = exp(-x) / (1-exp(-b))
@@ -6372,36 +6384,47 @@ class truncnorm_gen(rv_continuous):
 
     """
     def _argcheck(self, a, b):
-        self.a = a
-        self.b = b
-        self._nb = _norm_cdf(b)
-        self._na = _norm_cdf(a)
-        self._sb = _norm_sf(b)
-        self._sa = _norm_sf(a)
-        self._delta = np.where(self.a > 0,
-                               -(self._sb - self._sa),
-                               self._nb - self._na)
-        self._logdelta = np.log(self._delta)
         return a < b
 
+    def _get_support(self, a, b):
+        return a, b
+
+    def _get_norms(self, a, b):
+        _nb = _norm_cdf(b)
+        _na = _norm_cdf(a)
+        _sb = _norm_sf(b)
+        _sa = _norm_sf(a)
+        _delta = np.where(a > 0, _sa - _sb, _nb - _na)
+        with np.errstate(divide='ignore'):
+            return _na, _nb, _sa, _sb, _delta, np.log(_delta)
+
     def _pdf(self, x, a, b):
-        return _norm_pdf(x) / self._delta
+        ans = self._get_norms(a, b)
+        _delta = ans[4]
+        return _norm_pdf(x) / _delta
 
     def _logpdf(self, x, a, b):
-        return _norm_logpdf(x) - self._logdelta
+        ans = self._get_norms(a, b)
+        _logdelta = ans[5]
+        return _norm_logpdf(x) - _logdelta
 
     def _cdf(self, x, a, b):
-        return (_norm_cdf(x) - self._na) / self._delta
+        ans = self._get_norms(a, b)
+        _na, _delta = ans[0], ans[4]
+        return (_norm_cdf(x) - _na) / _delta
 
     def _ppf(self, q, a, b):
         # XXX Use _lazywhere...
-        ppf = np.where(self.a > 0,
-                       _norm_isf(q*self._sb + self._sa*(1.0-q)),
-                       _norm_ppf(q*self._nb + self._na*(1.0-q)))
+        ans = self._get_norms(a, b)
+        _na, _nb, _sa, _sb = ans[:4]
+        ppf = np.where(a > 0,
+                       _norm_isf(q*_sb + _sa*(1.0-q)),
+                       _norm_ppf(q*_nb + _na*(1.0-q)))
         return ppf
 
     def _stats(self, a, b):
-        nA, nB = self._na, self._nb
+        ans = self._get_norms(a, b)
+        nA, nB = ans[:2]
         d = nB - nA
         pA, pB = _norm_pdf(a), _norm_pdf(b)
         mu = (pA - pB) / d   # correction sign

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -635,7 +635,6 @@ class boltzmann_gen(rv_discrete):
 
     """
     def _argcheck(self, lambda_, N):
-        # self.b = N - 1
         return (lambda_ > 0) & (N > 0)
 
     def _get_support(self, lambda_, N):

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -1451,10 +1451,10 @@ class rv_continuous(rv_generic):
     For most of the scipy.stats distributions, the support interval doesn't
     depend on the shape parameters. ``x`` being in the support interval is
     equivalent to ``self.a <= x <= self.b``.  If either of the endpoints of
-    the support do depend on the shape parameters, then:
-      i) the distribution must implement the ``_get_support`` method; and
-     ii) those dependent endpoints must be omitted from the distribution's
-         call to the ``rv_continuous`` initializer.
+    the support do depend on the shape parameters, then
+    i) the distribution must implement the ``_get_support`` method; and
+    ii) those dependent endpoints must be omitted from the distribution's
+    call to the ``rv_continuous`` initializer.
 
     Correct, but potentially slow defaults exist for the remaining
     methods but for speed and/or accuracy you can over-ride::

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -875,7 +875,9 @@ class rv_generic(object):
         """Return the support of the (unscaled, unshifted) distribution.
 
         *Must* be overridden by distributions which have support dependent
-        upon the shape parameters of the distribution.
+        upon the shape parameters of the distribution.  Any such override
+        *must not* set or change any of the class members, as these members
+        are shared amongst all instances of the distribution.
 
         Parameters
         ----------

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -875,7 +875,7 @@ class rv_generic(object):
         """Return the support of the (unscaled, unshifted) distribution.
 
         *Must* be overridden by distributions which have support dependent
-        upon the parametrization.
+        upon the shape parameters of the distribution.
 
         Parameters
         ----------
@@ -885,7 +885,8 @@ class rv_generic(object):
         Returns
         -------
         a, b : numeric (float, or int or +/-np.inf)
-            end-points of the distribution's support.
+            end-points of the distribution's support for the specified
+            shape parameters.
         """
         return self.a, self.b
 
@@ -1432,7 +1433,7 @@ class rv_continuous(rv_generic):
     Public methods of an instance of a distribution class (e.g., ``pdf``,
     ``cdf``) check their arguments and pass valid arguments to private,
     computational methods (``_pdf``, ``_cdf``). For ``pdf(x)``, ``x`` is valid
-    if it is within the support of a distribution, ``self.a <= x <= self.b``.
+    if it is within the support of the distribution.
     Whether a shape parameter is valid is decided by an ``_argcheck`` method
     (which defaults to checking that its arguments are strictly positive.)
 
@@ -1445,8 +1446,13 @@ class rv_continuous(rv_generic):
     If positive argument checking is not correct for your RV
     then you will also need to re-define the ``_argcheck`` method.
 
-    ``_get_support`` must be overridden if the distribution's support depends
-    on the parametrization.
+    For most of the scipy.stats distributions, the support interval doesn't
+    depend on the shape parameters. ``x`` being in the support interval is
+    equivalent to ``self.a <= x <= self.b``.  If either of the endpoints of
+    the support do depend on the shape parameters, then:
+      i) the distribution must implement the ``_get_support`` method; and
+     ii) those dependent endpoints must be omitted from the distribution's
+         call to the ``rv_continuous`` initializer.
 
     Correct, but potentially slow defaults exist for the remaining
     methods but for speed and/or accuracy you can over-ride::

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -3445,10 +3445,8 @@ class rv_sample(rv_discrete):
         indx = np.argsort(np.ravel(xk))
         self.xk = np.take(np.ravel(xk), indx, 0)
         self.pk = np.take(np.ravel(pk), indx, 0)
-        # self.a = self.xk[0]
-        # self.b = self.xk[-1]
-        self.a = -np.inf
-        self.b = np.inf
+        self.a = self.xk[0]
+        self.b = self.xk[-1]
 
         self.qvals = np.cumsum(self.pk, axis=0)
 
@@ -3473,9 +3471,7 @@ class rv_sample(rv_discrete):
         a, b : numeric (float, or int or +/-np.inf)
             end-points of the distribution's support.
         """
-        _a = self.xk[0]
-        _b = self.xk[-1]
-        return _a, _b
+        return self.a, self.b
 
     def _pmf(self, x):
         return np.select([x == k for k in self.xk],

--- a/scipy/stats/tests/common_tests.py
+++ b/scipy/stats/tests/common_tests.py
@@ -37,7 +37,8 @@ def check_normalization(distfn, args, distname):
     npt.assert_allclose(normalization_expect, 1.0, atol=atol, rtol=rtol,
             err_msg=distname, verbose=True)
 
-    normalization_cdf = distfn.cdf(distfn.b, *args)
+    _a, _b = distfn.support(*args)
+    normalization_cdf = distfn.cdf(_b, *args)
     npt.assert_allclose(normalization_cdf, 1.0)
 
 
@@ -120,9 +121,9 @@ def check_entropy_vect_scale(distfn, arg):
 
 def check_edge_support(distfn, args):
     # Make sure that x=self.a and self.b are handled correctly.
-    x = [distfn.a, distfn.b]
+    x = distfn.support(*args)
     if isinstance(distfn, stats.rv_discrete):
-        x = [distfn.a - 1, distfn.b]
+        x = x[0]-1, x[1]
 
     npt.assert_equal(distfn.cdf(x, *args), [0.0, 1.0])
     npt.assert_equal(distfn.sf(x, *args), [1.0, 0.0])
@@ -222,7 +223,8 @@ def check_meth_dtype(distfn, arg, meths):
     for x in x_cast:
         # casting may have clipped the values, exclude those
         distfn._argcheck(*arg)
-        x = x[(distfn.a < x) & (x < distfn.b)]
+        _a, _b = distfn.support(*arg)
+        x = x[(_a < x) & (x < _b)]
         for meth in meths:
             val = meth(x, *arg)
             npt.assert_(val.dtype == np.float_)
@@ -251,7 +253,8 @@ def check_cmplx_deriv(distfn, arg):
     for x in x_cast:
         # casting may have clipped the values, exclude those
         distfn._argcheck(*arg)
-        x = x[(distfn.a < x) & (x < distfn.b)]
+        _a, _b = distfn.support(*arg)
+        x = x[(_a < x) & (x < _b)]
 
         pdf, cdf, sf = distfn.pdf(x, *arg), distfn.cdf(x, *arg), distfn.sf(x, *arg)
         assert_allclose(deriv(distfn.cdf, x, *arg), pdf, rtol=1e-5)

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -334,6 +334,35 @@ def test_broadcast_gh9990_regression():
     ans = [stats.reciprocal.cdf(_b, _a, _b) for _a, _b in zip(a,b)]
     npt.assert_array_almost_equal(stats.reciprocal.cdf(b, a, b), ans)
 
+def test_broadcast_gh7933_regression():
+    # Check broadcast works
+    stats.truncnorm.logpdf(
+        np.array([3.0, 2.0, 1.0]),
+        a=(1.5 - np.array([6.0, 5.0, 4.0])) / 3.0,
+        b=np.inf,
+        loc=np.array([6.0, 5.0, 4.0]),
+        scale=3.0
+    )
+
+def test_gh2002_regression():
+    # Add a check that broadcast works in situations where only some
+    # x-values are compatible with some of the shape arguments.
+    x = np.r_[-2:2:101j]
+    a = np.r_[-np.ones(50), np.ones(51)]
+    expected = [stats.truncnorm.pdf(_x, _a, np.inf) for _x, _a in zip(x, a)]
+    ans = stats.truncnorm.pdf(x, a, np.inf)
+    npt.assert_array_almost_equal(ans, expected)
+
+def test_gh1320_regression():
+    # Check that the first example from gh-1320 now works.
+    c = 2.62
+    stats.genextreme.ppf(0.5, np.array([[c], [c + 0.5]]))
+    # The other examples in gh-1320 appear to have stopped working
+    # some time ago.
+    # ans = stats.genextreme.moment(2, np.array([c, c + 0.5]))
+    # expected = np.array([25.50105963, 115.11191437])
+    # stats.genextreme.moment(5, np.array([[c], [c + 0.5]]))
+    # stats.genextreme.moment(5, np.array([c, c + 0.5]))
 
 def check_sample_meanvar_(distfn, arg, m, v, sm, sv, sn, msg):
     # this did not work, skipped silently by nose

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -112,6 +112,7 @@ def test_cont_basic(distname, arg):
         check_pdf_logpdf(distfn, arg, distname)
         check_cdf_logcdf(distfn, arg, distname)
         check_sf_logsf(distfn, arg, distname)
+        check_ppf_broadcast(distfn, arg, distname)
 
         alpha = 0.01
         if distname == 'rv_histogram_instance':
@@ -467,6 +468,19 @@ def check_cdf_logcdf(distfn, args, msg):
     logcdf = logcdf[np.isfinite(logcdf)]
     msg += " - logcdf-log(cdf) relationship"
     npt.assert_almost_equal(np.log(cdf), logcdf, decimal=7, err_msg=msg)
+
+
+def check_ppf_broadcast(distfn, arg, msg):
+    # compares ppf for multiple argsets.
+    num_repeats = 5
+    args = [] * num_repeats
+    if arg:
+        args = [np.array([_] * num_repeats) for _ in arg]
+
+    median = distfn.ppf(0.5, *arg)
+    medians = distfn.ppf(0.5, *args)
+    msg += " - ppf multiple"
+    npt.assert_almost_equal(medians, [median] * num_repeats, decimal=7, err_msg=msg)
 
 
 def check_distribution_rvs(dist, args, alpha, rvs):

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -286,6 +286,54 @@ def test_rvs_gh2069_regression():
     assert_raises(ValueError, stats.gamma.rvs, [1, 1, 1, 1], [0, 0, 0, 0],
                      [[1], [2]], (4,))
 
+def test_nomodify_gh9900_regression():
+    # Regression test for gh-9990
+    # Prior to gh-9990, calls to stats.truncnorm._cdf() use what ever was
+    # set inside the stats.truncnorm instance during stats.truncnorm.cdf().
+    # This could cause issues wth multi-threaded code.
+    # Since then, the calls to cdf() are not permitted to modify the global
+    # stats.truncnorm instance.
+    tn = stats.truncnorm
+    # Use the right-half truncated normal
+    # Check that the cdf and _cdf return the same result.
+    npt.assert_almost_equal(tn.cdf(1, 0, np.inf), 0.6826894921370859)
+    npt.assert_almost_equal(tn._cdf(1, 0, np.inf), 0.6826894921370859)
+
+    # Now use the left-half truncated normal
+    npt.assert_almost_equal(tn.cdf(-1, -np.inf, 0), 0.31731050786291415)
+    npt.assert_almost_equal(tn._cdf(-1, -np.inf, 0), 0.31731050786291415)
+
+    # Check that the right-half truncated normal _cdf hasn't changed
+    npt.assert_almost_equal(tn._cdf(1, 0, np.inf), 0.6826894921370859)  # NOT 1.6826894921370859
+    npt.assert_almost_equal(tn.cdf(1, 0, np.inf), 0.6826894921370859)
+
+    # Check that the left-half truncated normal _cdf hasn't changed
+    npt.assert_almost_equal(tn._cdf(-1, -np.inf, 0), 0.31731050786291415)  # Not -0.6826894921370859
+    npt.assert_almost_equal(tn.cdf(1, -np.inf, 0), 1)                     # Not 1.6826894921370859
+    npt.assert_almost_equal(tn.cdf(-1, -np.inf, 0), 0.31731050786291415)  # Not -0.6826894921370859
+
+
+def test_broadcast_gh9990_regression():
+    # Regression test for gh-9990
+    # The x-value 7 only lies within the support of 4 of the supplied
+    # distributions.  Prior to 9990, one array passed to
+    # stats.reciprocal._cdf would have 4 elements, but an array
+    # previously stored by stats.reciprocal_argcheck() would have 6, leading
+    # to a broadcast error.
+    a = np.array([1, 2, 3, 4, 5, 6])
+    b = np.array([8, 16, 1, 32, 1, 48])
+    ans = [stats.reciprocal.cdf(7, _a, _b) for _a, _b in zip(a,b)]
+    npt.assert_array_almost_equal(stats.reciprocal.cdf(7, a, b), ans)
+
+    ans = [stats.reciprocal.cdf(1, _a, _b) for _a, _b in zip(a,b)]
+    npt.assert_array_almost_equal(stats.reciprocal.cdf(1, a, b), ans)
+
+    ans = [stats.reciprocal.cdf(_a, _a, _b) for _a, _b in zip(a,b)]
+    npt.assert_array_almost_equal(stats.reciprocal.cdf(a, a, b), ans)
+
+    ans = [stats.reciprocal.cdf(_b, _a, _b) for _a, _b in zip(a,b)]
+    npt.assert_array_almost_equal(stats.reciprocal.cdf(b, a, b), ans)
+
 
 def check_sample_meanvar_(distfn, arg, m, v, sm, sv, sn, msg):
     # this did not work, skipped silently by nose

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -132,7 +132,8 @@ def check_cdf_ppf(distfn, arg, supp, msg):
                            supp, msg + '-roundtrip')
 
     if not hasattr(distfn, 'xk'):
-        supp1 = supp[supp < distfn.b]
+        _a, _b = distfn.support(*arg)
+        supp1 = supp[supp < _b]
         npt.assert_array_equal(distfn.ppf(distfn.cdf(supp1, *arg) + 1e-8, *arg),
                                supp1 + distfn.inc, msg + ' ppf-cdf-next')
         # -1e-8 could cause an error if pmf < 1e-8
@@ -195,8 +196,10 @@ def check_discrete_chisquare(distfn, arg, rvs, alpha, msg):
 
     # construct intervals with minimum mass `wsupp`.
     # intervals are left-half-open as in a cdf difference
-    lo = int(max(distfn.a, -1000))
-    distsupport = xrange(lo, int(min(distfn.b, 1000)) + 1)
+    _a, _b = distfn.support(*arg)
+    lo = int(max(_a, -1000))
+    high = int(min(_b, 1000)) + 1
+    distsupport = xrange(lo, high)
     last = 0
     distsupp = [lo]
     distmass = []
@@ -208,15 +211,15 @@ def check_discrete_chisquare(distfn, arg, rvs, alpha, msg):
             last = current
             if current > (1 - wsupp):
                 break
-    if distsupp[-1] < distfn.b:
-        distsupp.append(distfn.b)
+    if distsupp[-1] < _b:
+        distsupp.append(_b)
         distmass.append(1 - last)
     distsupp = np.array(distsupp)
     distmass = np.array(distmass)
 
     # convert intervals to right-half-open as required by histogram
     histsupp = distsupp + 1e-8
-    histsupp[0] = distfn.a
+    histsupp[0] = _a
 
     # find sample frequencies and perform chisquare test
     freq, hsupp = np.histogram(rvs, histsupp)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -474,6 +474,13 @@ class TestTruncnorm(object):
         x = stats.truncnorm.rvs(low, high, 0, 1, size=10)
         assert_(low < x.min() < x.max() < high)
 
+    def test_moments(self):
+        m, v, s, k = stats.truncnorm.stats(-30, 30, moments='mvsk')
+        assert_almost_equal(m, 0)
+        assert_almost_equal(v, 1)
+        assert_almost_equal(s, 0.0)
+        assert_almost_equal(k, 0.0)
+
     @pytest.mark.xfail(reason="truncnorm rvs is know to fail at extreme tails")
     def test_gh_2477_large_values(self):
         # Check a case that fails because of extreme tailness.

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -159,6 +159,17 @@ def test_support(dist):
     assert_equal(dist.logpdf(dist.b, *args), -np.inf)
 
 
+@pytest.mark.parametrize('dist,args,alpha', cases_test_all_distributions())
+def test_retrieving_support(dist, args, alpha):
+    """"""
+    dist = getattr(stats, dist)
+
+    loc, scale = 1, 2
+    supp = dist.support(*args)
+    supp_loc_scale = dist.support(*args, loc=loc, scale=scale)
+    assert_almost_equal(np.array(supp)*scale + loc, np.array(supp_loc_scale))
+
+
 class TestRandInt(object):
     def setup_method(self):
         np.random.seed(1234)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -749,13 +749,14 @@ class TestGenpareto(object):
         for c in [1., 0.]:
             c = np.asarray(c)
             stats.genpareto._argcheck(c)  # ugh
-            assert_equal(stats.genpareto.a, 0.)
-            assert_(np.isposinf(stats.genpareto.b))
+            a, b = stats.genpareto._get_support(c)
+            assert_equal(a, 0.)
+            assert_(np.isposinf(b))
 
         # c < 0: a=0, b=1/|c|
         c = np.asarray(-2.)
         stats.genpareto._argcheck(c)
-        assert_allclose([stats.genpareto.a, stats.genpareto.b], [0., 0.5])
+        assert_allclose(stats.genpareto._get_support(c), [0., 0.5])
 
     def test_c0(self):
         # with c=0, genpareto reduces to the exponential distribution
@@ -2188,14 +2189,14 @@ class TestFrozen(object):
         # depends on the value of the shape parameter:
         # for c > 0: a, b = 0, inf
         # for c < 0: a, b = 0, -1/c
-        rv = stats.genpareto(c=-0.1)
-        a, b = rv.dist.a, rv.dist.b
+        c = -0.1
+        rv = stats.genpareto(c=c)
+        a, b = rv.dist._get_support(c)
         assert_equal([a, b], [0., 10.])
-        assert_equal([rv.a, rv.b], [0., 10.])
 
-        stats.genpareto.pdf(0, c=0.1)  # this changes genpareto.b
-        assert_equal([rv.dist.a, rv.dist.b], [a, b])
-        assert_equal([rv.a, rv.b], [a, b])
+        c = 0.1
+        stats.genpareto.pdf(0, c=c)
+        assert_equal(rv.dist._get_support(c), [0, np.inf])
 
         rv1 = stats.genpareto(c=0.1)
         assert_(rv1.dist is not rv.dist)


### PR DESCRIPTION

Address incorrect probabilities, broadcasting issues and thread-safety
related to distributions setting member variables inside _argcheck().
Addresses gh-9896, gh-2002, gh-1320, gh-7933.

Add method _get_support(*args) to rv_generic (the default behaviour is to
return sef.a, self.b.)  Distributions which have support depending on parameters
need to override this method.
Add overrides for genextreme, kappa4, reciprocal, truncexpon, truncnorm,
binom, bernoulli, hypergeom, boltzmann, randint, rv_sample.
Move code which sets members variables from _argcheck() into _get_support()
and discard any code which actually sets member data.
As most code previously called self._argcheck() anyway before calling
_cdf()/_pdf()/_sf()/..., the impact on performance is perhaps minimal.
This fixes threading concerns, because the (global) distribution is no longer
being changed every call.
Fixes broadcasting issues because the _cdf(x, *args, **kwargs)/... calls now
actually use *args, which has the correct size.