### PR TITLE
BUG: sparse: Validate explicit shape if given with dense argument to coo_matrix

### DIFF
--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -181,8 +181,12 @@ class coo_matrix(_data_matrix, _minmax_mixin):
 
                 if M.ndim != 2:
                     raise TypeError('expected dimension <= 2 array or matrix')
-                else:
-                    self._shape = check_shape(M.shape)
+
+                self._shape = check_shape(M.shape)
+                if shape is not None:
+                    if check_shape(shape) != self._shape:
+                        raise ValueError('inconsistent shapes: %s != %s' %
+                                         (shape, self._shape))
 
                 self.row, self.col = M.nonzero()
                 self.data = M[self.row, self.col]

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -4034,6 +4034,14 @@ class TestCOO(sparse_test_class(getset=False,
         coo = coo_matrix(mat)
         assert_array_equal(coo.todense(),mat.reshape(1,-1))
 
+        # error if second arg interpreted as shape (gh-9919)
+        with pytest.raises(TypeError, match=r'object cannot be interpreted'):
+            coo_matrix([0, 11, 22, 33], ([0, 1, 2, 3], [0, 0, 0, 0]))
+
+        # error if explicit shape arg doesn't match the dense matrix
+        with pytest.raises(ValueError, match=r'inconsistent shapes'):
+            coo_matrix([0, 11, 22, 33], shape=(4, 4))
+
     @pytest.mark.xfail(run=False, reason='COO does not have a __getitem__')
     def test_iterator(self):
         pass


### PR DESCRIPTION
Fixes gh-9919.

There are a couple routes we could take when validating the `shape` kwarg in this situation, but given the context of the original bug, it should be sufficient to raise an error whenever the given shape (intentional or not) doesn't match the shape of the dense matrix being converted (the first argument).

Note that once scipy starts converting code to be explicitly py3k-only, we could consider marking the `shape` and `dtype` arguments as keyword only. This would prevent these sorts of errors more broadly, though perhaps at the expense of breaking existing user code.