### PR TITLE
BLD: add back pyproject.toml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,7 +91,7 @@ jobs:
       choco install -y mingw --forcex86 --force --version=5.3.0
     displayName: 'Install 32-bit mingw for 32-bit builds'
     condition: eq(variables['BITS'], 32)
-  - script: python -m pip install numpy cython==0.28.5 pytest pytest-timeout pytest-xdist pytest-env pytest-faulthandler Pillow mpmath matplotlib
+  - script: python -m pip install numpy cython==0.29.2 pytest pytest-timeout pytest-xdist pytest-env pytest-faulthandler Pillow mpmath matplotlib
     displayName: 'Install dependencies'
   - powershell: |
       # need a version of NumPy distutils that can build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,10 +15,11 @@ jobs:
            docker pull i386/ubuntu:bionic
            docker run -v $(pwd):/scipy i386/ubuntu:bionic /bin/bash -c "cd scipy && \
            apt-get -y update && \
-           apt-get -y install python3.6-dev pkg-config libpng-dev libjpeg8-dev libfreetype6-dev && \
-           python3 -m ensurepip && \
-           pip3 install --upgrade pip && \
-           pip3 install setuptools wheel numpy cython==0.29 pytest pytest-timeout pytest-xdist pytest-env pytest-faulthandler Pillow mpmath matplotlib && \
+           apt-get -y install curl python3.6-dev python3.6 python3-distutils pkg-config libpng-dev libjpeg8-dev libfreetype6-dev && \
+           curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
+           python3.6 get-pip.py && \
+           pip3 --version && \
+           pip3 install setuptools wheel numpy cython==0.29.2 pytest pytest-timeout pytest-xdist pytest-env pytest-faulthandler Pillow mpmath matplotlib --user && \
            apt-get -y install gfortran-5 wget && \
            cd .. && \
            mkdir openblas && cd openblas && \
@@ -27,7 +28,7 @@ jobs:
            cp -r ./usr/local/lib/* /usr/lib && \
            cp ./usr/local/include/* /usr/include && \
            cd ../scipy && \
-           F77=gfortran-5 F90=gfortran-5 python3 runtests.py --mode=full -- -n auto -rsx --junitxml=junit/test-results.xml"
+           F77=gfortran-5 F90=gfortran-5 python3.6 runtests.py --mode=full -- -n auto -rsx --junitxml=junit/test-results.xml"
     displayName: 'Run 32-bit Ubuntu Docker Build / Tests'
   - task: PublishTestResults@2
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,9 @@ jobs:
            docker pull i386/ubuntu:bionic
            docker run -v $(pwd):/scipy i386/ubuntu:bionic /bin/bash -c "cd scipy && \
            apt-get -y update && \
-           apt-get -y install python3.6-dev python3-pip pkg-config libpng-dev libjpeg8-dev libfreetype6-dev && \
+           apt-get -y install python3.6-dev pkg-config libpng-dev libjpeg8-dev libfreetype6-dev && \
+           python3 -m ensurepip && \
+           pip3 install --upgrade pip && \
            pip3 install setuptools wheel numpy cython==0.29 pytest pytest-timeout pytest-xdist pytest-env pytest-faulthandler Pillow mpmath matplotlib && \
            apt-get -y install gfortran-5 wget && \
            cd .. && \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = [
+    "wheel",
+    "setuptools",
+    "Cython>=0.29.2",
+    "numpy==1.13.3",
+]

--- a/setup.py
+++ b/setup.py
@@ -388,10 +388,8 @@ def parse_setuppy_commands():
 
 
 def configuration(parent_package='', top_path=None):
+    from scipy._build_utils.system_info import get_info, NotFoundError
     from numpy.distutils.misc_util import Configuration
-    from scipy._build_utils.system_info import get_info, NotFoundError, numpy_info
-    from numpy.distutils.misc_util import Configuration, get_numpy_include_dirs
-    from scipy._build_utils import (get_g77_abi_wrappers, split_fortran_files)
 
     lapack_opt = get_info('lapack_opt')
 

--- a/setup.py
+++ b/setup.py
@@ -256,6 +256,8 @@ def generate_cython():
                                    "to `pip` being too old, found version {}, "
                                    "needed is >= 18.0.0.".format(
                                    pip.__version__))
+            else:
+                raise RuntimeError("Running cythonize failed!")
         except ImportError:
             raise RuntimeError("Running cythonize failed!")
 

--- a/tools/cythonize.py
+++ b/tools/cythonize.py
@@ -79,7 +79,8 @@ def process_pyx(fromfile, tofile, cwd):
                 raise ImportError()
 
         if LooseVersion(cython_version) < LooseVersion(required_version):
-            raise Exception('Building SciPy requires Cython >= ' + required_version)
+            raise Exception('Building SciPy requires Cython >= {}, found '
+                            '{}'.format(required_version, cython_version))
 
     except ImportError:
         pass


### PR DESCRIPTION
Closes gh-8734 (see that issue for details).

Want to add this now so we can test it for a while before the next release.

Note that I expect CI to fail at the moment, because of old `pip` versions. Will update those, want to see the failures first. Pip versions installed at the moment:
- TravisCI: pip 18.1
- Azure: pip 9.0.1
- CircleCI: pip 10.0.1
- Appveyor: 19.0.3
