### PR TITLE
Fix empty constraint

### DIFF
--- a/scipy/optimize/_trustregion_constr/canonical_constraint.py
+++ b/scipy/optimize/_trustregion_constr/canonical_constraint.py
@@ -88,7 +88,7 @@ class CanonicalConstraint(object):
         def hess(x, v_eq, v_ineq):
             return empty_hess
 
-        return cls(0, 0, fun, jac, hess, np.empty(0))
+        return cls(0, 0, fun, jac, hess, np.empty(0, dtype=np.bool))
 
     @classmethod
     def concatenate(cls, canonical_constraints, sparse_jacobian):

--- a/scipy/optimize/tests/test_minimize_constrained.py
+++ b/scipy/optimize/tests/test_minimize_constrained.py
@@ -615,3 +615,44 @@ class TestTrustRegionConstr(TestCase):
         # Also check existence of the 'niter' attribute, for backward
         # compatibility
         assert_(result.get('niter', -1) == 1)
+
+class TestEmptyConstraint(TestCase):
+    """
+    Here we minimize x^2+y^2 subject to x^2-y^2>1.
+    The actual minimum is at (0, 0) which fails the constraint.
+    Therefore we will find a minimum on the boundary at (+/-1, 0).
+
+    When minimizing on the boundary, optimize uses a set of
+    constraints that removes the constraint that sets that
+    boundary.  In our case, there's only one constraint, so
+    the result is an empty constraint.
+
+    This tests that the empty constraint works.
+    """
+    def test_empty_constraint(self):
+
+        def function(x): return x[0]**2 + x[1]**2
+        def functionjacobian(x): return np.array([2.*x[0], 2.*x[1]])
+        def functionhvp(x, v): return 2.*v
+
+        def constraint(x): return np.array([x[0]**2 - x[1]**2])
+        def constraintjacobian(x): return np.array([[2*x[0], -2*x[1]]])
+        def constraintlcoh(x, v): return np.array([[2., 0.], [0., -2.]]) * v[0]
+
+        constraint = NonlinearConstraint(constraint, 1., np.inf, constraintjacobian, constraintlcoh)
+
+        startpoint = [1., 2.]
+
+        bounds = Bounds([-np.inf, -np.inf], [np.inf, np.inf])
+
+        result = minimize(
+          function,
+          startpoint,
+          method='trust-constr',
+          jac=functionjacobian,
+          hessp=functionhvp,
+          constraints=[constraint],
+          bounds=bounds,
+        )
+
+        assert_array_almost_equal(abs(result.x), np.array([1, 0]), decimal=4)

--- a/scipy/optimize/tests/test_minimize_constrained.py
+++ b/scipy/optimize/tests/test_minimize_constrained.py
@@ -631,13 +631,23 @@ class TestEmptyConstraint(TestCase):
     """
     def test_empty_constraint(self):
 
-        def function(x): return x[0]**2 + x[1]**2
-        def functionjacobian(x): return np.array([2.*x[0], 2.*x[1]])
-        def functionhvp(x, v): return 2.*v
+        def function(x):
+            return x[0]**2 + x[1]**2
 
-        def constraint(x): return np.array([x[0]**2 - x[1]**2])
-        def constraintjacobian(x): return np.array([[2*x[0], -2*x[1]]])
-        def constraintlcoh(x, v): return np.array([[2., 0.], [0., -2.]]) * v[0]
+        def functionjacobian(x):
+            return np.array([2.*x[0], 2.*x[1]])
+
+        def functionhvp(x, v):
+            return 2.*v
+
+        def constraint(x):
+            return np.array([x[0]**2 - x[1]**2])
+
+        def constraintjacobian(x):
+            return np.array([[2*x[0], -2*x[1]]])
+
+        def constraintlcoh(x, v):
+            return np.array([[2., 0.], [0., -2.]]) * v[0]
 
         constraint = NonlinearConstraint(constraint, 1., np.inf, constraintjacobian, constraintlcoh)
 


### PR DESCRIPTION
When using the empty constriant without this patch, I was getting an error [here](https://github.com/scipy/scipy/blob/5c342cd4335aab4835390fb36e4405b1a64407e5/scipy/optimize/_trustregion_constr/tr_interior_point.py#L93)

```
IndexError: arrays used as indices must be of integer (or boolean) type
```