### PR TITLE
DOC: correct `structure` description in `ndimage.label` docstring

### DIFF
--- a/scipy/ndimage/measurements.py
+++ b/scipy/ndimage/measurements.py
@@ -54,7 +54,9 @@ def label(input, structure=None, output=None):
         counted as features and zero values are considered the background.
     structure : array_like, optional
         A structuring element that defines feature connections.
-        `structure` must be symmetric.  If no structuring element is provided,
+        `structure` must be centrosymmetric
+        (see Notes).
+        If no structuring element is provided,
         one is automatically generated with a squared connectivity equal to
         one.  That is, for a 2-D `input` array, the default structuring element
         is::
@@ -65,7 +67,7 @@ def label(input, structure=None, output=None):
 
     output : (None, data-type, array_like), optional
         If `output` is a data type, it specifies the type of the resulting
-        labeled feature array
+        labeled feature array.
         If `output` is an array-like object, then `output` will be updated
         with the labeled features from this function.  This function can
         operate in-place, by passing output=input.
@@ -92,6 +94,29 @@ def label(input, structure=None, output=None):
     find_objects : generate a list of slices for the labeled features (or
                    objects); useful for finding features' position or
                    dimensions
+
+    Notes
+    -----
+    A centrosymmetric matrix is a matrix that is symmetric about the center.
+    See [1]_ for more information.
+
+    The `structure` matrix must be centrosymmetric to ensure
+    two-way connections.
+    For instance, if the `structure` matrix is not centrosymmetric
+    and is defined as::
+
+        [[0,1,0],
+         [1,1,0],
+         [0,0,0]]
+
+    and the `input` is::
+
+        [[1,2],
+         [0,3]]
+
+    then the structure matrix would indicate the
+    entry 2 in the input is connected to 1,
+    but 1 is not connected to 2.
 
     Examples
     --------
@@ -140,6 +165,14 @@ def label(input, structure=None, output=None):
            [0, 0, 0, 1, 0, 0],
            [2, 2, 0, 0, 1, 0],
            [0, 0, 0, 1, 0, 0]])
+
+    References
+    ----------
+
+    .. [1] James R. Weaver, "Centrosymmetric (cross-symmetric)
+       matrices, their basic properties, eigenvalues, and
+       eigenvectors." The American Mathematical Monthly 92.10
+       (1985): 711-717.
 
     """
     input = numpy.asarray(input)


### PR DESCRIPTION
Change `symmetric` requirement to say `centrosymmetric` and add
Notes section to the docstring to explain this requirement.

Closes #9869.