### PR TITLE
MAINT: remove extraneous distutils copies

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -98,17 +98,6 @@ install:
   # Install the scipy test dependencies.
   - '%CMD_IN_ENV% pip install -U --timeout 5 --retries 2 -r tools/ci/appveyor/requirements.txt'
 
-  # Replace numpy distutils with a version that can build with msvc + mingw-gfortran
-  - ps: |
-      $NumpyDir = $((python -c 'import os; import numpy; print(os.path.dirname(numpy.__file__))') | Out-String).Trim()
-      rm -r -Force "$NumpyDir\distutils"
-      $tmpdir = New-TemporaryFile | %{ rm $_; mkdir $_ }
-
-      echo $env:NUMPY_HEAD
-      echo $env:NUMPY_BRANCH
-      git clone -q --depth=1 -b $env:NUMPY_BRANCH $env:NUMPY_HEAD $tmpdir
-      mv $tmpdir\numpy\distutils $NumpyDir
-
 build_script:
   - ps: |
       $PYTHON_ARCH = $env:PYTHON_ARCH

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -95,15 +95,6 @@ jobs:
   - script: python -m pip install numpy cython==0.29.2 pytest pytest-timeout pytest-xdist pytest-env pytest-faulthandler Pillow mpmath matplotlib
     displayName: 'Install dependencies'
   - powershell: |
-      # need a version of NumPy distutils that can build
-      # with msvc + mingw-gfortran
-      $NumpyDir = $((python -c 'import os; import numpy; print(os.path.dirname(numpy.__file__))') | Out-String).Trim()
-      rm -r -Force "$NumpyDir\distutils"
-      $tmpdir = New-TemporaryFile | %{ rm $_; mkdir $_ }
-      git clone -q --depth=1 -b master https://github.com/numpy/numpy.git $tmpdir
-      mv $tmpdir\numpy\distutils $NumpyDir
-    displayName: 'Replace NumPy distutils'
-  - powershell: |
       If ($(BITS) -eq 32) {
           # 32-bit build requires careful adjustments
           # until Microsoft has a switch we can use


### PR DESCRIPTION
Testing on my fork seems to suggest we can safely remove these Windows CI code blocks now, presumably because we can depend on recent NumPy releases to have the appropriate `distutils` code.

If we want to expand Windows dev CI testing to include older versions of NumPy that may be a reason to want to keep this kind of workflow but restrict it to older-numpy matrix entries. Presumably there's something like that going on for Windows wheel builds. I'll leave that up to reviewers.