### PR TITLE
DOC: Updated documentation for nan_policy=propagate as per #9947

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -409,9 +409,10 @@ def mode(a, axis=0, nan_policy='propagate'):
         Axis along which to operate. Default is 0. If None, compute over
         the whole array `a`.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
-        Defines how to handle when input contains nan. 'propagate' returns nan,
-        'raise' throws an error, 'omit' performs the calculations ignoring nan
-        values. Default is 'propagate'.
+        Defines how to handle when input contains nan. 'propagate'
+        performs calculations keeping nan values,'raise' throws an error,
+        'omit' performs the calculations ignoring nan values. Default
+        is 'propagate'.
 
     Returns
     -------
@@ -435,6 +436,18 @@ def mode(a, axis=0, nan_policy='propagate'):
 
     >>> stats.mode(a, axis=None)
     (array([3]), array([3]))
+
+    When ''nan_policy=propagate'' nan values will be treated as
+    a unique element as it calls np.unique (which treats all nan values
+    as a unique element) :
+
+    >>> a = np.array([[1, 1, 2, 3], [1, 2, 2, np.nan], [1, 1, 1, np.nan]])
+    >>> a
+    array([[ 1.,  1.,  2.,  3.],
+           [ 1.,  2.,  2.,  nan.],
+           [ 1.,  1.,  1., nan]])
+    >>> stats.mode(a, nan_policy='propagate')
+    ModeResult(mode=array([[1., 1., 2., 3.]]), count=array([[3, 2, 2, 1]]))
 
     """
     a, axis = _chk_asarray(a, axis)
@@ -656,9 +669,10 @@ def tmin(a, lowerlimit=None, axis=0, inclusive=True, nan_policy='propagate'):
         This flag determines whether values exactly equal to the lower limit
         are included.  The default value is True.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
-        Defines how to handle when input contains nan. 'propagate' returns nan,
-        'raise' throws an error, 'omit' performs the calculations ignoring nan
-        values. Default is 'propagate'.
+        Defines how to handle when input contains nan. 'propagate'
+        performs calculations keeping nan values,'raise' throws an error,
+        'omit' performs the calculations ignoring nan values. Default
+        is 'propagate'.
 
     Returns
     -------
@@ -714,9 +728,10 @@ def tmax(a, upperlimit=None, axis=0, inclusive=True, nan_policy='propagate'):
         This flag determines whether values exactly equal to the upper limit
         are included.  The default value is True.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
-        Defines how to handle when input contains nan. 'propagate' returns nan,
-        'raise' throws an error, 'omit' performs the calculations ignoring nan
-        values. Default is 'propagate'.
+        Defines how to handle when input contains nan. 'propagate'
+        performs calculations keeping nan values,'raise' throws an error,
+        'omit' performs the calculations ignoring nan values. Default
+        is 'propagate'.
 
     Returns
     -------
@@ -875,9 +890,10 @@ def moment(a, moment=1, axis=0, nan_policy='propagate'):
        Axis along which the central moment is computed. Default is 0.
        If None, compute over the whole array `a`.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
-        Defines how to handle when input contains nan. 'propagate' returns nan,
-        'raise' throws an error, 'omit' performs the calculations ignoring nan
-        values. Default is 'propagate'.
+        Defines how to handle when input contains nan. 'propagate'
+        performs calculations keeping nan values,'raise' throws an error,
+        'omit' performs the calculations ignoring nan values. Default
+        is 'propagate'.
 
     Returns
     -------
@@ -1000,9 +1016,10 @@ def variation(a, axis=0, nan_policy='propagate'):
         Axis along which to calculate the coefficient of variation. Default
         is 0. If None, compute over the whole array `a`.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
-        Defines how to handle when input contains nan. 'propagate' returns nan,
-        'raise' throws an error, 'omit' performs the calculations ignoring nan
-        values. Default is 'propagate'.
+        Defines how to handle when input contains nan. 'propagate'
+        performs calculations keeping nan values,'raise' throws an error,
+        'omit' performs the calculations ignoring nan values. Default
+        is 'propagate'.
 
     Returns
     -------
@@ -1052,9 +1069,10 @@ def skew(a, axis=0, bias=True, nan_policy='propagate'):
     bias : bool, optional
         If False, then the calculations are corrected for statistical bias.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
-        Defines how to handle when input contains nan. 'propagate' returns nan,
-        'raise' throws an error, 'omit' performs the calculations ignoring nan
-        values. Default is 'propagate'.
+        Defines how to handle when input contains nan. 'propagate'
+        performs calculations keeping nan values,'raise' throws an error,
+        'omit' performs the calculations ignoring nan values. Default
+        is 'propagate'.
 
     Returns
     -------
@@ -1152,9 +1170,10 @@ def kurtosis(a, axis=0, fisher=True, bias=True, nan_policy='propagate'):
     bias : bool, optional
         If False, then the calculations are corrected for statistical bias.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
-        Defines how to handle when input contains nan. 'propagate' returns nan,
-        'raise' throws an error, 'omit' performs the calculations ignoring nan
-        values. Default is 'propagate'.
+        Defines how to handle when input contains nan. 'propagate'
+        performs calculations keeping nan values,'raise' throws an error,
+        'omit' performs the calculations ignoring nan values. Default
+        is 'propagate'.
 
     Returns
     -------
@@ -1228,9 +1247,10 @@ def describe(a, axis=0, ddof=1, bias=True, nan_policy='propagate'):
         If False, then the skewness and kurtosis calculations are corrected for
         statistical bias.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
-        Defines how to handle when input contains nan. 'propagate' returns nan,
-        'raise' throws an error, 'omit' performs the calculations ignoring nan
-        values. Default is 'propagate'.
+        Defines how to handle when input contains nan. 'propagate'
+        performs calculations keeping nan values,'raise' throws an error,
+        'omit' performs the calculations ignoring nan values. Default
+        is 'propagate'.
 
     Returns
     -------
@@ -1312,9 +1332,10 @@ def skewtest(a, axis=0, nan_policy='propagate'):
        Axis along which statistics are calculated. Default is 0.
        If None, compute over the whole array `a`.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
-        Defines how to handle when input contains nan. 'propagate' returns nan,
-        'raise' throws an error, 'omit' performs the calculations ignoring nan
-        values. Default is 'propagate'.
+        Defines how to handle when input contains nan. 'propagate'
+        performs calculations keeping nan values,'raise' throws an error,
+        'omit' performs the calculations ignoring nan values. Default
+        is 'propagate'.
 
     Returns
     -------
@@ -1393,9 +1414,10 @@ def kurtosistest(a, axis=0, nan_policy='propagate'):
        Axis along which to compute test. Default is 0. If None,
        compute over the whole array `a`.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
-        Defines how to handle when input contains nan. 'propagate' returns nan,
-        'raise' throws an error, 'omit' performs the calculations ignoring nan
-        values. Default is 'propagate'.
+        Defines how to handle when input contains nan. 'propagate'
+        performs calculations keeping nan values,'raise' throws an error,
+        'omit' performs the calculations ignoring nan values. Default
+        is 'propagate'.
 
     Returns
     -------
@@ -1488,9 +1510,10 @@ def normaltest(a, axis=0, nan_policy='propagate'):
         Axis along which to compute test. Default is 0. If None,
         compute over the whole array `a`.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
-        Defines how to handle when input contains nan. 'propagate' returns nan,
-        'raise' throws an error, 'omit' performs the calculations ignoring nan
-        values. Default is 'propagate'.
+        Defines how to handle when input contains nan. 'propagate'
+        performs calculations keeping nan values,'raise' throws an error,
+        'omit' performs the calculations ignoring nan values. Default
+        is 'propagate'.
 
     Returns
     -------
@@ -2203,9 +2226,10 @@ def sem(a, axis=0, ddof=1, nan_policy='propagate'):
         for bias in limited samples relative to the population estimate
         of variance. Defaults to 1.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
-        Defines how to handle when input contains nan. 'propagate' returns nan,
-        'raise' throws an error, 'omit' performs the calculations ignoring nan
-        values. Default is 'propagate'.
+        Defines how to handle when input contains nan. 'propagate'
+        performs calculations keeping nan values,'raise' throws an error,
+        'omit' performs the calculations ignoring nan values. Default
+        is 'propagate'.
 
     Returns
     -------
@@ -2529,8 +2553,9 @@ def iqr(x, axis=None, rng=(25, 75), scale='raw', nan_policy='propagate',
         `keepdims` flag.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
         Defines how to handle when input contains nan. 'propagate'
-        returns nan, 'raise' throws an error, 'omit' performs the
-        calculations ignoring nan values. Default is 'propagate'.
+        performs calculations keeping nan values,'raise' throws an error,
+        'omit' performs the calculations ignoring nan values. Default
+        is 'propagate'.
     interpolation : {'linear', 'lower', 'higher', 'midpoint', 'nearest'}, optional
         Specifies the interpolation method to use when the percentile
         boundaries lie between two data points `i` and `j`:
@@ -2674,8 +2699,9 @@ def median_absolute_deviation(x, axis=0, center=np.median, scale=1.4826,
         data.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
         Defines how to handle when input contains nan. 'propagate'
-        returns nan, 'raise' throws an error, 'omit' performs the
-        calculations ignoring nan values. Default is 'propagate'.
+        performs calculations keeping nan values,'raise' throws an error,
+        'omit' performs the calculations ignoring nan values. Default
+        is 'propagate'.
 
     Returns
     -------
@@ -3513,9 +3539,10 @@ def spearmanr(a, b=None, axis=0, nan_policy='propagate'):
         each row represents a variable, while the columns contain observations.
         If axis=None, then both arrays will be raveled.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
-        Defines how to handle when input contains nan. 'propagate' returns nan,
-        'raise' throws an error, 'omit' performs the calculations ignoring nan
-        values. Default is 'propagate'.
+        Defines how to handle when input contains nan. 'propagate'
+        performs calculations keeping nan values,'raise' throws an error,
+        'omit' performs the calculations ignoring nan values. Default
+        is 'propagate'.
 
     Returns
     -------
@@ -3746,9 +3773,10 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate', method='auto'
     initial_lexsort : bool, optional
         Unused (deprecated).
     nan_policy : {'propagate', 'raise', 'omit'}, optional
-        Defines how to handle when input contains nan. 'propagate' returns nan,
-        'raise' throws an error, 'omit' performs the calculations ignoring nan
-        values. Default is 'propagate'. Note that if the input contains nan
+        Defines how to handle when input contains nan. 'propagate'
+        performs calculations keeping nan values,'raise' throws an error,
+        'omit' performs the calculations ignoring nan values. Default
+        is 'propagate'. Note that if the input contains nan
         'omit' delegates to mstats_basic.kendalltau(), which has a different
         implementation.
     method: {'auto', 'asymptotic', 'exact'}, optional
@@ -4127,9 +4155,10 @@ def ttest_1samp(a, popmean, axis=0, nan_policy='propagate'):
         Axis along which to compute test. If None, compute over the whole
         array `a`.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
-        Defines how to handle when input contains nan. 'propagate' returns nan,
-        'raise' throws an error, 'omit' performs the calculations ignoring nan
-        values. Default is 'propagate'.
+        Defines how to handle when input contains nan. 'propagate'
+        performs calculations keeping nan values,'raise' throws an error,
+        'omit' performs the calculations ignoring nan values. Default
+        is 'propagate'.
 
     Returns
     -------
@@ -4342,9 +4371,10 @@ def ttest_ind(a, b, axis=0, equal_var=True, nan_policy='propagate'):
 
         .. versionadded:: 0.11.0
     nan_policy : {'propagate', 'raise', 'omit'}, optional
-        Defines how to handle when input contains nan. 'propagate' returns nan,
-        'raise' throws an error, 'omit' performs the calculations ignoring nan
-        values. Default is 'propagate'.
+        Defines how to handle when input contains nan. 'propagate'
+        performs calculations keeping nan values,'raise' throws an error,
+        'omit' performs the calculations ignoring nan values. Default
+        is 'propagate'.
 
 
     Returns
@@ -4461,9 +4491,10 @@ def ttest_rel(a, b, axis=0, nan_policy='propagate'):
         Axis along which to compute test. If None, compute over the whole
         arrays, `a`, and `b`.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
-        Defines how to handle when input contains nan. 'propagate' returns nan,
-        'raise' throws an error, 'omit' performs the calculations ignoring nan
-        values. Default is 'propagate'.
+        Defines how to handle when input contains nan. 'propagate'
+        performs calculations keeping nan values,'raise' throws an error,
+        'omit' performs the calculations ignoring nan values. Default
+        is 'propagate'.
 
     Returns
     -------
@@ -5349,9 +5380,10 @@ def kruskal(*args, **kwargs):
        Two or more arrays with the sample measurements can be given as
        arguments.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
-        Defines how to handle when input contains nan. 'propagate' returns nan,
-        'raise' throws an error, 'omit' performs the calculations ignoring nan
-        values. Default is 'propagate'.
+        Defines how to handle when input contains nan. 'propagate'
+        performs calculations keeping nan values,'raise' throws an error,
+        'omit' performs the calculations ignoring nan values. Default
+        is 'propagate'.
 
     Returns
     -------
@@ -5548,9 +5580,10 @@ def brunnermunzel(x, y, alternative="two-sided", distribution="t",
         distribution.
         Defaults value is 't' .
     nan_policy : {'propagate', 'raise', 'omit'}, optional
-        Defines how to handle when input contains nan. 'propagate' returns nan,
-        'raise' throws an error, 'omit' performs the calculations ignoring nan
-        values. Default is 'propagate'.
+        Defines how to handle when input contains nan. 'propagate'
+        performs calculations keeping nan values,'raise' throws an error,
+        'omit' performs the calculations ignoring nan values. Default
+        is 'propagate'.
 
     Returns
     -------

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -437,7 +437,7 @@ def mode(a, axis=0, nan_policy='propagate'):
     >>> stats.mode(a, axis=None)
     (array([3]), array([3]))
 
-    When ''nan_policy=propagate'' nan values will be treated as
+    When ``nan_policy=propagate`` nan values will be treated as
     unique elements as it calls np.unique (which treats all nan values
     as a unique element) :
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -444,7 +444,7 @@ def mode(a, axis=0, nan_policy='propagate'):
     >>> a = np.array([[1, 1, 2, 3], [1, 2, 2, np.nan], [1, 1, 1, np.nan]])
     >>> a
     array([[ 1.,  1.,  2.,  3.],
-           [ 1.,  2.,  2.,  nan.],
+           [ 1.,  2.,  2.,  nan],
            [ 1.,  1.,  1., nan]])
     >>> stats.mode(a, nan_policy='propagate')
     ModeResult(mode=array([[1., 1., 2., 3.]]), count=array([[3, 2, 2, 1]]))

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -409,10 +409,10 @@ def mode(a, axis=0, nan_policy='propagate'):
         Axis along which to operate. Default is 0. If None, compute over
         the whole array `a`.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
-        Defines how to handle when input contains nan. 'propagate'
-        performs calculations keeping nan values,'raise' throws an error,
-        'omit' performs the calculations ignoring nan values. Default
-        is 'propagate'.
+        Defines how to handle when the input contains nan. 'propagate' 
+        attempts to performs calculations keeping nan values,'raise'
+        throws an error,'omit' performs the calculations ignoring nan
+        values. Default is 'propagate'.
 
     Returns
     -------
@@ -438,7 +438,7 @@ def mode(a, axis=0, nan_policy='propagate'):
     (array([3]), array([3]))
 
     When ''nan_policy=propagate'' nan values will be treated as
-    a unique element as it calls np.unique (which treats all nan values
+    unique elements as it calls np.unique (which treats all nan values
     as a unique element) :
 
     >>> a = np.array([[1, 1, 2, 3], [1, 2, 2, np.nan], [1, 1, 1, np.nan]])
@@ -669,10 +669,10 @@ def tmin(a, lowerlimit=None, axis=0, inclusive=True, nan_policy='propagate'):
         This flag determines whether values exactly equal to the lower limit
         are included.  The default value is True.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
-        Defines how to handle when input contains nan. 'propagate'
-        performs calculations keeping nan values,'raise' throws an error,
-        'omit' performs the calculations ignoring nan values. Default
-        is 'propagate'.
+        Defines how to handle when the input contains nan. 'propagate' 
+        attempts to performs calculations keeping nan values,'raise'
+        throws an error,'omit' performs the calculations ignoring nan
+        values. Default is 'propagate'.
 
     Returns
     -------
@@ -728,10 +728,10 @@ def tmax(a, upperlimit=None, axis=0, inclusive=True, nan_policy='propagate'):
         This flag determines whether values exactly equal to the upper limit
         are included.  The default value is True.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
-        Defines how to handle when input contains nan. 'propagate'
-        performs calculations keeping nan values,'raise' throws an error,
-        'omit' performs the calculations ignoring nan values. Default
-        is 'propagate'.
+        Defines how to handle when the input contains nan. 'propagate' 
+        attempts to performs calculations keeping nan values,'raise'
+        throws an error,'omit' performs the calculations ignoring nan
+        values. Default is 'propagate'.
 
     Returns
     -------
@@ -890,10 +890,10 @@ def moment(a, moment=1, axis=0, nan_policy='propagate'):
        Axis along which the central moment is computed. Default is 0.
        If None, compute over the whole array `a`.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
-        Defines how to handle when input contains nan. 'propagate'
-        performs calculations keeping nan values,'raise' throws an error,
-        'omit' performs the calculations ignoring nan values. Default
-        is 'propagate'.
+        Defines how to handle when the input contains nan. 'propagate' 
+        attempts to performs calculations keeping nan values,'raise'
+        throws an error,'omit' performs the calculations ignoring nan
+        values. Default is 'propagate'.
 
     Returns
     -------
@@ -1016,10 +1016,10 @@ def variation(a, axis=0, nan_policy='propagate'):
         Axis along which to calculate the coefficient of variation. Default
         is 0. If None, compute over the whole array `a`.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
-        Defines how to handle when input contains nan. 'propagate'
-        performs calculations keeping nan values,'raise' throws an error,
-        'omit' performs the calculations ignoring nan values. Default
-        is 'propagate'.
+        Defines how to handle when the input contains nan. 'propagate' 
+        attempts to performs calculations keeping nan values,'raise'
+        throws an error,'omit' performs the calculations ignoring nan
+        values. Default is 'propagate'.
 
     Returns
     -------
@@ -1069,10 +1069,10 @@ def skew(a, axis=0, bias=True, nan_policy='propagate'):
     bias : bool, optional
         If False, then the calculations are corrected for statistical bias.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
-        Defines how to handle when input contains nan. 'propagate'
-        performs calculations keeping nan values,'raise' throws an error,
-        'omit' performs the calculations ignoring nan values. Default
-        is 'propagate'.
+        Defines how to handle when the input contains nan. 'propagate' 
+        attempts to performs calculations keeping nan values,'raise'
+        throws an error,'omit' performs the calculations ignoring nan
+        values. Default is 'propagate'.
 
     Returns
     -------
@@ -1170,10 +1170,10 @@ def kurtosis(a, axis=0, fisher=True, bias=True, nan_policy='propagate'):
     bias : bool, optional
         If False, then the calculations are corrected for statistical bias.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
-        Defines how to handle when input contains nan. 'propagate'
-        performs calculations keeping nan values,'raise' throws an error,
-        'omit' performs the calculations ignoring nan values. Default
-        is 'propagate'.
+        Defines how to handle when the input contains nan. 'propagate' 
+        attempts to performs calculations keeping nan values,'raise'
+        throws an error,'omit' performs the calculations ignoring nan
+        values. Default is 'propagate'.
 
     Returns
     -------
@@ -1247,10 +1247,10 @@ def describe(a, axis=0, ddof=1, bias=True, nan_policy='propagate'):
         If False, then the skewness and kurtosis calculations are corrected for
         statistical bias.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
-        Defines how to handle when input contains nan. 'propagate'
-        performs calculations keeping nan values,'raise' throws an error,
-        'omit' performs the calculations ignoring nan values. Default
-        is 'propagate'.
+        Defines how to handle when the input contains nan. 'propagate' 
+        attempts to performs calculations keeping nan values,'raise'
+        throws an error,'omit' performs the calculations ignoring nan
+        values. Default is 'propagate'.
 
     Returns
     -------
@@ -1332,10 +1332,10 @@ def skewtest(a, axis=0, nan_policy='propagate'):
        Axis along which statistics are calculated. Default is 0.
        If None, compute over the whole array `a`.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
-        Defines how to handle when input contains nan. 'propagate'
-        performs calculations keeping nan values,'raise' throws an error,
-        'omit' performs the calculations ignoring nan values. Default
-        is 'propagate'.
+        Defines how to handle when the input contains nan. 'propagate' 
+        attempts to performs calculations keeping nan values,'raise'
+        throws an error,'omit' performs the calculations ignoring nan
+        values. Default is 'propagate'.
 
     Returns
     -------
@@ -1414,10 +1414,10 @@ def kurtosistest(a, axis=0, nan_policy='propagate'):
        Axis along which to compute test. Default is 0. If None,
        compute over the whole array `a`.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
-        Defines how to handle when input contains nan. 'propagate'
-        performs calculations keeping nan values,'raise' throws an error,
-        'omit' performs the calculations ignoring nan values. Default
-        is 'propagate'.
+        Defines how to handle when the input contains nan. 'propagate' 
+        attempts to performs calculations keeping nan values,'raise'
+        throws an error,'omit' performs the calculations ignoring nan
+        values. Default is 'propagate'.
 
     Returns
     -------
@@ -1510,10 +1510,10 @@ def normaltest(a, axis=0, nan_policy='propagate'):
         Axis along which to compute test. Default is 0. If None,
         compute over the whole array `a`.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
-        Defines how to handle when input contains nan. 'propagate'
-        performs calculations keeping nan values,'raise' throws an error,
-        'omit' performs the calculations ignoring nan values. Default
-        is 'propagate'.
+        Defines how to handle when the input contains nan. 'propagate' 
+        attempts to performs calculations keeping nan values,'raise'
+        throws an error,'omit' performs the calculations ignoring nan
+        values. Default is 'propagate'.
 
     Returns
     -------
@@ -2226,10 +2226,10 @@ def sem(a, axis=0, ddof=1, nan_policy='propagate'):
         for bias in limited samples relative to the population estimate
         of variance. Defaults to 1.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
-        Defines how to handle when input contains nan. 'propagate'
-        performs calculations keeping nan values,'raise' throws an error,
-        'omit' performs the calculations ignoring nan values. Default
-        is 'propagate'.
+        Defines how to handle when the input contains nan. 'propagate' 
+        attempts to performs calculations keeping nan values,'raise'
+        throws an error,'omit' performs the calculations ignoring nan
+        values. Default is 'propagate'.
 
     Returns
     -------
@@ -2552,10 +2552,10 @@ def iqr(x, axis=None, rng=(25, 75), scale='raw', nan_policy='propagate',
         depend on the input array, `x`, the `axis` argument, and the
         `keepdims` flag.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
-        Defines how to handle when input contains nan. 'propagate'
-        performs calculations keeping nan values,'raise' throws an error,
-        'omit' performs the calculations ignoring nan values. Default
-        is 'propagate'.
+        Defines how to handle when the input contains nan. 'propagate' 
+        attempts to performs calculations keeping nan values,'raise'
+        throws an error,'omit' performs the calculations ignoring nan
+        values. Default is 'propagate'.
     interpolation : {'linear', 'lower', 'higher', 'midpoint', 'nearest'}, optional
         Specifies the interpolation method to use when the percentile
         boundaries lie between two data points `i` and `j`:
@@ -2698,10 +2698,10 @@ def median_absolute_deviation(x, axis=0, center=np.median, scale=1.4826,
         ensures consistency with the standard deviation for normally distributed
         data.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
-        Defines how to handle when input contains nan. 'propagate'
-        performs calculations keeping nan values,'raise' throws an error,
-        'omit' performs the calculations ignoring nan values. Default
-        is 'propagate'.
+        Defines how to handle when the input contains nan. 'propagate' 
+        attempts to performs calculations keeping nan values,'raise'
+        throws an error,'omit' performs the calculations ignoring nan
+        values. Default is 'propagate'.
 
     Returns
     -------
@@ -3539,10 +3539,10 @@ def spearmanr(a, b=None, axis=0, nan_policy='propagate'):
         each row represents a variable, while the columns contain observations.
         If axis=None, then both arrays will be raveled.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
-        Defines how to handle when input contains nan. 'propagate'
-        performs calculations keeping nan values,'raise' throws an error,
-        'omit' performs the calculations ignoring nan values. Default
-        is 'propagate'.
+        Defines how to handle when the input contains nan. 'propagate' 
+        attempts to performs calculations keeping nan values,'raise'
+        throws an error,'omit' performs the calculations ignoring nan
+        values. Default is 'propagate'.
 
     Returns
     -------
@@ -3773,10 +3773,10 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate', method='auto'
     initial_lexsort : bool, optional
         Unused (deprecated).
     nan_policy : {'propagate', 'raise', 'omit'}, optional
-        Defines how to handle when input contains nan. 'propagate'
-        performs calculations keeping nan values,'raise' throws an error,
-        'omit' performs the calculations ignoring nan values. Default
-        is 'propagate'. Note that if the input contains nan
+        Defines how to handle when the input contains nan. 'propagate' 
+        attempts to performs calculations keeping nan values,'raise'
+        throws an error,'omit' performs the calculations ignoring nan
+        values. Default is 'propagate'. Note that if the input contains nan
         'omit' delegates to mstats_basic.kendalltau(), which has a different
         implementation.
     method: {'auto', 'asymptotic', 'exact'}, optional
@@ -4155,10 +4155,10 @@ def ttest_1samp(a, popmean, axis=0, nan_policy='propagate'):
         Axis along which to compute test. If None, compute over the whole
         array `a`.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
-        Defines how to handle when input contains nan. 'propagate'
-        performs calculations keeping nan values,'raise' throws an error,
-        'omit' performs the calculations ignoring nan values. Default
-        is 'propagate'.
+        Defines how to handle when the input contains nan. 'propagate' 
+        attempts to performs calculations keeping nan values,'raise'
+        throws an error,'omit' performs the calculations ignoring nan
+        values. Default is 'propagate'.
 
     Returns
     -------
@@ -4371,11 +4371,10 @@ def ttest_ind(a, b, axis=0, equal_var=True, nan_policy='propagate'):
 
         .. versionadded:: 0.11.0
     nan_policy : {'propagate', 'raise', 'omit'}, optional
-        Defines how to handle when input contains nan. 'propagate'
-        performs calculations keeping nan values,'raise' throws an error,
-        'omit' performs the calculations ignoring nan values. Default
-        is 'propagate'.
-
+        Defines how to handle when the input contains nan. 'propagate' 
+        attempts to performs calculations keeping nan values,'raise'
+        throws an error,'omit' performs the calculations ignoring nan
+        values. Default is 'propagate'.
 
     Returns
     -------
@@ -4491,10 +4490,10 @@ def ttest_rel(a, b, axis=0, nan_policy='propagate'):
         Axis along which to compute test. If None, compute over the whole
         arrays, `a`, and `b`.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
-        Defines how to handle when input contains nan. 'propagate'
-        performs calculations keeping nan values,'raise' throws an error,
-        'omit' performs the calculations ignoring nan values. Default
-        is 'propagate'.
+        Defines how to handle when the input contains nan. 'propagate' 
+        attempts to performs calculations keeping nan values,'raise'
+        throws an error,'omit' performs the calculations ignoring nan
+        values. Default is 'propagate'.
 
     Returns
     -------
@@ -5380,10 +5379,10 @@ def kruskal(*args, **kwargs):
        Two or more arrays with the sample measurements can be given as
        arguments.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
-        Defines how to handle when input contains nan. 'propagate'
-        performs calculations keeping nan values,'raise' throws an error,
-        'omit' performs the calculations ignoring nan values. Default
-        is 'propagate'.
+        Defines how to handle when the input contains nan. 'propagate' 
+        attempts to performs calculations keeping nan values,'raise'
+        throws an error,'omit' performs the calculations ignoring nan
+        values. Default is 'propagate'.
 
     Returns
     -------
@@ -5580,10 +5579,10 @@ def brunnermunzel(x, y, alternative="two-sided", distribution="t",
         distribution.
         Defaults value is 't' .
     nan_policy : {'propagate', 'raise', 'omit'}, optional
-        Defines how to handle when input contains nan. 'propagate'
-        performs calculations keeping nan values,'raise' throws an error,
-        'omit' performs the calculations ignoring nan values. Default
-        is 'propagate'.
+        Defines how to handle when the input contains nan. 'propagate' 
+        attempts to performs calculations keeping nan values,'raise'
+        throws an error,'omit' performs the calculations ignoring nan
+        values. Default is 'propagate'.
 
     Returns
     -------

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -410,8 +410,8 @@ def mode(a, axis=0, nan_policy='propagate'):
         the whole array `a`.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
         Defines how to handle when the input contains nan. 'propagate' 
-        attempts to performs calculations keeping nan values,'raise'
-        throws an error,'omit' performs the calculations ignoring nan
+        attempts to performs calculations keeping nan values, 'raise'
+        throws an error, 'omit' performs the calculations ignoring nan
         values. Default is 'propagate'.
 
     Returns
@@ -670,8 +670,8 @@ def tmin(a, lowerlimit=None, axis=0, inclusive=True, nan_policy='propagate'):
         are included.  The default value is True.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
         Defines how to handle when the input contains nan. 'propagate' 
-        attempts to performs calculations keeping nan values,'raise'
-        throws an error,'omit' performs the calculations ignoring nan
+        attempts to performs calculations keeping nan values, 'raise'
+        throws an error, 'omit' performs the calculations ignoring nan
         values. Default is 'propagate'.
 
     Returns
@@ -729,8 +729,8 @@ def tmax(a, upperlimit=None, axis=0, inclusive=True, nan_policy='propagate'):
         are included.  The default value is True.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
         Defines how to handle when the input contains nan. 'propagate' 
-        attempts to performs calculations keeping nan values,'raise'
-        throws an error,'omit' performs the calculations ignoring nan
+        attempts to performs calculations keeping nan values, 'raise'
+        throws an error, 'omit' performs the calculations ignoring nan
         values. Default is 'propagate'.
 
     Returns
@@ -891,8 +891,8 @@ def moment(a, moment=1, axis=0, nan_policy='propagate'):
        If None, compute over the whole array `a`.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
         Defines how to handle when the input contains nan. 'propagate' 
-        attempts to performs calculations keeping nan values,'raise'
-        throws an error,'omit' performs the calculations ignoring nan
+        attempts to performs calculations keeping nan values, 'raise'
+        throws an error, 'omit' performs the calculations ignoring nan
         values. Default is 'propagate'.
 
     Returns
@@ -1017,8 +1017,8 @@ def variation(a, axis=0, nan_policy='propagate'):
         is 0. If None, compute over the whole array `a`.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
         Defines how to handle when the input contains nan. 'propagate' 
-        attempts to performs calculations keeping nan values,'raise'
-        throws an error,'omit' performs the calculations ignoring nan
+        attempts to performs calculations keeping nan values, 'raise'
+        throws an error, 'omit' performs the calculations ignoring nan
         values. Default is 'propagate'.
 
     Returns
@@ -1070,8 +1070,8 @@ def skew(a, axis=0, bias=True, nan_policy='propagate'):
         If False, then the calculations are corrected for statistical bias.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
         Defines how to handle when the input contains nan. 'propagate' 
-        attempts to performs calculations keeping nan values,'raise'
-        throws an error,'omit' performs the calculations ignoring nan
+        attempts to performs calculations keeping nan values, 'raise'
+        throws an error, 'omit' performs the calculations ignoring nan
         values. Default is 'propagate'.
 
     Returns
@@ -1171,8 +1171,8 @@ def kurtosis(a, axis=0, fisher=True, bias=True, nan_policy='propagate'):
         If False, then the calculations are corrected for statistical bias.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
         Defines how to handle when the input contains nan. 'propagate' 
-        attempts to performs calculations keeping nan values,'raise'
-        throws an error,'omit' performs the calculations ignoring nan
+        attempts to performs calculations keeping nan values, 'raise'
+        throws an error, 'omit' performs the calculations ignoring nan
         values. Default is 'propagate'.
 
     Returns
@@ -1248,8 +1248,8 @@ def describe(a, axis=0, ddof=1, bias=True, nan_policy='propagate'):
         statistical bias.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
         Defines how to handle when the input contains nan. 'propagate' 
-        attempts to performs calculations keeping nan values,'raise'
-        throws an error,'omit' performs the calculations ignoring nan
+        attempts to performs calculations keeping nan values, 'raise'
+        throws an error, 'omit' performs the calculations ignoring nan
         values. Default is 'propagate'.
 
     Returns
@@ -1333,8 +1333,8 @@ def skewtest(a, axis=0, nan_policy='propagate'):
        If None, compute over the whole array `a`.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
         Defines how to handle when the input contains nan. 'propagate' 
-        attempts to performs calculations keeping nan values,'raise'
-        throws an error,'omit' performs the calculations ignoring nan
+        attempts to performs calculations keeping nan values, 'raise'
+        throws an error, 'omit' performs the calculations ignoring nan
         values. Default is 'propagate'.
 
     Returns
@@ -1415,8 +1415,8 @@ def kurtosistest(a, axis=0, nan_policy='propagate'):
        compute over the whole array `a`.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
         Defines how to handle when the input contains nan. 'propagate' 
-        attempts to performs calculations keeping nan values,'raise'
-        throws an error,'omit' performs the calculations ignoring nan
+        attempts to performs calculations keeping nan values, 'raise'
+        throws an error, 'omit' performs the calculations ignoring nan
         values. Default is 'propagate'.
 
     Returns
@@ -1511,8 +1511,8 @@ def normaltest(a, axis=0, nan_policy='propagate'):
         compute over the whole array `a`.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
         Defines how to handle when the input contains nan. 'propagate' 
-        attempts to performs calculations keeping nan values,'raise'
-        throws an error,'omit' performs the calculations ignoring nan
+        attempts to performs calculations keeping nan values, 'raise'
+        throws an error, 'omit' performs the calculations ignoring nan
         values. Default is 'propagate'.
 
     Returns
@@ -2227,8 +2227,8 @@ def sem(a, axis=0, ddof=1, nan_policy='propagate'):
         of variance. Defaults to 1.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
         Defines how to handle when the input contains nan. 'propagate' 
-        attempts to performs calculations keeping nan values,'raise'
-        throws an error,'omit' performs the calculations ignoring nan
+        attempts to performs calculations keeping nan values, 'raise'
+        throws an error, 'omit' performs the calculations ignoring nan
         values. Default is 'propagate'.
 
     Returns
@@ -2553,8 +2553,8 @@ def iqr(x, axis=None, rng=(25, 75), scale='raw', nan_policy='propagate',
         `keepdims` flag.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
         Defines how to handle when the input contains nan. 'propagate' 
-        attempts to performs calculations keeping nan values,'raise'
-        throws an error,'omit' performs the calculations ignoring nan
+        attempts to performs calculations keeping nan values, 'raise'
+        throws an error, 'omit' performs the calculations ignoring nan
         values. Default is 'propagate'.
     interpolation : {'linear', 'lower', 'higher', 'midpoint', 'nearest'}, optional
         Specifies the interpolation method to use when the percentile
@@ -2699,8 +2699,8 @@ def median_absolute_deviation(x, axis=0, center=np.median, scale=1.4826,
         data.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
         Defines how to handle when the input contains nan. 'propagate' 
-        attempts to performs calculations keeping nan values,'raise'
-        throws an error,'omit' performs the calculations ignoring nan
+        attempts to performs calculations keeping nan values, 'raise'
+        throws an error, 'omit' performs the calculations ignoring nan
         values. Default is 'propagate'.
 
     Returns
@@ -3540,8 +3540,8 @@ def spearmanr(a, b=None, axis=0, nan_policy='propagate'):
         If axis=None, then both arrays will be raveled.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
         Defines how to handle when the input contains nan. 'propagate' 
-        attempts to performs calculations keeping nan values,'raise'
-        throws an error,'omit' performs the calculations ignoring nan
+        attempts to performs calculations keeping nan values, 'raise'
+        throws an error, 'omit' performs the calculations ignoring nan
         values. Default is 'propagate'.
 
     Returns
@@ -3774,8 +3774,8 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate', method='auto'
         Unused (deprecated).
     nan_policy : {'propagate', 'raise', 'omit'}, optional
         Defines how to handle when the input contains nan. 'propagate' 
-        attempts to performs calculations keeping nan values,'raise'
-        throws an error,'omit' performs the calculations ignoring nan
+        attempts to performs calculations keeping nan values, 'raise'
+        throws an error, 'omit' performs the calculations ignoring nan
         values. Default is 'propagate'. Note that if the input contains nan
         'omit' delegates to mstats_basic.kendalltau(), which has a different
         implementation.
@@ -4156,8 +4156,8 @@ def ttest_1samp(a, popmean, axis=0, nan_policy='propagate'):
         array `a`.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
         Defines how to handle when the input contains nan. 'propagate' 
-        attempts to performs calculations keeping nan values,'raise'
-        throws an error,'omit' performs the calculations ignoring nan
+        attempts to performs calculations keeping nan values, 'raise'
+        throws an error, 'omit' performs the calculations ignoring nan
         values. Default is 'propagate'.
 
     Returns
@@ -4372,8 +4372,8 @@ def ttest_ind(a, b, axis=0, equal_var=True, nan_policy='propagate'):
         .. versionadded:: 0.11.0
     nan_policy : {'propagate', 'raise', 'omit'}, optional
         Defines how to handle when the input contains nan. 'propagate' 
-        attempts to performs calculations keeping nan values,'raise'
-        throws an error,'omit' performs the calculations ignoring nan
+        attempts to performs calculations keeping nan values, 'raise'
+        throws an error, 'omit' performs the calculations ignoring nan
         values. Default is 'propagate'.
 
     Returns
@@ -4491,8 +4491,8 @@ def ttest_rel(a, b, axis=0, nan_policy='propagate'):
         arrays, `a`, and `b`.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
         Defines how to handle when the input contains nan. 'propagate' 
-        attempts to performs calculations keeping nan values,'raise'
-        throws an error,'omit' performs the calculations ignoring nan
+        attempts to performs calculations keeping nan values, 'raise'
+        throws an error, 'omit' performs the calculations ignoring nan
         values. Default is 'propagate'.
 
     Returns
@@ -5380,8 +5380,8 @@ def kruskal(*args, **kwargs):
        arguments.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
         Defines how to handle when the input contains nan. 'propagate' 
-        attempts to performs calculations keeping nan values,'raise'
-        throws an error,'omit' performs the calculations ignoring nan
+        attempts to performs calculations keeping nan values, 'raise'
+        throws an error, 'omit' performs the calculations ignoring nan
         values. Default is 'propagate'.
 
     Returns
@@ -5580,8 +5580,8 @@ def brunnermunzel(x, y, alternative="two-sided", distribution="t",
         Defaults value is 't' .
     nan_policy : {'propagate', 'raise', 'omit'}, optional
         Defines how to handle when the input contains nan. 'propagate' 
-        attempts to performs calculations keeping nan values,'raise'
-        throws an error,'omit' performs the calculations ignoring nan
+        attempts to performs calculations keeping nan values, 'raise'
+        throws an error, 'omit' performs the calculations ignoring nan
         values. Default is 'propagate'.
 
     Returns


### PR DESCRIPTION
Updated documentation for nan_policy='propagate' as per #9947 and added an example for stats.mode to make behaviour clear.

- [x]  Update documentation of nan_policy='propagate' to better describe the behaviour (see #9947)
- [x]  Add an example to mode as the results differs from what usually occurs.
- [x]  Closes  #9947