### PR TITLE
DOC: Fix documentation in scipy.interpolate.RectBivariateSpline

### DIFF
--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -1139,6 +1139,10 @@ class RectBivariateSpline(BivariateSpline):
     ----------
     x,y : array_like
         1-D arrays of coordinates in strictly ascending order.
+    tx, ty : array_like
+        Strictly ordered 1-D sequences of knots coordinates.
+    w : array_like, optional
+        Positive 1-D array of weights, of the same length as `x`, `y` and `z`.
     z : array_like
         2-D array of data with shape (x.size,y.size).
     bbox : array_like, optional


### PR DESCRIPTION
Fix #9718 and part of #9944 by adding definitions for `tx`, `ty` and `w`

However, the `__call__` method documentation still remains unclear. In the first definition [here](https://github.com/scipy/scipy/blob/90534919e139d2a81c24bf08341734ff41a3db12/scipy/interpolate/fitpack2.py#L273), it says that `ext=0` is default (and hence "extrapolation") [here](https://github.com/scipy/scipy/blob/90534919e139d2a81c24bf08341734ff41a3db12/scipy/interpolate/fitpack2.py#L294).

Does this hold true for all other `__call__` methods? (Others don't even seem to have the `ext` parameter)