### PR TITLE
ENH: Improve performance of lsmr

### DIFF
--- a/scipy/sparse/linalg/isolve/lsmr.py
+++ b/scipy/sparse/linalg/isolve/lsmr.py
@@ -316,15 +316,17 @@ def lsmr(A, b, damp=0.0, atol=1e-6, btol=1e-6, conlim=1e8,
         #         beta*u  =  a*v   -  alpha*u,
         #        alpha*v  =  A'*u  -  beta*v.
 
-        u = A.matvec(v) - alpha * u
+        u *= -alpha
+        u += A.matvec(v)
         beta = norm(u)
 
         if beta > 0:
-            u = (1 / beta) * u
-            v = A.rmatvec(u) - beta * v
+            u *= (1 / beta)
+            v *= -beta
+            v += A.rmatvec(u)
             alpha = norm(v)
             if alpha > 0:
-                v = (1 / alpha) * v
+                v *= (1 / alpha)
 
         # At this point, beta = beta_{k+1}, alpha = alpha_{k+1}.
 
@@ -351,9 +353,11 @@ def lsmr(A, b, damp=0.0, atol=1e-6, btol=1e-6, conlim=1e8,
 
         # Update h, h_hat, x.
 
-        hbar = h - (thetabar * rho / (rhoold * rhobarold)) * hbar
-        x = x + (zeta / (rho * rhobar)) * hbar
-        h = v - (thetanew / rho) * h
+        hbar *= - (thetabar * rho / (rhoold * rhobarold))
+        hbar += h
+        x += (zeta / (rho * rhobar)) * hbar
+        h *= - (thetanew / rho)
+        h += v
 
         # Estimate of ||r||.
 


### PR DESCRIPTION
Use in-place operators in the main loop to avoid temporary allocations
arrays where possible. 

On large problems (100,000s of variables) leads to a 10% decrease in runtime.