### PR TITLE
BUG: Fixes gh-7491, pdf at x=0 of fisk/burr/burr12/f distributions.

### DIFF
--- a/doc/source/tutorial/stats/continuous.rst
+++ b/doc/source/tutorial/stats/continuous.rst
@@ -215,6 +215,7 @@ Continuous Distributions in `scipy.stats`
    continuous_betaprime
    continuous_bradford
    continuous_burr
+   continuous_burr12
    continuous_cauchy
    continuous_chi
    continuous_chi2

--- a/doc/source/tutorial/stats/continuous_burr12.rst
+++ b/doc/source/tutorial/stats/continuous_burr12.rst
@@ -1,0 +1,26 @@
+
+.. _continuous-burr12:
+
+Burr12 Distribution
+===================
+
+There are two shape parameters :math:`c,d > 0` and the support is :math:`x \in [0,\infty)`.
+The Burr12 distibution is also known as the Singh-Maddala distibution.
+
+
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*}
+    f\left(x;c,d\right) & = & {cd}\frac{x^{c-1}}\left(1+x^{c}\right)^{d+1}} \\
+    F\left(x;c,d\right) & = & 1 - \left(1+x^{c}\right)^{-d}\\
+    G\left(q;c,d\right) & = & \left((1-q)^{-1/d}-1\right)^{-1/c}\\
+    S\left(x;c,d\right) & = & \left(1+x^{c}\right)^{-d}\\
+    \mu & = & d \Beta\left(d-\frac{1}{c}, 1+\frac{1}{c}\right)\\
+    \mu_{n} & = & d \Beta\left(d-\frac{n}{c}, 1+\frac{n}{c}\right)\\
+    m_{d} & = & \left(\frac{c-1}{c d + 1}\right)^{1/c}\\
+    m_{n} & = & \left(2^{1/d}-1\right)^{-1/c}
+    \end{eqnarray*}
+
+Implementation: `scipy.stats.burr12`

--- a/doc/source/tutorial/stats/continuous_burr12.rst
+++ b/doc/source/tutorial/stats/continuous_burr12.rst
@@ -13,14 +13,16 @@ The Burr12 distibution is also known as the Singh-Maddala distibution.
    :nowrap:
 
     \begin{eqnarray*}
-    f\left(x;c,d\right) & = & {cd}\frac{x^{c-1}}\left(1+x^{c}\right)^{d+1}} \\
+    f\left(x;c,d\right) & = & {cd} \frac{x^{c-1}} {\left(1+x^{c}\right)^{d+1}} \\
     F\left(x;c,d\right) & = & 1 - \left(1+x^{c}\right)^{-d}\\
     G\left(q;c,d\right) & = & \left((1-q)^{-1/d}-1\right)^{-1/c}\\
     S\left(x;c,d\right) & = & \left(1+x^{c}\right)^{-d}\\
-    \mu & = & d \Beta\left(d-\frac{1}{c}, 1+\frac{1}{c}\right)\\
-    \mu_{n} & = & d \Beta\left(d-\frac{n}{c}, 1+\frac{n}{c}\right)\\
-    m_{d} & = & \left(\frac{c-1}{c d + 1}\right)^{1/c}\\
+    \mu & = & d \,  B\left(d-\frac{1}{c}, 1+\frac{1}{c}\right)\\
+    \mu_{n} & = & d \, B\left(d-\frac{n}{c}, 1+\frac{n}{c}\right)\\
+    m_{d} & = & \left(\frac{c-1}{c d + 1}\right)^{1/c} \,\text{if }\quad c>1 \text{, otherwise }\quad 0\\
     m_{n} & = & \left(2^{1/d}-1\right)^{-1/c}
     \end{eqnarray*}
+
+where :math:`B(a, b) = \frac{\Gamma(a)\Gamma(b)}{\Gamma(a+b)}` is the Beta function.
 
 Implementation: `scipy.stats.burr12`

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -845,8 +845,13 @@ class burr_gen(rv_continuous):
         return mu, mu2, g1, g2
 
     def _munp(self, n, c, d):
-        nc = 1. * n / c
-        return d * sc.beta(1.0 - nc, d + nc)
+        def __munp(n, c, d):
+            nc = 1. * n / c
+            return d * sc.beta(1.0 - nc, d + nc)
+        n, c, d = np.asarray(n), np.asarray(c), np.asarray(d)
+        return _lazywhere((c > n) & (n == n) & (d == d), (c, d, n),
+                          lambda c, d, n: __munp(n, c, d),
+                          np.nan)
 
 
 burr = burr_gen(a=0.0, name='burr')

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -844,7 +844,7 @@ class burr_gen(rv_continuous):
             c > 3.0,
             (c, e1, e2, e3, e4, mu2_if_c),
             lambda c, e1, e2, e3, e4, mu2_if_c: (
-                ((e4 - 4*e3*e1 + 6*e2*e1**2 - 3*e1**4) /  mu2_if_c**2) - 3),
+                ((e4 - 4*e3*e1 + 6*e2*e1**2 - 3*e1**4) / mu2_if_c**2) - 3),
             fillvalue=np.nan)
         return mu, mu2, g1, g2
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -764,7 +764,10 @@ class burr_gen(rv_continuous):
     `burr` takes :math:`c` and :math:`d` as shape parameters.
 
     This is the PDF corresponding to the third CDF given in Burr's list;
-    specifically, it is equation (11) in Burr's paper [1]_.
+    specifically, it is equation (11) in Burr's paper [1]_. The distribution
+    is also commonly referred to as the Dagum distribution [2]_. If the
+    parameter :math:`c < 1` then the mean of the distribution does not
+    exist and if :math:`c < 2` the variance does not exist [2]_.
 
     %(after_notes)s
 
@@ -772,6 +775,9 @@ class burr_gen(rv_continuous):
     ----------
     .. [1] Burr, I. W. "Cumulative frequency functions", Annals of
        Mathematical Statistics, 13(2), pp 215-232 (1942).
+    .. [2] https://en.wikipedia.org/wiki/Dagum_distribution
+    .. [3] Kleiber, Christian. "A guide to the Dagum distributions."
+       Modeling Income Distributions and Lorenz Curves  pp 97-117 (2008).
 
     %(example)s
 
@@ -990,25 +996,6 @@ class fisk_gen(burr_gen):
 
     def _munp(self, n, c):
         return burr._munp(n, c, 1.0)
-
-    def _stats(self, c):
-        e1 = self._munp(1, c)
-        e2 = self._munp(2, c)
-        e3 = self._munp(3, c)
-        e4 = self._munp(4, c)
-        mu = np.where(c > 1.0, e1, np.nan)
-        mu2_if_c = e2 - mu**2
-        mu2 = np.where(c > 2.0, mu2_if_c, np.nan)
-        g1 = _lazywhere(c > 3.0, (c, e1, e2, e3, mu2_if_c),
-             lambda c, e1, e2, e3, mu2_if_c:
-             (e3 - 3 * e2 * e1 + 2 * e1**3) / np.sqrt((mu2_if_c)**3),
-             fillvalue=np.nan)
-        g2 = _lazywhere(c > 3.0, (c, e1, e2, e3, e4, mu2_if_c),
-             lambda c, e1, e2, e3, e4, mu2_if_c:
-             ((e4 - 4 * e3 * e1 + 6 * e2 * e1**2 - 3 * e1**4) /
-             mu2_if_c**2) - 3.,
-             fillvalue=np.nan)
-        return mu, mu2, g1, g2
 
     def _stats(self, c):
         return burr._stats(c, 1.0)

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -836,7 +836,7 @@ class burr_gen(rv_continuous):
             lambda c, e1, e2, e3, mu2_if_c: (e3 - 3*e2*e1 + 2*e1**3) / np.sqrt((mu2_if_c)**3),
             fillvalue=np.nan)
         g2 = _lazywhere(
-            c > 3.0,
+            c > 4.0,
             (c, e1, e2, e3, e4, mu2_if_c),
             lambda c, e1, e2, e3, e4, mu2_if_c: (
                 ((e4 - 4*e3*e1 + 6*e2*e1**2 - 3*e1**4) / mu2_if_c**2) - 3),

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -768,6 +768,7 @@ class burr_gen(rv_continuous):
     is also commonly referred to as the Dagum distribution [2]_. If the
     parameter :math:`c < 1` then the mean of the distribution does not
     exist and if :math:`c < 2` the variance does not exist [2]_.
+    The PDF is finite at the left endpoint :math:`x = 0` if :math:`c * d >= 1`.
 
     %(after_notes)s
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -803,7 +803,7 @@ class burr_gen(rv_continuous):
         cond = (xx == 0)
         if np.any(cond):
             xz = xx[cond]
-            output[cond] = np.log(c) + np.log(d) + sc.xlogy(c*d - 1, xz) - (d+1) * sc.log1p(x**(c))
+            output[cond] = np.log(c) + np.log(d) + sc.xlogy(c*d - 1, xz) - (d+1) * sc.log1p(xz**(c))
         if np.any(~cond):
             xnz = xx[~cond]
             output[~cond] = np.log(c) + np.log(d) + sc.xlogy(-c - 1, xnz) + sc.xlog1py(-d-1, xnz**(-c))

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -817,8 +817,32 @@ class burr_gen(rv_continuous):
     def _logcdf(self, x, c, d):
         return sc.log1p(x**(-c)) * (-d)
 
+    def _sf(self, x, c, d):
+        return np.exp(self._logsf(x, c, d))
+
+    def _logsf(self, x, c, d):
+        return np.log1p(- (1 + x**(-c))**(-d))
+
     def _ppf(self, q, c, d):
         return (q**(-1.0/d) - 1)**(-1.0/c)
+
+    def _stats(self, c, d):
+        nc = np.arange(1, 5).reshape(4,1) / c
+        #ek is the kth raw moment, e1 is the mean e2-e1**2 variance etc.
+        e1, e2, e3, e4 = sc.beta(d + nc, 1. - nc) * d
+        mu = np.where(c > 1.0, e1, np.nan)
+        mu2_if_c = e2 - mu**2
+        mu2 = np.where(c > 2.0, mu2_if_c, np.nan)
+        g1 = _lazywhere(c > 3.0, (c, e1, e2, e3, mu2_if_c),
+             lambda c, e1, e2, e3, mu2_if_c:
+             (e3 - 3*e2*e1 + 2*e1**3) / np.sqrt((mu2_if_c)**3),
+             fillvalue=np.nan)
+        g2 = _lazywhere(c > 3.0, (c, e1, e2, e3, e4, mu2_if_c),
+             lambda c, e1, e2, e3, e4, mu2_if_c:
+             ((e4 - 4*e3*e1 + 6*e2*e1**2 - 3*e1**4) /
+             mu2_if_c**2) - 3,
+             fillvalue=np.nan)
+        return mu, mu2, g1, g2
 
     def _munp(self, n, c, d):
         nc = 1. * n / c
@@ -936,23 +960,51 @@ class fisk_gen(burr_gen):
     """
     def _pdf(self, x, c):
         # fisk.pdf(x, c) = c * x**(-c-1) * (1 + x**(-c))**(-2)
-        return burr_gen._pdf(self, x, c, 1.0)
+        return burr._pdf(x, c, 1.0)
 
     def _cdf(self, x, c):
-        return burr_gen._cdf(self, x, c, 1.0)
+        return burr._cdf(x, c, 1.0)
+
+    def _sf(self, x, c):
+        return burr._sf(x, c, 1.0)
 
     def _logpdf(self, x, c):
         # fisk.pdf(x, c) = c * x**(-c-1) * (1 + x**(-c))**(-2)
-        return burr_gen._logpdf(self, x, c, 1.0)
+        return burr._logpdf(x, c, 1.0)
 
     def _logcdf(self, x, c):
-        return burr_gen._logcdf(self, x, c, 1.0)
+        return burr._logcdf(x, c, 1.0)
+
+    def _logsf(self, x, c):
+        return burr._logsf(x, c, 1.0)
 
     def _ppf(self, x, c):
-        return burr_gen._ppf(self, x, c, 1.0)
+        return burr._ppf(x, c, 1.0)
 
     def _munp(self, n, c):
-        return burr_gen._munp(self, n, c, 1.0)
+        return burr._munp(n, c, 1.0)
+
+    def _stats(self, c):
+        e1 = self._munp(1, c)
+        e2 = self._munp(2, c)
+        e3 = self._munp(3, c)
+        e4 = self._munp(4, c)
+        mu = np.where(c > 1.0, e1, np.nan)
+        mu2_if_c = e2 - mu**2
+        mu2 = np.where(c > 2.0, mu2_if_c, np.nan)
+        g1 = _lazywhere(c > 3.0, (c, e1, e2, e3, mu2_if_c),
+             lambda c, e1, e2, e3, mu2_if_c:
+             (e3 - 3 * e2 * e1 + 2 * e1**3) / np.sqrt((mu2_if_c)**3),
+             fillvalue=np.nan)
+        g2 = _lazywhere(c > 3.0, (c, e1, e2, e3, e4, mu2_if_c),
+             lambda c, e1, e2, e3, e4, mu2_if_c:
+             ((e4 - 4 * e3 * e1 + 6 * e2 * e1**2 - 3 * e1**4) /
+             mu2_if_c**2) - 3.,
+             fillvalue=np.nan)
+        return mu, mu2, g1, g2
+
+    def _stats(self, c):
+        return burr._stats(c, 1.0)
 
     def _entropy(self, c):
         return 2 - np.log(c)

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -446,6 +446,7 @@ def check_pdf_logpdf(distfn, args, msg):
         sup.filter(category=RuntimeWarning, message="divide by zero encountered in power")  # gengamma
         sup.filter(category=RuntimeWarning, message="invalid value encountered in add")  # genextreme
         sup.filter(category=RuntimeWarning, message="invalid value encountered in subtract")  # gengamma
+        sup.filter(category=RuntimeWarning, message="invalid value encountered in multiply")  # recipinvgauss
         pdf = distfn.pdf(vals, *args)
         logpdf = distfn.logpdf(vals, *args)
         pdf = pdf[(pdf != 0) & np.isfinite(pdf)]

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -454,7 +454,6 @@ def check_pdf_logpdf_at_endpoints(distfn, args, msg):
     points = np.array([0, 1])
     vals = distfn.ppf(points, *args)
     vals = vals[np.isfinite(vals)]
-    vals = vals[distfn._support_mask(vals)]
     with suppress_warnings() as sup:
         # Several distributions incur divide by zero or encounter invalid values when computing
         # the pdf or logpdf at the endpoints.

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -437,20 +437,28 @@ def check_pdf(distfn, arg, msg):
 
 def check_pdf_logpdf(distfn, args, msg):
     # compares pdf at several points with the log of the pdf
-    points = np.array([0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8])
+    points = np.array([0, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 1])
     vals = distfn.ppf(points, *args)
-    pdf = distfn.pdf(vals, *args)
-    logpdf = distfn.logpdf(vals, *args)
-    pdf = pdf[pdf != 0]
-    logpdf = logpdf[np.isfinite(logpdf)]
-    msg += " - logpdf-log(pdf) relationship"
-    npt.assert_almost_equal(np.log(pdf), logpdf, decimal=7, err_msg=msg)
+    vals = vals[np.isfinite(vals)]
+    with suppress_warnings() as sup:
+        sup.filter(category=RuntimeWarning, message="divide by zero encountered in true_divide")
+        sup.filter(category=RuntimeWarning, message="divide by zero encountered in log")
+        sup.filter(category=RuntimeWarning, message="divide by zero encountered in power")  # gengamma
+        sup.filter(category=RuntimeWarning, message="invalid value encountered in add")  # genextreme
+        sup.filter(category=RuntimeWarning, message="invalid value encountered in subtract")  # gengamma
+        pdf = distfn.pdf(vals, *args)
+        logpdf = distfn.logpdf(vals, *args)
+        pdf = pdf[(pdf != 0) & np.isfinite(pdf)]
+        logpdf = logpdf[np.isfinite(logpdf)]
+        msg += " - logpdf-log(pdf) relationship"
+        npt.assert_almost_equal(np.log(pdf), logpdf, decimal=7, err_msg=msg)
 
 
 def check_sf_logsf(distfn, args, msg):
     # compares sf at several points with the log of the sf
-    points = np.array([0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8])
+    points = np.array([0, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 1.0])
     vals = distfn.ppf(points, *args)
+    vals = vals[np.isfinite(vals)]
     sf = distfn.sf(vals, *args)
     logsf = distfn.logsf(vals, *args)
     sf = sf[sf != 0]
@@ -461,8 +469,9 @@ def check_sf_logsf(distfn, args, msg):
 
 def check_cdf_logcdf(distfn, args, msg):
     # compares cdf at several points with the log of the cdf
-    points = np.array([0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8])
+    points = np.array([0, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 1.0])
     vals = distfn.ppf(points, *args)
+    vals = vals[np.isfinite(vals)]
     cdf = distfn.cdf(vals, *args)
     logcdf = distfn.logcdf(vals, *args)
     cdf = cdf[cdf != 0]

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2845,6 +2845,37 @@ class TestBurr(object):
         assert_(np.isfinite(mean))
         assert_(np.isnan(variance))
 
+        c, d = 0.5, 3
+        e1, e2, e3, e4 = stats.burr._munp(np.array([1, 2, 3, 4]), c, d)
+        assert_(np.isnan(e1))
+        assert_(np.isnan(e2))
+        assert_(np.isnan(e3))
+        assert_(np.isnan(e4))
+        c, d = 1.5, 3
+        e1, e2, e3, e4 = stats.burr._munp([1, 2, 3, 4], c, d)
+        assert_(np.isfinite(e1))
+        assert_(np.isnan(e2))
+        assert_(np.isnan(e3))
+        assert_(np.isnan(e4))
+        c, d = 2.5, 3
+        e1, e2, e3, e4 = stats.burr._munp([1, 2, 3, 4], c, d)
+        assert_(np.isfinite(e1))
+        assert_(np.isfinite(e2))
+        assert_(np.isnan(e3))
+        assert_(np.isnan(e4))
+        c, d = 3.5, 3
+        e1, e2, e3, e4 = stats.burr._munp([1, 2, 3, 4], c, d)
+        assert_(np.isfinite(e1))
+        assert_(np.isfinite(e2))
+        assert_(np.isfinite(e3))
+        assert_(np.isnan(e4))
+        c, d = 4.5, 3
+        e1, e2, e3, e4 = stats.burr._munp([1, 2, 3, 4], c, d)
+        assert_(np.isfinite(e1))
+        assert_(np.isfinite(e2))
+        assert_(np.isfinite(e3))
+        assert_(np.isfinite(e4))
+
 
 def test_540_567():
     # test for nan returned in tickets 540, 567

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2824,6 +2824,8 @@ class TestBurr(object):
         # gh-9544.  Test from gh-9978
         c, d = 5.0, 3
         mean, variance = stats.burr(c, d).stats()
+        # mean = sc.beta(3 + 1/5, 1. - 1/5) * 3  = 1.4110263...
+        # var =  sc.beta(3 + 2 / 5, 1. - 2 / 5) * 3 - (sc.beta(3 + 1 / 5, 1. - 1 / 5) * 3) ** 2
         mean_hc, variance_hc = 1.4110263183925857, 0.22879948026191643
         assert_allclose(mean, mean_hc)
         assert_allclose(variance, variance_hc)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2820,6 +2820,10 @@ class TestBurr(object):
         correct = [_correct_ for _f, _args, _correct_ in data]
         assert_array_almost_equal(ans, correct)
 
+        ans = [_f.logpdf(_f.a, *_args) for _f, _args, _ in data]
+        correct = [np.log(_correct_) for _f, _args, _correct_ in data]
+        assert_array_almost_equal(ans, correct)
+
     def test_burr_stats_9544(self):
         # gh-9544.  Test from gh-9978
         c, d = 5.0, 3
@@ -2835,6 +2839,10 @@ class TestBurr(object):
         c, d = 0.5, 3
         mean, variance = stats.burr(c, d).stats()
         assert_(np.isnan(mean))
+        assert_(np.isnan(variance))
+        c, d = 1.5, 3
+        mean, variance = stats.burr(c, d).stats()
+        assert_(np.isfinite(mean))
         assert_(np.isnan(variance))
 
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -142,7 +142,7 @@ def test_vonmises_numerical():
 
 
 @pytest.mark.parametrize('dist',
-                         ['alpha', 'betaprime', 'burr', 'burr12',
+                         ['alpha', 'betaprime',
                           'fatiguelife', 'invgamma', 'invgauss', 'invweibull',
                           'johnsonsb', 'levy', 'levy_l', 'lognorm', 'gilbrat',
                           'powerlognorm', 'rayleigh', 'wald'])
@@ -1144,6 +1144,17 @@ class TestInvGamma(object):
 
 
 class TestF(object):
+    def test_endpoints(self):
+        # Compute the pdf at the left endpoint dst.a.
+        data = [[stats.f, (2, 1), 1.0]]
+        for _f, _args, _correct in data:
+            ans = _f.pdf(_f.a, *_args)
+            print(_f, (_args), ans, _correct, ans == _correct)
+
+        ans = [_f.pdf(_f.a, *_args) for _f, _args, _ in data]
+        correct = [_correct_ for _f, _args, _correct_ in data]
+        assert_array_almost_equal(ans, correct)
+
     def test_f_moments(self):
         # n-th moment of F distributions is only finite for n < dfd / 2
         m, v, s, k = stats.f.stats(11, 6.5, moments='mvsk')
@@ -2790,6 +2801,32 @@ class TestTriang(object):
             assert_equal(stats.triang.cdf(0., 1.), 0.)
             assert_equal(stats.triang.cdf(0.5, 1.), 0.25)
             assert_equal(stats.triang.cdf(1., 1.), 1)
+
+
+class TestBurr(object):
+    def test_endpoints_7491(self):
+        # gh-7491
+        # Compute the pdf at the left endpoint dst.a.
+        data = [
+            [stats.fisk, (1,), 1],
+            [stats.burr, (0.5, 2), 1],
+            [stats.burr, (1, 1), 1],
+            [stats.burr, (2, 0.5), 1],
+            [stats.burr12, (1, 0.5), 0.5],
+            [stats.burr12, (1, 1), 1.0],
+            [stats.burr12, (1, 2), 2.0]]
+
+        ans = [_f.pdf(_f.a, *_args) for _f, _args, _ in data]
+        correct = [_correct_ for _f, _args, _correct_ in data]
+        assert_array_almost_equal(ans, correct)
+
+    def test_burr_stats_9544(self):
+        # gh-9544
+        c, d = 5.0, 3
+        mean, variance = stats.burr(c, d).stats()
+        mean_hc, variance_hc = 1.4110263183925857, 0.22879948026191643
+        assert_allclose(mean_hc, mean_hc)
+        assert_allclose(variance, variance_hc)
 
 
 def test_540_567():

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2803,6 +2803,20 @@ class TestTriang(object):
             assert_equal(stats.triang.cdf(1., 1.), 1)
 
 
+class TestMielke(object):
+    def test_moments(self):
+        k, s = 4.642, 0.597
+        # n-th moment exists only if n < s
+        assert_equal(stats.mielke(k, s).moment(1), np.inf)
+        assert_equal(stats.mielke(k, 1.0).moment(1), np.inf)
+        assert_(np.isfinite(stats.mielke(k, 1.01).moment(1)))
+
+    def test_burr_equivalence(self):
+        x = np.linspace(0.01, 100, 50)
+        k, s = 2.45, 5.32
+        assert_allclose(stats.burr.pdf(x, s, k/s), stats.mielke.pdf(x, k, s))
+
+
 class TestBurr(object):
     def test_endpoints_7491(self):
         # gh-7491

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2821,11 +2821,11 @@ class TestBurr(object):
         assert_array_almost_equal(ans, correct)
 
     def test_burr_stats_9544(self):
-        # gh-9544
+        # gh-9544.  Test from gh-9978
         c, d = 5.0, 3
         mean, variance = stats.burr(c, d).stats()
         mean_hc, variance_hc = 1.4110263183925857, 0.22879948026191643
-        assert_allclose(mean_hc, mean_hc)
+        assert_allclose(mean, mean_hc)
         assert_allclose(variance, variance_hc)
 
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2828,6 +2828,13 @@ class TestBurr(object):
         assert_allclose(mean, mean_hc)
         assert_allclose(variance, variance_hc)
 
+    def test_burr_nan_mean_var_9544(self):
+        # gh-9544.  Test from gh-9978
+        c, d = 0.5, 3
+        mean, variance = stats.burr(c, d).stats()
+        assert_(np.isnan(mean))
+        assert_(np.isnan(variance))
+
 
 def test_540_567():
     # test for nan returned in tickets 540, 567


### PR DESCRIPTION
Enable computation of pdf, logpdf at left-hand end points of `fisk`, `burr`, `burr12` and `f` distributions.  Fixes gh-7491 and half of gh-9544.
Added regression test `TestBurr` class to `stats/tests/test_distributions.py`.  `TestBurr::test_burr_stats_9544` is the same test as `test_burr_stats` in gh-9978.

