### PR TITLE
DOC: Add numpy import statement to scipy.signal.cwt documentation

### DIFF
--- a/scipy/signal/wavelets.py
+++ b/scipy/signal/wavelets.py
@@ -346,6 +346,8 @@ def cwt(data, wavelet, widths):
 
     Examples
     --------
+
+    >>> import numpy as np
     >>> from scipy import signal
     >>> import matplotlib.pyplot as plt
     >>> t = np.linspace(-1, 1, 200, endpoint=False)


### PR DESCRIPTION
Currently, the example does not run if it is copied and pasted into an interpreter, because numpy is not imported. This pull request fixes this.