### PR TITLE
CI: pin Sphinx version to 1.8.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
             . venv/bin/activate
             pip install --install-option="--no-cython-compile" cython
             pip install numpy
-            pip install nose mpmath argparse Pillow codecov matplotlib Sphinx
+            pip install nose mpmath argparse Pillow codecov matplotlib Sphinx==1.8.5
 
       - run:
           name: build docs

--- a/pavement.py
+++ b/pavement.py
@@ -129,7 +129,7 @@ PYVER="3.6"
 
 # Paver options object, holds all default dirs
 options(bootstrap=Bunch(bootstrap_dir="bootstrap"),
-        virtualenv=Bunch(packages_to_install=["sphinx==1.1.3", "numpydoc"],
+        virtualenv=Bunch(packages_to_install=["sphinx==1.8.5", "numpydoc"],
                          no_site_packages=False),
         sphinx=Bunch(builddir="build", sourcedir="source", docroot='doc'),
         superpack=Bunch(builddir="build-superpack",


### PR DESCRIPTION
Sphinx 2.0.0 (just released) breaks the doc build. So fix CI first, investigate later.