### PR TITLE
BUG: Use const where possible in shortest_path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ setup.cfg
 .deps
 .libs
 .eggs
+pip-wheel-metadata
 
 # Paver generated files #
 #########################

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -455,7 +455,7 @@ def dijkstra(csgraph, directed=True, indices=None,
         predecessors[i, j] gives the index of the previous node in the
         path from point i to point j.  If no path exists between point
         i and j, then predecessors[i, j] = -9999
-        
+
     sources : ndarray, shape (n_nodes,)
         Returned only if min_only=True and return_predecessors=True.
         Contains the index of the source which had the shortest path
@@ -612,7 +612,7 @@ def dijkstra(csgraph, directed=True, indices=None,
 @cython.boundscheck(False)
 cdef _dijkstra_setup_heap_multi(FibonacciHeap *heap,
                                 FibonacciNode* nodes,
-                                int[:] source_indices,
+                                const int[:] source_indices,
                                 int[:] sources,
                                 double[:] dist_matrix,
                                 int return_pred):
@@ -640,9 +640,9 @@ cdef _dijkstra_setup_heap_multi(FibonacciHeap *heap,
 cdef _dijkstra_scan_heap_multi(FibonacciHeap *heap,
                                FibonacciNode *v,
                                FibonacciNode* nodes,
-                               double[:] csr_weights,
-                               int[:] csr_indices,
-                               int[:] csr_indptr,
+                               const double[:] csr_weights,
+                               const int[:] csr_indices,
+                               const int[:] csr_indptr,
                                int[:] pred,
                                int[:] sources,
                                int return_pred,
@@ -679,9 +679,9 @@ cdef _dijkstra_scan_heap_multi(FibonacciHeap *heap,
 cdef _dijkstra_scan_heap(FibonacciHeap *heap,
                          FibonacciNode *v,
                          FibonacciNode* nodes,
-                         double[:] csr_weights,
-                         int[:] csr_indices,
-                         int[:] csr_indptr,
+                         const double[:] csr_weights,
+                         const int[:] csr_indices,
+                         const int[:] csr_indptr,
                          int[:, :] pred,
                          int return_pred,
                          DTYPE_t limit,
@@ -712,10 +712,10 @@ cdef _dijkstra_scan_heap(FibonacciHeap *heap,
 
 @cython.boundscheck(False)
 cdef _dijkstra_directed(
-            int[:] source_indices,
-            double[:] csr_weights,
-            int[:] csr_indices,
-            int[:] csr_indptr,
+            const int[:] source_indices,
+            const double[:] csr_weights,
+            const int[:] csr_indices,
+            const int[:] csr_indptr,
             double[:, :] dist_matrix,
             int[:, :] pred,
             DTYPE_t limit):
@@ -756,10 +756,10 @@ cdef _dijkstra_directed(
 
 @cython.boundscheck(False)
 cdef _dijkstra_directed_multi(
-            int[:] source_indices,
-            double[:] csr_weights,
-            int[:] csr_indices,
-            int[:] csr_indptr,
+            const int[:] source_indices,
+            const double[:] csr_weights,
+            const int[:] csr_indices,
+            const int[:] csr_indptr,
             double[:] dist_matrix,
             int[:] pred,
             int[:] sources,
@@ -1043,10 +1043,10 @@ def bellman_ford(csgraph, directed=True, indices=None,
 
 
 cdef int _bellman_ford_directed(
-            int[:] source_indices,
-            double[:] csr_weights,
-            int[:] csr_indices,
-            int[:] csr_indptr,
+            const int[:] source_indices,
+            const double[:] csr_weights,
+            const int[:] csr_indices,
+            const int[:] csr_indptr,
             double[:, :] dist_matrix,
             int[:, :] pred):
     cdef:
@@ -1084,10 +1084,10 @@ cdef int _bellman_ford_directed(
 
 
 cdef int _bellman_ford_undirected(
-            int[:] source_indices,
-            double[:] csr_weights,
-            int[:] csr_indices,
-            int[:] csr_indptr,
+            const int[:] source_indices,
+            const double[:] csr_weights,
+            const int[:] csr_indices,
+            const int[:] csr_indptr,
             double[:, :] dist_matrix,
             int[:, :] pred):
     cdef:
@@ -1322,9 +1322,9 @@ cdef void _johnson_add_weights(
 
 
 cdef int _johnson_directed(
-            double[:] csr_weights,
-            int[:] csr_indices,
-            int[:] csr_indptr,
+            const double[:] csr_weights,
+            const int[:] csr_indices,
+            const int[:] csr_indptr,
             double[:] dist_array):
     cdef:
         unsigned int N = dist_array.shape[0]
@@ -1358,9 +1358,9 @@ cdef int _johnson_directed(
 
 
 cdef int _johnson_undirected(
-            double[:] csr_weights,
-            int[:] csr_indices,
-            int[:] csr_indptr,
+            const double[:] csr_weights,
+            const int[:] csr_indices,
+            const int[:] csr_indptr,
             double[:] dist_array):
     cdef:
         unsigned int N = dist_array.shape[0]

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -252,3 +252,15 @@ def test_overwrite():
     foo = G.copy()
     shortest_path(foo, overwrite=False)
     assert_array_equal(foo, G)
+
+
+@pytest.mark.parametrize('method', methods)
+def test_buffer(method):
+    # Smoke test that sparse matrices with read-only buffers (e.g., those from
+    # joblib workers) do not cause::
+    #
+    #     ValueError: buffer source array is read-only
+    #
+    G = scipy.sparse.csr_matrix([[1.]])
+    G.data.flags['WRITEABLE'] = False
+    shortest_path(G, method=method)


### PR DESCRIPTION
When running a parallel job with `joblib` (presumably due to #9664 adding typed memoryviews) I was getting:
```
  File "/home/larsoner/.local/lib/python3.7/site-packages/joblib/parallel.py", line 225, in __call__
    for func, args, kwargs in self.items]
  File "/home/larsoner/.local/lib/python3.7/site-packages/joblib/parallel.py", line 225, in <listcomp>
    for func, args, kwargs in self.items]
  File "/home/larsoner/python/mne-python/mne/source_space.py", line 2457, in _do_src_distances
    out = func(con, indices=idx)
  File "_shortest_path.pyx", line 579, in scipy.sparse.csgraph._shortest_path.dijkstra
  File "stringsource", line 654, in View.MemoryView.memoryview_cwrapper
  File "stringsource", line 349, in View.MemoryView.memoryview.__cinit__
ValueError: buffer source array is read-only
```
This PR adds a test that shows the error, and fixes it by using `const` types. @fcollman @tylerjereddy you were also on #9664, can you take a look?

Also has adds a line to `.gitignore` for a directory that appeared while doing some `pip` build/install stuff.