### PR TITLE
BUG: Make minimize_quadratic_1d work with infinite bounds correctly

### DIFF
--- a/scipy/optimize/_lsq/common.py
+++ b/scipy/optimize/_lsq/common.py
@@ -319,7 +319,7 @@ def minimize_quadratic_1d(a, b, lb, ub, c=0):
         if lb < extremum < ub:
             t.append(extremum)
     t = np.asarray(t)
-    y = a * t**2 + b * t + c
+    y = t * (a * t + b) + c
     min_index = np.argmin(y)
     return t[min_index], y[min_index]
 

--- a/scipy/optimize/tests/test_lsq_common.py
+++ b/scipy/optimize/tests/test_lsq_common.py
@@ -156,20 +156,45 @@ class TestQuadraticFunction(object):
 
         t, y = minimize_quadratic_1d(a, b, 1, 2)
         assert_equal(t, 1)
-        assert_equal(y, a * t**2 + b * t)
+        assert_allclose(y, a * t**2 + b * t, rtol=1e-15)
 
         t, y = minimize_quadratic_1d(a, b, -2, -1)
         assert_equal(t, -1)
-        assert_equal(y, a * t**2 + b * t)
+        assert_allclose(y, a * t**2 + b * t, rtol=1e-15)
 
         t, y = minimize_quadratic_1d(a, b, -1, 1)
         assert_equal(t, 0.1)
-        assert_equal(y, a * t**2 + b * t)
+        assert_allclose(y, a * t**2 + b * t, rtol=1e-15)
 
         c = 10
         t, y = minimize_quadratic_1d(a, b, -1, 1, c=c)
         assert_equal(t, 0.1)
-        assert_equal(y, a * t**2 + b * t + c)
+        assert_allclose(y, a * t**2 + b * t + c, rtol=1e-15)
+
+        t, y = minimize_quadratic_1d(a, b, -np.inf, np.inf, c=c)
+        assert_equal(t, 0.1)
+        assert_allclose(y, a * t ** 2 + b * t + c, rtol=1e-15)
+
+        t, y = minimize_quadratic_1d(a, b, 0, np.inf, c=c)
+        assert_equal(t, 0.1)
+        assert_allclose(y, a * t ** 2 + b * t + c, rtol=1e-15)
+
+        t, y = minimize_quadratic_1d(a, b, -np.inf, 0, c=c)
+        assert_equal(t, 0)
+        assert_allclose(y, a * t ** 2 + b * t + c, rtol=1e-15)
+
+        a = -1
+        b = 0.2
+        t, y = minimize_quadratic_1d(a, b, -np.inf, np.inf)
+        assert_equal(y, -np.inf)
+
+        t, y = minimize_quadratic_1d(a, b, 0, np.inf)
+        assert_equal(t, np.inf)
+        assert_equal(y, -np.inf)
+
+        t, y = minimize_quadratic_1d(a, b, -np.inf, 0)
+        assert_equal(t, -np.inf)
+        assert_equal(y, -np.inf)
 
     def test_evaluate_quadratic(self):
         s = np.array([1.0, -1.0])


### PR DESCRIPTION
Closes #9982. 

Let me explain how the reported bug occurred. When the algorithm tries to make a step along the gradient it comes down to optimizing a quadratic function with a positive coefficient before the quadratic term. When one of the bounds is infinite making an infinite step results in +infinity (because of the positive coefficient), so this should always be discarded in favor of a finite solution. However, the evaluation was implemented in such a way that we get `nan` instead of `+inf`. And `nan` was selected because of how `np.argmin` works. I reimplemented the evaluation such that it must never return `nan`.  

It's very hard to come up with a short test for `lsq_linear` which reproduces the reported bug. But I'm going to write a test for `evaluate_quadratic_1d`.