### PR TITLE
BUG: Do not remove 1s when calling sparse: reshape method #9994

### DIFF
--- a/scipy/sparse/sputils.py
+++ b/scipy/sparse/sputils.py
@@ -307,8 +307,8 @@ def check_shape(args, current_shape=None):
         else:
             raise ValueError('can only specify one unknown dimension')
 
-    if len(new_shape) > 2:
-        raise ValueError('shape too large to be a matrix')
+    if len(new_shape) != 2:
+        raise ValueError('matrix shape must be two-dimensional')
 
     return new_shape
 

--- a/scipy/sparse/sputils.py
+++ b/scipy/sparse/sputils.py
@@ -307,15 +307,6 @@ def check_shape(args, current_shape=None):
         else:
             raise ValueError('can only specify one unknown dimension')
 
-        # Add and remove ones like numpy.matrix.reshape
-        if len(new_shape) != 2:
-            new_shape = tuple(arg for arg in new_shape if arg != 1)
-
-            if len(new_shape) == 0:
-                new_shape = (1, 1)
-            elif len(new_shape) == 1:
-                new_shape = (1, new_shape[0])
-
     if len(new_shape) > 2:
         raise ValueError('shape too large to be a matrix')
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -749,6 +749,10 @@ class _TestCommon(object):
         x.shape = (2, 6)
         assert_array_equal(x.A, desired)
 
+        # Reshape to bad ndim
+        assert_raises(ValueError, x.reshape, (x.size,))
+        assert_raises(ValueError, x.reshape, (1, x.size, 1))
+
     @pytest.mark.slow
     def test_setdiag_comprehensive(self):
         def dense_setdiag(a, v, k):


### PR DESCRIPTION
#9994 
check_shape shouldn't remove 1s.
Besides what is mentioned in the issue, this causes weird behaviors like:
`
In [24]: from scipy.sparse import csr_matrix                                                                                   

In [25]: a = csr_matrix(np.eye(4))                                                                                             

In [26]: a.reshape(16,1,1)                                                                                              
Out[26]: 
<1x16 sparse matrix of type '<class 'numpy.float64'>'
	with 4 stored elements in COOrdinate format>
`