### PR TITLE
ENH: adds constraints for differential evolution

### DIFF
--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -168,9 +168,7 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
 
     constraints : {NonLinearConstraint, LinearConstraint, Bounds}
         Constraints on the solver, over and above those applied by the `bounds`
-        kwd. Uses the approach by Lampinen [5]_. There is no particular
-        advantage employing `LinearConstraint` over `NonLinearConstraint` as no
-        Jacobian/Hessian of the constraint functions is used.
+        kwd. Uses the approach by Lampinen [5]_.
 
         .. versionadded:: 1.4.0
 
@@ -446,9 +444,7 @@ class DifferentialEvolutionSolver(object):
         Requires that `func` be pickleable.
     constraints : {NonLinearConstraint, LinearConstraint, Bounds}
         Constraints on the solver, over and above those applied by the `bounds`
-        kwd. Uses the approach by Lampinen. There is no particular
-        advantage employing `LinearConstraint` over `NonLinearConstraint` as no
-        Jacobian/Hessian of the constraint functions is used.
+        kwd. Uses the approach by Lampinen.
     """
 
     # Dispatch of mutation strategy method (binomial or exponential).

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -10,7 +10,9 @@ from scipy.optimize import OptimizeResult, minimize
 from scipy.optimize.optimize import _status_message
 from scipy._lib._util import check_random_state, MapWrapper
 from scipy._lib.six import xrange, string_types
-from scipy.optimize._constraints import (Bounds, new_bounds_to_old)
+
+from scipy.optimize._constraints import (Bounds, new_bounds_to_old,
+                                         NonlinearConstraint, LinearConstraint)
 
 
 __all__ = ['differential_evolution']
@@ -23,7 +25,7 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
                            mutation=(0.5, 1), recombination=0.7, seed=None,
                            callback=None, disp=False, polish=True,
                            init='latinhypercube', atol=0, updating='immediate',
-                           workers=1):
+                           workers=1, constraints=()):
     """Finds the global minimum of a multivariate function.
 
     Differential Evolution is stochastic in nature (does not use gradient
@@ -114,7 +116,8 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
     polish : bool, optional
         If True (default), then `scipy.optimize.minimize` with the `L-BFGS-B`
         method is used to polish the best population member at the end, which
-        can improve the minimization slightly.
+        can improve the minimization slightly. If a constrained problem is
+        being studied then the `trust-constr` method is used instead.
     init : str or array-like, optional
         Specify which type of population initialization is performed. Should be
         one of:
@@ -163,6 +166,14 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
 
         .. versionadded:: 1.2.0
 
+    constraints : {NonLinearConstraint, LinearConstraint, Bounds}
+        Constraints on the solver, over and above those applied by the `bounds`
+        kwd. Uses the approach by Lampinen [5]_. There is no particular
+        advantage employing `LinearConstraint` over `NonLinearConstraint` as no
+        Jacobian/Hessian of the constraint functions is used.
+
+        .. versionadded:: 1.4.0
+
     Returns
     -------
     res : OptimizeResult
@@ -173,6 +184,8 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
         `OptimizeResult` for a description of other attributes.  If `polish`
         was employed, and a lower minimum was obtained by the polishing, then
         OptimizeResult also contains the ``jac`` attribute.
+        If the eventual solution does not satisfy the applied constraints
+        ``success`` will be `False`.
 
     Notes
     -----
@@ -233,6 +246,20 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
     >>> result.x, result.fun
     (array([1., 1., 1., 1., 1.]), 1.9216496320061384e-19)
 
+    Let's try and do a constrained minimization
+    >>> from scipy.optimize import NonlinearConstraint, Bounds
+    >>> def constr_f(x):
+    ...     return np.array(x[0] + x[1])
+    >>>
+    >>> # the sum of x[0] and x[1] must be less than 1.9
+    >>> nlc = NonlinearConstraint(constr_f, -np.inf, 1.9)
+    >>> # specify limits using a `Bounds` object.
+    >>> bounds = Bounds([0., 0.], [2., 2.])
+    >>> result = differential_evolution(rosen, bounds, constraints=(nlc),
+    ...                                 seed=1)
+    >>> result.x, result.fun
+    (array([0.96633867, 0.93363577]), 0.0011361355854792312)
+
     Next find the minimum of the Ackley function
     (https://en.wikipedia.org/wiki/Test_functions_for_optimization).
 
@@ -258,6 +285,10 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
            Characterization of structures from X-ray scattering data using
            genetic algorithms, Phil. Trans. R. Soc. Lond. A, 1999, 357,
            2827-2848
+    .. [5] Lampinen, J., A constraint handling approach for the differential
+           evolution algorithm. Proceedings of the 2002 Congress on
+           Evolutionary Computation. CEC'02 (Cat. No. 02TH8600). Vol. 2. IEEE,
+           2002.
     """
 
     # using a context manager means that any created Pool objects are
@@ -272,7 +303,8 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
                                      callback=callback,
                                      disp=disp, init=init, atol=atol,
                                      updating=updating,
-                                     workers=workers) as solver:
+                                     workers=workers,
+                                     constraints=constraints) as solver:
         ret = solver.solve()
 
     return ret
@@ -363,9 +395,10 @@ class DifferentialEvolutionSolver(object):
         the function halts. If callback returns `True`, then the minimization
         is halted (any polishing is still carried out).
     polish : bool, optional
-        If True, then `scipy.optimize.minimize` with the `L-BFGS-B` method
-        is used to polish the best population member at the end. This requires
-        a few more function evaluations.
+        If True (default), then `scipy.optimize.minimize` with the `L-BFGS-B`
+        method is used to polish the best population member at the end, which
+        can improve the minimization slightly. If a constrained problem is
+        being studied then the `trust-constr` method is used instead.
     maxfun : int, optional
         Set the maximum number of function evaluations. However, it probably
         makes more sense to set `maxiter` instead.
@@ -411,7 +444,11 @@ class DifferentialEvolutionSolver(object):
         This option will override the `updating` keyword to
         `updating='deferred'` if `workers != 1`.
         Requires that `func` be pickleable.
-
+    constraints : {NonLinearConstraint, LinearConstraint, Bounds}
+        Constraints on the solver, over and above those applied by the `bounds`
+        kwd. Uses the approach by Lampinen. There is no particular
+        advantage employing `LinearConstraint` over `NonLinearConstraint` as no
+        Jacobian/Hessian of the constraint functions is used.
     """
 
     # Dispatch of mutation strategy method (binomial or exponential).
@@ -437,7 +474,7 @@ class DifferentialEvolutionSolver(object):
                  tol=0.01, mutation=(0.5, 1), recombination=0.7, seed=None,
                  maxfun=np.inf, callback=None, disp=False, polish=True,
                  init='latinhypercube', atol=0, updating='immediate',
-                 workers=1):
+                 workers=1, constraints=()):
 
         if strategy in self._binomial:
             self.mutation_func = getattr(self, self._binomial[strategy])
@@ -543,6 +580,25 @@ class DifferentialEvolutionSolver(object):
                 raise ValueError(self.__init_error_msg)
         else:
             self.init_population_array(init)
+
+        # infrastructure for constraints
+        # dummy parameter vector for preparing constraints, this is required so
+        # that the number of constraints is known.
+        x0 = self._scale_parameters(self.population[0])
+
+        self.constraints = constraints
+        self._wrapped_constraints = []
+
+        if hasattr(constraints, '__len__'):
+            # sequence of constraints, this will also deal with default
+            # keyword parameter
+            for c in constraints:
+                self._wrapped_constraints.append(_ConstraintWrapper(c, x0))
+        else:
+            self._wrapped_constraints = [_ConstraintWrapper(constraints, x0)]
+
+        self.constraint_violation = np.zeros((self.num_population_members, 1))
+        self.feasible = np.ones(self.num_population_members, bool)
 
         self.disp = disp
 
@@ -684,8 +740,14 @@ class DifferentialEvolutionSolver(object):
         # that someone can set maxiter=0, at which point we still want the
         # initial energies to be calculated (the following loop isn't run).
         if np.all(np.isinf(self.population_energies)):
-            self.population_energies[:] = self._calculate_population_energies(
-                self.population)
+            self.feasible, self.constraint_violation = (
+                self._calculate_population_feasibilities(self.population))
+
+            # only work out population energies for feasible solutions
+            self.population_energies[self.feasible] = (
+                self._calculate_population_energies(
+                    self.population[self.feasible]))
+
             self._promote_lowest_energy()
 
         # do the optimisation.
@@ -741,15 +803,34 @@ class DifferentialEvolutionSolver(object):
             success=(warning_flag is not True))
 
         if self.polish:
+            polish_method = 'L-BFGS-B'
+
+            if self._wrapped_constraints:
+                polish_method = 'trust-constr'
+
+                constr_violation = self._constraint_violation_fn(DE_result.x)
+                if np.any(constr_violation > 0.):
+                    warnings.warn("differential evolution didn't find a"
+                                  " solution satisfying the constraints,"
+                                  " attempting to polish from the least"
+                                  " infeasible solution", UserWarning)
+
             result = minimize(self.func,
                               np.copy(DE_result.x),
-                              method='L-BFGS-B',
-                              bounds=self.limits.T)
+                              method=polish_method,
+                              bounds=self.limits.T,
+                              constraints=self.constraints)
 
             self._nfev += result.nfev
             DE_result.nfev = self._nfev
 
-            if result.fun < DE_result.fun:
+            # polishing solution is only accepted if there is an improvement in
+            # cost function, the polishing was successful and the solution lies
+            # within the bounds.
+            if (result.fun < DE_result.fun and
+                    result.success and
+                    np.all(result.x <= self.limits[1]) and
+                    np.all(self.limits[0] <= result.x)):
                 DE_result.fun = result.fun
                 DE_result.x = result.x
                 DE_result.jac = result.jac
@@ -757,11 +838,23 @@ class DifferentialEvolutionSolver(object):
                 self.population_energies[0] = result.fun
                 self.population[0] = self._unscale_parameters(result.x)
 
+        if self._wrapped_constraints:
+            DE_result.constr = [c.violation(DE_result.x) for
+                                c in self._wrapped_constraints]
+            DE_result.constr_violation = np.max(
+                np.concatenate(DE_result.constr))
+            DE_result.maxcv = DE_result.constr_violation
+            if DE_result.maxcv > 0:
+                # if the result is infeasible then success must be False
+                DE_result.success = False
+                DE_result.message = ("The solution does not satisfy the"
+                                    " constraints, MAXCV = " % DE_result.maxcv)
+
         return DE_result
 
     def _calculate_population_energies(self, population):
         """
-        Calculate the energies of all the population members at the same time.
+        Calculate the energies of a population.
 
         Parameters
         ----------
@@ -800,12 +893,74 @@ class DifferentialEvolutionSolver(object):
         return energies
 
     def _promote_lowest_energy(self):
-        # promotes the lowest energy to the first entry in the population
-        l = np.argmin(self.population_energies)
+        # swaps 'best solution' into first population entry
 
-        # put the lowest energy into the best solution position.
+        idx = np.arange(self.num_population_members)
+        feasible_solutions = idx[self.feasible]
+        if feasible_solutions.size:
+            # find the best feasible solution
+            idx_t = np.argmin(self.population_energies[feasible_solutions])
+            l = feasible_solutions[idx_t]
+        else:
+            # no solution was feasible, use 'best' infeasible solution, which
+            # will violate constraints the least
+            l = np.argmin(np.sum(self.constraint_violation, axis=1))
+
         self.population_energies[[0, l]] = self.population_energies[[l, 0]]
         self.population[[0, l], :] = self.population[[l, 0], :]
+        self.feasible[[0, l]] = self.feasible[[l, 0]]
+        self.constraint_violation[[0, l], :] = (
+        self.constraint_violation[[l, 0], :])
+
+    def _constraint_violation_fn(self, x):
+        """
+        Calculates total constraint violation for all the constraints, for a given
+        solution.
+
+        Parameters
+        ----------
+        x : ndarray
+            Solution vector
+
+        Returns
+        -------
+        cv : ndarray
+            Total violation of constraints. Has shape ``(M,)``, where M is the
+            number of constraints (if each constraint function only returns one
+            value)
+        """
+        return np.concatenate([c.violation(x) for c in self._wrapped_constraints])
+
+    def _calculate_population_feasibilities(self, population):
+        """
+        Calculate the feasibilities of a population.
+
+        Parameters
+        ----------
+        population : ndarray
+            An array of parameter vectors normalised to [0, 1] using lower
+            and upper limits. Has shape ``(np.size(population, 0), len(x))``.
+
+        Returns
+        -------
+        feasible, constraint_violation : ndarray, ndarray
+            Boolean array of feasibility for each population member, and an
+            array of the constraint violation for each population member.
+            constraint_violation has shape ``(np.size(population, 0), M)``,
+            where M is the number of constraints.
+        """
+        num_members = np.size(population, 0)
+        if not self._wrapped_constraints:
+            # shortcut for no constraints
+            return np.ones(num_members, bool), np.zeros((num_members, 1))
+
+        parameters_pop = self._scale_parameters(population)
+
+        constraint_violation = np.array([self._constraint_violation_fn(x)
+                                         for x in parameters_pop])
+        feasible = ~(np.sum(constraint_violation, axis=1) > 0)
+
+        return feasible, constraint_violation
 
     def __iter__(self):
         return self
@@ -823,6 +978,51 @@ class DifferentialEvolutionSolver(object):
         self._mapwrapper.close()
         self._mapwrapper.terminate()
 
+    def _accept_trial(self, energy_trial, feasible_trial, cv_trial,
+                      energy_orig, feasible_orig, cv_orig):
+        """
+        Trial is accepted if:
+        * it satisfies all constraints and provides a lower or equal objective
+          function value, while both the compared solutions are feasible
+        - or -
+        * it is feasible while the original solution is infeasible,
+        - or -
+        * it is infeasible, but provides a lower or equal constraint violation
+          for all constraint functions.
+
+        This test corresponds to section III of Lampinen [1]_.
+
+        Parameters
+        ----------
+        energy_trial : float
+            Energy of the trial solution
+        feasible_trial : float
+            Feasibility of trial solution
+        cv_trial : array-like
+            Excess constraint violation for the trial solution
+        energy_orig : float
+            Energy of the original solution
+        feasible_orig : float
+            Feasibility of original solution
+        cv_orig : array-like
+            Excess constraint violation for the original solution
+
+        Returns
+        -------
+        accepted : bool
+
+        """
+        if feasible_orig and feasible_trial:
+            return energy_trial <= energy_orig
+        elif feasible_trial and not feasible_orig:
+            return True
+        elif not feasible_trial and (cv_trial <= cv_orig).all():
+            # cv_trial < cv_orig would imply that both trial and orig are not
+            # feasible
+            return True
+
+        return False
+
     def __next__(self):
         """
         Evolve the population by a single generation
@@ -837,8 +1037,15 @@ class DifferentialEvolutionSolver(object):
         # the population may have just been initialized (all entries are
         # np.inf). If it has you have to calculate the initial energies
         if np.all(np.isinf(self.population_energies)):
-            self.population_energies[:] = self._calculate_population_energies(
-                self.population)
+            self.feasible, self.constraint_violation = (
+                self._calculate_population_feasibilities(self.population))
+
+            # only need to work out population energies for those that are
+            # feasible
+            self.population_energies[self.feasible] = (
+                self._calculate_population_energies(
+                    self.population[self.feasible]))
+
             self._promote_lowest_energy()
 
         if self.dither is not None:
@@ -861,18 +1068,37 @@ class DifferentialEvolutionSolver(object):
                 parameters = self._scale_parameters(trial)
 
                 # determine the energy of the objective function
-                energy = self.func(parameters)
-                self._nfev += 1
+                if self._wrapped_constraints:
+                    cv = self._constraint_violation_fn(parameters)
+                    feasible = False
+                    energy = np.inf
+                    if not np.sum(cv) > 0:
+                        # solution is feasible
+                        feasible = True
+                        energy = self.func(parameters)
+                        self._nfev += 1
+                else:
+                    feasible = True
+                    cv = np.atleast_2d([0.])
+                    energy = self.func(parameters)
+                    self._nfev += 1
 
-                # if the energy of the trial candidate is lower than the
-                # original population member then replace it
-                if energy < self.population_energies[candidate]:
+                # compare trial and population member
+                if self._accept_trial(energy, feasible, cv,
+                                      self.population_energies[candidate],
+                                      self.feasible[candidate],
+                                      self.constraint_violation[candidate]):
                     self.population[candidate] = trial
                     self.population_energies[candidate] = energy
+                    self.feasible[candidate] = feasible
+                    self.constraint_violation[candidate] = cv
 
-                    # if the trial candidate also has a lower energy than the
-                    # best solution then promote it to the best solution.
-                    if energy < self.population_energies[0]:
+                    # if the trial candidate is also better than the best
+                    # solution then promote it.
+                    if self._accept_trial(energy, feasible, cv,
+                                          self.population_energies[0],
+                                          self.feasible[0],
+                                          self.constraint_violation[0]):
                         self._promote_lowest_energy()
 
         elif self._updating == 'deferred':
@@ -888,17 +1114,32 @@ class DifferentialEvolutionSolver(object):
             # enforce bounds
             self._ensure_constraint(trial_pop)
 
-            # determine the energies of the objective function
-            trial_energies = self._calculate_population_energies(trial_pop)
+            # determine the energies of the objective function, but only for
+            # feasible trials
+            feasible, cv = self._calculate_population_feasibilities(trial_pop)
+            trial_energies = np.full(self.num_population_members, np.inf)
 
-            # which solutions are improved?
-            loc = trial_energies < self.population_energies
+            # only calculate for feasible entries
+            trial_energies[feasible] = self._calculate_population_energies(
+                trial_pop[feasible])
+
+            # which solutions are 'improved'?
+            loc = [self._accept_trial(*val) for val in
+                   zip(trial_energies, feasible, cv, self.population_energies,
+                       self.feasible, self.constraint_violation)]
+            loc = np.array(loc)
             self.population = np.where(loc[:, np.newaxis],
                                        trial_pop,
                                        self.population)
             self.population_energies = np.where(loc,
                                                 trial_energies,
                                                 self.population_energies)
+            self.feasible = np.where(loc,
+                                     feasible,
+                                     self.feasible)
+            self.constraint_violation = np.where(loc[:, np.newaxis],
+                                                 cv,
+                                                 self.constraint_violation)
 
             # make sure the best solution is updated if updating='deferred'.
             # put the lowest energy into the best solution position.
@@ -1026,3 +1267,84 @@ class _FunctionWrapper(object):
 
     def __call__(self, x):
         return self.f(x, *self.args)
+
+
+class _ConstraintWrapper(object):
+    """Object to wrap/evaluate user defined constraints.
+
+    Very similar in practice to `PreparedConstraint`, except that no evaluation
+    of jac/hess is performed (explicit or implicit).
+
+    If created successfully, it will contain the attributes listed below.
+
+    Parameters
+    ----------
+    constraint : {`NonlinearConstraint`, `LinearConstraint`, `Bounds`}
+        Constraint to check and prepare.
+    x0 : array_like
+        Initial vector of independent variables.
+
+    Attributes
+    ----------
+    fun : callable
+        Function defining the constraint wrapped by one of the convenience
+        classes.
+    bounds : 2-tuple
+        Contains lower and upper bounds for the constraints --- lb and ub.
+        These are converted to ndarray and have a size equal to the number of
+        the constraints.
+    """
+    def __init__(self, constraint, x0):
+        self.constraint = constraint
+
+        if isinstance(constraint, NonlinearConstraint):
+            def fun(x):
+                return np.atleast_1d(constraint.fun(x))
+        elif isinstance(constraint, LinearConstraint):
+            def fun(x):
+                A = np.atleast_2d(constraint.A)
+                return A.dot(x)
+        elif isinstance(constraint, Bounds):
+            def fun(x):
+                return x
+        else:
+            raise ValueError("`constraint` of an unknown type is passed.")
+
+        self.fun = fun
+
+        lb = np.asarray(constraint.lb, dtype=float)
+        ub = np.asarray(constraint.ub, dtype=float)
+
+        f0 = fun(x0)
+        m = f0.size
+
+        if lb.ndim == 0:
+            lb = np.resize(lb, m)
+        if ub.ndim == 0:
+            ub = np.resize(ub, m)
+
+        self.bounds = (lb, ub)
+
+    def __call__(self, x):
+        return np.atleast_1d(self.fun(x))
+
+    def violation(self, x):
+        """How much the constraint is exceeded by.
+
+        Parameters
+        ----------
+        x : array-like
+            Vector of independent variables
+
+        Returns
+        -------
+        excess : array-like
+            How much the constraint is exceeded by, for each of the
+            constraints specified by `_ConstraintWrapper.fun`.
+        """
+        ev = self.fun(np.asarray(x))
+
+        excess_lb = np.maximum(self.bounds[0] - ev, 0)
+        excess_ub = np.maximum(ev - self.bounds[1], 0)
+
+        return excess_lb + excess_ub

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -1000,3 +1000,30 @@ class TestDifferentialEvolutionSolver(object):
         assert_(np.all(np.array(c1(res.x)) <= np.array([92, 110, 25])))
         assert_(np.all(res.x >= np.array(bounds)[:, 0]))
         assert_(np.all(res.x <= np.array(bounds)[:, 1]))
+
+    def test_L9(self):
+        # Lampinen ([5]) test problem 9
+
+        def f(x):
+            x = np.hstack(([0], x))  # 1-indexed to match reference
+            return x[1]**2 + (x[2]-1)**2
+
+        def c1(x):
+            x = np.hstack(([0], x))  # 1-indexed to match reference
+            return [x[2] - x[1]**2]
+
+        N = NonlinearConstraint(c1, [-.001], [0.001])
+
+        bounds = [(-1, 1)]*2
+        constraints = (N)
+        res = differential_evolution(f, bounds, maxiter=1000, popsize=30,
+                                     mutation=0.9, recombination=0.9,
+                                     constraints=constraints)
+        x_opt = [np.sqrt(2)/2, 0.5]
+        f_opt = 0.75
+        assert_allclose(np.abs(res.x), x_opt, atol=0.01)
+        assert_allclose(res.fun, f_opt, atol=0.005)
+        assert_(np.all(np.array(c1(res.x)) >= -0.001))
+        assert_(np.all(np.array(c1(res.x)) <= 0.001))
+        assert_(np.all(res.x >= np.array(bounds)[:, 0]))
+        assert_(np.all(res.x <= np.array(bounds)[:, 1]))

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -787,3 +787,24 @@ class TestDifferentialEvolutionSolver(object):
         assert_allclose(res.x, x_opt, atol=1e-1, rtol=1e-1)
         assert_allclose(res.fun, f_opt, atol=3e-2, rtol=3e-2)
 
+        def c1(x):
+            temp = x
+            x = np.zeros(14)
+            x[1:] = temp
+            return [2*x[2] + 2*x[3] + x[11] + x[12],
+                    -8*x[3] + x[12]]
+
+        def c2(x):
+            temp = x
+            x = np.zeros(14)
+            x[1:] = temp
+            return -2*x[8] - x[9] + x[12]
+
+        L = LinearConstraint(A[:5, :], -np.inf, b[:5])
+        L2 = LinearConstraint(A[5:6, :], -np.inf, b[5:6])
+        N = NonlinearConstraint(c1, -np.inf, b[6:8])
+        N2 = NonlinearConstraint(c2, -np.inf, b[8:9])
+        constraints = (L, N, L2, N2)
+        res = differential_evolution(f, bounds, constraints=constraints)
+        assert_allclose(res.x, x_opt, atol=1e-1, rtol=1e-1)
+        assert_allclose(res.fun, f_opt, atol=3e-2, rtol=3e-2)

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -939,3 +939,29 @@ class TestDifferentialEvolutionSolver(object):
         assert_(np.all(np.array(c1(res.x)) <= 0))
         assert_(np.all(res.x >= np.array(bounds)[:, 0]))
         assert_(np.all(res.x <= np.array(bounds)[:, 1]))
+
+    def test_L6(self):
+        # Lampinen ([5]) test problem 6
+        def f(x):
+            x = np.hstack(([0], x))  # 1-indexed to match reference
+            fun = (x[1]-10)**3 + (x[2] - 20)**3
+            return fun
+
+        def c1(x):
+            x = np.hstack(([0], x))  # 1-indexed to match reference
+            return [(x[1]-5)**2 + (x[2] - 5)**2 - 100,
+                    -(x[1]-6)**2 - (x[2] - 5)**2 + 82.81]
+
+        N = NonlinearConstraint(c1, 0, np.inf)
+        bounds = [(13, 100), (0, 100)]
+        constraints = (N)
+        res = differential_evolution(f, bounds, maxiter=1000, popsize=15,
+                                     mutation=0.9, recombination=0.9,
+                                     constraints=constraints)
+        x_opt = (14.095, 0.84296)
+        f_opt = -6961.81381
+        assert_allclose(res.x, x_opt, atol=1e-1, rtol=1e-1)
+        assert_allclose(res.fun, f_opt, atol=75, rtol=.01)
+        assert_(np.all(np.array(c1(res.x)) >= 0))
+        assert_(np.all(res.x >= np.array(bounds)[:, 0]))
+        assert_(np.all(res.x <= np.array(bounds)[:, 1]))

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -803,3 +803,36 @@ class TestDifferentialEvolutionSolver(object):
 
         assert_allclose(res.x, x_opt, atol=1e-1, rtol=1e-1)
         assert_allclose(res.fun, f_opt, atol=3e-2, rtol=3e-2)
+
+    def test_L2(self):
+        # Lampinen ([5]) test problem 2
+
+        def f(x):
+            x = np.hstack(([0], x))  # 1-indexed to match reference
+            fun = ((x[1]-10)**2 + 5*(x[2]-12)**2 + x[3]**4 + 3*(x[4]-11)**2 +
+                   10*x[5]**6 + 7*x[6]**2 + x[7]**4 -4*x[6]*x[7] - 10*x[6] -
+                   8*x[7])
+            return fun
+
+        def c1(x):
+            x = np.hstack(([0], x))  # 1-indexed to match reference
+            return [127 - 2*x[1]**2 - 3*x[2]**4 - x[3] - 4*x[4]**2 - 5*x[5],
+                    196 - 23*x[1] - x[2]**2 - 6*x[6]**2 + 8*x[7],
+                    282 - 7*x[1] - 3*x[2] - 10*x[3]**2 - x[4] + x[5],
+                    -4*x[1]**2 - x[2]**2 + 3*x[1]*x[2] - 2*x[3]**2 - 5*x[6] + 11*x[7]]
+
+
+        N = NonlinearConstraint(c1, 0, np.inf)
+        x = (2.330499, 1.951372, -0.4775414, 4.365726,
+             -0.6244870, 1.038131, 1.594227)
+        bounds = [(-10, 10)]*7
+        constraints = (N)
+        res = differential_evolution(f, bounds, maxiter=4000, popsize=20,
+                                     mutation=0.9, recombination=0.9,
+                                     constraints=constraints)
+
+        f_opt = 680.6300599487869
+        assert_allclose(res.fun, f_opt, atol=5, rtol=1e-2)
+        assert_(np.all(np.array(c1(res.x)) >= 0))
+        assert_(np.all(res.x >= np.array(bounds)[:,0]))
+        assert_(np.all(res.x <= np.array(bounds)[:,1]))

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -837,8 +837,50 @@ class TestDifferentialEvolutionSolver(object):
         assert_(np.all(res.x >= np.array(bounds)[:, 0]))
         assert_(np.all(res.x <= np.array(bounds)[:, 1]))
 
+    def test_L3(self):
+        # Lampinen ([5]) test problem 3
+
+        def f(x):
+            x = np.hstack(([0], x))  # 1-indexed to match reference
+            fun = (x[1]**2 + x[2]**2 + x[1]*x[2] - 14*x[1] - 16*x[2] +
+                   (x[3]-10)**2 + 4*(x[4]-5)**2 + (x[5]-3)**2 + 2*(x[6]-1)**2 +
+                   5*x[7]**2 + 7*(x[8]-11)**2 + 2*(x[9]-10)**2 +
+                   (x[10] - 7)**2 + 45
+                   )
+            return fun  # maximize
+
+        A = np.zeros((4, 11))
+        A[1, [1, 2, 7, 8]] = -4, -5, 3, -9
+        A[2, [1, 2, 7, 8]] = -10, 8, 17, -2
+        A[3, [1, 2, 9, 10]] = 8, -2, -5, 2
+        A = A[1:, 1:]
+        b = np.array([-105, 0, -12])
+
+        def c1(x):
+            x = np.hstack(([0], x))  # 1-indexed to match reference
+            return [3*x[1] - 6*x[2] - 12*(x[9]-8)**2 + 7*x[10],
+                    -3*(x[1]-2)**2 - 4*(x[2]-3)**2 - 2*x[3]**2 + 7*x[4] + 120,
+                    -x[1]**2 - 2*(x[2]-2)**2 + 2*x[1]*x[2] - 14*x[5] + 6*x[6],
+                    -5*x[1]**2 - 8*x[2] - (x[3]-6)**2 + 2*x[4] + 40,
+                    -0.5*(x[1]-8)**2 - 2*(x[2]-4)**2 - 3*x[5]**2 + x[6] + 30]
+
+        L = LinearConstraint(A, b, np.inf)
+        N = NonlinearConstraint(c1, 0, np.inf)
+        bounds = [(-10, 10)]*10
+        constraints = (L, N)
+        res = differential_evolution(f, bounds, maxiter=5000, popsize=35, mutation=0.9, recombination=0.9, constraints=constraints)
+        x_opt = (2.171996, 2.363683, 8.773926, 5.095984, 0.990654,
+                 1.430574, 1.321644, 9.828726, 8.280092, 8.375927)
+        f_opt = 24.3062091
+        assert_allclose(res.x, x_opt, atol=0.2, rtol=0.2)
+        assert_allclose(res.fun, f_opt, atol=0.5, rtol=0.05)
+        assert_(np.all(A @ res.x >= b))
+        assert_(np.all(np.array(c1(res.x)) >= 0))
+        assert_(np.all(res.x >= np.array(bounds)[:, 0]))
+        assert_(np.all(res.x <= np.array(bounds)[:, 1]))
+
     def test_L5(self):
-        # Lampinen ([5]) test problem 2
+        # Lampinen ([5]) test problem 5
 
         def f(x):
             x = np.hstack(([0], x))  # 1-indexed to match reference

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -752,9 +752,7 @@ class TestDifferentialEvolutionSolver(object):
         # Lampinen ([5]) test problem 1
 
         def f(x):
-            temp = x
-            x = np.zeros(14)
-            x[1:] = temp  # 1-indexed to match reference
+            x = np.hstack(([0], x))  # 1-indexed to match reference
             fun = np.sum(5*x[1:5]) - 5*x[1:5]@x[1:5] - np.sum(x[5:])
             return fun
 
@@ -788,16 +786,12 @@ class TestDifferentialEvolutionSolver(object):
         assert_allclose(res.fun, f_opt, atol=3e-2, rtol=3e-2)
 
         def c1(x):
-            temp = x
-            x = np.zeros(14)
-            x[1:] = temp
+            x = np.hstack(([0], x))
             return [2*x[2] + 2*x[3] + x[11] + x[12],
                     -8*x[3] + x[12]]
 
         def c2(x):
-            temp = x
-            x = np.zeros(14)
-            x[1:] = temp
+            x = np.hstack(([0], x))
             return -2*x[8] - x[9] + x[12]
 
         L = LinearConstraint(A[:5, :], -np.inf, b[:5])
@@ -806,5 +800,6 @@ class TestDifferentialEvolutionSolver(object):
         N2 = NonlinearConstraint(c2, -np.inf, b[8:9])
         constraints = (L, N, L2, N2)
         res = differential_evolution(f, bounds, constraints=constraints)
+
         assert_allclose(res.x, x_opt, atol=1e-1, rtol=1e-1)
         assert_allclose(res.fun, f_opt, atol=3e-2, rtol=3e-2)

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -965,3 +965,35 @@ class TestDifferentialEvolutionSolver(object):
         assert_(np.all(np.array(c1(res.x)) >= 0))
         assert_(np.all(res.x >= np.array(bounds)[:, 0]))
         assert_(np.all(res.x <= np.array(bounds)[:, 1]))
+
+    def test_L7(self):
+        # Lampinen ([5]) test problem 7
+        def f(x):
+            x = np.hstack(([0], x))  # 1-indexed to match reference
+            fun = (5.3578547*x[3]**2 + 0.8356891*x[1]*x[5] +
+                   37.293239*x[1] - 40792.141)
+            return fun
+
+
+        def c1(x):
+            x = np.hstack(([0], x))  # 1-indexed to match reference
+            return [
+                    85.334407 + 0.0056858*x[2]*x[5] + 0.0006262*x[1]*x[4] - 0.0022053*x[3]*x[5],
+                    80.51249 + 0.0071317*x[2]*x[5] + 0.0029955*x[1]*x[2] + 0.0021813*x[3]**2,
+                    9.300961 + 0.0047026*x[3]*x[5] + 0.0012547*x[1]*x[3] + 0.0019085*x[3]*x[4]
+                    ]
+
+        N = NonlinearConstraint(c1, [0, 90, 20], [92, 110, 25])
+
+        bounds = [(78, 102), (33, 45)]+[(27, 45)]*3
+        constraints = (N)
+        res = differential_evolution(f, bounds, maxiter=2000, popsize=15,
+                                     mutation=0.9, recombination=0.9,
+                                     constraints=constraints)
+        x_opt = (78.0, 33.0, 29.995, 45.0, 36.776)
+        f_opt = -30665.5
+        assert_allclose(res.x, x_opt, atol=2)
+        assert_allclose(res.fun, f_opt, atol=300)
+        assert_(np.all(np.array(c1(res.x)) >= 0))
+        assert_(np.all(res.x >= np.array(bounds)[:, 0]))
+        assert_(np.all(res.x <= np.array(bounds)[:, 1]))

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -942,7 +942,7 @@ class TestDifferentialEvolutionSolver(object):
 
         f_opt = 7049.248
 
-        x_opt= [579.306692, 1359.97063, 5109.9707, 182.0177, 295.601172,
+        x_opt = [579.306692, 1359.97063, 5109.9707, 182.0177, 295.601172,
                 217.9823, 286.416528, 395.601172]
 
         assert_allclose(f(x_opt), f_opt, atol=0.001)

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -875,8 +875,9 @@ class TestDifferentialEvolutionSolver(object):
         N = NonlinearConstraint(c1, 0, np.inf)
         bounds = [(-10, 10)]*10
         constraints = (L, N)
-        res = differential_evolution(f, bounds, maxiter=5000, popsize=35, mutation=0.9, recombination=0.9, constraints=constraints)
-        x_opt = (2.171996, 2.363683, 8.773926, 5.095984, 0.990654,
+        res = differential_evolution(f, bounds, maxiter=5000, popsize=35, mutation=0.9,
+                                     recombination=0.9, constraints=constraints)
+        x_opt = (2.171996, 2.363683, 8.773926, 5.095984, 0.9906548,
                  1.430574, 1.321644, 9.828726, 8.280092, 8.375927)
         f_opt = 24.3062091
 

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -782,6 +782,7 @@ class TestDifferentialEvolutionSolver(object):
         x_opt = (1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3, 3, 1)
         f_opt = -15
 
+        assert_allclose(f(x_opt), f_opt)
         assert_allclose(res.x, x_opt, atol=1e-1)
         assert_allclose(res.fun, f_opt, atol=0.5)
         assert_(np.all(A@res.x <= b))
@@ -835,6 +836,9 @@ class TestDifferentialEvolutionSolver(object):
                                      constraints=constraints)
 
         f_opt = 680.6300599487869
+        x_opt = (2.330499, 1.951372, -0.4775414, 4.365726, -0.6244870, 1.038131, 1.594227)
+
+        assert_allclose(f(x_opt), f_opt)
         assert_allclose(res.fun, f_opt, atol=5)
         assert_(np.all(np.array(c1(res.x)) >= 0))
         assert_(np.all(res.x >= np.array(bounds)[:, 0]))
@@ -875,6 +879,8 @@ class TestDifferentialEvolutionSolver(object):
         x_opt = (2.171996, 2.363683, 8.773926, 5.095984, 0.990654,
                  1.430574, 1.321644, 9.828726, 8.280092, 8.375927)
         f_opt = 24.3062091
+
+        assert_allclose(f(x_opt), f_opt)
         assert_allclose(res.x, x_opt, atol=0.2)
         assert_allclose(res.fun, f_opt, atol=0.5)
         assert_(np.all(A @ res.x >= b))

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -784,6 +784,9 @@ class TestDifferentialEvolutionSolver(object):
 
         assert_allclose(res.x, x_opt, atol=1e-1, rtol=1e-1)
         assert_allclose(res.fun, f_opt, atol=3e-2, rtol=3e-2)
+        assert_(np.all(A@res.x <= b))
+        assert_(np.all(res.x >= np.array(bounds)[:,0]))
+        assert_(np.all(res.x <= np.array(bounds)[:,1]))
 
         def c1(x):
             x = np.hstack(([0], x))

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -940,13 +940,14 @@ class TestDifferentialEvolutionSolver(object):
                                      seed=1234, constraints=constraints,
                                      popsize=3)
 
-        f_opt = 7049.330923
-        x_opt = (579.3167, 1359.943, 5110.071, 182.0174, 295.5985, 217.9799,
-                 286.4162, 395.5979)
+        f_opt = 7049.248
 
-        assert_allclose(f(x_opt), f_opt)
-        assert_allclose(res.fun, f_opt, atol=0.1)
-        assert_allclose(res.x, x_opt, atol=0.12)
+        x_opt= [579.306692, 1359.97063, 5109.9707, 182.0177, 295.601172,
+                217.9823, 286.416528, 395.601172]
+
+        assert_allclose(f(x_opt), f_opt, atol=0.001)
+        assert_allclose(res.fun, f_opt, atol=0.001)
+        assert_allclose(res.x, x_opt, atol=0.0001)
         assert res.success
         assert_(np.all(A @ res.x <= b))
         assert_(np.all(np.array(c1(res.x)) >= 0))
@@ -959,7 +960,7 @@ class TestDifferentialEvolutionSolver(object):
         def f(x):
             x = np.hstack(([0], x))  # 1-indexed to match reference
             fun = (np.sin(2*np.pi*x[1])**3*np.sin(2*np.pi*x[2]) /
-                   (x[1]**3*(x[1]*x[2])))
+                   (x[1]**3*(x[1]+x[2])))
             return -fun  # maximize
 
         def c1(x):
@@ -974,11 +975,10 @@ class TestDifferentialEvolutionSolver(object):
         res = differential_evolution(f, bounds, strategy='rand1bin', seed=1234,
                                      constraints=constraints)
 
-        x_opt = (1.22067691, 4.24096915)
-        f_opt = -0.100738
-
-        assert_allclose(f(x_opt), f_opt, atol=2e-7)
-        assert_allclose(res.x, x_opt, atol=5e-3)
+        x_opt = (1.22797135, 4.24537337)
+        f_opt = -0.095825
+        print(res)
+        assert_allclose(f(x_opt), f_opt, atol=2e-5)
         assert_allclose(res.fun, f_opt, atol=1e-4)
         assert res.success
         assert_(np.all(np.array(c1(res.x)) <= 0))
@@ -1001,12 +1001,12 @@ class TestDifferentialEvolutionSolver(object):
         bounds = [(13, 100), (0, 100)]
         constraints = (N)
         res = differential_evolution(f, bounds, strategy='rand1bin', seed=1234,
-                                     constraints=constraints)
+                                     constraints=constraints, tol=1e-7)
         x_opt = (14.095, 0.84296)
         f_opt = -6961.814744
 
         assert_allclose(f(x_opt), f_opt, atol=1e-6)
-        assert_allclose(res.fun, f_opt, atol=0.05)
+        assert_allclose(res.fun, f_opt, atol=0.001)
         assert_allclose(res.x, x_opt, atol=1e-4)
         assert res.success
         assert_(np.all(np.array(c1(res.x)) >= 0))
@@ -1036,18 +1036,23 @@ class TestDifferentialEvolutionSolver(object):
 
         N = NonlinearConstraint(c1, [0, 90, 20], [92, 110, 25])
 
-        bounds = [(78, 102), (33, 45)]+[(27, 45)]*3
+        bounds = [(78, 102), (33, 45)] + [(27, 45)]*3
         constraints = (N)
 
         res = differential_evolution(f, bounds, strategy='rand1bin', seed=1234,
                                      constraints=constraints)
 
-        x_opt = (78.0, 33.0, 29.995, 45.0, 36.776)
-        f_opt = -30665.608768
+        # using our best solution, rather than Lampinen/Koziel. Koziel solution
+        # doesn't satisfy constraints, Lampinen f_opt just plain wrong.
+        x_opt = [78.00000686, 33.00000362, 29.99526064, 44.99999971,
+                 36.77579979]
+
+        f_opt = -30665.537578
 
         assert_allclose(f(x_opt), f_opt)
-        assert_allclose(res.fun, f_opt, atol=0.1)
         assert_allclose(res.x, x_opt, atol=1e-3)
+        assert_allclose(res.fun, f_opt, atol=1e-3)
+
         assert res.success
         assert_(np.all(np.array(c1(res.x)) >= np.array([0, 90, 20])))
         assert_(np.all(np.array(c1(res.x)) <= np.array([92, 110, 25])))

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -782,8 +782,8 @@ class TestDifferentialEvolutionSolver(object):
         x_opt = (1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3, 3, 1)
         f_opt = -15
 
-        assert_allclose(res.x, x_opt, atol=1e-1, rtol=1e-1)
-        assert_allclose(res.fun, f_opt, atol=3e-2, rtol=3e-2)
+        assert_allclose(res.x, x_opt, atol=1e-1)
+        assert_allclose(res.fun, f_opt, atol=0.5)
         assert_(np.all(A@res.x <= b))
         assert_(np.all(res.x >= np.array(bounds)[:, 0]))
         assert_(np.all(res.x <= np.array(bounds)[:, 1]))
@@ -804,8 +804,11 @@ class TestDifferentialEvolutionSolver(object):
         constraints = (L, N, L2, N2)
         res = differential_evolution(f, bounds, constraints=constraints)
 
-        assert_allclose(res.x, x_opt, atol=1e-1, rtol=1e-1)
-        assert_allclose(res.fun, f_opt, atol=3e-2, rtol=3e-2)
+        assert_allclose(res.x, x_opt, atol=1e-1)
+        assert_allclose(res.fun, f_opt, atol=0.5)
+        assert_(np.all(A@res.x <= b))
+        assert_(np.all(res.x >= np.array(bounds)[:, 0]))
+        assert_(np.all(res.x <= np.array(bounds)[:, 1]))
 
     def test_L2(self):
         # Lampinen ([5]) test problem 2
@@ -832,7 +835,7 @@ class TestDifferentialEvolutionSolver(object):
                                      constraints=constraints)
 
         f_opt = 680.6300599487869
-        assert_allclose(res.fun, f_opt, atol=5, rtol=1e-2)
+        assert_allclose(res.fun, f_opt, atol=5)
         assert_(np.all(np.array(c1(res.x)) >= 0))
         assert_(np.all(res.x >= np.array(bounds)[:, 0]))
         assert_(np.all(res.x <= np.array(bounds)[:, 1]))
@@ -872,8 +875,8 @@ class TestDifferentialEvolutionSolver(object):
         x_opt = (2.171996, 2.363683, 8.773926, 5.095984, 0.990654,
                  1.430574, 1.321644, 9.828726, 8.280092, 8.375927)
         f_opt = 24.3062091
-        assert_allclose(res.x, x_opt, atol=0.2, rtol=0.2)
-        assert_allclose(res.fun, f_opt, atol=0.5, rtol=0.05)
+        assert_allclose(res.x, x_opt, atol=0.2)
+        assert_allclose(res.fun, f_opt, atol=0.5)
         assert_(np.all(A @ res.x >= b))
         assert_(np.all(np.array(c1(res.x)) >= 0))
         assert_(np.all(res.x >= np.array(bounds)[:, 0]))
@@ -906,7 +909,7 @@ class TestDifferentialEvolutionSolver(object):
                                      mutation=0.9, recombination=0.9,
                                      constraints=constraints)
 
-        assert_allclose(res.fun, f_opt, atol=50, rtol=1)
+        assert_allclose(res.fun, f_opt, atol=75)
         assert_(np.all(A @ res.x <= b))
         assert_(np.all(np.array(c1(res.x)) >= 0))
         assert_(np.all(res.x >= np.array(bounds)[:, 0]))
@@ -934,8 +937,8 @@ class TestDifferentialEvolutionSolver(object):
                                      constraints=constraints)
         x_opt = (1.22067691, 4.24096915)
         f_opt = -0.10077999749728803
-        assert_allclose(res.x, x_opt, atol=1e-2, rtol=1e-2)
-        assert_allclose(res.fun, f_opt, atol=1e-4, rtol=1e-3)
+        assert_allclose(res.x, x_opt, atol=1e-2)
+        assert_allclose(res.fun, f_opt, atol=1e-4)
         assert_(np.all(np.array(c1(res.x)) <= 0))
         assert_(np.all(res.x >= np.array(bounds)[:, 0]))
         assert_(np.all(res.x <= np.array(bounds)[:, 1]))
@@ -960,8 +963,8 @@ class TestDifferentialEvolutionSolver(object):
                                      constraints=constraints)
         x_opt = (14.095, 0.84296)
         f_opt = -6961.81381
-        assert_allclose(res.x, x_opt, atol=1e-1, rtol=1e-1)
-        assert_allclose(res.fun, f_opt, atol=75, rtol=.01)
+        assert_allclose(res.x, x_opt, atol=1e-1)
+        assert_allclose(res.fun, f_opt, atol=75)
         assert_(np.all(np.array(c1(res.x)) >= 0))
         assert_(np.all(res.x >= np.array(bounds)[:, 0]))
         assert_(np.all(res.x <= np.array(bounds)[:, 1]))
@@ -973,7 +976,6 @@ class TestDifferentialEvolutionSolver(object):
             fun = (5.3578547*x[3]**2 + 0.8356891*x[1]*x[5] +
                    37.293239*x[1] - 40792.141)
             return fun
-
 
         def c1(x):
             x = np.hstack(([0], x))  # 1-indexed to match reference
@@ -992,8 +994,9 @@ class TestDifferentialEvolutionSolver(object):
                                      constraints=constraints)
         x_opt = (78.0, 33.0, 29.995, 45.0, 36.776)
         f_opt = -30665.5
-        assert_allclose(res.x, x_opt, atol=2)
+        assert_allclose(res.x, x_opt, atol=3)
         assert_allclose(res.fun, f_opt, atol=300)
-        assert_(np.all(np.array(c1(res.x)) >= 0))
+        assert_(np.all(np.array(c1(res.x)) >= np.array([0, 90, 20])))
+        assert_(np.all(np.array(c1(res.x)) <= np.array([92, 110, 25])))
         assert_(np.all(res.x >= np.array(bounds)[:, 0]))
         assert_(np.all(res.x <= np.array(bounds)[:, 1]))

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -947,7 +947,7 @@ class TestDifferentialEvolutionSolver(object):
 
         assert_allclose(f(x_opt), f_opt, atol=0.001)
         assert_allclose(res.fun, f_opt, atol=0.001)
-        assert_allclose(res.x, x_opt, atol=0.0001)
+        assert_allclose(res.x, x_opt, atol=0.002)
         assert res.success
         assert_(np.all(A @ res.x <= b))
         assert_(np.all(np.array(c1(res.x)) >= 0))

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -879,6 +879,39 @@ class TestDifferentialEvolutionSolver(object):
         assert_(np.all(res.x >= np.array(bounds)[:, 0]))
         assert_(np.all(res.x <= np.array(bounds)[:, 1]))
 
+    def test_L4(self):
+        # Lampinen ([5]) test problem 4
+        def f(x):
+            return np.sum(x[:3])
+
+        A = np.zeros((4, 9))
+        A[1, [4, 6]] = 0.0025, 0.0025
+        A[2, [5, 7, 4]] = 0.0025, 0.0025, -0.0025
+        A[3, [8, 5]] = 0.01, -0.01
+        A = A[1:, 1:]
+        b = np.array([1, 1, 1])
+
+        def c1(x):
+            x = np.hstack(([0], x))  # 1-indexed to match reference
+            return [x[1]*x[6] - 833.33252*x[4] - 100*x[1] + 83333.333,
+                    x[2]*x[7] - 1250*x[5] - x[2]*x[4] + 1250*x[4],
+                    x[3]*x[8] - 1250000 - x[3]*x[5] + 2500*x[5]]
+
+        L = LinearConstraint(A, -np.inf, 1)
+        N = NonlinearConstraint(c1, 0, np.inf)
+        f_opt = 7049.330923
+        bounds = [(100, 10000)] + [(1000, 10000)]*2 + [(10, 1000)]*5
+        constraints = (L, N)
+        res = differential_evolution(f, bounds, maxiter=9000, popsize=30,
+                                     mutation=0.9, recombination=0.9,
+                                     constraints=constraints)
+
+        assert_allclose(res.fun, f_opt, atol=50, rtol=1)
+        assert_(np.all(A @ res.x <= b))
+        assert_(np.all(np.array(c1(res.x)) >= 0))
+        assert_(np.all(res.x >= np.array(bounds)[:, 0]))
+        assert_(np.all(res.x <= np.array(bounds)[:, 1]))
+
     def test_L5(self):
         # Lampinen ([5]) test problem 5
 

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -785,8 +785,8 @@ class TestDifferentialEvolutionSolver(object):
         assert_allclose(res.x, x_opt, atol=1e-1, rtol=1e-1)
         assert_allclose(res.fun, f_opt, atol=3e-2, rtol=3e-2)
         assert_(np.all(A@res.x <= b))
-        assert_(np.all(res.x >= np.array(bounds)[:,0]))
-        assert_(np.all(res.x <= np.array(bounds)[:,1]))
+        assert_(np.all(res.x >= np.array(bounds)[:, 0]))
+        assert_(np.all(res.x <= np.array(bounds)[:, 1]))
 
         def c1(x):
             x = np.hstack(([0], x))
@@ -813,7 +813,7 @@ class TestDifferentialEvolutionSolver(object):
         def f(x):
             x = np.hstack(([0], x))  # 1-indexed to match reference
             fun = ((x[1]-10)**2 + 5*(x[2]-12)**2 + x[3]**4 + 3*(x[4]-11)**2 +
-                   10*x[5]**6 + 7*x[6]**2 + x[7]**4 -4*x[6]*x[7] - 10*x[6] -
+                   10*x[5]**6 + 7*x[6]**2 + x[7]**4 - 4*x[6]*x[7] - 10*x[6] -
                    8*x[7])
             return fun
 
@@ -824,10 +824,7 @@ class TestDifferentialEvolutionSolver(object):
                     282 - 7*x[1] - 3*x[2] - 10*x[3]**2 - x[4] + x[5],
                     -4*x[1]**2 - x[2]**2 + 3*x[1]*x[2] - 2*x[3]**2 - 5*x[6] + 11*x[7]]
 
-
         N = NonlinearConstraint(c1, 0, np.inf)
-        x = (2.330499, 1.951372, -0.4775414, 4.365726,
-             -0.6244870, 1.038131, 1.594227)
         bounds = [(-10, 10)]*7
         constraints = (N)
         res = differential_evolution(f, bounds, maxiter=4000, popsize=20,
@@ -837,5 +834,33 @@ class TestDifferentialEvolutionSolver(object):
         f_opt = 680.6300599487869
         assert_allclose(res.fun, f_opt, atol=5, rtol=1e-2)
         assert_(np.all(np.array(c1(res.x)) >= 0))
-        assert_(np.all(res.x >= np.array(bounds)[:,0]))
-        assert_(np.all(res.x <= np.array(bounds)[:,1]))
+        assert_(np.all(res.x >= np.array(bounds)[:, 0]))
+        assert_(np.all(res.x <= np.array(bounds)[:, 1]))
+
+    def test_L5(self):
+        # Lampinen ([5]) test problem 2
+
+        def f(x):
+            x = np.hstack(([0], x))  # 1-indexed to match reference
+            fun = (np.sin(2*np.pi*x[1])**3*np.sin(2*np.pi*x[2]) /
+                   (x[1]**3*(x[1]*x[2])))
+            return -fun  # maximize
+
+        def c1(x):
+            x = np.hstack(([0], x))  # 1-indexed to match reference
+            return [x[1]**2 - x[2] + 1,
+                    1 - x[1] + (x[2]-4)**2]
+
+        N = NonlinearConstraint(c1, -np.inf, 0)
+        bounds = [(0, 10)]*2
+        constraints = (N)
+        res = differential_evolution(f, bounds, maxiter=500, popsize=20,
+                                     mutation=0.9, recombination=0.9,
+                                     constraints=constraints)
+        x_opt = (1.22067691, 4.24096915)
+        f_opt = -0.10077999749728803
+        assert_allclose(res.x, x_opt, atol=1e-2, rtol=1e-2)
+        assert_allclose(res.fun, f_opt, atol=1e-4, rtol=1e-3)
+        assert_(np.all(np.array(c1(res.x)) <= 0))
+        assert_(np.all(res.x >= np.array(bounds)[:, 0]))
+        assert_(np.all(res.x <= np.array(bounds)[:, 1]))


### PR DESCRIPTION
Adds constraints for `differential_evolution` following [Lampinen](https://pdfs.semanticscholar.org/088e/60df2694230e8e9e841e19ec218cddba54fe.pdf)
Depends on #9990 being merged first.
The first commit adds the machinery, tests are being created.