### PR TITLE
BLD: fix Python 3.7 build with build isolation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,10 @@ matrix:
         - TESTMODE=fast
         - COVERAGE=
         - NUMPYSPEC="--pre --upgrade --timeout=60 -f $PRE_WHEELS numpy"
+        # Need a test with most recent Python version where we build from an
+        # sdist (uses pip build isolation), to check that the version we
+        # specify in pyproject.toml (will be older than --pre --upgrade) works
+        - USE_SDIST=1
     - python: 3.7
       dist: xenial # travis-ci/travis-ci/issues/9815
       sudo: true
@@ -188,12 +192,12 @@ script:
         python tools/suppress_output.py python setup.py sdist
         # Move out of source directory to avoid finding local scipy
         cd dist
-        # Use pip --build option to make ccache work better.
-        # However, this option is partially broken
-        # (see https://github.com/pypa/pip/issues/4242)
-        # and some shenanigans are needed to make it work.
         echo "pip install"
-        python ../tools/suppress_output.py pip install --no-cache-dir --no-build-isolation --build="$HOME/builds" --upgrade "file://`echo -n $PWD/scipy*`#egg=scipy" -v
+        # Note: uses build isolation, which is what pip does with sdists by default
+        # Note: don't use a fixed build dir (which would help for ccache), because
+        #       --build is partially broken and the workaround in commit b4617dd764
+        #       messes with build isolation.
+        pip install $PWD/scipy* -v
         cd ..
         USE_WHEEL_BUILD="--no-build"
     fi

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include MANIFEST.in
 include *.txt
 # Top-level build script
 include setup.py
+include pyproject.toml
 # All source files
 recursive-include scipy *
 recursive-include benchmarks *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,5 +3,7 @@ requires = [
     "wheel",
     "setuptools",
     "Cython>=0.29.2",
-    "numpy==1.13.3",
+    "numpy==1.13.3; python_version=='3.5'",
+    "numpy==1.13.3; python_version=='3.6'",
+    "numpy==1.14.5; python_version>='3.7'",
 ]


### PR DESCRIPTION
Broken now, see discussion on gh-9924.

First commit just tests that CI fails, then will push a fix after that.

This is a change to gh-8724 which added --no-build-isolation.
That PR does discuss that testing build isolation in CI would be a good idea;
it just didn't address that at the time.
    
The official Python 3.7 release date was 27 June 2018, so NumPy cut a release with support (1.14.5) for it right after. Therefore this should be the right fix.

Closes gh-10024.