### PR TITLE
BUG: Make sure that _binary_erosion only accepts an integer number of iterations.

### DIFF
--- a/scipy/ndimage/morphology.py
+++ b/scipy/ndimage/morphology.py
@@ -246,7 +246,6 @@ def _binary_erosion(input, structure, iterations, mask, output,
         output = bool
     output = _ni_support._get_output(output, input)
 
-    iterations = operator.index(iterations)
     if iterations == 1:
         _nd_image.binary_erosion(input, structure, mask, output,
                                  border_value, origin, invert, cit, 0)

--- a/scipy/ndimage/morphology.py
+++ b/scipy/ndimage/morphology.py
@@ -215,7 +215,11 @@ def generate_binary_structure(rank, connectivity):
 
 def _binary_erosion(input, structure, iterations, mask, output,
                     border_value, origin, invert, brute_force):
-    iterations = operator.index(iterations)
+    try:
+        iterations = operator.index(iterations)
+    except TypeError:
+        raise TypeError('iterations parameter should be an integer')
+
     input = numpy.asarray(input)
     if numpy.iscomplexobj(input):
         raise TypeError('Complex type not supported')

--- a/scipy/ndimage/morphology.py
+++ b/scipy/ndimage/morphology.py
@@ -215,6 +215,7 @@ def generate_binary_structure(rank, connectivity):
 
 def _binary_erosion(input, structure, iterations, mask, output,
                     border_value, origin, invert, brute_force):
+    iterations = operator.index(iterations)
     input = numpy.asarray(input)
     if numpy.iscomplexobj(input):
         raise TypeError('Complex type not supported')
@@ -396,7 +397,8 @@ def binary_dilation(input, structure=None, iterations=1, mask=None,
     iterations : int, optional
         The dilation is repeated `iterations` times (one, by default).
         If iterations is less than 1, the dilation is repeated until the
-        result does not change anymore.
+        result does not change anymore. Only an integer of iterations is
+        accepted.
     mask : array_like, optional
         If a mask is given, only those elements with a True value at
         the corresponding mask element are modified at each iteration.
@@ -528,11 +530,11 @@ def binary_opening(input, structure=None, iterations=1, output=None,
         is generated with a square connectivity equal to one (i.e., only
         nearest neighbors are connected to the center, diagonally-connected
         elements are not considered neighbors).
-    iterations : {int, float}, optional
+    iterations : int, optional
         The erosion step of the opening, then the dilation step are each
         repeated `iterations` times (one, by default). If `iterations` is
         less than 1, each operation is repeated until the result does
-        not change anymore.
+        not change anymore. Only an integer of iterations is accepted.
     output : ndarray, optional
         Array of the same shape as input, into which the output is placed.
         By default, a new array is created.
@@ -655,7 +657,7 @@ def binary_closing(input, structure=None, iterations=1, output=None,
         The dilation step of the closing, then the erosion step are each
         repeated `iterations` times (one, by default). If iterations is
         less than 1, each operations is repeated until the result does
-        not change anymore.
+        not change anymore. Only an integer of iterations is accepted.
     output : ndarray, optional
         Array of the same shape as input, into which the output is placed.
         By default, a new array is created.

--- a/scipy/ndimage/src/nd_image.c
+++ b/scipy/ndimage/src/nd_image.c
@@ -212,7 +212,7 @@ exit:
 static PyObject *Py_Correlate(PyObject *obj, PyObject *args)
 {
     PyArrayObject *input = NULL, *output = NULL, *weights = NULL;
-    PyArray_Dims origin;
+    PyArray_Dims origin = {NULL, 0};
     int mode;
     double cval;
 
@@ -297,7 +297,7 @@ static PyObject *Py_MinOrMaxFilter(PyObject *obj, PyObject *args)
 {
     PyArrayObject *input = NULL, *output = NULL, *footprint = NULL;
     PyArrayObject *structure = NULL;
-    PyArray_Dims origin;
+    PyArray_Dims origin = {NULL, 0};
     int mode, minimum;
     double cval;
 
@@ -333,7 +333,7 @@ exit:
 static PyObject *Py_RankFilter(PyObject *obj, PyObject *args)
 {
     PyArrayObject *input = NULL, *output = NULL, *footprint = NULL;
-    PyArray_Dims origin;
+    PyArray_Dims origin = {NULL, 0};
     int mode, rank;
     double cval;
 
@@ -528,7 +528,7 @@ static PyObject *Py_GenericFilter(PyObject *obj, PyObject *args)
     void *func = NULL, *data = NULL;
     NI_PythonCallbackData cbdata;
     int mode;
-    PyArray_Dims origin;
+    PyArray_Dims origin = {NULL, 0};
     double cval;
     ccallback_t callback;
     static ccallback_signature_t callback_signatures[] = {
@@ -1063,7 +1063,7 @@ static PyObject *Py_BinaryErosion(PyObject *obj, PyObject *args)
     int border_value, invert, center_is_true;
     int changed = 0, return_coordinates;
     NI_CoordinateList *coordinate_list = NULL;
-    PyArray_Dims origin;
+    PyArray_Dims origin = {NULL, 0};
 
     if (!PyArg_ParseTuple(args, "O&O&O&O&iO&iii",
                           NI_ObjectToInputArray, &input,
@@ -1113,7 +1113,7 @@ static PyObject *Py_BinaryErosion2(PyObject *obj, PyObject *args)
     PyArrayObject *array = NULL, *strct = NULL, *mask = NULL;
     PyObject *cobj = NULL;
     int invert, niter;
-    PyArray_Dims origin;
+    PyArray_Dims origin = {NULL, 0};
 
     if (!PyArg_ParseTuple(args, "O&O&O&iO&iO",
                           NI_ObjectToInputOutputArray, &array,

--- a/scipy/ndimage/tests/test_morphology.py
+++ b/scipy/ndimage/tests/test_morphology.py
@@ -9,6 +9,7 @@ def test_binary_erosion_noninteger_iterations():
     # non integer iterations
     data = numpy.ones([1])
     assert_raises(TypeError, sndi.binary_erosion, data, iterations=0.5)
+    assert_raises(TypeError, sndi.binary_erosion, data, iterations=1.5)
 
 
 def test_binary_dilation_noninteger_iterations():
@@ -16,6 +17,7 @@ def test_binary_dilation_noninteger_iterations():
     # non integer iterations
     data = numpy.ones([1])
     assert_raises(TypeError, sndi.binary_dilation, data, iterations=0.5)
+    assert_raises(TypeError, sndi.binary_dilation, data, iterations=1.5)
 
 
 def test_binary_opening_noninteger_iterations():
@@ -23,6 +25,7 @@ def test_binary_opening_noninteger_iterations():
     # non integer iterations
     data = numpy.ones([1])
     assert_raises(TypeError, sndi.binary_opening, data, iterations=0.5)
+    assert_raises(TypeError, sndi.binary_opening, data, iterations=1.5)
 
 
 def test_binary_closing_noninteger_iterations():
@@ -30,3 +33,17 @@ def test_binary_closing_noninteger_iterations():
     # non integer iterations
     data = numpy.ones([1])
     assert_raises(TypeError, sndi.binary_closing, data, iterations=0.5)
+    assert_raises(TypeError, sndi.binary_closing, data, iterations=1.5)
+
+
+def test_binary_closing_noninteger_brute_force_passes_when_true():
+    # regression test for gh-9905, gh-9909: ValueError for
+    # non integer iterations
+    data = numpy.ones([1])
+
+    assert sndi.binary_erosion(
+        data, iterations=2, brute_force=1.5
+    ) == sndi.binary_erosion(data, iterations=2, brute_force=bool(1.5))
+    assert sndi.binary_erosion(
+        data, iterations=2, brute_force=0.0
+    ) == sndi.binary_erosion(data, iterations=2, brute_force=bool(0.0))

--- a/scipy/ndimage/tests/test_morphology.py
+++ b/scipy/ndimage/tests/test_morphology.py
@@ -1,0 +1,32 @@
+import numpy
+from pytest import raises as assert_raises
+
+import scipy.ndimage as sndi
+
+
+def test_binary_erosion_noninteger_iterations():
+    # regression test for gh-9905, gh-9909: ValueError for
+    # non integer iterations
+    data = numpy.ones([1])
+    assert_raises(TypeError, sndi.binary_erosion, data, iterations=0.5)
+
+
+def test_binary_dilation_noninteger_iterations():
+    # regression test for gh-9905, gh-9909: ValueError for
+    # non integer iterations
+    data = numpy.ones([1])
+    assert_raises(TypeError, sndi.binary_dilation, data, iterations=0.5)
+
+
+def test_binary_opening_noninteger_iterations():
+    # regression test for gh-9905, gh-9909: ValueError for
+    # non integer iterations
+    data = numpy.ones([1])
+    assert_raises(TypeError, sndi.binary_opening, data, iterations=0.5)
+
+
+def test_binary_closing_noninteger_iterations():
+    # regression test for gh-9905, gh-9909: ValueError for
+    # non integer iterations
+    data = numpy.ones([1])
+    assert_raises(TypeError, sndi.binary_closing, data, iterations=0.5)


### PR DESCRIPTION
Addresses #9905 and #9909 

Avoids the resulting memory error by raising on non-integer inputs by using operator.index