### PR TITLE
Update link to airspeed-velocity

### DIFF
--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -76,7 +76,7 @@ def run_asv(args):
     except OSError as err:
         if err.errno == errno.ENOENT:
             print("Error when running '%s': %s\n" % (" ".join(cmd), str(err),))
-            print("You need to install Airspeed Velocity https://spacetelescope.github.io/asv/")
+            print("You need to install Airspeed Velocity https://airspeed-velocity.github.io/asv/")
             print("to run Scipy benchmarks")
             return 1
         raise


### PR DESCRIPTION
The current link was dead. The updated link redirects to https://asv.readthedocs.io