### PR TITLE
DOC: Update `interpolate.LSQSphereBivariateSpline` to include degree

### DIFF
--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -1393,6 +1393,9 @@ class LSQSphereBivariateSpline(SphereBivariateSpline):
     """
     Weighted least-squares bivariate spline approximation in spherical
     coordinates.
+    
+    Determines a smooth bicubic spline according to a given
+    set of knots in the `theta` and `phi` directions.
 
     .. versionadded:: 0.11.0
 


### PR DESCRIPTION
Add that the splines are "bicubic" to the description of the class.
Closes #9349.

`interpolate.LSQSphereBivariateSpline` calls a function `dfitpack.spherfit_lsq()` (see [the source](https://github.com/scipy/scipy/blob/master/scipy/interpolate/fitpack2.py#L1475) to verify). The `spherfit_lsq` [source](https://github.com/scipy/scipy/blob/master/scipy/interpolate/src/fitpack.pyf#L571) shows it's a wrapper for a fortran subroutine called `sphere.f`, using an option `iopt=-1`. The `sphere.f` [source](https://github.com/scipy/scipy/blob/master/scipy/interpolate/fitpack/sphere.f#L4) states that it determines "smooth bicubic spherical splines" and option `iopt=-1` "calculates a weighted least-squares spline according to a given set of knots..."