### PR TITLE
MAINT: special: Fix a few warnings that occur when compiling the cephes code.

### DIFF
--- a/scipy/special/cephes/hyp2f1.c
+++ b/scipy/special/cephes/hyp2f1.c
@@ -604,7 +604,6 @@ static double hyp2f1ra(double a, double b, double c, double x,
 static double hyp2f1_neg_c_equal_bc(double a, double b, double x)
 {
     double k;
-    double err;
     double collector = 1;
     double sum = 1;
     double collector_max = 1;

--- a/scipy/special/cephes/igam.c
+++ b/scipy/special/cephes/igam.c
@@ -120,7 +120,6 @@ static double big = 4.503599627370496e15;
 static double biginv = 2.22044604925031308085e-16;
 
 static double igamc_continued_fraction(double, double);
-static double igam_leading_factor(double, double);
 static double igam_series(double, double);
 static double igamc_series(double, double);
 static double asymptotic_series(double, double, int);

--- a/scipy/special/cephes/mtherr.c
+++ b/scipy/special/cephes/mtherr.c
@@ -80,7 +80,7 @@ void mtherr(const char *name, int code)
     /* Display error message defined
      * by the code argument.
      */
-    if (code <= 0 || code >= sizeof(conv_to_sf) / sizeof(conv_to_sf[0])) {
+    if (code <= 0 || (unsigned long) code >= sizeof(conv_to_sf) / sizeof(conv_to_sf[0])) {
         code = 0;
     }
 

--- a/scipy/special/cephes/polevl.h
+++ b/scipy/special/cephes/polevl.h
@@ -64,11 +64,11 @@
 #include "cephes.h"
 #include <numpy/npy_common.h>
 
-static NPY_INLINE double polevl(double x, double coef[], int N)
+static NPY_INLINE double polevl(double x, const double coef[], int N)
 {
     double ans;
     int i;
-    double *p;
+    const double *p;
 
     p = coef;
     ans = *p++;
@@ -87,10 +87,10 @@ static NPY_INLINE double polevl(double x, double coef[], int N)
  * Otherwise same as polevl.
  */
 
-static NPY_INLINE double p1evl(double x, double coef[], int N)
+static NPY_INLINE double p1evl(double x, const double coef[], int N)
 {
     double ans;
-    double *p;
+    const double *p;
     int i;
 
     p = coef;
@@ -106,12 +106,13 @@ static NPY_INLINE double p1evl(double x, double coef[], int N)
 
 /* Evaluate a rational function. See [1]. */
 
-static NPY_INLINE double ratevl(double x, double num[], int M, double denom[], int N)
+static NPY_INLINE double ratevl(double x, const double num[], int M,
+                                          const double denom[], int N)
 {
     int i, dir;
     double y, num_ans, denom_ans;
     double absx = fabs(x);
-    double *p;
+    const double *p;
 
     if (absx > 1) {
 	/* Evaluate as a polynomial in 1/x. */


### PR DESCRIPTION

* Removed the unused variable `err` in the function `hyp2f1_neg_c_equal_bc`
  in hyp2f1.c to fix:

      scipy/special/cephes/hyp2f1.c:607:12: warning: unused variable 'err' [-Wunused-variable]
          double err;
                 ^

* Removed the unused function prototype for `igam_leading_factor` in igam.c
  to fix:

      scipy/special/cephes/igam.c:123:15: warning: unused function 'igam_leading_factor' [-Wunused-function]
      static double igam_leading_factor(double, double);
                    ^

* Add a cast of `code` to `unsigned long` in the function `mtherr` in mtherr.c
  to fix:

      scipy/special/cephes/mtherr.c:83:27: warning: comparison of integers of different signs: 'int' and 'unsigned long' [-Wsign-compare]
          if (code <= 0 || code >= sizeof(conv_to_sf) / sizeof(conv_to_sf[0])) {
                           ~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

* Add `const` qualifiers where needed in the functions in polevl.h to fix
  several warnings of the form:

      scipy/special/cephes/expn.c:216:28: warning: passing 'const double *' to parameter of type 'double *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
              term = fac*polevl(lambda, A[k], Adegs[k]);
                                        ^~~~
      scipy/special/cephes/polevl.h:67:50: note: passing argument to parameter 'coef' here
      static NPY_INLINE double polevl(double x, double coef[], int N)