### PR TITLE
ENH: faster directed_hausdorff

### DIFF
--- a/scipy/spatial/_hausdorff.pyx
+++ b/scipy/spatial/_hausdorff.pyx
@@ -7,6 +7,9 @@ Directed Hausdorff Code
 #
 # Copyright (C)  Tyler Reddy, Richard Gowers, and Max Linke, 2016
 #
+# For the supporting index shuffling algorithm:
+# Copyright (C) Ben Pfaff, 2004.
+#
 # Distributed under the same BSD license as Scipy.
 #
 
@@ -16,56 +19,76 @@ import numpy as np
 cimport numpy as np
 cimport cython
 from libc.math cimport sqrt
+from libc.stdlib cimport srand, rand, RAND_MAX
+from libc.limits cimport UINT_MAX
 
 __all__ = ['directed_hausdorff']
 
+cdef extern from "numpy/npy_math.h":
+    double inf "NPY_INFINITY"
+
+@cython.wraparound(False)
 @cython.boundscheck(False)
-def directed_hausdorff(double[:,::1] ar1, double[:,::1] ar2, seed=0):
+@cython.cdivision(True)
+cdef void index_shuffler(long [::1] arr, size_t size):
+    cdef:
+        size_t i = 0
+        size_t j
+        int t
+
+    while i < (size - 1):
+        j = i + rand() / (RAND_MAX / (size - i) + 1)
+        t = arr[j]
+        arr[j] = arr[i]
+        arr[i] = t
+        i += 1
+
+@cython.wraparound(False)
+@cython.boundscheck(False)
+def directed_hausdorff(const double[:,::1] ar1,
+                       const double[:,::1] ar2,
+                       seed=0):
 
     cdef double cmax, cmin, d
-    cdef bint no_break_occurred
     cdef int N1 = ar1.shape[0]
     cdef int N2 = ar2.shape[0]
     cdef int data_dims = ar1.shape[1]
     cdef unsigned int i, j, k
     cdef unsigned int i_store = 0, j_store = 0, i_ret = 0, j_ret = 0
-    cdef long[:] resort1, resort2
+    cdef long[::1] resort1 = np.arange(N1)
+    cdef long[::1] resort2 = np.arange(N2)
 
     # shuffling the points in each array generally increases the likelihood of
     # an advantageous break in the inner search loop and never decreases the
     # performance of the algorithm
     rng = np.random.RandomState(seed)
-    resort1 = np.arange(N1)
-    resort2 = np.arange(N2)
-    rng.shuffle(resort1)
-    rng.shuffle(resort2)
-    ar1 = np.asarray(ar1)[resort1]
-    ar2 = np.asarray(ar2)[resort2]
+    srand(rng.randint(UINT_MAX, dtype=np.uint64))
+    index_shuffler(resort1, N1)
+    index_shuffler(resort2, N2)
 
     cmax = 0
     for i in range(N1):
-        no_break_occurred = True
-        cmin = np.inf
+        cmin = inf
         for j in range(N2):
-            d = 0
+            d = (ar1[resort1[i], 0] - ar2[resort2[j], 0])**2
 	    # faster performance with square of distance
 	    # avoid sqrt until very end
-            for k in range(data_dims):
-                d += (ar1[i, k] - ar2[j, k])**2
+            for k in range(1, data_dims):
+                d += (ar1[resort1[i], k] - ar2[resort2[j], k])**2
             if d < cmax: # break out of `for j` loop
-                no_break_occurred = False
+                cmin = -inf
                 break
 
             if d < cmin: # always true on first iteration of for-j loop
                 cmin = d
-                i_store = i
-                j_store = j
+                i_store = resort1[i]
+                j_store = resort2[j]
 
         # always true on first iteration of for-j loop, after that only
         # if d >= cmax
-        if cmin != np.inf and cmin > cmax and no_break_occurred == True:
+        if cmin > cmax:
             cmax = cmin
             i_ret = i_store
             j_ret = j_store
 
-    return (sqrt(cmax), resort1[i_ret], resort2[j_ret])
+    return (sqrt(cmax), i_ret, j_ret)

--- a/scipy/spatial/tests/test_hausdorff.py
+++ b/scipy/spatial/tests/test_hausdorff.py
@@ -123,3 +123,13 @@ class TestHausdorff(object):
         B = np.random.rand(4, 5)
         with pytest.raises(ValueError):
             directed_hausdorff(A, B)
+
+    def test_readonly_arrays(self):
+        # Cython code should be able to accept
+        # read-only buffers
+        self.path_1.flags.writeable = False
+        self.path_2.flags.writeable = False
+        actual = directed_hausdorff(self.path_1, self.path_2)[0]
+        expected = max(np.amin(distance.cdist(self.path_1, self.path_2),
+                               axis=1))
+        assert_almost_equal(actual, expected, decimal=9)


### PR DESCRIPTION
Need to address at least two things here:

- [x] make faster for very small data sets as well (is this possible without dispatching to separate functions at some size threshold?)
- [x] add a unit test for the read-only buffer handling enhancement

~Much faster for large data sets, but slower for very small:~

```
       before           after         ratio
     [1f5dd630]       [28ed1501]
     <master>         <hausdorff_cython_improve>
+     29.6±0.08μs         61.3±3μs     2.07  spatial.Hausdorff.time_directed_hausdorff(10)
-       112±0.7μs         66.8±2μs     0.60  spatial.Hausdorff.time_directed_hausdorff(100)
-     1.32±0.01ms          466±1μs     0.35  spatial.Hausdorff.time_directed_hausdorff(1000)
```

The full summary of advantages, which I should also summarize in the final commit message if this is ever good enough:

- use `NPY_INFINITY` from a C header file to avoid overhead calls to `np.inf`
- add support for read-only array input
- remove the awkward `no_break_occurred` variable
- ~remove extraneous `i_store` and `j_store` variables~
- reduce 6 shuffling-related Python overhead calls to 2, by using `permutation` on the indices--there's no need to shuffle the arrays themselves as long as the iteration happens in shuffled order
- simplify the control flow guard on infinity propagation to `cmax` by setting `cmin=-inf` prior to a break

It would be amazing if we had access to true Cython-level shuffled range(). Perhaps the associated overhead will drop with new randomgen efforts upstream.