### PR TITLE
ENH: Introduce CubicHermiteSpline

### DIFF
--- a/scipy/interpolate/__init__.py
+++ b/scipy/interpolate/__init__.py
@@ -22,10 +22,11 @@ Univariate interpolation
    interp1d
    BarycentricInterpolator
    KroghInterpolator
-   PchipInterpolator
    barycentric_interpolate
    krogh_interpolate
    pchip_interpolate
+   CubicHermiteSpline
+   PchipInterpolator
    Akima1DInterpolator
    CubicSpline
    PPoly

--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -61,7 +61,7 @@ def validate_input(x, y, axis, dydx=None):
     if dydx is not None:
         dydx = np.rollaxis(dydx, axis)
 
-    return x, dx, y, dydx
+    return x, dx, y, axis, dydx
 
 
 class CubicHermiteSpline(PPoly):
@@ -129,7 +129,7 @@ class CubicHermiteSpline(PPoly):
         if extrapolate is None:
             extrapolate = True
 
-        x, dx, y, dydx = validate_input(x, y, axis, dydx)
+        x, dx, y, axis, dydx = validate_input(x, y, axis, dydx)
 
         dxr = dx.reshape([dx.shape[0]] + [1] * (y.ndim - 1))
         slope = np.diff(y, axis=0) / dxr
@@ -403,7 +403,7 @@ class Akima1DInterpolator(CubicHermiteSpline):
     def __init__(self, x, y, axis=0):
         # Original implementation in MATLAB by N. Shamsundar (BSD licensed), see
         # https://www.mathworks.com/matlabcentral/fileexchange/1814-akima-interpolation
-        x, dx, y, _ = validate_input(x, y, axis)
+        x, dx, y, axis, _ = validate_input(x, y, axis)
         # determine slopes between breakpoints
         m = np.empty((x.size + 3, ) + y.shape[1:])
         dx = dx[(slice(None), ) + (None, ) * (y.ndim - 1)]
@@ -617,7 +617,7 @@ class CubicSpline(CubicHermiteSpline):
     .. [2] Carl de Boor, "A Practical Guide to Splines", Springer-Verlag, 1978.
     """
     def __init__(self, x, y, axis=0, bc_type='not-a-knot', extrapolate=None):
-        x, dx, y, _ = validate_input(x, y, axis)
+        x, dx, y, axis, _ = validate_input(x, y, axis)
         n = len(x)
 
         bc, y = self._validate_bc(bc_type, y, y.shape[1:], axis)

--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -59,7 +59,7 @@ def prepare_input(x, y, axis, dydx=None):
         raise ValueError("`y` must contain only finite values.")
 
     if dydx is not None and not np.all(np.isfinite(dydx)):
-            raise ValueError("`dydx` must contain only finite values.")
+        raise ValueError("`dydx` must contain only finite values.")
 
     dx = np.diff(x)
     if np.any(dx <= 0):

--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -127,6 +127,11 @@ class CubicHermiteSpline(PPoly):
     CubicSpline
     PPoly
 
+    Notes
+    -----
+    If you want to create a higher-order spline matching higher-order
+    derivatives, use `BPoly.from_derivatives`.
+
     References
     ----------
     .. [1] `Cubic Hermite spline

--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -65,7 +65,7 @@ def validate_input(x, y, axis, dydx=None):
 
 
 class CubicHermiteSpline(PPoly):
-    """Cubic interpolator which matches values and first derivatives.
+    """Piecewise-cubic interpolator matching values and first derivatives.
 
     The result is represented as a `PPoly` instance.
 

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -12,8 +12,9 @@ from pytest import raises as assert_raises
 from scipy.interpolate import (
     KroghInterpolator, krogh_interpolate,
     BarycentricInterpolator, barycentric_interpolate,
-    approximate_taylor_polynomial, pchip, PchipInterpolator,
-    pchip_interpolate, Akima1DInterpolator, CubicSpline, make_interp_spline)
+    approximate_taylor_polynomial, CubicHermiteSpline, pchip,
+    PchipInterpolator, pchip_interpolate, Akima1DInterpolator, CubicSpline,
+    make_interp_spline)
 
 from scipy._lib.six import xrange
 
@@ -480,6 +481,7 @@ class TestPCHIP(object):
         r = p.roots()
         assert_allclose(r, 0.5)
 
+
 class TestCubicSpline(object):
     @staticmethod
     def check_correctness(S, bc_start='not-a-knot', bc_end='not-a-knot',
@@ -662,3 +664,11 @@ class TestCubicSpline(object):
         # periodic condition, y[-1] must be equal to y[0]:
         assert_raises(ValueError, CubicSpline, x, y, 0, 'periodic', True)
 
+
+def test_CubicHermiteSpline():
+    x = [0, 2, 7]
+    y = [-1, 2, 3]
+    dydx = [0, 3, 7]
+    s = CubicHermiteSpline(x, y, dydx)
+    assert_allclose(s(x), y)
+    assert_allclose(s(x, 1), dydx)

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -670,5 +670,5 @@ def test_CubicHermiteSpline():
     y = [-1, 2, 3]
     dydx = [0, 3, 7]
     s = CubicHermiteSpline(x, y, dydx)
-    assert_allclose(s(x), y)
-    assert_allclose(s(x, 1), dydx)
+    assert_allclose(s(x), y, rtol=1e-15)
+    assert_allclose(s(x, 1), dydx, rtol=1e-15)

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -676,10 +676,20 @@ class TestCubicSpline(object):
         assert_raises(ValueError, CubicSpline, x, y, 0, 'periodic', True)
 
 
-def test_CubicHermiteSpline():
+def test_CubicHermiteSpline_correctness():
     x = [0, 2, 7]
     y = [-1, 2, 3]
     dydx = [0, 3, 7]
     s = CubicHermiteSpline(x, y, dydx)
     assert_allclose(s(x), y, rtol=1e-15)
     assert_allclose(s(x, 1), dydx, rtol=1e-15)
+
+
+def test_CubicHermiteSpline_error_handling():
+    x = [1, 2, 3]
+    y = [0, 3, 5]
+    dydx = [1, -1, 2, 3]
+    assert_raises(ValueError, CubicHermiteSpline, x, y, dydx)
+
+    dydx_with_nan = [1, 0, np.nan]
+    assert_raises(ValueError, CubicHermiteSpline, x, y, dydx_with_nan)

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -370,7 +370,7 @@ class TestPCHIP(object):
                 y1, y2 = y2, y1
             xp = np.linspace(x1, x2, 10)
             yp = p(xp)
-            assert_(((y1 <= yp) & (yp <= y2)).all())
+            assert_(((y1 <= yp + 1e-15) & (yp <= y2 + 1e-15)).all())
 
     def test_monotone(self):
         # PCHIP should preserve monotonicty

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -142,16 +142,18 @@ def test_deriv_shapes():
                     check_shape(ip, s1, s2, (), axis)
 
 
-def _check_complex(ip):
+def test_complex():
     x = [1, 2, 3, 4]
     y = [1, 2, 1j, 3]
-    p = ip(x, y)
-    assert_allclose(y, p(x))
 
-
-def test_complex():
     for ip in [KroghInterpolator, BarycentricInterpolator, pchip, CubicSpline]:
-        _check_complex(ip)
+        p = ip(x, y)
+        assert_allclose(y, p(x))
+
+    dydx = [0, -1j, 2, 3j]
+    p = CubicHermiteSpline(x, y, dydx)
+    assert_allclose(y, p(x))
+    assert_allclose(dydx, p(x, 1))
 
 
 class TestKrogh(object):


### PR DESCRIPTION
If we consider `Akima1DInterpolator`, `PchipInterpolator` and `CubicSpline` they all are constructed in a similar way --- derivatives at the breakpoints are computed (specific to the algorithm) and then the coefficients of cubic polynomials are computed from values and derivatives.

So I decided to introduce a base class which is constructed from values and derivatives, namely `CubicHermiteSpline`. Besides that it is a useful interpolator on its own, when values and derivatives are known (say measured coordinates and velocities).

Some doubts and considerations:

1. Having `CubicSpline` and `CubicHermiteSpline` is a bit confusion. Is it OK this way? Can we get away by selecting a better name? 
2. There is a way to achieve similar by `BPoly.from_derivatives`. But it is not very transparent, I basically found out about it when implementing `HermiteCubicSpline`. 
3. `PchipInterpolator` was subclassed from `BPoly`, but then it required conversion to `PPoly` when calling `roots`. I don't think it is a clean enough approach. That is subclassing everything from `CubicHermiteSpline` makes better sense to me.


@ev-br what do you think about introduction of `CubicHermiteSpline`?




