### PR TITLE
BENCH: Increase cython version in asv to fix benchmark builds

### DIFF
--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -29,7 +29,7 @@
     "matrix": {
         "numpy": [],
         "Tempita": [],
-        "Cython": ["0.27.3"],
+        "Cython": ["0.29.2"],
         "pytest": [],
         "six": [],
     },


### PR DESCRIPTION
Attemping to run the benchmarks fails with the error
```
Building SciPy requires Cython >= 0.29.2, found 0.27.3
```
I believe this has started after #9924 adds a pyproject.toml file which tools/cythonize.py checks for the required version.