### PR TITLE
BUG: Avoid exponnorm producing nan for small K values. 

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -1407,7 +1407,7 @@ class exponnorm_gen(rv_continuous):
         # Avoid overflows; setting np.exp(exparg) to the max float works
         #  all right here
         expval = _lazywhere(exparg < _LOGXMAX, (exparg,), np.exp, _XMAX)
-        return 0.5 * invK * expval * sc.erfc(-(x - invK) / np.sqrt(2))
+        return 0.5 * invK * (expval * sc.erfc(-(x - invK) / np.sqrt(2)))
 
     def _logpdf(self, x, K):
         invK = 1.0 / K

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1331,6 +1331,9 @@ class TestExponNorm(object):
         # Test for extreme values against overflows
         assert_almost_equal(stats.exponnorm.pdf(-900, 1), 0.0)
         assert_almost_equal(stats.exponnorm.pdf(+900, 1), 0.0)
+        assert_almost_equal(stats.exponnorm.pdf(1, 0.01), 0.0)
+        assert_almost_equal(stats.exponnorm.pdf(-900, 0.01), 0.0)
+        assert_almost_equal(stats.exponnorm.pdf(+900, 0.01), 0.0)
 
 
 class TestGenExpon(object):


### PR DESCRIPTION
Fixes #10003 with the fix suggested by @ev-br.