### PR TITLE
ENH: optimize: use SuiteSparse in linprog interior-point when available

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,7 +1,7 @@
 # Makefile for Sphinx documentation
 #
 
-PYVER ?= 3.6
+PYVER ?= 3.7
 PYTHON = python$(PYVER)
 
 # You can set these variables from the command line.

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,7 +1,7 @@
 # Makefile for Sphinx documentation
 #
 
-PYVER ?= 3.7
+PYVER ?= 3.6
 PYTHON = python$(PYVER)
 
 # You can set these variables from the command line.

--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -286,7 +286,7 @@ def _get_delta(
                         "occasionally, especially as the solution is "
                         "approached. However, if you see this frequently, "
                         "consider setting option 'cholesky' to False.",
-                        OptimizeWarning, stacklevel=2)
+                        OptimizeWarning, stacklevel=5)
                 elif has_umfpack:
                     has_umfpack = False
                 elif sym_pos:
@@ -297,7 +297,7 @@ def _get_delta(
                         "occasionally, especially as the solution is "
                         "approached. However, if you see this frequently, "
                         "consider setting option 'sym_pos' to False.",
-                        OptimizeWarning, stacklevel=2)
+                        OptimizeWarning, stacklevel=5)
                 elif not lstsq:
                     lstsq = True
                     warn(
@@ -309,7 +309,7 @@ def _get_delta(
                         "If you cannot improve the formulation, consider "
                         "setting 'lstsq' to True. Consider also setting "
                         "`presolve` to True, if it is not already.",
-                        OptimizeWarning, stacklevel=2)
+                        OptimizeWarning, stacklevel=5)
                 else:
                     raise e
                 solve = _get_solver(M, sparse, lstsq, sym_pos,
@@ -1085,32 +1085,32 @@ def _linprog_ip(
         if cholesky:
             warn("Sparse cholesky is only available with scikit-sparse. "
                  "Setting `cholesky = False`",
-                 OptimizeWarning, stacklevel=2)
+                 OptimizeWarning, stacklevel=3)
         cholesky = False
 
     if sparse and lstsq:
         warn("Invalid option combination 'sparse':True "
              "and 'lstsq':True; Sparse least squares is not recommended.",
-             OptimizeWarning, stacklevel=2)
+             OptimizeWarning, stacklevel=3)
 
     if sparse and not sym_pos:
         warn("Invalid option combination 'sparse':True "
              "and 'sym_pos':False; the effect is the same as sparse least "
              "squares, which is not recommended.",
-             OptimizeWarning, stacklevel=2)
+             OptimizeWarning, stacklevel=3)
 
     if lstsq and cholesky:
         warn("Invalid option combination 'lstsq':True "
              "and 'cholesky':True; option 'cholesky' has no effect when "
              "'lstsq' is set True.",
-             OptimizeWarning, stacklevel=2)
+             OptimizeWarning, stacklevel=3)
 
     valid_permc_spec = ('NATURAL', 'MMD_ATA', 'MMD_AT_PLUS_A', 'COLAMD')
     if permc_spec.upper() not in valid_permc_spec:
         warn("Invalid permc_spec option: '" + str(permc_spec) + "'. "
              "Acceptable values are 'NATURAL', 'MMD_ATA', 'MMD_AT_PLUS_A', "
              "and 'COLAMD'. Reverting to default.",
-             OptimizeWarning, stacklevel=2)
+             OptimizeWarning, stacklevel=3)
         permc_spec = 'MMD_AT_PLUS_A'
 
     # This can be an error

--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -72,13 +72,13 @@ def _get_solver(M, sparse=False, lstsq=False, sym_pos=True,
     """
     try:
         if sparse:
-            if lstsq or not(sym_pos):
+            if lstsq:
                 def solve(r, sym_pos=False):
                     return sps.linalg.lsqr(M, r)[0]
             elif cholesky:
                 solve = cholmod(M)
             else:
-                if has_umfpack:
+                if has_umfpack and sym_pos:
                     solve = sps.linalg.factorized(M)
                 else:  # factorized doesn't pass permc_spec
                     solve = sps.linalg.splu(M, permc_spec=permc_spec).solve
@@ -999,9 +999,8 @@ def _linprog_ip(
     solvers are attempted in the order indicated. Attempting, failing, and
     re-starting factorization can be time consuming, so if the problem is
     numerically challenging, options can be set to  bypass solvers that are
-    failing. Setting ``cholesky=False`` bypasses solver 1 for both sparse and
-    dense problems. Setting ``sym_pos=False`` bypasses solver 2 for dense
-    problems and skips to solver 4 for sparse problems. ``lstsq=True`` skips
+    failing. Setting ``cholesky=False`` skips to solver 2,
+    ``sym_pos=False`` skips to solver 3, and ``lstsq=True`` skips
     to solver 4 for both sparse and dense problems.
 
     Potential improvements for combatting issues associated with dense
@@ -1091,12 +1090,6 @@ def _linprog_ip(
     if sparse and lstsq:
         warn("Invalid option combination 'sparse':True "
              "and 'lstsq':True; Sparse least squares is not recommended.",
-             OptimizeWarning, stacklevel=3)
-
-    if sparse and not sym_pos:
-        warn("Invalid option combination 'sparse':True "
-             "and 'sym_pos':False; the effect is the same as sparse least "
-             "squares, which is not recommended.",
              OptimizeWarning, stacklevel=3)
 
     if lstsq and cholesky:

--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -287,8 +287,6 @@ def _get_delta(
                         "approached. However, if you see this frequently, "
                         "consider setting option 'cholesky' to False.",
                         OptimizeWarning, stacklevel=5)
-                elif has_umfpack:
-                    has_umfpack = False
                 elif sym_pos:
                     sym_pos = False
                     warn(
@@ -951,7 +949,7 @@ def _linprog_ip(
     Notes
     -----
     This method implements the algorithm outlined in [4]_ with ideas from [8]_
-    and a structure inspired by the simpler methods of [6]_ and [4]_.
+    and a structure inspired by the simpler methods of [6]_.
 
     The primal-dual path following method begins with initial 'guesses' of
     the primal and dual variables of the standard form problem and iteratively
@@ -981,19 +979,19 @@ def _linprog_ip(
     With default options, the solver used to perform the factorization depends
     on third-party software availability and the conditioning of the problem.
 
-    For dense problems, solvers are tried in the following order.::
+    For dense problems, solvers are tried in the following order:
 
-        1: ``scipy.linalg.cho_factor`` (if scikit-sparse and SuiteSparse are installed)
-        2: ``scipy.linalg.solve`` with option ``sym_pos=True``
-        3: ``scipy.linalg.solve`` with option ``sym_pos=False``
-        4: ``scipy.linalg.lstsq``
+    1. ``scipy.linalg.cho_factor`` (if scikit-sparse and SuiteSparse are installed)
+    2. ``scipy.linalg.solve`` with option ``sym_pos=True``
+    3. ``scipy.linalg.solve`` with option ``sym_pos=False``
+    4. ``scipy.linalg.lstsq``
 
     For sparse problems::
 
-        1: ``sksparse.cholmod.cholesky`` (if scikit-sparse and SuiteSparse are installed)
-        2: ``scipy.sparse.linalg.factorized`` (if scikits.umfpack and SuiteSparse are installed)
-        3: ``scipy.sparse.linalg.splu`` (which uses SuperLU distributed with SciPy)
-        4: ``scipy.sparse.linalg.lsqr``
+    1. ``sksparse.cholmod.cholesky`` (if scikit-sparse and SuiteSparse are installed)
+    2. ``scipy.sparse.linalg.factorized`` (if scikits.umfpack and SuiteSparse are installed)
+    3. ``scipy.sparse.linalg.splu`` (which uses SuperLU distributed with SciPy)
+    4. ``scipy.sparse.linalg.lsqr``
 
     If the solver fails for any reason, successively more robust (but slower)
     solvers are attempted in the order indicated. Attempting, failing, and

--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -26,15 +26,14 @@ from warnings import warn
 from scipy.linalg import LinAlgError
 from .optimize import OptimizeWarning, OptimizeResult, _check_unknown_options
 from ._linprog_util import _postsolve
+has_umfpack = True
+has_cholmod = True
 try:
     from sksparse.cholmod import cholesky as cholmod
-    has_cholmod = True
 except ImportError:
     has_cholmod = False
-has_umfpack = False
 try:
-    import scikits.umfpack as umfpack  # test whether to use factorized
-    has_umfpack = True
+    import scikits.umfpack  # test whether to use factorized
 except ImportError:
     has_umfpack = False
 
@@ -191,8 +190,6 @@ def _get_delta(
            2000. 197-232.
 
     """
-    global has_umfpack
-
     if A.shape[0] == 0:
         # If there are no constraints, some solvers fail (understandably)
         # rather than returning empty solution. This gets the job done.
@@ -1094,8 +1091,8 @@ def _linprog_ip(
         cholesky = False
 
     if sparse and lstsq:
-        warn("Invalid option combination 'sparse':True "
-             "and 'lstsq':True; Sparse least squares is not recommended.",
+        warn("Option combination 'sparse':True and 'lstsq':True "
+             "is not recommended.",
              OptimizeWarning, stacklevel=3)
 
     if lstsq and cholesky:

--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -286,7 +286,7 @@ def _get_delta(
                         "occasionally, especially as the solution is "
                         "approached. However, if you see this frequently, "
                         "consider setting option 'cholesky' to False.",
-                        OptimizeWarning)
+                        OptimizeWarning, stacklevel=2)
                 elif has_umfpack:
                     has_umfpack = False
                 elif sym_pos:
@@ -297,7 +297,7 @@ def _get_delta(
                         "occasionally, especially as the solution is "
                         "approached. However, if you see this frequently, "
                         "consider setting option 'sym_pos' to False.",
-                        OptimizeWarning)
+                        OptimizeWarning, stacklevel=2)
                 elif not lstsq:
                     lstsq = True
                     warn(
@@ -309,7 +309,7 @@ def _get_delta(
                         "If you cannot improve the formulation, consider "
                         "setting 'lstsq' to True. Consider also setting "
                         "`presolve` to True, if it is not already.",
-                        OptimizeWarning)
+                        OptimizeWarning, stacklevel=2)
                 else:
                     raise e
                 solve = _get_solver(M, sparse, lstsq, sym_pos,

--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -261,8 +261,8 @@ def _get_delta(
         # For sparse systems, the order is:
         # 1. sksparse.cholmod.cholesky (if available)
         # 2. scipy.sparse.linalg.factorized (if umfpack available)
-        #    scipy.sparse.linalg.splu (otherwise)
-        # 3. scipy.sparse.linalg.lsqr
+        # 3. scipy.sparse.linalg.splu
+        # 4. scipy.sparse.linalg.lsqr
         solved = False
         while(not solved):
             try:
@@ -982,15 +982,21 @@ def _linprog_ip(
     For dense problems, solvers are tried in the following order:
 
     1. ``scipy.linalg.cho_factor`` (if scikit-sparse and SuiteSparse are installed)
+    
     2. ``scipy.linalg.solve`` with option ``sym_pos=True``
+    
     3. ``scipy.linalg.solve`` with option ``sym_pos=False``
+    
     4. ``scipy.linalg.lstsq``
 
-    For sparse problems::
+    For sparse problems:
 
     1. ``sksparse.cholmod.cholesky`` (if scikit-sparse and SuiteSparse are installed)
+    
     2. ``scipy.sparse.linalg.factorized`` (if scikits.umfpack and SuiteSparse are installed)
+    
     3. ``scipy.sparse.linalg.splu`` (which uses SuperLU distributed with SciPy)
+    
     4. ``scipy.sparse.linalg.lsqr``
 
     If the solver fails for any reason, successively more robust (but slower)

--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -101,6 +101,8 @@ def _get_solver(M, sparse=False, lstsq=False, sym_pos=True,
     # what all of them are. It doesn't really matter: if the matrix can't be
     # factorized, return None. get_solver will be called again with different
     # inputs, and a new routine will try to factorize the matrix.
+    except KeyboardInterrupt:
+        raise
     except Exception:
         return None
     return solve

--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -79,7 +79,7 @@ def _get_solver(M, sparse=False, lstsq=False, sym_pos=True,
             else:
                 if has_umfpack:
                     solve = sps.linalg.factorized(M)
-                else: # factorized doesn't pass permc_spec
+                else:  # factorized doesn't pass permc_spec
                     solve = sps.linalg.splu(M, permc_spec=permc_spec).solve
 
         else:
@@ -96,7 +96,11 @@ def _get_solver(M, sparse=False, lstsq=False, sym_pos=True,
                 # with multiple right hand sides is much faster
                 def solve(r, sym_pos=sym_pos):
                     return sp.linalg.solve(M, r, sym_pos=sym_pos)
-    except:
+    # There are many things that can go wrong here, and it's hard to say
+    # what all of them are. It doesn't really matter: if the matrix can't be
+    # factorized, return None. get_solver will be called again with different
+    # inputs, and a new routine will try to factorize the matrix.
+    except Exception:
         return None
     return solve
 
@@ -276,35 +280,35 @@ def _get_delta(
                 if cholesky:
                     cholesky = False
                     warn(
-                    "Solving system with option 'cholesky':True "
-                    "failed. It is normal for this to happen "
-                    "occasionally, especially as the solution is "
-                    "approached. However, if you see this frequently, "
-                    "consider setting option 'cholesky' to False.",
-                    OptimizeWarning)
+                        "Solving system with option 'cholesky':True "
+                        "failed. It is normal for this to happen "
+                        "occasionally, especially as the solution is "
+                        "approached. However, if you see this frequently, "
+                        "consider setting option 'cholesky' to False.",
+                        OptimizeWarning)
                 elif has_umfpack:
                     has_umfpack = False
                 elif sym_pos:
                     sym_pos = False
                     warn(
-                    "Solving system with option 'sym_pos':True "
-                    "failed. It is normal for this to happen "
-                    "occasionally, especially as the solution is "
-                    "approached. However, if you see this frequently, "
-                    "consider setting option 'sym_pos' to False.",
-                    OptimizeWarning)
+                        "Solving system with option 'sym_pos':True "
+                        "failed. It is normal for this to happen "
+                        "occasionally, especially as the solution is "
+                        "approached. However, if you see this frequently, "
+                        "consider setting option 'sym_pos' to False.",
+                        OptimizeWarning)
                 elif not lstsq:
                     lstsq = True
                     warn(
-                    "Solving system with option 'sym_pos':False "
-                    "failed. This may happen occasionally, "
-                    "especially as the solution is "
-                    "approached. However, if you see this frequently, "
-                    "your problem may be numerically challenging. "
-                    "If you cannot improve the formulation, consider "
-                    "setting 'lstsq' to True. Consider also setting "
-                    "`presolve` to True, if it is not already.",
-                    OptimizeWarning)
+                        "Solving system with option 'sym_pos':False "
+                        "failed. This may happen occasionally, "
+                        "especially as the solution is "
+                        "approached. However, if you see this frequently, "
+                        "your problem may be numerically challenging. "
+                        "If you cannot improve the formulation, consider "
+                        "setting 'lstsq' to True. Consider also setting "
+                        "`presolve` to True, if it is not already.",
+                        OptimizeWarning)
                 else:
                     raise e
                 solve = _get_solver(M, sparse, lstsq, sym_pos,
@@ -972,7 +976,8 @@ def _linprog_ip(
     matrices involved are symmetric positive definite, so Cholesky
     decomposition can be used rather than the more expensive LU factorization.
 
-    With the default ``cholesky=True``, this is accomplished using
+    For dense problems,
+    and with the default ``cholesky=True``, this is accomplished using
     ``scipy.linalg.cho_factor`` followed by forward/backward substitutions
     via ``scipy.linalg.cho_solve``. With ``cholesky=False`` and
     ``sym_pos=True``, Cholesky decomposition is performed instead by

--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -29,13 +29,13 @@ from ._linprog_util import _postsolve
 try:
     from sksparse.cholmod import cholesky as cholmod
     has_cholmod = True
-except:
+except Exception:
     has_cholmod = False
 has_umfpack = False
 try:
     import scikits.umfpack as umfpack
     has_umfpack = True
-except:
+except Exception:
     has_umfpack = False
 
 def _get_solver(M, sparse=False, lstsq=False, sym_pos=True,
@@ -1081,9 +1081,10 @@ def _linprog_ip(
 
     # These should be warnings, not errors
     if (cholesky or cholesky is None) and sparse and not has_cholmod:
-        warn("Sparse cholesky is only available with scikit-sparse. Setting "
-             "`cholesky = False`",
-             OptimizeWarning)
+        if cholesky:
+            warn("Sparse cholesky is only available with scikit-sparse. "
+                 "Setting `cholesky = False`",
+                 OptimizeWarning)
         cholesky = False
 
     if sparse and lstsq:

--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -46,22 +46,33 @@ def _get_solver(M, sparse=False, lstsq=False, sym_pos=True,
 
     Parameters
     ----------
-    sparse : bool
+    M : 2D array
+        As defined in [4] Equation 8.31
+    sparse : bool (default = False)
         True if the system to be solved is sparse. This is typically set
         True when the original ``A_ub`` and ``A_eq`` arrays are sparse.
-    lstsq : bool
+    lstsq : bool (default = False)
         True if the system is ill-conditioned and/or (nearly) singular and
         thus a more robust least-squares solver is desired. This is sometimes
         needed as the solution is approached.
-    sym_pos : bool
+    sym_pos : bool (default = True)
         True if the system matrix is symmetric positive definite
         Sometimes this needs to be set false as the solution is approached,
         even when the system should be symmetric positive definite, due to
         numerical difficulties.
-    cholesky : bool
+    cholesky : bool (default = True)
         True if the system is to be solved by Cholesky, rather than LU,
         decomposition. This is typically faster unless the problem is very
         small or prone to numerical difficulties.
+    permc_spec : str (default = 'MMD_AT_PLUS_A')
+        Sparsity preservation strategy used by SuperLU. Acceptable values are:
+
+        - ``NATURAL``: natural ordering.
+        - ``MMD_ATA``: minimum degree ordering on the structure of A^T A.
+        - ``MMD_AT_PLUS_A``: minimum degree ordering on the structure of A^T+A.
+        - ``COLAMD``: approximate minimum degree column ordering.
+
+        See SuperLU documentation.
 
     Returns
     -------
@@ -981,21 +992,21 @@ def _linprog_ip(
     For dense problems, solvers are tried in the following order:
 
     1. ``scipy.linalg.cho_factor`` (if scikit-sparse and SuiteSparse are installed)
-    
+
     2. ``scipy.linalg.solve`` with option ``sym_pos=True``
-    
+
     3. ``scipy.linalg.solve`` with option ``sym_pos=False``
-    
+
     4. ``scipy.linalg.lstsq``
 
     For sparse problems:
 
     1. ``sksparse.cholmod.cholesky`` (if scikit-sparse and SuiteSparse are installed)
-    
+
     2. ``scipy.sparse.linalg.factorized`` (if scikits.umfpack and SuiteSparse are installed)
-    
+
     3. ``scipy.sparse.linalg.splu`` (which uses SuperLU distributed with SciPy)
-    
+
     4. ``scipy.sparse.linalg.lsqr``
 
     If the solver fails for any reason, successively more robust (but slower)

--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -29,17 +29,18 @@ from ._linprog_util import _postsolve
 try:
     from sksparse.cholmod import cholesky as cholmod
     has_cholmod = True
-except Exception:
+except ImportError:
     has_cholmod = False
 has_umfpack = False
 try:
-    import scikits.umfpack as umfpack
+    import scikits.umfpack as umfpack  # test whether to use factorized
     has_umfpack = True
-except Exception:
+except ImportError:
     has_umfpack = False
 
+
 def _get_solver(M, sparse=False, lstsq=False, sym_pos=True,
-                cholesky=True, permc_spec = 'MMD_AT_PLUS_A'):
+                cholesky=True, permc_spec='MMD_AT_PLUS_A'):
     """
     Given solver options, return a handle to the appropriate linear system
     solver.
@@ -1084,32 +1085,32 @@ def _linprog_ip(
         if cholesky:
             warn("Sparse cholesky is only available with scikit-sparse. "
                  "Setting `cholesky = False`",
-                 OptimizeWarning)
+                 OptimizeWarning, stacklevel=2)
         cholesky = False
 
     if sparse and lstsq:
         warn("Invalid option combination 'sparse':True "
              "and 'lstsq':True; Sparse least squares is not recommended.",
-             OptimizeWarning)
+             OptimizeWarning, stacklevel=2)
 
     if sparse and not sym_pos:
         warn("Invalid option combination 'sparse':True "
              "and 'sym_pos':False; the effect is the same as sparse least "
              "squares, which is not recommended.",
-             OptimizeWarning)
+             OptimizeWarning, stacklevel=2)
 
     if lstsq and cholesky:
         warn("Invalid option combination 'lstsq':True "
              "and 'cholesky':True; option 'cholesky' has no effect when "
              "'lstsq' is set True.",
-             OptimizeWarning)
+             OptimizeWarning, stacklevel=2)
 
     valid_permc_spec = ('NATURAL', 'MMD_ATA', 'MMD_AT_PLUS_A', 'COLAMD')
     if permc_spec.upper() not in valid_permc_spec:
         warn("Invalid permc_spec option: '" + str(permc_spec) + "'. "
              "Acceptable values are 'NATURAL', 'MMD_ATA', 'MMD_AT_PLUS_A', "
              "and 'COLAMD'. Reverting to default.",
-             OptimizeWarning)
+             OptimizeWarning, stacklevel=2)
         permc_spec = 'MMD_AT_PLUS_A'
 
     # This can be an error

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -11,6 +11,11 @@ from scipy.optimize import linprog, OptimizeWarning
 from scipy._lib._numpy_compat import _assert_warns, suppress_warnings
 from scipy.sparse.linalg import MatrixRankWarning
 from scipy.linalg import LinAlgWarning
+try:
+    from scikits.umfpack.umfpack import UmfpackWarning
+    has_umfpack = True
+except ModuleNotFoundError:
+    has_umfpack = False
 
 import pytest
 
@@ -823,6 +828,8 @@ class LinprogCommonTests(object):
         b_eq = [-4, 0, 0, 4]
 
         with suppress_warnings() as sup:
+            if has_umfpack:
+                sup.filter(RuntimeWarning, "(almost) singular matrix...")
             sup.filter(RuntimeWarning, "scipy.linalg.solve\nIll...")
             sup.filter(OptimizeWarning, "A_eq does not appear...")
             sup.filter(OptimizeWarning, "Solving system with option...")
@@ -1051,6 +1058,8 @@ class LinprogCommonTests(object):
             ])
 
         with suppress_warnings() as sup:
+            sup.filter(OptimizeWarning,
+                       "Solving system with option 'cholesky'")
             sup.filter(OptimizeWarning, "Solving system with option 'sym_pos'")
             sup.filter(RuntimeWarning, "invalid value encountered")
             sup.filter(LinAlgWarning)
@@ -1166,6 +1175,8 @@ class LinprogCommonTests(object):
         b_eq = np.array([[100], [0], [0], [0], [0]])
 
         with suppress_warnings() as sup:
+            if has_umfpack:
+                sup.filter(RuntimeWarning, "(almost) singular matrix...")
             sup.filter(OptimizeWarning, "A_eq does not appear...")
             res = linprog(c, A_ub, b_ub, A_eq, b_eq, bounds,
                           method=self.method, options=self.options)
@@ -1401,6 +1412,8 @@ class TestLinprogIPSparse(LinprogIPTests):
         bounds = (0, 1)
 
         with suppress_warnings() as sup:
+            if has_umfpack:
+                sup.filter(RuntimeWarning, "(almost) singular matrix...")
             sup.filter(MatrixRankWarning, "Matrix is exactly singular")
             sup.filter(OptimizeWarning, "Solving system with option...")
 

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -1468,6 +1468,7 @@ class TestLinprogIPSpecific(object):
         with suppress_warnings() as sup:
             sup.filter(RuntimeWarning, "scipy.linalg.solve\nIll...")
             sup.filter(OptimizeWarning, "Solving system with option...")
+            sup.filter(LinAlgWarning, "Ill-conditioned matrix...")
             res = linprog(c, A_ub=A, b_ub=b, method=self.method,
                           options={"ip": True, "disp": True})
             # ip code is independent of sparse/dense

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -824,7 +824,7 @@ class LinprogCommonTests(object):
 
         with suppress_warnings() as sup:
             # this is an UmfpackWarning but I had trouble importing it
-            sup.filter(RuntimeWarning, "(almost) singular matrix...")
+            sup.filter(Warning, "(almost) singular matrix...")
             sup.filter(RuntimeWarning, "scipy.linalg.solve\nIll...")
             sup.filter(OptimizeWarning, "A_eq does not appear...")
             sup.filter(OptimizeWarning, "Solving system with option...")
@@ -1170,7 +1170,7 @@ class LinprogCommonTests(object):
         b_eq = np.array([[100], [0], [0], [0], [0]])
 
         with suppress_warnings() as sup:
-            sup.filter(RuntimeWarning, "(almost) singular matrix...")
+            sup.filter(Warning, "(almost) singular matrix...")
             sup.filter(OptimizeWarning, "A_eq does not appear...")
             res = linprog(c, A_ub, b_ub, A_eq, b_eq, bounds,
                           method=self.method, options=self.options)
@@ -1206,7 +1206,7 @@ class LinprogCommonTests(object):
         desired_fun = 36.0000000000
 
         with suppress_warnings() as sup:
-            sup.filter(RuntimeWarning, "(almost) singular matrix...")
+            sup.filter(Warning, "(almost) singular matrix...")
             sup.filter(RuntimeWarning, "invalid value encountered")
             sup.filter(LinAlgWarning)
             res1 = linprog(c, A_ub, b_ub, A_eq, b_eq, bounds,
@@ -1218,7 +1218,7 @@ class LinprogCommonTests(object):
         bounds[2] = (None, None)
 
         with suppress_warnings() as sup:
-            sup.filter(RuntimeWarning, "(almost) singular matrix...")
+            sup.filter(Warning, "(almost) singular matrix...")
             sup.filter(RuntimeWarning, "invalid value encountered")
             sup.filter(LinAlgWarning)
             res2 = linprog(c, A_ub, b_ub, A_eq, b_eq, bounds,
@@ -1408,7 +1408,7 @@ class TestLinprogIPSparse(LinprogIPTests):
         bounds = (0, 1)
 
         with suppress_warnings() as sup:
-            sup.filter(RuntimeWarning, "(almost) singular matrix...")
+            sup.filter(Warning, "(almost) singular matrix...")
             sup.filter(MatrixRankWarning, "Matrix is exactly singular")
             sup.filter(OptimizeWarning, "Solving system with option...")
 

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -1218,6 +1218,7 @@ class LinprogCommonTests(object):
         bounds[2] = (None, None)
 
         with suppress_warnings() as sup:
+            sup.filter(RuntimeWarning, "(almost) singular matrix...")
             sup.filter(RuntimeWarning, "invalid value encountered")
             sup.filter(LinAlgWarning)
             res2 = linprog(c, A_ub, b_ub, A_eq, b_eq, bounds,

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -14,7 +14,7 @@ from scipy.linalg import LinAlgWarning
 try:
     from scikits.umfpack.umfpack import UmfpackWarning
     has_umfpack = True
-except ModuleNotFoundError:
+except ImportError:
     has_umfpack = False
 
 import pytest

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -11,11 +11,6 @@ from scipy.optimize import linprog, OptimizeWarning
 from scipy._lib._numpy_compat import _assert_warns, suppress_warnings
 from scipy.sparse.linalg import MatrixRankWarning
 from scipy.linalg import LinAlgWarning
-try:
-    from scikits.umfpack.umfpack import UmfpackWarning
-    has_umfpack = True
-except ImportError:
-    has_umfpack = False
 
 import pytest
 
@@ -828,8 +823,8 @@ class LinprogCommonTests(object):
         b_eq = [-4, 0, 0, 4]
 
         with suppress_warnings() as sup:
-            if has_umfpack:
-                sup.filter(RuntimeWarning, "(almost) singular matrix...")
+            # this is an UmfpackWarning but I had trouble importing it
+            sup.filter(RuntimeWarning, "(almost) singular matrix...")
             sup.filter(RuntimeWarning, "scipy.linalg.solve\nIll...")
             sup.filter(OptimizeWarning, "A_eq does not appear...")
             sup.filter(OptimizeWarning, "Solving system with option...")
@@ -1175,8 +1170,7 @@ class LinprogCommonTests(object):
         b_eq = np.array([[100], [0], [0], [0], [0]])
 
         with suppress_warnings() as sup:
-            if has_umfpack:
-                sup.filter(RuntimeWarning, "(almost) singular matrix...")
+            sup.filter(RuntimeWarning, "(almost) singular matrix...")
             sup.filter(OptimizeWarning, "A_eq does not appear...")
             res = linprog(c, A_ub, b_ub, A_eq, b_eq, bounds,
                           method=self.method, options=self.options)
@@ -1212,8 +1206,7 @@ class LinprogCommonTests(object):
         desired_fun = 36.0000000000
 
         with suppress_warnings() as sup:
-            if has_umfpack:
-                sup.filter(RuntimeWarning, "(almost) singular matrix...")
+            sup.filter(RuntimeWarning, "(almost) singular matrix...")
             sup.filter(RuntimeWarning, "invalid value encountered")
             sup.filter(LinAlgWarning)
             res1 = linprog(c, A_ub, b_ub, A_eq, b_eq, bounds,
@@ -1414,8 +1407,7 @@ class TestLinprogIPSparse(LinprogIPTests):
         bounds = (0, 1)
 
         with suppress_warnings() as sup:
-            if has_umfpack:
-                sup.filter(RuntimeWarning, "(almost) singular matrix...")
+            sup.filter(RuntimeWarning, "(almost) singular matrix...")
             sup.filter(MatrixRankWarning, "Matrix is exactly singular")
             sup.filter(OptimizeWarning, "Solving system with option...")
 

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -829,7 +829,7 @@ class LinprogCommonTests(object):
 
         with suppress_warnings() as sup:
             if has_umfpack:
-                sup.filter(UmfpackWarning, "(almost) singular matrix...")
+                sup.filter(RuntimeWarning, "(almost) singular matrix...")
             sup.filter(RuntimeWarning, "scipy.linalg.solve\nIll...")
             sup.filter(OptimizeWarning, "A_eq does not appear...")
             sup.filter(OptimizeWarning, "Solving system with option...")
@@ -1176,7 +1176,7 @@ class LinprogCommonTests(object):
 
         with suppress_warnings() as sup:
             if has_umfpack:
-                sup.filter(UmfpackWarning, "(almost) singular matrix...")
+                sup.filter(RuntimeWarning, "(almost) singular matrix...")
             sup.filter(OptimizeWarning, "A_eq does not appear...")
             res = linprog(c, A_ub, b_ub, A_eq, b_eq, bounds,
                           method=self.method, options=self.options)
@@ -1213,7 +1213,7 @@ class LinprogCommonTests(object):
 
         with suppress_warnings() as sup:
             if has_umfpack:
-                sup.filter(UmfpackWarning, "(almost) singular matrix...")
+                sup.filter(RuntimeWarning, "(almost) singular matrix...")
             sup.filter(RuntimeWarning, "invalid value encountered")
             sup.filter(LinAlgWarning)
             res1 = linprog(c, A_ub, b_ub, A_eq, b_eq, bounds,
@@ -1415,7 +1415,7 @@ class TestLinprogIPSparse(LinprogIPTests):
 
         with suppress_warnings() as sup:
             if has_umfpack:
-                sup.filter(UmfpackWarning, "(almost) singular matrix...")
+                sup.filter(RuntimeWarning, "(almost) singular matrix...")
             sup.filter(MatrixRankWarning, "Matrix is exactly singular")
             sup.filter(OptimizeWarning, "Solving system with option...")
 

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -11,6 +11,11 @@ from scipy.optimize import linprog, OptimizeWarning
 from scipy._lib._numpy_compat import _assert_warns, suppress_warnings
 from scipy.sparse.linalg import MatrixRankWarning
 from scipy.linalg import LinAlgWarning
+try:
+    from scikits.umfpack import UmfpackWarning
+    has_umfpack = True
+except ImportError:
+    has_umfpack = False
 
 import pytest
 
@@ -824,7 +829,8 @@ class LinprogCommonTests(object):
 
         with suppress_warnings() as sup:
             # this is an UmfpackWarning but I had trouble importing it
-            sup.filter(Warning, "(almost) singular matrix...")
+            if has_umfpack:
+                sup.filter(UmfpackWarning)
             sup.filter(RuntimeWarning, "scipy.linalg.solve\nIll...")
             sup.filter(OptimizeWarning, "A_eq does not appear...")
             sup.filter(OptimizeWarning, "Solving system with option...")
@@ -1170,7 +1176,8 @@ class LinprogCommonTests(object):
         b_eq = np.array([[100], [0], [0], [0], [0]])
 
         with suppress_warnings() as sup:
-            sup.filter(Warning, "(almost) singular matrix...")
+            if has_umfpack:
+                sup.filter(UmfpackWarning)
             sup.filter(OptimizeWarning, "A_eq does not appear...")
             res = linprog(c, A_ub, b_ub, A_eq, b_eq, bounds,
                           method=self.method, options=self.options)
@@ -1194,7 +1201,7 @@ class LinprogCommonTests(object):
         _assert_success(res, desired_x=[0, 0, 19, 16/3, 29/3])
 
     def test_bug_8662(self):
-        # linprog simplex used to report inncorrect optimal results
+        # linprog simplex used to report incorrect optimal results
         # https://github.com/scipy/scipy/issues/8662
         c = [-10, 10, 6, 3]
         A_ub = [[8, -8, -4, 6],
@@ -1206,7 +1213,8 @@ class LinprogCommonTests(object):
         desired_fun = 36.0000000000
 
         with suppress_warnings() as sup:
-            sup.filter(Warning, "(almost) singular matrix...")
+            if has_umfpack:
+                sup.filter(UmfpackWarning)
             sup.filter(RuntimeWarning, "invalid value encountered")
             sup.filter(LinAlgWarning)
             res1 = linprog(c, A_ub, b_ub, A_eq, b_eq, bounds,
@@ -1218,7 +1226,8 @@ class LinprogCommonTests(object):
         bounds[2] = (None, None)
 
         with suppress_warnings() as sup:
-            sup.filter(Warning, "(almost) singular matrix...")
+            if has_umfpack:
+                sup.filter(UmfpackWarning)
             sup.filter(RuntimeWarning, "invalid value encountered")
             sup.filter(LinAlgWarning)
             res2 = linprog(c, A_ub, b_ub, A_eq, b_eq, bounds,
@@ -1408,7 +1417,8 @@ class TestLinprogIPSparse(LinprogIPTests):
         bounds = (0, 1)
 
         with suppress_warnings() as sup:
-            sup.filter(Warning, "(almost) singular matrix...")
+            if has_umfpack:
+                sup.filter(UmfpackWarning)
             sup.filter(MatrixRankWarning, "Matrix is exactly singular")
             sup.filter(OptimizeWarning, "Solving system with option...")
 

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -829,7 +829,7 @@ class LinprogCommonTests(object):
 
         with suppress_warnings() as sup:
             if has_umfpack:
-                sup.filter(RuntimeWarning, "(almost) singular matrix...")
+                sup.filter(UmfpackWarning, "(almost) singular matrix...")
             sup.filter(RuntimeWarning, "scipy.linalg.solve\nIll...")
             sup.filter(OptimizeWarning, "A_eq does not appear...")
             sup.filter(OptimizeWarning, "Solving system with option...")
@@ -1176,7 +1176,7 @@ class LinprogCommonTests(object):
 
         with suppress_warnings() as sup:
             if has_umfpack:
-                sup.filter(RuntimeWarning, "(almost) singular matrix...")
+                sup.filter(UmfpackWarning, "(almost) singular matrix...")
             sup.filter(OptimizeWarning, "A_eq does not appear...")
             res = linprog(c, A_ub, b_ub, A_eq, b_eq, bounds,
                           method=self.method, options=self.options)
@@ -1212,6 +1212,8 @@ class LinprogCommonTests(object):
         desired_fun = 36.0000000000
 
         with suppress_warnings() as sup:
+            if has_umfpack:
+                sup.filter(UmfpackWarning, "(almost) singular matrix...")
             sup.filter(RuntimeWarning, "invalid value encountered")
             sup.filter(LinAlgWarning)
             res1 = linprog(c, A_ub, b_ub, A_eq, b_eq, bounds,
@@ -1413,7 +1415,7 @@ class TestLinprogIPSparse(LinprogIPTests):
 
         with suppress_warnings() as sup:
             if has_umfpack:
-                sup.filter(RuntimeWarning, "(almost) singular matrix...")
+                sup.filter(UmfpackWarning, "(almost) singular matrix...")
             sup.filter(MatrixRankWarning, "Matrix is exactly singular")
             sup.filter(OptimizeWarning, "Solving system with option...")
 


### PR DESCRIPTION
Use CHOLMOD if scikit-sparse is available
Use UMFPACK if scikit-umfpack is available

Benchmark results on the Netlib problems are below. 
<a href="https://plot.ly/~mdhaber/124/" target="_blank" title="Benchmarking_10026" style="display: block; text-align: center;"><img src="https://plot.ly/~mdhaber/124.png" alt="Benchmarking_10026" style="max-width: 100%;width: 1250px;"  width="1250" onerror="this.onerror=null;this.src='https://plot.ly/404.png';" /></a>
Each color corresponds with a solver used by `linprog` (`method='interior-point'`), each bar corresponds with a Netlib benchmark problem, and the top of each colored bar segment indicates the time taken for `linprog` to complete the benchmark problem. (A more detailed description of this plot style is available in #9636.)

The tops of the green portions of the bars are typically lower than the tops of the other colors, indicating that `linprog` typically solves the problems faster with CHOLMOD as the underlying solver. For some of the most time consuming six problems (leftmost columns), CHOLMOD doesn't shine so much, but I think the results for the rest of the problems indicates that it's worth having as an option.

(Note: UMFPACK is used in the presolve routine in all cases, so the time differences are due only to the solver used in the main interior-point routine. Given that UMFPACK is almost always faster than SuperLU in the main routine, it is likely that the trends would be somewhat amplified if SuperLU were used in the presolve routine for SuperLU tests.)