### PR TITLE
BUG/TST: optimize: Fix a test that occasionally raises an exception.

### DIFF
--- a/scipy/optimize/_trustregion_constr/tests/test_canonical_constraint.py
+++ b/scipy/optimize/_trustregion_constr/tests/test_canonical_constraint.py
@@ -234,9 +234,12 @@ def test_empty():
 
 
 def test_initial_constraints_as_canonical():
+    # rng is only used to generate the coefficients of the quadratic
+    # function that is used by the nonlinear constraint.
     rng = np.random.RandomState(0)
-    n = 4
-    x0 = np.random.rand(n)
+
+    x0 = np.array([0.5, 0.4, 0.3, 0.2])
+    n = len(x0)
 
     lb1 = [-1, -np.inf, -2, 3]
     ub1 = [1, np.inf, np.inf, 3]


### PR DESCRIPTION
The test `test_initial_constraints_as_canonical()` in
scipy/scipy/optimize/_trustregion_constr/tests/test_canonical_constraint.py
occasionally raises an exception when it is run, because the random initial
value `x0` that it generates does not satisfy the nonlinear constraint used
in the test.  To avoid this, use a fixed `x0` instead of generating it
randomly.

Closes gh-9308.