### PR TITLE
don't set flag to "converged" if max iter exceeded

### DIFF
--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -661,3 +661,24 @@ def test_gh_9608_preserve_array_shape():
         f, x0_array, fprime=fp, fprime2=fpp_array, full_output=True
     )
     assert result.converged.all()
+
+
+def test_gh9254_flag_if_maxiter_exceeded():
+    """
+    Test that if the maximum iterations is exceeded that the flag is not
+    converged.
+    """
+    maximum_iterations = 10
+    r = zeros.brentq(
+        lambda x: ((1.2*x - 2.3)*x + 3.4)*x - 4.5,
+        -30, 30, (), 1e-6, 1e-6, maximum_iterations,
+        full_output=True, disp=False)
+    assert r[1].flag == zeros.CONVERR
+    assert r[1].iterations == maximum_iterations
+    more_maximum_iterations = 100
+    r = zeros.brentq(
+        lambda x: ((1.2*x - 2.3)*x + 3.4)*x - 4.5,
+        -30, 30, (), 1e-6, 1e-6, more_maximum_iterations,
+        full_output=True, disp=False)
+    assert r[1].flag == zeros.CONVERGED
+    assert r[1].iterations < more_maximum_iterations

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -663,22 +663,22 @@ def test_gh_9608_preserve_array_shape():
     assert result.converged.all()
 
 
-def test_gh9254_flag_if_maxiter_exceeded():
+@pytest.mark.parametrize(
+    "maximum_iterations,flag_expected",
+    [(10, zeros.CONVERR), (100, zeros.CONVERGED)])
+def test_gh9254_flag_if_maxiter_exceeded(maximum_iterations, flag_expected):
     """
     Test that if the maximum iterations is exceeded that the flag is not
     converged.
     """
-    maximum_iterations = 10
-    r = zeros.brentq(
+    result = zeros.brentq(
         lambda x: ((1.2*x - 2.3)*x + 3.4)*x - 4.5,
         -30, 30, (), 1e-6, 1e-6, maximum_iterations,
         full_output=True, disp=False)
-    assert r[1].flag == zeros.CONVERR
-    assert r[1].iterations == maximum_iterations
-    more_maximum_iterations = 100
-    r = zeros.brentq(
-        lambda x: ((1.2*x - 2.3)*x + 3.4)*x - 4.5,
-        -30, 30, (), 1e-6, 1e-6, more_maximum_iterations,
-        full_output=True, disp=False)
-    assert r[1].flag == zeros.CONVERGED
-    assert r[1].iterations < more_maximum_iterations
+    assert result[1].flag == flag_expected
+    if flag_expected == zeros.CONVERR:
+        # didn't converge because exceeded maximum iterations
+        assert result[1].iterations == maximum_iterations
+    elif flag_expected == zeros.CONVERGED:
+        # converged before maximum iterations
+        assert result[1].iterations < maximum_iterations

--- a/scipy/optimize/zeros.c
+++ b/scipy/optimize/zeros.c
@@ -116,7 +116,7 @@ call_solver(solver_type solver, PyObject *self, PyObject *args)
         return NULL;
     }
 
-    if (solver_stats.error_num != 0) {
+    if (solver_stats.error_num != CONVERGED) {
         if (solver_stats.error_num == SIGNERR) {
             PyErr_SetString(PyExc_ValueError,
                     "f(a) and f(b) must have different signs");
@@ -129,11 +129,12 @@ call_solver(solver_type solver, PyObject *self, PyObject *args)
                         "Failed to converge after %d iterations.",
                         solver_stats.iterations);
                 PyErr_SetString(PyExc_RuntimeError, msg);
-                flag = 1;
                 return NULL;
             }
+            flag = CONVERR;
         }
     }
+    flag = CONVERGED;
     if (fulloutput) {
         return Py_BuildValue("diii",
                 zero, solver_stats.funcalls, solver_stats.iterations, flag);

--- a/scipy/optimize/zeros.c
+++ b/scipy/optimize/zeros.c
@@ -134,7 +134,10 @@ call_solver(solver_type solver, PyObject *self, PyObject *args)
             flag = CONVERR;
         }
     }
-    flag = CONVERGED;
+    else
+    {
+        flag = CONVERGED;
+    }
     if (fulloutput) {
         return Py_BuildValue("diii",
                 zero, solver_stats.funcalls, solver_stats.iterations, flag);

--- a/scipy/optimize/zeros.c
+++ b/scipy/optimize/zeros.c
@@ -134,8 +134,7 @@ call_solver(solver_type solver, PyObject *self, PyObject *args)
             flag = CONVERR;
         }
     }
-    else
-    {
+    else {
         flag = CONVERGED;
     }
     if (fulloutput) {


### PR DESCRIPTION
* be consistent with underlying functions `brentq`, `bisection`, `ridder` that return `error_num` of `CONVERR` when maximum iteration exceeded, not "converged"
* be consistent with Newton and TOMS748 also return `_CONVERR` if maximum iterations exceeded instead of "converged"
* closes #9254
* use macro `CONVERGED` to be explicit in test for non-convergence
* remove unused line `flag = 1;` before `return NULL` which raises an exception, so flag never used
* set `flag = CONVERR` to be consistent with underlying functions in `Zeros/` and Newton and TOMS
* explicitly set `flag = CONVERGED` if test for non-convergence fails, meaning successful convergence