### PR TITLE
Small speedup in samping from ortho and special_ortho groups

### DIFF
--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -136,3 +136,19 @@ class GaussianKDE(Benchmark):
         # test gaussian_kde evaluate on many points
         self.kernel(self.positions)
 
+
+class GroupSampling(Benchmark):
+    param_names = ['dim']
+    params = [[3, 10, 50, 200]]
+
+    def setup(self):
+        np.random.seed(12345678)
+
+    def time_unitary_group(self, dim):
+        stats.unitary_group.rvs(dim)
+
+    def time_ortho_group(self, dim):
+        stats.ortho_group.rvs(dim)
+
+    def time_special_ortho_group(self, dim):
+        stats.special_ortho_group.rvs(dim)

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -3388,10 +3388,13 @@ class special_ortho_group_gen(multi_rv_generic):
         D = np.empty((dim,))
         for n in range(dim-1):
             x = random_state.normal(size=(dim-n,))
+            norm2 = np.dot(x, x)
+            x0 = x[0].item()
             D[n] = np.sign(x[0]) if x[0] != 0 else 1
-            x[0] += D[n]*np.sqrt((x*x).sum())
+            x[0] += D[n]*np.sqrt(norm2)
+            x /= np.sqrt((norm2 - x0**2 + x[0]**2) / 2.)
             # Householder transformation
-            Hx = (np.eye(dim-n) - 2.*np.outer(x, x)/(x*x).sum())
+            Hx = (np.eye(dim-n) - np.outer(x, x))
             mat = np.eye(dim)
             mat[n:, n:] = Hx
             H = np.dot(H, mat)
@@ -3527,11 +3530,14 @@ class ortho_group_gen(multi_rv_generic):
         H = np.eye(dim)
         for n in range(dim):
             x = random_state.normal(size=(dim-n,))
+            norm2 = np.dot(x, x)
+            x0 = x[0].item()
             # random sign, 50/50, but chosen carefully to avoid roundoff error
             D = np.sign(x[0]) if x[0] != 0 else 1
-            x[0] += D*np.sqrt((x*x).sum())
+            x[0] += D * np.sqrt(norm2)
+            x /= np.sqrt((norm2 - x0**2 + x[0]**2) / 2.)
             # Householder transformation
-            Hx = -D*(np.eye(dim-n) - 2.*np.outer(x, x)/(x*x).sum())
+            Hx = -D*(np.eye(dim-n) - np.outer(x, x))
             mat = np.eye(dim)
             mat[n:, n:] = Hx
             H = np.dot(H, mat)


### PR DESCRIPTION
Makes 3 changes:
- Uses dot for norm^2,
- Reuse norm calculation, and
- do multiplications by scalars in a different place.

This should be identical up to floating point associativity differences such as between `dot(x, x)` and `(x*x).sum()`. `np.allclose` is satisfied for everything I've checked although `np.array_equal` is not.

I timed this on my desktop using only 1 core for `dim` ranging from 2 to 200. Current code is typically 5-15% slower and this tends to shrink for larger dims.

![ortho](https://user-images.githubusercontent.com/2081702/56071327-89a49480-5d42-11e9-9a04-bbf880ebcde6.png)

![special_ortho](https://user-images.githubusercontent.com/2081702/56071336-9b863780-5d42-11e9-9474-b928c1986cbc.png)

Notebook that generated the tests is here
https://github.com/JesseLivezey/scipy-ortho-speedup/blob/master/faster_ortho_groups.ipynb
