### PR TITLE
ENH: Significant speedup for ortho and special ortho group

### DIFF
--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -141,7 +141,7 @@ class GroupSampling(Benchmark):
     param_names = ['dim']
     params = [[3, 10, 50, 200]]
 
-    def setup(self):
+    def setup(self, dim):
         np.random.seed(12345678)
 
     def time_unitary_group(self, dim):

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -3394,7 +3394,7 @@ class special_ortho_group_gen(multi_rv_generic):
             x[0] += D[n]*np.sqrt(norm2)
             x /= np.sqrt((norm2 - x0**2 + x[0]**2) / 2.)
             # Householder transformation
-            H[:, n:] = H[:, n:] - np.outer(np.dot(H[:, n:], x), x)
+            H[:, n:] -= np.outer(np.dot(H[:, n:], x), x)
         D[-1] = (-1)**(dim-1)*D[:-1].prod()
         # Equivalent to np.dot(np.diag(D), H) but faster, apparently
         H = (D*H.T).T

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -3394,10 +3394,7 @@ class special_ortho_group_gen(multi_rv_generic):
             x[0] += D[n]*np.sqrt(norm2)
             x /= np.sqrt((norm2 - x0**2 + x[0]**2) / 2.)
             # Householder transformation
-            Hx = (np.eye(dim-n) - np.outer(x, x))
-            mat = np.eye(dim)
-            mat[n:, n:] = Hx
-            H = np.dot(H, mat)
+            H[:, n:] = H[:, n:] - np.outer(np.dot(H[:, n:], x), x)
         D[-1] = (-1)**(dim-1)*D[:-1].prod()
         # Equivalent to np.dot(np.diag(D), H) but faster, apparently
         H = (D*H.T).T
@@ -3537,10 +3534,7 @@ class ortho_group_gen(multi_rv_generic):
             x[0] += D * np.sqrt(norm2)
             x /= np.sqrt((norm2 - x0**2 + x[0]**2) / 2.)
             # Householder transformation
-            Hx = -D*(np.eye(dim-n) - np.outer(x, x))
-            mat = np.eye(dim)
-            mat[n:, n:] = Hx
-            H = np.dot(H, mat)
+            H[:, n:] = -D * (H[:, n:] - np.outer(np.dot(H[:, n:], x), x))
         return H
 
 


### PR DESCRIPTION
This PR makes 2 changes to `ortho_group.rvs()` and `special_ortho_group.rvs()` that significantly speed up the calculation.

1) The former `Hx` matrix is an identity minus a single outer product. In the next step it is matrix multiplied. It is faster to re-order this process as H.dot(I - xx^t) --> H - H.dot(x)x^T. In this re-ordering, you never have to do a matrix-matrix multiply.
2) The former `mat` matrix was block diagonal with the identity from 0 to n and `Hx` as the second block. On every loop, it was matrix multiplied by by `H`. The identity block means that you can just do the computation on a smaller and smaller subset of the columns of `H` at every iteration.

This changes the scaling of the computation and so it gives large speedups for `dim` > 100.

![ortho_group2](https://user-images.githubusercontent.com/2081702/56096560-b4a3fb00-5e9e-11e9-8b0e-630445ddc7e1.png)

![special_ortho2](https://user-images.githubusercontent.com/2081702/56096562-bc639f80-5e9e-11e9-8b45-6f5d358362b1.png)


@rgommers, this is a follow-up to #10058. It turns out I missed the most obvious ways to speed these function up in the first pass.