### PR TITLE
DOC: Reword parameter descriptions in `optimize.root_scalar`

### DIFF
--- a/scipy/optimize/_root_scalar.py
+++ b/scipy/optimize/_root_scalar.py
@@ -93,13 +93,14 @@ def root_scalar(f, args=(), method=None, bracket=None,
         A second guess.
     fprime : bool or callable, optional
         If `fprime` is a boolean and is True, `f` is assumed to return the
-        value of derivative along with the objective function.
+        value of the objective function and of the derivative.
         `fprime` can also be a callable returning the derivative of `f`. In
         this case, it must accept the same arguments as `f`.
     fprime2 : bool or callable, optional
         If `fprime2` is a boolean and is True, `f` is assumed to return the
-        value of 1st and 2nd derivatives along with the objective function.
-        `fprime2` can also be a callable returning the 2nd derivative of `f`.
+        value of the objective function and of the
+        first and second derivatives.
+        `fprime2` can also be a callable returning the second derivative of `f`.
         In this case, it must accept the same arguments as `f`.
     xtol : float, optional
         Tolerance (absolute) for termination.


### PR DESCRIPTION
Closes #10048.

The descriptions for `fprime` and `fprime2` imply `f` should return the derivative(s) *then* the objective function if those options are `True`, but the code says the reverse:

The [code](https://github.com/scipy/scipy/blob/v1.2.1/scipy/optimize/_root_scalar.py#L196) says that if `fprime` is not `None` and not `callable` and is `bool`, then `fprime = MemoizeDer(f).fprime` where `MemoizeDer(f).fprime` ([source](https://github.com/scipy/scipy/blob/v1.2.1/scipy/optimize/_root_scalar.py#L45)) is the argument of `f` at index 1. Same idea for `fprime2`.