### PR TITLE
BUG: signal: Fix error raised by savgol_coeffs when deriv > polyorder.

### DIFF
--- a/scipy/signal/_savitzky_golay.py
+++ b/scipy/signal/_savitzky_golay.py
@@ -62,8 +62,8 @@ def savgol_coeffs(window_length, polyorder, deriv=0, delta=1.0, pos=None,
     >>> savgol_coeffs(5, 2)
     array([-0.08571429,  0.34285714,  0.48571429,  0.34285714, -0.08571429])
     >>> savgol_coeffs(5, 2, deriv=1)
-    array([  2.00000000e-01,   1.00000000e-01,   2.00607895e-16,
-            -1.00000000e-01,  -2.00000000e-01])
+    array([ 2.00000000e-01,  1.00000000e-01,  2.07548111e-16, -1.00000000e-01,
+           -2.00000000e-01])
 
     Note that use='dot' simply reverses the coefficients.
 
@@ -80,7 +80,7 @@ def savgol_coeffs(window_length, polyorder, deriv=0, delta=1.0, pos=None,
     >>> x = np.array([1, 0, 1, 4, 9])
     >>> c = savgol_coeffs(5, 2, pos=4, deriv=1, use='dot')
     >>> c.dot(x)
-    6.0000000000000018
+    6.0
     """
 
     # An alternative method for finding the coefficients when deriv=0 is
@@ -112,6 +112,10 @@ def savgol_coeffs(window_length, polyorder, deriv=0, delta=1.0, pos=None,
 
     if use not in ['conv', 'dot']:
         raise ValueError("`use` must be 'conv' or 'dot'")
+
+    if deriv > polyorder:
+        coeffs = np.zeros(window_length)
+        return coeffs
 
     # Form the design matrix A.  The columns of A are powers of the integers
     # from -pos to window_length - pos - 1.  The powers (i.e. rows) range
@@ -310,7 +314,7 @@ def savgol_filter(x, window_length, polyorder, deriv=0, delta=1.0,
     the defaults for all other parameters.
 
     >>> savgol_filter(x, 5, 2)
-    array([ 1.66,  3.17,  3.54,  2.86,  0.66,  0.17,  1.  ,  4.  ,  9.  ])
+    array([1.66, 3.17, 3.54, 2.86, 0.66, 0.17, 1.  , 4.  , 9.  ])
 
     Note that the last five values in x are samples of a parabola, so
     when mode='interp' (the default) is used with polyorder=2, the last
@@ -318,7 +322,7 @@ def savgol_filter(x, window_length, polyorder, deriv=0, delta=1.0,
     `mode='nearest'`:
 
     >>> savgol_filter(x, 5, 2, mode='nearest')
-    array([ 1.74,  3.03,  3.54,  2.86,  0.66,  0.17,  1.  ,  4.6 ,  7.97])
+    array([1.74, 3.03, 3.54, 2.86, 0.66, 0.17, 1.  , 4.6 , 7.97])
 
     """
     if mode not in ["mirror", "constant", "nearest", "interp", "wrap"]:

--- a/scipy/signal/tests/test_savitzky_golay.py
+++ b/scipy/signal/tests/test_savitzky_golay.py
@@ -137,6 +137,19 @@ def test_sg_coeffs_deriv():
         assert_allclose(coeffs2.dot(x), d2x[pos], atol=1e-10)
 
 
+def test_sg_coeffs_deriv_gt_polyorder():
+    """
+    If deriv > polyorder, the coefficients should be all 0.
+    This is a regression test for a bug where, e.g.,
+        savgol_coeffs(5, polyorder=1, deriv=2)
+    raised an error.
+    """
+    coeffs = savgol_coeffs(5, polyorder=1, deriv=2)
+    assert_array_equal(coeffs, np.zeros(5))
+    coeffs = savgol_coeffs(7, polyorder=4, deriv=6)
+    assert_array_equal(coeffs, np.zeros(7))
+
+
 def test_sg_coeffs_large():
     # Test that for large values of window_length and polyorder the array of
     # coefficients returned is symmetric. The aim is to ensure that


### PR DESCRIPTION
An example of the problem:

    >>> from scipy.signal import savgol_coeffs
    >>> savgol_coeffs(window_length=7, polyorder=3, deriv=4)
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "[...]/site-packages/scipy/signal/_savitzky_golay.py", line 132, in savgol_coeffs
        y[deriv] = factorial(deriv) / (delta ** deriv)
    IndexError: index 4 is out of bounds for axis 0 with size 4

The correct result in this case is an array of zeros: for a
polynomial of degree m, the derivative of order n > m is
identically 0.  After this change, that's what we get:

    >>> from scipy.signal import savgol_coeffs
    >>> savgol_coeffs(window_length=7, polyorder=3, deriv=4)
    array([0., 0., 0., 0., 0., 0., 0.])

I also updated the outputs shown in the docstrings of savgol_coeffs
and savgol_filter.