### PR TITLE
BUG: optimize: fix curve_fit for mixed float32/float64 input

### DIFF
--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -720,6 +720,10 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
     if ydata.size == 0:
         raise ValueError("`ydata` must not be empty!")
 
+    # optimization may produce garbage for float32 inputs, cast them to float64
+    xdata = xdata.astype(float)
+    ydata = ydata.astype(float)
+
     # Determine type of sigma
     if sigma is not None:
         sigma = np.asarray(sigma)


### PR DESCRIPTION
`curve_fit` sometimes fails if xdata and ydata dtypes differ (one is float32, and the other is float64), or both are float32.

Failure modes are slightly different: for mixed-dtype input, it emits an OptimizeWarning and returns the initial guess (gh-9581); for float32+float32 inputs it quietly returns garbage (gh-7117)

Thus always cast them to float64. An alternative could be to use something like `np.promote_types` to keep things in float32 if both xdata and ydata are float32. 
Then float32+float32 case still needs fixing. It's not clear whether this can be really fixed reliably, and I suspect that estimating derivatives in single precision is a bad idea anyway. At any rate, I suggest that curve_fit stays on a robust side, and if someone really needs float32+float32, it's an enhancement request for `least_squares` (I'll comment on gh-7117 with some more details). 

fixes gh-9581, fixes gh-7117

Am marking this for the milestone 1.3.0, only because gh-7117 is in this milestone. Neither gh-7117 not gh-9581 are release blockers, so it's up to Tyler to decide.