### PR TITLE
DOC: Replace undefined `k` in `interpolate.splev` docstring

### DIFF
--- a/scipy/interpolate/fitpack.py
+++ b/scipy/interpolate/fitpack.py
@@ -310,7 +310,7 @@ def splev(x, tck, der=0, ext=0):
         of the spline. (Also see Notes.)
     der : int, optional
         The order of derivative of the spline to compute (must be less than
-        or equal to the degree of the spline).
+        or equal to k, the degree of the spline).
     ext : int, optional
         Controls the value returned for elements of ``x`` not in the
         interval defined by the knot sequence.

--- a/scipy/interpolate/fitpack.py
+++ b/scipy/interpolate/fitpack.py
@@ -310,7 +310,7 @@ def splev(x, tck, der=0, ext=0):
         of the spline. (Also see Notes.)
     der : int, optional
         The order of derivative of the spline to compute (must be less than
-        or equal to k).
+        or equal to the degree of the spline).
     ext : int, optional
         Controls the value returned for elements of ``x`` not in the
         interval defined by the knot sequence.


### PR DESCRIPTION
Closes #10068

This function wraps `_fitpack_impl.splev()` ([source](https://github.com/scipy/scipy/blob/v1.2.1/scipy/interpolate/fitpack.py#L368)) which defines `k` to be the third entry of tuple `tck`, a.k.a. the degree of the spline ([source](https://github.com/scipy/scipy/blob/v1.2.1/scipy/interpolate/_fitpack_impl.py#L580)).