### PR TITLE
TEST: use PyPy3.6 nightly build for testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ jobs:
       - run:
           name: install PyPy3.6-v7.0
           command: |
-            wget https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v7.0.0-linux64.tar.bz2 -O pypy.tar.bz2
+            wget http://buildbot.pypy.org/nightly/py3.6/pypy-c-jit-latest-linux64.tar.bz2 -O pypy.tar.bz2
             mkdir -p pypy3.6
             (cd pypy3.6; tar --strip-components=1 -xf ../pypy.tar.bz2)
             export PATH=${PWD}/pypy3.6/bin:$PATH
@@ -132,7 +132,7 @@ jobs:
             export NPY_NUM_BUILD_JOBS=`pypy3 -c 'import multiprocessing as mp; print(mp.cpu_count())'`
             pypy3 -mpip install --upgrade pip setuptools wheel
             pypy3 -mpip install Cython>=0.28.5
-            pypy3 -mpip install --no-build-isolation --extra-index https://antocuni.github.io/pypy-wheels/ubuntu pytest pytest-xdist pytest-timeout Tempita mpmath numpy>=1.15.0
+            pypy3 -mpip install --no-build-isolation --extra-index https://antocuni.github.io/pypy-wheels/ubuntu pytest pytest-xdist pytest-timeout Tempita mpmath numpy
       - run:
           name: build SciPy
           command: |


### PR DESCRIPTION
Numpy 1.16.3 started using a C-API that the latest PyPy release 7.1.1 did not implement. The API call was implemented in latest HEAD which is built nightly. Use this for testing SciPy.

An alternative would be to pin NumPy to a last known good version, I am not sure what will cause less churn. The PyPy linux64 nightly builds are reliable since that is the main development platform, but nothing is 100%.