### PR TITLE
ENH: optimize: linprog test CHOLMOD/UMFPACK solvers when available

### DIFF
--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -991,7 +991,7 @@ def _linprog_ip(
 
     For dense problems, solvers are tried in the following order:
 
-    1. ``scipy.linalg.cho_factor`` (if scikit-sparse and SuiteSparse are installed)
+    1. ``scipy.linalg.cho_factor``
 
     2. ``scipy.linalg.solve`` with option ``sym_pos=True``
 
@@ -1003,7 +1003,7 @@ def _linprog_ip(
 
     1. ``sksparse.cholmod.cholesky`` (if scikit-sparse and SuiteSparse are installed)
 
-    2. ``scipy.sparse.linalg.factorized`` (if scikits.umfpack and SuiteSparse are installed)
+    2. ``scipy.sparse.linalg.factorized`` (if scikit-umfpack and SuiteSparse are installed)
 
     3. ``scipy.sparse.linalg.splu`` (which uses SuperLU distributed with SciPy)
 

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -11,12 +11,19 @@ from scipy.optimize import linprog, OptimizeWarning
 from scipy._lib._numpy_compat import _assert_warns, suppress_warnings
 from scipy.sparse.linalg import MatrixRankWarning
 from scipy.linalg import LinAlgWarning
+
+has_umfpack = True
 try:
     from scikits.umfpack import UmfpackWarning
-    has_umfpack = True
 except ImportError:
     has_umfpack = False
 
+has_cholmod = True
+try:
+    import sksparse
+except ImportError:
+    has_cholmod = False
+    
 import pytest
 
 
@@ -1402,9 +1409,16 @@ class TestLinprogSimplexNoPresolve(LinprogSimplexTests):
 class TestLinprogIPDense(LinprogIPTests):
     options = {"sparse": False}
 
+if has_cholmod:
+    class TestLinprogIPSparseCholmod(LinprogIPTests):
+        options = {"sparse": True, "cholesky":True}
+        
+if has_umfpack:
+    class TestLinprogIPSparseUmfpack(LinprogIPTests):
+        options = {"sparse": True, "cholesky":False}
 
 class TestLinprogIPSparse(LinprogIPTests):
-    options = {"sparse": True}
+    options = {"sparse": True, "cholesky":False, "sym_pos":False}
 
     @pytest.mark.xfail(reason='Fails with ATLAS, see gh-7877')
     def test_bug_6690(self):

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -1478,6 +1478,21 @@ class TestLinprogIPSpecific(object):
     # the following tests don't need to be performed separately for
     # sparse presolve, sparse after presolve, and dense
 
+    def test_solver_select(self):
+        # check that default solver is selected as expected
+        if has_cholmod:
+            options = {'sparse':True, 'cholesky':True}
+        elif has_umfpack:
+            options = {'sparse':True, 'cholesky':False}
+        else:
+            options = {'sparse':True, 'cholesky':False, 'sym_pos':False}
+        A, b, c = lpgen_2d(20, 20)
+        res1 = linprog(c, A_ub=A, b_ub=b, method=self.method, options=options)
+        res2 = linprog(c, A_ub=A, b_ub=b, method=self.method) # default solver
+        assert_allclose(res1.fun, res2.fun,
+                        err_msg="linprog default solver unexpected result",
+                        rtol=1e-15, atol=1e-15)
+
     def test_unbounded_below_no_presolve_original(self):
         # formerly caused segfault in TravisCI w/ "cholesky":True
         c = [-1]


### PR DESCRIPTION
This repeats all of `linprog`'s sparse tests with all available solvers and checks that the intended default solver is attempted first.