### PR TITLE
MAINT: Fix CubicSplinerInterpolator for pandas

### DIFF
--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -26,9 +26,9 @@ def prepare_input(x, y, axis, dydx=None):
     """
 
     x, y = map(np.asarray, (x, y))
-
     if np.issubdtype(x.dtype, np.complexfloating):
         raise ValueError("`x` must contain real values.")
+    x = x.astype(float)
 
     if np.issubdtype(y.dtype, np.complexfloating):
         dtype = complex


### PR DESCRIPTION
Follow up of #10021. Should fix pandas-dev/pandas/issues/26189 I have tested it locally.

But I must say that their support of scipy interpolators is quite fragmentary.

@rgommers 

