### PR TITLE
ENH: integrate: add args argument to solve_ivp.

### DIFF
--- a/scipy/integrate/_ivp/ivp.py
+++ b/scipy/integrate/_ivp/ivp.py
@@ -169,11 +169,12 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
     The goal is to find y(t) approximately satisfying the differential
     equations, given an initial value y(t0)=y0.
 
-    Some of the solvers support integration in the complex domain, but note that
-    for stiff ODE solvers, the right-hand side must be complex-differentiable
-    (satisfy Cauchy-Riemann equations [11]_). To solve a problem in the complex
-    domain, pass y0 with a complex data type. Another option is always to
-    rewrite your problem for real and imaginary parts separately.
+    Some of the solvers support integration in the complex domain, but
+    note that for stiff ODE solvers, the right-hand side must be complex-
+    differentiable (satisfy Cauchy-Riemann equations [11]_). To solve a
+    problem in the complex domain, pass y0 with a complex data type. Another
+    option is always to rewrite your problem for real and imaginary parts
+    separately.
 
     Parameters
     ----------
@@ -198,14 +199,15 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
 
             * 'RK45' (default): Explicit Runge-Kutta method of order 5(4) [1]_.
               The error is controlled assuming accuracy of the fourth-order
-              method, but steps are taken using the fifth-order accurate formula
-              (local extrapolation is done). A quartic interpolation polynomial
-              is used for the dense output [2]_. Can be applied in the complex domain.
+              method, but steps are taken using the fifth-order accurate
+              formula (local extrapolation is done). A quartic interpolation
+              polynomial is used for the dense output [2]_. Can be applied in
+              the complex domain.
             * 'RK23': Explicit Runge-Kutta method of order 3(2) [3]_. The error
               is controlled assuming accuracy of the second-order method, but
               steps are taken using the third-order accurate formula (local
-              extrapolation is done). A cubic Hermite polynomial is used for the
-              dense output. Can be applied in the complex domain.
+              extrapolation is done). A cubic Hermite polynomial is used for
+              the dense output. Can be applied in the complex domain.
             * 'Radau': Implicit Runge-Kutta method of the Radau IIA family of
               order 5 [4]_. The error is controlled with a third-order accurate
               embedded formula. A cubic polynomial which satisfies the
@@ -214,8 +216,8 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
               on a backward differentiation formula for the derivative
               approximation [5]_. The implementation follows the one described
               in [6]_. A quasi-constant step scheme is used and accuracy is
-              enhanced using the NDF modification. Can be applied in the complex
-              domain.
+              enhanced using the NDF modification. Can be applied in the
+              complex domain.
             * 'LSODA': Adams/BDF method with automatic stiffness detection and
               switching [7]_, [8]_. This is a wrapper of the Fortran solver
               from ODEPACK.
@@ -229,11 +231,11 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
 
         You can also pass an arbitrary class derived from `OdeSolver` which
         implements the solver.
-    dense_output : bool, optional
-        Whether to compute a continuous solution. Default is False.
     t_eval : array_like or None, optional
         Times at which to store the computed solution, must be sorted and lie
         within `t_span`. If None (default), use points selected by the solver.
+    dense_output : bool, optional
+        Whether to compute a continuous solution. Default is False.
     events : callable, or list of callables, optional
         Events to track. If None (default), no events will be tracked.
         Each event occurs at the zeros of a continuous function of time and
@@ -284,10 +286,10 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
         passing array_like with shape (n,) for `atol`. Default values are
         1e-3 for `rtol` and 1e-6 for `atol`.
     jac : array_like, sparse_matrix, callable or None, optional
-        Jacobian matrix of the right-hand side of the system with respect to
-        y, required by the 'Radau', 'BDF' and 'LSODA' method. The Jacobian matrix
-        has shape (n, n) and its element (i, j) is equal to ``d f_i / d y_j``.
-        There are three ways to define the Jacobian:
+        Jacobian matrix of the right-hand side of the system with respect
+        to y, required by the 'Radau', 'BDF' and 'LSODA' method. The
+        Jacobian matrix has shape (n, n) and its element (i, j) is equal to
+        ``d f_i / d y_j``.  There are three ways to define the Jacobian:
 
             * If array_like or sparse_matrix, the Jacobian is assumed to
               be constant. Not supported by 'LSODA'.
@@ -301,24 +303,24 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
         It is generally recommended to provide the Jacobian rather than
         relying on a finite-difference approximation.
     jac_sparsity : array_like, sparse matrix or None, optional
-        Defines a sparsity structure of the Jacobian matrix for a
-        finite-difference approximation. Its shape must be (n, n). This argument
-        is ignored if `jac` is not `None`. If the Jacobian has only few non-zero
-        elements in *each* row, providing the sparsity structure will greatly
-        speed up the computations [10]_. A zero entry means that a corresponding
-        element in the Jacobian is always zero. If None (default), the Jacobian
-        is assumed to be dense.
+        Defines a sparsity structure of the Jacobian matrix for a finite-
+        difference approximation. Its shape must be (n, n). This argument
+        is ignored if `jac` is not `None`. If the Jacobian has only few
+        non-zero elements in *each* row, providing the sparsity structure
+        will greatly speed up the computations [10]_. A zero entry means that
+        a corresponding element in the Jacobian is always zero. If None
+        (default), the Jacobian is assumed to be dense.
         Not supported by 'LSODA', see `lband` and `uband` instead.
     lband, uband : int or None, optional
-        Parameters defining the bandwidth of the Jacobian for the 'LSODA' method,
-        i.e., ``jac[i, j] != 0 only for i - lband <= j <= i + uband``. Default is
-        None. Setting these requires your jac routine to return the Jacobian in the
-        packed format: the returned array must have ``n`` columns and
-        ``uband + lband + 1`` rows in which Jacobian diagonals are written.
-        Specifically ``jac_packed[uband + i - j , j] = jac[i, j]``. The same format
-        is used in `scipy.linalg.solve_banded` (check for an illustration).
-        These parameters can be also used with ``jac=None`` to reduce the
-        number of Jacobian elements estimated by finite differences.
+        Parameters defining the bandwidth of the Jacobian for the 'LSODA'
+        method, i.e., ``jac[i, j] != 0 only for i - lband <= j <= i + uband``.
+        Default is None. Setting these requires your jac routine to return the
+        Jacobian in the packed format: the returned array must have ``n``
+        columns and ``uband + lband + 1`` rows in which Jacobian diagonals are
+        written. Specifically ``jac_packed[uband + i - j , j] = jac[i, j]``.
+        The same format is used in `scipy.linalg.solve_banded` (check for an
+        illustration).  These parameters can be also used with ``jac=None`` to
+        reduce the number of Jacobian elements estimated by finite differences.
     min_step : float, optional
         The minimum allowed step size for 'LSODA' method. 
         By default `min_step` is zero.
@@ -421,9 +423,9 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
 
     Cannon fired upward with terminal event upon impact. The ``terminal`` and
     ``direction`` fields of an event are applied by monkey patching a function.
-    Here ``y[0]`` is position and ``y[1]`` is velocity. The projectile starts at
-    position 0 with velocity +10. Note that the integration never reaches t=100
-    because the event is terminal.
+    Here ``y[0]`` is position and ``y[1]`` is velocity. The projectile starts
+    at position 0 with velocity +10. Note that the integration never reaches
+    t=100 because the event is terminal.
 
     >>> def upward_cannon(t, y): return [y[1], -0.5]
     >>> def hit_ground(t, y): return y[0]
@@ -436,11 +438,11 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
     [0.00000000e+00 9.99900010e-05 1.09989001e-03 1.10988901e-02
      1.11088891e-01 1.11098890e+00 1.11099890e+01 4.00000000e+01]
 
-    Use `dense_output` and `events` to find position, which is 100, at the apex of
-    the cannonball's trajectory. Apex is not defined as terminal, so both apex
-    and hit_ground are found. There is no information at t=20, so the sol
-    attribute is used to evaluate the solution. The sol attribute is
-    returned by setting ``dense_output=True``.
+    Use `dense_output` and `events` to find position, which is 100, at the apex
+    of the cannonball's trajectory. Apex is not defined as terminal, so both
+    apex and hit_ground are found. There is no information at t=20, so the sol
+    attribute is used to evaluate the solution. The sol attribute is returned
+    by setting ``dense_output=True``.
 
     >>> def apex(t,y): return y[1]
     >>> sol = solve_ivp(upward_cannon, [0, 100], [0, 10], 


### PR DESCRIPTION
This pull request adds`args` to `scipy.integrate.solve_ivp`.  See the discussion in https://github.com/scipy/scipy/issues/8352.

Here's a demonstration script, "rossler_demo.py", that exercises the callable arguments `fun`, `jac` and `events`.

```

import numpy as np
from scipy.integrate import solve_ivp
import matplotlib.pyplot as plt


def rossler_sys(t, w, a, b, c):
    """
    Rössler system
    """
    x, y, z = w
    return [-y - z, x + a*y, b +z*(x - c)]


def rossler_jac(t, w, a, b, c):
    """
    Jacobian of the Rössler system.
    """
    x, y, z = w
    dxs = [0, -1, -1]
    dys = [1, a, 0]
    dzs = [z, 0, x - c]
    return [dxs, dys, dzs]


def x0event(t, w, a, b, c):
    """
    x = 0 event for the Rössler system.
    """
    x, y, z = w
    return x

x0event.direction = 1


# Rössler parameters
a = 0.1
b = 0.1
c = 14.0

w0 = [1, 1, 1]

print("Computing transient")
sol_trans = solve_ivp(rossler_sys, [0, 100], w0, args=(a, b, c))

print("Computing long solution, with events")
t = np.linspace(0, 500, 10001)
sol = solve_ivp(rossler_sys, [t[0], t[-1]], sol_trans.y[:, -1], t_eval=t,
                events=x0event, dense_output=True,
                args=(a, b, c), method='Radau', jac=rossler_jac)

# Compute the state at each event.
w_events = sol.sol(sol.t_events[0])

plt.figure(1)
plt.title('Rössler phase space, (x, y) projection')
plt.plot(sol.y[0], sol.y[1], 'k', linewidth=1, alpha=0.25)
plt.plot(np.zeros(w_events.shape[1]), w_events[1], 'r.', markersize=2.5, alpha=0.5)
plt.xlabel('x')
plt.ylabel('y')

plt.figure(2)
plt.title('y return map at x=0')
plt.plot(w_events[1, :-1], w_events[1, 1:], 'r.', alpha=0.5)
plt.xlabel('y[k]')
plt.ylabel('y[k+1]')

plt.show()
```

The script generates the following plots:

![Figure_1](https://user-images.githubusercontent.com/321463/56779628-d14b0780-67a9-11e9-809d-a4d411faca53.png)
![Figure_2](https://user-images.githubusercontent.com/321463/56779633-d60fbb80-67a9-11e9-83df-41faf651c6a1.png)
