### PR TITLE
DOC: Add missing docs for linprog unknown_options

### DIFF
--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -937,6 +937,10 @@ def _linprog_ip(
         interior point algorithm; test different values to determine which
         performs best for your problem. For more information, refer to
         ``scipy.sparse.linalg.splu``.
+    unkown_options : dict
+        Optional arguments not used by this particular solver. If
+        `unknown_options` is non-empty a warning is issued listing all
+        unused options.
 
     Returns
     -------

--- a/scipy/optimize/_linprog_rs.py
+++ b/scipy/optimize/_linprog_rs.py
@@ -486,6 +486,10 @@ def _linprog_rs(c, c0, A, b, x0=None, callback=None, maxiter=5000, tol=1e-12,
     disp : bool
         Set to ``True`` if indicators of optimization status are to be printed
         to the console each iteration.
+    unkown_options : dict
+        Optional arguments not used by this particular solver. If
+        `unknown_options` is non-empty a warning is issued listing all
+        unused options.
 
     Returns
     -------

--- a/scipy/optimize/_linprog_simplex.py
+++ b/scipy/optimize/_linprog_simplex.py
@@ -506,6 +506,10 @@ def _linprog_simplex(c, c0, A, b, maxiter=1000, disp=False, callback=None,
         prevent cycling. If False, choose pivots which should lead to a
         converged solution more quickly. The latter method is subject to
         cycling (non-convergence) in rare instances.
+    unkown_options : dict
+        Optional arguments not used by this particular solver. If
+        `unknown_options` is non-empty a warning is issued listing all
+        unused options.
 
     Returns
     -------


### PR DESCRIPTION
`unknown_options` is currently used in each of the linear programming
solvers (interior-point, simplex, revised-simplex) to warn users of any
options not used by that particular solver and is currently undocumented.

This commit documents this in each solver's docstring.