### PR TITLE
TST: dual_annealing set seed

### DIFF
--- a/scipy/optimize/tests/test__dual_annealing.py
+++ b/scipy/optimize/tests/test__dual_annealing.py
@@ -255,7 +255,8 @@ class TestDualAnnealing(TestCase):
             'method': 'SLSQP',
         }
         ret = dual_annealing(self.func, self.ld_bounds,
-                             local_search_options=minimizer_opts)
+                             local_search_options=minimizer_opts,
+                             seed=self.seed)
         assert_allclose(ret.fun, 0., atol=1e-7)
 
     def test_wrong_restart_temp(self):


### PR DESCRIPTION
Whilst developing code for a different minimiser this test started [failing](https://travis-ci.org/andyfaff/scipy/jobs/525549266) (without touching any `dual_annealing` code). I think it's due to the seed not being set on `dual_annealing`, different states of the numpy RNG could cause this. This PR sets a seed for the test that I'm experiencing the test failure.