### PR TITLE
ENH: stats: improve kendall_tau cache usage

### DIFF
--- a/scipy/stats/_stats.pyx
+++ b/scipy/stats/_stats.pyx
@@ -77,7 +77,7 @@ def von_mises_cdf(k_obj, x_obj):
 def _kendall_dis(intp_t[:] x, intp_t[:] y):
     cdef:
         intp_t sup = 1 + np.max(y)
-        intp_t[::1] arr = np.zeros(sup, dtype=np.intp)
+        intp_t[::1] arr = np.zeros(sup + ((sup - 1) >> 14), dtype=np.intp)
         intp_t i = 0, k = 0, size = x.size, idx
         int64_t dis = 0
 
@@ -87,7 +87,7 @@ def _kendall_dis(intp_t[:] x, intp_t[:] y):
                 dis += i
                 idx = y[k]
                 while idx != 0:
-                    dis -= arr[idx]
+                    dis -= arr[idx + (idx >> 14)]
                     idx = idx & (idx - 1)
 
                 k += 1
@@ -95,7 +95,7 @@ def _kendall_dis(intp_t[:] x, intp_t[:] y):
             while i < k:
                 idx = y[i]
                 while idx < sup:
-                    arr[idx] += 1
+                    arr[idx + (idx >> 14)] += 1
                     idx += idx & -idx
                 i += 1
 

--- a/scipy/stats/_stats.pyx
+++ b/scipy/stats/_stats.pyx
@@ -77,6 +77,7 @@ def von_mises_cdf(k_obj, x_obj):
 def _kendall_dis(intp_t[:] x, intp_t[:] y):
     cdef:
         intp_t sup = 1 + np.max(y)
+        # Use of `>> 14` improves cache performance of the Fenwick tree (see gh-10108)
         intp_t[::1] arr = np.zeros(sup + ((sup - 1) >> 14), dtype=np.intp)
         intp_t i = 0, k = 0, size = x.size, idx
         int64_t dis = 0


### PR DESCRIPTION
This pull request improves the cache efficiency of the subroutine used to compute the number of transposition in Kendall's τ computation. The timings in seconds on an Intel Core i7-7770 CPU @3.60GHz (Kaby Lake) are

    k        new                                       old
    18      0.05589556694030762     0.05243515968322754
    19      0.11377596855163574       0.10748624801635742
    20      0.2333989143371582       0.2219550609588623
    21      0.45459985733032227     0.4673912525177002
    22      0.9821414947509766       0.98244309425354
    23      2.0328445434570312      2.0543222427368164
    24      4.117265701293945         4.26338005065918
    25      8.355305671691895       8.964257001876831
    26      17.25917959213257         18.699312925338745
    27      35.32108664512634       38.955217361450195
    28      72.20554256439209       80.67914152145386
    29      144.18521857261658      162.25554394721985

The timings are for computing τ between a list of 2^k - 1 distinct elements and the the same list, reversed. The bigger the lists, the greater the improvement. The difference will vary depending on the cache architecture.