### PR TITLE
MAINT: _lib: Fix a build warning.

### DIFF
--- a/scipy/_lib/messagestream.pyx
+++ b/scipy/_lib/messagestream.pyx
@@ -64,7 +64,7 @@ cdef class MessageStream:
             try:
                 stdio.rewind(self.handle)
                 nread = stdio.fread(buf, 1, pos, self.handle)
-                if nread != pos:
+                if nread != <size_t>pos:
                     raise IOError("failed to read messages from buffer")
 
                 obj = PyBytes_FromStringAndSize(buf, nread)


### PR DESCRIPTION
Cast pos to size_t when comparing to nread.
Fixes this warning:

    gcc: scipy/_lib/messagestream.c
    scipy/_lib/messagestream.c:2050:35: warning: comparison of integers of different signs: 'size_t' (aka 'unsigned long') and 'long' [-Wsign-compare]
          __pyx_t_1 = ((__pyx_v_nread != __pyx_v_pos) != 0);
                        ~~~~~~~~~~~~~ ^  ~~~~~~~~~~~
    1 warning generated.