### PR TITLE
FIX: only print bounds when supported by minimizer (shgo)

### DIFF
--- a/scipy/optimize/_shgo.py
+++ b/scipy/optimize/_shgo.py
@@ -1146,13 +1146,14 @@ class SHGO(object):
             if 'bounds' in self.min_solver_args:
                 self.minimizer_kwargs['bounds'] = g_bounds
 
-            if self.disp:
-                print('bounds in kwarg:')
-                print(self.minimizer_kwargs['bounds'])
         else:
             g_bounds = self.construct_lcb_delaunay(x_min, ind=ind)
             if 'bounds' in self.min_solver_args:
                 self.minimizer_kwargs['bounds'] = g_bounds
+
+        if self.disp and 'bounds' in self.minimizer_kwargs:
+            print('bounds in kwarg:')
+            print(self.minimizer_kwargs['bounds'])
 
         # Local minimization using scipy.optimize.minimize:
         lres = minimize(self.func, x_min, **self.minimizer_kwargs)

--- a/scipy/optimize/tests/test__shgo.py
+++ b/scipy/optimize/tests/test__shgo.py
@@ -645,6 +645,12 @@ class TestShgoArguments(object):
         run_test(test1_1, n=1, iters=7, options=options,
                  sampling_method='sobol')
 
+    def test_16_disp_bounds_minimizer(self):
+        """Test disp=True with minimizers that do not support bounds """
+        options = {'disp': True}
+        minimizer_kwargs = {'method': 'nelder-mead'}
+        run_test(test1_2, sampling_method='simplicial',
+                 options=options, minimizer_kwargs=minimizer_kwargs)
 
 # Failure test functions
 class TestShgoFailures(object):


### PR DESCRIPTION
Currently, the ```scipy.optimize.shgo``` throws a ```KeyError``` for minimizer that do not support bounds in combination with ```disp=True``` and ```sampling_method='simplicial'```.

```
import numpy as np
from scipy.optimize import rosen, shgo

bounds = [(0,2), (0, 2), (0, 2), (0, 2), (0, 2)]
result = shgo(rosen, bounds, options={'disp': True}, minimizer_kwargs={'method': 'nelder-mead'})
```

results in:
```
Splitting first generation
Starting minimization at [1. 1. 1. 1. 1.]...
bounds in kwarg:
Traceback (most recent call last):
  File "shgo_scipy.py", line 6, in <module>
    minimizer_kwargs={'method': 'nelder-mead'})
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/scipy/optimize/_shgo.py", line 423, in shgo
    shc.construct_complex()
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/scipy/optimize/_shgo.py", line 733, in construct_complex
    self.find_minima()
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/scipy/optimize/_shgo.py", line 747, in find_minima
    self.minimise_pool(self.local_iter)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/scipy/optimize/_shgo.py", line 972, in minimise_pool
    lres_f_min = self.minimize(self.X_min[0], ind=self.minimizer_pool[0])
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/scipy/optimize/_shgo.py", line 1153, in minimize
    print(self.minimizer_kwargs['bounds'])
KeyError: 'bounds'
```

this PR fixes that by only printing it when ```bounds``` are in ```self.minimizer_kwargs```. Additionally, I have moved the code outside of the ```if self.sampling_method == 'simplicial':``` block as I suppose it should be printed as well when using ```sampling_method=sobol```. Perhaps @Stefan-Endres  can take a loot at this?