### PR TITLE
MAINT: improve rvs of randint in scipy.stats

### DIFF
--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -741,6 +741,9 @@ class randint_gen(rv_discrete):
 
     def _rvs(self, low, high):
         """An array of *size* random integers >= ``low`` and < ``high``."""
+        if np.asarray(low).size == 1 and np.asarray(high).size == 1:
+            # no need to vectorize in that case
+            return self._random_state.randint(low, high, size=self._size)
         if self._size is not None:
             # NumPy's RandomState.randint() doesn't broadcast its arguments.
             # Use `broadcast_to()` to extend the shapes of low and high

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -194,7 +194,7 @@ class TestRandInt(object):
         assert_array_almost_equal(vals, out)
 
     def test_cdf(self):
-        x = np.linspace(0,36,100)
+        x = np.linspace(0, 36, 100)
         k = numpy.floor(x)
         out = numpy.select([k >= 30, k >= 5], [1.0, (k-5.0+1)/(30-5.0)], 0)
         vals = stats.randint.cdf(x, 5, 30)


### PR DESCRIPTION
avoid `np.vectorize` in stats.randint if scalar parameters are used
This leads to a considerable reduction of the time needed to sample rvs:

```
timeit(randint2.rvs(0, 10, size=1000))
# before change (SciPy 1.2.1)
10.3 ms ± 23.4 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
# after change
268 µs ± 1.52 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```

cross-ref #10106