### PR TITLE
TST: refine Azure fail reports

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,8 +34,8 @@ jobs:
            cd ../scipy && \
            F77=gfortran-5 F90=gfortran-5 python3.6 runtests.py --mode=full -- -n auto -rsx --junitxml=junit/test-results.xml --cov=scipy --cov-report=xml --cov-report=html"
     displayName: 'Run 32-bit Ubuntu Docker Build / Tests'
-    continueOnError: true
   - task: PublishTestResults@2
+    condition: succeededOrFailed()
     inputs:
       testResultsFiles: '**/test-*.xml'
       failTaskOnFailedTests: true
@@ -131,8 +131,8 @@ jobs:
       $env:PATH = "C:\\ProgramData\\chocolatey\\lib\\mingw\\tools\\install\\mingw$(BITS)\\bin;" + $env:PATH
       python runtests.py -n --mode=$(TEST_MODE) -- -n auto -rsx --junitxml=junit/test-results.xml --cov=scipy --cov-report=xml --cov-report=html
     displayName: 'Run SciPy Test Suite'
-    continueOnError: true
   - task: PublishTestResults@2
+    condition: succeededOrFailed()
     inputs:
       testResultsFiles: '**/test-*.xml'
       failTaskOnFailedTests: true


### PR DESCRIPTION
See upstream discussion and fix; in short, removes Azure susceptibility to reporting success when a SciPy build fails before tests run
https://github.com/numpy/numpy/issues/13452
https://github.com/numpy/numpy/pull/13456

* Azure CI should no longer report
success when there are failures
outside of the test suite

* Azure CI will still always try
to publish test results, except
when a pipeline is manually cancelled