### PR TITLE
ENH: add method that creates new spline for a partial derivative of bivariate spline

### DIFF
--- a/scipy/interpolate/fitpack/pardtc.f
+++ b/scipy/interpolate/fitpack/pardtc.f
@@ -24,7 +24,7 @@ c   nuy     derivative. 0<=nux<kx, 0<=nuy<ky.
 c
 c  output parameters:
 c   newc  : real array containing the coefficients of the derivative.
-c           the dimension is (nx-3*nux-kx-1)*(ny-3*nuy-ky-1).
+c           the dimension is (nx-nux-kx-1)*(ny-nuy-ky-1).
 c   ier   : integer error flag
 c    ier=0 : normal return
 c    ier=10: invalid input data (see restrictions)
@@ -52,13 +52,13 @@ c
 c  latest update : may 2019
 c
 c  ..scalar arguments..
-      integer nx,ny,kx,ky,newkx,newky,nux,nuy,ier
+      integer nx,ny,kx,ky,nux,nuy,ier
 c  ..array arguments..
       real*8 tx(nx),ty(ny),c((nx-kx-1)*(ny-ky-1)),
-     * newc((nx-3*nux-kx-1)*(ny-3*nuy-ky-1))
+     * newc((nx-nux-kx-1)*(ny-nuy-ky-1))
 c  ..local scalars..
       integer i,j,kx1,ky1,lx,ly,l1,l2,m,m0,m1,
-     * nc,nkx1,nky1,nxx,nyy
+     * nc,nkx1,nky1,nxx,nyy,newkx,newky
       real*8 ak,fac
 c  ..
 c  before starting computations a data check is made. if the input data

--- a/scipy/interpolate/fitpack/pardtc.f
+++ b/scipy/interpolate/fitpack/pardtc.f
@@ -55,22 +55,22 @@ c  ..scalar arguments..
       integer nx,ny,kx,ky,nux,nuy,ier
 c  ..array arguments..
       real*8 tx(nx),ty(ny),c((nx-kx-1)*(ny-ky-1)),
-     * newc((nx-nux-kx-1)*(ny-nuy-ky-1))
+     * newc((nx-kx-1)*(ny-ky-1))
 c  ..local scalars..
       integer i,j,kx1,ky1,lx,ly,l1,l2,m,m0,m1,
-     * nc,nkx1,nky1,nxx,nyy,newkx,newky
+     * nnewc,nkx1,nky1,nxx,nyy,newkx,newky
       real*8 ak,fac
 c  ..
 c  before starting computations a data check is made. if the input data
 c  are invalid control is immediately repassed to the calling program.
       ier = 10
+      if(nux.lt.0 .or. nux.ge.kx) go to 400
+      if(nuy.lt.0 .or. nuy.ge.ky) go to 400
       kx1 = kx+1
       ky1 = ky+1
       nkx1 = nx-kx1
       nky1 = ny-ky1
       nc = nkx1*nky1
-      if(nux.lt.0 .or. nux.ge.kx) go to 400
-      if(nuy.lt.0 .or. nuy.ge.ky) go to 400
       ier = 0
       nxx = nkx1
       nyy = nky1

--- a/scipy/interpolate/fitpack/pardtc.f
+++ b/scipy/interpolate/fitpack/pardtc.f
@@ -1,0 +1,155 @@
+      subroutine pardtc(tx,nx,ty,ny,c,kx,ky,nux,nuy,newc,ier)
+c  subroutine pardtc takes the knots and coefficients of a bivariate
+c  spline, and returns the coefficients for a new bivariate spline that
+c  evaluates the partial derivative (order nux, nuy) of the original
+c  spline.
+c
+c  calling sequence:
+c     call pardtc(tx,nx,ty,ny,c,kx,ky,nux,nuy,newc,ier)
+c
+c  input parameters:
+c   tx    : real array, length nx, which contains the position of the
+c           knots in the x-direction.
+c   nx    : integer, giving the total number of knots in the x-direction
+c           (hidden)
+c   ty    : real array, length ny, which contains the position of the
+c           knots in the y-direction.
+c   ny    : integer, giving the total number of knots in the y-direction
+c           (hidden)
+c   c     : real array, length (nx-kx-1)*(ny-ky-1), which contains the
+c           b-spline coefficients.
+c   kx,ky : integer values, giving the degrees of the spline.
+c   nux   : integer values, specifying the order of the partial
+c   nuy     derivative. 0<=nux<kx, 0<=nuy<ky.
+c
+c  output parameters:
+c   newc  : real array containing the coefficients of the derivative.
+c           the dimension is (nx-3*nux-kx-1)*(ny-3*nuy-ky-1).
+c   ier   : integer error flag
+c    ier=0 : normal return
+c    ier=10: invalid input data (see restrictions)
+c
+c  restrictions:
+c   0 <= nux < kx, 0 <= nuy < kyc
+c
+c  other subroutines required:
+c    none
+c
+c  references :
+c   de boor c  : on calculating with b-splines, j. approximation theory
+c                6 (1972) 50-62.
+c   dierckx p. : curve and surface fitting with splines, monographs on
+c                numerical analysis, oxford university press, 1993.
+c
+c  based on the subroutine "parder" by Paul Dierckx.
+c
+c  author :
+c    Cong Ma
+c    Department of Mathematics and Applied Mathematics, U. of Cape Town
+c    Cross Campus Road, Rondebosch 7700, Cape Town, South Africa.
+c    e-mail : cong.ma@uct.ac.za
+c
+c  latest update : may 2019
+c
+c  ..scalar arguments..
+      integer nx,ny,kx,ky,newkx,newky,nux,nuy,ier
+c  ..array arguments..
+      real*8 tx(nx),ty(ny),c((nx-kx-1)*(ny-ky-1)),
+     * newc((nx-3*nux-kx-1)*(ny-3*nuy-ky-1))
+c  ..local scalars..
+      integer i,j,kx1,ky1,lx,ly,l1,l2,m,m0,m1,
+     * nc,nkx1,nky1,nxx,nyy
+      real*8 ak,fac
+c  ..
+c  before starting computations a data check is made. if the input data
+c  are invalid control is immediately repassed to the calling program.
+      ier = 10
+      kx1 = kx+1
+      ky1 = ky+1
+      nkx1 = nx-kx1
+      nky1 = ny-ky1
+      nc = nkx1*nky1
+      if(nux.lt.0 .or. nux.ge.kx) go to 400
+      if(nuy.lt.0 .or. nuy.ge.ky) go to 400
+      ier = 0
+      nxx = nkx1
+      nyy = nky1
+      newkx = kx
+      newky = ky
+c  the partial derivative of order (nux,nuy) of a bivariate spline of
+c  degrees kx,ky is a bivariate spline of degrees kx-nux,ky-nuy.
+c  we calculate the b-spline coefficients of this spline
+c  that is to say newkx = kx - nux, newky = ky - nuy
+      do 70 i=1,nc
+        newc(i) = c(i)
+  70  continue
+      if(nux.eq.0) go to 200
+      lx = 1
+      do 100 j=1,nux
+        ak = newkx
+        nxx = nxx-1
+        l1 = lx
+        m0 = 1
+        do 90 i=1,nxx
+          l1 = l1+1
+          l2 = l1+newkx
+          fac = tx(l2)-tx(l1)
+          if(fac.le.0.) go to 90
+          do 80 m=1,nyy
+            m1 = m0+nyy
+            newc(m0) = (newc(m1)-newc(m0))*ak/fac
+            m0  = m0+1
+  80      continue
+  90    continue
+        lx = lx+1
+        newkx = newkx-1
+ 100  continue
+ 200  if(nuy.eq.0) go to 400
+c orig: if(nuy.eq.0) go to 300
+      ly = 1
+      do 230 j=1,nuy
+        ak = newky
+        nyy = nyy-1
+        l1 = ly
+        do 220 i=1,nyy
+          l1 = l1+1
+          l2 = l1+newky
+          fac = ty(l2)-ty(l1)
+          if(fac.le.0.) go to 220
+          m0 = i
+          do 210 m=1,nxx
+            m1 = m0+1
+            newc(m0) = (newc(m1)-newc(m0))*ak/fac
+            m0  = m0+nky1
+ 210      continue
+ 220    continue
+        ly = ly+1
+        newky = newky-1
+ 230  continue
+      m0 = nyy
+      m1 = nky1
+      do 250 m=2,nxx
+        do 240 i=1,nyy
+          m0 = m0+1
+          m1 = m1+1
+          newc(m0) = newc(m1)
+ 240    continue
+        m1 = m1+nuy
+ 250  continue
+c300  iwx = 1+nxx*nyy
+c     iwy = iwx+mx*(kx1-nux)
+c
+c from parder.f:
+c     call fpbisp(tx(nux+1),nx-2*nux,ty(nuy+1),ny-2*nuy,newc,newkx,newky,
+c    * x,mx,y,my,z,newc(iwx),newc(iwy),iwrk(1),iwrk(mx+1))
+c
+c from bispev.f:
+c     call fpbisp(tx,       nx,      ty,       ny,      c,   kx,   ky,
+c    * x,mx,y,my,z,wrk(1),   wrk(iw),  iwrk(1),iwrk(mx+1))
+c
+c from fpbisp.f:
+c          fpbisp(tx,       nx,      ty,       ny,      c,   kx,   ky,
+c    * x,mx,y,my,z,wx,       wy,       lx,     ly)
+ 400  return
+      end
+

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -1076,7 +1076,7 @@ class BivariateSpline(_BivariateSplineBase):
         Returns
         -------
         spline :
-            Another spline of the same class, of order (kx - nx, ky - ny),
+            Another spline of the same class, of order (kx - nux, ky - nuy),
             representing the derivative of this spline.
         """
         if nux == 0 and nuy == 0:
@@ -1092,7 +1092,8 @@ class BivariateSpline(_BivariateSplineBase):
             newtx = tx[nux:nx - nux]
             newty = ty[nuy:ny - nuy]
             newkx, newky = kx - nux, ky - nuy
-            return self._from_tck((newtx, newty, newc, newkx, newky))
+            newclen = (nx - nux - kx - 1) * (ny - nuy - ky - 1)
+            return self._from_tck((newtx, newty, newc[:newclen], newkx, newky))
 
 
 class SmoothBivariateSpline(BivariateSpline):

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -1114,6 +1114,25 @@ class BivariateSpline(_BivariateSplineBase):
         kx, ky = self.degrees
         return dfitpack.dblint(tx, ty, c, kx, ky, xa, xb, ya, yb)
 
+    @staticmethod
+    def _validate_input(x, y, z, w, kx, ky, eps):
+        x, y, z = np.asarray(x), np.asarray(y), np.asarray(z)
+        if not x.size == y.size == z.size:
+            raise ValueError('x, y, and z should have a same length')
+
+        if w is not None:
+            w = np.asarray(w)
+            if x.size != w.size:
+                raise ValueError('x, y, z, and w should have a same length')
+            elif not np.all(w >= 0.0):
+                raise ValueError('w should be positive')
+        if (eps is not None) and (not 0.0 < eps < 1.0):
+            raise ValueError('eps should be between (0, 1)')
+        if not x.size >= (kx + 1) * (ky + 1):
+            raise ValueError('The length of x, y and z should be at least'
+                             ' (kx+1) * (ky+1)')
+        return x, y, z, w
+
 
 class _DerivedBivariateSpline(_BivariateSplineBase):
     """Bivariate spline constructed from the coefficients and knots of another

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -1081,6 +1081,16 @@ class BivariateSpline(_BivariateSplineBase):
         spline :
             A new spline of degrees (kx - nux, ky - nuy) representing the
             derivative of this spline.
+
+        Notes
+        -----
+        The returned spline is an instance of the class
+        ``_DerivedBivariateSpline`` that supports spline evaluation operations,
+        but is not directly constructed from original data.
+
+        See Also
+        --------
+        _DerivedBivariateSpline
         """
         if nux == 0 and nuy == 0:
             return self
@@ -1104,7 +1114,36 @@ class BivariateSpline(_BivariateSplineBase):
             newty = ty[nuy:ny - nuy]
             newkx, newky = kx - nux, ky - nuy
             newclen = (nx - nux - kx - 1) * (ny - nuy - ky - 1)
-            return self._from_tck((newtx, newty, newc[:newclen], newkx, newky))
+            return _DerivedBivariateSpline._from_tck((newtx, newty,
+                                                      newc[:newclen],
+                                                      newkx, newky))
+
+
+class _DerivedBivariateSpline(BivariateSpline):
+    """Bivariate spline constructed from the coefficients and knots of another
+    spline.
+
+    Notes
+    -----
+    The class is not meant to be instantiated directly from the data to be
+    interpolated or smoothed. As a result, its ``fp`` attribute and
+    ``get_residual`` method are inherited but overriden; ``AttributeError`` is
+    raised when they are accessed.
+
+    The other inherited attributes can be used as usual.
+    """
+    __invalid_why = ("is unavailable, because _DerivedBivariateSpline"
+                     " instance is not constructed from data that are to be"
+                     " interpolated or smoothed, but derived from the"
+                     " underlying knots and coefficients of another spline"
+                     " object")
+
+    @property
+    def fp(self):
+        raise AttributeError("attribute \"fp\" %s" % self.__invalid_why)
+
+    def get_residual(self):
+        raise AttributeError("method \"get_residual\" %s" % self.__invalid_why)
 
 
 class SmoothBivariateSpline(BivariateSpline):

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -965,10 +965,6 @@ class _BivariateSplineBase(object):
         The returned spline is an instance of the class
         ``_DerivedBivariateSpline`` that supports spline evaluation operations,
         but is not directly constructed from original data.
-
-        See Also
-        --------
-        _DerivedBivariateSpline
         """
         if nux == 0 and nuy == 0:
             return self

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -984,8 +984,8 @@ class BivariateSpline(_BivariateSplineBase):
     of data points ``(x, y, z)``.
 
     This class is meant to be subclassed, not instantiated directly.
-    To construct these splines, call either `SmoothBivariateSpline` or
-    `LSQBivariateSpline` or `RectBivariateSpline`.
+    To construct these splines, call `SmoothBivariateSpline`,
+    `LSQBivariateSpline`, or `RectBivariateSpline`.
 
     See Also
     --------
@@ -997,6 +997,7 @@ class BivariateSpline(_BivariateSplineBase):
         a bivariate spline using weighted least-squares fitting
     RectSphereBivariateSpline :
         a bivariate spline over a rectangular mesh on a sphere
+        to create a BivariateSpline using weighted least-squares fitting
     SmoothSphereBivariateSpline :
         a smoothing bivariate spline in spherical coordinates
     LSQSphereBivariateSpline :

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -1064,13 +1064,13 @@ class BivariateSpline(_BivariateSplineBase):
         kx, ky = self.degrees
         return dfitpack.dblint(tx, ty, c, kx, ky, xa, xb, ya, yb)
 
-    def partial_derivative(self, nx, ny):
+    def partial_derivative(self, nux, nuy):
         """Construct a new spline representing a partial derivative of this
         spline.
 
         Parameters
         ----------
-        nx, ny : int
+        nux, nuy : int
             Orders of the derivative in x and y respectively.
 
         Returns
@@ -1079,17 +1079,19 @@ class BivariateSpline(_BivariateSplineBase):
             Another spline of the same class, of order (kx - nx, ky - ny),
             representing the derivative of this spline.
         """
-        if nx == 0 and ny == 0:
+        if nux == 0 and nuy == 0:
             return self
         else:
             tx, ty, c = self.tck[:3]
             kx, ky = self.degrees
-            newc, ier = pardtc(tx, ty, c, kx, ky, nx, ny)
+            newc, ier = dfitpack.pardtc(tx, ty, c, kx, ky, nux, nuy)
             if not ier == 0:
                 raise ValueError("Error code returned by pardtc: %s" % ier)
-            newtx = tx[nx:len(tx) - 2 * nx]
-            newty = tx[ny:len(tx) - 2 * ny]
-            newkx, newky = kx - nx, ky - ny
+            nx = len(tx)
+            ny = len(ty)
+            newtx = tx[nux:nx - nux]
+            newty = ty[nuy:ny - nuy]
+            newkx, newky = kx - nux, ky - nuy
             return self._from_tck((newtx, newty, newc, newkx, newky))
 
 

--- a/scipy/interpolate/src/fitpack.pyf
+++ b/scipy/interpolate/src/fitpack.pyf
@@ -416,7 +416,7 @@ static F_INT calc_regrid_lwrk(F_INT mx, F_INT my, F_INT kx, F_INT ky,
        integer intent(in),check((1 <= ky) && (ky <= 5)) :: ky
        integer intent(in),depend(kx),check((0 <= nux) && (nux < kx)) :: nux
        integer intent(in),depend(ky),check((0 <= nuy) && (nux < ky)) :: nuy
-       real*8 dimension((nx-nux-kx-1)*(ny-nuy-ky-1)),&
+       real*8 dimension((nx-kx-1)*(ny-ky-1)),&
             depend(nx,ny,nux,nuy,kx,ky),intent(out) :: newc
        integer intent(out) :: ier
      end subroutine pardtc

--- a/scipy/interpolate/src/fitpack.pyf
+++ b/scipy/interpolate/src/fitpack.pyf
@@ -403,6 +403,24 @@ static F_INT calc_regrid_lwrk(F_INT mx, F_INT my, F_INT kx, F_INT ky,
        integer intent(out) :: ier
      end subroutine parder
 
+     subroutine pardtc(tx,nx,ty,ny,c,kx,ky,nux,nuy,newc,ier)
+       ! newc,ier = pardtc(tx,ty,c,kx,ky,nux,nuy)
+       threadsafe
+       real*8 dimension(nx),intent(in) :: tx
+       integer intent(hide),depend(tx) :: nx=len(tx)
+       real*8 dimension(ny),intent(in) :: ty
+       integer intent(hide),depend(ty) :: ny=len(ty)
+       real*8 intent(in),dimension((nx-kx-1)*(ny-ky-1)),depend(nx,ny,kx,ky),&
+            check(len(c)==(nx-kx-1)*(ny-ky-1)) :: c
+       integer intent(in),check((1 <= kx) && (kx <= 5)) :: kx
+       integer intent(in),check((1 <= ky) && (ky <= 5)) :: ky
+       integer intent(in),depend(kx),check((0 <= nux) && (nux < kx)) :: nux
+       integer intent(in),depend(ky),check((0 <= nuy) && (nux < ky)) :: nux
+       real*8 dimension((nx-3*nux-kx-1)*(ny-3*nuy-ky-1)),&
+            depend(nx,ny,nux,nuy,kx,ky),intent(out) :: newc
+       integer intent(out) :: ier
+     end subroutine pardtc
+
      subroutine bispeu(tx,nx,ty,ny,c,kx,ky,x,y,z,m,wrk,lwrk,ier)
        ! z,ier = bispeu(tx,ty,c,kx,ky,x,y)
        threadsafe

--- a/scipy/interpolate/src/fitpack.pyf
+++ b/scipy/interpolate/src/fitpack.pyf
@@ -410,13 +410,13 @@ static F_INT calc_regrid_lwrk(F_INT mx, F_INT my, F_INT kx, F_INT ky,
        integer intent(hide),depend(tx) :: nx=len(tx)
        real*8 dimension(ny),intent(in) :: ty
        integer intent(hide),depend(ty) :: ny=len(ty)
-       real*8 intent(in),dimension((nx-kx-1)*(ny-ky-1)),depend(nx,ny,kx,ky),&
-            check(len(c)==(nx-kx-1)*(ny-ky-1)) :: c
+       real*8 intent(in),dimension((nx-kx-1)*(ny-ky-1)),&
+            depend(nx,ny,kx,ky),check(len(c)==(nx-kx-1)*(ny-ky-1)) :: c
        integer intent(in),check((1 <= kx) && (kx <= 5)) :: kx
        integer intent(in),check((1 <= ky) && (ky <= 5)) :: ky
        integer intent(in),depend(kx),check((0 <= nux) && (nux < kx)) :: nux
-       integer intent(in),depend(ky),check((0 <= nuy) && (nux < ky)) :: nux
-       real*8 dimension((nx-3*nux-kx-1)*(ny-3*nuy-ky-1)),&
+       integer intent(in),depend(ky),check((0 <= nuy) && (nux < ky)) :: nuy
+       real*8 dimension((nx-nux-kx-1)*(ny-nuy-ky-1)),&
             depend(nx,ny,nux,nuy,kx,ky),intent(out) :: newc
        integer intent(out) :: ier
      end subroutine pardtc

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -995,6 +995,40 @@ class TestRectSphereBivariateSpline(object):
         zi2 = array([lut(xp, yp)[0,0] for xp, yp in zip(xi, yi)])
         assert_almost_equal(zi, zi2)
 
+    def test_invalid_input(self):
+        data = np.dot(np.atleast_2d(90. - np.linspace(-80., 80., 18)).T,
+                      np.atleast_2d(180. - np.abs(np.linspace(0., 350., 9)))).T
+
+        with assert_raises(ValueError) as exc_info:
+            lats = np.linspace(-1, 170, 9) * np.pi / 180.
+            lons = np.linspace(0, 350, 18) * np.pi / 180.
+            RectSphereBivariateSpline(lats, lons, data)
+        assert "u should be between [0, pi]" in str(exc_info.value)
+
+        with assert_raises(ValueError) as exc_info:
+            lats = np.linspace(10, 181, 9) * np.pi / 180.
+            lons = np.linspace(0, 350, 18) * np.pi / 180.
+            RectSphereBivariateSpline(lats, lons, data)
+        assert "u should be between [0, pi]" in str(exc_info.value)
+
+        with assert_raises(ValueError) as exc_info:
+            lats = np.linspace(10, 170, 9) * np.pi / 180.
+            lons = np.linspace(-181, 10, 18) * np.pi / 180.
+            RectSphereBivariateSpline(lats, lons, data)
+        assert "v[0] should be between [-pi, pi)" in str(exc_info.value)
+
+        with assert_raises(ValueError) as exc_info:
+            lats = np.linspace(10, 170, 9) * np.pi / 180.
+            lons = np.linspace(-10, 360, 18) * np.pi / 180.
+            RectSphereBivariateSpline(lats, lons, data)
+        assert "v[-1] should be v[0] + 2pi or less" in str(exc_info.value)
+
+        with assert_raises(ValueError) as exc_info:
+            lats = np.linspace(10, 170, 9) * np.pi / 180.
+            lons = np.linspace(10, 350, 18) * np.pi / 180.
+            RectSphereBivariateSpline(lats, lons, data, s=-1)
+        assert "s should be positive" in str(exc_info.value)
+
     def test_derivatives_grid(self):
         y = linspace(0.01, 2*pi-0.01, 7)
         x = linspace(0.01, pi-0.01, 7)

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -892,6 +892,14 @@ class TestRectBivariateSpline(object):
                                                                grid=False),
                                   dxdy)
 
+    def test_partial_derivative_order_too_large(self):
+        x = array([0, 1, 2, 3, 4], dtype=float)
+        y = x.copy()
+        z = ones((x.size, y.size))
+        lut = RectBivariateSpline(x, y, z)
+        with assert_raises(ValueError):
+            dlut = lut.partial_derivative(4, 1)
+
     def test_broadcast(self):
         x = array([1,2,3,4,5])
         y = array([1,2,3,4,5])

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -859,6 +859,39 @@ class TestRectBivariateSpline(object):
         assert_array_almost_equal(lut(x,y,dy=1,grid=False),dy)
         assert_array_almost_equal(lut(x,y,dx=1,dy=1,grid=False),dxdy)
 
+    def test_partial_derivative_method_grid(self):
+        x = array([1,2,3,4,5])
+        y = array([1,2,3,4,5])
+        z = array([[1,2,1,2,1],[1,2,1,2,1],[1,2,3,2,1],[1,2,2,2,1],[1,2,1,2,1]])
+        dx = array([[0,0,-20,0,0],[0,0,13,0,0],[0,0,4,0,0],
+            [0,0,-11,0,0],[0,0,4,0,0]])/6.
+        dy = array([[4,-1,0,1,-4],[4,-1,0,1,-4],[0,1.5,0,-1.5,0],
+            [2,.25,0,-.25,-2],[4,-1,0,1,-4]])
+        dxdy = array([[40,-25,0,25,-40],[-26,16.25,0,-16.25,26],
+            [-8,5,0,-5,8],[22,-13.75,0,13.75,-22],[-8,5,0,-5,8]])/6.
+        lut = RectBivariateSpline(x,y,z)
+        assert_array_almost_equal(lut.partial_derivative(1, 0)(x, y), dx)
+        assert_array_almost_equal(lut.partial_derivative(0, 1)(x, y), dy)
+        assert_array_almost_equal(lut.partial_derivative(1, 1)(x, y), dxdy)
+
+    def test_partial_derivative_method(self):
+        x = array([1,2,3,4,5])
+        y = array([1,2,3,4,5])
+        z = array([[1,2,1,2,1],[1,2,1,2,1],[1,2,3,2,1],[1,2,2,2,1],[1,2,1,2,1]])
+        dx = array([0,0,2./3,0,0])
+        dy = array([4,-1,0,-.25,-4])
+        dxdy = array([160,65,0,55,32])/24.
+        lut = RectBivariateSpline(x,y,z)
+        assert_array_almost_equal(lut.partial_derivative(1, 0)(x, y,
+                                                               grid=False),
+                                  dx)
+        assert_array_almost_equal(lut.partial_derivative(0, 1)(x, y,
+                                                               grid=False),
+                                  dy)
+        assert_array_almost_equal(lut.partial_derivative(1, 1)(x, y,
+                                                               grid=False),
+                                  dxdy)
+
     def test_broadcast(self):
         x = array([1,2,3,4,5])
         y = array([1,2,3,4,5])

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -1014,6 +1014,13 @@ class TestRectSphereBivariateSpline(object):
         assert_allclose(lut(x, y, dtheta=1, dphi=1), _numdiff_2d(lut, x, y, dx=1, dy=1, eps=1e-6),
                         rtol=1e-3, atol=1e-3)
 
+        assert_array_equal(lut(x, y, dtheta=1),
+                           lut.partial_derivative(1, 0)(x, y))
+        assert_array_equal(lut(x, y, dphi=1),
+                           lut.partial_derivative(0, 1)(x, y))
+        assert_array_equal(lut(x, y, dtheta=1, dphi=1),
+                           lut.partial_derivative(1, 1)(x, y))
+
     def test_derivatives(self):
         y = linspace(0.01, 2*pi-0.01, 7)
         x = linspace(0.01, pi-0.01, 7)
@@ -1037,39 +1044,12 @@ class TestRectSphereBivariateSpline(object):
                         _numdiff_2d(lambda x,y: lut(x,y,grid=False), x, y, dx=1, dy=1, eps=1e-6),
                         rtol=1e-3, atol=1e-3)
 
-    def test_invalid_input(self):
-        data = np.dot(np.atleast_2d(90. - np.linspace(-80., 80., 18)).T,
-                      np.atleast_2d(180. - np.abs(np.linspace(0., 350., 9)))).T
-
-        with assert_raises(ValueError) as exc_info:
-            lats = np.linspace(-1, 170, 9) * np.pi / 180.
-            lons = np.linspace(0, 350, 18) * np.pi / 180.
-            RectSphereBivariateSpline(lats, lons, data)
-        assert "u should be between [0, pi]" in str(exc_info.value)
-
-        with assert_raises(ValueError) as exc_info:
-            lats = np.linspace(10, 181, 9) * np.pi / 180.
-            lons = np.linspace(0, 350, 18) * np.pi / 180.
-            RectSphereBivariateSpline(lats, lons, data)
-        assert "u should be between [0, pi]" in str(exc_info.value)
-
-        with assert_raises(ValueError) as exc_info:
-            lats = np.linspace(10, 170, 9) * np.pi / 180.
-            lons = np.linspace(-181, 10, 18) * np.pi / 180.
-            RectSphereBivariateSpline(lats, lons, data)
-        assert "v[0] should be between [-pi, pi)" in str(exc_info.value)
-
-        with assert_raises(ValueError) as exc_info:
-            lats = np.linspace(10, 170, 9) * np.pi / 180.
-            lons = np.linspace(-10, 360, 18) * np.pi / 180.
-            RectSphereBivariateSpline(lats, lons, data)
-        assert "v[-1] should be v[0] + 2pi or less" in str(exc_info.value)
-
-        with assert_raises(ValueError) as exc_info:
-            lats = np.linspace(10, 170, 9) * np.pi / 180.
-            lons = np.linspace(10, 350, 18) * np.pi / 180.
-            RectSphereBivariateSpline(lats, lons, data, s=-1)
-        assert "s should be positive" in str(exc_info.value)
+        assert_array_equal(lut(x, y, dtheta=1, grid=False),
+                           lut.partial_derivative(1, 0)(x, y, grid=False))
+        assert_array_equal(lut(x, y, dphi=1, grid=False),
+                           lut.partial_derivative(0, 1)(x, y, grid=False))
+        assert_array_equal(lut(x, y, dtheta=1, dphi=1, grid=False),
+                           lut.partial_derivative(1, 1)(x, y, grid=False))
 
     def test_array_like_input(self):
         y = linspace(0.01, 2 * pi - 0.01, 7)


### PR DESCRIPTION
This changeset addresses issue #2047 by adding a method `partial_derivative` to the base class `BivariateSpline`.

<s>The major benefit is increased performance when evaluating derivatives with `grid=False`.</s> The major benefit is increased performance from reduction of call overhead. A typical usage case where this benefit may show up is the repeated evaluation of a particular derivative of the same spline with scalar arguments, for example in the integrand function of numerical quadrature using `scipy.integrate.dblquad` or `scipy.integrate.nquad`. Coefficients for the new spline representing the derivative are evaluated once and reused for each subsequent evaluations.

```Python console
In [1]: %paste                                                                  
import numpy
import scipy.interpolate as spi

xs = numpy.linspace(0, numpy.pi, 100)
ys = xs.copy()
zs = numpy.sin(xs[:, None] + ys[None, :])

orig = spi.RectBivariateSpline(xs, ys, zs)
der = orig.partial_derivative(0, 1)
## -- End pasted text --

In [2]: %timeit orig(0.23, 0.23, 0, 1, grid=False)                              
28.9 µs ± 322 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)

In [3]: %timeit der(0.23, 0.23, grid=False)                                     
3.88 µs ± 45.6 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```

The implementation uses a modified version of the FORTRAN code `parder.f`, named `pardtc.f`, to evaluate the new coefficients. The knot and coefficient arrays are then sliced in the Python code and passed to the `_from_tck` private classmethod to construct a new instance.

Things that I'm unsure of:

- maintainability of duplicated FORTRAN code
- better organization of unit tests for the bivariate splines (duplicated code; might want to do housekeeping in a separate changeset)
- whether it will play nice with typical subclasses of `BivariateSpline`

and I'd like to hear your comments. Thanks!

*edit*: more accurate description for the usage case where this could be beneficial.