### PR TITLE
MAINT: ndimage: Fix some compiler warnings.

### DIFF
--- a/scipy/ndimage/src/_ni_label.pyx
+++ b/scipy/ndimage/src/_ni_label.pyx
@@ -57,7 +57,7 @@ ctypedef fused data_t:
 ######################################################################
 cdef void fused_nonzero_line(data_t *p, np.intp_t stride,
                              np.uintp_t *line, np.intp_t L) nogil:
-    cdef np.uintp_t i
+    cdef np.intp_t i
     for i in range(L):
         line[i] = FOREGROUND if \
             (<data_t *> ((<char *> p) + i * stride))[0] \
@@ -69,7 +69,7 @@ cdef void fused_nonzero_line(data_t *p, np.intp_t stride,
 ######################################################################
 cdef void fused_read_line(data_t *p, np.intp_t stride,
                           np.uintp_t *line, np.intp_t L) nogil:
-    cdef np.uintp_t i
+    cdef np.intp_t i
     for i in range(L):
         line[i] = <np.uintp_t> (<data_t *> ((<char *> p) + i * stride))[0]
 
@@ -80,7 +80,7 @@ cdef void fused_read_line(data_t *p, np.intp_t stride,
 ######################################################################
 cdef bint fused_write_line(data_t *p, np.intp_t stride,
                            np.uintp_t *line, np.intp_t L) nogil:
-    cdef np.uintp_t i
+    cdef np.intp_t i
     for i in range(L):
         # Check before overwrite, as this prevents us accidentally writing a 0
         # in the foreground, which allows us to retry even when operating
@@ -178,7 +178,7 @@ cdef np.uintp_t label_line_with_neighbor(np.uintp_t *line,
                                          np.uintp_t next_region,
                                          np.uintp_t *mergetable) nogil:
     cdef:
-        np.uintp_t i
+        np.intp_t i
 
     for i in range(L):
         if line[i] != BACKGROUND:
@@ -257,7 +257,7 @@ cpdef _label(np.ndarray input,
         np.uintp_t *neighbor_buffer
         np.uintp_t *tmp
         np.uintp_t next_region, src_label, dest_label
-        int mergetable_size
+        np.uintp_t mergetable_size
         np.uintp_t *mergetable
 
     axis = -1  # choose best axis based on output

--- a/scipy/ndimage/src/ni_interpolation.c
+++ b/scipy/ndimage/src/ni_interpolation.c
@@ -131,7 +131,7 @@ int NI_SplineFilter1D(PyArrayObject *input, int order, int axis,
 {
     int npoles = 0, more;
     npy_intp kk, lines, len;
-    double *buffer = NULL, gain, poles[MAX_SPLINE_FILTER_POLES];
+    double *buffer = NULL, poles[MAX_SPLINE_FILTER_POLES];
     NI_LineBuffer iline_buffer, oline_buffer;
     NPY_BEGIN_THREADS_DEF;
 


### PR DESCRIPTION
The changes in _ni_label.pyx eliminate 31 compiler warnings of the form

    scipy/ndimage/src/_ni_label.c:2924:33: warning: comparison of integers of different signs: '__pyx_t_5numpy_uintp_t' (aka 'unsigned long') and '__pyx_t_5numpy_intp_t' (aka 'long') [-Wsign-compare]
      for (__pyx_t_3 = 0; __pyx_t_3 < __pyx_t_2; __pyx_t_3+=1) {

and these two:

    scipy/ndimage/src/_ni_label.c:11962:59: warning: comparison of integers of different signs: 'int' and 'unsigned long' [-Wsign-compare]
                        __pyx_t_4 = ((__pyx_v_mergetable_size < (__pyx_v_next_region + __pyx_v_L)) != 0);
                                      ~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    scipy/ndimage/src/_ni_label.c:12059:57: warning: comparison of integers of different signs: 'int' and 'unsigned long' [-Wsign-compare]
                      __pyx_t_4 = ((__pyx_v_mergetable_size < (__pyx_v_next_region + __pyx_v_L)) != 0);
                                    ~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

The change in ni_interpolate.c eliminates:

    scipy/ndimage/src/ni_interpolation.c:134:28: warning: unused variable 'gain' [-Wunused-variable]
        double *buffer = NULL, gain, poles[MAX_SPLINE_FILTER_POLES];
                               ^