### PR TITLE
MAINT: add rvs for semicircular in scipy.stats

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -6088,35 +6088,17 @@ class semicircular_gen(rv_continuous):
 
     """
     def _pdf(self, x):
-        # semicircular.pdf(x) = 2/pi * sqrt(1-x**2)
         return 2.0/np.pi*np.sqrt(1-x*x)
 
     def _cdf(self, x):
         return 0.5+1.0/np.pi*(x*np.sqrt(1-x*x) + np.arcsin(x))
 
     def _rvs(self):
-        size1d = tuple(np.atleast_1d(self._size))
-        N = int(np.prod(size1d))
-        x = np.zeros(N)
-        simulated = 0
-        # apply rejection method using that pdf(x) <= 2/pi on [-1,1]
-        # therefore pdf(x) <= 4/pi * pdf_uniform[-1, 1]
-        # see Devroye: Non-Uniform Random Variate Generation, 1986, p. 43
-        while simulated < N:
-            k = N - simulated
-            u = self._random_state.random_sample(size=k)
-            v = -1.0 + 2 * self._random_state.random_sample(size=k)
-            # accept = (4/np.pi * u <= self._pdf(v)) can be simplified to:
-            accept = (4*u**2 + v**2 <= 1)
-            num_accept = np.sum(accept)
-            if num_accept > 0:
-                x[simulated:(simulated + num_accept)] = v[accept]
-                simulated += num_accept
-
-        if self._size == ():
-            # return scalar if rvs() is called without size specified
-            return x[0]
-        return np.reshape(x, size1d)
+        # generate values uniformly distributed on the area under the pdf
+        # (semi-circle) by randomly generating the radius and angle
+        r = np.sqrt(self._random_state.random_sample(size=self._size))
+        a = np.cos(np.pi * self._random_state.random_sample(size=self._size))
+        return r * a
 
     def _stats(self):
         return 0, 0.25, 0, -1.0

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -50,7 +50,7 @@ distcont_extra = [
 
 distslow = ['kappa4', 'rdist', 'gausshyper',
             'recipinvgauss', 'genexpon',
-            'vonmises', 'vonmises_line', 'mielke', 'semicircular',
+            'vonmises', 'vonmises_line', 'mielke',
             'cosine', 'invweibull', 'powerlognorm', 'johnsonsu', 'kstwobign']
 # distslow are sorted by speed (very slow to slow)
 

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -240,7 +240,8 @@ def test_rvs_broadcast(dist, shape_args):
     # the implementation the rvs() method of a distribution changes, this
     # test might also have to be changed.
     shape_only = dist in ['betaprime', 'dgamma', 'exponnorm', 'norminvgauss',
-                          'nct', 'dweibull', 'rice', 'levy_stable', 'skewnorm']
+                          'nct', 'dweibull', 'rice', 'levy_stable', 'skewnorm',
+                          'semicircular']
 
     distfunc = getattr(stats, dist)
     loc = np.zeros(2)


### PR DESCRIPTION
add _rvs method and reference

```
timeit(stats.semicircular.rvs(size=1000))
# scipy 1.2.0
3.03 s ± 9.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
# new
2.38 ms ± 74.9 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

cross-ref #10106 