### PR TITLE
DEP: Add warning to linprog_verbose_callback

### DIFF
--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -33,6 +33,15 @@ __all__ = ['linprog', 'linprog_verbose_callback', 'linprog_terse_callback']
 __docformat__ = "restructuredtext en"
 
 
+@np.deprecate(
+    message="linprog_verbose_callback is to be deprecated in a future version. "
+    "It was designed to demonstrate the callback behaviour when the simplex "
+    "method was the only available solver, which has been superseded by the "
+    "interior-point and revised simplex methods. The callback displays "
+    "information, such as the simplex tableau and current phase, which are "
+    "not relevant for all available solvers and may confuse users who are not "
+    "familiar with each specific method. An example callback function "
+    "will be available in the SciPy tutorial.")
 def linprog_verbose_callback(res):
     """
     A sample callback function demonstrating the linprog callback interface.
@@ -75,12 +84,6 @@ def linprog_verbose_callback(res):
         message : str
             A string descriptor of the exit status of the optimization.
     """
-    warn(
-        "linprog_verbose_callback is set to be depreciated in version 1.6. "
-        "It demonstrates the callback interface using the simplex method, "
-        "which has been superseded by the interior-point and revised "
-        "simplex solvers.", DeprecationWarning)
-
     x = res['x']
     fun = res['fun']
     phase = res['phase']

--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -75,6 +75,12 @@ def linprog_verbose_callback(res):
         message : str
             A string descriptor of the exit status of the optimization.
     """
+    warn(
+        "linprog_verbose_callback is set to be depreciated in version 1.6. "
+        "It demonstrates the callback interface using the simplex method, "
+        "which has been superseded by the interior-point and revised "
+        "simplex solvers.", DeprecationWarning)
+
     x = res['x']
     fun = res['fun']
     phase = res['phase']

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -7,7 +7,7 @@ import numpy as np
 from numpy.testing import (assert_, assert_allclose, assert_equal,
                            assert_array_less)
 from pytest import raises as assert_raises
-from scipy.optimize import linprog, OptimizeWarning
+from scipy.optimize import linprog, linprog_verbose_callback, OptimizeWarning
 from scipy._lib._numpy_compat import _assert_warns, suppress_warnings
 from scipy.sparse.linalg import MatrixRankWarning
 from scipy.linalg import LinAlgWarning
@@ -207,6 +207,12 @@ def generic_callback_test(self):
     assert_allclose(last_cb['x'], res['x'])
     assert_allclose(last_cb['con'], res['con'])
     assert_allclose(last_cb['slack'], res['slack'])
+
+
+def test_linprog_verbose_callback_deprecation_warning():
+    c, A_ub, b_ub, A_eq, b_eq, x_star, f_star = nontrivial_problem()
+    with pytest.deprecated_call():
+        linprog(c, A_ub, b_ub, A_eq, b_eq, callback=linprog_verbose_callback)
 
 
 def test_unknown_solver():


### PR DESCRIPTION
``linprog_verbose_callback`` provides an example of the callback
interface for the linear programming function (`linprog`) using the
simplex solver. Since written the module has gained several new solvers
which are now prefered to the simplex solver. As the example no longer
reflects the prefered method, it will be deprecated.

This commit adds a DeprecationWarning to notify users of the upcoming
deprecation.