### PR TITLE
ENH: add handling of NaN in RuntimeWarning except clause

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -2466,9 +2466,11 @@ def gstd(a, axis=0, ddof=1):
                 'Infinite value encountered. The geometric standard deviation '
                 'is defined for strictly positive values only.')
         a_nan = np.isnan(a)
+        a_nan_any = a_nan.any()
         if a_nan.any():
             return np.exp(np.std(log(a, where=~a_nan), axis=axis, ddof=ddof))
-        elif np.less_equal(a, 0).any():
+        elif ((a_nan_any and np.less_equal(a[~a_nan], 0).any()) or
+              (not a_nan_any and np.less_equal(a, 0).any())):
             raise ValueError(
                 'Non positive value encountered. The geometric standard '
                 'deviation is defined for strictly positive values only.')
@@ -2476,7 +2478,7 @@ def gstd(a, axis=0, ddof=1):
             raise ValueError(w)
         else:
             #  Remaining warnings don't need to be exceptions.
-            warnings.warn(w)
+            return np.exp(np.std(log(a, where=~a_nan), axis=axis, ddof=ddof))
     except TypeError:
         raise ValueError(
             'Invalid array input. The inputs could not be '

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -2465,6 +2465,9 @@ def gstd(a, axis=0, ddof=1):
             raise ValueError(
                 'Infinite value encountered. The geometric standard deviation '
                 'is defined for strictly positive values only.')
+        a_nan = np.isnan(a)
+        if a_nan.any():
+            return np.exp(np.std(log(a, where=~a_nan), axis=axis, ddof=ddof))
         elif np.less_equal(a, 0).any():
             raise ValueError(
                 'Non positive value encountered. The geometric standard '

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -2467,7 +2467,9 @@ def gstd(a, axis=0, ddof=1):
                 'is defined for strictly positive values only.')
         a_nan = np.isnan(a)
         a_nan_any = a_nan.any()
-        if ((a_nan_any and np.less_equal(a[~a_nan], 0).any()) or
+        # exclude NaN's from negativity check, but
+        # avoid expensive masking for arrays with no NaN
+        if ((a_nan_any and np.less_equal(np.nanmin(a), 0)) or
               (not a_nan_any and np.less_equal(a, 0).any())):
             raise ValueError(
                 'Non positive value encountered. The geometric standard '

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -2467,9 +2467,7 @@ def gstd(a, axis=0, ddof=1):
                 'is defined for strictly positive values only.')
         a_nan = np.isnan(a)
         a_nan_any = a_nan.any()
-        if a_nan.any():
-            return np.exp(np.std(log(a, where=~a_nan), axis=axis, ddof=ddof))
-        elif ((a_nan_any and np.less_equal(a[~a_nan], 0).any()) or
+        if ((a_nan_any and np.less_equal(a[~a_nan], 0).any()) or
               (not a_nan_any and np.less_equal(a, 0).any())):
             raise ValueError(
                 'Non positive value encountered. The geometric standard '


### PR DESCRIPTION
In Intel distribution for Python numpy.log raises RuntimeWarning
when input contains np.nan, and the gstd in that case return None.
This happens on MacOSX.

```
import numpy as np
from scipy.stats import gstd

a = np.array([[1, 1, 1, 16], [np.nan, 1, 2, 3]])
print(gstd(a, axis=1)) # prints None, instead of np.array([4., np.nan])
```

Also when it does, the `np.less_equal` throws another warning when processing `np.nan`:

```
In [4]: gstd(np.array([[1, 1, 1, 16], [np.nan, 1, 2, 3]]), axis=1)
env_root/t_scipy_rc/bin/ipython:23: RuntimeWarning: invalid value encountered in less_equal
env_root/t_scipy_rc/bin/ipython:31: RuntimeWarning: invalid value encountered in log
```
