### PR TITLE
MAINT: Loosen linprog tol

### DIFF
--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -491,7 +491,6 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
 
     """
     meth = method.lower()
-    default_tol = 1e-12 if meth == 'simplex' else 1e-9
 
     if x0 is not None and meth != "revised simplex":
         warning_message = "x0 is used only when method is 'revised simplex'. "
@@ -499,7 +498,7 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
 
     c, A_ub, b_ub, A_eq, b_eq, bounds, solver_options, x0 = _parse_linprog(
         c, A_ub, b_ub, A_eq, b_eq, bounds, options, x0)
-    tol = solver_options.get('tol', default_tol)
+    tol = solver_options.get('tol', 1e-9)
 
     iteration = 0
     complete = False    # will become True if solved in presolve

--- a/scipy/optimize/_linprog_simplex.py
+++ b/scipy/optimize/_linprog_simplex.py
@@ -34,7 +34,7 @@ from .optimize import OptimizeResult, OptimizeWarning, _check_unknown_options
 from ._linprog_util import _postsolve
 
 
-def _pivot_col(T, tol=1.0E-12, bland=False):
+def _pivot_col(T, tol=1e-9, bland=False):
     """
     Given a linear programming simplex tableau, determine the column
     of the variable to enter the basis.
@@ -94,7 +94,7 @@ def _pivot_col(T, tol=1.0E-12, bland=False):
     return True, np.ma.nonzero(ma == ma.min())[0][0]
 
 
-def _pivot_row(T, basis, pivcol, phase, tol=1.0E-12, bland=False):
+def _pivot_row(T, basis, pivcol, phase, tol=1e-9, bland=False):
     """
     Given a linear programming simplex tableau, determine the row for the
     pivot operation.
@@ -165,7 +165,7 @@ def _pivot_row(T, basis, pivcol, phase, tol=1.0E-12, bland=False):
     return True, min_rows[0]
 
 
-def _apply_pivot(T, basis, pivrow, pivcol, tol=1e-12):
+def _apply_pivot(T, basis, pivrow, pivcol, tol=1e-9):
     """
     Pivot the simplex tableau inplace on the element given by (pivrow, pivol).
     The entering variable corresponds to the column given by pivcol forcing
@@ -229,7 +229,7 @@ def _apply_pivot(T, basis, pivrow, pivcol, tol=1e-12):
 
 
 def _solve_simplex(T, n, basis, maxiter=1000, phase=2, status=0, message='',
-                   callback=None, tol=1.0E-12, nit0=0, bland=False, _T_o=None):
+                   callback=None, tol=1e-9, nit0=0, bland=False, _T_o=None):
     """
     Solve a linear programming problem in "standard form" using the Simplex
     Method. Linear Programming is intended to solve the following problem form:
@@ -372,7 +372,7 @@ def _solve_simplex(T, n, basis, maxiter=1000, phase=2, status=0, message='',
                             if abs(T[pivrow, col]) > tol]
             if len(non_zero_row) > 0:
                 pivcol = non_zero_row[0]
-                _apply_pivot(T, basis, pivrow, pivcol)
+                _apply_pivot(T, basis, pivrow, pivcol, tol)
                 nit += 1
 
     if len(basis[:m]) == 0:
@@ -424,13 +424,13 @@ def _solve_simplex(T, n, basis, maxiter=1000, phase=2, status=0, message='',
                 status = 1
                 complete = True
             else:
-                _apply_pivot(T, basis, pivrow, pivcol)
+                _apply_pivot(T, basis, pivrow, pivcol, tol)
                 nit += 1
     return nit, status
 
 
 def _linprog_simplex(c, c0, A, b, maxiter=1000, disp=False, callback=None,
-                     tol=1.0E-12, bland=False, _T_o=None, **unknown_options):
+                     tol=1e-9, bland=False, _T_o=None, **unknown_options):
     """
     Minimize a linear objective function subject to linear equality and
     non-negativity constraints using the two phase simplex method.

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -2,6 +2,7 @@
 Unit test for Linear Programming
 """
 from __future__ import division, print_function, absolute_import
+import sys
 
 import numpy as np
 from numpy.testing import (assert_, assert_allclose, assert_equal,
@@ -1404,7 +1405,12 @@ class TestLinprogSimplexNoPresolve(LinprogSimplexTests):
     def setup_method(self):
         self.options = {'presolve': False}
 
-    @pytest.mark.xfail(reason='Fails with warning on 32-bit linux')
+    is_32_bit = np.intp(0).itemsize < 8
+    is_linux = sys.platform.startswith('linux')
+
+    @pytest.mark.xfail(
+        condition=is_32_bit and is_linux,
+        reason='Fails with warning on 32-bit linux')
     def test_bug_5400(self):
         super(TestLinprogSimplexNoPresolve, self).test_bug_5400()
 


### PR DESCRIPTION
The default tolerance for linprog(method='simplex') is currently 1e-12, this differs from the interior-point and revised simplex solvers (where it is 1e-9). Having the lower tolerance also led to a number of "bugs",
not because of the underlying logic - but because of issues with the tolerance which would have been avoided had the tolerance been higher.

Closes #9268
