### PR TITLE
TST: CI reproducer for SkylakeX issue

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,8 +27,8 @@ jobs:
            apt-get -y install gfortran-5 wget && \
            cd .. && \
            mkdir openblas && cd openblas && \
-           wget https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.3-186-g701ea883-manylinux1_i686.tar.gz && \
-           tar zxvf openblas-v0.3.3-186-g701ea883-manylinux1_i686.tar.gz && \
+           wget https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.5-274-g6a8b4269-manylinux1_i686.tar.gz && \
+           tar zxvf openblas-v0.3.5-274-g6a8b4269-manylinux1_i686.tar.gz && \
            cp -r ./usr/local/lib/* /usr/lib && \
            cp ./usr/local/include/* /usr/include && \
            cd ../scipy && \
@@ -49,8 +49,8 @@ jobs:
   pool:
     vmImage: 'VS2017-Win2016'
   variables:
-      OPENBLAS_32: https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.3-186-g701ea883-win32-gcc_7_1_0.zip
-      OPENBLAS_64: https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.3-186-g701ea883-win_amd64-gcc_7_1_0.zip
+      OPENBLAS_32: https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.5-274-g6a8b4269-win32-gcc_7_1_0.zip
+      OPENBLAS_64: https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.5-274-g6a8b4269-win_amd64-gcc_7_1_0.zip
   strategy:
     maxParallel: 4
     matrix:
@@ -95,7 +95,7 @@ jobs:
       Write-Host "Python Version: $pyversion"
       $target = "C:\\hostedtoolcache\\windows\\Python\\$pyversion\\$(PYTHON_ARCH)\\lib\\openblas.a"
       Write-Host "target path: $target"
-      cp $tmpdir\$(BITS)\lib\libopenblas_v0.3.3-186-g701ea883-gcc_7_1_0.a $target
+      cp $tmpdir\$(BITS)\lib\libopenblas_v0.3.5-274-g6a8b4269-gcc_7_1_0.a $target
     displayName: 'Download / Install OpenBLAS'
   - powershell: |
       # wheels appear to use mingw64 version 6.3.0, but 6.4.0
@@ -169,8 +169,8 @@ jobs:
     displayName: 'install gfortran'
   - script: |
        mkdir openblas && cd openblas
-       wget https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.3-186-g701ea883-macosx_10_9_x86_64-gf_1becaaa.tar.gz
-       tar -zxvf openblas-v0.3.3-186-g701ea883-macosx_10_9_x86_64-gf_1becaaa.tar.gz
+       wget https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.5-274-g6a8b4269-macosx_10_9_x86_64-gf_1becaaa.tar.gz
+       tar -zxvf openblas-v0.3.5-274-g6a8b4269-macosx_10_9_x86_64-gf_1becaaa.tar.gz
        cp ./usr/local/lib/* /usr/local/lib/
        cp ./usr/local/include/* /usr/local/include/
        cd ..

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -142,3 +142,49 @@ jobs:
       codeCoverageTool: Cobertura
       summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
       reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
+
+- job: Intel_SDE
+  pool:
+    # have to use Mac to reproduce SciPy problem reported in
+    # NumPy Issue 13401 because manylinux1
+    # gcc too old to enable our ecosystem OpenBLAS
+    # binaries to switch to SkylakeX kernel
+    vmImage: 'macOS-10.13'
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+        versionSpec: '3.7'
+        architecture: 'x64'
+  - script: /bin/bash -c "sudo xcode-select -s /Applications/Xcode_10.app/Contents/Developer"
+    displayName: 'select Xcode version'
+  - script: |
+      python -m pip install --upgrade pip setuptools wheel
+    displayName: 'install tools'
+  - script: python -m pip install numpy cython pytest pytest-timeout pytest-xdist pytest-env pytest-faulthandler pytest-cov Pillow mpmath matplotlib
+    displayName: 'Install dependencies'
+  - script: |
+      brew install gcc49
+      ln -s /usr/local/Cellar/gcc@4.9/4.9.4_1/lib/gcc/4.9/libgfortran.3.dylib /usr/local/lib/libgfortran.3.dylib
+      ln -s /usr/local/Cellar/gcc@4.9/4.9.4_1/lib/gcc/4.9/libquadmath.0.dylib /usr/local/lib/libquadmath.0.dylib
+    displayName: 'install gfortran'
+  - script: |
+       mkdir openblas && cd openblas
+       wget https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.3-186-g701ea883-macosx_10_9_x86_64-gf_1becaaa.tar.gz
+       tar -zxvf openblas-v0.3.3-186-g701ea883-macosx_10_9_x86_64-gf_1becaaa.tar.gz
+       cp ./usr/local/lib/* /usr/local/lib/
+       cp ./usr/local/include/* /usr/local/include/
+       cd ..
+    displayName: 'install OpenBLAS'
+  - script: |
+      mkdir dist
+      F77=gfortran-4.9 F90=gfortran-4.9 python -m pip wheel --no-build-isolation -v -v -v --wheel-dir=dist .
+      ls -tlrh dist
+      python -m pip install dist/scipy*.whl
+    displayName: 'Build / Install SciPy'
+  - bash: |
+      mkdir SDE && cd SDE
+      wget -O sde-external-8.35.0-2019-03-11-mac.tar.bz2 https://www.dropbox.com/s/rkgx577cb7pxc8c/sde-external-8.35.0-2019-03-11-mac.tar.bz2?dl=0
+      tar -xjvf sde-external-8.35.0-2019-03-11-mac.tar.bz2
+      cd ..
+      ./SDE/sde-external-8.35.0-2019-03-11-mac/sde64 -cpuid_in ./SDE/sde-external-8.35.0-2019-03-11-mac/misc/cpuid/skx/cpuid.def -- python runtests.py -n -s "linalg" --mode=full
+    displayName: 'Intel SDE testing for linalg / OpenBLAS'

--- a/scipy/linalg/tests/test_blas.py
+++ b/scipy/linalg/tests/test_blas.py
@@ -25,6 +25,7 @@ from numpy import float32, float64, complex64, complex128, arange, triu, \
 from numpy.random import rand, seed
 from scipy.linalg import _fblas as fblas, get_blas_funcs, toeplitz, solve, \
                                           solve_triangular
+from scipy.linalg import svd
 
 try:
     from scipy.linalg import _cblas as cblas
@@ -1077,3 +1078,14 @@ def test_trsm():
         Al[arange(m), arange(m)] = dtype(1)
         x2 = solve(Al.conj().T, alpha*B2.conj().T)
         assert_allclose(x1, x2.conj().T, atol=tol)
+
+
+def test_svd_avx_issue():
+    # test for OpenBLAS AVX issue reported
+    # upstream in NumPy Issue 13401, where
+    # SciPy fails with SkylakeX architecture
+    np.random.seed(0)
+    X = np.random.randn(100, 100) * 10
+    u, s, v = svd(X)
+    assert np.abs(np.mean(X - u @ np.diag(s) @ v)) < 1e-12
+    assert np.std(X - u @ np.diag(s) @ v) < 1e-12


### PR DESCRIPTION
Adds a CI reproducer for SciPy + OpenBLAS SkylakeX AVX linear algebra issue reported upstream in NumPy: https://github.com/numpy/numpy/issues/13401

This likely causes wheels linalg failures for NumPy `1.2.x` and `1.3.x` series on that particular architecture at the moment, so the purpose of the PR is to demonstrate that the failure happens under Intel SDE emulation of SkylakeX, and then demonstrate a fix by bumping OpenBLAS to the appropriate commit hash.

This mirrors my similar effort in NumPy, where the issue did indeed seem to be resolved by a more recent OpenBLAS--see there for more detailed discussion: https://github.com/numpy/numpy/pull/13466

Whether this ultimately belongs in SciPy repo or somewhere else in ecosystem is up to others to decide. There are some pertinent discussions / issues upstream in OpenBLAS as well.

