### PR TITLE
MAINT: add moments and improve doc of mielke in scipy.stats

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -4647,7 +4647,7 @@ class mielke_gen(rv_continuous):
             # n-th moment is defined for -k < n < s
             return sc.gamma((k+n)/s)*sc.gamma(1-n/s)/sc.gamma(k/s)
 
-        return _lazywhere(n > s, (n, k, s), nth_moment, np.inf)
+        return _lazywhere(n < s, (n, k, s), nth_moment, np.inf)
 
 
 mielke = mielke_gen(a=0.0, name='mielke')

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -35,11 +35,10 @@ not for numerically exact results.
 
 DECIMAL = 5  # specify the precision of the tests  # increased from 0 to 5
 
-# Last four of these fail all around. Need to be checked
+# Last three of these fail all around. Need to be checked
 distcont_extra = [
     ['betaprime', (100, 86)],
     ['fatiguelife', (5,)],
-    ['mielke', (4.6420495492121487, 0.59707419545516938)],
     ['invweibull', (0.58847112119264788,)],
     # burr: sample mean test fails still for c<1
     ['burr', (0.94839838075366045, 4.3820284068855795)],
@@ -48,10 +47,9 @@ distcont_extra = [
 ]
 
 
-distslow = ['kappa4', 'rdist', 'gausshyper',
-            'recipinvgauss', 'genexpon',
-            'vonmises', 'vonmises_line', 'mielke',
-            'cosine', 'invweibull', 'powerlognorm', 'johnsonsu', 'kstwobign']
+distslow = ['kappa4', 'rdist', 'gausshyper', 'recipinvgauss', 'genexpon',
+            'vonmises', 'vonmises_line', 'cosine', 'invweibull',
+            'powerlognorm', 'johnsonsu', 'kstwobign']
 # distslow are sorted by speed (very slow to slow)
 
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2792,6 +2792,20 @@ class TestTriang(object):
             assert_equal(stats.triang.cdf(1., 1.), 1)
 
 
+class TestMielke(object):
+    def test_moments(self):
+        k, s = 4.642, 0.597
+        # n-th moment exists only if n < s
+        assert_equal(stats.mielke(k, s).moment(1), np.inf)
+        assert_equal(stats.mielke(k, 1.0).moment(1), np.inf)
+        assert_(np.isfinite(stats.mielke(k, 1.01).moment(1)))
+
+    def test_burr_equivalence(self):
+        x = np.linspace(0.01, 100, 50)
+        k, s = 2.45, 5.32
+        assert_allclose(stats.burr.pdf(x, s, k/s), stats.mielke.pdf(x, k, s))
+
+
 def test_540_567():
     # test for nan returned in tickets 540, 567
     assert_almost_equal(stats.norm.cdf(-1.7624320982), 0.03899815971089126,


### PR DESCRIPTION
- doc update: point out that distribution is also called Dagum, and equivalent to Burr III
- add explicit expression for moments (this avoids a test failure described in scipy/stats/tests/test_continuous_basic.py)
- removed distribution from list of slow_distributions, both ppf and cdf are implemented and when i ran the tests, it was not slow