### PR TITLE
ENH: optimize: Clarify error when objective function returns array

### DIFF
--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -697,7 +697,7 @@ def _approx_fprime_helper(xk, f, epsilon, args=(), f0=None):
         if not np.isscalar(df):
             try:
                 df = df.item()
-            except ValueError:
+            except (ValueError, AttributeError):
                 raise ValueError("The user-provided "
                                  "objective function must "
                                  "return a scalar value.")

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -693,7 +693,15 @@ def _approx_fprime_helper(xk, f, epsilon, args=(), f0=None):
     for k in range(len(xk)):
         ei[k] = 1.0
         d = epsilon * ei
-        grad[k] = (f(*((xk + d,) + args)) - f0) / d[k]
+        df = (f(*((xk + d,) + args)) - f0) / d[k]
+        if not np.isscalar(df):
+            try:
+                df = df.item()
+            except ValueError:
+                raise ValueError("The user-provided "
+                                 "objective function must "
+                                 "return a scalar value.")
+        grad[k] = df
         ei[k] = 0.0
     return grad
 

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -431,6 +431,14 @@ class CheckOptimizeParameterized(CheckOptimize):
                         atol=1e-6, rtol=1e-7)
 
 
+def test_obj_func_returns_scalar():
+    match = ("The user-provided "
+             "objective function must "
+             "return a scalar value.")
+    with assert_raises(ValueError, match=match):
+        optimize.minimize(lambda x: x, np.array([1, 1]))
+    
+
 def test_neldermead_xatol_fatol():
     # gh4484
     # test we can call with fatol, xatol specified


### PR DESCRIPTION
Add a check to see if the user-provided objective function is
scalar, and if not, raise an exception explaining the issue.
Closes gh-10078.

This solution was similar to that proposed in the comments of #10078, except for an additional `try`/`except` to check for numpy arrays of length one (which are also acceptable inputs).

Here it is for `minimize`:
```
>>> import numpy as np
>>> from scipy.optimize import minimize
>>> 
>>> minimize(lambda x: x, np.array([1, 1]))
Traceback (most recent call last):
  File "/Users/lindsey/Dev/scipy-dev/scipy/scipy/optimize/optimize.py", line 699, in _approx_fprime_helper
    df = df.item()
ValueError: can only convert an array of size 1 to a Python scalar

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/lindsey/Dev/scipy-dev/scipy/scipy/optimize/_minimize.py", line 594, in minimize
    return _minimize_bfgs(fun, x0, args, jac, callback, **options)
  File "/Users/lindsey/Dev/scipy-dev/scipy/scipy/optimize/optimize.py", line 1004, in _minimize_bfgs
    gfk = myfprime(x0)
  File "/Users/lindsey/Dev/scipy-dev/scipy/scipy/optimize/optimize.py", line 326, in function_wrapper
    return function(*(wrapper_args + args))
  File "/Users/lindsey/Dev/scipy-dev/scipy/scipy/optimize/optimize.py", line 764, in approx_fprime
    return _approx_fprime_helper(xk, f, epsilon, args=args)
  File "/Users/lindsey/Dev/scipy-dev/scipy/scipy/optimize/optimize.py", line 701, in _approx_fprime_helper
    raise ValueError("The user-provided "
ValueError: The user-provided objective function must return a scalar value.
```