### PR TITLE
MAINT: stats: Implement cdf and ppf as ufuncs for the cosine distribution.

### DIFF
--- a/scipy/special/_cosine.c
+++ b/scipy/special/_cosine.c
@@ -1,0 +1,279 @@
+/*
+ *  The functions
+ *
+ *    cosine_cdf
+ *    cosine_invcdf
+ *
+ *  defined here are the kernels for the ufuncs
+ *
+ *    _cosine_cdf
+ *    _cosine_invcdf
+ *
+ *  defined in scipy.special._ufuncs.
+ *
+ *  The ufuncs are used by the class scipy.stats.cosine_gen.
+ */
+
+#include <stdio.h>
+#include <math.h>
+
+#include "cephes/polevl.h"
+
+
+//
+// p and q (below) are the coefficients in the numerator and denominator
+// polynomials (resp.) of the Pade approximation of
+//     f(x) = (pi + x + sin(x))/(2*pi)
+// at x=-pi.  The coefficients are ordered from lowest degree to highest.
+// These values are used in the function cosine_cdf_pade_approx_at_neg_pi(x).
+//
+// These coefficients can be derived by using mpmath as follows:
+//
+//    import mpmath
+//
+//    def f(x):
+//        return (mpmath.pi + x + mpmath.sin(x)) / (2*mpmath.pi)
+//
+//    # Note: 40 digits might be overkill; a few more digits than the default
+//    # might be sufficient.
+//    mpmath.mp.dps = 40
+//    ts = mpmath.taylor(f, -mpmath.pi, 20)
+//    p, q = mpmath.pade(ts, 9, 10)
+//
+// (A python script with that code is in special/_precompute/cosine_cdf.py.)
+//
+// The following are the values after converting to 64 bit floating point:
+// p = [0.0,
+//      0.0,
+//      0.0,
+//      0.026525823848649224,
+//      0.0,
+//      -0.0007883197097740538,
+//      0.0,
+//      1.0235408442872927e-05,
+//      0.0,
+//      -3.8360369451359084e-08]
+// q = [1.0,
+//      0.0,
+//      0.020281047093125535,
+//      0.0,
+//      0.00020944197182753272,
+//      0.0,
+//      1.4162345851873058e-06,
+//      0.0,
+//      6.498171564823105e-09,
+//      0.0,
+//      1.6955280904096042e-11]
+//
+
+
+//
+// Compute the CDF of the standard cosine distribution for x close to but
+// not less than -π.  A Pade approximant is used to avoid the loss of
+// precision that occurs in the formula 1/2 + (x + sin(x))/(2*pi) when
+// x is near -π.
+//
+static
+double cosine_cdf_pade_approx_at_neg_pi(double x)
+{
+    double h, h2, h3;
+    double numer, denom;
+    double numer_coeffs[] = {-3.8360369451359084e-08,
+                             1.0235408442872927e-05,
+                             -0.0007883197097740538,
+                             0.026525823848649224};
+    double denom_coeffs[] = {1.6955280904096042e-11,
+                             6.498171564823105e-09,
+                             1.4162345851873058e-06,
+                             0.00020944197182753272,
+                             0.020281047093125535,
+                             1.0};
+
+    // M_PI is not exactly π.  In fact, float64(π - M_PI) is
+    // 1.2246467991473532e-16.  h is supposed to be x + π, so to compute
+    // h accurately, we write the calculation as:
+    h = (x + M_PI) + 1.2246467991473532e-16;
+    h2 = h*h;
+    h3 = h2*h;
+    numer = h3*polevl(h2, numer_coeffs,
+                      sizeof(numer_coeffs)/sizeof(numer_coeffs[0]) - 1);
+    denom = polevl(h2, denom_coeffs,
+                   sizeof(denom_coeffs)/sizeof(denom_coeffs[0]) - 1);
+    return numer / denom;
+}
+
+
+//
+// cosine distribution cumulative distribution function (CDF).
+//
+double cosine_cdf(double x)
+{
+    if (x >= M_PI) {
+        return 1;
+    }
+    if (x < -M_PI) {
+        return 0;
+    }
+    if (x < -1.6) {
+        return cosine_cdf_pade_approx_at_neg_pi(x);
+    }
+    return 0.5 + (x + sin(x))/(2*M_PI);
+}
+
+
+// The CDF of the cosine distribution is
+//     p = (pi + x + sin(x)) / (2*pi),
+// We want the inverse of this.
+//
+// Move the factor 2*pi and the constant pi to express this as
+//     pi*(2*p - 1) = x + sin(x)
+// Then if f(x) = x + sin(x), and g(x) is the inverse of f, we have
+//     x = g(pi*(2*p - 1)).
+
+// The coefficients in the functions _p2 and _q2 are the coefficients in the
+// Pade approximation at p=0.5 to the inverse of x + sin(x).
+// The following steps were used to derive these:
+// 1. Find the coefficients of the Taylor polynomial of x + sin(x) at x = 0.
+//    A Taylor polynomial of order 22 was used.
+// 2. "Revert" the Taylor coefficients to find the Taylor polynomial of the
+//    inverse.  The method for series reversion is described at
+//        https://en.wikipedia.org/wiki/Bell_polynomials#Reversion_of_series
+// 3. Convert the Taylor coefficients of the inverse to the (11, 10) Pade
+//    approximant. The coefficients of the Pade approximant (converted to 64
+//    bit floating point) in increasing order of degree are:
+//      p = [0.0, 0.5,
+//           0.0, -0.11602142940208726,
+//           0.0, 0.009350454384541677,
+//           0.0, -0.00030539712907115167,
+//           0.0, 3.4900934227012284e-06,
+//           0.0, -6.8448463845552725e-09]
+//      q = [1.0,
+//           0.0, -0.25287619213750784,
+//           0.0, 0.022927496105281435,
+//           0.0, -0.0008916919927321117,
+//           0.0, 1.3728570152788793e-05,
+//           0.0, -5.579679571562129e-08]
+//
+// The nonzero values in p and q are used in the functions _p2 and _q2 below.
+// The functions assume that the square of the variable is passed in, and
+// _p2 does not include the outermost multiplicative factor.
+// So to evaluate x = invcdf(p) for a given p, the following is used:
+//        y = pi*(2*p - 1)
+//        x = y * _p2(y**2) / _q2(y**2)
+
+static
+double _p2(double t)
+{
+    double coeffs[] = {-6.8448463845552725e-09,
+                       3.4900934227012284e-06,
+                       -0.00030539712907115167,
+                       0.009350454384541677,
+                       -0.11602142940208726,
+                       0.5};
+    double v;
+
+    v = polevl(t, coeffs, sizeof(coeffs) / sizeof(coeffs[0]) - 1);
+    return v;
+}
+
+static
+double _q2(double t)
+{
+    double coeffs[] = {-5.579679571562129e-08,
+                       1.3728570152788793e-05,
+                       -0.0008916919927321117,
+                       0.022927496105281435,
+                       -0.25287619213750784,
+                       1.0};
+    double v;
+
+    v = polevl(t, coeffs, sizeof(coeffs) / sizeof(coeffs[0]) - 1);
+    return v;
+}
+
+
+//
+// Part of the asymptotic expansion of the inverse function at p=0.
+//
+// See, for example, the wikipedia article "Kepler's equation"
+// (https://en.wikipedia.org/wiki/Kepler%27s_equation).  In particular, see the
+// series expansion for the inverse Kepler equation when the eccentricity e is 1.
+//
+static
+double _poly_approx(double s)
+{
+    double s2;
+    double p;
+    double px;
+    double coeffs[] = {1.1911667949082915e-08,
+                       1.683039183039183e-07,
+                       43.0/17248000,
+                       1.0/25200,
+                       1.0/1400,
+                       1.0/60,
+                       1.0};
+    //
+    // p(s) = s + (1/60) * s**3 + (1/1400) * s**5 + (1/25200) * s**7 +
+    //        (43/17248000) * s**9 + (1213/7207200000) * s**11 +
+    //        (151439/12713500800000) * s**13 + ...
+    //
+    // Here we include terms up to s**13.
+    //
+    s2 = s*s;
+    p = s*polevl(s2, coeffs, sizeof(coeffs)/sizeof(coeffs[0]) - 1);
+    return p;
+}
+
+
+//
+// cosine distribution inverse CDF (aka percent point function).
+//
+double cosine_invcdf(double p)
+{
+    double x;
+    int sgn = 1;
+
+    if ((p < 0) || (p > 1)) {
+        return NAN;
+    }
+    if (p <= 1e-48) {
+        return -M_PI;
+    }
+    if (p == 1) {
+        return M_PI;
+    }
+
+    if (p > 0.5) {
+        p = 1.0 - p;
+        sgn = -1;
+    }
+
+    if (p < 0.0925) {
+        x = _poly_approx(cbrt(12*M_PI*p)) - M_PI;
+    }
+    else {
+        double y, y2;
+        y = M_PI*(2*p - 1);
+        y2 = y*y;
+        x = y * _p2(y2) / _q2(y2);
+    }
+
+    // For p < 0.0018, the asymptotic expansion at p=0 is sufficently
+    // accurate that no more work is needed.  Similarly, for p > 0.42,
+    // the Pade approximant is sufficiently accurate.  In between these
+    // bounds, we refine the estimate with Halley's method.
+    if ((0.0018 < p) && (p < 0.42)) {
+        // Apply one iteration of Halley's method, with
+        //    f(x)   = pi + x + sin(x) - y,
+        //    f'(x)  = 1 + cos(x),
+        //    f''(x) = -sin(x)
+        // where y = 2*pi*p.
+        double f0, f1, f2;
+        f0 = M_PI + x + sin(x) - 2*M_PI*p;
+        f1 = 1 + cos(x);
+        f2 = -sin(x);
+        x = x - 2*f0*f1/(2*f1*f1 - f0*f2);
+    }
+
+    return sgn*x;
+}

--- a/scipy/special/_cosine.h
+++ b/scipy/special/_cosine.h
@@ -1,0 +1,7 @@
+#ifndef _COS_H
+#define _COS_H
+
+double cosine_cdf(double x);
+double cosine_invcdf(double p);
+
+#endif

--- a/scipy/special/_precompute/cosine_cdf.py
+++ b/scipy/special/_precompute/cosine_cdf.py
@@ -1,0 +1,18 @@
+
+import mpmath
+
+
+def f(x):
+    return (mpmath.pi + x + mpmath.sin(x)) / (2*mpmath.pi)
+
+
+# Note: 40 digits might be overkill; a few more digits than the default
+# might be sufficient.
+mpmath.mp.dps = 40
+ts = mpmath.taylor(f, -mpmath.pi, 20)
+p, q = mpmath.pade(ts, 9, 10)
+
+p = [float(c) for c in p]
+q = [float(c) for c in q]
+print('p =', p)
+print('q =', q)

--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -24,6 +24,55 @@ add_newdoc("_sf_error_test_function",
     Private function; do not use.
     """)
 
+
+add_newdoc("_cosine_cdf",
+    """
+    _cosine_cdf(x)
+
+    Cumulative distribution function (CDF) of the cosine distribution::
+
+                 {             0,              x < -pi
+        cdf(x) = { (pi + x + sin(x))/(2*pi),   -pi <= x <= pi
+                 {             1,              x > pi
+
+    Parameters
+    ----------
+    x : array_like
+        `x` must contain real numbers.
+
+    Returns
+    -------
+    float
+        The cosine distribution CDF evaluated at `x`.
+
+    """)
+
+add_newdoc("_cosine_invcdf",
+    """
+    _cosine_invcdf(p)
+
+    Inverse of the cumulative distribution function (CDF) of the cosine
+    distribution.
+
+    The CDF of the cosine distribution is::
+
+        cdf(x) = (pi + x + sin(x))/(2*pi)
+
+    This function computes the inverse of cdf(x).
+
+    Parameters
+    ----------
+    p : array_like
+        `p` must contain real numbers in the interval ``0 <= p <= 1``.
+        `nan` is returned for values of `p` outside the interval [0, 1].
+
+    Returns
+    -------
+    float
+        The inverse of the cosine distribution CDF evaluated at `p`.
+
+    """)
+
 add_newdoc("sph_harm",
     r"""
     sph_harm(m, n, theta, phi)

--- a/scipy/special/functions.json
+++ b/scipy/special/functions.json
@@ -1,4 +1,14 @@
 {
+    "_cosine_cdf": {
+        "_cosine.h": {
+            "cosine_cdf": "d->d"
+        }
+    },
+    "_cosine_invcdf": {
+        "_cosine.h": {
+            "cosine_invcdf": "d->d"
+        }
+    },
     "_cospi": {
 	"cephes.h": {
 	    "cospi": "d->d"

--- a/scipy/special/setup.py
+++ b/scipy/special/setup.py
@@ -70,7 +70,9 @@ def configuration(parent_package='',top_path=None):
     # Extension _ufuncs
     headers = ['*.h', join('cephes', '*.h')]
     ufuncs_src = ['_ufuncs.c', 'sf_error.c', '_logit.c.src',
-                  "amos_wrappers.c", "cdf_wrappers.c", "specfun_wrappers.c"]
+                  'amos_wrappers.c', 'cdf_wrappers.c', 'specfun_wrappers.c',
+                  '_cosine.c']
+
     ufuncs_dep = (
         headers
         + ufuncs_src
@@ -113,7 +115,8 @@ def configuration(parent_package='',top_path=None):
     config.add_data_files('cython_special.pxd')
 
     cython_special_src = ['cython_special.c', 'sf_error.c', '_logit.c.src',
-                          "amos_wrappers.c", "cdf_wrappers.c", "specfun_wrappers.c"]
+                          'amos_wrappers.c', 'cdf_wrappers.c',
+                          'specfun_wrappers.c', '_cosine.c']
     cython_special_dep = (
         headers
         + ufuncs_src

--- a/scipy/special/tests/test_cosine_distr.py
+++ b/scipy/special/tests/test_cosine_distr.py
@@ -1,0 +1,84 @@
+
+import numpy as np
+from numpy.testing import assert_allclose
+import pytest
+from scipy.special._ufuncs import _cosine_cdf, _cosine_invcdf
+
+
+# These values are (x, p) where p is the expected exact value of 
+# _cosine_cdf(x).  These values will be tested for exact agreement.
+_coscdf_exact = [
+    (-4.0, 0.0),
+    (0, 0.5),
+    (np.pi, 1.0),
+    (4.0, 1.0),
+]
+
+@pytest.mark.parametrize("x, expected", _coscdf_exact)
+def test_cosine_cdf_exact(x, expected):
+    assert _cosine_cdf(x) == expected
+
+
+# These values are (x, p), where p is the expected value of
+# _cosine_cdf(x). The expected values were computed with mpmath using
+# 50 digits of precision.  These values will be tested for agreement
+# with the computed values using a very small relative tolerance.
+# The value at -np.pi is not 0, because -np.pi does not equal -π.
+_coscdf_close = [
+    (3.1409, 0.999999999991185),
+    (2.25, 0.9819328173287907),
+    # -1.6 is the threshold below which the Pade approximant is used.
+    (-1.599, 0.08641959838382553),
+    (-1.601, 0.086110582992713),
+    (-2.0, 0.0369709335961611),
+    (-3.0, 7.522387241801384e-05),
+    (-3.1415, 2.109869685443648e-14),
+    (-3.14159, 4.956444476505336e-19),
+    (-np.pi, 4.871934450264861e-50),
+]
+
+@pytest.mark.parametrize("x, expected", _coscdf_close)
+def test_cosine_cdf(x, expected):
+    assert_allclose(_cosine_cdf(x), expected, rtol=5e-15)
+
+
+# These values are (p, x) where x is the expected exact value of 
+# _cosine_invcdf(p).  These values will be tested for exact agreement.
+_cosinvcdf_exact = [
+    (0.0, -np.pi),
+    (0.5, 0.0),
+    (1.0, np.pi),
+]
+
+@pytest.mark.parametrize("p, expected", _cosinvcdf_exact)
+def test_cosine_invcdf_exact(p, expected):
+    assert _cosine_invcdf(p) == expected
+
+
+def test_cosine_invcdf_invalid_p():
+    # Check that p values outside of [0, 1] return nan.
+    assert np.isnan(_cosine_invcdf([-0.1, 1.1])).all()
+
+
+# These values are (p, x), where x is the expected value of _cosine_invcdf(p).
+# The expected values were computed with mpmath using 50 digits of precision.
+_cosinvcdf_close = [
+    (1e-50, -np.pi),
+    (1e-14, -3.1415204137058454),
+    (1e-08, -3.1343686589124524),
+    (0.0018001, -2.732563923138336),
+    (0.010, -2.41276589008678),
+    (0.060, -1.7881244975330157),
+    (0.125, -1.3752523669869274),
+    (0.250, -0.831711193579736),
+    (0.400, -0.3167954512395289),
+    (0.419, -0.25586025626919906),
+    (0.421, -0.24947570750445663),
+    (0.750, 0.831711193579736),
+    (0.940, 1.7881244975330153),
+    (0.9999999996, 3.1391220839917167),
+]
+
+@pytest.mark.parametrize("p, expected", _cosinvcdf_close)
+def test_cosine_invcdf(p, expected):
+    assert_allclose(_cosine_invcdf(p), expected, rtol=1e-14)

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -1335,7 +1335,16 @@ class cosine_gen(rv_continuous):
         return 1.0/2/np.pi*(1+np.cos(x))
 
     def _cdf(self, x):
-        return 1.0/2/np.pi*(np.pi + x + np.sin(x))
+        return scu._cosine_cdf(x)
+
+    def _sf(self, x):
+        return scu._cosine_cdf(-x)
+
+    def _ppf(self, p):
+        return scu._cosine_invcdf(p)
+
+    def _isf(self, p):
+        return -scu._cosine_invcdf(p)
 
     def _stats(self):
         return 0.0, np.pi*np.pi/3.0-2.0, 0.0, -6.0*(np.pi**4-90)/(5.0*(np.pi*np.pi-6)**2)

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -106,12 +106,12 @@ skip_fit_fix_test = {"MLE": skip_fit_fix_test_mle,
 # Here 'fail' mean produce wrong results and/or raise exceptions, depending
 # on the implementation details of corresponding special functions.
 # cf https://github.com/scipy/scipy/pull/4979 for a discussion.
-fails_cmplx = set(['beta', 'betaprime', 'chi', 'chi2', 'dgamma', 'dweibull',
-                   'erlang', 'f', 'gamma', 'gausshyper', 'gengamma',
+fails_cmplx = set(['beta', 'betaprime', 'chi', 'chi2', 'cosine', 'dgamma',
+                   'dweibull', 'erlang', 'f', 'gamma', 'gausshyper', 'gengamma',
                    'geninvgauss', 'gennorm', 'genpareto',
                    'halfgennorm', 'invgamma',
-                   'ksone', 'kstwo', 'kstwobign', 'levy_l', 'loggamma', 'logistic',
-                   'loguniform', 'maxwell', 'nakagami',
+                   'ksone', 'kstwo', 'kstwobign', 'levy_l', 'loggamma',
+                   'logistic', 'loguniform', 'maxwell', 'nakagami',
                    'ncf', 'nct', 'ncx2', 'norminvgauss', 'pearson3', 'rdist',
                    'reciprocal', 'rice', 'skewnorm', 't', 'tukeylambda',
                    'vonmises', 'vonmises_line', 'rv_histogram_instance'])

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -5371,7 +5371,7 @@ class TestNakagami:
 
         def dlogl_dnu(nu, loc, scale):
             return ((-2*nu + 1) * np.sum(1/(samples - loc))
-                   + 2*nu/scale**2 * np.sum(samples - loc))
+                    + 2*nu/scale**2 * np.sum(samples - loc))
 
         def dlogl_dloc(nu, loc, scale):
             return (N * (1 + np.log(nu) - polygamma(0, nu)) +

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -5443,6 +5443,7 @@ def test_support_gh13294_regression(distname, args):
         assert_equal(a, np.nan)
         assert_equal(b, np.nan)
 
+
 def test_support_broadcasting_gh13294_regression():
     a0, b0 = stats.norm.support([0, 0, 0, 1], [1, 1, 1, -1])
     ex_a0 = np.array([-np.inf, -np.inf, -np.inf, np.nan])
@@ -5466,6 +5467,26 @@ def test_support_broadcasting_gh13294_regression():
     assert_equal(b2, ex_b2)
     assert a2.shape == ex_a2.shape
     assert b2.shape == ex_b2.shape
+
+
+# Check a few values of the cosine distribution's cdf, sf, ppf and
+# isf methods.  Expected values were computed with mpmath.
+
+@pytest.mark.parametrize('x, expected',
+                         [(-3.14159, 4.956444476505336e-19),
+                          (3.14, 0.9999999998928399)])
+def test_cosine_cdf_sf(x, expected):
+    assert_allclose(stats.cosine.cdf(x), expected)
+    assert_allclose(stats.cosine.sf(-x), expected)
+
+
+@pytest.mark.parametrize('p, expected',
+                         [(1e-6, -3.1080612413765905),
+                          (1e-17, -3.141585429601399),
+                          (0.975, 2.1447547020964923)])
+def test_cosine_ppf_isf(p, expected):
+    assert_allclose(stats.cosine.ppf(p), expected)
+    assert_allclose(stats.cosine.isf(p), -expected)
 
 
 def test_distr_params_lists():


### PR DESCRIPTION
Closes gh-13417

MAINT: stats: Implement cdf and ppf as ufuncs for the cosine distribution.

The ultimate goal of this change is to add an efficient implementation
of the PPF (i.e. inverse CDF) for the cosine distribution in stats.

While testing the new inverse CDF function, I found that the existing
CDF function suffered from loss of precision near x=-pi.  The CDF is

    F(x) = (pi + x + sin(x))/(2*pi)

For example, if x = -3.141592, a direct translation of that function
using numpy.pi and numpy.sin gives:

    >>> x = -3.141592
    >>> (np.pi + x + np.sin(x))/(2*np.pi)
    -1.9483458130046464e-17

The CDF should never be negative, so that result is clearly nonsense.
Changing the order of the operands still gives a bad result:

    >>> (np.pi + (x + np.sin(x)))/(2*np.pi)
    0.0

In the neighborhood of -pi, the function is O((x+pi)**3), and -3.141592 + pi
is approximately 6.5e-07, so the result should be of the order 1e-21.

One of the main changes here is to create a ufunc, scipy.special._ufuncs._cosine_cdf,
that uses a Pade approximation of the CDF near x=-pi.  With this function, the
above value is computed much more accurately:

    >>> from scipy.special._ufuncs import _cosine_cdf
    >>> _cosine_cdf(x)
    7.406016328569848e-21

That result is, in fact, accurate to full 64 bit precision (checked
with mpmath).

The second big change here is to add a ufunc for the inverse of the CDF.
The new function is scipy.special._ufuncs._cosine_invcdf.

There is no closed-form expression for the inverse of the CDF, so we
have to compute it numerically. The idea is simple: get a good first
guess for the inverse value, and then apply Halley's method to refine
the result.

To get a good first guess, we'll use series expansions of the inverse.
Two series expansions will be used: one at the center of the function
(i.e. at p=0.5), and one at each end of the interval 0 <= p <= 1.
(Technically that's three expansions but the expansions at the ends
are related by symmetry.)

For the series at the ends (i.e. near p=0 and p=1), we can use
the series given in the wikipedia page on Kepler's equation
(https://en.wikipedia.org/wiki/Kepler%27s_equation).  The series
that we need is the expression for E when e = 1, given in the section
"Inverse Kepler equation".  This is the series that begins

    E = s + s**3/60 + s**5/1400 + ...,  with s = (6*M)**(1/3)

Translating that to p=0 gives, for p near 0,

    invcdf(p) = -pi + s +  s**3/60 + s**5/1400 + ...,

with s = (12*pi*p)**(1/3).

For the series in the center of the function, we revert the
Taylor series of x + sin(x) at x=0 and then convert the result
to a Pade approximant.  See the comments in _cosine.c
for more details.

The new functions _cosine_cdf and _cosine_invcdf are used in
the methods _cdf, _ppf, _sf and _isf of scipy.stats.cosine.

The efficient implementation of the _ppf method means we can
remove 'cosine' from the list of slow distributions in the file
stats/tests/test_continuous.py.