### PR TITLE
DEV: Run tests in parallel when --parallel flag is passed to runtests.py

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -284,7 +284,8 @@ def main(argv):
                       extra_argv=extra_argv,
                       doctests=args.doctests,
                       coverage=args.coverage,
-                      tests=tests)
+                      tests=tests,
+                      parallel=args.parallel)
     finally:
         os.chdir(cwd)
 

--- a/scipy/_lib/_testutils.py
+++ b/scipy/_lib/_testutils.py
@@ -27,7 +27,7 @@ class PytestTester(object):
         self.module_name = module_name
 
     def __call__(self, label="fast", verbose=1, extra_argv=None, doctests=False,
-                 coverage=False, tests=None):
+                 coverage=False, tests=None, parallel=None):
         import pytest
 
         module = sys.modules[self.module_name]
@@ -55,6 +55,14 @@ class PytestTester(object):
         if tests is None:
             tests = [self.module_name]
 
+        if parallel is not None and parallel > 1:
+            if _pytest_has_xdist():
+                pytest_args += ['-n', str(parallel)]
+            else:
+                import warnings
+                warnings.warn('Could not run tests in parallel because '
+                              'pytest-xdist plugin is not available.')
+
         pytest_args += ['--pyargs'] + list(tests)
 
         try:
@@ -63,6 +71,18 @@ class PytestTester(object):
             code = exc.code
 
         return (code == 0)
+
+
+def _pytest_has_xdist():
+    """
+    Check if the pytest-xdist plugin is installed, providing parallel tests
+    """
+
+    try:
+        import xdist
+        return True
+    except ImportError:
+        return False
 
 
 def check_free_memory(free_mb):


### PR DESCRIPTION
Related to #10101

Currently you need to specify number of jobs seperately for the build and test suite. This unifies them, while avoiding breaking the test suite when pytest-xdist is not available.

I couldn't find any official way to query the current pytest plugins, so please excuse the workaround.