### PR TITLE
TST: Register markers in conftest.py.

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,13 +1,12 @@
 [pytest]
 addopts = -l
-markers =
-    slow: mark test as slow
-    xslow: mark test as extremely slow (not run unless explicitly requested)
+
 filterwarnings =
     error
     always::scipy._lib._testutils.FPUModeChangeWarning
     once:.*LAPACK bug 0038.*:RuntimeWarning
     ignore:Using or importing the ABCs from 'collections'*:DeprecationWarning
     ignore:can't resolve package from __spec__ or __package__, falling back on __name__ and __path__:ImportWarning
+
 env =
     PYTHONHASHSEED=0

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -10,6 +10,13 @@ from scipy._lib._fpumode import get_fpu_mode
 from scipy._lib._testutils import FPUModeChangeWarning
 
 
+def pytest_configure(config):
+    config.addinivalue_line("markers",
+        "slow: Tests that are very slow.")
+    config.addinivalue_line("markers",
+        "xslow: mark test as extremely slow (not run unless explicitly requested)")
+
+
 def pytest_runtest_setup(item):
     if LooseVersion(pytest.__version__) >= LooseVersion("3.6.0"):
         mark = item.get_closest_marker("xslow")


### PR DESCRIPTION
Register the markers 'slow' and 'xslow' in the `conftest.py` file
instead of `pytest.ini` as the latter file is not always present.

Note that pytest >= 4.5.0 raises a warning if it finds unregistered markers.