### PR TITLE
TST: fix test issue for stats.pearsonr

### DIFF
--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -369,7 +369,7 @@ class TestCorrPearsonr(object):
 
         # The expected r and p are exact.
         assert_allclose(r, -1.0)
-        assert_allclose(p, 0.0)
+        assert_allclose(p, 0.0, atol=1e-7)
 
     def test_unequal_lengths(self):
         x = [1, 2, 3]


### PR DESCRIPTION
Fixes this:
```
>       assert_allclose(p, 0.0)
E       AssertionError:
E       Not equal to tolerance rtol=1e-07, atol=0
E
E       Mismatch: 100%
E       Max absolute difference: 1.34157586e-08
E       Max relative difference: inf
E        x: array(1.341576e-08)
E        y: array(0.)
```
Testing for "close to zero" should always have `atol > 0`