### PR TITLE
MAINT: 1.3.0 prep / safe backport

### DIFF
--- a/doc/release/1.3.0-notes.rst
+++ b/doc/release/1.3.0-notes.rst
@@ -2,8 +2,6 @@
 SciPy 1.3.0 Release Notes
 ==========================
 
-.. note:: Scipy 1.3.0 is not released yet!
-
 .. contents::
 
 SciPy 1.3.0 is the culmination of 5 months of hard work. It contains
@@ -203,6 +201,15 @@ can be used to track the new import locations for the relocated functions.
 
 For ``pinv``, ``pinv2``, and ``pinvh``, the default cutoff values are changed 
 for consistency (see the docs for the actual values).
+
+`scipy.optimize` changes
+---------------------------
+
+The default method for ``linprog`` is now ``'interior-point'``. The method's
+robustness and speed come at a cost: solutions may not be accurate to
+machine precision or correspond with a vertex of the polytope defined
+by the constraints. To revert to the original simplex method,
+include the argument ``method='simplex'``.
 
 `scipy.stats` changes
 ---------------------

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -369,7 +369,7 @@ class TestCorrPearsonr(object):
 
         # The expected r and p are exact.
         assert_allclose(r, -1.0)
-        assert_allclose(p, 0.0)
+        assert_allclose(p, 0.0, atol=1e-7)
 
     def test_unequal_lengths(self):
         x = [1, 2, 3]

--- a/setup.py
+++ b/setup.py
@@ -56,8 +56,8 @@ Operating System :: MacOS
 MAJOR = 1
 MINOR = 3
 MICRO = 0
-ISRELEASED = True
-VERSION = '%d.%d.%drc2' % (MAJOR, MINOR, MICRO)
+ISRELEASED = False
+VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
 
 # Return the git revision as a string


### PR DESCRIPTION
Hopefully pytest doesn't have a fit without backporting the warnings stuff. Beyond that, the changes are summarized below. I went through the backport labels and only 1 seemed appropriate & not already present for the 1.3.x branch at this point close to 1.3.0 "final" release.

If something is missing / looks wrong let me know--way cheaper to fix now vs. after release.

* set version to 1.3.0 unreleased
(remove the rc2)

* update release notes with a backward
incompatible change entry for scipy.optimize
as requested in gh-10160; remove note
about 1.3.0 not being released yet (now imminent
pending release commit) Fixes #10160

* backport #10182