### PR TITLE
DOC: fix a formatting issue in the scipy.spatial module docstring.

### DIFF
--- a/scipy/spatial/__init__.py
+++ b/scipy/spatial/__init__.py
@@ -63,10 +63,8 @@ tessellation (N-dim simplices), convex hull facets, and Voronoi ridges
 
 For Delaunay triangulations and convex hulls, the neighborhood
 structure of the simplices satisfies the condition:
-
-    ``tess.neighbors[i,j]`` is the neighboring simplex of the i-th
-    simplex, opposite to the j-vertex. It is -1 in case of no
-    neighbor.
+``tess.neighbors[i,j]`` is the neighboring simplex of the ``i``-th
+simplex, opposite to the ``j``-vertex. It is -1 in case of no neighbor.
 
 Convex hull facets also define a hyperplane equation::
 


### PR DESCRIPTION
[ci skip]

For the rendering issue, see current version of https://docs.scipy.org/doc/scipy/reference/spatial.html#module-scipy.spatial