### PR TITLE
Fewer checks on xdata for curve_fit.

### DIFF
--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -517,10 +517,10 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
         The model function, f(x, ...).  It must take the independent
         variable as the first argument and the parameters to fit as
         separate remaining arguments.
-    xdata : array_like
+    xdata : array_like or object
         The independent variable where the data is measured.
-        Must be an M-length sequence or an (k,M)-shaped array for functions
-        with k predictors.
+        Should usually be an M-length sequence or an (k,M)-shaped array for
+        functions with k predictors, but can actually be any object.
     ydata : array_like
         The dependent data, a length M array - nominally ``f(xdata, ...)``.
     p0 : array_like, optional
@@ -701,28 +701,24 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
         raise ValueError("Method 'lm' only works for unconstrained problems. "
                          "Use 'trf' or 'dogbox' instead.")
 
+    # optimization may produce garbage for float32 inputs, cast them to float64
+
     # NaNs can not be handled
     if check_finite:
-        ydata = np.asarray_chkfinite(ydata)
+        ydata = np.asarray_chkfinite(ydata, float)
     else:
-        ydata = np.asarray(ydata)
+        ydata = np.asarray(ydata, float)
 
     if isinstance(xdata, (list, tuple, np.ndarray)):
         # `xdata` is passed straight to the user-defined `f`, so allow
         # non-array_like `xdata`.
         if check_finite:
-            xdata = np.asarray_chkfinite(xdata)
+            xdata = np.asarray_chkfinite(xdata, float)
         else:
-            xdata = np.asarray(xdata)
+            xdata = np.asarray(xdata, float)
 
-    if xdata.size == 0:
-        raise ValueError("`xdata` must not be empty!")
     if ydata.size == 0:
         raise ValueError("`ydata` must not be empty!")
-
-    # optimization may produce garbage for float32 inputs, cast them to float64
-    xdata = xdata.astype(float)
-    ydata = ydata.astype(float)
 
     # Determine type of sigma
     if sigma is not None:

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -410,7 +410,9 @@ class TestCurveFit(object):
         assert_almost_equal(pcov[0,0], 0.0016, decimal=4)
 
         # Test if we get the same with full_output. Regression test for #1415.
-        res = curve_fit(func, self.x, self.y, full_output=1)
+        # Also test if check_finite can be turned off.
+        res = curve_fit(func, self.x, self.y,
+                        full_output=1, check_finite=False)
         (popt2, pcov2, infodict, errmsg, ier) = res
         assert_array_almost_equal(popt, popt2)
 
@@ -549,6 +551,11 @@ class TestCurveFit(object):
     def test_function_zero_params(self):
         # Fit args is zero, so "Unable to determine number of fit parameters."
         assert_raises(ValueError, curve_fit, lambda x: x, [1, 2], [3, 4])
+
+    def test_None_x(self):  # Added in GH10196
+        popt, pcov = curve_fit(lambda _, a: a * np.arange(10),
+                               None, 2 * np.arange(10))
+        assert_allclose(popt, [2.])
 
     def test_method_argument(self):
         def f(x, a, b):


### PR DESCRIPTION
The *xdata* argument to curve_fit is essentially a helper in the case
where one wants to write the fit function as `func(x, *params)`.  Until
scipy 1.3.0, it was possible to just pass a dummy value (e.g. None) as
*xdata*, e.g.
```
curve_fit(lambda _, a: a * np.arange(10), None, 2 * np.arange(10))
```
A comment in the implementation clearly states that the intent was for
*xdata* to be anything, including a non-array:
```
    if isinstance(xdata, (list, tuple, np.ndarray)):
        # `xdata` is passed straight to the user-defined `f`, so allow
        # non-array_like `xdata`.
```
(Effectively, this is an interface closer to the one of `least_squares`,
with the advantage that the covariance matrix is also returned.)

1.3.0 added two checks that make this impossible: it now requires that
*xdata* is not empty, and casts it to float64 for improved precision.

The non-emptiness check is spurious: it was introduced at the same time
as a check that *ydata* not be empty (which is necessary to avoid a
confusing error message, and is reasonable).  This PR removes it.

The cast to float64 can be applied only if xdata is indeed an
array-like, which this PR does.

xref #9893, #10076.