### PR TITLE
BUG: Compressed matrix indexing should return a scalar

### DIFF
--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -644,7 +644,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         indptr, indices, data = get_csr_submatrix(
             M, N, self.indptr, self.indices, self.data,
             major, major + 1, minor, minor + 1)
-        return np.array(data.sum(), dtype=self.dtype)
+        return data.sum(dtype=self.dtype)
 
     def _get_sliceXslice(self, row, col):
         major, minor = self._swap((row, col))

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2143,6 +2143,8 @@ class _TestGetSet(object):
                 for j in range(-N, N):
                     assert_equal(A[i,j], D[i,j])
 
+            assert_equal(type(A[1,1]), dtype)
+
             for ij in [(0,3),(-1,3),(4,0),(4,3),(4,-1), (1, 2, 3)]:
                 assert_raises((IndexError, TypeError), A.__getitem__, ij)
 


### PR DESCRIPTION
Fixes gh-10206

This matches how indexing was done prior to 1.3:

https://github.com/scipy/scipy/blob/a905607ef9143504bb48e148011cb78b461471e5/scipy/sparse/compressed.py#L885-L889