### PR TITLE
format nested OptimizeResults

### DIFF
--- a/scipy/_lib/six.py
+++ b/scipy/_lib/six.py
@@ -274,3 +274,13 @@ _add_doc(reraise, """Reraise an exception.""")
 def with_metaclass(meta, base=object):
     """Create a base class with a metaclass."""
     return meta("NewBase", (base,), {})
+
+
+if PY3:
+    from textwrap import indent
+else:
+    def indent(text, prefix, predicate=None):
+        return ''.join(
+            prefix+line if predicate is None or predicate(line) else line
+            for line in text.splitlines(True)
+        )

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -30,7 +30,7 @@ __docformat__ = "restructuredtext en"
 import warnings
 import sys
 import numpy
-from scipy._lib.six import callable, xrange
+from scipy._lib.six import callable, indent, xrange
 from numpy import (atleast_1d, eye, mgrid, argmin, zeros, shape, squeeze,
                    asarray, sqrt, Inf, asfarray, isinf)
 import numpy as np
@@ -119,10 +119,15 @@ class OptimizeResult(dict):
     __setattr__ = dict.__setitem__
     __delattr__ = dict.__delitem__
 
+    def __formatvforrepr(self, v, m):
+        if isinstance(v, OptimizeResult):
+            return "\n" + indent(repr(v), ' '*m)
+        return repr(v)
+
     def __repr__(self):
         if self.keys():
             m = max(map(len, list(self.keys()))) + 1
-            return '\n'.join([k.rjust(m) + ': ' + repr(v)
+            return '\n'.join([k.rjust(m) + ': ' + self.__formatvforrepr(v, m)
                               for k, v in sorted(self.items())])
         else:
             return self.__class__.__name__ + "()"


### PR DESCRIPTION
the use case is problems that have sub-problems, where you want to print the results of the sub-problem together with the main results for debugging purposes

My particular motivation: I have my own script to minimize multidimensional polynomials, and I'm using `OptimizeResult` to pass the results around.  I first see if it goes to -infinity anywhere on the sphere at infinity; if not, I minimize within the R^n space by taking the gradient and solving for when it's zero.  I want to have the results for both the problem on the boundary and the main problem.

I can imagine other use cases, though they're probably rare; I have trouble imagining a case where someone would want to nest `OptimizeResult`s but _not_ want to format them in a way similar to what I'm doing here.