### PR TITLE
DOC: Fix code of conduct formatting

### DIFF
--- a/doc/source/dev/conduct/code_of_conduct.rst
+++ b/doc/source/dev/conduct/code_of_conduct.rst
@@ -56,17 +56,17 @@ We strive to:
    others. Do not insult or put down other participants.  We will not accept
    harassment or other exclusionary behaviour, such as:
 
-    - Violent threats or language directed against another person.
-    - Sexist, racist, or otherwise discriminatory jokes and language.
-    - Posting sexually explicit or violent material.
-    - Posting (or threatening to post) other people's personally identifying information ("doxing").
-    - Sharing private content, such as emails sent privately or non-publicly,
-      or unlogged forums such as IRC channel history, without the sender's consent.
-    - Personal insults, especially those using racist or sexist terms.
-    - Unwelcome sexual attention.
-    - Excessive profanity. Please avoid swearwords; people differ greatly in their sensitivity to swearing.
-    - Repeated harassment of others. In general, if someone asks you to stop, then stop.
-    - Advocating for, or encouraging, any of the above behaviour.
+  - Violent threats or language directed against another person.
+  - Sexist, racist, or otherwise discriminatory jokes and language.
+  - Posting sexually explicit or violent material.
+  - Posting (or threatening to post) other people's personally identifying information ("doxing").
+  - Sharing private content, such as emails sent privately or non-publicly,
+    or unlogged forums such as IRC channel history, without the sender's consent.
+  - Personal insults, especially those using racist or sexist terms.
+  - Unwelcome sexual attention.
+  - Excessive profanity. Please avoid swearwords; people differ greatly in their sensitivity to swearing.
+  - Repeated harassment of others. In general, if someone asks you to stop, then stop.
+  - Advocating for, or encouraging, any of the above behaviour.
 
 
 Diversity Statement


### PR DESCRIPTION
Code of conduct unordered list is over indented