### PR TITLE
CI: Merge CircleCI for PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,18 @@ jobs:
       - checkout
 
       - run:
+          name: merge with upstream
+          command: |
+            echo $(git log -1 --pretty=%B) | tee gitlog.txt
+            echo ${CI_PULL_REQUEST//*pull\//} | tee merge.txt
+            if [[ $(cat merge.txt) != "" ]]; then
+              echo "Merging $(cat merge.txt)";
+              git remote add upstream git://github.com/scipy/scipy.git;
+              git pull --ff-only upstream "refs/pull/$(cat merge.txt)/merge";
+              git fetch upstream master;
+            fi
+
+      - run:
           name: update submodules
           command: |
             git submodule init

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -326,7 +326,7 @@ def validate_rst_syntax(text, name, dots=True):
 
     ok_unknown_items = set([
         'mod', 'currentmodule', 'autosummary', 'data',
-        'obj', 'versionadded', 'versionchanged', 'module', 'class',
+        'obj', 'versionadded', 'versionchanged', 'module', 'class', 'meth',
         'ref', 'func', 'toctree', 'moduleauthor',
         'sectionauthor', 'codeauthor', 'eq', 'doi', 'DOI', 'arXiv', 'arxiv'
     ])


### PR DESCRIPTION
Unlike Travis (and I think AppVeyor and Azure?), for PRs CircleCI builds the branch itself, not the merged-with-master version. This adds a few lines, adapted from what has been working for about a year now in [MNE-Python](https://github.com/mne-tools/mne-python/blob/master/.circleci/config.yml#L30-L40).

This should reduce the frequency with which people need to rebase their PRs due to CircleCI breaking.