### PR TITLE
WIP, TST: add compiled cov to Azure CI reports

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,29 +18,8 @@ jobs:
     vmImage: 'ubuntu-16.04'
   steps:
   - script: |
-           docker pull i386/ubuntu:bionic
-           docker run -v $(pwd):/scipy i386/ubuntu:bionic /bin/bash -c "cd scipy && \
-           apt-get -y update && \
-           apt-get -y install curl python3.6-dev python3.6 python3-distutils pkg-config libpng-dev libjpeg8-dev libfreetype6-dev && \
-           curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
-           python3.6 get-pip.py && \
-           pip3 --version && \
-           pip3 install setuptools wheel numpy cython==0.29.2 pytest pytest-timeout pytest-xdist pytest-env pytest-faulthandler pytest-cov Pillow mpmath matplotlib gcovr --user && \
-           export DEBIAN_FRONTEND=noninteractive && \
-           apt-get -y install g++-5 gcc-5 gfortran-5 wget mono-complete && \
-           cd .. && \
-           mkdir openblas && cd openblas && \
-           wget https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.3-186-g701ea883-manylinux1_i686.tar.gz && \
-           tar zxvf openblas-v0.3.3-186-g701ea883-manylinux1_i686.tar.gz && \
-           cp -r ./usr/local/lib/* /usr/lib && \
-           cp ./usr/local/include/* /usr/include && \
-           cd ../scipy && \
-           ln -sf /usr/bin/gfortran-5 /usr/bin/gfortran && \
-           ln -sf /usr/bin/gcc-5 /usr/bin/gcc && \
-           ln -sf /usr/bin/gcov-5 /usr/bin/gcov && \
-           ln -sf /usr/bin/g++-5 /usr/bin/g++ && \
-           wget https://dist.nuget.org/win-x86-commandline/latest/nuget.exe && \
-           mono nuget.exe install ReportGenerator && \
+           docker pull tylerreddy/scipy_gcov_debug
+           docker run -v $(pwd):/scipy tylerreddy/scipy_gcov_debug /bin/bash -c "cd scipy && \
            export NPY_DISTUTILS_APPEND_FLAGS=1 && \
            export CC='gcc --coverage' && \
            export CXX='g++ --coverage' && \
@@ -49,11 +28,12 @@ jobs:
            export LDFLAGS='--coverage' && \
            export FOPT='-O1' && \
            export OPT='-O1' && \
-           python3.6 runtests.py --mode=full -- -n auto -rsx --junitxml=junit/test-results.xml --cov=scipy --cov-report=xml && \
+           python3.6 -u runtests.py --mode=fast -- -n auto -rsx --junitxml=junit/test-results.xml --cov=scipy --cov-report=xml && \
            find . -name '*.gcno' -type f -exec gcov -pb {} + && \
            /root/.local/bin/gcovr -r . --xml -o coverage_compiled_langs.xml && \
-           mono ./ReportGenerator*/tools/net47/ReportGenerator.exe '-reports:**/coverage*.xml' '-targetdir:.' -reporttypes:'HtmlInline_AzurePipelines;Cobertura' && \
-           find . -name 'coverage*.xml' -delete"
+           mono ../ReportGenerator*/tools/net47/ReportGenerator.exe '-reports:**/coverage*.xml' '-targetdir:.' -reporttypes:'HtmlInline_AzurePipelines;Cobertura' && \
+           find . -name 'coverage*.xml' -delete && \
+           mkdir htmlcov && mv *.htm htmlcov && chmod -R 777 htmlcov"
     displayName: 'Run 32-bit Ubuntu Docker Build / Tests'
   - task: PublishTestResults@2
     condition: succeededOrFailed()
@@ -65,101 +45,4 @@ jobs:
     inputs:
       codeCoverageTool: Cobertura
       summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/Cobertura.xml'
-      reportDirectory: '$(System.DefaultWorkingDirectory)'
-- job: Windows
-  pool:
-    vmImage: 'VS2017-Win2016'
-  variables:
-      OPENBLAS_32: https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.3-186-g701ea883-win32-gcc_7_1_0.zip
-      OPENBLAS_64: https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.3-186-g701ea883-win_amd64-gcc_7_1_0.zip
-  strategy:
-    maxParallel: 4
-    matrix:
-        Python36-32bit-full:
-          PYTHON_VERSION: '3.6'
-          PYTHON_ARCH: 'x86'
-          TEST_MODE: full
-          OPENBLAS: $(OPENBLAS_32)
-          BITS: 32
-        Python35-64bit-full:
-          PYTHON_VERSION: '3.5'
-          PYTHON_ARCH: 'x64'
-          TEST_MODE: full
-          OPENBLAS: $(OPENBLAS_64)
-          BITS: 64
-        Python36-64bit-full:
-          PYTHON_VERSION: '3.6'
-          PYTHON_ARCH: 'x64'
-          TEST_MODE: full
-          OPENBLAS: $(OPENBLAS_64)
-          BITS: 64
-        Python37-64bit-full:
-          PYTHON_VERSION: '3.7'
-          PYTHON_ARCH: 'x64'
-          TEST_MODE: full
-          OPENBLAS: $(OPENBLAS_64)
-          BITS: 64
-  steps:
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: $(PYTHON_VERSION)
-      addToPath: true
-      architecture: $(PYTHON_ARCH)
-  - script: python -m pip install --upgrade pip setuptools wheel
-    displayName: 'Install tools'
-  - powershell: |
-      $wc = New-Object net.webclient;
-      $wc.Downloadfile("$(OPENBLAS)", "openblas.zip")
-      $tmpdir = New-TemporaryFile | %{ rm $_; mkdir $_ }
-      Expand-Archive "openblas.zip" $tmpdir
-      $pyversion = python -c "from __future__ import print_function; import sys; print(sys.version.split()[0])"
-      Write-Host "Python Version: $pyversion"
-      $target = "C:\\hostedtoolcache\\windows\\Python\\$pyversion\\$(PYTHON_ARCH)\\lib\\openblas.a"
-      Write-Host "target path: $target"
-      cp $tmpdir\$(BITS)\lib\libopenblas_v0.3.3-186-g701ea883-gcc_7_1_0.a $target
-    displayName: 'Download / Install OpenBLAS'
-  - powershell: |
-      # wheels appear to use mingw64 version 6.3.0, but 6.4.0
-      # is the closest match available from choco package manager
-      choco install -y mingw --forcex86 --force --version=6.4.0
-    displayName: 'Install 32-bit mingw for 32-bit builds'
-    condition: eq(variables['BITS'], 32)
-  - powershell: |
-      choco install -y mingw --force --version=6.4.0
-    displayName: 'Install 64-bit mingw for 64-bit builds'
-    condition: eq(variables['BITS'], 64)
-  - script: python -m pip install numpy cython==0.29.2 pytest pytest-timeout pytest-xdist pytest-env pytest-faulthandler pytest-cov Pillow mpmath matplotlib
-    displayName: 'Install dependencies'
-  - powershell: |
-      If ($(BITS) -eq 32) {
-          # 32-bit build requires careful adjustments
-          # until Microsoft has a switch we can use
-          # directly for i686 mingw
-          $env:NPY_DISTUTILS_APPEND_FLAGS = 1
-          $env:CFLAGS = "-m32"
-          $env:LDFLAGS = "-m32"
-          refreshenv
-      }
-      $env:PATH = "C:\\ProgramData\\chocolatey\\lib\\mingw\\tools\\install\\mingw$(BITS)\\bin;" + $env:PATH
-
-      mkdir dist
-      pip wheel --no-build-isolation -v -v -v --wheel-dir=dist .
-      ls dist -r | Foreach-Object {
-          pip install $_.FullName
-      }
-    displayName: 'Build SciPy'
-  - powershell: |
-      $env:PATH = "C:\\ProgramData\\chocolatey\\lib\\mingw\\tools\\install\\mingw$(BITS)\\bin;" + $env:PATH
-      python runtests.py -n --mode=$(TEST_MODE) -- -n auto -rsx --junitxml=junit/test-results.xml --cov=scipy --cov-report=xml
-    displayName: 'Run SciPy Test Suite'
-  - task: PublishTestResults@2
-    condition: succeededOrFailed()
-    inputs:
-      testResultsFiles: '**/test-*.xml'
-      failTaskOnFailedTests: true
-      testRunTitle: 'Publish test results for Python $(python.version)'
-  - task: PublishCodeCoverageResults@1
-    inputs:
-      codeCoverageTool: Cobertura
-      summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
       reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,6 +10,8 @@ trigger:
 # despite the numbering on the downloaded files
 # and should be updated to match scipy-wheels as appropriate
 
+variables:
+    disable.coverage.autogenerate: 'true'
 jobs:
 - job: Linux_Python_36_32bit_full
   pool:
@@ -47,10 +49,10 @@ jobs:
            export LDFLAGS='--coverage' && \
            export FOPT='-O1' && \
            export OPT='-O1' && \
-           python3.6 runtests.py --mode=full -- -n auto -rsx --junitxml=junit/test-results.xml --cov=scipy --cov-report=xml --cov-report=html && \
+           python3.6 runtests.py --mode=full -- -n auto -rsx --junitxml=junit/test-results.xml --cov=scipy --cov-report=xml && \
            find . -name '*.gcno' -type f -exec gcov -pb {} + && \
            /root/.local/bin/gcovr -r . --xml -o coverage_compiled_langs.xml && \
-           mono ./ReportGenerator.4.1.7/tools/net47/ReportGenerator.exe '-reports:**/coverage*.xml' '-targetdir:.' -reporttypes:Cobertura && \
+           mono ./ReportGenerator*/tools/net47/ReportGenerator.exe '-reports:**/coverage*.xml' '-targetdir:.' -reporttypes:'HtmlInline_AzurePipelines;Cobertura' && \
            find . -name 'coverage*.xml' -delete"
     displayName: 'Run 32-bit Ubuntu Docker Build / Tests'
   - task: PublishTestResults@2
@@ -63,7 +65,7 @@ jobs:
     inputs:
       codeCoverageTool: Cobertura
       summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/Cobertura.xml'
-      reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
+      reportDirectory: '$(System.DefaultWorkingDirectory)'
 - job: Windows
   pool:
     vmImage: 'VS2017-Win2016'
@@ -148,7 +150,7 @@ jobs:
     displayName: 'Build SciPy'
   - powershell: |
       $env:PATH = "C:\\ProgramData\\chocolatey\\lib\\mingw\\tools\\install\\mingw$(BITS)\\bin;" + $env:PATH
-      python runtests.py -n --mode=$(TEST_MODE) -- -n auto -rsx --junitxml=junit/test-results.xml --cov=scipy --cov-report=xml --cov-report=html
+      python runtests.py -n --mode=$(TEST_MODE) -- -n auto -rsx --junitxml=junit/test-results.xml --cov=scipy --cov-report=xml
     displayName: 'Run SciPy Test Suite'
   - task: PublishTestResults@2
     condition: succeededOrFailed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,8 +23,9 @@ jobs:
            curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
            python3.6 get-pip.py && \
            pip3 --version && \
-           pip3 install setuptools wheel numpy cython==0.29.2 pytest pytest-timeout pytest-xdist pytest-env pytest-faulthandler pytest-cov Pillow mpmath matplotlib --user && \
-           apt-get -y install gfortran-5 wget && \
+           pip3 install setuptools wheel numpy cython==0.29.2 pytest pytest-timeout pytest-xdist pytest-env pytest-faulthandler pytest-cov Pillow mpmath matplotlib gcovr --user && \
+           export DEBIAN_FRONTEND=noninteractive && \
+           apt-get -y install g++-5 gcc-5 gfortran-5 wget mono-complete && \
            cd .. && \
            mkdir openblas && cd openblas && \
            wget https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.3-186-g701ea883-manylinux1_i686.tar.gz && \
@@ -32,7 +33,25 @@ jobs:
            cp -r ./usr/local/lib/* /usr/lib && \
            cp ./usr/local/include/* /usr/include && \
            cd ../scipy && \
-           F77=gfortran-5 F90=gfortran-5 python3.6 runtests.py --mode=full -- -n auto -rsx --junitxml=junit/test-results.xml --cov=scipy --cov-report=xml --cov-report=html"
+           ln -sf /usr/bin/gfortran-5 /usr/bin/gfortran && \
+           ln -sf /usr/bin/gcc-5 /usr/bin/gcc && \
+           ln -sf /usr/bin/gcov-5 /usr/bin/gcov && \
+           ln -sf /usr/bin/g++-5 /usr/bin/g++ && \
+           wget https://dist.nuget.org/win-x86-commandline/latest/nuget.exe && \
+           mono nuget.exe install ReportGenerator && \
+           export NPY_DISTUTILS_APPEND_FLAGS=1 && \
+           export CC='gcc --coverage' && \
+           export CXX='g++ --coverage' && \
+           export F77='gfortran --coverage' && \
+           export F90='gfortran --coverage' && \
+           export LDFLAGS='--coverage' && \
+           export FOPT='-O1' && \
+           export OPT='-O1' && \
+           python3.6 runtests.py --mode=full -- -n auto -rsx --junitxml=junit/test-results.xml --cov=scipy --cov-report=xml --cov-report=html && \
+           find . -name '*.gcno' -type f -exec gcov -pb {} + && \
+           /root/.local/bin/gcovr -r . --xml -o coverage_compiled_langs.xml && \
+           mono ./ReportGenerator.4.1.7/tools/net47/ReportGenerator.exe '-reports:**/coverage*.xml' '-targetdir:.' -reporttypes:Cobertura && \
+           find . -name 'coverage*.xml' -delete"
     displayName: 'Run 32-bit Ubuntu Docker Build / Tests'
   - task: PublishTestResults@2
     condition: succeededOrFailed()
@@ -43,7 +62,7 @@ jobs:
   - task: PublishCodeCoverageResults@1
     inputs:
       codeCoverageTool: Cobertura
-      summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
+      summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/Cobertura.xml'
       reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
 - job: Windows
   pool:


### PR DESCRIPTION
This has proven substantially more difficult than desired, but the compiled code source files are starting to pop up in CI line coverage reports, albeit with all kinds of issues. This isn't made any easier with a 32-bit target as the only gcc job in Azure. I suspect, at this stage, the paths are a little mangled re:  runtests.py vs. source dir, but probably other issues too.

* use gcov and gcovr to report compiled
code line coverage in Azure CI interface;
this does not apply to the Windows Azure
jobs that are built with msvc

* compiler optimization level -O1 was needed
for unit tests to pass with gcov, perhaps because the sole
gcc job in our Azure matrix is 32-bit; ideally, we'd
use -O0, which has previously worked on 64-bit and
we may want to explore -Og in the future, which is
all optimizations that don't interfere with debugging

* using --gcov flag to runtests.py also did not work
for this 32-bit Linux Azure coverage run, even with
NPY_DISTUTILS_APPEND_FLAGS=1

* we now produce two Cobertura-format xml files, which
have to be fused prior to consumption by Azure CI machinery,
and for this task we install the open source equivalent of .NET
(mono), so that we can install nuget to install ReportGenerator &
run ReportGenerator itself outside of .NET core proper on 32-bit linux
(ReportGenerator can merge the Cobertura-format xml files)