### PR TITLE
DOC: Clarify new interfaces for legacy functions in 'optimize'

### DIFF
--- a/scipy/optimize/__init__.py
+++ b/scipy/optimize/__init__.py
@@ -334,7 +334,6 @@ Constrained multivariate methods:
    fmin_tnc - Truncated Newton code.
    fmin_cobyla - Constrained optimization by linear approximation.
    fmin_slsqp - Minimization using sequential least-squares programming.
-   differential_evolution - stochastic minimization using differential evolution.
 
 Univariate (scalar) minimization methods:
 

--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -356,6 +356,11 @@ def leastsq(func, x0, args=(), Dfun=None, full_output=0,
         found.  Otherwise, the solution was not found. In either case, the
         optional output variable 'mesg' gives more information.
 
+    See Also
+    --------
+    least_squares : Newer interface to solve nonlinear least-squares problems
+        with bounds on the variables. See ``method=='lm'`` in particular.
+
     Notes
     -----
     "leastsq" is a wrapper around MINPACK's lmdif and lmder algorithms.

--- a/scipy/optimize/nonlin.py
+++ b/scipy/optimize/nonlin.py
@@ -920,6 +920,11 @@ class BroydenFirst(GenericBroyden):
     %(broyden_params)s
     %(params_extra)s
 
+    See Also
+    --------
+    root : Interface to root finding algorithms for multivariate
+           functions. See ``method=='broyden1'`` in particular.
+
     Notes
     -----
     This algorithm implements the inverse Jacobian Quasi-Newton update
@@ -1013,6 +1018,11 @@ class BroydenSecond(BroydenFirst):
     %(broyden_params)s
     %(params_extra)s
 
+    See Also
+    --------
+    root : Interface to root finding algorithms for multivariate
+           functions. See ``method=='broyden2'`` in particular.
+
     Notes
     -----
     This algorithm implements the inverse Jacobian Quasi-Newton update
@@ -1064,6 +1074,11 @@ class Anderson(GenericBroyden):
         Regularization parameter for numerical stability.
         Compared to unity, good values of the order of 0.01.
     %(params_extra)s
+
+    See Also
+    --------
+    root : Interface to root finding algorithms for multivariate
+           functions. See ``method=='anderson'`` in particular.
 
     References
     ----------
@@ -1199,6 +1214,11 @@ class DiagBroyden(GenericBroyden):
     alpha : float, optional
         Initial guess for the Jacobian is (-1/alpha).
     %(params_extra)s
+
+    See Also
+    --------
+    root : Interface to root finding algorithms for multivariate
+           functions. See ``method=='diagbroyden'`` in particular.
     """
 
     def __init__(self, alpha=None):
@@ -1243,6 +1263,12 @@ class LinearMixing(GenericBroyden):
     alpha : float, optional
         The Jacobian approximation is (-1/alpha).
     %(params_extra)s
+
+    See Also
+    --------
+    root : Interface to root finding algorithms for multivariate
+           functions. See ``method=='linearmixing'`` in particular.
+
     """
 
     def __init__(self, alpha=None):
@@ -1278,6 +1304,11 @@ class ExcitingMixing(GenericBroyden):
 
        This algorithm may be useful for specific problems, but whether
        it will work may depend strongly on the problem.
+
+    See Also
+    --------
+    root : Interface to root finding algorithms for multivariate
+           functions. See ``method=='excitingmixing'`` in particular.
 
     Parameters
     ----------
@@ -1366,6 +1397,8 @@ class KrylovJacobian(Jacobian):
 
     See Also
     --------
+    root : Interface to root finding algorithms for multivariate
+           functions. See ``method=='krylov'`` in particular.
     scipy.sparse.linalg.gmres
     scipy.sparse.linalg.lgmres
 


### PR DESCRIPTION
In #8889 some functions in scipy.optimize were designated legacy functions in the module-level docstring. I've made sure that all of these functions mention the newer interfaces in their own docstrings.

Currently I've just added the information in the 'see also' section, following the example of the fmin_xxx functions (which already had referenced 'minimize' as an alternate interface). Would it also be useful to indicate that these functions are 'legacy' and that the newer interfaces are preferred in some place more visible (eg. a note near the beginning of the docstring)?

Also, the method 'differential_evolution' is listed both as a legacy and as a non-legacy function. I can't find a newer interface for it so I'm guessing it shouldn't be listed as a legacy function, but I might be missing something.