### PR TITLE
pass gmres.callback iterate rather than residual or norm thereof

### DIFF
--- a/scipy/sparse/linalg/isolve/iterative.py
+++ b/scipy/sparse/linalg/isolve/iterative.py
@@ -469,7 +469,7 @@ def gmres(A, b, x0=None, tol=1e-5, restart=None, maxiter=None, M=None, callback=
         error tolerance.  By default, no preconditioner is used.
     callback : function
         User-supplied function to call after each iteration.  It is called
-        as callback(rk), where rk is the current residual vector.
+        as callback(xk), where xk is the current solution vector.
     restrt : int, optional
         DEPRECATED - use `restart` instead.
 
@@ -560,7 +560,7 @@ def gmres(A, b, x0=None, tol=1e-5, restart=None, maxiter=None, M=None, callback=
         slice2 = slice(ndx2-1, ndx2-1+n)
         if (ijob == -1):  # gmres success, update last residual
             if resid_ready and callback is not None:
-                callback(presid / bnrm2)
+                callback(x)
                 resid_ready = False
             break
         elif (ijob == 1):
@@ -576,7 +576,7 @@ def gmres(A, b, x0=None, tol=1e-5, restart=None, maxiter=None, M=None, callback=
             work[slice2] *= sclr2
             work[slice2] += sclr1*matvec(work[slice1])
             if resid_ready and callback is not None:
-                callback(presid / bnrm2)
+                callback(x)
                 resid_ready = False
                 iter_num = iter_num+1
 

--- a/scipy/sparse/linalg/isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/isolve/tests/test_iterative.py
@@ -530,12 +530,15 @@ class TestQMR(object):
 class TestGMRES(object):
     def test_callback(self):
 
-        def store_residual(r, rvec):
-            rvec[rvec.nonzero()[0].max()+1] = r
-
         # Define, A,b
         A = csr_matrix(array([[-2,1,0,0,0,0],[1,-2,1,0,0,0],[0,1,-2,1,0,0],[0,0,1,-2,1,0],[0,0,0,1,-2,1],[0,0,0,0,1,-2]]))
         b = ones((A.shape[0],))
+
+
+        def store_residual(x, rvec):
+            rvec[rvec.nonzero()[0].max()+1] = np.linalg.norm(A @ x - b)
+
+
         maxiter = 1
         rvec = zeros(maxiter+1)
         rvec[0] = 1.0


### PR DESCRIPTION
As noted in #6198 and #7623, `scipy.sparse.linalg.gmres` treats its `callback` argument neither:
* like its siblings `cg`, `bicg`, &c., in passing it the iterate nor
* as specified in its documentation, in passing it the residual

but rather passes it a float, presumably some norm of the residual.

As discussed in #6198, I don't think it's possible to pass the residual since it's not immediately available from where `callback` is to be called (which might be why the buggy behaviour snuck in), so the present proposal is to pass it the iterate and change the documentation accordingly.

Thus this fixes #6198, though not the omnibus #7623 (which should perhaps be decomposed).

