### PR TITLE
MAINT: Pin to earlier Sphinx for now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,8 @@ jobs:
             sudo apt-get update
             sudo apt-get install libatlas-dev libatlas-base-dev liblapack-dev gfortran libgmp-dev libmpfr-dev libfreetype6-dev libpng-dev zlib1g zlib1g-dev texlive-fonts-recommended texlive-latex-recommended texlive-latex-extra texlive-generic-extra latexmk texlive-xetex fonts-freefont-otf
 
+      # Sphinx 2.1.0+ is stricter about warnings, so until we fix all of those, use 2.0.1
+      # so that we can keep nitpicky (-n) + warnings-as-errors (-W) modes
       - run:
           name: setup Python venv
           command: |
@@ -42,7 +44,7 @@ jobs:
             . venv/bin/activate
             pip install --install-option="--no-cython-compile" cython
             pip install numpy
-            pip install nose mpmath argparse Pillow codecov matplotlib Sphinx
+            pip install nose mpmath argparse Pillow codecov matplotlib "Sphinx<2.1"
 
       - run:
           name: build docs


### PR DESCRIPTION
This should make CircleCI happy. A better long-term fix is to actually fix the warnings we see on Sphinx 2.1+, but this will probably take a bunch of changes. We have many warnings like:
```
WARNING: don't know which module to import for autodocumenting 'step_size' (try placing a "module" or "currentmodule" directive in the document, or giving an explicit module name)
```
I hope to look into a systematic fix at some point, but for now let's get things green.

Closes #10261.