### PR TITLE
DOC: Recommend sos format in filtering functions

### DIFF
--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -2084,7 +2084,8 @@ def iirdesign(wp, ws, gpass, gstop, analog=False, ftype='ellip', output='ba',
 
     output : {'ba', 'zpk', 'sos'}, optional
         Type of output:  numerator/denominator ('ba'), pole-zero ('zpk'), or
-        second-order sections ('sos'). Default is 'ba'.
+        second-order sections ('sos'). Default is 'ba' for backwards
+        compatibility, but 'sos' should be used for general-purpose filtering.
     fs : float, optional
         The sampling frequency of the digital system.
 
@@ -2215,7 +2216,8 @@ def iirfilter(N, Wn, rp=None, rs=None, btype='band', analog=False,
 
     output : {'ba', 'zpk', 'sos'}, optional
         Type of output:  numerator/denominator ('ba'), pole-zero ('zpk'), or
-        second-order sections ('sos'). Default is 'ba'.
+        second-order sections ('sos'). Default is 'ba' for backwards
+        compatibility, but 'sos' should be used for general-purpose filtering.
     fs : float, optional
         The sampling frequency of the digital system.
 
@@ -2783,7 +2785,8 @@ def butter(N, Wn, btype='low', analog=False, output='ba', fs=None):
         returned.
     output : {'ba', 'zpk', 'sos'}, optional
         Type of output:  numerator/denominator ('ba'), pole-zero ('zpk'), or
-        second-order sections ('sos'). Default is 'ba'.
+        second-order sections ('sos'). Default is 'ba' for backwards
+        compatibility, but 'sos' should be used for general-purpose filtering.
     fs : float, optional
         The sampling frequency of the digital system.
 
@@ -2890,7 +2893,8 @@ def cheby1(N, rp, Wn, btype='low', analog=False, output='ba', fs=None):
         returned.
     output : {'ba', 'zpk', 'sos'}, optional
         Type of output:  numerator/denominator ('ba'), pole-zero ('zpk'), or
-        second-order sections ('sos'). Default is 'ba'.
+        second-order sections ('sos'). Default is 'ba' for backwards
+        compatibility, but 'sos' should be used for general-purpose filtering.
     fs : float, optional
         The sampling frequency of the digital system.
 
@@ -3006,7 +3010,8 @@ def cheby2(N, rs, Wn, btype='low', analog=False, output='ba', fs=None):
         returned.
     output : {'ba', 'zpk', 'sos'}, optional
         Type of output:  numerator/denominator ('ba'), pole-zero ('zpk'), or
-        second-order sections ('sos'). Default is 'ba'.
+        second-order sections ('sos'). Default is 'ba' for backwards
+        compatibility, but 'sos' should be used for general-purpose filtering.
     fs : float, optional
         The sampling frequency of the digital system.
 
@@ -3119,7 +3124,8 @@ def ellip(N, rp, rs, Wn, btype='low', analog=False, output='ba', fs=None):
         returned.
     output : {'ba', 'zpk', 'sos'}, optional
         Type of output:  numerator/denominator ('ba'), pole-zero ('zpk'), or
-        second-order sections ('sos'). Default is 'ba'.
+        second-order sections ('sos'). Default is 'ba' for backwards
+        compatibility, but 'sos' should be used for general-purpose filtering.
     fs : float, optional
         The sampling frequency of the digital system.
 

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1219,6 +1219,10 @@ def lfilter(b, a, x, axis=-1, zi=None):
     form II transposed implementation of the standard difference equation
     (see Notes).
 
+    The function `sosfilt` (and filter design using ``output='sos'``) should be
+    preferred over `lfilter` for most filtering tasks, as second-order sections
+    have fewer numerical problems.
+
     Parameters
     ----------
     b : array_like
@@ -2987,6 +2991,10 @@ def filtfilt(b, a, x, axis=-1, padtype='odd', padlen=None, method='pad',
     twice that of the original.
 
     The function provides options for handling the edges of the signal.
+
+    The function `sosfiltfilt` (and filter design using ``output='sos'``)
+    should be preferred over `filtfilt` for most filtering tasks, as
+    second-order sections have fewer numerical problems.
 
     Parameters
     ----------


### PR DESCRIPTION
For general filtering, second-order sections format will have less
numerical error than transfer function format.

https://dsp.stackexchange.com/q/58734/29

https://dsp.stackexchange.com/questions/55017/why-does-a-higher-sampling-frequency-mess-up-my-bandpass-filter#comment110320_55017

etc