### PR TITLE
MAINT: prepare LTS branch for SciPy 1.2.3

### DIFF
--- a/doc/release/1.2.3-notes.rst
+++ b/doc/release/1.2.3-notes.rst
@@ -1,0 +1,18 @@
+==========================
+SciPy 1.2.3 Release Notes
+==========================
+
+.. contents::
+
+SciPy 1.2.3 is a bug-fix release with no new features compared to 1.2.2.
+
+Authors
+=======
+
+Issues closed for 1.2.3
+-----------------------
+
+Pull requests for 1.2.3
+-----------------------
+
+

--- a/doc/source/release.1.2.3.rst
+++ b/doc/source/release.1.2.3.rst
@@ -1,0 +1,1 @@
+.. include:: ../release/1.2.3-notes.rst

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
    :maxdepth: 1
 
+   release.1.2.3
    release.1.2.2
    release.1.2.1
    release.1.2.0

--- a/pavement.py
+++ b/pavement.py
@@ -113,10 +113,10 @@ except AttributeError:
 #-----------------------------------
 
 # Source of the release notes
-RELEASE = 'doc/release/1.2.2-notes.rst'
+RELEASE = 'doc/release/1.2.3-notes.rst'
 
 # Start/end of the log (from git)
-LOG_START = 'v1.2.1'
+LOG_START = 'v1.2.2'
 LOG_END = 'maintenance/1.2.x'
 
 

--- a/setup.py
+++ b/setup.py
@@ -58,8 +58,8 @@ Operating System :: MacOS
 
 MAJOR = 1
 MINOR = 2
-MICRO = 2
-ISRELEASED = True
+MICRO = 3
+ISRELEASED = False
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
 


### PR DESCRIPTION
Hopefully we never need a `1.2.3` LTS, but just in case.