### PR TITLE
ENH: Add stacklevel to linprog warnings

### DIFF
--- a/scipy/optimize/_linprog_simplex.py
+++ b/scipy/optimize/_linprog_simplex.py
@@ -225,7 +225,7 @@ def _apply_pivot(T, basis, pivrow, pivcol, tol=1e-9):
             "Removing redundant constraints, changing the pivot strategy "
             "via Bland's rule or increasing the tolerance may "
             "help reduce the issue.".format(pivval, tol))
-        warn(message, OptimizeWarning)
+        warn(message, OptimizeWarning, stacklevel=5)
 
 
 def _solve_simplex(T, n, basis, maxiter=1000, phase=2, status=0, message='',

--- a/scipy/optimize/_linprog_util.py
+++ b/scipy/optimize/_linprog_util.py
@@ -65,7 +65,7 @@ def _check_sparse_inputs(options, A_ub, A_eq):
     if not sparse and (sps.issparse(A_eq) or sps.issparse(A_ub)):
         options['sparse'] = True
         warn("Sparse constraint matrix detected; setting 'sparse':True.",
-             OptimizeWarning)
+             OptimizeWarning, stacklevel=4)
     return options, A_ub, A_eq
 
 
@@ -745,7 +745,7 @@ def _presolve(c, A_ub, b_ub, A_eq, b_eq, bounds, x0, rr, tol=1e-9):
         if rr and A_eq.size > 0:  # TODO: Fast sparse rank check?
             A_eq, b_eq, status, message = _remove_redundancy_sparse(A_eq, b_eq)
             if A_eq.shape[0] < n_rows_A:
-                warn(redundancy_warning, OptimizeWarning)
+                warn(redundancy_warning, OptimizeWarning, stacklevel=1)
             if status != 0:
                 complete = True
         return (c, c0, A_ub, b_ub, A_eq, b_eq, bounds,
@@ -760,7 +760,7 @@ def _presolve(c, A_ub, b_ub, A_eq, b_eq, bounds, x0, rr, tol=1e-9):
         except Exception:  # oh well, we'll have to go with _remove_redundancy_dense
             rank = 0
     if rr and A_eq.size > 0 and rank < A_eq.shape[0]:
-        warn(redundancy_warning, OptimizeWarning)
+        warn(redundancy_warning, OptimizeWarning, stacklevel=3)
         dim_row_nullspace = A_eq.shape[0]-rank
         if dim_row_nullspace <= small_nullspace:
             A_eq, b_eq, status, message = _remove_redundancy(A_eq, b_eq)


### PR DESCRIPTION
Adds a stack level arguments to remaining linear programming functions, as requested by @ilayn and @mdhaber in #10143.

I'm not sure how to add automated tests that this is working. I have run it locally where it is working. Here is the output:

```sh
(scipy-dev) kai@T470:~/scipy$ python manual_tests.py 
params.py:22: OptimizeWarning: Sparse constraint matrix detected; setting 'sparse':True.
  linprog(**linprog_args)
params.py:27: OptimizeWarning: A_eq does not appear to be of full row rank. To improve performance, check the problem formulation for redundant equality constraints.
  res = linprog(c, A_eq=A, b_eq=b, method='revised simplex')
params.py:28: OptimizeWarning: A_eq does not appear to be of full row rank. To improve performance, check the problem formulation for redundant equality constraints.
  res2 = linprog(c, A_eq=A, b_eq=b, method='revised simplex', x0=res.x)
params.py:29: OptimizeWarning: A_eq does not appear to be of full row rank. To improve performance, check the problem formulation for redundant equality constraints.
  res3 = linprog(c + p, A_eq=A, b_eq=b, method='revised simplex', x0=res.x)
params.py:47: OptimizeWarning: A_eq does not appear to be of full row rank. To improve performance, check the problem formulation for redundant equality constraints.
  linprog(c, A_ub, b_ub, A_eq, b_eq, bounds, method='simplex')
```

PS should we consider if there is a nice way to automatically add the argument? As far as I know, they won't change anytime soon, but I still don't like having too many low-level magic numbers.