### PR TITLE
MAINT: stats: Use a constant value for sqrt(2/PI).

### DIFF
--- a/scipy/stats/_stats.pyx
+++ b/scipy/stats/_stats.pyx
@@ -29,8 +29,11 @@ cdef double von_mises_cdf_series(double k, double x, unsigned int p):
         return 0.5 + x / (2 * PI) + V / PI
 
 
+DEF SQRT2_PI = 0.79788456080286535588  # sqrt(2/pi)
+
+
 cdef von_mises_cdf_normalapprox(k, x):
-    b = math.sqrt(2 / PI) / scipy.special.i0e(k) # Check for negative k
+    b = SQRT2_PI / scipy.special.i0e(k)  # Check for negative k
     z = b * np.sin(x / 2.)
     return scipy.stats.norm.cdf(z)
 


### PR DESCRIPTION
This change eliminates the compiler warning

	scipy/stats/_stats.c:3280:5: warning: code will never be executed [-Wunreachable-code]
	    PyErr_SetString(PyExc_ZeroDivisionError, "float division");
	    ^~~~~~~~~~~~~~~

That warning comes from the C code generated by Cython:

	  /* "scipy/stats/_stats.pyx":33
	 *
	 * cdef von_mises_cdf_normalapprox(k, x):
	 *     b = math.sqrt(2 / PI) / scipy.special.i0e(k) # Check for negative k             # <<<<<<<<<<<<<<
	 *     z = b * np.sin(x / 2.)
	 *     return scipy.stats.norm.cdf(z)
	 */
	  if (unlikely(NPY_PI == 0)) {
	    PyErr_SetString(PyExc_ZeroDivisionError, "float division");
	    __PYX_ERR(0, 33, __pyx_L1_error)
	  }
	  __pyx_t_1 = PyFloat_FromDouble(sqrt((2.0 / NPY_PI))); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 33, __pyx_L1_error)

The C compiler knows that NPY_PI is not zero, so it warns that the code in
the if-block will never be executed.

The change replaces math.sqrt(2 / PI) in line 33 of _stats.pyx with
the explicit value 0.79788456080286535588.