### PR TITLE
MAINT: Deprecate NumPy functions in SciPy root

### DIFF
--- a/doc/release/1.4.0-notes.rst
+++ b/doc/release/1.4.0-notes.rst
@@ -82,6 +82,11 @@ Support for NumPy functions exposed via the root SciPy namespace is deprecated
 and will be removed in 2.0.0. For example, if you use ``scipy.rand`` or
 ``scipy.diag``, you should change your code to directly use
 :func:`numpy.random.rand` or :func:`numpy.diag`, respectively.
+They remain available in the currently continuing Scipy 1.x release series.
+
+The exception to this rule is using ``scipy.fft`` as a function --
+:mod:`scipy.fft` is now meant to be used only as a module, so the ability to
+call ``scipy.fft(...)`` will be removed in SciPy 1.5.0.
 
 Backwards incompatible changes
 ==============================

--- a/doc/release/1.4.0-notes.rst
+++ b/doc/release/1.4.0-notes.rst
@@ -81,7 +81,7 @@ Deprecated features
 Support for NumPy functions exposed via the root SciPy namespace is deprecated
 and will be removed in 2.0.0. For example, if you use ``scipy.rand`` or
 ``scipy.diag``, you should change your code to directly use
-:func:`numpy.random.rand` or :func:`numpy.diag`, respectively.
+:func:`numpy.random.default_rng` or :func:`numpy.diag`, respectively.
 They remain available in the currently continuing Scipy 1.x release series.
 
 The exception to this rule is using ``scipy.fft`` as a function --

--- a/doc/release/1.4.0-notes.rst
+++ b/doc/release/1.4.0-notes.rst
@@ -76,6 +76,13 @@ correct values for real-valued matrices.
 Deprecated features
 ===================
 
+`scipy` deprecations
+--------------------
+Support for NumPy functions exposed via the root SciPy namespace is deprecated
+and will be removed in 2.0.0. For example, if you use ``scipy.rand`` or
+``scipy.diag``, you should change your code to directly use
+:func:`numpy.random.rand` or :func:`numpy.diag`, respectively.
+
 Backwards incompatible changes
 ==============================
 

--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -72,31 +72,30 @@ import numpy as _num
 linalg = None
 _msg = ('scipy.{0} is deprecated and will be removed in SciPy 2.0.0, '
         'use numpy.{0} instead')
-for _key in dir(_num):
-    if not _key.startswith('_'):
-        _fun = getattr(_num, _key)
-        if callable(_fun):
-            _fun = _deprecated(_msg.format(_key))(_fun)
-        globals()[_key] = _fun
+for _key in _num.__all__:
+    _fun = getattr(_num, _key)
+    if callable(_fun):
+        _fun = _deprecated(_msg.format(_key))(_fun)
+    globals()[_key] = _fun
 from numpy.random import rand, randn
 _msg = ('scipy.{0} is deprecated and will be removed in SciPy 2.0.0, '
         'use numpy.random.{0} instead')
 rand = _deprecated(_msg.format('rand'))(rand)
 randn = _deprecated(_msg.format('randn'))(randn)
 from numpy.fft import fft, ifft
-_msg = ('scipy.{0} is deprecated and will be removed in SciPy 2.0.0, '
-        'use numpy.fft.{0} instead')
-fft = _deprecated(_msg.format('fft'))(fft)
-ifft = _deprecated(_msg.format('ifft'))(ifft)
+# fft is especially problematic, so we deprecate it with a shorter window
+fft = _deprecated('Using scipy.fft as a function is deprecated and will be '
+                  'removed in SciPy 1.5.0, use scipy.fft.fft instead.')(fft)
+ifft = _deprecated('scipy.ifft is deprecated and will be removed in SciPy '
+                   '2.0.0, use scipy.fft.ifft instead')(ifft)
 import numpy.lib.scimath as _sci
 _msg = ('scipy.{0} is deprecated and will be removed in SciPy 2.0.0, '
         'use numpy.lib.scimath.{0} instead')
-for _key in dir(_sci):
-    if not _key.startswith('_'):
-        _fun = getattr(_sci, _key)
-        if callable(_fun):
-            _fun = _deprecated(_msg.format(_key))(_fun)
-        globals()[_key] = _fun
+for _key in _sci.__all__:
+    _fun = getattr(_sci, _key)
+    if callable(_fun):
+        _fun = _deprecated(_msg.format(_key))(_fun)
+    globals()[_key] = _fun
 
 # Allow distributors to run custom init code
 from . import _distributor_init

--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -84,9 +84,12 @@ rand = _deprecated(_msg.format('rand'))(rand)
 randn = _deprecated(_msg.format('randn'))(randn)
 from numpy.fft import fft, ifft
 # fft is especially problematic, so we deprecate it with a shorter window
-fft = _deprecated('Using scipy.fft as a function is deprecated and will be '
-                  'removed in SciPy 1.5.0, use scipy.fft.fft instead.')(fft)
-_dep_fft = fft  # for wrapping in scipy.fft.__call__
+fft_msg = ('Using scipy.fft as a function is deprecated and will be '
+           'removed in SciPy 1.5.0, use scipy.fft.fft instead.')
+# for wrapping in scipy.fft.__call__, so the stacklevel is one off from the
+# usual (2)
+_dep_fft = _deprecated(fft_msg, stacklevel=3)(fft)
+fft = _deprecated(fft_msg)(fft)
 ifft = _deprecated('scipy.ifft is deprecated and will be removed in SciPy '
                    '2.0.0, use scipy.fft.ifft instead')(ifft)
 import numpy.lib.scimath as _sci

--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -86,6 +86,7 @@ from numpy.fft import fft, ifft
 # fft is especially problematic, so we deprecate it with a shorter window
 fft = _deprecated('Using scipy.fft as a function is deprecated and will be '
                   'removed in SciPy 1.5.0, use scipy.fft.fft instead.')(fft)
+_dep_fft = fft  # for wrapping in scipy.fft.__call__
 ifft = _deprecated('scipy.ifft is deprecated and will be removed in SciPy '
                    '2.0.0, use scipy.fft.ifft instead')(ifft)
 import numpy.lib.scimath as _sci

--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -66,13 +66,37 @@ if show_numpy_config is None:
         "Cannot import scipy when running from numpy source directory.")
 from numpy import __version__ as __numpy_version__
 
-# Import numpy symbols to scipy name space
+# Import numpy symbols to scipy name space (DEPRECATED)
+from ._lib.deprecation import _deprecated
 import numpy as _num
 linalg = None
-from numpy import *
+_msg = ('scipy.{0} is deprecated and will be removed in SciPy 2.0.0, '
+        'use numpy.{0} instead')
+for _key in dir(_num):
+    if not _key.startswith('_'):
+        _fun = getattr(_num, _key)
+        if callable(_fun):
+            _fun = _deprecated(_msg.format(_key))(_fun)
+        globals()[_key] = _fun
 from numpy.random import rand, randn
+_msg = ('scipy.{0} is deprecated and will be removed in SciPy 2.0.0, '
+        'use numpy.random.{0} instead')
+rand = _deprecated(_msg.format('rand'))(rand)
+randn = _deprecated(_msg.format('randn'))(randn)
 from numpy.fft import fft, ifft
-from numpy.lib.scimath import *
+_msg = ('scipy.{0} is deprecated and will be removed in SciPy 2.0.0, '
+        'use numpy.fft.{0} instead')
+fft = _deprecated(_msg.format('fft'))(fft)
+ifft = _deprecated(_msg.format('ifft'))(ifft)
+import numpy.lib.scimath as _sci
+_msg = ('scipy.{0} is deprecated and will be removed in SciPy 2.0.0, '
+        'use numpy.lib.scimath.{0} instead')
+for _key in dir(_sci):
+    if not _key.startswith('_'):
+        _fun = getattr(_sci, _key)
+        if callable(_fun):
+            _fun = _deprecated(_msg.format(_key))(_fun)
+        globals()[_key] = _fun
 
 # Allow distributors to run custom init code
 from . import _distributor_init

--- a/scipy/_lib/deprecation.py
+++ b/scipy/_lib/deprecation.py
@@ -1,0 +1,15 @@
+import warnings
+
+__all__ = ["_deprecated"]
+
+
+def _deprecated(msg):
+
+    def wrap(fun):
+        def call(*args, **kwargs):
+            warnings.warn(msg, category=DeprecationWarning)
+            return fun(*args, **kwargs)
+        call.__doc__ = msg
+        return call
+
+    return wrap

--- a/scipy/_lib/deprecation.py
+++ b/scipy/_lib/deprecation.py
@@ -9,7 +9,7 @@ def _deprecated(msg):
     def wrap(fun):
         @functools.wraps(fun)
         def call(*args, **kwargs):
-            warnings.warn(msg, category=DeprecationWarning)
+            warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
             return fun(*args, **kwargs)
         call.__doc__ = msg
         return call

--- a/scipy/_lib/deprecation.py
+++ b/scipy/_lib/deprecation.py
@@ -1,11 +1,13 @@
+import functools
 import warnings
 
 __all__ = ["_deprecated"]
 
 
 def _deprecated(msg):
-
+    """Deprecate a function by emitting a warning on use."""
     def wrap(fun):
+        @functools.wraps(fun)
         def call(*args, **kwargs):
             warnings.warn(msg, category=DeprecationWarning)
             return fun(*args, **kwargs)

--- a/scipy/_lib/deprecation.py
+++ b/scipy/_lib/deprecation.py
@@ -4,12 +4,13 @@ import warnings
 __all__ = ["_deprecated"]
 
 
-def _deprecated(msg):
+def _deprecated(msg, stacklevel=2):
     """Deprecate a function by emitting a warning on use."""
     def wrap(fun):
         @functools.wraps(fun)
         def call(*args, **kwargs):
-            warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
+            warnings.warn(msg, category=DeprecationWarning,
+                          stacklevel=stacklevel)
             return fun(*args, **kwargs)
         call.__doc__ = msg
         return call

--- a/scipy/_lib/tests/test__util.py
+++ b/scipy/_lib/tests/test__util.py
@@ -137,8 +137,10 @@ def test_numpy_deprecation(key):
         match = r'scipy\.%s is deprecated.*2\.0\.0' % key
     with deprecated_call(match=match) as dep:
         func(arg)  # deprecated
-    fname = os.path.splitext(os.path.basename(dep.list[0].filename))[0]
-    assert fname == 'test__util'
+    # in case we catch more than one dep warning
+    fnames = [os.path.splitext(d.filename)[0] for d in dep.list]
+    basenames = [os.path.basename(fname) for fname in fnames]
+    assert 'test__util' in basenames
     if key in ('rand', 'randn'):
         root = np.random
     elif key in ('fft', 'ifft'):

--- a/scipy/_lib/tests/test__util.py
+++ b/scipy/_lib/tests/test__util.py
@@ -1,6 +1,8 @@
 from __future__ import division, print_function, absolute_import
+
 from multiprocessing import Pool
 from multiprocessing.pool import Pool as PWL
+import os
 
 import numpy as np
 from numpy.testing import assert_equal, assert_
@@ -133,8 +135,10 @@ def test_numpy_deprecation(key):
         match = r'scipy\.fft.*deprecated.*1.5.0.*'
     else:
         match = r'scipy\.%s is deprecated.*2\.0\.0' % key
-    with deprecated_call(match=match):
+    with deprecated_call(match=match) as dep:
         func(arg)  # deprecated
+    fname = os.path.splitext(os.path.basename(dep.list[0].filename))[0]
+    assert fname == 'test__util'
     if key in ('rand', 'randn'):
         root = np.random
     elif key in ('fft', 'ifft'):

--- a/scipy/_lib/tests/test__util.py
+++ b/scipy/_lib/tests/test__util.py
@@ -129,7 +129,11 @@ def test_numpy_deprecation(key):
     else:
         arg = 2
     func = getattr(scipy, key)
-    with deprecated_call(match=r'scipy\.%s is deprecated.*2\.0\.0' % key):
+    if key == 'fft':
+        match = r'scipy\.fft.*deprecated.*1.5.0.*'
+    else:
+        match = r'scipy\.%s is deprecated.*2\.0\.0' % key
+    with deprecated_call(match=match):
         func(arg)  # deprecated
     if key in ('rand', 'randn'):
         root = np.random

--- a/scipy/fft/__init__.py
+++ b/scipy/fft/__init__.py
@@ -109,8 +109,8 @@ import sys
 class _FFTModule(sys.modules[__name__].__class__):
     @staticmethod
     def __call__(*args, **kwargs):
-        import numpy as np
-        return np.fft.fft(*args, **kwargs)
+        from scipy import _dep_fft
+        return _dep_fft(*args, **kwargs)
 
 
 import os

--- a/scipy/fft/tests/test_fft_function.py
+++ b/scipy/fft/tests/test_fft_function.py
@@ -1,18 +1,31 @@
+import pytest
+import numpy as np
 from numpy.testing import assert_allclose
+
 
 def test_fft_function():
     # Many NumPy symbols are imported into the scipy namespace, including
     # numpy.fft.fft as scipy.fft, conflicting with this module (gh-10253)
-    import scipy
-    scipy.random.seed(1234)
+    np.random.seed(1234)
 
     # Callable before scipy.fft is imported
-    x = scipy.randn(10) + 1j * scipy.randn(10)
-    y = scipy.ifft(scipy.fft(x))
+    import scipy
+    x = np.random.randn(10) + 1j * np.random.randn(10)
+    with pytest.deprecated_call(match=r'1\.5\.0'):
+        X = scipy.fft(x)
+    with pytest.deprecated_call(match=r'2\.0\.0'):
+        y = scipy.ifft(X)
     assert_allclose(y, x)
 
-    import scipy.fft
     # Callable after scipy.fft is imported
-    z = scipy.ifft(scipy.fft(x))
-    assert_allclose(z, x)
+    import scipy.fft
+    with pytest.warns(None):
+        y = scipy.ifft(scipy.fft(x))
+    assert_allclose(y, x)
     assert_allclose(scipy.fft(x), scipy.fft.fft(x))
+
+    # Callable when imported as
+    from scipy import fft
+    with pytest.warns(None):
+        y = scipy.ifft(fft(x))
+    assert_allclose(y, x)

--- a/scipy/fft/tests/test_fft_function.py
+++ b/scipy/fft/tests/test_fft_function.py
@@ -19,13 +19,18 @@ def test_fft_function():
 
     # Callable after scipy.fft is imported
     import scipy.fft
-    with pytest.warns(None):
-        y = scipy.ifft(scipy.fft(x))
+    assert_allclose(X, scipy.fft.fft(x))
+    with pytest.deprecated_call(match=r'1\.5\.0'):
+        X = scipy.fft(x)
+    assert_allclose(X, scipy.fft.fft(x))
+    with pytest.deprecated_call(match=r'2\.0\.0'):
+        y = scipy.ifft(X)
     assert_allclose(y, x)
-    assert_allclose(scipy.fft(x), scipy.fft.fft(x))
 
-    # Callable when imported as
+    # Callable when imported using from
     from scipy import fft
-    with pytest.warns(None):
-        y = scipy.ifft(fft(x))
+    with pytest.deprecated_call(match=r'1\.5\.0'):
+        X = fft(x)
+    with pytest.deprecated_call(match=r'2\.0\.0'):
+        y = scipy.ifft(X)
     assert_allclose(y, x)

--- a/scipy/sparse/linalg/eigen/lobpcg/tests/test_lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/tests/test_lobpcg.py
@@ -11,10 +11,11 @@ from numpy.testing import (assert_almost_equal, assert_equal,
 
 import pytest
 
-from scipy import (ones, rand, r_, diag)
-from scipy.linalg import (eig, eigh, toeplitz, orth)
-from scipy.sparse import (spdiags, diags, eye, random)
-from scipy.sparse.linalg import (eigs, LinearOperator)
+from numpy import ones, r_, diag, eye
+from numpy.random import rand
+from scipy.linalg import eig, eigh, toeplitz, orth
+from scipy.sparse import spdiags, diags, eye, random
+from scipy.sparse.linalg import eigs, LinearOperator
 from scipy.sparse.linalg.eigen.lobpcg import lobpcg
 
 def ElasticRod(n):
@@ -257,7 +258,7 @@ def test_eigs_consistency(n, atol):
     assert_allclose(np.sort(vals), np.sort(lvals), atol=1e-14)
 
 
-def test_verbosity():
+def test_verbosity(tmpdir):
     """Check that nonzero verbosity level code runs.
     """
     A, B = ElasticRod(100)

--- a/scipy/sparse/linalg/isolve/tests/test_gcrotmk.py
+++ b/scipy/sparse/linalg/isolve/tests/test_gcrotmk.py
@@ -72,7 +72,7 @@ class TestGCROTMK(object):
 
         assert_equal(flag0, 1)
         assert_equal(flag1, 1)
-        assert_(np.linalg.norm(A.dot(x0) - b) > 1e-3)
+        assert np.linalg.norm(A.dot(x0) - b) > 1e-3
 
         assert_allclose(x0, x1)
 


### PR DESCRIPTION
From discussion in #10238, it came up that we should probably deprecate support for `scipy.<NumPy function>`. This PR utilizes ~~sklearn's `deprecated` [decorator](https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/utils/deprecation.py)~~ a minimal `deprecated` decorator to deprecate them, marking them for removal in ~~1.5.0~~ 2.0, with `scipy.fft` removed in 1.5.0.