### PR TITLE
FIX: Avoid importing xdist when checking for availability

### DIFF
--- a/scipy/_lib/_testutils.py
+++ b/scipy/_lib/_testutils.py
@@ -77,12 +77,9 @@ def _pytest_has_xdist():
     """
     Check if the pytest-xdist plugin is installed, providing parallel tests
     """
-
-    try:
-        import xdist
-        return True
-    except ImportError:
-        return False
+    # Check xdist exists without importing, otherwise pytests emits warnings
+    from importlib.util import find_spec
+    return find_spec('xdist') is not None
 
 
 def check_free_memory(free_mb):


### PR DESCRIPTION
Fixes the following warning:
```
/home/peter/.local/lib/python3.7/site-packages/_pytest/config/__init__.py:781
/home/peter/.local/lib/python3.7/site-packages/_pytest/config/__init__.py:781
/home/peter/.local/lib/python3.7/site-packages/_pytest/config/__init__.py:781:
PytestAssertRewriteWarning: Module already imported so cannot be rewritten: xdist
self._mark_plugins_for_rewrite(hook)   
```

This is the method of import checking suggested by the [importlib docs](https://docs.python.org/3.6/library/importlib.html#checking-if-a-module-can-be-imported).