### PR TITLE
ENH: Made pade function work with complex inputs

### DIFF
--- a/scipy/interpolate/_pade.py
+++ b/scipy/interpolate/_pade.py
@@ -54,8 +54,8 @@ def pade(an, m, n=None):
     if N > len(an)-1:
         raise ValueError("Order of q+p <m+n> must be smaller than len(an).")
     an = an[:N+1]
-    Akj = eye(N+1, n+1)
-    Bkj = zeros((N+1, m), 'd')
+    Akj = eye(N+1, n+1, dtype=an.dtype)
+    Bkj = zeros((N+1, m), dtype=an.dtype)
     for row in range(1, m+1):
         Bkj[row,:row] = -(an[:row])[::-1]
     for row in range(m+1, N+1):

--- a/scipy/interpolate/tests/test_pade.py
+++ b/scipy/interpolate/tests/test_pade.py
@@ -67,7 +67,7 @@ def test_pade_4term_exp():
     
 def test_pade_ints():
     # Simple test sequences (one of ints, one of floats).
-    an_int = [1,   2,   3,   4]
+    an_int = [1, 2, 3, 4]
     an_flt = [1.0, 2.0, 3.0, 4.0]
 
     # Make sure integer arrays give the same result as float arrays with same values.

--- a/scipy/interpolate/tests/test_pade.py
+++ b/scipy/interpolate/tests/test_pade.py
@@ -64,3 +64,40 @@ def test_pade_4term_exp():
     assert_array_almost_equal(nump.c, [1.0])
     assert_array_almost_equal(denomp.c, [1.0/2, -1.0, 1.0])
 
+    
+def test_pade_ints():
+    # Simple test sequences (one of ints, one of floats).
+    an_int = [1,   2,   3,   4]
+    an_flt = [1.0, 2.0, 3.0, 4.0]
+
+    # Make sure integer arrays give the same result as float arrays with same values.
+    for i in range(0, len(an_int)):
+        for j in range(0, len(an_int) - i):
+
+            # Create float and int pade approximation for given order.
+            nump_int, denomp_int = pade(an_int, i, j)
+            nump_flt, denomp_flt = pade(an_flt, i, j)
+
+            # Check that they are the same.
+            assert_array_equal(nump_int.c, nump_flt.c)
+            assert_array_equal(denomp_int.c, denomp_flt.c)
+
+
+def test_pade_complex():
+    # Test sequence with known solutions - see page 6 of 10.1109/PESGM.2012.6344759.
+    # Variable x is parameter - these tests will work with any complex number.
+    x = 0.2 + 0.6j
+    an = [1.0, x, -x*x.conjugate(), x.conjugate()*(x**2) + x*(x.conjugate()**2),
+          -(x**3)*x.conjugate() - 3*(x*x.conjugate())**2 - x*(x.conjugate()**3)]
+
+    nump, denomp = pade(an, 1, 1)
+    assert_array_almost_equal(nump.c, [x + x.conjugate(), 1.0])
+    assert_array_almost_equal(denomp.c, [x.conjugate(), 1.0])
+
+    nump, denomp = pade(an, 1, 2)
+    assert_array_almost_equal(nump.c, [x**2, 2*x + x.conjugate(), 1.0])
+    assert_array_almost_equal(denomp.c, [x + x.conjugate(), 1.0])
+
+    nump, denomp = pade(an, 2, 2)
+    assert_array_almost_equal(nump.c, [x**2 + x*x.conjugate() + x.conjugate()**2, 2*(x + x.conjugate()), 1.0])
+    assert_array_almost_equal(denomp.c, [x.conjugate()**2, x + 2*x.conjugate(), 1.0])

--- a/scipy/interpolate/tests/test_pade.py
+++ b/scipy/interpolate/tests/test_pade.py
@@ -51,7 +51,7 @@ def test_pade_4term_exp():
     assert_array_almost_equal(nump.c, [1.0])
     assert_array_almost_equal(denomp.c, [-1.0/6, 0.5, -1.0, 1.0])
    
-    # Testing reducing array
+    # Testing reducing array.
     nump, denomp = pade(an, 0, 2)
     assert_array_almost_equal(nump.c, [0.5, 1.0, 1.0])
     assert_array_almost_equal(denomp.c, [1.0])


### PR DESCRIPTION
Original implementation was using default datatypes or datatypes not based on the input. For use cases where the input consists of complex numbers, the function would throw warnings that the imaginary part of the complex numbers were being thrown out. This change makes the function work (theoretically) for every datatype.