### PR TITLE
 DOC: Fix critical value significance levels in stats.anderson_ksamp

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -208,6 +208,7 @@ Jordi Montes for initial contribution of the Clarkson-Woodruff sketch.
 William Conner DiPaolo for improvements to the Clarkson-Woodruff transform.
 Forrest Collman for adding multi-target dijsktra to scipy.sparse.csgraph
 Carlos Ramos Carreño for adding support for relational attributes in loadarff.
+Jason M. Manley for documentation fixes.
 
 Institutions
 ------------

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -1919,7 +1919,8 @@ def anderson_ksamp(samples, midrank=True):
     statistic : float
         Normalized k-sample Anderson-Darling test statistic.
     critical_values : array
-        The critical values for significance levels 25%, 10%, 5%, 2.5%, 1%.
+        The critical values for significance levels 25%, 10%, 5%, 2.5%, 1%,
+        0.5%, 0.1%.
     significance_level : float
         An approximate significance level at which the null hypothesis for the
         provided samples can be rejected. The value is floored / capped at

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -1924,7 +1924,7 @@ def anderson_ksamp(samples, midrank=True):
     significance_level : float
         An approximate significance level at which the null hypothesis for the
         provided samples can be rejected. The value is floored / capped at
-        1% / 25%.
+        0.1% / 25%.
 
     Raises
     ------


### PR DESCRIPTION
Fixes error in documentation for k-sample Anderson test pointed out by @amulliner-dstl in #10263.

My first PR, hoping to contribute lots more! :)

Fixes #10263