### PR TITLE
BUG: Pass jac=None directly to lsoda

### DIFF
--- a/scipy/integrate/_ivp/lsoda.py
+++ b/scipy/integrate/_ivp/lsoda.py
@@ -125,10 +125,6 @@ class LSODA(OdeSolver):
 
         rtol, atol = validate_tol(rtol, atol, self.n)
 
-        if jac is None:  # No lambda as PEP8 insists.
-            def jac():
-                return None
-
         solver = ode(self.fun, jac)
         solver.set_integrator('lsoda', rtol=rtol, atol=atol, max_step=max_step,
                               min_step=min_step, first_step=first_step,
@@ -150,7 +146,7 @@ class LSODA(OdeSolver):
         itask = integrator.call_args[2]
         integrator.call_args[2] = 5
         solver._y, solver.t = integrator.run(
-            solver.f, solver.jac, solver._y, solver.t,
+            solver.f, solver.jac or (lambda: None), solver._y, solver.t,
             self.t_bound, solver.f_params, solver.jac_params)
         integrator.call_args[2] = itask
 

--- a/scipy/integrate/tests/test_ivp.py
+++ b/scipy/integrate/tests/test_ivp.py
@@ -297,6 +297,7 @@ def test_integration_const_jac():
         assert_allclose(res.sol(res.t), res.y, rtol=1e-14, atol=1e-14)
 
 
+@pytest.mark.timeout(5)
 @pytest.mark.parametrize('method', ['Radau', 'BDF', 'LSODA'])
 def test_integration_stiff(method):
     rtol = 1e-6

--- a/scipy/integrate/tests/test_ivp.py
+++ b/scipy/integrate/tests/test_ivp.py
@@ -2,6 +2,7 @@ from __future__ import division, print_function, absolute_import
 from itertools import product
 from numpy.testing import (assert_, assert_allclose,
                            assert_equal, assert_no_warnings)
+import pytest
 from pytest import raises as assert_raises
 from scipy._lib._numpy_compat import suppress_warnings
 import numpy as np
@@ -296,7 +297,8 @@ def test_integration_const_jac():
         assert_allclose(res.sol(res.t), res.y, rtol=1e-14, atol=1e-14)
 
 
-def test_integration_stiff():
+@pytest.mark.parametrize('method', ['Radau', 'BDF', 'LSODA'])
+def test_integration_stiff(method):
     rtol = 1e-6
     atol = 1e-6
     y0 = [1e4, 0, 0]
@@ -310,13 +312,12 @@ def test_integration_stiff():
             3e7 * y * y,
         ]
 
-    for method in ['Radau', 'BDF', 'LSODA']:
-        res = solve_ivp(fun_robertson, tspan, y0, rtol=rtol,
-                        atol=atol, method=method)
+    res = solve_ivp(fun_robertson, tspan, y0, rtol=rtol,
+                    atol=atol, method=method)
 
-        # If the stiff mode is not activated correctly, these numbers will be much bigger
-        assert_(res.nfev < 5000)
-        assert_(res.njev < 200)
+    # If the stiff mode is not activated correctly, these numbers will be much bigger
+    assert res.nfev < 5000
+    assert res.njev < 200
 
 
 def test_events():

--- a/scipy/integrate/tests/test_ivp.py
+++ b/scipy/integrate/tests/test_ivp.py
@@ -296,6 +296,29 @@ def test_integration_const_jac():
         assert_allclose(res.sol(res.t), res.y, rtol=1e-14, atol=1e-14)
 
 
+def test_integration_stiff():
+    rtol = 1e-6
+    atol = 1e-6
+    y0 = [1e4, 0, 0]
+    tspan = [0, 1e8]
+
+    def fun_robertson(t, state):
+        x, y, z = state
+        return [
+            -0.04 * x + 1e4 * y * z,
+            0.04 * x - 1e4 * y * z - 3e7 * y * y,
+            3e7 * y * y,
+        ]
+
+    for method in ['Radau', 'BDF', 'LSODA']:
+        res = solve_ivp(fun_robertson, tspan, y0, rtol=rtol,
+                        atol=atol, method=method)
+
+        # If the stiff mode is not activated correctly, these numbers will be much bigger
+        assert_(res.nfev < 5000)
+        assert_(res.njev < 200)
+
+
 def test_events():
     def event_rational_1(t, y):
         return y[0] - y[1] ** 0.7

--- a/scipy/integrate/tests/test_ivp.py
+++ b/scipy/integrate/tests/test_ivp.py
@@ -297,7 +297,7 @@ def test_integration_const_jac():
         assert_allclose(res.sol(res.t), res.y, rtol=1e-14, atol=1e-14)
 
 
-@pytest.mark.timeout(5)
+@pytest.mark.slow
 @pytest.mark.parametrize('method', ['Radau', 'BDF', 'LSODA'])
 def test_integration_stiff(method):
     rtol = 1e-6


### PR DESCRIPTION
This fixes #9901. If the Jacobian is not provided, LSODA must receive `jac=None` in the constructor, not `jac=(lambda:None)`. Otherwise, it will not compute the Jacobian via finite differences and use the stiff solver.