### PR TITLE
BUG: interpolate: UnivariateSpline.derivative.ext is 'zeros' if the original is 'const'

### DIFF
--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -461,7 +461,9 @@ class UnivariateSpline(object):
 
         """
         tck = fitpack.splder(self._eval_args, n)
-        return UnivariateSpline._from_tck(tck, self.ext)
+        # if self.ext is 'const', derivative.ext will be 'zeros'
+        ext = 1 if self.ext == 3 else self.ext
+        return UnivariateSpline._from_tck(tck, ext=ext)
 
     def antiderivative(self, n=1):
         """

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -141,6 +141,16 @@ class TestUnivariateSpline(object):
         assert_allclose(spl2(0.6) - spl2(0.2),
                         spl.integral(0.2, 0.6))
 
+    def test_derivative_extrapolation(self):
+        # Regression test for gh-10195: for a const-extrapolation spline
+        # its derivative evaluates to zero for extrapolation
+        x_values = [1, 2, 4, 6, 8.5]
+        y_values = [0.5, 0.8, 1.3, 2.5, 5]
+        f = UnivariateSpline(x_values, y_values, ext='const', k=3)
+
+        x = [-1, 0, -0.5, 9, 9.5, 10]
+        assert_allclose(f.derivative()(x), 0, atol=1e-15)
+
     def test_nan(self):
         # bail out early if the input data contains nans
         x = np.arange(10, dtype=float)


### PR DESCRIPTION
supersedes and closes gh-10220, closes gh-10195

If a UnivariateSpline instance has the extrapolation mode 'const', its derivative extrapolated values are zeros, so tweak the extrapolation mode.