### PR TITLE
ENH: Fast scipy.sparse.random with approximate density estimation 

### DIFF
--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -707,7 +707,11 @@ def random(m, n, density=0.01, format='coo', dtype=None,
         sampled using the same random state as is used for sampling
         the sparsity structure.
     density_estimation: str, optional
-        Should be either "exact" (default) or "probabilistic".
+        If "exact" (default) the condition ``res.nnz == int(n*m*density)`` is
+        strictly verified. If "probabilistic", it is verified on average but
+        for any given random state small deviations are expected.
+        The "probabilistic" method is often significantly faster, particularly
+        when``density < 0.1``.
 
     Returns
     -------
@@ -716,6 +720,11 @@ def random(m, n, density=0.01, format='coo', dtype=None,
     Notes
     -----
     Only float types are supported for now.
+
+    The run time and peak memory usage scale as ``O(n*m)`` or worse when
+    ``density_estimation`` method is "exact" (default), which can be  slow for
+    large array sizes. using the "probabilistic" method, which scales
+    as `O(nnz)` is then preferrable.
 
     Examples
     --------
@@ -790,9 +799,8 @@ greater than %d - this is not supported on this machine
         ind = random_state.choice(mn, size=k, replace=False)
     elif density_estimation == "probabilistic":
         if k >= n*m:
-            raise ValueError("provided density={:.f} is too high for method "
-                             "density_estimation='probabilistic'!"
-                             .format(density))
+            raise ValueError("expected density < 1 with "
+                             "density_estimation='probabilistic'!")
 
         # When sampling (1..N) with replacement p times we get
         # on average k unique values,
@@ -803,7 +811,9 @@ greater than %d - this is not supported on this machine
         ind = np.unique(ind)
         k = ind.shape[0]
     else:
-        raise ValueError
+        raise ValueError("density_estimation={}, expected one of "
+                         "['exact', 'probabilistic']!"
+                         .format(density_estimation))
 
     j = np.floor(ind * 1. / m).astype(tp, copy=False)
     i = (ind - j * m).astype(tp, copy=False)
@@ -831,6 +841,12 @@ def rand(m, n, density=0.01, format="coo", dtype=None, random_state=None,
     random_state : {numpy.random.RandomState, int}, optional
         Random number generator or random seed. If not given, the singleton
         numpy.random will be used.
+    density_estimation: str, optional
+        If "exact" (default) the condition ``res.nnz == int(n*m*density)`` is
+        strictly verified. If "probabilistic", it is verified on average but
+        for any given random state small deviations are expected.
+        The "probabilistic" method is often significantly faster, particularly
+        when``density < 0.1``.
 
     Returns
     -------
@@ -839,6 +855,11 @@ def rand(m, n, density=0.01, format="coo", dtype=None, random_state=None,
     Notes
     -----
     Only float types are supported for now.
+
+    The run time and peak memory usage scale as ``O(n*m)`` or worse when
+    ``density_estimation`` method is "exact" (default), which can be  slow for
+    large array sizes. using the "probabilistic" method, which scales
+    as `O(nnz)` is then preferrable.
 
     See Also
     --------

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -722,9 +722,9 @@ def random(m, n, density=0.01, format='coo', dtype=None,
     Only float types are supported for now.
 
     The run time and peak memory usage scale as ``O(n*m)`` or worse when
-    ``density_estimation`` method is "exact" (default), which can be  slow for
-    large array sizes. using the "probabilistic" method, which scales
-    as `O(nnz)` is then preferrable.
+    ``density_estimation`` method is "exact" (default), which can be slow for
+    large array sizes. Using the "probabilistic" method, which scales
+    as ``O(nnz)``, is then preferable.
 
     Examples
     --------
@@ -805,7 +805,7 @@ greater than %d - this is not supported on this machine
         # When sampling (1..N) with replacement p times we get
         # on average k unique values,
         #     k = N*(1 - ((N - 1)/N)**p)
-        # or inversly here with N=n*m,
+        # or inversely here with N=n*m,
         p = int(np.log(1 - k / (n*m)) / np.log(1 - 1 / (n*m)))
         ind = random_state.randint(0, n*m, size=p)
         ind = np.unique(ind)
@@ -857,9 +857,9 @@ def rand(m, n, density=0.01, format="coo", dtype=None, random_state=None,
     Only float types are supported for now.
 
     The run time and peak memory usage scale as ``O(n*m)`` or worse when
-    ``density_estimation`` method is "exact" (default), which can be  slow for
-    large array sizes. using the "probabilistic" method, which scales
-    as `O(nnz)` is then preferrable.
+    ``density_estimation`` method is "exact" (default), which can be slow for
+    large array sizes. Using the "probabilistic" method, which scales
+    as ``O(nnz)``, is then preferable.
 
     See Also
     --------


### PR DESCRIPTION
As discussed in https://github.com/scipy/scipy/issues/9699 sampling without replacement with `numpy.random.choice(.., replace=False)` is the bottleneck for `scipy.sparse.random`. One way to improve its performance is to improve the `random.choice` function in numpy, and some improvements have been obtained there not that long ago.

This PR explores another optimization direction, consisting to allow small deviation from the condition,
```py
X.nnz = int(density*X.shape[0]*X.shape[1])
```
In that case, we can use much faster sampling without replacement, and correct for collisions. This means that the sparse `density` of the returned array will have some (small) error with respect to that provided by the user, but in practical applications that is often acceptable in my experience.

This adds the `density_estimation="probabilistic"` option to optionally enable this method. Naming could be improved. 

## Benchmarks

```ipynb
In [1]: %load_ext memory_profiler
In [2]: from scipy import sparse

In [3]: %time X = sparse.rand(10_000, 100_000, density=0.001)
CPU times: user 45.5 s, sys: 1.31 s, total: 46.8 s
Wall time: 46.7 s
In [4]: X.nnz
Out[4]: 1000000
In [5]: %memit sparse.rand(10_000, 100_000, density=0.001)
peak memory: 7711.69 MiB, increment: 7629.59 MiB

In [6]: %time X = sparse.rand(10_000, 100_000, density=0.001,
   ...:                       density_estimation="probabilistic")
CPU times: user 306 ms, sys: 8.3 ms, total: 315 ms
Wall time: 81.6 ms
In [7]: X.nnz
Out[7]: 999986
In [8]: %memit sparse.rand(10_000, 100_000, density=0.001, 
   ...:                    density_estimation="probabilistic")
peak memory: 122.12 MiB, increment: 11.48 MiB
```
so on this example the proposed implementation is 500x faster and uses 60x less memory, for the cost of a 1e-5 relative error on `nnz`.

More importantly, though the time and memory complexity are much better. While the original implementation has something like `O(X.shape[0]*X.shape[1])` or worse for both (I haven't done detailed benchmarks), this method is ~ `O(X.nnz)`. This means that it can easily generate sparse matrices with shapes in the range of millions, as long as `density` is low, which is virtually impossible with the current implementation on master.

Hopefully closes #9699 

cc @perimosocordiae
