### PR TITLE
scipy.spatial enhancement request

### DIFF
--- a/scipy/spatial/qhull.pyx
+++ b/scipy/spatial/qhull.pyx
@@ -1722,6 +1722,9 @@ class Delaunay(_QhullUser):
     vertex_neighbor_vertices : tuple of two ndarrays of int; (indptr, indices)
         Neighboring vertices of vertices. The indices of neighboring
         vertices of vertex `k` are ``indices[indptr[k]:indptr[k+1]]``.
+    furthest_site
+        True if this was a furthest site triangulation and False if not.
+        .. versionadded:: x.y.z
 
     Raises
     ------
@@ -1836,6 +1839,8 @@ class Delaunay(_QhullUser):
         qhull = _Qhull(b"d", points, qhull_options, required_options=b"Qt",
                        furthest_site=furthest_site, incremental=incremental)
         _QhullUser.__init__(self, qhull, incremental=incremental)
+
+        self.furthest_site = furthest_site
 
     def _update(self, qhull):
         qhull.triangulate()
@@ -2515,6 +2520,9 @@ class Voronoi(_QhullUser):
         Index of the Voronoi region for each input point.
         If qhull option "Qc" was not specified, the list will contain -1
         for points that are not associated with a Voronoi region.
+    furthest_site
+        True if this was a furthest site triangulation and False if not.
+        .. versionadded:: x.y.z
 
     Raises
     ------
@@ -2598,6 +2606,8 @@ class Voronoi(_QhullUser):
         qhull = _Qhull(b"v", points, qhull_options, furthest_site=furthest_site,
                        incremental=incremental)
         _QhullUser.__init__(self, qhull, incremental=incremental)
+
+        self.furthest_site = furthest_site
 
     def _update(self, qhull):
         self.vertices, self.ridge_points, self.ridge_vertices, \

--- a/scipy/spatial/qhull.pyx
+++ b/scipy/spatial/qhull.pyx
@@ -1725,7 +1725,7 @@ class Delaunay(_QhullUser):
     furthest_site
         True if this was a furthest site triangulation and False if not.
 
-        .. versionadded:: x.y.z
+        .. versionadded:: 1.4.0
 
     Raises
     ------
@@ -2524,7 +2524,7 @@ class Voronoi(_QhullUser):
     furthest_site
         True if this was a furthest site triangulation and False if not.
 
-        .. versionadded:: x.y.z
+        .. versionadded:: 1.4.0
 
     Raises
     ------

--- a/scipy/spatial/qhull.pyx
+++ b/scipy/spatial/qhull.pyx
@@ -1724,6 +1724,7 @@ class Delaunay(_QhullUser):
         vertices of vertex `k` are ``indices[indptr[k]:indptr[k+1]]``.
     furthest_site
         True if this was a furthest site triangulation and False if not.
+
         .. versionadded:: x.y.z
 
     Raises
@@ -2522,6 +2523,7 @@ class Voronoi(_QhullUser):
         for points that are not associated with a Voronoi region.
     furthest_site
         True if this was a furthest site triangulation and False if not.
+
         .. versionadded:: x.y.z
 
     Raises

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -953,9 +953,9 @@ class TestVoronoi:
         points = [(0, 0), (0, 1), (1, 0), (0.5, 0.5), (1.1, 1.1)]
 
         vor = Voronoi(points)
-        assert_equal(vor.furthest_site==False)
+        assert_equal(vor.furthest_site,False)
         vor = Voronoi(points,furthest_site=True)
-        assert_equal(vor.furthest_site==True)
+        assert_equal(vor.furthest_site,True)
 
     @pytest.mark.parametrize("name", sorted(INCREMENTAL_DATASETS))
     def test_incremental(self, name):

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -949,6 +949,14 @@ class TestVoronoi:
         """
         self._compare_qvoronoi(points, output, furthest_site=True)
 
+    def test_furthest_site_flag(self):
+        points = [(0, 0), (0, 1), (1, 0), (0.5, 0.5), (1.1, 1.1)]
+
+        vor = Voronoi(points)
+        assert_equal(vor.furthest_site==False)
+        vor = Voronoi(points,furthest_site=True)
+        assert_equal(vor.furthest_site==True)
+
     @pytest.mark.parametrize("name", sorted(INCREMENTAL_DATASETS))
     def test_incremental(self, name):
         # Test incremental construction of the triangulation


### PR DESCRIPTION
I would like to add an element to the qhull interface - I would like the class to keep track of whether Voronoi diagrams and Delaunay triangulations were created as nearest site or furthest site diagrams.

Some of my applications are getting fairly large, and it is cumbersome and error-prone to pass the furthest_site argument around.  As an example, I modified voronoi_plot_2d to do furthest site plots as well as the default nearest site diagrams.  Since my plotting routines are in a different module, it was much simpler to have the plotting routine get the information directly from the Voronoi class.