### PR TITLE
DOC: update the example for PPoly.solve

### DIFF
--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -1211,7 +1211,7 @@ class PPoly(_PPolyBase):
 
         >>> from scipy.interpolate import PPoly
         >>> pp = PPoly(np.array([[1, -4, 3], [1, 0, 0]]).T, [-2, 1, 2])
-        >>> pp.roots()
+        >>> pp.solve()
         array([-1.,  1.])
         """
         if extrapolate is None:


### PR DESCRIPTION
Fixed the problem that currently the example for `PPoly.solve` actually uses `PPoly.roots`.