### PR TITLE
TST: add tests for stats.tvar with unflattened arrays

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -210,6 +210,7 @@ Forrest Collman for adding multi-target dijsktra to scipy.sparse.csgraph
 Carlos Ramos Carreño for adding support for relational attributes in loadarff.
 Jason M. Manley for documentation fixes.
 Aidan Dang for block QR wrappers in scipy.linalg.lapack.
+Clement Ng for modifying tests in scipy.stats.
 
 Institutions
 ------------

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -633,13 +633,12 @@ def tvar(a, limits=None, inclusive=(True, True), axis=0, ddof=1):
 
     """
     a = asarray(a)
-    a = a.astype(float).ravel()
+    a = a.astype(float)
     if limits is None:
-        n = len(a)
-        return a.var() * n / (n - 1.)
+        return a.var(ddof=ddof, axis=axis)
     am = _mask_to_limits(a, limits, inclusive)
-    return np.ma.var(am, ddof=ddof, axis=axis)
-
+    amnan = am.filled(fill_value=np.nan)
+    return np.nanvar(amnan, ddof=ddof, axis=axis)
 
 def tmin(a, lowerlimit=None, axis=0, inclusive=True, nan_policy='propagate'):
     """

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -77,6 +77,31 @@ class TestTrimmedStats(object):
         y = stats.tvar(X, limits=None)
         assert_approx_equal(y, X.var(ddof=1), significant=self.dprec)
 
+        x_2d = arange(63, dtype=float64).reshape((9, 7))
+        y = stats.tvar(x_2d, axis=None)
+        assert_approx_equal(y, x_2d.var(ddof=1), significant=self.dprec)
+
+        y = stats.tvar(x_2d, axis=0)
+        assert_array_almost_equal(y[0], np.full((1, 7), 367.50000000), decimal=8)
+
+        y = stats.tvar(x_2d, axis=1)
+        assert_array_almost_equal(y[0], np.full((1, 9), 4.66666667), decimal=8)
+
+        y = stats.tvar(x_2d[3, :])
+        assert_approx_equal(y, 4.666666666666667, significant=self.dprec)
+
+        with suppress_warnings() as sup:
+            r = sup.record(RuntimeWarning, "Degrees of freedom <= 0 for slice.")
+
+            # Limiting some values along one axis
+            y = stats.tvar(x_2d, limits=(1, 5), axis=1, inclusive=(True, True))
+            assert_approx_equal(y[0], 2.5, significant=self.dprec)
+
+            # Limiting all values along one axis
+            y = stats.tvar(x_2d, limits=(0, 6), axis=1, inclusive=(True, True))
+            assert_approx_equal(y[0], 4.666666666666667, significant=self.dprec)
+            assert_equal(y[1], np.nan)
+
     def test_tstd(self):
         y = stats.tstd(X, (2, 8), (True, True))
         assert_approx_equal(y, 2.1602468994692865, significant=self.dprec)


### PR DESCRIPTION
Adds tests to gh-8359. Also a cleanup of the previous [PR](https://github.com/scipy/scipy/pull/10264).