### PR TITLE
BUG: linalg/interpolative: fix interp_decomp modifying input

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -211,6 +211,7 @@ Carlos Ramos Carreño for adding support for relational attributes in loadarff.
 Jason M. Manley for documentation fixes.
 Aidan Dang for block QR wrappers in scipy.linalg.lapack.
 Clement Ng for modifying tests in scipy.stats.
+Fletcher H. Easton for a bug fix in scipy.linalg.interpolative.
 
 Institutions
 ------------

--- a/scipy/linalg/_interpolative_backend.py
+++ b/scipy/linalg/_interpolative_backend.py
@@ -228,7 +228,10 @@ def iddr_id(A, k):
         Interpolation coefficients.
     :rtype: :class:`numpy.ndarray`
     """
-    A = np.asfortranarray(A)
+    if A.flags['F_CONTIGUOUS']:
+        A = A.copy()
+    else:
+        A = np.asfortranarray(A)
     idx, rnorms = _id.iddr_id(A, k)
     n = A.shape[1]
     proj = A.T.ravel()[:k*(n-k)].reshape((k, n-k), order='F')

--- a/scipy/linalg/_interpolative_backend.py
+++ b/scipy/linalg/_interpolative_backend.py
@@ -37,6 +37,18 @@ import numpy as np
 _RETCODE_ERROR = RuntimeError("nonzero return code")
 
 
+def _asfortranarray_copy(A):
+    """
+    Same as np.asfortranarray, but ensure a copy
+    """
+    A = np.asarray(A)
+    if A.flags.f_contiguous:
+        A = A.copy(order="F")
+    else:
+        A = np.asfortranarray(A)
+    return A
+
+
 #------------------------------------------------------------------------------
 # id_rand.f
 #------------------------------------------------------------------------------
@@ -203,7 +215,7 @@ def iddp_id(eps, A):
         Interpolation coefficients.
     :rtype: :class:`numpy.ndarray`
     """
-    A = np.asfortranarray(A)
+    A = _asfortranarray_copy(A)
     k, idx, rnorms = _id.iddp_id(eps, A)
     n = A.shape[1]
     proj = A.T.ravel()[:k*(n-k)].reshape((k, n-k), order='F')
@@ -228,10 +240,7 @@ def iddr_id(A, k):
         Interpolation coefficients.
     :rtype: :class:`numpy.ndarray`
     """
-    if A.flags['F_CONTIGUOUS']:
-        A = A.copy()
-    else:
-        A = np.asfortranarray(A)
+    A = _asfortranarray_copy(A)
     idx, rnorms = _id.iddr_id(A, k)
     n = A.shape[1]
     proj = A.T.ravel()[:k*(n-k)].reshape((k, n-k), order='F')
@@ -1000,7 +1009,7 @@ def idzp_id(eps, A):
         Interpolation coefficients.
     :rtype: :class:`numpy.ndarray`
     """
-    A = np.asfortranarray(A)
+    A = _asfortranarray_copy(A)
     k, idx, rnorms = _id.idzp_id(eps, A)
     n = A.shape[1]
     proj = A.T.ravel()[:k*(n-k)].reshape((k, n-k), order='F')
@@ -1025,7 +1034,7 @@ def idzr_id(A, k):
         Interpolation coefficients.
     :rtype: :class:`numpy.ndarray`
     """
-    A = np.asfortranarray(A)
+    A = _asfortranarray_copy(A)
     idx, rnorms = _id.idzr_id(A, k)
     n = A.shape[1]
     proj = A.T.ravel()[:k*(n-k)].reshape((k, n-k), order='F')

--- a/scipy/linalg/tests/test_interpolative.py
+++ b/scipy/linalg/tests/test_interpolative.py
@@ -32,6 +32,7 @@ from scipy.linalg import hilbert, svdvals, norm
 from scipy.sparse.linalg import aslinearoperator
 from scipy.linalg.interpolative import interp_decomp
 import time
+import itertools
 
 from numpy.testing import assert_, assert_allclose
 from pytest import raises as assert_raises
@@ -278,11 +279,17 @@ class TestInterpolativeDecomposition(object):
         assert_allclose(A, B.dot(P))
 
     def test_bug_9793(self):
-        A = np.array([[-1, -1, -1, 0, 0, 0],
-                      [0, 0, 0, 1, 1, 1],
-                      [1, 0, 0, 1, 0, 0],
-                      [0, 1, 0, 0, 1, 0],
-                      [0, 0, 1, 0, 0, 1]], dtype=float)
-        B = A.copy()
-        idx, proj = interp_decomp(A.T, 1, rand=False)
-        assert_(np.array_equal(A, B))
+        dtypes = [np.float_, np.complex_]
+        rands = [True, False]
+        epss = [1, 0.1]
+
+        for dtype, eps, rand in itertools.product(dtypes, epss, rands):
+            A = np.array([[-1, -1, -1, 0, 0, 0],
+                          [0, 0, 0, 1, 1, 1],
+                          [1, 0, 0, 1, 0, 0],
+                          [0, 1, 0, 0, 1, 0],
+                          [0, 0, 1, 0, 0, 1]],
+                         dtype=dtype, order="C")
+            B = A.copy()
+            interp_decomp(A.T, eps, rand=rand)
+            assert_(np.array_equal(A, B))

--- a/scipy/linalg/tests/test_interpolative.py
+++ b/scipy/linalg/tests/test_interpolative.py
@@ -30,6 +30,7 @@ import scipy.linalg.interpolative as pymatrixid
 import numpy as np
 from scipy.linalg import hilbert, svdvals, norm
 from scipy.sparse.linalg import aslinearoperator
+from scipy.linalg.interpolative import interp_decomp
 import time
 
 from numpy.testing import assert_, assert_allclose
@@ -276,3 +277,12 @@ class TestInterpolativeDecomposition(object):
         B = pymatrixid.reconstruct_skel_matrix(A, k, idx)
         assert_allclose(A, B.dot(P))
 
+    def test_bug_9793(self):
+        A = np.array([[-1, -1, -1, 0, 0, 0],
+                      [0, 0, 0, 1, 1, 1],
+                      [1, 0, 0, 1, 0, 0],
+                      [0, 1, 0, 0, 1, 0],
+                      [0, 0, 1, 0, 0, 1]], dtype=float)
+        B = A.copy()
+        idx, proj = interp_decomp(A.T, 1, rand=False)
+        assert_(np.array_equal(A, B))


### PR DESCRIPTION
A bug in the iddr_id routine caused the paramater matrix to be
modified in-place. Fixed by checking if the matrix has the flag
F_CONTIGUOUS before making an explicit copy. Fixes #9793.