### PR TITLE
MAINT: linalg: Use the new fft subpackage in linalg.dft test and docstring.

### DIFF
--- a/scipy/linalg/special_matrices.py
+++ b/scipy/linalg/special_matrices.py
@@ -1012,19 +1012,23 @@ def dft(n, scale=None):
     Examples
     --------
     >>> from scipy.linalg import dft
-    >>> np.set_printoptions(precision=5, suppress=True)
-    >>> x = np.array([1, 2, 3, 0, 3, 2, 1, 0])
-    >>> m = dft(8)
-    >>> m.dot(x)   # Compute the DFT of x
-    array([ 12.+0.j,  -2.-2.j,   0.-4.j,  -2.+2.j,   4.+0.j,  -2.-2.j,
-            -0.+4.j,  -2.+2.j])
+    >>> np.set_printoptions(precision=2, suppress=True)  # for compact output
+    >>> m = dft(5)
+    >>> m
+    array([[ 1.  +0.j  ,  1.  +0.j  ,  1.  +0.j  ,  1.  +0.j  ,  1.  +0.j  ],
+           [ 1.  +0.j  ,  0.31-0.95j, -0.81-0.59j, -0.81+0.59j,  0.31+0.95j],
+           [ 1.  +0.j  , -0.81-0.59j,  0.31+0.95j,  0.31-0.95j, -0.81+0.59j],
+           [ 1.  +0.j  , -0.81+0.59j,  0.31-0.95j,  0.31+0.95j, -0.81-0.59j],
+           [ 1.  +0.j  ,  0.31+0.95j, -0.81+0.59j, -0.81-0.59j,  0.31-0.95j]])
+    >>> x = np.array([1, 2, 3, 0, 3])
+    >>> m @ x  # Compute the DFT of x
+    array([ 9.  +0.j  ,  0.12-0.81j, -2.12+3.44j, -2.12-3.44j,  0.12+0.81j])
 
-    Verify that ``m.dot(x)`` is the same as ``fft(x)``.
+    Verify that ``m @ x`` is the same as ``fft(x)``.
 
-    >>> from scipy.fftpack import fft
-    >>> fft(x)     # Same result as m.dot(x)
-    array([ 12.+0.j,  -2.-2.j,   0.-4.j,  -2.+2.j,   4.+0.j,  -2.-2.j,
-             0.+4.j,  -2.+2.j])
+    >>> from scipy.fft import fft
+    >>> fft(x)     # Same result as m @ x
+    array([ 9.  +0.j  ,  0.12-0.81j, -2.12+3.44j, -2.12-3.44j,  0.12+0.81j])
     """
     if scale not in [None, 'sqrtn', 'n']:
         raise ValueError("scale must be None, 'sqrtn', or 'n'; "

--- a/scipy/linalg/tests/test_special_matrices.py
+++ b/scipy/linalg/tests/test_special_matrices.py
@@ -8,7 +8,7 @@ from pytest import raises as assert_raises
 
 from scipy._lib.six import xrange
 
-from scipy import fftpack
+from scipy.fft import fft
 from scipy.special import comb
 from scipy.linalg import (toeplitz, hankel, circulant, hadamard, leslie, dft,
                           companion, tri, triu, tril, kron, block_diag,
@@ -607,7 +607,7 @@ def test_dft():
     x = array([0, 1, 2, 3, 4, 5, 0, 1])
     m = dft(8)
     mx = m.dot(x)
-    fx = fftpack.fft(x)
+    fx = fft(x)
     assert_array_almost_equal(mx, fx)
 
 


### PR DESCRIPTION
Also tweaked the dft docstring to show the matrix m.