### PR TITLE
BUG: Fix unstable standard deviation calculation in histogram

### DIFF
--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -562,11 +562,10 @@ def binned_statistic_dd(sample, values, statistic='mean',
         result.fill(0)
         flatcount = np.bincount(binnumbers, None)
         a = flatcount.nonzero()
-        for vv in xrange(Vdim):
-            flatsum = np.bincount(binnumbers, values[vv])
-            flatsum2 = np.bincount(binnumbers, values[vv] ** 2)
-            result[vv, a] = np.sqrt(flatsum2[a] / flatcount[a] -
-                                    (flatsum[a] / flatcount[a]) ** 2)
+        for i in np.unique(binnumbers):
+            for vv in xrange(Vdim):
+                #NOTE: take std dev by bin, np.std() is 2-pass and stable
+                result[vv, i] = np.std(values[vv, binnumbers == i])
     elif statistic == 'count':
         result.fill(0)
         flatcount = np.bincount(binnumbers, None)

--- a/scipy/stats/tests/test_binned_statistic.py
+++ b/scipy/stats/tests/test_binned_statistic.py
@@ -19,6 +19,7 @@ class TestBinnedStatistic(object):
         cls.v = np.random.random(100)
         cls.X = np.random.random((100, 3))
         cls.w = np.random.random(100)
+        cls.u = np.random.random(100) + 1e6
 
     def test_1d_count(self):
         x = self.x
@@ -38,6 +39,17 @@ class TestBinnedStatistic(object):
         statistics = [u'mean', u'median', u'count', u'sum']
         for statistic in statistics:
             res = binned_statistic(x, v, statistic, bins=10)
+
+    def test_big_number_std(self):
+        # tests for numerical stability of std calculation
+        # see issue gh-10126 for more
+        x = self.x
+        u = self.u
+
+        stat1, edges1, bc = binned_statistic(x, u, 'std', bins=10)
+        stat2, edges2, bc = binned_statistic(x, u, np.std, bins=10)
+
+        assert_allclose(stat1, stat2)
 
     def test_1d_result_attributes(self):
         x = self.x


### PR DESCRIPTION
Closes  #10126 

2 commits: first commit adds unit test that is broken by existing logic (unstable variance/standard deviation calculation) 

second commit adds a fix by calculation of `np.std()` inside each cell of the d-dimensional histogram.  