### PR TITLE
Bug: interpolate.NearestNDInterpolator (issue #10352)

### DIFF
--- a/scipy/interpolate/ndgriddata.py
+++ b/scipy/interpolate/ndgriddata.py
@@ -62,7 +62,7 @@ class NearestNDInterpolator(NDInterpolatorBase):
         if tree_options is None:
             tree_options = dict()
         self.tree = cKDTree(self.points, **tree_options)
-        self.values = y
+        self.values = np.array(y)
 
     def __call__(self, *args):
         """

--- a/scipy/interpolate/ndgriddata.py
+++ b/scipy/interpolate/ndgriddata.py
@@ -62,7 +62,7 @@ class NearestNDInterpolator(NDInterpolatorBase):
         if tree_options is None:
             tree_options = dict()
         self.tree = cKDTree(self.points, **tree_options)
-        self.values = np.array(y)
+        self.values = np.asarray(y)
 
     def __call__(self, *args):
         """

--- a/scipy/interpolate/tests/test_ndgriddata.py
+++ b/scipy/interpolate/tests/test_ndgriddata.py
@@ -175,3 +175,17 @@ def test_nearest_options():
     nndi_o = NearestNDInterpolator(x, y, tree_options=opts)
     assert_allclose(nndi(x), nndi_o(x), atol=1e-14)
 
+
+def test_nearest_nd_interpolator():
+    nd = np.array([[0, 0, 0, 0, 1, 0, 1],
+                   [0, 0, 0, 0, 0, 1, 1],
+                   [0, 0, 0, 0, 1, 1, 2]])
+    d = nd[:, 3:]
+
+    # z is np.array
+    NI = NearestNDInterpolator((d[0], d[1]), d[2])
+    assert_array_equal(NI([0.1, 0.9], [0.1, 0.9]), [0, 2])
+
+    # z is list
+    NI = NearestNDInterpolator((d[0], d[1]), list(d[2]))
+    assert_array_equal(NI([0.1, 0.9], [0.1, 0.9]), [0, 2])

--- a/scipy/interpolate/tests/test_ndgriddata.py
+++ b/scipy/interpolate/tests/test_ndgriddata.py
@@ -176,7 +176,7 @@ def test_nearest_options():
     assert_allclose(nndi(x), nndi_o(x), atol=1e-14)
 
 
-def test_nearest_nd_interpolator():
+def test_nearest_list_argument():
     nd = np.array([[0, 0, 0, 0, 1, 0, 1],
                    [0, 0, 0, 0, 0, 1, 1],
                    [0, 0, 0, 0, 1, 1, 2]])


### PR DESCRIPTION
fix  #10352
The problem is solved by casting the searched array.