### PR TITLE
Use correct environment marker syntax

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,6 @@ requires = [
     "Cython>=0.29.2",
     "numpy==1.13.3; python_version=='3.5'",
     "numpy==1.13.3; python_version=='3.6'",
-    "numpy==1.14.5; python_version>='3.7'",
+    "numpy==1.14.5; python_version not in '3.5;3.6'",
     "pybind11>=2.2.4",
 ]


### PR DESCRIPTION
[According to PEP 345](https://www.python.org/dev/peps/pep-0345/#environment-markers), environment markers are strings and can only compared to strings using “==”, “!=”, “in”, and “not in”.