### PR TITLE
DOC: Add pybind11 requirment to HACKING.rst.txt

### DIFF
--- a/HACKING.rst.txt
+++ b/HACKING.rst.txt
@@ -368,7 +368,7 @@ command ``source scipy-dev/bin/activate``, and ``deactivate`` to exit from the
 virtual environment and back to your previous shell.  With scipy-dev
 activated, install first Scipy's dependencies::
 
-    $ pip install NumPy pytest Cython
+    $ pip install numpy pytest cython pybind11
 
 After that, you can install a development version of Scipy, for example via::
 


### PR DESCRIPTION
The addition of the scipy.fft module (#10238) adds pybind11 as an additional
build time dependency. This has already been documented in
INSTALL.rst.txt (#10348) but not in HACKING.rst.txt. This commit adds
pybind11 to the required dependencies.