### PR TITLE
DOC: linalg: Refer to scipy.fft.fft (not fftpack) in the dft docstring.

### DIFF
--- a/scipy/linalg/special_matrices.py
+++ b/scipy/linalg/special_matrices.py
@@ -1001,7 +1001,7 @@ def dft(n, scale=None):
     -----
     When `scale` is None, multiplying a vector by the matrix returned by
     `dft` is mathematically equivalent to (but much less efficient than)
-    the calculation performed by `scipy.fftpack.fft`.
+    the calculation performed by `scipy.fft.fft`.
 
     .. versionadded:: 0.14.0
 


### PR DESCRIPTION
This should have been part of https://github.com/scipy/scipy/pull/10350.