### PR TITLE
ENH: Prefer scipy.fft to scipy.fftpack in scipy.signal

### DIFF
--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -18,7 +18,8 @@ Using any of these subpackages requires an explicit import.  For example,
 ::
 
  cluster                      --- Vector Quantization / Kmeans
- fftpack                      --- Discrete Fourier Transform algorithms
+ fft                          --- Discrete Fourier transforms
+ fftpack                      --- Legacy discrete Fourier transforms
  integrate                    --- Integration routines
  interpolate                  --- Interpolation Tools
  io                           --- Data input and output
@@ -85,13 +86,6 @@ del _num
 del linalg
 __all__.remove('linalg')
 
-# The existence of the scipy.fft function breaks doc builds
-import os as _os
-if _os.environ.get('_SCIPY_BUILDING_DOC') == 'True':
-    del fft
-    __all__.remove('fft')
-del _os
-
 # We first need to detect if we're being called as part of the scipy
 # setup procedure itself in a reliable manner.
 try:
@@ -128,3 +122,7 @@ else:
     from scipy._lib._testutils import PytestTester
     test = PytestTester(__name__)
     del PytestTester
+
+    # This makes "from scipy import fft" return scipy.fft, not np.fft
+    del fft
+    from . import fft

--- a/scipy/fft/_helper.py
+++ b/scipy/fft/_helper.py
@@ -1,4 +1,5 @@
 import scipy.fftpack as _fftpack
+from scipy.fftpack.helper import _init_nd_shape_and_axes_sorted  # noqa: F401
 
 
 def next_fast_len(target, dtype=None):

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -15,7 +15,7 @@ from numpy import (atleast_1d, poly, polyval, roots, real, asarray,
                    mintypecode)
 from numpy.polynomial.polynomial import polyval as npp_polyval
 
-from scipy import special, optimize, fftpack
+from scipy import special, optimize, fft as sp_fft
 from scipy.special import comb, factorial
 from scipy._lib._numpy_compat import polyvalfromroots
 
@@ -347,7 +347,7 @@ def freqz(b, a=1, worN=512, whole=False, plot=None, fs=2*pi):
 
     1. An integer value is given for `worN`.
     2. `worN` is fast to compute via FFT (i.e.,
-       `next_fast_len(worN) <scipy.fftpack.next_fast_len>` equals `worN`).
+       `next_fast_len(worN) <scipy.fft.next_fast_len>` equals `worN`).
     3. The denominator coefficients are a single value (``a.shape[0] == 1``).
     4. `worN` is at least as long as the numerator coefficients
        (``worN >= b.shape[0]``).
@@ -438,17 +438,17 @@ def freqz(b, a=1, worN=512, whole=False, plot=None, fs=2*pi):
         lastpoint = 2 * pi if whole else pi
         w = np.linspace(0, lastpoint, N, endpoint=False)
         if (a.size == 1 and N >= b.shape[0] and
-                fftpack.next_fast_len(N) == N and
+                sp_fft.next_fast_len(N) == N and
                 (b.ndim == 1 or (b.shape[-1] == 1))):
             # if N is fast, 2 * N will be fast, too, so no need to check
             n_fft = N if whole else N * 2
             if np.isrealobj(b) and np.isrealobj(a):
-                fft_func = np.fft.rfft
+                fft_func = sp_fft.rfft
             else:
-                fft_func = fftpack.fft
+                fft_func = sp_fft.fft
             h = fft_func(b, n=n_fft, axis=0)[:N]
             h /= a
-            if fft_func is np.fft.rfft and whole:
+            if fft_func is sp_fft.rfft and whole:
                 # exclude DC and maybe Nyquist (no need to use axis_reverse
                 # here because we can build reversal with the truncation)
                 stop = -1 if n_fft % 2 == 1 else -2

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -4,7 +4,7 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from scipy import fftpack
+from scipy import fft as sp_fft
 from . import signaltools
 from .windows import get_window
 from ._spectral import _lombscargle
@@ -187,7 +187,7 @@ def periodogram(x, fs=1.0, window='boxcar', nfft=None, detrend='constant',
         done. Defaults to 'constant'.
     return_onesided : bool, optional
         If `True`, return a one-sided spectrum for real data. If
-        `False` return a two-sided spectrum. Defaults to `True`, but for 
+        `False` return a two-sided spectrum. Defaults to `True`, but for
         complex data, a two-sided spectrum is always returned.
     scaling : { 'density', 'spectrum' }, optional
         Selects between computing the power spectral density ('density')
@@ -333,7 +333,7 @@ def welch(x, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
         done. Defaults to 'constant'.
     return_onesided : bool, optional
         If `True`, return a one-sided spectrum for real data. If
-        `False` return a two-sided spectrum. Defaults to `True`, but for 
+        `False` return a two-sided spectrum. Defaults to `True`, but for
         complex data, a two-sided spectrum is always returned.
     scaling : { 'density', 'spectrum' }, optional
         Selects between computing the power spectral density ('density')
@@ -498,7 +498,7 @@ def csd(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
         done. Defaults to 'constant'.
     return_onesided : bool, optional
         If `True`, return a one-sided spectrum for real data. If
-        `False` return a two-sided spectrum. Defaults to `True`, but for 
+        `False` return a two-sided spectrum. Defaults to `True`, but for
         complex data, a two-sided spectrum is always returned.
     scaling : { 'density', 'spectrum' }, optional
         Selects between computing the cross spectral density ('density')
@@ -641,7 +641,7 @@ def spectrogram(x, fs=1.0, window=('tukey', .25), nperseg=None, noverlap=None,
         done. Defaults to 'constant'.
     return_onesided : bool, optional
         If `True`, return a one-sided spectrum for real data. If
-        `False` return a two-sided spectrum. Defaults to `True`, but for 
+        `False` return a two-sided spectrum. Defaults to `True`, but for
         complex data, a two-sided spectrum is always returned.
     scaling : { 'density', 'spectrum' }, optional
         Selects between computing the power spectral density ('density')
@@ -697,6 +697,7 @@ def spectrogram(x, fs=1.0, window=('tukey', .25), nperseg=None, noverlap=None,
     Examples
     --------
     >>> from scipy import signal
+    >>> from scipy.fft import fftshift
     >>> import matplotlib.pyplot as plt
 
     Generate a test signal, a 2 Vrms sine wave whose frequency is slowly
@@ -725,7 +726,7 @@ def spectrogram(x, fs=1.0, window=('tukey', .25), nperseg=None, noverlap=None,
     Note, if using output that is not one sided, then use the following:
 
     >>> f, t, Sxx = signal.spectrogram(x, fs, return_onesided=False)
-    >>> plt.pcolormesh(t, np.fft.fftshift(f), np.fft.fftshift(Sxx, axes=0))
+    >>> plt.pcolormesh(t, fftshift(f), fftshift(Sxx, axes=0))
     >>> plt.ylabel('Frequency [Hz]')
     >>> plt.xlabel('Time [sec]')
     >>> plt.show()
@@ -1060,7 +1061,7 @@ def stft(x, fs=1.0, window='hann', nperseg=256, noverlap=None, nfft=None,
         done. Defaults to `False`.
     return_onesided : bool, optional
         If `True`, return a one-sided spectrum for real data. If
-        `False` return a two-sided spectrum. Defaults to `True`, but for 
+        `False` return a two-sided spectrum. Defaults to `True`, but for
         complex data, a two-sided spectrum is always returned.
     boundary : str or None, optional
         Specifies whether the input signal is extended at both ends, and
@@ -1411,11 +1412,7 @@ def istft(Zxx, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
         if win.shape[0] != nperseg:
             raise ValueError('window must have length of {0}'.format(nperseg))
 
-    if input_onesided:
-        ifunc = np.fft.irfft
-    else:
-        ifunc = fftpack.ifft
-
+    ifunc = sp_fft.irfft if input_onesided else sp_fft.ifft
     xsubs = ifunc(Zxx, axis=-2, n=nfft)[..., :nperseg, :]
 
     # Initialize output and normalization arrays
@@ -1626,7 +1623,7 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
         done. Defaults to 'constant'.
     return_onesided : bool, optional
         If `True`, return a one-sided spectrum for real data. If
-        `False` return a two-sided spectrum. Defaults to `True`, but for 
+        `False` return a two-sided spectrum. Defaults to `True`, but for
         complex data, a two-sided spectrum is always returned.
     scaling : { 'density', 'spectrum' }, optional
         Selects between computing the cross spectral density ('density')
@@ -1828,9 +1825,9 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
         sides = 'twosided'
 
     if sides == 'twosided':
-        freqs = fftpack.fftfreq(nfft, 1/fs)
+        freqs = sp_fft.fftfreq(nfft, 1/fs)
     elif sides == 'onesided':
-        freqs = np.fft.rfftfreq(nfft, 1/fs)
+        freqs = sp_fft.rfftfreq(nfft, 1/fs)
 
     # Perform the windowed FFTs
     result = _fft_helper(x, win, detrend_func, nperseg, noverlap, nfft, sides)
@@ -1914,10 +1911,10 @@ def _fft_helper(x, win, detrend_func, nperseg, noverlap, nfft, sides):
 
     # Perform the fft. Acts on last axis by default. Zero-pads automatically
     if sides == 'twosided':
-        func = fftpack.fft
+        func = sp_fft.fft
     else:
         result = result.real
-        func = np.fft.rfft
+        func = sp_fft.rfft
     result = func(result, n=nfft)
 
     return result

--- a/scipy/signal/tests/test_fir_filter_design.py
+++ b/scipy/signal/tests/test_fir_filter_design.py
@@ -7,10 +7,10 @@ from numpy.testing import (assert_almost_equal, assert_array_almost_equal,
 from pytest import raises as assert_raises
 import pytest
 
-from scipy.linalg import LinAlgWarning
+from scipy.fft import fft
 from scipy.special import sinc
 from scipy.signal import kaiser_beta, kaiser_atten, kaiserord, \
-        firwin, firwin2, freqz, remez, firls, minimum_phase
+    firwin, firwin2, freqz, remez, firls, minimum_phase
 
 
 def test_kaiser_beta():
@@ -585,8 +585,8 @@ class TestMinimumPhase(object):
         for n in (2, 3, 10, 11, 15, 16, 17, 20, 21, 100, 101):
             h = rng.randn(n)
             h_new = minimum_phase(np.convolve(h, h[::-1]))
-            assert_allclose(np.abs(np.fft.fft(h_new)),
-                            np.abs(np.fft.fft(h)), rtol=1e-4)
+            assert_allclose(np.abs(fft(h_new)),
+                            np.abs(fft(h)), rtol=1e-4)
 
     def test_hilbert(self):
         # compare to MATLAB output of reference implementation

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -213,7 +213,7 @@ class TestConvolve(_TestConvolve):
                 kwargs = {'rtol': 1.0e-4, 'atol': 1e-6}
             elif 'float16' in [t1, t2]:
                 # atol is default for np.allclose
-                kwargs = {'rtol': 1e-3, 'atol': 1e-8}
+                kwargs = {'rtol': 1e-3, 'atol': 1e-3}
             else:
                 # defaults for np.allclose (different from assert_allclose)
                 kwargs = {'rtol': 1e-5, 'atol': 1e-8}
@@ -699,9 +699,10 @@ class TestFFTConvolve(object):
                                       [-4, -1],
                                       [-1, -4]])
     def test_random_data_multidim_axes(self, axes):
+        a_shape, b_shape = (123, 22), (132, 11)
         np.random.seed(1234)
-        a = np.random.rand(123, 222) + 1j * np.random.rand(123, 222)
-        b = np.random.rand(132, 111) + 1j * np.random.rand(132, 111)
+        a = np.random.rand(*a_shape) + 1j * np.random.rand(*a_shape)
+        b = np.random.rand(*b_shape) + 1j * np.random.rand(*b_shape)
         expected = convolve2d(a, b, 'full')
 
         a = a[:, :, None, None, None]
@@ -718,7 +719,7 @@ class TestFFTConvolve(object):
         expected = np.tile(expected, [2, 1, 3, 4, 1])
 
         out = fftconvolve(a, b, 'full', axes=axes)
-        assert_(np.allclose(out, expected, rtol=1e-10))
+        assert_allclose(out, expected, rtol=1e-10, atol=1e-10)
 
     @pytest.mark.slow
     @pytest.mark.parametrize(
@@ -2655,7 +2656,7 @@ class TestDeconvolve(object):
         recovered, remainder = signal.deconvolve(recorded, impulse_response)
         assert_allclose(recovered, original)
 
-        
+
 class TestDetrend(object):
 
     def test_basic(self):
@@ -2664,7 +2665,7 @@ class TestDetrend(object):
         assert_array_almost_equal(detrended, detrended_exact)
 
     def test_copy(self):
-        x = array([1, 1.2, 1.5, 1.6, 2.4]) 
+        x = array([1, 1.2, 1.5, 1.6, 2.4])
         copy_array = detrend(x, overwrite_data=False)
         inplace = detrend(x, overwrite_data=True)
         assert_array_almost_equal(copy_array, inplace)

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -8,7 +8,8 @@ import pytest
 from pytest import raises as assert_raises
 
 from scipy._lib._numpy_compat import suppress_warnings
-from scipy import signal, fftpack
+from scipy import signal
+from scipy.fft import fftfreq
 from scipy.signal import (periodogram, welch, lombscargle, csd, coherence,
                           spectrogram, stft, istft, check_COLA, check_NOLA)
 from scipy.signal.spectral import _spectral_helper
@@ -40,7 +41,7 @@ class TestPeriodogram(object):
         x = np.zeros(16)
         x[0] = 1
         f, p = periodogram(x, return_onesided=False)
-        assert_allclose(f, fftpack.fftfreq(16, 1.0))
+        assert_allclose(f, fftfreq(16, 1.0))
         q = np.ones(16)/16.0
         q[0] = 0
         assert_allclose(p, q)
@@ -78,7 +79,7 @@ class TestPeriodogram(object):
         x = np.zeros(16, dtype=int)
         x[0] = 1
         f, p = periodogram(x, return_onesided=False)
-        assert_allclose(f, fftpack.fftfreq(16, 1.0))
+        assert_allclose(f, fftfreq(16, 1.0))
         q = np.ones(16)/16.0
         q[0] = 0
         assert_allclose(p, q)
@@ -87,7 +88,7 @@ class TestPeriodogram(object):
         x = np.zeros(16, np.complex128)
         x[0] = 1.0 + 2.0j
         f, p = periodogram(x, return_onesided=False)
-        assert_allclose(f, fftpack.fftfreq(16, 1.0))
+        assert_allclose(f, fftfreq(16, 1.0))
         q = 5.0*np.ones(16)/16.0
         q[0] = 0
         assert_allclose(p, q)
@@ -201,7 +202,7 @@ class TestPeriodogram(object):
         x = np.zeros(16, 'f')
         x[0] = 1
         f, p = periodogram(x, return_onesided=False)
-        assert_allclose(f, fftpack.fftfreq(16, 1.0))
+        assert_allclose(f, fftfreq(16, 1.0))
         q = np.ones(16, 'f')/16.0
         q[0] = 0
         assert_allclose(p, q)
@@ -211,7 +212,7 @@ class TestPeriodogram(object):
         x = np.zeros(16, 'F')
         x[0] = 1.0 + 2.0j
         f, p = periodogram(x, return_onesided=False)
-        assert_allclose(f, fftpack.fftfreq(16, 1.0))
+        assert_allclose(f, fftfreq(16, 1.0))
         q = 5.0*np.ones(16, 'f')/16.0
         q[0] = 0
         assert_allclose(p, q)
@@ -244,7 +245,7 @@ class TestWelch(object):
         x[0] = 1
         x[8] = 1
         f, p = welch(x, nperseg=8, return_onesided=False)
-        assert_allclose(f, fftpack.fftfreq(8, 1.0))
+        assert_allclose(f, fftfreq(8, 1.0))
         q = np.array([0.08333333, 0.07638889, 0.11111111, 0.11111111,
                       0.11111111, 0.11111111, 0.11111111, 0.07638889])
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
@@ -284,7 +285,7 @@ class TestWelch(object):
         x[0] = 1
         x[8] = 1
         f, p = welch(x, nperseg=8, return_onesided=False)
-        assert_allclose(f, fftpack.fftfreq(8, 1.0))
+        assert_allclose(f, fftfreq(8, 1.0))
         q = np.array([0.08333333, 0.07638889, 0.11111111, 0.11111111,
                       0.11111111, 0.11111111, 0.11111111, 0.07638889])
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
@@ -294,7 +295,7 @@ class TestWelch(object):
         x[0] = 1.0 + 2.0j
         x[8] = 1.0 + 2.0j
         f, p = welch(x, nperseg=8, return_onesided=False)
-        assert_allclose(f, fftpack.fftfreq(8, 1.0))
+        assert_allclose(f, fftfreq(8, 1.0))
         q = np.array([0.41666667, 0.38194444, 0.55555556, 0.55555556,
                       0.55555556, 0.55555556, 0.55555556, 0.38194444])
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
@@ -447,7 +448,7 @@ class TestWelch(object):
         x[0] = 1
         x[8] = 1
         f, p = welch(x, nperseg=8, return_onesided=False)
-        assert_allclose(f, fftpack.fftfreq(8, 1.0))
+        assert_allclose(f, fftfreq(8, 1.0))
         q = np.array([0.08333333, 0.07638889, 0.11111111,
                       0.11111111, 0.11111111, 0.11111111, 0.11111111,
                       0.07638889], 'f')
@@ -459,7 +460,7 @@ class TestWelch(object):
         x[0] = 1.0 + 2.0j
         x[8] = 1.0 + 2.0j
         f, p = welch(x, nperseg=8, return_onesided=False)
-        assert_allclose(f, fftpack.fftfreq(8, 1.0))
+        assert_allclose(f, fftfreq(8, 1.0))
         q = np.array([0.41666666, 0.38194442, 0.55555552, 0.55555552,
                       0.55555558, 0.55555552, 0.55555552, 0.38194442], 'f')
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
@@ -470,7 +471,7 @@ class TestWelch(object):
         x = np.zeros(12)
 
         nfft = 24
-        f = fftpack.fftfreq(nfft, 1.0)[:nfft//2+1]
+        f = fftfreq(nfft, 1.0)[:nfft//2+1]
         f[-1] *= -1
         fodd, _ = welch(x, nperseg=5, nfft=nfft)
         feven, _ = welch(x, nperseg=6, nfft=nfft)
@@ -478,7 +479,7 @@ class TestWelch(object):
         assert_allclose(f, feven)
 
         nfft = 25
-        f = fftpack.fftfreq(nfft, 1.0)[:(nfft + 1)//2]
+        f = fftfreq(nfft, 1.0)[:(nfft + 1)//2]
         fodd, _ = welch(x, nperseg=5, nfft=nfft)
         feven, _ = welch(x, nperseg=6, nfft=nfft)
         assert_allclose(f, fodd)
@@ -584,7 +585,7 @@ class TestCSD:
         x[0] = 1
         x[8] = 1
         f, p = csd(x, x, nperseg=8, return_onesided=False)
-        assert_allclose(f, fftpack.fftfreq(8, 1.0))
+        assert_allclose(f, fftfreq(8, 1.0))
         q = np.array([0.08333333, 0.07638889, 0.11111111, 0.11111111,
                       0.11111111, 0.11111111, 0.11111111, 0.07638889])
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
@@ -624,7 +625,7 @@ class TestCSD:
         x[0] = 1
         x[8] = 1
         f, p = csd(x, x, nperseg=8, return_onesided=False)
-        assert_allclose(f, fftpack.fftfreq(8, 1.0))
+        assert_allclose(f, fftfreq(8, 1.0))
         q = np.array([0.08333333, 0.07638889, 0.11111111, 0.11111111,
                       0.11111111, 0.11111111, 0.11111111, 0.07638889])
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
@@ -634,7 +635,7 @@ class TestCSD:
         x[0] = 1.0 + 2.0j
         x[8] = 1.0 + 2.0j
         f, p = csd(x, x, nperseg=8, return_onesided=False)
-        assert_allclose(f, fftpack.fftfreq(8, 1.0))
+        assert_allclose(f, fftfreq(8, 1.0))
         q = np.array([0.41666667, 0.38194444, 0.55555556, 0.55555556,
                       0.55555556, 0.55555556, 0.55555556, 0.38194444])
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
@@ -812,7 +813,7 @@ class TestCSD:
         x[0] = 1
         x[8] = 1
         f, p = csd(x, x, nperseg=8, return_onesided=False)
-        assert_allclose(f, fftpack.fftfreq(8, 1.0))
+        assert_allclose(f, fftfreq(8, 1.0))
         q = np.array([0.08333333, 0.07638889, 0.11111111,
                       0.11111111, 0.11111111, 0.11111111, 0.11111111,
                       0.07638889], 'f')
@@ -824,7 +825,7 @@ class TestCSD:
         x[0] = 1.0 + 2.0j
         x[8] = 1.0 + 2.0j
         f, p = csd(x, x, nperseg=8, return_onesided=False)
-        assert_allclose(f, fftpack.fftfreq(8, 1.0))
+        assert_allclose(f, fftfreq(8, 1.0))
         q = np.array([0.41666666, 0.38194442, 0.55555552, 0.55555552,
                       0.55555558, 0.55555552, 0.55555552, 0.38194442], 'f')
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
@@ -836,7 +837,7 @@ class TestCSD:
         y = np.ones(12)
 
         nfft = 24
-        f = fftpack.fftfreq(nfft, 1.0)[:nfft//2+1]
+        f = fftfreq(nfft, 1.0)[:nfft//2+1]
         f[-1] *= -1
         fodd, _ = csd(x, y, nperseg=5, nfft=nfft)
         feven, _ = csd(x, y, nperseg=6, nfft=nfft)
@@ -844,7 +845,7 @@ class TestCSD:
         assert_allclose(f, feven)
 
         nfft = 25
-        f = fftpack.fftfreq(nfft, 1.0)[:(nfft + 1)//2]
+        f = fftfreq(nfft, 1.0)[:(nfft + 1)//2]
         fodd, _ = csd(x, y, nperseg=5, nfft=nfft)
         feven, _ = csd(x, y, nperseg=6, nfft=nfft)
         assert_allclose(f, fodd)
@@ -1283,7 +1284,6 @@ class TestSTFT(object):
             assert_allclose(t, tr[:len(t)], err_msg=msg)
             assert_allclose(x, xr[:len(x)], err_msg=msg)
 
-    @pytest.mark.xfail(reason="Needs complex rfft from fftpack, see gh-2487 + gh-6058")
     def test_roundtrip_float32(self):
         np.random.seed(1234)
 
@@ -1302,7 +1302,7 @@ class TestSTFT(object):
 
             msg = '{0}, {1}'.format(window, noverlap)
             assert_allclose(t, t, err_msg=msg)
-            assert_allclose(x, xr, err_msg=msg, rtol=1e-4)
+            assert_allclose(x, xr, err_msg=msg, rtol=1e-4, atol=1e-5)
             assert_(x.dtype == xr.dtype)
 
     def test_roundtrip_complex(self):

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -10,7 +10,7 @@ from numpy.testing import (assert_array_almost_equal, assert_array_equal,
 from pytest import raises as assert_raises
 
 from scipy._lib._numpy_compat import suppress_warnings
-from scipy import fftpack
+from scipy.fft import fft
 from scipy.signal import windows, get_window, resample, hann as dep_hann
 
 
@@ -613,9 +613,9 @@ def test_windowfunc_basics():
             assert_array_less(window(9, *params, sym=False), 1.01)
 
             # Check that DFT-even spectrum is purely real for odd and even
-            assert_allclose(fftpack.fft(window(10, *params, sym=False)).imag,
+            assert_allclose(fft(window(10, *params, sym=False)).imag,
                             0, atol=1e-14)
-            assert_allclose(fftpack.fft(window(11, *params, sym=False)).imag,
+            assert_allclose(fft(window(11, *params, sym=False)).imag,
                             0, atol=1e-14)
 
 

--- a/scipy/signal/windows/windows.py
+++ b/scipy/signal/windows/windows.py
@@ -6,7 +6,7 @@ import operator
 import warnings
 
 import numpy as np
-from scipy import fftpack, linalg, special
+from scipy import linalg, special, fft as sp_fft
 from scipy._lib.six import string_types
 
 __all__ = ['boxcar', 'triang', 'parzen', 'bohman', 'blackman', 'nuttall',
@@ -87,7 +87,7 @@ def general_cosine(M, a, sym=True):
     the sidelobe level in red:
 
     >>> from scipy.signal.windows import general_cosine
-    >>> from scipy.fftpack import fft, fftshift
+    >>> from scipy.fft import fft, fftshift
     >>> import matplotlib.pyplot as plt
 
     >>> window = general_cosine(1000, HFT90D, sym=False)
@@ -145,7 +145,7 @@ def boxcar(M, sym=True):
     Plot the window and its frequency response:
 
     >>> from scipy import signal
-    >>> from scipy.fftpack import fft, fftshift
+    >>> from scipy.fft import fft, fftshift
     >>> import matplotlib.pyplot as plt
 
     >>> window = signal.boxcar(51)
@@ -202,7 +202,7 @@ def triang(M, sym=True):
     Plot the window and its frequency response:
 
     >>> from scipy import signal
-    >>> from scipy.fftpack import fft, fftshift
+    >>> from scipy.fft import fft, fftshift
     >>> import matplotlib.pyplot as plt
 
     >>> window = signal.triang(51)
@@ -267,7 +267,7 @@ def parzen(M, sym=True):
     Plot the window and its frequency response:
 
     >>> from scipy import signal
-    >>> from scipy.fftpack import fft, fftshift
+    >>> from scipy.fft import fft, fftshift
     >>> import matplotlib.pyplot as plt
 
     >>> window = signal.parzen(51)
@@ -326,7 +326,7 @@ def bohman(M, sym=True):
     Plot the window and its frequency response:
 
     >>> from scipy import signal
-    >>> from scipy.fftpack import fft, fftshift
+    >>> from scipy.fft import fft, fftshift
     >>> import matplotlib.pyplot as plt
 
     >>> window = signal.bohman(51)
@@ -417,7 +417,7 @@ def blackman(M, sym=True):
     Plot the window and its frequency response:
 
     >>> from scipy import signal
-    >>> from scipy.fftpack import fft, fftshift
+    >>> from scipy.fft import fft, fftshift
     >>> import matplotlib.pyplot as plt
 
     >>> window = signal.blackman(51)
@@ -478,7 +478,7 @@ def nuttall(M, sym=True):
     Plot the window and its frequency response:
 
     >>> from scipy import signal
-    >>> from scipy.fftpack import fft, fftshift
+    >>> from scipy.fft import fft, fftshift
     >>> import matplotlib.pyplot as plt
 
     >>> window = signal.nuttall(51)
@@ -525,7 +525,7 @@ def blackmanharris(M, sym=True):
     Plot the window and its frequency response:
 
     >>> from scipy import signal
-    >>> from scipy.fftpack import fft, fftshift
+    >>> from scipy.fft import fft, fftshift
     >>> import matplotlib.pyplot as plt
 
     >>> window = signal.blackmanharris(51)
@@ -586,7 +586,7 @@ def flattop(M, sym=True):
     Plot the window and its frequency response:
 
     >>> from scipy import signal
-    >>> from scipy.fftpack import fft, fftshift
+    >>> from scipy.fft import fft, fftshift
     >>> import matplotlib.pyplot as plt
 
     >>> window = signal.flattop(51)
@@ -676,7 +676,7 @@ def bartlett(M, sym=True):
     Plot the window and its frequency response:
 
     >>> from scipy import signal
-    >>> from scipy.fftpack import fft, fftshift
+    >>> from scipy.fft import fft, fftshift
     >>> import matplotlib.pyplot as plt
 
     >>> window = signal.bartlett(51)
@@ -765,7 +765,7 @@ def hann(M, sym=True):
     Plot the window and its frequency response:
 
     >>> from scipy import signal
-    >>> from scipy.fftpack import fft, fftshift
+    >>> from scipy.fft import fft, fftshift
     >>> import matplotlib.pyplot as plt
 
     >>> window = signal.hann(51)
@@ -832,7 +832,7 @@ def tukey(M, alpha=0.5, sym=True):
     Plot the window and its frequency response:
 
     >>> from scipy import signal
-    >>> from scipy.fftpack import fft, fftshift
+    >>> from scipy.fft import fft, fftshift
     >>> import matplotlib.pyplot as plt
 
     >>> window = signal.tukey(51)
@@ -902,7 +902,7 @@ def barthann(M, sym=True):
     Plot the window and its frequency response:
 
     >>> from scipy import signal
-    >>> from scipy.fftpack import fft, fftshift
+    >>> from scipy.fft import fft, fftshift
     >>> import matplotlib.pyplot as plt
 
     >>> window = signal.barthann(51)
@@ -982,7 +982,7 @@ def general_hamming(M, alpha, sym=True):
     plot these different windows.
 
     >>> from scipy.signal.windows import general_hamming
-    >>> from scipy.fftpack import fft, fftshift
+    >>> from scipy.fft import fft, fftshift
     >>> import matplotlib.pyplot as plt
 
     >>> fig1, spatial_plot = plt.subplots()
@@ -1074,7 +1074,7 @@ def hamming(M, sym=True):
     Plot the window and its frequency response:
 
     >>> from scipy import signal
-    >>> from scipy.fftpack import fft, fftshift
+    >>> from scipy.fft import fft, fftshift
     >>> import matplotlib.pyplot as plt
 
     >>> window = signal.hamming(51)
@@ -1183,7 +1183,7 @@ def kaiser(M, beta, sym=True):
     Plot the window and its frequency response:
 
     >>> from scipy import signal
-    >>> from scipy.fftpack import fft, fftshift
+    >>> from scipy.fft import fft, fftshift
     >>> import matplotlib.pyplot as plt
 
     >>> window = signal.kaiser(51, beta=14)
@@ -1248,7 +1248,7 @@ def gaussian(M, std, sym=True):
     Plot the window and its frequency response:
 
     >>> from scipy import signal
-    >>> from scipy.fftpack import fft, fftshift
+    >>> from scipy.fft import fft, fftshift
     >>> import matplotlib.pyplot as plt
 
     >>> window = signal.gaussian(51, std=7)
@@ -1318,7 +1318,7 @@ def general_gaussian(M, p, sig, sym=True):
     Plot the window and its frequency response:
 
     >>> from scipy import signal
-    >>> from scipy.fftpack import fft, fftshift
+    >>> from scipy.fft import fft, fftshift
     >>> import matplotlib.pyplot as plt
 
     >>> window = signal.general_gaussian(51, p=1.5, sig=7)
@@ -1415,7 +1415,7 @@ def chebwin(M, at, sym=True):
     Plot the window and its frequency response:
 
     >>> from scipy import signal
-    >>> from scipy.fftpack import fft, fftshift
+    >>> from scipy.fft import fft, fftshift
     >>> import matplotlib.pyplot as plt
 
     >>> window = signal.chebwin(51, at=100)
@@ -1462,13 +1462,13 @@ def chebwin(M, at, sym=True):
     # Appropriate IDFT and filling up
     # depending on even/odd M
     if M % 2:
-        w = np.real(fftpack.fft(p))
+        w = np.real(sp_fft.fft(p))
         n = (M + 1) // 2
         w = w[:n]
         w = np.concatenate((w[n - 1:0:-1], w))
     else:
         p = p * np.exp(1.j * np.pi / M * np.r_[0:M])
-        w = np.real(fftpack.fft(p))
+        w = np.real(sp_fft.fft(p))
         n = M // 2 + 1
         w = np.concatenate((w[n - 1:0:-1], w[1:n]))
     w = w / max(w)
@@ -1522,7 +1522,7 @@ def slepian(M, width, sym=True):
     Plot the window and its frequency response:
 
     >>> from scipy import signal
-    >>> from scipy.fftpack import fft, fftshift
+    >>> from scipy.fft import fft, fftshift
     >>> import matplotlib.pyplot as plt
 
     >>> window = signal.slepian(51, width=0.3)
@@ -1592,7 +1592,7 @@ def cosine(M, sym=True):
     Plot the window and its frequency response:
 
     >>> from scipy import signal
-    >>> from scipy.fftpack import fft, fftshift
+    >>> from scipy.fft import fft, fftshift
     >>> import matplotlib.pyplot as plt
 
     >>> window = signal.cosine(51)
@@ -1665,7 +1665,7 @@ def exponential(M, center=None, tau=1., sym=True):
     Plot the symmetric window and its frequency response:
 
     >>> from scipy import signal
-    >>> from scipy.fftpack import fft, fftshift
+    >>> from scipy.fft import fft, fftshift
     >>> import matplotlib.pyplot as plt
 
     >>> M = 51
@@ -1957,7 +1957,7 @@ def dpss(M, NW, Kmax=None, sym=True, norm=None, return_ratios=False):
             if norm == 'approximate':
                 correction = M**2 / float(M**2 + NW)
             else:
-                s = np.fft.rfft(windows[0])
+                s = sp_fft.rfft(windows[0])
                 shift = -(1 - 1./M) * np.arange(1, M//2 + 1)
                 s[1:] *= 2 * np.exp(-1j * np.pi * shift)
                 correction = M / s.real.sum()
@@ -1973,9 +1973,9 @@ def dpss(M, NW, Kmax=None, sym=True, norm=None, return_ratios=False):
 def _fftautocorr(x):
     """Compute the autocorrelation of a real array and crop the result."""
     N = x.shape[-1]
-    use_N = fftpack.next_fast_len(2*N-1)
-    x_fft = np.fft.rfft(x, use_N, axis=-1)
-    cxy = np.fft.irfft(x_fft * x_fft.conj(), n=use_N)[:, :N]
+    use_N = sp_fft.next_fast_len(2*N-1)
+    x_fft = sp_fft.rfft(x, use_N, axis=-1)
+    cxy = sp_fft.irfft(x_fft * x_fft.conj(), n=use_N)[:, :N]
     # Or equivalently (but in most cases slower):
     # cxy = np.array([np.convolve(xx, yy[::-1], mode='full')
     #                 for xx, yy in zip(x, x)])[:, N-1:2*N-1]
@@ -2033,7 +2033,7 @@ def get_window(window, Nx, fftbins=True):
     fftbins : bool, optional
         If True (default), create a "periodic" window, ready to use with
         `ifftshift` and be multiplied by the result of an FFT (see also
-        `fftpack.fftfreq`).
+        :func:`~scipy.fft.fftfreq`).
         If False, create a "symmetric" window, for use in filter design.
 
     Returns


### PR DESCRIPTION
Change `scipy.signal` to prefer `scipy.fft` over `scipy.fftpack` and `scipy.fft.rfft` over `np.fft.rfft`.

Have not tested locally, let's see if this works. Will push commits to fix when it inevitably doesn't.