### PR TITLE
DOC: Tweaks to fft documentation

### DIFF
--- a/scipy/fft/_basic.py
+++ b/scipy/fft/_basic.py
@@ -6,7 +6,7 @@ def fft(x, n=None, axis=-1, norm=None, overwrite_x=False):
 
     This function computes the one-dimensional *n*-point discrete Fourier
     Transform (DFT) with the efficient Fast Fourier Transform (FFT)
-    algorithm [CT].
+    algorithm [1]_.
 
     Parameters
     ----------
@@ -54,8 +54,10 @@ def fft(x, n=None, axis=-1, norm=None, overwrite_x=False):
     FFT (Fast Fourier Transform) refers to a way the discrete Fourier Transform
     (DFT) can be calculated efficiently, by using symmetries in the calculated
     terms. The symmetry is highest when `n` is a power of 2, and the transform
-    is therefore most efficient for these sizes. If you can tolerate
-    zero-padding the input, use `next_fast_len`.
+    is therefore most efficient for these sizes. For poorly factorizable sizes,
+    `scipy.fft` uses Bluestein's algorithm [2]_ and so is never worse than
+    O(`n` log `n`). Further performance improvements may be seen by zero-padding
+    the input using `next_fast_len`.
 
     If ``x`` is a 1d array, then the `fft` is equivalent to ::
 
@@ -88,9 +90,12 @@ def fft(x, n=None, axis=-1, norm=None, overwrite_x=False):
 
     References
     ----------
-    .. [CT] Cooley, James W., and John W. Tukey, 1965, "An algorithm for the
-            machine calculation of complex Fourier series," *Math. Comput.*
-            19: 297-301.
+    .. [1] Cooley, James W., and John W. Tukey, 1965, "An algorithm for the
+           machine calculation of complex Fourier series," *Math. Comput.*
+           19: 297-301.
+    .. [2] Bluestein, L., 1970, "A linear filtering approach to the
+           computation of discrete Fourier transform". *IEEE Transactions on
+           Audio and Electroacoustics.* 18 (4): 451-455.
 
     Examples
     --------

--- a/scipy/fft/_helper.py
+++ b/scipy/fft/_helper.py
@@ -9,8 +9,8 @@ def next_fast_len(target, dtype=None):
     input length. Thus, the transforms are fastest when using composites of the
     prime factors handled by the fft implementation. If there are efficient
     functions for all radices <= `n` then the result is the smallest number `x`
-    >= ``target`` with only prime factors < `n`. (These are also known as
-    `n`-smooth numbers, regular numbers, or Hamming numbers.)
+    >= ``target`` with only prime factors < `n`. (Also known as `n`-smooth
+    numbers)
 
     Parameters
     ----------

--- a/scipy/fft/_pocketfft/basic.py
+++ b/scipy/fft/_pocketfft/basic.py
@@ -165,14 +165,14 @@ def ifft2(x, shape=None, axes=(-2,-1), norm=None, overwrite_x=False):
 
 def rfft2(x, shape=None, axes=(-2,-1), norm=None, overwrite_x=False):
     """
-    2-D dicsrete Fourier transform of a real sequence
+    2-D discrete Fourier transform of a real sequence
     """
     return rfftn(x, shape, axes, norm, overwrite_x)
 
 
 def irfft2(x, shape=None, axes=(-2,-1), norm=None, overwrite_x=False):
     """
-    2-D dicsrete inverse Fourier transform of a real sequence
+    2-D discrete inverse Fourier transform of a real sequence
     """
     return irfftn(x, shape, axes, norm, overwrite_x)
 
@@ -217,7 +217,7 @@ def ifftn(x, shape=None, axes=None, norm=None, overwrite_x=False):
     return pfft.ifftn(tmp, axes, norm, overwrite_x, _default_workers)
 
 def rfftn(x, shape=None, axes=None, norm=None, overwrite_x=False):
-    """Return multi-dimentional discrete Fourier transform of real input"""
+    """Return multi-dimensional discrete Fourier transform of real input"""
     tmp = np.asarray(x)
 
     if not np.isrealobj(tmp):

--- a/scipy/fftpack/basic.py
+++ b/scipy/fftpack/basic.py
@@ -405,7 +405,7 @@ def rfft(x, n=None, axis=-1, overwrite_x=False):
 
     See Also
     --------
-    fft, irfft, numpy.fft.rfft
+    fft, irfft, scipy.fft.rfft
 
     Notes
     -----
@@ -416,8 +416,8 @@ def rfft(x, n=None, axis=-1, overwrite_x=False):
     will be converted to double precision.  Long-double precision inputs are
     not supported.
 
-    To get an output with a complex datatype, consider using the related
-    function `numpy.fft.rfft`.
+    To get an output with a complex datatype, consider using the newer
+    function `scipy.fft.rfft`.
 
     Examples
     --------
@@ -473,7 +473,7 @@ def irfft(x, n=None, axis=-1, overwrite_x=False):
 
     See Also
     --------
-    rfft, ifft, numpy.fft.irfft
+    rfft, ifft, scipy.fft.irfft
 
     Notes
     -----
@@ -498,7 +498,7 @@ def irfft(x, n=None, axis=-1, overwrite_x=False):
     For details on input parameters, see `rfft`.
 
     To process (conjugate-symmetric) frequency-domain data with a complex
-    datatype, consider using the related function `numpy.fft.irfft`.
+    datatype, consider using the newer function `scipy.fft.irfft`.
 
     Examples
     --------


### PR DESCRIPTION
This fixes the typos pointed out by @endolith in #10238 and updates the `scipy.fftpack` documentation to link to `scipy.fft.rfft` instead of the NumPy version.