### PR TITLE
TST, MAINT: adjustments for pytest 5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -154,7 +154,7 @@ before_install:
   - travis_retry pip install --upgrade pip setuptools wheel
   - travis_retry pip install cython
   - if [ -n "$NUMPYSPEC" ]; then travis_retry pip install $NUMPYSPEC; fi
-  - travis_retry pip install --upgrade pytest pytest-xdist pytest-faulthandler mpmath argparse Pillow codecov
+  - travis_retry pip install --upgrade pytest pytest-xdist mpmath argparse Pillow codecov
   - travis_retry pip install gmpy2  # speeds up mpmath (scipy.special tests)
   - travis_retry pip install pybind11
   - |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,7 @@ jobs:
            curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
            python3.6 get-pip.py && \
            pip3 --version && \
-           pip3 install setuptools wheel numpy cython==0.29.2 pybind11 pytest pytest-timeout pytest-xdist pytest-env pytest-faulthandler pytest-cov Pillow mpmath matplotlib --user && \
+           pip3 install setuptools wheel numpy cython==0.29.2 pybind11 pytest pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath matplotlib --user && \
            apt-get -y install gfortran-5 wget && \
            cd .. && \
            mkdir openblas && cd openblas && \
@@ -107,7 +107,7 @@ jobs:
       choco install -y mingw --force --version=6.4.0
     displayName: 'Install 64-bit mingw for 64-bit builds'
     condition: eq(variables['BITS'], 64)
-  - script: python -m pip install numpy cython==0.29.2 pybind11 pytest pytest-timeout pytest-xdist pytest-env pytest-faulthandler pytest-cov Pillow mpmath matplotlib
+  - script: python -m pip install numpy cython==0.29.2 pybind11 pytest pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath matplotlib
     displayName: 'Install dependencies'
   - powershell: |
       If ($(BITS) -eq 32) {

--- a/doc/source/building/windows.rst
+++ b/doc/source/building/windows.rst
@@ -225,7 +225,7 @@ not be used. Attempting to build with the MSYS2 Python will not work correctly.*
 .. code:: shell
 
     /c/Users/<user name>/AppData/Local/Programs/Python/Python36/python.exe \
-         -m pip install numpy>=1.14.0 cython pytest pytest-xdist pytest-faulthandler
+         -m pip install numpy>=1.14.0 cython pytest pytest-xdist
 
 Please note that this is a simpler procedure than what is used for the official binaries.
 **Your binaries will only work with the latest NumPy (v1.14.0dev and higher)**. For

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,6 +7,8 @@ filterwarnings =
     once:.*LAPACK bug 0038.*:RuntimeWarning
     ignore:Using or importing the ABCs from 'collections'*:DeprecationWarning
     ignore:can't resolve package from __spec__ or __package__, falling back on __name__ and __path__:ImportWarning
+    once:the imp module is deprecated in favour of importlib.*:DeprecationWarning
+    once:the imp module is deprecated in favour of importlib.*:PendingDeprecationWarning
 
 env =
     PYTHONHASHSEED=0

--- a/setup.py
+++ b/setup.py
@@ -108,16 +108,9 @@ def get_version_info():
     elif os.path.exists('scipy/version.py'):
         # must be a source distribution, use existing version file
         # load it as a separate module to not load scipy/__init__.py
-        # based on approach described in python-ideas
-        # https://mail.python.org/pipermail/python-ideas/2014-December/030265.html
-        import importlib
-        module_name = 'scipy.version'
-        path = 'scipy/version.py'
-        loader = importlib.machinery.SourceFileLoader(module_name, path)
-        spec = importlib.machinery.ModuleSpec(module_name, loader, origin=path)
-        module = importlib.util.module_from_spec(spec)
-        version = loader.exec_module(module)
-        GIT_REVISION = version.git_revision
+        import runpy
+        ns = runpy.run_path('scipy/version.py')
+        GIT_REVISION = ns['git_revision']
     else:
         GIT_REVISION = "Unknown"
 

--- a/setup.py
+++ b/setup.py
@@ -108,8 +108,15 @@ def get_version_info():
     elif os.path.exists('scipy/version.py'):
         # must be a source distribution, use existing version file
         # load it as a separate module to not load scipy/__init__.py
-        import imp
-        version = imp.load_source('scipy.version', 'scipy/version.py')
+        # based on approach described in python-ideas
+        # https://mail.python.org/pipermail/python-ideas/2014-December/030265.html
+        import importlib
+        module_name = 'scipy.version'
+        path = 'scipy/version.py'
+        loader = importlib.machinery.SourceFileLoader(module_name, path)
+        spec = importlib.machinery.ModuleSpec(module_name, loader, origin=path)
+        module = importlib.util.module_from_spec(spec)
+        version = loader.exec_module(module)
         GIT_REVISION = version.git_revision
     else:
         GIT_REVISION = "Unknown"

--- a/tools/ci/appveyor/requirements.txt
+++ b/tools/ci/appveyor/requirements.txt
@@ -5,7 +5,6 @@ pytest
 pytest-timeout
 pytest-xdist
 pytest-env
-pytest-faulthandler
 Pillow
 mpmath
 matplotlib


### PR DESCRIPTION
Fixes #10376 ; may require some iteration since I can't reproduce locally.

* prefer importlib over imp to avoid deprecation warnings
since master branch no longer has a support burden for Python 2

* pytest-faulthandler can be removed from infrastructure and
docs because it has been merged into pytest core now