### PR TITLE
ENH: _lib: allow new np.random.Generator in check_random_state

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -178,6 +178,7 @@ def check_random_state(seed):
     by np.random.
     If seed is an int, return a new RandomState instance seeded with seed.
     If seed is already a RandomState instance, return it.
+    If seed is a new-style np.random.Generator, return it.
     Otherwise raise ValueError.
     """
     if seed is None or seed is np.random:
@@ -186,6 +187,12 @@ def check_random_state(seed):
         return np.random.RandomState(seed)
     if isinstance(seed, np.random.RandomState):
         return seed
+    try:
+        # Generator is only available in numpy >= 1.17
+        if isinstance(seed, np.random.Generator):
+            return seed
+    except AttributeError:
+        pass
     raise ValueError('%r cannot be used to seed a numpy.random.RandomState'
                      ' instance' % seed)
 

--- a/scipy/_lib/tests/test__util.py
+++ b/scipy/_lib/tests/test__util.py
@@ -56,6 +56,11 @@ def test_check_random_state():
     rsi = check_random_state(None)
     assert_equal(type(rsi), np.random.RandomState)
     assert_raises(ValueError, check_random_state, 'a')
+    if hasattr(np.random, 'Generator'):
+        # np.random.Generator is only available in numpy >= 1.17
+        rg = np.random.Generator(np.random.PCG64())
+        rsi = check_random_state(rg)
+        assert_equal(type(rsi), np.random.Generator)
 
 
 class TestMapWrapper(object):


### PR DESCRIPTION
Recognize and pass through new-style `np.random.Generator` instances with scipy random generation in `_lib._util.check_random_state`.

Defaults are not changed.