### PR TITLE
BUG: sparse: set writeability to be forward-compatible with numpy>=1.17

### DIFF
--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -13,7 +13,7 @@ import numpy as np
 
 from scipy._lib.six import xrange, zip
 from .base import spmatrix, isspmatrix
-from ._index import IndexMixin, INT_TYPES
+from ._index import IndexMixin, INT_TYPES, _broadcast_arrays
 from .sputils import (getdtype, isshape, isscalarlike, upcast_scalar,
                       get_index_dtype, check_shape, check_reshape_kwargs,
                       asmatrix)
@@ -267,7 +267,7 @@ class lil_matrix(spmatrix, IndexMixin):
 
     def _get_columnXarray(self, row, col):
         # outer indexing
-        row, col = np.broadcast_arrays(row[:,None], col)
+        row, col = _broadcast_arrays(row[:,None], col)
         return self._get_arrayXarray(row, col)
 
     def _get_arrayXarray(self, row, col):
@@ -330,7 +330,7 @@ class lil_matrix(spmatrix, IndexMixin):
             return
         # Fall back to densifying x
         x = np.asarray(x.toarray(), dtype=self.dtype)
-        x, _ = np.broadcast_arrays(x, row)
+        x, _ = _broadcast_arrays(x, row)
         self._set_arrayXarray(row, col, x)
 
     def __setitem__(self, key, x):


### PR DESCRIPTION
Numpy >= 1.17.0 transitions broadcast_arrays to return
read-only arrays. Set writeability explicitly to avoid warnings.
Retain the old writeability rules, as our Cython code assumes
the old behavior.

As a future cleanup, we could change the LIL Cython code to use
read-only arrays where appropriate --- if that works. Hence, here's
a safer quick fix to get the CI back to green.