### PR TITLE
BUG: Fixes gh-7491, pdf at x=0 of fisk/burr/burr12/f distributions.

### DIFF
--- a/doc/source/tutorial/stats/continuous.rst
+++ b/doc/source/tutorial/stats/continuous.rst
@@ -215,6 +215,7 @@ Continuous Distributions in `scipy.stats`
    continuous_betaprime
    continuous_bradford
    continuous_burr
+   continuous_burr12
    continuous_cauchy
    continuous_chi
    continuous_chi2

--- a/doc/source/tutorial/stats/continuous_burr12.rst
+++ b/doc/source/tutorial/stats/continuous_burr12.rst
@@ -1,0 +1,28 @@
+
+.. _continuous-burr12:
+
+Burr12 Distribution
+===================
+
+There are two shape parameters :math:`c,d > 0` and the support is :math:`x \in [0,\infty)`.
+The Burr12 distibution is also known as the Singh-Maddala distibution.
+
+
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*}
+    f\left(x;c,d\right) & = & {cd} \frac{x^{c-1}} {\left(1+x^{c}\right)^{d+1}} \\
+    F\left(x;c,d\right) & = & 1 - \left(1+x^{c}\right)^{-d}\\
+    G\left(q;c,d\right) & = & \left((1-q)^{-1/d}-1\right)^{-1/c}\\
+    S\left(x;c,d\right) & = & \left(1+x^{c}\right)^{-d}\\
+    \mu & = & d \,  B\left(d-\frac{1}{c}, 1+\frac{1}{c}\right)\\
+    \mu_{n} & = & d \, B\left(d-\frac{n}{c}, 1+\frac{n}{c}\right)\\
+    m_{d} & = & \left(\frac{c-1}{c d + 1}\right)^{1/c} \,\text{if }\quad c>1 \text{, otherwise }\quad 0\\
+    m_{n} & = & \left(2^{1/d}-1\right)^{-1/c}
+    \end{eqnarray*}
+
+where :math:`B(a, b) = \frac{\Gamma(a)\Gamma(b)}{\Gamma(a+b)}` is the Beta function.
+
+Implementation: `scipy.stats.burr12`

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -758,14 +758,18 @@ class burr_gen(rv_continuous):
 
     .. math::
 
-        f(x, c, d) = c d x^{-c-1} (1+x^{-c})^{-d-1}
+        f(x, c, d) = c d x^{-c - 1} / (1 + x^{-c})^{d + 1}
 
     for :math:`x >= 0` and :math:`c, d > 0`.
 
     `burr` takes :math:`c` and :math:`d` as shape parameters.
 
     This is the PDF corresponding to the third CDF given in Burr's list;
-    specifically, it is equation (11) in Burr's paper [1]_.
+    specifically, it is equation (11) in Burr's paper [1]_. The distribution
+    is also commonly referred to as the Dagum distribution [2]_. If the
+    parameter :math:`c < 1` then the mean of the distribution does not
+    exist and if :math:`c < 2` the variance does not exist [2]_.
+    The PDF is finite at the left endpoint :math:`x = 0` if :math:`c * d >= 1`.
 
     %(after_notes)s
 
@@ -773,25 +777,82 @@ class burr_gen(rv_continuous):
     ----------
     .. [1] Burr, I. W. "Cumulative frequency functions", Annals of
        Mathematical Statistics, 13(2), pp 215-232 (1942).
+    .. [2] https://en.wikipedia.org/wiki/Dagum_distribution
+    .. [3] Kleiber, Christian. "A guide to the Dagum distributions."
+       Modeling Income Distributions and Lorenz Curves  pp 97-117 (2008).
 
     %(example)s
 
     """
-    _support_mask = rv_continuous._open_support_mask
+    # Do not set _support_mask to rv_continuous._open_support_mask
+    # Whether the left-hand endpoint is suitable for pdf evaluation is dependent
+    # on the values of c and d: if c*d >= 1, the pdf is finite, otherwise infinite.
 
     def _pdf(self, x, c, d):
         # burr.pdf(x, c, d) = c * d * x**(-c-1) * (1+x**(-c))**(-d-1)
-        return c * d * (x**(-c - 1.0)) * ((1 + x**(-c))**(-d - 1.0))
+        output = _lazywhere(x == 0, [x, c, d],
+                   lambda x_, c_, d_: c_ * d_ * (x_**(c_*d_-1)) / (1 + x_**c_),
+                   f2 = lambda x_, c_, d_: (c_ * d_ * (x_ ** (-c_ - 1.0)) /
+                                            ((1 + x_ ** (-c_)) ** (d_ + 1.0))))
+        if output.ndim == 0:
+            return output[()]
+        return output
+
+    def _logpdf(self, x, c, d):
+        output = _lazywhere(
+            x == 0, [x, c, d],
+            lambda x_, c_, d_: (np.log(c_) + np.log(d_) + sc.xlogy(c_*d_ - 1, x_)
+                                - (d_+1) * sc.log1p(x_**(c_))),
+            f2 = lambda x_, c_, d_: (np.log(c_) + np.log(d_)
+                                     + sc.xlogy(-c_ - 1, x_)
+                                     - sc.xlog1py(d_+1, x_**(-c_))))
+        if output.ndim == 0:
+            return output[()]
+        return output
 
     def _cdf(self, x, c, d):
         return (1 + x**(-c))**(-d)
 
+    def _logcdf(self, x, c, d):
+        return sc.log1p(x**(-c)) * (-d)
+
+    def _sf(self, x, c, d):
+        return np.exp(self._logsf(x, c, d))
+
+    def _logsf(self, x, c, d):
+        return np.log1p(- (1 + x**(-c))**(-d))
+
     def _ppf(self, q, c, d):
         return (q**(-1.0/d) - 1)**(-1.0/c)
 
+    def _stats(self, c, d):
+        nc = np.arange(1, 5).reshape(4,1) / c
+        #ek is the kth raw moment, e1 is the mean e2-e1**2 variance etc.
+        e1, e2, e3, e4 = sc.beta(d + nc, 1. - nc) * d
+        mu = np.where(c > 1.0, e1, np.nan)
+        mu2_if_c = e2 - mu**2
+        mu2 = np.where(c > 2.0, mu2_if_c, np.nan)
+        g1 = _lazywhere(
+            c > 3.0,
+            (c, e1, e2, e3, mu2_if_c),
+            lambda c, e1, e2, e3, mu2_if_c: (e3 - 3*e2*e1 + 2*e1**3) / np.sqrt((mu2_if_c)**3),
+            fillvalue=np.nan)
+        g2 = _lazywhere(
+            c > 4.0,
+            (c, e1, e2, e3, e4, mu2_if_c),
+            lambda c, e1, e2, e3, e4, mu2_if_c: (
+                ((e4 - 4*e3*e1 + 6*e2*e1**2 - 3*e1**4) / mu2_if_c**2) - 3),
+            fillvalue=np.nan)
+        return mu, mu2, g1, g2
+
     def _munp(self, n, c, d):
-        nc = 1. * n / c
-        return d * sc.beta(1.0 - nc, d + nc)
+        def __munp(n, c, d):
+            nc = 1. * n / c
+            return d * sc.beta(1.0 - nc, d + nc)
+        n, c, d = np.asarray(n), np.asarray(c), np.asarray(d)
+        return _lazywhere((c > n) & (n == n) & (d == d), (c, d, n),
+                          lambda c, d, n: __munp(n, c, d),
+                          np.nan)
 
 
 burr = burr_gen(a=0.0, name='burr')
@@ -813,7 +874,7 @@ class burr12_gen(rv_continuous):
 
     .. math::
 
-        f(x, c, d) = c d x^{c-1} (1+x^c)^{-d-1}
+        f(x, c, d) = c d x^{c-1} / (1 + x^c)^{d + 1}
 
     for :math:`x >= 0` and :math:`c, d > 0`.
 
@@ -835,11 +896,12 @@ class burr12_gen(rv_continuous):
 
     .. [2] https://www.itl.nist.gov/div898/software/dataplot/refman2/auxillar/b12pdf.htm
 
+    .. [3] "Burr distribution",
+       https://en.wikipedia.org/wiki/Burr_distribution
+
     %(example)s
 
     """
-    _support_mask = rv_continuous._open_support_mask
-
     def _pdf(self, x, c, d):
         # burr12.pdf(x, c, d) = c * d * x**(c-1) * (1+x**(c))**(-d-1)
         return np.exp(self._logpdf(x, c, d))
@@ -905,16 +967,32 @@ class fisk_gen(burr_gen):
     """
     def _pdf(self, x, c):
         # fisk.pdf(x, c) = c * x**(-c-1) * (1 + x**(-c))**(-2)
-        return burr_gen._pdf(self, x, c, 1.0)
+        return burr._pdf(x, c, 1.0)
 
     def _cdf(self, x, c):
-        return burr_gen._cdf(self, x, c, 1.0)
+        return burr._cdf(x, c, 1.0)
+
+    def _sf(self, x, c):
+        return burr._sf(x, c, 1.0)
+
+    def _logpdf(self, x, c):
+        # fisk.pdf(x, c) = c * x**(-c-1) * (1 + x**(-c))**(-2)
+        return burr._logpdf(x, c, 1.0)
+
+    def _logcdf(self, x, c):
+        return burr._logcdf(x, c, 1.0)
+
+    def _logsf(self, x, c):
+        return burr._logsf(x, c, 1.0)
 
     def _ppf(self, x, c):
-        return burr_gen._ppf(self, x, c, 1.0)
+        return burr._ppf(x, c, 1.0)
 
     def _munp(self, n, c):
-        return burr_gen._munp(self, n, c, 1.0)
+        return burr._munp(n, c, 1.0)
+
+    def _stats(self, c):
+        return burr._stats(c, 1.0)
 
     def _entropy(self, c):
         return 2 - np.log(c)
@@ -1678,7 +1756,7 @@ class f_gen(rv_continuous):
     def _logpdf(self, x, dfn, dfd):
         n = 1.0 * dfn
         m = 1.0 * dfd
-        lPx = m/2 * np.log(m) + n/2 * np.log(n) + (n/2 - 1) * np.log(x)
+        lPx = m/2 * np.log(m) + n/2 * np.log(n) + sc.xlogy(n/2 - 1, x)
         lPx -= ((n+m)/2) * np.log(m + n*x) + sc.betaln(n/2, m/2)
         return lPx
 


### PR DESCRIPTION
Replaces gh-9983 (rebase had trouble merging with gh-10154 --- this PR applies the same modifications manually to current master.)

Enable computation of `pdf`, `logpdf` at left-hand end points of `fisk`, `burr`,
`burr12` and `f` distrbutions.  Fixes gh-7491 and half of gh-9544.
Incorporate gh-9978 from @rlucas7 to address gh-9544.
Updated docstring of `stats.burr` distribution.
Added tutorial for `stats.burr12`.
Removed an ignored implementation of `fisk._stats()`.
In `stats.burr.{pdf,logpdf}` replaced two separate long code blocks with a simpler `_lazywhere`.
Explicitly handle `c<=n` in `stats.burr._munp()`.
Added consistency  checking of `pdf` and `logpdf` to `stats.test_continuous_basic.py`.
Added a filter for `stats.recipinvgauss` in `check_pdf_logpdf()`.
Added any finite distribution endpoints to list of x-values checked in
`{check_pdf_logpdf, check_sf_logsf, check_cdf_logcdf}`.
Added another test case to `test_burr_stats_9544()`.