### PR TITLE
Remove warning about output shape of zoom

### DIFF
--- a/scipy/ndimage/interpolation.py
+++ b/scipy/ndimage/interpolation.py
@@ -602,14 +602,6 @@ def zoom(input, zoom, output=None, order=3, mode='constant', cval=0.0,
     output_shape = tuple(
             [int(round(ii * jj)) for ii, jj in zip(input.shape, zoom)])
 
-    output_shape_old = tuple(
-            [int(ii * jj) for ii, jj in zip(input.shape, zoom)])
-    if output_shape != output_shape_old:
-        warnings.warn(
-                "From scipy 0.13.0, the output shape of zoom() is calculated "
-                "with round() instead of int() - for these inputs the size of "
-                "the returned array has changed.", UserWarning)
-
     zoom_div = numpy.array(output_shape, float) - 1
     # Zooming to infinite values is unpredictable, so just choose
     # zoom factor 1 instead

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -2152,10 +2152,7 @@ class TestNdimage:
     def test_zoom_output_shape_roundoff(self):
         arr = numpy.zeros((3, 11, 25))
         zoom = (4.0 / 3, 15.0 / 11, 29.0 / 25)
-        with suppress_warnings() as sup:
-            sup.filter(UserWarning,
-                       "From scipy 0.13.0, the output shape of zoom.. is calculated with round.. instead of int")
-            out = ndimage.zoom(arr, zoom)
+        out = ndimage.zoom(arr, zoom)
         assert_array_equal(out.shape, (4, 15, 29))
 
     def test_rotate01(self):


### PR DESCRIPTION
This warning dates from SciPy 0.13 and is probably not useful to anyone at this point.

Fixes #10395