### PR TITLE
ENH: Add check_finite to sp.linalg.norm

### DIFF
--- a/scipy/linalg/misc.py
+++ b/scipy/linalg/misc.py
@@ -16,7 +16,7 @@ class LinAlgWarning(RuntimeWarning):
     pass
 
 
-def norm(a, ord=None, axis=None, keepdims=False):
+def norm(a, ord=None, axis=None, keepdims=False, check_finite=True):
     """
     Matrix or vector norm.
 
@@ -41,6 +41,10 @@ def norm(a, ord=None, axis=None, keepdims=False):
         If this is set to True, the axes which are normed over are left in the
         result as dimensions with size one.  With this option the result will
         broadcast correctly against the original `a`.
+    check_finite : bool, optional
+        Whether to check that the input matrix contains only finite numbers.
+        Disabling may give a performance gain, but may result in problems
+        (crashes, non-termination) if the inputs do contain infinities or NaNs.
 
     Returns
     -------
@@ -134,7 +138,10 @@ def norm(a, ord=None, axis=None, keepdims=False):
 
     """
     # Differs from numpy only in non-finite handling and the use of blas.
-    a = np.asarray_chkfinite(a)
+    if check_finite:
+        a = np.asarray_chkfinite(a)
+    else:
+        a = np.asarray(a)
 
     # Only use optimized norms if axis and keepdims are not specified.
     if a.dtype.char in 'fdFD' and axis is None and not keepdims:


### PR DESCRIPTION
Result of this message and follow-up by @rgommers : https://mail.python.org/pipermail/scipy-dev/2019-July/023602.html

In my use-case (relatively huge, complex arrays), `sp.linalg.norm` was not faster than `np.linalg.norm`, so I tried the numba approach. Given Ralfs answer in the email made me look again. It turns out that calling `get_blas_funcs` results in the same speed as the numba version, but the `asarray_ckfinite` adds a heavy overhead.

This PR adds the possibility to skip the non-finite handling, as other functions in scipy do.

Example:

```py
import numba
import numpy as np
import scipy as sp

@numba.njit(nogil=True, fastmath=True, cache=True)
def norm(x):
    """Jitted version of np.linalg.norm(x, ord=None)."""
    return np.linalg.norm(x)

# A biggish, random, complex array
a = np.random.rand(int(1e8))+1j*np.random.rand(int(1e8))

# Timing

print("1. numba(np.linalg.norm) : ", end="")
%timeit norm(a)

print("2. scipy get_blas_funcs  : ", end="")
%timeit sp.linalg.get_blas_funcs('nrm2', dtype=a.dtype)(a)

print("3. np.linalg.norm        : ", end="")
%timeit np.linalg.norm(a)

print("4a sp.linalg.norm        : ", end="")
%timeit sp.linalg.norm(a)

print("4b \> check_finite=False : ", end="")
%timeit sp.linalg.norm(a, check_finite=False)

# Ensure they are the same
res_numba = norm(a)
res_blas = sp.linalg.get_blas_funcs('nrm2', dtype=a.dtype)(a)
res_numpy = np.linalg.norm(a)
res_scipy = sp.linalg.norm(a)
res_scipy2 = sp.linalg.norm(a, check_finite=False)

print("Tests: ",
      np.allclose(res_numba, res_numpy, atol=0), 
      np.allclose(res_blas, res_numpy, atol=0),
      np.allclose(res_scipy, res_numpy, atol=0),
      np.allclose(res_scipy2, res_numpy, atol=0))
```

Output:
```
1. numba(np.linalg.norm) : 103 ms ± 157 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
2. scipy get_blas_funcs  : 104 ms ± 370 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
3. np.linalg.norm        : 219 ms ± 2.07 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
4a sp.linalg.norm        : 273 ms ± 2.99 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
4b \> check_finite=False : 104 ms ± 447 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
Tests:  True True True True
```