### PR TITLE
CI: uninstall nose on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -174,6 +174,7 @@ before_install:
         # XXX: replace with asv>=0.4 when 0.4 is released
         travis_retry pip install git+https://github.com/airspeed-velocity/asv.git@00c23497463ee63051e886c41a63a254c24f41c5
     fi
+  - pip uninstall -y nose
   - python -V
   - ccache -s
   - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -171,8 +171,7 @@ before_install:
     fi
   - |
     if [ "${ASV_CHECK}" == "1" ]; then
-        # XXX: replace with asv>=0.4 when 0.4 is released
-        travis_retry pip install git+https://github.com/airspeed-velocity/asv.git@00c23497463ee63051e886c41a63a254c24f41c5
+        travis_retry pip install "asv>=0.4.1"
     fi
   - pip uninstall -y nose
   - python -V


### PR DESCRIPTION
The test suite is not supposed to depend on nose, so we should check
that.