### PR TITLE
TST: optimize: test should use assert_allclose for fp comparisons

### DIFF
--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -791,7 +791,7 @@ class TestCurveFit(object):
                                      xdata=xdata,
                                      ydata=0,
                                      method=method)
-            assert_array_equal(pcov0, pcov1)
+            assert_allclose(pcov0, pcov1, rtol=1e-12)
 
 
 class TestFixedPoint(object):


### PR DESCRIPTION
Fixes failure on scipy-wheels on OSX.