### PR TITLE
ENH: special: make `ellipk` a ufunc

### DIFF
--- a/scipy/special/_ellipk.pxd
+++ b/scipy/special/_ellipk.pxd
@@ -1,0 +1,5 @@
+from ._cephes cimport ellpk
+
+
+cdef inline double ellipk(double m) nogil:
+    return ellpk(1.0 - m)

--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -1402,6 +1402,52 @@ add_newdoc("ellipkm1",
            http://www.netlib.org/cephes/
     """)
 
+add_newdoc("ellipk",
+    r"""
+    ellipk(m)
+
+    Complete elliptic integral of the first kind.
+
+    This function is defined as
+
+    .. math:: K(m) = \int_0^{\pi/2} [1 - m \sin(t)^2]^{-1/2} dt
+
+    Parameters
+    ----------
+    m : array_like
+        The parameter of the elliptic integral.
+
+    Returns
+    -------
+    K : array_like
+        Value of the elliptic integral.
+
+    Notes
+    -----
+    For more precision around point m = 1, use `ellipkm1`, which this
+    function calls.
+
+    The parameterization in terms of :math:`m` follows that of section
+    17.2 in [1]_. Other parameterizations in terms of the
+    complementary parameter :math:`1 - m`, modular angle
+    :math:`\sin^2(\alpha) = m`, or modulus :math:`k^2 = m` are also
+    used, so be careful that you choose the correct parameter.
+
+    See Also
+    --------
+    ellipkm1 : Complete elliptic integral of the first kind around m = 1
+    ellipkinc : Incomplete elliptic integral of the first kind
+    ellipe : Complete elliptic integral of the second kind
+    ellipeinc : Incomplete elliptic integral of the second kind
+
+    References
+    ----------
+    .. [1] Milton Abramowitz and Irene A. Stegun, eds.
+           Handbook of Mathematical Functions with Formulas,
+           Graphs, and Mathematical Tables. New York: Dover, 1972.
+
+    """)
+
 add_newdoc("ellipkinc",
     r"""
     ellipkinc(phi, m)

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -12,7 +12,7 @@ from numpy import (pi, asarray, floor, isscalar, iscomplex, real,
                    imag, sqrt, where, mgrid, sin, place, issubdtype,
                    extract, inexact, nan, zeros, sinc)
 from . import _ufuncs as ufuncs
-from ._ufuncs import (ellipkm1, mathieu_a, mathieu_b, iv, jv, gamma,
+from ._ufuncs import (mathieu_a, mathieu_b, iv, jv, gamma,
                       psi, _zeta, hankel1, hankel2, yv, kv, ndtri,
                       poch, binom, hyp0f1)
 from . import specfun
@@ -23,7 +23,7 @@ from ._comb import _comb_int
 __all__ = ['ai_zeros', 'assoc_laguerre', 'bei_zeros', 'beip_zeros',
            'ber_zeros', 'bernoulli', 'berp_zeros',
            'bessel_diff_formula', 'bi_zeros', 'clpmn', 'comb',
-           'digamma', 'diric', 'ellipk', 'erf_zeros', 'erfcinv',
+           'digamma', 'diric', 'erf_zeros', 'erfcinv',
            'erfinv', 'euler', 'factorial', 'factorialk', 'factorial2',
            'fresnel_zeros', 'fresnelc_zeros', 'fresnels_zeros',
            'gamma', 'h1vp', 'h2vp', 'hankel1', 'hankel2', 'hyp0f1',
@@ -858,7 +858,7 @@ def erf_zeros(nt):
     array([1.45061616+1.880943j])
 
     Check that erf is (close to) zero for the value returned by erf_zeros
-    
+
     >>> special.erf(special.erf_zeros(1))
     array([4.95159469e-14-1.16407394e-16j])
 
@@ -1446,7 +1446,7 @@ def ai_zeros(nt):
         Values of Ai(x) evaluated at first `nt` zeros of Ai'(x)
     aip : ndarray
         Values of Ai'(x) evaluated at first `nt` zeros of Ai(x)
-        
+
     Examples
     --------
     >>> from scipy import special
@@ -1459,7 +1459,7 @@ def ai_zeros(nt):
     array([ 0.53565666, -0.41901548,  0.38040647])
     >>> aip
     array([ 0.70121082, -0.80311137,  0.86520403])
-    
+
     References
     ----------
     .. [1] Zhang, Shanjie and Jin, Jianming. "Computation of Special
@@ -1497,7 +1497,7 @@ def bi_zeros(nt):
         Values of Bi(x) evaluated at first `nt` zeros of Bi'(x)
     bip : ndarray
         Values of Bi'(x) evaluated at first `nt` zeros of Bi(x)
-    
+
     Examples
     --------
     >>> from scipy import special
@@ -1510,7 +1510,7 @@ def bi_zeros(nt):
     array([-0.45494438,  0.39652284, -0.36796916])
     >>> bip
     array([ 0.60195789, -0.76031014,  0.83699101])
-    
+
     References
     ----------
     .. [1] Zhang, Shanjie and Jin, Jianming. "Computation of Special
@@ -1870,51 +1870,6 @@ def obl_cv_seq(m, n, c):
     return specfun.segv(m, n, c, -1)[1][:maxL]
 
 
-def ellipk(m):
-    r"""Complete elliptic integral of the first kind.
-
-    This function is defined as
-
-    .. math:: K(m) = \int_0^{\pi/2} [1 - m \sin(t)^2]^{-1/2} dt
-
-    Parameters
-    ----------
-    m : array_like
-        The parameter of the elliptic integral.
-
-    Returns
-    -------
-    K : array_like
-        Value of the elliptic integral.
-
-    Notes
-    -----
-    For more precision around point m = 1, use `ellipkm1`, which this
-    function calls.
-
-    The parameterization in terms of :math:`m` follows that of section
-    17.2 in [1]_. Other parameterizations in terms of the
-    complementary parameter :math:`1 - m`, modular angle
-    :math:`\sin^2(\alpha) = m`, or modulus :math:`k^2 = m` are also
-    used, so be careful that you choose the correct parameter.
-
-    See Also
-    --------
-    ellipkm1 : Complete elliptic integral of the first kind around m = 1
-    ellipkinc : Incomplete elliptic integral of the first kind
-    ellipe : Complete elliptic integral of the second kind
-    ellipeinc : Incomplete elliptic integral of the second kind
-
-    References
-    ----------
-    .. [1] Milton Abramowitz and Irene A. Stegun, eds.
-           Handbook of Mathematical Functions with Formulas,
-           Graphs, and Mathematical Tables. New York: Dover, 1972.
-
-    """
-    return ellipkm1(1 - asarray(m))
-
-
 def comb(N, k, exact=False, repetition=False):
     """The number of combinations of N things taken k at a time.
 
@@ -1945,7 +1900,7 @@ def comb(N, k, exact=False, repetition=False):
     Notes
     -----
     - Array arguments accepted only for exact=False case.
-    - If N < 0, or k < 0, then 0 is returned.    
+    - If N < 0, or k < 0, then 0 is returned.
     - If k > N and repetition=False, then 0 is returned.
 
     Examples
@@ -2302,4 +2257,3 @@ def zeta(x, q=None, out=None):
     if q is None:
         q = 1
     return _zeta(x, q, out)
-

--- a/scipy/special/functions.json
+++ b/scipy/special/functions.json
@@ -339,6 +339,11 @@
             "ellpk": "d->d"
         }
     },
+    "ellipk": {
+	"_ellipk.pxd": {
+	    "ellipk": "d->d"
+	}
+    },
     "entr": {
         "_convex_analysis.pxd": {
             "entr": "d->d"

--- a/scipy/special/tests/test_cython_special.py
+++ b/scipy/special/tests/test_cython_special.py
@@ -81,6 +81,7 @@ PARAMS = [
     (special.ellipj, cython_special._ellipj_pywrap, ('dd',), None),
     (special.ellipkinc, cython_special.ellipkinc, ('dd',), None),
     (special.ellipkm1, cython_special.ellipkm1, ('d',), None),
+    (special.ellipk, cython_special.ellipk, ('d',), None),
     (special.entr, cython_special.entr, ('d',), None),
     (special.erf, cython_special.erf, ('d', 'D'), None),
     (special.erfc, cython_special.erfc, ('d', 'D'), None),


### PR DESCRIPTION
No algorithmic changes are made; the main point of the change is that
it causes `ellipk` to show up in `cython_special`.