### PR TITLE
MAINT: ndimage: malloc fail check 

### DIFF
--- a/scipy/ndimage/src/ni_morphology.c
+++ b/scipy/ndimage/src/ni_morphology.c
@@ -623,6 +623,10 @@ int NI_DistanceTransformBruteForce(PyArrayObject* input, int metric,
             temp->index = jj;
             temp->coordinates = malloc(PyArray_NDIM(input) *
                                        sizeof(npy_intp));
+            if (!temp->coordinates) {
+                PyErr_NoMemory();
+                goto exit;
+            }
             for (kk = 0; kk < PyArray_NDIM(input); kk++) {
                 temp->coordinates[kk] = ii.coordinates[kk];
             }

--- a/scipy/ndimage/src/ni_morphology.c
+++ b/scipy/ndimage/src/ni_morphology.c
@@ -625,6 +625,7 @@ int NI_DistanceTransformBruteForce(PyArrayObject* input, int metric,
                                        sizeof(npy_intp));
             if (!temp->coordinates) {
                 PyErr_NoMemory();
+                free(temp);
                 goto exit;
             }
             for (kk = 0; kk < PyArray_NDIM(input); kk++) {

--- a/scipy/ndimage/src/ni_morphology.c
+++ b/scipy/ndimage/src/ni_morphology.c
@@ -625,7 +625,6 @@ int NI_DistanceTransformBruteForce(PyArrayObject* input, int metric,
                                        sizeof(npy_intp));
             if (!temp->coordinates) {
                 PyErr_NoMemory();
-                free(temp);
                 goto exit;
             }
             for (kk = 0; kk < PyArray_NDIM(input); kk++) {


### PR DESCRIPTION
Added malloc checks for returning null based on issue #9999 for the `ni_morphology.c`.