### PR TITLE
BLD: Divert output from test compiles into a temporary directory

### DIFF
--- a/scipy/fft/_pocketfft/setup.py
+++ b/scipy/fft/_pocketfft/setup.py
@@ -13,7 +13,7 @@ def try_compile(compiler, code=None, flags=[], ext='.cpp'):
             f.write(code)
 
         try:
-            compiler.compile([fname], extra_postargs=flags)
+            compiler.compile([fname], output_dir=temp_dir, extra_postargs=flags)
         except CompileError:
             return False
     return True


### PR DESCRIPTION
Fixes #10445

Haven't actually reproduced the issue but should be visible from CI logs.