### PR TITLE
ENH: Extend find_peaks_cwt to take numbers and iterables for widths argument.

### DIFF
--- a/scipy/signal/_peak_finding.py
+++ b/scipy/signal/_peak_finding.py
@@ -1206,8 +1206,8 @@ def find_peaks_cwt(vector, widths, wavelet=None, max_distances=None,
         1-D array in which to find the peaks.
     widths : float or sequence
         Single width or 1-D array-like of widths to use for calculating
-        the CWT matrix. In general,
-        this range should cover the expected width of peaks of interest.
+        the CWT matrix. In general, this range should cover the expected
+        width of peaks of interest.
     wavelet : callable, optional
         Should take two parameters and return a 1-D array to convolve
         with `vector`. The first parameter determines the number of points
@@ -1281,7 +1281,7 @@ def find_peaks_cwt(vector, widths, wavelet=None, max_distances=None,
     ([32], array([ 1.6]), array([ 0.9995736]))
 
     """
-    widths = np.asarray(widths)
+    widths = np.array(widths, copy=False, ndmin=1)
 
     if gap_thresh is None:
         gap_thresh = np.ceil(widths[0])
@@ -1290,7 +1290,6 @@ def find_peaks_cwt(vector, widths, wavelet=None, max_distances=None,
     if wavelet is None:
         wavelet = ricker
 
-    widths = np.array(widths, copy=False, ndmin=1)
 
     cwt_dat = cwt(vector, wavelet, widths)
     ridge_lines = _identify_ridge_lines(cwt_dat, max_distances, gap_thresh)

--- a/scipy/signal/_peak_finding.py
+++ b/scipy/signal/_peak_finding.py
@@ -1290,7 +1290,6 @@ def find_peaks_cwt(vector, widths, wavelet=None, max_distances=None,
     if wavelet is None:
         wavelet = ricker
 
-
     cwt_dat = cwt(vector, wavelet, widths)
     ridge_lines = _identify_ridge_lines(cwt_dat, max_distances, gap_thresh)
     filtered = _filter_ridge_lines(cwt_dat, ridge_lines, min_length=min_length,

--- a/scipy/signal/_peak_finding.py
+++ b/scipy/signal/_peak_finding.py
@@ -1204,8 +1204,9 @@ def find_peaks_cwt(vector, widths, wavelet=None, max_distances=None,
     ----------
     vector : ndarray
         1-D array in which to find the peaks.
-    widths : sequence
-        1-D array of widths to use for calculating the CWT matrix. In general,
+    widths : float or sequence
+        Single width or 1-D array-like of widths to use for calculating
+        the CWT matrix. In general,
         this range should cover the expected width of peaks of interest.
     wavelet : callable, optional
         Should take two parameters and return a 1-D array to convolve
@@ -1288,6 +1289,8 @@ def find_peaks_cwt(vector, widths, wavelet=None, max_distances=None,
         max_distances = widths / 4.0
     if wavelet is None:
         wavelet = ricker
+
+    widths = np.array(widths, copy=False, ndmin=1)
 
     cwt_dat = cwt(vector, wavelet, widths)
     ridge_lines = _identify_ridge_lines(cwt_dat, max_distances, gap_thresh)

--- a/scipy/signal/tests/test_peak_finding.py
+++ b/scipy/signal/tests/test_peak_finding.py
@@ -855,7 +855,3 @@ class TestFindPeaksCwt(object):
                                     min_length=None)
         np.testing.assert_array_equal(found_locs, act_locs,
                              "Found maximum locations did not equal those expected")
-
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/scipy/signal/tests/test_peak_finding.py
+++ b/scipy/signal/tests/test_peak_finding.py
@@ -822,3 +822,40 @@ class TestFindPeaksCwt(object):
         widths = np.arange(10, 50)
         found_locs = find_peaks_cwt(test_data, widths, min_snr=5, noise_perc=30)
         np.testing.assert_equal(len(found_locs), 0)
+
+    def test_find_peaks_with_different_width_dtypes(self):
+        """
+        Verify that the `width` argument
+        in `find_peaks_cwt` can take numbers
+        and iterables.
+        """
+        xs = np.arange(0, np.pi, 0.05)
+        test_data = np.sin(xs)
+        widths = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        found_locs = find_peaks_cwt(test_data, widths)
+        np.testing.assert_equal(found_locs, [32])
+
+        widths = (1, 2, 3, 4, 5, 6, 7, 8, 9)
+        found_locs = find_peaks_cwt(test_data, widths)
+        np.testing.assert_equal(found_locs, [32])
+
+        noise_amp = 1.0
+        num_points = 100
+        np.random.seed(181819141)
+        test_data = (np.random.rand(num_points) - 0.5) * (2 * noise_amp)
+        widths = [x for x in range(10, 50)]
+        found_locs = find_peaks_cwt(test_data, widths, min_snr=5, noise_perc=30)
+        np.testing.assert_equal(len(found_locs), 0)
+
+        sigmas = [5.0, 3.0, 10.0, 20.0, 10.0, 50.0]
+        num_points = 500
+        test_data, act_locs = _gen_gaussians_even(sigmas, num_points)
+        widths = [x / 10.0 for x in range(1, int(10 * max(sigmas)), 10)]
+        found_locs = find_peaks_cwt(test_data, widths, gap_thresh=2, min_snr=0,
+                                    min_length=None)
+        np.testing.assert_array_equal(found_locs, act_locs,
+                             "Found maximum locations did not equal those expected")
+
+
+if __name__ == "__main__":
+    run_module_suite()


### PR DESCRIPTION
Added regression test for iterable and tuple dtypes passed into the `width` argument of `find_peaks_cwt`.

Supersedes and closes gh-5304