### PR TITLE
BUG: special: fix values of `hyperu` for negative `x`

### DIFF
--- a/scipy/special/_hypergeometric.pxd
+++ b/scipy/special/_hypergeometric.pxd
@@ -1,0 +1,28 @@
+from . cimport sf_error
+
+cdef extern from "numpy/npy_math.h":
+    double NPY_NAN
+    double NPY_INFINITY
+
+cdef extern from 'specfun_wrappers.h':
+    double hypU_wrap(double, double, double) nogil
+
+cdef extern from 'c_misc/misc.h':
+    double poch(double, double) nogil
+
+
+cdef inline double hyperu(double a, double b, double x) nogil:
+    if x < 0.0:
+        sf_error.error("hyperu", sf_error.DOMAIN, NULL)
+        return NPY_NAN
+
+    if x == 0.0:
+        if b > 1.0:
+            # DMLF 13.2.16-18
+            sf_error.error("hyperu", sf_error.SINGULAR, NULL)
+            return NPY_INFINITY
+        else:
+            # DLMF 13.2.14-15 and 13.2.19-21
+            return poch(1.0 - b + a, -a)
+
+    return hypU_wrap(a, b, x)

--- a/scipy/special/functions.json
+++ b/scipy/special/functions.json
@@ -660,8 +660,8 @@
         }
     },
     "hyperu": {
-        "specfun_wrappers.h": {
-            "hypU_wrap": "ddd->d"
+        "_hypergeometric.pxd": {
+            "hyperu": "ddd->d"
         }
     },
     "i0": {

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -479,9 +479,6 @@ class TestCephes(object):
     def test_hyp2f1(self):
         assert_equal(cephes.hyp2f1(1,1,1,0),1.0)
 
-    def test_hyperu(self):
-        assert_equal(cephes.hyperu(0,1,1),1.0)
-
     def test_i0(self):
         assert_equal(cephes.i0(0),1.0)
 

--- a/scipy/special/tests/test_hypergeometric.py
+++ b/scipy/special/tests/test_hypergeometric.py
@@ -1,0 +1,17 @@
+import numpy as np
+
+import scipy.special as sc
+
+
+class TestHyperu:
+
+    def test_negative_x(self):
+        a, b, x = np.meshgrid(
+            [-1, -0.5, 0, 0.5, 1],
+            [-1, -0.5, 0, 0.5, 1],
+            np.linspace(-100, -1, 10),
+        )
+        assert np.all(np.isnan(sc.hyperu(a, b, x)))
+
+    def test_special_cases(self):
+        assert sc.hyperu(0, 1, 1) == 1.0

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -121,7 +121,7 @@ def test_hyperu_around_0():
             dataset.append((a, b, 0, float(mpmath.hyperu(a, b, 0))))
     dataset = np.array(dataset)
 
-    FuncData(sc.hyperu, dataset, (0, 1, 2), 3, rtol=1e-15, atol=5e-14).check()
+    FuncData(sc.hyperu, dataset, (0, 1, 2), 3, rtol=1e-15, atol=5e-13).check()
 
 # ------------------------------------------------------------------------------
 # hyp2f1

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -102,6 +102,28 @@ def test_hyp0f1_gh_1609():
 
 
 # ------------------------------------------------------------------------------
+# hyperu
+# ------------------------------------------------------------------------------
+
+@check_version(mpmath, '0.19')
+def test_hyperu_around_0():
+    dataset = []
+    # DLMF 13.2.14-15 test points.
+    for n in np.arange(-5, 5):
+        for b in np.linspace(-5, 5, 20):
+            a = -n
+            dataset.append((a, b, 0, float(mpmath.hyperu(a, b, 0))))
+            a = -n + b - 1
+            dataset.append((a, b, 0, float(mpmath.hyperu(a, b, 0))))
+    # DLMF 13.2.16-22 test points.
+    for a in [-10.5, -1.5, -0.5, 0, 0.5, 1, 10]:
+        for b in [-1.0, -0.5, 0, 0.5, 1, 1.5, 2, 2.5]:
+            dataset.append((a, b, 0, float(mpmath.hyperu(a, b, 0))))
+    dataset = np.array(dataset)
+
+    FuncData(sc.hyperu, dataset, (0, 1, 2), 3, rtol=1e-15, atol=5e-14).check()
+
+# ------------------------------------------------------------------------------
 # hyp2f1
 # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
The real domain of `hyperu` does not include the negative `x` axis, so
always return NaN there. Also fix return values at `x = 0` by using
various formulas from the DLMF. Closes gh-10402.