### PR TITLE
DOC: Added comment clarifying the call for dcsrch.f in lbfgsb.f

### DIFF
--- a/scipy/optimize/lbfgsb_src/lbfgsb.f
+++ b/scipy/optimize/lbfgsb_src/lbfgsb.f
@@ -2456,6 +2456,10 @@ c     This subroutine calls subroutine dcsrch from the Minpack2 library
 c       to perform the line search.  Subroutine dscrch is safeguarded so
 c       that all trial points lie within the feasible region.
 c
+c     Be mindful that the dcsrch subroutine being called is a copy in
+c       this file (lbfgsb.f) and NOT in the Minpack2 copy distributed
+c       by scipy.
+c      
 c     Subprograms called:
 c
 c       Minpack2 Library ... dcsrch.

--- a/scipy/optimize/minpack2/dcsrch.f
+++ b/scipy/optimize/minpack2/dcsrch.f
@@ -159,7 +159,7 @@ c     Initialization block.
       if (task(1:5) .eq. 'START') then
 
 c        Check the input arguments for errors.
-
+         
          if (stp .lt. stpmin) task = 'ERROR: STP .LT. STPMIN'
          if (stp .gt. stpmax) task = 'ERROR: STP .GT. STPMAX'
          if (g .ge. zero) task = 'ERROR: INITIAL G .GE. ZERO'


### PR DESCRIPTION
In lbfgsb.f, there is a call to dcsrch.f which is supposed to be an external Minpack2 subroutine; however, what we actually call is a copy of dcsrch which lives in the lbfgsb.f file, with a different call signature (some arguments are in a different order). I added a comment in lbfgsb.f to clarify this to anyone reading the code.