### PR TITLE
BUG: Allow ckdtree to accept empty data input

### DIFF
--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -544,8 +544,12 @@ cdef class cKDTree:
             if ((self.data < 0)[:, periodic_mask]).any():
                 raise ValueError("Negative input data are outside of the periodic box.")
 
-        self.maxes = np.ascontiguousarray(np.amax(self.data,axis=0), dtype=np.float64)
-        self.mins = np.ascontiguousarray(np.amin(self.data,axis=0), dtype=np.float64)
+        self.maxes = np.ascontiguousarray(
+            np.amax(self.data, axis=0) if self.n > 0 else np.zeros(self.m),
+            dtype=np.float64)
+        self.mins = np.ascontiguousarray(
+            np.amin(self.data,axis=0) if self.n > 0 else np.zeros(self.m),
+            dtype=np.float64)
         self.indices = np.ascontiguousarray(np.arange(self.n,dtype=np.intp))
 
         self._pre_init()

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -1389,6 +1389,33 @@ def test_query_ball_point_length():
     assert_array_equal(length, length3)
     assert_array_equal(length, length4)
 
+@pytest.mark.parametrize("balanced_tree, compact_nodes",
+    [(True, False),
+     (True, True),
+     (False, False),
+     (False, True)])
+def test_cdktree_empty_input(balanced_tree, compact_nodes):
+    # https://github.com/scipy/scipy/issues/5040
+    np.random.seed(1234)
+    empty_v3 = np.empty(shape=(0, 3))
+    query_v3 = np.ones(shape=(1, 3))
+    query_v2 = np.ones(shape=(2, 3))
+
+    tree = cKDTree(empty_v3, balanced_tree=balanced_tree, compact_nodes=compact_nodes)
+    length = tree.query_ball_point(query_v3, 0.3, return_length=True)
+    assert length == 0
+
+    dd, ii = tree.query(query_v2, 2)
+    assert ii.shape == (2, 2)
+    assert dd.shape == (2, 2)
+    assert np.isinf(dd).all()
+
+    N = tree.count_neighbors(tree, [0, 1])
+    assert_array_equal(N, [0, 0])
+
+    M = tree.sparse_distance_matrix(tree, 0.3)
+    assert M.shape == (0, 0)
+
 class Test_sorted_query_ball_point(object):
 
     def setup_method(self):


### PR DESCRIPTION
Allow ckdtree to take empty data input of shape (0, m).

Fixes #5040.
