### PR TITLE
BUG:TST: Compute lwork safely

### DIFF
--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -703,6 +703,9 @@ class TestHetrd(object):
             # query lwork
             lwork, info = hetrd_lwork(n)
             assert_equal(info, 0)
+            # lwork returns complex which segfaults hetrd call below
+            # use the safe and recommended option
+            lwork = _compute_lwork(hetrd_lwork, n)
 
             # check lower=1 behavior (shouldn't do much since the matrix is
             # upper triangular)

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -22,7 +22,7 @@ from numpy import (eye, ones, zeros, zeros_like, triu, tril, tril_indices,
 from numpy.random import rand, randint, seed
 
 from scipy.linalg import _flapack as flapack
-from scipy.linalg import inv, svd, cholesky, solve, ldl
+from scipy.linalg import inv, svd, cholesky, solve, ldl, norm
 from scipy.linalg.lapack import _compute_lwork
 
 try:
@@ -106,16 +106,16 @@ class TestFlapackSimple(object):
             [-27, -9, -25]])
 
         for dtype in 'fdFD':
-            for norm in 'Mm1OoIiFfEe':
+            for norm_str in 'Mm1OoIiFfEe':
                 a1 = a.astype(dtype)
                 if dtype.isupper():
                     # is complex dtype
                     a1[0, 0] += 1j
 
                 lange, = get_lapack_funcs(('lange',), (a1,))
-                value = lange(norm, a1)
+                value = lange(norm_str, a1)
 
-                if norm in 'FfEe':
+                if norm_str in 'FfEe':
                     if dtype in 'Ff':
                         decimal = 3
                     else:
@@ -123,11 +123,11 @@ class TestFlapackSimple(object):
                     ref = np.sqrt(np.sum(np.square(np.abs(a1))))
                     assert_almost_equal(value, ref, decimal)
                 else:
-                    if norm in 'Mm':
+                    if norm_str in 'Mm':
                         ref = np.max(np.abs(a1))
-                    elif norm in '1Oo':
+                    elif norm_str in '1Oo':
                         ref = np.max(np.sum(np.abs(a1), axis=0))
-                    elif norm in 'Ii':
+                    elif norm_str in 'Ii':
                         ref = np.max(np.sum(np.abs(a1), axis=1))
 
                     assert_equal(value, ref)
@@ -168,8 +168,8 @@ class TestLeastSquaresSolvers(object):
 
         for dtype in REAL_DTYPES:
             a1 = np.array([[1.0, 2.0],
-                          [4.0, 5.0],
-                          [7.0, 8.0]], dtype=dtype)
+                           [4.0, 5.0],
+                           [7.0, 8.0]], dtype=dtype)
             b1 = np.array([16.0, 17.0, 20.0], dtype=dtype)
             gels, gels_lwork, geqrf = get_lapack_funcs(
                     ('gels', 'gels_lwork', 'geqrf'), (a1, b1))
@@ -193,8 +193,8 @@ class TestLeastSquaresSolvers(object):
 
         for dtype in COMPLEX_DTYPES:
             a1 = np.array([[1.0+4.0j, 2.0],
-                          [4.0+0.5j, 5.0-3.0j],
-                          [7.0-2.0j, 8.0+0.7j]], dtype=dtype)
+                           [4.0+0.5j, 5.0-3.0j],
+                           [7.0-2.0j, 8.0+0.7j]], dtype=dtype)
             b1 = np.array([16.0, 17.0+2.0j, 20.0-4.0j], dtype=dtype)
             gels, gels_lwork, geqrf = get_lapack_funcs(
                     ('gels', 'gels_lwork', 'geqrf'), (a1, b1))
@@ -212,15 +212,15 @@ class TestLeastSquaresSolvers(object):
             assert_allclose(x[:-1],
                             np.array([1.161753632288328-1.901075709391912j,
                                       1.735882340522193+1.521240901196909j],
-                            dtype=dtype), rtol=25*np.finfo(dtype).eps)
+                                     dtype=dtype), rtol=25*np.finfo(dtype).eps)
             lqr_truth, _, _, _ = geqrf(a1)
             assert_array_equal(lqr, lqr_truth)
 
     def test_gelsd(self):
         for dtype in REAL_DTYPES:
             a1 = np.array([[1.0, 2.0],
-                          [4.0, 5.0],
-                          [7.0, 8.0]], dtype=dtype)
+                           [4.0, 5.0],
+                           [7.0, 8.0]], dtype=dtype)
             b1 = np.array([16.0, 17.0, 20.0], dtype=dtype)
             gelsd, gelsd_lwork = get_lapack_funcs(('gelsd', 'gelsd_lwork'),
                                                   (a1, b1))
@@ -239,7 +239,8 @@ class TestLeastSquaresSolvers(object):
             x, s, rank, info = gelsd(a1, b1, lwork, iwork_size,
                                      -1, False, False)
             assert_allclose(x[:-1], np.array([-14.333333333333323,
-                                             14.999999999999991], dtype=dtype),
+                                              14.999999999999991],
+                                             dtype=dtype),
                             rtol=25*np.finfo(dtype).eps)
             assert_allclose(s, np.array([12.596017180511966,
                                          0.583396253199685], dtype=dtype),
@@ -247,8 +248,8 @@ class TestLeastSquaresSolvers(object):
 
         for dtype in COMPLEX_DTYPES:
             a1 = np.array([[1.0+4.0j, 2.0],
-                          [4.0+0.5j, 5.0-3.0j],
-                          [7.0-2.0j, 8.0+0.7j]], dtype=dtype)
+                           [4.0+0.5j, 5.0-3.0j],
+                           [7.0-2.0j, 8.0+0.7j]], dtype=dtype)
             b1 = np.array([16.0, 17.0+2.0j, 20.0-4.0j], dtype=dtype)
             gelsd, gelsd_lwork = get_lapack_funcs(('gelsd', 'gelsd_lwork'),
                                                   (a1, b1))
@@ -270,7 +271,7 @@ class TestLeastSquaresSolvers(object):
             assert_allclose(x[:-1],
                             np.array([1.161753632288328-1.901075709391912j,
                                       1.735882340522193+1.521240901196909j],
-                            dtype=dtype), rtol=25*np.finfo(dtype).eps)
+                                     dtype=dtype), rtol=25*np.finfo(dtype).eps)
             assert_allclose(s,
                             np.array([13.035514762572043, 4.337666985231382],
                                      dtype=dtype), rtol=25*np.finfo(dtype).eps)
@@ -279,8 +280,8 @@ class TestLeastSquaresSolvers(object):
 
         for dtype in REAL_DTYPES:
             a1 = np.array([[1.0, 2.0],
-                          [4.0, 5.0],
-                          [7.0, 8.0]], dtype=dtype)
+                           [4.0, 5.0],
+                           [7.0, 8.0]], dtype=dtype)
             b1 = np.array([16.0, 17.0, 20.0], dtype=dtype)
             gelss, gelss_lwork = get_lapack_funcs(('gelss', 'gelss_lwork'),
                                                   (a1, b1))
@@ -297,7 +298,8 @@ class TestLeastSquaresSolvers(object):
 
             v, x, s, rank, work, info = gelss(a1, b1, -1, lwork, False, False)
             assert_allclose(x[:-1], np.array([-14.333333333333323,
-                                             14.999999999999991], dtype=dtype),
+                                              14.999999999999991],
+                                             dtype=dtype),
                             rtol=25*np.finfo(dtype).eps)
             assert_allclose(s, np.array([12.596017180511966,
                                          0.583396253199685], dtype=dtype),
@@ -305,8 +307,8 @@ class TestLeastSquaresSolvers(object):
 
         for dtype in COMPLEX_DTYPES:
             a1 = np.array([[1.0+4.0j, 2.0],
-                          [4.0+0.5j, 5.0-3.0j],
-                          [7.0-2.0j, 8.0+0.7j]], dtype=dtype)
+                           [4.0+0.5j, 5.0-3.0j],
+                           [7.0-2.0j, 8.0+0.7j]], dtype=dtype)
             b1 = np.array([16.0, 17.0+2.0j, 20.0-4.0j], dtype=dtype)
             gelss, gelss_lwork = get_lapack_funcs(('gelss', 'gelss_lwork'),
                                                   (a1, b1))
@@ -335,8 +337,8 @@ class TestLeastSquaresSolvers(object):
 
         for dtype in REAL_DTYPES:
             a1 = np.array([[1.0, 2.0],
-                          [4.0, 5.0],
-                          [7.0, 8.0]], dtype=dtype)
+                           [4.0, 5.0],
+                           [7.0, 8.0]], dtype=dtype)
             b1 = np.array([16.0, 17.0, 20.0], dtype=dtype)
             gelsy, gelsy_lwork = get_lapack_funcs(('gelsy', 'gelss_lwork'),
                                                   (a1, b1))
@@ -355,13 +357,14 @@ class TestLeastSquaresSolvers(object):
             v, x, j, rank, info = gelsy(a1, b1, jptv, np.finfo(dtype).eps,
                                         lwork, False, False)
             assert_allclose(x[:-1], np.array([-14.333333333333323,
-                                             14.999999999999991], dtype=dtype),
+                                              14.999999999999991],
+                                             dtype=dtype),
                             rtol=25*np.finfo(dtype).eps)
 
         for dtype in COMPLEX_DTYPES:
             a1 = np.array([[1.0+4.0j, 2.0],
-                          [4.0+0.5j, 5.0-3.0j],
-                          [7.0-2.0j, 8.0+0.7j]], dtype=dtype)
+                           [4.0+0.5j, 5.0-3.0j],
+                           [7.0-2.0j, 8.0+0.7j]], dtype=dtype)
             b1 = np.array([16.0, 17.0+2.0j, 20.0-4.0j], dtype=dtype)
             gelsy, gelsy_lwork = get_lapack_funcs(('gelsy', 'gelss_lwork'),
                                                   (a1, b1))
@@ -434,13 +437,13 @@ class TestDlasd4(object):
         m_vec = np.array([3.12, 5.7, -4.8, -2.2])
 
         M = np.hstack((np.vstack((np.diag(sigmas[0:-1]),
-                       np.zeros((1, len(m_vec) - 1)))), m_vec[:, np.newaxis]))
+                                  np.zeros((1, len(m_vec) - 1)))),
+                       m_vec[:, np.newaxis]))
         SM = svd(M, full_matrices=False, compute_uv=False, overwrite_a=False,
                  check_finite=False)
 
         it_len = len(sigmas)
-        sgm = np.concatenate((sigmas[::-1], (sigmas[0] +
-                              it_len*np.sqrt(np.sum(np.power(m_vec, 2))),)))
+        sgm = np.concatenate((sigmas[::-1], [sigmas[0] + it_len*norm(m_vec)]))
         mvc = np.concatenate((m_vec[::-1], (0,)))
 
         lasd4 = get_lapack_funcs('lasd4', (sigmas,))
@@ -617,7 +620,7 @@ class TestSytrd(object):
             # ```
             # This is a NumPy issue
             # <https://github.com/numpy/numpy/issues/9617>.
-            # TODO once the issue has been resolved, test for n=1
+            # TODO Once the minimum NumPy version is past 1.14, test for n=1
 
             # some upper triangular array
             n = 3
@@ -689,7 +692,7 @@ class TestHetrd(object):
             # ```
             # This is a NumPy issue
             # <https://github.com/numpy/numpy/issues/9617>.
-            # TODO once the issue has been resolved, test for n=1
+            # TODO Once the minimum NumPy version is past 1.14, test for n=1
 
             # some upper triangular array
             n = 3
@@ -824,7 +827,7 @@ def test_sycon_hecon():
         # Since sycon only refers to upper/lower part, conj() is safe here.
         A = (A + A.conj().T)/2 + 2*np.eye(n, dtype=dtype)
 
-        anorm = np.linalg.norm(A, 1)
+        anorm = norm(A, 1)
         lwork = _compute_lwork(func_lwork, n)
         ldu, ipiv, _ = functrf(A, lwork=lwork, lower=1)
         rcond, _ = funcon(a=ldu, ipiv=ipiv, anorm=anorm, lower=1)
@@ -1281,6 +1284,7 @@ def test_syconv():
         a, e, info = syconv(ldu, ipiv, lower=0)
         assert_allclose(triu(a, 1), triu(U[perm, :], 1), atol=tol, rtol=0.)
 
+
 class TestBlockedQR(object):
     """
     Tests for the blocked QR factorization, namely through geqrt, gemqrt, tpqrt
@@ -1303,8 +1307,8 @@ class TestBlockedQR(object):
             a, t, info = geqrt(n, A)
             assert(info == 0)
 
-            # Extract elementary reflectors from lower triangle, adding the main
-            # diagonal of ones.
+            # Extract elementary reflectors from lower triangle, adding the
+            # main diagonal of ones.
             v = np.tril(a, -1) + np.eye(n, dtype=dtype)
             # Generate the block Householder transform I - VTV^H
             Q = np.eye(n, dtype=dtype) - v @ t @ v.T.conj()
@@ -1370,7 +1374,7 @@ class TestBlockedQR(object):
                 a, b, t, info = tpqrt(l, n, A, B)
                 assert(info == 0)
 
-                # Check that lower triangular portion of A has not been modified
+                # Check that lower triangular part of A has not been modified
                 assert_equal(np.tril(a, -1), np.tril(A, -1))
                 # Check that elements not part of the pentagonal portion of B
                 # have not been modified.

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -700,10 +700,11 @@ class TestHetrd(object):
                 )
             np.fill_diagonal(A, np.real(np.diag(A)))
 
-            # query lwork
-            lwork, info = hetrd_lwork(n)
-            assert_equal(info, 0)
-            # lwork returns complex which segfaults hetrd call below
+            # test query lwork
+            for x in [0, 1]:
+                _, info = hetrd_lwork(n, lower=x)
+                assert_equal(info, 0)
+            # lwork returns complex which segfaults hetrd call (gh-10388)
             # use the safe and recommended option
             lwork = _compute_lwork(hetrd_lwork, n)
 


### PR DESCRIPTION
Closes #10388 

The lwork computation returns a complex number and this trips up the f2py for some reason in the debug mode when this is used as an integer later. 

Locally tested @Kai-Striega's scenario and it passed.