### PR TITLE
TST: special: only show max atol/rtol for test points that failed

### DIFF
--- a/scipy/special/_testutils.py
+++ b/scipy/special/_testutils.py
@@ -292,8 +292,8 @@ class FuncData(object):
             if np.any(bad_j):
                 # Some bad results: inform what, where, and how bad
                 msg = [""]
-                msg.append("Max |adiff|: %g" % diff.max())
-                msg.append("Max |rdiff|: %g" % rdiff.max())
+                msg.append("Max |adiff|: %g" % diff[bad_j].max())
+                msg.append("Max |rdiff|: %g" % rdiff[bad_j].max())
                 msg.append("Bad results (%d out of %d) for the following points (in output %d):"
                            % (np.sum(bad_j), point_count, output_num,))
                 for j in np.nonzero(bad_j)[0]:


### PR DESCRIPTION
Currently when using `FuncData` the maximum atol/rtol for all points
is printed when there are only some bad points. This makes it hard to
diagnose what went wrong because e.g. the atol for the entire test set
could be quite high but acceptable (because there are some very large
values being tested). Fix that by only showing the maximum atol/rtol
within the points that failed.