### PR TITLE
BUG: Correctly align fft inputs

### DIFF
--- a/scipy/fft/_pocketfft/basic.py
+++ b/scipy/fft/_pocketfft/basic.py
@@ -26,7 +26,8 @@ def _asfarray(x):
     elif x.dtype.kind not in 'fc':
         return np.asarray(x, np.float64)
 
-    return np.asarray(x)
+    # Always align input
+    return np.array(x, copy=not x.flags['ALIGNED'])
 
 def _datacopied(arr, original):
     """


### PR DESCRIPTION
Ref https://github.com/scipy/scipy/issues/10175#issuecomment-506801174

I wasn't sure how to actually test this code but have since found `/proc/cpu/alignment` on ARM linux. If there's no difference between runs of this test program, there hasn't been any unaligned accesses.

```python
from scipy.fft import fft; import numpy as np

a = np.zeros(100, dtype='u1,c8')['f1']
assert not a.flags['ALIGNED']
b = fft(a, overwrite_x=True)
```

This fixes it for me.
cc @mreineck