### PR TITLE
ENH: lower-memory duplicate generator checking in spatial.SphericalVoronoi

### DIFF
--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -15,7 +15,7 @@ import numpy as np
 import scipy
 import itertools
 from . import _voronoi
-from scipy.spatial.distance import pdist
+from scipy.spatial import cKDTree
 
 __all__ = ['SphericalVoronoi']
 
@@ -228,7 +228,7 @@ class SphericalVoronoi:
         else:
             self.radius = 1
 
-        if pdist(self.points).min() <= threshold * self.radius:
+        if cKDTree(self.points).query_pairs(threshold * self.radius):
             raise ValueError("Duplicate generators present.")
 
         max_discrepancy = sphere_check(self.points,

--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -15,7 +15,7 @@ import numpy as np
 import scipy
 import itertools
 from . import _voronoi
-from scipy.spatial.distance import pdist
+from scipy.spatial import cKDTree
 
 __all__ = ['SphericalVoronoi']
 
@@ -228,7 +228,7 @@ class SphericalVoronoi:
         else:
             self.radius = 1
 
-        if pdist(self.points).min() <= threshold * self.radius:
+        if len(cKDTree(self.points).query_pairs(threshold * self.radius)) > 0:
             raise ValueError("Duplicate generators present.")
 
         max_discrepancy = sphere_check(self.points,


### PR DESCRIPTION
In the `spatial.SphericalVoronoi` module, the use of pdist to find duplicate generators uses quadratic memory. On my laptop this restricts the current implementation to about 50,000 points. I have used `scipy.spatial.cKDTree` to reduce the memory requirements.  Better performance is an extra benefit - here are timings from `spatial.SphericalVor.time_spherical_voronoi_calculation`:

```
============ ============ ============
 num_points     master     this PR
------------ ------------ ------------
     10        531±2μs     536±0.8μs  
    100        1.65±0ms     1.66±0ms  
    1000      15.3±0.1ms   13.4±0.1ms 
    5000      159±0.8ms    70.8±0.8ms 
   10000      507±0.8ms     147±2ms   
============ ============ ============
```

This PR is taken from my sloppy effort in #10439
