### PR TITLE
MAINT: renamed T_o/_T_o to postsolve_args

### DIFF
--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -516,28 +516,35 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
         (c, c0, A_ub, b_ub, A_eq, b_eq, bounds, x, x0, undo, complete, status,
             message) = _presolve(c, A_ub, b_ub, A_eq, b_eq, bounds, x0, rr, tol)
 
+    postsolve_args = (c_o, A_ub_o, b_ub_o, A_eq_o, b_eq_o, bounds, undo)
+
     if not complete:
         A, b, c, c0, x0 = _get_Abc(c, c0, A_ub, b_ub, A_eq,
                                    b_eq, bounds, x0, undo)
-        T_o = (c_o, A_ub_o, b_ub_o, A_eq_o, b_eq_o, bounds, undo)
+
         if meth == 'simplex':
             x, status, message, iteration = _linprog_simplex(
-                c, c0=c0, A=A, b=b, callback=callback, _T_o=T_o, **solver_options)
+                c, c0=c0, A=A, b=b, callback=callback,
+                postsolve_args=postsolve_args, **solver_options)
         elif meth == 'interior-point':
             x, status, message, iteration = _linprog_ip(
-                c, c0=c0, A=A, b=b, callback=callback, _T_o=T_o, **solver_options)
+                c, c0=c0, A=A, b=b, callback=callback,
+                postsolve_args=postsolve_args, **solver_options)
         elif meth == 'revised simplex':
             x, status, message, iteration = _linprog_rs(
-                c, c0=c0, A=A, b=b, x0=x0, callback=callback, _T_o=T_o, **solver_options)
+                c, c0=c0, A=A, b=b, x0=x0, callback=callback,
+                postsolve_args=postsolve_args, **solver_options)
         else:
             raise ValueError('Unknown solver %s' % method)
 
     # Eliminate artificial variables, re-introduce presolved variables, etc...
     # need modified bounds here to translate variables appropriately
     disp = solver_options.get('disp', False)
-    x, fun, slack, con, status, message = _postprocess(
-        x, c_o, A_ub_o, b_ub_o, A_eq_o, b_eq_o, bounds,
-        complete, undo, status, message, tol, iteration, disp)
+
+    x, fun, slack, con, status, message = _postprocess(x, postsolve_args,
+                                                       complete, status,
+                                                       message, tol,
+                                                       iteration, disp)
 
     sol = {
         'x': x,

--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -678,7 +678,7 @@ def _ip_hsd(A, b, c, c0, alpha0, beta, maxiter, disp, tol, sparse, lstsq,
                 A string descriptor of the exit status of the optimization.
     postsolve_args : tuple
         Data needed by _postsolve to convert the solution to the standard-form
-        problem into the the solution to the original problem.
+        problem into the solution to the original problem.
 
     Returns
     -------
@@ -840,16 +840,16 @@ def _ip_hsd(A, b, c, c0, alpha0, beta, maxiter, disp, tol, sparse, lstsq,
 
 def _linprog_ip(
         c,
-        c0=0,
-        A=None,
-        b=None,
-        callback=None,
-        postsolve_args=(),
+        c0,
+        A,
+        b,
+        callback,
+        postsolve_args,
+        maxiter=1000,
+        tol=1e-8,
+        disp=False,
         alpha0=.99995,
         beta=0.1,
-        maxiter=1000,
-        disp=False,
-        tol=1e-8,
         sparse=False,
         lstsq=False,
         sym_pos=True,
@@ -890,18 +890,18 @@ def _linprog_ip(
         Callback function to be executed once per iteration.
     postsolve_args : tuple
         Data needed by _postsolve to convert the solution to the standard-form
-        problem into the the solution to the original problem.
+        problem into the solution to the original problem.
 
     Options
     -------
     maxiter : int (default = 1000)
         The maximum number of iterations of the algorithm.
-    disp : bool (default = False)
-        Set to ``True`` if indicators of optimization status are to be printed
-        to the console each iteration.
     tol : float (default = 1e-8)
         Termination tolerance to be used for all termination criteria;
         see [4]_ Section 4.5.
+    disp : bool (default = False)
+        Set to ``True`` if indicators of optimization status are to be printed
+        to the console each iteration.
     alpha0 : float (default = 0.99995)
         The maximal step size for Mehrota's predictor-corrector search
         direction; see :math:`\beta_{3}` of [4]_ Table 8.1.

--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -119,25 +119,9 @@ def _get_solver(M, sparse=False, lstsq=False, sym_pos=True,
     return solve
 
 
-def _get_delta(
-        A,
-        b,
-        c,
-        x,
-        y,
-        z,
-        tau,
-        kappa,
-        gamma,
-        eta,
-        sparse=False,
-        lstsq=False,
-        sym_pos=True,
-        cholesky=True,
-        pc=True,
-        ip=False,
-        permc_spec='MMD_AT_PLUS_A'
-        ):
+def _get_delta(A, b, c, x, y, z, tau, kappa, gamma, eta, sparse=False,
+               lstsq=False, sym_pos=True, cholesky=True, pc=True, ip=False,
+               permc_spec='MMD_AT_PLUS_A'):
     """
     Given standard form problem defined by ``A``, ``b``, and ``c``;
     current variable estimates ``x``, ``y``, ``z``, ``tau``, and ``kappa``;
@@ -838,26 +822,10 @@ def _ip_hsd(A, b, c, c0, alpha0, beta, maxiter, disp, tol, sparse, lstsq,
     return x_hat, status, message, iteration
 
 
-def _linprog_ip(
-        c,
-        c0,
-        A,
-        b,
-        callback,
-        postsolve_args,
-        maxiter=1000,
-        tol=1e-8,
-        disp=False,
-        alpha0=.99995,
-        beta=0.1,
-        sparse=False,
-        lstsq=False,
-        sym_pos=True,
-        cholesky=None,
-        pc=True,
-        ip=False,
-        permc_spec='MMD_AT_PLUS_A',
-        **unknown_options):
+def _linprog_ip(c, c0, A, b, callback, postsolve_args, maxiter=1000, tol=1e-8,
+                disp=False, alpha0=.99995, beta=0.1, sparse=False, lstsq=False,
+                sym_pos=True, cholesky=None, pc=True, ip=False,
+                permc_spec='MMD_AT_PLUS_A', **unknown_options):
     r"""
     Minimize a linear objective function subject to linear
     equality and non-negativity constraints using the interior point method

--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -676,6 +676,9 @@ def _ip_hsd(A, b, c, c0, alpha0, beta, maxiter, disp, tol, sparse, lstsq,
                 The number of iterations performed.
             message : str
                 A string descriptor of the exit status of the optimization.
+    postsolve_args : tuple
+        Data needed by _postsolve to convert the solution to the standard-form
+        problem into the the solution to the original problem.
 
     Returns
     -------
@@ -841,7 +844,7 @@ def _linprog_ip(
         A=None,
         b=None,
         callback=None,
-        postsolve_args=[],
+        postsolve_args=(),
         alpha0=.99995,
         beta=0.1,
         maxiter=1000,
@@ -883,6 +886,11 @@ def _linprog_ip(
     b : 1D array
         1D array of values representing the right hand side of each equality
         constraint (row) in ``A``.
+    callback : callable, optional
+        Callback function to be executed once per iteration.
+    postsolve_args : tuple
+        Data needed by _postsolve to convert the solution to the standard-form
+        problem into the the solution to the original problem.
 
     Options
     -------

--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -567,7 +567,7 @@ def _display_iter(rho_p, rho_d, rho_g, alpha, rho_mu, obj, header=False):
 
 
 def _ip_hsd(A, b, c, c0, alpha0, beta, maxiter, disp, tol, sparse, lstsq,
-            sym_pos, cholesky, pc, ip, permc_spec, callback, _T_o):
+            sym_pos, cholesky, pc, ip, permc_spec, callback, postsolve_args):
     r"""
     Solve a linear programming problem in standard form:
 
@@ -724,7 +724,7 @@ def _ip_hsd(A, b, c, c0, alpha0, beta, maxiter, disp, tol, sparse, lstsq,
     if disp:
         _display_iter(rho_p, rho_d, rho_g, "-", rho_mu, obj, header=True)
     if callback is not None:
-        x_o, fun, slack, con, _, _ = _postsolve(x/tau, *_T_o,
+        x_o, fun, slack, con, _, _ = _postsolve(x/tau, postsolve_args,
                                                 tol=tol)
         res = OptimizeResult({'x': x_o, 'fun': fun, 'slack': slack,
                               'con': con, 'nit': iteration, 'phase': 1,
@@ -805,7 +805,7 @@ def _ip_hsd(A, b, c, c0, alpha0, beta, maxiter, disp, tol, sparse, lstsq,
         if disp:
             _display_iter(rho_p, rho_d, rho_g, alpha, rho_mu, obj)
         if callback is not None:
-            x_o, fun, slack, con, _, _ = _postsolve(x/tau, *_T_o,
+            x_o, fun, slack, con, _, _ = _postsolve(x/tau, postsolve_args,
                                                     tol=tol)
             res = OptimizeResult({'x': x_o, 'fun': fun, 'slack': slack,
                                   'con': con, 'nit': iteration, 'phase': 1,
@@ -841,7 +841,7 @@ def _linprog_ip(
         A=None,
         b=None,
         callback=None,
-        _T_o=[],
+        postsolve_args=[],
         alpha0=.99995,
         beta=0.1,
         maxiter=1000,
@@ -1146,6 +1146,6 @@ def _linprog_ip(
                                             maxiter, disp, tol, sparse,
                                             lstsq, sym_pos, cholesky,
                                             pc, ip, permc_spec, callback,
-                                            _T_o)
+                                            postsolve_args)
 
     return x, status, message, iteration

--- a/scipy/optimize/_linprog_rs.py
+++ b/scipy/optimize/_linprog_rs.py
@@ -30,7 +30,7 @@ from .optimize import OptimizeResult
 
 
 def _phase_one(A, b, x0, maxiter, tol, maxupdate, mast, pivot, callback=None,
-               postsolve_args=[], disp=False):
+               postsolve_args=(), disp=False):
     """
     The purpose of phase one is to find an initial basic feasible solution
     (BFS) to the original problem.
@@ -57,9 +57,11 @@ def _phase_one(A, b, x0, maxiter, tol, maxupdate, mast, pivot, callback=None,
 
     # solve auxiliary problem
     phase_one_n = n
+    iter_k = 0
     x, basis, status, iter_k = _phase_two(c, A, x, basis, maxiter, tol,
-                                          maxupdate, mast, pivot, 0, callback,
-                                          postsolve_args, disp, phase_one_n)
+                                          maxupdate, mast, pivot, iter_k,
+                                          callback, postsolve_args, disp,
+                                          phase_one_n)
 
     # check for infeasibility
     residual = c.dot(x)
@@ -308,7 +310,7 @@ def _display_iter(phase, iteration, slack, con, fun):
 
 
 def _phase_two(c, A, x, b, maxiter, tol, maxupdate, mast, pivot, iteration=0,
-               callback=None, postsolve_args=[], disp=False, phase_one_n=None):
+               callback=None, postsolve_args=(), disp=False, phase_one_n=None):
     """
     The heart of the simplex method. Beginning with a basic feasible solution,
     moves to adjacent basic feasible solutions successively lower reduced cost.
@@ -399,8 +401,8 @@ def _phase_two(c, A, x, b, maxiter, tol, maxupdate, mast, pivot, iteration=0,
     return x, b, status, iteration
 
 
-def _linprog_rs(c, c0, A, b, x0=None, callback=None, maxiter=5000, tol=1e-12,
-                maxupdate=10, mast=False, pivot="mrc", postsolve_args=[],
+def _linprog_rs(c, c0, A, b, x0=None, callback=None, postsolve_args=(),
+                maxiter=5000, tol=1e-12, maxupdate=10, mast=False, pivot="mrc",
                 disp=False, **unknown_options):
     """
     Solve the following linear programming problem via a two-phase
@@ -457,6 +459,9 @@ def _linprog_rs(c, c0, A, b, x0=None, callback=None, maxiter=5000, tol=1e-12,
                 The number of iterations performed.
             message : str
                 A string descriptor of the exit status of the optimization.
+    postsolve_args : tuple
+        Data needed by _postsolve to convert the solution to the standard-form
+        problem into the the solution to the original problem.
 
     Options
     -------

--- a/scipy/optimize/_linprog_simplex.py
+++ b/scipy/optimize/_linprog_simplex.py
@@ -231,7 +231,7 @@ def _apply_pivot(T, basis, pivrow, pivcol, tol=1e-9):
 
 def _solve_simplex(T, n, basis, maxiter=1000, phase=2, status=0, message='',
                    callback=None, tol=1e-9, nit0=0, bland=False,
-                   postsolve_args=[]):
+                   postsolve_args=()):
     """
     Solve a linear programming problem in "standard form" using the Simplex
     Method. Linear Programming is intended to solve the following problem form:
@@ -322,6 +322,9 @@ def _solve_simplex(T, n, basis, maxiter=1000, phase=2, status=0, message='',
                 The number of iterations performed.
             message : str
                 A string descriptor of the exit status of the optimization.
+    postsolve_args : tuple
+        Data needed by _postsolve to convert the solution to the standard-form
+        problem into the the solution of the original problem.
     tol : float
         The tolerance which determines when a solution is "close enough" to
         zero in Phase 1 to be considered a basic feasible solution or close
@@ -431,7 +434,7 @@ def _solve_simplex(T, n, basis, maxiter=1000, phase=2, status=0, message='',
 
 
 def _linprog_simplex(c, c0, A, b, maxiter=1000, disp=False, callback=None,
-                     tol=1e-9, bland=False, postsolve_args=[],
+                     tol=1e-9, bland=False, postsolve_args=(),
                      **unknown_options):
     """
     Minimize a linear objective function subject to linear equality and
@@ -492,6 +495,9 @@ def _linprog_simplex(c, c0, A, b, maxiter=1000, disp=False, callback=None,
                 The number of iterations performed.
             message : str
                 A string descriptor of the exit status of the optimization.
+    postsolve_args : tuple
+        Data needed by _postsolve to convert the solution to the standard-form
+        problem into the the solution of the original problem.
 
     Options
     -------

--- a/scipy/optimize/_linprog_util.py
+++ b/scipy/optimize/_linprog_util.py
@@ -1065,6 +1065,7 @@ def _get_Abc(c, c0=0, A_ub=None, b_ub=None, A_eq=None, b_eq=None, bounds=None,
 
     # add slack variables
     A2 = vstack([eye(A_ub.shape[0]), zeros((A_eq.shape[0], A_ub.shape[0]))])
+
     A = hstack([A1, A2])
 
     # lower bound: substitute xi = xi' + lb
@@ -1113,8 +1114,7 @@ def _display_summary(message, status, fun, iteration):
     print("         Iterations: {0:d}".format(iteration))
 
 
-def _postsolve(x, c, A_ub=None, b_ub=None, A_eq=None, b_eq=None, bounds=None,
-               complete=False, undo=[], tol=1e-8, copy=False):
+def _postsolve(x, postsolve_args, complete=False, tol=1e-8, copy=False):
     """
     Given solution x to presolved, standard form linear program x, add
     fixed variables back into the problem and undo the variable substitutions
@@ -1173,6 +1173,7 @@ def _postsolve(x, c, A_ub=None, b_ub=None, A_eq=None, b_eq=None, bounds=None,
     # we need these modified values to undo the variable substitutions
     # in retrospect, perhaps this could have been simplified if the "undo"
     # variable also contained information for undoing variable substitutions
+    c, A_ub, b_ub, A_eq, b_eq, bounds, undo = postsolve_args
 
     n_x = len(c)
 
@@ -1329,9 +1330,8 @@ def _check_result(x, fun, status, slack, con, lb, ub, tol, message):
     return status, message
 
 
-def _postprocess(x, c, A_ub=None, b_ub=None, A_eq=None, b_eq=None, bounds=None,
-                 complete=False, undo=[], status=0, message="", tol=1e-8,
-                 iteration=None, disp=False):
+def _postprocess(x, postsolve_args, complete=False, status=0, message="",
+                 tol=1e-8, iteration=None, disp=False):
     """
     Given solution x to presolved, standard form linear program x, add
     fixed variables back into the problem and undo the variable substitutions
@@ -1405,8 +1405,7 @@ def _postprocess(x, c, A_ub=None, b_ub=None, A_eq=None, b_eq=None, bounds=None,
     """
 
     x, fun, slack, con, lb, ub = _postsolve(
-        x, c, A_ub, b_ub, A_eq, b_eq,
-        bounds, complete, undo, tol
+        x, postsolve_args, complete, tol
     )
 
     status, message = _check_result(

--- a/scipy/optimize/_linprog_util.py
+++ b/scipy/optimize/_linprog_util.py
@@ -1126,27 +1126,33 @@ def _postsolve(x, postsolve_args, complete=False, tol=1e-8, copy=False):
     ----------
     x : 1D array
         Solution vector to the standard-form problem.
-    c : 1D array
-        Original coefficients of the linear objective function to be minimized.
-    A_ub : 2D array, optional
-        2D array such that ``A_ub @ x`` gives the values of the upper-bound
-        inequality constraints at ``x``.
-    b_ub : 1D array, optional
-        1D array of values representing the upper-bound of each inequality
-        constraint (row) in ``A_ub``.
-    A_eq : 2D array, optional
-        2D array such that ``A_eq @ x`` gives the values of the equality
-        constraints at ``x``.
-    b_eq : 1D array, optional
-        1D array of values representing the RHS of each equality constraint
-        (row) in ``A_eq``.
-    bounds : sequence of tuples
-        Bounds, as modified in presolve
+    postsolve_args : tuple
+        Data needed by _postsolve to convert the solution to the standard-form
+        problem into the the solution to the original problem, including:
+
+        c : 1D array
+            Original coefficients of the linear objective function to be
+            minimized.
+        A_ub : 2D array, optional
+            2D array such that ``A_ub @ x`` gives the values of the upper-bound
+            inequality constraints at ``x``.
+        b_ub : 1D array, optional
+            1D array of values representing the upper-bound of each inequality
+            constraint (row) in ``A_ub``.
+        A_eq : 2D array, optional
+            2D array such that ``A_eq @ x`` gives the values of the equality
+            constraints at ``x``.
+        b_eq : 1D array, optional
+            1D array of values representing the RHS of each equality constraint
+            (row) in ``A_eq``.
+        bounds : sequence of tuples
+            Bounds, as modified in presolve
+        undo: list of tuples
+            (`index`, `value`) pairs that record the original index and fixed value
+            for each variable removed from the problem
+
     complete : bool
         Whether the solution is was determined in presolve (``True`` if so)
-    undo: list of tuples
-        (`index`, `value`) pairs that record the original index and fixed value
-        for each variable removed from the problem
     tol : float
         Termination tolerance; see [1]_ Section 4.5.
 

--- a/scipy/optimize/_linprog_util.py
+++ b/scipy/optimize/_linprog_util.py
@@ -1128,7 +1128,7 @@ def _postsolve(x, postsolve_args, complete=False, tol=1e-8, copy=False):
         Solution vector to the standard-form problem.
     postsolve_args : tuple
         Data needed by _postsolve to convert the solution to the standard-form
-        problem into the the solution to the original problem, including:
+        problem into the solution to the original problem, including:
 
         c : 1D array
             Original coefficients of the linear objective function to be


### PR DESCRIPTION
Renames variables `T_o`/`_T_o` to `postsolve_args` and delays unpacking
until `_postsolve`, where the values are ultimately used.

Partially addresses gh-9671 