### PR TITLE
ENH: Normalise the inverse DCT/DST in scipy.fft

### DIFF
--- a/doc/source/tutorial/fft.rst
+++ b/doc/source/tutorial/fft.rst
@@ -286,7 +286,7 @@ Type I DCT
 __________
 
 SciPy uses the following definition of the unnormalized DCT-I
-(``norm='None'``):
+(``norm=None``):
 
 .. math::
 
@@ -294,14 +294,13 @@ SciPy uses the following definition of the unnormalized DCT-I
     \cos\left(\frac{\pi nk}{N-1}\right),
     \qquad 0 \le k < N.
 
-Only ``None`` is supported as normalization mode for DCT-I. Note also that the
-DCT-I is only supported for input size > 1
+Note that the DCT-I is only supported for input size > 1
 
 Type II DCT
 ___________
 
 SciPy uses the following definition of the unnormalized DCT-II
-(``norm='None'``):
+(``norm=None``):
 
 .. math::
 
@@ -328,7 +327,7 @@ Type III DCT
 ____________
 
 SciPy uses the following definition of the unnormalized DCT-III
-(``norm='None'``):
+(``norm=None``):
 
 .. math::
 
@@ -347,9 +346,10 @@ DCT and IDCT
 ____________
 
 
-The (unnormalized) DCT-III is the inverse of the (unnormalized) DCT-II, up to
-a factor `2N`. The orthonormalized DCT-III is exactly the inverse of the orthonormalized DCT-
-II. The function :func:`idct` performs the mappings between the DCT and IDCT types.
+The (unnormalized) DCT-III is the inverse of the (unnormalized) DCT-II, up to a
+factor `2N`. The orthonormalized DCT-III is exactly the inverse of the
+orthonormalized DCT- II. The function :func:`idct` performs the mappings between
+the DCT and IDCT types, as well as performing the correct normalization.
 
 The example below shows the relation between DCT and IDCT for different types
 and normalizations.
@@ -357,22 +357,31 @@ and normalizations.
 >>> from scipy.fft import dct, idct
 >>> x = np.array([1.0, 2.0, 1.0, -1.0, 1.5])
 >>> dct(dct(x, type=2, norm='ortho'), type=3, norm='ortho')
-[1.0, 2.0, 1.0, -1.0, 1.5]
->>>  # scaling factor 2*N = 10
->>> idct(dct(x, type=2), type=2)
-array([ 10.,  20.,  10., -10.,  15.])
->>>  # no scaling factor
->>> idct(dct(x, type=2, norm='ortho'), type=2, norm='ortho')
 array([ 1. ,  2. ,  1. , -1. ,  1.5])
 >>>  # scaling factor 2*N = 10
->>> idct(dct(x, type=3), type=3)
+>>> dct(dct(x, type=2), type=3)
 array([ 10.,  20.,  10., -10.,  15.])
 >>>  # no scaling factor
->>> idct(dct(x, type=3, norm='ortho'), type=3, norm='ortho')
+>>> idct(dct(x, type=2), type=2)
+array([ 1. ,  2. ,  1. , -1. ,  1.5])
+
+>>> dct(dct(x, type=1, norm='ortho'), type=1, norm='ortho')
 array([ 1. ,  2. ,  1. , -1. ,  1.5])
 >>>  # scaling factor 2*(N-1) = 8
+>>> dct(dct(x, type=1), type=1)
+array([ 8. ,  16.,  8. , -8. ,  12.])
+>>>  # no scaling factor
 >>> idct(dct(x, type=1), type=1)
-array([  8.,  16.,   8.,  -8.,  12.])
+array([ 1. ,  2. ,  1. , -1. ,  1.5])
+
+>>> dct(dct(x, type=4, norm='ortho'), type=4, norm='ortho')
+array([ 1. ,  2. ,  1. , -1. ,  1.5])
+>>>  # scaling factor 2*N = 10
+>>> dct(dct(x, type=4), type=4)
+array([ 10.,  20.,  10., -10.,  15.])
+>>>  # no scaling factor
+>>> idct(dct(x, type=4), type=4)
+array([ 1. ,  2. ,  1. , -1. ,  1.5])
 
 Example
 _______
@@ -429,22 +438,21 @@ Type I DST
 __________
 
 DST-I assumes the input is odd around n=-1 and n=N. SciPy uses the following
-definition of the unnormalized DST-I (``norm='None'``):
+definition of the unnormalized DST-I (``norm=None``):
 
 .. math::
 
     y[k] = 2\sum_{n=0}^{N-1} x[n]  \sin\left( \pi {(n+1) (k+1)}\over{N+1}
     \right), \qquad 0 \le k < N.
 
-Only ``None`` is supported as normalization mode for DST-I. Note also that the
-DST-I is only supported for input size > 1. The (unnormalized) DST-I is its
-own inverse, up to a factor `2(N+1)`.
+Note also that the DST-I is only supported for input size > 1. The
+(unnormalized) DST-I is its own inverse, up to a factor `2(N+1)`.
 
 Type II DST
 ___________
 
 DST-II assumes the input is odd around n=-1/2 and even around n=N. SciPy uses
-the following definition of the unnormalized DST-II (``norm='None'``):
+the following definition of the unnormalized DST-II (``norm=None``):
 
 .. math::
 
@@ -455,7 +463,7 @@ Type III DST
 ____________
 
 DST-III assumes the input is odd around n=-1 and even around n=N-1. SciPy uses
-the following definition of the unnormalized DST-III (``norm='None'``):
+the following definition of the unnormalized DST-III (``norm=None``):
 
 .. math::
 
@@ -472,22 +480,32 @@ and normalizations.
 
 >>> from scipy.fft import dst, idst
 >>> x = np.array([1.0, 2.0, 1.0, -1.0, 1.5])
+>>> dst(dst(x, type=2, norm='ortho'), type=3, norm='ortho')
+array([ 1. ,  2. ,  1. , -1. ,  1.5])
 >>>  # scaling factor 2*N = 10
+>>> dst(dst(x, type=2), type=3)
+array([ 10.,  20.,  10., -10.,  15.])
+>>>  # no scaling factor
 >>> idst(dst(x, type=2), type=2)
-array([ 10.,  20.,  10., -10.,  15.])
+array([ 1. ,  2. ,  1. , -1. ,  1.5])
+
+>>> dst(dst(x, type=1, norm='ortho'), type=1, norm='ortho')
+array([ 1. ,  2. ,  1. , -1. ,  1.5])
+>>>  # scaling factor 2*(N+1) = 12
+>>> dst(dst(x, type=1), type=1)
+array([ 12.,  24.,  12., -12.,  18.])
 >>>  # no scaling factor
->>> idst(dst(x, type=2, norm='ortho'), type=2, norm='ortho')
+>>> idst(dst(x, type=1), type=1)
+array([ 1. ,  2. ,  1. , -1. ,  1.5])
+
+>>> dst(dst(x, type=4, norm='ortho'), type=4, norm='ortho')
 array([ 1. ,  2. ,  1. , -1. ,  1.5])
 >>>  # scaling factor 2*N = 10
->>> idst(dst(x, type=3), type=3)
+>>> dst(dst(x, type=4), type=4)
 array([ 10.,  20.,  10., -10.,  15.])
 >>>  # no scaling factor
->>> idst(dst(x, type=3, norm='ortho'), type=3, norm='ortho')
+>>> idst(dst(x, type=4), type=4)
 array([ 1. ,  2. ,  1. , -1. ,  1.5])
->>>  # scaling factor 2*(N+1) = 8
->>> idst(dst(x, type=1), type=1)
-array([ 12.,  24.,  12., -12.,  18.])
-
 
 References
 ----------

--- a/doc/source/tutorial/fft.rst
+++ b/doc/source/tutorial/fft.rst
@@ -351,35 +351,51 @@ factor `2N`. The orthonormalized DCT-III is exactly the inverse of the
 orthonormalized DCT- II. The function :func:`idct` performs the mappings between
 the DCT and IDCT types, as well as performing the correct normalization.
 
-The example below shows the relation between DCT and IDCT for different types
-and normalizations.
+The following example shows the relation between DCT and IDCT for different
+types and normalizations.
 
 >>> from scipy.fft import dct, idct
 >>> x = np.array([1.0, 2.0, 1.0, -1.0, 1.5])
+
+The DCT-II and DCT-III are each others inverses, so for an orthonormal transform
+we return back to the original signal.
+
 >>> dct(dct(x, type=2, norm='ortho'), type=3, norm='ortho')
 array([ 1. ,  2. ,  1. , -1. ,  1.5])
->>>  # scaling factor 2*N = 10
+
+Doing the same under default normalization however, we pick up an extra scaling
+factor of :math:`2N=10` since the forward transform is unnormalized.
+
 >>> dct(dct(x, type=2), type=3)
 array([ 10.,  20.,  10., -10.,  15.])
->>>  # no scaling factor
+
+For this reason, we should use the function `idct` using the same type for both,
+giving a correctly normalized result.
+
+>>> # Normalized inverse: no scaling factor
 >>> idct(dct(x, type=2), type=2)
 array([ 1. ,  2. ,  1. , -1. ,  1.5])
 
+Analogous results can be seen for the DCT-I which is its own inverse up to a
+factor of :math:`2(N-1)`
+
 >>> dct(dct(x, type=1, norm='ortho'), type=1, norm='ortho')
 array([ 1. ,  2. ,  1. , -1. ,  1.5])
->>>  # scaling factor 2*(N-1) = 8
+>>> # Unnormalized round-trip via DCT-I: scaling factor 2*(N-1) = 8
 >>> dct(dct(x, type=1), type=1)
 array([ 8. ,  16.,  8. , -8. ,  12.])
->>>  # no scaling factor
+>>> # Normalized inverse: no scaling factor
 >>> idct(dct(x, type=1), type=1)
 array([ 1. ,  2. ,  1. , -1. ,  1.5])
 
+And for the DCT-IV which is also its own inverse up to a factor of :math:`2N`
+
 >>> dct(dct(x, type=4, norm='ortho'), type=4, norm='ortho')
 array([ 1. ,  2. ,  1. , -1. ,  1.5])
->>>  # scaling factor 2*N = 10
+>>> # Unnormalized round-trip via DCT-IV: scaling factor 2*N = 10
 >>> dct(dct(x, type=4), type=4)
 array([ 10.,  20.,  10., -10.,  15.])
->>>  # no scaling factor
+>>> # Normalized inverse: no scaling factor
 >>> idct(dct(x, type=4), type=4)
 array([ 1. ,  2. ,  1. , -1. ,  1.5])
 
@@ -475,19 +491,32 @@ DST and IDST
 ____________
 
 
-The example below shows the relation between DST and IDST for different types
-and normalizations.
+The following example below shows the relation between DST and IDST for
+different types and normalizations.
 
 >>> from scipy.fft import dst, idst
 >>> x = np.array([1.0, 2.0, 1.0, -1.0, 1.5])
+
+The DST-II and DST-III are each others inverses, so for an orthonormal transform
+we return back to the original signal.
+
 >>> dst(dst(x, type=2, norm='ortho'), type=3, norm='ortho')
 array([ 1. ,  2. ,  1. , -1. ,  1.5])
->>>  # scaling factor 2*N = 10
+
+Doing the same under default normalization however, we pick up an extra scaling
+factor of :math:`2N=10` since the forward transform is unnormalized.
+
 >>> dst(dst(x, type=2), type=3)
 array([ 10.,  20.,  10., -10.,  15.])
->>>  # no scaling factor
+
+For this reason, we should use the function `idst` using the same type for both,
+giving a correctly normalized result.
+
 >>> idst(dst(x, type=2), type=2)
 array([ 1. ,  2. ,  1. , -1. ,  1.5])
+
+Analogous results can be seen for the DST-I which is its own inverse up to a
+factor of :math:`2(N-1)`
 
 >>> dst(dst(x, type=1, norm='ortho'), type=1, norm='ortho')
 array([ 1. ,  2. ,  1. , -1. ,  1.5])
@@ -497,6 +526,8 @@ array([ 12.,  24.,  12., -12.,  18.])
 >>>  # no scaling factor
 >>> idst(dst(x, type=1), type=1)
 array([ 1. ,  2. ,  1. , -1. ,  1.5])
+
+And for the DST-IV which is also its own inverse up to a factor of :math:`2N`
 
 >>> dst(dst(x, type=4, norm='ortho'), type=4, norm='ortho')
 array([ 1. ,  2. ,  1. , -1. ,  1.5])

--- a/scipy/fft/_backend.py
+++ b/scipy/fft/_backend.py
@@ -1,6 +1,7 @@
 import scipy._lib.uarray as ua
 import scipy.fftpack as _fftpack
 from . import _pocketfft
+from . import _realtransforms
 
 
 class _ScipyBackend:
@@ -15,10 +16,21 @@ class _ScipyBackend:
     """
     __ua_domain__ = "numpy.scipy.fft"
 
+    realtransforms = {
+        'dct': _fftpack.dct,
+        'dst': _fftpack.dst,
+        'dctn': _fftpack.dctn,
+        'dstn': _fftpack.dstn,
+        'idct': _realtransforms._idct,
+        'idst': _realtransforms._idst,
+        'idctn': _realtransforms._idctn,
+        'idstn': _realtransforms._idstn,
+    }
+
     @staticmethod
     def __ua_function__(method, args, kwargs):
         fn = (getattr(_pocketfft, method.__name__, None)
-              or getattr(_fftpack, method.__name__, None))
+              or _ScipyBackend.realtransforms.get(method.__name__, None))
 
         if fn is None:
             return NotImplemented

--- a/scipy/fft/_realtransforms.py
+++ b/scipy/fft/_realtransforms.py
@@ -81,7 +81,7 @@ def dctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
     --------
     >>> from scipy.fft import dctn, idctn
     >>> y = np.random.randn(16, 16)
-    >>> np.allclose(y, idctn(dctn(y, norm='ortho'), norm='ortho'))
+    >>> np.allclose(y, idctn(dctn(y)))
     True
 
     """
@@ -134,7 +134,7 @@ def idctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
     --------
     >>> from scipy.fft import dctn, idctn
     >>> y = np.random.randn(16, 16)
-    >>> np.allclose(y, idctn(dctn(y, norm='ortho'), norm='ortho'))
+    >>> np.allclose(y, idctn(dctn(y)))
     True
 
     """
@@ -194,7 +194,7 @@ def dstn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
     --------
     >>> from scipy.fft import dstn, idstn
     >>> y = np.random.randn(16, 16)
-    >>> np.allclose(y, idstn(dstn(y, norm='ortho'), norm='ortho'))
+    >>> np.allclose(y, idstn(dstn(y)))
     True
 
     """
@@ -247,7 +247,7 @@ def idstn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
     --------
     >>> from scipy.fft import dstn, idstn
     >>> y = np.random.randn(16, 16)
-    >>> np.allclose(y, idstn(dstn(y, norm='ortho'), norm='ortho'))
+    >>> np.allclose(y, idstn(dstn(y)))
     True
 
     """
@@ -298,6 +298,10 @@ def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
     For a single dimension array ``x``, ``dct(x, norm='ortho')`` is equal to
     MATLAB ``dct(x)``.
 
+    For ``norm=None``, there is no scaling on `dct` and the `idct` is scaled by
+    ``1/N`` where ``N`` is the "logical" size of the DCT. For ``norm='ortho'``
+    both directions are scaled by the same factor ``1/sqrt(N)``.
+
     There are theoretically 8 types of the DCT, only the first 4 types are
     implemented in scipy. 'The' DCT generally refers to DCT type 2, and 'the'
     Inverse DCT generally refers to DCT type 3.
@@ -321,9 +325,6 @@ def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
         f = \begin{cases}
          \frac{1}{2}\sqrt{\frac{1}{N-1}} & \text{if }k=0\text{ or }N-1, \\
          \frac{1}{2}\sqrt{\frac{2}{N-1}} & \text{otherwise} \end{cases}
-
-    .. versionadded:: 1.2.0
-       Orthonormalization in DCT-I.
 
     .. note::
        The DCT-I is only supported for input size > 1.
@@ -380,9 +381,6 @@ def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
     .. math::
 
         f = \frac{1}{\sqrt{2N}}
-
-    .. versionadded:: 1.2.0
-       Support for DCT-IV.
 
     References
     ----------
@@ -446,11 +444,11 @@ def idct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
     For a single dimension array `x`, ``idct(x, norm='ortho')`` is equal to
     MATLAB ``idct(x)``.
 
-    'The' IDCT is the IDCT of type 2, which is the same as DCT of type 3.
+    'The' IDCT is the IDCT-II, which is the same as the normalized DCT-III.
 
-    IDCT of type 1 is the DCT of type 1, IDCT of type 2 is the DCT of type
-    3, and IDCT of type 3 is the DCT of type 2. IDCT of type 4 is the DCT
-    of type 4. For the definition of these types, see `dct`.
+    The IDCT is equivalent to a normal DCT except for the normalization and
+    type. DCT type 1 and 4 are their own inverse and DCTs 2 and 3 are each
+    other's inverses.
 
     Examples
     --------
@@ -461,7 +459,7 @@ def idct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
     >>> from scipy.fft import ifft, idct
     >>> ifft(np.array([ 30.,  -8.,   6.,  -2.,   6.,  -8.])).real
     array([  4.,   3.,   5.,  10.,   5.,   3.])
-    >>> idct(np.array([ 30.,  -8.,   6.,  -2.]), 1) / 6
+    >>> idct(np.array([ 30.,  -8.,   6.,  -2.]), 1)
     array([  4.,   3.,   5.,  10.])
 
     """
@@ -510,6 +508,11 @@ def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
     Notes
     -----
     For a single dimension array ``x``.
+
+    For ``norm=None``, there is no scaling on the `dst` and the `idst` is
+    scaled by ``1/N`` where ``N`` is the "logical" size of the DST. For
+    ``norm='ortho'`` both directions are scaled by the same factor
+    ``1/sqrt(N)``.
 
     There are theoretically 8 types of the DST for different combinations of
     even/odd boundary conditions and boundary off sets [1]_, only the first
@@ -561,8 +564,6 @@ def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
     to a factor `2N`. The orthonormalized DST-III is exactly the inverse of the
     orthonormalized DST-II.
 
-    .. versionadded:: 0.11.0
-
     **Type IV**
 
     There are several definitions of the DST-IV, we use the following (for
@@ -575,9 +576,6 @@ def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
 
     The (unnormalized) DST-IV is its own inverse, up to a factor `2N`. The
     orthonormalized DST-IV is exactly its own inverse.
-
-    .. versionadded:: 1.2.0
-       Support for DST-IV.
 
     References
     ----------
@@ -622,13 +620,12 @@ def idst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
 
     Notes
     -----
-    'The' IDST is the IDST of type 2, which is the same as DST of type 3.
 
-    IDST of type 1 is the DST of type 1, IDST of type 2 is the DST of type
-    3, and IDST of type 3 is the DST of type 2. For the definition of these
-    types, see `dst`.
+    'The' IDST is the IDST-II, which is the same as the normalized DST-III.
 
-    .. versionadded:: 0.11.0
+    The IDST is equivalent to a normal DST except for the normalization and
+    type. DST type 1 and 4 are their own inverse and DSTs 2 and 3 are each
+    other's inverses.
 
     """
     return (Dispatchable(x, np.ndarray),)

--- a/scipy/fft/_realtransforms.py
+++ b/scipy/fft/_realtransforms.py
@@ -3,54 +3,582 @@ from ._basic import _dispatch
 from scipy._lib.uarray import Dispatchable
 from scipy._lib.doccer import doc_replace
 import numpy as np
-import functools
 
 __all__ = ['dct', 'idct', 'dst', 'idst', 'dctn', 'idctn', 'dstn', 'idstn']
 
 
 @_dispatch
-@doc_replace(_fftpack.dctn, 'fftpack', 'fft')
 def dctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
+    """
+    Return multidimensional Discrete Cosine Transform along the specified axes.
+
+    Parameters
+    ----------
+    x : array_like
+        The input array.
+    type : {1, 2, 3, 4}, optional
+        Type of the DCT (see Notes). Default type is 2.
+    shape : int or array_like of ints or None, optional
+        The shape of the result.  If both `shape` and `axes` (see below) are
+        None, `shape` is ``x.shape``; if `shape` is None but `axes` is
+        not None, then `shape` is ``scipy.take(x.shape, axes, axis=0)``.
+        If ``shape[i] > x.shape[i]``, the i-th dimension is padded with zeros.
+        If ``shape[i] < x.shape[i]``, the i-th dimension is truncated to
+        length ``shape[i]``.
+        If any element of `shape` is -1, the size of the corresponding
+        dimension of `x` is used.
+    axes : int or array_like of ints or None, optional
+        Axes along which the DCT is computed.
+        The default is over all axes.
+    norm : {None, 'ortho'}, optional
+        Normalization mode (see Notes). Default is None.
+    overwrite_x : bool, optional
+        If True, the contents of `x` can be destroyed; the default is False.
+
+    Returns
+    -------
+    y : ndarray of real
+        The transformed input array.
+
+    See Also
+    --------
+    idctn : Inverse multidimensional DCT
+
+    Notes
+    -----
+    For full details of the DCT types and normalization modes, as well as
+    references, see `dct`.
+
+    Examples
+    --------
+    >>> from scipy.fft import dctn, idctn
+    >>> y = np.random.randn(16, 16)
+    >>> np.allclose(y, idctn(dctn(y, norm='ortho'), norm='ortho'))
+    True
+
+    """
     return (Dispatchable(x, np.ndarray),)
 
 
 @_dispatch
-@doc_replace(_fftpack.idctn, 'fftpack', 'fft')
 def idctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
+    """
+    Return multidimensional Discrete Cosine Transform along the specified axes.
+
+    Parameters
+    ----------
+    x : array_like
+        The input array.
+    type : {1, 2, 3, 4}, optional
+        Type of the DCT (see Notes). Default type is 2.
+    shape : int or array_like of ints or None, optional
+        The shape of the result.  If both `shape` and `axes` (see below) are
+        None, `shape` is ``x.shape``; if `shape` is None but `axes` is
+        not None, then `shape` is ``scipy.take(x.shape, axes, axis=0)``.
+        If ``shape[i] > x.shape[i]``, the i-th dimension is padded with zeros.
+        If ``shape[i] < x.shape[i]``, the i-th dimension is truncated to
+        length ``shape[i]``.
+        If any element of `shape` is -1, the size of the corresponding
+        dimension of `x` is used.
+    axes : int or array_like of ints or None, optional
+        Axes along which the IDCT is computed.
+        The default is over all axes.
+    norm : {None, 'ortho'}, optional
+        Normalization mode (see Notes). Default is None.
+    overwrite_x : bool, optional
+        If True, the contents of `x` can be destroyed; the default is False.
+
+    Returns
+    -------
+    y : ndarray of real
+        The transformed input array.
+
+    See Also
+    --------
+    dctn : multidimensional DCT
+
+    Notes
+    -----
+    For full details of the IDCT types and normalization modes, as well as
+    references, see `idct`.
+
+    Examples
+    --------
+    >>> from scipy.fft import dctn, idctn
+    >>> y = np.random.randn(16, 16)
+    >>> np.allclose(y, idctn(dctn(y, norm='ortho'), norm='ortho'))
+    True
+
+    """
     return (Dispatchable(x, np.ndarray),)
 
 
 @_dispatch
-@doc_replace(_fftpack.dstn, 'fftpack', 'fft')
 def dstn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
+    """
+    Return multidimensional Discrete Sine Transform along the specified axes.
+
+    Parameters
+    ----------
+    x : array_like
+        The input array.
+    type : {1, 2, 3, 4}, optional
+        Type of the DST (see Notes). Default type is 2.
+    shape : int or array_like of ints or None, optional
+        The shape of the result.  If both `shape` and `axes` (see below) are
+        None, `shape` is ``x.shape``; if `shape` is None but `axes` is
+        not None, then `shape` is ``scipy.take(x.shape, axes, axis=0)``.
+        If ``shape[i] > x.shape[i]``, the i-th dimension is padded with zeros.
+        If ``shape[i] < x.shape[i]``, the i-th dimension is truncated to
+        length ``shape[i]``.
+        If any element of `shape` is -1, the size of the corresponding
+        dimension of `x` is used.
+    axes : int or array_like of ints or None, optional
+        Axes along which the DCT is computed.
+        The default is over all axes.
+    norm : {None, 'ortho'}, optional
+        Normalization mode (see Notes). Default is None.
+    overwrite_x : bool, optional
+        If True, the contents of `x` can be destroyed; the default is False.
+
+    Returns
+    -------
+    y : ndarray of real
+        The transformed input array.
+
+    See Also
+    --------
+    idstn : Inverse multidimensional DST
+
+    Notes
+    -----
+    For full details of the DST types and normalization modes, as well as
+    references, see `dst`.
+
+    Examples
+    --------
+    >>> from scipy.fft import dstn, idstn
+    >>> y = np.random.randn(16, 16)
+    >>> np.allclose(y, idstn(dstn(y, norm='ortho'), norm='ortho'))
+    True
+
+    """
     return (Dispatchable(x, np.ndarray),)
 
 
 @_dispatch
-@doc_replace(_fftpack.idstn, 'fftpack', 'fft')
 def idstn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
+    """
+    Return multidimensional Discrete Sine Transform along the specified axes.
+
+    Parameters
+    ----------
+    x : array_like
+        The input array.
+    type : {1, 2, 3, 4}, optional
+        Type of the DST (see Notes). Default type is 2.
+    shape : int or array_like of ints or None, optional
+        The shape of the result.  If both `shape` and `axes` (see below) are
+        None, `shape` is ``x.shape``; if `shape` is None but `axes` is
+        not None, then `shape` is ``scipy.take(x.shape, axes, axis=0)``.
+        If ``shape[i] > x.shape[i]``, the i-th dimension is padded with zeros.
+        If ``shape[i] < x.shape[i]``, the i-th dimension is truncated to
+        length ``shape[i]``.
+        If any element of `shape` is -1, the size of the corresponding
+        dimension of `x` is used.
+    axes : int or array_like of ints or None, optional
+        Axes along which the IDST is computed.
+        The default is over all axes.
+    norm : {None, 'ortho'}, optional
+        Normalization mode (see Notes). Default is None.
+    overwrite_x : bool, optional
+        If True, the contents of `x` can be destroyed; the default is False.
+
+    Returns
+    -------
+    y : ndarray of real
+        The transformed input array.
+
+    See Also
+    --------
+    dstn : multidimensional DST
+
+    Notes
+    -----
+    For full details of the IDST types and normalization modes, as well as
+    references, see `idst`.
+
+    Examples
+    --------
+    >>> from scipy.fft import dstn, idstn
+    >>> y = np.random.randn(16, 16)
+    >>> np.allclose(y, idstn(dstn(y, norm='ortho'), norm='ortho'))
+    True
+
+    """
     return (Dispatchable(x, np.ndarray),)
 
 
 @_dispatch
-@doc_replace(_fftpack.dct, 'fftpack', 'fft')
 def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
+    r"""
+    Return the Discrete Cosine Transform of arbitrary type sequence x.
+
+    Parameters
+    ----------
+    x : array_like
+        The input array.
+    type : {1, 2, 3, 4}, optional
+        Type of the DCT (see Notes). Default type is 2.
+    n : int, optional
+        Length of the transform.  If ``n < x.shape[axis]``, `x` is
+        truncated.  If ``n > x.shape[axis]``, `x` is zero-padded. The
+        default results in ``n = x.shape[axis]``.
+    axis : int, optional
+        Axis along which the dct is computed; the default is over the
+        last axis (i.e., ``axis=-1``).
+    norm : {None, 'ortho'}, optional
+        Normalization mode (see Notes). Default is None.
+    overwrite_x : bool, optional
+        If True, the contents of `x` can be destroyed; the default is False.
+
+    Returns
+    -------
+    y : ndarray of real
+        The transformed input array.
+
+    See Also
+    --------
+    idct : Inverse DCT
+
+    Notes
+    -----
+    For a single dimension array ``x``, ``dct(x, norm='ortho')`` is equal to
+    MATLAB ``dct(x)``.
+
+    There are theoretically 8 types of the DCT, only the first 4 types are
+    implemented in scipy. 'The' DCT generally refers to DCT type 2, and 'the'
+    Inverse DCT generally refers to DCT type 3.
+
+    **Type I**
+
+    There are several definitions of the DCT-I; we use the following
+    (for ``norm=None``)
+
+    .. math::
+
+       y_k = x_0 + (-1)^k x_{N-1} + 2 \sum_{n=1}^{N-2} x_n \cos\left(
+       \frac{\pi k n}{N-1} \right)
+
+    If ``norm='ortho'``, ``x[0]`` and ``x[N-1]`` are multiplied by a scaling
+    factor of :math:`\sqrt{2}`, and ``y[k]`` is multiplied by a scaling factor
+    ``f``
+
+    .. math::
+
+        f = \begin{cases}
+         \frac{1}{2}\sqrt{\frac{1}{N-1}} & \text{if }k=0\text{ or }N-1, \\
+         \frac{1}{2}\sqrt{\frac{2}{N-1}} & \text{otherwise} \end{cases}
+
+    .. versionadded:: 1.2.0
+       Orthonormalization in DCT-I.
+
+    .. note::
+       The DCT-I is only supported for input size > 1.
+
+    **Type II**
+
+    There are several definitions of the DCT-II; we use the following
+    (for ``norm=None``)
+
+    .. math::
+
+       y_k = 2 \sum_{n=0}^{N-1} x_n \cos\left(\frac{\pi k(2n+1)}{2N} \right)
+
+    If ``norm='ortho'``, ``y[k]`` is multiplied by a scaling factor ``f``
+
+    .. math::
+       f = \begin{cases}
+       \sqrt{\frac{1}{4N}} & \text{if }k=0, \\
+       \sqrt{\frac{1}{2N}} & \text{otherwise} \end{cases}
+
+    Which makes the corresponding matrix of coefficients orthonormal
+    (``O @ O.T = np.eye(N)``).
+
+    **Type III**
+
+    There are several definitions, we use the following (for ``norm=None``)
+
+    .. math::
+
+       y_k = x_0 + 2 \sum_{n=1}^{N-1} x_n \cos\left(\frac{\pi(2k+1)n}{2N}\right)
+
+    or, for ``norm='ortho'``
+
+    .. math::
+
+       y_k = \frac{x_0}{\sqrt{N}} + \sqrt{\frac{2}{N}} \sum_{n=1}^{N-1} x_n
+       \cos\left(\frac{\pi(2k+1)n}{2N}\right)
+
+    The (unnormalized) DCT-III is the inverse of the (unnormalized) DCT-II, up
+    to a factor `2N`. The orthonormalized DCT-III is exactly the inverse of
+    the orthonormalized DCT-II.
+
+    **Type IV**
+
+    There are several definitions of the DCT-IV; we use the following
+    (for ``norm=None``)
+
+    .. math::
+
+       y_k = 2 \sum_{n=0}^{N-1} x_n \cos\left(\frac{\pi(2k+1)(2n+1)}{4N} \right)
+
+    If ``norm='ortho'``, ``y[k]`` is multiplied by a scaling factor ``f``
+
+    .. math::
+
+        f = \frac{1}{\sqrt{2N}}
+
+    .. versionadded:: 1.2.0
+       Support for DCT-IV.
+
+    References
+    ----------
+    .. [1] 'A Fast Cosine Transform in One and Two Dimensions', by J.
+           Makhoul, `IEEE Transactions on acoustics, speech and signal
+           processing` vol. 28(1), pp. 27-34,
+           :doi:`10.1109/TASSP.1980.1163351` (1980).
+    .. [2] Wikipedia, "Discrete cosine transform",
+           https://en.wikipedia.org/wiki/Discrete_cosine_transform
+
+    Examples
+    --------
+    The Type 1 DCT is equivalent to the FFT (though faster) for real,
+    even-symmetrical inputs.  The output is also real and even-symmetrical.
+    Half of the FFT input is used to generate half of the FFT output:
+
+    >>> from scipy.fft import fft, dct
+    >>> fft(np.array([4., 3., 5., 10., 5., 3.])).real
+    array([ 30.,  -8.,   6.,  -2.,   6.,  -8.])
+    >>> dct(np.array([4., 3., 5., 10.]), 1)
+    array([ 30.,  -8.,   6.,  -2.])
+
+    """
     return (Dispatchable(x, np.ndarray),)
 
 
 @_dispatch
-@doc_replace(_fftpack.idct, 'fftpack', 'fft')
 def idct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
+    """
+    Return the Inverse Discrete Cosine Transform of an arbitrary type sequence.
+
+    Parameters
+    ----------
+    x : array_like
+        The input array.
+    type : {1, 2, 3, 4}, optional
+        Type of the DCT (see Notes). Default type is 2.
+    n : int, optional
+        Length of the transform.  If ``n < x.shape[axis]``, `x` is
+        truncated.  If ``n > x.shape[axis]``, `x` is zero-padded. The
+        default results in ``n = x.shape[axis]``.
+    axis : int, optional
+        Axis along which the idct is computed; the default is over the
+        last axis (i.e., ``axis=-1``).
+    norm : {None, 'ortho'}, optional
+        Normalization mode (see Notes). Default is None.
+    overwrite_x : bool, optional
+        If True, the contents of `x` can be destroyed; the default is False.
+
+    Returns
+    -------
+    idct : ndarray of real
+        The transformed input array.
+
+    See Also
+    --------
+    dct : Forward DCT
+
+    Notes
+    -----
+    For a single dimension array `x`, ``idct(x, norm='ortho')`` is equal to
+    MATLAB ``idct(x)``.
+
+    'The' IDCT is the IDCT of type 2, which is the same as DCT of type 3.
+
+    IDCT of type 1 is the DCT of type 1, IDCT of type 2 is the DCT of type
+    3, and IDCT of type 3 is the DCT of type 2. IDCT of type 4 is the DCT
+    of type 4. For the definition of these types, see `dct`.
+
+    Examples
+    --------
+    The Type 1 DCT is equivalent to the DFT for real, even-symmetrical
+    inputs.  The output is also real and even-symmetrical.  Half of the IFFT
+    input is used to generate half of the IFFT output:
+
+    >>> from scipy.fft import ifft, idct
+    >>> ifft(np.array([ 30.,  -8.,   6.,  -2.,   6.,  -8.])).real
+    array([  4.,   3.,   5.,  10.,   5.,   3.])
+    >>> idct(np.array([ 30.,  -8.,   6.,  -2.]), 1) / 6
+    array([  4.,   3.,   5.,  10.])
+
+    """
     return (Dispatchable(x, np.ndarray),)
 
 
 @_dispatch
-@doc_replace(_fftpack.dst, 'fftpack', 'fft')
 def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
+    r"""
+    Return the Discrete Sine Transform of arbitrary type sequence x.
+
+    Parameters
+    ----------
+    x : array_like
+        The input array.
+    type : {1, 2, 3, 4}, optional
+        Type of the DST (see Notes). Default type is 2.
+    n : int, optional
+        Length of the transform.  If ``n < x.shape[axis]``, `x` is
+        truncated.  If ``n > x.shape[axis]``, `x` is zero-padded. The
+        default results in ``n = x.shape[axis]``.
+    axis : int, optional
+        Axis along which the dst is computed; the default is over the
+        last axis (i.e., ``axis=-1``).
+    norm : {None, 'ortho'}, optional
+        Normalization mode (see Notes). Default is None.
+    overwrite_x : bool, optional
+        If True, the contents of `x` can be destroyed; the default is False.
+
+    Returns
+    -------
+    dst : ndarray of reals
+        The transformed input array.
+
+    See Also
+    --------
+    idst : Inverse DST
+
+    Notes
+    -----
+    For a single dimension array ``x``.
+
+    There are theoretically 8 types of the DST for different combinations of
+    even/odd boundary conditions and boundary off sets [1]_, only the first
+    4 types are implemented in scipy.
+
+    **Type I**
+
+    There are several definitions of the DST-I; we use the following
+    for ``norm=None``. DST-I assumes the input is odd around `n=-1` and `n=N`.
+
+    .. math::
+
+        y_k = 2 \sum_{n=0}^{N-1} x_n \sin\left(\frac{\pi(k+1)(n+1)}{N+1}\right)
+
+    Note that the DST-I is only supported for input size > 1.
+    The (unnormalized) DST-I is its own inverse, up to a factor `2(N+1)`.
+    The orthonormalized DST-I is exactly its own inverse.
+
+    **Type II**
+
+    There are several definitions of the DST-II; we use the following for
+    ``norm=None``. DST-II assumes the input is odd around `n=-1/2` and
+    `n=N-1/2`; the output is odd around :math:`k=-1` and even around `k=N-1`
+
+    .. math::
+
+        y_k = 2 \sum_{n=0}^{N-1} x_n \sin\left(\frac{\pi(k+1)(2n+1)}{2N}\right)
+
+    if ``norm='ortho'``, ``y[k]`` is multiplied by a scaling factor ``f``
+
+    .. math::
+
+        f = \begin{cases}
+        \sqrt{\frac{1}{4N}} & \text{if }k = 0, \\
+        \sqrt{\frac{1}{2N}} & \text{otherwise} \end{cases}
+
+    **Type III**
+
+    There are several definitions of the DST-III, we use the following (for
+    ``norm=None``). DST-III assumes the input is odd around `n=-1` and even
+    around `n=N-1`
+
+    .. math::
+
+        y_k = (-1)^k x_{N-1} + 2 \sum_{n=0}^{N-2} x_n \sin\left(
+        \frac{\pi(2k+1)(n+1)}{2N}\right)
+
+    The (unnormalized) DST-III is the inverse of the (unnormalized) DST-II, up
+    to a factor `2N`. The orthonormalized DST-III is exactly the inverse of the
+    orthonormalized DST-II.
+
+    .. versionadded:: 0.11.0
+
+    **Type IV**
+
+    There are several definitions of the DST-IV, we use the following (for
+    ``norm=None``). DST-IV assumes the input is odd around `n=-0.5` and even
+    around `n=N-0.5`
+
+    .. math::
+
+        y_k = 2 \sum_{n=0}^{N-1} x_n \sin\left(\frac{\pi(2k+1)(2n+1)}{4N}\right)
+
+    The (unnormalized) DST-IV is its own inverse, up to a factor `2N`. The
+    orthonormalized DST-IV is exactly its own inverse.
+
+    .. versionadded:: 1.2.0
+       Support for DST-IV.
+
+    References
+    ----------
+    .. [1] Wikipedia, "Discrete sine transform",
+           https://en.wikipedia.org/wiki/Discrete_sine_transform
+
+    """
     return (Dispatchable(x, np.ndarray),)
 
 
-@_dispatch
-@doc_replace(_fftpack.idst, 'fftpack', 'fft')
 def idst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
+    """
+    Return the Inverse Discrete Sine Transform of an arbitrary type sequence.
+
+    Parameters
+    ----------
+    x : array_like
+        The input array.
+    type : {1, 2, 3, 4}, optional
+        Type of the DST (see Notes). Default type is 2.
+    n : int, optional
+        Length of the transform.  If ``n < x.shape[axis]``, `x` is
+        truncated.  If ``n > x.shape[axis]``, `x` is zero-padded. The
+        default results in ``n = x.shape[axis]``.
+    axis : int, optional
+        Axis along which the idst is computed; the default is over the
+        last axis (i.e., ``axis=-1``).
+    norm : {None, 'ortho'}, optional
+        Normalization mode (see Notes). Default is None.
+    overwrite_x : bool, optional
+        If True, the contents of `x` can be destroyed; the default is False.
+
+    Returns
+    -------
+    idst : ndarray of real
+        The transformed input array.
+
+    See Also
+    --------
+    dst : Forward DST
+
+    Notes
+    -----
+    'The' IDST is the IDST of type 2, which is the same as DST of type 3.
+
+    IDST of type 1 is the DST of type 1, IDST of type 2 is the DST of type
+    3, and IDST of type 3 is the DST of type 2. For the definition of these
+    types, see `dst`.
+
+    .. versionadded:: 0.11.0
+
+    """
     return (Dispatchable(x, np.ndarray),)

--- a/scipy/fft/tests/test_backend.py
+++ b/scipy/fft/tests/test_backend.py
@@ -2,6 +2,7 @@ import numpy as np
 import scipy.fft
 from scipy.fft import set_backend
 from scipy.fft import _pocketfft
+from scipy.fft import _realtransforms as rt
 import scipy.fftpack as fftpack
 from scipy.fft.tests import mock_backend
 
@@ -21,8 +22,8 @@ np_funcs = (np.fft.fft, np.fft.fft2, np.fft.fftn,
             np.fft.irfft, np.fft.irfft2, np.fft.irfftn,
             np.fft.hfft, _pocketfft.hfft2, _pocketfft.hfftn,  # np has no hfftn
             np.fft.ihfft, _pocketfft.ihfft2, _pocketfft.ihfftn,
-            fftpack.dct, fftpack.idct, fftpack.dctn, fftpack.idctn,
-            fftpack.dst, fftpack.idst, fftpack.dstn, fftpack.idstn)
+            fftpack.dct, rt._idct, fftpack.dctn, rt._idctn,
+            fftpack.dst, rt._idst, fftpack.dstn, rt._idstn)
 
 funcs = (scipy.fft.fft, scipy.fft.fft2, scipy.fft.fftn,
          scipy.fft.ifft, scipy.fft.ifft2, scipy.fft.ifftn,

--- a/scipy/fft/tests/test_real_transforms.py
+++ b/scipy/fft/tests/test_real_transforms.py
@@ -28,7 +28,7 @@ def test_identity_1d(forward, backward, type, n, axis, norm):
     pad = [(0, 0)] * 2
     pad[axis] = (0, 4)
 
-    y2 = np.pad(y, pad)
+    y2 = np.pad(y, pad, mode='edge')
     z2 = backward(y2, type, n, axis, norm)
     assert_allclose(z2, x)
 
@@ -71,7 +71,7 @@ def test_identity_nd(forward, backward, type, shape, axes, norm):
         for a in axes:
             pad[a] = (0, 4)
 
-    y2 = np.pad(y, pad)
+    y2 = np.pad(y, pad, mode='edge')
     z2 = backward(y2, type, shape, axes, norm)
     assert_allclose(z2, x)
 

--- a/scipy/fft/tests/test_real_transforms.py
+++ b/scipy/fft/tests/test_real_transforms.py
@@ -1,0 +1,87 @@
+
+import numpy as np
+from numpy.testing import assert_allclose
+import pytest
+
+from scipy.fft import dct, idct, dctn, idctn, dst, idst, dstn, idstn
+import scipy.fft as fft
+from scipy import fftpack
+
+# scipy.fft wraps the fftpack versions but with normalized inverse transforms.
+# So, the forward transforms and definitions are already thoroughly tested in
+# fftpack/test_real_transforms.py
+
+
+@pytest.mark.parametrize("forward, backward", [(dct, idct), (dst, idst)])
+@pytest.mark.parametrize("type", [1, 2, 3, 4])
+@pytest.mark.parametrize("n", [2, 3, 4, 5, 10, 16])
+@pytest.mark.parametrize("axis", [0, 1])
+@pytest.mark.parametrize("norm", [None, 'ortho'])
+def test_identity_1d(forward, backward, type, n, axis, norm):
+    # Test the identity f^-1(f(x)) == x
+    x = np.random.rand(n, n)
+
+    y = forward(x, type, axis=axis, norm=norm)
+    z = backward(y, type, axis=axis, norm=norm)
+    assert_allclose(z, x)
+
+    pad = [(0, 0)] * 2
+    pad[axis] = (0, 4)
+
+    y2 = np.pad(y, pad)
+    z2 = backward(y2, type, n, axis, norm)
+    assert_allclose(z2, x)
+
+
+@pytest.mark.parametrize("forward, backward", [(dctn, idctn), (dstn, idstn)])
+@pytest.mark.parametrize("type", [1, 2, 3, 4])
+@pytest.mark.parametrize("shape, axes",
+                         [
+                             ((4, 4), 0),
+                             ((4, 4), 1),
+                             ((4, 4), None),
+                             ((4, 4), (0, 1)),
+                             ((10, 12), None),
+                             ((10, 12), (0, 1)),
+                             ((4, 5, 6), None),
+                             ((4, 5, 6), 1),
+                             ((4, 5, 6), (0, 2)),
+                         ])
+@pytest.mark.parametrize("norm", [None, 'ortho'])
+def test_identity_nd(forward, backward, type, shape, axes, norm):
+    # Test the identity f^-1(f(x)) == x
+
+    x = np.random.random(shape)
+
+    if axes is not None:
+        shape = np.take(shape, axes)
+
+    y = forward(x, type, axes=axes, norm=norm)
+    z = backward(y, type, axes=axes, norm=norm)
+    assert_allclose(z, x)
+
+    if axes is None:
+        pad = [(0, 4)] * x.ndim
+    elif isinstance(axes, int):
+        pad = [(0, 0)] * x.ndim
+        pad[axes] = (0, 4)
+    else:
+        pad = [(0, 0)] * x.ndim
+
+        for a in axes:
+            pad[a] = (0, 4)
+
+    y2 = np.pad(y, pad)
+    z2 = backward(y2, type, shape, axes, norm)
+    assert_allclose(z2, x)
+
+
+@pytest.mark.parametrize("func", ['dct', 'dst', 'dctn', 'dstn'])
+@pytest.mark.parametrize("type", [1, 2, 3, 4])
+@pytest.mark.parametrize("norm", [None, 'ortho'])
+def test_fftpack_equivalience(func, type, norm):
+    x = np.random.rand(8, 16)
+    fft_res = getattr(fft, func)(x, type, norm=norm)
+    fftpack_res = getattr(fftpack, func)(x, type, norm=norm)
+
+    assert_allclose(fft_res, fftpack_res)

--- a/scipy/optimize/_trustregion_constr/tests/test_canonical_constraint.py
+++ b/scipy/optimize/_trustregion_constr/tests/test_canonical_constraint.py
@@ -158,7 +158,7 @@ def test_nonlinear_constraint():
 def test_concatenation():
     rng = np.random.RandomState(0)
     n = 4
-    x0 = np.random.rand(n)
+    x0 = rng.rand(n)
 
     f1 = x0
     J1 = np.eye(n)


### PR DESCRIPTION
Closes #3677

As described in the issue, this adds the correct normalization factor to the inverse dct/dst such that the identity `idct(dct(x)) == x` is true for all normalization modes. This is consistent with the other FFT functions in `scipy.fft`

~I will fix the merge conflicts with #10383 after one is merged.~ ✔️ 