### PR TITLE
CI: include python debug for Travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,19 @@
 #   http://lint.travis-ci.org/
 language: python
 sudo: false
+addons:
+  apt:
+    packages: &common_packages
+    - libatlas-dev
+    - libatlas-base-dev
+    - liblapack-dev
+    - gfortran
+    - libgmp-dev
+    - libmpfr-dev
+    - libsuitesparse-dev
+    - ccache
+    - swig
+    - libmpc-dev
 env:
   global:
    # Wheelhouse for pre-release wheels
@@ -42,6 +55,21 @@ matrix:
         - TESTMODE=full
         - COVERAGE="--coverage --gcov"
         - NUMPYSPEC="numpy==1.15.4"
+    # Test SciPy with the debug version of Python.
+    # However travis only specifies regular or development builds of Python
+    # so we must install python3-dbg using apt.
+    - language: generic
+      dist: xenial # Requirex Xenial(ubunu 18.04) as python-dbg uses py3.5
+      env:
+        - TESTMODE=fast
+        - NUMPYSPEC="--upgrade numpy"
+        - USE_DEBUG=1
+      addons:
+        apt:
+          packages:
+            - *common_packages
+            - python3-dbg
+            - python3-dev
     - python: 3.6
       env:
         - TESTMODE=fast
@@ -73,26 +101,12 @@ matrix:
         - COVERAGE=
         - NUMPYSPEC="--upgrade numpy"
         - MB_PYTHON_VERSION=3.7
-addons:
-  apt:
-    packages:
-    - libatlas-dev
-    - libatlas-base-dev
-    - liblapack-dev
-    - gfortran
-    - libgmp-dev
-    - libmpfr-dev
-    - libsuitesparse-dev
-    - ccache
-    - swig
-    - libmpc-dev
 cache:
   directories:
     - $HOME/.ccache
     - $HOME/.cache/pip
     - $HOME/Library/Caches/pip
 before_install:
-  # Work in our own virtualenv to isolate from travis-ci packages.
   - echo $TRAVIS_OS_NAME
   - |
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
@@ -151,6 +165,15 @@ before_install:
   - ulimit -a
   - mkdir builds
   - cd builds
+  - |
+    if [ "${USE_DEBUG}" == "1" ];
+    then
+        # Work in our own virtualenv to isolate from travis-ci packages.
+        travis_retry pip install -U virtualenv
+        virtualenv --python=python3-dbg venv
+        source venv/bin/activate
+    fi
+  - python -V
   - travis_retry pip install --upgrade pip setuptools wheel
   - travis_retry pip install cython
   - if [ -n "$NUMPYSPEC" ]; then travis_retry pip install $NUMPYSPEC; fi
@@ -174,7 +197,6 @@ before_install:
         travis_retry pip install "asv>=0.4.1"
     fi
   - pip uninstall -y nose
-  - python -V
   - ccache -s
   - cd ..
   - set -o pipefail

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,8 +57,8 @@ matrix:
         - NUMPYSPEC="numpy==1.15.4"
     # Test SciPy with the debug version of Python.
     # However travis only specifies regular or development builds of Python
-    # so we must install python3-dbg using apt.
-    - language: generic
+    # so we must install python3.5-dbg using apt.
+    - python: 3.5
       dist: xenial # Requirex Xenial(ubunu 18.04) as python-dbg uses py3.5
       env:
         - TESTMODE=fast
@@ -68,8 +68,8 @@ matrix:
         apt:
           packages:
             - *common_packages
-            - python3-dbg
-            - python3-dev
+            - python3.5-dbg
+            - python3.5-dev
     - python: 3.6
       env:
         - TESTMODE=fast

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,12 +58,12 @@ matrix:
     # Test SciPy with the debug version of Python.
     # However travis only specifies regular or development builds of Python
     # so we must install python3.5-dbg using apt.
-    - python: 3.5
-      dist: xenial # Requirex Xenial(ubunu 18.04) as python-dbg uses py3.5
+    - language: generic
+      dist: xenial  # Requires Xenial(ubunu 18.04) as python-dbg uses py3.5
       env:
+        - USE_DEBUG=python3.5-dbg
         - TESTMODE=fast
         - NUMPYSPEC="--upgrade numpy"
-        - USE_DEBUG=1
       addons:
         apt:
           packages:
@@ -166,14 +166,13 @@ before_install:
   - mkdir builds
   - cd builds
   - |
-    if [ "${USE_DEBUG}" == "1" ];
-    then
+    if [ -n "${USE_DEBUG}" ]; then
         # Work in our own virtualenv to isolate from travis-ci packages.
-        travis_retry pip install -U virtualenv
-        virtualenv --python=python3-dbg venv
+        virtualenv --python=$USE_DEBUG venv
         source venv/bin/activate
     fi
-  - python -V
+  - python -V -V
+  - python -c 'import sys; print("Python debug build:", hasattr(sys, "gettotalrefcount"))'
   - travis_retry pip install --upgrade pip setuptools wheel
   - travis_retry pip install cython
   - if [ -n "$NUMPYSPEC" ]; then travis_retry pip install $NUMPYSPEC; fi


### PR DESCRIPTION
Our current CI setup does not run with a debug or 32bit version of Python for Travis-CI. This has led to several issues that may be related to Python's debug symbols (e.g. #9245, #10388).
This PR will:

- [x] add a build using python-dbg

P.S. I've been having some problems setting up Travis-CI to run locally following this [stackoverflow](https://stackoverflow.com/questions/21053657/how-to-run-travis-ci-locally/49019950#49019950) guide. Has anyone got any tips?