### PR TITLE
TST: special: use `__tracebackhide__` to get better error messages

### DIFF
--- a/scipy/special/_testutils.py
+++ b/scipy/special/_testutils.py
@@ -1,10 +1,9 @@
 from __future__ import division, print_function, absolute_import
 
 import os
-
-from distutils.version import LooseVersion
-
 import functools
+import operator
+from distutils.version import LooseVersion
 
 import numpy as np
 from numpy.testing import assert_
@@ -174,7 +173,9 @@ class FuncData(object):
 
     def check(self, data=None, dtype=None, dtypes=None):
         """Check the special function against the data."""
-        __tracebackhide__ = True
+        __tracebackhide__ = operator.methodcaller(
+            'errisinstance', AssertionError
+        )
 
         if self.knownfailure:
             pytest.xfail(reason=self.knownfailure)

--- a/scipy/special/_testutils.py
+++ b/scipy/special/_testutils.py
@@ -174,6 +174,7 @@ class FuncData(object):
 
     def check(self, data=None, dtype=None, dtypes=None):
         """Check the special function against the data."""
+        __tracebackhide__ = True
 
         if self.knownfailure:
             pytest.xfail(reason=self.knownfailure)


### PR DESCRIPTION
`FuncData` already carefully formats the exception that it raises, so
additional traceback data just obscures the bad points. Hide it by
setting `__tracebackhide__ = True`.

Here's a comparison if you're interested:

<details>
<summary>Before</summary>
<p>

```
========================================================================================== test session starts ===========================================================================================
platform darwin -- Python 3.7.1, pytest-4.6.2, py-1.7.0, pluggy-0.12.0
rootdir: /Users/Josh/Projects/scipy-dev/python3/scipy, inifile: pytest.ini
plugins: forked-1.0.2, xdist-1.28.0
collected 1 item

scipy/special/tests/test_mpmath.py F                                                                                                                                                               [100%]

================================================================================================ FAILURES ================================================================================================
__________________________________________________________________________________________ test_hyperu_around_0 __________________________________________________________________________________________

    @check_version(mpmath, '0.19')
    def test_hyperu_around_0():
        dataset = []
        # DLMF 13.2.14-15 test points.
        for n in np.arange(-5, 5):
            for b in np.linspace(-5, 5, 20):
                a = -n
                dataset.append((a, b, 0, float(mpmath.hyperu(a, b, 0))))
                a = -n + b - 1
                dataset.append((a, b, 0, float(mpmath.hyperu(a, b, 0))))
        # DLMF 13.2.16-22 test points.
        for a in [-10.5, -1.5, -0.5, 0, 0.5, 1, 10]:
            for b in [-1.0, -0.5, 0, 0.5, 1, 1.5, 2, 2.5]:
                dataset.append((a, b, 0, float(mpmath.hyperu(a, b, 0))))
        dataset = np.array(dataset)

>       FuncData(sc.hyperu, dataset, (0, 1, 2), 3, rtol=1e-15, atol=5e-15).check()

a          = 10
b          = 2.5
dataset    = array([[ 5.00000000e+00, -5.00000000e+00,  0.00000000e+00,
         3.30687831e-05],
       [-1.00000000e+00, -5.00000...00e+00,
                    inf],
       [ 1.00000000e+01,  2.50000000e+00,  0.00000000e+00,
                    inf]])
n          = 4

scipy/special/tests/test_mpmath.py:124:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <Data for hyperu>
data = array([[ 5.00000000e+00, -5.00000000e+00,  0.00000000e+00,
         3.30687831e-05],
       [-1.00000000e+00, -5.00000...00e+00,
                    inf],
       [ 1.00000000e+01,  2.50000000e+00,  0.00000000e+00,
                    inf]])
dtype = dtype('float64'), dtypes = None

    def check(self, data=None, dtype=None, dtypes=None):
        """Check the special function against the data."""

        if self.knownfailure:
            pytest.xfail(reason=self.knownfailure)

        if data is None:
            data = self.data

        if dtype is None:
            dtype = data.dtype
        else:
            data = data.astype(dtype)

        rtol, atol = self.get_tolerances(dtype)

        # Apply given filter functions
        if self.param_filter:
            param_mask = np.ones((data.shape[0],), np.bool_)
            for j, filter in zip(self.param_columns, self.param_filter):
                if filter:
                    param_mask &= list(filter(data[:,j]))
            data = data[param_mask]

        # Pick parameters from the correct columns
        params = []
        for idx, j in enumerate(self.param_columns):
            if np.iscomplexobj(j):
                j = int(j.imag)
                params.append(data[:,j].astype(complex))
            elif dtypes and idx < len(dtypes):
                params.append(data[:, j].astype(dtypes[idx]))
            else:
                params.append(data[:,j])

        # Helper for evaluating results
        def eval_func_at_params(func, skip_mask=None):
            if self.vectorized:
                got = func(*params)
            else:
                got = []
                for j in range(len(params[0])):
                    if skip_mask is not None and skip_mask[j]:
                        got.append(np.nan)
                        continue
                    got.append(func(*tuple([params[i][j] for i in range(len(params))])))
                got = np.asarray(got)
            if not isinstance(got, tuple):
                got = (got,)
            return got

        # Evaluate function to be tested
        got = eval_func_at_params(self.func)

        # Grab the correct results
        if self.result_columns is not None:
            # Correct results passed in with the data
            wanted = tuple([data[:,icol] for icol in self.result_columns])
        else:
            # Function producing correct results passed in
            skip_mask = None
            if self.nan_ok and len(got) == 1:
                # Don't spend time evaluating what doesn't need to be evaluated
                skip_mask = np.isnan(got[0])
            wanted = eval_func_at_params(self.result_func, skip_mask=skip_mask)

        # Check the validity of each output returned
        assert_(len(got) == len(wanted))

        for output_num, (x, y) in enumerate(zip(got, wanted)):
            if np.issubdtype(x.dtype, np.complexfloating) or self.ignore_inf_sign:
                pinf_x = np.isinf(x)
                pinf_y = np.isinf(y)
                minf_x = np.isinf(x)
                minf_y = np.isinf(y)
            else:
                pinf_x = np.isposinf(x)
                pinf_y = np.isposinf(y)
                minf_x = np.isneginf(x)
                minf_y = np.isneginf(y)
            nan_x = np.isnan(x)
            nan_y = np.isnan(y)

            olderr = np.seterr(all='ignore')
            try:
                abs_y = np.absolute(y)
                abs_y[~np.isfinite(abs_y)] = 0
                diff = np.absolute(x - y)
                diff[~np.isfinite(diff)] = 0

                rdiff = diff / np.absolute(y)
                rdiff[~np.isfinite(rdiff)] = 0
            finally:
                np.seterr(**olderr)

            tol_mask = (diff <= atol + rtol*abs_y)
            pinf_mask = (pinf_x == pinf_y)
            minf_mask = (minf_x == minf_y)

            nan_mask = (nan_x == nan_y)

            bad_j = ~(tol_mask & pinf_mask & minf_mask & nan_mask)

            point_count = bad_j.size
            if self.nan_ok:
                bad_j &= ~nan_x
                bad_j &= ~nan_y
                point_count -= (nan_x | nan_y).sum()

            if not self.distinguish_nan_and_inf and not self.nan_ok:
                # If nan's are okay we've already covered all these cases
                inf_x = np.isinf(x)
                inf_y = np.isinf(y)
                both_nonfinite = (inf_x & nan_y) | (nan_x & inf_y)
                bad_j &= ~both_nonfinite
                point_count -= both_nonfinite.sum()

            if np.any(bad_j):
                # Some bad results: inform what, where, and how bad
                msg = [""]
                msg.append("Max |adiff|: %g" % diff[bad_j].max())
                msg.append("Max |rdiff|: %g" % rdiff[bad_j].max())
                msg.append("Bad results (%d out of %d) for the following points (in output %d):"
                           % (np.sum(bad_j), point_count, output_num,))
                for j in np.nonzero(bad_j)[0]:
                    j = int(j)
                    fmt = lambda x: "%30s" % np.array2string(x[j], precision=18)
                    a = "  ".join(map(fmt, params))
                    b = "  ".join(map(fmt, got))
                    c = "  ".join(map(fmt, wanted))
                    d = fmt(rdiff)
                    msg.append("%s => %s != %s  (rdiff %s)" % (a, b, c, d))
>               assert_(False, "\n".join(msg))
E               AssertionError:
E               Max |adiff|: 3.07241e-14
E               Max |rdiff|: 1
E               Bad results (4 out of 456) for the following points (in output 0):
E                           -6.421052631578947             -3.4210526315789473                              0. =>                             0. !=          9.265394549483148e-15  (rdiff                             1.)
E                           -7.421052631578947             -3.4210526315789473                              0. =>                             0. !=        -2.7796183648449443e-14  (rdiff                             1.)
E                           -6.894736842105264             -2.8947368421052633                              0. =>         1.4029390231210951e-14 !=                             0.  (rdiff                             0.)
E                           -7.368421052631579              -2.368421052631579                              0. =>          3.072409369366093e-14 !=                             0.  (rdiff                             0.)

a          = '            -7.368421052631579              -2.368421052631579                              0.'
abs_y      = array([3.30687831e-05, 5.00000000e+00, 4.70373481e-05, 2.09056025e+00,
       6.87957972e-05, 9.24075393e-01, 1.039806...7.44764615e-08, 2.75573192e-07, 1.56400569e-06,
       0.00000000e+00, 0.00000000e+00, 0.00000000e+00, 0.00000000e+00])
atol       = 5e-15
b          = '         3.072409369366093e-14'
bad_j      = array([False, False, False, False, False, False, False, False, False,
       False, False, False, False, False, False,...       False, False, False, False, False, False, False, False, False,
       False, False, False, False, False, False])
c          = '                            0.'
d          = '                            0.'
data       = array([[ 5.00000000e+00, -5.00000000e+00,  0.00000000e+00,
         3.30687831e-05],
       [-1.00000000e+00, -5.00000...00e+00,
                    inf],
       [ 1.00000000e+01,  2.50000000e+00,  0.00000000e+00,
                    inf]])
diff       = array([6.77626358e-21, 0.00000000e+00, 6.77626358e-20, 4.44089210e-16,
       0.00000000e+00, 1.11022302e-16, 0.000000...2.64697796e-23, 5.29395592e-23, 4.23516474e-22,
       0.00000000e+00, 0.00000000e+00, 0.00000000e+00, 0.00000000e+00])
dtype      = dtype('float64')
dtypes     = None
eval_func_at_params = <function FuncData.check.<locals>.eval_func_at_params at 0x11595c268>
filter     = None
fmt        = <function FuncData.check.<locals>.<lambda> at 0x11fe9bd90>
got        = (array([ 3.30687831e-05,  5.00000000e+00,  4.70373481e-05,  2.09056025e+00,
        6.87957972e-05,  9.24075393e-01,  ...15e-08,  2.75573192e-07,  1.56400569e-06,
                   inf,             inf,             inf,             inf]),)
idx        = 2
j          = 371
minf_mask  = array([ True,  True,  True,  True,  True,  True,  True,  True,  True,
        True,  True,  True,  True,  True,  True,...        True,  True,  True,  True,  True,  True,  True,  True,  True,
        True,  True,  True,  True,  True,  True])
minf_x     = array([False, False, False, False, False, False, False, False, False,
       False, False, False, False, False, False,...       False, False, False, False, False, False, False, False, False,
       False, False, False, False, False, False])
minf_y     = array([False, False, False, False, False, False, False, False, False,
       False, False, False, False, False, False,...       False, False, False, False, False, False, False, False, False,
       False, False, False, False, False, False])
msg        = ['', 'Max |adiff|: 3.07241e-14', 'Max |rdiff|: 1', 'Bad results (4 out of 456) for the following points (in output 0):...  0. =>                             0. !=        -2.7796183648449443e-14  (rdiff                             1.)', ...]
nan_mask   = array([ True,  True,  True,  True,  True,  True,  True,  True,  True,
        True,  True,  True,  True,  True,  True,...        True,  True,  True,  True,  True,  True,  True,  True,  True,
        True,  True,  True,  True,  True,  True])
nan_x      = array([False, False, False, False, False, False, False, False, False,
       False, False, False, False, False, False,...       False, False, False, False, False, False, False, False, False,
       False, False, False, False, False, False])
nan_y      = array([False, False, False, False, False, False, False, False, False,
       False, False, False, False, False, False,...       False, False, False, False, False, False, False, False, False,
       False, False, False, False, False, False])
olderr     = {'divide': 'warn', 'invalid': 'warn', 'over': 'warn', 'under': 'ignore'}
output_num = 0
param_mask = array([ True,  True,  True,  True,  True,  True,  True,  True,  True,
        True,  True,  True,  True,  True,  True,...        True,  True,  True,  True,  True,  True,  True,  True,  True,
        True,  True,  True,  True,  True,  True])
params     = [array([  5.        ,  -1.        ,   5.        ,  -0.47368421,
         5.        ,   0.05263158,   5.        ,   0.5...., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.])]
pinf_mask  = array([ True,  True,  True,  True,  True,  True,  True,  True,  True,
        True,  True,  True,  True,  True,  True,...        True,  True,  True,  True,  True,  True,  True,  True,  True,
        True,  True,  True,  True,  True,  True])
pinf_x     = array([False, False, False, False, False, False, False, False, False,
       False, False, False, False, False, False,...       False, False, False,  True,  True,  True,  True, False, False,
       False, False,  True,  True,  True,  True])
pinf_y     = array([False, False, False, False, False, False, False, False, False,
       False, False, False, False, False, False,...       False, False, False,  True,  True,  True,  True, False, False,
       False, False,  True,  True,  True,  True])
point_count = 456
rdiff      = array([2.04914211e-16, 0.00000000e+00, 1.44061344e-15, 2.12425932e-16,
       0.00000000e+00, 1.20144204e-16, 0.000000...3.55411348e-16, 1.92107072e-16, 2.70789599e-16,
       0.00000000e+00, 0.00000000e+00, 0.00000000e+00, 0.00000000e+00])
rtol       = 1e-15
self       = <Data for hyperu>
tol_mask   = array([ True,  True,  True,  True,  True,  True,  True,  True,  True,
        True,  True,  True,  True,  True,  True,...        True,  True,  True,  True,  True,  True,  True,  True,  True,
        True,  True,  True,  True,  True,  True])
wanted     = (array([ 3.30687831e-05,  5.00000000e+00,  4.70373481e-05,  2.09056025e+00,
        6.87957972e-05,  9.24075393e-01,  ...15e-08,  2.75573192e-07,  1.56400569e-06,
                   inf,             inf,             inf,             inf]),)
x          = array([ 3.30687831e-05,  5.00000000e+00,  4.70373481e-05,  2.09056025e+00,
        6.87957972e-05,  9.24075393e-01,  1...4615e-08,  2.75573192e-07,  1.56400569e-06,
                   inf,             inf,             inf,             inf])
y          = array([ 3.30687831e-05,  5.00000000e+00,  4.70373481e-05,  2.09056025e+00,
        6.87957972e-05,  9.24075393e-01,  1...4615e-08,  2.75573192e-07,  1.56400569e-06,
                   inf,             inf,             inf,             inf])

scipy/special/_testutils.py:307: AssertionError
======================================================================================== 1 failed in 0.30 seconds =======================================================================================
```

</p></details>

<details>
<summary>After</summary>
<p>

```
================================================================================================ FAILURES ================================================================================================
__________________________________________________________________________________________ test_hyperu_around_0 __________________________________________________________________________________________

    @check_version(mpmath, '0.19')
    def test_hyperu_around_0():
        dataset = []
        # DLMF 13.2.14-15 test points.
        for n in np.arange(-5, 5):
            for b in np.linspace(-5, 5, 20):
                a = -n
                dataset.append((a, b, 0, float(mpmath.hyperu(a, b, 0))))
                a = -n + b - 1
                dataset.append((a, b, 0, float(mpmath.hyperu(a, b, 0))))
        # DLMF 13.2.16-22 test points.
        for a in [-10.5, -1.5, -0.5, 0, 0.5, 1, 10]:
            for b in [-1.0, -0.5, 0, 0.5, 1, 1.5, 2, 2.5]:
                dataset.append((a, b, 0, float(mpmath.hyperu(a, b, 0))))
        dataset = np.array(dataset)

>       FuncData(sc.hyperu, dataset, (0, 1, 2), 3, rtol=1e-15, atol=5e-15).check()
E       AssertionError:
E       Max |adiff|: 3.07241e-14
E       Max |rdiff|: 1
E       Bad results (4 out of 456) for the following points (in output 0):
E                   -6.421052631578947             -3.4210526315789473                              0. =>                             0. !=          9.265394549483148e-15  (rdiff                             1.)
E                   -7.421052631578947             -3.4210526315789473                              0. =>                             0. !=        -2.7796183648449443e-14  (rdiff                             1.)
E                   -6.894736842105264             -2.8947368421052633                              0. =>         1.4029390231210951e-14 !=                             0.  (rdiff                             0.)
E                   -7.368421052631579              -2.368421052631579                              0. =>          3.072409369366093e-14 !=                             0.  (rdiff                             0.)

a          = 10
b          = 2.5
dataset    = array([[ 5.00000000e+00, -5.00000000e+00,  0.00000000e+00,
         3.30687831e-05],
       [-1.00000000e+00, -5.00000...00e+00,
                    inf],
       [ 1.00000000e+01,  2.50000000e+00,  0.00000000e+00,
                    inf]])
n          = 4

scipy/special/tests/test_mpmath.py:124: AssertionError
======================================================================================== 1 failed in 0.30 seconds ========================================================================================
```

</p>
</details>