### PR TITLE
Add RuntimeError in _distn_infrastructure.py in fit() method 

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -284,6 +284,9 @@ class norm_gen(rv_continuous):
 
         data = np.asarray(data)
 
+        if not np.isfinite(data).all():
+            raise RuntimeError("The data contains non-finite values.")
+
         if floc is None:
             loc = data.mean()
         else:
@@ -584,10 +587,14 @@ class beta_gen(rv_continuous):
         # "Two unknown parameters" in the section "Maximum likelihood" of
         # the Wikipedia article on the Beta distribution for the formulas.)
 
+        if not np.isfinite(data).all():
+            raise RuntimeError("The data contains non-finite values.")
+
         # Normalize the data to the interval [0, 1].
         data = (np.ravel(data) - floc) / fscale
         if np.any(data <= 0) or np.any(data >= 1):
             raise FitDataError("beta", lower=floc, upper=floc + fscale)
+
         xbar = data.mean()
 
         if f0 is not None or f1 is not None:
@@ -1440,7 +1447,12 @@ class expon_gen(rv_continuous):
                              "optimize.")
 
         data = np.asarray(data)
+
+        if not np.isfinite(data).all():
+            raise RuntimeError("The data contains non-finite values.")
+
         data_min = data.min()
+
         if floc is None:
             # ML estimate of the location is the minimum of the data.
             loc = data_min
@@ -2752,8 +2764,13 @@ class gamma_gen(rv_continuous):
 
         # Fixed location is handled by shifting the data.
         data = np.asarray(data)
+
+        if not np.isfinite(data).all():
+            raise RuntimeError("The data contains non-finite values.")
+
         if np.any(data <= floc):
             raise FitDataError("gamma", lower=floc, upper=np.inf)
+
         if floc != 0:
             # Don't do the subtraction in-place, because `data` might be a
             # view of the input array.
@@ -4892,6 +4909,10 @@ class lognorm_gen(rv_continuous):
                              "optimize.")
 
         data = np.asarray(data)
+
+        if not np.isfinite(data).all():
+            raise RuntimeError("The data contains non-finite values.")
+
         floc = float(floc)
         if floc != 0:
             # Shifting the data by floc. Don't do the subtraction in-place,
@@ -7373,6 +7394,9 @@ class uniform_gen(rv_continuous):
                              "optimize.")
 
         data = np.asarray(data)
+
+        if not np.isfinite(data).all():
+            raise RuntimeError("The data contains non-finite values.")
 
         # MLE for the uniform distribution
         # --------------------------------

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -2232,6 +2232,8 @@ class rv_continuous(rv_generic):
         penalty applied for samples outside of range of the distribution. The
         returned answer is not guaranteed to be the globally optimal MLE, it
         may only be locally optimal, or the optimization may fail altogether.
+        If the data contain any of np.nan, np.inf, or -np.inf, the fit routine
+        will throw a RuntimeError.
 
         Examples
         --------
@@ -2274,6 +2276,9 @@ class rv_continuous(rv_generic):
         Narg = len(args)
         if Narg > self.numargs:
             raise TypeError("Too many input arguments.")
+
+        if not np.isfinite(data).all():
+            raise RuntimeError("The data contains non-finite values.")
 
         start = [None]*2
         if (Narg < self.numargs) or not ('loc' in kwds and

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2066,14 +2066,14 @@ class TestFitMethod(object):
     def setup_method(self):
         np.random.seed(1234)
 
-    # skip these b/c depracated, or only loc and scale arguments
+    # skip these b/c deprecated, or only loc and scale arguments
     fitSkipNonFinite = ['frechet_l', 'frechet_r', 'expon', 'norm', 'uniform', ]
 
     @pytest.mark.parametrize('dist,args', distcont)
     def test_fit_w_non_finite_data_values(self, dist, args):
         """gh-10300"""
         if dist in self.fitSkipNonFinite:
-            pytest.skip("%s fit known to fail or depracated" % dist)
+            pytest.skip("%s fit known to fail or deprecated" % dist)
         x = np.array([1.6483, 2.7169, 2.4667, 1.1791, 3.5433, np.nan])
         y = np.array([1.6483, 2.7169, 2.4667, 1.1791, 3.5433, np.inf])
         distfunc = getattr(stats, dist)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1491,6 +1491,42 @@ class TestExpon(object):
         assert_equal(stats.expon.cdf(1e-18), 1e-18)
         assert_equal(stats.expon.isf(stats.expon.sf(40)), 40)
 
+    def test_nan_raises_error(self):
+        # see gh-issue 10300
+        x = np.array([1.6483, 2.7169, 2.4667, 1.1791, 3.5433, np.nan])
+        assert_raises(RuntimeError, stats.expon.fit, x)
+
+    def test_inf_raises_error(self):
+        # see gh-issue 10300
+        x = np.array([1.6483, 2.7169, 2.4667, 1.1791, 3.5433, np.inf])
+        assert_raises(RuntimeError, stats.expon.fit, x)
+
+
+class TestNorm(object):
+    """gh-10300"""
+    def test_nan_raises_error(self):
+        # see gh-issue 10300
+        x = np.array([1.6483, 2.7169, 2.4667, 1.1791, 3.5433, np.nan])
+        assert_raises(RuntimeError, stats.norm.fit, x)
+
+    def test_inf_raises_error(self):
+        # see gh-issue 10300
+        x = np.array([1.6483, 2.7169, 2.4667, 1.1791, 3.5433, np.inf])
+        assert_raises(RuntimeError, stats.norm.fit, x)
+
+
+class TestUniform(object):
+    """gh-10300"""
+    def test_nan_raises_error(self):
+        # see gh-issue 10300
+        x = np.array([1.6483, 2.7169, 2.4667, 1.1791, 3.5433, np.nan])
+        assert_raises(RuntimeError, stats.uniform.fit, x)
+
+    def test_inf_raises_error(self):
+        # see gh-issue 10300
+        x = np.array([1.6483, 2.7169, 2.4667, 1.1791, 3.5433, np.inf])
+        assert_raises(RuntimeError, stats.uniform.fit, x)
+
 
 class TestExponNorm(object):
     def test_moments(self):
@@ -1519,6 +1555,16 @@ class TestExponNorm(object):
         K = 1.0 / (lam * sig)
         sts = stats.exponnorm.stats(K, loc=mu, scale=sig, moments='mvsk')
         assert_almost_equal(sts, get_moms(lam, sig, mu))
+
+    def test_nan_raises_error(self):
+        # see gh-issue 10300
+        x = np.array([1.6483, 2.7169, 2.4667, 1.1791, 3.5433, np.nan])
+        assert_raises(RuntimeError, stats.exponnorm.fit, x, floc=0, fscale=1)
+
+    def test_inf_raises_error(self):
+        # see gh-issue 10300
+        x = np.array([1.6483, 2.7169, 2.4667, 1.1791, 3.5433, np.inf])
+        assert_raises(RuntimeError, stats.exponnorm.fit, x, floc=0, fscale=1)
 
     def test_extremes_x(self):
         # Test for extreme values against overflows
@@ -2019,6 +2065,22 @@ class TestFitMethod(object):
 
     def setup_method(self):
         np.random.seed(1234)
+
+    # skip these b/c depracated, or only loc and scale arguments
+    fitSkipNonFinite = ['frechet_l', 'frechet_r', 'expon', 'norm', 'uniform', ]
+
+    @pytest.mark.parametrize('dist,args', distcont)
+    def test_fit_w_non_finite_data_values(self, dist, args):
+        """gh-10300"""
+        if dist in self.fitSkipNonFinite:
+            pytest.skip("%s fit known to fail or depracated" % dist)
+        with np.errstate(all='ignore'), suppress_warnings() as sup:
+            sup.filter(category=DeprecationWarning, message=".*frechet_")
+        x = np.array([1.6483, 2.7169, 2.4667, 1.1791, 3.5433, np.nan])
+        y = np.array([1.6483, 2.7169, 2.4667, 1.1791, 3.5433, np.inf])
+        distfunc = getattr(stats, dist)
+        assert_raises(RuntimeError, distfunc.fit, x, floc=0, fscale=1)
+        assert_raises(RuntimeError, distfunc.fit, y, floc=0, fscale=1)
 
     def test_fix_fit_2args_lognorm(self):
         # Regression test for #1551.

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2074,8 +2074,6 @@ class TestFitMethod(object):
         """gh-10300"""
         if dist in self.fitSkipNonFinite:
             pytest.skip("%s fit known to fail or depracated" % dist)
-        with np.errstate(all='ignore'), suppress_warnings() as sup:
-            sup.filter(category=DeprecationWarning, message=".*frechet_")
         x = np.array([1.6483, 2.7169, 2.4667, 1.1791, 3.5433, np.nan])
         y = np.array([1.6483, 2.7169, 2.4667, 1.1791, 3.5433, np.inf])
         distfunc = getattr(stats, dist)


### PR DESCRIPTION
This PR is _one_ proposal to fix #10300 from the discussion w/ @chrisb83  @WarrenWeckesser  and  @kmundnic (who opened the issue). From the discussion on the issue thread it is not clear to me if we want to implement a `nan_policy` for fit or simply throw an error. Given the inconsistency in the current behavior any fix will change the behavior of the `fit()` method. I'd rather have the fix w/minimal disruption to the user base, not sure if this approach or `nan_policy` has less disruption. This implementation was quicker to put together than a full `nan_policy`. However, if we want a full `nan_policy` we should close this PR w/o merging and I'll work towards implementing a `nan_policy`. The 3 commits here are minimal, and replicate the issue in #10300 and resolve the issue by throwing a `RuntimeError` with a descriptive message of the issue. 