### PR TITLE
BENCH, MAINT: wheel_cache_size has been renamed build_cache_size

### DIFF
--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -44,7 +44,7 @@
     "env_dir": "env",
 
     "environment_type": "virtualenv",
-    "wheel_cache_size": 10,
+    "build_cache_size": 10,
 
     // The directory (relative to the current directory) that raw benchmark
     // results are stored in.  If not provided, defaults to "results".


### PR DESCRIPTION
Fixes this warning:
>* `wheel_cache_size` has been renamed to `build_cache_size`. Update your `asv.conf.json` accordingly.

Looks like this requires `asv v0.3` or above which is from september last year.