### PR TITLE
MAINT: More uses of numpy symbols in scipy namespace

### DIFF
--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -84,17 +84,17 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False,
 
     Examples
     --------
-    >>> from scipy import random, linalg, dot, diag, all, allclose
-    >>> a = random.randn(9, 6)
+    >>> from scipy import linalg
+    >>> a = np.random.randn(9, 6)
 
     >>> q, r = linalg.qr(a)
-    >>> allclose(a, np.dot(q, r))
+    >>> np.allclose(a, np.dot(q, r))
     True
     >>> q.shape, r.shape
     ((9, 9), (9, 6))
 
     >>> r2 = linalg.qr(a, mode='r')
-    >>> allclose(r, r2)
+    >>> np.allclose(r, r2)
     True
 
     >>> q3, r3 = linalg.qr(a, mode='economic')
@@ -102,10 +102,10 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False,
     ((9, 6), (6, 6))
 
     >>> q4, r4, p4 = linalg.qr(a, pivoting=True)
-    >>> d = abs(diag(r4))
-    >>> all(d[1:] <= d[:-1])
+    >>> d = np.abs(np.diag(r4))
+    >>> np.all(d[1:] <= d[:-1])
     True
-    >>> allclose(a[:, p4], dot(q4, r4))
+    >>> np.allclose(a[:, p4], np.dot(q4, r4))
     True
     >>> q4.shape, r4.shape, p4.shape
     ((9, 9), (9, 6), (6,))

--- a/scipy/sparse/linalg/isolve/iterative/test.py
+++ b/scipy/sparse/linalg/isolve/iterative/test.py
@@ -1,14 +1,14 @@
 from __future__ import division, print_function, absolute_import
 
-from scipy import *
 from iterative import *
+import numpy as np
 
 
 def test_fun(alpha, x, beta, y, A, n):
     # compute z = alpha*A*x + beta*y
     xx = x[:n]
     yy = y[:n]
-    w = dot(A,xx)
+    w = np.dot(A,xx)
     z = alpha*w+beta*yy
     y[:n] = z
     return
@@ -18,8 +18,8 @@ def test_fun_t(alpha, x, beta, y, A, n):
     # compute z = alpha*A*x + beta*y
     xx = x[:n]
     yy = y[:n]
-    AA = conj(transpose(A))
-    w = dot(AA,xx)
+    AA = np.conj(np.transpose(A))
+    w = np.dot(AA,xx)
     z = alpha*w+beta*yy
     y[:n] = z
     return
@@ -46,24 +46,24 @@ def test_psolveq_t(x,b,which,n):
 
 
 n = 5
-dA = 1.0*array([[2, -1, 0, 0, 0],
-                [-1, 2, -1, 0, 0],
-                [0, -1, 2, -1, 0],
-                [0, 0, -1, 2, -1],
-                [0, 0, 0, 1, 2]])
-db = 1.0*array([0,1,1,0,0])
+dA = 1.0*np.array([[2, -1, 0, 0, 0],
+                   [-1, 2, -1, 0, 0],
+                   [0, -1, 2, -1, 0],
+                   [0, 0, -1, 2, -1],
+                   [0, 0, 0, 1, 2]])
+db = 1.0*np.array([0,1,1,0,0])
 
-##zA = (1.0+0j)*array([[      2, -1+0.1j,       0,       0,       0],
-##                     [-1+0.1j,       2, -1-0.1j,       0,       0],
-##                     [      0, -1-0.1j,       2, -1+0.1j,       0],
-##                     [      0,       0, -1+0.1j,       2, -1-0.1j],
-##                     [      0,       0,       0,      -1,  2-0.1j]])
-zA = (1.0+0j)*array([[2, -1 + 1j, 0, 0, 0],
-                     [-1+0.1j, 2, -1-0.1j, 0, 0],
-                     [0, -1 - 1j, 2, -1+0.1j, 0],
-                     [0, 0, -1+0.1j, 2, -1-0.1j],
-                     [0, 0, 0, -1, 2-0.1j]])
-zb = (1.0+0j)*array([0,1,1,0,0])
+##zA = (1.0+0j)*np.array([[      2, -1+0.1j,       0,       0,       0],
+##                        [-1+0.1j,       2, -1-0.1j,       0,       0],
+##                        [      0, -1-0.1j,       2, -1+0.1j,       0],
+##                        [      0,       0, -1+0.1j,       2, -1-0.1j],
+##                        [      0,       0,       0,      -1,  2-0.1j]])
+zA = (1.0+0j)*np.array([[2, -1 + 1j, 0, 0, 0],
+                        [-1+0.1j, 2, -1-0.1j, 0, 0],
+                        [0, -1 - 1j, 2, -1+0.1j, 0],
+                        [0, 0, -1+0.1j, 2, -1-0.1j],
+                        [0, 0, 0, -1, 2-0.1j]])
+zb = (1.0+0j)*np.array([0,1,1,0,0])
 
 dx = 0*db.copy()
 zx = 0*zb.copy()

--- a/scipy/sparse/linalg/isolve/minres.py
+++ b/scipy/sparse/linalg/isolve/minres.py
@@ -348,7 +348,7 @@ def minres(A, b, x0=None, shift=0.0, tol=1e-5, maxiter=None,
 
 
 if __name__ == '__main__':
-    from scipy import ones, arange
+    from numpy import ones, arange
     from scipy.linalg import norm
     from scipy.sparse import spdiags
 


### PR DESCRIPTION
Related to #10290

I found a few more cases matching the pattern `"from scipy import"`. Mostly just in examples and suplimentary code rather than actual implementations.