### PR TITLE
ENH: Improve fftn performance

### DIFF
--- a/scipy/fft/_pocketfft/basic.py
+++ b/scipy/fft/_pocketfft/basic.py
@@ -6,11 +6,13 @@ from __future__ import division, print_function, absolute_import
 import numpy as np
 import functools
 from scipy.fft._pocketfft import pypocketfft as pfft
-from scipy.fftpack.helper import _init_nd_shape_and_axes
+from scipy.fftpack.helper import (_init_nd_shape_and_axes_impl
+                                  as _init_nd_shape_and_axes)
 
 
 # TODO: Build with OpenMp and add configuration support
 _default_workers = 1
+
 
 def _asfarray(x):
     """

--- a/scipy/fft/_pocketfft/tests/test_basic.py
+++ b/scipy/fft/_pocketfft/tests/test_basic.py
@@ -747,12 +747,12 @@ class TestFftn(object):
     def test_invalid_sizes(self):
         with assert_raises(ValueError,
                            match="invalid number of data points"
-                           r" \(\[1 0\]\) specified"):
+                           r" \(\[1, 0\]\) specified"):
             fftn([[]])
 
         with assert_raises(ValueError,
                            match="invalid number of data points"
-                           r" \(\[ 4 -3\]\) specified"):
+                           r" \(\[4, -3\]\) specified"):
             fftn([[1, 1], [2, 2]], (4, -3))
 
     def test_no_axes(self):
@@ -794,12 +794,12 @@ class TestIfftn(object):
     def test_invalid_sizes(self):
         with assert_raises(ValueError,
                            match="invalid number of data points"
-                           r" \(\[1 0\]\) specified"):
+                           r" \(\[1, 0\]\) specified"):
             ifftn([[]])
 
         with assert_raises(ValueError,
                            match="invalid number of data points"
-                           r" \(\[ 4 -3\]\) specified"):
+                           r" \(\[4, -3\]\) specified"):
             ifftn([[1, 1], [2, 2]], (4, -3))
 
     def test_no_axes(self):
@@ -839,12 +839,12 @@ class TestRfftn(object):
     def test_invalid_sizes(self, func):
         with assert_raises(ValueError,
                            match="invalid number of data points"
-                           r" \(\[1 0\]\) specified"):
+                           r" \(\[1, 0\]\) specified"):
             func([[]])
 
         with assert_raises(ValueError,
                            match="invalid number of data points"
-                           r" \(\[ 4 -3\]\) specified"):
+                           r" \(\[4, -3\]\) specified"):
             func([[1, 1], [2, 2]], (4, -3))
 
     @pytest.mark.parametrize('func', [rfftn, irfftn])

--- a/scipy/fftpack/tests/test_basic.py
+++ b/scipy/fftpack/tests/test_basic.py
@@ -748,12 +748,12 @@ class TestFftn(object):
     def test_invalid_sizes(self):
         with assert_raises(ValueError,
                            match="invalid number of data points"
-                           r" \(\[1 0\]\) specified"):
+                           r" \(\[1, 0\]\) specified"):
             fftn([[]])
 
         with assert_raises(ValueError,
                            match="invalid number of data points"
-                           r" \(\[ 4 -3\]\) specified"):
+                           r" \(\[4, -3\]\) specified"):
             fftn([[1, 1], [2, 2]], (4, -3))
 
 
@@ -791,12 +791,12 @@ class TestIfftn(object):
     def test_invalid_sizes(self):
         with assert_raises(ValueError,
                            match="invalid number of data points"
-                           r" \(\[1 0\]\) specified"):
+                           r" \(\[1, 0\]\) specified"):
             ifftn([[]])
 
         with assert_raises(ValueError,
                            match="invalid number of data points"
-                           r" \(\[ 4 -3\]\) specified"):
+                           r" \(\[4, -3\]\) specified"):
             ifftn([[1, 1], [2, 2]], (4, -3))
 
 


### PR DESCRIPTION
#### What does this implement/fix?
`fftpack`'s `_init_nd_shape_and_axes` is quite slow due to it's use of very small length numpy arrays. Moving over to list comprehensions gives a nice speed improvement (except possibly for *very* high dimensional transforms).

~I put this in `_pocketfft` instead of modifying `fftpack` because the `fftpack` users of this function assume the return value is an array which `_pocketfft` doesn't.~

#### Additional information
This simple benchmark shows the improvements: up to 40 us (98%!) faster in some cases, particularly those involving `None`:
```python
In [1]: from scipy.fft._pocketfft.basic import _init_nd_shape_and_axes as pocket_init
In [2]: from scipy.fftpack.helper import _init_nd_shape_and_axes as pack_init
In [3]: trials = [(None, None), (None, (1,)), ((10, 20, 30), None), ((10, 20, 30), (2, 1, 0))]
In [4]: import numpy as np; x = np.random.random((128, 64, 64))
In [5]: for s, a in trials:
...:     print('Trial fttpack: ', s, a)
...:     %timeit pack_init(x, s, a)
...:     print('Trial pocketfft: ', s, a)
...:     %timeit pocket_init(x, s, a)
...:
Trial fttpack:  None None
43.4 µs ± 2.69 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
Trial pocketfft:  None None
930 ns ± 69.5 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
Trial fttpack:  None (1,)
37.8 µs ± 2.03 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
Trial pocketfft:  None (1,)
6.23 µs ± 332 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
Trial fttpack:  (10, 20, 30) None
40.6 µs ± 3.01 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
Trial pocketfft:  (10, 20, 30) None
6.72 µs ± 398 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
Trial fttpack:  (10, 20, 30) (2, 1, 0)
35.7 µs ± 3.08 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
Trial pocketfft:  (10, 20, 30) (2, 1, 0)
13.6 µs ± 572 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```