### PR TITLE
ENH: Use DCT and DST from pocketfft

### DIFF
--- a/benchmarks/benchmarks/fft_basic.py
+++ b/benchmarks/benchmarks/fft_basic.py
@@ -124,6 +124,29 @@ class RFft(Benchmark):
         self.irfft(self.y)
 
 
+class RealTransforms1D(Benchmark):
+    params = [
+        [75, 100, 135, 256, 313, 512, 675, 1024, 2025, 2048],
+        ['I', 'II', 'III', 'IV'],
+        ['scipy.fftpack', 'scipy.fft']
+    ]
+    param_names = ['size', 'type', 'module']
+
+    def setup(self, size, type, module):
+        self.x = random([size]).astype(double)
+
+        module = module_map[module]
+        self.dct = getattr(module, 'dct')
+        self.dst = getattr(module, 'dst')
+        self.type = {'I':1, 'II':2, 'III':3, 'IV':4}[type]
+
+    def time_dct(self, size, type, module):
+        self.dct(self.x, self.type)
+
+    def time_dst(self, size, type, module):
+        self.dst(self.x, self.type)
+
+
 class Fftn(Benchmark):
     params = [
         ["100x100", "313x100", "1000x100", "256x256", "512x512"],
@@ -144,6 +167,29 @@ class Fftn(Benchmark):
 
     def time_fftn(self, size, cmplx, module):
         self.fftn(self.x)
+
+
+class RealTransformsND(Benchmark):
+    params = [
+        ['75x75', '100x100', '135x135', '313x363', '1000x100', '256x256'],
+        ['I', 'II', 'III', 'IV'],
+        ['scipy.fftpack', 'scipy.fft']
+    ]
+    param_names = ['size', 'type', 'module']
+
+    def setup(self, size, type, module):
+        size = list(map(int, size.split('x')))
+        self.x = random(size).astype(double)
+
+        self.dctn = getattr(module_map[module], 'dctn')
+        self.dstn = getattr(module_map[module], 'dstn')
+        self.type = {'I':1, 'II':2, 'III':3, 'IV':4}[type]
+
+    def time_dctn(self, size, type, module):
+        self.dctn(self.x, self.type)
+
+    def time_dstn(self, size, type, module):
+        self.dstn(self.x, self.type)
 
 
 class FftBackends(Benchmark):

--- a/scipy/fft/_backend.py
+++ b/scipy/fft/_backend.py
@@ -16,21 +16,9 @@ class _ScipyBackend:
     """
     __ua_domain__ = "numpy.scipy.fft"
 
-    realtransforms = {
-        'dct': _fftpack.dct,
-        'dst': _fftpack.dst,
-        'dctn': _fftpack.dctn,
-        'dstn': _fftpack.dstn,
-        'idct': _realtransforms._idct,
-        'idst': _realtransforms._idst,
-        'idctn': _realtransforms._idctn,
-        'idstn': _realtransforms._idstn,
-    }
-
     @staticmethod
     def __ua_function__(method, args, kwargs):
-        fn = (getattr(_pocketfft, method.__name__, None)
-              or _ScipyBackend.realtransforms.get(method.__name__, None))
+        fn = getattr(_pocketfft, method.__name__, None)
 
         if fn is None:
             return NotImplemented

--- a/scipy/fft/_pocketfft/README.md
+++ b/scipy/fft/_pocketfft/README.md
@@ -1,8 +1,8 @@
 pypocketfft
 ===========
 
-This package provides Fast Fourier and Hartley transforms with a simple
-Python interface.
+This package provides Fast Fourier, trigonometric and Hartley transforms with a
+simple Python interface.
 
 The central algorithms are derived from Paul Swarztrauber's FFTPACK code
 (http://www.netlib.org/fftpack).
@@ -10,11 +10,11 @@ The central algorithms are derived from Paul Swarztrauber's FFTPACK code
 Features
 --------
 - supports fully complex and half-complex (i.e. complex-to-real and
-  real-to-complex) FFTs
-- supports multidimensional arrays and selection of the axes to be transformed.
-- supports single and double precision
+  real-to-complex) FFTs, discrete sine/cosine transforms and Hartley transforms
+- achieves very high accuracy for all transforms
+- supports multidimensional arrays and selection of the axes to be transformed
+- supports single, double, and long double precision
 - makes use of CPU vector instructions when performing 2D and higher-dimensional
   transforms
-- does not have persistent transform plans, which makes the interface simpler
 - supports prime-length transforms without degrading to O(N**2) performance
-- Has optional OpenMP support for multidimensional transforms
+- has optional OpenMP support for multidimensional transforms

--- a/scipy/fft/_pocketfft/__init__.py
+++ b/scipy/fft/_pocketfft/__init__.py
@@ -1,6 +1,7 @@
 """ FFT backend using pypocketfft """
 
 from .basic import *
+from .realtransforms import *
 
 from scipy._lib._testutils import PytestTester
 test = PytestTester(__name__)

--- a/scipy/fft/_pocketfft/realtransforms.py
+++ b/scipy/fft/_pocketfft/realtransforms.py
@@ -1,0 +1,109 @@
+import numpy as np
+from . import pypocketfft as pfft
+from .basic import (_asfarray, _init_nd_shape_and_axes, _datacopied,
+                    _fix_shape, _fix_shape_1d, _normalization,
+                    _default_workers)
+import functools
+
+
+def _r2r(forward, transform, x, type=2, n=None, axis=-1, norm=None,
+         overwrite_x=False):
+    """Forward or backward 1d DCT/DST
+
+    Parameters
+    ----------
+    forward: bool
+        Transform direction (determines type and normalisation)
+    transform: {pypocketfft.dct, pypocketfft.dst}
+        The transform to perform
+    """
+    tmp = _asfarray(x)
+    overwrite_x = overwrite_x or _datacopied(tmp, x)
+    norm = _normalization(norm, forward)
+
+    if not forward:
+        if type == 2:
+            type = 3
+        elif type == 3:
+            type = 2
+
+    if n is not None:
+        tmp, copied = _fix_shape_1d(tmp, n, axis)
+        overwrite_x = overwrite_x or copied
+    elif tmp.shape[axis] < 1:
+        raise ValueError("invalid number of data points ({0}) specified"
+                         .format(tmp.shape[axis]))
+
+    out = (tmp if overwrite_x else None)
+
+    # For complex input, transform real and imaginary components seperably
+    if np.iscomplexobj(x):
+        out = out or np.empty_like(tmp)
+        transform(tmp.real, type, (axis,), norm, out.real, _default_workers)
+        transform(tmp.imag, type, (axis,), norm, out.imag, _default_workers)
+        return out
+
+    return transform(tmp, type, (axis,), norm, out, _default_workers)
+
+
+dct = functools.partial(_r2r, True, pfft.dct)
+dct.__name__ = 'dct'
+idct = functools.partial(_r2r, False, pfft.dct)
+idct.__name__ = 'idct'
+
+dst = functools.partial(_r2r, True, pfft.dst)
+dst.__name__ = 'dst'
+idst = functools.partial(_r2r, False, pfft.dst)
+idst.__name__ = 'idst'
+
+
+def _r2rn(forward, transform, x, type=2, shape=None, axes=None, norm=None,
+          overwrite_x=False):
+    """Forward or backward nd DCT/DST
+
+    Parameters
+    ----------
+    forward: bool
+        Transform direction (determines type and normalisation)
+    transform: {pypocketfft.dct, pypocketfft.dst}
+        The transform to perform
+    """
+    tmp = _asfarray(x)
+
+    shape, axes = _init_nd_shape_and_axes(tmp, shape, axes)
+    overwrite_x = overwrite_x or _datacopied(tmp, x)
+
+    if len(axes) == 0:
+        return x
+
+    tmp, copied = _fix_shape(tmp, shape, axes)
+    overwrite_x = overwrite_x or copied
+
+    if not forward:
+        if type == 2:
+            type = 3
+        elif type == 3:
+            type = 2
+
+    norm = _normalization(norm, forward)
+    out = (tmp if overwrite_x else None)
+
+    # For complex input, transform real and imaginary components seperably
+    if np.iscomplexobj(x):
+        out = out or np.empty_like(tmp)
+        transform(tmp.real, type, axes, norm, out.real, _default_workers)
+        transform(tmp.imag, type, axes, norm, out.imag, _default_workers)
+        return out
+
+    return transform(tmp, type, axes, norm, out, _default_workers)
+
+
+dctn = functools.partial(_r2rn, True, pfft.dct)
+dctn.__name__ = 'dctn'
+idctn = functools.partial(_r2rn, False, pfft.dct)
+idctn.__name__ = 'idctn'
+
+dstn = functools.partial(_r2rn, True, pfft.dst)
+dstn.__name__ = 'dstn'
+idstn = functools.partial(_r2rn, False, pfft.dst)
+idstn.__name__ = 'idstn'

--- a/scipy/fft/_pocketfft/tests/test_real_transforms.py
+++ b/scipy/fft/_pocketfft/tests/test_real_transforms.py
@@ -1,0 +1,815 @@
+from __future__ import division, print_function, absolute_import
+
+from os.path import join, dirname
+
+import numpy as np
+from numpy.testing import assert_array_almost_equal, assert_equal
+import pytest
+from pytest import raises as assert_raises
+
+from scipy.fft._pocketfft.realtransforms import (
+    dct, idct, dst, idst, dctn, idctn, dstn, idstn)
+
+fftpack_test_dir = join(dirname(__file__), '..', '..', '..', 'fftpack', 'tests')
+
+# Matlab reference data
+MDATA = np.load(join(fftpack_test_dir, 'test.npz'))
+X = [MDATA['x%d' % i] for i in range(8)]
+Y = [MDATA['y%d' % i] for i in range(8)]
+
+# FFTW reference data: the data are organized as follows:
+#    * SIZES is an array containing all available sizes
+#    * for every type (1, 2, 3, 4) and every size, the array dct_type_size
+#    contains the output of the DCT applied to the input np.linspace(0, size-1,
+#    size)
+FFTWDATA_DOUBLE = np.load(join(fftpack_test_dir, 'fftw_double_ref.npz'))
+FFTWDATA_SINGLE = np.load(join(fftpack_test_dir, 'fftw_single_ref.npz'))
+FFTWDATA_SIZES = FFTWDATA_DOUBLE['sizes']
+
+
+def fftw_dct_ref(type, size, dt):
+    x = np.linspace(0, size-1, size).astype(dt)
+    dt = np.result_type(np.float32, dt)
+    if dt == np.double:
+        data = FFTWDATA_DOUBLE
+    elif dt == np.float32:
+        data = FFTWDATA_SINGLE
+    else:
+        raise ValueError()
+    y = (data['dct_%d_%d' % (type, size)]).astype(dt)
+    return x, y, dt
+
+
+def fftw_dst_ref(type, size, dt):
+    x = np.linspace(0, size-1, size).astype(dt)
+    dt = np.result_type(np.float32, dt)
+    if dt == np.double:
+        data = FFTWDATA_DOUBLE
+    elif dt == np.float32:
+        data = FFTWDATA_SINGLE
+    else:
+        raise ValueError()
+    y = (data['dst_%d_%d' % (type, size)]).astype(dt)
+    return x, y, dt
+
+
+def dct_2d_ref(x, **kwargs):
+    """Calculate reference values for testing dct2."""
+    x = np.array(x, copy=True)
+    for row in range(x.shape[0]):
+        x[row, :] = dct(x[row, :], **kwargs)
+    for col in range(x.shape[1]):
+        x[:, col] = dct(x[:, col], **kwargs)
+    return x
+
+
+def idct_2d_ref(x, **kwargs):
+    """Calculate reference values for testing idct2."""
+    x = np.array(x, copy=True)
+    for row in range(x.shape[0]):
+        x[row, :] = idct(x[row, :], **kwargs)
+    for col in range(x.shape[1]):
+        x[:, col] = idct(x[:, col], **kwargs)
+    return x
+
+
+def dst_2d_ref(x, **kwargs):
+    """Calculate reference values for testing dst2."""
+    x = np.array(x, copy=True)
+    for row in range(x.shape[0]):
+        x[row, :] = dst(x[row, :], **kwargs)
+    for col in range(x.shape[1]):
+        x[:, col] = dst(x[:, col], **kwargs)
+    return x
+
+
+def idst_2d_ref(x, **kwargs):
+    """Calculate reference values for testing idst2."""
+    x = np.array(x, copy=True)
+    for row in range(x.shape[0]):
+        x[row, :] = idst(x[row, :], **kwargs)
+    for col in range(x.shape[1]):
+        x[:, col] = idst(x[:, col], **kwargs)
+    return x
+
+
+def naive_dct1(x, norm=None):
+    """Calculate textbook definition version of DCT-I."""
+    x = np.array(x, copy=True)
+    N = len(x)
+    M = N-1
+    y = np.zeros(N)
+    m0, m = 1, 2
+    if norm == 'ortho':
+        m0 = np.sqrt(1.0/M)
+        m = np.sqrt(2.0/M)
+    for k in range(N):
+        for n in range(1, N-1):
+            y[k] += m*x[n]*np.cos(np.pi*n*k/M)
+        y[k] += m0 * x[0]
+        y[k] += m0 * x[N-1] * (1 if k % 2 == 0 else -1)
+    if norm == 'ortho':
+        y[0] *= 1/np.sqrt(2)
+        y[N-1] *= 1/np.sqrt(2)
+    return y
+
+
+def naive_dst1(x, norm=None):
+    """Calculate textbook definition version  of DST-I."""
+    x = np.array(x, copy=True)
+    N = len(x)
+    M = N+1
+    y = np.zeros(N)
+    for k in range(N):
+        for n in range(N):
+            y[k] += 2*x[n]*np.sin(np.pi*(n+1.0)*(k+1.0)/M)
+    if norm == 'ortho':
+        y *= np.sqrt(0.5/M)
+    return y
+
+
+def naive_dct4(x, norm=None):
+    """Calculate textbook definition version  of DCT-IV."""
+    x = np.array(x, copy=True)
+    N = len(x)
+    y = np.zeros(N)
+    for k in range(N):
+        for n in range(N):
+            y[k] += x[n]*np.cos(np.pi*(n+0.5)*(k+0.5)/(N))
+    if norm == 'ortho':
+        y *= np.sqrt(2.0/N)
+    else:
+        y *= 2
+    return y
+
+
+def naive_dst4(x, norm=None):
+    """Calculate textbook definition version  of DST-IV."""
+    x = np.array(x, copy=True)
+    N = len(x)
+    y = np.zeros(N)
+    for k in range(N):
+        for n in range(N):
+            y[k] += x[n]*np.sin(np.pi*(n+0.5)*(k+0.5)/(N))
+    if norm == 'ortho':
+        y *= np.sqrt(2.0/N)
+    else:
+        y *= 2
+    return y
+
+
+class TestComplex(object):
+    def test_dct_complex64(self):
+        y = dct(1j*np.arange(5, dtype=np.complex64))
+        x = 1j*dct(np.arange(5))
+        assert_array_almost_equal(x, y)
+
+    def test_dct_complex(self):
+        y = dct(np.arange(5)*1j)
+        x = 1j*dct(np.arange(5))
+        assert_array_almost_equal(x, y)
+
+    def test_idct_complex(self):
+        y = idct(np.arange(5)*1j)
+        x = 1j*idct(np.arange(5))
+        assert_array_almost_equal(x, y)
+
+    def test_dst_complex64(self):
+        y = dst(np.arange(5, dtype=np.complex64)*1j)
+        x = 1j*dst(np.arange(5))
+        assert_array_almost_equal(x, y)
+
+    def test_dst_complex(self):
+        y = dst(np.arange(5)*1j)
+        x = 1j*dst(np.arange(5))
+        assert_array_almost_equal(x, y)
+
+    def test_idst_complex(self):
+        y = idst(np.arange(5)*1j)
+        x = 1j*idst(np.arange(5))
+        assert_array_almost_equal(x, y)
+
+
+class _TestDCTBase(object):
+    def setup_method(self):
+        self.rdt = None
+        self.dec = 14
+        self.type = None
+
+    def test_definition(self):
+        for i in FFTWDATA_SIZES:
+            x, yr, dt = fftw_dct_ref(self.type, i, self.rdt)
+            y = dct(x, type=self.type)
+            assert_equal(y.dtype, dt)
+            # XXX: we divide by np.max(y) because the tests fail otherwise. We
+            # should really use something like assert_array_approx_equal. The
+            # difference is due to fftw using a better algorithm w.r.t error
+            # propagation compared to the ones from fftpack.
+            assert_array_almost_equal(y / np.max(y), yr / np.max(y), decimal=self.dec,
+                    err_msg="Size %d failed" % i)
+
+    def test_axis(self):
+        nt = 2
+        for i in [7, 8, 9, 16, 32, 64]:
+            x = np.random.randn(nt, i)
+            y = dct(x, type=self.type)
+            for j in range(nt):
+                assert_array_almost_equal(y[j], dct(x[j], type=self.type),
+                        decimal=self.dec)
+
+            x = x.T
+            y = dct(x, axis=0, type=self.type)
+            for j in range(nt):
+                assert_array_almost_equal(y[:,j], dct(x[:,j], type=self.type),
+                        decimal=self.dec)
+
+
+class _TestDCTIBase(_TestDCTBase):
+    def test_definition_ortho(self):
+        # Test orthornomal mode.
+        for i in range(len(X)):
+            x = np.array(X[i], dtype=self.rdt)
+            dt = np.result_type(np.float32, self.rdt)
+            y = dct(x, norm='ortho', type=1)
+            y2 = naive_dct1(x, norm='ortho')
+            assert_equal(y.dtype, dt)
+            assert_array_almost_equal(y / np.max(y), y2 / np.max(y), decimal=self.dec)
+
+class _TestDCTIIBase(_TestDCTBase):
+    def test_definition_matlab(self):
+        # Test correspondence with matlab (orthornomal mode).
+        for i in range(len(X)):
+            dt = np.result_type(np.float32, self.rdt)
+            x = np.array(X[i], dtype=dt)
+
+            yr = Y[i]
+            y = dct(x, norm="ortho", type=2)
+            assert_equal(y.dtype, dt)
+            assert_array_almost_equal(y, yr, decimal=self.dec)
+
+
+class _TestDCTIIIBase(_TestDCTBase):
+    def test_definition_ortho(self):
+        # Test orthornomal mode.
+        for i in range(len(X)):
+            x = np.array(X[i], dtype=self.rdt)
+            dt = np.result_type(np.float32, self.rdt)
+            y = dct(x, norm='ortho', type=2)
+            xi = dct(y, norm="ortho", type=3)
+            assert_equal(xi.dtype, dt)
+            assert_array_almost_equal(xi, x, decimal=self.dec)
+
+class _TestDCTIVBase(_TestDCTBase):
+    def test_definition_ortho(self):
+        # Test orthornomal mode.
+        for i in range(len(X)):
+            x = np.array(X[i], dtype=self.rdt)
+            dt = np.result_type(np.float32, self.rdt)
+            y = dct(x, norm='ortho', type=4)
+            y2 = naive_dct4(x, norm='ortho')
+            assert_equal(y.dtype, dt)
+            assert_array_almost_equal(y / np.max(y), y2 / np.max(y), decimal=self.dec)
+
+
+class TestDCTIDouble(_TestDCTIBase):
+    def setup_method(self):
+        self.rdt = np.double
+        self.dec = 10
+        self.type = 1
+
+
+class TestDCTIFloat(_TestDCTIBase):
+    def setup_method(self):
+        self.rdt = np.float32
+        self.dec = 4
+        self.type = 1
+
+
+class TestDCTIInt(_TestDCTIBase):
+    def setup_method(self):
+        self.rdt = int
+        self.dec = 5
+        self.type = 1
+
+
+class TestDCTIIDouble(_TestDCTIIBase):
+    def setup_method(self):
+        self.rdt = np.double
+        self.dec = 10
+        self.type = 2
+
+
+class TestDCTIIFloat(_TestDCTIIBase):
+    def setup_method(self):
+        self.rdt = np.float32
+        self.dec = 5
+        self.type = 2
+
+
+class TestDCTIIInt(_TestDCTIIBase):
+    def setup_method(self):
+        self.rdt = int
+        self.dec = 5
+        self.type = 2
+
+
+class TestDCTIIIDouble(_TestDCTIIIBase):
+    def setup_method(self):
+        self.rdt = np.double
+        self.dec = 14
+        self.type = 3
+
+
+class TestDCTIIIFloat(_TestDCTIIIBase):
+    def setup_method(self):
+        self.rdt = np.float32
+        self.dec = 5
+        self.type = 3
+
+
+class TestDCTIIIInt(_TestDCTIIIBase):
+    def setup_method(self):
+        self.rdt = int
+        self.dec = 5
+        self.type = 3
+
+
+class TestDCTIVDouble(_TestDCTIVBase):
+    def setup_method(self):
+        self.rdt = np.double
+        self.dec = 12
+        self.type = 3
+
+
+class TestDCTIVFloat(_TestDCTIVBase):
+    def setup_method(self):
+        self.rdt = np.float32
+        self.dec = 5
+        self.type = 3
+
+
+class TestDCTIVInt(_TestDCTIVBase):
+    def setup_method(self):
+        self.rdt = int
+        self.dec = 5
+        self.type = 3
+
+
+class _TestIDCTBase(object):
+    def setup_method(self):
+        self.rdt = None
+        self.dec = 14
+        self.type = None
+
+    def test_definition(self):
+        for i in FFTWDATA_SIZES:
+            xr, yr, dt = fftw_dct_ref(self.type, i, self.rdt)
+            x = idct(yr, type=self.type)
+            assert_equal(x.dtype, dt)
+            # XXX: we divide by np.max(y) because the tests fail otherwise. We
+            # should really use something like assert_array_approx_equal. The
+            # difference is due to fftw using a better algorithm w.r.t error
+            # propagation compared to the ones from fftpack.
+            assert_array_almost_equal(x / np.max(x), xr / np.max(x), decimal=self.dec,
+                    err_msg="Size %d failed" % i)
+
+
+class TestIDCTIDouble(_TestIDCTBase):
+    def setup_method(self):
+        self.rdt = np.double
+        self.dec = 10
+        self.type = 1
+
+
+class TestIDCTIFloat(_TestIDCTBase):
+    def setup_method(self):
+        self.rdt = np.float32
+        self.dec = 4
+        self.type = 1
+
+
+class TestIDCTIInt(_TestIDCTBase):
+    def setup_method(self):
+        self.rdt = int
+        self.dec = 4
+        self.type = 1
+
+
+class TestIDCTIIDouble(_TestIDCTBase):
+    def setup_method(self):
+        self.rdt = np.double
+        self.dec = 10
+        self.type = 2
+
+
+class TestIDCTIIFloat(_TestIDCTBase):
+    def setup_method(self):
+        self.rdt = np.float32
+        self.dec = 5
+        self.type = 2
+
+
+class TestIDCTIIInt(_TestIDCTBase):
+    def setup_method(self):
+        self.rdt = int
+        self.dec = 5
+        self.type = 2
+
+
+class TestIDCTIIIDouble(_TestIDCTBase):
+    def setup_method(self):
+        self.rdt = np.double
+        self.dec = 14
+        self.type = 3
+
+
+class TestIDCTIIIFloat(_TestIDCTBase):
+    def setup_method(self):
+        self.rdt = np.float32
+        self.dec = 5
+        self.type = 3
+
+
+class TestIDCTIIIInt(_TestIDCTBase):
+    def setup_method(self):
+        self.rdt = int
+        self.dec = 5
+        self.type = 3
+
+class TestIDCTIVDouble(_TestIDCTBase):
+    def setup_method(self):
+        self.rdt = np.double
+        self.dec = 12
+        self.type = 4
+
+
+class TestIDCTIVFloat(_TestIDCTBase):
+    def setup_method(self):
+        self.rdt = np.float32
+        self.dec = 5
+        self.type = 4
+
+
+class TestIDCTIVInt(_TestIDCTBase):
+    def setup_method(self):
+        self.rdt = int
+        self.dec = 5
+        self.type = 4
+
+class _TestDSTBase(object):
+    def setup_method(self):
+        self.rdt = None  # dtype
+        self.dec = None  # number of decimals to match
+        self.type = None  # dst type
+
+    def test_definition(self):
+        for i in FFTWDATA_SIZES:
+            xr, yr, dt = fftw_dst_ref(self.type, i, self.rdt)
+            y = dst(xr, type=self.type)
+            assert_equal(y.dtype, dt)
+            # XXX: we divide by np.max(y) because the tests fail otherwise. We
+            # should really use something like assert_array_approx_equal. The
+            # difference is due to fftw using a better algorithm w.r.t error
+            # propagation compared to the ones from fftpack.
+            assert_array_almost_equal(y / np.max(y), yr / np.max(y), decimal=self.dec,
+                    err_msg="Size %d failed" % i)
+
+
+class _TestDSTIBase(_TestDSTBase):
+    def test_definition_ortho(self):
+        # Test orthornomal mode.
+        for i in range(len(X)):
+            x = np.array(X[i], dtype=self.rdt)
+            dt = np.result_type(np.float32, self.rdt)
+            y = dst(x, norm='ortho', type=1)
+            y2 = naive_dst1(x, norm='ortho')
+            assert_equal(y.dtype, dt)
+            assert_array_almost_equal(y / np.max(y), y2 / np.max(y), decimal=self.dec)
+
+class _TestDSTIVBase(_TestDSTBase):
+    def test_definition_ortho(self):
+        # Test orthornomal mode.
+        for i in range(len(X)):
+            x = np.array(X[i], dtype=self.rdt)
+            dt = np.result_type(np.float32, self.rdt)
+            y = dst(x, norm='ortho', type=4)
+            y2 = naive_dst4(x, norm='ortho')
+            assert_equal(y.dtype, dt)
+            assert_array_almost_equal(y, y2, decimal=self.dec)
+
+class TestDSTIDouble(_TestDSTIBase):
+    def setup_method(self):
+        self.rdt = np.double
+        self.dec = 12
+        self.type = 1
+
+
+class TestDSTIFloat(_TestDSTIBase):
+    def setup_method(self):
+        self.rdt = np.float32
+        self.dec = 4
+        self.type = 1
+
+
+class TestDSTIInt(_TestDSTIBase):
+    def setup_method(self):
+        self.rdt = int
+        self.dec = 5
+        self.type = 1
+
+
+class TestDSTIIDouble(_TestDSTBase):
+    def setup_method(self):
+        self.rdt = np.double
+        self.dec = 14
+        self.type = 2
+
+
+class TestDSTIIFloat(_TestDSTBase):
+    def setup_method(self):
+        self.rdt = np.float32
+        self.dec = 6
+        self.type = 2
+
+
+class TestDSTIIInt(_TestDSTBase):
+    def setup_method(self):
+        self.rdt = int
+        self.dec = 6
+        self.type = 2
+
+
+class TestDSTIIIDouble(_TestDSTBase):
+    def setup_method(self):
+        self.rdt = np.double
+        self.dec = 14
+        self.type = 3
+
+
+class TestDSTIIIFloat(_TestDSTBase):
+    def setup_method(self):
+        self.rdt = np.float32
+        self.dec = 7
+        self.type = 3
+
+
+class TestDSTIIIInt(_TestDSTBase):
+    def setup_method(self):
+        self.rdt = int
+        self.dec = 7
+        self.type = 3
+
+
+class TestDSTIVDouble(_TestDSTIVBase):
+    def setup_method(self):
+        self.rdt = np.double
+        self.dec = 12
+        self.type = 4
+
+
+class TestDSTIVFloat(_TestDSTIVBase):
+    def setup_method(self):
+        self.rdt = np.float32
+        self.dec = 4
+        self.type = 4
+
+
+class TestDSTIVInt(_TestDSTIVBase):
+    def setup_method(self):
+        self.rdt = int
+        self.dec = 5
+        self.type = 4
+
+
+class _TestIDSTBase(object):
+    def setup_method(self):
+        self.rdt = None
+        self.dec = None
+        self.type = None
+
+    def test_definition(self):
+        for i in FFTWDATA_SIZES:
+            xr, yr, dt = fftw_dst_ref(self.type, i, self.rdt)
+            x = idst(yr, type=self.type)
+            assert_equal(x.dtype, dt)
+            # XXX: we divide by np.max(x) because the tests fail otherwise. We
+            # should really use something like assert_array_approx_equal. The
+            # difference is due to fftw using a better algorithm w.r.t error
+            # propagation compared to the ones from fftpack.
+            assert_array_almost_equal(x / np.max(x), xr / np.max(x), decimal=self.dec,
+                    err_msg="Size %d failed" % i)
+
+
+class TestIDSTIDouble(_TestIDSTBase):
+    def setup_method(self):
+        self.rdt = np.double
+        self.dec = 12
+        self.type = 1
+
+
+class TestIDSTIFloat(_TestIDSTBase):
+    def setup_method(self):
+        self.rdt = np.float32
+        self.dec = 4
+        self.type = 1
+
+
+class TestIDSTIInt(_TestIDSTBase):
+    def setup_method(self):
+        self.rdt = int
+        self.dec = 4
+        self.type = 1
+
+
+class TestIDSTIIDouble(_TestIDSTBase):
+    def setup_method(self):
+        self.rdt = np.double
+        self.dec = 14
+        self.type = 2
+
+
+class TestIDSTIIFloat(_TestIDSTBase):
+    def setup_method(self):
+        self.rdt = np.float32
+        self.dec = 6
+        self.type = 2
+
+
+class TestIDSTIIInt(_TestIDSTBase):
+    def setup_method(self):
+        self.rdt = int
+        self.dec = 6
+        self.type = 2
+
+
+class TestIDSTIIIDouble(_TestIDSTBase):
+    def setup_method(self):
+        self.rdt = np.double
+        self.dec = 14
+        self.type = 3
+
+
+class TestIDSTIIIFloat(_TestIDSTBase):
+    def setup_method(self):
+        self.rdt = np.float32
+        self.dec = 6
+        self.type = 3
+
+
+class TestIDSTIIIInt(_TestIDSTBase):
+    def setup_method(self):
+        self.rdt = int
+        self.dec = 6
+        self.type = 3
+
+
+class TestIDSTIVDouble(_TestIDSTBase):
+    def setup_method(self):
+        self.rdt = np.double
+        self.dec = 12
+        self.type = 4
+
+
+class TestIDSTIVFloat(_TestIDSTBase):
+    def setup_method(self):
+        self.rdt = np.float32
+        self.dec = 6
+        self.type = 4
+
+
+class TestIDSTIVnt(_TestIDSTBase):
+    def setup_method(self):
+        self.rdt = int
+        self.dec = 6
+        self.type = 4
+
+
+class TestOverwrite(object):
+    """Check input overwrite behavior."""
+
+    real_dtypes = [np.float32, np.float64]
+
+    def _check(self, x, routine, type, fftsize, axis, norm, overwrite_x,
+               should_overwrite, **kw):
+        x2 = x.copy()
+        routine(x2, type, fftsize, axis, norm, overwrite_x=overwrite_x)
+
+        sig = "%s(%s%r, %r, axis=%r, overwrite_x=%r)" % (
+            routine.__name__, x.dtype, x.shape, fftsize, axis, overwrite_x)
+        if not should_overwrite:
+            assert_equal(x2, x, err_msg="spurious overwrite in %s" % sig)
+
+    def _check_1d(self, routine, dtype, shape, axis):
+        np.random.seed(1234)
+        if np.issubdtype(dtype, np.complexfloating):
+            data = np.random.randn(*shape) + 1j*np.random.randn(*shape)
+        else:
+            data = np.random.randn(*shape)
+        data = data.astype(dtype)
+
+        for type in [1, 2, 3, 4]:
+            for overwrite_x in [True, False]:
+                for norm in [None, 'ortho']:
+                    should_overwrite = overwrite_x
+                    self._check(data, routine, type, None, axis, norm,
+                                overwrite_x, should_overwrite)
+
+    def test_dct(self):
+        for dtype in self.real_dtypes:
+            self._check_1d(dct, dtype, (16,), -1)
+            self._check_1d(dct, dtype, (16, 2), 0)
+            self._check_1d(dct, dtype, (2, 16), 1)
+
+    def test_idct(self):
+        for dtype in self.real_dtypes:
+            self._check_1d(idct, dtype, (16,), -1)
+            self._check_1d(idct, dtype, (16, 2), 0)
+            self._check_1d(idct, dtype, (2, 16), 1)
+
+    def test_dst(self):
+        for dtype in self.real_dtypes:
+            self._check_1d(dst, dtype, (16,), -1)
+            self._check_1d(dst, dtype, (16, 2), 0)
+            self._check_1d(dst, dtype, (2, 16), 1)
+
+    def test_idst(self):
+        for dtype in self.real_dtypes:
+            self._check_1d(idst, dtype, (16,), -1)
+            self._check_1d(idst, dtype, (16, 2), 0)
+            self._check_1d(idst, dtype, (2, 16), 1)
+
+
+class Test_DCTN_IDCTN(object):
+    dec = 14
+    dct_type = [1, 2, 3, 4]
+    norms = [None, 'ortho']
+    rstate = np.random.RandomState(1234)
+    shape = (32, 16)
+    data = rstate.randn(*shape)
+
+    @pytest.mark.parametrize('fforward,finverse', [(dctn, idctn),
+                                                   (dstn, idstn)])
+    @pytest.mark.parametrize('axes', [None,
+                                      1, (1,), [1],
+                                      0, (0,), [0],
+                                      (0, 1), [0, 1],
+                                      (-2, -1), [-2, -1]])
+    @pytest.mark.parametrize('dct_type', dct_type)
+    @pytest.mark.parametrize('norm', ['ortho'])
+    def test_axes_round_trip(self, fforward, finverse, axes, dct_type, norm):
+        tmp = fforward(self.data, type=dct_type, axes=axes, norm=norm)
+        tmp = finverse(tmp, type=dct_type, axes=axes, norm=norm)
+        assert_array_almost_equal(self.data, tmp, decimal=12)
+
+    @pytest.mark.parametrize('fforward,fforward_ref', [(dctn, dct_2d_ref),
+                                                       (dstn, dst_2d_ref)])
+    @pytest.mark.parametrize('dct_type', dct_type)
+    @pytest.mark.parametrize('norm', norms)
+    def test_dctn_vs_2d_reference(self, fforward, fforward_ref,
+                                  dct_type, norm):
+        y1 = fforward(self.data, type=dct_type, axes=None, norm=norm)
+        y2 = fforward_ref(self.data, type=dct_type, norm=norm)
+        assert_array_almost_equal(y1, y2, decimal=11)
+
+    @pytest.mark.parametrize('finverse,finverse_ref', [(idctn, idct_2d_ref),
+                                                       (idstn, idst_2d_ref)])
+    @pytest.mark.parametrize('dct_type', dct_type)
+    @pytest.mark.parametrize('norm', [None, 'ortho'])
+    def test_idctn_vs_2d_reference(self, finverse, finverse_ref,
+                                   dct_type, norm):
+        fdata = dctn(self.data, type=dct_type, norm=norm)
+        y1 = finverse(fdata, type=dct_type, norm=norm)
+        y2 = finverse_ref(fdata, type=dct_type, norm=norm)
+        assert_array_almost_equal(y1, y2, decimal=11)
+
+    @pytest.mark.parametrize('fforward,finverse', [(dctn, idctn),
+                                                   (dstn, idstn)])
+    def test_axes_and_shape(self, fforward, finverse):
+        with assert_raises(ValueError,
+                           match="when given, axes and shape arguments"
+                           " have to be of the same length"):
+            fforward(self.data, shape=self.data.shape[0], axes=(0, 1))
+
+        with assert_raises(ValueError,
+                           match="when given, axes and shape arguments"
+                           " have to be of the same length"):
+            fforward(self.data, shape=self.data.shape[0], axes=None)
+
+        with assert_raises(ValueError,
+                           match="when given, axes and shape arguments"
+                           " have to be of the same length"):
+            fforward(self.data, shape=self.data.shape, axes=0)
+
+    @pytest.mark.parametrize('fforward', [dctn, dstn])
+    def test_shape(self, fforward):
+        tmp = fforward(self.data, shape=(128, 128), axes=None)
+        assert_equal(tmp.shape, (128, 128))
+
+    @pytest.mark.parametrize('fforward,finverse', [(dctn, idctn),
+                                                   (dstn, idstn)])
+    @pytest.mark.parametrize('axes', [1, (1,), [1],
+                                      0, (0,), [0]])
+    def test_shape_is_none_with_axes(self, fforward, finverse, axes):
+        tmp = fforward(self.data, shape=None, axes=axes, norm='ortho')
+        tmp = finverse(tmp, shape=None, axes=axes, norm='ortho')
+        assert_array_almost_equal(self.data, tmp, decimal=self.dec)

--- a/scipy/fft/_pocketfft/version.md
+++ b/scipy/fft/_pocketfft/version.md
@@ -4,10 +4,13 @@ pypocketfft version
 
 SciPy currently vendors [pypocketfft][repo] at:
 
-    commit cd58e6a1da24ccc2571b998c9f83374e7d9ed783
+    commit 656b2373624bfb83ad1bc9388fa6c561eb2bb9e0
+    Merge: 0276f55 20f3b84
     Author: Martin Reinecke <martin@mpa-garching.mpg.de>
-    Date:   Mon Jul 8 19:05:41 2019 +0200
+    Date:   Sat Jul 20 13:16:46 2019 +0200
 
-        fixes for problems with multiprocessing noticed within scipy
+        Merge branch 'sincos' into 'master'
+
+        DCT/DST support
 
 repo: https://gitlab.mpcdf.mpg.de/mtr/pypocketfft

--- a/scipy/fft/_realtransforms.py
+++ b/scipy/fft/_realtransforms.py
@@ -6,35 +6,6 @@ import numpy as np
 __all__ = ['dct', 'idct', 'dst', 'idst', 'dctn', 'idctn', 'dstn', 'idstn']
 
 
-def _normalize_inverse(x, kind, type, axes):
-    """Normalizes the inverse transform inplace
-
-    Parameters
-    ----------
-    x : array_like
-        The output array of the unnormalized inverse transform, modified inplace
-    kind : {'s', 'c'}
-        Whether the trasform is discrete sine or cosine
-    type : {1, 2, 3, 4}
-        Type of DCT/DST
-    axes : int or array_like of ints or None
-        Axes along which the DCT/DST has been computed
-    """
-    if axes is None:
-        shape = np.array(x.shape)
-    else:
-        shape = np.take(x.shape, axes)
-
-    if type == 1:
-        if kind == 'c':
-            shape -= 1
-        else:
-            shape += 1
-
-    N = np.prod(2 * shape)
-    x /= N
-
-
 @_dispatch
 def dctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
     """
@@ -141,13 +112,6 @@ def idctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
     return (Dispatchable(x, np.ndarray),)
 
 
-def _idctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
-    y = _fftpack.idctn(x, type, shape, axes, norm, overwrite_x)
-    if norm is None:
-        _normalize_inverse(y, 'c', type, axes)
-    return y
-
-
 @_dispatch
 def dstn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
     """
@@ -252,13 +216,6 @@ def idstn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
 
     """
     return (Dispatchable(x, np.ndarray),)
-
-
-def _idstn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
-    y = _fftpack.idstn(x, type, shape, axes, norm, overwrite_x)
-    if norm is None:
-        _normalize_inverse(y, 's', type, axes)
-    return y
 
 
 @_dispatch
@@ -466,13 +423,6 @@ def idct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
     return (Dispatchable(x, np.ndarray),)
 
 
-def _idct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
-    y = _fftpack.idct(x, type, n, axis, norm, overwrite_x)
-    if norm is None:
-        _normalize_inverse(y, 'c', type, axis)
-    return y
-
-
 @_dispatch
 def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
     r"""
@@ -629,10 +579,3 @@ def idst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
 
     """
     return (Dispatchable(x, np.ndarray),)
-
-
-def _idst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
-    y = _fftpack.idst(x, type, n, axis, norm, overwrite_x)
-    if norm is None:
-        _normalize_inverse(y, 's', type, axis)
-    return y

--- a/scipy/fft/tests/test_backend.py
+++ b/scipy/fft/tests/test_backend.py
@@ -22,8 +22,8 @@ np_funcs = (np.fft.fft, np.fft.fft2, np.fft.fftn,
             np.fft.irfft, np.fft.irfft2, np.fft.irfftn,
             np.fft.hfft, _pocketfft.hfft2, _pocketfft.hfftn,  # np has no hfftn
             np.fft.ihfft, _pocketfft.ihfft2, _pocketfft.ihfftn,
-            fftpack.dct, rt._idct, fftpack.dctn, rt._idctn,
-            fftpack.dst, rt._idst, fftpack.dstn, rt._idstn)
+            _pocketfft.dct, _pocketfft.idct, _pocketfft.dctn, _pocketfft.idctn,
+            _pocketfft.dst, _pocketfft.idst, _pocketfft.dstn, _pocketfft.idstn)
 
 funcs = (scipy.fft.fft, scipy.fft.fft2, scipy.fft.fftn,
          scipy.fft.ifft, scipy.fft.ifft2, scipy.fft.ifftn,


### PR DESCRIPTION
#### Reference issue
Addresses part of #10488

#### What does this implement/fix?
This adds all variants of discrete (co)sine transform to `_pocketfft`:
   `dct`, `idct`, `dst`, `idst`, `dctn`, `idctn`, `dstn`, `idstn` 

#### Additional information
~The tests are currently failing and the issues seem genuine: the failing tests are against textbook definitions and FFTW generated data.~

cc: @mreineck