### PR TITLE
ENH: faster circumcenter calculation in spatial.SphericalVoronoi

### DIFF
--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -11,12 +11,14 @@ Spherical Voronoi Code
 # Distributed under the same BSD license as SciPy.
 #
 
+import warnings
 import numpy as np
 import scipy
 from . import _voronoi
 from scipy.spatial import cKDTree
 
 __all__ = ['SphericalVoronoi']
+
 
 def sphere_check(points, radius, center):
     """ Determines distance of generators from theoretical sphere
@@ -28,65 +30,6 @@ def sphere_check(points, radius, center):
                             ((points[...,2] - center[2]) ** 2))
     max_discrepancy = (np.sqrt(actual_squared_radii) - radius).max()
     return abs(max_discrepancy)
-
-def calc_circumcenters(tetrahedrons):
-    """ Calculates the cirumcenters of the circumspheres of tetrahedrons.
-
-    An implementation based on
-    http://mathworld.wolfram.com/Circumsphere.html
-
-    Parameters
-    ----------
-    tetrahedrons : an array of shape (N, 4, 3)
-        consisting of N tetrahedrons defined by 4 points in 3D
-
-    Returns
-    ----------
-    circumcenters : an array of shape (N, 3)
-        consisting of the N circumcenters of the tetrahedrons in 3D
-
-    """
-
-    num = tetrahedrons.shape[0]
-    a = np.concatenate((tetrahedrons, np.ones((num, 4, 1))), axis=2)
-
-    sums = np.sum(tetrahedrons ** 2, axis=2)
-    d = np.concatenate((sums[:, :, np.newaxis], a), axis=2)
-
-    dx = np.delete(d, 1, axis=2)
-    dy = np.delete(d, 2, axis=2)
-    dz = np.delete(d, 3, axis=2)
-
-    dx = np.linalg.det(dx)
-    dy = -np.linalg.det(dy)
-    dz = np.linalg.det(dz)
-    a = np.linalg.det(a)
-
-    nominator = np.vstack((dx, dy, dz))
-    denominator = 2*a
-    return (nominator / denominator).T
-
-
-def project_to_sphere(points, center, radius):
-    """
-    Projects the elements of points onto the sphere defined
-    by center and radius.
-
-    Parameters
-    ----------
-    points : array of floats of shape (npoints, ndim)
-             consisting of the points in a space of dimension ndim
-    center : array of floats of shape (ndim,)
-            the center of the sphere to project on
-    radius : float
-            the radius of the sphere to project on
-
-    returns: array of floats of shape (npoints, ndim)
-            the points projected onto the sphere
-    """
-
-    lengths = scipy.spatial.distance.cdist(points, np.array([center]))
-    return (points - center) / lengths * radius + center
 
 
 class SphericalVoronoi:
@@ -114,10 +57,8 @@ class SphericalVoronoi:
         the points in 3D to generate the Voronoi diagram from
     radius : double
         radius of the sphere
-        Default: None (forces estimation, which is less precise)
     center : double array of shape (3,)
         center of the sphere
-        Default: None (assumes sphere is centered at origin)
     vertices : double array of shape (nvertices, 3)
         Voronoi vertices corresponding to points
     regions : list of list of integers of shape (npoints, _ )
@@ -135,35 +76,19 @@ class SphericalVoronoi:
     The spherical Voronoi diagram algorithm proceeds as follows. The Convex
     Hull of the input points (generators) is calculated, and is equivalent to
     their Delaunay triangulation on the surface of the sphere [Caroli]_.
-    A 3D Delaunay tetrahedralization is obtained by including the origin of
-    the coordinate system as the fourth vertex of each simplex of the Convex
-    Hull. The circumcenters of all tetrahedra in the system are calculated and
-    projected to the surface of the sphere, producing the Voronoi vertices.
-    The Delaunay tetrahedralization neighbour information is then used to
+    The Convex Hull neighbour information is then used to
     order the Voronoi region vertices around each generator. The latter
     approach is substantially less sensitive to floating point issues than
     angle-based methods of Voronoi region vertex sorting.
 
-    The surface area of spherical polygons is calculated by decomposing them
-    into triangles and using L'Huilier's Theorem to calculate the spherical
-    excess of each triangle [Weisstein]_. The sum of the spherical excesses is
-    multiplied by the square of the sphere radius to obtain the surface area
-    of the spherical polygon. For nearly-degenerate spherical polygons an area
-    of approximately 0 is returned by default, rather than attempting the
-    unstable calculation.
-
     Empirical assessment of spherical Voronoi algorithm performance suggests
     quadratic time complexity (loglinear is optimal, but algorithms are more
-    challenging to implement). The reconstitution of the surface area of the
-    sphere, measured as the sum of the surface areas of all Voronoi regions,
-    is closest to 100 % for larger (>> 10) numbers of generators.
+    challenging to implement).
 
     References
     ----------
     .. [Caroli] Caroli et al. Robust and Efficient Delaunay triangulations of
                 points on or close to a sphere. Research Report RR-7004, 2009.
-    .. [Weisstein] "L'Huilier's Theorem." From MathWorld -- A Wolfram Web
-                Resource. http://mathworld.wolfram.com/LHuiliersTheorem.html
 
     See Also
     --------
@@ -216,16 +141,26 @@ class SphericalVoronoi:
 
     """
 
-    def __init__(self, points, radius=None, center=None, threshold=1e-06):
+    def __init__(self, points, radius=1, center=(0, 0, 0), threshold=1e-06):
+        if radius is None:
+            radius = 1.
+            warnings.warn('`radius` is `None`. '
+                          'This will raise an error in a future version. '
+                          'Please provide a floating point number '
+                          '(i.e. `radius=1`).',
+                          DeprecationWarning)
+
+        if center is None:
+            center = (0, 0, 0)
+            warnings.warn('`center` is `None`. '
+                          'This will raise an error in a future version. '
+                          'Please provide a coordinate '
+                          '(i.e. `center=(0, 0, 0)`)',
+                          DeprecationWarning)
+
         self.points = points
-        if np.any(center):
-            self.center = center
-        else:
-            self.center = np.zeros(3)
-        if radius:
-            self.radius = radius
-        else:
-            self.radius = 1
+        self.radius = radius
+        self.center = np.array(center)
 
         if cKDTree(self.points).query_pairs(threshold * self.radius):
             raise ValueError("Duplicate generators present.")
@@ -250,32 +185,15 @@ class SphericalVoronoi:
         Tyler Reddy, Ross Hemsley and Nikolai Nowaczyk
         """
 
-        # perform 3D Delaunay triangulation on data set
-        # (here ConvexHull can also be used, and is faster)
+        # get Convex Hull
         self._tri = scipy.spatial.ConvexHull(self.points)
 
-        # add the center to each of the simplices in tri to get the same
-        # tetrahedrons we'd have gotten from Delaunay tetrahedralization
-        # tetrahedrons will have shape: (2N-4, 4, 3)
-        tetrahedrons = self._tri.points[self._tri.simplices]
-        tetrahedrons = np.insert(
-            tetrahedrons,
-            3,
-            np.array([self.center]),
-            axis=1
-        )
+        # triangles will have shape: (2N-4, 3, 3)
+        triangles = self._tri.points[self._tri.simplices]
 
-        # produce circumcenters of tetrahedrons from 3D Delaunay
+        # get circumcenters of Convex Hull triangles from facet equations
         # circumcenters will have shape: (2N-4, 3)
-        circumcenters = calc_circumcenters(tetrahedrons)
-
-        # project tetrahedron circumcenters to the surface of the sphere
-        # self.vertices will have shape: (2N-4, 3)
-        self.vertices = project_to_sphere(
-            circumcenters,
-            self.center,
-            self.radius
-        )
+        self.vertices = self.radius * self._tri.equations[:, :-1] + self.center
 
         # calculate regions from triangulation
         # simplex_indices will have shape: (2N-4,)
@@ -308,14 +226,13 @@ class SphericalVoronoi:
 
         This is done as follows: Recall that the n-th region in regions
         surrounds the n-th generator in points and that the k-th
-        Voronoi vertex in vertices is the projected circumcenter of the
-        tetrahedron obtained by the k-th triangle in _tri.simplices (and the
-        origin). For each region n, we choose the first triangle (=Voronoi
-        vertex) in _tri.simplices and a vertex of that triangle not equal to
-        the center n. These determine a unique neighbor of that triangle,
-        which is then chosen as the second triangle. The second triangle
-        will have a unique vertex not equal to the current vertex or the
-        center. This determines a unique neighbor of the second triangle,
+        Voronoi vertex in vertices is the circumcenter of the k-th triangle
+        in _tri.simplices.  For each region n, we choose the first triangle
+        (=Voronoi vertex) in _tri.simplices and a vertex of that triangle
+        not equal to the center n. These determine a unique neighbor of that
+        triangle, which is then chosen as the second triangle. The second
+        triangle will have a unique vertex not equal to the current vertex or
+        the center. This determines a unique neighbor of the second triangle,
         which is then chosen as the third triangle and so forth. We proceed
         through all the triangles (=Voronoi vertices) belonging to the
         generator in points and obtain a sorted version of the vertices

--- a/scipy/spatial/tests/test_spherical_voronoi.py
+++ b/scipy/spatial/tests/test_spherical_voronoi.py
@@ -5,60 +5,12 @@ from numpy.testing import (assert_equal,
                            assert_almost_equal,
                            assert_array_equal,
                            assert_array_almost_equal)
+import warnings
 from pytest import raises as assert_raises
+from pytest import warns as assert_warns
 from scipy.spatial import SphericalVoronoi, distance
 from scipy.spatial import _spherical_voronoi as spherical_voronoi
-
-
-class TestCircumcenters(object):
-
-    def test_circumcenters(self):
-        tetrahedrons = np.array([
-            [[1, 2, 3],
-             [-1.1, -2.1, -3.1],
-             [-1.2, 2.2, 3.2],
-             [-1.3, -2.3, 3.3]],
-            [[10, 20, 30],
-             [-10.1, -20.1, -30.1],
-             [-10.2, 20.2, 30.2],
-             [-10.3, -20.3, 30.3]]
-        ])
-
-        result = spherical_voronoi.calc_circumcenters(tetrahedrons)
-
-        expected = [
-            [-0.5680861153262529, -0.133279590288315, 0.1843323216995444],
-            [-0.5965330784014926, -0.1480377040397778, 0.1981967854886021]
-        ]
-
-        assert_array_almost_equal(result, expected)
-
-
-class TestProjectToSphere(object):
-
-    def test_unit_sphere(self):
-        points = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
-        center = np.array([0, 0, 0])
-        radius = 1
-        projected = spherical_voronoi.project_to_sphere(points, center, radius)
-        assert_array_almost_equal(points, projected)
-
-    def test_scaled_points(self):
-        points = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
-        center = np.array([0, 0, 0])
-        radius = 1
-        scaled = points * 2
-        projected = spherical_voronoi.project_to_sphere(scaled, center, radius)
-        assert_array_almost_equal(points, projected)
-
-    def test_translated_sphere(self):
-        points = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
-        center = np.array([1, 2, 3])
-        translated = points + center
-        radius = 1
-        projected = spherical_voronoi.project_to_sphere(translated, center,
-                                                        radius)
-        assert_array_almost_equal(translated, projected)
+from scipy._lib._numpy_compat import suppress_warnings
 
 
 class TestSphericalVoronoi(object):
@@ -75,6 +27,27 @@ class TestSphericalVoronoi(object):
             [0.79979205, 0.54555747, 0.25039913]]
         )
 
+        # Issue #9386
+        self.hemisphere_points = np.array([
+            [0.88610999, -0.42383021, 0.18755541],
+            [0.51980039, -0.72622668, 0.4498915],
+            [0.56540011, -0.81629197, -0.11827989],
+            [0.69659682, -0.69972598, 0.15854467]])
+
+        # Issue #8859
+        phi = np.linspace(0, 2 * np.pi, 10, endpoint=False)    # azimuth angle
+        theta = np.linspace(0.001, np.pi * 0.4, 5)    # polar angle
+        theta = theta[np.newaxis, :].T
+
+        phiv, thetav = np.meshgrid(phi, theta)
+        phiv = np.reshape(phiv, (50, 1))
+        thetav = np.reshape(thetav, (50, 1))
+
+        x = np.cos(phiv) * np.sin(thetav)
+        y = np.sin(phiv) * np.sin(thetav)
+        z = np.cos(thetav)
+        self.hemisphere_points2 = np.concatenate([x, y, z], axis=1)
+
     def test_constructor(self):
         center = np.array([1, 2, 3])
         radius = 2
@@ -83,7 +56,7 @@ class TestSphericalVoronoi(object):
         # the radius / center to match the generators so adjust
         # accordingly here
         s2 = SphericalVoronoi(self.points * radius, radius)
-        s3 = SphericalVoronoi(self.points + center, None, center)
+        s3 = SphericalVoronoi(self.points + center, center=center)
         s4 = SphericalVoronoi(self.points * radius + center, radius, center)
         assert_array_equal(s1.center, np.array([0, 0, 0]))
         assert_equal(s1.radius, 1)
@@ -97,7 +70,7 @@ class TestSphericalVoronoi(object):
     def test_vertices_regions_translation_invariance(self):
         sv_origin = SphericalVoronoi(self.points)
         center = np.array([1, 1, 1])
-        sv_translated = SphericalVoronoi(self.points + center, None, center)
+        sv_translated = SphericalVoronoi(self.points + center, center=center)
         assert_array_equal(sv_origin.regions, sv_translated.regions)
         assert_array_almost_equal(sv_origin.vertices + center,
                                   sv_translated.vertices)
@@ -108,6 +81,29 @@ class TestSphericalVoronoi(object):
         assert_array_equal(sv_unit.regions, sv_scaled.regions)
         assert_array_almost_equal(sv_unit.vertices * 2,
                                   sv_scaled.vertices)
+
+    def test_old_radius_api(self):
+        sv_unit = SphericalVoronoi(self.points, radius=1)
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning, "`radius` is `None`")
+            sv = SphericalVoronoi(self.points, None)
+            assert_array_almost_equal(sv_unit.vertices, sv.vertices)
+
+    def test_old_radius_api_warning(self):
+        with assert_warns(DeprecationWarning):
+            sv = SphericalVoronoi(self.points, None)
+
+    def test_old_center_api(self):
+        sv_unit = SphericalVoronoi(self.points, radius=1, center=(0, 0, 0))
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning, "`radius` is `None`")
+            sup.filter(DeprecationWarning, "`center` is `None`")
+            sv = SphericalVoronoi(self.points, None, None)
+            assert_array_almost_equal(sv_unit.vertices, sv.vertices)
+
+    def test_old_center_api_warning(self):
+        with assert_warns(DeprecationWarning):
+            sv = SphericalVoronoi(self.points, None, None)
 
     def test_sort_vertices_of_regions(self):
         sv = SphericalVoronoi(self.points)
@@ -164,3 +160,13 @@ class TestSphericalVoronoi(object):
         with assert_raises(ValueError):
             sv = spherical_voronoi.SphericalVoronoi(self.points,
                                                     center=[0.1,0,0])
+
+    def test_single_hemisphere_handling(self):
+        # Test solution of Issues #9386, #8859
+
+        for points in [self.hemisphere_points, self.hemisphere_points2]:
+            sv = SphericalVoronoi(points)
+            triangles = sv._tri.points[sv._tri.simplices]
+            dots = np.einsum('ij,ij->i', sv.vertices, triangles[:, 0])
+            circumradii = np.arccos(np.clip(dots, -1, 1))
+            assert np.max(circumradii) > np.pi / 2


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #9386, #8859, #10484

#### What does this implement/fix?
Implements a faster algorithm for calculation of circumcenters, with better numerical stability.
Benchmarks:
```
============ ============= =============
 num_points      master       this PR
------------ ------------- -------------
     10         494±4μs      410±5μs   
    100         1.32±0ms     955±3μs   
    1000      10.2±0.08ms   6.85±0.1ms 
    5000      53.6±0.07ms   35.2±0.6ms 
   10000       112±0.6ms     76.4±1ms  
============ ============= =============
```

-Resolves circumcenter signs properly, which means points in a single hemisphere are correctly handled.

-Updated docstrings

-Changed default parameter values to their actual values, rather than `None`.

#### Additional information
<!--Any additional information you think is important.-->
-A remaining edge case is input data consisting of a point set on a great circle.  If the points are equi-spaced, the correct output should resemble the segments of an orange.  I can implement this in a later PR.

~~-The new reference is a paper of mine.  I thought it might be of interest if readers would like to understand the algorithm for calculating circumcenters.  If it is not appropriate I don't mind taking it out again.~~