### PR TITLE
Splrep _curfit_cache global variable bugfix

### DIFF
--- a/scipy/interpolate/_fitpack_impl.py
+++ b/scipy/interpolate/_fitpack_impl.py
@@ -316,7 +316,7 @@ _curfit_cache = {'t': array([], float), 'wrk': array([], float),
 
 
 def splrep(x, y, w=None, xb=None, xe=None, k=3, task=0, s=None, t=None,
-           full_output=0, per=0, quiet=1, ext_cache=None):
+           full_output=0, per=0, quiet=1, cache=None):
     # or cache=None? Also, _curfit_cache is used elsewhere
     """
     Find the B-spline representation of 1-D curve.
@@ -443,10 +443,11 @@ def splrep(x, y, w=None, xb=None, xe=None, k=3, task=0, s=None, t=None,
     """
     # cache appears to be optional mostly
     # no-op on the cache if task doesn't require
-    if ext_cache is None or task <= 0:
+    if task == 1 and cache is None:
+        raise ValueError("Must call splrep with cache argument for task=1")
+    if task <= 0 and cache is None:
         cache = {}
-    else:
-        cache = ext_cache
+
     x, y = map(atleast_1d, [x, y])
     m = len(x)
     if w is None:

--- a/scipy/interpolate/_fitpack_impl.py
+++ b/scipy/interpolate/_fitpack_impl.py
@@ -311,13 +311,8 @@ def splprep(x, w=None, u=None, ub=None, ue=None, k=3, task=0, s=None, t=None,
         return tcku
 
 
-_curfit_cache = {'t': array([], float), 'wrk': array([], float),
-                 'iwrk': array([], intc)}
-
-
 def splrep(x, y, w=None, xb=None, xe=None, k=3, task=0, s=None, t=None,
            full_output=0, per=0, quiet=1, cache=None):
-    # or cache=None? Also, _curfit_cache is used elsewhere
     """
     Find the B-spline representation of 1-D curve.
 
@@ -375,6 +370,9 @@ def splrep(x, y, w=None, xb=None, xe=None, k=3, task=0, s=None, t=None,
         Non-zero to suppress messages.
         This parameter is deprecated; use standard Python warning filters
         instead.
+    cache : dict, optional
+        Stores the results of a previous call of splrep for the same data, to
+        be used when task==1 after a previous call with task==0 or task==-1.
 
     Returns
     -------
@@ -441,12 +439,11 @@ def splrep(x, y, w=None, xb=None, xe=None, k=3, task=0, s=None, t=None,
     >>> plt.show()
 
     """
-    # cache appears to be optional mostly
-    # no-op on the cache if task doesn't require
     if task == 1 and cache is None:
         raise ValueError("Must call splrep with cache argument for task=1")
     if task <= 0 and cache is None:
-        cache = {}
+        cache = {'t': array([], float), 'wrk': array([], float),
+                 'iwrk': array([], intc)}
 
     x, y = map(atleast_1d, [x, y])
     m = len(x)
@@ -806,7 +803,7 @@ _surfit_cache = {'tx': array([], float), 'ty': array([], float),
 
 def bisplrep(x, y, z, w=None, xb=None, xe=None, yb=None, ye=None,
              kx=3, ky=3, task=0, s=None, eps=1e-16, tx=None, ty=None,
-             full_output=0, nxest=None, nyest=None, quiet=1):
+             full_output=0, nxest=None, nyest=None, quiet=1, cache=None):
     """
     Find a bivariate B-spline representation of a surface.
 
@@ -857,6 +854,9 @@ def bisplrep(x, y, z, w=None, xb=None, xe=None, yb=None, ye=None,
         Non-zero to suppress printing of messages.
         This parameter is deprecated; use standard Python warning filters
         instead.
+    cache : dict, optional
+        Stores the results of a previous call of bisplrep for the same data, to
+        be used when task==1 after a previous call with task==0 or task==-1.
 
     Returns
     -------
@@ -893,6 +893,11 @@ def bisplrep(x, y, z, w=None, xb=None, xe=None, yb=None, ye=None,
        Numerical Analysis, Oxford University Press, 1993.
 
     """
+    if task == 1 and cache is None:
+        raise ValueError("Must call splrep with cache argument for task=1")
+    if task <= 0 and cache is None:
+        cache = {'t': array([], float), 'wrk': array([], float),
+                 'iwrk': array([], intc)}
     x, y, z = map(ravel, [x, y, z])  # ensure 1-d arrays.
     m = len(x)
     if not (m == len(y) == len(z)):
@@ -963,9 +968,9 @@ def bisplrep(x, y, z, w=None, xb=None, xe=None, yb=None, ye=None,
     tx, ty, c, o = _fitpack._surfit(x, y, z, w, xb, xe, yb, ye, kx, ky,
                                     task, s, eps, tx, ty, nxest, nyest,
                                     wrk, lwrk1, lwrk2)
-    _curfit_cache['tx'] = tx
-    _curfit_cache['ty'] = ty
-    _curfit_cache['wrk'] = o['wrk']
+    cache['tx'] = tx
+    cache['ty'] = ty
+    cache['wrk'] = o['wrk']
     ier, fp = o['ier'], o['fp']
     tck = [tx, ty, c, kx, ky]
 

--- a/scipy/interpolate/_fitpack_impl.py
+++ b/scipy/interpolate/_fitpack_impl.py
@@ -316,7 +316,8 @@ _curfit_cache = {'t': array([], float), 'wrk': array([], float),
 
 
 def splrep(x, y, w=None, xb=None, xe=None, k=3, task=0, s=None, t=None,
-           full_output=0, per=0, quiet=1):
+           full_output=0, per=0, quiet=1, ext_cache=None):
+    # or cache=None? Also, _curfit_cache is used elsewhere
     """
     Find the B-spline representation of 1-D curve.
 
@@ -440,8 +441,12 @@ def splrep(x, y, w=None, xb=None, xe=None, k=3, task=0, s=None, t=None,
     >>> plt.show()
 
     """
-    if task <= 0:
-        _curfit_cache = {}
+    # cache appears to be optional mostly
+    # no-op on the cache if task doesn't require
+    if ext_cache is None or task <= 0:
+        cache = {}
+    else:
+        cache = ext_cache
     x, y = map(atleast_1d, [x, y])
     m = len(x)
     if w is None:
@@ -474,26 +479,26 @@ def splrep(x, y, w=None, xb=None, xe=None, k=3, task=0, s=None, t=None,
         if t is None:
             raise TypeError('Knots must be given for task=-1')
         numknots = len(t)
-        _curfit_cache['t'] = empty((numknots + 2*k + 2,), float)
-        _curfit_cache['t'][k+1:-k-1] = t
-        nest = len(_curfit_cache['t'])
+        cache['t'] = empty((numknots + 2*k + 2,), float)
+        cache['t'][k+1:-k-1] = t
+        nest = len(cache['t'])
     elif task == 0:
         if per:
             nest = max(m + 2*k, 2*k + 3)
         else:
             nest = max(m + k + 1, 2*k + 3)
         t = empty((nest,), float)
-        _curfit_cache['t'] = t
+        cache['t'] = t
     if task <= 0:
         if per:
-            _curfit_cache['wrk'] = empty((m*(k + 1) + nest*(8 + 5*k),), float)
+            cache['wrk'] = empty((m*(k + 1) + nest*(8 + 5*k),), float)
         else:
-            _curfit_cache['wrk'] = empty((m*(k + 1) + nest*(7 + 3*k),), float)
-        _curfit_cache['iwrk'] = empty((nest,), intc)
+            cache['wrk'] = empty((m*(k + 1) + nest*(7 + 3*k),), float)
+        cache['iwrk'] = empty((nest,), intc)
     try:
-        t = _curfit_cache['t']
-        wrk = _curfit_cache['wrk']
-        iwrk = _curfit_cache['iwrk']
+        t = cache['t']
+        wrk = cache['wrk']
+        iwrk = cache['iwrk']
     except KeyError:
         raise TypeError("must call with task=1 only after"
                         " call with task=0,-1")

--- a/scipy/interpolate/fitpack.py
+++ b/scipy/interpolate/fitpack.py
@@ -217,6 +217,9 @@ def splrep(x, y, w=None, xb=None, xe=None, k=3, task=0, s=None, t=None,
         Non-zero to suppress messages.
         This parameter is deprecated; use standard Python warning filters
         instead.
+    cache : dict, optional
+        Stores the results of a previous call of bisplrep for the same data, to
+        be used when task==1 after a previous call with task==0 or task==-1.
 
     Returns
     -------

--- a/scipy/interpolate/fitpack.py
+++ b/scipy/interpolate/fitpack.py
@@ -159,7 +159,7 @@ def splprep(x, w=None, u=None, ub=None, ue=None, k=3, task=0, s=None, t=None,
 
 
 def splrep(x, y, w=None, xb=None, xe=None, k=3, task=0, s=None, t=None,
-           full_output=0, per=0, quiet=1):
+           full_output=0, per=0, quiet=1, cache=None):
     """
     Find the B-spline representation of 1-D curve.
 
@@ -286,7 +286,7 @@ def splrep(x, y, w=None, xb=None, xe=None, k=3, task=0, s=None, t=None,
     >>> plt.show()
 
     """
-    res = _impl.splrep(x, y, w, xb, xe, k, task, s, t, full_output, per, quiet)
+    res = _impl.splrep(x, y, w, xb, xe, k, task, s, t, full_output, per, quiet, cache)
     return res
 
 

--- a/scipy/interpolate/tests/test_fitpack.py
+++ b/scipy/interpolate/tests/test_fitpack.py
@@ -260,13 +260,6 @@ class TestSmokeTests(object):
 
 
 class TestSplrep(object):
-    def test_caching(self):
-        # from scipy.interpolate.fitpack import _curfit_cache
-        x = range(5)
-        y = range(5, 10)
-        knots, coefficients, degree = splrep(x, y, task=0)
-        # assert_equal(_curfit_cache['t'], knots)
-
     def test_task_argument(self):
         x, y  = range(5), range(5, 10)
         # must call splrep twice to cache values

--- a/scipy/interpolate/tests/test_fitpack.py
+++ b/scipy/interpolate/tests/test_fitpack.py
@@ -3,6 +3,7 @@ from __future__ import division, print_function, absolute_import
 import os
 
 import numpy as np
+import pytest
 from numpy.testing import (assert_equal, assert_allclose, assert_,
                            assert_almost_equal, assert_array_almost_equal)
 from pytest import raises as assert_raises
@@ -261,10 +262,16 @@ class TestSmokeTests(object):
 
 class TestSplrep(object):
     def test_task_argument(self):
-        x, y  = range(5), range(5, 10)
-        # must call splrep twice to cache values
+        x, y = range(5), range(5, 10)
         tck1 = splrep(x, y, task=0)
-        tck2 = splrep(x, y, task=1) # check if runnable
+        with pytest.raises(ValueError):
+            tck2 = splrep(x, y, task=1)
+
+    def test_cache_argument(self):
+        x, y = range(5), range(5, 10)
+        splrep_cache = {}
+        tck1 = splrep(x, y, task=0, cache=splrep_cache)
+        tck2 = splrep(x, y, task=1, cache=splrep_cache)
 
 
 class TestSplev(object):

--- a/scipy/interpolate/tests/test_fitpack.py
+++ b/scipy/interpolate/tests/test_fitpack.py
@@ -259,6 +259,21 @@ class TestSmokeTests(object):
         self.check_5()
 
 
+class TestSplrep(object):
+    def test_caching(self):
+        # from scipy.interpolate.fitpack import _curfit_cache
+        x = range(5)
+        y = range(5, 10)
+        knots, coefficients, degree = splrep(x, y, task=0)
+        # assert_equal(_curfit_cache['t'], knots)
+
+    def test_task_argument(self):
+        x, y  = range(5), range(5, 10)
+        # must call splrep twice to cache values
+        tck1 = splrep(x, y, task=0)
+        tck2 = splrep(x, y, task=1) # check if runnable
+
+
 class TestSplev(object):
     def test_1d_shape(self):
         x = [1,2,3,4,5]

--- a/scipy/interpolate/tests/test_fitpack.py
+++ b/scipy/interpolate/tests/test_fitpack.py
@@ -8,7 +8,7 @@ from numpy.testing import (assert_equal, assert_allclose, assert_,
                            assert_almost_equal, assert_array_almost_equal)
 from pytest import raises as assert_raises
 
-from numpy import array, asarray, pi, sin, cos, arange, dot, ravel, sqrt, round
+from numpy import array, asarray, pi, sin, cos, arange, dot, ravel, sqrt, round, intc
 from scipy import interpolate
 from scipy.interpolate.fitpack import (splrep, splev, bisplrep, bisplev,
      sproot, splprep, splint, spalde, splder, splantider, insert, dblint)
@@ -263,15 +263,16 @@ class TestSmokeTests(object):
 class TestSplrep(object):
     def test_task_argument(self):
         x, y = range(5), range(5, 10)
-        tck1 = splrep(x, y, task=0)
+        splrep(x, y, task=0)
         with pytest.raises(ValueError):
-            tck2 = splrep(x, y, task=1)
+            splrep(x, y, task=1)
 
     def test_cache_argument(self):
         x, y = range(5), range(5, 10)
-        splrep_cache = {}
-        tck1 = splrep(x, y, task=0, cache=splrep_cache)
-        tck2 = splrep(x, y, task=1, cache=splrep_cache)
+        splrep_cache = {'t': array([], float), 'wrk': array([], float),
+                        'iwrk': array([], intc)}
+        splrep(x, y, task=0, cache=splrep_cache)
+        splrep(x, y, task=1, cache=splrep_cache)
 
 
 class TestSplev(object):
@@ -414,6 +415,19 @@ class TestBisplrep(object):
         # code to crash when compiled with -O3
         bisplrep(data[:,0], data[:,1], data[:,2], kx=3, ky=3, s=0,
                  full_output=True)
+
+    def test_task_argument(self):
+        x, y, z = np.arange(16), np.arange(16, 32), np.arange(32, 48)
+        bisplrep(x, y, z, task=0)
+        with pytest.raises(ValueError):
+            bisplrep(x, y, z, task=1)
+
+    def test_cache_argument(self):
+        x, y, z = np.arange(16), np.arange(16, 32), np.arange(32, 48)
+        bisplrep_cache = {'t': array([], float), 'wrk': array([], float),
+                 'iwrk': array([], intc)}
+        bisplrep(x, y, z, task=0, cache=bisplrep_cache)
+        bisplrep(x, y, z, task=1, cache=bisplrep_cache)
 
 
 def test_dblint():


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Supersedes and closes gh-2884
#### What does this implement/fix?
<!--Please explain your changes.-->
Replaced _`curfit_cache` global variable with optional user-passed `cache` variable.

#### Additional information
<!--Any additional information you think is important.-->