### PR TITLE
BUG: spatial/qhull: get HalfspaceIntersection.dual_points from the correct array

### DIFF
--- a/scipy/spatial/qhull.pyx
+++ b/scipy/spatial/qhull.pyx
@@ -126,6 +126,8 @@ cdef extern from "qhull_src/src/libqhull_r.h":
         int num_vertices
         int center_size
         unsigned int facet_id
+        int hull_dim
+        int num_points
         pointT *first_point
         pointT *input_points
         coordT* feasible_point
@@ -687,7 +689,7 @@ cdef class _Qhull:
             The array of points contained in Qhull.
 
         """
-        cdef vertexT *vertex
+        cdef pointT *point
         cdef int i, j, numpoints, point_ndim
         cdef np.ndarray[np.npy_double, ndim=2] points
 
@@ -701,20 +703,15 @@ cdef class _Qhull:
         if self._is_delaunay:
             point_ndim += 1
 
-        numvertices = self._qh.num_vertices
+        numpoints = self._qh.num_points
+        points = np.zeros((numpoints, point_ndim))
 
-        vertex = self._qh.vertex_list
-        points = np.zeros((numvertices, point_ndim))
-
-        i = 0
         with nogil:
-            while vertex and vertex.next:
-                j = 0
-                for j in xrange(point_ndim):
-                    points[i, j] = vertex.point[j]
-
-                i += 1
-                vertex = vertex.next
+            point = self._qh.first_point
+            for i in range(numpoints):
+                for j in range(point_ndim):
+                    points[i,j] = point[j]
+                point += self._qh.hull_dim
 
         return points
 

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -1106,3 +1106,39 @@ class Test_HalfspaceIntersection(object):
             self.assert_unordered_allclose(inc_hs.intersections, hs.intersections)
 
         inc_hs.close()
+
+    def test_cube(self):
+        # Halfspaces of the cube:
+        halfspaces = np.array([[-1., 0., 0., 0.],  # x >= 0
+                               [1., 0., 0., -1.],  # x <= 1
+                               [0., -1., 0., 0.],  # y >= 0
+                               [0., 1., 0., -1.],  # y <= 1
+                               [0., 0., -1., 0.],  # z >= 0
+                               [0., 0., 1., -1.]])  # z <= 1
+        point = np.array([0.5, 0.5, 0.5])
+
+        hs = qhull.HalfspaceIntersection(halfspaces, point)
+
+        # qhalf H0.5,0.5,0.5 o < input.txt
+        qhalf_points = np.array([
+            [-2, 0, 0],
+            [2, 0, 0],
+            [0, -2, 0],
+            [0, 2, 0],
+            [0, 0, -2],
+            [0, 0, 2]])
+        qhalf_facets = [
+            [2, 4, 0],
+            [4, 2, 1],
+            [5, 2, 0],
+            [2, 5, 1],
+            [3, 4, 1],
+            [4, 3, 0],
+            [5, 3, 1],
+            [3, 5, 0]]
+
+        assert len(qhalf_facets) == len(hs.dual_facets)
+        for a, b in zip(qhalf_facets, hs.dual_facets):
+            assert set(a) == set(b)  # facet orientation can differ
+
+        assert_allclose(hs.dual_points, qhalf_points)


### PR DESCRIPTION
Qhull stores half-space intersection points in the `points` array, which
gives the canonical ordering for the dual hull points. `qhalf Hx,y o` indeed
prints exactly these points.

The order of points in `vertex_list` may be permuted, and should not be
used here.

Fixes gh-10501