### PR TITLE
DOC: interp2d, note nearest neighbor extrapolation

### DIFF
--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -154,7 +154,7 @@ class interp2d(object):
     fill_value : number, optional
         If provided, the value to use for points outside of the
         interpolation domain. If omitted (None), values outside
-        the domain are extrapolated.
+        the domain are extrapolated via nearest-neighbor extrapolation.
 
     See Also
     --------


### PR DESCRIPTION
#### Reference issue
Addresses documentation concerns in #8099 

#### What does this implement/fix?
Notes that `interp2d` uses nearest-neighbor extrapolation (the default in `fitpack.bisplev`) for any extrapolated points, unlike `interp1d`.

#### Additional information
I think it would still be worth implementing extrapolation protocols to make `interp2d` more like `interp1d`, but this documentation should at least help those who were super confused like me...