### PR TITLE
 ENH: Speedup fftconvolve 

### DIFF
--- a/benchmarks/benchmarks/signal.py
+++ b/benchmarks/benchmarks/signal.py
@@ -88,26 +88,22 @@ class Convolve2D(Benchmark):
 
 
 class FFTConvolve(Benchmark):
-    param_names = ['mode']
+    param_names = ['mode', 'size']
     params = [
-        ['full', 'valid', 'same']
+        ['full', 'valid', 'same'],
+        [(a,b) for a,b in product((1, 2, 8, 36, 60, 150, 200, 500), repeat=2)
+         if b <= a]
     ]
 
-    def setup(self, mode):
+    def setup(self, mode, size):
         np.random.seed(1234)
         # sample a bunch of pairs of 2d arrays
         pairs = []
-        for ma, nb in product((1, 2, 8, 13, 30, 36, 50, 75), repeat=2):
-            a = np.random.randn(ma)
-            b = np.random.randn(nb)
-            pairs.append((a, b))
-        self.pairs = pairs
+        self.a = np.random.randn(size[0])
+        self.b = np.random.randn(size[1])
 
-    def time_convolve2d(self, mode):
-        for a, b in self.pairs:
-            if b.shape[0] > a.shape[0]:
-                continue
-            signal.fftconvolve(a, b, mode=mode)
+    def time_convolve2d(self, mode, size):
+        signal.fftconvolve(self.a, self.b, mode=mode)
 
 
 class Convolve(Benchmark):

--- a/scipy/fft/_helper.py
+++ b/scipy/fft/_helper.py
@@ -146,45 +146,4 @@ def _init_nd_shape_and_axes(x, shape, axes):
         The shape of the result. It is a 1D integer array.
 
     """
-    s, a = _helper._init_nd_shape_and_axes(np.asarray(x), shape, axes)
-    return np.asarray(s), np.asarray(a)
-
-
-def _init_nd_shape_and_axes_sorted(x, shape, axes):
-    """Handle and sort shape and axes arguments for n-dimensional transforms.
-
-    This is identical to `_init_nd_shape_and_axes`, except the axes are
-    returned in sorted order and the shape is reordered to match.
-
-    Parameters
-    ----------
-    x : array_like
-        The input array.
-    shape : int or array_like of ints or None
-        The shape of the result.  If both `shape` and `axes` (see below) are
-        None, `shape` is ``x.shape``; if `shape` is None but `axes` is
-        not None, then `shape` is ``scipy.take(x.shape, axes, axis=0)``.
-        If `shape` is -1, the size of the corresponding dimension of `x` is
-        used.
-    axes : int or array_like of ints or None
-        Axes along which the calculation is computed.
-        The default is over all axes.
-        Negative indices are automatically converted to their positive
-        counterpart.
-
-    Returns
-    -------
-    shape : array
-        The shape of the result. It is a 1D integer array.
-    axes : array
-        The shape of the result. It is a 1D integer array.
-
-    """
-    noaxes = axes is None
-    shape, axes = _init_nd_shape_and_axes(x, shape, axes)
-
-    if not noaxes:
-        shape = shape[axes.argsort()]
-        axes.sort()
-
-    return shape, axes
+    return _helper._init_nd_shape_and_axes(x, shape, axes)

--- a/scipy/fft/_helper.py
+++ b/scipy/fft/_helper.py
@@ -1,7 +1,6 @@
 from . import _pocketfft
 from ._pocketfft import helper as _helper
 from bisect import bisect_left
-import numpy as np
 
 
 def _next_regular_len(target):

--- a/scipy/fft/_pocketfft/helper.py
+++ b/scipy/fft/_pocketfft/helper.py
@@ -7,6 +7,32 @@ import operator
 _default_workers = 1
 
 
+def _iterable_of_int(x, name=None):
+    """Convert ``x`` to an iterable sequence of int
+
+    Parameters
+    ----------
+    x : value, or Iterable of values, convertible to int
+    name : str, optional
+        Name of the argument being converted, only used in the error message
+
+    Returns
+    -------
+    y : ``List[int]``
+    """
+    if not isinstance(x, Iterable):
+        x = (x,)
+
+    try:
+        x = [operator.index(a) for a in x]
+    except TypeError as e:
+        name = name or "value"
+        raise ValueError("{} must be a scalar or iterable of integers"
+                         .format(name)) from e
+
+    return x
+
+
 def _init_nd_shape_and_axes(x, shape, axes):
     """Handles shape and axes arguments for nd transforms"""
     noshape = shape is None
@@ -15,15 +41,7 @@ def _init_nd_shape_and_axes(x, shape, axes):
     if noaxes:
         axes = range(x.ndim)
     else:
-        if not isinstance(axes, Iterable):
-            axes = (axes,)
-
-        try:
-            axes = [operator.index(a) for a in axes]
-        except TypeError as e:
-            raise ValueError("when given, axes values must be a scalar "
-                             "or iterable of integers") from e
-
+        axes = _iterable_of_int(axes, 'axes')
         axes = [a + x.ndim if a < 0 else a for a in axes]
 
         if any(a >= x.ndim or a < 0 for a in axes):
@@ -32,14 +50,7 @@ def _init_nd_shape_and_axes(x, shape, axes):
             raise ValueError("all axes must be unique")
 
     if not noshape:
-        if not isinstance(shape, Iterable):
-            shape = (shape,)
-
-        try:
-            shape = [operator.index(s) for s in shape]
-        except TypeError as e:
-            raise ValueError("when given, shape values must be a scalar "
-                             "or iterable of integers") from e
+        shape = _iterable_of_int(shape, 'shape')
 
         if len(axes) != len(shape):
             raise ValueError("when given, axes and shape arguments"

--- a/scipy/fft/_pocketfft/helper.py
+++ b/scipy/fft/_pocketfft/helper.py
@@ -1,5 +1,5 @@
 import numpy as np
-from collections.abc import Iterable
+from numbers import Number
 import operator
 
 
@@ -12,7 +12,7 @@ def _iterable_of_int(x, name=None):
 
     Parameters
     ----------
-    x : value, or Iterable of values, convertible to int
+    x : value, or sequence of values, convertible to int
     name : str, optional
         Name of the argument being converted, only used in the error message
 
@@ -20,7 +20,7 @@ def _iterable_of_int(x, name=None):
     -------
     y : ``List[int]``
     """
-    if not isinstance(x, Iterable):
+    if isinstance(x, Number):
         x = (x,)
 
     try:

--- a/scipy/fft/_pocketfft/helper.py
+++ b/scipy/fft/_pocketfft/helper.py
@@ -1,4 +1,6 @@
 import numpy as np
+from collections.abc import Iterable
+import operator
 
 
 # TODO: Build with OpenMp and add configuration support
@@ -13,15 +15,14 @@ def _init_nd_shape_and_axes(x, shape, axes):
     if noaxes:
         axes = range(x.ndim)
     else:
-        axes = np.atleast_1d(axes)
+        if not isinstance(axes, Iterable):
+            axes = (axes,)
 
-        if axes.size == 0:
-            axes = axes.astype(np.intc)
-
-        if not axes.ndim == 1:
-            raise ValueError("when given, axes values must be a scalar or vector")
-        if not np.issubdtype(axes.dtype, np.integer):
-            raise ValueError("when given, axes values must be integers")
+        try:
+            axes = [operator.index(a) for a in axes]
+        except TypeError as e:
+            raise ValueError("when given, axes values must be a scalar "
+                             "or iterable of integers") from e
 
         axes = [a + x.ndim if a < 0 else a for a in axes]
 
@@ -31,15 +32,15 @@ def _init_nd_shape_and_axes(x, shape, axes):
             raise ValueError("all axes must be unique")
 
     if not noshape:
-        shape = np.atleast_1d(shape)
+        if not isinstance(shape, Iterable):
+            shape = (shape,)
 
-        if shape.size == 0:
-            shape = shape.astype(np.intc)
+        try:
+            shape = [operator.index(s) for s in shape]
+        except TypeError as e:
+            raise ValueError("when given, shape values must be a scalar "
+                             "or iterable of integers") from e
 
-        if shape.ndim != 1:
-            raise ValueError("when given, shape values must be a scalar or vector")
-        if not np.issubdtype(shape.dtype, np.integer):
-            raise ValueError("when given, shape values must be integers")
         if len(axes) != len(shape):
             raise ValueError("when given, axes and shape arguments"
                              " have to be of the same length")

--- a/scipy/fft/tests/test_helper.py
+++ b/scipy/fft/tests/test_helper.py
@@ -259,14 +259,12 @@ class Test_init_nd_shape_and_axes(object):
 
     def test_errors(self):
         x = np.zeros(1)
-        with assert_raises(ValueError,
-                           match="when given, axes values must be a scalar"
-                           " or iterable of integers"):
+        with assert_raises(ValueError, match="axes must be a scalar or "
+                           "iterable of integers"):
             _init_nd_shape_and_axes(x, shape=None, axes=[[1, 2], [3, 4]])
 
-        with assert_raises(ValueError,
-                           match="when given, axes values must be a scalar"
-                           " or iterable of integers"):
+        with assert_raises(ValueError, match="axes must be a scalar or "
+                           "iterable of integers"):
             _init_nd_shape_and_axes(x, shape=None, axes=[1., 2., 3., 4.])
 
         with assert_raises(ValueError,
@@ -281,14 +279,12 @@ class Test_init_nd_shape_and_axes(object):
                            match="all axes must be unique"):
             _init_nd_shape_and_axes(x, shape=None, axes=[0, 0])
 
-        with assert_raises(ValueError,
-                           match="when given, shape values must be a scalar"
-                           " or iterable of integers"):
+        with assert_raises(ValueError, match="shape must be a scalar or "
+                           "iterable of integers"):
             _init_nd_shape_and_axes(x, shape=[[1, 2], [3, 4]], axes=None)
 
-        with assert_raises(ValueError,
-                           match="when given, shape values must be a scalar"
-                           " or iterable of integers"):
+        with assert_raises(ValueError, match="shape must be a scalar or "
+                           "iterable of integers"):
             _init_nd_shape_and_axes(x, shape=[1., 2., 3., 4.], axes=None)
 
         with assert_raises(ValueError,

--- a/scipy/fft/tests/test_helper.py
+++ b/scipy/fft/tests/test_helper.py
@@ -1,6 +1,5 @@
 from scipy.fft._helper import (next_fast_len, _next_regular_len,
-                               _init_nd_shape_and_axes,
-                               _init_nd_shape_and_axes_sorted)
+                               _init_nd_shape_and_axes)
 from numpy.testing import assert_equal, assert_
 from pytest import raises as assert_raises
 import numpy as np
@@ -128,7 +127,7 @@ class TestNextRegularLen(object):
 class Test_init_nd_shape_and_axes(object):
 
     def test_py_0d_defaults(self):
-        x = 4
+        x = np.array(4)
         shape = None
         axes = None
 
@@ -136,11 +135,6 @@ class Test_init_nd_shape_and_axes(object):
         axes_expected = np.array([])
 
         shape_res, axes_res = _init_nd_shape_and_axes(x, shape, axes)
-
-        assert_equal(shape_res, shape_expected)
-        assert_equal(axes_res, axes_expected)
-
-        shape_res, axes_res = _init_nd_shape_and_axes_sorted(x, shape, axes)
 
         assert_equal(shape_res, shape_expected)
         assert_equal(axes_res, axes_expected)
@@ -158,13 +152,8 @@ class Test_init_nd_shape_and_axes(object):
         assert_equal(shape_res, shape_expected)
         assert_equal(axes_res, axes_expected)
 
-        shape_res, axes_res = _init_nd_shape_and_axes_sorted(x, shape, axes)
-
-        assert_equal(shape_res, shape_expected)
-        assert_equal(axes_res, axes_expected)
-
     def test_py_1d_defaults(self):
-        x = [1, 2, 3]
+        x = np.array([1, 2, 3])
         shape = None
         axes = None
 
@@ -172,11 +161,6 @@ class Test_init_nd_shape_and_axes(object):
         axes_expected = np.array([0])
 
         shape_res, axes_res = _init_nd_shape_and_axes(x, shape, axes)
-
-        assert_equal(shape_res, shape_expected)
-        assert_equal(axes_res, axes_expected)
-
-        shape_res, axes_res = _init_nd_shape_and_axes_sorted(x, shape, axes)
 
         assert_equal(shape_res, shape_expected)
         assert_equal(axes_res, axes_expected)
@@ -194,14 +178,9 @@ class Test_init_nd_shape_and_axes(object):
         assert_equal(shape_res, shape_expected)
         assert_equal(axes_res, axes_expected)
 
-        shape_res, axes_res = _init_nd_shape_and_axes_sorted(x, shape, axes)
-
-        assert_equal(shape_res, shape_expected)
-        assert_equal(axes_res, axes_expected)
-
     def test_py_2d_defaults(self):
-        x = [[1, 2, 3, 4],
-             [5, 6, 7, 8]]
+        x = np.array([[1, 2, 3, 4],
+                      [5, 6, 7, 8]])
         shape = None
         axes = None
 
@@ -209,11 +188,6 @@ class Test_init_nd_shape_and_axes(object):
         axes_expected = np.array([0, 1])
 
         shape_res, axes_res = _init_nd_shape_and_axes(x, shape, axes)
-
-        assert_equal(shape_res, shape_expected)
-        assert_equal(axes_res, axes_expected)
-
-        shape_res, axes_res = _init_nd_shape_and_axes_sorted(x, shape, axes)
 
         assert_equal(shape_res, shape_expected)
         assert_equal(axes_res, axes_expected)
@@ -231,11 +205,6 @@ class Test_init_nd_shape_and_axes(object):
         assert_equal(shape_res, shape_expected)
         assert_equal(axes_res, axes_expected)
 
-        shape_res, axes_res = _init_nd_shape_and_axes_sorted(x, shape, axes)
-
-        assert_equal(shape_res, shape_expected)
-        assert_equal(axes_res, axes_expected)
-
     def test_np_5d_defaults(self):
         x = np.zeros([6, 2, 5, 3, 4])
         shape = None
@@ -245,11 +214,6 @@ class Test_init_nd_shape_and_axes(object):
         axes_expected = np.array([0, 1, 2, 3, 4])
 
         shape_res, axes_res = _init_nd_shape_and_axes(x, shape, axes)
-
-        assert_equal(shape_res, shape_expected)
-        assert_equal(axes_res, axes_expected)
-
-        shape_res, axes_res = _init_nd_shape_and_axes_sorted(x, shape, axes)
 
         assert_equal(shape_res, shape_expected)
         assert_equal(axes_res, axes_expected)
@@ -267,11 +231,6 @@ class Test_init_nd_shape_and_axes(object):
         assert_equal(shape_res, shape_expected)
         assert_equal(axes_res, axes_expected)
 
-        shape_res, axes_res = _init_nd_shape_and_axes_sorted(x, shape, axes)
-
-        assert_equal(shape_res, shape_expected)
-        assert_equal(axes_res, axes_expected)
-
     def test_np_5d_set_axes(self):
         x = np.zeros([6, 2, 5, 3, 4])
         shape = None
@@ -281,19 +240,6 @@ class Test_init_nd_shape_and_axes(object):
         axes_expected = np.array([4, 1, 2])
 
         shape_res, axes_res = _init_nd_shape_and_axes(x, shape, axes)
-
-        assert_equal(shape_res, shape_expected)
-        assert_equal(axes_res, axes_expected)
-
-    def test_np_5d_set_axes_sorted(self):
-        x = np.zeros([6, 2, 5, 3, 4])
-        shape = None
-        axes = [4, 1, 2]
-
-        shape_expected = np.array([2, 5, 4])
-        axes_expected = np.array([1, 2, 4])
-
-        shape_res, axes_res = _init_nd_shape_and_axes_sorted(x, shape, axes)
 
         assert_equal(shape_res, shape_expected)
         assert_equal(axes_res, axes_expected)
@@ -311,49 +257,39 @@ class Test_init_nd_shape_and_axes(object):
         assert_equal(shape_res, shape_expected)
         assert_equal(axes_res, axes_expected)
 
-    def test_np_5d_set_shape_axes_sorted(self):
-        x = np.zeros([6, 2, 5, 3, 4])
-        shape = [10, -1, 2]
-        axes = [1, 0, 3]
-
-        shape_expected = np.array([6, 10, 2])
-        axes_expected = np.array([0, 1, 3])
-
-        shape_res, axes_res = _init_nd_shape_and_axes_sorted(x, shape, axes)
-
-        assert_equal(shape_res, shape_expected)
-        assert_equal(axes_res, axes_expected)
-
     def test_errors(self):
+        x = np.zeros(1)
         with assert_raises(ValueError,
                            match="when given, axes values must be a scalar"
-                           " or vector"):
-            _init_nd_shape_and_axes([0], shape=None, axes=[[1, 2], [3, 4]])
+                           " or iterable of integers"):
+            _init_nd_shape_and_axes(x, shape=None, axes=[[1, 2], [3, 4]])
 
         with assert_raises(ValueError,
-                           match="when given, axes values must be integers"):
-            _init_nd_shape_and_axes([0], shape=None, axes=[1., 2., 3., 4.])
-
-        with assert_raises(ValueError,
-                           match="axes exceeds dimensionality of input"):
-            _init_nd_shape_and_axes([0], shape=None, axes=[1])
+                           match="when given, axes values must be a scalar"
+                           " or iterable of integers"):
+            _init_nd_shape_and_axes(x, shape=None, axes=[1., 2., 3., 4.])
 
         with assert_raises(ValueError,
                            match="axes exceeds dimensionality of input"):
-            _init_nd_shape_and_axes([0], shape=None, axes=[-2])
+            _init_nd_shape_and_axes(x, shape=None, axes=[1])
+
+        with assert_raises(ValueError,
+                           match="axes exceeds dimensionality of input"):
+            _init_nd_shape_and_axes(x, shape=None, axes=[-2])
 
         with assert_raises(ValueError,
                            match="all axes must be unique"):
-            _init_nd_shape_and_axes([0], shape=None, axes=[0, 0])
+            _init_nd_shape_and_axes(x, shape=None, axes=[0, 0])
 
         with assert_raises(ValueError,
-                           match="when given, shape values must be a scalar "
-                           "or vector"):
-            _init_nd_shape_and_axes([0], shape=[[1, 2], [3, 4]], axes=None)
+                           match="when given, shape values must be a scalar"
+                           " or iterable of integers"):
+            _init_nd_shape_and_axes(x, shape=[[1, 2], [3, 4]], axes=None)
 
         with assert_raises(ValueError,
-                           match="when given, shape values must be integers"):
-            _init_nd_shape_and_axes([0], shape=[1., 2., 3., 4.], axes=None)
+                           match="when given, shape values must be a scalar"
+                           " or iterable of integers"):
+            _init_nd_shape_and_axes(x, shape=[1., 2., 3., 4.], axes=None)
 
         with assert_raises(ValueError,
                            match="when given, axes and shape arguments"
@@ -364,9 +300,9 @@ class Test_init_nd_shape_and_axes(object):
         with assert_raises(ValueError,
                            match="invalid number of data points"
                            r" \(\[0\]\) specified"):
-            _init_nd_shape_and_axes([0], shape=[0], axes=None)
+            _init_nd_shape_and_axes(x, shape=[0], axes=None)
 
         with assert_raises(ValueError,
                            match="invalid number of data points"
                            r" \(\[-2\]\) specified"):
-            _init_nd_shape_and_axes([0], shape=-2, axes=None)
+            _init_nd_shape_and_axes(x, shape=-2, axes=None)

--- a/scipy/fftpack/helper.py
+++ b/scipy/fftpack/helper.py
@@ -4,7 +4,6 @@ import operator
 from numpy.fft.helper import fftshift, ifftshift, fftfreq
 from scipy.fft._helper import _next_regular_len
 import numpy as np
-
 __all__ = ['fftshift', 'ifftshift', 'fftfreq', 'rfftfreq', 'next_fast_len']
 
 

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -11,7 +11,7 @@ from . import sigtools, dlti
 from ._upfirdn import upfirdn, _output_len
 from scipy._lib.six import callable
 from scipy import linalg, fft as sp_fft
-from scipy.fft._helper import _init_nd_shape_and_axes_sorted
+from scipy.fft._helper import _init_nd_shape_and_axes
 from numpy import (allclose, angle, arange, argsort, array, asarray,
                    atleast_1d, atleast_2d, cast, dot, exp, expand_dims,
                    iscomplexobj, mean, ndarray, newaxis, ones, pi,
@@ -368,32 +368,26 @@ def fftconvolve(in1, in2, mode="full", axes=None):
     elif in1.size == 0 or in2.size == 0:  # empty arrays
         return array([])
 
-    _, axes = _init_nd_shape_and_axes_sorted(in1, shape=None, axes=axes)
+    s1 = in1.shape
+    s2 = in2.shape
+    _, axes = _init_nd_shape_and_axes(in1, shape=None, axes=axes)
 
-    if not noaxes and not axes.size:
-        raise ValueError("when provided, axes cannot be empty")
+    if not noaxes:
+        if not axes.size:
+            raise ValueError("when provided, axes cannot be empty")
 
     # Axes of length 1 can rely on broadcasting rules for multipy, no fft needed
-    axes = np.array([a for a in axes
-                     if in1.shape[a] != 1 and in2.shape[a] != 1], axes.dtype)
+    axes = [a for a in axes if in1.shape[a] != 1 and in2.shape[a] != 1]
 
-    if noaxes:
-        other_axes = array([], dtype=np.intc)
-    else:
-        other_axes = np.setdiff1d(np.arange(in1.ndim), axes)
-
-    s1 = array(in1.shape)
-    s2 = array(in2.shape)
-
-    if not np.all((s1[other_axes] == s2[other_axes])
-                  | (s1[other_axes] == 1) | (s2[other_axes] == 1)):
+    if not all(s1[a] == s2[a] | s1[a] == 1 | s2[a] ==1
+               for a in range(in1.ndim) if a not in axes):
         raise ValueError("incompatible shapes for in1 and in2:"
                          " {0} and {1}".format(in1.shape, in2.shape))
 
-    complex_result = (np.issubdtype(in1.dtype, np.complexfloating)
-                      or np.issubdtype(in2.dtype, np.complexfloating))
-    shape = np.maximum(s1, s2)
-    shape[axes] = s1[axes] + s2[axes] - 1
+    shape = [max((s1[i], s2[i])) if i not in axes else s1[i] + s2[i] - 1
+             for i in range(in1.ndim)]
+
+    complex_result = (in1.dtype.kind == 'c' or in2.dtype.kind == 'c')
 
     # Check that input sizes are compatible with 'valid' mode
     if _inputs_swap_needed(mode, s1, s2):
@@ -402,7 +396,7 @@ def fftconvolve(in1, in2, mode="full", axes=None):
 
     if axes.size:
         # Speed up FFT by padding to optimal size
-        fshape = [sp_fft.next_fast_len(d) for d in shape[axes]]
+        fshape = [sp_fft.next_fast_len(shape[a]) for a in axes]
         fslice = tuple([slice(sz) for sz in shape])
         if not complex_result:
             fft, ifft = sp_fft.rfftn, sp_fft.irfftn
@@ -419,8 +413,8 @@ def fftconvolve(in1, in2, mode="full", axes=None):
     elif mode == "same":
         return _centered(ret, s1)
     elif mode == "valid":
-        shape_valid = shape.copy()
-        shape_valid[axes] = s1[axes] - s2[axes] + 1
+        shape_valid = [shape[a] if a not in axes else s1[a] - s2[a] + 1
+                       for a in range(in1.ndim)]
         return _centered(ret, shape_valid)
     else:
         raise ValueError("acceptable mode flags are 'valid',"

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -373,13 +373,13 @@ def fftconvolve(in1, in2, mode="full", axes=None):
     _, axes = _init_nd_shape_and_axes(in1, shape=None, axes=axes)
 
     if not noaxes:
-        if not axes.size:
+        if not len(axes):
             raise ValueError("when provided, axes cannot be empty")
 
     # Axes of length 1 can rely on broadcasting rules for multipy, no fft needed
     axes = [a for a in axes if in1.shape[a] != 1 and in2.shape[a] != 1]
 
-    if not all(s1[a] == s2[a] | s1[a] == 1 | s2[a] ==1
+    if not all(s1[a] == s2[a] or s1[a] == 1 or s2[a] ==1
                for a in range(in1.ndim) if a not in axes):
         raise ValueError("incompatible shapes for in1 and in2:"
                          " {0} and {1}".format(in1.shape, in2.shape))

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -372,9 +372,8 @@ def fftconvolve(in1, in2, mode="full", axes=None):
     s2 = in2.shape
     _, axes = _init_nd_shape_and_axes(in1, shape=None, axes=axes)
 
-    if not noaxes:
-        if not len(axes):
-            raise ValueError("when provided, axes cannot be empty")
+    if not noaxes and not len(axes):
+        raise ValueError("when provided, axes cannot be empty")
 
     # Axes of length 1 can rely on broadcasting rules for multipy, no fft needed
     axes = [a for a in axes if in1.shape[a] != 1 and in2.shape[a] != 1]
@@ -394,7 +393,7 @@ def fftconvolve(in1, in2, mode="full", axes=None):
         # Convolution is commutative; order doesn't have any effect on output
         in1, s1, in2, s2 = in2, s2, in1, s1
 
-    if axes.size:
+    if len(axes):
         # Speed up FFT by padding to optimal size
         fshape = [sp_fft.next_fast_len(shape[a]) for a in axes]
         fslice = tuple([slice(sz) for sz in shape])

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -378,7 +378,7 @@ def fftconvolve(in1, in2, mode="full", axes=None):
     # Axes of length 1 can rely on broadcasting rules for multipy, no fft needed
     axes = [a for a in axes if in1.shape[a] != 1 and in2.shape[a] != 1]
 
-    if not all(s1[a] == s2[a] or s1[a] == 1 or s2[a] ==1
+    if not all(s1[a] == s2[a] or s1[a] == 1 or s2[a] == 1
                for a in range(in1.ndim) if a not in axes):
         raise ValueError("incompatible shapes for in1 and in2:"
                          " {0} and {1}".format(in1.shape, in2.shape))

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -785,14 +785,12 @@ class TestFFTConvolve(object):
                            match="when provided, axes cannot be empty"):
             fftconvolve([1], [2], axes=[])
 
-        with assert_raises(ValueError,
-                           match="when given, axes values must be a scalar"
-                           " or iterable of integers"):
+        with assert_raises(ValueError, match="axes must be a scalar or "
+                           "iterable of integers"):
             fftconvolve([1], [2], axes=[[1, 2], [3, 4]])
 
-        with assert_raises(ValueError,
-                           match="when given, axes values must be a scalar"
-                           " or iterable of integers"):
+        with assert_raises(ValueError, match="axes must be a scalar or "
+                           "iterable of integers"):
             fftconvolve([1], [2], axes=[1., 2., 3., 4.])
 
         with assert_raises(ValueError,

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -787,11 +787,12 @@ class TestFFTConvolve(object):
 
         with assert_raises(ValueError,
                            match="when given, axes values must be a scalar"
-                           " or vector"):
+                           " or iterable of integers"):
             fftconvolve([1], [2], axes=[[1, 2], [3, 4]])
 
         with assert_raises(ValueError,
-                           match="when given, axes values must be integers"):
+                           match="when given, axes values must be a scalar"
+                           " or iterable of integers"):
             fftconvolve([1], [2], axes=[1., 2., 3., 4.])
 
         with assert_raises(ValueError,


### PR DESCRIPTION
#### Reference issue
See https://github.com/scipy/scipy/pull/10507#issuecomment-514593823

#### What does this implement/fix?
This applies the same principle from #10490 to `fftconvolve`. Axes and shape are usually very small so numpy arrays are much slower than using normal python list comprehensions.

This also goes further than #10490 and removes numpy arrays from `_init_nd_shape_and_axes` completely. Even when shape and axes are given, which is always the case in `fftconvolve`. I left this out of #10490 because I'm not 100% confident that it will accept the same range of inputs but for "normal" cases like tuples, lists and numpy arrays this will definitely work.

~Note: Please wait until after #10507 has been merged, these do conflict~

#### Additional information
Performance results from the following code
```python
setup = '''
from scipy.fft import rfft, irfft, next_fast_len
from scipy.fft import fft, fftn
from scipy.signal import fftconvolve
import numpy as np

x = np.random.random(1000)
N = next_fast_len(2 * 1000 - 1)
'''
n=1000000
print('fft            :', time('fft(x, N, -1)', setup, n))
print('fftn           :', time('fftn(x, N, -1)', setup, n))
print('fftconvolve    :', time('fftconvolve(x, x)', setup, n))
print('manual convolve:', time('irfft(rfft(x, N) * rfft(x, N), N)[:x.shape[0]].copy()', setup, n))
```

Before:
```
fft            : (24.44, 25.42) us
fftn           : (43.84, 45.51) us
fftconvolve    : (187.89, 189.99) us
manual convolve: (69.57, 72.25) us
```

After:
```
fft            : (23.41, 24.09) us
fftn           : (28.28, 29.15) us
fftconvolve    : (92.73, 94.34) us
manual convolve: (65.77, 68.52) us
```

So `fftn` is now closer to `fft` and `fftconvolve` is almost as fast as a manual fft convolution.