### PR TITLE
API: Rename scipy.fft DCT/DST shape argument to s

### DIFF
--- a/scipy/fft/_realtransforms.py
+++ b/scipy/fft/_realtransforms.py
@@ -7,7 +7,7 @@ __all__ = ['dct', 'idct', 'dst', 'idst', 'dctn', 'idctn', 'dstn', 'idstn']
 
 
 @_dispatch
-def dctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
+def dctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False):
     """
     Return multidimensional Discrete Cosine Transform along the specified axes.
 
@@ -17,15 +17,15 @@ def dctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
         The input array.
     type : {1, 2, 3, 4}, optional
         Type of the DCT (see Notes). Default type is 2.
-    shape : int or array_like of ints or None, optional
-        The shape of the result.  If both `shape` and `axes` (see below) are
-        None, `shape` is ``x.shape``; if `shape` is None but `axes` is
-        not None, then `shape` is ``scipy.take(x.shape, axes, axis=0)``.
-        If ``shape[i] > x.shape[i]``, the i-th dimension is padded with zeros.
-        If ``shape[i] < x.shape[i]``, the i-th dimension is truncated to
-        length ``shape[i]``.
-        If any element of `shape` is -1, the size of the corresponding
-        dimension of `x` is used.
+    s : int or array_like of ints or None, optional
+        The shape of the result.  If both `s` and `axes` (see below) are None,
+        `s` is ``x.shape``; if `s` is None but `axes` is not None, then `s` is
+        ``scipy.take(x.shape, axes, axis=0)``.
+        If ``s[i] > x.shape[i]``, the i-th dimension is padded with zeros.
+        If ``s[i] < x.shape[i]``, the i-th dimension is truncated to length
+        ``s[i]``.
+        If any element of `s` is -1, the size of the corresponding dimension of
+        `x` is used.
     axes : int or array_like of ints or None, optional
         Axes along which the DCT is computed.
         The default is over all axes.
@@ -60,7 +60,7 @@ def dctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
 
 
 @_dispatch
-def idctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
+def idctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False):
     """
     Return multidimensional Discrete Cosine Transform along the specified axes.
 
@@ -70,15 +70,15 @@ def idctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
         The input array.
     type : {1, 2, 3, 4}, optional
         Type of the DCT (see Notes). Default type is 2.
-    shape : int or array_like of ints or None, optional
-        The shape of the result.  If both `shape` and `axes` (see below) are
-        None, `shape` is ``x.shape``; if `shape` is None but `axes` is
-        not None, then `shape` is ``scipy.take(x.shape, axes, axis=0)``.
-        If ``shape[i] > x.shape[i]``, the i-th dimension is padded with zeros.
-        If ``shape[i] < x.shape[i]``, the i-th dimension is truncated to
-        length ``shape[i]``.
-        If any element of `shape` is -1, the size of the corresponding
-        dimension of `x` is used.
+    s : int or array_like of ints or None, optional
+        The shape of the result.  If both `s` and `axes` (see below) are
+        None, `s` is ``x.shape``; if `s` is None but `axes` is
+        not None, then `s` is ``scipy.take(x.shape, axes, axis=0)``.
+        If ``s[i] > x.shape[i]``, the i-th dimension is padded with zeros.
+        If ``s[i] < x.shape[i]``, the i-th dimension is truncated to length
+        ``s[i]``.
+        If any element of `s` is -1, the size of the corresponding dimension of
+        `x` is used.
     axes : int or array_like of ints or None, optional
         Axes along which the IDCT is computed.
         The default is over all axes.
@@ -113,7 +113,7 @@ def idctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
 
 
 @_dispatch
-def dstn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
+def dstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False):
     """
     Return multidimensional Discrete Sine Transform along the specified axes.
 
@@ -123,15 +123,15 @@ def dstn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
         The input array.
     type : {1, 2, 3, 4}, optional
         Type of the DST (see Notes). Default type is 2.
-    shape : int or array_like of ints or None, optional
-        The shape of the result.  If both `shape` and `axes` (see below) are
-        None, `shape` is ``x.shape``; if `shape` is None but `axes` is
-        not None, then `shape` is ``scipy.take(x.shape, axes, axis=0)``.
-        If ``shape[i] > x.shape[i]``, the i-th dimension is padded with zeros.
-        If ``shape[i] < x.shape[i]``, the i-th dimension is truncated to
-        length ``shape[i]``.
-        If any element of `shape` is -1, the size of the corresponding
-        dimension of `x` is used.
+    s : int or array_like of ints or None, optional
+        The shape of the result.  If both `s` and `axes` (see below) are None,
+        `s` is ``x.shape``; if `s` is None but `axes` is not None, then `s` is
+        ``scipy.take(x.shape, axes, axis=0)``.
+        If ``s[i] > x.shape[i]``, the i-th dimension is padded with zeros.
+        If ``s[i] < x.shape[i]``, the i-th dimension is truncated to length
+        ``s[i]``.
+        If any element of `shape` is -1, the size of the corresponding dimension
+        of `x` is used.
     axes : int or array_like of ints or None, optional
         Axes along which the DCT is computed.
         The default is over all axes.
@@ -166,7 +166,7 @@ def dstn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
 
 
 @_dispatch
-def idstn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
+def idstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False):
     """
     Return multidimensional Discrete Sine Transform along the specified axes.
 
@@ -176,15 +176,15 @@ def idstn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
         The input array.
     type : {1, 2, 3, 4}, optional
         Type of the DST (see Notes). Default type is 2.
-    shape : int or array_like of ints or None, optional
-        The shape of the result.  If both `shape` and `axes` (see below) are
-        None, `shape` is ``x.shape``; if `shape` is None but `axes` is
-        not None, then `shape` is ``scipy.take(x.shape, axes, axis=0)``.
-        If ``shape[i] > x.shape[i]``, the i-th dimension is padded with zeros.
-        If ``shape[i] < x.shape[i]``, the i-th dimension is truncated to
-        length ``shape[i]``.
-        If any element of `shape` is -1, the size of the corresponding
-        dimension of `x` is used.
+    s : int or array_like of ints or None, optional
+        The shape of the result.  If both `s` and `axes` (see below) are None,
+        `s` is ``x.shape``; if `s` is None but `axes` is not None, then `s` is
+        ``scipy.take(x.shape, axes, axis=0)``.
+        If ``s[i] > x.shape[i]``, the i-th dimension is padded with zeros.
+        If ``s[i] < x.shape[i]``, the i-th dimension is truncated to length
+        ``s[i]``.
+        If any element of `s` is -1, the size of the corresponding dimension of
+        `x` is used.
     axes : int or array_like of ints or None, optional
         Axes along which the IDST is computed.
         The default is over all axes.


### PR DESCRIPTION
#### What does this implement/fix?
The `shape` parameter for the n-dimensional DCT and DST functions are renamed `s`.

#### Additional information
This was an oversight in the API for `scipy.fft`. As you can see from the [docs], every function under the "FFTs" section uses `s` rather than `shape`. This is done for consistency with the [`numpy.fft` API][numpy].

While this does hurt compatability with `scipy.fftpack`, it also makes the interface for `scipy.fft` more consistent.

[docs]: https://scipy.github.io/devdocs/fft.html
[numpy]: https://numpy.org/devdocs/reference/routines.fft.html