### PR TITLE
BUG: fixed improper rotations in spatial.transform.rotation.match_vectors

### DIFF
--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -1620,6 +1620,12 @@ class Rotation(object):
 
         B = np.einsum('ji,jk->ik', weights[:, None] * a, b)
         u, s, vh = np.linalg.svd(B)
+
+        # Correct improper rotation if necessary (as in Kabsch algorithm)
+        if np.linalg.det(u @ vh) < 0:
+            s[-1] = -s[-1]
+            u[:, -1] = -u[:, -1]
+
         C = np.dot(u, vh)
 
         zeta = (s[0]+s[1]) * (s[1]+s[2]) * (s[2]+s[0])

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -791,6 +791,17 @@ def test_match_vectors_no_noise():
     assert_allclose(c.as_quat(), est.as_quat())
 
 
+def test_match_vectors_improper_rotation():
+    # Tests correct logic for issue #10444
+    x = np.array([[0.89299824, -0.44372674, 0.0752378],
+                  [0.60221789, -0.47564102, -0.6411702]])
+    y = np.array([[0.02386536, -0.82176463, 0.5693271],
+                  [-0.27654929, -0.95191427, -0.1318321]])
+
+    est, cov = Rotation.match_vectors(x, y)
+    assert_allclose(x, est.apply(y), atol=1e-6)
+
+
 def test_match_vectors_noise():
     np.random.seed(0)
     n_vectors = 100


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes issue #10444

#### What does this implement/fix?
<!--Please explain your changes.-->
Corrects improper rotations as done in the Kabsch algorithm.

#### Additional information
<!--Any additional information you think is important.-->
A unit test has been added using the data provided by @sinanus in issue #10444