### PR TITLE
DOC: update roadmap with scipy.stats goals

### DIFF
--- a/doc/source/roadmap-detailed.rst
+++ b/doc/source/roadmap-detailed.rst
@@ -355,15 +355,28 @@ functions, and spheroidal wave functions. Three possible ways to handle this:
 stats
 `````
 
-This module is in good shape overall.  New functionality that's similar to
-what's already present can continue to be added; more advanced statistical
-routines may fit better in ``statsmodels``.  Some ideas for new contributions
-are:
+The ``scipy.stats`` subpackage does not seek to duplicate the advanced 
+functionality of downstream packages (e.g. StatsModels, LinearModels, PyMC3),
+but to provide a solid foundation for them. The following improvements will 
+help SciPy better serve this role.
 
-- Implementing (well-known) distributions to the ``stats.distributions``
-  framework is always welcome.
-- Continuing work on making the function signatures of ``stats`` and
-  ``stats.mstats`` more consistent, and adding tests to ensure that that
+- Add fundamental and widely used hypothesis tests, including the various types
+  of ANOVA and ANCOVA.
+- Where appropriate, provide more than just a p-value as the result of a 
+  statistical test; include also confidence intervals and measures of effect 
+  size in the results.
+- Ensure that fitting a probability distribution to a data set is
+  easily accomplished with methods tailored to the distribution and 
+  and with calculations to assess the quality of the fit.
+- Implement additional widely used continuous and discrete probability 
+  distributions, including mixture distributions.
+- Improve the core calculations provided by SciPy's probability distributions 
+  so they can robustly handle wide ranges of parameter values.
+  
+In addition, we should:
+
+- Continue work on making the function signatures of ``stats`` and
+  ``stats.mstats`` more consistent, and add tests to ensure that that
   remains the case.
 - Return ``Bunch`` objects from functions that now return many values, and for
   functions for which extra return values are desired (see
@@ -372,5 +385,5 @@ are:
   example implement an exact two-sided KS test (see
   `gh-8341 <https://github.com/scipy/scipy/issues/8341>`__) or a one-sided
   Wilcoxon test (see `gh-9046 <https://github.com/scipy/scipy/issues/9046>`__).
-- There are a number of issues regarding ``stats.mannwhitneyu``, and a stalled
-  PR in `gh-4933 <https://github.com/scipy/scipy/pull/4933>`__ could be picked up.
+- Address the various issues regarding ``stats.mannwhitneyu``, and pick up the 
+  stalled PR in `gh-4933 <https://github.com/scipy/scipy/pull/4933>`__.

--- a/doc/source/roadmap.rst
+++ b/doc/source/roadmap.rst
@@ -4,7 +4,7 @@ SciPy Roadmap
 =============
 
 This roadmap page contains only the most important ideas and needs for SciPy
-going forward.  For a more detailed roadmap, including per-submodule status,
+going forward.  For a more detailed roadmap, including per-subpackage status,
 many more ideas, API stability and more, see :ref:`scipy-roadmap-detailed`.
 
 
@@ -53,7 +53,7 @@ along.  The tentative plan is:
 Fourier transform enhancements
 ------------------------------
 
-The new ``scipy.fft`` submodule should be extended to add a backend system with
+The new ``scipy.fft`` subpackage should be extended to add a backend system with
 support for PyFFTW and mkl-fft.
 
 
@@ -98,11 +98,8 @@ however; we need to make it faster and make it easier to compare performance of
 optimizers via plotting performance profiles.
 
 
-Linear programming enhancements
--------------------------------
+Statistics enhancements
+-----------------------
 
-Recently all known issues with ``optimize.linprog`` have been solved.  Now we
-have many ideas for additional functionality (e.g. integer constraints, sparse
-matrix support, performance improvements), see gh-9269.
-
-
+The `scipy.stats` enhancements listed in the `scipy-roadmap-detailed`_ are of
+particularly high importance to the project.


### PR DESCRIPTION
Three changes here. 
In order of increasing significance:

1. "submodule" -> "subpackage", which is more accurate. Not a big deal; just happened to notice it since we made this change in the paper.
2. Removed `linprog` from [top level roadmap](http://scipy.github.io/devdocs/roadmap.html). Did I put that there? I'm all about `linprog`, and I'd be happy to keep it here, but I'm not sure it's at the same priority level as the rest.
3. Added `scipy.stats` to top level roadmap. I'm hoping that others agree that `scipy.stats` belongs here, since our [CZI grant](https://chanzuckerberg.com/rfa/essential-open-source-software-for-science/) proposal is all about it. Also added to the [detailed roadmap](http://scipy.github.io/devdocs/roadmap-detailed.html) some particulars from the proposal. Avoided changing what was already written about stats.