### PR TITLE
CI: add 3.8-dev to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,10 @@ matrix:
             - *common_packages
             - python3.5-dbg
             - python3.5-dev
+   - python: 3.8-dev
+      env:
+        - TESTMODE=fast
+        - NUMPYSPEC="numpy"
     - python: 3.6
       env:
         - TESTMODE=fast

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ matrix:
             - *common_packages
             - python3.5-dbg
             - python3.5-dev
-   - python: 3.8-dev
+    - python: 3.8-dev
       env:
         - TESTMODE=fast
         - NUMPYSPEC="numpy"

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,8 @@ matrix:
             - python3.5-dbg
             - python3.5-dev
     - python: 3.8-dev
+      dist: xenial
+      sudo: true
       env:
         - TESTMODE=fast
         - NUMPYSPEC="numpy"

--- a/scipy/odr/__odrpack.c
+++ b/scipy/odr/__odrpack.c
@@ -477,7 +477,7 @@ PyObject *odr(PyObject * self, PyObject * args, PyObject * kwds)
   int full_output = 0;
   double taufac = 0.0, sstol = -1.0, partol = -1.0;
   char *errfile = NULL, *rptfile = NULL;
-  int lerrfile = 0, lrptfile = 0;
+  Py_ssize_t lerrfile = 0, lrptfile = 0;
   PyArrayObject *beta = NULL, *y = NULL, *x = NULL, *we = NULL, *wd = NULL;
   PyArrayObject *ifixb = NULL, *ifixx = NULL;
   PyArrayObject *stpb = NULL, *stpd = NULL, *sclb = NULL, *scld = NULL;

--- a/scipy/odr/odrpack.h
+++ b/scipy/odr/odrpack.h
@@ -1,3 +1,4 @@
+#define PY_SSIZE_T_CLEAN
 #include "Python.h"
 #include "numpy/arrayobject.h"
 


### PR DESCRIPTION
Meant to submit against my own fork first, to reduce load on CI, but obviously made a mistake.

Python 3.8 will be released in a few months and we should start running our CI against it.