### PR TITLE
MAINT: special: don't register `i0` with `numpy.dual`

### DIFF
--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -645,10 +645,6 @@ from ._spherical_bessel import (spherical_jn, spherical_yn, spherical_in,
 
 __all__ = [s for s in dir() if not s.startswith('_')]
 
-from numpy.dual import register_func
-register_func('i0',i0)
-del register_func
-
 from scipy._lib._testutils import PytestTester
 test = PytestTester(__name__)
 del PytestTester


### PR DESCRIPTION
#### Reference issue:

https://github.com/scipy/scipy/issues/10441

#### What does this implement/fix?

It removes the registration of `special.i0` with `numpy.dual`, so that `numpy.dual.i0` will unconditionally use the NumPy version of `i0` regardless of whether `special` is imported or not.

#### Additional information

`numpy.dual` is no longer actively developed and has some import-order gotchas:

```python
In [1]: import scipy.special as sc

In [2]: from numpy.dual import i0

In [3]: import numpy as np

In [4]: x = np.linspace(1, 100, 500)

In [5]: %timeit i0(x)  # Using SciPy's i0 successfully
26.8 µs ± 78.9 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

```python
In [1]: from numpy.dual import i0

In [2]: import scipy.special as sc

In [3]: import numpy as np

In [4]: x = np.linspace(1, 100, 500)

In [5]: %timeit i0(x)  # Oops, using NumPy's i0 this time
139 µs ± 6.67 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

In addition, if people want to potentially use SciPy's `i0` and fall back to the NumPy version, then they can easily do:

```python
try:
    from scipy.special import i0
except ImportError:
    from numpy import i0
```

which is easier to understand. Indeed, as far as I can tell using `dual` now would require similar tricks:

```python
try:
    import scipy.special as sc
except ImportError:
    pass
from numpy.dual import i0
```

except that the intent is less clear (and would make a linter unhappy).

Furthermore, I can't actually find any uses of `numpy.dual.i0` in the wild; Google searches like:

- `"from numpy.dual import i0" site::https://github.com`
- `"numpy.dual.i0" site::https://github.com`
- `"dual.i0" site::https://github.com`

don't turn up any results.

Finally, removing the registration is backwards-compatible in the sense that old code will continue to run; after the change we have:

```python
In [1]: import scipy.special as sc

In [2]: from numpy.dual import i0

In [3]: import numpy as np

In [4]: x = np.linspace(1, 100, 500)

In [5]: %timeit i0(x)  # Not using SciPy anymore
134 µs ± 5.25 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

It will just be slower.