### PR TITLE
ENH: Adding border option to signal.resample_poly

### DIFF
--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2340,7 +2340,7 @@ def resample_poly(x, up, down, axis=0, window=('kaiser', 5.0), border='zero'):
         coefficients to employ. See below for details.
     border : string, optional
         `zero`, `mean` or `edge`. Changes assumptions on the values beyond the
-		boundary. If `zero`, assumed to be zero. If `mean`, assumed to be the
+        boundary. If `zero`, assumed to be zero. If `mean`, assumed to be the
         mean. If `edge` assumed to continue a linear trend defined by the
         first and last points.
 
@@ -2379,7 +2379,7 @@ def resample_poly(x, up, down, axis=0, window=('kaiser', 5.0), border='zero'):
     coefficients.
 
     The argument border changes assumptions on the values beyond the
-	boundary. The default (border=`zero`) is to assume that they are zero. In
+    boundary. The default (border=`zero`) is to assume that they are zero. In
     other cases, the mean or a linear trend is substracted from the signal
     prior to resampling, and then reapplied to the output.
 

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2350,7 +2350,7 @@ def resample_poly(x, up, down, axis=0, window=('kaiser', 5.0),
         `constant`, `mean` or `line`. Changes assumptions on values beyond the
         boundary. If `constant`, assumed to be `cval` (default zero). If `line`
         assumed to continue a linear trend defined by the first and last
-        points. `mean`, `median`, `maximum` and `minimum` work as in np.pad and
+        points. `mean`, `median`, `maximum` and `minimum` work as in `np.pad` and
         assume that the values beyond the boundary are the mean, median,
         maximum or minimum respectively of the array along the axis.
 

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2322,8 +2322,8 @@ def resample_poly(x, up, down, axis=0, window=('kaiser', 5.0), border='zero'):
     The signal `x` is upsampled by the factor `up`, a zero-phase low-pass
     FIR filter is applied, and then it is downsampled by the factor `down`.
     The resulting sample rate is ``up / down`` times the original sample
-    rate. Values beyond the boundary of the signal are assumed to be zero
-    during the filtering step.
+    rate. By default, values beyond the boundary of the signal are assumed
+    to be zero during the filtering step.
 
     Parameters
     ----------
@@ -2338,6 +2338,11 @@ def resample_poly(x, up, down, axis=0, window=('kaiser', 5.0), border='zero'):
     window : string, tuple, or array_like, optional
         Desired window to use to design the low-pass filter, or the FIR filter
         coefficients to employ. See below for details.
+    border : string, optional
+        `zero`, `mean` or `edge`. Changes assumptions on the values beyond the
+		boundary. If `zero`, assumed to be zero. If `mean`, assumed to be the
+        mean. If `edge` assumed to continue a linear trend defined by the
+        first and last points.
 
     Returns
     -------
@@ -2372,6 +2377,11 @@ def resample_poly(x, up, down, axis=0, window=('kaiser', 5.0), border='zero'):
     For any other type of `window`, the functions `scipy.signal.get_window`
     and `scipy.signal.firwin` are called to generate the appropriate filter
     coefficients.
+
+    The argument border changes assumptions on the values beyond the
+	boundary. The default (border=`zero`) is to assume that they are zero. In
+    other cases, the mean or a linear trend is substracted from the signal
+    prior to resampling, and then reapplied to the output.
 
     The first sample of the returned vector is the same as the first
     sample of the input vector. The spacing between samples is changed

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2354,7 +2354,9 @@ def resample_poly(x, up, down, axis=0, window=('kaiser', 5.0),
         assume that the values beyond the boundary are the mean, median,
         maximum or minimum respectively of the array along the axis.
     cval : float, optional
-        Value to use if `padtype='constant'`. Default is zero
+        Value to use if `padtype='constant'`. Default is zero.
+
+        .. versionadded:: 1.4.0
 
     Returns
     -------

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2418,7 +2418,6 @@ def resample_poly(x, up, down, axis=0, window=('kaiser', 5.0), border='zero'):
 
     >>> N = 5
     >>> x = np.linspace(0, 1, N, endpoint=False)
-
     >>> y = 2 + x**2 - 1.7*np.sin(x) + .2*np.cos(11*x)
     >>> y2 = 1 + x**3 + 0.1*np.sin(x) + .1*np.cos(11*x)
     >>> Y = np.stack([y, y2], axis=-1)
@@ -2437,7 +2436,6 @@ def resample_poly(x, up, down, axis=0, window=('kaiser', 5.0), border='zero'):
     >>>     plt.plot(xr, y2[:,i], 'r.', label='zero')
     >>>     plt.plot(x, Y[:,i], 'k-')
     >>>     plt.legend()
-    >>>
     >>> plt.show()
 
     """

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2340,9 +2340,11 @@ def resample_poly(x, up, down, axis=0, window=('kaiser', 5.0), border='zero'):
         coefficients to employ. See below for details.
     border : string, optional
         `zero`, `mean` or `line`. Changes assumptions on the values beyond the
-        boundary. If `zero`, assumed to be zero. If `mean`, assumed to be the
-        mean. If `line` assumed to continue a linear trend defined by the
-        first and last points.
+        boundary. If `zero`, assumed to be zero. If `line` assumed to continue
+        a linear trend defined by the first and last points. `mean`, `median`,
+        `maximum` and `minimum` work as in np.pad and assume that the values
+        beyond the boundary are the mean, median, maximum or minimum
+        respectively of the array along the axis.
 
     Returns
     -------
@@ -2380,8 +2382,9 @@ def resample_poly(x, up, down, axis=0, window=('kaiser', 5.0), border='zero'):
 
     The argument border changes assumptions on the values beyond the
     boundary. The default (border=`zero`) is to assume that they are zero. In
-    other cases, the mean or a linear trend is substracted from the signal
-    prior to resampling, and then reapplied to the output.
+    other cases, a constant (`mean`, `median`, `maximum` or `minimum`), or a
+    linear trend is substracted from the signal prior to resampling, and then
+    reapplied to the output.
 
     The first sample of the returned vector is the same as the first
     sample of the input vector. The spacing between samples is changed
@@ -2389,7 +2392,7 @@ def resample_poly(x, up, down, axis=0, window=('kaiser', 5.0), border='zero'):
 
     Examples
     --------
-    Note that the end of the resampled data rises to meet the first
+    By default, the end of the resampled data rises to meet the first
     sample of the next cycle for the FFT method, and gets closer to zero
     for the polyphase method:
 
@@ -2407,6 +2410,36 @@ def resample_poly(x, up, down, axis=0, window=('kaiser', 5.0), border='zero'):
     >>> plt.plot(10, y[0], 'bo', 10, 0., 'ro')  # boundaries
     >>> plt.legend(['resample', 'resamp_poly', 'data'], loc='best')
     >>> plt.show()
+
+    This default behaviour can be changed by using the border option:
+
+    >>> import numpy as np
+    >>> from scipy import signal
+
+    >>> N = 5
+    >>> x = np.linspace(0, 1, N, endpoint=False)
+
+    >>> y = 2 + x**2 - 1.7*np.sin(x) + .2*np.cos(11*x)
+    >>> y2 = 1 + x**3 + 0.1*np.sin(x) + .1*np.cos(11*x)
+    >>> Y = np.stack([y, y2], axis=-1)
+    >>> up = 4
+    >>> xr = np.linspace(0, 1, N*up, endpoint=False)
+
+    >>> y2 = signal.resample_poly(Y, up, 1, border='zero')
+    >>> y3 = signal.resample_poly(Y, up, 1, border='mean')
+    >>> y4 = signal.resample_poly(Y, up, 1, border='line')
+
+    >>> import matplotlib.pyplot as plt
+    >>> for i in [0,1]:
+    >>>     plt.figure()
+    >>>     plt.plot(xr, y4[:,i], 'g.', label='line')
+    >>>     plt.plot(xr, y3[:,i], 'y.', label='mean')
+    >>>     plt.plot(xr, y2[:,i], 'r.', label='zero')
+    >>>     plt.plot(x, Y[:,i], 'k-')
+    >>>     plt.legend()
+    >>>
+    >>> plt.show()
+
     """
     x = asarray(x)
     if up != int(up):

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -94,6 +94,7 @@ def _inputs_swap_needed(mode, shape1, shape2):
 
     return False
 
+
 def _reshape_nd(x1d, ndim, axis):
     """
     Reshape x1d to size 1 along all axes in ``range(ndim)`` except for ``axis``.
@@ -101,6 +102,7 @@ def _reshape_nd(x1d, ndim, axis):
     shape = [1] * ndim
     shape[axis] = x1d.size
     return x1d.reshape(shape)
+
 
 def correlate(in1, in2, mode='full', method='auto'):
     r"""
@@ -2514,7 +2516,8 @@ def resample_poly(x, up, down, axis=0, window=('kaiser', 5.0),
         background_line = [x.take(0, axis),
                            (x.take(-1, axis) - x.take(0, axis))*n_in/(n_in-1)]
     else:
-        raise ValueError('padtype must be line, maximum, mean, median, minimum or constant')
+        raise ValueError(
+            'padtype must be line, maximum, mean, median, minimum or constant')
 
     if padtype == 'line' or padtype in funcs:
         rel_len = np.linspace(0.0, 1.0, n_in, endpoint=False)

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2396,12 +2396,6 @@ def resample_poly(x, up, down, axis=0, window=('kaiser', 5.0),
     and `scipy.signal.firwin` are called to generate the appropriate filter
     coefficients.
 
-    The argument padtype changes assumptions on the values beyond the
-    boundary. The default (padtype=`constant`) is to assume that they are zero.
-    In other cases, a constant (`mean`, `median`, `maximum` or `minimum`), or a
-    linear trend is substracted from the signal prior to resampling, and then
-    reapplied to the output.
-
     The first sample of the returned vector is the same as the first
     sample of the input vector. The spacing between samples is changed
     from ``dx`` to ``dx * down / float(up)``.

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2353,6 +2353,8 @@ def resample_poly(x, up, down, axis=0, window=('kaiser', 5.0),
         points. `mean`, `median`, `maximum` and `minimum` work as in np.pad and
         assume that the values beyond the boundary are the mean, median,
         maximum or minimum respectively of the array along the axis.
+
+        .. versionadded:: 1.4.0
     cval : float, optional
         Value to use if `padtype='constant'`. Default is zero.
 

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2430,12 +2430,12 @@ def resample_poly(x, up, down, axis=0, window=('kaiser', 5.0), border='zero'):
 
     >>> import matplotlib.pyplot as plt
     >>> for i in [0,1]:
-    >>>     plt.figure()
-    >>>     plt.plot(xr, y4[:,i], 'g.', label='line')
-    >>>     plt.plot(xr, y3[:,i], 'y.', label='mean')
-    >>>     plt.plot(xr, y2[:,i], 'r.', label='zero')
-    >>>     plt.plot(x, Y[:,i], 'k-')
-    >>>     plt.legend()
+    ...     plt.figure()
+    ...     plt.plot(xr, y4[:,i], 'g.', label='line')
+    ...     plt.plot(xr, y3[:,i], 'y.', label='mean')
+    ...     plt.plot(xr, y2[:,i], 'r.', label='zero')
+    ...     plt.plot(x, Y[:,i], 'k-')
+    ...     plt.legend()
     >>> plt.show()
 
     """

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -866,7 +866,9 @@ class TestWiener(object):
         assert_array_almost_equal(signal.wiener(g), h, decimal=6)
         assert_array_almost_equal(signal.wiener(g, mysize=3), h, decimal=6)
 
+
 padtype_options = ["constant", "mean", "median", "minimum", "maximum", "line"]
+
 
 class TestResample(object):
     def test_basic(self):
@@ -1006,13 +1008,14 @@ class TestResample(object):
 
         # More tests of fft method (Master 0.18.1 fails these)
         if method == 'fft':
-            x1 = np.array([1.+0.j,0.+0.j])
-            y1_test = signal.resample(x1,4)
-            y1_true = np.array([1.+0.j,0.5+0.j,0.+0.j,0.5+0.j])  # upsampling a complex array
+            x1 = np.array([1.+0.j, 0.+0.j])
+            y1_test = signal.resample(x1, 4)
+            # upsampling a complex array
+            y1_true = np.array([1.+0.j, 0.5+0.j, 0.+0.j, 0.5+0.j])
             assert_allclose(y1_test, y1_true, atol=1e-12)
-            x2 = np.array([1.,0.5,0.,0.5])
-            y2_test = signal.resample(x2,2)  # downsampling a real array
-            y2_true = np.array([1.,0.])
+            x2 = np.array([1., 0.5, 0., 0.5])
+            y2_test = signal.resample(x2, 2)  # downsampling a real array
+            y2_true = np.array([1., 0.])
             assert_allclose(y2_test, y2_true, atol=1e-12)
 
     def test_poly_vs_filtfilt(self):
@@ -1050,7 +1053,8 @@ class TestResample(object):
                     x = np.random.random((nx,))
                     weights = np.random.random((nweights,))
                     y_g = correlate1d(x, weights[::-1], mode='constant')
-                    y_s = signal.resample_poly(x, up=1, down=down, window=weights)
+                    y_s = signal.resample_poly(
+                        x, up=1, down=down, window=weights)
                     assert_allclose(y_g[::down], y_s)
 
 

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -882,7 +882,9 @@ class TestResample(object):
         # Other degenerate conditions
         assert_raises(ValueError, signal.resample_poly, sig, 'yo', 1)
         assert_raises(ValueError, signal.resample_poly, sig, 1, 0)
-        assert_raises(ValueError, signal.resample_poly, sig, 2, 1, border='')
+        assert_raises(ValueError, signal.resample_poly, sig, 2, 1, padtype='')
+        assert_raises(ValueError, signal.resample_poly, sig, 2, 1,
+                      padtype='mean', cval=10)
 
         # test for issue #6505 - should not modify window.shape when axis ≠ 0
         sig2 = np.tile(np.arange(160), (2, 1))
@@ -920,22 +922,22 @@ class TestResample(object):
         impulse = np.zeros(3)
         window = np.random.RandomState(0).randn(2)
         window_orig = window.copy()
-        for border in ['zero', 'mean', 'median', 'maximum', 'minimum', 'line']:
-            signal.resample_poly(impulse, 5, 1, window=window, border=border)
+        for padtype in ['constant', 'mean', 'median', 'maximum', 'minimum', 'line']:
+            signal.resample_poly(impulse, 5, 1, window=window, padtype=padtype)
             assert_array_equal(window, window_orig)
 
     def test_output_float32(self):
         # Test that float32 inputs yield a float32 output
         x = np.arange(10, dtype=np.float32)
         h = np.array([1, 1, 1], dtype=np.float32)
-        for border in ['zero', 'mean', 'median', 'maximum', 'minimum', 'line']:
-            y = signal.resample_poly(x, 1, 2, window=h, border=border)
+        for padtype in ['constant', 'mean', 'median', 'maximum', 'minimum', 'line']:
+            y = signal.resample_poly(x, 1, 2, window=h, padtype=padtype)
             assert_(y.dtype == np.float32)
 
-    @pytest.mark.parametrize('method, ext, border', [
+    @pytest.mark.parametrize('method, ext, padtype', [
         ('fft', False, None),
-        ('polyphase', False, 'zero'),
-        ('polyphase', True, 'zero'),
+        ('polyphase', False, 'constant'),
+        ('polyphase', True, 'constant'),
         ('polyphase', False, 'mean'),
         ('polyphase', True, 'mean'),
         ('polyphase', False, 'median'),
@@ -943,7 +945,7 @@ class TestResample(object):
         ('polyphase', False, 'line'),
         ('polyphase', True, 'line'),
     ])
-    def test_resample_methods(self, method, ext, border):
+    def test_resample_methods(self, method, ext, padtype):
         # Test resampling of sinusoids and random noise (1-sec)
         rate = 100
         rates_to = [49, 50, 51, 99, 100, 101, 199, 200, 201]
@@ -969,9 +971,9 @@ class TestResample(object):
                     half_len = 10 * max_rate
                     window = signal.firwin(2 * half_len + 1, f_c,
                                            window=('kaiser', 5.0))
-                    polyargs = {'window': window, 'border': border}
+                    polyargs = {'window': window, 'padtype': padtype}
                 else:
-                    polyargs = {'border': border}
+                    polyargs = {'padtype': padtype}
 
                 y_resamps = signal.resample_poly(x, rate_to, rate, axis=-1,
                                                  **polyargs)
@@ -996,7 +998,7 @@ class TestResample(object):
                 y_resamp = signal.resample(x, rate_to)
             else:
                 y_resamp = signal.resample_poly(x, rate_to, rate,
-                                                border=border)
+                                                padtype=padtype)
             assert_array_equal(y_to.shape, y_resamp.shape)
             corr = np.corrcoef(y_to, y_resamp)[0, 1]
             assert_(corr > 0.99, msg=corr)

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -920,7 +920,7 @@ class TestResample(object):
         impulse = np.zeros(3)
         window = np.random.RandomState(0).randn(2)
         window_orig = window.copy()
-        for border in ['zero', 'mean', 'edge']:
+        for border in ['zero', 'mean', 'median', 'maximum', 'minimum', 'line']:
             signal.resample_poly(impulse, 5, 1, window=window, border=border)
             assert_array_equal(window, window_orig)
 
@@ -928,7 +928,7 @@ class TestResample(object):
         # Test that float32 inputs yield a float32 output
         x = np.arange(10, dtype=np.float32)
         h = np.array([1, 1, 1], dtype=np.float32)
-        for border in ['zero', 'mean', 'edge']:
+        for border in ['zero', 'mean', 'median', 'maximum', 'minimum', 'line']:
             y = signal.resample_poly(x, 1, 2, window=h, border=border)
             assert_(y.dtype == np.float32)
 
@@ -938,8 +938,10 @@ class TestResample(object):
         ('polyphase', True, 'zero'),
         ('polyphase', False, 'mean'),
         ('polyphase', True, 'mean'),
-        ('polyphase', False, 'edge'),
-        ('polyphase', True, 'edge'),
+        ('polyphase', False, 'median'),
+        ('polyphase', True, 'median'),
+        ('polyphase', False, 'line'),
+        ('polyphase', True, 'line'),
     ])
     def test_resample_methods(self, method, ext, border):
         # Test resampling of sinusoids and random noise (1-sec)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
None

#### What does this implement/fix?
It adds a border option to resample_poly. Before, resample_poly always assumed that data beyond the boundary was zero. I left that option as default, so the PR is completely backwards compatible. I added two more options: 'mean' assumes that the values before and after are the mean of the signal. 'edge' assumes that it follows the linear trend defined by first and last point.

Example of a x4 resampling where 'mean' and 'edge' outperform 'zero' (the old default). Black line is the original, and color points are the resampled arrays.

![Figure_2](https://user-images.githubusercontent.com/20156812/62011430-44c93000-b170-11e9-8c1b-99f7738929c9.png)


#### Additional information
I also modified some tests to cover all border options.