### PR TITLE
MAINT: _lib: avoid a compiler warning in _lib/uarray

### DIFF
--- a/scipy/_lib/_uarray/_uarray_dispatch.cxx
+++ b/scipy/_lib/_uarray/_uarray_dispatch.cxx
@@ -891,7 +891,7 @@ int Function::clear(Function * self)
 
 PyGetSetDef Function_getset[] =
 {
-  {"__dict__", PyObject_GenericGetDict, PyObject_GenericSetDict},
+  {(char*)"__dict__", PyObject_GenericGetDict, PyObject_GenericSetDict},
   {NULL} /* Sentinel */
 };
 


### PR DESCRIPTION
Fix a compiler warning :

```
compile options: '-I/home/br/virtualenvs/scipy_py35/lib/python3.5/site-packages/numpy/core/include -I/usr/include/python3.5m -I/home/br/virtualenvs/scipy_py35/include/python3.5m -c'
extra options: '--std=c++14 -fvisibility=hidden'
x86_64-linux-gnu-g++: scipy/_lib/_uarray/_uarray_dispatch.cxx
scipy/_lib/_uarray/_uarray_dispatch.cxx:896:1: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
 };
 ^
```