### PR TITLE
MAINT: interpolate: fix more compile warnings in interpolate/_ppoly.pyx

### DIFF
--- a/scipy/interpolate/_ppoly.pyx
+++ b/scipy/interpolate/_ppoly.pyx
@@ -567,7 +567,7 @@ def real_roots(double[:,:,::1] c, double[::1] x, double y, bint report_discont,
 @cython.wraparound(False)
 @cython.boundscheck(False)
 @cython.cdivision(True)
-cdef int find_interval_ascending(double *x,
+cdef int find_interval_ascending(const double *x,
                                  size_t nx,
                                  double xval,
                                  int prev_interval=0,
@@ -652,7 +652,7 @@ cdef int find_interval_ascending(double *x,
 @cython.wraparound(False)
 @cython.boundscheck(False)
 @cython.cdivision(True)
-cdef int find_interval_descending(double *x,
+cdef int find_interval_descending(const double *x,
                                  size_t nx,
                                  double xval,
                                  int prev_interval=0,


### PR DESCRIPTION
Add a const qualifier to fix a wall of compiler warnings

```
compile options: '-DNO_ATLAS_INFO=1 -DHAVE_CBLAS -I/usr/local/include -I/usr/include -I/home/br/virtualenvs/scipy_py35/include -I/home/br/virtualenvs/scipy_py35/lib/python3.5/site-packages/numpy/core/include -I/usr/include/python3.5m -I/home/br/virtualenvs/scipy_py35/include/python3.5m -c'
x86_64-linux-gnu-gcc: scipy/interpolate/_ppoly.c
scipy/interpolate/_ppoly.c: In function ‘__pyx_pf_5scipy_11interpolate_6_ppoly_14evaluate’:
scipy/interpolate/_ppoly.c:3473:81: warning: passing argument 1 of ‘__pyx_f_5scipy_11interpolate_6_ppoly_find_interval_ascending’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
       __pyx_t_10 = __pyx_f_5scipy_11interpolate_6_ppoly_find_interval_ascending((&(*((double const  *) ( /* dim=0 */ ((char *) (((double const  *) __pyx_v_x.data) + __pyx_t_9)) )))), (__pyx_v_x.shape[0]), __pyx_v_xval, &__pyx_t_11); 
                                                                                 ^
scipy/interpolate/_ppoly.c:2024:12: note: expected ‘double *’ but argument is of type ‘const double *’
 static int __pyx_f_5scipy_11interpolate_6_ppoly_find_interval_ascending(double *, size_t, double, struct __pyx_opt_args_5scipy_11interpolate_6_ppoly_find_interval_ascending *__pyx_optional_args); /*proto*/
            ^
scipy/interpolate/_ppoly.c:3506:82: warning: passing argument 1 of ‘__pyx_f_5scipy_11interpolate_6_ppoly_find_interval_descending’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
       __pyx_t_10 = __pyx_f_5scipy_11interpolate_6_ppoly_find_interval_descending((&(*((double const  *) ( /* dim=0 */ ((char *) (((double const  *) __pyx_v_x.data) + __pyx_t_12)) )))), (__pyx_v_x.shape[0]), __pyx_v_xval, &__pyx_t_13); 
                                                                                  ^
scipy/interpolate/_ppoly.c:2025:12: note: expected ‘double *’ but argument is of type ‘const double *’
 static int __pyx_f_5scipy_11interpolate_6_ppoly_find_interval_descending(double *, size_t, double, struct __pyx_opt_args_5scipy_11interpolate_6_ppoly_find_interval_descending *__pyx_optional_args); /*proto*/
            ^
scipy/interpolate/_ppoly.c: In function ‘__pyx_pf_5scipy_11interpolate_6_ppoly_16evaluate’:
scipy/interpolate/_ppoly.c:3970:81: warning: passing argument 1 of ‘__pyx_f_5scipy_11interpolate_6_ppoly_find_interval_ascending’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
       __pyx_t_10 = __pyx_f_5scipy_11interpolate_6_ppoly_find_interval_ascending((&(*((double const  *) ( /* dim=0 */ ((char *) (((double const  *) __pyx_v_x.data) + __pyx_t_9)) )))), (__pyx_v_x.shape[0]), __pyx_v_xval, &__pyx_t_11); 
                                                                                 ^
scipy/interpolate/_ppoly.c:2024:12: note: expected ‘double *’ but argument is of type ‘const double *’
 static int __pyx_f_5scipy_11interpolate_6_ppoly_find_interval_ascending(double *, size_t, double, struct __pyx_opt_args_5scipy_11interpolate_6_ppoly_find_interval_ascending *__pyx_optional_args); /*proto*/
            ^
scipy/interpolate/_ppoly.c:4003:82: warning: passing argument 1 of ‘__pyx_f_5scipy_11interpolate_6_ppoly_find_interval_descending’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
       __pyx_t_10 = __pyx_f_5scipy_11interpolate_6_ppoly_find_interval_descending((&(*((double const  *) ( /* dim=0 */ ((char *) (((double const  *) __pyx_v_x.data) + __pyx_t_12)) )))), (__pyx_v_x.shape[0]), __pyx_v_xval, &__pyx_t_13); 
                                                                                  ^
scipy/interpolate/_ppoly.c:2025:12: note: expected ‘double *’ but argument is of type ‘const double *’
 static int __pyx_f_5scipy_11interpolate_6_ppoly_find_interval_descending(double *, size_t, double, struct __pyx_opt_args_5scipy_11interpolate_6_ppoly_find_interval_descending *__pyx_optional_args); /*proto*/
            ^
scipy/interpolate/_ppoly.c: In function ‘__pyx_pf_5scipy_11interpolate_6_ppoly_32integrate’:
scipy/interpolate/_ppoly.c:8951:78: warning: passing argument 1 of ‘__pyx_f_5scipy_11interpolate_6_ppoly_find_interval_ascending’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
     __pyx_t_6 = __pyx_f_5scipy_11interpolate_6_ppoly_find_interval_ascending((&(*((double const  *) ( /* dim=0 */ ((char *) (((double const  *) __pyx_v_x.data) + __pyx_t_5)) )))), (__pyx_v_x.shape[0]), __pyx_v_a, &__pyx_t_7); 
                                                                              ^
scipy/interpolate/_ppoly.c:2024:12: note: expected ‘double *’ but argument is of type ‘const double *’
 static int __pyx_f_5scipy_11interpolate_6_ppoly_find_interval_ascending(double *, size_t, double, struct __pyx_opt_args_5scipy_11interpolate_6_ppoly_find_interval_ascending *__pyx_optional_args); /*proto*/
            ^
scipy/interpolate/_ppoly.c:8973:78: warning: passing argument 1 of ‘__pyx_f_5scipy_11interpolate_6_ppoly_find_interval_ascending’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
     __pyx_t_6 = __pyx_f_5scipy_11interpolate_6_ppoly_find_interval_ascending((&(*((double const  *) ( /* dim=0 */ ((char *) (((double const  *) __pyx_v_x.data) + __pyx_t_8)) )))), (__pyx_v_x.shape[0]), __pyx_v_b, &__pyx_t_7); 
                                                                              ^
scipy/interpolate/_ppoly.c:2024:12: note: expected ‘double *’ but argument is of type ‘const double *’
 static int __pyx_f_5scipy_11interpolate_6_ppoly_find_interval_ascending(double *, size_t, double, struct __pyx_opt_args_5scipy_11interpolate_6_ppoly_find_interval_ascending *__pyx_optional_args); /*proto*/
            ^
scipy/interpolate/_ppoly.c:9018:79: warning: passing argument 1 of ‘__pyx_f_5scipy_11interpolate_6_ppoly_find_interval_descending’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
     __pyx_t_6 = __pyx_f_5scipy_11interpolate_6_ppoly_find_interval_descending((&(*((double const  *) ( /* dim=0 */ ((char *) (((double const  *) __pyx_v_x.data) + __pyx_t_11)) )))), (__pyx_v_x.shape[0]), __pyx_v_a, &__pyx_t_12); 
                                                                               ^
scipy/interpolate/_ppoly.c:2025:12: note: expected ‘double *’ but argument is of type ‘const double *’
 static int __pyx_f_5scipy_11interpolate_6_ppoly_find_interval_descending(double *, size_t, double, struct __pyx_opt_args_5scipy_11interpolate_6_ppoly_find_interval_descending *__pyx_optional_args); /*proto*/
            ^
scipy/interpolate/_ppoly.c:9040:79: warning: passing argument 1 of ‘__pyx_f_5scipy_11interpolate_6_ppoly_find_interval_descending’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
     __pyx_t_6 = __pyx_f_5scipy_11interpolate_6_ppoly_find_interval_descending((&(*((double const  *) ( /* dim=0 */ ((char *) (((double const  *) __pyx_v_x.data) + __pyx_t_13)) )))), (__pyx_v_x.shape[0]), __pyx_v_b, &__pyx_t_12); 
                                                                               ^
scipy/interpolate/_ppoly.c:2025:12: note: expected ‘double *’ but argument is of type ‘const double *’
 static int __pyx_f_5scipy_11interpolate_6_ppoly_find_interval_descending(double *, size_t, double, struct __pyx_opt_args_5scipy_11interpolate_6_ppoly_find_interval_descending *__pyx_optional_args); /*proto*/
            ^
scipy/interpolate/_ppoly.c: In function ‘__pyx_pf_5scipy_11interpolate_6_ppoly_34integrate’:
scipy/interpolate/_ppoly.c:9591:78: warning: passing argument 1 of ‘__pyx_f_5scipy_11interpolate_6_ppoly_find_interval_ascending’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
     __pyx_t_6 = __pyx_f_5scipy_11interpolate_6_ppoly_find_interval_ascending((&(*((double const  *) ( /* dim=0 */ ((char *) (((double const  *) __pyx_v_x.data) + __pyx_t_5)) )))), (__pyx_v_x.shape[0]), __pyx_v_a, &__pyx_t_7); 
                                                                              ^
scipy/interpolate/_ppoly.c:2024:12: note: expected ‘double *’ but argument is of type ‘const double *’
 static int __pyx_f_5scipy_11interpolate_6_ppoly_find_interval_ascending(double *, size_t, double, struct __pyx_opt_args_5scipy_11interpolate_6_ppoly_find_interval_ascending *__pyx_optional_args); /*proto*/
            ^
scipy/interpolate/_ppoly.c:9613:78: warning: passing argument 1 of ‘__pyx_f_5scipy_11interpolate_6_ppoly_find_interval_ascending’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
     __pyx_t_6 = __pyx_f_5scipy_11interpolate_6_ppoly_find_interval_ascending((&(*((double const  *) ( /* dim=0 */ ((char *) (((double const  *) __pyx_v_x.data) + __pyx_t_8)) )))), (__pyx_v_x.shape[0]), __pyx_v_b, &__pyx_t_7); 
                                                                              ^
scipy/interpolate/_ppoly.c:2024:12: note: expected ‘double *’ but argument is of type ‘const double *’
 static int __pyx_f_5scipy_11interpolate_6_ppoly_find_interval_ascending(double *, size_t, double, struct __pyx_opt_args_5scipy_11interpolate_6_ppoly_find_interval_ascending *__pyx_optional_args); /*proto*/
            ^
scipy/interpolate/_ppoly.c:9658:79: warning: passing argument 1 of ‘__pyx_f_5scipy_11interpolate_6_ppoly_find_interval_descending’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
     __pyx_t_6 = __pyx_f_5scipy_11interpolate_6_ppoly_find_interval_descending((&(*((double const  *) ( /* dim=0 */ ((char *) (((double const  *) __pyx_v_x.data) + __pyx_t_11)) )))), (__pyx_v_x.shape[0]), __pyx_v_a, &__pyx_t_12); 
                                                                               ^
scipy/interpolate/_ppoly.c:2025:12: note: expected ‘double *’ but argument is of type ‘const double *’
 static int __pyx_f_5scipy_11interpolate_6_ppoly_find_interval_descending(double *, size_t, double, struct __pyx_opt_args_5scipy_11interpolate_6_ppoly_find_interval_descending *__pyx_optional_args); /*proto*/
            ^
scipy/interpolate/_ppoly.c:9680:79: warning: passing argument 1 of ‘__pyx_f_5scipy_11interpolate_6_ppoly_find_interval_descending’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
     __pyx_t_6 = __pyx_f_5scipy_11interpolate_6_ppoly_find_interval_descending((&(*((double const  *) ( /* dim=0 */ ((char *) (((double const  *) __pyx_v_x.data) + __pyx_t_13)) )))), (__pyx_v_x.shape[0]), __pyx_v_b, &__pyx_t_12); 
                                                                               ^
scipy/interpolate/_ppoly.c:2025:12: note: expected ‘double *’ but argument is of type ‘const double *’
 static int __pyx_f_5scipy_11interpolate_6_ppoly_find_interval_descending(double *, size_t, double, struct __pyx_opt_args_5scipy_11interpolate_6_ppoly_find_interval_descending *__pyx_optional_args); /*proto*/

```