### PR TITLE
Feature request.  Add furthest site Voronoi diagrams to scipy.spatial.plotutils.

### DIFF
--- a/scipy/spatial/_plotutils.py
+++ b/scipy/spatial/_plotutils.py
@@ -242,6 +242,8 @@ def voronoi_plot_2d(vor, ax=None, **kw):
 
             midpoint = vor.points[pointidx].mean(axis=0)
             direction = np.sign(np.dot(midpoint - center, n)) * n
+            if (vor.furthest_site):
+                direction = -direction
             far_point = vor.vertices[i] + direction * ptp_bound.max()
 
             infinite_segments.append([vor.vertices[i], far_point])


### PR DESCRIPTION
This two line change adds furthest site diagrams to voronoi_plot_2d.

The following is a sample.  The code can be found at https://github.com/rtshort/voronoi.

![exampl1](https://user-images.githubusercontent.com/2798381/62048234-36573480-b1c1-11e9-8069-4a13dd5b732a.png)
