### PR TITLE
[BUG] Fix bug in trimr when inclusive=False

### DIFF
--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -1361,13 +1361,13 @@ def trimr(a, limits=None, inclusive=(True, True), axis=None):
             if low_inclusive:
                 lowidx = int(low_limit*n)
             else:
-                lowidx = np.round(low_limit*n)
+                lowidx = int(np.round(low_limit*n))
             a[idx[:lowidx]] = masked
         if up_limit is not None:
             if up_inclusive:
                 upidx = n - int(n*up_limit)
             else:
-                upidx = n - np.round(n*up_limit)
+                upidx = n - int(np.round(n*up_limit))
             a[idx[upidx:]] = masked
         return a
 

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -413,8 +413,11 @@ class TestTrimming(object):
     def test_trimr(self):
         x = ma.arange(10)
         result = mstats.trimr(x, limits=(0.15, 0.14), inclusive=(False, False))
-        expected = [None, None, 2, 3, 4, 5, 6, 7, 8, None]
+        expected = ma.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+                            mask=[1, 1, 0, 0, 0, 0, 0, 0, 0, 1])
+        pytest.set_trace()
         assert_equal(result, expected)
+        assert_equal(result.mask, expected.mask)
 
     def test_trimmedmean(self):
         data = ma.array([77, 87, 88,114,151,210,219,246,253,262,

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -410,6 +410,12 @@ class TestTrimming(object):
         assert_equal(mstats.trimboth(x).count(), 60)
         assert_equal(mstats.trimtail(x).count(), 80)
 
+    def test_trimr(self):
+        x = ma.arange(10)
+        result = mstats.trimr(x, limits=(0.15, 0.14), inclusive=(False, False))
+        expected = [None, None, 2, 3, 4, 5, 6, 7, 8, None]
+        assert_equal(result, expected)
+
     def test_trimmedmean(self):
         data = ma.array([77, 87, 88,114,151,210,219,246,253,262,
                          296,299,306,376,428,515,666,1310,2611])

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -415,7 +415,6 @@ class TestTrimming(object):
         result = mstats.trimr(x, limits=(0.15, 0.14), inclusive=(False, False))
         expected = ma.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
                             mask=[1, 1, 0, 0, 0, 0, 0, 0, 0, 1])
-        pytest.set_trace()
         assert_equal(result, expected)
         assert_equal(result.mask, expected.mask)
 


### PR DESCRIPTION
when `inclusive=False`, `mstats.trimr` runs into `TypeError` i.e., `TypeError: slice indices must be integers or None or have an __index__ method`.

```
import numpy.ma as ma
import scipy.stats.mstats as mstats

a = ma.arange(10)
mstats.trimr(a, limits=(0.15, 0.14), inclusive=(False, False)
```