### PR TITLE
add scipy.signal.upfirdn signal extension modes

### DIFF
--- a/scipy/signal/_upfirdn.py
+++ b/scipy/signal/_upfirdn.py
@@ -80,7 +80,7 @@ class _UpFIRDn(object):
         self._h_trans_flip = _pad_h(h, self._up)
         self._h_trans_flip = np.ascontiguousarray(self._h_trans_flip)
 
-    def apply_filter(self, x, axis=-1, mode='zero', cval=0):
+    def apply_filter(self, x, axis=-1, mode='constant', cval=0):
         """Apply the prepared filter to the specified axis of a nD signal x"""
         output_len = _output_len(len(self._h_trans_flip), x.shape[axis],
                                  self._up, self._down)
@@ -95,7 +95,7 @@ class _UpFIRDn(object):
         return out
 
 
-def upfirdn(h, x, up=1, down=1, axis=-1, mode="zero", cval=0):
+def upfirdn(h, x, up=1, down=1, axis=-1, mode='constant', cval=0):
     """Upsample, FIR filter, and downsample
 
     Parameters
@@ -113,7 +113,12 @@ def upfirdn(h, x, up=1, down=1, axis=-1, mode="zero", cval=0):
         linear filter. The filter is applied to each subarray along
         this axis. Default is -1.
     mode : str, optional
-        The signal extension mode to use. TODO: details
+        The signal extension mode to use. The set
+        ``{'constant', 'symmetric', 'reflect', 'edge', 'wrap'}`` correspond to
+        modes provided by ``numpy.pad``. ``'smooth'`` implements a smooth
+        extension by extending based on the slope of the last 2 points at each
+        end of the array. ``'antireflect'`` and ``'antisymmetric'`` are
+        anti-symmetric versions of ``'reflect'`` and ``'symmetric'``.
     cval : float, optional
         The constant value to use when ``mode == 'constant'`.
 

--- a/scipy/signal/_upfirdn.py
+++ b/scipy/signal/_upfirdn.py
@@ -120,7 +120,7 @@ def upfirdn(h, x, up=1, down=1, axis=-1, mode='constant', cval=0):
     mode : str, optional
         The signal extension mode to use. The set
         ``{"constant", "symmetric", "reflect", "edge", "wrap"}`` correspond to
-        modes provided by ``numpy.pad``. ``"smooth"`` implements a smooth
+        modes provided by `numpy.pad`. ``"smooth"`` implements a smooth
         extension by extending based on the slope of the last 2 points at each
         end of the array. ``"antireflect"`` and ``"antisymmetric"`` are
         anti-symmetric versions of ``"reflect"`` and ``"symmetric"``. The mode

--- a/scipy/signal/_upfirdn.py
+++ b/scipy/signal/_upfirdn.py
@@ -120,12 +120,12 @@ def upfirdn(h, x, up=1, down=1, axis=-1, mode='constant', cval=0):
     mode : str, optional
         The signal extension mode to use. The set
         ``{'constant', 'symmetric', 'reflect', 'edge', 'wrap'}`` correspond to
-        modes provided by ``numpy.pad``. ``'smooth'`` implements a smooth
+        modes provided by ``numpy.pad``. ``"smooth"`` implements a smooth
         extension by extending based on the slope of the last 2 points at each
-        end of the array. ``'antireflect'`` and ``'antisymmetric'`` are
-        anti-symmetric versions of ``'reflect'`` and ``'symmetric'``.
+        end of the array. ``"antireflect"`` and ``"antisymmetric"`` are
+        anti-symmetric versions of ``"reflect"`` and ``"symmetric"``.
     cval : float, optional
-        The constant value to use when ``mode == 'constant'`.
+        The constant value to use when ``mode == "constant"``.
 
     Returns
     -------

--- a/scipy/signal/_upfirdn.py
+++ b/scipy/signal/_upfirdn.py
@@ -37,7 +37,6 @@ from ._upfirdn_apply import _output_len, _apply, mode_enum
 
 __all__ = ['upfirdn', '_output_len']
 
-
 _upfirdn_modes = [
     'constant', 'wrap', 'edge', 'smooth', 'symmetric', 'reflect',
     'antisymmetric', 'antireflect'

--- a/scipy/signal/_upfirdn.py
+++ b/scipy/signal/_upfirdn.py
@@ -39,7 +39,7 @@ __all__ = ['upfirdn', '_output_len']
 
 _upfirdn_modes = [
     'constant', 'wrap', 'edge', 'smooth', 'symmetric', 'reflect',
-    'antisymmetric', 'antireflect'
+    'antisymmetric', 'antireflect', 'line',
 ]
 
 

--- a/scipy/signal/_upfirdn.py
+++ b/scipy/signal/_upfirdn.py
@@ -119,13 +119,19 @@ def upfirdn(h, x, up=1, down=1, axis=-1, mode='constant', cval=0):
         this axis. Default is -1.
     mode : str, optional
         The signal extension mode to use. The set
-        ``{'constant', 'symmetric', 'reflect', 'edge', 'wrap'}`` correspond to
+        ``{"constant", "symmetric", "reflect", "edge", "wrap"}`` correspond to
         modes provided by ``numpy.pad``. ``"smooth"`` implements a smooth
         extension by extending based on the slope of the last 2 points at each
         end of the array. ``"antireflect"`` and ``"antisymmetric"`` are
-        anti-symmetric versions of ``"reflect"`` and ``"symmetric"``.
+        anti-symmetric versions of ``"reflect"`` and ``"symmetric"``. The mode
+        `"line"` extends the signal based on a linear trend defined by the
+        first and last points along the ``axis``.
+
+        .. versionadded:: 1.4.0
     cval : float, optional
         The constant value to use when ``mode == "constant"``.
+
+        .. versionadded:: 1.4.0
 
     Returns
     -------

--- a/scipy/signal/_upfirdn.py
+++ b/scipy/signal/_upfirdn.py
@@ -33,7 +33,7 @@
 
 import numpy as np
 
-from ._upfirdn_apply import _output_len, _apply
+from ._upfirdn_apply import _output_len, _apply, mode_enum
 
 __all__ = ['upfirdn', '_output_len']
 
@@ -58,6 +58,12 @@ def _pad_h(h, up):
     return h_full
 
 
+def _check_mode(mode):
+    mode = mode.lower()
+    enum = mode_enum(mode)
+    return enum
+
+
 class _UpFIRDn(object):
     def __init__(self, h, x_dtype, up, down):
         """Helper for resampling"""
@@ -74,7 +80,7 @@ class _UpFIRDn(object):
         self._h_trans_flip = _pad_h(h, self._up)
         self._h_trans_flip = np.ascontiguousarray(self._h_trans_flip)
 
-    def apply_filter(self, x, axis=-1):
+    def apply_filter(self, x, axis=-1, mode='zero', cval=0):
         """Apply the prepared filter to the specified axis of a nD signal x"""
         output_len = _output_len(len(self._h_trans_flip), x.shape[axis],
                                  self._up, self._down)
@@ -82,13 +88,14 @@ class _UpFIRDn(object):
         output_shape[axis] = output_len
         out = np.zeros(output_shape, dtype=self._output_type, order='C')
         axis = axis % x.ndim
+        mode = _check_mode(mode)
         _apply(np.asarray(x, self._output_type),
                self._h_trans_flip, out,
-               self._up, self._down, axis)
+               self._up, self._down, axis, mode, cval)
         return out
 
 
-def upfirdn(h, x, up=1, down=1, axis=-1):
+def upfirdn(h, x, up=1, down=1, axis=-1, mode="zero", cval=0):
     """Upsample, FIR filter, and downsample
 
     Parameters
@@ -105,6 +112,10 @@ def upfirdn(h, x, up=1, down=1, axis=-1):
         The axis of the input data array along which to apply the
         linear filter. The filter is applied to each subarray along
         this axis. Default is -1.
+    mode : str, optional
+        The signal extension mode to use. TODO: details
+    cval : float, optional
+        The constant value to use when ``mode == 'constant'`.
 
     Returns
     -------
@@ -180,4 +191,4 @@ def upfirdn(h, x, up=1, down=1, axis=-1):
     x = np.asarray(x)
     ufd = _UpFIRDn(h, x.dtype, up, down)
     # This is equivalent to (but faster than) using np.apply_along_axis
-    return ufd.apply_filter(x, axis)
+    return ufd.apply_filter(x, axis, mode, cval)

--- a/scipy/signal/_upfirdn.py
+++ b/scipy/signal/_upfirdn.py
@@ -38,6 +38,12 @@ from ._upfirdn_apply import _output_len, _apply, mode_enum
 __all__ = ['upfirdn', '_output_len']
 
 
+_upfirdn_modes = [
+    'constant', 'wrap', 'edge', 'smooth', 'symmetric', 'reflect',
+    'antisymmetric', 'antireflect'
+]
+
+
 def _pad_h(h, up):
     """Store coefficients in a transposed, flipped arrangement.
 

--- a/scipy/signal/_upfirdn_apply.pyx
+++ b/scipy/signal/_upfirdn_apply.pyx
@@ -238,6 +238,8 @@ cdef DTYPE_t _extend_right(DTYPE_t *x, np.intp_t idx, np.intp_t len_x,
         return -1.
 
 
+@cython.boundscheck(False)
+@cython.wraparound(False)
 cpdef _pad_test(np.ndarray[DTYPE_t] data, np.intp_t npre=0, np.intp_t npost=0,
                 object mode=0, DTYPE_t cval=0):
     """1D test function for signal extension modes.

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2343,12 +2343,14 @@ def resample_poly(x, up, down, axis=0, window=('kaiser', 5.0),
         Desired window to use to design the low-pass filter, or the FIR filter
         coefficients to employ. See below for details.
     padtype : string, optional
-        `constant`, `mean` or `line`. Changes assumptions on values beyond the
-        boundary. If `constant`, assumed to be `cval` (default zero). If `line`
-        assumed to continue a linear trend defined by the first and last
-        points. `mean`, `median`, `maximum` and `minimum` work as in `np.pad` and
-        assume that the values beyond the boundary are the mean, median,
-        maximum or minimum respectively of the array along the axis.
+        `constant`, `line`, `mean`, `median`, `maximum`, `minimum` or any of
+        the other signal extension modes supported by `scipy.signal.upfirdn`.
+        Changes assumptions on values beyond the boundary. If `constant`,
+        assumed to be `cval` (default zero). If `line` assumed to continue a
+        linear trend defined by the first and last points. `mean`, `median`,
+        `maximum` and `minimum` work as in `np.pad` and assume that the values
+        beyond the boundary are the mean, median, maximum or minimum
+        respectively of the array along the axis.
 
         .. versionadded:: 1.4.0
     cval : float, optional

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -95,15 +95,6 @@ def _inputs_swap_needed(mode, shape1, shape2):
     return False
 
 
-def _reshape_nd(x1d, ndim, axis):
-    """
-    Reshape x1d to size 1 along all axes in ``range(ndim)`` except for ``axis``.
-    """
-    shape = [1] * ndim
-    shape[axis] = x1d.size
-    return x1d.reshape(shape)
-
-
 def correlate(in1, in2, mode='full', method='auto'):
     r"""
     Cross-correlate two N-dimensional arrays.
@@ -2507,10 +2498,7 @@ def resample_poly(x, up, down, axis=0, window=('kaiser', 5.0),
              'minimum': np.amin, 'maximum': np.amax}
     upfirdn_kwargs = {'mode': 'constant', 'cval': 0}
     if padtype in funcs:
-        background_line = [funcs[padtype](x, axis=axis), 0]
-    elif padtype == 'line':
-        background_line = [x.take(0, axis),
-                           (x.take(-1, axis) - x.take(0, axis))*n_in/(n_in-1)]
+        background_values = funcs[padtype](x, axis=axis, keepdims=True)
     elif padtype in _upfirdn_modes:
         upfirdn_kwargs = {'mode': padtype}
         if padtype == 'constant':
@@ -2519,15 +2507,11 @@ def resample_poly(x, up, down, axis=0, window=('kaiser', 5.0),
             upfirdn_kwargs['cval'] = cval
     else:
         raise ValueError(
-            'padtype must be one of: line, maximum, mean, median, minimum, ' +
+            'padtype must be one of: maximum, mean, median, minimum, ' +
             ', '.join(_upfirdn_modes))
 
-    if padtype == 'line' or padtype in funcs:
-        rel_len = np.linspace(0.0, 1.0, n_in, endpoint=False)
-        rel_len_nd = _reshape_nd(rel_len, x.ndim, axis)
-        background_in = np.expand_dims(background_line[0], axis) +\
-            np.expand_dims(background_line[1], axis) * rel_len_nd
-        x = x - background_in.astype(x.dtype)
+    if padtype in funcs:
+        x = x - background_values
 
     # filter then remove excess
     y = upfirdn(h, x, up, down, axis=axis, **upfirdn_kwargs)
@@ -2536,12 +2520,8 @@ def resample_poly(x, up, down, axis=0, window=('kaiser', 5.0),
     y_keep = y[tuple(keep)]
 
     # Add background back
-    if padtype == 'line' or padtype in funcs:
-        rel_len = np.linspace(0.0, 1.0, n_out, endpoint=False)
-        rel_len_nd = _reshape_nd(rel_len, x.ndim, axis)
-        background_out = np.expand_dims(background_line[0], axis) +\
-            np.expand_dims(background_line[1], axis) * rel_len_nd
-        y_keep += background_out.astype(x.dtype)
+    if padtype in funcs:
+        y_keep += background_values
 
     return y_keep
 

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -27,6 +27,7 @@ from scipy.signal import (
     sosfilt_zi, tf2zpk, BadCoefficients, detrend)
 from scipy.signal.windows import hann
 from scipy.signal.signaltools import _filtfilt_gust
+from scipy.signal._upfirdn import _upfirdn_modes
 
 
 if sys.version_info.major >= 3 and sys.version_info.minor >= 5:
@@ -876,7 +877,8 @@ class TestWiener(object):
         assert_array_almost_equal(signal.wiener(g, mysize=3), h, decimal=6)
 
 
-padtype_options = ["constant", "mean", "median", "minimum", "maximum", "line"]
+padtype_options = ["mean", "median", "minimum", "maximum", "line"]
+padtype_options += _upfirdn_modes
 
 
 class TestResample(object):

--- a/scipy/signal/tests/test_upfirdn.py
+++ b/scipy/signal/tests/test_upfirdn.py
@@ -32,14 +32,17 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
+from copy import copy
 import numpy as np
 from itertools import product
 
 from numpy.testing import assert_equal, assert_allclose
 from pytest import raises as assert_raises
+import pytest
 
 from scipy.signal import upfirdn, firwin, lfilter
-from scipy.signal._upfirdn import _output_len
+from scipy.signal._upfirdn import _output_len, _upfirdn_modes
+from scipy.signal._upfirdn_apply import _pad_test
 
 
 def upfirdn_naive(x, h, up=1, down=1):
@@ -173,3 +176,51 @@ class TestUpfirdn(object):
             tests.append(UpFIRDnCase(p, q, h, x_dtype))
 
         return tests
+
+    @pytest.mark.parametrize('mode', _upfirdn_modes)
+    def test_extensions(self, mode):
+        """Test vs. manually computed results for modes not in numpy's pad."""
+        x = np.array([1, 2, 3, 1], dtype=float)
+        npre, npost = 6, 6
+        y = _pad_test(x, npre=npre, npost=npost, mode=mode)
+        if mode == 'antisymmetric':
+            y_expected = np.asarray(
+                [3, 1, -1, -3, -2, -1, 1, 2, 3, 1, -1, -3, -2, -1, 1, 2])
+        elif mode == 'antireflect':
+            y_expected = np.asarray(
+                [1, 2, 3, 1, -1, 0, 1, 2, 3, 1, -1, 0, 1, 2, 3, 1])
+        elif mode == 'smooth':
+            y_expected = np.asarray(
+                [-5, -4, -3, -2, -1, 0, 1, 2, 3, 1, -1, -3, -5, -7, -9, -11])
+        else:
+            y_expected = np.pad(x, (npre, npost), mode=mode)
+        assert_allclose(y, y_expected)
+
+    @pytest.mark.parametrize(
+        'size, h_len, mode, dtype',
+        product(
+            [8],
+            [4, 5, 26],  # include cases with h_len > 2*size
+            _upfirdn_modes,
+            [np.float32, np.float64, np.complex64, np.complex128],
+        )
+    )
+    def test_modes(self, size, h_len, mode, dtype):
+        random_state = np.random.RandomState(5)
+        x = random_state.randn(size).astype(dtype)
+        if dtype in (np.complex64, np.complex128):
+            x += 1j * random_state.randn(size)
+        h = np.arange(1, 1 + h_len, dtype=x.real.dtype)
+
+        y = upfirdn(h, x, up=1, down=1, mode=mode)
+        # expected result: pad the input, filter with zero padding, then crop
+        npad = h_len - 1
+        if mode in ['antisymmetric', 'antireflect', 'smooth']:
+            # use _pad_test test function for modes not supported by np.pad.
+            xpad = _pad_test(x, npre=npad, npost=npad, mode=mode)
+        else:
+            xpad = np.pad(x, npad, mode=mode)
+        ypad = upfirdn(h, xpad, up=1, down=1, mode='constant')
+        y_expected = ypad[npad:-npad]
+
+        assert_allclose(y, y_expected)

--- a/scipy/signal/tests/test_upfirdn.py
+++ b/scipy/signal/tests/test_upfirdn.py
@@ -223,4 +223,4 @@ class TestUpfirdn(object):
         ypad = upfirdn(h, xpad, up=1, down=1, mode='constant')
         y_expected = ypad[npad:-npad]
 
-        assert_allclose(y, y_expected)
+        assert_allclose(y, y_expected, atol=1e-6, rtol=1e-6)

--- a/scipy/signal/tests/test_upfirdn.py
+++ b/scipy/signal/tests/test_upfirdn.py
@@ -192,6 +192,11 @@ class TestUpfirdn(object):
         elif mode == 'smooth':
             y_expected = np.asarray(
                 [-5, -4, -3, -2, -1, 0, 1, 2, 3, 1, -1, -3, -5, -7, -9, -11])
+        elif mode == "line":
+            lin_slope = (x[-1] - x[0]) / (len(x) - 1)
+            left = x[0] + np.arange(-npre, 0, 1) * lin_slope
+            right = x[-1] + np.arange(1, npost + 1) * lin_slope
+            y_expected = np.concatenate((left, x, right))
         else:
             y_expected = np.pad(x, (npre, npost), mode=mode)
         assert_allclose(y, y_expected)
@@ -215,7 +220,7 @@ class TestUpfirdn(object):
         y = upfirdn(h, x, up=1, down=1, mode=mode)
         # expected result: pad the input, filter with zero padding, then crop
         npad = h_len - 1
-        if mode in ['antisymmetric', 'antireflect', 'smooth']:
+        if mode in ['antisymmetric', 'antireflect', 'smooth', 'line']:
             # use _pad_test test function for modes not supported by np.pad.
             xpad = _pad_test(x, npre=npad, npost=npad, mode=mode)
         else:


### PR DESCRIPTION



<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

This PR complements the signal extension modes proposed in #10543.

#### What does this implement/fix?
<!--Please explain your changes.-->

This is an implementation of various signal extension modes such as `symmetric`, `periodic`, etc. for `scipy.signal.upfirdn`. Currently (prior to this PR) extension by zero padding is assumed. I have used names matching `numpy.pad` where possible. 

#### Additional information
<!--Any additional information you think is important.-->

Three additional modes (`smooth`, `antireflect` and `antisymmetric`) were included because they [are in PyWavelets](https://pywavelets.readthedocs.io/en/latest/ref/signal-extension-modes.html#signal-extension-modes) (from which this code is adapted). They can be removed if it is desired to just stick with methods available in `numpy.pad`.

I had already implemented this for another project. If this feature seems desirable for SciPy itself, I can proceed to polish it up and add tests here.

TODO
- [x] tests
