### PR TITLE
BUG: optimize: increase tol to fix #10349

### DIFF
--- a/scipy/optimize/_remove_redundancy.py
+++ b/scipy/optimize/_remove_redundancy.py
@@ -432,7 +432,7 @@ def _remove_redundancy(A, b):
                        "off redundancy removal, or try turning off presolve "
                        "altogether.")
             break
-        if np.any(np.abs(v.dot(b)) > tol * 10):  # factor of 10 to fix 10038
+        if np.any(np.abs(v.dot(b)) > tol * 100):  # factor of 100 to fix 10038 and 10349
             status = 2
             message = ("There is a linear combination of rows of A_eq that "
                        "results in zero, suggesting a redundant constraint. "

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -1312,6 +1312,24 @@ class LinprogCommonTests(object):
                       method=self.method, options=self.options)
         _assert_success(res, desired_x=[10, -3], desired_fun=-22)
 
+    def test_bug_10349(self):
+        """
+        Test for tolerance issue on LPs with equality constraints
+        https://github.com/scipy/scipy/issues/10349
+        """
+        A_eq = np.array([[1, 1, 0, 0, 0, 0],
+                         [0, 0, 1, 1, 0, 0],
+                         [0, 0, 0, 0, 1, 1],
+                         [1, 0, 1, 0, 0, 0],
+                         [0, 0, 0, 1, 1, 0],
+                         [0, 1, 0, 0, 0, 1]])
+        b_eq = np.array([221, 210, 10, 141, 198, 102])
+        c = np.concatenate((0, 1, np.zeros(4)), axis=None)
+        with suppress_warnings() as sup:
+            sup.filter(OptimizeWarning, "A_eq does not appear...")
+            res = linprog(c, A_eq=A_eq, b_eq=b_eq)
+        _assert_success(res, desired_x=[129, 92, 12, 198, 0, 10], desired_fun=92)
+
 #########################
 # Method-specific Tests #
 #########################

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -1314,7 +1314,7 @@ class LinprogCommonTests(object):
 
     def test_bug_10349(self):
         """
-        Test for tolerance issue on LPs with equality constraints
+        Test for redundancy removal tolerance issue
         https://github.com/scipy/scipy/issues/10349
         """
         A_eq = np.array([[1, 1, 0, 0, 0, 0],

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -1327,7 +1327,8 @@ class LinprogCommonTests(object):
         c = np.concatenate((0, 1, np.zeros(4)), axis=None)
         with suppress_warnings() as sup:
             sup.filter(OptimizeWarning, "A_eq does not appear...")
-            res = linprog(c, A_eq=A_eq, b_eq=b_eq)
+            res = linprog(c, A_ub, b_ub, A_eq, b_eq, bounds,
+                          method=self.method, options=self.options)
         _assert_success(res, desired_x=[129, 92, 12, 198, 0, 10], desired_fun=92)
 
 #########################


### PR DESCRIPTION
This adds a test for the problem in #10349, which is expected to break at least 1 CI test.
Another commit will follow to increase the tolerance by an additional factor of 10, similar to #10059.