### PR TITLE
improve least_squares error msg for mismatched shape

### DIFF
--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -807,7 +807,8 @@ def least_squares(
     f0 = fun_wrapped(x0)
 
     if f0.ndim != 1:
-        raise ValueError("`fun` must return at most 1-d array_like.")
+        raise ValueError("`fun` must return at most 1-d array_like. "
+                         "f0.shape: {0}".format(f0.shape))
 
     if not np.all(np.isfinite(f0)):
         raise ValueError("Residuals are not finite in the initial point.")


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->


#### Additional information
<!--Any additional information you think is important.-->
The message `ValueError: fun must return at most 1-d array_like.`
would be more helpful, when it tells what the shape of the return value was.


Btw.: https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message does not work