### PR TITLE
 ENH: linalg: memoize get_lapack/blas_funcs to speed it up 

### DIFF
--- a/benchmarks/benchmarks/linalg.py
+++ b/benchmarks/benchmarks/linalg.py
@@ -231,3 +231,17 @@ class SpecialMatrices(Benchmark):
 
     def time_tri(self, size):
         sl.tri(size)
+
+
+class GetFuncs(Benchmark):
+    def setup(self):
+        self.x = np.eye(1)
+
+    def time_get_blas_funcs(self):
+        sl.blas.get_blas_funcs('gemm', dtype=float)
+
+    def time_get_blas_funcs_2(self):
+        sl.blas.get_blas_funcs(('gemm', 'axpy'), (self.x, self.x))
+
+    def time_small_cholesky(self):
+        sl.cholesky(self.x)

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -632,7 +632,7 @@ All functions
 
 from __future__ import division, print_function, absolute_import
 import numpy as _np
-from .blas import _get_funcs
+from .blas import _get_funcs, _memoize_get_funcs
 from scipy.linalg import _flapack
 try:
     from scipy.linalg import _clapack
@@ -679,6 +679,7 @@ _lapack_alias = {
 }
 
 
+@_memoize_get_funcs
 def get_lapack_funcs(names, arrays=(), dtype=None):
     """Return available LAPACK function objects from names.
 


### PR DESCRIPTION
The `scipy.linalg.get_lapack/blas_funcs` are relatively slow and can take time comparable to the Fortran codes for small matrices.

Speed it up (~10x) by memoization: the fortran routine for a given dtype never changes.

This is prompted by gh-10512 --- after this PR, `get_lapack_funcs` runtime goes to ~0.5µs for cache hit, whereas `cholesky(x)` for a 1x1 matrix takes 16µs, so getting the func becomes insignificant.

Benchmark:
```
       before           after         ratio
     [2331b37b]       [fdf08144]
     <master>         <memoize-get-funcs>
-     22.9±0.03μs       15.8±0.1μs     0.69  linalg.GetFuncs.time_small_cholesky
-     8.24±0.05μs      1.20±0.01μs     0.15  linalg.GetFuncs.time_get_blas_funcs_2
-     5.73±0.09μs         554±20ns     0.10  linalg.GetFuncs.time_get_blas_funcs
```