### PR TITLE
ENH: Update fft next_fast_len

### DIFF
--- a/scipy/fft/_helper.py
+++ b/scipy/fft/_helper.py
@@ -4,7 +4,7 @@ from bisect import bisect_left
 import numpy as np
 
 
-def next_fast_len(target, type='C2C'):
+def next_fast_len(target, kind='C2C'):
     """Find the next fast size of input data to ``fft``, for zero-padding, etc.
 
     SciPy's FFT algorithms gain their speed by a recursive divide and conquer
@@ -19,8 +19,8 @@ def next_fast_len(target, type='C2C'):
     ----------
     target : int
         Length to start searching from.  Must be a positive integer.
-    type : {'C2C', 'C2R', 'R2C'}, optional
-        Transform type
+    kind : {'C2C', 'C2R', 'R2C'}, optional
+        Kind of transform to be performed
         - 'C2C': Complex to complex (e.g. `fft`, `ifft`)
         - 'C2R': Complex to real (e.g. `irfft`, `hfft`)
         - 'R2C': Real to complex (e.g. `rfft`, `ihfft`)
@@ -35,7 +35,7 @@ def next_fast_len(target, type='C2C'):
     The result of this function may change in future as performance
     considerations change, for example if new prime factors are added.
 
-    Calling `fft` or `ifft` with real input data performs an 'R2C' type
+    Calling `fft` or `ifft` with real input data performs an ``'R2C'``
     transform internally.
 
     Examples
@@ -60,7 +60,7 @@ def next_fast_len(target, type='C2C'):
     >>> b = fft.fft(a, 131072)
 
     """
-    return _helper.next_fast_len(target, type)
+    return _helper.next_fast_len(target, kind)
 
 
 def _init_nd_shape_and_axes(x, shape, axes):

--- a/scipy/fft/_helper.py
+++ b/scipy/fft/_helper.py
@@ -1,69 +1,7 @@
 from . import _pocketfft
 from ._pocketfft import helper as _helper
 from bisect import bisect_left
-import sys
-import operator
 import numpy as np
-
-
-def _next_regular_len(target):
-    """Returns smallest 5-smooth length >= target"""
-    hams = (8, 9, 10, 12, 15, 16, 18, 20, 24, 25, 27, 30, 32, 36, 40, 45, 48,
-            50, 54, 60, 64, 72, 75, 80, 81, 90, 96, 100, 108, 120, 125, 128,
-            135, 144, 150, 160, 162, 180, 192, 200, 216, 225, 240, 243, 250,
-            256, 270, 288, 300, 320, 324, 360, 375, 384, 400, 405, 432, 450,
-            480, 486, 500, 512, 540, 576, 600, 625, 640, 648, 675, 720, 729,
-            750, 768, 800, 810, 864, 900, 960, 972, 1000, 1024, 1080, 1125,
-            1152, 1200, 1215, 1250, 1280, 1296, 1350, 1440, 1458, 1500, 1536,
-            1600, 1620, 1728, 1800, 1875, 1920, 1944, 2000, 2025, 2048, 2160,
-            2187, 2250, 2304, 2400, 2430, 2500, 2560, 2592, 2700, 2880, 2916,
-            3000, 3072, 3125, 3200, 3240, 3375, 3456, 3600, 3645, 3750, 3840,
-            3888, 4000, 4050, 4096, 4320, 4374, 4500, 4608, 4800, 4860, 5000,
-            5120, 5184, 5400, 5625, 5760, 5832, 6000, 6075, 6144, 6250, 6400,
-            6480, 6561, 6750, 6912, 7200, 7290, 7500, 7680, 7776, 8000, 8100,
-            8192, 8640, 8748, 9000, 9216, 9375, 9600, 9720, 10000)
-
-    target = int(target)
-
-    if target <= 6:
-        return target
-
-    # Quickly check if it's already a power of 2
-    if not (target & (target-1)):
-        return target
-
-    # Get result quickly for small sizes, since FFT itself is similarly fast.
-    if target <= hams[-1]:
-        return hams[bisect_left(hams, target)]
-
-    match = float('inf')  # Anything found will be smaller
-    p5 = 1
-    while p5 < target:
-        p35 = p5
-        while p35 < target:
-            # Ceiling integer division, avoiding conversion to float
-            # (quotient = ceil(target / p35))
-            quotient = -(-target // p35)
-
-            # Quickly find next power of 2 >= quotient
-            p2 = 2**((quotient - 1).bit_length())
-
-            N = p2 * p35
-            if N == target:
-                return N
-            elif N < match:
-                match = N
-            p35 *= 3
-            if p35 == target:
-                return p35
-        if p35 < match:
-            match = p35
-        p5 *= 5
-        if p5 == target:
-            return p5
-    if p5 < match:
-        match = p5
-    return match
 
 
 def next_fast_len(target, type='C2C'):
@@ -95,7 +33,7 @@ def next_fast_len(target, type='C2C'):
     Notes
     -----
     The result of this function may change in future as performance
-    considerations chage, for example if new prime factors are added.
+    considerations change, for example if new prime factors are added.
 
     Calling `fft` or `ifft` with real input data performs an 'R2C' type
     transform internally.
@@ -122,15 +60,6 @@ def next_fast_len(target, type='C2C'):
     >>> b = fft.fft(a, 131072)
 
     """
-    target = operator.index(target)
-
-    if type not in ['C2C', 'R2C', 'C2R']:
-        raise ValueError('Unknown transform type: {}'.format(type))
-
-    # Use python implementation if a size_t would overflow
-    if (target-1)*11 > sys.maxsize:
-        return _next_regular_len(target)
-
     return _helper.next_fast_len(target, type)
 
 

--- a/scipy/fft/_pocketfft/helper.py
+++ b/scipy/fft/_pocketfft/helper.py
@@ -2,6 +2,8 @@ import numpy as np
 from numbers import Number
 import operator
 from .pypocketfft import good_size
+import operator
+import sys
 
 
 # TODO: Build with OpenMp and add configuration support
@@ -147,5 +149,15 @@ def _normalization(norm, forward):
         "Invalid norm value {}, should be None or \"ortho\".".format(norm))
 
 def next_fast_len(target, type='C2C'):
-    real = {'C2C': False, 'R2C': True, 'C2R': True}[type]
+    try:
+        real = {'C2C': False, 'R2C': True, 'C2R': True}[type]
+    except KeyError:
+        raise ValueError('Unknown transform type: {}'.format(type))
+
+    target = operator.index(target)
+
+    # Error if a size_t result could overflow
+    if (target-1)*11 > sys.maxsize:
+        raise ValueError(
+            'Target length is too large to perform an FFT: {}' .format(target))
     return good_size(target, real)

--- a/scipy/fft/_pocketfft/helper.py
+++ b/scipy/fft/_pocketfft/helper.py
@@ -1,6 +1,7 @@
 import numpy as np
 from numbers import Number
 import operator
+from .pypocketfft import good_size
 
 
 # TODO: Build with OpenMp and add configuration support
@@ -144,3 +145,7 @@ def _normalization(norm, forward):
 
     raise ValueError(
         "Invalid norm value {}, should be None or \"ortho\".".format(norm))
+
+def next_fast_len(target, type='C2C'):
+    real = {'C2C': False, 'R2C': True, 'C2R': True}[type]
+    return good_size(target, real)

--- a/scipy/fft/_pocketfft/helper.py
+++ b/scipy/fft/_pocketfft/helper.py
@@ -148,11 +148,11 @@ def _normalization(norm, forward):
     raise ValueError(
         "Invalid norm value {}, should be None or \"ortho\".".format(norm))
 
-def next_fast_len(target, type='C2C'):
+def next_fast_len(target, kind='C2C'):
     try:
-        real = {'C2C': False, 'R2C': True, 'C2R': True}[type]
+        real = {'C2C': False, 'R2C': True, 'C2R': True}[kind]
     except KeyError:
-        raise ValueError('Unknown transform type: {}'.format(type))
+        raise ValueError('Unknown transform kind: {}'.format(kind))
 
     target = operator.index(target)
 

--- a/scipy/fft/_pocketfft/pocketfft_hdronly.h
+++ b/scipy/fft/_pocketfft/pocketfft_hdronly.h
@@ -198,6 +198,8 @@ template<typename T> struct cmplx {
   cmplx(T r_, T i_) : r(r_), i(i_) {}
   void Set(T r_, T i_) { r=r_; i=i_; }
   void Set(T r_) { r=r_; i=T(0); }
+  void Split(T &r_, T &i_) const { r_=r; i_=i; }
+  void SplitConj(T &r_, T &i_) const { r_=r; i_=-i; }
   cmplx &operator+= (const cmplx &other)
     { r+=other.r; i+=other.i; return *this; }
   template<typename T2>cmplx &operator*= (T2 other)
@@ -209,13 +211,19 @@ template<typename T> struct cmplx {
     r = tmp;
     return *this;
     }
-  cmplx operator+ (const cmplx &other) const
-    { return cmplx(r+other.r, i+other.i); }
-  cmplx operator- (const cmplx &other) const
-    { return cmplx(r-other.r, i-other.i); }
+  template<typename T2>cmplx &operator+= (const cmplx<T2> &other)
+    { r+=other.r; i+=other.i; return *this; }
+  template<typename T2>cmplx &operator-= (const cmplx<T2> &other)
+    { r-=other.r; i-=other.i; return *this; }
   template<typename T2> auto operator* (const T2 &other) const
     -> cmplx<decltype(r*other)>
     { return {r*other, i*other}; }
+  template<typename T2> auto operator+ (const cmplx<T2> &other) const
+    -> cmplx<decltype(r+other.r)>
+    { return {r+other.r, i+other.i}; }
+  template<typename T2> auto operator- (const cmplx<T2> &other) const
+    -> cmplx<decltype(r+other.r)>
+    { return {r-other.r, i-other.i}; }
   template<typename T2> auto operator* (const cmplx<T2> &other) const
     -> cmplx<decltype(r+other.r)>
     { return {r*other.r-i*other.i, r*other.i + i*other.r}; }
@@ -227,8 +235,11 @@ template<typename T> struct cmplx {
                : Tres(r*other.r-i*other.i, r*other.i+i*other.r);
     }
 };
-template<typename T> void PMC(cmplx<T> &a, cmplx<T> &b,
-  const cmplx<T> &c, const cmplx<T> &d)
+template<typename T> inline void PMINPLACE(T &a, T &b)
+  { T t = a; a+=b; b=t-b; }
+template<typename T> inline void MPINPLACE(T &a, T &b)
+  { T t = a; a-=b; b=t+b; }
+template<typename T> void PMC(T &a, T &b, const T &c, const T &d)
   { a = c+d; b = c-d; }
 template<typename T> cmplx<T> conj(const cmplx<T> &a)
   { return {a.r, -a.i}; }
@@ -445,17 +456,58 @@ struct util // hack to avoid duplicate symbols
     }
 
   /* returns the smallest composite of 2, 3, 5, 7 and 11 which is >= n */
-  static POCKETFFT_NOINLINE size_t good_size(size_t n)
+  static POCKETFFT_NOINLINE size_t good_size_cmplx(size_t n)
     {
     if (n<=12) return n;
 
     size_t bestfac=2*n;
-    for (size_t f2=1; f2<bestfac; f2*=2)
-      for (size_t f23=f2; f23<bestfac; f23*=3)
-        for (size_t f235=f23; f235<bestfac; f235*=5)
-          for (size_t f2357=f235; f2357<bestfac; f2357*=7)
-            for (size_t f235711=f2357; f235711<bestfac; f235711*=11)
-              if (f235711>=n) bestfac=f235711;
+    for (size_t f11=1; f11<bestfac; f11*=11)
+      for (size_t f117=f11; f117<bestfac; f117*=7)
+        for (size_t f1175=f117; f1175<bestfac; f1175*=5)
+          {
+          size_t x=f1175;
+          while (x<n) x*=2;
+          for (;;)
+            {
+            if (x<n)
+              x*=3;
+            else if (x>n)
+              {
+              if (x<bestfac) bestfac=x;
+              if (x&1) break;
+              x>>=1;
+              }
+            else
+              return n;
+            }
+          }
+    return bestfac;
+    }
+
+  /* returns the smallest composite of 2, 3, 5 which is >= n */
+  static POCKETFFT_NOINLINE size_t good_size_real(size_t n)
+    {
+    if (n<=6) return n;
+
+    size_t bestfac=2*n;
+    for (size_t f5=1; f5<bestfac; f5*=5)
+      {
+      size_t x = f5;
+      while (x<n) x *= 2;
+      for (;;)
+        {
+        if (x<n)
+          x*=3;
+        else if (x>n)
+          {
+          if (x<bestfac) bestfac=x;
+          if (x&1) break;
+          x>>=1;
+          }
+        else
+          return n;
+        }
+      }
     return bestfac;
     }
 
@@ -845,8 +897,6 @@ template <bool fwd, typename T> void ROTX135(T &a)
   else
     { auto tmp_=a.r; a.r=hsqt2*(-a.r-a.i); a.i=hsqt2*(tmp_-a.i); }
   }
-template<typename T> inline void PMINPLACE(T &a, T &b)
-  { T t = a; a.r+=b.r; a.i+=b.i; b.r=t.r-b.r; b.i=t.i-b.i; }
 
 template<bool fwd, typename T> void pass8 (size_t ido, size_t l1,
   const T * POCKETFFT_RESTRICT cc, T * POCKETFFT_RESTRICT ch,
@@ -865,74 +915,71 @@ template<bool fwd, typename T> void pass8 (size_t ido, size_t l1,
     for (size_t k=0; k<l1; ++k)
       {
       T a0, a1, a2, a3, a4, a5, a6, a7;
-      PMC(a0,a4,CC(0,0,k),CC(0,4,k));
       PMC(a1,a5,CC(0,1,k),CC(0,5,k));
-      PMC(a2,a6,CC(0,2,k),CC(0,6,k));
       PMC(a3,a7,CC(0,3,k),CC(0,7,k));
-      ROTX90<fwd>(a6);
-      ROTX90<fwd>(a7);
-      PMINPLACE(a0,a2);
       PMINPLACE(a1,a3);
-      PMINPLACE(a4,a6);
+      ROTX90<fwd>(a3);
+
+      ROTX90<fwd>(a7);
       PMINPLACE(a5,a7);
       ROTX45<fwd>(a5);
-      ROTX90<fwd>(a3);
       ROTX135<fwd>(a7);
-      PMC(CH(0,k,0),CH(0,k,4),a0,a1);
-      PMC(CH(0,k,1),CH(0,k,5),a4,a5);
-      PMC(CH(0,k,2),CH(0,k,6),a2,a3);
-      PMC(CH(0,k,3),CH(0,k,7),a6,a7);
+
+      PMC(a0,a4,CC(0,0,k),CC(0,4,k));
+      PMC(a2,a6,CC(0,2,k),CC(0,6,k));
+      PMC(CH(0,k,0),CH(0,k,4),a0+a2,a1);
+      PMC(CH(0,k,2),CH(0,k,6),a0-a2,a3);
+      ROTX90<fwd>(a6);
+      PMC(CH(0,k,1),CH(0,k,5),a4+a6,a5);
+      PMC(CH(0,k,3),CH(0,k,7),a4-a6,a7);
       }
   else
     for (size_t k=0; k<l1; ++k)
       {
+      {
       T a0, a1, a2, a3, a4, a5, a6, a7;
-      PMC(a0,a4,CC(0,0,k),CC(0,4,k));
       PMC(a1,a5,CC(0,1,k),CC(0,5,k));
-      PMC(a2,a6,CC(0,2,k),CC(0,6,k));
       PMC(a3,a7,CC(0,3,k),CC(0,7,k));
-      ROTX90<fwd>(a6);
-      ROTX90<fwd>(a7);
-      PMINPLACE(a0,a2);
       PMINPLACE(a1,a3);
-      PMINPLACE(a4,a6);
+      ROTX90<fwd>(a3);
+
+      ROTX90<fwd>(a7);
       PMINPLACE(a5,a7);
       ROTX45<fwd>(a5);
-      ROTX90<fwd>(a3);
       ROTX135<fwd>(a7);
-      PMC(CH(0,k,0),CH(0,k,4),a0,a1);
-      PMC(CH(0,k,1),CH(0,k,5),a4,a5);
-      PMC(CH(0,k,2),CH(0,k,6),a2,a3);
-      PMC(CH(0,k,3),CH(0,k,7),a6,a7);
 
+      PMC(a0,a4,CC(0,0,k),CC(0,4,k));
+      PMC(a2,a6,CC(0,2,k),CC(0,6,k));
+      PMC(CH(0,k,0),CH(0,k,4),a0+a2,a1);
+      PMC(CH(0,k,2),CH(0,k,6),a0-a2,a3);
+      ROTX90<fwd>(a6);
+      PMC(CH(0,k,1),CH(0,k,5),a4+a6,a5);
+      PMC(CH(0,k,3),CH(0,k,7),a4-a6,a7);
+      }
       for (size_t i=1; i<ido; ++i)
         {
         T a0, a1, a2, a3, a4, a5, a6, a7;
-        PMC(a0,a4,CC(i,0,k),CC(i,4,k));
         PMC(a1,a5,CC(i,1,k),CC(i,5,k));
-        PMC(a2,a6,CC(i,2,k),CC(i,6,k));
         PMC(a3,a7,CC(i,3,k),CC(i,7,k));
-        ROTX90<fwd>(a6);
         ROTX90<fwd>(a7);
-        PMINPLACE(a0,a2);
         PMINPLACE(a1,a3);
-        PMINPLACE(a4,a6);
+        ROTX90<fwd>(a3);
         PMINPLACE(a5,a7);
         ROTX45<fwd>(a5);
-        ROTX90<fwd>(a3);
         ROTX135<fwd>(a7);
-        PMINPLACE(a0,a1);
-        PMINPLACE(a2,a3);
-        PMINPLACE(a4,a5);
-        PMINPLACE(a6,a7);
-        CH(i,k,0) = a0;
-        CH(i,k,1) = a4.template special_mul<fwd>(WA(0,i));
-        CH(i,k,2) = a2.template special_mul<fwd>(WA(1,i));
-        CH(i,k,3) = a6.template special_mul<fwd>(WA(2,i));
-        CH(i,k,4) = a1.template special_mul<fwd>(WA(3,i));
-        CH(i,k,5) = a5.template special_mul<fwd>(WA(4,i));
-        CH(i,k,6) = a3.template special_mul<fwd>(WA(5,i));
-        CH(i,k,7) = a7.template special_mul<fwd>(WA(6,i));
+        PMC(a0,a4,CC(i,0,k),CC(i,4,k));
+        PMC(a2,a6,CC(i,2,k),CC(i,6,k));
+        PMINPLACE(a0,a2);
+        CH(i,k,0) = a0+a1;
+        CH(i,k,4) = (a0-a1).template special_mul<fwd>(WA(3,i));
+        CH(i,k,2) = (a2+a3).template special_mul<fwd>(WA(1,i));
+        CH(i,k,6) = (a2-a3).template special_mul<fwd>(WA(5,i));
+        ROTX90<fwd>(a6);
+        PMINPLACE(a4,a6);
+        CH(i,k,1) = (a4+a5).template special_mul<fwd>(WA(0,i));
+        CH(i,k,5) = (a4-a5).template special_mul<fwd>(WA(4,i));
+        CH(i,k,3) = (a6+a7).template special_mul<fwd>(WA(2,i));
+        CH(i,k,7) = (a6-a7).template special_mul<fwd>(WA(6,i));
         }
       }
    }
@@ -2145,7 +2192,7 @@ template<typename T0> class fftblue
 
   public:
     POCKETFFT_NOINLINE fftblue(size_t length)
-      : n(length), n2(util::good_size(n*2-1)), plan(n2), mem(n+n2),
+      : n(length), n2(util::good_size_cmplx(n*2-1)), plan(n2), mem(n+n2),
         bk(mem.data()), bkf(mem.data()+n)
       {
       /* initialize b_k */
@@ -2226,7 +2273,7 @@ template<typename T0> class pocketfft_c
         return;
         }
       double comp1 = util::cost_guess(length);
-      double comp2 = 2*util::cost_guess(util::good_size(2*length-1));
+      double comp2 = 2*util::cost_guess(util::good_size_cmplx(2*length-1));
       comp2*=1.5; /* fudge factor that appears to give good overall performance */
       if (comp2<comp1) // use Bluestein
         blueplan=unique_ptr<fftblue<T0>>(new fftblue<T0>(length));
@@ -2266,7 +2313,7 @@ template<typename T0> class pocketfft_r
         return;
         }
       double comp1 = 0.5*util::cost_guess(length);
-      double comp2 = 2*util::cost_guess(util::good_size(2*length-1));
+      double comp2 = 2*util::cost_guess(util::good_size_cmplx(2*length-1));
       comp2*=1.5; /* fudge factor that appears to give good overall performance */
       if (comp2<comp1) // use Bluestein
         blueplan=unique_ptr<fftblue<T0>>(new fftblue<T0>(length));
@@ -2293,6 +2340,7 @@ template<typename T0> class pocketfft_r
 //
 // sine/cosine transforms
 //
+
 template<typename T0> class T_dct1
   {
   private:
@@ -2302,7 +2350,8 @@ template<typename T0> class T_dct1
     POCKETFFT_NOINLINE T_dct1(size_t length)
       : fftplan(2*(length-1)) {}
 
-    template<typename T> POCKETFFT_NOINLINE void exec(T c[], T0 fct, bool ortho) const
+    template<typename T> POCKETFFT_NOINLINE void exec(T c[], T0 fct, bool ortho,
+      int /*type*/, bool /*cosine*/) const
       {
       constexpr T0 sqrt2=T0(1.414213562373095048801688724209698L);
       size_t N=fftplan.length(), n=N/2+1;
@@ -2323,14 +2372,39 @@ template<typename T0> class T_dct1
     size_t length() const { return fftplan.length()/2+1; }
   };
 
-template<typename T0> class T_dct2
+template<typename T0> class T_dst1
+  {
+  private:
+    pocketfft_r<T0> fftplan;
+
+  public:
+    POCKETFFT_NOINLINE T_dst1(size_t length)
+      : fftplan(2*(length+1)) {}
+
+    template<typename T> POCKETFFT_NOINLINE void exec(T c[], T0 fct,
+      bool /*ortho*/, int /*type*/, bool /*cosine*/) const
+      {
+      size_t N=fftplan.length(), n=N/2-1;
+      arr<T> tmp(N);
+      tmp[0] = tmp[n+1] = c[0]*0;
+      for (size_t i=0; i<n; ++i)
+        { tmp[i+1]=c[i]; tmp[N-1-i]=-c[i]; }
+      fftplan.forward(tmp.data(), fct);
+      for (size_t i=0; i<n; ++i)
+        c[i] = -tmp[2*i+2];
+      }
+
+    size_t length() const { return fftplan.length()/2-1; }
+  };
+
+template<typename T0> class T_dcst23
   {
   private:
     pocketfft_r<T0> fftplan;
     vector<T0> twiddle;
 
   public:
-    POCKETFFT_NOINLINE T_dct2(size_t length)
+    POCKETFFT_NOINLINE T_dcst23(size_t length)
       : fftplan(length), twiddle(length)
       {
       constexpr T0 pi = T0(3.141592653589793238462643383279502884197L);
@@ -2338,111 +2412,62 @@ template<typename T0> class T_dct2
         twiddle[i] = T0(cos(0.5*pi*T0(i+1)/T0(length)));
       }
 
-    template<typename T> POCKETFFT_NOINLINE void exec(T c[], T0 fct, bool ortho) const
+    template<typename T> POCKETFFT_NOINLINE void exec(T c[], T0 fct, bool ortho,
+      int type, bool cosine) const
       {
       constexpr T0 sqrt2=T0(1.414213562373095048801688724209698L);
       size_t N=length();
-      if (N==1)
-        c[0]*=2*fct;
-      else if (N==2)
+      size_t NS2 = (N+1)/2;
+      if (type==2)
         {
-        T x1 = 2*fct*(c[0]+c[1]);
-        c[1] = sqrt2*fct*(c[0]-c[1]);
-        c[0] = x1;
-        }
-      else
-        {
-        size_t NS2 = (N+1)/2;
-        for (size_t i=2; i<N; i+=2)
-          {
-          T xim1 = T0(0.5)*(c[i-1]+c[i]);
-          c[i] = T0(0.5)*(c[i]-c[i-1]);
-          c[i-1] = xim1;
-          }
+        if (!cosine)
+          for (size_t k=1; k<N; k+=2)
+            c[k] = -c[k];
+        c[0] *= 2;
+        if ((N&1)==0) c[N-1]*=2;
+        for (size_t k=1; k<N-1; k+=2)
+          MPINPLACE(c[k+1], c[k]);
         fftplan.backward(c, fct);
         for (size_t k=1, kc=N-1; k<NS2; ++k, --kc)
           {
-          T tmp = twiddle[k-1]*c[kc]+twiddle[kc-1]*c[k];
-          c[kc] = twiddle[k-1]*c[k]-twiddle[kc-1]*c[kc];
-          c[k] = tmp;
+          T t1 = twiddle[k-1]*c[kc]+twiddle[kc-1]*c[k];
+          T t2 = twiddle[k-1]*c[k]-twiddle[kc-1]*c[kc];
+          c[k] = T0(0.5)*(t1+t2); c[kc]=T0(0.5)*(t1-t2);
           }
         if ((N&1)==0)
-          c[NS2] = twiddle[NS2-1]*(c[NS2]+c[NS2]);
-        for (size_t k=1, kc=N-1; k<NS2; ++k, --kc)
-          {
-          T tmp = c[k]+c[kc];
-          c[kc] = c[k]-c[kc];
-          c[k] = tmp;
-          }
-        c[0] *= 2;
-        }
-      if (ortho) c[0]/=sqrt2;
-      }
-
-    size_t length() const { return fftplan.length(); }
-  };
-
-template<typename T0> class T_dct3
-  {
-  private:
-    pocketfft_r<T0> fftplan;
-    vector<T0> twiddle;
-
-  public:
-    POCKETFFT_NOINLINE T_dct3(size_t length)
-      : fftplan(length), twiddle(length)
-      {
-      constexpr T0 pi = T0(3.141592653589793238462643383279502884197L);
-      for (size_t i=0; i<length; ++i)
-        twiddle[i] = T0(cos(0.5*pi*T0(i+1)/T0(length)));
-      }
-
-    template<typename T> POCKETFFT_NOINLINE void exec(T c[], T0 fct, bool ortho) const
-      {
-      constexpr T0 sqrt2=T0(1.414213562373095048801688724209698L);
-      size_t N=length();
-      if (ortho) c[0]*=sqrt2;
-      if (N==1)
-        c[0]*=fct;
-      else if (N==2)
-        {
-        T TSQX = sqrt2*c[1];
-        c[1] = fct*(c[0]-TSQX);
-        c[0] = fct*(c[0]+TSQX);
+          c[NS2] *= twiddle[NS2-1];
+        if (!cosine)
+          for (size_t k=0, kc=N-1; k<kc; ++k, --kc)
+            swap(c[k], c[kc]);
+        if (ortho) c[0]/=sqrt2;
         }
       else
         {
-        size_t NS2 = (N+1)/2;
+        if (ortho) c[0]*=sqrt2;
+        if (!cosine)
+          for (size_t k=0, kc=N-1; k<NS2; ++k, --kc)
+            swap(c[k], c[kc]);
         for (size_t k=1, kc=N-1; k<NS2; ++k, --kc)
           {
-          T tmp = c[k]-c[kc];
-          c[k] = c[k]+c[kc];
-          c[kc] = tmp;
+          T t1=c[k]+c[kc], t2=c[k]-c[kc];
+          c[k] = twiddle[k-1]*t2+twiddle[kc-1]*t1;
+          c[kc]= twiddle[k-1]*t1-twiddle[kc-1]*t2;
           }
         if ((N&1)==0)
-          c[NS2] = c[NS2]+c[NS2];
-        for (size_t k=1, kc=N-1; k<NS2; ++k, --kc)
-          {
-          T tmp = twiddle[k-1]*c[k]-twiddle[kc-1]*c[kc];
-          c[k] = twiddle[k-1]*c[kc]+twiddle[kc-1]*c[k];
-          c[kc] = tmp;
-          }
-        if ((N&1)==0)
-          c[NS2] = twiddle[NS2-1]*c[NS2];
+          c[NS2] *= 2*twiddle[NS2-1];
         fftplan.forward(c, fct);
-        for (size_t i=2; i<N; i+=2)
-          {
-          T xim1 = c[i-1]-c[i];
-          c[i] += c[i-1];
-          c[i-1] = xim1;
-          }
+        for (size_t k=1; k<N-1; k+=2)
+          MPINPLACE(c[k], c[k+1]);
+        if (!cosine)
+          for (size_t k=1; k<N; k+=2)
+            c[k] = -c[k];
         }
       }
 
     size_t length() const { return fftplan.length(); }
   };
 
-template<typename T0> class T_dct4
+template<typename T0> class T_dcst4
   {
   // even length algorithm from
   // https://www.appletonaudio.com/blog/2013/derivation-of-fast-dct-4-algorithm-based-on-dft/
@@ -2453,7 +2478,7 @@ template<typename T0> class T_dct4
     arr<cmplx<T0>> C2;
 
   public:
-    POCKETFFT_NOINLINE T_dct4(size_t length)
+    POCKETFFT_NOINLINE T_dcst4(size_t length)
       : N(length),
         fft((N&1) ? nullptr : new pocketfft_c<T0>(N/2)),
         rfft((N&1)? new pocketfft_r<T0>(N) : nullptr),
@@ -2468,9 +2493,14 @@ template<typename T0> class T_dct4
           }
       }
 
-    template<typename T> POCKETFFT_NOINLINE void exec(T c[], T0 fct, bool /*ortho*/) const
+    template<typename T> POCKETFFT_NOINLINE void exec(T c[], T0 fct,
+      bool /*ortho*/, int /*type*/, bool cosine) const
       {
       constexpr T0 sqrt2=T0(1.414213562373095048801688724209698L);
+      size_t n2 = N/2;
+      if (!cosine)
+        for (size_t k=0, kc=N-1; k<n2; ++k, --kc)
+          swap(c[k], c[kc]);
       if (N&1)
         {
         // The following code is derived from the FFTW3 function apply_re11()
@@ -2479,11 +2509,9 @@ template<typename T0> class T_dct4
 
         auto SGN_SET = [](T x, size_t i) {return (i%2) ? -x : x;};
         arr<T> y(N);
-        size_t n2 = N/2;
-        size_t i;
         {
-        size_t m;
-        for (i=0, m=n2; m<N; ++i, m+=4)
+        size_t i=0, m=n2;
+        for (; m<N; ++i, m+=4)
           y[i] = c[m];
         for (; m<2*N; ++i, m+=4)
           y[i] = -c[2*N-m-1];
@@ -2496,7 +2524,9 @@ template<typename T0> class T_dct4
           y[i] = c[m];
         }
         rfft->forward(y.data(), fct);
-        for (i=0; i+i+1<n2; ++i)
+        {
+        size_t i=0;
+        for (; i+i+1<n2; ++i)
           {
           size_t k = i+i+1;
           T c1=y[2*k-1], s1=y[2*k], c2=y[2*k+1], s2=y[2*k+2];
@@ -2511,140 +2541,34 @@ template<typename T0> class T_dct4
           c[i] = sqrt2 * (SGN_SET(cx, (i+1)/2) + SGN_SET(sx, i/2));
           c[N-(i+1)] = sqrt2 * (SGN_SET(cx, (i+2)/2) + SGN_SET(sx, (i+1)/2));
           }
+        }
         c[n2] = sqrt2 * SGN_SET(y[0], (n2+1)/2);
 
         // FFTW-derived code ends here
         }
       else
         {
-        arr<cmplx<T>> y(N/2);
-        for(size_t i=0; i<N/2; ++i)
+        // even length algorithm from
+        // https://www.appletonaudio.com/blog/2013/derivation-of-fast-dct-4-algorithm-based-on-dft/
+        arr<cmplx<T>> y(n2);
+        for(size_t i=0; i<n2; ++i)
           {
           y[i].Set(c[2*i],c[N-1-2*i]);
           y[i] *= C2[i];
           }
         fft->forward(y.data(), fct);
-        for(size_t i=0; i<N/2; ++i)
-          y[i] *= C2[i];
-        for(size_t i=0; i<N/2; ++i)
+        for(size_t i=0, ic=n2-1; i<n2; ++i, --ic)
           {
-          c[2*i] = 2*y[i].r;
-          c[2*i+1] = -2*y[N/2-1-i].i;
+          c[2*i  ] =  2*(y[i ].r*C2[i ].r-y[i ].i*C2[i ].i);
+          c[2*i+1] = -2*(y[ic].i*C2[ic].r+y[ic].r*C2[ic].i);
           }
         }
+      if (!cosine)
+        for (size_t k=1; k<N; k+=2)
+          c[k] = -c[k];
       }
 
     size_t length() const { return N; }
-  };
-
-template<typename T0> class T_dst1
-  {
-  private:
-    pocketfft_r<T0> fftplan;
-
-  public:
-    POCKETFFT_NOINLINE T_dst1(size_t length)
-      : fftplan(2*(length+1)) {}
-
-    template<typename T> POCKETFFT_NOINLINE void exec(T c[], T0 fct, bool /*ortho*/) const
-      {
-      size_t N=fftplan.length(), n=N/2-1;
-      arr<T> tmp(N);
-      tmp[0] = tmp[n+1] = c[0]*0;
-      for (size_t i=0; i<n; ++i)
-        {
-        tmp[i+1] = c[i];
-        tmp[N-1-i] = -c[i];
-        }
-      fftplan.forward(tmp.data(), fct);
-      for (size_t i=0; i<n; ++i)
-        c[i] = -tmp[2*i+2];
-      }
-
-    size_t length() const { return fftplan.length()/2-1; }
-  };
-
-template<typename T0> class T_dst2
-  {
-  private:
-    T_dct2<T0> dct;
-
-  public:
-    POCKETFFT_NOINLINE T_dst2(size_t length)
-      : dct(length) {}
-
-    template<typename T> POCKETFFT_NOINLINE void exec(T c[], T0 fct, bool ortho) const
-      {
-      constexpr T0 sqrt2=T0(1.414213562373095048801688724209698L);
-      size_t N=length();
-      if (N==1)
-        c[0]*=2*fct;
-      else
-        {
-        for (size_t k=1; k<N; k+=2)
-          c[k] = -c[k];
-        dct.exec(c, fct, false);
-        for (size_t k=0, kc=N-1; k<kc; ++k, --kc)
-          swap(c[k], c[kc]);
-        }
-      if (ortho) c[0]/=sqrt2;
-      }
-
-    size_t length() const { return dct.length(); }
-  };
-
-template<typename T0> class T_dst3
-  {
-  private:
-    T_dct3<T0> dct;
-
-  public:
-    POCKETFFT_NOINLINE T_dst3(size_t length)
-      : dct(length) {}
-
-    template<typename T> POCKETFFT_NOINLINE void exec(T c[], T0 fct, bool ortho)
-      {
-      constexpr T0 sqrt2=T0(1.414213562373095048801688724209698L);
-      size_t N=length();
-      if (ortho) c[0]*=sqrt2;
-      if (N==1)
-        c[0]*=fct;
-      else
-        {
-        size_t NS2 = N/2;
-        for (size_t k=0, kc=N-1; k<NS2; ++k, --kc)
-          swap(c[k], c[kc]);
-        dct.exec(c, fct, false);
-        for (size_t k=1; k<N; k+=2)
-          c[k] = -c[k];
-        }
-      }
-
-    size_t length() const { return dct.length(); }
-  };
-
-template<typename T0> class T_dst4
-  {
-  private:
-    T_dct4<T0> dct;
-
-  public:
-    POCKETFFT_NOINLINE T_dst4(size_t length)
-      : dct(length) {}
-
-    template<typename T> POCKETFFT_NOINLINE void exec(T c[], T0 fct, bool /*ortho*/)
-      {
-      size_t N=length();
-      //if (N==1) { c[0]*=fct; return; }
-      size_t NS2 = N/2;
-      for (size_t k=0, kc=N-1; k<NS2; ++k, --kc)
-        swap(c[k], c[kc]);
-      dct.exec(c, fct, false);
-      for (size_t k=1; k<N; k+=2)
-        c[k] = -c[k];
-      }
-
-    size_t length() const { return dct.length(); }
   };
 
 
@@ -2998,25 +2922,16 @@ template<typename T> POCKETFFT_NOINLINE void general_c(
     while (it.remaining()>0)
       {
       it.advance(1);
-      auto tdata = reinterpret_cast<cmplx<T> *>(storage.data());
-      if ((&tin[0]==&out[0]) && (it.stride_out()==sizeof(cmplx<T>))) // fully in-place
-        forward ? plan->forward (&out[it.oofs(0)], fct)
-                : plan->backward(&out[it.oofs(0)], fct);
-      else if (it.stride_out()==sizeof(cmplx<T>)) // compute FFT in output location
-        {
+      auto buf = it.stride_out() == sizeof(cmplx<T>) ?
+        &out[it.oofs(0)] : reinterpret_cast<cmplx<T> *>(storage.data());
+
+      if (buf != &tin[it.iofs(0)])
         for (size_t i=0; i<len; ++i)
-          out[it.oofs(i)] = tin[it.iofs(i)];
-        forward ? plan->forward (&out[it.oofs(0)], fct)
-                : plan->backward(&out[it.oofs(0)], fct);
-        }
-      else
-        {
+          buf[i] = tin[it.iofs(i)];
+      forward ? plan->forward (buf, fct) : plan->backward(buf, fct);
+      if (buf != &out[it.oofs(0)])
         for (size_t i=0; i<len; ++i)
-          tdata[i] = tin[it.iofs(i)];
-        forward ? plan->forward (tdata, fct) : plan->backward(tdata, fct);
-        for (size_t i=0; i<len; ++i)
-          out[it.oofs(i)] = tdata[i];
-        }
+          out[it.oofs(i)] = buf[i];
       }
 } // end of parallel region
     fct = T(1); // factor has been applied, use 1 for remaining axes
@@ -3093,7 +3008,7 @@ template<typename T> POCKETFFT_NOINLINE void general_hartley(
 
 template<typename Trafo, typename T> POCKETFFT_NOINLINE void general_dcst(
   const cndarr<T> &in, ndarr<T> &out, const shape_t &axes,
-  T fct, bool ortho, size_t POCKETFFT_NTHREADS)
+  T fct, bool ortho, int type, bool cosine, size_t POCKETFFT_NTHREADS)
   {
   shared_ptr<Trafo> plan;
 
@@ -3121,7 +3036,7 @@ template<typename Trafo, typename T> POCKETFFT_NOINLINE void general_dcst(
         for (size_t i=0; i<len; ++i)
           for (size_t j=0; j<vlen; ++j)
             tdatav[i][j] = tin[it.iofs(j,i)];
-        plan->exec(tdatav, fct, ortho);
+        plan->exec(tdatav, fct, ortho, type, cosine);
         for (size_t i=0; i<len; ++i)
           for (size_t j=0; j<vlen; ++j)
             out[it.oofs(j,i)] = tdatav[i][j];
@@ -3130,23 +3045,16 @@ template<typename Trafo, typename T> POCKETFFT_NOINLINE void general_dcst(
     while (it.remaining()>0)
       {
       it.advance(1);
-      auto tdata = reinterpret_cast<T *>(storage.data());
-      if ((&tin[0]==&out[0]) && (it.stride_out()==sizeof(T))) // fully in-place
-        plan->exec(&out[it.oofs(0)], fct, ortho);
-      else if (it.stride_out()==sizeof(T)) // compute FFT in output location
-        {
+      auto buf = it.stride_out() == sizeof(T) ? &out[it.oofs(0)]
+        : reinterpret_cast<T *>(storage.data());
+
+      if (buf != &tin[it.iofs(0)])
         for (size_t i=0; i<len; ++i)
-          out[it.oofs(i)] = tin[it.iofs(i)];
-        plan->exec(&out[it.oofs(0)], fct, ortho);
-        }
-      else
-        {
+          buf[i] = tin[it.iofs(i)];
+      plan->exec(buf, fct, ortho, type, cosine);
+      if (buf != &out[it.oofs(0)])
         for (size_t i=0; i<len; ++i)
-          tdata[i] = tin[it.iofs(i)];
-        plan->exec(tdata, fct, ortho);
-        for (size_t i=0; i<len; ++i)
-          out[it.oofs(i)] = tdata[i];
-        }
+          out[it.oofs(i)] = buf[i];
       }
 } // end of parallel region
     fct = T(1); // factor has been applied, use 1 for remaining axes
@@ -3240,17 +3148,11 @@ template<typename T> POCKETFFT_NOINLINE void general_c2r(
       if (forward)
         for (; i<len-1; i+=2, ++ii)
           for (size_t j=0; j<vlen; ++j)
-            {
-            tdatav[i  ][j] = in[it.iofs(j,ii)].r;
-            tdatav[i+1][j] = -in[it.iofs(j,ii)].i;
-            }
+            in[it.iofs(j,ii)].SplitConj(tdatav[i][j], tdatav[i+1][j]);
       else
         for (; i<len-1; i+=2, ++ii)
           for (size_t j=0; j<vlen; ++j)
-            {
-            tdatav[i  ][j] = in[it.iofs(j,ii)].r;
-            tdatav[i+1][j] = in[it.iofs(j,ii)].i;
-            }
+            in[it.iofs(j,ii)].Split(tdatav[i][j], tdatav[i+1][j]);
       if (i<len)
         for (size_t j=0; j<vlen; ++j)
           tdatav[i][j] = in[it.iofs(j,ii)].r;
@@ -3270,16 +3172,10 @@ template<typename T> POCKETFFT_NOINLINE void general_c2r(
     size_t i=1, ii=1;
     if (forward)
       for (; i<len-1; i+=2, ++ii)
-        {
-        tdata[i  ] =  in[it.iofs(ii)].r;
-        tdata[i+1] = -in[it.iofs(ii)].i;
-        }
+        in[it.iofs(ii)].SplitConj(tdata[i], tdata[i+1]);
     else
       for (; i<len-1; i+=2, ++ii)
-        {
-        tdata[i  ] = in[it.iofs(ii)].r;
-        tdata[i+1] = in[it.iofs(ii)].i;
-        }
+        in[it.iofs(ii)].Split(tdata[i], tdata[i+1]);
     if (i<len)
       tdata[i] = in[it.iofs(ii)].r;
     }
@@ -3322,14 +3218,12 @@ template<typename T> POCKETFFT_NOINLINE void general_r(
             tdatav[i][j] = tin[it.iofs(j,i)];
         if ((!r2c) && forward)
           for (size_t i=2; i<len; i+=2)
-            for (size_t j=0; j<vlen; ++j)
-              tdatav[i][j] = -tdatav[i][j];
+            tdatav[i] = -tdatav[i];
         forward ? plan->forward (tdatav, fct)
                 : plan->backward(tdatav, fct);
         if (r2c && (!forward))
           for (size_t i=2; i<len; i+=2)
-            for (size_t j=0; j<vlen; ++j)
-              tdatav[i][j] = -tdatav[i][j];
+            tdatav[i] = -tdatav[i];
         for (size_t i=0; i<len; ++i)
           for (size_t j=0; j<vlen; ++j)
             out[it.oofs(j,i)] = tdatav[i][j];
@@ -3338,45 +3232,22 @@ template<typename T> POCKETFFT_NOINLINE void general_r(
     while (it.remaining()>0)
       {
       it.advance(1);
-      auto tdata = reinterpret_cast<T *>(storage.data());
-      if ((&tin[0]==&out[0]) && (it.stride_out()==sizeof(T))) // fully in-place
-        {
-        if ((!r2c) && forward)
-          for (size_t i=2; i<len; i+=2)
-            out[it.oofs(i)] = -out[it.oofs(i)];
-        forward ? plan->forward (&out[it.oofs(0)], fct)
-                : plan->backward(&out[it.oofs(0)], fct);
-        if (r2c && (!forward))
-          for (size_t i=2; i<len; i+=2)
-            out[it.oofs(i)] = -out[it.oofs(i)];
-        }
-      else if (it.stride_out()==sizeof(T)) // compute FFT in output location
-        {
+      auto buf = it.stride_out() == sizeof(T) ?
+        &out[it.oofs(0)] : reinterpret_cast<T *>(storage.data());
+
+      if (buf != &tin[it.iofs(0)])
         for (size_t i=0; i<len; ++i)
-          out[it.oofs(i)] = tin[it.iofs(i)];
-        if ((!r2c) && forward)
-          for (size_t i=2; i<len; i+=2)
-            out[it.oofs(i)] = -out[it.oofs(i)];
-        forward ? plan->forward (&out[it.oofs(0)], fct)
-                : plan->backward(&out[it.oofs(0)], fct);
-        if (r2c && (!forward))
-          for (size_t i=2; i<len; i+=2)
-            out[it.oofs(i)] = -out[it.oofs(i)];
-        }
-      else
-        {
+          buf[i] = tin[it.iofs(i)];
+      if ((!r2c) && forward)
+        for (size_t i=2; i<len; i+=2)
+          buf[i] = -buf[i];
+      forward ? plan->forward(buf, fct) : plan->backward(buf, fct);
+      if (r2c && (!forward))
+        for (size_t i=2; i<len; i+=2)
+          buf[i] = -buf[i];
+      if (buf != &out[it.oofs(0)])
         for (size_t i=0; i<len; ++i)
-          tdata[i] = tin[it.iofs(i)];
-        if ((!r2c) && forward)
-          for (size_t i=2; i<len; i+=2)
-            tdata[i] = -tdata[i];
-        forward ? plan->forward (tdata, fct) : plan->backward(tdata, fct);
-        if (r2c && (!forward))
-          for (size_t i=2; i<len; i+=2)
-            tdata[i] = -tdata[i];
-        for (size_t i=0; i<len; ++i)
-          out[it.oofs(i)] = tdata[i];
-        }
+          out[it.oofs(i)] = buf[i];
       }
 } // end of parallel region
     fct = T(1); // factor has been applied, use 1 for remaining axes
@@ -3407,15 +3278,11 @@ template<typename T> void dct(const shape_t &shape,
   cndarr<T> ain(data_in, shape, stride_in);
   ndarr<T> aout(data_out, shape, stride_out);
   if (type==1)
-    general_dcst<T_dct1<T>>(ain, aout, axes, fct, ortho, nthreads);
-  else if (type==2)
-    general_dcst<T_dct2<T>>(ain, aout, axes, fct, ortho, nthreads);
-  else if (type==3)
-    general_dcst<T_dct3<T>>(ain, aout, axes, fct, ortho, nthreads);
+    general_dcst<T_dct1<T>>(ain, aout, axes, fct, ortho, type, true, nthreads);
   else if (type==4)
-    general_dcst<T_dct4<T>>(ain, aout, axes, fct, ortho, nthreads);
+    general_dcst<T_dcst4<T>>(ain, aout, axes, fct, ortho, type, true, nthreads);
   else
-    throw runtime_error("unsupported DCT type");
+    general_dcst<T_dcst23<T>>(ain, aout, axes, fct, ortho, type, true, nthreads);
   }
 
 template<typename T> void dst(const shape_t &shape,
@@ -3428,15 +3295,11 @@ template<typename T> void dst(const shape_t &shape,
   cndarr<T> ain(data_in, shape, stride_in);
   ndarr<T> aout(data_out, shape, stride_out);
   if (type==1)
-    general_dcst<T_dst1<T>>(ain, aout, axes, fct, ortho, nthreads);
-  else if (type==2)
-    general_dcst<T_dst2<T>>(ain, aout, axes, fct, ortho, nthreads);
-  else if (type==3)
-    general_dcst<T_dst3<T>>(ain, aout, axes, fct, ortho, nthreads);
+    general_dcst<T_dst1<T>>(ain, aout, axes, fct, ortho, type, false, nthreads);
   else if (type==4)
-    general_dcst<T_dst4<T>>(ain, aout, axes, fct, ortho, nthreads);
+    general_dcst<T_dcst4<T>>(ain, aout, axes, fct, ortho, type, false, nthreads);
   else
-    throw runtime_error("unsupported DST type");
+    general_dcst<T_dcst23<T>>(ain, aout, axes, fct, ortho, type, false, nthreads);
   }
 
 template<typename T> void r2c(const shape_t &shape_in,

--- a/scipy/fft/_pocketfft/pypocketfft.cxx
+++ b/scipy/fft/_pocketfft/pypocketfft.cxx
@@ -377,6 +377,12 @@ py::array genuine_hartley(const py::array &in, const py::object &axes_,
   DISPATCH(in, f64, f32, flong, complex2hartley, (in, tmp, axes_, out_))
   }
 
+size_t good_size(size_t n, bool real)
+  {
+  using namespace pocketfft::detail;
+  return real ? util::good_size_real(n) : util::good_size_cmplx(n);
+  }
+
 const char *pypocketfft_DS = R"""(Fast Fourier and Hartley transforms.
 
 This module supports
@@ -662,6 +668,22 @@ numpy.ndarray (same shape and data type as `a`)
     The transformed data
 )""";
 
+const char * good_size_DS = R"""(Returns a good length to pad an FFT to.
+
+Parameters
+----------
+n : int
+    Minimum transform length
+real : bool, optional
+    True if either input or output of FFT should be fully real.
+
+Returns
+-------
+out : int
+    The smallest fast size >= n
+
+)""";
+
 } // unnamed namespace
 
 PYBIND11_MODULE(pypocketfft, m)
@@ -685,4 +707,5 @@ PYBIND11_MODULE(pypocketfft, m)
     "out"_a=None, "nthreads"_a=1);
   m.def("dst", dst, dst_DS, "a"_a, "type"_a, "axes"_a=None, "inorm"_a=0,
     "out"_a=None, "nthreads"_a=1);
+  m.def("good_size", good_size, good_size_DS, "n"_a, "real"_a=false);
   }

--- a/scipy/fft/_pocketfft/version.md
+++ b/scipy/fft/_pocketfft/version.md
@@ -4,13 +4,13 @@ pypocketfft version
 
 SciPy currently vendors [pypocketfft][repo] at:
 
-    commit 656b2373624bfb83ad1bc9388fa6c561eb2bb9e0
-    Merge: 0276f55 20f3b84
+    commit 869e68d243138c188cafa8334d92f94ded600a90
+    Merge: 6f1bba7 140e68f
     Author: Martin Reinecke <martin@mpa-garching.mpg.de>
-    Date:   Sat Jul 20 13:16:46 2019 +0200
+    Date:   Thu Aug 1 13:33:46 2019 +0200
 
-        Merge branch 'sincos' into 'master'
+        Merge branch 'tweak_codelet_8' into 'master'
 
-        DCT/DST support
+        Tweak length-8 codelet
 
 repo: https://gitlab.mpcdf.mpg.de/mtr/pypocketfft

--- a/scipy/fft/tests/test_helper.py
+++ b/scipy/fft/tests/test_helper.py
@@ -1,7 +1,9 @@
 from scipy.fft._helper import next_fast_len, _init_nd_shape_and_axes
 from numpy.testing import assert_equal, assert_
 from pytest import raises as assert_raises
+import pytest
 import numpy as np
+import sys
 
 _5_smooth_numbers = [
     2, 3, 4, 5, 6, 8, 9, 10,
@@ -63,10 +65,19 @@ class TestNextFastLen(object):
             testN = next_fast_len(x)
             assert_equal(testN, next_fast_len(int(x)))
 
-    def testnext_fast_len_strict(self):
+    def testnext_fast_len_small(self):
         hams = {
             1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 8, 8: 8, 14: 15, 15: 15,
-            16: 16, 17: 18, 1021: 1024, 1536: 1536, 51200000: 51200000,
+            16: 16, 17: 18, 1021: 1024, 1536: 1536, 51200000: 51200000
+        }
+        for x, y in hams.items():
+            assert_equal(next_fast_len(x, 'R2C'), y)
+
+    @pytest.mark.xfail(sys.maxsize < 2**32,
+                       reason="Hamming Numbers too large for 32-bit",
+                       raises=ValueError, strict=True)
+    def testnext_fast_len_big(self):
+        hams = {
             510183360: 510183360, 510183360 + 1: 512000000,
             511000000: 512000000,
             854296875: 854296875, 854296875 + 1: 859963392,

--- a/scipy/fft/tests/test_helper.py
+++ b/scipy/fft/tests/test_helper.py
@@ -1,5 +1,4 @@
-from scipy.fft._helper import (next_fast_len, _next_regular_len,
-                               _init_nd_shape_and_axes)
+from scipy.fft._helper import next_fast_len, _init_nd_shape_and_axes
 from numpy.testing import assert_equal, assert_
 from pytest import raises as assert_raises
 import numpy as np
@@ -16,9 +15,31 @@ def test_next_fast_len():
         assert_equal(next_fast_len(n), n)
 
 
-class TestNextRegularLen(object):
+def _assert_n_smooth(x, n):
+    x_orig = x
+    if n < 2:
+        assert False
 
-    def test_next_regular_len(self):
+    while True:
+        q, r = divmod(x, 2)
+        if r != 0:
+            break
+        x = q
+
+    for d in range(3, n+1, 2):
+        while True:
+            q, r = divmod(x, d)
+            if r != 0:
+                break
+            x = q
+
+    assert x == 1, \
+           'x={} is not {}-smooth, remainder={}'.format(x_orig, n, x)
+
+
+class TestNextFastLen(object):
+
+    def test_next_fast_len(self):
         np.random.seed(1234)
 
         def nums():
@@ -27,30 +48,22 @@ class TestNextRegularLen(object):
             yield 2**5 * 3**5 * 4**5 + 1
 
         for n in nums():
-            m = _next_regular_len(n)
-            msg = "n=%d, m=%d" % (n, m)
+            m = next_fast_len(n)
+            _assert_n_smooth(m, 11)
+            assert m == next_fast_len(n, 'C2C')
 
-            assert_(m >= n, msg)
-
-            # check regularity
-            k = m
-            for d in [2, 3, 5]:
-                while True:
-                    a, b = divmod(k, d)
-                    if b == 0:
-                        k = a
-                    else:
-                        break
-            assert_equal(k, 1, err_msg=msg)
+            m = next_fast_len(n, 'R2C')
+            _assert_n_smooth(m, 5)
+            assert m == next_fast_len(n, 'C2R')
 
     def test_np_integers(self):
         ITYPES = [np.int16, np.int32, np.int64, np.uint16, np.uint32, np.uint64]
         for ityp in ITYPES:
             x = ityp(12345)
-            testN = _next_regular_len(x)
-            assert_equal(testN, _next_regular_len(int(x)))
+            testN = next_fast_len(x)
+            assert_equal(testN, next_fast_len(int(x)))
 
-    def test_next_regular_len_strict(self):
+    def testnext_fast_len_strict(self):
         hams = {
             1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 8, 8: 8, 14: 15, 15: 15,
             16: 16, 17: 18, 1021: 1024, 1536: 1536, 51200000: 51200000,
@@ -82,46 +95,9 @@ class TestNextRegularLen(object):
             288325195312500000 - 1: 288325195312500000,
             288325195312500000: 288325195312500000,
             288325195312500000 + 1: 288555831593533440,
-            # power of 3    3**83
-            3990838394187339929534246675572349035227 - 1:
-                3990838394187339929534246675572349035227,
-            3990838394187339929534246675572349035227:
-                3990838394187339929534246675572349035227,
-            # power of 2     2**135
-            43556142965880123323311949751266331066368 - 1:
-                43556142965880123323311949751266331066368,
-            43556142965880123323311949751266331066368:
-                43556142965880123323311949751266331066368,
-            # power of 5      5**57
-            6938893903907228377647697925567626953125 - 1:
-                6938893903907228377647697925567626953125,
-            6938893903907228377647697925567626953125:
-                6938893903907228377647697925567626953125,
-            # http://www.drdobbs.com/228700538
-            # 2**96 * 3**1 * 5**13
-            290142196707511001929482240000000000000 - 1:
-                290142196707511001929482240000000000000,
-            290142196707511001929482240000000000000:
-                290142196707511001929482240000000000000,
-            290142196707511001929482240000000000000 + 1:
-                290237644800000000000000000000000000000,
-            # 2**36 * 3**69 * 5**7
-            4479571262811807241115438439905203543080960000000 - 1:
-                4479571262811807241115438439905203543080960000000,
-            4479571262811807241115438439905203543080960000000:
-                4479571262811807241115438439905203543080960000000,
-            4479571262811807241115438439905203543080960000000 + 1:
-                4480327901140333639941336854183943340032000000000,
-            # 2**37 * 3**44 * 5**42
-            30774090693237851027531250000000000000000000000000000000000000 - 1:
-                30774090693237851027531250000000000000000000000000000000000000,
-            30774090693237851027531250000000000000000000000000000000000000:
-                30774090693237851027531250000000000000000000000000000000000000,
-            30774090693237851027531250000000000000000000000000000000000000 + 1:
-                30778180617309082445871527002041377406962596539492679680000000,
         }
         for x, y in hams.items():
-            assert_equal(_next_regular_len(x), y)
+            assert_equal(next_fast_len(x, 'R2C'), y)
 
 
 class Test_init_nd_shape_and_axes(object):

--- a/scipy/fftpack/helper.py
+++ b/scipy/fftpack/helper.py
@@ -2,7 +2,7 @@ from __future__ import division, print_function, absolute_import
 
 import operator
 from numpy.fft.helper import fftshift, ifftshift, fftfreq
-from scipy.fft._helper import _next_regular_len
+from scipy.fft._pocketfft.helper import next_fast_len
 import numpy as np
 __all__ = ['fftshift', 'ifftshift', 'fftfreq', 'rfftfreq', 'next_fast_len']
 
@@ -94,4 +94,5 @@ def next_fast_len(target):
     >>> b = fftpack.fft(a, 16384)
 
     """
-    return _next_regular_len(target)
+    # Real transforms use regular sizes so this is backwards compatible
+    return next_fast_len(target, 'R2C')

--- a/scipy/fftpack/helper.py
+++ b/scipy/fftpack/helper.py
@@ -2,7 +2,7 @@ from __future__ import division, print_function, absolute_import
 
 import operator
 from numpy.fft.helper import fftshift, ifftshift, fftfreq
-from scipy.fft._pocketfft.helper import next_fast_len
+import scipy.fft._pocketfft.helper as _helper
 import numpy as np
 __all__ = ['fftshift', 'ifftshift', 'fftfreq', 'rfftfreq', 'next_fast_len']
 
@@ -95,4 +95,4 @@ def next_fast_len(target):
 
     """
     # Real transforms use regular sizes so this is backwards compatible
-    return next_fast_len(target, 'R2C')
+    return _helper.next_fast_len(target, 'R2C')

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -394,13 +394,16 @@ def fftconvolve(in1, in2, mode="full", axes=None):
         in1, s1, in2, s2 = in2, s2, in1, s1
 
     if len(axes):
-        # Speed up FFT by padding to optimal size
-        fshape = [sp_fft.next_fast_len(shape[a]) for a in axes]
-        fslice = tuple([slice(sz) for sz in shape])
         if not complex_result:
             fft, ifft = sp_fft.rfftn, sp_fft.irfftn
+            kind = 'R2C'
         else:
             fft, ifft = sp_fft.fftn, sp_fft.ifftn
+            kind = 'C2C'
+
+        # Speed up FFT by padding to optimal size
+        fshape = [sp_fft.next_fast_len(shape[a], kind) for a in axes]
+        fslice = tuple([slice(sz) for sz in shape])
         sp1 = fft(in1, fshape, axes=axes)
         sp2 = fft(in2, fshape, axes=axes)
         ret = ifft(sp1 * sp2, fshape, axes=axes)[fslice].copy()


### PR DESCRIPTION
#### Reference issue
This completes the `TODO` in `scipy.fft.next_fast_len`
https://github.com/scipy/scipy/blob/9f7ca1ed7be17a7d1dd211722c5cc1eca33bcec0/scipy/fft/_helper.py#L115

#### What does this implement/fix?
`next_fast_len` now returns 11-smooth numbers by default with the argument `type: {'C2C', 'R2C', 'C2R'}` added to cover real transforms that are only fast for 5-smooth numbers. Additionally, the search algorithm is implemented in the C++ code making it ~5x faster for small sizes and significantly faster for sizes that were not in the lookup table before.

I have also slightly loosened the guarantees made by the the docstring since @mreineck has pointed out that the smallest n-smooth number isn't always actually fastest. The different codelets can have different performance costs and so in future it might be possible to find faster lengths.
(See https://gitlab.mpcdf.mpg.de/mtr/pypocketfft/merge_requests/18)

#### Additional information
We previously discussed having a `dtype` parameter but this is not sufficient because `irfft` has a complex input but is still a real transform.

Question: This retains the old python search code for cases where the c++ code may overflow a `size_t`. Is this worth while or would it be better to just raise an error?