### PR TITLE
BUG: Fix query_ball_point with discontiguous input

### DIFF
--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -923,11 +923,11 @@ cdef class cKDTree:
             result = np.empty(retshape, dtype=object)
             vout = result.reshape(-1)
 
-        vxx = np.reshape(x, (-1, x.shape[-1]))
-        vrr = np.reshape(r, (-1))
+        vxx = np.ascontiguousarray(x).reshape(-1, x.shape[-1])
+        vrr = np.ascontiguousarray(r).reshape(-1)
 
         def _thread_func(np.intp_t start, np.intp_t stop):
-            cdef: 
+            cdef:
                 vector[np.intp_t] **vvres
                 np.intp_t i
                 np.intp_t *cur

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -1389,6 +1389,34 @@ def test_query_ball_point_length():
     assert_array_equal(length, length3)
     assert_array_equal(length, length4)
 
+def test_discontiguous():
+
+    np.random.seed(1234)
+    data = np.random.normal(size=(100, 3))
+    d_contiguous = np.arange(100) * 0.04
+    d_discontiguous = np.ascontiguousarray(
+                          np.arange(100)[::-1] * 0.04)[::-1]
+    query_contiguous = np.random.normal(size=(100, 3))
+    query_discontiguous = np.ascontiguousarray(query_contiguous.T).T
+    assert query_discontiguous.strides[-1] != query_contiguous.strides[-1]
+    assert d_discontiguous.strides[-1] != d_contiguous.strides[-1]
+
+    tree = cKDTree(data)
+
+    length1 = tree.query_ball_point(query_contiguous,
+                                    d_contiguous, return_length=True)
+    length2 = tree.query_ball_point(query_discontiguous,
+                                    d_discontiguous, return_length=True)
+
+    assert_array_equal(length1, length2)
+
+    d1, i1 = tree.query(query_contiguous, 1)
+    d2, i2 = tree.query(query_discontiguous, 1)
+
+    assert_array_equal(d1, d2)
+    assert_array_equal(i1, i2)
+
+
 @pytest.mark.parametrize("balanced_tree, compact_nodes",
     [(True, False),
      (True, True),


### PR DESCRIPTION
#### Reference issue

Closes gh-10572

#### What does this implement/fix?
This PR fixes discontiguous input to ckdtree's query_ball_point method.

#### Additional information
Regression due to #9915.

I kept it as two commits to ease validation. The test case fails without the fix.