### PR TITLE
ENH: convenience function for rotation magnitudes

### DIFF
--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -210,6 +210,7 @@ class Rotation(object):
     apply
     __mul__
     inv
+    magnitude
     __getitem__
     random
     match_vectors
@@ -1427,6 +1428,38 @@ class Rotation(object):
         if self._single:
             quat = quat[0]
         return self.__class__(quat, normalized=True, copy=False)
+
+    def magnitude(self):
+        """Get the magnitude(s) of the rotation(s).
+
+        Returns
+        -------
+        magnitude : ndarray or float
+            Angle(s) in radians, float if object contains a single rotation
+            and ndarray if object contains multiple rotations.
+
+        Examples
+        --------
+        >>> from scipy.spatial.transform import Rotation as R
+        >>> r = R.from_quat(np.eye(4))
+        >>> r.magnitude()
+        array([3.14159265, 3.14159265, 3.14159265, 0.        ])
+
+        Magnitude of a single rotation:
+
+        >>> r[0].magnitude()
+        3.141592653589793
+        """
+
+        quat = self._quat.reshape((len(self), 4))
+        s = np.linalg.norm(quat[:, :3], axis=1)
+        c = np.abs(quat[:, 3])
+        angles = 2 * np.arctan2(s, c)
+
+        if self._single:
+            return angles[0]
+        else:
+            return angles
 
     def __getitem__(self, indexer):
         """Extract rotation(s) at given index(es) from object.

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -621,6 +621,25 @@ def test_inv_single_rotation():
     assert_array_almost_equal(result2, eye3d)
 
 
+def test_magnitude():
+    r = Rotation.from_quat(np.eye(4))
+    result = r.magnitude()
+    assert_array_almost_equal(result, [np.pi, np.pi, np.pi, 0])
+
+    r = Rotation.from_quat(-np.eye(4))
+    result = r.magnitude()
+    assert_array_almost_equal(result, [np.pi, np.pi, np.pi, 0])
+
+
+def test_magnitude_single_rotation():
+    r = Rotation.from_quat(np.eye(4))
+    result1 = r[0].magnitude()
+    assert_allclose(result1, np.pi)
+
+    result2 = r[3].magnitude()
+    assert_allclose(result2, 0)
+
+
 def test_apply_single_rotation_single_point():
     dcm = np.array([
         [0, -1, 0],


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### What does this implement/fix?
<!--Please explain your changes.-->
This implements a convenience function for calculating the magnitude of a rotation:
`p.magnitude()`

Using the existing code to get the magnitudes is more verbose.
```
if len(p) == 1:
    magnitude = np.linalg.norm(p.as_rotvec())
else:
    magnitude = np.linalg.norm(p.as_rotvec(), axis=1)
```

Suggestions for a better function name are very welcome.