### PR TITLE
DOC: remove release note update from PR checklist

### DIFF
--- a/doc/source/dev/contributor/development_workflow.rst
+++ b/doc/source/dev/contributor/development_workflow.rst
@@ -274,8 +274,6 @@ Checklist before submitting a PR
 -  Is the code style correct? See :ref:`pep8-scipy`.
 -  Are there benchmarks? See :ref:`benchmarking-with-asv`.
 -  Is the commit message `formatted correctly`_?
--  Is the new functionality mentioned in the release notes of the next
-   release? An editable draft of the most recent notes is on `the wiki`_.
 -  Is the docstring of the new functionality tagged with
    ``.. versionadded:: X.Y.Z`` (where ``X.Y.Z`` is the version number of the
    next release? See the ``updating``, ``workers``, and ``constraints``


### PR DESCRIPTION
The documentation had as a point on its checklist for actions "before submitting" a PR that the contents should be added to the release notes, with a reference to the wiki. However, [the wiki page itself](https://github.com/scipy/scipy/wiki/Release-note-entries-for-SciPy-1.4.0) states that the addition should happen only after the PR gets merged (which of course makes more sense). The Core Developer Guide [already states](https://scipy.github.io/devdocs/dev/core-dev/index.html#release-notes) that release notes should be updated on merge, so no change is necessary there.