### PR TITLE
BUG: multidimensional scipy.fft functions should accept 's' rather than 'shape'

### DIFF
--- a/scipy/fft/_pocketfft/basic.py
+++ b/scipy/fft/_pocketfft/basic.py
@@ -90,55 +90,55 @@ irfft = functools.partial(c2r, False)
 irfft.__name__ = 'irfft'
 
 
-def fft2(x, shape=None, axes=(-2,-1), norm=None, overwrite_x=False):
+def fft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False):
     """
     2-D discrete Fourier transform.
     """
-    return fftn(x, shape, axes, norm, overwrite_x)
+    return fftn(x, s, axes, norm, overwrite_x)
 
 
-def ifft2(x, shape=None, axes=(-2,-1), norm=None, overwrite_x=False):
+def ifft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False):
     """
     2-D discrete inverse Fourier transform of real or complex sequence.
     """
-    return ifftn(x, shape, axes, norm, overwrite_x)
+    return ifftn(x, s, axes, norm, overwrite_x)
 
 
-def rfft2(x, shape=None, axes=(-2,-1), norm=None, overwrite_x=False):
+def rfft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False):
     """
     2-D discrete Fourier transform of a real sequence
     """
-    return rfftn(x, shape, axes, norm, overwrite_x)
+    return rfftn(x, s, axes, norm, overwrite_x)
 
 
-def irfft2(x, shape=None, axes=(-2,-1), norm=None, overwrite_x=False):
+def irfft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False):
     """
     2-D discrete inverse Fourier transform of a real sequence
     """
-    return irfftn(x, shape, axes, norm, overwrite_x)
+    return irfftn(x, s, axes, norm, overwrite_x)
 
 
-def hfft2(x, shape=None, axes=(-2,-1), norm=None, overwrite_x=False):
+def hfft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False):
     """
     2-D discrete Fourier transform of a Hermitian sequence
     """
-    return hfftn(x, shape, axes, norm, overwrite_x)
+    return hfftn(x, s, axes, norm, overwrite_x)
 
 
-def ihfft2(x, shape=None, axes=(-2,-1), norm=None, overwrite_x=False):
+def ihfft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False):
     """
     2-D discrete inverse Fourier transform of a Hermitian sequence
     """
-    return ihfftn(x, shape, axes, norm, overwrite_x)
+    return ihfftn(x, s, axes, norm, overwrite_x)
 
 
-def c2cn(forward, x, shape=None, axes=None, norm=None, overwrite_x=False):
+def c2cn(forward, x, s=None, axes=None, norm=None, overwrite_x=False):
     """
     Return multidimensional discrete Fourier transform.
     """
     tmp = _asfarray(x)
 
-    shape, axes = _init_nd_shape_and_axes(tmp, shape, axes)
+    shape, axes = _init_nd_shape_and_axes(tmp, s, axes)
     overwrite_x = overwrite_x or _datacopied(tmp, x)
 
     if len(axes) == 0:
@@ -158,14 +158,14 @@ fftn.__name__ = 'fftn'
 ifftn = functools.partial(c2cn, False)
 ifftn.__name__ = 'ifftn'
 
-def r2cn(forward, x, shape=None, axes=None, norm=None, overwrite_x=False):
+def r2cn(forward, x, s=None, axes=None, norm=None, overwrite_x=False):
     """Return multi-dimensional discrete Fourier transform of real input"""
     tmp = _asfarray(x)
 
     if not np.isrealobj(tmp):
         raise TypeError("x must be a real sequence")
 
-    shape, axes = _init_nd_shape_and_axes(tmp, shape, axes)
+    shape, axes = _init_nd_shape_and_axes(tmp, s, axes)
     tmp, _ = _fix_shape(tmp, shape, axes)
     norm = _normalization(norm, forward)
 
@@ -182,7 +182,7 @@ ihfftn = functools.partial(r2cn, False)
 ihfftn.__name__ = 'ihfftn'
 
 
-def c2rn(forward, x, shape=None, axes=None, norm=None, overwrite_x=False):
+def c2rn(forward, x, s=None, axes=None, norm=None, overwrite_x=False):
     """Multi-dimensional inverse discrete fourier transform with real output"""
     tmp = _asfarray(x)
 
@@ -190,8 +190,8 @@ def c2rn(forward, x, shape=None, axes=None, norm=None, overwrite_x=False):
     if np.isrealobj(tmp):
         tmp = tmp + 0.j
 
-    noshape = shape is None
-    shape, axes = _init_nd_shape_and_axes(tmp, shape, axes)
+    noshape = s is None
+    shape, axes = _init_nd_shape_and_axes(tmp, s, axes)
 
     if len(axes) == 0:
         raise ValueError("at least 1 axis must be transformed")

--- a/scipy/fft/_pocketfft/realtransforms.py
+++ b/scipy/fft/_pocketfft/realtransforms.py
@@ -57,7 +57,7 @@ idst = functools.partial(_r2r, False, pfft.dst)
 idst.__name__ = 'idst'
 
 
-def _r2rn(forward, transform, x, type=2, shape=None, axes=None, norm=None,
+def _r2rn(forward, transform, x, type=2, s=None, axes=None, norm=None,
           overwrite_x=False):
     """Forward or backward nd DCT/DST
 
@@ -70,7 +70,7 @@ def _r2rn(forward, transform, x, type=2, shape=None, axes=None, norm=None,
     """
     tmp = _asfarray(x)
 
-    shape, axes = _init_nd_shape_and_axes(tmp, shape, axes)
+    shape, axes = _init_nd_shape_and_axes(tmp, s, axes)
     overwrite_x = overwrite_x or _datacopied(tmp, x)
 
     if len(axes) == 0:

--- a/scipy/fft/_pocketfft/tests/test_basic.py
+++ b/scipy/fft/_pocketfft/tests/test_basic.py
@@ -470,7 +470,7 @@ class Testfft2(object):
         # fftn (and hence fft2) used to break when both axes and shape were
         # used
         x = numpy.ones((4, 4, 2))
-        y = fft2(x, shape=(8, 8), axes=(-3, -2))
+        y = fft2(x, s=(8, 8), axes=(-3, -2))
         y_r = numpy.fft.fftn(x, s=(8, 8), axes=(-3, -2))
         assert_array_almost_equal(y, y_r)
 
@@ -699,10 +699,10 @@ class TestFftn(object):
                     [0, 0, 0, 0],
                     [0, 0, 0, 0]]
 
-        y = fftn(small_x, shape=(4, 4))
+        y = fftn(small_x, s=(4, 4))
         assert_array_almost_equal(y, fftn(large_x1))
 
-        y = fftn(small_x, shape=(3, 4))
+        y = fftn(small_x, s=(3, 4))
         assert_array_almost_equal(y, fftn(large_x1[:-1]))
 
     def test_shape_axes_argument(self):
@@ -713,9 +713,9 @@ class TestFftn(object):
                           [4, 5, 6, 0],
                           [7, 8, 9, 0],
                           [0, 0, 0, 0]])
-        y = fftn(small_x, shape=(4, 4), axes=(-2, -1))
+        y = fftn(small_x, s=(4, 4), axes=(-2, -1))
         assert_array_almost_equal(y, fftn(large_x1))
-        y = fftn(small_x, shape=(4, 4), axes=(-1, -2))
+        y = fftn(small_x, s=(4, 4), axes=(-1, -2))
 
         assert_array_almost_equal(y, swapaxes(
             fftn(swapaxes(large_x1, -1, -2)), -1, -2))
@@ -723,17 +723,17 @@ class TestFftn(object):
     def test_shape_axes_argument2(self):
         # Change shape of the last axis
         x = numpy.random.random((10, 5, 3, 7))
-        y = fftn(x, axes=(-1,), shape=(8,))
+        y = fftn(x, axes=(-1,), s=(8,))
         assert_array_almost_equal(y, fft(x, axis=-1, n=8))
 
         # Change shape of an arbitrary axis which is not the last one
         x = numpy.random.random((10, 5, 3, 7))
-        y = fftn(x, axes=(-2,), shape=(8,))
+        y = fftn(x, axes=(-2,), s=(8,))
         assert_array_almost_equal(y, fft(x, axis=-2, n=8))
 
         # Change shape of axes: cf #244, where shape and axes were mixed up
         x = numpy.random.random((4, 4, 2))
-        y = fftn(x, axes=(-3, -2), shape=(8, 8))
+        y = fftn(x, axes=(-3, -2), s=(8, 8))
         assert_array_almost_equal(y,
                                   numpy.fft.fftn(x, axes=(-3, -2), s=(8, 8)))
 
@@ -742,7 +742,7 @@ class TestFftn(object):
         with assert_raises(ValueError,
                            match="when given, axes and shape arguments"
                            " have to be of the same length"):
-            fftn(x, shape=(8, 8, 2, 1))
+            fftn(x, s=(8, 8, 2, 1))
 
     def test_invalid_sizes(self):
         with assert_raises(ValueError,

--- a/scipy/fft/_pocketfft/tests/test_real_transforms.py
+++ b/scipy/fft/_pocketfft/tests/test_real_transforms.py
@@ -788,21 +788,21 @@ class Test_DCTN_IDCTN(object):
         with assert_raises(ValueError,
                            match="when given, axes and shape arguments"
                            " have to be of the same length"):
-            fforward(self.data, shape=self.data.shape[0], axes=(0, 1))
+            fforward(self.data, s=self.data.shape[0], axes=(0, 1))
 
         with assert_raises(ValueError,
                            match="when given, axes and shape arguments"
                            " have to be of the same length"):
-            fforward(self.data, shape=self.data.shape[0], axes=None)
+            fforward(self.data, s=self.data.shape[0], axes=None)
 
         with assert_raises(ValueError,
                            match="when given, axes and shape arguments"
                            " have to be of the same length"):
-            fforward(self.data, shape=self.data.shape, axes=0)
+            fforward(self.data, s=self.data.shape, axes=0)
 
     @pytest.mark.parametrize('fforward', [dctn, dstn])
     def test_shape(self, fforward):
-        tmp = fforward(self.data, shape=(128, 128), axes=None)
+        tmp = fforward(self.data, s=(128, 128), axes=None)
         assert_equal(tmp.shape, (128, 128))
 
     @pytest.mark.parametrize('fforward,finverse', [(dctn, idctn),
@@ -810,6 +810,6 @@ class Test_DCTN_IDCTN(object):
     @pytest.mark.parametrize('axes', [1, (1,), [1],
                                       0, (0,), [0]])
     def test_shape_is_none_with_axes(self, fforward, finverse, axes):
-        tmp = fforward(self.data, shape=None, axes=axes, norm='ortho')
-        tmp = finverse(tmp, shape=None, axes=axes, norm='ortho')
+        tmp = fforward(self.data, s=None, axes=axes, norm='ortho')
+        tmp = finverse(tmp, s=None, axes=axes, norm='ortho')
         assert_array_almost_equal(self.data, tmp, decimal=self.dec)

--- a/scipy/fft/tests/test_numpy.py
+++ b/scipy/fft/tests/test_numpy.py
@@ -171,6 +171,24 @@ class TestFFT1D(object):
             tr_op = np.transpose(op(x, axes=a), a)
             assert_array_almost_equal(op_tr, tr_op)
 
+    @pytest.mark.parametrize("op", [fft.fft2, fft.ifft2,
+                                    fft.rfft2, fft.irfft2,
+                                    fft.hfft2, fft.ihfft2,
+                                    fft.fftn, fft.ifftn,
+                                    fft.rfftn, fft.irfftn,
+                                    fft.hfftn, fft.ihfftn])
+    def test_axes_subset_with_shape(self, op):
+        x = random((16, 8, 4))
+        axes = [(0, 1, 2), (0, 2, 1), (1, 2, 0)]
+        for a in axes:
+            # different shape on the first two axes
+            shape = tuple([2*x.shape[ax] if ax in a[:2] else x.shape[ax]
+                           for ax in range(x.ndim)])
+            # transform only the first two axes
+            op_tr = op(np.transpose(x, a), s=shape[:2], axes=(0, 1))
+            tr_op = np.transpose(op(x, s=shape[:2], axes=a[:2]), a)
+            assert_array_almost_equal(op_tr, tr_op)
+
     def test_all_1d_norm_preserving(self):
         # verify that round-trip transforms are norm-preserving
         x = random(30)


### PR DESCRIPTION

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
None

#### What does this implement/fix?
There is a bug when trying to specify argument `s` within the multidimensional FFT functions in `scipy.fft`

to reproduce:
```Python
import numpy as np
from scipy.fft import fftn
fftn(np.ones((256, 256, 8)), s=(512, 512), axes=(0, 1))
```
gives
```TypeError: c2cn() got an unexpected keyword argument 's'```

Using `shape` instead of `s` works, but that contradicts both the docstring and the `numpy.fft` API, so I assumed using `s` is the desired solution.

The cause appears to be a mistake in variable naming for the internal pypocketfft-related functions such as `c2cn`.  I think this was not caught in part because the `scipy.fftpack` tests pass the shape argument positionally. I extended `test_numpy.py` to add cases using `s=` explicitly.

#### Additional information
<!--Any additional information you think is important.-->