### PR TITLE
BUG: integrate/lsoda: never abort run, set error istate instead

### DIFF
--- a/scipy/integrate/odepack.py
+++ b/scipy/integrate/odepack.py
@@ -21,7 +21,8 @@ _msgs = {2: "Integration successful.",
          -4: "Repeated error test failures (internal error).",
          -5: "Repeated convergence failures (perhaps bad Jacobian or tolerances).",
          -6: "Error weight became zero during problem.",
-         -7: "Internal workspace insufficient to finish (internal error)."
+         -7: "Internal workspace insufficient to finish (internal error).",
+         -8: "Run terminated (internal error)."
          }
 
 

--- a/scipy/integrate/odepack/lsoda.f
+++ b/scipy/integrate/odepack/lsoda.f
@@ -1648,8 +1648,7 @@ c
  710  call xerrwv('lsoda--  repeated occurrences of illegal input    ',
      1   50, 302, 0, 0, 0, 0, 0, 0.0d0, 0.0d0)
 c
- 800  call xerrwv('lsoda--  run aborted.. apparent infinite loop     ',
-     1   50, 303, 2, 0, 0, 0, 0, 0.0d0, 0.0d0)
+ 800  istate = -8
       return
 c----------------------- end of subroutine lsoda -----------------------
       end


### PR DESCRIPTION
Make LSODA never call Fortran 'stop', which occurs on xerrwv level (4th
argument) being 2. Instead, set error istate and continue, and leave
error handling to Python code.

I don't know a case where this condition is triggered; checked that it
works by reverting the fix in gh-8822 so that the test case there
can be used. gh-8822 does not fix the general case, so address it here.

See gh-8217

Supersedes #8225