### PR TITLE
ENH: Add an option to specify the FFT size in SciPy.signal.fftconvolve

### DIFF
--- a/scipy/fft/_helper.py
+++ b/scipy/fft/_helper.py
@@ -63,7 +63,7 @@ def next_fast_len(target, kind='C2C'):
     return _helper.next_fast_len(target, kind)
 
 
-def _init_nd_shape_and_axes(x, shape, axes):
+def _init_nd_shape_and_axes(x, shape, axes, keep_neg1=False):
     """Handle shape and axes arguments for n-dimensional transforms.
 
     Returns the shape and axes in a standard form, taking into account negative
@@ -78,12 +78,16 @@ def _init_nd_shape_and_axes(x, shape, axes):
         None, `shape` is ``x.shape``; if `shape` is None but `axes` is
         not None, then `shape` is ``scipy.take(x.shape, axes, axis=0)``.
         If `shape` is -1, the size of the corresponding dimension of `x` is
-        used.
+        used if `keep_neg` is `False`, otherwise it is kept as-is.
     axes : int or array_like of ints or None
         Axes along which the calculation is computed.
         The default is over all axes.
         Negative indices are automatically converted to their positive
         counterpart.
+    keep_neg1 : bool, optional
+        If `False` (default), `shape` values of `-1` are converted to
+        ``scipy.take(x.shape, axes, axis=0)``.
+        If `True`, they are kept as `-1`.
 
     Returns
     -------
@@ -93,4 +97,4 @@ def _init_nd_shape_and_axes(x, shape, axes):
         The shape of the result. It is a 1D integer array.
 
     """
-    return _helper._init_nd_shape_and_axes(x, shape, axes)
+    return _helper._init_nd_shape_and_axes(x, shape, axes, keep_neg1=keep_neg1)

--- a/scipy/fft/_pocketfft/helper.py
+++ b/scipy/fft/_pocketfft/helper.py
@@ -36,7 +36,7 @@ def _iterable_of_int(x, name=None):
     return x
 
 
-def _init_nd_shape_and_axes(x, shape, axes):
+def _init_nd_shape_and_axes(x, shape, axes, keep_neg1=False):
     """Handles shape and axes arguments for nd transforms"""
     noshape = shape is None
     noaxes = axes is None
@@ -59,13 +59,15 @@ def _init_nd_shape_and_axes(x, shape, axes):
             raise ValueError("when given, axes and shape arguments"
                              " have to be of the same length")
 
-        shape = [x.shape[a] if s == -1 else s for s, a in zip(shape, axes)]
+        if not keep_neg1:
+            shape = [x.shape[a] if s == -1 else s for s, a in
+                     zip(shape, axes)]
     elif noaxes:
         shape = list(x.shape)
     else:
         shape = [x.shape[a] for a in axes]
 
-    if any(s < 1 for s in shape):
+    if not all(s > 0 or (keep_neg1 and s == -1) for s in shape):
         raise ValueError(
             "invalid number of data points ({0}) specified".format(shape))
 

--- a/scipy/fft/tests/test_helper.py
+++ b/scipy/fft/tests/test_helper.py
@@ -218,6 +218,34 @@ class Test_init_nd_shape_and_axes(object):
         assert_equal(shape_res, shape_expected)
         assert_equal(axes_res, axes_expected)
 
+    def test_np_5d_set_shape_nokeep(self):
+        x = np.zeros([6, 2, 5, 3, 4])
+        shape = [10, -1, -1, 1, 4]
+        axes = None
+
+        shape_expected = np.array([10, 2, 5, 1, 4])
+        axes_expected = np.array([0, 1, 2, 3, 4])
+
+        shape_res, axes_res = _init_nd_shape_and_axes(x, shape,
+                                                      axes, False)
+
+        assert_equal(shape_res, shape_expected)
+        assert_equal(axes_res, axes_expected)
+
+    def test_np_5d_set_shape_keep(self):
+        x = np.zeros([6, 2, 5, 3, 4])
+        shape = [10, -1, -1, 1, 4]
+        axes = None
+
+        shape_expected = np.array([10, -1, -1, 1, 4])
+        axes_expected = np.array([0, 1, 2, 3, 4])
+
+        shape_res, axes_res = _init_nd_shape_and_axes(x, shape,
+                                                      axes, True)
+
+        assert_equal(shape_res, shape_expected)
+        assert_equal(axes_res, axes_expected)
+
     def test_np_5d_set_axes(self):
         x = np.zeros([6, 2, 5, 3, 4])
         shape = None
@@ -240,6 +268,33 @@ class Test_init_nd_shape_and_axes(object):
         axes_expected = np.array([1, 0, 3])
 
         shape_res, axes_res = _init_nd_shape_and_axes(x, shape, axes)
+
+        assert_equal(shape_res, shape_expected)
+        assert_equal(axes_res, axes_expected)
+
+    def test_np_5d_set_shape_axes_nokeep(self):
+        x = np.zeros([6, 2, 5, 3, 4])
+        shape = [10, -1, 2]
+        axes = [1, 0, 3]
+
+        shape_expected = np.array([10, 6, 2])
+        axes_expected = np.array([1, 0, 3])
+
+        shape_res, axes_res = _init_nd_shape_and_axes(x, shape,
+                                                      axes, False)
+
+        assert_equal(shape_res, shape_expected)
+        assert_equal(axes_res, axes_expected)
+
+    def test_np_5d_set_shape_axes_keep(self):
+        x = np.zeros([6, 2, 5, 3, 4])
+        shape = [10, -1, 2]
+        axes = [1, 0, 3]
+
+        shape_expected = np.array([10, -1, 2])
+        axes_expected = np.array([1, 0, 3])
+
+        shape_res, axes_res = _init_nd_shape_and_axes(x, shape, axes, True)
 
         assert_equal(shape_res, shape_expected)
         assert_equal(axes_res, axes_expected)

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -414,14 +414,19 @@ class TestConvolve2d(_TestConvolve2d):
 class TestFFTConvolve(object):
 
     @pytest.mark.parametrize('axes', ['', None, 0, [0], -1, [-1]])
-    def test_real(self, axes):
+    @pytest.mark.parametrize('fshape', ['', None, 7, [7], 20, [20], -1, [-1]])
+    def test_real(self, axes, fshape):
         a = array([1, 2, 3])
         expected = array([1, 4, 10, 12, 9.])
 
-        if axes == '':
+        if axes == '' and fshape == '':
             out = fftconvolve(a, a)
-        else:
+        elif axes == '':
+            out = fftconvolve(a, a, fshape=fshape)
+        elif fshape == '':
             out = fftconvolve(a, a, axes=axes)
+        else:
+            out = fftconvolve(a, a, axes=axes, fshape=fshape)
 
         assert_array_almost_equal(out, expected)
 
@@ -437,14 +442,20 @@ class TestFFTConvolve(object):
         assert_array_almost_equal(out, expected)
 
     @pytest.mark.parametrize('axes', ['', None, 0, [0], -1, [-1]])
-    def test_complex(self, axes):
+    @pytest.mark.parametrize('fshape', ['', None, 7, [7], 20, [20], -1, [-1]])
+    def test_complex(self, axes, fshape):
         a = array([1 + 1j, 2 + 2j, 3 + 3j])
         expected = array([0 + 2j, 0 + 8j, 0 + 20j, 0 + 24j, 0 + 18j])
 
-        if axes == '':
+        if axes == '' and fshape == '':
             out = fftconvolve(a, a)
-        else:
+        elif axes == '':
+            out = fftconvolve(a, a, fshape=fshape)
+        elif fshape == '':
             out = fftconvolve(a, a, axes=axes)
+        else:
+            out = fftconvolve(a, a, axes=axes, fshape=fshape)
+
         assert_array_almost_equal(out, expected)
 
     @pytest.mark.parametrize('axes', [1, [1], -1, [-1]])
@@ -468,17 +479,33 @@ class TestFFTConvolve(object):
                                       [1, -2],
                                       [-2, -1],
                                       [-1, -2]])
-    def test_2d_real_same(self, axes):
+    @pytest.mark.parametrize('fshape', ['',
+                                        None,
+                                        [7, 7],
+                                        [20, 20],
+                                        [7, 20],
+                                        [20, 7],
+                                        [-1, -1],
+                                        [-1, 7],
+                                        [7, -1],
+                                        [-1, 20],
+                                        [20, -1]])
+    def test_2d_real_same(self, axes, fshape):
         a = array([[1, 2, 3],
                    [4, 5, 6]])
         expected = array([[1, 4, 10, 12, 9],
                           [8, 26, 56, 54, 36],
                           [16, 40, 73, 60, 36]])
 
-        if axes == '':
+        if axes == '' and fshape == '':
             out = fftconvolve(a, a)
-        else:
+        elif axes == '':
+            out = fftconvolve(a, a, fshape=fshape)
+        elif fshape == '':
             out = fftconvolve(a, a, axes=axes)
+        else:
+            out = fftconvolve(a, a, axes=axes, fshape=fshape)
+
         assert_array_almost_equal(out, expected)
 
     @pytest.mark.parametrize('axes', [[1, 2],
@@ -512,7 +539,18 @@ class TestFFTConvolve(object):
                                       [1, -2],
                                       [-2, -1],
                                       [-1, -2]])
-    def test_2d_complex_same(self, axes):
+    @pytest.mark.parametrize('fshape', ['',
+                                        None,
+                                        [7, 7],
+                                        [20, 20],
+                                        [7, 20],
+                                        [20, 7],
+                                        [-1, -1],
+                                        [-1, 7],
+                                        [7, -1],
+                                        [-1, 20],
+                                        [20, -1]])
+    def test_2d_complex_same(self, axes, fshape):
         a = array([[1 + 2j, 3 + 4j, 5 + 6j],
                    [2 + 1j, 4 + 3j, 6 + 5j]])
         expected = array([
@@ -521,10 +559,14 @@ class TestFFTConvolve(object):
             [3 + 4j, 10 + 20j, 21 + 56j, 18 + 76j, 11 + 60j]
             ])
 
-        if axes == '':
+        if axes == '' and fshape == '':
             out = fftconvolve(a, a)
-        else:
+        elif axes == '':
+            out = fftconvolve(a, a, fshape=fshape)
+        elif fshape == '':
             out = fftconvolve(a, a, axes=axes)
+        else:
+            out = fftconvolve(a, a, axes=axes, fshape=fshape)
 
         assert_array_almost_equal(out, expected)
 
@@ -552,23 +594,34 @@ class TestFFTConvolve(object):
         assert_array_almost_equal(out, expected)
 
     @pytest.mark.parametrize('axes', ['', None, 0, [0], -1, [-1]])
-    def test_real_same_mode(self, axes):
+    @pytest.mark.parametrize('fshape', ['', None,
+                                        11, [11], 20, [20], -1, [-1]])
+    def test_real_same_mode(self, axes, fshape):
         a = array([1, 2, 3])
         b = array([3, 3, 5, 6, 8, 7, 9, 0, 1])
         expected_1 = array([35., 41., 47.])
         expected_2 = array([9., 20., 25., 35., 41., 47., 39., 28., 2.])
 
-        if axes == '':
-            out = fftconvolve(a, b, 'same')
+        if axes == '' and fshape == '':
+            out_1 = fftconvolve(a, b, 'same')
+        elif axes == '':
+            out_1 = fftconvolve(a, b, 'same', fshape=fshape)
+        elif fshape == '':
+            out_1 = fftconvolve(a, b, 'same', axes=axes)
         else:
-            out = fftconvolve(a, b, 'same', axes=axes)
-        assert_array_almost_equal(out, expected_1)
+            out_1 = fftconvolve(a, b, 'same', axes=axes, fshape=fshape)
 
-        if axes == '':
-            out = fftconvolve(b, a, 'same')
+        if axes == '' and fshape == '':
+            out_2 = fftconvolve(b, a, 'same')
+        elif axes == '':
+            out_2 = fftconvolve(b, a, 'same', fshape=fshape)
+        elif fshape == '':
+            out_2 = fftconvolve(b, a, 'same', axes=axes)
         else:
-            out = fftconvolve(b, a, 'same', axes=axes)
-        assert_array_almost_equal(out, expected_2)
+            out_2 = fftconvolve(b, a, 'same', axes=axes, fshape=fshape)
+
+        assert_array_almost_equal(out_1, expected_1)
+        assert_array_almost_equal(out_2, expected_2)
 
     @pytest.mark.parametrize('axes', [1, -1, [1], [-1]])
     def test_real_same_mode_axes(self, axes):
@@ -589,23 +642,34 @@ class TestFFTConvolve(object):
         assert_array_almost_equal(out, expected_2)
 
     @pytest.mark.parametrize('axes', ['', None, 0, [0], -1, [-1]])
-    def test_valid_mode_real(self, axes):
+    @pytest.mark.parametrize('fshape', ['', None,
+                                        11, [11], 20, [20], -1, [-1]])
+    def test_valid_mode_real(self, axes, fshape):
         # See gh-5897
         a = array([3, 2, 1])
         b = array([3, 3, 5, 6, 8, 7, 9, 0, 1])
         expected = array([24., 31., 41., 43., 49., 25., 12.])
 
-        if axes == '':
-            out = fftconvolve(a, b, 'valid')
+        if axes == '' and fshape == '':
+            out_1 = fftconvolve(a, b, 'valid')
+        elif axes == '':
+            out_1 = fftconvolve(a, b, 'valid', fshape=fshape)
+        elif fshape == '':
+            out_1 = fftconvolve(a, b, 'valid', axes=axes)
         else:
-            out = fftconvolve(a, b, 'valid', axes=axes)
-        assert_array_almost_equal(out, expected)
+            out_1 = fftconvolve(a, b, 'valid', axes=axes, fshape=fshape)
 
-        if axes == '':
-            out = fftconvolve(b, a, 'valid')
+        if axes == '' and fshape == '':
+            out_2 = fftconvolve(b, a, 'valid')
+        elif axes == '':
+            out_2 = fftconvolve(b, a, 'valid', fshape=fshape)
+        elif fshape == '':
+            out_2 = fftconvolve(b, a, 'valid', axes=axes)
         else:
-            out = fftconvolve(b, a, 'valid', axes=axes)
-        assert_array_almost_equal(out, expected)
+            out_2 = fftconvolve(b, a, 'valid', axes=axes, fshape=fshape)
+
+        assert_array_almost_equal(out_1, expected)
+        assert_array_almost_equal(out_2, expected)
 
     @pytest.mark.parametrize('axes', [1, [1]])
     def test_valid_mode_real_axes(self, axes):
@@ -622,22 +686,32 @@ class TestFFTConvolve(object):
         assert_array_almost_equal(out, expected)
 
     @pytest.mark.parametrize('axes', ['', None, 0, [0], -1, [-1]])
-    def test_valid_mode_complex(self, axes):
+    @pytest.mark.parametrize('fshape', ['', None, 7, [7], 20, [20], -1, [-1]])
+    def test_valid_mode_complex(self, axes, fshape):
         a = array([3 - 1j, 2 + 7j, 1 + 0j])
         b = array([3 + 2j, 3 - 3j, 5 + 0j, 6 - 1j, 8 + 0j])
         expected = array([45. + 12.j, 30. + 23.j, 48 + 32.j])
 
-        if axes == '':
-            out = fftconvolve(a, b, 'valid')
+        if axes == '' and fshape == '':
+            out_1 = fftconvolve(a, b, 'valid')
+        elif axes == '':
+            out_1 = fftconvolve(a, b, 'valid', fshape=fshape)
+        elif fshape == '':
+            out_1 = fftconvolve(a, b, 'valid', axes=axes)
         else:
-            out = fftconvolve(a, b, 'valid', axes=axes)
-        assert_array_almost_equal(out, expected)
+            out_1 = fftconvolve(a, b, 'valid', axes=axes, fshape=fshape)
 
-        if axes == '':
-            out = fftconvolve(b, a, 'valid')
+        if axes == '' and fshape == '':
+            out_2 = fftconvolve(b, a, 'valid')
+        elif axes == '':
+            out_2 = fftconvolve(b, a, 'valid', fshape=fshape)
+        elif fshape == '':
+            out_2 = fftconvolve(b, a, 'valid', axes=axes)
         else:
-            out = fftconvolve(b, a, 'valid', axes=axes)
-        assert_array_almost_equal(out, expected)
+            out_2 = fftconvolve(b, a, 'valid', axes=axes, fshape=fshape)
+
+        assert_array_almost_equal(out_1, expected)
+        assert_array_almost_equal(out_2, expected)
 
     @pytest.mark.parametrize('axes', [1, [1], -1, [-1]])
     def test_valid_mode_complex_axes(self, axes):
@@ -674,17 +748,34 @@ class TestFFTConvolve(object):
         assert_equal(out, a * b)
 
     @pytest.mark.parametrize('axes', ['', None, 0, [0], -1, [-1]])
-    def test_random_data(self, axes):
+    @pytest.mark.parametrize('fshape', ['', None,
+                                        2553, [2553], 2592, [2592], -1, [-1]])
+    def test_random_data(self, axes, fshape):
         np.random.seed(1234)
         a = np.random.rand(1233) + 1j * np.random.rand(1233)
         b = np.random.rand(1321) + 1j * np.random.rand(1321)
         expected = np.convolve(a, b, 'full')
 
-        if axes == '':
-            out = fftconvolve(a, b, 'full')
+        if axes == '' and fshape == '':
+            out_1 = fftconvolve(a, b, 'full')
+        elif axes == '':
+            out_1 = fftconvolve(a, b, 'full', fshape=fshape)
+        elif fshape == '':
+            out_1 = fftconvolve(a, b, 'full', axes=axes)
         else:
-            out = fftconvolve(a, b, 'full', axes=axes)
-        assert_(np.allclose(out, expected, rtol=1e-10))
+            out_1 = fftconvolve(a, b, 'full', axes=axes, fshape=fshape)
+
+        if axes == '' and fshape == '':
+            out_2 = fftconvolve(b, a, 'full')
+        elif axes == '':
+            out_2 = fftconvolve(b, a, 'full', fshape=fshape)
+        elif fshape == '':
+            out_2 = fftconvolve(b, a, 'full', axes=axes)
+        else:
+            out_2 = fftconvolve(b, a, 'full', axes=axes, fshape=fshape)
+
+        assert_(np.allclose(out_1, expected, rtol=1e-10))
+        assert_(np.allclose(out_2, expected, rtol=1e-10))
 
     @pytest.mark.parametrize('axes', [1, [1], -1, [-1]])
     def test_random_data_axes(self, axes):
@@ -764,6 +855,14 @@ class TestFFTConvolve(object):
                            r" \(5L?, 6L?, 2L?, 1L?\) and"
                            r" \(5L?, 6L?, 3L?, 1L?\)"):
             fftconvolve(a, b, axes=[0, 1])
+
+    def test_invalid_shapes_fshape(self):
+        a = np.zeros([5, 6, 2, 1])
+        b = np.zeros([5, 6, 3, 1])
+        with assert_raises(ValueError,
+                           match=r"fshape must be at least as large as"
+                           " the convolved size"):
+            fftconvolve(a, b, fshape=[2, 15, 15, 15])
 
     @pytest.mark.parametrize('a,b',
                              [([1], 2),


### PR DESCRIPTION
This add an `fshape` argument to ``SciPy.signal.fftconvolve``.
This allows the user to override the automatically-calculated FFT
shape, as they can with most FFT-related function.