### PR TITLE
ENH: Add an env variable SCIPY_USE_G77_ABI_WRAPPER

### DIFF
--- a/doc/source/building/linux.rst
+++ b/doc/source/building/linux.rst
@@ -186,3 +186,18 @@ If you build NumPy for ia32 bit platforms:
 ::
 
    $export LD_LIBRARY_PATH=/opt/intel/composer_xe_2013/mkl/lib/ia32: /opt/intel/composer_xe_2013/compiler/lib/ia32:$LD_LIBRARY_PATH
+
+
+====================
+Fortran ABI mismatch
+====================
+
+Some linear algebra libraries are built with G77 ABI and others with GFortran ABI and these two ABIs are incompatible.
+Therefore if you build scipy with `gfortran` and link to a linear algebra library like MKL which is built with G77 ABI
+then there'll be an exception or a segfault. SciPy fixes this by using the CBLAS API for the few functions in the
+BLAS API that suffers from this issue.
+
+Note that SciPy needs to know at build time, what needs to be done and the build system will automatically check
+whether linear algebra library is MKL and if so use the CBLAS API instead of the BLAS API. If autodetection fails or
+if the user wants to override this autodetection mechanism, setting the environment variable `SCIPY_USE_G77_ABI_WRAPPER`
+to 0 or 1 to disable or enable using CBLAS API.

--- a/doc/source/building/linux.rst
+++ b/doc/source/building/linux.rst
@@ -192,12 +192,17 @@ If you build NumPy for ia32 bit platforms:
 Fortran ABI mismatch
 ====================
 
-Some linear algebra libraries are built with G77 ABI and others with GFortran ABI and these two ABIs are incompatible.
-Therefore if you build scipy with `gfortran` and link to a linear algebra library like MKL which is built with G77 ABI
-then there'll be an exception or a segfault. SciPy fixes this by using the CBLAS API for the few functions in the
-BLAS API that suffers from this issue.
+Some linear algebra libraries are built with G77 ABI and others with
+GFortran ABI and these two ABIs are incompatible. Therefore if you
+build scipy with `gfortran` and link to a linear algebra library like
+MKL which is built with G77 ABI then there'll be an exception or a
+segfault. SciPy fixes this by using the CBLAS API for the few
+functions in the BLAS API that suffers from this issue.
 
-Note that SciPy needs to know at build time, what needs to be done and the build system will automatically check
-whether linear algebra library is MKL and if so use the CBLAS API instead of the BLAS API. If autodetection fails or
-if the user wants to override this autodetection mechanism, setting the environment variable `SCIPY_USE_G77_ABI_WRAPPER`
-to 0 or 1 to disable or enable using CBLAS API.
+Note that SciPy needs to know at build time, what needs to be done and
+the build system will automatically check whether linear algebra
+library is MKL and if so use the CBLAS API instead of the BLAS API.
+If autodetection fails or if the user wants to override this
+autodetection mechanism, setting the environment variable
+`SCIPY_USE_G77_ABI_WRAPPER` to 0 or 1 to disable or enable using CBLAS
+API.

--- a/scipy/_build_utils/_fortran.py
+++ b/scipy/_build_utils/_fortran.py
@@ -20,8 +20,11 @@ def uses_mkl(info):
 
 def needs_g77_abi_wrapper(info):
     """Returns True if g77 ABI wrapper must be used."""
-    return str(os.getenv("SCIPY_USE_G77_ABI_WRAPPER", uses_mkl(info))) == "True"
-
+    try:
+        needs_wrapper = int(os.environ["SCIPY_USE_G77_ABI_WRAPPER"]) != 0
+    except KeyError:
+        needs_wrapper = uses_mkl(info)
+    return needs_wrapper
 
 def get_g77_abi_wrappers(info):
     """

--- a/scipy/_build_utils/_fortran.py
+++ b/scipy/_build_utils/_fortran.py
@@ -20,7 +20,7 @@ def uses_mkl(info):
 
 def needs_g77_abi_wrapper(info):
     """Returns True if g77 ABI wrapper must be used."""
-    return uses_mkl(info)
+    return str(os.getenv("SCIPY_USE_G77_ABI_WRAPPER", uses_mkl(info))) == "True"
 
 
 def get_g77_abi_wrappers(info):


### PR DESCRIPTION
When automatically switching the underlying BLAS layer, scipy doesn't know whether the BLAS implementation use g77 ABI or not.
With this environment variable, a user can tell scipy to always assume g77 ABI and use the cblas_* functions.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->