### PR TITLE
API: Replicate numpy's fftn behaviour when s is given but not axes

### DIFF
--- a/scipy/fft/_basic.py
+++ b/scipy/fft/_basic.py
@@ -561,8 +561,6 @@ def fftn(x, s=None, axes=None, norm=None, overwrite_x=False):
     axes : sequence of ints, optional
         Axes over which to compute the FFT.  If not given, the last ``len(s)``
         axes are used, or all axes if `s` is also not specified.
-        Repeated indices in `axes` means that the transform over that axis is
-        performed multiple times.
     norm : {None, "ortho"}, optional
         Normalization mode (see `fft`). Default is None.
     overwrite_x : bool, optional
@@ -665,8 +663,6 @@ def ifftn(x, s=None, axes=None, norm=None, overwrite_x=False):
     axes : sequence of ints, optional
         Axes over which to compute the IFFT.  If not given, the last ``len(s)``
         axes are used, or all axes if `s` is also not specified.
-        Repeated indices in `axes` means that the inverse transform over that
-        axis is performed multiple times.
     norm : {None, "ortho"}, optional
         Normalization mode (see `fft`). Default is None.
     overwrite_x : bool, optional
@@ -750,10 +746,8 @@ def fft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False):
         if `s` is not given, the shape of the input along the axes specified
         by `axes` is used.
     axes : sequence of ints, optional
-        Axes over which to compute the FFT.  If not given, the last two
-        axes are used.  A repeated index in `axes` means the transform over
-        that axis is performed multiple times.  A one-element sequence means
-        that a one-dimensional FFT is performed.
+        Axes over which to compute the FFT. If not given, the last two axes are
+        used.
     norm : {None, "ortho"}, optional
         Normalization mode (see `fft`). Default is None.
     overwrite_x : bool, optional
@@ -849,9 +843,7 @@ def ifft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False):
         by `axes` is used.  See notes for issue on `ifft` zero padding.
     axes : sequence of ints, optional
         Axes over which to compute the FFT.  If not given, the last two
-        axes are used.  A repeated index in `axes` means the transform over
-        that axis is performed multiple times.  A one-element sequence means
-        that a one-dimensional FFT is performed.
+        axes are used.
     norm : {None, "ortho"}, optional
         Normalization mode (see `fft`). Default is None.
     overwrite_x : bool, optional
@@ -1067,8 +1059,6 @@ def irfftn(x, s=None, axes=None, norm=None, overwrite_x=False):
     axes : sequence of ints, optional
         Axes over which to compute the inverse FFT. If not given, the last
         `len(s)` axes are used, or all axes if `s` is also not specified.
-        Repeated indices in `axes` means that the inverse transform over that
-        axis is performed multiple times.
     norm : {None, "ortho"}, optional
         Normalization mode (see `fft`). Default is None.
     overwrite_x : bool, optional
@@ -1200,8 +1190,6 @@ def hfftn(x, s=None, axes=None, norm=None, overwrite_x=False):
     axes : sequence of ints, optional
         Axes over which to compute the inverse FFT. If not given, the last
         `len(s)` axes are used, or all axes if `s` is also not specified.
-        Repeated indices in `axes` means that the inverse transform over that
-        axis is performed multiple times.
     norm : {None, "ortho"}, optional
         Normalization mode (see `fft`). Default is None.
     overwrite_x : bool, optional

--- a/scipy/fft/_pocketfft/helper.py
+++ b/scipy/fft/_pocketfft/helper.py
@@ -41,9 +41,7 @@ def _init_nd_shape_and_axes(x, shape, axes):
     noshape = shape is None
     noaxes = axes is None
 
-    if noaxes:
-        axes = range(x.ndim)
-    else:
+    if not noaxes:
         axes = _iterable_of_int(axes, 'axes')
         axes = [a + x.ndim if a < 0 else a for a in axes]
 
@@ -55,13 +53,18 @@ def _init_nd_shape_and_axes(x, shape, axes):
     if not noshape:
         shape = _iterable_of_int(shape, 'shape')
 
-        if len(axes) != len(shape):
+        if axes and len(axes) != len(shape):
             raise ValueError("when given, axes and shape arguments"
                              " have to be of the same length")
+        if noaxes:
+            if len(shape) > x.ndim:
+                raise ValueError("shape requires more axes than are present")
+            axes = range(x.ndim - len(shape), x.ndim)
 
         shape = [x.shape[a] if s == -1 else s for s, a in zip(shape, axes)]
     elif noaxes:
         shape = list(x.shape)
+        axes = range(x.ndim)
     else:
         shape = [x.shape[a] for a in axes]
 

--- a/scipy/fft/_pocketfft/tests/test_basic.py
+++ b/scipy/fft/_pocketfft/tests/test_basic.py
@@ -740,8 +740,7 @@ class TestFftn(object):
     def test_shape_argument_more(self):
         x = zeros((4, 4, 2))
         with assert_raises(ValueError,
-                           match="when given, axes and shape arguments"
-                           " have to be of the same length"):
+                           match="shape requires more axes than are present"):
             fftn(x, s=(8, 8, 2, 1))
 
     def test_invalid_sizes(self):

--- a/scipy/fft/_pocketfft/tests/test_real_transforms.py
+++ b/scipy/fft/_pocketfft/tests/test_real_transforms.py
@@ -793,11 +793,6 @@ class Test_DCTN_IDCTN(object):
         with assert_raises(ValueError,
                            match="when given, axes and shape arguments"
                            " have to be of the same length"):
-            fforward(self.data, s=self.data.shape[0], axes=None)
-
-        with assert_raises(ValueError,
-                           match="when given, axes and shape arguments"
-                           " have to be of the same length"):
             fforward(self.data, s=self.data.shape, axes=0)
 
     @pytest.mark.parametrize('fforward', [dctn, dstn])

--- a/scipy/fft/_realtransforms.py
+++ b/scipy/fft/_realtransforms.py
@@ -26,8 +26,8 @@ def dctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False):
         If any element of `s` is -1, the size of the corresponding dimension of
         `x` is used.
     axes : int or array_like of ints or None, optional
-        Axes along which the DCT is computed.
-        The default is over all axes.
+        Axes over which the DCT is computed.  If not given, the last ``len(s)``
+        axes are used, or all axes if `s` is also not specified.
     norm : {None, 'ortho'}, optional
         Normalization mode (see Notes). Default is None.
     overwrite_x : bool, optional
@@ -79,8 +79,8 @@ def idctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False):
         If any element of `s` is -1, the size of the corresponding dimension of
         `x` is used.
     axes : int or array_like of ints or None, optional
-        Axes along which the IDCT is computed.
-        The default is over all axes.
+        Axes over which the IDCT is computed.  If not given, the last ``len(s)``
+        axes are used, or all axes if `s` is also not specified.
     norm : {None, 'ortho'}, optional
         Normalization mode (see Notes). Default is None.
     overwrite_x : bool, optional
@@ -132,8 +132,8 @@ def dstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False):
         If any element of `shape` is -1, the size of the corresponding dimension
         of `x` is used.
     axes : int or array_like of ints or None, optional
-        Axes along which the DCT is computed.
-        The default is over all axes.
+        Axes over which the DST is computed.  If not given, the last ``len(s)``
+        axes are used, or all axes if `s` is also not specified.
     norm : {None, 'ortho'}, optional
         Normalization mode (see Notes). Default is None.
     overwrite_x : bool, optional
@@ -185,8 +185,8 @@ def idstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False):
         If any element of `s` is -1, the size of the corresponding dimension of
         `x` is used.
     axes : int or array_like of ints or None, optional
-        Axes along which the IDST is computed.
-        The default is over all axes.
+        Axes over which the IDST is computed.  If not given, the last ``len(s)``
+        axes are used, or all axes if `s` is also not specified.
     norm : {None, 'ortho'}, optional
         Normalization mode (see Notes). Default is None.
     overwrite_x : bool, optional

--- a/scipy/fft/tests/test_helper.py
+++ b/scipy/fft/tests/test_helper.py
@@ -1,5 +1,5 @@
 from scipy.fft._helper import next_fast_len, _init_nd_shape_and_axes
-from numpy.testing import assert_equal, assert_
+from numpy.testing import assert_equal, assert_, assert_array_equal
 from pytest import raises as assert_raises
 import pytest
 import numpy as np
@@ -243,6 +243,13 @@ class Test_init_nd_shape_and_axes(object):
 
         assert_equal(shape_res, shape_expected)
         assert_equal(axes_res, axes_expected)
+
+    def test_shape_axes_subset(self):
+        x = np.zeros((2, 3, 4, 5))
+        shape, axes = _init_nd_shape_and_axes(x, shape=(5, 5, 5), axes=None)
+
+        assert_array_equal(shape, [5, 5, 5])
+        assert_array_equal(axes, [1, 2, 3])
 
     def test_errors(self):
         x = np.zeros(1)

--- a/scipy/fftpack/basic.py
+++ b/scipy/fftpack/basic.py
@@ -8,6 +8,7 @@ __all__ = ['fft','ifft','fftn','ifftn','rfft','irfft',
            'fft2','ifft2']
 
 from scipy.fft import _pocketfft
+from .helper import _good_shape
 
 
 def fft(x, n=None, axis=-1, overwrite_x=False):
@@ -332,6 +333,7 @@ def fftn(x, shape=None, axes=None, overwrite_x=False):
     True
 
     """
+    shape = _good_shape(x, shape, axes)
     return _pocketfft.fftn(x, shape, axes, None, overwrite_x)
 
 
@@ -363,6 +365,7 @@ def ifftn(x, shape=None, axes=None, overwrite_x=False):
     True
 
     """
+    shape = _good_shape(x, shape, axes)
     return _pocketfft.ifftn(x, shape, axes, None, overwrite_x)
 
 

--- a/scipy/fftpack/helper.py
+++ b/scipy/fftpack/helper.py
@@ -96,3 +96,16 @@ def next_fast_len(target):
     """
     # Real transforms use regular sizes so this is backwards compatible
     return _helper.next_fast_len(target, 'R2C')
+
+
+def _good_shape(x, shape, axes):
+    """Ensure that shape argument is valid for scipy.fftpack
+
+    scipy.fftpack does not support len(shape) < x.ndim when axes is not given.
+    """
+    if shape and not axes:
+        shape = _helper._iterable_of_int(shape, 'shape')
+        if len(shape) != np.ndim(x):
+            raise ValueError("when given, axes and shape arguments"
+                             " have to be of the same length")
+    return shape

--- a/scipy/fftpack/realtransforms.py
+++ b/scipy/fftpack/realtransforms.py
@@ -7,6 +7,7 @@ from __future__ import division, print_function, absolute_import
 __all__ = ['dct', 'idct', 'dst', 'idst', 'dctn', 'idctn', 'dstn', 'idstn']
 
 from scipy.fft import _pocketfft
+from .helper import _good_shape
 
 _inverse_typemap = {1: 1, 2: 3, 3: 2, 4: 4}
 
@@ -60,6 +61,7 @@ def dctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
     True
 
     """
+    shape = _good_shape(x, shape, axes)
     return _pocketfft.dctn(x, type, shape, axes, norm, overwrite_x)
 
 
@@ -113,6 +115,7 @@ def idctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
 
     """
     type = _inverse_typemap[type]
+    shape = _good_shape(x, shape, axes)
     return _pocketfft.dctn(x, type, shape, axes, norm, overwrite_x)
 
 
@@ -165,6 +168,7 @@ def dstn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
     True
 
     """
+    shape = _good_shape(x, shape, axes)
     return _pocketfft.dstn(x, type, shape, axes, norm, overwrite_x)
 
 
@@ -218,6 +222,7 @@ def idstn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
 
     """
     type = _inverse_typemap[type]
+    shape = _good_shape(x, shape, axes)
     return _pocketfft.dstn(x, type, shape, axes, norm, overwrite_x)
 
 


### PR DESCRIPTION
#### Reference issue
Closes gh-10588

#### What does this implement/fix?
This updates the helper function `_init_nd_shape_and_axes` to allow `len(s)` < `x.ndim` when `axes=None`.  I've also added extra checks to `fftpack` to ensure it keeps the old behaviour.

#### Additional information
I've also noticed another difference from numpy fft:
>Repeated indices in `axes` means that the inverse transform over that
        axis is performed multiple times.

whereas `scipy.fft` will complain about axes not being unique. In this case I'm not convinced that NumPy's behaviour is better though. It seems like something more likely to just be a mistake and I also know that `pyfftw` doesn't handle this correctly. So, I've just removed that comment from the docs.