### PR TITLE
DOC: dev: update documentation vs. github pull request workflow features

### DIFF
--- a/doc/source/dev/contributor/reviewing_prs.rst
+++ b/doc/source/dev/contributor/reviewing_prs.rst
@@ -6,6 +6,58 @@
 Reviewing Pull Requests
 =======================
 
+.. _pull-request-workflow-features:
+
+Using workflow features
+-----------------------
+
+When reviewing pull requests, please use workflow tracking features on
+Github as appropriate:
+
+1. After you have finished reviewing, and want to ask for the submitter
+   to make the changes:
+
+   - Change your review status to "Changes requested".
+
+     This can be done on Github, PR page, ``Files changed`` tab,
+     ``Review changes`` (button on top right).
+
+   - Alternatively: add the ``needs-work`` label.
+
+     This can be done on the PR page, ``Labels`` menu on the right.
+
+2. When you re-review the same pull request again, and want to request
+   more changes:
+
+   - Do the "Changes requested" thing again, even if the previous status
+     was also 'Changes requested'.
+
+   - Alternatively:
+     Remove the existing ``needs-work`` label, and then re-add the label
+     back again. (Github will add a notice on the page that you did so.)
+
+3. If you're happy about the current status:
+
+   - Mark the pull request as Approved (same way as Changes requested).
+
+   - Alternatively: remove the ``needs-work`` label.
+
+   - Alternatively (for core developers): merge the pull request, if
+     you think it is ready to be merged.
+
+This allows automatically tracking which PRs are in need of attention.
+
+The review status is listed at: https://pav.iki.fi/scipy-needs-work/
+The page can also be generated using https://github.com/pv/github-needs-work
+
+Some of the information is also visible on Github directly, although
+(as of Aug 2019) Github does not show which pull requests have been
+updated since the last review.
+
+
+Code from pull request
+----------------------
+
 When you review a pull request created by someone else, it's helpful to have a
 copy of their code on your own machine so that you can play with it locally.
 

--- a/doc/source/dev/core-dev/github.rst.inc
+++ b/doc/source/dev/core-dev/github.rst.inc
@@ -15,7 +15,7 @@ nature of the issue or pull request (``enhancement``, ``maintenance``,
 
 - ``easy-fix``: for issues suitable to be tackled by new contributors.
 - ``needs-work``: for pull requests that have review comments that haven't been
-  addressed for a while.
+  addressed.
 - ``needs-decision``: for issues or pull requests that need a decision.
 - ``needs-champion``: for pull requests that were not finished by the original
   author, but are worth resurrecting.
@@ -28,6 +28,14 @@ particular release should be set to the corresponding milestone.  After a pull
 request is merged, its milestone (and that of the issue it closes) should be
 set to the next upcoming release - this makes it easy to get an overview of
 changes and to add a complete list of those to the release notes.
+
+
+Pull request review workflow
+----------------------------
+
+When reviewing pull requests, please make use of pull request workflow
+features, see :ref:`pull-request-workflow-features`.
+
 
 Dealing with pull requests
 --------------------------


### PR DESCRIPTION
Add contributor and core developer documentation asking to use some of the Github workflow features when reviewing pull requests.

The point here would be to enable automated tracking of the pull request review status.

Github review UI partly works, but unfortunately appears unable to list which PRs have been updated since the review. This however can be done with an external script (https://github.com/pv/github-needs-work), for which regularly updated output is at https://pav.iki.fi/scipy-needs-work/
This has been around for several years now, but maybe it would be useful to advertise it more officially, and ask people to use the Github review features (or use labels) to add the metadata needed.

(c.f. https://mail.python.org/pipermail/scipy-dev/2019-August/023651.html)