### PR TITLE
BUG: interpolate: fix broken conversions between PPoly/BPoly objects

### DIFF
--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -1310,6 +1310,10 @@ class PPoly(_PPolyBase):
             based on first and last intervals, or to return NaNs.
             If 'periodic', periodic extrapolation is used. Default is True.
         """
+        if not isinstance(bp, BPoly):
+            raise TypeError(".from_bernstein_basis only accepts BPoly instances. "
+                            "Got %s instead." % type(bp))
+
         dx = np.diff(bp.x)
         k = bp.c.shape[0] - 1  # polynomial order
 
@@ -1614,6 +1618,10 @@ class BPoly(_PPolyBase):
             based on first and last intervals, or to return NaNs.
             If 'periodic', periodic extrapolation is used. Default is True.
         """
+        if not isinstance(pp, PPoly):
+            raise TypeError(".from_power_basis only accepts PPoly instances. "
+                            "Got %s instead." % type(pp))
+
         dx = np.diff(pp.x)
         k = pp.c.shape[0] - 1   # polynomial order
 

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -1795,6 +1795,18 @@ class TestPolyConversions(object):
         assert_allclose(bp(xp), pp(xp))
         assert_allclose(bp(xp), bp1(xp))
 
+    def test_broken_conversions(self):
+        # regression test for gh-10597: from_power_basis only accepts PPoly etc
+        x = [0, 1, 3]
+        c = [[3, 3], [1, 1], [4, 2]]        
+        pp = PPoly(c, x)
+        with assert_raises(TypeError):
+            PPoly.from_bernstein_basis(pp)
+
+        bp = BPoly(c, x)
+        with assert_raises(TypeError):
+            BPoly.from_power_basis(bp)
+
 
 class TestBPolyFromDerivatives(object):
     def test_make_poly_1(self):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

closes gh-10597

#### What does this implement/fix?
<!--Please explain your changes.-->

In scipy 1.3.0, the base class of the `PchipInterpolator` changed from BPoly to PPoly. This was supposed to be an implementation detail, but it leaked, and some users, as it turns out, were doing the conversion manually. These conversions now silently produce garbage. 

Therefore, type-check before converting between bases and make it fail for obviously wrong conversions. gh-10597 suggested a warning, but I think it should rather be a hard fail. 

#### Additional information
<!--Any additional information you think is important.-->

This is a regression of Scipy 1.3.0, so it should be considered for backporting. Am tentatively flagging it with the 1.3.1 milestone, for the RM's decision.