### PR TITLE
MAINT: Change c*np.ones(...) to np.full(..., c, ...) in many places

### DIFF
--- a/scipy/fft/tests/test_numpy.py
+++ b/scipy/fft/tests/test_numpy.py
@@ -279,7 +279,7 @@ class TestFFTThreadSafe(object):
                 'Function returned wrong value in multithreaded context')
 
     def test_fft(self):
-        a = np.full(self.input_shape, 1+0j)
+        a = np.ones(self.input_shape, dtype=np.complex128)
         self._test_mtsame(fft.fft, a)
 
     def test_ifft(self):

--- a/scipy/fft/tests/test_numpy.py
+++ b/scipy/fft/tests/test_numpy.py
@@ -279,11 +279,11 @@ class TestFFTThreadSafe(object):
                 'Function returned wrong value in multithreaded context')
 
     def test_fft(self):
-        a = np.ones(self.input_shape) * 1+0j
+        a = np.full(self.input_shape, 1+0j)
         self._test_mtsame(fft.fft, a)
 
     def test_ifft(self):
-        a = np.ones(self.input_shape) * 1+0j
+        a = np.full(self.input_shape, 1+0j)
         self._test_mtsame(fft.ifft, a)
 
     def test_rfft(self):
@@ -291,7 +291,7 @@ class TestFFTThreadSafe(object):
         self._test_mtsame(fft.rfft, a)
 
     def test_irfft(self):
-        a = np.ones(self.input_shape) * 1+0j
+        a = np.full(self.input_shape, 1+0j)
         self._test_mtsame(fft.irfft, a)
 
     def test_hfft(self):

--- a/scipy/io/tests/test_netcdf.py
+++ b/scipy/io/tests/test_netcdf.py
@@ -421,13 +421,13 @@ def test_append_recordDimension():
             # Open the file in append mode and add data
             with netcdf_file('withRecordDimension.nc', 'a') as f:
                 f.variables['time'].data = np.append(f.variables["time"].data, i)
-                f.variables['testData'][i, :, :] = np.ones((dataSize, dataSize))*i
+                f.variables['testData'][i, :, :] = np.full((dataSize, dataSize), i)
                 f.flush()
 
             # Read the file and check that append worked
             with netcdf_file('withRecordDimension.nc') as f:
                 assert_equal(f.variables['time'][-1], i)
-                assert_equal(f.variables['testData'][-1, :, :].copy(), np.ones((dataSize, dataSize))*i)
+                assert_equal(f.variables['testData'][-1, :, :].copy(), np.full((dataSize, dataSize), i))
                 assert_equal(f.variables['time'].data.shape[0], i+1)
                 assert_equal(f.variables['testData'].data.shape[0], i+1)
 

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -31,7 +31,7 @@ from scipy.linalg.lapack import dgbtrf, dgbtrs, zgbtrf, zgbtrs, \
 from scipy.linalg.misc import norm
 from scipy.linalg._decomp_qz import _select_function
 
-from numpy import array, transpose, diag, ones, linalg, \
+from numpy import array, transpose, diag, ones, full, linalg, \
      argsort, zeros, arange, float32, complex64, dot, conj, identity, \
      ravel, sqrt, iscomplex, shape, sort, conjugate, sign, \
      asarray, isfinite, ndarray, outer, eye, dtype, empty,\
@@ -396,24 +396,24 @@ class TestEigBanded(object):
         self.KU = 2   # number of superdiagonals (above the diagonal)
 
         # symmetric band matrix
-        self.sym_mat = (diag(1.0*ones(N))
-                     + diag(-1.0*ones(N-1), -1) + diag(-1.0*ones(N-1), 1)
-                     + diag(-2.0*ones(N-2), -2) + diag(-2.0*ones(N-2), 2))
+        self.sym_mat = (diag(full(N, 1.0))
+                     + diag(full(N-1, -1.0), -1) + diag(full(N-1, -1.0), 1)
+                     + diag(full(N-2, -2.0), -2) + diag(full(N-2, -2.0), 2))
 
         # hermitian band matrix
-        self.herm_mat = (diag(-1.0*ones(N))
-                     + 1j*diag(1.0*ones(N-1), -1) - 1j*diag(1.0*ones(N-1), 1)
-                     + diag(-2.0*ones(N-2), -2) + diag(-2.0*ones(N-2), 2))
+        self.herm_mat = (diag(full(N, -1.0))
+                     + 1j*diag(full(N-1, 1.0), -1) - 1j*diag(full(N-1, 1.0), 1)
+                     + diag(full(N-2, -2.0), -2) + diag(full(N-2, -2.0), 2))
 
         # general real band matrix
-        self.real_mat = (diag(1.0*ones(N))
-                     + diag(-1.0*ones(N-1), -1) + diag(-3.0*ones(N-1), 1)
-                     + diag(2.0*ones(N-2), -2) + diag(-2.0*ones(N-2), 2))
+        self.real_mat = (diag(full(N, 1.0))
+                     + diag(full(N-1, -1.0), -1) + diag(full(N-1, -3.0), 1)
+                     + diag(full(N-2, 2.0), -2) + diag(full(N-2, -2.0), 2))
 
         # general complex band matrix
-        self.comp_mat = (1j*diag(1.0*ones(N))
-                     + diag(-1.0*ones(N-1), -1) + 1j*diag(-3.0*ones(N-1), 1)
-                     + diag(2.0*ones(N-2), -2) + diag(-2.0*ones(N-2), 2))
+        self.comp_mat = (1j*diag(full(N, 1.0))
+                     + diag(full(N-1, -1.0), -1) + 1j*diag(full(N-1, -3.0), 1)
+                     + diag(full(N-2, 2.0), -2) + diag(full(N-2, -2.0), 2))
 
         # Eigenvalues and -vectors from linalg.eig
         ew, ev = linalg.eig(self.sym_mat)
@@ -662,8 +662,8 @@ class TestEigTridiagonal(object):
         N = 10
 
         # symmetric band matrix
-        self.d = 1.0*ones(N)
-        self.e = -1.0*ones(N-1)
+        self.d = full(N, 1.0)
+        self.e = full(N-1, -1.0)
         self.full_mat = (diag(self.d) + diag(self.e, -1) + diag(self.e, 1))
 
         ew, ev = linalg.eig(self.full_mat)

--- a/scipy/linalg/tests/test_decomp_update.py
+++ b/scipy/linalg/tests/test_decomp_update.py
@@ -664,7 +664,7 @@ class BaseQRinsert(BaseQRdeltas):
         a, q, r, u = self.generate('sqr', which='row', p=3)
         for row in range(r.shape[0] + 1):
             q1, r1 = qr_insert(q, r, u, row)
-            a1 = np.insert(a, row*np.ones(3, np.intp), u, 0)
+            a1 = np.insert(a, np.full(3, row, np.intp), u, 0)
             check_qr(q1, r1, a1, self.rtol, self.atol)
 
     def test_sqr_1_col(self):
@@ -679,7 +679,7 @@ class BaseQRinsert(BaseQRdeltas):
         a, q, r, u = self.generate('sqr', which='col', p=3)
         for col in range(r.shape[1] + 1):
             q1, r1 = qr_insert(q, r, u, col, 'col', overwrite_qru=False)
-            a1 = np.insert(a, col*np.ones(3, np.intp), u, 1)
+            a1 = np.insert(a, np.full(3, col, np.intp), u, 1)
             check_qr(q1, r1, a1, self.rtol, self.atol)
 
     def test_tall_1_row(self):
@@ -694,7 +694,7 @@ class BaseQRinsert(BaseQRdeltas):
         a, q, r, u = self.generate('tall', which='row', p=3)
         for row in range(r.shape[0] + 1):
             q1, r1 = qr_insert(q, r, u, row)
-            a1 = np.insert(a, row*np.ones(3, np.intp), u, 0)
+            a1 = np.insert(a, np.full(3, row, np.intp), u, 0)
             check_qr(q1, r1, a1, self.rtol, self.atol)
 
     def test_tall_1_col(self):
@@ -712,7 +712,7 @@ class BaseQRinsert(BaseQRdeltas):
         a, q, r, u = self.generate('tall', which='col', p=p)
         for col in range(r.shape[1] + 1):
             q1, r1 = qr_insert(q, r, u, col, 'col', overwrite_qru=False)
-            a1 = np.insert(a, col*np.ones(p, np.intp), u, 1)
+            a1 = np.insert(a, np.full(p, col, np.intp), u, 1)
             check_qr(q1, r1, a1, self.rtol, self.atol)
 
     def test_tall_p_col_tall(self):
@@ -742,7 +742,7 @@ class BaseQRinsert(BaseQRdeltas):
         a, q, r, u = self.generate('fat', which='row', p=p)
         for row in range(r.shape[0] + 1):
             q1, r1 = qr_insert(q, r, u, row)
-            a1 = np.insert(a, row*np.ones(p, np.intp), u, 0)
+            a1 = np.insert(a, np.full(p, row, np.intp), u, 0)
             check_qr(q1, r1, a1, self.rtol, self.atol)
     
     def test_fat_p_row_fat(self):
@@ -769,7 +769,7 @@ class BaseQRinsert(BaseQRdeltas):
         a, q, r, u = self.generate('fat', which='col', p=3)
         for col in range(r.shape[1] + 1):
             q1, r1 = qr_insert(q, r, u, col, 'col', overwrite_qru=False)
-            a1 = np.insert(a, col*np.ones(3, np.intp), u, 1)
+            a1 = np.insert(a, np.full(3, col, np.intp), u, 1)
             check_qr(q1, r1, a1, self.rtol, self.atol)
 
     def test_economic_1_row(self):
@@ -784,7 +784,7 @@ class BaseQRinsert(BaseQRdeltas):
         a, q, r, u = self.generate('tall', 'economic', 'row', 3)
         for row in range(r.shape[0] + 1):
             q1, r1 = qr_insert(q, r, u, row, overwrite_qru=False)
-            a1 = np.insert(a, row*np.ones(3, np.intp), u, 0)
+            a1 = np.insert(a, np.full(3, row, np.intp), u, 0)
             check_qr(q1, r1, a1, self.rtol, self.atol, False)
 
     def test_economic_1_col(self):
@@ -810,7 +810,7 @@ class BaseQRinsert(BaseQRdeltas):
         a, q, r, u = self.generate('tall', 'economic', which='col', p=p)
         for col in range(r.shape[1] + 1):
             q1, r1 = qr_insert(q, r, u, col, 'col', overwrite_qru=False)
-            a1 = np.insert(a, col*np.ones(p, np.intp), u, 1)
+            a1 = np.insert(a, np.full(p, col, np.intp), u, 1)
             check_qr(q1, r1, a1, self.rtol, self.atol, False)
 
     def test_economic_p_col_eco(self):
@@ -836,7 +836,7 @@ class BaseQRinsert(BaseQRdeltas):
         a, q, r, u = self.generate('Mx1', which='row', p=3)
         for row in range(r.shape[0] + 1):
             q1, r1 = qr_insert(q, r, u, row)
-            a1 = np.insert(a, row*np.ones(3, np.intp), u, 0)
+            a1 = np.insert(a, np.full(3, row, np.intp), u, 0)
             check_qr(q1, r1, a1, self.rtol, self.atol)
 
     def test_Mx1_1_col(self):
@@ -850,7 +850,7 @@ class BaseQRinsert(BaseQRdeltas):
         a, q, r, u = self.generate('Mx1', which='col', p=3)
         for col in range(r.shape[1] + 1):
             q1, r1 = qr_insert(q, r, u, col, 'col', overwrite_qru=False)
-            a1 = np.insert(a, col*np.ones(3, np.intp), u, 1)
+            a1 = np.insert(a, np.full(3, col, np.intp), u, 1)
             check_qr(q1, r1, a1, self.rtol, self.atol)
 
     def test_Mx1_economic_1_row(self):
@@ -864,7 +864,7 @@ class BaseQRinsert(BaseQRdeltas):
         a, q, r, u = self.generate('Mx1', 'economic', 'row', 3)
         for row in range(r.shape[0] + 1):
             q1, r1 = qr_insert(q, r, u, row)
-            a1 = np.insert(a, row*np.ones(3, np.intp), u, 0)
+            a1 = np.insert(a, np.full(3, row, np.intp), u, 0)
             check_qr(q1, r1, a1, self.rtol, self.atol, False)
 
     def test_Mx1_economic_1_col(self):
@@ -878,7 +878,7 @@ class BaseQRinsert(BaseQRdeltas):
         a, q, r, u = self.generate('Mx1', 'economic', 'col', 3)
         for col in range(r.shape[1] + 1):
             q1, r1 = qr_insert(q, r, u, col, 'col', overwrite_qru=False)
-            a1 = np.insert(a, col*np.ones(3, np.intp), u, 1)
+            a1 = np.insert(a, np.full(3, col, np.intp), u, 1)
             check_qr(q1, r1, a1, self.rtol, self.atol, False)
 
     def test_1xN_1_row(self):
@@ -892,7 +892,7 @@ class BaseQRinsert(BaseQRdeltas):
         a, q, r, u = self.generate('1xN', which='row', p=3)
         for row in range(r.shape[0] + 1):
             q1, r1 = qr_insert(q, r, u, row)
-            a1 = np.insert(a, row*np.ones(3, np.intp), u, 0)
+            a1 = np.insert(a, np.full(3, row, np.intp), u, 0)
             check_qr(q1, r1, a1, self.rtol, self.atol)
 
     def test_1xN_1_col(self):
@@ -906,7 +906,7 @@ class BaseQRinsert(BaseQRdeltas):
         a, q, r, u = self.generate('1xN', which='col', p=3)
         for col in range(r.shape[1] + 1):
             q1, r1 = qr_insert(q, r, u, col, 'col', overwrite_qru=False)
-            a1 = np.insert(a, col*np.ones(3, np.intp), u, 1)
+            a1 = np.insert(a, np.full(3, col, np.intp), u, 1)
             check_qr(q1, r1, a1, self.rtol, self.atol)
 
     def test_1x1_1_row(self):
@@ -920,7 +920,7 @@ class BaseQRinsert(BaseQRdeltas):
         a, q, r, u = self.generate('1x1', which='row', p=3)
         for row in range(r.shape[0] + 1):
             q1, r1 = qr_insert(q, r, u, row)
-            a1 = np.insert(a, row*np.ones(3, np.intp), u, 0)
+            a1 = np.insert(a, np.full(3, row, np.intp), u, 0)
             check_qr(q1, r1, a1, self.rtol, self.atol)
 
     def test_1x1_1_col(self):
@@ -934,7 +934,7 @@ class BaseQRinsert(BaseQRdeltas):
         a, q, r, u = self.generate('1x1', which='col', p=3)
         for col in range(r.shape[1] + 1):
             q1, r1 = qr_insert(q, r, u, col, 'col', overwrite_qru=False)
-            a1 = np.insert(a, col*np.ones(3, np.intp), u, 1)
+            a1 = np.insert(a, np.full(3, col, np.intp), u, 1)
             check_qr(q1, r1, a1, self.rtol, self.atol)
     
     def test_1x1_1_scalar(self):
@@ -954,7 +954,7 @@ class BaseQRinsert(BaseQRdeltas):
             if p == 1:
                 ai = np.insert(a, k, u0, 0 if which == 'row' else 1)
             else:
-                ai = np.insert(a, k*np.ones(p, np.intp),
+                ai = np.insert(a, np.full(p, k, np.intp),
                         u0 if which == 'row' else u0, 
                         0 if which == 'row' else 1)
 

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -492,8 +492,8 @@ def test_rot():
         c = 0.6
         s = 0.8
 
-        u = np.ones(4, dtype) * 3
-        v = np.ones(4, dtype) * 4
+        u = np.full(4, 3, dtype)
+        v = np.full(4, 4, dtype)
         atol = 10**-(np.finfo(dtype).precision-1)
 
         if dtype in 'fd':

--- a/scipy/linalg/tests/test_solvers.py
+++ b/scipy/linalg/tests/test_solvers.py
@@ -533,7 +533,7 @@ def test_solve_discrete_are():
     A = np.triu(np.ones((3, 3)))
     A[0, 1] = -1
     B = np.array([[1, 1, 0], [0, 0, 1]]).T
-    Q = -2*np.ones_like(A) + np.diag([8, -1, -1.9])
+    Q = np.full_like(A, -2) + np.diag([8, -1, -1.9])
     R = np.diag([-10, 0.1])
     assert_raises(LinAlgError, solve_continuous_are, A, B, Q, R)
 
@@ -685,7 +685,7 @@ def test_are_validate_args():
             assert_raises(ValueError, x, sym, sym, sym, nsym)
 
     def test_singularity():
-        sing = 1e12 * np.ones((3, 3))
+        sing = np.full((3, 3), 1e12)
         sing[2, 2] -= 1
         sq = np.eye(3)
         for x in (solve_continuous_are, solve_discrete_are):
@@ -694,7 +694,7 @@ def test_are_validate_args():
         assert_raises(ValueError, solve_continuous_are, sq, sq, sq, sing)
 
     def test_finiteness():
-        nm = np.ones((2, 2)) * np.nan
+        nm = np.full((2, 2), np.nan)
         sq = np.eye(2)
         for x in (solve_continuous_are, solve_discrete_are):
             assert_raises(ValueError, x, nm, sq, sq, sq)

--- a/scipy/linalg/tests/test_special_matrices.py
+++ b/scipy/linalg/tests/test_special_matrices.py
@@ -328,7 +328,7 @@ class TestHelmert(object):
             H_full = helmert(n, full=True)
             H_partial = helmert(n)
             for U in H_full[1:, :].T, H_partial.T:
-                C = np.eye(n) - np.ones((n, n)) / n
+                C = np.eye(n) - np.full((n, n), 1 / n)
                 assert_allclose(U.dot(U.T), C)
                 assert_allclose(U.T.dot(U), np.eye(n-1), atol=1e-12)
 

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -680,8 +680,8 @@ class DifferentialEvolutionSolver(object):
                                  self.parameter_count)
 
         # reset population energies
-        self.population_energies = (np.ones(self.num_population_members) *
-                                    np.inf)
+        self.population_energies = np.full(self.num_population_members,
+                                           np.inf)
 
         # reset number of function evaluations counter
         self._nfev = 0

--- a/scipy/optimize/_trustregion_constr/tests/test_qp_subproblem.py
+++ b/scipy/optimize/_trustregion_constr/tests/test_qp_subproblem.py
@@ -389,7 +389,7 @@ class TestModifiedDogleg(TestCase):
         z = cauchy_point
         d = newton_point-cauchy_point
         t = ((x-z)/(d))
-        assert_array_almost_equal(t, 0.40807330*np.ones(3))
+        assert_array_almost_equal(t, np.full(3, 0.40807330))
         assert_array_almost_equal(np.linalg.norm(x), 2)
 
         # line between cauchy_point and newton_point contains best point
@@ -399,7 +399,7 @@ class TestModifiedDogleg(TestCase):
         z = cauchy_point
         d = newton_point-cauchy_point
         t = ((x-z)/(d))
-        assert_array_almost_equal(t, 0.7498195*np.ones(3))
+        assert_array_almost_equal(t, np.full(3, 0.7498195))
         assert_array_almost_equal(x[0], -1)
 
         # line between origin and cauchy_point contains best point
@@ -409,7 +409,7 @@ class TestModifiedDogleg(TestCase):
         z = origin
         d = cauchy_point
         t = ((x-z)/(d))
-        assert_array_almost_equal(t, 0.573936265*np.ones(3))
+        assert_array_almost_equal(t, np.full(3, 0.573936265))
         assert_array_almost_equal(np.linalg.norm(x), 1)
 
         # line between origin and newton_point contains best point
@@ -419,7 +419,7 @@ class TestModifiedDogleg(TestCase):
         z = origin
         d = newton_point
         t = ((x-z)/(d))
-        assert_array_almost_equal(t, 0.4478827364*np.ones(3))
+        assert_array_almost_equal(t, np.full(3, 0.4478827364))
         assert_array_almost_equal(x[1], 1)
 
 

--- a/scipy/optimize/nonlin.py
+++ b/scipy/optimize/nonlin.py
@@ -1227,7 +1227,7 @@ class DiagBroyden(GenericBroyden):
 
     def setup(self, x, F, func):
         GenericBroyden.setup(self, x, F, func)
-        self.d = np.ones((self.shape[0],), dtype=self.dtype) / self.alpha
+        self.d = np.full((self.shape[0],), 1 / self.alpha, dtype=self.dtype) 
 
     def solve(self, f, tol=0):
         return -f / self.d

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -1083,7 +1083,7 @@ class TestDifferentialEvolutionSolver(object):
                     1294.8
                     ]
         L = LinearConstraint(A, b, np.inf)
-        N = NonlinearConstraint(c1, -0.001*np.ones(3), 0.001*np.ones(3))
+        N = NonlinearConstraint(c1, np.full(3, -0.001), np.full(3, 0.001))
 
         bounds = [(0, 1200)]*2+[(-.55, .55)]*2
         constraints = (L, N)

--- a/scipy/optimize/tests/test__numdiff.py
+++ b/scipy/optimize/tests/test__numdiff.py
@@ -45,7 +45,7 @@ def test_group_columns():
 class TestAdjustSchemeToBounds(object):
     def test_no_bounds(self):
         x0 = np.zeros(3)
-        h = np.ones(3) * 1e-2
+        h = np.full(3, 1e-2)
         inf_lower = np.empty_like(x0)
         inf_upper = np.empty_like(x0)
         inf_lower.fill(-np.inf)
@@ -438,7 +438,7 @@ class TestApproxDerivativeSparse(object):
             assert_(isinstance(J, csr_matrix))
             assert_allclose(J.toarray(), self.J_true, rtol=1e-6)
 
-            rel_step = 1e-8 * np.ones_like(self.x0)
+            rel_step = np.full_like(self.x0, 1e-8)
             rel_step[::2] *= -1
             J = approx_derivative(self.fun, self.x0, method=method,
                                   rel_step=rel_step, sparsity=(A, groups))

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -113,7 +113,7 @@ def pressure_network_fun_and_grad(flow_rates, Qtot, k):
 class TestFSolve(object):
     def test_pressure_network_no_gradient(self):
         # fsolve without gradient, equal pipes -> equal flows.
-        k = np.ones(4) * 0.5
+        k = np.full(4, 0.5)
         Qtot = 4
         initial_guess = array([2., 0., 2., 0.])
         final_flows, info, ier, mesg = optimize.fsolve(
@@ -124,7 +124,7 @@ class TestFSolve(object):
 
     def test_pressure_network_with_gradient(self):
         # fsolve with gradient, equal pipes -> equal flows
-        k = np.ones(4) * 0.5
+        k = np.full(4, 0.5)
         Qtot = 4
         initial_guess = array([2., 0., 2., 0.])
         final_flows = optimize.fsolve(
@@ -182,7 +182,7 @@ class TestFSolve(object):
             return pressure_network(*args)
 
         # fsolve without gradient, equal pipes -> equal flows.
-        k = np.ones(4) * 0.5
+        k = np.full(4, 0.5)
         Qtot = 4
         initial_guess = array([2., 0., 2., 0.])
         final_flows, info, ier, mesg = optimize.fsolve(
@@ -197,7 +197,7 @@ class TestFSolve(object):
             return pressure_network_jacobian(*args)
 
         # fsolve with gradient, equal pipes -> equal flows
-        k = np.ones(4) * 0.5
+        k = np.full(4, 0.5)
         Qtot = 4
         initial_guess = array([2., 0., 2., 0.])
         final_flows = optimize.fsolve(
@@ -215,7 +215,7 @@ class TestFSolve(object):
 class TestRootHybr(object):
     def test_pressure_network_no_gradient(self):
         # root/hybr without gradient, equal pipes -> equal flows
-        k = np.ones(4) * 0.5
+        k = np.full(4, 0.5)
         Qtot = 4
         initial_guess = array([2., 0., 2., 0.])
         final_flows = optimize.root(pressure_network, initial_guess,
@@ -224,7 +224,7 @@ class TestRootHybr(object):
 
     def test_pressure_network_with_gradient(self):
         # root/hybr with gradient, equal pipes -> equal flows
-        k = np.ones(4) * 0.5
+        k = np.full(4, 0.5)
         Qtot = 4
         initial_guess = array([[2., 0., 2., 0.]])
         final_flows = optimize.root(pressure_network, initial_guess,
@@ -235,7 +235,7 @@ class TestRootHybr(object):
     def test_pressure_network_with_gradient_combined(self):
         # root/hybr with gradient and function combined, equal pipes -> equal
         # flows
-        k = np.ones(4) * 0.5
+        k = np.full(4, 0.5)
         Qtot = 4
         initial_guess = array([2., 0., 2., 0.])
         final_flows = optimize.root(pressure_network_fun_and_grad,
@@ -247,7 +247,7 @@ class TestRootHybr(object):
 class TestRootLM(object):
     def test_pressure_network_no_gradient(self):
         # root/lm without gradient, equal pipes -> equal flows
-        k = np.ones(4) * 0.5
+        k = np.full(4, 0.5)
         Qtot = 4
         initial_guess = array([2., 0., 2., 0.])
         final_flows = optimize.root(pressure_network, initial_guess,

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -662,7 +662,7 @@ class TestOptimizeSimple(CheckOptimize):
         f = optimize.rosen
         g = optimize.rosen_der
         values = []
-        x0 = np.ones(7) * 1000
+        x0 = np.full(7, 1000)
 
         def objfun(x):
             value = f(x)

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -661,7 +661,7 @@ def test_gh_9608_preserve_array_shape():
         )
 
     def fpp_array(x):
-        return 2*np.ones(np.shape(x), dtype=np.float32)
+        return np.full(np.shape(x), 2, dtype=np.float32)
 
     result = zeros.newton(
         f, x0_array, fprime=fp, fprime2=fpp_array, full_output=True

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -11,7 +11,7 @@ import numpy as np
 from numpy import (atleast_1d, poly, polyval, roots, real, asarray,
                    resize, pi, absolute, logspace, r_, sqrt, tan, log10,
                    arctan, arcsinh, sin, exp, cosh, arccosh, ceil, conjugate,
-                   zeros, sinh, append, concatenate, prod, ones, array,
+                   zeros, sinh, append, concatenate, prod, ones, full, array,
                    mintypecode)
 from numpy.polynomial.polynomial import polyval as npp_polyval
 
@@ -2747,8 +2747,8 @@ def lp2bs_zpk(z, p, k, wo=1.0, bw=1.0):
                         p_hp - sqrt(p_hp**2 - wo**2)))
 
     # Move any zeros that were at infinity to the center of the stopband
-    z_bs = append(z_bs, +1j*wo * ones(degree))
-    z_bs = append(z_bs, -1j*wo * ones(degree))
+    z_bs = append(z_bs, full(degree, +1j*wo))
+    z_bs = append(z_bs, full(degree, -1j*wo))
 
     # Cancel out gain change caused by inversion
     k_bs = k * real(prod(-z) / prod(-p))

--- a/scipy/signal/tests/test_cont2discrete.py
+++ b/scipy/signal/tests/test_cont2discrete.py
@@ -17,12 +17,12 @@ from scipy.signal import tf2ss, impulse2, dimpulse, step2, dstep
 class TestC2D(object):
     def test_zoh(self):
         ac = np.eye(2)
-        bc = 0.5 * np.ones((2, 1))
+        bc = np.full((2, 1), 0.5)
         cc = np.array([[0.75, 1.0], [1.0, 1.0], [1.0, 0.25]])
         dc = np.array([[0.0], [0.0], [-0.33]])
 
         ad_truth = 1.648721270700128 * np.eye(2)
-        bd_truth = 0.324360635350064 * np.ones((2, 1))
+        bd_truth = np.full((2, 1), 0.324360635350064)
         # c and d in discrete should be equal to their continuous counterparts
         dt_requested = 0.5
 
@@ -36,13 +36,13 @@ class TestC2D(object):
 
     def test_foh(self):
         ac = np.eye(2)
-        bc = 0.5 * np.ones((2, 1))
+        bc = np.full((2, 1), 0.5)
         cc = np.array([[0.75, 1.0], [1.0, 1.0], [1.0, 0.25]])
         dc = np.array([[0.0], [0.0], [-0.33]])
 
         # True values are verified with Matlab
         ad_truth = 1.648721270700128 * np.eye(2)
-        bd_truth = 0.420839287058789 * np.ones((2, 1))
+        bd_truth = np.full((2, 1), 0.420839287058789)
         cd_truth = cc
         dd_truth = np.array([[0.260262223725224],
                              [0.297442541400256],
@@ -59,13 +59,13 @@ class TestC2D(object):
 
     def test_impulse(self):
         ac = np.eye(2)
-        bc = 0.5 * np.ones((2, 1))
+        bc = np.full((2, 1), 0.5)
         cc = np.array([[0.75, 1.0], [1.0, 1.0], [1.0, 0.25]])
         dc = np.array([[0.0], [0.0], [0.0]])
 
         # True values are verified with Matlab
         ad_truth = 1.648721270700128 * np.eye(2)
-        bd_truth = 0.412180317675032 * np.ones((2, 1))
+        bd_truth = np.full((2, 1), 0.412180317675032)
         cd_truth = cc
         dd_truth = np.array([[0.4375], [0.5], [0.3125]])
         dt_requested = 0.5
@@ -81,7 +81,7 @@ class TestC2D(object):
 
     def test_gbt(self):
         ac = np.eye(2)
-        bc = 0.5 * np.ones((2, 1))
+        bc = np.full((2, 1), 0.5)
         cc = np.array([[0.75, 1.0], [1.0, 1.0], [1.0, 0.25]])
         dc = np.array([[0.0], [0.0], [-0.33]])
 
@@ -89,7 +89,7 @@ class TestC2D(object):
         alpha = 1.0 / 3.0
 
         ad_truth = 1.6 * np.eye(2)
-        bd_truth = 0.3 * np.ones((2, 1))
+        bd_truth = np.full((2, 1), 0.3)
         cd_truth = np.array([[0.9, 1.2],
                              [1.2, 1.2],
                              [1.2, 0.3]])
@@ -107,14 +107,14 @@ class TestC2D(object):
 
     def test_euler(self):
         ac = np.eye(2)
-        bc = 0.5 * np.ones((2, 1))
+        bc = np.full((2, 1), 0.5)
         cc = np.array([[0.75, 1.0], [1.0, 1.0], [1.0, 0.25]])
         dc = np.array([[0.0], [0.0], [-0.33]])
 
         dt_requested = 0.5
 
         ad_truth = 1.5 * np.eye(2)
-        bd_truth = 0.25 * np.ones((2, 1))
+        bd_truth = np.full((2, 1), 0.25)
         cd_truth = np.array([[0.75, 1.0],
                              [1.0, 1.0],
                              [1.0, 0.25]])
@@ -131,14 +131,14 @@ class TestC2D(object):
 
     def test_backward_diff(self):
         ac = np.eye(2)
-        bc = 0.5 * np.ones((2, 1))
+        bc = np.full((2, 1), 0.5)
         cc = np.array([[0.75, 1.0], [1.0, 1.0], [1.0, 0.25]])
         dc = np.array([[0.0], [0.0], [-0.33]])
 
         dt_requested = 0.5
 
         ad_truth = 2.0 * np.eye(2)
-        bd_truth = 0.5 * np.ones((2, 1))
+        bd_truth = np.full((2, 1), 0.5)
         cd_truth = np.array([[1.5, 2.0],
                              [2.0, 2.0],
                              [2.0, 0.5]])
@@ -156,14 +156,14 @@ class TestC2D(object):
 
     def test_bilinear(self):
         ac = np.eye(2)
-        bc = 0.5 * np.ones((2, 1))
+        bc = np.full((2, 1), 0.5)
         cc = np.array([[0.75, 1.0], [1.0, 1.0], [1.0, 0.25]])
         dc = np.array([[0.0], [0.0], [-0.33]])
 
         dt_requested = 0.5
 
         ad_truth = (5.0 / 3.0) * np.eye(2)
-        bd_truth = (1.0 / 3.0) * np.ones((2, 1))
+        bd_truth = np.full((2, 1), 1.0 / 3.0)
         cd_truth = np.array([[1.0, 4.0 / 3.0],
                              [4.0 / 3.0, 4.0 / 3.0],
                              [4.0 / 3.0, 1.0 / 3.0]])
@@ -183,7 +183,7 @@ class TestC2D(object):
         # Same continuous system again, but change sampling rate
 
         ad_truth = 1.4 * np.eye(2)
-        bd_truth = 0.2 * np.ones((2, 1))
+        bd_truth = np.full((2, 1), 0.2)
         cd_truth = np.array([[0.9, 1.2], [1.2, 1.2], [1.2, 0.3]])
         dd_truth = np.array([[0.175], [0.2], [-0.205]])
 

--- a/scipy/signal/tests/test_dltisys.py
+++ b/scipy/signal/tests/test_dltisys.py
@@ -27,8 +27,8 @@ class TestDLTI(object):
         # Create an input matrix with inputs down the columns (3 cols) and its
         # respective time input vector
         u = np.hstack((np.linspace(0, 4.0, num=5)[:, np.newaxis],
-                       0.01 * np.ones((5, 1)),
-                       -0.002 * np.ones((5, 1))))
+                       np.full((5, 1), 0.01),
+                       np.full((5, 1), -0.002)))
         t_in = np.linspace(0, 2.0, num=5)
 
         # Define the known result

--- a/scipy/signal/tests/test_fir_filter_design.py
+++ b/scipy/signal/tests/test_fir_filter_design.py
@@ -565,7 +565,7 @@ class TestMinimumPhase(object):
         # not enough taps
         assert_raises(ValueError, minimum_phase, [1.])
         assert_raises(ValueError, minimum_phase, [1., 1.])
-        assert_raises(ValueError, minimum_phase, np.ones(10) * 1j)
+        assert_raises(ValueError, minimum_phase, np.full(10, 1j))
         assert_raises(ValueError, minimum_phase, 'foo')
         assert_raises(ValueError, minimum_phase, np.ones(10), n_fft=8)
         assert_raises(ValueError, minimum_phase, np.ones(10), method='foo')

--- a/scipy/signal/tests/test_max_len_seq.py
+++ b/scipy/signal/tests/test_max_len_seq.py
@@ -52,7 +52,7 @@ class TestMLS(object):
                     assert_allclose(tester[0], out_len, err_msg=err_msg)
                     # steady-state is -1
                     err_msg = "mls steady-state has incorrect value"
-                    assert_allclose(tester[1:], -1 * np.ones(out_len - 1),
+                    assert_allclose(tester[1:], np.full(out_len - 1, -1),
                                     err_msg=err_msg)
                     # let's do the split thing using a couple options
                     for n in (1, 2**(nbits - 1)):

--- a/scipy/signal/tests/test_peak_finding.py
+++ b/scipy/signal/tests/test_peak_finding.py
@@ -149,18 +149,18 @@ class TestRidgeLines(object):
 
     def test_empty(self):
         test_matr = np.zeros([20, 100])
-        lines = _identify_ridge_lines(test_matr, 2*np.ones(20), 1)
+        lines = _identify_ridge_lines(test_matr, np.full(20, 2), 1)
         assert_(len(lines) == 0)
 
     def test_minimal(self):
         test_matr = np.zeros([20, 100])
         test_matr[0, 10] = 1
-        lines = _identify_ridge_lines(test_matr, 2*np.ones(20), 1)
+        lines = _identify_ridge_lines(test_matr, np.full(20, 2), 1)
         assert_(len(lines) == 1)
 
         test_matr = np.zeros([20, 100])
         test_matr[0:2, 10] = 1
-        lines = _identify_ridge_lines(test_matr, 2*np.ones(20), 1)
+        lines = _identify_ridge_lines(test_matr, np.full(20, 2), 1)
         assert_(len(lines) == 1)
 
     def test_single_pass(self):
@@ -170,7 +170,7 @@ class TestRidgeLines(object):
         length = 12
         line = _gen_ridge_line([0, 25], test_matr.shape, length, distances, gaps)
         test_matr[line[0], line[1]] = 1
-        max_distances = max(distances)*np.ones(20)
+        max_distances = np.full(20, max(distances))
         identified_lines = _identify_ridge_lines(test_matr, max_distances, max(gaps) + 1)
         assert_array_equal(identified_lines, [line])
 
@@ -182,7 +182,7 @@ class TestRidgeLines(object):
         line = _gen_ridge_line([0, 25], test_matr.shape, length, distances, gaps)
         test_matr[line[0], line[1]] = 1
         max_dist = 3
-        max_distances = max_dist*np.ones(20)
+        max_distances = np.full(20, max_dist)
         #This should get 2 lines, since the distance is too large
         identified_lines = _identify_ridge_lines(test_matr, max_distances, max(gaps) + 1)
         assert_(len(identified_lines) == 2)
@@ -203,7 +203,7 @@ class TestRidgeLines(object):
         line = _gen_ridge_line([0, 25], test_matr.shape, length, distances, gaps)
         test_matr[line[0], line[1]] = 1
         max_dist = 6
-        max_distances = max_dist*np.ones(20)
+        max_distances = np.full(20, max_dist)
         #This should get 2 lines, since the gap is too large
         identified_lines = _identify_ridge_lines(test_matr, max_distances, max_gap)
         assert_(len(identified_lines) == 2)
@@ -224,7 +224,7 @@ class TestRidgeLines(object):
         line = _gen_ridge_line([0, 25], test_matr.shape, length, distances, gaps)
         test_matr[line[0], line[1]] = 1
         max_dist = 1
-        max_distances = max_dist*np.ones(50)
+        max_distances = np.full(50, max_dist)
         #This should get 3 lines, since the gaps are too large
         identified_lines = _identify_ridge_lines(test_matr, max_distances, max_gap)
         assert_(len(identified_lines) == 3)

--- a/scipy/signal/tests/test_savitzky_golay.py
+++ b/scipy/signal/tests/test_savitzky_golay.py
@@ -127,7 +127,7 @@ def test_sg_coeffs_deriv():
     i = np.array([-2.0, 0.0, 2.0, 4.0, 6.0])
     x = i ** 2 / 4
     dx = i / 2
-    d2x = 0.5 * np.ones_like(i)
+    d2x = np.full_like(i, 0.5)
     for pos in range(x.size):
         coeffs0 = savgol_coeffs(5, 3, pos=pos, delta=2.0, use='dot')
         assert_allclose(coeffs0.dot(x), x[pos], atol=1e-10)
@@ -227,7 +227,7 @@ def test_sg_filter_interp_edges():
                    6 * t,
                    3 * t ** 2 - 1.0])
     d2x = np.array([np.zeros_like(t),
-                    6 * np.ones_like(t),
+                    np.full_like(t, 6),
                     6 * t])
 
     window_length = 7

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -42,7 +42,7 @@ class TestPeriodogram(object):
         x[0] = 1
         f, p = periodogram(x, return_onesided=False)
         assert_allclose(f, fftfreq(16, 1.0))
-        q = np.ones(16)/16.0
+        q = np.full(16, 1/16.0)
         q[0] = 0
         assert_allclose(p, q)
 
@@ -80,7 +80,7 @@ class TestPeriodogram(object):
         x[0] = 1
         f, p = periodogram(x, return_onesided=False)
         assert_allclose(f, fftfreq(16, 1.0))
-        q = np.ones(16)/16.0
+        q = np.full(16, 1/16.0)
         q[0] = 0
         assert_allclose(p, q)
 
@@ -89,7 +89,7 @@ class TestPeriodogram(object):
         x[0] = 1.0 + 2.0j
         f, p = periodogram(x, return_onesided=False)
         assert_allclose(f, fftfreq(16, 1.0))
-        q = 5.0*np.ones(16)/16.0
+        q = np.full(16, 5.0/16.0)
         q[0] = 0
         assert_allclose(p, q)
 
@@ -203,7 +203,7 @@ class TestPeriodogram(object):
         x[0] = 1
         f, p = periodogram(x, return_onesided=False)
         assert_allclose(f, fftfreq(16, 1.0))
-        q = np.ones(16, 'f')/16.0
+        q = np.full(16, 1/16.0, 'f')
         q[0] = 0
         assert_allclose(p, q)
         assert_(p.dtype == q.dtype)
@@ -213,7 +213,7 @@ class TestPeriodogram(object):
         x[0] = 1.0 + 2.0j
         f, p = periodogram(x, return_onesided=False)
         assert_allclose(f, fftfreq(16, 1.0))
-        q = 5.0*np.ones(16, 'f')/16.0
+        q = np.full(16, 5.0/16.0, 'f')
         q[0] = 0
         assert_allclose(p, q)
         assert_(p.dtype == q.dtype)

--- a/scipy/signal/tests/test_wavelets.py
+++ b/scipy/signal/tests/test_wavelets.py
@@ -126,7 +126,7 @@ class TestWavelets(object):
 
         widths = [len_data * 10]
         #Note: this wavelet isn't defined quite right, but is fine for this test
-        flat_wavelet = lambda l, w: np.ones(w) / w
+        flat_wavelet = lambda l, w: np.full(w, 1 / w)
         cwt_dat = wavelets.cwt(test_data, flat_wavelet, widths)
         assert_array_almost_equal(cwt_dat, np.mean(test_data))
 

--- a/scipy/sparse/linalg/isolve/minres.py
+++ b/scipy/sparse/linalg/isolve/minres.py
@@ -348,7 +348,7 @@ def minres(A, b, x0=None, shift=0.0, tol=1e-5, maxiter=None,
 
 
 if __name__ == '__main__':
-    from numpy import ones, arange
+    from numpy import zeros, arange
     from scipy.linalg import norm
     from scipy.sparse import spdiags
 
@@ -363,6 +363,6 @@ if __name__ == '__main__':
     A = spdiags([arange(1,n+1,dtype=float)], [0], n, n, format='csr')
     M = spdiags([1.0/arange(1,n+1,dtype=float)], [0], n, n, format='csr')
     A.psolve = M.matvec
-    b = 0*ones(A.shape[0])
+    b = zeros(A.shape[0])
     x = minres(A,b,tol=1e-12,maxiter=None,callback=cb)
     # x = cg(A,b,x0=b,tol=1e-12,maxiter=None,callback=cb)[0]

--- a/scipy/sparse/linalg/tests/test_expm_multiply.py
+++ b/scipy/sparse/linalg/tests/test_expm_multiply.py
@@ -209,7 +209,7 @@ class TestExpmActionInterval(object):
     
         # Test A int, B complex
         A = scipy.sparse.diags(np.arange(5),format='csr', dtype=int)
-        B = 1j*np.ones(5, dtype=complex)
+        B = np.full(5, 1j, dtype=complex)
         Aexpm = scipy.sparse.diags(np.exp(np.arange(5)),format='csr')
         assert_allclose(expm_multiply(A,B,0,1)[-1], Aexpm.dot(B))
 

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -334,7 +334,7 @@ class Test_random_ball_compiled_periodic(ball_consistency):
         np.random.seed(1234)
         self.data = np.random.uniform(size=(n,m))
         self.T = cKDTree(self.data,leafsize=2, boxsize=1)
-        self.x = np.ones(m) * 0.1
+        self.x = np.full(m, 0.1)
         self.p = 2.
         self.eps = 0
         self.d = 0.2
@@ -1308,8 +1308,8 @@ def test_ckdtree_duplicated_inputs():
     n = 1024
     for m in range(1, 8):
         data = np.concatenate([
-            np.ones((n // 2, m)) * 1,
-            np.ones((n // 2, m)) * 2], axis=0)
+            np.full((n // 2, m), 1),
+            np.full((n // 2, m), 2)], axis=0)
 
         # it shall not divide more than 3 nodes.
         # root left (1), and right (2)

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1552,10 +1552,10 @@ class TestEllip(object):
             mvals.append(m)
             m = np.nextafter(m, 1)
         f = special.ellipkinc(phi, mvals)
-        assert_array_almost_equal_nulp(f, 1.0259330100195334 * np.ones_like(f), 1)
+        assert_array_almost_equal_nulp(f, np.full_like(f, 1.0259330100195334), 1)
         # this bug also appears at phi + n * pi for at least small n
         f1 = special.ellipkinc(phi + pi, mvals)
-        assert_array_almost_equal_nulp(f1, 5.1296650500976675 * np.ones_like(f1), 2)
+        assert_array_almost_equal_nulp(f1, np.full_like(f1, 5.1296650500976675), 2)
 
     def test_ellipkinc_singular(self):
         # ellipkinc(phi, 1) has closed form and is finite only for phi in (-pi/2, pi/2)
@@ -1620,10 +1620,10 @@ class TestEllip(object):
             mvals.append(m)
             m = np.nextafter(m, 1)
         f = special.ellipeinc(phi, mvals)
-        assert_array_almost_equal_nulp(f, 0.84442884574781019 * np.ones_like(f), 2)
+        assert_array_almost_equal_nulp(f, np.full_like(f, 0.84442884574781019), 2)
         # this bug also appears at phi + n * pi for at least small n
         f1 = special.ellipeinc(phi + pi, mvals)
-        assert_array_almost_equal_nulp(f1, 3.3471442287390509 * np.ones_like(f1), 4)
+        assert_array_almost_equal_nulp(f1, np.full_like(f1, 3.3471442287390509), 4)
 
 
 class TestErf(object):

--- a/scipy/special/tests/test_ellip_harm.py
+++ b/scipy/special/tests/test_ellip_harm.py
@@ -160,7 +160,7 @@ def test_ellip_norm():
     points = []
     for n in range(4):
         for p in range(1, 2*n+2):
-            points.append((h2, k2, n*np.ones(h2.size), p*np.ones(h2.size)))
+            points.append((h2, k2, np.full(h2.size, n), np.full(h2.size, p)))
     points = np.array(points)
     with suppress_warnings() as sup:
         sup.filter(IntegrationWarning, "The occurrence of roundoff error")

--- a/scipy/special/tests/test_spherical_bessel.py
+++ b/scipy/special/tests/test_spherical_bessel.py
@@ -113,7 +113,7 @@ class TestSphericalYn:
         # https://dlmf.nist.gov/10.52.E2
         n = np.array([0, 1, 2, 5, 10, 100])
         x = 0
-        assert_allclose(spherical_yn(n, x), -inf*np.ones(shape=n.shape))
+        assert_allclose(spherical_yn(n, x), np.full(n.shape, -inf))
 
     def test_spherical_yn_at_zero_complex(self):
         # Consistently with numpy:
@@ -123,7 +123,7 @@ class TestSphericalYn:
         # (-inf + nan*j)
         n = np.array([0, 1, 2, 5, 10, 100])
         x = 0 + 0j
-        assert_allclose(spherical_yn(n, x), nan*np.ones(shape=n.shape))
+        assert_allclose(spherical_yn(n, x), np.full(n.shape, nan))
 
 
 class TestSphericalJnYnCrossProduct:
@@ -232,13 +232,13 @@ class TestSphericalKn:
         # https://dlmf.nist.gov/10.52.E2
         n = np.array([0, 1, 2, 5, 10, 100])
         x = 0
-        assert_allclose(spherical_kn(n, x), inf*np.ones(shape=n.shape))
+        assert_allclose(spherical_kn(n, x), np.full(n.shape, inf))
 
     def test_spherical_kn_at_zero_complex(self):
         # https://dlmf.nist.gov/10.52.E2
         n = np.array([0, 1, 2, 5, 10, 100])
         x = 0 + 0j
-        assert_allclose(spherical_kn(n, x), nan*np.ones(shape=n.shape))
+        assert_allclose(spherical_kn(n, x), np.full(n.shape, nan))
 
 
 class SphericalDerivativesTestCase:

--- a/scipy/stats/kde.py
+++ b/scipy/stats/kde.py
@@ -526,7 +526,7 @@ class gaussian_kde(object):
 
         >>> import matplotlib.pyplot as plt
         >>> fig, ax = plt.subplots()
-        >>> ax.plot(x1, np.ones(x1.shape) / (4. * x1.size), 'bo',
+        >>> ax.plot(x1, np.full(x1.shape, 1 / (4. * x1.size)), 'bo',
         ...         label='Data points (rescaled)')
         >>> ax.plot(xs, y1, label='Scott (default)')
         >>> ax.plot(xs, y2, label='Silverman')

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -115,7 +115,7 @@ def test_rvs_broadcast(dist, shape_args):
     for k in range(nargs):
         shp = (k + 3,) + (1,)*(k + 1)
         param_val = shape_args[k]
-        allargs.append(np.full(shp, param_val, dtype=np.array(param_val).dtype))
+        allargs.append(np.full(shp, param_val))
         bshape.insert(0, shp[0])
     allargs.append(loc)
     bshape.append(loc.size)

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -115,7 +115,7 @@ def test_rvs_broadcast(dist, shape_args):
     for k in range(nargs):
         shp = (k + 3,) + (1,)*(k + 1)
         param_val = shape_args[k]
-        allargs.append(param_val*np.ones(shp, dtype=np.array(param_val).dtype))
+        allargs.append(np.full(shp, param_val, dtype=np.array(param_val).dtype))
         bshape.insert(0, shp[0])
     allargs.append(loc)
     bshape.append(loc.size)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1313,15 +1313,15 @@ class TestRvDiscrete(object):
         # tests added for gh-9565
 
         # mismatch of 2d inputs
-        xk, pk = np.arange(4).reshape((2, 2)), np.ones((2, 3)) / 6
+        xk, pk = np.arange(4).reshape((2, 2)), np.full((2, 3), 1/6)
         assert_raises(ValueError, stats.rv_discrete, **dict(values=(xk, pk)))
 
         # same number of elements, but shapes not compatible
-        xk, pk = np.arange(6).reshape((3, 2)), np.ones((2, 3)) / 6
+        xk, pk = np.arange(6).reshape((3, 2)), np.full((2, 3), 1/6)
         assert_raises(ValueError, stats.rv_discrete, **dict(values=(xk, pk)))
 
         # same shapes => no error
-        xk, pk = np.arange(6).reshape((3, 2)), np.ones((3, 2)) / 6
+        xk, pk = np.arange(6).reshape((3, 2)), np.full((3, 2), 1/6)
         assert_equal(stats.rv_discrete(values=(xk, pk)).pmf(0), 1/6)
 
 

--- a/scipy/stats/tests/test_fit.py
+++ b/scipy/stats/tests/test_fit.py
@@ -72,7 +72,7 @@ def test_cont_fit(distname, arg):
 
     truearg = np.hstack([arg, [0.0, 1.0]])
     diffthreshold = np.max(np.vstack([truearg*thresh_percent,
-                                      np.ones(distfn.numargs+2)*thresh_min]),
+                                      np.full(distfn.numargs+2, thresh_min)]),
                            0)
 
     for fit_size in fit_sizes:

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -1079,8 +1079,8 @@ class TestCompareWithStats(object):
         np.random.seed(1234567)
         x = np.random.randn(n)
         y = x + np.random.randn(n)
-        xm = np.ones(len(x) + 5) * 1e16
-        ym = np.ones(len(y) + 5) * 1e16
+        xm = np.full(len(x) + 5, 1e16)
+        ym = np.full(len(y) + 5, 1e16)
         xm[0:len(x)] = x
         ym[0:len(y)] = y
         mask = xm > 9e15
@@ -1089,10 +1089,10 @@ class TestCompareWithStats(object):
         return x, y, xm, ym
 
     def generate_xy_sample2D(self, n, nx):
-        x = np.ones((n, nx)) * np.nan
-        y = np.ones((n, nx)) * np.nan
-        xm = np.ones((n+5, nx)) * np.nan
-        ym = np.ones((n+5, nx)) * np.nan
+        x = np.full((n, nx), np.nan)
+        y = np.full((n, nx), np.nan)
+        xm = np.full((n+5, nx), np.nan)
+        ym = np.full((n+5, nx), np.nan)
 
         for i in range(nx):
             x[:, i], y[:, i], dx, dy = self.generate_xy_sample(n)

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -283,7 +283,7 @@ class TestMultivariateNormal(object):
         x = np.random.randn(n, n)
         cov = np.dot(x, x.T)
         s, u = scipy.linalg.eigh(cov)
-        s = 0.5 * np.ones(n)
+        s = np.full(n, 0.5)
         s[0] = 1.0
         s[-1] = 1e-7
         cov = np.dot(u, np.dot(np.diag(s), u.T))
@@ -461,9 +461,9 @@ class TestMatrixNormal(object):
         # Check that bad inputs raise errors
         num_rows = 4
         num_cols = 3
-        M = 0.3 * np.ones((num_rows,num_cols))
-        U = 0.5 * np.identity(num_rows) + 0.5 * np.ones((num_rows, num_rows))
-        V = 0.7 * np.identity(num_cols) + 0.3 * np.ones((num_cols, num_cols))
+        M = np.full((num_rows,num_cols), 0.3)
+        U = 0.5 * np.identity(num_rows) + np.full((num_rows, num_rows), 0.5)
+        V = 0.7 * np.identity(num_cols) + np.full((num_cols, num_cols), 0.3)
 
         # Incorrect dimensions
         assert_raises(ValueError, matrix_normal, np.zeros((5,4,3)))
@@ -482,9 +482,9 @@ class TestMatrixNormal(object):
         # Check that default argument handling works
         num_rows = 4
         num_cols = 3
-        M = 0.3 * np.ones((num_rows,num_cols))
-        U = 0.5 * np.identity(num_rows) + 0.5 * np.ones((num_rows, num_rows))
-        V = 0.7 * np.identity(num_cols) + 0.3 * np.ones((num_cols, num_cols))
+        M = np.full((num_rows,num_cols), 0.3)
+        U = 0.5 * np.identity(num_rows) + np.full((num_rows, num_rows), 0.5)
+        V = 0.7 * np.identity(num_cols) + np.full((num_cols, num_cols), 0.3)
         Z = np.zeros((num_rows, num_cols))
         Zr = np.zeros((num_rows, 1))
         Zc = np.zeros((1, num_cols))
@@ -521,10 +521,10 @@ class TestMatrixNormal(object):
         # Check that covariance can be specified with scalar or vector
         num_rows = 4
         num_cols = 3
-        M = 0.3 * np.ones((num_rows,num_cols))
-        Uv = 0.2*np.ones(num_rows)
+        M = np.full((num_rows, num_cols), 0.3)
+        Uv = np.full(num_rows, 0.2)
         Us = 0.2
-        Vv = 0.1*np.ones(num_cols)
+        Vv = np.full(num_cols, 0.1)
         Vs = 0.1
 
         Ir = np.identity(num_rows)
@@ -542,9 +542,9 @@ class TestMatrixNormal(object):
     def test_frozen_matrix_normal(self):
         for i in range(1,5):
             for j in range(1,5):
-                M = 0.3 * np.ones((i,j))
-                U = 0.5 * np.identity(i) + 0.5 * np.ones((i,i))
-                V = 0.7 * np.identity(j) + 0.3 * np.ones((j,j))
+                M = np.full((i,j), 0.3)
+                U = 0.5 * np.identity(i) + np.full((i,i), 0.5)
+                V = 0.7 * np.identity(j) + np.full((j,j), 0.3)
 
                 frozen = matrix_normal(mean=M, rowcov=U, colcov=V)
 
@@ -568,9 +568,9 @@ class TestMatrixNormal(object):
         # treating as a multivariate normal.
         for i in range(1,5):
             for j in range(1,5):
-                M = 0.3 * np.ones((i,j))
-                U = 0.5 * np.identity(i) + 0.5 * np.ones((i,i))
-                V = 0.7 * np.identity(j) + 0.3 * np.ones((j,j))
+                M = np.full((i,j), 0.3)
+                U = 0.5 * np.identity(i) + np.full((i,i), 0.5)
+                V = 0.7 * np.identity(j) + np.full((j,j), 0.3)
 
                 frozen = matrix_normal(mean=M, rowcov=U, colcov=V)
                 X = frozen.rvs(random_state=1234)
@@ -590,9 +590,9 @@ class TestMatrixNormal(object):
         # Check array of inputs has the same output as the separate entries.
         num_rows = 4
         num_cols = 3
-        M = 0.3 * np.ones((num_rows,num_cols))
-        U = 0.5 * np.identity(num_rows) + 0.5 * np.ones((num_rows, num_rows))
-        V = 0.7 * np.identity(num_cols) + 0.3 * np.ones((num_cols, num_cols))
+        M = np.full((num_rows,num_cols), 0.3)
+        U = 0.5 * np.identity(num_rows) + np.full((num_rows, num_rows), 0.5)
+        V = 0.7 * np.identity(num_cols) + np.full((num_cols, num_cols), 0.3)
         N = 10
 
         frozen = matrix_normal(mean=M, rowcov=U, colcov=V)
@@ -613,9 +613,9 @@ class TestMatrixNormal(object):
         # Check that the sample moments match the parameters
         num_rows = 4
         num_cols = 3
-        M = 0.3 * np.ones((num_rows,num_cols))
-        U = 0.5 * np.identity(num_rows) + 0.5 * np.ones((num_rows, num_rows))
-        V = 0.7 * np.identity(num_cols) + 0.3 * np.ones((num_cols, num_cols))
+        M = np.full((num_rows,num_cols), 0.3)
+        U = 0.5 * np.identity(num_rows) + np.full((num_rows, num_rows), 0.5)
+        V = 0.7 * np.identity(num_cols) + np.full((num_cols, num_cols), 0.3)
         N = 1000
 
         frozen = matrix_normal(mean=M, rowcov=U, colcov=V)
@@ -708,37 +708,37 @@ class TestDirichlet(object):
 
     def test_data_too_deep_c(self):
         alpha = np.array([1.0, 2.0, 3.0])
-        x = np.ones((2, 7, 7)) / 14
+        x = np.full((2, 7, 7), 1 / 14)
         assert_raises(ValueError, dirichlet.pdf, x, alpha)
         assert_raises(ValueError, dirichlet.logpdf, x, alpha)
 
     def test_alpha_too_deep(self):
         alpha = np.array([[1.0, 2.0], [3.0, 4.0]])
-        x = np.ones((2, 2, 7)) / 4
+        x = np.full((2, 2, 7), 1 / 4)
         assert_raises(ValueError, dirichlet.pdf, x, alpha)
         assert_raises(ValueError, dirichlet.logpdf, x, alpha)
 
     def test_alpha_correct_depth(self):
         alpha = np.array([1.0, 2.0, 3.0])
-        x = np.ones((3, 7)) / 3
+        x = np.full((3, 7), 1 / 3)
         dirichlet.pdf(x, alpha)
         dirichlet.logpdf(x, alpha)
 
     def test_non_simplex_data(self):
         alpha = np.array([1.0, 2.0, 3.0])
-        x = np.ones((3, 7)) / 2
+        x = np.full((3, 7), 1 / 2)
         assert_raises(ValueError, dirichlet.pdf, x, alpha)
         assert_raises(ValueError, dirichlet.logpdf, x, alpha)
 
     def test_data_vector_too_short(self):
         alpha = np.array([1.0, 2.0, 3.0, 4.0])
-        x = np.ones((2, 7)) / 2
+        x = np.full((2, 7), 1 / 2)
         assert_raises(ValueError, dirichlet.pdf, x, alpha)
         assert_raises(ValueError, dirichlet.logpdf, x, alpha)
 
     def test_data_vector_too_long(self):
         alpha = np.array([1.0, 2.0, 3.0, 4.0])
-        x = np.ones((5, 7)) / 5
+        x = np.full((5, 7), 1 / 5)
         assert_raises(ValueError, dirichlet.pdf, x, alpha)
         assert_raises(ValueError, dirichlet.logpdf, x, alpha)
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1896,10 +1896,10 @@ class TestIQR(object):
         y = np.ones((4, 5, 6)) * np.arange(6)
         assert_array_equal(stats.iqr(y, axis=0), np.zeros((5, 6)))
         assert_array_equal(stats.iqr(y, axis=1), np.zeros((4, 6)))
-        assert_array_equal(stats.iqr(y, axis=2), 2.5 * np.ones((4, 5)))
+        assert_array_equal(stats.iqr(y, axis=2), np.full((4, 5), 2.5))
         assert_array_equal(stats.iqr(y, axis=(0, 1)), np.zeros(6))
-        assert_array_equal(stats.iqr(y, axis=(0, 2)), 3. * np.ones(5))
-        assert_array_equal(stats.iqr(y, axis=(1, 2)), 3. * np.ones(4))
+        assert_array_equal(stats.iqr(y, axis=(0, 2)), np.full(5, 3.))
+        assert_array_equal(stats.iqr(y, axis=(1, 2)), np.full(4, 3.))
 
     def test_scalarlike(self):
         x = np.arange(1) + 7.0
@@ -1916,8 +1916,8 @@ class TestIQR(object):
     def test_2D(self):
         x = np.arange(15).reshape((3, 5))
         assert_equal(stats.iqr(x), 7.0)
-        assert_array_equal(stats.iqr(x, axis=0), 5. * np.ones(5))
-        assert_array_equal(stats.iqr(x, axis=1), 2. * np.ones(3))
+        assert_array_equal(stats.iqr(x, axis=0), np.full(5, 5.))
+        assert_array_equal(stats.iqr(x, axis=1), np.full(3, 2.))
         assert_array_equal(stats.iqr(x, axis=(0, 1)), 7.0)
         assert_array_equal(stats.iqr(x, axis=(1, 0)), 7.0)
 
@@ -2110,7 +2110,7 @@ class TestIQR(object):
                 _check_warnings(w, RuntimeWarning, 3)
             else:
                 assert_equal(stats.iqr(x, nan_policy='omit'), 7.5)
-                assert_equal(stats.iqr(x, axis=0, nan_policy='omit'), 5 * np.ones(5))
+                assert_equal(stats.iqr(x, axis=0, nan_policy='omit'), np.full(5, 5))
                 assert_equal(stats.iqr(x, axis=1, nan_policy='omit'), [2, 2.5, 2])
 
         assert_raises(ValueError, stats.iqr, x, nan_policy='raise')
@@ -3476,7 +3476,7 @@ class TestDescribe(object):
         assert_array_almost_equal(kurt, -3.0, decimal=13)
 
     def test_describe_numbers(self):
-        x = np.vstack((np.ones((3,4)), 2 * np.ones((2,4))))
+        x = np.vstack((np.ones((3,4)), np.full((2, 4), 2)))
         nc, mmc = (5, ([1., 1., 1., 1.], [2., 2., 2., 2.]))
         mc = np.array([1.4, 1.4, 1.4, 1.4])
         vc = np.array([0.3, 0.3, 0.3, 0.3])
@@ -3523,7 +3523,7 @@ class TestDescribe(object):
         check_named_results(actual, attributes)
 
     def test_describe_ddof(self):
-        x = np.vstack((np.ones((3, 4)), 2 * np.ones((2, 4))))
+        x = np.vstack((np.ones((3, 4)), np.full((2, 4), 2)))
         nc, mmc = (5, ([1., 1., 1., 1.], [2., 2., 2., 2.]))
         mc = np.array([1.4, 1.4, 1.4, 1.4])
         vc = np.array([0.24, 0.24, 0.24, 0.24])
@@ -3538,7 +3538,7 @@ class TestDescribe(object):
         assert_array_almost_equal(kurt, kurtc, decimal=13)
 
     def test_describe_axis_none(self):
-        x = np.vstack((np.ones((3, 4)), 2 * np.ones((2, 4))))
+        x = np.vstack((np.ones((3, 4)), np.full((2, 4), 2)))
 
         # expected values
         e_nobs, e_minmax = (20, (1.0, 2.0))


### PR DESCRIPTION
#### What does this implement/fix?
When c is a scalar, c * np.ones(...) and np.full(..., c, ...) produce the same output, but np.full is [faster](https://stackoverflow.com/a/45006691/125507)
and clearer in intent, so I (somewhat mechanically) replaced a lot of instances.

```
timeit np.ones((100, 1000)) / 12.
725 µs ± 37.3 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

timeit np.full((100, 1000), 1 / 12.)
75.2 µs ± 7.44 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

I did not change ones inside benchmarks or where I wasn't sure that it's always a scalar.