### PR TITLE
Univariate splines should require x to be strictly increasing for interpolation and increasing for smoothing

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -213,6 +213,7 @@ Aidan Dang for block QR wrappers in scipy.linalg.lapack.
 Clement Ng for modifying tests in scipy.stats.
 Fletcher H. Easton for a bug fix in scipy.linalg.interpolative.
 Christian Brueffer for improvements to code readability/style and documentation.
+Timothy C. Willard for contributions to x-value requirements in scipy.interpolate.
 
 
 Institutions

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -77,7 +77,8 @@ class UnivariateSpline(object):
     Parameters
     ----------
     x : (N,) array_like
-        1-D array of independent input data. Must be increasing.
+        1-D array of independent input data. Must be increasing;
+        must be strictly increasing if `s` is 0.
     y : (N,) array_like
         1-D array of dependent input data, of the same length as `x`.
     w : (N,) array_like, optional
@@ -173,8 +174,12 @@ class UnivariateSpline(object):
                     not w_finite):
                 raise ValueError("x and y array must not contain "
                                  "NaNs or infs.")
-        if not np.all(diff(x) > 0.0):
-            raise ValueError("x must be increasing")
+        if s is None or s > 0:
+            if not np.all(diff(x) >= 0.0):
+                raise ValueError("x must be increasing if s > 0")
+        else:
+            if not np.all(diff(x) > 0.0):
+                raise ValueError("x must be strictly increasing if s = 0")
 
         # _data == x,y,w,xb,xe,k,s,n,t,c,fp,fpint,nrdata,ier
         try:
@@ -531,7 +536,7 @@ class InterpolatedUnivariateSpline(UnivariateSpline):
     Parameters
     ----------
     x : (N,) array_like
-        Input dimension of data points -- must be increasing
+        Input dimension of data points -- must be strictly increasing
     y : (N,) array_like
         input dimension of data points
     w : (N,) array_like, optional
@@ -600,7 +605,7 @@ class InterpolatedUnivariateSpline(UnivariateSpline):
                     not w_finite):
                 raise ValueError("Input must not contain NaNs or infs.")
         if not np.all(diff(x) > 0.0):
-            raise ValueError('x must be increasing')
+            raise ValueError('x must be strictly increasing')
 
         # _data == x,y,w,xb,xe,k,s,n,t,c,fp,fpint,nrdata,ier
         self._data = dfitpack.fpcurf0(x, y, k, w=w, xb=bbox[0],
@@ -738,7 +743,7 @@ class LSQUnivariateSpline(UnivariateSpline):
             if (not np.isfinite(x).all() or not np.isfinite(y).all() or
                     not w_finite or not np.isfinite(t).all()):
                 raise ValueError("Input(s) must not contain NaNs or infs.")
-        if not np.all(diff(x) > 0.0):
+        if not np.all(diff(x) >= 0.0):
             raise ValueError('x must be increasing')
 
         # _data == x,y,w,xb,xe,k,s,n,t,c,fp,fpint,nrdata,ier

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -174,7 +174,7 @@ class UnivariateSpline(object):
                 raise ValueError("x and y array must not contain "
                                  "NaNs or infs.")
         if not np.all(diff(x) > 0.0):
-            raise ValueError('x must be strictly increasing')
+            raise ValueError("x must be increasing")
 
         # _data == x,y,w,xb,xe,k,s,n,t,c,fp,fpint,nrdata,ier
         try:
@@ -547,7 +547,8 @@ class InterpolatedUnivariateSpline(UnivariateSpline):
         not in the interval defined by the knot sequence.
 
         * if ext=0 or 'extrapolate', return the extrapolated value.
-        * if ext=1 or 'zeros', return 0
+        * if ext=1 all(diff(x) > 0.0):
++            raise ValueEror 'zeros', return 0
         * if ext=2 or 'raise', raise a ValueError
         * if ext=3 of 'const', return the boundary value.
 
@@ -600,7 +601,7 @@ class InterpolatedUnivariateSpline(UnivariateSpline):
                     not w_finite):
                 raise ValueError("Input must not contain NaNs or infs.")
         if not np.all(diff(x) > 0.0):
-            raise ValueError('x must be strictly increasing')
+            raise ValueError('x must be increasing')
 
         # _data == x,y,w,xb,xe,k,s,n,t,c,fp,fpint,nrdata,ier
         self._data = dfitpack.fpcurf0(x, y, k, w=w, xb=bbox[0],
@@ -739,7 +740,7 @@ class LSQUnivariateSpline(UnivariateSpline):
                     not w_finite or not np.isfinite(t).all()):
                 raise ValueError("Input(s) must not contain NaNs or infs.")
         if not np.all(diff(x) > 0.0):
-            raise ValueError('x must be strictly increasing')
+            raise ValueError('x must be increasing')
 
         # _data == x,y,w,xb,xe,k,s,n,t,c,fp,fpint,nrdata,ier
         xb = bbox[0]

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -547,8 +547,7 @@ class InterpolatedUnivariateSpline(UnivariateSpline):
         not in the interval defined by the knot sequence.
 
         * if ext=0 or 'extrapolate', return the extrapolated value.
-        * if ext=1 all(diff(x) > 0.0):
-+            raise ValueEror 'zeros', return 0
+        * if ext=1 or 'zeros', return 0
         * if ext=2 or 'raise', raise a ValueError
         * if ext=3 of 'const', return the boundary value.
 

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -177,11 +177,27 @@ class TestUnivariateSpline(object):
             assert_raises(ValueError, LSQUnivariateSpline,
                     **dict(x=x, y=y, t=t, w=w, check_finite=True))
 
-    def test_increasing_x(self):
+    def test_strictly_increasing_x(self):
+        # Test the x is not required to be strictly increasing, see ticket #8535
         xx = np.arange(10, dtype=float)
         yy = xx**3
         x = np.arange(10, dtype=float)
         x[1] = x[0]
+        y = x**3
+        w = np.ones_like(x)
+        # also test LSQUnivariateSpline [which needs explicit knots]
+        spl = UnivariateSpline(xx, yy, check_finite=True)
+        t = spl.get_knots()[3:4]  # interior knots w/ default k=3
+        spl2 = UnivariateSpline(x=x, y=y, w=w, check_finite=True)
+        spl3 = InterpolatedUnivariateSpline(x=x, y=y, check_finite=True)
+        spl4 = LSQUnivariateSpline(x=x, y=y, t=t, w=w, check_finite=True)
+    
+    def test_increasing_x(self):
+        # Test that x is required to be increasing, see ticket #8535
+        xx = np.arange(10, dtype=float)
+        yy = xx**3
+        x = np.arange(10, dtype=float)
+        x[1] = x[0] - 1.0
         y = x**3
         w = np.ones_like(x)
         # also test LSQUnivariateSpline [which needs explicit knots]

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -178,7 +178,10 @@ class TestUnivariateSpline(object):
                     **dict(x=x, y=y, t=t, w=w, check_finite=True))
 
     def test_strictly_increasing_x(self):
-        # Test the x is not required to be strictly increasing, see ticket #8535
+        # Test the x is required to be strictly increasing for
+        # UnivariateSpline if s=0 and for InterpolatedUnivariateSpline,
+        # but merely increasing for UnivariateSpline if s>0
+        # and for LSQUnivariateSpline; see ticket #8535
         xx = np.arange(10, dtype=float)
         yy = xx**3
         x = np.arange(10, dtype=float)
@@ -188,10 +191,13 @@ class TestUnivariateSpline(object):
         # also test LSQUnivariateSpline [which needs explicit knots]
         spl = UnivariateSpline(xx, yy, check_finite=True)
         t = spl.get_knots()[3:4]  # interior knots w/ default k=3
-        spl2 = UnivariateSpline(x=x, y=y, w=w, check_finite=True)
-        spl3 = InterpolatedUnivariateSpline(x=x, y=y, check_finite=True)
-        spl4 = LSQUnivariateSpline(x=x, y=y, t=t, w=w, check_finite=True)
-    
+        spl2 = UnivariateSpline(x=x, y=y, w=w, s=1, check_finite=True)
+        spl3 = LSQUnivariateSpline(x=x, y=y, t=t, w=w, check_finite=True)
+        assert_raises(ValueError, UnivariateSpline,
+                **dict(x=x, y=y, s=0, check_finite=True))
+        assert_raises(ValueError, InterpolatedUnivariateSpline,
+                **dict(x=x, y=y, check_finite=True))
+
     def test_increasing_x(self):
         # Test that x is required to be increasing, see ticket #8535
         xx = np.arange(10, dtype=float)


### PR DESCRIPTION
#### Reference issue
Closes gh-8535.

#### What does this implement/fix?
rebased gh-9085 and fixed merge conflicts, then implemented the suggestion of @jxrossel to have `x` be required to be increasing for interpolation (`UnivariateSpline(..., s=0)` `InterpolatedUnivariateSpline`) and merely increasing for smoothing (`UnivariateSpline(..., s>0)` and `LSQUnivariateSpline`).