### PR TITLE
ENH: Add parallel computation to scipy.fft

### DIFF
--- a/scipy/fft/__init__.py
+++ b/scipy/fft/__init__.py
@@ -55,6 +55,8 @@ Helper functions
    fftfreq - Return the Discrete Fourier Transform sample frequencies
    rfftfreq - DFT sample frequencies (for usage with rfft, irfft)
    next_fast_len - Find the optimal length to zero-pad an FFT for speed
+   set_workers - Context manager to set default number of workers
+   get_workers - Get the current default number of workers
 
 Backend control
 ===============
@@ -80,6 +82,7 @@ from ._helper import next_fast_len
 from ._backend import (set_backend, skip_backend, set_global_backend,
                        register_backend)
 from numpy.fft import fftfreq, rfftfreq, fftshift, ifftshift
+from ._pocketfft.helper import set_workers, get_workers
 
 __all__ = [
     'fft', 'ifft', 'fft2','ifft2', 'fftn', 'ifftn',
@@ -88,7 +91,8 @@ __all__ = [
     'fftfreq', 'rfftfreq', 'fftshift', 'ifftshift',
     'next_fast_len',
     'dct', 'idct', 'dst', 'idst', 'dctn', 'idctn', 'dstn', 'idstn',
-    'set_backend', 'skip_backend', 'set_global_backend', 'register_backend']
+    'set_backend', 'skip_backend', 'set_global_backend', 'register_backend',
+    'get_workers', 'set_workers']
 
 from numpy.dual import register_func
 for k in ['fft', 'ifft', 'fftn', 'ifftn', 'fft2', 'ifft2']:

--- a/scipy/fft/_basic.py
+++ b/scipy/fft/_basic.py
@@ -112,6 +112,12 @@ def fft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
     rely on the contents of ``x`` after the transform as this may change in
     future without warning.
 
+    The ``workers`` argument specifies the maximum number of parallel jobs to
+    split the FFT computation into. This will execute independent 1-dimensional
+    FFTs within ``x``. So, ``x`` must be at least 2-dimensional and the
+    non-transformed axes must be large enough to split into chunks. If ``x`` is
+    too small, fewer jobs may be used than requested.
+
     References
     ----------
     .. [1] Cooley, James W., and John W. Tukey, 1965, "An algorithm for the
@@ -188,7 +194,7 @@ def ifft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
         See :func:`fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater.
+        unlimited. Must be 0 or greater. See `fft` for more details.
 
     Returns
     -------
@@ -272,7 +278,7 @@ def rfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
         See :func:`fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater.
+        unlimited. Must be 0 or greater. See `fft` for more details.
 
     Returns
     -------
@@ -367,7 +373,7 @@ def irfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
         See :func:`fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater.
+        unlimited. Must be 0 or greater. See `fft` for more details.
 
     Returns
     -------
@@ -451,7 +457,7 @@ def hfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
         See `fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater.
+        unlimited. Must be 0 or greater. See `fft` for more details.
 
     Returns
     -------
@@ -524,7 +530,7 @@ def ihfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
         See `fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater.
+        unlimited. Must be 0 or greater. See `fft` for more details.
 
     Returns
     -------
@@ -589,7 +595,7 @@ def fftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
         See :func:`fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater.
+        unlimited. Must be 0 or greater. See `fft` for more details.
 
     Returns
     -------
@@ -694,7 +700,7 @@ def ifftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
         See :func:`fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater.
+        unlimited. Must be 0 or greater. See `fft` for more details.
 
     Returns
     -------
@@ -782,7 +788,7 @@ def fft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None):
         See :func:`fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater.
+        unlimited. Must be 0 or greater. See `fft` for more details.
 
     Returns
     -------
@@ -881,7 +887,7 @@ def ifft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None):
         See :func:`fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater.
+        unlimited. Must be 0 or greater. See `fft` for more details.
 
     Returns
     -------
@@ -965,7 +971,7 @@ def rfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
         See :func:`fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater.
+        unlimited. Must be 0 or greater. See `fft` for more details.
 
     Returns
     -------
@@ -1043,7 +1049,7 @@ def rfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None):
         See :func:`fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater.
+        unlimited. Must be 0 or greater. See `fft` for more details.
 
     Returns
     -------
@@ -1105,7 +1111,7 @@ def irfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
         See :func:`fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater.
+        unlimited. Must be 0 or greater. See `fft` for more details.
 
     Returns
     -------
@@ -1186,7 +1192,7 @@ def irfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False,
         See :func:`fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater.
+        unlimited. Must be 0 or greater. See `fft` for more details.
 
     Returns
     -------
@@ -1243,7 +1249,7 @@ def hfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
         See :func:`fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater.
+        unlimited. Must be 0 or greater. See `fft` for more details.
 
     Returns
     -------
@@ -1332,7 +1338,7 @@ def hfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None):
         See `fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater.
+        unlimited. Must be 0 or greater. See `fft` for more details.
 
     Returns
     -------
@@ -1386,7 +1392,7 @@ def ihfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
         See :func:`fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater.
+        unlimited. Must be 0 or greater. See `fft` for more details.
 
     Returns
     -------
@@ -1462,7 +1468,7 @@ def ihfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False,
         See :func:`fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater.
+        unlimited. Must be 0 or greater. See `fft` for more details.
 
     Returns
     -------

--- a/scipy/fft/_basic.py
+++ b/scipy/fft/_basic.py
@@ -50,7 +50,7 @@ def fft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
         See the notes below for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation. If negative,
-        the value wraps around from ``os.cpu_count()``. See `fft` for more
+        the value wraps around from ``os.cpu_count()``. See below for more
         details.
 
     Returns
@@ -195,8 +195,8 @@ def ifft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
         See :func:`fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation. If negative,
-        the value wraps around from ``os.cpu_count()``. See `fft` for more
-        details.
+        the value wraps around from ``os.cpu_count()``.
+        See :func:`~scipy.fft.fft` for more details.
 
     Returns
     -------
@@ -280,8 +280,8 @@ def rfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
         See :func:`fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation. If negative,
-        the value wraps around from ``os.cpu_count()``. See `fft` for more
-        details.
+        the value wraps around from ``os.cpu_count()``.
+        See :func:`~scipy.fft.fft` for more details.
 
     Returns
     -------
@@ -376,8 +376,8 @@ def irfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
         See :func:`fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation. If negative,
-        the value wraps around from ``os.cpu_count()``. See `fft` for more
-        details.
+        the value wraps around from ``os.cpu_count()``.
+        See :func:`~scipy.fft.fft` for more details.
 
     Returns
     -------
@@ -461,8 +461,8 @@ def hfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
         See `fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation. If negative,
-        the value wraps around from ``os.cpu_count()``. See `fft` for more
-        details.
+        the value wraps around from ``os.cpu_count()``.
+        See :func:`~scipy.fft.fft` for more details.
 
     Returns
     -------
@@ -535,8 +535,8 @@ def ihfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
         See `fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation. If negative,
-        the value wraps around from ``os.cpu_count()``. See `fft` for more
-        details.
+        the value wraps around from ``os.cpu_count()``.
+        See :func:`~scipy.fft.fft` for more details.
 
     Returns
     -------
@@ -601,8 +601,8 @@ def fftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
         See :func:`fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation. If negative,
-        the value wraps around from ``os.cpu_count()``. See `fft` for more
-        details.
+        the value wraps around from ``os.cpu_count()``.
+        See :func:`~scipy.fft.fft` for more details.
 
     Returns
     -------
@@ -707,8 +707,8 @@ def ifftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
         See :func:`fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation. If negative,
-        the value wraps around from ``os.cpu_count()``. See `fft` for more
-        details.
+        the value wraps around from ``os.cpu_count()``.
+        See :func:`~scipy.fft.fft` for more details.
 
     Returns
     -------
@@ -796,8 +796,8 @@ def fft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None):
         See :func:`fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation. If negative,
-        the value wraps around from ``os.cpu_count()``. See `fft` for more
-        details.
+        the value wraps around from ``os.cpu_count()``.
+        See :func:`~scipy.fft.fft` for more details.
 
     Returns
     -------
@@ -896,8 +896,8 @@ def ifft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None):
         See :func:`fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation. If negative,
-        the value wraps around from ``os.cpu_count()``. See `fft` for more
-        details.
+        the value wraps around from ``os.cpu_count()``.
+        See :func:`~scipy.fft.fft` for more details.
 
     Returns
     -------
@@ -981,8 +981,8 @@ def rfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
         See :func:`fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation. If negative,
-        the value wraps around from ``os.cpu_count()``. See `fft` for more
-        details.
+        the value wraps around from ``os.cpu_count()``.
+        See :func:`~scipy.fft.fft` for more details.
 
     Returns
     -------
@@ -1060,8 +1060,8 @@ def rfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None):
         See :func:`fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation. If negative,
-        the value wraps around from ``os.cpu_count()``. See `fft` for more
-        details.
+        the value wraps around from ``os.cpu_count()``.
+        See :func:`~scipy.fft.fft` for more details.
 
     Returns
     -------
@@ -1123,8 +1123,8 @@ def irfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
         See :func:`fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation. If negative,
-        the value wraps around from ``os.cpu_count()``. See `fft` for more
-        details.
+        the value wraps around from ``os.cpu_count()``.
+        See :func:`~scipy.fft.fft` for more details.
 
     Returns
     -------
@@ -1205,8 +1205,8 @@ def irfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False,
         See :func:`fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation. If negative,
-        the value wraps around from ``os.cpu_count()``. See `fft` for more
-        details.
+        the value wraps around from ``os.cpu_count()``.
+        See :func:`~scipy.fft.fft` for more details.
 
     Returns
     -------
@@ -1263,8 +1263,8 @@ def hfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
         See :func:`fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation. If negative,
-        the value wraps around from ``os.cpu_count()``. See `fft` for more
-        details.
+        the value wraps around from ``os.cpu_count()``.
+        See :func:`~scipy.fft.fft` for more details.
 
     Returns
     -------
@@ -1353,8 +1353,8 @@ def hfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None):
         See `fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation. If negative,
-        the value wraps around from ``os.cpu_count()``. See `fft` for more
-        details.
+        the value wraps around from ``os.cpu_count()``.
+        See :func:`~scipy.fft.fft` for more details.
 
     Returns
     -------
@@ -1408,8 +1408,8 @@ def ihfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
         See :func:`fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation. If negative,
-        the value wraps around from ``os.cpu_count()``. See `fft` for more
-        details.
+        the value wraps around from ``os.cpu_count()``.
+        See :func:`~scipy.fft.fft` for more details.
 
     Returns
     -------
@@ -1485,8 +1485,8 @@ def ihfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False,
         See :func:`fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation. If negative,
-        the value wraps around from ``os.cpu_count()``. See `fft` for more
-        details.
+        the value wraps around from ``os.cpu_count()``.
+        See :func:`~scipy.fft.fft` for more details.
 
     Returns
     -------

--- a/scipy/fft/_basic.py
+++ b/scipy/fft/_basic.py
@@ -21,7 +21,7 @@ def _dispatch(func):
 
 
 @_dispatch
-def fft(x, n=None, axis=-1, norm=None, overwrite_x=False):
+def fft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
     """
     Compute the one-dimensional discrete Fourier Transform.
 
@@ -48,6 +48,9 @@ def fft(x, n=None, axis=-1, norm=None, overwrite_x=False):
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
         See the notes below for more details.
+    workers : int, optional
+        Maximum number of workers to use for parallel computation, or 0 for
+        unlimited. Must be 0 or greater.
 
     Returns
     -------
@@ -145,7 +148,7 @@ def fft(x, n=None, axis=-1, norm=None, overwrite_x=False):
 
 
 @_dispatch
-def ifft(x, n=None, axis=-1, norm=None, overwrite_x=False):
+def ifft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
     """
     Compute the one-dimensional inverse discrete Fourier Transform.
 
@@ -183,6 +186,9 @@ def ifft(x, n=None, axis=-1, norm=None, overwrite_x=False):
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
         See :func:`fft` for more details.
+    workers : int, optional
+        Maximum number of workers to use for parallel computation, or 0 for
+        unlimited. Must be 0 or greater.
 
     Returns
     -------
@@ -239,7 +245,7 @@ def ifft(x, n=None, axis=-1, norm=None, overwrite_x=False):
 
 
 @_dispatch
-def rfft(x, n=None, axis=-1, norm=None, overwrite_x=False):
+def rfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
     """
     Compute the one-dimensional discrete Fourier Transform for real input.
 
@@ -264,6 +270,9 @@ def rfft(x, n=None, axis=-1, norm=None, overwrite_x=False):
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
         See :func:`fft` for more details.
+    workers : int, optional
+        Maximum number of workers to use for parallel computation, or 0 for
+        unlimited. Must be 0 or greater.
 
     Returns
     -------
@@ -322,7 +331,7 @@ def rfft(x, n=None, axis=-1, norm=None, overwrite_x=False):
 
 
 @_dispatch
-def irfft(x, n=None, axis=-1, norm=None, overwrite_x=False):
+def irfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
     """
     Compute the inverse of the n-point DFT for real input.
 
@@ -356,6 +365,9 @@ def irfft(x, n=None, axis=-1, norm=None, overwrite_x=False):
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
         See :func:`fft` for more details.
+    workers : int, optional
+        Maximum number of workers to use for parallel computation, or 0 for
+        unlimited. Must be 0 or greater.
 
     Returns
     -------
@@ -413,7 +425,7 @@ def irfft(x, n=None, axis=-1, norm=None, overwrite_x=False):
 
 
 @_dispatch
-def hfft(x, n=None, axis=-1, norm=None, overwrite_x=False):
+def hfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
     """
     Compute the FFT of a signal that has Hermitian symmetry, i.e., a real
     spectrum.
@@ -437,6 +449,9 @@ def hfft(x, n=None, axis=-1, norm=None, overwrite_x=False):
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
         See `fft` for more details.
+    workers : int, optional
+        Maximum number of workers to use for parallel computation, or 0 for
+        unlimited. Must be 0 or greater.
 
     Returns
     -------
@@ -485,7 +500,7 @@ def hfft(x, n=None, axis=-1, norm=None, overwrite_x=False):
 
 
 @_dispatch
-def ihfft(x, n=None, axis=-1, norm=None, overwrite_x=False):
+def ihfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
     """
     Compute the inverse FFT of a signal that has Hermitian symmetry.
 
@@ -504,6 +519,12 @@ def ihfft(x, n=None, axis=-1, norm=None, overwrite_x=False):
         axis is used.
     norm : {None, "ortho"}, optional
         Normalization mode (see `fft`). Default is None.
+    overwrite_x : bool, optional
+        If True, the contents of `x` can be destroyed; the default is False.
+        See `fft` for more details.
+    workers : int, optional
+        Maximum number of workers to use for parallel computation, or 0 for
+        unlimited. Must be 0 or greater.
 
     Returns
     -------
@@ -538,7 +559,7 @@ def ihfft(x, n=None, axis=-1, norm=None, overwrite_x=False):
 
 
 @_dispatch
-def fftn(x, s=None, axes=None, norm=None, overwrite_x=False):
+def fftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
     """
     Compute the N-dimensional discrete Fourier Transform.
 
@@ -566,6 +587,9 @@ def fftn(x, s=None, axes=None, norm=None, overwrite_x=False):
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
         See :func:`fft` for more details.
+    workers : int, optional
+        Maximum number of workers to use for parallel computation, or 0 for
+        unlimited. Must be 0 or greater.
 
     Returns
     -------
@@ -632,7 +656,7 @@ def fftn(x, s=None, axes=None, norm=None, overwrite_x=False):
 
 
 @_dispatch
-def ifftn(x, s=None, axes=None, norm=None, overwrite_x=False):
+def ifftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
     """
     Compute the N-dimensional inverse discrete Fourier Transform.
 
@@ -668,6 +692,9 @@ def ifftn(x, s=None, axes=None, norm=None, overwrite_x=False):
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
         See :func:`fft` for more details.
+    workers : int, optional
+        Maximum number of workers to use for parallel computation, or 0 for
+        unlimited. Must be 0 or greater.
 
     Returns
     -------
@@ -724,7 +751,7 @@ def ifftn(x, s=None, axes=None, norm=None, overwrite_x=False):
 
 
 @_dispatch
-def fft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False):
+def fft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None):
     """
     Compute the 2-dimensional discrete Fourier Transform
 
@@ -753,6 +780,9 @@ def fft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False):
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
         See :func:`fft` for more details.
+    workers : int, optional
+        Maximum number of workers to use for parallel computation, or 0 for
+        unlimited. Must be 0 or greater.
 
     Returns
     -------
@@ -813,7 +843,7 @@ def fft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False):
 
 
 @_dispatch
-def ifft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False):
+def ifft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None):
     """
     Compute the 2-dimensional inverse discrete Fourier Transform.
 
@@ -849,6 +879,9 @@ def ifft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False):
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
         See :func:`fft` for more details.
+    workers : int, optional
+        Maximum number of workers to use for parallel computation, or 0 for
+        unlimited. Must be 0 or greater.
 
     Returns
     -------
@@ -899,7 +932,7 @@ def ifft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False):
 
 
 @_dispatch
-def rfftn(x, s=None, axes=None, norm=None, overwrite_x=False):
+def rfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
     """
     Compute the N-dimensional discrete Fourier Transform for real input.
 
@@ -930,6 +963,9 @@ def rfftn(x, s=None, axes=None, norm=None, overwrite_x=False):
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
         See :func:`fft` for more details.
+    workers : int, optional
+        Maximum number of workers to use for parallel computation, or 0 for
+        unlimited. Must be 0 or greater.
 
     Returns
     -------
@@ -988,7 +1024,7 @@ def rfftn(x, s=None, axes=None, norm=None, overwrite_x=False):
 
 
 @_dispatch
-def rfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False):
+def rfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None):
     """
     Compute the 2-dimensional FFT of a real array.
 
@@ -1005,6 +1041,9 @@ def rfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False):
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
         See :func:`fft` for more details.
+    workers : int, optional
+        Maximum number of workers to use for parallel computation, or 0 for
+        unlimited. Must be 0 or greater.
 
     Returns
     -------
@@ -1027,7 +1066,7 @@ def rfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False):
 
 
 @_dispatch
-def irfftn(x, s=None, axes=None, norm=None, overwrite_x=False):
+def irfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
     """
     Compute the inverse of the N-dimensional FFT of real input.
 
@@ -1064,6 +1103,9 @@ def irfftn(x, s=None, axes=None, norm=None, overwrite_x=False):
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
         See :func:`fft` for more details.
+    workers : int, optional
+        Maximum number of workers to use for parallel computation, or 0 for
+        unlimited. Must be 0 or greater.
 
     Returns
     -------
@@ -1123,7 +1165,8 @@ def irfftn(x, s=None, axes=None, norm=None, overwrite_x=False):
 
 
 @_dispatch
-def irfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False):
+def irfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False,
+           workers=None):
     """
     Compute the 2-dimensional inverse FFT of a real array.
 
@@ -1141,6 +1184,9 @@ def irfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False):
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
         See :func:`fft` for more details.
+    workers : int, optional
+        Maximum number of workers to use for parallel computation, or 0 for
+        unlimited. Must be 0 or greater.
 
     Returns
     -------
@@ -1161,7 +1207,7 @@ def irfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False):
 
 
 @_dispatch
-def hfftn(x, s=None, axes=None, norm=None, overwrite_x=False):
+def hfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
     """
     Compute the N-dimensional FFT of Hermitian symmetric complex input, i.e. a
     signal with a real spectrum.
@@ -1195,6 +1241,9 @@ def hfftn(x, s=None, axes=None, norm=None, overwrite_x=False):
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
         See :func:`fft` for more details.
+    workers : int, optional
+        Maximum number of workers to use for parallel computation, or 0 for
+        unlimited. Must be 0 or greater.
 
     Returns
     -------
@@ -1264,7 +1313,7 @@ def hfftn(x, s=None, axes=None, norm=None, overwrite_x=False):
 
 
 @_dispatch
-def hfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False):
+def hfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None):
     """
     Compute the 2-dimensional FFT of a Hermitian complex array.
 
@@ -1281,6 +1330,9 @@ def hfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False):
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
         See `fft` for more details.
+    workers : int, optional
+        Maximum number of workers to use for parallel computation, or 0 for
+        unlimited. Must be 0 or greater.
 
     Returns
     -------
@@ -1302,7 +1354,7 @@ def hfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False):
 
 
 @_dispatch
-def ihfftn(x, s=None, axes=None, norm=None, overwrite_x=False):
+def ihfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
     """
     Compute the N-dimensional inverse discrete Fourier Transform for a real
     spectrum.
@@ -1332,6 +1384,9 @@ def ihfftn(x, s=None, axes=None, norm=None, overwrite_x=False):
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
         See :func:`fft` for more details.
+    workers : int, optional
+        Maximum number of workers to use for parallel computation, or 0 for
+        unlimited. Must be 0 or greater.
 
     Returns
     -------
@@ -1386,7 +1441,8 @@ def ihfftn(x, s=None, axes=None, norm=None, overwrite_x=False):
 
 
 @_dispatch
-def ihfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False):
+def ihfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False,
+           workers=None):
     """
     Compute the 2-dimensional inverse FFT of a real spectrum.
 
@@ -1404,6 +1460,9 @@ def ihfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False):
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
         See :func:`fft` for more details.
+    workers : int, optional
+        Maximum number of workers to use for parallel computation, or 0 for
+        unlimited. Must be 0 or greater.
 
     Returns
     -------

--- a/scipy/fft/_basic.py
+++ b/scipy/fft/_basic.py
@@ -49,8 +49,9 @@ def fft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
         If True, the contents of `x` can be destroyed; the default is False.
         See the notes below for more details.
     workers : int, optional
-        Maximum number of workers to use for parallel computation, or -1 for
-        unlimited. Must be -1 or >0.
+        Maximum number of workers to use for parallel computation. If negative,
+        the value wraps around from ``os.cpu_count()``. See `fft` for more
+        details.
 
     Returns
     -------
@@ -193,8 +194,9 @@ def ifft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
         If True, the contents of `x` can be destroyed; the default is False.
         See :func:`fft` for more details.
     workers : int, optional
-        Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be -1 or >0. See `fft` for more details.
+        Maximum number of workers to use for parallel computation. If negative,
+        the value wraps around from ``os.cpu_count()``. See `fft` for more
+        details.
 
     Returns
     -------
@@ -277,8 +279,9 @@ def rfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
         If True, the contents of `x` can be destroyed; the default is False.
         See :func:`fft` for more details.
     workers : int, optional
-        Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be -1 or >0. See `fft` for more details.
+        Maximum number of workers to use for parallel computation. If negative,
+        the value wraps around from ``os.cpu_count()``. See `fft` for more
+        details.
 
     Returns
     -------
@@ -372,8 +375,9 @@ def irfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
         If True, the contents of `x` can be destroyed; the default is False.
         See :func:`fft` for more details.
     workers : int, optional
-        Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be -1 or >0. See `fft` for more details.
+        Maximum number of workers to use for parallel computation. If negative,
+        the value wraps around from ``os.cpu_count()``. See `fft` for more
+        details.
 
     Returns
     -------
@@ -456,8 +460,9 @@ def hfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
         If True, the contents of `x` can be destroyed; the default is False.
         See `fft` for more details.
     workers : int, optional
-        Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be -1 or >0. See `fft` for more details.
+        Maximum number of workers to use for parallel computation. If negative,
+        the value wraps around from ``os.cpu_count()``. See `fft` for more
+        details.
 
     Returns
     -------
@@ -529,8 +534,9 @@ def ihfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
         If True, the contents of `x` can be destroyed; the default is False.
         See `fft` for more details.
     workers : int, optional
-        Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be -1 or >0. See `fft` for more details.
+        Maximum number of workers to use for parallel computation. If negative,
+        the value wraps around from ``os.cpu_count()``. See `fft` for more
+        details.
 
     Returns
     -------
@@ -594,8 +600,9 @@ def fftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
         If True, the contents of `x` can be destroyed; the default is False.
         See :func:`fft` for more details.
     workers : int, optional
-        Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be -1 or >0. See `fft` for more details.
+        Maximum number of workers to use for parallel computation. If negative,
+        the value wraps around from ``os.cpu_count()``. See `fft` for more
+        details.
 
     Returns
     -------
@@ -699,8 +706,9 @@ def ifftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
         If True, the contents of `x` can be destroyed; the default is False.
         See :func:`fft` for more details.
     workers : int, optional
-        Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be -1 or >0. See `fft` for more details.
+        Maximum number of workers to use for parallel computation. If negative,
+        the value wraps around from ``os.cpu_count()``. See `fft` for more
+        details.
 
     Returns
     -------
@@ -787,8 +795,9 @@ def fft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None):
         If True, the contents of `x` can be destroyed; the default is False.
         See :func:`fft` for more details.
     workers : int, optional
-        Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be -1 or >0. See `fft` for more details.
+        Maximum number of workers to use for parallel computation. If negative,
+        the value wraps around from ``os.cpu_count()``. See `fft` for more
+        details.
 
     Returns
     -------
@@ -886,8 +895,9 @@ def ifft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None):
         If True, the contents of `x` can be destroyed; the default is False.
         See :func:`fft` for more details.
     workers : int, optional
-        Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be -1 or >0. See `fft` for more details.
+        Maximum number of workers to use for parallel computation. If negative,
+        the value wraps around from ``os.cpu_count()``. See `fft` for more
+        details.
 
     Returns
     -------
@@ -970,8 +980,9 @@ def rfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
         If True, the contents of `x` can be destroyed; the default is False.
         See :func:`fft` for more details.
     workers : int, optional
-        Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be -1 or >0. See `fft` for more details.
+        Maximum number of workers to use for parallel computation. If negative,
+        the value wraps around from ``os.cpu_count()``. See `fft` for more
+        details.
 
     Returns
     -------
@@ -1048,8 +1059,9 @@ def rfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None):
         If True, the contents of `x` can be destroyed; the default is False.
         See :func:`fft` for more details.
     workers : int, optional
-        Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be -1 or >0. See `fft` for more details.
+        Maximum number of workers to use for parallel computation. If negative,
+        the value wraps around from ``os.cpu_count()``. See `fft` for more
+        details.
 
     Returns
     -------
@@ -1110,8 +1122,9 @@ def irfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
         If True, the contents of `x` can be destroyed; the default is False.
         See :func:`fft` for more details.
     workers : int, optional
-        Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be -1 or >0. See `fft` for more details.
+        Maximum number of workers to use for parallel computation. If negative,
+        the value wraps around from ``os.cpu_count()``. See `fft` for more
+        details.
 
     Returns
     -------
@@ -1191,8 +1204,9 @@ def irfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False,
         If True, the contents of `x` can be destroyed; the default is False.
         See :func:`fft` for more details.
     workers : int, optional
-        Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be -1 or >0. See `fft` for more details.
+        Maximum number of workers to use for parallel computation. If negative,
+        the value wraps around from ``os.cpu_count()``. See `fft` for more
+        details.
 
     Returns
     -------
@@ -1248,8 +1262,9 @@ def hfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
         If True, the contents of `x` can be destroyed; the default is False.
         See :func:`fft` for more details.
     workers : int, optional
-        Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be -1 or >0. See `fft` for more details.
+        Maximum number of workers to use for parallel computation. If negative,
+        the value wraps around from ``os.cpu_count()``. See `fft` for more
+        details.
 
     Returns
     -------
@@ -1337,8 +1352,9 @@ def hfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None):
         If True, the contents of `x` can be destroyed; the default is False.
         See `fft` for more details.
     workers : int, optional
-        Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be -1 or >0. See `fft` for more details.
+        Maximum number of workers to use for parallel computation. If negative,
+        the value wraps around from ``os.cpu_count()``. See `fft` for more
+        details.
 
     Returns
     -------
@@ -1391,8 +1407,9 @@ def ihfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
         If True, the contents of `x` can be destroyed; the default is False.
         See :func:`fft` for more details.
     workers : int, optional
-        Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be -1 or >0. See `fft` for more details.
+        Maximum number of workers to use for parallel computation. If negative,
+        the value wraps around from ``os.cpu_count()``. See `fft` for more
+        details.
 
     Returns
     -------
@@ -1467,8 +1484,9 @@ def ihfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False,
         If True, the contents of `x` can be destroyed; the default is False.
         See :func:`fft` for more details.
     workers : int, optional
-        Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be -1 or >0. See `fft` for more details.
+        Maximum number of workers to use for parallel computation. If negative,
+        the value wraps around from ``os.cpu_count()``. See `fft` for more
+        details.
 
     Returns
     -------

--- a/scipy/fft/_basic.py
+++ b/scipy/fft/_basic.py
@@ -49,8 +49,8 @@ def fft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
         If True, the contents of `x` can be destroyed; the default is False.
         See the notes below for more details.
     workers : int, optional
-        Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater.
+        Maximum number of workers to use for parallel computation, or -1 for
+        unlimited. Must be -1 or >0.
 
     Returns
     -------
@@ -194,7 +194,7 @@ def ifft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
         See :func:`fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater. See `fft` for more details.
+        unlimited. Must be -1 or >0. See `fft` for more details.
 
     Returns
     -------
@@ -278,7 +278,7 @@ def rfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
         See :func:`fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater. See `fft` for more details.
+        unlimited. Must be -1 or >0. See `fft` for more details.
 
     Returns
     -------
@@ -373,7 +373,7 @@ def irfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
         See :func:`fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater. See `fft` for more details.
+        unlimited. Must be -1 or >0. See `fft` for more details.
 
     Returns
     -------
@@ -457,7 +457,7 @@ def hfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
         See `fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater. See `fft` for more details.
+        unlimited. Must be -1 or >0. See `fft` for more details.
 
     Returns
     -------
@@ -530,7 +530,7 @@ def ihfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
         See `fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater. See `fft` for more details.
+        unlimited. Must be -1 or >0. See `fft` for more details.
 
     Returns
     -------
@@ -595,7 +595,7 @@ def fftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
         See :func:`fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater. See `fft` for more details.
+        unlimited. Must be -1 or >0. See `fft` for more details.
 
     Returns
     -------
@@ -700,7 +700,7 @@ def ifftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
         See :func:`fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater. See `fft` for more details.
+        unlimited. Must be -1 or >0. See `fft` for more details.
 
     Returns
     -------
@@ -788,7 +788,7 @@ def fft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None):
         See :func:`fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater. See `fft` for more details.
+        unlimited. Must be -1 or >0. See `fft` for more details.
 
     Returns
     -------
@@ -887,7 +887,7 @@ def ifft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None):
         See :func:`fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater. See `fft` for more details.
+        unlimited. Must be -1 or >0. See `fft` for more details.
 
     Returns
     -------
@@ -971,7 +971,7 @@ def rfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
         See :func:`fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater. See `fft` for more details.
+        unlimited. Must be -1 or >0. See `fft` for more details.
 
     Returns
     -------
@@ -1049,7 +1049,7 @@ def rfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None):
         See :func:`fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater. See `fft` for more details.
+        unlimited. Must be -1 or >0. See `fft` for more details.
 
     Returns
     -------
@@ -1111,7 +1111,7 @@ def irfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
         See :func:`fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater. See `fft` for more details.
+        unlimited. Must be -1 or >0. See `fft` for more details.
 
     Returns
     -------
@@ -1192,7 +1192,7 @@ def irfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False,
         See :func:`fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater. See `fft` for more details.
+        unlimited. Must be -1 or >0. See `fft` for more details.
 
     Returns
     -------
@@ -1249,7 +1249,7 @@ def hfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
         See :func:`fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater. See `fft` for more details.
+        unlimited. Must be -1 or >0. See `fft` for more details.
 
     Returns
     -------
@@ -1338,7 +1338,7 @@ def hfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None):
         See `fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater. See `fft` for more details.
+        unlimited. Must be -1 or >0. See `fft` for more details.
 
     Returns
     -------
@@ -1392,7 +1392,7 @@ def ihfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
         See :func:`fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater. See `fft` for more details.
+        unlimited. Must be -1 or >0. See `fft` for more details.
 
     Returns
     -------
@@ -1468,7 +1468,7 @@ def ihfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False,
         See :func:`fft` for more details.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater. See `fft` for more details.
+        unlimited. Must be -1 or >0. See `fft` for more details.
 
     Returns
     -------

--- a/scipy/fft/_pocketfft/basic.py
+++ b/scipy/fft/_pocketfft/basic.py
@@ -8,13 +8,15 @@ import functools
 from . import pypocketfft as pfft
 from .helper import (_asfarray, _init_nd_shape_and_axes, _datacopied,
                      _fix_shape, _fix_shape_1d, _normalization,
-                     _default_workers)
+                     _workers)
 
-def c2c(forward, x, n=None, axis=-1, norm=None, overwrite_x=False):
+def c2c(forward, x, n=None, axis=-1, norm=None, overwrite_x=False,
+        workers=None):
     """ Return discrete Fourier transform of real or complex sequence. """
     tmp = _asfarray(x)
     overwrite_x = overwrite_x or _datacopied(tmp, x)
     norm = _normalization(norm, forward)
+    workers = _workers(workers)
 
     if n is not None:
         tmp, copied = _fix_shape_1d(tmp, n, axis)
@@ -25,7 +27,7 @@ def c2c(forward, x, n=None, axis=-1, norm=None, overwrite_x=False):
 
     out = (tmp if overwrite_x and tmp.dtype.kind == 'c' else None)
 
-    return pfft.c2c(tmp, (axis,), forward, norm, out, _default_workers)
+    return pfft.c2c(tmp, (axis,), forward, norm, out, workers)
 
 
 fft = functools.partial(c2c, True)
@@ -34,12 +36,14 @@ ifft = functools.partial(c2c, False)
 ifft.__name__ = 'ifft'
 
 
-def r2c(forward, x, n=None, axis=-1, norm=None, overwrite_x=False):
+def r2c(forward, x, n=None, axis=-1, norm=None, overwrite_x=False,
+        workers=None):
     """
     Discrete Fourier transform of a real sequence.
     """
     tmp = _asfarray(x)
     norm = _normalization(norm, forward)
+    workers = _workers(workers)
 
     if not np.isrealobj(tmp):
         raise TypeError("x must be a real sequence")
@@ -51,7 +55,7 @@ def r2c(forward, x, n=None, axis=-1, norm=None, overwrite_x=False):
                          .format(tmp.shape[axis]))
 
     # Note: overwrite_x is not utilised
-    return pfft.r2c(tmp, (axis,), forward, norm, None, _default_workers)
+    return pfft.r2c(tmp, (axis,), forward, norm, None, workers)
 
 
 rfft = functools.partial(r2c, True)
@@ -60,12 +64,14 @@ ihfft = functools.partial(r2c, False)
 ihfft.__name__ = 'ihfft'
 
 
-def c2r(forward, x, n=None, axis=-1, norm=None, overwrite_x=False):
+def c2r(forward, x, n=None, axis=-1, norm=None, overwrite_x=False,
+        workers=None):
     """
     Return inverse discrete Fourier transform of real sequence x.
     """
     tmp = _asfarray(x)
     norm = _normalization(norm, forward)
+    workers = _workers(workers)
 
     # TODO: Optimize for hermitian and real?
     if np.isrealobj(tmp):
@@ -81,7 +87,7 @@ def c2r(forward, x, n=None, axis=-1, norm=None, overwrite_x=False):
         tmp, _ = _fix_shape_1d(tmp, (n//2) + 1, axis)
 
     # Note: overwrite_x is not utilised
-    return pfft.c2r(tmp, (axis,), n, forward, norm, None, _default_workers)
+    return pfft.c2r(tmp, (axis,), n, forward, norm, None, workers)
 
 
 hfft = functools.partial(c2r, True)
@@ -90,49 +96,50 @@ irfft = functools.partial(c2r, False)
 irfft.__name__ = 'irfft'
 
 
-def fft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False):
+def fft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False, workers=None):
     """
     2-D discrete Fourier transform.
     """
-    return fftn(x, s, axes, norm, overwrite_x)
+    return fftn(x, s, axes, norm, overwrite_x, workers)
 
 
-def ifft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False):
+def ifft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False, workers=None):
     """
     2-D discrete inverse Fourier transform of real or complex sequence.
     """
-    return ifftn(x, s, axes, norm, overwrite_x)
+    return ifftn(x, s, axes, norm, overwrite_x, workers)
 
 
-def rfft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False):
+def rfft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False, workers=None):
     """
     2-D discrete Fourier transform of a real sequence
     """
-    return rfftn(x, s, axes, norm, overwrite_x)
+    return rfftn(x, s, axes, norm, overwrite_x, workers)
 
 
-def irfft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False):
+def irfft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False, workers=None):
     """
     2-D discrete inverse Fourier transform of a real sequence
     """
-    return irfftn(x, s, axes, norm, overwrite_x)
+    return irfftn(x, s, axes, norm, overwrite_x, workers)
 
 
-def hfft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False):
+def hfft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False, workers=None):
     """
     2-D discrete Fourier transform of a Hermitian sequence
     """
-    return hfftn(x, s, axes, norm, overwrite_x)
+    return hfftn(x, s, axes, norm, overwrite_x, workers)
 
 
-def ihfft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False):
+def ihfft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False, workers=None):
     """
     2-D discrete inverse Fourier transform of a Hermitian sequence
     """
-    return ihfftn(x, s, axes, norm, overwrite_x)
+    return ihfftn(x, s, axes, norm, overwrite_x, workers)
 
 
-def c2cn(forward, x, s=None, axes=None, norm=None, overwrite_x=False):
+def c2cn(forward, x, s=None, axes=None, norm=None, overwrite_x=False,
+         workers=None):
     """
     Return multidimensional discrete Fourier transform.
     """
@@ -140,6 +147,7 @@ def c2cn(forward, x, s=None, axes=None, norm=None, overwrite_x=False):
 
     shape, axes = _init_nd_shape_and_axes(tmp, s, axes)
     overwrite_x = overwrite_x or _datacopied(tmp, x)
+    workers = _workers(workers)
 
     if len(axes) == 0:
         return x
@@ -150,7 +158,7 @@ def c2cn(forward, x, s=None, axes=None, norm=None, overwrite_x=False):
     norm = _normalization(norm, forward)
     out = (tmp if overwrite_x and tmp.dtype.kind == 'c' else None)
 
-    return pfft.c2c(tmp, axes, forward, norm, out, _default_workers)
+    return pfft.c2c(tmp, axes, forward, norm, out, workers)
 
 
 fftn = functools.partial(c2cn, True)
@@ -158,7 +166,8 @@ fftn.__name__ = 'fftn'
 ifftn = functools.partial(c2cn, False)
 ifftn.__name__ = 'ifftn'
 
-def r2cn(forward, x, s=None, axes=None, norm=None, overwrite_x=False):
+def r2cn(forward, x, s=None, axes=None, norm=None, overwrite_x=False,
+         workers=None):
     """Return multi-dimensional discrete Fourier transform of real input"""
     tmp = _asfarray(x)
 
@@ -168,12 +177,13 @@ def r2cn(forward, x, s=None, axes=None, norm=None, overwrite_x=False):
     shape, axes = _init_nd_shape_and_axes(tmp, s, axes)
     tmp, _ = _fix_shape(tmp, shape, axes)
     norm = _normalization(norm, forward)
+    workers = _workers(workers)
 
     if len(axes) == 0:
         raise ValueError("at least 1 axis must be transformed")
 
     # Note: overwrite_x is not utilised
-    return pfft.r2c(tmp, axes, forward, norm, None, _default_workers)
+    return pfft.r2c(tmp, axes, forward, norm, None, workers)
 
 
 rfftn = functools.partial(r2cn, True)
@@ -182,7 +192,8 @@ ihfftn = functools.partial(r2cn, False)
 ihfftn.__name__ = 'ihfftn'
 
 
-def c2rn(forward, x, s=None, axes=None, norm=None, overwrite_x=False):
+def c2rn(forward, x, s=None, axes=None, norm=None, overwrite_x=False,
+         workers=None):
     """Multi-dimensional inverse discrete fourier transform with real output"""
     tmp = _asfarray(x)
 
@@ -200,6 +211,7 @@ def c2rn(forward, x, s=None, axes=None, norm=None, overwrite_x=False):
         shape[-1] = (x.shape[axes[-1]] - 1) * 2
 
     norm = _normalization(norm, forward)
+    workers = _workers(workers)
 
     # Last axis utilises hermitian symmetry
     lastsize = shape[-1]
@@ -208,7 +220,7 @@ def c2rn(forward, x, s=None, axes=None, norm=None, overwrite_x=False):
     tmp, _ = _fix_shape(tmp, shape, axes)
 
     # Note: overwrite_x is not utilised
-    return pfft.c2r(tmp, axes, lastsize, forward, norm, None, _default_workers)
+    return pfft.c2r(tmp, axes, lastsize, forward, norm, None, workers)
 
 
 hfftn = functools.partial(c2rn, True)
@@ -222,6 +234,7 @@ def r2r_fftpack(forward, x, n=None, axis=-1, norm=None, overwrite_x=False):
     tmp = _asfarray(x)
     overwrite_x = overwrite_x or _datacopied(tmp, x)
     norm = _normalization(norm, forward)
+    workers = _workers(None)
 
     if tmp.dtype.kind == 'c':
         raise ValueError('x must be a real sequence')
@@ -235,8 +248,7 @@ def r2r_fftpack(forward, x, n=None, axis=-1, norm=None, overwrite_x=False):
 
     out = (tmp if overwrite_x else None)
 
-    return pfft.r2r_fftpack(tmp, (axis,), forward, forward, norm, out,
-                            _default_workers)
+    return pfft.r2r_fftpack(tmp, (axis,), forward, forward, norm, out, workers)
 
 
 rfft_fftpack = functools.partial(r2r_fftpack, True)

--- a/scipy/fft/_pocketfft/helper.py
+++ b/scipy/fft/_pocketfft/helper.py
@@ -6,7 +6,7 @@ import operator
 import sys
 
 
-# TODO: Build with OpenMp and add configuration support
+# TODO: Add configuration support
 _default_workers = 1
 
 
@@ -150,6 +150,17 @@ def _normalization(norm, forward):
 
     raise ValueError(
         "Invalid norm value {}, should be None or \"ortho\".".format(norm))
+
+
+def _workers(workers):
+    if workers is None:
+        return _default_workers
+
+    if workers < 0:
+        raise ValueError("workers must be >= 0")
+
+    return workers
+
 
 def next_fast_len(target, kind='C2C'):
     try:

--- a/scipy/fft/_pocketfft/helper.py
+++ b/scipy/fft/_pocketfft/helper.py
@@ -4,10 +4,12 @@ import operator
 from .pypocketfft import good_size
 import operator
 import sys
+import os
 
 
 # TODO: Add configuration support
 _default_workers = 1
+_cpu_count = os.cpu_count()
 
 
 def _iterable_of_int(x, name=None):
@@ -156,10 +158,13 @@ def _workers(workers):
     if workers is None:
         return _default_workers
 
-    if workers == 0 or workers < -1:
-        raise ValueError("workers must be > 0, or -1")
+    if workers < 0:
+        workers += 1 + _cpu_count
 
-    return workers if workers != -1 else 0
+    if workers <= 0:
+        raise ValueError("workers value out of range")
+
+    return workers
 
 
 def next_fast_len(target, kind='C2C'):

--- a/scipy/fft/_pocketfft/helper.py
+++ b/scipy/fft/_pocketfft/helper.py
@@ -156,10 +156,10 @@ def _workers(workers):
     if workers is None:
         return _default_workers
 
-    if workers < 0:
-        raise ValueError("workers must be >= 0")
+    if workers == 0 or workers < -1:
+        raise ValueError("workers must be > 0, or -1")
 
-    return workers
+    return workers if workers != -1 else 0
 
 
 def next_fast_len(target, kind='C2C'):

--- a/scipy/fft/_pocketfft/helper.py
+++ b/scipy/fft/_pocketfft/helper.py
@@ -159,10 +159,13 @@ def _workers(workers):
         return getattr(_config, 'default_workers', 1)
 
     if workers < 0:
-        workers += 1 + _cpu_count
-
-    if workers <= 0:
-        raise ValueError("workers value out of range")
+        if workers >= -_cpu_count:
+            workers += 1 + _cpu_count
+        else:
+            raise ValueError("workers value out of range; got {}, must not be"
+                             " less than {}".format(workers, -_cpu_count))
+    elif workers == 0:
+        raise ValueError("workers must not be zero")
 
     return workers
 

--- a/scipy/fft/_pocketfft/pocketfft_hdronly.h
+++ b/scipy/fft/_pocketfft/pocketfft_hdronly.h
@@ -62,8 +62,16 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <array>
 #include <mutex>
 #endif
-#ifdef POCKETFFT_OPENMP
-#include <omp.h>
+
+#include <mutex>
+#include <condition_variable>
+#include <thread>
+#include <queue>
+#include <atomic>
+#include <functional>
+
+#ifdef POCKETFFT_PTHREADS
+#  include <pthread.h>
 #endif
 
 
@@ -235,14 +243,19 @@ template<typename T> struct cmplx {
                : Tres(r*other.r-i*other.i, r*other.i+i*other.r);
     }
 };
+template<typename T> inline void PM(T &a, T &b, T c, T d)
+  { a=c+d; b=c-d; }
 template<typename T> inline void PMINPLACE(T &a, T &b)
   { T t = a; a+=b; b=t-b; }
 template<typename T> inline void MPINPLACE(T &a, T &b)
   { T t = a; a-=b; b=t+b; }
-template<typename T> void PMC(T &a, T &b, const T &c, const T &d)
-  { a = c+d; b = c-d; }
 template<typename T> cmplx<T> conj(const cmplx<T> &a)
   { return {a.r, -a.i}; }
+template<bool fwd, typename T, typename T2> void special_mul (const cmplx<T> &v1, const cmplx<T2> &v2, cmplx<T> &res)
+  {
+  res = fwd ? cmplx<T>(v1.r*v2.r+v1.i*v2.i, v1.i*v2.r-v1.r*v2.i)
+            : cmplx<T>(v1.r*v2.r-v1.i*v2.i, v1.r*v2.i+v1.i*v2.r);
+  }
 
 template<typename T> void ROT90(cmplx<T> &a)
   { auto tmp_=a.r; a.r=-a.i; a.i=tmp_; }
@@ -552,21 +565,205 @@ struct util // hack to avoid duplicate symbols
     if (axis>=shape.size()) throw invalid_argument("bad axis number");
     }
 
-#ifdef POCKETFFT_OPENMP
-    static size_t nthreads() { return size_t(omp_get_num_threads()); }
-    static size_t thread_num() { return size_t(omp_get_thread_num()); }
     static size_t thread_count (size_t nthreads, const shape_t &shape,
-      size_t axis)
+      size_t axis, size_t vlen)
       {
       if (nthreads==1) return 1;
-      if (prod(shape) < 20*shape[axis]) return 1;
-      return (nthreads==0) ? size_t(omp_get_max_threads()) : nthreads;
+      size_t size = prod(shape);
+      size_t parallel = size / (shape[axis] * vlen);
+      if (shape[axis] < 1000)
+        parallel /= 4;
+      size_t max_threads = nthreads == 0 ?
+        thread::hardware_concurrency() : nthreads;
+      return max(size_t(1), min(parallel, max_threads));
       }
-#else
-    static constexpr size_t nthreads() { return 1; }
-    static constexpr size_t thread_num() { return 0; }
-#endif
   };
+
+namespace threading {
+thread_local size_t thread_id = 0;
+thread_local size_t num_threads = 1;
+
+class latch
+  {
+    atomic<size_t> num_left_;
+    mutex mut_;
+    condition_variable completed_;
+    using lock_t = unique_lock<mutex>;
+
+  public:
+    latch(size_t n): num_left_(n) {}
+
+    void count_down()
+      {
+      {
+      lock_t lock(mut_);
+      if (--num_left_)
+        return;
+      }
+      completed_.notify_all();
+      }
+
+    void wait()
+      {
+      lock_t lock(mut_);
+      completed_.wait(lock, [this]{ return is_ready(); });
+      }
+    bool is_ready() { return num_left_ == 0; }
+  };
+
+template <typename T> class concurrent_queue
+  {
+    queue<T> q_;
+    mutex mut_;
+    condition_variable item_added_;
+    bool shutdown_;
+    using lock_t = unique_lock<mutex>;
+
+  public:
+    concurrent_queue(): shutdown_(false) {}
+
+    void push(T val)
+      {
+      {
+      lock_t lock(mut_);
+      if (shutdown_)
+        throw runtime_error("Item added to queue after shutdown");
+      q_.push(move(val));
+      }
+      item_added_.notify_one();
+      }
+
+    bool pop(T & val)
+      {
+      lock_t lock(mut_);
+      item_added_.wait(lock, [this] { return (!q_.empty() || shutdown_); });
+      if (q_.empty())
+        return false;  // We are shutting down
+
+      val = std::move(q_.front());
+      q_.pop();
+      return true;
+      }
+
+    void shutdown()
+      {
+      {
+      lock_t lock(mut_);
+      shutdown_ = true;
+      }
+      item_added_.notify_all();
+      }
+
+    void restart() { shutdown_ = false; }
+  };
+
+class thread_pool
+  {
+    concurrent_queue<function<void()>> work_queue_;
+    vector<thread> threads_;
+
+    void worker_main()
+      {
+      function<void()> work;
+      while (work_queue_.pop(work))
+        work();
+      }
+
+    void create_threads()
+      {
+      size_t nthreads = threads_.size();
+      for (size_t i=0; i<nthreads; ++i)
+        {
+        try { threads_[i] = thread([this]{ worker_main(); }); }
+        catch (...)
+          {
+          shutdown();
+          throw;
+          }
+        }
+      }
+
+  public:
+    explicit thread_pool(size_t nthreads):
+      threads_(nthreads)
+      { create_threads(); }
+
+    thread_pool(): thread_pool(thread::hardware_concurrency()) {}
+
+    ~thread_pool() { shutdown(); }
+
+    void submit(function<void()> work)
+      {
+      work_queue_.push(move(work));
+      }
+
+    void shutdown()
+      {
+      work_queue_.shutdown();
+      for (auto &thread : threads_)
+        if (thread.joinable())
+          thread.join();
+      }
+
+    void restart()
+      {
+      work_queue_.restart();
+      create_threads();
+      }
+  };
+
+thread_pool & get_pool()
+  {
+  static thread_pool pool;
+#ifdef POCKETFFT_PTHREADS
+  static once_flag f;
+  call_once(f,
+    []{
+    pthread_atfork(
+      +[]{ get_pool().shutdown(); },  // prepare
+      +[]{ get_pool().restart(); },   // parent
+      +[]{ get_pool().restart(); }    // child
+      );
+    });
+#endif
+
+  return pool;
+  }
+
+/** Map a function f over nthreads */
+template <typename Func>
+void thread_map(size_t nthreads, Func f)
+  {
+  if (nthreads == 0)
+    nthreads = thread::hardware_concurrency();
+
+  if (nthreads == 1)
+    { f(); return; }
+
+  auto & pool = get_pool();
+  latch counter(nthreads);
+  exception_ptr ex;
+  mutex ex_mut;
+  for (size_t i=0; i<nthreads; ++i)
+    {
+    pool.submit(
+      [&f, &counter, &ex, &ex_mut, i, nthreads] {
+      thread_id = i;
+      num_threads = nthreads;
+      try { f(); }
+      catch (...)
+        {
+        lock_guard<mutex> lock(ex_mut);
+        ex = current_exception();
+        }
+      counter.count_down();
+      });
+    }
+  counter.wait();
+  if (ex)
+    rethrow_exception(ex);
+  }
+}
 
 //
 // complex FFTPACK transforms
@@ -590,7 +787,7 @@ template<typename T0> class cfftp
 
 template<bool fwd, typename T> void pass2 (size_t ido, size_t l1,
   const T * POCKETFFT_RESTRICT cc, T * POCKETFFT_RESTRICT ch,
-  const cmplx<T0> * POCKETFFT_RESTRICT wa)
+  const cmplx<T0> * POCKETFFT_RESTRICT wa) const
   {
   constexpr size_t cdim=2;
 
@@ -615,34 +812,31 @@ template<bool fwd, typename T> void pass2 (size_t ido, size_t l1,
       for (size_t i=1; i<ido; ++i)
         {
         CH(i,k,0) = CC(i,0,k)+CC(i,1,k);
-        CH(i,k,1) = (CC(i,0,k)-CC(i,1,k)).template special_mul<fwd>(WA(0,i));
+        special_mul<fwd>(CC(i,0,k)-CC(i,1,k),WA(0,i),CH(i,k,1));
         }
       }
   }
 
 #define POCKETFFT_PREP3(idx) \
         T t0 = CC(idx,0,k), t1, t2; \
-        PMC (t1,t2,CC(idx,1,k),CC(idx,2,k)); \
+        PM (t1,t2,CC(idx,1,k),CC(idx,2,k)); \
         CH(idx,k,0)=t0+t1;
 #define POCKETFFT_PARTSTEP3a(u1,u2,twr,twi) \
         { \
-        T ca,cb; \
-        ca=t0+t1*twr; \
-        cb=t2*twi; ROT90(cb); \
-        PMC(CH(0,k,u1),CH(0,k,u2),ca,cb) ;\
+        T ca=t0+t1*twr; \
+        T cb{-t2.i*twi, t2.r*twi}; \
+        PM(CH(0,k,u1),CH(0,k,u2),ca,cb) ;\
         }
 #define POCKETFFT_PARTSTEP3b(u1,u2,twr,twi) \
         { \
-        T ca,cb,da,db; \
-        ca=t0+t1*twr; \
-        cb=t2*twi; ROT90(cb); \
-        PMC(da,db,ca,cb); \
-        CH(i,k,u1) = da.template special_mul<fwd>(WA(u1-1,i)); \
-        CH(i,k,u2) = db.template special_mul<fwd>(WA(u2-1,i)); \
+        T ca=t0+t1*twr; \
+        T cb{-t2.i*twi, t2.r*twi}; \
+        special_mul<fwd>(ca+cb,WA(u1-1,i),CH(i,k,u1)); \
+        special_mul<fwd>(ca-cb,WA(u2-1,i),CH(i,k,u2)); \
         }
 template<bool fwd, typename T> void pass3 (size_t ido, size_t l1,
   const T * POCKETFFT_RESTRICT cc, T * POCKETFFT_RESTRICT ch,
-  const cmplx<T0> * POCKETFFT_RESTRICT wa)
+  const cmplx<T0> * POCKETFFT_RESTRICT wa) const
   {
   constexpr size_t cdim=3;
   constexpr T0 tw1r=-0.5,
@@ -682,7 +876,7 @@ template<bool fwd, typename T> void pass3 (size_t ido, size_t l1,
 
 template<bool fwd, typename T> void pass4 (size_t ido, size_t l1,
   const T * POCKETFFT_RESTRICT cc, T * POCKETFFT_RESTRICT ch,
-  const cmplx<T0> * POCKETFFT_RESTRICT wa)
+  const cmplx<T0> * POCKETFFT_RESTRICT wa) const
   {
   constexpr size_t cdim=4;
 
@@ -697,43 +891,42 @@ template<bool fwd, typename T> void pass4 (size_t ido, size_t l1,
     for (size_t k=0; k<l1; ++k)
       {
       T t1, t2, t3, t4;
-      PMC(t2,t1,CC(0,0,k),CC(0,2,k));
-      PMC(t3,t4,CC(0,1,k),CC(0,3,k));
+      PM(t2,t1,CC(0,0,k),CC(0,2,k));
+      PM(t3,t4,CC(0,1,k),CC(0,3,k));
       ROTX90<fwd>(t4);
-      PMC(CH(0,k,0),CH(0,k,2),t2,t3);
-      PMC(CH(0,k,1),CH(0,k,3),t1,t4);
+      PM(CH(0,k,0),CH(0,k,2),t2,t3);
+      PM(CH(0,k,1),CH(0,k,3),t1,t4);
       }
   else
     for (size_t k=0; k<l1; ++k)
       {
       {
       T t1, t2, t3, t4;
-      PMC(t2,t1,CC(0,0,k),CC(0,2,k));
-      PMC(t3,t4,CC(0,1,k),CC(0,3,k));
+      PM(t2,t1,CC(0,0,k),CC(0,2,k));
+      PM(t3,t4,CC(0,1,k),CC(0,3,k));
       ROTX90<fwd>(t4);
-      PMC(CH(0,k,0),CH(0,k,2),t2,t3);
-      PMC(CH(0,k,1),CH(0,k,3),t1,t4);
+      PM(CH(0,k,0),CH(0,k,2),t2,t3);
+      PM(CH(0,k,1),CH(0,k,3),t1,t4);
       }
       for (size_t i=1; i<ido; ++i)
         {
-        T c2, c3, c4, t1, t2, t3, t4;
+        T t1, t2, t3, t4;
         T cc0=CC(i,0,k), cc1=CC(i,1,k),cc2=CC(i,2,k),cc3=CC(i,3,k);
-        PMC(t2,t1,cc0,cc2);
-        PMC(t3,t4,cc1,cc3);
+        PM(t2,t1,cc0,cc2);
+        PM(t3,t4,cc1,cc3);
         ROTX90<fwd>(t4);
-        PMC(CH(i,k,0),c3,t2,t3);
-        PMC(c2,c4,t1,t4);
-        CH(i,k,1) = c2.template special_mul<fwd>(WA(0,i));
-        CH(i,k,2) = c3.template special_mul<fwd>(WA(1,i));
-        CH(i,k,3) = c4.template special_mul<fwd>(WA(2,i));
+        CH(i,k,0) = t2+t3;
+        special_mul<fwd>(t1+t4,WA(0,i),CH(i,k,1));
+        special_mul<fwd>(t2-t3,WA(1,i),CH(i,k,2));
+        special_mul<fwd>(t1-t4,WA(2,i),CH(i,k,3));
         }
       }
   }
 
 #define POCKETFFT_PREP5(idx) \
         T t0 = CC(idx,0,k), t1, t2, t3, t4; \
-        PMC (t1,t4,CC(idx,1,k),CC(idx,4,k)); \
-        PMC (t2,t3,CC(idx,2,k),CC(idx,3,k)); \
+        PM (t1,t4,CC(idx,1,k),CC(idx,4,k)); \
+        PM (t2,t3,CC(idx,2,k),CC(idx,3,k)); \
         CH(idx,k,0).r=t0.r+t1.r+t2.r; \
         CH(idx,k,0).i=t0.i+t1.i+t2.i;
 
@@ -744,7 +937,7 @@ template<bool fwd, typename T> void pass4 (size_t ido, size_t l1,
         ca.i=t0.i+twar*t1.i+twbr*t2.i; \
         cb.i=twai*t4.r twbi*t3.r; \
         cb.r=-(twai*t4.i twbi*t3.i); \
-        PMC(CH(0,k,u1),CH(0,k,u2),ca,cb); \
+        PM(CH(0,k,u1),CH(0,k,u2),ca,cb); \
         }
 
 #define POCKETFFT_PARTSTEP5b(u1,u2,twar,twbr,twai,twbi) \
@@ -754,13 +947,12 @@ template<bool fwd, typename T> void pass4 (size_t ido, size_t l1,
         ca.i=t0.i+twar*t1.i+twbr*t2.i; \
         cb.i=twai*t4.r twbi*t3.r; \
         cb.r=-(twai*t4.i twbi*t3.i); \
-        PMC(da,db,ca,cb); \
-        CH(i,k,u1) = da.template special_mul<fwd>(WA(u1-1,i)); \
-        CH(i,k,u2) = db.template special_mul<fwd>(WA(u2-1,i)); \
+        special_mul<fwd>(ca+cb,WA(u1-1,i),CH(i,k,u1)); \
+        special_mul<fwd>(ca-cb,WA(u2-1,i),CH(i,k,u2)); \
         }
 template<bool fwd, typename T> void pass5 (size_t ido, size_t l1,
   const T * POCKETFFT_RESTRICT cc, T * POCKETFFT_RESTRICT ch,
-  const cmplx<T0> * POCKETFFT_RESTRICT wa)
+  const cmplx<T0> * POCKETFFT_RESTRICT wa) const
   {
   constexpr size_t cdim=5;
   constexpr T0 tw1r= T0(0.3090169943749474241022934171828191L),
@@ -805,9 +997,9 @@ template<bool fwd, typename T> void pass5 (size_t ido, size_t l1,
 
 #define POCKETFFT_PREP7(idx) \
         T t1 = CC(idx,0,k), t2, t3, t4, t5, t6, t7; \
-        PMC (t2,t7,CC(idx,1,k),CC(idx,6,k)); \
-        PMC (t3,t6,CC(idx,2,k),CC(idx,5,k)); \
-        PMC (t4,t5,CC(idx,3,k),CC(idx,4,k)); \
+        PM (t2,t7,CC(idx,1,k),CC(idx,6,k)); \
+        PM (t3,t6,CC(idx,2,k),CC(idx,5,k)); \
+        PM (t4,t5,CC(idx,3,k),CC(idx,4,k)); \
         CH(idx,k,0).r=t1.r+t2.r+t3.r+t4.r; \
         CH(idx,k,0).i=t1.i+t2.i+t3.i+t4.i;
 
@@ -818,7 +1010,7 @@ template<bool fwd, typename T> void pass5 (size_t ido, size_t l1,
         ca.i=t1.i+x1*t2.i+x2*t3.i+x3*t4.i; \
         cb.i=y1*t7.r y2*t6.r y3*t5.r; \
         cb.r=-(y1*t7.i y2*t6.i y3*t5.i); \
-        PMC(out1,out2,ca,cb); \
+        PM(out1,out2,ca,cb); \
         }
 #define POCKETFFT_PARTSTEP7a(u1,u2,x1,x2,x3,y1,y2,y3) \
         POCKETFFT_PARTSTEP7a0(u1,u2,x1,x2,x3,y1,y2,y3,CH(0,k,u1),CH(0,k,u2))
@@ -826,13 +1018,13 @@ template<bool fwd, typename T> void pass5 (size_t ido, size_t l1,
         { \
         T da,db; \
         POCKETFFT_PARTSTEP7a0(u1,u2,x1,x2,x3,y1,y2,y3,da,db) \
-        CH(i,k,u1) = da.template special_mul<fwd>(WA(u1-1,i)); \
-        CH(i,k,u2) = db.template special_mul<fwd>(WA(u2-1,i)); \
+        special_mul<fwd>(da,WA(u1-1,i),CH(i,k,u1)); \
+        special_mul<fwd>(db,WA(u2-1,i),CH(i,k,u2)); \
         }
 
 template<bool fwd, typename T> void pass7(size_t ido, size_t l1,
   const T * POCKETFFT_RESTRICT cc, T * POCKETFFT_RESTRICT ch,
-  const cmplx<T0> * POCKETFFT_RESTRICT wa)
+  const cmplx<T0> * POCKETFFT_RESTRICT wa) const
   {
   constexpr size_t cdim=7;
   constexpr T0 tw1r= T0(0.6234898018587335305250048840042398L),
@@ -881,7 +1073,7 @@ template<bool fwd, typename T> void pass7(size_t ido, size_t l1,
 #undef POCKETFFT_PARTSTEP7a
 #undef POCKETFFT_PREP7
 
-template <bool fwd, typename T> void ROTX45(T &a)
+template <bool fwd, typename T> void ROTX45(T &a) const
   {
   constexpr T0 hsqt2=T0(0.707106781186547524400844362104849L);
   if (fwd)
@@ -889,7 +1081,7 @@ template <bool fwd, typename T> void ROTX45(T &a)
   else
     { auto tmp_=a.r; a.r=hsqt2*(a.r-a.i); a.i=hsqt2*(a.i+tmp_); }
   }
-template <bool fwd, typename T> void ROTX135(T &a)
+template <bool fwd, typename T> void ROTX135(T &a) const
   {
   constexpr T0 hsqt2=T0(0.707106781186547524400844362104849L);
   if (fwd)
@@ -900,7 +1092,7 @@ template <bool fwd, typename T> void ROTX135(T &a)
 
 template<bool fwd, typename T> void pass8 (size_t ido, size_t l1,
   const T * POCKETFFT_RESTRICT cc, T * POCKETFFT_RESTRICT ch,
-  const cmplx<T0> * POCKETFFT_RESTRICT wa)
+  const cmplx<T0> * POCKETFFT_RESTRICT wa) const
   {
   constexpr size_t cdim=8;
 
@@ -915,8 +1107,8 @@ template<bool fwd, typename T> void pass8 (size_t ido, size_t l1,
     for (size_t k=0; k<l1; ++k)
       {
       T a0, a1, a2, a3, a4, a5, a6, a7;
-      PMC(a1,a5,CC(0,1,k),CC(0,5,k));
-      PMC(a3,a7,CC(0,3,k),CC(0,7,k));
+      PM(a1,a5,CC(0,1,k),CC(0,5,k));
+      PM(a3,a7,CC(0,3,k),CC(0,7,k));
       PMINPLACE(a1,a3);
       ROTX90<fwd>(a3);
 
@@ -925,21 +1117,21 @@ template<bool fwd, typename T> void pass8 (size_t ido, size_t l1,
       ROTX45<fwd>(a5);
       ROTX135<fwd>(a7);
 
-      PMC(a0,a4,CC(0,0,k),CC(0,4,k));
-      PMC(a2,a6,CC(0,2,k),CC(0,6,k));
-      PMC(CH(0,k,0),CH(0,k,4),a0+a2,a1);
-      PMC(CH(0,k,2),CH(0,k,6),a0-a2,a3);
+      PM(a0,a4,CC(0,0,k),CC(0,4,k));
+      PM(a2,a6,CC(0,2,k),CC(0,6,k));
+      PM(CH(0,k,0),CH(0,k,4),a0+a2,a1);
+      PM(CH(0,k,2),CH(0,k,6),a0-a2,a3);
       ROTX90<fwd>(a6);
-      PMC(CH(0,k,1),CH(0,k,5),a4+a6,a5);
-      PMC(CH(0,k,3),CH(0,k,7),a4-a6,a7);
+      PM(CH(0,k,1),CH(0,k,5),a4+a6,a5);
+      PM(CH(0,k,3),CH(0,k,7),a4-a6,a7);
       }
   else
     for (size_t k=0; k<l1; ++k)
       {
       {
       T a0, a1, a2, a3, a4, a5, a6, a7;
-      PMC(a1,a5,CC(0,1,k),CC(0,5,k));
-      PMC(a3,a7,CC(0,3,k),CC(0,7,k));
+      PM(a1,a5,CC(0,1,k),CC(0,5,k));
+      PM(a3,a7,CC(0,3,k),CC(0,7,k));
       PMINPLACE(a1,a3);
       ROTX90<fwd>(a3);
 
@@ -948,38 +1140,38 @@ template<bool fwd, typename T> void pass8 (size_t ido, size_t l1,
       ROTX45<fwd>(a5);
       ROTX135<fwd>(a7);
 
-      PMC(a0,a4,CC(0,0,k),CC(0,4,k));
-      PMC(a2,a6,CC(0,2,k),CC(0,6,k));
-      PMC(CH(0,k,0),CH(0,k,4),a0+a2,a1);
-      PMC(CH(0,k,2),CH(0,k,6),a0-a2,a3);
+      PM(a0,a4,CC(0,0,k),CC(0,4,k));
+      PM(a2,a6,CC(0,2,k),CC(0,6,k));
+      PM(CH(0,k,0),CH(0,k,4),a0+a2,a1);
+      PM(CH(0,k,2),CH(0,k,6),a0-a2,a3);
       ROTX90<fwd>(a6);
-      PMC(CH(0,k,1),CH(0,k,5),a4+a6,a5);
-      PMC(CH(0,k,3),CH(0,k,7),a4-a6,a7);
+      PM(CH(0,k,1),CH(0,k,5),a4+a6,a5);
+      PM(CH(0,k,3),CH(0,k,7),a4-a6,a7);
       }
       for (size_t i=1; i<ido; ++i)
         {
         T a0, a1, a2, a3, a4, a5, a6, a7;
-        PMC(a1,a5,CC(i,1,k),CC(i,5,k));
-        PMC(a3,a7,CC(i,3,k),CC(i,7,k));
+        PM(a1,a5,CC(i,1,k),CC(i,5,k));
+        PM(a3,a7,CC(i,3,k),CC(i,7,k));
         ROTX90<fwd>(a7);
         PMINPLACE(a1,a3);
         ROTX90<fwd>(a3);
         PMINPLACE(a5,a7);
         ROTX45<fwd>(a5);
         ROTX135<fwd>(a7);
-        PMC(a0,a4,CC(i,0,k),CC(i,4,k));
-        PMC(a2,a6,CC(i,2,k),CC(i,6,k));
+        PM(a0,a4,CC(i,0,k),CC(i,4,k));
+        PM(a2,a6,CC(i,2,k),CC(i,6,k));
         PMINPLACE(a0,a2);
         CH(i,k,0) = a0+a1;
-        CH(i,k,4) = (a0-a1).template special_mul<fwd>(WA(3,i));
-        CH(i,k,2) = (a2+a3).template special_mul<fwd>(WA(1,i));
-        CH(i,k,6) = (a2-a3).template special_mul<fwd>(WA(5,i));
+        special_mul<fwd>(a0-a1,WA(3,i),CH(i,k,4));
+        special_mul<fwd>(a2+a3,WA(1,i),CH(i,k,2));
+        special_mul<fwd>(a2-a3,WA(5,i),CH(i,k,6));
         ROTX90<fwd>(a6);
         PMINPLACE(a4,a6);
-        CH(i,k,1) = (a4+a5).template special_mul<fwd>(WA(0,i));
-        CH(i,k,5) = (a4-a5).template special_mul<fwd>(WA(4,i));
-        CH(i,k,3) = (a6+a7).template special_mul<fwd>(WA(2,i));
-        CH(i,k,7) = (a6-a7).template special_mul<fwd>(WA(6,i));
+        special_mul<fwd>(a4+a5,WA(0,i),CH(i,k,1));
+        special_mul<fwd>(a4-a5,WA(4,i),CH(i,k,5));
+        special_mul<fwd>(a6+a7,WA(2,i),CH(i,k,3));
+        special_mul<fwd>(a6-a7,WA(6,i),CH(i,k,7));
         }
       }
    }
@@ -987,11 +1179,11 @@ template<bool fwd, typename T> void pass8 (size_t ido, size_t l1,
 
 #define POCKETFFT_PREP11(idx) \
         T t1 = CC(idx,0,k), t2, t3, t4, t5, t6, t7, t8, t9, t10, t11; \
-        PMC (t2,t11,CC(idx,1,k),CC(idx,10,k)); \
-        PMC (t3,t10,CC(idx,2,k),CC(idx, 9,k)); \
-        PMC (t4,t9 ,CC(idx,3,k),CC(idx, 8,k)); \
-        PMC (t5,t8 ,CC(idx,4,k),CC(idx, 7,k)); \
-        PMC (t6,t7 ,CC(idx,5,k),CC(idx, 6,k)); \
+        PM (t2,t11,CC(idx,1,k),CC(idx,10,k)); \
+        PM (t3,t10,CC(idx,2,k),CC(idx, 9,k)); \
+        PM (t4,t9 ,CC(idx,3,k),CC(idx, 8,k)); \
+        PM (t5,t8 ,CC(idx,4,k),CC(idx, 7,k)); \
+        PM (t6,t7 ,CC(idx,5,k),CC(idx, 6,k)); \
         CH(idx,k,0).r=t1.r+t2.r+t3.r+t4.r+t5.r+t6.r; \
         CH(idx,k,0).i=t1.i+t2.i+t3.i+t4.i+t5.i+t6.i;
 
@@ -1001,7 +1193,7 @@ template<bool fwd, typename T> void pass8 (size_t ido, size_t l1,
           cb; \
         cb.i=y1*t11.r y2*t10.r y3*t9.r y4*t8.r y5*t7.r; \
         cb.r=-(y1*t11.i y2*t10.i y3*t9.i y4*t8.i y5*t7.i ); \
-        PMC(out1,out2,ca,cb); \
+        PM(out1,out2,ca,cb); \
         }
 #define POCKETFFT_PARTSTEP11a(u1,u2,x1,x2,x3,x4,x5,y1,y2,y3,y4,y5) \
         POCKETFFT_PARTSTEP11a0(u1,u2,x1,x2,x3,x4,x5,y1,y2,y3,y4,y5,CH(0,k,u1),CH(0,k,u2))
@@ -1009,13 +1201,13 @@ template<bool fwd, typename T> void pass8 (size_t ido, size_t l1,
         { \
         T da,db; \
         POCKETFFT_PARTSTEP11a0(u1,u2,x1,x2,x3,x4,x5,y1,y2,y3,y4,y5,da,db) \
-        CH(i,k,u1) = da.template special_mul<fwd>(WA(u1-1,i)); \
-        CH(i,k,u2) = db.template special_mul<fwd>(WA(u2-1,i)); \
+        special_mul<fwd>(da,WA(u1-1,i),CH(i,k,u1)); \
+        special_mul<fwd>(db,WA(u2-1,i),CH(i,k,u2)); \
         }
 
 template<bool fwd, typename T> void pass11 (size_t ido, size_t l1,
   const T * POCKETFFT_RESTRICT cc, T * POCKETFFT_RESTRICT ch,
-  const cmplx<T0> * POCKETFFT_RESTRICT wa)
+  const cmplx<T0> * POCKETFFT_RESTRICT wa) const
   {
   constexpr size_t cdim=11;
   constexpr T0 tw1r= T0(0.8412535328311811688618116489193677L),
@@ -1077,7 +1269,7 @@ template<bool fwd, typename T> void pass11 (size_t ido, size_t l1,
 template<bool fwd, typename T> void passg (size_t ido, size_t ip,
   size_t l1, T * POCKETFFT_RESTRICT cc, T * POCKETFFT_RESTRICT ch,
   const cmplx<T0> * POCKETFFT_RESTRICT wa,
-  const cmplx<T0> * POCKETFFT_RESTRICT csarr)
+  const cmplx<T0> * POCKETFFT_RESTRICT csarr) const
   {
   const size_t cdim=ip;
   size_t ipph = (ip+1)/2;
@@ -1105,7 +1297,7 @@ template<bool fwd, typename T> void passg (size_t ido, size_t ip,
   for (size_t j=1, jc=ip-1; j<ipph; ++j, --jc)
     for (size_t k=0; k<l1; ++k)
       for (size_t i=0; i<ido; ++i)
-        PMC(CH(i,k,j),CH(i,k,jc),CC(i,j,k),CC(i,jc,k));
+        PM(CH(i,k,j),CH(i,k,jc),CC(i,j,k),CC(i,jc,k));
   for (size_t k=0; k<l1; ++k)
     for (size_t i=0; i<ido; ++i)
       {
@@ -1161,7 +1353,7 @@ template<bool fwd, typename T> void passg (size_t ido, size_t ip,
       for (size_t ik=0; ik<idl1; ++ik)
         {
         T t1=CX2(ik,j), t2=CX2(ik,jc);
-        PMC(CX2(ik,j),CX2(ik,jc),t1,t2);
+        PM(CX2(ik,j),CX2(ik,jc),t1,t2);
         }
   else
     {
@@ -1169,21 +1361,21 @@ template<bool fwd, typename T> void passg (size_t ido, size_t ip,
       for (size_t k=0; k<l1; ++k)
         {
         T t1=CX(0,k,j), t2=CX(0,k,jc);
-        PMC(CX(0,k,j),CX(0,k,jc),t1,t2);
+        PM(CX(0,k,j),CX(0,k,jc),t1,t2);
         for (size_t i=1; i<ido; ++i)
           {
           T x1, x2;
-          PMC(x1,x2,CX(i,k,j),CX(i,k,jc));
+          PM(x1,x2,CX(i,k,j),CX(i,k,jc));
           size_t idij=(j-1)*(ido-1)+i-1;
-          CX(i,k,j) = x1.template special_mul<fwd>(wa[idij]);
+          special_mul<fwd>(x1,wa[idij],CX(i,k,j));
           idij=(jc-1)*(ido-1)+i-1;
-          CX(i,k,jc) = x2.template special_mul<fwd>(wa[idij]);
+          special_mul<fwd>(x2,wa[idij],CX(i,k,jc));
           }
         }
     }
   }
 
-template<bool fwd, typename T> void pass_all(T c[], T0 fct)
+template<bool fwd, typename T> void pass_all(T c[], T0 fct) const
   {
   if (length==1) { c[0]*=fct; return; }
   size_t l1=1;
@@ -1232,11 +1424,8 @@ template<bool fwd, typename T> void pass_all(T c[], T0 fct)
   }
 
   public:
-    template<typename T> void forward(T c[], T0 fct)
-      { pass_all<true>(c, fct); }
-
-    template<typename T> void backward(T c[], T0 fct)
-      { pass_all<false>(c, fct); }
+    template<typename T> void exec(T c[], T0 fct, bool fwd) const
+      { fwd ? pass_all<true>(c, fct) : pass_all<false>(c, fct); }
 
   private:
     POCKETFFT_NOINLINE void factorize()
@@ -1333,17 +1522,14 @@ template<typename T0> class rfftp
     void add_factor(size_t factor)
       { fact.push_back({factor, nullptr, nullptr}); }
 
-template<typename T> inline void PM(T &a, T &b, T c, T d)
-  { a=c+d; b=c-d; }
-
 /* (a+ib) = conj(c+id) * (e+if) */
 template<typename T1, typename T2, typename T3> inline void MULPM
-  (T1 &a, T1 &b, T2 c, T2 d, T3 e, T3 f)
+  (T1 &a, T1 &b, T2 c, T2 d, T3 e, T3 f) const
   {  a=c*e+d*f; b=c*f-d*e; }
 
 template<typename T> void radf2 (size_t ido, size_t l1,
   const T * POCKETFFT_RESTRICT cc, T * POCKETFFT_RESTRICT ch,
-  const T0 * POCKETFFT_RESTRICT wa)
+  const T0 * POCKETFFT_RESTRICT wa) const
   {
   constexpr size_t cdim=2;
 
@@ -1382,7 +1568,7 @@ template<typename T> void radf2 (size_t ido, size_t l1,
 
 template<typename T> void radf3(size_t ido, size_t l1,
   const T * POCKETFFT_RESTRICT cc, T * POCKETFFT_RESTRICT ch,
-  const T0 * POCKETFFT_RESTRICT wa)
+  const T0 * POCKETFFT_RESTRICT wa) const
   {
   constexpr size_t cdim=3;
   constexpr T0 taur=-0.5, taui=T0(0.8660254037844386467637231707529362L);
@@ -1422,7 +1608,7 @@ template<typename T> void radf3(size_t ido, size_t l1,
 
 template<typename T> void radf4(size_t ido, size_t l1,
   const T * POCKETFFT_RESTRICT cc, T * POCKETFFT_RESTRICT ch,
-  const T0 * POCKETFFT_RESTRICT wa)
+  const T0 * POCKETFFT_RESTRICT wa) const
   {
   constexpr size_t cdim=4;
   constexpr T0 hsqt2=T0(0.707106781186547524400844362104849L);
@@ -1470,7 +1656,7 @@ template<typename T> void radf4(size_t ido, size_t l1,
 
 template<typename T> void radf5(size_t ido, size_t l1,
   const T * POCKETFFT_RESTRICT cc, T * POCKETFFT_RESTRICT ch,
-  const T0 * POCKETFFT_RESTRICT wa)
+  const T0 * POCKETFFT_RESTRICT wa) const
   {
   constexpr size_t cdim=5;
   constexpr T0 tr11= T0(0.3090169943749474241022934171828191L),
@@ -1527,7 +1713,7 @@ template<typename T> void radf5(size_t ido, size_t l1,
 
 template<typename T> void radfg(size_t ido, size_t ip, size_t l1,
   T * POCKETFFT_RESTRICT cc, T * POCKETFFT_RESTRICT ch,
-  const T0 * POCKETFFT_RESTRICT wa, const T0 * POCKETFFT_RESTRICT csarr)
+  const T0 * POCKETFFT_RESTRICT wa, const T0 * POCKETFFT_RESTRICT csarr) const
   {
   const size_t cdim=ip;
   size_t ipph=(ip+1)/2;
@@ -1557,15 +1743,13 @@ template<typename T> void radfg(size_t ido, size_t ip, size_t l1,
         for (size_t i=1; i<=ido-2; i+=2)                      // 112
           {
           T t1=C1(i,k,j ), t2=C1(i+1,k,j ),
-                 t3=C1(i,k,jc), t4=C1(i+1,k,jc);
+            t3=C1(i,k,jc), t4=C1(i+1,k,jc);
           T x1=wa[idij]*t1 + wa[idij+1]*t2,
-                 x2=wa[idij]*t2 - wa[idij+1]*t1,
-                 x3=wa[idij2]*t3 + wa[idij2+1]*t4,
-                 x4=wa[idij2]*t4 - wa[idij2+1]*t3;
-          C1(i  ,k,j ) = x1+x3;
-          C1(i  ,k,jc) = x2-x4;
-          C1(i+1,k,j ) = x2+x4;
-          C1(i+1,k,jc) = x3-x1;
+            x2=wa[idij]*t2 - wa[idij+1]*t1,
+            x3=wa[idij2]*t3 + wa[idij2+1]*t4,
+            x4=wa[idij2]*t4 - wa[idij2+1]*t3;
+          PM(C1(i,k,j),C1(i+1,k,jc),x3,x1);
+          PM(C1(i+1,k,j),C1(i,k,jc),x2,x4);
           idij+=2;
           idij2+=2;
           }
@@ -1575,11 +1759,7 @@ template<typename T> void radfg(size_t ido, size_t ip, size_t l1,
 
   for (size_t j=1, jc=ip-1; j<ipph; ++j,--jc)                // 123
     for (size_t k=0; k<l1; ++k)                              // 122
-      {
-      T t1=C1(0,k,j), t2=C1(0,k,jc);
-      C1(0,k,j ) = t1+t2;
-      C1(0,k,jc) = t2-t1;
-      }
+      MPINPLACE(C1(0,k,jc), C1(0,k,j));
 
 //everything in C
 //memset(ch,0,ip*l1*ido*sizeof(double));
@@ -1675,7 +1855,7 @@ template<typename T> void radfg(size_t ido, size_t ip, size_t l1,
 
 template<typename T> void radb2(size_t ido, size_t l1,
   const T * POCKETFFT_RESTRICT cc, T * POCKETFFT_RESTRICT ch,
-  const T0 * POCKETFFT_RESTRICT wa)
+  const T0 * POCKETFFT_RESTRICT wa) const
   {
   constexpr size_t cdim=2;
 
@@ -1707,7 +1887,7 @@ template<typename T> void radb2(size_t ido, size_t l1,
 
 template<typename T> void radb3(size_t ido, size_t l1,
   const T * POCKETFFT_RESTRICT cc, T * POCKETFFT_RESTRICT ch,
-  const T0 * POCKETFFT_RESTRICT wa)
+  const T0 * POCKETFFT_RESTRICT wa) const
   {
   constexpr size_t cdim=3;
   constexpr T0 taur=-0.5, taui=T0(0.8660254037844386467637231707529362L);
@@ -1748,7 +1928,7 @@ template<typename T> void radb3(size_t ido, size_t l1,
 
 template<typename T> void radb4(size_t ido, size_t l1,
   const T * POCKETFFT_RESTRICT cc, T * POCKETFFT_RESTRICT ch,
-  const T0 * POCKETFFT_RESTRICT wa)
+  const T0 * POCKETFFT_RESTRICT wa) const
   {
   constexpr size_t cdim=4;
   constexpr T0 sqrt2=T0(1.414213562373095048801688724209698L);
@@ -1801,7 +1981,7 @@ template<typename T> void radb4(size_t ido, size_t l1,
 
 template<typename T> void radb5(size_t ido, size_t l1,
   const T * POCKETFFT_RESTRICT cc, T * POCKETFFT_RESTRICT ch,
-  const T0 * POCKETFFT_RESTRICT wa)
+  const T0 * POCKETFFT_RESTRICT wa) const
   {
   constexpr size_t cdim=5;
   constexpr T0 tr11= T0(0.3090169943749474241022934171828191L),
@@ -1861,7 +2041,7 @@ template<typename T> void radb5(size_t ido, size_t l1,
 
 template<typename T> void radbg(size_t ido, size_t ip, size_t l1,
   T * POCKETFFT_RESTRICT cc, T * POCKETFFT_RESTRICT ch,
-  const T0 * POCKETFFT_RESTRICT wa, const T0 * POCKETFFT_RESTRICT csarr)
+  const T0 * POCKETFFT_RESTRICT wa, const T0 * POCKETFFT_RESTRICT csarr) const
   {
   const size_t cdim=ip;
   size_t ipph=(ip+1)/ 2;
@@ -1961,10 +2141,7 @@ template<typename T> void radbg(size_t ido, size_t ip, size_t l1,
       CH2(ik,0) += CH2(ik,j);
   for (size_t j=1, jc=ip-1; j<ipph; ++j,--jc)   // 124
     for (size_t k=0; k<l1; ++k)
-      {
-      CH(0,k,j ) = C1(0,k,j)-C1(0,k,jc);
-      CH(0,k,jc) = C1(0,k,j)+C1(0,k,jc);
-      }
+      PM(CH(0,k,jc),CH(0,k,j),C1(0,k,j),C1(0,k,jc));
 
   if (ido==1) return;
 
@@ -1997,7 +2174,7 @@ template<typename T> void radbg(size_t ido, size_t ip, size_t l1,
     }
   }
 
-    template<typename T> void copy_and_norm(T *c, T *p1, size_t n, T0 fct)
+    template<typename T> void copy_and_norm(T *c, T *p1, size_t n, T0 fct) const
       {
       if (p1!=c)
         {
@@ -2014,60 +2191,51 @@ template<typename T> void radbg(size_t ido, size_t ip, size_t l1,
       }
 
   public:
-    template<typename T> void forward(T c[], T0 fct)
+    template<typename T> void exec(T c[], T0 fct, bool r2hc) const
       {
       if (length==1) { c[0]*=fct; return; }
-      size_t n=length;
-      size_t l1=n, nf=fact.size();
+      size_t n=length, nf=fact.size();
       arr<T> ch(n);
       T *p1=c, *p2=ch.data();
 
-      for(size_t k1=0; k1<nf;++k1)
-        {
-        size_t k=nf-k1-1;
-        size_t ip=fact[k].fct;
-        size_t ido=n / l1;
-        l1 /= ip;
-        if(ip==4)
-          radf4(ido, l1, p1, p2, fact[k].tw);
-        else if(ip==2)
-          radf2(ido, l1, p1, p2, fact[k].tw);
-        else if(ip==3)
-          radf3(ido, l1, p1, p2, fact[k].tw);
-        else if(ip==5)
-          radf5(ido, l1, p1, p2, fact[k].tw);
-        else
-          { radfg(ido, ip, l1, p1, p2, fact[k].tw, fact[k].tws); swap (p1,p2); }
-        swap (p1,p2);
-        }
-      copy_and_norm(c,p1,n,fct);
-      }
+      if (r2hc)
+        for(size_t k1=0, l1=n; k1<nf;++k1)
+          {
+          size_t k=nf-k1-1;
+          size_t ip=fact[k].fct;
+          size_t ido=n / l1;
+          l1 /= ip;
+          if(ip==4)
+            radf4(ido, l1, p1, p2, fact[k].tw);
+          else if(ip==2)
+            radf2(ido, l1, p1, p2, fact[k].tw);
+          else if(ip==3)
+            radf3(ido, l1, p1, p2, fact[k].tw);
+          else if(ip==5)
+            radf5(ido, l1, p1, p2, fact[k].tw);
+          else
+            { radfg(ido, ip, l1, p1, p2, fact[k].tw, fact[k].tws); swap (p1,p2); }
+          swap (p1,p2);
+          }
+      else
+        for(size_t k=0, l1=1; k<nf; k++)
+          {
+          size_t ip = fact[k].fct,
+                 ido= n/(ip*l1);
+          if(ip==4)
+            radb4(ido, l1, p1, p2, fact[k].tw);
+          else if(ip==2)
+            radb2(ido, l1, p1, p2, fact[k].tw);
+          else if(ip==3)
+            radb3(ido, l1, p1, p2, fact[k].tw);
+          else if(ip==5)
+            radb5(ido, l1, p1, p2, fact[k].tw);
+          else
+            radbg(ido, ip, l1, p1, p2, fact[k].tw, fact[k].tws);
+          swap (p1,p2);
+          l1*=ip;
+          }
 
-    template<typename T> void backward(T c[], T0 fct)
-      {
-      if (length==1) { c[0]*=fct; return; }
-      size_t n=length;
-      size_t l1=1, nf=fact.size();
-      arr<T> ch(n);
-      T *p1=c, *p2=ch.data();
-
-      for(size_t k=0; k<nf; k++)
-        {
-        size_t ip = fact[k].fct,
-               ido= n/(ip*l1);
-        if(ip==4)
-          radb4(ido, l1, p1, p2, fact[k].tw);
-        else if(ip==2)
-          radb2(ido, l1, p1, p2, fact[k].tw);
-        else if(ip==3)
-          radb3(ido, l1, p1, p2, fact[k].tw);
-        else if(ip==5)
-          radb5(ido, l1, p1, p2, fact[k].tw);
-        else
-          radbg(ido, ip, l1, p1, p2, fact[k].tw, fact[k].tws);
-        swap (p1,p2);
-        l1*=ip;
-        }
       copy_and_norm(c,p1,n,fct);
       }
 
@@ -2165,25 +2333,25 @@ template<typename T0> class fftblue
     arr<cmplx<T0>> mem;
     cmplx<T0> *bk, *bkf;
 
-    template<bool fwd, typename T> void fft(cmplx<T> c[], T0 fct)
+    template<bool fwd, typename T> void fft(cmplx<T> c[], T0 fct) const
       {
       arr<cmplx<T>> akf(n2);
 
       /* initialize a_k and FFT it */
       for (size_t m=0; m<n; ++m)
-        akf[m] = c[m].template special_mul<fwd>(bk[m]);
+        special_mul<fwd>(c[m],bk[m],akf[m]);
       auto zero = akf[0]*T0(0);
       for (size_t m=n; m<n2; ++m)
         akf[m]=zero;
 
-      plan.forward (akf.data(),1.);
+      plan.exec (akf.data(),1.,true);
 
       /* do the convolution */
       for (size_t m=0; m<n2; ++m)
         akf[m] = akf[m].template special_mul<!fwd>(bkf[m]);
 
       /* inverse FFT */
-      plan.backward (akf.data(),1.);
+      plan.exec (akf.data(),1.,false);
 
       /* multiply by b_k */
       for (size_t m=0; m<n; ++m)
@@ -2215,40 +2383,38 @@ template<typename T0> class fftblue
         bkf[m] = bkf[n2-m] = bk[m]*xn2;
       for (size_t m=n;m<=(n2-n);++m)
         bkf[m].Set(0.,0.);
-      plan.forward(bkf,1.);
+      plan.exec(bkf,1.,true);
       }
 
-    template<typename T> void backward(cmplx<T> c[], T0 fct)
-      { fft<false>(c,fct); }
+    template<typename T> void exec(cmplx<T> c[], T0 fct, bool fwd) const
+      { fwd ? fft<true>(c,fct) : fft<false>(c,fct); }
 
-    template<typename T> void forward(cmplx<T> c[], T0 fct)
-      { fft<true>(c,fct); }
-
-    template<typename T> void backward_r(T c[], T0 fct)
+    template<typename T> void exec_r(T c[], T0 fct, bool fwd)
       {
       arr<cmplx<T>> tmp(n);
-      tmp[0].Set(c[0],c[0]*0);
-      memcpy (reinterpret_cast<void *>(tmp.data()+1),
-              reinterpret_cast<void *>(c+1), (n-1)*sizeof(T));
-      if ((n&1)==0) tmp[n/2].i=T0(0)*c[0];
-      for (size_t m=1; 2*m<n; ++m)
-        tmp[n-m].Set(tmp[m].r, -tmp[m].i);
-      fft<false>(tmp.data(),fct);
-      for (size_t m=0; m<n; ++m)
-        c[m] = tmp[m].r;
+      if (fwd)
+        {
+        auto zero = T0(0)*c[0];
+        for (size_t m=0; m<n; ++m)
+          tmp[m].Set(c[m], zero);
+        fft<true>(tmp.data(),fct);
+        c[0] = tmp[0].r;
+        memcpy (c+1, tmp.data()+1, (n-1)*sizeof(T));
+        }
+      else
+        {
+        tmp[0].Set(c[0],c[0]*0);
+        memcpy (reinterpret_cast<void *>(tmp.data()+1),
+                reinterpret_cast<void *>(c+1), (n-1)*sizeof(T));
+        if ((n&1)==0) tmp[n/2].i=T0(0)*c[0];
+        for (size_t m=1; 2*m<n; ++m)
+          tmp[n-m].Set(tmp[m].r, -tmp[m].i);
+        fft<false>(tmp.data(),fct);
+        for (size_t m=0; m<n; ++m)
+          c[m] = tmp[m].r;
+        }
       }
-
-    template<typename T> void forward_r(T c[], T0 fct)
-      {
-      arr<cmplx<T>> tmp(n);
-      auto zero = T0(0)*c[0];
-      for (size_t m=0; m<n; ++m)
-        tmp[m].Set(c[m], zero);
-      fft<true>(tmp.data(),fct);
-      c[0] = tmp[0].r;
-      memcpy (c+1, tmp.data()+1, (n-1)*sizeof(T));
-      }
-    };
+  };
 
 //
 // flexible (FFTPACK/Bluestein) complex 1D transform
@@ -2281,11 +2447,8 @@ template<typename T0> class pocketfft_c
         packplan=unique_ptr<cfftp<T0>>(new cfftp<T0>(length));
       }
 
-    template<typename T> POCKETFFT_NOINLINE void backward(cmplx<T> c[], T0 fct) const
-      { packplan ? packplan->backward(c,fct) : blueplan->backward(c,fct); }
-
-    template<typename T> POCKETFFT_NOINLINE void forward(cmplx<T> c[], T0 fct) const
-      { packplan ? packplan->forward(c,fct) : blueplan->forward(c,fct); }
+    template<typename T> POCKETFFT_NOINLINE void exec(cmplx<T> c[], T0 fct, bool fwd) const
+      { packplan ? packplan->exec(c,fct,fwd) : blueplan->exec(c,fct,fwd); }
 
     size_t length() const { return len; }
   };
@@ -2321,17 +2484,8 @@ template<typename T0> class pocketfft_r
         packplan=unique_ptr<rfftp<T0>>(new rfftp<T0>(length));
       }
 
-    template<typename T> POCKETFFT_NOINLINE void backward(T c[], T0 fct) const
-      {
-      packplan ? packplan->backward(c,fct)
-               : blueplan->backward_r(c,fct);
-      }
-
-    template<typename T> POCKETFFT_NOINLINE void forward(T c[], T0 fct) const
-      {
-      packplan ? packplan->forward(c,fct)
-               : blueplan->forward_r(c,fct);
-      }
+    template<typename T> POCKETFFT_NOINLINE void exec(T c[], T0 fct, bool fwd) const
+      { packplan ? packplan->exec(c,fct,fwd) : blueplan->exec_r(c,fct,fwd); }
 
     size_t length() const { return len; }
   };
@@ -2361,12 +2515,12 @@ template<typename T0> class T_dct1
       tmp[0] = c[0];
       for (size_t i=1; i<n; ++i)
         tmp[i] = tmp[N-i] = c[i];
-      fftplan.forward(tmp.data(), fct);
+      fftplan.exec(tmp.data(), fct, true);
       c[0] = tmp[0];
       for (size_t i=1; i<n; ++i)
         c[i] = tmp[2*i-1];
       if (ortho)
-        { c[0]/=sqrt2; c[n-1]/=sqrt2; }
+        { c[0]*=sqrt2*T0(0.5); c[n-1]*=sqrt2*T0(0.5); }
       }
 
     size_t length() const { return fftplan.length()/2+1; }
@@ -2389,7 +2543,7 @@ template<typename T0> class T_dst1
       tmp[0] = tmp[n+1] = c[0]*0;
       for (size_t i=0; i<n; ++i)
         { tmp[i+1]=c[i]; tmp[N-1-i]=-c[i]; }
-      fftplan.forward(tmp.data(), fct);
+      fftplan.exec(tmp.data(), fct, true);
       for (size_t i=0; i<n; ++i)
         c[i] = -tmp[2*i+2];
       }
@@ -2427,7 +2581,7 @@ template<typename T0> class T_dcst23
         if ((N&1)==0) c[N-1]*=2;
         for (size_t k=1; k<N-1; k+=2)
           MPINPLACE(c[k+1], c[k]);
-        fftplan.backward(c, fct);
+        fftplan.exec(c, fct, false);
         for (size_t k=1, kc=N-1; k<NS2; ++k, --kc)
           {
           T t1 = twiddle[k-1]*c[kc]+twiddle[kc-1]*c[k];
@@ -2439,7 +2593,7 @@ template<typename T0> class T_dcst23
         if (!cosine)
           for (size_t k=0, kc=N-1; k<kc; ++k, --kc)
             swap(c[k], c[kc]);
-        if (ortho) c[0]/=sqrt2;
+        if (ortho) c[0]*=sqrt2*T0(0.5);
         }
       else
         {
@@ -2455,7 +2609,7 @@ template<typename T0> class T_dcst23
           }
         if ((N&1)==0)
           c[NS2] *= 2*twiddle[NS2-1];
-        fftplan.forward(c, fct);
+        fftplan.exec(c, fct, true);
         for (size_t k=1; k<N-1; k+=2)
           MPINPLACE(c[k], c[k+1]);
         if (!cosine)
@@ -2523,7 +2677,7 @@ template<typename T0> class T_dcst4
         for (; i<N; ++i, m+=4)
           y[i] = c[m];
         }
-        rfft->forward(y.data(), fct);
+        rfft->exec(y.data(), fct, true);
         {
         size_t i=0;
         for (; i+i+1<n2; ++i)
@@ -2556,7 +2710,7 @@ template<typename T0> class T_dcst4
           y[i].Set(c[2*i],c[N-1-2*i]);
           y[i] *= C2[i];
           }
-        fft->forward(y.data(), fct);
+        fft->exec(y.data(), fct, true);
         for(size_t i=0, ic=n2-1; i<n2; ++i, --ic)
           {
           c[2*i  ] =  2*(y[i ].r*C2[i ].r-y[i ].i*C2[i ].i);
@@ -2699,10 +2853,10 @@ template<size_t N> class multi_iter
         str_i(iarr.stride(idim_)), p_oi(0), str_o(oarr.stride(idim_)),
         idim(idim_), rem(iarr.size()/iarr.shape(idim))
       {
-      auto nshares = util::nthreads();
+      auto nshares = threading::num_threads;
       if (nshares==1) return;
       if (nshares==0) throw runtime_error("can't run with zero threads");
-      auto myshare = util::thread_num();
+      auto myshare = threading::thread_id;
       if (myshare>=nshares) throw runtime_error("impossible share requested");
       size_t nbase = rem/nshares;
       size_t additional = rem%nshares;
@@ -2850,6 +3004,8 @@ template<> struct VTYPE<long double>
   {
   using type = long double __attribute__ ((vector_size (VLEN<long double>::val*sizeof(long double))));
   };
+
+template <typename T> using vtype_t = typename VTYPE<T>::type;
 #endif
 
 template<typename T> arr<char> alloc_tmp(const shape_t &shape,
@@ -2874,387 +3030,307 @@ template<typename T> arr<char> alloc_tmp(const shape_t &shape,
   return arr<char>(tmpsize*elemsize);
   }
 
-#ifdef POCKETFFT_OPENMP
-#define POCKETFFT_NTHREADS nthreads
-#else
-#define POCKETFFT_NTHREADS
-#endif
-
-template<typename T> POCKETFFT_NOINLINE void general_c(
-  const cndarr<cmplx<T>> &in, ndarr<cmplx<T>> &out,
-  const shape_t &axes, bool forward, T fct, size_t POCKETFFT_NTHREADS)
+template <typename T, size_t vlen> void copy_input(const multi_iter<vlen> &it,
+  const cndarr<cmplx<T>> &src, cmplx<vtype_t<T>> *POCKETFFT_RESTRICT dst)
   {
-  shared_ptr<pocketfft_c<T>> plan;
+  for (size_t i=0; i<it.length_in(); ++i)
+    for (size_t j=0; j<vlen; ++j)
+      {
+      dst[i].r[j] = src[it.iofs(j,i)].r;
+      dst[i].i[j] = src[it.iofs(j,i)].i;
+      }
+  }
+
+template <typename T, size_t vlen> void copy_input(const multi_iter<vlen> &it,
+  const cndarr<T> &src, vtype_t<T> *POCKETFFT_RESTRICT dst)
+  {
+  for (size_t i=0; i<it.length_in(); ++i)
+    for (size_t j=0; j<vlen; ++j)
+      dst[i][j] = src[it.iofs(j,i)];
+  }
+
+template <typename T, size_t vlen> void copy_input(const multi_iter<vlen> &it,
+  const cndarr<T> &src, T *POCKETFFT_RESTRICT dst)
+  {
+  if (dst == &src[it.iofs(0)]) return;  // in-place
+  for (size_t i=0; i<it.length_in(); ++i)
+    dst[i] = src[it.iofs(i)];
+  }
+
+template<typename T, size_t vlen> void copy_output(const multi_iter<vlen> &it,
+  const cmplx<vtype_t<T>> *POCKETFFT_RESTRICT src, ndarr<cmplx<T>> &dst)
+  {
+  for (size_t i=0; i<it.length_out(); ++i)
+    for (size_t j=0; j<vlen; ++j)
+      dst[it.oofs(j,i)].Set(src[i].r[j],src[i].i[j]);
+  }
+
+template<typename T, size_t vlen> void copy_output(const multi_iter<vlen> &it,
+  const vtype_t<T> *POCKETFFT_RESTRICT src, ndarr<T> &dst)
+  {
+  for (size_t i=0; i<it.length_out(); ++i)
+    for (size_t j=0; j<vlen; ++j)
+      dst[it.oofs(j,i)] = src[i][j];
+  }
+
+template<typename T, size_t vlen> void copy_output(const multi_iter<vlen> &it,
+  const T *POCKETFFT_RESTRICT src, ndarr<T> &dst)
+  {
+  if (src == &dst[it.oofs(0)]) return;  // in-place
+  for (size_t i=0; i<it.length_out(); ++i)
+    dst[it.oofs(i)] = src[i];
+  }
+
+template <typename T> struct add_vec { using type = vtype_t<T>; };
+template <typename T> struct add_vec<cmplx<T>>
+  { using type = cmplx<vtype_t<T>>; };
+template <typename T> using add_vec_t = typename add_vec<T>::type;
+
+template<typename Tplan, typename T, typename T0, typename Exec>
+POCKETFFT_NOINLINE void general_nd(const cndarr<T> &in, ndarr<T> &out,
+  const shape_t &axes, T0 fct, size_t nthreads, const Exec & exec,
+  const bool allow_inplace=true)
+  {
+  shared_ptr<Tplan> plan;
 
   for (size_t iax=0; iax<axes.size(); ++iax)
     {
-    constexpr auto vlen = VLEN<T>::val;
+    constexpr auto vlen = VLEN<T0>::val;
     size_t len=in.shape(axes[iax]);
     if ((!plan) || (len!=plan->length()))
-      plan = get_plan<pocketfft_c<T>>(len);
+      plan = get_plan<Tplan>(len);
 
-#ifdef POCKETFFT_OPENMP
-#pragma omp parallel num_threads(util::thread_count(nthreads, in.shape(), axes[iax]))
-#endif
-{
-    auto storage = alloc_tmp<T>(in.shape(), len, sizeof(cmplx<T>));
-    const auto &tin(iax==0? in : out);
-    multi_iter<vlen> it(tin, out, axes[iax]);
+    threading::thread_map(util::thread_count(nthreads, in.shape(), axes[iax], vlen),
+      [&] {
+        auto storage = alloc_tmp<T0>(in.shape(), len, sizeof(T));
+        const auto &tin(iax==0? in : out);
+        multi_iter<vlen> it(tin, out, axes[iax]);
 #ifndef POCKETFFT_NO_VECTORS
-    if (vlen>1)
-      while (it.remaining()>=vlen)
-        {
-        using vtype = typename VTYPE<T>::type;
-        it.advance(vlen);
-        auto tdatav = reinterpret_cast<cmplx<vtype> *>(storage.data());
-        for (size_t i=0; i<len; ++i)
-          for (size_t j=0; j<vlen; ++j)
+        if (vlen>1)
+          while (it.remaining()>=vlen)
             {
-            tdatav[i].r[j] = tin[it.iofs(j,i)].r;
-            tdatav[i].i[j] = tin[it.iofs(j,i)].i;
+            it.advance(vlen);
+            auto tdatav = reinterpret_cast<add_vec_t<T> *>(storage.data());
+            exec(it, tin, out, tdatav, *plan, fct);
             }
-        forward ? plan->forward (tdatav, fct) : plan->backward(tdatav, fct);
-        for (size_t i=0; i<len; ++i)
-          for (size_t j=0; j<vlen; ++j)
-            out[it.oofs(j,i)].Set(tdatav[i].r[j],tdatav[i].i[j]);
-        }
 #endif
-    while (it.remaining()>0)
-      {
-      it.advance(1);
-      auto buf = it.stride_out() == sizeof(cmplx<T>) ?
-        &out[it.oofs(0)] : reinterpret_cast<cmplx<T> *>(storage.data());
-
-      if (buf != &tin[it.iofs(0)])
-        for (size_t i=0; i<len; ++i)
-          buf[i] = tin[it.iofs(i)];
-      forward ? plan->forward (buf, fct) : plan->backward(buf, fct);
-      if (buf != &out[it.oofs(0)])
-        for (size_t i=0; i<len; ++i)
-          out[it.oofs(i)] = buf[i];
-      }
-} // end of parallel region
-    fct = T(1); // factor has been applied, use 1 for remaining axes
+        while (it.remaining()>0)
+          {
+          it.advance(1);
+          auto buf = allow_inplace && it.stride_out() == sizeof(T) ?
+            &out[it.oofs(0)] : reinterpret_cast<T *>(storage.data());
+          exec(it, tin, out, buf, *plan, fct);
+          }
+      });  // end of parallel region
+    fct = T0(1); // factor has been applied, use 1 for remaining axes
     }
   }
 
-template<typename T> POCKETFFT_NOINLINE void general_hartley(
-  const cndarr<T> &in, ndarr<T> &out, const shape_t &axes, T fct,
-  size_t POCKETFFT_NTHREADS)
+struct ExecC2C
   {
-  shared_ptr<pocketfft_r<T>> plan;
+  bool forward;
 
-  for (size_t iax=0; iax<axes.size(); ++iax)
+  template <typename T0, typename T, size_t vlen> void operator () (
+    const multi_iter<vlen> &it, const cndarr<cmplx<T0>> &in,
+    ndarr<cmplx<T0>> &out, T * buf, const pocketfft_c<T0> &plan, T0 fct) const
     {
-    constexpr auto vlen = VLEN<T>::val;
-    size_t len=in.shape(axes[iax]);
-    if ((!plan) || (len!=plan->length()))
-      plan = get_plan<pocketfft_r<T>>(len);
+    copy_input(it, in, buf);
+    plan.exec(buf, fct, forward);
+    copy_output(it, buf, out);
+    }
+  };
 
-#ifdef POCKETFFT_OPENMP
-#pragma omp parallel num_threads(util::thread_count(nthreads, in.shape(), axes[iax]))
-#endif
-{
+template <typename T, size_t vlen> void copy_hartley(const multi_iter<vlen> &it,
+  const vtype_t<T> *POCKETFFT_RESTRICT src, ndarr<T> &dst)
+  {
+  for (size_t j=0; j<vlen; ++j)
+    dst[it.oofs(j,0)] = src[0][j];
+  size_t i=1, i1=1, i2=it.length_out()-1;
+  for (i=1; i<it.length_out()-1; i+=2, ++i1, --i2)
+    for (size_t j=0; j<vlen; ++j)
+      {
+        dst[it.oofs(j,i1)] = src[i][j]+src[i+1][j];
+        dst[it.oofs(j,i2)] = src[i][j]-src[i+1][j];
+      }
+  if (i<it.length_out())
+    for (size_t j=0; j<vlen; ++j)
+      dst[it.oofs(j,i1)] = src[i][j];
+  }
+
+template <typename T, size_t vlen> void copy_hartley(const multi_iter<vlen> &it,
+  const T *POCKETFFT_RESTRICT src, ndarr<T> &dst)
+  {
+  dst[it.oofs(0)] = src[0];
+  size_t i=1, i1=1, i2=it.length_out()-1;
+  for (i=1; i<it.length_out()-1; i+=2, ++i1, --i2)
+    {
+    dst[it.oofs(i1)] = src[i]+src[i+1];
+    dst[it.oofs(i2)] = src[i]-src[i+1];
+    }
+  if (i<it.length_out())
+    dst[it.oofs(i1)] = src[i];
+  }
+
+struct ExecHartley
+  {
+  template <typename T0, typename T, size_t vlen> void operator () (
+    const multi_iter<vlen> &it, const cndarr<T0> &in, ndarr<T0> &out,
+    T * buf, const pocketfft_r<T0> &plan, T0 fct) const
+    {
+    copy_input(it, in, buf);
+    plan.exec(buf, fct, true);
+    copy_hartley(it, buf, out);
+    }
+  };
+
+struct ExecDcst
+  {
+  bool ortho;
+  int type;
+  bool cosine;
+
+  template <typename T0, typename T, typename Tplan, size_t vlen>
+  void operator () (const multi_iter<vlen> &it, const cndarr<T0> &in,
+    ndarr<T0> &out, T * buf, const Tplan &plan, T0 fct) const
+    {
+    copy_input(it, in, buf);
+    plan.exec(buf, fct, ortho, type, cosine);
+    copy_output(it, buf, out);
+    }
+  };
+
+template<typename T> POCKETFFT_NOINLINE void general_r2c(
+  const cndarr<T> &in, ndarr<cmplx<T>> &out, size_t axis, bool forward, T fct,
+  size_t nthreads)
+  {
+  auto plan = get_plan<pocketfft_r<T>>(in.shape(axis));
+  constexpr auto vlen = VLEN<T>::val;
+  size_t len=in.shape(axis);
+  threading::thread_map(util::thread_count(nthreads, in.shape(), axis, vlen),
+    [&] {
     auto storage = alloc_tmp<T>(in.shape(), len, sizeof(T));
-    const auto &tin(iax==0 ? in : out);
-    multi_iter<vlen> it(tin, out, axes[iax]);
+    multi_iter<vlen> it(in, out, axis);
 #ifndef POCKETFFT_NO_VECTORS
     if (vlen>1)
       while (it.remaining()>=vlen)
         {
-        using vtype = typename VTYPE<T>::type;
         it.advance(vlen);
-        auto tdatav = reinterpret_cast<vtype *>(storage.data());
-        for (size_t i=0; i<len; ++i)
-          for (size_t j=0; j<vlen; ++j)
-            tdatav[i][j] = tin[it.iofs(j,i)];
-        plan->forward(tdatav, fct);
+        auto tdatav = reinterpret_cast<vtype_t<T> *>(storage.data());
+        copy_input(it, in, tdatav);
+        plan->exec(tdatav, fct, true);
         for (size_t j=0; j<vlen; ++j)
-          out[it.oofs(j,0)] = tdatav[0][j];
-        size_t i=1, i1=1, i2=len-1;
-        for (i=1; i<len-1; i+=2, ++i1, --i2)
-          for (size_t j=0; j<vlen; ++j)
-            {
-            out[it.oofs(j,i1)] = tdatav[i][j]+tdatav[i+1][j];
-            out[it.oofs(j,i2)] = tdatav[i][j]-tdatav[i+1][j];
-            }
+          out[it.oofs(j,0)].Set(tdatav[0][j]);
+        size_t i=1, ii=1;
+        if (forward)
+          for (; i<len-1; i+=2, ++ii)
+            for (size_t j=0; j<vlen; ++j)
+              out[it.oofs(j,ii)].Set(tdatav[i][j], tdatav[i+1][j]);
+        else
+          for (; i<len-1; i+=2, ++ii)
+            for (size_t j=0; j<vlen; ++j)
+              out[it.oofs(j,ii)].Set(tdatav[i][j], -tdatav[i+1][j]);
         if (i<len)
           for (size_t j=0; j<vlen; ++j)
-            out[it.oofs(j,i1)] = tdatav[i][j];
+            out[it.oofs(j,ii)].Set(tdatav[i][j]);
         }
 #endif
     while (it.remaining()>0)
       {
       it.advance(1);
       auto tdata = reinterpret_cast<T *>(storage.data());
-      for (size_t i=0; i<len; ++i)
-        tdata[i] = tin[it.iofs(i)];
-      plan->forward(tdata, fct);
-      // Hartley order
-      out[it.oofs(0)] = tdata[0];
-      size_t i=1, i1=1, i2=len-1;
-      for (i=1; i<len-1; i+=2, ++i1, --i2)
-        {
-        out[it.oofs(i1)] = tdata[i]+tdata[i+1];
-        out[it.oofs(i2)] = tdata[i]-tdata[i+1];
-        }
-      if (i<len)
-        out[it.oofs(i1)] = tdata[i];
-      }
-} // end of parallel region
-    fct = T(1); // factor has been applied, use 1 for remaining axes
-    }
-  }
-
-template<typename Trafo, typename T> POCKETFFT_NOINLINE void general_dcst(
-  const cndarr<T> &in, ndarr<T> &out, const shape_t &axes,
-  T fct, bool ortho, int type, bool cosine, size_t POCKETFFT_NTHREADS)
-  {
-  shared_ptr<Trafo> plan;
-
-  for (size_t iax=0; iax<axes.size(); ++iax)
-    {
-    constexpr auto vlen = VLEN<T>::val;
-    size_t len=in.shape(axes[iax]);
-    if ((!plan) || (len!=plan->length()))
-      plan = get_plan<Trafo>(len);
-
-#ifdef POCKETFFT_OPENMP
-#pragma omp parallel num_threads(util::thread_count(nthreads, in.shape(), axes[iax]))
-#endif
-{
-    auto storage = alloc_tmp<T>(in.shape(), len, sizeof(T));
-    const auto &tin(iax==0 ? in : out);
-    multi_iter<vlen> it(tin, out, axes[iax]);
-#ifndef POCKETFFT_NO_VECTORS
-    if (vlen>1)
-      while (it.remaining()>=vlen)
-        {
-        using vtype = typename VTYPE<T>::type;
-        it.advance(vlen);
-        auto tdatav = reinterpret_cast<vtype *>(storage.data());
-        for (size_t i=0; i<len; ++i)
-          for (size_t j=0; j<vlen; ++j)
-            tdatav[i][j] = tin[it.iofs(j,i)];
-        plan->exec(tdatav, fct, ortho, type, cosine);
-        for (size_t i=0; i<len; ++i)
-          for (size_t j=0; j<vlen; ++j)
-            out[it.oofs(j,i)] = tdatav[i][j];
-        }
-#endif
-    while (it.remaining()>0)
-      {
-      it.advance(1);
-      auto buf = it.stride_out() == sizeof(T) ? &out[it.oofs(0)]
-        : reinterpret_cast<T *>(storage.data());
-
-      if (buf != &tin[it.iofs(0)])
-        for (size_t i=0; i<len; ++i)
-          buf[i] = tin[it.iofs(i)];
-      plan->exec(buf, fct, ortho, type, cosine);
-      if (buf != &out[it.oofs(0)])
-        for (size_t i=0; i<len; ++i)
-          out[it.oofs(i)] = buf[i];
-      }
-} // end of parallel region
-    fct = T(1); // factor has been applied, use 1 for remaining axes
-    }
-  }
-
-template<typename T> POCKETFFT_NOINLINE void general_r2c(
-  const cndarr<T> &in, ndarr<cmplx<T>> &out, size_t axis, bool forward, T fct,
-  size_t POCKETFFT_NTHREADS)
-  {
-  auto plan = get_plan<pocketfft_r<T>>(in.shape(axis));
-  constexpr auto vlen = VLEN<T>::val;
-  size_t len=in.shape(axis);
-#ifdef POCKETFFT_OPENMP
-#pragma omp parallel num_threads(util::thread_count(nthreads, in.shape(), axis))
-#endif
-{
-  auto storage = alloc_tmp<T>(in.shape(), len, sizeof(T));
-  multi_iter<vlen> it(in, out, axis);
-#ifndef POCKETFFT_NO_VECTORS
-  if (vlen>1)
-    while (it.remaining()>=vlen)
-      {
-      using vtype = typename VTYPE<T>::type;
-      it.advance(vlen);
-      auto tdatav = reinterpret_cast<vtype *>(storage.data());
-      for (size_t i=0; i<len; ++i)
-        for (size_t j=0; j<vlen; ++j)
-          tdatav[i][j] = in[it.iofs(j,i)];
-      plan->forward(tdatav, fct);
-      for (size_t j=0; j<vlen; ++j)
-        out[it.oofs(j,0)].Set(tdatav[0][j]);
+      copy_input(it, in, tdata);
+      plan->exec(tdata, fct, true);
+      out[it.oofs(0)].Set(tdata[0]);
       size_t i=1, ii=1;
       if (forward)
         for (; i<len-1; i+=2, ++ii)
-          for (size_t j=0; j<vlen; ++j)
-            out[it.oofs(j,ii)].Set(tdatav[i][j], tdatav[i+1][j]);
+          out[it.oofs(ii)].Set(tdata[i], tdata[i+1]);
       else
         for (; i<len-1; i+=2, ++ii)
-          for (size_t j=0; j<vlen; ++j)
-            out[it.oofs(j,ii)].Set(tdatav[i][j], -tdatav[i+1][j]);
+          out[it.oofs(ii)].Set(tdata[i], -tdata[i+1]);
       if (i<len)
-        for (size_t j=0; j<vlen; ++j)
-          out[it.oofs(j,ii)].Set(tdatav[i][j]);
+        out[it.oofs(ii)].Set(tdata[i]);
       }
-#endif
-  while (it.remaining()>0)
-    {
-    it.advance(1);
-    auto tdata = reinterpret_cast<T *>(storage.data());
-    for (size_t i=0; i<len; ++i)
-      tdata[i] = in[it.iofs(i)];
-    plan->forward(tdata, fct);
-    out[it.oofs(0)].Set(tdata[0]);
-    size_t i=1, ii=1;
-    if (forward)
-      for (; i<len-1; i+=2, ++ii)
-        out[it.oofs(ii)].Set(tdata[i], tdata[i+1]);
-    else
-      for (; i<len-1; i+=2, ++ii)
-        out[it.oofs(ii)].Set(tdata[i], -tdata[i+1]);
-    if (i<len)
-      out[it.oofs(ii)].Set(tdata[i]);
-    }
-} // end of parallel region
+    });  // end of parallel region
   }
 template<typename T> POCKETFFT_NOINLINE void general_c2r(
   const cndarr<cmplx<T>> &in, ndarr<T> &out, size_t axis, bool forward, T fct,
-  size_t POCKETFFT_NTHREADS)
+  size_t nthreads)
   {
   auto plan = get_plan<pocketfft_r<T>>(out.shape(axis));
   constexpr auto vlen = VLEN<T>::val;
   size_t len=out.shape(axis);
-#ifdef POCKETFFT_OPENMP
-#pragma omp parallel num_threads(util::thread_count(nthreads, in.shape(), axis))
-#endif
-{
-  auto storage = alloc_tmp<T>(out.shape(), len, sizeof(T));
-  multi_iter<vlen> it(in, out, axis);
+  threading::thread_map(util::thread_count(nthreads, in.shape(), axis, vlen),
+    [&] {
+      auto storage = alloc_tmp<T>(out.shape(), len, sizeof(T));
+      multi_iter<vlen> it(in, out, axis);
 #ifndef POCKETFFT_NO_VECTORS
-  if (vlen>1)
-    while (it.remaining()>=vlen)
-      {
-      using vtype = typename VTYPE<T>::type;
-      it.advance(vlen);
-      auto tdatav = reinterpret_cast<vtype *>(storage.data());
-      for (size_t j=0; j<vlen; ++j)
-        tdatav[0][j]=in[it.iofs(j,0)].r;
-      {
-      size_t i=1, ii=1;
-      if (forward)
-        for (; i<len-1; i+=2, ++ii)
+      if (vlen>1)
+        while (it.remaining()>=vlen)
+          {
+          it.advance(vlen);
+          auto tdatav = reinterpret_cast<vtype_t<T> *>(storage.data());
           for (size_t j=0; j<vlen; ++j)
-            in[it.iofs(j,ii)].SplitConj(tdatav[i][j], tdatav[i+1][j]);
-      else
-        for (; i<len-1; i+=2, ++ii)
-          for (size_t j=0; j<vlen; ++j)
-            in[it.iofs(j,ii)].Split(tdatav[i][j], tdatav[i+1][j]);
-      if (i<len)
-        for (size_t j=0; j<vlen; ++j)
-          tdatav[i][j] = in[it.iofs(j,ii)].r;
-      }
-      plan->backward(tdatav, fct);
-      for (size_t i=0; i<len; ++i)
-        for (size_t j=0; j<vlen; ++j)
-          out[it.oofs(j,i)] = tdatav[i][j];
-      }
+            tdatav[0][j]=in[it.iofs(j,0)].r;
+          {
+          size_t i=1, ii=1;
+          if (forward)
+            for (; i<len-1; i+=2, ++ii)
+              for (size_t j=0; j<vlen; ++j)
+                in[it.iofs(j,ii)].SplitConj(tdatav[i][j], tdatav[i+1][j]);
+          else
+            for (; i<len-1; i+=2, ++ii)
+              for (size_t j=0; j<vlen; ++j)
+                in[it.iofs(j,ii)].Split(tdatav[i][j], tdatav[i+1][j]);
+          if (i<len)
+            for (size_t j=0; j<vlen; ++j)
+              tdatav[i][j] = in[it.iofs(j,ii)].r;
+          }
+          plan->exec(tdatav, fct, false);
+          copy_output(it, tdatav, out);
+          }
 #endif
-  while (it.remaining()>0)
-    {
-    it.advance(1);
-    auto tdata = reinterpret_cast<T *>(storage.data());
-    tdata[0]=in[it.iofs(0)].r;
-    {
-    size_t i=1, ii=1;
-    if (forward)
-      for (; i<len-1; i+=2, ++ii)
-        in[it.iofs(ii)].SplitConj(tdata[i], tdata[i+1]);
-    else
-      for (; i<len-1; i+=2, ++ii)
-        in[it.iofs(ii)].Split(tdata[i], tdata[i+1]);
-    if (i<len)
-      tdata[i] = in[it.iofs(ii)].r;
-    }
-    plan->backward(tdata, fct);
-    for (size_t i=0; i<len; ++i)
-      out[it.oofs(i)] = tdata[i];
-    }
-} // end of parallel region
-  }
-
-template<typename T> POCKETFFT_NOINLINE void general_r(
-  const cndarr<T> &in, ndarr<T> &out, const shape_t &axes, bool r2c,
-  bool forward, T fct, size_t POCKETFFT_NTHREADS)
-  {
-  shared_ptr<pocketfft_r<T>> plan;
-
-  for (size_t iax=0; iax<axes.size(); ++iax)
-    {
-    constexpr auto vlen = VLEN<T>::val;
-    size_t len=in.shape(axes[iax]);
-    if ((!plan) || (len!=plan->length()))
-      plan = get_plan<pocketfft_r<T>>(len);
-
-#ifdef POCKETFFT_OPENMP
-#pragma omp parallel num_threads(util::thread_count(nthreads, in.shape(), axes[iax]))
-#endif
-{
-    auto storage = alloc_tmp<T>(in.shape(), len, sizeof(T));
-    const auto &tin(iax==0 ? in : out);
-    multi_iter<vlen> it(tin, out, axes[iax]);
-#ifndef POCKETFFT_NO_VECTORS
-    if (vlen>1)
-      while (it.remaining()>=vlen)
+      while (it.remaining()>0)
         {
-        using vtype = typename VTYPE<T>::type;
-        it.advance(vlen);
-        auto tdatav = reinterpret_cast<vtype *>(storage.data());
-        for (size_t i=0; i<len; ++i)
-          for (size_t j=0; j<vlen; ++j)
-            tdatav[i][j] = tin[it.iofs(j,i)];
-        if ((!r2c) && forward)
-          for (size_t i=2; i<len; i+=2)
-            tdatav[i] = -tdatav[i];
-        forward ? plan->forward (tdatav, fct)
-                : plan->backward(tdatav, fct);
-        if (r2c && (!forward))
-          for (size_t i=2; i<len; i+=2)
-            tdatav[i] = -tdatav[i];
-        for (size_t i=0; i<len; ++i)
-          for (size_t j=0; j<vlen; ++j)
-            out[it.oofs(j,i)] = tdatav[i][j];
+        it.advance(1);
+        auto tdata = reinterpret_cast<T *>(storage.data());
+        tdata[0]=in[it.iofs(0)].r;
+        {
+        size_t i=1, ii=1;
+        if (forward)
+          for (; i<len-1; i+=2, ++ii)
+            in[it.iofs(ii)].SplitConj(tdata[i], tdata[i+1]);
+        else
+          for (; i<len-1; i+=2, ++ii)
+            in[it.iofs(ii)].Split(tdata[i], tdata[i+1]);
+        if (i<len)
+          tdata[i] = in[it.iofs(ii)].r;
         }
-#endif
-    while (it.remaining()>0)
-      {
-      it.advance(1);
-      auto buf = it.stride_out() == sizeof(T) ?
-        &out[it.oofs(0)] : reinterpret_cast<T *>(storage.data());
-
-      if (buf != &tin[it.iofs(0)])
-        for (size_t i=0; i<len; ++i)
-          buf[i] = tin[it.iofs(i)];
-      if ((!r2c) && forward)
-        for (size_t i=2; i<len; i+=2)
-          buf[i] = -buf[i];
-      forward ? plan->forward(buf, fct) : plan->backward(buf, fct);
-      if (r2c && (!forward))
-        for (size_t i=2; i<len; i+=2)
-          buf[i] = -buf[i];
-      if (buf != &out[it.oofs(0)])
-        for (size_t i=0; i<len; ++i)
-          out[it.oofs(i)] = buf[i];
-      }
-} // end of parallel region
-    fct = T(1); // factor has been applied, use 1 for remaining axes
-    }
+        plan->exec(tdata, fct, false);
+        copy_output(it, tdata, out);
+        }
+    });  // end of parallel region
   }
 
-#undef POCKETFFT_NTHREADS
+struct ExecR2R
+  {
+  bool r2c, forward;
+
+  template <typename T0, typename T, size_t vlen> void operator () (
+    const multi_iter<vlen> &it, const cndarr<T0> &in, ndarr<T0> &out, T * buf,
+    const pocketfft_r<T0> &plan, T0 fct) const
+    {
+    copy_input(it, in, buf);
+    if ((!r2c) && forward)
+      for (size_t i=2; i<it.length_out(); i+=2)
+        buf[i] = -buf[i];
+    plan.exec(buf, fct, forward);
+    if (r2c && (!forward))
+      for (size_t i=2; i<it.length_out(); i+=2)
+        buf[i] = -buf[i];
+    copy_output(it, buf, out);
+    }
+  };
 
 template<typename T> void c2c(const shape_t &shape, const stride_t &stride_in,
   const stride_t &stride_out, const shape_t &axes, bool forward,
@@ -3265,7 +3341,7 @@ template<typename T> void c2c(const shape_t &shape, const stride_t &stride_in,
   util::sanity_check(shape, stride_in, stride_out, data_in==data_out, axes);
   cndarr<cmplx<T>> ain(data_in, shape, stride_in);
   ndarr<cmplx<T>> aout(data_out, shape, stride_out);
-  general_c(ain, aout, axes, forward, fct, nthreads);
+  general_nd<pocketfft_c<T>>(ain, aout, axes, fct, nthreads, ExecC2C{forward});
   }
 
 template<typename T> void dct(const shape_t &shape,
@@ -3277,12 +3353,13 @@ template<typename T> void dct(const shape_t &shape,
   util::sanity_check(shape, stride_in, stride_out, data_in==data_out, axes);
   cndarr<T> ain(data_in, shape, stride_in);
   ndarr<T> aout(data_out, shape, stride_out);
+  const ExecDcst exec{ortho, type, true};
   if (type==1)
-    general_dcst<T_dct1<T>>(ain, aout, axes, fct, ortho, type, true, nthreads);
+    general_nd<T_dct1<T>>(ain, aout, axes, fct, nthreads, exec);
   else if (type==4)
-    general_dcst<T_dcst4<T>>(ain, aout, axes, fct, ortho, type, true, nthreads);
+    general_nd<T_dcst4<T>>(ain, aout, axes, fct, nthreads, exec);
   else
-    general_dcst<T_dcst23<T>>(ain, aout, axes, fct, ortho, type, true, nthreads);
+    general_nd<T_dcst23<T>>(ain, aout, axes, fct, nthreads, exec);
   }
 
 template<typename T> void dst(const shape_t &shape,
@@ -3294,12 +3371,13 @@ template<typename T> void dst(const shape_t &shape,
   util::sanity_check(shape, stride_in, stride_out, data_in==data_out, axes);
   cndarr<T> ain(data_in, shape, stride_in);
   ndarr<T> aout(data_out, shape, stride_out);
+  const ExecDcst exec{ortho, type, false};
   if (type==1)
-    general_dcst<T_dst1<T>>(ain, aout, axes, fct, ortho, type, false, nthreads);
+    general_nd<T_dst1<T>>(ain, aout, axes, fct, nthreads, exec);
   else if (type==4)
-    general_dcst<T_dcst4<T>>(ain, aout, axes, fct, ortho, type, false, nthreads);
+    general_nd<T_dcst4<T>>(ain, aout, axes, fct, nthreads, exec);
   else
-    general_dcst<T_dcst23<T>>(ain, aout, axes, fct, ortho, type, false, nthreads);
+    general_nd<T_dcst23<T>>(ain, aout, axes, fct, nthreads, exec);
   }
 
 template<typename T> void r2c(const shape_t &shape_in,
@@ -3383,7 +3461,8 @@ template<typename T> void r2r_fftpack(const shape_t &shape,
   util::sanity_check(shape, stride_in, stride_out, data_in==data_out, axes);
   cndarr<T> ain(data_in, shape, stride_in);
   ndarr<T> aout(data_out, shape, stride_out);
-  general_r(ain, aout, axes, real2hermitian, forward, fct, nthreads);
+  general_nd<pocketfft_r<T>>(ain, aout, axes, fct, nthreads,
+    ExecR2R{real2hermitian, forward});
   }
 
 template<typename T> void r2r_separable_hartley(const shape_t &shape,
@@ -3394,7 +3473,8 @@ template<typename T> void r2r_separable_hartley(const shape_t &shape,
   util::sanity_check(shape, stride_in, stride_out, data_in==data_out, axes);
   cndarr<T> ain(data_in, shape, stride_in);
   ndarr<T> aout(data_out, shape, stride_out);
-  general_hartley(ain, aout, axes, fct, nthreads);
+  general_nd<pocketfft_r<T>>(ain, aout, axes, fct, nthreads, ExecHartley{},
+    false);
   }
 
 } // namespace detail

--- a/scipy/fft/_pocketfft/pocketfft_hdronly.h
+++ b/scipy/fft/_pocketfft/pocketfft_hdronly.h
@@ -2990,8 +2990,10 @@ class rev_iter
     size_t remaining() const { return rem; }
   };
 
-#ifndef POCKETFFT_NO_VECTORS
 template<typename T> struct VTYPE {};
+template <typename T> using vtype_t = typename VTYPE<T>::type;
+
+#ifndef POCKETFFT_NO_VECTORS
 template<> struct VTYPE<float>
   {
   using type = float __attribute__ ((vector_size (VLEN<float>::val*sizeof(float))));
@@ -3004,8 +3006,6 @@ template<> struct VTYPE<long double>
   {
   using type = long double __attribute__ ((vector_size (VLEN<long double>::val*sizeof(long double))));
   };
-
-template <typename T> using vtype_t = typename VTYPE<T>::type;
 #endif
 
 template<typename T> arr<char> alloc_tmp(const shape_t &shape,

--- a/scipy/fft/_pocketfft/pocketfft_hdronly.h
+++ b/scipy/fft/_pocketfft/pocketfft_hdronly.h
@@ -3095,16 +3095,17 @@ POCKETFFT_NOINLINE void general_nd(const cndarr<T> &in, ndarr<T> &out,
 
   for (size_t iax=0; iax<axes.size(); ++iax)
     {
-    constexpr auto vlen = VLEN<T0>::val;
     size_t len=in.shape(axes[iax]);
     if ((!plan) || (len!=plan->length()))
       plan = get_plan<Tplan>(len);
 
-    threading::thread_map(util::thread_count(nthreads, in.shape(), axes[iax], vlen),
+    threading::thread_map(
+      util::thread_count(nthreads, in.shape(), axes[iax], VLEN<T>::val),
       [&] {
+        constexpr auto vlen = VLEN<T0>::val;
         auto storage = alloc_tmp<T0>(in.shape(), len, sizeof(T));
         const auto &tin(iax==0? in : out);
-        multi_iter<vlen> it(tin, out, axes[iax]);
+        multi_iter<VLEN<T0>::val> it(tin, out, axes[iax]);
 #ifndef POCKETFFT_NO_VECTORS
         if (vlen>1)
           while (it.remaining()>=vlen)
@@ -3204,10 +3205,11 @@ template<typename T> POCKETFFT_NOINLINE void general_r2c(
   size_t nthreads)
   {
   auto plan = get_plan<pocketfft_r<T>>(in.shape(axis));
-  constexpr auto vlen = VLEN<T>::val;
   size_t len=in.shape(axis);
-  threading::thread_map(util::thread_count(nthreads, in.shape(), axis, vlen),
+  threading::thread_map(
+    util::thread_count(nthreads, in.shape(), axis, VLEN<T>::val),
     [&] {
+    constexpr auto vlen = VLEN<T>::val;
     auto storage = alloc_tmp<T>(in.shape(), len, sizeof(T));
     multi_iter<vlen> it(in, out, axis);
 #ifndef POCKETFFT_NO_VECTORS
@@ -3258,10 +3260,11 @@ template<typename T> POCKETFFT_NOINLINE void general_c2r(
   size_t nthreads)
   {
   auto plan = get_plan<pocketfft_r<T>>(out.shape(axis));
-  constexpr auto vlen = VLEN<T>::val;
   size_t len=out.shape(axis);
-  threading::thread_map(util::thread_count(nthreads, in.shape(), axis, vlen),
+  threading::thread_map(
+    util::thread_count(nthreads, in.shape(), axis, VLEN<T>::val),
     [&] {
+      constexpr auto vlen = VLEN<T>::val;
       auto storage = alloc_tmp<T>(out.shape(), len, sizeof(T));
       multi_iter<vlen> it(in, out, axis);
 #ifndef POCKETFFT_NO_VECTORS

--- a/scipy/fft/_pocketfft/realtransforms.py
+++ b/scipy/fft/_pocketfft/realtransforms.py
@@ -1,13 +1,12 @@
 import numpy as np
 from . import pypocketfft as pfft
 from .helper import (_asfarray, _init_nd_shape_and_axes, _datacopied,
-                     _fix_shape, _fix_shape_1d, _normalization,
-                     _default_workers)
+                     _fix_shape, _fix_shape_1d, _normalization, _workers)
 import functools
 
 
 def _r2r(forward, transform, x, type=2, n=None, axis=-1, norm=None,
-         overwrite_x=False):
+         overwrite_x=False, workers=None):
     """Forward or backward 1d DCT/DST
 
     Parameters
@@ -20,6 +19,7 @@ def _r2r(forward, transform, x, type=2, n=None, axis=-1, norm=None,
     tmp = _asfarray(x)
     overwrite_x = overwrite_x or _datacopied(tmp, x)
     norm = _normalization(norm, forward)
+    workers = _workers(workers)
 
     if not forward:
         if type == 2:
@@ -39,11 +39,11 @@ def _r2r(forward, transform, x, type=2, n=None, axis=-1, norm=None,
     # For complex input, transform real and imaginary components seperably
     if np.iscomplexobj(x):
         out = out or np.empty_like(tmp)
-        transform(tmp.real, type, (axis,), norm, out.real, _default_workers)
-        transform(tmp.imag, type, (axis,), norm, out.imag, _default_workers)
+        transform(tmp.real, type, (axis,), norm, out.real, workers)
+        transform(tmp.imag, type, (axis,), norm, out.imag, workers)
         return out
 
-    return transform(tmp, type, (axis,), norm, out, _default_workers)
+    return transform(tmp, type, (axis,), norm, out, workers)
 
 
 dct = functools.partial(_r2r, True, pfft.dct)
@@ -58,7 +58,7 @@ idst.__name__ = 'idst'
 
 
 def _r2rn(forward, transform, x, type=2, s=None, axes=None, norm=None,
-          overwrite_x=False):
+          overwrite_x=False, workers=None):
     """Forward or backward nd DCT/DST
 
     Parameters
@@ -86,16 +86,17 @@ def _r2rn(forward, transform, x, type=2, s=None, axes=None, norm=None,
             type = 2
 
     norm = _normalization(norm, forward)
+    workers = _workers(workers)
     out = (tmp if overwrite_x else None)
 
     # For complex input, transform real and imaginary components seperably
     if np.iscomplexobj(x):
         out = out or np.empty_like(tmp)
-        transform(tmp.real, type, axes, norm, out.real, _default_workers)
-        transform(tmp.imag, type, axes, norm, out.imag, _default_workers)
+        transform(tmp.real, type, axes, norm, out.real, workers)
+        transform(tmp.imag, type, axes, norm, out.imag, workers)
         return out
 
-    return transform(tmp, type, axes, norm, out, _default_workers)
+    return transform(tmp, type, axes, norm, out, workers)
 
 
 dctn = functools.partial(_r2rn, True, pfft.dct)

--- a/scipy/fft/_pocketfft/setup.py
+++ b/scipy/fft/_pocketfft/setup.py
@@ -1,7 +1,7 @@
 
 def pre_build_hook(build_ext, ext):
     from scipy._build_utils.compiler_helper import (get_cxx_std_flag,
-                                                    try_add_flag)
+                                                    try_add_flag, try_compile)
     cc = build_ext._cxx_compiler
     args = ext.extra_compile_args
 
@@ -13,6 +13,11 @@ def pre_build_hook(build_ext, ext):
         args.append('/EHsc')
     else:
         try_add_flag(args, cc, '-fvisibility=hidden')
+
+        has_pthreads = try_compile(cc, code='#include <pthread.h>\n'
+                                   'int main(int argc, char **argv) {}')
+        if has_pthreads:
+            ext.define_macros.append(('POCKETFFT_PTHREADS', None))
 
         import sys
         if sys.platform == 'darwin':

--- a/scipy/fft/_pocketfft/setup.py
+++ b/scipy/fft/_pocketfft/setup.py
@@ -1,7 +1,7 @@
 
 def pre_build_hook(build_ext, ext):
-    from scipy._build_utils.compiler_helper import (get_cxx_std_flag,
-                                                    try_add_flag, try_compile)
+    from scipy._build_utils.compiler_helper import (
+        get_cxx_std_flag, try_add_flag, try_compile, has_flag)
     cc = build_ext._cxx_compiler
     args = ext.extra_compile_args
 
@@ -19,10 +19,11 @@ def pre_build_hook(build_ext, ext):
         if has_pthreads:
             ext.define_macros.append(('POCKETFFT_PTHREADS', None))
 
+        min_macos_flag = '-mmacosx-version-min=10.9'
         import sys
-        if sys.platform == 'darwin':
-            args.append('-mmacosx-version-min=10.7')
-            try_add_flag(args, cc, '-stdlib=libc++')
+        if sys.platform == 'darwin' and has_flag(cc, min_macos_flag):
+            args.append(min_macos_flag)
+            ext.extra_link_args.append(min_macos_flag)
 
 
 def configuration(parent_package='', top_path=None):

--- a/scipy/fft/_pocketfft/version.md
+++ b/scipy/fft/_pocketfft/version.md
@@ -4,11 +4,17 @@ pypocketfft version
 
 SciPy currently vendors [pypocketfft] at:
 
-    commit e551513b9f3d1368459d446e393c205a6056f1c4
-    Author: Peter Bell <peterbell10@live.co.uk>
-    Date:   Thu Aug 8 13:33:21 2019 +0100
+    commit c0f74f610adfc60b8b5e3c3bce6477e646329f63
+	Merge: c573384 dce19de
+	Author: Martin Reinecke <martin@mpa-garching.mpg.de>
+	Date:   Wed Aug 14 15:25:48 2019 +0200
 
-        Handle exceptions thrown in parallel regions
+        Merge branch 'macos-issues' into 'master'
+
+        macOS issues
+
+        See merge request mtr/pypocketfft!27
+
 
 
 pypocketfft: https://gitlab.mpcdf.mpg.de/mtr/pypocketfft

--- a/scipy/fft/_pocketfft/version.md
+++ b/scipy/fft/_pocketfft/version.md
@@ -2,15 +2,13 @@
 pypocketfft version
 -------------------
 
-SciPy currently vendors [pypocketfft][repo] at:
+SciPy currently vendors [pypocketfft] at:
 
-    commit 869e68d243138c188cafa8334d92f94ded600a90
-    Merge: 6f1bba7 140e68f
-    Author: Martin Reinecke <martin@mpa-garching.mpg.de>
-    Date:   Thu Aug 1 13:33:46 2019 +0200
+    commit e551513b9f3d1368459d446e393c205a6056f1c4
+    Author: Peter Bell <peterbell10@live.co.uk>
+    Date:   Thu Aug 8 13:33:21 2019 +0100
 
-        Merge branch 'tweak_codelet_8' into 'master'
+        Handle exceptions thrown in parallel regions
 
-        Tweak length-8 codelet
 
-repo: https://gitlab.mpcdf.mpg.de/mtr/pypocketfft
+pypocketfft: https://gitlab.mpcdf.mpg.de/mtr/pypocketfft

--- a/scipy/fft/_realtransforms.py
+++ b/scipy/fft/_realtransforms.py
@@ -35,7 +35,7 @@ def dctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
         If True, the contents of `x` can be destroyed; the default is False.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater. See `fft` for more details.
+        unlimited. Must be -1 or >0. See `fft` for more details.
 
     Returns
     -------
@@ -92,7 +92,7 @@ def idctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
         If True, the contents of `x` can be destroyed; the default is False.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater. See `fft` for more details.
+        unlimited. Must be -1 or >0. See `fft` for more details.
 
     Returns
     -------
@@ -149,7 +149,7 @@ def dstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
         If True, the contents of `x` can be destroyed; the default is False.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater. See `fft` for more details.
+        unlimited. Must be -1 or >0. See `fft` for more details.
 
     Returns
     -------
@@ -206,7 +206,7 @@ def idstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
         If True, the contents of `x` can be destroyed; the default is False.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater. See `fft` for more details.
+        unlimited. Must be -1 or >0. See `fft` for more details.
 
     Returns
     -------
@@ -257,7 +257,7 @@ def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
         If True, the contents of `x` can be destroyed; the default is False.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater. See `fft` for more details.
+        unlimited. Must be -1 or >0. See `fft` for more details.
 
     Returns
     -------
@@ -407,7 +407,7 @@ def idct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
         If True, the contents of `x` can be destroyed; the default is False.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater. See `fft` for more details.
+        unlimited. Must be -1 or >0. See `fft` for more details.
 
     Returns
     -------
@@ -469,7 +469,7 @@ def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
         If True, the contents of `x` can be destroyed; the default is False.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater. See `fft` for more details.
+        unlimited. Must be -1 or >0. See `fft` for more details.
 
     Returns
     -------
@@ -586,7 +586,7 @@ def idst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
         If True, the contents of `x` can be destroyed; the default is False.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater. See `fft` for more details.
+        unlimited. Must be -1 or >0. See `fft` for more details.
 
     Returns
     -------

--- a/scipy/fft/_realtransforms.py
+++ b/scipy/fft/_realtransforms.py
@@ -34,8 +34,9 @@ def dctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
     workers : int, optional
-        Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be -1 or >0. See `fft` for more details.
+        Maximum number of workers to use for parallel computation. If negative,
+        the value wraps around from ``os.cpu_count()``. See `fft` for more
+        details.
 
     Returns
     -------
@@ -91,8 +92,9 @@ def idctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
     workers : int, optional
-        Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be -1 or >0. See `fft` for more details.
+        Maximum number of workers to use for parallel computation. If negative,
+        the value wraps around from ``os.cpu_count()``. See `fft` for more
+        details.
 
     Returns
     -------
@@ -148,8 +150,9 @@ def dstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
     workers : int, optional
-        Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be -1 or >0. See `fft` for more details.
+        Maximum number of workers to use for parallel computation. If negative,
+        the value wraps around from ``os.cpu_count()``. See `fft` for more
+        details.
 
     Returns
     -------
@@ -205,8 +208,9 @@ def idstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
     workers : int, optional
-        Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be -1 or >0. See `fft` for more details.
+        Maximum number of workers to use for parallel computation. If negative,
+        the value wraps around from ``os.cpu_count()``. See `fft` for more
+        details.
 
     Returns
     -------
@@ -256,8 +260,9 @@ def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
     workers : int, optional
-        Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be -1 or >0. See `fft` for more details.
+        Maximum number of workers to use for parallel computation. If negative,
+        the value wraps around from ``os.cpu_count()``. See `fft` for more
+        details.
 
     Returns
     -------
@@ -406,8 +411,9 @@ def idct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
     workers : int, optional
-        Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be -1 or >0. See `fft` for more details.
+        Maximum number of workers to use for parallel computation. If negative,
+        the value wraps around from ``os.cpu_count()``. See `fft` for more
+        details.
 
     Returns
     -------
@@ -468,8 +474,9 @@ def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
     workers : int, optional
-        Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be -1 or >0. See `fft` for more details.
+        Maximum number of workers to use for parallel computation. If negative,
+        the value wraps around from ``os.cpu_count()``. See `fft` for more
+        details.
 
     Returns
     -------
@@ -585,8 +592,9 @@ def idst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
     workers : int, optional
-        Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be -1 or >0. See `fft` for more details.
+        Maximum number of workers to use for parallel computation. If negative,
+        the value wraps around from ``os.cpu_count()``. See `fft` for more
+        details.
 
     Returns
     -------

--- a/scipy/fft/_realtransforms.py
+++ b/scipy/fft/_realtransforms.py
@@ -35,7 +35,7 @@ def dctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
         If True, the contents of `x` can be destroyed; the default is False.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater.
+        unlimited. Must be 0 or greater. See `fft` for more details.
 
     Returns
     -------
@@ -92,7 +92,7 @@ def idctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
         If True, the contents of `x` can be destroyed; the default is False.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater.
+        unlimited. Must be 0 or greater. See `fft` for more details.
 
     Returns
     -------
@@ -149,7 +149,7 @@ def dstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
         If True, the contents of `x` can be destroyed; the default is False.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater.
+        unlimited. Must be 0 or greater. See `fft` for more details.
 
     Returns
     -------
@@ -206,7 +206,7 @@ def idstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
         If True, the contents of `x` can be destroyed; the default is False.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater.
+        unlimited. Must be 0 or greater. See `fft` for more details.
 
     Returns
     -------
@@ -257,7 +257,7 @@ def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
         If True, the contents of `x` can be destroyed; the default is False.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater.
+        unlimited. Must be 0 or greater. See `fft` for more details.
 
     Returns
     -------
@@ -407,7 +407,7 @@ def idct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
         If True, the contents of `x` can be destroyed; the default is False.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater.
+        unlimited. Must be 0 or greater. See `fft` for more details.
 
     Returns
     -------
@@ -469,7 +469,7 @@ def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
         If True, the contents of `x` can be destroyed; the default is False.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater.
+        unlimited. Must be 0 or greater. See `fft` for more details.
 
     Returns
     -------
@@ -586,7 +586,7 @@ def idst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
         If True, the contents of `x` can be destroyed; the default is False.
     workers : int, optional
         Maximum number of workers to use for parallel computation, or 0 for
-        unlimited. Must be 0 or greater.
+        unlimited. Must be 0 or greater. See `fft` for more details.
 
     Returns
     -------

--- a/scipy/fft/_realtransforms.py
+++ b/scipy/fft/_realtransforms.py
@@ -6,7 +6,8 @@ __all__ = ['dct', 'idct', 'dst', 'idst', 'dctn', 'idctn', 'dstn', 'idstn']
 
 
 @_dispatch
-def dctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False):
+def dctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
+         workers=None):
     """
     Return multidimensional Discrete Cosine Transform along the specified axes.
 
@@ -32,6 +33,9 @@ def dctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False):
         Normalization mode (see Notes). Default is None.
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
+    workers : int, optional
+        Maximum number of workers to use for parallel computation, or 0 for
+        unlimited. Must be 0 or greater.
 
     Returns
     -------
@@ -59,7 +63,8 @@ def dctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False):
 
 
 @_dispatch
-def idctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False):
+def idctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
+          workers=None):
     """
     Return multidimensional Discrete Cosine Transform along the specified axes.
 
@@ -85,6 +90,9 @@ def idctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False):
         Normalization mode (see Notes). Default is None.
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
+    workers : int, optional
+        Maximum number of workers to use for parallel computation, or 0 for
+        unlimited. Must be 0 or greater.
 
     Returns
     -------
@@ -112,7 +120,8 @@ def idctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False):
 
 
 @_dispatch
-def dstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False):
+def dstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
+         workers=None):
     """
     Return multidimensional Discrete Sine Transform along the specified axes.
 
@@ -138,6 +147,9 @@ def dstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False):
         Normalization mode (see Notes). Default is None.
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
+    workers : int, optional
+        Maximum number of workers to use for parallel computation, or 0 for
+        unlimited. Must be 0 or greater.
 
     Returns
     -------
@@ -165,7 +177,8 @@ def dstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False):
 
 
 @_dispatch
-def idstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False):
+def idstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
+          workers=None):
     """
     Return multidimensional Discrete Sine Transform along the specified axes.
 
@@ -191,6 +204,9 @@ def idstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False):
         Normalization mode (see Notes). Default is None.
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
+    workers : int, optional
+        Maximum number of workers to use for parallel computation, or 0 for
+        unlimited. Must be 0 or greater.
 
     Returns
     -------
@@ -218,7 +234,7 @@ def idstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False):
 
 
 @_dispatch
-def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
+def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
     r"""
     Return the Discrete Cosine Transform of arbitrary type sequence x.
 
@@ -239,6 +255,9 @@ def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
         Normalization mode (see Notes). Default is None.
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
+    workers : int, optional
+        Maximum number of workers to use for parallel computation, or 0 for
+        unlimited. Must be 0 or greater.
 
     Returns
     -------
@@ -364,7 +383,8 @@ def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
 
 
 @_dispatch
-def idct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
+def idct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
+         workers=None):
     """
     Return the Inverse Discrete Cosine Transform of an arbitrary type sequence.
 
@@ -385,6 +405,9 @@ def idct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
         Normalization mode (see Notes). Default is None.
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
+    workers : int, optional
+        Maximum number of workers to use for parallel computation, or 0 for
+        unlimited. Must be 0 or greater.
 
     Returns
     -------
@@ -423,7 +446,7 @@ def idct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
 
 
 @_dispatch
-def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
+def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
     r"""
     Return the Discrete Sine Transform of arbitrary type sequence x.
 
@@ -444,6 +467,9 @@ def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
         Normalization mode (see Notes). Default is None.
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
+    workers : int, optional
+        Maximum number of workers to use for parallel computation, or 0 for
+        unlimited. Must be 0 or greater.
 
     Returns
     -------
@@ -536,7 +562,8 @@ def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
 
 
 @_dispatch
-def idst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
+def idst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
+         workers=None):
     """
     Return the Inverse Discrete Sine Transform of an arbitrary type sequence.
 
@@ -557,6 +584,9 @@ def idst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
         Normalization mode (see Notes). Default is None.
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
+    workers : int, optional
+        Maximum number of workers to use for parallel computation, or 0 for
+        unlimited. Must be 0 or greater.
 
     Returns
     -------

--- a/scipy/fft/_realtransforms.py
+++ b/scipy/fft/_realtransforms.py
@@ -35,8 +35,8 @@ def dctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
         If True, the contents of `x` can be destroyed; the default is False.
     workers : int, optional
         Maximum number of workers to use for parallel computation. If negative,
-        the value wraps around from ``os.cpu_count()``. See `fft` for more
-        details.
+        the value wraps around from ``os.cpu_count()``.
+        See :func:`~scipy.fft.fft` for more details.
 
     Returns
     -------
@@ -93,8 +93,8 @@ def idctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
         If True, the contents of `x` can be destroyed; the default is False.
     workers : int, optional
         Maximum number of workers to use for parallel computation. If negative,
-        the value wraps around from ``os.cpu_count()``. See `fft` for more
-        details.
+        the value wraps around from ``os.cpu_count()``.
+        See :func:`~scipy.fft.fft` for more details.
 
     Returns
     -------
@@ -151,8 +151,8 @@ def dstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
         If True, the contents of `x` can be destroyed; the default is False.
     workers : int, optional
         Maximum number of workers to use for parallel computation. If negative,
-        the value wraps around from ``os.cpu_count()``. See `fft` for more
-        details.
+        the value wraps around from ``os.cpu_count()``.
+        See :func:`~scipy.fft.fft` for more details.
 
     Returns
     -------
@@ -209,8 +209,8 @@ def idstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
         If True, the contents of `x` can be destroyed; the default is False.
     workers : int, optional
         Maximum number of workers to use for parallel computation. If negative,
-        the value wraps around from ``os.cpu_count()``. See `fft` for more
-        details.
+        the value wraps around from ``os.cpu_count()``.
+        See :func:`~scipy.fft.fft` for more details.
 
     Returns
     -------
@@ -261,8 +261,8 @@ def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
         If True, the contents of `x` can be destroyed; the default is False.
     workers : int, optional
         Maximum number of workers to use for parallel computation. If negative,
-        the value wraps around from ``os.cpu_count()``. See `fft` for more
-        details.
+        the value wraps around from ``os.cpu_count()``.
+        See :func:`~scipy.fft.fft` for more details.
 
     Returns
     -------
@@ -412,8 +412,8 @@ def idct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
         If True, the contents of `x` can be destroyed; the default is False.
     workers : int, optional
         Maximum number of workers to use for parallel computation. If negative,
-        the value wraps around from ``os.cpu_count()``. See `fft` for more
-        details.
+        the value wraps around from ``os.cpu_count()``.
+        See :func:`~scipy.fft.fft` for more details.
 
     Returns
     -------
@@ -475,8 +475,8 @@ def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
         If True, the contents of `x` can be destroyed; the default is False.
     workers : int, optional
         Maximum number of workers to use for parallel computation. If negative,
-        the value wraps around from ``os.cpu_count()``. See `fft` for more
-        details.
+        the value wraps around from ``os.cpu_count()``.
+        See :func:`~scipy.fft.fft` for more details.
 
     Returns
     -------
@@ -593,8 +593,8 @@ def idst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
         If True, the contents of `x` can be destroyed; the default is False.
     workers : int, optional
         Maximum number of workers to use for parallel computation. If negative,
-        the value wraps around from ``os.cpu_count()``. See `fft` for more
-        details.
+        the value wraps around from ``os.cpu_count()``.
+        See :func:`~scipy.fft.fft` for more details.
 
     Returns
     -------

--- a/scipy/fft/tests/test_multithreading.py
+++ b/scipy/fft/tests/test_multithreading.py
@@ -11,7 +11,6 @@ def x():
     return np.random.randn(512, 128)  # Must be large enough to qualify for mt
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize("func", [
     fft.fft, fft.ifft, fft.fft2, fft.ifft2, fft.fftn, fft.ifftn,
     fft.rfft, fft.irfft, fft.rfft2, fft.irfft2, fft.rfftn, fft.irfftn,

--- a/scipy/fft/tests/test_multithreading.py
+++ b/scipy/fft/tests/test_multithreading.py
@@ -17,7 +17,7 @@ def x():
     fft.dct, fft.idct, fft.dctn, fft.idctn,
     fft.dst, fft.idst, fft.dstn, fft.idstn,
 ])
-@pytest.mark.parametrize("workers", [2, 0])
+@pytest.mark.parametrize("workers", [2, -1])
 def test_threaded_same(x, func, workers):
     expected = func(x, workers=1)
     actual = func(x, workers=workers)
@@ -39,3 +39,11 @@ def test_mixed_threads_processes(x):
         assert_allclose(r, expect)
 
     fft.fft(x, workers=2)
+
+def test_invalid_workers(x):
+
+    with pytest.raises(ValueError, match='workers must be'):
+        fft.fft(x, workers=0)
+
+    with pytest.raises(ValueError, match='workers must be'):
+        fft.ifft(x, workers=-2)

--- a/scipy/fft/tests/test_multithreading.py
+++ b/scipy/fft/tests/test_multithreading.py
@@ -3,6 +3,8 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 import multiprocessing
+import os
+
 
 @pytest.fixture(scope='module')
 def x():
@@ -41,7 +43,6 @@ def test_mixed_threads_processes(x):
     fft.fft(x, workers=2)
 
 def test_invalid_workers(x):
-    import os
     cpus = os.cpu_count()
 
     fft.ifft([1], workers=-cpus)
@@ -51,3 +52,32 @@ def test_invalid_workers(x):
 
     with pytest.raises(ValueError, match='workers value out of range'):
         fft.ifft(x, workers=-cpus-1)
+
+
+def test_set_get_workers():
+    cpus = os.cpu_count()
+    assert fft.get_workers() == 1
+    with fft.set_workers(4):
+        assert fft.get_workers() == 4
+
+        with fft.set_workers(-1):
+            assert fft.get_workers() == cpus
+
+        assert fft.get_workers() == 4
+
+    assert fft.get_workers() == 1
+
+    with fft.set_workers(-cpus):
+        assert fft.get_workers() == 1
+
+
+def test_set_workers_invalid():
+    cpus = os.cpu_count()
+
+    with pytest.raises(ValueError, match='workers value out of range'):
+        with fft.set_workers(0):
+            pass
+
+    with pytest.raises(ValueError, match='workers value out of range'):
+        with fft.set_workers(-os.cpu_count()-1):
+            pass

--- a/scipy/fft/tests/test_multithreading.py
+++ b/scipy/fft/tests/test_multithreading.py
@@ -1,0 +1,41 @@
+from scipy import fft
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+import multiprocessing
+
+@pytest.fixture(scope='module')
+def x():
+    return np.random.randn(512, 128)  # Must be large enough to qualify for mt
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("func", [
+    fft.fft, fft.ifft, fft.fft2, fft.ifft2, fft.fftn, fft.ifftn,
+    fft.rfft, fft.irfft, fft.rfft2, fft.irfft2, fft.rfftn, fft.irfftn,
+    fft.hfft, fft.ihfft, fft.hfft2, fft.ihfft2, fft.hfftn, fft.ihfftn,
+    fft.dct, fft.idct, fft.dctn, fft.idctn,
+    fft.dst, fft.idst, fft.dstn, fft.idstn,
+])
+@pytest.mark.parametrize("workers", [2, 0])
+def test_threaded_same(x, func, workers):
+    expected = func(x, workers=1)
+    actual = func(x, workers=workers)
+    assert_allclose(actual, expected)
+
+
+def _mt_fft(x):
+    return fft.fft(x, workers=2)
+
+
+def test_mixed_threads_processes(x):
+    # Test that the fft threadpool is safe to use before & after fork
+    expect = fft.fft(x, workers=2)
+
+    with multiprocessing.Pool(2) as p:
+        res = p.map(_mt_fft, [x for _ in range(4)])
+
+    for r in res:
+        assert_allclose(r, expect)
+
+    fft.fft(x, workers=2)

--- a/scipy/fft/tests/test_multithreading.py
+++ b/scipy/fft/tests/test_multithreading.py
@@ -46,7 +46,7 @@ def test_invalid_workers(x):
 
     fft.ifft([1], workers=-cpus)
 
-    with pytest.raises(ValueError, match='workers value out of range'):
+    with pytest.raises(ValueError, match='workers must not be zero'):
         fft.fft(x, workers=0)
 
     with pytest.raises(ValueError, match='workers value out of range'):
@@ -73,7 +73,7 @@ def test_set_get_workers():
 def test_set_workers_invalid():
     cpus = os.cpu_count()
 
-    with pytest.raises(ValueError, match='workers value out of range'):
+    with pytest.raises(ValueError, match='workers must not be zero'):
         with fft.set_workers(0):
             pass
 

--- a/scipy/fft/tests/test_multithreading.py
+++ b/scipy/fft/tests/test_multithreading.py
@@ -41,9 +41,13 @@ def test_mixed_threads_processes(x):
     fft.fft(x, workers=2)
 
 def test_invalid_workers(x):
+    import os
+    cpus = os.cpu_count()
 
-    with pytest.raises(ValueError, match='workers must be'):
+    fft.ifft([1], workers=-cpus)
+
+    with pytest.raises(ValueError, match='workers value out of range'):
         fft.fft(x, workers=0)
 
-    with pytest.raises(ValueError, match='workers must be'):
-        fft.ifft(x, workers=-2)
+    with pytest.raises(ValueError, match='workers value out of range'):
+        fft.ifft(x, workers=-cpus-1)


### PR DESCRIPTION
#### What does this implement/fix?
I've moved pypocketfft from OpenMP to a custom thread-pool written using plain C++11. This implementation uses `pthread_atfork` to cleanly handle `fork` on posix systems.

With this, I can enable multithreading for all of the transforms in `scipy.fft` via a `workers` argument.

#### Example

```python
In [2]: x = np.random.randn(1024, 1000).astype(complex)

In [3]: %timeit scipy.fft.fft(x)  # Defaults to 1 thread, as before
8.25 ms ± 80.1 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [4]: %timeit scipy.fft.fft(x, workers=-1)  # Threads chosen automatically
3.61 ms ± 117 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```