### PR TITLE
WIP: ENH: 3D rotation groups

### DIFF
--- a/scipy/spatial/transform/_rotation_groups.py
+++ b/scipy/spatial/transform/_rotation_groups.py
@@ -1,0 +1,140 @@
+import numpy as np
+from scipy.constants import golden as phi
+
+
+def icosahedral(cls):
+    g1 = tetrahedral(cls).as_quat()
+    a = 0.5
+    b = 0.5 / phi
+    c = phi / 2
+    g2 = np.array([[+a, +b, +c, 0],
+                   [+a, +b, -c, 0],
+                   [+a, +c, 0, +b],
+                   [+a, +c, 0, -b],
+                   [+a, -b, +c, 0],
+                   [+a, -b, -c, 0],
+                   [+a, -c, 0, +b],
+                   [+a, -c, 0, -b],
+                   [+a, 0, +b, +c],
+                   [+a, 0, +b, -c],
+                   [+a, 0, -b, +c],
+                   [+a, 0, -b, -c],
+                   [+b, +a, 0, +c],
+                   [+b, +a, 0, -c],
+                   [+b, +c, +a, 0],
+                   [+b, +c, -a, 0],
+                   [+b, -a, 0, +c],
+                   [+b, -a, 0, -c],
+                   [+b, -c, +a, 0],
+                   [+b, -c, -a, 0],
+                   [+b, 0, +c, +a],
+                   [+b, 0, +c, -a],
+                   [+b, 0, -c, +a],
+                   [+b, 0, -c, -a],
+                   [+c, +a, +b, 0],
+                   [+c, +a, -b, 0],
+                   [+c, +b, 0, +a],
+                   [+c, +b, 0, -a],
+                   [+c, -a, +b, 0],
+                   [+c, -a, -b, 0],
+                   [+c, -b, 0, +a],
+                   [+c, -b, 0, -a],
+                   [+c, 0, +a, +b],
+                   [+c, 0, +a, -b],
+                   [+c, 0, -a, +b],
+                   [+c, 0, -a, -b],
+                   [0, +a, +c, +b],
+                   [0, +a, +c, -b],
+                   [0, +a, -c, +b],
+                   [0, +a, -c, -b],
+                   [0, +b, +a, +c],
+                   [0, +b, +a, -c],
+                   [0, +b, -a, +c],
+                   [0, +b, -a, -c],
+                   [0, +c, +b, +a],
+                   [0, +c, +b, -a],
+                   [0, +c, -b, +a],
+                   [0, +c, -b, -a]])
+    return cls.from_quat(np.concatenate((g1, g2)))
+
+
+def octahedral(cls):
+    g1 = tetrahedral(cls).as_quat()
+    c = np.sqrt(2) / 2
+    g2 = np.array([[+c, 0, 0, +c],
+                   [0, +c, 0, +c],
+                   [0, 0, +c, +c],
+                   [0, 0, -c, +c],
+                   [0, -c, 0, +c],
+                   [-c, 0, 0, +c],
+                   [0, +c, +c, 0],
+                   [0, -c, +c, 0],
+                   [+c, 0, +c, 0],
+                   [-c, 0, +c, 0],
+                   [+c, +c, 0, 0],
+                   [-c, +c, 0, 0]])
+    return cls.from_quat(np.concatenate((g1, g2)))
+
+
+def tetrahedral(cls):
+    g1 = np.eye(4)
+    c = 0.5
+    g2 = np.array([[c, -c, -c, +c],
+                   [c, -c, +c, +c],
+                   [c, +c, -c, +c],
+                   [c, +c, +c, +c],
+                   [c, -c, -c, -c],
+                   [c, -c, +c, -c],
+                   [c, +c, -c, -c],
+                   [c, +c, +c, -c]])
+    return cls.from_quat(np.concatenate((g1, g2)))
+
+
+def dicyclic(cls, n, axis=2):
+    g1 = cyclic(cls, n, axis).as_rotvec()
+
+    thetas = np.linspace(0, np.pi, n, endpoint=False)
+    rv = np.pi * np.vstack([np.zeros(n), np.cos(thetas), np.sin(thetas)]).T
+    g2 = np.roll(rv, axis, axis=1)
+    return cls.from_rotvec(np.concatenate((g1, g2)))
+
+
+def cyclic(cls, n, axis=2):
+    thetas = np.linspace(0, 2 * np.pi, n, endpoint=False)
+    rv = np.vstack([thetas, np.zeros(n), np.zeros(n)]).T
+    return cls.from_rotvec(np.roll(rv, axis, axis=1))
+
+
+def create_group(cls, group, axis='Z'):
+    if not isinstance(group, str):
+        raise ValueError("`group` argument must be a string")
+
+    permitted_axes = ['x', 'y', 'z', 'X', 'Y', 'Z']
+    if axis not in permitted_axes:
+        raise ValueError("`axis` must be one of " + ", ".join(permitted_axes))
+
+    if group in ['I', 'O', 'T']:
+        symbol = group
+        order = 1
+    elif group[:1] in ['C', 'D'] and group[1:].isdigit():
+        symbol = group[:1]
+        order = int(group[1:])
+    else:
+        raise ValueError("`group` must be one of 'I', 'O', 'T', 'Dn', 'Cn'")
+
+    if order < 1:
+        raise ValueError("Group order must be positive")
+
+    axis = 'xyz'.index(axis.lower())
+    if symbol == 'I':
+        return icosahedral(cls)
+    elif symbol == 'O':
+        return octahedral(cls)
+    elif symbol == 'T':
+        return tetrahedral(cls)
+    elif symbol == 'D':
+        return dicyclic(cls, order, axis=axis)
+    elif symbol == 'C':
+        return cyclic(cls, order, axis=axis)
+    else:
+        assert False

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -5,6 +5,7 @@ import warnings
 import numpy as np
 import scipy.linalg
 from scipy._lib._util import check_random_state
+from ._rotation_groups import create_group
 
 
 _AXIS_TO_IND = {'x': 0, 'y': 1, 'z': 2}
@@ -211,6 +212,7 @@ class Rotation(object):
     __mul__
     inv
     magnitude
+    create_group
     __getitem__
     random
     match_vectors
@@ -1460,6 +1462,44 @@ class Rotation(object):
             return angles[0]
         else:
             return angles
+
+    @classmethod
+    def create_group(cls, group, axis='Z'):
+        """Create a 3D rotation group.
+
+        Parameters
+        ----------
+        group : string
+            The name of the group. Must be one of 'I', 'O', 'T', 'Dn', 'Cn',
+            where `n` is a positive integer. The groups are:
+
+                * I: Icosahedral group
+                * O: Octahedral group
+                * T: Tetrahedral group
+                * D: Dicyclic group
+                * C: Cyclic group
+
+        axis : integer
+            The cyclic rotation axis. Must be one of ['X', 'Y', 'Z'] (or
+            lowercase). Default is 'Z'. Ignored for groups 'I', 'O', and 'T'.
+
+        Returns
+        -------
+        rotation : `Rotation` instance
+            Object containing the elements of the rotation group.
+
+        Notes
+        -----
+        This method generates rotation groups only. The full 3-dimensional
+        point groups [PointGroups]_ also contain reflections.
+
+        References
+        ----------
+        .. [PointGroups] `Point groups
+           <https://en.wikipedia.org/wiki/Point_groups_in_three_dimensions>`_
+           on Wikipedia.
+        """
+        return create_group(cls, group, axis=axis)
 
     def __getitem__(self, indexer):
         """Extract rotation(s) at given index(es) from object.

--- a/scipy/spatial/transform/tests/test_rotation_groups.py
+++ b/scipy/spatial/transform/tests/test_rotation_groups.py
@@ -1,0 +1,153 @@
+from __future__ import division, print_function, absolute_import
+
+import pytest
+
+import numpy as np
+from scipy.spatial.transform import Rotation
+from scipy.optimize import linear_sum_assignment
+from scipy.spatial.distance import cdist
+from scipy.constants import golden as phi
+from scipy.spatial import cKDTree
+
+
+TOL = 1E-12
+NS = range(1, 13)
+NAMES = ["I", "O", "T"] + ["C%d" % n for n in NS] + ["D%d" % n for n in NS]
+SIZES = [60, 24, 12] + list(NS) + [2 * n for n in NS]
+
+
+def _calculate_rmsd(P, Q):
+    """Calculates the root-mean-square distance between the points of P and Q.
+    The distance is taken as the minimum over all possible matchings.  It is
+    zero if P and Q are identical and non-zero if not.
+    """
+    distance_matrix = cdist(P, Q, metric='sqeuclidean')
+    matching = linear_sum_assignment(distance_matrix)
+    return np.sqrt(distance_matrix[matching].sum())
+
+
+def _generate_pyramid(n, axis):
+    thetas = np.linspace(0, 2 * np.pi, n + 1)[:-1]
+    P = np.vstack([np.zeros(n), np.cos(thetas), np.sin(thetas)]).T
+    P = np.concatenate((P, [[1, 0, 0]]))
+    return np.roll(P, axis, axis=1)
+
+
+def _generate_prism(n, axis):
+    thetas = np.linspace(0, 2 * np.pi, n + 1)[:-1]
+    bottom = np.vstack([-np.ones(n), np.cos(thetas), np.sin(thetas)]).T
+    top = np.vstack([+np.ones(n), np.cos(thetas), np.sin(thetas)]).T
+    P = np.concatenate((bottom, top))
+    return np.roll(P, axis, axis=1)
+
+
+def _generate_icosahedron():
+    x = np.array([[0, -1, -phi],
+                  [0, -1, +phi],
+                  [0, +1, -phi],
+                  [0, +1, +phi]])
+    return np.concatenate([np.roll(x, i, axis=1) for i in range(3)])
+
+
+def _generate_octahedron():
+    return np.array([[-1, 0, 0], [+1, 0, 0], [0, -1, 0],
+                     [0, +1, 0], [0, 0, -1], [0, 0, +1]])
+
+
+def _generate_tetrahedron():
+    return np.array([[1, 1, 1], [1, -1, -1], [-1, 1, -1], [-1, -1, 1]])
+
+
+@pytest.mark.parametrize("name", [-1, None, True, np.array(['C3'])])
+def test_group_type(name):
+    with pytest.raises(ValueError,
+                       match="must be a string"):
+        Rotation.create_group(name)
+
+
+@pytest.mark.parametrize("name", ["Q", " ", "CA", "C ", "DA", "D ", "I2", ""])
+def test_group_name(name):
+    with pytest.raises(ValueError,
+                       match="must be one of 'I', 'O', 'T', 'Dn', 'Cn'"):
+        Rotation.create_group(name)
+
+
+@pytest.mark.parametrize("name", ["C0", "D0"])
+def test_group_order_positive(name):
+    with pytest.raises(ValueError,
+                       match="Group order must be positive"):
+        Rotation.create_group(name)
+
+
+@pytest.mark.parametrize("axis", ['A', 'b', 0, 1, 2, 4, False, None])
+def test_axis_valid(axis):
+    with pytest.raises(ValueError,
+                       match="`axis` must be one of"):
+        Rotation.create_group("C1", axis)
+
+
+def test_icosahedral():
+    """The icosahedral group fixes the rotations of an icosahedron. Here we
+    test that the icosahedron is invariant after application of the elements
+    of the rotation group."""
+    P = _generate_icosahedron()
+    for g in Rotation.create_group("I"):
+        g = Rotation.from_quat(g.as_quat())
+        assert _calculate_rmsd(P, g.apply(P)) < TOL
+
+
+def test_octahedral():
+    """Test that the octahedral group correctly fixes the rotations of an
+    octahedron."""
+    P = _generate_octahedron()
+    for g in Rotation.create_group("O"):
+        assert _calculate_rmsd(P, g.apply(P)) < TOL
+
+
+def test_tetrahedral():
+    """Test that the tetrahedral group correctly fixes the rotations of a
+    tetrahedron."""
+    P = _generate_tetrahedron()
+    for g in Rotation.create_group("T"):
+        assert _calculate_rmsd(P, g.apply(P)) < TOL
+
+
+@pytest.mark.parametrize("n", NS)
+@pytest.mark.parametrize("axis", 'XYZ')
+def test_dicyclic(n, axis):
+    """Test that the dicyclic group correctly fixes the rotations of a
+    prism."""
+    P = _generate_prism(n, axis='XYZ'.index(axis))
+    for g in Rotation.create_group("D%d" % n, axis=axis):
+        assert _calculate_rmsd(P, g.apply(P)) < TOL
+
+
+@pytest.mark.parametrize("n", NS)
+@pytest.mark.parametrize("axis", 'XYZ')
+def test_cyclic(n, axis):
+    """Test that the cyclic group correctly fixes the rotations of a
+    pyramid."""
+    P = _generate_pyramid(n, axis='XYZ'.index(axis))
+    for g in Rotation.create_group("C%d" % n, axis=axis):
+        assert _calculate_rmsd(P, g.apply(P)) < TOL
+
+
+@pytest.mark.parametrize("name, size", zip(NAMES, SIZES))
+def test_group_sizes(name, size):
+    assert len(Rotation.create_group(name)) == size
+
+
+@pytest.mark.parametrize("name, size", zip(NAMES, SIZES))
+def test_group_no_duplicates(name, size):
+    g = Rotation.create_group(name)
+    kdtree = cKDTree(g.as_quat())
+    assert len(kdtree.query_pairs(1E-3)) == 0
+
+
+@pytest.mark.parametrize("name, size", zip(NAMES, SIZES))
+def test_group_symmetry(name, size):
+    g = Rotation.create_group(name)
+    q = np.concatenate((-g.as_quat(), g.as_quat()))
+    distance = np.sort(cdist(q, q))
+    deltas = np.max(distance, axis=0) - np.min(distance, axis=0)
+    assert (deltas < TOL).all()


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR adds 3D rotation groups and enables angular distances to be calculated for objects with symmetrically equivalent rotations, such as cubes, hexagons, icosahedra etc.

With the `magnitude` function introduced in #10576, angular distances between rotations can be calculated as
```
(a.inv() * b).magnitude()
```

If the `Rotation` object represents the orientations of 3D objects with rotational symmetries, however, the angular distance should be taken as the minimum over all symmetrically equivalent rotations.  To calculate this using the functions added in this PR:
```
g = RotationGroup.octahedral
f = RotationGroup.fundamental(a.inv() * b, g)
d = f.magnitude()
```

This type of calculation is important for crystallographic applications, where the angular distance is called the "misorientation" and the minimum distance (over all symmetrical equivalents) is called the "disorientation": https://en.wikipedia.org/wiki/Misorientation

This PR includes all 3D rotation groups, including non-crystallographic groups such as the icosahedral and tetrahedral groups.