### PR TITLE
BENCH: Added 'trust-constr' to minimize benchmarks

### DIFF
--- a/benchmarks/benchmarks/optimize.py
+++ b/benchmarks/benchmarks/optimize.py
@@ -230,9 +230,10 @@ class _BenchOptimizers(Benchmark):
                        "Newton-CG", 'dogleg', 'trust-ncg', 'trust-exact',
                        'trust-krylov', 'trust-constr']
 
-        # L-BFGS-B, BFGS can use gradients, but examine performance when
-        # numerical differentiation is used.
-        fonly_methods = ["COBYLA", 'Powell', 'nelder-mead', 'L-BFGS-B', 'BFGS']
+        # L-BFGS-B, BFGS, trust-constr can use gradients, but examine
+        # performance when numerical differentiation is used.
+        fonly_methods = ["COBYLA", 'Powell', 'nelder-mead', 'L-BFGS-B', 'BFGS',
+                         'trust-constr']
         for method in fonly_methods:
             if method not in methods:
                 continue

--- a/benchmarks/benchmarks/optimize.py
+++ b/benchmarks/benchmarks/optimize.py
@@ -228,7 +228,7 @@ class _BenchOptimizers(Benchmark):
             methods = ["COBYLA", 'Powell', 'nelder-mead',
                        'L-BFGS-B', 'BFGS', 'CG', 'TNC', 'SLSQP',
                        "Newton-CG", 'dogleg', 'trust-ncg', 'trust-exact',
-                       'trust-krylov']
+                       'trust-krylov', 'trust-constr']
 
         # L-BFGS-B, BFGS can use gradients, but examine performance when
         # numerical differentiation is used.
@@ -254,7 +254,7 @@ class _BenchOptimizers(Benchmark):
                 self.add_result(res, t1-t0, method)
 
         hessian_methods = ["Newton-CG", 'dogleg', 'trust-ncg',
-                           'trust-exact', 'trust-krylov']
+                           'trust-exact', 'trust-krylov', 'trust-constr']
         if self.hess is not None:
             for method in hessian_methods:
                 if method not in methods:
@@ -276,7 +276,7 @@ class BenchSmoothUnbounded(Benchmark):
         ["COBYLA", 'Powell', 'nelder-mead',
          'L-BFGS-B', 'BFGS', 'CG', 'TNC', 'SLSQP',
          "Newton-CG", 'dogleg', 'trust-ncg', 'trust-exact',
-         'trust-krylov'],
+         'trust-krylov', 'trust-constr'],
         ["mean_nfev", "mean_time"]
     ]
     param_names = ["test function", "solver", "result type"]

--- a/benchmarks/benchmarks/optimize.py
+++ b/benchmarks/benchmarks/optimize.py
@@ -243,7 +243,8 @@ class _BenchOptimizers(Benchmark):
             t1 = time.time()
             self.add_result(res, t1-t0, method)
 
-        gradient_methods = ['L-BFGS-B', 'BFGS', 'CG', 'TNC', 'SLSQP']
+        gradient_methods = ['L-BFGS-B', 'BFGS', 'CG', 'TNC', 'SLSQP',
+                            'trust-constr']
         if self.der is not None:
             for method in gradient_methods:
                 if method not in methods:


### PR DESCRIPTION
#### What does this implement/fix?
`'trust-constr'` was missing from the lists of `minimize` methods benchmarked in `/benchmarks/benchmarks/optimize.py`; this adds it.

#### Additional information
Haven't tested locally yet; should do that before merging.