### PR TITLE
DOC: stats: Fix spelling of 'support'.

### DIFF
--- a/doc/source/tutorial/stats/continuous_alpha.rst
+++ b/doc/source/tutorial/stats/continuous_alpha.rst
@@ -5,7 +5,7 @@ Alpha Distribution
 ==================
 
 One shape parameter :math:`\alpha>0` (parameter :math:`\beta` in DATAPLOT
-is a scale-parameter). The suport for the standard form is :math:`x>0`.
+is a scale-parameter). The support for the standard form is :math:`x>0`.
 
 .. math::
    :nowrap:

--- a/doc/source/tutorial/stats/continuous_f.rst
+++ b/doc/source/tutorial/stats/continuous_f.rst
@@ -7,7 +7,7 @@ Fratio (or F) Distribution
 The distribution of :math:`\left(X_{1}/X_{2}\right)\left(\nu_{2}/\nu_{1}\right)`
 if :math:`X_{1}` is chi-squared with :math:`v_{1}` degrees of freedom
 and :math:`X_{2}` is chi-squared with :math:`v_{2}` degrees of freedom.
-The suport is :math:`x\geq0`.
+The support is :math:`x\geq0`.
 
 .. math::
    :nowrap:


### PR DESCRIPTION


#### What does this implement/fix?
Fixes the spelling of "support" in two places in the `stats` tutorials.

