### PR TITLE
MAINT: special: avoid overflow longer in `zeta` for negative arguments

### DIFF
--- a/scipy/special/tests/test_zeta.py
+++ b/scipy/special/tests/test_zeta.py
@@ -43,3 +43,9 @@ def test_riemann_zeta_special_cases():
 
     assert_allclose(sc.zeta(2), np.pi**2/6, rtol=1e-12)
     assert_allclose(sc.zeta(4), np.pi**4/90, rtol=1e-12)
+
+
+def test_riemann_zeta_avoid_overflow():
+    s = -260.00000000001
+    desired = -5.6966307844402683127e+297  # Computed with Mpmath
+    assert_allclose(sc.zeta(s), desired, atol=0, rtol=5e-14)


### PR DESCRIPTION
#### Reference issue

None

#### What does this implement/fix?

Overflow for negative arguments in `zeta(x, q=None)` is avoided until the last bitter moment.

#### Additional information

The `zeta` implementation already uses the Lanczos approximation to avoid overflow in the gamma term, but overflow can be avoided for even longer by using the fact that the sine term in the reflection formula can be small and briefly prevent the gamma term from overflowing.