### PR TITLE
MAINT: pep8 flag for runtests.py fixes #3619

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -132,7 +132,7 @@ def main(argv):
         #           "E123,E125,E126,E127,E128,E226,E231,E251,E265,E266,E302,"
         #           "E402,E501,E712,E721,E731,E741,W291,W293,W391,W503,W504"
         #           "--exclude=scipy/_lib/six.py")
-        os.system("pycodestyle scipy")
+        os.system("pycodestyle scipy benchmarks/benchmarks")
         sys.exit(0)
 
     if args.bench_compare:

--- a/runtests.py
+++ b/runtests.py
@@ -123,7 +123,17 @@ def main(argv):
                               ))
     parser.add_argument("args", metavar="ARGS", default=[], nargs=REMAINDER,
                         help="Arguments to pass to Nose, Python or shell")
+    parser.add_argument("--pep8", action="store_true", default=False,
+                        help="Perform pep8 check with pycodestyle.")
     args = parser.parse_args(argv)
+
+    if args.pep8:
+        # os.system("flake8 scipy --ignore=F403,F841,F401,F811,F405,E121,E122,"
+        #           "E123,E125,E126,E127,E128,E226,E231,E251,E265,E266,E302,"
+        #           "E402,E501,E712,E721,E731,E741,W291,W293,W391,W503,W504"
+        #           "--exclude=scipy/_lib/six.py")
+        os.system("pycodestyle scipy")
+        sys.exit(0)
 
     if args.bench_compare:
         args.bench = True


### PR DESCRIPTION
Adds a PEP8 check to `runtests.py`, running `pycodestyle` according to the config in `tox.ini`