### PR TITLE
BUG: interpolate: integral(a, b) should be zero when both limits are outside of the interpolation range

### DIFF
--- a/scipy/interpolate/fitpack/fpintb.f
+++ b/scipy/interpolate/fitpack/fpintb.f
@@ -1,4 +1,5 @@
       subroutine fpintb(t,n,bint,nk1,x,y)
+      implicit none
 c  subroutine fpintb calculates integrals of the normalized b-splines
 c  nj,k+1(x) of degree k, defined on the set of knots t(j),j=1,2,...n.
 c  it makes use of the formulae of gaffney for the calculation of
@@ -47,6 +48,7 @@ c  the integration limits are arranged in increasing order.
       min = 1
   30  if(a.lt.t(k1)) a = t(k1)
       if(b.gt.t(nk1+1)) b = t(nk1+1)
+      if(a.gt.b) go to 160
 c  using the expression of gaffney for the indefinite integral of a
 c  b-spline we find that
 c  bint(j) = (t(j+k+1)-t(j))*(res(j,b)-res(j,a))/(k+1)

--- a/scipy/interpolate/fitpack/splint.f
+++ b/scipy/interpolate/fitpack/splint.f
@@ -1,4 +1,5 @@
       real*8 function splint(t,n,c,k,a,b,wrk)
+      implicit none
 c  function splint calculates the integral of a spline function s(x)
 c  of degree k, which is given in its normalized b-spline representation
 c

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -151,6 +151,16 @@ class TestUnivariateSpline(object):
         x = [-1, 0, -0.5, 9, 9.5, 10]
         assert_allclose(f.derivative()(x), 0, atol=1e-15)
 
+    def test_integral_out_of_bounds(self):
+        # Regression test for gh-7906: .integral(a, b) is wrong if both 
+        # a and b are out-of-bounds
+        x = np.linspace(0., 1., 7)
+        for ext in range(4):
+            f = UnivariateSpline(x, x, s=0, ext=ext)
+            for (a, b) in [(1, 1), (1, 5), (2, 5),
+                           (0, 0), (-2, 0), (-2, -1)]:
+                assert_allclose(f.integral(a, b), 0, atol=1e-15)
+
     def test_nan(self):
         # bail out early if the input data contains nans
         x = np.arange(10, dtype=float)


### PR DESCRIPTION
Integrals should be zero when both limits are outside of the interpolation range

fixes gh-7906

The bug was that FITPACK moves the out-of-range upper limit of integration to the upper bound of the base interval, and the out-of-range lower limit to the lower bound. This way, if both limits are, say, above the upper bound, the lower limit stays above it, and the computational routine goes haywire.
