### PR TITLE
BUG: special: use series for `hyp1f1` when it converges rapidly

### DIFF
--- a/scipy/special/_hypergeometric.pxd
+++ b/scipy/special/_hypergeometric.pxd
@@ -1,13 +1,18 @@
-from . cimport sf_error
+from libc.math cimport fabs, exp, floor, M_PI
 
+from . cimport sf_error
 from ._cephes cimport poch
 
 cdef extern from "numpy/npy_math.h":
+    double npy_isnan(double x) nogil
     double NPY_NAN
     double NPY_INFINITY
 
 cdef extern from 'specfun_wrappers.h':
     double hypU_wrap(double, double, double) nogil
+    double hyp1f1_wrap(double, double, double) nogil
+
+DEF EPS = 2.220446049250313e-16
 
 
 cdef inline double hyperu(double a, double b, double x) nogil:
@@ -25,3 +30,53 @@ cdef inline double hyperu(double a, double b, double x) nogil:
             return poch(1.0 - b + a, -a)
 
     return hypU_wrap(a, b, x)
+
+
+cdef inline double hyp1f1(double a, double b, double x) nogil:
+    if npy_isnan(a) or npy_isnan(b) or npy_isnan(x):
+        return NPY_NAN
+    if b <= 0 and b == floor(b):
+        return NPY_INFINITY
+    elif a == 0 or x == 0:
+        return 1
+    elif a == -1:
+        return 1 - x / b
+    elif a == b:
+        return exp(x)
+    elif a - b == 1:
+        return (1 + x / b) * exp(x)
+    elif a == 1 and b == 2:
+        return (exp(x) - 1) / x
+    elif a <= 0 and a == floor(a):
+        # For `a` a negative integer the series is finite.
+        return hyp1f1_series(a, b, x)
+
+    if b > 0 and (fabs(a) + 1) * fabs(x) < 0.9 * b:
+        # At for the kth term of the series we are multiplying by
+        #
+        # t_k = (a + b) * x / ((b + k) * (k + 1))
+        #
+        # We have that
+        #
+        # |t_k| < (|a| + 1) * |x| / |b|,
+        #
+        # which means that in this branch we get geometric
+        # convergence.
+        return hyp1f1_series(a, b, x)
+
+    return hyp1f1_wrap(a, b, x)
+
+
+cdef inline double hyp1f1_series(double a, double b, double x) nogil:
+    cdef int k
+    cdef double term = 1
+    cdef double result = 1
+    for k in range(500):
+        term *= (a + k) * x / (b + k) / (k + 1)
+        result += term
+        if fabs(term) <= EPS * fabs(result):
+            break
+    else:
+        sf_error.error("hyp1f1", sf_error.NO_RESULT, NULL)
+        result = NPY_NAN
+    return result

--- a/scipy/special/_hypergeometric.pxd
+++ b/scipy/special/_hypergeometric.pxd
@@ -52,7 +52,7 @@ cdef inline double hyp1f1(double a, double b, double x) nogil:
         return hyp1f1_series(a, b, x)
 
     if b > 0 and (fabs(a) + 1) * fabs(x) < 0.9 * b:
-        # At for the kth term of the series we are multiplying by
+        # For the kth term of the series we are multiplying by
         #
         # t_k = (a + b) * x / ((b + k) * (k + 1))
         #

--- a/scipy/special/functions.json
+++ b/scipy/special/functions.json
@@ -656,9 +656,11 @@
         }
     },
     "hyp1f1": {
+	"_hypergeometric.pxd": {
+	    "hyp1f1": "ddd->d"
+	},
         "specfun_wrappers.h": {
-            "chyp1f1_wrap": "ddD->D",
-            "hyp1f1_wrap": "ddd->d"
+            "chyp1f1_wrap": "ddD->D"
         }
     },
     "hyp2f1": {

--- a/scipy/special/specfun/specfun.f
+++ b/scipy/special/specfun/specfun.f
@@ -5349,27 +5349,6 @@ C
         A1=A
         X0=X
         HG=0.0D0
-        IF (B.EQ.0.0D0.OR.B.EQ.-ABS(INT(B))) THEN
-           HG=1.0D+300
-        ELSE IF (A.EQ.0.0D0.OR.X.EQ.0.0D0) THEN
-           HG=1.0D0
-        ELSE IF (A.EQ.-1.0D0) THEN
-           HG=1.0D0-X/B
-        ELSE IF (A.EQ.B) THEN
-           HG=DEXP(X)
-        ELSE IF (A-B.EQ.1.0D0) THEN
-           HG=(1.0D0+X/B)*DEXP(X)
-        ELSE IF (A.EQ.1.0D0.AND.B.EQ.2.0D0) THEN
-           HG=(DEXP(X)-1.0D0)/X
-        ELSE IF (A.EQ.INT(A).AND.A.LT.0.0D0) THEN
-           M=INT(-A)
-           R=1.0D0
-           HG=1.0D0
-           DO 10 K=1,M
-              R=R*(A+K-1.0D0)/K/(B+K-1.0D0)*X
-10            HG=HG+R
-        ENDIF
-        IF (HG.NE.0.0D0) RETURN
 C       DLMF 13.2.39
         IF (X.LT.0.0D0) THEN
            A=B-A

--- a/scipy/special/specfun_wrappers.c
+++ b/scipy/special/specfun_wrappers.c
@@ -131,10 +131,6 @@ double hyp1f1_wrap(double a, double b, double x) {
    double outy;
 
    F_FUNC(chgm,CHGM)(&a, &b, &x, &outy);
-   if (outy == 1e300) {
-     sf_error("hyp1f1", SF_ERROR_OVERFLOW, NULL);
-     outy = NPY_INFINITY;
-   }
    return outy;
 }
 

--- a/scipy/special/tests/test_hypergeometric.py
+++ b/scipy/special/tests/test_hypergeometric.py
@@ -1,3 +1,4 @@
+import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 from numpy.testing import assert_equal
@@ -21,25 +22,28 @@ class TestHyperu:
 
 class TestHyp1f1:
 
-    def test_special_cases(self):
-        assert all(np.isnan([
-            sc.hyp1f1(np.nan, 1, 1),
-            sc.hyp1f1(1, np.nan, 1),
-            sc.hyp1f1(1, 1, np.nan)
-        ]))
+    @pytest.mark.parametrize('a, b, x', [
+        (np.nan, 1, 1),
+        (1, np.nan, 1),
+        (1, 1, np.nan)
+    ])
+    def test_nan_inputs(self, a, b, x):
+        assert np.isnan(sc.hyp1f1(a, b, x))
+
+    def test_poles(self):
         assert_equal(sc.hyp1f1(1, [0, -1, -2, -3, -4], 0.5), np.infty)
 
+    @pytest.mark.parametrize('a, b, x, result', [
+        (-1, 1, 0.5, 0.5),
+        (1, 1, 0.5, 1.6487212707001281468),
+        (2, 1, 0.5, 2.4730819060501922203),
+        (1, 2, 0.5, 1.2974425414002562937),
+        (-10, 1, 0.5, -0.38937441413785204475)
+    ])
+    def test_special_cases(self, a, b, x, result):
         # Hit all the special case branches at the beginning of the
         # function. Desired answers computed using Mpmath.
-        points = (
-            ((-1, 1, 0.5), 0.5),
-            ((1, 1, 0.5), 1.6487212707001281468),
-            ((2, 1, 0.5), 2.4730819060501922203),
-            ((1, 2, 0.5), 1.2974425414002562937),
-            ((-10, 1, 0.5), -0.38937441413785204475)
-        )
-        for point, result in points:
-            assert_allclose(sc.hyp1f1(*point), result, atol=0, rtol=1e-15)
+        assert_allclose(sc.hyp1f1(a, b, x), result, atol=0, rtol=1e-15)
 
     def test_gh_3492(self):
         desired = 0.99973683897677527773  # Computed using Mpmath

--- a/scipy/special/tests/test_hypergeometric.py
+++ b/scipy/special/tests/test_hypergeometric.py
@@ -1,4 +1,6 @@
 import numpy as np
+from numpy.testing import assert_allclose
+from numpy.testing import assert_equal
 
 import scipy.special as sc
 
@@ -15,3 +17,44 @@ class TestHyperu:
 
     def test_special_cases(self):
         assert sc.hyperu(0, 1, 1) == 1.0
+
+
+class TestHyp1f1:
+
+    def test_special_cases(self):
+        assert all(np.isnan([
+            sc.hyp1f1(np.nan, 1, 1),
+            sc.hyp1f1(1, np.nan, 1),
+            sc.hyp1f1(1, 1, np.nan)
+        ]))
+        assert_equal(sc.hyp1f1(1, [0, -1, -2, -3, -4], 0.5), np.infty)
+
+        # Hit all the special case branches at the beginning of the
+        # function. Desired answers computed using Mpmath.
+        points = (
+            ((-1, 1, 0.5), 0.5),
+            ((1, 1, 0.5), 1.6487212707001281468),
+            ((2, 1, 0.5), 2.4730819060501922203),
+            ((1, 2, 0.5), 1.2974425414002562937),
+            ((-10, 1, 0.5), -0.38937441413785204475)
+        )
+        for point, result in points:
+            assert_allclose(sc.hyp1f1(*point), result, atol=0, rtol=1e-15)
+
+    def test_gh_3492(self):
+        desired = 0.99973683897677527773  # Computed using Mpmath
+        assert_allclose(
+            sc.hyp1f1(0.01, 150, -4),
+            desired,
+            atol=0,
+            rtol=1e-15
+        )
+
+    def test_gh_3593(self):
+        desired = 1.0020033381011970966  # Computed using Mpmath
+        assert_allclose(
+            sc.hyp1f1(1, 5, 0.01),
+            desired,
+            atol=0,
+            rtol=1e-15
+        )

--- a/scipy/special/tests/test_hypergeometric.py
+++ b/scipy/special/tests/test_hypergeometric.py
@@ -6,7 +6,7 @@ from numpy.testing import assert_equal
 import scipy.special as sc
 
 
-class TestHyperu:
+class TestHyperu(object):
 
     def test_negative_x(self):
         a, b, x = np.meshgrid(
@@ -20,7 +20,7 @@ class TestHyperu:
         assert sc.hyperu(0, 1, 1) == 1.0
 
 
-class TestHyp1f1:
+class TestHyp1f1(object):
 
     @pytest.mark.parametrize('a, b, x', [
         (np.nan, 1, 1),

--- a/scipy/special/tests/test_hypergeometric.py
+++ b/scipy/special/tests/test_hypergeometric.py
@@ -45,6 +45,35 @@ class TestHyp1f1(object):
         # function. Desired answers computed using Mpmath.
         assert_allclose(sc.hyp1f1(a, b, x), result, atol=0, rtol=1e-15)
 
+    @pytest.mark.parametrize('a, b, x, result', [
+        (1, 1, 0.44, 1.5527072185113360455),
+        (-1, 1, 0.44, 0.55999999999999999778),
+        (100, 100, 0.89, 2.4351296512898745592),
+        (-100, 100, 0.89, 0.40739062490768104667),
+        (1.5, 100, 59.99, 3.8073513625965598107),
+        (-1.5, 100, 59.99, 0.25099240047125826943)
+    ])
+    def test_geometric_convergence(self, a, b, x, result):
+        # Test the region where we are relying on the ratio of
+        #
+        # (|a| + 1) * |x| / |b|
+        #
+        # being small. Desired answers computed using Mpmath
+        assert_allclose(sc.hyp1f1(a, b, x), result, atol=0, rtol=1e-15)
+
+    @pytest.mark.parametrize('a, b, x, result', [
+        (-1, 1, 1.5, -0.5),
+        (-10, 1, 1.5, 0.41801777430943080357),
+        (-25, 1, 1.5, 0.25114491646037839809),
+        (-50, 1, 1.5, -0.25683643975194756115),
+        (-51, 1, 1.5, -0.19843162753845452972)
+    ])
+    def test_a_negative_integer(self, a, b, x, result):
+        # Desired answers computed using Mpmath. After -51 the
+        # relative error becomes unsatisfactory and we start returning
+        # NaN.
+        assert_allclose(sc.hyp1f1(a, b, x), result, atol=0, rtol=1e-9)
+
     def test_gh_3492(self):
         desired = 0.99973683897677527773  # Computed using Mpmath
         assert_allclose(

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -1358,12 +1358,20 @@ class TestSystematic(object):
         # in the intermediate calculations. Can be fixed by implementing an
         # asymptotic expansion for Bessel functions for large order.
 
-    @pytest.mark.xfail(run=False)
     def test_hyp1f1(self):
-        assert_mpmath_equal(inf_to_nan(sc.hyp1f1),
-                            exception_to_nan(lambda a, b, x: mpmath.hyp1f1(a, b, x, **HYPERKW)),
-                            [Arg(-1e5, 1e5), Arg(-1e5, 1e5), Arg()],
-                            n=2000)
+        def mpmath_hyp1f1(a, b, x):
+            try:
+                return mpmath.hyp1f1(a, b, x)
+            except ZeroDivisionError:
+                return np.inf
+
+        assert_mpmath_equal(
+            sc.hyp1f1,
+            mpmath_hyp1f1,
+            [Arg(-50, 50), Arg(1, 50, inclusive_a=False), Arg(-50, 50)],
+            n=500,
+            nan_ok=False
+        )
 
     @pytest.mark.xfail(run=False)
     def test_hyp1f1_complex(self):


### PR DESCRIPTION
#### Reference issue

Closes gh-3492; closes gh-3593.

#### What does this implement/fix?

The accuracy of `hyp1f1`is improved in the regime where `b > 0` and

```
(abs(a) + 1) * abs(x) < 0.9 * b.
```

#### Additional information

Currently the specfun implementation of `hyp1f1` doesn't always use the hypergeometric series in regions of rapid convergence. For the above combination of parameters geometric convergence is guaranteed, so use the series there.

Also move the collection of `hyp1f1` special cases out of specfun and into Cython; mostly as a first step to moving the entire implementation into Cython (because I'm tired of writing Fortran 77 code 😞).