### PR TITLE
ENH: allow matching of general bipartite graphs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -203,6 +203,7 @@ scipy/sparse/csgraph/_shortest_path.c
 scipy/sparse/csgraph/_tools.c
 scipy/sparse/csgraph/_traversal.c
 scipy/sparse/csgraph/_flow.c
+scipy/sparse/csgraph/_matching.c
 scipy/sparse/csgraph/_reordering.c
 scipy/sparse/linalg/dsolve/umfpack/_umfpack.py
 scipy/sparse/linalg/dsolve/umfpack/_umfpack_wrap.c

--- a/benchmarks/benchmarks/sparse_csgraph_matching.py
+++ b/benchmarks/benchmarks/sparse_csgraph_matching.py
@@ -9,7 +9,7 @@ from .common import Benchmark
 
 
 class MaximumBipartiteMatching(Benchmark):
-    params = [[1000, 5000, 10000], [0.01, 0.1, 0.2]]
+    params = [[1000, 2500], [0.01, 0.1]]
     param_names = ['n', 'density']
 
     def setup(self, n, density):

--- a/benchmarks/benchmarks/sparse_csgraph_matching.py
+++ b/benchmarks/benchmarks/sparse_csgraph_matching.py
@@ -1,0 +1,21 @@
+import scipy.sparse
+
+try:
+    from scipy.sparse.csgraph import maximum_bipartite_matching
+except ImportError:
+    pass
+
+from .common import Benchmark
+
+
+class MaximumBipartiteMatching(Benchmark):
+    params = [[1000, 5000, 10000], [0.01, 0.1, 0.2]]
+    param_names = ['n', 'density']
+
+    def setup(self, n, density):
+        graph = scipy.sparse.rand(n, n, density=density,
+                                  format='csr', random_state=42)
+        self.graph = graph
+
+    def time_maximum_bipartite_matching(self, n, density):
+        maximum_bipartite_matching(self.graph)

--- a/benchmarks/benchmarks/sparse_csgraph_matching.py
+++ b/benchmarks/benchmarks/sparse_csgraph_matching.py
@@ -1,3 +1,4 @@
+import numpy as np
 import scipy.sparse
 
 try:
@@ -9,12 +10,17 @@ from .common import Benchmark
 
 
 class MaximumBipartiteMatching(Benchmark):
-    params = [[1000, 2500], [0.01, 0.1]]
+    params = [[5000, 7500, 10000], [0.0001, 0.0005, 0.001]]
     param_names = ['n', 'density']
 
     def setup(self, n, density):
-        graph = scipy.sparse.rand(n, n, density=density,
-                                  format='csr', random_state=42)
+        # Create random sparse matrices. Note that we could use
+        # scipy.sparse.rand for this purpose, but simply using np.random and
+        # disregarding duplicates is quite a bit faster.
+        np.random.seed(42)
+        d = np.random.randint(0, n, size=(int(n*n*density), 2))
+        graph = scipy.sparse.csr_matrix((np.ones(len(d)), (d[:, 0], d[:, 1])),
+                                        shape=(n, n))
         self.graph = graph
 
     def time_maximum_bipartite_matching(self, n, density):

--- a/scipy/sparse/csgraph/__init__.py
+++ b/scipy/sparse/csgraph/__init__.py
@@ -25,12 +25,8 @@ Contents
    depth_first_tree -- construct a depth-first tree from a given node
    minimum_spanning_tree -- construct the minimum spanning tree of a graph
    reverse_cuthill_mckee -- compute permutation for reverse Cuthill-McKee ordering
-<<<<<<< HEAD
    maximum_flow -- solve the maximum flow problem for a graph
-   maximum_bipartite_matching -- compute permutation to make diagonal zero free
-=======
    maximum_bipartite_matching -- compute a maximum matching of a bipartite graph
->>>>>>> ENH: allow matching of general bipartite graphs
    structural_rank -- compute the structural rank of a graph
    NegativeCycleError
 

--- a/scipy/sparse/csgraph/__init__.py
+++ b/scipy/sparse/csgraph/__init__.py
@@ -25,8 +25,12 @@ Contents
    depth_first_tree -- construct a depth-first tree from a given node
    minimum_spanning_tree -- construct the minimum spanning tree of a graph
    reverse_cuthill_mckee -- compute permutation for reverse Cuthill-McKee ordering
+<<<<<<< HEAD
    maximum_flow -- solve the maximum flow problem for a graph
    maximum_bipartite_matching -- compute permutation to make diagonal zero free
+=======
+   maximum_bipartite_matching -- compute a maximum matching of a bipartite graph
+>>>>>>> ENH: allow matching of general bipartite graphs
    structural_rank -- compute the structural rank of a graph
    NegativeCycleError
 
@@ -186,8 +190,8 @@ from ._traversal import breadth_first_order, depth_first_order, \
     breadth_first_tree, depth_first_tree, connected_components
 from ._min_spanning_tree import minimum_spanning_tree
 from ._flow import maximum_flow
-from ._reordering import reverse_cuthill_mckee, maximum_bipartite_matching, \
-    structural_rank
+from ._matching import maximum_bipartite_matching
+from ._reordering import reverse_cuthill_mckee, structural_rank
 from ._tools import construct_dist_matrix, reconstruct_path,\
     csgraph_from_dense, csgraph_to_dense, csgraph_masked_from_dense,\
     csgraph_from_masked, csgraph_to_masked

--- a/scipy/sparse/csgraph/_matching.pyx
+++ b/scipy/sparse/csgraph/_matching.pyx
@@ -1,0 +1,266 @@
+cimport cython
+import numpy as np
+cimport numpy as np
+
+from scipy.sparse import (csr_matrix,
+                          isspmatrix_coo, isspmatrix_csc, isspmatrix_csr)
+
+
+def maximum_bipartite_matching(graph, perm_type='row'):
+    r"""
+    maximum_bipartite_matching(graph, perm_type='row')
+
+    Returns a matching of a bipartite graph whose cardinality is as least that
+    of any given matching of the graph.
+
+    Parameters
+    ----------
+    graph : sparse matrix
+        Input sparse in CSR format whose rows represent one partition of the
+        graph and whose columns represent the other partition. An edge between
+        two vertices is indicated by the corresponding entry in the matrix
+        existing in its sparse representation.
+    perm_type : str, {'row', 'column'}
+        Which partition to return the matching in terms of: If ``'row'``, the
+        function produces an array whose length is the number of columns in the
+        input, and whose :math:`j`'th element is the row matched to the
+        :math:`j`'th column. Conversely, if ``perm_type`` is ``'column'``, this
+        returns the columns matched to each row.
+
+    Returns
+    -------
+    perm : ndarray
+        A matching of the vertices in one of the two partitions. Unmatched
+        vertices are represented by a ``-1`` in the result.
+
+    Notes
+    -----
+    This function uses of the Hopcroft--Karp algorithm [1]_. Its time
+    complexity is :math:`O(\lvert E \rvert \sqrt{\lvert V \rvert})`, and its
+    space complexity is linear in the number of rows. In practice, this
+    asymmetry between rows and columns means that it can be more efficient to
+    transpose the input if it contains more columns than rows.
+
+    By Kőnig's theorem, the cardinality of the matching is also the number of
+    vertices appearing in a minimum vertex cover of the graph.
+
+    Note that if the sparse representation contains explicit zeros, these are
+    still counted as edges.
+    .. versionadded:: 0.15.0
+
+    Examples
+    --------
+    >>> from scipy.sparse import csr_matrix
+    >>> from scipy.sparse.csgraph import maximum_bipartite_matching
+
+    As a simple example, consider a bipartite graph in which the partitions
+    contain 2 and 3 elements respectively. Suppose that one partition contains
+    vertices labelled 0 and 1, and that the other partition contains vertices
+    labelled a, b, and c. Suppose that there are edges connecting 0 and c,
+    1 and a, and 1 and b. This graph would then be represented by the following
+    sparse matrix:
+    >>> graph = csr_matrix([[0, 0, 1], [1, 1, 0]])
+
+    Here, the 1s could be anything, as long as they end up being stored as
+    elements in the sparse matrix. We can now calculate matximum matchings as
+    follows:
+    >>> print(maximum_bipartite_matching(graph, perm_type='column'))
+    [2 0]
+    >>> print(maximum_bipartite_matching(graph, perm_type='row'))
+    [ 1 -1  0]
+
+    The first output tells us that 1 and 2 are matched with c and a
+    respectively, and the second output tells us that a, b, and c are matched
+    with 1, nothing, and 0 respectively.
+
+    Note that explicit zeros are still converted to edges. This means that a
+    different way to represent the above graph is by using the CSR structure
+    directly as follows:
+
+    >>> data = [0, 0, 0]
+    >>> indices = [2, 0, 1]
+    >>> indptr = [0, 1, 3]
+    >>> graph = csr_matrix((data, indices, indptr))
+    >>> print(maximum_bipartite_matching(graph, perm_type='column'))
+    [2 0]
+    >>> print(maximum_bipartite_matching(graph, perm_type='row'))
+    [ 1 -1  0]
+
+    When one or both of the partitions are empty, the matching is empty as
+    well:
+    >>> graph = csr_matrix((2, 0))
+    >>> print(maximum_bipartite_matching(graph, perm_type='column'))
+    [-1 -1]
+    >>> print(maximum_bipartite_matching(graph, perm_type='row'))
+    []
+
+    When the input matrix is square, and the graph is known to admit a perfect
+    matching, i.e. a matching with the property that every vertex in the graph
+    belongs to some edge in the matching, then one can view the output as the
+    permutation of rows (or columns) turning the input matrix into one with the
+    property that all diagonal elements are non-empty:
+    >>> a = [[0, 1, 2, 0], [1, 0, 0, 1], [2, 0, 0, 3], [0, 1, 3, 0]]
+    >>> graph = csr_matrix(a)
+    >>> perm = maximum_bipartite_matching(graph, perm_type='row')
+    >>> graph[perm].toarray()
+    [[1 0 0 1]
+     [0 1 2 0]
+     [0 1 3 0]
+     [2 0 0 3]]
+
+    References
+    ----------
+    .. [1] John E. Hopcroft and Richard M. Karp. “An n^{5 / 2} Algorithm for
+           Maximum Matchings in Bipartite Graphs” In: SIAM Journal of Computing
+           2.4 (1973), pp. 225–231. <https://dx.doi.org/10.1137/0202019>.
+
+    """
+    if isspmatrix_csc(graph) or isspmatrix_coo(graph):
+        graph = graph.tocsr()
+    elif not isspmatrix_csr(graph):
+        raise TypeError("graph must be in CSC, CSR, or COO format.")
+    i, j = graph.shape
+    x, y = _hopcroft_karp(graph.indices, graph.indptr, i, j)
+    return np.asarray(x if perm_type == 'column' else y)
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cdef tuple _hopcroft_karp(int[:] indices, int[:] indptr, int i, int j):
+    cdef int INF = 2147483647  # Max 32-bit signed int
+    # x will end up containing the matchings of rows to columns, while
+    # y will contain the matchings of columns to rows.
+    cdef int[:] x = np.empty(i, dtype=np.int32)
+    cdef int[:] y = np.empty(j, dtype=np.int32)
+
+    # During the BFS step, dist will keep track of the level of the search. We
+    # only keep track of this for the vertices in the left partition. Note that
+    # the array is one longer than the cardinality of the left partition:
+    # throughout the algorithm, we make use of the standard trick of adding an
+    # auxiliary vertex whose index will be i, and whose semantics are that
+    # every unmatched column will be matched with this vertex.
+    cdef int[:] dist = np.empty(i + 1, dtype=np.int32)
+
+    cdef int k, v, w, up, u, u_old
+
+    # At the end of the day, unmatched vertices will have a value of -1. As
+    # mentioned above, unmatched vertices in the right partition will be
+    # matched to the auxiliary vertex i, and we will set their value to -1
+    # only when we have found a maximum matching.
+    for k in range(i):
+        x[k] = -1
+
+    for k in range(j):
+        y[k] = i
+
+    # Set up three structures for use in our searches: q will represent a queue
+    # of vertices for use during the BFS step. As above, we will only keep
+    # track of the vertices in the left partition, as well as the auxiliary
+    # vertex; as no vertex is added more than once, the capacity of the queue
+    # will be i + 1. As in a circular buffer, we use two pointers, head and
+    # tail to keep track of the ends of the queue: Elements are dequeued from
+    # head and queued at tail.
+    cdef int[:] q = np.empty(i + 1, dtype=np.int32)
+    cdef int head, tail
+
+    # Similarly, we use a stack for our depth-first search. As above, we only
+    # represent vertices in the left partition, and since no augmenting path
+    # will visit more than i of thse before encountering an unmatched vertex
+    # (as represented by i), the stack capacity can be limited to i + 1.
+    # Elements will be pushed to stack_head and popped from stack_head - 1.
+    cdef int[:] stack = np.empty(i + 1, dtype=np.int32)
+    cdef int stack_head
+
+    # Finally, during our depth-first search, we keep track of the vertices we
+    # have visited. This will simplify the updates to the matching that occurs
+    # when an augmenting path is found. Elements will be pushed to path_head
+    # and popped from path_head - 1.
+    cdef int[:] path = np.empty(i, dtype=np.int32)
+    cdef int path_head
+
+    # The breadth-first search part of the algorithm. This will terminate when
+    # we are unable to find a path to an unassigned vertex, which boils down to
+    # not being able to find a path to the auxiliary vertex i.
+    while True:
+        # Empty the queue by resetting the two pointers.
+        head = 0
+        tail = 0
+        for v in range(i):
+            if x[v] < 0:
+                dist[v] = 0
+                # Enqueue v. Note that in an ordinary circular buffer, we would
+                # avoid overflows by wrapping around indices, but since we will
+                # never enqueue more than i + 1 different elements at a single
+                # iteration, we can avoid doing so.
+                q[tail] = v
+                tail += 1
+            else:
+                dist[v] = INF
+        dist[i] = INF
+        # Check if the queue is empty. Note than in an ordinary circular buffer
+        # some care needs to be taken with this check when the buffer is full,
+        # which we can avoid as above.
+        while head < tail:
+            v = q[head]
+            head += 1
+            if dist[v] < dist[i]:
+                for up in range(indptr[v], indptr[v+1]):
+                    u = indices[up]
+                    if dist[y[u]] == INF:
+                        dist[y[u]] = dist[v] + 1
+                        q[tail] = y[u]
+                        tail += 1
+        # Vertices not encountered during the BFS will have a dist of INF. In
+        # particular, dist[i] will be INF exactly when we did not encounter any
+        # unmatched vertices.
+        if dist[i] == INF:
+            break
+
+        # Depth-first search starting from every unmatched vertex.
+        for w in range(i):
+            if x[w] < 0:
+                done = False
+                # Initialize stack to contain only w and reset path.
+                stack[0] = w
+                stack_head = 1
+                path_head = 0
+                while stack_head != 0:
+                    # Pop v from stack and push it to path.
+                    stack_head -= 1
+                    v = stack[stack_head]
+                    path[path_head] = v
+                    path_head += 1
+                    could_augment = False
+                    for up in range(indptr[v], indptr[v + 1]):
+                        u = indices[up]
+                        if dist[y[u]] == dist[v] + 1:
+                            could_augment = True
+                            # If y[u] is unmatched, we have found an augmenting
+                            # path. We update the matching and move on to the
+                            # next unmatched vertex.
+                            if y[u] == i:
+                                done = True
+                                while path_head != 0:
+                                    path_head -= 1
+                                    v = path[path_head]
+                                    u_old = x[v]
+                                    y[u] = v
+                                    x[v] = u
+                                    u = u_old
+                                break
+                            stack[stack_head] = y[u]
+                            stack_head += 1
+                    if done:
+                        break
+                    # Mark v as a vertex from which it is impossible to augment
+                    # to avoid considering it multiple times, and remove it
+                    # from path before moving on to next candidate.
+                    if not could_augment:
+                        dist[v] = INF
+                        path_head -= 1
+
+    for k in range(j):
+        if y[k] == i:
+            y[k] = -1
+
+    return x, y

--- a/scipy/sparse/csgraph/_matching.pyx
+++ b/scipy/sparse/csgraph/_matching.pyx
@@ -159,11 +159,8 @@ cdef tuple _hopcroft_karp(ITYPE_t[:] indices, ITYPE_t[:] indptr,
     # mentioned above, unmatched vertices in the right partition will be
     # matched to the auxiliary vertex i, and we will set their value to -1
     # only when we have found a maximum matching.
-    for k in range(i):
-        x[k] = -1
-
-    for k in range(j):
-        y[k] = i
+    x.fill(-1)
+    y.fill(i)
 
     # Set up three structures for use in our searches: q will represent a queue
     # of vertices for use during the BFS step. As above, we will only keep

--- a/scipy/sparse/csgraph/_matching.pyx
+++ b/scipy/sparse/csgraph/_matching.pyx
@@ -135,12 +135,13 @@ def maximum_bipartite_matching(graph, perm_type='row'):
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef tuple _hopcroft_karp(int[:] indices, int[:] indptr, int i, int j):
-    cdef int INF = 2147483647  # Max 32-bit signed int
+cdef tuple _hopcroft_karp(ITYPE_t[:] indices, ITYPE_t[:] indptr,
+                          ITYPE_t i, ITYPE_t j):
+    cdef ITYPE_t INF = np.iinfo(ITYPE).max
     # x will end up containing the matchings of rows to columns, while
     # y will contain the matchings of columns to rows.
-    cdef int[:] x = np.empty(i, dtype=ITYPE)
-    cdef int[:] y = np.empty(j, dtype=ITYPE)
+    cdef ITYPE_t[:] x = np.empty(i, dtype=ITYPE)
+    cdef ITYPE_t[:] y = np.empty(j, dtype=ITYPE)
 
     # During the BFS step, dist will keep track of the level of the search. We
     # only keep track of this for the vertices in the left partition. Note that
@@ -148,9 +149,9 @@ cdef tuple _hopcroft_karp(int[:] indices, int[:] indptr, int i, int j):
     # throughout the algorithm, we make use of the standard trick of adding an
     # auxiliary vertex whose index will be i, and whose semantics are that
     # every unmatched column will be matched with this vertex.
-    cdef int[:] dist = np.empty(i + 1, dtype=ITYPE)
+    cdef ITYPE_t[:] dist = np.empty(i + 1, dtype=ITYPE)
 
-    cdef int k, v, w, up, u, u_old
+    cdef ITYPE_t k, v, w, up, u, u_old
 
     # At the end of the day, unmatched vertices will have a value of -1. As
     # mentioned above, unmatched vertices in the right partition will be
@@ -169,23 +170,23 @@ cdef tuple _hopcroft_karp(int[:] indices, int[:] indptr, int i, int j):
     # will be i + 1. As in a circular buffer, we use two pointers, head and
     # tail to keep track of the ends of the queue: Elements are dequeued from
     # head and queued at tail.
-    cdef int[:] q = np.empty(i + 1, dtype=ITYPE)
-    cdef int head, tail
+    cdef ITYPE_t[:] q = np.empty(i + 1, dtype=ITYPE)
+    cdef ITYPE_t head, tail
 
     # Similarly, we use a stack for our depth-first search. As above, we only
     # represent vertices in the left partition, and since no augmenting path
     # will visit more than i of thse before encountering an unmatched vertex
     # (as represented by i), the stack capacity can be limited to i + 1.
     # Elements will be pushed to stack_head and popped from stack_head - 1.
-    cdef int[:] stack = np.empty(i + 1, dtype=ITYPE)
-    cdef int stack_head
+    cdef ITYPE_t[:] stack = np.empty(i + 1, dtype=ITYPE)
+    cdef ITYPE_t stack_head
 
     # Finally, during our depth-first search, we keep track of the vertices we
     # have visited. This will simplify the updates to the matching that occurs
     # when an augmenting path is found. Elements will be pushed to path_head
     # and popped from path_head - 1.
-    cdef int[:] path = np.empty(i, dtype=ITYPE)
-    cdef int path_head
+    cdef ITYPE_t[:] path = np.empty(i, dtype=ITYPE)
+    cdef ITYPE_t path_head
 
     # The breadth-first search part of the algorithm. This will terminate when
     # we are unable to find a path to an unassigned vertex, which boils down to

--- a/scipy/sparse/csgraph/_matching.pyx
+++ b/scipy/sparse/csgraph/_matching.pyx
@@ -38,7 +38,7 @@ def maximum_bipartite_matching(graph, perm_type='row'):
 
     Notes
     -----
-    This function uses of the Hopcroft--Karp algorithm [1]_. Its time
+    This function implements the Hopcroft--Karp algorithm [1]_. Its time
     complexity is :math:`O(\lvert E \rvert \sqrt{\lvert V \rvert})`, and its
     space complexity is linear in the number of rows. In practice, this
     asymmetry between rows and columns means that it can be more efficient to
@@ -57,7 +57,6 @@ def maximum_bipartite_matching(graph, perm_type='row'):
     .. [1] John E. Hopcroft and Richard M. Karp. "An n^{5 / 2} Algorithm for
            Maximum Matchings in Bipartite Graphs" In: SIAM Journal of Computing
            2.4 (1973), pp. 225--231. <https://dx.doi.org/10.1137/0202019>.
-
 
     Examples
     --------

--- a/scipy/sparse/csgraph/_matching.pyx
+++ b/scipy/sparse/csgraph/_matching.pyx
@@ -49,6 +49,13 @@ def maximum_bipartite_matching(graph, perm_type='row'):
 
     .. versionadded:: 0.15.0
 
+    References
+    ----------
+    .. [1] John E. Hopcroft and Richard M. Karp. "An n^{5 / 2} Algorithm for
+           Maximum Matchings in Bipartite Graphs" In: SIAM Journal of Computing
+           2.4 (1973), pp. 225--231. <https://dx.doi.org/10.1137/0202019>.
+
+
     Examples
     --------
     >>> from scipy.sparse import csr_matrix
@@ -112,12 +119,6 @@ def maximum_bipartite_matching(graph, perm_type='row'):
      [0 1 2 0]
      [0 1 3 0]
      [2 0 0 3]]
-
-    References
-    ----------
-    .. [1] John E. Hopcroft and Richard M. Karp. "An n^{5 / 2} Algorithm for
-           Maximum Matchings in Bipartite Graphs" In: SIAM Journal of Computing
-           2.4 (1973), pp. 225--231. <https://dx.doi.org/10.1137/0202019>.
 
     """
     if isspmatrix_csc(graph) or isspmatrix_coo(graph):

--- a/scipy/sparse/csgraph/_matching.pyx
+++ b/scipy/sparse/csgraph/_matching.pyx
@@ -107,7 +107,7 @@ def maximum_bipartite_matching(graph, perm_type='row'):
     >>> a = [[0, 1, 2, 0], [1, 0, 0, 1], [2, 0, 0, 3], [0, 1, 3, 0]]
     >>> graph = csr_matrix(a)
     >>> perm = maximum_bipartite_matching(graph, perm_type='row')
-    >>> graph[perm].toarray()
+    >>> print(graph[perm].toarray())
     [[1 0 0 1]
      [0 1 2 0]
      [0 1 3 0]

--- a/scipy/sparse/csgraph/_matching.pyx
+++ b/scipy/sparse/csgraph/_matching.pyx
@@ -159,8 +159,11 @@ cdef tuple _hopcroft_karp(ITYPE_t[:] indices, ITYPE_t[:] indptr,
     # mentioned above, unmatched vertices in the right partition will be
     # matched to the auxiliary vertex i, and we will set their value to -1
     # only when we have found a maximum matching.
-    x.fill(-1)
-    y.fill(i)
+    for k in range(i):
+        x[k] = -1
+
+    for k in range(j):
+        y[k] = i
 
     # Set up three structures for use in our searches: q will represent a queue
     # of vertices for use during the BFS step. As above, we will only keep

--- a/scipy/sparse/csgraph/_matching.pyx
+++ b/scipy/sparse/csgraph/_matching.pyx
@@ -41,7 +41,7 @@ def maximum_bipartite_matching(graph, perm_type='row'):
     asymmetry between rows and columns means that it can be more efficient to
     transpose the input if it contains more columns than rows.
 
-    By König's theorem, the cardinality of the matching is also the number of
+    By Konig's theorem, the cardinality of the matching is also the number of
     vertices appearing in a minimum vertex cover of the graph.
 
     Note that if the sparse representation contains explicit zeros, these are
@@ -116,7 +116,7 @@ def maximum_bipartite_matching(graph, perm_type='row'):
     ----------
     .. [1] John E. Hopcroft and Richard M. Karp. "An n^{5 / 2} Algorithm for
            Maximum Matchings in Bipartite Graphs" In: SIAM Journal of Computing
-           2.4 (1973), pp. 225–231. <https://dx.doi.org/10.1137/0202019>.
+           2.4 (1973), pp. 225--231. <https://dx.doi.org/10.1137/0202019>.
 
     """
     if isspmatrix_csc(graph) or isspmatrix_coo(graph):

--- a/scipy/sparse/csgraph/_matching.pyx
+++ b/scipy/sparse/csgraph/_matching.pyx
@@ -50,7 +50,10 @@ def maximum_bipartite_matching(graph, perm_type='row'):
     Note that if the sparse representation contains explicit zeros, these are
     still counted as edges.
 
-    .. versionadded:: 0.15.0
+    The implementation was changed in SciPy 1.4.0 to allow matching of general
+    bipartite graphs, where previous versions would assume that a perfect
+    matching existed. As such, code written against 1.4.0 will not necessarily
+    work on older versions.
 
     References
     ----------

--- a/scipy/sparse/csgraph/_matching.pyx
+++ b/scipy/sparse/csgraph/_matching.pyx
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 cimport cython
 import numpy as np
 cimport numpy as np

--- a/scipy/sparse/csgraph/_matching.pyx
+++ b/scipy/sparse/csgraph/_matching.pyx
@@ -59,11 +59,13 @@ def maximum_bipartite_matching(graph, perm_type='row'):
     labelled a, b, and c. Suppose that there are edges connecting 0 and c,
     1 and a, and 1 and b. This graph would then be represented by the following
     sparse matrix:
+
     >>> graph = csr_matrix([[0, 0, 1], [1, 1, 0]])
 
     Here, the 1s could be anything, as long as they end up being stored as
     elements in the sparse matrix. We can now calculate matximum matchings as
     follows:
+
     >>> print(maximum_bipartite_matching(graph, perm_type='column'))
     [2 0]
     >>> print(maximum_bipartite_matching(graph, perm_type='row'))
@@ -88,6 +90,7 @@ def maximum_bipartite_matching(graph, perm_type='row'):
 
     When one or both of the partitions are empty, the matching is empty as
     well:
+
     >>> graph = csr_matrix((2, 0))
     >>> print(maximum_bipartite_matching(graph, perm_type='column'))
     [-1 -1]
@@ -99,6 +102,7 @@ def maximum_bipartite_matching(graph, perm_type='row'):
     belongs to some edge in the matching, then one can view the output as the
     permutation of rows (or columns) turning the input matrix into one with the
     property that all diagonal elements are non-empty:
+
     >>> a = [[0, 1, 2, 0], [1, 0, 0, 1], [2, 0, 0, 3], [0, 1, 3, 0]]
     >>> graph = csr_matrix(a)
     >>> perm = maximum_bipartite_matching(graph, perm_type='row')

--- a/scipy/sparse/csgraph/_matching.pyx
+++ b/scipy/sparse/csgraph/_matching.pyx
@@ -57,14 +57,14 @@ def maximum_bipartite_matching(graph, perm_type='row'):
     As a simple example, consider a bipartite graph in which the partitions
     contain 2 and 3 elements respectively. Suppose that one partition contains
     vertices labelled 0 and 1, and that the other partition contains vertices
-    labelled a, b, and c. Suppose that there are edges connecting 0 and c,
-    1 and a, and 1 and b. This graph would then be represented by the following
+    labelled A, B, and C. Suppose that there are edges connecting 0 and C,
+    1 and A, and 1 and B. This graph would then be represented by the following
     sparse matrix:
 
     >>> graph = csr_matrix([[0, 0, 1], [1, 1, 0]])
 
     Here, the 1s could be anything, as long as they end up being stored as
-    elements in the sparse matrix. We can now calculate matximum matchings as
+    elements in the sparse matrix. We can now calculate maximum matchings as
     follows:
 
     >>> print(maximum_bipartite_matching(graph, perm_type='column'))
@@ -72,8 +72,8 @@ def maximum_bipartite_matching(graph, perm_type='row'):
     >>> print(maximum_bipartite_matching(graph, perm_type='row'))
     [ 1 -1  0]
 
-    The first output tells us that 1 and 2 are matched with c and a
-    respectively, and the second output tells us that a, b, and c are matched
+    The first output tells us that 1 and 2 are matched with C and A
+    respectively, and the second output tells us that A, B, and C are matched
     with 1, nothing, and 0 respectively.
 
     Note that explicit zeros are still converted to edges. This means that a

--- a/scipy/sparse/csgraph/_matching.pyx
+++ b/scipy/sparse/csgraph/_matching.pyx
@@ -46,6 +46,7 @@ def maximum_bipartite_matching(graph, perm_type='row'):
 
     Note that if the sparse representation contains explicit zeros, these are
     still counted as edges.
+
     .. versionadded:: 0.15.0
 
     Examples

--- a/scipy/sparse/csgraph/_matching.pyx
+++ b/scipy/sparse/csgraph/_matching.pyx
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 cimport cython
 import numpy as np
 cimport numpy as np
@@ -42,7 +41,7 @@ def maximum_bipartite_matching(graph, perm_type='row'):
     asymmetry between rows and columns means that it can be more efficient to
     transpose the input if it contains more columns than rows.
 
-    By Kőnig's theorem, the cardinality of the matching is also the number of
+    By König's theorem, the cardinality of the matching is also the number of
     vertices appearing in a minimum vertex cover of the graph.
 
     Note that if the sparse representation contains explicit zeros, these are
@@ -111,8 +110,8 @@ def maximum_bipartite_matching(graph, perm_type='row'):
 
     References
     ----------
-    .. [1] John E. Hopcroft and Richard M. Karp. “An n^{5 / 2} Algorithm for
-           Maximum Matchings in Bipartite Graphs” In: SIAM Journal of Computing
+    .. [1] John E. Hopcroft and Richard M. Karp. "An n^{5 / 2} Algorithm for
+           Maximum Matchings in Bipartite Graphs" In: SIAM Journal of Computing
            2.4 (1973), pp. 225–231. <https://dx.doi.org/10.1137/0202019>.
 
     """

--- a/scipy/sparse/csgraph/_matching.pyx
+++ b/scipy/sparse/csgraph/_matching.pyx
@@ -2,8 +2,11 @@ cimport cython
 import numpy as np
 cimport numpy as np
 
+
 from scipy.sparse import (csr_matrix,
                           isspmatrix_coo, isspmatrix_csc, isspmatrix_csr)
+
+include "parameters.pxi"
 
 
 def maximum_bipartite_matching(graph, perm_type='row'):
@@ -136,8 +139,8 @@ cdef tuple _hopcroft_karp(int[:] indices, int[:] indptr, int i, int j):
     cdef int INF = 2147483647  # Max 32-bit signed int
     # x will end up containing the matchings of rows to columns, while
     # y will contain the matchings of columns to rows.
-    cdef int[:] x = np.empty(i, dtype=np.int32)
-    cdef int[:] y = np.empty(j, dtype=np.int32)
+    cdef int[:] x = np.empty(i, dtype=ITYPE)
+    cdef int[:] y = np.empty(j, dtype=ITYPE)
 
     # During the BFS step, dist will keep track of the level of the search. We
     # only keep track of this for the vertices in the left partition. Note that
@@ -145,7 +148,7 @@ cdef tuple _hopcroft_karp(int[:] indices, int[:] indptr, int i, int j):
     # throughout the algorithm, we make use of the standard trick of adding an
     # auxiliary vertex whose index will be i, and whose semantics are that
     # every unmatched column will be matched with this vertex.
-    cdef int[:] dist = np.empty(i + 1, dtype=np.int32)
+    cdef int[:] dist = np.empty(i + 1, dtype=ITYPE)
 
     cdef int k, v, w, up, u, u_old
 
@@ -166,7 +169,7 @@ cdef tuple _hopcroft_karp(int[:] indices, int[:] indptr, int i, int j):
     # will be i + 1. As in a circular buffer, we use two pointers, head and
     # tail to keep track of the ends of the queue: Elements are dequeued from
     # head and queued at tail.
-    cdef int[:] q = np.empty(i + 1, dtype=np.int32)
+    cdef int[:] q = np.empty(i + 1, dtype=ITYPE)
     cdef int head, tail
 
     # Similarly, we use a stack for our depth-first search. As above, we only
@@ -174,14 +177,14 @@ cdef tuple _hopcroft_karp(int[:] indices, int[:] indptr, int i, int j):
     # will visit more than i of thse before encountering an unmatched vertex
     # (as represented by i), the stack capacity can be limited to i + 1.
     # Elements will be pushed to stack_head and popped from stack_head - 1.
-    cdef int[:] stack = np.empty(i + 1, dtype=np.int32)
+    cdef int[:] stack = np.empty(i + 1, dtype=ITYPE)
     cdef int stack_head
 
     # Finally, during our depth-first search, we keep track of the vertices we
     # have visited. This will simplify the updates to the matching that occurs
     # when an augmenting path is found. Elements will be pushed to path_head
     # and popped from path_head - 1.
-    cdef int[:] path = np.empty(i, dtype=np.int32)
+    cdef int[:] path = np.empty(i, dtype=ITYPE)
     cdef int path_head
 
     # The breadth-first search part of the algorithm. This will terminate when

--- a/scipy/sparse/csgraph/_reordering.pyx
+++ b/scipy/sparse/csgraph/_reordering.pyx
@@ -7,9 +7,11 @@ from __future__ import absolute_import
 import numpy as np
 cimport numpy as np
 from warnings import warn
-from scipy.sparse import (csc_matrix, isspmatrix, isspmatrix_coo, 
-                        isspmatrix_csc, isspmatrix_csr,
-                        SparseEfficiencyWarning)
+from scipy.sparse import (csc_matrix, csr_matrix, isspmatrix, isspmatrix_coo,
+                          isspmatrix_csc, isspmatrix_csr,
+                          SparseEfficiencyWarning)
+from . import maximum_bipartite_matching
+
 
 include 'parameters.pxi'
 
@@ -75,85 +77,6 @@ def reverse_cuthill_mckee(graph, symmetric_mode=False):
     if not symmetric_mode:
         graph = graph+graph.transpose()
     return _reverse_cuthill_mckee(graph.indices, graph.indptr, nrows)
-
-
-def maximum_bipartite_matching(graph, perm_type='row'):
-    """
-    maximum_bipartite_matching(graph, perm_type='row')
-    
-    Returns an array of row or column permutations that makes
-    the diagonal of a nonsingular square CSC sparse matrix zero free.  
-    
-    Such a permutation is always possible provided that the matrix 
-    is nonsingular. This function looks at the structure of the matrix 
-    only. The input matrix will be converted to CSC matrix format if
-    necessary.
-
-    Parameters
-    ----------
-    graph : sparse matrix
-        Input sparse in CSC format
-    perm_type : str, {'row', 'column'}
-        Type of permutation to generate.
-
-    Returns
-    -------
-    perm : ndarray
-        Array of row or column permutations.
-
-    Notes
-    -----
-    This function relies on a maximum cardinality bipartite matching 
-    algorithm based on a breadth-first search (BFS) of the underlying 
-    graph.
-
-    .. versionadded:: 0.15.0
-
-    References
-    ----------
-    I. S. Duff, K. Kaya, and B. Ucar, "Design, Implementation, and 
-    Analysis of Maximum Transversal Algorithms", ACM Trans. Math. Softw.
-    38, no. 2, (2011).
-
-    Examples
-    --------
-    >>> from scipy.sparse import csr_matrix
-    >>> from scipy.sparse.csgraph import maximum_bipartite_matching
-
-    >>> graph = [
-    ... [0, 1 , 2, 0],
-    ... [1, 0, 0, 1],
-    ... [2, 0, 0, 3],
-    ... [0, 1, 3, 0]
-    ... ]
-    >>> graph = csr_matrix(graph)
-    >>> print(graph)
-      (0, 1)	1
-      (0, 2)	2
-      (1, 0)	1
-      (1, 3)	1
-      (2, 0)	2
-      (2, 3)	3
-      (3, 1)	1
-      (3, 2)	3
-
-    >>> maximum_bipartite_matching(graph, perm_type='row')
-    array([1, 0, 3, 2], dtype=int32)
-
-    """
-    cdef np.npy_intp nrows = graph.shape[0]
-    if nrows != graph.shape[1]:
-        raise ValueError('Maximum bipartite matching requires a square matrix.')
-    if isspmatrix_csr(graph) or isspmatrix_coo(graph):
-        graph = graph.tocsc()
-    elif not isspmatrix_csc(graph):
-        raise TypeError("graph must be in CSC, CSR, or COO format.")
-    if perm_type == 'column':
-        graph = graph.transpose().tocsc()
-    perm = _maximum_bipartite_matching(graph.indices, graph.indptr, nrows)
-    if np.any(perm==-1):
-        raise Exception('Possibly singular input matrix.')
-    return perm
 
 
 cdef _node_degrees(
@@ -247,63 +170,6 @@ def _reverse_cuthill_mckee(np.ndarray[int32_or_int64, ndim=1, mode="c"] ind,
     return order[::-1]
 
 
-def _maximum_bipartite_matching(
-        np.ndarray[int32_or_int64, ndim=1, mode="c"] inds,
-        np.ndarray[int32_or_int64, ndim=1, mode="c"] ptrs,
-        np.npy_intp n):
-    """
-    Maximum bipartite matching of a graph in CSC format.
-    """
-    cdef np.ndarray[int32_or_int64] visited = np.zeros(n, dtype=inds.dtype)
-    cdef np.ndarray[ITYPE_t] queue = np.zeros(n, dtype=ITYPE)
-    cdef np.ndarray[ITYPE_t] previous = np.zeros(n, dtype=ITYPE)
-    cdef np.ndarray[int32_or_int64] match = np.empty(n, dtype=inds.dtype)
-    cdef np.ndarray[ITYPE_t] row_match = np.empty(n, dtype=ITYPE)
-    cdef np.npy_intp queue_ptr, queue_col, ptr, i, j, queue_size
-    cdef np.npy_intp col, next_num = 1
-    cdef int32_or_int64 row, temp, eptr
-
-    for i in range(n):
-        match[i] = -1
-        row_match[i] = -1
-
-    for i in range(n):
-        if match[i] == -1 and (ptrs[i] != ptrs[i + 1]):
-            queue[0] = i
-            queue_ptr = 0
-            queue_size = 1
-            while (queue_size > queue_ptr):
-                queue_col = queue[queue_ptr]
-                queue_ptr += 1
-                eptr = ptrs[queue_col + 1]
-                for ptr in range(ptrs[queue_col], eptr):
-                    row = inds[ptr]
-                    temp = visited[row]
-                    if (temp != next_num and temp != -1):
-                        previous[row] = queue_col
-                        visited[row] = next_num
-                        col = row_match[row]
-                        if (col == -1):
-                            while (row != -1):
-                                col = previous[row]
-                                temp = match[col]
-                                match[col] = row
-                                row_match[row] = col
-                                row = temp
-                            next_num += 1
-                            queue_size = 0
-                            break
-                        else:
-                            queue[queue_size] = col
-                            queue_size += 1
-
-            if match[i] == -1:
-                for j in range(1, queue_size):
-                    visited[match[queue[j]]] = -1
-
-    return match
-
-
 def structural_rank(graph):
     """
     structural_rank(graph)
@@ -341,7 +207,7 @@ def structural_rank(graph):
     >>> from scipy.sparse.csgraph import structural_rank
 
     >>> graph = [
-    ... [0, 1 , 2, 0],
+    ... [0, 1, 2, 0],
     ... [1, 0, 0, 1],
     ... [2, 0, 0, 3],
     ... [0, 1, 3, 0]
@@ -363,16 +229,13 @@ def structural_rank(graph):
     """
     if not isspmatrix:
         raise TypeError('Input must be a sparse matrix')
-    if not isspmatrix_csc(graph):
-        if not (isspmatrix_csr(graph) or isspmatrix_coo(graph)):
+    if not isspmatrix_csr(graph):
+        if not (isspmatrix_csc(graph) or isspmatrix_coo(graph)):
             warn('Input matrix should be in CSC, CSR, or COO matrix format',
                     SparseEfficiencyWarning)
-        graph = csc_matrix(graph)
+        graph = csr_matrix(graph)
     # If A is a tall matrix, then transpose.
     if graph.shape[0] > graph.shape[1]:
-        graph = graph.T.tocsc()
-    rank = np.sum(_maximum_bipartite_matching(graph.indices, 
-                    graph.indptr, graph.shape[1]) >= 0)
+        graph = graph.T.tocsr()
+    rank = np.sum(maximum_bipartite_matching(graph) >= 0)
     return rank
-
-

--- a/scipy/sparse/csgraph/setup.py
+++ b/scipy/sparse/csgraph/setup.py
@@ -20,6 +20,10 @@ def configuration(parent_package='', top_path=None):
     config.add_extension('_min_spanning_tree',
          sources=['_min_spanning_tree.c'],
          include_dirs=[numpy.get_include()])
+
+    config.add_extension('_matching',
+         sources=['_matching.c'],
+         include_dirs=[numpy.get_include()])
     
     config.add_extension('_flow',
          sources=['_flow.c'],

--- a/scipy/sparse/csgraph/tests/test_matching.py
+++ b/scipy/sparse/csgraph/tests/test_matching.py
@@ -1,0 +1,122 @@
+import numpy as np
+from numpy.testing import assert_array_equal, assert_equal
+import pytest
+
+from scipy.sparse import csr_matrix, coo_matrix, diags
+from scipy.sparse.csgraph import maximum_bipartite_matching
+
+
+def test_raises_on_dense_input():
+    with pytest.raises(TypeError):
+        graph = np.array([[0, 1], [0, 0]])
+        maximum_bipartite_matching(graph)
+
+
+def test_empty_graph():
+    graph = csr_matrix((0, 0))
+    x = maximum_bipartite_matching(graph, perm_type='row')
+    y = maximum_bipartite_matching(graph, perm_type='column')
+    expected_matching = np.array([])
+    assert_array_equal(expected_matching, x)
+    assert_array_equal(expected_matching, y)
+
+
+def test_empty_left_partition():
+    graph = csr_matrix((2, 0))
+    x = maximum_bipartite_matching(graph, perm_type='row')
+    y = maximum_bipartite_matching(graph, perm_type='column')
+    assert_array_equal(np.array([]), x)
+    assert_array_equal(np.array([-1, -1]), y)
+
+
+def test_empty_right_partition():
+    graph = csr_matrix((0, 3))
+    x = maximum_bipartite_matching(graph, perm_type='row')
+    y = maximum_bipartite_matching(graph, perm_type='column')
+    assert_array_equal(np.array([-1, -1, -1]), x)
+    assert_array_equal(np.array([]), y)
+
+
+def test_graph_with_no_edges():
+    graph = csr_matrix((2, 2))
+    x = maximum_bipartite_matching(graph, perm_type='row')
+    y = maximum_bipartite_matching(graph, perm_type='column')
+    assert_array_equal(np.array([-1, -1]), x)
+    assert_array_equal(np.array([-1, -1]), y)
+
+
+def test_graph_that_causes_augmentation():
+    # In this graph, column 1 is initially assigned to row 1, but it should be
+    # reassigned to make room for row 2.
+    graph = csr_matrix([[1, 1], [1, 0]])
+    x = maximum_bipartite_matching(graph, perm_type='column')
+    y = maximum_bipartite_matching(graph, perm_type='row')
+    expected_matching = np.array([1, 0])
+    assert_array_equal(expected_matching, x)
+    assert_array_equal(expected_matching, y)
+
+
+def test_graph_with_more_rows_than_columns():
+    graph = csr_matrix([[1, 1], [1, 0], [0, 1]])
+    x = maximum_bipartite_matching(graph, perm_type='column')
+    y = maximum_bipartite_matching(graph, perm_type='row')
+    assert_array_equal(np.array([0, -1, 1]), x)
+    assert_array_equal(np.array([0, 2]), y)
+
+
+def test_graph_with_more_columns_than_rows():
+    graph = csr_matrix([[1, 1, 0], [0, 0, 1]])
+    x = maximum_bipartite_matching(graph, perm_type='column')
+    y = maximum_bipartite_matching(graph, perm_type='row')
+    assert_array_equal(np.array([0, 2]), x)
+    assert_array_equal(np.array([0, -1, 1]), y)
+
+
+def test_explicit_zeros_count_as_edges():
+    data = [0, 0]
+    indices = [1, 0]
+    indptr = [0, 1, 2]
+    graph = csr_matrix((data, indices, indptr), shape=(2, 2))
+    x = maximum_bipartite_matching(graph, perm_type='row')
+    y = maximum_bipartite_matching(graph, perm_type='column')
+    expected_matching = np.array([1, 0])
+    assert_array_equal(expected_matching, x)
+    assert_array_equal(expected_matching, y)
+
+
+def test_large_random_graph_with_one_edge_incident_to_each_vertex():
+    A = diags(np.ones(25), offsets=0, format='csr')
+    rand_perm = np.random.permutation(25)
+    rand_perm2 = np.random.permutation(25)
+
+    Rrow = np.arange(25)
+    Rcol = rand_perm
+    Rdata = np.ones(25, dtype=int)
+    Rmat = coo_matrix((Rdata, (Rrow, Rcol))).tocsr()
+
+    Crow = rand_perm2
+    Ccol = np.arange(25)
+    Cdata = np.ones(25, dtype=int)
+    Cmat = coo_matrix((Cdata, (Crow, Ccol))).tocsr()
+    # Randomly permute identity matrix
+    B = Rmat * A * Cmat
+
+    # Row permute
+    perm = maximum_bipartite_matching(B, perm_type='row')
+    Rrow = np.arange(25)
+    Rcol = perm
+    Rdata = np.ones(25, dtype=int)
+    Rmat = coo_matrix((Rdata, (Rrow, Rcol))).tocsr()
+    C1 = Rmat * B
+
+    # Column permute
+    perm2 = maximum_bipartite_matching(B, perm_type='column')
+    Crow = perm2
+    Ccol = np.arange(25)
+    Cdata = np.ones(25, dtype=int)
+    Cmat = coo_matrix((Cdata, (Crow, Ccol))).tocsr()
+    C2 = B * Cmat
+
+    # Should get identity matrix back
+    assert_equal(any(C1.diagonal() == 0), False)
+    assert_equal(any(C2.diagonal() == 0), False)

--- a/scipy/sparse/csgraph/tests/test_matching.py
+++ b/scipy/sparse/csgraph/tests/test_matching.py
@@ -85,6 +85,7 @@ def test_explicit_zeros_count_as_edges():
 
 
 def test_large_random_graph_with_one_edge_incident_to_each_vertex():
+    np.random.seed(42)
     A = diags(np.ones(25), offsets=0, format='csr')
     rand_perm = np.random.permutation(25)
     rand_perm2 = np.random.permutation(25)

--- a/scipy/sparse/csgraph/tests/test_reordering.py
+++ b/scipy/sparse/csgraph/tests/test_reordering.py
@@ -2,9 +2,9 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 from numpy.testing import assert_equal
-from scipy.sparse.csgraph import (reverse_cuthill_mckee,
-        maximum_bipartite_matching, structural_rank)
+from scipy.sparse.csgraph import reverse_cuthill_mckee, structural_rank
 from scipy.sparse import diags, csc_matrix, csr_matrix, coo_matrix
+
 
 def test_graph_reverse_cuthill_mckee():
     A = np.array([[1, 0, 0, 0, 1, 0, 0, 0],
@@ -47,55 +47,6 @@ def test_graph_reverse_cuthill_mckee_ordering():
     correct_perm = np.array([12, 14, 4, 6, 10, 8, 2, 15,
                 0, 13, 7, 5, 9, 11, 1, 3])
     assert_equal(perm, correct_perm)
-
-
-def test_graph_maximum_bipartite_matching():
-    A = diags(np.ones(25), offsets=0, format='csc')
-    rand_perm = np.random.permutation(25)
-    rand_perm2 = np.random.permutation(25)
-
-    Rrow = np.arange(25)
-    Rcol = rand_perm
-    Rdata = np.ones(25,dtype=int)
-    Rmat = coo_matrix((Rdata,(Rrow,Rcol))).tocsc()
-
-    Crow = rand_perm2
-    Ccol = np.arange(25)
-    Cdata = np.ones(25,dtype=int)
-    Cmat = coo_matrix((Cdata,(Crow,Ccol))).tocsc()
-    # Randomly permute identity matrix
-    B = Rmat*A*Cmat
-    
-    # Row permute
-    perm = maximum_bipartite_matching(B,perm_type='row')
-    Rrow = np.arange(25)
-    Rcol = perm
-    Rdata = np.ones(25,dtype=int)
-    Rmat = coo_matrix((Rdata,(Rrow,Rcol))).tocsc()
-    C1 = Rmat*B
-    
-    # Column permute
-    perm2 = maximum_bipartite_matching(B,perm_type='column')
-    Crow = perm2
-    Ccol = np.arange(25)
-    Cdata = np.ones(25,dtype=int)
-    Cmat = coo_matrix((Cdata,(Crow,Ccol))).tocsc()
-    C2 = B*Cmat
-    
-    # Should get identity matrix back
-    assert_equal(any(C1.diagonal() == 0), False)
-    assert_equal(any(C2.diagonal() == 0), False)
-    
-    # Test int64 indices input
-    B.indices = B.indices.astype('int64')
-    B.indptr = B.indptr.astype('int64')
-    perm = maximum_bipartite_matching(B,perm_type='row')
-    Rrow = np.arange(25)
-    Rcol = perm
-    Rdata = np.ones(25,dtype=int)
-    Rmat = coo_matrix((Rdata,(Rrow,Rcol))).tocsc()
-    C3 = Rmat*B
-    assert_equal(any(C3.diagonal() == 0), False)
 
 
 def test_graph_structural_rank():


### PR DESCRIPTION
This provides a Cython implementation of the Hopcroft--Karp algorithm for solving the [maximum matching problem for bipartite graphs](https://en.wikipedia.org/wiki/Maximum_cardinality_matching).

## Context and motivation

SciPy currently implements a solver for maximum bipartite matching in `scipy.sparse.csgraph.maximum_bipartite_matching`. However, the main interest in this one appears to have been in reordering rows/columns of sparse matrices, and the function makes the assumptions that the partitions in the input graph have equal cardinality and that a perfect matching exists; as such, not much maximization is actually going on and all the algorithm does is find a feasible solution. Now, there's nothing wrong with that, but it's likely not what you might expect coming to a method called `maximum_bipartite_matching` from a graph theory context.

This PR ties in with the discussion towards the end of #10296 in which the topic was including a version of `scipy.optimize.linear_sum_assignment` that takes advantage of sparsity; although this is a separate problem, before moving to that it seemed to make more sense to deal with the more fundamental problem of finding a maximum matching. It also follows the spirit of #10566 and provides an implementation of a well-known algorithm that's easy to understand and thus hopefully maintain, with an eye towards performance so that we improve on the existing implementation for the cases where they overlap, and with large improvements over pure Python implementations such as the one in NetworkX.

The algorithm revolves around the notion of augmenting paths, which matches the approaches in `scipy.optimize.linear_sum_assignment` and the proposed `scipy.sparse.csgraph.maximum_flow`; this isn't a huge benefit in and of itself, but it does mean that being able to read one makes it easier to read the others. As such, a reviewer with a surplus of time going through this might also want to take a look at #10566.

In the process, we also fix an issue with the old documentation: Here, the main concern was permuting the rows/columns of a matrix to make its diagonal zero-free, but in case the input matrix contained explicit zeros in its sparse representation, the diagonal would in fact as well; we fix this by turning the bug into a feature and explicitly interpreting explicit zeros as edges in the bipartite graph. We keep the original motivation as an example in the xmldoc of the revised function.


## Correctness

In addition to the included unit tests, we've run checks against the corresponding function in NetworkX, checking that the cardinalities of a maximum matching agree for random inputs, e.g.:

```python
from random import randint, random
for _ in range(100):
    n = randint(100, 1000)
    m = randint(100, 1000)
    density = random()
    graph = scipy.sparse.rand(n, m, density=density, format='csr')
    G = nx.algorithms.bipartite.from_biadjacency_matrix(graph)
    assert 2 * np.sum(maximum_bipartite_matching(graph, perm_type='column') >= 0) ==\
        len(nx.algorithms.bipartite.maximum_matching(G, top_nodes=range(n)))
```

This clearly does not prove correctness in any way, but it does at least provide some confidence that it's working.


## Performance

Using the same random matrices as above we can provide a rough benchmark of our approach against the existing implementation and the one available in NetworkX. How well it performs will depend on characteristics of the input, but we do at least seem to be gaining a good amount of performance in addition to solving a much more general problem:

```python
n = 5000
density = .1
graph = scipy.sparse.rand(n, n, density=density, format='csr', random_state=42)
G = nx.algorithms.bipartite.from_biadjacency_matrix(graph)
```

```
>>> %timeit maximum_bipartite_matching(graph, perm_type='column')
8.95 ms ± 183 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
>>> %timeit old_maximum_bipartite_matching(graph, perm_type='column')
141 ms ± 8.52 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
>>> %timeit nx.algorithms.bipartite.maximum_matching(G, top_nodes=range(n))
2.01 s ± 118 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

Marking this as WIP just to get a chance to look at the CI output, including the documentation this builds.