### PR TITLE
BUG: Fixed 2 asv benchmarks

### DIFF
--- a/benchmarks/benchmarks/spatial.py
+++ b/benchmarks/benchmarks/spatial.py
@@ -110,6 +110,7 @@ class Radius(LimitedParamBenchmark):
                                                     (8,1000,30),
                                                     (16,1000,30)]
         self.time_query_ball_point.__func__.setup = self.setup_query_ball_point
+        self.time_query_ball_point_nosort.__func__.setup = self.setup_query_ball_point
         self.time_query_pairs.__func__.setup = self.setup_query_pairs
 
     def setup(self, *args):
@@ -331,4 +332,3 @@ class Hausdorff(Benchmark):
     def time_directed_hausdorff(self, num_points):
         # time directed_hausdorff code in 3 D
         distance.directed_hausdorff(self.points1, self.points2)
-

--- a/benchmarks/benchmarks/special.py
+++ b/benchmarks/benchmarks/special.py
@@ -31,7 +31,7 @@ class Airy(Benchmark):
 
 class Erf(Benchmark):
     def setup(self, *args):
-        self.rand = np.random.rand(1e5)
+        self.rand = np.random.rand(100000)
 
     def time_real(self, offset):
         erf(self.rand + offset)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### What does this implement/fix?
<!--Please explain your changes.-->
Fixes 2 `asv` tests that were no longer running.

https://pv.github.io/scipy-bench/#special.Erf.time_real
Arg to `np.random.rand` was a float rather than an int.

https://pv.github.io/scipy-bench/#spatial.Radius.time_query_ball_point_nosort
Setup was not done correctly.