### PR TITLE
DOC: fix typo in diagonal method of spmatrix base class [ci skip]

### DIFF
--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -1103,7 +1103,7 @@ class spmatrix(object):
         Parameters
         ----------
         k : int, optional
-            Which diagonal to set, corresponding to elements a[i, i+k].
+            Which diagonal to get, corresponding to elements a[i, i+k].
             Default: 0 (the main diagonal).
 
             .. versionadded:: 1.0


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
set -> get in `diagonal` method
#### Additional information
<!--Any additional information you think is important.-->