### PR TITLE
TST, MAINT: pin pytest in Travis CI for Python 3.5-dbg bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -183,6 +183,12 @@ before_install:
   - travis_retry pip install cython
   - if [ -n "$NUMPYSPEC" ]; then travis_retry pip install $NUMPYSPEC; fi
   - travis_retry pip install --upgrade pytest pytest-xdist mpmath argparse Pillow codecov
+  - |
+    if [ -n "${USE_DEBUG}" ]; then
+        # see gh-10676; need to pin pytest version with debug
+        # Python 3.5
+        travis_retry pip install pytest==5.0.1
+    fi
   - travis_retry pip install gmpy2  # speeds up mpmath (scipy.special tests)
   - travis_retry pip install pybind11
   - |


### PR DESCRIPTION
Fixes #10676 

But only if I'm lucky -- it is a bit of a guess :)

I think there was just a big pytest `5.1.0` release that removed tons of deprecations--maybe enough to cause a bit of craziness with Python 3.5 in some cases?