### PR TITLE
TST: sparse.linalg: fix arnoldi test seed

### DIFF
--- a/scipy/sparse/linalg/isolve/tests/test_gcrotmk.py
+++ b/scipy/sparse/linalg/isolve/tests/test_gcrotmk.py
@@ -59,7 +59,7 @@ class TestGCROTMK(object):
         assert_(allclose(x1, x0, rtol=1e-14))
 
     def test_arnoldi(self):
-        np.random.rand(1234)
+        np.random.seed(1)
 
         A = eye(2000) + rand(2000, 2000, density=5e-4)
         b = np.random.rand(2000)


### PR DESCRIPTION
Fix typo in test --- it should have been calling np.random.seed, not np.random.rand.