### PR TITLE
TST: special: require Mpmath 1.1.0 for `test_hyperu_around_0`

### DIFF
--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -105,7 +105,7 @@ def test_hyp0f1_gh_1609():
 # hyperu
 # ------------------------------------------------------------------------------
 
-@check_version(mpmath, '0.19')
+@check_version(mpmath, '1.1.0')
 def test_hyperu_around_0():
     dataset = []
     # DLMF 13.2.14-15 test points.


### PR DESCRIPTION
#### Reference issue

Closes gh-10683.

#### What does this implement/fix?

Version 1.0.x has an issue that causes the test to fail, so this requires at least 1.1.0 to run the test.

#### Additional information

None.
<!--Any additional information you think is important.-->