### PR TITLE
FIX: sphinx isattributedescriptor is not available in sphinx < 2.1

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -21,9 +21,9 @@ needs_sphinx = '1.6'
 # ua._Function should not be treated as an attribute
 from sphinx.util import inspect
 import scipy._lib.uarray as ua
-old_isattrdesc = inspect.isattributedescriptor
-inspect.isattributedescriptor = (lambda obj: old_isattrdesc(obj)
-                                 and not isinstance(obj, ua._Function))
+old_isdesc = inspect.isdescriptor
+inspect.isdescriptor = (lambda obj: old_isdesc(obj)
+                        and not isinstance(obj, ua._Function))
 
 # -----------------------------------------------------------------------------
 # General configuration

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -12,10 +12,10 @@ os.environ['_SCIPY_BUILDING_DOC'] = 'True'
 
 # Check Sphinx version
 import sphinx
-if sphinx.__version__ < "1.6":
-    raise RuntimeError("Sphinx 1.6 or newer required")
+if sphinx.__version__ < "2.0":
+    raise RuntimeError("Sphinx 2.0 or newer required")
 
-needs_sphinx = '1.6'
+needs_sphinx = '2.0'
 
 # Workaround for sphinx-doc/sphinx#6573
 # ua._Function should not be treated as an attribute


### PR DESCRIPTION
#### Reference issue
Fixes gh-10685 (@pvanmulbregt can you verify?)

#### What does this implement/fix?
`isattributedescriptor` was only added to `sphinx.util.inspect` in version 2.1 so I patch `isdescriptor` instead which is available in older sphinx and is used to implement `isattributedescriptor`.

I've also updated the minimum sphinx version in the config file to match the toolchain roadmap. Can revert if we don't want this to be a hard error (the roadmap does also say "Whatever recent versions work").
