### PR TITLE
DOC: special: clarify format of parameters/returns sections for ufuncs

### DIFF
--- a/doc/source/dev/core-dev/modules.rst.inc
+++ b/doc/source/dev/core-dev/modules.rst.inc
@@ -7,6 +7,8 @@ useful to be aware of while contributing.
 ``scipy.special``
 -----------------
 
+.. highlight:: none
+
 Many of the functions in ``special`` are vectorized versions of scalar
 functions. The scalar functions are written by hand and the necessary
 loops for vectorization are generated automatically. This section
@@ -22,7 +24,30 @@ write a C wrapper around the code; for examples of such wrappers see
 ``specfun_wrappers.c``.
 
 After implementing the scalar function, register the new function by
-adding a line to the ``FUNC`` string in ``generate_ufuncs.py``. The
-docstring for that file explains the format. Also add documentation
-for the new function by adding an entry to ``add_newdocs.py``; look in
-the file for examples.
+adding an entry to ``functions.json``. The docstring in
+``generate_ufuncs.py`` explains the format. Also add documentation for
+the new function by adding an entry to ``add_newdocs.py``; look in the
+file for examples.
+
+When writing the parameters section of the documentation for ufuncs,
+the type of an argument should be ``array_like``. Discussion of
+whether an argument can be e.g. real or complex-valued should be saved
+for the description. So for example, if we were to document the
+parameters for the Gamma function then it should look like this::
+
+  Parameters
+  ----------
+  z : array_like
+      Real or complex valued argument
+
+When documenting the returns section, the type of the returned value
+should be ``scalar or ndarray`` since ufuncs return scalars when given
+scalars as arguments. Also keep in mind that providing a ``name`` for
+the return value is optional, and indeed is often not helpful for
+special functions. So for the Gamma function we might have something
+like this::
+
+  Returns
+  -------
+  scalar or ndarray
+      Values of the Gamma function


### PR DESCRIPTION
#### Reference issue

Closes gh-7149.

#### What does this implement/fix?

This adds information to the `special` part of the core devdocs explaining how the `Parameters`/`Returns` sections should be formatted for ufuncs in special.

#### Additional information

This closes the above issue in the sense that it gives us a standard to adhere to going forward. It does not actually change any docstrings to use that standard (though some do already), but that is IMO better handled by a gradual process.