### PR TITLE
ENH: higher-dimensional input in `spatial.SphericalVoronoi`

### DIFF
--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -27,12 +27,12 @@ class SphericalVoronoi:
 
     Parameters
     ----------
-    points : ndarray of floats, shape (npoints, 3)
+    points : ndarray of floats, shape (npoints, ndim)
         Coordinates of points from which to construct a spherical
         Voronoi diagram.
     radius : float, optional
         Radius of the sphere (Default: 1)
-    center : ndarray of floats, shape (3,)
+    center : ndarray of floats, shape (ndim,)
         Center of sphere (Default: origin)
     threshold : float
         Threshold for detecting duplicate points and
@@ -41,13 +41,13 @@ class SphericalVoronoi:
 
     Attributes
     ----------
-    points : double array of shape (npoints, 3)
-        the points in 3D to generate the Voronoi diagram from
+    points : double array of shape (npoints, ndim)
+        the points in `ndim` dimensions to generate the Voronoi diagram from
     radius : double
         radius of the sphere
-    center : double array of shape (3,)
+    center : double array of shape (ndim,)
         center of the sphere
-    vertices : double array of shape (nvertices, 3)
+    vertices : double array of shape (nvertices, ndim)
         Voronoi vertices corresponding to points
     regions : list of list of integers of shape (npoints, _ )
         the n-th entry is a list consisting of the indices
@@ -128,8 +128,8 @@ class SphericalVoronoi:
     >>> plt.show()
 
     """
+    def __init__(self, points, radius=1, center=None, threshold=1e-06):
 
-    def __init__(self, points, radius=1, center=(0, 0, 0), threshold=1e-06):
         if radius is None:
             radius = 1.
             warnings.warn('`radius` is `None`. '
@@ -138,18 +138,20 @@ class SphericalVoronoi:
                           '(i.e. `radius=1`).',
                           DeprecationWarning)
 
-        if center is None:
-            center = (0, 0, 0)
-            warnings.warn('`center` is `None`. '
-                          'This will raise an error in a future version. '
-                          'Please provide a coordinate '
-                          '(i.e. `center=(0, 0, 0)`)',
-                          DeprecationWarning)
-
         self.points = points
         self.radius = radius
-        self.center = np.array(center)
         self.threshold = threshold
+        self._dim = len(points[0])
+        if center is None:
+            self.center = np.zeros(self._dim)
+        else:
+            self.center = np.array(center)
+
+        # test degenerate input
+        self._rank = np.linalg.matrix_rank(self.points - self.center,
+                                           tol=self.threshold * self.radius)
+        if self._rank <= 1:
+            raise ValueError("Rank of input points must be at least 2")
 
         if cKDTree(self.points).query_pairs(self.threshold * self.radius):
             raise ValueError("Duplicate generators present.")
@@ -212,37 +214,25 @@ class SphericalVoronoi:
         This algorithm was discussed at PyData London 2015 by
         Tyler Reddy, Ross Hemsley and Nikolai Nowaczyk
         """
-
-        # test degenerate input
-        self._rank = np.linalg.matrix_rank(self.points - self.center,
-                                           tol=self.threshold * self.radius)
-        if self._rank <= 1:
-            raise ValueError("Rank of input points must be at least 2")
-        elif self._rank == 2:
+        if self._dim == 3 and self._rank == 2:
             self._handle_geodesic_input()
             return
 
         # get Convex Hull
         self._tri = scipy.spatial.ConvexHull(self.points)
-
-        # triangles will have shape: (2N-4, 3, 3)
-        triangles = self._tri.points[self._tri.simplices]
-
         # get circumcenters of Convex Hull triangles from facet equations
-        # circumcenters will have shape: (2N-4, 3)
+        # for 3D input circumcenters will have shape: (2N-4, 3)
         self.vertices = self.radius * self._tri.equations[:, :-1] + self.center
-
         # calculate regions from triangulation
-        # simplex_indices will have shape: (2N-4,)
+        # for 3D input simplex_indices will have shape: (2N-4,)
         simplex_indices = np.arange(self._tri.simplices.shape[0])
-        # tri_indices will have shape: (6N-12,)
-        tri_indices = np.column_stack([simplex_indices, simplex_indices,
-            simplex_indices]).ravel()
-        # point_indices will have shape: (6N-12,)
+        # for 3D input tri_indices will have shape: (6N-12,)
+        tri_indices = np.column_stack([simplex_indices] * self._dim).ravel()
+        # for 3D input point_indices will have shape: (6N-12,)
         point_indices = self._tri.simplices.ravel()
-        # indices will have shape: (6N-12,)
+        # for 3D input indices will have shape: (6N-12,)
         indices = np.argsort(point_indices, kind='mergesort')
-        # flattened_groups will have shape: (6N-12,)
+        # for 3D input flattened_groups will have shape: (6N-12,)
         flattened_groups = tri_indices[indices].astype(np.intp)
         # intervals will have shape: (N+1,)
         intervals = np.cumsum(np.bincount(point_indices + 1))
@@ -254,6 +244,11 @@ class SphericalVoronoi:
 
     def sort_vertices_of_regions(self):
         """Sort indices of the vertices to be (counter-)clockwise ordered.
+
+        Raises
+        ------
+        TypeError
+            If the points are not three-dimensional.
 
         Notes
         -----
@@ -275,6 +270,8 @@ class SphericalVoronoi:
         generator in points and obtain a sorted version of the vertices
         of its surrounding region.
         """
+        if self._dim != 3:
+            raise TypeError("Only supported for three-dimensional point sets")
         if self._rank == 2:
             return  # regions are sorted by construction
         _voronoi.sort_vertices_of_regions(self._tri.simplices, self.regions)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### What does this implement/fix?
<!--Please explain your changes.-->
This adds support for higher-dimensional input in `spatial.SphericalVoronoi`.  ~It also adds a `circumradii` attribute, which calculates the radius of each facet.~

#### Additional information
<!--Any additional information you think is important.-->
Builds on the discussion in #10494 