### PR TITLE
BUG: ScalarFunction stores original array

### DIFF
--- a/scipy/optimize/_differentiable_functions.py
+++ b/scipy/optimize/_differentiable_functions.py
@@ -490,7 +490,7 @@ class LinearVectorFunction(object):
 
     def _update_x(self, x):
         if not np.array_equal(x, self.x):
-            self.x = x
+            self.x = np.copy(x)
             self.f_updated = False
 
     def fun(self, x):

--- a/scipy/optimize/_differentiable_functions.py
+++ b/scipy/optimize/_differentiable_functions.py
@@ -146,14 +146,14 @@ class ScalarFunction(object):
                 self.x_prev = self.x
                 self.g_prev = self.g
 
-                self.x = x
+                self.x = np.copy(x)
                 self.f_updated = False
                 self.g_updated = False
                 self.H_updated = False
                 self._update_hess()
         else:
             def update_x(x):
-                self.x = x
+                self.x = np.copy(x)
                 self.f_updated = False
                 self.g_updated = False
                 self.H_updated = False

--- a/scipy/optimize/_differentiable_functions.py
+++ b/scipy/optimize/_differentiable_functions.py
@@ -405,14 +405,14 @@ class VectorFunction(object):
                 self._update_jac()
                 self.x_prev = self.x
                 self.J_prev = self.J
-                self.x = x
+                self.x = np.copy(x)
                 self.f_updated = False
                 self.J_updated = False
                 self.H_updated = False
                 self._update_hess()
         else:
             def update_x(x):
-                self.x = x
+                self.x = np.copy(x)
                 self.f_updated = False
                 self.J_updated = False
                 self.H_updated = False

--- a/scipy/optimize/_differentiable_functions.py
+++ b/scipy/optimize/_differentiable_functions.py
@@ -146,14 +146,14 @@ class ScalarFunction(object):
                 self.x_prev = self.x
                 self.g_prev = self.g
 
-                self.x = np.copy(x)
+                self.x = np.atleast_1d(x).astype(float)
                 self.f_updated = False
                 self.g_updated = False
                 self.H_updated = False
                 self._update_hess()
         else:
             def update_x(x):
-                self.x = np.copy(x)
+                self.x = np.atleast_1d(x).astype(float)
                 self.f_updated = False
                 self.g_updated = False
                 self.H_updated = False
@@ -405,14 +405,14 @@ class VectorFunction(object):
                 self._update_jac()
                 self.x_prev = self.x
                 self.J_prev = self.J
-                self.x = np.copy(x)
+                self.x = np.atleast_1d(x).astype(float)
                 self.f_updated = False
                 self.J_updated = False
                 self.H_updated = False
                 self._update_hess()
         else:
             def update_x(x):
-                self.x = np.copy(x)
+                self.x = np.atleast_1d(x).astype(float)
                 self.f_updated = False
                 self.J_updated = False
                 self.H_updated = False
@@ -490,7 +490,7 @@ class LinearVectorFunction(object):
 
     def _update_x(self, x):
         if not np.array_equal(x, self.x):
-            self.x = np.copy(x)
+            self.x = np.atleast_1d(x).astype(float)
             self.f_updated = False
 
     def fun(self, x):


### PR DESCRIPTION
There is a bug in `optimize._differentiable_functions.ScalarFunction`, the class is storing the supplied x-array for caching purposes. However, instead of storing a copy it's storing the supplied array. This means that if the supplied array is modified in-place the `ScalarFunction` is evaluating the function incorrectly.

```
>>> from scipy.optimize._differentiable_functions import ScalarFunction
>>> def f(x):
...         return np.sum(np.asarray(x)**2)

>>> x = np.array([1., 2., 3.])
>>> sf = ScalarFunction(f, x, (), '3-point', lambda x: x, None, (-np.inf, np.inf))
>>> x is sf.x
False
>>> sf.fun(x)
14.0
>>> x is sf.x
False
>>> x[0] = 0.
>>> sf.fun(x)
13.0
>>> x is sf.x
True
>>> x[0] = 1.0
>>> sf.fun(x)     # should be 14.0
13.0
>>> sf.x is x
True
```

This PR adds the above test (in the first commit). In subsequent tests the bug in `ScalarFunction` is fixed.
