### PR TITLE
ENH: ScalarFunction.fun_and_grad

### DIFF
--- a/scipy/optimize/_differentiable_functions.py
+++ b/scipy/optimize/_differentiable_functions.py
@@ -192,6 +192,13 @@ class ScalarFunction(object):
         self._update_hess()
         return self.H
 
+    def fun_and_grad(self, x):
+        if not np.array_equal(x, self.x):
+            self._update_x_impl(x)
+        self._update_fun()
+        self._update_grad()
+        return self.f, self.g
+
 
 class VectorFunction(object):
     """Vector function and its derivatives.


### PR DESCRIPTION
This PR adds a `ScalarFunction.fun_and_grad` method, returning the function and gradient evaluation at the same time. Whilst these can be obtained separately without extra function evaluations there are some locations in `scipy.optimize` where [both have to be obtained](https://github.com/scipy/scipy/blob/master/scipy/optimize/lbfgsb.py#L279), and it would be easier to have a single call than using a wrapper to call them both.
