### PR TITLE
BUG: Check if pyx file is in directory with six module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,14 @@ matrix:
         - TESTMODE=full
         - COVERAGE="--coverage --gcov"
         - NUMPYSPEC="numpy==1.15.4"
+    - python: 3.7
+      dist: xenial # travis-ci/travis-ci/issues/9815
+      sudo: true
+      env:
+        - TESTMODE=fast
+        - NUMPYSPEC="numpy"
+      install:
+        - python setup.py install
     # Test SciPy with the debug version of Python.
     # However travis only specifies regular or development builds of Python
     # so we must install python3.5-dbg using apt.

--- a/tools/cythonize.py
+++ b/tools/cythonize.py
@@ -91,7 +91,13 @@ def process_pyx(fromfile, tofile, cwd):
 
     try:
         try:
-            r = subprocess.call(['cython'] + flags + ["-o", tofile, fromfile], cwd=cwd)
+            if os.path.exists(os.path.join(cwd, 'six.py')):
+                r = subprocess.call(['cython'] + flags +
+                                    ["-o", os.path.join(cwd, tofile),
+                                     os.path.join(cwd, fromfile)])
+            else:
+                r = subprocess.call(['cython'] + flags + ["-o", tofile, fromfile],
+                                    cwd=cwd)
             if r != 0:
                 raise Exception('Cython failed')
         except OSError:

--- a/tools/cythonize.py
+++ b/tools/cythonize.py
@@ -93,7 +93,8 @@ def process_pyx(fromfile, tofile, cwd):
         try:
             if os.path.exists(os.path.join(cwd, 'six.py')):
                 r = subprocess.call(['cython'] + flags +
-                                    ["-o", os.path.join(cwd, tofile),
+                                    ["-o",
+                                     os.path.join(cwd, tofile),
                                      os.path.join(cwd, fromfile)])
             else:
                 r = subprocess.call(['cython'] + flags + ["-o", tofile, fromfile],
@@ -105,8 +106,9 @@ def process_pyx(fromfile, tofile, cwd):
             # executable on the path, see gh-2397.
             r = subprocess.call([sys.executable, '-c',
                                  'import sys; from Cython.Compiler.Main import '
-                                 'setuptools_main as main; sys.exit(main())'] + flags +
-                                 ["-o", tofile, fromfile],
+                                 'setuptools_main as main; sys.exit(main())']
+                                + flags +
+                                ["-o", tofile, fromfile],
                                 cwd=cwd)
             if r != 0:
                 raise Exception("Cython either isn't installed or it failed.")


### PR DESCRIPTION
The `_lib` directory containes a copy of the six module that makes the
cythonization fail when cython is run there. This error appears only when building
from source with the command `python setup.py install`. As a workaround do not change the current directory to `scipy/_lib` to execute the cython command.

```

 1 > python setup.py install --user
 2 
 3 Note: if you need reliable uninstall behavior, then install
 4 with pip instead of using `setup.py install`:
 5 
 6   - `pip install .`       (from a git repo or downloaded source
 7                            release)
 8   - `pip install scipy`   (last SciPy release on PyPI)
 9 
10 
11 Cythonizing sources
12 Running scipy/linalg/_generate_pyx.py
13 Running scipy/special/_generate_pyx.py
14 Processing scipy/linalg/cython_blas.pyx
15 Processing scipy/linalg/_solve_toeplitz.pyx
16 Processing scipy/linalg/cython_lapack.pyx
17 Processing scipy/linalg/_decomp_update.pyx.in
18 Processing scipy/io/matlab/streams.pyx
19 Processing scipy/io/matlab/mio5_utils.pyx
20 Processing scipy/io/matlab/mio_utils.pyx
21 Processing scipy/special/_ufuncs.pyx
22 Processing scipy/special/_comb.pyx
23 Processing scipy/special/cython_special.pyx
24 Processing scipy/special/_test_round.pyx
25 Processing scipy/special/_ufuncs_cxx.pyx
26 Processing scipy/special/_ellip_harm_2.pyx
27 Processing scipy/signal/_max_len_seq_inner.pyx
28 Processing scipy/signal/_upfirdn_apply.pyx
29 Processing scipy/signal/_spectral.pyx
30 Processing scipy/signal/_peak_finding_utils.pyx
31 Processing scipy/cluster/_optimal_leaf_ordering.pyx
32 Processing scipy/cluster/_hierarchy.pyx
33 Processing scipy/cluster/_vq.pyx
34 Processing scipy/sparse/_csparsetools.pyx.in
35 Processing scipy/sparse/csgraph/_shortest_path.pyx
36 Processing scipy/sparse/csgraph/_reordering.pyx
37 Processing scipy/sparse/csgraph/_tools.pyx
38 Processing scipy/sparse/csgraph/_traversal.pyx
39 Processing scipy/sparse/csgraph/_min_spanning_tree.pyx
40 Processing scipy/_lib/messagestream.pyx
41 Traceback (most recent call last):
42   File "/usr/bin/cython", line 6, in <module>
43     from pkg_resources import load_entry_point
44   File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 58, in <module>
45     from six.moves import urllib, map, filter
46 ModuleNotFoundError: No module named 'six.moves'; 'six' is not a package
47 Processing scipy/_lib/_ccallback_c.pyx
48 Traceback (most recent call last):
49   File "/home/miguel/project/scipy/scipy/tools/cythonize.py", line 307, in <module>
50     main()
51   File "/home/miguel/project/scipy/scipy/tools/cythonize.py", line 303, in main
52     find_process_files(root_dir)
53   File "/home/miguel/project/scipy/scipy/tools/cythonize.py", line 292, in find_process_files
54     for result in pool.imap_unordered(lambda args: process(*args), jobs):
55   File "/usr/lib/python3.7/multiprocessing/pool.py", line 748, in next
56     raise value
57   File "/usr/lib/python3.7/multiprocessing/pool.py", line 121, in worker
58     result = (True, func(*args, **kwds))
59   File "/home/miguel/project/scipy/scipy/tools/cythonize.py", line 292, in <lambda>
60     for result in pool.imap_unordered(lambda args: process(*args), jobs):
61   File "/home/miguel/project/scipy/scipy/tools/cythonize.py", line 231, in process
62     processor_function(fromfile, tofile, cwd=path)
63   File "/home/miguel/project/scipy/scipy/tools/cythonize.py", line 96, in process_pyx
64     raise Exception('Cython failed')
65 Exception: Cython failed
66 Traceback (most recent call last):
67   File "setup.py", line 540, in <module>
68     setup_package()
69   File "setup.py", line 524, in setup_package
70     generate_cython()
71   File "setup.py", line 292, in generate_cython
72     raise RuntimeError("Running cythonize failed!")
73 RuntimeError: Running cythonize failed!
74 Traceback (most recent call last):
75   File "/usr/bin/cython", line 6, in <module>
76     from pkg_resources import load_entry_point
77   File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 58, in <module>
78     from six.moves import urllib, map, filter
79 ModuleNotFoundError: No module named 'six.moves'; 'six' is not a package
```

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->