### PR TITLE
BUG: sparse: Loosen checks on sparse fancy assignment

### DIFF
--- a/scipy/sparse/_index.py
+++ b/scipy/sparse/_index.py
@@ -120,10 +120,9 @@ class IndexMixin(object):
             # Make x and i into the same shape
             x = np.asarray(x, dtype=self.dtype)
             x, _ = _broadcast_arrays(x, i)
-            if x.shape != i.shape:
-                raise ValueError("shape mismatch in assignment")
             if x.size == 0:
                 return
+            x = x.reshape(i.shape)
             self._set_arrayXarray(i, j, x)
 
     def _validate_indices(self, key):

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2774,6 +2774,12 @@ class _TestFancyIndexing(object):
         mat = self.spmatrix(array([[1, 0], [0, 1]]))
         assert_raises(ValueError, mat.__setitem__, (0, 0), np.array([1,2]))
 
+    def test_fancy_indexing_2d_assign(self):
+        # regression test for gh-10695
+        mat = self.spmatrix(array([[1, 0], [2, 3]]))
+        mat[[0, 1], [1, 1]] = mat[[1, 0], [0, 0]]
+        assert_equal(todense(mat), array([[1, 2], [2, 1]]))
+
     def test_fancy_indexing_empty(self):
         B = asmatrix(arange(50).reshape(5,10))
         B[1,:] = 0

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2777,7 +2777,10 @@ class _TestFancyIndexing(object):
     def test_fancy_indexing_2d_assign(self):
         # regression test for gh-10695
         mat = self.spmatrix(array([[1, 0], [2, 3]]))
-        mat[[0, 1], [1, 1]] = mat[[1, 0], [0, 0]]
+        with suppress_warnings() as sup:
+            sup.filter(SparseEfficiencyWarning,
+                       "Changing the sparsity structure")
+            mat[[0, 1], [1, 1]] = mat[[1, 0], [0, 0]]
         assert_equal(todense(mat), array([[1, 2], [2, 1]]))
 
     def test_fancy_indexing_empty(self):


### PR DESCRIPTION
#### Reference issue
Fixes gh-10695.

#### What does this implement/fix?
Loosens checks on the array to set during fancy assignment on sparse matrices. See the example given in the linked issue for more details.