### PR TITLE
DOC: iprint doc lbfgsb closes #5482

### DIFF
--- a/scipy/optimize/lbfgsb.py
+++ b/scipy/optimize/lbfgsb.py
@@ -240,6 +240,16 @@ def _minimize_lbfgsb(fun, x0, args=(), jac=None, bounds=None,
         Maximum number of function evaluations.
     maxiter : int
         Maximum number of iterations.
+    iprint : int, optional
+        Controls the frequency of output. ``iprint < 0`` means no output;
+        ``iprint = 0``    print only one line at the last iteration;
+        ``0 < iprint < 99`` print also f and ``|proj g|`` every iprint iterations;
+        ``iprint = 99``   print details of every iteration except n-vectors;
+        ``iprint = 100``  print also the changes of active set and final x;
+        ``iprint > 100``  print details of every iteration including x and g.
+    callback : callable, optional
+        Called after each iteration, as ``callback(xk)``, where ``xk`` is the
+        current parameter vector.
     maxls : int, optional
         Maximum number of line search steps (per iteration). Default is 20.
 


### PR DESCRIPTION
Adds `iprint` and `callback` to the LBFGSB docstring, thereby fixing #5482