### PR TITLE
MAINT: Add direct link to doc build artifact

### DIFF
--- a/.circleci/artifact_path
+++ b/.circleci/artifact_path
@@ -1,0 +1,1 @@
+0/html-scipyorg/index.html


### PR DESCRIPTION
Closes #10706.

Should produce a direct link in the commit status once CircleCI completes.