### PR TITLE
DOC: Formatting fix  rv_continuous.expect docs

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -2490,6 +2490,7 @@ class rv_continuous(rv_generic):
         --------
 
         To understand the effect of the bounds of integration consider
+        
         >>> from scipy.stats import expon
         >>> expon(1).expect(lambda x: 1, lb=0.0, ub=2.0)
         0.6321205588285578


### PR DESCRIPTION
Due to a missing empty line between text and code, example code was being rendered as plaintext


#### What does this implement/fix?
Fixes a small documentation formatting issue

#### Additional information
<!--Any additional information you think is important.-->