### PR TITLE
DOC: silence random warning in doc build for `stats.binned_statistic_dd`

### DIFF
--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -39,7 +39,7 @@ def binned_statistic(x, values, statistic='mean',
 
           * 'mean' : compute the mean of values for points within each bin.
             Empty bins will be represented by NaN.
-          * 'std' : compute the standard deviation within each bin. This 
+          * 'std' : compute the standard deviation within each bin. This
             is implicitly calculated with ddof=0.
           * 'median' : compute the median of values for points within each
             bin. Empty bins will be represented by NaN.
@@ -215,7 +215,7 @@ def binned_statistic_2d(x, y, values, statistic='mean',
 
           * 'mean' : compute the mean of values for points within each bin.
             Empty bins will be represented by NaN.
-          * 'std' : compute the standard deviation within each bin. This 
+          * 'std' : compute the standard deviation within each bin. This
             is implicitly calculated with ddof=0.
           * 'median' : compute the median of values for points within each
             bin. Empty bins will be represented by NaN.
@@ -388,7 +388,7 @@ def binned_statistic_dd(sample, values, statistic='mean',
             referenced.
           * 'sum' : compute the sum of values for points within each bin.
             This is identical to a weighted histogram.
-          * 'std' : compute the standard deviation within each bin. This 
+          * 'std' : compute the standard deviation within each bin. This
             is implicitly calculated with ddof=0.
           * 'min' : compute the minimum of values for points within each bin.
             Empty bins will be represented by NaN.
@@ -472,7 +472,7 @@ def binned_statistic_dd(sample, values, statistic='mean',
     >>> mu = np.array([0., 1.])
     >>> sigma = np.array([[1., -0.5],[-0.5, 1.5]])
     >>> multinormal = stats.multivariate_normal(mu, sigma)
-    >>> data = multinormal.rvs(size=600)
+    >>> data = multinormal.rvs(size=600, random_state=235412)
     >>> data.shape
     (600, 2)
 
@@ -498,7 +498,8 @@ def binned_statistic_dd(sample, values, statistic='mean',
 
     >>> fig = plt.figure()
     >>> ax = fig.add_subplot(111, projection='3d')
-    >>> ax.bar3d(x, y, z, dx, dy, bincounts)
+    >>> with np.errstate(divide='ignore'):   # silence random axes3d warning
+    ...     ax.bar3d(x, y, z, dx, dy, bincounts)
 
     """
     known_stats = ['mean', 'median', 'count', 'sum', 'std','min','max']


### PR DESCRIPTION
This isn't visible in CI, it will depend on Matplotlib version and
perhaps NumPy build as well.  It doesn't affect the generated 3D figure.

The warning:
```
/home/rgommers/code/scipy/scipy/stats/_binned_statistic.py:docstring of scipy.stats.binned_statistic_dd:118: WARNING: Exception occurred in plotting scipy-stats-binned_statistic_dd-1
 from /home/rgommers/code/scipy/doc/source/generated/scipy.stats.binned_statistic_dd.rst:
Traceback (most recent call last):
  File "/home/rgommers/anaconda3/lib/python3.7/site-packages/matplotlib/sphinxext/plot_directive.py", line 515, in run_code
    exec(code, ns)
  File "<string>", line 38, in <module>
  File "/home/rgommers/anaconda3/lib/python3.7/site-packages/mpl_toolkits/mplot3d/axes3d.py", line 2558, in bar3d
    sfacecolors = self._shade_colors(facecolors, normals)
  File "/home/rgommers/anaconda3/lib/python3.7/site-packages/mpl_toolkits/mplot3d/axes3d.py", line 1765, in _shade_colors
    shade = ((normals / np.linalg.norm(normals, axis=1, keepdims=True))
RuntimeWarning: divide by zero encountered in true_divide
```

While we're at it, seed the random number drawing.