### PR TITLE
DEV: Add doc option to runtests.py

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
           command: |
             . venv/bin/activate
             export SHELL=$(which bash)
-            python -u runtests.py -g --shell -- -c 'make -C doc PYTHON=python html-scipyorg latex'
+            python -u runtests.py -g -j2 --doc html-scipyorg --doc latex
             make -C doc/build/latex all-pdf LATEXOPTS="-file-line-error -halt-on-error"
             cp -f doc/build/latex/scipy-ref.pdf doc/build/html-scipyorg/
 

--- a/doc/source/scipyoptdoc.py
+++ b/doc/source/scipyoptdoc.py
@@ -47,6 +47,7 @@ else:
 
 def setup(app):
     app.add_domain(ScipyOptimizeInterfaceDomain)
+    return {'parallel_read_safe': True}
 
 
 def _option_required_str(x):

--- a/runtests.py
+++ b/runtests.py
@@ -125,6 +125,8 @@ def main(argv):
                         help="Arguments to pass to Nose, Python or shell")
     parser.add_argument("--pep8", action="store_true", default=False,
                         help="Perform pep8 check with pycodestyle.")
+    parser.add_argument("--doc", action="append", nargs="?",
+                        const="html-scipyorg", help="Build documentation")
     args = parser.parse_args(argv)
 
     if args.pep8:
@@ -191,6 +193,14 @@ def main(argv):
         print("Spawning a Unix shell...")
         os.execv(shell, [shell] + extra_argv)
         sys.exit(1)
+
+    if args.doc:
+        cmd = ["make", "-Cdoc", 'PYTHON="{}"'.format(sys.executable)]
+        cmd += args.doc
+        if args.parallel:
+            cmd.append('SPHINXOPTS="-j{}"'.format(args.parallel))
+        subprocess.run(cmd, check=True)
+        sys.exit(0)
 
     if args.coverage:
         dst_dir = os.path.join(ROOT_DIR, 'build', 'coverage')


### PR DESCRIPTION
#### What does this implement/fix?
The documentation can now be built using `runtests.py` e.g.
```shell
python3 runtests.py -j4 --doc html --doc latex
```
will build both html and latex.

Using this ensures that the same python is used to build SciPy and to build the docs, so issues like https://github.com/scipy/scipy/pull/10687#discussion_r316897205 should never happen. The `-j` argument is also passed through to sphinx, so the docs can be built in parallel.