### PR TITLE
MAINT: get rid of gramA, gramB text files that lobpcg tests leave behind

### DIFF
--- a/scipy/sparse/linalg/eigen/lobpcg/tests/test_lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/tests/test_lobpcg.py
@@ -266,7 +266,7 @@ def test_verbosity():
     V = rand(n, m)
     X = orth(V)
     _, _ = lobpcg(A, X, B=B, tol=1e-5, maxiter=30, largest=False,
-                  verbosityLevel=11)
+                  verbosityLevel=9)
 
 
 def test_tolerance_float32():
@@ -299,6 +299,7 @@ def test_random_initial_float32():
     assert_allclose(eigvals, -np.arange(1, 1 + m), atol=1e-2)
 
 
+@pytest.mark.slow
 def test_diagonal_data_types():
     """Check lobpcg for diagonal matrices for all matrix types.
     """


### PR DESCRIPTION
Also mark a test that takes ~25 sec. as slow.  Would be nice to trim that test down.