### PR TITLE
DOC: add min_only to docstring for Dijkstra's algorithm

### DIFF
--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -396,7 +396,7 @@ def dijkstra(csgraph, directed=True, indices=None,
              bint min_only=False):
     """
     dijkstra(csgraph, directed=True, indices=None, return_predecessors=False,
-             unweighted=False, limit=np.inf)
+             unweighted=False, limit=np.inf, min_only=False)
 
     Dijkstra algorithm using Fibonacci Heaps
 


### PR DESCRIPTION
The parameter `min_only` was introduced recently but not added to the docstring for the method. As a result, it does not appear in the [built reference guide](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.csgraph.dijkstra.html); this simply adds the missing parameter.