### PR TITLE
DOC: spell out difference between source and target in shortest path algorithms

### DIFF
--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -96,7 +96,7 @@ def shortest_path(csgraph, method='auto',
         method == 'FW' and csgraph is a dense, c-ordered array with
         dtype=float64.
     indices : array_like or int, optional
-        If specified, only compute the paths for the points at the given
+        If specified, only compute the paths from the points at the given
         indices. Incompatible with method == 'FW'.
 
     Returns
@@ -131,7 +131,7 @@ def shortest_path(csgraph, method='auto',
     >>> from scipy.sparse.csgraph import shortest_path
 
     >>> graph = [
-    ... [0, 1 , 2, 0],
+    ... [0, 1, 2, 0],
     ... [0, 0, 0, 1],
     ... [2, 0, 0, 3],
     ... [0, 0, 0, 0]
@@ -414,7 +414,7 @@ def dijkstra(csgraph, directed=True, indices=None,
         algorithm can progress from point i to j or j to i along either
         csgraph[i, j] or csgraph[j, i].
     indices : array_like or int, optional
-        if specified, only compute the paths for the points at the given
+        if specified, only compute the paths from the points at the given
         indices.
     return_predecessors : bool, optional
         If True, return the size (N, N) predecesor matrix
@@ -431,9 +431,9 @@ def dijkstra(csgraph, directed=True, indices=None,
         .. versionadded:: 0.14.0
     min_only : bool, optional
         If False (default), for every node in the graph, find the shortest path
-        to every node in indices.
-        If True, for every node in the graph, find the shortest path to any of
-        the nodes in indices (which can be substantially faster).
+        from every node in indices.
+        If True, for every node in the graph, find the shortest path from any
+        of the nodes in indices (which can be substantially faster).
 
         .. versionadded:: 1.3.0
 
@@ -443,8 +443,9 @@ def dijkstra(csgraph, directed=True, indices=None,
         The matrix of distances between graph nodes. If min_only=False,
         dist_matrix has shape (n_indices, n_nodes) and dist_matrix[i, j]
         gives the shortest distance from point i to point j along the graph.
-        If min_only=True, dist_matrix has shape (n_nodes,) and contains the
-        shortest path from each node to any of the nodes in indices.
+        If min_only=True, dist_matrix has shape (n_nodes,) and contains for
+        a given node the shortest path to that node from any of the nodes
+        in indices.
     predecessors : ndarray, shape ([n_indices, ]n_nodes,)
         If min_only=False, this has shape (n_indices, n_nodes),
         otherwise it has shape (n_nodes,).
@@ -483,7 +484,7 @@ def dijkstra(csgraph, directed=True, indices=None,
     >>> from scipy.sparse.csgraph import dijkstra
 
     >>> graph = [
-    ... [0, 1 , 2, 0],
+    ... [0, 1, 2, 0],
     ... [0, 0, 0, 1],
     ... [0, 0, 0, 3],
     ... [0, 0, 0, 0]
@@ -906,9 +907,9 @@ def bellman_ford(csgraph, directed=True, indices=None,
 
     Compute the shortest path lengths using the Bellman-Ford algorithm.
 
-    The Bellman-ford algorithm can robustly deal with graphs with negative
+    The Bellman-Ford algorithm can robustly deal with graphs with negative
     weights.  If a negative cycle is detected, an error is raised.  For
-    graphs without negative edge weights, dijkstra's algorithm may be faster.
+    graphs without negative edge weights, Dijkstra's algorithm may be faster.
 
     .. versionadded:: 0.11.0
 
@@ -923,7 +924,7 @@ def bellman_ford(csgraph, directed=True, indices=None,
         algorithm can progress from point i to j along csgraph[i, j] or
         csgraph[j, i]
     indices : array_like or int, optional
-        if specified, only compute the paths for the points at the given
+        if specified, only compute the paths from the points at the given
         indices.
     return_predecessors : bool, optional
         If True, return the size (N, N) predecesor matrix
@@ -964,7 +965,7 @@ def bellman_ford(csgraph, directed=True, indices=None,
     >>> from scipy.sparse.csgraph import bellman_ford
 
     >>> graph = [
-    ... [0, 1 , 2, 0],
+    ... [0, 1 ,2, 0],
     ... [0, 0, 0, 1],
     ... [2, 0, 0, 3],
     ... [0, 0, 0, 0]
@@ -1142,7 +1143,7 @@ def johnson(csgraph, directed=True, indices=None,
     algorithm to quickly find shortest paths in a way that is robust to
     the presence of negative cycles.  If a negative cycle is detected,
     an error is raised.  For graphs without negative edge weights,
-    dijkstra() may be faster.
+    dijkstra may be faster.
 
     .. versionadded:: 0.11.0
 
@@ -1157,7 +1158,7 @@ def johnson(csgraph, directed=True, indices=None,
         algorithm can progress from point i to j along csgraph[i, j] or
         csgraph[j, i]
     indices : array_like or int, optional
-        if specified, only compute the paths for the points at the given
+        if specified, only compute the paths from the points at the given
         indices.
     return_predecessors : bool, optional
         If True, return the size (N, N) predecesor matrix
@@ -1198,7 +1199,7 @@ def johnson(csgraph, directed=True, indices=None,
     >>> from scipy.sparse.csgraph import johnson
 
     >>> graph = [
-    ... [0, 1 , 2, 0],
+    ... [0, 1, 2, 0],
     ... [0, 0, 0, 1],
     ... [2, 0, 0, 3],
     ... [0, 0, 0, 0]


### PR DESCRIPTION
The existing documentation would either not make it clear what vertices are considered sources, and which are targets, or it would be inconsistent and swap the roles of sources and targets (cf. https://github.com/scipy/scipy/issues/10733). This streamlines the documentation accordingly.

In the process, we also remove a few redundant spaces, and improve formatting slightly.

#### Reference issue
Closes #10733.