### PR TITLE
Fix for Python 4

### DIFF
--- a/scipy/_lib/six.py
+++ b/scipy/_lib/six.py
@@ -27,7 +27,8 @@ __author__ = "Benjamin Peterson <benjamin@python.org>"
 __version__ = "1.2.0"
 
 
-# True if we are running on Python 3.
+# Useful for very coarse version differentiation.
+PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
 
 if PY3:

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -27,7 +27,7 @@ from ._arraytools import axis_slice, axis_reverse, odd_ext, even_ext, const_ext
 from .filter_design import cheby1, _validate_sos
 from .fir_filter_design import firwin
 
-if sys.version_info.major >= 3 and sys.version_info.minor >= 5:
+if sys.version_info >= (3, 5):
     from math import gcd
 else:
     from fractions import gcd

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -29,7 +29,7 @@ from scipy.signal.windows import hann
 from scipy.signal.signaltools import _filtfilt_gust
 
 
-if sys.version_info.major >= 3 and sys.version_info.minor >= 5:
+if sys.version_info >= (3, 5):
     from math import gcd
 else:
     from fractions import gcd

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -4,7 +4,7 @@
 #
 from __future__ import division, print_function, absolute_import
 
-from scipy._lib.six import string_types, exec_, PY3
+from scipy._lib.six import string_types, exec_, PY2
 from scipy._lib._util import getargspec_no_self as _getargspec
 
 import sys
@@ -37,11 +37,11 @@ import numpy as np
 
 from ._constants import _XMAX
 
-if PY3:
+if PY2:
+    instancemethod = types.MethodType
+else:
     def instancemethod(func, obj, cls):
         return types.MethodType(func, obj)
-else:
-    instancemethod = types.MethodType
 
 
 # These are the docstring parts used for substitution in specific

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -165,7 +165,7 @@ from __future__ import division, print_function, absolute_import
 import warnings
 import sys
 import math
-if sys.version_info.major >= 3 and sys.version_info.minor >= 5:
+if sys.version_info >= (3, 5):
     from math import gcd
 else:
     from fractions import gcd

--- a/tools/authors.py
+++ b/tools/authors.py
@@ -21,15 +21,15 @@ import io
 import subprocess
 
 try:
-    from scipy._lib.six import PY3
+    from scipy._lib.six import PY2
 except ImportError:
     sys.path.insert(0, os.path.join(os.path.dirname(__file__),
                                     os.pardir, 'scipy', 'lib'))
-    from six import PY3
-if PY3:
-    stdout_b = sys.stdout.buffer
-else:
+    from six import PY2
+if PY2:
     stdout_b = sys.stdout
+else:
+    stdout_b = sys.stdout.buffer
 
 
 MAILMAP_FILE = os.path.join(os.path.dirname(__file__), "..", ".mailmap")


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

We don't yet know if 3.10 or 4.0 will follow Python 3.9, but whichever it is, it will probably happen in [2020 when Python 3.9 reaches beta](https://www.python.org/dev/peps/pep-0596/#schedule).

There's some code which checks the Python major version is exactly 3, similar to this:

```python
if sys.version_info[0] == 3:
    # Python 3+ code
else:
    # Python 2 code
```

When run on Python 4, it will run the Python 2 code! Instead:

```python
if sys.version_info[0] == 2:
    # Python 2 code
else:
    # Python 3+ code
```

This PR re-adds `PY2` from upstream `six.py`, and uses that instead of `PY3`.

#### Additional information

Found using https://github.com/asottile/flake8-2020:
```console
$ pip install -U flake8-2020
...
$ flake8 --select YTT
./tools/authors.py:29:4: YTT202: `six.PY3` referenced (python4), use `not six.PY2`
./scipy/_lib/six.py:31:7: YTT201: `sys.version_info[0] == 3` referenced (python4), use `>=`
```
