### PR TITLE
BUG: optimize/slsqp: deal with singular BFGS update

### DIFF
--- a/scipy/optimize/slsqp/slsqp_optmz.f
+++ b/scipy/optimize/slsqp/slsqp_optmz.f
@@ -970,7 +970,7 @@ C  TRANSFORM G AND H TO GET LEAST DISTANCE PROBLEM
       mode=5
       DO 30 i=1,mg
           DO 20 j=1,n
-              IF (ABS(e(j,j)).LT.epmach) GOTO 50
+              IF (.NOT.(ABS(e(j,j)).GE.epmach)) GOTO 50
    20         g(i,j)=(g(i,j)-ddot_sl(j-1,g(i,1),lg,e(1,j),1))/e(j,j)
    30     h(i)=h(i)-ddot_sl(n,g(i,1),lg,f,1)
 
@@ -1074,7 +1074,7 @@ C  SOLVE DUAL PROBLEM
 C  COMPUTE SOLUTION OF PRIMAL PROBLEM
 
       fac=one-ddot_sl(m,h,1,w(iy),1)
-      IF(diff(one+fac,one).LE.ZERO) GOTO 50
+      IF(.NOT.(diff(one+fac,one).GT.ZERO)) GOTO 50
       mode=1
       fac=one/fac
       DO 40 j=1,n

--- a/scipy/optimize/slsqp/slsqp_optmz.f
+++ b/scipy/optimize/slsqp/slsqp_optmz.f
@@ -562,6 +562,15 @@ C   L*D*L'*S
           CALL dscal_sl(n, h4, u, 1)
           CALL daxpy_sl(n, one-h4, v, 1, u, 1)
       ENDIF
+      IF (h1.EQ.0 .or. h2.EQ.0) THEN
+C         Singular update: reset hessian.  The code jumps to 255 if too
+C         many resets are encountered, expecting h3 to store current
+C         constraint violation. But h3 has been overwritten at this
+C         point, so set it to nan to avoid spurious exit.
+          h3 = 0d0
+          h3 = 1/h3
+          GO TO 110
+      end if
       CALL ldl(n, l, u, +one/h1, v)
       CALL ldl(n, l, v, -one/h2, u)
 

--- a/scipy/optimize/slsqp/slsqp_optmz.f
+++ b/scipy/optimize/slsqp/slsqp_optmz.f
@@ -503,6 +503,15 @@ C   CHECK CONVERGENCE
 C   CHECK relaxed CONVERGENCE in case of positive directional derivative
 
   255 CONTINUE
+      h3 = ZERO
+      DO 256 j=1,m
+         IF (j.LE.meq) THEN
+             h1 = c(j)
+         ELSE
+             h1 = ZERO
+         ENDIF
+         h3 = h3 + MAX(-c(j),h1)
+  256 CONTINUE
       IF ((ABS(f-f0).LT.tol .OR. dnrm2_(n,s,1).LT.tol) .AND. h3.LT.tol
      *     .AND. .NOT. badlin)
      *   THEN
@@ -563,12 +572,7 @@ C   L*D*L'*S
           CALL daxpy_sl(n, one-h4, v, 1, u, 1)
       ENDIF
       IF (h1.EQ.0 .or. h2.EQ.0) THEN
-C         Singular update: reset hessian.  The code jumps to 255 if too
-C         many resets are encountered, expecting h3 to store current
-C         constraint violation. But h3 has been overwritten at this
-C         point, so set it to nan to avoid spurious exit.
-          h3 = 0d0
-          h3 = 1/h3
+C         Singular update: reset hessian.
           GO TO 110
       end if
       CALL ldl(n, l, u, +one/h1, v)

--- a/scipy/optimize/tests/test_slsqp.py
+++ b/scipy/optimize/tests/test_slsqp.py
@@ -535,3 +535,17 @@ class TestSLSQP(object):
         np.testing.assert_allclose(res.fun, 0.5443310539518)
         np.testing.assert_allclose(res.x, [0.33333333, 0.2962963])
         assert res.success
+
+    def test_gh9640(self):
+        np.random.seed(10)
+        cons = ({'type': 'ineq', 'fun': lambda x: -x[0] - x[1] - 3},
+                {'type': 'ineq', 'fun': lambda x: x[1] + x[2] - 2})
+        bnds = ((-2, 2), (-2, 2), (-2, 2))
+
+        target = lambda x: 1
+        x0 = [-1.8869783504471584, -0.640096352696244, -0.8174212253407696]
+        res = minimize(target, x0, method='SLSQP', bounds=bnds, constraints=cons,
+                       options={'disp':False, 'maxiter':10000})
+
+        # The problem is infeasible, so it cannot succeed
+        assert not res.success


### PR DESCRIPTION
#### Reference issue
Closes: gh-9640

#### What does this implement/fix?

SLSQP can run to singular BFGS updates, which it doesn't handle, and may exit with nan outputs and successful exit code. To avoid this, do the most trivial thing and just reset the matrix. This might not lead to convergence, but gets rid of false successful exits.

Also fix suspicious convergence check in the case where SLSQP exits due to too many bfgs resets when encountering positive directional derivative. This looks like a bug where it was forgotten that after gotoing to label `255` the variable `h3` does not contain the constraint violation, because the associated initialization code of the basic convergence check (at label `240`) is skipped.

Moreover, fix SLSQP linalg function behavior when encountering nans. The fix is simply rewriting positivity guard `if (x <= 0)` as `if (.not.(x > 0))` to guard also against x nan.

The linalg changes are no-ops if there are no nans, and with nans generally give error exits. The BFGS update tweak is only triggered in cases where the code previously divided by zero. The SLSQP exit-on-too-many-resets check is also a corner case. So there should be no impact in non-problematic cases.

### Additional information
With this change, the code in the original message in gh-9640 returns
```
the value of constraint function 0 is -0.12032366628974467
the value of constraint function 1 is -0.8796763337102553
     fun: 1.0
     jac: array([0., 0., 0.])
 message: 'Positive directional derivative for linesearch'
    nfev: 140
     nit: 13
    njev: 12
  status: 8
 success: False
       x: array([-2.        , -0.87967633,  2.        ])
```