### PR TITLE
ENH: special: add a real dispatch for `wrightomega`

### DIFF
--- a/scipy/special/_precompute/wrightomega.py
+++ b/scipy/special/_precompute/wrightomega.py
@@ -19,11 +19,25 @@ def wrightomega_series_error(x):
     return abs(series - desired) / desired
 
 
+def wrightomega_exp_error(x):
+    exponential_approx = mpmath.exp(x)
+    desired = mpmath_wrightomega(x)
+    return abs(exponential_approx - desired) / desired
+
+
 def main():
     desired_error = 2 * np.finfo(float).eps
+    print('Series Error')
     for x in [1e5, 1e10, 1e15, 1e20]:
-        error = wrightomega_series_error(x)
-        print(error, error < desired_error)
+        with mpmath.workdps(100):
+            error = wrightomega_series_error(x)
+        print(x, error, error < desired_error)
+
+    print('Exp error')
+    for x in [-10, -25, -50, -100, -200, -400, -700, -740]:
+        with mpmath.workdps(100):
+            error = wrightomega_exp_error(x)
+        print(x, error, error < desired_error)
 
 
 if __name__ == '__main__':

--- a/scipy/special/_precompute/wrightomega.py
+++ b/scipy/special/_precompute/wrightomega.py
@@ -14,8 +14,7 @@ def mpmath_wrightomega(x):
 
 
 def wrightomega_series_error(x):
-    w = mpmath.log(x)
-    series = x + w - w / x
+    series = x
     desired = mpmath_wrightomega(x)
     return abs(series - desired) / desired
 

--- a/scipy/special/_precompute/wrightomega.py
+++ b/scipy/special/_precompute/wrightomega.py
@@ -1,0 +1,31 @@
+from __future__ import division, print_function, absolute_import
+
+import numpy as np
+
+try:
+    import mpmath
+    import matplotlib.pyplot as plt
+except ImportError:
+    pass
+
+
+def mpmath_wrightomega(x):
+    return mpmath.lambertw(mpmath.exp(x), mpmath.mpf('-0.5'))
+
+
+def wrightomega_series_error(x):
+    w = mpmath.log(x)
+    series = x + w - w / x
+    desired = mpmath_wrightomega(x)
+    return abs(series - desired) / desired
+
+
+def main():
+    desired_error = 2 * np.finfo(float).eps
+    for x in [1e5, 1e10, 1e15, 1e20]:
+        error = wrightomega_series_error(x)
+        print(error, error < desired_error)
+
+
+if __name__ == '__main__':
+    main()

--- a/scipy/special/_wright.cxx
+++ b/scipy/special/_wright.cxx
@@ -13,4 +13,9 @@ npy_cdouble wrightomega(npy_cdouble zp)
     return npy_cpack(real(w), imag(w));
 }
 
+double wrightomega_real(double x)
+{
+  return wright::wrightomega_real(x);
+}
+
 EXTERN_C_END

--- a/scipy/special/_wright.h
+++ b/scipy/special/_wright.h
@@ -19,6 +19,7 @@ EXTERN_C_START
 #include <numpy/npy_math.h>
 
 npy_cdouble wrightomega(npy_cdouble zp);
+double wrightomega_real(double x);
 
 EXTERN_C_END
 

--- a/scipy/special/functions.json
+++ b/scipy/special/functions.json
@@ -1340,7 +1340,8 @@
     },
     "wrightomega": {
         "_wright.h++": {
-            "wrightomega": "D->D"
+            "wrightomega": "D->D",
+            "wrightomega_real": "d->d"
         }
     },
     "xlog1py": {

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -1860,7 +1860,8 @@ class TestSystematic(object):
             sc.wrightomega,
             mpmath_wrightomega_real,
             [Arg()],
-            rtol=1e-14,
+            rtol=1e-15,
+            atol=0,
             nan_ok=False,
         )
 

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -1856,11 +1856,14 @@ class TestSystematic(object):
         def mpmath_wrightomega_real(x):
             return mpmath.lambertw(mpmath.exp(x), mpmath.mpf('-0.5'))
 
+        # For x < -1000 the Wright Omega function is just 0 to double
+        # precision, and for x > 1e21 it is just x to double
+        # precision.
         assert_mpmath_equal(
             sc.wrightomega,
             mpmath_wrightomega_real,
-            [Arg()],
-            rtol=1e-15,
+            [Arg(-1000, 1e21)],
+            rtol=5e-15,
             atol=0,
             nan_ok=False,
         )

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -1852,6 +1852,18 @@ class TestSystematic(object):
                             rtol=5e-10,
                             ignore_inf_sign=True)
 
+    def test_wrightomega_real(self):
+        def mpmath_wrightomega_real(x):
+            return mpmath.lambertw(mpmath.exp(x), mpmath.mpf('-0.5'))
+
+        assert_mpmath_equal(
+            sc.wrightomega,
+            mpmath_wrightomega_real,
+            [Arg()],
+            rtol=1e-14,
+            nan_ok=False,
+        )
+
     def test_wrightomega(self):
         assert_mpmath_equal(sc.wrightomega,
                             lambda z: _mpmath_wrightomega(z, 25),

--- a/scipy/special/tests/test_wrightomega.py
+++ b/scipy/special/tests/test_wrightomega.py
@@ -90,6 +90,28 @@ def test_wrightomega_real_series_crossover():
     )
 
 
+def test_wrightomega_exp_approximation_crossover():
+    desired_error = 2 * np.finfo(float).eps
+    crossover = -50
+    x_before_crossover = np.nextafter(crossover, np.inf)
+    x_after_crossover = np.nextafter(crossover, -np.inf)
+    # Computed using Mpmath
+    desired_before_crossover = 1.9287498479639314876e-22
+    desired_after_crossover = 1.9287498479639040784e-22
+    assert_allclose(
+        sc.wrightomega(x_before_crossover),
+        desired_before_crossover,
+        atol=0,
+        rtol=desired_error,
+    )
+    assert_allclose(
+        sc.wrightomega(x_after_crossover),
+        desired_after_crossover,
+        atol=0,
+        rtol=desired_error,
+    )
+
+
 def test_wrightomega_real_versus_complex():
     x = np.linspace(-500, 500, 1001)
     assert_allclose(

--- a/scipy/special/tests/test_wrightomega.py
+++ b/scipy/special/tests/test_wrightomega.py
@@ -5,6 +5,7 @@ import numpy as np
 from numpy.testing import assert_, assert_equal, assert_allclose
 
 import scipy.special as sc
+from scipy.special._testutils import assert_func_equal
 
 
 def test_wrightomega_nan():
@@ -114,9 +115,5 @@ def test_wrightomega_exp_approximation_crossover():
 
 def test_wrightomega_real_versus_complex():
     x = np.linspace(-500, 500, 1001)
-    assert_allclose(
-        sc.wrightomega(x),
-        sc.wrightomega(x + 0j).real,
-        atol=0,
-        rtol=1e-14,
-    )
+    results = sc.wrightomega(x + 0j).real
+    assert_func_equal(sc.wrightomega, results, x, atol=0, rtol=1e-15)

--- a/scipy/special/tests/test_wrightomega.py
+++ b/scipy/special/tests/test_wrightomega.py
@@ -113,7 +113,11 @@ def test_wrightomega_exp_approximation_crossover():
     )
 
 
+@pytest.mark.xfail(
+    run=False,
+    reason='Fails for old versions of gcc (< 6.5)'
+)
 def test_wrightomega_real_versus_complex():
     x = np.linspace(-500, 500, 1001)
     results = sc.wrightomega(x + 0j).real
-    assert_func_equal(sc.wrightomega, results, x, atol=0, rtol=1e-15)
+    assert_func_equal(sc.wrightomega, results, x, atol=0, rtol=1e-14)

--- a/scipy/special/tests/test_wrightomega.py
+++ b/scipy/special/tests/test_wrightomega.py
@@ -113,10 +113,6 @@ def test_wrightomega_exp_approximation_crossover():
     )
 
 
-@pytest.mark.xfail(
-    run=False,
-    reason='Fails for old versions of gcc (< 6.5)'
-)
 def test_wrightomega_real_versus_complex():
     x = np.linspace(-500, 500, 1001)
     results = sc.wrightomega(x + 0j).real

--- a/scipy/special/wright.cc
+++ b/scipy/special/wright.cc
@@ -103,7 +103,7 @@ wright::wrightomega_ext(complex<double> z, complex<double> *w,
   /* extract real and imaginary parts of z */
   x=real(z);
   y=imag(z);
-  
+
   /* compute if we are near the branch cuts */
   ympi=y-pi;
   yppi=y+pi;
@@ -292,35 +292,35 @@ wright::wrightomega_ext(complex<double> z, complex<double> *w,
   /**********************************/
   /* Regularize if near branch cuts */
   /**********************************/
-  if (x <= -0.1e1 + near && (fabs(ympi) <= near || fabs(yppi) <= near)) 
-    { 
+  if (x <= -0.1e1 + near && (fabs(ympi) <= near || fabs(yppi) <= near))
+    {
       s = -1.0;
       if (fabs(ympi) <= near)
         {
           /* Recompute ympi with directed rounding */
           ympi = add_round_up(y, -pi);
-          
+
           if( ympi <= 0.0)
             {
               ympi = add_round_down(y, -pi);
             }
-          
+
           z = x + I*ympi;
         }
       else
         {
           /* Recompute yppi with directed rounding */
           yppi = add_round_up(y, pi);
-          
+
           if( yppi <= 0.0)
             {
               yppi = add_round_down(y, pi);
             }
-          
+
           z = x + I*yppi;
         }
     }
-  
+
   /*****************/
   /* Iteration one */
   /*****************/
@@ -329,7 +329,7 @@ wright::wrightomega_ext(complex<double> z, complex<double> *w,
   wp1=s**w+1.0;
   e=r/wp1*(2.0*wp1*(wp1+2.0/3.0*r)-r)/(2.0*wp1*(wp1+2.0/3.0*r)-2.0*r);
   *w=*w*(1.0+e);
-  
+
   /*****************/
   /* Iteration two */
   /*****************/
@@ -353,7 +353,7 @@ wright::wrightomega_ext(complex<double> z, complex<double> *w,
     {
       *cond = z/(1.0+*w);
     }
-      
+
   return 0;
 }
 
@@ -362,5 +362,76 @@ wright::wrightomega(complex<double> z)
 {
   complex<double> w;
   wrightomega_ext(z,&w,NULL);
+  return w;
+}
+
+
+double
+wright::wrightomega_real(double x)
+{
+  double w, wp1, e, r;
+
+  /* NaN output for NaN input  */
+  if (sc_isnan(x))
+    {
+      return x;
+    }
+
+  /* Positive infinity is asymptotically x */
+  /* Negative infinity is zero */
+  if (sc_isinf(x))
+    {
+      if (x > 0.0)
+	{
+	  return x;
+	}
+      else
+	{
+	  return 0.0;
+	}
+    }
+
+  /* Split int three distinct intervals (-inf,-2), [-2,1), [1,inf) */
+  if (x < -2.0)
+    {
+      /* exponential is approx < 1.3e-1 accurate */
+      w = exp(x);
+      if (w == 0.0)
+        {
+          /* Skip the iterative scheme because it computes log(w) */
+          sf_error("wrightomega", SF_ERROR_UNDERFLOW, "underflow in exponential series");
+          return w;
+        }
+    }
+  else if (x < 1)
+    {
+      /* on [-2,1) approx < 1.5e-1 accurate */
+      w = exp(2.0*(x-1.0)/3.0);
+    }
+  else
+    {
+      /* infinite series with 2 terms approx <1.7e-1 accurate */
+      w = log(x);
+      w = x - w + w/x;
+      if (x > 1e20) {
+	return w;
+      }
+    }
+
+  /* Iteration one of Fritsch, Shafer, and Crowley (FSC) iteration */
+  r = x - w - log(w);
+  wp1 = w + 1.0;
+  e = r/wp1*(2.0*wp1*(wp1+2.0/3.0*r)-r)/(2.0*wp1*(wp1+2.0/3.0*r)-2.0*r);
+  w = w*(1.0+e);
+
+  /* Iteration two (if needed based on the condition number) */
+  if (abs((2.0*w*w-8.0*w-1.0)*pow(abs(r),4.0)) >= TWOITERTOL*72.0*pow(abs(wp1),6.0))
+    {
+      r = x - w - log(w);
+      wp1 = w+1.0;
+      e = r/wp1*(2.0*wp1*(wp1+2.0/3.0*r)-r)/(2.0*wp1*(wp1+2.0/3.0*r)-2.0*r);
+      w = w*(1.0+e);
+    }
+
   return w;
 }

--- a/scipy/special/wright.cc
+++ b/scipy/special/wright.cc
@@ -391,30 +391,38 @@ wright::wrightomega_real(double x)
 	}
     }
 
-  /* Split int three distinct intervals (-inf,-2), [-2,1), [1,inf) */
-  if (x < -2.0)
+  if (x < -50.0)
     {
-      /* exponential is approx < 1.3e-1 accurate */
+      /*
+       * Skip the iterative scheme because it exp(x) is already
+       * accurate to double precision.
+       */
       w = exp(x);
       if (w == 0.0)
         {
-          /* Skip the iterative scheme because it computes log(w) */
           sf_error("wrightomega", SF_ERROR_UNDERFLOW, "underflow in exponential series");
-          return w;
         }
+      return w;
     }
-  else if (x < 1)
-    {
-      /* on [-2,1) approx < 1.5e-1 accurate */
-      w = exp(2.0*(x-1.0)/3.0);
-    }
-  else if (x > 1e20)
+  if (x > 1e20)
     {
       /*
        * Skip the iterative scheme because the result is just x to
        * double precision
        */
       return x;
+    }
+
+  /* Split int three distinct intervals (-inf,-2), [-2,1), [1,inf) */
+  if (x < -2.0)
+    {
+      /* exponential is approx < 1.3e-1 accurate */
+      w = exp(x);
+    }
+  else if (x < 1)
+    {
+      /* on [-2,1) approx < 1.5e-1 accurate */
+      w = exp(2.0*(x-1.0)/3.0);
     }
   else
     {

--- a/scipy/special/wright.cc
+++ b/scipy/special/wright.cc
@@ -408,14 +408,19 @@ wright::wrightomega_real(double x)
       /* on [-2,1) approx < 1.5e-1 accurate */
       w = exp(2.0*(x-1.0)/3.0);
     }
+  else if (x > 1e20)
+    {
+      /*
+       * Skip the iterative scheme because the result is just x to
+       * double precision
+       */
+      return x;
+    }
   else
     {
       /* infinite series with 2 terms approx <1.7e-1 accurate */
       w = log(x);
       w = x - w + w/x;
-      if (x > 1e20) {
-	return w;
-      }
     }
 
   /* Iteration one of Fritsch, Shafer, and Crowley (FSC) iteration */

--- a/scipy/special/wright.cc
+++ b/scipy/special/wright.cc
@@ -438,7 +438,7 @@ wright::wrightomega_real(double x)
   w = w*(1.0+e);
 
   /* Iteration two (if needed based on the condition number) */
-  if (abs((2.0*w*w-8.0*w-1.0)*pow(abs(r),4.0)) >= TWOITERTOL*72.0*pow(abs(wp1),6.0))
+  if (fabs((2.0*w*w-8.0*w-1.0)*pow(fabs(r),4.0)) >= TWOITERTOL*72.0*pow(fabs(wp1),6.0))
     {
       r = x - w - log(w);
       wp1 = w+1.0;

--- a/scipy/special/wright.hh
+++ b/scipy/special/wright.hh
@@ -8,7 +8,8 @@ namespace wright {
 int wrightomega_ext(std::complex<double> z, std::complex<double> *w,
 		    std::complex<double> *cond);
 std::complex<double> wrightomega(std::complex<double> z);
+double wrightomega_real(double x);
 
 };
-  
+
 #endif /* wright.hh */


### PR DESCRIPTION
#### Reference issue

Closes gh-10596.

#### What does this implement/fix?

A real dispatch is added to `special.wrightomega`.

#### Additional information

This is the algorithm provided by @pierslawrence in gh-10596 with one modification.

For very large `x` the FSC iteration can overflow causing NaN to be returned. For those large values, however, the initial guess of `x - log(x) + log(x) / x` is already sufficiently accurate, so we can just return the initial guess. A bit of experimenting (see `_precompute/wrightomega.py`) shows that a crossover of `x = 1e20` works fine. @pierslawrence what do you think?