### PR TITLE
MAINT: make cython code more precise

### DIFF
--- a/scipy/linalg/_decomp_update.pyx.in
+++ b/scipy/linalg/_decomp_update.pyx.in
@@ -1207,7 +1207,7 @@ cdef form_qTu(cnp.ndarray q, cnp.ndarray u, void* qTuvoid, int* qTus,
     cdef void* uvoid
     cdef int qs[2]
     cdef int us[2]
-    cdef int ldu
+    cdef int ldu, p
 
     if cnp.PyArray_CHKFLAGS(q, cnp.NPY_F_CONTIGUOUS):
         qvoid = extract(q, qs)

--- a/scipy/ndimage/src/_ni_label.pyx
+++ b/scipy/ndimage/src/_ni_label.pyx
@@ -271,7 +271,7 @@ cpdef _label(np.ndarray input,
 
     # we only process this many neighbors from the itstruct iterator before
     # reaching the center, where we stop
-    num_neighbors = (structure.size / 3) // 2
+    num_neighbors = (structure.size // 3) // 2
 
     # Create two buffer arrays for reading/writing labels.
     # Add an entry at the end and beginning to simplify some bounds checks.

--- a/scipy/ndimage/src/_ni_label.pyx
+++ b/scipy/ndimage/src/_ni_label.pyx
@@ -271,7 +271,7 @@ cpdef _label(np.ndarray input,
 
     # we only process this many neighbors from the itstruct iterator before
     # reaching the center, where we stop
-    num_neighbors = (structure.size // 3) // 2
+    num_neighbors = structure.size // (3 * 2)
 
     # Create two buffer arrays for reading/writing labels.
     # Add an entry at the end and beginning to simplify some bounds checks.


### PR DESCRIPTION
A new version of cython will automatically convert expressions like `arr.size` and `ndarray.shape[0]` from a python attribute lookup to pure-C `PyArray_Size(arr)` and `PyArray_DIMS(arr)[0]`. This will make such code faster and will enable NumPy to eventually make the ndarray structure opaque.

In preparation for that, I tried building scipy with https://github.com/cython/cython/pull/3115. It uncovered these implicit conversions to `int` that must now be made explicitly.