### PR TITLE
TST Avoid assert_allclose(.., atol=0) when comparing against 0

### DIFF
--- a/scipy/sparse/linalg/isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/isolve/tests/test_iterative.py
@@ -437,7 +437,7 @@ def test_zero_rhs(solver):
             if solver is not minres:
                 x, info = solver(A, b, tol=tol, atol=0, x0=ones(10))
                 if info == 0:
-                    assert_allclose(x, 0)
+                    assert_allclose(x, 0, atol=1e-100)
 
                 x, info = solver(A, b, tol=tol, atol=tol)
                 assert_equal(info, 0)


### PR DESCRIPTION
Avoid `assert_allclose(.., atol=0)` when comparing against 0 in `test_zero_rhs[lgmres]`.

Fixes of the test failures with BLIS reported in https://github.com/scipy/scipy/issues/10744 

The failure was,
```
    def test_zero_rhs(solver):
[...]
>                       assert_allclose(x, 0)
E                       AssertionError: 
E                       Not equal to tolerance rtol=1e-07, atol=0
E                       
E                       Mismatch: 100%
E                       Max absolute difference: 1.19386456e-164
E                       Max relative difference: inf
E                        x: array([ 5.155324e-165,  7.054654e-165,  4.341326e-165, -1.193865e-164,
E                              -2.713329e-165, -7.597320e-165, -5.426657e-166, -4.341326e-165,
E                               3.255994e-165, -8.682651e-165])
E                        y: array(0)
```