### PR TITLE
MAINT: lbfgsb func_and_grad should use copy

### DIFF
--- a/scipy/optimize/lbfgsb.py
+++ b/scipy/optimize/lbfgsb.py
@@ -342,7 +342,8 @@ def _minimize_lbfgsb(fun, x0, args=(), jac=None, bounds=None,
             # Note that interruptions due to maxfun are postponed
             # until the completion of the current minimization iteration.
             # Overwrite f and g:
-            f, g = func_and_grad(x)
+            # we provide a copy because x is modified in-place by setulb
+            f, g = func_and_grad(np.copy(x))
         elif task_str.startswith(b'NEW_X'):
             # new iteration
             n_iterations += 1

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -70,7 +70,7 @@ class CheckOptimize(object):
         log_pdot = np.dot(self.F, x)
         logZ = np.log(sum(np.exp(log_pdot)))
         f = logZ - np.dot(self.K, x)
-        self.trace.append(x)
+        self.trace.append(np.copy(x))
         return f
 
     def grad(self, x):
@@ -561,12 +561,6 @@ class TestOptimizeSimple(CheckOptimize):
         # SciPy 0.7.0. Don't allow them to increase.
         assert_(self.funccalls == 7, self.funccalls)
         assert_(self.gradcalls == 5, self.gradcalls)
-
-        # Ensure that the function behaves the same; this is from SciPy 0.7.0
-        assert_allclose(self.trace[3:5],
-                        [[0., -0.52489628, 0.48753042],
-                         [0., -0.52489628, 0.48753042]],
-                        atol=1e-14, rtol=1e-7)
 
     def test_l_bfgs_b_numjac(self):
         # L-BFGS-B with numerical jacobian


### PR DESCRIPTION
There is an issue in `_minimize_lbfgsb` in `optimize/lbfgsb.py`. When the minimizer is [requested](https://github.com/scipy/scipy/blob/master/scipy/optimize/lbfgsb.py#L345) to call the function and gradient it should be providing a copy of `x` to the user, but instead passes `x` directly.

I first noticed this issue in #10673 with [this failing test](https://github.com/scipy/scipy/blob/master/scipy/optimize/tests/test_optimize.py#L360).
The test keeps a trace of all the `x` arrays passed to the objective function. However, if you get the existing code to print out the trace all the entries are the same. This shouldn't occur, `x` should be changing as the minimization proceeds, converging on the solution.

The tracer is appending the `x` array to a list. However, the `x` array is being modified in-place by `_lbfgsb.setulb`. Thus the trace just ends up as a list of the same array appended time and time again.
Here the solution is to fix the tracer in the test by making it do a copy when it appends to the list, remove the exact trace requested in `test_l_bfgs_b`, and also to change `_minimize_lbfgsb` to pass a copy of `x` when is asks for evaluation of `func_and_grad`.