### PR TITLE
MAINT: SciPy 1.2.3 LTS backports / prep

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           name: install Debian dependencies
           command: |
             sudo apt-get update
-            sudo apt-get install libatlas-dev libatlas-base-dev liblapack-dev gfortran libgmp-dev libmpfr-dev libfreetype6-dev libpng-dev zlib1g zlib1g-dev texlive-fonts-recommended texlive-latex-recommended texlive-latex-extra texlive-generic-extra latexmk texlive-xetex
+            sudo apt-get install libatlas-dev libatlas-base-dev liblapack-dev gfortran libgmp-dev libmpfr-dev libfreetype6-dev libpng-dev zlib1g zlib1g-dev texlive-fonts-recommended texlive-latex-recommended texlive-latex-extra texlive-generic-extra latexmk texlive-xetex fonts-freefont-otf
 
       - run:
           name: setup Python venv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,9 @@ jobs:
           command: |
             sudo apt-get update
             sudo apt-get install libatlas-dev libatlas-base-dev liblapack-dev gfortran libgmp-dev libmpfr-dev libfreetype6-dev libpng-dev zlib1g zlib1g-dev texlive-fonts-recommended texlive-latex-recommended texlive-latex-extra texlive-generic-extra latexmk texlive-xetex fonts-freefont-otf
+            sudo sh -c 'echo "deb http://ftp.de.debian.org/debian sid main" >> /etc/apt/sources.list'
+            sudo apt-get update
+            sudo apt-get install xindy
 
       - run:
           name: setup Python venv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,8 @@ jobs:
             . venv/bin/activate
             pip install --install-option="--no-cython-compile" cython
             pip install numpy
-            pip install nose mpmath argparse Pillow codecov matplotlib Sphinx==1.7.2
+            pip install nose mpmath argparse Pillow codecov matplotlib Sphinx
+            pip install pybind11
 
       - run:
           name: build docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
             . venv/bin/activate
             pip install --install-option="--no-cython-compile" cython
             pip install numpy
-            pip install nose mpmath argparse Pillow codecov matplotlib Sphinx
+            pip install nose mpmath argparse Pillow codecov matplotlib "Sphinx<2.1"
             pip install pybind11
 
       - run:

--- a/.travis.yml
+++ b/.travis.yml
@@ -145,7 +145,7 @@ before_install:
   - travis_retry pip install --upgrade pip setuptools wheel
   - travis_retry pip install cython
   - if [ -n "$NUMPYSPEC" ]; then travis_retry pip install $NUMPYSPEC; fi
-  - travis_retry pip install --upgrade pytest pytest-xdist pytest-faulthandler mpmath argparse Pillow codecov
+  - travis_retry pip install --upgrade pytest pytest-xdist mpmath argparse Pillow codecov
   - travis_retry pip install gmpy2  # speeds up mpmath (scipy.special tests)
   - |
     if [ "${TESTMODE}" == "full" ]; then

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,7 @@ jobs:
            docker run -v $(pwd):/scipy i386/ubuntu:bionic /bin/bash -c "cd scipy && \
            apt-get -y update && \
            apt-get -y install python3.6-dev python3-pip pkg-config libpng-dev libjpeg8-dev libfreetype6-dev && \
-           pip3 install setuptools wheel 'numpy<1.17' cython==0.29 pytest pytest-timeout pytest-xdist pytest-env pytest-faulthandler Pillow mpmath matplotlib && \
+           pip3 install setuptools wheel 'numpy<1.17' cython==0.29 pytest pytest-timeout pytest-xdist pytest-env Pillow mpmath matplotlib && \
            apt-get -y install gfortran-5 wget && \
            cd .. && \
            mkdir openblas && cd openblas && \
@@ -105,7 +105,7 @@ jobs:
       choco install -y mingw --force --version=6.4.0
     displayName: 'Install 64-bit mingw for 64-bit builds'
     condition: eq(variables['BITS'], 64)
-  - bash: python -m pip install 'numpy<1.17' cython==0.28.5 pytest pytest-timeout pytest-xdist pytest-env pytest-faulthandler Pillow mpmath matplotlib
+  - bash: python -m pip install 'numpy<1.17' cython==0.28.5 pytest pytest-timeout pytest-xdist pytest-env Pillow mpmath matplotlib
     displayName: 'Install dependencies'
   - powershell: |
       If ($(BITS) -eq 32) {

--- a/doc/release/1.2.3-notes.rst
+++ b/doc/release/1.2.3-notes.rst
@@ -16,6 +16,7 @@ Authors
 * Pauli Virtanen
 * Eric Larson
 * Yu Feng
+* ananyashreyjain
 
 Issues closed for 1.2.3
 -----------------------
@@ -23,6 +24,7 @@ Issues closed for 1.2.3
 * `#10303 <https://github.com/scipy/scipy/issues/10303>`__: BUG: optimize: `linprog` failing TestLinprogSimplexBland::test_unbounded_below_no_presolve_corrected 
 * `#10376 <https://github.com/scipy/scipy/issues/10376>`__: TST: Travis CI fails (with pytest 5.0 ?)
 * `#10384 <https://github.com/scipy/scipy/issues/10384>`__: CircleCI doc build failing on new warnings
+* `#11266 <https://github.com/scipy/scipy/issues/11266>`__: Sparse matrix constructor data type detection changes on Numpy 1.18.0
 
 Pull requests for 1.2.3
 -----------------------
@@ -32,5 +34,6 @@ Pull requests for 1.2.3
 * `#10377 <https://github.com/scipy/scipy/pull/10377>`__: TST, MAINT: adjustments for pytest 5.0
 * `#10379 <https://github.com/scipy/scipy/pull/10379>`__: BUG: sparse: set writeability to be forward-compatible with numpy>=1.17
 * `#10426 <https://github.com/scipy/scipy/pull/10426>`__: MAINT: Fix doc build bugs
+* `#11269 <https://github.com/scipy/scipy/pull/11269>`__: Fix: Sparse matrix constructor data type detection changes on Numpy 1.18.0
 
 

--- a/doc/release/1.2.3-notes.rst
+++ b/doc/release/1.2.3-notes.rst
@@ -32,6 +32,7 @@ Pull requests for 1.2.3
 * `#10306 <https://github.com/scipy/scipy/pull/10306>`__: BUG: optimize: Fix for 10303
 * `#10309 <https://github.com/scipy/scipy/pull/10309>`__: BUG: Pass jac=None directly to lsoda
 * `#10377 <https://github.com/scipy/scipy/pull/10377>`__: TST, MAINT: adjustments for pytest 5.0
+* `#10379 <https://github.com/scipy/scipy/pull/10379>`__: BUG: sparse: set writeability to be forward-compatible with numpy>=1.17
 * `#10426 <https://github.com/scipy/scipy/pull/10426>`__: MAINT: Fix doc build bugs
 * `#10457 <https://github.com/scipy/scipy/pull/10457>`__: BUG: Allow ckdtree to accept empty data input
 * `#10503 <https://github.com/scipy/scipy/pull/10503>`__: BUG: spatial/qhull: get HalfspaceIntersection.dual_points from the correct array

--- a/doc/release/1.2.3-notes.rst
+++ b/doc/release/1.2.3-notes.rst
@@ -9,10 +9,31 @@ SciPy 1.2.3 is a bug-fix release with no new features compared to 1.2.2.
 Authors
 =======
 
+* Geordie McBain
+* Matt Haberland
+* David Hagen
+* Tyler Reddy
+* Pauli Virtanen
+* Eric Larson
+* Yu Feng
+
 Issues closed for 1.2.3
 -----------------------
+* `#5040 <https://github.com/scipy/scipy/issues/5040>`__: BUG: Empty data handling of (c)KDTrees
+* `#9901 <https://github.com/scipy/scipy/issues/9901>`__: lsoda fails to detect stiff problem when called from solve_ivp
+* `#10303 <https://github.com/scipy/scipy/issues/10303>`__: BUG: optimize: `linprog` failing TestLinprogSimplexBland::test_unbounded_below_no_presolve_corrected 
+* `#10376 <https://github.com/scipy/scipy/issues/10376>`__: TST: Travis CI fails (with pytest 5.0 ?)
+* `#10384 <https://github.com/scipy/scipy/issues/10384>`__: CircleCI doc build failing on new warnings
+* `#10501 <https://github.com/scipy/scipy/issues/10501>`__: BUG: scipy.spatial.HalfspaceIntersection works incorrectly
 
 Pull requests for 1.2.3
 -----------------------
+* `#10071 <https://github.com/scipy/scipy/pull/10071>`__: DOC: reconstruct SuperLU permutation matrices avoiding SparseEfficiencyWarning
+* `#10306 <https://github.com/scipy/scipy/pull/10306>`__: BUG: optimize: Fix for 10303
+* `#10309 <https://github.com/scipy/scipy/pull/10309>`__: BUG: Pass jac=None directly to lsoda
+* `#10377 <https://github.com/scipy/scipy/pull/10377>`__: TST, MAINT: adjustments for pytest 5.0
+* `#10426 <https://github.com/scipy/scipy/pull/10426>`__: MAINT: Fix doc build bugs
+* `#10457 <https://github.com/scipy/scipy/pull/10457>`__: BUG: Allow ckdtree to accept empty data input
+* `#10503 <https://github.com/scipy/scipy/pull/10503>`__: BUG: spatial/qhull: get HalfspaceIntersection.dual_points from the correct array
 
 

--- a/doc/release/1.2.3-notes.rst
+++ b/doc/release/1.2.3-notes.rst
@@ -17,15 +17,18 @@ Authors
 * Eric Larson
 * Yu Feng
 * ananyashreyjain
+* Nikolay Mayorov
 
 Issues closed for 1.2.3
 -----------------------
+* `#4915 <https://github.com/scipy/scipy/issues/4915>`__: Bug in unique_roots in scipy.signal.signaltools.py for roots with same magnitude
 * `#9901 <https://github.com/scipy/scipy/issues/9901>`__: lsoda fails to detect stiff problem when called from solve_ivp
 * `#9988 <https://github.com/scipy/scipy/issues/9988>`__: doc build broken with Sphinx 2.0.0
 * `#10303 <https://github.com/scipy/scipy/issues/10303>`__: BUG: optimize: `linprog` failing TestLinprogSimplexBland::test_unbounded_below_no_presolve_corrected 
 * `#10376 <https://github.com/scipy/scipy/issues/10376>`__: TST: Travis CI fails (with pytest 5.0 ?)
 * `#10384 <https://github.com/scipy/scipy/issues/10384>`__: CircleCI doc build failing on new warnings
 * `#10535 <https://github.com/scipy/scipy/issues/10535>`__: TST: master branch CI failures 
+* `#11198 <https://github.com/scipy/scipy/issues/11198>`__: BUG: sparse eigs (arpack) shift-invert drops the smallest eigenvalue for some k
 * `#11266 <https://github.com/scipy/scipy/issues/11266>`__: Sparse matrix constructor data type detection changes on Numpy 1.18.0
 
 Pull requests for 1.2.3
@@ -38,6 +41,10 @@ Pull requests for 1.2.3
 * `#10379 <https://github.com/scipy/scipy/pull/10379>`__: BUG: sparse: set writeability to be forward-compatible with numpy>=1.17
 * `#10426 <https://github.com/scipy/scipy/pull/10426>`__: MAINT: Fix doc build bugs
 * `#10540 <https://github.com/scipy/scipy/pull/10540>`__: MAINT: Fix Travis and Circle 
+* `#10833 <https://github.com/scipy/scipy/pull/10833>`__: BUG: Fix subspace_angles for complex values
+* `#10882 <https://github.com/scipy/scipy/pull/10882>`__: BUG: sparse/arpack: fix incorrect code for complex hermitian M
+* `#10961 <https://github.com/scipy/scipy/pull/10961>`__: BUG: Fix signal.unique_roots
+* `#11199 <https://github.com/scipy/scipy/pull/11199>`__: BUG: sparse.linalg: mistake in unsymm. real shift-invert ARPACK eigenvalue selection
 * `#11269 <https://github.com/scipy/scipy/pull/11269>`__: Fix: Sparse matrix constructor data type detection changes on Numpy 1.18.0
 
 

--- a/doc/release/1.2.3-notes.rst
+++ b/doc/release/1.2.3-notes.rst
@@ -19,7 +19,6 @@ Authors
 
 Issues closed for 1.2.3
 -----------------------
-* `#5040 <https://github.com/scipy/scipy/issues/5040>`__: BUG: Empty data handling of (c)KDTrees
 * `#9901 <https://github.com/scipy/scipy/issues/9901>`__: lsoda fails to detect stiff problem when called from solve_ivp
 * `#10303 <https://github.com/scipy/scipy/issues/10303>`__: BUG: optimize: `linprog` failing TestLinprogSimplexBland::test_unbounded_below_no_presolve_corrected 
 * `#10376 <https://github.com/scipy/scipy/issues/10376>`__: TST: Travis CI fails (with pytest 5.0 ?)
@@ -34,7 +33,6 @@ Pull requests for 1.2.3
 * `#10377 <https://github.com/scipy/scipy/pull/10377>`__: TST, MAINT: adjustments for pytest 5.0
 * `#10379 <https://github.com/scipy/scipy/pull/10379>`__: BUG: sparse: set writeability to be forward-compatible with numpy>=1.17
 * `#10426 <https://github.com/scipy/scipy/pull/10426>`__: MAINT: Fix doc build bugs
-* `#10457 <https://github.com/scipy/scipy/pull/10457>`__: BUG: Allow ckdtree to accept empty data input
 * `#10503 <https://github.com/scipy/scipy/pull/10503>`__: BUG: spatial/qhull: get HalfspaceIntersection.dual_points from the correct array
 
 

--- a/doc/release/1.2.3-notes.rst
+++ b/doc/release/1.2.3-notes.rst
@@ -24,6 +24,7 @@ Issues closed for 1.2.3
 * `#10303 <https://github.com/scipy/scipy/issues/10303>`__: BUG: optimize: `linprog` failing TestLinprogSimplexBland::test_unbounded_below_no_presolve_corrected 
 * `#10376 <https://github.com/scipy/scipy/issues/10376>`__: TST: Travis CI fails (with pytest 5.0 ?)
 * `#10384 <https://github.com/scipy/scipy/issues/10384>`__: CircleCI doc build failing on new warnings
+* `#10535 <https://github.com/scipy/scipy/issues/10535>`__: TST: master branch CI failures 
 * `#11266 <https://github.com/scipy/scipy/issues/11266>`__: Sparse matrix constructor data type detection changes on Numpy 1.18.0
 
 Pull requests for 1.2.3
@@ -34,6 +35,7 @@ Pull requests for 1.2.3
 * `#10377 <https://github.com/scipy/scipy/pull/10377>`__: TST, MAINT: adjustments for pytest 5.0
 * `#10379 <https://github.com/scipy/scipy/pull/10379>`__: BUG: sparse: set writeability to be forward-compatible with numpy>=1.17
 * `#10426 <https://github.com/scipy/scipy/pull/10426>`__: MAINT: Fix doc build bugs
+* `#10540 <https://github.com/scipy/scipy/pull/10540>`__: MAINT: Fix Travis and Circle 
 * `#11269 <https://github.com/scipy/scipy/pull/11269>`__: Fix: Sparse matrix constructor data type detection changes on Numpy 1.18.0
 
 

--- a/doc/release/1.2.3-notes.rst
+++ b/doc/release/1.2.3-notes.rst
@@ -21,6 +21,7 @@ Authors
 Issues closed for 1.2.3
 -----------------------
 * `#9901 <https://github.com/scipy/scipy/issues/9901>`__: lsoda fails to detect stiff problem when called from solve_ivp
+* `#9988 <https://github.com/scipy/scipy/issues/9988>`__: doc build broken with Sphinx 2.0.0
 * `#10303 <https://github.com/scipy/scipy/issues/10303>`__: BUG: optimize: `linprog` failing TestLinprogSimplexBland::test_unbounded_below_no_presolve_corrected 
 * `#10376 <https://github.com/scipy/scipy/issues/10376>`__: TST: Travis CI fails (with pytest 5.0 ?)
 * `#10384 <https://github.com/scipy/scipy/issues/10384>`__: CircleCI doc build failing on new warnings
@@ -29,6 +30,7 @@ Issues closed for 1.2.3
 
 Pull requests for 1.2.3
 -----------------------
+* `#9992 <https://github.com/scipy/scipy/pull/9992>`__: MAINT: Undo Sphinx pin 
 * `#10071 <https://github.com/scipy/scipy/pull/10071>`__: DOC: reconstruct SuperLU permutation matrices avoiding SparseEfficiencyWarning
 * `#10306 <https://github.com/scipy/scipy/pull/10306>`__: BUG: optimize: Fix for 10303
 * `#10309 <https://github.com/scipy/scipy/pull/10309>`__: BUG: Pass jac=None directly to lsoda

--- a/doc/release/1.2.3-notes.rst
+++ b/doc/release/1.2.3-notes.rst
@@ -23,7 +23,6 @@ Issues closed for 1.2.3
 * `#10303 <https://github.com/scipy/scipy/issues/10303>`__: BUG: optimize: `linprog` failing TestLinprogSimplexBland::test_unbounded_below_no_presolve_corrected 
 * `#10376 <https://github.com/scipy/scipy/issues/10376>`__: TST: Travis CI fails (with pytest 5.0 ?)
 * `#10384 <https://github.com/scipy/scipy/issues/10384>`__: CircleCI doc build failing on new warnings
-* `#10501 <https://github.com/scipy/scipy/issues/10501>`__: BUG: scipy.spatial.HalfspaceIntersection works incorrectly
 
 Pull requests for 1.2.3
 -----------------------
@@ -33,6 +32,5 @@ Pull requests for 1.2.3
 * `#10377 <https://github.com/scipy/scipy/pull/10377>`__: TST, MAINT: adjustments for pytest 5.0
 * `#10379 <https://github.com/scipy/scipy/pull/10379>`__: BUG: sparse: set writeability to be forward-compatible with numpy>=1.17
 * `#10426 <https://github.com/scipy/scipy/pull/10426>`__: MAINT: Fix doc build bugs
-* `#10503 <https://github.com/scipy/scipy/pull/10503>`__: BUG: spatial/qhull: get HalfspaceIntersection.dual_points from the correct array
 
 

--- a/doc/release/1.2.3-notes.rst
+++ b/doc/release/1.2.3-notes.rst
@@ -4,7 +4,8 @@ SciPy 1.2.3 Release Notes
 
 .. contents::
 
-SciPy 1.2.3 is a bug-fix release with no new features compared to 1.2.2.
+SciPy 1.2.3 is a bug-fix release with no new features compared to 1.2.2. It is
+part of the long-term support (LTS) release series for Python 2.7.
 
 Authors
 =======
@@ -18,16 +19,23 @@ Authors
 * Yu Feng
 * ananyashreyjain
 * Nikolay Mayorov
+* Evgeni Burovski 
+* Warren Weckesser
 
 Issues closed for 1.2.3
 -----------------------
 * `#4915 <https://github.com/scipy/scipy/issues/4915>`__: Bug in unique_roots in scipy.signal.signaltools.py for roots with same magnitude
+* `#5546 <https://github.com/scipy/scipy/issues/5546>`__: ValueError raised if scipy.sparse.linalg.expm recieves array larger than 200x200
+* `#7117 <https://github.com/scipy/scipy/issues/7117>`__: Warn users when using float32 input data to curve_fit and friends
+* `#7906 <https://github.com/scipy/scipy/issues/7906>`__: Wrong result from scipy.interpolate.UnivariateSpline.integral for out-of-bounds 
+* `#9581 <https://github.com/scipy/scipy/issues/9581>`__: Least-squares minimization fails silently when x and y data are different types
 * `#9901 <https://github.com/scipy/scipy/issues/9901>`__: lsoda fails to detect stiff problem when called from solve_ivp
 * `#9988 <https://github.com/scipy/scipy/issues/9988>`__: doc build broken with Sphinx 2.0.0
 * `#10303 <https://github.com/scipy/scipy/issues/10303>`__: BUG: optimize: `linprog` failing TestLinprogSimplexBland::test_unbounded_below_no_presolve_corrected 
 * `#10376 <https://github.com/scipy/scipy/issues/10376>`__: TST: Travis CI fails (with pytest 5.0 ?)
 * `#10384 <https://github.com/scipy/scipy/issues/10384>`__: CircleCI doc build failing on new warnings
 * `#10535 <https://github.com/scipy/scipy/issues/10535>`__: TST: master branch CI failures 
+* `#11121 <https://github.com/scipy/scipy/issues/11121>`__: Calls to `scipy.interpolate.splprep` increase RAM usage.
 * `#11198 <https://github.com/scipy/scipy/issues/11198>`__: BUG: sparse eigs (arpack) shift-invert drops the smallest eigenvalue for some k
 * `#11266 <https://github.com/scipy/scipy/issues/11266>`__: Sparse matrix constructor data type detection changes on Numpy 1.18.0
 
@@ -35,15 +43,20 @@ Pull requests for 1.2.3
 -----------------------
 * `#9992 <https://github.com/scipy/scipy/pull/9992>`__: MAINT: Undo Sphinx pin 
 * `#10071 <https://github.com/scipy/scipy/pull/10071>`__: DOC: reconstruct SuperLU permutation matrices avoiding SparseEfficiencyWarning
+* `#10076 <https://github.com/scipy/scipy/pull/10076>`__: BUG: optimize: fix curve_fit for mixed float32/float64 input
+* `#10138 <https://github.com/scipy/scipy/pull/10138>`__: BUG: special: Invalid arguments to ellip_harm can crash Python.
 * `#10306 <https://github.com/scipy/scipy/pull/10306>`__: BUG: optimize: Fix for 10303
 * `#10309 <https://github.com/scipy/scipy/pull/10309>`__: BUG: Pass jac=None directly to lsoda
 * `#10377 <https://github.com/scipy/scipy/pull/10377>`__: TST, MAINT: adjustments for pytest 5.0
 * `#10379 <https://github.com/scipy/scipy/pull/10379>`__: BUG: sparse: set writeability to be forward-compatible with numpy>=1.17
 * `#10426 <https://github.com/scipy/scipy/pull/10426>`__: MAINT: Fix doc build bugs
 * `#10540 <https://github.com/scipy/scipy/pull/10540>`__: MAINT: Fix Travis and Circle 
+* `#10633 <https://github.com/scipy/scipy/pull/10633>`__: BUG: interpolate: integral(a, b) should be zero when both limits are outside of the interpolation range
 * `#10833 <https://github.com/scipy/scipy/pull/10833>`__: BUG: Fix subspace_angles for complex values
 * `#10882 <https://github.com/scipy/scipy/pull/10882>`__: BUG: sparse/arpack: fix incorrect code for complex hermitian M
+* `#10906 <https://github.com/scipy/scipy/pull/10906>`__: BUG: sparse/linalg: fix expm for np.matrix inputs
 * `#10961 <https://github.com/scipy/scipy/pull/10961>`__: BUG: Fix signal.unique_roots
+* `#11126 <https://github.com/scipy/scipy/pull/11126>`__: BUG: interpolate/fitpack: fix memory leak in splprep
 * `#11199 <https://github.com/scipy/scipy/pull/11199>`__: BUG: sparse.linalg: mistake in unsymm. real shift-invert ARPACK eigenvalue selection
 * `#11269 <https://github.com/scipy/scipy/pull/11269>`__: Fix: Sparse matrix constructor data type detection changes on Numpy 1.18.0
 

--- a/doc/source/_templates/autosummary/property.rst
+++ b/doc/source/_templates/autosummary/property.rst
@@ -1,0 +1,8 @@
+:orphan:
+
+{{ fullname }}
+{{ underline }}
+
+.. currentmodule:: {{ module }}
+
+.. autoproperty:: {{ objname }}

--- a/doc/source/tutorial/fftpack.rst
+++ b/doc/source/tutorial/fftpack.rst
@@ -127,7 +127,7 @@ truncated for illustrative purposes).
     >>> from scipy.signal import blackman
     >>> w = blackman(N)
     >>> ywf = fft(y*w)
-    >>> xf = np.linspace(0.0, 1.0/(2.0*T), N/2)
+    >>> xf = np.linspace(0.0, 1.0/(2.0*T), N//2)
     >>> import matplotlib.pyplot as plt
     >>> plt.semilogy(xf[1:N//2], 2.0/N * np.abs(yf[1:N//2]), '-b')
     >>> plt.semilogy(xf[1:N//2], 2.0/N * np.abs(ywf[1:N//2]), '-r')

--- a/doc/source/tutorial/io.rst
+++ b/doc/source/tutorial/io.rst
@@ -323,7 +323,7 @@ Matrix Market files
 Wav sound files (:mod:`scipy.io.wavfile`)
 -----------------------------------------
 
-.. module:: scipy.io.wavfile
+.. currentmodule:: scipy.io.wavfile
 
 .. autosummary::
 
@@ -333,7 +333,7 @@ Wav sound files (:mod:`scipy.io.wavfile`)
 Arff files (:mod:`scipy.io.arff`)
 ---------------------------------
 
-.. automodule:: scipy.io.arff
+.. currentmodule:: scipy.io.arff
 
 .. autosummary::
 
@@ -342,7 +342,7 @@ Arff files (:mod:`scipy.io.arff`)
 Netcdf (:mod:`scipy.io.netcdf`)
 -------------------------------
 
-.. module:: scipy.io.netcdf
+.. currentmodule:: scipy.io
 
 .. autosummary::
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -10,5 +10,8 @@ filterwarnings =
     ignore:the matrix subclass is not the recommended way*:PendingDeprecationWarning
     ignore:Using or importing the ABCs from 'collections'*:DeprecationWarning
     ignore:can't resolve package from __spec__ or __package__, falling back on __name__ and __path__:ImportWarning
+    once:the imp module is deprecated in favour of importlib.*:DeprecationWarning
+    once:the imp module is deprecated in favour of importlib.*:PendingDeprecationWarning
+
 env =
     PYTHONHASHSEED=0

--- a/scipy/_lib/_ccallback.py
+++ b/scipy/_lib/_ccallback.py
@@ -40,9 +40,9 @@ class LowLevelCallable(tuple):
     Attributes
     ----------
     function
-        Callback function given
+        Callback function given.
     user_data
-        User data given
+        User data given.
     signature
         Signature of the function.
 

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -11,6 +11,19 @@ import inspect
 
 import numpy as np
 
+def _broadcast_arrays(a, b):
+    """
+    Same as np.broadcast_arrays(a, b) but old writeability rules.
+    Numpy >= 1.17.0 transitions broadcast_arrays to return
+    read-only arrays. Set writeability explicitly to avoid warnings.
+    Retain the old writeability rules, as our Cython code assumes
+    the old behavior.
+    """
+    # backport based on gh-10379
+    x, y = np.broadcast_arrays(a, b)
+    x.flags.writeable = a.flags.writeable
+    y.flags.writeable = b.flags.writeable
+    return x, y
 
 def _valarray(shape, value=np.nan, typecode=None):
     """Return an array of all value.

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -9,8 +9,6 @@ from collections import namedtuple
 from multiprocessing import Pool
 import inspect
 
-from scipy._lib._version import NumpyVersion
-
 import numpy as np
 
 def _broadcast_arrays(a, b):
@@ -23,9 +21,8 @@ def _broadcast_arrays(a, b):
     """
     # backport based on gh-10379
     x, y = np.broadcast_arrays(a, b)
-    if NumpyVersion(np.__version__) >= '1.17.0':
-        x.flags.writeable = a.flags.writeable
-        y.flags.writeable = b.flags.writeable
+    x.flags.writeable = a.flags.writeable
+    y.flags.writeable = b.flags.writeable
     return x, y
 
 def _valarray(shape, value=np.nan, typecode=None):

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -9,6 +9,8 @@ from collections import namedtuple
 from multiprocessing import Pool
 import inspect
 
+from scipy._lib._version import NumpyVersion
+
 import numpy as np
 
 def _broadcast_arrays(a, b):
@@ -21,8 +23,9 @@ def _broadcast_arrays(a, b):
     """
     # backport based on gh-10379
     x, y = np.broadcast_arrays(a, b)
-    x.flags.writeable = a.flags.writeable
-    y.flags.writeable = b.flags.writeable
+    if NumpyVersion(np.__version__) >= '1.17.0':
+        x.flags.writeable = a.flags.writeable
+        y.flags.writeable = b.flags.writeable
     return x, y
 
 def _valarray(shape, value=np.nan, typecode=None):

--- a/scipy/integrate/_ivp/lsoda.py
+++ b/scipy/integrate/_ivp/lsoda.py
@@ -125,10 +125,6 @@ class LSODA(OdeSolver):
 
         rtol, atol = validate_tol(rtol, atol, self.n)
 
-        if jac is None:  # No lambda as PEP8 insists.
-            def jac():
-                return None
-
         solver = ode(self.fun, jac)
         solver.set_integrator('lsoda', rtol=rtol, atol=atol, max_step=max_step,
                               min_step=min_step, first_step=first_step,
@@ -150,7 +146,7 @@ class LSODA(OdeSolver):
         itask = integrator.call_args[2]
         integrator.call_args[2] = 5
         solver._y, solver.t = integrator.run(
-            solver.f, solver.jac, solver._y, solver.t,
+            solver.f, solver.jac or (lambda: None), solver._y, solver.t,
             self.t_bound, solver.f_params, solver.jac_params)
         integrator.call_args[2] = itask
 

--- a/scipy/integrate/tests/test_ivp.py
+++ b/scipy/integrate/tests/test_ivp.py
@@ -297,6 +297,7 @@ def test_integration_const_jac():
         assert_allclose(res.sol(res.t), res.y, rtol=1e-14, atol=1e-14)
 
 
+@pytest.mark.timeout(5)
 @pytest.mark.parametrize('method', ['Radau', 'BDF', 'LSODA'])
 def test_integration_stiff(method):
     rtol = 1e-6

--- a/scipy/integrate/tests/test_ivp.py
+++ b/scipy/integrate/tests/test_ivp.py
@@ -2,6 +2,7 @@ from __future__ import division, print_function, absolute_import
 from itertools import product
 from numpy.testing import (assert_, assert_allclose,
                            assert_equal, assert_no_warnings)
+import pytest
 from pytest import raises as assert_raises
 from scipy._lib._numpy_compat import suppress_warnings
 import numpy as np
@@ -296,7 +297,8 @@ def test_integration_const_jac():
         assert_allclose(res.sol(res.t), res.y, rtol=1e-14, atol=1e-14)
 
 
-def test_integration_stiff():
+@pytest.mark.parametrize('method', ['Radau', 'BDF', 'LSODA'])
+def test_integration_stiff(method):
     rtol = 1e-6
     atol = 1e-6
     y0 = [1e4, 0, 0]
@@ -310,13 +312,12 @@ def test_integration_stiff():
             3e7 * y * y,
         ]
 
-    for method in ['Radau', 'BDF', 'LSODA']:
-        res = solve_ivp(fun_robertson, tspan, y0, rtol=rtol,
-                        atol=atol, method=method)
+    res = solve_ivp(fun_robertson, tspan, y0, rtol=rtol,
+                    atol=atol, method=method)
 
-        # If the stiff mode is not activated correctly, these numbers will be much bigger
-        assert_(res.nfev < 5000)
-        assert_(res.njev < 200)
+    # If the stiff mode is not activated correctly, these numbers will be much bigger
+    assert res.nfev < 5000
+    assert res.njev < 200
 
 
 def test_events():

--- a/scipy/integrate/tests/test_ivp.py
+++ b/scipy/integrate/tests/test_ivp.py
@@ -296,6 +296,29 @@ def test_integration_const_jac():
         assert_allclose(res.sol(res.t), res.y, rtol=1e-14, atol=1e-14)
 
 
+def test_integration_stiff():
+    rtol = 1e-6
+    atol = 1e-6
+    y0 = [1e4, 0, 0]
+    tspan = [0, 1e8]
+
+    def fun_robertson(t, state):
+        x, y, z = state
+        return [
+            -0.04 * x + 1e4 * y * z,
+            0.04 * x - 1e4 * y * z - 3e7 * y * y,
+            3e7 * y * y,
+        ]
+
+    for method in ['Radau', 'BDF', 'LSODA']:
+        res = solve_ivp(fun_robertson, tspan, y0, rtol=rtol,
+                        atol=atol, method=method)
+
+        # If the stiff mode is not activated correctly, these numbers will be much bigger
+        assert_(res.nfev < 5000)
+        assert_(res.njev < 200)
+
+
 def test_events():
     def event_rational_1(t, y):
         return y[0] - y[1] ** 0.7

--- a/scipy/integrate/tests/test_ivp.py
+++ b/scipy/integrate/tests/test_ivp.py
@@ -297,7 +297,7 @@ def test_integration_const_jac():
         assert_allclose(res.sol(res.t), res.y, rtol=1e-14, atol=1e-14)
 
 
-@pytest.mark.timeout(5)
+@pytest.mark.slow
 @pytest.mark.parametrize('method', ['Radau', 'BDF', 'LSODA'])
 def test_integration_stiff(method):
     rtol = 1e-6

--- a/scipy/interpolate/_ppoly.pyx
+++ b/scipy/interpolate/_ppoly.pyx
@@ -533,11 +533,8 @@ def real_roots(double[:,:,::1] c, double[::1] x, double y, bint report_discont,
                     wr[i] += x[interval]
                     if interval == 0 and extrapolate:
                         # Half-open to the left/right.
-                        # Might also be the only interval, in which case there is
-                        # no limitation.
-                        if (interval != c.shape[1] - 1 and
-                            (ascending and not wr[i] <= x[interval+1] or
-                             not ascending and not wr[i] >= x[interval + 1])):
+                        if (ascending and not wr[i] <= x[interval+1] or
+                            not ascending and not wr[i] >= x[interval + 1]):
                                 continue
                     elif interval == c.shape[1] - 1 and extrapolate:
                         # Half-open to the right/left.

--- a/scipy/interpolate/_ppoly.pyx
+++ b/scipy/interpolate/_ppoly.pyx
@@ -533,8 +533,11 @@ def real_roots(double[:,:,::1] c, double[::1] x, double y, bint report_discont,
                     wr[i] += x[interval]
                     if interval == 0 and extrapolate:
                         # Half-open to the left/right.
-                        if (ascending and not wr[i] <= x[interval+1] or
-                            not ascending and not wr[i] >= x[interval + 1]):
+                        # Might also be the only interval, in which case there is
+                        # no limitation.
+                        if (interval != c.shape[1] - 1 and
+                            (ascending and not wr[i] <= x[interval+1] or
+                             not ascending and not wr[i] >= x[interval + 1])):
                                 continue
                     elif interval == c.shape[1] - 1 and extrapolate:
                         # Half-open to the right/left.

--- a/scipy/interpolate/fitpack/fpintb.f
+++ b/scipy/interpolate/fitpack/fpintb.f
@@ -1,4 +1,5 @@
       subroutine fpintb(t,n,bint,nk1,x,y)
+      implicit none
 c  subroutine fpintb calculates integrals of the normalized b-splines
 c  nj,k+1(x) of degree k, defined on the set of knots t(j),j=1,2,...n.
 c  it makes use of the formulae of gaffney for the calculation of
@@ -47,6 +48,7 @@ c  the integration limits are arranged in increasing order.
       min = 1
   30  if(a.lt.t(k1)) a = t(k1)
       if(b.gt.t(nk1+1)) b = t(nk1+1)
+      if(a.gt.b) go to 160
 c  using the expression of gaffney for the indefinite integral of a
 c  b-spline we find that
 c  bint(j) = (t(j+k+1)-t(j))*(res(j,b)-res(j,a))/(k+1)

--- a/scipy/interpolate/fitpack/splint.f
+++ b/scipy/interpolate/fitpack/splint.f
@@ -1,4 +1,5 @@
       real*8 function splint(t,n,c,k,a,b,wrk)
+      implicit none
 c  function splint calculates the integral of a spline function s(x)
 c  of degree k, which is given in its normalized b-spline representation
 c

--- a/scipy/interpolate/src/_fitpackmodule.c
+++ b/scipy/interpolate/src/_fitpackmodule.c
@@ -463,10 +463,18 @@ fitpack_parcur(PyObject *dummy, PyObject *args)
         goto fail;
     }
     if (iopt == 0|| n > no) {
+        Py_XDECREF(ap_wrk);
+        ap_wrk = NULL;
+        Py_XDECREF(ap_iwrk);
+        ap_iwrk = NULL;
+
         dims[0] = n;
         ap_wrk = (PyArrayObject *)PyArray_SimpleNew(1, dims, NPY_DOUBLE);
+        if (ap_wrk == NULL) {
+            goto fail;
+        }
         ap_iwrk = (PyArrayObject *)PyArray_SimpleNew(1, dims, NPY_INT);
-        if (ap_wrk == NULL || ap_iwrk == NULL) {
+        if (ap_iwrk == NULL) {
             goto fail;
         }
     }

--- a/scipy/interpolate/src/_fitpackmodule.c
+++ b/scipy/interpolate/src/_fitpackmodule.c
@@ -432,6 +432,8 @@ fitpack_parcur(PyObject *dummy, PyObject *args)
         }
         n = no = ap_t->dimensions[0];
         memcpy(t, ap_t->data, n*sizeof(double));
+        Py_DECREF(ap_t);
+        ap_t = NULL;
     }
     if (iopt == 1) {
         memcpy(wrk, ap_wrk->data, n*sizeof(double));

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -141,6 +141,16 @@ class TestUnivariateSpline(object):
         assert_allclose(spl2(0.6) - spl2(0.2),
                         spl.integral(0.2, 0.6))
 
+    def test_integral_out_of_bounds(self):
+        # Regression test for gh-7906: .integral(a, b) is wrong if both 
+        # a and b are out-of-bounds
+        x = np.linspace(0., 1., 7)
+        for ext in range(4):
+            f = UnivariateSpline(x, x, s=0, ext=ext)
+            for (a, b) in [(1, 1), (1, 5), (2, 5),
+                           (0, 0), (-2, 0), (-2, -1)]:
+                assert_allclose(f.integral(a, b), 0, atol=1e-15)
+
     def test_nan(self):
         # bail out early if the input data contains nans
         x = np.arange(10, dtype=float)

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -661,16 +661,3 @@ class TestCubicSpline(object):
 
         # periodic condition, y[-1] must be equal to y[0]:
         assert_raises(ValueError, CubicSpline, x, y, 0, 'periodic', True)
-
-
-def test_roots_extrapolate_gh_11185():
-    x = np.array([0.001, 0.002])
-    y = np.array([1.66066935e-06, 1.10410807e-06])
-    dy = np.array([-1.60061854, -1.600619])
-    p = CubicHermiteSpline(x, y, dy)
-
-    # roots(extrapolate=True) for a polynomial with a single interval
-    # should return all three real roots
-    r = p.roots(extrapolate=True)
-    assert_equal(p.c.shape[1], 1)
-    assert_equal(r.size, 3)

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -662,3 +662,15 @@ class TestCubicSpline(object):
         # periodic condition, y[-1] must be equal to y[0]:
         assert_raises(ValueError, CubicSpline, x, y, 0, 'periodic', True)
 
+
+def test_roots_extrapolate_gh_11185():
+    x = np.array([0.001, 0.002])
+    y = np.array([1.66066935e-06, 1.10410807e-06])
+    dy = np.array([-1.60061854, -1.600619])
+    p = CubicHermiteSpline(x, y, dy)
+
+    # roots(extrapolate=True) for a polynomial with a single interval
+    # should return all three real roots
+    r = p.roots(extrapolate=True)
+    assert_equal(p.c.shape[1], 1)
+    assert_equal(r.size, 3)

--- a/scipy/linalg/decomp_svd.py
+++ b/scipy/linalg/decomp_svd.py
@@ -472,15 +472,15 @@ def subspace_angles(A, B):
     del B
 
     # 2. Compute SVD for cosine
-    QA_T_QB = dot(QA.T, QB)
-    sigma = svdvals(QA_T_QB)
+    QA_H_QB = dot(QA.T.conj(), QB)
+    sigma = svdvals(QA_H_QB)
 
     # 3. Compute matrix B
     if QA.shape[1] >= QB.shape[1]:
-        B = QB - dot(QA, QA_T_QB)
+        B = QB - dot(QA, QA_H_QB)
     else:
-        B = QA - dot(QB, QA_T_QB.T)
-    del QA, QB, QA_T_QB
+        B = QA - dot(QB, QA_H_QB.T.conj())
+    del QA, QB, QA_H_QB
 
     # 4. Compute SVD for sine
     mask = sigma ** 2 >= 0.5
@@ -490,6 +490,7 @@ def subspace_angles(A, B):
         mu_arcsin = 0.
 
     # 5. Compute the principal angles
-    # with reverse ordering of sigma because smallest sigma belongs to largest angle theta
+    # with reverse ordering of sigma because smallest sigma belongs to largest
+    # angle theta
     theta = where(mask, mu_arcsin, arccos(clip(sigma[::-1], -1., 1.)))
     return theta

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -2736,6 +2736,14 @@ def test_subspace_angles():
     expected = np.array([np.pi/2, 0, 0])
     assert_allclose(subspace_angles(A, B), expected, rtol=1e-12)
 
+    # Complex
+    # second column in "b" does not affect result, just there so that
+    # b can have more cols than a, and vice-versa (both conditional code paths)
+    a = [[1 + 1j], [0]]
+    b = [[1 - 1j, 0], [0, 1]]
+    assert_allclose(subspace_angles(a, b), 0., atol=1e-14)
+    assert_allclose(subspace_angles(b, a), 0., atol=1e-14)
+
 
 class TestCDF2RDF(object):
 

--- a/scipy/optimize/_linprog_simplex.py
+++ b/scipy/optimize/_linprog_simplex.py
@@ -63,6 +63,7 @@ def _pivot_col(T, tol=1.0E-12, bland=False):
     if ma.count() == 0:
         return False, np.nan
     if bland:
+        # ma.mask is sometimes 0d
         return True, np.nonzero(ma.mask == False)[0][0]
     return True, np.ma.nonzero(ma == ma.min())[0][0]
 

--- a/scipy/optimize/_linprog_simplex.py
+++ b/scipy/optimize/_linprog_simplex.py
@@ -64,7 +64,7 @@ def _pivot_col(T, tol=1.0E-12, bland=False):
         return False, np.nan
     if bland:
         # ma.mask is sometimes 0d
-        return True, np.nonzero(ma.mask == False)[0][0]
+        return True, np.nonzero(np.logical_not(np.atleast_1d(ma.mask)))[0][0]
     return True, np.ma.nonzero(ma == ma.min())[0][0]
 
 

--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -129,7 +129,7 @@ def fsolve(func, x0, args=(), fprime=None, full_output=0,
     See Also
     --------
     root : Interface to root finding algorithms for multivariate
-    functions. See the 'hybr' `method` in particular.
+           functions. See the ``method=='hybr'`` in particular.
 
     Notes
     -----

--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -712,6 +712,10 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
         else:
             xdata = np.asarray(xdata)
 
+    # optimization may produce garbage for float32 inputs, cast them to float64
+    xdata = xdata.astype(float)
+    ydata = ydata.astype(float)
+
     # Determine type of sigma
     if sigma is not None:
         sigma = np.asarray(sigma)

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -3,6 +3,8 @@ Unit tests for optimization routines from minpack.py.
 """
 from __future__ import division, print_function, absolute_import
 
+import warnings
+
 from numpy.testing import (assert_, assert_almost_equal, assert_array_equal,
         assert_array_almost_equal, assert_allclose)
 from pytest import raises as assert_raises
@@ -706,6 +708,55 @@ class TestCurveFit(object):
 
                 assert_allclose(popt1, popt2, atol=1e-14)
                 assert_allclose(pcov1, pcov2, atol=1e-14)
+
+    def test_dtypes(self):
+        # regression test for gh-9581: curve_fit fails if x and y dtypes differ
+        x = np.arange(-3, 5)
+        y = 1.5*x + 3.0 + 0.5*np.sin(x)
+
+        def func(x, a, b):
+            return a*x + b
+
+        for method in ['lm', 'trf', 'dogbox']:
+            for dtx in [np.float32, np.float64]:
+                for dty in [np.float32, np.float64]:
+                    x = x.astype(dtx)
+                    y = y.astype(dty)
+
+                with warnings.catch_warnings():
+                    warnings.simplefilter("error", OptimizeWarning)
+                    p, cov = curve_fit(func, x, y, method=method)
+
+                    assert np.isfinite(cov).all()
+                    assert not np.allclose(p, 1)   # curve_fit's initial value
+
+    def test_dtypes2(self):
+        # regression test for gh-7117: curve_fit fails if
+        # both inputs are float32
+        def hyperbola(x, s_1, s_2, o_x, o_y, c):
+            b_2 = (s_1 + s_2) / 2
+            b_1 = (s_2 - s_1) / 2
+            return o_y + b_1*(x-o_x) + b_2*np.sqrt((x-o_x)**2 + c**2/4)
+
+        min_fit = np.array([-3.0, 0.0, -2.0, -10.0, 0.0])
+        max_fit = np.array([0.0, 3.0, 3.0, 0.0, 10.0])
+        guess = np.array([-2.5/3.0, 4/3.0, 1.0, -4.0, 0.5])
+
+        params = [-2, .4, -1, -5, 9.5]
+        xdata = np.array([-32, -16, -8, 4, 4, 8, 16, 32])
+        ydata = hyperbola(xdata, *params)
+
+        # run optimization twice, with xdata being float32 and float64
+        popt_64, _ = curve_fit(f=hyperbola, xdata=xdata, ydata=ydata, p0=guess,
+                               bounds=(min_fit, max_fit))
+
+        xdata = xdata.astype(np.float32)
+        ydata = hyperbola(xdata, *params)
+
+        popt_32, _ = curve_fit(f=hyperbola, xdata=xdata, ydata=ydata, p0=guess,
+                               bounds=(min_fit, max_fit))
+
+        assert_allclose(popt_32, popt_64, atol=2e-5)
 
 
 class TestFixedPoint(object):

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -696,8 +696,12 @@ def brentq(f, a, b, args=(),
         Object containing information about the convergence.  In particular,
         ``r.converged`` is True if the routine converged.
 
-    See Also
-    --------
+    Notes
+    -----
+    `f` must be continuous.  f(a) and f(b) must have opposite signs.
+
+    Related functions fall into several classes:
+
     multivariate local optimizers
       `fmin`, `fmin_powell`, `fmin_cg`, `fmin_bfgs`, `fmin_ncg`
     nonlinear least squares minimizer
@@ -714,10 +718,6 @@ def brentq(f, a, b, args=(),
       `brenth`, `ridder`, `bisect`, `newton`
     scalar fixed-point finder
       `fixed_point`
-
-    Notes
-    -----
-    `f` must be continuous.  f(a) and f(b) must have opposite signs.
 
     References
     ----------

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -7,7 +7,7 @@ import operator
 import threading
 import sys
 import timeit
-
+from scipy.spatial import cKDTree
 from . import sigtools, dlti
 from ._upfirdn import upfirdn, _output_len
 from scipy._lib.six import callable
@@ -1716,32 +1716,42 @@ def cmplx_sort(p):
 
 
 def unique_roots(p, tol=1e-3, rtype='min'):
-    """
-    Determine unique roots and their multiplicities from a list of roots.
+    """Determine unique roots and their multiplicities from a list of roots.
 
     Parameters
     ----------
     p : array_like
         The list of roots.
     tol : float, optional
-        The tolerance for two roots to be considered equal. Default is 1e-3.
-    rtype : {'max', 'min, 'avg'}, optional
+        The tolerance for two roots to be considered equal in terms of
+        the distance between them. Default is 1e-3. Refer to Notes about
+        the details on roots grouping.
+    rtype : {'max', 'maximum', 'min', 'minimum', 'avg', 'mean'}, optional
         How to determine the returned root if multiple roots are within
         `tol` of each other.
 
-          - 'max': pick the maximum of those roots.
-          - 'min': pick the minimum of those roots.
-          - 'avg': take the average of those roots.
+          - 'max', 'maximum': pick the maximum of those roots
+          - 'min', 'minimum': pick the minimum of those roots
+          - 'avg', 'mean': take the average of those roots
+
+        When finding minimum or maximum among complex roots they are compared
+        first by the real part and then by the imaginary part.
 
     Returns
     -------
-    pout : ndarray
-        The list of unique roots, sorted from low to high.
-    mult : ndarray
+    unique : ndarray
+        The list of unique roots.
+    multiplicity : ndarray
         The multiplicity of each root.
 
     Notes
     -----
+    If we have 3 roots ``a``, ``b`` and ``c``, such that ``a`` is close to
+    ``b`` and ``b`` is close to ``c`` (distance is less than `tol`), then it
+    doesn't necessarily mean that ``a`` is close to ``c``. It means that roots
+    grouping is not unique. In this function we use "greedy" grouping going
+    through the roots in the order they are given in the input `p`.
+
     This utility function is not specific to roots but can be used for any
     sequence of values for which uniqueness and multiplicity has to be
     determined. For a more general routine, see `numpy.unique`.
@@ -1756,39 +1766,40 @@ def unique_roots(p, tol=1e-3, rtype='min'):
 
     >>> uniq[mult > 1]
     array([ 1.305])
-
     """
     if rtype in ['max', 'maximum']:
-        comproot = np.max
+        reduce = np.max
     elif rtype in ['min', 'minimum']:
-        comproot = np.min
+        reduce = np.min
     elif rtype in ['avg', 'mean']:
-        comproot = np.mean
+        reduce = np.mean
     else:
         raise ValueError("`rtype` must be one of "
                          "{'max', 'maximum', 'min', 'minimum', 'avg', 'mean'}")
-    p = asarray(p) * 1.0
-    tol = abs(tol)
-    p, indx = cmplx_sort(p)
-    pout = []
-    mult = []
-    indx = -1
-    curp = p[0] + 5 * tol
-    sameroots = []
-    for k in range(len(p)):
-        tr = p[k]
-        if abs(tr - curp) < tol:
-            sameroots.append(tr)
-            curp = comproot(sameroots)
-            pout[indx] = curp
-            mult[indx] += 1
-        else:
-            pout.append(tr)
-            curp = tr
-            sameroots = [tr]
-            indx += 1
-            mult.append(1)
-    return array(pout), array(mult)
+
+    p = np.asarray(p)
+
+    points = np.empty((len(p), 2))
+    points[:, 0] = np.real(p)
+    points[:, 1] = np.imag(p)
+    tree = cKDTree(points)
+
+    p_unique = []
+    p_multiplicity = []
+    used = np.zeros(len(p), dtype=bool)
+    for i in range(len(p)):
+        if used[i]:
+            continue
+
+        group = tree.query_ball_point(points[i], tol)
+        group = [x for x in group if not used[x]]
+
+        p_unique.append(reduce(p[group]))
+        p_multiplicity.append(len(group))
+
+        used[group] = True
+
+    return np.asarray(p_unique), np.asarray(p_multiplicity)
 
 
 def invres(r, p, k, tol=1e-3, rtype='avg'):

--- a/scipy/signal/tests/test_fir_filter_design.py
+++ b/scipy/signal/tests/test_fir_filter_design.py
@@ -549,7 +549,7 @@ class TestMinimumPhase(object):
         k = [0.349585548646686, 0.373552164395447, 0.326082685363438,
              0.077152207480935, -0.129943946349364, -0.059355880509749]
         m = minimum_phase(h, 'hilbert')
-        assert_allclose(m, k, rtol=2e-3)
+        assert_allclose(m, k, rtol=5e-3)
 
         # f=[0 0.8 0.9 1];
         # a=[0 0 1 1];

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2705,7 +2705,10 @@ class TestUniqueRoots(object):
 
     def test_gh_4915(self):
         p = np.roots(np.convolve(np.ones(5), np.ones(5)))
-        true_roots = [-(-1)**(1/5), (-1)**(4/5), -(-1)**(3/5), (-1)**(2/5)]
+        true_roots = [-(-1 + 0j)**(1/5),
+                       (-1 + 0j)**(4/5),
+                       -(-1 + 0j)**(3/5),
+                       (-1 + 0j)**(2/5)]
 
         unique, multiplicity = unique_roots(p)
         unique = np.sort(unique)

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -24,7 +24,7 @@ from scipy.signal import (
     correlate, convolve, convolve2d, fftconvolve, choose_conv_method,
     hilbert, hilbert2, lfilter, lfilter_zi, filtfilt, butter, zpk2tf, zpk2sos,
     invres, invresz, vectorstrength, lfiltic, tf2sos, sosfilt, sosfiltfilt,
-    sosfilt_zi, tf2zpk, BadCoefficients)
+    sosfilt_zi, tf2zpk, BadCoefficients, unique_roots)
 from scipy.signal.windows import hann
 from scipy.signal.signaltools import _filtfilt_gust
 
@@ -2652,3 +2652,78 @@ class TestDeconvolve(object):
         recorded = [0, 2, 1, 0, 2, 3, 1, 0, 0]
         recovered, remainder = signal.deconvolve(recorded, impulse_response)
         assert_allclose(recovered, original)
+
+
+class TestUniqueRoots(object):
+    def test_real_no_repeat(self):
+        p = [-1.0, -0.5, 0.3, 1.2, 10.0]
+        unique, multiplicity = unique_roots(p)
+        assert_almost_equal(unique, p, decimal=15)
+        assert_equal(multiplicity, np.ones(len(p)))
+
+    def test_real_repeat(self):
+        p = [-1.0, -0.95, -0.89, -0.8, 0.5, 1.0, 1.05]
+
+        unique, multiplicity = unique_roots(p, tol=1e-1, rtype='min')
+        assert_almost_equal(unique, [-1.0, -0.89, 0.5, 1.0], decimal=15)
+        assert_equal(multiplicity, [2, 2, 1, 2])
+
+        unique, multiplicity = unique_roots(p, tol=1e-1, rtype='max')
+        assert_almost_equal(unique, [-0.95, -0.8, 0.5, 1.05], decimal=15)
+        assert_equal(multiplicity, [2, 2, 1, 2])
+
+        unique, multiplicity = unique_roots(p, tol=1e-1, rtype='avg')
+        assert_almost_equal(unique, [-0.975, -0.845, 0.5, 1.025], decimal=15)
+        assert_equal(multiplicity, [2, 2, 1, 2])
+
+    def test_complex_no_repeat(self):
+        p = [-1.0, 1.0j, 0.5 + 0.5j, -1.0 - 1.0j, 3.0 + 2.0j]
+        unique, multiplicity = unique_roots(p)
+        assert_almost_equal(unique, p, decimal=15)
+        assert_equal(multiplicity, np.ones(len(p)))
+
+    def test_complex_repeat(self):
+        p = [-1.0, -1.0 + 0.05j, -0.95 + 0.15j, -0.90 + 0.15j, 0.0,
+             0.5 + 0.5j, 0.45 + 0.55j]
+
+        unique, multiplicity = unique_roots(p, tol=1e-1, rtype='min')
+        assert_almost_equal(unique, [-1.0, -0.95 + 0.15j, 0.0, 0.45 + 0.55j],
+                            decimal=15)
+        assert_equal(multiplicity, [2, 2, 1, 2])
+
+        unique, multiplicity = unique_roots(p, tol=1e-1, rtype='max')
+        assert_almost_equal(unique,
+                            [-1.0 + 0.05j, -0.90 + 0.15j, 0.0, 0.5 + 0.5j],
+                            decimal=15)
+        assert_equal(multiplicity, [2, 2, 1, 2])
+
+        unique, multiplicity = unique_roots(p, tol=1e-1, rtype='avg')
+        assert_almost_equal(
+            unique, [-1.0 + 0.025j, -0.925 + 0.15j, 0.0, 0.475 + 0.525j],
+            decimal=15)
+        assert_equal(multiplicity, [2, 2, 1, 2])
+
+    def test_gh_4915(self):
+        p = np.roots(np.convolve(np.ones(5), np.ones(5)))
+        true_roots = [-(-1)**(1/5), (-1)**(4/5), -(-1)**(3/5), (-1)**(2/5)]
+
+        unique, multiplicity = unique_roots(p)
+        unique = np.sort(unique)
+
+        assert_almost_equal(np.sort(unique), true_roots, decimal=7)
+        assert_equal(multiplicity, [2, 2, 2, 2])
+
+    def test_complex_roots_extra(self):
+        unique, multiplicity = unique_roots([1.0, 1.0j, 1.0])
+        assert_almost_equal(unique, [1.0, 1.0j], decimal=15)
+        assert_equal(multiplicity, [2, 1])
+
+        unique, multiplicity = unique_roots([1, 1 + 2e-9, 1e-9 + 1j], tol=0.1)
+        assert_almost_equal(unique, [1.0, 1e-9 + 1.0j], decimal=15)
+        assert_equal(multiplicity, [2, 1])
+
+    def test_single_unique_root(self):
+        p = np.random.rand(100) + 1j * np.random.rand(100)
+        unique, multiplicity = unique_roots(p, 2)
+        assert_almost_equal(unique, [np.min(p)], decimal=15)
+        assert_equal(multiplicity, [100])

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -12,6 +12,7 @@ from bisect import bisect_left
 import numpy as np
 
 from scipy._lib.six import xrange, zip
+from scipy._lib._util import _broadcast_arrays
 from .base import spmatrix, isspmatrix
 from .sputils import (getdtype, isshape, isscalarlike, IndexMixin,
                       upcast_scalar, get_index_dtype, isintlike, check_shape,
@@ -344,7 +345,7 @@ class lil_matrix(spmatrix, IndexMixin):
 
         # Make x and i into the same shape
         x = np.asarray(x, dtype=self.dtype)
-        x, _ = np.broadcast_arrays(x, i)
+        x, _ = _broadcast_arrays(x, i)
 
         if x.shape != i.shape:
             raise ValueError("shape mismatch in assignment")

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -11,8 +11,14 @@ from bisect import bisect_left
 
 import numpy as np
 
+from scipy._lib._version import NumpyVersion
 from scipy._lib.six import xrange, zip
-from scipy._lib._util import _broadcast_arrays
+
+if NumpyVersion(np.__version__) >= '1.17.0':
+    from scipy._lib._util import _broadcast_arrays
+else:
+    from numpy import broadcast_arrays as _broadcast_arrays
+
 from .base import spmatrix, isspmatrix
 from .sputils import (getdtype, isshape, isscalarlike, IndexMixin,
                       upcast_scalar, get_index_dtype, isintlike, check_shape,

--- a/scipy/sparse/linalg/dsolve/_add_newdocs.py
+++ b/scipy/sparse/linalg/dsolve/_add_newdocs.py
@@ -69,10 +69,8 @@ add_newdoc('scipy.sparse.linalg.dsolve._superlu', 'SuperLU',
 
     The permutation matrices can be constructed:
 
-    >>> Pr = csc_matrix((4, 4))
-    >>> Pr[lu.perm_r, np.arange(4)] = 1
-    >>> Pc = csc_matrix((4, 4))
-    >>> Pc[np.arange(4), lu.perm_c] = 1
+    >>> Pr = csc_matrix((np.ones(4), (lu.perm_r, np.arange(4))))
+    >>> Pc = csc_matrix((np.ones(4), (np.arange(4), lu.perm_c)))
 
     We can reassemble the original matrix:
 

--- a/scipy/sparse/linalg/eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/arpack.py
@@ -852,22 +852,27 @@ class _UnsymmetricArpackParams(_ArpackParams):
                 z = z[:, :nreturned]
             else:
                 # we got one extra eigenvalue (likely a cc pair, but which?)
-                # cut at approx precision for sorting
-                rd = np.round(d, decimals=_ndigits[self.tp])
+                if self.mode in (1, 2):
+                    rd = d
+                elif self.mode in (3, 4):
+                    rd = 1 / (d - self.sigma)
+
                 if self.which in ['LR', 'SR']:
                     ind = np.argsort(rd.real)
                 elif self.which in ['LI', 'SI']:
                     # for LI,SI ARPACK returns largest,smallest
-                    # abs(imaginary) why?
+                    # abs(imaginary) (complex pairs come together)
                     ind = np.argsort(abs(rd.imag))
                 else:
                     ind = np.argsort(abs(rd))
+
                 if self.which in ['LR', 'LM', 'LI']:
-                    d = d[ind[-k:]]
-                    z = z[:, ind[-k:]]
-                if self.which in ['SR', 'SM', 'SI']:
-                    d = d[ind[:k]]
-                    z = z[:, ind[:k]]
+                    ind = ind[-k:][::-1]
+                elif self.which in ['SR', 'SM', 'SI']:
+                    ind = ind[:k]
+
+                d = d[ind]
+                z = z[:, ind]
         else:
             # complex is so much simpler...
             d, z, ierr =\

--- a/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
@@ -208,7 +208,7 @@ def eval_evec(symmetric, d, typ, k, which, v0=None, sigma=None,
     ac = mattype(a)
 
     if general:
-        b = d['bmat'].astype(typ.lower())
+        b = d['bmat'].astype(typ)
         bc = mattype(b)
 
     # get exact eigenvalues
@@ -301,6 +301,8 @@ class SymmetricParams:
                             pos_definite=True).astype('f').astype('d')
         Ac = generate_matrix(N, hermitian=True, pos_definite=True,
                              complex=True).astype('F').astype('D')
+        Mc = generate_matrix(N, hermitian=True, pos_definite=True,
+                             complex=True).astype('F').astype('D')
         v0 = np.random.random(N)
 
         # standard symmetric problem
@@ -329,8 +331,15 @@ class SymmetricParams:
         GH['v0'] = v0
         GH['eval'] = eigh(GH['mat'], GH['bmat'], eigvals_only=True)
 
+        # general hermitian problem with hermitian M
+        GHc = DictWithRepr("gen-hermitian-Mc")
+        GHc['mat'] = Ac
+        GHc['bmat'] = Mc
+        GHc['v0'] = v0
+        GHc['eval'] = eigh(GHc['mat'], GHc['bmat'], eigvals_only=True)
+
         self.real_test_cases = [SS, GS]
-        self.complex_test_cases = [SH, GH]
+        self.complex_test_cases = [SH, GH, GHc]
 
 
 class NonSymmetricParams:

--- a/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
@@ -7,6 +7,7 @@ To run tests locally:
 """
 
 import threading
+import itertools
 
 import numpy as np
 
@@ -17,7 +18,7 @@ import pytest
 
 from numpy import dot, conj, random
 from scipy.linalg import eig, eigh, hilbert, svd
-from scipy.sparse import csc_matrix, csr_matrix, isspmatrix, diags
+from scipy.sparse import csc_matrix, csr_matrix, isspmatrix, diags, rand
 from scipy.sparse.linalg import LinearOperator, aslinearoperator
 from scipy.sparse.linalg.eigen.arpack import eigs, eigsh, svds, \
      ArpackNoConvergence, arpack
@@ -972,3 +973,42 @@ def test_eigsh_for_k_greater():
         # Test 'A' for different types
         assert_raises(TypeError, eigsh, aslinearoperator(A), k=4)
         assert_raises(TypeError, eigsh, A_sparse, M=M_dense, k=4)
+
+
+def test_real_eigs_real_k_subset():
+    np.random.seed(1)
+
+    n = 10
+    A = rand(n, n, density=0.5)
+    A.data *= 2
+    A.data -= 1
+
+    v0 = np.ones(n)
+
+    whichs = ['LM', 'SM', 'LR', 'SR', 'LI', 'SI']
+    dtypes = [np.float32, np.float64]
+
+    for which, sigma, dtype in itertools.product(whichs, [None, 0, 5], dtypes):
+        prev_w = np.array([], dtype=dtype)
+        eps = np.finfo(dtype).eps
+        for k in range(1, 9):
+            w, z = eigs(A.astype(dtype), k=k, which=which, sigma=sigma,
+                        v0=v0.astype(dtype), tol=0)
+            assert_allclose(np.linalg.norm(A.dot(z) - z * w), 0, atol=np.sqrt(eps))
+
+            # Check that the set of eigenvalues for `k` is a subset of that for `k+1`
+            dist = abs(prev_w[:,None] - w).min(axis=1)
+            assert_allclose(dist, 0, atol=np.sqrt(eps))
+
+            prev_w = w
+
+            # Check sort order
+            if sigma is None:
+                d = w
+            else:
+                d = 1 / (w - sigma)
+
+            if which == 'LM':
+                # ARPACK is systematic for 'LM', but sort order
+                # appears not well defined for other modes
+                assert np.all(np.diff(abs(d)) <= 1e-6)

--- a/scipy/sparse/linalg/matfuncs.py
+++ b/scipy/sparse/linalg/matfuncs.py
@@ -611,7 +611,7 @@ def _expm(A, use_exact_onenorm):
     # algorithms.
 
     # Avoid indiscriminate asarray() to allow sparse or other strange arrays.
-    if isinstance(A, (list, tuple)):
+    if isinstance(A, (list, tuple, np.matrix)):
         A = np.asarray(A)
     if len(A.shape) != 2 or A.shape[0] != A.shape[1]:
         raise ValueError('expected a square matrix')

--- a/scipy/sparse/linalg/tests/test_matfuncs.py
+++ b/scipy/sparse/linalg/tests/test_matfuncs.py
@@ -524,6 +524,17 @@ class TestExpM(object):
                 atol = 1e-13 * abs(expected).max()
                 assert_allclose(got, expected, atol=atol)
 
+    def test_matrix_input(self):
+        # Large np.matrix inputs should work, gh-5546
+        A = np.zeros((200, 200))
+        A[-1,0] = 1
+        B0 = expm(A)
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning, "the matrix subclass.*")
+            sup.filter(PendingDeprecationWarning, "the matrix subclass.*")
+            B = expm(np.matrix(A))
+        assert_allclose(B, B0)
+
 
 class TestOperators(object):
 

--- a/scipy/sparse/sputils.py
+++ b/scipy/sparse/sputils.py
@@ -7,6 +7,8 @@ import operator
 import warnings
 import numpy as np
 
+from scipy._lib._util import _broadcast_arrays
+
 __all__ = ['upcast', 'getdtype', 'isscalarlike', 'isintlike',
            'isshape', 'issequence', 'isdense', 'ismatrix', 'get_sum_dtype']
 
@@ -455,7 +457,7 @@ class IndexMixin(object):
             # row vector special case
             j = np.atleast_1d(j)
             if i.ndim == 1:
-                i, j = np.broadcast_arrays(i, j)
+                i, j = _broadcast_arrays(i, j)
                 i = i[:, None]
                 j = j[:, None]
                 return i, j
@@ -464,7 +466,7 @@ class IndexMixin(object):
             if i_slice and j.ndim > 1:
                 raise IndexError('index returns 3-dim structure')
 
-        i, j = np.broadcast_arrays(i, j)
+        i, j = _broadcast_arrays(i, j)
 
         if i.ndim == 1:
             # return column vectors for 1-D indexing

--- a/scipy/sparse/sputils.py
+++ b/scipy/sparse/sputils.py
@@ -7,7 +7,12 @@ import operator
 import warnings
 import numpy as np
 
-from scipy._lib._util import _broadcast_arrays
+from scipy._lib._version import NumpyVersion
+
+if NumpyVersion(np.__version__) >= '1.17.0':
+    from scipy._lib._util import _broadcast_arrays
+else:
+    from numpy import broadcast_arrays as _broadcast_arrays
 
 __all__ = ['upcast', 'getdtype', 'isscalarlike', 'isintlike',
            'isshape', 'issequence', 'isdense', 'ismatrix', 'get_sum_dtype']

--- a/scipy/sparse/sputils.py
+++ b/scipy/sparse/sputils.py
@@ -13,7 +13,7 @@ __all__ = ['upcast', 'getdtype', 'isscalarlike', 'isintlike',
            'isshape', 'issequence', 'isdense', 'ismatrix', 'get_sum_dtype']
 
 supported_dtypes = ['bool', 'int8', 'uint8', 'short', 'ushort', 'intc',
-                    'uintc', 'longlong', 'ulonglong', 'single', 'double',
+                    'uintc', 'l', 'L', 'longlong', 'ulonglong', 'single', 'double',
                     'longdouble', 'csingle', 'cdouble', 'clongdouble']
 supported_dtypes = [np.typeDict[x] for x in supported_dtypes]
 

--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -556,12 +556,8 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
             if ((self.data < 0)[:, periodic_mask]).any():
                 raise ValueError("Negative input data are outside of the periodic box.")
 
-        self.maxes = np.ascontiguousarray(
-            np.amax(self.data, axis=0) if self.n > 0 else np.zeros(self.m),
-            dtype=np.float64)
-        self.mins = np.ascontiguousarray(
-            np.amin(self.data,axis=0) if self.n > 0 else np.zeros(self.m),
-            dtype=np.float64)
+        self.maxes = np.ascontiguousarray(np.amax(self.data,axis=0), dtype=np.float64)
+        self.mins = np.ascontiguousarray(np.amin(self.data,axis=0), dtype=np.float64)
         self.indices = np.ascontiguousarray(np.arange(self.n,dtype=np.intp))
 
         self._pre_init()

--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -556,8 +556,12 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
             if ((self.data < 0)[:, periodic_mask]).any():
                 raise ValueError("Negative input data are outside of the periodic box.")
 
-        self.maxes = np.ascontiguousarray(np.amax(self.data,axis=0), dtype=np.float64)
-        self.mins = np.ascontiguousarray(np.amin(self.data,axis=0), dtype=np.float64)
+        self.maxes = np.ascontiguousarray(
+            np.amax(self.data, axis=0) if self.n > 0 else np.zeros(self.m),
+            dtype=np.float64)
+        self.mins = np.ascontiguousarray(
+            np.amin(self.data,axis=0) if self.n > 0 else np.zeros(self.m),
+            dtype=np.float64)
         self.indices = np.ascontiguousarray(np.arange(self.n,dtype=np.intp))
 
         self._pre_init()

--- a/scipy/spatial/qhull.pyx
+++ b/scipy/spatial/qhull.pyx
@@ -125,8 +125,6 @@ cdef extern from "qhull_src/src/libqhull_r.h":
         int num_vertices
         int center_size
         unsigned int facet_id
-        int hull_dim
-        int num_points
         pointT *first_point
         pointT *input_points
         coordT* feasible_point
@@ -679,7 +677,7 @@ cdef class _Qhull:
             The array of points contained in Qhull.
 
         """
-        cdef pointT *point
+        cdef vertexT *vertex
         cdef int i, j, numpoints, point_ndim
         cdef np.ndarray[np.npy_double, ndim=2] points
 
@@ -693,15 +691,20 @@ cdef class _Qhull:
         if self._is_delaunay:
             point_ndim += 1
 
-        numpoints = self._qh.num_points
-        points = np.zeros((numpoints, point_ndim))
+        numvertices = self._qh.num_vertices
 
+        vertex = self._qh.vertex_list
+        points = np.zeros((numvertices, point_ndim))
+
+        i = 0
         with nogil:
-            point = self._qh.first_point
-            for i in range(numpoints):
-                for j in range(point_ndim):
-                    points[i,j] = point[j]
-                point += self._qh.hull_dim
+            while vertex and vertex.next:
+                j = 0
+                for j in xrange(point_ndim):
+                    points[i, j] = vertex.point[j]
+
+                i += 1
+                vertex = vertex.next
 
         return points
 

--- a/scipy/spatial/qhull.pyx
+++ b/scipy/spatial/qhull.pyx
@@ -125,6 +125,8 @@ cdef extern from "qhull_src/src/libqhull_r.h":
         int num_vertices
         int center_size
         unsigned int facet_id
+        int hull_dim
+        int num_points
         pointT *first_point
         pointT *input_points
         coordT* feasible_point
@@ -677,7 +679,7 @@ cdef class _Qhull:
             The array of points contained in Qhull.
 
         """
-        cdef vertexT *vertex
+        cdef pointT *point
         cdef int i, j, numpoints, point_ndim
         cdef np.ndarray[np.npy_double, ndim=2] points
 
@@ -691,20 +693,15 @@ cdef class _Qhull:
         if self._is_delaunay:
             point_ndim += 1
 
-        numvertices = self._qh.num_vertices
+        numpoints = self._qh.num_points
+        points = np.zeros((numpoints, point_ndim))
 
-        vertex = self._qh.vertex_list
-        points = np.zeros((numvertices, point_ndim))
-
-        i = 0
         with nogil:
-            while vertex and vertex.next:
-                j = 0
-                for j in xrange(point_ndim):
-                    points[i, j] = vertex.point[j]
-
-                i += 1
-                vertex = vertex.next
+            point = self._qh.first_point
+            for i in range(numpoints):
+                for j in range(point_ndim):
+                    points[i,j] = point[j]
+                point += self._qh.hull_dim
 
         return points
 

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -1335,62 +1335,6 @@ def test_short_knn():
             [0., 0.01, np.inf, np.inf],
             [0., np.inf, np.inf, np.inf]])
 
-def test_query_ball_point_vector_r():
-
-    np.random.seed(1234)
-    data = np.random.normal(size=(100, 3))
-    query = np.random.normal(size=(100, 3))
-    tree = cKDTree(data)
-    d = np.random.uniform(0, 0.3, size=len(query))
-
-    rvector = tree.query_ball_point(query, d)
-    rscalar = [tree.query_ball_point(qi, di) for qi, di in zip(query, d)]
-    for a, b in zip(rvector, rscalar):
-        assert_array_equal(sorted(a), sorted(b))
-
-def test_query_ball_point_length():
-
-    np.random.seed(1234)
-    data = np.random.normal(size=(100, 3))
-    query = np.random.normal(size=(100, 3))
-    tree = cKDTree(data)
-    d = 0.3
-
-    length = tree.query_ball_point(query, d, return_length=True)
-    length2 = [len(ind) for ind in tree.query_ball_point(query, d, return_length=False)]
-    length3 = [len(tree.query_ball_point(qi, d)) for qi in query]
-    length4 = [tree.query_ball_point(qi, d, return_length=True) for qi in query]
-    assert_array_equal(length, length2)
-    assert_array_equal(length, length3)
-    assert_array_equal(length, length4)
-
-@pytest.mark.parametrize("balanced_tree, compact_nodes",
-    [(True, False),
-     (True, True),
-     (False, False),
-     (False, True)])
-def test_cdktree_empty_input(balanced_tree, compact_nodes):
-    # https://github.com/scipy/scipy/issues/5040
-    np.random.seed(1234)
-    empty_v3 = np.empty(shape=(0, 3))
-    query_v3 = np.ones(shape=(1, 3))
-    query_v2 = np.ones(shape=(2, 3))
-
-    tree = cKDTree(empty_v3, balanced_tree=balanced_tree, compact_nodes=compact_nodes)
-    length = tree.query_ball_point(query_v3, 0.3, return_length=True)
-    assert length == 0
-
-    dd, ii = tree.query(query_v2, 2)
-    assert ii.shape == (2, 2)
-    assert dd.shape == (2, 2)
-    assert np.isinf(dd).all()
-
-    N = tree.count_neighbors(tree, [0, 1])
-    assert_array_equal(N, [0, 0])
-
-    M = tree.sparse_distance_matrix(tree, 0.3)
-    assert M.shape == (0, 0)
-
 class Test_sorted_query_ball_point(object):
 
     def setup_method(self):

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -1335,6 +1335,62 @@ def test_short_knn():
             [0., 0.01, np.inf, np.inf],
             [0., np.inf, np.inf, np.inf]])
 
+def test_query_ball_point_vector_r():
+
+    np.random.seed(1234)
+    data = np.random.normal(size=(100, 3))
+    query = np.random.normal(size=(100, 3))
+    tree = cKDTree(data)
+    d = np.random.uniform(0, 0.3, size=len(query))
+
+    rvector = tree.query_ball_point(query, d)
+    rscalar = [tree.query_ball_point(qi, di) for qi, di in zip(query, d)]
+    for a, b in zip(rvector, rscalar):
+        assert_array_equal(sorted(a), sorted(b))
+
+def test_query_ball_point_length():
+
+    np.random.seed(1234)
+    data = np.random.normal(size=(100, 3))
+    query = np.random.normal(size=(100, 3))
+    tree = cKDTree(data)
+    d = 0.3
+
+    length = tree.query_ball_point(query, d, return_length=True)
+    length2 = [len(ind) for ind in tree.query_ball_point(query, d, return_length=False)]
+    length3 = [len(tree.query_ball_point(qi, d)) for qi in query]
+    length4 = [tree.query_ball_point(qi, d, return_length=True) for qi in query]
+    assert_array_equal(length, length2)
+    assert_array_equal(length, length3)
+    assert_array_equal(length, length4)
+
+@pytest.mark.parametrize("balanced_tree, compact_nodes",
+    [(True, False),
+     (True, True),
+     (False, False),
+     (False, True)])
+def test_cdktree_empty_input(balanced_tree, compact_nodes):
+    # https://github.com/scipy/scipy/issues/5040
+    np.random.seed(1234)
+    empty_v3 = np.empty(shape=(0, 3))
+    query_v3 = np.ones(shape=(1, 3))
+    query_v2 = np.ones(shape=(2, 3))
+
+    tree = cKDTree(empty_v3, balanced_tree=balanced_tree, compact_nodes=compact_nodes)
+    length = tree.query_ball_point(query_v3, 0.3, return_length=True)
+    assert length == 0
+
+    dd, ii = tree.query(query_v2, 2)
+    assert ii.shape == (2, 2)
+    assert dd.shape == (2, 2)
+    assert np.isinf(dd).all()
+
+    N = tree.count_neighbors(tree, [0, 1])
+    assert_array_equal(N, [0, 0])
+
+    M = tree.sparse_distance_matrix(tree, 0.3)
+    assert M.shape == (0, 0)
+
 class Test_sorted_query_ball_point(object):
 
     def setup_method(self):

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -1006,39 +1006,3 @@ class Test_HalfspaceIntersection(object):
             self.assert_unordered_allclose(inc_hs.intersections, hs.intersections)
 
         inc_hs.close()
-
-    def test_cube(self):
-        # Halfspaces of the cube:
-        halfspaces = np.array([[-1., 0., 0., 0.],  # x >= 0
-                               [1., 0., 0., -1.],  # x <= 1
-                               [0., -1., 0., 0.],  # y >= 0
-                               [0., 1., 0., -1.],  # y <= 1
-                               [0., 0., -1., 0.],  # z >= 0
-                               [0., 0., 1., -1.]])  # z <= 1
-        point = np.array([0.5, 0.5, 0.5])
-
-        hs = qhull.HalfspaceIntersection(halfspaces, point)
-
-        # qhalf H0.5,0.5,0.5 o < input.txt
-        qhalf_points = np.array([
-            [-2, 0, 0],
-            [2, 0, 0],
-            [0, -2, 0],
-            [0, 2, 0],
-            [0, 0, -2],
-            [0, 0, 2]])
-        qhalf_facets = [
-            [2, 4, 0],
-            [4, 2, 1],
-            [5, 2, 0],
-            [2, 5, 1],
-            [3, 4, 1],
-            [4, 3, 0],
-            [5, 3, 1],
-            [3, 5, 0]]
-
-        assert len(qhalf_facets) == len(hs.dual_facets)
-        for a, b in zip(qhalf_facets, hs.dual_facets):
-            assert set(a) == set(b)  # facet orientation can differ
-
-        assert_allclose(hs.dual_points, qhalf_points)

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -1006,3 +1006,39 @@ class Test_HalfspaceIntersection(object):
             self.assert_unordered_allclose(inc_hs.intersections, hs.intersections)
 
         inc_hs.close()
+
+    def test_cube(self):
+        # Halfspaces of the cube:
+        halfspaces = np.array([[-1., 0., 0., 0.],  # x >= 0
+                               [1., 0., 0., -1.],  # x <= 1
+                               [0., -1., 0., 0.],  # y >= 0
+                               [0., 1., 0., -1.],  # y <= 1
+                               [0., 0., -1., 0.],  # z >= 0
+                               [0., 0., 1., -1.]])  # z <= 1
+        point = np.array([0.5, 0.5, 0.5])
+
+        hs = qhull.HalfspaceIntersection(halfspaces, point)
+
+        # qhalf H0.5,0.5,0.5 o < input.txt
+        qhalf_points = np.array([
+            [-2, 0, 0],
+            [2, 0, 0],
+            [0, -2, 0],
+            [0, 2, 0],
+            [0, 0, -2],
+            [0, 0, 2]])
+        qhalf_facets = [
+            [2, 4, 0],
+            [4, 2, 1],
+            [5, 2, 0],
+            [2, 5, 1],
+            [3, 4, 1],
+            [4, 3, 0],
+            [5, 3, 1],
+            [3, 5, 0]]
+
+        assert len(qhalf_facets) == len(hs.dual_facets)
+        for a, b in zip(qhalf_facets, hs.dual_facets):
+            assert set(a) == set(b)  # facet orientation can differ
+
+        assert_allclose(hs.dual_points, qhalf_points)

--- a/scipy/special/_ellip_harm.pxd
+++ b/scipy/special/_ellip_harm.pxd
@@ -49,6 +49,11 @@ cdef extern from "lapack_defs.h":
 cdef inline double* lame_coefficients(double h2, double k2, int n, int p,
                                       void **bufferp, double signm,
                                       double signn) nogil:
+
+    # Ensure that the caller can safely call free(*bufferp) even if an
+    # invalid argument is found in the following validation code.
+    bufferp[0] = NULL
+
     if n < 0:
         sf_error.error("ellip_harm", sf_error.ARG, "invalid value for n")
         return NULL

--- a/scipy/special/tests/test_ellip_harm.py
+++ b/scipy/special/tests/test_ellip_harm.py
@@ -271,3 +271,11 @@ def test_ellip_harm():
     points = np.array(points)
     assert_func_equal(ellip_harm, ellip_harm_known, points, rtol=1e-12)
 
+
+def test_ellip_harm_invalid_p():
+    # Regression test. This should return nan.
+    n = 4
+    # Make p > 2*n + 1.
+    p = 2*n + 2
+    result = ellip_harm(0.5, 2.0, n, p, 0.2)
+    assert np.isnan(result)

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3048,7 +3048,10 @@ def pearsonr(x, y):
 
     References
     ----------
-    http://www.statsoft.com/textbook/glosp.html#Pearson%20Correlation
+    .. [1] "Pearson correlation coefficient", Wikipedia,
+           https://en.wikipedia.org/wiki/Pearson_correlation_coefficient
+    .. [2] Student, "Probable error of a correlation coefficient",
+           Biometrika, Volume 6, Issue 2-3, 1 September 1908, pp. 302-310.
 
     Examples
     --------

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3010,6 +3010,41 @@ def pearsonr(x, y):
     where :math:`m_x` is the mean of the vector :math:`x` and :math:`m_y` is
     the mean of the vector :math:`y`.
 
+    Under the assumption that x and y are drawn from independent normal
+    distributions (so the population correlation coefficient is 0), the
+    probability density function of the sample correlation coefficient r
+    is ([1]_, [2]_)::
+
+               (1 - r**2)**(n/2 - 2)
+        f(r) = ---------------------
+                  B(1/2, n/2 - 1)
+
+    where n is the number of samples, and B is the beta function.  This
+    is sometimes referred to as the exact distribution of r.  This is
+    the distribution that is used in `pearsonr` to compute the p-value.
+    The distribution is a beta distribution on the interval [-1, 1],
+    with equal shape parameters a = b = n/2 - 1.  In terms of SciPy's
+    implementation of the beta distribution, the distribution of r is::
+
+        dist = scipy.stats.beta(n/2 - 1, n/2 - 1, loc=-1, scale=2)
+
+    The p-value returned by `pearsonr` is a two-sided p-value.  For a
+    given sample with correlation coefficient r, the p-value is
+    the probability that abs(r') of a random sample x' and y' drawn from
+    the population with zero correlation would be greater than or equal
+    to abs(r).  In terms of the object ``dist`` shown above, the p-value
+    for a given r and length n can be computed as::
+
+        p = 2*dist.cdf(-abs(r))
+
+    When n is 2, the above continuous distribution is not well-defined.
+    One can interpret the limit of the beta distribution as the shape
+    parameters a and b approach a = b = 0 as a discrete distribution with
+    equal probability masses at r = 1 and r = -1.  More directly, one
+    can observe that, given the data x = [x1, x2] and y = [y1, y2], and
+    assuming x1 != x2 and y1 != y2, the only possible values for r are 1
+    and -1.  Because abs(r') for any sample x' and y' with length 2 will
+    be 1, the two-sided p-value for a sample of length 2 is always 1.
 
     References
     ----------

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -136,7 +136,7 @@ def test_cont_basic(distname, arg):
         check_pickling(distfn, arg)
 
         # Entropy
-        if distname not in ['ksone', 'kstwobign']:
+        if distname not in ['ksone', 'kstwobign', 'ncf', 'crystalball']:
             check_entropy(distfn, arg, distname)
 
         if distfn.numargs == 0:

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2084,7 +2084,10 @@ class TestIQR(object):
                                     np.array([2, np.nan, 2]) / 1.3489795)
                 assert_equal(stats.iqr(x, axis=1, scale=2.0, nan_policy='propagate'),
                              [1, np.nan, 1])
-                _check_warnings(w, RuntimeWarning, 6)
+                if numpy_version <= '1.16.6':
+                    _check_warnings(w, RuntimeWarning, 6)
+                else:
+                    _check_warnings(w, RuntimeWarning, 0)
 
         if numpy_version < '1.9.0a':
             with warnings.catch_warnings(record=True) as w:

--- a/setup.py
+++ b/setup.py
@@ -111,16 +111,9 @@ def get_version_info():
     elif os.path.exists('scipy/version.py'):
         # must be a source distribution, use existing version file
         # load it as a separate module to not load scipy/__init__.py
-        # based on approach described in python-ideas
-        # https://mail.python.org/pipermail/python-ideas/2014-December/030265.html
-        import importlib
-        module_name = 'scipy.version'
-        path = 'scipy/version.py'
-        loader = importlib.machinery.SourceFileLoader(module_name, path)
-        spec = importlib.machinery.ModuleSpec(module_name, loader, origin=path)
-        module = importlib.util.module_from_spec(spec)
-        version = loader.exec_module(module)
-        GIT_REVISION = version.git_revision
+        import runpy
+        ns = runpy.run_path('scipy/version.py')
+        GIT_REVISION = ns['git_revision']
     else:
         GIT_REVISION = "Unknown"
 

--- a/setup.py
+++ b/setup.py
@@ -111,8 +111,15 @@ def get_version_info():
     elif os.path.exists('scipy/version.py'):
         # must be a source distribution, use existing version file
         # load it as a separate module to not load scipy/__init__.py
-        import imp
-        version = imp.load_source('scipy.version', 'scipy/version.py')
+        # based on approach described in python-ideas
+        # https://mail.python.org/pipermail/python-ideas/2014-December/030265.html
+        import importlib
+        module_name = 'scipy.version'
+        path = 'scipy/version.py'
+        loader = importlib.machinery.SourceFileLoader(module_name, path)
+        spec = importlib.machinery.ModuleSpec(module_name, loader, origin=path)
+        module = importlib.util.module_from_spec(spec)
+        version = loader.exec_module(module)
         GIT_REVISION = version.git_revision
     else:
         GIT_REVISION = "Unknown"

--- a/tools/ci/appveyor/requirements.txt
+++ b/tools/ci/appveyor/requirements.txt
@@ -4,7 +4,6 @@ pytest
 pytest-timeout
 pytest-xdist
 pytest-env
-pytest-faulthandler
 Pillow
 mpmath
 matplotlib


### PR DESCRIPTION
Definitely a WIP for now -- let me know if I'm missing PRs to backport for the 1.2.x LTS (Python 2.7) series. I've included the list of backport candidates considered so far & reasonings for picking / rejecting below the fold. This can be tricky because of the backport-candidate labels being targeted to different milestones & things sometimes only making sense for 1.3.x vs. 1.2.x, etc.

<details>

* https://github.com/scipy/scipy/pull/10671
* https://github.com/scipy/scipy/pull/10693
* https://github.com/scipy/scipy/pull/10071
  - cherry-picked / initial mention in relnotes
* https://github.com/scipy/scipy/pull/10196
  - doesn't seem relevant to 1.2.x
* https://github.com/scipy/scipy/pull/10207
  - doesn't seem relevant to 1.2.x
* https://github.com/scipy/scipy/pull/10233
  - doesn't seem relevant to 1.2.x ?
* https://github.com/scipy/scipy/pull/10306
  - cherry-picked / initial mention in relnotes
* https://github.com/scipy/scipy/pull/10309
  - cherry-picked / initial mention in relnotes
* https://github.com/scipy/scipy/pull/10377
  - cherry-picking with mods because docs for 2.7 won't be quite the same w.r.t pytest; initial mention in relnotes
* https://github.com/scipy/scipy/pull/10379
  - scipy/sparse/_index.py doesn't seem to exist in 1.2.x, **but I have backported the concept now**
* https://github.com/scipy/scipy/pull/10426
  - cherry-picked / initial mention in relnotes
* https://github.com/scipy/scipy/pull/10431
  - only affects Python 3.x, so can skip this I think
* https://github.com/scipy/scipy/pull/10457
  - cherry-picked / initial mention in relnotes
* https://github.com/scipy/scipy/pull/10503
  - cherry-picked / initial mention in relnotes
* https://github.com/scipy/scipy/pull/10516
  - backport conflicts look annoying -- could try maybe
* https://github.com/scipy/scipy/pull/10540
* https://github.com/scipy/scipy/pull/10573
* https://github.com/scipy/scipy/pull/10600
  - not needed according to Evgeni
</details>

Pretty sure I had at least two local Python 2.7 test failures with the base branch before backports, so won't be surprised to see CI complaints initially here.