### PR TITLE
ENH: calculation of region areas in spatial.SphericalVoronoi

### DIFF
--- a/benchmarks/benchmarks/spatial.py
+++ b/benchmarks/benchmarks/spatial.py
@@ -321,6 +321,21 @@ class SphericalVorSort(Benchmark):
         """
         self.sv.sort_vertices_of_regions()
 
+
+class SphericalVorAreas(Benchmark):
+    params = [10, 100, 1000, 5000, 10000]
+    param_names = ['num_points']
+
+    def setup(self, num_points):
+        self.points = generate_spherical_points(num_points)
+        self.sv = SphericalVoronoi(self.points, radius=1,
+                                   center=np.zeros(3))
+
+    def time_spherical_polygon_area_calculation(self, num_points):
+        """Time the area calculation in the Spherical Voronoi code."""
+        self.sv.calculate_areas()
+
+
 class Xdist(Benchmark):
     params = ([10, 100, 1000], ['euclidean', 'minkowski', 'cityblock',
     'seuclidean', 'sqeuclidean', 'cosine', 'correlation', 'hamming', 'jaccard',

--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -325,7 +325,7 @@ class SphericalVoronoi:
         spherical polygons (not planar). The sum of the areas is
         `4 * pi * radius**2`.
 
-        .. versionadded:: 1.4.0
+        .. versionadded:: 1.5.0
 
         Returns
         -------

--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -212,24 +212,22 @@ class SphericalVoronoi:
             h, vh, circle = -h, -vh, -circle
         circle_radius = np.sqrt(np.maximum(0, self.radius**2 - h**2))
 
+        # calculate the north and south poles in this basis
+        poles = [[0, 0, self.radius], [0, 0, -self.radius]]
+
         # calculate spherical voronoi diagram on the circle
         lower_dimensional = SphericalVoronoi(circle[:, :2],
                                              radius=circle_radius)
         n = len(lower_dimensional.vertices)
         vertices = h * np.ones((n, 3))
         vertices[:, :2] = lower_dimensional.vertices
-        vertices = vertices @ vh
-
-        # calculate the north and south poles in this basis
-        poles = [[0, 0, self.radius], [0, 0, -self.radius]] @ vh
 
         # north and south poles are also Voronoi vertices
-        vertices = np.concatenate((vertices, poles))
+        self.vertices = np.concatenate((vertices, poles)) @ vh + self.center
 
         # each region contains two vertices from the plane and the north and
         # south poles
         self.regions = [[a, n, b, n + 1] for a, b in lower_dimensional.regions]
-        self.vertices = vertices + self.center
 
     def _calc_vertices_regions(self):
         """

--- a/scipy/spatial/tests/test_spherical_voronoi.py
+++ b/scipy/spatial/tests/test_spherical_voronoi.py
@@ -13,6 +13,7 @@ from scipy.spatial import _spherical_voronoi as spherical_voronoi
 from scipy.spatial.transform import Rotation
 from scipy.optimize import linear_sum_assignment
 from scipy.constants import golden as phi
+from scipy.spatial import geometric_slerp
 
 
 TOL = 1E-10
@@ -382,3 +383,15 @@ class TestSphericalVoronoi(object):
         sv = SphericalVoronoi(points)
         areas = sv.calculate_areas()
         assert_almost_equal(areas, 4 * np.pi / len(points))
+
+    def test_ultra_close_gens(self):
+        # use geometric_slerp to produce generators that
+        # are close together, to push the limits
+        # of the area (angle) calculations
+        # also, limit generators to a single hemisphere
+        path = geometric_slerp([0, 0, 1],
+                               [1, 0, 0],
+                               t=np.linspace(0, 1, 1000))
+        sv = SphericalVoronoi(path)
+        areas = sv.calculate_areas()
+        assert_almost_equal(areas.sum(), 4 * np.pi)

--- a/scipy/spatial/tests/test_spherical_voronoi.py
+++ b/scipy/spatial/tests/test_spherical_voronoi.py
@@ -226,7 +226,7 @@ class TestSphericalVoronoi(object):
 
         for points in [self.hemisphere_points, self.hemisphere_points2]:
             sv = SphericalVoronoi(points)
-            triangles = sv._tri.points[sv._tri.simplices]
+            triangles = sv.points[sv._simplices]
             dots = np.einsum('ij,ij->i', sv.vertices, triangles[:, 0])
             circumradii = np.arccos(np.clip(dots, -1, 1))
             assert np.max(circumradii) > np.pi / 2
@@ -305,7 +305,7 @@ class TestSphericalVoronoi(object):
 
         # verify Euler characteristic
         cell_counts = []
-        simplices = np.sort(sv._tri.simplices)
+        simplices = np.sort(sv._simplices)
         for i in range(1, dim + 1):
             cells = []
             for indices in itertools.combinations(range(dim), i):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### What does this implement/fix?
<!--Please explain your changes.-->
This adds a method to calculate the areas of Voronoi regions in the `SphericalVoronoi` class.
Benchmarks:
```
============ =============
 num_points               
------------ -------------
    10          313±7μs   
    100       1.18±0.04ms 
    1000      9.66±0.2ms 
    5000      46.6±0.6ms 
   10000       93.6±2ms  
============ =============
```

#### Additional information
<!--Any additional information you think is important.-->
The `sort_vertices_of_regions` method sorts the regions in-place.  This means that we can't call it from within the `SphericalVoronoi` class without unexpected side-effects.  A call to the `calculate_areas` method added in this PR changes the region list.