### PR TITLE
BENCH: optimize: more comprehensive linprog benchmarking

### DIFF
--- a/benchmarks/benchmarks/optimize_linprog.py
+++ b/benchmarks/benchmarks/optimize_linprog.py
@@ -184,8 +184,9 @@ class Netlib(Benchmark):
     def track_netlib(self, meth, prob):
         if self.fun is None:
             self.time_netlib(meth, prob)
-        self.error = np.abs(self.fun - self.obj)
-        return self.error
+        self.abs_error = np.abs(self.fun - self.obj)
+        self.rel_error = np.abs((self.fun - self.obj)/self.obj)
+        return min(self.abs_error, self.rel_error)
 
 
 class Netlib_RR(Benchmark):
@@ -234,8 +235,13 @@ class Netlib_RR(Benchmark):
         if meth == _remove_redundancy_sparse:
             self.rr_A = self.rr_A.todense()
 
-#        rr_rank = np.linalg.matrix_rank(self.rr_A)
+        rr_rank = np.linalg.matrix_rank(self.rr_A)
         rr_rows = self.rr_A.shape[0]
 
-        self.error = rr_rows - self.true_rank
-        return self.error
+        self.error1 = rr_rank - self.true_rank
+        self.error2 = rr_rows - self.true_rank
+
+        if abs(self.error1) > abs(self.error2):
+            return float(self.error1)
+        else:
+            return float(self.error2)

--- a/benchmarks/benchmarks/optimize_linprog.py
+++ b/benchmarks/benchmarks/optimize_linprog.py
@@ -5,9 +5,9 @@ from __future__ import division, print_function, absolute_import
 
 # Import testing parameters
 try:
-    from scipy.optimize import linprog
+    from scipy.optimize import linprog, OptimizeWarning
     from scipy.linalg import toeplitz
-    from scipy.optimize.tests.test_linprog import lpgen_2d
+    from scipy.optimize.tests.test_linprog import lpgen_2d, magic_square
     from numpy.testing import suppress_warnings
     import numpy as np
     import os
@@ -16,7 +16,7 @@ except ImportError:
 
 from .common import Benchmark
 
-methods = ["simplex", "interior-point"]
+methods = ["revised simplex", "interior-point"]
 problems = ["AFIRO", "BLEND"]
 
 
@@ -28,6 +28,24 @@ def klee_minty(D):
     b_ub = np.array([5**(i + 1) for i in range(D)])
     c = -np.array([2**(D - i - 1) for i in range(D)])
     return c, A_ub, b_ub
+
+
+class MagicSquare(Benchmark):
+
+    params = [
+        methods,
+        [3, 4]
+    ]
+    param_names = ['method', 'dimensions']
+
+    def setup(self, meth, dims):
+        self.A_eq, self.b_eq, self.c, numbers = magic_square(dims)
+
+    def time_magic_square(self, meth, dims):
+        with suppress_warnings() as sup:
+            sup.filter(OptimizeWarning, "A_eq does not appear")
+            linprog(c=self.c, A_eq=self.A_eq, b_eq=self.b_eq,
+                    bounds=(0, 1), method=meth)
 
 
 class KleeMinty(Benchmark):

--- a/benchmarks/benchmarks/optimize_linprog.py
+++ b/benchmarks/benchmarks/optimize_linprog.py
@@ -79,7 +79,7 @@ class MagicSquare(Benchmark):
 
     def track_magic_square(self, meth, prob):
         dims, obj = prob
-        if not self.fun:
+        if self.fun is None:
             self.time_magic_square(meth, prob)
         self.error = np.abs(self.fun - obj)
         return self.error
@@ -105,7 +105,7 @@ class KleeMinty(Benchmark):
         self.x = res.x
 
     def track_klee_minty(self, meth, prob):
-        if not self.fun:
+        if self.fun is None:
             self.time_klee_minty(meth, prob)
         self.error = np.abs(self.fun - self.obj)
         return self.error
@@ -139,7 +139,7 @@ class Netlib(Benchmark):
 
     def setup(self, meth, prob):
         dir_path = os.path.dirname(os.path.realpath(__file__))
-        datafile = os.join(dir_path, "linprog_benchmark_files", prob + ".npz")
+        datafile = os.path.join(dir_path, "linprog_benchmark_files", prob + ".npz")
         data = np.load(datafile, allow_pickle=True)
         self.c = data["c"]
         self.A_eq = data["A_eq"]
@@ -163,7 +163,7 @@ class Netlib(Benchmark):
         self.fun = res.fun
 
     def track_netlib(self, meth, prob):
-        if not self.fun:
+        if self.fun is None:
             self.time_netlib(meth, prob)
         self.error = np.abs(self.fun - self.obj)
         return self.error
@@ -209,11 +209,8 @@ class Netlib_RR(Benchmark):
         self.rr_A, b, status, message = meth(self.A_eq, self.b_eq)
 
     def track_netlib_rr(self, meth, prob):
-        if not self.rr_A:
+        if self.rr_A is None:
             self.time_netlib_rr(meth, prob)
-
-#        if (meth.__name__, prob) in self.known_fails:
-#            return
 
         if meth == _remove_redundancy_sparse:
             self.rr_A = self.rr_A.todense()
@@ -223,11 +220,3 @@ class Netlib_RR(Benchmark):
 
         self.error = rr_rows - self.true_rank
         return self.error
-
-#        np.testing.assert_equal(rr_rank, self.true_rank)
-#        if prob == 'WOOD1P':
-#            # both dense methods return matrix with 243 rows,
-#            # but matrix_rank thinks rank=242
-#            np.testing.assert_equal(rr_rows, 243)
-#        else:
-#            np.testing.assert_equal(rr_rows, self.true_rank)

--- a/benchmarks/benchmarks/optimize_linprog.py
+++ b/benchmarks/benchmarks/optimize_linprog.py
@@ -139,8 +139,8 @@ class Netlib(Benchmark):
 
     def setup(self, meth, prob):
         dir_path = os.path.dirname(os.path.realpath(__file__))
-        data = np.load(dir_path + "/linprog_benchmark_files/" + prob + ".npz",
-                       allow_pickle=True)
+        datafile = os.join(dir_path, "linprog_benchmark_files", prob + ".npz")
+        data = np.load(datafile, allow_pickle=True)
         self.c = data["c"]
         self.A_eq = data["A_eq"]
         self.A_ub = data["A_ub"]
@@ -209,11 +209,11 @@ class Netlib_RR(Benchmark):
         self.rr_A, b, status, message = meth(self.A_eq, self.b_eq)
 
     def track_netlib_rr(self, meth, prob):
-#        if (meth.__name__, prob) in self.known_fails:
-#            return
-
         if not self.rr_A:
             self.time_netlib_rr(meth, prob)
+
+#        if (meth.__name__, prob) in self.known_fails:
+#            return
 
         if meth == _remove_redundancy_sparse:
             self.rr_A = self.rr_A.todense()

--- a/benchmarks/benchmarks/optimize_linprog.py
+++ b/benchmarks/benchmarks/optimize_linprog.py
@@ -19,9 +19,19 @@ except ImportError:
 
 from .common import Benchmark
 
+try:
+    # the value of SCIPY_XSLOW is used to control whether slow benchmarks run
+    slow = int(os.environ.get('SCIPY_XSLOW', 0))
+except ValueError:
+    pass
+
+
 methods = [("interior-point", {"sparse": True}),
            ("interior-point", {"sparse": False}),
            ("revised simplex", {})]
+rr_methods = [_remove_redundancy, _remove_redundancy_dense,
+              _remove_redundancy_sparse]
+
 problems = ['25FV47', '80BAU3B', 'ADLITTLE', 'AFIRO', 'AGG', 'AGG2', 'AGG3',
             'BANDM', 'BEACONFD', 'BLEND', 'BNL1', 'BNL2', 'BORE3D', 'BRANDY',
             'CAPRI', 'CYCLE', 'CZPROB', 'D6CUBE', 'DEGEN2', 'DEGEN3', 'E226',
@@ -35,11 +45,14 @@ problems = ['25FV47', '80BAU3B', 'ADLITTLE', 'AFIRO', 'AGG', 'AGG2', 'AGG3',
             'SHIP08S', 'SHIP12L', 'SHIP12S', 'SIERRA', 'STAIR', 'STANDATA',
             'STANDMPS', 'STOCFOR1', 'STOCFOR2', 'TRUSS', 'TUFF', 'VTP-BASE',
             'WOOD1P', 'WOODW']
-rr_methods = [_remove_redundancy, _remove_redundancy_dense,
-              _remove_redundancy_sparse]
 rr_problems = ['AFIRO', 'BLEND', 'FINNIS', 'RECIPE', 'SCSD6', 'VTP-BASE',
                'BORE3D', 'CYCLE', 'DEGEN2', 'DEGEN3', 'ETAMACRO', 'PILOTNOV',
                'QAP8', 'RECIPE', 'SCORPION', 'SHELL', 'SIERRA', 'WOOD1P']
+if not slow:
+    problems = ['ADLITTLE', 'AFIRO', 'BLEND', 'BEACONFD', 'GROW7', 'LOTFI',
+                'SC105', 'SCTAP1', 'SHARE2B', 'STOCFOR1']
+    rr_problems = ['AFIRO', 'BLEND', 'FINNIS', 'RECIPE', 'SCSD6', 'VTP-BASE',
+                   'DEGEN2', 'ETAMACRO', 'RECIPE']
 
 
 def klee_minty(D):
@@ -62,6 +75,11 @@ class MagicSquare(Benchmark):
         [(3, 1.7305505947214375), (4, 1.5485271031586025),
          (5, 1.807494583582637), (6, 1.747266446858304)]
     ]
+    if not slow:
+        params = [
+            methods,
+            [(3, 1.7305505947214375), (4, 1.5485271031586025)]
+        ]
     param_names = ['method', '(dimensions, objective)']
 
     def setup(self, meth, prob):
@@ -139,7 +157,8 @@ class Netlib(Benchmark):
 
     def setup(self, meth, prob):
         dir_path = os.path.dirname(os.path.realpath(__file__))
-        datafile = os.path.join(dir_path, "linprog_benchmark_files", prob + ".npz")
+        datafile = os.path.join(dir_path, "linprog_benchmark_files",
+                                prob + ".npz")
         data = np.load(datafile, allow_pickle=True)
         self.c = data["c"]
         self.A_eq = data["A_eq"]

--- a/benchmarks/benchmarks/optimize_linprog.py
+++ b/benchmarks/benchmarks/optimize_linprog.py
@@ -16,8 +16,22 @@ except ImportError:
 
 from .common import Benchmark
 
-methods = ["revised simplex", "interior-point"]
-problems = ["AFIRO", "BLEND"]
+methods = [("interior-point", {"sparse": True}),
+           ("interior-point", {"sparse": False}),
+           ("revised simplex", {})]
+problems = ['25FV47', '80BAU3B', 'ADLITTLE', 'AFIRO', 'AGG', 'AGG2', 'AGG3',
+            'BANDM', 'BEACONFD', 'BLEND', 'BNL1', 'BNL2', 'BORE3D', 'BRANDY',
+            'CAPRI', 'CYCLE', 'CZPROB', 'D6CUBE', 'DEGEN2', 'DEGEN3', 'E226',
+            'ETAMACRO', 'FFFFF800', 'FINNIS', 'FIT1D', 'FIT1P', 'GANGES',
+            'GFRD-PNC', 'GROW15', 'GROW22', 'GROW7', 'ISRAEL', 'KB2', 'LOTFI',
+            'MAROS', 'MODSZK1', 'PEROLD', 'PILOT', 'PILOT-WE', 'PILOT4',
+            'PILOTNOV', 'QAP8', 'RECIPE', 'SC105', 'SC205', 'SC50A', 'SC50B',
+            'SCAGR25', 'SCAGR7', 'SCFXM1', 'SCFXM2', 'SCFXM3', 'SCORPION',
+            'SCRS8', 'SCSD1', 'SCSD6', 'SCSD8', 'SCTAP1', 'SCTAP2', 'SCTAP3',
+            'SHARE1B', 'SHARE2B', 'SHELL', 'SHIP04L', 'SHIP04S', 'SHIP08L',
+            'SHIP08S', 'SHIP12L', 'SHIP12S', 'SIERRA', 'STAIR', 'STANDATA',
+            'STANDMPS', 'STOCFOR1', 'STOCFOR2', 'TRUSS', 'TUFF', 'VTP-BASE',
+            'WOOD1P', 'WOODW']
 
 
 def klee_minty(D):
@@ -46,12 +60,16 @@ class MagicSquare(Benchmark):
         self.A_eq, self.b_eq, self.c, numbers = magic_square(dims)
 
     def time_magic_square(self, meth, prob):
-        dims, obj = prob
+        method, options = meth
         with suppress_warnings() as sup:
             sup.filter(OptimizeWarning, "A_eq does not appear")
             res = linprog(c=self.c, A_eq=self.A_eq, b_eq=self.b_eq,
-                          bounds=(0, 1), method=meth)
-            np.testing.assert_allclose(obj, res.fun, rtol=1e-6, atol=1e-3)
+                          bounds=(0, 1), method=method, options=options)
+            self.fun = res.fun
+
+    def teardown(self, meth, prob):
+        dims, obj = prob
+        np.testing.assert_allclose(obj, self.fun, rtol=1e-6, atol=1e-3)
 
 
 class KleeMinty(Benchmark):
@@ -64,12 +82,17 @@ class KleeMinty(Benchmark):
 
     def setup(self, meth, dims):
         self.c, self.A_ub, self.b_ub, self.xf, self.obj = klee_minty(dims)
-        self.meth = meth
 
     def time_klee_minty(self, meth, dims):
-        res = linprog(c=self.c, A_ub=self.A_ub, b_ub=self.b_ub, method=self.meth)
-        np.testing.assert_allclose(self.obj, res.fun, rtol=1e-6, atol=1e-3)
-        np.testing.assert_allclose(self.xf, res.x, rtol=1e-6, atol=1e-3)
+        method, options = meth
+        res = linprog(c=self.c, A_ub=self.A_ub, b_ub=self.b_ub,
+                      method=method, options=options)
+        self.fun = res.fun
+        self.x = res.x
+
+    def teardown(self, meth, prob):
+        np.testing.assert_allclose(self.obj, self.fun, rtol=1e-6, atol=1e-3)
+        np.testing.assert_allclose(self.xf, self.x, rtol=1e-6, atol=1e-3)
 
 
 class LpGen(Benchmark):
@@ -82,12 +105,13 @@ class LpGen(Benchmark):
 
     def setup(self, meth, m, n):
         self.A, self.b, self.c = lpgen_2d(m, n)
-        self.meth = meth
 
     def time_lpgen(self, meth, m, n):
+        method, options = meth
         with suppress_warnings() as sup:
             sup.filter(RuntimeWarning, "scipy.linalg.solve\nIll-conditioned")
-            linprog(c=self.c, A_ub=self.A, b_ub=self.b, method=self.meth)
+            linprog(c=self.c, A_ub=self.A, b_ub=self.b,
+                    method=method, options=options)
 
 
 class Netlib(Benchmark):
@@ -99,21 +123,27 @@ class Netlib(Benchmark):
 
     def setup(self, meth, prob):
         dir_path = os.path.dirname(os.path.realpath(__file__))
-        data = np.load(dir_path + "/linprog_benchmark_files/" + prob + ".npz")
+        data = np.load(dir_path + "/linprog_benchmark_files/" + prob + ".npz",
+                       allow_pickle=True)
         self.c = data["c"]
         self.A_eq = data["A_eq"]
         self.A_ub = data["A_ub"]
         self.b_ub = data["b_ub"]
         self.b_eq = data["b_eq"]
-        self.bounds = (0, None)
+        self.bounds = np.squeeze(data["bounds"])
         self.obj = float(data["obj"].flatten()[0])
 
     def time_netlib(self, meth, prob):
+        method, options = meth
         res = linprog(c=self.c,
                       A_ub=self.A_ub,
                       b_ub=self.b_ub,
                       A_eq=self.A_eq,
                       b_eq=self.b_eq,
                       bounds=self.bounds,
-                      method=meth)
-        np.testing.assert_allclose(self.obj, res.fun)
+                      method=method,
+                      options=options)
+        self.fun = res.fun
+
+    def teardown(self, meth, prob):
+        np.testing.assert_allclose(self.obj, self.fun, rtol=1e-4, atol=1e-4)


### PR DESCRIPTION
92 [Netlib LP test problem](http://www.numerical.rl.ac.uk/cute/netlib.html) definitions have been included in SciPy's `benchmarks` folder since `interior-point` was added, but only two very easy problems run by default in the benchmark suite. I believe this was mostly because `simplex` had trouble with the more difficult problems. Now that `revised simplex` is available and `simplex` is retained only as a legacy method, `revised simplex` should replace `simplex` in the benchmarks and more benchmarks should be run.

This PR:
- replaces `simplex` with `revised simplex`
- runs the benchmarks for both dense and sparse `interior point`
- adds the magic square problem (LP-relaxation of a 0-1 integer program for finding a magic square) as a benchmark
- adds many additional Netlib problems to run by default (and corrects an issue with the bounds)
- separately benchmarks `linprog`'s redundancy removal routines

Some questions (thoughts @tylerjereddy @andyfaff ?):
- [x] how long should the entire `linprog` benchmark suite take to run with default options? *Update: I'll shoot for about a minute, then allow slow benchmarks with environment variables.*
- [x] should slow benchmarks be enabled separately using environment variables? *Update: Probably. I'll add this.*
- [x] is it appropriate to check accuracy in benchmarks? currently I've added assertions to check whether the solutions are within a given tolerance, but it would be even better if I could measure and report the error (just as time is measured and reported) *Update: I see I can use `track` benchmarks. Great. I'll do that.*
- [x] `revised simplex` does not terminate successfully for some of the problems it finds numerically challenging, which is OK. If it is appropriate to check solution accuracy/success, I'll keep them. If not, should I skip them? *Update: won't skip; I'll keep them since I can track successes*

*Update: I'll base tracking and controlling with environment variables on `BenchGlobal`.*

#### Reference issue
Addresses items in gh-9269