### PR TITLE
MAINT: list of minimize methods

### DIFF
--- a/benchmarks/benchmarks/optimize.py
+++ b/benchmarks/benchmarks/optimize.py
@@ -14,6 +14,7 @@ try:
     from scipy.optimize.optimize import rosen, rosen_der, rosen_hess
     from scipy.optimize import (leastsq, basinhopping, differential_evolution,
                                 dual_annealing, OptimizeResult)
+    from scipy.optimize._minimize import MINIMIZE_METHODS
 except ImportError:
     pass
 
@@ -225,10 +226,7 @@ class _BenchOptimizers(Benchmark):
         kwargs = self.minimizer_kwargs
 
         if methods is None:
-            methods = ["COBYLA", 'Powell', 'nelder-mead',
-                       'L-BFGS-B', 'BFGS', 'CG', 'TNC', 'SLSQP',
-                       "Newton-CG", 'dogleg', 'trust-ncg', 'trust-exact',
-                       'trust-krylov', 'trust-constr']
+            methods = MINIMIZE_METHODS
 
         # L-BFGS-B, BFGS, trust-constr can use gradients, but examine
         # performance when numerical differentiation is used.

--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -39,6 +39,11 @@ from ._constraints import (old_bound_to_new, new_bounds_to_old,
                            NonlinearConstraint, LinearConstraint, Bounds)
 
 
+MINIMIZE_METHODS = ['nelder-mead', 'powell', 'cg', 'bfgs', 'newton-cg',
+                    'l-bfgs-b', 'tnc', 'cobyla', 'slsqp', 'trust-constr',
+                    'dogleg', 'trust-ncg', 'trust-exact', 'trust-krylov']
+
+
 def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
              hessp=None, bounds=None, constraints=(), tol=None,
              callback=None, options=None):

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -23,6 +23,7 @@ from pytest import raises as assert_raises
 
 from scipy._lib._numpy_compat import suppress_warnings
 from scipy import optimize
+from scipy.optimize._minimize import MINIMIZE_METHODS
 
 
 def test_check_grad():
@@ -746,12 +747,10 @@ class TestOptimizeSimple(CheckOptimize):
             assert_(func(sol1.x) < func(sol2.x),
                     "%s: %s vs. %s" % (method, func(sol1.x), func(sol2.x)))
 
-    @pytest.mark.parametrize('method', ['fmin', 'fmin_powell', 'fmin_cg', 'fmin_bfgs',
-                                        'fmin_ncg', 'fmin_l_bfgs_b', 'fmin_tnc',
-                                        'fmin_slsqp',
-                                        'Nelder-Mead', 'Powell', 'CG', 'BFGS', 'Newton-CG', 'L-BFGS-B',
-                                        'TNC', 'SLSQP', 'trust-constr', 'dogleg', 'trust-ncg',
-                                        'trust-exact', 'trust-krylov'])
+    @pytest.mark.parametrize('method',
+                             ['fmin', 'fmin_powell', 'fmin_cg', 'fmin_bfgs',
+                              'fmin_ncg', 'fmin_l_bfgs_b', 'fmin_tnc',
+                              'fmin_slsqp'] + MINIMIZE_METHODS)
     def test_minimize_callback_copies_array(self, method):
         # Check that arrays passed to callbacks are not modified
         # inplace by the optimizer afterward
@@ -1231,13 +1230,10 @@ class TestOptimizeResultAttributes(object):
         self.bounds = [(0., 10.), (0., 10.)]
 
     def test_attributes_present(self):
-        methods = ['Nelder-Mead', 'Powell', 'CG', 'BFGS', 'Newton-CG',
-                   'L-BFGS-B', 'TNC', 'COBYLA', 'SLSQP', 'dogleg',
-                   'trust-ncg']
         attributes = ['nit', 'nfev', 'x', 'success', 'status', 'fun',
                       'message']
         skip = {'COBYLA': ['nit']}
-        for method in methods:
+        for method in MINIMIZE_METHODS:
             with suppress_warnings() as sup:
                 sup.filter(RuntimeWarning,
                            "Method .+ does not use (gradient|Hessian.*) information")

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -755,6 +755,10 @@ class TestOptimizeSimple(CheckOptimize):
         # Check that arrays passed to callbacks are not modified
         # inplace by the optimizer afterward
 
+        # cobyla doesn't have callback
+        if method == 'cobyla':
+            return
+
         if method in ('fmin_tnc', 'fmin_l_bfgs_b'):
             func = lambda x: (optimize.rosen(x), optimize.rosen_der(x))
         else:
@@ -779,14 +783,14 @@ class TestOptimizeSimple(CheckOptimize):
                 kw['method'] = method
                 return optimize.minimize(*a, **kw)
 
-            if method == 'TNC':
+            if method == 'tnc':
                 kwargs['options'] = dict(maxiter=100)
             else:
                 kwargs['options'] = dict(maxiter=5)
 
         if method in ('fmin_ncg',):
             kwargs['fprime'] = jac
-        elif method in ('Newton-CG',):
+        elif method in ('newton-cg',):
             kwargs['jac'] = jac
         elif method in ('trust-krylov', 'trust-exact', 'trust-ncg', 'dogleg',
                         'trust-constr'):
@@ -1232,7 +1236,7 @@ class TestOptimizeResultAttributes(object):
     def test_attributes_present(self):
         attributes = ['nit', 'nfev', 'x', 'success', 'status', 'fun',
                       'message']
-        skip = {'COBYLA': ['nit']}
+        skip = {'cobyla': ['nit']}
         for method in MINIMIZE_METHODS:
             with suppress_warnings() as sup:
                 sup.filter(RuntimeWarning,


### PR DESCRIPTION
It struck me that it might be useful to have a list of all the minimize methods listed somewhere. This PR adds this list.
 
- is it worth having the list (e.g. would be useable in #10756, #10640)?
- is the naming right?
- all caps?
- is it worth adding lists for methods requiring grad/{hess, hessp}?