### PR TITLE
DOC: svds can also compute the smallest singular values

### DIFF
--- a/scipy/sparse/linalg/eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/arpack.py
@@ -1703,7 +1703,7 @@ def _herm(x):
 
 def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
          maxiter=None, return_singular_vectors=True):
-    """Compute the largest k singular values/vectors for a sparse matrix.
+    """Compute the largest or smallest k singular values/vectors for a sparse matrix.
 
     Parameters
     ----------


### PR DESCRIPTION

#### What does this implement/fix?
Update the docstring of svds to reflect the fact that it can compute
the smallest eigenvalues through keyword which='SM'.

Previous docstring is misleading in that it seems that
only the largest eigenvalues can be computed.
