### PR TITLE
BUG: Fix corner case for sos2zpk

### DIFF
--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -1222,17 +1222,20 @@ def sos2zpk(sos):
 
     Notes
     -----
+    The number of zeros and poles returned will be ``n_sections * 2``
+    even if some of these are (effectively) zero.
+
     .. versionadded:: 0.16.0
     """
     sos = np.asarray(sos)
     n_sections = sos.shape[0]
-    z = np.empty(n_sections*2, np.complex128)
-    p = np.empty(n_sections*2, np.complex128)
+    z = np.zeros(n_sections*2, np.complex128)
+    p = np.zeros(n_sections*2, np.complex128)
     k = 1.
     for section in range(n_sections):
         zpk = tf2zpk(sos[section, :3], sos[section, 3:])
-        z[2*section:2*(section+1)] = zpk[0]
-        p[2*section:2*(section+1)] = zpk[1]
+        z[2*section:2*section+len(zpk[0])] = zpk[0]
+        p[2*section:2*section+len(zpk[1])] = zpk[1]
         k *= zpk[2]
     return z, p, k
 

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -241,6 +241,20 @@ class TestSos2Zpk(object):
         assert_allclose(_cplxpair(p2), p)
         assert_allclose(k2, k)
 
+    def test_fewer_zeros(self):
+        """Test not the expected number of p/z (effectively at origin)."""
+        sos = butter(3, 0.1, output='sos')
+        z, p, k = sos2zpk(sos)
+        assert len(z) == 4
+        assert len(p) == 4
+
+        sos = butter(12, [5., 30.], 'bandpass', fs=1200., analog=False,
+                    output='sos')
+        with pytest.warns(BadCoefficients, match='Badly conditioned'):
+            z, p, k = sos2zpk(sos)
+        assert len(z) == 24
+        assert len(p) == 24
+
 
 class TestSos2Tf(object):
 


### PR DESCRIPTION
Fixes a bug with `sos2zpk`:
```
>>> from scipy.signal import butter, sos2zpk
>>> sos = butter(3, 0.5)
>>> sos2zpk(sos)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/larsoner/python/scipy/scipy/signal/filter_design.py", line 1235, in sos2zpk
    p[2*section:2*(section+1)] = zpk[1]
ValueError: could not broadcast input array from shape (0) into shape (2)
```
There is no guarantee we actually get two (non-zero) poles or zeros from each section, as in general it can be fewer than that. This PR makes it so that it only fills in the values where necessary.

Another option would be to cull the "effectively zero" ones. Not sure which is better, but the "effectively zero" case is pretty easy for users to do with something like `mask = np.isclose(z, 0., atol=1e-14)`, setting `atol` as required or however else they want to do it. And in the current pattern, you can check to see which sections were effectively first-order by reshaping the output, so it might actually be more usable than a reduced version (?).