### PR TITLE
Fix error type for complex input to scipy.fftpack.rfft and irfft

### DIFF
--- a/scipy/fft/_pocketfft/basic.py
+++ b/scipy/fft/_pocketfft/basic.py
@@ -237,7 +237,7 @@ def r2r_fftpack(forward, x, n=None, axis=-1, norm=None, overwrite_x=False):
     workers = _workers(None)
 
     if tmp.dtype.kind == 'c':
-        raise ValueError('x must be a real sequence')
+        raise TypeError('x must be a real sequence')
 
     if n is not None:
         tmp, copied = _fix_shape_1d(tmp, n, axis)

--- a/scipy/fftpack/tests/test_basic.py
+++ b/scipy/fftpack/tests/test_basic.py
@@ -313,6 +313,10 @@ class _TestRFFTBase(object):
         assert_equal(x, expected)
         assert_equal(xs.data, expected)
 
+    def test_complex_input(self):
+        assert_raises(TypeError, rfft, np.arange(4, dtype=np.complex64))
+
+
 class TestRFFTDouble(_TestRFFTBase):
     def setup_method(self):
         self.cdt = np.cdouble
@@ -375,6 +379,9 @@ class _TestIRFFTBase(object):
     def test_invalid_sizes(self):
         assert_raises(ValueError, irfft, [])
         assert_raises(ValueError, irfft, [[1,1],[2,2]], -5)
+
+    def test_complex_input(self):
+        assert_raises(TypeError, irfft, np.arange(4, dtype=np.complex64))
 
 
 # self.ndec is bogus; we should have a assert_array_approx_equal for number of


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
None

#### What does this implement/fix?

When a complex-valued array is given as the input to `scipy.fftpack.rfft` or `scipy.fftpack.irfft`, the error type raised on current master is `ValueError` while in prior releases it was `TypeError`.

I assume this was an unintentional change introduced when replacing the FFTPack fortran code with pypocketfft. I noticed, the difference due to a test failure in the pyFFTW test suite when using the current SciPy master.

The new `scipy.fft.rfft` also returns a `TypeError`, so this makes it consistent with that as well.

#### Additional information
<!--Any additional information you think is important.-->