### PR TITLE
ENH: solve_triangular C order improvement

### DIFF
--- a/benchmarks/benchmarks/linalg.py
+++ b/benchmarks/benchmarks/linalg.py
@@ -37,14 +37,14 @@ class Bench(Benchmark):
             # skip: slow, and not useful to benchmark numpy
             raise NotImplementedError()
 
-        a = random([size,size])
+        a = random([size, size])
         # larger diagonal ensures non-singularity:
         for i in range(size):
-            a[i,i] = 10*(.1+a[i,i])
+            a[i, i] = 10*(.1+a[i, i])
         b = random([size])
 
         if contig != 'contig':
-            a = a[-1::-1,-1::-1]  # turn into a non-contiguous array
+            a = a[-1::-1, -1::-1]  # turn into a non-contiguous array
             assert_(not a.flags['CONTIGUOUS'])
 
         self.a = a
@@ -55,6 +55,14 @@ class Bench(Benchmark):
             nl.solve(self.a, self.b)
         else:
             sl.solve(self.a, self.b)
+
+    def time_solve_triangular(self, size, contig, module):
+        # treats self.a as a lower-triangular matrix by ignoring the strictly
+        # upper-triangular part
+        if module == 'numpy':
+            pass
+        else:
+            sl.solve_triangular(self.a, self.b, lower=True)
 
     def time_inv(self, size, contig, module):
         if module == 'numpy':

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -809,6 +809,26 @@ class TestSolveTriangular(object):
         sol = solve_triangular(A, b, lower=True, trans=1)
         assert_array_almost_equal(sol, [[.5-.5j, -.25-.25j], [0, 0.5]])
 
+        # check other option combinations with complex rhs
+        b = np.diag([1+1j, 1+2j])
+        sol = solve_triangular(A, b, lower=True, trans=0)
+        assert_array_almost_equal(sol, [[1, 0], [-0.5j, 0.5+1j]])
+
+        sol = solve_triangular(A, b, lower=True, trans=1)
+        assert_array_almost_equal(sol, [[1, 0.25-0.75j], [0, 0.5+1j]])
+
+        sol = solve_triangular(A, b, lower=True, trans=2)
+        assert_array_almost_equal(sol, [[1j, -0.75-0.25j], [0, 0.5+1j]])
+
+        sol = solve_triangular(A.T, b, lower=False, trans=0)
+        assert_array_almost_equal(sol, [[1, 0.25-0.75j], [0, 0.5+1j]])
+
+        sol = solve_triangular(A.T, b, lower=False, trans=1)
+        assert_array_almost_equal(sol, [[1, 0], [-0.5j, 0.5+1j]])
+
+        sol = solve_triangular(A.T, b, lower=False, trans=2)
+        assert_array_almost_equal(sol, [[1j, 0], [-0.5, 0.5+1j]])
+
     def test_check_finite(self):
         """
         solve_triangular on a simple 2x2 matrix.
@@ -939,7 +959,7 @@ class TestLstsq(object):
                         assert_allclose(dot(a, x), b,
                                         atol=25 * _eps_cast(a1.dtype),
                                         rtol=25 * _eps_cast(a1.dtype),
-                                         err_msg="driver: %s" % lapack_driver)
+                                        err_msg="driver: %s" % lapack_driver)
 
     def test_simple_overdet(self):
         for dtype in REAL_DTYPES:


### PR DESCRIPTION
<!-- 


Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes gh-9207.

#### What does this implement/fix?
Performace improvement in `scipy.linalg.solve_triangular` when `a` is in C order, as suggested in https://github.com/scipy/scipy/issues/9207#issuecomment-417956881.

#### Additional information
There are some PEP8 fixes and a benchmark for `solve_triangular` in `linalg.Bench`. The few final lines from running
```
python runtests.py --bench-compare master linalg.Bench
```
are
```
       before           after         ratio
     [e2b3be2a]       [f825a7fc]
     <master>         <solve-triangular-c-order>
-      4.12±0.2ms       2.72±0.2ms     0.66  linalg.Bench.time_solve_triangular(1000, 'nocont', 'scipy')
-        519±30μs         211±30μs     0.41  linalg.Bench.time_solve_triangular(500, 'contig', 'scipy')
-      3.81±0.2ms      1.10±0.03ms     0.29  linalg.Bench.time_solve_triangular(1000, 'contig', 'scipy')

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.
```