### PR TITLE
Fix behavior of `exp1` on branch cut and add docstring

### DIFF
--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -2427,14 +2427,83 @@ add_newdoc("eval_hermitenorm",
     """)
 
 add_newdoc("exp1",
-    """
-    exp1(z)
+    r"""
+    exp1(z, out=None)
 
-    Exponential integral E_1 of complex argument z
+    Exponential integral E1.
 
-    ::
+    For complex :math:`z \ne 0` the exponential integral can be defined as
+    [1]_
 
-        integral(exp(-z*t)/t, t=1..inf).
+    .. math::
+
+       E_1(z) = \int_z^\infty \frac{e^{-t}}{t} dt,
+
+    where the path of the integral does not cross the negative real
+    axis or pass through the origin.
+
+    Parameters
+    ----------
+    z: array_like
+        Real or complex argument.
+    out: ndarray, optional
+        Optional output array for the function results
+
+    Returns
+    -------
+    scalar or ndarray
+        Values of the exponential integral E1
+
+    See Also
+    --------
+    expi : exponential integral :math:`Ei`
+    expn : generalization of :math:`E_1`
+
+    Notes
+    -----
+    For :math:`x > 0` it is related to the exponential integral
+    :math:`Ei` (see `expi`) via the relation
+
+    .. math::
+
+       E_1(x) = -Ei(-x).
+
+    References
+    ----------
+    .. [1] Digital Library of Mathematical Functions, 6.2.1
+           https://dlmf.nist.gov/6.2#E1
+
+    Examples
+    --------
+    >>> import scipy.special as sc
+
+    It has a pole at 0.
+
+    >>> sc.exp1(0)
+    inf
+
+    It has a branch cut on the negative real axis.
+
+    >>> sc.exp1(-1)
+    nan
+    >>> sc.exp1(complex(-1, 0))
+    (-1.8951178163559368-3.141592653589793j)
+    >>> sc.exp1(complex(-1, -0.0))
+    (-1.8951178163559368+3.141592653589793j)
+
+    It approaches 0 along the positive real axis.
+
+    >>> sc.exp1([1, 10, 100, 1000])
+    array([2.19383934e-01, 4.15696893e-06, 3.68359776e-46, 0.00000000e+00])
+
+    It is related to `expi`.
+
+    >>> x = np.array([1, 2, 3, 4])
+    >>> sc.exp1(x)
+    array([0.21938393, 0.04890051, 0.01304838, 0.00377935])
+    >>> -sc.expi(-x)
+    array([0.21938393, 0.04890051, 0.01304838, 0.00377935])
+
     """)
 
 add_newdoc("exp10",

--- a/scipy/special/specfun/specfun.f
+++ b/scipy/special/specfun/specfun.f
@@ -8738,8 +8738,9 @@ C          Power series
 10         CONTINUE
 15         CONTINUE
            IF (X.LE.0.0.AND.DIMAG(Z).EQ.0.0) THEN
-C             Careful on the branch cut -- avoid signed zeros
-              CE1=-EL-CDLOG(-Z)+Z*CE1-PI*(0.0D0,1.0D0)
+C     Careful on the branch cut -- use the sign of the imaginary part
+C     to get the right sign on the factor if pi.
+              CE1=-EL-CDLOG(-Z)+Z*CE1-DSIGN(PI,DIMAG(Z))*(0.0D0,1.0D0)
            ELSE
               CE1=-EL-CDLOG(Z)+Z*CE1
            ENDIF

--- a/scipy/special/specfun/specfun.f
+++ b/scipy/special/specfun/specfun.f
@@ -5276,7 +5276,7 @@ C       Output:  EI --- Ei(x)
 C       ============================================
 C
         IMPLICIT NONE
-        DOUBLE COMPLEX Z, CEI, IMF
+        DOUBLE COMPLEX Z, CEI
         DOUBLE PRECISION PI
         PI=3.141592653589793D0
         CALL E1Z(-Z, CEI)
@@ -5287,7 +5287,7 @@ C
            CEI = CEI - (0d0,1d0)*PI
         ELSE IF (DIMAG(Z).EQ.0) THEN
            IF (DBLE(Z).GT.0) THEN
-              CEI = CEI - (0d0,1d0)*PI
+              CEI = CEI + (0d0,1d0)*DSIGN(PI,DIMAG(Z))
            ENDIF
         ENDIF
         RETURN

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -321,9 +321,6 @@ class TestCephes(object):
     def test_erfc(self):
         assert_equal(cephes.erfc(0), 1.0)
 
-    def test_expi(self):
-        cephes.expi(1)
-
     def test_expn(self):
         cephes.expn(1,1)
 

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -321,20 +321,11 @@ class TestCephes(object):
     def test_erfc(self):
         assert_equal(cephes.erfc(0), 1.0)
 
-    def test_exp1(self):
-        cephes.exp1(1)
-
     def test_expi(self):
         cephes.expi(1)
 
     def test_expn(self):
         cephes.expn(1,1)
-
-    def test_exp1_reg(self):
-        # Regression for #834
-        a = cephes.exp1(-complex(19.9999990))
-        b = cephes.exp1(-complex(19.9999991))
-        assert_array_almost_equal(a.imag, b.imag)
 
     def test_exp10(self):
         assert_approx_equal(cephes.exp10(2),100.0)

--- a/scipy/special/tests/test_exponential_integrals.py
+++ b/scipy/special/tests/test_exponential_integrals.py
@@ -1,0 +1,29 @@
+from numpy.testing import assert_allclose
+import scipy.special as sc
+
+
+class TestExp1(object):
+
+    def test_branch_cut(self):
+        assert sc.exp1(complex(-1, 0)).imag == (
+            -sc.exp1(complex(-1, -0.0)).imag
+        )
+
+        assert_allclose(
+            sc.exp1(complex(-1, 0)),
+            sc.exp1(-1 + 1e-20j),
+            atol=0,
+            rtol=1e-15
+        )
+        assert_allclose(
+            sc.exp1(complex(-1, -0.0)),
+            sc.exp1(-1 - 1e-20j),
+            atol=0,
+            rtol=1e-15
+        )
+
+    def test_exp1_834(self):
+        # Regression test for #834
+        a = sc.exp1(-complex(19.9999990))
+        b = sc.exp1(-complex(19.9999991))
+        assert_allclose(a.imag, b.imag, atol=0, rtol=1e-15)

--- a/scipy/special/tests/test_exponential_integrals.py
+++ b/scipy/special/tests/test_exponential_integrals.py
@@ -1,3 +1,6 @@
+import pytest
+
+import numpy as np
 from numpy.testing import assert_allclose
 import scipy.special as sc
 
@@ -5,6 +8,7 @@ import scipy.special as sc
 class TestExp1(object):
 
     def test_branch_cut(self):
+        assert np.isnan(sc.exp1(-1))
         assert sc.exp1(complex(-1, 0)).imag == (
             -sc.exp1(complex(-1, -0.0)).imag
         )
@@ -22,8 +26,44 @@ class TestExp1(object):
             rtol=1e-15
         )
 
-    def test_exp1_834(self):
+    def test_834(self):
         # Regression test for #834
         a = sc.exp1(-complex(19.9999990))
         b = sc.exp1(-complex(19.9999991))
         assert_allclose(a.imag, b.imag, atol=0, rtol=1e-15)
+
+
+class TestExpi(object):
+
+    @pytest.mark.parametrize('result', [
+        sc.expi(complex(-1, 0)),
+        sc.expi(complex(-1, -0.0)),
+        sc.expi(-1)
+    ])
+    def test_branch_cut(self, result):
+        desired = -0.21938393439552027368  # Computed using Mpmath
+        assert_allclose(result, desired, atol=0, rtol=1e-14)
+
+    def test_near_branch_cut(self):
+        lim_from_above = sc.expi(-1 + 1e-20j)
+        lim_from_below = sc.expi(-1 - 1e-20j)
+        assert_allclose(
+            lim_from_above.real,
+            lim_from_below.real,
+            atol=0,
+            rtol=1e-15
+        )
+        assert_allclose(
+            lim_from_above.imag,
+            -lim_from_below.imag,
+            atol=0,
+            rtol=1e-15
+        )
+
+    def test_continuity_on_positive_real_axis(self):
+        assert_allclose(
+            sc.expi(complex(1, 0)),
+            sc.expi(complex(1, -0.0)),
+            atol=0,
+            rtol=1e-15
+        )


### PR DESCRIPTION
#### Reference issue

None.

#### What does this implement/fix?

Two things:

- Fix the behavior of `exp1` on the branch cut (first commit)
- Add a full docstring for `exp1` (second commit)

#### Additional information

Currently `exp1` does not respect imaginary parts with negative zeros on the branch cut. For example we have

```python
>>> import scipy.special as sc
>>> sc.exp1(complex(-1, 0))
(-1.8951178163559368-3.141592653589793j)
>>> sc.exp1(complex(-1, -0.0))
(-1.8951178163559368-3.141592653589793j)
```

The second value is incorrect since

```python
>>> sc.exp1(complex(-1, -1e-12))
(-1.8951178163559368+3.141592653587075j)
```

Fix that, and also add a full docstring for the function.