### PR TITLE
Travis CI: sudo is deprecated and Xenial is default distro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 # After changing this file, check it on:
 #   http://lint.travis-ci.org/
 language: python
-sudo: false
 addons:
   apt:
     packages: &common_packages
@@ -38,8 +37,6 @@ matrix:
         - |
           grep -rlIP '[^\x00-\x7F]' scipy | grep '\.pyx\?' | sort > unicode.out; grep -rlI '# -\*- coding: \(utf-8\|latin-1\) -\*-' scipy | grep '\.pyx\?' | sort > coding.out; comm -23 unicode.out coding.out > test_code.out; cat test_code.out;  test \! -s test_code.out
     - python: 3.7
-      dist: xenial # travis-ci/travis-ci/issues/9815
-      sudo: true
       env:
         - TESTMODE=fast
         - COVERAGE=
@@ -49,8 +46,6 @@ matrix:
         # specify in pyproject.toml (will be older than --pre --upgrade) works
         - USE_SDIST=1
     - python: 3.7
-      dist: xenial # travis-ci/travis-ci/issues/9815
-      sudo: true
       env:
         - TESTMODE=full
         - COVERAGE="--coverage --gcov"
@@ -59,7 +54,6 @@ matrix:
     # However travis only specifies regular or development builds of Python
     # so we must install python3.5-dbg using apt.
     - language: generic
-      dist: xenial  # Requires Xenial(ubunu 18.04) as python-dbg uses py3.5
       env:
         - USE_DEBUG=python3.5-dbg
         - TESTMODE=fast
@@ -71,8 +65,6 @@ matrix:
             - python3.5-dbg
             - python3.5-dev
     - python: 3.8-dev
-      dist: xenial
-      sudo: true
       env:
         - TESTMODE=fast
         - NUMPYSPEC="numpy"


### PR DESCRIPTION
The __sudo:__ tag is fully deprecated on Travis CI and __Xenial__ is the default Linux distro.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
Simplify by removing out-of-date configuration.

#### Additional information
<!--Any additional information you think is important.-->