### PR TITLE
ENH: linalg: LU with full pivoting (wrappers for ?getc2/?gesc2)

### DIFF
--- a/scipy/linalg/flapack_gen.pyf.src
+++ b/scipy/linalg/flapack_gen.pyf.src
@@ -231,6 +231,7 @@ subroutine <prefix>getc2(n,a,ipiv,jpiv,info)
 
     integer depend(a),intent(hide):: n = shape(a,0)
     <ftype> dimension(n,n),intent(in,out,copy,out=lu) :: a
+    check(shape(a,0)==shape(a,1)) :: a
     integer dimension(n),depend(n),intent(out) :: ipiv
     integer dimension(n),depend(n),intent(out) :: jpiv
     integer intent(out):: info
@@ -238,7 +239,7 @@ subroutine <prefix>getc2(n,a,ipiv,jpiv,info)
 end subroutine <prefix>getc2
 
 subroutine <prefix>gesc2(n,lu,rhs,ipiv,jpiv,scale)
-    ! x,scale = gesc2(lu,rhs,ipiv,jpiv,overwrite_b=0)
+    ! x,scale = gesc2(lu,rhs,ipiv,jpiv,overwrite_rhs=0)
     ! Solve  A * X = scale * RHS
     ! A = P * L * U * Q
     threadsafe
@@ -251,7 +252,7 @@ subroutine <prefix>gesc2(n,lu,rhs,ipiv,jpiv,scale)
     <ftype> dimension(n),intent(in,out,copy,out=x),depend(n),check(shape(lu,0)==len(rhs)) :: rhs
     integer dimension(n),intent(in),depend(n) :: ipiv
     integer dimension(n),intent(in),depend(n) :: jpiv
-    <ftype2> intent(out):: scale
+    <ftypereal> intent(out):: scale
 
 end subroutine <prefix>gesc2
 

--- a/scipy/linalg/flapack_gen.pyf.src
+++ b/scipy/linalg/flapack_gen.pyf.src
@@ -221,6 +221,22 @@ subroutine <prefix>getrs(n,nrhs,lu,piv,b,info,trans)
 
 end subroutine <prefix>getrs
 
+subroutine <prefix>getc2(n,a,ipiv,jpiv,info)
+    ! lu,ipiv,jpiv,info = getc2(a,overwrite_a=0)
+    ! Compute an LU factorization of with complete pivoting of a general n-by-n matrix.
+    ! A = P * L * U * Q
+    threadsafe
+    callstatement {int i;(*f2py_func)(&n,a,&n,ipiv,jpiv,&info);for(i=0;i\<n;--ipiv[i],--jpiv[i++]);}
+    callprotoargument int*,<ctype>*,int*,int*,int*,int*
+
+    integer depend(a),intent(hide):: n = shape(a,0)
+    <ftype> dimension(n,n),intent(in,out,copy,out=lu) :: a
+    integer dimension(n),depend(n),intent(out) :: ipiv
+    integer dimension(n),depend(n),intent(out) :: jpiv
+    integer intent(out):: info
+
+end subroutine <prefix>getc2
+
 subroutine <prefix>getri(n,lu,piv,work,lwork,info)
     ! inv_a,info = getri(lu,piv,lwork=3*n,overwrite_lu=0)
     ! Find A inverse A^-1.

--- a/scipy/linalg/flapack_gen.pyf.src
+++ b/scipy/linalg/flapack_gen.pyf.src
@@ -237,6 +237,24 @@ subroutine <prefix>getc2(n,a,ipiv,jpiv,info)
 
 end subroutine <prefix>getc2
 
+subroutine <prefix>gesc2(n,lu,rhs,ipiv,jpiv,scale)
+    ! x,scale = gesc2(lu,rhs,ipiv,jpiv,overwrite_b=0)
+    ! Solve  A * X = scale * RHS
+    ! A = P * L * U * Q
+    threadsafe
+    callstatement {int i;for(i=0;i\<n;++ipiv[i],++jpiv[i++]);(*f2py_func)(&n,lu,&n,rhs,ipiv,jpiv,&scale);for(i=0;i\<n;--ipiv[i],--jpiv[i++]);}
+    callprotoargument int*,<ctype>*,int*,<ctype>*,int*,int*,<ctypereal>*
+
+    integer depend(lu),intent(hide):: n = shape(lu,0)
+    <ftype> dimension(n,n),intent(in) :: lu
+    check(shape(lu,0)==shape(lu,1)) :: lu
+    <ftype> dimension(n),intent(in,out,copy,out=x),depend(n),check(shape(lu,0)==len(rhs)) :: rhs
+    integer dimension(n),intent(in),depend(n) :: ipiv
+    integer dimension(n),intent(in),depend(n) :: jpiv
+    <ftype2> intent(out):: scale
+
+end subroutine <prefix>gesc2
+
 subroutine <prefix>getri(n,lu,piv,work,lwork,info)
     ! inv_a,info = getri(lu,piv,lwork=3*n,overwrite_lu=0)
     ! Find A inverse A^-1.

--- a/scipy/linalg/flapack_gen.pyf.src
+++ b/scipy/linalg/flapack_gen.pyf.src
@@ -221,34 +221,36 @@ subroutine <prefix>getrs(n,nrhs,lu,piv,b,info,trans)
 
 end subroutine <prefix>getrs
 
-subroutine <prefix>getc2(n,a,ipiv,jpiv,info)
+subroutine <prefix>getc2(n,a,lda,ipiv,jpiv,info)
     ! lu,ipiv,jpiv,info = getc2(a,overwrite_a=0)
     ! Compute an LU factorization of with complete pivoting of a general n-by-n matrix.
     ! A = P * L * U * Q
     threadsafe
-    callstatement {int i;(*f2py_func)(&n,a,&n,ipiv,jpiv,&info);for(i=0;i\<n;--ipiv[i],--jpiv[i++]);}
+    callstatement {int i;(*f2py_func)(&n,a,&lda,ipiv,jpiv,&info);for(i=0;i\<n;--ipiv[i],--jpiv[i++]);}
     callprotoargument int*,<ctype>*,int*,int*,int*,int*
 
     integer depend(a),intent(hide):: n = shape(a,0)
     <ftype> dimension(n,n),intent(in,out,copy,out=lu) :: a
     check(shape(a,0)==shape(a,1)) :: a
+    integer intent(hide),depend(a):: lda = MAX(1,shape(a,0))
     integer dimension(n),depend(n),intent(out) :: ipiv
     integer dimension(n),depend(n),intent(out) :: jpiv
     integer intent(out):: info
 
 end subroutine <prefix>getc2
 
-subroutine <prefix>gesc2(n,lu,rhs,ipiv,jpiv,scale)
+subroutine <prefix>gesc2(n,lu,lda,rhs,ipiv,jpiv,scale)
     ! x,scale = gesc2(lu,rhs,ipiv,jpiv,overwrite_rhs=0)
     ! Solve  A * X = scale * RHS
     ! A = P * L * U * Q
     threadsafe
-    callstatement {int i;for(i=0;i\<n;++ipiv[i],++jpiv[i++]);(*f2py_func)(&n,lu,&n,rhs,ipiv,jpiv,&scale);for(i=0;i\<n;--ipiv[i],--jpiv[i++]);}
+    callstatement {int i;for(i=0;i\<n;++ipiv[i],++jpiv[i++]);(*f2py_func)(&n,lu,&lda,rhs,ipiv,jpiv,&scale);for(i=0;i\<n;--ipiv[i],--jpiv[i++]);}
     callprotoargument int*,<ctype>*,int*,<ctype>*,int*,int*,<ctypereal>*
 
     integer depend(lu),intent(hide):: n = shape(lu,0)
     <ftype> dimension(n,n),intent(in) :: lu
     check(shape(lu,0)==shape(lu,1)) :: lu
+    integer intent(hide),depend(lu):: lda = MAX(1,shape(lu,0))
     <ftype> dimension(n),intent(in,out,copy,out=x),depend(n),check(shape(lu,0)==len(rhs)) :: rhs
     integer dimension(n),intent(in),depend(n) :: ipiv
     integer dimension(n),intent(in),depend(n) :: jpiv

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -224,6 +224,11 @@ All functions
    cgetrs
    zgetrs
 
+   sgesc2
+   dgesc2
+   cgesc2
+   zgesc2
+
    sgges
    dgges
    cgges

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -204,6 +204,11 @@ All functions
    cgetrf
    zgetrf
 
+   sgetc2
+   dgetc2
+   cgetc2
+   zgetc2
+
    sgetri
    dgetri
    cgetri

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -1594,6 +1594,7 @@ def test_geequ():
             assert_allclose(desired_cplx.astype(dtype), r[:, None]*A*c,
                             rtol=0, atol=1e-4)
 
+<<<<<<< HEAD
 
 def test_syequb():
     desired_log2s = np.array([0, 0, 0, 0, 0, 0, -1, -1, -2, -3])
@@ -1628,3 +1629,44 @@ def test_heequb():
         post3_7_lapack_result = np.log2(s).astype(int) == desired_log2s[1, :]
 
         assert pre3_7_lapack_result.all() or post3_7_lapack_result.all()
+=======
+        getrs = get_lapack_funcs('getrs', dtype=dtype)
+        x, info = getrs(lu, piv, b, trans=False, overwrite_b=False)
+        if ind < 2:
+            assert_array_almost_equal(desired_x_real.astype(dtype),
+                                      x, decimal=4)
+        else:
+            assert_array_almost_equal(desired_x_cplx.astype(dtype),
+                                      x, decimal=4)
+
+
+def test_getc2_gesc2():
+    np.random.seed(42)
+    n = 10
+    desired_real = np.random.rand(n)
+    desired_cplx = np.random.rand(n) + np.random.rand(n)*1j
+
+    for ind, dtype in enumerate(DTYPES):
+        if ind < 2:
+            A = np.random.rand(n, n)
+            A = A.astype(dtype)
+            b = A @ desired_real
+            b = b.astype(dtype)
+        else:
+            A = np.random.rand(n, n) + np.random.rand(n, n)*1j
+            A = A.astype(dtype)
+            b = A @ desired_cplx
+            b = b.astype(dtype)
+
+        getc2 = get_lapack_funcs('getc2', dtype=dtype)
+        gesc2 = get_lapack_funcs('gesc2', dtype=dtype)
+        lu, ipiv, jpiv, info = getc2(A, overwrite_a=0)
+        x, scale = gesc2(lu, b, ipiv, jpiv, overwrite_rhs=0)
+
+        if ind < 2:
+            assert_array_almost_equal(desired_real.astype(dtype),
+                                      x, decimal=4)
+        else:
+            assert_array_almost_equal(desired_cplx.astype(dtype),
+                                      x, decimal=4)
+>>>>>>> Fixed minor mistakes in ?gesc2 wrapper, added tests

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -1594,7 +1594,6 @@ def test_geequ():
             assert_allclose(desired_cplx.astype(dtype), r[:, None]*A*c,
                             rtol=0, atol=1e-4)
 
-<<<<<<< HEAD
 
 def test_syequb():
     desired_log2s = np.array([0, 0, 0, 0, 0, 0, -1, -1, -2, -3])
@@ -1629,15 +1628,6 @@ def test_heequb():
         post3_7_lapack_result = np.log2(s).astype(int) == desired_log2s[1, :]
 
         assert pre3_7_lapack_result.all() or post3_7_lapack_result.all()
-=======
-        getrs = get_lapack_funcs('getrs', dtype=dtype)
-        x, info = getrs(lu, piv, b, trans=False, overwrite_b=False)
-        if ind < 2:
-            assert_array_almost_equal(desired_x_real.astype(dtype),
-                                      x, decimal=4)
-        else:
-            assert_array_almost_equal(desired_x_cplx.astype(dtype),
-                                      x, decimal=4)
 
 
 def test_getc2_gesc2():
@@ -1665,8 +1655,7 @@ def test_getc2_gesc2():
 
         if ind < 2:
             assert_array_almost_equal(desired_real.astype(dtype),
-                                      x, decimal=4)
+                                      x/scale, decimal=4)
         else:
             assert_array_almost_equal(desired_cplx.astype(dtype),
-                                      x, decimal=4)
->>>>>>> Fixed minor mistakes in ?gesc2 wrapper, added tests
+                                      x/scale, decimal=4)

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -1560,10 +1560,6 @@ def test_geequ():
                           [1.58e+00, -2.69e+00, -2.90e-10, -1.04e+00],
                           [-1.11e+00, -6.60e-01, -5.90e-11, 8.00e-01]])
             A = A.astype(dtype)
-            b = np.array([[9.52, 18.47],
-                          [24.35, 2.25],
-                          [0.77, -13.28],
-                          [-6.22, -6.21]], dtype=dtype)
         else:
             A = np.array([[-1.34e+00, 0.28e+10, -6.39e+00],
                           [-1.70e+00, 3.31e+10, -0.15e+00],
@@ -1573,16 +1569,6 @@ def test_geequ():
                            [0.39e-10, 1.47e+00, -0.69e-10]])*1j
 
             A = A.astype(dtype)
-            b = np.array([[26.26, 31.32],
-                          [6.43, 15.86],
-                          [-5.75, -2.15],
-                          [1.16, -2.56]], dtype=dtype)
-            b += np.array([[51.78, -6.7],
-                           [-8.68, -1.42],
-                           [25.31, 30.19],
-                           [2.57, 7.55]])*1j
-
-            b = b.astype(dtype)
 
         geequ = get_lapack_funcs('geequ', dtype=dtype)
         r, c, rowcnd, colcnd, amax, info = geequ(A)

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -1551,7 +1551,6 @@ def test_geequ():
                              [0.8607+0.1393*1j,
                               -0.2759+0.7241*1j,
                               -0.1642-0.1365*1j]])
-
     for ind, dtype in enumerate(DTYPES):
         if ind < 2:
             # Use examples from the NAG documentation

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -1551,6 +1551,7 @@ def test_geequ():
                              [0.8607+0.1393*1j,
                               -0.2759+0.7241*1j,
                               -0.1642-0.1365*1j]])
+
     for ind, dtype in enumerate(DTYPES):
         if ind < 2:
             # Use examples from the NAG documentation
@@ -1559,6 +1560,10 @@ def test_geequ():
                           [1.58e+00, -2.69e+00, -2.90e-10, -1.04e+00],
                           [-1.11e+00, -6.60e-01, -5.90e-11, 8.00e-01]])
             A = A.astype(dtype)
+            b = np.array([[9.52, 18.47],
+                          [24.35, 2.25],
+                          [0.77, -13.28],
+                          [-6.22, -6.21]], dtype=dtype)
         else:
             A = np.array([[-1.34e+00, 0.28e+10, -6.39e+00],
                           [-1.70e+00, 3.31e+10, -0.15e+00],
@@ -1568,6 +1573,16 @@ def test_geequ():
                            [0.39e-10, 1.47e+00, -0.69e-10]])*1j
 
             A = A.astype(dtype)
+            b = np.array([[26.26, 31.32],
+                          [6.43, 15.86],
+                          [-5.75, -2.15],
+                          [1.16, -2.56]], dtype=dtype)
+            b += np.array([[51.78, -6.7],
+                           [-8.68, -1.42],
+                           [25.31, 30.19],
+                           [2.57, 7.55]])*1j
+
+            b = b.astype(dtype)
 
         geequ = get_lapack_funcs('geequ', dtype=dtype)
         r, c, rowcnd, colcnd, amax, info = geequ(A)


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Partially addresses gh-10788

#### What does this implement/fix?
<!--Please explain your changes.-->
This wraps LAPACK's ?getc2 and ?gesc2.
I'll add a `complete_pivoting` argument to `lu_factor` in a separate PR.
