### PR TITLE
BUG: sparse: Fix possible double-free in free_std_vector_typenum

### DIFF
--- a/scipy/sparse/sparsetools/sparsetools.cxx
+++ b/scipy/sparse/sparsetools/sparsetools.cxx
@@ -510,6 +510,7 @@ static void free_std_vector_typenum(int typenum, void *p)
 #define PROCESS(ntype, ctype)                                   \
     if (PyArray_EquivTypenums(typenum, ntype)) {                \
         delete ((std::vector<ctype>*)p);                        \
+        return;                                                 \
     }
 
     PROCESS(NPY_BOOL, npy_bool_wrapper);


### PR DESCRIPTION
If NPY_CDOUBLE == NPY_CLONGDOUBLE, a double free will occur. Also, once the array is freed it's unnecessary to do anything else in this function.

Bug identified by [scan-build](https://clang-analyzer.llvm.org/scan-build.html).