### PR TITLE
BUG: fix UnboundLocalError in Radau (scipy#10775)

### DIFF
--- a/scipy/integrate/_ivp/radau.py
+++ b/scipy/integrate/_ivp/radau.py
@@ -98,6 +98,7 @@ def solve_collocation_system(fun, t, y, h, Z0, scale, tol,
     dW_norm_old = None
     dW = np.empty_like(W)
     converged = False
+    rate = None
     for k in range(NEWTON_MAXITER):
         for i in range(3):
             F[i] = fun(t + ch[i], y + Z[i])
@@ -118,8 +119,6 @@ def solve_collocation_system(fun, t, y, h, Z0, scale, tol,
         dW_norm = norm(dW / scale)
         if dW_norm_old is not None:
             rate = dW_norm / dW_norm_old
-        else:
-            rate = None
 
         if (rate is not None and (rate >= 1 or
                 rate ** (NEWTON_MAXITER - k) / (1 - rate) * dW_norm > tol)):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #10775

#### What does this implement/fix?
<!--Please explain your changes.-->
Set ``rate=None`` before the `isfinite` check, in case the latter causes an early break. Fixes the `UnboundLocalError` that was raised when the function tried to return an unbound `rate`. 
Also remove the `else:` branch previously on lines 121-122 as it is now redundant (it would set ``rate=None`` when `dW_norm_old` was also `None`, but `dW_norm_old` is `None` only in the first iteration and the newly added ``rate=None`` covers that case).

#### Additional information
<!--Any additional information you think is important.-->
The ``rate=None`` can be put inside the loop instead. However, this would change the previous behavior (in terms of the returned `rate`) if the `isfinite` check were to fail _after_ the first iteration.

Thanks to @nmayorov for the help in the bug report.