### PR TITLE
ENH: Speed up next_fast_len with LRU cache

### DIFF
--- a/benchmarks/benchmarks/fft_basic.py
+++ b/benchmarks/benchmarks/fft_basic.py
@@ -103,6 +103,25 @@ class Fft(Benchmark):
         self.ifft(self.x)
 
 
+class NextFastLen(Benchmark):
+    params = [
+        [12, 13,  # small ones
+         1021, 1024,  # 2 ** 10 and a prime
+         16381, 16384,  # 2 ** 14 and a prime
+         262139, 262144,  # 2 ** 17 and a prime
+         999983, 1048576,  # 2 ** 20 and a prime
+         ],
+    ]
+    param_names = ['size']
+
+    def setup(self, size):
+        if not has_scipy_fft:
+            raise NotImplementedError
+
+    def time_next_fast_len(self, size):
+        scipy_fft.next_fast_len(size)
+
+
 class RFft(Benchmark):
     params = [
         [100, 256, 313, 512, 1000, 1024, 2048, 2048*2, 2048*4],

--- a/scipy/fft/_helper.py
+++ b/scipy/fft/_helper.py
@@ -1,9 +1,13 @@
-from . import _pocketfft
-from ._pocketfft import helper as _helper
+from functools import lru_cache
 from bisect import bisect_left
+
 import numpy as np
 
+from . import _pocketfft
+from ._pocketfft import helper as _helper
 
+
+@lru_cache()
 def next_fast_len(target, kind='C2C'):
     """Find the next fast size of input data to ``fft``, for zero-padding, etc.
 


### PR DESCRIPTION
On `master` the new benchmark gives:
```
                 size               
              --------- ------------
                  12      592±7ns   
                  13      672±70ns  
                 1021     821±40ns  
                 1024     729±70ns  
                16381    1.05±0.3μs 
                16384     678±40ns  
                262139   1.61±0.1μs 
                262144    716±40ns  
                999983   1.74±0.2μs 
               1048576    723±30ns
```
And on this PR, implementing @pv's alternative idea from #10589:
```
                 size             
              --------- ----------
                  12     196±10ns 
                  13     205±10ns 
                 1021    208±20ns 
                 1024    193±30ns 
                16381    196±10ns 
                16384    201±30ns 
                262139   172±10ns 
                262144   211±20ns 
                999983   195±10ns 
               1048576   186±20ns 
```
LRU default cache size is 128 which seems reasonable for storing these.

Closes #10589.