### PR TITLE
ENH: Speed up next_fast_len

### DIFF
--- a/benchmarks/benchmarks/fft_basic.py
+++ b/benchmarks/benchmarks/fft_basic.py
@@ -103,6 +103,25 @@ class Fft(Benchmark):
         self.ifft(self.x)
 
 
+class NextFastLen(Benchmark):
+    params = [
+        [12, 13,  # small ones
+         1021, 1024,  # 2 ** 10 and a prime
+         16381, 16384,  # 2 ** 14 and a prime
+         262139, 262144,  # 2 ** 17 and a prime
+         999983, 1048576,  # 2 ** 20 and a prime
+         ],
+    ]
+    param_names = ['size']
+
+    def setup(self, size):
+        if not has_scipy_fft:
+            raise NotImplementedError
+
+    def time_next_fast_len(self, size):
+        scipy_fft.next_fast_len(size)
+
+
 class RFft(Benchmark):
     params = [
         [100, 256, 313, 512, 1000, 1024, 2048, 2048*2, 2048*4],

--- a/benchmarks/benchmarks/fft_basic.py
+++ b/benchmarks/benchmarks/fft_basic.py
@@ -119,6 +119,9 @@ class NextFastLen(Benchmark):
             raise NotImplementedError
 
     def time_next_fast_len(self, size):
+        scipy_fft.next_fast_len.__wrapped__(size)
+
+    def time_next_fast_len_cached(self, size):
         scipy_fft.next_fast_len(size)
 
 

--- a/scipy/fft/_helper.py
+++ b/scipy/fft/_helper.py
@@ -62,6 +62,8 @@ def next_fast_len(target, real=False):
     pass
 
 
+# Directly wrap the c-function good_size but take the docstring etc. from the
+# next_fast_len function above
 next_fast_len = update_wrapper(lru_cache()(_helper.good_size), next_fast_len)
 next_fast_len.__wrapped__ = _helper.good_size
 

--- a/scipy/fft/_helper.py
+++ b/scipy/fft/_helper.py
@@ -1,9 +1,13 @@
-from . import _pocketfft
-from ._pocketfft import helper as _helper
+from functools import lru_cache
 from bisect import bisect_left
+
 import numpy as np
 
+from . import _pocketfft
+from ._pocketfft import helper as _helper
 
+
+@lru_cache()
 def next_fast_len(target, kind='C2C'):
     """Find the next fast size of input data to ``fft``, for zero-padding, etc.
 

--- a/scipy/fft/_helper.py
+++ b/scipy/fft/_helper.py
@@ -1,14 +1,11 @@
-from functools import lru_cache
-from bisect import bisect_left
-
+from functools import update_wrapper, lru_cache
 import numpy as np
 
 from . import _pocketfft
 from ._pocketfft import helper as _helper
 
 
-@lru_cache()
-def next_fast_len(target, kind='C2C'):
+def next_fast_len(target, real=False):
     """Find the next fast size of input data to ``fft``, for zero-padding, etc.
 
     SciPy's FFT algorithms gain their speed by a recursive divide and conquer
@@ -23,11 +20,9 @@ def next_fast_len(target, kind='C2C'):
     ----------
     target : int
         Length to start searching from.  Must be a positive integer.
-    kind : {'C2C', 'C2R', 'R2C'}, optional
-        Kind of transform to be performed
-        - 'C2C': Complex to complex (e.g. `fft`, `ifft`)
-        - 'C2R': Complex to real (e.g. `irfft`, `hfft`)
-        - 'R2C': Real to complex (e.g. `rfft`, `ihfft`)
+    real : bool, optional
+        True if the FFT involves real input or output (e.g. `rfft` or `hfft` but
+        not `fft`). Defaults to False.
 
     Returns
     -------
@@ -64,7 +59,11 @@ def next_fast_len(target, kind='C2C'):
     >>> b = fft.fft(a, 131072)
 
     """
-    return _helper.next_fast_len(target, kind)
+    pass
+
+
+next_fast_len = update_wrapper(lru_cache()(_helper.good_size), next_fast_len)
+next_fast_len.__wrapped__ = _helper.good_size
 
 
 def _init_nd_shape_and_axes(x, shape, axes):

--- a/scipy/fft/_pocketfft/helper.py
+++ b/scipy/fft/_pocketfft/helper.py
@@ -208,18 +208,3 @@ def get_workers():
     4
     """
     return getattr(_config, 'default_workers', 1)
-
-
-def next_fast_len(target, kind='C2C'):
-    try:
-        real = {'C2C': False, 'R2C': True, 'C2R': True}[kind]
-    except KeyError:
-        raise ValueError('Unknown transform kind: {}'.format(kind))
-
-    target = operator.index(target)
-
-    # Error if a size_t result could overflow
-    if (target-1)*11 > sys.maxsize:
-        raise ValueError(
-            'Target length is too large to perform an FFT: {}' .format(target))
-    return good_size(target, real)

--- a/scipy/fft/_pocketfft/pypocketfft.cxx
+++ b/scipy/fft/_pocketfft/pypocketfft.cxx
@@ -377,10 +377,28 @@ py::array genuine_hartley(const py::array &in, const py::object &axes_,
   DISPATCH(in, f64, f32, flong, complex2hartley, (in, tmp, axes_, out_))
   }
 
-size_t good_size(size_t n, bool real)
+ PyObject * good_size(PyObject * self, PyObject * args)
   {
+  Py_ssize_t n_ = -1;
+  int real = false;
+  if (!PyArg_ParseTuple(args, "n|p:good_size", &n_, &real))
+    return nullptr;
+
+  if (n_<0)
+    {
+    PyErr_SetString(PyExc_ValueError, "Target length must be positive");
+    return nullptr;
+    }
+  if ((n_-1) > static_cast<Py_ssize_t>(std::numeric_limits<size_t>::max() / 11))
+    {
+    PyErr_Format(PyExc_ValueError,
+                 "Target length is too large to perform an FFT: %zi", n_);
+    return nullptr;
+    }
+  const auto n = static_cast<size_t>(n_);
   using namespace pocketfft::detail;
-  return real ? util::good_size_real(n) : util::good_size_cmplx(n);
+  return PyLong_FromSize_t(
+    real ? util::good_size_real(n) : util::good_size_cmplx(n));
   }
 
 const char *pypocketfft_DS = R"""(Fast Fourier and Hartley transforms.
@@ -707,5 +725,8 @@ PYBIND11_MODULE(pypocketfft, m)
     "out"_a=None, "nthreads"_a=1);
   m.def("dst", dst, dst_DS, "a"_a, "type"_a, "axes"_a=None, "inorm"_a=0,
     "out"_a=None, "nthreads"_a=1);
-  m.def("good_size", good_size, good_size_DS, "n"_a, "real"_a=false);
+
+  static PyMethodDef good_size_meth[] =
+    {{"good_size", good_size, METH_VARARGS, good_size_DS}, {0}};
+  PyModule_AddFunctions(m.ptr(), good_size_meth);
   }

--- a/scipy/fft/tests/test_helper.py
+++ b/scipy/fft/tests/test_helper.py
@@ -52,11 +52,10 @@ class TestNextFastLen(object):
         for n in nums():
             m = next_fast_len(n)
             _assert_n_smooth(m, 11)
-            assert m == next_fast_len(n, 'C2C')
+            assert m == next_fast_len(n, False)
 
-            m = next_fast_len(n, 'R2C')
+            m = next_fast_len(n, True)
             _assert_n_smooth(m, 5)
-            assert m == next_fast_len(n, 'C2R')
 
     def test_np_integers(self):
         ITYPES = [np.int16, np.int32, np.int64, np.uint16, np.uint32, np.uint64]
@@ -71,7 +70,7 @@ class TestNextFastLen(object):
             16: 16, 17: 18, 1021: 1024, 1536: 1536, 51200000: 51200000
         }
         for x, y in hams.items():
-            assert_equal(next_fast_len(x, 'R2C'), y)
+            assert_equal(next_fast_len(x, True), y)
 
     @pytest.mark.xfail(sys.maxsize < 2**32,
                        reason="Hamming Numbers too large for 32-bit",
@@ -108,7 +107,7 @@ class TestNextFastLen(object):
             288325195312500000 + 1: 288555831593533440,
         }
         for x, y in hams.items():
-            assert_equal(next_fast_len(x, 'R2C'), y)
+            assert_equal(next_fast_len(x, True), y)
 
 
 class Test_init_nd_shape_and_axes(object):

--- a/scipy/fftpack/helper.py
+++ b/scipy/fftpack/helper.py
@@ -95,7 +95,7 @@ def next_fast_len(target):
 
     """
     # Real transforms use regular sizes so this is backwards compatible
-    return _helper.next_fast_len(target, True)
+    return _helper.good_size(target, True)
 
 
 def _good_shape(x, shape, axes):

--- a/scipy/fftpack/helper.py
+++ b/scipy/fftpack/helper.py
@@ -95,7 +95,7 @@ def next_fast_len(target):
 
     """
     # Real transforms use regular sizes so this is backwards compatible
-    return _helper.next_fast_len(target, 'R2C')
+    return _helper.next_fast_len(target, True)
 
 
 def _good_shape(x, shape, axes):

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -405,13 +405,12 @@ def fftconvolve(in1, in2, mode="full", axes=None):
     if len(axes):
         if not complex_result:
             fft, ifft = sp_fft.rfftn, sp_fft.irfftn
-            kind = 'R2C'
         else:
             fft, ifft = sp_fft.fftn, sp_fft.ifftn
-            kind = 'C2C'
 
         # Speed up FFT by padding to optimal size
-        fshape = [sp_fft.next_fast_len(shape[a], kind) for a in axes]
+        fshape = [
+            sp_fft.next_fast_len(shape[a], not complex_result) for a in axes]
         fslice = tuple([slice(sz) for sz in shape])
         sp1 = fft(in1, fshape, axes=axes)
         sp2 = fft(in2, fshape, axes=axes)


### PR DESCRIPTION
#### Reference issue
Closes #10804, closes #10589

#### What does this implement/fix?
This supercedes #10804, extending it to also speed up `next_fast_len.__wrapped__`. The python overhead is brought down from ~550 ns to ~85 ns by binding the function directly in the c-api and replacing the `kind` argument with the `real` argument used in the C++ binding version.

#### Additional information
Here are the improved timings I see:
```
In [1]: from scipy.fft import next_fast_len
In [2]: %timeit next_fast_len.__wrapped__(12)
86.8 ns ± 3.78 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)
In [3]: %timeit next_fast_len.__wrapped__(997)
222 ns ± 3.43 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
In [4]: %timeit next_fast_len.__wrapped__(1000)
135 ns ± 0.593 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)
In [5]: %timeit next_fast_len.__wrapped__(16381)
415 ns ± 10.7 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```

cc @larsoner @mreineck