### PR TITLE
ENH: Raise catchable exceptions for bad Fortran files

### DIFF
--- a/scipy/io/__init__.py
+++ b/scipy/io/__init__.py
@@ -46,6 +46,8 @@ Unformatted Fortran files
    :toctree: generated/
 
    FortranFile - A file object for unformatted sequential Fortran files
+   FortranEOFError - Exception indicating the end of a well-formed file
+   FortranFormattingError - Exception indicating an inappropriate end
 
 Netcdf
 ======

--- a/scipy/io/__init__.py
+++ b/scipy/io/__init__.py
@@ -100,7 +100,7 @@ from .matlab import loadmat, savemat, whosmat, byteordercodes
 from .netcdf import netcdf_file, netcdf_variable
 
 # Fortran file support
-from ._fortran import FortranFile
+from ._fortran import FortranFile, FortranEOFError, FortranFormattingError
 
 from .mmio import mminfo, mmread, mmwrite
 from .idl import readsav

--- a/scipy/io/_fortran.py
+++ b/scipy/io/_fortran.py
@@ -13,12 +13,22 @@ __all__ = ['FortranFile', 'FortranEOFError', 'FortranFormattingError']
 
 
 class FortranEOFError(TypeError, IOError):
-    # The code used to raise TypeErrors at the end of the file
-    # so we want to make sure they catch this error.
+    """Indicates that the file ended properly.
+
+    This error descends from TypeError because the code used to raise
+    TypeError (and this was the only way to know that the file had
+    ended) so users might have ``except TypeError:``.
+
+    """
     pass
 
 
 class FortranFormattingError(TypeError, IOError):
+    """Indicates that the file ended mid-record.
+
+    Descends from TypeError for backward compatibility.
+
+    """
     pass
 
 

--- a/scipy/io/_fortran.py
+++ b/scipy/io/_fortran.py
@@ -9,7 +9,17 @@ from __future__ import division, print_function, absolute_import
 import warnings
 import numpy as np
 
-__all__ = ['FortranFile']
+__all__ = ['FortranFile', 'FortranEOFError', 'FortranFormattingError']
+
+
+class FortranEOFError(TypeError):
+    # The code used to raise TypeErrors at the end of the file
+    # so we want to make sure they catch this error.
+    pass
+
+
+class FortranFormattingError(TypeError):
+    pass
 
 
 class FortranFile(object):
@@ -105,8 +115,15 @@ class FortranFile(object):
 
         self._header_dtype = header_dtype
 
-    def _read_size(self):
-        return int(np.fromfile(self._fp, dtype=self._header_dtype, count=1))
+    def _read_size(self, eof_ok=False):
+        n = self._header_dtype.itemsize
+        b = self._fp.read(n)
+        if (not b) and eof_ok:
+            raise FortranEOFError("End of file occurred at end of record")
+        elif len(b) < n:
+            raise FortranFormattingError(
+                "End of file in the middle of the record size")
+        return int(np.frombuffer(b, dtype=self._header_dtype, count=1))
 
     def write_record(self, *items):
         """
@@ -216,7 +233,7 @@ class FortranFile(object):
         elif not dtypes:
             raise ValueError('Must specify at least one dtype')
 
-        first_size = self._read_size()
+        first_size = self._read_size(eof_ok=True)
 
         dtypes = tuple(np.dtype(dtype) for dtype in dtypes)
         block_size = sum(dtype.itemsize for dtype in dtypes)
@@ -236,6 +253,9 @@ class FortranFile(object):
         data = []
         for dtype in dtypes:
             r = np.fromfile(self._fp, dtype=dtype, count=num_blocks)
+            if len(r) != num_blocks:
+                raise FortranFormattingError(
+                    "End of file in the middle of a record")
             if dtype.shape != ():
                 # Squeeze outmost block dimension for array items
                 if num_blocks == 1:

--- a/scipy/io/_fortran.py
+++ b/scipy/io/_fortran.py
@@ -12,13 +12,13 @@ import numpy as np
 __all__ = ['FortranFile', 'FortranEOFError', 'FortranFormattingError']
 
 
-class FortranEOFError(TypeError):
+class FortranEOFError(TypeError, IOError):
     # The code used to raise TypeErrors at the end of the file
     # so we want to make sure they catch this error.
     pass
 
 
-class FortranFormattingError(TypeError):
+class FortranFormattingError(TypeError, IOError):
     pass
 
 
@@ -171,6 +171,14 @@ class FortranFile(object):
         -------
         data : ndarray
             A one-dimensional array object.
+
+        Raises
+        ------
+        FortranEOFError
+            To signal that no further records are available
+        FortranFormattingError
+            To signal that the end of the file was encountered
+            part-way through a record
 
         Notes
         -----

--- a/scipy/io/tests/test_fortran.py
+++ b/scipy/io/tests/test_fortran.py
@@ -8,8 +8,12 @@ import re
 
 from numpy.testing import assert_equal, assert_allclose
 import numpy as np
+import pytest
 
-from scipy.io import FortranFile, _test_fortran
+from scipy.io import (FortranFile,
+                      _test_fortran,
+                      FortranEOFError,
+                      FortranFormattingError)
 
 
 DATA_PATH = path.join(path.dirname(__file__), 'data')
@@ -157,3 +161,76 @@ def test_fortran_roundtrip(tmpdir):
     assert_equal(a3, a)
     assert_equal(b2, b)
     assert_equal(b3, b)
+
+
+def test_fortran_eof_ok(tmpdir):
+    filename = path.join(tmpdir, "scratch")
+    np.random.seed(1)
+    with FortranFile(filename, 'w') as f:
+        f.write_record(np.random.randn(5))
+        f.write_record(np.random.randn(3))
+    with FortranFile(filename, 'r') as f:
+        assert len(f.read_reals()) == 5
+        assert len(f.read_reals()) == 3
+        with pytest.raises(FortranEOFError):
+            f.read_reals()
+
+
+def test_fortran_eof_broken_size(tmpdir):
+    filename = path.join(tmpdir, "scratch")
+    np.random.seed(1)
+    with FortranFile(filename, 'w') as f:
+        f.write_record(np.random.randn(5))
+        f.write_record(np.random.randn(3))
+    with open(filename, "ab") as f:
+        f.write(b"\xff")
+    with FortranFile(filename, 'r') as f:
+        assert len(f.read_reals()) == 5
+        assert len(f.read_reals()) == 3
+        with pytest.raises(FortranFormattingError):
+            f.read_reals()
+
+
+def test_fortran_bogus_size(tmpdir):
+    filename = path.join(tmpdir, "scratch")
+    np.random.seed(1)
+    with FortranFile(filename, 'w') as f:
+        f.write_record(np.random.randn(5))
+        f.write_record(np.random.randn(3))
+    with open(filename, "w+b") as f:
+        f.write(b"\xff\xff")
+    with FortranFile(filename, 'r') as f:
+        with pytest.raises(FortranFormattingError):
+            f.read_reals()
+
+
+def test_fortran_eof_broken_record(tmpdir):
+    filename = path.join(tmpdir, "scratch")
+    np.random.seed(1)
+    with FortranFile(filename, 'w') as f:
+        f.write_record(np.random.randn(5))
+        f.write_record(np.random.randn(3))
+    with open(filename, "ab") as f:
+        f.truncate(path.getsize(filename)-20)
+    with FortranFile(filename, 'r') as f:
+        assert len(f.read_reals()) == 5
+        with pytest.raises(FortranFormattingError):
+            f.read_reals()
+
+
+def test_fortran_eof_multidimensional(tmpdir):
+    filename = path.join(tmpdir, "scratch")
+    n, m, q = 3, 5, 7
+    dt = np.dtype([("field", np.float, (n, m))])
+    a = np.zeros(q, dtype=dt)
+    with FortranFile(filename, 'w') as f:
+        f.write_record(a[0])
+        f.write_record(a)
+        f.write_record(a)
+    with open(filename, "ab") as f:
+        f.truncate(path.getsize(filename)-20)
+    with FortranFile(filename, 'r') as f:
+        assert len(f.read_record(dtype=dt)) == 1
+        assert len(f.read_record(dtype=dt)) == q
+        with pytest.raises(FortranFormattingError):
+            f.read_record(dtype=dt)

--- a/scipy/io/tests/test_fortran.py
+++ b/scipy/io/tests/test_fortran.py
@@ -164,7 +164,7 @@ def test_fortran_roundtrip(tmpdir):
 
 
 def test_fortran_eof_ok(tmpdir):
-    filename = path.join(tmpdir, "scratch")
+    filename = path.join(str(tmpdir), "scratch")
     np.random.seed(1)
     with FortranFile(filename, 'w') as f:
         f.write_record(np.random.randn(5))
@@ -177,7 +177,7 @@ def test_fortran_eof_ok(tmpdir):
 
 
 def test_fortran_eof_broken_size(tmpdir):
-    filename = path.join(tmpdir, "scratch")
+    filename = path.join(str(tmpdir), "scratch")
     np.random.seed(1)
     with FortranFile(filename, 'w') as f:
         f.write_record(np.random.randn(5))
@@ -192,7 +192,7 @@ def test_fortran_eof_broken_size(tmpdir):
 
 
 def test_fortran_bogus_size(tmpdir):
-    filename = path.join(tmpdir, "scratch")
+    filename = path.join(str(tmpdir), "scratch")
     np.random.seed(1)
     with FortranFile(filename, 'w') as f:
         f.write_record(np.random.randn(5))
@@ -205,7 +205,7 @@ def test_fortran_bogus_size(tmpdir):
 
 
 def test_fortran_eof_broken_record(tmpdir):
-    filename = path.join(tmpdir, "scratch")
+    filename = path.join(str(tmpdir), "scratch")
     np.random.seed(1)
     with FortranFile(filename, 'w') as f:
         f.write_record(np.random.randn(5))
@@ -219,7 +219,7 @@ def test_fortran_eof_broken_record(tmpdir):
 
 
 def test_fortran_eof_multidimensional(tmpdir):
-    filename = path.join(tmpdir, "scratch")
+    filename = path.join(str(tmpdir), "scratch")
     n, m, q = 3, 5, 7
     dt = np.dtype([("field", np.float, (n, m))])
     a = np.zeros(q, dtype=dt)


### PR DESCRIPTION
Currently Fortran files let you know you've hit the last record by raising TypeError, the same thing
they raise if the Fortran file has somehow been truncated in the middle of a record or if some unexpected actual TypeError occurs. This patch introduces two new exception classes users can
catch if they want to detect these conditions. These classes, unfortunately, are subclasses of
TypeError in case existing users are already catching TypeError.

Also included are a few tests checking the new behaviour.
