### PR TITLE
Fixed compiler_helper.py to allow compilation with ICC on Linux

### DIFF
--- a/scipy/_build_utils/compiler_helper.py
+++ b/scipy/_build_utils/compiler_helper.py
@@ -30,10 +30,15 @@ def has_flag(compiler, flag, ext=None):
 
 def get_cxx_std_flag(compiler):
     """Detects compiler flag for c++14, c++11 or None if not detected"""
-    gnu_flags = ['--std=c++14', '--std=c++11']
+    # GNU C compiler documentation use single dash:
+    #    https://gcc.gnu.org/onlinedocs/gcc/Standards.html
+    # but silently understands two dahes like --std=c++11 too.
+    # Other GCC compatible compilers, like Intel C Compiler on Linux do not.
+    gnu_flags = ['-std=c++14', '-std=c++11']
     flags_by_cc = {
         'msvc': ['/std:c++14', None],
-        'intelw': ['/Qstd=c++14', '/Qstd=c++11']
+        'intelw': ['/Qstd=c++14', '/Qstd=c++11'],
+        'intelem': ['-std=c++14', '-std=c++11']
     }
     flags = flags_by_cc.get(compiler.compiler_type, gnu_flags)
 


### PR DESCRIPTION
GNU C Compiler documented option to specify the standard uses single dash, see https://gcc.gnu.org/onlinedocs/gcc/Standards.html

GCC silently accepts `--std=name` and translates it into `-std=name`, but Intel C Compiler does not. 

A solution is to add 'intelem' entry to `flags_by_cc`, but I also took the liberty to change `gnu_flags` to be as stated in the documentation.

