### PR TITLE
ENH: Fast gaussian kernel estimator

### DIFF
--- a/scipy/stats/_stats.pyx
+++ b/scipy/stats/_stats.pyx
@@ -548,9 +548,10 @@ def _gaussian_kernel_estimate(double[:, :] points, double[:, :] values,
         int m = xi.shape[0]
         double arg, residual, norm
 
-    assert xi.shape[1] == d, "points and xi must have same trailing dim"
-    assert precision.shape[0] == d and precision.shape[1] == d, \
-        "precision matrix must match data dims"
+    if xi.shape[1] != d:
+        raise ValueError("points and xi must have same trailing dim")
+    if precision.shape[0] != d or precision.shape[1] != d:
+        raise ValueError("precision matrix must match data dims")
 
     # Evaluate the normalisation
     norm = np.sqrt(np.linalg.det(precision) / (2 * np.pi) ** d)

--- a/scipy/stats/kde.py
+++ b/scipy/stats/kde.py
@@ -32,6 +32,7 @@ import numpy as np
 
 # Local imports.
 from . import mvn
+from ._stats import _gaussian_kernel_estimate
 
 
 __all__ = ['gaussian_kde']
@@ -237,29 +238,11 @@ class gaussian_kde(object):
                     self.d)
                 raise ValueError(msg)
 
-        output_dtype = np.common_type(self.covariance, points)
-        result = zeros((m,), dtype=output_dtype)
-
-        whitening = linalg.cholesky(self.inv_cov)
-        scaled_dataset = dot(whitening, self.dataset)
-        scaled_points = dot(whitening, points)
-
-        if m >= self.n:
-            # there are more points than data, so loop over data
-            for i in range(self.n):
-                diff = scaled_dataset[:, i, newaxis] - scaled_points
-                energy = sum(diff * diff, axis=0) / 2.0
-                result += self.weights[i]*exp(-energy)
-        else:
-            # loop over points
-            for i in range(m):
-                diff = scaled_dataset - scaled_points[:, i, newaxis]
-                energy = sum(diff * diff, axis=0) / 2.0
-                result[i] = sum(exp(-energy)*self.weights, axis=0)
-
-        result = result / self._norm_factor
-
-        return result
+        result = _gaussian_kernel_estimate(
+            self.dataset.T.astype(float), self.weights[:, None].astype(float),
+            points.T.astype(float), self.inv_cov.astype(float)
+        )
+        return result[:, 0]
 
     __call__ = evaluate
 
@@ -625,7 +608,7 @@ class gaussian_kde(object):
                 diff = self.dataset - points[:, i, newaxis]
                 tdiff = dot(self.inv_cov, diff)
                 energy = sum(diff * tdiff, axis=0) / 2.0
-                result[i] = logsumexp(-energy, b=self.weights / 
+                result[i] = logsumexp(-energy, b=self.weights /
                                       self._norm_factor)
 
         return result

--- a/scipy/stats/kde.py
+++ b/scipy/stats/kde.py
@@ -238,8 +238,19 @@ class gaussian_kde(object):
                     self.d)
                 raise ValueError(msg)
 
-        result = gaussian_kernel_estimate(self.dataset.T, self.weights[:, None], points.T,
-                                          self.inv_cov)
+        output_dtype = np.common_type(self.covariance, points)
+        itemsize = np.dtype(output_dtype).itemsize
+        if itemsize == 4:
+            spec = 'float'
+        elif itemsize == 8:
+            spec = 'double'
+        elif itemsize in (12, 16):
+            spec = 'long double'
+        else:
+            raise TypeError('%s has unexpected item size %d' %
+                            (output_dtype, itemsize))
+        result = gaussian_kernel_estimate[spec](self.dataset.T, self.weights[:, None],
+                                                points.T, self.inv_cov, output_dtype)
         return result[:, 0]
 
     __call__ = evaluate

--- a/scipy/stats/kde.py
+++ b/scipy/stats/kde.py
@@ -32,7 +32,7 @@ import numpy as np
 
 # Local imports.
 from . import mvn
-from ._stats import _gaussian_kernel_estimate
+from ._stats import gaussian_kernel_estimate
 
 
 __all__ = ['gaussian_kde']
@@ -238,10 +238,8 @@ class gaussian_kde(object):
                     self.d)
                 raise ValueError(msg)
 
-        result = _gaussian_kernel_estimate(
-            self.dataset.T.astype(float), self.weights[:, None].astype(float),
-            points.T.astype(float), self.inv_cov.astype(float)
-        )
+        result = gaussian_kernel_estimate(self.dataset.T, self.weights[:, None], points.T,
+                                          self.inv_cov)
         return result[:, 0]
 
     __call__ = evaluate

--- a/scipy/stats/tests/test_kdeoth.py
+++ b/scipy/stats/tests/test_kdeoth.py
@@ -316,24 +316,28 @@ def test_kde_integer_input():
     assert_array_almost_equal(kde(x1), y_expected, decimal=6)
 
 
-_ftypes = [getattr(np, dtype) for dtype in ['float32', 'float64', 'float96',
-                                            'float128', 'int32', 'int64']
-           if hasattr(np, dtype)]
+_ftypes = ['float32', 'float64', 'float96', 'float128', 'int32', 'int64']
 
 @pytest.mark.parametrize("bw_type", _ftypes + ["scott", "silverman"])
 @pytest.mark.parametrize("weights_type", _ftypes)
 @pytest.mark.parametrize("dataset_type", _ftypes)
 @pytest.mark.parametrize("point_type", _ftypes)
 def test_kde_output_dtype(point_type, dataset_type, weights_type, bw_type):
-    # test that for any given combination of input datatypes we get the
-    # appropriate result datatype
-    weights = np.arange(5, dtype=weights_type)
+    # Check whether the datatypes are available
+    point_type = getattr(np, point_type, None)
+    dataset_type = getattr(np, weights_type, None)
+    weights_type = getattr(np, weights_type, None)
 
     if bw_type in ["scott", "silverman"]:
         bw = bw_type
     else:
-        bw = bw_type(3)
+        bw_type = getattr(np, bw_type, None)
+        bw = bw_type(3) if bw_type else None
 
+    if any(dt is None for dt in [point_type, dataset_type, weights_type, bw]):
+        pytest.skip()
+
+    weights = np.arange(5, dtype=weights_type)
     dataset = np.arange(5, dtype=dataset_type)
     k = stats.kde.gaussian_kde(dataset, bw_method=bw, weights=weights)
     points = np.arange(5, dtype=point_type)
@@ -455,7 +459,7 @@ def test_seed():
     gkde_1d_weighted = stats.gaussian_kde(xn_1d, weights=wn)
     test_seed_sub(gkde_1d_weighted)
 
-    # Test 2D case 
+    # Test 2D case
     mean = np.array([1.0, 3.0])
     covariance = np.array([[1.0, 2.0], [2.0, 6.0]])
     xn_2d = np.random.multivariate_normal(mean, covariance, size=n_basesample).T


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

<!--#### Reference issue-->
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?

This change provides a cython-based implementation to evaluate gaussian kernel estimates which should improve the performance of `gaussian_kde`. It could also be used to evaluate the Nadarya-Watson estimator, and I've kept the function relatively generic by supporting vector-valued weights.

#### Additional information
<!--Any additional information you think is important.-->

```
python runtests.py --bench-compare master stats.GaussianKDE
· Creating environments
· Discovering benchmarks.....
·· Uninstalling from virtualenv-py3.7-Cython0.29.2-Tempita-numpy-pybind11-pytest-six..
·· Installing 2465d671 <fast-gaussian-de> into virtualenv-py3.7-Cython0.29.2-Tempita-numpy-pybind11-pytest-six...
· Running 4 total benchmarks (2 commits * 1 environments * 2 benchmarks)
[  0.00%] · For scipy commit 9b87b584 <master> (round 1/2):
[  0.00%] ·· Building for virtualenv-py3.7-Cython0.29.2-Tempita-numpy-pybind11-pytest-six..........
[  0.00%] ·· Benchmarking virtualenv-py3.7-Cython0.29.2-Tempita-numpy-pybind11-pytest-six
[ 12.50%] ··· Running (stats.GaussianKDE.time_gaussian_kde_evaluate_few_points--)..
[ 25.00%] · For scipy commit 2465d671 <fast-gaussian-de> (round 1/2):
[ 25.00%] ·· Building for virtualenv-py3.7-Cython0.29.2-Tempita-numpy-pybind11-pytest-six..........
[ 25.00%] ·· Benchmarking virtualenv-py3.7-Cython0.29.2-Tempita-numpy-pybind11-pytest-six
[ 37.50%] ··· Running (stats.GaussianKDE.time_gaussian_kde_evaluate_few_points--)..
[ 50.00%] · For scipy commit 2465d671 <fast-gaussian-de> (round 2/2):
[ 50.00%] ·· Benchmarking virtualenv-py3.7-Cython0.29.2-Tempita-numpy-pybind11-pytest-six
[ 62.50%] ··· stats.GaussianKDE.time_gaussian_kde_evaluate_few_points                                               463±7μs
[ 75.00%] ··· stats.GaussianKDE.time_gaussian_kde_evaluate_many_points                                           1.40±0.01s
[ 75.00%] · For scipy commit 9b87b584 <master> (round 2/2):
[ 75.00%] ·· Building for virtualenv-py3.7-Cython0.29.2-Tempita-numpy-pybind11-pytest-six..........
[ 75.00%] ·· Benchmarking virtualenv-py3.7-Cython0.29.2-Tempita-numpy-pybind11-pytest-six
[ 87.50%] ··· stats.GaussianKDE.time_gaussian_kde_evaluate_few_points                                              661±40μs
[100.00%] ··· stats.GaussianKDE.time_gaussian_kde_evaluate_many_points                                           1.53±0.07s
       before           after         ratio
     [9b87b584]       [2465d671]
     <master>         <fast-gaussian-de>
-        661±40μs          463±7μs     0.70  stats.GaussianKDE.time_gaussian_kde_evaluate_few_points

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.
```