### PR TITLE
MAINT: special: change some features of the Voigt function

### DIFF
--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -316,7 +316,7 @@ Error Function and Fresnel Integrals
    fresnel_zeros -- Compute nt complex zeros of sine and cosine Fresnel integrals S(z) and C(z).
    modfresnelp   -- Modified Fresnel positive integrals
    modfresnelm   -- Modified Fresnel negative integrals
-   voigt         -- Voigt profile.
+   voigt_profile -- Voigt profile.
 
 These are not universal functions:
 

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -85,7 +85,6 @@ __all__ = [
     'riccati_jn',
     'riccati_yn',
     'sinc',
-    'voigt',
     'y0_zeros',
     'y1_zeros',
     'y1p_zeros',
@@ -2255,53 +2254,6 @@ def factorialk(n, k, exact=True):
         return val
     else:
         raise NotImplementedError
-
-
-def voigt(x, sigma=1.0, gamma=1.0, mu=0.0):
-    r"""
-    Voigt profile.
-
-    The Voigt profile is a convolution of a 1D Normal distribution with
-    standard deviation ``sigma`` and a 1D Cauchy distribution with half-width at
-    half-maximum ``gamma``.
-
-    Parameters
-    ----------
-    x : array_like
-        Input argument.
-    sigma : array_like, optional
-        The standard deviation of the Normal distribution part. The default is
-        1.0.
-    gamma : array_like, optional
-        The half-width at half-maximum of the Cauchy distribution part. The
-        default is 1.0.
-    mu : array_like, optional
-        The location of the peak profile. The default is 0.0.
-
-    Returns
-    -------
-    y : array_like
-        The Voigt profile at the given position. It will have the same shape as
-        `x`.
-
-    Notes
-    -----
-    It can be expressed in terms of Faddeeva function
-
-    .. math:: V(x;\sigma,\gamma,\mu) = \frac{Re[w(z)]}{\sigma\sqrt{2\pi}},
-    .. math:: z = \frac{x-\mu+i\gamma}{\sqrt{2}\sigma}
-
-    where :math:`w(z)` is the Faddeeva function.
-
-    See Also
-    --------
-    wofz : Faddeeva function
-
-    References
-    ----------
-    .. [1] https://en.wikipedia.org/wiki/Voigt_profile
-    """
-    return ufuncs._voigt(x, sigma, gamma, mu)
 
 
 def zeta(x, q=None, out=None):

--- a/scipy/special/_faddeeva.cxx
+++ b/scipy/special/_faddeeva.cxx
@@ -77,7 +77,7 @@ npy_cdouble faddeeva_ndtr(npy_cdouble zp)
 
 /*
  * Log of the normal CDF for complex arguments.
- * 
+ *
  * This is equivalent to log(ndtr(z)), but is more robust to overflow at $z\to\infty$.
  * This implementation uses the Faddeva computation, $\erfc(z) = \exp(-z^2) w(iz)$,
  * taking special care to select the principal branch of the log function
@@ -100,7 +100,7 @@ npy_cdouble faddeeva_log_ndtr(npy_cdouble zp)
 
     /* Compute the principal branch of $log(exp(-z^2))$, using the fact that
      * $log(e^t) = log|e^t| + i Arg(e^t)$, and that if $t = r + is$, then
-     * $e^t = e^r (\cos(s) + i \sin(s))$. 
+     * $e^t = e^r (\cos(s) + i \sin(s))$.
      */
     double mRe_z2 = (y - x) * (x + y); // Re(-z^2), being careful of overflow
     double mIm_z2 = -2*x*y; // Im(-z^2)
@@ -123,12 +123,12 @@ npy_cdouble faddeeva_log_ndtr(npy_cdouble zp)
     return npy_cpack(real(result), im);
 }
 
-double faddeeva_voigt(double x, double sigma, double gamma, double mu)
+double faddeeva_voigt_profile(double x, double sigma, double gamma)
 {
     const double INV_SQRT_2 = 0.707106781186547524401;
     const double SQRT_2PI = 2.5066282746310002416123552393401042;
 
-    double zreal = (x-mu) / sigma * INV_SQRT_2;
+    double zreal = x / sigma * INV_SQRT_2;
     double zimag = gamma / sigma * INV_SQRT_2;
     std::complex<double> z(zreal, zimag);
     std::complex<double> w = Faddeeva::w(z);

--- a/scipy/special/_faddeeva.h
+++ b/scipy/special/_faddeeva.h
@@ -34,7 +34,7 @@ npy_cdouble faddeeva_dawsn_complex(npy_cdouble zp);
 npy_cdouble faddeeva_ndtr(npy_cdouble zp);
 npy_cdouble faddeeva_log_ndtr(npy_cdouble zp);
 
-double faddeeva_voigt(double x, double sigma, double gamma, double mu);
+double faddeeva_voigt_profile(double x, double sigma, double gamma);
 
 EXTERN_C_END
 

--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -104,9 +104,49 @@ add_newdoc("_lambertw",
     Internal function, use `lambertw` instead.
     """)
 
-add_newdoc("_voigt",
-    """
-    Internal function, use `voigt` instead.
+add_newdoc("voigt_profile",
+    r"""
+    voigt_profile(x, sigma, gamma, out=None)
+
+    Voigt profile.
+
+    The Voigt profile is a convolution of a 1D Normal distribution with
+    standard deviation ``sigma`` and a 1D Cauchy distribution with half-width at
+    half-maximum ``gamma``.
+
+    Parameters
+    ----------
+    x : array_like
+        Real argument
+    sigma : array_like
+        The standard deviation of the Normal distribution part
+    gamma : array_like
+        The half-width at half-maximum of the Cauchy distribution part
+    out : ndarray, optional
+        Optional output array for the function values
+
+    Returns
+    -------
+    scalar or ndarray
+        The Voigt profile at the given arguments
+
+    Notes
+    -----
+    It can be expressed in terms of Faddeeva function
+
+    .. math:: V(x; \sigma, \gamma) = \frac{Re[w(z)]}{\sigma\sqrt{2\pi}},
+    .. math:: z = \frac{x + i\gamma}{\sqrt{2}\sigma}
+
+    where :math:`w(z)` is the Faddeeva function.
+
+    See Also
+    --------
+    wofz : Faddeeva function
+
+    References
+    ----------
+    .. [1] https://en.wikipedia.org/wiki/Voigt_profile
+
     """)
 
 add_newdoc("wrightomega",

--- a/scipy/special/functions.json
+++ b/scipy/special/functions.json
@@ -112,9 +112,9 @@
             "struve_power_series": "ddi*d->d"
         }
     },
-    "_voigt" : {
+    "voigt_profile" : {
         "_faddeeva.h++" : {
-            "faddeeva_voigt": "dddd->d"
+            "faddeeva_voigt_profile": "ddd->d"
         }
     },
     "_zeta": {

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1005,23 +1005,6 @@ class TestCephes(object):
         ]
         assert_func_equal(cephes.wofz, w, z, rtol=1e-13)
 
-    def test_voigt(self):
-        x = np.array([-7.89, -0.05, -13.98, -12.66, 11.34, -11.56, -9.17,
-                      16.59, 9.11, -43.33])
-        sigma = np.array([45.06, 7.98, 16.83, 0.21, 4.25, 20.40, 25.61, 18.05,
-                          2.12, 0.30])
-        gamma = np.array([6.66, 24.13, 42.37, 6.32, 21.96, 30.53, 8.32, 2.50,
-                          39.33, 45.68])
-        mu = np.array([-0.90, 9.81, 16.39, 11.35, -4.00, -1.10, -16.40, 2.17,
-                       -26.34, 19.12])
-        inp = np.array([x, sigma, gamma, mu]).T
-        # obtained from Mathematica: PDF[VoigtDistribution[g, s], x - m]
-        res = np.array([0.007814991977202203,0.010812438037546024,
-                        0.005002213710481824,0.003264178482142271,
-                        0.009796933140171458,0.007708387983265838,
-                        0.011866733688978792,0.014941654349762511,
-                        0.004471089949150293,0.002428855941768048])
-        assert_func_equal(special.voigt, res, inp, rtol=1e-10, atol=1e-13)
 
 class TestAiry(object):
     def test_airy(self):
@@ -1720,11 +1703,6 @@ class TestErf(object):
         vals = [np.nan, -np.inf, np.inf]
         expected = [np.nan + np.nan * 1.j, 0.-0.j, 0.+0.j]
         assert_allclose(special.wofz(vals), expected, rtol=1e-15)
-
-    def test_voigt_nan_inf(self):
-        vals = [np.nan, -np.inf, np.inf]
-        expected = [np.nan, -0.0, 0.0]
-        assert_allclose(special.voigt(vals), expected, rtol=1e-15)
 
 
 class TestEuler(object):

--- a/scipy/special/tests/test_cython_special.py
+++ b/scipy/special/tests/test_cython_special.py
@@ -255,6 +255,7 @@ PARAMS = [
     (special.struve, cython_special.struve, ('dd',), None),
     (special.tandg, cython_special.tandg, ('d',), None),
     (special.tklmbda, cython_special.tklmbda, ('dd',), None),
+    (special.voigt_profile, cython_special.voigt_profile, ('ddd',), None),
     (special.wofz, cython_special.wofz, ('D',), None),
     (special.wrightomega, cython_special.wrightomega, ('D',), None),
     (special.xlog1py, cython_special.xlog1py, ('dd', 'DD'), None),

--- a/scipy/special/tests/test_faddeeva.py
+++ b/scipy/special/tests/test_faddeeva.py
@@ -1,0 +1,59 @@
+import pytest
+
+import numpy as np
+from numpy.testing import assert_allclose
+import scipy.special as sc
+from scipy.special._testutils import FuncData
+
+
+class TestVoigtProfile(object):
+
+    @pytest.mark.parametrize('x, sigma, gamma', [
+        (np.nan, 1, 1),
+        (0, np.nan, 1),
+        (0, 1, np.nan)
+    ])
+    def test_nan(self, x, sigma, gamma):
+        assert np.isnan(sc.voigt_profile(x, sigma, gamma))
+
+    @pytest.mark.parametrize('x, desired', [
+        (-np.inf, 0),
+        (np.inf, 0)
+    ])
+    def test_inf(self, x, desired):
+        assert sc.voigt_profile(x, 1, 1) == desired
+
+    def test_against_mathematica(self):
+        # Results obtained from Mathematica by computing
+        #
+        # PDF[VoigtDistribution[gamma, sigma], x]
+        #
+        points = np.array([
+            [-7.89, 45.06, 6.66, 0.0077921073660388806401],
+            [-0.05, 7.98, 24.13, 0.012068223646769913478],
+            [-13.98, 16.83, 42.37, 0.0062442236362132357833],
+            [-12.66, 0.21, 6.32, 0.010052516161087379402],
+            [11.34, 4.25, 21.96, 0.0113698923627278917805],
+            [-11.56, 20.40, 30.53, 0.0076332760432097464987],
+            [-9.17, 25.61, 8.32, 0.011646345779083005429],
+            [16.59, 18.05, 2.50, 0.013637768837526809181],
+            [9.11, 2.12, 39.33, 0.0076644040807277677585],
+            [-43.33, 0.30, 45.68, 0.0036680463875330150996]
+        ])
+        FuncData(
+            sc.voigt_profile,
+            points,
+            (0, 1, 2),
+            3,
+            atol=0,
+            rtol=1e-15
+        ).check()
+
+    def test_symmetry(self):
+        x = np.linspace(0, 10, 20)
+        assert_allclose(
+            sc.voigt_profile(x, 1, 1),
+            sc.voigt_profile(-x, 1, 1),
+            rtol=1e-15,
+            atol=0
+        )


### PR DESCRIPTION

#### Reference issue

None

#### What does this implement/fix?

This changes some aspects of the Voigt profile function to make it more closely match the literature and conform more to the special API. Note that the function has not been present in a release yet (it was added here https://github.com/scipy/scipy/pull/9311/files), so we are free to modify the API at will.

#### Additional information

In particular, this PR:

- Renames the function to `voigt_profile` to better distinguish it from the Voigt functions `U` and `V` (see e.g. https://dlmf.nist.gov/7.19)
- Removes the default arguments as this is uncommon in the special API
- Removes the `mu` parameter as this is not how the function is typically defined in the literature (see e.g. Wikipedia which is referenced in the docstring: https://en.wikipedia.org/wiki/Voigt_profile). Note that we are not losing functionality since you can easily do `sc.voigt_profile(x - mu, sigma, gamma)`.

The tests are also moved to a new file `test_faddeeva.py` to avoid the general test explosion in `test_basic.py` and are extended a teensy bit.

cc @mfkasim91 (I apologize for not bringing these things up during code review; I was busy with other things at the time.)