### PR TITLE
BUG: Fix subspace_angles for complex values

### DIFF
--- a/doc/release/1.4.0-notes.rst
+++ b/doc/release/1.4.0-notes.rst
@@ -47,6 +47,9 @@ lambda expressions for them.
 
 `scipy.linalg` improvements
 ---------------------------
+The function ``scipy.linalg.subspace_angles(A, B)`` now gives correct
+results for complex-valued matrices. Before this, the function only returned
+correct values for real-valued matrices.
 
 
 `scipy.ndimage` improvements

--- a/scipy/linalg/decomp_svd.py
+++ b/scipy/linalg/decomp_svd.py
@@ -472,15 +472,15 @@ def subspace_angles(A, B):
     del B
 
     # 2. Compute SVD for cosine
-    QA_T_QB = dot(QA.T, QB)
-    sigma = svdvals(QA_T_QB)
+    QA_H_QB = dot(QA.T.conj(), QB)
+    sigma = svdvals(QA_H_QB)
 
     # 3. Compute matrix B
     if QA.shape[1] >= QB.shape[1]:
-        B = QB - dot(QA, QA_T_QB)
+        B = QB - dot(QA, QA_H_QB)
     else:
-        B = QA - dot(QB, QA_T_QB.T)
-    del QA, QB, QA_T_QB
+        B = QA - dot(QB, QA_H_QB.T.conj())
+    del QA, QB, QA_H_QB
 
     # 4. Compute SVD for sine
     mask = sigma ** 2 >= 0.5
@@ -490,6 +490,7 @@ def subspace_angles(A, B):
         mu_arcsin = 0.
 
     # 5. Compute the principal angles
-    # with reverse ordering of sigma because smallest sigma belongs to largest angle theta
+    # with reverse ordering of sigma because smallest sigma belongs to largest
+    # angle theta
     theta = where(mask, mu_arcsin, arccos(clip(sigma[::-1], -1., 1.)))
     return theta

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -2736,6 +2736,14 @@ def test_subspace_angles():
     expected = np.array([np.pi/2, 0, 0])
     assert_allclose(subspace_angles(A, B), expected, rtol=1e-12)
 
+    # Complex
+    # second column in "b" does not affect result, just there so that
+    # b can have more cols than a, and vice-versa (both conditional code paths)
+    a = [[1 + 1j], [0]]
+    b = [[1 - 1j, 0], [0, 1]]
+    assert_allclose(subspace_angles(a, b), 0., atol=1e-14)
+    assert_allclose(subspace_angles(b, a), 0., atol=1e-14)
+
 
 class TestCDF2RDF(object):
 


### PR DESCRIPTION
`subspace_angles` was giving the wrong result for complex values because we weren't using the conjugate transpose.