### PR TITLE
MAINT: use the define for NPY_NO_DEPRECATED_API, fix where needed

### DIFF
--- a/scipy/cluster/_vq.pyx
+++ b/scipy/cluster/_vq.pyx
@@ -118,7 +118,7 @@ cdef int _vq(vq_type *obs, vq_type *code_book,
 
     # M[i][j] is the inner product of the i-th obs and j-th code
     # M = obs * codes.T
-    cal_M(nobs, ncodes, nfeat, obs, code_book, <vq_type *>M.data)
+    cal_M(nobs, ncodes, nfeat, obs, code_book, <vq_type *>np.PyArray_DATA(M))
 
     for i in range(nobs):
         for j in range(ncodes):
@@ -232,13 +232,13 @@ def vq(np.ndarray obs, np.ndarray codes):
     outdists.fill(np.inf)
 
     if obs.dtype.type is np.float32:
-        _vq(<float32_t *>obs.data, <float32_t *>codes.data,
-            ncodes, nfeat, nobs, <int32_t *>outcodes.data,
-            <float32_t *>outdists.data)
+        _vq(<float32_t *>np.PyArray_DATA(obs), <float32_t *>np.PyArray_DATA(codes),
+            ncodes, nfeat, nobs, <int32_t *>np.PyArray_DATA(outcodes),
+            <float32_t *>np.PyArray_DATA(outdists))
     elif obs.dtype.type is np.float64:
-        _vq(<float64_t *>obs.data, <float64_t *>codes.data,
-            ncodes, nfeat, nobs, <int32_t *>outcodes.data,
-            <float64_t *>outdists.data)
+        _vq(<float64_t *>np.PyArray_DATA(obs), <float64_t *>np.PyArray_DATA(codes),
+            ncodes, nfeat, nobs, <int32_t *>np.PyArray_DATA(outcodes),
+            <float64_t *>np.PyArray_DATA(outdists))
 
     return outcodes, outdists
 
@@ -355,14 +355,14 @@ def update_cluster_means(np.ndarray obs, np.ndarray labels, int nc):
         raise ValueError('ndim different than 1 or 2 are not supported')
 
     if obs.dtype.type is np.float32:
-        has_members = _update_cluster_means(<float32_t *>obs.data,
-                                            <int32_t *>labels.data,
-                                            <float32_t *>cb.data,
+        has_members = _update_cluster_means(<float32_t *>np.PyArray_DATA(obs),
+                                            <int32_t *>np.PyArray_DATA(labels),
+                                            <float32_t *>np.PyArray_DATA(cb),
                                             obs.shape[0], nc, nfeat)
     elif obs.dtype.type is np.float64:
-        has_members = _update_cluster_means(<float64_t *>obs.data,
-                                            <int32_t *>labels.data,
-                                            <float64_t *>cb.data,
+        has_members = _update_cluster_means(<float64_t *>np.PyArray_DATA(obs),
+                                            <int32_t *>np.PyArray_DATA(labels),
+                                            <float64_t *>np.PyArray_DATA(cb),
                                             obs.shape[0], nc, nfeat)
 
     return cb, has_members

--- a/scipy/cluster/setup.py
+++ b/scipy/cluster/setup.py
@@ -11,6 +11,7 @@ else:
 def configuration(parent_package='', top_path=None):
     from scipy._build_utils.system_info import get_info
     from numpy.distutils.misc_util import Configuration, get_numpy_include_dirs
+    from scipy._build_utils import numpy_nodepr_api
     config = Configuration('cluster', parent_package, top_path)
 
     blas_opt = get_info('lapack_opt')
@@ -20,15 +21,18 @@ def configuration(parent_package='', top_path=None):
     config.add_extension('_vq',
         sources=[('_vq.c')],
         include_dirs=[get_numpy_include_dirs()],
-        extra_info=blas_opt)
+        extra_info=blas_opt,
+        **numpy_nodepr_api)
 
     config.add_extension('_hierarchy',
         sources=[('_hierarchy.c')],
-        include_dirs=[get_numpy_include_dirs()])
+        include_dirs=[get_numpy_include_dirs()],
+        **numpy_nodepr_api)
 
     config.add_extension('_optimal_leaf_ordering',
         sources=[('_optimal_leaf_ordering.c')],
-        include_dirs=[get_numpy_include_dirs()])
+        include_dirs=[get_numpy_include_dirs()],
+        **numpy_nodepr_api)
 
     return config
 

--- a/scipy/fftpack/setup.py
+++ b/scipy/fftpack/setup.py
@@ -7,12 +7,15 @@ from os.path import join
 
 def configuration(parent_package='',top_path=None):
     from numpy.distutils.misc_util import Configuration
+    from scipy._build_utils import numpy_nodepr_api
 
     config = Configuration('fftpack',parent_package, top_path)
 
     config.add_data_dir('tests')
 
-    config.add_extension('convolve', sources=['convolve.c'])
+    config.add_extension('convolve',
+                         sources=['convolve.c'],
+                         **numpy_nodepr_api)
     return config
 
 

--- a/scipy/integrate/__quadpack.h
+++ b/scipy/integrate/__quadpack.h
@@ -356,11 +356,11 @@ static PyObject *quadpack_qagse(PyObject *dummy, PyObject *args) {
   ap_rlist = (PyArrayObject *)PyArray_SimpleNew(1,limit_shape,NPY_DOUBLE);
   ap_elist = (PyArrayObject *)PyArray_SimpleNew(1,limit_shape,NPY_DOUBLE);
   if (ap_iord == NULL || ap_alist == NULL || ap_blist == NULL || ap_rlist == NULL || ap_elist == NULL) goto fail;
-  iord = (int *)ap_iord->data;
-  alist = (double *)ap_alist->data;
-  blist = (double *)ap_blist->data;
-  rlist = (double *)ap_rlist->data;
-  elist = (double *)ap_elist->data;
+  iord = (int *)PyArray_DATA(ap_iord);
+  alist = (double *)PyArray_DATA(ap_alist);
+  blist = (double *)PyArray_DATA(ap_blist);
+  rlist = (double *)PyArray_DATA(ap_rlist);
+  elist = (double *)PyArray_DATA(ap_elist);
 
   if (setjmp(callback.error_buf) != 0) {
       goto fail;
@@ -439,11 +439,11 @@ static PyObject *quadpack_qagie(PyObject *dummy, PyObject *args) {
   ap_elist = (PyArrayObject *)PyArray_SimpleNew(1,limit_shape,NPY_DOUBLE);
   if (ap_iord == NULL || ap_alist == NULL || ap_blist == NULL || ap_rlist == NULL
       || ap_elist == NULL) goto fail;
-  iord = (int *)ap_iord->data;
-  alist = (double *)ap_alist->data;
-  blist = (double *)ap_blist->data;
-  rlist = (double *)ap_rlist->data;
-  elist = (double *)ap_elist->data;
+  iord = (int *)PyArray_DATA(ap_iord);
+  alist = (double *)PyArray_DATA(ap_alist);
+  blist = (double *)PyArray_DATA(ap_blist);
+  rlist = (double *)PyArray_DATA(ap_rlist);
+  elist = (double *)PyArray_DATA(ap_elist);
 
   if (setjmp(callback.error_buf) != 0) {
       goto fail;
@@ -518,9 +518,9 @@ static PyObject *quadpack_qagpe(PyObject *dummy, PyObject *args) {
 
   ap_points = (PyArrayObject *)PyArray_ContiguousFromObject(o_points, NPY_DOUBLE, 1, 1);
   if (ap_points == NULL) goto fail;
-  npts2 = ap_points->dimensions[0];
+  npts2 = PyArray_DIMS(ap_points)[0];
   npts2_shape[0] = npts2;
-  points = (double *)ap_points->data;
+  points = (double *)PyArray_DATA(ap_points);
 
   /* Setup iwork and work arrays */
   ap_iord = (PyArrayObject *)PyArray_SimpleNew(1,limit_shape,NPY_INT);
@@ -532,14 +532,14 @@ static PyObject *quadpack_qagpe(PyObject *dummy, PyObject *args) {
   ap_level = (PyArrayObject *)PyArray_SimpleNew(1,limit_shape,NPY_DOUBLE);
   ap_ndin = (PyArrayObject *)PyArray_SimpleNew(1,npts2_shape,NPY_DOUBLE);
   if (ap_iord == NULL || ap_alist == NULL || ap_blist == NULL || ap_rlist == NULL || ap_elist == NULL || ap_pts == NULL || ap_level == NULL || ap_ndin == NULL) goto fail;
-  iord = (int *)ap_iord->data;
-  alist = (double *)ap_alist->data;
-  blist = (double *)ap_blist->data;
-  rlist = (double *)ap_rlist->data;
-  elist = (double *)ap_elist->data;
-  pts = (double *)ap_pts->data;
-  level = (int *)ap_level->data;
-  ndin = (int *)ap_level->data;
+  iord = (int *)PyArray_DATA(ap_iord);
+  alist = (double *)PyArray_DATA(ap_alist);
+  blist = (double *)PyArray_DATA(ap_blist);
+  rlist = (double *)PyArray_DATA(ap_rlist);
+  elist = (double *)PyArray_DATA(ap_elist);
+  pts = (double *)PyArray_DATA(ap_pts);
+  level = (int *)PyArray_DATA(ap_level);
+  ndin = (int *)PyArray_DATA(ap_level);
 
   if (setjmp(callback.error_buf) != 0) {
       goto fail;
@@ -623,7 +623,7 @@ static PyObject *quadpack_qawoe(PyObject *dummy, PyObject *args) {
   if (o_chebmo != NULL) {
     ap_chebmo = (PyArrayObject *)PyArray_ContiguousFromObject(o_chebmo, NPY_DOUBLE, 2, 2);
     if (ap_chebmo == NULL) goto fail;
-    if (ap_chebmo->dimensions[1] != maxp1 || ap_chebmo->dimensions[0] != 25)
+    if (PyArray_DIMS(ap_chebmo)[1] != maxp1 || PyArray_DIMS(ap_chebmo)[0] != 25)
       PYERR(quadpack_error,"Chebyshev moment array has the wrong size.");
   }
   else {
@@ -632,7 +632,7 @@ static PyObject *quadpack_qawoe(PyObject *dummy, PyObject *args) {
     ap_chebmo = (PyArrayObject *)PyArray_SimpleNew(2,sz,NPY_DOUBLE);
     if (ap_chebmo == NULL) goto fail;
   }
-  chebmo = (double *) ap_chebmo->data;
+  chebmo = (double *) PyArray_DATA(ap_chebmo);
 
   /* Setup iwork and work arrays */
   ap_iord = (PyArrayObject *)PyArray_SimpleNew(1,limit_shape,NPY_INT);
@@ -642,12 +642,12 @@ static PyObject *quadpack_qawoe(PyObject *dummy, PyObject *args) {
   ap_rlist = (PyArrayObject *)PyArray_SimpleNew(1,limit_shape,NPY_DOUBLE);
   ap_elist = (PyArrayObject *)PyArray_SimpleNew(1,limit_shape,NPY_DOUBLE);
   if (ap_iord == NULL || ap_nnlog == NULL || ap_alist == NULL || ap_blist == NULL || ap_rlist == NULL || ap_elist == NULL) goto fail;
-  iord = (int *)ap_iord->data;
-  nnlog = (int *)ap_nnlog->data;
-  alist = (double *)ap_alist->data;
-  blist = (double *)ap_blist->data;
-  rlist = (double *)ap_rlist->data;
-  elist = (double *)ap_elist->data;
+  iord = (int *)PyArray_DATA(ap_iord);
+  nnlog = (int *)PyArray_DATA(ap_nnlog);
+  alist = (double *)PyArray_DATA(ap_alist);
+  blist = (double *)PyArray_DATA(ap_blist);
+  rlist = (double *)PyArray_DATA(ap_rlist);
+  elist = (double *)PyArray_DATA(ap_elist);
 
   if (setjmp(callback.error_buf) != 0) {
       goto fail;
@@ -729,7 +729,7 @@ static PyObject *quadpack_qawfe(PyObject *dummy, PyObject *args) {
   sz[1] = maxp1;
   ap_chebmo = (PyArrayObject *)PyArray_SimpleNew(2,sz,NPY_DOUBLE);
   if (ap_chebmo == NULL) goto fail;
-  chebmo = (double *) ap_chebmo->data;
+  chebmo = (double *) PyArray_DATA(ap_chebmo);
 
   /* Setup iwork and work arrays */
   ap_iord = (PyArrayObject *)PyArray_SimpleNew(1,limit_shape,NPY_INT);
@@ -742,15 +742,15 @@ static PyObject *quadpack_qawfe(PyObject *dummy, PyObject *args) {
   ap_erlst = (PyArrayObject *)PyArray_SimpleNew(1,limlst_shape,NPY_DOUBLE);
   ap_ierlst = (PyArrayObject *)PyArray_SimpleNew(1,limlst_shape,NPY_INT);
   if (ap_iord == NULL || ap_nnlog == NULL || ap_alist == NULL || ap_blist == NULL || ap_rlist == NULL || ap_elist == NULL || ap_rslst == NULL || ap_erlst == NULL || ap_ierlst == NULL) goto fail;
-  iord = (int *)ap_iord->data;
-  nnlog = (int *)ap_nnlog->data;
-  alist = (double *)ap_alist->data;
-  blist = (double *)ap_blist->data;
-  rlist = (double *)ap_rlist->data;
-  elist = (double *)ap_elist->data;
-  rslst = (double *)ap_rslst->data;
-  erlst = (double *)ap_erlst->data;
-  ierlst = (int *)ap_ierlst->data;
+  iord = (int *)PyArray_DATA(ap_iord);
+  nnlog = (int *)PyArray_DATA(ap_nnlog);
+  alist = (double *)PyArray_DATA(ap_alist);
+  blist = (double *)PyArray_DATA(ap_blist);
+  rlist = (double *)PyArray_DATA(ap_rlist);
+  elist = (double *)PyArray_DATA(ap_elist);
+  rslst = (double *)PyArray_DATA(ap_rslst);
+  erlst = (double *)PyArray_DATA(ap_erlst);
+  ierlst = (int *)PyArray_DATA(ap_ierlst);
 
   if (setjmp(callback.error_buf) != 0) {
       goto fail;
@@ -837,11 +837,11 @@ static PyObject *quadpack_qawce(PyObject *dummy, PyObject *args) {
   ap_rlist = (PyArrayObject *)PyArray_SimpleNew(1,limit_shape,NPY_DOUBLE);
   ap_elist = (PyArrayObject *)PyArray_SimpleNew(1,limit_shape,NPY_DOUBLE);
   if (ap_iord == NULL || ap_alist == NULL || ap_blist == NULL || ap_rlist == NULL || ap_elist == NULL) goto fail;
-  iord = (int *)ap_iord->data;
-  alist = (double *)ap_alist->data;
-  blist = (double *)ap_blist->data;
-  rlist = (double *)ap_rlist->data;
-  elist = (double *)ap_elist->data;
+  iord = (int *)PyArray_DATA(ap_iord);
+  alist = (double *)PyArray_DATA(ap_alist);
+  blist = (double *)PyArray_DATA(ap_blist);
+  rlist = (double *)PyArray_DATA(ap_rlist);
+  elist = (double *)PyArray_DATA(ap_elist);
 
   if (setjmp(callback.error_buf) != 0) {
       goto fail;
@@ -918,11 +918,11 @@ static PyObject *quadpack_qawse(PyObject *dummy, PyObject *args) {
   ap_rlist = (PyArrayObject *)PyArray_SimpleNew(1,limit_shape,NPY_DOUBLE);
   ap_elist = (PyArrayObject *)PyArray_SimpleNew(1,limit_shape,NPY_DOUBLE);
   if (ap_iord == NULL || ap_alist == NULL || ap_blist == NULL || ap_rlist == NULL || ap_elist == NULL) goto fail;
-  iord = (int *)ap_iord->data;
-  alist = (double *)ap_alist->data;
-  blist = (double *)ap_blist->data;
-  rlist = (double *)ap_rlist->data;
-  elist = (double *)ap_elist->data;
+  iord = (int *)PyArray_DATA(ap_iord);
+  alist = (double *)PyArray_DATA(ap_alist);
+  blist = (double *)PyArray_DATA(ap_blist);
+  rlist = (double *)PyArray_DATA(ap_rlist);
+  elist = (double *)PyArray_DATA(ap_elist);
 
   if (setjmp(callback.error_buf) != 0) {
       goto fail;

--- a/scipy/integrate/setup.py
+++ b/scipy/integrate/setup.py
@@ -44,6 +44,7 @@ def configuration(parent_package='',top_path=None):
         lapack_opt = dict(lapack_opt)
         include_dirs.extend(lapack_opt.pop('include_dirs'))
 
+    lapack_opt.update(numpy_nodepr_api)
     config.add_extension('_quadpack',
                          sources=['_quadpackmodule.c'],
                          libraries=['quadpack', 'mach'] + lapack_libs,
@@ -54,7 +55,6 @@ def configuration(parent_package='',top_path=None):
 
     # odepack/lsoda-odeint
     odepack_opts = lapack_opt.copy()
-    odepack_opts.update(numpy_nodepr_api)
     config.add_extension('_odepack',
                          sources=['_odepackmodule.c'],
                          libraries=['lsoda', 'mach'] + lapack_libs,
@@ -79,7 +79,8 @@ def configuration(parent_package='',top_path=None):
     config.add_extension('_dop',
                          sources=['dop.pyf'],
                          libraries=['dop'],
-                         depends=dop_src)
+                         depends=dop_src,
+                         **numpy_nodepr_api)
 
     config.add_extension('_test_multivariate',
                          sources=quadpack_test_src)

--- a/scipy/interpolate/setup.py
+++ b/scipy/interpolate/setup.py
@@ -5,6 +5,7 @@ from os.path import join
 
 def configuration(parent_package='',top_path=None):
     from numpy.distutils.misc_util import Configuration
+    from scipy._build_utils import numpy_nodepr_api
 
     config = Configuration('interpolate', parent_package, top_path)
 
@@ -12,7 +13,8 @@ def configuration(parent_package='',top_path=None):
     config.add_library('fitpack', sources=fitpack_src)
 
     config.add_extension('interpnd',
-                         sources=['interpnd.c'])
+                         sources=['interpnd.c'],
+                         **numpy_nodepr_api)
 
     config.add_extension('_ppoly',
                          sources=['_ppoly.c'])
@@ -20,19 +22,22 @@ def configuration(parent_package='',top_path=None):
     config.add_extension('_bspl',
                          sources=['_bspl.c'],
                          libraries=['fitpack'],
-                         depends=['src/__fitpack.h'] + fitpack_src)
+                         depends=['src/__fitpack.h'] + fitpack_src,
+                         **numpy_nodepr_api)
 
     config.add_extension('_fitpack',
                          sources=['src/_fitpackmodule.c'],
                          libraries=['fitpack'],
                          depends=(['src/__fitpack.h','src/multipack.h']
-                                  + fitpack_src)
+                                  + fitpack_src),
+                         **numpy_nodepr_api,
                          )
 
     config.add_extension('dfitpack',
                          sources=['src/fitpack.pyf'],
                          libraries=['fitpack'],
                          depends=fitpack_src,
+                         **numpy_nodepr_api,
                          )
 
     config.add_data_dir('tests')

--- a/scipy/interpolate/src/_fitpackmodule.c
+++ b/scipy/interpolate/src/_fitpackmodule.c
@@ -4,6 +4,13 @@
  */
 
 #include <Python.h>
+
+/* uses the old numpy API since it sets the data attribute */
+#ifdef NPY_NO_DEPRECATED_API
+#undef NPY_NO_DEPRECATED_API
+#endif
+#define NPY_NO_DEPRECATED_API 0
+
 #include "numpy/arrayobject.h"
 
 #define PyInt_AsLong PyLong_AsLong

--- a/scipy/io/matlab/mio5_utils.pyx
+++ b/scipy/io/matlab/mio5_utils.pyx
@@ -457,7 +457,7 @@ cdef class VarReader5:
             el_count = byte_count // dt.itemsize
         cdef int flags = 0
         if copy:
-            flags = cnp.NPY_WRITEABLE
+            flags = cnp.NPY_ARRAY_WRITEABLE
         Py_INCREF(<object> dt)
         el = PyArray_NewFromDescr(&PyArray_Type,
                                    dt,

--- a/scipy/io/matlab/numpy_rephrasing.h
+++ b/scipy/io/matlab/numpy_rephrasing.h
@@ -1,5 +1,5 @@
 #include <numpy/arrayobject.h>
-#define PyArray_Set_BASE(arr, obj) PyArray_BASE(arr) = obj
+#define PyArray_Set_BASE(arr, obj) PyArray_SetBaseObject(arr, obj)
 #define PyArray_PyANewFromDescr(descr, nd, dims, data, parent)                 \
         PyArray_NewFromDescr(&PyArray_Type, descr, nd, dims,                  \
                              NULL, data, 0, parent)

--- a/scipy/io/matlab/setup.py
+++ b/scipy/io/matlab/setup.py
@@ -3,10 +3,13 @@ from __future__ import division, print_function, absolute_import
 
 def configuration(parent_package='io',top_path=None):
     from numpy.distutils.misc_util import Configuration
+    from scipy._build_utils import numpy_nodepr_api
     config = Configuration('matlab', parent_package, top_path)
     config.add_extension('streams', sources=['streams.c'])
-    config.add_extension('mio_utils', sources=['mio_utils.c'])
-    config.add_extension('mio5_utils', sources=['mio5_utils.c'])
+    config.add_extension('mio_utils', sources=['mio_utils.c'],
+                         **numpy_nodepr_api)
+    config.add_extension('mio5_utils', sources=['mio5_utils.c'],
+                         **numpy_nodepr_api)
     config.add_data_dir('tests')
     return config
 

--- a/scipy/io/setup.py
+++ b/scipy/io/setup.py
@@ -3,10 +3,12 @@ from __future__ import division, print_function, absolute_import
 
 def configuration(parent_package='',top_path=None):
     from numpy.distutils.misc_util import Configuration
+    from scipy._build_utils import numpy_nodepr_api
     config = Configuration('io', parent_package, top_path)
 
     config.add_extension('_test_fortran',
-                         sources=['_test_fortran.pyf', '_test_fortran.f'])
+                         sources=['_test_fortran.pyf', '_test_fortran.f'],
+                         **numpy_nodepr_api)
 
     config.add_data_dir('tests')
     config.add_subpackage('matlab')

--- a/scipy/linalg/_decomp_update.pyx.in
+++ b/scipy/linalg/_decomp_update.pyx.in
@@ -59,7 +59,7 @@ cdef extern from "numpy/npy_math.h":
 
 from numpy.linalg import LinAlgError
 
-# This is used in place of, e.g., cnp.NPY_C_CONTIGUOUS, to indicate that a C
+# This is used in place of, e.g., cnp.NPY_ARRAY_C_CONTIGUOUS, to indicate that a C
 # F or non contiguous array is acceptable.
 cdef int ARRAY_ANYORDER = 0
 
@@ -1209,7 +1209,7 @@ cdef form_qTu(cnp.ndarray q, cnp.ndarray u, void* qTuvoid, int* qTus,
     cdef int us[2]
     cdef int ldu, p
 
-    if cnp.PyArray_CHKFLAGS(q, cnp.NPY_F_CONTIGUOUS):
+    if cnp.PyArray_CHKFLAGS(q, cnp.NPY_ARRAY_F_CONTIGUOUS):
         qvoid = extract(q, qs)
         if u.ndim == 1:
             uvoid = extract(u, us)
@@ -1229,16 +1229,16 @@ cdef form_qTu(cnp.ndarray q, cnp.ndarray u, void* qTuvoid, int* qTus,
                         col(<double_complex*>qTuvoid, qTus, k), qTus[0])
         elif u.ndim == 2:
             p = u.shape[1]
-            if cnp.PyArray_CHKFLAGS(u, cnp.NPY_F_CONTIGUOUS):
+            if cnp.PyArray_CHKFLAGS(u, cnp.NPY_ARRAY_F_CONTIGUOUS):
                 utrans = N
                 uvoid = extract(u, us)
                 ldu = u.shape[0]
-            elif cnp.PyArray_CHKFLAGS(u, cnp.NPY_C_CONTIGUOUS):
+            elif cnp.PyArray_CHKFLAGS(u, cnp.NPY_ARRAY_C_CONTIGUOUS):
                 utrans = T
                 uvoid = extract(u, us)
                 ldu = u.shape[1]
             else:
-                u = PyArray_FromArray(u, NULL, cnp.NPY_F_CONTIGUOUS)
+                u = PyArray_FromArray(u, NULL, cnp.NPY_ARRAY_F_CONTIGUOUS)
                 utrans = N
                 uvoid = extract(u, us)
                 ldu = u.shape[0]
@@ -1257,7 +1257,7 @@ cdef form_qTu(cnp.ndarray q, cnp.ndarray u, void* qTuvoid, int* qTus,
                         <double_complex*>uvoid, ldu, 0,
                         col(<double_complex*>qTuvoid, qTus, k), m)
 
-    elif cnp.PyArray_CHKFLAGS(q, cnp.NPY_C_CONTIGUOUS):
+    elif cnp.PyArray_CHKFLAGS(q, cnp.NPY_ARRAY_C_CONTIGUOUS):
         qvoid = extract(q, qs)
         if u.ndim == 1:
             uvoid = extract(u, us)
@@ -1281,16 +1281,16 @@ cdef form_qTu(cnp.ndarray q, cnp.ndarray u, void* qTuvoid, int* qTus,
                 blas_t_conj(m, col(<double_complex*>qTuvoid, qTus, k), qTus)
         elif u.ndim == 2:
             p = u.shape[1]
-            if cnp.PyArray_CHKFLAGS(u, cnp.NPY_F_CONTIGUOUS):
+            if cnp.PyArray_CHKFLAGS(u, cnp.NPY_ARRAY_F_CONTIGUOUS):
                 utrans = N
                 uvoid = extract(u, us)
                 ldu = u.shape[0]
-            elif cnp.PyArray_CHKFLAGS(u, cnp.NPY_C_CONTIGUOUS):
+            elif cnp.PyArray_CHKFLAGS(u, cnp.NPY_ARRAY_C_CONTIGUOUS):
                 utrans = T
                 uvoid = extract(u, us)
                 ldu = u.shape[1]
             else:
-                u = PyArray_FromArray(u, NULL, cnp.NPY_F_CONTIGUOUS)
+                u = PyArray_FromArray(u, NULL, cnp.NPY_ARRAY_F_CONTIGUOUS)
                 utrans = N
                 uvoid = extract(u, us)
                 ldu = u.shape[0]
@@ -1326,7 +1326,7 @@ cdef validate_array(cnp.ndarray a, bint chkfinite):
     for j in range(a.ndim):
         if a.strides[j] <= 0:
             copy = True
-        if (a.strides[j] / a.descr.itemsize) >= libc.limits.INT_MAX:
+        if (a.strides[j] / cnp.PyArray_ITEMSIZE(a)) >= libc.limits.INT_MAX:
             copy = True
         if a.shape[j] >= libc.limits.INT_MAX:
             raise ValueError('Input array too large for use with BLAS')
@@ -1336,7 +1336,7 @@ cdef validate_array(cnp.ndarray a, bint chkfinite):
             raise ValueError('array must not contain infs or NaNs')
 
     if copy:
-        return PyArray_FromArray(a, NULL, cnp.NPY_F_CONTIGUOUS)
+        return PyArray_FromArray(a, NULL, cnp.NPY_ARRAY_F_CONTIGUOUS)
     return a
 
 cdef tuple validate_qr(object q0, object r0, bint overwrite_q, int q_order,
@@ -1346,14 +1346,14 @@ cdef tuple validate_qr(object q0, object r0, bint overwrite_q, int q_order,
     cdef int typecode
     cdef bint economic = False
 
-    q_order |= cnp.NPY_BEHAVED_NS | cnp.NPY_ELEMENTSTRIDES
-    r_order |= cnp.NPY_BEHAVED_NS | cnp.NPY_ELEMENTSTRIDES
+    q_order |= cnp.NPY_ARRAY_BEHAVED_NS | cnp.NPY_ARRAY_ELEMENTSTRIDES
+    r_order |= cnp.NPY_ARRAY_BEHAVED_NS | cnp.NPY_ARRAY_ELEMENTSTRIDES
 
     if not overwrite_q:
-        q_order |= cnp.NPY_ENSURECOPY
+        q_order |= cnp.NPY_ARRAY_ENSURECOPY
 
     if not overwrite_r:
-        r_order |= cnp.NPY_ENSURECOPY
+        r_order |= cnp.NPY_ARRAY_ENSURECOPY
 
     # in the interests of giving better error messages take any number of
     # dimensions here.
@@ -1540,9 +1540,9 @@ def qr_delete(Q, R, k, int p=1, which='row', overwrite_qr=False,
                 norm = np.linalg.norm(qnew)
                 return qnew / norm, r1 * norm
             if not cnp.PyArray_ISONESEGMENT(q1):
-                q1 = PyArray_FromArray(q1, NULL, cnp.NPY_F_CONTIGUOUS)
+                q1 = PyArray_FromArray(q1, NULL, cnp.NPY_ARRAY_F_CONTIGUOUS)
                 qisF = True
-            elif cnp.PyArray_CHKFLAGS(q1, cnp.NPY_F_CONTIGUOUS):
+            elif cnp.PyArray_CHKFLAGS(q1, cnp.NPY_ARRAY_F_CONTIGUOUS):
                 qisF = True
             else:
                 qisF = False
@@ -1581,7 +1581,7 @@ def qr_delete(Q, R, k, int p=1, which='row', overwrite_qr=False,
         # inputs and to avoid allocating a work array for that case.
         if p1 > 1:
             q1, r1, typecode, m, n, economic = validate_qr(Q, R, overwrite,
-                    cnp.NPY_F_CONTIGUOUS, overwrite, cnp.NPY_F_CONTIGUOUS,
+                    cnp.NPY_ARRAY_F_CONTIGUOUS, overwrite, cnp.NPY_ARRAY_F_CONTIGUOUS,
                     chkfinite)
         else:
             q1, r1, typecode, m, n, economic = validate_qr(Q, R, overwrite,
@@ -1763,7 +1763,7 @@ def qr_insert(Q, R, u, k, which='row', rcond=None, overwrite_qru=False, check_fi
 cdef qr_insert_row(Q, R, u, int k, bint overwrite_qru, bint check_finite):
     cdef cnp.ndarray q1, r1, u1, qnew, rnew
     cdef int j
-    cdef int u_flags = cnp.NPY_BEHAVED_NS | cnp.NPY_ELEMENTSTRIDES
+    cdef int u_flags = cnp.NPY_ARRAY_BEHAVED_NS | cnp.NPY_ARRAY_ELEMENTSTRIDES
     cdef int typecode, m, n, p, info
     cdef void* qptr
     cdef void* rptr
@@ -1812,9 +1812,9 @@ cdef qr_insert_row(Q, R, u, int k, bint overwrite_qru, bint check_finite):
     if economic:
         if not overwrite_qru:
             r1 = PyArray_FromArray(r1, NULL,
-                    cnp.NPY_F_CONTIGUOUS | cnp.NPY_ENSURECOPY)
+                    cnp.NPY_ARRAY_F_CONTIGUOUS | cnp.NPY_ARRAY_ENSURECOPY)
             u1 = PyArray_FromArray(u1, NULL,
-                    cnp.NPY_F_CONTIGUOUS | cnp.NPY_ENSURECOPY)
+                    cnp.NPY_ARRAY_F_CONTIGUOUS | cnp.NPY_ARRAY_ENSURECOPY)
 
         shape[0] = m + p
         shape[1] = n + p
@@ -1835,8 +1835,8 @@ cdef qr_insert_row(Q, R, u, int k, bint overwrite_qru, bint check_finite):
                 {{endfor}}
         else:
             # only copies if necessary.
-            r1 = PyArray_FromArray(r1, NULL, cnp.NPY_F_CONTIGUOUS)
-            u1 = PyArray_FromArray(u1, NULL, cnp.NPY_F_CONTIGUOUS)
+            r1 = PyArray_FromArray(r1, NULL, cnp.NPY_ARRAY_F_CONTIGUOUS)
+            u1 = PyArray_FromArray(u1, NULL, cnp.NPY_ARRAY_F_CONTIGUOUS)
             qptr = extract(qnew, qs)
             rptr = extract(r1, rs)
             uptr = extract(u1, us)
@@ -1884,7 +1884,7 @@ cdef qr_insert_col(Q, R, u, int k, rcond, bint overwrite_qru, bint check_finite)
     cdef cnp.ndarray q1, r1, u1, qnew, rnew
     cdef int j
     cdef int q_flags = ARRAY_ANYORDER
-    cdef int u_flags = cnp.NPY_BEHAVED_NS | cnp.NPY_ELEMENTSTRIDES
+    cdef int u_flags = cnp.NPY_ARRAY_BEHAVED_NS | cnp.NPY_ARRAY_ELEMENTSTRIDES
     cdef int typecode, m, n, p, info, p_eco, p_full
     cdef void* qptr
     cdef void* rptr
@@ -1907,7 +1907,7 @@ cdef qr_insert_col(Q, R, u, int k, rcond, bint overwrite_qru, bint check_finite)
     q1, r1, typecode, m, n, economic = validate_qr(Q, R, True, ARRAY_ANYORDER,
             True, ARRAY_ANYORDER, check_finite)
     if not overwrite_qru:
-        u_flags |= cnp.NPY_ENSURECOPY | cnp.NPY_F_CONTIGUOUS
+        u_flags |= cnp.NPY_ARRAY_ENSURECOPY | cnp.NPY_ARRAY_F_CONTIGUOUS
     u1 = PyArray_CheckFromAny(u, NULL, 0, 0, u_flags, NULL)
 
     if cnp.PyArray_TYPE(u1) != typecode:
@@ -1954,8 +1954,8 @@ cdef qr_insert_col(Q, R, u, int k, rcond, bint overwrite_qru, bint check_finite)
         else:
             p_eco = m-n
             p_full = p - p_eco
-            if not cnp.PyArray_CHKFLAGS(u1, cnp.NPY_F_CONTIGUOUS):
-                u1 = PyArray_FromArray(u1, NULL, cnp.NPY_F_CONTIGUOUS)
+            if not cnp.PyArray_CHKFLAGS(u1, cnp.NPY_ARRAY_F_CONTIGUOUS):
+                u1 = PyArray_FromArray(u1, NULL, cnp.NPY_ARRAY_F_CONTIGUOUS)
         shape[0] = m
         shape[1] = n+p_eco
         qnew = cnp.PyArray_ZEROS(2, shape, typecode, 1)
@@ -1989,10 +1989,10 @@ RCONDS = ['&frc', '&drc', '&cfrc', '&cdrc']
         return qnew, rnew
     else:
         if (not cnp.PyArray_ISONESEGMENT(q1)) or u1.ndim == 2:
-            q1 = PyArray_FromArray(q1, NULL, cnp.NPY_F_CONTIGUOUS)
-        if (not overwrite_qru and cnp.PyArray_CHKFLAGS(q1, cnp.NPY_C_CONTIGUOUS)
+            q1 = PyArray_FromArray(q1, NULL, cnp.NPY_ARRAY_F_CONTIGUOUS)
+        if (not overwrite_qru and cnp.PyArray_CHKFLAGS(q1, cnp.NPY_ARRAY_C_CONTIGUOUS)
             and (typecode == cnp.NPY_CFLOAT or typecode == cnp.NPY_CDOUBLE)):
-            u_flags |= cnp.NPY_ENSURECOPY
+            u_flags |= cnp.NPY_ARRAY_ENSURECOPY
             u1 = PyArray_FromArray(u1, NULL, u_flags)
 
         shape[0] = m
@@ -2189,7 +2189,7 @@ def qr_update(Q, R, u, v, overwrite_qruv=False, check_finite=True):
 
     """
     cdef cnp.ndarray q1, r1, u1, v1, qTu, s
-    cdef int uv_flags = cnp.NPY_BEHAVED_NS | cnp.NPY_ELEMENTSTRIDES
+    cdef int uv_flags = cnp.NPY_ARRAY_BEHAVED_NS | cnp.NPY_ARRAY_ELEMENTSTRIDES
     cdef int typecode, p, m, n, info
     cdef void* qptr
     cdef void* rptr
@@ -2213,7 +2213,7 @@ def qr_update(Q, R, u, v, overwrite_qruv=False, check_finite=True):
             overwrite, ARRAY_ANYORDER, chkfinite)
 
     if not overwrite:
-        uv_flags |= cnp.NPY_ENSURECOPY
+        uv_flags |= cnp.NPY_ARRAY_ENSURECOPY
     u1 = PyArray_CheckFromAny(u, NULL, 0, 0, uv_flags, NULL)
     v1 = PyArray_CheckFromAny(v, NULL, 0, 0, uv_flags, NULL)
 
@@ -2267,9 +2267,9 @@ def qr_update(Q, R, u, v, overwrite_qruv=False, check_finite=True):
         length = 2*n
         s = cnp.PyArray_ZEROS(ndim, &length, typecode, 1)
         if not cnp.PyArray_ISONESEGMENT(q1):
-            q1 = PyArray_FromArray(q1, NULL, cnp.NPY_F_CONTIGUOUS)
+            q1 = PyArray_FromArray(q1, NULL, cnp.NPY_ARRAY_F_CONTIGUOUS)
             qisF = True
-        elif cnp.PyArray_CHKFLAGS(q1, cnp.NPY_F_CONTIGUOUS):
+        elif cnp.PyArray_CHKFLAGS(q1, cnp.NPY_ARRAY_F_CONTIGUOUS):
             qisF = True
         else:
             qisF = False
@@ -2304,7 +2304,7 @@ def qr_update(Q, R, u, v, overwrite_qruv=False, check_finite=True):
         qTuptr = extract(qTu, qTus)
         if p == 1:
             if not cnp.PyArray_ISONESEGMENT(q1):
-                q1 = PyArray_FromArray(q1, NULL, cnp.NPY_F_CONTIGUOUS)
+                q1 = PyArray_FromArray(q1, NULL, cnp.NPY_ARRAY_F_CONTIGUOUS)
             form_qTu(q1, u1, qTuptr, qTus, 0)
             qptr = extract(q1, qs)
             rptr = extract(r1, rs)
@@ -2317,15 +2317,15 @@ def qr_update(Q, R, u, v, overwrite_qruv=False, check_finite=True):
                         <{{CNAME}}*>vptr, vs)
                 {{endfor}}
         else:
-            if not cnp.PyArray_CHKFLAGS(q1, cnp.NPY_F_CONTIGUOUS):
-                q1 = PyArray_FromArray(q1, NULL, cnp.NPY_F_CONTIGUOUS)
-            if not cnp.PyArray_CHKFLAGS(r1, cnp.NPY_F_CONTIGUOUS):
-                r1 = PyArray_FromArray(r1, NULL, cnp.NPY_F_CONTIGUOUS)
+            if not cnp.PyArray_CHKFLAGS(q1, cnp.NPY_ARRAY_F_CONTIGUOUS):
+                q1 = PyArray_FromArray(q1, NULL, cnp.NPY_ARRAY_F_CONTIGUOUS)
+            if not cnp.PyArray_CHKFLAGS(r1, cnp.NPY_ARRAY_F_CONTIGUOUS):
+                r1 = PyArray_FromArray(r1, NULL, cnp.NPY_ARRAY_F_CONTIGUOUS)
             if not cnp.PyArray_ISONESEGMENT(u1):
-                u1 = PyArray_FromArray(u1, NULL, cnp.NPY_F_CONTIGUOUS)
+                u1 = PyArray_FromArray(u1, NULL, cnp.NPY_ARRAY_F_CONTIGUOUS)
             # v.T must be F contiguous --> v must be C contiguous
-            if not cnp.PyArray_CHKFLAGS(v1, cnp.NPY_C_CONTIGUOUS):
-                v1 = PyArray_FromArray(v1, NULL, cnp.NPY_C_CONTIGUOUS)
+            if not cnp.PyArray_CHKFLAGS(v1, cnp.NPY_ARRAY_C_CONTIGUOUS):
+                v1 = PyArray_FromArray(v1, NULL, cnp.NPY_ARRAY_C_CONTIGUOUS)
             v1 = v1.T
             form_qTu(q1, u1, qTuptr, qTus, 0)
             qptr = extract(q1, qs)

--- a/scipy/linalg/setup.py
+++ b/scipy/linalg/setup.py
@@ -8,7 +8,8 @@ def configuration(parent_package='', top_path=None):
     from distutils.sysconfig import get_python_inc
     from scipy._build_utils.system_info import get_info, NotFoundError, numpy_info
     from numpy.distutils.misc_util import Configuration, get_numpy_include_dirs
-    from scipy._build_utils import (get_g77_abi_wrappers, split_fortran_files)
+    from scipy._build_utils import (get_g77_abi_wrappers, split_fortran_files,
+         numpy_nodepr_api)
 
     config = Configuration('linalg', parent_package, top_path)
 
@@ -26,7 +27,8 @@ def configuration(parent_package='', top_path=None):
     config.add_extension('_fblas',
                          sources=sources,
                          depends=['fblas_l?.pyf.src'],
-                         extra_info=lapack_opt
+                         extra_info=lapack_opt,
+                         **numpy_nodepr_api,
                          )
 
     # flapack:
@@ -46,7 +48,8 @@ def configuration(parent_package='', top_path=None):
                                   'flapack_sym_herm.pyf.src',
                                   'flapack_other.pyf.src',
                                   'flapack_user.pyf.src'],
-                         extra_info=lapack_opt
+                         extra_info=lapack_opt,
+                         **numpy_nodepr_api,
                          )
 
     if atlas_version is not None:
@@ -54,20 +57,23 @@ def configuration(parent_package='', top_path=None):
         config.add_extension('_cblas',
                              sources=['cblas.pyf.src'],
                              depends=['cblas.pyf.src', 'cblas_l1.pyf.src'],
-                             extra_info=lapack_opt
+                             extra_info=lapack_opt,
+                             **numpy_nodepr_api,
                              )
 
         # clapack:
         config.add_extension('_clapack',
                              sources=['clapack.pyf.src'],
                              depends=['clapack.pyf.src'],
-                             extra_info=lapack_opt
+                             extra_info=lapack_opt,
+                             **numpy_nodepr_api,
                              )
 
     # _flinalg:
     config.add_extension('_flinalg',
                          sources=[join('src', 'det.f'), join('src', 'lu.f')],
-                         extra_info=lapack_opt
+                         extra_info=lapack_opt,
+                             **numpy_nodepr_api,
                          )
 
     # _interpolative:
@@ -119,13 +125,16 @@ def configuration(parent_package='', top_path=None):
                                  routines_to_split)
     fnames = [join('src', 'id_dist', 'src', f) for f in fnames]
     config.add_extension('_interpolative', fnames + ["interpolative.pyf"],
-                         extra_info=lapack_opt
+                         extra_info=lapack_opt,
+                         **numpy_nodepr_api,
                          )
 
     # _solve_toeplitz:
     config.add_extension('_solve_toeplitz',
                          sources=[('_solve_toeplitz.c')],
-                         include_dirs=[get_numpy_include_dirs()])
+                         include_dirs=[get_numpy_include_dirs()],
+                         **numpy_nodepr_api,
+                        )
 
     config.add_data_dir('tests')
 
@@ -144,7 +153,9 @@ def configuration(parent_package='', top_path=None):
                                   'fortran_defs.h', '_blas_subroutines.h'],
                          include_dirs=['.'],
                          libraries=['fwrappers'],
-                         extra_info=lapack_opt)
+                         extra_info=lapack_opt,
+                         **numpy_nodepr_api,
+                        )
 
     config.add_extension('cython_lapack',
                          sources=['cython_lapack.c'],
@@ -152,10 +163,14 @@ def configuration(parent_package='', top_path=None):
                                   'fortran_defs.h', '_lapack_subroutines.h'],
                          include_dirs=['.'],
                          libraries=['fwrappers'],
-                         extra_info=lapack_opt)
+                         extra_info=lapack_opt,
+                         **numpy_nodepr_api,
+                        )
 
     config.add_extension('_decomp_update',
-                         sources=['_decomp_update.c'])
+                         sources=['_decomp_update.c'],
+                         **numpy_nodepr_api,
+                        )
 
     # Add any license files
     config.add_data_files('src/id_dist/doc/doc.tex')

--- a/scipy/ndimage/setup.py
+++ b/scipy/ndimage/setup.py
@@ -31,7 +31,9 @@ def configuration(parent_package='', top_path=None):
     # Cython wants the .c and .pyx to have the underscore.
     config.add_extension("_ni_label",
                          sources=["src/_ni_label.c",],
-                         include_dirs=['src']+[get_include()])
+                         include_dirs=['src']+[get_include()],
+                         **numpy_nodepr_api,
+                        )
 
     config.add_extension("_ctest",
                          sources=["src/_ctest.c"],
@@ -48,7 +50,9 @@ def configuration(parent_package='', top_path=None):
                          define_macros=_define_macros)
 
     config.add_extension("_cytest",
-                         sources=["src/_cytest.c"])
+                         sources=["src/_cytest.c"],
+                         **numpy_nodepr_api,
+                        )
 
     config.add_data_dir('tests')
 

--- a/scipy/ndimage/src/_ni_label.pyx
+++ b/scipy/ndimage/src/_ni_label.pyx
@@ -205,8 +205,8 @@ cpdef _label(np.ndarray input,
              np.ndarray structure,
              np.ndarray output):
     # check dimensions
-    # To understand the need for the casts to object, see
-    # http://trac.cython.org/cython_trac/ticket/302
+    # To understand the need for the casts to object in order to use
+    # tuple.__eq__, see https://github.com/cython/cython/issues/863
     assert (<object> input).shape == (<object> output).shape, \
         ("Shapes must match for input and output,"
          "{} != {}".format((<object> input).shape, (<object> output).shape))
@@ -278,8 +278,8 @@ cpdef _label(np.ndarray input,
     L = input.shape[axis]
     _line_buffer = np.empty(L + 2, dtype=np.uintp)
     _neighbor_buffer = np.empty(L + 2, dtype=np.uintp)
-    line_buffer = <np.uintp_t *> _line_buffer.data
-    neighbor_buffer = <np.uintp_t *> _neighbor_buffer.data
+    line_buffer = <np.uintp_t *> np.PyArray_DATA(_line_buffer)
+    neighbor_buffer = <np.uintp_t *> np.PyArray_DATA(_neighbor_buffer)
 
     # Add fenceposts with background values
     line_buffer[0] = neighbor_buffer[0] = BACKGROUND

--- a/scipy/optimize/_trlib/setup.py
+++ b/scipy/optimize/_trlib/setup.py
@@ -3,6 +3,7 @@ from __future__ import division, print_function, absolute_import
 def configuration(parent_package='', top_path=None):
     from numpy import get_include
     from scipy._build_utils.system_info import get_info, NotFoundError
+    from scipy._build_utils import numpy_nodepr_api
     from numpy.distutils.misc_util import Configuration
     
     from os.path import join, dirname
@@ -17,6 +18,7 @@ def configuration(parent_package='', top_path=None):
                                   'trlib_quadratic_zero.c', 'trlib_tri_factor.c'],
                          include_dirs=[get_include(), lib_inc, 'trlib'],
                          extra_info=lapack_opt,
+                         **numpy_nodepr_api,
                          )
     return config
 

--- a/scipy/optimize/setup.py
+++ b/scipy/optimize/setup.py
@@ -83,9 +83,13 @@ def configuration(parent_package='',top_path=None):
                                           for x in ["nnls.f","nnls.pyf"]],
                          **numpy_nodepr_api)
 
-    config.add_extension('_group_columns', sources=['_group_columns.c'],)
+    config.add_extension('_group_columns', sources=['_group_columns.c'],
+                         **numpy_nodepr_api,
+                        )
 
-    config.add_extension('_bglu_dense', sources=['_bglu_dense.c'])
+    config.add_extension('_bglu_dense', sources=['_bglu_dense.c'],
+                         **numpy_nodepr_api,
+                        )
 
     config.add_subpackage('_lsq')
 

--- a/scipy/signal/_upfirdn_apply.pyx
+++ b/scipy/signal/_upfirdn_apply.pyx
@@ -91,9 +91,9 @@ def _apply(np.ndarray data, DTYPE_t [::1] h_trans_flip, np.ndarray out,
     output_info.strides = <np.intp_t *> out.strides
     output_info.shape = <np.intp_t *> out.shape
 
-    data_ptr = <DTYPE_t*> data.data
+    data_ptr = <DTYPE_t*> np.PyArray_DATA(data)
     filter_ptr = <DTYPE_t*> &h_trans_flip[0]
-    out_ptr = <DTYPE_t*> out.data
+    out_ptr = <DTYPE_t*> np.PyArray_DATA(out)
 
     with nogil:
         retval = _apply_axis_inner(data_ptr, data_info,

--- a/scipy/signal/setup.py
+++ b/scipy/signal/setup.py
@@ -18,13 +18,22 @@ def configuration(parent_package='', top_path=None):
                                   'correlate_nd.c.src'],
                          depends=['sigtools.h'],
                          include_dirs=['.'],
-                         **numpy_nodepr_api)
+                         **numpy_nodepr_api,
+                        )
 
-    config.add_extension('_spectral', sources=['_spectral.c'])
-    config.add_extension('_max_len_seq_inner', sources=['_max_len_seq_inner.c'])
+    config.add_extension('_spectral', sources=['_spectral.c'],
+                         **numpy_nodepr_api,
+                        )
+    config.add_extension('_max_len_seq_inner', sources=['_max_len_seq_inner.c'],
+                         **numpy_nodepr_api,
+                        )
     config.add_extension('_peak_finding_utils',
-                         sources=['_peak_finding_utils.c'])
-    config.add_extension('_upfirdn_apply', sources=['_upfirdn_apply.c'])
+                         sources=['_peak_finding_utils.c'],
+                         **numpy_nodepr_api,
+                        )
+    config.add_extension('_upfirdn_apply', sources=['_upfirdn_apply.c'],
+                         **numpy_nodepr_api,
+                        )
     spline_src = ['splinemodule.c', 'S_bspline_util.c', 'D_bspline_util.c',
                   'C_bspline_util.c', 'Z_bspline_util.c', 'bspline_util.c']
     config.add_extension('spline', sources=spline_src, **numpy_nodepr_api)

--- a/scipy/sparse/csgraph/_tools.pyx
+++ b/scipy/sparse/csgraph/_tools.pyx
@@ -394,7 +394,7 @@ cdef void _populate_graph(np.ndarray[DTYPE_t, ndim=1, mode='c'] data,
     # of size [N, N], which is also the size of the sparse matrix
     cdef unsigned int N = graph.shape[0]
     cdef np.ndarray null_flag = np.ones((N, N), dtype=bool, order='C')
-    cdef np.npy_bool* null_ptr = <np.npy_bool*> null_flag.data
+    cdef np.npy_bool* null_ptr = <np.npy_bool*> np.PyArray_DATA(null_flag)
     cdef unsigned int row, col, i
 
     for row in range(N):

--- a/scipy/sparse/csgraph/setup.py
+++ b/scipy/sparse/csgraph/setup.py
@@ -4,29 +4,40 @@ from __future__ import division, print_function, absolute_import
 def configuration(parent_package='', top_path=None):
     import numpy
     from numpy.distutils.misc_util import Configuration
+    from scipy._build_utils import numpy_nodepr_api
 
     config = Configuration('csgraph', parent_package, top_path)
 
     config.add_data_dir('tests')
 
     config.add_extension('_shortest_path',
-         sources=['_shortest_path.c'],
-         include_dirs=[numpy.get_include()])
+                         sources=['_shortest_path.c'],
+                         include_dirs=[numpy.get_include()],
+                         **numpy_nodepr_api,
+                        )
 
     config.add_extension('_traversal',
-         sources=['_traversal.c'],
-         include_dirs=[numpy.get_include()])
+                         sources=['_traversal.c'],
+                         include_dirs=[numpy.get_include()],
+                         **numpy_nodepr_api,
+                        )
 
     config.add_extension('_min_spanning_tree',
-         sources=['_min_spanning_tree.c'],
-         include_dirs=[numpy.get_include()])
+                         sources=['_min_spanning_tree.c'],
+                         include_dirs=[numpy.get_include()],
+                         **numpy_nodepr_api,
+                        )
     
     config.add_extension('_reordering',
-         sources=['_reordering.c'],
-         include_dirs=[numpy.get_include()])
+                         sources=['_reordering.c'],
+                         include_dirs=[numpy.get_include()],
+                         **numpy_nodepr_api,
+                        )
 
     config.add_extension('_tools',
-         sources=['_tools.c'],
-         include_dirs=[numpy.get_include()])
+                         sources=['_tools.c'],
+                         include_dirs=[numpy.get_include()],
+                         **numpy_nodepr_api,
+                        )
 
     return config

--- a/scipy/sparse/linalg/eigen/arpack/setup.py
+++ b/scipy/sparse/linalg/eigen/arpack/setup.py
@@ -6,7 +6,7 @@ from os.path import join
 def configuration(parent_package='',top_path=None):
     from scipy._build_utils.system_info import get_info, NotFoundError
     from numpy.distutils.misc_util import Configuration
-    from scipy._build_utils import get_g77_abi_wrappers
+    from scipy._build_utils import get_g77_abi_wrappers, numpy_nodepr_api
 
     lapack_opt = get_info('lapack_opt')
 
@@ -26,6 +26,7 @@ def configuration(parent_package='',top_path=None):
                          libraries=['arpack_scipy'],
                          extra_info=lapack_opt,
                          depends=arpack_sources,
+                         **numpy_nodepr_api,
                          )
 
     config.add_data_dir('tests')

--- a/scipy/sparse/linalg/isolve/setup.py
+++ b/scipy/sparse/linalg/isolve/setup.py
@@ -6,7 +6,7 @@ from os.path import join
 def configuration(parent_package='',top_path=None):
     from scipy._build_utils.system_info import get_info, NotFoundError
     from numpy.distutils.misc_util import Configuration
-    from scipy._build_utils import get_g77_abi_wrappers
+    from scipy._build_utils import get_g77_abi_wrappers, numpy_nodepr_api
 
     config = Configuration('isolve',parent_package,top_path)
 
@@ -31,7 +31,9 @@ def configuration(parent_package='',top_path=None):
 
     config.add_extension('_iterative',
                          sources=sources,
-                         extra_info=lapack_opt)
+                         extra_info=lapack_opt,
+                         **numpy_nodepr_api
+                        )
 
     config.add_data_dir('tests')
 

--- a/scipy/sparse/setup.py
+++ b/scipy/sparse/setup.py
@@ -7,6 +7,7 @@ import subprocess
 
 def configuration(parent_package='',top_path=None):
     from numpy.distutils.misc_util import Configuration
+    from scipy._build_utils import numpy_nodepr_api
 
     config = Configuration('sparse',parent_package,top_path)
 
@@ -16,7 +17,9 @@ def configuration(parent_package='',top_path=None):
     config.add_subpackage('csgraph')
 
     config.add_extension('_csparsetools',
-                         sources=['_csparsetools.c'])
+                         sources=['_csparsetools.c'],
+                         **numpy_nodepr_api,
+                        )
 
     def get_sparsetools_sources(ext, build_dir):
         # Defer generation of source files
@@ -44,8 +47,9 @@ def configuration(parent_package='',top_path=None):
                'sparsetools.h',
                'util.h']
     depends = [os.path.join('sparsetools', hdr) for hdr in depends],
+    macros = [('__STDC_FORMAT_MACROS', 1)] + numpy_nodepr_api['define_macros']
     config.add_extension('_sparsetools',
-                         define_macros=[('__STDC_FORMAT_MACROS', 1)],
+                         define_macros=macros,
                          depends=depends,
                          include_dirs=['sparsetools'],
                          sources=[os.path.join('sparsetools', 'sparsetools.cxx'),
@@ -53,7 +57,7 @@ def configuration(parent_package='',top_path=None):
                                   os.path.join('sparsetools', 'csc.cxx'),
                                   os.path.join('sparsetools', 'bsr.cxx'),
                                   os.path.join('sparsetools', 'other.cxx'),
-                                  get_sparsetools_sources]
+                                  get_sparsetools_sources],
                          )
 
     return config

--- a/scipy/spatial/setup.py
+++ b/scipy/spatial/setup.py
@@ -15,6 +15,7 @@ def configuration(parent_package='', top_path=None):
     from numpy.distutils.misc_util import Configuration, get_numpy_include_dirs
     from numpy.distutils.misc_util import get_info as get_misc_info
     from scipy._build_utils.system_info import get_info as get_sys_info
+    from scipy._build_utils import numpy_nodepr_api
     from distutils.sysconfig import get_python_inc
 
     config = Configuration('spatial', parent_package, top_path)
@@ -65,7 +66,9 @@ def configuration(parent_package='', top_path=None):
     ext = config.add_extension('ckdtree',
                          sources=['ckdtree.cxx'] + ckdtree_src,
                          depends=ckdtree_dep,
-                         include_dirs=inc_dirs + [join('ckdtree', 'src')])
+                         include_dirs=inc_dirs + [join('ckdtree', 'src')],
+                         **numpy_nodepr_api,
+                        )
     ext._pre_build_hook = pre_build_hook
 
     # _distance_wrap
@@ -73,13 +76,19 @@ def configuration(parent_package='', top_path=None):
                          sources=[join('src', 'distance_wrap.c')],
                          depends=[join('src', 'distance_impl.h')],
                          include_dirs=[get_numpy_include_dirs()],
-                         extra_info=get_misc_info("npymath"))
+                         extra_info=get_misc_info("npymath"),
+                         **numpy_nodepr_api,
+                        )
 
     config.add_extension('_voronoi',
-                         sources=['_voronoi.c'])
+                         sources=['_voronoi.c'],
+                         **numpy_nodepr_api,
+                        )
 
     config.add_extension('_hausdorff',
-                         sources=['_hausdorff.c'])
+                         sources=['_hausdorff.c'],
+                         **numpy_nodepr_api,
+                        )
 
     # Add license files
     config.add_data_files('qhull_src/COPYING.txt')

--- a/scipy/spatial/src/distance_wrap.c
+++ b/scipy/spatial/src/distance_wrap.c
@@ -66,12 +66,12 @@
         }                                                               \
         else {                                                          \
             NPY_BEGIN_ALLOW_THREADS;                                    \
-            XA = (const type *)XA_->data;                               \
-            XB = (const type *)XB_->data;                               \
-            dm = (double *)dm_->data;                                   \
-            mA = XA_->dimensions[0];                                    \
-            mB = XB_->dimensions[0];                                    \
-            n = XA_->dimensions[1];                                     \
+            XA = (const type *)PyArray_DATA(XA_);                       \
+            XB = (const type *)PyArray_DATA(XB_);                       \
+            dm = (double *)PyArray_DATA(dm_);                           \
+            mA = PyArray_DIMS(XA_)[0];                                    \
+            mB = PyArray_DIMS(XB_)[0];                                    \
+            n = PyArray_DIMS(XA_)[1];                                     \
             cdist_ ## name ## _ ## type(XA, XB, dm, mA, mB, n);         \
             NPY_END_ALLOW_THREADS;                                      \
         }                                                               \
@@ -113,13 +113,13 @@ static PyObject *cdist_hamming_double_wrap(
   }
   else {
     NPY_BEGIN_ALLOW_THREADS;
-    XA = (const double*)XA_->data;
-    XB = (const double*)XB_->data;
-    w = (const double*)w_->data;
-    dm = (double*)dm_->data;
-    mA = XA_->dimensions[0];
-    mB = XB_->dimensions[0];
-    n = XA_->dimensions[1];
+    XA = (const double*)PyArray_DATA(XA_);
+    XB = (const double*)PyArray_DATA(XB_);
+    w = (const double*)PyArray_DATA(w_);
+    dm = (double*)PyArray_DATA(dm_);
+    mA = PyArray_DIMS(XA_)[0];
+    mB = PyArray_DIMS(XB_)[0];
+    n = PyArray_DIMS(XA_)[1];
     cdist_hamming_double(XA, XB, dm, mA, mB, n, w);
     NPY_END_ALLOW_THREADS;
   }
@@ -144,13 +144,13 @@ static PyObject *cdist_hamming_char_wrap(
   }
   else {
     NPY_BEGIN_ALLOW_THREADS;
-    XA = (const char*)XA_->data;
-    XB = (const char*)XB_->data;
-    w = (const double*)w_->data;
-    dm = (double*)dm_->data;
-    mA = XA_->dimensions[0];
-    mB = XB_->dimensions[0];
-    n = XA_->dimensions[1];
+    XA = (const char*)PyArray_DATA(XA_);
+    XB = (const char*)PyArray_DATA(XB_);
+    w = (const double*)PyArray_DATA(w_);
+    dm = (double*)PyArray_DATA(dm_);
+    mA = PyArray_DIMS(XA_)[0];
+    mB = PyArray_DIMS(XB_)[0];
+    n = PyArray_DIMS(XA_)[1];
     cdist_hamming_char(XA, XB, dm, mA, mB, n, w);
     NPY_END_ALLOW_THREADS;
   }
@@ -174,12 +174,12 @@ static PyObject *cdist_cosine_double_wrap(PyObject *self, PyObject *args,
   else {
     NPY_BEGIN_THREADS_DEF;
     NPY_BEGIN_THREADS;
-    XA = (const double*)XA_->data;
-    XB = (const double*)XB_->data;
-    dm = (double*)dm_->data;
-    mA = XA_->dimensions[0];
-    mB = XB_->dimensions[0];
-    n = XA_->dimensions[1];
+    XA = (const double*)PyArray_DATA(XA_);
+    XB = (const double*)PyArray_DATA(XB_);
+    dm = (double*)PyArray_DATA(dm_);
+    mA = PyArray_DIMS(XA_)[0];
+    mB = PyArray_DIMS(XB_)[0];
+    n = PyArray_DIMS(XA_)[1];
 
     status = cdist_cosine(XA, XB, dm, mA, mB, n);
     NPY_END_THREADS;
@@ -207,13 +207,13 @@ static PyObject *cdist_mahalanobis_double_wrap(PyObject *self, PyObject *args,
   else {
     NPY_BEGIN_THREADS_DEF;
     NPY_BEGIN_THREADS;
-    XA = (const double*)XA_->data;
-    XB = (const double*)XB_->data;
-    covinv = (const double*)covinv_->data;
-    dm = (double*)dm_->data;
-    mA = XA_->dimensions[0];
-    mB = XB_->dimensions[0];
-    n = XA_->dimensions[1];
+    XA = (const double*)PyArray_DATA(XA_);
+    XB = (const double*)PyArray_DATA(XB_);
+    covinv = (const double*)PyArray_DATA(covinv_);
+    dm = (double*)PyArray_DATA(dm_);
+    mA = PyArray_DIMS(XA_)[0];
+    mB = PyArray_DIMS(XB_)[0];
+    n = PyArray_DIMS(XA_)[1];
 
     status = cdist_mahalanobis(XA, XB, dm, mA, mB, n, covinv);
     NPY_END_THREADS;
@@ -241,12 +241,12 @@ static PyObject *cdist_minkowski_double_wrap(PyObject *self, PyObject *args,
   }
   else {
     NPY_BEGIN_ALLOW_THREADS;
-    XA = (const double*)XA_->data;
-    XB = (const double*)XB_->data;
-    dm = (double*)dm_->data;
-    mA = XA_->dimensions[0];
-    mB = XB_->dimensions[0];
-    n = XA_->dimensions[1];
+    XA = (const double*)PyArray_DATA(XA_);
+    XB = (const double*)PyArray_DATA(XB_);
+    dm = (double*)PyArray_DATA(dm_);
+    mA = PyArray_DIMS(XA_)[0];
+    mB = PyArray_DIMS(XB_)[0];
+    n = PyArray_DIMS(XA_)[1];
     cdist_minkowski(XA, XB, dm, mA, mB, n, p);
     NPY_END_ALLOW_THREADS;
   }
@@ -269,13 +269,13 @@ static PyObject *cdist_seuclidean_double_wrap(PyObject *self, PyObject *args,
   }
   else {
     NPY_BEGIN_ALLOW_THREADS;
-    XA = (const double*)XA_->data;
-    XB = (const double*)XB_->data;
-    dm = (double*)dm_->data;
-    var = (double*)var_->data;
-    mA = XA_->dimensions[0];
-    mB = XB_->dimensions[0];
-    n = XA_->dimensions[1];
+    XA = (const double*)PyArray_DATA(XA_);
+    XB = (const double*)PyArray_DATA(XB_);
+    dm = (double*)PyArray_DATA(dm_);
+    var = (double*)PyArray_DATA(var_);
+    mA = PyArray_DIMS(XA_)[0];
+    mB = PyArray_DIMS(XB_)[0];
+    n = PyArray_DIMS(XA_)[1];
 
     cdist_seuclidean(XA, XB, var, dm, mA, mB, n);
     NPY_END_ALLOW_THREADS;
@@ -302,13 +302,13 @@ static PyObject *cdist_weighted_minkowski_double_wrap(
   }
   else {
     NPY_BEGIN_ALLOW_THREADS;
-    XA = (const double*)XA_->data;
-    XB = (const double*)XB_->data;
-    w = (const double*)w_->data;
-    dm = (double*)dm_->data;
-    mA = XA_->dimensions[0];
-    mB = XB_->dimensions[0];
-    n = XA_->dimensions[1];
+    XA = (const double*)PyArray_DATA(XA_);
+    XB = (const double*)PyArray_DATA(XB_);
+    w = (const double*)PyArray_DATA(w_);
+    dm = (double*)PyArray_DATA(dm_);
+    mA = PyArray_DIMS(XA_)[0];
+    mB = PyArray_DIMS(XB_)[0];
+    n = PyArray_DIMS(XA_)[1];
     cdist_weighted_minkowski(XA, XB, dm, mA, mB, n, p, w);
     NPY_END_ALLOW_THREADS;
   }
@@ -331,10 +331,10 @@ static PyObject *cdist_weighted_minkowski_double_wrap(
         }                                                               \
         else {                                                          \
             NPY_BEGIN_ALLOW_THREADS;                                    \
-            X = (const type *)X_->data;                                 \
-            dm = (double *)dm_->data;                                   \
-            m = X_->dimensions[0];                                      \
-            n = X_->dimensions[1];                                      \
+            X = (const type *)PyArray_DATA(X_);                                 \
+            dm = (double *)PyArray_DATA(dm_);                                   \
+            m = PyArray_DIMS(X_)[0];                                      \
+            n = PyArray_DIMS(X_)[1];                                      \
             pdist_ ## name ## _ ## type(X, dm, m, n);                   \
             NPY_END_ALLOW_THREADS;                                      \
         }                                                               \
@@ -376,11 +376,11 @@ static PyObject *pdist_hamming_double_wrap(
   }
   else {
     NPY_BEGIN_ALLOW_THREADS;
-    X = (const double*)X_->data;
-    dm = (double*)dm_->data;
-    w = (const double*)w_->data;
-    m = X_->dimensions[0];
-    n = X_->dimensions[1];
+    X = (const double*)PyArray_DATA(X_);
+    dm = (double*)PyArray_DATA(dm_);
+    w = (const double*)PyArray_DATA(w_);
+    m = PyArray_DIMS(X_)[0];
+    n = PyArray_DIMS(X_)[1];
 
     pdist_hamming_double(X, dm, m, n, w);
     NPY_END_ALLOW_THREADS;
@@ -406,11 +406,11 @@ static PyObject *pdist_hamming_char_wrap(
   }
   else {
     NPY_BEGIN_ALLOW_THREADS;
-    X = (const char*)X_->data;
-    dm = (double*)dm_->data;
-    w = (const double*)w_->data;
-    m = X_->dimensions[0];
-    n = X_->dimensions[1];
+    X = (const char*)PyArray_DATA(X_);
+    dm = (double*)PyArray_DATA(dm_);
+    w = (const double*)PyArray_DATA(w_);
+    m = PyArray_DIMS(X_)[0];
+    n = PyArray_DIMS(X_)[1];
 
     pdist_hamming_char(X, dm, m, n, w);
     NPY_END_ALLOW_THREADS;
@@ -435,10 +435,10 @@ static PyObject *pdist_cosine_double_wrap(PyObject *self, PyObject *args,
   else {
     NPY_BEGIN_THREADS_DEF;
     NPY_BEGIN_THREADS;
-    X = (const double*)X_->data;
-    dm = (double*)dm_->data;
-    m = X_->dimensions[0];
-    n = X_->dimensions[1];
+    X = (const double*)PyArray_DATA(X_);
+    dm = (double*)PyArray_DATA(dm_);
+    m = PyArray_DIMS(X_)[0];
+    n = PyArray_DIMS(X_)[1];
     
     status = pdist_cosine(X, dm, m, n);
     NPY_END_THREADS;
@@ -466,11 +466,11 @@ static PyObject *pdist_mahalanobis_double_wrap(PyObject *self, PyObject *args,
   else {
     NPY_BEGIN_THREADS_DEF;
     NPY_BEGIN_THREADS;
-    X = (const double*)X_->data;
-    covinv = (const double*)covinv_->data;
-    dm = (double*)dm_->data;
-    m = X_->dimensions[0];
-    n = X_->dimensions[1];
+    X = (const double*)PyArray_DATA(X_);
+    covinv = (const double*)PyArray_DATA(covinv_);
+    dm = (double*)PyArray_DATA(dm_);
+    m = PyArray_DIMS(X_)[0];
+    n = PyArray_DIMS(X_)[1];
 
     status = pdist_mahalanobis(X, dm, m, n, covinv);
     NPY_END_THREADS;
@@ -497,10 +497,10 @@ static PyObject *pdist_minkowski_double_wrap(PyObject *self, PyObject *args,
   }
   else {
     NPY_BEGIN_ALLOW_THREADS;
-    X = (double*)X_->data;
-    dm = (double*)dm_->data;
-    m = X_->dimensions[0];
-    n = X_->dimensions[1];
+    X = (double*)PyArray_DATA(X_);
+    dm = (double*)PyArray_DATA(dm_);
+    m = PyArray_DIMS(X_)[0];
+    n = PyArray_DIMS(X_)[1];
 
     pdist_minkowski(X, dm, m, n, p);
     NPY_END_ALLOW_THREADS;
@@ -525,11 +525,11 @@ static PyObject *pdist_seuclidean_double_wrap(PyObject *self, PyObject *args,
   }
   else {
     NPY_BEGIN_ALLOW_THREADS;
-    X = (double*)X_->data;
-    dm = (double*)dm_->data;
-    var = (double*)var_->data;
-    m = X_->dimensions[0];
-    n = X_->dimensions[1];
+    X = (double*)PyArray_DATA(X_);
+    dm = (double*)PyArray_DATA(dm_);
+    var = (double*)PyArray_DATA(var_);
+    m = PyArray_DIMS(X_)[0];
+    n = PyArray_DIMS(X_)[1];
 
     pdist_seuclidean(X, var, dm, m, n);
     NPY_END_ALLOW_THREADS;
@@ -555,11 +555,11 @@ static PyObject *pdist_weighted_minkowski_double_wrap(
   }
   else {
     NPY_BEGIN_ALLOW_THREADS;
-    X = (double*)X_->data;
-    dm = (double*)dm_->data;
-    w = (double*)w_->data;
-    m = X_->dimensions[0];
-    n = X_->dimensions[1];
+    X = (double*)PyArray_DATA(X_);
+    dm = (double*)PyArray_DATA(dm_);
+    w = (double*)PyArray_DATA(w_);
+    m = PyArray_DIMS(X_)[0];
+    n = PyArray_DIMS(X_)[1];
 
     pdist_weighted_minkowski(X, dm, m, n, p, w);
     NPY_END_ALLOW_THREADS;
@@ -578,14 +578,14 @@ static PyObject *to_squareform_from_vector_wrap(PyObject *self, PyObject *args)
     return 0;
   }
   NPY_BEGIN_ALLOW_THREADS;
-  n = M_->dimensions[0];
-  elsize = M_->descr->elsize;
+  n = PyArray_DIMS(M_)[0];
+  elsize = PyArray_ITEMSIZE(M_);
   if (elsize == 8) {
     dist_to_squareform_from_vector_double(
-        (double*)M_->data, (const double*)v_->data, n);
+        (double*)PyArray_DATA(M_), (const double*)PyArray_DATA(v_), n);
   } else {
     dist_to_squareform_from_vector_generic(
-        (char*)M_->data, (const char*)v_->data, n, elsize);
+        (char*)PyArray_DATA(M_), (const char*)PyArray_DATA(v_), n, elsize);
   }
   NPY_END_ALLOW_THREADS;
   return Py_BuildValue("");
@@ -604,10 +604,10 @@ static PyObject *to_vector_from_squareform_wrap(PyObject *self, PyObject *args)
   }
   else {
     NPY_BEGIN_ALLOW_THREADS;
-    M = (const char*)M_->data;
-    v = (char*)v_->data;
-    n = M_->dimensions[0];
-    s = M_->descr->elsize;
+    M = (const char*)PyArray_DATA(M_);
+    v = (char*)PyArray_DATA(v_);
+    n = PyArray_DIMS(M_)[0];
+    s = PyArray_ITEMSIZE(M_);
     dist_to_vector_from_squareform(M, v, n, s);
     NPY_END_ALLOW_THREADS;
   }

--- a/scipy/special/setup.py
+++ b/scipy/special/setup.py
@@ -18,10 +18,11 @@ except ImportError:
 def configuration(parent_package='',top_path=None):
     from numpy.distutils.misc_util import Configuration
     from scipy._build_utils.system_info import get_info as get_system_info
+    from scipy._build_utils import numpy_nodepr_api
 
     config = Configuration('special', parent_package, top_path)
 
-    define_macros = []
+    define_macros = numpy_nodepr_api['define_macros']
     if sys.platform == 'win32':
         # define_macros.append(('NOINFINITIES',None))
         # define_macros.append(('NONANS',None))
@@ -59,8 +60,9 @@ def configuration(parent_package='',top_path=None):
                          sources=['specfun.pyf'],
                          f2py_options=['--no-wrap-functions'],
                          depends=specfun_src,
-                         define_macros=[],
-                         libraries=['sc_specfun'])
+                         libraries=['sc_specfun'],
+                         **numpy_nodepr_api,
+                        )
 
     # Extension _ufuncs
     headers = ['*.h', join('cephes', '*.h')]
@@ -81,6 +83,7 @@ def configuration(parent_package='',top_path=None):
         ['sc_amos', 'sc_cephes', 'sc_mach', 'sc_cdf', 'sc_specfun']
     )
     cfg.setdefault('define_macros', []).extend(define_macros)
+    cfg.update(numpy_nodepr_api)
     config.add_extension('_ufuncs',
                          depends=ufuncs_dep,
                          sources=ufuncs_src,
@@ -98,9 +101,11 @@ def configuration(parent_package='',top_path=None):
                          depends=ufuncs_cxx_dep,
                          include_dirs=[curdir] + inc_dirs,
                          define_macros=define_macros,
-                         extra_info=get_info("npymath"))
+                         extra_info=get_info("npymath"),
+                        )
 
     cfg = dict(get_system_info('lapack_opt'))
+    cfg.update(numpy_nodepr_api)
     config.add_extension('_ellip_harm_2',
                          sources=['_ellip_harm_2.c', 'sf_error.c',],
                          **cfg
@@ -127,6 +132,7 @@ def configuration(parent_package='',top_path=None):
         ['sc_amos', 'sc_cephes', 'sc_mach', 'sc_cdf', 'sc_specfun']
     )
     cfg.setdefault('define_macros', []).extend(define_macros)
+    cfg.update(numpy_nodepr_api)
     config.add_extension('cython_special',
                          depends=cython_special_dep,
                          sources=cython_special_src,

--- a/scipy/stats/setup.py
+++ b/scipy/stats/setup.py
@@ -5,6 +5,7 @@ from os.path import join
 
 def configuration(parent_package='',top_path=None):
     from numpy.distutils.misc_util import Configuration
+    from scipy._build_utils import numpy_nodepr_api
     config = Configuration('stats', parent_package, top_path)
 
     config.add_data_dir('tests')
@@ -17,17 +18,20 @@ def configuration(parent_package='',top_path=None):
         sources=['statlib.pyf'],
         f2py_options=['--no-wrap-functions'],
         libraries=['statlib'],
-        depends=statlib_src
+        depends=statlib_src,
+        **numpy_nodepr_api,
     )
 
     # add _stats module
     config.add_extension('_stats',
         sources=['_stats.c'],
+        **numpy_nodepr_api,
     )
 
     # add mvn module
     config.add_extension('mvn',
         sources=['mvn.pyf','mvndst.f'],
+        **numpy_nodepr_api,
     )
 
     return config


### PR DESCRIPTION
Build on #4351. Now that the "new" numpy API is quite mature, use it throughout the code. There was only one place I could not use the 1.7 API: in `scipy/interpolate/src/_fitpackmodule.c`