### PR TITLE
ENH: Adding optional parameter to stats.zscores to allow for ignoring NaNs

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -2285,7 +2285,7 @@ def sem(a, axis=0, ddof=1, nan_policy='propagate'):
     return s
 
 
-def zscore(a, axis=0, ddof=0):
+def zscore(a, axis=0, ddof=0, skipna=False):
     """
     Calculate the z score of each value in the sample, relative to the
     sample mean and standard deviation.
@@ -2300,6 +2300,8 @@ def zscore(a, axis=0, ddof=0):
     ddof : int, optional
         Degrees of freedom correction in the calculation of the
         standard deviation. Default is 0.
+    skipna : bool, optional
+        Allows NaNs to be ignored when calculating the z-score.
 
     Returns
     -------
@@ -2338,8 +2340,14 @@ def zscore(a, axis=0, ddof=0):
            [-0.82780366,  1.4457416 , -0.43867764, -0.1792603 ]])
     """
     a = np.asanyarray(a)
-    mns = a.mean(axis=axis, keepdims=True)
-    sstd = a.std(axis=axis, ddof=ddof, keepdims=True)
+
+    if skipna:
+        mns = np.nanmean(a=a, axis=axis, keepdims=True)
+        sstd = np.nanstd(a=a, axis=axis, ddof=ddof, keepdims=True)
+    else:
+        mns = a.mean(axis=axis, keepdims=True)
+        sstd = a.std(axis=axis, ddof=ddof, keepdims=True)
+
     return (a - mns) / sstd
 
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -2285,7 +2285,7 @@ def sem(a, axis=0, ddof=1, nan_policy='propagate'):
     return s
 
 
-def zscore(a, axis=0, ddof=0, skipna=False):
+def zscore(a, axis=0, ddof=0, nan_policy='propagate'):
     """
     Calculate the z score of each value in the sample, relative to the
     sample mean and standard deviation.
@@ -2300,9 +2300,10 @@ def zscore(a, axis=0, ddof=0, skipna=False):
     ddof : int, optional
         Degrees of freedom correction in the calculation of the
         standard deviation. Default is 0.
-    skipna : bool, optional
-        Allows NaNs to be ignored when calculating the z-score.
-
+    nan_policy : {'propagate', 'raise', 'omit'}, optional
+        Defines how to handle when input contains nan. 'propagate' returns nan,
+        'raise' throws an error, 'omit' performs the calculations ignoring nan
+        values. Default is 'propagate'.
     Returns
     -------
     zscore : array_like
@@ -2341,7 +2342,9 @@ def zscore(a, axis=0, ddof=0, skipna=False):
     """
     a = np.asanyarray(a)
 
-    if skipna:
+    contains_nan, nan_policy = _contains_nan(a, nan_policy)
+
+    if contains_nan and nan_policy == 'omit':
         mns = np.nanmean(a=a, axis=axis, keepdims=True)
         sstd = np.nanstd(a=a, axis=axis, ddof=ddof, keepdims=True)
     else:

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1772,25 +1772,24 @@ class TestVariability(object):
         assert_array_almost_equal(z[1], z1_expected)
 
     def test_zscore_nan_propagate(self):
-        # Test nan_policy set to 'propogate'
         x = np.array([1, 2, np.nan, 4, 5])
-
         z = stats.zscore(x, nan_policy='propagate')
-
-        expected = np.array([np.nan, np.nan, np.nan, np.nan, np.nan])
-        assert_array_equal(z, expected)
+        assert all(np.isnan(z))
 
     def test_zscore_nan_omit(self):
-        # Test nan_policy set to 'omit'
         x = np.array([1, 2, np.nan, 4, 5])
 
         z = stats.zscore(x, nan_policy='omit')
 
-        expected = np.array([-1.2649110640673518, -0.6324555320336759, np.nan, 0.6324555320336759, 1.2649110640673518])
+        expected = np.array([-1.2649110640673518,
+                             -0.6324555320336759,
+                             np.nan,
+                             0.6324555320336759,
+                             1.2649110640673518
+                             ])
         assert_array_almost_equal(z, expected)
 
     def test_zscore_nan_raise(self):
-        # Test nan_policy set to 'raise'
         x = np.array([1, 2, np.nan, 4, 5])
 
         assert_raises(ValueError, stats.zscore, x, nan_policy='raise')

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1771,23 +1771,29 @@ class TestVariability(object):
         assert_array_almost_equal(z[0], z0_expected)
         assert_array_almost_equal(z[1], z1_expected)
 
-    def test_zscore_nan_default(self):
-        # test skipnan keyword in zscore
+    def test_zscore_nan_propagate(self):
+        # Test nan_policy set to 'propogate'
         x = np.array([1, 2, np.nan, 4, 5])
 
-        z = stats.zscore(x, skipna=False)
+        z = stats.zscore(x, nan_policy='propagate')
 
         expected = np.array([np.nan, np.nan, np.nan, np.nan, np.nan])
         assert_array_equal(z, expected)
 
-    def test_zscore_ignore_nan(self):
-        # test skipnan keyword in zscore
+    def test_zscore_nan_omit(self):
+        # Test nan_policy set to 'omit'
         x = np.array([1, 2, np.nan, 4, 5])
 
-        z = stats.zscore(x, skipna=True)
+        z = stats.zscore(x, nan_policy='omit')
 
         expected = np.array([-1.2649110640673518, -0.6324555320336759, np.nan, 0.6324555320336759, 1.2649110640673518])
         assert_array_almost_equal(z, expected)
+
+    def test_zscore_nan_raise(self):
+        # Test nan_policy set to 'raise'
+        x = np.array([1, 2, np.nan, 4, 5])
+
+        assert_raises(ValueError, stats.zscore, x, nan_policy='raise')
 
     def test_mad(self):
         dat = np.array([2.20, 2.20, 2.4, 2.4, 2.5, 2.7, 2.8, 2.9, 3.03,

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1771,6 +1771,24 @@ class TestVariability(object):
         assert_array_almost_equal(z[0], z0_expected)
         assert_array_almost_equal(z[1], z1_expected)
 
+    def test_zscore_nan_default(self):
+        # test skipnan keyword in zscore
+        x = np.array([1, 2, np.nan, 4, 5])
+
+        z = stats.zscore(x, skipna=False)
+
+        expected = np.array([np.nan, np.nan, np.nan, np.nan, np.nan])
+        assert_array_equal(z, expected)
+
+    def test_zscore_ignore_nan(self):
+        # test skipnan keyword in zscore
+        x = np.array([1, 2, np.nan, 4, 5])
+
+        z = stats.zscore(x, skipna=True)
+
+        expected = np.array([-1.2649110640673518, -0.6324555320336759, np.nan, 0.6324555320336759, 1.2649110640673518])
+        assert_array_almost_equal(z, expected)
+
     def test_mad(self):
         dat = np.array([2.20, 2.20, 2.4, 2.4, 2.5, 2.7, 2.8, 2.9, 3.03,
                 3.03, 3.10, 3.37, 3.4, 3.4, 3.4, 3.5, 3.6, 3.7, 3.7,


### PR DESCRIPTION
#### What does this implement/fix?
Currently stats.zscores will return an array of NaNs if one or more values in an input array is NaN. This PR implements an optional parameter to allow the NaNs to be ignored and z-scores to be calculated based on the data present. 

The current behavior is preserved as default. Therefore, no existing code would be impacted by the change.

#### Additional information
In addition to updating the docstring I added two unit tests. One shows the current (default) behavior being constant, and the other shows the new (optional) behavior.

Thank you for taking the time to take a look!