### PR TITLE
Rebase kruskal fix

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5928,7 +5928,7 @@ def kruskal(*args, **kwargs):
     for i in range(num_groups):
         ssbn += _square_of_sums(ranked[j[i]:j[i+1]]) / n[i]
 
-    totaln = np.sum(n, dtype='uint64')
+    totaln = np.sum(n, dtype=float)
     h = 12.0 / (totaln * (totaln + 1)) * ssbn - 3 * (totaln + 1)
     df = num_groups - 1
     h /= ties

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5928,7 +5928,7 @@ def kruskal(*args, **kwargs):
     for i in range(num_groups):
         ssbn += _square_of_sums(ranked[j[i]:j[i+1]]) / n[i]
 
-    totaln = np.sum(n)
+    totaln = np.sum(n, dtype='uint64')
     h = 12.0 / (totaln * (totaln + 1)) * ssbn - 3 * (totaln + 1)
     df = num_groups - 1
     h /= ties

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4531,8 +4531,8 @@ class TestKruskal(object):
     def test_large_no_samples(self):
         # Test to see if large samples are handled correctly.
         n = 50000
-        x=np.random.randn(n)
-        y=np.random.randn(n) + 50
+        x = np.random.randn(n)
+        y = np.random.randn(n) + 50
         h, p = stats.kruskal(x, y)
         expected = 0
         assert_approx_equal(p, expected)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4527,6 +4527,15 @@ class TestKruskal(object):
         assert_almost_equal(stats.kruskal(x, x, nan_policy='omit'), (0.0, 1.0))
         assert_raises(ValueError, stats.kruskal, x, x, nan_policy='raise')
         assert_raises(ValueError, stats.kruskal, x, x, nan_policy='foobar')
+        
+    def test_large_no_samples(self):
+        # Test to see if large samples are handled correctly.
+        n = 50000
+        x=np.random.randn(n)
+        y=np.random.randn(n) + 50
+        h, p = stats.kruskal(x, y)
+        expected = 0
+        assert_approx_equal(p, expected)
 
 
 class TestCombinePvalues(object):

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4527,18 +4527,14 @@ class TestKruskal(object):
         assert_almost_equal(stats.kruskal(x, x, nan_policy='omit'), (0.0, 1.0))
         assert_raises(ValueError, stats.kruskal, x, x, nan_policy='raise')
         assert_raises(ValueError, stats.kruskal, x, x, nan_policy='foobar')
-        
     def test_large_no_samples(self):
         # Test to see if large samples are handled correctly.
         n = 50000
-        np.random.seed(0)  # Make the test reproducible.
-        x = np.random.randn(n)
-        y = np.random.randn(n) + 50
+        x=np.random.randn(n)
+        y=np.random.randn(n) + 50
         h, p = stats.kruskal(x, y)
-        expected_p = 0
-        assert_approx_equal(p, expected_p)
-        expected_h = 74999.250007499941
-        assert_approx_equal(h, expected_h)
+        expected = 0
+        assert_approx_equal(p, expected)
 
 
 class TestCombinePvalues(object):

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4527,11 +4527,12 @@ class TestKruskal(object):
         assert_almost_equal(stats.kruskal(x, x, nan_policy='omit'), (0.0, 1.0))
         assert_raises(ValueError, stats.kruskal, x, x, nan_policy='raise')
         assert_raises(ValueError, stats.kruskal, x, x, nan_policy='foobar')
+    
     def test_large_no_samples(self):
         # Test to see if large samples are handled correctly.
         n = 50000
-        x=np.random.randn(n)
-        y=np.random.randn(n) + 50
+        x = np.random.randn(n)
+        y = np.random.randn(n) + 50
         h, p = stats.kruskal(x, y)
         expected = 0
         assert_approx_equal(p, expected)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4531,11 +4531,14 @@ class TestKruskal(object):
     def test_large_no_samples(self):
         # Test to see if large samples are handled correctly.
         n = 50000
+        np.random.seed(0) # Make the test reproducible.
         x = np.random.randn(n)
         y = np.random.randn(n) + 50
         h, p = stats.kruskal(x, y)
-        expected = 0
-        assert_approx_equal(p, expected)
+        expected_p = 0
+        assert_approx_equal(p, expected_p)
+        expected_h = 74999.250007499941
+        assert_approx_equal(h, expected_h)
 
 
 class TestCombinePvalues(object):

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4531,7 +4531,7 @@ class TestKruskal(object):
     def test_large_no_samples(self):
         # Test to see if large samples are handled correctly.
         n = 50000
-        np.random.seed(0) # Make the test reproducible.
+        np.random.seed(0)  # Make the test reproducible.
         x = np.random.randn(n)
         y = np.random.randn(n) + 50
         h, p = stats.kruskal(x, y)


### PR DESCRIPTION
This is a rebase for an existing bug fix for bug #7759. The original fix #7763 was forgotten and not merged. 

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes #7759
Closes #7763 

#### What does this implement/fix?

This fixes an overflow in scipy.stats.kruskal for large samples.

#### Additional information
<!--Any additional information you think is important.-->