### PR TITLE
remove redundant __getitem__ from scipy.sparse.lil

### DIFF
--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -225,16 +225,6 @@ class lil_matrix(spmatrix, IndexMixin):
             raise IndexError('Index dimension must be <= 2')
         return x
 
-    def __getitem__(self, key):
-        # Fast path for simple (int, int) indexing.
-        if (isinstance(key, tuple) and len(key) == 2 and
-                isinstance(key[0], INT_TYPES) and
-                isinstance(key[1], INT_TYPES)):
-            # lil_get1 handles validation for us.
-            return self._get_intXint(*key)
-        # Everything else takes the normal path.
-        return IndexMixin.__getitem__(self, key)
-
     def _get_intXint(self, row, col):
         v = _csparsetools.lil_get1(self.shape[0], self.shape[1], self.rows,
                                    self.data, row, col)


### PR DESCRIPTION
This PR removes redundant code, repeated in lines. The __getitem__ function was declared twice:
 https://github.com/scipy/scipy/blob/746aaef2b3dfaa3ab690e7531a223b2f3f52725e/scipy/sparse/lil.py#L208
and
https://github.com/scipy/scipy/blob/746aaef2b3dfaa3ab690e7531a223b2f3f52725e/scipy/sparse/lil.py#L228