### PR TITLE
Better handling of empty (not missing) docstrings

### DIFF
--- a/scipy/constants/__init__.py
+++ b/scipy/constants/__init__.py
@@ -328,7 +328,7 @@ _constant_names = [(_k.lower(), _k, _v)
 _constant_names = "\n".join(["``%s``%s  %s %s" % (_x[1], " "*(66-len(_x[1])),
                                                   _x[2][0], _x[2][1])
                              for _x in sorted(_constant_names)])
-if __doc__ is not None:
+if __doc__:
     __doc__ = __doc__ % dict(constant_names=_constant_names)
 
 del _constant_names

--- a/scipy/integrate/quadrature.py
+++ b/scipy/integrate/quadrature.py
@@ -29,7 +29,7 @@ def _copy_func(f):
 
 
 trapz = _copy_func(trapz)
-if sys.flags.optimize <= 1:
+if trapz.__doc__:
     trapz.__doc__ = trapz.__doc__.replace('sum, cumsum', 'numpy.cumsum')
 
 

--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -332,7 +332,7 @@ def deco(name):
     if hasattr(f, '__qualname__'):
         wrapped.__qualname__ = f.__qualname__
 
-    if f.__doc__ is not None:
+    if f.__doc__:
         lines = f.__doc__.splitlines()
         for li, line in enumerate(lines):
             if line.strip() == 'Parameters':

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -2844,7 +2844,7 @@ class erlang_gen(gamma_gen):
     def fit(self, data, *args, **kwds):
         return super(erlang_gen, self).fit(data, *args, **kwds)
 
-    if fit.__doc__ is not None:
+    if fit.__doc__:
         fit.__doc__ = (rv_continuous.fit.__doc__ +
             """
             Notes

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -1468,7 +1468,7 @@ def trim(a, limits=None, inclusive=(True,True), relative=False, axis=None):
         return trima(a, limits=limits, inclusive=inclusive)
 
 
-if trim.__doc__ is not None:
+if trim.__doc__:
     trim.__doc__ = trim.__doc__ % trimdoc
 
 
@@ -1561,7 +1561,7 @@ def trimmed_mean(a, limits=(0.1,0.1), inclusive=(1,1), relative=True,
         return trima(a,limits=limits,inclusive=inclusive).mean(axis=axis)
 
 
-if trimmed_mean.__doc__ is not None:
+if trimmed_mean.__doc__:
     trimmed_mean.__doc__ = trimmed_mean.__doc__ % trimdoc
 
 
@@ -1586,7 +1586,7 @@ def trimmed_var(a, limits=(0.1,0.1), inclusive=(1,1), relative=True,
     return out.var(axis=axis, ddof=ddof)
 
 
-if trimmed_var.__doc__ is not None:
+if trimmed_var.__doc__:
     trimmed_var.__doc__ = trimmed_var.__doc__ % trimdoc
 
 
@@ -1610,7 +1610,7 @@ def trimmed_std(a, limits=(0.1,0.1), inclusive=(1,1), relative=True,
     return out.std(axis=axis,ddof=ddof)
 
 
-if trimmed_std.__doc__ is not None:
+if trimmed_std.__doc__:
     trimmed_std.__doc__ = trimmed_std.__doc__ % trimdoc
 
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### What does this implement/fix?
Some python build tools/processes set docstrings to empty strings. (Not -OO). This can be beneficial to work around various libraries depending on docstrings existing but not caring about their value. Some places in scipy already work with empty string, this aligns some existing handling that wasn't consistent.

#### Additional information
<!--Any additional information you think is important.-->