### PR TITLE
ENH: option to reuse scipy.interpolate.RegularGridInterpolator with new values

### DIFF
--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -2326,8 +2326,11 @@ class RegularGridInterpolator(object):
     points : tuple of ndarray of float, with shapes (m1, ), ..., (mn, )
         The points defining the regular grid in n dimensions.
 
-    values : array_like, shape (m1, ..., mn, ...)
+    values : array_like, shape (m1, ..., mn, ...), optional
         The data on the regular grid in n dimensions.
+
+    xi : ndarray of shape (..., ndim), optional
+        The coordinates to sample the gridded data at
 
     method : str, optional
         The method of interpolation to perform. Supported are "linear" and
@@ -2410,12 +2413,114 @@ class RegularGridInterpolator(object):
     # this class is based on code originally programmed by Johannes Buchner,
     # see https://github.com/JohannesBuchner/regulargrid
 
-    def __init__(self, points, values, method="linear", bounds_error=True,
-                 fill_value=np.nan):
+    def __init__(self, points, values=None, xi=None, method="linear",
+                 bounds_error=True, fill_value=np.nan):
+
+        self._set_method(method)
+
+        self._set_points(points)
+
+        self.fill_value = fill_value
+
+        if values is not None:
+            self._set_values(values)
+
+        self.bounds_error = bounds_error
+
+        if xi is not None:
+            self._set_xi(xi)
+            self._set_interp_param()
+
+    def __call__(self, xi=None, values=None, method=None,
+                 bounds_error=True, fill_value=np.nan):
+        """
+        Interpolation at coordinates
+
+        Parameters
+        ----------
+        xi : ndarray of shape (..., ndim), optional
+            The coordinates to sample the gridded data at
+
+        values : array_like, shape (m1, ..., mn, ...), optional
+            The data on the regular grid in n dimensions.
+
+        method : str, optional
+            The method of interpolation to perform. Supported are "linear" and
+            "nearest". This parameter will become the default for the object's
+            ``__call__`` method. Default is "linear".
+
+        bounds_error : bool, optional
+            If True, when interpolated values are requested outside of the
+            domain of the input data, a ValueError is raised.
+            If False, then `fill_value` is used.
+
+        fill_value : number, optional
+            If provided, the value to use for points outside of the
+            interpolation domain. If None, values outside
+            the domain are extrapolated.
+
+        """
+        if method is not None:
+            self._set_method(method)
+
+        self.bounds_error = bounds_error and self.bounds_error
+
+        if xi is not None:
+            self._set_xi(xi)
+            self._set_interp_param()
+
+        if not np.isnan(fill_value):
+            self.fill_value = fill_value
+
+        if values is not None:
+            self._set_values(values)
+
+        if self.method == "linear":
+            result = self._evaluate_linear()
+        elif self.method == "nearest":
+            result = self._evaluate_nearest()
+
+        if not self.bounds_error and self.fill_value is not None:
+            result[self.out_of_bounds] = self.fill_value
+
+        result_shape = self.xi_shape[:-1] + self.values.shape[self.ndim:]
+
+        return result.reshape(result_shape)
+
+    def _set_method(self, method):
         if method not in ["linear", "nearest"]:
             raise ValueError("Method '%s' is not defined" % method)
         self.method = method
-        self.bounds_error = bounds_error
+
+    def _set_points(self, points):
+        for i, p in enumerate(points):
+            if not np.all(np.diff(p) > 0.):
+                raise ValueError("The points in dimension %d must be strictly "
+                                 "ascending" % i)
+            if not np.asarray(p).ndim == 1:
+                raise ValueError("The points in dimension %d must be "
+                                 "1-dimensional" % i)
+
+        self.points = points
+        self.grid = tuple([np.asarray(p) for p in points])
+        self.ndim = len(self.grid)
+
+    def _set_xi(self, xi):
+        ndim = self.ndim
+        xi = _ndim_coords_from_arrays(xi, ndim=ndim)
+        if xi.shape[-1] != len(self.grid):
+            raise ValueError("The requested sample points xi have dimension "
+                             "%d, but this RegularGridInterpolator has "
+                             "dimension %d" % (xi.shape[1], ndim))
+
+        xi_shape = xi.shape
+        xi = xi.reshape(-1, xi_shape[-1])
+
+        self.xi = xi
+        self.xi_shape = xi_shape
+
+    def _set_values(self, values):
+        points = self.points
 
         if not hasattr(values, 'ndim'):
             # allow reasonable duck-typed values
@@ -2429,7 +2534,18 @@ class RegularGridInterpolator(object):
             if not np.issubdtype(values.dtype, np.inexact):
                 values = values.astype(float)
 
-        self.fill_value = fill_value
+        for i, p in enumerate(points):
+            if not values.shape[i] == len(p):
+                raise ValueError("There are %d points and %d values in "
+                                 "dimension %d" % (len(p), values.shape[i], i))
+
+        self.values = values
+
+        self._check_fill_value()
+
+    def _check_fill_value(self):
+        values = self.values
+        fill_value = self.fill_value
         if fill_value is not None:
             fill_value_dtype = np.asarray(fill_value).dtype
             if (hasattr(values, 'dtype') and not
@@ -2438,86 +2554,50 @@ class RegularGridInterpolator(object):
                 raise ValueError("fill_value must be either 'None' or "
                                  "of a type compatible with values")
 
-        for i, p in enumerate(points):
-            if not np.all(np.diff(p) > 0.):
-                raise ValueError("The points in dimension %d must be strictly "
-                                 "ascending" % i)
-            if not np.asarray(p).ndim == 1:
-                raise ValueError("The points in dimension %d must be "
-                                 "1-dimensional" % i)
-            if not values.shape[i] == len(p):
-                raise ValueError("There are %d points and %d values in "
-                                 "dimension %d" % (len(p), values.shape[i], i))
-        self.grid = tuple([np.asarray(p) for p in points])
-        self.values = values
+    def _check_bounds(self):
+        xi = self.xi
+        for i, p in enumerate(xi.T):
+            if not np.logical_and(np.all(self.grid[i][0] <= p),
+                                  np.all(p <= self.grid[i][-1])):
+                raise ValueError("One of the requested xi is out of bounds "
+                                 "in dimension %d" % i)
 
-    def __call__(self, xi, method=None):
-        """
-        Interpolation at coordinates
-
-        Parameters
-        ----------
-        xi : ndarray of shape (..., ndim)
-            The coordinates to sample the gridded data at
-
-        method : str
-            The method of interpolation to perform. Supported are "linear" and
-            "nearest".
-
-        """
-        method = self.method if method is None else method
-        if method not in ["linear", "nearest"]:
-            raise ValueError("Method '%s' is not defined" % method)
-
-        ndim = len(self.grid)
-        xi = _ndim_coords_from_arrays(xi, ndim=ndim)
-        if xi.shape[-1] != len(self.grid):
-            raise ValueError("The requested sample points xi have dimension "
-                             "%d, but this RegularGridInterpolator has "
-                             "dimension %d" % (xi.shape[1], ndim))
-
-        xi_shape = xi.shape
-        xi = xi.reshape(-1, xi_shape[-1])
-
-        if self.bounds_error:
-            for i, p in enumerate(xi.T):
-                if not np.logical_and(np.all(self.grid[i][0] <= p),
-                                      np.all(p <= self.grid[i][-1])):
-                    raise ValueError("One of the requested xi is out of bounds "
-                                     "in dimension %d" % i)
-
-        indices, norm_distances, out_of_bounds = self._find_indices(xi.T)
-        if method == "linear":
-            result = self._evaluate_linear(indices,
-                                           norm_distances,
-                                           out_of_bounds)
-        elif method == "nearest":
-            result = self._evaluate_nearest(indices,
-                                            norm_distances,
-                                            out_of_bounds)
-        if not self.bounds_error and self.fill_value is not None:
-            result[out_of_bounds] = self.fill_value
-
-        return result.reshape(xi_shape[:-1] + self.values.shape[ndim:])
-
-    def _evaluate_linear(self, indices, norm_distances, out_of_bounds):
-        # slice for broadcasting over trailing dimensions in self.values
-        vslice = (slice(None),) + (None,)*(self.values.ndim - len(indices))
+    def _set_linear_param(self, indices, norm_distances):
+        weights = []
+        edges = []
 
         # find relevant values
         # each i and i+1 represents a edge
-        edges = itertools.product(*[[i, i + 1] for i in indices])
-        values = 0.
-        for edge_indices in edges:
-            weight = 1.
+        edges_iter = itertools.product(*[[i, i + 1] for i in indices])
+
+        for edge_indices in edges_iter:
+            weight_edge = 1.
             for ei, i, yi in zip(edge_indices, indices, norm_distances):
-                weight *= np.where(ei == i, 1 - yi, yi)
-            values += np.asarray(self.values[edge_indices]) * weight[vslice]
+                weight_edge *= np.where(ei == i, 1 - yi, yi)
+            weights.append(weight_edge)
+            edges.append(edge_indices)
+        self.param = (weights, edges)
+
+    def _evaluate_linear(self):
+        weights, edges = self.param
+        # slice for broadcasting over trailing dimensions in self.values
+        vslice = (slice(None),) + (None,)*(self.values.ndim - self.li)
+
+        # find relevant values
+        # each i and i+1 represents a edge
+        values = 0.
+        for edge, weight in zip(edges, weights):
+            values += np.asarray(self.values[edge]) * weight[vslice]
         return values
 
-    def _evaluate_nearest(self, indices, norm_distances, out_of_bounds):
+    def _set_nearest_param(self, indices, norm_distances):
         idx_res = [np.where(yi <= .5, i, i + 1)
                    for i, yi in zip(indices, norm_distances)]
+
+        self.param = idx_res
+
+    def _evaluate_nearest(self):
+        idx_res = self.param
         return self.values[tuple(idx_res)]
 
     def _find_indices(self, xi):
@@ -2538,7 +2618,20 @@ class RegularGridInterpolator(object):
             if not self.bounds_error:
                 out_of_bounds += x < grid[0]
                 out_of_bounds += x > grid[-1]
+
+        self.li = len(indices)
+
         return indices, norm_distances, out_of_bounds
+
+    def _set_interp_param(self):
+        if self.bounds_error:
+            self._check_bounds()
+        indices, norm_distances, out_of_bounds = self._find_indices(self.xi.T)
+        if self.method == "linear":
+            self._set_linear_param(indices, norm_distances)
+        if self.method == "nearest":
+            self._set_nearest_param(indices, norm_distances)
+        self.out_of_bounds = out_of_bounds
 
 
 def interpn(points, values, xi, method="linear", bounds_error=True,

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -2358,10 +2358,11 @@ def _ppoly4d_eval(c, xs, xnew, ynew, znew, unew, nu=None):
 
 
 class TestRegularGridInterpolator(object):
-    def _get_sample_4d(self):
+    def _get_sample_4d(self, n = 3):
         # create a 4d grid of 3 points in each dimension
-        points = [(0., .5, 1.)] * 4
-        values = np.asarray([0., .5, 1.])
+        base = np.linspace(0., 1, n)
+        points = [base]*4
+        values = base
         values0 = values[:, np.newaxis, np.newaxis, np.newaxis]
         values1 = values[np.newaxis, :, np.newaxis, np.newaxis]
         values2 = values[np.newaxis, np.newaxis, :, np.newaxis]
@@ -2478,7 +2479,7 @@ class TestRegularGridInterpolator(object):
         points, values = self._get_sample_4d()
         interp = RegularGridInterpolator(points, values)
         sample = np.asarray([[0., 0., 0., 0.], [1., 1., 1., 1.]])
-        assert_raises(ValueError, interp, sample, "undefmethod")
+        assert_raises(ValueError, interp, sample, method="undefmethod")
         sample = np.asarray([[0., 0., 0.], [1., 1., 1.]])
         assert_raises(ValueError, interp, sample)
         sample = np.asarray([[0., 0., 0., 0.], [1., 1., 1., 1.1]])
@@ -2580,6 +2581,19 @@ class TestRegularGridInterpolator(object):
         xi = [(1, 1, 1)]
         interpolator = RegularGridInterpolator(points, values)
         interpolator = RegularGridInterpolator(points, values, fill_value=0.)
+
+    def test_two_paths(self):
+        size = 4
+        points, values = self._get_sample_4d(n=size)
+        sample = np.random.random((int((size)**4), 4))
+
+        interp1 = RegularGridInterpolator(points, values=values)
+        result1 = interp1(xi=sample)
+
+        interp2 = RegularGridInterpolator(points, xi=sample)
+        result2 = interp2(values=values)
+
+        assert_array_almost_equal(result1, result2)
 
 
 class MyValue(object):


### PR DESCRIPTION
Currently scipy.interpolate.RegularGridInterpolator is initialised with the source values and takes the target points as parameter when called.
This pull request adds the possibility to provide the target points at initialisation and to give the values when the object is called.
To achieve this goal, the modularity (and hence the readability) of the code has been significantly improved.
A quick benchmark shows a reduction of computation time by a factor 2.

I hope the requested changes do not alter the stability of the code.
An alternative would be to create a new class for this functionality.

