### PR TITLE
ENH: option to reuse binnumbers in stats.binned_statistic_dd

### DIFF
--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -356,7 +356,8 @@ BinnedStatisticddResult = namedtuple('BinnedStatisticddResult',
 
 
 def binned_statistic_dd(sample, values, statistic='mean',
-                        bins=10, range=None, expand_binnumbers=False):
+                        bins=10, range=None, expand_binnumbers=False,
+                        binned_statistic_result=None):
     """
     Compute a multidimensional binned statistic for a set of data.
 
@@ -398,14 +399,12 @@ def binned_statistic_dd(sample, values, statistic='mean',
             values, and outputs a single numerical statistic. This function
             will be called on the values in each bin.  Empty bins will be
             represented by function([]), or NaN if this returns an error.
-
     bins : sequence or int, optional
         The bin specification must be in one of the following forms:
 
           * A sequence of arrays describing the bin edges along each dimension.
           * The number of bins for each dimension (nx, ny, ... = bins).
           * The number of bins for all dimensions (nx = ny = ... = bins).
-
     range : sequence, optional
         A sequence of lower and upper bin edges to be used if the edges are
         not given explicitly in `bins`. Defaults to the minimum and maximum
@@ -418,6 +417,11 @@ def binned_statistic_dd(sample, values, statistic='mean',
         dimension.
         See the `binnumber` returned value, and the `Examples` section of
         `binned_statistic_2d`.
+    binned_statistic_result : binnedStatisticddResult
+        Result of a previous call to the function in order to reuse bin edges
+        and bin numbers with new values and/or a different statistic.
+        To reuse bin numbers, `expand_binnumbers` must have been set to False
+        (the default)
 
         .. versionadded:: 0.17.0
 
@@ -501,8 +505,13 @@ def binned_statistic_dd(sample, values, statistic='mean',
     >>> with np.errstate(divide='ignore'):   # silence random axes3d warning
     ...     ax.bar3d(x, y, z, dx, dy, bincounts)
 
+    Reuse bin numbers and bin edges with new values:
+
+    >>> ret2 = stats.binned_statistic_dd(data, -np.arange(600),
+    ...                                  binned_statistic_result=ret,
+    ...                                  statistic='mean')
     """
-    known_stats = ['mean', 'median', 'count', 'sum', 'std','min','max']
+    known_stats = ['mean', 'median', 'count', 'sum', 'std', 'min', 'max']
     if not callable(statistic) and statistic not in known_stats:
         raise ValueError('invalid statistic %r' % (statistic,))
 
@@ -529,10 +538,6 @@ def binned_statistic_dd(sample, values, statistic='mean',
         raise AttributeError('The number of `values` elements must match the '
                              'length of each `sample` dimension.')
 
-    nbin = np.empty(Ndim, int)    # Number of bins in each dimension
-    edges = Ndim * [None]         # Bin edges for each dim (will be 2D array)
-    dedges = Ndim * [None]        # Spacing between edges (will be 2D array)
-
     try:
         M = len(bins)
         if M != Ndim:
@@ -541,55 +546,15 @@ def binned_statistic_dd(sample, values, statistic='mean',
     except TypeError:
         bins = Ndim * [bins]
 
-    # Select range for each dimension
-    # Used only if number of bins is given.
-    if range is None:
-        smin = np.atleast_1d(np.array(sample.min(axis=0), float))
-        smax = np.atleast_1d(np.array(sample.max(axis=0), float))
+    if binned_statistic_result is None:
+        nbin, edges, dedges = _bin_edges(sample, bins, range)
+        binnumbers = _bin_numbers(sample, nbin, edges, dedges)
     else:
-        smin = np.zeros(Ndim)
-        smax = np.zeros(Ndim)
-        for i in xrange(Ndim):
-            smin[i], smax[i] = range[i]
-
-    # Make sure the bins have a finite width.
-    for i in xrange(len(smin)):
-        if smin[i] == smax[i]:
-            smin[i] = smin[i] - .5
-            smax[i] = smax[i] + .5
-
-    # Create edge arrays
-    for i in xrange(Ndim):
-        if np.isscalar(bins[i]):
-            nbin[i] = bins[i] + 2  # +2 for outlier bins
-            edges[i] = np.linspace(smin[i], smax[i], nbin[i] - 1)
-        else:
-            edges[i] = np.asarray(bins[i], float)
-            nbin[i] = len(edges[i]) + 1  # +1 for outlier bins
-        dedges[i] = np.diff(edges[i])
-
-    nbin = np.asarray(nbin)
-
-    # Compute the bin number each sample falls into, in each dimension
-    sampBin = [
-        np.digitize(sample[:, i], edges[i])
-        for i in xrange(Ndim)
-    ]
-
-    # Using `digitize`, values that fall on an edge are put in the right bin.
-    # For the rightmost bin, we want values equal to the right
-    # edge to be counted in the last bin, and not as an outlier.
-    for i in xrange(Ndim):
-        # Find the rounding precision
-        decimal = int(-np.log10(dedges[i].min())) + 6
-        # Find which points are on the rightmost edge.
-        on_edge = np.where(np.around(sample[:, i], decimal) ==
-                           np.around(edges[i][-1], decimal))[0]
-        # Shift these points one bin to the left.
-        sampBin[i][on_edge] -= 1
-
-    # Compute the sample indices in the flattened statistic matrix.
-    binnumbers = np.ravel_multi_index(sampBin, nbin)
+        edges = binned_statistic_result.bin_edges
+        nbin = np.array([len(edges[i]) + 1 for i in xrange(Ndim)])
+        # +1 for outlier bins
+        dedges = [np.diff(edges[i]) for i in xrange(Ndim)]
+        binnumbers = binned_statistic_result.binnumber
 
     result = np.empty([Vdim, nbin.prod()], float)
 
@@ -606,7 +571,7 @@ def binned_statistic_dd(sample, values, statistic='mean',
         a = flatcount.nonzero()
         for i in np.unique(binnumbers):
             for vv in xrange(Vdim):
-                #NOTE: take std dev by bin, np.std() is 2-pass and stable
+                # NOTE: take std dev by bin, np.std() is 2-pass and stable
                 result[vv, i] = np.std(values[vv, binnumbers == i])
     elif statistic == 'count':
         result.fill(0)
@@ -664,3 +629,75 @@ def binned_statistic_dd(sample, values, statistic='mean',
     result = result.reshape(input_shape[:-1] + list(nbin-2))
 
     return BinnedStatisticddResult(result, edges, binnumbers)
+
+
+def _bin_edges(sample, bins=None, range=None):
+    """ Create edge arrays
+    """
+    Dlen, Ndim = sample.shape
+
+    nbin = np.empty(Ndim, int)    # Number of bins in each dimension
+    edges = Ndim * [None]         # Bin edges for each dim (will be 2D array)
+    dedges = Ndim * [None]        # Spacing between edges (will be 2D array)
+
+    # Select range for each dimension
+    # Used only if number of bins is given.
+    if range is None:
+        smin = np.atleast_1d(np.array(sample.min(axis=0), float))
+        smax = np.atleast_1d(np.array(sample.max(axis=0), float))
+    else:
+        smin = np.zeros(Ndim)
+        smax = np.zeros(Ndim)
+        for i in xrange(Ndim):
+            smin[i], smax[i] = range[i]
+
+    # Make sure the bins have a finite width.
+    for i in xrange(len(smin)):
+        if smin[i] == smax[i]:
+            smin[i] = smin[i] - .5
+            smax[i] = smax[i] + .5
+
+    # Create edge arrays
+    for i in xrange(Ndim):
+        if np.isscalar(bins[i]):
+            nbin[i] = bins[i] + 2  # +2 for outlier bins
+            edges[i] = np.linspace(smin[i], smax[i], nbin[i] - 1)
+        else:
+            edges[i] = np.asarray(bins[i], float)
+            nbin[i] = len(edges[i]) + 1  # +1 for outlier bins
+        dedges[i] = np.diff(edges[i])
+
+    nbin = np.asarray(nbin)
+
+    return nbin, edges, dedges
+
+
+def _bin_numbers(sample, nbin, edges, dedges):
+    """Compute the bin number each sample falls into, in each dimension
+    """
+    Dlen, Ndim = sample.shape
+
+    sampBin = [
+        np.digitize(sample[:, i], edges[i])
+        for i in xrange(Ndim)
+    ]
+
+    # Using `digitize`, values that fall on an edge are put in the right bin.
+    # For the rightmost bin, we want values equal to the right
+    # edge to be counted in the last bin, and not as an outlier.
+    for i in xrange(Ndim):
+        # Find the rounding precision
+        try:
+            decimal = int(-np.log10(dedges[i].min())) + 6
+        except RuntimeWarning:
+            raise ValueError('The smallest edge difference is numerically 0.')
+        # Find which points are on the rightmost edge.
+        on_edge = np.where(np.around(sample[:, i], decimal) ==
+                           np.around(edges[i][-1], decimal))[0]
+        # Shift these points one bin to the left.
+        sampBin[i][on_edge] -= 1
+
+    # Compute the sample indices in the flattened statistic matrix.
+    binnumbers = np.ravel_multi_index(sampBin, nbin)
+
+    return binnumbers

--- a/scipy/stats/tests/test_binned_statistic.py
+++ b/scipy/stats/tests/test_binned_statistic.py
@@ -2,6 +2,7 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 from numpy.testing import assert_allclose
+from pytest import raises as assert_raises
 from scipy.stats import (binned_statistic, binned_statistic_2d,
                          binned_statistic_dd)
 
@@ -38,7 +39,7 @@ class TestBinnedStatistic(object):
         v = self.v
         statistics = [u'mean', u'median', u'count', u'sum']
         for statistic in statistics:
-            res = binned_statistic(x, v, statistic, bins=10)
+            binned_statistic(x, v, statistic, bins=10)
 
     def test_big_number_std(self):
         # tests for numerical stability of std calculation
@@ -88,11 +89,11 @@ class TestBinnedStatistic(object):
 
         assert_allclose(stat1, stat2)
         assert_allclose(edges1, edges2)
-        
+
     def test_1d_min(self):
         x = self.x
         v = self.v
-        
+
         stat1, edges1, bc = binned_statistic(x, v, 'min', bins=10)
         stat2, edges2, bc = binned_statistic(x, v, np.min, bins=10)
 
@@ -102,13 +103,13 @@ class TestBinnedStatistic(object):
     def test_1d_max(self):
         x = self.x
         v = self.v
-        
+
         stat1, edges1, bc = binned_statistic(x, v, 'max', bins=10)
         stat2, edges2, bc = binned_statistic(x, v, np.max, bins=10)
 
         assert_allclose(stat1, stat2)
         assert_allclose(edges1, edges2)
-        
+
     def test_1d_median(self):
         x = self.x
         v = self.v
@@ -447,3 +448,28 @@ class TestBinnedStatistic(object):
         assert_allclose(bcx, bc2[0])
         assert_allclose(bcy, bc2[1])
         assert_allclose(bcz, bc2[2])
+
+    def test_dd_binned_statistic_result(self):
+        # NOTE: tests the reuse of bin_edges from previous call
+        x = np.random.random((10000, 3))
+        v = np.random.random((10000))
+        bins = np.linspace(0, 1, 10)
+        bins = (bins, bins, bins)
+
+        result = binned_statistic_dd(x, v, 'mean', bins=bins)
+        stat = result.statistic
+
+        result = binned_statistic_dd(x, v, 'mean',
+                                     binned_statistic_result=result)
+        stat2 = result.statistic
+
+        assert_allclose(stat, stat2)
+
+    def test_dd_zero_dedges(self):
+        x = np.random.random((10000, 3))
+        v = np.random.random((10000))
+        bins = np.linspace(0, 1, 10)
+        bins = np.append(bins, 1)
+        bins = (bins, bins, bins)
+        assert_raises(ValueError, binned_statistic_dd,
+                      x, v, 'mean', bins=bins)


### PR DESCRIPTION
Dear scipy developers,

This is my first pull request to the scipy project !

It adds the functionality of reusing the bin numbers in scipy.stats.binned_statistic_dd.
This is useful when new values are available for the same dataset.
A quick benchmark shows a decrease in computation time by a factor 3.

Best regards,

Edouard