### PR TITLE
BUG: special: fix incomplete gamma functions for infinite `a`

### DIFF
--- a/scipy/special/cephes/igam.c
+++ b/scipy/special/cephes/igam.c
@@ -125,18 +125,23 @@ static double igamc_series(double, double);
 static double asymptotic_series(double, double, int);
 
 
-double igam(a, x)
-double a, x;
+double igam(double a, double x)
 {
     double absxma_a;
 
-    /* Check zero integration limit first */
-    if (x == 0)
-	return (0.0);
-
-    if ((x < 0) || (a <= 0)) {
+    if (x < 0 || a <= 0) {
 	sf_error("gammainc", SF_ERROR_DOMAIN, NULL);
-	return (NPY_NAN);
+	return NPY_NAN;
+    } else if (npy_isinf(a)) {
+	if (npy_isinf(x)) {
+	    return NPY_NAN;
+	}
+	return 0;
+    } else if (x == 0) {
+	/* Zero integration limit */
+	return 0;
+    } else if (npy_isinf(x)) {
+	return 1;
     }
 
     /* Asymptotic regime where a ~ x; see [2]. */
@@ -159,13 +164,18 @@ double igamc(double a, double x)
 {
     double absxma_a;
 
-    if ((x < 0) || (a <= 0)) {
+    if (x < 0 || a <= 0) {
 	sf_error("gammaincc", SF_ERROR_DOMAIN, NULL);
-	return (NPY_NAN);
+	return NPY_NAN;
+    } else if (npy_isinf(a)) {
+	if (npy_isinf(x)) {
+	    return NPY_NAN;
+	}
+	return 1;
     } else if (x == 0) {
 	return 1;
-    } else if (cephes_isinf(x)) {
-	return 0.0;
+    } else if (npy_isinf(x)) {
+	return 0;
     }
 
     /* Asymptotic regime where a ~ x; see [2]. */

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -409,12 +409,6 @@ class TestCephes(object):
     def test_gamma(self):
         assert_equal(cephes.gamma(5),24.0)
 
-    def test_gammainc(self):
-        assert_equal(cephes.gammainc(5,0),0.0)
-
-    def test_gammaincc(self):
-        assert_equal(cephes.gammaincc(5,0),1.0)
-
     def test_gammainccinv(self):
         assert_equal(cephes.gammainccinv(5,1),0.0)
 
@@ -1910,36 +1904,6 @@ class TestGamma(object):
         gamln = special.gammaln(3)
         lngam = log(special.gamma(3))
         assert_almost_equal(gamln,lngam,8)
-
-    def test_gammainc(self):
-        gama = special.gammainc(.5,.5)
-        assert_almost_equal(gama,.7,1)
-
-    def test_gammaincnan(self):
-        gama = special.gammainc(-1,1)
-        assert_(isnan(gama))
-
-    def test_gammainczero(self):
-        # bad arg but zero integration limit
-        gama = special.gammainc(-1,0)
-        assert_equal(gama,0.0)
-
-    def test_gammaincinf(self):
-        gama = special.gammainc(0.5, np.inf)
-        assert_equal(gama,1.0)
-
-    def test_gammaincc(self):
-        gicc = special.gammaincc(.5,.5)
-        greal = 1 - special.gammainc(.5,.5)
-        assert_almost_equal(gicc,greal,8)
-
-    def test_gammainccnan(self):
-        gama = special.gammaincc(-1,1)
-        assert_(isnan(gama))
-
-    def test_gammainccinf(self):
-        gama = special.gammaincc(0.5,np.inf)
-        assert_equal(gama,0.0)
 
     def test_gammainccinv(self):
         gccinv = special.gammainccinv(.5,.5)

--- a/scipy/special/tests/test_gammainc.py
+++ b/scipy/special/tests/test_gammainc.py
@@ -1,17 +1,61 @@
 from __future__ import division, print_function, absolute_import
 
+import pytest
+
 import numpy as np
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_array_equal
 
 import scipy.special as sc
 from scipy.special._testutils import FuncData
 
 
-def test_line():
-    # Test on the line a = x where a simpler asymptotic expansion
-    # (analog of DLMF 8.12.15) is available.
+INVALID_POINTS = [
+    (1, -1),
+    (0, 0),
+    (-1, 1),
+    (0, 1),
+    (np.nan, 1),
+    (1, np.nan)
+]
 
-    def gammainc_line(x):
+
+class TestGammainc(object):
+
+    @pytest.mark.parametrize('a, x', INVALID_POINTS)
+    def test_domain(self, a, x):
+        assert np.isnan(sc.gammainc(a, x))
+
+    @pytest.mark.parametrize('a, x, desired', [
+        (np.inf, 1, 0),
+        (np.inf, 0, 0),
+        (np.inf, np.inf, np.nan),
+        (1, np.inf, 1)
+    ])
+    def test_infinite_arguments(self, a, x, desired):
+        result = sc.gammainc(a, x)
+        if np.isnan(desired):
+            assert np.isnan(result)
+        else:
+            assert result == desired
+
+    def test_infinite_limits(self):
+        # Test that large arguments converge to the hard-coded limits
+        # at infinity.
+        assert_allclose(
+            sc.gammainc(1000, 100),
+            sc.gammainc(np.inf, 100),
+            atol=1e-200,  # Use `atol` since the function converges to 0.
+            rtol=0
+        )
+        assert sc.gammainc(100, 1000) == sc.gammainc(100, np.inf)
+
+    def test_x_zero(self):
+        a = np.arange(1, 10)
+        assert_array_equal(sc.gammainc(a, 0), 0)
+
+    def gammainc_line(self, x):
+        # The line a = x where a simpler asymptotic expansion (analog
+        # of DLMF 8.12.15) is available.
         c = np.array([-1/3, -1/540, 25/6048, 101/155520,
                       -3184811/3695155200, -2745493/8151736420])
         res = 0
@@ -23,24 +67,57 @@ def test_line():
         res += 0.5
         return res
 
-    x = np.logspace(np.log10(25), 300, 500)
-    a = x.copy()
-    dataset = np.vstack((a, x, gammainc_line(x))).T
+    def test_line(self):
+        x = np.logspace(np.log10(25), 300, 500)
+        a = x
+        dataset = np.vstack((a, x, self.gammainc_line(x))).T
+        FuncData(sc.gammainc, dataset, (0, 1), 2, rtol=1e-11).check()
 
-    FuncData(sc.gammainc, dataset, (0, 1), 2, rtol=1e-11).check()
+    def test_roundtrip(self):
+        a = np.logspace(-5, 10, 100)
+        x = np.logspace(-5, 10, 100)
+
+        y = sc.gammaincinv(a, sc.gammainc(a, x))
+        assert_allclose(x, y, rtol=1e-10)
 
 
-def test_gammainc_roundtrip():
-    a = np.logspace(-5, 10, 100)
-    x = np.logspace(-5, 10, 100)
+class TestGammaincc(object):
 
-    y = sc.gammaincinv(a, sc.gammainc(a, x))
-    assert_allclose(x, y, rtol=1e-10)
+    @pytest.mark.parametrize('a, x', INVALID_POINTS)
+    def test_domain(self, a, x):
+        assert np.isnan(sc.gammaincc(a, x))
 
+    @pytest.mark.parametrize('a, x, desired', [
+        (np.inf, 1, 1),
+        (np.inf, 0, 1),
+        (np.inf, np.inf, np.nan),
+        (1, np.inf, 0)
+    ])
+    def test_infinite_arguments(self, a, x, desired):
+        result = sc.gammaincc(a, x)
+        if np.isnan(desired):
+            assert np.isnan(result)
+        else:
+            assert result == desired
 
-def test_gammaincc_roundtrip():
-    a = np.logspace(-5, 10, 100)
-    x = np.logspace(-5, 10, 100)
+    def test_infinite_limits(self):
+        # Test that large arguments converge to the hard-coded limits
+        # at infinity.
+        assert sc.gammaincc(1000, 100) == sc.gammaincc(np.inf, 100)
+        assert_allclose(
+            sc.gammaincc(100, 1000),
+            sc.gammaincc(100, np.inf),
+            atol=1e-200,  # Use `atol` since the function converges to 0.
+            rtol=0
+        )
 
-    y = sc.gammainccinv(a, sc.gammaincc(a, x))
-    assert_allclose(x, y, rtol=1e-14)
+    def test_x_zero(self):
+        a = np.arange(1, 10)
+        assert_array_equal(sc.gammaincc(a, 0), 1)
+
+    def test_roundtrip(self):
+        a = np.logspace(-5, 10, 100)
+        x = np.logspace(-5, 10, 100)
+
+        y = sc.gammainccinv(a, sc.gammaincc(a, x))
+        assert_allclose(x, y, rtol=1e-14)


### PR DESCRIPTION
#### Reference issue

Closes https://github.com/scipy/scipy/issues/10856.

#### What does this implement/fix?

- Fix the upper/lower incomplete gamma functions for infinite values of `a`
- Fix a bug where `gammainc` would return `0` for `x == 0` even when `a` was outside the domain
- Rearrange the incomplete gamma tests into classes for better organization
- Add tests for infinite values and other edge cases

#### Additional information

For `a = np.inf`, `sc.gammaincc(a, x)` (the regularized upper incomplete gamma function) currently gives

```python
>>> import numpy as np
>>> import scipy.special as sc
>>> sc.gammaincc(np.inf, 1)
nan
```

From the function definition (see e.g. https://dlmf.nist.gov/8.2#E4), we can see that as `a` goes to infinity the integrand `t^(a - 1) * exp(-t)` grows so that for any finite `x` the bulk of the area occurs after `x`. After dividing by the regularizing `Gamma(a)` factor the limit should be `1`.

On the other hand, if both `a` and `x` approach infinity the limit depends on the path taken, so we should continue to return `nan` in that case.

Similar considerations apply for `sc.gammainc`; or just apply the relation `gammainc(a, x) = 1 - gammaincc(a, x)`.