### PR TITLE
MAINT: Also store latex directory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,10 @@ jobs:
           path: doc/build/html-scipyorg
           destination: html-scipyorg
 
+      - store_artifacts:
+          path: doc/build/latex
+          destination: latex
+
       - persist_to_workspace:
           root: doc/build
           paths:


### PR DESCRIPTION
Store the `build/latex` artifacts. Should help debugging things like #10823 in the future.