### PR TITLE
handle duplicate x_min values in interp1d

### DIFF
--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -449,6 +449,10 @@ class interp1d(_Interpolator1D):
         if not assume_sorted:
             ind = np.argsort(x)
             x = x[ind]
+            gx = x > x[0]  # prevents nan bring returned when there are duplicate values of min(x)
+            gx[0] = True
+            x = x[gx]
+            ind = ind[gx]
             y = np.take(y, ind, axis=axis)
 
         if x.ndim != 1:


### PR DESCRIPTION
#### Reference issue
#4304

#### What does this implement/fix?
interpolate.interp1d will return nan if the minimum x value is duplicated

#### Additional information
- the solution is implemented by removing duplicate value of x_min when assume_sorted is set to false
- testing is done
- this should be considered a bug because duplicate values of x that aren't the minimum value do not result in nans being returned
- also the current behavior of nan return without a warning or error being raised is definitely not ideal
- an alternative solution is to put this code in after sorting, so that the error is handled when assume_sorted is true and there are duplicate x_mins