### PR TITLE
ENH: Add beta-binomial distribution to scipy.stats

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -221,6 +221,8 @@ Angeline G. Burrell for implementing nan_policy in the circular statistics
 Michael Marien for contributing to scipy.stats.entropy
 Joseph Weston for a bug fix in scipy.optimize.zeros.
 Peyton Murray for a bug fix in scipy.optimize.curve_fit.
+Leo P. Singer for bug fixes in scipy.optimize and scipy.interpolate and
+   contribution of the beta-binomial distribution to scipy.stats.
 
 Institutions
 ------------

--- a/doc/source/tutorial/stats.rst
+++ b/doc/source/tutorial/stats.rst
@@ -106,7 +106,7 @@ introspection:
     >>> print('number of continuous distributions: %d' % len(dist_continu))
     number of continuous distributions: 98
     >>> print('number of discrete distributions:   %d' % len(dist_discrete))
-    number of discrete distributions:   14
+    number of discrete distributions:   15
 
 
 Common methods

--- a/doc/source/tutorial/stats/discrete.rst
+++ b/doc/source/tutorial/stats/discrete.rst
@@ -256,6 +256,7 @@ Discrete Distributions in `scipy.stats`
    :maxdepth: 1
 
    discrete_bernoulli
+   discrete_betabinom
    discrete_binom
    discrete_boltzmann
    discrete_planck

--- a/doc/source/tutorial/stats/discrete_betabinom.rst
+++ b/doc/source/tutorial/stats/discrete_betabinom.rst
@@ -1,0 +1,27 @@
+
+.. _discrete-betabinom:
+
+Beta-Binomial Distribution
+==========================
+
+The beta-binomial distribution is a binomial distribution with a probability of success `p` that follows a beta distribution. The probability mass function for `betabinom`, defined for :math:`0 \leq k \leq n`, is:
+
+.. math::
+
+    f(k; n, a, b) = \binom{n}{k} \frac{B(k + a, n - k + b)}{B(a, b)}
+
+for ``k`` in ``{0, 1,..., n}``, where :math:`B(a, b)` is the Beta function.
+
+In the limiting case of :math:`a = b = 1`, the beta-binomial distribution reduces to a discrete uniform distribution:
+
+.. math::
+
+    f(k; n, 1, 1) = \frac{1}{n + 1}
+
+In the limiting case of :math:`n = 1`, the beta-binomial distribution reduces to a Bernoulli distribution with the shape parameter :math:`p = a / (a + b)`:
+
+.. math::
+
+    f(k; 1, a, b) = \begin{cases}a / (a + b) & \text{if}\; k = 0 \\b / (a + b) & \text{if}\; k = 1\end{cases}
+
+Implementation: `scipy.stats.betabinom`

--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -147,6 +147,7 @@ Discrete distributions
    :toctree: generated/
 
    bernoulli         -- Bernoulli
+   betabinom         -- Beta-Binomial
    binom             -- Binomial
    boltzmann         -- Boltzmann (Truncated Discrete Exponential)
    dlaplace          -- Discrete Laplacian

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -203,8 +203,8 @@ class betabinom_gen(rv_discrete):
         g1, g2 = None, None
         if 's' in moments:
             g1 = 1.0 / sqrt(var)
-            g1 *= (a + b + 2 * n) * (b ** 2 - a ** 2)
-            g1 /= (a + b + 2)
+            g1 *= (a + b + 2 * n) * (b - a)
+            g1 /= (a + b + 2) * (a + b)
         if 'k' in moments:
             g2 = 0.0 + a + b
             g2 *= (a + b - 1 + 6 * n)

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -173,6 +173,8 @@ class betabinom_gen(rv_discrete):
 
     %(after_notes)s
 
+    .. versionadded:: 1.4.0
+
     %(example)s
 
     """

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -193,7 +193,7 @@ class betabinom_gen(rv_discrete):
 
     def _logpmf(self, x, n, a, b):
         k = floor(x)
-        combiln = gamln(n + 1) - (gamln(k + 1) + gamln(n - k + 1))
+        combiln = -log(n + 1) - betaln(n - k + 1, k + 1)
         return combiln + betaln(k + a, n - k + b) - betaln(a, b)
 
     def _pmf(self, x, n, a, b):

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -168,7 +168,8 @@ class betabinom_gen(rv_discrete):
 
        f(k) = \binom{n}{k} \frac{B(k + a, n - k + b)}{B(a, b)}
 
-    for ``k`` in ``{0, 1,..., n}``, where :math:`B(a, b)` is the beta function.
+    for ``k`` in ``{0, 1,..., n}``, :math:`n \geq 0`, :math:`a > 0`,
+    :math:`b > 0`, where :math:`B(a, b)` is the beta function.
 
     `betabinom` takes :math:`n`, :math:`a`, and :math:`b` as shape parameters.
 

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -164,8 +164,7 @@ class betabinom_gen(rv_discrete):
 
     .. math::
 
-       f(k) = \left(\begin{array}n \\ k\end{array}\right)
-            \frac{B(k + a, n - k + b)}{B(a, b)}
+       f(k) = \binom{n}{k} \frac{B(k + a, n - k + b)}{B(a, b)}
 
     for ``k`` in ``{0, 1,..., n}``, where :math:`B(a, b)` is the beta function.
 

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -206,7 +206,7 @@ class betabinom_gen(rv_discrete):
             g1 *= (a + b + 2 * n) * (b - a)
             g1 /= (a + b + 2) * (a + b)
         if 'k' in moments:
-            g2 = 0.0 + a + b
+            g2 = a + b
             g2 *= (a + b - 1 + 6 * n)
             g2 += 3 * a * b * (n - 2)
             g2 += 6 * n ** 2
@@ -214,6 +214,7 @@ class betabinom_gen(rv_discrete):
             g2 -= 18 * e_p * e_q * n ** 2
             g2 *= (a + b) ** 2 * (1 + a + b)
             g2 /= (n * a * b * (a + b + 2) * (a + b + 3) * (a + b + n))
+            g2 -= 3
         return mu, var, g1, g2
 
 

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -171,6 +171,10 @@ class betabinom_gen(rv_discrete):
 
     `betabinom` takes :math:`n`, :math:`a`, and :math:`b` as shape parameters.
 
+    References
+    ----------
+    .. [1] https://en.wikipedia.org/wiki/Beta-binomial_distribution
+
     %(after_notes)s
 
     .. versionadded:: 1.4.0

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -200,7 +200,7 @@ class betabinom_gen(rv_discrete):
     def _pmf(self, x, n, a, b):
         return exp(self._logpmf(x, n, a, b))
 
-    def _stats(self, n, a, b, moments = 'mv'):
+    def _stats(self, n, a, b, moments='mv'):
         e_p = a / (a + b)
         e_q = 1 - e_p
         mu = n * e_p

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -13,7 +13,6 @@ from numpy import floor, ceil, log, exp, sqrt, log1p, expm1, tanh, cosh, sinh
 
 import numpy as np
 
-from ._continuous_distns import beta
 from ._distn_infrastructure import (
         rv_discrete, _ncx2_pdf, _ncx2_cdf, get_distribution_names)
 
@@ -190,7 +189,7 @@ class betabinom_gen(rv_discrete):
         return 0, n
 
     def _argcheck(self, n, a, b):
-        return (n >= 0) & beta._argcheck(a, b)
+        return (n >= 0) & (a > 0) & (b > 0)
 
     def _logpmf(self, x, n, a, b):
         k = floor(x)

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -159,6 +159,9 @@ class betabinom_gen(rv_discrete):
 
     Notes
     -----
+    The beta-binomial distribution is a binomial distribution with a
+    probability of success `p` that follows a beta distribution.
+
     The probability mass function for `betabinom` is:
 
     .. math::
@@ -176,6 +179,10 @@ class betabinom_gen(rv_discrete):
     %(after_notes)s
 
     .. versionadded:: 1.4.0
+
+    See Also
+    --------
+    beta, binom
 
     %(example)s
 

--- a/scipy/stats/_distr_params.py
+++ b/scipy/stats/_distr_params.py
@@ -111,6 +111,7 @@ distcont = [
 
 distdiscrete = [
     ['bernoulli',(0.3,)],
+    ['betabinom', (5, 2.3098496451481823, 0.62687954300963677)],
     ['binom', (5, 0.4)],
     ['boltzmann',(1.4, 19)],
     ['dlaplace', (0.8,)],  # 0.5

--- a/scipy/stats/_distr_params.py
+++ b/scipy/stats/_distr_params.py
@@ -111,7 +111,7 @@ distcont = [
 
 distdiscrete = [
     ['bernoulli',(0.3,)],
-    ['betabinom', (5, 2.3098496451481823, 0.62687954300963677)],
+    ['betabinom', (5, 2.3, 0.63)],
     ['binom', (5, 0.4)],
     ['boltzmann',(1.4, 19)],
     ['dlaplace', (0.8,)],  # 0.5

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -100,7 +100,7 @@ def test_rvs_broadcast(dist, shape_args):
     # implementation detail of the distribution, not a requirement.  If
     # the implementation the rvs() method of a distribution changes, this
     # test might also have to be changed.
-    shape_only = dist in ['skellam', 'yulesimon']
+    shape_only = dist in ['betabinom', 'skellam', 'yulesimon']
 
     try:
         distfunc = getattr(stats, dist)

--- a/scipy/stats/tests/test_discrete_distns.py
+++ b/scipy/stats/tests/test_discrete_distns.py
@@ -58,3 +58,13 @@ def test_betabinom_a_and_b_unity():
     p = betabinom(n, 1, 1).pmf(k)
     expected = np.repeat(1 / (n + 1), n + 1)
     assert_almost_equal(p, expected)
+
+
+def test_betabinom_bernoulli():
+    # test limiting case that betabinom(1, a, b) = bernoulli(a / (a + b))
+    a = 2.3
+    b = 0.63
+    k = np.arange(2)
+    p = betabinom(1, a, b).pmf(k)
+    expected = bernoulli(a / (a + b)).pmf(k)
+    assert_almost_equal(p, expected)

--- a/scipy/stats/tests/test_discrete_distns.py
+++ b/scipy/stats/tests/test_discrete_distns.py
@@ -1,6 +1,6 @@
 from __future__ import division, print_function, absolute_import
 
-from scipy.stats import hypergeom, bernoulli, boltzmann
+from scipy.stats import betabinom, hypergeom, bernoulli, boltzmann
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_equal, assert_allclose
 
@@ -48,3 +48,13 @@ def test_boltzmann_upper_bound():
     c = boltzmann.cdf(k, lam, N)
     expected = [0, 0, 0, 4/7, 6/7, 1, 1, 1]
     assert_allclose(c, expected, rtol=1e-13)
+
+
+def test_betabinom_a_and_b_unity():
+    # test limiting case that betabinom(n, 1, 1) is a discrete uniform
+    # distribution from 0 to n
+    n = 20
+    k = np.arange(n + 1)
+    p = betabinom(n, 1, 1).pmf(k)
+    expected = np.repeat(1 / (n + 1), n + 1)
+    assert_almost_equal(p, expected)


### PR DESCRIPTION
#### Reference issue
Closes gh-7102.

#### What does this implement/fix?
Add the beta-binomial distribution as `scipy.stats.betabinom`.

#### Additional information

This code is adapted from the version provided by @PikalaxALT in issue #7102. The following changes were made:

* Remove the brute-force implementations of `_cdf` and `_sf`, since the base clase `rv_discrete` already provides a brute-force implementation.
* Adjust imports to match code style of `_discrete_distns.py`.
* Remove some `float()` casts that are no longer necessary in Python 3 and that would break Numpy vectorization.
* Fill in basic documentation.