### PR TITLE
MAINT: (ndimage) More robust check for output being a numpy dtype

### DIFF
--- a/scipy/ndimage/_ni_support.py
+++ b/scipy/ndimage/_ni_support.py
@@ -73,7 +73,8 @@ def _get_output(output, input, shape=None):
         shape = input.shape
     if output is None:
         output = numpy.zeros(shape, dtype=input.dtype.name)
-    elif type(output) in [type(type), type(numpy.zeros((4,)).dtype)]:
+    elif isinstance(output, (type, numpy.dtype)):
+        # Classes (like `np.float32`) and dtypes are interpreted as dtype
         output = numpy.zeros(shape, dtype=output)
     elif isinstance(output, string_types):
         output = numpy.typeDict[output]


### PR DESCRIPTION
The current logic assumes that all classes are types (which is only
semi true, but probably OK). It also assumes that all numpy dtypes
are not only instances of `np.dtype` but that their type:
`type(dtype) is np.dtype`.
This replaces both checks with the corresponding, more robust,
`isinstance` check.

Note that this is currently not relavent, but will become so if
NumPy redesigns the dtype system, which would (in all likelyhood)
encompass the creation of `np.dtype` subclasses.

---

This is not currently testable (at least not in a good way I can think of), but future-proofs SciPy against upgrades in NumPy. I personally hope that this is the only dtype related fix required within SciPy (hopefully also the only UFunc related fix required at least initially).