### PR TITLE
DOC: Added instructions on adding a new distribution to scipy.stats.

### DIFF
--- a/doc/source/dev/contributor/adding_new.rst
+++ b/doc/source/dev/contributor/adding_new.rst
@@ -1,0 +1,11 @@
+.. _adding-new:
+
+Adding New Methods, Functions, and Classes
+==========================================
+
+
+While adding code to SciPy is in most cases quite straight forward, there are a few places where that is not the case.
+This document contains detailed information on some specific situations where
+it may not be clear from the outset what is involved in the task.
+
+.. include:: adding_new/new_stats_distribution.rst.inc

--- a/doc/source/dev/contributor/adding_new/new_stats_distribution.rst.inc
+++ b/doc/source/dev/contributor/adding_new/new_stats_distribution.rst.inc
@@ -1,17 +1,19 @@
 Adding A New Statistics Distribution
 ------------------------------------
 
-For hundreds of years statisticians, mathematicians and scientists have needed to
-understand, analyze and model data.
-This has led to a plethora of statisics distributions, many of which are related to others.
+For hundreds of years statisticians, mathematicians and scientists have needed
+to understand, analyze and model data.
+This has led to a plethora of statisics distributions, many of which are
+related to others.
 Modeling of new types of data continues to give rise to new distributions,
 as does theoretical considerations being applied to new disciplines.
-SciPy models about a dozen discrete distributions :ref:`discrete-random-variables`
-and 100 continuous distributions :ref:`continuous-random-variables`.
+SciPy models about a dozen discrete distributions
+:ref:`discrete-random-variables` and 100 continuous distributions
+:ref:`continuous-random-variables`.
 
 To add a new distribution, a good reference is needed.
-Scipy typically uses [JKB]_ as its gold standard, with WikipediaDistributions_ articles
-often providing some extra details and/or graphical plots.
+Scipy typically uses [JKB]_ as its gold standard, with WikipediaDistributions_
+articles often providing some extra details and/or graphical plots.
 
 How to create a new continuous distribution
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -29,39 +31,56 @@ Before Implementation
   - It may have been implemented with a different parameterization (shape parameters).
   - It may be a specialization of a more general family of distributions.
 
-It is very common for multiple disciplines to discover/rediscover a distribution (or a specialization or paramaterization).
-There are a few existing SciPy distributions which are specializations of other distributions.
-E.g. The `scipy.stats.arcsine` distribution is a specialization of the `scipy.stats.beta` distribution.
-These exist for (very!) historical and widespread usage reasons.
-At this time, adding new specializations/reparametrizations of existing distributions to SciPy is not supported,
-mainly due to the increase in user confusion resulting from such additions.
+It is very common for multiple disciplines to discover/rediscover a
+distribution (or a specialization or different parameterization).
+There are a few existing SciPy distributions which are specializations
+of other distributions.  E.g. The :class:`scipy.stats.arcsine` distribution
+is a specialization of the :class:`scipy.stats.beta` distribution.
+These duplications exist for (very!) historical and widespread usage reasons.
+At this time, adding new specializations/reparametrizations of existing
+distributions to SciPy is not supported,  mainly due to the increase in user
+confusion resulting from such additions.
 
-2. Create a SciPy Issue on github listing the distribution, references and reasons for its inclusion.
+2. Create a SciPy Issue on github listing the distribution, references and
+   reasons for its inclusion.
 
 
 Implementation
 ..............
 
-#. Find an already existing distribution similar to XXXXX. Use its code as a template for XXXXX.
-#. Read the docstring for class `stats.rv_continuous` in `scipy/stats/_distn_infrastructure.py`.
-#. Write the new code, insert it into `scipy/stats/_continuous_distns.py`, which is in (mostly) alphabetical order by distribution name.
-#. Does the distribution have infinite support? If not, left and/or right endpoints `a`, `b` need to be specified.
-#. If the support depends upon the shape parameters, `_get_support()` needs to be implemented.
-#. The default `_argcheck()` implementation checks that the shape parameters are positive.  Create a more appropriate implementation.
-#. If the `ppf()` is expensive to compute relative to `pdf()`, consider setting its `momtype`.
-#. If the `rvs()` is expensive to compute, consider implementing a specific `_rvs()`.
-#. Add the name to the listing in the docstring of `scipy/stats/__init__.py`.
-#. Add the name and a good set of example shape parameters to the `distcont` list in `scipy/stats/_distr_params.py`.
-These shape parameters are used for testing and automatic documentation generation.
-#. Add a `TestXXXXX` class and any specific tests to `scipy/stats/tests/test_distributions.py`.
+#. Find an already existing distribution similar to ``XXXXX``.
+   Use its code as a template for ``XXXXX``.
+#. Read the docstring for class ``rv_continuous`` in
+   ``scipy/stats/_distn_infrastructure.py``.
+#. Write the new code for class ``xxxx_gen`` and insert it into
+   ``scipy/stats/_continuous_distns.py``,  which is in (mostly) alphabetical
+   order by distribution name.
+#. Does the distribution have infinite support? If not, left and/or right
+   endpoints ``a``, ``b`` need to be specified in the call to ``xxxx_gen()``.
+#. If the support depends upon the shape parameters,
+   ``xxxx_gen._get_support()`` needs to be implemented.
+#. The default ``_argcheck()`` implementation checks that the shape parameters
+   are positive.  Create a more appropriate implementation.
+#. If ``xxxx_gen.ppf()`` is expensive to compute relative to
+   ``xxxx_gen.pdf()``, consider setting the ``momtype`` in the call
+   to ``xxxx_gen()``.
+#. If ``xxxx_gen.rvs()`` is expensive to compute, consider implementing a
+   specific ``xxxx_gen._rvs()``.
+#. Add the name to the listing in the docstring of
+   ``scipy/stats/__init__.py``.
+#. Add the name and a good set of example shape parameters to the ``distcont``
+   list in ``scipy/stats/_distr_params.py``. These shape parameters are used
+   for testing and automatic documentation generation.
+#. Add a ``TestXXXXX` class and any specific tests to
+   ``scipy/stats/tests/test_distributions.py``.
 #. Run and pass(!) the tests.
 
 After Implementation
 ....................
 
-#. Add a tutorial `doc/source/tutorial/stats/continuous_XXXXX.rst`
-#. Add an entry to `doc/source/tutorial/stats/continuous.rst`.
-#. Update the # distributions in the example code in `doc/source/tutorial/stats.rst`.
+#. Add a tutorial ``doc/source/tutorial/stats/continuous_XXXXX.rst``
+#. Add an entry to ``doc/source/tutorial/stats/continuous.rst``.
+#. Update the ``number of continuous distributions`` in the example code in ``doc/source/tutorial/stats.rst``.
 #. Build the documentation successfully.
 #. Submit a PR.
 

--- a/doc/source/dev/contributor/adding_new/new_stats_distribution.rst.inc
+++ b/doc/source/dev/contributor/adding_new/new_stats_distribution.rst.inc
@@ -18,14 +18,15 @@ articles often providing some extra details and/or graphical plots.
 How to create a new continuous distribution
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-There are a few steps to be done to add continuous distribution XXXXX to SciPy.
+There are a few steps to be done to add a continuous distribution to SciPy.
 (Adding a discrete distribution is similar).
+We'll use the fictitious "Squirrel" distribution in the instructions below.
 
 
 Before Implementation
 .....................
 
-1. See if it already been implemented (that saves a lot of effort!)
+1. See if ``Squirrel`` has already been implemented (that saves a lot of effort!)
 
   - It may have been implemented with a different name.
   - It may have been implemented with a different parameterization (shape parameters).
@@ -41,46 +42,49 @@ At this time, adding new specializations/reparametrizations of existing
 distributions to SciPy is not supported,  mainly due to the increase in user
 confusion resulting from such additions.
 
-2. Create a SciPy Issue on github listing the distribution, references and
-   reasons for its inclusion.
+2. Create a `SciPy Issue on github <https://github.com/scipy/scipy/issues>`_,
+   listing the distribution, references and reasons for its inclusion.
 
 
 Implementation
 ..............
 
-#. Find an already existing distribution similar to ``XXXXX``.
-   Use its code as a template for ``XXXXX``.
+#. Find an already existing distribution similar to ``Squirrel``.
+   Use its code as a template for ``Squirrel``.
 #. Read the docstring for class ``rv_continuous`` in
-   ``scipy/stats/_distn_infrastructure.py``.
-#. Write the new code for class ``xxxx_gen`` and insert it into
-   ``scipy/stats/_continuous_distns.py``,  which is in (mostly) alphabetical
-   order by distribution name.
+   `scipy/stats/_distn_infrastructure.py <https://github.com/scipy/scipy/blob/master/scipy/stats/_distn_infrastructure.py#L1378>`_.
+#. Write the new code for class ``squirrel_gen`` and insert it into
+   `scipy/stats/_continuous_distns.py <https://github.com/scipy/scipy/blob/master/scipy/stats/_continuous_distns.py>`_,
+   which is in (mostly) alphabetical order by distribution name.
 #. Does the distribution have infinite support? If not, left and/or right
-   endpoints ``a``, ``b`` need to be specified in the call to ``xxxx_gen()``.
+   endpoints ``a``, ``b`` need to be specified in the call to ``squirrel_gen(name='squirrel', a=?, b=?)``.
 #. If the support depends upon the shape parameters,
-   ``xxxx_gen._get_support()`` needs to be implemented.
-#. The default ``_argcheck()`` implementation checks that the shape parameters
+   ``squirrel_gen._get_support()`` needs to be implemented.
+#. The default inherited ``_argcheck()`` implementation checks that the shape parameters
    are positive.  Create a more appropriate implementation.
-#. If ``xxxx_gen.ppf()`` is expensive to compute relative to
-   ``xxxx_gen.pdf()``, consider setting the ``momtype`` in the call
-   to ``xxxx_gen()``.
-#. If ``xxxx_gen.rvs()`` is expensive to compute, consider implementing a
-   specific ``xxxx_gen._rvs()``.
+#. If ``squirrel_gen.ppf()`` is expensive to compute relative to
+   ``squirrel_gen.pdf()``, consider setting the ``momtype`` in the call
+   to ``squirrel_gen()``.
+#. If ``squirrel_gen.rvs()`` is expensive to compute, consider implementing a
+   specific ``squirrel_gen._rvs()``.
 #. Add the name to the listing in the docstring of
-   ``scipy/stats/__init__.py``.
+   `scipy/stats/__init__.py <https://github.com/scipy/scipy/blob/master/scipy/stats/__init__.py>`_.
 #. Add the name and a good set of example shape parameters to the ``distcont``
-   list in ``scipy/stats/_distr_params.py``. These shape parameters are used
-   for testing and automatic documentation generation.
-#. Add a ``TestXXXXX` class and any specific tests to
-   ``scipy/stats/tests/test_distributions.py``.
+   list in
+   `scipy/stats/_distr_params.py <https://github.com/scipy/scipy/blob/master/scipy/stats/_distr_params.py#L5>`_.
+   These shape parameters are used both for testing and automatic documentation generation.
+#. Add a ``TestSquirrel`` class and any specific tests to
+   `scipy/stats/tests/test_distributions.py <https://github.com/scipy/scipy/blob/master/scipy/stats/tests/test_distributions.py>`_.
 #. Run and pass(!) the tests.
 
 After Implementation
 ....................
 
-#. Add a tutorial ``doc/source/tutorial/stats/continuous_XXXXX.rst``
-#. Add an entry to ``doc/source/tutorial/stats/continuous.rst``.
-#. Update the ``number of continuous distributions`` in the example code in ``doc/source/tutorial/stats.rst``.
+#. Add a tutorial ``doc/source/tutorial/stats/continuous_squirrel.rst``
+#. Add it to the listing of continuous distributions in
+   `doc/source/tutorial/stats/continuous.rst <https://github.com/scipy/scipy/blob/master/doc/source/tutorial/stats/continuous.rst>`_.
+#. Update the ``number of continuous distributions`` in the example code in
+   `doc/source/tutorial/stats.rst <https://github.com/scipy/scipy/blob/master/doc/source/tutorial/stats.rst>`_.
 #. Build the documentation successfully.
 #. Submit a PR.
 

--- a/doc/source/dev/contributor/adding_new/new_stats_distribution.rst.inc
+++ b/doc/source/dev/contributor/adding_new/new_stats_distribution.rst.inc
@@ -47,9 +47,12 @@ Implementation
 #. Write the new code, insert it into `scipy/stats/_continuous_distns.py`, which is in (mostly) alphabetical order by distribution name.
 #. Does the distribution have infinite support? If not, left and/or right endpoints `a`, `b` need to be specified.
 #. If the support depends upon the shape parameters, `_get_support()` needs to be implemented.
+#. The default `_argcheck()` implementation checks that the shape parameters are positive.  Create a more appropriate implementation.
 #. If the `ppf()` is expensive to compute relative to `pdf()`, consider setting its `momtype`.
+#. If the `rvs()` is expensive to compute, consider implementing a specific `_rvs()`.
 #. Add the name to the listing in the docstring of `scipy/stats/__init__.py`.
 #. Add the name and a good set of example shape parameters to the `distcont` list in `scipy/stats/_distr_params.py`.
+These shape parameters are used for testing and automatic documentation generation.
 #. Add a `TestXXXXX` class and any specific tests to `scipy/stats/tests/test_distributions.py`.
 #. Run and pass(!) the tests.
 

--- a/doc/source/dev/contributor/adding_new/new_stats_distribution.rst.inc
+++ b/doc/source/dev/contributor/adding_new/new_stats_distribution.rst.inc
@@ -1,0 +1,71 @@
+Adding A New Statistics Distribution
+------------------------------------
+
+For hundreds of years statisticians, mathematicians and scientists have needed to
+understand, analyze and model data.
+This has led to a plethora of statisics distributions, many of which are related to others.
+Modeling of new types of data continues to give rise to new distributions,
+as does theoretical considerations being applied to new disciplines.
+SciPy models about a dozen discrete distributions :ref:`discrete-random-variables`
+and 100 continuous distributions :ref:`continuous-random-variables`.
+
+To add a new distribution, a good reference is needed.
+Scipy typically uses [JKB]_ as its gold standard, with WikipediaDistributions_ articles
+often providing some extra details and/or graphical plots.
+
+How to create a new continuous distribution
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+There are a few steps to be done to add continuous distribution XXXXX to SciPy.
+(Adding a discrete distribution is similar).
+
+
+Before Implementation
+.....................
+
+1. See if it already been implemented (that saves a lot of effort!)
+
+  - It may have been implemented with a different name.
+  - It may have been implemented with a different parameterization (shape parameters).
+  - It may be a specialization of a more general family of distributions.
+
+It is very common for multiple disciplines to discover/rediscover a distribution (or a specialization or paramaterization).
+There are a few existing SciPy distributions which are specializations of other distributions.
+E.g. The `scipy.stats.arcsine` distribution is a specialization of the `scipy.stats.beta` distribution.
+These exist for (very!) historical and widespread usage reasons.
+At this time, adding new specializations/reparametrizations of existing distributions to SciPy is not supported,
+mainly due to the increase in user confusion resulting from such additions.
+
+2. Create a SciPy Issue on github listing the distribution, references and reasons for its inclusion.
+
+
+Implementation
+..............
+
+#. Find an already existing distribution similar to XXXXX. Use its code as a template for XXXXX.
+#. Read the docstring for class `stats.rv_continuous` in `scipy/stats/_distn_infrastructure.py`.
+#. Write the new code, insert it into `scipy/stats/_continuous_distns.py`, which is in (mostly) alphabetical order by distribution name.
+#. Does the distribution have infinite support? If not, left and/or right endpoints `a`, `b` need to be specified.
+#. If the support depends upon the shape parameters, `_get_support()` needs to be implemented.
+#. If the `ppf()` is expensive to compute relative to `pdf()`, consider setting its `momtype`.
+#. Add the name to the listing in the docstring of `scipy/stats/__init__.py`.
+#. Add the name and a good set of example shape parameters to the `distcont` list in `scipy/stats/_distr_params.py`.
+#. Add a `TestXXXXX` class and any specific tests to `scipy/stats/tests/test_distributions.py`.
+#. Run and pass(!) the tests.
+
+After Implementation
+....................
+
+#. Add a tutorial `doc/source/tutorial/stats/continuous_XXXXX.rst`
+#. Add an entry to `doc/source/tutorial/stats/continuous.rst`.
+#. Update the # distributions in the example code in `doc/source/tutorial/stats.rst`.
+#. Build the documentation successfully.
+#. Submit a PR.
+
+References
+^^^^^^^^^^
+
+.. [JKB] Johnson, Kotz, and Balakrishnan, "Continuous Univariate Distributions, Volume 1", Second Edition, John Wiley and Sons,
+           p. 173 (1994).
+
+.. _WikipediaDistributions: https://en.wikipedia.org/wiki/List_of_probability_distributions

--- a/doc/source/dev/contributor/contributor_toc.rst
+++ b/doc/source/dev/contributor/contributor_toc.rst
@@ -34,7 +34,9 @@ Editing SciPy
 - :ref:`scipy-api` contains some important notes about how SciPy code is organized and documents the structure of the SciPy API; if you are going to import other SciPy code, read this first
 - :ref:`reviewing-prs` explains how to review another author's SciPy code locally
 - :doc:`numpy:reference/distutils_guide` - check this out before adding any new files to SciPy
-- :ref:`core-dev-guide` has background information including how decisions are made and how a release is prepared; it's geared toward :ref:`Core Developers<governance>`, but contains useful information for all contributors
+- :ref:`adding-new` has information on how to add new methods, functions and classes
+- :ref:`core-dev-guide` has background information including how decisions are made and how a release is prepared; it's geared toward :ref:`Core Developers <governance>`, but contains useful information for all contributors
+
 
 .. _unit-tests:
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -67,6 +67,7 @@ For a more detailed look at how the SciPy project works:
    dev/contributor/runtests
    dev/contributor/benchmarking
    dev/contributor/cython
+   dev/contributor/adding_new
 
 .. These files are not intended to be in any toctree. because they have not
    been maintained.They should only be reached via the contributor guide if


### PR DESCRIPTION
The procedure for adding a new statistics distribution to `scipy.stats` isn't in the doc. The process is sufficiently complicated enough that it should be. 

#### Reference issue
Closes gh-10386.

#### What does this implement/fix?
This PR adds instructions for adding a new statistics distribution to scipy.stats.  It uses a doc/rst framework suggested in gh-10386.  This framework should be suitable for adding specific instructions on other complicated areas such as `scipy.special`.