### PR TITLE
BUG: make C-implemented root finders work with functools.lru_cache

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -218,6 +218,7 @@ Timothy C. Willard for contributions to x-value requirements in scipy.interpolat
 Andrew Knyazev, the original author of LOBPCG, for advice on and maintenance of
    sparse.linalg.lobpcg
 Michael Marien for contributing to scipy.stats.entropy
+Joseph Weston for a bug fix in scipy.optimize.zeros.
 
 Institutions
 ------------

--- a/scipy/optimize/zeros.c
+++ b/scipy/optimize/zeros.c
@@ -27,7 +27,7 @@
 
 typedef struct {
     PyObject *function;
-    PyObject *args;
+    PyObject *xargs;
     jmp_buf env;
 } scipy_zeros_parameters;
 
@@ -37,13 +37,34 @@ static double
 scipy_zeros_functions_func(double x, void *params)
 {
     scipy_zeros_parameters *myparams = params;
-    PyObject *args, *f, *retval=NULL;
+    PyObject *args, *xargs, *item, *f, *retval=NULL;
+    Py_ssize_t i, len;
     double val;
 
-    args = myparams->args;
+    xargs = myparams->xargs;
+    /* Need to create a new 'args' tuple on each call in case 'f' is
+       stateful and keeps references to it (e.g. functools.lru_cache) */
+    len = PyTuple_Size(xargs);
+    /* Make room for the double as first argument */
+    args = PyArgs(New)(len + 1);
+    if (args == NULL) {
+        PyErr_SetString(PyExc_RuntimeError, "Failed to allocate arguments");
+        longjmp(myparams->env, 1);
+    }
+    PyArgs(SET_ITEM)(args, 0, Py_BuildValue("d", x));
+    for (i = 0; i < len; i++) {
+        item = PyTuple_GetItem(xargs, i);
+        if (item == NULL) {
+            Py_DECREF(args);
+            longjmp(myparams->env, 1);
+        }
+        Py_INCREF(item);
+        PyArgs(SET_ITEM)(args, i+1, item);
+    }
+
     f = myparams->function;
-    PyArgs(SetItem)(args, 0, Py_BuildValue("d",x));
     retval = PyObject_CallObject(f,args);
+    Py_DECREF(args);
     if (retval == NULL) {
         longjmp(myparams->env, 1);
     }
@@ -61,12 +82,10 @@ static PyObject *
 call_solver(solver_type solver, PyObject *self, PyObject *args)
 {
     double a, b, xtol, rtol, zero;
-    Py_ssize_t len;
-    int iter, i, fulloutput, disp=1, flag=0;
+    int iter, fulloutput, disp=1, flag=0;
     scipy_zeros_parameters params;
     scipy_zeros_info solver_stats;
-    PyObject *f, *xargs, *item;
-    volatile PyObject *fargs = NULL;
+    PyObject *f, *xargs;
 
     if (!PyArg_ParseTuple(args, "OddddiOi|i",
                 &f, &a, &b, &xtol, &rtol, &iter, &xargs, &fulloutput, &disp)) {
@@ -82,37 +101,16 @@ call_solver(solver_type solver, PyObject *self, PyObject *args)
         return NULL;
     }
 
-    len = PyTuple_Size(xargs);
-    /* Make room for the double as first argument */
-    fargs = PyArgs(New)(len + 1);
-    if (fargs == NULL) {
-        PyErr_SetString(PyExc_RuntimeError, "Failed to allocate arguments");
-        return NULL;
-    }
-
-    for (i = 0; i < len; i++) {
-        item = PyTuple_GetItem(xargs, i);
-        if (item == NULL) {
-            Py_DECREF(fargs);
-            return NULL;
-        }
-        Py_INCREF(item);
-        PyArgs(SET_ITEM)(fargs, i+1, item);
-    }
-
     params.function = f;
-    params.args = (PyObject *)fargs;  /* Discard the volatile attribute */
+    params.xargs = xargs;
 
     if (!setjmp(params.env)) {
         /* direct return */
         solver_stats.error_num = 0;
         zero = solver(scipy_zeros_functions_func, a, b, xtol, rtol,
                       iter, (void*)&params, &solver_stats);
-        Py_DECREF(fargs);
-        fargs = NULL;
     } else {
         /* error return from Python function */
-        Py_DECREF(fargs);
         return NULL;
     }
 


### PR DESCRIPTION
#### Reference issue
Closes #10846.

#### What does this implement/fix?
C-implemented root finders in `scipy.optimize` raise `SystemError` when passed a function wrapped with `functools.lru_cache`. This is because when calling C-implemented root finders we create the tuple of arguments to pass to the underlying function once, and modify only the first entry on subsequent calls. This breaks when the argument tuple is stored internally by `functools.lru_cache`.

My fix is to instead construct a new argument tuple each time the underlying function is called.

As this change has the potential to slow down the root finders I ran the following benchmark:

```
from scipy.optimize.zeros import bisect

def f(x):
    return x

# The slowest root finder
%timeit bisect(f, -1, 1 + 1/3)
```
on `master` this gives:
```4.78 µs ± 277 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)```
on this branch this gives:
```5.18 µs ± 204 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)```

which represents an 8% slowdown. I think that this is pretty much an upper bound on the slowdown, as the function we're finding the root of is trivial, and this is using the most naive root-finder (i.e. it does the least amount of work per function call).

#### Additional information
This bug is present in older versions of Scipy, but I have applied the fix on top of `master`. I could not find any information on Scipy's policy regarding how far back bugfixes should be applied. Let me know if I should apply this fix to one of the `maintenance/*` branches instead.