### PR TITLE
DOC: fixed broken url

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@ http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checkli
 
 Also, please name and describe your PR as you would write a
 commit message:
-https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message
+https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message
 
 Note that we are a team of volunteers; we appreciate your
 patience during the review process.


### PR DESCRIPTION
This corrects the second URL in the pull request template.

development_workflow.html is in `/dev` not `/dev/gitwash`