### PR TITLE
ENH: Match R functionality for hmean

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -403,7 +403,7 @@ def hmean(a, axis=0, dtype=None):
             return size / np.sum(1.0 / a, axis=axis, dtype=dtype)
     else:
         raise ValueError("Harmonic mean only defined if all elements greater "
-                         "than equal to zero")
+                         "than or equal to zero")
 
 
 ModeResult = namedtuple('ModeResult', ('mode', 'count'))

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -333,7 +333,7 @@ def gmean(a, axis=0, dtype=None):
     return np.exp(log_a.mean(axis=axis))
 
 
-def hmean(a, axis=0, dtype=None, allow_zero=False):
+def hmean(a, axis=0, dtype=None):
     """
     Calculate the harmonic mean along the specified axis.
 
@@ -389,7 +389,7 @@ def hmean(a, axis=0, dtype=None, allow_zero=False):
     """
     if not isinstance(a, np.ndarray):
         a = np.array(a, dtype=dtype)
-    if (allow_zero and np.all(a >= 0)) or np.all(a > 0):
+    if np.all(a >= 0):
         # Harmonic mean only defined if greater than or equal to to zero.
         if isinstance(a, np.ma.MaskedArray):
             size = a.count(axis)
@@ -403,7 +403,7 @@ def hmean(a, axis=0, dtype=None, allow_zero=False):
             return size / np.sum(1.0 / a, axis=axis, dtype=dtype)
     else:
         raise ValueError("Harmonic mean only defined if all elements greater "
-                         "than %szero" % ('or equal to ' if allow_zero else ''))
+                         "than equal to zero")
 
 
 ModeResult = namedtuple('ModeResult', ('mode', 'count'))

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -387,8 +387,8 @@ def hmean(a, axis=0, dtype=None, allow_zero=False):
     """
     if not isinstance(a, np.ndarray):
         a = np.array(a, dtype=dtype)
-    if np.all(a > 0) or (allow_zero and np.all(a >= 0)):
-        # Harmonic mean only defined if greater than zero
+    if np.all(a >= 0):
+        # Harmonic mean only defined if greater than or equal to to zero.
         if isinstance(a, np.ma.MaskedArray):
             size = a.count(axis)
         else:
@@ -401,8 +401,7 @@ def hmean(a, axis=0, dtype=None, allow_zero=False):
             return size / np.sum(1.0 / a, axis=axis, dtype=dtype)
     else:
         raise ValueError("Harmonic mean only defined if all elements greater "
-                         "than %szero" % \
-                            ('or equal to ' if allow_zero else ''))
+                         "than or equal to zero")
 
 
 ModeResult = namedtuple('ModeResult', ('mode', 'count'))

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -354,8 +354,10 @@ def hmean(a, axis=0, dtype=None, allow_zero=False):
         platform integer is used.
     allow_zero : bool, optional
         If `allow_zero` is False then hmean will raise a ValueError if any of
-        the elements in a are 0. If `allow_zero` is True then hmean will return
-        0 if any of the elements in a are 0.
+        the elements in `a` are 0. If `allow_zero` is True then hmean will
+        return 0 if any of the elements in `a` are 0.
+
+        .. versionadded:: 1.4.0
 
     Returns
     -------
@@ -387,7 +389,7 @@ def hmean(a, axis=0, dtype=None, allow_zero=False):
     """
     if not isinstance(a, np.ndarray):
         a = np.array(a, dtype=dtype)
-    if np.all(a >= 0):
+    if (allow_zero and np.all(a >= 0)) or np.all(a > 0):
         # Harmonic mean only defined if greater than or equal to to zero.
         if isinstance(a, np.ma.MaskedArray):
             size = a.count(axis)
@@ -401,7 +403,7 @@ def hmean(a, axis=0, dtype=None, allow_zero=False):
             return size / np.sum(1.0 / a, axis=axis, dtype=dtype)
     else:
         raise ValueError("Harmonic mean only defined if all elements greater "
-                         "than or equal to zero")
+                         "than %szero" % ('or equal to ' if allow_zero else ''))
 
 
 ModeResult = namedtuple('ModeResult', ('mode', 'count'))

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -352,12 +352,6 @@ def hmean(a, axis=0, dtype=None):
         dtype of `a`, unless `a` has an integer `dtype` with a precision less
         than that of the default platform integer. In that case, the default
         platform integer is used.
-    allow_zero : bool, optional
-        If `allow_zero` is False then hmean will raise a ValueError if any of
-        the elements in `a` are 0. If `allow_zero` is True then hmean will
-        return 0 if any of the elements in `a` are 0.
-
-        .. versionadded:: 1.4.0
 
     Returns
     -------

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3945,15 +3945,11 @@ class TestHarMean(object):
     def test_1d_array_with_zero(self):
         a = np.array([1, 0])
         desired = 0.0
-        assert_equal(stats.hmean(a, allow_zero=True), desired)
-
-    def test_1d_array_with_disallowed_zero(self):
-        a = np.array([1, 0])
-        assert_raises(ValueError, stats.hmean, a)
+        assert_equal(stats.hmean(a), desired)
 
     def test_1d_array_with_negative_value(self):
         a = np.array([1, 0, -1])
-        assert_raises(ValueError, stats.hmean, a, allow_zero=True)
+        assert_raises(ValueError, stats.hmean, a)
 
     # Note the next tests use axis=None as default, not axis=0
     def test_2d_list(self):
@@ -3977,7 +3973,7 @@ class TestHarMean(object):
     def test_2d_axis0_with_zero(self):
         a = [[10, 0, 30, 40], [50, 60, 70, 80], [90, 100, 110, 120]]
         desired = np.array([22.88135593, 0.0, 52.90076336, 65.45454545])
-        assert_allclose(stats.hmean(a, axis=0, allow_zero=True), desired)
+        assert_allclose(stats.hmean(a, axis=0), desired)
 
     def test_2d_axis1(self):
         #  Test a 2d list with axis=1
@@ -3988,7 +3984,7 @@ class TestHarMean(object):
     def test_2d_axis1_with_zero(self):
         a = [[10, 0, 30, 40], [50, 60, 70, 80], [90, 100, 110, 120]]
         desired = np.array([0.0, 63.03939962, 103.80078637])
-        assert_allclose(stats.hmean(a, axis=1, allow_zero=True), desired)
+        assert_allclose(stats.hmean(a, axis=1), desired)
 
     def test_2d_matrix_axis0(self):
         #  Test a 2d list with axis=0

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3942,6 +3942,15 @@ class TestHarMean(object):
         desired = 34.1417152147
         check_equal_hmean(a, desired)
 
+    def test_1d_array_with_zero(self):
+        a = np.array([1, 0])
+        assert_raises(ValueError, stats.hmean, a)
+
+    def test_1d_array_with_allowed_zero(self):
+        a = np.array([1, 0])
+        desired = 0.0
+        assert_equal(stats.hmean(a, allow_zero=True), desired)
+
     # Note the next tests use axis=None as default, not axis=0
     def test_2d_list(self):
         #  Test a 2d list
@@ -3961,11 +3970,21 @@ class TestHarMean(object):
         desired = np.array([22.88135593, 39.13043478, 52.90076336, 65.45454545])
         check_equal_hmean(a, desired, axis=0)
 
+    def test_2d_axis0_with_zero_allowed(self):
+        a = [[10, 0, 30, 40], [50, 60, 70, 80], [90, 100, 110, 120]]
+        desired = np.array([22.88135593, 0.0, 52.90076336, 65.45454545])
+        assert_allclose(stats.hmean(a, axis=0, allow_zero=True), desired)
+
     def test_2d_axis1(self):
         #  Test a 2d list with axis=1
         a = [[10, 20, 30, 40], [50, 60, 70, 80], [90, 100, 110, 120]]
         desired = np.array([19.2, 63.03939962, 103.80078637])
         check_equal_hmean(a, desired, axis=1)
+
+    def test_2d_axis1_with_zero_allowed(self):
+        a = [[10, 0, 30, 40], [50, 60, 70, 80], [90, 100, 110, 120]]
+        desired = np.array([0.0, 63.03939962, 103.80078637])
+        assert_allclose(stats.hmean(a, axis=1, allow_zero=True), desired)
 
     def test_2d_matrix_axis0(self):
         #  Test a 2d list with axis=0
@@ -4550,7 +4569,7 @@ class TestKruskal(object):
         assert_almost_equal(stats.kruskal(x, x, nan_policy='omit'), (0.0, 1.0))
         assert_raises(ValueError, stats.kruskal, x, x, nan_policy='raise')
         assert_raises(ValueError, stats.kruskal, x, x, nan_policy='foobar')
-    
+
     def test_large_no_samples(self):
         # Test to see if large samples are handled correctly.
         n = 50000

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3944,12 +3944,8 @@ class TestHarMean(object):
 
     def test_1d_array_with_zero(self):
         a = np.array([1, 0])
-        assert_raises(ValueError, stats.hmean, a)
-
-    def test_1d_array_with_allowed_zero(self):
-        a = np.array([1, 0])
         desired = 0.0
-        assert_equal(stats.hmean(a, allow_zero=True), desired)
+        assert_equal(stats.hmean(a), desired)
 
     # Note the next tests use axis=None as default, not axis=0
     def test_2d_list(self):
@@ -3970,10 +3966,10 @@ class TestHarMean(object):
         desired = np.array([22.88135593, 39.13043478, 52.90076336, 65.45454545])
         check_equal_hmean(a, desired, axis=0)
 
-    def test_2d_axis0_with_zero_allowed(self):
+    def test_2d_axis0_with_zero(self):
         a = [[10, 0, 30, 40], [50, 60, 70, 80], [90, 100, 110, 120]]
         desired = np.array([22.88135593, 0.0, 52.90076336, 65.45454545])
-        assert_allclose(stats.hmean(a, axis=0, allow_zero=True), desired)
+        assert_allclose(stats.hmean(a, axis=0), desired)
 
     def test_2d_axis1(self):
         #  Test a 2d list with axis=1
@@ -3981,10 +3977,10 @@ class TestHarMean(object):
         desired = np.array([19.2, 63.03939962, 103.80078637])
         check_equal_hmean(a, desired, axis=1)
 
-    def test_2d_axis1_with_zero_allowed(self):
+    def test_2d_axis1_with_zero(self):
         a = [[10, 0, 30, 40], [50, 60, 70, 80], [90, 100, 110, 120]]
         desired = np.array([0.0, 63.03939962, 103.80078637])
-        assert_allclose(stats.hmean(a, axis=1, allow_zero=True), desired)
+        assert_allclose(stats.hmean(a, axis=1), desired)
 
     def test_2d_matrix_axis0(self):
         #  Test a 2d list with axis=0

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3945,7 +3945,15 @@ class TestHarMean(object):
     def test_1d_array_with_zero(self):
         a = np.array([1, 0])
         desired = 0.0
-        assert_equal(stats.hmean(a), desired)
+        assert_equal(stats.hmean(a, allow_zero=True), desired)
+
+    def test_1d_array_with_disallowed_zero(self):
+        a = np.array([1, 0])
+        assert_raises(ValueError, stats.hmean, a)
+
+    def test_1d_array_with_negative_value(self):
+        a = np.array([1, 0, -1])
+        assert_raises(ValueError, stats.hmean, a, allow_zero=True)
 
     # Note the next tests use axis=None as default, not axis=0
     def test_2d_list(self):
@@ -3969,7 +3977,7 @@ class TestHarMean(object):
     def test_2d_axis0_with_zero(self):
         a = [[10, 0, 30, 40], [50, 60, 70, 80], [90, 100, 110, 120]]
         desired = np.array([22.88135593, 0.0, 52.90076336, 65.45454545])
-        assert_allclose(stats.hmean(a, axis=0), desired)
+        assert_allclose(stats.hmean(a, axis=0, allow_zero=True), desired)
 
     def test_2d_axis1(self):
         #  Test a 2d list with axis=1
@@ -3980,7 +3988,7 @@ class TestHarMean(object):
     def test_2d_axis1_with_zero(self):
         a = [[10, 0, 30, 40], [50, 60, 70, 80], [90, 100, 110, 120]]
         desired = np.array([0.0, 63.03939962, 103.80078637])
-        assert_allclose(stats.hmean(a, axis=1), desired)
+        assert_allclose(stats.hmean(a, axis=1, allow_zero=True), desired)
 
     def test_2d_matrix_axis0(self):
         #  Test a 2d list with axis=0


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes [#8165 ](https://github.com/scipy/scipy/issues/8165)

#### What does this implement/fix?
It adds an optional argument, `allow_zero`, to `stats.hmean` which has the function return `0.0` when one of the elements of the array-like first argument is zero.

#### Additional information
This PR will allow `scipy` to behave like R's implementation of harmonic mean without breaking backwards compatibility.