### PR TITLE
ENH: sparse/linalg: support pydata/sparse matrices

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -191,7 +191,7 @@ before_install:
   - travis_retry pip install gmpy2  # speeds up mpmath (scipy.special tests)
   - travis_retry pip install pybind11
   - |
-    if [ -z "${USE_DEBUG}" -a "${TRAVIS_PYTHON_VERSION}" != "3.8-dev" ]; then
+    if [ -z "${USE_DEBUG}" -a "${TRAVIS_CPU_ARCH}" == "amd64" -a "${TRAVIS_PYTHON_VERSION}" != "3.8" ]; then
         travis_retry pip install --only-binary=:all: sparse
     fi
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -191,6 +191,10 @@ before_install:
   - travis_retry pip install gmpy2  # speeds up mpmath (scipy.special tests)
   - travis_retry pip install pybind11
   - |
+    if [ -z "${USE_DEBUG}" -a "${TRAVIS_PYTHON_VERSION}" != "3.8-dev" ]; then
+        travis_retry pip install --only-binary=:all: sparse
+    fi
+  - |
     if [ "${TESTMODE}" == "full" ]; then
         travis_retry pip install pytest-cov coverage matplotlib==3.2.0rc1 scikit-umfpack scikit-sparse
     fi

--- a/doc/source/dev/core-dev/distributing.rst.inc
+++ b/doc/source/dev/core-dev/distributing.rst.inc
@@ -28,6 +28,7 @@ are:
 - Pillow_ (for image loading/saving)
 - scikits.umfpack_ (optionally used in ``sparse.linalg``)
 - mpmath_ (for more extended tests in ``special``)
+- pydata/sparse  (compatibility support in ``scipy.sparse``)
 
 *Unconditional build-time dependencies:*
 

--- a/doc/source/toolchain.rst
+++ b/doc/source/toolchain.rst
@@ -203,6 +203,16 @@ scikit-umfpack  Recent    https://pypi.org/project/scikit-umfpack/
 =============== ======== ==========================================
 
 
+Moreover, Scipy supports interaction with other libraries. The test suite
+has additional compatibility tests that are run when these are installed:
+
+=========================  ========  ====================================
+ Tool                      Version    URL
+=========================  ========  ====================================
+pydata/sparse              Recent     https://github.com/pydata/sparse/
+=========================  ========  ====================================
+
+
 Testing and Benchmarking
 --------------------------
 

--- a/scipy/sparse/linalg/_expm_multiply.py
+++ b/scipy/sparse/linalg/_expm_multiply.py
@@ -8,6 +8,7 @@ import numpy as np
 import scipy.linalg
 import scipy.sparse.linalg
 from scipy.sparse.linalg import aslinearoperator
+from scipy.sparse.sputils import is_pydata_spmatrix
 
 __all__ = ['expm_multiply']
 
@@ -16,6 +17,8 @@ def _exact_inf_norm(A):
     # A compatibility function which should eventually disappear.
     if scipy.sparse.isspmatrix(A):
         return max(abs(A).sum(axis=1).flat)
+    elif is_pydata_spmatrix(A):
+        return max(abs(A).sum(axis=1))
     else:
         return np.linalg.norm(A, np.inf)
 
@@ -24,6 +27,8 @@ def _exact_1_norm(A):
     # A compatibility function which should eventually disappear.
     if scipy.sparse.isspmatrix(A):
         return max(abs(A).sum(axis=0).flat)
+    elif is_pydata_spmatrix(A):
+        return max(abs(A).sum(axis=0))
     else:
         return np.linalg.norm(A, 1)
 
@@ -32,6 +37,8 @@ def _trace(A):
     # A compatibility function which should eventually disappear.
     if scipy.sparse.isspmatrix(A):
         return A.diagonal().sum()
+    elif is_pydata_spmatrix(A):
+        return A.to_scipy_sparse().diagonal().sum()
     else:
         return np.trace(A)
 
@@ -41,6 +48,9 @@ def _ident_like(A):
     if scipy.sparse.isspmatrix(A):
         return scipy.sparse.construct.eye(A.shape[0], A.shape[1],
                 dtype=A.dtype, format=A.format)
+    elif is_pydata_spmatrix(A):
+        import sparse
+        return sparse.eye(A.shape[0], A.shape[1], dtype=A.dtype)
     else:
         return np.eye(A.shape[0], A.shape[1], dtype=A.dtype)
 

--- a/scipy/sparse/linalg/dsolve/_superlumodule.c
+++ b/scipy/sparse/linalg/dsolve/_superlumodule.c
@@ -208,21 +208,23 @@ static PyObject *Py_gstrf(PyObject * self, PyObject * args,
     PyArrayObject *rowind, *colptr, *nzvals;
     SuperMatrix A = { 0 };
     PyObject *result;
+    PyObject *py_csc_construct_func = NULL;
     PyObject *option_dict = NULL;
     int type;
     int ilu = 0;
 
     static char *kwlist[] = { "N", "nnz", "nzvals", "colind", "rowptr",
-	"options", "ilu",
+        "csc_construct_func", "options", "ilu",
 	NULL
     };
 
     int res =
-	PyArg_ParseTupleAndKeywords(args, keywds, "iiO!O!O!|Oi", kwlist,
+	PyArg_ParseTupleAndKeywords(args, keywds, "iiO!O!O!O|Oi", kwlist,
 				    &N, &nnz,
 				    &PyArray_Type, &nzvals,
 				    &PyArray_Type, &rowind,
 				    &PyArray_Type, &colptr,
+                                    &py_csc_construct_func,
 				    &option_dict,
 				    &ilu);
 
@@ -247,7 +249,7 @@ static PyObject *Py_gstrf(PyObject * self, PyObject * args,
 	goto fail;
     }
 
-    result = newSuperLUObject(&A, option_dict, type, ilu);
+    result = newSuperLUObject(&A, option_dict, type, ilu, py_csc_construct_func);
     if (result == NULL) {
 	goto fail;
     }

--- a/scipy/sparse/linalg/dsolve/_superluobject.h
+++ b/scipy/sparse/linalg/dsolve/_superluobject.h
@@ -37,6 +37,7 @@ typedef struct {
     int *perm_c;
     PyObject *cached_U;
     PyObject *cached_L;
+    PyObject *py_csc_construct_func;
     int type;
 } SuperLUObject;
 
@@ -56,9 +57,10 @@ int NRFormat_from_spMatrix(SuperMatrix *, int, int, int, PyArrayObject *,
 int NCFormat_from_spMatrix(SuperMatrix *, int, int, int, PyArrayObject *,
 			   PyArrayObject *, PyArrayObject *, int);
 int LU_to_csc_matrix(SuperMatrix *L, SuperMatrix *U,
-                     PyObject **L_csc, PyObject **U_csc);
+                     PyObject **L_csc, PyObject **U_csc,
+                     PyObject *py_csc_construct_func);
 colperm_t superlu_module_getpermc(int);
-PyObject *newSuperLUObject(SuperMatrix *, PyObject *, int, int);
+PyObject *newSuperLUObject(SuperMatrix *, PyObject *, int, int, PyObject *);
 int set_superlu_options_from_dict(superlu_options_t * options,
 				  int ilu, PyObject * option_dict,
 				  int *panel_size, int *relax);

--- a/scipy/sparse/linalg/interface.py
+++ b/scipy/sparse/linalg/interface.py
@@ -47,7 +47,7 @@ import warnings
 import numpy as np
 
 from scipy.sparse import isspmatrix
-from scipy.sparse.sputils import isshape, isintlike, asmatrix
+from scipy.sparse.sputils import isshape, isintlike, asmatrix, is_pydata_spmatrix
 
 __all__ = ['LinearOperator', 'aslinearoperator']
 
@@ -801,7 +801,7 @@ def aslinearoperator(A):
         A = np.atleast_2d(np.asarray(A))
         return MatrixLinearOperator(A)
 
-    elif isspmatrix(A):
+    elif isspmatrix(A) or is_pydata_spmatrix(A):
         return MatrixLinearOperator(A)
 
     else:

--- a/scipy/sparse/linalg/tests/test_pydata_sparse.py
+++ b/scipy/sparse/linalg/tests/test_pydata_sparse.py
@@ -1,0 +1,226 @@
+import pytest
+
+import numpy as np
+import scipy.sparse as sp
+import scipy.sparse.linalg as splin
+
+from numpy.testing import assert_allclose
+
+try:
+    import sparse
+except ImportError:
+    sparse = None
+
+pytestmark = pytest.mark.skipif(sparse is None,
+                                reason="pydata/sparse not installed")
+
+
+def test_isolve_gmres():
+    # Several of the iterative solvers use the same
+    # isolve.utils.make_system wrapper code, so test just one of them.
+    np.random.seed(1234)
+
+    A = sparse.COO(np.random.rand(5, 5))
+    b = np.random.rand(5)
+
+    x, info = splin.gmres(A, b, atol=1e-15)
+    assert info == 0
+    assert isinstance(x, np.ndarray)
+    assert_allclose(A @ x, b)
+
+
+def test_lsmr():
+    np.random.seed(1234)
+
+    A_dense = np.random.rand(5, 5)
+    A = sparse.COO(A_dense)
+    b = np.random.rand(5)
+
+    res0 = splin.lsmr(A_dense, b)
+    res = splin.lsmr(A, b)
+    assert_allclose(res[0], res0[0])
+
+
+def test_lsqr():
+    np.random.seed(1234)
+
+    A_dense = np.random.rand(5, 5)
+    A = sparse.COO(A_dense)
+    b = np.random.rand(5)
+
+    res0 = splin.lsqr(A_dense, b)
+    res = splin.lsqr(A, b)
+    assert_allclose(res[0], res0[0])
+
+
+def test_eigs():
+    np.random.seed(1234)
+
+    A_dense = np.random.rand(10, 10)
+    A_dense = A_dense @ A_dense.T
+    A = sparse.COO(A_dense)
+
+    M_dense = np.random.rand(10, 10)
+    M_dense = M_dense @ M_dense.T
+    M = sparse.COO(M_dense)
+
+    v0 = np.random.rand(10)
+
+    w_dense, v_dense = splin.eigs(A_dense, k=3, v0=v0)
+    w, v = splin.eigs(A, k=3, v0=v0)
+
+    assert_allclose(w, w_dense)
+    assert_allclose(v, v_dense)
+
+    w_dense, v_dense = splin.eigs(A_dense, M=M_dense, k=3, v0=v0)
+    w, v = splin.eigs(A, M=M_dense, k=3, v0=v0)
+
+    assert_allclose(w, w_dense)
+    assert_allclose(v, v_dense)
+
+    w_dense, v_dense = splin.eigsh(A_dense, M=M_dense, k=3, v0=v0)
+    w, v = splin.eigsh(A, M=M_dense, k=3, v0=v0)
+
+    assert_allclose(w, w_dense)
+    assert_allclose(v, v_dense)
+
+
+def test_svds():
+    np.random.seed(1234)
+
+    A_dense = np.random.rand(10, 10)
+    A_dense = A_dense @ A_dense.T
+    A = sparse.COO(A_dense)
+
+    v0 = np.random.rand(10)
+
+    u0, s0, vt0 = splin.svds(A_dense, k=3, v0=v0)
+    u, s, vt = splin.svds(A, k=3, v0=v0)
+
+    assert_allclose(s, s0)
+    assert_allclose(u, u0)
+    assert_allclose(vt, vt0)
+
+
+def test_lobpcg():
+    np.random.seed(1234)
+
+    A_dense = np.random.rand(10, 10)
+    A_dense = A_dense @ A_dense.T
+    A = sparse.COO(A_dense)
+
+    X = np.random.rand(10, 1)
+
+    w_dense, v_dense = splin.lobpcg(A_dense, X)
+    w, v = splin.lobpcg(A, X)
+
+    assert_allclose(w, w_dense)
+    assert_allclose(v, v_dense)
+
+
+def test_spsolve():
+    np.random.seed(1234)
+
+    A_dense = np.random.rand(10, 10) + 10*np.eye(10)
+    A = sparse.COO(A_dense)
+
+    b = np.random.rand(10)
+    b2 = np.random.rand(10, 3)
+
+    x0 = splin.spsolve(sp.csc_matrix(A_dense), b)
+    x = splin.spsolve(A, b)
+    assert isinstance(x, np.ndarray)
+    assert_allclose(x, x0)
+
+    x0 = splin.spsolve(sp.csc_matrix(A_dense), b)
+    x = splin.spsolve(A, b, use_umfpack=True)
+    assert isinstance(x, np.ndarray)
+    assert_allclose(x, x0)
+
+    x0 = splin.spsolve(sp.csc_matrix(A_dense), b2)
+    x = splin.spsolve(A, b2)
+    assert isinstance(x, np.ndarray)
+    assert_allclose(x, x0)
+
+    x0 = splin.spsolve(sp.csc_matrix(A_dense),
+                       sp.csc_matrix(A_dense))
+    x = splin.spsolve(A, A)
+    assert isinstance(x, type(A))
+    assert_allclose(x.todense(), x0.todense())
+
+
+def test_splu():
+    # NB. spilu follows same code paths, so no need to test separately
+    np.random.seed(1234)
+
+    A_dense = np.random.rand(10, 10) + 10*np.eye(10)
+    A = sparse.COO(A_dense)
+    lu = splin.splu(A)
+
+    assert isinstance(lu.L, sparse.COO)
+    assert isinstance(lu.U, sparse.COO)
+
+    Pr = sparse.COO(sp.csc_matrix((np.ones(10), (lu.perm_r, np.arange(10)))))
+    Pc = sparse.COO(sp.csc_matrix((np.ones(10), (np.arange(10), lu.perm_c))))
+    A2 = Pr.T @ lu.L @ lu.U @ Pc.T
+
+    assert_allclose(A2.todense(), A.todense())
+
+    z = lu.solve(A.todense())
+    assert_allclose(z, np.eye(10), atol=1e-10)
+
+
+def test_spsolve_triangular():
+    np.random.seed(1234)
+
+    A_dense = np.tril(np.random.rand(10, 10) + 10*np.eye(10))
+    A = sparse.COO(A_dense)
+    b = np.random.rand(10)
+
+    x = splin.spsolve_triangular(A, b)
+    assert_allclose(A @ x, b)
+
+
+def test_onenormest():
+    np.random.seed(1234)
+
+    A_dense = np.random.rand(10, 10)
+    A = sparse.COO(A_dense)
+
+    est0 = splin.onenormest(A_dense)
+    est = splin.onenormest(A)
+    assert_allclose(est, est0)
+
+
+def test_inv():
+    np.random.seed(1234)
+
+    A_dense = np.random.rand(10, 10)
+    A = sparse.COO(A_dense)
+
+    x0 = splin.inv(sp.csc_matrix(A_dense))
+    x = splin.inv(A)
+    assert_allclose(x.todense(), x0.todense())
+
+
+def test_expm():
+    np.random.seed(1234)
+
+    A_dense = np.random.rand(10, 10)
+    A = sparse.COO(A_dense)
+
+    x0 = splin.expm(sp.csc_matrix(A_dense))
+    x = splin.expm(A)
+    assert_allclose(x.todense(), x0.todense())
+
+
+def test_expm_multiply():
+    np.random.seed(1234)
+
+    A_dense = np.random.rand(10, 10)
+    A = sparse.COO(A_dense)
+    b = np.random.rand(10)
+
+    x0 = splin.expm_multiply(A_dense, b)
+    x = splin.expm_multiply(A, b)
+    assert_allclose(x, x0)

--- a/scipy/sparse/linalg/tests/test_pydata_sparse.py
+++ b/scipy/sparse/linalg/tests/test_pydata_sparse.py
@@ -137,7 +137,6 @@ def test_spsolve(matrices):
 
 
 def test_splu(matrices):
-    # NB. spilu follows same code paths, so no need to test separately
     A_dense, A_sparse, b = matrices
     n = len(b)
     sparse_cls = type(A_sparse)
@@ -155,6 +154,19 @@ def test_splu(matrices):
 
     z = lu.solve(A_sparse.todense())
     assert_allclose(z, np.eye(n), atol=1e-10)
+
+
+def test_spilu(matrices):
+    A_dense, A_sparse, b = matrices
+    sparse_cls = type(A_sparse)
+
+    lu = splin.spilu(A_sparse)
+
+    assert isinstance(lu.L, sparse_cls)
+    assert isinstance(lu.U, sparse_cls)
+
+    z = lu.solve(A_sparse.todense())
+    assert_allclose(z, np.eye(len(b)), atol=1e-3)
 
 
 def test_spsolve_triangular(matrices):

--- a/scipy/sparse/linalg/tests/test_pydata_sparse.py
+++ b/scipy/sparse/linalg/tests/test_pydata_sparse.py
@@ -19,8 +19,7 @@ msg = "pydata/sparse (0.8) does not implement necessary operations"
 
 
 sparse_params = [pytest.param("COO"),
-                 pytest.param("DOK", marks=[pytest.mark.xfail(reason=msg)]),
-                 pytest.param("CSD", marks=[pytest.mark.xfail(reason=msg)])]
+                 pytest.param("DOK", marks=[pytest.mark.xfail(reason=msg)])]
 
 
 @pytest.fixture(params=sparse_params)

--- a/scipy/sparse/sputils.py
+++ b/scipy/sparse/sputils.py
@@ -3,6 +3,7 @@
 
 from __future__ import division, print_function, absolute_import
 
+import sys
 import operator
 import warnings
 import numpy as np
@@ -328,6 +329,14 @@ def check_reshape_kwargs(kwargs):
         raise TypeError('reshape() got unexpected keywords arguments: {}'
                         .format(', '.join(kwargs.keys())))
     return order, copy
+
+
+def is_pydata_spmatrix(m):
+    """
+    Check whether object is pydata/sparse matrix, avoiding importing the module.
+    """
+    base_cls = getattr(sys.modules.get('sparse'), 'SparseArray', None)
+    return base_cls is not None and isinstance(m, base_cls)
 
 
 ###############################################################################


### PR DESCRIPTION
Add support for https://github.com/pydata/sparse sparse matrices to scipy.sparse.linalg.

Although that package is not yet mature, basic support for it in scipy.sparse.linalg appears
to be fairly low-effort.

xref https://github.com/pydata/sparse/issues/293