### PR TITLE
BUG: sparse/linalg: fix expm for np.matrix inputs

### DIFF
--- a/scipy/sparse/linalg/matfuncs.py
+++ b/scipy/sparse/linalg/matfuncs.py
@@ -611,7 +611,7 @@ def _expm(A, use_exact_onenorm):
     # algorithms.
 
     # Avoid indiscriminate asarray() to allow sparse or other strange arrays.
-    if isinstance(A, (list, tuple)):
+    if isinstance(A, (list, tuple, np.matrix)):
         A = np.asarray(A)
     if len(A.shape) != 2 or A.shape[0] != A.shape[1]:
         raise ValueError('expected a square matrix')

--- a/scipy/sparse/linalg/tests/test_matfuncs.py
+++ b/scipy/sparse/linalg/tests/test_matfuncs.py
@@ -525,6 +525,17 @@ class TestExpM(object):
                 atol = 1e-13 * abs(expected).max()
                 assert_allclose(got, expected, atol=atol)
 
+    def test_matrix_input(self):
+        # Large np.matrix inputs should work, gh-5546
+        A = np.zeros((200, 200))
+        A[-1,0] = 1
+        B0 = expm(A)
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning, "the matrix subclass.*")
+            sup.filter(PendingDeprecationWarning, "the matrix subclass.*")
+            B = expm(np.matrix(A))
+        assert_allclose(B, B0)
+
 
 class TestOperators(object):
 


### PR DESCRIPTION
#### Reference issue
Closes: gh-5546

#### What does this implement/fix?
The expm implementation contains code that does not work with np.matrix (at least the MatrixPower linear operator part of it has _rmatvec that assumes self._A is ndarray). This is a minimal fix to avoid problems, by converting matrix inputs to ndarray.

#### Additional information
Expm returned np.ndarray output for np.matrix input also previously, so there's no behavior change.