### PR TITLE
ENH: warn user that quad() ignores `points=...` when `weight=...` is …

### DIFF
--- a/scipy/integrate/quadpack.py
+++ b/scipy/integrate/quadpack.py
@@ -112,7 +112,8 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
         A sequence of break points in the bounded integration interval
         where local difficulties of the integrand may occur (e.g.,
         singularities, discontinuities). The sequence does not have
-        to be sorted.
+        to be sorted. Note that this option cannot be used in conjunction
+        with ``weight``.
     weight : float or int, optional
         String indicating weighting function. Full explanation for this
         and the remaining arguments can be found below.
@@ -203,8 +204,8 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
     The input variables, *weight* and *wvar*, are used to weight the
     integrand by a select list of functions.  Different integration
     methods are used to compute the integral with these weighting
-    functions.  The possible values of weight and the corresponding
-    weighting functions are.
+    functions, and these do not support specifying break points. The
+    possible values of weight and the corresponding weighting functions are.
 
     ==========  ===================================   =====================
     ``weight``  Weight function used                  ``wvar``
@@ -340,6 +341,10 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
         retval = _quad(func, a, b, args, full_output, epsabs, epsrel, limit,
                        points)
     else:
+        if points is not None:
+            msg = ("Break points cannot be specified when using weighted integrand.\n"
+                   "Continuing, ignoring specified points.")
+            warnings.warn(msg, IntegrationWarning, stacklevel=2)
         retval = _quad_weight(func, a, b, args, full_output, epsabs, epsrel,
                               limlst, limit, maxp1, weight, wvar, wopts)
 


### PR DESCRIPTION
…specified


<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?

integrate.quad() allows user to specify points of local difficulty (`points=...`)
and a weighting function (`weight=...`). These are handled by different quadpack
routines and are mutually exclusive. However this was not explicit in the docstrings.
Providing both resulted in points of local difficulty being silently ignored.

Updated docstrings to reflect this; added code to display warning message if
both options are provided. Otherwise behaviour remains unchanged: we attempt
to evaluate weighted integrand without reference to breakpoints.

#### Additional information
<!--Any additional information you think is important.-->