### PR TITLE
CI: fix Travis CI py3.8 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ matrix:
     - python: 3.8-dev
       env:
         - TESTMODE=fast
-        - NUMPYSPEC="numpy"
+        - NUMPYSPEC="--pre --upgrade --timeout=60 -f $PRE_WHEELS numpy"
     - python: 3.6
       env:
         - TESTMODE=fast


### PR DESCRIPTION
Switch py3.8 numpy to dev version.  Previously, the build used some
Travis-supplied Numpy dev version, which occasionally has bugs and
updates on an unknown schedule.

For some reason, numpy==1.17.2 results to a test failure in TestLIL.test_dot
(spurious nan appearing in pure-numpy computed results, so seems to be
a numpy bug for py3.8 + 1.17.2).