### PR TITLE
ENH: scipy.sparse.lil: tocsr accelerated

### DIFF
--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -451,13 +451,11 @@ class lil_matrix(spmatrix, IndexMixin):
 
     def tocsr(self, copy=False):
         lst = [len(x) for x in self.rows]
-        indptr_dtype = get_index_dtype(maxval=sum(lst))
-        indptr = np.cumsum([0] + lst, dtype=indptr_dtype)
+        idx_dtype = get_index_dtype(maxval=max(self.shape[1], sum(lst)))
+        indptr = np.cumsum([0] + lst, dtype=idx_dtype)
+        indices = np.empty(indptr[-1], dtype=idx_dtype)
+        data = np.empty(indptr[-1], dtype=self.dtype)
 
-        indices_dtype = get_index_dtype(maxval=self.shape[1])
-        data_dtype = self.dtype
-        indices = np.empty(indptr[-1], indices_dtype)
-        data = np.empty(indptr[-1], data_dtype)
         start = 0
         for stop, indices_i, data_i in zip(indptr[1:], self.rows, self.data):
             indices[start:stop] = indices_i


### PR DESCRIPTION
This PR accelerates the `tocsr` method of the `lil_matrix` in `scipy.sparse` by about 35%. This also accelerates other methods of the `lil_matrix` which use `tocsr`.