### PR TITLE
BUG: Forbid passing 'args' as kwarg in scipy.optimize.curve_fit

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -219,6 +219,7 @@ Andrew Knyazev, the original author of LOBPCG, for advice on and maintenance of
    sparse.linalg.lobpcg
 Michael Marien for contributing to scipy.stats.entropy
 Joseph Weston for a bug fix in scipy.optimize.zeros.
+Peyton Murray for a bug fix in scipy.optimize.curve_fit.
 
 Institutions
 ------------

--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -751,6 +751,12 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
     elif jac is None and method != 'lm':
         jac = '2-point'
 
+    if 'args' in kwargs:
+        # The specification for the model function `f` does not support
+        # additional arguments. Refer to the `curve_fit` docstring for
+        # acceptable call signatures of `f`.
+        raise ValueError("'args' is not an acceptable keyword argument.")
+
     if method == 'lm':
         # Remove full_output from kwargs, otherwise we're passing it in twice.
         return_full = kwargs.pop('full_output', False)

--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -755,7 +755,7 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
         # The specification for the model function `f` does not support
         # additional arguments. Refer to the `curve_fit` docstring for
         # acceptable call signatures of `f`.
-        raise ValueError("'args' is not an acceptable keyword argument.")
+        raise ValueError("'args' is not a supported keyword argument.")
 
     if method == 'lm':
         # Remove full_output from kwargs, otherwise we're passing it in twice.

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -801,7 +801,7 @@ class TestCurveFit(object):
         def func(x, a, b):
             return a * x + b
 
-        with assert_raises(ValueError) as exc_info:
+        with assert_raises(ValueError):
             curve_fit(func,
                       xdata=[1, 2, 3, 4],
                       ydata=[5, 9, 13, 17],

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -25,6 +25,7 @@ class ReturnShape(object):
     __init__ takes the argument 'shape', which should be a tuple of ints.  When an instance
     it called with a single argument 'x', it returns numpy.ones(shape).
     """
+
     def __init__(self, shape):
         self.shape = shape
 
@@ -431,6 +432,7 @@ class TestCurveFit(object):
             """This class tests if curve_fit passes the correct number of
                arguments when the model function is a class instance method.
             """
+
             def func(self, x, a, b):
                 return b * x**a
 
@@ -792,6 +794,19 @@ class TestCurveFit(object):
                                      ydata=0,
                                      method=method)
             assert_allclose(pcov0, pcov1)
+
+    def test_args_in_kwargs(self):
+        # Ensure that `args` cannot be passed as keyword argument to `curve_fit`
+
+        def func(x, a, b):
+            return a * x + b
+
+        with assert_raises(ValueError) as exc_info:
+            curve_fit(func,
+                      xdata=[1, 2, 3, 4],
+                      ydata=[5, 9, 13, 17],
+                      p0=[1],
+                      args=(1,))
 
 
 class TestFixedPoint(object):


### PR DESCRIPTION
#### Reference issue
Addresses #5502.

#### What does this implement/fix?
Raise an exception when 'args' is passed as a keyword argument to scipy.optimize.curve_fit. I also added a test to make sure that the exception is raised as expected.