### PR TITLE
added error message in fallback to matvec failure

### DIFF
--- a/scipy/sparse/linalg/interface.py
+++ b/scipy/sparse/linalg/interface.py
@@ -181,8 +181,8 @@ class LinearOperator(object):
         try:
             return np.hstack([self.matvec(col.reshape(-1,1)) for col in X.T])
         except ValueError:
-            raise ValueError('The user-defined matvec(v) function must properly
-                             handle the case where v has shape (N,1).')
+            raise ValueError("""The user-defined matvec(v) function must properly
+                             handle the case where v has shape (N,1).""")
 
     def _matvec(self, x):
         """Default matrix-vector multiplication handler.

--- a/scipy/sparse/linalg/interface.py
+++ b/scipy/sparse/linalg/interface.py
@@ -181,8 +181,12 @@ class LinearOperator(object):
         try:
             return np.hstack([self.matvec(col.reshape(-1,1)) for col in X.T])
         except ValueError:
-            raise ValueError('The user-defined matvec(v) function must properly'
-                             'handle the case where v has shape (N,1).')
+            col = X.T[:,0]
+            matvec_col = self.matvec(col.reshape(-1,1))
+            raise ValueError('The user-defined matvec(v) function must return'
+                             'shape (N,1) if v has shape (N,1). Instead,'
+                             'matvec(v) has shape %r, where v has shape %r.' 
+                             % (matvec_col.shape, col.shape))
 
     def _matvec(self, x):
         """Default matrix-vector multiplication handler.

--- a/scipy/sparse/linalg/interface.py
+++ b/scipy/sparse/linalg/interface.py
@@ -178,8 +178,11 @@ class LinearOperator(object):
         Falls back on the user-defined _matvec method, so defining that will
         define matrix multiplication (though in a very suboptimal way).
         """
-
-        return np.hstack([self.matvec(col.reshape(-1,1)) for col in X.T])
+        try:
+            return np.hstack([self.matvec(col.reshape(-1,1)) for col in X.T])
+        except ValueError:
+            raise ValueError('The user-defined matvec(v) function must properly
+                             handle the case where v has shape (N,1).')
 
     def _matvec(self, x):
         """Default matrix-vector multiplication handler.

--- a/scipy/sparse/linalg/interface.py
+++ b/scipy/sparse/linalg/interface.py
@@ -181,8 +181,8 @@ class LinearOperator(object):
         try:
             return np.hstack([self.matvec(col.reshape(-1,1)) for col in X.T])
         except ValueError:
-            raise ValueError("""The user-defined matvec(v) function must properly
-                             handle the case where v has shape (N,1).""")
+            raise ValueError('The user-defined matvec(v) function must properly'
+                             'handle the case where v has shape (N,1).')
 
     def _matvec(self, x):
         """Default matrix-vector multiplication handler.

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -452,3 +452,24 @@ def test_transpose_noconjugate():
 
     assert_equal(B.dot(v), Y.dot(v))
     assert_equal(B.T.dot(v), Y.T.dot(v))
+
+def test_matmat_fallback_to_matvec_error():
+    dim = 2
+    shp = (dim, dim)
+    eye_matrix = np.eye(dim)
+    x = np.arange(dim)
+
+    def mv(y):
+        return x*y
+    def mm(z):
+        return x*z
+    def mm_via_mv(z):
+       return np.array([mv(y) for y in z.T])
+
+    LO_with_mm = LinearOperator(shp, matvec=mv, matmat=mm)
+    assert_equal(LO_with_mm.matmat(eye_matrix), np.diagflat(x))
+    LO_with_mm_via_mv = LinearOperator(shp, matvec=mv, matmat=mm_via_mv)
+    assert_equal(LO_with_mm_via_mv.matmat(eye_matrix), np.diagflat(x))
+
+    LO_withot_mm = LinearOperator(shp, matvec=mv)
+    mm_test = LO_withot_mm.matmat(eye_matrix)

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -461,15 +461,21 @@ def test_matmat_fallback_to_matvec_error():
 
     def mv(y):
         return x*y
+
     def mm(z):
         return x*z
-    def mm_via_mv(z):
-       return np.array([mv(y) for y in z.T])
 
-    LO_with_mm = LinearOperator(shp, matvec=mv, matmat=mm)
+    def mm_via_mv(z):
+        return np.array([mv(y) for y in z.T])
+
+    LO_with_mm = interface.LinearOperator(shp, matvec=mv, matmat=mm)
     assert_equal(LO_with_mm.matmat(eye_matrix), np.diagflat(x))
-    LO_with_mm_via_mv = LinearOperator(shp, matvec=mv, matmat=mm_via_mv)
+
+    LO_with_mm_via_mv = interface.LinearOperator(shp, matvec=mv, matmat=mm_via_mv)
     assert_equal(LO_with_mm_via_mv.matmat(eye_matrix), np.diagflat(x))
 
-    LO_withot_mm = LinearOperator(shp, matvec=mv)
-    mm_test = LO_withot_mm.matmat(eye_matrix)
+    string_expected = ('The user-defined matvec(v) function must return'
+                             'shape (N,1) if v has shape (N,1). Instead,'
+                             'matvec(v) has shape [1,2], where v has shape [2,1].') 
+    LO_withot_mm = interface.LinearOperator(shp, matvec=mv)
+    assert_equal(LO_withot_mm.matmat(eye_matrix), string_expected)


### PR DESCRIPTION
#### Reference issue
Closes https://github.com/scipy/scipy/issues/8444

#### What does this implement/fix?
added specific error message when sparse.linalg.LinearOperator.matmat cannot fallback properly to matvec, an extended version of
```
        try:
            return np.hstack([self.matvec(col.reshape(-1,1)) for col in X.T])
        except ValueError:
            raise ValueError('The user-defined matvec(v) function must properly'
                                      'handle the case where v has shape (N,1).')
```