### PR TITLE
MAINT: Updates for 3.8

### DIFF
--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -1,10 +1,8 @@
 # Pytest customization
 from __future__ import division, absolute_import, print_function
 
-import gc
 import os
 import pytest
-import sys
 import warnings
 
 from distutils.version import LooseVersion
@@ -46,19 +44,3 @@ def check_fpu_mode(request):
         warnings.warn("FPU mode changed from {0:#x} to {1:#x} during "
                       "the test".format(old_mode, new_mode),
                       category=FPUModeChangeWarning, stacklevel=0)
-
-
-@pytest.fixture
-def pool():
-    """Fixture for tests that use MapWrapper (not as a context manager)."""
-    # See https://bugs.python.org/issue38501
-    # We only need to decorate tests that do not use `with mapwrapper:`
-    # because the problem occurs when close/terminate are not explicitly
-    # called, and garbage collection is supposed to take care of it.
-    if sys.version_info >= (3, 8):
-        pytest.xfail('Python 3.8 hangs when cleaning up a pool')
-    yield
-    # Clean up immediately after the test to trigger the problem.
-    # This way, any problems occur in the given test rather than potentially
-    # mysteriously later, e.g., in the `sparse` test that does gc.collect().
-    gc.collect()

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -48,9 +48,9 @@ def check_fpu_mode(request):
                       category=FPUModeChangeWarning, stacklevel=0)
 
 
-@pytest.yield_fixture(scope="module")
+@pytest.fixture
 def pool():
-    """Fixture for tests that use multiprocessing.pool."""
+    """Fixture for tests that use MapWrapper (not as a context manager)."""
     # See https://bugs.python.org/issue38501
     # We only need to decorate tests that do not use `with mapwrapper:`
     # because the problem occurs when close/terminate are not explicitly
@@ -58,4 +58,7 @@ def pool():
     if sys.version_info >= (3, 8):
         pytest.xfail('Python 3.8 hangs when cleaning up a pool')
     yield
-    gc.collect()  # clean up
+    # Clean up immediately after the test to trigger the problem.
+    # This way, any problems occur in the given test rather than potentially
+    # mysteriously later, e.g., in the `sparse` test that does gc.collect().
+    gc.collect()

--- a/scipy/io/netcdf.py
+++ b/scipy/io/netcdf.py
@@ -767,7 +767,7 @@ class netcdf_file(object):
         values = self.fp.read(int(count))
         self.fp.read(-count % 4)  # read padding
 
-        if typecode is not 'c':
+        if typecode != 'c':
             values = frombuffer(values, dtype='>%s' % typecode).copy()
             if values.shape == (1,):
                 values = values[0]
@@ -1095,4 +1095,3 @@ class netcdf_variable(object):
 
 NetCDFFile = netcdf_file
 NetCDFVariable = netcdf_variable
-

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -1,7 +1,9 @@
 """
 Unit tests for the differential global minimization algorithm.
 """
+import gc
 import multiprocessing
+import sys
 
 from scipy.optimize._differentialevolution import (DifferentialEvolutionSolver,
                                                    _ConstraintWrapper)
@@ -17,6 +19,11 @@ from numpy.testing import (assert_equal, assert_allclose,
                            assert_string_equal, assert_)
 from pytest import raises as assert_raises, warns
 import pytest
+
+
+knownfail_on_py38 = pytest.mark.xfail(
+    sys.version_info >= (3, 8), run=False,
+    reason='Python 3.8 hangs when cleaning up MapWrapper')
 
 
 class TestDifferentialEvolutionSolver(object):
@@ -527,7 +534,8 @@ class TestDifferentialEvolutionSolver(object):
         assert_(solver._mapwrapper._mapfunc is map)
         solver.solve()
 
-    def test_immediate_updating(self, pool):
+    @knownfail_on_py38
+    def test_immediate_updating(self):
         # check setting of immediate updating, with default workers
         bounds = [(0., 2.), (0., 2.)]
         solver = DifferentialEvolutionSolver(rosen, bounds)
@@ -538,8 +546,11 @@ class TestDifferentialEvolutionSolver(object):
         with warns(UserWarning):
             solver = DifferentialEvolutionSolver(rosen, bounds, workers=2)
         assert_(solver._updating == 'deferred')
+        del solver
+        gc.collect()  # ensure MapWrapper cleans up properly
 
-    def test_parallel(self, pool):
+    @knownfail_on_py38
+    def test_parallel(self):
         # smoke test for parallelisation with deferred updating
         bounds = [(0., 2.), (0., 2.)]
         with multiprocessing.Pool(2) as p, DifferentialEvolutionSolver(
@@ -553,6 +564,8 @@ class TestDifferentialEvolutionSolver(object):
             assert_(solver._mapwrapper.pool is not None)
             assert_(solver._updating == 'deferred')
             solver.solve()
+        del solver
+        gc.collect()  # ensure MapWrapper cleans up properly
 
     def test_converged(self):
         solver = DifferentialEvolutionSolver(rosen, [(0, 2), (0, 2)])

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -3,10 +3,9 @@ Unit tests for the differential global minimization algorithm.
 """
 import multiprocessing
 
-from scipy.optimize import _differentialevolution
 from scipy.optimize._differentialevolution import (DifferentialEvolutionSolver,
                                                    _ConstraintWrapper)
-from scipy.optimize import differential_evolution, minimize
+from scipy.optimize import differential_evolution
 from scipy.optimize._constraints import (Bounds, NonlinearConstraint,
                                          LinearConstraint)
 from scipy.optimize import rosen
@@ -528,7 +527,7 @@ class TestDifferentialEvolutionSolver(object):
         assert_(solver._mapwrapper._mapfunc is map)
         solver.solve()
 
-    def test_immediate_updating(self):
+    def test_immediate_updating(self, pool):
         # check setting of immediate updating, with default workers
         bounds = [(0., 2.), (0., 2.)]
         solver = DifferentialEvolutionSolver(rosen, bounds)
@@ -538,9 +537,9 @@ class TestDifferentialEvolutionSolver(object):
         # is being overridden by the workers keyword
         with warns(UserWarning):
             solver = DifferentialEvolutionSolver(rosen, bounds, workers=2)
-            assert_(solver._updating == 'deferred')
+        assert_(solver._updating == 'deferred')
 
-    def test_parallel(self):
+    def test_parallel(self, pool):
         # smoke test for parallelisation with deferred updating
         bounds = [(0., 2.), (0., 2.)]
         with multiprocessing.Pool(2) as p, DifferentialEvolutionSolver(

--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -694,7 +694,7 @@ def _bin_numbers(sample, nbin, edges, dedges):
         # Find the rounding precision
         try:
             decimal = int(-np.log10(dedges[i].min())) + 6
-        except RuntimeWarning:
+        except exceptions:
             raise ValueError('The smallest edge difference is numerically 0.')
         # Find which points are on the rightmost edge.
         on_edge = np.where(np.around(sample[:, i], decimal) ==

--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -1,5 +1,7 @@
 from __future__ import division, print_function, absolute_import
 
+import sys
+
 import numpy as np
 from scipy._lib.six import callable, xrange
 from scipy._lib._numpy_compat import suppress_warnings
@@ -685,6 +687,9 @@ def _bin_numbers(sample, nbin, edges, dedges):
     # Using `digitize`, values that fall on an edge are put in the right bin.
     # For the rightmost bin, we want values equal to the right
     # edge to be counted in the last bin, and not as an outlier.
+    exceptions = (RuntimeWarning,)
+    if sys.version_info >= (3, 8):
+        exceptions += (OverflowError,)  # Python3.8 int(np.inf) throws this
     for i in xrange(Ndim):
         # Find the rounding precision
         try:

--- a/scipy/stats/tests/test_binned_statistic.py
+++ b/scipy/stats/tests/test_binned_statistic.py
@@ -471,5 +471,5 @@ class TestBinnedStatistic(object):
         bins = np.linspace(0, 1, 10)
         bins = np.append(bins, 1)
         bins = (bins, bins, bins)
-        assert_raises(ValueError, binned_statistic_dd,
-                      x, v, 'mean', bins=bins)
+        with assert_raises(ValueError, match='difference is numerically 0'):
+            binned_statistic_dd(x, v, 'mean', bins=bins)


### PR DESCRIPTION
Fixes two errors when running 3.8, one with `"is" with a literal. Did you mean "=="?` and another where `int(np.inf)` throws a different error type.