### PR TITLE
MAINT: Bump CircleCI Python version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     docker:
       # CircleCI maintains a library of pre-built images
       # documented at https://circleci.com/docs/2.0/circleci-images/
-      - image: circleci/python:3.7.0
+      - image: circleci/python:3.7.3
 
     working_directory: ~/repo
 


### PR DESCRIPTION
Should fix https://circleci.com/gh/scipy/scipy/15626 by using an image from the CircleCI image list.