### PR TITLE
MAINT: Add Python 3.8 to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,11 @@ requires = [
     "Cython>=0.29.2",
     "numpy==1.13.3; python_version=='3.5' and platform_system!='AIX'",
     "numpy==1.13.3; python_version=='3.6' and platform_system!='AIX'",
-    "numpy==1.14.5; python_version>='3.7' and platform_system!='AIX'",
+    "numpy==1.14.5; python_version=='3.7' and platform_system!='AIX'",
+    "numpy==1.17.3; python_version>='3.8' and platform_system!='AIX'",
     "numpy==1.16.0; python_version=='3.5' and platform_system=='AIX'",
     "numpy==1.16.0; python_version=='3.6' and platform_system=='AIX'",
-    "numpy==1.16.0; python_version>='3.7' and platform_system=='AIX'",
+    "numpy==1.16.0; python_version=='3.7' and platform_system=='AIX'",
+    "numpy==1.17.3; python_version>='3.8' and platform_system=='AIX'",
     "pybind11>=2.2.4",
 ]


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->


<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

Numpy 1.17.3 has now been released, with support for Python 3.8. 

This pull request adds Python 3.8 to `pyproject.toml` with Numpy 1.17.3.


<!--Any additional information you think is important.-->