### PR TITLE
MAINT: add hotfix for wheel build fail, for context->gh PR #10861

### DIFF
--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -690,10 +690,11 @@ def _bin_numbers(sample, nbin, edges, dedges):
     # Using `digitize`, values that fall on an edge are put in the right bin.
     # For the rightmost bin, we want values equal to the right
     # edge to be counted in the last bin, and not as an outlier.
-    exceptions = (RuntimeWarning,)
+    exceptions = (RuntimeWarning, OverflowError, FloatingPointError)
     if sys.version_info >= (3, 8):
         exceptions += (OverflowError,)  # Python3.8 int(np.inf) throws this
     for i in xrange(Ndim):
+        with np.errstate(divide='raise'):
         # Find the rounding precision
         try:
             decimal = int(-np.log10(dedges[i].min())) + 6

--- a/scipy/stats/tests/test_binned_statistic.py
+++ b/scipy/stats/tests/test_binned_statistic.py
@@ -481,5 +481,5 @@ class TestBinnedStatistic(object):
         bins = np.linspace(0, 1, 10)
         bins = np.append(bins, 1)
         bins = (bins, bins, bins)
-        with assert_raises(ValueError, match='difference is numerically 0'):
-            binned_statistic_dd(x, v, 'mean', bins=bins)
+        assert_raises(FloatingPointError, binned_statistic_dd, x, v, 'mean',
+                bins=bins)


### PR DESCRIPTION
#### Reference issue
See the discussion at the end of PR #10861  for context. 

#### What does this implement/fix?
The merge of the `reuse` feature of `binned_statistic_dd()` broke the wheel build.
This PR would (maybe/hopefully) fix the intermittent failure. 

#### Additional information
The feature enhancement PR (e.g. #10861) added a unit test which is supposed to catch the edge case when 2 bin edges have a numerically 0.0 edge case. 
@rgommers noted that the change causes some intermittent errors in the wheel build.
The log of the build fail is here: 
https://travis-ci.org/MacPython/scipy-wheels/jobs/596997894
Let's see if the PR fixes.