### PR TITLE
BLD: update Cython version to 0.29.13

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ jobs:
            curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
            python3.6 get-pip.py && \
            pip3 --version && \
-           pip3 install setuptools wheel numpy cython==0.29.2 pybind11 pytest pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath matplotlib --user && \
+           pip3 install setuptools wheel numpy cython==0.29.13 pybind11 pytest pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath matplotlib --user && \
            apt-get -y install gfortran-5 wget && \
            cd .. && \
            mkdir openblas && cd openblas && \
@@ -106,7 +106,7 @@ jobs:
       choco install -y mingw --force --version=6.4.0
     displayName: 'Install 64-bit mingw for 64-bit builds'
     condition: eq(variables['BITS'], 64)
-  - script: python -m pip install numpy cython==0.29.2 pybind11 pytest pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath matplotlib
+  - script: python -m pip install numpy cython==0.29.13 pybind11 pytest pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath matplotlib
     displayName: 'Install dependencies'
   - powershell: |
       If ($(BITS) -eq 32) {

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -29,7 +29,7 @@
     "matrix": {
         "numpy": [],
         "Tempita": [],
-        "Cython": ["0.29.2"],
+        "Cython": ["0.29.13"],
         "pytest": [],
         "pybind11": [],
         "six": [],

--- a/doc/source/toolchain.rst
+++ b/doc/source/toolchain.rst
@@ -173,7 +173,7 @@ SciPy always requires a recent Cython compiler.
 ======== ============ ===============
  Tool    Tool Version  SciPy version
 ======== ============ ===============
-Cython     >= 0.29.2   1.2.1
+Cython     >= 0.29.13  1.2.1
 ======== ============ ===============
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "wheel",
     "setuptools",
-    "Cython>=0.29.2",
+    "Cython>=0.29.13",
     "numpy==1.13.3; python_version=='3.5' and platform_system!='AIX'",
     "numpy==1.13.3; python_version=='3.6' and platform_system!='AIX'",
     "numpy==1.14.5; python_version=='3.7' and platform_system!='AIX'",


### PR DESCRIPTION
Needed for Python 3.8 support.  Bump uniformly for all supported
Python versions to keep things simple.

This is a follow-up to gh-10938
