### PR TITLE
BUG: setting verbose > 2 in minimize with trust-constr method leads to TypeError closes 10880

### DIFF
--- a/scipy/optimize/_trustregion_constr/report.py
+++ b/scipy/optimize/_trustregion_constr/report.py
@@ -17,6 +17,12 @@ class ReportBase(object):
 
     @classmethod
     def print_iteration(cls, *args):
+        # args[3] is obj func. It should really be a float. However,
+        # trust-constr typically provides a length 1 array. We have to coerce
+        # it to a float otherwise the string format doesn't work.
+        args = list(args)
+        args[3] = float(args[3])
+
         iteration_format = ["{{:{}}}".format(x) for x in cls.ITERATION_FORMATS]
         fmt = "|" + "|".join(iteration_format) + "|"
         print(fmt.format(*args))

--- a/scipy/optimize/_trustregion_constr/tests/test_report.py
+++ b/scipy/optimize/_trustregion_constr/tests/test_report.py
@@ -9,8 +9,8 @@ from scipy.optimize import minimize, Bounds
 def test_gh10880():
     # checks that verbose reporting works with trust-constr
     bnds = Bounds(1, 2)
-    opts = {'maxiter' : 1000, 'verbose' : 2}
+    opts = {'maxiter': 1000, 'verbose': 2}
     res = minimize(lambda x: x**2, x0=2., method='trust-constr', bounds=bnds, options=opts)
 
-    opts = {'maxiter' : 1000, 'verbose' : 3}
+    opts = {'maxiter': 1000, 'verbose': 3}
     res = minimize(lambda x: x**2, x0=2., method='trust-constr', bounds=bnds, options=opts)

--- a/scipy/optimize/_trustregion_constr/tests/test_report.py
+++ b/scipy/optimize/_trustregion_constr/tests/test_report.py
@@ -1,0 +1,16 @@
+import numpy as np
+from numpy.testing import (TestCase, assert_array_almost_equal,
+                           assert_array_equal, assert_array_less,
+                           assert_raises, assert_equal, assert_,
+                           run_module_suite, assert_allclose, assert_warns,
+                           dec)
+from scipy.optimize import minimize, Bounds
+
+def test_gh10880():
+    # checks that verbose reporting works with trust-constr
+    bnds = Bounds(1, 2)
+    opts = {'maxiter' : 1000, 'verbose' : 2}
+    res = minimize(lambda x: x**2, x0=2., method='trust-constr', bounds=bnds, options=opts)
+
+    opts = {'maxiter' : 1000, 'verbose' : 3}
+    res = minimize(lambda x: x**2, x0=2., method='trust-constr', bounds=bnds, options=opts)


### PR DESCRIPTION
#10880 shows that setting verbose >= 2 in minimize with trust-constr method leads to TypeError.
The report printing done by trust-constr when verbose >=2 involves printing the function value. However, trust-constr returns a length 1 array and the formatting fails because it is expecting a float.
This PR fixes that error by coercing the length 1 array to a float.