### PR TITLE
DOC: fixed Ricker wavelet formula

### DIFF
--- a/scipy/signal/wavelets.py
+++ b/scipy/signal/wavelets.py
@@ -266,9 +266,9 @@ def ricker(points, a):
 
     It models the function:
 
-        ``A (1 - x^2/a^2) exp(-x^2/2 a^2)``,
+        ``A * (1 - (x/a)**2) * exp(-0.5*(x/a)**2)``,
 
-    where ``A = 2/sqrt(3a)pi^1/4``.
+    where ``A = 2/(sqrt(3a)*(pi**1/4))``.
 
     Parameters
     ----------


### PR DESCRIPTION
- equations are one-lined in website documentation, making the
  fractions false by the absence of parenthesis;
- to follow the convention from other docstrings, exponentiation is put
  in Python-formatted form instead of LaTeX one;
- in the same spirit, implicit multiplication is avoided,
  and some other minor changes are made for cosmetic purposes;