### PR TITLE
BUG: special: fix `factorial` return type for 0-d inputs

### DIFF
--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2139,6 +2139,9 @@ def factorial(n, exact=False):
                     out[n == current] = val
             return out
     else:
+        if np.ndim(n) == 0:
+            return 0 if n < 0 else gamma(n + 1)
+
         n = asarray(n)
         vals = gamma(n + 1)
         return where(n >= 0, vals, 0)

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1818,6 +1818,15 @@ class TestFactorialFunctions(object):
             assert_array_equal(special.factorial([n], True),
                                special.factorial([n], False))
 
+    @pytest.mark.parametrize('x, exact', [
+        (1, True),
+        (1, False),
+        (np.array(1), True),
+        (np.array(1), False),
+    ])
+    def test_factorial_0d_return_type(self, x, exact):
+        assert np.isscalar(special.factorial(x, exact=exact))
+
     def test_factorial2(self):
         assert_array_almost_equal([105., 384., 945.],
                                   special.factorial2([7, 8, 9], exact=False))


### PR DESCRIPTION
#### Reference issue

Closes gh-7400.

#### What does this implement/fix?

The return type of `special.factorial` is changed to be a scalar for 0-d inputs.

#### Additional information

This should make the function consistent with other ufuncs, e.g.

```python
>>> import numpy as np
>>> np.sin(np.array(1.0))
0.8414709848078965
>>> np.sin(1.0)
0.8414709848078965
```