### PR TITLE
WIP: make pdtr(int, double) be pdtr(double, double)

### DIFF
--- a/scipy/special/_cephes.pxd
+++ b/scipy/special/_cephes.pxd
@@ -68,7 +68,7 @@ cdef extern from "cephes.h" nogil:
     double erf(double x)
     double ndtri(double y0)
     double pdtrc(int k, double m)
-    double pdtr(int k, double m)
+    double pdtr(double k, double m)
     double pdtri(int k, double y)
     double poch(double x, double m)
     double psi(double x)

--- a/scipy/special/_cephes.pxd
+++ b/scipy/special/_cephes.pxd
@@ -67,7 +67,7 @@ cdef extern from "cephes.h" nogil:
     double erfc(double a)
     double erf(double x)
     double ndtri(double y0)
-    double pdtrc(int k, double m)
+    double pdtrc(double k, double m)
     double pdtr(double k, double m)
     double pdtri(int k, double y)
     double poch(double x, double m)

--- a/scipy/special/_legacy.pxd
+++ b/scipy/special/_legacy.pxd
@@ -18,7 +18,7 @@ cdef extern from "numpy/npy_math.h" nogil:
     double nan "NPY_NAN"
 
 from ._cephes cimport (bdtrc, bdtr, bdtri, expn, nbdtrc,
-                       nbdtr, nbdtri, pdtrc, pdtr, pdtri, kn, yn,
+                       nbdtr, nbdtri, pdtri, kn, yn,
                        smirnov, smirnovi, smirnovc, smirnovci, smirnovp)
 
 cdef extern from "amos_wrappers.h":
@@ -91,18 +91,6 @@ cdef inline double nbdtri_unsafe(double k, double n, double p) nogil:
         return nan
     _legacy_cast_check("nbdtri", k, n)
     return nbdtri(<int>k, <int>n, p)
-
-cdef inline double pdtrc_unsafe(double k, double m) nogil:
-    if npy_isnan(k):
-        return k
-    _legacy_cast_check("pdtrc", k, 0)
-    return pdtrc(<int>k, m)
-
-cdef inline double pdtr_unsafe(double k, double m) nogil:
-    if npy_isnan(k):
-        return k
-    _legacy_cast_check("pdtr", k, 0)
-    return pdtr(<int>k, m)
 
 cdef inline double pdtri_unsafe(double k, double y) nogil:
     if npy_isnan(k):

--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -7044,7 +7044,7 @@ add_newdoc("pdtr",
 
     Returns the sum of the first `k` terms of the Poisson distribution:
     sum(exp(-m) * m**j / j!, j=0..k) = gammaincc( k+1, m).  Arguments
-    must both be positive and `k` an integer.
+    must both be positive doubles.
     """)
 
 add_newdoc("pdtrc",

--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -7044,7 +7044,7 @@ add_newdoc("pdtr",
 
     Returns the sum of the first `k` terms of the Poisson distribution:
     sum(exp(-m) * m**j / j!, j=0..k) = gammaincc( k+1, m).  Arguments
-    must both be positive doubles.
+    must both be non-negative doubles.
     """)
 
 add_newdoc("pdtrc",
@@ -7055,7 +7055,7 @@ add_newdoc("pdtrc",
 
     Returns the sum of the terms from k+1 to infinity of the Poisson
     distribution: sum(exp(-m) * m**j / j!, j=k+1..inf) = gammainc(
-    k+1, m).  Arguments must both be positive and `k` an integer.
+    k+1, m).  Arguments must both be non-negative doubles.
     """)
 
 add_newdoc("pdtri",

--- a/scipy/special/cephes.h
+++ b/scipy/special/cephes.h
@@ -95,7 +95,7 @@ extern double erf(double x);
 extern double ndtri(double y0);
 
 extern double pdtrc(int k, double m);
-extern double pdtr(int k, double m);
+extern double pdtr(double k, double m);
 extern double pdtri(int k, double y);
 
 extern double poch(double x, double m);

--- a/scipy/special/cephes.h
+++ b/scipy/special/cephes.h
@@ -94,7 +94,7 @@ extern double erfc(double a);
 extern double erf(double x);
 extern double ndtri(double y0);
 
-extern double pdtrc(int k, double m);
+extern double pdtrc(double k, double m);
 extern double pdtr(double k, double m);
 extern double pdtri(int k, double y);
 

--- a/scipy/special/cephes/pdtr.c
+++ b/scipy/special/cephes/pdtr.c
@@ -145,20 +145,18 @@ double m;
 }
 
 
-double pdtr(k, m)
-int k;
-double m;
+double pdtr(double k, double m)
 {
     double v;
 
-    if ((k < 0) || (m < 0.0)) {
+    if ( k < 0.0 || m < 0.0 ) {
         sf_error("pdtr", SF_ERROR_DOMAIN, NULL);
         return (NPY_NAN);
     }
     if (m == 0.0) {
         return 1.0;
     }
-    v = k + 1;
+    v = floor(k) + 1;
     return (igamc(v, m));
 }
 

--- a/scipy/special/cephes/pdtr.c
+++ b/scipy/special/cephes/pdtr.c
@@ -149,7 +149,7 @@ double pdtr(double k, double m)
 {
     double v;
 
-    if ( k < 0.0 || m < 0.0 ) {
+    if (k < 0 || m < 0) {
         sf_error("pdtr", SF_ERROR_DOMAIN, NULL);
         return (NPY_NAN);
     }

--- a/scipy/special/cephes/pdtr.c
+++ b/scipy/special/cephes/pdtr.c
@@ -127,20 +127,18 @@
 
 #include "mconf.h"
 
-double pdtrc(k, m)
-int k;
-double m;
+double pdtrc(double k, double m)
 {
     double v;
 
-    if ((k < 0) || (m < 0.0)) {
+    if (k < 0.0 || m < 0.0) {
         sf_error("pdtrc", SF_ERROR_DOMAIN, NULL);
         return (NPY_NAN);
     }
     if (m == 0.0) {
         return 0.0;
     }
-    v = k + 1;
+    v = floor(k) + 1;
     return (igam(v, m));
 }
 

--- a/scipy/special/functions.json
+++ b/scipy/special/functions.json
@@ -1124,11 +1124,8 @@
         }
     },
     "pdtr": {
-        "_legacy.pxd": {
-            "pdtr_unsafe": "dd->d"
-        },
         "cephes.h": {
-            "pdtr": "id->d"
+            "pdtr": "dd->d"
         }
     },
     "pdtrc": {

--- a/scipy/special/functions.json
+++ b/scipy/special/functions.json
@@ -1129,11 +1129,8 @@
         }
     },
     "pdtrc": {
-        "_legacy.pxd": {
-            "pdtrc_unsafe": "dd->d"
-        },
         "cephes.h": {
-            "pdtrc": "id->d"
+            "pdtrc": "dd->d"
         }
     },
     "pdtri": {

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -3264,8 +3264,6 @@ def test_legacy():
         assert_equal(special.nbdtrc(1, 2, 0.3), special.nbdtrc(1.8, 2.8, 0.3))
         assert_equal(special.nbdtr(1, 2, 0.3), special.nbdtr(1.8, 2.8, 0.3))
         assert_equal(special.nbdtri(1, 2, 0.3), special.nbdtri(1.8, 2.8, 0.3))
-        assert_equal(special.pdtrc(1, 0.3), special.pdtrc(1.8, 0.3))
-        assert_equal(special.pdtr(1.0, 0.3), special.pdtr(1.8, 0.3))
         assert_equal(special.pdtri(1, 0.3), special.pdtri(1.8, 0.3))
         assert_equal(special.kn(1, 0.3), special.kn(1.8, 0.3))
         assert_equal(special.yn(1, 0.3), special.yn(1.8, 0.3))

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -808,11 +808,11 @@ class TestCephes(object):
         cephes.pbwa(1,0)
 
     def test_pdtr(self):
-        val = cephes.pdtr(0, 1)
+        val = cephes.pdtr(0.0, 1.0)
         assert_almost_equal(val, np.exp(-1))
         # Edge case: m = 0.
-        val = cephes.pdtr([0, 1, 2], 0.0)
-        assert_array_equal(val, [1, 1, 1])
+        val = cephes.pdtr([0.0, 1.0, 2.0], 0.0)
+        assert_array_equal(val, [1.0, 1.0, 1.0])
 
     def test_pdtrc(self):
         val = cephes.pdtrc(0, 1)
@@ -3265,7 +3265,7 @@ def test_legacy():
         assert_equal(special.nbdtr(1, 2, 0.3), special.nbdtr(1.8, 2.8, 0.3))
         assert_equal(special.nbdtri(1, 2, 0.3), special.nbdtri(1.8, 2.8, 0.3))
         assert_equal(special.pdtrc(1, 0.3), special.pdtrc(1.8, 0.3))
-        assert_equal(special.pdtr(1, 0.3), special.pdtr(1.8, 0.3))
+        assert_equal(special.pdtr(1.0, 0.3), special.pdtr(1.8, 0.3))
         assert_equal(special.pdtri(1, 0.3), special.pdtri(1.8, 0.3))
         assert_equal(special.kn(1, 0.3), special.kn(1.8, 0.3))
         assert_equal(special.yn(1, 0.3), special.yn(1.8, 0.3))

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -808,11 +808,11 @@ class TestCephes(object):
         cephes.pbwa(1,0)
 
     def test_pdtr(self):
-        val = cephes.pdtr(0.0, 1.0)
+        val = cephes.pdtr(0, 1)
         assert_almost_equal(val, np.exp(-1))
         # Edge case: m = 0.
-        val = cephes.pdtr([0.0, 1.0, 2.0], 0.0)
-        assert_array_equal(val, [1.0, 1.0, 1.0])
+        val = cephes.pdtr([0, 1, 2], 0)
+        assert_array_equal(val, [1, 1, 1])
 
     def test_pdtrc(self):
         val = cephes.pdtrc(0, 1)

--- a/scipy/special/tests/test_cython_special.py
+++ b/scipy/special/tests/test_cython_special.py
@@ -224,7 +224,7 @@ PARAMS = [
     (special.pbdv, cython_special._pbdv_pywrap, ('dd',), None),
     (special.pbvv, cython_special._pbvv_pywrap, ('dd',), None),
     (special.pbwa, cython_special._pbwa_pywrap, ('dd',), None),
-    (special.pdtr, cython_special.pdtr, ('ld', 'dd'), None),
+    (special.pdtr, cython_special.pdtr, ('dd', 'dd'), None),
     (special.pdtrc, cython_special.pdtrc, ('ld', 'dd'), None),
     (special.pdtri, cython_special.pdtri, ('ld', 'dd'), None),
     (special.pdtrik, cython_special.pdtrik, ('dd',), None),

--- a/scipy/special/tests/test_cython_special.py
+++ b/scipy/special/tests/test_cython_special.py
@@ -225,7 +225,7 @@ PARAMS = [
     (special.pbvv, cython_special._pbvv_pywrap, ('dd',), None),
     (special.pbwa, cython_special._pbwa_pywrap, ('dd',), None),
     (special.pdtr, cython_special.pdtr, ('dd', 'dd'), None),
-    (special.pdtrc, cython_special.pdtrc, ('ld', 'dd'), None),
+    (special.pdtrc, cython_special.pdtrc, ('dd', 'dd'), None),
     (special.pdtri, cython_special.pdtri, ('ld', 'dd'), None),
     (special.pdtrik, cython_special.pdtrik, ('dd',), None),
     (special.poch, cython_special.poch, ('dd',), None),

--- a/scipy/special/tests/test_pdtr.py
+++ b/scipy/special/tests/test_pdtr.py
@@ -1,0 +1,51 @@
+import numpy as np
+from numpy import isnan
+
+import pytest
+from numpy.testing import (assert_almost_equal, assert_array_equal)
+
+from scipy import special
+import scipy.special._ufuncs as cephes
+
+
+class TestCephes(object):
+    # old tests with int args
+    def test_pdtr(self):
+        val = cephes.pdtr(0, 1)
+        assert_almost_equal(val, np.exp(-1))
+        # Edge case: m = 0.
+        val = cephes.pdtr([0, 1, 2], 0)
+        assert_array_equal(val, [1, 1, 1])
+        # test the rounding from double -> int
+        double_val = cephes.pdtr([0.1, 1.1, 2.1], 1.0)
+        int_val = cephes.pdtr([0, 1, 2], 1.0)
+        assert_array_equal(double_val, int_val)
+
+    def test_pdtrc(self):
+        val = cephes.pdtrc(0, 1)
+        assert_almost_equal(val, 1 - np.exp(-1))
+        # Edge case: m = 0.
+        val = cephes.pdtrc([0, 1, 2], 0.0)
+        assert_array_equal(val, [0, 0, 0])
+        # test the rounding from double -> int
+        double_val = cephes.pdtrc([0.1, 1.1, 2.1], 1.0)
+        int_val = cephes.pdtrc([0, 1, 2], 1.0)
+        assert_array_equal(double_val, int_val)
+
+    #test np.inf arguments
+    def test_pdtr_np_inf(self):
+        val = cephes.pdtr(np.inf, 1.0)
+        assert_almost_equal(val, 1.0)
+
+    def test_pdtrc_np_inf(self):
+        val = cephes.pdtrc(np.inf, 1.0)
+        assert_almost_equal(val, 0.0)
+
+    #test -1.1 is np.nan, negative values are not valid domain
+    def test_pdtr_np_inf(self):
+        val = cephes.pdtr(-1.1, 1.0)
+        assert isnan(val)
+
+    def test_pdtrc_np_inf(self):
+        val = cephes.pdtrc(-1.1, 1.0)
+        assert isnan(val)

--- a/scipy/special/tests/test_pdtr.py
+++ b/scipy/special/tests/test_pdtr.py
@@ -11,7 +11,8 @@ class TestCephes(object):
     def test_pdtr(self):
         val = sc.pdtr(0, 1)
         assert_almost_equal(val, np.exp(-1))
-        # Edge case: m = 0.
+
+    def test_m_zero(self):
         val = sc.pdtr([0, 1, 2], 0)
         assert_array_equal(val, [1, 1, 1])
 
@@ -23,7 +24,8 @@ class TestCephes(object):
     def test_pdtrc(self):
         val = sc.pdtrc(0, 1)
         assert_almost_equal(val, 1 - np.exp(-1))
-        # Edge case: m = 0.
+
+    def test_m_zero(self):
         val = sc.pdtrc([0, 1, 2], 0.0)
         assert_array_equal(val, [0, 0, 0])
 

--- a/scipy/special/tests/test_pdtr.py
+++ b/scipy/special/tests/test_pdtr.py
@@ -5,7 +5,6 @@ from numpy.testing import assert_almost_equal, assert_array_equal
 from numpy import isnan
 
 
-
 class TestCephes(object):
     # old tests with int args
     def test_pdtr(self):

--- a/scipy/special/tests/test_pdtr.py
+++ b/scipy/special/tests/test_pdtr.py
@@ -1,51 +1,49 @@
 import numpy as np
+import scipy.special as sc
+import pytest
+from numpy.testing import assert_almost_equal, assert_array_equal
 from numpy import isnan
 
-import pytest
-from numpy.testing import (assert_almost_equal, assert_array_equal)
-
-from scipy import special
-import scipy.special._ufuncs as cephes
 
 
 class TestCephes(object):
     # old tests with int args
     def test_pdtr(self):
-        val = cephes.pdtr(0, 1)
+        val = sc.pdtr(0, 1)
         assert_almost_equal(val, np.exp(-1))
         # Edge case: m = 0.
-        val = cephes.pdtr([0, 1, 2], 0)
+        val = sc.pdtr([0, 1, 2], 0)
         assert_array_equal(val, [1, 1, 1])
-        # test the rounding from double -> int
-        double_val = cephes.pdtr([0.1, 1.1, 2.1], 1.0)
-        int_val = cephes.pdtr([0, 1, 2], 1.0)
+
+    def test_pdtr_rounding(self):
+        double_val = sc.pdtr([0.1, 1.1, 2.1], 1.0)
+        int_val = sc.pdtr([0, 1, 2], 1.0)
         assert_array_equal(double_val, int_val)
 
     def test_pdtrc(self):
-        val = cephes.pdtrc(0, 1)
+        val = sc.pdtrc(0, 1)
         assert_almost_equal(val, 1 - np.exp(-1))
         # Edge case: m = 0.
-        val = cephes.pdtrc([0, 1, 2], 0.0)
+        val = sc.pdtrc([0, 1, 2], 0.0)
         assert_array_equal(val, [0, 0, 0])
-        # test the rounding from double -> int
-        double_val = cephes.pdtrc([0.1, 1.1, 2.1], 1.0)
-        int_val = cephes.pdtrc([0, 1, 2], 1.0)
+
+    def test_pdtrc_rounding(self):
+        double_val = sc.pdtrc([0.1, 1.1, 2.1], 1.0)
+        int_val = sc.pdtrc([0, 1, 2], 1.0)
         assert_array_equal(double_val, int_val)
 
-    #test np.inf arguments
-    def test_pdtr_np_inf(self):
-        val = cephes.pdtr(np.inf, 1.0)
+    def test_pdtr_inf(self):
+        val = sc.pdtr(np.inf, 1.0)
         assert_almost_equal(val, 1.0)
 
-    def test_pdtrc_np_inf(self):
-        val = cephes.pdtrc(np.inf, 1.0)
+    def test_pdtrc_inf(self):
+        val = sc.pdtrc(np.inf, 1.0)
         assert_almost_equal(val, 0.0)
 
-    #test -1.1 is np.nan, negative values are not valid domain
-    def test_pdtr_np_inf(self):
-        val = cephes.pdtr(-1.1, 1.0)
+    def test_pdtr_domain(self):
+        val = sc.pdtr(-1.1, 1.0)
         assert isnan(val)
 
-    def test_pdtrc_np_inf(self):
-        val = cephes.pdtrc(-1.1, 1.0)
+    def test_pdtrc_domain(self):
+        val = sc.pdtrc(-1.1, 1.0)
         assert isnan(val)

--- a/scipy/special/tests/test_pdtr.py
+++ b/scipy/special/tests/test_pdtr.py
@@ -2,12 +2,10 @@ import numpy as np
 import scipy.special as sc
 import pytest
 from numpy.testing import assert_almost_equal, assert_array_equal
-from numpy import isnan
 
 
-class TestCephes(object):
-    # old tests with int args
-    def test_pdtr(self):
+class TestPdtr(object):
+    def test(self):
         val = sc.pdtr(0, 1)
         assert_almost_equal(val, np.exp(-1))
 
@@ -15,12 +13,21 @@ class TestCephes(object):
         val = sc.pdtr([0, 1, 2], 0)
         assert_array_equal(val, [1, 1, 1])
 
-    def test_pdtr_rounding(self):
+    def test_rounding(self):
         double_val = sc.pdtr([0.1, 1.1, 2.1], 1.0)
         int_val = sc.pdtr([0, 1, 2], 1.0)
         assert_array_equal(double_val, int_val)
 
-    def test_pdtrc(self):
+    def test_inf(self):
+        val = sc.pdtr(np.inf, 1.0)
+        assert_almost_equal(val, 1.0)
+
+    def test_domain(self):
+        val = sc.pdtr(-1.1, 1.0)
+        assert np.isnan(val)
+
+class TestPdtrc(object):
+    def test_value(self):
         val = sc.pdtrc(0, 1)
         assert_almost_equal(val, 1 - np.exp(-1))
 
@@ -28,23 +35,15 @@ class TestCephes(object):
         val = sc.pdtrc([0, 1, 2], 0.0)
         assert_array_equal(val, [0, 0, 0])
 
-    def test_pdtrc_rounding(self):
+    def test_rounding(self):
         double_val = sc.pdtrc([0.1, 1.1, 2.1], 1.0)
         int_val = sc.pdtrc([0, 1, 2], 1.0)
         assert_array_equal(double_val, int_val)
 
-    def test_pdtr_inf(self):
-        val = sc.pdtr(np.inf, 1.0)
-        assert_almost_equal(val, 1.0)
-
-    def test_pdtrc_inf(self):
+    def test_inf(self):
         val = sc.pdtrc(np.inf, 1.0)
         assert_almost_equal(val, 0.0)
 
-    def test_pdtr_domain(self):
-        val = sc.pdtr(-1.1, 1.0)
-        assert isnan(val)
-
-    def test_pdtrc_domain(self):
+    def test_domain(self):
         val = sc.pdtrc(-1.1, 1.0)
-        assert isnan(val)
+        assert np.isnan(val)


### PR DESCRIPTION
#### Reference issue
work in progress for #10855 

#### What does this implement/fix?
This is changes the type in `special.pdtr` to take doubles for the argument in the poisson. 

It passes the test runner e.g. `python runtests.py -s special` 
but to do so requires ***manually*** changing the signature for `pdtr` in `scipy/special/_ufuncs_defs.h` which appears to get written as `(int, double)` during the build process. 
 
This ***doesn't*** remove the warning nor the `nan` output with `k=np.inf` as mentioned in #10855 though I think some other stuff needs to be changed but not sure what exactly. 
#### Additional information
I poked around (and broke my build in the process) it looks like the is a helper function defined in a few spots called `pdtr_unsafe()`.

I'm not clear what need to get cut from legacy wrappers. 
@person142 could you clarify that part for me please? 

I tried: 
```
diff --git a/scipy/special/_legacy.pxd b/scipy/special/_legacy.pxd
index e6d17e76b..82b01565a 100644
--- a/scipy/special/_legacy.pxd
+++ b/scipy/special/_legacy.pxd
@@ -18,7 +18,7 @@ cdef extern from "numpy/npy_math.h" nogil:
     double nan "NPY_NAN"
 
 from ._cephes cimport (bdtrc, bdtr, bdtri, expn, nbdtrc,
-                       nbdtr, nbdtri, pdtrc, pdtr, pdtri, kn, yn,
+                       nbdtr, nbdtri, pdtrc, pdtri, kn, yn,
                        smirnov, smirnovi, smirnovc, smirnovci, smirnovp)
 
 cdef extern from "amos_wrappers.h":
@@ -98,12 +98,6 @@ cdef inline double pdtrc_unsafe(double k, double m) nogil:
     _legacy_cast_check("pdtrc", k, 0)
     return pdtrc(<int>k, m)
 
-cdef inline double pdtr_unsafe(double k, double m) nogil:
-    if npy_isnan(k):
-        return k
-    _legacy_cast_check("pdtr", k, 0)
-    return pdtr(<int>k, m)
-
 cdef inline double pdtri_unsafe(double k, double y) nogil:
     if npy_isnan(k):
         return k
```
but that broke the build as there are several other places where this function is called. 