### PR TITLE
BUG: Fix signal.unique_roots

### DIFF
--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1742,8 +1742,8 @@ def unique_roots(p, tol=1e-3, rtype='min'):
           - 'min', 'minimum': pick the minimum of those roots
           - 'avg', 'mean': take the average of those roots
 
-        Note that complex roots are compared first by the real part and then
-        by the imaginary part.
+        When finding minimum or maximum among complex roots they are compared
+        first by the real part and then by the imaginary part.
 
     Returns
     -------

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1786,28 +1786,26 @@ def unique_roots(p, tol=1e-3, rtype='min'):
                          "{'max', 'maximum', 'min', 'minimum', 'avg', 'mean'}")
 
     p = np.asarray(p)
+
     points = np.empty((len(p), 2))
     points[:, 0] = np.real(p)
     points[:, 1] = np.imag(p)
-
     tree = cKDTree(points)
-    pairs = tree.query_pairs(tol)
-
-    groups = dict()
-    used = set()
-    for i, j in sorted(pairs):  # sort to predict the behavior
-        if i not in used:
-            groups.setdefault(i, [i]).append(j)
-            used.add(j)
 
     p_unique = []
     p_multiplicity = []
-
+    used = np.zeros(len(p), dtype=bool)
     for i in range(len(p)):
-        if i not in used:
-            group = groups.get(i, [i])
-            p_unique.append(reduce(p[group]))
-            p_multiplicity.append(len(group))
+        if used[i]:
+            continue
+
+        group = tree.query_ball_point(points[i], tol)
+        group = [x for x in group if not used[x]]
+
+        p_unique.append(reduce(p[group]))
+        p_multiplicity.append(len(group))
+
+        used[group] = True
 
     return np.asarray(p_unique), np.asarray(p_multiplicity)
 

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1733,7 +1733,7 @@ def unique_roots(p, tol=1e-3, rtype='min'):
     tol : float, optional
         The tolerance for two roots to be considered equal in terms of
         the distance between them. Default is 1e-3. Refer to Notes about
-        the details about roots grouping.
+        the details on roots grouping.
     rtype : {'max', 'maximum', 'min', 'minimum', 'avg', 'mean'}, optional
         How to determine the returned root if multiple roots are within
         `tol` of each other.

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1748,7 +1748,7 @@ def unique_roots(p, tol=1e-3, rtype='min'):
     Returns
     -------
     unique : ndarray
-        The list of unique roots in the same order as in the input `p`.
+        The list of unique roots.
     multiplicity : ndarray
         The multiplicity of each root.
 
@@ -1791,12 +1791,11 @@ def unique_roots(p, tol=1e-3, rtype='min'):
     points[:, 1] = np.imag(p)
 
     tree = cKDTree(points)
-    pairs = tree.query_pairs(tol, output_type='ndarray')
-    pairs = np.sort(pairs, axis=0)
+    pairs = tree.query_pairs(tol)
 
     groups = dict()
     used = set()
-    for i, j in pairs:
+    for i, j in sorted(pairs):  # sort to predict the behavior
         if i not in used:
             groups.setdefault(i, [i]).append(j)
             used.add(j)

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1724,32 +1724,42 @@ def cmplx_sort(p):
 
 
 def unique_roots(p, tol=1e-3, rtype='min'):
-    """
-    Determine unique roots and their multiplicities from a list of roots.
+    """Determine unique roots and their multiplicities from a list of roots.
 
     Parameters
     ----------
     p : array_like
         The list of roots.
     tol : float, optional
-        The tolerance for two roots to be considered equal. Default is 1e-3.
-    rtype : {'max', 'min, 'avg'}, optional
+        The tolerance for two roots to be considered equal in terms of
+        the distance between them. Default is 1e-3. Refer to Notes about
+        the details about roots grouping.
+    rtype : {'max', 'maximum', 'min', 'minimum', 'avg', 'mean'}, optional
         How to determine the returned root if multiple roots are within
         `tol` of each other.
 
-          - 'max': pick the maximum of those roots.
-          - 'min': pick the minimum of those roots.
-          - 'avg': take the average of those roots.
+          - 'max', 'maximum': pick the maximum of those roots
+          - 'min', 'minimum': pick the minimum of those roots
+          - 'avg', 'mean': take the average of those roots
+
+        Note that complex roots are compared first by the real part and then
+        by the imaginary part.
 
     Returns
     -------
-    pout : ndarray
-        The list of unique roots, sorted from low to high.
-    mult : ndarray
+    unique : ndarray
+        The list of unique roots in the same order as in the input `p`.
+    multiplicity : ndarray
         The multiplicity of each root.
 
     Notes
     -----
+    If we have 3 roots ``a``, ``b`` and ``c``, such that ``a`` is close to
+    ``b`` and ``b`` is close to ``c`` (distance is less than `tol`), then it
+    doesn't necessarily mean that ``a`` is close to ``c``. It means that roots
+    grouping is not unique. In this function we use "greedy" grouping going
+    through the roots in the order they are given in the input `p`.
+
     This utility function is not specific to roots but can be used for any
     sequence of values for which uniqueness and multiplicity has to be
     determined. For a more general routine, see `numpy.unique`.

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2785,3 +2785,9 @@ class TestUniqueRoots(object):
         unique, multiplicity = unique_roots([1, 1 + 2e-9, 1e-9 + 1j], tol=0.1)
         assert_almost_equal(unique, [1.0, 1e-9 + 1.0j], decimal=15)
         assert_equal(multiplicity, [2, 1])
+
+    def test_single_unique_root(self):
+        p = np.random.rand(100) + 1j * np.random.rand(100)
+        unique, multiplicity = unique_roots(p, 2)
+        assert_almost_equal(unique, [np.min(p)], decimal=15)
+        assert_equal(multiplicity, [100])

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -24,7 +24,7 @@ from scipy.signal import (
     correlate, convolve, convolve2d, fftconvolve, choose_conv_method,
     hilbert, hilbert2, lfilter, lfilter_zi, filtfilt, butter, zpk2tf, zpk2sos,
     invres, invresz, vectorstrength, lfiltic, tf2sos, sosfilt, sosfiltfilt,
-    sosfilt_zi, tf2zpk, BadCoefficients, detrend)
+    sosfilt_zi, tf2zpk, BadCoefficients, detrend, unique_roots)
 from scipy.signal.windows import hann
 from scipy.signal.signaltools import _filtfilt_gust
 
@@ -2716,3 +2716,72 @@ class TestDetrend(object):
         copy_array = detrend(x, overwrite_data=False)
         inplace = detrend(x, overwrite_data=True)
         assert_array_almost_equal(copy_array, inplace)
+
+
+class TestUniqueRoots(object):
+    def test_real_no_repeat(self):
+        p = [-1.0, -0.5, 0.3, 1.2, 10.0]
+        unique, multiplicity = unique_roots(p)
+        assert_almost_equal(unique, p, decimal=15)
+        assert_equal(multiplicity, np.ones(len(p)))
+
+    def test_real_repeat(self):
+        p = [-1.0, -0.95, -0.89, -0.8, 0.5, 1.0, 1.05]
+
+        unique, multiplicity = unique_roots(p, tol=1e-1, rtype='min')
+        assert_almost_equal(unique, [-1.0, -0.89, 0.5, 1.0], decimal=15)
+        assert_equal(multiplicity, [2, 2, 1, 2])
+
+        unique, multiplicity = unique_roots(p, tol=1e-1, rtype='max')
+        assert_almost_equal(unique, [-0.95, -0.8, 0.5, 1.05], decimal=15)
+        assert_equal(multiplicity, [2, 2, 1, 2])
+
+        unique, multiplicity = unique_roots(p, tol=1e-1, rtype='avg')
+        assert_almost_equal(unique, [-0.975, -0.845, 0.5, 1.025], decimal=15)
+        assert_equal(multiplicity, [2, 2, 1, 2])
+
+    def test_complex_no_repeat(self):
+        p = [-1.0, 1.0j, 0.5 + 0.5j, -1.0 - 1.0j, 3.0 + 2.0j]
+        unique, multiplicity = unique_roots(p)
+        assert_almost_equal(unique, p, decimal=15)
+        assert_equal(multiplicity, np.ones(len(p)))
+
+    def test_complex_repeat(self):
+        p = [-1.0, -1.0 + 0.05j, -0.95 + 0.15j, -0.90 + 0.15j, 0.0,
+             0.5 + 0.5j, 0.45 + 0.55j]
+
+        unique, multiplicity = unique_roots(p, tol=1e-1, rtype='min')
+        assert_almost_equal(unique, [-1.0, -0.95 + 0.15j, 0.0, 0.45 + 0.55j],
+                            decimal=15)
+        assert_equal(multiplicity, [2, 2, 1, 2])
+
+        unique, multiplicity = unique_roots(p, tol=1e-1, rtype='max')
+        assert_almost_equal(unique,
+                            [-1.0 + 0.05j, -0.90 + 0.15j, 0.0, 0.5 + 0.5j],
+                            decimal=15)
+        assert_equal(multiplicity, [2, 2, 1, 2])
+
+        unique, multiplicity = unique_roots(p, tol=1e-1, rtype='avg')
+        assert_almost_equal(
+            unique, [-1.0 + 0.025j, -0.925 + 0.15j, 0.0, 0.475 + 0.525j],
+            decimal=15)
+        assert_equal(multiplicity, [2, 2, 1, 2])
+
+    def test_gh_4915(self):
+        p = np.roots(np.convolve(np.ones(5), np.ones(5)))
+        true_roots = [-(-1)**(1/5), (-1)**(4/5), -(-1)**(3/5), (-1)**(2/5)]
+
+        unique, multiplicity = unique_roots(p)
+        unique = np.sort(unique)
+
+        assert_almost_equal(np.sort(unique), true_roots, decimal=7)
+        assert_equal(multiplicity, [2, 2, 2, 2])
+
+    def test_complex_roots_extra(self):
+        unique, multiplicity = unique_roots([1.0, 1.0j, 1.0])
+        assert_almost_equal(unique, [1.0, 1.0j], decimal=15)
+        assert_equal(multiplicity, [2, 1])
+
+        unique, multiplicity = unique_roots([1, 1 + 2e-9, 1e-9 + 1j], tol=0.1)
+        assert_almost_equal(unique, [1.0, 1e-9 + 1.0j], decimal=15)
+        assert_equal(multiplicity, [2, 1])


### PR DESCRIPTION
#### Reference issue

#4915

#### What does this implement/fix?
`signal.unique_roots` is supposed to find unique roots among a list of real or complex roots, meaning that roots closer to each other than `tol` are considered identical. 

The previous implementation relied on passing through the sorted list of roots. It works for real roots in 1-dimensional space, but doesn't work for complex roots which live in 2-dimensional space where sorting doesn't help at all.

I use `cKDTree` for finding neighboring roots and the time complexity `O(n * log(n) + sum(multiplicity))`. Note that `sum(multiplicity)` occurs because I use `query_pairs` and it might be `O(n**2)` when each root close to all other roots. 

I think `sum(multiplicity)` can be eliminated by more careful usage of `cKDTree`, but it will make the code lengthier and probably slower for typical normal cases.

*Update*: I tweaked the code to make the complexity solid `O(n * log(n))`, due to implementation it works about 10 times slower when each root is unique, however it doesn't choke when there are ~n repeated roots. I think this is a preferable tradeoff.

