### PR TITLE
ENH: Make Slerp callable with a scalar argument

### DIFF
--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -1990,7 +1990,7 @@ class Slerp(object):
 
         Parameters
         ----------
-        times : array_like, 1D
+        times : float or array_like
             Times to compute the interpolations at.
 
         Returns
@@ -2001,10 +2001,11 @@ class Slerp(object):
         """
         # Clearly differentiate from self.times property
         compute_times = np.asarray(times)
-        if compute_times.ndim != 1:
-            raise ValueError("Expected times to be specified in a 1 "
-                             "dimensional array, got {} "
-                             "dimensions.".format(compute_times.ndim))
+        if compute_times.ndim > 1:
+            raise ValueError("`times` must be at most 1-dimensional.")
+
+        single_time = compute_times.ndim == 0
+        compute_times = np.atleast_1d(compute_times)
 
         # side = 'left' (default) excludes t_min.
         ind = np.searchsorted(self.times, compute_times) - 1
@@ -2017,5 +2018,10 @@ class Slerp(object):
 
         alpha = (compute_times - self.times[ind]) / self.timedelta[ind]
 
-        return (self.rotations[ind] *
-                Rotation.from_rotvec(self.rotvecs[ind] * alpha[:, None]))
+        result = (self.rotations[ind] *
+                  Rotation.from_rotvec(self.rotvecs[ind] * alpha[:, None]))
+
+        if single_time:
+            result = result[0]
+
+        return result

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -1990,8 +1990,9 @@ class Slerp(object):
 
         Parameters
         ----------
-        times : float or array_like
-            Times to compute the interpolations at.
+        times : array_like
+            Times to compute the interpolations at. Can be a scalar or
+            1-dimensional.
 
         Returns
         -------

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -1050,7 +1050,7 @@ def test_slerp_call_time_dim_mismatch():
     s = Slerp(t, r)
 
     with pytest.raises(ValueError,
-                       match="times to be specified in a 1 dimensional array"):
+                       match="`times` must be at most 1-dimensional."):
         interp_times = np.array([[3.5],
                                  [4.2]])
         s(interp_times)
@@ -1066,3 +1066,15 @@ def test_slerp_call_time_out_of_range():
         s([0, 1, 2])
     with pytest.raises(ValueError, match="times must be within the range"):
         s([1, 2, 6])
+
+
+def test_slerp_call_scalar_time():
+    r = Rotation.from_euler('X', [0, 80], degrees=True)
+    s = Slerp([0, 1], r)
+
+    r_interpolated = s(0.25)
+    r_interpolated_expected = Rotation.from_euler('X', 20, degrees=True)
+
+    delta = r_interpolated * r_interpolated_expected.inv()
+
+    assert_allclose(delta.magnitude(), 0, atol=1e-16)


### PR DESCRIPTION
#### What does this implement/fix?

Now we can do
```
s = Slerp(...)
r = s(0.5)  # Single rotation in r
```

Very simple change, I also moved Slerp-related code and tests into separate files, which makes sense.

@rgommers @tylerjereddy @pmla please take a look if possible, not much to review here.

