### PR TITLE
MAINT: prepare for SciPy 1.3.2

### DIFF
--- a/doc/release/1.3.2-notes.rst
+++ b/doc/release/1.3.2-notes.rst
@@ -1,0 +1,17 @@
+==========================
+SciPy 1.3.2 Release Notes
+==========================
+
+.. contents::
+
+SciPy 1.3.2 is a bug-fix and maintenance release that adds
+support for Python 3.8.
+
+Authors
+=======
+
+Issues closed for 1.3.2
+-----------------------
+
+Pull requests for 1.3.2
+-----------------------

--- a/doc/source/release.1.3.2.rst
+++ b/doc/source/release.1.3.2.rst
@@ -1,0 +1,1 @@
+.. include:: ../release/1.3.2-notes.rst

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
    :maxdepth: 1
 
+   release.1.3.2
    release.1.3.1
    release.1.3.0
    release.1.2.1

--- a/pavement.py
+++ b/pavement.py
@@ -113,10 +113,10 @@ except AttributeError:
 #-----------------------------------
 
 # Source of the release notes
-RELEASE = 'doc/release/1.3.1-notes.rst'
+RELEASE = 'doc/release/1.3.2-notes.rst'
 
 # Start/end of the log (from git)
-LOG_START = 'v1.3.0'
+LOG_START = 'v1.3.1'
 LOG_END = 'maintenance/1.3.x'
 
 

--- a/setup.py
+++ b/setup.py
@@ -55,8 +55,8 @@ Operating System :: MacOS
 
 MAJOR = 1
 MINOR = 3
-MICRO = 1
-ISRELEASED = True
+MICRO = 2
+ISRELEASED = False
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
 


### PR DESCRIPTION
* add new files associated with the new
bug-fix / maintenance release notes for
SciPy 1.3.2

* bump maintenance branch version to 1.3.2
unreleased

Primary motivation is to get wheels with Python 3.8 support out pretty soon.