### PR TITLE
MAINT: use 3.8 stable in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,9 +64,9 @@ matrix:
             - *common_packages
             - python3.5-dbg
             - python3.5-dev
-    - python: 3.8-dev
+    - python: 3.8
       env:
-        - TESTMODE=fast
+        - TESTMODE=full
         - NUMPYSPEC="--pre --upgrade --timeout=60 -f $PRE_WHEELS numpy"
     - python: 3.6
       env:
@@ -192,7 +192,7 @@ before_install:
   - travis_retry pip install pybind11
   - |
     if [ "${TESTMODE}" == "full" ]; then
-        travis_retry pip install pytest-cov coverage matplotlib scikit-umfpack scikit-sparse
+        travis_retry pip install pytest-cov coverage matplotlib==3.2.0rc1 scikit-umfpack scikit-sparse
     fi
   - |
     if [ "${REFGUIDE_CHECK}" == "1" ]; then


### PR DESCRIPTION
* adjust Travis CI to use Python 3.8
stable instead of 3.8-dev; also,
run the full test suite for this matrix
entry now

Of interest to backport to #10970, if it works, for robust check on Python 3.8 support as we aim to get `1.3.2` out soon.