### PR TITLE
BUG: Handle complex gains in zpk2sos

### DIFF
--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -1507,7 +1507,7 @@ def zpk2sos(z, p, k, pairing='nearest'):
     # Construct the system, reversing order so the "worst" are last
     p_sos = np.reshape(p_sos[::-1], (n_sections, 2))
     z_sos = np.reshape(z_sos[::-1], (n_sections, 2))
-    gains = np.ones(n_sections)
+    gains = np.ones(n_sections, np.array(k).dtype)
     gains[0] = k
     for si in range(n_sections):
         x = zpk2tf(z_sos[si], p_sos[si], gains[si])

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -161,21 +161,24 @@ class TestCplxReal(object):
 
 class TestTf2zpk(object):
 
-    def test_simple(self):
+    @pytest.mark.parametrize('dt', (np.float64, np.complex128))
+    def test_simple(self, dt):
         z_r = np.array([0.5, -0.5])
         p_r = np.array([1.j / np.sqrt(2), -1.j / np.sqrt(2)])
         # Sort the zeros/poles so that we don't fail the test if the order
         # changes
         z_r.sort()
         p_r.sort()
-        b = np.poly(z_r)
-        a = np.poly(p_r)
+        b = np.poly(z_r).astype(dt)
+        a = np.poly(p_r).astype(dt)
 
         z, p, k = tf2zpk(b, a)
         z.sort()
         p.sort()
         assert_array_almost_equal(z, z_r)
         assert_array_almost_equal(p, p_r)
+        assert_array_almost_equal(k, 1.)
+        assert k.dtype == dt
 
     def test_bad_filter(self):
         # Regression test for #651: better handling of badly conditioned
@@ -285,6 +288,17 @@ class TestTf2Sos(object):
 
 
 class TestZpk2Sos(object):
+
+    @pytest.mark.parametrize('dt', 'fdgFDG')
+    @pytest.mark.parametrize('pairing', ('nearest', 'keep_odd'))
+    def test_dtypes(self, dt, pairing):
+        z = np.array([-1, -1]).astype(dt)
+        ct = dt.upper()  # the poles have to be complex
+        p = np.array([0.57149 + 0.29360j, 0.57149 - 0.29360j]).astype(ct)
+        k = np.array(1).astype(dt)
+        sos = zpk2sos(z, p, k, pairing=pairing)
+        sos2 = [[1, 2, 1, 1, -1.14298, 0.41280]]  # octave & MATLAB
+        assert_array_almost_equal(sos, sos2, decimal=4)
 
     def test_basic(self):
         for pairing in ('nearest', 'keep_odd'):


### PR DESCRIPTION
Bug found while working on #10650. If `k` is complex when calling `zpk2sos` then you can end up with the warning:
```
numpy.ComplexWarning: Casting complex values to real discards the imaginary part
```
This fixes it by setting the dtype of the `gains` variable that is used for `sos` to match that of the original input gain `k`.