### PR TITLE
TST: skip test_kendalltau ppc64le

### DIFF
--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -247,8 +247,8 @@ class TestCorr(object):
         attributes = ('correlation', 'pvalue')
         check_named_results(res, attributes, ma=True)
 
-    @pytest.mark.xfail(platform.machine() == 'ppc64le',
-                       reason="fails on ppc64le")
+    @pytest.mark.skipif(platform.machine() == 'ppc64le',
+                        reason="fails/crashes on ppc64le")
     def test_kendalltau(self):
         # simple case without ties
         x = ma.array(np.arange(10))


### PR DESCRIPTION
* test_kendalltau() can hard crash on
ppc64le, circumventing the xfail, so
it is now marked with a skip to prevent
execution entirely on that platform;
this has been causing issues in our CI

Noted by Ralf here: https://github.com/scipy/scipy/pull/10972#issuecomment-545949804
But it has been happening too regularly to put up with for much longer I think.