### PR TITLE
BUG: boxcox data dimension and constancy check #5112

### DIFF
--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -952,7 +952,7 @@ def boxcox(x, lmbda=None, alpha=None):
     Parameters
     ----------
     x : ndarray
-        Input array.  Must be positive 1-dimensional. Must not be constant.
+        Input array.  Must be positive 1-dimensional.  Must not be constant.
     lmbda : {None, scalar}, optional
         If `lmbda` is not None, do the transformation for that value.
 

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -947,12 +947,12 @@ def _boxcox_conf_interval(x, lmax, alpha):
 
 def boxcox(x, lmbda=None, alpha=None):
     r"""
-    Return a positive dataset transformed by a Box-Cox power transformation.
+    Return a dataset transformed by a Box-Cox power transformation.
 
     Parameters
     ----------
     x : ndarray
-        Input array.  Should be 1-dimensional.
+        Input array.  Must be positive 1-dimensional. Must not be constant.
     lmbda : {None, scalar}, optional
         If `lmbda` is not None, do the transformation for that value.
 
@@ -1032,8 +1032,14 @@ def boxcox(x, lmbda=None, alpha=None):
 
     """
     x = np.asarray(x)
+    if x.ndim != 1:
+        raise ValueError("Data must be 1-dimensional.")
+
     if x.size == 0:
         return x
+
+    if np.all(x == x[0]):
+        raise ValueError("Data must not be constant.")
 
     if any(x <= 0):
         raise ValueError("Data must be positive.")

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1325,7 +1325,7 @@ class TestBoxcox(object):
         # Raise ValueError if data is constant.
         assert_raises(ValueError, stats.boxcox, np.array([1]))
         # Raise ValueError if data is not 1-dimensional.
-        assert_raises(ValueError, stats.boxcox, np.array([[1]]))
+        assert_raises(ValueError, stats.boxcox, np.array([[1], [2]]))
 
     def test_empty(self):
         assert_(stats.boxcox([]).shape == (0,))

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1320,8 +1320,12 @@ class TestBoxcox(object):
 
     def test_boxcox_bad_arg(self):
         # Raise ValueError if any data value is negative.
-        x = np.array([-1])
+        x = np.array([-1, 2])
         assert_raises(ValueError, stats.boxcox, x)
+        # Raise ValueError if data is constant.
+        assert_raises(ValueError, stats.boxcox, np.array([1]))
+        # Raise ValueError if data is not 1-dimensional.
+        assert_raises(ValueError, stats.boxcox, np.array([[1]]))
 
     def test_empty(self):
         assert_(stats.boxcox([]).shape == (0,))


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #5112

#### What does this implement/fix?
<!--Please explain your changes.-->
This raises ValueError when data is not 1-dimensional or all values are equal. Docstring has been improved as well.