### PR TITLE
API: Rename dcm to (rotation) matrix in Rotation class

### DIFF
--- a/scipy/spatial/tests/test_spherical_voronoi.py
+++ b/scipy/spatial/tests/test_spherical_voronoi.py
@@ -184,7 +184,7 @@ class TestSphericalVoronoi(object):
     @pytest.mark.parametrize("center", [(0, 0, 0), (1, 2, 3)])
     def test_geodesic_input(self, n, radius, center):
         np.random.seed(0)
-        U = Rotation.random().as_dcm()
+        U = Rotation.random().as_matrix()
         thetas = np.linspace(0, 2 * np.pi, n, endpoint=False)
         points = np.vstack([np.sin(thetas), np.cos(thetas), np.zeros(n)]).T
         points = radius * points @ U

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -613,7 +613,7 @@ class Rotation(object):
 
     @classmethod
     @np.deprecate(message="from_dcm is renamed to from_matrix in scipy 1.4.0 "
-                          "and will be removed in scipy 1.5.0")
+                          "and will be removed in scipy 1.6.0")
     def from_dcm(cls, dcm):
         return cls.from_matrix(dcm)
 
@@ -999,7 +999,7 @@ class Rotation(object):
             return matrix
 
     @np.deprecate(message="as_dcm is renamed to as_matrix in scipy 1.4.0 "
-                          "and will be removed in scipy 1.5.0")
+                          "and will be removed in scipy 1.6.0")
     def as_dcm(self):
         return self.as_matrix()
 

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -612,7 +612,8 @@ class Rotation(object):
             return cls(quat, normalized=True, copy=False)
 
     @classmethod
-    @np.deprecate(message="from_dcm is renamed to from_matrix in scipy 1.4.0")
+    @np.deprecate(message="from_dcm is renamed to from_matrix in scipy 1.4.0 "
+                          "and will be removed in scipy 1.5.0")
     def from_dcm(cls, dcm):
         return cls.from_matrix(dcm)
 
@@ -997,7 +998,8 @@ class Rotation(object):
         else:
             return matrix
 
-    @np.deprecate(message="as_dcm is renamed to as_matrix in scipy 1.4.0")
+    @np.deprecate(message="as_dcm is renamed to as_matrix in scipy 1.4.0 "
+                          "and will be removed in scipy 1.5.0")
     def as_dcm(self):
         return self.as_matrix()
 

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -243,7 +243,7 @@ class Rotation(object):
 
     The rotation can be expressed in any of the other formats:
 
-    >>> r.as_dcm()
+    >>> r.as_matrix()
     array([[ 2.22044605e-16, -1.00000000e+00,  0.00000000e+00],
     [ 1.00000000e+00,  2.22044605e-16,  0.00000000e+00],
     [ 0.00000000e+00,  0.00000000e+00,  1.00000000e+00]])
@@ -254,7 +254,7 @@ class Rotation(object):
 
     The same rotation can be initialized using a direction cosine matrix:
 
-    >>> r = R.from_dcm(np.array([
+    >>> r = R.as_matrix(np.array([
     ... [0, -1, 0],
     ... [1, 0, 0],
     ... [0, 0, 1]]))
@@ -276,7 +276,7 @@ class Rotation(object):
 
     >>> r.as_quat()
     array([0.        , 0.        , 0.70710678, 0.70710678])
-    >>> r.as_dcm()
+    >>> r.as_matrix()
     array([[ 2.22044605e-16, -1.00000000e+00,  0.00000000e+00],
            [ 1.00000000e+00,  2.22044605e-16,  0.00000000e+00],
            [ 0.00000000e+00,  0.00000000e+00,  1.00000000e+00]])
@@ -293,7 +293,7 @@ class Rotation(object):
 
     >>> r.as_quat()
     array([0.        , 0.        , 0.70710678, 0.70710678])
-    >>> r.as_dcm()
+    >>> r.as_matrix()
     array([[ 2.22044605e-16, -1.00000000e+00,  0.00000000e+00],
            [ 1.00000000e+00,  2.22044605e-16,  0.00000000e+00],
            [ 0.00000000e+00,  0.00000000e+00,  1.00000000e+00]])
@@ -333,7 +333,7 @@ class Rotation(object):
            [0.        , 0.38268343, 0.        , 0.92387953],
            [0.39190384, 0.36042341, 0.43967974, 0.72331741]])
     >>> p = r[0]
-    >>> p.as_dcm()
+    >>> p.as_matrix()
     array([[ 2.22044605e-16, -1.00000000e+00,  0.00000000e+00],
            [ 1.00000000e+00,  2.22044605e-16,  0.00000000e+00],
            [ 0.00000000e+00,  0.00000000e+00,  1.00000000e+00]])
@@ -883,7 +883,7 @@ class Rotation(object):
 
         Represent a single rotation:
 
-        >>> r = R.from_dcm([
+        >>> r = R.as_matrix([
         ... [0, -1, 0],
         ... [1, 0, 0],
         ... [0, 0, 1]])
@@ -1172,7 +1172,7 @@ class Rotation(object):
 
         seq = seq.lower()
 
-        angles = _compute_euler_from_dcm(self.as_dcm(), seq, extrinsic)
+        angles = _compute_euler_from_dcm(self.as_matrix(), seq, extrinsic)
         if degrees:
             angles = np.rad2deg(angles)
 
@@ -1191,7 +1191,7 @@ class Rotation(object):
               expressed in the original frame before and after the rotation.
 
         In terms of DCMs, this application is the same as
-        ``self.as_dcm().dot(vectors)``.
+        ``self.as_matrix().dot(vectors)``.
 
         Parameters
         ----------
@@ -1225,7 +1225,7 @@ class Rotation(object):
 
         >>> vector = np.array([1, 0, 0])
         >>> r = R.from_rotvec([0, 0, np.pi/2])
-        >>> r.as_dcm()
+        >>> r.as_matrix()
         array([[ 2.22044605e-16, -1.00000000e+00,  0.00000000e+00],
                [ 1.00000000e+00,  2.22044605e-16,  0.00000000e+00],
                [ 0.00000000e+00,  0.00000000e+00,  1.00000000e+00]])
@@ -1240,7 +1240,7 @@ class Rotation(object):
         ... [1, 0, 0],
         ... [1, 2, 3]])
         >>> r = R.from_rotvec([0, 0, np.pi/4])
-        >>> r.as_dcm()
+        >>> r.as_matrix()
         array([[ 0.70710678, -0.70710678,  0.        ],
                [ 0.70710678,  0.70710678,  0.        ],
                [ 0.        ,  0.        ,  1.        ]])
@@ -1254,7 +1254,7 @@ class Rotation(object):
 
         >>> r = R.from_rotvec([[0, 0, np.pi/4], [np.pi/2, 0, 0]])
         >>> vector = np.array([1,2,3])
-        >>> r.as_dcm()
+        >>> r.as_matrix()
         array([[[ 7.07106781e-01, -7.07106781e-01,  0.00000000e+00],
                 [ 7.07106781e-01,  7.07106781e-01,  0.00000000e+00],
                 [ 0.00000000e+00,  0.00000000e+00,  1.00000000e+00]],
@@ -1305,7 +1305,7 @@ class Rotation(object):
             single_vector = True
             vectors = vectors[None, :]
 
-        dcm = self.as_dcm()
+        dcm = self.as_matrix()
         if self._single:
             dcm = dcm[None, :, :]
 
@@ -1333,7 +1333,7 @@ class Rotation(object):
 
         If `p` and `q` are two rotations, then the composition of 'q followed
         by p' is equivalent to `p * q`. In terms of DCMs, the composition can
-        be expressed as `p.as_dcm().dot(q.as_dcm())`.
+        be expressed as `p.as_matrix().dot(q.as_matrix())`.
 
         Parameters
         ----------
@@ -1363,16 +1363,16 @@ class Rotation(object):
 
         >>> p = R.from_quat([0, 0, 1, 1])
         >>> q = R.from_quat([1, 0, 0, 1])
-        >>> p.as_dcm()
+        >>> p.as_matrix()
         array([[ 0., -1.,  0.],
                [ 1.,  0.,  0.],
                [ 0.,  0.,  1.]])
-        >>> q.as_dcm()
+        >>> q.as_matrix()
         array([[ 1.,  0.,  0.],
                [ 0.,  0., -1.],
                [ 0.,  1.,  0.]])
         >>> r = p * q
-        >>> r.as_dcm()
+        >>> r.as_matrix()
         array([[0., 0., 1.],
                [1., 0., 0.],
                [0., 1., 0.]])
@@ -1494,7 +1494,7 @@ class Rotation(object):
         The mean used is the chordal L2 mean (also called the projected or
         induced arithmetic mean). If ``p`` is a set of rotations with mean
         ``m``, then ``m`` is the rotation which minimizes
-        ``(weights[:, None, None] * (p.as_dcm() - m.as_dcm())**2).sum()``.
+        ``(weights[:, None, None] * (p.as_matrix() - m.as_matrix())**2).sum()``.
 
         Examples
         --------
@@ -1886,7 +1886,7 @@ class Rotation(object):
         kappa = s[0]*s[1] + s[1]*s[2] + s[2]*s[0]
         sensitivity = ((kappa * np.eye(3) + np.dot(B, B.T)) /
                        (zeta * a.shape[0]))
-        return cls.from_dcm(C), sensitivity
+        return cls.from_matrix(C), sensitivity
 
 
 class Slerp(object):

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -910,15 +910,15 @@ class Rotation(object):
         else:
             return self._quat.copy()
 
-    def as_dcm(self):
-        """Represent as direction cosine matrices.
+    def as_matrix(self):
+        """Represent as rotation matrix.
 
-        3D rotations can be represented using direction cosine matrices, which
+        3D rotations can be represented using rotation matrices, which
         are 3 x 3 real orthogonal matrices with determinant equal to +1 [1]_.
 
         Returns
         -------
-        dcm : ndarray, shape (3, 3) or (N, 3, 3)
+        matrix : ndarray, shape (3, 3) or (N, 3, 3)
             Shape depends on shape of inputs used for initialization.
 
         References
@@ -932,36 +932,35 @@ class Rotation(object):
         Represent a single rotation:
 
         >>> r = R.from_rotvec([0, 0, np.pi/2])
-        >>> r.as_dcm()
+        >>> r.as_matrix()
         array([[ 2.22044605e-16, -1.00000000e+00,  0.00000000e+00],
                [ 1.00000000e+00,  2.22044605e-16,  0.00000000e+00],
                [ 0.00000000e+00,  0.00000000e+00,  1.00000000e+00]])
-        >>> r.as_dcm().shape
+        >>> r.as_matrix().shape
         (3, 3)
 
         Represent a stack with a single rotation:
 
         >>> r = R.from_quat([[1, 1, 0, 0]])
-        >>> r.as_dcm()
+        >>> r.as_matrix()
         array([[[ 0.,  1.,  0.],
                 [ 1.,  0.,  0.],
                 [ 0.,  0., -1.]]])
-        >>> r.as_dcm().shape
+        >>> r.as_matrix().shape
         (1, 3, 3)
 
         Represent multiple rotations:
 
         >>> r = R.from_rotvec([[np.pi/2, 0, 0], [0, 0, np.pi/2]])
-        >>> r.as_dcm()
+        >>> r.as_matrix()
         array([[[ 1.00000000e+00,  0.00000000e+00,  0.00000000e+00],
                 [ 0.00000000e+00,  2.22044605e-16, -1.00000000e+00],
                 [ 0.00000000e+00,  1.00000000e+00,  2.22044605e-16]],
                [[ 2.22044605e-16, -1.00000000e+00,  0.00000000e+00],
                 [ 1.00000000e+00,  2.22044605e-16,  0.00000000e+00],
                 [ 0.00000000e+00,  0.00000000e+00,  1.00000000e+00]]])
-        >>> r.as_dcm().shape
+        >>> r.as_matrix().shape
         (2, 3, 3)
-
         """
         x = self._quat[:, 0]
         y = self._quat[:, 1]
@@ -981,24 +980,28 @@ class Rotation(object):
         xw = x * w
 
         num_rotations = len(self)
-        dcm = np.empty((num_rotations, 3, 3))
+        matrix = np.empty((num_rotations, 3, 3))
 
-        dcm[:, 0, 0] = x2 - y2 - z2 + w2
-        dcm[:, 1, 0] = 2 * (xy + zw)
-        dcm[:, 2, 0] = 2 * (xz - yw)
+        matrix[:, 0, 0] = x2 - y2 - z2 + w2
+        matrix[:, 1, 0] = 2 * (xy + zw)
+        matrix[:, 2, 0] = 2 * (xz - yw)
 
-        dcm[:, 0, 1] = 2 * (xy - zw)
-        dcm[:, 1, 1] = - x2 + y2 - z2 + w2
-        dcm[:, 2, 1] = 2 * (yz + xw)
+        matrix[:, 0, 1] = 2 * (xy - zw)
+        matrix[:, 1, 1] = - x2 + y2 - z2 + w2
+        matrix[:, 2, 1] = 2 * (yz + xw)
 
-        dcm[:, 0, 2] = 2 * (xz + yw)
-        dcm[:, 1, 2] = 2 * (yz - xw)
-        dcm[:, 2, 2] = - x2 - y2 + z2 + w2
+        matrix[:, 0, 2] = 2 * (xz + yw)
+        matrix[:, 1, 2] = 2 * (yz - xw)
+        matrix[:, 2, 2] = - x2 - y2 + z2 + w2
 
         if self._single:
-            return dcm[0]
+            return matrix[0]
         else:
-            return dcm
+            return matrix
+
+    @np.deprecate(message="as_dcm is renamed to as_matrix in scipy 1.4.0")
+    def as_dcm(self):
+        return self.as_matrix()
 
     def as_rotvec(self):
         """Represent as rotation vectors.

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -254,10 +254,9 @@ class Rotation(object):
 
     The same rotation can be initialized using a rotation matrix:
 
-    >>> r = R.as_matrix(np.array([
-    ... [0, -1, 0],
-    ... [1, 0, 0],
-    ... [0, 0, 1]]))
+    >>> r = R.from_matrix([[0, -1, 0],
+    ...                    [1, 0, 0],
+    ...                    [0, 0, 1]])
 
     Representation in other formats:
 
@@ -883,10 +882,9 @@ class Rotation(object):
 
         Represent a single rotation:
 
-        >>> r = R.as_matrix([
-        ... [0, -1, 0],
-        ... [1, 0, 0],
-        ... [0, 0, 1]])
+        >>> r = R.from_matrix([[0, -1, 0],
+        ...                    [1, 0, 0],
+        ...                    [0, 0, 1]])
         >>> r.as_quat()
         array([0.        , 0.        , 0.70710678, 0.70710678])
         >>> r.as_quat().shape
@@ -898,7 +896,7 @@ class Rotation(object):
         >>> r.as_quat().shape
         (1, 4)
 
-        Represent multiple rotaions in a single object:
+        Represent multiple rotations in a single object:
 
         >>> r = R.from_rotvec([[np.pi, 0, 0], [0, 0, np.pi/2]])
         >>> r.as_quat().shape

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -67,16 +67,16 @@ def test_zero_norms_from_quat():
         Rotation.from_quat(x)
 
 
-def test_as_dcm_single_1d_quaternion():
+def test_as_matrix_single_1d_quaternion():
     quat = [0, 0, 0, 1]
-    mat = Rotation.from_quat(quat).as_dcm()
+    mat = Rotation.from_quat(quat).as_matrix()
     # mat.shape == (3,3) due to 1d input
     assert_array_almost_equal(mat, np.eye(3))
 
 
-def test_as_dcm_single_2d_quaternion():
+def test_as_matrix_single_2d_quaternion():
     quat = [[0, 0, 1, 1]]
-    mat = Rotation.from_quat(quat).as_dcm()
+    mat = Rotation.from_quat(quat).as_matrix()
     assert_equal(mat.shape, (1, 3, 3))
     expected_mat = np.array([
         [0, -1, 0],
@@ -86,14 +86,14 @@ def test_as_dcm_single_2d_quaternion():
     assert_array_almost_equal(mat[0], expected_mat)
 
 
-def test_as_dcm_from_square_input():
+def test_as_matrix_from_square_input():
     quats = [
             [0, 0, 1, 1],
             [0, 1, 0, 1],
             [0, 0, 0, 1],
             [0, 0, 0, -1]
             ]
-    mat = Rotation.from_quat(quats).as_dcm()
+    mat = Rotation.from_quat(quats).as_matrix()
     assert_equal(mat.shape, (4, 3, 3))
 
     expected0 = np.array([
@@ -114,13 +114,13 @@ def test_as_dcm_from_square_input():
     assert_array_almost_equal(mat[3], np.eye(3))
 
 
-def test_as_dcm_from_generic_input():
+def test_as_matrix_from_generic_input():
     quats = [
             [0, 0, 1, 1],
             [0, 1, 0, 1],
             [1, 2, 3, 4]
             ]
-    mat = Rotation.from_quat(quats).as_dcm()
+    mat = Rotation.from_quat(quats).as_matrix()
     assert_equal(mat.shape, (3, 3, 3))
 
     expected0 = np.array([
@@ -145,57 +145,57 @@ def test_as_dcm_from_generic_input():
     assert_array_almost_equal(mat[2], expected2)
 
 
-def test_from_single_2d_dcm():
-    dcm = [
+def test_from_single_2d_matrix():
+    mat = [
             [0, 0, 1],
             [1, 0, 0],
             [0, 1, 0]
             ]
     expected_quat = [0.5, 0.5, 0.5, 0.5]
     assert_array_almost_equal(
-            Rotation.from_dcm(dcm).as_quat(),
+            Rotation.from_matrix(mat).as_quat(),
             expected_quat)
 
 
-def test_from_single_3d_dcm():
-    dcm = np.array([
+def test_from_single_3d_matrix():
+    mat = np.array([
         [0, 0, 1],
         [1, 0, 0],
         [0, 1, 0]
         ]).reshape((1, 3, 3))
     expected_quat = np.array([0.5, 0.5, 0.5, 0.5]).reshape((1, 4))
     assert_array_almost_equal(
-            Rotation.from_dcm(dcm).as_quat(),
+            Rotation.from_matrix(mat).as_quat(),
             expected_quat)
 
 
-def test_from_dcm_calculation():
+def test_from_matrix_calculation():
     expected_quat = np.array([1, 1, 6, 1]) / np.sqrt(39)
-    dcm = np.array([
+    mat = np.array([
             [-0.8974359, -0.2564103, 0.3589744],
             [0.3589744, -0.8974359, 0.2564103],
             [0.2564103, 0.3589744, 0.8974359]
             ])
     assert_array_almost_equal(
-            Rotation.from_dcm(dcm).as_quat(),
+            Rotation.from_matrix(mat).as_quat(),
             expected_quat)
     assert_array_almost_equal(
-            Rotation.from_dcm(dcm.reshape((1, 3, 3))).as_quat(),
+            Rotation.from_matrix(mat.reshape((1, 3, 3))).as_quat(),
             expected_quat.reshape((1, 4)))
 
 
-def test_dcm_calculation_pipeline():
-    dcm = special_ortho_group.rvs(3, size=10, random_state=0)
-    assert_array_almost_equal(Rotation.from_dcm(dcm).as_dcm(), dcm)
+def test_matrix_calculation_pipeline():
+    mat = special_ortho_group.rvs(3, size=10, random_state=0)
+    assert_array_almost_equal(Rotation.from_matrix(mat).as_matrix(), mat)
 
 
-def test_from_dcm_ortho_output():
+def test_from_matrix_ortho_output():
     np.random.seed(0)
     dcm = np.random.random((100, 3, 3))
-    ortho_dcm = Rotation.from_dcm(dcm).as_dcm()
+    ortho_mat = Rotation.from_matrix(dcm).as_matrix()
 
-    mult_result = np.einsum('...ij,...jk->...ik', ortho_dcm,
-                            ortho_dcm.transpose((0, 2, 1)))
+    mult_result = np.einsum('...ij,...jk->...ik', ortho_mat,
+                            ortho_mat.transpose((0, 2, 1)))
 
     eye3d = np.zeros((100, 3, 3))
     for i in range(3):
@@ -324,8 +324,8 @@ def test_from_euler_single_rotation():
 
 
 def test_single_intrinsic_extrinsic_rotation():
-    extrinsic = Rotation.from_euler('z', 90, degrees=True).as_dcm()
-    intrinsic = Rotation.from_euler('Z', 90, degrees=True).as_dcm()
+    extrinsic = Rotation.from_euler('z', 90, degrees=True).as_matrix()
+    intrinsic = Rotation.from_euler('Z', 90, degrees=True).as_matrix()
     assert_allclose(extrinsic, intrinsic)
 
 
@@ -341,13 +341,13 @@ def test_from_euler_rotation_order():
 
 def test_from_euler_elementary_extrinsic_rotation():
     # Simple test to check if extrinsic rotations are implemented correctly
-    dcm = Rotation.from_euler('zx', [90, 90], degrees=True).as_dcm()
+    mat = Rotation.from_euler('zx', [90, 90], degrees=True).as_matrix()
     expected_dcm = np.array([
         [0, -1, 0],
         [0, 0, -1],
         [1, 0, 0]
     ])
-    assert_array_almost_equal(dcm, expected_dcm)
+    assert_array_almost_equal(mat, expected_dcm)
 
 
 def test_from_euler_intrinsic_rotation_312():
@@ -356,21 +356,21 @@ def test_from_euler_intrinsic_rotation_312():
         [30, 60, 30],
         [45, 30, 60]
         ]
-    dcm = Rotation.from_euler('ZXY', angles, degrees=True).as_dcm()
+    mat = Rotation.from_euler('ZXY', angles, degrees=True).as_matrix()
 
-    assert_array_almost_equal(dcm[0], np.array([
+    assert_array_almost_equal(mat[0], np.array([
         [0.3061862, -0.2500000, 0.9185587],
         [0.8838835, 0.4330127, -0.1767767],
         [-0.3535534, 0.8660254, 0.3535534]
     ]))
 
-    assert_array_almost_equal(dcm[1], np.array([
+    assert_array_almost_equal(mat[1], np.array([
         [0.5334936, -0.2500000, 0.8080127],
         [0.8080127, 0.4330127, -0.3995191],
         [-0.2500000, 0.8660254, 0.4330127]
     ]))
 
-    assert_array_almost_equal(dcm[2], np.array([
+    assert_array_almost_equal(mat[2], np.array([
         [0.0473672, -0.6123725, 0.7891491],
         [0.6597396, 0.6123725, 0.4355958],
         [-0.7500000, 0.5000000, 0.4330127]
@@ -383,21 +383,21 @@ def test_from_euler_intrinsic_rotation_313():
         [30, 60, 30],
         [45, 30, 60]
         ]
-    dcm = Rotation.from_euler('ZXZ', angles, degrees=True).as_dcm()
+    mat = Rotation.from_euler('ZXZ', angles, degrees=True).as_matrix()
 
-    assert_array_almost_equal(dcm[0], np.array([
+    assert_array_almost_equal(mat[0], np.array([
         [0.43559574, -0.78914913, 0.4330127],
         [0.65973961, -0.04736717, -0.750000],
         [0.61237244, 0.61237244, 0.500000]
     ]))
 
-    assert_array_almost_equal(dcm[1], np.array([
+    assert_array_almost_equal(mat[1], np.array([
         [0.6250000, -0.64951905, 0.4330127],
         [0.64951905, 0.1250000, -0.750000],
         [0.4330127, 0.750000, 0.500000]
     ]))
 
-    assert_array_almost_equal(dcm[2], np.array([
+    assert_array_almost_equal(mat[2], np.array([
         [-0.1767767, -0.91855865, 0.35355339],
         [0.88388348, -0.30618622, -0.35355339],
         [0.4330127, 0.25000000, 0.8660254]
@@ -410,21 +410,21 @@ def test_from_euler_extrinsic_rotation_312():
         [30, 60, 30],
         [45, 30, 60]
         ]
-    dcm = Rotation.from_euler('zxy', angles, degrees=True).as_dcm()
+    mat = Rotation.from_euler('zxy', angles, degrees=True).as_matrix()
 
-    assert_array_almost_equal(dcm[0], np.array([
+    assert_array_almost_equal(mat[0], np.array([
         [0.91855865, 0.1767767, 0.35355339],
         [0.25000000, 0.4330127, -0.8660254],
         [-0.30618622, 0.88388348, 0.35355339]
     ]))
 
-    assert_array_almost_equal(dcm[1], np.array([
+    assert_array_almost_equal(mat[1], np.array([
         [0.96650635, -0.0580127, 0.2500000],
         [0.25000000, 0.4330127, -0.8660254],
         [-0.0580127, 0.89951905, 0.4330127]
     ]))
 
-    assert_array_almost_equal(dcm[2], np.array([
+    assert_array_almost_equal(mat[2], np.array([
         [0.65973961, -0.04736717, 0.7500000],
         [0.61237244, 0.61237244, -0.5000000],
         [-0.43559574, 0.78914913, 0.4330127]
@@ -437,21 +437,21 @@ def test_from_euler_extrinsic_rotation_313():
         [30, 60, 30],
         [45, 30, 60]
         ]
-    dcm = Rotation.from_euler('zxz', angles, degrees=True).as_dcm()
+    mat = Rotation.from_euler('zxz', angles, degrees=True).as_matrix()
 
-    assert_array_almost_equal(dcm[0], np.array([
+    assert_array_almost_equal(mat[0], np.array([
         [0.43559574, -0.65973961, 0.61237244],
         [0.78914913, -0.04736717, -0.61237244],
         [0.4330127, 0.75000000, 0.500000]
     ]))
 
-    assert_array_almost_equal(dcm[1], np.array([
+    assert_array_almost_equal(mat[1], np.array([
         [0.62500000, -0.64951905, 0.4330127],
         [0.64951905, 0.12500000, -0.750000],
         [0.4330127, 0.75000000, 0.500000]
     ]))
 
-    assert_array_almost_equal(dcm[2], np.array([
+    assert_array_almost_equal(mat[2], np.array([
         [-0.1767767, -0.88388348, 0.4330127],
         [0.91855865, -0.30618622, -0.250000],
         [0.35355339, 0.35355339, 0.8660254]
@@ -511,26 +511,26 @@ def test_as_euler_degenerate_asymmetric_axes():
             # Extrinsic rotations
             seq = ''.join(seq_tuple)
             rotation = Rotation.from_euler(seq, angles, degrees=True)
-            dcm_expected = rotation.as_dcm()
+            mat_expected = rotation.as_matrix()
 
             angle_estimates = rotation.as_euler(seq, degrees=True)
-            dcm_estimated = Rotation.from_euler(
+            mat_estimated = Rotation.from_euler(
                 seq, angle_estimates, degrees=True
-                ).as_dcm()
+                ).as_matrix()
 
-            assert_array_almost_equal(dcm_expected, dcm_estimated)
+            assert_array_almost_equal(mat_expected, mat_estimated)
 
             # Intrinsic rotations
             seq = seq.upper()
             rotation = Rotation.from_euler(seq, angles, degrees=True)
-            dcm_expected = rotation.as_dcm()
+            mat_expected = rotation.as_matrix()
 
             angle_estimates = rotation.as_euler(seq, degrees=True)
-            dcm_estimated = Rotation.from_euler(
+            mat_estimated = Rotation.from_euler(
                 seq, angle_estimates, degrees=True
-                ).as_dcm()
+                ).as_matrix()
 
-            assert_array_almost_equal(dcm_expected, dcm_estimated)
+            assert_array_almost_equal(mat_expected, mat_estimated)
 
 
 def test_as_euler_degenerate_symmetric_axes():
@@ -551,26 +551,26 @@ def test_as_euler_degenerate_symmetric_axes():
                 # Extrinsic rotations
                 seq = axis1 + axis2 + axis1
                 rotation = Rotation.from_euler(seq, angles, degrees=True)
-                dcm_expected = rotation.as_dcm()
+                mat_expected = rotation.as_matrix()
 
                 angle_estimates = rotation.as_euler(seq, degrees=True)
-                dcm_estimated = Rotation.from_euler(
+                mat_estimated = Rotation.from_euler(
                     seq, angle_estimates, degrees=True
-                    ).as_dcm()
+                    ).as_matrix()
 
-                assert_array_almost_equal(dcm_expected, dcm_estimated)
+                assert_array_almost_equal(mat_expected, mat_estimated)
 
                 # Intrinsic rotations
                 seq = seq.upper()
                 rotation = Rotation.from_euler(seq, angles, degrees=True)
-                dcm_expected = rotation.as_dcm()
+                mat_expected = rotation.as_matrix()
 
                 angle_estimates = rotation.as_euler(seq, degrees=True)
-                dcm_estimated = Rotation.from_euler(
+                mat_estimated = Rotation.from_euler(
                     seq, angle_estimates, degrees=True
-                    ).as_dcm()
+                    ).as_matrix()
 
-                assert_array_almost_equal(dcm_expected, dcm_estimated)
+                assert_array_almost_equal(mat_expected, mat_estimated)
 
 
 def test_inv():
@@ -579,10 +579,10 @@ def test_inv():
     p = Rotation.from_quat(np.random.normal(size=(n, 4)))
     q = p.inv()
 
-    p_dcm = p.as_dcm()
-    q_dcm = q.as_dcm()
-    result1 = np.einsum('...ij,...jk->...ik', p_dcm, q_dcm)
-    result2 = np.einsum('...ij,...jk->...ik', q_dcm, p_dcm)
+    p_mat = p.as_matrix()
+    q_mat = q.as_matrix()
+    result1 = np.einsum('...ij,...jk->...ik', p_mat, q_mat)
+    result2 = np.einsum('...ij,...jk->...ik', q_mat, p_mat)
 
     eye3d = np.empty((n, 3, 3))
     eye3d[:] = np.eye(3)
@@ -596,10 +596,10 @@ def test_inv_single_rotation():
     p = Rotation.from_quat(np.random.normal(size=(4,)))
     q = p.inv()
 
-    p_dcm = p.as_dcm()
-    q_dcm = q.as_dcm()
-    res1 = np.dot(p_dcm, q_dcm)
-    res2 = np.dot(q_dcm, p_dcm)
+    p_mat = p.as_matrix()
+    q_mat = q.as_matrix()
+    res1 = np.dot(p_mat, q_mat)
+    res2 = np.dot(q_mat, p_mat)
 
     eye = np.eye(3)
 
@@ -609,10 +609,10 @@ def test_inv_single_rotation():
     x = Rotation.from_quat(np.random.normal(size=(1, 4)))
     y = x.inv()
 
-    x_dcm = x.as_dcm()
-    y_dcm = y.as_dcm()
-    result1 = np.einsum('...ij,...jk->...ik', x_dcm, y_dcm)
-    result2 = np.einsum('...ij,...jk->...ik', y_dcm, x_dcm)
+    x_matrix = x.as_matrix()
+    y_matrix = y.as_matrix()
+    result1 = np.einsum('...ij,...jk->...ik', x_matrix, y_matrix)
+    result2 = np.einsum('...ij,...jk->...ik', y_matrix, x_matrix)
 
     eye3d = np.empty((1, 3, 3))
     eye3d[:] = np.eye(3)
@@ -734,13 +734,13 @@ def test_reduction_scalar_calculation():
 
 
 def test_apply_single_rotation_single_point():
-    dcm = np.array([
+    mat = np.array([
         [0, -1, 0],
         [1, 0, 0],
         [0, 0, 1]
     ])
-    r_1d = Rotation.from_dcm(dcm)
-    r_2d = Rotation.from_dcm(np.expand_dims(dcm, axis=0))
+    r_1d = Rotation.from_matrix(mat)
+    r_2d = Rotation.from_matrix(np.expand_dims(mat, axis=0))
 
     v_1d = np.array([1, 2, 3])
     v_2d = np.expand_dims(v_1d, axis=0)
@@ -762,13 +762,13 @@ def test_apply_single_rotation_single_point():
 
 
 def test_apply_single_rotation_multiple_points():
-    dcm = np.array([
+    mat = np.array([
         [0, -1, 0],
         [1, 0, 0],
         [0, 0, 1]
     ])
-    r1 = Rotation.from_dcm(dcm)
-    r2 = Rotation.from_dcm(np.expand_dims(dcm, axis=0))
+    r1 = Rotation.from_matrix(mat)
+    r2 = Rotation.from_matrix(np.expand_dims(mat, axis=0))
 
     v = np.array([[1, 2, 3], [4, 5, 6]])
     v_rotated = np.array([[-2, 1, 3], [-5, 4, 6]])
@@ -783,18 +783,18 @@ def test_apply_single_rotation_multiple_points():
 
 
 def test_apply_multiple_rotations_single_point():
-    dcm = np.empty((2, 3, 3))
-    dcm[0] = np.array([
+    mat = np.empty((2, 3, 3))
+    mat[0] = np.array([
         [0, -1, 0],
         [1, 0, 0],
         [0, 0, 1]
     ])
-    dcm[1] = np.array([
+    mat[1] = np.array([
         [1, 0, 0],
         [0, 0, -1],
         [0, 1, 0]
     ])
-    r = Rotation.from_dcm(dcm)
+    r = Rotation.from_matrix(mat)
 
     v1 = np.array([1, 2, 3])
     v2 = np.expand_dims(v1, axis=0)
@@ -811,18 +811,18 @@ def test_apply_multiple_rotations_single_point():
 
 
 def test_apply_multiple_rotations_multiple_points():
-    dcm = np.empty((2, 3, 3))
-    dcm[0] = np.array([
+    mat = np.empty((2, 3, 3))
+    mat[0] = np.array([
         [0, -1, 0],
         [1, 0, 0],
         [0, 0, 1]
     ])
-    dcm[1] = np.array([
+    mat[1] = np.array([
         [1, 0, 0],
         [0, 0, -1],
         [0, 1, 0]
     ])
-    r = Rotation.from_dcm(dcm)
+    r = Rotation.from_matrix(mat)
 
     v = np.array([[1, 2, 3], [4, 5, 6]])
     v_rotated = np.array([[-2, 1, 3], [4, -6, 5]])
@@ -833,37 +833,37 @@ def test_apply_multiple_rotations_multiple_points():
 
 
 def test_getitem():
-    dcm = np.empty((2, 3, 3))
-    dcm[0] = np.array([
+    mat = np.empty((2, 3, 3))
+    mat[0] = np.array([
         [0, -1, 0],
         [1, 0, 0],
         [0, 0, 1]
     ])
-    dcm[1] = np.array([
+    mat[1] = np.array([
         [1, 0, 0],
         [0, 0, -1],
         [0, 1, 0]
     ])
-    r = Rotation.from_dcm(dcm)
+    r = Rotation.from_matrix(mat)
 
-    assert_allclose(r[0].as_dcm(), dcm[0])
-    assert_allclose(r[1].as_dcm(), dcm[1])
-    assert_allclose(r[:-1].as_dcm(), np.expand_dims(dcm[0], axis=0))
+    assert_allclose(r[0].as_matrix(), mat[0])
+    assert_allclose(r[1].as_matrix(), mat[1])
+    assert_allclose(r[:-1].as_matrix(), np.expand_dims(mat[0], axis=0))
 
 
 def test_n_rotations():
-    dcm = np.empty((2, 3, 3))
-    dcm[0] = np.array([
+    mat = np.empty((2, 3, 3))
+    mat[0] = np.array([
         [0, -1, 0],
         [1, 0, 0],
         [0, 0, 1]
     ])
-    dcm[1] = np.array([
+    mat[1] = np.array([
         [1, 0, 0],
         [0, 0, -1],
         [0, 1, 0]
     ])
-    r = Rotation.from_dcm(dcm)
+    r = Rotation.from_matrix(mat)
 
     assert_equal(len(r), 2)
     assert_equal(len(r[0]), 1)
@@ -890,7 +890,7 @@ def test_match_vectors_no_rotation():
     y = x.copy()
 
     r, p = Rotation.match_vectors(x, y)
-    assert_array_almost_equal(r.as_dcm(), np.eye(3))
+    assert_array_almost_equal(r.as_matrix(), np.eye(3))
 
 
 def test_match_vectors_no_noise():

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -191,8 +191,8 @@ def test_matrix_calculation_pipeline():
 
 def test_from_matrix_ortho_output():
     np.random.seed(0)
-    dcm = np.random.random((100, 3, 3))
-    ortho_mat = Rotation.from_matrix(dcm).as_matrix()
+    mat = np.random.random((100, 3, 3))
+    ortho_mat = Rotation.from_matrix(mat).as_matrix()
 
     mult_result = np.einsum('...ij,...jk->...ik', ortho_mat,
                             ortho_mat.transpose((0, 2, 1)))
@@ -342,12 +342,12 @@ def test_from_euler_rotation_order():
 def test_from_euler_elementary_extrinsic_rotation():
     # Simple test to check if extrinsic rotations are implemented correctly
     mat = Rotation.from_euler('zx', [90, 90], degrees=True).as_matrix()
-    expected_dcm = np.array([
+    expected_mat = np.array([
         [0, -1, 0],
         [0, 0, -1],
         [1, 0, 0]
     ])
-    assert_array_almost_equal(mat, expected_dcm)
+    assert_array_almost_equal(mat, expected_mat)
 
 
 def test_from_euler_intrinsic_rotation_312():
@@ -498,7 +498,8 @@ def test_as_euler_symmetric_axes():
 
 
 def test_as_euler_degenerate_asymmetric_axes():
-    # Since we cannot check for angle equality, we check for dcm equality
+    # Since we cannot check for angle equality, we check for rotation matrix
+    # equality
     angles = np.array([
         [45, 90, 35],
         [35, -90, 20],
@@ -534,7 +535,8 @@ def test_as_euler_degenerate_asymmetric_axes():
 
 
 def test_as_euler_degenerate_symmetric_axes():
-    # Since we cannot check for angle equality, we check for dcm equality
+    # Since we cannot check for angle equality, we check for rotation matrix
+    # equality
     angles = np.array([
         [15, 0, 60],
         [35, 0, 75],


### PR DESCRIPTION
#### Reference issue

#10959

#### What does this implement/fix?

As discussed in #10959  the term "Direction Cosine Matrix" is not very common and "Rotation Matrix" is a better alternative. So here I introduce `from_matrix/as_matrix` methods whereas `from_dcm/as_dcm` are marked as deprecated. Only "rotation matrix" is mentioned in the docstrings and in the code now.