### PR TITLE
MAINT: add support for a==0 and x>0 edge case to igam and igamc

### DIFF
--- a/scipy/special/cephes/igam.c
+++ b/scipy/special/cephes/igam.c
@@ -129,7 +129,7 @@ double igam(double a, double x)
 {
     double absxma_a;
 
-    if(x < 0 || a < 0) {
+    if (x < 0 || a < 0) {
         sf_error("gammainc", SF_ERROR_DOMAIN, NULL);
         return NPY_NAN;
     } else if (a == 0) {

--- a/scipy/special/cephes/igam.c
+++ b/scipy/special/cephes/igam.c
@@ -129,25 +129,25 @@ double igam(double a, double x)
 {
     double absxma_a;
 
-    if (x < 0 || a < 0) {
-	sf_error("gammainc", SF_ERROR_DOMAIN, NULL);
-	return NPY_NAN;
+    if(x < 0 || a < 0) {
+        sf_error("gammainc", SF_ERROR_DOMAIN, NULL);
+        return NPY_NAN;
     } else if (a == 0) {
-	    if(x > 0) {
-		return 1;
-	    } else {
-		return NPY_NAN;
-	    }
-    } else if (npy_isinf(a)) {
-	if (npy_isinf(x)) {
-	    return NPY_NAN;
-	}
-	return 0;
+        if (x > 0) {
+            return 1;
+        } else {
+            return NPY_NAN;
+        }
     } else if (x == 0) {
-	/* Zero integration limit */
-	return 0;
+        /* Zero integration limit */
+        return 0;
+    } else if (npy_isinf(a)) {
+        if (npy_isinf(x)) {
+            return NPY_NAN;
+        }
+        return 0;
     } else if (npy_isinf(x)) {
-	return 1;
+        return 1;
     }
 
     /* Asymptotic regime where a ~ x; see [2]. */
@@ -174,17 +174,17 @@ double igamc(double a, double x)
 	sf_error("gammaincc", SF_ERROR_DOMAIN, NULL);
 	return NPY_NAN;
     } else if (a == 0) {
-        if ( x > 0 ) {
-		return 0;
+        if (x > 0) {
+	    return 0;
 	} else {
-		return NPY_NAN;
+	    return NPY_NAN;
 	}
+    } else if (x == 0) {
+	return 1;
     } else if (npy_isinf(a)) {
 	if (npy_isinf(x)) {
 	    return NPY_NAN;
 	}
-	return 1;
-    } else if (x == 0) {
 	return 1;
     } else if (npy_isinf(x)) {
 	return 0;

--- a/scipy/special/cephes/igam.c
+++ b/scipy/special/cephes/igam.c
@@ -129,9 +129,15 @@ double igam(double a, double x)
 {
     double absxma_a;
 
-    if (x < 0 || a <= 0) {
+    if (x < 0 || a < 0) {
 	sf_error("gammainc", SF_ERROR_DOMAIN, NULL);
 	return NPY_NAN;
+    } else if (a == 0) {
+	    if(x > 0) {
+		return 1;
+	    } else {
+		return NPY_NAN;
+	    }
     } else if (npy_isinf(a)) {
 	if (npy_isinf(x)) {
 	    return NPY_NAN;
@@ -164,9 +170,15 @@ double igamc(double a, double x)
 {
     double absxma_a;
 
-    if (x < 0 || a <= 0) {
+    if (x < 0 || a < 0) {
 	sf_error("gammaincc", SF_ERROR_DOMAIN, NULL);
 	return NPY_NAN;
+    } else if (a == 0) {
+        if ( x > 0 ) {
+		return 0;
+	} else {
+		return NPY_NAN;
+	}
     } else if (npy_isinf(a)) {
 	if (npy_isinf(x)) {
 	    return NPY_NAN;

--- a/scipy/special/tests/test_gammainc.py
+++ b/scipy/special/tests/test_gammainc.py
@@ -55,12 +55,10 @@ class TestGammainc(object):
         a = np.arange(1, 10)
         assert_array_equal(sc.gammainc(a, 0), 0)
 
-    def test_nan_at_a_and_x_0(self):
-        assert np.isnan(sc.gammainc(0,0))
-
     def test_limit_check(self):
         result = sc.gammainc(1e-10, 1)
-        assert np.isclose(result, 1)
+        limit = sc.gammainc(0, 1)
+        assert np.isclose(result, limit)
 
     def gammainc_line(self, x):
         # The line a = x where a simpler asymptotic expansion (analog
@@ -123,13 +121,10 @@ class TestGammaincc(object):
             rtol=0
         )
 
-    def test_nan_a_and_x_0(self):
-        result = sc.gammaincc(0,0)
-        assert np.isnan(result)
-
     def test_limit_check(self):
-        limit = sc.gammaincc(1e-10,1)
-        assert np.isclose(limit, 0)
+        result = sc.gammaincc(1e-10,1)
+        limit = sc.gammaincc(0,1)
+        assert np.isclose(result, limit)
 
     def test_x_zero(self):
         a = np.arange(1, 10)

--- a/scipy/special/tests/test_gammainc.py
+++ b/scipy/special/tests/test_gammainc.py
@@ -13,7 +13,6 @@ INVALID_POINTS = [
     (1, -1),
     (0, 0),
     (-1, 1),
-    (0, 1),
     (np.nan, 1),
     (1, np.nan)
 ]
@@ -24,6 +23,9 @@ class TestGammainc(object):
     @pytest.mark.parametrize('a, x', INVALID_POINTS)
     def test_domain(self, a, x):
         assert np.isnan(sc.gammainc(a, x))
+
+    def test_a_eq_0_x_gt_0(self):
+        assert sc.gammainc(0, 1) == 1
 
     @pytest.mark.parametrize('a, x, desired', [
         (np.inf, 1, 0),
@@ -86,6 +88,9 @@ class TestGammaincc(object):
     @pytest.mark.parametrize('a, x', INVALID_POINTS)
     def test_domain(self, a, x):
         assert np.isnan(sc.gammaincc(a, x))
+
+    def test_a_eq_0_x_gt_0(self):
+        assert sc.gammaincc(0, 1) == 0
 
     @pytest.mark.parametrize('a, x, desired', [
         (np.inf, 1, 1),

--- a/scipy/special/tests/test_gammainc.py
+++ b/scipy/special/tests/test_gammainc.py
@@ -55,6 +55,13 @@ class TestGammainc(object):
         a = np.arange(1, 10)
         assert_array_equal(sc.gammainc(a, 0), 0)
 
+    def test_nan_at_a_and_x_0(self):
+        assert np.isnan(sc.gammainc(0,0))
+
+    def test_limit_check(self):
+        result = sc.gammainc(1e-10, 1)
+        assert np.isclose(result, 1)
+
     def gammainc_line(self, x):
         # The line a = x where a simpler asymptotic expansion (analog
         # of DLMF 8.12.15) is available.
@@ -115,6 +122,14 @@ class TestGammaincc(object):
             atol=1e-200,  # Use `atol` since the function converges to 0.
             rtol=0
         )
+
+    def test_nan_a_and_x_0(self):
+        result = sc.gammaincc(0,0)
+        assert np.isnan(result)
+
+    def test_limit_check(self):
+        limit = sc.gammaincc(1e-10,1)
+        assert np.isclose(limit, 0)
 
     def test_x_zero(self):
         a = np.arange(1, 10)


### PR DESCRIPTION
#### Reference issue
Closes #10948 

#### What does this implement/fix?
Adds the edge case of `a==0 && x>0` to not emit  `nan` in `igamc` and `igam` and adds unit tests for the new values. 