### PR TITLE
BUG: signal: fixed issue #10360

### DIFF
--- a/scipy/signal/fir_filter_design.py
+++ b/scipy/signal/fir_filter_design.py
@@ -641,8 +641,8 @@ def firwin2(numtaps, freq, gain, nfreqs=None, window='hamming', nyq=None,
         # Tweak any repeated values in freq so that interp works.
         freq = np.array(freq, copy=True)
         eps = np.finfo(float).eps * nyq
-        for k in range(len(freq)):
-            if k < len(freq) - 1 and freq[k] == freq[k + 1]:
+        for k in range(len(freq) - 1):
+            if freq[k] == freq[k + 1]:
                 freq[k] = freq[k] - eps
                 freq[k + 1] = freq[k + 1] + eps
         # Check if freq is strictly increasing after tweak

--- a/scipy/signal/fir_filter_design.py
+++ b/scipy/signal/fir_filter_design.py
@@ -637,7 +637,7 @@ def firwin2(numtaps, freq, gain, nfreqs=None, window='hamming', nyq=None,
         freq = np.array(freq, copy=True)
 
     # Tweak any repeated values in freq so that interp works.
-    eps = np.finfo(float).eps
+    eps = np.finfo(float).eps * nyq
     for k in range(len(freq)):
         if k < len(freq) - 1 and freq[k] == freq[k + 1]:
             freq[k] = freq[k] - eps

--- a/scipy/signal/fir_filter_design.py
+++ b/scipy/signal/fir_filter_design.py
@@ -637,23 +637,20 @@ def firwin2(numtaps, freq, gain, nfreqs=None, window='hamming', nyq=None,
     if nfreqs is None:
         nfreqs = 1 + 2 ** int(ceil(log(numtaps, 2)))
 
-    d = np.diff(freq)
     if (d == 0).any():
+        # Tweak any repeated values in freq so that interp works.
         freq = np.array(freq, copy=True)
-
-    # Tweak any repeated values in freq so that interp works.
-    eps = np.finfo(float).eps * nyq
-    for k in range(len(freq)):
-        if k < len(freq) - 1 and freq[k] == freq[k + 1]:
-            freq[k] = freq[k] - eps
-            freq[k + 1] = freq[k + 1] + eps
-
-    # Check if freq is strictly increasing after tweak
-    d = np.diff(freq)
-    if (d <= 0).any():
-        raise ValueError("freq cannot contain numbers that are too close "
-                         "(within eps * nyquist: "
-                         "{}) to a repeated value".format(eps))
+        eps = np.finfo(float).eps * nyq
+        for k in range(len(freq)):
+            if k < len(freq) - 1 and freq[k] == freq[k + 1]:
+                freq[k] = freq[k] - eps
+                freq[k + 1] = freq[k + 1] + eps
+        # Check if freq is strictly increasing after tweak
+        d = np.diff(freq)
+        if (d <= 0).any():
+            raise ValueError("freq cannot contain numbers that are too close "
+                             "(within eps * (fs/2): "
+                             "{}) to a repeated value".format(eps))
 
     # Linearly interpolate the desired response on a uniform mesh `x`.
     x = np.linspace(0.0, nyq, nfreqs)

--- a/scipy/signal/fir_filter_design.py
+++ b/scipy/signal/fir_filter_design.py
@@ -651,8 +651,9 @@ def firwin2(numtaps, freq, gain, nfreqs=None, window='hamming', nyq=None,
     # Check if freq is strictly increasing after tweak
     d = np.diff(freq)
     if (d <= 0).any():
-        raise ValueError("Freq cannot contain number that is too "
-                         "close to some repeated value")
+        raise ValueError("freq cannot contain numbers that are too close "
+                         "(within eps * nyquist: "
+                         "{}) to a repeated value".format(eps))
 
     # Linearly interpolate the desired response on a uniform mesh `x`.
     x = np.linspace(0.0, nyq, nfreqs)

--- a/scipy/signal/fir_filter_design.py
+++ b/scipy/signal/fir_filter_design.py
@@ -607,6 +607,10 @@ def firwin2(numtaps, freq, gain, nfreqs=None, window='hamming', nyq=None,
     d2 = d[:-1] + d[1:]
     if (d2 == 0).any():
         raise ValueError('A value in freq must not occur more than twice.')
+    if freq[1] == 0:
+        raise ValueError('Value 0 must not be repeated in freq')
+    if freq[-2] == nyq:
+        raise ValueError('Value fs/2 must not be repeated in freq')
 
     if antisymmetric:
         if numtaps % 2 == 0:
@@ -642,6 +646,12 @@ def firwin2(numtaps, freq, gain, nfreqs=None, window='hamming', nyq=None,
         if k < len(freq) - 1 and freq[k] == freq[k + 1]:
             freq[k] = freq[k] - eps
             freq[k + 1] = freq[k + 1] + eps
+
+    # Check if freq is strictly increasing after tweak
+    d = np.diff(freq)
+    if (d <= 0).any():
+        raise ValueError("Freq cannot contain number that is too "
+                         "close to some repeated value")
 
     # Linearly interpolate the desired response on a uniform mesh `x`.
     x = np.linspace(0.0, nyq, nfreqs)

--- a/scipy/signal/fir_filter_design.py
+++ b/scipy/signal/fir_filter_design.py
@@ -505,7 +505,8 @@ def firwin2(numtaps, freq, gain, nfreqs=None, window='hamming', nyq=None,
         Nyquist.  The Nyquist frequency is half `fs`.
         The values in `freq` must be nondecreasing.  A value can be repeated
         once to implement a discontinuity.  The first value in `freq` must
-        be 0, and the last value must be ``fs/2``.
+        be 0, and the last value must be ``fs/2``. Values 0 and ``fs/2`` must
+        not be repeated.
     gain : array_like
         The filter gains at the frequency sampling points. Certain
         constraints to gain values, depending on the filter type, are applied,

--- a/scipy/signal/fir_filter_design.py
+++ b/scipy/signal/fir_filter_design.py
@@ -632,6 +632,10 @@ def firwin2(numtaps, freq, gain, nfreqs=None, window='hamming', nyq=None,
     if nfreqs is None:
         nfreqs = 1 + 2 ** int(ceil(log(numtaps, 2)))
 
+    d = np.diff(freq)
+    if (d == 0).any():
+        freq = np.array(freq, copy=True)
+
     # Tweak any repeated values in freq so that interp works.
     eps = np.finfo(float).eps
     for k in range(len(freq)):

--- a/scipy/signal/tests/test_fir_filter_design.py
+++ b/scipy/signal/tests/test_fir_filter_design.py
@@ -278,42 +278,50 @@ class TestFirwin2(object):
 
     def test_invalid_args(self):
         # `freq` and `gain` have different lengths.
-        assert_raises(ValueError, firwin2, 50, [0, 0.5, 1], [0.0, 1.0])
+        with assert_raises(ValueError, match='must be of same length'):
+            firwin2(50, [0, 0.5, 1], [0.0, 1.0])
         # `nfreqs` is less than `ntaps`.
-        assert_raises(ValueError, firwin2, 50, [0, 0.5, 1], [0.0, 1.0, 1.0], nfreqs=33)
+        with assert_raises(ValueError, match='ntaps must be less than nfreqs'):
+            firwin2(50, [0, 0.5, 1], [0.0, 1.0, 1.0], nfreqs=33)
         # Decreasing value in `freq`
-        assert_raises(ValueError, firwin2, 50, [0, 0.5, 0.4, 1.0], [0, .25, .5, 1.0])
+        with assert_raises(ValueError, match='must be nondecreasing'):
+            firwin2(50, [0, 0.5, 0.4, 1.0], [0, .25, .5, 1.0])
         # Value in `freq` repeated more than once.
-        assert_raises(ValueError, firwin2, 50, [0, .1, .1, .1, 1.0],
-                                               [0.0, 0.5, 0.75, 1.0, 1.0])
+        with assert_raises(ValueError, match='must not occur more than twice'):
+            firwin2(50, [0, .1, .1, .1, 1.0], [0.0, 0.5, 0.75, 1.0, 1.0])
         # `freq` does not start at 0.0.
-        assert_raises(ValueError, firwin2, 50, [0.5, 1.0], [0.0, 1.0])
+        with assert_raises(ValueError, match='start with 0'):
+            firwin2(50, [0.5, 1.0], [0.0, 1.0])
         # `freq` does not end at fs/2.
-        assert_raises(ValueError, firwin2, 50, [0.0, 0.5], [0.0, 1.0])
+        with assert_raises(ValueError, match='end with fs/2'):
+            firwin2(50, [0.0, 0.5], [0.0, 1.0])
         # Value 0 is repeated in `freq`
-        assert_raises(ValueError, firwin2, 50, [0.0, 0.0, 0.5, 1.0],
-                                               [1.0, 1.0, 0.0, 0.0])
+        with assert_raises(ValueError, match='0 must not be repeated'):
+            firwin2(50, [0.0, 0.0, 0.5, 1.0], [1.0, 1.0, 0.0, 0.0])
         # Value fs/2 is repeated in `freq`
-        assert_raises(ValueError, firwin2, 50, [0.0, 0.5, 1.0, 1.0],
-                                               [1.0, 1.0, 0.0, 0.0])
+        with assert_raises(ValueError, match='fs/2 must not be repeated'):
+            firwin2(50, [0.0, 0.5, 1.0, 1.0], [1.0, 1.0, 0.0, 0.0])
         # Value in `freq` that is too close to a repeated number
-        assert_raises(ValueError, firwin2, 50,
-                      [0.0, 0.5 - np.finfo(float).eps * 0.5, 0.5, 0.5, 1.0],
-                      [1.0, 1.0, 1.0, 0.0, 0.0])
+        with assert_raises(ValueError, match='cannot contain numbers '
+                                             'that are too close'):
+            firwin2(50, [0.0, 0.5 - np.finfo(float).eps * 0.5, 0.5, 0.5, 1.0],
+                        [1.0, 1.0, 1.0, 0.0, 0.0])
+
         # Type II filter, but the gain at nyquist frequency is not zero.
-        assert_raises(ValueError, firwin2, 16, [0.0, 0.5, 1.0], [0.0, 1.0, 1.0])
+        with assert_raises(ValueError, match='Type II filter'):
+            firwin2(16, [0.0, 0.5, 1.0], [0.0, 1.0, 1.0])
 
         # Type III filter, but the gains at nyquist and zero rate are not zero.
-        assert_raises(ValueError, firwin2, 17, [0.0, 0.5, 1.0], [0.0, 1.0, 1.0],
-                      antisymmetric=True)
-        assert_raises(ValueError, firwin2, 17, [0.0, 0.5, 1.0], [1.0, 1.0, 0.0],
-                      antisymmetric=True)
-        assert_raises(ValueError, firwin2, 17, [0.0, 0.5, 1.0], [1.0, 1.0, 1.0],
-                      antisymmetric=True)
+        with assert_raises(ValueError, match='Type III filter'):
+            firwin2(17, [0.0, 0.5, 1.0], [0.0, 1.0, 1.0], antisymmetric=True)
+        with assert_raises(ValueError, match='Type III filter'):
+            firwin2(17, [0.0, 0.5, 1.0], [1.0, 1.0, 0.0], antisymmetric=True)
+        with assert_raises(ValueError, match='Type III filter'):
+            firwin2(17, [0.0, 0.5, 1.0], [1.0, 1.0, 1.0], antisymmetric=True)
 
         # Type IV filter, but the gain at zero rate is not zero.
-        assert_raises(ValueError, firwin2, 16, [0.0, 0.5, 1.0], [1.0, 1.0, 0.0],
-                      antisymmetric=True)
+        with assert_raises(ValueError, match='Type IV filter'):
+            firwin2(16, [0.0, 0.5, 1.0], [1.0, 1.0, 0.0], antisymmetric=True)
 
     def test01(self):
         width = 0.04

--- a/scipy/signal/tests/test_fir_filter_design.py
+++ b/scipy/signal/tests/test_fir_filter_design.py
@@ -392,6 +392,18 @@ class TestFirwin2(object):
         taps2 = firwin2(80, [0.0, 30.0, 60.0], [1.0, 1.0, 0.0], nyq=60.0)
         assert_array_almost_equal(taps1, taps2)
 
+    def test_tuple(self):
+        taps1 = firwin2(150, (0.0, 0.5, 0.5, 1.0), (1.0, 1.0, 0.0, 0.0))
+        taps2 = firwin2(150, [0.0, 0.5, 0.5, 1.0], [1.0, 1.0, 0.0, 0.0])
+        assert_array_almost_equal(taps1, taps2)
+
+    def test_input_modyfication(self):
+        freq1 = np.array([0.0, 0.5, 0.5, 1.0])
+        freq2 = np.array(freq1)
+        firwin2(80, freq1, [1.0, 1.0, 0.0, 0.0])
+        assert_equal(freq1, freq2)
+
+
 class TestRemez(object):
 
     def test_bad_args(self):

--- a/scipy/signal/tests/test_fir_filter_design.py
+++ b/scipy/signal/tests/test_fir_filter_design.py
@@ -288,7 +288,18 @@ class TestFirwin2(object):
                                                [0.0, 0.5, 0.75, 1.0, 1.0])
         # `freq` does not start at 0.0.
         assert_raises(ValueError, firwin2, 50, [0.5, 1.0], [0.0, 1.0])
-
+        # `freq` does not end at fs/2.
+        assert_raises(ValueError, firwin2, 50, [0.0, 0.5], [0.0, 1.0])
+        # Value 0 is repeated in `freq`
+        assert_raises(ValueError, firwin2, 50, [0.0, 0.0, 0.5, 1.0],
+                                               [1.0, 1.0, 0.0, 0.0])
+        # Value fs/2 is repeated in `freq`
+        assert_raises(ValueError, firwin2, 50, [0.0, 0.5, 1.0, 1.0],
+                                               [1.0, 1.0, 0.0, 0.0])
+        # Value in `freq` that is too close to a repeated number
+        assert_raises(ValueError, firwin2, 50,
+                      [0.0, 0.5 - np.finfo(float).eps * 0.5, 0.5, 0.5, 1.0],
+                      [1.0, 1.0, 1.0, 0.0, 0.0])
         # Type II filter, but the gain at nyquist frequency is not zero.
         assert_raises(ValueError, firwin2, 16, [0.0, 0.5, 1.0], [0.0, 1.0, 1.0])
 
@@ -300,7 +311,7 @@ class TestFirwin2(object):
         assert_raises(ValueError, firwin2, 17, [0.0, 0.5, 1.0], [1.0, 1.0, 1.0],
                       antisymmetric=True)
 
-        # Type VI filter, but the gain at zero rate is not zero.
+        # Type IV filter, but the gain at zero rate is not zero.
         assert_raises(ValueError, firwin2, 16, [0.0, 0.5, 1.0], [1.0, 1.0, 0.0],
                       antisymmetric=True)
 


### PR DESCRIPTION
#### Reference issue
Fixes #10360

#### What does this implement/fix?
This fixes few bugs in firwin2 function:

1. Ensures that freq array is not modified and can be passed as tuple.
2. Adds additional requirements for freq and raises an exception when they are not met.
3. Multiplies eps by Nyquist  frequency.

I also added two tests as described here #10360. 

