### PR TITLE
TST: Relax tolerance in upfirdn test_modes

### DIFF
--- a/scipy/signal/tests/test_upfirdn.py
+++ b/scipy/signal/tests/test_upfirdn.py
@@ -228,4 +228,8 @@ class TestUpfirdn(object):
         ypad = upfirdn(h, xpad, up=1, down=1, mode='constant')
         y_expected = ypad[npad:-npad]
 
-        assert_allclose(y, y_expected, atol=1e-6, rtol=1e-6)
+        if dtype in (np.float32, np.complex64):
+            atol = rtol = 1e-5
+        else:
+            atol = rtol = 1e-12
+        assert_allclose(y, y_expected, atol=atol, rtol=rtol)

--- a/scipy/signal/tests/test_upfirdn.py
+++ b/scipy/signal/tests/test_upfirdn.py
@@ -228,8 +228,5 @@ class TestUpfirdn(object):
         ypad = upfirdn(h, xpad, up=1, down=1, mode='constant')
         y_expected = ypad[npad:-npad]
 
-        if dtype in (np.float32, np.complex64):
-            atol = rtol = 1e-5
-        else:
-            atol = rtol = 1e-12
+        atol = rtol = np.finfo(dtype).eps * 1e2
         assert_allclose(y, y_expected, atol=atol, rtol=rtol)


### PR DESCRIPTION
This PR relaxes the tolerance used for single precision cases for a test case introduced recently in #10552.

Some test cases at scipy-wheels are failing with the current setting of 1e-6. For example:
https://travis-ci.org/MacPython/scipy-wheels/jobs/604686365#L15033

When I test locally on 64-bit linux with Numpy 1.17.3 the arrays being compared are actually identical and would pass for any tolerance. I am not sure where the source of difference is for the cases on scipy-wheels CI, but think 1e-5 should be acceptable for single-precision comparisons.
