### PR TITLE
TST: bump tolerance in optimize tests

### DIFF
--- a/scipy/optimize/tests/test__dual_annealing.py
+++ b/scipy/optimize/tests/test__dual_annealing.py
@@ -11,16 +11,16 @@ from scipy.optimize._dual_annealing import ObjectiveFunWrapper
 from scipy.optimize._dual_annealing import EnergyState
 from scipy.optimize._dual_annealing import LocalSearchWrapper
 from scipy.optimize import rosen, rosen_der
+import pytest
 import numpy as np
-from numpy.testing import (assert_equal, TestCase, assert_allclose,
-                           assert_array_less)
+from numpy.testing import assert_equal, assert_allclose, assert_array_less
 from pytest import raises as assert_raises
 from scipy._lib._util import check_random_state
 
 
-class TestDualAnnealing(TestCase):
+class TestDualAnnealing:
 
-    def setUp(self):
+    def setup_method(self):
         # A function that returns always infinity for initialization tests
         self.weirdfunc = lambda x: np.inf
         # 2-D bounds for testing function
@@ -36,9 +36,6 @@ class TestDualAnnealing(TestCase):
         self.rs = check_random_state(self.seed)
         self.nb_fun_call = 0
         self.ngev = 0
-
-    def tearDown(self):
-        pass
 
     def callback(self, x, f, context):
         # For testing callback mechanism. Should stop for e <= 1 as
@@ -108,38 +105,37 @@ class TestDualAnnealing(TestCase):
         assert ret.success
 
     def test_high_dim(self):
-        ret = dual_annealing(self.func, self.hd_bounds)
+        ret = dual_annealing(self.func, self.hd_bounds, seed=self.seed)
         assert_allclose(ret.fun, 0., atol=1e-12)
         assert ret.success
 
     def test_low_dim_no_ls(self):
         ret = dual_annealing(self.func, self.ld_bounds,
-                             no_local_search=True)
+                             no_local_search=True, seed=self.seed)
         assert_allclose(ret.fun, 0., atol=1e-4)
 
     def test_high_dim_no_ls(self):
         ret = dual_annealing(self.func, self.hd_bounds,
-                             no_local_search=True)
+                             no_local_search=True, seed=self.seed)
         assert_allclose(ret.fun, 0., atol=1e-4)
 
     def test_nb_fun_call(self):
-        ret = dual_annealing(self.func, self.ld_bounds)
+        ret = dual_annealing(self.func, self.ld_bounds, seed=self.seed)
         assert_equal(self.nb_fun_call, ret.nfev)
 
     def test_nb_fun_call_no_ls(self):
         ret = dual_annealing(self.func, self.ld_bounds,
-                no_local_search=True)
+                             no_local_search=True, seed=self.seed)
         assert_equal(self.nb_fun_call, ret.nfev)
 
     def test_max_reinit(self):
         assert_raises(ValueError, dual_annealing, self.weirdfunc,
-                self.ld_bounds)
+                      self.ld_bounds)
 
     def test_reproduce(self):
-        seed = 1234
-        res1 = dual_annealing(self.func, self.ld_bounds, seed=seed)
-        res2 = dual_annealing(self.func, self.ld_bounds, seed=seed)
-        res3 = dual_annealing(self.func, self.ld_bounds, seed=seed)
+        res1 = dual_annealing(self.func, self.ld_bounds, seed=self.seed)
+        res2 = dual_annealing(self.func, self.ld_bounds, seed=self.seed)
+        res3 = dual_annealing(self.func, self.ld_bounds, seed=self.seed)
         # If we have reproducible results, x components found has to
         # be exactly the same, which is not the case with no seeding
         assert_equal(res1.x, res2.x)
@@ -148,21 +144,22 @@ class TestDualAnnealing(TestCase):
     def test_bounds_integrity(self):
         wrong_bounds = [(-5.12, 5.12), (1, 0), (5.12, 5.12)]
         assert_raises(ValueError, dual_annealing, self.func,
-                wrong_bounds)
+                      wrong_bounds)
 
     def test_bound_validity(self):
         invalid_bounds = [(-5, 5), (-np.inf, 0), (-5, 5)]
         assert_raises(ValueError, dual_annealing, self.func,
-                invalid_bounds)
+                      invalid_bounds)
         invalid_bounds = [(-5, 5), (0, np.inf), (-5, 5)]
         assert_raises(ValueError, dual_annealing, self.func,
-                invalid_bounds)
+                      invalid_bounds)
         invalid_bounds = [(-5, 5), (0, np.nan), (-5, 5)]
         assert_raises(ValueError, dual_annealing, self.func,
-                invalid_bounds)
+                      invalid_bounds)
 
     def test_max_fun_ls(self):
-        ret = dual_annealing(self.func, self.ld_bounds, maxfun=100)
+        ret = dual_annealing(self.func, self.ld_bounds, maxfun=100,
+                             seed=self.seed)
 
         ls_max_iter = min(max(
             len(self.ld_bounds) * LocalSearchWrapper.LS_MAXITER_RATIO,
@@ -173,91 +170,51 @@ class TestDualAnnealing(TestCase):
 
     def test_max_fun_no_ls(self):
         ret = dual_annealing(self.func, self.ld_bounds,
-                             no_local_search=True, maxfun=500)
+                             no_local_search=True, maxfun=500, seed=self.seed)
         assert ret.nfev <= 500
         assert not ret.success
 
     def test_maxiter(self):
-        ret = dual_annealing(self.func, self.ld_bounds, maxiter=700)
+        ret = dual_annealing(self.func, self.ld_bounds, maxiter=700,
+                             seed=self.seed)
         assert ret.nit <= 700
 
     # Testing that args are passed correctly for dual_annealing
     def test_fun_args_ls(self):
         ret = dual_annealing(self.func, self.ld_bounds,
-                             args=((3.14159, )))
+                             args=((3.14159,)), seed=self.seed)
         assert_allclose(ret.fun, 3.14159, atol=1e-6)
 
     # Testing that args are passed correctly for pure simulated annealing
     def test_fun_args_no_ls(self):
         ret = dual_annealing(self.func, self.ld_bounds,
-                             args=((3.14159, )), no_local_search=True)
+                             args=((3.14159, )), no_local_search=True,
+                             seed=self.seed)
         assert_allclose(ret.fun, 3.14159, atol=1e-4)
 
     def test_callback_stop(self):
         # Testing that callback make the algorithm stop for
         # fun value <= 1.0 (see callback method)
         ret = dual_annealing(self.func, self.ld_bounds,
-                             callback=self.callback)
+                             callback=self.callback, seed=self.seed)
         assert ret.fun <= 1.0
         assert 'stop early' in ret.message[0]
         assert not ret.success
 
-    def test_neldermead_ls_minimizer(self):
-        minimizer_opts = {
-            'method': 'Nelder-Mead',
-        }
+    @pytest.mark.parametrize('method, atol', [
+        ('Nelder-Mead', 2e-5),
+        ('COBYLA', 1e-5),
+        ('Powell', 1e-8),
+        ('CG', 1e-8),
+        ('BFGS', 1e-8),
+        ('TNC', 1e-8),
+        ('SLSQP', 1e-7),
+    ])
+    def test_multi_ls_minimizer(self, method, atol):
         ret = dual_annealing(self.func, self.ld_bounds,
-                             local_search_options=minimizer_opts)
-        assert_allclose(ret.fun, 0., atol=2e-5)
-
-    def test_powell_ls_minimizer(self):
-        minimizer_opts = {
-            'method': 'Powell',
-        }
-        ret = dual_annealing(self.func, self.ld_bounds,
-                             local_search_options=minimizer_opts)
-        assert_allclose(ret.fun, 0., atol=1e-8)
-
-    def test_cg_ls_minimizer(self):
-        minimizer_opts = {
-            'method': 'CG',
-        }
-        ret = dual_annealing(self.func, self.ld_bounds,
-                             local_search_options=minimizer_opts)
-        assert_allclose(ret.fun, 0., atol=1e-8)
-
-    def test_bfgs_ls_minimizer(self):
-        minimizer_opts = {
-            'method': 'BFGS',
-        }
-        ret = dual_annealing(self.func, self.ld_bounds,
-                             local_search_options=minimizer_opts)
-        assert_allclose(ret.fun, 0., atol=1e-8)
-
-    def test_tnc_ls_minimizer(self):
-        minimizer_opts = {
-            'method': 'TNC',
-        }
-        ret = dual_annealing(self.func, self.ld_bounds,
-                             local_search_options=minimizer_opts)
-        assert_allclose(ret.fun, 0., atol=1e-8)
-
-    def test_colyba_ls_minimizer(self):
-        minimizer_opts = {
-            'method': 'COBYLA',
-        }
-        ret = dual_annealing(self.func, self.ld_bounds,
-                             local_search_options=minimizer_opts)
-        assert_allclose(ret.fun, 0., atol=1e-5)
-
-    def test_slsqp_ls_minimizer(self):
-        minimizer_opts = {
-            'method': 'SLSQP',
-        }
-        ret = dual_annealing(self.func, self.ld_bounds,
-                             local_search_options=minimizer_opts,
+                             local_search_options=dict(method=method),
                              seed=self.seed)
-        assert_allclose(ret.fun, 0., atol=1e-7)
+        assert_allclose(ret.fun, 0., atol=atol)
 
     def test_wrong_restart_temp(self):
         assert_raises(ValueError, dual_annealing, self.func,
@@ -270,5 +227,6 @@ class TestDualAnnealing(TestCase):
             'jac': self.rosen_der_wrapper,
         }
         ret = dual_annealing(rosen, self.ld_bounds,
-                             local_search_options=minimizer_opts)
+                             local_search_options=minimizer_opts,
+                             seed=self.seed)
         assert ret.njev == self.ngev

--- a/scipy/optimize/tests/test__dual_annealing.py
+++ b/scipy/optimize/tests/test__dual_annealing.py
@@ -202,13 +202,13 @@ class TestDualAnnealing(TestCase):
         assert 'stop early' in ret.message[0]
         assert not ret.success
 
-    def test_neldermed_ls_minimizer(self):
+    def test_neldermead_ls_minimizer(self):
         minimizer_opts = {
             'method': 'Nelder-Mead',
         }
         ret = dual_annealing(self.func, self.ld_bounds,
                              local_search_options=minimizer_opts)
-        assert_allclose(ret.fun, 0., atol=1e-6)
+        assert_allclose(ret.fun, 0., atol=2e-5)
 
     def test_powell_ls_minimizer(self):
         minimizer_opts = {


### PR DESCRIPTION
Many recent PRs [are failing with](https://travis-ci.org/scipy/scipy/jobs/604748715):
```
    def test_neldermed_ls_minimizer(self):
        minimizer_opts = {
            'method': 'Nelder-Mead',
        }
        ret = dual_annealing(self.func, self.ld_bounds,
                             local_search_options=minimizer_opts)
>       assert_allclose(ret.fun, 0., atol=1e-6)
E       AssertionError: 
E       Not equal to tolerance rtol=1e-07, atol=1e-06
E       
E       Mismatch: 100%
E       Max absolute difference: 1.07764087e-05
E       Max relative difference: inf
E        x: array(1.077641e-05)
E        y: array(0.)
```
This just bumps the tol to 2e-5 (and fixes a spelling error). @sgubianpm it looks like this is code you wrote back in #9306 in case you want to comment.