### PR TITLE
DOC: update 1.3.2 release notes

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -151,6 +151,7 @@ Helder Cesar <heldercro@gmail.com> Helder <heldercro@gmail.com>
 Helmut Toplitzer <helmut.toplitzer@ait.ac.at> HelmutAIT <helmut.toplitzer@ait.ac.at>
 Henry Lin <hlin117@gmail.com> hlin117 <hlin117@gmail.com>
 Hiroki IKEDA <ikeda_hiroki@icloud.com> IKEDA Hiroki <ikeda_hiroki@icloud.com>
+Huize Wang <huizew@gmail.com> Huize <huizew@gmail.com>
 Max Silbiger <hollowaytape@retro-type.com> hollowaytape <hollowaytape@retro-type.com>
 Ion Elberdin <ionelberdin@gmail.com> Ion <ionelberdin@gmail.com>
 Ilhan Polat <ilhanpolat@gmail.com> ilayn <ilhanpolat@gmail.com>

--- a/doc/release/1.3.2-notes.rst
+++ b/doc/release/1.3.2-notes.rst
@@ -10,8 +10,58 @@ support for Python 3.8.
 Authors
 =======
 
+* CJ Carey
+* Martin Gauch +
+* Ralf Gommers
+* Matt Haberland
+* Eric Larson
+* Nikolay Mayorov
+* Sam McCormack +
+* Andrew Nelson
+* Tyler Reddy
+* Pauli Virtanen
+* Huize Wang +
+* Warren Weckesser
+* Joseph Weston +
+
+A total of 13 people contributed to this release.
+People with a "+" by their names contributed a patch for the first time.
+This list of names is automatically generated, and may not be fully complete.
+
 Issues closed for 1.3.2
 -----------------------
 
+* `#4915 <https://github.com/scipy/scipy/issues/4915>`__: Bug in unique_roots in scipy.signal.signaltools.py for roots...
+* `#5161 <https://github.com/scipy/scipy/issues/5161>`__: Optimizers reporting success when the minimum is NaN
+* `#5546 <https://github.com/scipy/scipy/issues/5546>`__: ValueError raised if scipy.sparse.linalg.expm recieves array...
+* `#10124 <https://github.com/scipy/scipy/issues/10124>`__: linprog(method='revised simplex') doctest bug
+* `#10609 <https://github.com/scipy/scipy/issues/10609>`__: Graph shortest path with Floyd-Warshall removes explicit zeros.
+* `#10658 <https://github.com/scipy/scipy/issues/10658>`__: BUG: stats: Formula for the variance of the noncentral F distribution...
+* `#10695 <https://github.com/scipy/scipy/issues/10695>`__: BUG: Assignation issues in csr_matrix with fancy indexing
+* `#10846 <https://github.com/scipy/scipy/issues/10846>`__: root_scalar fails when passed a function wrapped with functools.lru_cache
+* `#10902 <https://github.com/scipy/scipy/issues/10902>`__: CI: travis osx build failure
+* `#10967 <https://github.com/scipy/scipy/issues/10967>`__: macOS build failure in SuperLU on maintenance/1.3.x
+* `#10976 <https://github.com/scipy/scipy/issues/10976>`__: Typo in sp.stats.wilcoxon docstring
+
+
 Pull requests for 1.3.2
 -----------------------
+
+* `#10498 <https://github.com/scipy/scipy/pull/10498>`__: TST: optimize: fixed \`linprog\` \`"disp": True\` bug
+* `#10536 <https://github.com/scipy/scipy/pull/10536>`__: CI: add 3.8-dev to travis
+* `#10671 <https://github.com/scipy/scipy/pull/10671>`__: BUG: stats: Fix the formula for the variance of the noncentral...
+* `#10693 <https://github.com/scipy/scipy/pull/10693>`__: BUG: ScalarFunction stores original array
+* `#10700 <https://github.com/scipy/scipy/pull/10700>`__: BUG: sparse: Loosen checks on sparse fancy assignment
+* `#10709 <https://github.com/scipy/scipy/pull/10709>`__: BUG: Fix floyd_warshall to support zero-weight edges
+* `#10756 <https://github.com/scipy/scipy/pull/10756>`__: BUG: optimize: ensure solvers exit with success=False for nan...
+* `#10833 <https://github.com/scipy/scipy/pull/10833>`__: BUG: Fix subspace_angles for complex values
+* `#10882 <https://github.com/scipy/scipy/pull/10882>`__: BUG: sparse/arpack: fix incorrect code for complex hermitian...
+* `#10891 <https://github.com/scipy/scipy/pull/10891>`__: BUG: make C-implemented root finders work with functools.lru_cache
+* `#10906 <https://github.com/scipy/scipy/pull/10906>`__: BUG: sparse/linalg: fix expm for np.matrix inputs
+* `#10917 <https://github.com/scipy/scipy/pull/10917>`__: CI: fix travis osx CI
+* `#10930 <https://github.com/scipy/scipy/pull/10930>`__: MAINT: Updates for 3.8
+* `#10938 <https://github.com/scipy/scipy/pull/10938>`__: MAINT: Add Python 3.8 to pyproject.toml
+* `#10943 <https://github.com/scipy/scipy/pull/10943>`__: BLD: update Cython version to 0.29.13
+* `#10961 <https://github.com/scipy/scipy/pull/10961>`__: BUG: Fix signal.unique_roots
+* `#10971 <https://github.com/scipy/scipy/pull/10971>`__: MAINT: use 3.8 stable in CI
+* `#10977 <https://github.com/scipy/scipy/pull/10977>`__: DOC: Fix typo in sp.stats.wilcoxon docsting


### PR DESCRIPTION
* update the release notes for SciPy `1.3.2`
using `authors.py`, `gh_lists.py`, and a little
manual curation, after adjusting milestones
on the appropriate GitHub issues/PRs