### PR TITLE
MAINT: Rework residue and residuez

### DIFF
--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2347,14 +2347,14 @@ def _compute_factors(roots, multiplicity):
     return result
 
 
-def _compute_residuals(poles, multiplicity, numerator):
+def _compute_residues(poles, multiplicity, numerator):
     denominator_factors = _compute_factors(poles, multiplicity)
 
-    residuals = []
+    residues = []
     for pole, mult, factor in zip(poles, multiplicity,
                                   denominator_factors):
         if mult == 1:
-            residuals.append(np.polyval(numerator, pole) /
+            residues.append(np.polyval(numerator, pole) /
                              np.polyval(factor, pole))
         else:
             numer = numerator.copy()
@@ -2368,9 +2368,9 @@ def _compute_residuals(poles, multiplicity, numerator):
                 numer = np.polysub(numer, r * factor)
                 block.append(r)
 
-            residuals.extend(reversed(block))
+            residues.extend(reversed(block))
 
-    return np.asarray(residuals)
+    return np.asarray(residues)
 
 
 def residue(b, a, tol=1e-3, rtype='avg'):
@@ -2465,14 +2465,14 @@ def residue(b, a, tol=1e-3, rtype='avg'):
     unique_poles, order = cmplx_sort(unique_poles)
     multiplicity = multiplicity[order]
 
-    residuals = _compute_residuals(unique_poles, multiplicity, b)
+    residues = _compute_residues(unique_poles, multiplicity, b)
 
     index = 0
     for pole, mult in zip(unique_poles, multiplicity):
         poles[index:index + mult] = pole
         index += mult
 
-    return residuals / a[0], poles, np.trim_zeros(k, 'f')
+    return residues / a[0], poles, np.trim_zeros(k, 'f')
 
 
 def residuez(b, a, tol=1e-3, rtype='avg'):
@@ -2552,18 +2552,18 @@ def residuez(b, a, tol=1e-3, rtype='avg'):
     unique_poles, order = cmplx_sort(unique_poles)
     multiplicity = multiplicity[order]
 
-    residuals = _compute_residuals(1 / unique_poles, multiplicity, b_rev)
+    residues = _compute_residues(1 / unique_poles, multiplicity, b_rev)
 
     index = 0
-    powers = np.empty(len(residuals), dtype=int)
+    powers = np.empty(len(residues), dtype=int)
     for pole, mult in zip(unique_poles, multiplicity):
         poles[index:index + mult] = pole
         powers[index:index + mult] = 1 + np.arange(mult)
         index += mult
 
-    residuals *= (-poles) ** powers / a_rev[0]
+    residues *= (-poles) ** powers / a_rev[0]
 
-    return residuals, poles, np.trim_zeros(k_rev[::-1], 'f')
+    return residues, poles, np.trim_zeros(k_rev[::-1], 'f')
 
 
 def invresz(r, p, k, tol=1e-3, rtype='avg'):

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2419,7 +2419,8 @@ def residue(b, a, tol=1e-3, rtype='avg'):
     Returns
     -------
     r : ndarray
-        Residues.
+        Residues corresponding to the poles. For repeated poles, the residues
+        are ordered to correspond to ascending by power fractions.
     p : ndarray
         Poles order by magnitude in ascending order.
     k : ndarray
@@ -2519,7 +2520,8 @@ def residuez(b, a, tol=1e-3, rtype='avg'):
     Returns
     -------
     r : ndarray
-        Residues.
+        Residues corresponding to the poles. For repeated poles, the residues
+        are ordered to correspond to ascending by power fractions.
     p : ndarray
         Poles order by magnitude in ascending order.
     k : ndarray

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2349,6 +2349,7 @@ def _compute_factors(roots, multiplicity):
 
 def _compute_residues(poles, multiplicity, numerator):
     denominator_factors = _compute_factors(poles, multiplicity)
+    numerator = numerator.astype(poles.dtype)
 
     residues = []
     for pole, mult, factor in zip(poles, multiplicity,
@@ -2449,6 +2450,16 @@ def residue(b, a, tol=1e-3, rtype='avg'):
            review of computational methodology and efficiency", Journal of
            Computational and Applied Mathematics, Vol. 9, 1983.
     """
+    b = np.asarray(b)
+    a = np.asarray(a)
+    if (np.issubdtype(b.dtype, np.complexfloating)
+            or np.issubdtype(a.dtype, np.complexfloating)):
+        b = b.astype(complex)
+        a = a.astype(complex)
+    else:
+        b = b.astype(float)
+        a = a.astype(float)
+
     b = np.trim_zeros(np.atleast_1d(b), 'f')
     a = np.trim_zeros(np.atleast_1d(a), 'f')
 
@@ -2531,6 +2542,16 @@ def residuez(b, a, tol=1e-3, rtype='avg'):
     --------
     invresz, residue, unique_roots
     """
+    b = np.asarray(b)
+    a = np.asarray(a)
+    if (np.issubdtype(b.dtype, np.complexfloating)
+            or np.issubdtype(a.dtype, np.complexfloating)):
+        b = b.astype(complex)
+        a = a.astype(complex)
+    else:
+        b = b.astype(float)
+        a = a.astype(float)
+
     b = np.trim_zeros(np.atleast_1d(b), 'b')
     a = np.trim_zeros(np.atleast_1d(a), 'b')
 

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2449,11 +2449,14 @@ def residue(b, a, tol=1e-3, rtype='avg'):
             monomial = np.array([1, -pole])
             factor, d = np.polydiv(factor, monomial)
 
+            block = []
             for _ in range(mult):
                 numer, n = np.polydiv(numer, monomial)
                 r = n[0] / d[0]
                 numer = np.polysub(numer, r * factor)
-                residuals.append(r)
+                block.append(r)
+
+            residuals.extend(reversed(block))
 
         poles[len(residuals) - mult:len(residuals)] = pole
 

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2355,7 +2355,7 @@ def _compute_residues(poles, multiplicity, numerator):
                                   denominator_factors):
         if mult == 1:
             residues.append(np.polyval(numerator, pole) /
-                             np.polyval(factor, pole))
+                            np.polyval(factor, pole))
         else:
             numer = numerator.copy()
             monomial = np.array([1, -pole])

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2348,8 +2348,7 @@ def _compute_factors(roots, multiplicity):
 
 
 def residue(b, a, tol=1e-3, rtype='avg'):
-    """
-    Compute partial-fraction expansion of b(s) / a(s).
+    """Compute partial-fraction expansion of b(s) / a(s).
 
     If `M` is the degree of numerator `b` and `N` the degree of denominator
     `a`::
@@ -2375,12 +2374,21 @@ def residue(b, a, tol=1e-3, rtype='avg'):
     such as analog filters or digital filters in controls engineering.  For
     negative powers of z (typical for digital filters in DSP), use `residuez`.
 
+    See Notes for details about the algorithm.
+
     Parameters
     ----------
     b : array_like
         Numerator polynomial coefficients.
     a : array_like
         Denominator polynomial coefficients.
+    tol : float, optional
+        The tolerance for two roots to be considered equal in terms of
+        the distance between them. Default is 1e-3. See `unique_roots`
+        for further details.
+    rtype : {'avg', 'min', 'max'}, optional
+        Method for computing a root to represent a group of identical roots.
+        Default is 'avg'. See `unique_roots` for further details.
 
     Returns
     -------
@@ -2395,6 +2403,24 @@ def residue(b, a, tol=1e-3, rtype='avg'):
     --------
     invres, residuez, numpy.poly, unique_roots
 
+    Notes
+    -----
+    The "deflation through subtraction" numerical algorithm is used for
+    computations --- method 6 in [1]_.
+
+    The form of partial fraction expansion depends on roots multiplicity in
+    the exact mathematical sense. However there is no way to exactly
+    determine multiplicity of roots in numerical computing. Thus you should
+    think of the result of `residue` with given `tol` as partial fraction
+    expansion computed for the denominator composed of the computed roots with
+    empirically determined multiplicity. The choice of `tol` can drastically
+    change the result if there are close roots of the denominator.
+
+    References
+    ----------
+    .. [1] J. F. Mahoney, B. D. Sivazlian, "Partial fractions expansion: a
+           review of computational methodology and efficiency", Journal of
+           Computational and Applied Mathematics, Vol. 9, 1983.
     """
     b = np.trim_zeros(np.atleast_1d(b), 'f')
     a = np.trim_zeros(np.atleast_1d(a), 'f')

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2422,7 +2422,7 @@ def residue(b, a, tol=1e-3, rtype='avg'):
         Residues corresponding to the poles. For repeated poles, the residues
         are ordered to correspond to ascending by power fractions.
     p : ndarray
-        Poles order by magnitude in ascending order.
+        Poles ordered by magnitude in ascending order.
     k : ndarray
         Coefficients of the direct polynomial term.
 
@@ -2432,16 +2432,16 @@ def residue(b, a, tol=1e-3, rtype='avg'):
 
     Notes
     -----
-    The "deflation through subtraction" numerical algorithm is used for
+    The "deflation through subtraction" algorithm is used for
     computations --- method 6 in [1]_.
 
-    The form of partial fraction expansion depends on roots multiplicity in
+    The form of partial fraction expansion depends on poles multiplicity in
     the exact mathematical sense. However there is no way to exactly
-    determine multiplicity of roots in numerical computing. Thus you should
-    think of the result of `residue` with given `tol` as partial fraction
-    expansion computed for the denominator composed of the computed roots with
-    empirically determined multiplicity. The choice of `tol` can drastically
-    change the result if there are close roots of the denominator.
+    determine multiplicity of roots of a polynomial in numerical computing.
+    Thus you should think of the result of `residue` with given `tol` as
+    partial fraction expansion computed for the denominator composed of the
+    computed poles with empirically determined multiplicity. The choice of
+    `tol` can drastically change the result if there are close poles.
 
     References
     ----------
@@ -2523,7 +2523,7 @@ def residuez(b, a, tol=1e-3, rtype='avg'):
         Residues corresponding to the poles. For repeated poles, the residues
         are ordered to correspond to ascending by power fractions.
     p : ndarray
-        Poles order by magnitude in ascending order.
+        Poles ordered by magnitude in ascending order.
     k : ndarray
         Coefficients of the direct polynomial term.
 

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2563,7 +2563,7 @@ def residuez(b, a, tol=1e-3, rtype='avg'):
 
     residues *= (-poles) ** powers / a_rev[0]
 
-    return residues, poles, np.trim_zeros(k_rev[::-1], 'f')
+    return residues, poles, np.trim_zeros(k_rev[::-1], 'b')
 
 
 def invresz(r, p, k, tol=1e-3, rtype='avg'):

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2475,8 +2475,7 @@ def residue(b, a, tol=1e-3, rtype='avg'):
 
 
 def residuez(b, a, tol=1e-3, rtype='avg'):
-    """
-    Compute partial-fraction expansion of b(z) / a(z).
+    """Compute partial-fraction expansion of b(z) / a(z).
 
     If `M` is the degree of numerator `b` and `N` the degree of denominator
     `a`::
@@ -2501,26 +2500,34 @@ def residuez(b, a, tol=1e-3, rtype='avg'):
     This function is used for polynomials in negative powers of z,
     such as digital filters in DSP.  For positive powers, use `residue`.
 
+    See Notes of `residue` for details about the algorithm.
+
     Parameters
     ----------
     b : array_like
         Numerator polynomial coefficients.
     a : array_like
         Denominator polynomial coefficients.
+    tol : float, optional
+        The tolerance for two roots to be considered equal in terms of
+        the distance between them. Default is 1e-3. See `unique_roots`
+        for further details.
+    rtype : {'avg', 'min', 'max'}, optional
+        Method for computing a root to represent a group of identical roots.
+        Default is 'avg'. See `unique_roots` for further details.
 
     Returns
     -------
     r : ndarray
         Residues.
     p : ndarray
-        Poles.
+        Poles order by magnitude in ascending order.
     k : ndarray
         Coefficients of the direct polynomial term.
 
     See Also
     --------
     invresz, residue, unique_roots
-
     """
     b = np.trim_zeros(np.atleast_1d(b), 'b')
     a = np.trim_zeros(np.atleast_1d(a), 'b')

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2457,7 +2457,7 @@ def residue(b, a, tol=1e-3, rtype='avg'):
 
     poles = np.roots(a)
     if b.size == 0:
-        return np.zeros(poles.shape), poles, np.array([])
+        return np.zeros(poles.shape), cmplx_sort(poles)[0], np.array([])
 
     k, b = np.polydiv(b, a)
 
@@ -2542,7 +2542,7 @@ def residuez(b, a, tol=1e-3, rtype='avg'):
 
     poles = np.roots(a)
     if b.size == 0:
-        return np.zeros(poles.shape), poles, np.array([])
+        return np.zeros(poles.shape), cmplx_sort(poles)[0], np.array([])
 
     b_rev = b[::-1]
     a_rev = a[::-1]

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2618,7 +2618,8 @@ class TestPartialFractionExpansion(object):
         assert_equal(p.size, 0)
         assert_equal(k.size, 0)
 
-        assert_raises(ValueError, residue, 1, 0)
+        with pytest.raises(ValueError, match="Denominator `a` is zero."):
+            residue(1, 0)
 
     def test_residuez_general(self):
         r, p, k = residuez([1, 6, 6, 2], [1, -(2 + 1j), (1 + 2j), -1j])
@@ -2729,8 +2730,13 @@ class TestPartialFractionExpansion(object):
         assert_equal(p.size, 0)
         assert_equal(k.size, 0)
 
-        assert_raises(ValueError, residuez, 1, 0)
-        assert_raises(ValueError, residuez, 1, [0, 1, 2, 3])
+        with pytest.raises(ValueError, match="Denominator `a` is zero."):
+            residuez(1, 0)
+
+        with pytest.raises(ValueError,
+                           match="First coefficient of determinant `a` must "
+                                 "be non-zero."):
+            residuez(1, [0, 1, 2, 3])
 
     def test_invresz_one_coefficient_bug(self):
         # Regression test for issue in gh-4646.

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2509,18 +2509,19 @@ class TestHilbert2(object):
 
 
 class TestPartialFractionExpansion(object):
+    @staticmethod
+    def assert_rp_almost_equal(r, p, r_true, p_true):
+        r_true = np.asarray(r_true)
+        p_true = np.asarray(p_true)
+
+        distance = np.hypot(abs(p[:, None] - p_true),
+                            abs(r[:, None] - r_true))
+
+        rows, cols = linear_sum_assignment(distance)
+        assert_allclose(p[rows], p_true[cols])
+        assert_allclose(r[rows], r_true[cols])
+
     def test_residue_general(self):
-        def assert_rp_almost_equal(r, p, r_true, p_true):
-            r_true = np.asarray(r_true)
-            p_true = np.asarray(p_true)
-
-            distance = np.hypot(abs(p[:, None] - p_true),
-                                abs(r[:, None] - r_true))
-
-            rows, cols = linear_sum_assignment(distance)
-            assert_allclose(p[rows], p_true[cols])
-            assert_allclose(r[rows], r_true[cols])
-
         # Test are taken from issue #4464, note that poles in scipy are
         # in increasing by absolute value order, opposite to MATLAB.
         r, p, k = residue([5, 3, -2, 7], [-4, 0, 8, 3])
@@ -2539,13 +2540,13 @@ class TestPartialFractionExpansion(object):
         assert_equal(k.size, 0)
 
         r, p, k = residue([4, 3], [2, -3.4, 1.98, -0.406])
-        assert_rp_almost_equal(r, p,
-                               [-18.125 - 13.125j, -18.125 + 13.125j, 36.25],
-                               [0.5 - 0.2j, 0.5 + 0.2j, 0.7])
+        self.assert_rp_almost_equal(
+            r, p, [-18.125 - 13.125j, -18.125 + 13.125j, 36.25],
+            [0.5 - 0.2j, 0.5 + 0.2j, 0.7])
         assert_equal(k.size, 0)
 
         r, p, k = residue([2, 1], [1, 5, 8, 4])
-        assert_rp_almost_equal(r, p, [-1, 1, 3], [-1, -2, -2])
+        self.assert_rp_almost_equal(r, p, [-1, 1, 3], [-1, -2, -2])
         assert_equal(k.size, 0)
 
         r, p, k = residue([3, -1.1, 0.88, -2.396, 1.348],
@@ -2560,11 +2561,12 @@ class TestPartialFractionExpansion(object):
         assert_equal(k.size, 0)
 
         r, p, k = residue([1, 0, -5], [1, 0, 0, 0, -1])
-        assert_rp_almost_equal(r, p, [1, 1.5j, -1.5j, -1], [-1, -1j, 1j, 1])
+        self.assert_rp_almost_equal(r, p,
+                                    [1, 1.5j, -1.5j, -1], [-1, -1j, 1j, 1])
         assert_equal(k.size, 0)
 
         r, p, k = residue([3, 8, 6], [1, 3, 3, 1])
-        assert_rp_almost_equal(r, p, [1,2, 3], [-1, -1, -1])
+        self.assert_rp_almost_equal(r, p, [1, 2, 3], [-1, -1, -1])
         assert_equal(k.size, 0)
 
         r, p, k = residue([3, -1], [1, -3, 2])
@@ -2583,9 +2585,8 @@ class TestPartialFractionExpansion(object):
         assert_almost_equal(k, [7, 23])
 
         r, p, k = residue([2, 3, -1], [1, -3, 4, -2])
-        assert_rp_almost_equal(r, p,
-                              [4, -1 + 3.5j, -1 - 3.5j],
-                               [1, 1 - 1j, 1 + 1j])
+        self.assert_rp_almost_equal(r, p, [4, -1 + 3.5j, -1 - 3.5j],
+                                    [1, 1 - 1j, 1 + 1j])
         assert_almost_equal(k.size, 0)
 
     def test_residue_leading_zeros(self):

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2610,7 +2610,7 @@ class TestPartialFractionExpansion(object):
         # Several tests for zero numerator and denominator.
         r, p, k = residue([0, 0], [1, 6, 8])
         assert_almost_equal(r, [0, 0])
-        assert_almost_equal(p, [-4, -2])
+        assert_almost_equal(p, [-2, -4])
         assert_equal(k.size, 0)
 
         r, p, k = residue(0, 1)
@@ -2721,7 +2721,7 @@ class TestPartialFractionExpansion(object):
     def test_residuez_degenerate(self):
         r, p, k = residuez([0, 0], [1, 6, 8])
         assert_almost_equal(r, [0, 0])
-        assert_almost_equal(p, [-4, -2])
+        assert_almost_equal(p, [-2, -4])
         assert_equal(k.size, 0)
 
         r, p, k = residuez(0, 1)


### PR DESCRIPTION
#### What does this implement/fix?

Implementation of partial fraction expansion relied on a textbook "residue method" with fraction differentiation and all that. I decided to investigate whether there are established numerical methods for doing PFE. 

I have found a rather old paper called "Partial fractions expansion: a review of computational methodology and efficiency" with nine methods described there. And the "textbook method" was only mentioned as the one which is not recommended for computer implementation. 

So I picked another method which is relatively easy to understand and implement, doesn't have special cases and quite efficient in terms of number of required operations. Number 6 in the paper.

I've extended the documentation and included tests for `residuez`. The new implementation passes all tests from #4562, #4464 and #4561

Overall it looks like a more solid proper implementation now. The previous one was more of a literal translation of a theoretical method and not very clean or efficiently written.


@ilayn @larsoner It's not super obvious changes, but someone needs to review this. I'm happy to clarify any specifics of the code.

Closes #4562, #4561, #10929