### PR TITLE
MAINT: Rework invres and invresz

### DIFF
--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2590,6 +2590,10 @@ def invres(r, p, k, tol=1e-3, rtype='avg'):
     residue, invresz, unique_roots
 
     """
+    r = np.atleast_1d(r)
+    p = np.atleast_1d(p)
+    k = np.atleast_1d(k)
+
     unique_poles, multiplicity = _group_poles(p, tol, rtype)
     factors, denominator = _compute_factors(unique_poles, multiplicity,
                                             include_powers=True)
@@ -2660,6 +2664,10 @@ def invresz(r, p, k, tol=1e-3, rtype='avg'):
     residuez, unique_roots, invres
 
     """
+    r = np.atleast_1d(r)
+    p = np.atleast_1d(p)
+    k = np.atleast_1d(k)
+
     unique_poles, multiplicity = _group_poles(p, tol, rtype)
     factors, denominator = _compute_factors(unique_poles, multiplicity,
                                             include_powers=True)

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2238,6 +2238,81 @@ def unique_roots(p, tol=1e-3, rtype='min'):
     return np.asarray(p_unique), np.asarray(p_multiplicity)
 
 
+def invres(r, p, k, tol=1e-3, rtype='avg'):
+    """Compute b(s) and a(s) from partial fraction expansion.
+
+    If `M` is the degree of numerator `b` and `N` the degree of denominator
+    `a`::
+
+              b(s)     b[0] s**(M) + b[1] s**(M-1) + ... + b[M]
+      H(s) = ------ = ------------------------------------------
+              a(s)     a[0] s**(N) + a[1] s**(N-1) + ... + a[N]
+
+    then the partial-fraction expansion H(s) is defined as::
+
+               r[0]       r[1]             r[-1]
+           = -------- + -------- + ... + --------- + k(s)
+             (s-p[0])   (s-p[1])         (s-p[-1])
+
+    If there are any repeated roots (closer together than `tol`), then H(s)
+    has terms like::
+
+          r[i]      r[i+1]              r[i+n-1]
+        -------- + ----------- + ... + -----------
+        (s-p[i])  (s-p[i])**2          (s-p[i])**n
+
+    This function is used for polynomials in positive powers of s or z,
+    such as analog filters or digital filters in controls engineering.  For
+    negative powers of z (typical for digital filters in DSP), use `invresz`.
+
+    Parameters
+    ----------
+    r : array_like
+        Residues corresponding to the poles. For repeated poles, the residues
+        must be ordered to correspond to ascending by power fractions.
+    p : array_like
+        Poles. Equal poles must be adjacent.
+    k : array_like
+        Coefficients of the direct polynomial term.
+    tol : float, optional
+        The tolerance for two roots to be considered equal in terms of
+        the distance between them. Default is 1e-3. See `unique_roots`
+        for further details.
+    rtype : {'avg', 'min', 'max'}, optional
+        Method for computing a root to represent a group of identical roots.
+        Default is 'avg'. See `unique_roots` for further details.
+
+    Returns
+    -------
+    b : ndarray
+        Numerator polynomial coefficients.
+    a : ndarray
+        Denominator polynomial coefficients.
+
+    See Also
+    --------
+    residue, invresz, unique_roots
+
+    """
+    r = np.atleast_1d(r)
+    p = np.atleast_1d(p)
+    k = np.trim_zeros(np.atleast_1d(k), 'f')
+
+    unique_poles, multiplicity = _group_poles(p, tol, rtype)
+    factors, denominator = _compute_factors(unique_poles, multiplicity,
+                                            include_powers=True)
+
+    if len(k) == 0:
+        numerator = 0
+    else:
+        numerator = np.polymul(k, denominator)
+
+    for residue, factor in zip(r, factors):
+        numerator = np.polyadd(numerator, residue * factor)
+
+    return numerator, denominator
+
+
 def _compute_factors(roots, multiplicity, include_powers=False):
     """Compute the total polynomial divided by factors for each root."""
     current = np.array([1])
@@ -2539,81 +2614,6 @@ def _group_poles(poles, tol, rtype):
     multiplicity.append(len(block))
 
     return np.asarray(unique), np.asarray(multiplicity)
-
-
-def invres(r, p, k, tol=1e-3, rtype='avg'):
-    """Compute b(s) and a(s) from partial fraction expansion.
-
-    If `M` is the degree of numerator `b` and `N` the degree of denominator
-    `a`::
-
-              b(s)     b[0] s**(M) + b[1] s**(M-1) + ... + b[M]
-      H(s) = ------ = ------------------------------------------
-              a(s)     a[0] s**(N) + a[1] s**(N-1) + ... + a[N]
-
-    then the partial-fraction expansion H(s) is defined as::
-
-               r[0]       r[1]             r[-1]
-           = -------- + -------- + ... + --------- + k(s)
-             (s-p[0])   (s-p[1])         (s-p[-1])
-
-    If there are any repeated roots (closer together than `tol`), then H(s)
-    has terms like::
-
-          r[i]      r[i+1]              r[i+n-1]
-        -------- + ----------- + ... + -----------
-        (s-p[i])  (s-p[i])**2          (s-p[i])**n
-
-    This function is used for polynomials in positive powers of s or z,
-    such as analog filters or digital filters in controls engineering.  For
-    negative powers of z (typical for digital filters in DSP), use `invresz`.
-
-    Parameters
-    ----------
-    r : array_like
-        Residues corresponding to the poles. For repeated poles, the residues
-        must be ordered to correspond to ascending by power fractions.
-    p : array_like
-        Poles. Equal poles must be adjacent.
-    k : array_like
-        Coefficients of the direct polynomial term.
-    tol : float, optional
-        The tolerance for two roots to be considered equal in terms of
-        the distance between them. Default is 1e-3. See `unique_roots`
-        for further details.
-    rtype : {'avg', 'min', 'max'}, optional
-        Method for computing a root to represent a group of identical roots.
-        Default is 'avg'. See `unique_roots` for further details.
-
-    Returns
-    -------
-    b : ndarray
-        Numerator polynomial coefficients.
-    a : ndarray
-        Denominator polynomial coefficients.
-
-    See Also
-    --------
-    residue, invresz, unique_roots
-
-    """
-    r = np.atleast_1d(r)
-    p = np.atleast_1d(p)
-    k = np.trim_zeros(np.atleast_1d(k), 'f')
-
-    unique_poles, multiplicity = _group_poles(p, tol, rtype)
-    factors, denominator = _compute_factors(unique_poles, multiplicity,
-                                            include_powers=True)
-
-    if len(k) == 0:
-        numerator = 0
-    else:
-        numerator = np.polymul(k, denominator)
-
-    for residue, factor in zip(r, factors):
-        numerator = np.polyadd(numerator, residue * factor)
-
-    return numerator, denominator
 
 
 def invresz(r, p, k, tol=1e-3, rtype='avg'):

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2503,6 +2503,37 @@ def residuez(b, a, tol=1e-3, rtype='avg'):
     return residues, poles, np.trim_zeros(k_rev[::-1], 'b')
 
 
+def _group_poles(poles, tol, rtype):
+    if rtype in ['max', 'maximum']:
+        reduce = np.max
+    elif rtype in ['min', 'minimum']:
+        reduce = np.min
+    elif rtype in ['avg', 'mean']:
+        reduce = np.mean
+    else:
+        raise ValueError("`rtype` must be one of "
+                         "{'max', 'maximum', 'min', 'minimum', 'avg', 'mean'}")
+
+    unique = []
+    multiplicity = []
+
+    pole = poles[0]
+    block = [pole]
+    for i in range(1, len(poles)):
+        if abs(poles[i] - pole) <= tol:
+            block.append(pole)
+        else:
+            unique.append(reduce(block))
+            multiplicity.append(len(block))
+            pole = poles[i]
+            block = [pole]
+
+    unique.append(reduce(block))
+    multiplicity.append(len(block))
+
+    return np.asarray(unique), np.asarray(multiplicity)
+
+
 def invres(r, p, k, tol=1e-3, rtype='avg'):
     """
     Compute b(s) and a(s) from partial fraction expansion.

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2603,7 +2603,6 @@ def invres(r, p, k, tol=1e-3, rtype='avg'):
     factors, denominator = _compute_factors(unique_poles, multiplicity,
                                             include_powers=True)
 
-    k = np.trim_zeros(k, 'f')
     if len(k) == 0:
         numerator = 0
     else:
@@ -2676,7 +2675,7 @@ def invresz(r, p, k, tol=1e-3, rtype='avg'):
     factors, denominator = _compute_factors(unique_poles, multiplicity,
                                             include_powers=True,
                                             inverse_argument=True)
-    k = np.trim_zeros(k, 'b')
+
     if len(k) == 0:
         numerator = 0
     else:

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2267,6 +2267,15 @@ def _compute_factors(roots, multiplicity, include_powers=False,
             current = np.polymul(current, monomial)
         factors.extend(reversed(block))
 
+    # When computing denominator in powers of 1/z, zero poles will reduce
+    # its order. It is correct mathematically, but to conform to MATLAB
+    # results we want to make the denominator to have the full power with zero
+    # coefficients.
+    if inverse_argument:
+        current = np.polyadd(current,
+                             np.zeros(np.sum(multiplicity) + 1,
+                                      dtype=current.dtype))
+
     return factors, current
 
 

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2386,7 +2386,10 @@ def residue(b, a, tol=1e-3, rtype='avg'):
     if b.size == 0:
         return np.zeros(poles.shape), cmplx_sort(poles)[0], np.array([])
 
-    k, b = np.polydiv(b, a)
+    if len(b) < len(a):
+        k = np.empty(0)
+    else:
+        k, b = np.polydiv(b, a)
 
     unique_poles, multiplicity = unique_roots(poles, tol=tol, rtype=rtype)
     unique_poles, order = cmplx_sort(unique_poles)
@@ -2399,7 +2402,7 @@ def residue(b, a, tol=1e-3, rtype='avg'):
         poles[index:index + mult] = pole
         index += mult
 
-    return residues / a[0], poles, np.trim_zeros(k, 'f')
+    return residues / a[0], poles, k
 
 
 def residuez(b, a, tol=1e-3, rtype='avg'):
@@ -2483,7 +2486,11 @@ def residuez(b, a, tol=1e-3, rtype='avg'):
 
     b_rev = b[::-1]
     a_rev = a[::-1]
-    k_rev, b_rev = np.polydiv(b_rev, a_rev)
+
+    if len(b_rev) < len(a_rev):
+        k_rev = np.empty(0)
+    else:
+        k_rev, b_rev = np.polydiv(b_rev, a_rev)
 
     unique_poles, multiplicity = unique_roots(poles, tol=tol, rtype=rtype)
     unique_poles, order = cmplx_sort(unique_poles)
@@ -2500,7 +2507,7 @@ def residuez(b, a, tol=1e-3, rtype='avg'):
 
     residues *= (-poles) ** powers / a_rev[0]
 
-    return residues, poles, np.trim_zeros(k_rev[::-1], 'b')
+    return residues, poles, k_rev[::-1]
 
 
 def _group_poles(poles, tol, rtype):

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2592,7 +2592,7 @@ def invres(r, p, k, tol=1e-3, rtype='avg'):
     """
     r = np.atleast_1d(r)
     p = np.atleast_1d(p)
-    k = np.atleast_1d(k)
+    k = np.trim_zeros(np.atleast_1d(k), 'f')
 
     unique_poles, multiplicity = _group_poles(p, tol, rtype)
     factors, denominator = _compute_factors(unique_poles, multiplicity,
@@ -2666,7 +2666,7 @@ def invresz(r, p, k, tol=1e-3, rtype='avg'):
     """
     r = np.atleast_1d(r)
     p = np.atleast_1d(p)
-    k = np.atleast_1d(k)
+    k = np.trim_zeros(np.atleast_1d(k), 'b')
 
     unique_poles, multiplicity = _group_poles(p, tol, rtype)
     factors, denominator = _compute_factors(unique_poles, multiplicity,

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2249,7 +2249,7 @@ def _compute_factors(roots, multiplicity, include_powers=False):
         suffixes.append(current)
     suffixes = suffixes[::-1]
 
-    result = []
+    factors = []
     current = np.array([1])
     for pole, mult, suffix in zip(roots, multiplicity, suffixes):
         monomial = np.array([1, -pole])
@@ -2258,13 +2258,13 @@ def _compute_factors(roots, multiplicity, include_powers=False):
             if i == 0 or include_powers:
                 block.append(np.polymul(current, suffix))
             current = np.polymul(current, monomial)
-        result.extend(reversed(block))
+        factors.extend(reversed(block))
 
-    return result
+    return factors, current
 
 
 def _compute_residues(poles, multiplicity, numerator):
-    denominator_factors = _compute_factors(poles, multiplicity)
+    denominator_factors, _ = _compute_factors(poles, multiplicity)
     numerator = numerator.astype(poles.dtype)
 
     residues = []

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2535,8 +2535,7 @@ def _group_poles(poles, tol, rtype):
 
 
 def invres(r, p, k, tol=1e-3, rtype='avg'):
-    """
-    Compute b(s) and a(s) from partial fraction expansion.
+    """Compute b(s) and a(s) from partial fraction expansion.
 
     If `M` is the degree of numerator `b` and `N` the degree of denominator
     `a`::
@@ -2565,20 +2564,19 @@ def invres(r, p, k, tol=1e-3, rtype='avg'):
     Parameters
     ----------
     r : array_like
-        Residues.
+        Residues corresponding to the poles. For repeated poles, the residues
+        must be ordered to correspond to ascending by power fractions.
     p : array_like
-        Poles.
+        Poles. Equal poles must be adjacent.
     k : array_like
         Coefficients of the direct polynomial term.
     tol : float, optional
-        The tolerance for two roots to be considered equal. Default is 1e-3.
-    rtype : {'max', 'min, 'avg'}, optional
-        How to determine the returned root if multiple roots are within
-        `tol` of each other.
-
-          - 'max': pick the maximum of those roots.
-          - 'min': pick the minimum of those roots.
-          - 'avg': take the average of those roots.
+        The tolerance for two roots to be considered equal in terms of
+        the distance between them. Default is 1e-3. See `unique_roots`
+        for further details.
+    rtype : {'avg', 'min', 'max'}, optional
+        Method for computing a root to represent a group of identical roots.
+        Default is 'avg'. See `unique_roots` for further details.
 
     Returns
     -------
@@ -2608,8 +2606,7 @@ def invres(r, p, k, tol=1e-3, rtype='avg'):
 
 
 def invresz(r, p, k, tol=1e-3, rtype='avg'):
-    """
-    Compute b(z) and a(z) from partial fraction expansion.
+    """Compute b(z) and a(z) from partial fraction expansion.
 
     If `M` is the degree of numerator `b` and `N` the degree of denominator
     `a`::
@@ -2637,20 +2634,19 @@ def invresz(r, p, k, tol=1e-3, rtype='avg'):
     Parameters
     ----------
     r : array_like
-        Residues.
+        Residues corresponding to the poles. For repeated poles, the residues
+        must be ordered to correspond to ascending by power fractions.
     p : array_like
-        Poles.
+        Poles. Equal poles must be adjacent.
     k : array_like
         Coefficients of the direct polynomial term.
     tol : float, optional
-        The tolerance for two roots to be considered equal. Default is 1e-3.
-    rtype : {'max', 'min, 'avg'}, optional
-        How to determine the returned root if multiple roots are within
-        `tol` of each other.
-
-          - 'max': pick the maximum of those roots.
-          - 'min': pick the minimum of those roots.
-          - 'avg': take the average of those roots.
+        The tolerance for two roots to be considered equal in terms of
+        the distance between them. Default is 1e-3. See `unique_roots`
+        for further details.
+    rtype : {'avg', 'min', 'max'}, optional
+        Method for computing a root to represent a group of identical roots.
+        Default is 'avg'. See `unique_roots` for further details.
 
     Returns
     -------

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2776,6 +2776,30 @@ class TestPartialFractionExpansion(object):
         assert_allclose(a_observed, a_expected)
         assert_allclose(b_observed, b_expected)
 
+    def test_invres(self):
+        b, a = invres([1], [1], [])
+        assert_almost_equal(b, [1])
+        assert_almost_equal(a, [1, -1])
+
+        b, a = invres([1 - 1j, 2, 0.5 - 3j], [1, 0.5j, 1 + 1j], [])
+        assert_almost_equal(b, [3.5 - 4j, -8.5 + 0.25j, 3.5 + 3.25j])
+        assert_almost_equal(a, [1, -2 - 1.5j, 0.5 + 2j, 0.5 - 0.5j])
+
+        b, a = invres([0.5, 1], [1 - 1j, 2 + 2j], [1, 2, 3])
+        assert_almost_equal(b, [1, -1 - 1j, 1 - 2j, 0.5 - 3j, 10])
+        assert_almost_equal(a, [1,  -3 - 1j, 4])
+
+        b, a = invres([-1, 2, 1j, 3 - 1j, 4, -2],
+                      [-1, 2 - 1j, 2 - 1j, 3, 3, 3], [])
+        assert_almost_equal(b, [4 - 1j, -28 + 16j, 40 - 62j, 100 + 24j,
+                                -292 + 219j, 192 - 268j])
+        assert_almost_equal(a, [1, -12 + 2j, 53 - 20j, -96 + 68j, 27 - 72j,
+                                108 - 54j, -81 + 108j])
+
+        b, a = invres([-1, 1j], [1, 1], [1, 2])
+        assert_almost_equal(b, [1, 0, -4, 3 + 1j])
+        assert_almost_equal(a, [1, -2, 1])
+
     def test_invres_distinct_roots(self):
         # This test was inspired by github issue 2496.
         r = [3 / 10, -1 / 6, -2 / 15]

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2868,6 +2868,15 @@ class TestPartialFractionExpansion(object):
         assert_almost_equal(b, [1j, 1, -3, 2])
         assert_almost_equal(a, [1, -2, 1])
 
+    def test_inverse_scalar_arguments(self):
+        b, a = invres(1, 1, 1)
+        assert_almost_equal(b, [1, 0])
+        assert_almost_equal(a, [1, -1])
+
+        b, a = invresz(1, 1, 1)
+        assert_almost_equal(b, [2, -1])
+        assert_almost_equal(a, [1, -1])
+
 
 class TestVectorstrength(object):
 

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2843,6 +2843,30 @@ class TestPartialFractionExpansion(object):
         k = []
         assert_raises(ValueError, invres, r, p, k, rtype='median')
 
+    def test_invresz(self):
+        b, a = invresz([1], [1], [])
+        assert_almost_equal(b, [1])
+        assert_almost_equal(a, [1, -1])
+
+        b, a = invresz([1 - 1j, 2, 0.5 - 3j], [1, 0.5j, 1 + 1j], [])
+        assert_almost_equal(b, [3.5 - 4j, -8.5 + 0.25j, 3.5 + 3.25j])
+        assert_almost_equal(a, [1, -2 - 1.5j, 0.5 + 2j, 0.5 - 0.5j])
+
+        b, a = invresz([0.5, 1], [1 - 1j, 2 + 2j], [1, 2, 3])
+        assert_almost_equal(b, [2.5, -3 - 1j, 1 - 2j, -1 - 3j, 12])
+        assert_almost_equal(a, [1, -3 - 1j, 4])
+
+        b, a = invresz([-1, 2, 1j, 3 - 1j, 4, -2],
+                       [-1, 2 - 1j, 2 - 1j, 3, 3, 3], [])
+        assert_almost_equal(b, [6, -50 + 11j, 100 - 72j, 80 + 58j,
+                                -354 + 228j, 234 - 297j])
+        assert_almost_equal(a, [1, -12 + 2j, 53 - 20j, -96 + 68j, 27 - 72j,
+                                108 - 54j, -81 + 108j])
+
+        b, a = invresz([-1, 1j], [1, 1], [1, 2])
+        assert_almost_equal(b, [1j, 1, -3, 2])
+        assert_almost_equal(a, [1, -2, 1])
+
 
 class TestVectorstrength(object):
 

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2806,6 +2806,7 @@ class TestPartialFractionExpansion(object):
         k = []
         with pytest.raises(ValueError, match="`rtype` must be one of"):
             invres(r, p, k, rtype='median')
+        with pytest.raises(ValueError, match="`rtype` must be one of"):
             invresz(r, p, k, rtype='median')
 
     def test_invresz_one_coefficient_bug(self):

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2524,14 +2524,15 @@ class TestPartialFractionExpansion(object):
         assert_almost_equal(r[rows], r_true[cols], decimal=decimal)
 
     def test_compute_factors(self):
-        factors = _compute_factors([1, 2, 3], [3, 2, 1])
+        factors, poly = _compute_factors([1, 2, 3], [3, 2, 1])
         assert_equal(len(factors), 3)
         assert_almost_equal(factors[0], np.poly([2, 2, 3]))
         assert_almost_equal(factors[1], np.poly([1, 1, 1, 3]))
         assert_almost_equal(factors[2], np.poly([1, 1, 1, 2, 2]))
+        assert_almost_equal(poly, np.poly([1, 1, 1, 2, 2, 3]))
 
-        factors = _compute_factors([1, 2, 3], [3, 2, 1],
-                                   include_powers=True)
+        factors, poly = _compute_factors([1, 2, 3], [3, 2, 1],
+                                         include_powers=True)
         assert_equal(len(factors), 6)
         assert_almost_equal(factors[0], np.poly([1, 1, 2, 2, 3]))
         assert_almost_equal(factors[1], np.poly([1, 2, 2, 3]))
@@ -2539,6 +2540,7 @@ class TestPartialFractionExpansion(object):
         assert_almost_equal(factors[3], np.poly([1, 1, 1, 2, 3]))
         assert_almost_equal(factors[4], np.poly([1, 1, 1, 3]))
         assert_almost_equal(factors[5], np.poly([1, 1, 1, 2, 2]))
+        assert_almost_equal(poly, np.poly([1, 1, 1, 2, 2, 3]))
 
     def test_group_poles(self):
         unique, multiplicity = _group_poles(

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2813,12 +2813,9 @@ class TestPartialFractionExpansion(object):
         r = [1]
         p = [2]
         k = [0]
-        a_expected = [1.0, 0.0]
-        b_expected = [1.0, -2.0]
-        a_observed, b_observed = invresz(r, p, k)
-
-        assert_allclose(a_observed, a_expected)
-        assert_allclose(b_observed, b_expected)
+        b, a = invresz(r, p, k)
+        assert_allclose(b, [1.0])
+        assert_allclose(a, [1.0, -2.0])
 
     def test_invres(self):
         b, a = invres([1], [1], [])

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2764,6 +2764,50 @@ class TestPartialFractionExpansion(object):
                                  "be non-zero."):
             residuez(1, [0, 1, 2, 3])
 
+    def test_inverse_unique_roots_different_rtypes(self):
+        # This test was inspired by github issue 2496.
+        r = [3 / 10, -1 / 6, -2 / 15]
+        p = [0, -2, -5]
+        k = []
+        b_expected = [0, 1, 3]
+        a_expected = [1, 7, 10, 0]
+
+        # With the default tolerance, the rtype does not matter
+        # for this example.
+        for rtype in ('avg', 'mean', 'min', 'minimum', 'max', 'maximum'):
+            b, a = invres(r, p, k, rtype=rtype)
+            assert_allclose(b, b_expected)
+            assert_allclose(a, a_expected)
+
+            b, a = invresz(r, p, k, rtype=rtype)
+            assert_allclose(b, b_expected)
+            assert_allclose(a, a_expected)
+
+    def test_inverse_repeated_roots_different_rtypes(self):
+        r = [3 / 20, -7 / 36, -1 / 6, 2 / 45]
+        p = [0, -2, -2, -5]
+        k = []
+        b_expected = [0, 0, 1, 3]
+        b_expected_z = [-1/6, -2/3, 11/6, 3]
+        a_expected = [1, 9, 24, 20, 0]
+
+        for rtype in ('avg', 'mean', 'min', 'minimum', 'max', 'maximum'):
+            b, a = invres(r, p, k, rtype=rtype)
+            assert_allclose(b, b_expected, atol=1e-14)
+            assert_allclose(a, a_expected)
+
+            b, a = invresz(r, p, k, rtype=rtype)
+            assert_allclose(b, b_expected_z, atol=1e-14)
+            assert_allclose(a, a_expected)
+
+    def test_inverse_bad_rtype(self):
+        r = [3 / 20, -7 / 36, -1 / 6, 2 / 45]
+        p = [0, -2, -2, -5]
+        k = []
+        with pytest.raises(ValueError, match="`rtype` must be one of"):
+            invres(r, p, k, rtype='median')
+            invresz(r, p, k, rtype='median')
+
     def test_invresz_one_coefficient_bug(self):
         # Regression test for issue in gh-4646.
         r = [1]
@@ -2799,49 +2843,6 @@ class TestPartialFractionExpansion(object):
         b, a = invres([-1, 1j], [1, 1], [1, 2])
         assert_almost_equal(b, [1, 0, -4, 3 + 1j])
         assert_almost_equal(a, [1, -2, 1])
-
-    def test_invres_distinct_roots(self):
-        # This test was inspired by github issue 2496.
-        r = [3 / 10, -1 / 6, -2 / 15]
-        p = [0, -2, -5]
-        k = []
-        a_expected = [0, 1, 3]
-        b_expected = [1, 7, 10, 0]
-        a_observed, b_observed = invres(r, p, k)
-        assert_allclose(a_observed, a_expected)
-        assert_allclose(b_observed, b_expected)
-        rtypes = ('avg', 'mean', 'min', 'minimum', 'max', 'maximum')
-
-        # With the default tolerance, the rtype does not matter
-        # for this example.
-        for rtype in rtypes:
-            a_observed, b_observed = invres(r, p, k, rtype=rtype)
-            assert_allclose(a_observed, a_expected)
-            assert_allclose(b_observed, b_expected)
-
-        # With unrealistically large tolerances, repeated roots may be inferred
-        # and the rtype comes into play.
-        ridiculous_tolerance = 1e10
-        for rtype in rtypes:
-            a, b = invres(r, p, k, tol=ridiculous_tolerance, rtype=rtype)
-
-    def test_invres_repeated_roots(self):
-        r = [3 / 20, -7 / 36, -1 / 6, 2 / 45]
-        p = [0, -2, -2, -5]
-        k = []
-        a_expected = [0, 0, 1, 3]
-        b_expected = [1, 9, 24, 20, 0]
-        rtypes = ('avg', 'mean', 'min', 'minimum', 'max', 'maximum')
-        for rtype in rtypes:
-            a_observed, b_observed = invres(r, p, k, rtype=rtype)
-            assert_allclose(a_observed, a_expected, atol=1e-14)
-            assert_allclose(b_observed, b_expected)
-
-    def test_invres_bad_rtype(self):
-        r = [3 / 20, -7 / 36, -1 / 6, 2 / 45]
-        p = [0, -2, -2, -5]
-        k = []
-        assert_raises(ValueError, invres, r, p, k, rtype='median')
 
     def test_invresz(self):
         b, a = invresz([1], [1], [])

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2781,7 +2781,7 @@ class TestPartialFractionExpansion(object):
         r = [3 / 10, -1 / 6, -2 / 15]
         p = [0, -2, -5]
         k = []
-        a_expected = [1, 3]
+        a_expected = [0, 1, 3]
         b_expected = [1, 7, 10, 0]
         a_observed, b_observed = invres(r, p, k)
         assert_allclose(a_observed, a_expected)
@@ -2805,12 +2805,12 @@ class TestPartialFractionExpansion(object):
         r = [3 / 20, -7 / 36, -1 / 6, 2 / 45]
         p = [0, -2, -2, -5]
         k = []
-        a_expected = [1, 3]
+        a_expected = [0, 0, 1, 3]
         b_expected = [1, 9, 24, 20, 0]
         rtypes = ('avg', 'mean', 'min', 'minimum', 'max', 'maximum')
         for rtype in rtypes:
             a_observed, b_observed = invres(r, p, k, rtype=rtype)
-            assert_allclose(a_observed, a_expected)
+            assert_allclose(a_observed, a_expected, atol=1e-14)
             assert_allclose(b_observed, b_expected)
 
     def test_invres_bad_rtype(self):

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2831,7 +2831,7 @@ class TestPartialFractionExpansion(object):
 
         b, a = invres([0.5, 1], [1 - 1j, 2 + 2j], [1, 2, 3])
         assert_almost_equal(b, [1, -1 - 1j, 1 - 2j, 0.5 - 3j, 10])
-        assert_almost_equal(a, [1,  -3 - 1j, 4])
+        assert_almost_equal(a, [1, -3 - 1j, 4])
 
         b, a = invres([-1, 2, 1j, 3 - 1j, 4, -2],
                       [-1, 2 - 1j, 2 - 1j, 3, 3, 3], [])


### PR DESCRIPTION
#### What does this implement/fix?
Follow up of  #10997

`invres` and `invresz` were untested and most likely worked incorrectly, especially after my recent changes.

I tried to make them behave as MATLAB functions. Now repeated poles must go sequentially in `p`, this is the only logical way and this is how it is done in MATLAB.

I believe the implementation is quite a bit cleaner now as well.

Review after #10997

Closes #4464
Closes #4561