### PR TITLE
DOC: special: add references for `rel_entr`

### DIFF
--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -7410,23 +7410,30 @@ add_newdoc("radian",
 
 add_newdoc("rel_entr",
     r"""
-    rel_entr(x, y)
+    rel_entr(x, y, out=None)
 
     Elementwise function for computing relative entropy.
 
-    .. math:: \mathrm{rel\_entr}(x, y) = \begin{cases} x \log(x / y) & x > 0, y > 0 \\ 0 & x = 0, y \ge 0 \\ \infty & \text{otherwise} \end{cases}
+    .. math::
+
+        \mathrm{rel\_entr}(x, y) =
+            \begin{cases}
+                x \log(x / y) & x > 0, y > 0 \\
+                0 & x = 0, y \ge 0 \\
+                \infty & \text{otherwise}
+            \end{cases}
 
     Parameters
     ----------
-    x : ndarray
-        First input array.
-    y : ndarray
-        Second input array.
+    x, y : array_like
+        Input arrays
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
-    res : ndarray
-        Output array.
+    scalar or ndarray
+        Relative entropy of the inputs
 
     See Also
     --------
@@ -7434,9 +7441,27 @@ add_newdoc("rel_entr",
 
     Notes
     -----
+    .. versionadded:: 0.15.0
+
     This function is jointly convex in x and y.
 
-    .. versionadded:: 0.15.0
+    The origin of this function is in convex programming; see
+    [1]_. Given two discrete probability distributions :math:`p_1,
+    \ldots, p_n` and :math:`q_1, \ldots, q_n`, to get the relative
+    entropy of statistics compute the sum
+
+    .. math::
+
+        \sum_{i = 1}^n \mathrm{rel\_entr}(p_i, q_i).
+
+    See [2]_ for details.
+
+    References
+    ----------
+    .. [1] Grant, Boyd, and Ye, "CVX: Matlab Software for Disciplined Convex
+        Programming", http://cvxr.com/cvx/
+    .. [2] Kullback-Leibler divergence,
+        https://en.wikipedia.org/wiki/Kullback%E2%80%93Leibler_divergence
 
     """)
 


### PR DESCRIPTION
#### Reference issue

None.

#### What does this implement/fix?

References are added to the `rel_entr` docstring.

#### Additional information

In particular:

- Give a reference for the function's origin in convex programming
- Explain how it relates to what is usually called relative entropy