### PR TITLE
MAINT: Filter unrelated warning

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -132,6 +132,9 @@ for key in (
         ):
     warnings.filterwarnings(  # deal with other modules having bad imports
         'ignore', message=".*" + key, category=DeprecationWarning)
+warnings.filterwarnings(  # matplotlib<->pyparsing issue
+    'ignore', message="Exception creating Regex for oneOf.*",
+    category=SyntaxWarning)
 # warnings in examples (mostly) that we allow
 # TODO: eventually these should be eliminated!
 for key in (


### PR DESCRIPTION
Quick fix for an unrelated matplotlib<->pyparsing warning that's showing up in CircleCI. Since we treat warnings as errors, CircleCI is currently failing (e.g., [here](https://circleci.com/gh/scipy/scipy/16005) for #11012).