### PR TITLE
improving error message for cubic-interpolate with duplicates

### DIFF
--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -795,8 +795,10 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
 
     y = np.rollaxis(y, axis)    # now internally interp axis is zero
 
-    if x.ndim != 1 or np.any(x[1:] <= x[:-1]):
+    if x.ndim != 1 or np.any(x[1:] < x[:-1]):
         raise ValueError("Expect x to be a 1-D sorted array_like.")
+    if np.any(x[1:] == x[:-1]):
+        raise ValueError("Expect x to not have duplicates")
     if k < 0:
         raise ValueError("Expect non-negative k.")
     if t.ndim != 1 or np.any(t[1:] < t[:-1]):


### PR DESCRIPTION
Add a specific error message for when there are duplicates

Snippet
```py
from scipy.interpolate import interp1d
import numpy as np
interp1d(x=[0, 1, 1, 2], y=[0, 1, 2, 3], kind='cubic')
```
Returns
```ValueError: Expect x to be a 1-D sorted array_like.```

#### Reference issue
Sort of
https://github.com/scipy/scipy/issues/10347
https://github.com/scipy/scipy/issues/9886

#### What does this implement/fix?
Better error messages when an array with duplicate values is used

#### Additional information
A beginner probably doesn't implicitly understand that "ValueError: Expect x to be a 1-D sorted array_like." means there are duplicate values.