### PR TITLE
MAINT: update choose_conv_method for pocketfft implementation

### DIFF
--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1087,8 +1087,8 @@ def choose_conv_method(in1, in2, mode='full', measure=False):
 
     Notes
     -----
-    Generally, this method is about 90% accurate (99% for 2D signals and 85%
-    accurate for 2D signals for randomly chosen input sizes). For precision
+    Generally, this method is 99% accurate for 2D signals and 85% accurate
+    for 1D signals for randomly chosen input sizes. For precision
     (e.g., for different hardware), use ``measure=True`` to find the fastest
     method by timing the convolution.
 
@@ -1096,16 +1096,16 @@ def choose_conv_method(in1, in2, mode='full', measure=False):
     than 5 times slower than the faster method (at least in our
     experiments). There is a 99.9% chance of this ratio being less than 2 for 2D
     signals and less than 5 for 1D signals. This function is most inaccurate for
-    fast 1D convolutions taking less that 0.01 seconds. The speed tests were
-    performed on an Amazon EC2 r5a.2xlarge machine.
+    1D convolutions that take less than 0.01 seconds with ``method='direct'``.
+    These speed tests were performed on an Amazon EC2 r5a.2xlarge machine.
 
     This function generalizes fairly decently across hardware. The specific
     values for this function were tuned on an mid-2014 15-inch MacBook Pro with
     16GB RAM and a 2.5GHz Intel i7 processor. The speed tests on the EC2
     machine performed slightly better than the tests on Macbook Pro.
 
-    The convolution is timed the convolutions if ``measure=True``.
-    There are cases when `fftconvolve` supports the inputs but this function
+    The convolution is timed if ``measure=True``.  There are cases when
+    `fftconvolve` supports the inputs but this function
     returns `direct` (e.g., to protect against floating point integer
     precision).
 

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1092,7 +1092,7 @@ def choose_conv_method(in1, in2, mode='full', measure=False):
     (e.g., for different hardware), use ``measure=True`` to find the fastest
     method by timing the convolution.
 
-    If this funciton is incorrect, the estimated method will vary by less
+    If this function is incorrect, the estimated method will vary by less
     than 5 times slower than the faster method (at least in our
     experiments). There is a 99.9% chance of this ratio being less than 2 for 2D
     signals and less than 5 for 1D signals. This function is most inaccurate for

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -897,7 +897,7 @@ def _conv_ops(x_shape, h_shape, mode):
     if mode == "full":
         out_shape = [n + k - 1 for n, k in zip(x_shape, h_shape)]
     elif mode == "valid":
-        out_shape = [max(n, k) - min(n, k) + 1 for n, k in zip(x_shape, h_shape)],
+        out_shape = [max(n, k) - min(n, k) + 1 for n, k in zip(x_shape, h_shape)]
     elif mode == "same":
         out_shape = x_shape
     else:
@@ -912,7 +912,7 @@ def _conv_ops(x_shape, h_shape, mode):
         elif mode == "valid":
             direct_ops = (s2 - s1 + 1) * s1 if s2 >= s1 else (s1 - s2 + 1) * s2
         elif mode == "same":
-            direct_mul = s1 * s2 if s1 <= s2 else s1 * s2 - (s2 // 2) * ((s2 + 1) // 2)
+            direct_ops = s1 * s2 if s1 <= s2 else s1 * s2 - (s2 // 2) * ((s2 + 1) // 2)
     else:
         if mode == "full":
             direct_ops = min(_prod(s1), _prod(s2)) * _prod(out_shape)

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -932,7 +932,7 @@ def _conv_ops(x_shape, h_shape, mode):
 
     full_out_shape = [n + k - 1 for n, k in zip(x_shape, h_shape)]
     N = _prod(shape)
-    fft_ops = 3 * N * np.log(n)  # 3 separate FFTs of size full_out_shape
+    fft_ops = 3 * N * np.log(N)  # 3 separate FFTs of size full_out_shape
     return fft_ops, direct_ops
 
 

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1087,21 +1087,22 @@ def choose_conv_method(in1, in2, mode='full', measure=False):
 
     Notes
     -----
-    Generally, this method is about 85% accurate for randomly chosen input
-    sizes for 1D signals and >95% accurate otherwise. For precision, use
-    ``measure=True`` to find the fastest method by running and measuring
-    the convolutions.
+    Generally, this method is about 90% accurate (99% for 2D signals and 85%
+    accurate for 2D signals for randomly chosen input sizes). For precision
+    (e.g., for different hardware), use ``measure=True`` to find the fastest
+    method by timing the convolution.
 
     If this funciton is incorrect, the estimated method will very like by less
-    than 10 times slower than the other faster method (at least in our
-    experiments). There is a 95% chance of this ratio being less than 2 for 2D
-    signals and less than 3.5 for 1D signals (except 1D signals with
-    ``mode=='same'`` and ``len(in1) < len(in2)``, which has a 95% probability
-    of the ratio being less than 20).
+    than 5 times slower than the faster method (at least in our
+    experiments). There is a 99.9% chance of this ratio being less than 2 for 2D
+    signals and less than 5 for 1D signals. This function is most inaccurate for
+    fast 1D convolutions taking less that 0.01 seconds. The speed tests were
+    performed on an Amazon EC2 r5a.2xlarge machine.
 
-    The estimation values were tuned on an mid-2014 15-inch MacBook Pro with
-    16GB RAM and a 2.5GHz Intel i7 processor. We found this function
-    generalizes decently across machines.
+    This function generalizes fairly decently across hardware. The specific
+    values for this function were tuned on an mid-2014 15-inch MacBook Pro with
+    16GB RAM and a 2.5GHz Intel i7 processor. The speed tests on the EC2
+    machine performed slightly better than the tests on Macbook Pro.
 
     The convolution is timed the convolutions if ``measure=True``.
     There are cases when `fftconvolve` supports the inputs but this function

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1077,26 +1077,22 @@ def choose_conv_method(in1, in2, mode='full', measure=False):
 
     Notes
     -----
-    For large n, ``measure=False`` is accurate and can quickly determine the
-    fastest method to perform the convolution. Generally, this method is about
-    90% accurate for randomly chosen input sizes. However, this is not as
-    accurate for small inputs.
+    Generally, this method is about 90% accurate for randomly chosen input
+    sizes. For precision, use ``measure=True`` to find the fastest method by
+    running and measuring the convolutions. This function is most inaccurate
+    for small sized 1D inputs.
 
-    If this funciton is incorrect, the estimate is about up to 7 times slower
-    than the other faster method (i.e., the estimated method is *at most* 7
-    times slower than the fastest method). For the modes ``full``, ``valid``
-    and ``same`` there is at least a 95% chance of the ratio being less
-    than 2.5, 3.2 and 4.5 respectively (at least in our testing). This is
-    function is least accurate when the convolution takes less than
-    approximately 0.3ms for 1D signals where ``mode=='same'`` and
-    ``len(in1) < len(in2)``.
+    If this funciton is incorrect, the estimated method is less than 10 times
+    slower than the other faster method (at least in our experiments).
+    There is a 95% chance of this ratio being less than 3 for all signals
+    except 1D signals with ``mode=='same'`` (in which case there's a
+    95% probability the ratio is less than 5).
 
     The estimation values were tuned on an mid-2014 15-inch MacBook Pro with
     16GB RAM and a 2.5GHz Intel i7 processor. We found this function
     generalizes decently across machines.
 
-    If ``measure=True``, time the convolutions. Because this function uses
-    `fftconvolve`, an error will be thrown if it does not support the inputs.
+    The convolution is timed the convolutions if ``measure=True``.
     There are cases when `fftconvolve` supports the inputs but this function
     returns `direct` (e.g., to protect against floating point integer
     precision).
@@ -1118,9 +1114,11 @@ def choose_conv_method(in1, in2, mode='full', measure=False):
 
     >>> img2 = np.random.rand(32, 32)
     >>> filter2 = np.random.rand(8, 8)
-    >>> # `method` works with correlate and convolve
     >>> corr2 = signal.correlate(img2, filter2, mode='same', method=method)
     >>> conv2 = signal.convolve(img2, filter2, mode='same', method=method)
+
+    The output of this function (``method``) works with `correlate` and
+    `convolve`.
 
     """
     volume = np.asarray(in1)

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1096,14 +1096,19 @@ def choose_conv_method(in1, in2, mode='full', measure=False):
     Experiments were run on an Amazon EC2 r5a.2xlarge machine to test this
     function. These experiments measured the ratio between the time required
     when using ``method='auto'`` and the time required for the fastest method
-    (i.e., ``time_auto / min(time_fft, time_direct)``).  In these experiments,
-    we found:
+    (i.e., ``ratio = time_auto / min(time_fft, time_direct)``). In these
+    experiments, we found:
 
-    * There is a 95% chance of this ratio being less than 2.5 for 1D signals
-      and a 99% chance of being less than 1.5 for 2D signals.
+    * There is a 95% chance of this ratio being less than 1.5 for 1D signals
+      and a 99% chance of being less than 2.5 for 2D signals.
+    * The ratio was always less than 2.5/5 for 1D/2D signals respectively in
+      our experiments.
     * This function is most inaccurate for 1D convolutions that take between 1
       and 10 milliseconds with ``method='direct'``. A good proxy for this
-      (at least in our experiments) is ``1e6 <= in1.size * in2.size <= 1e7``.
+      (at least in our experiments) is ``1e6 <= in1.size * in2.size <= 1e7``
+
+    The 2D results almost certainly generalize to 3D/4D/etc because it relies on
+    the same implementation (the 1D implementation is different).
 
     All the numbers above are specific to the EC2 machine. However, we did find
     that this function generalizes fairly decently across hardware. The speed

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1087,16 +1087,16 @@ def choose_conv_method(in1, in2, mode='full', measure=False):
 
     Notes
     -----
-    Generally, this method is about 90% accurate for randomly chosen input
+    Generally, this method is about 85% accurate for randomly chosen input
     sizes for 1D signals and >95% accurate otherwise. For precision, use
     ``measure=True`` to find the fastest method by running and measuring
     the convolutions.
 
-    If this funciton is incorrect, the estimated method is less than 10 times
-    slower than the other faster method (at least in our experiments).
-    There is a 95% chance of this ratio being less than 3 for all signals
-    (except 1D signals with ``mode=='same'`` and ``len(in1) < len(in2)``,
-    which has a 95% probability of the ratio being less than 5.5).
+    If this funciton is incorrect, the estimated method will very like by less
+    than 10 times slower than the other faster method (at least in our
+    experiments). There is a 95% chance of this ratio being less than 2 for 2D signals and less than 3.5 for 1D signals (except 1D signals with
+    ``mode=='same'`` and ``len(in1) < len(in2)``, which has a 95% probability
+    of the ratio being less than 20).
 
     The estimation values were tuned on an mid-2014 15-inch MacBook Pro with
     16GB RAM and a 2.5GHz Intel i7 processor. We found this function

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1090,22 +1090,28 @@ def choose_conv_method(in1, in2, mode='full', measure=False):
     Generally, this method is 99% accurate for 2D signals and 85% accurate
     for 1D signals for randomly chosen input sizes. For precision
     (e.g., for different hardware), use ``measure=True`` to find the fastest
-    method by timing the convolution.
+    method by timing the convolution (which can be used to avoid the minimal
+    overhead of finding the fastest ``method`` later).
 
-    If this funciton is incorrect, the estimated method will vary by less
-    than 5 times slower than the faster method (at least in our
-    experiments). There is a 99.9% chance of this ratio being less than 2 for 2D
-    signals and less than 5 for 1D signals. This function is most inaccurate for
-    1D convolutions that take less than 0.01 seconds with ``method='direct'``.
-    These speed tests were performed on an Amazon EC2 r5a.2xlarge machine.
+    Experiments were run on an Amazon EC2 r5a.2xlarge machine to test this
+    function. These experiments measured the ratio between the time required
+    when using ``method='auto'`` and the time required for the fastest method
+    (i.e., ``time_auto / min(time_fft, time_direct)``).  In these experiments,
+    we found:
 
-    This function generalizes fairly decently across hardware. The specific
-    values for this function were tuned on an mid-2014 15-inch MacBook Pro with
-    16GB RAM and a 2.5GHz Intel i7 processor. The speed tests on the EC2
-    machine performed slightly better than the tests on Macbook Pro.
+    * There is a 95% chance of this ratio being less than 2.5 for 1D signals
+      and a 99% chance of being less than 1.5 for 2D signals.
+    * This function is most inaccurate for 1D convolutions that take between 1
+      and 10 milliseconds with ``method='direct'``. A good proxy for this
+      (at least in our experiments) is ``1e6 <= in1.size * in2.size <= 1e7``.
 
-    The convolution is timed if ``measure=True``.  There are cases when
-    `fftconvolve` supports the inputs but this function
+    All the numbers above are specific to the EC2 machine. However, we did find
+    that this function generalizes fairly decently across hardware. The speed
+    tests were of similar quality (and even slightly better) than the same
+    tests performed on the machine to tune this function's numbers (a mid-2014
+    15-inch MacBook Pro with 16GB RAM and a 2.5GHz Intel i7 processor).
+
+    There are cases when `fftconvolve` supports the inputs but this function
     returns `direct` (e.g., to protect against floating point integer
     precision).
 

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -896,8 +896,9 @@ def _conv_ops(x_shape, h_shape, mode):
     """
     Find the number of operations required for direct/fft methods of
     convolution. The direct operations were recorded by making a dummy class to
-    record the number of multplications, and the FFT operations rely on the
-    (well-known) computational complexity of the FFT.
+    record the number of operations by overriding ``__mul__`` and ``__add__``.
+    The FFT operations rely on the (well-known) computational complexity of the
+    FFT (and the implementation of ``_freq_domain_conv``).
 
     """
     x_size, h_size = _prod(x_shape), _prod(h_shape)

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1081,14 +1081,21 @@ def choose_conv_method(in1, in2, mode='full', measure=False):
     Notes
     -----
     For large n, ``measure=False`` is accurate and can quickly determine the
-    fastest method to perform the convolution.  However, this is not as
-    accurate for small n (when any dimension in the input or output is small).
+    fastest method to perform the convolution. Generally, this method is about
+    90% accurate for randomly chosen input sizes. However, this is not as
+    accurate for small inputs.
 
-    In practice, we found that this function estimates the faster method up to
-    a multiplicative factor of 5 (i.e., the estimated method is *at most* 5
-    times slower than the fastest method). The estimation values were tuned on
-    an early 2015 MacBook Pro with 8GB RAM but we found that the prediction
-    held *fairly* accurately across different machines.
+    If this funciton is incorrect, the estimate is about up to 7 times slower
+    than the other faster method (i.e., the estimated method is *at most* 7
+    times slower than the fastest method). For the modes ``full``, ``valid``
+    and ``same`` there is at least a 95% chance of the ratio being less
+    than 2.5, 3.2 and 4.5 respectively (at least in our testing). This is
+    function is least accurate when the convolution takes less than
+    approximately 0.3ms for 1D signals where ``len(in1) < len(in2)``.
+
+    The estimation values were tuned on an mid-2014 15-inch MacBook Pro with
+    16GB RAM and a 2.5GHz Intel i7 processor. We found this function
+    generalizes decently across machines.
 
     If ``measure=True``, time the convolutions. Because this function uses
     `fftconvolve`, an error will be thrown if it does not support the inputs.
@@ -1103,8 +1110,8 @@ def choose_conv_method(in1, in2, mode='full', measure=False):
     Estimate the fastest method for a given input:
 
     >>> from scipy import signal
-    >>> a = np.random.randn(1000)
-    >>> b = np.random.randn(1000000)
+    >>> a = np.random.randn(1000000)
+    >>> b = np.random.randn(1000)
     >>> method = signal.choose_conv_method(a, b, mode='same')
     >>> method
     'fft'

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1112,21 +1112,19 @@ def choose_conv_method(in1, in2, mode='full', measure=False):
     Estimate the fastest method for a given input:
 
     >>> from scipy import signal
-    >>> a = np.random.randn(1000000)
-    >>> b = np.random.randn(1000)
-    >>> method = signal.choose_conv_method(a, b, mode='same')
+    >>> img = np.random.rand(32, 32)
+    >>> filter = np.random.rand(8, 8)
+    >>> method = signal.choose_conv_method(img, filter, mode='same')
     >>> method
     'fft'
 
     This can then be applied to other arrays of the same dtype and shape:
 
-    >>> c = np.random.randn(1000)
-    >>> d = np.random.randn(1000000)
+    >>> img2 = np.random.rand(32, 32)
+    >>> filter2 = np.random.rand(8, 8)
     >>> # `method` works with correlate and convolve
-    >>> corr1 = signal.correlate(a, b, mode='same', method=method)
-    >>> corr2 = signal.correlate(c, d, mode='same', method=method)
-    >>> conv1 = signal.convolve(a, b, mode='same', method=method)
-    >>> conv2 = signal.convolve(c, d, mode='same', method=method)
+    >>> corr2 = signal.correlate(img2, filter2, mode='same', method=method)
+    >>> conv2 = signal.convolve(img2, filter2, mode='same', method=method)
 
     """
     volume = np.asarray(in1)

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -897,7 +897,7 @@ def _conv_ops(x_shape, h_shape, mode):
     if mode == "full":
         out_shape = [n + k - 1 for n, k in zip(x_shape, h_shape)]
     elif mode == "valid":
-        out_shape = [max(n, k) - min(n, k) + 1 for n, k in zip(x_shape, h_shape)],
+        out_shape = [abs(n - k) + 1 for n, k in zip(x_shape, h_shape)],
     elif mode == "same":
         out_shape = x_shape
     else:

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1092,7 +1092,7 @@ def choose_conv_method(in1, in2, mode='full', measure=False):
     (e.g., for different hardware), use ``measure=True`` to find the fastest
     method by timing the convolution.
 
-    If this funciton is incorrect, the estimated method will very like by less
+    If this funciton is incorrect, the estimated method will vary by less
     than 5 times slower than the faster method (at least in our
     experiments). There is a 99.9% chance of this ratio being less than 2 for 2D
     signals and less than 5 for 1D signals. This function is most inaccurate for

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -936,7 +936,7 @@ def _conv_ops(x_shape, h_shape, mode):
     return fft_ops, direct_ops
 
 
-def _fftconv_faster(x, h, mode, test=True):
+def _fftconv_faster(x, h, mode):
     """
     See if using fftconvolve or convolve is faster.
 
@@ -955,7 +955,10 @@ def _fftconv_faster(x, h, mode, test=True):
 
     Notes
     -----
-    See docstring of `choose_conv_method` for details on how tuned.
+    See docstring of `choose_conv_method` for details on tuning hardware.
+
+    See pull request 11031 for more detail:
+    https://github.com/scipy/scipy/pull/11031.
 
     """
     fft_ops, direct_ops = _conv_ops(x.shape, h.shape, mode)
@@ -1084,15 +1087,15 @@ def choose_conv_method(in1, in2, mode='full', measure=False):
     Notes
     -----
     Generally, this method is about 90% accurate for randomly chosen input
-    sizes. For precision, use ``measure=True`` to find the fastest method by
-    running and measuring the convolutions. This function is most inaccurate
-    for small sized 1D inputs.
+    sizes for 1D signals and >95% accurate otherwise. For precision, use
+    ``measure=True`` to find the fastest method by running and measuring
+    the convolutions.
 
     If this funciton is incorrect, the estimated method is less than 10 times
     slower than the other faster method (at least in our experiments).
     There is a 95% chance of this ratio being less than 3 for all signals
-    except 1D signals with ``mode=='same'`` (in which case there's a
-    95% probability the ratio is less than 5).
+    (except 1D signals with ``mode=='same'`` and ``len(in1) < len(in2)``,
+    which has a 95% probability of the ratio being less than 5.5).
 
     The estimation values were tuned on an mid-2014 15-inch MacBook Pro with
     16GB RAM and a 2.5GHz Intel i7 processor. We found this function

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1094,7 +1094,8 @@ def choose_conv_method(in1, in2, mode='full', measure=False):
 
     If this funciton is incorrect, the estimated method will very like by less
     than 10 times slower than the other faster method (at least in our
-    experiments). There is a 95% chance of this ratio being less than 2 for 2D signals and less than 3.5 for 1D signals (except 1D signals with
+    experiments). There is a 95% chance of this ratio being less than 2 for 2D
+    signals and less than 3.5 for 1D signals (except 1D signals with
     ``mode=='same'`` and ``len(in1) < len(in2)``, which has a 95% probability
     of the ratio being less than 20).
 

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -968,7 +968,7 @@ def _fftconv_faster(x, h, mode, test=True):
 
     """
     fft_ops, direct_ops = _conv_ops(x.shape, h.shape, mode)
-    big_O_constant = _get_fft_constant(mode, x.ndim, _prod(x.shape), _prod(h.shape))
+    big_O_constant = _get_fft_constant(mode, x.ndim, x.size, h.size)
     return big_O_constant * fft_ops < direct_ops
 
 

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -929,7 +929,7 @@ def _get_fft_constant(mode, ndim, x_size, h_size, test=False):
         constants = {
             "valid": 14.336458,
             "full": 11.548068,
-            "same": 15.747428 if h_size <= x_size else 0.73367078,
+            "same": 15.747428 if h_size < x_size else 0.73367078,
         }
     else:
         constants = {

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -895,11 +895,9 @@ def _prod(iterable):
 def _conv_ops(x_shape, h_shape, mode):
     """
     Find the number of operations required for direct/fft methods of
-    convolution
-
-    The direct operations were recorded by making a dummy class to record the
-    number of multplications. The number of additions is always less than or
-    equal to the number of multiplications. More detail visible at [1].
+    convolution. The direct operations were recorded by making a dummy class to
+    record the number of multplications, and the FFT operations rely on the
+    (well-known) computational complexity of the FFT.
 
     """
     x_size, h_size = _prod(x_shape), _prod(h_shape)

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -962,16 +962,17 @@ def _fftconv_faster(x, h, mode):
 
     """
     fft_ops, direct_ops = _conv_ops(x.shape, h.shape, mode)
-    offset = 0 if x.ndim == 1 else -2e-4
+    offset = -1e-3 if x.ndim == 1 else -1e-4
     constants = {
-        "valid": (7.28800943e-6, 3.344823e-7, offset),
-        "full": (7.2673e-6, 2.01e-7, offset),
-        "same": (2.3223e-5, 1.51e-6, offset) if h.size <= x.size else\
-                (2.3427e-5, 17e-6, offset),
+            "valid": (1.89095737e-9, 2.1364985e-10, offset),
+            "full": (1.7649070e-9, 2.1414831e-10, offset),
+            "same": (3.2646654e-9, 2.8478277e-10, offset)
+            if h.size <= x.size
+            else (3.21635404e-9, 1.1773253e-8, -1e-5),
     } if x.ndim == 1 else {
-            "valid": (4.24046e-9, 3.344823e-8, offset),
-            "full": (3.4457e-9, 2.06903e-8, offset),
-            "same": (4.14859e-9, 1.65125e-8, offset),
+            "valid": (1.85927e-9, 2.11242e-8, offset),
+            "full": (1.99817e-9, 1.66174e-8, offset),
+            "same": (2.04735e-9, 1.55367e-8, offset),
     }
     O_fft, O_direct, O_offset = constants[mode]
     return O_fft * fft_ops < O_direct * direct_ops + O_offset

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -931,7 +931,7 @@ def _conv_ops(x_shape, h_shape, mode):
             direct_ops = _prod(s1) * _prod(s2)
 
     full_out_shape = [n + k - 1 for n, k in zip(x_shape, h_shape)]
-    N = _prod(shape)
+    N = _prod(full_out_shape)
     fft_ops = 3 * N * np.log(N)  # 3 separate FFTs of size full_out_shape
     return fft_ops, direct_ops
 

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1091,7 +1091,8 @@ def choose_conv_method(in1, in2, mode='full', measure=False):
     and ``same`` there is at least a 95% chance of the ratio being less
     than 2.5, 3.2 and 4.5 respectively (at least in our testing). This is
     function is least accurate when the convolution takes less than
-    approximately 0.3ms for 1D signals where ``len(in1) < len(in2)``.
+    approximately 0.3ms for 1D signals where ``mode=='same'`` and
+    ``len(in1) < len(in2)``.
 
     The estimation values were tuned on an mid-2014 15-inch MacBook Pro with
     16GB RAM and a 2.5GHz Intel i7 processor. We found this function

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -931,8 +931,8 @@ def _conv_ops(x_shape, h_shape, mode):
             direct_ops = _prod(s1) * _prod(s2)
 
     full_out_shape = [n + k - 1 for n, k in zip(x_shape, h_shape)]
-    N = [_prod(shape) for shape in [x_shape, h_shape, full_out_shape]]
-    fft_ops = sum(n * np.log(n) for n in N)
+    N = _prod(shape)
+    fft_ops = 3 * N * np.log(n)  # 3 separate FFTs of size full_out_shape
     return fft_ops, direct_ops
 
 

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1042,10 +1042,10 @@ def choose_conv_method(in1, in2, mode='full', measure=False):
     Find the fastest convolution/correlation method.
 
     This primarily exists to be called during the ``method='auto'`` option in
-    `convolve` and `correlate`, but can also be used when performing many
-    convolutions of the same input shapes and dtypes, determining
-    which method to use for all of them, either to avoid the overhead of the
-    'auto' option or to use accurate real-world measurements.
+    `convolve` and `correlate`. It can also be used to determine the value of
+    ``method`` for many different convolutions of the same dtype/shape.
+    In addition, it supports timing the convolution to adapt the value of
+    ``method`` to a particular set of inputs and/or hardware.
 
     Parameters
     ----------
@@ -1087,10 +1087,11 @@ def choose_conv_method(in1, in2, mode='full', measure=False):
     Notes
     -----
     Generally, this method is 99% accurate for 2D signals and 85% accurate
-    for 1D signals for randomly chosen input sizes. For precision
-    (e.g., for different hardware), use ``measure=True`` to find the fastest
-    method by timing the convolution (which can be used to avoid the minimal
-    overhead of finding the fastest ``method`` later).
+    for 1D signals for randomly chosen input sizes. For precision, use
+    ``measure=True`` to find the fastest method by timing the convolution.
+    This can be used to avoid the minimal overhead of finding the fastest
+    ``method`` later, or to adapt the value of ``method`` to a particular set
+    of inputs.
 
     Experiments were run on an Amazon EC2 r5a.2xlarge machine to test this
     function. These experiments measured the ratio between the time required
@@ -1100,14 +1101,13 @@ def choose_conv_method(in1, in2, mode='full', measure=False):
 
     * There is a 95% chance of this ratio being less than 1.5 for 1D signals
       and a 99% chance of being less than 2.5 for 2D signals.
-    * The ratio was always less than 2.5/5 for 1D/2D signals respectively in
-      our experiments.
+    * The ratio was always less than 2.5/5 for 1D/2D signals respectively.
     * This function is most inaccurate for 1D convolutions that take between 1
       and 10 milliseconds with ``method='direct'``. A good proxy for this
-      (at least in our experiments) is ``1e6 <= in1.size * in2.size <= 1e7``
+      (at least in our experiments) is ``1e6 <= in1.size * in2.size <= 1e7``.
 
-    The 2D results almost certainly generalize to 3D/4D/etc because it relies on
-    the same implementation (the 1D implementation is different).
+    The 2D results almost certainly generalize to 3D/4D/etc because the
+    implementation is the same (the 1D implementation is different).
 
     All the numbers above are specific to the EC2 machine. However, we did find
     that this function generalizes fairly decently across hardware. The speed

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -912,7 +912,7 @@ def _conv_ops(x_shape, h_shape, mode):
         elif mode == "valid":
             direct_ops = (s2 - s1 + 1) * s1 if s2 >= s1 else (s1 - s2 + 1) * s2
         elif mode == "same":
-            direct_ops = s1 * s2 if s1 <= s2 else s1 * s2 - (s2 // 2) * ((s2 + 1) // 2)
+            direct_ops = s1 * s2 if s1 < s2 else s1 * s2 - (s2 // 2) * ((s2 + 1) // 2)
     else:
         if mode == "full":
             direct_ops = min(_prod(s1), _prod(s2)) * _prod(out_shape)

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2242,11 +2242,9 @@ def check_filtfilt_gust(b, a, shape, axis, irlen=None):
 
 
 def test_choose_conv_method():
-    for ndim in [1, 2]:
-        for mode in ['valid', 'same', 'full']:
+    for mode in ['valid', 'same', 'full']:
+        for ndim in [1, 2]:
             n, k, true_method = 8, 6, 'direct'
-            if ndim == 2 and mode in {"same", "full"}:
-                n, k, true_method = 10, 2, 'direct'
             x = np.random.randn(*((n,) * ndim))
             h = np.random.randn(*((k,) * ndim))
 

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2242,11 +2242,13 @@ def check_filtfilt_gust(b, a, shape, axis, irlen=None):
 
 
 def test_choose_conv_method():
-    for mode in ['valid', 'same', 'full']:
-        for ndims in [1, 2]:
+    for ndim in [1, 2]:
+        for mode in ['valid', 'same', 'full']:
             n, k, true_method = 8, 6, 'direct'
-            x = np.random.randn(*((n,) * ndims))
-            h = np.random.randn(*((k,) * ndims))
+            if ndim == 2 and mode in {"same", "full"}:
+                n, k, true_method = 10, 2, 'direct'
+            x = np.random.randn(*((n,) * ndim))
+            h = np.random.randn(*((k,) * ndim))
 
             method = choose_conv_method(x, h, mode=mode)
             assert_equal(method, true_method)


### PR DESCRIPTION
#### Reference issue
* Closes #10887
* Closes #10427
* This PR doesn't include the constant offset like #10904

#### What does this implement/fix?
This updates the `choose_conv_method` numbers to adapt the PocketFFT implementation, as requested by @larsoner in https://github.com/scipy/scipy/pull/10904#issuecomment-548829953.

TODO:

- [x] verify that this PR has the expected speedups  
*Note: these experiments are in https://github.com/scipy/scipy/pull/11031#issuecomment-553068427*

#### Additional information

@drorspei deserves to be an author on this commit. I used their analysis on the number of multiplications/additions in https://github.com/drorspei/misc/blob/master/notebooks/conv-complexity.ipynb.

Some preliminary experiments:

``` python
>>> from scipy.signal import choose_conv_method
>>> import numpy as np
>>> rand = np.random.rand
>>> modes = ["full", "valid", "same"]
>>> [choose_conv_method(rand(10), rand(2), mode) for mode in modes]
['direct', 'direct', 'direct']
>>> [choose_conv_method(rand(2), rand(10), mode) for mode in modes]
['direct', 'direct', 'fft']
>>> choose_conv_method(rand(2), rand(10), "same", measure=True)
('direct', {'fft': 9.504000190645457e-05, 'direct': 1.192550000268966e-05})
>>> choose_conv_method(rand(4), rand(10), "same")
'fft'
>>> choose_conv_method(rand(4), rand(4), "same")
'direct'
>>> choose_conv_method(rand(2), rand(3), "same")
'fft'
>>> choose_conv_method(rand(2), rand(3), "same", measure=True)
('direct', {'fft': 8.895000006305054e-05, 'direct': 1.1751199985155836e-05})
```