### PR TITLE
TST: fix tf2zpk test failure due to incorrect complex sorting.

### DIFF
--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -174,7 +174,9 @@ class TestTf2zpk(object):
 
         z, p, k = tf2zpk(b, a)
         z.sort()
-        p.sort()
+        # The real part of `p` is ~0.0, so sort by imaginary part
+        p = p[np.argsort(p.imag)]
+
         assert_array_almost_equal(z, z_r)
         assert_array_almost_equal(p, p_r)
         assert_array_almost_equal(k, 1.)


### PR DESCRIPTION
Closes gh-11041.

`np.sort` sorts by the real part of complex numbers first, so if those are all zero modulo some numerical noise things can go wrong.