### PR TITLE
MAINT: choose_conv_method can choose fftconvolution for longcomplex

### DIFF
--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1090,12 +1090,6 @@ def choose_conv_method(in1, in2, mode='full', measure=False):
         chosen_method = 'fft' if times['fft'] < times['direct'] else 'direct'
         return chosen_method, times
 
-    # fftconvolve doesn't support complex256
-    fftconv_unsup = "complex256" if sys.maxsize > 2**32 else "complex192"
-    if hasattr(np, fftconv_unsup):
-        if volume.dtype == fftconv_unsup or kernel.dtype == fftconv_unsup:
-            return 'direct'
-
     # for integer input,
     # catch when more precision required than float provides (representing an
     # integer as float can lose precision in fftconvolve if larger than 2**52)

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -995,6 +995,18 @@ class TestAllFreqConvolves(object):
                            match="all axes must be unique"):
             convapproach([1], [2], axes=[0, 0])
 
+    @pytest.mark.parametrize('dtype', [np.longfloat, np.longcomplex])
+    def test_longdtype_input(self, dtype):
+        x = np.random.random((27, 27)).astype(dtype)
+        y = np.random.random((4, 4)).astype(dtype)
+        if np.iscomplexobj(dtype()):
+            x += .1j
+            y -= .1j
+
+        res = fftconvolve(x, y)
+        assert_allclose(res, convolve(x, y, method='direct'))
+        assert res.dtype == dtype
+
 
 class TestMedFilt(object):
 


### PR DESCRIPTION
#### What does this implement/fix?
Now that `scipy.fft` supports `long double`, `choose_conv_method` should allow `fftconvolve` for `long double`input.
