### PR TITLE
MAINT: make bdt{r,rc,ri}() functions accept double n,k args + tests

### DIFF
--- a/scipy/special/_cephes.pxd
+++ b/scipy/special/_cephes.pxd
@@ -1,8 +1,8 @@
 cdef extern from "cephes.h" nogil:
     int airy(double x, double *ai, double *aip, double *bi, double *bip)
-    double bdtrc(int k, int n, double p)
-    double bdtr(int k, int n, double p)
-    double bdtri(int k, int n, double y)
+    double bdtrc(double k, int n, double p)
+    double bdtr(double k, int n, double p)
+    double bdtri(double k, int n, double y)
     double beta(double a, double b)
     double lbeta(double a, double b)
     double btdtr(double a, double b, double x)

--- a/scipy/special/_legacy.pxd
+++ b/scipy/special/_legacy.pxd
@@ -16,6 +16,7 @@ from .sph_harm cimport sph_harmonic
 cdef extern from "numpy/npy_math.h" nogil:
     double npy_isnan(double)
     double nan "NPY_NAN"
+    double npy_isinf(double)
 
 from ._cephes cimport (bdtrc, bdtr, bdtri, expn, nbdtrc,
                        nbdtr, nbdtri, pdtri, kn, yn,
@@ -35,6 +36,12 @@ cdef inline void _legacy_cast_check(char *func_name, double x, double y) nogil:
                                "floating point number truncated to an integer",
                                1)
 
+cdef inline void _legacy_deprecation(char *func_name, double x, double y) nogil:
+        with gil:
+            PyErr_WarnEx_noerr(DeprecationWarning,
+                               "non-integer arg n is deprecated, removed in SciPy 1.7.x",
+                               1)
+
 cdef inline double complex sph_harmonic_unsafe(double m, double n,
                                                double theta, double phi) nogil:
     if npy_isnan(m) or npy_isnan(n):
@@ -50,23 +57,26 @@ cdef inline double ellip_harmonic_unsafe(double h2, double k2, double n,
     _legacy_cast_check("_ellip_harm", n, p)
     return ellip_harmonic(h2, k2, <int>n, <int>p, l, signm, signn)
 
-cdef inline double bdtrc_unsafe(double k, double n, double p) nogil:
-    if npy_isnan(k) or npy_isnan(n):
-        return nan
-    _legacy_cast_check("bdtrc", k, n)
-    return bdtrc(<int>k, <int>n, p)
-
 cdef inline double bdtr_unsafe(double k, double n, double p) nogil:
-    if npy_isnan(k) or npy_isnan(n):
+    _legacy_deprecation("bdtr", k, n)
+    if npy_isnan(n) or npy_isinf(n):
         return nan
-    _legacy_cast_check("bdtr", k, n)
-    return bdtr(<int>k, <int>n, p)
+    else:
+        return bdtr(k, <int>n, p)
 
-cdef inline double bdtri_unsafe(double k, double n, double y) nogil:
-    if npy_isnan(k) or npy_isnan(n):
+cdef inline double bdtrc_unsafe(double k, double n, double p) nogil:
+    _legacy_deprecation("bdtrc", k, n)
+    if npy_isnan(n) or npy_isinf(n):
         return nan
-    _legacy_cast_check("bdtri", k, n)
-    return bdtri(<int>k, <int>n, y)
+    else:
+        return bdtrc(k, <int>n, p)
+
+cdef inline double bdtri_unsafe(double k, double n, double p) nogil:
+    _legacy_deprecation("bdtri", k, n)
+    if npy_isnan(n) or npy_isinf(n):
+        return nan
+    else:
+        return bdtri(k, <int>n, p)
 
 cdef inline double expn_unsafe(double n, double x) nogil:
     if npy_isnan(n):

--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -374,15 +374,15 @@ add_newdoc("bdtr",
 
     Binomial distribution cumulative distribution function.
 
-    Sum of the terms 0 through `k` of the Binomial probability density.
+    Sum of the terms 0 through `floor(k)` of the Binomial probability density.
 
     .. math::
-        \mathrm{bdtr}(k, n, p) = \sum_{j=0}^k {{n}\choose{j}} p^j (1-p)^{n-j}
+        \mathrm{bdtr}(k, n, p) = \sum_{j=0}^\lfloor k \rfloor {{n}\choose{j}} p^j (1-p)^{n-j}
 
     Parameters
     ----------
     k : array_like
-        Number of successes (int).
+        Number of successes (double), rounded down to the nearest integer.
     n : array_like
         Number of events (int).
     p : array_like
@@ -391,7 +391,7 @@ add_newdoc("bdtr",
     Returns
     -------
     y : ndarray
-        Probability of `k` or fewer successes in `n` independent events with
+        Probability of `floor(k)` or fewer successes in `n` independent events with
         success probabilities of `p`.
 
     Notes
@@ -400,7 +400,7 @@ add_newdoc("bdtr",
     function is employed, according to the formula,
 
     .. math::
-        \mathrm{bdtr}(k, n, p) = I_{1 - p}(n - k, k + 1).
+        \mathrm{bdtr}(k, n, p) = I_{1 - p}(n - \lfloor k \rfloor, \lfloor k \rfloor + 1).
 
     Wrapper for the Cephes [1]_ routine `bdtr`.
 
@@ -417,7 +417,8 @@ add_newdoc("bdtrc",
 
     Binomial distribution survival function.
 
-    Sum of the terms `k + 1` through `n` of the binomial probability density,
+    Sum of the terms `floor(k) + 1` through `n` of the binomial probability
+    density,
 
     .. math::
         \mathrm{bdtrc}(k, n, p) = \sum_{j=k+1}^n {{n}\choose{j}} p^j (1-p)^{n-j}
@@ -425,7 +426,7 @@ add_newdoc("bdtrc",
     Parameters
     ----------
     k : array_like
-        Number of successes (int).
+        Number of successes (double), rounded down to nearest integer.
     n : array_like
         Number of events (int)
     p : array_like
@@ -434,8 +435,8 @@ add_newdoc("bdtrc",
     Returns
     -------
     y : ndarray
-        Probability of `k + 1` or more successes in `n` independent events
-        with success probabilities of `p`.
+        Probability of `floor(k) + 1` or more successes in `n` independent
+        events with success probabilities of `p`.
 
     See also
     --------
@@ -448,7 +449,7 @@ add_newdoc("bdtrc",
     function is employed, according to the formula,
 
     .. math::
-        \mathrm{bdtrc}(k, n, p) = I_{p}(k + 1, n - k).
+        \mathrm{bdtrc}(k, n, p) = I_{p}(\lfloor k \rfloor + 1, n - \lfloor k \rfloor).
 
     Wrapper for the Cephes [1]_ routine `bdtrc`.
 
@@ -460,7 +461,7 @@ add_newdoc("bdtrc",
     """)
 
 add_newdoc("bdtri",
-    """
+    r"""
     bdtri(k, n, y)
 
     Inverse function to `bdtr` with respect to `p`.
@@ -472,7 +473,7 @@ add_newdoc("bdtri",
     Parameters
     ----------
     k : array_like
-        Number of successes (float).
+        Number of successes (float), rounded down to the nearest integer.
     n : array_like
         Number of events (float)
     y : array_like
@@ -482,7 +483,7 @@ add_newdoc("bdtri",
     Returns
     -------
     p : ndarray
-        The event probability such that `bdtr(k, n, p) = y`.
+        The event probability such that `bdtr(\lfloor k \rfloor, n, p) = y`.
 
     See also
     --------

--- a/scipy/special/cephes.h
+++ b/scipy/special/cephes.h
@@ -9,9 +9,9 @@ extern "C" {
 
 extern int airy(double x, double *ai, double *aip, double *bi, double *bip);
 
-extern double bdtrc(int k, int n, double p);
-extern double bdtr(int k, int n, double p);
-extern double bdtri(int k, int n, double y);
+extern double bdtrc(double k, int n, double p);
+extern double bdtr(double k, int n, double p);
+extern double bdtri(double k, int n, double y);
 
 extern double besselpoly(double a, double lambda, double nu);
 

--- a/scipy/special/cephes/bdtr.c
+++ b/scipy/special/cephes/bdtr.c
@@ -104,7 +104,7 @@
  * int k, n;
  * double p, y, bdtri();
  *
- * p = bdtr( k, n, y );
+ * p = bdtri( k, n, y );
  *
  * DESCRIPTION:
  *
@@ -147,32 +147,31 @@
  */
 
 #include "mconf.h"
+#include <numpy/npy_math.h>
 
-double bdtrc(k, n, p)
-int k, n;
-double p;
+double bdtrc(double k, int n, double p)
 {
     double dk, dn;
+    double fk = floor(k);
 
-    if (npy_isnan(p)) {
+    if (npy_isnan(p) || npy_isnan(k)) {
 	return NPY_NAN;
     }
-    if ((p < 0.0) || (p > 1.0)) {
-	goto domerr;
-    }
-    if (k < 0) {
-	return 1.0;
-    }
 
-    if (n < k) {
-      domerr:
+    if (p < 0.0 || p > 1.0 || n < fk) {
 	sf_error("bdtrc", SF_ERROR_DOMAIN, NULL);
 	return NPY_NAN;
     }
 
-    if (k == n)
-	return (0.0);
-    dn = n - k;
+    if (fk < 0) {
+	return 1.0;
+    }
+
+    if (fk == n) {
+        return 0.0;
+    }
+
+    dn = n - fk;
     if (k == 0) {
 	if (p < .01)
 	    dk = -expm1(dn * log1p(-p));
@@ -180,71 +179,77 @@ double p;
 	    dk = 1.0 - pow(1.0 - p, dn);
     }
     else {
-	dk = k + 1;
+	dk = fk + 1;
 	dk = incbet(dk, dn, p);
     }
-    return (dk);
+    return dk;
 }
 
 
 
-double bdtr(k, n, p)
-int k, n;
-double p;
+double bdtr(double k, int n, double p)
 {
     double dk, dn;
+    double fk = floor(k);
 
-    if ((p < 0.0) || (p > 1.0))
-	goto domerr;
-    if ((k < 0) || (n < k)) {
-      domerr:
-	sf_error("bdtr", SF_ERROR_DOMAIN, NULL);
-	return (NPY_NAN);
+    if (npy_isnan(p) || npy_isnan(k)) {
+	return NPY_NAN;
     }
 
-    if (k == n)
-	return (1.0);
+    if (p < 0.0 || p > 1.0 || fk < 0 || n < fk) {
+        sf_error("bdtr", SF_ERROR_DOMAIN, NULL);
+        return NPY_NAN;
+    }
 
-    dn = n - k;
-    if (k == 0) {
+    if (fk == n)
+	return 1.0;
+
+    dn = n - fk;
+    if (fk == 0) {
 	dk = pow(1.0 - p, dn);
     }
     else {
-	dk = k + 1;
+	dk = fk + 1.;
 	dk = incbet(dn, dk, 1.0 - p);
     }
-    return (dk);
+    return dk;
 }
 
 
-double bdtri(k, n, y)
-int k, n;
-double y;
+double bdtri(double k, int n, double y)
 {
-    double dk, dn, p;
+    double p, dn, dk;
+    double fk = floor(k);
 
-    if ((y < 0.0) || (y > 1.0))
-	goto domerr;
-    if ((k < 0) || (n <= k)) {
-      domerr:
-	sf_error("bdtri", SF_ERROR_DOMAIN, NULL);
-	return (NPY_NAN);
+    if (npy_isnan(k)) {
+	return NPY_NAN;
     }
 
-    dn = n - k;
-    if (k == 0) {
-	if (y > 0.8)
+    if (y < 0.0 || y > 1.0 || fk < 0.0 || n <= fk) {
+	sf_error("bdtri", SF_ERROR_DOMAIN, NULL);
+	return NPY_NAN;
+    }
+
+    dn = n - fk;
+
+    if (fk == n)
+	return 1.0;
+
+    if (fk == 0) {
+	if (y > 0.8) {
 	    p = -expm1(log1p(y - 1.0) / dn);
-	else
+	}
+	else {
 	    p = 1.0 - pow(y, 1.0 / dn);
+	}
     }
     else {
-	dk = k + 1;
+	dk = fk + 1;
 	p = incbet(dn, dk, 0.5);
 	if (p > 0.5)
 	    p = incbi(dk, dn, 1.0 - y);
 	else
 	    p = 1.0 - incbi(dn, dk, y);
     }
-    return (p);
+    return p;
 }

--- a/scipy/special/functions.json
+++ b/scipy/special/functions.json
@@ -144,7 +144,7 @@
             "bdtr_unsafe": "ddd->d"
         },
         "cephes.h": {
-            "bdtr": "iid->d"
+            "bdtr": "did->d"
         }
     },
     "bdtrc": {
@@ -152,7 +152,7 @@
             "bdtrc_unsafe": "ddd->d"
         },
         "cephes.h": {
-            "bdtrc": "iid->d"
+            "bdtrc": "did->d"
         }
     },
     "bdtri": {
@@ -160,7 +160,7 @@
             "bdtri_unsafe": "ddd->d"
         },
         "cephes.h": {
-            "bdtri": "iid->d"
+            "bdtri": "did->d"
         }
     },
     "bdtrik": {

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -3254,9 +3254,6 @@ def test_legacy():
     # Legacy behavior: truncating arguments to integers
     with suppress_warnings() as sup:
         sup.filter(RuntimeWarning, "floating point number truncated to an integer")
-        assert_equal(special.bdtrc(1, 2, 0.3), special.bdtrc(1.8, 2.8, 0.3))
-        assert_equal(special.bdtr(1, 2, 0.3), special.bdtr(1.8, 2.8, 0.3))
-        assert_equal(special.bdtri(1, 2, 0.3), special.bdtri(1.8, 2.8, 0.3))
         assert_equal(special.expn(1, 0.3), special.expn(1.8, 0.3))
         assert_equal(special.nbdtrc(1, 2, 0.3), special.nbdtrc(1.8, 2.8, 0.3))
         assert_equal(special.nbdtr(1, 2, 0.3), special.nbdtr(1.8, 2.8, 0.3))

--- a/scipy/special/tests/test_bdtr.py
+++ b/scipy/special/tests/test_bdtr.py
@@ -1,0 +1,113 @@
+import numpy as np
+import scipy.special as sc
+import pytest
+from scipy._lib._numpy_compat import suppress_warnings
+from numpy.testing import assert_allclose, assert_array_equal, assert_warns
+
+
+class TestBdtr(object):
+    def test(self):
+        val = sc.bdtr(0, 1, 0.5)
+        assert_allclose(val, 0.5)
+
+    def test_sum_is_one(self):
+        val = sc.bdtr([0, 1, 2], 2, 0.5)
+        assert_array_equal(val, [0.25, 0.75, 1.0])
+
+    def test_rounding(self):
+        double_val = sc.bdtr([0.1, 1.1, 2.1], 2, 0.5)
+        int_val = sc.bdtr([0, 1, 2], 2, 0.5)
+        assert_array_equal(double_val, int_val)
+
+    @pytest.mark.parametrize('k, n, p', [
+        (np.inf, 2, 0.5),
+        (1.0, np.inf, 0.5),
+        (1.0, 2, np.inf)
+    ])
+    def test_inf(self, k, n, p):
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning)
+            val = sc.bdtr(k, n, p)
+        assert np.isnan(val)
+
+    def test_domain(self):
+        val = sc.bdtr(-1.1, 1, 0.5)
+        assert np.isnan(val)
+
+
+class TestBdtrc(object):
+    def test_value(self):
+        val = sc.bdtrc(0, 1, 0.5)
+        assert_allclose(val, 0.5)
+
+    def test_sum_is_one(self):
+        val = sc.bdtrc([0, 1, 2], 2, 0.5)
+        assert_array_equal(val, [0.75, 0.25, 0.0])
+
+    def test_rounding(self):
+        double_val = sc.bdtrc([0.1, 1.1, 2.1], 2, 0.5)
+        int_val = sc.bdtrc([0, 1, 2], 2, 0.5)
+        assert_array_equal(double_val, int_val)
+
+    @pytest.mark.parametrize('k, n, p', [
+        (np.inf, 2, 0.5),
+        (1.0, np.inf, 0.5),
+        (1.0, 2, np.inf)
+    ])
+    def test_inf(self, k, n, p):
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning)
+            val = sc.bdtrc(k, n, p)
+        assert np.isnan(val)
+
+    def test_domain(self):
+        val = sc.bdtrc(-1.1, 1, 0.5)
+        val2 = sc.bdtrc(2.1, 1, 0.5)
+        assert np.isnan(val2)
+        assert_allclose(val, 1.0)
+
+    def test_bdtr_bdtrc_sum_to_one(self):
+        bdtr_vals = sc.bdtr([0, 1, 2], 2, 0.5)
+        bdtrc_vals = sc.bdtrc([0, 1, 2], 2, 0.5)
+        vals = bdtr_vals + bdtrc_vals
+        assert_allclose(vals, [1.0, 1.0, 1.0])
+
+
+class TestBdtri(object):
+    def test_value(self):
+        val = sc.bdtri(0, 1, 0.5)
+        assert_allclose(val, 0.5)
+
+    def test_sum_is_one(self):
+        val = sc.bdtri([0, 1], 2, 0.5)
+        actual = np.asarray([1 - 1/np.sqrt(2), 1/np.sqrt(2)])
+        assert_allclose(val, actual)
+
+    def test_rounding(self):
+        double_val = sc.bdtri([0.1, 1.1], 2, 0.5)
+        int_val = sc.bdtri([0, 1], 2, 0.5)
+        assert_allclose(double_val, int_val)
+
+    @pytest.mark.parametrize('k, n, p', [
+        (np.inf, 2, 0.5),
+        (1.0, np.inf, 0.5),
+        (1.0, 2, np.inf)
+    ])
+    def test_inf(self, k, n, p):
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning)
+            val = sc.bdtri(k, n, p)
+        assert np.isnan(val)
+
+    @pytest.mark.parametrize('k, n, p', [
+        (-1.1, 1, 0.5),
+        (2.1, 1, 0.5)
+    ])
+    def test_domain(self, k, n, p):
+        val = sc.bdtri(k, n, p)
+        assert np.isnan(val)
+
+    def test_bdtr_bdtri_roundtrip(self):
+        bdtr_vals = sc.bdtr([0, 1, 2], 2, 0.5)
+        roundtrip_vals = sc.bdtri([0, 1, 2], 2, bdtr_vals)
+        assert_allclose(roundtrip_vals, [0.5, 0.5, np.nan])

--- a/scipy/special/tests/test_bdtr.py
+++ b/scipy/special/tests/test_bdtr.py
@@ -1,8 +1,7 @@
 import numpy as np
 import scipy.special as sc
 import pytest
-from scipy._lib._numpy_compat import suppress_warnings
-from numpy.testing import assert_allclose, assert_array_equal, assert_warns
+from numpy.testing import assert_allclose, assert_array_equal, assert_warns, suppress_warnings
 
 
 class TestBdtr(object):

--- a/scipy/special/tests/test_cython_special.py
+++ b/scipy/special/tests/test_cython_special.py
@@ -1,11 +1,7 @@
 from __future__ import division, print_function, absolute_import
-
-from itertools import product
-
-from numpy.testing import assert_allclose
-from scipy._lib._numpy_compat import suppress_warnings
 import pytest
-
+from itertools import product
+from numpy.testing import assert_allclose, suppress_warnings
 from scipy import special
 from scipy.special import cython_special
 

--- a/scipy/special/tests/test_cython_special.py
+++ b/scipy/special/tests/test_cython_special.py
@@ -3,6 +3,7 @@ from __future__ import division, print_function, absolute_import
 from itertools import product
 
 from numpy.testing import assert_allclose
+from scipy._lib._numpy_compat import suppress_warnings
 import pytest
 
 from scipy import special
@@ -42,9 +43,9 @@ PARAMS = [
     (special.agm, cython_special.agm, ('dd',), None),
     (special.airy, cython_special._airy_pywrap, ('d', 'D'), None),
     (special.airye, cython_special._airye_pywrap, ('d', 'D'), None),
-    (special.bdtr, cython_special.bdtr, ('lld', 'ddd'), None),
-    (special.bdtrc, cython_special.bdtrc, ('lld', 'ddd'), None),
-    (special.bdtri, cython_special.bdtri, ('lld', 'ddd'), None),
+    (special.bdtr, cython_special.bdtr, ('dld', 'ddd'), None),
+    (special.bdtrc, cython_special.bdtrc, ('dld', 'ddd'), None),
+    (special.bdtri, cython_special.bdtri, ('dld', 'ddd'), None),
     (special.bdtrik, cython_special.bdtrik, ('ddd',), None),
     (special.bdtrin, cython_special.bdtrin, ('ddd',), None),
     (special.bei, cython_special.bei, ('d',), None),
@@ -329,6 +330,8 @@ def test_cython_api(param):
         # Test it
         pts = _generate_test_points(typecodes)
         for pt in pts:
-            pyval = pyfunc(*pt)
-            cyval = cy_spec_func(*pt)
+            with suppress_warnings() as sup:
+                sup.filter(DeprecationWarning)
+                pyval = pyfunc(*pt)
+                cyval = cy_spec_func(*pt)
             assert_allclose(cyval, pyval, err_msg="{} {} {}".format(pt, typecodes, signature))

--- a/scipy/special/tests/test_nan_inputs.py
+++ b/scipy/special/tests/test_nan_inputs.py
@@ -6,7 +6,6 @@ from __future__ import division, print_function, absolute_import
 import numpy as np
 from numpy.testing import assert_array_equal, assert_, suppress_warnings
 import pytest
-
 import scipy.special as sc
 
 
@@ -44,7 +43,9 @@ def test_nan_inputs(func):
         sup.filter(RuntimeWarning,
                    "floating point number truncated to an integer")
         try:
-            res = func(*args)
+            with suppress_warnings() as sup:
+                sup.filter(DeprecationWarning)
+                res = func(*args)
         except TypeError:
             # One of the arguments doesn't take real inputs
             return


### PR DESCRIPTION
#### Reference issue
Closes gh-7058

#### What does this implement/fix?
This PR changes the signature for the `bdtr()`, `bdtrc()`, and `bdtri()` functions to accept all arguments as doubles (with appropriate floor/rounding). 

#### Additional information
I'm not clear about the `bdtri()` function. In 1 or 2 cases the unit tests I've written return `np.nan` and I'm unsure if that this the desired behavior for the `bdtri()` function. Would specifically like feedback on that function. Of course feedback on the other 2 functions is also welcome. 