### PR TITLE
DOC: special: add reference for orthogonal polynomial functions

### DIFF
--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -1938,7 +1938,7 @@ add_newdoc("eval_jacobi",
 
     where :math:`(\cdot)_n` is the Pochhammer symbol; see `poch`. When
     :math:`n` is an integer the result is a polynomial of degree
-    :math:`n`.
+    :math:`n`. See 22.5.42 in [AS]_ for details.
 
     Parameters
     ----------
@@ -1963,6 +1963,13 @@ add_newdoc("eval_jacobi",
     roots_jacobi : roots and quadrature weights of Jacobi polynomials
     jacobi : Jacobi polynomial object
     hyp2f1 : Gauss hypergeometric function
+
+    References
+    ----------
+    .. [AS] Milton Abramowitz and Irene A. Stegun, eds.
+        Handbook of Mathematical Functions with Formulas,
+        Graphs, and Mathematical Tables. New York: Dover, 1972.
+
     """)
 
 add_newdoc("eval_sh_jacobi",
@@ -1978,7 +1985,8 @@ add_newdoc("eval_sh_jacobi",
         G_n^{(p, q)}(x)
           = \binom{2n + p - 1}{n}^{-1} P_n^{(p - q, q - 1)}(2x - 1),
 
-    where :math:`P_n^{(\cdot, \cdot)}` is the n-th Jacobi polynomial.
+    where :math:`P_n^{(\cdot, \cdot)}` is the n-th Jacobi
+    polynomial. See 22.5.2 in [AS]_ for details.
 
     Parameters
     ----------
@@ -2001,6 +2009,13 @@ add_newdoc("eval_sh_jacobi",
                       polynomials
     sh_jacobi : shifted Jacobi polynomial object
     eval_jacobi : evaluate Jacobi polynomials
+
+    References
+    ----------
+    .. [AS] Milton Abramowitz and Irene A. Stegun, eds.
+        Handbook of Mathematical Functions with Formulas,
+        Graphs, and Mathematical Tables. New York: Dover, 1972.
+
     """)
 
 add_newdoc("eval_gegenbauer",
@@ -2018,7 +2033,7 @@ add_newdoc("eval_gegenbauer",
           {}_2F_1(-n, 2\alpha + n; \alpha + 1/2; (1 - z)/2).
 
     When :math:`n` is an integer the result is a polynomial of degree
-    :math:`n`.
+    :math:`n`. See 22.5.46 in [AS]_ for details.
 
     Parameters
     ----------
@@ -2042,6 +2057,13 @@ add_newdoc("eval_gegenbauer",
                        polynomials
     gegenbauer : Gegenbauer polynomial object
     hyp2f1 : Gauss hypergeometric function
+
+    References
+    ----------
+    .. [AS] Milton Abramowitz and Irene A. Stegun, eds.
+        Handbook of Mathematical Functions with Formulas,
+        Graphs, and Mathematical Tables. New York: Dover, 1972.
+
     """)
 
 add_newdoc("eval_chebyt",
@@ -2058,7 +2080,7 @@ add_newdoc("eval_chebyt",
         T_n(x) = {}_2F_1(n, -n; 1/2; (1 - x)/2).
 
     When :math:`n` is an integer the result is a polynomial of degree
-    :math:`n`.
+    :math:`n`. See 22.5.47 in [AS]_ for details.
 
     Parameters
     ----------
@@ -2087,6 +2109,13 @@ add_newdoc("eval_chebyt",
     -----
     This routine is numerically stable for `x` in ``[-1, 1]`` at least
     up to order ``10000``.
+
+    References
+    ----------
+    .. [AS] Milton Abramowitz and Irene A. Stegun, eds.
+        Handbook of Mathematical Functions with Formulas,
+        Graphs, and Mathematical Tables. New York: Dover, 1972.
+
     """)
 
 add_newdoc("eval_chebyu",
@@ -2103,7 +2132,7 @@ add_newdoc("eval_chebyu",
         U_n(x) = (n + 1) {}_2F_1(-n, n + 2; 3/2; (1 - x)/2).
 
     When :math:`n` is an integer the result is a polynomial of degree
-    :math:`n`.
+    :math:`n`. See 22.5.48 in [AS]_ for details.
 
     Parameters
     ----------
@@ -2126,6 +2155,13 @@ add_newdoc("eval_chebyu",
     chebyu : Chebyshev polynomial object
     eval_chebyt : evaluate Chebyshev polynomials of the first kind
     hyp2f1 : Gauss hypergeometric function
+
+    References
+    ----------
+    .. [AS] Milton Abramowitz and Irene A. Stegun, eds.
+        Handbook of Mathematical Functions with Formulas,
+        Graphs, and Mathematical Tables. New York: Dover, 1972.
+
     """)
 
 add_newdoc("eval_chebys",
@@ -2141,7 +2177,8 @@ add_newdoc("eval_chebys",
 
         S_n(x) = U_n(x/2)
 
-    where :math:`U_n` is a Chebyshev polynomial of the second kind.
+    where :math:`U_n` is a Chebyshev polynomial of the second
+    kind. See 22.5.13 in [AS]_ for details.
 
     Parameters
     ----------
@@ -2162,6 +2199,26 @@ add_newdoc("eval_chebys",
                    polynomials of the second kind on [-2, 2]
     chebys : Chebyshev polynomial object
     eval_chebyu : evaluate Chebyshev polynomials of the second kind
+
+    References
+    ----------
+    .. [AS] Milton Abramowitz and Irene A. Stegun, eds.
+        Handbook of Mathematical Functions with Formulas,
+        Graphs, and Mathematical Tables. New York: Dover, 1972.
+
+    Examples
+    --------
+    >>> import scipy.special as sc
+
+    They are a scaled version of the Chebyshev polynomials of the
+    second kind.
+
+    >>> x = np.linspace(-2, 2, 6)
+    >>> sc.eval_chebys(3, x)
+    array([-4.   ,  0.672,  0.736, -0.736, -0.672,  4.   ])
+    >>> sc.eval_chebyu(3, x / 2)
+    array([-4.   ,  0.672,  0.736, -0.736, -0.672,  4.   ])
+
     """)
 
 add_newdoc("eval_chebyc",
@@ -2175,9 +2232,10 @@ add_newdoc("eval_chebyc",
 
     .. math::
 
-        S_n(x) = T_n(x/2)
+        C_n(x) = 2 T_n(x/2)
 
-    where :math:`T_n` is a Chebyshev polynomial of the first kind.
+    where :math:`T_n` is a Chebyshev polynomial of the first kind. See
+    22.5.11 in [AS]_ for details.
 
     Parameters
     ----------
@@ -2199,6 +2257,26 @@ add_newdoc("eval_chebyc",
     chebyc : Chebyshev polynomial object
     numpy.polynomial.chebyshev.Chebyshev : Chebyshev series
     eval_chebyt : evaluate Chebycshev polynomials of the first kind
+
+    References
+    ----------
+    .. [AS] Milton Abramowitz and Irene A. Stegun, eds.
+        Handbook of Mathematical Functions with Formulas,
+        Graphs, and Mathematical Tables. New York: Dover, 1972.
+
+    Examples
+    --------
+    >>> import scipy.special as sc
+
+    They are a scaled version of the Chebyshev polynomials of the
+    first kind.
+
+    >>> x = np.linspace(-2, 2, 6)
+    >>> sc.eval_chebyc(3, x)
+    array([-2.   ,  1.872,  1.136, -1.136, -1.872,  2.   ])
+    >>> 2 * sc.eval_chebyt(3, x / 2)
+    array([-2.   ,  1.872,  1.136, -1.136, -1.872,  2.   ])
+
     """)
 
 add_newdoc("eval_sh_chebyt",
@@ -2214,7 +2292,8 @@ add_newdoc("eval_sh_chebyt",
 
         T_n^*(x) = T_n(2x - 1)
 
-    where :math:`T_n` is a Chebyshev polynomial of the first kind.
+    where :math:`T_n` is a Chebyshev polynomial of the first kind. See
+    22.5.14 in [AS]_ for details.
 
     Parameters
     ----------
@@ -2236,6 +2315,13 @@ add_newdoc("eval_sh_chebyt",
     sh_chebyt : shifted Chebyshev polynomial object
     eval_chebyt : evaluate Chebyshev polynomials of the first kind
     numpy.polynomial.chebyshev.Chebyshev : Chebyshev series
+
+    References
+    ----------
+    .. [AS] Milton Abramowitz and Irene A. Stegun, eds.
+        Handbook of Mathematical Functions with Formulas,
+        Graphs, and Mathematical Tables. New York: Dover, 1972.
+
     """)
 
 add_newdoc("eval_sh_chebyu",
@@ -2251,7 +2337,8 @@ add_newdoc("eval_sh_chebyu",
 
         U_n^*(x) = U_n(2x - 1)
 
-    where :math:`U_n` is a Chebyshev polynomial of the first kind.
+    where :math:`U_n` is a Chebyshev polynomial of the first kind. See
+    22.5.15 in [AS]_ for details.
 
     Parameters
     ----------
@@ -2272,6 +2359,13 @@ add_newdoc("eval_sh_chebyu",
                       Chebychev polynomials of the second kind
     sh_chebyu : shifted Chebyshev polynomial object
     eval_chebyu : evaluate Chebyshev polynomials of the second kind
+
+    References
+    ----------
+    .. [AS] Milton Abramowitz and Irene A. Stegun, eds.
+        Handbook of Mathematical Functions with Formulas,
+        Graphs, and Mathematical Tables. New York: Dover, 1972.
+
     """)
 
 add_newdoc("eval_legendre",
@@ -2288,7 +2382,7 @@ add_newdoc("eval_legendre",
         P_n(x) = {}_2F_1(-n, n + 1; 1; (1 - x)/2).
 
     When :math:`n` is an integer the result is a polynomial of degree
-    :math:`n`.
+    :math:`n`. See 22.5.49 in [AS]_ for details.
 
     Parameters
     ----------
@@ -2311,6 +2405,13 @@ add_newdoc("eval_legendre",
     legendre : Legendre polynomial object
     hyp2f1 : Gauss hypergeometric function
     numpy.polynomial.legendre.Legendre : Legendre series
+
+    References
+    ----------
+    .. [AS] Milton Abramowitz and Irene A. Stegun, eds.
+        Handbook of Mathematical Functions with Formulas,
+        Graphs, and Mathematical Tables. New York: Dover, 1972.
+
     """)
 
 add_newdoc("eval_sh_legendre",
@@ -2325,7 +2426,8 @@ add_newdoc("eval_sh_legendre",
 
         P_n^*(x) = P_n(2x - 1)
 
-    where :math:`P_n` is a Legendre polynomial.
+    where :math:`P_n` is a Legendre polynomial. See 2.2.11 in [AS]_
+    for details.
 
     Parameters
     ----------
@@ -2347,6 +2449,13 @@ add_newdoc("eval_sh_legendre",
     sh_legendre : shifted Legendre polynomial object
     eval_legendre : evaluate Legendre polynomials
     numpy.polynomial.legendre.Legendre : Legendre series
+
+    References
+    ----------
+    .. [AS] Milton Abramowitz and Irene A. Stegun, eds.
+        Handbook of Mathematical Functions with Formulas,
+        Graphs, and Mathematical Tables. New York: Dover, 1972.
+
     """)
 
 add_newdoc("eval_genlaguerre",
@@ -2364,8 +2473,8 @@ add_newdoc("eval_genlaguerre",
           {}_1F_1(-n, \alpha + 1, x).
 
     When :math:`n` is an integer the result is a polynomial of degree
-    :math:`n`. The Laguerre polynomials are the special case where
-    :math:`\alpha = 0`.
+    :math:`n`. See 22.5.54 in [AS]_ for details. The Laguerre
+    polynomials are the special case where :math:`\alpha = 0`.
 
     Parameters
     ----------
@@ -2391,45 +2500,59 @@ add_newdoc("eval_genlaguerre",
     genlaguerre : generalized Laguerre polynomial object
     hyp1f1 : confluent hypergeometric function
     eval_laguerre : evaluate Laguerre polynomials
+
+    References
+    ----------
+    .. [AS] Milton Abramowitz and Irene A. Stegun, eds.
+        Handbook of Mathematical Functions with Formulas,
+        Graphs, and Mathematical Tables. New York: Dover, 1972.
+
     """)
 
 add_newdoc("eval_laguerre",
-     r"""
-     eval_laguerre(n, x, out=None)
+    r"""
+    eval_laguerre(n, x, out=None)
 
-     Evaluate Laguerre polynomial at a point.
+    Evaluate Laguerre polynomial at a point.
 
-     The Laguerre polynomials can be defined via the confluent
-     hypergeometric function :math:`{}_1F_1` as
+    The Laguerre polynomials can be defined via the confluent
+    hypergeometric function :math:`{}_1F_1` as
 
-     .. math::
+    .. math::
 
-         L_n(x) = {}_1F_1(-n, 1, x).
+        L_n(x) = {}_1F_1(-n, 1, x).
 
-     When :math:`n` is an integer the result is a polynomial of degree
-     :math:`n`.
+    See 22.5.16 and 22.5.54 in [AS]_ for details. When :math:`n` is an
+    integer the result is a polynomial of degree :math:`n`.
 
-     Parameters
-     ----------
-     n : array_like
-         Degree of the polynomial. If not an integer the result is
-         determined via the relation to the confluent hypergeometric
-         function.
-     x : array_like
-         Points at which to evaluate the Laguerre polynomial
+    Parameters
+    ----------
+    n : array_like
+        Degree of the polynomial. If not an integer the result is
+        determined via the relation to the confluent hypergeometric
+        function.
+    x : array_like
+        Points at which to evaluate the Laguerre polynomial
 
-     Returns
-     -------
-     L : ndarray
-         Values of the Laguerre polynomial
+    Returns
+    -------
+    L : ndarray
+        Values of the Laguerre polynomial
 
-     See Also
-     --------
-     roots_laguerre : roots and quadrature weights of Laguerre
-                      polynomials
-     laguerre : Laguerre polynomial object
-     numpy.polynomial.laguerre.Laguerre : Laguerre series
-     eval_genlaguerre : evaluate generalized Laguerre polynomials
+    See Also
+    --------
+    roots_laguerre : roots and quadrature weights of Laguerre
+                     polynomials
+    laguerre : Laguerre polynomial object
+    numpy.polynomial.laguerre.Laguerre : Laguerre series
+    eval_genlaguerre : evaluate generalized Laguerre polynomials
+
+    References
+    ----------
+    .. [AS] Milton Abramowitz and Irene A. Stegun, eds.
+        Handbook of Mathematical Functions with Formulas,
+        Graphs, and Mathematical Tables. New York: Dover, 1972.
+
      """)
 
 add_newdoc("eval_hermite",
@@ -2444,7 +2567,8 @@ add_newdoc("eval_hermite",
 
         H_n(x) = (-1)^n e^{x^2} \frac{d^n}{dx^n} e^{-x^2};
 
-    :math:`H_n` is a polynomial of degree :math:`n`.
+    :math:`H_n` is a polynomial of degree :math:`n`. See 22.11.7 in
+    [AS]_ for details.
 
     Parameters
     ----------
@@ -2465,6 +2589,13 @@ add_newdoc("eval_hermite",
     hermite : physicist's Hermite polynomial object
     numpy.polynomial.hermite.Hermite : Physicist's Hermite series
     eval_hermitenorm : evaluate Probabilist's Hermite polynomials
+
+    References
+    ----------
+    .. [AS] Milton Abramowitz and Irene A. Stegun, eds.
+        Handbook of Mathematical Functions with Formulas,
+        Graphs, and Mathematical Tables. New York: Dover, 1972.
+
     """)
 
 add_newdoc("eval_hermitenorm",
@@ -2480,7 +2611,8 @@ add_newdoc("eval_hermitenorm",
 
         He_n(x) = (-1)^n e^{x^2/2} \frac{d^n}{dx^n} e^{-x^2/2};
 
-    :math:`He_n` is a polynomial of degree :math:`n`.
+    :math:`He_n` is a polynomial of degree :math:`n`. See 22.11.8 in
+    [AS]_ for details.
 
     Parameters
     ----------
@@ -2501,6 +2633,13 @@ add_newdoc("eval_hermitenorm",
     hermitenorm : probabilist's Hermite polynomial object
     numpy.polynomial.hermite_e.HermiteE : Probabilist's Hermite series
     eval_hermite : evaluate physicist's Hermite polynomials
+
+    References
+    ----------
+    .. [AS] Milton Abramowitz and Irene A. Stegun, eds.
+        Handbook of Mathematical Functions with Formulas,
+        Graphs, and Mathematical Tables. New York: Dover, 1972.
+
     """)
 
 add_newdoc("exp1",

--- a/scipy/special/orthogonal.py
+++ b/scipy/special/orthogonal.py
@@ -221,12 +221,13 @@ def _gen_roots_and_weights(n, mu0, an_func, bn_func, f, df, symmetrize, mu):
 def roots_jacobi(n, alpha, beta, mu=False):
     r"""Gauss-Jacobi quadrature.
 
-    Computes the sample points and weights for Gauss-Jacobi quadrature. The
-    sample points are the roots of the n-th degree Jacobi polynomial,
-    :math:`P^{\alpha, \beta}_n(x)`.  These sample points and weights
-    correctly integrate polynomials of degree :math:`2n - 1` or less over the
-    interval :math:`[-1, 1]` with weight function
-    :math:`f(x) = (1 - x)^{\alpha} (1 + x)^{\beta}`.
+    Compute the sample points and weights for Gauss-Jacobi
+    quadrature. The sample points are the roots of the n-th degree
+    Jacobi polynomial, :math:`P^{\alpha, \beta}_n(x)`. These sample
+    points and weights correctly integrate polynomials of degree
+    :math:`2n - 1` or less over the interval :math:`[-1, 1]` with
+    weight function :math:`w(x) = (1 - x)^{\alpha} (1 +
+    x)^{\beta}`. See 22.2.1 in [AS]_ for details.
 
     Parameters
     ----------
@@ -252,6 +253,13 @@ def roots_jacobi(n, alpha, beta, mu=False):
     --------
     scipy.integrate.quadrature
     scipy.integrate.fixed_quad
+
+    References
+    ----------
+    .. [AS] Milton Abramowitz and Irene A. Stegun, eds.
+        Handbook of Mathematical Functions with Formulas,
+        Graphs, and Mathematical Tables. New York: Dover, 1972.
+
     """
     m = int(n)
     if n < 1 or n != m:
@@ -343,12 +351,13 @@ def jacobi(n, alpha, beta, monic=False):
 def roots_sh_jacobi(n, p1, q1, mu=False):
     """Gauss-Jacobi (shifted) quadrature.
 
-    Computes the sample points and weights for Gauss-Jacobi (shifted)
-    quadrature. The sample points are the roots of the n-th degree shifted
-    Jacobi polynomial, :math:`G^{p,q}_n(x)`.  These sample points and weights
-    correctly integrate polynomials of degree :math:`2n - 1` or less over the
-    interval :math:`[0, 1]` with weight function
-    :math:`f(x) = (1 - x)^{p-q} x^{q-1}`
+    Compute the sample points and weights for Gauss-Jacobi (shifted)
+    quadrature. The sample points are the roots of the n-th degree
+    shifted Jacobi polynomial, :math:`G^{p,q}_n(x)`. These sample
+    points and weights correctly integrate polynomials of degree
+    :math:`2n - 1` or less over the interval :math:`[0, 1]` with
+    weight function :math:`w(x) = (1 - x)^{p-q} x^{q-1}`. See 22.2.2
+    in [AS]_ for details.
 
     Parameters
     ----------
@@ -374,6 +383,13 @@ def roots_sh_jacobi(n, p1, q1, mu=False):
     --------
     scipy.integrate.quadrature
     scipy.integrate.fixed_quad
+
+    References
+    ----------
+    .. [AS] Milton Abramowitz and Irene A. Stegun, eds.
+        Handbook of Mathematical Functions with Formulas,
+        Graphs, and Mathematical Tables. New York: Dover, 1972.
+
     """
     if (p1-q1) <= -1 or q1 <= 0:
         raise ValueError("(p - q) must be greater than -1, and q must be greater than 0.")
@@ -446,12 +462,13 @@ def sh_jacobi(n, p, q, monic=False):
 def roots_genlaguerre(n, alpha, mu=False):
     r"""Gauss-generalized Laguerre quadrature.
 
-    Computes the sample points and weights for Gauss-generalized Laguerre
-    quadrature. The sample points are the roots of the n-th degree generalized
-    Laguerre polynomial, :math:`L^{\alpha}_n(x)`.  These sample points and
-    weights correctly integrate polynomials of degree :math:`2n - 1` or less
-    over the interval :math:`[0, \infty]` with weight function
-    :math:`f(x) = x^{\alpha} e^{-x}`.
+    Compute the sample points and weights for Gauss-generalized
+    Laguerre quadrature. The sample points are the roots of the n-th
+    degree generalized Laguerre polynomial, :math:`L^{\alpha}_n(x)`.
+    These sample points and weights correctly integrate polynomials of
+    degree :math:`2n - 1` or less over the interval :math:`[0,
+    \infty]` with weight function :math:`w(x) = x^{\alpha}
+    e^{-x}`. See 22.3.9 in [AS]_ for details.
 
     Parameters
     ----------
@@ -475,6 +492,13 @@ def roots_genlaguerre(n, alpha, mu=False):
     --------
     scipy.integrate.quadrature
     scipy.integrate.fixed_quad
+
+    References
+    ----------
+    .. [AS] Milton Abramowitz and Irene A. Stegun, eds.
+        Handbook of Mathematical Functions with Formulas,
+        Graphs, and Mathematical Tables. New York: Dover, 1972.
+
     """
     m = int(n)
     if n < 1 or n != m:
@@ -567,11 +591,12 @@ def genlaguerre(n, alpha, monic=False):
 def roots_laguerre(n, mu=False):
     r"""Gauss-Laguerre quadrature.
 
-    Computes the sample points and weights for Gauss-Laguerre quadrature.
-    The sample points are the roots of the n-th degree Laguerre polynomial,
-    :math:`L_n(x)`.  These sample points and weights correctly integrate
-    polynomials of degree :math:`2n - 1` or less over the interval
-    :math:`[0, \infty]` with weight function :math:`f(x) = e^{-x}`.
+    Compute the sample points and weights for Gauss-Laguerre
+    quadrature. The sample points are the roots of the n-th degree
+    Laguerre polynomial, :math:`L_n(x)`. These sample points and
+    weights correctly integrate polynomials of degree :math:`2n - 1`
+    or less over the interval :math:`[0, \infty]` with weight function
+    :math:`w(x) = e^{-x}`. See 22.2.13 in [AS]_ for details.
 
     Parameters
     ----------
@@ -594,6 +619,13 @@ def roots_laguerre(n, mu=False):
     scipy.integrate.quadrature
     scipy.integrate.fixed_quad
     numpy.polynomial.laguerre.laggauss
+
+    References
+    ----------
+    .. [AS] Milton Abramowitz and Irene A. Stegun, eds.
+        Handbook of Mathematical Functions with Formulas,
+        Graphs, and Mathematical Tables. New York: Dover, 1972.
+
     """
     return roots_genlaguerre(n, 0.0, mu=mu)
 
@@ -649,11 +681,13 @@ def laguerre(n, monic=False):
 def roots_hermite(n, mu=False):
     r"""Gauss-Hermite (physicst's) quadrature.
 
-    Computes the sample points and weights for Gauss-Hermite quadrature.
-    The sample points are the roots of the n-th degree Hermite polynomial,
-    :math:`H_n(x)`.  These sample points and weights correctly integrate
-    polynomials of degree :math:`2n - 1` or less over the interval
-    :math:`[-\infty, \infty]` with weight function :math:`f(x) = e^{-x^2}`.
+    Compute the sample points and weights for Gauss-Hermite
+    quadrature. The sample points are the roots of the n-th degree
+    Hermite polynomial, :math:`H_n(x)`. These sample points and
+    weights correctly integrate polynomials of degree :math:`2n - 1`
+    or less over the interval :math:`[-\infty, \infty]` with weight
+    function :math:`w(x) = e^{-x^2}`. See 22.2.14 in [AS]_ for
+    details.
 
     Parameters
     ----------
@@ -693,16 +727,19 @@ def roots_hermite(n, mu=False):
     References
     ----------
     .. [townsend.trogdon.olver-2014]
-       Townsend, A. and Trogdon, T. and Olver, S. (2014)
-       *Fast computation of Gauss quadrature nodes and
-       weights on the whole real line*. :arXiv:`1410.5286`.
-
+        Townsend, A. and Trogdon, T. and Olver, S. (2014)
+        *Fast computation of Gauss quadrature nodes and
+        weights on the whole real line*. :arXiv:`1410.5286`.
     .. [townsend.trogdon.olver-2015]
-       Townsend, A. and Trogdon, T. and Olver, S. (2015)
-       *Fast computation of Gauss quadrature nodes and
-       weights on the whole real line*.
-       IMA Journal of Numerical Analysis
-       :doi:`10.1093/imanum/drv002`.
+        Townsend, A. and Trogdon, T. and Olver, S. (2015)
+        *Fast computation of Gauss quadrature nodes and
+        weights on the whole real line*.
+        IMA Journal of Numerical Analysis
+        :doi:`10.1093/imanum/drv002`.
+    .. [AS] Milton Abramowitz and Irene A. Stegun, eds.
+        Handbook of Mathematical Functions with Formulas,
+        Graphs, and Mathematical Tables. New York: Dover, 1972.
+
     """
     m = int(n)
     if n < 1 or n != m:
@@ -1140,11 +1177,13 @@ def hermite(n, monic=False):
 def roots_hermitenorm(n, mu=False):
     r"""Gauss-Hermite (statistician's) quadrature.
 
-    Computes the sample points and weights for Gauss-Hermite quadrature.
-    The sample points are the roots of the n-th degree Hermite polynomial,
-    :math:`He_n(x)`.  These sample points and weights correctly integrate
-    polynomials of degree :math:`2n - 1` or less over the interval
-    :math:`[-\infty, \infty]` with weight function :math:`f(x) = e^{-x^2/2}`.
+    Compute the sample points and weights for Gauss-Hermite
+    quadrature. The sample points are the roots of the n-th degree
+    Hermite polynomial, :math:`He_n(x)`. These sample points and
+    weights correctly integrate polynomials of degree :math:`2n - 1`
+    or less over the interval :math:`[-\infty, \infty]` with weight
+    function :math:`w(x) = e^{-x^2/2}`. See 22.2.15 in [AS]_ for more
+    details.
 
     Parameters
     ----------
@@ -1179,6 +1218,13 @@ def roots_hermitenorm(n, mu=False):
     scipy.integrate.quadrature
     scipy.integrate.fixed_quad
     numpy.polynomial.hermite_e.hermegauss
+
+    References
+    ----------
+    .. [AS] Milton Abramowitz and Irene A. Stegun, eds.
+        Handbook of Mathematical Functions with Formulas,
+        Graphs, and Mathematical Tables. New York: Dover, 1972.
+
     """
     m = int(n)
     if n < 1 or n != m:
@@ -1258,12 +1304,13 @@ def hermitenorm(n, monic=False):
 def roots_gegenbauer(n, alpha, mu=False):
     r"""Gauss-Gegenbauer quadrature.
 
-    Computes the sample points and weights for Gauss-Gegenbauer quadrature.
-    The sample points are the roots of the n-th degree Gegenbauer polynomial,
-    :math:`C^{\alpha}_n(x)`.  These sample points and weights correctly
-    integrate polynomials of degree :math:`2n - 1` or less over the interval
-    :math:`[-1, 1]` with weight function
-    :math:`f(x) = (1 - x^2)^{\alpha - 1/2}`.
+    Compute the sample points and weights for Gauss-Gegenbauer
+    quadrature. The sample points are the roots of the n-th degree
+    Gegenbauer polynomial, :math:`C^{\alpha}_n(x)`. These sample
+    points and weights correctly integrate polynomials of degree
+    :math:`2n - 1` or less over the interval :math:`[-1, 1]` with
+    weight function :math:`w(x) = (1 - x^2)^{\alpha - 1/2}`. See
+    22.2.3 in [AS]_ for more details.
 
     Parameters
     ----------
@@ -1287,6 +1334,13 @@ def roots_gegenbauer(n, alpha, mu=False):
     --------
     scipy.integrate.quadrature
     scipy.integrate.fixed_quad
+
+    References
+    ----------
+    .. [AS] Milton Abramowitz and Irene A. Stegun, eds.
+        Handbook of Mathematical Functions with Formulas,
+        Graphs, and Mathematical Tables. New York: Dover, 1972.
+
     """
     m = int(n)
     if n < 1 or n != m:
@@ -1361,11 +1415,13 @@ def gegenbauer(n, alpha, monic=False):
 def roots_chebyt(n, mu=False):
     r"""Gauss-Chebyshev (first kind) quadrature.
 
-    Computes the sample points and weights for Gauss-Chebyshev quadrature.
-    The sample points are the roots of the n-th degree Chebyshev polynomial of
-    the first kind, :math:`T_n(x)`.  These sample points and weights correctly
-    integrate polynomials of degree :math:`2n - 1` or less over the interval
-    :math:`[-1, 1]` with weight function :math:`f(x) = 1/\sqrt{1 - x^2}`.
+    Computes the sample points and weights for Gauss-Chebyshev
+    quadrature. The sample points are the roots of the n-th degree
+    Chebyshev polynomial of the first kind, :math:`T_n(x)`.  These
+    sample points and weights correctly integrate polynomials of
+    degree :math:`2n - 1` or less over the interval :math:`[-1, 1]`
+    with weight function :math:`w(x) = 1/\sqrt{1 - x^2}`. See 22.2.4
+    in [AS]_ for more details.
 
     Parameters
     ----------
@@ -1388,6 +1444,13 @@ def roots_chebyt(n, mu=False):
     scipy.integrate.quadrature
     scipy.integrate.fixed_quad
     numpy.polynomial.chebyshev.chebgauss
+
+    References
+    ----------
+    .. [AS] Milton Abramowitz and Irene A. Stegun, eds.
+        Handbook of Mathematical Functions with Formulas,
+        Graphs, and Mathematical Tables. New York: Dover, 1972.
+
     """
     m = int(n)
     if n < 1 or n != m:
@@ -1455,11 +1518,13 @@ def chebyt(n, monic=False):
 def roots_chebyu(n, mu=False):
     r"""Gauss-Chebyshev (second kind) quadrature.
 
-    Computes the sample points and weights for Gauss-Chebyshev quadrature.
-    The sample points are the roots of the n-th degree Chebyshev polynomial of
-    the second kind, :math:`U_n(x)`.  These sample points and weights correctly
-    integrate polynomials of degree :math:`2n - 1` or less over the interval
-    :math:`[-1, 1]` with weight function :math:`f(x) = \sqrt{1 - x^2}`.
+    Computes the sample points and weights for Gauss-Chebyshev
+    quadrature. The sample points are the roots of the n-th degree
+    Chebyshev polynomial of the second kind, :math:`U_n(x)`. These
+    sample points and weights correctly integrate polynomials of
+    degree :math:`2n - 1` or less over the interval :math:`[-1, 1]`
+    with weight function :math:`w(x) = \sqrt{1 - x^2}`. See 22.2.5 in
+    [AS]_ for details.
 
     Parameters
     ----------
@@ -1481,6 +1546,13 @@ def roots_chebyu(n, mu=False):
     --------
     scipy.integrate.quadrature
     scipy.integrate.fixed_quad
+
+    References
+    ----------
+    .. [AS] Milton Abramowitz and Irene A. Stegun, eds.
+        Handbook of Mathematical Functions with Formulas,
+        Graphs, and Mathematical Tables. New York: Dover, 1972.
+
     """
     m = int(n)
     if n < 1 or n != m:
@@ -1541,11 +1613,13 @@ def chebyu(n, monic=False):
 def roots_chebyc(n, mu=False):
     r"""Gauss-Chebyshev (first kind) quadrature.
 
-    Computes the sample points and weights for Gauss-Chebyshev quadrature.
-    The sample points are the roots of the n-th degree Chebyshev polynomial of
-    the first kind, :math:`C_n(x)`.  These sample points and weights correctly
-    integrate polynomials of degree :math:`2n - 1` or less over the interval
-    :math:`[-2, 2]` with weight function :math:`f(x) = 1/\sqrt{1 - (x/2)^2}`.
+    Compute the sample points and weights for Gauss-Chebyshev
+    quadrature. The sample points are the roots of the n-th degree
+    Chebyshev polynomial of the first kind, :math:`C_n(x)`. These
+    sample points and weights correctly integrate polynomials of
+    degree :math:`2n - 1` or less over the interval :math:`[-2, 2]`
+    with weight function :math:`w(x) = 1 / \sqrt{1 - (x/2)^2}`. See
+    22.2.6 in [AS]_ for more details.
 
     Parameters
     ----------
@@ -1567,6 +1641,13 @@ def roots_chebyc(n, mu=False):
     --------
     scipy.integrate.quadrature
     scipy.integrate.fixed_quad
+
+    References
+    ----------
+    .. [AS] Milton Abramowitz and Irene A. Stegun, eds.
+        Handbook of Mathematical Functions with Formulas,
+        Graphs, and Mathematical Tables. New York: Dover, 1972.
+
     """
     x, w, m = roots_chebyt(n, True)
     x *= 2
@@ -1638,11 +1719,13 @@ def chebyc(n, monic=False):
 def roots_chebys(n, mu=False):
     r"""Gauss-Chebyshev (second kind) quadrature.
 
-    Computes the sample points and weights for Gauss-Chebyshev quadrature.
-    The sample points are the roots of the n-th degree Chebyshev polynomial of
-    the second kind, :math:`S_n(x)`.  These sample points and weights correctly
-    integrate polynomials of degree :math:`2n - 1` or less over the interval
-    :math:`[-2, 2]` with weight function :math:`f(x) = \sqrt{1 - (x/2)^2}`.
+    Compute the sample points and weights for Gauss-Chebyshev
+    quadrature. The sample points are the roots of the n-th degree
+    Chebyshev polynomial of the second kind, :math:`S_n(x)`. These
+    sample points and weights correctly integrate polynomials of
+    degree :math:`2n - 1` or less over the interval :math:`[-2, 2]`
+    with weight function :math:`w(x) = \sqrt{1 - (x/2)^2}`. See 22.2.7
+    in [AS]_ for more details.
 
     Parameters
     ----------
@@ -1664,6 +1747,13 @@ def roots_chebys(n, mu=False):
     --------
     scipy.integrate.quadrature
     scipy.integrate.fixed_quad
+
+    References
+    ----------
+    .. [AS] Milton Abramowitz and Irene A. Stegun, eds.
+        Handbook of Mathematical Functions with Formulas,
+        Graphs, and Mathematical Tables. New York: Dover, 1972.
+
     """
     x, w, m = roots_chebyu(n, True)
     x *= 2
@@ -1736,12 +1826,13 @@ def chebys(n, monic=False):
 def roots_sh_chebyt(n, mu=False):
     r"""Gauss-Chebyshev (first kind, shifted) quadrature.
 
-    Computes the sample points and weights for Gauss-Chebyshev quadrature.
-    The sample points are the roots of the n-th degree shifted Chebyshev
-    polynomial of the first kind, :math:`T_n(x)`.  These sample points and
-    weights correctly integrate polynomials of degree :math:`2n - 1` or less
-    over the interval :math:`[0, 1]` with weight function
-    :math:`f(x) = 1/\sqrt{x - x^2}`.
+    Compute the sample points and weights for Gauss-Chebyshev
+    quadrature. The sample points are the roots of the n-th degree
+    shifted Chebyshev polynomial of the first kind, :math:`T_n(x)`.
+    These sample points and weights correctly integrate polynomials of
+    degree :math:`2n - 1` or less over the interval :math:`[0, 1]`
+    with weight function :math:`w(x) = 1/\sqrt{x - x^2}`. See 22.2.8
+    in [AS]_ for more details.
 
     Parameters
     ----------
@@ -1763,6 +1854,13 @@ def roots_sh_chebyt(n, mu=False):
     --------
     scipy.integrate.quadrature
     scipy.integrate.fixed_quad
+
+    References
+    ----------
+    .. [AS] Milton Abramowitz and Irene A. Stegun, eds.
+        Handbook of Mathematical Functions with Formulas,
+        Graphs, and Mathematical Tables. New York: Dover, 1972.
+
     """
     xw = roots_chebyt(n, mu)
     return ((xw[0] + 1) / 2,) + xw[1:]
@@ -1808,12 +1906,13 @@ def sh_chebyt(n, monic=False):
 def roots_sh_chebyu(n, mu=False):
     r"""Gauss-Chebyshev (second kind, shifted) quadrature.
 
-    Computes the sample points and weights for Gauss-Chebyshev quadrature.
-    The sample points are the roots of the n-th degree shifted Chebyshev
-    polynomial of the second kind, :math:`U_n(x)`.  These sample points and
-    weights correctly integrate polynomials of degree :math:`2n - 1` or less
-    over the interval :math:`[0, 1]` with weight function
-    :math:`f(x) = \sqrt{x - x^2}`.
+    Computes the sample points and weights for Gauss-Chebyshev
+    quadrature. The sample points are the roots of the n-th degree
+    shifted Chebyshev polynomial of the second kind, :math:`U_n(x)`.
+    These sample points and weights correctly integrate polynomials of
+    degree :math:`2n - 1` or less over the interval :math:`[0, 1]`
+    with weight function :math:`w(x) = \sqrt{x - x^2}`. See 22.2.9 in
+    [AS]_ for more details.
 
     Parameters
     ----------
@@ -1835,6 +1934,13 @@ def roots_sh_chebyu(n, mu=False):
     --------
     scipy.integrate.quadrature
     scipy.integrate.fixed_quad
+
+    References
+    ----------
+    .. [AS] Milton Abramowitz and Irene A. Stegun, eds.
+        Handbook of Mathematical Functions with Formulas,
+        Graphs, and Mathematical Tables. New York: Dover, 1972.
+
     """
     x, w, m = roots_chebyu(n, True)
     x = (x + 1) / 2
@@ -1884,11 +1990,12 @@ def sh_chebyu(n, monic=False):
 def roots_legendre(n, mu=False):
     r"""Gauss-Legendre quadrature.
 
-    Computes the sample points and weights for Gauss-Legendre quadrature.
-    The sample points are the roots of the n-th degree Legendre polynomial
-    :math:`P_n(x)`.  These sample points and weights correctly integrate
-    polynomials of degree :math:`2n - 1` or less over the interval
-    :math:`[-1, 1]` with weight function :math:`f(x) = 1.0`.
+    Compute the sample points and weights for Gauss-Legendre
+    quadrature. The sample points are the roots of the n-th degree
+    Legendre polynomial :math:`P_n(x)`. These sample points and
+    weights correctly integrate polynomials of degree :math:`2n - 1`
+    or less over the interval :math:`[-1, 1]` with weight function
+    :math:`w(x) = 1.0`. See 2.2.10 in [AS]_ for more details.
 
     Parameters
     ----------
@@ -1911,6 +2018,13 @@ def roots_legendre(n, mu=False):
     scipy.integrate.quadrature
     scipy.integrate.fixed_quad
     numpy.polynomial.legendre.leggauss
+
+    References
+    ----------
+    .. [AS] Milton Abramowitz and Irene A. Stegun, eds.
+        Handbook of Mathematical Functions with Formulas,
+        Graphs, and Mathematical Tables. New York: Dover, 1972.
+
     """
     m = int(n)
     if n < 1 or n != m:
@@ -1985,11 +2099,12 @@ def legendre(n, monic=False):
 def roots_sh_legendre(n, mu=False):
     r"""Gauss-Legendre (shifted) quadrature.
 
-    Computes the sample points and weights for Gauss-Legendre quadrature.
-    The sample points are the roots of the n-th degree shifted Legendre
-    polynomial :math:`P^*_n(x)`.  These sample points and weights correctly
-    integrate polynomials of degree :math:`2n - 1` or less over the interval
-    :math:`[0, 1]` with weight function :math:`f(x) = 1.0`.
+    Compute the sample points and weights for Gauss-Legendre
+    quadrature. The sample points are the roots of the n-th degree
+    shifted Legendre polynomial :math:`P^*_n(x)`. These sample points
+    and weights correctly integrate polynomials of degree :math:`2n -
+    1` or less over the interval :math:`[0, 1]` with weight function
+    :math:`w(x) = 1.0`. See 2.2.11 in [AS]_ for details.
 
     Parameters
     ----------
@@ -2011,6 +2126,13 @@ def roots_sh_legendre(n, mu=False):
     --------
     scipy.integrate.quadrature
     scipy.integrate.fixed_quad
+
+    References
+    ----------
+    .. [AS] Milton Abramowitz and Irene A. Stegun, eds.
+        Handbook of Mathematical Functions with Formulas,
+        Graphs, and Mathematical Tables. New York: Dover, 1972.
+
     """
     x, w = roots_legendre(n)
     x = (x + 1) / 2


### PR DESCRIPTION
#### Reference issue

None

#### What does this implement/fix?

Add references to:

- The `eval_*` functions
- The `roots_*` functions

This is basically a massive "find the right equation in Abramowitz and Stegun for the formulas in the docstring".

#### Additional information

Also fix:

- a spacing issue in the `eval_laguerre` docstring
- a connection formula in the `eval_chebyc` docstring

These were uncovered while adding the references.