### PR TITLE
MAINT: proper random number initialization and readability fix

### DIFF
--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -195,10 +195,10 @@ class SphericalVoronoi:
         invb = np.argsort(np.roll(indices, 1))
 
         n = len(self.points)
-        regions = np.vstack([invf,                           # forward neigh.
-                             [len(self.points)] * n,         # north pole
-                             invb,                           # backward neigh.
-                             [len(self.points) + 1] * n]).T  # south pole
+        regions = np.vstack([invf,            # forward neighbor
+                             [n] * n,         # north pole
+                             invb,            # backward neighbor
+                             [n + 1] * n]).T  # south pole
 
         self.regions = [list(region) for region in regions]
         self.vertices = vertices + self.center

--- a/scipy/spatial/tests/test_spherical_voronoi.py
+++ b/scipy/spatial/tests/test_spherical_voronoi.py
@@ -183,8 +183,7 @@ class TestSphericalVoronoi(object):
     @pytest.mark.parametrize("radius", [0.5, 1, 2])
     @pytest.mark.parametrize("center", [(0, 0, 0), (1, 2, 3)])
     def test_geodesic_input(self, n, radius, center):
-        np.random.seed(0)
-        U = Rotation.random().as_matrix()
+        U = Rotation.random(random_state=0).as_matrix()
         thetas = np.linspace(0, 2 * np.pi, n, endpoint=False)
         points = np.vstack([np.sin(thetas), np.cos(thetas), np.zeros(n)]).T
         points = radius * points @ U


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
This fixes a couple of issues that I overlooked in #10776.
* Seed for generation of random rotations is properly initialized.
* Variable re-use makes the code more readable

#### Additional information
<!--Any additional information you think is important.-->
This PR is intended to make #10692 more digestible.