### PR TITLE
TST: bump test precision for dual_annealing SLSQP test

### DIFF
--- a/scipy/optimize/tests/test__dual_annealing.py
+++ b/scipy/optimize/tests/test__dual_annealing.py
@@ -208,7 +208,7 @@ class TestDualAnnealing:
         ('CG', 1e-8),
         ('BFGS', 1e-8),
         ('TNC', 1e-8),
-        ('SLSQP', 1e-7),
+        ('SLSQP', 2e-7),
     ])
     def test_multi_ls_minimizer(self, method, atol):
         ret = dual_annealing(self.func, self.ld_bounds,


### PR DESCRIPTION
This failure showed up on Windows with VS2017 + Ifort 2019, see
https://github.com/conda-forge/scipy-feedstock/issues/119

[ci skip]