### PR TITLE
API: Deprecated normalized keyword in Rotation

### DIFF
--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -1785,7 +1785,24 @@ class Rotation(object):
 
         where :math:`w_i`'s are the `weights` corresponding to each vector.
 
-        The rotation is estimated using Markley's SVD method [1]_.
+        The rotation is estimated with Kabsch algorithm [1]_.
+
+        This method also computes the sensitivity of the estimated rotation to
+        small perturbations of the vector measurements. Specifically we
+        consider the rotation estimate error as a small rotation vector of
+        frame A. The sensitivity matrix is proportional to the covariance of
+        this rotation vector assuming that the vectors in `a` was measured with
+        errors significantly less than their lengths. To get the true
+        covariance matrix, the returned sensitivity matrix must be multiplied
+        by harmonic mean [3]_ of variance in each observation. Note that
+        `weights` are supposed to be inversely proportional to the observation
+        variances to get consistent results. For example, if all vectors are
+        measured with the same accuracy of 0.01 (`weights` must be all equal),
+        then you should multiple the sensitivity matrix by 0.01**2 to get the
+        covariance.
+
+        Refer to [2]_ for more rigorous discussion of the covariance
+        estimation.
 
         Parameters
         ----------
@@ -1796,32 +1813,26 @@ class Rotation(object):
             Vector components observed in another frame B. Each row of `b`
             denotes a vector.
         weights : array_like shape (N,), optional
-            Weights describing the relative importance of the vectors in
-            `a`. If None (default), then all values in `weights` are assumed to
-            be equal.
+            Weights describing the relative importance of the vector
+            observations. If None (default), then all values in `weights` are
+            assumed to be equal.
 
         Returns
         -------
         estimated_rotation : `Rotation` instance
             Best estimate of the rotation that transforms `b` to `a`.
         sensitivity_matrix : ndarray, shape (3, 3)
-            Scaled covariance of the attitude errors expressed as the small
-            rotation vector of frame A. Multiply with harmonic mean [3]_ of
-            variance in each observation to get true covariance matrix. The
-            error model is detailed in [2]_.
+            Sensitivity matrix of the estimated rotation estimate as explained
+            above.
 
         References
         ----------
-        .. [1] F. Landis Markley,
+        .. [1] https://en.wikipedia.org/wiki/Kabsch_algorithm
+        .. [2] F. Landis Markley,
                 "Attitude determination using vector observations: a fast
                 optimal matrix algorithm", Journal of Astronautical Sciences,
                 Vol. 41, No.2, 1993, pp. 261-280.
-        .. [2] F. Landis Markley,
-                "Attitude determination using vector observations and the
-                Singular Value Decomposition", Journal of Astronautical
-                Sciences, Vol. 38, No.3, 1988, pp. 245-258.
         .. [3] https://en.wikipedia.org/wiki/Harmonic_mean
-
         """
         a = np.asarray(a)
         if a.ndim != 2 or a.shape[-1] != 3:

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -407,7 +407,7 @@ class Rotation(object):
         return self._quat.shape[0]
 
     @classmethod
-    def from_quat(cls, quat, normalized=False):
+    def from_quat(cls, quat, normalized=None):
         """Initialize from quaternions.
 
         3D rotations can be represented using unit-norm quaternions [1]_.
@@ -416,11 +416,8 @@ class Rotation(object):
         ----------
         quat : array_like, shape (N, 4) or (4,)
             Each row is a (possibly non-unit norm) quaternion in scalar-last
-            (x, y, z, w) format.
-        normalized : bool, optional
-            If False, input quaternions are normalized to unit norm before
-            being stored. If True, quaternions are assumed to already have
-            unit norm and are stored as given. Default is False.
+            (x, y, z, w) format. Each quaternion will be normalized to unit
+            norm.
 
         Returns
         -------
@@ -463,20 +460,18 @@ class Rotation(object):
         >>> r.as_quat().shape
         (1, 4)
 
-        By default, quaternions are normalized before initialization.
+        Quaternions are normalized before initialization.
 
         >>> r = R.from_quat([0, 0, 1, 1])
         >>> r.as_quat()
         array([0.        , 0.        , 0.70710678, 0.70710678])
-
-        If unit norms are ensured, skip the normalization step.
-
-        >>> r = R.from_quat([0, 0, 1, 0], normalized=True)
-        >>> r.as_quat()
-        array([0., 0., 1., 0.])
-
         """
-        return cls(quat, not normalized)
+        if normalized is not None:
+            warnings.warn("`normalized` is deprecated in scipy 1.4.0 and "
+                          "will be removed in scipy 1.6.0. The input `quat` "
+                          "is always normalized.", DeprecationWarning)
+
+        return cls(quat, normalize=True)
 
     @classmethod
     def from_matrix(cls, matrix):

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -1775,7 +1775,7 @@ class Rotation(object):
         return cls(sample)
 
     @classmethod
-    def match_vectors(cls, a, b, weights=None, normalized=None):
+    def match_vectors(cls, a, b, weights=None):
         """Estimate a rotation to match two sets of vectors.
 
         Find a rotation between frames A and B which best matches a set of
@@ -1870,15 +1870,6 @@ class Rotation(object):
                                  "{} values and {} vectors.".format(
                                     weights.shape[0], b.shape[0]))
         weights = weights / np.sum(weights)
-
-        if normalized is not None:
-            warnings.warn("`normalized` is deprecated in scipy 1.4.0 and "
-                          "will be removed in scipy 1.6.0.",
-                          DeprecationWarning)
-
-            if normalized:
-                a = a / scipy.linalg.norm(a, axis=1)[:, None]
-                b = b / scipy.linalg.norm(b, axis=1)[:, None]
 
         B = np.einsum('ji,jk->ik', weights[:, None] * a, b)
         u, s, vh = np.linalg.svd(B)

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -418,6 +418,11 @@ class Rotation(object):
             Each row is a (possibly non-unit norm) quaternion in scalar-last
             (x, y, z, w) format. Each quaternion will be normalized to unit
             norm.
+        normalized
+            Deprecated argument. Has no effect, input `quat` is always
+            normalized.
+
+            .. deprecated:: 1.4.0
 
         Returns
         -------

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -1770,7 +1770,7 @@ class Rotation(object):
         return cls(sample)
 
     @classmethod
-    def match_vectors(cls, a, b, weights=None, normalized=False):
+    def match_vectors(cls, a, b, weights=None, normalized=None):
         """Estimate a rotation to match two sets of vectors.
 
         Find a rotation between frames A and B which best matches a set of unit
@@ -1791,18 +1791,14 @@ class Rotation(object):
         ----------
         a : array_like, shape (N, 3)
             Vector components observed in initial frame A. Each row of `a`
-            denotes a vector.
+            denotes a vector. Vectors will be normalized to unit norm.
         b : array_like, shape (N, 3)
             Vector components observed in another frame B. Each row of `b`
-            denotes a vector.
+            denotes a vector. Vectors will be normalized to unit norm.
         weights : array_like shape (N,), optional
             Weights describing the relative importance of the vectors in
             `a`. If None (default), then all values in `weights` are assumed to
             be equal.
-        normalized : bool, optional
-            If True, assume input vectors `a` and `b` to have unit norm. If
-            False, normalize `a` and `b` before estimating rotation. Default
-            is False.
 
         Returns
         -------
@@ -1859,9 +1855,13 @@ class Rotation(object):
                                     weights.shape[0], b.shape[0]))
         weights = weights / np.sum(weights)
 
-        if not normalized:
-            a = a / scipy.linalg.norm(a, axis=1)[:, None]
-            b = b / scipy.linalg.norm(b, axis=1)[:, None]
+        if normalized is not None:
+            warnings.warn("`normalized` is deprecated in scipy 1.4.0 and "
+                          "will be removed in scipy 1.6.0. The input vectors "
+                          "are always normalized.", DeprecationWarning)
+
+        a = a / scipy.linalg.norm(a, axis=1)[:, None]
+        b = b / scipy.linalg.norm(b, axis=1)[:, None]
 
         B = np.einsum('ji,jk->ik', weights[:, None] * a, b)
         u, s, vh = np.linalg.svd(B)

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -1773,7 +1773,7 @@ class Rotation(object):
     def match_vectors(cls, a, b, weights=None, normalized=None):
         """Estimate a rotation to match two sets of vectors.
 
-        Find a rotation between frames A and B which best matches a set of unit
+        Find a rotation between frames A and B which best matches a set of
         vectors `a` and `b` observed in these frames. The following loss
         function is minimized to solve for the rotation matrix
         :math:`C`:
@@ -1791,10 +1791,10 @@ class Rotation(object):
         ----------
         a : array_like, shape (N, 3)
             Vector components observed in initial frame A. Each row of `a`
-            denotes a vector. Vectors will be normalized to unit norm.
+            denotes a vector.
         b : array_like, shape (N, 3)
             Vector components observed in another frame B. Each row of `b`
-            denotes a vector. Vectors will be normalized to unit norm.
+            denotes a vector.
         weights : array_like shape (N,), optional
             Weights describing the relative importance of the vectors in
             `a`. If None (default), then all values in `weights` are assumed to
@@ -1857,11 +1857,12 @@ class Rotation(object):
 
         if normalized is not None:
             warnings.warn("`normalized` is deprecated in scipy 1.4.0 and "
-                          "will be removed in scipy 1.6.0. The input vectors "
-                          "are always normalized.", DeprecationWarning)
+                          "will be removed in scipy 1.6.0.",
+                          DeprecationWarning)
 
-        a = a / scipy.linalg.norm(a, axis=1)[:, None]
-        b = b / scipy.linalg.norm(b, axis=1)[:, None]
+            if normalized:
+                a = a / scipy.linalg.norm(a, axis=1)[:, None]
+                b = b / scipy.linalg.norm(b, axis=1)[:, None]
 
         B = np.einsum('ji,jk->ik', weights[:, None] * a, b)
         u, s, vh = np.linalg.svd(B)

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -365,7 +365,7 @@ class Rotation(object):
     output formats supported, consult the individual method's examples.
 
     """
-    def __init__(self, quat, normalize=False, copy=True):
+    def __init__(self, quat, normalize=True, copy=True):
         self._single = False
         quat = np.asarray(quat, dtype=float)
 

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -880,7 +880,7 @@ def test_quat_ownership():
         [0, 1, 0, 0],
         [0, 0, 1, 0]
     ])
-    r = Rotation.from_quat(quat, normalized=True)
+    r = Rotation.from_quat(quat)
     s = r[0:2]
 
     r._quat[0] = np.array([0, -1, 0, 0])


### PR DESCRIPTION
#### Reference issue

#10968

#### What does this implement/fix?

As explained in #10968 `normalized` keyword was not a good choice. There are serval options to improve the situation, but probably the easiest is to remove this keyword (through deprecation) and always do the normalization ---  it's not expensive operation and it guarantees that the `Rotation` has the valid state.

Note that in `Rotation.__init__` I changed `normalized` to `normalize` with the opposite meaning. But it is stated in the documentation that `__init__` is not supposed to used directly, so I think this is a legit change.

I think it would be good to make this change for 1.4.0, if do it at all.

@larsoner @pmla @rgommers 