### PR TITLE
BUG: skip deprecation for numpy top-level types

### DIFF
--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -72,9 +72,10 @@ import numpy as _num
 linalg = None
 _msg = ('scipy.{0} is deprecated and will be removed in SciPy 2.0.0, '
         'use numpy.{0} instead')
+# deprecate callable objects, skipping classes
 for _key in _num.__all__:
     _fun = getattr(_num, _key)
-    if callable(_fun):
+    if callable(_fun) and not isinstance(_fun, type):
         _fun = _deprecated(_msg.format(_key))(_fun)
     globals()[_key] = _fun
 from numpy.random import rand, randn

--- a/scipy/_lib/deprecation.py
+++ b/scipy/_lib/deprecation.py
@@ -7,6 +7,12 @@ __all__ = ["_deprecated"]
 def _deprecated(msg, stacklevel=2):
     """Deprecate a function by emitting a warning on use."""
     def wrap(fun):
+        if isinstance(fun, type):
+            warnings.warn(
+                "Trying to deprecate class {!r}".format(fun),
+                category=RuntimeWarning, stacklevel=2)
+            return fun
+
         @functools.wraps(fun)
         def call(*args, **kwargs):
             warnings.warn(msg, category=DeprecationWarning,

--- a/scipy/_lib/tests/test__util.py
+++ b/scipy/_lib/tests/test__util.py
@@ -123,7 +123,7 @@ def test_mapwrapper_parallel():
 # get our custom ones and a few from the "import *" cases
 @pytest.mark.parametrize(
     'key', ('fft', 'ifft', 'diag', 'arccos',
-            'randn', 'rand', 'array', 'finfo'))
+            'randn', 'rand', 'array'))
 def test_numpy_deprecation(key):
     """Test that 'from numpy import *' functions are deprecated."""
     if key in ('fft', 'ifft', 'diag', 'arccos'):
@@ -152,3 +152,21 @@ def test_numpy_deprecation(key):
     func_np = getattr(root, key)
     func_np(arg)  # not deprecated
     assert func_np is not func
+    # classes should remain classes
+    if isinstance(func_np, type):
+        assert isinstance(func, type)
+
+
+def test_numpy_deprecation_functionality():
+    # Check that the deprecation wrappers don't break basic Numpy
+    # functionality
+    with deprecated_call():
+        x = scipy.array([1, 2, 3], dtype=scipy.float64)
+        assert x.dtype == scipy.float64
+        assert x.dtype == np.float64
+
+        x = scipy.finfo(scipy.float32)
+        assert x.eps == np.finfo(np.float32).eps
+
+        assert scipy.float64 == np.float64
+        assert issubclass(np.float64, scipy.float64)


### PR DESCRIPTION
Deprecation decoration of type objects is more likely to cause problems
than for functions, so don't do it. Deprecation of plain functions is
likely enough to result to deprecation warnings in most cases.

This would likely be important to fix for Scipy 1.4.0, as otherwise we break
the backward compatibility here.

E.g. the array scalar type objects are often used in `dtype=` arguments
and possibly compared with other scalar objects, and our deprecation
decoration currently breaks that:
```
>>> import scipy, numpy as np
>>> assert scipy.array([1,2,3], dtype=scipy.float64).dtype == np.float64
__main__:1: DeprecationWarning: scipy.array is deprecated and will be removed in SciPy 2.0.0, use numpy.array instead
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/pauli/prj/scipy/scipy/scipy/_lib/deprecation.py", line 14, in call
    return fun(*args, **kwargs)
TypeError: data type not understood
>>> assert scipy.float64 == np.float64
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AssertionError
```
It's possible to do the decoration so that the above still works, via
subclassing with metaclass, but it's hard to be sure that covers everything
necessary. Since deprecation of functions already likely generates deprecation
warnings in suspect code, it's probably enough.