### PR TITLE
ENH: stats.dlaplace.rvs improvements

### DIFF
--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -941,13 +941,19 @@ class dlaplace_gen(rv_discrete):
         # The discrete Laplace is equivalent to the two-sided geometric
         # distribution with PMF:
         #   f(k) = (1 - alpha)/(1 + alpha) * alpha^abs(k)
+        #   Reference:
+        #     https://www.sciencedirect.com/science/
+        #     article/abs/pii/S0378375804003519
         # Furthermore, the two-sided geometric distribution is
         # equivalent to the difference between two iid geometric 
         # distributions.
+        #   Reference (page 179):
+        #     https://pdfs.semanticscholar.org/61b3/
+        #     b99f466815808fd0d03f5d2791eea8b541a1.pdf
         # Thus, we can leverage the following:
         #   1) alpha = e^-a
         #   2) probability_of_success = 1 - alpha (Bernoulli trial)
-        probOfSuccess = 1. - np.exp(-np.asarray(a))
+        probOfSuccess = -np.expm1(-np.asarray(a))
         x = self._random_state.geometric(probOfSuccess, size=self._size)
         y = self._random_state.geometric(probOfSuccess, size=self._size)
         return x - y

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -937,6 +937,21 @@ class dlaplace_gen(rv_discrete):
     def _entropy(self, a):
         return a / sinh(a) - log(tanh(a/2.0))
 
+    def _rvs(self, a):
+        # The discrete Laplace is equivalent to the two-sided geometric
+        # distribution with PMF:
+        #   f(k) = (1 - alpha)/(1 + alpha) * alpha^abs(k)
+        # Furthermore, the two-sided geometric distribution is
+        # equivalent to the difference between two iid geometric 
+        # distributions.
+        # Thus, we can leverage the following:
+        #   1) alpha = e^-a
+        #   2) probability_of_success = 1 - alpha (Bernoulli trial)
+        probOfSuccess = 1. - np.exp(-np.asarray(a))
+        x = self._random_state.geometric(probOfSuccess, size=self._size)
+        y = self._random_state.geometric(probOfSuccess, size=self._size)
+        return x - y
+
 
 dlaplace = dlaplace_gen(a=-np.inf,
                         name='dlaplace', longname='A discrete Laplacian')

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -100,7 +100,7 @@ def test_rvs_broadcast(dist, shape_args):
     # implementation detail of the distribution, not a requirement.  If
     # the implementation the rvs() method of a distribution changes, this
     # test might also have to be changed.
-    shape_only = dist in ['betabinom', 'skellam', 'yulesimon']
+    shape_only = dist in ['betabinom', 'skellam', 'yulesimon', 'dlaplace']
 
     try:
         distfunc = getattr(stats, dist)


### PR DESCRIPTION
This change adds a custom rvs() to stats.dlaplace. The new rvs() is
approx. twice as fast as the default rvs() which inverts the CDF.
This change also appears to improve stability when generating large
sample sizes (~100mil+).

Mailing list threads discussing this change are at:
https://mail.python.org/pipermail/scipy-dev/2019-November/023851.html
https://mail.python.org/pipermail/scipy-dev/2019-November/023855.html