### PR TITLE
REL: set version to 1.5.0.dev0

### DIFF
--- a/doc/release/1.5.0-notes.rst
+++ b/doc/release/1.5.0-notes.rst
@@ -1,0 +1,103 @@
+==========================
+SciPy 1.5.0 Release Notes
+==========================
+
+.. note:: Scipy 1.5.0 is not released yet!
+
+.. contents::
+
+SciPy 1.5.0 is the culmination of X months of hard work. It contains
+many new features, numerous bug-fixes, improved test coverage and better
+documentation. There have been a number of deprecations and API changes
+in this release, which are documented below. All users are encouraged to
+upgrade to this release, as there are a large number of bug-fixes and
+optimizations. Before upgrading, we recommend that users check that
+their own code does not use deprecated SciPy functionality (to do so,
+run your code with ``python -Wd`` and check for ``DeprecationWarning`` s).
+Our development attention will now shift to bug-fix releases on the
+1.3.x branch, and on adding new features on the master branch.
+
+This release requires Python 3.6+ and NumPy 1.13.3 or greater.
+
+For running on PyPy, PyPy3 6.0+ and NumPy 1.15.0 are required.
+
+Highlights of this release
+--------------------------
+
+-
+
+
+New features
+============
+
+`scipy.integrate` improvements
+------------------------------
+
+
+`scipy.interpolate` improvements
+--------------------------------
+
+`scipy.io` improvements
+-----------------------
+
+
+`scipy.linalg` improvements
+---------------------------
+
+
+`scipy.ndimage` improvements
+----------------------------
+
+
+`scipy.optimize` improvements
+-----------------------------
+
+
+`scipy.signal` improvements
+---------------------------
+
+
+`scipy.sparse` improvements
+---------------------------
+
+`scipy.spatial` improvements
+----------------------------
+
+`scipy.stats` improvements
+--------------------------
+
+Deprecated features
+===================
+
+`scipy` deprecations
+--------------------
+
+Backwards incompatible changes
+==============================
+
+`scipy.interpolate` changes
+---------------------------
+
+`scipy.linalg` changes
+----------------------
+
+`scipy.signal` changes
+----------------------
+
+`scipy.stats` changes
+---------------------
+
+
+Other changes
+=============
+
+
+Authors
+=======
+
+
+Issues closed for 1.5.0
+-----------------------
+
+Pull requests for 1.5.0
+-----------------------

--- a/doc/source/release.1.5.0.rst
+++ b/doc/source/release.1.5.0.rst
@@ -1,0 +1,1 @@
+.. include:: ../release/1.5.0-notes.rst

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
    :maxdepth: 1
 
+   release.1.5.0
    release.1.4.0
    release.1.3.2
    release.1.3.1

--- a/pavement.py
+++ b/pavement.py
@@ -113,10 +113,10 @@ except AttributeError:
 #-----------------------------------
 
 # Source of the release notes
-RELEASE = 'doc/release/1.4.0-notes.rst'
+RELEASE = 'doc/release/1.5.0-notes.rst'
 
 # Start/end of the log (from git)
-LOG_START = 'v1.3.0'
+LOG_START = 'v1.4.0'
 LOG_END = 'master'
 
 

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ Operating System :: MacOS
 """
 
 MAJOR = 1
-MINOR = 4
+MINOR = 5
 MICRO = 0
 ISRELEASED = False
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)


### PR DESCRIPTION
Don't merge until the `1.4.0` release notes update has been merged & we have branched `1.4.x`.

Just getting this ready now so it isn't done late at night..