### PR TITLE
API: Replace Rotation.match_vectors with align_vectors

### DIFF
--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -1779,62 +1779,7 @@ class Rotation(object):
                           "align_vectors in scipy 1.4.0 and will be removed "
                           "in scipy 1.6.0")
     def match_vectors(cls, a, b, weights=None, normalized=False):
-        """Estimate a rotation to match two sets of vectors.
-
-        Find a rotation between frames A and B which best matches a set of unit
-        vectors `a` and `b` observed in these frames. The following loss
-        function is minimized to solve for the rotation matrix
-        :math:`C`:
-
-        .. math::
-
-            L(C) = \\frac{1}{2} \\sum_{i = 1}^{n} w_i \\lVert \\mathbf{a}_i -
-            C \\mathbf{b}_i \\rVert^2 ,
-
-        where :math:`w_i`'s are the `weights` corresponding to each vector.
-
-        The rotation is estimated using Markley's SVD method [1]_.
-
-        Parameters
-        ----------
-        a : array_like, shape (N, 3)
-            Vector components observed in initial frame A. Each row of `a`
-            denotes a vector.
-        b : array_like, shape (N, 3)
-            Vector components observed in another frame B. Each row of `b`
-            denotes a vector.
-        weights : array_like shape (N,), optional
-            Weights describing the relative importance of the vectors in
-            `a`. If None (default), then all values in `weights` are assumed to
-            be equal.
-        normalized : bool, optional
-            If True, assume input vectors `a` and `b` to have unit norm. If
-            False, normalize `a` and `b` before estimating rotation. Default
-            is False.
-
-        Returns
-        -------
-        estimated_rotation : `Rotation` instance
-            Best estimate of the rotation that transforms `b` to `a`.
-        sensitivity_matrix : ndarray, shape (3, 3)
-            Scaled covariance of the attitude errors expressed as the small
-            rotation vector of frame A. Multiply with harmonic mean [3]_ of
-            variance in each observation to get true covariance matrix. The
-            error model is detailed in [2]_.
-
-        References
-        ----------
-        .. [1] F. Landis Markley,
-                "Attitude determination using vector observations: a fast
-                optimal matrix algorithm", Journal of Astronautical Sciences,
-                Vol. 41, No.2, 1993, pp. 261-280.
-        .. [2] F. Landis Markley,
-                "Attitude determination using vector observations and the
-                Singular Value Decomposition", Journal of Astronautical
-                Sciences, Vol. 38, No.3, 1988, pp. 245-258.
-        .. [3] https://en.wikipedia.org/wiki/Harmonic_mean
-
-        """
+        """Deprecated in favor of `align_vectors`."""
         a = np.asarray(a)
         if a.ndim != 2 or a.shape[-1] != 3:
             raise ValueError("Expected input `a` to have shape (N, 3), "

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -2000,15 +2000,16 @@ class Rotation(object):
 
         C = np.dot(u, vh)
 
-        zeta = (s[0]+s[1]) * (s[1]+s[2]) * (s[2]+s[0])
-        if np.abs(zeta) <= 1e-16:
-            raise ValueError("Three component error vector has infinite "
-                             "covariance. It is impossible to determine the "
-                             "rotation uniquely.")
+        if s[1] + s[2] < 1e-16 * s[0]:
+            warnings.warn("Optimal rotation is poorly defined for the given "
+                          "arrangement of vectors.")
 
-        kappa = s[0]*s[1] + s[1]*s[2] + s[2]*s[0]
-        sensitivity = np.mean(weights) / zeta * (
-                kappa * np.eye(3) + np.dot(B, B.T))
+        zeta = (s[0]+s[1]) * (s[1]+s[2]) * (s[2]+s[0])
+        kappa = s[0] * s[1] + s[1] * s[2] + s[2] * s[0]
+        with np.errstate(divide='ignore', invalid='ignore'):
+            sensitivity = np.mean(weights) / zeta * (
+                    kappa * np.eye(3) + np.dot(B, B.T))
+
         lambda0 = 0.5 * np.sum(weights * np.sum(b**2 + a**2, axis=1))
 
         return cls.from_matrix(C), lambda0 - np.sum(s), sensitivity

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -2010,9 +2010,10 @@ class Rotation(object):
             sensitivity = np.mean(weights) / zeta * (
                     kappa * np.eye(3) + np.dot(B, B.T))
 
-        lambda0 = 0.5 * np.sum(weights * np.sum(b**2 + a**2, axis=1))
+        loss = max(0.5 * np.sum(weights * np.sum(b ** 2 + a ** 2, axis=1))
+                   - np.sum(s), 0)
 
-        return cls.from_matrix(C), lambda0 - np.sum(s), sensitivity
+        return cls.from_matrix(C), loss, sensitivity
 
 
 class Slerp(object):

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -1926,10 +1926,6 @@ class Rotation(object):
                              ", got {} and {} respectively.".format(
                                 a.shape, b.shape))
 
-        if b.shape[0] == 1:
-            raise ValueError("Rotation cannot be estimated using a single "
-                             "vector.")
-
         if weights is None:
             weights = np.ones(len(b))
         else:
@@ -1954,8 +1950,8 @@ class Rotation(object):
         C = np.dot(u, vh)
 
         if s[1] + s[2] < 1e-16 * s[0]:
-            warnings.warn("Optimal rotation is poorly defined for the given "
-                          "arrangement of vectors.")
+            warnings.warn("Optimal rotation is not uniquely or poorly defined "
+                          "for the given sets of vectors.")
 
         rmsd = np.sqrt(max(
             np.sum(weights * np.sum(b ** 2 + a ** 2, axis=1)) - 2 * np.sum(s),

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -1944,8 +1944,11 @@ class Rotation(object):
         -------
         estimated_rotation : `Rotation` instance
             Best estimate of the rotation that transforms `b` to `a`.
-        minimum_loss : float
-            Achieved minimum value of the loss function.
+        rmsd : float
+            Root mean square distance (weighted) between the given set of
+            vectors after alignment. It is equal to ``sqrt(2 * minimum_loss)``,
+            where ``minimum_loss`` is the loss function evaluated for the
+            found optimal rotation.
         sensitivity_matrix : ndarray, shape (3, 3)
             Sensitivity matrix of the estimated rotation estimate as explained
             above.
@@ -2013,7 +2016,7 @@ class Rotation(object):
         loss = max(0.5 * np.sum(weights * np.sum(b ** 2 + a ** 2, axis=1))
                    - np.sum(s), 0)
 
-        return cls.from_matrix(C), loss, sensitivity
+        return cls.from_matrix(C), np.sqrt(2 * loss), sensitivity
 
 
 class Slerp(object):

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -218,7 +218,7 @@ class Rotation(object):
     __getitem__
     identity
     random
-    match_vectors
+    align_vectors
 
     See Also
     --------
@@ -1775,10 +1775,128 @@ class Rotation(object):
         return cls(sample)
 
     @classmethod
-    def match_vectors(cls, a, b, weights=None):
+    @np.deprecate(message="match_vectors is deprecated in favor of "
+                          "align_vectors in scipy 1.4.0 and will be removed "
+                          "in scipy 1.6.0")
+    def match_vectors(cls, a, b, weights=None, normalized=False):
         """Estimate a rotation to match two sets of vectors.
 
-        Find a rotation between frames A and B which best matches a set of
+        Find a rotation between frames A and B which best matches a set of unit
+        vectors `a` and `b` observed in these frames. The following loss
+        function is minimized to solve for the rotation matrix
+        :math:`C`:
+
+        .. math::
+
+            L(C) = \\frac{1}{2} \\sum_{i = 1}^{n} w_i \\lVert \\mathbf{a}_i -
+            C \\mathbf{b}_i \\rVert^2 ,
+
+        where :math:`w_i`'s are the `weights` corresponding to each vector.
+
+        The rotation is estimated using Markley's SVD method [1]_.
+
+        Parameters
+        ----------
+        a : array_like, shape (N, 3)
+            Vector components observed in initial frame A. Each row of `a`
+            denotes a vector.
+        b : array_like, shape (N, 3)
+            Vector components observed in another frame B. Each row of `b`
+            denotes a vector.
+        weights : array_like shape (N,), optional
+            Weights describing the relative importance of the vectors in
+            `a`. If None (default), then all values in `weights` are assumed to
+            be equal.
+        normalized : bool, optional
+            If True, assume input vectors `a` and `b` to have unit norm. If
+            False, normalize `a` and `b` before estimating rotation. Default
+            is False.
+
+        Returns
+        -------
+        estimated_rotation : `Rotation` instance
+            Best estimate of the rotation that transforms `b` to `a`.
+        sensitivity_matrix : ndarray, shape (3, 3)
+            Scaled covariance of the attitude errors expressed as the small
+            rotation vector of frame A. Multiply with harmonic mean [3]_ of
+            variance in each observation to get true covariance matrix. The
+            error model is detailed in [2]_.
+
+        References
+        ----------
+        .. [1] F. Landis Markley,
+                "Attitude determination using vector observations: a fast
+                optimal matrix algorithm", Journal of Astronautical Sciences,
+                Vol. 41, No.2, 1993, pp. 261-280.
+        .. [2] F. Landis Markley,
+                "Attitude determination using vector observations and the
+                Singular Value Decomposition", Journal of Astronautical
+                Sciences, Vol. 38, No.3, 1988, pp. 245-258.
+        .. [3] https://en.wikipedia.org/wiki/Harmonic_mean
+
+        """
+        a = np.asarray(a)
+        if a.ndim != 2 or a.shape[-1] != 3:
+            raise ValueError("Expected input `a` to have shape (N, 3), "
+                             "got {}".format(a.shape))
+        b = np.asarray(b)
+        if b.ndim != 2 or b.shape[-1] != 3:
+            raise ValueError("Expected input `b` to have shape (N, 3), "
+                             "got {}.".format(b.shape))
+
+        if a.shape != b.shape:
+            raise ValueError("Expected inputs `a` and `b` to have same shapes"
+                             ", got {} and {} respectively.".format(
+                                a.shape, b.shape))
+
+        if b.shape[0] == 1:
+            raise ValueError("Rotation cannot be estimated using a single "
+                             "vector.")
+
+        if weights is None:
+            weights = np.ones(b.shape[0])
+        else:
+            weights = np.asarray(weights)
+            if weights.ndim != 1:
+                raise ValueError("Expected `weights` to be 1 dimensional, got "
+                                 "shape {}.".format(weights.shape))
+            if weights.shape[0] != b.shape[0]:
+                raise ValueError("Expected `weights` to have number of values "
+                                 "equal to number of input vectors, got "
+                                 "{} values and {} vectors.".format(
+                                    weights.shape[0], b.shape[0]))
+        weights = weights / np.sum(weights)
+
+        if not normalized:
+            a = a / scipy.linalg.norm(a, axis=1)[:, None]
+            b = b / scipy.linalg.norm(b, axis=1)[:, None]
+
+        B = np.einsum('ji,jk->ik', weights[:, None] * a, b)
+        u, s, vh = np.linalg.svd(B)
+
+        # Correct improper rotation if necessary (as in Kabsch algorithm)
+        if np.linalg.det(u @ vh) < 0:
+            s[-1] = -s[-1]
+            u[:, -1] = -u[:, -1]
+
+        C = np.dot(u, vh)
+
+        zeta = (s[0]+s[1]) * (s[1]+s[2]) * (s[2]+s[0])
+        if np.abs(zeta) <= 1e-16:
+            raise ValueError("Three component error vector has infinite "
+                             "covariance. It is impossible to determine the "
+                             "rotation uniquely.")
+
+        kappa = s[0]*s[1] + s[1]*s[2] + s[2]*s[0]
+        sensitivity = ((kappa * np.eye(3) + np.dot(B, B.T)) /
+                       (zeta * a.shape[0]))
+        return cls.from_matrix(C), sensitivity
+
+    @classmethod
+    def align_vectors(cls, a, b, weights=None):
+        """Estimate a rotation to align two sets of vectors.
+
+        Find a rotation between frames A and B which best aligns a set of
         vectors `a` and `b` observed in these frames. The following loss
         function is minimized to solve for the rotation matrix
         :math:`C`:

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -887,36 +887,36 @@ def test_quat_ownership():
     assert_allclose(s._quat[0], np.array([1, 0, 0, 0]))
 
 
-def test_match_vectors_no_rotation():
+def test_align_vectors_no_rotation():
     x = np.array([[1, 2, 3], [4, 5, 6]])
     y = x.copy()
 
-    r, p = Rotation.match_vectors(x, y)
+    r, p = Rotation.align_vectors(x, y)
     assert_array_almost_equal(r.as_matrix(), np.eye(3))
 
 
-def test_match_vectors_no_noise():
+def test_align_vectors_no_noise():
     np.random.seed(0)
     c = Rotation.from_quat(np.random.normal(size=4))
     b = np.random.normal(size=(5, 3))
     a = c.apply(b)
 
-    est, cov = Rotation.match_vectors(a, b)
+    est, cov = Rotation.align_vectors(a, b)
     assert_allclose(c.as_quat(), est.as_quat())
 
 
-def test_match_vectors_improper_rotation():
+def test_align_vectors_improper_rotation():
     # Tests correct logic for issue #10444
     x = np.array([[0.89299824, -0.44372674, 0.0752378],
                   [0.60221789, -0.47564102, -0.6411702]])
     y = np.array([[0.02386536, -0.82176463, 0.5693271],
                   [-0.27654929, -0.95191427, -0.1318321]])
 
-    est, cov = Rotation.match_vectors(x, y)
+    est, cov = Rotation.align_vectors(x, y)
     assert_allclose(x, est.apply(y), atol=1e-6)
 
 
-def test_match_vectors_noise():
+def test_align_vectors_noise():
     np.random.seed(0)
     n_vectors = 100
     rot = Rotation.from_euler('xyz', np.random.normal(size=3))
@@ -937,7 +937,7 @@ def test_match_vectors_noise():
     # rotations to each vector.
     noisy_result = noise.apply(result)
 
-    est, cov = Rotation.match_vectors(noisy_result, vectors)
+    est, cov = Rotation.align_vectors(noisy_result, vectors)
 
     # Use rotation compositions to find out closeness
     error_vector = (rot * est.inv()).as_rotvec()

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -978,6 +978,26 @@ def test_align_vectors_single_vector():
         assert_allclose(rmsd, 0, atol=1e-16)
 
 
+def test_align_vectors_invalid_input():
+    with pytest.raises(ValueError, match="Expected input `a` to have shape"):
+        Rotation.align_vectors([1, 2, 3], [[1, 2, 3]])
+
+    with pytest.raises(ValueError, match="Expected input `b` to have shape"):
+        Rotation.align_vectors([[1, 2, 3]], [1, 2, 3])
+
+    with pytest.raises(ValueError, match="Expected inputs `a` and `b` "
+                                         "to have same shapes"):
+        Rotation.align_vectors([[1, 2, 3],[4, 5, 6]], [[1, 2, 3]])
+
+    with pytest.raises(ValueError,
+                       match="Expected `weights` to be 1 dimensional"):
+        Rotation.align_vectors([[1, 2, 3]], [[1, 2, 3]], weights=[[1]])
+
+    with pytest.raises(ValueError,
+                       match="Expected `weights` to have number of values"):
+        Rotation.align_vectors([[1, 2, 3]], [[1, 2, 3]], weights=[1, 2])
+
+
 def test_random_rotation_shape():
     assert_equal(Rotation.random().as_quat().shape, (4,))
     assert_equal(Rotation.random(None).as_quat().shape, (4,))

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -972,6 +972,12 @@ def test_align_vectors_noise():
     assert_allclose(rmsd, np.sum((noisy_result - est.apply(vectors))**2)**0.5)
 
 
+def test_align_vectors_single_vector():
+    with pytest.warns(UserWarning, match="Optimal rotation is not"):
+        r_estimate, rmsd = Rotation.align_vectors([[1, -1, 1]], [[1, 1, -1]])
+        assert_allclose(rmsd, 0, atol=1e-16)
+
+
 def test_random_rotation_shape():
     assert_equal(Rotation.random().as_quat().shape, (4,))
     assert_equal(Rotation.random(None).as_quat().shape, (4,))

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -919,6 +919,20 @@ def test_align_vectors_improper_rotation():
     assert_allclose(loss, 0, atol=1e-14)
 
 
+def test_align_vectors_scaled_weights():
+    rng = np.random.RandomState(0)
+    c = Rotation.random(random_state=rng)
+    b = rng.normal(size=(5, 3))
+    a = c.apply(b)
+
+    est1, loss1, cov1 = Rotation.align_vectors(a, b, np.ones(5))
+    est2, loss2, cov2 = Rotation.align_vectors(a, b, 2 * np.ones(5))
+
+    assert_allclose(est1.as_matrix(), est2.as_matrix())
+    assert_allclose(2 * loss1, loss2)
+    assert_allclose(cov1, cov2)
+
+
 def test_align_vectors_noise():
     np.random.seed(0)
     n_vectors = 100

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -891,9 +891,9 @@ def test_align_vectors_no_rotation():
     x = np.array([[1, 2, 3], [4, 5, 6]])
     y = x.copy()
 
-    r, loss, p = Rotation.align_vectors(x, y)
+    r, rmsd, p = Rotation.align_vectors(x, y)
     assert_array_almost_equal(r.as_matrix(), np.eye(3))
-    assert_allclose(loss, 0, atol=1e-13)
+    assert_allclose(rmsd, 0, atol=1e-6)
 
 
 def test_align_vectors_no_noise():
@@ -902,9 +902,9 @@ def test_align_vectors_no_noise():
     b = np.random.normal(size=(5, 3))
     a = c.apply(b)
 
-    est, loss, cov = Rotation.align_vectors(a, b)
+    est, rmsd, cov = Rotation.align_vectors(a, b)
     assert_allclose(c.as_quat(), est.as_quat())
-    assert_allclose(loss, 0, atol=1e-14)
+    assert_allclose(rmsd, 0, atol=1e-7)
 
 
 def test_align_vectors_improper_rotation():
@@ -914,9 +914,9 @@ def test_align_vectors_improper_rotation():
     y = np.array([[0.02386536, -0.82176463, 0.5693271],
                   [-0.27654929, -0.95191427, -0.1318321]])
 
-    est, loss, cov = Rotation.align_vectors(x, y)
+    est, rmsd, cov = Rotation.align_vectors(x, y)
     assert_allclose(x, est.apply(y), atol=1e-6)
-    assert_allclose(loss, 0, atol=1e-14)
+    assert_allclose(rmsd, 0, atol=1e-7)
 
 
 def test_align_vectors_scaled_weights():
@@ -925,11 +925,11 @@ def test_align_vectors_scaled_weights():
     b = rng.normal(size=(5, 3))
     a = c.apply(b)
 
-    est1, loss1, cov1 = Rotation.align_vectors(a, b, np.ones(5))
-    est2, loss2, cov2 = Rotation.align_vectors(a, b, 2 * np.ones(5))
+    est1, rmsd1, cov1 = Rotation.align_vectors(a, b, np.ones(5))
+    est2, rmsd2, cov2 = Rotation.align_vectors(a, b, 2 * np.ones(5))
 
     assert_allclose(est1.as_matrix(), est2.as_matrix())
-    assert_allclose(2 * loss1, loss2)
+    assert_allclose(np.sqrt(2) * rmsd1, rmsd2)
     assert_allclose(cov1, cov2)
 
 
@@ -954,7 +954,7 @@ def test_align_vectors_noise():
     # rotations to each vector.
     noisy_result = noise.apply(result)
 
-    est, loss, cov = Rotation.align_vectors(noisy_result, vectors)
+    est, rmsd, cov = Rotation.align_vectors(noisy_result, vectors)
 
     # Use rotation compositions to find out closeness
     error_vector = (rot * est.inv()).as_rotvec()
@@ -968,7 +968,7 @@ def test_align_vectors_noise():
     assert_allclose(cov[1, 1], 0, atol=tolerance)
     assert_allclose(cov[2, 2], 0, atol=tolerance)
 
-    assert_allclose(loss, 0.5 * np.sum((noisy_result - est.apply(vectors))**2))
+    assert_allclose(rmsd, np.sum((noisy_result - est.apply(vectors))**2)**0.5)
 
 
 def test_random_rotation_shape():

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -891,7 +891,7 @@ def test_align_vectors_no_rotation():
     x = np.array([[1, 2, 3], [4, 5, 6]])
     y = x.copy()
 
-    r, rmsd, p = Rotation.align_vectors(x, y)
+    r, rmsd = Rotation.align_vectors(x, y)
     assert_array_almost_equal(r.as_matrix(), np.eye(3))
     assert_allclose(rmsd, 0, atol=1e-6)
 
@@ -902,7 +902,7 @@ def test_align_vectors_no_noise():
     b = np.random.normal(size=(5, 3))
     a = c.apply(b)
 
-    est, rmsd, cov = Rotation.align_vectors(a, b)
+    est, rmsd = Rotation.align_vectors(a, b)
     assert_allclose(c.as_quat(), est.as_quat())
     assert_allclose(rmsd, 0, atol=1e-7)
 
@@ -914,7 +914,7 @@ def test_align_vectors_improper_rotation():
     y = np.array([[0.02386536, -0.82176463, 0.5693271],
                   [-0.27654929, -0.95191427, -0.1318321]])
 
-    est, rmsd, cov = Rotation.align_vectors(x, y)
+    est, rmsd = Rotation.align_vectors(x, y)
     assert_allclose(x, est.apply(y), atol=1e-6)
     assert_allclose(rmsd, 0, atol=1e-7)
 
@@ -925,8 +925,8 @@ def test_align_vectors_scaled_weights():
     b = rng.normal(size=(5, 3))
     a = c.apply(b)
 
-    est1, rmsd1, cov1 = Rotation.align_vectors(a, b, np.ones(5))
-    est2, rmsd2, cov2 = Rotation.align_vectors(a, b, 2 * np.ones(5))
+    est1, rmsd1, cov1 = Rotation.align_vectors(a, b, np.ones(5), True)
+    est2, rmsd2, cov2 = Rotation.align_vectors(a, b, 2 * np.ones(5), True)
 
     assert_allclose(est1.as_matrix(), est2.as_matrix())
     assert_allclose(np.sqrt(2) * rmsd1, rmsd2)
@@ -954,7 +954,8 @@ def test_align_vectors_noise():
     # rotations to each vector.
     noisy_result = noise.apply(result)
 
-    est, rmsd, cov = Rotation.align_vectors(noisy_result, vectors)
+    est, rmsd, cov = Rotation.align_vectors(noisy_result, vectors,
+                                            return_sensitivity=True)
 
     # Use rotation compositions to find out closeness
     error_vector = (rot * est.inv()).as_rotvec()


### PR DESCRIPTION
#### Reference issue
#10968
#11056


#### What does this implement/fix?
As suggested by @pmla in #11056, a better way to improve `match_vectors` is to introduce a new function `align_vectors` where conceptual flaws of `match_vectors` is fixed. The old `match_vectors` is fully restored, but marked deprecated.

@pmla please review whether you like the description and the new returned minimum loss value.

@rgommers @tylerjereddy 

It must be the final change for 1.4.0 regarding `Rotation`.