### PR TITLE
DOC: more 1.4.0 release note fixes

### DIFF
--- a/doc/release/1.4.0-notes.rst
+++ b/doc/release/1.4.0-notes.rst
@@ -309,7 +309,7 @@ Deprecated features
 Support for NumPy functions exposed via the root SciPy namespace is deprecated
 and will be removed in 2.0.0. For example, if you use ``scipy.rand`` or
 ``scipy.diag``, you should change your code to directly use
-:func:`numpy.random.default_rng` or :func:`numpy.diag`, respectively.
+``numpy.random.default_rng`` or ``numpy.diag``, respectively.
 They remain available in the currently continuing Scipy 1.x release series.
 
 The exception to this rule is using ``scipy.fft`` as a function --
@@ -356,7 +356,7 @@ https://github.com/scipy/scipy/issues/10968.
 
 `scipy.signal` changes
 ----------------------
-:func:`scipy.signal.resample` behavior for length-1 signal inputs has been
+`scipy.signal.resample` behavior for length-1 signal inputs has been
 fixed to output a constant (DC) value rather than an impulse, consistent with
 the assumption of signal periodicity in the FFT method.
 
@@ -366,7 +366,7 @@ time-asymmetric wavelets.
 
 `scipy.stats` changes
 ---------------------
-:func:`scipy.stats.loguniform` added with better documentation as (an alias for
+`scipy.stats.loguniform` added with better documentation as (an alias for
 ``scipy.stats.reciprocal``). ``loguniform`` generates random variables
 that are equally likely in the log space; e.g., ``1``, ``10`` and ``100``
 are all equally likely if ``loguniform(10 ** 0, 10 ** 2).rvs()`` is used.


### PR DESCRIPTION
* remove use of ":func:" in 1.4.0 release notes

~* fix a reference to `scipy.stats.reciprocal`~

Changes were suggested at the bottom of https://github.com/scipy/scipy/pull/11061 by @fuglede and Ralf.

I'm assuming we only use single backticks for `scipy` references, not for `numpy`..