### PR TITLE
BUG: stats: fix freezing of some distributions

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -429,7 +429,7 @@ class rv_frozen(object):
 
         shapes, _, _ = self.dist._parse_args(*args, **kwds)
         self.dist._argcheck(*shapes)
-        self.a, self.b = self.dist._get_support(*args, **kwds)
+        self.a, self.b = self.dist._get_support(*shapes)
 
     @property
     def random_state(self):

--- a/scipy/stats/tests/common_tests.py
+++ b/scipy/stats/tests/common_tests.py
@@ -292,6 +292,19 @@ def check_pickling(distfn, args):
     distfn.random_state = rndm
 
 
+def check_freezing(distfn, args):
+    # regression test for gh-11089: freezing a distribution fails
+    # if loc and/or scale are specified
+    if isinstance(distfn, stats.rv_continuous):
+        locscale = {'loc': 1, 'scale': 2}
+    else:
+        locscale = {'loc': 1}
+
+    rv = distfn(*args, **locscale)
+    assert rv.a == distfn(*args).a
+    assert rv.b == distfn(*args).b
+
+
 def check_rvs_broadcast(distfunc, distname, allargs, shape, shape_only, otype):
     np.random.seed(123)
     with suppress_warnings() as sup:

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -16,7 +16,7 @@ from. common_tests import (check_normalization, check_moment, check_mean_expect,
                            check_edge_support, check_named_args,
                            check_random_state_property,
                            check_meth_dtype, check_ppf_dtype, check_cmplx_deriv,
-                           check_pickling, check_rvs_broadcast)
+                           check_pickling, check_rvs_broadcast, check_freezing)
 from scipy.stats._distr_params import distcont
 
 """
@@ -153,6 +153,7 @@ def test_cont_basic(distname, arg):
         check_named_args(distfn, x, arg, locscale_defaults, meths)
         check_random_state_property(distfn, arg)
         check_pickling(distfn, arg)
+        check_freezing(distfn, arg)
 
         # Entropy
         if distname not in ['kstwobign']:

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -11,7 +11,7 @@ from .common_tests import (check_normalization, check_moment, check_mean_expect,
                            check_kurt_expect, check_entropy,
                            check_private_entropy, check_edge_support,
                            check_named_args, check_random_state_property,
-                           check_pickling, check_rvs_broadcast)
+                           check_pickling, check_rvs_broadcast, check_freezing)
 from scipy.stats._distr_params import distdiscrete
 
 vals = ([1, 2, 3, 4], [0.1, 0.2, 0.3, 0.4])
@@ -58,6 +58,7 @@ def test_discrete_basic(distname, arg, first_case):
             check_scale_docstring(distfn)
         check_random_state_property(distfn, arg)
         check_pickling(distfn, arg)
+        check_freezing(distfn, arg)
 
         # Entropy
         check_entropy(distfn, arg, distname)


### PR DESCRIPTION
closes gh-11089

Freezing some distributions fails if loc and/or scale are specified.
This is because not all distributions' `_get_support` accepts them
[and it should not, because it returns the support of an
unshifted, unscaled distribution]

Am adding the backport-candidate label since gh-11089 reports the issue in the maintenance/1.4.x branch.