### PR TITLE
BUG: scipy.sparse.csgraph: fixed issue #10774

### DIFF
--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -630,12 +630,12 @@ cdef _dijkstra_setup_heap_multi(FibonacciHeap *heap,
     heap.min_node = NULL
     for i in range(Nind):
         j_source = source_indices[i]
-        if nodes[j_source].state == SCANNED:
+        current_node = &nodes[j_source]
+        if current_node.state == SCANNED:
             continue
         dist_matrix[j_source] = 0
         if return_pred:
             sources[j_source] = j_source
-        current_node = &nodes[j_source]
         current_node.state = SCANNED
         current_node.source = j_source
         insert_node(heap, &nodes[j_source])

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -630,6 +630,8 @@ cdef _dijkstra_setup_heap_multi(FibonacciHeap *heap,
     heap.min_node = NULL
     for i in range(Nind):
         j_source = source_indices[i]
+        if nodes[j_source].state == SCANNED:
+            continue
         dist_matrix[j_source] = 0
         if return_pred:
             sources[j_source] = j_source

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -149,7 +149,7 @@ def test_undirected_sparse_zero():
 @pytest.mark.parametrize('directed, SP_ans',
                          ((True, directed_SP),
                           (False, undirected_SP)))
-@pytest.mark.parametrize('indices', ([0, 2, 4], [0, 4], [3, 4]))
+@pytest.mark.parametrize('indices', ([0, 2, 4], [0, 4], [3, 4], [0, 0]))
 def test_dijkstra_indices_min_only(directed, SP_ans, indices):
     SP_ans = np.array(SP_ans)
     indices = np.array(indices, dtype=np.int64)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #10774
#### What does this implement/fix?

When duplicate indices were passed to scipy.sparse.csgraph.djisktra with the min_only=True option the same vertex was added multiple times to the heap which later resulted in an infinite loop. Fixed by adding a check before insertion. 