### PR TITLE
MAINT: backports for 1.3.3

### DIFF
--- a/doc/release/1.3.3-notes.rst
+++ b/doc/release/1.3.3-notes.rst
@@ -5,13 +5,27 @@ SciPy 1.3.3 Release Notes
 .. contents::
 
 SciPy 1.3.3 is a bug-fix release with no new features
-compared to 1.3.2.
+compared to 1.3.2. In particular, a test suite issue
+involving multiprocessing was fixed for Windows and
+Python 3.8 on macOS. 
+
+Wheels were also updated to place msvcp140.dll at the 
+appropriate location, which was previously causing issues.
 
 Authors
 =======
 
+Ilhan Polat
+Tyler Reddy
+Ralf Gommers
+
 Issues closed for 1.3.3
 -----------------------
 
+* `#11033 <https://github.com/scipy/scipy/issues/11033>`__: deadlock on osx for python 3.8
+
+
 Pull requests for 1.3.3
 -----------------------
+
+* `#11034 <https://github.com/scipy/scipy/pull/11034>`__: MAINT: TST: Skip tests with multiprocessing that use "spawn" start method

--- a/scipy/_lib/tests/test__util.py
+++ b/scipy/_lib/tests/test__util.py
@@ -5,6 +5,7 @@ from multiprocessing.pool import Pool as PWL
 
 import numpy as np
 from numpy.testing import assert_equal, assert_
+import pytest
 from pytest import raises as assert_raises
 
 from scipy._lib._util import _aligned_zeros, check_random_state, MapWrapper
@@ -110,38 +111,3 @@ def test_mapwrapper_parallel():
         assert_equal(list(out), out_arg)
     finally:
         p.close()
-
-
-# get our custom ones and a few from the "import *" cases
-@pytest.mark.parametrize(
-    'key', ('fft', 'ifft', 'diag', 'arccos',
-            'randn', 'rand', 'array', 'finfo'))
-def test_numpy_deprecation(key):
-    """Test that 'from numpy import *' functions are deprecated."""
-    if key in ('fft', 'ifft', 'diag', 'arccos'):
-        arg = [1.0, 0.]
-    elif key == 'finfo':
-        arg = float
-    else:
-        arg = 2
-    func = getattr(scipy, key)
-    if key == 'fft':
-        match = r'scipy\.fft.*deprecated.*1.5.0.*'
-    else:
-        match = r'scipy\.%s is deprecated.*2\.0\.0' % key
-    with deprecated_call(match=match) as dep:
-        func(arg)  # deprecated
-    # in case we catch more than one dep warning
-    fnames = [os.path.splitext(d.filename)[0] for d in dep.list]
-    basenames = [os.path.basename(fname) for fname in fnames]
-    assert 'test__util' in basenames
-    if key in ('rand', 'randn'):
-        root = np.random
-    elif key in ('fft', 'ifft'):
-        root = np.fft
-    else:
-        root = np
-    func_np = getattr(root, key)
-    func_np(arg)  # not deprecated
-    assert func_np is not func
->>>>>>> 9eed43b78... MAINT:TST: Skipped tests that use spawn start method

--- a/scipy/_lib/tests/test__util.py
+++ b/scipy/_lib/tests/test__util.py
@@ -1,5 +1,6 @@
 from __future__ import division, print_function, absolute_import
-from multiprocessing import Pool
+
+from multiprocessing import Pool, get_start_method
 from multiprocessing.pool import Pool as PWL
 
 import numpy as np
@@ -58,52 +59,89 @@ def test_check_random_state():
     assert_raises(ValueError, check_random_state, 'a')
 
 
-class TestMapWrapper(object):
+def test_mapwrapper_serial():
+    in_arg = np.arange(10.)
+    out_arg = np.sin(in_arg)
 
-    def setup_method(self):
-        self.input = np.arange(10.)
-        self.output = np.sin(self.input)
+    p = MapWrapper(1)
+    assert_(p._mapfunc is map)
+    assert_(p.pool is None)
+    assert_(p._own_pool is False)
+    out = list(p(np.sin, in_arg))
+    assert_equal(out, out_arg)
 
-    def test_serial(self):
-        p = MapWrapper(1)
-        assert_(p._mapfunc is map)
-        assert_(p.pool is None)
-        assert_(p._own_pool is False)
-        out = list(p(np.sin, self.input))
-        assert_equal(out, self.output)
+    with assert_raises(RuntimeError):
+        p = MapWrapper(0)
 
-        with assert_raises(RuntimeError):
-            p = MapWrapper(0)
 
-    def test_parallel(self):
-        with MapWrapper(2) as p:
-            out = p(np.sin, self.input)
-            assert_equal(list(out), self.output)
+@pytest.mark.skipif(get_start_method() != 'fork',
+                    reason=('multiprocessing with spawn method is not'
+                            ' compatible with pytest.'))
+def test_mapwrapper_parallel():
+    in_arg = np.arange(10.)
+    out_arg = np.sin(in_arg)
 
-            assert_(p._own_pool is True)
-            assert_(isinstance(p.pool, PWL))
-            assert_(p._mapfunc is not None)
+    with MapWrapper(2) as p:
+        out = p(np.sin, in_arg)
+        assert_equal(list(out), out_arg)
 
-        # the context manager should've closed the internal pool
-        # check that it has by asking it to calculate again.
-        with assert_raises(Exception) as excinfo:
-            p(np.sin, self.input)
+        assert_(p._own_pool is True)
+        assert_(isinstance(p.pool, PWL))
+        assert_(p._mapfunc is not None)
 
-        # on py27 an AssertionError is raised, on >py27 it's a ValueError
-        err_type = excinfo.type
-        assert_((err_type is ValueError) or (err_type is AssertionError))
+    # the context manager should've closed the internal pool
+    # check that it has by asking it to calculate again.
+    with assert_raises(Exception) as excinfo:
+        p(np.sin, in_arg)
 
-        # can also set a PoolWrapper up with a map-like callable instance
-        try:
-            p = Pool(2)
-            q = MapWrapper(p.map)
+    assert_(excinfo.type is ValueError)
 
-            assert_(q._own_pool is False)
-            q.close()
+    # can also set a PoolWrapper up with a map-like callable instance
+    try:
+        p = Pool(2)
+        q = MapWrapper(p.map)
 
-            # closing the PoolWrapper shouldn't close the internal pool
-            # because it didn't create it
-            out = p.map(np.sin, self.input)
-            assert_equal(list(out), self.output)
-        finally:
-            p.close()
+        assert_(q._own_pool is False)
+        q.close()
+
+        # closing the PoolWrapper shouldn't close the internal pool
+        # because it didn't create it
+        out = p.map(np.sin, in_arg)
+        assert_equal(list(out), out_arg)
+    finally:
+        p.close()
+
+
+# get our custom ones and a few from the "import *" cases
+@pytest.mark.parametrize(
+    'key', ('fft', 'ifft', 'diag', 'arccos',
+            'randn', 'rand', 'array', 'finfo'))
+def test_numpy_deprecation(key):
+    """Test that 'from numpy import *' functions are deprecated."""
+    if key in ('fft', 'ifft', 'diag', 'arccos'):
+        arg = [1.0, 0.]
+    elif key == 'finfo':
+        arg = float
+    else:
+        arg = 2
+    func = getattr(scipy, key)
+    if key == 'fft':
+        match = r'scipy\.fft.*deprecated.*1.5.0.*'
+    else:
+        match = r'scipy\.%s is deprecated.*2\.0\.0' % key
+    with deprecated_call(match=match) as dep:
+        func(arg)  # deprecated
+    # in case we catch more than one dep warning
+    fnames = [os.path.splitext(d.filename)[0] for d in dep.list]
+    basenames = [os.path.basename(fname) for fname in fnames]
+    assert 'test__util' in basenames
+    if key in ('rand', 'randn'):
+        root = np.random
+    elif key in ('fft', 'ifft'):
+        root = np.fft
+    else:
+        root = np
+    func_np = getattr(root, key)
+    func_np(arg)  # not deprecated
+    assert func_np is not func
+>>>>>>> 9eed43b78... MAINT:TST: Skipped tests that use spawn start method

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -12,7 +12,7 @@ To run it in its simplest form::
 from __future__ import division, print_function, absolute_import
 
 import itertools
-
+import multiprocessing
 import numpy as np
 from numpy.testing import (assert_allclose, assert_equal,
                            assert_,
@@ -53,8 +53,13 @@ class CheckOptimize(object):
     (the machine translation example of Berger et al in
     Computational Linguistics, vol 22, num 1, pp 39--72, 1996.)
     """
+
     def setup_method(self):
-        self.F = np.array([[1,1,1],[1,1,0],[1,0,1],[1,0,0],[1,0,0]])
+        self.F = np.array([[1, 1, 1],
+                           [1, 1, 0],
+                           [1, 0, 1],
+                           [1, 0, 0],
+                           [1, 0, 0]])
         self.K = np.array([1., 0.3, 0.5])
         self.startparams = np.zeros(3, np.float64)
         self.solution = np.array([0., -0.524869316, 0.487525860])
@@ -152,7 +157,8 @@ class CheckOptimizeParameterized(CheckOptimize):
                                         args=(), maxiter=self.maxiter,
                                         full_output=True, disp=self.disp,
                                         retall=False)
-            (params, fopt, gopt, Hopt, func_calls, grad_calls, warnflag) = retval
+            (params, fopt, gopt, Hopt,
+             func_calls, grad_calls, warnflag) = retval
 
         assert_allclose(self.func(params), self.func(self.solution),
                         atol=1e-6)
@@ -233,14 +239,14 @@ class CheckOptimizeParameterized(CheckOptimize):
                     'return_all': False}
             res = optimize.minimize(self.func, self.startparams, args=(),
                                     method='Nelder-mead', options=opts)
-            params, fopt, numiter, func_calls, warnflag, final_simplex = (
+            params, fopt, numiter, func_calls, warnflag = (
                     res['x'], res['fun'], res['nit'], res['nfev'],
-                    res['status'], res['final_simplex'])
+                    res['status'])
         else:
             retval = optimize.fmin(self.func, self.startparams,
-                                        args=(), maxiter=self.maxiter,
-                                        full_output=True, disp=self.disp,
-                                        retall=False)
+                                   args=(), maxiter=self.maxiter,
+                                   full_output=True, disp=self.disp,
+                                   retall=False)
             (params, fopt, numiter, func_calls, warnflag) = retval
 
         assert_allclose(self.func(params), self.func(self.solution),
@@ -262,22 +268,24 @@ class CheckOptimizeParameterized(CheckOptimize):
         simplex = np.zeros((4, 3))
         simplex[...] = self.startparams
         for j in range(3):
-            simplex[j+1,j] += 0.1
+            simplex[j+1, j] += 0.1
 
         if self.use_wrapper:
             opts = {'maxiter': self.maxiter, 'disp': False,
                     'return_all': True, 'initial_simplex': simplex}
             res = optimize.minimize(self.func, self.startparams, args=(),
                                     method='Nelder-mead', options=opts)
-            params, fopt, numiter, func_calls, warnflag = \
-                    res['x'], res['fun'], res['nit'], res['nfev'], \
-                    res['status']
+            params, fopt, numiter, func_calls, warnflag = (res['x'],
+                                                           res['fun'],
+                                                           res['nit'],
+                                                           res['nfev'],
+                                                           res['status'])
             assert_allclose(res['allvecs'][0], simplex[0])
         else:
             retval = optimize.fmin(self.func, self.startparams,
-                                        args=(), maxiter=self.maxiter,
-                                        full_output=True, disp=False, retall=False,
-                                        initial_simplex=simplex)
+                                   args=(), maxiter=self.maxiter,
+                                   full_output=True, disp=False, retall=False,
+                                   initial_simplex=simplex)
 
             (params, fopt, numiter, func_calls, warnflag) = retval
 
@@ -302,7 +310,7 @@ class CheckOptimizeParameterized(CheckOptimize):
         simplex = np.zeros((3, 2))
         simplex[...] = self.startparams[:2]
         for j in range(2):
-            simplex[j+1,j] += 0.1
+            simplex[j+1, j] += 0.1
         bad_simplices.append(simplex)
 
         simplex = np.zeros((3, 3))
@@ -313,10 +321,15 @@ class CheckOptimizeParameterized(CheckOptimize):
                 opts = {'maxiter': self.maxiter, 'disp': False,
                         'return_all': False, 'initial_simplex': simplex}
                 assert_raises(ValueError,
-                              optimize.minimize, self.func, self.startparams, args=(),
-                              method='Nelder-mead', options=opts)
+                              optimize.minimize,
+                              self.func,
+                              self.startparams,
+                              args=(),
+                              method='Nelder-mead',
+                              options=opts)
             else:
-                assert_raises(ValueError, optimize.fmin, self.func, self.startparams,
+                assert_raises(ValueError, optimize.fmin,
+                              self.func, self.startparams,
                               args=(), maxiter=self.maxiter,
                               full_output=True, disp=False, retall=False,
                               initial_simplex=simplex)
@@ -352,9 +365,9 @@ class CheckOptimizeParameterized(CheckOptimize):
         # SciPy 0.7.0. Don't allow them to increase.
         assert_(self.funccalls == 7, self.funccalls)
         assert_(self.gradcalls <= 22, self.gradcalls)  # 0.13.0
-        #assert_(self.gradcalls <= 18, self.gradcalls) # 0.9.0
-        #assert_(self.gradcalls == 18, self.gradcalls) # 0.8.0
-        #assert_(self.gradcalls == 22, self.gradcalls) # 0.7.0
+        # assert_(self.gradcalls <= 18, self.gradcalls) # 0.9.0
+        # assert_(self.gradcalls == 18, self.gradcalls) # 0.8.0
+        # assert_(self.gradcalls == 22, self.gradcalls) # 0.7.0
 
         # Ensure that the function behaves the same; this is from SciPy 0.7.0
         assert_allclose(self.trace[3:5],
@@ -431,6 +444,14 @@ class CheckOptimizeParameterized(CheckOptimize):
                         atol=1e-6, rtol=1e-7)
 
 
+def test_obj_func_returns_scalar():
+    match = ("The user-provided "
+             "objective function must "
+             "return a scalar value.")
+    with assert_raises(ValueError, match=match):
+        optimize.minimize(lambda x: x, np.array([1, 1]))
+
+
 def test_neldermead_xatol_fatol():
     # gh4484
     # test we can call with fatol, xatol specified
@@ -442,18 +463,20 @@ def test_neldermead_xatol_fatol():
                  optimize._minimize._minimize_neldermead,
                  func, [1, 1], xtol=1e-3, ftol=1e-3, maxiter=2)
 
+
 def test_neldermead_adaptive():
     func = lambda x: np.sum(x**2)
-    p0 = [0.15746215, 0.48087031, 0.44519198, 0.4223638, 0.61505159, 0.32308456,
-      0.9692297, 0.4471682, 0.77411992, 0.80441652, 0.35994957, 0.75487856,
-      0.99973421, 0.65063887, 0.09626474]
-   
+    p0 = [0.15746215, 0.48087031, 0.44519198, 0.4223638, 0.61505159,
+          0.32308456, 0.9692297, 0.4471682, 0.77411992, 0.80441652,
+          0.35994957, 0.75487856, 0.99973421, 0.65063887, 0.09626474]
+
     res = optimize.minimize(func, p0, method='Nelder-Mead')
     assert_equal(res.success, False)
- 
+
     res = optimize.minimize(func, p0, method='Nelder-Mead',
-                    options={'adaptive':True})
+                            options={'adaptive': True})
     assert_equal(res.success, True)
+
 
 class TestOptimizeWrapperDisp(CheckOptimizeParameterized):
     use_wrapper = True
@@ -509,7 +532,7 @@ class TestOptimizeSimple(CheckOptimize):
     def test_bfgs_numerical_jacobian(self):
         # BFGS with numerical jacobian and a vector epsilon parameter.
         # define the epsilon parameter using a random vector
-        epsilon = np.sqrt(np.finfo(float).eps) * np.random.rand(len(self.solution))
+        epsilon = np.sqrt(np.spacing(1.)) * np.random.rand(len(self.solution))
 
         params = optimize.fmin_bfgs(self.func, self.startparams,
                                     epsilon=epsilon, args=(),
@@ -596,7 +619,8 @@ class TestOptimizeSimple(CheckOptimize):
         assert_almost_equal(res.fun, c.fun)
         assert_equal(res.status, 1)
         assert_(res.success is False)
-        assert_equal(res.message.decode(), 'STOP: TOTAL NO. of ITERATIONS REACHED LIMIT')
+        assert_equal(res.message.decode(),
+                     'STOP: TOTAL NO. of ITERATIONS REACHED LIMIT')
 
     def test_minimize_l_bfgs_b(self):
         # Minimize with L-BFGS-B method
@@ -633,7 +657,7 @@ class TestOptimizeSimple(CheckOptimize):
 
     def test_minimize_l_bfgs_maxls(self):
         # check that the maxls is passed down to the Fortran routine
-        sol = optimize.minimize(optimize.rosen, np.array([-1.2,1.0]),
+        sol = optimize.minimize(optimize.rosen, np.array([-1.2, 1.0]),
                                 method='L-BFGS-B', jac=optimize.rosen_der,
                                 options={'disp': False, 'maxls': 1})
         assert_(not sol.success)
@@ -667,7 +691,7 @@ class TestOptimizeSimple(CheckOptimize):
     def test_custom(self):
         # This function comes from the documentation example.
         def custmin(fun, x0, args=(), maxfev=None, stepsize=0.1,
-                maxiter=100, callback=None, **options):
+                    maxiter=100, callback=None, **options):
             bestx = x0
             besty = fun(x0)
             funcalls = 1
@@ -783,13 +807,16 @@ class TestOptimizeSimple(CheckOptimize):
 
         sol = routine(func, x0, callback=callback, **kwargs)
 
-        # Check returned arrays coincide with their copies and have no memory overlap
+        # Check returned arrays coincide with their copies
+        # and have no memory overlap
         assert_(len(results) > 2)
         assert_(all(np.all(x == y) for x, y in results))
-        assert_(not any(np.may_share_memory(x[0], y[0]) for x, y in itertools.combinations(results, 2)))
+        assert_(not any(np.may_share_memory(x[0], y[0])
+                        for x, y in itertools.combinations(results, 2)))
 
-    @pytest.mark.parametrize('method', ['nelder-mead', 'powell', 'cg', 'bfgs', 'newton-cg',
-                              'l-bfgs-b', 'tnc', 'cobyla', 'slsqp'])
+    @pytest.mark.parametrize('method', ['nelder-mead', 'powell', 'cg',
+                                        'bfgs', 'newton-cg', 'l-bfgs-b',
+                                        'tnc', 'cobyla', 'slsqp'])
     def test_no_increase(self, method):
         # Check that the solver doesn't return a value worse than the
         # initial point.
@@ -838,10 +865,15 @@ class TestOptimizeSimple(CheckOptimize):
 
         x0 = np.array([10.])
         sol_0 = optimize.minimize(f, x0)
-        sol_1 = optimize.minimize(f, x0, constraints=[{'type': 'ineq', 'fun': cons}])
+        sol_1 = optimize.minimize(f, x0, constraints=[{'type': 'ineq',
+                                                       'fun': cons}])
         sol_2 = optimize.minimize(f, x0, bounds=[(5, 10)])
-        sol_3 = optimize.minimize(f, x0, constraints=[{'type': 'ineq', 'fun': cons}], bounds=[(5, 10)])
-        sol_4 = optimize.minimize(f, x0, constraints=[{'type': 'ineq', 'fun': cons}], bounds=[(1, 10)])
+        sol_3 = optimize.minimize(f, x0,
+                                  constraints=[{'type': 'ineq', 'fun': cons}],
+                                  bounds=[(5, 10)])
+        sol_4 = optimize.minimize(f, x0,
+                                  constraints=[{'type': 'ineq', 'fun': cons}],
+                                  bounds=[(1, 10)])
         for sol in [sol_0, sol_1, sol_2, sol_3, sol_4]:
             assert_(sol.success)
         assert_allclose(sol_0.x, 0, atol=1e-7)
@@ -894,7 +926,8 @@ class TestOptimizeSimple(CheckOptimize):
             res = optimize.minimize(f, x0, jac=g, method=method,
                                     options=options)
 
-            err_msg = "{0} {1}: {2}: {3}".format(method, scale, first_step_size,
+            err_msg = "{0} {1}: {2}: {3}".format(method, scale,
+                                                 first_step_size,
                                                  res)
 
             assert_(res.success, err_msg)
@@ -905,18 +938,20 @@ class TestOptimizeSimple(CheckOptimize):
                 if method in ('CG', 'BFGS'):
                     assert_allclose(first_step_size[0], 1.01, err_msg=err_msg)
                 else:
-                    # Newton-CG and L-BFGS-B use different logic for the first step,
-                    # but are both scaling invariant with step sizes ~ 1
-                    assert_(first_step_size[0] > 0.5 and first_step_size[0] < 3,
-                            err_msg)
+                    # Newton-CG and L-BFGS-B use different logic for the first
+                    # step, but are both scaling invariant with step sizes ~ 1
+                    assert_(first_step_size[0] > 0.5 and
+                            first_step_size[0] < 3, err_msg)
             else:
                 # step size has upper bound of ||grad||, so line
                 # search makes many small steps
                 pass
 
-    @pytest.mark.parametrize('method', ['nelder-mead', 'powell', 'cg', 'bfgs', 'newton-cg',
-                                        'l-bfgs-b', 'tnc', 'cobyla', 'slsqp', 'trust-constr',
-                                        'dogleg', 'trust-ncg', 'trust-exact', 'trust-krylov'])
+    @pytest.mark.parametrize('method', ['nelder-mead', 'powell', 'cg', 'bfgs',
+                                        'newton-cg', 'l-bfgs-b', 'tnc',
+                                        'cobyla', 'slsqp', 'trust-constr',
+                                        'dogleg', 'trust-ncg', 'trust-exact',
+                                        'trust-krylov'])
     def test_nan_values(self, method):
         # Check nan values result to failed exit status
         np.random.seed(1234)
@@ -941,8 +976,10 @@ class TestOptimizeSimple(CheckOptimize):
 
         x0 = np.array([1.0])
 
-        needs_grad = method in ('newton-cg', 'trust-krylov', 'trust-exact', 'trust-ncg', 'dogleg')
-        needs_hess = method in ('trust-krylov', 'trust-exact', 'trust-ncg', 'dogleg')
+        needs_grad = method in ('newton-cg', 'trust-krylov', 'trust-exact',
+                                'trust-ncg', 'dogleg')
+        needs_hess = method in ('trust-krylov', 'trust-exact', 'trust-ncg',
+                                'dogleg')
 
         funcs = [func, func2]
         grads = [grad] if needs_grad else [grad, None]
@@ -955,7 +992,8 @@ class TestOptimizeSimple(CheckOptimize):
 
             for f, g, h in itertools.product(funcs, grads, hesss):
                 count = [0]
-                sol = optimize.minimize(f, x0, jac=g, hess=h, method=method, options=dict(maxiter=20))
+                sol = optimize.minimize(f, x0, jac=g, hess=h, method=method,
+                                        options=dict(maxiter=20))
                 assert_equal(sol.success, False)
 
 
@@ -1070,15 +1108,15 @@ class TestOptimizeScalar(object):
         assert_(not x.success)
 
         x = optimize.minimize_scalar(self.fun, bracket=(-3, -2),
-                                    args=(1.5, ), method='Brent').x
+                                     args=(1.5, ), method='Brent').x
         assert_allclose(x, self.solution, atol=1e-6)
 
         x = optimize.minimize_scalar(self.fun, method='Brent',
-                                    args=(1.5,)).x
+                                     args=(1.5,)).x
         assert_allclose(x, self.solution, atol=1e-6)
 
         x = optimize.minimize_scalar(self.fun, bracket=(-15, -1, 15),
-                                    args=(1.5, ), method='Brent').x
+                                     args=(1.5, ), method='Brent').x
         assert_allclose(x, self.solution, atol=1e-6)
 
         x = optimize.minimize_scalar(self.fun, bracket=(-3, -2),
@@ -1098,13 +1136,13 @@ class TestOptimizeScalar(object):
         assert_allclose(x, 1, atol=1e-4)
 
         x = optimize.minimize_scalar(self.fun, bounds=(1, 5), args=(1.5, ),
-                                    method='bounded').x
+                                     method='bounded').x
         assert_allclose(x, self.solution, atol=1e-6)
 
         x = optimize.minimize_scalar(self.fun, bounds=(np.array([1]),
-                                                      np.array([5])),
-                                    args=(np.array([1.5]), ),
-                                    method='bounded').x
+                                                       np.array([5])),
+                                     args=(np.array([1.5]), ),
+                                     method='bounded').x
         assert_allclose(x, self.solution, atol=1e-6)
 
         assert_raises(ValueError, optimize.minimize_scalar, self.fun,
@@ -1120,7 +1158,7 @@ class TestOptimizeScalar(object):
     def test_minimize_scalar_custom(self):
         # This function comes from the documentation example.
         def custmin(fun, bracket, args=(), maxfev=None, stepsize=0.1,
-                maxiter=100, callback=None, **options):
+                    maxiter=100, callback=None, **options):
             bestx = (bracket[1] + bracket[0]) / 2.0
             besty = fun(bestx)
             funcalls = 1
@@ -1147,7 +1185,8 @@ class TestOptimizeScalar(object):
             return optimize.OptimizeResult(fun=besty, x=bestx, nit=niter,
                                            nfev=funcalls, success=(niter > 1))
 
-        res = optimize.minimize_scalar(self.fun, bracket=(0, 4), method=custmin,
+        res = optimize.minimize_scalar(self.fun, bracket=(0, 4),
+                                       method=custmin,
                                        options=dict(stepsize=0.05))
         assert_allclose(res.x, self.solution, atol=1e-6)
 
@@ -1178,7 +1217,8 @@ class TestOptimizeScalar(object):
             sup.filter(RuntimeWarning, ".*does not use gradient.*")
 
             count = [0]
-            sol = optimize.minimize_scalar(func, bracket=bracket, bounds=bounds, method=method,
+            sol = optimize.minimize_scalar(func, bracket=bracket,
+                                           bounds=bounds, method=method,
                                            options=dict(maxiter=20))
             assert_equal(sol.success, False)
 
@@ -1292,7 +1332,8 @@ class TestOptimizeResultAttributes(object):
         for method in methods:
             with suppress_warnings() as sup:
                 sup.filter(RuntimeWarning,
-                           "Method .+ does not use (gradient|Hessian.*) information")
+                           ("Method .+ does not use (gradient|Hessian.*)"
+                            " information"))
                 res = optimize.minimize(self.func, self.x0, method=method,
                                         jac=self.jac, hess=self.hess,
                                         hessp=self.hessp)
@@ -1370,13 +1411,16 @@ class TestBrute:
 
         optimize.brute(f, [(-1, 1)], Ns=3, finish=None)
 
+    @pytest.mark.skipif(multiprocessing.get_start_method() != 'fork',
+                        reason=('multiprocessing with spawn method is not'
+                                ' compatible with pytest.'))
     def test_workers(self):
         # check that parallel evaluation works
         resbrute = optimize.brute(brute_func, self.rranges, args=self.params,
                                   full_output=True, finish=None)
 
         resbrute1 = optimize.brute(brute_func, self.rranges, args=self.params,
-                                  full_output=True, finish=None, workers=2)
+                                   full_output=True, finish=None, workers=2)
 
         assert_allclose(resbrute1[-1], resbrute[-1])
         assert_allclose(resbrute1[0], resbrute[0])
@@ -1391,7 +1435,7 @@ class TestIterationLimits(object):
 
     def slow_func(self, v):
         self.funcalls += 1
-        r,t = np.sqrt(v[0]**2+v[1]**2), np.arctan2(v[0],v[1])
+        r, t = np.sqrt(v[0]**2+v[1]**2), np.arctan2(v[0], v[1])
         return np.sin(r*20 + t)+r*0.5
 
     def test_neldermead_limit(self):
@@ -1401,36 +1445,42 @@ class TestIterationLimits(object):
         self.check_limits("powell", 1000)
 
     def check_limits(self, method, default_iters):
-        for start_v in [[0.1,0.1], [1,1], [2,2]]:
+        for start_v in [[0.1, 0.1], [1, 1], [2, 2]]:
             for mfev in [50, 500, 5000]:
                 self.funcalls = 0
                 res = optimize.minimize(self.slow_func, start_v,
-                      method=method, options={"maxfev":mfev})
+                                        method=method,
+                                        options={"maxfev": mfev})
                 assert_(self.funcalls == res["nfev"])
                 if res["success"]:
                     assert_(res["nfev"] < mfev)
                 else:
                     assert_(res["nfev"] >= mfev)
-            for mit in [50, 500,5000]:
+            for mit in [50, 500, 5000]:
                 res = optimize.minimize(self.slow_func, start_v,
-                      method=method, options={"maxiter":mit})
+                                        method=method,
+                                        options={"maxiter": mit})
                 if res["success"]:
                     assert_(res["nit"] <= mit)
                 else:
                     assert_(res["nit"] >= mit)
-            for mfev,mit in [[50,50], [5000,5000],[5000,np.inf]]:
+            for mfev, mit in [[50, 50], [5000, 5000], [5000, np.inf]]:
                 self.funcalls = 0
                 res = optimize.minimize(self.slow_func, start_v,
-                      method=method, options={"maxiter":mit, "maxfev":mfev})
+                                        method=method,
+                                        options={"maxiter": mit,
+                                                 "maxfev": mfev})
                 assert_(self.funcalls == res["nfev"])
                 if res["success"]:
                     assert_(res["nfev"] < mfev and res["nit"] <= mit)
                 else:
                     assert_(res["nfev"] >= mfev or res["nit"] >= mit)
-            for mfev,mit in [[np.inf,None], [None,np.inf]]:
+            for mfev, mit in [[np.inf, None], [None, np.inf]]:
                 self.funcalls = 0
                 res = optimize.minimize(self.slow_func, start_v,
-                      method=method, options={"maxiter":mit, "maxfev":mfev})
+                                        method=method,
+                                        options={"maxiter": mit,
+                                                 "maxfev": mfev})
                 assert_(self.funcalls == res["nfev"])
                 if res["success"]:
                     if mfev is None:
@@ -1439,4 +1489,4 @@ class TestIterationLimits(object):
                         assert_(res["nit"] <= default_iters*2)
                 else:
                     assert_(res["nfev"] >= default_iters*2 or
-                        res["nit"] >= default_iters*2)
+                            res["nit"] >= default_iters*2)

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -444,14 +444,6 @@ class CheckOptimizeParameterized(CheckOptimize):
                         atol=1e-6, rtol=1e-7)
 
 
-def test_obj_func_returns_scalar():
-    match = ("The user-provided "
-             "objective function must "
-             "return a scalar value.")
-    with assert_raises(ValueError, match=match):
-        optimize.minimize(lambda x: x, np.array([1, 1]))
-
-
 def test_neldermead_xatol_fatol():
     # gh4484
     # test we can call with fatol, xatol specified


### PR DESCRIPTION
Backports:

#11034 

`1.3.3` will aim to fix the Python 3.8/Windows multiprocessing issues in the test suite & the DLL problem fixed in wheels repo: https://github.com/MacPython/scipy-wheels/pull/59

@ilayn @rgommers 

- Do release notes look "ok" for this single PR backport/release?
-  The merge conflicts were pretty brutal, so do skim over (the noise from apparent whitespace changes isn't helpful here either)