### PR TITLE
ENH: special: Cythonise erfinv, erfcinv

### DIFF
--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -34,8 +34,6 @@ __all__ = [
     'digamma',
     'diric',
     'erf_zeros',
-    'erfcinv',
-    'erfinv',
     'euler',
     'factorial',
     'factorial2',
@@ -805,87 +803,6 @@ def riccati_yn(n, x):
         n1 = n
     nm, jn, jnp = specfun.rcty(n1, x)
     return jn[:(n+1)], jnp[:(n+1)]
-
-
-def erfinv(y):
-    """Inverse of the error function erf.
-
-    Computes the inverse of the error function.
-
-    In complex domain, there is no unique complex number w satisfying erf(w)=z.
-    This indicates a true inverse function would have multi-value. When the domain restricts to the real, -1 < x < 1,
-    there is a unique real number satisfying erf(erfinv(x)) = x.
-
-    Parameters
-    ----------
-    y : ndarray
-        Argument at which to evaluate. Domain: [-1, 1]
-
-    Returns
-    -------
-    erfinv : ndarray
-        The inverse of erf of y, element-wise
-
-    Examples
-    --------
-    1) evaluating a float number
-
-    >>> from scipy import special
-    >>> special.erfinv(0.5)
-    0.4769362762044698
-
-    2) evaluating a ndarray
-
-    >>> from scipy import special
-    >>> y = np.linspace(-1.0, 1.0, num=10)
-    >>> special.erfinv(y)
-    array([       -inf, -0.86312307, -0.5407314 , -0.30457019, -0.0987901 ,
-            0.0987901 ,  0.30457019,  0.5407314 ,  0.86312307,         inf])
-
-    """
-    return ndtri((y+1)/2.0)/sqrt(2)
-
-
-def erfcinv(y):
-    """Inverse of the complementary error function erfc.
-
-    Computes the inverse of the complementary error function erfc.
-
-    In complex domain, there is no unique complex number w satisfying erfc(w)=z.
-    This indicates a true inverse function would have multi-value. When the domain restricts to the real, 0 < x < 2,
-    there is a unique real number satisfying erfc(erfcinv(x)) = erfcinv(erfc(x)).
-
-    It is related to inverse of the error function by erfcinv(1-x) = erfinv(x)
-
-    Parameters
-    ----------
-    y : ndarray
-        Argument at which to evaluate. Domain: [0, 2]
-
-    Returns
-    -------
-    erfcinv : ndarray
-        The inverse of erfc of y, element-wise
-
-    Examples
-    --------
-    1) evaluating a float number
-
-    >>> from scipy import special
-    >>> special.erfcinv(0.5)
-    0.4769362762044698
-
-    2) evaluating a ndarray
-
-    >>> from scipy import special
-    >>> y = np.linspace(0.0, 2.0, num=11)
-    >>> special.erfcinv(y)
-    array([        inf,  0.9061938 ,  0.59511608,  0.37080716,  0.17914345,
-            -0.        , -0.17914345, -0.37080716, -0.59511608, -0.9061938 ,
-                  -inf])
-
-    """
-    return -ndtri(0.5*y)/sqrt(2)
 
 
 def erf_zeros(nt):

--- a/scipy/special/_cephes.pxd
+++ b/scipy/special/_cephes.pxd
@@ -66,6 +66,8 @@ cdef extern from "cephes.h" nogil:
     double log_ndtr(double a)
     double erfc(double a)
     double erf(double x)
+    double erfinv(double y)
+    double erfcinv(double y)
     double ndtri(double y0)
     double pdtrc(double k, double m)
     double pdtr(double k, double m)

--- a/scipy/special/_erfinv.h
+++ b/scipy/special/_erfinv.h
@@ -1,0 +1,62 @@
+#ifndef ERF_INV_H
+#define ERF_INV_H
+
+/*
+ * mconf configures NANS, INFINITYs etc. for cephes and includes some standard
+ * headers. Although erfinv and erfcinv are not defined in cephes, erf and erfc
+ * are. We want to keep the behaviour consistent for the inverse functions and
+ * so need to include mconf.
+ */
+#include "cephes/mconf.h"
+
+/*
+ * Inverse of the error function.
+ *
+ * Computes the inverse of the error function on the restricted domain
+ * -1 < y < 1. This restriction ensures the existence of a unique result
+ * such that erf(erfinv(y)) = y.
+ */
+double erfinv(double y) {
+    if (cephes_isnan(y)) {
+        sf_error("erfinv", SF_ERROR_DOMAIN, NULL);
+        return NPY_NAN;
+    }
+    else if (y <= -1) {
+        sf_error("erfinv", SF_ERROR_DOMAIN, NULL);
+        return -NPY_INFINITY;
+    }
+    else if (y >= 1) {
+        sf_error("erfinv", SF_ERROR_DOMAIN, NULL);
+        return NPY_INFINITY;
+    }
+    else {
+        return ndtri(0.5 * (y+1)) * NPY_SQRT1_2;
+    }
+}
+
+/*
+ * Inverse of the complementary error function.
+ *
+ * Computes the inverse of the complimentary error function on the restricted
+ * domain 0 < y < 2. This restriction ensures the existence of a unique result
+ * such that erfc(erfcinv(y)) = y.
+ */
+double erfcinv(double y) {
+    if (cephes_isnan(y)) {
+        sf_error("erfcinv", SF_ERROR_DOMAIN, NULL);
+        return NPY_NAN;
+    }
+    else if (y <= 0) {
+        sf_error("erfcinv", SF_ERROR_DOMAIN, NULL);
+        return NPY_INFINITY;
+    }
+    else if (y >= 2) {
+        sf_error("erfcinv", SF_ERROR_DOMAIN, NULL);
+        return -NPY_INFINITY;
+    }
+    else {
+        return -ndtri(0.5 * y) * NPY_SQRT1_2;
+    }
+}
+
+#endif // ERF_INV_H

--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -1944,9 +1944,9 @@ add_newdoc("erfinv",
 
     See Also
     --------
-        erf : Error function of a complex argument
-        erfc : Complementary error function, ``1 - erf(x)``
-        erfcinv : Inverse of the complementary error function
+    erf : Error function of a complex argument
+    erfc : Complementary error function, ``1 - erf(x)``
+    erfcinv : Inverse of the complementary error function
 
     Examples
     --------
@@ -1990,9 +1990,9 @@ add_newdoc("erfcinv",
 
     See Also
     --------
-        erf : Error function of a complex argument
-        erfc : Complementary error function, ``1 - erf(x)``
-        erfinv : Inverse of the error function
+    erf : Error function of a complex argument
+    erfc : Complementary error function, ``1 - erf(x)``
+    erfinv : Inverse of the error function
 
     Examples
     --------

--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -1922,6 +1922,97 @@ add_newdoc("erfcx",
 
     """)
 
+add_newdoc("erfinv",
+    """Inverse of the error function.
+
+    Computes the inverse of the error function.
+
+    In the complex domain, there is no unique complex number w satisfying
+    erf(w)=z. This indicates a true inverse function would have multi-value.
+    When the domain restricts to the real, -1 < x < 1, there is a unique real
+    number satisfying erf(erfinv(x)) = x.
+
+    Parameters
+    ----------
+    y : ndarray
+        Argument at which to evaluate. Domain: [-1, 1]
+
+    Returns
+    -------
+    erfinv : ndarray
+        The inverse of erf of y, element-wise)
+
+    See Also
+    --------
+        erf : Error function of a complex argument
+        erfc : Complementary error function, ``1 - erf(x)``
+        erfcinv : Inverse of the complementary error function
+
+    Examples
+    --------
+    1) evaluating a float number
+
+    >>> from scipy import special
+    >>> special.erfinv(0.5)
+    0.4769362762044698
+
+    2) evaluating an ndarray
+
+    >>> from scipy import special
+    >>> y = np.linspace(-1.0, 1.0, num=10)
+    >>> special.erfinv(y)
+    array([       -inf, -0.86312307, -0.5407314 , -0.30457019, -0.0987901 ,
+            0.0987901 ,  0.30457019,  0.5407314 ,  0.86312307,         inf])
+
+    """)
+
+add_newdoc("erfcinv",
+    """Inverse of the complementary error function.
+
+    Computes the inverse of the complementary error function.
+
+    In the complex domain, there is no unique complex number w satisfying
+    erfc(w)=z. This indicates a true inverse function would have multi-value.
+    When the domain restricts to the real, 0 < x < 2, there is a unique real
+    number satisfying erfc(erfcinv(x)) = erfcinv(erfc(x)).
+
+    It is related to inverse of the error function by erfcinv(1-x) = erfinv(x)
+
+    Parameters
+    ----------
+    y : ndarray
+        Argument at which to evaluate. Domain: [0, 2]
+
+    Returns
+    -------
+    erfcinv : ndarray
+        The inverse of erfc of y, element-wise
+
+    See Also
+    --------
+        erf : Error function of a complex argument
+        erfc : Complementary error function, ``1 - erf(x)``
+        erfinv : Inverse of the error function
+
+    Examples
+    --------
+    1) evaluating a float number
+
+    >>> from scipy import special
+    >>> special.erfcinv(0.5)
+    0.4769362762044698
+
+    2) evaluating an ndarray
+
+    >>> from scipy import special
+    >>> y = np.linspace(0.0, 2.0, num=11)
+    >>> special.erfcinv(y)
+    array([        inf,  0.9061938 ,  0.59511608,  0.37080716,  0.17914345,
+           -0.        , -0.17914345, -0.37080716, -0.59511608, -0.9061938 ,
+                  -inf])
+
+    """)
+
 add_newdoc("eval_jacobi",
     r"""
     eval_jacobi(n, alpha, beta, x, out=None)

--- a/scipy/special/cephes.h
+++ b/scipy/special/cephes.h
@@ -92,6 +92,8 @@ extern double ndtr(double a);
 extern double log_ndtr(double a);
 extern double erfc(double a);
 extern double erf(double x);
+extern double erfinv(double y);
+extern double erfcinv(double y);
 extern double ndtri(double y0);
 
 extern double pdtrc(double k, double m);

--- a/scipy/special/cephes/cephes_names.h
+++ b/scipy/special/cephes/cephes_names.h
@@ -64,6 +64,8 @@
 #define ndtr cephes_ndtr
 #define erfc cephes_erfc
 #define erf cephes_erf
+#define erfinv cephes_erfinv
+#define erfcinv cephes_erfcinv
 #define ndtri cephes_ndtri
 #define pdtrc cephes_pdtrc
 #define pdtr cephes_pdtr

--- a/scipy/special/cephes/erfinv.c
+++ b/scipy/special/cephes/erfinv.c
@@ -20,17 +20,15 @@ double erfinv(double y) {
     if ((domain_lb < y) && (y < domain_ub)) {
         return ndtri(0.5 * (y+1)) * NPY_SQRT1_2;
     }
-    else if (cephes_isnan(y)) {
-        sf_error("erfinv", SF_ERROR_DOMAIN, NULL);
-        return y;
-    }
     else if (y == domain_lb) {
-        sf_error("erfinv", SF_ERROR_DOMAIN, NULL);
         return -NPY_INFINITY;
     }
     else if (y == domain_ub) {
-        sf_error("erfinv", SF_ERROR_DOMAIN, NULL);
         return NPY_INFINITY;
+    }
+    else if (cephes_isnan(y)) {
+        sf_error("erfinv", SF_ERROR_DOMAIN, NULL);
+        return y;
     }
     else {
         sf_error("erfinv", SF_ERROR_DOMAIN, NULL);
@@ -52,17 +50,15 @@ double erfcinv(double y) {
     if ((domain_lb < y) && (y < domain_ub)) {
         return -ndtri(0.5 * y) * NPY_SQRT1_2;
     }
-    else if (cephes_isnan(y)) {
-        sf_error("erfcinv", SF_ERROR_DOMAIN, NULL);
-        return y;
-    }
     else if (y == domain_lb) {
-        sf_error("erfcinv", SF_ERROR_DOMAIN, NULL);
         return NPY_INFINITY;
     }
     else if (y == domain_ub) {
-        sf_error("erfcinv", SF_ERROR_DOMAIN, NULL);
         return -NPY_INFINITY;
+    }
+    else if (cephes_isnan(y)) {
+        sf_error("erfcinv", SF_ERROR_DOMAIN, NULL);
+        return y;
     }
     else {
         sf_error("erfcinv", SF_ERROR_DOMAIN, NULL);

--- a/scipy/special/cephes/erfinv.c
+++ b/scipy/special/cephes/erfinv.c
@@ -1,13 +1,10 @@
-#ifndef ERF_INV_H
-#define ERF_INV_H
-
 /*
  * mconf configures NANS, INFINITYs etc. for cephes and includes some standard
  * headers. Although erfinv and erfcinv are not defined in cephes, erf and erfc
  * are. We want to keep the behaviour consistent for the inverse functions and
  * so need to include mconf.
  */
-#include "cephes/mconf.h"
+#include "mconf.h"
 
 /*
  * Inverse of the error function.
@@ -17,20 +14,27 @@
  * such that erf(erfinv(y)) = y.
  */
 double erfinv(double y) {
-    if (cephes_isnan(y)) {
-        sf_error("erfinv", SF_ERROR_DOMAIN, NULL);
-        return NPY_NAN;
+    const double domain_lb = -1;
+    const double domain_ub = 1;
+
+    if ((domain_lb < y) && (y < domain_ub)) {
+        return ndtri(0.5 * (y+1)) * NPY_SQRT1_2;
     }
-    else if (y <= -1) {
+    else if (cephes_isnan(y)) {
+        sf_error("erfinv", SF_ERROR_DOMAIN, NULL);
+        return y;
+    }
+    else if (y == domain_lb) {
         sf_error("erfinv", SF_ERROR_DOMAIN, NULL);
         return -NPY_INFINITY;
     }
-    else if (y >= 1) {
+    else if (y == domain_ub) {
         sf_error("erfinv", SF_ERROR_DOMAIN, NULL);
         return NPY_INFINITY;
     }
     else {
-        return ndtri(0.5 * (y+1)) * NPY_SQRT1_2;
+        sf_error("erfinv", SF_ERROR_DOMAIN, NULL);
+        return NPY_NAN;
     }
 }
 
@@ -42,21 +46,26 @@ double erfinv(double y) {
  * such that erfc(erfcinv(y)) = y.
  */
 double erfcinv(double y) {
-    if (cephes_isnan(y)) {
-        sf_error("erfcinv", SF_ERROR_DOMAIN, NULL);
-        return NPY_NAN;
+    const double domain_lb = 0;
+    const double domain_ub = 2;
+
+    if ((domain_lb < y) && (y < domain_ub)) {
+        return -ndtri(0.5 * y) * NPY_SQRT1_2;
     }
-    else if (y <= 0) {
+    else if (cephes_isnan(y)) {
+        sf_error("erfcinv", SF_ERROR_DOMAIN, NULL);
+        return y;
+    }
+    else if (y == domain_lb) {
         sf_error("erfcinv", SF_ERROR_DOMAIN, NULL);
         return NPY_INFINITY;
     }
-    else if (y >= 2) {
+    else if (y == domain_ub) {
         sf_error("erfcinv", SF_ERROR_DOMAIN, NULL);
         return -NPY_INFINITY;
     }
     else {
-        return -ndtri(0.5 * y) * NPY_SQRT1_2;
+        sf_error("erfcinv", SF_ERROR_DOMAIN, NULL);
+        return NPY_NAN;
     }
 }
-
-#endif // ERF_INV_H

--- a/scipy/special/functions.json
+++ b/scipy/special/functions.json
@@ -383,12 +383,12 @@
         }
     },
     "erfinv": {
-        "_erfinv.h": {
+        "cephes.h": {
             "erfinv": "d->d"
         }
     },
     "erfcinv": {
-        "_erfinv.h": {
+        "cephes.h": {
             "erfcinv": "d->d"
         }
     },

--- a/scipy/special/functions.json
+++ b/scipy/special/functions.json
@@ -382,6 +382,16 @@
             "faddeeva_erfi_complex": "D->D"
         }
     },
+    "erfinv": {
+        "_erfinv.h": {
+            "erfinv": "d->d"
+        }
+    },
+    "erfcinv": {
+        "_erfinv.h": {
+            "erfcinv": "d->d"
+        }
+    },
     "eval_chebyc": {
         "orthogonal_eval.pxd": {
             "eval_chebyc[double complex]": "dD->D",

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1659,16 +1659,6 @@ class TestErf(object):
             rtol=1e-12
             )
 
-    def test_erfcinv(self):
-        i = special.erfcinv(1)
-        # Use assert_array_equal instead of assert_equal, so the comparison
-        # of -0.0 and 0.0 doesn't fail.
-        assert_array_equal(i, 0)
-
-    def test_erfinv(self):
-        i = special.erfinv(0)
-        assert_equal(i,0)
-
     def test_erf_nan_inf(self):
         vals = [np.nan, -np.inf, np.inf]
         expected = [np.nan, -1, 1]

--- a/scipy/special/tests/test_cython_special.py
+++ b/scipy/special/tests/test_cython_special.py
@@ -87,6 +87,8 @@ PARAMS = [
     (special.erfc, cython_special.erfc, ('d', 'D'), None),
     (special.erfcx, cython_special.erfcx, ('d', 'D'), None),
     (special.erfi, cython_special.erfi, ('d', 'D'), None),
+    (special.erfinv, cython_special.erfinv, ('d'), None),
+    (special.erfcinv, cython_special.erfcinv, ('d'), None),
     (special.eval_chebyc, cython_special.eval_chebyc, ('dd', 'dD', 'ld'), None),
     (special.eval_chebys, cython_special.eval_chebys, ('dd', 'dD', 'ld'),
      'd and l differ for negative int'),

--- a/scipy/special/tests/test_erfinv.py
+++ b/scipy/special/tests/test_erfinv.py
@@ -32,16 +32,28 @@ class TestInverseErrorFunction:
         'f, x, y',
         [
             (sc.erfinv, -1, -np.inf),
+            (sc.erfinv, 0, 0),
             (sc.erfinv, 1, np.inf),
+            (sc.erfinv, -100, np.nan),
+            (sc.erfinv, 100, np.nan),
             (sc.erfcinv, 0, np.inf),
+            (sc.erfcinv, 1, -0.0),
             (sc.erfcinv, 2, -np.inf),
+            (sc.erfcinv, -100, np.nan),
+            (sc.erfcinv, 100, np.nan),
         ],
         ids=[
-            'erfinv lower bound',
-            'erfinv upper bound',
-            'erfcinv lower bound',
-            'erfcinv upper bound',
+            'erfinv at lower bound',
+            'erfinv at midpoint',
+            'erfinv at upper bound',
+            'erfinv below lower bound',
+            'erfinv above upper bound',
+            'erfcinv at lower bound',
+            'erfcinv at midpoint',
+            'erfcinv at upper bound',
+            'erfcinv below lower bound',
+            'erfcinv above upper bound',
         ]
     )
-    def test_at_domain_bounds(self, f, x, y):
+    def test_domain_bounds(self, f, x, y):
         assert_equal(f(x), y)

--- a/scipy/special/tests/test_erfinv.py
+++ b/scipy/special/tests/test_erfinv.py
@@ -1,0 +1,47 @@
+import numpy as np
+from numpy.testing import assert_allclose, assert_equal
+import pytest
+
+import scipy.special as sc
+
+class TestInverseErrorFunction:
+    def test_compliment(self):
+        # Test erfcinv(1 - x) == erfinv(x)
+        x = np.linspace(-1, 1, 101)
+        assert_allclose(sc.erfcinv(1 - x), sc.erfinv(x), rtol=0, atol=1e-15)
+
+    def test_literal_values(self):
+        # calculated via https://keisan.casio.com/exec/system/1180573448
+        # for y = 0, 0.1, ... , 0.9
+        actual = sc.erfinv(np.linspace(0, 0.9, 10))
+        expected = [
+            0,
+            0.08885599049425768701574,
+            0.1791434546212916764928,
+            0.27246271472675435562,
+            0.3708071585935579290583,
+            0.4769362762044698733814,
+            0.5951160814499948500193,
+            0.7328690779592168522188,
+            0.9061938024368232200712,
+            1.163087153676674086726,
+        ]
+        assert_allclose(actual, expected, rtol=0, atol=1e-15)
+
+    @pytest.mark.parametrize(
+        'f, x, y',
+        [
+            (sc.erfinv, -1, -np.inf),
+            (sc.erfinv, 1, np.inf),
+            (sc.erfcinv, 0, np.inf),
+            (sc.erfcinv, 2, -np.inf),
+        ],
+        ids=[
+            'erfinv lower bound',
+            'erfinv upper bound',
+            'erfcinv lower bound',
+            'erfcinv upper bound',
+        ]
+    )
+    def test_at_domain_bounds(self, f, x, y):
+        assert_equal(f(x), y)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
See request in #10030

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR adds cython bindings for the inverse error function and inverse complementary error functions.

#### Additional information
<!--Any additional information you think is important.-->
I'm still new to working with the ufunc machinery inside special, so I may have made some "obvious" mistakes somewhere. In addition, I've added some tests, these were added before any changes were made to ensure the behaviour doesn't change.