### PR TITLE
BUG: special: Return NaN outside the domain of `eval_hermite`

### DIFF
--- a/scipy/special/orthogonal_eval.pxd
+++ b/scipy/special/orthogonal_eval.pxd
@@ -482,7 +482,12 @@ cdef inline double eval_hermitenorm(long n, double x) nogil:
     cdef double y1, y2, y3
 
     if n < 0:
-        return 0.0
+        sf_error.error(
+            "eval_hermitenorm",
+            sf_error.DOMAIN,
+            "polynomial only defined for nonnegative n",
+        )
+        return nan
     elif n == 0:
         return 1.0
     elif n == 1:
@@ -502,4 +507,11 @@ cdef inline double eval_hermitenorm(long n, double x) nogil:
 
 @cython.cdivision(True)
 cdef inline double eval_hermite(long n, double x) nogil:
+    if n < 0:
+        sf_error.error(
+            "eval_hermite",
+            sf_error.DOMAIN,
+            "polynomial only defined for nonnegative n",
+        )
+        return nan
     return eval_hermitenorm(n, sqrt(2)*x) * 2**(n/2.0)

--- a/scipy/special/tests/test_orthogonal_eval.py
+++ b/scipy/special/tests/test_orthogonal_eval.py
@@ -246,3 +246,9 @@ class TestRecurrence(object):
         v = orth.eval_hermite(70, 1.0)
         a = -1.457076485701412e60
         assert_allclose(v,a)
+
+
+def test_hermite_domain():
+    # Regression test for gh-11091.
+    assert np.isnan(orth.eval_hermite(-1, 1.0))
+    assert np.isnan(orth.eval_hermitenorm(-1, 1.0))


### PR DESCRIPTION
#### Reference issue
Closes gh-11091.

#### What does this implement/fix?
Make `eval_hermite` and `eval_hermitenorm` return NaN for unsupported orders.

#### Additional information
Note that for the Hermite polynomials we just support the actual polynomials, not the extension via parabolic cylinder/hypergeometric functions.