### PR TITLE
BUG: special: fix `hyp1f1` for nonnegative integral `a` and `b`

### DIFF
--- a/scipy/special/_hypergeometric.pxd
+++ b/scipy/special/_hypergeometric.pxd
@@ -1,5 +1,7 @@
 from libc.math cimport fabs, exp, floor, M_PI
 
+import cython
+
 from . cimport sf_error
 from ._cephes cimport expm1, poch
 
@@ -16,6 +18,7 @@ DEF EPS = 2.220446049250313e-16
 DEF ACCEPTABLE_RTOL = 1e-7
 
 
+@cython.cdivision(True)
 cdef inline double hyperu(double a, double b, double x) nogil:
     if x < 0.0:
         sf_error.error("hyperu", sf_error.DOMAIN, NULL)
@@ -33,10 +36,15 @@ cdef inline double hyperu(double a, double b, double x) nogil:
     return hypU_wrap(a, b, x)
 
 
+@cython.cdivision(True)
 cdef inline double hyp1f1(double a, double b, double x) nogil:
     if npy_isnan(a) or npy_isnan(b) or npy_isnan(x):
         return NPY_NAN
     if b <= 0 and b == floor(b):
+        # There is potentially a pole.
+        if b <= a < 0 and a == floor(a):
+            # The Pochammer symbol (a)_n cancels the pole.
+            return hyp1f1_series_track_convergence(a, b, x)
         return NPY_INFINITY
     elif a == 0 or x == 0:
         return 1
@@ -69,6 +77,7 @@ cdef inline double hyp1f1(double a, double b, double x) nogil:
     return hyp1f1_wrap(a, b, x)
 
 
+@cython.cdivision(True)
 cdef inline double hyp1f1_series_track_convergence(
     double a,
     double b,
@@ -78,11 +87,22 @@ cdef inline double hyp1f1_series_track_convergence(
     # prohibitive number of terms to converge. This function computes
     # the series while monitoring those conditions.
     cdef int k
+    cdef double apk, bpk
     cdef double term = 1
     cdef double result = 1
     cdef double abssum = result
     for k in range(1000):
-        term *= (a + k) * x / (b + k) / (k + 1)
+        apk = a + k
+        bpk = b + k
+        if bpk != 0:
+            term *= apk * x / bpk / (k + 1)
+        elif apk == 0:
+            # The Pochammer symbol in the denominator has become zero,
+            # but we still have the continuation formula DLMF 13.2.5.
+            term = 0
+        else:
+            # We hit a pole
+            return NPY_NAN
         abssum += fabs(term)
         result += term
         if fabs(term) <= EPS * fabs(result):
@@ -97,6 +117,7 @@ cdef inline double hyp1f1_series_track_convergence(
     return NPY_NAN
 
 
+@cython.cdivision(True)
 cdef inline double hyp1f1_series(double a, double b, double x) nogil:
     cdef int k
     cdef double term = 1

--- a/scipy/special/tests/test_hypergeometric.py
+++ b/scipy/special/tests/test_hypergeometric.py
@@ -91,3 +91,12 @@ class TestHyp1f1(object):
             atol=0,
             rtol=1e-15
         )
+
+    @pytest.mark.parametrize('a, b, x, desired', [
+        (-1, -2, 2, 2),
+        (-1, -4, 10, 3.5),
+        (-2, -2, 1, 2.5)
+    ])
+    def test_gh_11099(self, a, b, x, desired):
+        # All desired results computed using Mpmath
+        assert sc.hyp1f1(a, b, x) == desired


### PR DESCRIPTION
#### Reference issue
Closes gh-11099.

#### What does this implement/fix?
Currently `hyp1f1` unconditionally returns infinity when `b` is a
nonnegative integer, but if `a` is also a nonnegative integer then the
function could be nonsingular. Handle that case correctly.

#### Additional information
None.