### PR TITLE
fix Cython warnings related to _stats.pyx

### DIFF
--- a/scipy/stats/_stats.pyx
+++ b/scipy/stats/_stats.pyx
@@ -365,14 +365,15 @@ def _transform_distance_matrix(distx, disty, global_corr='mgc', is_ranked=True):
 
 
 # MGC specific functions
-
+@cython.wraparound(False)
+@cython.boundscheck(False)
 cdef _expected_covar(float64_t[:, :] distx, float64_t[:, :] disty,
                      int64_t[:, :] rank_distx, int64_t[:, :] rank_disty,
                      float64_t[:, :] cov_xy, float64_t[:] expectx,
                      float64_t[:] expecty):
     # summing up the the element-wise product of A and B based on the ranks,
     # yields the local family of covariances
-    cdef int n = distx.shape[0]
+    cdef intp_t n = distx.shape[0]
     cdef float64_t a, b
     cdef intp_t i, j, k, l
     for i in range(n):
@@ -390,8 +391,11 @@ cdef _expected_covar(float64_t[:, :] distx, float64_t[:, :] disty,
     return np.asarray(expectx), np.asarray(expecty)
 
 
-cdef _covar_map(float64_t[:, :] cov_xy, nx, ny):
+@cython.wraparound(False)
+@cython.boundscheck(False)
+cdef _covar_map(float64_t[:, :] cov_xy, intp_t nx, intp_t ny):
     # get covariances for each k and l
+    cdef intp_t k, l
     for k in range(nx - 1):
         for l in range(ny - 1):
             cov_xy[k+1, l+1] += (cov_xy[k+1, l] + cov_xy[k, l+1] - cov_xy[k, l])
@@ -407,9 +411,9 @@ def _local_covariance(distx, disty, rank_distx, rank_disty):
     rank_distx = np.asarray(rank_distx, np.int64) - 1
     rank_disty = np.asarray(rank_disty, np.int64) - 1
 
-    cdef int n = distx.shape[0]
-    cdef int nx = np.max(rank_distx) + 1
-    cdef int ny = np.max(rank_disty) + 1
+    cdef intp_t n = distx.shape[0]
+    cdef intp_t nx = np.max(rank_distx) + 1
+    cdef intp_t ny = np.max(rank_disty) + 1
     cdef ndarray cov_xy = np.zeros((nx, ny))
     cdef ndarray expectx = np.zeros(nx)
     cdef ndarray expecty = np.zeros(ny)

--- a/scipy/stats/_stats.pyx
+++ b/scipy/stats/_stats.pyx
@@ -143,7 +143,7 @@ cdef _invert_in_place(intp_t[:] perm):
 @cython.wraparound(False)
 @cython.boundscheck(False)
 def _toint64(x):
-    cdef intp_t i, j = 0, l = len(x)
+    cdef intp_t i = 0, j = 0, l = len(x)
     cdef intp_t[::1] perm = np.argsort(x, kind='quicksort')
     # The type of this array must be one of the supported types
     cdef int64_t[::1] result = np.ndarray(l, dtype=np.int64)


### PR DESCRIPTION

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
None

#### What does this implement/fix?
<!--Please explain your changes.-->

When compiling 1.4.0rc1, I noticed the following warning:
```    warning: _stats.pyx:397:41: Index should be typed for more efficient access```


This PR just adds types to a few variables in the Cython code (I think this code was newly introduced by #10524)

I also changed a few `int` to `intp_t`, because I think that is the type that should be used for shapes / indexing?


#### Additional information
<!--Any additional information you think is important.-->

The second commit here fixes a second, unrelated warning:
```
scipy/stats/_stats.c:5244:6: warning: ‘__pyx_v_i’ may be used uninitialized in this function [-Wmaybe-uninitialized]
   if (__pyx_t_12) {
```
