### PR TITLE
BUG: interpolate/fitpack: fix memory leak in splprep

### DIFF
--- a/scipy/interpolate/src/_fitpackmodule.c
+++ b/scipy/interpolate/src/_fitpackmodule.c
@@ -468,10 +468,18 @@ fitpack_parcur(PyObject *dummy, PyObject *args)
         goto fail;
     }
     if (iopt == 0|| n > no) {
+        Py_XDECREF(ap_wrk);
+        ap_wrk = NULL;
+        Py_XDECREF(ap_iwrk);
+        ap_iwrk = NULL;
+
         dims[0] = n;
         ap_wrk = (PyArrayObject *)PyArray_SimpleNew(1, dims, NPY_DOUBLE);
+        if (ap_wrk == NULL) {
+            goto fail;
+        }
         ap_iwrk = (PyArrayObject *)PyArray_SimpleNew(1, dims, NPY_INT);
-        if (ap_wrk == NULL || ap_iwrk == NULL) {
+        if (ap_iwrk == NULL) {
             goto fail;
         }
     }

--- a/scipy/interpolate/src/_fitpackmodule.c
+++ b/scipy/interpolate/src/_fitpackmodule.c
@@ -437,6 +437,8 @@ fitpack_parcur(PyObject *dummy, PyObject *args)
         }
         n = no = ap_t->dimensions[0];
         memcpy(t, ap_t->data, n*sizeof(double));
+        Py_DECREF(ap_t);
+        ap_t = NULL;
     }
     if (iopt == 1) {
         memcpy(wrk, ap_wrk->data, n*sizeof(double));


### PR DESCRIPTION
#### Reference issue
Closes: gh-11121

#### What does this implement/fix?
Fixes a memory leak in `splprep`.

These two issues in the C code appear clear once you notice them. We don't currently have test suite machinery for checking this type of leaks, so no tests can be added, but checked manually and with [pytest-leaks](https://github.com/abalkin/pytest-leaks).