### PR TITLE
DOC/MAINT: convert hyperlinks to interlinks

### DIFF
--- a/doc/source/building/index.rst
+++ b/doc/source/building/index.rst
@@ -31,7 +31,7 @@ Scipy has several tunable build-time options, which can be set.
 
 - Environment variables ``NPY_LAPACK_ORDER``, ``NPY_BLAS_ORDER``, ``OPENBLAS``,
   ``ATLAS``, etc., also controlling library configuration.
-  See `Numpy documentation <numpy-blasdoc>`_ for more details.
+  See :ref:`NumPy documentation <numpy:accelerated-blas-lapack-libraries>` for more details.
 
 - Environment variable ``NPY_USE_BLAS_ILP64=1``: build using 64-bit
   integer size (ILP64) BLAS+LAPACK libraries.
@@ -40,5 +40,3 @@ Scipy has several tunable build-time options, which can be set.
   integer size (LP64) BLAS+LAPACK libraries to be available and
   configured. This is because only some components in Scipy make use
   of the 64-bit capabilities.
-
-.. _numpy-blasdoc: https://numpy.org/devdocs/user/building.html#accelerated-blas-lapack-libraries

--- a/doc/source/dev/contributor/benchmarking.rst
+++ b/doc/source/dev/contributor/benchmarking.rst
@@ -12,7 +12,7 @@ benchmark test results online, writing a benchmark test, and running it
 locally. For a video run-through of writing a test and running it
 locally, see* \ `Benchmarking SciPy`_\ *.*
 
-As written in the `airspeed velocity (asv) documentation`_:
+As written in the :doc:`airspeed velocity (asv) documentation <asv:index>`:
 
  Airspeed velocity (asv) is a tool for benchmarking Python packages over their
  lifetime. Runtime, memory consumption, and even custom-computed values
@@ -162,16 +162,13 @@ review the results by navigating to http://127.0.0.1:8080 (local
 machine, port 8080).
 
 For much more information about the ``asv`` commands,
-see the airspeed velocity `Commands`_ documentation. (Tip:
+see the airspeed velocity :doc:`asv:commands` documentation. (Tip:
 check out the ``asv find`` command and the ``--quick``,
 ``--skip-existing-commits``, and ``--profile`` options for ``asv run``.)
 
 .. _git revisions documentation: https://git-scm.com/docs/gitrevisions#_specifying_ranges
-.. _Commands: https://asv.readthedocs.io/en/stable/commands.html#commands
 .. _airspeed velocity: https://github.com/airspeed-velocity/asv
-.. _Using airspeed velocity: https://asv.readthedocs.io/en/stable/using.html#running-benchmarks
 .. _Benchmarking SciPy: https://youtu.be/edLQ8KRpupQ
-.. _airspeed velocity (asv) documentation: https://asv.readthedocs.io/en/stable/
 .. _airspeed velocity of an unladen scipy: https://pv.github.io/scipy-bench/
 .. _SciPy benchmarks readme: https://github.com/scipy/scipy/blob/master/benchmarks/README.rst
 .. _Klee-Minty hypercube problem: https://en.wikipedia.org/wiki/Klee%E2%80%93Minty_cube

--- a/doc/source/dev/contributor/rendering_documentation.rst
+++ b/doc/source/dev/contributor/rendering_documentation.rst
@@ -25,7 +25,7 @@ To render the documentation on your own machine:
    You need to be able to ``import scipy`` regardless of Python's working
    directory; the ``python setup.py develop`` and ``conda develop`` commands
    from the :ref:`quickstart <dev-env>` guides make this possible.
-#. Install `Sphinx`_, `PyData Sphinx theme`_, `Sphinx-Panels`_ and `matplotlib`_. For
+#. Install `Sphinx`_, `PyData Sphinx theme`_, `Sphinx-Panels`_, and :doc:`matplotlib <matplotlib:index>`. For
    example, if you're using the Anaconda distribution of Python, enter in a
    terminal window ``conda install sphinx pydata-sphinx-theme sphinx-panels matplotlib --channel conda-forge``.
    The list of requirements is in ``scipy/doc_requirements.txt``.
@@ -71,7 +71,6 @@ on the cloud.
 .. _Sphinx: https://www.sphinx-doc.org/en/master/
 .. _PyData Sphinx theme: https://pydata-sphinx-theme.readthedocs.io/en/latest/
 .. _Sphinx-Panels: https://sphinx-panels.readthedocs.io/en/latest/
-.. _matplotlib: https://www.matplotlib.org/
 .. _Rendering SciPy Documentation with Sphinx: https://youtu.be/kGSYU39EhJQ
 .. _git submodules: https://git-scm.com/book/en/v2/Git-Tools-Submodules
 .. _Make build automation tool: https://en.wikipedia.org/wiki/Make_(software)

--- a/doc/source/dev/roadmap.rst
+++ b/doc/source/dev/roadmap.rst
@@ -22,9 +22,8 @@ parts of the SciPy API work, and improve support over time.
 In addition to making use of NumPy protocols like ``__array_function__``, we can
 make use of these protocols in SciPy as well.  That will make it possible to
 (re)implement SciPy functions like, e.g., those in ``scipy.signal`` for Dask
-or GPU arrays (see
-`NEP 18 - use outside of NumPy <http://www.numpy.org/neps/nep-0018-array-function-protocol.html#use-outside-of-numpy>`__).  NumPy's features in this areas are still evolving,
-see e.g. `NEP 37 - A dispatch protocol for NumPy-like modules <https://numpy.org/neps/nep-0037-array-module.html>`__,
+or GPU arrays (see :ref:`NEP 18 - use outside of NumPy <NEP18>`).  NumPy's features in this areas are still evolving,
+see e.g. :ref:`NEP 37 - A dispatch protocol for NumPy-like modules <NEP37>`,
 and SciPy is an important "client" for those features.
 
 

--- a/doc/source/dev/toolchain.rst
+++ b/doc/source/dev/toolchain.rst
@@ -46,7 +46,7 @@ Python Versions
 ^^^^^^^^^^^^^^^
 
 SciPy is compatible with several versions of Python.  When dropping support for
-older Python versions, SciPy takes guidance from NEP 29 [10]_.  Python 2.7
+older Python versions, SciPy takes guidance from :ref:`NEP 29 <NEP29>`. Python 2.7
 support was dropped for SciPy releases numbered 1.3 and above but is still
 available in release 1.2.x, which is a long-term support release [1]_, [2]_.
 
@@ -99,15 +99,15 @@ Official Builds
 Currently, SciPy wheels are being built as follows:
 
 ================  ========================  ===========================  ==============================
- Platform          Azure Base Image [14]_    Compilers                    Comment
+ Platform          Azure Base Image [13]_    Compilers                    Comment
 ================  ========================  ===========================  ==============================
 Linux (nightly)    ``ubuntu-18.04``          GCC 4.8                      See ``azure-pipelines.yml``
-Linux (release)    ``ubuntu-18.04``          GCC 7.5                      Built in separate repo [15]_
-OSX                ``macOS-10.14``           LLVM 11.0                    Built in separate repo [15]_
+Linux (release)    ``ubuntu-18.04``          GCC 7.5                      Built in separate repo [14]_
+OSX                ``macOS-10.14``           LLVM 11.0                    Built in separate repo [14]_
 Windows            ``VS2017-Win2016``        Visual Studio 2017 (15.9)    See ``azure-pipelines.yml``
 ================  ========================  ===========================  ==============================
 
-Note that the OSX wheels additionally vendor gfortran 4.8, see [15]_.
+Note that the OSX wheels additionally vendor gfortran 4.8, see [14]_.
 
 
 C Compilers
@@ -119,10 +119,10 @@ there was a long-standing restriction that Windows builds of SciPy had to use
 the same version of the Microsoft Visual C++ compiler as were used for CPython
 itself, for reasons of ABI-compatibility [6]_, [7]_, [8]_, [9]_.
 
-With the introduction of the "Universal C Runtime" [16]_ since the release of
+With the introduction of the "Universal C Runtime" [15]_ since the release of
 Visual Studio 2015, this restriction has been lifted. For more context, see the
 explanations by Steve Dower (member of the CPython-on-Windows core developers)
-on this topic [17]_.
+on this topic [16]_.
 
 The use of MS Visual Studio 9.0 (which doesn't have support C99)
 to build Python 2.7 has meant that C code in SciPy has had to conform
@@ -132,16 +132,16 @@ longer imposed by compilers. For GCC version < 5, an explicit ``-std=c99``
 may have to be added by the user if C99 features are used in SciPy code.
 
 In terms of C language standards, it's relevant to note that C11 has optional
-features [12]_ (e.g. atomics, threading), some of which (VLAs & complex types)
+features [11]_ (e.g. atomics, threading), some of which (VLAs & complex types)
 were mandatory in the C99 standard. C17 (occasionally called C18) can be
 considered a bug fix for C11, so generally, C11 may be skipped entirely.
 
 SciPy has been restricted in the use of more advanced language features by the
 available compiler support, and Microsoft in particular has taken very long to
 achieve conformance to C99/C11/C17, however starting from MS Visual Studio 16.8,
-C11/C17 is supported [11]_ (though without the C11 optional features).
+C11/C17 is supported [10]_ (though without the C11 optional features).
 
-Therefore, using C features beyond C90 is contingent upon updating the windows
+Therefore, using C features beyond C90 is contingent upon updating the Windows
 toolchain for SciPy, as well as checking compiler support for the desired feature
 across all minimally supported compiler versions. In short:
 
@@ -235,7 +235,7 @@ Cython     >= 0.29.18  1.5.0
 OpenMP support
 ^^^^^^^^^^^^^^
 
-For various reasons [13]_, SciPy cannot be distributed with built-in OpenMP support.
+For various reasons [12]_, SciPy cannot be distributed with built-in OpenMP support.
 When using the optional Pythran support, OpenMP-enabled parallel code can be
 generated when building from source.
 
@@ -283,7 +283,7 @@ Testing and benchmarking require recent versions of:
  Tool                      Version    URL
 =========================  ========  ====================================
 pytest                     Recent     https://docs.pytest.org/en/latest/
-asv (airspeed velocity)    Recent     https://asv.readthedocs.io/
+asv (airspeed velocity)    Recent     :doc:`https://asv.readthedocs.io/ <asv:index>`
 =========================  ========  ====================================
 
 
@@ -343,11 +343,10 @@ References
 .. [7] https://pythondev.readthedocs.io/windows.html#python-and-visual-studio-version-matrix
 .. [8] https://en.wikipedia.org/wiki/Microsoft_Visual_C%2B%2B#Internal_version_numbering
 .. [9] https://wiki.python.org/moin/WindowsCompilers
-.. [10] https://numpy.org/neps/nep-0029-deprecation_policy.html
-.. [11] https://devblogs.microsoft.com/cppblog/c11-and-c17-standard-support-arriving-in-msvc/
-.. [12] https://en.wikipedia.org/wiki/C11_%28C_standard_revision%29#Optional_features
-.. [13] https://github.com/scipy/scipy/issues/10239
-.. [14] https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted
-.. [15] https://github.com/MacPython/scipy-wheels
-.. [16] https://docs.microsoft.com/en-gb/cpp/windows/universal-crt-deployment
-.. [17] https://discuss.python.org/t/toolchain-upgrade-on-windows/6377/4
+.. [10] https://devblogs.microsoft.com/cppblog/c11-and-c17-standard-support-arriving-in-msvc/
+.. [11] https://en.wikipedia.org/wiki/C11_%28C_standard_revision%29#Optional_features
+.. [12] https://github.com/scipy/scipy/issues/10239
+.. [13] https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted
+.. [14] https://github.com/MacPython/scipy-wheels
+.. [15] https://docs.microsoft.com/en-gb/cpp/windows/universal-crt-deployment
+.. [16] https://discuss.python.org/t/toolchain-upgrade-on-windows/6377/4

--- a/doc/source/tutorial/io.rst
+++ b/doc/source/tutorial/io.rst
@@ -5,7 +5,7 @@ File IO (:mod:`scipy.io`)
 
 .. currentmodule:: scipy.io
 
-.. seealso:: `NumPy IO routines <https://www.numpy.org/devdocs/reference/routines.io.html>`__
+.. seealso:: :doc:`NumPy IO routines <numpy:reference/routines.io>`
 
 MATLAB files
 ------------

--- a/doc/source/tutorial/linalg.rst
+++ b/doc/source/tutorial/linalg.rst
@@ -18,10 +18,7 @@ also a 2-D array.
 scipy.linalg vs numpy.linalg
 ----------------------------
 
-.. TODO: replace numpy.linalg HTML link with `numpy.linalg` once NumPy updates doc
-
-:mod:`scipy.linalg` contains all the functions in
-`numpy.linalg <https://www.numpy.org/devdocs/reference/routines.linalg.html>`__.
+:mod:`scipy.linalg` contains all the functions in :mod:`numpy.linalg`,
 plus some other more advanced ones not contained in ``numpy.linalg``.
 
 Another advantage of using ``scipy.linalg`` over ``numpy.linalg`` is that


### PR DESCRIPTION
Work in progress.

This PR converts numpy.org and scipy.org hyperlinks to interlinks wherever possible in all reST files found in `/doc` and its subdirectories.