### PR TITLE
BUG: expm handling of empty input

### DIFF
--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -629,6 +629,12 @@ class TestExpM(object):
         assert_allclose(outTwo[0, 0], complex(-0.52896401032626006,
                                               -0.84864425749518878))
 
+    def test_empty_matrix_input(self):
+        # handle gh-11082
+        A = np.zeros((0, 0))
+        result = expm(A)
+        assert result.size == 0
+
 
 class TestExpmFrechet(object):
 

--- a/scipy/sparse/linalg/matfuncs.py
+++ b/scipy/sparse/linalg/matfuncs.py
@@ -605,6 +605,14 @@ def _expm(A, use_exact_onenorm):
     if len(A.shape) != 2 or A.shape[0] != A.shape[1]:
         raise ValueError('expected a square matrix')
 
+    # gracefully handle size-0 input,
+    # carefully handling sparse scenario
+    if A.shape == (0, 0):
+        out = np.zeros([0, 0], dtype=A.dtype)
+        if isspmatrix(A) or is_pydata_spmatrix(A):
+            return A.__class__(out)
+        return out
+
     # Trivial case
     if A.shape == (1, 1):
         out = [[np.exp(A[0, 0])]]


### PR DESCRIPTION
Fixes #11082

* `scipy.linalg.expm` of a size-0 input should now return
a size-0 array instead of raising an Exception

Not sure if even more careful handling is needed for array subclass/strange type issues. Locally, test suite seems happy.