### PR TITLE
Fix wavfile import for scipy.io

### DIFF
--- a/scipy/io/__init__.py
+++ b/scipy/io/__init__.py
@@ -95,6 +95,7 @@ Arff files (:mod:`scipy.io.arff`)
 """
 from __future__ import division, print_function, absolute_import
 
+from . import wavfile
 # matfile read and write
 from .matlab import loadmat, savemat, whosmat, byteordercodes
 


### PR DESCRIPTION
Fixes error :No module named wavfile in scipy.io