### PR TITLE
[BUG] fix rvs output shape in multivariate distributions

### DIFF
--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -48,13 +48,15 @@ def _squeeze_output(out, axis=None):
 
     Parameters
     ----------
+    out : array_like
+        Input data.
     axis : None or int or tuple of ints, optional
         Subset of single-dimensional entries in the shape.
 
     Returns
     -------
     out : array
-        The input array with single-dimensional entries removed.
+        The input array, but with all or a subset of the dimensions of length 1 removed.
 
     """
     out = out.squeeze(axis)

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -669,7 +669,8 @@ class multivariate_normal_gen(multi_rv_generic):
         random_state = self._get_random_state(random_state)
         out = random_state.multivariate_normal(mean, cov, size)
 
-        if not isinstance(size, int):
+        size = np.asanyarray(size)
+        if size.ndim != 0:
             all_axes_count = len(out.shape)
             size_axes_count = len(size)
             axs = tuple(i for i in range(size_axes_count, all_axes_count) if out.shape[i] == 1)
@@ -2164,10 +2165,10 @@ class wishart_gen(multi_rv_generic):
 
         out = self._rvs(n, shape, dim, df, C, random_state)
 
-        if not isinstance(size, int):
+        size = np.asanyarray(size)
+        if size.ndim != 0:
             all_axes_count = len(out.shape)
             size_axes_count = len(size)
-            print(all_axes_count, size_axes_count)
             axs = tuple(i for i in range(size_axes_count, all_axes_count) if out.shape[i] == 1)
             return _squeeze_output(out, axs)
 
@@ -2302,10 +2303,11 @@ class wishart_frozen(multi_rv_frozen):
         n, shape = self._dist._process_size(size)
         out = self._dist._rvs(n, shape, self.dim, self.df,
                               self.C, random_state)
-        if not isinstance(size, int):
+
+        size = np.asanyarray(size)
+        if size.ndim != 0:
             all_axes_count = len(out.shape)
             size_axes_count = len(size)
-            print(all_axes_count, size_axes_count)
             axs = tuple(i for i in range(size_axes_count, all_axes_count) if out.shape[i] == 1)
             return _squeeze_output(out, axs)
 
@@ -2797,7 +2799,8 @@ class invwishart_gen(wishart_gen):
 
         out = self._rvs(n, shape, dim, df, C, random_state)
 
-        if not isinstance(size, int):
+        size = np.asanyarray(size)
+        if size.ndim != 0:
             all_axes_count = len(out.shape)
             size_axes_count = len(size)
             axs = tuple(i for i in range(size_axes_count, all_axes_count) if out.shape[i] == 1)
@@ -2874,10 +2877,11 @@ class invwishart_frozen(multi_rv_frozen):
 
         out = self._dist._rvs(n, shape, self.dim, self.df,
                               self.C, random_state)
-        if not isinstance(size, int):
+
+        size = np.asanyarray(size)
+        if size.ndim != 0:
             all_axes_count = len(out.shape)
             size_axes_count = len(size)
-            print(all_axes_count, size_axes_count)
             axs = tuple(i for i in range(size_axes_count, all_axes_count) if out.shape[i] == 1)
             return _squeeze_output(out, axs)
 

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -2164,6 +2164,13 @@ class wishart_gen(multi_rv_generic):
 
         out = self._rvs(n, shape, dim, df, C, random_state)
 
+        if not isinstance(size, int):
+            all_axes_count = len(out.shape)
+            size_axes_count = len(size)
+            print(all_axes_count, size_axes_count)
+            axs = tuple(i for i in range(size_axes_count, all_axes_count) if out.shape[i] == 1)
+            return _squeeze_output(out, axs)
+
         return _squeeze_output(out)
 
     def _entropy(self, dim, df, log_det_scale):
@@ -2295,6 +2302,13 @@ class wishart_frozen(multi_rv_frozen):
         n, shape = self._dist._process_size(size)
         out = self._dist._rvs(n, shape, self.dim, self.df,
                               self.C, random_state)
+        if not isinstance(size, int):
+            all_axes_count = len(out.shape)
+            size_axes_count = len(size)
+            print(all_axes_count, size_axes_count)
+            axs = tuple(i for i in range(size_axes_count, all_axes_count) if out.shape[i] == 1)
+            return _squeeze_output(out, axs)
+
         return _squeeze_output(out)
 
     def entropy(self):
@@ -2783,6 +2797,12 @@ class invwishart_gen(wishart_gen):
 
         out = self._rvs(n, shape, dim, df, C, random_state)
 
+        if not isinstance(size, int):
+            all_axes_count = len(out.shape)
+            size_axes_count = len(size)
+            axs = tuple(i for i in range(size_axes_count, all_axes_count) if out.shape[i] == 1)
+            return _squeeze_output(out, axs)
+
         return _squeeze_output(out)
 
     def entropy(self):
@@ -2854,6 +2874,12 @@ class invwishart_frozen(multi_rv_frozen):
 
         out = self._dist._rvs(n, shape, self.dim, self.df,
                               self.C, random_state)
+        if not isinstance(size, int):
+            all_axes_count = len(out.shape)
+            size_axes_count = len(size)
+            print(all_axes_count, size_axes_count)
+            axs = tuple(i for i in range(size_axes_count, all_axes_count) if out.shape[i] == 1)
+            return _squeeze_output(out, axs)
 
         return _squeeze_output(out)
 

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -671,12 +671,12 @@ class multivariate_normal_gen(multi_rv_generic):
         random_state = self._get_random_state(random_state)
         out = random_state.multivariate_normal(mean, cov, size)
 
-        size = np.asanyarray(size)
+        size = np.asarray(size)
         if size.ndim != 0:
             all_axes_count = len(out.shape)
             size_axes_count = len(size)
-            axs = tuple(i for i in range(size_axes_count, all_axes_count) if out.shape[i] == 1)
-            return _squeeze_output(out, axs)
+            axes = tuple(i for i in range(size_axes_count, all_axes_count) if out.shape[i] == 1)
+            return _squeeze_output(out, axes)
 
         return _squeeze_output(out)
 
@@ -2167,12 +2167,12 @@ class wishart_gen(multi_rv_generic):
 
         out = self._rvs(n, shape, dim, df, C, random_state)
 
-        size = np.asanyarray(size)
+        size = np.asarray(size)
         if size.ndim != 0:
             all_axes_count = len(out.shape)
             size_axes_count = len(size)
-            axs = tuple(i for i in range(size_axes_count, all_axes_count) if out.shape[i] == 1)
-            return _squeeze_output(out, axs)
+            axes = tuple(i for i in range(size_axes_count, all_axes_count) if out.shape[i] == 1)
+            return _squeeze_output(out, axes)
 
         return _squeeze_output(out)
 
@@ -2306,12 +2306,12 @@ class wishart_frozen(multi_rv_frozen):
         out = self._dist._rvs(n, shape, self.dim, self.df,
                               self.C, random_state)
 
-        size = np.asanyarray(size)
+        size = np.asarray(size)
         if size.ndim != 0:
             all_axes_count = len(out.shape)
             size_axes_count = len(size)
-            axs = tuple(i for i in range(size_axes_count, all_axes_count) if out.shape[i] == 1)
-            return _squeeze_output(out, axs)
+            axes = tuple(i for i in range(size_axes_count, all_axes_count) if out.shape[i] == 1)
+            return _squeeze_output(out, axes)
 
         return _squeeze_output(out)
 
@@ -2801,12 +2801,12 @@ class invwishart_gen(wishart_gen):
 
         out = self._rvs(n, shape, dim, df, C, random_state)
 
-        size = np.asanyarray(size)
+        size = np.asarray(size)
         if size.ndim != 0:
             all_axes_count = len(out.shape)
             size_axes_count = len(size)
-            axs = tuple(i for i in range(size_axes_count, all_axes_count) if out.shape[i] == 1)
-            return _squeeze_output(out, axs)
+            axes = tuple(i for i in range(size_axes_count, all_axes_count) if out.shape[i] == 1)
+            return _squeeze_output(out, axes)
 
         return _squeeze_output(out)
 
@@ -2880,12 +2880,12 @@ class invwishart_frozen(multi_rv_frozen):
         out = self._dist._rvs(n, shape, self.dim, self.df,
                               self.C, random_state)
 
-        size = np.asanyarray(size)
+        size = np.asarray(size)
         if size.ndim != 0:
             all_axes_count = len(out.shape)
             size_axes_count = len(size)
-            axs = tuple(i for i in range(size_axes_count, all_axes_count) if out.shape[i] == 1)
-            return _squeeze_output(out, axs)
+            axes = tuple(i for i in range(size_axes_count, all_axes_count) if out.shape[i] == 1)
+            return _squeeze_output(out, axes)
 
         return _squeeze_output(out)
 

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -56,7 +56,8 @@ def _squeeze_output(out, axis=None):
     Returns
     -------
     out : array
-        The input array, but with all or a subset of the dimensions of length 1 removed.
+        The input array, but with all or a subset of the dimensions of length 1 removed,
+        converted to scalar, if necessary.
 
     """
     out = out.squeeze(axis)

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -41,13 +41,23 @@ random_state : None or int or np.random.RandomState instance, optional
 """
 
 
-def _squeeze_output(out):
+def _squeeze_output(out, axis=None):
     """
     Remove single-dimensional entries from array and convert to scalar,
     if necessary.
 
+    Parameters
+    ----------
+    axis : None or int or tuple of ints, optional
+        Subset of single-dimensional entries in the shape.
+
+    Returns
+    -------
+    out : array
+        The input array with single-dimensional entries removed.
+
     """
-    out = out.squeeze()
+    out = out.squeeze(axis)
     if out.ndim == 0:
         out = out[()]
     return out
@@ -639,7 +649,7 @@ class multivariate_normal_gen(multi_rv_generic):
         Parameters
         ----------
         %(_mvn_doc_default_callparams)s
-        size : integer, optional
+        size : integer or tuple of integers, optional
             Number of samples to draw (default 1).
         %(_doc_random_state)s
 
@@ -658,6 +668,13 @@ class multivariate_normal_gen(multi_rv_generic):
 
         random_state = self._get_random_state(random_state)
         out = random_state.multivariate_normal(mean, cov, size)
+
+        if not isinstance(size, int):
+            all_axes_count = len(out.shape)
+            size_axes_count = len(size)
+            axs = tuple(i for i in range(size_axes_count, all_axes_count) if out.shape[i] == 1)
+            return _squeeze_output(out, axs)
+
         return _squeeze_output(out)
 
     def entropy(self, mean=None, cov=1):

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -1039,6 +1039,25 @@ class TestWishart(object):
         alpha = 0.01
         check_distribution_rvs('chi2', args, alpha, rvs)
 
+    def test_rvs_shape(self):
+        # Check that rvs returns an array of the right shape
+        dim = 4
+        scale = np.arange(dim) + 1
+        df = 10
+        w = wishart(df, scale)
+
+        sample = w.rvs(size=(1,))
+        assert_equal(sample.shape, (1, dim, dim))
+
+        sample = w.rvs(size=(3, 1, 1))
+        assert_equal(sample.shape, (3, 1, 1, dim, dim))
+
+        sample = wishart.rvs(df, scale, size=(1,))
+        assert_equal(sample.shape, (1, dim, dim))
+
+        sample = wishart.rvs(df, (1,), size=(1, 1, 2))
+        assert_equal(sample.shape, (1, 1, 2))
+
 class TestMultinomial(object):
     def test_logpmf(self):
         vals1 = multinomial.logpmf((3,4), 7, (0.3, 0.7))
@@ -1346,6 +1365,25 @@ class TestInvwishart(object):
                     - (nu + p + 1)/2*logdetX
                     - 0.5*M.trace())
         assert_allclose(prob, expected)
+
+    def test_rvs_shape(self):
+        # Check that rvs returns an array of the right shape
+        dim = 4
+        scale = np.arange(dim) + 1
+        df = 10
+        w = invwishart(df, scale)
+
+        sample = w.rvs(size=(1,))
+        assert_equal(sample.shape, (1, dim, dim))
+
+        sample = w.rvs(size=(2, 1, 1))
+        assert_equal(sample.shape, (2, 1, 1, dim, dim))
+
+        sample = invwishart.rvs(df, scale, size=(1, 2))
+        assert_equal(sample.shape, (1, 2, dim, dim))
+
+        sample = invwishart.rvs(df, (1,), size=(1, 1, 2))
+        assert_equal(sample.shape, (1, 1, 2))
 
 
 class TestSpecialOrthoGroup(object):

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -414,6 +414,15 @@ class TestMultivariateNormal(object):
         sample = u.rvs(N)
         assert_equal(sample.shape, (N, ))
 
+        sample = multivariate_normal.rvs(size=(1,))
+        assert_equal(sample.shape, (1,))
+
+        sample = multivariate_normal.rvs(mean=(3,), size=(1, 3, 1))
+        assert_equal(sample.shape, (1, 3, 1))
+
+        sample = multivariate_normal.rvs(mean=np.zeros(3), size=(1,))
+        assert_equal(sample.shape, (1, 3))
+
     def test_large_sample(self):
         # Generate large sample and compare sample mean and sample covariance
         # with mean and covariance matrix.


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #7689

#### What does this implement/fix?
<!--Please explain your changes.-->
Some multivariate distributions (`multivariate_normal`, `wishart` and `invwishart`) `rvs` methods return output with incorrect shape. As @WarrenWeckesser noted, it is due to the indiscriminate use of `squeeze`.

#### Additional information
<!--Any additional information you think is important.-->
In my solution, axes that were given with the `size` parameter are being skipped by `squeeze`.