### PR TITLE
BUG: Fix random state bug multiscale_graphcorr

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -4411,7 +4411,7 @@ def _perm_test(x, y, stat, compute_distance, reps=1000, workers=-1,
     mapwrapper = MapWrapper(workers)
     random_state = check_random_state(random_state)
     seeds = random_state.permutation(np.arange(reps))
-    random_states = [check_random_state(seeds[i]) for i in range(reps)]
+    random_states = [check_random_state(seeds) for seed in seeds]
     parallelp = _ParallelP(x=x, y=y, compute_distance=compute_distance,
                            random_states=random_states)
     null_dist = np.array(list(mapwrapper(parallelp, range(reps))))

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -4407,11 +4407,14 @@ def _perm_test(x, y, stat, compute_distance, reps=1000, workers=-1,
     null_dist : list
         The approximated null distribution.
     """
+    # generate seeds for each rep (change to new parallel random number
+    # capabilities in numpy >= 1.17+)
+    random_state = check_random_state(random_state)
+    random_states = [np.random.RandomState(random_state.randint(1<<32, size=4,
+                     dtype=np.uint32)) for _ in range(reps)]
+
     # parallelizes with specified workers over number of reps and set seeds
     mapwrapper = MapWrapper(workers)
-    random_state = check_random_state(random_state)
-    seeds = random_state.permutation(np.arange(reps))
-    random_states = [check_random_state(seed) for seed in seeds]
     parallelp = _ParallelP(x=x, y=y, compute_distance=compute_distance,
                            random_states=random_states)
     null_dist = np.array(list(mapwrapper(parallelp, range(reps))))

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -4410,11 +4410,11 @@ def _perm_test(x, y, stat, compute_distance, reps=1000, workers=-1,
     # parallelizes with specified workers over number of reps and set seeds
     mapwrapper = MapWrapper(workers)
     if workers == 1:
-        random_states = [check_random_state(0)]
+        random_states = check_random_state(0)
     else:
         random_state = check_random_state(random_state)
-        seeds = random_state.permutation(np.arange(reps))
-        random_states = [check_random_state(seeds[i]) for i in range(reps)]
+    seeds = random_state.permutation(np.arange(reps))
+    random_states = [check_random_state(seeds[i]) for i in range(reps)]
     parallelp = _ParallelP(x=x, y=y, compute_distance=compute_distance,
                            random_states=random_states)
     null_dist = np.array(list(mapwrapper(parallelp, range(reps))))

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -4410,7 +4410,7 @@ def _perm_test(x, y, stat, compute_distance, reps=1000, workers=-1,
     # parallelizes with specified workers over number of reps and set seeds
     mapwrapper = MapWrapper(workers)
     if workers == 1:
-        random_states = check_random_state(0)
+        random_state = check_random_state(0)
     else:
         random_state = check_random_state(random_state)
     seeds = random_state.permutation(np.arange(reps))

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -4411,7 +4411,7 @@ def _perm_test(x, y, stat, compute_distance, reps=1000, workers=-1,
     mapwrapper = MapWrapper(workers)
     random_state = check_random_state(random_state)
     seeds = random_state.permutation(np.arange(reps))
-    random_states = [check_random_state(seeds) for seed in seeds]
+    random_states = [check_random_state(seed) for seed in seeds]
     parallelp = _ParallelP(x=x, y=y, compute_distance=compute_distance,
                            random_states=random_states)
     null_dist = np.array(list(mapwrapper(parallelp, range(reps))))

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -4625,7 +4625,7 @@ def multiscale_graphcorr(x, y, compute_distance=_euclidean_dist, reps=1000,
 
     >>> x = np.arange(100)
     >>> y = np.arange(79)
-    >>> mgc = multiscale_graphcorr(x, y)
+    >>> mgc = multiscale_graphcorr(x, y, random_state=1)
     >>> '%.3f, %.2f' % (mgc.stat, mgc.pvalue)
     '0.033, 0.02'
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -4409,10 +4409,7 @@ def _perm_test(x, y, stat, compute_distance, reps=1000, workers=-1,
     """
     # parallelizes with specified workers over number of reps and set seeds
     mapwrapper = MapWrapper(workers)
-    if workers == 1:
-        random_state = check_random_state(0)
-    else:
-        random_state = check_random_state(random_state)
+    random_state = check_random_state(random_state)
     seeds = random_state.permutation(np.arange(reps))
     random_states = [check_random_state(seeds[i]) for i in range(reps)]
     parallelp = _ParallelP(x=x, y=y, compute_distance=compute_distance,

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -4410,8 +4410,8 @@ def _perm_test(x, y, stat, compute_distance, reps=1000, workers=-1,
     # generate seeds for each rep (change to new parallel random number
     # capabilities in numpy >= 1.17+)
     random_state = check_random_state(random_state)
-    random_states = [np.random.RandomState(random_state.randint(1<<32, size=4,
-                     dtype=np.uint32)) for _ in range(reps)]
+    random_states = [np.random.RandomState(random_state.randint(1 << 32,
+                     size=4, dtype=np.uint32)) for _ in range(reps)]
 
     # parallelizes with specified workers over number of reps and set seeds
     mapwrapper = MapWrapper(workers)

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -4435,7 +4435,7 @@ MGCResult = namedtuple('MGCResult', ('stat', 'pvalue', 'mgc_dict'))
 
 
 def multiscale_graphcorr(x, y, compute_distance=_euclidean_dist, reps=1000,
-                         workers=1, random_state=None, is_twosamp=False):
+                         workers=1, is_twosamp=False, random_state=None):
     r"""
     Computes the Multiscale Graph Correlation (MGC) test statistic.
 
@@ -4485,15 +4485,15 @@ def multiscale_graphcorr(x, y, compute_distance=_euclidean_dist, reps=1000,
         ``multiprocessing.Pool.map`` for evaluating the p-value in parallel.
         This evaluation is carried out as ``workers(func, iterable)``.
         Requires that `func` be pickleable. The default is ``1``.
-    random_state : int or np.random.RandomState instance, optional
-        If already a RandomState instance, use it.
-        If seed is an int, return a new RandomState instance seeded with seed.
-        If None, use np.random.RandomState. Default is None.
     is_twosamp : bool, optional
         If `True`, a two sample test will be run. If ``x`` and ``y`` have
         shapes ``(n, p)`` and ``(m, p)``, this optional will be overriden and
         set to ``True``. Set to ``True`` if ``x`` and ``y`` both have shapes
         ``(n, p)`` and a two sample test is desired. The default is ``False``.
+    random_state : int or np.random.RandomState instance, optional
+        If already a RandomState instance, use it.
+        If seed is an int, return a new RandomState instance seeded with seed.
+        If None, use np.random.RandomState. Default is None.
 
     Returns
     -------

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -5276,3 +5276,12 @@ class TestMGCStat(object):
         stat, pvalue, _ = stats.multiscale_graphcorr(x, y, workers=2)
         assert_approx_equal(stat, 0.97, significant=1)
         assert_approx_equal(pvalue, 0.001, significant=1)
+
+    def test_random_state(self):
+        # generate x and y
+        x, y = self._simulations(samps=100, dims=1, sim_type="linear")
+
+        # test stat and pvalue
+        stat, pvalue, _ = stats.multiscale_graphcorr(x, y, random_state=1)
+        assert_approx_equal(stat, 0.97, significant=1)
+        assert_approx_equal(pvalue, 0.001, significant=1)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes https://github.com/scipy/scipy/issues/11100

#### What does this implement/fix?
<!--Please explain your changes.-->
Fixes bug for possible nonindependent streams for parallelized p-value computation. It generates a set of seeds based on the ``random_state`` input and then assigns one independently to each replication.

#### Additional information
<!--Any additional information you think is important.-->