### PR TITLE
DEV: Update Dockerfile comments for missing dependency

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -19,8 +19,10 @@
 #
 # The available Python executables are python3.6 and python3.7 (along with
 # pip3.6 and pip3.7.
-# The image does not come bundled with cython/numpy/pytest, those need to
+# The image does not come bundled with cython/numpy/pytest/pybind11, those need to
 # be installed with pip before trying to build/run scipy.
+#
+# pip install cython numpy pytest pybind11
 #
 
 

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -22,7 +22,7 @@
 # The image does not come bundled with cython/numpy/pytest/pybind11, those need to
 # be installed with pip before trying to build/run scipy.
 #
-# pip install cython numpy pytest pybind11
+# pip3 install cython numpy pytest pybind11
 #
 
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue

#11154 

#### What does this implement/fix?

As described #11154, scipy needs pybind11, but the dockerfile comment is missing.

This change is good for beginner developers of scipy. 
