### PR TITLE
ENH/ BUG: Pydata sparse equality

### DIFF
--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -232,16 +232,17 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         # Dense other.
         elif isdense(other):
             return self.todense() == other
+        # Pydata sparse other.
+        elif is_pydata_spmatrix(other):
+            return NotImplemented
         # Sparse other.
-        elif isspmatrix(other) or is_pydata_spmatrix(other):
+        elif isspmatrix(other):
             warn("Comparing sparse matrices using == is inefficient, try using"
                  " != instead.", SparseEfficiencyWarning, stacklevel=3)
             # TODO sparse broadcasting
             if self.shape != other.shape:
                 return False
-            if is_pydata_spmatrix(other):
-                other = other.to_scipy_sparse()
-            if self.format != other.format:
+            elif self.format != other.format:
                 other = other.asformat(self.format)
             res = self._binopt(other, '_ne_')
             all_true = self.__class__(np.ones(self.shape, dtype=np.bool_))
@@ -269,14 +270,15 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         # Dense other.
         elif isdense(other):
             return self.todense() != other
+        # Pydata sparse other.
+        elif is_pydata_spmatrix(other):
+            return NotImplemented
         # Sparse other.
-        elif isspmatrix(other) or is_pydata_spmatrix(other):
+        elif isspmatrix(other):
             # TODO sparse broadcasting
             if self.shape != other.shape:
                 return True
-            if is_pydata_spmatrix(other):
-                other = other.to_scipy_sparse()
-            if self.format != other.format:
+            elif self.format != other.format:
                 other = other.asformat(self.format)
             return self._binopt(other, '_ne_')
         else:

--- a/scipy/sparse/linalg/tests/test_pydata_sparse.py
+++ b/scipy/sparse/linalg/tests/test_pydata_sparse.py
@@ -227,10 +227,9 @@ def test_expm_multiply(matrices):
 
 def test_eq(same_matrix):
     sp_sparse, pd_sparse = same_matrix
-    with pytest.warns(sp.SparseEfficiencyWarning):
-        assert (sp_sparse == pd_sparse).sum() == np.multiply(*sp_sparse.shape)
+    assert np.all(sp_sparse == pd_sparse)
 
 
 def test_ne(same_matrix):
     sp_sparse, pd_sparse = same_matrix
-    assert (sp_sparse != pd_sparse).sum() == 0
+    assert not np.any(sp_sparse != pd_sparse)

--- a/scipy/sparse/linalg/tests/test_pydata_sparse.py
+++ b/scipy/sparse/linalg/tests/test_pydata_sparse.py
@@ -227,9 +227,9 @@ def test_expm_multiply(matrices):
 
 def test_eq(same_matrix):
     sp_sparse, pd_sparse = same_matrix
-    assert np.all(sp_sparse == pd_sparse)
+    assert (sp_sparse == pd_sparse).all()
 
 
 def test_ne(same_matrix):
     sp_sparse, pd_sparse = same_matrix
-    assert not np.any(sp_sparse != pd_sparse)
+    assert not (sp_sparse != pd_sparse).any()


### PR DESCRIPTION
#### Reference issue

Fixes #11163

#### What does this implement/fix?

Fix comparison between pydata sparse arrays and sparse matrices.

#### Additional information

I was a little unsure of the best way to do this. I've made a kinda messy function messier, but I don't think this is worth a rewrite of that function. A more elegant solution could be to try and defer to the other object if it satisfies the array interface.

Additionally the test probably don't belong in under `sparse.linalg`, but I wasn't sure where else this should go, especially since I'd be copying code otherwise. I figured I'd leave code organization decisions up to maintainers, so let me know where to move things.