### PR TITLE
BUG: io.matlab: Squeeze 0d to numpy scalars, not python ones

### DIFF
--- a/scipy/io/matlab/mio.py
+++ b/scipy/io/matlab/mio.py
@@ -207,10 +207,10 @@ def loadmat(file_name, mdict=None, appendmat=True, **kwargs):
     >>> matstruct_squeezed['teststruct'].shape
     ()
     >>> matstruct_squeezed['teststruct']['complexfield'].shape
-    ()
-    >>> matstruct_squeezed['teststruct']['complexfield'].item()
+    (3,)
+    >>> matstruct_squeezed['teststruct']['complexfield']
     array([ 1.41421356+1.41421356j,  2.71828183+2.71828183j,
-        3.14159265+3.14159265j])
+            3.14159265+3.14159265j])
     """
     variable_names = kwargs.pop('variable_names', None)
     with _open_file_context(file_name, appendmat) as f:

--- a/scipy/io/matlab/mio_utils.pyx
+++ b/scipy/io/matlab/mio_utils.pyx
@@ -16,7 +16,7 @@ cpdef object squeeze_element(cnp.ndarray arr):
     if not arr.size:
         return np.array([])
     cdef cnp.ndarray arr2 = np.squeeze(arr)
-    # We want to squeeze 0d arrays, unless they are record arrays
+    # We want to squeeze 0d arrays into scalars
     if arr2.ndim == 0:
         return arr2[()]
     return arr2

--- a/scipy/io/matlab/mio_utils.pyx
+++ b/scipy/io/matlab/mio_utils.pyx
@@ -17,8 +17,8 @@ cpdef object squeeze_element(cnp.ndarray arr):
         return np.array([])
     cdef cnp.ndarray arr2 = np.squeeze(arr)
     # We want to squeeze 0d arrays, unless they are record arrays
-    if arr2.ndim == 0 and arr2.dtype.kind != 'V':
-        return arr2.item()
+    if arr2.ndim == 0:
+        return arr2[()]
     return arr2
 
 

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -1017,7 +1017,7 @@ def test_scalar_squeeze():
     out_d = loadmat(stream, squeeze_me=True)
     assert_(isinstance(out_d['scalar'], float))
     assert_(isinstance(out_d['string'], string_types))
-    assert_(isinstance(out_d['st'], np.ndarray))
+    assert_(isinstance(out_d['st'], np.void))
 
 
 def test_str_round():

--- a/scipy/io/matlab/tests/test_mio_utils.py
+++ b/scipy/io/matlab/tests/test_mio_utils.py
@@ -16,11 +16,10 @@ def test_squeeze_element():
     a = np.zeros((1,3))
     assert_array_equal(np.squeeze(a), squeeze_element(a))
     # 0-D output from squeeze gives scalar
-    sq_int = squeeze_element(np.zeros((1,1), dtype=float))
-    assert_(isinstance(sq_int, float))
-    # Unless it's a structured array
-    sq_sa = squeeze_element(np.zeros((1,1),dtype=[('f1', 'f')]))
-    assert_(isinstance(sq_sa, np.ndarray))
+    sq_float = squeeze_element(np.zeros((1,1), dtype=np.float_))
+    assert_(isinstance(sq_float, np.float_))
+    sq_sa = squeeze_element(np.zeros((1,1), dtype=[('f1', 'f')]))
+    assert_(isinstance(sq_sa, np.void))
 
 
 def test_chars_strings():


### PR DESCRIPTION
This squeezes 0d void arrays to void scalars, which are far easier to index

`.item()` does not do the right thing on void scalars, as it returns a tuple.

Apologies for the commit messages, this was done through the web ui where amending isn't possible. I'm hoping you're OK with squashing them at merge time?

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Related to https://github.com/numpy/numpy/issues/14964

#### What does this implement/fix?
This makes `scipy.io.load_mat` load scalars as numpy scalars instead of pure-python ones. More valuably, this loads matlab structs as `np.void` objects instead of 0d `np.array` objects, which works out better for nested object arrays.

#### Additional information
<!--Any additional information you think is important.-->