### PR TITLE
BUG: empty sparse slice shapes

### DIFF
--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -783,11 +783,6 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         i0, i1 = _process_slice(major, M)
         j0, j1 = _process_slice(minor, N)
 
-        if i0 == 'empty' or j0 == 'empty':
-            out = np.zeros(shape=(0, self.shape[1]),
-                           dtype=self.dtype)
-            return self.__class__(out)
-
         if i0 == 0 and j0 == 0 and i1 == M and j1 == N:
             return self.copy() if copy else self
 
@@ -1281,8 +1276,7 @@ def _process_slice(sl, num):
         i0, i1, stride = sl.indices(num)
         if stride != 1:
             raise ValueError('slicing with step != 1 not supported')
-        if i0 > i1:
-            return 'empty', 'empty'
+        i0 = min(i0, i1)  # give an empty slice when i0 > i1
     elif isintlike(sl):
         if sl < 0:
             sl += num

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -784,7 +784,8 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         j0, j1 = _process_slice(minor, N)
 
         if i0 == 'empty' or j0 == 'empty':
-            out = np.zeros([0, 0], dtype=self.dtype)
+            out = np.zeros(shape=(0, self.shape[1]),
+                           dtype=self.dtype)
             return self.__class__(out)
 
         if i0 == 0 and j0 == 0 and i1 == M and j1 == N:

--- a/scipy/sparse/tests/test_csc.py
+++ b/scipy/sparse/tests/test_csc.py
@@ -36,23 +36,38 @@ def test_csc_getcol():
         assert_array_almost_equal(arr_col, csc_col.toarray())
         assert_(type(csc_col) is csc_matrix)
 
-@pytest.mark.parametrize("matrix_input, expected_shape",
+@pytest.mark.parametrize("matrix_input, axis, expected_shape",
     [(csc_matrix([[1, 0],
                 [0, 0],
                 [0, 2]]),
-      (0, 2)),
+      0, (0, 2)),
+     (csc_matrix([[1, 0],
+                [0, 0],
+                [0, 2]]),
+      1, (3, 0)),
+     (csc_matrix([[1, 0],
+                [0, 0],
+                [0, 2]]),
+      'both', (0, 0)),
      (csc_matrix([[0, 1, 0, 0, 0, 0],
                 [0, 0, 0, 0, 0, 0],
                 [0, 0, 2, 3, 0, 1]]),
-      (0, 6))])
-def test_csc_empty_slices(matrix_input, expected_shape):
+      0, (0, 6))])
+def test_csc_empty_slices(matrix_input, axis, expected_shape):
     # see gh-11127 for related discussion
     slice_1 = matrix_input.A.shape[0] - 1
     slice_2 = slice_1
     slice_3 = slice_2 - 1
 
-    actual_shape_1 = matrix_input[slice_1:slice_2, :].A.shape
-    actual_shape_2 = matrix_input[slice_1:slice_3, :].A.shape
+    if axis == 0:
+        actual_shape_1 = matrix_input[slice_1:slice_2, :].A.shape
+        actual_shape_2 = matrix_input[slice_1:slice_3, :].A.shape
+    elif axis == 1:
+        actual_shape_1 = matrix_input[:, slice_1:slice_2].A.shape
+        actual_shape_2 = matrix_input[:, slice_1:slice_3].A.shape
+    elif axis == 'both':
+        actual_shape_1 = matrix_input[slice_1:slice_2, slice_1:slice_2].A.shape
+        actual_shape_2 = matrix_input[slice_1:slice_3, slice_1:slice_3].A.shape
 
     assert actual_shape_1 == expected_shape
     assert actual_shape_1 == actual_shape_2

--- a/scipy/sparse/tests/test_csc.py
+++ b/scipy/sparse/tests/test_csc.py
@@ -4,6 +4,8 @@ import numpy as np
 from numpy.testing import assert_array_almost_equal, assert_
 from scipy.sparse import csr_matrix, csc_matrix
 
+import pytest
+
 
 def test_csc_getrow():
     N = 10
@@ -34,3 +36,23 @@ def test_csc_getcol():
         assert_array_almost_equal(arr_col, csc_col.toarray())
         assert_(type(csc_col) is csc_matrix)
 
+@pytest.mark.parametrize("matrix_input, expected_shape",
+    [(csc_matrix([[1, 0],
+                [0, 0],
+                [0, 2]]),
+      (0, 2)),
+     (csc_matrix([[0, 1, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0],
+                [0, 0, 2, 3, 0, 1]]),
+      (0, 6))])
+def test_csc_empty_slices(matrix_input, expected_shape):
+    # see gh-11127 for related discussion
+    slice_1 = matrix_input.A.shape[0] - 1
+    slice_2 = slice_1
+    slice_3 = slice_2 - 1
+
+    actual_shape_1 = matrix_input[slice_1:slice_2, :].A.shape
+    actual_shape_2 = matrix_input[slice_1:slice_3, :].A.shape
+
+    assert actual_shape_1 == expected_shape
+    assert actual_shape_1 == actual_shape_2

--- a/scipy/sparse/tests/test_csr.py
+++ b/scipy/sparse/tests/test_csr.py
@@ -4,6 +4,8 @@ import numpy as np
 from numpy.testing import assert_array_almost_equal, assert_
 from scipy.sparse import csr_matrix
 
+import pytest
+
 
 def _check_csr_rowslice(i, sl, X, Xcsr):
     np_slice = X[i, sl]
@@ -58,3 +60,23 @@ def test_csr_getcol():
         assert_array_almost_equal(arr_col, csr_col.toarray())
         assert_(type(csr_col) is csr_matrix)
 
+@pytest.mark.parametrize("matrix_input, expected_shape",
+    [(csr_matrix([[1, 0, 0, 0],
+                [0, 0, 0, 0],
+                [0, 2, 3, 0]]),
+      (0, 4)),
+     (csr_matrix([[0, 1, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 2, 3, 0]]),
+      (0, 5))])
+def test_csr_empty_slices(matrix_input, expected_shape):
+    # see gh-11127 for related discussion
+    slice_1 = matrix_input.A.shape[0] - 1
+    slice_2 = slice_1
+    slice_3 = slice_2 - 1
+
+    actual_shape_1 = matrix_input[slice_1:slice_2, :].A.shape
+    actual_shape_2 = matrix_input[slice_1:slice_3, :].A.shape
+
+    assert actual_shape_1 == expected_shape
+    assert actual_shape_1 == actual_shape_2

--- a/scipy/sparse/tests/test_csr.py
+++ b/scipy/sparse/tests/test_csr.py
@@ -60,23 +60,38 @@ def test_csr_getcol():
         assert_array_almost_equal(arr_col, csr_col.toarray())
         assert_(type(csr_col) is csr_matrix)
 
-@pytest.mark.parametrize("matrix_input, expected_shape",
+@pytest.mark.parametrize("matrix_input, axis, expected_shape",
     [(csr_matrix([[1, 0, 0, 0],
                 [0, 0, 0, 0],
                 [0, 2, 3, 0]]),
-      (0, 4)),
+      0, (0, 4)),
+     (csr_matrix([[1, 0, 0, 0],
+                [0, 0, 0, 0],
+                [0, 2, 3, 0]]),
+      1, (3, 0)),
+     (csr_matrix([[1, 0, 0, 0],
+                [0, 0, 0, 0],
+                [0, 2, 3, 0]]),
+      'both', (0, 0)),
      (csr_matrix([[0, 1, 0, 0, 0],
                 [0, 0, 0, 0, 0],
                 [0, 0, 2, 3, 0]]),
-      (0, 5))])
-def test_csr_empty_slices(matrix_input, expected_shape):
+      0, (0, 5))])
+def test_csr_empty_slices(matrix_input, axis, expected_shape):
     # see gh-11127 for related discussion
     slice_1 = matrix_input.A.shape[0] - 1
     slice_2 = slice_1
     slice_3 = slice_2 - 1
 
-    actual_shape_1 = matrix_input[slice_1:slice_2, :].A.shape
-    actual_shape_2 = matrix_input[slice_1:slice_3, :].A.shape
+    if axis == 0:
+        actual_shape_1 = matrix_input[slice_1:slice_2, :].A.shape
+        actual_shape_2 = matrix_input[slice_1:slice_3, :].A.shape
+    elif axis == 1:
+        actual_shape_1 = matrix_input[:, slice_1:slice_2].A.shape
+        actual_shape_2 = matrix_input[:, slice_1:slice_3].A.shape
+    elif axis == 'both':
+        actual_shape_1 = matrix_input[slice_1:slice_2, slice_1:slice_2].A.shape
+        actual_shape_2 = matrix_input[slice_1:slice_3, slice_1:slice_3].A.shape
 
     assert actual_shape_1 == expected_shape
     assert actual_shape_1 == actual_shape_2


### PR DESCRIPTION
Motivated by continued concerns raised here: https://github.com/scipy/scipy/pull/11127#issuecomment-560623439

* CSC and CSR sparse matrix slices
that return empty matrices should
now correctly preserve a shape
of `(0, original_shape[1])`

I'm not a `sparse` expert---please do check & push/overwrite as needed.

Perhaps the tests might be abstracted to the base test module to verify both classes at the same time..