### PR TITLE
BUG: redundant fft in signal.resample

### DIFF
--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2830,7 +2830,6 @@ def resample(x, num, t=None, axis=0, window=None):
     >>> plt.show()
     """
     x = np.asarray(x)
-    X = sp_fft.fft(x, axis=axis)
     Nx = x.shape[axis]
 
     # Check if we can use faster real FFT


### PR DESCRIPTION
```
     
    x = np.asarray(x)
    X = sp_fft.fft(x, axis=axis)
    Nx = x.shape[axis]

    # Check if we can use faster real FFT
    real_input = np.isrealobj(x)

    # Forward transform
    if real_input:
        X = sp_fft.rfft(x, axis=axis)
    else:  # Full complex FFT
        X = sp_fft.fft(x, axis=axis)

```

the second line: **X = sp_fft.fft(x, axis=axis)** is redundant and the X variable will be override by rfft or fft based on if it's real input.