### PR TITLE
Fix dtype validation of "seuclidean" metric V parameter

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -316,8 +316,6 @@ def _validate_seuclidean_kwargs(X, m, n, **kwargs):
         V = np.var(X.astype(np.double), axis=0, ddof=1)
     else:
         V = np.asarray(V, order='c')
-        if V.dtype != np.double:
-            raise TypeError('Variance vector V must contain doubles.')
         if len(V.shape) != 1:
             raise ValueError('Variance vector V must '
                              'be one-dimensional.')

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -767,6 +767,11 @@ class TestPdist(object):
         Y_test1 = pdist(X, 'seuclidean')
         _assert_within_tol(Y_test1, Y_right, eps)
 
+        # Check no error is raise when V has float32 dtype (#11171).
+        V = np.var(X, axis=0, ddof=1)
+        Y_test2 = pdist(X, 'seuclidean', V=V)
+        _assert_within_tol(Y_test1, Y_right, eps)
+
     def test_pdist_seuclidean_random_nonC(self):
         # Test pdist(X, 'test_sqeuclidean') [the non-C implementation]
         eps = 1e-05


### PR DESCRIPTION
The validation of the V parameter of the "seuclidean" metric raises an error if V does not have a double dtype. It seems like a bug because other metrics, such as "mahalanobis" accept float dtype for their parameters and metrics support float dtype for the input X.

```
>>> import numpy as np
>>> from scipy.spatial.distance import pdist
>>> X = np.random.random_sample((10, 10)).astype(np.float32)
>>> V = np.var(X, axis=0, ddof=1)

>>> V.dtype
dtype('float32')

>>> pdist(X, metric="seuclidean", V=V)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/jeremie/R/dev/scipy/scipy/spatial/distance.py", line 2060, in pdist
    X, typ, kwargs = _validate_pdist_input(X, m, n,
  File "/home/jeremie/R/dev/scipy/scipy/spatial/distance.py", line 307, in _validate_pdist_input
    kwargs = _validate_kwargs(X, m, n, **kwargs)
  File "/home/jeremie/R/dev/scipy/scipy/spatial/distance.py", line 320, in _validate_seuclidean_kwargs
    raise TypeError('Variance vector V must contain doubles.')
TypeError: Variance vector V must contain doubles.
```

Based on the above remarks, I simply propose to remove this check.