### PR TITLE
MAINT: remove fortran file splitting

### DIFF
--- a/scipy/_build_utils/_fortran.py
+++ b/scipy/_build_utils/_fortran.py
@@ -4,8 +4,7 @@ import glob
 from distutils.dep_util import newer
 
 
-__all__ = ['needs_g77_abi_wrapper', 'split_fortran_files',
-           'get_g77_abi_wrappers']
+__all__ = ['needs_g77_abi_wrapper', 'get_g77_abi_wrappers']
 
 
 def uses_mkl(info):
@@ -44,84 +43,3 @@ def get_g77_abi_wrappers(info):
             os.path.join(path, 'src', 'wrap_dummy_g77_abi.f'),
         ]
     return wrapper_sources
-
-
-def split_fortran_files(source_dir, subroutines=None):
-    """Split each file in `source_dir` into separate files per subroutine.
-
-    Parameters
-    ----------
-    source_dir : str
-        Full path to directory in which sources to be split are located.
-    subroutines : list of str, optional
-        Subroutines to split. (Default: all)
-
-    Returns
-    -------
-    fnames : list of str
-        List of file names (not including any path) that were created
-        in `source_dir`.
-
-    Notes
-    -----
-    This function is useful for code that can't be compiled with g77 because of
-    type casting errors which do work with gfortran.
-
-    Created files are named: ``original_name + '_subr_i' + '.f'``, with ``i``
-    starting at zero and ending at ``num_subroutines_in_file - 1``.
-
-    """
-
-    if subroutines is not None:
-        subroutines = [x.lower() for x in subroutines]
-
-    def split_file(fname):
-        with open(fname, 'rb') as f:
-            lines = f.readlines()
-            subs = []
-            need_split_next = True
-
-            # find lines with SUBROUTINE statements
-            for ix, line in enumerate(lines):
-                m = re.match(b'^\\s+subroutine\\s+([a-z0-9_]+)\\s*\\(', line, re.I)
-                if m and line[0] not in b'Cc!*':
-                    if subroutines is not None:
-                        subr_name = m.group(1).decode('ascii').lower()
-                        subr_wanted = (subr_name in subroutines)
-                    else:
-                        subr_wanted = True
-                    if subr_wanted or need_split_next:
-                        need_split_next = subr_wanted
-                        subs.append(ix)
-
-            # check if no split needed
-            if len(subs) <= 1:
-                return [fname]
-
-            # write out one file per subroutine
-            new_fnames = []
-            num_files = len(subs)
-            for nfile in range(num_files):
-                new_fname = fname[:-2] + '_subr_' + str(nfile) + '.f'
-                new_fnames.append(new_fname)
-                if not newer(fname, new_fname):
-                    continue
-                with open(new_fname, 'wb') as fn:
-                    if nfile + 1 == num_files:
-                        fn.writelines(lines[subs[nfile]:])
-                    else:
-                        fn.writelines(lines[subs[nfile]:subs[nfile+1]])
-
-        return new_fnames
-
-    exclude_pattern = re.compile('_subr_[0-9]')
-    source_fnames = [f for f in sorted(glob.glob(os.path.join(source_dir, '*.f')))
-                             if not exclude_pattern.search(os.path.basename(f))]
-    fnames = []
-    for source_fname in source_fnames:
-        created_files = split_file(source_fname)
-        if created_files is not None:
-            for cfile in created_files:
-                fnames.append(os.path.basename(cfile))
-
-    return fnames

--- a/scipy/linalg/setup.py
+++ b/scipy/linalg/setup.py
@@ -8,7 +8,7 @@ def configuration(parent_package='', top_path=None):
     from distutils.sysconfig import get_python_inc
     from scipy._build_utils.system_info import get_info, NotFoundError, numpy_info
     from numpy.distutils.misc_util import Configuration, get_numpy_include_dirs
-    from scipy._build_utils import (get_g77_abi_wrappers, split_fortran_files)
+    from scipy._build_utils import get_g77_abi_wrappers
 
     config = Configuration('linalg', parent_package, top_path)
 
@@ -71,54 +71,9 @@ def configuration(parent_package='', top_path=None):
                          )
 
     # _interpolative:
-    routines_to_split = [
-        'dfftb1',
-        'dfftf1',
-        'dffti1',
-        'dsint1',
-        'dzfft1',
-        'id_srand',
-        'idd_copyints',
-        'idd_id2svd0',
-        'idd_pairsamps',
-        'idd_permute',
-        'idd_permuter',
-        'idd_random_transf0',
-        'idd_random_transf0_inv',
-        'idd_random_transf_init0',
-        'idd_subselect',
-        'iddp_asvd0',
-        'iddp_rsvd0',
-        'iddr_asvd0',
-        'iddr_rsvd0',
-        'idz_estrank0',
-        'idz_id2svd0',
-        'idz_permute',
-        'idz_permuter',
-        'idz_random_transf0_inv',
-        'idz_random_transf_init0',
-        'idz_random_transf_init00',
-        'idz_realcomp',
-        'idz_realcomplex',
-        'idz_reco',
-        'idz_subselect',
-        'idzp_aid0',
-        'idzp_aid1',
-        'idzp_asvd0',
-        'idzp_rsvd0',
-        'idzr_asvd0',
-        'idzr_reco',
-        'idzr_rsvd0',
-        'zfftb1',
-        'zfftf1',
-        'zffti1',
-    ]
-    print('Splitting linalg.interpolative Fortran source files')
-    dirname = os.path.split(os.path.abspath(__file__))[0]
-    fnames = split_fortran_files(join(dirname, 'src', 'id_dist', 'src'),
-                                 routines_to_split)
-    fnames = [join('src', 'id_dist', 'src', f) for f in fnames]
-    config.add_extension('_interpolative', fnames + ["interpolative.pyf"],
+    config.add_extension('_interpolative',
+                         sources=[join('src', 'id_dist', 'src', '*.f'),
+                                  "interpolative.pyf"],
                          extra_info=lapack_opt
                          )
 


### PR DESCRIPTION
Minor maintenance cleanup: this was required for supporting g77,
but we don't support that compiler any more.