### PR TITLE
MAINT: add rvs method to argus in scipy.stats

### DIFF
--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -52,7 +52,7 @@ distslow = ['kappa4', 'gausshyper', 'recipinvgauss', 'genexpon',
 # distslow are sorted by speed (very slow to slow)
 
 # skip check_fit_args (test is slow)
-skip_fit_test = ['argus', 'exponpow', 'exponweib', 'gausshyper', 'genexpon',
+skip_fit_test = ['exponpow', 'exponweib', 'gausshyper', 'genexpon',
                  'halfgennorm', 'gompertz', 'johnsonsb', 'johnsonsu',
                  'kappa4', 'ksone', 'kstwo', 'kstwobign', 'mielke', 'ncf', 'nct',
                  'powerlognorm', 'powernorm', 'recipinvgauss', 'trapz',
@@ -60,7 +60,7 @@ skip_fit_test = ['argus', 'exponpow', 'exponweib', 'gausshyper', 'genexpon',
                  'levy_stable', 'rv_histogram_instance']
 
 # skip check_fit_args_fix (test is slow)
-skip_fit_fix_test = ['argus', 'burr', 'exponpow', 'exponweib',
+skip_fit_fix_test = ['burr', 'exponpow', 'exponweib',
                      'gausshyper', 'genexpon', 'halfgennorm',
                      'gompertz', 'johnsonsb', 'johnsonsu', 'kappa4',
                      'ksone', 'kstwo', 'kstwobign', 'levy_stable', 'mielke', 'ncf',
@@ -264,9 +264,9 @@ def test_rvs_broadcast(dist, shape_args):
     # implementation detail of the distribution, not a requirement.  If
     # the implementation the rvs() method of a distribution changes, this
     # test might also have to be changed.
-    shape_only = dist in ['betaprime', 'dgamma', 'dweibull', 'exponnorm',
-                          'geninvgauss', 'levy_stable', 'nct', 'norminvgauss',
-                          'rice', 'skewnorm', 'semicircular']
+    shape_only = dist in ['argus', 'betaprime', 'dgamma', 'dweibull',
+                          'exponnorm', 'geninvgauss', 'levy_stable', 'nct',
+                          'norminvgauss', 'rice', 'skewnorm', 'semicircular']
 
     distfunc = getattr(stats, dist)
     loc = np.zeros(2)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -4147,25 +4147,6 @@ def test_crystalball_function_moments():
     assert_allclose(expected_5th_moment, calculated_5th_moment, rtol=0.001)
 
 
-def test_argus_function():
-    # There is no usable reference implementation.
-    # (RootFit implementation returns unreasonable results which are not
-    # normalized correctly.)
-    # Instead we do some tests if the distribution behaves as expected for
-    # different shapes and scales.
-    for i in range(1, 10):
-        for j in range(1, 10):
-            assert_equal(stats.argus.pdf(i + 0.001, chi=j, scale=i), 0.0)
-            assert_(stats.argus.pdf(i - 0.001, chi=j, scale=i) > 0.0)
-            assert_equal(stats.argus.pdf(-0.001, chi=j, scale=i), 0.0)
-            assert_(stats.argus.pdf(+0.001, chi=j, scale=i) > 0.0)
-
-    for i in range(1, 10):
-        assert_equal(stats.argus.cdf(1.0, chi=i), 1.0)
-        assert_equal(stats.argus.cdf(1.0, chi=i),
-                     1.0 - stats.argus.sf(1.0, chi=i))
-
-
 def test_ncf_variance():
     # Regression test for gh-10658 (incorrect variance formula for ncf).
     # The correct value of ncf.var(2, 6, 4), 42.75, can be verified with, for
@@ -4283,8 +4264,14 @@ def test_loguniform():
     assert np.abs(np.median(vals) - 1000) <= 10
 
 
-def test_argus_rvs_large_chi():
-    np.random.seed(325)
-    # test that the rejection algorithm can handle large values of chi
-    x = stats.argus.rvs(50, size=500)
-    assert_almost_equal(stats.argus(50).mean(), x.mean(), decimal=4)
+class TestArgus(object):
+    def test_argus_rvs_large_chi(self):
+        # test that the algorithm can handle large values of chi
+        x = stats.argus.rvs(50, size=500, random_state=325)
+        assert_almost_equal(stats.argus(50).mean(), x.mean(), decimal=4)
+
+    def test_argus_rvs_ratio_uniforms(self):
+        # test that the ratio of uniforms algorithms works for chi > 2.611
+        x = stats.argus.rvs(3.5, size=1500, random_state=1535)
+        assert_almost_equal(stats.argus(3.5).mean(), x.mean(), decimal=3)
+        assert_almost_equal(stats.argus(3.5).std(), x.std(), decimal=3)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -4281,3 +4281,10 @@ def test_loguniform():
     vals, _ = np.histogram(np.log10(rvs), bins=10)
     assert 900 <= vals.min() <= vals.max() <= 1100
     assert np.abs(np.median(vals) - 1000) <= 10
+
+
+def test_argus_rvs_large_chi():
+    np.random.seed(325)
+    # test that the rejection algorithm can handle large values of chi
+    x = stats.argus.rvs(50, size=500)
+    assert_almost_equal(stats.argus(50).mean(), x.mean(), decimal=4)


### PR DESCRIPTION
#### Reference issue
ARGUS rvs is slow: #10106

#### What does this implement/fix?
Add a sampling method (_rvs) for the ARGUS distribution

#### Additional information
I implemented a simple rejection algorithm (description is in the code, I did all the math myself :) ).

timit results for `chi=1.0` (value in `_distr_params.py`) to generate 10k rvs:

Current: 6.53 ms ± 363 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
New: 508 µs ± 23.5 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

(When I did the simulation in 10106, it took much longer to generate rvs with the default method, I don't know why).

For large values of chi (i.e. chi > 26), `exp(chi**2 / 2)` is infinite and the method does not work. This is not too relevant since the density is almost 0 everywhere except very close to 1.
