### PR TITLE
ENH: linalg: Add lwork wrapper for ?geqrf

### DIFF
--- a/scipy/linalg/flapack_gen.pyf.src
+++ b/scipy/linalg/flapack_gen.pyf.src
@@ -980,7 +980,7 @@ end subroutine <prefix>geqrf
 
 subroutine <prefix>geqrf_lwork(m,n,a,tau,work,lwork,info)
     ! work, info = geqrf_lwork(m, n)
-    ! Calcualte the size of the ?geqrf work array.
+    ! Calculate the optimal size of the ?geqrf work array.
 
     fortranname <prefix>geqrf
     callstatement (*f2py_func)(&m,&n,&a,&m,&tau,&work,&lwork,&info)

--- a/scipy/linalg/flapack_gen.pyf.src
+++ b/scipy/linalg/flapack_gen.pyf.src
@@ -978,6 +978,24 @@ subroutine <prefix>geqrf(m,n,a,tau,work,lwork,info)
 
 end subroutine <prefix>geqrf
 
+subroutine <prefix>geqrf_lwork(m,n,a,tau,work,lwork,info)
+    ! work, info = geqrf_lwork(m, n)
+    ! Calcualte the size of the ?geqrf work array.
+
+    fortranname <prefix>geqrf
+    callstatement (*f2py_func)(&m,&n,&a,&m,&tau,&work,&lwork,&info)
+    callprotoargument int*,int*,<ctype>*,int*,<ctype>*,<ctype>*,int*,int*
+
+    integer intent(in), check(m > 0) :: m
+    integer intent(in), check(n > 0) :: n
+    <ftype> intent(hide) :: a
+    <ftype> intent(hide) :: tau
+    integer intent(hide) :: lwork = -1
+    <ftype> intent(out) :: work
+    integer intent(out) :: info
+
+end subroutine <prefix>geqrf_lwork
+
 subroutine <prefix>gerqf(m,n,a,tau,work,lwork,info)
    ! rq_a,tau,work,info = gerqf(a,lwork=3*n,overwrite_a=0)
    ! Compute an RQ factorization of a real M-by-N matrix A:

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -164,6 +164,11 @@ All functions
    cgeqrf
    zgeqrf
 
+   sgeqrf_lwork
+   dgeqrf_lwork
+   cgeqrf_lwork
+   zgeqrf_lwork
+
    sgerqf
    dgerqf
    cgerqf

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -407,16 +407,15 @@ class TestLeastSquaresSolvers(object):
 
 
 @pytest.mark.parametrize('dtype', DTYPES)
-def test_geqrf_lwork(dtype):
+@pytest.mark.parametrize('shape', [(3, 4), (5, 2), (2**18, 2**18)])
+def test_geqrf_lwork(dtype, shape):
     geqrf, geqrf_lwork = get_lapack_funcs(
         ('geqrf', 'geqrf_lwork'),
         dtype=dtype,
     )
-    m, n = 4, 3
-    _, _, work, _ = geqrf(np.ones((m, n), dtype=dtype), lwork=-1)
+    m, n = shape
     lwork, info = geqrf_lwork(m=m, n=n)
     assert_equal(info, 0)
-    assert_equal(lwork, work[0])
 
 
 class TestRegression(object):

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -409,10 +409,7 @@ class TestLeastSquaresSolvers(object):
 @pytest.mark.parametrize('dtype', DTYPES)
 @pytest.mark.parametrize('shape', [(3, 4), (5, 2), (2**18, 2**18)])
 def test_geqrf_lwork(dtype, shape):
-    geqrf, geqrf_lwork = get_lapack_funcs(
-        ('geqrf', 'geqrf_lwork'),
-        dtype=dtype,
-    )
+    geqrf_lwork = get_lapack_funcs(('geqrf_lwork'), dtype=dtype)
     m, n = shape
     lwork, info = geqrf_lwork(m=m, n=n)
     assert_equal(info, 0)

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -406,6 +406,19 @@ class TestLeastSquaresSolvers(object):
                             rtol=25*np.finfo(dtype).eps)
 
 
+@pytest.mark.parametrize('dtype', DTYPES)
+def test_geqrf_lwork(dtype):
+    geqrf, geqrf_lwork = get_lapack_funcs(
+        ('geqrf', 'geqrf_lwork'),
+        dtype=dtype,
+    )
+    m, n = 4, 3
+    _, _, work, _ = geqrf(np.ones((m, n), dtype=dtype), lwork=-1)
+    lwork, info = geqrf_lwork(m=m, n=n)
+    assert_equal(info, 0)
+    assert_equal(lwork, work[0])
+
+
 class TestRegression(object):
 
     def test_ticket_1645(self):


### PR DESCRIPTION
This commit adds the missing wrapper for ?geqrf_lwork as discussed in #11169. 

@ilayn would you please take a look over this? The main issue I came across is trying to find the required values to pass. Looking at ``ilaenv`` it requires each dimension `m`, `n` but is there a more general way to find the required arguments?