### PR TITLE
BUG: fix edge counting in shortest_path

### DIFF
--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -171,9 +171,9 @@ def shortest_path(csgraph, method='auto',
             Nk = csgraph.count()
             edges = csgraph.compressed()
         else:
-            csgraph[~np.isfinite(csgraph)] = 0
-            Nk = np.sum(csgraph > 0)
-            edges = csgraph
+            edges = csgraph[np.isfinite(csgraph)]
+            edges = edges[edges != 0]
+            Nk = edges.size
 
         if indices is not None or Nk < N * N / 4:
             if (np.any(edges < 0)):

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -166,10 +166,10 @@ def shortest_path(csgraph, method='auto',
         issparse = isspmatrix(csgraph)
         if issparse:
             Nk = csgraph.nnz
-            if isspmatrix_csr(csgraph) or isspmatrix_csc(csgraph):
+            if csgraph.format in ('csr', 'csc', 'coo'):
                 edges = csgraph.data
-            else: 
-                edges = csgraph.tocsr().data
+            else:
+                edges = csgraph.tocoo().data
         elif np.ma.isMaskedArray(csgraph):
             Nk = csgraph.count()
             edges = csgraph.compressed()

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -166,7 +166,10 @@ def shortest_path(csgraph, method='auto',
         issparse = isspmatrix(csgraph)
         if issparse:
             Nk = csgraph.nnz
-            edges = csgraph.data
+            if isspmatrix_csr(csgraph) or isspmatrix_csc(csgraph):
+                edges = csgraph.data
+            else: 
+                edges = csgraph.tocsr().data
         elif np.ma.isMaskedArray(csgraph):
             Nk = csgraph.count()
             edges = csgraph.compressed()

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -176,7 +176,7 @@ def shortest_path(csgraph, method='auto',
             Nk = edges.size
 
         if indices is not None or Nk < N * N / 4:
-            if (np.any(edges < 0)):
+            if np.any(edges < 0):
                 method = 'J'
             else:
                 method = 'D'

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -166,12 +166,17 @@ def shortest_path(csgraph, method='auto',
         issparse = isspmatrix(csgraph)
         if issparse:
             Nk = csgraph.nnz
+            edges = csgraph.data
+        elif np.ma.isMaskedArray(csgraph):
+            Nk = csgraph.count()
+            edges = csgraph.compressed()
         else:
+            csgraph[~np.isfinite(csgraph)] = 0
             Nk = np.sum(csgraph > 0)
+            edges = csgraph
 
         if indices is not None or Nk < N * N / 4:
-            if ((issparse and np.any(csgraph.data < 0))
-                      or (not issparse and np.any(csgraph < 0))):
+            if (np.any(edges < 0)):
                 method = 'J'
             else:
                 method = 'D'

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -319,12 +319,18 @@ def test_NaN_warnings():
     for r in record:
         assert r.category is not RuntimeWarning
 
+
 def test_lil_matrix():
-    # Test that using lil sparse matrix do not cause error 
-    G_dense = np.array([[0, 3, 0, 0 ,0],
+    # Test that using lil sparse matrix do not cause error
+    G_dense = np.array([[0, 3, 0, 0, 0],
                         [0, 0, -1, 0, 0],
                         [0, 0, 0, 2, 0],
                         [0, 0, 0, 0, 4],
-                        [0, 0, 0, 0, 0]])
+                        [0, 0, 0, 0, 0]], dtype=float)
+    SP = shortest_path(G_dense)
+    G_csr = scipy.sparse.csr_matrix(G_dense)
+    G_csc = scipy.sparse.csc_matrix(G_dense)
     G_lil = scipy.sparse.lil_matrix(G_dense)
-    shortest_path(G_lil)
+    assert_array_almost_equal(SP, shortest_path(G_csr))
+    assert_array_almost_equal(SP, shortest_path(G_csc))
+    assert_array_almost_equal(SP, shortest_path(G_lil))

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -320,8 +320,8 @@ def test_NaN_warnings():
         assert r.category is not RuntimeWarning
 
 
-def test_lil_matrix():
-    # Test that using lil sparse matrix do not cause error
+def test_sparse_matrices():
+    # Test that using lil,csr and csc sparse matrix do not cause error
     G_dense = np.array([[0, 3, 0, 0, 0],
                         [0, 0, -1, 0, 0],
                         [0, 0, 0, 2, 0],

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -316,5 +316,5 @@ def test_buffer(method):
 def test_NaN_warnings():
     with pytest.warns(None) as record:
         shortest_path(np.array([[0, 1], [np.nan, 0]]))
-    for i in range(len(record)):
-        assert record[i].category is not RuntimeWarning
+    for r in record:
+        assert r.category is not RuntimeWarning

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -316,4 +316,5 @@ def test_buffer(method):
 def test_NaN_warnings():
     with pytest.warns(None) as record:
         shortest_path(np.array([[0, 1], [np.nan, 0]]))
-    assert not record
+    for i in range(len(record)):
+        assert record[i].category is not RuntimeWarning

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -311,3 +311,9 @@ def test_buffer(method):
     G = scipy.sparse.csr_matrix([[1.]])
     G.data.flags['WRITEABLE'] = False
     shortest_path(G, method=method)
+
+
+def test_NaN_warnings():
+    with pytest.warns(None) as record:
+        shortest_path(np.array([[0, 1], [np.nan, 0]]))
+    assert not record

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -318,3 +318,13 @@ def test_NaN_warnings():
         shortest_path(np.array([[0, 1], [np.nan, 0]]))
     for r in record:
         assert r.category is not RuntimeWarning
+
+def test_lil_matrix():
+    # Test that using lil sparse matrix do not cause error 
+    G_dense = np.array([[0, 3, 0, 0 ,0],
+                        [0, 0, -1, 0, 0],
+                        [0, 0, 0, 2, 0],
+                        [0, 0, 0, 0, 4],
+                        [0, 0, 0, 0, 0]])
+    G_lil = scipy.sparse.lil_matrix(G_dense)
+    shortest_path(G_lil)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->
#### What does this implement/fix?
In the shortest paths function(with method == 'auto') there was a bug in counting edges for dense graph representation. (non-existent edges marked with np.inf were counted, while existing edges with weight 0 were skipped). This could lead to the selection of a suboptimal algorithm.
I fixed it by splitting it into two cases:
* For dense masked representation I counted number of non-masked elements.
* For dense array representation I changed elements equal to inf and NaN to 0 and then I counted number of elements bigger than 0.

I also got rid of the warnings that popped up when non-existent edges were marked by NaN. Thus this fixes #5144.

