### PR TITLE
BUG: #11207 _minimize_scalar_bounded: reference before assignment

### DIFF
--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -55,6 +55,7 @@ _status_message = {'success': 'Optimization terminated successfully.',
 class MemoizeJac(object):
     """ Decorator that caches the value gradient of function each time it
     is called. """
+
     def __init__(self, fun):
         self.fun = fun
         self.jac = None
@@ -111,6 +112,7 @@ class OptimizeResult(dict):
     with attribute accessors, one can see which attributes are available
     using the `keys()` method.
     """
+
     def __getattr__(self, name):
         try:
             return self[name]
@@ -1795,6 +1797,7 @@ def _minimize_scalar_bounded(func, bounds, args=(),
     fx = func(x, *args)
     num = 1
     fmin_data = (1, xf, fx)
+    fu = np.inf
 
     ffulc = fnfc = fx
     xm = 0.5 * (a + b)
@@ -2988,6 +2991,7 @@ class _Brute_Wrapper(object):
     """
     Object to wrap user cost function for optimize.brute, allowing picklability
     """
+
     def __init__(self, f, args):
         self.f = f
         self.args = [] if args is None else args

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -1175,6 +1175,11 @@ class TestOptimizeScalar(object):
         x = optimize.fminbound(self.fun, 1, np.array(5))
         assert_allclose(x, self.solution, atol=1e-6)
 
+    def test_gh11207(self):
+        def fun(x):
+            return x**2
+        optimize.fminbound(fun, 0, 0)
+
     def test_minimize_scalar(self):
         # combine all tests above for the minimize_scalar wrapper
         x = optimize.minimize_scalar(self.fun).x


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes gh-11207

#### What does this implement/fix?
<!--Please explain your changes.-->
This avoid a reference before assignment in `fminbound()` and adds a test to make sure this error never happens again.

#### Additional information
<!--Any additional information you think is important.-->