### PR TITLE
ENH: Adds Carlson's elliptic integrals in `scipy.special`

### DIFF
--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -59,6 +59,8 @@ Elliptic functions and integrals
    ellipkinc -- Incomplete elliptic integral of the first kind.
    ellipe    -- Complete elliptic integral of the second kind.
    ellipeinc -- Incomplete elliptic integral of the second kind.
+   ellipc1   -- Incomplete Carlson integral of the first kind.
+   ellipc2   -- Incomplete Carlson integral of the second kind.
 
 Bessel functions
 ----------------
@@ -671,6 +673,8 @@ __all__ = _ufuncs.__all__ + _basic.__all__ + orthogonal.__all__ + [
     'spherical_yn',
     'spherical_in',
     'spherical_kn',
+    'ellipc1',
+    'ellipc2'
 ]
 
 from scipy._lib._testutils import PytestTester

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -90,7 +90,9 @@ __all__ = [
     'ynp_zeros',
     'yv',
     'yvp',
-    'zeta'
+    'zeta',
+    'ellipc1',
+    'ellipc2'
 ]
 
 
@@ -2276,7 +2278,7 @@ def ellipc1(x, y, z, errtol=3e-4):
 
     Returns
     -------
-    RF : ndarray
+    rf : ndarray
         Value of the incomplete first order elliptic integral
 
     Notes
@@ -2347,7 +2349,7 @@ def ellipc2(x, y, z, errtol=1e-4):
 
     Returns
     -------
-    RD : ndarray
+    rd : ndarray
         Value of the incomplete second order elliptic integral
 
     Notes

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2293,15 +2293,15 @@ def ellipc1(x, y, z, errtol=3e-4):
     xn = x.copy()
     yn = y.copy()
     zn = z.copy()
-    An = (xn + yn + zn) / 3.0
-    Q = (3. * errtol) ** (-1 / 6.) * \
-        np.max(np.abs([An - xn, An - yn, An - zn]), axis=0)
+    an = (xn + yn + zn) / 3.0
+    qq = (3. * errtol) ** (-1 / 6.) * \
+        np.max(np.abs([an - xn, an - yn, an - zn]), axis=0)
     # Convergence has to be done element-by-element:
     index = np.ndindex(*x.shape)
     for v in index:
         n = 0
         # Convergence condition
-        while 4.**(-n) * Q[v] > abs(An[v]):
+        while 4.**(-n) * qq[v] > abs(an[v]):
             xnroot = np.sqrt(xn[v])
             ynroot = np.sqrt(yn[v])
             znroot = np.sqrt(zn[v])
@@ -2310,18 +2310,18 @@ def ellipc1(x, y, z, errtol=3e-4):
             xn[v] = (xn[v] + lamda) * 0.250
             yn[v] = (yn[v] + lamda) * 0.250
             zn[v] = (zn[v] + lamda) * 0.250
-            An[v] = (An[v] + lamda) * 0.250
+            an[v] = (an[v] + lamda) * 0.250
 
     # post convergence calculation
-    X = 1. - xn / An
-    Y = 1. - yn / An
+    X = 1. - xn / an
+    Y = 1. - yn / an
     Z = - X - Y
-    E2 = X * Y - Z * Z
-    E3 = X * Y * Z
-    RF = An**(-1 / 2.) * \
-        (1 - E2 / 10. + E3 / 14. + (E2**2) / 24. - 3 / 44. * E2 * E3)
+    e2 = X * Y - Z * Z
+    e3 = X * Y * Z
+    rf = an**(-1 / 2.) * \
+        (1 - e2 / 10. + e3 / 14. + (e2**2) / 24. - 3 / 44. * e2 * e3)
 
-    return RF
+    return rf
 
 
 def ellipc2(x, y, z, errtol=1e-4):
@@ -2364,10 +2364,10 @@ def ellipc2(x, y, z, errtol=1e-4):
     xn = x.copy()
     yn = y.copy()
     zn = z.copy()
-    A0 = (xn + yn + 3. * zn) / 5.0
-    An = A0.copy()
-    Q = (errtol / 4.) ** (-1 / 6.) * \
-        np.max(np.abs([An - xn, An - yn, An - zn]), axis=0)
+    a0 = (xn + yn + 3. * zn) / 5.0
+    an = a0.copy()
+    qq = (errtol / 4.) ** (-1 / 6.) * \
+        np.max(np.abs([an - xn, an - yn, an - zn]), axis=0)
     sum_term = np.zeros(x.shape, dtype=x.dtype)
     n = np.zeros(x.shape)
 
@@ -2375,7 +2375,7 @@ def ellipc2(x, y, z, errtol=1e-4):
     index = np.ndindex(*x.shape)
     for v in index:
         # Convergence condition
-        while 4.**(-n[v]) * Q[v] > abs(An[v]):
+        while 4.**(-n[v]) * qq[v] > abs(an[v]):
             xnroot = np.sqrt(xn[v])
             ynroot = np.sqrt(yn[v])
             znroot = np.sqrt(zn[v])
@@ -2386,20 +2386,20 @@ def ellipc2(x, y, z, errtol=1e-4):
             xn[v] = (xn[v] + lamda) * 0.250
             yn[v] = (yn[v] + lamda) * 0.250
             zn[v] = (zn[v] + lamda) * 0.250
-            An[v] = (An[v] + lamda) * 0.250
+            an[v] = (an[v] + lamda) * 0.250
 
     # post convergence calculation
-    X = (A0 - x) / (4.**(n) * An)
-    Y = (A0 - y) / (4.**(n) * An)
+    X = (a0 - x) / (4.**(n) * an)
+    Y = (a0 - y) / (4.**(n) * an)
     Z = - (X + Y) / 3.
-    E2 = X * Y - 6. * Z * Z
-    E3 = (3. * X * Y - 8. * Z * Z) * Z
-    E4 = 3. * (X * Y - Z * Z) * Z**2.
-    E5 = X * Y * Z**3.
-    RD = \
-        4**(-n) * An**(-3 / 2.) * \
-        (1 - 3 / 14. * E2 + 1 / 6. * E3 +
-         9 / 88. * (E2**2) - 3 / 22. * E4 - 9 / 52. * E2 * E3 +
-         3 / 26. * E5) + 3 * sum_term
+    e2 = X * Y - 6. * Z * Z
+    e3 = (3. * X * Y - 8. * Z * Z) * Z
+    e4 = 3. * (X * Y - Z * Z) * Z**2.
+    e5 = X * Y * Z**3.
+    rd = \
+        4**(-n) * an**(-3 / 2.) * \
+        (1 - 3 / 14. * e2 + 1 / 6. * e3 +
+         9 / 88. * (e2**2) - 3 / 22. * e4 - 9 / 52. * e2 * e3 +
+         3 / 26. * e5) + 3 * sum_term
 
-    return RD
+    return rd

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2287,6 +2287,8 @@ def ellipc1(x, y, z, errtol=3e-4):
     ----------
     .. [1] Carlson, B.C., 1994. Numerical computation of real or complex
            elliptic integrals. arXiv:math/9409227 [math.CA]
+
+    .. versionadded:: 1.5.0
     """
     xn = x.copy()
     yn = y.copy()
@@ -2351,6 +2353,13 @@ def ellipc2(x, y, z, errtol=1e-4):
     Notes
     ------
     x, y, and z have to be nonnegative and at most x or y is zero.
+
+    References
+    ----------
+    .. [1] Carlson, B.C., 1994. Numerical computation of real or complex
+           elliptic integrals. arXiv:math/9409227 [math.CA]
+
+    .. versionadded:: 1.5.0
     """
     xn = x.copy()
     yn = y.copy()

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -35,7 +35,7 @@ from numpy.testing import (assert_equal, assert_almost_equal,
 
 from scipy import special
 import scipy.special._ufuncs as cephes
-from scipy.special import ellipk, zeta
+from scipy.special import ellipk, zeta, ellipc1, ellipc2
 
 from scipy.special._testutils import with_special_errors, \
      assert_func_equal, FuncData
@@ -3397,3 +3397,74 @@ def test_pseudo_huber():
     z = np.array(np.random.randn(10, 2).tolist() + [[0, 0.5], [0.5, 0]])
     w = np.vectorize(xfunc, otypes=[np.float64])(z[:,0], z[:,1])
     assert_func_equal(special.pseudo_huber, w, z, rtol=1e-13, atol=1e-13)
+
+
+def test_ellipc1():
+    # Define inputs that we know the outputs from:
+    # Carlson, B.C., 1994. Numerical computation of real or complex
+    # elliptic integrals. arXiv:math/9409227 [math.CA]
+
+    # Real values (test in 2D format)
+    x = np.array([[1.0, 0.5], [2.0, 2.0]])
+    y = np.array([[2.0, 1.0], [3.0, 3.0]])
+    z = np.array([[0.0, 0.0], [4.0, 4.0]])
+
+    # Define reference outputs
+    RF_ref = np.array([[1.3110287771461, 1.8540746773014],
+                       [0.58408284167715, 0.58408284167715]])
+
+    # Compute integrals
+    RF = ellipc1(x, y, z)
+
+    # Compare
+    assert_array_almost_equal(RF, RF_ref)
+
+    # Complex values
+    x = np.array([1j, 1j - 1, 1j, 1j - 1])
+    y = np.array([-1j, 1j, -1j, 1j])
+    z = np.array([0.0, 0.0, 2, 1 - 1j])
+
+    # Define reference outputs
+    RF_ref = np.array([1.8540746773014, 0.79612586584234 - 1.2138566698365j,
+                       1.0441445654064, 0.93912050218619 - 0.53296252018635j])
+    # Compute integrals
+    RF = ellipc1(x, y, z, errtol=3e-5)
+
+    # Compare
+    assert_array_almost_equal(RF, RF_ref)
+
+
+def test_ellipc2():
+
+    # Define inputs that we know the outputs from:
+    # Carlson, B.C., 1994. Numerical computation of real or complex
+    # elliptic integrals. arXiv:math/9409227 [math.CA]
+
+    # Real values
+    x = np.array([0.0, 2.0])
+    y = np.array([2.0, 3.0])
+    z = np.array([1.0, 4.0])
+
+    # Defene reference outputs
+    RD_ref = np.array([1.7972103521034, 0.16510527294261])
+
+    # Compute integrals
+    RD = ellipc2(x, y, z, errtol=1e-5)
+
+    # Compare
+    assert_array_almost_equal(RD, RD_ref)
+
+    # Complex values (testing in 2D format)
+    x = np.array([[1j, 0.0], [0.0, -2 - 1j]])
+    y = np.array([[-1j, 1j], [1j-1, -1j]])
+    z = np.array([[2.0, -1j], [1j, -1 + 1j]])
+
+    # Defene reference outputs
+    RD_ref = np.array([[0.65933854154220, 1.2708196271910 + 2.7811120159521j],
+                       [-1.8577235439239 - 0.96193450888839j,
+                        1.8249027393704 - 1.2218475784827j]])
+    # Compute integrals
+    RD = ellipc2(x, y, z, errtol=1e-5)
+
+    # Compare
+    assert_array_almost_equal(RD, RD_ref)


### PR DESCRIPTION

#### Reference issue
Addresses https://github.com/scipy/scipy/issues/4452

#### What does this implement/fix?
This implements Carlson's elliptical integral functions 

This was implemented by @RafaelNH as part of the DIPY, which is BSD licensed. I am wondering how t give him and the project credit and signify that is used in accordance with the original license.