### PR TITLE
Improved Radial Basis Function Interpolation

### DIFF
--- a/scipy/interpolate/__init__.py
+++ b/scipy/interpolate/__init__.py
@@ -171,6 +171,7 @@ from .fitpack import *
 from .fitpack2 import *
 
 from .rbf import Rbf
+from .radial_basis_interp import RadialBasisFunction
 
 from .polyint import *
 

--- a/scipy/interpolate/radial_basis_interp.py
+++ b/scipy/interpolate/radial_basis_interp.py
@@ -1,0 +1,200 @@
+import sys
+if sys.version_info[0] >2:
+    unicode = str
+
+import numpy as np
+import scipy.spatial
+from scipy.special import xlogy
+import scipy.linalg
+
+class RadialBasisFunction(object):
+    """
+    Augmented Radial Basis function interpolation with (optional) polynomial 
+    augmentation. The construction follows [1] with code borrowed from [2] 
+    for the kernel (which they call the "function")
+    
+    Parameters
+    ----------
+    X : (Npoints, Ndims) ndarray of floats
+        Data point coordinates.
+
+    f : (Npoints,) ndarray of float or complex
+        Data values.
+
+    degree : int optional
+        Use an augmented RBF. Specify the *total* degree fit if given as an 
+        integer. If given as a matrix, must be (P+1,ndim) shape. This is the 
+        degree of the augmenting polynomial. Default: 0
+    
+    kernel : string, callable, or int optional
+        Default: gaussian
+        The radial basis kernel, based on the radius, r
+        If string:
+            'multiquadric': sqrt((r/epsilon)**2 + 1)
+            'inverse': 1.0/sqrt((r/epsilon)**2 + 1)
+            'gaussian': exp(-(r/epsilon)**2)
+            'linear': r
+            'cubic': r**3
+            'quintic': r**5
+            'thin_plate': r**2 * log(r)
+        If callable
+            must take the arguments (r,epsilon) and ignore epsilon if 
+            not needed. 
+        If integer:
+            Spline of the form: r**kernel if kernel is odd else r**kernel*log(r)
+
+    epsilon: float or None , optional
+        Adjustable parameter for some kernels. Default: None
+        
+    smooth : float or None, optional
+        Values greater than zero increase the smoothness of the
+        approximation.  0 is for interpolation (default). Actually set to
+        max(smooth,1e-10 * ||f||) for numerical precision
+
+    Theory:
+    ------
+    The RBF is based on a radial distance 
+    
+        r_j = ||x - x_j||                                               (1)
+    
+    with the kernel phi(r) and an optional "Agumenting" polynomial of set 
+    degree. The interpolant is of the form: [1]
+    
+        s(x) = sum_{j=1}^N c_j * phi(r_j) + sum_{k \in P} g_k * p_k     (2)
+    
+    where `P` is a polynomial index and `p_k` is the corresponding
+    polynomial (e.g. k = {1,2,0} then p_k = x*y^2*z^0).
+    
+    In order to solve for c_j and g_k we enforce 
+        (a) s(x_j) = f_j for all j (i.e. exact interpolation)
+        (b) sum_{j=1}^N c_j*p_k(x_j) = 0 for all k=1,...,N 
+    
+    That results in a matrix system:
+        ____________________________________________________   ___     ___
+       |                            |                       | |   |   |   |
+       |   phi(||x_i - x_j||) (N,N) |   p_k(x_j) (N,len(K)) | | c |   | f |
+       |                            |                       | |   | = |   | (3)
+       |----------------------------|-----------------------| |---|   |---|
+       |       p_k(x_j).T           |           0           | | g |   | 0 |
+        ----------------------------------------------------   ---     ---
+      
+    which is then solved. Given c and g, (2) can be used to solve for
+    any given x
+    
+    References:
+    ----------  
+    [1] G. B. Wright. Radial Basis Function Interpolation: Numerical and 
+        Analytical Developments. PhD thesis, University of Colorado, 2003.
+
+    [2] SciPy version 1.1.0
+        https://github.com/scipy/scipy/blob/v1.1.0/scipy/interpolate/rbf.py
+    
+    [3] S. Rippa. An algorithm for selecting a good value for the parameter 
+        c in radial basis function interpolation. Advances in Computational 
+        Mathematics, 11(2-3):193–210, 1999.
+        
+    [4] J. D. Martin and T. W. Simpson. Use of Kriging Models to Approximate 
+        Deterministic Computer Models. AIAA journal, 43(4):853–863, 2005.
+
+    """
+    def __init__(self,X,f,degree=0,
+                 epsilon=1,smooth=0,
+                 kernel='gaussian',_solve=True):
+        self.X = X = np.atleast_2d(X)
+        self.N,self.ndim = X.shape
+        self.f = f = np.ravel(f)
+        self.degree = degree
+        self.kernel = kernel
+        self.epsilon = epsilon
+        
+        
+        r = scipy.spatial.distance.cdist(X,X)
+
+        self.smooth = max(float(smooth),1e-10*scipy.linalg.norm(f)/np.sqrt(len(f))) # Scale by ||f||
+        
+        K = self._kernel(r) + np.eye(self.N)*self.smooth
+        P = RadialBasisFunction.vandermond(X,degree=self.degree)
+        
+        # Build the matrix
+        Z = np.zeros([P.shape[1]]*2)
+        z = np.zeros(P.shape[1])
+        KP = np.block([[K   , P],
+                       [P.T , Z]])
+        b = np.hstack([f,z])
+        coef = scipy.linalg.solve(KP,b)
+        self.rbf_coef = coef[:self.N]
+        self.poly_coef = coef[self.N:]
+        
+
+    def __call__(self,X):
+        X = np.atleast_2d(X)
+        K = self._kernel( scipy.spatial.distance.cdist(X,self.X) )
+        P = RadialBasisFunction.vandermond(X,degree=self.degree)
+        return K.dot(self.rbf_coef) + P.dot(self.poly_coef)
+
+    def _kernel(self,r):
+        r = np.asarray(r)
+        if callable(self.kernel):
+            return self.kernel(r,self.epsilon)
+        elif isinstance(self.kernel,(int,np.integer)):
+            if np.mod(self.kernel,2) == 0:
+                return xlogy(r**self.kernel,r)
+            else:
+                return r**self.kernel
+        elif not isinstance(self.kernel,(str,unicode)):
+            raise ValueError('Kernel must be a callable with signature (r,epsilon), an integer (spline) or a valid string')
+        
+        kernel = self.kernel.lower().replace(' ','_').replace('-','_')
+        
+        if kernel in ['multiquadric']:
+            return np.sqrt((r/self.epsilon)**2 + 1)
+        elif kernel in ['inverse_multiquadric','inverse']:
+            return 1.0/np.sqrt((1.0/self.epsilon*r)**2 + 1)
+        elif kernel in ['gaussian','squared_exponential']:
+            return np.exp(-(1.0/self.epsilon*r)**2)
+        elif kernel in ['linear']:
+            return r
+        elif kernel in ['cubic']:
+            return r**3
+        elif kernel in ['quintic']:
+            return r**5
+        elif kernel in ['thin_plate']:
+            return xlogy(r**2, r)
+        else:
+            raise ValueError('Not valid kernel name')
+    
+    @staticmethod
+    def vandermond(X,degree):
+        """
+        Return a Vandermond matrix of X up to the
+        *total* order degree
+        """
+        X = np.atleast_2d(X)
+        ndim = X.shape[1]
+        index = np.asarray(RadialBasisFunction.total_index(degree,ndim),dtype=int)
+        V = np.ones([X.shape[0],len(index)])
+        for d in range(ndim):
+            v = np.fliplr(np.vander(X[:,d],N=degree+1))
+            V *= v[:,index[:,d]]
+        return V
+
+    
+    @staticmethod
+    def total_index(P,ndim,sort=True):
+        P = tuple([P]*ndim)
+        curr = [0]*ndim
+        ind = []
+        ind.append(tuple(curr))
+        while True:
+            for d in range(ndim):
+                if sum(curr) < P[0]:
+                    curr[d] += 1
+                    break
+                else:
+                    curr[d] = 0
+            else:
+                break
+            ind.append(tuple(curr))
+        if sort:
+            ind.sort(key=lambda a:(sum(a),(np.array(a)**2).sum(),a[::-1]))
+        return ind

--- a/scipy/interpolate/rbf.py
+++ b/scipy/interpolate/rbf.py
@@ -55,7 +55,7 @@ from scipy.spatial.distance import cdist, pdist, squareform
 
 __all__ = ['Rbf']
 
-@np.deprecate(new_name='scipy.interpolate.RadialBasisFunction')
+
 class Rbf(object):
     """
     Rbf(*args)

--- a/scipy/interpolate/rbf.py
+++ b/scipy/interpolate/rbf.py
@@ -55,7 +55,7 @@ from scipy.spatial.distance import cdist, pdist, squareform
 
 __all__ = ['Rbf']
 
-
+@np.deprecate(new_name='scipy.interpolate.RadialBasisFunction')
 class Rbf(object):
     """
     Rbf(*args)

--- a/scipy/interpolate/tests/test_radial_basis.py
+++ b/scipy/interpolate/tests/test_radial_basis.py
@@ -1,0 +1,62 @@
+"""Test the new RBF function"""
+
+from __future__ import division, print_function, absolute_import
+
+
+import numpy as np
+from numpy.testing import (assert_, assert_array_almost_equal,
+                           assert_almost_equal)
+
+import itertools
+
+from scipy.interpolate import RadialBasisFunction
+
+def check_exact_interp():
+
+    """
+    Check for exact interpolation varying:
+        * Dimensions
+        * Kernels
+        * Agumenting polynomials
+    """
+    kernels = [
+        # Named scalable
+        'multiquadric','inverse','gaussian',
+        
+        # Named splines
+        'linear','cubic','quintic','thin_plate',
+
+        # integer splines
+        1,2,3,4,5,
+        
+        # callable -- odd gaussian-like kernel
+        lambda r,eps: np.exp(-r**4/eps**2)]
+    
+    dims = [None,1,2,3,5,10]
+    degrees = [0,1,2,3]
+    
+    N = 300 # Needs to be big enough for highest dim and highest degree poly
+    
+    np.random.seed(3101)
+    X = np.random.uniform(size=(N,dims[-1]))
+    
+    for kernel,dim,degree in itertools.product(kernels,dims,degrees):
+        if dim is None:
+            x = X[:,0] # shape N,
+            f = np.sin(2*np.pi*x)
+        else:
+            x = X[:,:dim]
+            f = np.sin(2*np.pi*x).sum(axis=1)
+        
+        epsilon = None # Use the default
+        
+        rbf = RadialBasisFunction(x,f,
+                                  degree=degree,
+                                  kernel=kernel,
+                                  epsilon=epsilon)
+        y = rbf(x)
+        assert_array_almost_equal(f,y,decimal=4) # Especially for higher orders
+        #print(kernel,dim,degree,np.max(np.abs(y-f)),np.linalg.norm(y-f)/np.sqrt(N))
+
+if __name__ == '__main__':
+    check_exact_interp()


### PR DESCRIPTION
#### Reference issue
This is a first attempt at implimented what I sketched in #9904 and also addresses #7157.

#### What does this implement/fix?
`scipy.interpolate.RadialBasisFunction` as an eventual replacement for `scipy.interpolate.Rbf`

#### Additional information

Things I think need to be addressed are in bullets

I also added an np.deprecate to the old Rbf though it should probably be updated with concrete deprecation plans

* This needs to be checked to make sure it is in the right format

I added a few tests but there are likely more worth considering. I am not sure the best approach to test things like how well it does away from the training data without hard coding results. That is a qualitative measure and will depend the settings. I can tell you in practice it works very well if your data is smooth

* I am not sure if this test is being run in the test suite
* I would like some ideas on how to best assess quality of the interp. It may even be out of scope!

The documentation inline is very detailed. May be too detailed? It also includes references. [1] and [2] are the main ones but [3] and [4] are referenced in the documentation for resources on how to choose epsilon

* Does the documentation need to be mirrored elsehwere?

Some things I considered but did *not* impliment:

* Leave-one-out error estimate (see discussions in #9904)
* Scaling the input to a unit-hypercube. I note it as a tip, but it is not done. It would be super easy to add. Thoughts?

Anything else? This is my first major contribution so I may be missing some key steps.

Thanks!
