### PR TITLE
TST: pytest.ini pytest6 compat

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 addopts = -l
+junit_family=xunit2
 
 filterwarnings =
     error


### PR DESCRIPTION
Addresses part of #11174. Please check azure logs that the warning in question has been suppressed/fixed. This is lifted from @mattip fix in NumPy: https://github.com/numpy/numpy/pull/15082

* add value to `pytest.ini` for pytest6/junit compatibility

