### PR TITLE
BUG: scipy/interpolate: fix PPoly/Cubic*Spline roots() extrapolation for single-interval case

### DIFF
--- a/scipy/interpolate/_ppoly.pyx
+++ b/scipy/interpolate/_ppoly.pyx
@@ -528,8 +528,11 @@ def real_roots(double[:,:,::1] c, double[::1] x, double y, bint report_discont,
                     wr[i] += x[interval]
                     if interval == 0 and extrapolate:
                         # Half-open to the left/right.
-                        if (ascending and not wr[i] <= x[interval+1] or
-                            not ascending and not wr[i] >= x[interval + 1]):
+                        # Might also be the only interval, in which case there is
+                        # no limitation.
+                        if (interval != c.shape[1] - 1 and
+                            (ascending and not wr[i] <= x[interval+1] or
+                             not ascending and not wr[i] >= x[interval + 1])):
                                 continue
                     elif interval == c.shape[1] - 1 and extrapolate:
                         # Half-open to the right/left.

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -693,3 +693,16 @@ def test_CubicHermiteSpline_error_handling():
 
     dydx_with_nan = [1, 0, np.nan]
     assert_raises(ValueError, CubicHermiteSpline, x, y, dydx_with_nan)
+
+
+def test_roots_extrapolate_gh_11185():
+    x = np.array([0.001, 0.002])
+    y = np.array([1.66066935e-06, 1.10410807e-06])
+    dy = np.array([-1.60061854, -1.600619])
+    p = CubicHermiteSpline(x, y, dy)
+
+    # roots(extrapolate=True) for a polynomial with a single interval
+    # should return all three real roots
+    r = p.roots(extrapolate=True)
+    assert_equal(p.c.shape[1], 1)
+    assert_equal(r.size, 3)


### PR DESCRIPTION
#### Reference issue
See gh-11185

#### What does this implement/fix?
Fix mistake in PPoly.roots(extrapolate=True) when a piecewise polynomial
has only a single interval. Previously, roots to the right of the
interval were not considered.