### PR TITLE
TST: use stable ppc64le in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,8 +99,9 @@ matrix:
         - COVERAGE=
         - NUMPYSPEC="--upgrade numpy"
         - MB_PYTHON_VERSION=3.7
-    - os: linux-ppc64le
-      python: 3.6
+    - python: 3.6
+      os: linux
+      arch: ppc64le
       env:
         - TESTMODE=fast
         - COVERAGE=


### PR DESCRIPTION
* a recent announcement from the Travis
CI team encourages usage of os/arch fields
over the legacy linux-pp64le entry "to
make sure your jobs run smoothly"; see:
https://blog.travis-ci.com/2019-11-12-multi-cpu-architecture-ibm-power-ibm-z

* this is based on a similar recent CI update
performed in NumPy here:
https://github.com/numpy/numpy/pull/14907