### PR TITLE
BUG: Explicit dtype specification in _upfirdn.py

### DIFF
--- a/scipy/signal/_upfirdn.py
+++ b/scipy/signal/_upfirdn.py
@@ -89,6 +89,8 @@ class _UpFIRDn(object):
         """Apply the prepared filter to the specified axis of a N-D signal x"""
         output_len = _output_len(len(self._h_trans_flip), x.shape[axis],
                                  self._up, self._down)
+        # Explicit use of np.int64 for output_shape dtype avoids OverflowError
+        # when allocating large array on platforms where np.int_ is 32 bits
         output_shape = np.asarray(x.shape, dtype=np.int64)
         output_shape[axis] = output_len
         out = np.zeros(output_shape, dtype=self._output_type, order='C')

--- a/scipy/signal/_upfirdn.py
+++ b/scipy/signal/_upfirdn.py
@@ -89,7 +89,7 @@ class _UpFIRDn(object):
         """Apply the prepared filter to the specified axis of a N-D signal x"""
         output_len = _output_len(len(self._h_trans_flip), x.shape[axis],
                                  self._up, self._down)
-        output_shape = np.asarray(x.shape)
+        output_shape = np.asarray(x.shape, dtype=np.int64)
         output_shape[axis] = output_len
         out = np.zeros(output_shape, dtype=self._output_type, order='C')
         axis = axis % x.ndim


### PR DESCRIPTION
Issue: By default, the shape of the output array created by `scipy.signal.upfirdn` was specified by an array with the default `dtype` of  `np._int`, which on some platforms is equal to `np.int32`. As a result, `upfirdn` would fail when passed a (large) signal array `x` if any dimension had length > 2^32-1.

#### Reference issue
Closes #11128.

#### What does this implement/fix?
This fix explicitly sets the `dtype` of the array which specifies the shape of the array returned by `upfirdn` to `np.int64`.

#### Additional information
See https://github.com/numpy/numpy/issues/9464 for additional details.