### PR TITLE
MAINT: Improved error message for Wn range in iirfilter.

### DIFF
--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -2343,6 +2343,9 @@ def iirfilter(N, Wn, rp=None, rs=None, btype='band', analog=False,
     # Pre-warp frequencies for digital filter design
     if not analog:
         if numpy.any(Wn <= 0) or numpy.any(Wn >= 1):
+            if fs is not None:
+                raise ValueError("Digital filter critical frequencies "
+                                 "must be 0 < Wn < fs/2 (fs={} -> fs/2={})".format(fs, fs/2))
             raise ValueError("Digital filter critical frequencies "
                              "must be 0 < Wn < 1")
         fs = 2.0


### PR DESCRIPTION
#### Reference issue
Closes #11235 

#### What does this implement/fix?
The existing error message for the range of Wn was misleading if `fs` was used as parameter for the function.

#### Additional information
values for `fs` and `fs/2` provided in the error message so it is clear to everybody.