### PR TITLE
ENH: optimize: dense redundancy removal routine optimizations

### DIFF
--- a/scipy/optimize/_remove_redundancy.py
+++ b/scipy/optimize/_remove_redundancy.py
@@ -178,15 +178,10 @@ def _remove_redundancy_dense(A, rhs, true_rank=None):
     # matrix from the original problem - not on the canonical form matrix,
     # which would have many more column singletons due to slack variables
     # from the inequality constraints.
-    # The thoughts on "crashing" the initial basis sound useful, but the
-    # description of the procedure seems to assume a lot of familiarity with
-    # the subject; it is not very explicit. I already went through enough
-    # trouble getting the basic algorithm working, so I was not interested in
-    # trying to decipher this, too. (Overall, the paper is fraught with
-    # mistakes and ambiguities - which is strange, because the rest of
-    # Andersen's papers are quite good.)
+    # The thoughts on "crashing" the initial basis are only really useful if
+    # the matrix is sparse.
 
-    lu = np.eye(m, order='F'), np.arange(m)  # LU for initial basis is trivial
+    lu = np.eye(m, order='F'), np.arange(m)  # initial LU is trivial
     perm_r = lu[1]
     for i in v:
 

--- a/scipy/optimize/_remove_redundancy.py
+++ b/scipy/optimize/_remove_redundancy.py
@@ -163,7 +163,10 @@ def _remove_redundancy_dense(A, rhs):
     perm_r = None
 
     A_orig = A
-    A = np.hstack((np.eye(m), A))
+    B = np.eye(m, order='F')  # Fortran order is more efficient here
+    A = np.empty((m, m + n), order="F")
+    A[:, :m] = B
+    A[:, m:] = A_orig
     e = np.zeros(m)
 
     # Implements basic algorithm from [2]
@@ -182,7 +185,6 @@ def _remove_redundancy_dense(A, rhs):
     # mistakes and ambiguities - which is strange, because the rest of
     # Andersen's papers are quite good.)
 
-    B = A[:, b]
     for i in v:
 
         e[i] = 1

--- a/scipy/optimize/_remove_redundancy.py
+++ b/scipy/optimize/_remove_redundancy.py
@@ -185,6 +185,8 @@ def _remove_redundancy_dense(A, rhs):
     # mistakes and ambiguities - which is strange, because the rest of
     # Andersen's papers are quite good.)
 
+    lu = np.eye(m, order='F'), np.arange(m)  # LU for initial basis is trivial
+    perm_r = lu[1]
     for i in v:
 
         e[i] = 1

--- a/scipy/optimize/_remove_redundancy.py
+++ b/scipy/optimize/_remove_redundancy.py
@@ -158,11 +158,12 @@ def _remove_redundancy_dense(A, rhs, true_rank=None):
     # This is better as a list than a set because column order of basis matrix
     # needs to be consistent.
     d = []                  # Indices of dependent rows
-    lu = None
     perm_r = None
 
     A_orig = A
-    A = np.hstack((np.eye(m), A))
+    A = np.zeros((m, m + n), order='F')
+    np.fill_diagonal(A, 1)
+    A[:, m:] = A_orig
     e = np.zeros(m)
 
     js_candidates = np.arange(m, m+n, dtype=int)  # candidate columns for basis
@@ -187,7 +188,6 @@ def _remove_redundancy_dense(A, rhs, true_rank=None):
 
     lu = np.eye(m, order='F'), np.arange(m)  # LU for initial basis is trivial
     perm_r = lu[1]
-    B = A[:, b]
     for i in v:
 
         e[i] = 1
@@ -198,7 +198,7 @@ def _remove_redundancy_dense(A, rhs, true_rank=None):
             j = b[i-1]
             lu = bg_update_dense(lu, perm_r, A[:, j], i-1)
         except Exception:
-            lu = scipy.linalg.lu_factor(B)
+            lu = scipy.linalg.lu_factor(A[:, b])
             LU, p = lu
             perm_r = list(range(m))
             for i1, i2 in enumerate(p):
@@ -217,7 +217,6 @@ def _remove_redundancy_dense(A, rhs, true_rank=None):
             c = abs(A[:, j_indices].transpose().dot(pi))
             if (c > tolapiv).any():
                 j = js[j_index + np.argmax(c)]  # very independent column
-                B[:, i] = A[:, j]
                 b[i] = j
                 js_mask[j-m] = False
                 break

--- a/scipy/optimize/_remove_redundancy.py
+++ b/scipy/optimize/_remove_redundancy.py
@@ -105,7 +105,7 @@ def bg_update_dense(plu, perm_r, v, j):
     return LU, p
 
 
-def _remove_redundancy_dense(A, rhs):
+def _remove_redundancy_dense(A, rhs, true_rank=None):
     """
     Eliminates redundant equations from system of equations defined by Ax = b
     and identifies infeasibilities.
@@ -232,6 +232,8 @@ def _remove_redundancy_dense(A, rhs):
                 return A_orig, rhs, status, message
             else:  # dependent
                 d.append(i)
+                if true_rank is not None and len(d) == m - true_rank:
+                    break   # found all redundancies
 
     keep = set(range(m))
     keep = list(keep - set(d))

--- a/scipy/optimize/_remove_redundancy.py
+++ b/scipy/optimize/_remove_redundancy.py
@@ -162,10 +162,7 @@ def _remove_redundancy_dense(A, rhs, true_rank=None):
     perm_r = None
 
     A_orig = A
-    B = np.eye(m, order='F')  # Fortran order is more efficient here
-    A = np.empty((m, m + n), order="F")
-    A[:, :m] = B
-    A[:, m:] = A_orig
+    A = np.hstack((np.eye(m), A))
     e = np.zeros(m)
 
     js_candidates = np.arange(m, m+n, dtype=int)  # candidate columns for basis
@@ -190,6 +187,7 @@ def _remove_redundancy_dense(A, rhs, true_rank=None):
 
     lu = np.eye(m, order='F'), np.arange(m)  # LU for initial basis is trivial
     perm_r = lu[1]
+    B = A[:, b]
     for i in v:
 
         e[i] = 1

--- a/scipy/optimize/_remove_redundancy.py
+++ b/scipy/optimize/_remove_redundancy.py
@@ -8,7 +8,7 @@ from __future__ import division, print_function, absolute_import
 import numpy as np
 from scipy.linalg import svd
 import scipy
-from scipy.linalg.blas import dtrsv
+from scipy.linalg.blas import dtrsm
 
 
 def _row_count(A):
@@ -97,7 +97,7 @@ def bg_update_dense(plu, perm_r, v, j):
     LU, p = plu
 
     vperm = v[perm_r]
-    u = dtrsv(LU, vperm, lower=1, diag=1)
+    u = dtrsm(1, LU, vperm, lower=1, diag=1)
     LU[:j+1, j] = u[:j+1]
     l = u[j+1:]
     piv = LU[j, j]

--- a/scipy/optimize/_remove_redundancy.py
+++ b/scipy/optimize/_remove_redundancy.py
@@ -8,6 +8,7 @@ from __future__ import division, print_function, absolute_import
 import numpy as np
 from scipy.linalg import svd
 import scipy
+from scipy.linalg.blas import dtrsv
 
 
 def _row_count(A):
@@ -95,8 +96,8 @@ def _remove_zero_rows(A, b):
 def bg_update_dense(plu, perm_r, v, j):
     LU, p = plu
 
-    u = scipy.linalg.solve_triangular(LU, v[perm_r], lower=True,
-                                      unit_diagonal=True)
+    vperm = v[perm_r]
+    u = dtrsv(LU, vperm, lower=1, diag=1)
     LU[:j+1, j] = u[:j+1]
     l = u[j+1:]
     piv = LU[j, j]

--- a/scipy/optimize/tests/test__remove_redundancy.py
+++ b/scipy/optimize/tests/test__remove_redundancy.py
@@ -16,6 +16,9 @@ from numpy.testing import (
 
 from .test_linprog import magic_square
 from scipy.optimize._remove_redundancy import _remove_redundancy
+from scipy.optimize._remove_redundancy import _remove_redundancy_dense
+from scipy.optimize._remove_redundancy import _remove_redundancy_sparse
+from scipy.sparse import csc_matrix
 
 
 def setup_module():
@@ -48,192 +51,192 @@ def _assert_success(
             rtol=rtol,
             atol=atol)
 
+class RRCommonTests(object):
+    def test_no_redundancy(self):
+        m, n = 10, 10
+        A0 = np.random.rand(m, n)
+        b0 = np.random.rand(m)
+        A1, b1, status, message = self.rr(A0, b0)
+        assert_allclose(A0, A1)
+        assert_allclose(b0, b1)
+        assert_equal(status, 0)
 
-def test_no_redundancy():
-    m, n = 10, 10
-    A0 = np.random.rand(m, n)
-    b0 = np.random.rand(m)
-    A1, b1, status, message = _remove_redundancy(A0, b0)
-    assert_allclose(A0, A1)
-    assert_allclose(b0, b1)
-    assert_equal(status, 0)
+    def test_infeasible_zero_row(self):
+        A = np.eye(3)
+        A[1, :] = 0
+        b = np.random.rand(3)
+        A1, b1, status, message = self.rr(A, b)
+        assert_equal(status, 2)
 
+    def test_remove_zero_row(self):
+        A = np.eye(3)
+        A[1, :] = 0
+        b = np.random.rand(3)
+        b[1] = 0
+        A1, b1, status, message = self.rr(A, b)
+        assert_equal(status, 0)
+        assert_allclose(A1, A[[0, 2], :])
+        assert_allclose(b1, b[[0, 2]])
 
-def test_infeasible_zero_row():
-    A = np.eye(3)
-    A[1, :] = 0
-    b = np.random.rand(3)
-    A1, b1, status, message = _remove_redundancy(A, b)
-    assert_equal(status, 2)
+    def test_infeasible_m_gt_n(self):
+        m, n = 20, 10
+        A0 = np.random.rand(m, n)
+        b0 = np.random.rand(m)
+        A1, b1, status, message = self.rr(A0, b0)
+        assert_equal(status, 2)
 
+    def test_infeasible_m_eq_n(self):
+        m, n = 10, 10
+        A0 = np.random.rand(m, n)
+        b0 = np.random.rand(m)
+        A0[-1, :] = 2 * A0[-2, :]
+        A1, b1, status, message = self.rr(A0, b0)
+        assert_equal(status, 2)
 
-def test_remove_zero_row():
-    A = np.eye(3)
-    A[1, :] = 0
-    b = np.random.rand(3)
-    b[1] = 0
-    A1, b1, status, message = _remove_redundancy(A, b)
-    assert_equal(status, 0)
-    assert_allclose(A1, A[[0, 2], :])
-    assert_allclose(b1, b[[0, 2]])
+    def test_infeasible_m_lt_n(self):
+        m, n = 9, 10
+        A0 = np.random.rand(m, n)
+        b0 = np.random.rand(m)
+        A0[-1, :] = np.arange(m - 1).dot(A0[:-1])
+        A1, b1, status, message = self.rr(A0, b0)
+        assert_equal(status, 2)
 
+    def test_m_gt_n(self):
+        np.random.seed(2032)
+        m, n = 20, 10
+        A0 = np.random.rand(m, n)
+        b0 = np.random.rand(m)
+        x = np.linalg.solve(A0[:n, :], b0[:n])
+        b0[n:] = A0[n:, :].dot(x)
+        A1, b1, status, message = self.rr(A0, b0)
+        assert_equal(status, 0)
+        assert_equal(A1.shape[0], n)
+        assert_equal(np.linalg.matrix_rank(A1), n)
 
-def test_infeasible_m_gt_n():
-    m, n = 20, 10
-    A0 = np.random.rand(m, n)
-    b0 = np.random.rand(m)
-    A1, b1, status, message = _remove_redundancy(A0, b0)
-    assert_equal(status, 2)
+    def test_m_gt_n_rank_deficient(self):
+        m, n = 20, 10
+        A0 = np.zeros((m, n))
+        A0[:, 0] = 1
+        b0 = np.ones(m)
+        A1, b1, status, message = self.rr(A0, b0)
+        assert_equal(status, 0)
+        assert_allclose(A1, A0[0:1, :])
+        assert_allclose(b1, b0[0])
 
+    def test_m_lt_n_rank_deficient(self):
+        m, n = 9, 10
+        A0 = np.random.rand(m, n)
+        b0 = np.random.rand(m)
+        A0[-1, :] = np.arange(m - 1).dot(A0[:-1])
+        b0[-1] = np.arange(m - 1).dot(b0[:-1])
+        A1, b1, status, message = self.rr(A0, b0)
+        assert_equal(status, 0)
+        assert_equal(A1.shape[0], 8)
+        assert_equal(np.linalg.matrix_rank(A1), 8)
 
-def test_infeasible_m_eq_n():
-    m, n = 10, 10
-    A0 = np.random.rand(m, n)
-    b0 = np.random.rand(m)
-    A0[-1, :] = 2 * A0[-2, :]
-    A1, b1, status, message = _remove_redundancy(A0, b0)
-    assert_equal(status, 2)
+    def test_dense1(self):
+        A = np.ones((6, 6))
+        A[0, :3] = 0
+        A[1, 3:] = 0
+        A[3:, ::2] = -1
+        A[3, :2] = 0
+        A[4, 2:] = 0
+        b = np.zeros(A.shape[0])
 
+        A2 = A[[0, 1, 3, 4], :]
+        b2 = np.zeros(4)
 
-def test_infeasible_m_lt_n():
-    m, n = 9, 10
-    A0 = np.random.rand(m, n)
-    b0 = np.random.rand(m)
-    A0[-1, :] = np.arange(m - 1).dot(A0[:-1])
-    A1, b1, status, message = _remove_redundancy(A0, b0)
-    assert_equal(status, 2)
+        A1, b1, status, message = self.rr(A, b)
+        assert_allclose(A1, A2)
+        assert_allclose(b1, b2)
+        assert_equal(status, 0)
 
+    def test_dense2(self):
+        A = np.eye(6)
+        A[-2, -1] = 1
+        A[-1, :] = 1
+        b = np.zeros(A.shape[0])
+        A1, b1, status, message = self.rr(A, b)
+        assert_allclose(A1, A[:-1, :])
+        assert_allclose(b1, b[:-1])
+        assert_equal(status, 0)
 
-def test_m_gt_n():
-    np.random.seed(2032)
-    m, n = 20, 10
-    A0 = np.random.rand(m, n)
-    b0 = np.random.rand(m)
-    x = np.linalg.solve(A0[:n, :], b0[:n])
-    b0[n:] = A0[n:, :].dot(x)
-    A1, b1, status, message = _remove_redundancy(A0, b0)
-    assert_equal(status, 0)
-    assert_equal(A1.shape[0], n)
-    assert_equal(np.linalg.matrix_rank(A1), n)
+    def test_dense3(self):
+        A = np.eye(6)
+        A[-2, -1] = 1
+        A[-1, :] = 1
+        b = np.random.rand(A.shape[0])
+        b[-1] = np.sum(b[:-1])
+        A1, b1, status, message = self.rr(A, b)
+        assert_allclose(A1, A[:-1, :])
+        assert_allclose(b1, b[:-1])
+        assert_equal(status, 0)
 
+    def test_m_gt_n_sparse(self):
+        np.random.seed(2013)
+        m, n = 20, 5
+        p = 0.1
+        A = np.random.rand(m, n)
+        A[np.random.rand(m, n) > p] = 0
+        rank = np.linalg.matrix_rank(A)
+        b = np.zeros(A.shape[0])
+        A1, b1, status, message = self.rr(A, b)
+        assert_equal(status, 0)
+        assert_equal(A1.shape[0], rank)
+        assert_equal(np.linalg.matrix_rank(A1), rank)
 
-def test_m_gt_n_rank_deficient():
-    m, n = 20, 10
-    A0 = np.zeros((m, n))
-    A0[:, 0] = 1
-    b0 = np.ones(m)
-    A1, b1, status, message = _remove_redundancy(A0, b0)
-    assert_equal(status, 0)
-    assert_allclose(A1, A0[0:1, :])
-    assert_allclose(b1, b0[0])
+    def test_m_lt_n_sparse(self):
+        np.random.seed(2017)
+        m, n = 20, 50
+        p = 0.05
+        A = np.random.rand(m, n)
+        A[np.random.rand(m, n) > p] = 0
+        rank = np.linalg.matrix_rank(A)
+        b = np.zeros(A.shape[0])
+        A1, b1, status, message = self.rr(A, b)
+        assert_equal(status, 0)
+        assert_equal(A1.shape[0], rank)
+        assert_equal(np.linalg.matrix_rank(A1), rank)
 
+    def test_m_eq_n_sparse(self):
+        np.random.seed(2017)
+        m, n = 100, 100
+        p = 0.01
+        A = np.random.rand(m, n)
+        A[np.random.rand(m, n) > p] = 0
+        rank = np.linalg.matrix_rank(A)
+        b = np.zeros(A.shape[0])
+        A1, b1, status, message = self.rr(A, b)
+        assert_equal(status, 0)
+        assert_equal(A1.shape[0], rank)
+        assert_equal(np.linalg.matrix_rank(A1), rank)
 
-def test_m_lt_n_rank_deficient():
-    m, n = 9, 10
-    A0 = np.random.rand(m, n)
-    b0 = np.random.rand(m)
-    A0[-1, :] = np.arange(m - 1).dot(A0[:-1])
-    b0[-1] = np.arange(m - 1).dot(b0[:-1])
-    A1, b1, status, message = _remove_redundancy(A0, b0)
-    assert_equal(status, 0)
-    assert_equal(A1.shape[0], 8)
-    assert_equal(np.linalg.matrix_rank(A1), 8)
+    def test_magic_square(self):
+        A, b, c, numbers = magic_square(3)
+        A1, b1, status, message = self.rr(A, b)
+        assert_equal(status, 0)
+        assert_equal(A1.shape[0], 23)
+        assert_equal(np.linalg.matrix_rank(A1), 23)
 
-
-def test_dense1():
-    A = np.ones((6, 6))
-    A[0, :3] = 0
-    A[1, 3:] = 0
-    A[3:, ::2] = -1
-    A[3, :2] = 0
-    A[4, 2:] = 0
-    b = np.zeros(A.shape[0])
-
-    A2 = A[[0, 1, 3, 4], :]
-    b2 = np.zeros(4)
-
-    A1, b1, status, message = _remove_redundancy(A, b)
-    assert_allclose(A1, A2)
-    assert_allclose(b1, b2)
-    assert_equal(status, 0)
-
-
-def test_dense2():
-    A = np.eye(6)
-    A[-2, -1] = 1
-    A[-1, :] = 1
-    b = np.zeros(A.shape[0])
-    A1, b1, status, message = _remove_redundancy(A, b)
-    assert_allclose(A1, A[:-1, :])
-    assert_allclose(b1, b[:-1])
-    assert_equal(status, 0)
-
-
-def test_dense3():
-    A = np.eye(6)
-    A[-2, -1] = 1
-    A[-1, :] = 1
-    b = np.random.rand(A.shape[0])
-    b[-1] = np.sum(b[:-1])
-    A1, b1, status, message = _remove_redundancy(A, b)
-    assert_allclose(A1, A[:-1, :])
-    assert_allclose(b1, b[:-1])
-    assert_equal(status, 0)
-
-
-def test_m_gt_n_sparse():
-    np.random.seed(2013)
-    m, n = 20, 5
-    p = 0.1
-    A = np.random.rand(m, n)
-    A[np.random.rand(m, n) > p] = 0
-    rank = np.linalg.matrix_rank(A)
-    b = np.zeros(A.shape[0])
-    A1, b1, status, message = _remove_redundancy(A, b)
-    assert_equal(status, 0)
-    assert_equal(A1.shape[0], rank)
-    assert_equal(np.linalg.matrix_rank(A1), rank)
-
-
-def test_m_lt_n_sparse():
-    np.random.seed(2017)
-    m, n = 20, 50
-    p = 0.05
-    A = np.random.rand(m, n)
-    A[np.random.rand(m, n) > p] = 0
-    rank = np.linalg.matrix_rank(A)
-    b = np.zeros(A.shape[0])
-    A1, b1, status, message = _remove_redundancy(A, b)
-    assert_equal(status, 0)
-    assert_equal(A1.shape[0], rank)
-    assert_equal(np.linalg.matrix_rank(A1), rank)
-
-
-def test_m_eq_n_sparse():
-    np.random.seed(2017)
-    m, n = 100, 100
-    p = 0.01
-    A = np.random.rand(m, n)
-    A[np.random.rand(m, n) > p] = 0
-    rank = np.linalg.matrix_rank(A)
-    b = np.zeros(A.shape[0])
-    A1, b1, status, message = _remove_redundancy(A, b)
-    assert_equal(status, 0)
-    assert_equal(A1.shape[0], rank)
-    assert_equal(np.linalg.matrix_rank(A1), rank)
-
-
-def test_magic_square():
-    A, b, c, numbers = magic_square(3)
-    A1, b1, status, message = _remove_redundancy(A, b)
-    assert_equal(status, 0)
-    assert_equal(A1.shape[0], 23)
-    assert_equal(np.linalg.matrix_rank(A1), 23)
+    def test_magic_square2(self):
+        A, b, c, numbers = magic_square(4)
+        A1, b1, status, message = self.rr(A, b)
+        assert_equal(status, 0)
+        assert_equal(A1.shape[0], 39)
+        assert_equal(np.linalg.matrix_rank(A1), 39)
 
 
-def test_magic_square2():
-    A, b, c, numbers = magic_square(4)
-    A1, b1, status, message = _remove_redundancy(A, b)
-    assert_equal(status, 0)
-    assert_equal(A1.shape[0], 39)
-    assert_equal(np.linalg.matrix_rank(A1), 39)
+class TestRRSVD(RRCommonTests):
+    def rr(self, A, b):
+        return _remove_redundancy(A, b)
+
+
+class TestRRPivotDense(RRCommonTests):
+    def rr(self, A, b):
+        return _remove_redundancy_dense(A, b)
+
+
+class TestRRPivotSparse(RRCommonTests):
+    def rr(self, A, b):
+        A1, b1, status, message = _remove_redundancy_sparse(csc_matrix(A), b)
+        return A1.toarray(), b1, status, message


### PR DESCRIPTION
This PR includes four efficiency improvements for `linprog`'s dense redundancy removal routine. For easier review, please consider each commit separately.

This PR also improves the redundancy removal test suite: previously only the SVD-based RR method was being tested; now all three RR routines go through the same tests.  Unfortunately, GH is not good at detecting the changes. _ALL_ I did to `test__remove_redundancy.py` is:

- add all the separate tests to a class, `RRCommonTests`
- Create three subclasses, `TestRRSVD`. `TestRRPivotDense`, and `TestRRPivotSparse`, each with their own definition of method `rr`
- Replace calls to `_remove_redundancy` with `self.rr`

The fastest way to verify that no unintended changes were introduced is probably to perform the changes in reverse to get back the original file.

@hakeemo I had these in mind for a while. Thanks for the nudge to revisit the redundancy removal routines! Some of these ideas might be helpful if you make the change you suggested in gh-11215. Or, if you'd like, I can just add those changes in this PR.

@Kai-Striega I think made a similar mistake as in gh-10602! How did you get rid of the unintended changes to the submodule?