### PR TITLE
BUG: rv_discrete.ppf() to handle loc

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -3236,8 +3236,8 @@ class rv_discrete(rv_generic):
         cond = cond0 & cond1
         output = valarray(shape(cond), value=self.badvalue, typecode='d')
         # output type 'd' to handle nin and inf
-        place(output, (q == 0)*(cond == cond), _a-1)
-        place(output, cond2, _b)
+        place(output, (q == 0)*(cond == cond), _a-1 + loc)
+        place(output, cond2, _b + loc)
         if np.any(cond):
             goodargs = argsreduce(cond, *((q,)+args+(loc,)))
             loc, goodargs = goodargs[-1], goodargs[:-1]

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -1,4 +1,5 @@
 from __future__ import division, print_function, absolute_import
+
 import numpy.testing as npt
 import numpy as np
 from scipy._lib.six import xrange
@@ -36,7 +37,7 @@ def test_discrete_basic(distname, arg, first_case):
     supp = np.unique(rvs)
     m, v = distfn.stats(*arg)
     check_cdf_ppf(distfn, arg, supp, distname + ' cdf_ppf')
-    
+
     check_pmf_cdf(distfn, arg, distname)
     check_oth(distfn, arg, supp, distname + ' oth')
     check_edge_support(distfn, arg)
@@ -44,7 +45,7 @@ def test_discrete_basic(distname, arg, first_case):
     alpha = 0.01
     check_discrete_chisquare(distfn, arg, rvs, alpha,
            distname + ' chisquare')
-    
+
     if first_case:
         locscale_defaults = (0,)
         meths = [distfn.pmf, distfn.logpmf, distfn.cdf, distfn.logcdf,
@@ -131,11 +132,12 @@ def test_ppf_with_loc(dist, args):
     except TypeError:
         distfn = dist
     #check with a negative, no and positive relocation.
+    np.random.seed(1942349)
     re_locs = [np.random.randint(-10, -1), 0, np.random.randint(1, 10)]
     _a, _b = distfn.support(*args)
     for loc in re_locs:
         npt.assert_array_equal(
-            [_a-1+loc, _b+loc], 
+            [_a-1+loc, _b+loc],
             [distfn.ppf(0.0, *args, loc=loc), distfn.ppf(1.0, *args, loc=loc)]
             )
 
@@ -250,3 +252,4 @@ def check_scale_docstring(distfn):
     if distfn.__doc__ is not None:
         # Docstrings can be stripped if interpreter is run with -OO
         npt.assert_('scale' not in distfn.__doc__)
+

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -127,10 +127,10 @@ def test_rvs_broadcast(dist, shape_args):
 @pytest.mark.parametrize('dist,args', distdiscrete)
 def test_ppf_with_loc(dist, args):
     try:
-        distfn = getattr(stats, dist) #stats.rv_discrete(name='custom', values=vals)
+        distfn = getattr(stats, dist)
     except TypeError:
         distfn = dist
-    #check with a negative, non and positive relocation.
+    #check with a negative, no and positive relocation.
     re_locs = [np.random.randint(-10, -1), 0, np.random.randint(1, 10)]
     _a, _b = distfn.support(*args)
     for loc in re_locs:

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -1,5 +1,4 @@
 from __future__ import division, print_function, absolute_import
-
 import numpy.testing as npt
 import numpy as np
 from scipy._lib.six import xrange
@@ -37,7 +36,7 @@ def test_discrete_basic(distname, arg, first_case):
     supp = np.unique(rvs)
     m, v = distfn.stats(*arg)
     check_cdf_ppf(distfn, arg, supp, distname + ' cdf_ppf')
-
+    
     check_pmf_cdf(distfn, arg, distname)
     check_oth(distfn, arg, supp, distname + ' oth')
     check_edge_support(distfn, arg)
@@ -45,7 +44,7 @@ def test_discrete_basic(distname, arg, first_case):
     alpha = 0.01
     check_discrete_chisquare(distfn, arg, rvs, alpha,
            distname + ' chisquare')
-
+    
     if first_case:
         locscale_defaults = (0,)
         meths = [distfn.pmf, distfn.logpmf, distfn.cdf, distfn.logcdf,
@@ -123,6 +122,22 @@ def test_rvs_broadcast(dist, shape_args):
     # bshape holds the expected shape when loc, scale, and the shape
     # parameters are all broadcast together.
     check_rvs_broadcast(distfunc, dist, allargs, bshape, shape_only, [np.int_])
+
+
+@pytest.mark.parametrize('dist,args', distdiscrete)
+def test_ppf_with_loc(dist, args):
+    try:
+        distfn = getattr(stats, dist) #stats.rv_discrete(name='custom', values=vals)
+    except TypeError:
+        distfn = dist
+    #check with a negative, non and positive relocation.
+    re_locs = [np.random.randint(-10, -1), 0, np.random.randint(1, 10)]
+    _a, _b = distfn.support(*args)
+    for loc in re_locs:
+        npt.assert_array_equal(
+            [_a-1+loc, _b+loc], 
+            [distfn.ppf(0.0, *args, loc=loc), distfn.ppf(1.0, *args, loc=loc)]
+            )
 
 
 def check_cdf_ppf(distfn, arg, supp, msg):
@@ -235,4 +250,3 @@ def check_scale_docstring(distfn):
     if distfn.__doc__ is not None:
         # Docstrings can be stripped if interpreter is run with -OO
         npt.assert_('scale' not in distfn.__doc__)
-


### PR DESCRIPTION

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Issue #11132

#### What does this implement/fix?
<!--Please explain your changes.-->
Updated  rv_discrete to support shifting loc of distribution. Before this change ppf(0) and ppf(1) returns the same result (respectively _a = min(xk) - 1 and _b = max(xk)), even though the optional parameter `loc` is given. 
After the change ppf(0) = _a + loc and ppf(1) = _b + loc

#### Additional information
<!--Any additional information you think is important.-->
Thanks to @josef-pkt for his comments!