### PR TITLE
MAINT: forward port 1.4.1 release notes

### DIFF
--- a/doc/release/1.4.1-notes.rst
+++ b/doc/release/1.4.1-notes.rst
@@ -1,0 +1,26 @@
+==========================
+SciPy 1.4.1 Release Notes
+==========================
+
+.. contents::
+
+SciPy 1.4.1 is a bug-fix release with no new features
+compared to 1.4.0. Importantly, it aims to fix a problem
+where an older version of pybind11 may cause a segmentation
+fault when imported alongside incompatible libraries.
+
+Authors
+=======
+
+* Ralf Gommers
+* Tyler Reddy
+
+Issues closed for 1.4.1
+-----------------------
+
+* `#11237 <https://github.com/scipy/scipy/issues/11237>`__: Seg fault when importing torch
+
+Pull requests for 1.4.1
+-----------------------
+
+* `#11238 <https://github.com/scipy/scipy/pull/11238>`__: BLD: update minimum pybind11 version to 2.4.0.

--- a/doc/source/release.1.4.1.rst
+++ b/doc/source/release.1.4.1.rst
@@ -1,0 +1,1 @@
+.. include:: ../release/1.4.1-notes.rst

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -6,6 +6,7 @@ Release Notes
    :maxdepth: 1
 
    release.1.5.0
+   release.1.4.1
    release.1.4.0
    release.1.3.3
    release.1.3.2


### PR DESCRIPTION
Forward port SciPy `1.4.1` release notes following release this morning.