### PR TITLE
BUG: fix kendalltau issue where p-value becomes >1

### DIFF
--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -622,6 +622,8 @@ def kendalltau(x, y, use_ties=True, use_missing=False, method='auto'):
             prob = 2.0/np.math.factorial(n)
         elif c == 1:
             prob = 2.0/np.math.factorial(n-1)
+        elif 2*c == (n*(n-1))/2:
+            pvalue = 1.0
         else:
             old = [0.0]*(c+1)
             new = [0.0]*(c+1)

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -622,7 +622,7 @@ def kendalltau(x, y, use_ties=True, use_missing=False, method='auto'):
             prob = 2.0/np.math.factorial(n)
         elif c == 1:
             prob = 2.0/np.math.factorial(n-1)
-        elif 2*c == (n*(n-1))/2:
+        elif 2*c == (n*(n-1))//2:
             pvalue = 1.0
         else:
             old = [0.0]*(c+1)

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -4131,7 +4131,7 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate', method='auto'
             method = 'asymptotic'
 
     if xtie == 0 and ytie == 0 and method == 'exact':
-        # Exact p-value, see Maurice G. Kendall, "Rank Correlation Methods" (4th Edition), Charles Griffin & Co., 1970.
+        # Exact p-value, see p. 68 of Maurice G. Kendall, "Rank Correlation Methods" (4th Edition), Charles Griffin & Co., 1970.
         c = min(dis, tot-dis)
         if size <= 0:
             raise ValueError
@@ -4145,6 +4145,8 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate', method='auto'
             pvalue = 2.0/math.factorial(size) if size < 171 else 0.0
         elif c == 1:
             pvalue = 2.0/math.factorial(size-1) if (size-1) < 171 else 0.0
+        elif 2*c == tot:
+            pvalue = 1.0
         else:
             new = [0.0]*(c+1)
             new[0] = 1.0
@@ -4155,6 +4157,7 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate', method='auto'
                     new[k] += new[k-1]
                 for k in range(j,c+1):
                     new[k] += new[k-1] - old[k-j]
+
             pvalue = 2.0*sum(new)/math.factorial(size) if size < 171 else 0.0
 
     elif method == 'asymptotic':

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -882,8 +882,8 @@ class TestCorrSpearmanrTies(object):
 def test_kendalltau():
 
     # case without ties, con-dis equal zero
-    x = [5,2,1,3,6,4,7,8]
-    y = [5,2,6,3,1,8,7,4]
+    x = [5, 2, 1, 3, 6, 4, 7, 8]
+    y = [5, 2, 6, 3, 1, 8, 7, 4]
     # Cross-check with exact result from R:
     # cor.test(x,y,method="kendall",exact=1)
     expected = (0.0, 1.0)
@@ -892,8 +892,8 @@ def test_kendalltau():
     assert_approx_equal(res[1], expected[1])
 
     # case without ties, con-dis equal zero
-    x = [0,5,2,1,3,6,4,7,8]
-    y = [5,2,0,6,3,1,8,7,4]
+    x = [0, 5, 2, 1, 3, 6, 4, 7, 8]
+    y = [5, 2, 0, 6, 3, 1, 8, 7, 4]
     # Cross-check with exact result from R:
     # cor.test(x,y,method="kendall",exact=1)
     expected = (0.0, 1.0)
@@ -902,8 +902,8 @@ def test_kendalltau():
     assert_approx_equal(res[1], expected[1])
 
     # case without ties, con-dis close to zero
-    x = [5,2,1,3,6,4,7]
-    y = [5,2,6,3,1,7,4]
+    x = [5, 2, 1, 3, 6, 4, 7]
+    y = [5, 2, 6, 3, 1, 7, 4]
     # Cross-check with exact result from R:
     # cor.test(x,y,method="kendall",exact=1)
     expected = (-0.14285714286, 0.77261904762)
@@ -912,8 +912,8 @@ def test_kendalltau():
     assert_approx_equal(res[1], expected[1])
 
     # case without ties, con-dis close to zero
-    x = [2,1,3,6,4,7,8]
-    y = [2,6,3,1,8,7,4]
+    x = [2, 1, 3, 6, 4, 7, 8]
+    y = [2, 6, 3, 1, 8, 7, 4]
     # Cross-check with exact result from R:
     # cor.test(x,y,method="kendall",exact=1)
     expected = (0.047619047619, 1.0)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -881,7 +881,7 @@ class TestCorrSpearmanrTies(object):
 
 def test_kendalltau():
 
-    # case without ties, maximum con-dis
+    # case without ties, con-dis equal zero
     x = [5,2,1,3,6,4,7,8]
     y = [5,2,6,3,1,8,7,4]
     # Cross-check with exact result from R:
@@ -891,7 +891,7 @@ def test_kendalltau():
     assert_approx_equal(res[0], expected[0])
     assert_approx_equal(res[1], expected[1])
 
-    # case without ties, maximum con-dis
+    # case without ties, con-dis equal zero
     x = [0,5,2,1,3,6,4,7,8]
     y = [5,2,0,6,3,1,8,7,4]
     # Cross-check with exact result from R:
@@ -901,7 +901,7 @@ def test_kendalltau():
     assert_approx_equal(res[0], expected[0])
     assert_approx_equal(res[1], expected[1])
 
-    # case without ties, almost maximum con-dis
+    # case without ties, con-dis close to zero
     x = [5,2,1,3,6,4,7]
     y = [5,2,6,3,1,7,4]
     # Cross-check with exact result from R:
@@ -911,7 +911,7 @@ def test_kendalltau():
     assert_approx_equal(res[0], expected[0])
     assert_approx_equal(res[1], expected[1])
 
-    # case without ties, almost maximum con-dis
+    # case without ties, con-dis close to zero
     x = [2,1,3,6,4,7,8]
     y = [2,6,3,1,8,7,4]
     # Cross-check with exact result from R:

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -880,6 +880,47 @@ class TestCorrSpearmanrTies(object):
 
 
 def test_kendalltau():
+
+    # case without ties, maximum con-dis
+    x = [5,2,1,3,6,4,7,8]
+    y = [5,2,6,3,1,8,7,4]
+    # Cross-check with exact result from R:
+    # cor.test(x,y,method="kendall",exact=1)
+    expected = (0.0, 1.0)
+    res = stats.kendalltau(x, y)
+    assert_approx_equal(res[0], expected[0])
+    assert_approx_equal(res[1], expected[1])
+
+    # case without ties, maximum con-dis
+    x = [0,5,2,1,3,6,4,7,8]
+    y = [5,2,0,6,3,1,8,7,4]
+    # Cross-check with exact result from R:
+    # cor.test(x,y,method="kendall",exact=1)
+    expected = (0.0, 1.0)
+    res = stats.kendalltau(x, y)
+    assert_approx_equal(res[0], expected[0])
+    assert_approx_equal(res[1], expected[1])
+
+    # case without ties, almost maximum con-dis
+    x = [5,2,1,3,6,4,7]
+    y = [5,2,6,3,1,7,4]
+    # Cross-check with exact result from R:
+    # cor.test(x,y,method="kendall",exact=1)
+    expected = (-0.14285714286, 0.77261904762)
+    res = stats.kendalltau(x, y)
+    assert_approx_equal(res[0], expected[0])
+    assert_approx_equal(res[1], expected[1])
+
+    # case without ties, almost maximum con-dis
+    x = [2,1,3,6,4,7,8]
+    y = [2,6,3,1,8,7,4]
+    # Cross-check with exact result from R:
+    # cor.test(x,y,method="kendall",exact=1)
+    expected = (0.047619047619, 1.0)
+    res = stats.kendalltau(x, y)
+    assert_approx_equal(res[0], expected[0])
+    assert_approx_equal(res[1], expected[1])
+
     # simple case without ties
     x = np.arange(10)
     y = np.arange(10)


### PR DESCRIPTION
Fixes the issue of stats.kendalltau(), where in some cases a
p-value larger than 1 was returned.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Fixes issue #11175 
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
Check added for the special case of concordance-discordance around zero.
<!--Please explain your changes.-->
