### PR TITLE
MAINT: make special.factorial handle nan correctly

### DIFF
--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2344,9 +2344,9 @@ def factorial(n, exact=False):
             out = np.empty_like(n, dtype=dt)
 
             # Handle invalid/trivial values
-            un = un[un > 1]
             # Ignore runtime warning when less operator used w/np.nan
             with np.errstate(all='ignore'):
+                un = un[un > 1]
                 out[n < 2] = 1
                 out[n < 0] = 0
 

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2323,10 +2323,7 @@ def factorial(n, exact=False):
     """
     if exact:
         if np.ndim(n) == 0:
-            if not np.isnan(n):
-                return _factorial(n)
-            else:
-                return n
+            return _factorial(n)
         else:
             n = asarray(n)
             un = np.unique(n).astype(object)
@@ -2362,20 +2359,11 @@ def factorial(n, exact=False):
 
             if np.isnan(n).any():
                 out = out.astype(np.float64)
-                out[np.isnan(n)] = np.nan
+                out[np.isnan(n)] = n[np.isnan(n)]
             return out
     else:
-        if np.ndim(n) == 0:
-            return _factorial(n)
-
         n = asarray(n)
-        vals = gamma(n + 1)
-        # Ignore runtime warning when less operator used w/np.nan
-        with np.errstate(all='ignore'):
-            out = where(n >= 0, vals, 0)
-
-        if np.isnan(n).any():
-            out[np.isnan(n)] = np.nan
+        out = _factorial(n)
         return out
 
 

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -13,7 +13,7 @@ from numpy import (pi, asarray, floor, isscalar, iscomplex, real,
 from . import _ufuncs as ufuncs
 from ._ufuncs import (mathieu_a, mathieu_b, iv, jv, gamma,
                       psi, hankel1, hankel2, yv, kv, ndtri,
-                      poch, binom, hyp0f1, _factorial)
+                      poch, binom, hyp0f1)
 from . import specfun
 from . import orthogonal
 from ._comb import _comb_int
@@ -2323,7 +2323,9 @@ def factorial(n, exact=False):
     """
     if exact:
         if np.ndim(n) == 0:
-            return _factorial(n)
+            if np.isnan(n):
+                return n
+            return 0 if n < 0 else math.factorial(n)
         else:
             n = asarray(n)
             un = np.unique(n).astype(object)
@@ -2363,7 +2365,7 @@ def factorial(n, exact=False):
             return out
     else:
         n = asarray(n)
-        out = _factorial(n)
+        out = ufuncs._factorial(n)
         return out
 
 

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -13,7 +13,7 @@ from numpy import (pi, asarray, floor, isscalar, iscomplex, real,
 from . import _ufuncs as ufuncs
 from ._ufuncs import (mathieu_a, mathieu_b, iv, jv, gamma,
                       psi, hankel1, hankel2, yv, kv, ndtri,
-                      poch, binom, hyp0f1)
+                      poch, binom, hyp0f1, _factorial)
 from . import specfun
 from . import orthogonal
 from ._comb import _comb_int
@@ -2324,9 +2324,9 @@ def factorial(n, exact=False):
     if exact:
         if np.ndim(n) == 0:
             if not np.isnan(n):
-                return 0 if n < 0 else math.factorial(n)
+                return _factorial(n)
             else:
-                return np.nan
+                return n
         else:
             n = asarray(n)
             un = np.unique(n).astype(object)
@@ -2366,10 +2366,7 @@ def factorial(n, exact=False):
             return out
     else:
         if np.ndim(n) == 0:
-            if not np.isnan(n):
-                return 0 if n < 0 else gamma(n + 1)
-            else:
-                return np.nan
+            return _factorial(n)
 
         n = asarray(n)
         vals = gamma(n + 1)

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2364,7 +2364,6 @@ def factorial(n, exact=False):
                 out[np.isnan(n)] = n[np.isnan(n)]
             return out
     else:
-        n = asarray(n)
         out = ufuncs._factorial(n)
         return out
 

--- a/scipy/special/_factorial.pxd
+++ b/scipy/special/_factorial.pxd
@@ -1,0 +1,8 @@
+from ._cephes cimport Gamma
+
+
+cdef inline double _factorial(double n) nogil:
+    if n < 0:
+        return 0
+    else:
+        return Gamma(n + 1)

--- a/scipy/special/_factorial.pxd
+++ b/scipy/special/_factorial.pxd
@@ -1,17 +1,8 @@
 from ._cephes cimport Gamma
 
 
-cdef extern from "numpy/npy_math.h" nogil:
-    double npy_isnan(double)
-
-
 cdef inline double _factorial(double n) nogil:
     if n < 0:
         return 0
-    elif npy_isnan(n):
-        return n
-    elif <int>n != n:
-        with gil:
-            raise ValueError("factorial() only accepts integral values")
     else:
         return Gamma(n + 1)

--- a/scipy/special/_factorial.pxd
+++ b/scipy/special/_factorial.pxd
@@ -1,8 +1,17 @@
 from ._cephes cimport Gamma
 
 
+cdef extern from "numpy/npy_math.h" nogil:
+    double npy_isnan(double)
+
+
 cdef inline double _factorial(double n) nogil:
     if n < 0:
         return 0
+    elif npy_isnan(n):
+        return n
+    elif <int>n != n:
+        with gil:
+            raise ValueError("factorial() only accepts integral values")
     else:
         return Gamma(n + 1)

--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -9463,3 +9463,8 @@ add_newdoc("owens_t",
     .. [1] M. Patefield and D. Tandy, "Fast and accurate calculation of
            Owen's T Function", Statistical Software vol. 5, pp. 1-25, 2000.
     """)
+
+add_newdoc("_factorial",
+    """
+    Internal function, do not use.
+    """)

--- a/scipy/special/functions.json
+++ b/scipy/special/functions.json
@@ -353,6 +353,11 @@
 	    "ellipk": "d->d"
 	}
     },
+    "_factorial": {
+	"_factorial.pxd": {
+	    "_factorial": "d->d"
+	}
+    },
     "entr": {
         "_convex_analysis.pxd": {
             "entr": "d->d"

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1820,6 +1820,23 @@ class TestFactorialFunctions(object):
         assert_equal(special.factorialk(5, 1, exact=True), 120)
         assert_equal(special.factorialk(5, 3, exact=True), 10)
 
+    @pytest.mark.parametrize('x, exact', [
+        (np.nan, True),
+        (np.nan, False),
+        (np.array([np.nan]), True),
+        (np.array([np.nan]), False),
+    ])
+    def test_nan_inputs(self, x, exact):
+        result = special.factorial(x, exact=exact)
+        assert_(np.isnan(result))
+
+    def test_mixed_nan_inputs(self):
+        x = np.array([np.nan, 1, 2, 3, np.nan])
+        result = special.factorial(x, exact=True)
+        assert_equal(np.array([np.nan, 1, 2, 6, np.nan]), result)
+        result = special.factorial(x, exact=False)
+        assert_equal(np.array([np.nan, 1, 2, 6, np.nan]), result)
+
 
 class TestFresnel(object):
     def test_fresnel(self):

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1837,6 +1837,10 @@ class TestFactorialFunctions(object):
         result = special.factorial(x, exact=False)
         assert_equal(np.array([np.nan, 1, 2, 6, np.nan]), result)
 
+    def test_non_integral_inputs(self):
+        assert_raises(ValueError, special.factorial, 1.3, True)
+        assert_raises(ValueError, special.factorial, 1.1, False)
+
 
 class TestFresnel(object):
     def test_fresnel(self):

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1837,10 +1837,6 @@ class TestFactorialFunctions(object):
         result = special.factorial(x, exact=False)
         assert_equal(np.array([np.nan, 1, 2, 6, np.nan]), result)
 
-    def test_non_integral_inputs(self):
-        assert_raises(ValueError, special.factorial, 1.3, True)
-        assert_raises(ValueError, special.factorial, 1.1, False)
-
 
 class TestFresnel(object):
     def test_fresnel(self):


### PR DESCRIPTION

#### Reference issue
Closes #11022 

#### What does this implement/fix?
Previously, `scipy.special.factorial` did not always handle `nan` correctly. 
This PR fixes the `nan` behavior to propogate as expected.

#### Additional information
There are added unit tests too that account for `nan` scalar, `np.array([np.nan])` and mixed arrays, e.g. `np.array([np.nan, 1, 2., np.nan])`. All 3 cases are handled as expected. 