### PR TITLE
WIP: sparse redundancy removal routine optimizations

### DIFF
--- a/scipy/optimize/_remove_redundancy.py
+++ b/scipy/optimize/_remove_redundancy.py
@@ -273,6 +273,36 @@ class my_csc_matrix(csc_matrix):
             array[i1:i2] = data
             return array
 
+    def solve(self, b, trans=False):
+        if not trans:
+            x = np.zeros(self.shape[0])
+            b = b.reshape(-1,1)
+            p = np.zeros((self.shape[0], 1))
+            if self.upper:
+                cols = range(-1, -len(x)-1, -1)
+            else:
+                cols = range(len(x))
+            for i in cols:
+                x[i] = (b-p)[i]/self[i, i]
+                p += x[i]*self[:, i]
+            return x.ravel()
+        if trans:
+            A = self.T # now CSR
+            n = self.shape[0]
+            x = np.zeros(n)
+            if self.upper:
+                cols = range(len(x))
+                start_col = 0
+                inc = 1
+            else:
+                cols = range(n-1, 0, -1)
+                start_col = n-1
+                inc = -1
+            for i in cols:
+                p = A[i,start_col:i:inc]@x[start_col:i:inc]
+                x[i] = (b[i]-p)/self[i, i]
+            return x.ravel()
+
     def update(self, column, data):
         if self.upper:
             data = data[:column+1, 0]
@@ -330,7 +360,7 @@ class LUSolver:
         u = self.fl.solve(v.toarray())
         U.update(j, u)
 #        U2[:j+1, j] = u[:j+1]
-        l = u[j+1:]
+#        l = u[j+1:]
         piv = U[j, j]
 
 #        update = np.array(L[:, j] + u/piv)

--- a/scipy/optimize/_remove_redundancy.py
+++ b/scipy/optimize/_remove_redundancy.py
@@ -233,10 +233,10 @@ def _remove_redundancy_dense(A, rhs):
 
 class my_csc_matrix(csc_matrix):
 
-    def __init__(self, shape, *args, upper=None, **kwargs):
-        super().__init__(shape, *args, **kwargs)
+    def __init__(self, *args, upper=None, **kwargs):
+        super().__init__(*args, **kwargs)
         if upper is not None:
-            n = shape[0]
+            n = args[0][0]
             self.upper = upper
             self.my_nnz = n
             self.my_indices = np.arange(2*n, dtype=np.int32)

--- a/scipy/optimize/_remove_redundancy.py
+++ b/scipy/optimize/_remove_redundancy.py
@@ -231,23 +231,13 @@ def _remove_redundancy_dense(A, rhs):
     return A_orig[keep, :], rhs[keep], status, message
 
 
-def split_splu(f):
-    L = f.L
-    U = f.U
-    m, n = f.L.shape
-
-    Pr = eye(m, format='csc')
-    Pr = Pr[f.perm_r, :]
-    Pc = eye(m, format='csc')
-    Pc = Pc[:, f.perm_c]
-    return L, U, Pr.T, Pc.T
-
-
 class LUSolver:
     def __init__(self, m):
         I = eye(m, format='csc')
         self.fl = splu(I, permc_spec="NATURAL")
         self.fu = splu(I, permc_spec="NATURAL")
+        self.L = eye(m, format='csc')
+        self.U = eye(m, format='csc')
 
     def solve(self, b, trans=False):
         if trans:
@@ -259,15 +249,10 @@ class LUSolver:
         return x
 
     def update(self, v, j):
-        L, a, b, c = split_splu(self.fl)
-        a2, U, b2, c2 = split_splu(self.fu)
+        L = self.L
+        U = self.U
         m, n = L.shape
-        assert(np.allclose(a.toarray(), np.eye(m)))
-        assert(np.allclose(b.toarray(), np.eye(m)))
-        assert(np.allclose(c.toarray(), np.eye(m)))
-        assert(np.allclose(a2.toarray(), np.eye(m)))
-        assert(np.allclose(b2.toarray(), np.eye(m)))
-        assert(np.allclose(c2.toarray(), np.eye(m)))
+
         u = self.fl.solve(v.toarray())
         U[:j+1, j] = u[:j+1]
         l = u[j+1:]
@@ -357,7 +342,7 @@ def _remove_redundancy_sparse(A, rhs):
     # until the SciPy SuperLU interface permits control over column
     # permutation - see issue #7700.
 
-    B2= LUSolver(m)
+    B2 = LUSolver(m)
     for i in v:
         B = A[:, b]
 
@@ -365,8 +350,8 @@ def _remove_redundancy_sparse(A, rhs):
         if i > 0:
             e[i-1] = 0
 
-        pi = scipy.sparse.linalg.spsolve(B.transpose(), e).reshape(-1,1)
-        pi2 = B2.solve(e, True) # scipy.sparse.linalg.spsolve(B.transpose(), e).reshape(-1, 1)
+        pi = scipy.sparse.linalg.spsolve(B.transpose(), e).reshape(-1, 1)
+        pi2 = B2.solve(e, True)
         assert(np.allclose(pi.ravel(), pi2.ravel()))
 
         js = list(k-set(b))  # not efficient, but this is not the time sink...

--- a/scipy/optimize/tests/test__remove_redundancy.py
+++ b/scipy/optimize/tests/test__remove_redundancy.py
@@ -15,7 +15,12 @@ from numpy.testing import (
     assert_equal)
 
 from .test_linprog import magic_square
-from scipy.optimize._remove_redundancy import _remove_redundancy
+from scipy.optimize._remove_redundancy import _remove_redundancy_sparse
+from scipy.sparse import csc_matrix
+
+
+def _remove_redundancy(A, b):
+    return _remove_redundancy_sparse(csc_matrix(A), b)
 
 
 def setup_module():

--- a/scipy/sparse/linalg/dsolve/linsolve.py
+++ b/scipy/sparse/linalg/dsolve/linsolve.py
@@ -321,6 +321,11 @@ def splu(A, permc_spec=None, diag_pivot_thresh=None,
                     PanelSize=panel_size, Relax=relax)
     if options is not None:
         _options.update(options)
+
+    # Ensure no column permutations applied
+    if (_options["ColPerm"] == "NATURAL"):
+        _options["SymmetricMode"] = True
+
     return _superlu.gstrf(N, A.nnz, A.data, A.indices, A.indptr,
                           csc_construct_func=csc_construct_func,
                           ilu=False, options=_options)
@@ -407,6 +412,11 @@ def spilu(A, drop_tol=None, fill_factor=None, drop_rule=None, permc_spec=None,
                     PanelSize=panel_size, Relax=relax)
     if options is not None:
         _options.update(options)
+
+    # Ensure no column permutations applied
+    if (_options["ColPerm"] == "NATURAL"):
+        _options["SymmetricMode"] = True
+
     return _superlu.gstrf(N, A.nnz, A.data, A.indices, A.indptr,
                           csc_construct_func=csc_construct_func,
                           ilu=True, options=_options)

--- a/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
@@ -547,29 +547,30 @@ class TestSplu(object):
         lu = splu(a_)
         assert_array_equal(lu.perm_r, lu.perm_c)
 
-    def test_splu_natural_permc(self):
+    @pytest.mark.parametrize("splu_fun, rtol", [(splu, 1e-7), (spilu, 1e-1)])
+    def test_natural_permc(self, splu_fun, rtol):
         # Test that the "NATURAL" permc_spec does not permute the matrix
-        n = 1000
+        np.random.seed(42)
+        n = 500
         p = 0.01
-        a = scipy.sparse.random(n,n,p)
-        # Make a diagonal dominant, to make sure it is not singular
-        a += (n+1)*scipy.sparse.identity(n)
-        a_ = csc_matrix(a)
-        lu = splu(a_, permc_spec = "NATURAL")
-        # Assert that output col permutations are sequential ordering
-        assert_(np.all(lu.perm_c == np.arange(n)))
+        A = scipy.sparse.random(n, n, p)
+        x = np.random.rand(n)
+        # Make A diagonal dominant to make sure it is not singular
+        A += (n+1)*scipy.sparse.identity(n)
+        A_ = csc_matrix(A)
+        b = A_ @ x
 
-    def test_spilu_natural_permc(self):
-        # Test that the "NATURAL" permc_spec does not permute the matrix
-        n = 1000
-        p = 0.01
-        a = scipy.sparse.random(n,n,p)
-        # Make a diagonal dominant, to make sure it is not singular
-        a += (n+1)*scipy.sparse.identity(n)
-        a_ = csc_matrix(a)
-        lu = spilu(a_, permc_spec = "NATURAL")
-        # Assert that output col permutations are sequential ordering
-        assert_(np.all(lu.perm_c == np.arange(n)))
+        # without permc_spec, permutation is not identity
+        lu = splu_fun(A_)
+        assert_(np.any(lu.perm_c != np.arange(n)))
+
+        # with permc_spec="NATURAL", permutation is identity
+        lu = splu_fun(A_, permc_spec="NATURAL")
+        assert_array_equal(lu.perm_c, np.arange(n))
+
+        # Also, lu decomposition is valid
+        x2 = lu.solve(b)
+        assert_allclose(x, x2, rtol=rtol)
 
     @pytest.mark.skipif(not hasattr(sys, 'getrefcount'), reason="no sys.getrefcount")
     def test_lu_refcount(self):

--- a/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
@@ -557,7 +557,7 @@ class TestSplu(object):
         a_ = csc_matrix(a)
         lu = splu(a_, permc_spec = "NATURAL")
         # Assert that output col permutations are sequential ordering
-        assert_(np.all(lu.perm_c==np.arange(n)))
+        assert_(np.all(lu.perm_c == np.arange(n)))
 
     def test_spilu_natural_permc(self):
         # Test that the "NATURAL" permc_spec does not permute the matrix
@@ -569,7 +569,7 @@ class TestSplu(object):
         a_ = csc_matrix(a)
         lu = spilu(a_, permc_spec = "NATURAL")
         # Assert that output col permutations are sequential ordering
-        assert_(np.all(lu.perm_c==np.arange(n)))
+        assert_(np.all(lu.perm_c == np.arange(n)))
 
     @pytest.mark.skipif(not hasattr(sys, 'getrefcount'), reason="no sys.getrefcount")
     def test_lu_refcount(self):

--- a/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
@@ -547,6 +547,30 @@ class TestSplu(object):
         lu = splu(a_)
         assert_array_equal(lu.perm_r, lu.perm_c)
 
+    def test_splu_natural_permc(self):
+        # Test that the "NATURAL" permc_spec does not permute the matrix
+        n = 1000
+        p = 0.01
+        a = scipy.sparse.random(n,n,p)
+        # Make a diagonal dominant, to make sure it is not singular
+        a += (n+1)*scipy.sparse.identity(n)
+        a_ = csc_matrix(a)
+        lu = splu(a_, permc_spec = "NATURAL")
+        # Assert that output col permutations are sequential ordering
+        assert_(np.all(lu.perm_c==np.arange(n)))
+
+    def test_spilu_natural_permc(self):
+        # Test that the "NATURAL" permc_spec does not permute the matrix
+        n = 1000
+        p = 0.01
+        a = scipy.sparse.random(n,n,p)
+        # Make a diagonal dominant, to make sure it is not singular
+        a += (n+1)*scipy.sparse.identity(n)
+        a_ = csc_matrix(a)
+        lu = spilu(a_, permc_spec = "NATURAL")
+        # Assert that output col permutations are sequential ordering
+        assert_(np.all(lu.perm_c==np.arange(n)))
+
     @pytest.mark.skipif(not hasattr(sys, 'getrefcount'), reason="no sys.getrefcount")
     def test_lu_refcount(self):
         # Test that we are keeping track of the reference count with splu.


### PR DESCRIPTION
The sparse redundancy removal routine for `linprog` has always been inefficient. Both `_remove_redundancy_dense` and `_remove_redundancy_sparse` implement the algorithm from [here](https://www.tandfonline.com/doi/abs/10.1080/10556789508805634), but `_remove_redundancy_dense` is able to efficiently update the LU factorization of the basis matrix whereas `_remove_redundancy_sparse` factors it from scratch every time. This PR was an attempt to remedy that. It works, but it's slower than the original, and I'm stuck. I thought I'd open it anyway to see if I can get some help.

In the last two commits, I've added an `LUSolver` class that maintains an LU factorization of the basis matrix. Since the basis matrix is initially the identify, it starts with the L and U factors as the identify matrix. As each column of the basis matrix is replaced, the `update` method updates the L and U factors according to the same formulae as in `_remove_redundancy_dense`. The `solve` method solves a linear system using the updated LU factorization.

Note that the `LUSolver` objects have one SuperLU object for `L` and a separate SuperLU object for `U`. This is a hack because SuperLU doesn't seem to let me create an LU object from separate L and U matrices, nor can I edit the L and U atrributes within a SuperLU object. My first question is: is there a better way?

Other questions are in the self-review of the code.
Thanks for taking a look!

@hakeemo thought you might be interested.