### PR TITLE
Fix: Can no longer slice csr_matrix in 1.3.0 

### DIFF
--- a/scipy/sparse/_index.py
+++ b/scipy/sparse/_index.py
@@ -331,8 +331,13 @@ def _compatible_boolean_index(idx):
     # Absence of attributes `ndim` or `dtype` indicates a
     # non compatible index array.
     if not hasattr(idx, 'ndim') or not hasattr(idx, 'dtype'):
-        idx = np.asanyarray(idx)
-    if idx.dtype.kind == 'b':
+        if hasattr(idx, '__iter__'):
+            first = next(iter(idx), None)
+            if isinstance(first, bool):
+                idx = np.asanyarray(idx)
+                if idx.dtype.kind == 'b':
+                    return idx
+    elif idx.dtype.kind == 'b':
         return idx
     return None
 

--- a/scipy/sparse/_index.py
+++ b/scipy/sparse/_index.py
@@ -326,19 +326,18 @@ def _check_ellipsis(index):
 
 def _compatible_boolean_index(idx):
     """Returns a boolean index array that can be converted to
-    integer array. Returns None if no such array exists """
-    if hasattr(idx, '__iter__'):
-        if isinstance(idx, np.ndarray):
-            if idx.dtype.kind == 'b':
-                return idx
-        else:
-            for v in idx:
-                if not isinstance(v, bool):
-                    return None
-            return np.fromiter(idx, dtype=bool)
+    integer array. Returns None if no such array exists.
+    """
+    # Absence of attributes `ndim` or `dtype` indicates a
+    # non compatible index array.
+    if not hasattr(idx, 'ndim') or not hasattr(idx, 'dtype'):
+        idx = np.asanyarray(idx)
+    if idx.dtype.kind == 'b':
+        return idx
+    return None
 
 
 def _boolean_index_to_array(idx):
     if idx.ndim > 1:
         raise IndexError('invalid index shape')
-    return idx.nonzero()[0]
+    return np.where(idx)[0]

--- a/scipy/sparse/_index.py
+++ b/scipy/sparse/_index.py
@@ -276,9 +276,9 @@ def _unpack_index(index):
             'Indexing with sparse matrices is not supported '
             'except boolean indexing where matrix and index '
             'are equal shapes.')
-    if isinstance(row, np.ndarray) and row.dtype.kind == 'b':
+    if hasattr(row, 'ndim') and row.dtype.kind == 'b':
         row = _boolean_index_to_array(row)
-    if isinstance(col, np.ndarray) and col.dtype.kind == 'b':
+    if hasattr(col, 'ndim') and col.dtype.kind == 'b':
         col = _boolean_index_to_array(col)
     return row, col
 
@@ -325,4 +325,4 @@ def _check_ellipsis(index):
 def _boolean_index_to_array(idx):
     if idx.ndim > 1:
         raise IndexError('invalid index shape')
-    return idx.nonzero()[0]
+    return np.where(idx != 0)[0]

--- a/scipy/sparse/tests/test_csr.py
+++ b/scipy/sparse/tests/test_csr.py
@@ -95,3 +95,12 @@ def test_csr_empty_slices(matrix_input, axis, expected_shape):
 
     assert actual_shape_1 == expected_shape
     assert actual_shape_1 == actual_shape_2
+
+
+def test_csr_bool_indexing():
+    data = csr_matrix([[0, 1, 2], [3, 4, 5], [6, 7, 8]])
+    list_indices = [False, True, False]
+    array_indices = np.array(list_indices)
+    slice_list = data[list_indices].toarray()
+    slice_array = data[array_indices].toarray()
+    assert (slice_list == slice_array).all()

--- a/scipy/sparse/tests/test_csr.py
+++ b/scipy/sparse/tests/test_csr.py
@@ -99,8 +99,19 @@ def test_csr_empty_slices(matrix_input, axis, expected_shape):
 
 def test_csr_bool_indexing():
     data = csr_matrix([[0, 1, 2], [3, 4, 5], [6, 7, 8]])
-    list_indices = [False, True, False]
-    array_indices = np.array(list_indices)
-    slice_list = data[list_indices].toarray()
-    slice_array = data[array_indices].toarray()
-    assert (slice_list == slice_array).all()
+    list_indices1 = [False, True, False]
+    array_indices1 = np.array(list_indices1)
+    list_indices2 = [[False, True, False], [False, True, False], [False, True, False]]
+    array_indices2 = np.array(list_indices2)
+    list_indices3 = ([False, True, False], [False, True, False])
+    array_indices3 = (np.array(list_indices3[0]), np.array(list_indices3[1]))
+    slice_list1 = data[list_indices1].toarray()
+    slice_array1 = data[array_indices1].toarray()
+    slice_list2 = data[list_indices2]
+    slice_array2 = data[array_indices2]
+    slice_list3 = data[list_indices3]
+    slice_array3 = data[array_indices3]
+    assert (slice_list1 == slice_array1).all()
+    assert (slice_list2 == slice_array2).all()
+    assert (slice_list3 == slice_array3).all()
+


### PR DESCRIPTION
Fixes
#11200

This PR will provide a certain degree of leniency in array types used for storing boolean indices when converting them to integers. For example, after this PR, CSR matrices can be sliced directly with boolean indices even if the boolean indices are not stored as `numpy.ndarray`.