### PR TITLE
BUG: Rework the scaling in the ks_2samp two-sided exact test.

### DIFF
--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3112,6 +3112,8 @@ class TestKSTwoSamples(object):
         print(x[0], x[-1], y[0], y[-1])
         self._testOne(x, y, 'two-sided', 0.10597913208679133, 3.3149311398483503e-49, mode='asymp')
         self._testOne(x, y, 'two-sided', 0.10597913208679133, 2.7755575615628914e-15, mode='exact')
+        self._testOne(x, y, 'greater', 0.10597913208679133, 2.7947433906389253e-41, mode='asymp')
+        self._testOne(x, y, 'less', 0.09658002199780022, 2.7947433906389253e-41, mode='asymp')
 
     @pytest.mark.slow
     def testLargeBoth(self):
@@ -3122,7 +3124,7 @@ class TestKSTwoSamples(object):
         x = np.linspace(1, 200, n1) - delta
         y = np.linspace(2, 200, n2)
         self._testOne(x, y, 'two-sided', 563.0 / lcm, 0.99915729949018561, mode='asymp')
-        self._testOne(x, y, 'two-sided', 563.0 / lcm, 1.0, mode='exact')
+        self._testOne(x, y, 'two-sided', 563.0 / lcm, 0.9990456491488628, mode='exact')
         self._testOne(x, y, 'two-sided', 563.0 / lcm, 0.99915729949018561, mode='auto')
         self._testOne(x, y, 'greater', 563.0 / lcm, 0.7561851877420673)
         self._testOne(x, y, 'less', 10.0 / lcm, 0.9998239693191724)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3095,6 +3095,24 @@ class TestKSTwoSamples(object):
         self._testOne(x, y, 'greater', 561.0 / lcm, 0.99115454582047591)
         self._testOne(x, y, 'less', 55275.0 / lcm, 3.1317328311518713e-26)
 
+    def test_gh11184(self):
+        # 3000, 3001, exact two-sided
+        np.random.seed(123456)
+        x = np.random.normal(size=3000)
+        y = np.random.normal(size=3001) * 1.5
+        print(x[0], x[-1], y[0], y[-1])
+        self._testOne(x, y, 'two-sided', 0.11292880151060758, 2.7755575615628914e-15, mode='asymp')
+        self._testOne(x, y, 'two-sided', 0.11292880151060758, 2.7755575615628914e-15, mode='exact')
+
+    def test_gh11184_bigger(self):
+        # 10000, 10001, exact two-sided
+        np.random.seed(123456)
+        x = np.random.normal(size=10000)
+        y = np.random.normal(size=10001) * 1.5
+        print(x[0], x[-1], y[0], y[-1])
+        self._testOne(x, y, 'two-sided', 0.10597913208679133, 3.3149311398483503e-49, mode='asymp')
+        self._testOne(x, y, 'two-sided', 0.10597913208679133, 2.7755575615628914e-15, mode='exact')
+
     @pytest.mark.slow
     def testLargeBoth(self):
         # 10000, 11000


### PR DESCRIPTION
Rework the scaling in stats.py:_compute_prob_inside_method() based on
magnitide of biggest value rather than presuming that the binomial
will be sufficient to keep dynamic range within needs.

#### Reference issue
Closes gh-11184

#### What does this implement/fix?
Some intermediate computations were implicitly assuming that applying terms of a binomial factor would keep the results within a double's dynamic range.  For large sample sizes this wasn't always true.

Rescale the intermediate values when they reach 2**900 and apply the binomial and undo the scaling at the end of the computation.
