### PR TITLE
Fix: Sparse matrix constructor data type detection changes on Numpy 1.18.0

### DIFF
--- a/scipy/sparse/sputils.py
+++ b/scipy/sparse/sputils.py
@@ -12,7 +12,7 @@ __all__ = ['upcast', 'getdtype', 'isscalarlike', 'isintlike',
            'isshape', 'issequence', 'isdense', 'ismatrix', 'get_sum_dtype']
 
 supported_dtypes = ['bool', 'int8', 'uint8', 'short', 'ushort', 'intc',
-                    'uintc', 'int64', 'uint64', 'longlong', 'ulonglong', 'single', 'double',
+                    'uintc', 'l', 'L', 'longlong', 'ulonglong', 'single', 'double',
                     'longdouble', 'csingle', 'cdouble', 'clongdouble']
 supported_dtypes = [np.typeDict[x] for x in supported_dtypes]
 

--- a/scipy/sparse/sputils.py
+++ b/scipy/sparse/sputils.py
@@ -12,7 +12,7 @@ __all__ = ['upcast', 'getdtype', 'isscalarlike', 'isintlike',
            'isshape', 'issequence', 'isdense', 'ismatrix', 'get_sum_dtype']
 
 supported_dtypes = ['bool', 'int8', 'uint8', 'short', 'ushort', 'intc',
-                    'uintc', 'longlong', 'ulonglong', 'single', 'double',
+                    'uintc', 'int64', 'uint64', 'longlong', 'ulonglong', 'single', 'double',
                     'longdouble', 'csingle', 'cdouble', 'clongdouble']
 supported_dtypes = [np.typeDict[x] for x in supported_dtypes]
 


### PR DESCRIPTION
Fixes
 #11266

`np.int64` was missing from the list of supported numpy data types which was causing the `np.int64` to get directly converted to `np.longlong` with Numpy 1.18.0.