### PR TITLE
MAINT: Cleanup conditionals for unsupported numpy verisons

### DIFF
--- a/scipy/_build_utils/__init__.py
+++ b/scipy/_build_utils/__init__.py
@@ -1,6 +1,5 @@
 import numpy as np
 from ._fortran import *
-from scipy._lib._version import NumpyVersion
 
 
 # Don't use the deprecated NumPy C API. Define this to a fixed version instead of
@@ -9,11 +8,8 @@ from scipy._lib._version import NumpyVersion
 #
 #   config.add_extension('_name', sources=['source_fname'], **numpy_nodepr_api)
 #
-if NumpyVersion(np.__version__) >= '1.10.0.dev':
-    numpy_nodepr_api = dict(define_macros=[("NPY_NO_DEPRECATED_API",
-                                            "NPY_1_9_API_VERSION")])
-else:
-    numpy_nodepr_api = dict()
+numpy_nodepr_api = dict(define_macros=[("NPY_NO_DEPRECATED_API",
+                                        "NPY_1_9_API_VERSION")])
 
 
 from scipy._lib._testutils import PytestTester

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -21,8 +21,6 @@ from scipy.linalg import (solve, inv, det, lstsq, pinv, pinv2, pinvh, norm,
 
 from scipy.linalg._testutils import assert_no_overwrite
 
-from scipy._lib._version import NumpyVersion
-
 REAL_DTYPES = [np.float32, np.float64, np.longdouble]
 COMPLEX_DTYPES = [np.complex64, np.complex128, np.clongdouble]
 DTYPES = REAL_DTYPES + COMPLEX_DTYPES
@@ -1363,7 +1361,6 @@ class TestVectorNorms(object):
         assert_allclose(norm(a, axis=1), [[3.60555128, 4.12310563]] * 2)
         assert_allclose(norm(a, 1, axis=1), [[5.] * 2] * 2)
 
-    @pytest.mark.skipif(NumpyVersion(np.__version__) < '1.10.0', reason="")
     def test_keepdims_kwd(self):
         a = np.array([[[2, 1], [3, 4]]] * 2, 'd')
         b = norm(a, axis=1, keepdims=True)
@@ -1411,7 +1408,6 @@ class TestMatrixNorms(object):
         assert_allclose(b, d)
         assert_(b.shape == c.shape == d.shape)
 
-    @pytest.mark.skipif(NumpyVersion(np.__version__) < '1.10.0', reason="")
     def test_keepdims_kwd(self):
         a = np.arange(120, dtype='d').reshape(2, 3, 4, 5)
         b = norm(a, ord=np.inf, axis=(1, 0), keepdims=True)

--- a/scipy/sparse/_matrix_io.py
+++ b/scipy/sparse/_matrix_io.py
@@ -4,16 +4,11 @@ import sys
 import numpy as np
 import scipy.sparse
 
-from scipy._lib._version import NumpyVersion
-
 __all__ = ['save_npz', 'load_npz']
 
 
-if NumpyVersion(np.__version__) >= '1.10.0':
-    # Make loading safe vs. malicious input
-    PICKLE_KWARGS = dict(allow_pickle=False)
-else:
-    PICKLE_KWARGS = dict()
+# Make loading safe vs. malicious input
+PICKLE_KWARGS = dict(allow_pickle=False)
 
 
 def save_npz(file, matrix, compressed=True):

--- a/scipy/sparse/linalg/tests/test_norm.py
+++ b/scipy/sparse/linalg/tests/test_norm.py
@@ -8,7 +8,6 @@ from numpy.linalg import norm as npnorm
 from numpy.testing import assert_equal, assert_allclose
 from pytest import raises as assert_raises
 
-from scipy._lib._version import NumpyVersion
 import scipy.sparse
 from scipy.sparse.linalg import norm as spnorm
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -47,7 +47,6 @@ from scipy.sparse.sputils import (supported_dtypes, isscalarlike,
                                   get_index_dtype, asmatrix, matrix)
 from scipy.sparse.linalg import splu, expm, inv
 
-from scipy._lib._version import NumpyVersion
 from scipy._lib.decorator import decorator
 
 import pytest
@@ -1794,8 +1793,7 @@ class _TestCommon(object):
                 assert_array_equal(sum2, dat + dat)
 
         for dtype in self.math_dtypes:
-            if (dtype == np.dtype('bool')) and (
-                    NumpyVersion(np.__version__) >= '1.9.0.dev'):
+            if dtype == np.dtype('bool'):
                 # boolean array subtraction deprecated in 1.9.0
                 continue
 
@@ -2039,8 +2037,6 @@ class _TestCommon(object):
 
 
 class _TestInplaceArithmetic(object):
-    @pytest.mark.skipif(NumpyVersion(np.__version__) < "1.13.0",
-                        reason="numpy version doesn't respect array priority")
     def test_inplace_dense(self):
         a = np.ones((3, 4))
         b = self.spmatrix(a)
@@ -2448,19 +2444,16 @@ class _TestSlicing(object):
         assert_equal(a[1, 1, ...], b[1, 1, ...])
         assert_equal(a[1, ..., 1], b[1, ..., 1])
 
-    @pytest.mark.skipif(NumpyVersion(np.__version__) >= '1.9.0.dev', reason="")
     def test_multiple_ellipsis_slicing(self):
         b = asmatrix(arange(50).reshape(5,10))
         a = self.spmatrix(b)
 
-        assert_array_equal(a[..., ...].A, b[..., ...].A)
-        assert_array_equal(a[..., ..., ...].A, b[..., ..., ...].A)
-        assert_array_equal(a[1, ..., ...].A, b[1, ..., ...].A)
-        assert_array_equal(a[1:, ..., ...].A, b[1:, ..., ...].A)
-        assert_array_equal(a[..., ..., 1:].A, b[..., ..., 1:].A)
-
-        # Bug in NumPy's slicing
-        assert_array_equal(a[..., ..., 1].A, b[..., ..., 1].A.reshape((5,1)))
+        assert_array_equal(a[..., ...].A, b[:, :].A)
+        assert_array_equal(a[..., ..., ...].A, b[:, :].A)
+        assert_array_equal(a[1, ..., ...].A, b[1, :].A)
+        assert_array_equal(a[1:, ..., ...].A, b[1:, :].A)
+        assert_array_equal(a[..., ..., 1:].A, b[:, 1:].A)
+        assert_array_equal(a[..., ..., 1].A, b[:, 1].A)
 
 
 class _TestSlicingAssign(object):
@@ -3117,8 +3110,7 @@ class _TestArithmetic(object):
                 assert_array_equal(A + Bsp,D1)          # check dense + sparse
 
                 # subtraction
-                if (np.dtype('bool') in [x, y]) and (
-                        NumpyVersion(np.__version__) >= '1.9.0.dev'):
+                if np.dtype('bool') in [x, y]:
                     # boolean array subtraction deprecated in 1.9.0
                     continue
 

--- a/scipy/sparse/tests/test_matrix_io.py
+++ b/scipy/sparse/tests/test_matrix_io.py
@@ -8,7 +8,6 @@ import tempfile
 import pytest
 from pytest import raises as assert_raises
 from numpy.testing import assert_equal, assert_
-from scipy._lib._version import NumpyVersion
 
 from scipy.sparse import (csc_matrix, csr_matrix, bsr_matrix, dia_matrix,
                           coo_matrix, save_npz, load_npz, dok_matrix)
@@ -53,8 +52,6 @@ def test_save_and_load_one_entry():
     _check_save_and_load(dense_matrix)
 
 
-@pytest.mark.skipif(NumpyVersion(np.__version__) < '1.10.0',
-                    reason='disabling unpickling requires numpy >= 1.10.0')
 def test_malicious_load():
     class Executor(object):
         def __reduce__(self):

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -40,8 +40,6 @@ from scipy.special import ellipk, zeta
 from scipy.special._testutils import with_special_errors, \
      assert_func_equal, FuncData
 
-from scipy._lib._version import NumpyVersion
-
 import math
 
 
@@ -333,8 +331,6 @@ class TestCephes(object):
         assert_equal(cephes.expm1(-np.inf), -1)
         assert_equal(cephes.expm1(np.nan), np.nan)
 
-    # Earlier numpy version don't guarantee that npy_cexp conforms to C99.
-    @pytest.mark.skipif(NumpyVersion(np.__version__) < '1.9.0', reason='')
     def test_expm1_complex(self):
         expm1 = cephes.expm1
         assert_equal(expm1(0 + 0j), 0 + 0j)
@@ -575,8 +571,6 @@ class TestCephes(object):
         assert_equal(log1p(-2), np.nan)
         assert_equal(log1p(np.inf), np.inf)
 
-    # earlier numpy version don't guarantee that npy_clog conforms to C99
-    @pytest.mark.skipif(NumpyVersion(np.__version__) < '1.9.0', reason='')
     def test_log1p_complex(self):
         log1p = cephes.log1p
         c = complex


### PR DESCRIPTION
#### What does this implement/fix?
This removes a few explicit workarounds for older numpy versions that are no-longer supported. Most of these are test skips for `numpy < 1.10` with one for `numpy < 1.13.0` in `sparse.test_base`.