### PR TITLE
TST/CI: improve traceback formatting for test failures

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ jobs:
            cp -r ./usr/local/lib/* /usr/lib && \
            cp ./usr/local/include/* /usr/include && \
            cd ../scipy && \
-           F77=gfortran-5 F90=gfortran-5 python3.6 runtests.py --mode=full -- -n auto -s --junitxml=junit/test-results.xml --cov=scipy --cov-report=xml --cov-report=html"
+           F77=gfortran-5 F90=gfortran-5 python3.6 runtests.py --mode=full -- -n auto -s --junitxml=junit/test-results.xml --cov-config=.coveragerc --cov-report=xml --cov-report=html"
     displayName: 'Run 32-bit Ubuntu Docker Build / Tests'
   - task: PublishTestResults@2
     condition: succeededOrFailed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ jobs:
            cp -r ./usr/local/lib/* /usr/lib && \
            cp ./usr/local/include/* /usr/include && \
            cd ../scipy && \
-           F77=gfortran-5 F90=gfortran-5 python3.6 runtests.py --mode=full -- -n auto -sx --junitxml=junit/test-results.xml --cov=scipy --cov-report=xml --cov-report=html"
+           F77=gfortran-5 F90=gfortran-5 python3.6 runtests.py --mode=full -- -n auto -s --junitxml=junit/test-results.xml --cov=scipy --cov-report=xml --cov-report=html"
     displayName: 'Run 32-bit Ubuntu Docker Build / Tests'
   - task: PublishTestResults@2
     condition: succeededOrFailed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ jobs:
            cp -r ./usr/local/lib/* /usr/lib && \
            cp ./usr/local/include/* /usr/include && \
            cd ../scipy && \
-           F77=gfortran-5 F90=gfortran-5 python3.6 runtests.py --mode=full -- -n auto -rsx --junitxml=junit/test-results.xml --cov=scipy --cov-report=xml --cov-report=html"
+           F77=gfortran-5 F90=gfortran-5 python3.6 runtests.py --mode=full -- -n auto -sx --junitxml=junit/test-results.xml --cov=scipy --cov-report=xml --cov-report=html"
     displayName: 'Run 32-bit Ubuntu Docker Build / Tests'
   - task: PublishTestResults@2
     condition: succeededOrFailed()

--- a/scipy/_lib/_testutils.py
+++ b/scipy/_lib/_testutils.py
@@ -33,7 +33,7 @@ class PytestTester(object):
         module = sys.modules[self.module_name]
         module_path = os.path.abspath(module.__path__[0])
 
-        pytest_args = ['--tb=short']
+        pytest_args = ['--showlocals', '--tb=short']
 
         if doctests:
             raise ValueError("Doctests not supported")

--- a/scipy/_lib/_testutils.py
+++ b/scipy/_lib/_testutils.py
@@ -33,7 +33,7 @@ class PytestTester(object):
         module = sys.modules[self.module_name]
         module_path = os.path.abspath(module.__path__[0])
 
-        pytest_args = ['-l']
+        pytest_args = ['--tb=short']
 
         if doctests:
             raise ValueError("Doctests not supported")


### PR DESCRIPTION
Change the default traceback format to something a lot shorter and saner.
The Pytest `short` mode looks slightly nicer than `native` to me, but both are
fine. The super long default `auto` mode should go though, it makes CI logs
completely unreadable. 

We can make it configurable if anyone has a use for the long mode (I don't).

For docs see https://docs.pytest.org/en/latest/usage.html#modifying-python-traceback-printing

Comparing how these look:

<details>

`--tb=short`:
```
___________________________ TestSystematic.test_ei ____________________________
../scipy/scipy/special/tests/test_mpmath.py:1055: in test_ei
    rtol=6e-16)
../scipy/scipy/special/_mptestutils.py:286: in assert_mpmath_equal
    d.check()
../scipy/scipy/special/_mptestutils.py:273: in check
    reraise(*sys.exc_info())
../scipy/scipy/_lib/six.py:204: in reraise
    raise value
../scipy/scipy/special/_mptestutils.py:269: in check
    param_filter=self.param_filter)
../scipy/scipy/special/_testutils.py:85: in assert_func_equal
    fdata.check()
E   AssertionError:
E   Max |adiff|: 5.68434e-13
E       ...
```

`--tb=native`:
```
___________________________ TestSystematic.test_ei ____________________________
Traceback (most recent call last):
  File "/home/rgommers/code/scipy/scipy/special/tests/test_mpmath.py", line 1055, in test_ei
    rtol=6e-16)
  File "/home/rgommers/code/scipy/scipy/special/_mptestutils.py", line 286, in assert_mpmath_equal
    d.check()
  File "/home/rgommers/code/scipy/scipy/special/_mptestutils.py", line 273, in check
    reraise(*sys.exc_info())
  File "/home/rgommers/code/scipy/scipy/_lib/six.py", line 204, in reraise
    raise value
  File "/home/rgommers/code/scipy/scipy/special/_mptestutils.py", line 269, in check
    param_filter=self.param_filter)
  File "/home/rgommers/code/scipy/scipy/special/_testutils.py", line 85, in assert_func_equal
    fdata.check()
  File "/home/rgommers/code/scipy/scipy/special/_testutils.py", line 309, in check
    assert_(False, "\n".join(msg))
  File "/home/rgommers/anaconda3/lib/python3.7/site-packages/numpy/testing/_private/utils.py", line 98, in assert_
    raise AssertionError(smsg)
AssertionError:
Max |adiff|: 5.68434e-13
...
```

`--tb=auto` (default):
```
___________________________ TestSystematic.test_ei ____________________________

self = <scipy.special.tests.test_mpmath.TestSystematic object at 0x7f28caf689e8>

    def test_ei(self):
        assert_mpmath_equal(sc.expi,
                            mpmath.ei,
                            [Arg()],
>                           rtol=6e-16)

self       = <scipy.special.tests.test_mpmath.TestSystematic object at 0x7f28caf689e8>

../scipy/scipy/special/tests/test_mpmath.py:1055:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../scipy/scipy/special/_mptestutils.py:286: in assert_mpmath_equal
    d.check()
../scipy/scipy/special/_mptestutils.py:273: in check
    reraise(*sys.exc_info())
../scipy/scipy/_lib/six.py:204: in reraise
    raise value
../scipy/scipy/special/_mptestutils.py:269: in check
    param_filter=self.param_filter)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

func = <ufunc 'expi'>
results = <function MpmathData.check.<locals>.<lambda> at 0x7f28caf6bf28>
points = array([[-8.98846567e+307],
       [-1.00651365e+303],
       [-1.12707748e+298],
       [-1.26208288e+293],
       [-1...971e+288],
       [ 1.26208288e+293],
       [ 1.12707748e+298],
       [ 1.00651365e+303],
       [ 8.98846567e+307]])
rtol = 6e-16, atol = 1e-300, param_filter = None, knownfailure = None
vectorized = False, dtype = None, nan_ok = True, ignore_inf_sign = False
distinguish_nan_and_inf = True

    def assert_func_equal(func, results, points, rtol=None, atol=None,
                          param_filter=None, knownfailure=None,
                          vectorized=True, dtype=None, nan_ok=False,
                          ignore_inf_sign=False, distinguish_nan_and_inf=True):
        if hasattr(points, 'next'):
            # it's a generator
            points = list(points)

        points = np.asarray(points)
        if points.ndim == 1:
            points = points[:,None]
        nparams = points.shape[1]

        if hasattr(results, '__name__'):
            # function
            data = points
            result_columns = None
            result_func = results
        else:
            # dataset
            data = np.c_[points, results]
            result_columns = list(range(nparams, data.shape[1]))
            result_func = None

        fdata = FuncData(func, data, list(range(nparams)),
                         result_columns=result_columns, result_func=result_func,
                         rtol=rtol, atol=atol, param_filter=param_filter,
                         knownfailure=knownfailure, nan_ok=nan_ok, vectorized=vectorized,
                         ignore_inf_sign=ignore_inf_sign,
                         distinguish_nan_and_inf=distinguish_nan_and_inf)
>       fdata.check()
E       AssertionError:
E       Max |adiff|: 5.68434e-13
E       ...

atol       = 1e-300
data       = array([[-8.98846567e+307],
       [-1.00651365e+303],
       [-1.12707748e+298],
       [-1.26208288e+293],
       [-1...971e+288],
       [ 1.26208288e+293],
       [ 1.12707748e+298],
       [ 1.00651365e+303],
       [ 8.98846567e+307]])
distinguish_nan_and_inf = True
dtype      = None
fdata      = <Data for expi>
func       = <ufunc 'expi'>
ignore_inf_sign = False
knownfailure = None
nan_ok     = True
nparams    = 1
param_filter = None
points     = array([[-8.98846567e+307],
       [-1.00651365e+303],
       [-1.12707748e+298],
       [-1.26208288e+293],
       [-1...971e+288],
       [ 1.26208288e+293],
       [ 1.12707748e+298],
       [ 1.00651365e+303],
       [ 8.98846567e+307]])
result_columns = None
result_func = <function MpmathData.check.<locals>.<lambda> at 0x7f28caf6bf28>
results    = <function MpmathData.check.<locals>.<lambda> at 0x7f28caf6bf28>
rtol       = 6e-16
vectorized = False
```

</details>

Here is an example of the current CI failures, there's 849 lines of output for 11 failures, and it's almost impossible to even find where one failure ends and the next one begins: https://dev.azure.com/scipy-org/SciPy/_build/results?buildId=4384&view=logs&j=dca3794b-c3dc-52e6-709a-3545ea017448&t=42f16a10-8379-5482-623d-4749ae3e519a

The second commit removes `-r` for Azure. That flag controls the output of skip/xfail; having one line per skipped or xfailed test printed to the CI log below the actual test failures is terrible behavior (we have >350 of them right now).