### PR TITLE
fix docs & behavior for mode sequences in ndimage filters

### DIFF
--- a/scipy/ndimage/_ni_support.py
+++ b/scipy/ndimage/_ni_support.py
@@ -30,6 +30,7 @@
 
 from __future__ import division, print_function, absolute_import
 
+from collections.abc import Iterable
 import numpy
 
 
@@ -56,7 +57,7 @@ def _normalize_sequence(input, rank):
     check if its length is equal to the length of array.
     """
     is_str = isinstance(input, str)
-    if hasattr(input, '__iter__') and not is_str:
+    if not is_str and isinstance(input, Iterable):
         normalized = list(input)
         if len(normalized) != rank:
             err = "sequence argument must have length equal to input rank"

--- a/scipy/ndimage/filters.py
+++ b/scipy/ndimage/filters.py
@@ -618,6 +618,8 @@ def _correlate_or_convolve(input, weights, output, mode, cval, origin,
     if not weights.flags.contiguous:
         weights = weights.copy()
     output = _ni_support._get_output(output, input)
+    if hasattr(mode, '__iter__') and not isinstance(mode, str):
+        raise RuntimeError("A sequence of modes is not supported")
     mode = _ni_support._extend_mode_to_code(mode)
     _nd_image.correlate(input, weights, output, mode, cval, origins)
     return output
@@ -637,7 +639,7 @@ def correlate(input, weights, output=None, mode='reflect', cval=0.0,
     weights : ndarray
         array of weights, same number of dimensions as input
     %(output)s
-    %(mode_multiple)s
+    %(mode)s
     %(cval)s
     %(origin_multiple)s
 
@@ -663,7 +665,7 @@ def convolve(input, weights, output=None, mode='reflect', cval=0.0,
     weights : array_like
         Array of weights, same number of dimensions as input
     %(output)s
-    %(mode_multiple)s
+    %(mode)s
     cval : scalar, optional
         Value to fill past edges of input if `mode` is 'constant'. Default
         is 0.0
@@ -1027,6 +1029,10 @@ def _min_or_max_filter(input, size, footprint, structure, output, mode,
                 raise RuntimeError('structure array has incorrect shape')
             if not structure.flags.contiguous:
                 structure = structure.copy()
+        if hasattr(mode, '__iter__') and not isinstance(mode, str):
+            raise RuntimeError(
+                "A sequence of modes is not supported for non-separable "
+                "footprints")
         mode = _ni_support._extend_mode_to_code(mode)
         _nd_image.min_or_max_filter(input, footprint, structure, output,
                                     mode, cval, origins, minimum)
@@ -1051,6 +1057,11 @@ def minimum_filter(input, size=None, footprint=None, output=None,
     -------
     minimum_filter : ndarray
         Filtered array. Has the same shape as `input`.
+
+    Notes
+    -----
+    A sequence of modes (one per axis) is only supported when the footprint is
+    separable. Otherwise, a single mode string must be provided.
 
     Examples
     --------
@@ -1088,6 +1099,11 @@ def maximum_filter(input, size=None, footprint=None, output=None,
     -------
     maximum_filter : ndarray
         Filtered array. Has the same shape as `input`.
+
+    Notes
+    -----
+    A sequence of modes (one per axis) is only supported when the footprint is
+    separable. Otherwise, a single mode string must be provided.
 
     Examples
     --------
@@ -1157,6 +1173,10 @@ def _rank_filter(input, rank, size=None, footprint=None, output=None,
     else:
         output = _ni_support._get_output(output, input)
         mode = _ni_support._extend_mode_to_code(mode)
+        if hasattr(mode, '__iter__') and not isinstance(mode, str):
+            raise RuntimeError(
+                "A sequence of modes is not supported by non-separable rank "
+                "filters")
         _nd_image.rank_filter(input, rank, footprint, output, mode, cval,
                               origins)
         return output
@@ -1175,7 +1195,7 @@ def rank_filter(input, rank, size=None, footprint=None, output=None,
         indicates the largest element.
     %(size_foot)s
     %(output)s
-    %(mode_multiple)s
+    %(mode)s
     %(cval)s
     %(origin_multiple)s
 
@@ -1214,7 +1234,7 @@ def median_filter(input, size=None, footprint=None, output=None,
     %(input)s
     %(size_foot)s
     %(output)s
-    %(mode_multiple)s
+    %(mode)s
     %(cval)s
     %(origin_multiple)s
 
@@ -1254,7 +1274,7 @@ def percentile_filter(input, percentile, size=None, footprint=None,
         percentile = -20 equals percentile = 80
     %(size_foot)s
     %(output)s
-    %(mode_multiple)s
+    %(mode)s
     %(cval)s
     %(origin_multiple)s
 
@@ -1381,7 +1401,7 @@ def generic_filter(input, function, size=None, footprint=None,
         Function to apply at each element.
     %(size_foot)s
     %(output)s
-    %(mode_multiple)s
+    %(mode)s
     %(cval)s
     %(origin_multiple)s
     %(extra_arguments)s

--- a/scipy/ndimage/filters.py
+++ b/scipy/ndimage/filters.py
@@ -1172,11 +1172,11 @@ def _rank_filter(input, rank, size=None, footprint=None, output=None,
                               origins)
     else:
         output = _ni_support._get_output(output, input)
-        mode = _ni_support._extend_mode_to_code(mode)
         if hasattr(mode, '__iter__') and not isinstance(mode, str):
             raise RuntimeError(
                 "A sequence of modes is not supported by non-separable rank "
                 "filters")
+        mode = _ni_support._extend_mode_to_code(mode)
         _nd_image.rank_filter(input, rank, footprint, output, mode, cval,
                               origins)
         return output

--- a/scipy/ndimage/filters.py
+++ b/scipy/ndimage/filters.py
@@ -29,6 +29,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from __future__ import division, print_function, absolute_import
+from collections.abc import Iterable
 import warnings
 import numbers
 import numpy
@@ -618,7 +619,7 @@ def _correlate_or_convolve(input, weights, output, mode, cval, origin,
     if not weights.flags.contiguous:
         weights = weights.copy()
     output = _ni_support._get_output(output, input)
-    if hasattr(mode, '__iter__') and not isinstance(mode, str):
+    if not isinstance(mode, str) and isinstance(mode, Iterable):
         raise RuntimeError("A sequence of modes is not supported")
     mode = _ni_support._extend_mode_to_code(mode)
     _nd_image.correlate(input, weights, output, mode, cval, origins)
@@ -1029,7 +1030,7 @@ def _min_or_max_filter(input, size, footprint, structure, output, mode,
                 raise RuntimeError('structure array has incorrect shape')
             if not structure.flags.contiguous:
                 structure = structure.copy()
-        if hasattr(mode, '__iter__') and not isinstance(mode, str):
+        if not isinstance(mode, str) and isinstance(mode, Iterable):
             raise RuntimeError(
                 "A sequence of modes is not supported for non-separable "
                 "footprints")
@@ -1172,7 +1173,7 @@ def _rank_filter(input, rank, size=None, footprint=None, output=None,
                               origins)
     else:
         output = _ni_support._get_output(output, input)
-        if hasattr(mode, '__iter__') and not isinstance(mode, str):
+        if not isinstance(mode, str) and isinstance(mode, Iterable):
             raise RuntimeError(
                 "A sequence of modes is not supported by non-separable rank "
                 "filters")

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -756,8 +756,8 @@ class TestNdimage:
                                    [2, 2, 1, 1, 1],
                                    [5, 3, 3, 1, 1]], output)
         # separable footprint should allow mode sequence
-        output = ndimage.minimum_filter(array, footprint=footprint,
-                                        mode=['reflect', 'reflect'])
+        output2 = ndimage.minimum_filter(array, footprint=footprint,
+                                         mode=['reflect', 'reflect'])
         assert_array_almost_equal(output2, output)
 
     def test_minimum_filter07(self):
@@ -838,8 +838,8 @@ class TestNdimage:
                                    [7, 9, 9, 9, 5],
                                    [8, 9, 9, 9, 7]], output)
         # separable footprint should allow mode sequence
-        output = ndimage.maximum_filter(array, footprint=footprint,
-                                        mode=['reflect', 'reflect'])
+        output2 = ndimage.maximum_filter(array, footprint=footprint,
+                                         mode=['reflect', 'reflect'])
         assert_array_almost_equal(output2, output)
 
     def test_maximum_filter07(self):

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -318,6 +318,14 @@ class TestNdimage:
             assert_array_almost_equal([[2, 3, 5], [5, 6, 8]], output)
             assert_equal(output.dtype.type, numpy.float32)
 
+    def test_correlate_mode_sequence(self):
+        kernel = numpy.ones((2, 2))
+        array = numpy.ones((3, 3), float)
+        with assert_raises(RuntimeError):
+            ndimage.correlate(array, kernel, mode=['nearest', 'reflect'])
+        with assert_raises(RuntimeError):
+            ndimage.convolve(array, kernel, mode=['nearest', 'reflect'])
+
     def test_correlate19(self):
         kernel = numpy.array([[1, 0],
                               [0, 1]])
@@ -422,6 +430,7 @@ class TestNdimage:
                 ndimage.convolve1d(array, weights, axis=0,
                                    mode='nearest', output=output, origin=1)
                 assert_array_almost_equal(output, tcov)
+
 
     def test_gauss01(self):
         input = numpy.array([[1, 2, 3],
@@ -743,7 +752,8 @@ class TestNdimage:
                              [7, 6, 9, 3, 5],
                              [5, 8, 3, 7, 1]])
         footprint = [[1, 1, 1], [1, 1, 1]]
-        output = ndimage.minimum_filter(array, footprint=footprint)
+        output = ndimage.minimum_filter(array, footprint=footprint,
+                                        mode=['reflect', 'reflect'])
         assert_array_almost_equal([[2, 2, 1, 1, 1],
                                    [2, 2, 1, 1, 1],
                                    [5, 3, 3, 1, 1]], output)
@@ -757,6 +767,9 @@ class TestNdimage:
         assert_array_almost_equal([[2, 2, 1, 1, 1],
                                    [2, 3, 1, 3, 1],
                                    [5, 5, 3, 3, 1]], output)
+        with assert_raises(RuntimeError):
+            ndimage.minimum_filter(array, footprint=footprint,
+                                   mode=['reflect', 'constant'])
 
     def test_minimum_filter08(self):
         array = numpy.array([[3, 2, 5, 1, 4],
@@ -818,7 +831,9 @@ class TestNdimage:
                              [7, 6, 9, 3, 5],
                              [5, 8, 3, 7, 1]])
         footprint = [[1, 1, 1], [1, 1, 1]]
-        output = ndimage.maximum_filter(array, footprint=footprint)
+        # separable footprint should allow mode sequence
+        output = ndimage.maximum_filter(array, footprint=footprint,
+                                        mode=['reflect', 'reflect'])
         assert_array_almost_equal([[3, 5, 5, 5, 4],
                                    [7, 9, 9, 9, 5],
                                    [8, 9, 9, 9, 7]], output)
@@ -832,6 +847,10 @@ class TestNdimage:
         assert_array_almost_equal([[3, 5, 5, 5, 4],
                                    [7, 7, 9, 9, 5],
                                    [7, 9, 8, 9, 7]], output)
+        # non-separable footprint should not allow mode sequence
+        with assert_raises(RuntimeError):
+            ndimage.maximum_filter(array, footprint=footprint,
+                                   mode=['reflect', 'reflect'])
 
     def test_maximum_filter08(self):
         array = numpy.array([[3, 2, 5, 1, 4],
@@ -930,6 +949,15 @@ class TestNdimage:
         assert_array_almost_equal(expected, output)
         output = ndimage.median_filter(array, size=(2, 3))
         assert_array_almost_equal(expected, output)
+
+        # non-separable: does not allow mode sequence
+        with assert_raises(RuntimeError):
+            ndimage.percentile_filter(array, 50.0, size=(2, 3),
+                                      mode=['reflect', 'constant'])
+        with assert_raises(RuntimeError):
+            ndimage.rank_filter(array, 3, size=(2, 3), mode=['reflect']*2)
+        with assert_raises(RuntimeError):
+            ndimage.median_filter(array, size=(2, 3), mode=['reflect']*2)
 
     def test_rank09(self):
         expected = [[3, 3, 2, 4, 4],
@@ -1067,6 +1095,14 @@ class TestNdimage:
                 a, _filter_func, footprint=footprint, extra_arguments=(cf,),
                 extra_keywords={'total': cf.sum()})
             assert_array_almost_equal(r1, r2)
+
+        # generic_filter doesn't allow mode sequence
+        with assert_raises(RuntimeError):
+            r2 = ndimage.generic_filter(
+                a, _filter_func, mode=['reflect', 'reflect'],
+                footprint=footprint, extra_arguments=(cf,),
+                extra_keywords={'total': cf.sum()})
+
 
     def test_extend01(self):
         array = numpy.array([1, 2, 3])

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -431,7 +431,6 @@ class TestNdimage:
                                    mode='nearest', output=output, origin=1)
                 assert_array_almost_equal(output, tcov)
 
-
     def test_gauss01(self):
         input = numpy.array([[1, 2, 3],
                              [2, 4, 6]], numpy.float32)
@@ -752,11 +751,14 @@ class TestNdimage:
                              [7, 6, 9, 3, 5],
                              [5, 8, 3, 7, 1]])
         footprint = [[1, 1, 1], [1, 1, 1]]
-        output = ndimage.minimum_filter(array, footprint=footprint,
-                                        mode=['reflect', 'reflect'])
+        output = ndimage.minimum_filter(array, footprint=footprint)
         assert_array_almost_equal([[2, 2, 1, 1, 1],
                                    [2, 2, 1, 1, 1],
                                    [5, 3, 3, 1, 1]], output)
+        # separable footprint should allow mode sequence
+        output = ndimage.minimum_filter(array, footprint=footprint,
+                                        mode=['reflect', 'reflect'])
+        assert_array_almost_equal(output2, output)
 
     def test_minimum_filter07(self):
         array = numpy.array([[3, 2, 5, 1, 4],
@@ -831,12 +833,14 @@ class TestNdimage:
                              [7, 6, 9, 3, 5],
                              [5, 8, 3, 7, 1]])
         footprint = [[1, 1, 1], [1, 1, 1]]
-        # separable footprint should allow mode sequence
-        output = ndimage.maximum_filter(array, footprint=footprint,
-                                        mode=['reflect', 'reflect'])
+        output = ndimage.maximum_filter(array, footprint=footprint)
         assert_array_almost_equal([[3, 5, 5, 5, 4],
                                    [7, 9, 9, 9, 5],
                                    [8, 9, 9, 9, 7]], output)
+        # separable footprint should allow mode sequence
+        output = ndimage.maximum_filter(array, footprint=footprint,
+                                        mode=['reflect', 'reflect'])
+        assert_array_almost_equal(output2, output)
 
     def test_maximum_filter07(self):
         array = numpy.array([[3, 2, 5, 1, 4],
@@ -1102,7 +1106,6 @@ class TestNdimage:
                 a, _filter_func, mode=['reflect', 'reflect'],
                 footprint=footprint, extra_arguments=(cf,),
                 extra_keywords={'total': cf.sum()})
-
 
     def test_extend01(self):
         array = numpy.array([1, 2, 3])


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->
closes #9632

#### What does this implement/fix?
A few of the `scipy.ndimage.filters` docstrings suggest that a sequence of modes is supported when it is not. This PR fixes this and also adds a more informative error for cases like that reported in #9632.

The underlying C code in `scipy.ndimage` does not support a sequence of modes. Sequence of mode support is currently only possible when the filtering operation can be applied as a separable sequence of 1d filters.

#### Additional information

`convolve`, `correlate`, `median_filter` and `generic_filter` are not separable and just needed a doc fix to not suggest that a sequence of modes is allowed.

`minimum_filter` and `maximum_filter` can support a sequence of modes when the filter footprint is separable, so I have just added a Notes section explaining that. I added a more informative `RuntimeError` when a sequence is provided and this is not the case. 

`rank_filter` and `percentile_filter` are also generally not separable, so I have updated the docstring to reflect that. However, for these two, there are specific cases where they call either `minimum_filter` or `maximum_filter` internally. In those edge cases, a sequence of modes is possible, as the modes argument just gets passed on to `minimum_filter` or `maximum_filter`. I think it is probably best not to document that as supported behavior, but I did not explicitly disallow it here.
