### PR TITLE
BUG: make loadmat/savemat file opening close resources correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -186,7 +186,7 @@ before_install:
   - |
     if [ -n "${USE_DEBUG}" ]; then
         # see gh-10676; need to pin pytest version with debug
-        # Python 3.7
+        # Python 3.6
         travis_retry pip install pytest==5.0.1
     fi
   - travis_retry pip install gmpy2  # speeds up mpmath (scipy.special tests)

--- a/scipy/io/matlab/mio.py
+++ b/scipy/io/matlab/mio.py
@@ -17,9 +17,11 @@ __all__ = ['mat_reader_factory', 'loadmat', 'savemat', 'whosmat']
 @contextmanager
 def _open_file_context(file_like, appendmat, mode='rb'):
     f, opened = _open_file(file_like, appendmat, mode)
-    yield f
-    if opened:
-        f.close()
+    try:
+        yield f
+    finally:
+        if opened:
+            f.close()
 
 
 def _open_file(file_like, appendmat, mode='rb'):


### PR DESCRIPTION
This pattern is given in the contextmanager docs; without it we see `"Exception ignored in .... ResourceWarning"` printed in the test suite output (after changing to pytest's `--tb=short` formatting).

Also clean up a minor doc issue in `.travis.yml` that I introduced yesterday
