### PR TITLE
CI: skip Azure and TravisCI builds on merges and direct pushes to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ env:
 matrix:
   include:
     - python: 3.6
+      if: type = pull_request
       env:
         - PYFLAKES=1
         - PEP8=1
@@ -36,6 +37,7 @@ matrix:
         - |
           grep -rlIP '[^\x00-\x7F]' scipy | grep '\.pyx\?' | sort > unicode.out; grep -rlI '# -\*- coding: \(utf-8\|latin-1\) -\*-' scipy | grep '\.pyx\?' | sort > coding.out; comm -23 unicode.out coding.out > test_code.out; cat test_code.out;  test \! -s test_code.out
     - python: 3.7
+      if: type = pull_request
       env:
         - TESTMODE=fast
         - COVERAGE=
@@ -45,6 +47,7 @@ matrix:
         # specify in pyproject.toml (will be older than --pre --upgrade) works
         - USE_SDIST=1
     - python: 3.7
+      if: type = pull_request
       env:
         - TESTMODE=full
         - COVERAGE="--coverage --gcov"
@@ -53,6 +56,7 @@ matrix:
     # However travis only specifies regular or development builds of Python
     # so we must install python3.6-dbg using apt.
     - language: generic
+      if: type = pull_request
       dist: bionic
       env:
         - USE_DEBUG=python3.6-dbg
@@ -65,10 +69,12 @@ matrix:
             - python3.6-dbg
             - python3.6-dev
     - python: 3.8
+      if: type = pull_request
       env:
         - TESTMODE=full
         - NUMPYSPEC="--pre --upgrade --timeout=60 -f $PRE_WHEELS numpy"
     - python: 3.6
+      if: type = pull_request
       env:
         - TESTMODE=fast
         - COVERAGE=
@@ -77,12 +83,14 @@ matrix:
         - NUMPYSPEC="--upgrade numpy"
         - ASV_CHECK=1
     - python: 3.6
+      if: type = pull_request
       env:
         - TESTMODE=fast
         - COVERAGE=
         - NUMPYSPEC="numpy==1.17.4"
         - USE_SDIST=1
     - python: 3.6
+      if: type = pull_request
       env:
         - TESTMODE=fast
         - COVERAGE=
@@ -93,6 +101,7 @@ matrix:
         # flag. This environment variable starts all Py instances in -OO mode.
         - PYTHONOPTIMIZE=2
     - os: osx
+      if: type = pull_request
       language: generic
       env:
         - TESTMODE=fast
@@ -100,6 +109,7 @@ matrix:
         - NUMPYSPEC="--upgrade numpy"
         - MB_PYTHON_VERSION=3.7
     - python: 3.6
+      if: type = pull_request
       os: linux
       arch: ppc64le
       env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,12 +5,20 @@ trigger:
     include:
       - master
       - maintenance/*
+  paths:
+    include:
+      - '*'
+    exclude:
+      - 'benchmarks/*'
+      - './*.txt'
+      - 'site.cfg.example'
 
 # the version of OpenBLAS used is currently 0.3.7
 # and should be updated to match scipy-wheels as appropriate
 
 jobs:
 - job: Linux_Python_36_32bit_full
+  condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')  # skip for PR merges
   pool:
     vmImage: 'ubuntu-16.04'
   steps:
@@ -45,6 +53,7 @@ jobs:
       summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
       reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
 - job: Windows
+  condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')  # skip for PR merges
   pool:
     vmImage: 'VS2017-Win2016'
   variables:


### PR DESCRIPTION
Reason: this is very wasteful, if CI on a PR passes then it will pass on master as well. And if it doesn't, then it's highly likely to be a test flake that's unrelated to the merge commit being tested.

Also, Azure sends out spammy emails on either pass or fail of merge builds, which is annoying.

Mailing list discussion: https://mail.python.org/pipermail/scipy-dev/2019-October/023815.html

There doesn't seem to be a way to not have a trigger fire on merging for either Azure or TravisCI, so conditionals are apparently the way to achieve this. See, e.g., https://stackoverflow.com/questions/59076697/azure-devops-build-pipeline-ci-triggers-not-working-on-pr-merge-to-master-when

On Azure, also skip all CI for changes that aren't tested by CI anyway (benchmarks, some plain text files).
