### PR TITLE
DOC: Fix import in scipy.io.wavfile.read sample code

### DIFF
--- a/scipy/io/wavfile.py
+++ b/scipy/io/wavfile.py
@@ -228,7 +228,7 @@ def read(filename, mmap=False):
     Examples
     --------
     >>> from os.path import dirname, join as pjoin
-    >>> from scipy.io.wavfile import read
+    >>> from scipy.io import wavfile
     >>> import scipy.io
 
     Get the filename for an example .wav file from the tests/data directory.
@@ -238,7 +238,7 @@ def read(filename, mmap=False):
 
     Load the .wav file contents.
 
-    >>> samplerate, data = read(wav_fname)
+    >>> samplerate, data = wavfile.read(wav_fname)
     >>> print(f"number of channels = {data.shape[1]}")
     number of channels = 2
     >>> length = data.shape[0] / samplerate

--- a/scipy/io/wavfile.py
+++ b/scipy/io/wavfile.py
@@ -228,16 +228,17 @@ def read(filename, mmap=False):
     Examples
     --------
     >>> from os.path import dirname, join as pjoin
-    >>> import scipy.io as sio
+    >>> from scipy.io.wavfile import read
+    >>> import scipy.io
 
     Get the filename for an example .wav file from the tests/data directory.
 
-    >>> data_dir = pjoin(dirname(sio.__file__), 'tests', 'data')
+    >>> data_dir = pjoin(dirname(scipy.io.__file__), 'tests', 'data')
     >>> wav_fname = pjoin(data_dir, 'test-44100Hz-2ch-32bit-float-be.wav')
 
     Load the .wav file contents.
 
-    >>> samplerate, data = sio.wavfile.read(wav_fname)
+    >>> samplerate, data = read(wav_fname)
     >>> print(f"number of channels = {data.shape[1]}")
     number of channels = 2
     >>> length = data.shape[0] / samplerate


### PR DESCRIPTION
DOC: Fix import in scipy.io.wavfile.read sample code

The following code gives an error of "AttributeError: module 'scipy.io' has no attribute 'wavfile'"
```python
import scipy.io as sio
sio.wavfile
```
To fix it, I changed the import to `scipy.io.wavfile`. Consequently, since the `sio` definition no longer exists, I modifed the code that uses `sio` to use the name `scipy.io` directly.
