### PR TITLE
BUG: Use context manager for open

### DIFF
--- a/scipy/io/arff/tests/test_arffread.py
+++ b/scipy/io/arff/tests/test_arffread.py
@@ -73,12 +73,10 @@ class TestData(object):
 
     def test_filelike(self):
         # Test reading from file-like object (StringIO)
-        f1 = open(test1)
-        data1, meta1 = loadarff(f1)
-        f1.close()
-        f2 = open(test1)
-        data2, meta2 = loadarff(StringIO(f2.read()))
-        f2.close()
+        with open(test1) as f1:
+            data1, meta1 = loadarff(f1)
+        with open(test1) as f2:
+            data2, meta2 = loadarff(StringIO(f2.read()))
         assert_(data1 == data2)
         assert_(repr(meta1) == repr(meta2))
 
@@ -122,9 +120,8 @@ class TestNoData(object):
 class TestHeader(object):
     def test_type_parsing(self):
         # Test parsing type of attribute from their value.
-        ofile = open(test2)
-        rel, attrs = read_header(ofile)
-        ofile.close()
+        with open(test2) as ofile:
+            rel, attrs = read_header(ofile)
 
         expected = ['numeric', 'numeric', 'numeric', 'numeric', 'numeric',
                     'numeric', 'string', 'string', 'nominal', 'nominal']
@@ -135,17 +132,15 @@ class TestHeader(object):
     def test_badtype_parsing(self):
         # Test parsing wrong type of attribute from their value.
         def badtype_read():
-            ofile = open(test3)
-            rel, attrs = read_header(ofile)
-            ofile.close()
+            with open(test3) as ofile:
+                _, _ = read_header(ofile)
 
         assert_raises(ParseArffError, badtype_read)
 
     def test_fullheader1(self):
         # Parsing trivial header with nothing.
-        ofile = open(test1)
-        rel, attrs = read_header(ofile)
-        ofile.close()
+        with open(test1) as ofile:
+            rel, attrs = read_header(ofile)
 
         # Test relation
         assert_(rel == 'test1')
@@ -161,9 +156,8 @@ class TestHeader(object):
         assert_(attrs[4].values == ('class0', 'class1', 'class2', 'class3'))
 
     def test_dateheader(self):
-        ofile = open(test7)
-        rel, attrs = read_header(ofile)
-        ofile.close()
+        with open(test7) as ofile:
+            rel, attrs = read_header(ofile)
 
         assert_(rel == 'test7')
 
@@ -186,9 +180,8 @@ class TestHeader(object):
 
     def test_dateheader_unsupported(self):
         def read_dateheader_unsupported():
-            ofile = open(test8)
-            rel, attrs = read_header(ofile)
-            ofile.close()
+            with open(test8) as ofile:
+                _, _ = read_header(ofile)
 
         assert_raises(ValueError, read_dateheader_unsupported)
 


### PR DESCRIPTION
While reviewing #11286 I noticed a couple of unclosed arff I/O warnings. I think they were probably from the `read_dateheader_unsupported` test since that one should lead to an unclosed file, but figured it was worth cleaning up all `open` uses in that test file while I was at it.