### PR TITLE
DOC: special: fix typo in `chdtri` docstring

### DIFF
--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -1523,7 +1523,7 @@ add_newdoc("chdtri",
     Returns
     -------
     x : scalar or ndarray
-        Value so that he probability a Chi square random variable
+        Value so that the probability a Chi square random variable
         with `v` degrees of freedom is greater than `x` equals `p`.
 
     See Also


### PR DESCRIPTION
#### Reference issue
None

#### What does this implement/fix?
Fix a typo caught here https://github.com/scipy/scipy/pull/11285/files#r361881359.

#### Additional information
None