### PR TITLE
DOC: special: add to docstrings of Bessel zeros and derivatives

### DIFF
--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -255,8 +255,9 @@ def jnjnp_zeros(nt):
 def jnyn_zeros(n, nt):
     """Compute nt zeros of Bessel functions Jn(x), Jn'(x), Yn(x), and Yn'(x).
 
-    Returns 4 arrays of length `nt`, corresponding to the first `nt` zeros of
-    Jn(x), Jn'(x), Yn(x), and Yn'(x), respectively.
+    Returns 4 arrays of length `nt`, corresponding to the first `nt`
+    zeros of Jn(x), Jn'(x), Yn(x), and Yn'(x), respectively. The zeros
+    are returned in ascending order.
 
     Parameters
     ----------
@@ -265,7 +266,20 @@ def jnyn_zeros(n, nt):
     nt : int
         Number (<=1200) of zeros to compute
 
-    See jn_zeros, jnp_zeros, yn_zeros, ynp_zeros to get separate arrays.
+    Returns
+    -------
+    Jn : ndarray
+        First `nt` zeros of Jn
+    Jnp : ndarray
+        First `nt` zeros of Jn'
+    Yn : ndarray
+        First `nt` zeros of Yn
+    Ynp : ndarray
+        First `nt` zeros of Yn'
+
+    See Also
+    --------
+    jn_zeros, jnp_zeros, yn_zeros, ynp_zeros
 
     References
     ----------
@@ -284,7 +298,12 @@ def jnyn_zeros(n, nt):
 
 
 def jn_zeros(n, nt):
-    """Compute zeros of integer-order Bessel function Jn(x).
+    r"""Compute zeros of integer-order Bessel functions Jn.
+
+    Compute `nt` zeros of the Bessel functions :math:`J_n(x)` on the
+    interval :math:`(0, \infty)`. The zeros are returned in ascending
+    order. Note that this interval excludes the zero at :math:`x = 0`
+    that exists for :math:`n > 0`.
 
     Parameters
     ----------
@@ -293,18 +312,51 @@ def jn_zeros(n, nt):
     nt : int
         Number of zeros to return
 
+    Returns
+    -------
+    ndarray
+        First `n` zeros of the Bessel function.
+
+    See Also
+    --------
+    jv
+
     References
     ----------
     .. [1] Zhang, Shanjie and Jin, Jianming. "Computation of Special
            Functions", John Wiley and Sons, 1996, chapter 5.
            https://people.sc.fsu.edu/~jburkardt/f_src/special_functions/special_functions.html
+
+    Examples
+    --------
+    >>> import scipy.special as sc
+
+    We can check that we are getting approximations of the zeros by
+    evaluating them with `jv`.
+
+    >>> n = 1
+    >>> x = sc.jn_zeros(n, 3)
+    >>> x
+    array([ 3.83170597,  7.01558667, 10.17346814])
+    >>> sc.jv(n, x)
+    array([-0.00000000e+00,  1.72975330e-16,  2.89157291e-16])
+
+    Note that the zero at ``x = 0`` for ``n > 0`` is not included.
+
+    >>> sc.jv(1, 0)
+    0.0
 
     """
     return jnyn_zeros(n, nt)[0]
 
 
 def jnp_zeros(n, nt):
-    """Compute zeros of integer-order Bessel function derivative Jn'(x).
+    r"""Compute zeros of integer-order Bessel function derivatives Jn'.
+
+    Compute `nt` zeros of the functions :math:`J_n'(x)` on the
+    interval :math:`(0, \infty)`. The zeros are returned in ascending
+    order. Note that this interval excludes the zero at :math:`x = 0`
+    that exists for :math:`n > 1`.
 
     Parameters
     ----------
@@ -313,18 +365,49 @@ def jnp_zeros(n, nt):
     nt : int
         Number of zeros to return
 
+    Returns
+    -------
+    ndarray
+        First `n` zeros of the Bessel function.
+
+    See Also
+    --------
+    jvp, jv
+
     References
     ----------
     .. [1] Zhang, Shanjie and Jin, Jianming. "Computation of Special
            Functions", John Wiley and Sons, 1996, chapter 5.
            https://people.sc.fsu.edu/~jburkardt/f_src/special_functions/special_functions.html
+
+    Examples
+    --------
+    >>> import scipy.special as sc
+
+    We can check that we are getting approximations of the zeros by
+    evaluating them with `jvp`.
+
+    >>> n = 2
+    >>> x = sc.jnp_zeros(n, 3)
+    >>> x
+    array([3.05423693, 6.70613319, 9.96946782])
+    >>> sc.jvp(n, x)
+    array([ 2.77555756e-17,  2.08166817e-16, -3.01841885e-16])
+
+    Note that the zero at ``x = 0`` for ``n > 1`` is not included.
+
+    >>> sc.jvp(n, 0)
+    0.0
 
     """
     return jnyn_zeros(n, nt)[1]
 
 
 def yn_zeros(n, nt):
-    """Compute zeros of integer-order Bessel function Yn(x).
+    r"""Compute zeros of integer-order Bessel function Yn(x).
+
+    Compute `nt` zeros of the functions :math:`Y_n(x)` on the interval
+    :math:`(0, \infty)`. The zeros are returned in ascending order.
 
     Parameters
     ----------
@@ -333,18 +416,45 @@ def yn_zeros(n, nt):
     nt : int
         Number of zeros to return
 
+    Returns
+    -------
+    ndarray
+        First `n` zeros of the Bessel function.
+
+    See Also
+    --------
+    yn, yv
+
     References
     ----------
     .. [1] Zhang, Shanjie and Jin, Jianming. "Computation of Special
            Functions", John Wiley and Sons, 1996, chapter 5.
            https://people.sc.fsu.edu/~jburkardt/f_src/special_functions/special_functions.html
+
+    Examples
+    --------
+    >>> import scipy.special as sc
+
+    We can check that we are getting approximations of the zeros by
+    evaluating them with `yn`.
+
+    >>> n = 2
+    >>> x = sc.yn_zeros(n, 3)
+    >>> x
+    array([ 3.38424177,  6.79380751, 10.02347798])
+    >>> sc.yn(n, x)
+    array([-1.94289029e-16,  8.32667268e-17, -1.52655666e-16])
 
     """
     return jnyn_zeros(n, nt)[2]
 
 
 def ynp_zeros(n, nt):
-    """Compute zeros of integer-order Bessel function derivative Yn'(x).
+    r"""Compute zeros of integer-order Bessel function derivatives Yn'(x).
+
+    Compute `nt` zeros of the functions :math:`Y_n'(x)` on the
+    interval :math:`(0, \infty)`. The zeros are returned in ascending
+    order.
 
     Parameters
     ----------
@@ -353,11 +463,29 @@ def ynp_zeros(n, nt):
     nt : int
         Number of zeros to return
 
+    See Also
+    --------
+    yvp
+
     References
     ----------
     .. [1] Zhang, Shanjie and Jin, Jianming. "Computation of Special
            Functions", John Wiley and Sons, 1996, chapter 5.
            https://people.sc.fsu.edu/~jburkardt/f_src/special_functions/special_functions.html
+
+    Examples
+    --------
+    >>> import scipy.special as sc
+
+    We can check that we are getting approximations of the zeros by
+    evaluating them with `yvp`.
+
+    >>> n = 2
+    >>> x = sc.ynp_zeros(n, 3)
+    >>> x
+    array([ 5.00258293,  8.3507247 , 11.57419547])
+    >>> sc.yvp(n, x)
+    array([ 2.22044605e-16, -3.33066907e-16,  2.94902991e-16])
 
     """
     return jnyn_zeros(n, nt)[3]
@@ -486,16 +614,25 @@ def _bessel_diff_formula(v, z, n, L, phase):
 
 
 def jvp(v, z, n=1):
-    """Compute nth derivative of Bessel function Jv(z) with respect to `z`.
+    """Compute derivatives of Bessel functions of the first kind.
+
+    Compute the nth derivative of the Bessel function `Jv` with
+    respect to `z`.
 
     Parameters
     ----------
     v : float
         Order of Bessel function
     z : complex
-        Argument at which to evaluate the derivative
+        Argument at which to evaluate the derivative; can be real or
+        complex.
     n : int, default 1
         Order of derivative
+
+    Returns
+    -------
+    scalar or ndarray
+        Values of the derivative of the Bessel function.
 
     Notes
     -----
@@ -518,7 +655,10 @@ def jvp(v, z, n=1):
 
 
 def yvp(v, z, n=1):
-    """Compute nth derivative of Bessel function Yv(z) with respect to `z`.
+    """Compute derivatives of Bessel functions of the second kind.
+
+    Compute the nth derivative of the Bessel function `Yv` with
+    respect to `z`.
 
     Parameters
     ----------
@@ -528,6 +668,11 @@ def yvp(v, z, n=1):
         Argument at which to evaluate the derivative
     n : int, default 1
         Order of derivative
+
+    Returns
+    -------
+    scalar or ndarray
+        nth derivative of the Bessel function.
 
     Notes
     -----
@@ -605,17 +750,29 @@ def kvp(v, z, n=1):
 
 
 def ivp(v, z, n=1):
-    """Compute nth derivative of modified Bessel function Iv(z) with respect
-    to `z`.
+    """Compute derivatives of modified Bessel functions of the first kind.
+
+    Compute the nth derivative of the modified Bessel function `Iv`
+    with respect to `z`.
 
     Parameters
     ----------
-    v : array_like of float
+    v : array_like
         Order of Bessel function
-    z : array_like of complex
-        Argument at which to evaluate the derivative
+    z : array_like
+        Argument at which to evaluate the derivative; can be real or
+        complex.
     n : int, default 1
         Order of derivative
+
+    Returns
+    -------
+    scalar or ndarray
+        nth derivative of the modified Bessel function.
+
+    See Also
+    --------
+    iv
 
     Notes
     -----
@@ -642,12 +799,18 @@ def h1vp(v, z, n=1):
 
     Parameters
     ----------
-    v : float
+    v : array_like
         Order of Hankel function
-    z : complex
-        Argument at which to evaluate the derivative
+    z : array_like
+        Argument at which to evaluate the derivative. Can be real or
+        complex.
     n : int, default 1
         Order of derivative
+
+    Returns
+    -------
+    scalar or ndarray
+        Values of the derivative of the Hankel function.
 
     Notes
     -----
@@ -674,12 +837,18 @@ def h2vp(v, z, n=1):
 
     Parameters
     ----------
-    v : float
+    v : array_like
         Order of Hankel function
-    z : complex
-        Argument at which to evaluate the derivative
+    z : array_like
+        Argument at which to evaluate the derivative. Can be real or
+        complex.
     n : int, default 1
         Order of derivative
+
+    Returns
+    -------
+    scalar or ndarray
+        Values of the derivative of the Hankel function.
 
     Notes
     -----


### PR DESCRIPTION
#### Reference issue
None

#### What does this implement/fix?
The docstrings for the Bessel zeros functions and Bessel derivatives
functions have various gaps, for example missing returns, see also,
and examples sections. Add those where applicable.

#### Additional information
None