### PR TITLE
ENH: build infrastructure for ILP64 BLAS + ARPACK conversion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,7 @@ matrix:
       env:
         - TESTMODE=full
         - NUMPYSPEC="--pre --upgrade --timeout=60 -f $PRE_WHEELS numpy"
+        - NPY_USE_BLAS_ILP64=1
     - python: 3.6
       if: type = pull_request
       env:
@@ -119,6 +120,14 @@ before_install:
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       free -m
       export PATH=/usr/lib/ccache:$PATH
+    fi
+  - |
+    if [[ "$NPY_USE_BLAS_ILP64" == "1" ]]; then
+      target=$(python tools/openblas_support.py)
+      echo "[openblas64_]" > site.cfg
+      echo "library_dirs = $target/lib" >> site.cfg
+      echo "include_dirs = $target/include" >> site.cfg
+      echo "runtime_library_dirs = $target/lib" >> site.cfg
     fi
   - export CCACHE_COMPRESS=1
   - python --version # just to check

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,25 +71,22 @@ jobs:
           PYTHON_VERSION: '3.6'
           PYTHON_ARCH: 'x86'
           TEST_MODE: full
-          OPENBLAS: $(OPENBLAS_32)
           BITS: 32
         Python36-64bit-full:
           PYTHON_VERSION: '3.6'
           PYTHON_ARCH: 'x64'
           TEST_MODE: full
-          OPENBLAS: $(OPENBLAS_64)
           BITS: 64
         Python37-64bit-full:
           PYTHON_VERSION: '3.7'
           PYTHON_ARCH: 'x64'
           TEST_MODE: full
-          OPENBLAS: $(OPENBLAS_64)
           BITS: 64
-        Python38-64bit-full:
+        Python38-64bit-full-ilp64:
           PYTHON_VERSION: '3.8'
           PYTHON_ARCH: 'x64'
           TEST_MODE: full
-          OPENBLAS: $(OPENBLAS_64)
+          NPY_USE_BLAS_ILP64: 1
           BITS: 64
   steps:
   - task: UsePythonVersion@0
@@ -102,10 +99,20 @@ jobs:
   - powershell: |
       $pyversion = python -c "import sys; print(sys.version.split()[0])"
       Write-Host "Python Version: $pyversion"
-      $target = "C:\\hostedtoolcache\\windows\\Python\\$pyversion\\$(PYTHON_ARCH)\\lib\\openblas.a"
-      Write-Host "target path: $target"
-      $openblas = python tools/openblas_support.py
-      cp $openblas $target
+      function Download-OpenBLAS($ilp64) {
+          if ($ilp64 -eq '1') { $target_name = "openblas64_.a" } else { $target_name = "openblas.a" }
+          $target = "C:\\hostedtoolcache\\windows\\Python\\$pyversion\\$(PYTHON_ARCH)\\lib\\$target_name"
+          Write-Host "target path: $target"
+          $old_value = $env:NPY_USE_BLAS_ILP64
+          $env:NPY_USE_BLAS_ILP64 = $ilp64
+          $openblas = python tools/openblas_support.py
+          $env:NPY_USE_BLAS_ILP64 = $old_value
+          cp $openblas $target
+      }
+      Download-OpenBLAS('0')
+      If ($env:NPY_USE_BLAS_ILP64 -eq '1') {
+          Download-OpenBLAS('1')
+      }
     displayName: 'Download / Install OpenBLAS'
   - powershell: |
       # wheels appear to use mingw64 version 6.3.0, but 6.4.0

--- a/doc/source/building/index.rst
+++ b/doc/source/building/index.rst
@@ -19,3 +19,26 @@ Build instructions for different operating systems and an FAQ:
    windows
    macosx
    faq
+
+
+Reference for build options
+===========================
+
+Scipy has several tunable build-time options, which can be set.
+
+- ``site.cfg``: build-time library configuration file, see
+  ``site.cfg.example`` for details.
+
+- Environment variables ``NPY_LAPACK_ORDER``, ``NPY_BLAS_ORDER``, ``OPENBLAS``,
+  ``ATLAS``, etc., also controlling library configuration.
+  See `Numpy documentation <numpy-blasdoc>`_ for more details.
+
+- Environment variable ``NPY_USE_BLAS_ILP64=1``: build using 64-bit
+  integer size (ILP64) BLAS+LAPACK libraries.
+
+  Note that even when this is set, Scipy requires *also* 32-bit
+  integer size (LP64) BLAS+LAPACK libraries to be available and
+  configured. This is because only some components in Scipy make use
+  of the 64-bit capabilities.
+
+.. _numpy-blasdoc: https://numpy.org/devdocs/user/building.html#accelerated-blas-lapack-libraries

--- a/scipy/_build_utils/__init__.py
+++ b/scipy/_build_utils/__init__.py
@@ -1,3 +1,5 @@
+import os
+
 import numpy as np
 from ._fortran import *
 
@@ -10,6 +12,10 @@ from ._fortran import *
 #
 numpy_nodepr_api = dict(define_macros=[("NPY_NO_DEPRECATED_API",
                                         "NPY_1_9_API_VERSION")])
+
+
+def uses_blas64():
+    return (os.environ.get("NPY_USE_BLAS_ILP64", "0") != "0")
 
 
 from scipy._lib._testutils import PytestTester

--- a/scipy/_build_utils/_fortran.py
+++ b/scipy/_build_utils/_fortran.py
@@ -1,9 +1,15 @@
 import re
 import os
+import sys
+from distutils.util import get_platform
+
+import numpy as np
 
 
 __all__ = ['needs_g77_abi_wrapper', 'get_g77_abi_wrappers',
-           'gfortran_legacy_flag_hook']
+           'gfortran_legacy_flag_hook', 'blas_ilp64_pre_build_hook',
+           'get_f2py_int64_options', 'generic_pre_build_hook',
+           'write_file_content']
 
 
 def uses_mkl(info):
@@ -67,3 +73,288 @@ def gfortran_legacy_flag_hook(cmd, ext):
 
         if compiler.compiler_type == "gnu95" and compiler.version >= LooseVersion("10"):
             try_add_flag(args, compiler, "-fallow-argument-mismatch")
+
+
+def _get_build_src_dir():
+    plat_specifier = ".{}-{}.{}".format(get_platform(), *sys.version_info[:2])
+    return os.path.join('build', 'src' + plat_specifier)
+
+
+def get_f2py_int64_options():
+    if np.dtype('i') == np.dtype(np.int64):
+        int64_name = 'int'
+    elif np.dtype('l') == np.dtype(np.int64):
+        int64_name = 'long'
+    elif np.dtype('q') == np.dtype(np.int64):
+        int64_name = 'long_long'
+    else:
+        raise RuntimeError("No 64-bit integer type available in f2py!")
+
+    f2cmap_fn = os.path.join(_get_build_src_dir(), 'int64.f2cmap')
+    text = "{'integer': {'': '%s'}, 'logical': {'': '%s'}}\n" % (
+        int64_name, int64_name)
+
+    write_file_content(f2cmap_fn, text)
+
+    return ['--f2cmap', f2cmap_fn]
+
+
+def blas_ilp64_pre_build_hook(blas_info):
+    """
+    Pre-build hook for adding ILP64 BLAS compilation flags, and
+    mangling Fortran source files to rename BLAS/LAPACK symbols when
+    there are symbol suffixes.
+
+    Examples
+    --------
+    ::
+
+        from scipy._build_utils import blas_ilp64_pre_build_hook
+        ext = config.add_extension(...)
+        ext._pre_build_hook = blas_ilp64_pre_build_hook(blas_info)
+
+    """
+    return lambda cmd, ext: _blas_ilp64_pre_build_hook(cmd, ext, blas_info)
+
+
+def _blas_ilp64_pre_build_hook(cmd, ext, blas_info):
+    # Determine BLAS symbol suffix/prefix, if any
+    macros = dict(blas_info.get('define_macros', []))
+    prefix = macros.get('BLAS_SYMBOL_PREFIX', '')
+    suffix = macros.get('BLAS_SYMBOL_SUFFIX', '')
+
+    if suffix:
+        if not suffix.endswith('_'):
+            # Symbol suffix has to end with '_' to be Fortran-compatible
+            raise RuntimeError("BLAS/LAPACK has incompatible symbol suffix: "
+                               "{!r}".format(suffix))
+
+        suffix = suffix[:-1]
+
+    # When symbol prefix/suffix is present, we have to patch sources
+    if prefix or suffix:
+        include_dir = os.path.join(_get_build_src_dir(), 'blas64-include')
+
+        fcompiler_flags = {
+            'gnu95': ['-fdefault-integer-8', '-cpp', '-ffree-line-length-none',
+                      '-ffixed-line-length-none', '-I' + include_dir],
+        }
+
+        # Add the include dir for C code
+        if isinstance(ext, dict):
+            ext.setdefault('include_dirs', [])
+            ext['include_dirs'].append(include_dir)
+        else:
+            ext.include_dirs.append(include_dir)
+
+        # Create name-mapping include files
+        include_name_f = 'blas64-prefix-defines.inc'
+        include_name_c = 'blas64-prefix-defines.h'
+        include_fn_f = os.path.join(include_dir, include_name_f)
+        include_fn_c = os.path.join(include_dir, include_name_c)
+
+        text = ""
+        for symbol in get_blas_lapack_symbols():
+            text += '#define {} {}{}_{}\n'.format(symbol, prefix, symbol, suffix)
+            text += '#define {} {}{}_{}\n'.format(symbol.upper(), prefix, symbol, suffix)
+
+            # Code generation may give source codes with mixed-case names
+            for j in (1, 2):
+                s = symbol[:j].lower() + symbol[j:].upper()
+                text += '#define {} {}{}_{}\n'.format(s, prefix, symbol, suffix)
+                s = symbol[:j].upper() + symbol[j:].lower()
+                text += '#define {} {}{}_{}\n'.format(s, prefix, symbol, suffix)
+
+        write_file_content(include_fn_f, text)
+
+        ctext = re.sub(r'^#define (.*) (.*)$', r'#define \1_ \2_', text, flags=re.M)
+        write_file_content(include_fn_c, text + "\n" + ctext)
+
+        # Patch sources to include it
+        def patch_source(filename, old_text):
+            text = '#include "{}"\n'.format(include_name_f)
+            text += old_text
+            return text
+    else:
+        fcompiler_flags = {
+            'gnu95': ['-fdefault-integer-8'],
+        }
+        patch_source = None
+
+    return generic_pre_build_hook(cmd, ext,
+                                  fcompiler_flags=fcompiler_flags,
+                                  patch_source_func=patch_source,
+                                  source_fnpart="_blas64")
+
+
+def generic_pre_build_hook(cmd, ext, fcompiler_flags, patch_source_func=None,
+                           source_fnpart=None):
+    """
+    Pre-build hook for adding compiler flags and patching sources.
+
+    Parameters
+    ----------
+    cmd : distutils.core.Command
+        Hook input. Current distutils command (build_clib or build_ext).
+    ext : dict or numpy.distutils.extension.Extension
+        Hook input. Configuration information for library (dict, build_clib)
+        or extension (numpy.distutils.extension.Extension, build_ext).
+    fcompiler_flags : dict
+        Dictionary of ``{'compiler_name': ['-flag1', ...]}`` containing
+        compiler flags to set.
+    patch_source_func : callable, optional
+        Function patching sources, see `_generic_patch_sources` below.
+    source_fnpart : str, optional
+        String to append to the modified file basename before extension.
+
+    """
+    is_clib = isinstance(ext, dict)
+
+    if is_clib:
+        build_info = ext
+        del ext
+
+        # build_clib doesn't have separate f77/f90 compilers
+        f77 = cmd._f_compiler
+        f90 = cmd._f_compiler
+    else:
+        f77 = cmd._f77_compiler
+        f90 = cmd._f90_compiler
+
+    # Add compiler flags
+    if is_clib:
+        f77_args = build_info.setdefault('extra_f77_compile_args', [])
+        f90_args = build_info.setdefault('extra_f90_compile_args', [])
+        compilers = [(f77, f77_args), (f90, f90_args)]
+    else:
+        compilers = [(f77, ext.extra_f77_compile_args),
+                     (f90, ext.extra_f90_compile_args)]
+
+    for compiler, args in compilers:
+        if compiler is None:
+            continue
+
+        try:
+            flags = fcompiler_flags[compiler.compiler_type]
+        except KeyError:
+            raise RuntimeError("Compiler {!r} is not supported in this "
+                               "configuration.".format(compiler.compiler_type))
+
+        args.extend(flag for flag in flags if flag not in args)
+
+    # Mangle sources
+    if patch_source_func is not None:
+        if is_clib:
+            build_info.setdefault('depends', []).extend(build_info['sources'])
+            new_sources = _generic_patch_sources(build_info['sources'], patch_source_func,
+                                                 source_fnpart)
+            build_info['sources'][:] = new_sources
+        else:
+            ext.depends.extend(ext.sources)
+            new_sources = _generic_patch_sources(ext.sources, patch_source_func,
+                                                 source_fnpart)
+            ext.sources[:] = new_sources
+
+
+def _generic_patch_sources(filenames, patch_source_func, source_fnpart, root_dir=None):
+    """
+    Patch Fortran sources, creating new source files.
+
+    Parameters
+    ----------
+    filenames : list
+        List of Fortran source files to patch.
+        Files not ending in ``.f`` or ``.f90`` are left unaltered.
+    patch_source_func : callable(filename, old_contents) -> new_contents
+        Function to apply to file contents, returning new file contents
+        as a string.
+    source_fnpart : str
+        String to append to the modified file basename before extension.
+    root_dir : str, optional
+        Source root directory. Default: cwd
+
+    Returns
+    -------
+    new_filenames : list
+        List of names of the newly created patched sources.
+
+    """
+    new_filenames = []
+
+    if root_dir is None:
+        root_dir = os.getcwd()
+
+    root_dir = os.path.abspath(root_dir)
+    src_dir = os.path.join(root_dir, _get_build_src_dir())
+
+    for src in filenames:
+        base, ext = os.path.splitext(os.path.basename(src))
+
+        if ext not in ('.f', '.f90'):
+            new_filenames.append(src)
+            continue
+
+        with open(src, 'r') as fsrc:
+            text = patch_source_func(src, fsrc.read())
+
+        # Generate useful target directory name under src_dir
+        src_path = os.path.abspath(os.path.dirname(src))
+
+        for basedir in [src_dir, root_dir]:
+            if os.path.commonpath([src_path, basedir]) == basedir:
+                rel_path = os.path.relpath(src_path, basedir)
+                break
+        else:
+            raise ValueError(f"{src!r} not under {root_dir!r}")
+
+        dst = os.path.join(src_dir, rel_path, base + source_fnpart + ext)
+        write_file_content(dst, text)
+
+        new_filenames.append(dst)
+
+    return new_filenames
+
+
+def write_file_content(filename, content):
+    """
+    Write content to file, but only if it differs from the current one.
+    """
+    if os.path.isfile(filename):
+        with open(filename, 'r') as f:
+            old_content = f.read()
+
+        if old_content == content:
+            return
+
+    dirname = os.path.dirname(filename)
+    if not os.path.isdir(dirname):
+        os.makedirs(dirname)
+
+    with open(filename, 'w') as f:
+        f.write(content)
+
+
+def get_blas_lapack_symbols():
+    cached = getattr(get_blas_lapack_symbols, 'cached', None)
+    if cached is not None:
+        return cached
+
+    # Symbols not in Cython Lapack interface
+    symbols = """
+    sisnan dlaisnan slaisnan ilaenv iparmq lsamen xerbla
+    cgegs cgegv cgelsx cgeqpf cggsvd cggsvp clahrd clatzm ctzrqf
+    dgegs dgegv dgelsx dgeqpf dggsvd dggsvp dlahrd dlatzm dtzrqf
+    sgegs sgegv sgelsx sgeqpf sggsvd sggsvp slahrd slatzm stzrqf
+    zgegs zgegv zgelsx zgeqpf zggsvd zggsvp zlahrd zlatzm ztzrqf
+    """.split()
+
+    srcdir = os.path.join(os.path.dirname(__file__), os.pardir, 'linalg')
+    for fn in ['cython_blas_signatures.txt', 'cython_lapack_signatures.txt']:
+        with open(os.path.join(srcdir, fn), 'r') as f:
+            for line in f:
+                m = re.match(r"^\s*[a-z]+\s+([a-z0-9]+)\(", line)
+                if m:
+                    symbols.append(m.group(1))
+
+    get_blas_lapack_symbols.cached = tuple(sorted(set(symbols)))
+    return get_blas_lapack_symbols.cached

--- a/scipy/linalg/_cython_signature_generator.py
+++ b/scipy/linalg/_cython_signature_generator.py
@@ -101,98 +101,103 @@ void zgeesx(char *jobvs, char *sort, zselect1 *select, char *sense, int *n, z *a
 void zgges(char *jobvsl, char *jobvsr, char *sort, zselect2 *selctg, int *n, z *a, int *lda, z *b, int *ldb, int *sdim, z *alpha, z *beta, z *vsl, int *ldvsl, z *vsr, int *ldvsr, z *work, int *lwork, d *rwork, bint *bwork, int *info)
 void zggesx(char *jobvsl, char *jobvsr, char *sort, zselect2 *selctg, char *sense, int *n, z *a, int *lda, z *b, int *ldb, int *sdim, z *alpha, z *beta, z *vsl, int *ldvsl, z *vsr, int *ldvsr, d *rconde, d *rcondv, z *work, int *lwork, d *rwork, int *iwork, int *liwork, bint *bwork, int *info)'''
 
+
+# Exclude scabs and sisnan since they aren't currently included
+# in the scipy-specific ABI wrappers.
+blas_exclusions = ['scabs1', 'xerbla']
+
+# Exclude all routines that do not have consistent interfaces from
+# LAPACK 3.4.0 through 3.6.0.
+# Also exclude routines with string arguments to avoid
+# compatibility woes with different standards for string arguments.
+lapack_exclusions = [
+              # Not included because people should be using the
+              # C standard library function instead.
+              # sisnan is also not currently included in the
+              # ABI wrappers.
+              'sisnan', 'dlaisnan', 'slaisnan',
+              # Exclude slaneg because it isn't currently included
+              # in the ABI wrappers
+              'slaneg',
+              # Excluded because they require Fortran string arguments.
+              'ilaenv', 'iparmq', 'lsamen', 'xerbla',
+              # Exclude XBLAS routines since they aren't included
+              # by default.
+              'cgesvxx', 'dgesvxx', 'sgesvxx', 'zgesvxx',
+              'cgerfsx', 'dgerfsx', 'sgerfsx', 'zgerfsx',
+              'cla_gerfsx_extended', 'dla_gerfsx_extended',
+              'sla_gerfsx_extended', 'zla_gerfsx_extended',
+              'cla_geamv', 'dla_geamv', 'sla_geamv', 'zla_geamv',
+              'dla_gercond', 'sla_gercond',
+              'cla_gercond_c', 'zla_gercond_c',
+              'cla_gercond_x', 'zla_gercond_x',
+              'cla_gerpvgrw', 'dla_gerpvgrw',
+              'sla_gerpvgrw', 'zla_gerpvgrw',
+              'csysvxx', 'dsysvxx', 'ssysvxx', 'zsysvxx',
+              'csyrfsx', 'dsyrfsx', 'ssyrfsx', 'zsyrfsx',
+              'cla_syrfsx_extended', 'dla_syrfsx_extended',
+              'sla_syrfsx_extended', 'zla_syrfsx_extended',
+              'cla_syamv', 'dla_syamv', 'sla_syamv', 'zla_syamv',
+              'dla_syrcond', 'sla_syrcond',
+              'cla_syrcond_c', 'zla_syrcond_c',
+              'cla_syrcond_x', 'zla_syrcond_x',
+              'cla_syrpvgrw', 'dla_syrpvgrw',
+              'sla_syrpvgrw', 'zla_syrpvgrw',
+              'cposvxx', 'dposvxx', 'sposvxx', 'zposvxx',
+              'cporfsx', 'dporfsx', 'sporfsx', 'zporfsx',
+              'cla_porfsx_extended', 'dla_porfsx_extended',
+              'sla_porfsx_extended', 'zla_porfsx_extended',
+              'dla_porcond', 'sla_porcond',
+              'cla_porcond_c', 'zla_porcond_c',
+              'cla_porcond_x', 'zla_porcond_x',
+              'cla_porpvgrw', 'dla_porpvgrw',
+              'sla_porpvgrw', 'zla_porpvgrw',
+              'cgbsvxx', 'dgbsvxx', 'sgbsvxx', 'zgbsvxx',
+              'cgbrfsx', 'dgbrfsx', 'sgbrfsx', 'zgbrfsx',
+              'cla_gbrfsx_extended', 'dla_gbrfsx_extended',
+              'sla_gbrfsx_extended', 'zla_gbrfsx_extended',
+              'cla_gbamv', 'dla_gbamv', 'sla_gbamv', 'zla_gbamv',
+              'dla_gbrcond', 'sla_gbrcond',
+              'cla_gbrcond_c', 'zla_gbrcond_c',
+              'cla_gbrcond_x', 'zla_gbrcond_x',
+              'cla_gbrpvgrw', 'dla_gbrpvgrw',
+              'sla_gbrpvgrw', 'zla_gbrpvgrw',
+              'chesvxx', 'zhesvxx',
+              'cherfsx', 'zherfsx',
+              'cla_herfsx_extended', 'zla_herfsx_extended',
+              'cla_heamv', 'zla_heamv',
+              'cla_hercond_c', 'zla_hercond_c',
+              'cla_hercond_x', 'zla_hercond_x',
+              'cla_herpvgrw', 'zla_herpvgrw',
+              'sla_lin_berr', 'cla_lin_berr',
+              'dla_lin_berr', 'zla_lin_berr',
+              'clarscl2', 'dlarscl2', 'slarscl2', 'zlarscl2',
+              'clascl2', 'dlascl2', 'slascl2', 'zlascl2',
+              'cla_wwaddw', 'dla_wwaddw', 'sla_wwaddw', 'zla_wwaddw',
+              # Removed between 3.3.1 and 3.4.0.
+              'cla_rpvgrw', 'dla_rpvgrw', 'sla_rpvgrw', 'zla_rpvgrw',
+              # Signatures changed between 3.4.0 and 3.4.1.
+              'dlasq5', 'slasq5',
+              # Routines deprecated in LAPACK 3.6.0
+              'cgegs', 'cgegv', 'cgelsx',
+              'cgeqpf', 'cggsvd', 'cggsvp',
+              'clahrd', 'clatzm', 'ctzrqf',
+              'dgegs', 'dgegv', 'dgelsx',
+              'dgeqpf', 'dggsvd', 'dggsvp',
+              'dlahrd', 'dlatzm', 'dtzrqf',
+              'sgegs', 'sgegv', 'sgelsx',
+              'sgeqpf', 'sggsvd', 'sggsvp',
+              'slahrd', 'slatzm', 'stzrqf',
+              'zgegs', 'zgegv', 'zgelsx',
+              'zgeqpf', 'zggsvd', 'zggsvp',
+              'zlahrd', 'zlatzm', 'ztzrqf']
+
+
 if __name__ == '__main__':
     from sys import argv
     libname, src_dir, outfile = argv[1:]
-    # Exclude scabs and sisnan since they aren't currently included
-    # in the scipy-specific ABI wrappers.
     if libname.lower() == 'blas':
-        sigs_from_dir(src_dir, outfile, exclusions=['scabs1', 'xerbla'])
+        sigs_from_dir(src_dir, outfile, exclusions=blas_exclusions)
     elif libname.lower() == 'lapack':
-        # Exclude all routines that do not have consistent interfaces from
-        # LAPACK 3.4.0 through 3.6.0.
-        # Also exclude routines with string arguments to avoid
-        # compatibility woes with different standards for string arguments.
-        exclusions = [
-                      # Not included because people should be using the
-                      # C standard library function instead.
-                      # sisnan is also not currently included in the
-                      # ABI wrappers.
-                      'sisnan', 'dlaisnan', 'slaisnan',
-                      # Exclude slaneg because it isn't currently included
-                      # in the ABI wrappers
-                      'slaneg',
-                      # Excluded because they require Fortran string arguments.
-                      'ilaenv', 'iparmq', 'lsamen', 'xerbla',
-                      # Exclude XBLAS routines since they aren't included
-                      # by default.
-                      'cgesvxx', 'dgesvxx', 'sgesvxx', 'zgesvxx',
-                      'cgerfsx', 'dgerfsx', 'sgerfsx', 'zgerfsx',
-                      'cla_gerfsx_extended', 'dla_gerfsx_extended',
-                      'sla_gerfsx_extended', 'zla_gerfsx_extended',
-                      'cla_geamv', 'dla_geamv', 'sla_geamv', 'zla_geamv',
-                      'dla_gercond', 'sla_gercond',
-                      'cla_gercond_c', 'zla_gercond_c',
-                      'cla_gercond_x', 'zla_gercond_x',
-                      'cla_gerpvgrw', 'dla_gerpvgrw',
-                      'sla_gerpvgrw', 'zla_gerpvgrw',
-                      'csysvxx', 'dsysvxx', 'ssysvxx', 'zsysvxx',
-                      'csyrfsx', 'dsyrfsx', 'ssyrfsx', 'zsyrfsx',
-                      'cla_syrfsx_extended', 'dla_syrfsx_extended',
-                      'sla_syrfsx_extended', 'zla_syrfsx_extended',
-                      'cla_syamv', 'dla_syamv', 'sla_syamv', 'zla_syamv',
-                      'dla_syrcond', 'sla_syrcond',
-                      'cla_syrcond_c', 'zla_syrcond_c',
-                      'cla_syrcond_x', 'zla_syrcond_x',
-                      'cla_syrpvgrw', 'dla_syrpvgrw',
-                      'sla_syrpvgrw', 'zla_syrpvgrw',
-                      'cposvxx', 'dposvxx', 'sposvxx', 'zposvxx',
-                      'cporfsx', 'dporfsx', 'sporfsx', 'zporfsx',
-                      'cla_porfsx_extended', 'dla_porfsx_extended',
-                      'sla_porfsx_extended', 'zla_porfsx_extended',
-                      'dla_porcond', 'sla_porcond',
-                      'cla_porcond_c', 'zla_porcond_c',
-                      'cla_porcond_x', 'zla_porcond_x',
-                      'cla_porpvgrw', 'dla_porpvgrw',
-                      'sla_porpvgrw', 'zla_porpvgrw',
-                      'cgbsvxx', 'dgbsvxx', 'sgbsvxx', 'zgbsvxx',
-                      'cgbrfsx', 'dgbrfsx', 'sgbrfsx', 'zgbrfsx',
-                      'cla_gbrfsx_extended', 'dla_gbrfsx_extended',
-                      'sla_gbrfsx_extended', 'zla_gbrfsx_extended',
-                      'cla_gbamv', 'dla_gbamv', 'sla_gbamv', 'zla_gbamv',
-                      'dla_gbrcond', 'sla_gbrcond',
-                      'cla_gbrcond_c', 'zla_gbrcond_c',
-                      'cla_gbrcond_x', 'zla_gbrcond_x',
-                      'cla_gbrpvgrw', 'dla_gbrpvgrw',
-                      'sla_gbrpvgrw', 'zla_gbrpvgrw',
-                      'chesvxx', 'zhesvxx',
-                      'cherfsx', 'zherfsx',
-                      'cla_herfsx_extended', 'zla_herfsx_extended',
-                      'cla_heamv', 'zla_heamv',
-                      'cla_hercond_c', 'zla_hercond_c',
-                      'cla_hercond_x', 'zla_hercond_x',
-                      'cla_herpvgrw', 'zla_herpvgrw',
-                      'sla_lin_berr', 'cla_lin_berr',
-                      'dla_lin_berr', 'zla_lin_berr',
-                      'clarscl2', 'dlarscl2', 'slarscl2', 'zlarscl2',
-                      'clascl2', 'dlascl2', 'slascl2', 'zlascl2',
-                      'cla_wwaddw', 'dla_wwaddw', 'sla_wwaddw', 'zla_wwaddw',
-                      # Removed between 3.3.1 and 3.4.0.
-                      'cla_rpvgrw', 'dla_rpvgrw', 'sla_rpvgrw', 'zla_rpvgrw',
-                      # Signatures changed between 3.4.0 and 3.4.1.
-                      'dlasq5', 'slasq5',
-                      # Routines deprecated in LAPACK 3.6.0
-                      'cgegs', 'cgegv', 'cgelsx',
-                      'cgeqpf', 'cggsvd', 'cggsvp',
-                      'clahrd', 'clatzm', 'ctzrqf',
-                      'dgegs', 'dgegv', 'dgelsx',
-                      'dgeqpf', 'dggsvd', 'dggsvp',
-                      'dlahrd', 'dlatzm', 'dtzrqf',
-                      'sgegs', 'sgegv', 'sgelsx',
-                      'sgeqpf', 'sggsvd', 'sggsvp',
-                      'slahrd', 'slatzm', 'stzrqf',
-                      'zgegs', 'zgegv', 'zgelsx',
-                      'zgeqpf', 'zggsvd', 'zggsvp',
-                      'zlahrd', 'zlatzm', 'ztzrqf']
         sigs_from_dir(src_dir, outfile, manual_wrappers=lapack_manual_wrappers,
-                      exclusions=exclusions)
+                      exclusions=lapack_exclusions)

--- a/scipy/sparse/linalg/eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/arpack.py
@@ -41,6 +41,8 @@ __docformat__ = "restructuredtext en"
 __all__ = ['eigs', 'eigsh', 'svds', 'ArpackError', 'ArpackNoConvergence']
 
 from . import _arpack
+arpack_int = _arpack.timing.nbx.dtype
+
 import numpy as np
 import warnings
 from scipy.sparse.linalg.interface import aslinearoperator, LinearOperator
@@ -339,7 +341,7 @@ class _ArpackParams(object):
         ncv = min(ncv, n)
 
         self.v = np.zeros((n, ncv), tp)  # holds Ritz vectors
-        self.iparam = np.zeros(11, "int")
+        self.iparam = np.zeros(11, arpack_int)
 
         # set solver mode and parameters
         ishfts = 1
@@ -528,7 +530,7 @@ class _SymmetricArpackParams(_ArpackParams):
         self.iterate_infodict = _SAUPD_ERRORS[ltr]
         self.extract_infodict = _SEUPD_ERRORS[ltr]
 
-        self.ipntr = np.zeros(11, "int")
+        self.ipntr = np.zeros(11, arpack_int)
 
     def iterate(self):
         self.ido, self.tol, self.resid, self.v, self.iparam, self.ipntr, self.info = \
@@ -708,7 +710,7 @@ class _UnsymmetricArpackParams(_ArpackParams):
         self.iterate_infodict = _NAUPD_ERRORS[ltr]
         self.extract_infodict = _NEUPD_ERRORS[ltr]
 
-        self.ipntr = np.zeros(14, "int")
+        self.ipntr = np.zeros(14, arpack_int)
 
         if self.tp in 'FD':
             # Use _aligned_zeros to work around a f2py bug in Numpy 1.9.1

--- a/scipy/sparse/linalg/eigen/arpack/setup.py
+++ b/scipy/sparse/linalg/eigen/arpack/setup.py
@@ -5,9 +5,19 @@ def configuration(parent_package='',top_path=None):
     from scipy._build_utils.system_info import get_info
     from numpy.distutils.misc_util import Configuration
     from scipy._build_utils import (get_g77_abi_wrappers,
-                                    gfortran_legacy_flag_hook)
+                                    gfortran_legacy_flag_hook,
+                                    blas_ilp64_pre_build_hook,
+                                    uses_blas64, get_f2py_int64_options)
 
-    lapack_opt = get_info('lapack_opt')
+    if uses_blas64():
+        lapack_opt = get_info('lapack_ilp64_opt', 2)
+        pre_build_hook = (gfortran_legacy_flag_hook,
+                          blas_ilp64_pre_build_hook(lapack_opt))
+        f2py_options = get_f2py_int64_options()
+    else:
+        lapack_opt = get_info('lapack_opt')
+        pre_build_hook = gfortran_legacy_flag_hook
+        f2py_options = None
 
     config = Configuration('arpack', parent_package, top_path)
 
@@ -18,16 +28,15 @@ def configuration(parent_package='',top_path=None):
 
     config.add_library('arpack_scipy', sources=arpack_sources,
                        include_dirs=[join('ARPACK', 'SRC')],
-                       _pre_build_hook=gfortran_legacy_flag_hook)
+                       _pre_build_hook=pre_build_hook)
 
-    ext_sources = ['arpack.pyf.src']
     ext = config.add_extension('_arpack',
-                               sources=ext_sources,
+                               sources=['arpack.pyf.src'],
                                libraries=['arpack_scipy'],
+                               f2py_options=f2py_options,
                                extra_info=lapack_opt,
-                               depends=arpack_sources,
-                               )
-    ext._pre_build_hook = gfortran_legacy_flag_hook
+                               depends=arpack_sources)
+    ext._pre_build_hook = pre_build_hook
 
     config.add_data_dir('tests')
 


### PR DESCRIPTION
Implement basic infrastructure for using ILP64 (i.e. 64-bit integer size) BLAS/LAPACK in Fortran code.

- Support for specifying 64-bit integer size in f2py.
- Support for setting Fortran compiler flags for 64-bit integer size. Currently only for gfortran, but can be extended later.
- Support for BLAS/LAPACK [symbol name suffixes and prefixes](https://github.com/xianyi/OpenBLAS/issues/646) in Fortran code. This is done by patching Fortran sources (via preprocessor) on the fly --- it is preferable to manually editing e.g. arpack sources.

Moreover:

- One monkeypatch bugfix is required for Numpy 1.18.0 to make msvc+gfortran on Windows work with multiple openblas libraries.
- Convert ARPACK to ILP64 BLAS, if available.

Building with `NPY_USE_BLAS_ILP64=1` requires Numpy >= 1.18.0 for the necessary `numpy.distutils` updates.

A full (draft) patchset for converting all libraries in Scipy is in gh-11193, of which this is the initial part. See also general comments there.

Implementing this in all parts of scipy would generally resolve issues that originate from integer overflows with too large work array etc. sizes, see e.g. gh-11261, gh-5102, gh-5489