### PR TITLE
DOC: special: fix typo in `besselpoly` docstring

### DIFF
--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -889,7 +889,7 @@ add_newdoc("besselpoly",
 
     Weighted integral of the Bessel function of the first kind.
 
-    Comptues
+    Computes
 
     .. math::
 


### PR DESCRIPTION
#### Reference issue
None

#### What does this implement/fix?
Fix a mispelling `comptues` -> `computes` in the `besselpoly` docstring. Pointed out here https://github.com/scipy/scipy/pull/11297#discussion_r362333293.

#### Additional information
None