### PR TITLE
ENH: MAINT: Rewrite of eigh() and relevant wrappers

### DIFF
--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -273,9 +273,10 @@ def eigh(a, b=None, lower=True, eigvals_only=False, overwrite_a=False,
     Solves a standard or generalized eigenvalue problem for a complex
     Hermitian or real symmetric matrix.
 
-    Find eigenvalues array w and optionally eigenvectors array v of array
-    ``a``, where ``b`` is positive definite such that for every eigenvalue
-    λ (i-th entry of w) and its eigenvector vi (i-th column of v) satisfies::
+    Find eigenvalues array ``w`` and optionally eigenvectors array ``v`` of
+    array ``a``, where ``b`` is positive definite such that for every
+    eigenvalue λ (i-th entry of w) and its eigenvector vi (i-th column of v)
+    satisfies::
 
                       a @ vi = λ * b @ vi
         vi.conj().T @ a @ vi = λ
@@ -315,7 +316,8 @@ def eigh(a, b=None, lower=True, eigvals_only=False, overwrite_a=False,
         generalized (where b is not None) problems. See the Notes section.
     type : int, optional
         For the generalized problems, this keyword specifies the problem type
-        to be solved for w and v (only takes 1, 2, 3 as possible inputs)::
+        to be solved for ``w`` and ``v`` (only takes 1, 2, 3 as possible
+        inputs)::
 
             1 =>     a @ v = w @ b @ v
             2 => a @ b @ v = w @ v
@@ -323,10 +325,10 @@ def eigh(a, b=None, lower=True, eigvals_only=False, overwrite_a=False,
 
         This keyword is ignored for standard problems.
     overwrite_a : bool, optional
-        Whether to overwrite data in `a` (may improve performance). Default
+        Whether to overwrite data in ``a`` (may improve performance). Default
         is False.
     overwrite_b : bool, optional
-        Whether to overwrite data in `b` (may improve performance). Default
+        Whether to overwrite data in ``b`` (may improve performance). Default
         is False.
     check_finite : bool, optional
         Whether to check that the input matrices contain only finite numbers.
@@ -372,7 +374,7 @@ def eigh(a, b=None, lower=True, eigvals_only=False, overwrite_a=False,
     LinAlgError
         If eigenvalue computation does not converge, an error occurred, or
         b matrix is not definite positive. Note that if input matrices are
-        not symmetric or Hermitian, no error is reported but results will
+        not symmetric or Hermitian, no error will be reported but results will
         be wrong.
 
     See Also
@@ -386,16 +388,17 @@ def eigh(a, b=None, lower=True, eigvals_only=False, overwrite_a=False,
     -----
     This function does not check the input array for being hermitian/symmetric
     in order to allow for representing arrays with only their upper/lower
-    triangular parts. Also, note that even though not referenced, finiteness
-    check applies to the whole array and unaffected by "lower" keyword.
+    triangular parts. Also, note that even though not taken into account,
+    finiteness check applies to the whole array and unaffected by "lower"
+    keyword.
 
     This function uses LAPACK drivers for computations in all possible keyword
     combinations, prefixed with ``sy`` if arrays are real and ``he`` if
     complex. As a brief summary, the slowest and the most robust driver is the
     classical ``<sy/he>ev`` which uses symmetric QR. ``<sy/he>evr`` is seen as
     the optimal choice for the most general cases. However, there are certain
-    occassions that ``<sy/he>evd`` computes faster in the expense of more
-    memory usage. ``<sy/he>evx`` while still being faster than ``<sy/he>ev``
+    occassions that ``<sy/he>evd`` computes faster at the expense of more
+    memory usage. ``<sy/he>evx``, while still being faster than ``<sy/he>ev``,
     often performs worse than the rest except when very few eigenvalues are
     requested for large arrays though there is still no performance guarantee.
 

--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -455,7 +455,7 @@ def eigh(a, b=None, lower=True, eigvals_only=False, overwrite_a=False,
     # Check indices if given
     if subset_by_index:
         lo, hi = [int(x) for x in subset_by_index]
-        if not (0 <= lo < hi < n):
+        if not (0 <= lo <= hi < n):
             raise ValueError('Requested eigenvalue indices are not valid. '
                              'Valid range is [0, {}] and start <= end, but '
                              'start={}, end={} is given'.format(n-1, lo, hi))

--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -386,7 +386,8 @@ def eigh(a, b=None, lower=True, eigvals_only=False, overwrite_a=False,
     -----
     This function does not check the input array for being hermitian/symmetric
     in order to allow for representing arrays with only their upper/lower
-    triangular parts.
+    triangular parts. Also, note that even though not referenced, finiteness
+    check applies to the whole array and unaffected by "lower" keyword.
 
     This function uses LAPACK drivers for computations in all possible keyword
     combinations, prefixed with ``sy`` if arrays are real and ``he`` if

--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -529,7 +529,11 @@ def eigh(a, b=None, lower=True, eigvals_only=False, overwrite_a=False,
     if b is None:  # Standard problem
         drv, drvlw = get_lapack_funcs((pfx + driver, pfx+driver+'_lwork'),
                                       [a1])
-        lw = _compute_lwork(drvlw, n, lower=lower)
+        clw_args = {'n': n, 'lower': lower}
+        if driver == 'evd':
+            clw_args.update({'compute_v': 0 if _job == "N" else 1})
+
+        lw = _compute_lwork(drvlw, **clw_args)
         # Multiple lwork vars
         if isinstance(drvlw, tuple):
             lwork_args = dict(zip(lwork_spec[pfx+driver], lw))

--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -411,6 +411,28 @@ def eigh(a, b=None, lower=True, eigvals_only=False, overwrite_a=False,
     >>> np.allclose(A @ v - v @ np.diag(w), np.zeros((4, 4)))
     True
 
+    Request only the eigenvalues
+
+    >>> w = eigh(A, eigvals_only=True)
+
+    Request eigenvalues that are less than 10.
+
+    >>> A = np.array([[34, -4, -10, -7, 2],
+                      [-4, 7, 2, 12, 0],
+                      [-10, 2, 44, 2, -19],
+                      [-7, 12, 2, 79, -34],
+                      [2, 0, -19, -34, 29]])
+    >>> eigh(A, eigvals_only=True, subset_by_value=[-np.inf, 10])
+    array([6.69199443e-07, 9.11938152e+00])
+
+    Request the largest second eigenvalue and its eigenvector
+
+    >>> w, v = eigh(A, subset_by_index=[1, 1])
+    >>> w
+    array([9.11938152])
+    >>> v.shape  % only a single column is returned
+    (5, 1)
+
     """
     # set lower
     uplo = 'L' if lower else 'U'
@@ -971,6 +993,8 @@ def eigvalsh(a, b=None, lower=True, overwrite_a=False,
 
     Examples
     --------
+    For more examples see `scipy.linalg.eigh`.
+
     >>> from scipy.linalg import eigvalsh
     >>> A = np.array([[6, 3, 1, 5], [3, 0, 5, 1], [1, 5, 6, 2], [5, 1, 2, 2]])
     >>> w = eigvalsh(A)

--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -418,10 +418,10 @@ def eigh(a, b=None, lower=True, eigvals_only=False, overwrite_a=False,
     Request eigenvalues that are less than 10.
 
     >>> A = np.array([[34, -4, -10, -7, 2],
-                      [-4, 7, 2, 12, 0],
-                      [-10, 2, 44, 2, -19],
-                      [-7, 12, 2, 79, -34],
-                      [2, 0, -19, -34, 29]])
+    ...               [-4, 7, 2, 12, 0],
+    ...               [-10, 2, 44, 2, -19],
+    ...               [-7, 12, 2, 79, -34],
+    ...               [2, 0, -19, -34, 29]])
     >>> eigh(A, eigvals_only=True, subset_by_value=[-np.inf, 10])
     array([6.69199443e-07, 9.11938152e+00])
 
@@ -430,7 +430,7 @@ def eigh(a, b=None, lower=True, eigvals_only=False, overwrite_a=False,
     >>> w, v = eigh(A, subset_by_index=[1, 1])
     >>> w
     array([9.11938152])
-    >>> v.shape  % only a single column is returned
+    >>> v.shape  # only a single column is returned
     (5, 1)
 
     """

--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #
 # Author: Pearu Peterson, March 2002
 #

--- a/scipy/linalg/flapack_sym_herm.pyf.src
+++ b/scipy/linalg/flapack_sym_herm.pyf.src
@@ -650,67 +650,151 @@ subroutine <prefix2c>hetrd_lwork(lower,n,a,lda,d,e,tau,work,lwork,info)
 
 end subroutine <prefix2c>hetrd_lwork
 
-subroutine <prefix2>syevr(jobz,range,uplo,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,isuppz,work,lwork,iwork,liwork,info)
-    ! Standard Eigenvalue Problem
-    ! simple/expert driver: all eigenvectors or optionally selected eigenvalues
-    ! algorithm: Relatively Robust Representation
-    ! matrix storage
-    ! Real - Single precision
-    character intent(in) :: jobz='V'
-    character intent(in) :: range='A'
-    character intent(in) :: uplo='L'
-    integer intent(hide) :: n=shape(a,0)
-    <ftype2> intent(in,copy,aligned8),dimension(n,n) :: a
-    integer intent(hide),depend(n,a) :: lda=n
-    <ftype2> intent(hide) :: vl=0
-    <ftype2> intent(hide) :: vu=1
+subroutine <prefix2>syevr(jobz,range,uplo,n,a,lda,vl,vu,il,iu,abstol,w,z,m,ldz,isuppz,work,lwork,iwork,liwork,info)
+    ! Standard Symmetric/HermitianEigenvalue Problem
+    ! Real - Single precision / Double precision
+    !
+    ! if jobz = 'N' there are no eigvecs hence 0x0 'z' returned
+    ! if jobz = 'V' and range = 'A', z is (nxn)
+    ! if jobz = 'V' and range = 'V', z is (nxn) since returned number of eigs is unknown beforehand
+    ! if jobz = 'V' and range = 'I', z is (nx(iu-il+1))
+    fortranname <prefix2>syevr
+    callstatement (*f2py_func)(jobz,range,uplo,&n,a,&lda,&vl,&vu,&il,&iu,&abstol,&m,w,z,&ldz,isuppz,work,&lwork,iwork,&liwork,&info)
+    callprotoargument char*,char*,char*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,int*,int*,int*
+
+    <ftype2> intent(in,copy,aligned8),check(shape(a,0)==shape(a,1)),dimension(n,n) :: a
+    character optional,intent(in),check(*jobz=='N'||*jobz=='V') :: jobz='V'
+    character optional,intent(in),check(*range=='A'||*range=='V' ||*range=='I') :: range='A'
+    character optional,intent(in),check(*uplo=='U'||*uplo=='L') :: uplo='L'
     integer optional,intent(in) :: il=1
     integer optional,intent(in),depend(n) :: iu=n
-    <ftype2> intent(hide) :: abstol=0.
-    integer  intent(hide),depend(iu) :: m=iu-il+1
+    <ftype2> optional,intent(in) :: vl=0.0
+    <ftype2> optional,intent(in),check(vu>vl),depend(vl) :: vu=1.0
+    <ftype2> intent(in) :: abstol=0.0
+    integer optional,intent(in),depend(n),check(lwork>=1||lwork==-1) :: lwork=max(26*n,1)
+    integer optional,intent(in),depend(n),check(liwork>=1||liwork==-1):: liwork= max(1,10*n)
+
+    integer intent(hide),depend(a) :: n=shape(a,0)
+    integer intent(hide),depend(n) :: lda=max(1,n)
+    integer intent(hide),depend(z) :: ldz=max(1,shape(z,0))
+    <ftype2>  intent(hide),dimension(lwork),depend(lwork) :: work
+    integer intent(hide),dimension(liwork),depend(liwork) :: iwork
+
     <ftype2> intent(out),dimension(n),depend(n) :: w
-    <ftype2> intent(out),dimension(n,m),depend(n,m) :: z
-    integer intent(hide),check(shape(z,0)==ldz),depend(n,z) :: ldz=n
-    integer intent(hide),dimension(2*m) :: isuppz
-    integer intent(in),depend(n) :: lwork=max(26*n,1)
-    <ftype2>  intent(hide),dimension(lwork) :: work
-    integer intent(hide),depend(n):: liwork=10*n
-    integer intent(hide),dimension(liwork) :: iwork
-    integer  intent(out) :: info
+    ! FIXME: f2py doesn't support 0-sized arrays for NumPy version <1.14, until then return 1x1.
+    <ftype2> intent(out),dimension((*jobz=='N'?1:MAX(1,n)),(*jobz=='N'?1:(*range=='I'?iu-il+1:MAX(1,n)))),depend(n,jobz,range,iu,il) :: z
+    integer intent(out) :: m
+    ! Only returned if range=='A' or range=='I' and il, iu = 1, n
+    integer intent(out),dimension((*jobz=='N'?1:MAX(2,2*(*range=='A'||(*range=='I' && iu-il+1==n)?n:0)))),depend(n,iu,il,jobz) :: isuppz
+    integer intent(out) :: info
 
 end subroutine <prefix2>syevr
 
-subroutine <prefix2c>heevr(jobz,range,uplo,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,isuppz,work,lwork,rwork,lrwork,iwork,liwork,info)
-    ! Standard Eigenvalue Problem
-    ! simple/expert driver: all eigenvectors or optionally selected eigenvalues
-    ! algorithm: Relatively Robust Representation
-    ! matrix storage
-    ! Complex - Single precision
-    character intent(in) :: jobz='V'
-    character intent(in) :: range='A'
-    character intent(in) :: uplo='L'
-    integer intent(hide) :: n=shape(a,0)
-    <ftype2c> intent(in,copy,aligned8),dimension(n,n) :: a
-    integer intent(hide),depend(n,a) :: lda=n
-    <ftype2> intent(hide) :: vl=0
-    <ftype2> intent(hide) :: vu=1
+subroutine <prefix2>syevr_lwork(uplo,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,isuppz,work,lwork,iwork,liwork,info)
+    ! LWORK routines for (s/d)syevr
+    fortranname <prefix2>syevr
+    callstatement (*f2py_func)("N","A",uplo,&n,&a,&lda,&vl,&vu,&il,&iu,&abstol,&m,w,z,&ldz,isuppz,&work,&lwork,&iwork,&liwork,&info)
+    callprotoargument char*,char*,char*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,int*,int*,int*
+
+    ! Inputs
+    integer intent(in):: n
+    character optional,intent(in),check(*uplo=='U' || *uplo=='L') :: uplo='L'
+    ! Not referenced
+    <ftype2> intent(hide) :: a
+    integer intent(hide),depend(n) :: lda = max(1,n)
+    <ftype2> intent(hide) :: vl=0.
+    <ftype2> intent(hide) :: vu=1.
+    integer intent(hide) :: il=1
+    integer intent(hide) :: iu=2
+    <ftype2> intent(hide) :: abstol=0.
+    integer  intent(hide) :: m=1
+    <ftype2> intent(hide),dimension(1) :: w
+    <ftype2> intent(hide),dimension(1,1) :: z
+    integer intent(hide),depend(n):: ldz = max(1,n)
+    integer intent(hide),dimension(2) :: isuppz
+    integer intent(hide) :: lwork = -1
+    integer intent(hide) :: liwork = -1
+    ! Outputs
+    <ftype2> intent(out) :: work
+    integer intent(out) :: iwork
+    integer intent(out) :: info
+
+end subroutine <prefix2>syevr_lwork
+
+subroutine <prefix2c>heevr(jobz,range,uplo,n,a,lda,vl,vu,il,iu,abstol,w,z,m,ldz,isuppz,work,lwork,rwork,lrwork,iwork,liwork,info)
+    ! Standard Symmetric/HermitianEigenvalue Problem
+    ! Complex - Single precision / Double precision
+    !
+    ! if jobz = 'N' there are no eigvecs hence 0x0 'z' returned
+    ! if jobz = 'V' and range = 'A', z is (nxn)
+    ! if jobz = 'V' and range = 'V', z is (nxn) since returned number of eigs is unknown beforehand
+    ! if jobz = 'V' and range = 'I', z is (nx(iu-il+1))
+    fortranname <prefix2c>heevr
+    callstatement (*f2py_func)(jobz,range,uplo,&n,a,&lda,&vl,&vu,&il,&iu,&abstol,&m,w,z,&ldz,isuppz,work,&lwork,rwork,&lrwork,iwork,&liwork,&info)
+    callprotoargument char*,char*,char*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2c>*,int*,int*,<ctype2c>*,int*,<ctype2>*,int*,int*,int*,int*
+
+    <ftype2c> intent(in,copy,aligned8),check(shape(a,0)==shape(a,1)),dimension(n,n) :: a
+    character optional,intent(in),check(*jobz=='N'||*jobz=='V') :: jobz='V'
+    character optional,intent(in),check(*range=='A'||*range=='V' ||*range=='I') :: range='A'
+    character optional,intent(in),check(*uplo=='U'||*uplo=='L') :: uplo='L'
     integer optional,intent(in) :: il=1
     integer optional,intent(in),depend(n) :: iu=n
-    <ftype2> intent(hide) :: abstol=0.
-    integer  intent(hide),depend(iu) :: m=iu-il+1
-    <ftype2> intent(out),dimension(n),depend(n) :: w
-    <ftype2c> intent(out),dimension(n,m),depend(n,m) :: z
-    integer intent(hide),check(shape(z,0)==ldz),depend(n,z) :: ldz=n
-    integer intent(hide),dimension(2*m) :: isuppz
-    integer intent(in),depend(n) :: lwork=max(18*n,1)
-    <ftype2c>  intent(hide),dimension(lwork) :: work
-    integer intent(hide),depend(n) :: lrwork=24*n
+    <ftype2> optional,intent(in) :: vl=0.0
+    <ftype2> optional,intent(in),check(vu>vl),depend(vl) :: vu=1.0
+    <ftype2> intent(in) :: abstol=0.0
+    integer optional,intent(in),depend(n),check(lwork>=1||lwork==-1) :: lwork=max(2*n,1)
+    integer optional,intent(in),depend(n),check(lwork>=1||lwork==-1) :: lrwork=max(24*n,1)
+    integer optional,intent(in),depend(n),check(liwork>=1||liwork==-1):: liwork= max(1,10*n)
+
+    integer intent(hide),depend(a) :: n=shape(a,0)
+    integer intent(hide),depend(n) :: lda=max(1,n)
+    integer intent(hide),depend(z) :: ldz=max(1,shape(z,0))
+    <ftype2c>  intent(hide),dimension(lwork),depend(lwork) :: work
     <ftype2> intent(hide),dimension(lrwork) :: rwork
-    integer intent(hide),depend(n):: liwork=10*n
-    integer intent(hide),dimension(liwork) :: iwork
-    integer  intent(out) :: info
+    integer intent(hide),dimension(liwork),depend(liwork) :: iwork
+
+    <ftype2> intent(out),dimension(n),depend(n) :: w
+    ! FIXME: f2py doesn't support 0-sized arrays for NumPy version <1.14, until then return 1x1.
+    <ftype2c> intent(out),dimension((*jobz=='N'?1:MAX(1,n)),(*jobz=='N'?1:(*range=='I'?iu-il+1:MAX(1,n)))),depend(n,jobz,range,iu,il) :: z
+    integer intent(out) :: m
+    ! Only returned if range=='A' or range=='I' and il, iu = 1, n
+    integer intent(out),dimension((*jobz=='N'?1:MAX(2,2*(*range=='A'||(*range=='I' && iu-il+1==n)?n:0)))),depend(n,iu,il,jobz) :: isuppz
+    integer intent(out) :: info
 
 end subroutine <prefix2c>heevr
+
+subroutine <prefix2c>heevr_lwork(uplo,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,isuppz,work,lwork,rwork,lrwork,iwork,liwork,info)
+    ! LWORK routines for (c/z)heevr
+    fortranname <prefix2c>heevr
+    callstatement (*f2py_func)("N","A",uplo,&n,&a,&lda,&vl,&vu,&il,&iu,&abstol,&m,w,z,&ldz,isuppz,&work,&lwork,&rwork,&lrwork,&iwork,&liwork,&info)
+    callprotoargument char*,char*,char*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2c>*,int*,int*,<ctype2c>*,int*,<ctype2>*,int*,int*,int*,int*
+
+    ! Inputs
+    integer intent(in):: n
+    character optional,intent(in),check(*uplo=='U' || *uplo=='L') :: uplo='L'
+    ! Not referenced
+    <ftype2c> intent(hide) :: a
+    integer intent(hide),depend(n) :: lda = max(1,n)
+    <ftype2> intent(hide) :: vl=0.
+    <ftype2> intent(hide) :: vu=1.
+    integer intent(hide) :: il=1
+    integer intent(hide) :: iu=2
+    <ftype2> intent(hide) :: abstol=0.
+    integer  intent(hide) :: m=1
+    <ftype2> intent(hide),dimension(1) :: w
+    <ftype2c> intent(hide),dimension(1,1) :: z
+    integer intent(hide),depend(n):: ldz = max(1,n)
+    integer intent(hide),dimension(2) :: isuppz
+    integer intent(hide) :: lwork = -1
+    integer intent(hide) :: lrwork = -1
+    integer intent(hide) :: liwork = -1
+    ! Outputs
+    <ftype2c> intent(out) :: work
+    <ftype2> intent(out) :: rwork
+    integer intent(out) :: iwork
+    integer intent(out) :: info
+
+end subroutine <prefix2c>heevr_work
 
 subroutine <prefix2>sygv(itype,jobz,uplo,n,a,lda,b,ldb,w,work,lwork,info)
     ! Generalized Eigenvalue Problem

--- a/scipy/linalg/flapack_sym_herm.pyf.src
+++ b/scipy/linalg/flapack_sym_herm.pyf.src
@@ -1,7 +1,7 @@
 ! Signatures for f2py-wrappers of FORTRAN LAPACK Symmetric/Hermitian Matrix functions.
 !
 
-subroutine <prefix2>syev(compute_v,lower,n,w,a,work,lwork,info)
+subroutine <prefix2>syev(compute_v,lower,n,w,a,lda,work,lwork,info)
     ! w,v,info = syev(a,compute_v=1,lower=0,lwork=3*n-1,overwrite_a=0)
     ! Compute all eigenvalues and, optionally, eigenvectors of a
     ! real symmetric matrix A.
@@ -9,7 +9,7 @@ subroutine <prefix2>syev(compute_v,lower,n,w,a,work,lwork,info)
     ! Performance tip:
     !   If compute_v=0 then set also overwrite_a=1.
 
-    callstatement (*f2py_func)((compute_v?"V":"N"),(lower?"L":"U"),&n,a,&n,w,work,&lwork,&info)
+    callstatement (*f2py_func)((compute_v?"V":"N"),(lower?"L":"U"),&n,a,&lda,w,work,&lwork,&info)
     callprotoargument char*,char*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*
 
     integer optional,intent(in):: compute_v = 1
@@ -17,6 +17,7 @@ subroutine <prefix2>syev(compute_v,lower,n,w,a,work,lwork,info)
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
 
     integer intent(hide),depend(a):: n = shape(a,0)
+    integer intent(hide),depend(a):: lda = MAX(1,shape(a,0))
     <ftype2> dimension(n,n),check(shape(a,0)==shape(a,1)) :: a
     intent(in,copy,out,out=v) :: a
 
@@ -30,7 +31,28 @@ subroutine <prefix2>syev(compute_v,lower,n,w,a,work,lwork,info)
 
 end subroutine <prefix2>syev
 
-subroutine <prefix2c>heev(compute_v,lower,n,w,a,work,lwork,rwork,info)
+subroutine <prefix2>syev_lwork(lower,n,w,a,lda,work,lwork,info)
+    ! LWORK routines for syev
+
+    fortranname <prefix2>syev
+
+    callstatement (*f2py_func)("N",(lower?"L":"U"),&n,&a,&lda,&w,&work,&lwork,&info)
+    callprotoargument char*,char*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*
+    
+     integer intent(in):: n
+     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
+     
+     integer intent(hide),depend(n):: lda = MAX(1, n)
+     <ftype2> intent(hide):: a
+     <ftype2> intent(hide):: w
+     integer intent(hide):: lwork = -1
+    
+     <ftype2> intent(out):: work
+     integer intent(out):: info
+     
+end subroutine <prefix2>syev_lwork
+
+subroutine <prefix2c>heev(compute_v,lower,n,w,a,lda,work,lwork,rwork,info)
     ! w,v,info = syev(a,compute_v=1,lower=0,lwork=3*n-1,overwrite_a=0)
     ! Compute all eigenvalues and, optionally, eigenvectors of a
     ! complex Hermitian matrix A.
@@ -38,14 +60,14 @@ subroutine <prefix2c>heev(compute_v,lower,n,w,a,work,lwork,rwork,info)
     ! Warning:
     !   If compute_v=0 and overwrite_a=1, the contents of a is destroyed.
 
-    callstatement (*f2py_func)((compute_v?"V":"N"),(lower?"L":"U"),&n,a,&n,w,work,&lwork,rwork,&info)
+    callstatement (*f2py_func)((compute_v?"V":"N"),(lower?"L":"U"),&n,a,&lda,w,work,&lwork,rwork,&info)
     callprotoargument char*,char*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2c>*,int*,<ctype2>*,int*
 
-    integer optional,intent(in):: compute_v = 1
-    check(compute_v==1||compute_v==0) compute_v
+    integer optional,intent(in),check(compute_v==1||compute_v==0) :: compute_v = 1
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
 
     integer intent(hide),depend(a):: n = shape(a,0)
+    integer intent(hide),depend(a):: lda = MAX(1,shape(a,0))
     <ftype2c> dimension(n,n),check(shape(a,0)==shape(a,1)) :: a
     intent(in,copy,out,out=v) :: a
 
@@ -54,14 +76,34 @@ subroutine <prefix2c>heev(compute_v,lower,n,w,a,work,lwork,rwork,info)
     integer optional,intent(in),depend(n) :: lwork=max(2*n-1,1)
     check(lwork>=2*n-1) :: lwork
     <ftype2c> dimension(lwork),intent(hide),depend(lwork) :: work
-
     <ftype2> dimension(3*n-1),intent(hide),depend(n) :: rwork
 
     integer intent(out) :: info
 
 end subroutine <prefix2c>heev
 
-subroutine <prefix2>syevd(compute_v,lower,n,w,a,work,lwork,iwork,liwork,info)
+subroutine <prefix2c>heev_lwork(lower,n,w,a,lda,work,lwork,rwork,info)
+    ! LWORK routines for heev
+
+    fortranname <prefix2c>heev
+    callstatement (*f2py_func)("N",(lower?"L":"U"),&n,&a,&lda,&w,&work,&lwork,&rwork,&info)
+    callprotoargument char*,char*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2c>*,int*,<ctype2>*,int*
+
+     integer intent(in):: n
+     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
+     
+     integer intent(hide),depend(n):: lda = MAX(1, n)
+     <ftype2c> intent(hide):: a
+     <ftype2> intent(hide):: w
+     <ftype2> intent(hide):: rwork
+     integer intent(hide):: lwork = -1
+
+     <ftype2c> intent(out):: work
+     integer intent(out):: info
+     
+end subroutine <prefix2c>heev_lwork
+
+subroutine <prefix2>syevd(compute_v,lower,n,w,a,lda,work,lwork,iwork,liwork,info)
     ! w,v,info = syevd(a,compute_v=1,lower=0,lwork=min_lwork,overwrite_a=0)
     ! Compute all eigenvalues and, optionally, eigenvectors of a
     ! real symmetric matrix A using D&C.
@@ -69,7 +111,7 @@ subroutine <prefix2>syevd(compute_v,lower,n,w,a,work,lwork,iwork,liwork,info)
     ! Performance tip:
     !   If compute_v=0 then set also overwrite_a=1.
 
-    callstatement (*f2py_func)((compute_v?"V":"N"),(lower?"L":"U"),&n,a,&n,w,work,&lwork,iwork,&liwork,&info)
+    callstatement (*f2py_func)((compute_v?"V":"N"),(lower?"L":"U"),&n,a,&lda,w,work,&lwork,iwork,&liwork,&info)
     callprotoargument char*,char*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,int*,int*
 
     integer optional,intent(in):: compute_v = 1
@@ -79,7 +121,7 @@ subroutine <prefix2>syevd(compute_v,lower,n,w,a,work,lwork,iwork,liwork,info)
     integer intent(hide),depend(a):: n = shape(a,0)
     <ftype2> dimension(n,n),check(shape(a,0)==shape(a,1)) :: a
     intent(in,copy,out,out=v) :: a
-
+    integer intent(hide),depend(n) :: lda = MAX(1,n)
     <ftype2> dimension(n),intent(out),depend(n) :: w
 
     integer optional,intent(in),depend(n,compute_v) :: lwork=max((compute_v?1+6*n+2*n*n:2*n+1),1)
@@ -93,7 +135,30 @@ subroutine <prefix2>syevd(compute_v,lower,n,w,a,work,lwork,iwork,liwork,info)
 
 end subroutine <prefix2>syevd
 
-subroutine <prefix2c>heevd(compute_v,lower,n,w,a,work,lwork,iwork,liwork,rwork,lrwork,info)
+subroutine <prefix2>syevd_lwork(lower,n,w,a,lda,work,lwork,iwork,liwork,info)
+    ! LWORK routines for syevd
+
+    fortranname <prefix2>syevd
+
+    callstatement (*f2py_func)("N",(lower?"L":"U"),&n,&a,&lda,&w,&work,&lwork,&iwork,&liwork,&info)
+    callprotoargument char*,char*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,int*,int*
+
+    integer intent(in):: n
+    integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
+    
+    integer intent(hide):: lda = MAX(1,n)
+    <ftype2> intent(hide):: a
+    <ftype2> intent(hide):: w
+    integer intent(hide):: lwork = -1
+    integer intent(hide):: liwork = -1
+    
+    <ftype2> intent(out):: work
+    integer intent(out):: iwork
+    integer intent(out):: info
+
+end subroutine <prefix2>syevd_lwork
+
+subroutine <prefix2c>heevd(compute_v,lower,n,w,a,lda,work,lwork,iwork,liwork,rwork,lrwork,info)
     ! w,v,info = heevd(a,compute_v=1,lower=0,lwork=min_lwork,overwrite_a=0)
     ! Compute all eigenvalues and, optionally, eigenvectors of a
     ! complex Hermitian matrix A using D&C.
@@ -101,7 +166,7 @@ subroutine <prefix2c>heevd(compute_v,lower,n,w,a,work,lwork,iwork,liwork,rwork,l
     ! Warning:
     !   If compute_v=0 and overwrite_a=1, the contents of a is destroyed.
 
-    callstatement (*f2py_func)((compute_v?"V":"N"),(lower?"L":"U"),&n,a,&n,w,work,&lwork,rwork,&lrwork,iwork,&liwork,&info)
+    callstatement (*f2py_func)((compute_v?"V":"N"),(lower?"L":"U"),&n,a,&lda,w,work,&lwork,rwork,&lrwork,iwork,&liwork,&info)
     callprotoargument char*,char*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2c>*,int*,<ctype2>*,int*,int*,int*,int*
 
     integer optional,intent(in):: compute_v = 1
@@ -111,7 +176,7 @@ subroutine <prefix2c>heevd(compute_v,lower,n,w,a,work,lwork,iwork,liwork,rwork,l
     integer intent(hide),depend(a):: n = shape(a,0)
     <ftype2c> dimension(n,n),check(shape(a,0)==shape(a,1)) :: a
     intent(in,copy,out,out=v) :: a
-
+    integer intent(hide),depend(n) :: lda = MAX(1,n)
     <ftype2> dimension(n),intent(out),depend(n) :: w
 
     integer optional,intent(in),depend(n,compute_v) :: lwork=max((compute_v?2*n+n*n:n+1),1)
@@ -126,6 +191,31 @@ subroutine <prefix2c>heevd(compute_v,lower,n,w,a,work,lwork,iwork,liwork,rwork,l
     integer intent(out) :: info
 
 end subroutine <prefix2c>heevd
+
+subroutine <prefix2c>heevd_lwork(lower,n,w,a,lda,work,lwork,iwork,liwork,rwork,lrwork,info)
+    ! LWORK routines for heevd
+    
+    fortranname <prefix2c>heevd
+    
+    callstatement (*f2py_func)("N",(lower?"L":"U"),&n,&a,&lda,&w,&work,&lwork,&rwork,&lrwork,&iwork,&liwork,&info)
+    callprotoargument char*,char*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2c>*,int*,<ctype2>*,int*,int*,int*,int*
+
+    integer intent(in):: n
+    integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
+    
+    integer intent(hide):: lda=MAX(1,n)
+    <ftype2c> intent(hide):: a
+    <ftype2> intent(hide):: w
+    integer intent(hide):: lwork=-1
+    integer intent(hide):: liwork=-1
+    integer intent(hide):: lrwork=-1
+    
+    <ftype2c> intent(out):: work
+    <ftype2> intent(out):: rwork
+    integer intent(out):: iwork
+    integer intent(out):: info
+
+end subroutine <prefix2c>heevd_lwork
 
    subroutine <prefix>sytf2(lower,n,a,lda,ipiv,info)
 
@@ -571,7 +661,7 @@ subroutine <prefix2>sytrd(lower,n,a,lda,d,e,tau,work,lwork,info)
     ! tridiagonal form T by an orthogonal similarity transformation:
     ! Q**T * A * Q = T.
 
-    callstatement (*f2py_func)((lower?"L":"U"),&n,a,&lda,d,e,tau,work,&lwork,&info);
+    callstatement (*f2py_func)((lower?'L':'U'),&n,a,&lda,d,e,tau,work,&lwork,&info);
     callprotoargument char*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,int*,int*
 
     integer intent(hide),depend(a) :: lda=MAX(shape(a,0),1)
@@ -591,7 +681,7 @@ end subroutine <prefix2>sytrd
 subroutine <prefix2>sytrd_lwork(lower,n,a,lda,d,e,tau,work,lwork,info)
     ! lwork computation for sytrd
     fortranname <prefix2>sytrd
-    callstatement (*f2py_func)((lower?"L":"U"),&n,&a,&lda,&d,&e,&tau,&work,&lwork,&info);
+    callstatement (*f2py_func)((lower?'L':'U'),&n,&a,&lda,&d,&e,&tau,&work,&lwork,&info);
     callprotoargument char*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,int*,int*
 
     integer intent(in) :: n
@@ -613,7 +703,7 @@ subroutine <prefix2c>hetrd(lower,n,a,lda,d,e,tau,work,lwork,info)
     ! tridiagonal form T by an orthogonal similarity transformation:
     ! Q**H * A * Q = T.
 
-    callstatement (*f2py_func)((lower?"L":"U"),&n,a,&lda,d,e,tau,work,&lwork,&info);
+    callstatement (*f2py_func)((lower?'L':'U'),&n,a,&lda,d,e,tau,work,&lwork,&info);
     callprotoargument char*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,<ctype2c>*,<ctype2c>*,int*,int*
 
     integer intent(hide),depend(a) :: lda=MAX(shape(a,0),1)
@@ -633,7 +723,7 @@ end subroutine <prefix2c>hetrd
 subroutine <prefix2c>hetrd_lwork(lower,n,a,lda,d,e,tau,work,lwork,info)
     ! lwork computation for hetrd
     fortranname <prefix2c>hetrd
-    callstatement (*f2py_func)((lower?"L":"U"),&n,&a,&lda,&d,&e,&tau,&work,&lwork,&info);
+    callstatement (*f2py_func)((lower?'L':'U'),&n,&a,&lda,&d,&e,&tau,&work,&lwork,&info);
     callprotoargument char*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,<ctype2c>*,<ctype2c>*,int*,int*
 
     integer intent(in) :: n
@@ -650,7 +740,7 @@ subroutine <prefix2c>hetrd_lwork(lower,n,a,lda,d,e,tau,work,lwork,info)
 
 end subroutine <prefix2c>hetrd_lwork
 
-subroutine <prefix2>syevr(jobz,range,uplo,n,a,lda,vl,vu,il,iu,abstol,w,z,m,ldz,isuppz,work,lwork,iwork,liwork,info)
+subroutine <prefix2>syevr(compute_v,range,lower,n,a,lda,vl,vu,il,iu,abstol,w,z,m,ldz,isuppz,work,lwork,iwork,liwork,info)
     ! Standard Symmetric/HermitianEigenvalue Problem
     ! Real - Single precision / Double precision
     !
@@ -658,18 +748,18 @@ subroutine <prefix2>syevr(jobz,range,uplo,n,a,lda,vl,vu,il,iu,abstol,w,z,m,ldz,i
     ! if jobz = 'V' and range = 'A', z is (nxn)
     ! if jobz = 'V' and range = 'V', z is (nxn) since returned number of eigs is unknown beforehand
     ! if jobz = 'V' and range = 'I', z is (nx(iu-il+1))
-    fortranname <prefix2>syevr
-    callstatement (*f2py_func)(jobz,range,uplo,&n,a,&lda,&vl,&vu,&il,&iu,&abstol,&m,w,z,&ldz,isuppz,work,&lwork,iwork,&liwork,&info)
+
+    callstatement (*f2py_func)((compute_v?'V':'N'),range,(lower?'L':'U'),&n,a,&lda,&vl,&vu,&il,&iu,&abstol,&m,w,z,&ldz,isuppz,work,&lwork,iwork,&liwork,&info)
     callprotoargument char*,char*,char*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,int*,int*,int*
 
     <ftype2> intent(in,copy,aligned8),check(shape(a,0)==shape(a,1)),dimension(n,n) :: a
-    character optional,intent(in),check(*jobz=='N'||*jobz=='V') :: jobz='V'
+    integer optional,intent(in),check(compute_v==1||compute_v==0):: compute_v = 1
     character optional,intent(in),check(*range=='A'||*range=='V' ||*range=='I') :: range='A'
-    character optional,intent(in),check(*uplo=='U'||*uplo=='L') :: uplo='L'
-    integer optional,intent(in) :: il=1
-    integer optional,intent(in),depend(n) :: iu=n
+    integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
+    integer optional,intent(in),check(il>=1) :: il=1
+    integer optional,intent(in),check(iu>=il||iu<=n),depend(il,n) :: iu=n
     <ftype2> optional,intent(in) :: vl=0.0
-    <ftype2> optional,intent(in),check(vu>vl),depend(vl) :: vu=1.0
+    <ftype2> optional,intent(in),check(vu>=vl),depend(vl) :: vu=1.0
     <ftype2> intent(in) :: abstol=0.0
     integer optional,intent(in),depend(n),check(lwork>=1||lwork==-1) :: lwork=max(26*n,1)
     integer optional,intent(in),depend(n),check(liwork>=1||liwork==-1):: liwork= max(1,10*n)
@@ -681,24 +771,23 @@ subroutine <prefix2>syevr(jobz,range,uplo,n,a,lda,vl,vu,il,iu,abstol,w,z,m,ldz,i
     integer intent(hide),dimension(liwork),depend(liwork) :: iwork
 
     <ftype2> intent(out),dimension(n),depend(n) :: w
-    ! FIXME: f2py doesn't support 0-sized arrays for NumPy version <1.14, until then return 1x1.
-    <ftype2> intent(out),dimension((*jobz=='N'?1:MAX(1,n)),(*jobz=='N'?1:(*range=='I'?iu-il+1:MAX(1,n)))),depend(n,jobz,range,iu,il) :: z
+    <ftype2> intent(out),dimension((compute_v?MAX(0,n):0),(compute_v?(range[0]=='I'?iu-il+1:MAX(1,n)):0)),depend(n,compute_v,range,iu,il) :: z
     integer intent(out) :: m
     ! Only returned if range=='A' or range=='I' and il, iu = 1, n
-    integer intent(out),dimension((*jobz=='N'?1:MAX(2,2*(*range=='A'||(*range=='I' && iu-il+1==n)?n:0)))),depend(n,iu,il,jobz) :: isuppz
+    integer intent(out),dimension((compute_v?(2*(range[0]=='A'||(range[0]=='I' && iu-il+1==n)?n:0)):0)),depend(n,iu,il,compute_v,range) :: isuppz
     integer intent(out) :: info
 
 end subroutine <prefix2>syevr
 
-subroutine <prefix2>syevr_lwork(uplo,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,isuppz,work,lwork,iwork,liwork,info)
+subroutine <prefix2>syevr_lwork(lower,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,isuppz,work,lwork,iwork,liwork,info)
     ! LWORK routines for (s/d)syevr
     fortranname <prefix2>syevr
-    callstatement (*f2py_func)("N","A",uplo,&n,&a,&lda,&vl,&vu,&il,&iu,&abstol,&m,w,z,&ldz,isuppz,&work,&lwork,&iwork,&liwork,&info)
+    callstatement (*f2py_func)('N','A',(lower?'L':'U'),&n,&a,&lda,&vl,&vu,&il,&iu,&abstol,&m,&w,&z,&ldz,&isuppz,&work,&lwork,&iwork,&liwork,&info)
     callprotoargument char*,char*,char*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,int*,int*,int*
 
     ! Inputs
     integer intent(in):: n
-    character optional,intent(in),check(*uplo=='U' || *uplo=='L') :: uplo='L'
+    integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
     ! Not referenced
     <ftype2> intent(hide) :: a
     integer intent(hide),depend(n) :: lda = max(1,n)
@@ -708,10 +797,10 @@ subroutine <prefix2>syevr_lwork(uplo,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,isuppz
     integer intent(hide) :: iu=2
     <ftype2> intent(hide) :: abstol=0.
     integer  intent(hide) :: m=1
-    <ftype2> intent(hide),dimension(1) :: w
-    <ftype2> intent(hide),dimension(1,1) :: z
+    <ftype2> intent(hide) :: w
+    <ftype2> intent(hide) :: z
     integer intent(hide),depend(n):: ldz = max(1,n)
-    integer intent(hide),dimension(2) :: isuppz
+    integer intent(hide) :: isuppz
     integer intent(hide) :: lwork = -1
     integer intent(hide) :: liwork = -1
     ! Outputs
@@ -721,7 +810,7 @@ subroutine <prefix2>syevr_lwork(uplo,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,isuppz
 
 end subroutine <prefix2>syevr_lwork
 
-subroutine <prefix2c>heevr(jobz,range,uplo,n,a,lda,vl,vu,il,iu,abstol,w,z,m,ldz,isuppz,work,lwork,rwork,lrwork,iwork,liwork,info)
+subroutine <prefix2c>heevr(compute_v,range,lower,n,a,lda,vl,vu,il,iu,abstol,w,z,m,ldz,isuppz,work,lwork,rwork,lrwork,iwork,liwork,info)
     ! Standard Symmetric/HermitianEigenvalue Problem
     ! Complex - Single precision / Double precision
     !
@@ -729,14 +818,14 @@ subroutine <prefix2c>heevr(jobz,range,uplo,n,a,lda,vl,vu,il,iu,abstol,w,z,m,ldz,
     ! if jobz = 'V' and range = 'A', z is (nxn)
     ! if jobz = 'V' and range = 'V', z is (nxn) since returned number of eigs is unknown beforehand
     ! if jobz = 'V' and range = 'I', z is (nx(iu-il+1))
-    fortranname <prefix2c>heevr
-    callstatement (*f2py_func)(jobz,range,uplo,&n,a,&lda,&vl,&vu,&il,&iu,&abstol,&m,w,z,&ldz,isuppz,work,&lwork,rwork,&lrwork,iwork,&liwork,&info)
+
+    callstatement (*f2py_func)((compute_v?'V':'N'),range,(lower?'L':'U'),&n,a,&lda,&vl,&vu,&il,&iu,&abstol,&m,w,z,&ldz,isuppz,work,&lwork,rwork,&lrwork,iwork,&liwork,&info)
     callprotoargument char*,char*,char*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2c>*,int*,int*,<ctype2c>*,int*,<ctype2>*,int*,int*,int*,int*
 
     <ftype2c> intent(in,copy,aligned8),check(shape(a,0)==shape(a,1)),dimension(n,n) :: a
-    character optional,intent(in),check(*jobz=='N'||*jobz=='V') :: jobz='V'
+    integer optional,intent(in),check(compute_v==1||compute_v==0):: compute_v = 1
     character optional,intent(in),check(*range=='A'||*range=='V' ||*range=='I') :: range='A'
-    character optional,intent(in),check(*uplo=='U'||*uplo=='L') :: uplo='L'
+    integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
     integer optional,intent(in) :: il=1
     integer optional,intent(in),depend(n) :: iu=n
     <ftype2> optional,intent(in) :: vl=0.0
@@ -754,24 +843,23 @@ subroutine <prefix2c>heevr(jobz,range,uplo,n,a,lda,vl,vu,il,iu,abstol,w,z,m,ldz,
     integer intent(hide),dimension(liwork),depend(liwork) :: iwork
 
     <ftype2> intent(out),dimension(n),depend(n) :: w
-    ! FIXME: f2py doesn't support 0-sized arrays for NumPy version <1.14, until then return 1x1.
-    <ftype2c> intent(out),dimension((*jobz=='N'?1:MAX(1,n)),(*jobz=='N'?1:(*range=='I'?iu-il+1:MAX(1,n)))),depend(n,jobz,range,iu,il) :: z
+    <ftype2c> intent(out),dimension((compute_v?MAX(0,n):0),(compute_v?(range[0]=='I'?iu-il+1:MAX(1,n)):0)),depend(n,compute_v,range,iu,il) :: z
     integer intent(out) :: m
     ! Only returned if range=='A' or range=='I' and il, iu = 1, n
-    integer intent(out),dimension((*jobz=='N'?1:MAX(2,2*(*range=='A'||(*range=='I' && iu-il+1==n)?n:0)))),depend(n,iu,il,jobz) :: isuppz
+    integer intent(out),dimension((compute_v?(2*(range[0]=='A'||(range[0]=='I' && iu-il+1==n)?n:0)):0)),depend(n,iu,il,range,compute_v) :: isuppz
     integer intent(out) :: info
 
 end subroutine <prefix2c>heevr
 
-subroutine <prefix2c>heevr_lwork(uplo,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,isuppz,work,lwork,rwork,lrwork,iwork,liwork,info)
+subroutine <prefix2c>heevr_lwork(n,lower,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,isuppz,work,lwork,rwork,lrwork,iwork,liwork,info)
     ! LWORK routines for (c/z)heevr
     fortranname <prefix2c>heevr
-    callstatement (*f2py_func)("N","A",uplo,&n,&a,&lda,&vl,&vu,&il,&iu,&abstol,&m,w,z,&ldz,isuppz,&work,&lwork,&rwork,&lrwork,&iwork,&liwork,&info)
+    callstatement (*f2py_func)('N','A',(lower?'L':'U'),&n,&a,&lda,&vl,&vu,&il,&iu,&abstol,&m,&w,&z,&ldz,&isuppz,&work,&lwork,&rwork,&lrwork,&iwork,&liwork,&info)
     callprotoargument char*,char*,char*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2c>*,int*,int*,<ctype2c>*,int*,<ctype2>*,int*,int*,int*,int*
 
     ! Inputs
     integer intent(in):: n
-    character optional,intent(in),check(*uplo=='U' || *uplo=='L') :: uplo='L'
+    integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
     ! Not referenced
     <ftype2c> intent(hide) :: a
     integer intent(hide),depend(n) :: lda = max(1,n)
@@ -781,10 +869,10 @@ subroutine <prefix2c>heevr_lwork(uplo,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,isupp
     integer intent(hide) :: iu=2
     <ftype2> intent(hide) :: abstol=0.
     integer  intent(hide) :: m=1
-    <ftype2> intent(hide),dimension(1) :: w
-    <ftype2c> intent(hide),dimension(1,1) :: z
+    <ftype2> intent(hide) :: w
+    <ftype2c> intent(hide) :: z
     integer intent(hide),depend(n):: ldz = max(1,n)
-    integer intent(hide),dimension(2) :: isuppz
+    integer intent(hide) :: isuppz
     integer intent(hide) :: lwork = -1
     integer intent(hide) :: lrwork = -1
     integer intent(hide) :: liwork = -1
@@ -796,96 +884,294 @@ subroutine <prefix2c>heevr_lwork(uplo,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,isupp
 
 end subroutine <prefix2c>heevr_work
 
-subroutine <prefix2>sygv(itype,jobz,uplo,n,a,lda,b,ldb,w,work,lwork,info)
-    ! Generalized Eigenvalue Problem
-    ! simple driver (all eigenvectors)
-    ! algorithm: standard
-    ! matrix storage
-    ! Real - Single precision
-    integer optional,intent(in) :: itype=1
-    character intent(in) :: jobz='V'
-    character intent(in) :: uplo='L'
-    integer intent(hide) :: n=shape(a,0)
-    <ftype2> intent(in,copy,out,aligned8),dimension(n,n) :: a
-    integer intent(hide),depend(n,a) :: lda=n
-    <ftype2> intent(in,copy,aligned8),dimension(n,n) :: b
-    integer intent(hide),depend(n,b) :: ldb=n
+subroutine <prefix2>syevx(compute_v,range,lower,n,a,lda,vl,vu,il,iu,abstol,w,z,m,ldz,work,lwork,iwork,ifail,info)
+    ! DSYEVX computes selected eigenvalues and, optionally, eigenvectors
+    ! of a real symmetric matrix A.  Eigenvalues and eigenvectors can be
+    ! selected by specifying either a range of values or a range of indices
+    ! for the desired eigenvalues.
+
+    callstatement (*f2py_func)((compute_v?'V':'N'),range,(lower?'L':'U'),&n,a,&lda,&vl,&vu,&il,&iu,&abstol,&m,w,z,&ldz,work,&lwork,iwork,ifail,&info)
+    callprotoargument char*,char*,char*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,int*,int*,int*
+    
+    integer optional,intent(in),check(compute_v==1||compute_v==0):: compute_v = 1
+    character optional,intent(in),check(*range=='A'||*range=='V' ||*range=='I') :: range='A'
+    integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
+    integer intent(hide),depend(a) :: n=shape(a,0)
+    integer optional,intent(in) :: il=1
+    integer optional,intent(in),depend(n) :: iu=n
+    <ftype2> optional,intent(in) :: vl=0.0
+    <ftype2> optional,intent(in),check(vu>vl),depend(vl) :: vu=1.0
+    <ftype2> intent(in) :: abstol=0.0
+    integer optional,intent(in),depend(n),check(lwork>=1||lwork==-1) :: lwork=max(8*n,1)
+
+    <ftype2> intent(in,copy),check(shape(a,0)==shape(a,1)),dimension(n,n) :: a
+    integer intent(hide),depend(n) :: lda=max(1,n)
+    integer intent(hide),depend(z) :: ldz=max(1,shape(z,0))
+    <ftype2>  intent(hide),dimension(lwork),depend(lwork) :: work
+    integer intent(hide),dimension(5*n),depend(n) :: iwork
+
     <ftype2> intent(out),dimension(n),depend(n) :: w
-    integer intent(hide) :: lwork=max(3*n-1,1)
-    <ftype2> intent(hide),dimension(lwork) :: work
+    <ftype2> intent(out),dimension((compute_v?MAX(0,n):0),(compute_v?(range[0]=='I'?iu-il+1:MAX(1,n)):0)),depend(n,compute_v,range,iu,il) :: z
+    integer intent(out) :: m
+    integer intent(out),dimension((compute_v?n:0)),depend(compute_v,n):: ifail
+    integer intent(out) :: info
+    
+end subroutine <prefix2>syevx
+
+subroutine <prefix2>syevx_lwork(lower,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,work,lwork,iwork,ifail,info)
+    ! LWORK routines for (d/s)syevx
+
+    fortranname <prefix2>syevx
+    callstatement (*f2py_func)("N","A",(lower?'L':'U'),&n,&a,&lda,&vl,&vu,&il,&iu,&abstol,&m,&w,&z,&ldz,&work,&lwork,&iwork,&ifail,&info)
+    callprotoargument char*,char*,char*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,int*,int*,int*
+    
+    integer intent(in):: n
+    integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
+
+    <ftype2> intent(hide):: a
+    integer intent(hide),depend(n):: lda = MAX(1,n)
+    integer intent(hide):: il = 1
+    integer intent(hide):: iu = 0
+    <ftype2> intent(hide):: vl = 0.0
+    <ftype2> intent(hide):: vu = 1.0
+    <ftype2> intent(hide):: abstol = 0.0
+    integer intent(hide):: m
+    <ftype2> intent(hide):: w
+    <ftype2> intent(hide):: z
+    integer intent(hide),depend(n):: ldz = MAX(1,n)
+    integer intent(hide):: lwork = -1
+    integer intent(hide):: iwork
+    integer intent(hide):: ifail
+        
+    <ftype2> intent(out):: work
+    integer intent(out):: info
+
+end subroutine <prefix2>syevx_lwork
+
+subroutine <prefix2c>heevx(compute_v,range,lower,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,work,lwork,rwork,iwork,ifail,info)
+    ! (C/Z)HEEVX computes selected eigenvalues and, optionally, eigenvectors
+    ! of a complex Hermitian matrix A.  Eigenvalues and eigenvectors can
+    ! be selected by specifying either a range of values or a range of
+    ! indices for the desired eigenvalues.
+
+    callstatement (*f2py_func)((compute_v?'V':'N'),range,(lower?'L':'U'),&n,a,&lda,&vl,&vu,&il,&iu,&abstol,&m,w,z,&ldz,work,&lwork,&rwork,iwork,ifail,&info)
+    callprotoargument char*,char*,char*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,int*,int*,int*
+    
+    integer optional,intent(in),check(compute_v==1||compute_v==0):: compute_v = 1
+    character optional,intent(in),check(*range=='A'||*range=='V' ||*range=='I') :: range='A'
+    integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
+    integer intent(hide),depend(a) :: n=shape(a,0)
+    integer optional,intent(in) :: il=1
+    integer optional,intent(in),depend(n) :: iu=n
+    <ftype2> optional,intent(in) :: vl=0.0
+    <ftype2> optional,intent(in),check(vu>vl),depend(vl) :: vu=1.0
+    <ftype2> intent(in) :: abstol=0.0
+    integer optional,intent(in),depend(n),check(lwork>=1||lwork==-1) :: lwork=max(2*n,1)
+
+    <ftype2c> intent(in,copy),check(shape(a,0)==shape(a,1)),dimension(n,n) :: a
+    integer intent(hide),depend(n) :: lda=max(1,n)
+    integer intent(hide),depend(z) :: ldz=max(1,shape(z,0))
+    <ftype2c>  intent(hide),dimension(lwork),depend(lwork) :: work
+    integer intent(hide),dimension(5*n),depend(n) :: iwork
+    <ftype2> intent(hide),dimenion(7*n),depend(n) :: rwork
+
+    <ftype2> intent(out),dimension(n),depend(n) :: w
+    <ftype2c> intent(out),dimension((compute_v?MAX(0,n):0),(compute_v?(range[0]=='I'?iu-il+1:MAX(1,n)):0)),depend(n,compute_v,range,iu,il) :: z
+    integer intent(out) :: m
+    integer intent(out),dimension((compute_v?n:0)),depend(compute_v,n):: ifail
+    integer intent(out) :: info
+    
+end subroutine <prefix2c>heevx
+
+subroutine <prefix2c>heevx_lwork(lower,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,work,lwork,rwork,iwork,ifail,info)
+    ! LWORK routines for (c/z)heevx
+
+    fortranname <prefix2c>heevx
+    callstatement (*f2py_func)('N','A',(lower?'L':'U'),&n,&a,&lda,&vl,&vu,&il,&iu,&abstol,&m,&w,&z,&ldz,&work,&lwork,&rwork,&iwork,&ifail,&info)
+    callprotoargument char*,char*,char*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,int*,int*,int*
+    
+    integer intent(in):: n
+    integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
+
+    <ftype2c> intent(hide):: a
+    integer intent(hide),depend(n):: lda = MAX(1,n)
+    integer intent(hide):: il = 1
+    integer intent(hide):: iu = 0
+    <ftype2> intent(hide):: vl = 0.0
+    <ftype2> intent(hide):: vu = 1.0
+    <ftype2> intent(hide):: abstol = 0.0
+    integer intent(hide):: m
+    <ftype2> intent(hide):: w
+    <ftype2c> intent(hide):: z
+    integer intent(hide),depend(n):: ldz = MAX(1,n)
+    integer intent(hide):: lwork = -1
+    <ftype2> intent(hide):: rwork
+    integer intent(hide):: iwork
+    integer intent(hide):: ifail
+        
+    <ftype2c> intent(out):: work
+    integer intent(out):: info
+
+end subroutine <prefix2c>heevx_lwork
+
+subroutine <prefix2>sygv(itype,jobz,uplo,n,a,lda,b,ldb,w,work,lwork,info)
+    ! Generalized Symmetric Eigenvalue Problem
+    ! Real - Single precision / Double precision
+    !
+    ! if jobz = 'N' there are no eigvecs returned
+    ! if jobz = 'V' 'a' contains eigvecs
+
+    callstatement (*f2py_func)(&itype,jobz,uplo,&n,a,&lda,b,&ldb,w,work,&lwork,&info)
+    callprotoargument int*,char*,char*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*
+    !                itype,jobz ,uplo , n  ,    a    ,lda ,    b    , ldb,   w     , work   ,lwork, info
+
+    <ftype2> intent(in,copy,aligned8,out,out=v),check(shape(a,0)==shape(a,1)),dimension(n,n) :: a
+    <ftype2> intent(in,copy,aligned8),check(shape(b,0)==shape(b,1)),check(shape(b,0)==n),dimension(n,n),depend(n) :: b
+    integer optional,intent(in),check(itype > 0 || itype < 4) :: itype = 1
+    character optional,intent(in),check(*jobz=='N'||*jobz=='V') :: jobz='V'
+    character optional,intent(in),check(*uplo=='U'||*uplo=='L') :: uplo='L'
+    integer optional,intent(in),depend(n),check(lwork>0||lwork==-1) :: lwork=max(3*n-1,1)
+
+    integer intent(hide),depend(a) :: n=shape(a,0)
+    integer intent(hide),depend(n) :: lda=max(1,n)
+    integer intent(hide),depend(b) :: ldb=max(1,shape(b,0))
+    <ftype2>  intent(hide),dimension(lwork),depend(lwork) :: work
+
+    <ftype2> intent(out),dimension(n),depend(n) :: w
     integer intent(out) :: info
 
 end subroutine <prefix2>sygv
 
+subroutine <prefix2>sygv_lwork(itype,jobz,uplo,n,a,lda,b,ldb,w,work,lwork,info)
+    ! LWORK routine for (S,D)SYGV
+
+    fortranname <prefix2>sygv
+    callstatement (*f2py_func)(&itype,'N',uplo,&n,&a,&lda,&b,&ldb,&w,&work,&lwork,&info)
+    callprotoargument int*,char*,char*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*
+
+    ! Inputs
+    integer intent(in):: n
+    character optional,intent(in),check(*uplo=='U' || *uplo=='L') :: uplo='L'
+    ! Not referenced
+    integer intent(hide) :: itype=1
+    <ftype2> intent(hide) :: a
+    <ftype2> intent(hide) :: b
+    integer intent(hide) :: lda=max(1,n)
+    integer intent(hide) :: ldb=max(1,n)
+    integer intent(hide) :: lwork=-1
+    <ftype2> intent(hide) :: w
+    ! Outputs
+    <ftype2> intent(out) :: work
+    integer intent(out) :: info
+
+end subroutine <prefix2>sygv_lwork
+
 subroutine <prefix2c>hegv(itype,jobz,uplo,n,a,lda,b,ldb,w,work,lwork,rwork,info)
-    ! Generalized Eigenvalue Problem
-    ! simple driver (all eigenvectors)
-    ! algorithm: standard
-    ! matrix storage
-    ! Complex - Single precision
-    integer optional,intent(in) :: itype=1
-    character intent(in) :: jobz='V'
-    character intent(in) :: uplo='L'
-    integer intent(hide) :: n=shape(a,0)
-    <ftype2c> intent(in,copy,out,aligned8),dimension(n,n) :: a
-    integer intent(hide),depend(n,a) :: lda=n
-    <ftype2c> intent(in,copy,aligned8),dimension(n,n) :: b
-    integer intent(hide),depend(n,b) :: ldb=n
+    ! Generalized Symmetric Eigenvalue Problem
+    ! Complex - Single precision / Double precision
+    !
+    ! if jobz = 'N' there are no eigvecs returned
+    ! if jobz = 'V' 'a' contains eigvecs
+
+    callstatement (*f2py_func)(&itype,jobz,uplo,&n,a,&lda,b,&ldb,w,work,&lwork,rwork,&info)
+    callprotoargument int*,char*,char*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2c>*,int*,<ctype2>*,int*
+
+    <ftype2c> intent(in,copy,aligned8,out,out=v),check(shape(a,0)==shape(a,1)),dimension(n,n) :: a
+    <ftype2c> intent(in,copy,aligned8),check(shape(b,0)==shape(b,1)),check(shape(b,0)==n),dimension(n,n),depend(n) :: b
+    integer optional,intent(in),check(itype > 0 || itype < 4) :: itype = 1
+    character optional,intent(in),check(*jobz=='N'||*jobz=='V') :: jobz='V'
+    character optional,intent(in),check(*uplo=='U'||*uplo=='L') :: uplo='L'
+    integer optional,intent(in),depend(n),check(lwork>0||lwork==-1) :: lwork=max(2*n-1,1)
+
+    integer intent(hide),depend(a) :: n=shape(a,0)
+    integer intent(hide),depend(n) :: lda=max(1,n)
+    integer intent(hide),depend(b) :: ldb=max(1,shape(b,0))
+    <ftype2c> intent(hide),dimension(lwork),depend(lwork) :: work
+    <ftype2> intent(hide),dimension(MAX(1,3*n-2)),depend(n) :: rwork
+
     <ftype2> intent(out),dimension(n),depend(n) :: w
-    integer intent(hide) :: lwork=max(18*n-1,1)
-    <ftype2c> intent(hide),dimension(lwork) :: work
-    <ftype2> intent(hide),dimension(3*n-2) :: rwork
     integer intent(out) :: info
 
 end subroutine <prefix2c>hegv
+
+subroutine <prefix2c>hegv_lwork(itype,uplo,n,a,lda,b,ldb,w,work,lwork,rwork,info)
+    ! LWORK Query routine for (c/z)hegv
+
+    fortranname <prefix2c>hegv
+    callstatement (*f2py_func)(&itype,'N',uplo,&n,&a,&lda,&b,&ldb,&w,&work,&lwork,&rwork,&info)
+    callprotoargument int*,char*,char*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2c>*,int*,<ctype2>*,int*
+
+    ! Inputs
+    integer intent(in):: n
+    character optional,intent(in),check(*uplo=='U' || *uplo=='L') :: uplo='L'
+    ! Not referenced
+    integer intent(hide) :: itype=1
+    <ftype2c> intent(hide) :: a
+    <ftype2c> intent(hide) :: b
+    integer intent(hide) :: lda=1
+    integer intent(hide) :: ldb=1
+    integer intent(hide) :: lwork=-1
+    <ftype2> intent(hide) :: w
+    <ftype2> intent(hide) :: rwork
+    ! Outputs
+    <ftype2c> intent(out) :: work
+    integer intent(out) :: info
+
+end subroutine <prefix2c>hegv_lwork
 
 !
 ! Divide and conquer routines for generalized eigenvalue problem
 !
 subroutine <prefix2>sygvd(itype,jobz,uplo,n,a,lda,b,ldb,w,work,lwork,iwork,liwork,info)
-    ! Generalized Eigenvalue Problem
-    ! simple driver (all eigenvectors)
-    ! algorithm: divide and conquer
-    ! matrix storage
-    ! Real - Single precision
-    integer optional,intent(in) :: itype=1
-    character intent(in) :: jobz='V'
-    character intent(in) :: uplo='L'
-    integer intent(hide) :: n=shape(a,0)
-    <ftype2> intent(in,copy,out,aligned8),dimension(n,n) :: a
-    integer intent(hide),depend(n,a) :: lda=n
-    <ftype2> intent(in,copy,aligned8),dimension(n,n) :: b
-    integer intent(hide),depend(n,b) :: ldb=n
+
+    ! No call to ILAENV is performed. Hence no need for (d/s)sygvd_lwork. Default sizes are optimal.
+
+    callstatement (*f2py_func)(&itype,jobz,uplo,&n,a,&lda,b,&ldb,w,work,&lwork,iwork,&liwork,&info)
+    callprotoargument int*,char*,char*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,int*,int*
+
+    <ftype2> intent(in,copy,aligned8,out,out=v),check(shape(a,0)==shape(a,1)),dimension(n,n) :: a
+    <ftype2> intent(in,copy,aligned8),check(shape(b,0)==shape(b,1)),check(shape(b,0)==n),dimension(n,n),depend(n) :: b
+    integer optional,intent(in),check(itype > 0 || itype < 4) :: itype = 1
+    character optional,intent(in),check(*jobz=='N'||*jobz=='V') :: jobz='V'
+    character optional,intent(in),check(*uplo=='U'||*uplo=='L') :: uplo='L'
+    integer optional,intent(in),depend(n),check(lwork>0||lwork==-1) :: lwork=(*jobz=='N'?2*n+1:1+6*n+2*n*n)
+    integer optional,intent(in),depend(n),check(liwork>0||liwork==-1) :: liwork=(*jobz=='N'?1:5*n+3)
+
+    integer intent(hide),depend(a) :: n=shape(a,0)
+    integer intent(hide),depend(n) :: lda=max(1,n)
+    integer intent(hide),depend(b) :: ldb=max(1,shape(b,0))
+    <ftype2> intent(hide),dimension(lwork),depend(lwork) :: work
+    integer intent(hide),dimension(liwork),depend(liwork) :: iwork
+
     <ftype2> intent(out),dimension(n),depend(n) :: w
-    integer intent(in),depend(n) :: lwork=max(1+6*n+2*n*n,1)
-    <ftype2> intent(hide),dimension(lwork) :: work
-    integer intent(hide),depend(n) :: liwork=3+5*n
-    integer intent(hide),dimension(liwork) :: iwork
     integer intent(out) :: info
 
 end subroutine <prefix2>sygvd
 
 subroutine <prefix2c>hegvd(itype,jobz,uplo,n,a,lda,b,ldb,w,work,lwork,rwork,lrwork,iwork,liwork,info)
-    ! Generalized Eigenvalue Problem
-    ! simple driver (all eigenvectors)
-    ! algorithm: divide and conquer
-    ! matrix storage
-    ! Complex - Single precision
-    integer optional,intent(in) :: itype=1
-    character intent(in) :: jobz='V'
-    character intent(in) :: uplo='L'
-    integer intent(hide) :: n=shape(a,0)
-    <ftype2c> intent(in,copy,out,aligned8),dimension(n,n) :: a
-    integer intent(hide),depend(n,a) :: lda=n
-    <ftype2c> intent(in,copy,aligned8),dimension(n,n) :: b
-    integer intent(hide),depend(n,b) :: ldb=n
+
+    ! No call to ILAENV is performed. Hence no need for (c/z)hegvd_lwork. Default sizes are optimal.
+
+    callstatement (*f2py_func)(&itype,jobz,uplo,&n,a,&lda,b,&ldb,w,work,&lwork,rwork,&lrwork,iwork,&liwork,&info)
+    callprotoargument int*,char*,char*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2c>*,int*,<ctype2>*,int*,int*,int*,int*
+
+    <ftype2c> intent(in,copy,aligned8,out,out=v),check(shape(a,0)==shape(a,1)),dimension(n,n) :: a
+    <ftype2c> intent(in,copy,aligned8),check(shape(b,0)==shape(b,1)),check(shape(b,0)==n),dimension(n,n),depend(n) :: b
+    integer optional,intent(in),check(itype > 0 || itype < 4) :: itype = 1
+    character optional,intent(in),check(*jobz=='N'||*jobz=='V') :: jobz='V'
+    character optional,intent(in),check(*uplo=='U'||*uplo=='L') :: uplo='L'
+    integer optional,intent(in),depend(n),check(lwork>0||lwork==-1) :: lwork=(*jobz=='N'?n+1:n*(n+2))
+    integer optional,intent(in),depend(n),check(lrwork>0||lrwork==-1) :: lrwork=max((*jobz=='N'?n:2*n*n+5*n+1),1)
+    integer optional,intent(in),depend(n),check(liwork>0||liwork==-1) :: liwork=(*jobz=='N'?1:5*n+3)
+
+    integer intent(hide),depend(a) :: n=shape(a,0)
+    integer intent(hide),depend(n) :: lda=max(1,n)
+    integer intent(hide),depend(b) :: ldb=max(1,shape(b,0))
+    <ftype2c> intent(hide),dimension(lwork),depend(lwork) :: work
+    <ftype2> intent(hide),dimension(lrwork),depend(lrwork) :: rwork
+    integer intent(hide),dimension(liwork),depend(liwork) :: iwork
+
     <ftype2> intent(out),dimension(n),depend(n) :: w
-    integer intent(in),depend(n) :: lwork=max(2*n+n*n,1)
-    <ftype2c> intent(hide),dimension(lwork) :: work
-    integer intent(hide),depend(n) :: lrwork=1+5*n+2*n*n
-    <ftype2> intent(hide),dimension(lrwork) :: rwork
-    integer intent(hide),depend(n) :: liwork=3+5*n
-    integer intent(hide),dimension(liwork) :: iwork
     integer intent(out) :: info
 
 end subroutine <prefix2c>hegvd
@@ -894,68 +1180,147 @@ end subroutine <prefix2c>hegvd
 ! Expert routines for generalized eigenvalue problem
 !
 subroutine <prefix2>sygvx(itype,jobz,range,uplo,n,a,lda,b,ldb,vl,vu,il,iu,abstol,m,w,z,ldz,work,lwork,iwork,ifail,info)
-    ! Generalized Eigenvalue Problem
-    ! expert driver (selected eigenvectors)
-    ! algorithm: standard
-    ! matrix storage
-    ! Real - Single precision
-    integer optional,intent(in) :: itype=1
-    character intent(in) :: jobz='V'
-    character intent(hide) :: range='I'
-    character intent(in) :: uplo='L'
-    integer intent(hide) :: n=shape(a,0)
-    <ftype2> intent(in,copy,aligned8),dimension(n,n) :: a
-    integer intent(hide),depend(n,a) :: lda=n
-    <ftype2> intent(in,copy,aligned8),dimension(n,n) :: b
-    integer intent(hide),depend(n,b) :: ldb=n
-    <ftype2> intent(hide) :: vl=0.
-    <ftype2> intent(hide) :: vu=0.
+    ! (S/D)SYGVX computes selected eigenvalues, and optionally, eigenvectors
+    ! of a real generalized symmetric-definite eigenproblem, of the form
+    ! A*x=(lambda)*B*x,  A*Bx=(lambda)*x,  or B*A*x=(lambda)*x.  Here A
+    ! and B are assumed to be symmetric and B is also positive definite.
+    ! Eigenvalues and eigenvectors can be selected by specifying either a
+    ! range of values or a range of indices for the desired eigenvalues.
+
+    callstatement (*f2py_func)(&itype,jobz,range,uplo,&n,a,&lda,b,&ldb,&vl,&vu,&il,&iu,&abstol,&m,w,z,&ldz,work,&lwork,iwork,ifail,&info)
+    callprotoargument int*,char*,char*,char*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,int*,int*,int*
+    
+    integer optional,intent(in),check(itype>0||itype<4) :: itype=1
+    character optional,intent(in),check(*jobz=='N'||*jobz=='V') :: jobz='V'
+    character optional,intent(in),check(*uplo=='U'||*uplo=='L') :: uplo='L'
+    character optional,intent(in),check(*range=='A'||*range=='V' ||*range=='I') :: range='A'
+    integer intent(hide),depend(a) :: n=shape(a,0)
     integer optional,intent(in) :: il=1
-    integer intent(in) :: iu
-    <ftype2> intent(hide) :: abstol=0.
-    integer intent(hide),depend(iu) :: m=iu-il+1
+    integer optional,intent(in),depend(n) :: iu=n
+    <ftype2> optional,intent(in) :: vl=0.0
+    <ftype2> optional,intent(in),check(vu>vl),depend(vl) :: vu=1.0
+    <ftype2> intent(in) :: abstol=0.0
+    integer optional,intent(in),depend(n),check(lwork>=1||lwork==-1) :: lwork=max(8*n,1)
+
+    <ftype2> intent(in,copy),check(shape(a,0)==shape(a,1)),dimension(n,n) :: a
+    <ftype2> intent(in,copy,aligned8),check(shape(b,0)==shape(b,1)),check(shape(b,0)==n),dimension(n,n),depend(n) :: b
+    integer intent(hide),depend(n) :: lda=max(1,n)
+    integer intent(hide),depend(n) :: ldb=max(1,n)
+    integer intent(hide),depend(z) :: ldz=max(1,shape(z,0))
+    <ftype2>  intent(hide),dimension(lwork),depend(lwork) :: work
+    integer intent(hide),dimension(5*n),depend(n) :: iwork
+
     <ftype2> intent(out),dimension(n),depend(n) :: w
-    <ftype2> intent(out),dimension(n,m),depend(n,m) :: z
-    integer intent(hide),check(shape(z,0)==ldz),depend(n,z) :: ldz=n
-    integer intent(in),depend(n) :: lwork=max(8*n,1)
-    <ftype2> intent(hide),dimension(lwork),depend(n,lwork) :: work
-    integer intent(hide),dimension(5*n) :: iwork
-    integer intent(out),dimension(n),depend(n) :: ifail
+    <ftype2> intent(out),dimension((jobz[0]=='V'?MAX(0,n):0),(jobz[0]=='V'?(range[0]=='I'?iu-il+1:MAX(1,n)):0)),depend(n,jobz,range,iu,il) :: z
+    integer intent(out) :: m
+    integer intent(out),dimension((jobz[0]=='N'?n:0)),depend(jobz,n):: ifail
     integer intent(out) :: info
 
 end subroutine <prefix2>sygvx
 
+subroutine <prefix2>sygvx_lwork(itype,uplo,n,a,lda,b,ldb,vl,vu,il,iu,abstol,m,w,z,ldz,work,lwork,iwork,ifail,info)
+    ! LWORK Query routine for (s/d)sygvx
+    fortranname <prefix2>sygvx
+    callstatement (*f2py_func)(&itype,'N','A',uplo,&n,&a,&lda,&b,&ldb,&vl,&vu,&il,&iu,&abstol,&m,&w,&z,&ldz,&work,&lwork,&iwork,&ifail,&info)
+    callprotoargument int*,char*,char*,char*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,int*,int*,int*
+
+    integer intent(in):: n
+    character optional,intent(in),check(*uplo=='U'||*uplo=='L') :: uplo='L'
+
+    integer intent(hide):: itype = 1
+    <ftype2> intent(hide):: a
+    integer intent(hide),depend(n):: lda = MAX(1,n)
+    <ftype2> intent(hide):: b
+    integer intent(hide):: ldb = MAX(1,n)
+    integer intent(hide):: il = 1
+    integer intent(hide):: iu = 0
+    <ftype2> intent(hide):: vl = 0.0
+    <ftype2> intent(hide):: vu = 1.0
+    <ftype2> intent(hide):: abstol = 0.0
+    integer intent(hide):: m
+    <ftype2> intent(hide):: w
+    <ftype2> intent(hide):: z
+    integer intent(hide),depend(n):: ldz = MAX(1,n)
+    integer intent(hide):: lwork = -1
+    integer intent(hide):: iwork
+    integer intent(hide):: ifail
+
+    <ftype2> intent(out):: work
+    integer intent(out):: info
+
+end subroutine <prefix2>sygvx_lwork
+
 subroutine <prefix2c>hegvx(itype,jobz,range,uplo,n,a,lda,b,ldb,vl,vu,il,iu,abstol,m,w,z,ldz,work,lwork,rwork,iwork,ifail,info)
-    ! Generalized Eigenvalue Problem
-    ! expert driver (selected eigenvectors)
-    ! algorithm: standard
-    ! matrix storage
-    ! Complex - Single precision
-    integer optional,intent(in) :: itype=1
-    character intent(in) :: jobz='V'
-    character intent(hide) :: range='I'
-    character intent(in) :: uplo='L'
-    integer intent(hide) :: n=shape(a,0)
-    <ftype2c> intent(in,copy,aligned8),dimension(n,n) :: a
-    integer intent(hide),depend(n,a) :: lda=n
-    <ftype2c> intent(in,copy,aligned8),dimension(n,n) :: b
-    integer intent(hide),depend(n,b) :: ldb=n
-    <ftype2> intent(hide) :: vl=0.
-    <ftype2> intent(hide) :: vu=0.
+    ! (C/Z)HEGVX computes selected eigenvalues, and optionally, eigenvectors
+    ! of a complex generalized Hermitian-definite eigenproblem, of the form
+    ! A*x=(lambda)*B*x,  A*Bx=(lambda)*x,  or B*A*x=(lambda)*x.  Here A and
+    ! B are assumed to be Hermitian and B is also positive definite.
+    ! Eigenvalues and eigenvectors can be selected by specifying either a
+    ! range of values or a range of indices for the desired eigenvalues.
+    callstatement (*f2py_func)(&itype,jobz,range,uplo,&n,a,&lda,b,&ldb,&vl,&vu,&il,&iu,&abstol,&m,w,z,&ldz,work,&lwork,rwork,iwork,ifail,&info)
+    callprotoargument int*,char*,char*,char*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,int*,int*,int*
+    
+    integer optional,intent(in),check(itype>0||itype<4) :: itype=1
+    character optional,intent(in),check(*jobz=='N'||*jobz=='V') :: jobz='V'
+    character optional,intent(in),check(*uplo=='U'||*uplo=='L') :: uplo='L'
+    character optional,intent(in),check(*range=='A'||*range=='V' ||*range=='I') :: range='A'
+    integer intent(hide),depend(a) :: n=shape(a,0)
     integer optional,intent(in) :: il=1
-    integer intent(in) :: iu
-    <ftype2> intent(hide) :: abstol=0.
-    integer intent(hide),depend(iu) :: m=iu-il+1
+    integer optional,intent(in),depend(n) :: iu=n
+    <ftype2> optional,intent(in) :: vl=0.0
+    <ftype2> optional,intent(in),check(vu>vl),depend(vl) :: vu=1.0
+    <ftype2> intent(in) :: abstol=0.0
+    integer optional,intent(in),depend(n),check(lwork>=1||lwork==-1) :: lwork=max(2*n,1)
+
+    <ftype2> intent(in,copy),check(shape(a,0)==shape(a,1)),dimension(n,n) :: a
+    <ftype2> intent(in,copy,aligned8),check(shape(b,0)==shape(b,1)),check(shape(b,0)==n),dimension(n,n),depend(n) :: b
+    integer intent(hide),depend(n) :: lda=max(1,n)
+    integer intent(hide),depend(n) :: ldb=max(1,n)
+    integer intent(hide),depend(z) :: ldz=max(1,shape(z,0))
+    <ftype2>  intent(hide),dimension(lwork),depend(lwork) :: work
+    integer intent(hide),dimension(5*n),depend(n) :: iwork
+    <ftype2> intent(hide),dimension(7*n),depend(n) :: rwork
+
     <ftype2> intent(out),dimension(n),depend(n) :: w
-    <ftype2c> intent(out),dimension(n,m),depend(n,m) :: z
-    integer intent(hide),check(shape(z,0)==ldz),depend(n,z) :: ldz=n
-    integer intent(in),depend(n) :: lwork=max(18*n-1,1)
-    <ftype2c> intent(hide),dimension(lwork),depend(n,lwork) :: work
-    <ftype2> intent(hide),dimension(7*n) :: rwork
-    integer intent(hide),dimension(5*n) :: iwork
-    integer intent(out),dimension(n),depend(n) :: ifail
+    <ftype2> intent(out),dimension((jobz[0]=='V'?MAX(0,n):0),(jobz[0]=='V'?(range[0]=='I'?iu-il+1:MAX(1,n)):0)),depend(n,jobz,range,iu,il) :: z
+    integer intent(out) :: m
+    integer intent(out),dimension((jobz[0]=='N'?n:0)),depend(jobz,n):: ifail
     integer intent(out) :: info
+
 end subroutine <prefix2c>hegvx
+
+subroutine <prefix2c>hegvx_lwork(itype,uplo,n,a,lda,b,ldb,vl,vu,il,iu,abstol,m,w,z,ldz,work,lwork,rwork,iwork,ifail,info)
+    ! LWORK Query routine for (c/z)hegvx
+    fortranname <prefix2c>hegvx
+    callstatement (*f2py_func)(&itype,"N","A",uplo,&n,&a,&lda,&b,&ldb,&vl,&vu,&il,&iu,&abstol,&m,&w,&z,&ldz,&work,&lwork,&rwork,&iwork,&ifail,&info)
+    callprotoargument int*,char*,char*,char*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,int*,int*,int*
+
+    integer intent(in):: n
+    character optional,intent(in),check(*uplo=='U'||*uplo=='L') :: uplo='L'
+
+    integer intent(hide):: itype = 1
+    <ftype2> intent(hide):: a
+    integer intent(hide),depend(n):: lda = MAX(1,n)
+    <ftype2> intent(hide):: b
+    integer intent(hide):: ldb = MAX(1,n)
+    integer intent(hide):: il = 1
+    integer intent(hide):: iu = 0
+    <ftype2> intent(hide):: vl = 0.0
+    <ftype2> intent(hide):: vu = 1.0
+    <ftype2> intent(hide):: abstol = 0.0
+    integer intent(hide):: m
+    <ftype2> intent(hide):: w
+    <ftype2> intent(hide):: z
+    integer intent(hide),depend(n):: ldz = MAX(1,n)
+    integer intent(hide):: lwork = -1
+    <ftype2> intent(hide):: rwork
+    integer intent(hide):: iwork
+    integer intent(hide):: ifail
+
+    <ftype2> intent(out):: work
+    integer intent(out):: info
+
+end subroutine <prefix2c>hegvx_lwork
 
 subroutine <prefix>syequb(lower,n,a,lda,s,scond,amax,work,info)
 

--- a/scipy/linalg/flapack_sym_herm.pyf.src
+++ b/scipy/linalg/flapack_sym_herm.pyf.src
@@ -114,8 +114,7 @@ subroutine <prefix2>syevd(compute_v,lower,n,w,a,lda,work,lwork,iwork,liwork,info
     callstatement (*f2py_func)((compute_v?"V":"N"),(lower?"L":"U"),&n,a,&lda,w,work,&lwork,iwork,&liwork,&info)
     callprotoargument char*,char*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,int*,int*
 
-    integer optional,intent(in):: compute_v = 1
-    check(compute_v==1||compute_v==0) compute_v
+    integer optional,intent(in),check(compute_v==1||compute_v==0) :: compute_v = 1
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
 
     integer intent(hide),depend(a):: n = shape(a,0)
@@ -135,16 +134,17 @@ subroutine <prefix2>syevd(compute_v,lower,n,w,a,lda,work,lwork,iwork,liwork,info
 
 end subroutine <prefix2>syevd
 
-subroutine <prefix2>syevd_lwork(lower,n,w,a,lda,work,lwork,iwork,liwork,info)
+subroutine <prefix2>syevd_lwork(compute_v,lower,n,w,a,lda,work,lwork,iwork,liwork,info)
     ! LWORK routines for syevd
 
     fortranname <prefix2>syevd
 
-    callstatement (*f2py_func)("N",(lower?"L":"U"),&n,&a,&lda,&w,&work,&lwork,&iwork,&liwork,&info)
+    callstatement (*f2py_func)((compute_v?"V":"N"),(lower?"L":"U"),&n,&a,&lda,&w,&work,&lwork,&iwork,&liwork,&info)
     callprotoargument char*,char*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,int*,int*
 
     integer intent(in):: n
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
+    integer optional,intent(in),check(compute_v==0||compute_v==1) :: compute_v = 1
     
     integer intent(hide):: lda = MAX(1,n)
     <ftype2> intent(hide):: a
@@ -192,16 +192,17 @@ subroutine <prefix2c>heevd(compute_v,lower,n,w,a,lda,work,lwork,iwork,liwork,rwo
 
 end subroutine <prefix2c>heevd
 
-subroutine <prefix2c>heevd_lwork(lower,n,w,a,lda,work,lwork,iwork,liwork,rwork,lrwork,info)
+subroutine <prefix2c>heevd_lwork(compute_v,lower,n,w,a,lda,work,lwork,iwork,liwork,rwork,lrwork,info)
     ! LWORK routines for heevd
     
     fortranname <prefix2c>heevd
     
-    callstatement (*f2py_func)("N",(lower?"L":"U"),&n,&a,&lda,&w,&work,&lwork,&rwork,&lrwork,&iwork,&liwork,&info)
+    callstatement (*f2py_func)((compute_v?"V":"N"),(lower?"L":"U"),&n,&a,&lda,&w,&work,&lwork,&rwork,&lrwork,&iwork,&liwork,&info)
     callprotoargument char*,char*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2c>*,int*,<ctype2>*,int*,int*,int*,int*
 
     integer intent(in):: n
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
+    integer optional,intent(in),check(compute_v==0||compute_v==1) :: compute_v = 1
     
     integer intent(hide):: lda=MAX(1,n)
     <ftype2c> intent(hide):: a

--- a/scipy/linalg/flapack_sym_herm.pyf.src
+++ b/scipy/linalg/flapack_sym_herm.pyf.src
@@ -661,7 +661,7 @@ subroutine <prefix2>sytrd(lower,n,a,lda,d,e,tau,work,lwork,info)
     ! tridiagonal form T by an orthogonal similarity transformation:
     ! Q**T * A * Q = T.
 
-    callstatement (*f2py_func)((lower?'L':'U'),&n,a,&lda,d,e,tau,work,&lwork,&info);
+    callstatement (*f2py_func)((lower?"L":"U"),&n,a,&lda,d,e,tau,work,&lwork,&info);
     callprotoargument char*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,int*,int*
 
     integer intent(hide),depend(a) :: lda=MAX(shape(a,0),1)
@@ -681,7 +681,7 @@ end subroutine <prefix2>sytrd
 subroutine <prefix2>sytrd_lwork(lower,n,a,lda,d,e,tau,work,lwork,info)
     ! lwork computation for sytrd
     fortranname <prefix2>sytrd
-    callstatement (*f2py_func)((lower?'L':'U'),&n,&a,&lda,&d,&e,&tau,&work,&lwork,&info);
+    callstatement (*f2py_func)((lower?"L":"U"),&n,&a,&lda,&d,&e,&tau,&work,&lwork,&info);
     callprotoargument char*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,int*,int*
 
     integer intent(in) :: n
@@ -703,7 +703,7 @@ subroutine <prefix2c>hetrd(lower,n,a,lda,d,e,tau,work,lwork,info)
     ! tridiagonal form T by an orthogonal similarity transformation:
     ! Q**H * A * Q = T.
 
-    callstatement (*f2py_func)((lower?'L':'U'),&n,a,&lda,d,e,tau,work,&lwork,&info);
+    callstatement (*f2py_func)((lower?"L":"U"),&n,a,&lda,d,e,tau,work,&lwork,&info);
     callprotoargument char*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,<ctype2c>*,<ctype2c>*,int*,int*
 
     integer intent(hide),depend(a) :: lda=MAX(shape(a,0),1)
@@ -723,7 +723,7 @@ end subroutine <prefix2c>hetrd
 subroutine <prefix2c>hetrd_lwork(lower,n,a,lda,d,e,tau,work,lwork,info)
     ! lwork computation for hetrd
     fortranname <prefix2c>hetrd
-    callstatement (*f2py_func)((lower?'L':'U'),&n,&a,&lda,&d,&e,&tau,&work,&lwork,&info);
+    callstatement (*f2py_func)((lower?"L":"U"),&n,&a,&lda,&d,&e,&tau,&work,&lwork,&info);
     callprotoargument char*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,<ctype2c>*,<ctype2c>*,int*,int*
 
     integer intent(in) :: n
@@ -749,7 +749,7 @@ subroutine <prefix2>syevr(compute_v,range,lower,n,a,lda,vl,vu,il,iu,abstol,w,z,m
     ! if jobz = 'V' and range = 'V', z is (nxn) since returned number of eigs is unknown beforehand
     ! if jobz = 'V' and range = 'I', z is (nx(iu-il+1))
 
-    callstatement (*f2py_func)((compute_v?'V':'N'),range,(lower?'L':'U'),&n,a,&lda,&vl,&vu,&il,&iu,&abstol,&m,w,z,&ldz,isuppz,work,&lwork,iwork,&liwork,&info)
+    callstatement (*f2py_func)((compute_v?"V":"N"),range,(lower?"L":"U"),&n,a,&lda,&vl,&vu,&il,&iu,&abstol,&m,w,z,&ldz,isuppz,work,&lwork,iwork,&liwork,&info)
     callprotoargument char*,char*,char*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,int*,int*,int*
 
     <ftype2> intent(in,copy,aligned8),check(shape(a,0)==shape(a,1)),dimension(n,n) :: a
@@ -771,10 +771,10 @@ subroutine <prefix2>syevr(compute_v,range,lower,n,a,lda,vl,vu,il,iu,abstol,w,z,m
     integer intent(hide),dimension(liwork),depend(liwork) :: iwork
 
     <ftype2> intent(out),dimension(n),depend(n) :: w
-    <ftype2> intent(out),dimension((compute_v?MAX(0,n):0),(compute_v?(range[0]=='I'?iu-il+1:MAX(1,n)):0)),depend(n,compute_v,range,iu,il) :: z
+    <ftype2> intent(out),dimension((compute_v?MAX(0,n):0),(compute_v?(*range=='I'?iu-il+1:MAX(1,n)):0)),depend(n,compute_v,range,iu,il) :: z
     integer intent(out) :: m
     ! Only returned if range=='A' or range=='I' and il, iu = 1, n
-    integer intent(out),dimension((compute_v?(2*(range[0]=='A'||(range[0]=='I' && iu-il+1==n)?n:0)):0)),depend(n,iu,il,compute_v,range) :: isuppz
+    integer intent(out),dimension((compute_v?(2*(*range=='A'||(*range=='I' && iu-il+1==n)?n:0)):0)),depend(n,iu,il,compute_v,range) :: isuppz
     integer intent(out) :: info
 
 end subroutine <prefix2>syevr
@@ -782,7 +782,7 @@ end subroutine <prefix2>syevr
 subroutine <prefix2>syevr_lwork(lower,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,isuppz,work,lwork,iwork,liwork,info)
     ! LWORK routines for (s/d)syevr
     fortranname <prefix2>syevr
-    callstatement (*f2py_func)('N','A',(lower?'L':'U'),&n,&a,&lda,&vl,&vu,&il,&iu,&abstol,&m,&w,&z,&ldz,&isuppz,&work,&lwork,&iwork,&liwork,&info)
+    callstatement (*f2py_func)("N","A",(lower?"L":"U"),&n,&a,&lda,&vl,&vu,&il,&iu,&abstol,&m,&w,&z,&ldz,&isuppz,&work,&lwork,&iwork,&liwork,&info)
     callprotoargument char*,char*,char*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,int*,int*,int*
 
     ! Inputs
@@ -819,7 +819,7 @@ subroutine <prefix2c>heevr(compute_v,range,lower,n,a,lda,vl,vu,il,iu,abstol,w,z,
     ! if jobz = 'V' and range = 'V', z is (nxn) since returned number of eigs is unknown beforehand
     ! if jobz = 'V' and range = 'I', z is (nx(iu-il+1))
 
-    callstatement (*f2py_func)((compute_v?'V':'N'),range,(lower?'L':'U'),&n,a,&lda,&vl,&vu,&il,&iu,&abstol,&m,w,z,&ldz,isuppz,work,&lwork,rwork,&lrwork,iwork,&liwork,&info)
+    callstatement (*f2py_func)((compute_v?"V":"N"),range,(lower?"L":"U"),&n,a,&lda,&vl,&vu,&il,&iu,&abstol,&m,w,z,&ldz,isuppz,work,&lwork,rwork,&lrwork,iwork,&liwork,&info)
     callprotoargument char*,char*,char*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2c>*,int*,int*,<ctype2c>*,int*,<ctype2>*,int*,int*,int*,int*
 
     <ftype2c> intent(in,copy,aligned8),check(shape(a,0)==shape(a,1)),dimension(n,n) :: a
@@ -843,10 +843,10 @@ subroutine <prefix2c>heevr(compute_v,range,lower,n,a,lda,vl,vu,il,iu,abstol,w,z,
     integer intent(hide),dimension(liwork),depend(liwork) :: iwork
 
     <ftype2> intent(out),dimension(n),depend(n) :: w
-    <ftype2c> intent(out),dimension((compute_v?MAX(0,n):0),(compute_v?(range[0]=='I'?iu-il+1:MAX(1,n)):0)),depend(n,compute_v,range,iu,il) :: z
+    <ftype2c> intent(out),dimension((compute_v?MAX(0,n):0),(compute_v?(*range=='I'?iu-il+1:MAX(1,n)):0)),depend(n,compute_v,range,iu,il) :: z
     integer intent(out) :: m
     ! Only returned if range=='A' or range=='I' and il, iu = 1, n
-    integer intent(out),dimension((compute_v?(2*(range[0]=='A'||(range[0]=='I' && iu-il+1==n)?n:0)):0)),depend(n,iu,il,range,compute_v) :: isuppz
+    integer intent(out),dimension((compute_v?(2*(*range=='A'||(*range=='I' && iu-il+1==n)?n:0)):0)),depend(n,iu,il,range,compute_v) :: isuppz
     integer intent(out) :: info
 
 end subroutine <prefix2c>heevr
@@ -854,7 +854,7 @@ end subroutine <prefix2c>heevr
 subroutine <prefix2c>heevr_lwork(n,lower,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,isuppz,work,lwork,rwork,lrwork,iwork,liwork,info)
     ! LWORK routines for (c/z)heevr
     fortranname <prefix2c>heevr
-    callstatement (*f2py_func)('N','A',(lower?'L':'U'),&n,&a,&lda,&vl,&vu,&il,&iu,&abstol,&m,&w,&z,&ldz,&isuppz,&work,&lwork,&rwork,&lrwork,&iwork,&liwork,&info)
+    callstatement (*f2py_func)("N","A",(lower?"L":"U"),&n,&a,&lda,&vl,&vu,&il,&iu,&abstol,&m,&w,&z,&ldz,&isuppz,&work,&lwork,&rwork,&lrwork,&iwork,&liwork,&info)
     callprotoargument char*,char*,char*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2c>*,int*,int*,<ctype2c>*,int*,<ctype2>*,int*,int*,int*,int*
 
     ! Inputs
@@ -890,7 +890,7 @@ subroutine <prefix2>syevx(compute_v,range,lower,n,a,lda,vl,vu,il,iu,abstol,w,z,m
     ! selected by specifying either a range of values or a range of indices
     ! for the desired eigenvalues.
 
-    callstatement (*f2py_func)((compute_v?'V':'N'),range,(lower?'L':'U'),&n,a,&lda,&vl,&vu,&il,&iu,&abstol,&m,w,z,&ldz,work,&lwork,iwork,ifail,&info)
+    callstatement (*f2py_func)((compute_v?"V":"N"),range,(lower?"L":"U"),&n,a,&lda,&vl,&vu,&il,&iu,&abstol,&m,w,z,&ldz,work,&lwork,iwork,ifail,&info)
     callprotoargument char*,char*,char*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,int*,int*,int*
     
     integer optional,intent(in),check(compute_v==1||compute_v==0):: compute_v = 1
@@ -911,7 +911,7 @@ subroutine <prefix2>syevx(compute_v,range,lower,n,a,lda,vl,vu,il,iu,abstol,w,z,m
     integer intent(hide),dimension(5*n),depend(n) :: iwork
 
     <ftype2> intent(out),dimension(n),depend(n) :: w
-    <ftype2> intent(out),dimension((compute_v?MAX(0,n):0),(compute_v?(range[0]=='I'?iu-il+1:MAX(1,n)):0)),depend(n,compute_v,range,iu,il) :: z
+    <ftype2> intent(out),dimension((compute_v?MAX(0,n):0),(compute_v?(*range=='I'?iu-il+1:MAX(1,n)):0)),depend(n,compute_v,range,iu,il) :: z
     integer intent(out) :: m
     integer intent(out),dimension((compute_v?n:0)),depend(compute_v,n):: ifail
     integer intent(out) :: info
@@ -922,7 +922,7 @@ subroutine <prefix2>syevx_lwork(lower,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,work,
     ! LWORK routines for (d/s)syevx
 
     fortranname <prefix2>syevx
-    callstatement (*f2py_func)("N","A",(lower?'L':'U'),&n,&a,&lda,&vl,&vu,&il,&iu,&abstol,&m,&w,&z,&ldz,&work,&lwork,&iwork,&ifail,&info)
+    callstatement (*f2py_func)("N","A",(lower?"L":"U"),&n,&a,&lda,&vl,&vu,&il,&iu,&abstol,&m,&w,&z,&ldz,&work,&lwork,&iwork,&ifail,&info)
     callprotoargument char*,char*,char*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,int*,int*,int*
     
     integer intent(in):: n
@@ -954,7 +954,7 @@ subroutine <prefix2c>heevx(compute_v,range,lower,n,a,lda,vl,vu,il,iu,abstol,m,w,
     ! be selected by specifying either a range of values or a range of
     ! indices for the desired eigenvalues.
 
-    callstatement (*f2py_func)((compute_v?'V':'N'),range,(lower?'L':'U'),&n,a,&lda,&vl,&vu,&il,&iu,&abstol,&m,w,z,&ldz,work,&lwork,&rwork,iwork,ifail,&info)
+    callstatement (*f2py_func)((compute_v?"V":"N"),range,(lower?"L":"U"),&n,a,&lda,&vl,&vu,&il,&iu,&abstol,&m,w,z,&ldz,work,&lwork,&rwork,iwork,ifail,&info)
     callprotoargument char*,char*,char*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,int*,int*,int*
     
     integer optional,intent(in),check(compute_v==1||compute_v==0):: compute_v = 1
@@ -976,7 +976,7 @@ subroutine <prefix2c>heevx(compute_v,range,lower,n,a,lda,vl,vu,il,iu,abstol,m,w,
     <ftype2> intent(hide),dimenion(7*n),depend(n) :: rwork
 
     <ftype2> intent(out),dimension(n),depend(n) :: w
-    <ftype2c> intent(out),dimension((compute_v?MAX(0,n):0),(compute_v?(range[0]=='I'?iu-il+1:MAX(1,n)):0)),depend(n,compute_v,range,iu,il) :: z
+    <ftype2c> intent(out),dimension((compute_v?MAX(0,n):0),(compute_v?(*range=='I'?iu-il+1:MAX(1,n)):0)),depend(n,compute_v,range,iu,il) :: z
     integer intent(out) :: m
     integer intent(out),dimension((compute_v?n:0)),depend(compute_v,n):: ifail
     integer intent(out) :: info
@@ -987,7 +987,7 @@ subroutine <prefix2c>heevx_lwork(lower,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,work
     ! LWORK routines for (c/z)heevx
 
     fortranname <prefix2c>heevx
-    callstatement (*f2py_func)('N','A',(lower?'L':'U'),&n,&a,&lda,&vl,&vu,&il,&iu,&abstol,&m,&w,&z,&ldz,&work,&lwork,&rwork,&iwork,&ifail,&info)
+    callstatement (*f2py_func)("N","A",(lower?"L":"U"),&n,&a,&lda,&vl,&vu,&il,&iu,&abstol,&m,&w,&z,&ldz,&work,&lwork,&rwork,&iwork,&ifail,&info)
     callprotoargument char*,char*,char*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,int*,int*,int*
     
     integer intent(in):: n
@@ -1046,7 +1046,7 @@ subroutine <prefix2>sygv_lwork(itype,jobz,uplo,n,a,lda,b,ldb,w,work,lwork,info)
     ! LWORK routine for (S,D)SYGV
 
     fortranname <prefix2>sygv
-    callstatement (*f2py_func)(&itype,'N',uplo,&n,&a,&lda,&b,&ldb,&w,&work,&lwork,&info)
+    callstatement (*f2py_func)(&itype,jobz,uplo,&n,&a,&lda,&b,&ldb,&w,&work,&lwork,&info)
     callprotoargument int*,char*,char*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*
 
     ! Inputs
@@ -1054,6 +1054,7 @@ subroutine <prefix2>sygv_lwork(itype,jobz,uplo,n,a,lda,b,ldb,w,work,lwork,info)
     character optional,intent(in),check(*uplo=='U' || *uplo=='L') :: uplo='L'
     ! Not referenced
     integer intent(hide) :: itype=1
+    character intent(hide) :: jobz="N"
     <ftype2> intent(hide) :: a
     <ftype2> intent(hide) :: b
     integer intent(hide) :: lda=max(1,n)
@@ -1075,6 +1076,7 @@ subroutine <prefix2c>hegv(itype,jobz,uplo,n,a,lda,b,ldb,w,work,lwork,rwork,info)
 
     callstatement (*f2py_func)(&itype,jobz,uplo,&n,a,&lda,b,&ldb,w,work,&lwork,rwork,&info)
     callprotoargument int*,char*,char*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2c>*,int*,<ctype2>*,int*
+    !                itype,jobz ,uplo , n  ,    a     ,lda ,    b     , ldb,   w     , work     ,lwork,rwork   ,info
 
     <ftype2c> intent(in,copy,aligned8,out,out=v),check(shape(a,0)==shape(a,1)),dimension(n,n) :: a
     <ftype2c> intent(in,copy,aligned8),check(shape(b,0)==shape(b,1)),check(shape(b,0)==n),dimension(n,n),depend(n) :: b
@@ -1094,11 +1096,11 @@ subroutine <prefix2c>hegv(itype,jobz,uplo,n,a,lda,b,ldb,w,work,lwork,rwork,info)
 
 end subroutine <prefix2c>hegv
 
-subroutine <prefix2c>hegv_lwork(itype,uplo,n,a,lda,b,ldb,w,work,lwork,rwork,info)
+subroutine <prefix2c>hegv_lwork(itype,jobz,uplo,n,a,lda,b,ldb,w,work,lwork,rwork,info)
     ! LWORK Query routine for (c/z)hegv
 
     fortranname <prefix2c>hegv
-    callstatement (*f2py_func)(&itype,'N',uplo,&n,&a,&lda,&b,&ldb,&w,&work,&lwork,&rwork,&info)
+    callstatement (*f2py_func)(&itype,jobz,uplo,&n,&a,&lda,&b,&ldb,&w,&work,&lwork,&rwork,&info)
     callprotoargument int*,char*,char*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2c>*,int*,<ctype2>*,int*
 
     ! Inputs
@@ -1106,10 +1108,11 @@ subroutine <prefix2c>hegv_lwork(itype,uplo,n,a,lda,b,ldb,w,work,lwork,rwork,info
     character optional,intent(in),check(*uplo=='U' || *uplo=='L') :: uplo='L'
     ! Not referenced
     integer intent(hide) :: itype=1
+    character intent(hide) :: jobz="N"
     <ftype2c> intent(hide) :: a
     <ftype2c> intent(hide) :: b
-    integer intent(hide) :: lda=1
-    integer intent(hide) :: ldb=1
+    integer intent(hide),depend(n) :: lda=MAX(1,n)
+    integer intent(hide),depend(n) :: ldb=MAX(1,n)
     integer intent(hide) :: lwork=-1
     <ftype2> intent(hide) :: w
     <ftype2> intent(hide) :: rwork
@@ -1221,7 +1224,7 @@ end subroutine <prefix2>sygvx
 subroutine <prefix2>sygvx_lwork(itype,uplo,n,a,lda,b,ldb,vl,vu,il,iu,abstol,m,w,z,ldz,work,lwork,iwork,ifail,info)
     ! LWORK Query routine for (s/d)sygvx
     fortranname <prefix2>sygvx
-    callstatement (*f2py_func)(&itype,'N','A',uplo,&n,&a,&lda,&b,&ldb,&vl,&vu,&il,&iu,&abstol,&m,&w,&z,&ldz,&work,&lwork,&iwork,&ifail,&info)
+    callstatement (*f2py_func)(&itype,"N","A",uplo,&n,&a,&lda,&b,&ldb,&vl,&vu,&il,&iu,&abstol,&m,&w,&z,&ldz,&work,&lwork,&iwork,&ifail,&info)
     callprotoargument int*,char*,char*,char*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,int*,int*,int*
 
     integer intent(in):: n

--- a/scipy/linalg/flapack_sym_herm.pyf.src
+++ b/scipy/linalg/flapack_sym_herm.pyf.src
@@ -1014,7 +1014,7 @@ subroutine <prefix2c>heevx_lwork(lower,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,work
 
 end subroutine <prefix2c>heevx_lwork
 
-subroutine <prefix2>sygv(itype,jobz,uplo,n,a,lda,b,ldb,w,work,lwork,info)
+subroutine <prefix2>sygv(itype,jobz,uplo,n,lda,ldb,w,a,b,work,lwork,info)
     ! Generalized Symmetric Eigenvalue Problem
     ! Real - Single precision / Double precision
     !
@@ -1067,7 +1067,7 @@ subroutine <prefix2>sygv_lwork(itype,jobz,uplo,n,a,lda,b,ldb,w,work,lwork,info)
 
 end subroutine <prefix2>sygv_lwork
 
-subroutine <prefix2c>hegv(itype,jobz,uplo,n,a,lda,b,ldb,w,work,lwork,rwork,info)
+subroutine <prefix2c>hegv(itype,jobz,uplo,n,lda,ldb,w,a,b,work,lwork,rwork,info)
     ! Generalized Symmetric Eigenvalue Problem
     ! Complex - Single precision / Double precision
     !
@@ -1125,7 +1125,7 @@ end subroutine <prefix2c>hegv_lwork
 !
 ! Divide and conquer routines for generalized eigenvalue problem
 !
-subroutine <prefix2>sygvd(itype,jobz,uplo,n,a,lda,b,ldb,w,work,lwork,iwork,liwork,info)
+subroutine <prefix2>sygvd(itype,jobz,uplo,n,lda,ldb,w,a,b,work,lwork,iwork,liwork,info)
 
     ! No call to ILAENV is performed. Hence no need for (d/s)sygvd_lwork. Default sizes are optimal.
 
@@ -1151,7 +1151,7 @@ subroutine <prefix2>sygvd(itype,jobz,uplo,n,a,lda,b,ldb,w,work,lwork,iwork,liwor
 
 end subroutine <prefix2>sygvd
 
-subroutine <prefix2c>hegvd(itype,jobz,uplo,n,a,lda,b,ldb,w,work,lwork,rwork,lrwork,iwork,liwork,info)
+subroutine <prefix2c>hegvd(itype,jobz,uplo,n,lda,ldb,w,a,b,work,lwork,rwork,lrwork,iwork,liwork,info)
 
     ! No call to ILAENV is performed. Hence no need for (c/z)hegvd_lwork. Default sizes are optimal.
 
@@ -1182,7 +1182,7 @@ end subroutine <prefix2c>hegvd
 !
 ! Expert routines for generalized eigenvalue problem
 !
-subroutine <prefix2>sygvx(itype,jobz,range,uplo,n,a,lda,b,ldb,vl,vu,il,iu,abstol,m,w,z,ldz,work,lwork,iwork,ifail,info)
+subroutine <prefix2>sygvx(itype,jobz,range,uplo,n,a,lda,b,ldb,vl,vu,il,iu,abstol,w,z,m,ldz,work,lwork,iwork,ifail,info)
     ! (S/D)SYGVX computes selected eigenvalues, and optionally, eigenvectors
     ! of a real generalized symmetric-definite eigenproblem, of the form
     ! A*x=(lambda)*B*x,  A*Bx=(lambda)*x,  or B*A*x=(lambda)*x.  Here A
@@ -1194,9 +1194,9 @@ subroutine <prefix2>sygvx(itype,jobz,range,uplo,n,a,lda,b,ldb,vl,vu,il,iu,abstol
     callprotoargument int*,char*,char*,char*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,int*,int*,int*
     
     integer optional,intent(in),check(itype>0||itype<4) :: itype=1
-    character optional,intent(in),check(*jobz=='N'||*jobz=='V') :: jobz='V'
-    character optional,intent(in),check(*uplo=='U'||*uplo=='L') :: uplo='L'
-    character optional,intent(in),check(*range=='A'||*range=='V' ||*range=='I') :: range='A'
+    character optional,intent(in),check(*jobz=='N'||*jobz=='V') :: jobz="V"
+    character optional,intent(in),check(*uplo=='U'||*uplo=='L') :: uplo="L"
+    character optional,intent(in),check(*range=='A'||*range=='V' ||*range=='I') :: range="A"
     integer intent(hide),depend(a) :: n=shape(a,0)
     integer optional,intent(in) :: il=1
     integer optional,intent(in),depend(n) :: iu=n
@@ -1207,16 +1207,16 @@ subroutine <prefix2>sygvx(itype,jobz,range,uplo,n,a,lda,b,ldb,vl,vu,il,iu,abstol
 
     <ftype2> intent(in,copy),check(shape(a,0)==shape(a,1)),dimension(n,n) :: a
     <ftype2> intent(in,copy,aligned8),check(shape(b,0)==shape(b,1)),check(shape(b,0)==n),dimension(n,n),depend(n) :: b
-    integer intent(hide),depend(n) :: lda=max(1,n)
-    integer intent(hide),depend(n) :: ldb=max(1,n)
-    integer intent(hide),depend(z) :: ldz=max(1,shape(z,0))
+    integer intent(hide),depend(a) :: lda=MAX(1,shape(a,0))
+    integer intent(hide),depend(b) :: ldb=MAX(1,shape(b,0))
+    integer intent(hide),depend(z) :: ldz=MAX(1,shape(z,0))
     <ftype2>  intent(hide),dimension(lwork),depend(lwork) :: work
     integer intent(hide),dimension(5*n),depend(n) :: iwork
 
     <ftype2> intent(out),dimension(n),depend(n) :: w
     <ftype2> intent(out),dimension((jobz[0]=='V'?MAX(0,n):0),(jobz[0]=='V'?(range[0]=='I'?iu-il+1:MAX(1,n)):0)),depend(n,jobz,range,iu,il) :: z
     integer intent(out) :: m
-    integer intent(out),dimension((jobz[0]=='N'?n:0)),depend(jobz,n):: ifail
+    integer intent(out),dimension((jobz[0]=='N'?0:n)),depend(jobz,n):: ifail
     integer intent(out) :: info
 
 end subroutine <prefix2>sygvx
@@ -1253,7 +1253,7 @@ subroutine <prefix2>sygvx_lwork(itype,uplo,n,a,lda,b,ldb,vl,vu,il,iu,abstol,m,w,
 
 end subroutine <prefix2>sygvx_lwork
 
-subroutine <prefix2c>hegvx(itype,jobz,range,uplo,n,a,lda,b,ldb,vl,vu,il,iu,abstol,m,w,z,ldz,work,lwork,rwork,iwork,ifail,info)
+subroutine <prefix2c>hegvx(itype,jobz,range,uplo,n,a,lda,b,ldb,vl,vu,il,iu,abstol,w,z,m,ldz,work,lwork,rwork,iwork,ifail,info)
     ! (C/Z)HEGVX computes selected eigenvalues, and optionally, eigenvectors
     ! of a complex generalized Hermitian-definite eigenproblem, of the form
     ! A*x=(lambda)*B*x,  A*Bx=(lambda)*x,  or B*A*x=(lambda)*x.  Here A and
@@ -1261,7 +1261,7 @@ subroutine <prefix2c>hegvx(itype,jobz,range,uplo,n,a,lda,b,ldb,vl,vu,il,iu,absto
     ! Eigenvalues and eigenvectors can be selected by specifying either a
     ! range of values or a range of indices for the desired eigenvalues.
     callstatement (*f2py_func)(&itype,jobz,range,uplo,&n,a,&lda,b,&ldb,&vl,&vu,&il,&iu,&abstol,&m,w,z,&ldz,work,&lwork,rwork,iwork,ifail,&info)
-    callprotoargument int*,char*,char*,char*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,int*,int*,int*
+    callprotoargument int*,char*,char*,char*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,int*,int*,int*
     
     integer optional,intent(in),check(itype>0||itype<4) :: itype=1
     character optional,intent(in),check(*jobz=='N'||*jobz=='V') :: jobz='V'
@@ -1275,19 +1275,19 @@ subroutine <prefix2c>hegvx(itype,jobz,range,uplo,n,a,lda,b,ldb,vl,vu,il,iu,absto
     <ftype2> intent(in) :: abstol=0.0
     integer optional,intent(in),depend(n),check(lwork>=1||lwork==-1) :: lwork=max(2*n,1)
 
-    <ftype2> intent(in,copy),check(shape(a,0)==shape(a,1)),dimension(n,n) :: a
-    <ftype2> intent(in,copy,aligned8),check(shape(b,0)==shape(b,1)),check(shape(b,0)==n),dimension(n,n),depend(n) :: b
+    <ftype2c> intent(in,copy),check(shape(a,0)==shape(a,1)),dimension(n,n) :: a
+    <ftype2c> intent(in,copy,aligned8),check(shape(b,0)==shape(b,1)),check(shape(b,0)==n),dimension(n,n),depend(n) :: b
     integer intent(hide),depend(n) :: lda=max(1,n)
     integer intent(hide),depend(n) :: ldb=max(1,n)
     integer intent(hide),depend(z) :: ldz=max(1,shape(z,0))
-    <ftype2>  intent(hide),dimension(lwork),depend(lwork) :: work
+    <ftype2c>  intent(hide),dimension(lwork),depend(lwork) :: work
     integer intent(hide),dimension(5*n),depend(n) :: iwork
     <ftype2> intent(hide),dimension(7*n),depend(n) :: rwork
 
     <ftype2> intent(out),dimension(n),depend(n) :: w
-    <ftype2> intent(out),dimension((jobz[0]=='V'?MAX(0,n):0),(jobz[0]=='V'?(range[0]=='I'?iu-il+1:MAX(1,n)):0)),depend(n,jobz,range,iu,il) :: z
+    <ftype2c> intent(out),dimension((jobz[0]=='V'?MAX(0,n):0),(jobz[0]=='V'?(range[0]=='I'?iu-il+1:MAX(1,n)):0)),depend(n,jobz,range,iu,il) :: z
     integer intent(out) :: m
-    integer intent(out),dimension((jobz[0]=='N'?n:0)),depend(jobz,n):: ifail
+    integer intent(out),dimension((jobz[0]=='N'?0:n)),depend(jobz,n):: ifail
     integer intent(out) :: info
 
 end subroutine <prefix2c>hegvx
@@ -1296,15 +1296,15 @@ subroutine <prefix2c>hegvx_lwork(itype,uplo,n,a,lda,b,ldb,vl,vu,il,iu,abstol,m,w
     ! LWORK Query routine for (c/z)hegvx
     fortranname <prefix2c>hegvx
     callstatement (*f2py_func)(&itype,"N","A",uplo,&n,&a,&lda,&b,&ldb,&vl,&vu,&il,&iu,&abstol,&m,&w,&z,&ldz,&work,&lwork,&rwork,&iwork,&ifail,&info)
-    callprotoargument int*,char*,char*,char*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,int*,int*,int*
+    callprotoargument int*,char*,char*,char*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,int*,int*,int*
 
     integer intent(in):: n
     character optional,intent(in),check(*uplo=='U'||*uplo=='L') :: uplo='L'
 
     integer intent(hide):: itype = 1
-    <ftype2> intent(hide):: a
+    <ftype2c> intent(hide):: a
     integer intent(hide),depend(n):: lda = MAX(1,n)
-    <ftype2> intent(hide):: b
+    <ftype2c> intent(hide):: b
     integer intent(hide):: ldb = MAX(1,n)
     integer intent(hide):: il = 1
     integer intent(hide):: iu = 0
@@ -1313,14 +1313,14 @@ subroutine <prefix2c>hegvx_lwork(itype,uplo,n,a,lda,b,ldb,vl,vu,il,iu,abstol,m,w
     <ftype2> intent(hide):: abstol = 0.0
     integer intent(hide):: m
     <ftype2> intent(hide):: w
-    <ftype2> intent(hide):: z
+    <ftype2c> intent(hide):: z
     integer intent(hide),depend(n):: ldz = MAX(1,n)
     integer intent(hide):: lwork = -1
     <ftype2> intent(hide):: rwork
     integer intent(hide):: iwork
     integer intent(hide):: ifail
 
-    <ftype2> intent(out):: work
+    <ftype2c> intent(out):: work
     integer intent(out):: info
 
 end subroutine <prefix2c>hegvx_lwork

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -280,6 +280,9 @@ All functions
    cheevr
    zheevr
 
+   cheevr_lwork
+   zheevr_lwork
+
    chegst
    zhegst
 
@@ -506,6 +509,9 @@ All functions
 
    ssyevr
    dsyevr
+
+   ssyevr_lwork
+   dsyevr_lwork
 
    ssygst
    dsygst

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -765,7 +765,7 @@ _lapack_alias = {
 }
 
 
-# Place guards against markdown problems with special characters
+# Place guards against docstring rendering issues with special characters
 p1 = regex_compile(r'with bounds (?P<b>.*?)( and (?P<s>.*?) storage){0,1}\n')
 p2 = regex_compile(r'Default: (?P<d>.*?)\n')
 
@@ -776,6 +776,7 @@ def backtickrepl(m):
                 ''.format(m.group('b'), m.group('s')))
     else:
         return 'with bounds ``{}``\n'.format(m.group('b'))
+
 
 for routine in [ssyevr, dsyevr, cheevr, zheevr,
                 ssyevx, dsyevx, cheevx, zheevx,

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -301,11 +301,17 @@ All functions
    chegv
    zhegv
 
+   chegv_lwork
+   zhegv_lwork
+
    chegvd
    zhegvd
 
    chegvx
    zhegvx
+
+   chegvx_lwork
+   zhegvx_lwork
 
    chesv
    zhesv
@@ -531,17 +537,32 @@ All functions
    ssyevr_lwork
    dsyevr_lwork
 
+   ssyevx
+   dsyevx
+   
+   ssyevx_lwork
+   dsyevx_lwork
+
    ssygst
    dsygst
 
    ssygv
    dsygv
 
+   ssygv_lwork
+   dsygv_lwork
+
    ssygvd
    dsygvd
 
+   ssygvd_lwork
+   dsygvd_lwork
+
    ssygvx
    dsygvx
+
+   ssygvx_lwork
+   dsygvx_lwork
 
    ssysv
    dsysv

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -539,7 +539,7 @@ All functions
 
    ssyevx
    dsyevx
-   
+
    ssyevx_lwork
    dsyevx_lwork
 
@@ -554,9 +554,6 @@ All functions
 
    ssygvd
    dsygvd
-
-   ssygvd_lwork
-   dsygvd_lwork
 
    ssygvx
    dsygvx
@@ -722,6 +719,7 @@ from __future__ import division, print_function, absolute_import
 import numpy as _np
 from .blas import _get_funcs, _memoize_get_funcs
 from scipy.linalg import _flapack
+import re
 try:
     from scipy.linalg import _clapack
 except ImportError:
@@ -765,6 +763,17 @@ _lapack_alias = {
     'cormqr': 'cunmqr', 'zormqr': 'zunmqr',
     'corgrq': 'cungrq', 'zorgrq': 'zungrq',
 }
+
+
+# Place guards against markdown problems with special characters
+p = re.compile(r'with bounds (?P<m>.*?)\n', re.MULTILINE)
+for routine in [ssyevr, dsyevr, cheevr, zheevr,
+                ssyevx, dsyevx, cheevx, zheevx,
+                ssygvd, dsygvd, chegvd, zhegvd]:
+    if routine.__doc__:
+        routine.__doc__ = p.sub(r'with bounds ``\1``\n', routine.__doc__)
+    else:
+        continue
 
 
 @_memoize_get_funcs

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -274,14 +274,26 @@ All functions
    cheev
    zheev
 
+   cheev_lwork
+   zheev_lwork
+
    cheevd
    zheevd
+
+   cheevd_lwork
+   zheevd_lwork
 
    cheevr
    zheevr
 
    cheevr_lwork
    zheevr_lwork
+
+   cheevx
+   zheevx
+
+   cheevx_lwork
+   zheevx_lwork
 
    chegst
    zhegst
@@ -504,8 +516,14 @@ All functions
    ssyev
    dsyev
 
+   ssyev_lwork
+   dsyev_lwork
+
    ssyevd
    dsyevd
+
+   ssyevd_lwork
+   dsyevd_lwork
 
    ssyevr
    dsyevr

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -34,11 +34,9 @@ from scipy.linalg.misc import norm
 from scipy.linalg._decomp_qz import _select_function
 from scipy.stats import ortho_group
 
-from numpy import (array, transpose, diag, ones, full, linalg, argsort,
-                   zeros, arange, float32, complex64, dot, conj, identity,
-                   ravel, sqrt, iscomplex, shape, sort, conjugate, sign,
-                   asarray, isfinite, ndarray, outer, eye, dtype, empty,
-                   triu, tril)
+from numpy import (array, diag, ones, full, linalg, argsort, zeros, arange,
+                   float32, complex64, ravel, sqrt, iscomplex, shape, sort,
+                   sign, asarray, isfinite, ndarray, eye, dtype, triu, tril)
 
 from numpy.random import seed, random
 
@@ -83,8 +81,6 @@ def clear_fuss(ar, fuss_binary_bits=7):
 
 
 # XXX: This function should be available through numpy.testing
-
-
 def assert_dtype_equal(act, des):
     if isinstance(act, ndarray):
         act = act.dtype
@@ -96,12 +92,12 @@ def assert_dtype_equal(act, des):
     else:
         des = dtype(des)
 
-    assert_(act == des, 'dtype mismatch: "%s" (should be "%s") ' % (act, des))
+    assert_(act == des,
+            'dtype mismatch: "{}" (should be "{}")'.format(act, des))
+
 
 # XXX: This function should not be defined here, but somewhere in
 #      scipy.linalg namespace
-
-
 def symrand(dim_or_eigv):
     """Return a random symmetric (Hermitian) matrix.
 
@@ -122,7 +118,7 @@ def symrand(dim_or_eigv):
         raise TypeError("input type not supported.")
 
     v = ortho_group.rvs(dim)
-    h = dot(dot(v.T.conj(), diag(d)), v)
+    h = v.T.conj() @ diag(d) @ v
     # to avoid roundoff errors, symmetrize the matrix (again)
     h = 0.5*(h.T+h)
     return h
@@ -138,81 +134,81 @@ def _complex_symrand(dim, dtype):
 class TestEigVals(object):
 
     def test_simple(self):
-        a = [[1,2,3],[1,2,3],[2,5,6]]
+        a = [[1, 2, 3], [1, 2, 3], [2, 5, 6]]
         w = eigvals(a)
-        exact_w = [(9+sqrt(93))/2,0,(9-sqrt(93))/2]
-        assert_array_almost_equal(w,exact_w)
+        exact_w = [(9+sqrt(93))/2, 0, (9-sqrt(93))/2]
+        assert_array_almost_equal(w, exact_w)
 
     def test_simple_tr(self):
-        a = array([[1,2,3],[1,2,3],[2,5,6]],'d')
-        a = transpose(a).copy()
-        a = transpose(a)
+        a = array([[1, 2, 3], [1, 2, 3], [2, 5, 6]], 'd').T
+        a = a.copy()
+        a = a.T
         w = eigvals(a)
-        exact_w = [(9+sqrt(93))/2,0,(9-sqrt(93))/2]
-        assert_array_almost_equal(w,exact_w)
+        exact_w = [(9+sqrt(93))/2, 0, (9-sqrt(93))/2]
+        assert_array_almost_equal(w, exact_w)
 
     def test_simple_complex(self):
-        a = [[1,2,3],[1,2,3],[2,5,6+1j]]
+        a = [[1, 2, 3], [1, 2, 3], [2, 5, 6+1j]]
         w = eigvals(a)
         exact_w = [(9+1j+sqrt(92+6j))/2,
                    0,
                    (9+1j-sqrt(92+6j))/2]
-        assert_array_almost_equal(w,exact_w)
+        assert_array_almost_equal(w, exact_w)
 
     def test_finite(self):
-        a = [[1,2,3],[1,2,3],[2,5,6]]
+        a = [[1, 2, 3], [1, 2, 3], [2, 5, 6]]
         w = eigvals(a, check_finite=False)
-        exact_w = [(9+sqrt(93))/2,0,(9-sqrt(93))/2]
-        assert_array_almost_equal(w,exact_w)
+        exact_w = [(9+sqrt(93))/2, 0, (9-sqrt(93))/2]
+        assert_array_almost_equal(w, exact_w)
 
 
 class TestEig(object):
 
     def test_simple(self):
-        a = [[1,2,3],[1,2,3],[2,5,6]]
-        w,v = eig(a)
-        exact_w = [(9+sqrt(93))/2,0,(9-sqrt(93))/2]
-        v0 = array([1,1,(1+sqrt(93)/3)/2])
-        v1 = array([3.,0,-1])
-        v2 = array([1,1,(1-sqrt(93)/3)/2])
-        v0 = v0 / sqrt(dot(v0,transpose(v0)))
-        v1 = v1 / sqrt(dot(v1,transpose(v1)))
-        v2 = v2 / sqrt(dot(v2,transpose(v2)))
-        assert_array_almost_equal(w,exact_w)
-        assert_array_almost_equal(v0,v[:,0]*sign(v[0,0]))
-        assert_array_almost_equal(v1,v[:,1]*sign(v[0,1]))
-        assert_array_almost_equal(v2,v[:,2]*sign(v[0,2]))
+        a = array([[1, 2, 3], [1, 2, 3], [2, 5, 6]])
+        w, v = eig(a)
+        exact_w = [(9+sqrt(93))/2, 0, (9-sqrt(93))/2]
+        v0 = array([1, 1, (1+sqrt(93)/3)/2])
+        v1 = array([3., 0, -1])
+        v2 = array([1, 1, (1-sqrt(93)/3)/2])
+        v0 = v0 / norm(v0)
+        v1 = v1 / norm(v1)
+        v2 = v2 / norm(v2)
+        assert_array_almost_equal(w, exact_w)
+        assert_array_almost_equal(v0, v[:, 0]*sign(v[0, 0]))
+        assert_array_almost_equal(v1, v[:, 1]*sign(v[0, 1]))
+        assert_array_almost_equal(v2, v[:, 2]*sign(v[0, 2]))
         for i in range(3):
-            assert_array_almost_equal(dot(a,v[:,i]),w[i]*v[:,i])
-        w,v = eig(a,left=1,right=0)
+            assert_array_almost_equal(a @ v[:, i], w[i]*v[:, i])
+        w, v = eig(a, left=1, right=0)
         for i in range(3):
-            assert_array_almost_equal(dot(transpose(a),v[:,i]),w[i]*v[:,i])
+            assert_array_almost_equal(a.T @ v[:, i], w[i]*v[:, i])
 
     def test_simple_complex_eig(self):
-        a = [[1,2],[-2,1]]
-        w,vl,vr = eig(a,left=1,right=1)
+        a = array([[1, 2], [-2, 1]])
+        w, vl, vr = eig(a, left=1, right=1)
         assert_array_almost_equal(w, array([1+2j, 1-2j]))
         for i in range(2):
-            assert_array_almost_equal(dot(a,vr[:,i]),w[i]*vr[:,i])
+            assert_array_almost_equal(a @ vr[:, i], w[i]*vr[:, i])
         for i in range(2):
-            assert_array_almost_equal(dot(conjugate(transpose(a)),vl[:,i]),
-                                      conjugate(w[i])*vl[:,i])
+            assert_array_almost_equal(a.conj().T @ vl[:, i],
+                                      w[i].conj()*vl[:, i])
 
     def test_simple_complex(self):
-        a = [[1,2,3],[1,2,3],[2,5,6+1j]]
-        w,vl,vr = eig(a,left=1,right=1)
+        a = array([[1, 2, 3], [1, 2, 3], [2, 5, 6+1j]])
+        w, vl, vr = eig(a, left=1, right=1)
         for i in range(3):
-            assert_array_almost_equal(dot(a,vr[:,i]),w[i]*vr[:,i])
+            assert_array_almost_equal(a @ vr[:, i], w[i]*vr[:, i])
         for i in range(3):
-            assert_array_almost_equal(dot(conjugate(transpose(a)),vl[:,i]),
-                                      conjugate(w[i])*vl[:,i])
+            assert_array_almost_equal(a.conj().T @ vl[:, i],
+                                      w[i].conj()*vl[:, i])
 
     def test_gh_3054(self):
         a = [[1]]
         b = [[0]]
         w, vr = eig(a, b, homogeneous_eigvals=True)
-        assert_allclose(w[1,0], 0)
-        assert_(w[0,0] != 0)
+        assert_allclose(w[1, 0], 0)
+        assert_(w[0, 0] != 0)
         assert_allclose(vr, 1)
 
         w, vr = eig(a, b)
@@ -232,39 +228,43 @@ class TestEig(object):
         # Eigenvalues in homogeneous coordinates
         w, vr = eig(A, B0, homogeneous_eigvals=True)
         wt = eigvals(A, B0, homogeneous_eigvals=True)
-        val1 = dot(A, vr) * w[1,:]
-        val2 = dot(B, vr) * w[0,:]
+        val1 = A @ vr * w[1, :]
+        val2 = B @ vr * w[0, :]
         for i in range(val1.shape[1]):
-            assert_allclose(val1[:,i], val2[:,i], rtol=1e-13, atol=1e-13, err_msg=msg)
+            assert_allclose(val1[:, i], val2[:, i],
+                            rtol=1e-13, atol=1e-13, err_msg=msg)
 
         if B0 is None:
-            assert_allclose(w[1,:], 1)
-            assert_allclose(wt[1,:], 1)
+            assert_allclose(w[1, :], 1)
+            assert_allclose(wt[1, :], 1)
 
         perm = np.lexsort(w)
         permt = np.lexsort(wt)
-        assert_allclose(w[:,perm], wt[:,permt], atol=1e-7, rtol=1e-7,
+        assert_allclose(w[:, perm], wt[:, permt], atol=1e-7, rtol=1e-7,
                         err_msg=msg)
 
         length = np.empty(len(vr))
+
         for i in range(len(vr)):
-            length[i] = norm(vr[:,i])
+            length[i] = norm(vr[:, i])
+
         assert_allclose(length, np.ones(length.size), err_msg=msg,
                         atol=1e-7, rtol=1e-7)
 
         # Convert homogeneous coordinates
-        beta_nonzero = (w[1,:] != 0)
-        wh = w[0,beta_nonzero] / w[1,beta_nonzero]
+        beta_nonzero = (w[1, :] != 0)
+        wh = w[0, beta_nonzero] / w[1, beta_nonzero]
 
         # Eigenvalues in standard coordinates
         w, vr = eig(A, B0)
         wt = eigvals(A, B0)
-        val1 = dot(A, vr)
-        val2 = dot(B, vr) * w
+        val1 = A @ vr
+        val2 = B @ vr * w
         res = val1 - val2
         for i in range(res.shape[1]):
-            if np.all(isfinite(res[:,i])):
-                assert_allclose(res[:,i], 0, rtol=1e-13, atol=1e-13, err_msg=msg)
+            if np.all(isfinite(res[:, i])):
+                assert_allclose(res[:, i], 0,
+                                rtol=1e-13, atol=1e-13, err_msg=msg)
 
         w_fin = w[isfinite(w)]
         wt_fin = wt[isfinite(wt)]
@@ -275,7 +275,7 @@ class TestEig(object):
 
         length = np.empty(len(vr))
         for i in range(len(vr)):
-            length[i] = norm(vr[:,i])
+            length[i] = norm(vr[:, i])
         assert_allclose(length, np.ones(length.size), err_msg=msg)
 
         # Compare homogeneous and nonhomogeneous versions
@@ -285,10 +285,16 @@ class TestEig(object):
     def test_singular(self):
         # Example taken from
         # https://web.archive.org/web/20040903121217/http://www.cs.umu.se/research/nla/singular_pairs/guptri/matlab.html
-        A = array(([22,34,31,31,17], [45,45,42,19,29], [39,47,49,26,34],
-            [27,31,26,21,15], [38,44,44,24,30]))
-        B = array(([13,26,25,17,24], [31,46,40,26,37], [26,40,19,25,25],
-            [16,25,27,14,23], [24,35,18,21,22]))
+        A = array([[22, 34, 31, 31, 17],
+                   [45, 45, 42, 19, 29],
+                   [39, 47, 49, 26, 34],
+                   [27, 31, 26, 21, 15],
+                   [38, 44, 44, 24, 30]])
+        B = array([[13, 26, 25, 17, 24],
+                   [31, 46, 40, 26, 37],
+                   [26, 40, 19, 25, 25],
+                   [16, 25, 27, 14, 23],
+                   [24, 35, 18, 21, 22]])
 
         olderr = np.seterr(all='ignore')
         try:
@@ -298,11 +304,11 @@ class TestEig(object):
 
     def test_falker(self):
         # Test matrices giving some Nan generalized eigenvalues.
-        M = diag(array(([1,0,3])))
-        K = array(([2,-1,-1],[-1,2,-1],[-1,-1,2]))
-        D = array(([1,-1,0],[-1,1,0],[0,0,0]))
-        Z = zeros((3,3))
-        I3 = identity(3)
+        M = diag(array(([1, 0, 3])))
+        K = array(([2, -1, -1], [-1, 2, -1], [-1, -1, 2]))
+        D = array(([1, -1, 0], [-1, 1, 0], [0, 0, 0]))
+        Z = zeros((3, 3))
+        I3 = eye(3)
         A = bmat([[I3, Z], [Z, -K]])
         B = bmat([[Z, I3], [M, D]])
 
@@ -353,31 +359,32 @@ class TestEig(object):
         self._check_gen_eig(A, B)
 
     def test_check_finite(self):
-        a = [[1,2,3],[1,2,3],[2,5,6]]
-        w,v = eig(a, check_finite=False)
-        exact_w = [(9+sqrt(93))/2,0,(9-sqrt(93))/2]
-        v0 = array([1,1,(1+sqrt(93)/3)/2])
-        v1 = array([3.,0,-1])
-        v2 = array([1,1,(1-sqrt(93)/3)/2])
-        v0 = v0 / sqrt(dot(v0,transpose(v0)))
-        v1 = v1 / sqrt(dot(v1,transpose(v1)))
-        v2 = v2 / sqrt(dot(v2,transpose(v2)))
-        assert_array_almost_equal(w,exact_w)
-        assert_array_almost_equal(v0,v[:,0]*sign(v[0,0]))
-        assert_array_almost_equal(v1,v[:,1]*sign(v[0,1]))
-        assert_array_almost_equal(v2,v[:,2]*sign(v[0,2]))
+        a = [[1, 2, 3], [1, 2, 3], [2, 5, 6]]
+        w, v = eig(a, check_finite=False)
+        exact_w = [(9+sqrt(93))/2, 0, (9-sqrt(93))/2]
+        v0 = array([1, 1, (1+sqrt(93)/3)/2])
+        v1 = array([3., 0, -1])
+        v2 = array([1, 1, (1-sqrt(93)/3)/2])
+        v0 = v0 / norm(v0)
+        v1 = v1 / norm(v1)
+        v2 = v2 / norm(v2)
+        assert_array_almost_equal(w, exact_w)
+        assert_array_almost_equal(v0, v[:, 0]*sign(v[0, 0]))
+        assert_array_almost_equal(v1, v[:, 1]*sign(v[0, 1]))
+        assert_array_almost_equal(v2, v[:, 2]*sign(v[0, 2]))
         for i in range(3):
-            assert_array_almost_equal(dot(a,v[:,i]),w[i]*v[:,i])
+            assert_array_almost_equal(a @ v[:, i], w[i]*v[:, i])
 
     def test_not_square_error(self):
         """Check that passing a non-square array raises a ValueError."""
-        A = np.arange(6).reshape(3,2)
+        A = np.arange(6).reshape(3, 2)
         assert_raises(ValueError, eig, A)
 
     def test_shape_mismatch(self):
-        """Check that passing arrays of with different shapes raises a ValueError."""
-        A = identity(2)
-        B = np.arange(9.0).reshape(3,3)
+        """Check that passing arrays of with different shapes
+        raises a ValueError."""
+        A = eye(2)
+        B = np.arange(9.0).reshape(3, 3)
         assert_raises(ValueError, eig, A, B)
         assert_raises(ValueError, eig, B, A)
 
@@ -395,36 +402,40 @@ class TestEigBanded(object):
 
         # symmetric band matrix
         self.sym_mat = (diag(full(N, 1.0))
-                     + diag(full(N-1, -1.0), -1) + diag(full(N-1, -1.0), 1)
-                     + diag(full(N-2, -2.0), -2) + diag(full(N-2, -2.0), 2))
+                        + diag(full(N-1, -1.0), -1) + diag(full(N-1, -1.0), 1)
+                        + diag(full(N-2, -2.0), -2) + diag(full(N-2, -2.0), 2))
 
         # hermitian band matrix
         self.herm_mat = (diag(full(N, -1.0))
-                     + 1j*diag(full(N-1, 1.0), -1) - 1j*diag(full(N-1, 1.0), 1)
-                     + diag(full(N-2, -2.0), -2) + diag(full(N-2, -2.0), 2))
+                         + 1j*diag(full(N-1, 1.0), -1)
+                         - 1j*diag(full(N-1, 1.0), 1)
+                         + diag(full(N-2, -2.0), -2)
+                         + diag(full(N-2, -2.0), 2))
 
         # general real band matrix
         self.real_mat = (diag(full(N, 1.0))
-                     + diag(full(N-1, -1.0), -1) + diag(full(N-1, -3.0), 1)
-                     + diag(full(N-2, 2.0), -2) + diag(full(N-2, -2.0), 2))
+                         + diag(full(N-1, -1.0), -1) + diag(full(N-1, -3.0), 1)
+                         + diag(full(N-2, 2.0), -2) + diag(full(N-2, -2.0), 2))
 
         # general complex band matrix
         self.comp_mat = (1j*diag(full(N, 1.0))
-                     + diag(full(N-1, -1.0), -1) + 1j*diag(full(N-1, -3.0), 1)
-                     + diag(full(N-2, 2.0), -2) + diag(full(N-2, -2.0), 2))
+                         + diag(full(N-1, -1.0), -1)
+                         + 1j*diag(full(N-1, -3.0), 1)
+                         + diag(full(N-2, 2.0), -2)
+                         + diag(full(N-2, -2.0), 2))
 
         # Eigenvalues and -vectors from linalg.eig
         ew, ev = linalg.eig(self.sym_mat)
         ew = ew.real
         args = argsort(ew)
         self.w_sym_lin = ew[args]
-        self.evec_sym_lin = ev[:,args]
+        self.evec_sym_lin = ev[:, args]
 
         ew, ev = linalg.eig(self.herm_mat)
         ew = ew.real
         args = argsort(ew)
         self.w_herm_lin = ew[args]
-        self.evec_herm_lin = ev[:,args]
+        self.evec_herm_lin = ev[:, args]
 
         # Extract upper bands from symmetric and hermitian band matrices
         # (for use in dsbevd, dsbevx, zhbevd, zhbevx
@@ -433,27 +444,29 @@ class TestEigBanded(object):
         self.bandmat_sym = zeros((LDAB, N), dtype=float)
         self.bandmat_herm = zeros((LDAB, N), dtype=complex)
         for i in range(LDAB):
-            self.bandmat_sym[LDAB-i-1,i:N] = diag(self.sym_mat, i)
-            self.bandmat_herm[LDAB-i-1,i:N] = diag(self.herm_mat, i)
+            self.bandmat_sym[LDAB-i-1, i:N] = diag(self.sym_mat, i)
+            self.bandmat_herm[LDAB-i-1, i:N] = diag(self.herm_mat, i)
 
         # Extract bands from general real and complex band matrix
         # (for use in dgbtrf, dgbtrs and their single precision versions)
         LDAB = 2*self.KL + self.KU + 1
         self.bandmat_real = zeros((LDAB, N), dtype=float)
-        self.bandmat_real[2*self.KL,:] = diag(self.real_mat)     # diagonal
+        self.bandmat_real[2*self.KL, :] = diag(self.real_mat)  # diagonal
         for i in range(self.KL):
             # superdiagonals
-            self.bandmat_real[2*self.KL-1-i,i+1:N] = diag(self.real_mat, i+1)
+            self.bandmat_real[2*self.KL-1-i, i+1:N] = diag(self.real_mat, i+1)
             # subdiagonals
-            self.bandmat_real[2*self.KL+1+i,0:N-1-i] = diag(self.real_mat,-i-1)
+            self.bandmat_real[2*self.KL+1+i, 0:N-1-i] = diag(self.real_mat,
+                                                             -i-1)
 
         self.bandmat_comp = zeros((LDAB, N), dtype=complex)
-        self.bandmat_comp[2*self.KL,:] = diag(self.comp_mat)     # diagonal
+        self.bandmat_comp[2*self.KL, :] = diag(self.comp_mat)  # diagonal
         for i in range(self.KL):
             # superdiagonals
-            self.bandmat_comp[2*self.KL-1-i,i+1:N] = diag(self.comp_mat, i+1)
+            self.bandmat_comp[2*self.KL-1-i, i+1:N] = diag(self.comp_mat, i+1)
             # subdiagonals
-            self.bandmat_comp[2*self.KL+1+i,0:N-1-i] = diag(self.comp_mat,-i-1)
+            self.bandmat_comp[2*self.KL+1+i, 0:N-1-i] = diag(self.comp_mat,
+                                                             -i-1)
 
         # absolute value for linear equation system A*x = b
         self.b = 1.0*arange(N)
@@ -465,7 +478,7 @@ class TestEigBanded(object):
         """Compare dsbev eigenvalues and eigenvectors with
            the result of linalg.eig."""
         w, evec, info = dsbev(self.bandmat_sym, compute_v=1)
-        evec_ = evec[:,argsort(w)]
+        evec_ = evec[:, argsort(w)]
         assert_array_almost_equal(sort(w), self.w_sym_lin)
         assert_array_almost_equal(abs(evec_), abs(self.evec_sym_lin))
 
@@ -473,18 +486,18 @@ class TestEigBanded(object):
         """Compare dsbevd eigenvalues and eigenvectors with
            the result of linalg.eig."""
         w, evec, info = dsbevd(self.bandmat_sym, compute_v=1)
-        evec_ = evec[:,argsort(w)]
+        evec_ = evec[:, argsort(w)]
         assert_array_almost_equal(sort(w), self.w_sym_lin)
         assert_array_almost_equal(abs(evec_), abs(self.evec_sym_lin))
 
     def test_dsbevx(self):
         """Compare dsbevx eigenvalues and eigenvectors
            with the result of linalg.eig."""
-        N,N = shape(self.sym_mat)
-        ## Achtung: Argumente 0.0,0.0,range?
+        N, N = shape(self.sym_mat)
+        # Achtung: Argumente 0.0,0.0,range?
         w, evec, num, ifail, info = dsbevx(self.bandmat_sym, 0.0, 0.0, 1, N,
-                                       compute_v=1, range=2)
-        evec_ = evec[:,argsort(w)]
+                                           compute_v=1, range=2)
+        evec_ = evec[:, argsort(w)]
         assert_array_almost_equal(sort(w), self.w_sym_lin)
         assert_array_almost_equal(abs(evec_), abs(self.evec_sym_lin))
 
@@ -492,18 +505,18 @@ class TestEigBanded(object):
         """Compare zhbevd eigenvalues and eigenvectors
            with the result of linalg.eig."""
         w, evec, info = zhbevd(self.bandmat_herm, compute_v=1)
-        evec_ = evec[:,argsort(w)]
+        evec_ = evec[:, argsort(w)]
         assert_array_almost_equal(sort(w), self.w_herm_lin)
         assert_array_almost_equal(abs(evec_), abs(self.evec_herm_lin))
 
     def test_zhbevx(self):
         """Compare zhbevx eigenvalues and eigenvectors
            with the result of linalg.eig."""
-        N,N = shape(self.herm_mat)
-        ## Achtung: Argumente 0.0,0.0,range?
+        N, N = shape(self.herm_mat)
+        # Achtung: Argumente 0.0,0.0,range?
         w, evec, num, ifail, info = zhbevx(self.bandmat_herm, 0.0, 0.0, 1, N,
-                                       compute_v=1, range=2)
-        evec_ = evec[:,argsort(w)]
+                                           compute_v=1, range=2)
+        evec_ = evec[:, argsort(w)]
         assert_array_almost_equal(sort(w), self.w_herm_lin)
         assert_array_almost_equal(abs(evec_), abs(self.evec_herm_lin))
 
@@ -521,7 +534,7 @@ class TestEigBanded(object):
         ind1 = 2
         ind2 = np.longlong(6)
         w_sym_ind = eigvals_banded(self.bandmat_sym,
-                                    select='i', select_range=(ind1, ind2))
+                                   select='i', select_range=(ind1, ind2))
         assert_array_almost_equal(sort(w_sym_ind),
                                   self.w_sym_lin[ind1:ind2+1])
         w_herm_ind = eigvals_banded(self.bandmat_herm,
@@ -533,14 +546,15 @@ class TestEigBanded(object):
         v_lower = self.w_sym_lin[ind1] - 1.0e-5
         v_upper = self.w_sym_lin[ind2] + 1.0e-5
         w_sym_val = eigvals_banded(self.bandmat_sym,
-                                select='v', select_range=(v_lower, v_upper))
+                                   select='v', select_range=(v_lower, v_upper))
         assert_array_almost_equal(sort(w_sym_val),
                                   self.w_sym_lin[ind1:ind2+1])
 
         v_lower = self.w_herm_lin[ind1] - 1.0e-5
         v_upper = self.w_herm_lin[ind2] + 1.0e-5
         w_herm_val = eigvals_banded(self.bandmat_herm,
-                                select='v', select_range=(v_lower, v_upper))
+                                    select='v',
+                                    select_range=(v_lower, v_upper))
         assert_array_almost_equal(sort(w_herm_val),
                                   self.w_herm_lin[ind1:ind2+1])
 
@@ -552,12 +566,12 @@ class TestEigBanded(object):
         """Compare eigenvalues and eigenvectors of eig_banded
            with those of linalg.eig. """
         w_sym, evec_sym = eig_banded(self.bandmat_sym)
-        evec_sym_ = evec_sym[:,argsort(w_sym.real)]
+        evec_sym_ = evec_sym[:, argsort(w_sym.real)]
         assert_array_almost_equal(sort(w_sym), self.w_sym_lin)
         assert_array_almost_equal(abs(evec_sym_), abs(self.evec_sym_lin))
 
         w_herm, evec_herm = eig_banded(self.bandmat_herm)
-        evec_herm_ = evec_herm[:,argsort(w_herm.real)]
+        evec_herm_ = evec_herm[:, argsort(w_herm.real)]
         assert_array_almost_equal(sort(w_herm), self.w_herm_lin)
         assert_array_almost_equal(abs(evec_herm_), abs(self.evec_herm_lin))
 
@@ -565,53 +579,57 @@ class TestEigBanded(object):
         ind1 = 2
         ind2 = 6
         w_sym_ind, evec_sym_ind = eig_banded(self.bandmat_sym,
-                                    select='i', select_range=(ind1, ind2))
+                                             select='i',
+                                             select_range=(ind1, ind2))
         assert_array_almost_equal(sort(w_sym_ind),
                                   self.w_sym_lin[ind1:ind2+1])
         assert_array_almost_equal(abs(evec_sym_ind),
-                                  abs(self.evec_sym_lin[:,ind1:ind2+1]))
+                                  abs(self.evec_sym_lin[:, ind1:ind2+1]))
 
         w_herm_ind, evec_herm_ind = eig_banded(self.bandmat_herm,
-                                    select='i', select_range=(ind1, ind2))
+                                               select='i',
+                                               select_range=(ind1, ind2))
         assert_array_almost_equal(sort(w_herm_ind),
                                   self.w_herm_lin[ind1:ind2+1])
         assert_array_almost_equal(abs(evec_herm_ind),
-                                  abs(self.evec_herm_lin[:,ind1:ind2+1]))
+                                  abs(self.evec_herm_lin[:, ind1:ind2+1]))
 
         # extracting eigenvalues with respect to a value range
         v_lower = self.w_sym_lin[ind1] - 1.0e-5
         v_upper = self.w_sym_lin[ind2] + 1.0e-5
         w_sym_val, evec_sym_val = eig_banded(self.bandmat_sym,
-                                select='v', select_range=(v_lower, v_upper))
+                                             select='v',
+                                             select_range=(v_lower, v_upper))
         assert_array_almost_equal(sort(w_sym_val),
                                   self.w_sym_lin[ind1:ind2+1])
         assert_array_almost_equal(abs(evec_sym_val),
-                                  abs(self.evec_sym_lin[:,ind1:ind2+1]))
+                                  abs(self.evec_sym_lin[:, ind1:ind2+1]))
 
         v_lower = self.w_herm_lin[ind1] - 1.0e-5
         v_upper = self.w_herm_lin[ind2] + 1.0e-5
         w_herm_val, evec_herm_val = eig_banded(self.bandmat_herm,
-                                select='v', select_range=(v_lower, v_upper))
+                                               select='v',
+                                               select_range=(v_lower, v_upper))
         assert_array_almost_equal(sort(w_herm_val),
                                   self.w_herm_lin[ind1:ind2+1])
         assert_array_almost_equal(abs(evec_herm_val),
-                                  abs(self.evec_herm_lin[:,ind1:ind2+1]))
+                                  abs(self.evec_herm_lin[:, ind1:ind2+1]))
 
         w_sym, evec_sym = eig_banded(self.bandmat_sym, check_finite=False)
-        evec_sym_ = evec_sym[:,argsort(w_sym.real)]
+        evec_sym_ = evec_sym[:, argsort(w_sym.real)]
         assert_array_almost_equal(sort(w_sym), self.w_sym_lin)
         assert_array_almost_equal(abs(evec_sym_), abs(self.evec_sym_lin))
 
     def test_dgbtrf(self):
         """Compare dgbtrf  LU factorisation with the LU factorisation result
            of linalg.lu."""
-        M,N = shape(self.real_mat)
+        M, N = shape(self.real_mat)
         lu_symm_band, ipiv, info = dgbtrf(self.bandmat_real, self.KL, self.KU)
 
         # extract matrix u from lu_symm_band
-        u = diag(lu_symm_band[2*self.KL,:])
+        u = diag(lu_symm_band[2*self.KL, :])
         for i in range(self.KL + self.KU):
-            u += diag(lu_symm_band[2*self.KL-1-i,i+1:N], i+1)
+            u += diag(lu_symm_band[2*self.KL-1-i, i+1:N], i+1)
 
         p_lin, l_lin, u_lin = lu(self.real_mat, permute_l=0)
         assert_array_almost_equal(u, u_lin)
@@ -619,13 +637,13 @@ class TestEigBanded(object):
     def test_zgbtrf(self):
         """Compare zgbtrf  LU factorisation with the LU factorisation result
            of linalg.lu."""
-        M,N = shape(self.comp_mat)
+        M, N = shape(self.comp_mat)
         lu_symm_band, ipiv, info = zgbtrf(self.bandmat_comp, self.KL, self.KU)
 
         # extract matrix u from lu_symm_band
-        u = diag(lu_symm_band[2*self.KL,:])
+        u = diag(lu_symm_band[2*self.KL, :])
         for i in range(self.KL + self.KU):
-            u += diag(lu_symm_band[2*self.KL-1-i,i+1:N], i+1)
+            u += diag(lu_symm_band[2*self.KL-1-i, i+1:N], i+1)
 
         p_lin, l_lin, u_lin = lu(self.comp_mat, permute_l=0)
         assert_array_almost_equal(u, u_lin)
@@ -874,29 +892,34 @@ class TestEigh:
 
 class TestLU(object):
     def setup_method(self):
-        self.a = array([[1,2,3],[1,2,3],[2,5,6]])
-        self.ca = array([[1,2,3],[1,2,3],[2,5j,6]])
+        self.a = array([[1, 2, 3], [1, 2, 3], [2, 5, 6]])
+        self.ca = array([[1, 2, 3], [1, 2, 3], [2, 5j, 6]])
         # Those matrices are more robust to detect problems in permutation
         # matrices than the ones above
-        self.b = array([[1,2,3],[4,5,6],[7,8,9]])
-        self.cb = array([[1j,2j,3j],[4j,5j,6j],[7j,8j,9j]])
+        self.b = array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+        self.cb = array([[1j, 2j, 3j], [4j, 5j, 6j], [7j, 8j, 9j]])
 
         # Reectangular matrices
         self.hrect = array([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 12, 12]])
-        self.chrect = 1.j * array([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 12, 12]])
+        self.chrect = 1.j * array([[1, 2, 3, 4],
+                                   [5, 6, 7, 8],
+                                   [9, 10, 12, 12]])
 
         self.vrect = array([[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 12, 12]])
-        self.cvrect = 1.j * array([[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 12, 12]])
+        self.cvrect = 1.j * array([[1, 2, 3],
+                                   [4, 5, 6],
+                                   [7, 8, 9],
+                                   [10, 12, 12]])
 
         # Medium sizes matrices
         self.med = random((30, 40))
         self.cmed = random((30, 40)) + 1.j * random((30, 40))
 
     def _test_common(self, data):
-        p,l,u = lu(data)
-        assert_array_almost_equal(dot(dot(p,l),u),data)
-        pl,u = lu(data,permute_l=1)
-        assert_array_almost_equal(dot(pl,u),data)
+        p, l, u = lu(data)
+        assert_array_almost_equal(p @ l @ u, data)
+        pl, u = lu(data, permute_l=1)
+        assert_array_almost_equal(pl @ u, data)
 
     # Simple tests
     def test_simple(self):
@@ -935,12 +958,12 @@ class TestLU(object):
 
     def test_check_finite(self):
         p, l, u = lu(self.a, check_finite=False)
-        assert_array_almost_equal(dot(dot(p,l),u), self.a)
+        assert_array_almost_equal(p @ l @ u, self.a)
 
     def test_simple_known(self):
         # Ticket #1458
         for order in ['C', 'F']:
-            A = np.array([[2, 1],[0, 1.]], order=order)
+            A = np.array([[2, 1], [0, 1.]], order=order)
             LU, P = lu_factor(A)
             assert_array_almost_equal(LU, np.array([[2, 1], [0, 1]]))
             assert_array_equal(P, np.array([0, 1]))
@@ -948,6 +971,7 @@ class TestLU(object):
 
 class TestLUSingle(TestLU):
     """LU testers for single precision, real and double"""
+
     def setup_method(self):
         TestLU.setup_method(self)
 
@@ -971,28 +995,23 @@ class TestLUSolve(object):
         seed(1234)
 
     def test_lu(self):
-        a0 = random((10,10))
+        a0 = random((10, 10))
         b = random((10,))
 
         for order in ['C', 'F']:
             a = np.array(a0, order=order)
-
-            x1 = solve(a,b)
-
+            x1 = solve(a, b)
             lu_a = lu_factor(a)
-            x2 = lu_solve(lu_a,b)
-
-            assert_array_almost_equal(x1,x2)
+            x2 = lu_solve(lu_a, b)
+            assert_array_almost_equal(x1, x2)
 
     def test_check_finite(self):
-        a = random((10,10))
+        a = random((10, 10))
         b = random((10,))
-        x1 = solve(a,b)
-
+        x1 = solve(a, b)
         lu_a = lu_factor(a, check_finite=False)
-        x2 = lu_solve(lu_a,b, check_finite=False)
-
-        assert_array_almost_equal(x1,x2)
+        x2 = lu_solve(lu_a, b, check_finite=False)
+        assert_array_almost_equal(x1, x2)
 
 
 class TestSVD_GESDD(object):
@@ -1005,95 +1024,97 @@ class TestSVD_GESDD(object):
         assert_raises(ValueError, svd, [[1.]], lapack_driver='foo')
 
     def test_simple(self):
-        a = [[1,2,3],[1,20,3],[2,5,6]]
+        a = [[1, 2, 3], [1, 20, 3], [2, 5, 6]]
         for full_matrices in (True, False):
-            u,s,vh = svd(a, full_matrices=full_matrices,
-                         lapack_driver=self.lapack_driver)
-            assert_array_almost_equal(dot(transpose(u),u),identity(3))
-            assert_array_almost_equal(dot(transpose(vh),vh),identity(3))
-            sigma = zeros((u.shape[0],vh.shape[0]),s.dtype.char)
+            u, s, vh = svd(a, full_matrices=full_matrices,
+                           lapack_driver=self.lapack_driver)
+            assert_array_almost_equal(u.T @ u, eye(3))
+            assert_array_almost_equal(vh.T @ vh, eye(3))
+            sigma = zeros((u.shape[0], vh.shape[0]), s.dtype.char)
             for i in range(len(s)):
-                sigma[i,i] = s[i]
-            assert_array_almost_equal(dot(dot(u,sigma),vh),a)
+                sigma[i, i] = s[i]
+            assert_array_almost_equal(u @ sigma @ vh, a)
 
     def test_simple_singular(self):
-        a = [[1,2,3],[1,2,3],[2,5,6]]
+        a = [[1, 2, 3], [1, 2, 3], [2, 5, 6]]
         for full_matrices in (True, False):
-            u,s,vh = svd(a, full_matrices=full_matrices,
-                         lapack_driver=self.lapack_driver)
-            assert_array_almost_equal(dot(transpose(u),u),identity(3))
-            assert_array_almost_equal(dot(transpose(vh),vh),identity(3))
-            sigma = zeros((u.shape[0],vh.shape[0]),s.dtype.char)
+            u, s, vh = svd(a, full_matrices=full_matrices,
+                           lapack_driver=self.lapack_driver)
+            assert_array_almost_equal(u.T @ u, eye(3))
+            assert_array_almost_equal(vh.T @ vh, eye(3))
+            sigma = zeros((u.shape[0], vh.shape[0]), s.dtype.char)
             for i in range(len(s)):
-                sigma[i,i] = s[i]
-            assert_array_almost_equal(dot(dot(u,sigma),vh),a)
+                sigma[i, i] = s[i]
+            assert_array_almost_equal(u @ sigma @ vh, a)
 
     def test_simple_underdet(self):
-        a = [[1,2,3],[4,5,6]]
+        a = [[1, 2, 3], [4, 5, 6]]
         for full_matrices in (True, False):
-            u,s,vh = svd(a, full_matrices=full_matrices,
-                         lapack_driver=self.lapack_driver)
-            assert_array_almost_equal(dot(transpose(u),u),identity(u.shape[0]))
-            sigma = zeros((u.shape[0],vh.shape[0]),s.dtype.char)
+            u, s, vh = svd(a, full_matrices=full_matrices,
+                           lapack_driver=self.lapack_driver)
+            assert_array_almost_equal(u.T @ u, eye(u.shape[0]))
+            sigma = zeros((u.shape[0], vh.shape[0]), s.dtype.char)
             for i in range(len(s)):
-                sigma[i,i] = s[i]
-            assert_array_almost_equal(dot(dot(u,sigma),vh),a)
+                sigma[i, i] = s[i]
+            assert_array_almost_equal(u @ sigma @ vh, a)
 
     def test_simple_overdet(self):
-        a = [[1,2],[4,5],[3,4]]
+        a = [[1, 2], [4, 5], [3, 4]]
         for full_matrices in (True, False):
-            u,s,vh = svd(a, full_matrices=full_matrices,
-                         lapack_driver=self.lapack_driver)
-            assert_array_almost_equal(dot(transpose(u),u), identity(u.shape[1]))
-            assert_array_almost_equal(dot(transpose(vh),vh),identity(2))
-            sigma = zeros((u.shape[1],vh.shape[0]),s.dtype.char)
+            u, s, vh = svd(a, full_matrices=full_matrices,
+                           lapack_driver=self.lapack_driver)
+            assert_array_almost_equal(u.T @ u, eye(u.shape[1]))
+            assert_array_almost_equal(vh.T @ vh, eye(2))
+            sigma = zeros((u.shape[1], vh.shape[0]), s.dtype.char)
             for i in range(len(s)):
-                sigma[i,i] = s[i]
-            assert_array_almost_equal(dot(dot(u,sigma),vh),a)
+                sigma[i, i] = s[i]
+            assert_array_almost_equal(u @ sigma @ vh, a)
 
     def test_random(self):
         n = 20
         m = 15
         for i in range(3):
-            for a in [random([n,m]),random([m,n])]:
+            for a in [random([n, m]), random([m, n])]:
                 for full_matrices in (True, False):
-                    u,s,vh = svd(a, full_matrices=full_matrices,
-                                 lapack_driver=self.lapack_driver)
-                    assert_array_almost_equal(dot(transpose(u),u),identity(u.shape[1]))
-                    assert_array_almost_equal(dot(vh, transpose(vh)),identity(vh.shape[0]))
-                    sigma = zeros((u.shape[1],vh.shape[0]),s.dtype.char)
+                    u, s, vh = svd(a, full_matrices=full_matrices,
+                                   lapack_driver=self.lapack_driver)
+                    assert_array_almost_equal(u.T @ u, eye(u.shape[1]))
+                    assert_array_almost_equal(vh @ vh.T, eye(vh.shape[0]))
+                    sigma = zeros((u.shape[1], vh.shape[0]), s.dtype.char)
                     for i in range(len(s)):
-                        sigma[i,i] = s[i]
-                    assert_array_almost_equal(dot(dot(u,sigma),vh),a)
+                        sigma[i, i] = s[i]
+                    assert_array_almost_equal(u @ sigma @ vh, a)
 
     def test_simple_complex(self):
-        a = [[1,2,3],[1,2j,3],[2,5,6]]
+        a = [[1, 2, 3], [1, 2j, 3], [2, 5, 6]]
         for full_matrices in (True, False):
-            u,s,vh = svd(a, full_matrices=full_matrices,
-                         lapack_driver=self.lapack_driver)
-            assert_array_almost_equal(dot(conj(transpose(u)),u),identity(u.shape[1]))
-            assert_array_almost_equal(dot(conj(transpose(vh)),vh),identity(vh.shape[0]))
-            sigma = zeros((u.shape[0],vh.shape[0]),s.dtype.char)
+            u, s, vh = svd(a, full_matrices=full_matrices,
+                           lapack_driver=self.lapack_driver)
+            assert_array_almost_equal(u.conj().T @ u, eye(u.shape[1]))
+            assert_array_almost_equal(vh.conj().T @ vh, eye(vh.shape[0]))
+            sigma = zeros((u.shape[0], vh.shape[0]), s.dtype.char)
             for i in range(len(s)):
-                sigma[i,i] = s[i]
-            assert_array_almost_equal(dot(dot(u,sigma),vh),a)
+                sigma[i, i] = s[i]
+            assert_array_almost_equal(u @ sigma @ vh, a)
 
     def test_random_complex(self):
         n = 20
         m = 15
         for i in range(3):
             for full_matrices in (True, False):
-                for a in [random([n,m]),random([m,n])]:
+                for a in [random([n, m]), random([m, n])]:
                     a = a + 1j*random(list(a.shape))
-                    u,s,vh = svd(a, full_matrices=full_matrices,
-                                 lapack_driver=self.lapack_driver)
-                    assert_array_almost_equal(dot(conj(transpose(u)),u),identity(u.shape[1]))
+                    u, s, vh = svd(a, full_matrices=full_matrices,
+                                   lapack_driver=self.lapack_driver)
+                    assert_array_almost_equal(u.conj().T @ u,
+                                              eye(u.shape[1]))
                     # This fails when [m,n]
-                    # assert_array_almost_equal(dot(conj(transpose(vh)),vh),identity(len(vh),dtype=vh.dtype.char))
-                    sigma = zeros((u.shape[1],vh.shape[0]),s.dtype.char)
+                    # assert_array_almost_equal(vh.conj().T @ vh,
+                    #                        eye(len(vh),dtype=vh.dtype.char))
+                    sigma = zeros((u.shape[1], vh.shape[0]), s.dtype.char)
                     for i in range(len(s)):
-                        sigma[i,i] = s[i]
-                    assert_array_almost_equal(dot(dot(u,sigma),vh),a)
+                        sigma[i, i] = s[i]
+                    assert_array_almost_equal(u @ sigma @ vh, a)
 
     def test_crash_1580(self):
         sizes = [(13, 23), (30, 50), (60, 100)]
@@ -1105,14 +1126,14 @@ class TestSVD_GESDD(object):
                 svd(a, lapack_driver=self.lapack_driver)
 
     def test_check_finite(self):
-        a = [[1,2,3],[1,20,3],[2,5,6]]
-        u,s,vh = svd(a, check_finite=False, lapack_driver=self.lapack_driver)
-        assert_array_almost_equal(dot(transpose(u),u),identity(3))
-        assert_array_almost_equal(dot(transpose(vh),vh),identity(3))
-        sigma = zeros((u.shape[0],vh.shape[0]),s.dtype.char)
+        a = [[1, 2, 3], [1, 20, 3], [2, 5, 6]]
+        u, s, vh = svd(a, check_finite=False, lapack_driver=self.lapack_driver)
+        assert_array_almost_equal(u.T @ u, eye(3))
+        assert_array_almost_equal(vh.T @ vh, eye(3))
+        sigma = zeros((u.shape[0], vh.shape[0]), s.dtype.char)
         for i in range(len(s)):
-            sigma[i,i] = s[i]
-        assert_array_almost_equal(dot(dot(u,sigma),vh),a)
+            sigma[i, i] = s[i]
+        assert_array_almost_equal(u @ sigma @ vh, a)
 
     def test_gh_5039(self):
         # This is a smoke test for https://github.com/scipy/scipy/issues/5039
@@ -1146,43 +1167,43 @@ class TestSVDVals(object):
             assert_equal(s, np.empty(0))
 
     def test_simple(self):
-        a = [[1,2,3],[1,2,3],[2,5,6]]
+        a = [[1, 2, 3], [1, 2, 3], [2, 5, 6]]
         s = svdvals(a)
         assert_(len(s) == 3)
         assert_(s[0] >= s[1] >= s[2])
 
     def test_simple_underdet(self):
-        a = [[1,2,3],[4,5,6]]
+        a = [[1, 2, 3], [4, 5, 6]]
         s = svdvals(a)
         assert_(len(s) == 2)
         assert_(s[0] >= s[1])
 
     def test_simple_overdet(self):
-        a = [[1,2],[4,5],[3,4]]
+        a = [[1, 2], [4, 5], [3, 4]]
         s = svdvals(a)
         assert_(len(s) == 2)
         assert_(s[0] >= s[1])
 
     def test_simple_complex(self):
-        a = [[1,2,3],[1,20,3j],[2,5,6]]
+        a = [[1, 2, 3], [1, 20, 3j], [2, 5, 6]]
         s = svdvals(a)
         assert_(len(s) == 3)
         assert_(s[0] >= s[1] >= s[2])
 
     def test_simple_underdet_complex(self):
-        a = [[1,2,3],[4,5j,6]]
+        a = [[1, 2, 3], [4, 5j, 6]]
         s = svdvals(a)
         assert_(len(s) == 2)
         assert_(s[0] >= s[1])
 
     def test_simple_overdet_complex(self):
-        a = [[1,2],[4,5],[3j,4]]
+        a = [[1, 2], [4, 5], [3j, 4]]
         s = svdvals(a)
         assert_(len(s) == 2)
         assert_(s[0] >= s[1])
 
     def test_check_finite(self):
-        a = [[1,2,3],[1,2,3],[2,5,6]]
+        a = [[1, 2, 3], [1, 2, 3], [2, 5, 6]]
         s = svdvals(a, check_finite=False)
         assert_(len(s) == 3)
         assert_(s[0] >= s[1] >= s[2])
@@ -1198,7 +1219,8 @@ class TestSVDVals(object):
 class TestDiagSVD(object):
 
     def test_simple(self):
-        assert_array_almost_equal(diagsvd([1,0,0],3,3),[[1,0,0],[0,0,0],[0,0,0]])
+        assert_array_almost_equal(diagsvd([1, 0, 0], 3, 3),
+                                  [[1, 0, 0], [0, 0, 0], [0, 0, 0]])
 
 
 class TestQR(object):
@@ -1207,386 +1229,386 @@ class TestQR(object):
         seed(1234)
 
     def test_simple(self):
-        a = [[8,2,3],[2,9,3],[5,3,6]]
-        q,r = qr(a)
-        assert_array_almost_equal(dot(transpose(q),q),identity(3))
-        assert_array_almost_equal(dot(q,r),a)
+        a = [[8, 2, 3], [2, 9, 3], [5, 3, 6]]
+        q, r = qr(a)
+        assert_array_almost_equal(q.T @ q, eye(3))
+        assert_array_almost_equal(q @ r, a)
 
     def test_simple_left(self):
-        a = [[8,2,3],[2,9,3],[5,3,6]]
-        q,r = qr(a)
+        a = [[8, 2, 3], [2, 9, 3], [5, 3, 6]]
+        q, r = qr(a)
         c = [1, 2, 3]
-        qc,r2 = qr_multiply(a, c, "left")
-        assert_array_almost_equal(dot(q, c), qc)
+        qc, r2 = qr_multiply(a, c, "left")
+        assert_array_almost_equal(q @ c, qc)
         assert_array_almost_equal(r, r2)
-        qc,r2 = qr_multiply(a, identity(3), "left")
+        qc, r2 = qr_multiply(a, eye(3), "left")
         assert_array_almost_equal(q, qc)
 
     def test_simple_right(self):
-        a = [[8,2,3],[2,9,3],[5,3,6]]
-        q,r = qr(a)
+        a = [[8, 2, 3], [2, 9, 3], [5, 3, 6]]
+        q, r = qr(a)
         c = [1, 2, 3]
-        qc,r2 = qr_multiply(a, c)
-        assert_array_almost_equal(dot(c, q), qc)
+        qc, r2 = qr_multiply(a, c)
+        assert_array_almost_equal(c @ q, qc)
         assert_array_almost_equal(r, r2)
-        qc,r = qr_multiply(a, identity(3))
+        qc, r = qr_multiply(a, eye(3))
         assert_array_almost_equal(q, qc)
 
     def test_simple_pivoting(self):
-        a = np.asarray([[8,2,3],[2,9,3],[5,3,6]])
-        q,r,p = qr(a, pivoting=True)
+        a = np.asarray([[8, 2, 3], [2, 9, 3], [5, 3, 6]])
+        q, r, p = qr(a, pivoting=True)
         d = abs(diag(r))
         assert_(np.all(d[1:] <= d[:-1]))
-        assert_array_almost_equal(dot(transpose(q),q),identity(3))
-        assert_array_almost_equal(dot(q,r),a[:,p])
-        q2,r2 = qr(a[:,p])
-        assert_array_almost_equal(q,q2)
-        assert_array_almost_equal(r,r2)
+        assert_array_almost_equal(q.T @ q, eye(3))
+        assert_array_almost_equal(q @ r, a[:, p])
+        q2, r2 = qr(a[:, p])
+        assert_array_almost_equal(q, q2)
+        assert_array_almost_equal(r, r2)
 
     def test_simple_left_pivoting(self):
-        a = [[8,2,3],[2,9,3],[5,3,6]]
-        q,r,jpvt = qr(a, pivoting=True)
+        a = [[8, 2, 3], [2, 9, 3], [5, 3, 6]]
+        q, r, jpvt = qr(a, pivoting=True)
         c = [1, 2, 3]
-        qc,r,jpvt = qr_multiply(a, c, "left", True)
-        assert_array_almost_equal(dot(q, c), qc)
+        qc, r, jpvt = qr_multiply(a, c, "left", True)
+        assert_array_almost_equal(q @ c, qc)
 
     def test_simple_right_pivoting(self):
-        a = [[8,2,3],[2,9,3],[5,3,6]]
-        q,r,jpvt = qr(a, pivoting=True)
+        a = [[8, 2, 3], [2, 9, 3], [5, 3, 6]]
+        q, r, jpvt = qr(a, pivoting=True)
         c = [1, 2, 3]
-        qc,r,jpvt = qr_multiply(a, c, pivoting=True)
-        assert_array_almost_equal(dot(c, q), qc)
+        qc, r, jpvt = qr_multiply(a, c, pivoting=True)
+        assert_array_almost_equal(c @ q, qc)
 
     def test_simple_trap(self):
-        a = [[8,2,3],[2,9,3]]
-        q,r = qr(a)
-        assert_array_almost_equal(dot(transpose(q),q),identity(2))
-        assert_array_almost_equal(dot(q,r),a)
+        a = [[8, 2, 3], [2, 9, 3]]
+        q, r = qr(a)
+        assert_array_almost_equal(q.T @ q, eye(2))
+        assert_array_almost_equal(q @ r, a)
 
     def test_simple_trap_pivoting(self):
-        a = np.asarray([[8,2,3],[2,9,3]])
-        q,r,p = qr(a, pivoting=True)
+        a = np.asarray([[8, 2, 3], [2, 9, 3]])
+        q, r, p = qr(a, pivoting=True)
         d = abs(diag(r))
         assert_(np.all(d[1:] <= d[:-1]))
-        assert_array_almost_equal(dot(transpose(q),q),identity(2))
-        assert_array_almost_equal(dot(q,r),a[:,p])
-        q2,r2 = qr(a[:,p])
-        assert_array_almost_equal(q,q2)
-        assert_array_almost_equal(r,r2)
+        assert_array_almost_equal(q.T @ q, eye(2))
+        assert_array_almost_equal(q @ r, a[:, p])
+        q2, r2 = qr(a[:, p])
+        assert_array_almost_equal(q, q2)
+        assert_array_almost_equal(r, r2)
 
     def test_simple_tall(self):
         # full version
-        a = [[8,2],[2,9],[5,3]]
-        q,r = qr(a)
-        assert_array_almost_equal(dot(transpose(q),q),identity(3))
-        assert_array_almost_equal(dot(q,r),a)
+        a = [[8, 2], [2, 9], [5, 3]]
+        q, r = qr(a)
+        assert_array_almost_equal(q.T @ q, eye(3))
+        assert_array_almost_equal(q @ r, a)
 
     def test_simple_tall_pivoting(self):
         # full version pivoting
-        a = np.asarray([[8,2],[2,9],[5,3]])
-        q,r,p = qr(a, pivoting=True)
+        a = np.asarray([[8, 2], [2, 9], [5, 3]])
+        q, r, p = qr(a, pivoting=True)
         d = abs(diag(r))
         assert_(np.all(d[1:] <= d[:-1]))
-        assert_array_almost_equal(dot(transpose(q),q),identity(3))
-        assert_array_almost_equal(dot(q,r),a[:,p])
-        q2,r2 = qr(a[:,p])
-        assert_array_almost_equal(q,q2)
-        assert_array_almost_equal(r,r2)
+        assert_array_almost_equal(q.T @ q, eye(3))
+        assert_array_almost_equal(q @ r, a[:, p])
+        q2, r2 = qr(a[:, p])
+        assert_array_almost_equal(q, q2)
+        assert_array_almost_equal(r, r2)
 
     def test_simple_tall_e(self):
         # economy version
-        a = [[8,2],[2,9],[5,3]]
-        q,r = qr(a, mode='economic')
-        assert_array_almost_equal(dot(transpose(q),q),identity(2))
-        assert_array_almost_equal(dot(q,r),a)
-        assert_equal(q.shape, (3,2))
-        assert_equal(r.shape, (2,2))
+        a = [[8, 2], [2, 9], [5, 3]]
+        q, r = qr(a, mode='economic')
+        assert_array_almost_equal(q.T @ q, eye(2))
+        assert_array_almost_equal(q @ r, a)
+        assert_equal(q.shape, (3, 2))
+        assert_equal(r.shape, (2, 2))
 
     def test_simple_tall_e_pivoting(self):
         # economy version pivoting
-        a = np.asarray([[8,2],[2,9],[5,3]])
-        q,r,p = qr(a, pivoting=True, mode='economic')
+        a = np.asarray([[8, 2], [2, 9], [5, 3]])
+        q, r, p = qr(a, pivoting=True, mode='economic')
         d = abs(diag(r))
         assert_(np.all(d[1:] <= d[:-1]))
-        assert_array_almost_equal(dot(transpose(q),q),identity(2))
-        assert_array_almost_equal(dot(q,r),a[:,p])
-        q2,r2 = qr(a[:,p], mode='economic')
-        assert_array_almost_equal(q,q2)
-        assert_array_almost_equal(r,r2)
+        assert_array_almost_equal(q.T @ q, eye(2))
+        assert_array_almost_equal(q @ r, a[:, p])
+        q2, r2 = qr(a[:, p], mode='economic')
+        assert_array_almost_equal(q, q2)
+        assert_array_almost_equal(r, r2)
 
     def test_simple_tall_left(self):
-        a = [[8,2],[2,9],[5,3]]
-        q,r = qr(a, mode="economic")
+        a = [[8, 2], [2, 9], [5, 3]]
+        q, r = qr(a, mode="economic")
         c = [1, 2]
-        qc,r2 = qr_multiply(a, c, "left")
-        assert_array_almost_equal(dot(q, c), qc)
+        qc, r2 = qr_multiply(a, c, "left")
+        assert_array_almost_equal(q @ c, qc)
         assert_array_almost_equal(r, r2)
-        c = array([1,2,0])
-        qc,r2 = qr_multiply(a, c, "left", overwrite_c=True)
-        assert_array_almost_equal(dot(q, c[:2]), qc)
-        qc,r = qr_multiply(a, identity(2), "left")
+        c = array([1, 2, 0])
+        qc, r2 = qr_multiply(a, c, "left", overwrite_c=True)
+        assert_array_almost_equal(q @ c[:2], qc)
+        qc, r = qr_multiply(a, eye(2), "left")
         assert_array_almost_equal(qc, q)
 
     def test_simple_tall_left_pivoting(self):
-        a = [[8,2],[2,9],[5,3]]
-        q,r,jpvt = qr(a, mode="economic", pivoting=True)
+        a = [[8, 2], [2, 9], [5, 3]]
+        q, r, jpvt = qr(a, mode="economic", pivoting=True)
         c = [1, 2]
-        qc,r,kpvt = qr_multiply(a, c, "left", True)
+        qc, r, kpvt = qr_multiply(a, c, "left", True)
         assert_array_equal(jpvt, kpvt)
-        assert_array_almost_equal(dot(q, c), qc)
-        qc,r,jpvt = qr_multiply(a, identity(2), "left", True)
+        assert_array_almost_equal(q @ c, qc)
+        qc, r, jpvt = qr_multiply(a, eye(2), "left", True)
         assert_array_almost_equal(qc, q)
 
     def test_simple_tall_right(self):
-        a = [[8,2],[2,9],[5,3]]
-        q,r = qr(a, mode="economic")
+        a = [[8, 2], [2, 9], [5, 3]]
+        q, r = qr(a, mode="economic")
         c = [1, 2, 3]
-        cq,r2 = qr_multiply(a, c)
-        assert_array_almost_equal(dot(c, q), cq)
+        cq, r2 = qr_multiply(a, c)
+        assert_array_almost_equal(c @ q, cq)
         assert_array_almost_equal(r, r2)
-        cq,r = qr_multiply(a, identity(3))
+        cq, r = qr_multiply(a, eye(3))
         assert_array_almost_equal(cq, q)
 
     def test_simple_tall_right_pivoting(self):
-        a = [[8,2],[2,9],[5,3]]
-        q,r,jpvt = qr(a, pivoting=True, mode="economic")
+        a = [[8, 2], [2, 9], [5, 3]]
+        q, r, jpvt = qr(a, pivoting=True, mode="economic")
         c = [1, 2, 3]
-        cq,r,jpvt = qr_multiply(a, c, pivoting=True)
-        assert_array_almost_equal(dot(c, q), cq)
-        cq,r,jpvt = qr_multiply(a, identity(3), pivoting=True)
+        cq, r, jpvt = qr_multiply(a, c, pivoting=True)
+        assert_array_almost_equal(c @ q, cq)
+        cq, r, jpvt = qr_multiply(a, eye(3), pivoting=True)
         assert_array_almost_equal(cq, q)
 
     def test_simple_fat(self):
         # full version
-        a = [[8,2,5],[2,9,3]]
-        q,r = qr(a)
-        assert_array_almost_equal(dot(transpose(q),q),identity(2))
-        assert_array_almost_equal(dot(q,r),a)
-        assert_equal(q.shape, (2,2))
-        assert_equal(r.shape, (2,3))
+        a = [[8, 2, 5], [2, 9, 3]]
+        q, r = qr(a)
+        assert_array_almost_equal(q.T @ q, eye(2))
+        assert_array_almost_equal(q @ r, a)
+        assert_equal(q.shape, (2, 2))
+        assert_equal(r.shape, (2, 3))
 
     def test_simple_fat_pivoting(self):
         # full version pivoting
-        a = np.asarray([[8,2,5],[2,9,3]])
-        q,r,p = qr(a, pivoting=True)
+        a = np.asarray([[8, 2, 5], [2, 9, 3]])
+        q, r, p = qr(a, pivoting=True)
         d = abs(diag(r))
         assert_(np.all(d[1:] <= d[:-1]))
-        assert_array_almost_equal(dot(transpose(q),q),identity(2))
-        assert_array_almost_equal(dot(q,r),a[:,p])
-        assert_equal(q.shape, (2,2))
-        assert_equal(r.shape, (2,3))
-        q2,r2 = qr(a[:,p])
-        assert_array_almost_equal(q,q2)
-        assert_array_almost_equal(r,r2)
+        assert_array_almost_equal(q.T @ q, eye(2))
+        assert_array_almost_equal(q @ r, a[:, p])
+        assert_equal(q.shape, (2, 2))
+        assert_equal(r.shape, (2, 3))
+        q2, r2 = qr(a[:, p])
+        assert_array_almost_equal(q, q2)
+        assert_array_almost_equal(r, r2)
 
     def test_simple_fat_e(self):
         # economy version
-        a = [[8,2,3],[2,9,5]]
-        q,r = qr(a, mode='economic')
-        assert_array_almost_equal(dot(transpose(q),q),identity(2))
-        assert_array_almost_equal(dot(q,r),a)
-        assert_equal(q.shape, (2,2))
-        assert_equal(r.shape, (2,3))
+        a = [[8, 2, 3], [2, 9, 5]]
+        q, r = qr(a, mode='economic')
+        assert_array_almost_equal(q.T @ q, eye(2))
+        assert_array_almost_equal(q @ r, a)
+        assert_equal(q.shape, (2, 2))
+        assert_equal(r.shape, (2, 3))
 
     def test_simple_fat_e_pivoting(self):
         # economy version pivoting
-        a = np.asarray([[8,2,3],[2,9,5]])
-        q,r,p = qr(a, pivoting=True, mode='economic')
+        a = np.asarray([[8, 2, 3], [2, 9, 5]])
+        q, r, p = qr(a, pivoting=True, mode='economic')
         d = abs(diag(r))
         assert_(np.all(d[1:] <= d[:-1]))
-        assert_array_almost_equal(dot(transpose(q),q),identity(2))
-        assert_array_almost_equal(dot(q,r),a[:,p])
-        assert_equal(q.shape, (2,2))
-        assert_equal(r.shape, (2,3))
-        q2,r2 = qr(a[:,p], mode='economic')
-        assert_array_almost_equal(q,q2)
-        assert_array_almost_equal(r,r2)
+        assert_array_almost_equal(q.T @ q, eye(2))
+        assert_array_almost_equal(q @ r, a[:, p])
+        assert_equal(q.shape, (2, 2))
+        assert_equal(r.shape, (2, 3))
+        q2, r2 = qr(a[:, p], mode='economic')
+        assert_array_almost_equal(q, q2)
+        assert_array_almost_equal(r, r2)
 
     def test_simple_fat_left(self):
-        a = [[8,2,3],[2,9,5]]
-        q,r = qr(a, mode="economic")
+        a = [[8, 2, 3], [2, 9, 5]]
+        q, r = qr(a, mode="economic")
         c = [1, 2]
-        qc,r2 = qr_multiply(a, c, "left")
-        assert_array_almost_equal(dot(q, c), qc)
+        qc, r2 = qr_multiply(a, c, "left")
+        assert_array_almost_equal(q @ c, qc)
         assert_array_almost_equal(r, r2)
-        qc,r = qr_multiply(a, identity(2), "left")
+        qc, r = qr_multiply(a, eye(2), "left")
         assert_array_almost_equal(qc, q)
 
     def test_simple_fat_left_pivoting(self):
-        a = [[8,2,3],[2,9,5]]
-        q,r,jpvt = qr(a, mode="economic", pivoting=True)
+        a = [[8, 2, 3], [2, 9, 5]]
+        q, r, jpvt = qr(a, mode="economic", pivoting=True)
         c = [1, 2]
-        qc,r,jpvt = qr_multiply(a, c, "left", True)
-        assert_array_almost_equal(dot(q, c), qc)
-        qc,r,jpvt = qr_multiply(a, identity(2), "left", True)
+        qc, r, jpvt = qr_multiply(a, c, "left", True)
+        assert_array_almost_equal(q @ c, qc)
+        qc, r, jpvt = qr_multiply(a, eye(2), "left", True)
         assert_array_almost_equal(qc, q)
 
     def test_simple_fat_right(self):
-        a = [[8,2,3],[2,9,5]]
-        q,r = qr(a, mode="economic")
+        a = [[8, 2, 3], [2, 9, 5]]
+        q, r = qr(a, mode="economic")
         c = [1, 2]
-        cq,r2 = qr_multiply(a, c)
-        assert_array_almost_equal(dot(c, q), cq)
+        cq, r2 = qr_multiply(a, c)
+        assert_array_almost_equal(c @ q, cq)
         assert_array_almost_equal(r, r2)
-        cq,r = qr_multiply(a, identity(2))
+        cq, r = qr_multiply(a, eye(2))
         assert_array_almost_equal(cq, q)
 
     def test_simple_fat_right_pivoting(self):
-        a = [[8,2,3],[2,9,5]]
-        q,r,jpvt = qr(a, pivoting=True, mode="economic")
+        a = [[8, 2, 3], [2, 9, 5]]
+        q, r, jpvt = qr(a, pivoting=True, mode="economic")
         c = [1, 2]
-        cq,r,jpvt = qr_multiply(a, c, pivoting=True)
-        assert_array_almost_equal(dot(c, q), cq)
-        cq,r,jpvt = qr_multiply(a, identity(2), pivoting=True)
+        cq, r, jpvt = qr_multiply(a, c, pivoting=True)
+        assert_array_almost_equal(c @ q, cq)
+        cq, r, jpvt = qr_multiply(a, eye(2), pivoting=True)
         assert_array_almost_equal(cq, q)
 
     def test_simple_complex(self):
-        a = [[3,3+4j,5],[5,2,2+7j],[3,2,7]]
-        q,r = qr(a)
-        assert_array_almost_equal(dot(conj(transpose(q)),q),identity(3))
-        assert_array_almost_equal(dot(q,r),a)
+        a = [[3, 3+4j, 5], [5, 2, 2+7j], [3, 2, 7]]
+        q, r = qr(a)
+        assert_array_almost_equal(q.conj().T @ q, eye(3))
+        assert_array_almost_equal(q @ r, a)
 
     def test_simple_complex_left(self):
-        a = [[3,3+4j,5],[5,2,2+7j],[3,2,7]]
-        q,r = qr(a)
+        a = [[3, 3+4j, 5], [5, 2, 2+7j], [3, 2, 7]]
+        q, r = qr(a)
         c = [1, 2, 3+4j]
-        qc,r = qr_multiply(a, c, "left")
-        assert_array_almost_equal(dot(q, c), qc)
-        qc,r = qr_multiply(a, identity(3), "left")
+        qc, r = qr_multiply(a, c, "left")
+        assert_array_almost_equal(q @ c, qc)
+        qc, r = qr_multiply(a, eye(3), "left")
         assert_array_almost_equal(q, qc)
 
     def test_simple_complex_right(self):
-        a = [[3,3+4j,5],[5,2,2+7j],[3,2,7]]
-        q,r = qr(a)
+        a = [[3, 3+4j, 5], [5, 2, 2+7j], [3, 2, 7]]
+        q, r = qr(a)
         c = [1, 2, 3+4j]
-        qc,r = qr_multiply(a, c)
-        assert_array_almost_equal(dot(c, q), qc)
-        qc,r = qr_multiply(a, identity(3))
+        qc, r = qr_multiply(a, c)
+        assert_array_almost_equal(c @ q, qc)
+        qc, r = qr_multiply(a, eye(3))
         assert_array_almost_equal(q, qc)
 
     def test_simple_tall_complex_left(self):
-        a = [[8,2+3j],[2,9],[5+7j,3]]
-        q,r = qr(a, mode="economic")
+        a = [[8, 2+3j], [2, 9], [5+7j, 3]]
+        q, r = qr(a, mode="economic")
         c = [1, 2+2j]
-        qc,r2 = qr_multiply(a, c, "left")
-        assert_array_almost_equal(dot(q, c), qc)
+        qc, r2 = qr_multiply(a, c, "left")
+        assert_array_almost_equal(q @ c, qc)
         assert_array_almost_equal(r, r2)
-        c = array([1,2,0])
-        qc,r2 = qr_multiply(a, c, "left", overwrite_c=True)
-        assert_array_almost_equal(dot(q, c[:2]), qc)
-        qc,r = qr_multiply(a, identity(2), "left")
+        c = array([1, 2, 0])
+        qc, r2 = qr_multiply(a, c, "left", overwrite_c=True)
+        assert_array_almost_equal(q @ c[:2], qc)
+        qc, r = qr_multiply(a, eye(2), "left")
         assert_array_almost_equal(qc, q)
 
     def test_simple_complex_left_conjugate(self):
-        a = [[3,3+4j,5],[5,2,2+7j],[3,2,7]]
-        q,r = qr(a)
+        a = [[3, 3+4j, 5], [5, 2, 2+7j], [3, 2, 7]]
+        q, r = qr(a)
         c = [1, 2, 3+4j]
-        qc,r = qr_multiply(a, c, "left", conjugate=True)
-        assert_array_almost_equal(dot(q.conjugate(), c), qc)
+        qc, r = qr_multiply(a, c, "left", conjugate=True)
+        assert_array_almost_equal(q.conj() @ c, qc)
 
     def test_simple_complex_tall_left_conjugate(self):
-        a = [[3,3+4j],[5,2+2j],[3,2]]
-        q,r = qr(a, mode='economic')
+        a = [[3, 3+4j], [5, 2+2j], [3, 2]]
+        q, r = qr(a, mode='economic')
         c = [1, 3+4j]
-        qc,r = qr_multiply(a, c, "left", conjugate=True)
-        assert_array_almost_equal(dot(q.conjugate(), c), qc)
+        qc, r = qr_multiply(a, c, "left", conjugate=True)
+        assert_array_almost_equal(q.conj() @ c, qc)
 
     def test_simple_complex_right_conjugate(self):
-        a = [[3,3+4j,5],[5,2,2+7j],[3,2,7]]
-        q,r = qr(a)
-        c = [1, 2, 3+4j]
-        qc,r = qr_multiply(a, c, conjugate=True)
-        assert_array_almost_equal(dot(c, q.conjugate()), qc)
+        a = [[3, 3+4j, 5], [5, 2, 2+7j], [3, 2, 7]]
+        q, r = qr(a)
+        c = np.array([1, 2, 3+4j])
+        qc, r = qr_multiply(a, c, conjugate=True)
+        assert_array_almost_equal(c @ q.conj(), qc)
 
     def test_simple_complex_pivoting(self):
-        a = np.asarray([[3,3+4j,5],[5,2,2+7j],[3,2,7]])
-        q,r,p = qr(a, pivoting=True)
+        a = array([[3, 3+4j, 5], [5, 2, 2+7j], [3, 2, 7]])
+        q, r, p = qr(a, pivoting=True)
         d = abs(diag(r))
         assert_(np.all(d[1:] <= d[:-1]))
-        assert_array_almost_equal(dot(conj(transpose(q)),q),identity(3))
-        assert_array_almost_equal(dot(q,r),a[:,p])
-        q2,r2 = qr(a[:,p])
-        assert_array_almost_equal(q,q2)
-        assert_array_almost_equal(r,r2)
+        assert_array_almost_equal(q.conj().T @ q, eye(3))
+        assert_array_almost_equal(q @ r, a[:, p])
+        q2, r2 = qr(a[:, p])
+        assert_array_almost_equal(q, q2)
+        assert_array_almost_equal(r, r2)
 
     def test_simple_complex_left_pivoting(self):
-        a = np.asarray([[3,3+4j,5],[5,2,2+7j],[3,2,7]])
-        q,r,jpvt = qr(a, pivoting=True)
+        a = array([[3, 3+4j, 5], [5, 2, 2+7j], [3, 2, 7]])
+        q, r, jpvt = qr(a, pivoting=True)
         c = [1, 2, 3+4j]
-        qc,r,jpvt = qr_multiply(a, c, "left", True)
-        assert_array_almost_equal(dot(q, c), qc)
+        qc, r, jpvt = qr_multiply(a, c, "left", True)
+        assert_array_almost_equal(q @ c, qc)
 
     def test_simple_complex_right_pivoting(self):
-        a = np.asarray([[3,3+4j,5],[5,2,2+7j],[3,2,7]])
-        q,r,jpvt = qr(a, pivoting=True)
+        a = array([[3, 3+4j, 5], [5, 2, 2+7j], [3, 2, 7]])
+        q, r, jpvt = qr(a, pivoting=True)
         c = [1, 2, 3+4j]
-        qc,r,jpvt = qr_multiply(a, c, pivoting=True)
-        assert_array_almost_equal(dot(c, q), qc)
+        qc, r, jpvt = qr_multiply(a, c, pivoting=True)
+        assert_array_almost_equal(c @ q, qc)
 
     def test_random(self):
         n = 20
         for k in range(2):
-            a = random([n,n])
-            q,r = qr(a)
-            assert_array_almost_equal(dot(transpose(q),q),identity(n))
-            assert_array_almost_equal(dot(q,r),a)
+            a = random([n, n])
+            q, r = qr(a)
+            assert_array_almost_equal(q.T @ q, eye(n))
+            assert_array_almost_equal(q @ r, a)
 
     def test_random_left(self):
         n = 20
         for k in range(2):
-            a = random([n,n])
-            q,r = qr(a)
+            a = random([n, n])
+            q, r = qr(a)
             c = random([n])
-            qc,r = qr_multiply(a, c, "left")
-            assert_array_almost_equal(dot(q, c), qc)
-            qc,r = qr_multiply(a, identity(n), "left")
+            qc, r = qr_multiply(a, c, "left")
+            assert_array_almost_equal(q @ c, qc)
+            qc, r = qr_multiply(a, eye(n), "left")
             assert_array_almost_equal(q, qc)
 
     def test_random_right(self):
         n = 20
         for k in range(2):
-            a = random([n,n])
-            q,r = qr(a)
+            a = random([n, n])
+            q, r = qr(a)
             c = random([n])
-            cq,r = qr_multiply(a, c)
-            assert_array_almost_equal(dot(c, q), cq)
-            cq,r = qr_multiply(a, identity(n))
+            cq, r = qr_multiply(a, c)
+            assert_array_almost_equal(c @ q, cq)
+            cq, r = qr_multiply(a, eye(n))
             assert_array_almost_equal(q, cq)
 
     def test_random_pivoting(self):
         n = 20
         for k in range(2):
-            a = random([n,n])
-            q,r,p = qr(a, pivoting=True)
+            a = random([n, n])
+            q, r, p = qr(a, pivoting=True)
             d = abs(diag(r))
             assert_(np.all(d[1:] <= d[:-1]))
-            assert_array_almost_equal(dot(transpose(q),q),identity(n))
-            assert_array_almost_equal(dot(q,r),a[:,p])
-            q2,r2 = qr(a[:,p])
-            assert_array_almost_equal(q,q2)
-            assert_array_almost_equal(r,r2)
+            assert_array_almost_equal(q.T @ q, eye(n))
+            assert_array_almost_equal(q @ r, a[:, p])
+            q2, r2 = qr(a[:, p])
+            assert_array_almost_equal(q, q2)
+            assert_array_almost_equal(r, r2)
 
     def test_random_tall(self):
         # full version
         m = 200
         n = 100
         for k in range(2):
-            a = random([m,n])
-            q,r = qr(a)
-            assert_array_almost_equal(dot(transpose(q),q),identity(m))
-            assert_array_almost_equal(dot(q,r),a)
+            a = random([m, n])
+            q, r = qr(a)
+            assert_array_almost_equal(q.T @ q, eye(m))
+            assert_array_almost_equal(q @ r, a)
 
     def test_random_tall_left(self):
         # full version
         m = 200
         n = 100
         for k in range(2):
-            a = random([m,n])
-            q,r = qr(a, mode="economic")
+            a = random([m, n])
+            q, r = qr(a, mode="economic")
             c = random([n])
-            qc,r = qr_multiply(a, c, "left")
-            assert_array_almost_equal(dot(q, c), qc)
-            qc,r = qr_multiply(a, identity(n), "left")
+            qc, r = qr_multiply(a, c, "left")
+            assert_array_almost_equal(q @ c, qc)
+            qc, r = qr_multiply(a, eye(n), "left")
             assert_array_almost_equal(qc, q)
 
     def test_random_tall_right(self):
@@ -1594,12 +1616,12 @@ class TestQR(object):
         m = 200
         n = 100
         for k in range(2):
-            a = random([m,n])
-            q,r = qr(a, mode="economic")
+            a = random([m, n])
+            q, r = qr(a, mode="economic")
             c = random([m])
-            cq,r = qr_multiply(a, c)
-            assert_array_almost_equal(dot(c, q), cq)
-            cq,r = qr_multiply(a, identity(m))
+            cq, r = qr_multiply(a, c)
+            assert_array_almost_equal(c @ q, cq)
+            cq, r = qr_multiply(a, eye(m))
             assert_array_almost_equal(cq, q)
 
     def test_random_tall_pivoting(self):
@@ -1607,140 +1629,141 @@ class TestQR(object):
         m = 200
         n = 100
         for k in range(2):
-            a = random([m,n])
-            q,r,p = qr(a, pivoting=True)
+            a = random([m, n])
+            q, r, p = qr(a, pivoting=True)
             d = abs(diag(r))
             assert_(np.all(d[1:] <= d[:-1]))
-            assert_array_almost_equal(dot(transpose(q),q),identity(m))
-            assert_array_almost_equal(dot(q,r),a[:,p])
-            q2,r2 = qr(a[:,p])
-            assert_array_almost_equal(q,q2)
-            assert_array_almost_equal(r,r2)
+            assert_array_almost_equal(q.T @ q, eye(m))
+            assert_array_almost_equal(q @ r, a[:, p])
+            q2, r2 = qr(a[:, p])
+            assert_array_almost_equal(q, q2)
+            assert_array_almost_equal(r, r2)
 
     def test_random_tall_e(self):
         # economy version
         m = 200
         n = 100
         for k in range(2):
-            a = random([m,n])
-            q,r = qr(a, mode='economic')
-            assert_array_almost_equal(dot(transpose(q),q),identity(n))
-            assert_array_almost_equal(dot(q,r),a)
-            assert_equal(q.shape, (m,n))
-            assert_equal(r.shape, (n,n))
+            a = random([m, n])
+            q, r = qr(a, mode='economic')
+            assert_array_almost_equal(q.T @ q, eye(n))
+            assert_array_almost_equal(q @ r, a)
+            assert_equal(q.shape, (m, n))
+            assert_equal(r.shape, (n, n))
 
     def test_random_tall_e_pivoting(self):
         # economy version pivoting
         m = 200
         n = 100
         for k in range(2):
-            a = random([m,n])
-            q,r,p = qr(a, pivoting=True, mode='economic')
+            a = random([m, n])
+            q, r, p = qr(a, pivoting=True, mode='economic')
             d = abs(diag(r))
             assert_(np.all(d[1:] <= d[:-1]))
-            assert_array_almost_equal(dot(transpose(q),q),identity(n))
-            assert_array_almost_equal(dot(q,r),a[:,p])
-            assert_equal(q.shape, (m,n))
-            assert_equal(r.shape, (n,n))
-            q2,r2 = qr(a[:,p], mode='economic')
-            assert_array_almost_equal(q,q2)
-            assert_array_almost_equal(r,r2)
+            assert_array_almost_equal(q.T @ q, eye(n))
+            assert_array_almost_equal(q @ r, a[:, p])
+            assert_equal(q.shape, (m, n))
+            assert_equal(r.shape, (n, n))
+            q2, r2 = qr(a[:, p], mode='economic')
+            assert_array_almost_equal(q, q2)
+            assert_array_almost_equal(r, r2)
 
     def test_random_trap(self):
         m = 100
         n = 200
         for k in range(2):
-            a = random([m,n])
-            q,r = qr(a)
-            assert_array_almost_equal(dot(transpose(q),q),identity(m))
-            assert_array_almost_equal(dot(q,r),a)
+            a = random([m, n])
+            q, r = qr(a)
+            assert_array_almost_equal(q.T @ q, eye(m))
+            assert_array_almost_equal(q @ r, a)
 
     def test_random_trap_pivoting(self):
         m = 100
         n = 200
         for k in range(2):
-            a = random([m,n])
-            q,r,p = qr(a, pivoting=True)
+            a = random([m, n])
+            q, r, p = qr(a, pivoting=True)
             d = abs(diag(r))
             assert_(np.all(d[1:] <= d[:-1]))
-            assert_array_almost_equal(dot(transpose(q),q),identity(m))
-            assert_array_almost_equal(dot(q,r),a[:,p])
-            q2,r2 = qr(a[:,p])
-            assert_array_almost_equal(q,q2)
-            assert_array_almost_equal(r,r2)
+            assert_array_almost_equal(q.T @ q, eye(m))
+            assert_array_almost_equal(q @ r, a[:, p])
+            q2, r2 = qr(a[:, p])
+            assert_array_almost_equal(q, q2)
+            assert_array_almost_equal(r, r2)
 
     def test_random_complex(self):
         n = 20
         for k in range(2):
-            a = random([n,n])+1j*random([n,n])
-            q,r = qr(a)
-            assert_array_almost_equal(dot(conj(transpose(q)),q),identity(n))
-            assert_array_almost_equal(dot(q,r),a)
+            a = random([n, n])+1j*random([n, n])
+            q, r = qr(a)
+            assert_array_almost_equal(q.conj().T @ q, eye(n))
+            assert_array_almost_equal(q @ r, a)
 
     def test_random_complex_left(self):
         n = 20
         for k in range(2):
-            a = random([n,n])+1j*random([n,n])
-            q,r = qr(a)
+            a = random([n, n])+1j*random([n, n])
+            q, r = qr(a)
             c = random([n])+1j*random([n])
-            qc,r = qr_multiply(a, c, "left")
-            assert_array_almost_equal(dot(q, c), qc)
-            qc,r = qr_multiply(a, identity(n), "left")
+            qc, r = qr_multiply(a, c, "left")
+            assert_array_almost_equal(q @ c, qc)
+            qc, r = qr_multiply(a, eye(n), "left")
             assert_array_almost_equal(q, qc)
 
     def test_random_complex_right(self):
         n = 20
         for k in range(2):
-            a = random([n,n])+1j*random([n,n])
-            q,r = qr(a)
+            a = random([n, n])+1j*random([n, n])
+            q, r = qr(a)
             c = random([n])+1j*random([n])
-            cq,r = qr_multiply(a, c)
-            assert_array_almost_equal(dot(c, q), cq)
-            cq,r = qr_multiply(a, identity(n))
+            cq, r = qr_multiply(a, c)
+            assert_array_almost_equal(c @ q, cq)
+            cq, r = qr_multiply(a, eye(n))
             assert_array_almost_equal(q, cq)
 
     def test_random_complex_pivoting(self):
         n = 20
         for k in range(2):
-            a = random([n,n])+1j*random([n,n])
-            q,r,p = qr(a, pivoting=True)
+            a = random([n, n])+1j*random([n, n])
+            q, r, p = qr(a, pivoting=True)
             d = abs(diag(r))
             assert_(np.all(d[1:] <= d[:-1]))
-            assert_array_almost_equal(dot(conj(transpose(q)),q),identity(n))
-            assert_array_almost_equal(dot(q,r),a[:,p])
-            q2,r2 = qr(a[:,p])
-            assert_array_almost_equal(q,q2)
-            assert_array_almost_equal(r,r2)
+            assert_array_almost_equal(q.conj().T @ q, eye(n))
+            assert_array_almost_equal(q @ r, a[:, p])
+            q2, r2 = qr(a[:, p])
+            assert_array_almost_equal(q, q2)
+            assert_array_almost_equal(r, r2)
 
     def test_check_finite(self):
-        a = [[8,2,3],[2,9,3],[5,3,6]]
-        q,r = qr(a, check_finite=False)
-        assert_array_almost_equal(dot(transpose(q),q),identity(3))
-        assert_array_almost_equal(dot(q,r),a)
+        a = [[8, 2, 3], [2, 9, 3], [5, 3, 6]]
+        q, r = qr(a, check_finite=False)
+        assert_array_almost_equal(q.T @ q, eye(3))
+        assert_array_almost_equal(q @ r, a)
 
     def test_lwork(self):
-        a = [[8,2,3],[2,9,3],[5,3,6]]
+        a = [[8, 2, 3], [2, 9, 3], [5, 3, 6]]
         # Get comparison values
-        q,r = qr(a, lwork=None)
+        q, r = qr(a, lwork=None)
 
         # Test against minimum valid lwork
-        q2,r2 = qr(a, lwork=3)
-        assert_array_almost_equal(q2,q)
-        assert_array_almost_equal(r2,r)
+        q2, r2 = qr(a, lwork=3)
+        assert_array_almost_equal(q2, q)
+        assert_array_almost_equal(r2, r)
 
         # Test against larger lwork
-        q3,r3 = qr(a, lwork=10)
-        assert_array_almost_equal(q3,q)
-        assert_array_almost_equal(r3,r)
+        q3, r3 = qr(a, lwork=10)
+        assert_array_almost_equal(q3, q)
+        assert_array_almost_equal(r3, r)
 
         # Test against explicit lwork=-1
-        q4,r4 = qr(a, lwork=-1)
-        assert_array_almost_equal(q4,q)
-        assert_array_almost_equal(r4,r)
+        q4, r4 = qr(a, lwork=-1)
+        assert_array_almost_equal(q4, q)
+        assert_array_almost_equal(r4, r)
 
         # Test against invalid lwork
-        assert_raises(Exception, qr, (a,), {'lwork':0})
-        assert_raises(Exception, qr, (a,), {'lwork':2})
+        assert_raises(Exception, qr, (a,), {'lwork': 0})
+        assert_raises(Exception, qr, (a,), {'lwork': 2})
+
 
 class TestRQ(object):
 
@@ -1748,261 +1771,261 @@ class TestRQ(object):
         seed(1234)
 
     def test_simple(self):
-        a = [[8,2,3],[2,9,3],[5,3,6]]
-        r,q = rq(a)
-        assert_array_almost_equal(dot(q, transpose(q)),identity(3))
-        assert_array_almost_equal(dot(r,q),a)
+        a = [[8, 2, 3], [2, 9, 3], [5, 3, 6]]
+        r, q = rq(a)
+        assert_array_almost_equal(q @ q.T, eye(3))
+        assert_array_almost_equal(r @ q, a)
 
     def test_r(self):
-        a = [[8,2,3],[2,9,3],[5,3,6]]
-        r,q = rq(a)
+        a = [[8, 2, 3], [2, 9, 3], [5, 3, 6]]
+        r, q = rq(a)
         r2 = rq(a, mode='r')
         assert_array_almost_equal(r, r2)
 
     def test_random(self):
         n = 20
         for k in range(2):
-            a = random([n,n])
-            r,q = rq(a)
-            assert_array_almost_equal(dot(q, transpose(q)),identity(n))
-            assert_array_almost_equal(dot(r,q),a)
+            a = random([n, n])
+            r, q = rq(a)
+            assert_array_almost_equal(q @ q.T, eye(n))
+            assert_array_almost_equal(r @ q, a)
 
     def test_simple_trap(self):
-        a = [[8,2,3],[2,9,3]]
-        r,q = rq(a)
-        assert_array_almost_equal(dot(transpose(q),q),identity(3))
-        assert_array_almost_equal(dot(r,q),a)
+        a = [[8, 2, 3], [2, 9, 3]]
+        r, q = rq(a)
+        assert_array_almost_equal(q.T @ q, eye(3))
+        assert_array_almost_equal(r @ q, a)
 
     def test_simple_tall(self):
-        a = [[8,2],[2,9],[5,3]]
-        r,q = rq(a)
-        assert_array_almost_equal(dot(transpose(q),q),identity(2))
-        assert_array_almost_equal(dot(r,q),a)
+        a = [[8, 2], [2, 9], [5, 3]]
+        r, q = rq(a)
+        assert_array_almost_equal(q.T @ q, eye(2))
+        assert_array_almost_equal(r @ q, a)
 
     def test_simple_fat(self):
-        a = [[8,2,5],[2,9,3]]
-        r,q = rq(a)
-        assert_array_almost_equal(dot(transpose(q),q),identity(3))
-        assert_array_almost_equal(dot(r,q),a)
+        a = [[8, 2, 5], [2, 9, 3]]
+        r, q = rq(a)
+        assert_array_almost_equal(q @ q.T, eye(3))
+        assert_array_almost_equal(r @ q, a)
 
     def test_simple_complex(self):
-        a = [[3,3+4j,5],[5,2,2+7j],[3,2,7]]
-        r,q = rq(a)
-        assert_array_almost_equal(dot(q, conj(transpose(q))),identity(3))
-        assert_array_almost_equal(dot(r,q),a)
+        a = [[3, 3+4j, 5], [5, 2, 2+7j], [3, 2, 7]]
+        r, q = rq(a)
+        assert_array_almost_equal(q @ q.conj().T, eye(3))
+        assert_array_almost_equal(r @ q, a)
 
     def test_random_tall(self):
         m = 200
         n = 100
         for k in range(2):
-            a = random([m,n])
-            r,q = rq(a)
-            assert_array_almost_equal(dot(q, transpose(q)),identity(n))
-            assert_array_almost_equal(dot(r,q),a)
+            a = random([m, n])
+            r, q = rq(a)
+            assert_array_almost_equal(q @ q.T, eye(n))
+            assert_array_almost_equal(r @ q, a)
 
     def test_random_trap(self):
         m = 100
         n = 200
         for k in range(2):
-            a = random([m,n])
-            r,q = rq(a)
-            assert_array_almost_equal(dot(q, transpose(q)),identity(n))
-            assert_array_almost_equal(dot(r,q),a)
+            a = random([m, n])
+            r, q = rq(a)
+            assert_array_almost_equal(q @ q.T, eye(n))
+            assert_array_almost_equal(r @ q, a)
 
     def test_random_trap_economic(self):
         m = 100
         n = 200
         for k in range(2):
-            a = random([m,n])
-            r,q = rq(a, mode='economic')
-            assert_array_almost_equal(dot(q,transpose(q)),identity(m))
-            assert_array_almost_equal(dot(r,q),a)
+            a = random([m, n])
+            r, q = rq(a, mode='economic')
+            assert_array_almost_equal(q @ q.T, eye(m))
+            assert_array_almost_equal(r @ q, a)
             assert_equal(q.shape, (m, n))
             assert_equal(r.shape, (m, m))
 
     def test_random_complex(self):
         n = 20
         for k in range(2):
-            a = random([n,n])+1j*random([n,n])
-            r,q = rq(a)
-            assert_array_almost_equal(dot(q, conj(transpose(q))),identity(n))
-            assert_array_almost_equal(dot(r,q),a)
+            a = random([n, n])+1j*random([n, n])
+            r, q = rq(a)
+            assert_array_almost_equal(q @ q.conj().T, eye(n))
+            assert_array_almost_equal(r @ q, a)
 
     def test_random_complex_economic(self):
         m = 100
         n = 200
         for k in range(2):
-            a = random([m,n])+1j*random([m,n])
-            r,q = rq(a, mode='economic')
-            assert_array_almost_equal(dot(q,conj(transpose(q))),identity(m))
-            assert_array_almost_equal(dot(r,q),a)
+            a = random([m, n])+1j*random([m, n])
+            r, q = rq(a, mode='economic')
+            assert_array_almost_equal(q @ q.conj().T, eye(m))
+            assert_array_almost_equal(r @ q, a)
             assert_equal(q.shape, (m, n))
             assert_equal(r.shape, (m, m))
 
     def test_check_finite(self):
-        a = [[8,2,3],[2,9,3],[5,3,6]]
-        r,q = rq(a, check_finite=False)
-        assert_array_almost_equal(dot(q, transpose(q)),identity(3))
-        assert_array_almost_equal(dot(r,q),a)
-
-
-transp = transpose
+        a = [[8, 2, 3], [2, 9, 3], [5, 3, 6]]
+        r, q = rq(a, check_finite=False)
+        assert_array_almost_equal(q @ q.T, eye(3))
+        assert_array_almost_equal(r @ q, a)
 
 
 class TestSchur(object):
 
     def test_simple(self):
-        a = [[8,12,3],[2,9,3],[10,3,6]]
-        t,z = schur(a)
-        assert_array_almost_equal(dot(dot(z,t),transp(conj(z))),a)
-        tc,zc = schur(a,'complex')
+        a = [[8, 12, 3], [2, 9, 3], [10, 3, 6]]
+        t, z = schur(a)
+        assert_array_almost_equal(z @ t @ z.conj().T, a)
+        tc, zc = schur(a, 'complex')
         assert_(np.any(ravel(iscomplex(zc))) and np.any(ravel(iscomplex(tc))))
-        assert_array_almost_equal(dot(dot(zc,tc),transp(conj(zc))),a)
-        tc2,zc2 = rsf2csf(tc,zc)
-        assert_array_almost_equal(dot(dot(zc2,tc2),transp(conj(zc2))),a)
+        assert_array_almost_equal(zc @ tc @ zc.conj().T, a)
+        tc2, zc2 = rsf2csf(tc, zc)
+        assert_array_almost_equal(zc2 @ tc2 @ zc2.conj().T, a)
 
     def test_sort(self):
-        a = [[4.,3.,1.,-1.],[-4.5,-3.5,-1.,1.],[9.,6.,-4.,4.5],[6.,4.,-3.,3.5]]
-        s,u,sdim = schur(a,sort='lhp')
-        assert_array_almost_equal([[0.1134,0.5436,0.8316,0.],
-                                   [-0.1134,-0.8245,0.5544,0.],
-                                   [-0.8213,0.1308,0.0265,-0.5547],
-                                   [-0.5475,0.0872,0.0177,0.8321]],
-                                  u,3)
-        assert_array_almost_equal([[-1.4142,0.1456,-11.5816,-7.7174],
-                                   [0.,-0.5000,9.4472,-0.7184],
-                                   [0.,0.,1.4142,-0.1456],
-                                   [0.,0.,0.,0.5]],
-                                  s,3)
-        assert_equal(2,sdim)
+        a = [[4., 3., 1., -1.],
+             [-4.5, -3.5, -1., 1.],
+             [9., 6., -4., 4.5],
+             [6., 4., -3., 3.5]]
+        s, u, sdim = schur(a, sort='lhp')
+        assert_array_almost_equal([[0.1134, 0.5436, 0.8316, 0.],
+                                   [-0.1134, -0.8245, 0.5544, 0.],
+                                   [-0.8213, 0.1308, 0.0265, -0.5547],
+                                   [-0.5475, 0.0872, 0.0177, 0.8321]],
+                                  u, 3)
+        assert_array_almost_equal([[-1.4142, 0.1456, -11.5816, -7.7174],
+                                   [0., -0.5000, 9.4472, -0.7184],
+                                   [0., 0., 1.4142, -0.1456],
+                                   [0., 0., 0., 0.5]],
+                                  s, 3)
+        assert_equal(2, sdim)
 
-        s,u,sdim = schur(a,sort='rhp')
-        assert_array_almost_equal([[0.4862,-0.4930,0.1434,-0.7071],
-                                   [-0.4862,0.4930,-0.1434,-0.7071],
-                                   [0.6042,0.3944,-0.6924,0.],
-                                   [0.4028,0.5986,0.6924,0.]],
-                                  u,3)
-        assert_array_almost_equal([[1.4142,-0.9270,4.5368,-14.4130],
-                                   [0.,0.5,6.5809,-3.1870],
-                                   [0.,0.,-1.4142,0.9270],
-                                   [0.,0.,0.,-0.5]],
-                                  s,3)
-        assert_equal(2,sdim)
+        s, u, sdim = schur(a, sort='rhp')
+        assert_array_almost_equal([[0.4862, -0.4930, 0.1434, -0.7071],
+                                   [-0.4862, 0.4930, -0.1434, -0.7071],
+                                   [0.6042, 0.3944, -0.6924, 0.],
+                                   [0.4028, 0.5986, 0.6924, 0.]],
+                                  u, 3)
+        assert_array_almost_equal([[1.4142, -0.9270, 4.5368, -14.4130],
+                                   [0., 0.5, 6.5809, -3.1870],
+                                   [0., 0., -1.4142, 0.9270],
+                                   [0., 0., 0., -0.5]],
+                                  s, 3)
+        assert_equal(2, sdim)
 
-        s,u,sdim = schur(a,sort='iuc')
-        assert_array_almost_equal([[0.5547,0.,-0.5721,-0.6042],
-                                   [-0.8321,0.,-0.3814,-0.4028],
-                                   [0.,0.7071,-0.5134,0.4862],
-                                   [0.,0.7071,0.5134,-0.4862]],
-                                  u,3)
-        assert_array_almost_equal([[-0.5000,0.0000,-6.5809,-4.0974],
-                                   [0.,0.5000,-3.3191,-14.4130],
-                                   [0.,0.,1.4142,2.1573],
-                                   [0.,0.,0.,-1.4142]],
-                                  s,3)
-        assert_equal(2,sdim)
+        s, u, sdim = schur(a, sort='iuc')
+        assert_array_almost_equal([[0.5547, 0., -0.5721, -0.6042],
+                                   [-0.8321, 0., -0.3814, -0.4028],
+                                   [0., 0.7071, -0.5134, 0.4862],
+                                   [0., 0.7071, 0.5134, -0.4862]],
+                                  u, 3)
+        assert_array_almost_equal([[-0.5000, 0.0000, -6.5809, -4.0974],
+                                   [0., 0.5000, -3.3191, -14.4130],
+                                   [0., 0., 1.4142, 2.1573],
+                                   [0., 0., 0., -1.4142]],
+                                  s, 3)
+        assert_equal(2, sdim)
 
-        s,u,sdim = schur(a,sort='ouc')
-        assert_array_almost_equal([[0.4862,-0.5134,0.7071,0.],
-                                   [-0.4862,0.5134,0.7071,0.],
-                                   [0.6042,0.5721,0.,-0.5547],
-                                   [0.4028,0.3814,0.,0.8321]],
-                                  u,3)
-        assert_array_almost_equal([[1.4142,-2.1573,14.4130,4.0974],
-                                   [0.,-1.4142,3.3191,6.5809],
-                                   [0.,0.,-0.5000,0.],
-                                   [0.,0.,0.,0.5000]],
-                                  s,3)
-        assert_equal(2,sdim)
+        s, u, sdim = schur(a, sort='ouc')
+        assert_array_almost_equal([[0.4862, -0.5134, 0.7071, 0.],
+                                   [-0.4862, 0.5134, 0.7071, 0.],
+                                   [0.6042, 0.5721, 0., -0.5547],
+                                   [0.4028, 0.3814, 0., 0.8321]],
+                                  u, 3)
+        assert_array_almost_equal([[1.4142, -2.1573, 14.4130, 4.0974],
+                                   [0., -1.4142, 3.3191, 6.5809],
+                                   [0., 0., -0.5000, 0.],
+                                   [0., 0., 0., 0.5000]],
+                                  s, 3)
+        assert_equal(2, sdim)
 
-        rhp_function = lambda x: x >= 0.0
-        s,u,sdim = schur(a,sort=rhp_function)
-        assert_array_almost_equal([[0.4862,-0.4930,0.1434,-0.7071],
-                                   [-0.4862,0.4930,-0.1434,-0.7071],
-                                   [0.6042,0.3944,-0.6924,0.],
-                                   [0.4028,0.5986,0.6924,0.]],
-                                  u,3)
-        assert_array_almost_equal([[1.4142,-0.9270,4.5368,-14.4130],
-                                   [0.,0.5,6.5809,-3.1870],
-                                   [0.,0.,-1.4142,0.9270],
-                                   [0.,0.,0.,-0.5]],
-                                  s,3)
-        assert_equal(2,sdim)
+        s, u, sdim = schur(a, sort=lambda x: x >= 0.0)
+        assert_array_almost_equal([[0.4862, -0.4930, 0.1434, -0.7071],
+                                   [-0.4862, 0.4930, -0.1434, -0.7071],
+                                   [0.6042, 0.3944, -0.6924, 0.],
+                                   [0.4028, 0.5986, 0.6924, 0.]],
+                                  u, 3)
+        assert_array_almost_equal([[1.4142, -0.9270, 4.5368, -14.4130],
+                                   [0., 0.5, 6.5809, -3.1870],
+                                   [0., 0., -1.4142, 0.9270],
+                                   [0., 0., 0., -0.5]],
+                                  s, 3)
+        assert_equal(2, sdim)
 
     def test_sort_errors(self):
-        a = [[4.,3.,1.,-1.],[-4.5,-3.5,-1.,1.],[9.,6.,-4.,4.5],[6.,4.,-3.,3.5]]
+        a = [[4., 3., 1., -1.],
+             [-4.5, -3.5, -1., 1.],
+             [9., 6., -4., 4.5],
+             [6., 4., -3., 3.5]]
         assert_raises(ValueError, schur, a, sort='unsupported')
         assert_raises(ValueError, schur, a, sort=1)
 
     def test_check_finite(self):
-        a = [[8,12,3],[2,9,3],[10,3,6]]
-        t,z = schur(a, check_finite=False)
-        assert_array_almost_equal(dot(dot(z,t),transp(conj(z))),a)
+        a = [[8, 12, 3], [2, 9, 3], [10, 3, 6]]
+        t, z = schur(a, check_finite=False)
+        assert_array_almost_equal(z @ t @ z.conj().T, a)
 
 
 class TestHessenberg(object):
 
     def test_simple(self):
-        a = [[-149, -50,-154],
+        a = [[-149, -50, -154],
              [537, 180, 546],
              [-27, -9, -25]]
-        h1 = [[-149.0000,42.2037,-156.3165],
-              [-537.6783,152.5511,-554.9272],
-              [0,0.0728, 2.4489]]
-        h,q = hessenberg(a,calc_q=1)
-        assert_array_almost_equal(dot(transp(q),dot(a,q)),h)
-        assert_array_almost_equal(h,h1,decimal=4)
+        h1 = [[-149.0000, 42.2037, -156.3165],
+              [-537.6783, 152.5511, -554.9272],
+              [0, 0.0728, 2.4489]]
+        h, q = hessenberg(a, calc_q=1)
+        assert_array_almost_equal(q.T @ a @ q, h)
+        assert_array_almost_equal(h, h1, decimal=4)
 
     def test_simple_complex(self):
-        a = [[-149, -50,-154],
+        a = [[-149, -50, -154],
              [537, 180j, 546],
              [-27j, -9, -25]]
-        h,q = hessenberg(a,calc_q=1)
-        h1 = dot(transp(conj(q)),dot(a,q))
-        assert_array_almost_equal(h1,h)
+        h, q = hessenberg(a, calc_q=1)
+        assert_array_almost_equal(q.conj().T @ a @ q, h)
 
     def test_simple2(self):
-        a = [[1,2,3,4,5,6,7],
-             [0,2,3,4,6,7,2],
-             [0,2,2,3,0,3,2],
-             [0,0,2,8,0,0,2],
-             [0,3,1,2,0,1,2],
-             [0,1,2,3,0,1,0],
-             [0,0,0,0,0,1,2]]
-        h,q = hessenberg(a,calc_q=1)
-        assert_array_almost_equal(dot(transp(q),dot(a,q)),h)
+        a = [[1, 2, 3, 4, 5, 6, 7],
+             [0, 2, 3, 4, 6, 7, 2],
+             [0, 2, 2, 3, 0, 3, 2],
+             [0, 0, 2, 8, 0, 0, 2],
+             [0, 3, 1, 2, 0, 1, 2],
+             [0, 1, 2, 3, 0, 1, 0],
+             [0, 0, 0, 0, 0, 1, 2]]
+        h, q = hessenberg(a, calc_q=1)
+        assert_array_almost_equal(q.T @ a @ q, h)
 
     def test_simple3(self):
         a = np.eye(3)
         a[-1, 0] = 2
         h, q = hessenberg(a, calc_q=1)
-        assert_array_almost_equal(dot(transp(q), dot(a, q)), h)
+        assert_array_almost_equal(q.T @ a @ q, h)
 
     def test_random(self):
         n = 20
         for k in range(2):
-            a = random([n,n])
-            h,q = hessenberg(a,calc_q=1)
-            assert_array_almost_equal(dot(transp(q),dot(a,q)),h)
+            a = random([n, n])
+            h, q = hessenberg(a, calc_q=1)
+            assert_array_almost_equal(q.T @ a @ q, h)
 
     def test_random_complex(self):
         n = 20
         for k in range(2):
-            a = random([n,n])+1j*random([n,n])
-            h,q = hessenberg(a,calc_q=1)
-            h1 = dot(transp(conj(q)),dot(a,q))
-            assert_array_almost_equal(h1,h)
+            a = random([n, n])+1j*random([n, n])
+            h, q = hessenberg(a, calc_q=1)
+            assert_array_almost_equal(q.conj().T @ a @ q, h)
 
     def test_check_finite(self):
-        a = [[-149, -50,-154],
+        a = [[-149, -50, -154],
              [537, 180, 546],
              [-27, -9, -25]]
-        h1 = [[-149.0000,42.2037,-156.3165],
-              [-537.6783,152.5511,-554.9272],
-              [0,0.0728, 2.4489]]
-        h,q = hessenberg(a,calc_q=1, check_finite=False)
-        assert_array_almost_equal(dot(transp(q),dot(a,q)),h)
-        assert_array_almost_equal(h,h1,decimal=4)
+        h1 = [[-149.0000, 42.2037, -156.3165],
+              [-537.6783, 152.5511, -554.9272],
+              [0, 0.0728, 2.4489]]
+        h, q = hessenberg(a, calc_q=1, check_finite=False)
+        assert_array_almost_equal(q.T @ a @ q, h)
+        assert_array_almost_equal(h, h1, decimal=4)
 
     def test_2x2(self):
         a = [[2, 1], [7, 12]]
@@ -2023,63 +2046,63 @@ class TestQZ(object):
 
     def test_qz_single(self):
         n = 5
-        A = random([n,n]).astype(float32)
-        B = random([n,n]).astype(float32)
-        AA,BB,Q,Z = qz(A,B)
-        assert_array_almost_equal(dot(dot(Q,AA),Z.T), A, decimal=5)
-        assert_array_almost_equal(dot(dot(Q,BB),Z.T), B, decimal=5)
-        assert_array_almost_equal(dot(Q,Q.T), eye(n), decimal=5)
-        assert_array_almost_equal(dot(Z,Z.T), eye(n), decimal=5)
+        A = random([n, n]).astype(float32)
+        B = random([n, n]).astype(float32)
+        AA, BB, Q, Z = qz(A, B)
+        assert_array_almost_equal(Q @ AA @ Z.T, A, decimal=5)
+        assert_array_almost_equal(Q @ BB @ Z.T, B, decimal=5)
+        assert_array_almost_equal(Q @ Q.T, eye(n), decimal=5)
+        assert_array_almost_equal(Z @ Z.T, eye(n), decimal=5)
         assert_(np.all(diag(BB) >= 0))
 
     def test_qz_double(self):
         n = 5
-        A = random([n,n])
-        B = random([n,n])
-        AA,BB,Q,Z = qz(A,B)
-        assert_array_almost_equal(dot(dot(Q,AA),Z.T), A)
-        assert_array_almost_equal(dot(dot(Q,BB),Z.T), B)
-        assert_array_almost_equal(dot(Q,Q.T), eye(n))
-        assert_array_almost_equal(dot(Z,Z.T), eye(n))
+        A = random([n, n])
+        B = random([n, n])
+        AA, BB, Q, Z = qz(A, B)
+        assert_array_almost_equal(Q @ AA @ Z.T, A)
+        assert_array_almost_equal(Q @ BB @ Z.T, B)
+        assert_array_almost_equal(Q @ Q.T, eye(n))
+        assert_array_almost_equal(Z @ Z.T, eye(n))
         assert_(np.all(diag(BB) >= 0))
 
     def test_qz_complex(self):
         n = 5
-        A = random([n,n]) + 1j*random([n,n])
-        B = random([n,n]) + 1j*random([n,n])
-        AA,BB,Q,Z = qz(A,B)
-        assert_array_almost_equal(dot(dot(Q,AA),Z.conjugate().T), A)
-        assert_array_almost_equal(dot(dot(Q,BB),Z.conjugate().T), B)
-        assert_array_almost_equal(dot(Q,Q.conjugate().T), eye(n))
-        assert_array_almost_equal(dot(Z,Z.conjugate().T), eye(n))
+        A = random([n, n]) + 1j*random([n, n])
+        B = random([n, n]) + 1j*random([n, n])
+        AA, BB, Q, Z = qz(A, B)
+        assert_array_almost_equal(Q @ AA @ Z.conj().T, A)
+        assert_array_almost_equal(Q @ BB @ Z.conj().T, B)
+        assert_array_almost_equal(Q @ Q.conj().T, eye(n))
+        assert_array_almost_equal(Z @ Z.conj().T, eye(n))
         assert_(np.all(diag(BB) >= 0))
         assert_(np.all(diag(BB).imag == 0))
 
     def test_qz_complex64(self):
         n = 5
-        A = (random([n,n]) + 1j*random([n,n])).astype(complex64)
-        B = (random([n,n]) + 1j*random([n,n])).astype(complex64)
-        AA,BB,Q,Z = qz(A,B)
-        assert_array_almost_equal(dot(dot(Q,AA),Z.conjugate().T), A, decimal=5)
-        assert_array_almost_equal(dot(dot(Q,BB),Z.conjugate().T), B, decimal=5)
-        assert_array_almost_equal(dot(Q,Q.conjugate().T), eye(n), decimal=5)
-        assert_array_almost_equal(dot(Z,Z.conjugate().T), eye(n), decimal=5)
+        A = (random([n, n]) + 1j*random([n, n])).astype(complex64)
+        B = (random([n, n]) + 1j*random([n, n])).astype(complex64)
+        AA, BB, Q, Z = qz(A, B)
+        assert_array_almost_equal(Q @ AA @ Z.conj().T, A, decimal=5)
+        assert_array_almost_equal(Q @ BB @ Z.conj().T, B, decimal=5)
+        assert_array_almost_equal(Q @ Q.conj().T, eye(n), decimal=5)
+        assert_array_almost_equal(Z @ Z.conj().T, eye(n), decimal=5)
         assert_(np.all(diag(BB) >= 0))
         assert_(np.all(diag(BB).imag == 0))
 
     def test_qz_double_complex(self):
         n = 5
-        A = random([n,n])
-        B = random([n,n])
-        AA,BB,Q,Z = qz(A,B, output='complex')
-        aa = dot(dot(Q,AA),Z.conjugate().T)
+        A = random([n, n])
+        B = random([n, n])
+        AA, BB, Q, Z = qz(A, B, output='complex')
+        aa = Q @ AA @ Z.conj().T
         assert_array_almost_equal(aa.real, A)
         assert_array_almost_equal(aa.imag, 0)
-        bb = dot(dot(Q,BB),Z.conjugate().T)
+        bb = Q @ BB @ Z.conj().T
         assert_array_almost_equal(bb.real, B)
         assert_array_almost_equal(bb.imag, 0)
-        assert_array_almost_equal(dot(Q,Q.conjugate().T), eye(n))
-        assert_array_almost_equal(dot(Z,Z.conjugate().T), eye(n))
+        assert_array_almost_equal(Q @ Q.conj().T, eye(n))
+        assert_array_almost_equal(Z @ Z.conj().T, eye(n))
         assert_(np.all(diag(BB) >= 0))
 
     def test_qz_double_sort(self):
@@ -2097,27 +2120,25 @@ class TestQZ(object):
         #              [1.0,   3.0,  -4.0,   3.0],
         #              [1.0,   3.0,  -4.0,   4.0]])
         A = np.array([[3.9, 12.5, -34.5, 2.5],
-                 [4.3, 21.5, -47.5, 7.5],
-                 [4.3, 1.5, -43.5, 3.5],
-                 [4.4, 6.0, -46.0, 6.0]])
+                      [4.3, 21.5, -47.5, 7.5],
+                      [4.3, 1.5, -43.5, 3.5],
+                      [4.4, 6.0, -46.0, 6.0]])
 
         B = np.array([[1.0, 1.0, -3.0, 1.0],
                       [1.0, 3.0, -5.0, 4.4],
                       [1.0, 2.0, -4.0, 1.0],
                       [1.2, 3.0, -4.0, 4.0]])
 
-        sort = lambda ar,ai,beta: ai == 0
-
-        assert_raises(ValueError, qz, A, B, sort=sort)
+        assert_raises(ValueError, qz, A, B, sort=lambda ar, ai, beta: ai == 0)
         if False:
-            AA,BB,Q,Z,sdim = qz(A,B,sort=sort)
+            AA, BB, Q, Z, sdim = qz(A, B, sort=lambda ar, ai, beta: ai == 0)
             # assert_(sdim == 2)
             assert_(sdim == 4)
-            assert_array_almost_equal(dot(dot(Q,AA),Z.T), A)
-            assert_array_almost_equal(dot(dot(Q,BB),Z.T), B)
+            assert_array_almost_equal(Q @ AA @ Z.T, A)
+            assert_array_almost_equal(Q @ BB @ Z.T, B)
 
-            # test absolute values bc the sign is ambiguous and might be platform
-            # dependent
+            # test absolute values bc the sign is ambiguous and
+            # might be platform dependent
             assert_array_almost_equal(np.abs(AA), np.abs(np.array(
                             [[35.7864, -80.9061, -12.0629, -9.498],
                              [0., 2.7638, -2.3505, 7.3256],
@@ -2185,13 +2206,13 @@ class TestQZ(object):
 
     def test_check_finite(self):
         n = 5
-        A = random([n,n])
-        B = random([n,n])
-        AA,BB,Q,Z = qz(A,B,check_finite=False)
-        assert_array_almost_equal(dot(dot(Q,AA),Z.T), A)
-        assert_array_almost_equal(dot(dot(Q,BB),Z.T), B)
-        assert_array_almost_equal(dot(Q,Q.T), eye(n))
-        assert_array_almost_equal(dot(Z,Z.T), eye(n))
+        A = random([n, n])
+        B = random([n, n])
+        AA, BB, Q, Z = qz(A, B, check_finite=False)
+        assert_array_almost_equal(Q @ AA @ Z.T, A)
+        assert_array_almost_equal(Q @ BB @ Z.T, B)
+        assert_array_almost_equal(Q @ Q.T, eye(n))
+        assert_array_almost_equal(Z @ Z.T, eye(n))
         assert_(np.all(diag(BB) >= 0))
 
 
@@ -2252,7 +2273,6 @@ class TestOrdQZ(object):
 
         # example with (alpha, beta) = (0, 0)
         A5 = np.diag([1, 0])
-        B5 = np.diag([1, 0])
 
         cls.A = [A1, A2, A3, A4, A5]
         cls.B = [B1, B2, B3, B4, A5]
@@ -2269,11 +2289,11 @@ class TestOrdQZ(object):
     def check(self, A, B, sort, AA, BB, alpha, beta, Q, Z):
         Id = np.eye(*A.shape)
         # make sure Q and Z are orthogonal
-        assert_array_almost_equal(Q.dot(Q.T.conj()), Id)
-        assert_array_almost_equal(Z.dot(Z.T.conj()), Id)
+        assert_array_almost_equal(Q @ Q.T.conj(), Id)
+        assert_array_almost_equal(Z @ Z.T.conj(), Id)
         # check factorization
-        assert_array_almost_equal(Q.dot(AA), A.dot(Z))
-        assert_array_almost_equal(Q.dot(BB), B.dot(Z))
+        assert_array_almost_equal(Q @ AA, A @ Z)
+        assert_array_almost_equal(Q @ BB, B @ Z)
         # check shape of AA and BB
         assert_array_equal(np.tril(AA, -2), np.zeros(AA.shape))
         assert_array_equal(np.tril(BB, -1), np.zeros(BB.shape))
@@ -2365,9 +2385,9 @@ class TestOrdQZ(object):
         A1 = np.eye(2)
         B1 = np.diag([-2, 0.5])
         expected1 = [('lhp', [-0.5, 2]),
-                    ('rhp', [2, -0.5]),
-                    ('iuc', [-0.5, 2]),
-                    ('ouc', [2, -0.5])]
+                     ('rhp', [2, -0.5]),
+                     ('iuc', [-0.5, 2]),
+                     ('ouc', [2, -0.5])]
         A2 = np.eye(2)
         B2 = np.diag([-2 + 1j, 0.5 + 0.5j])
         expected2 = [('lhp', [1/(-2 + 1j), 1/(0.5 + 0.5j)]),
@@ -2418,17 +2438,17 @@ class TestOrdQZWorkspaceSize(object):
 
         # raises error if lwork parameter to dtrsen is too small
         for ddtype in [np.float32, np.float64]:
-            A = random((N,N)).astype(ddtype)
-            B = random((N,N)).astype(ddtype)
-            # sort = lambda alphar, alphai, beta: alphar**2 + alphai**2< beta**2
-            sort = lambda alpha, beta: alpha < beta
-            [S,T,alpha,beta,U,V] = ordqz(A,B,sort=sort, output='real')
+            A = random((N, N)).astype(ddtype)
+            B = random((N, N)).astype(ddtype)
+            # sort = lambda ar, ai, b: ar**2 + ai**2 < b**2
+            _ = ordqz(A, B, sort=lambda alpha, beta: alpha < beta,
+                      output='real')
 
         for ddtype in [np.complex, np.complex64]:
-            A = random((N,N)).astype(ddtype)
-            B = random((N,N)).astype(ddtype)
-            sort = lambda alpha, beta: alpha < beta
-            [S,T,alpha,beta,U,V] = ordqz(A,B,sort=sort, output='complex')
+            A = random((N, N)).astype(ddtype)
+            B = random((N, N)).astype(ddtype)
+            _ = ordqz(A, B, sort=lambda alpha, beta: alpha < beta,
+                      output='complex')
 
     @pytest.mark.slow
     def test_decompose_ouc(self):
@@ -2437,9 +2457,9 @@ class TestOrdQZWorkspaceSize(object):
 
         # segfaults if lwork parameter to dtrsen is too small
         for ddtype in [np.float32, np.float64, np.complex, np.complex64]:
-            A = random((N,N)).astype(ddtype)
-            B = random((N,N)).astype(ddtype)
-            [S,T,alpha,beta,U,V] = ordqz(A,B,sort='ouc')
+            A = random((N, N)).astype(ddtype)
+            B = random((N, N)).astype(ddtype)
+            S, T, alpha, beta, U, V = ordqz(A, B, sort='ouc')
 
 
 class TestDatacopied(object):
@@ -2447,7 +2467,7 @@ class TestDatacopied(object):
     def test_datacopied(self):
         from scipy.linalg.decomp import _datacopied
 
-        M = matrix([[0,1],[2,3]])
+        M = matrix([[0, 1], [2, 3]])
         A = asarray(M)
         L = M.tolist()
         M2 = M.copy()
@@ -2515,46 +2535,48 @@ def check_lapack_misaligned(func, args, kwargs):
     args = list(args)
     for i in range(len(args)):
         a = args[:]
-        if isinstance(a[i],np.ndarray):
+        if isinstance(a[i], np.ndarray):
             # Try misaligning a[i]
             aa = np.zeros(a[i].size*a[i].dtype.itemsize+8, dtype=np.uint8)
-            aa = np.frombuffer(aa.data, offset=4, count=a[i].size, dtype=a[i].dtype)
+            aa = np.frombuffer(aa.data, offset=4, count=a[i].size,
+                               dtype=a[i].dtype)
             aa.shape = a[i].shape
             aa[...] = a[i]
             a[i] = aa
-            func(*a,**kwargs)
+            func(*a, **kwargs)
             if len(a[i].shape) > 1:
                 a[i] = a[i].T
-                func(*a,**kwargs)
+                func(*a, **kwargs)
 
 
-@pytest.mark.xfail(run=False, reason="Ticket #1152, triggers a segfault in rare cases.")
+@pytest.mark.xfail(run=False,
+                   reason="Ticket #1152, triggers a segfault in rare cases.")
 def test_lapack_misaligned():
-    M = np.eye(10,dtype=float)
+    M = np.eye(10, dtype=float)
     R = np.arange(100)
-    R.shape = 10,10
-    S = np.arange(20000,dtype=np.uint8)
+    R.shape = 10, 10
+    S = np.arange(20000, dtype=np.uint8)
     S = np.frombuffer(S.data, offset=4, count=100, dtype=float)
     S.shape = 10, 10
     b = np.ones(10)
     LU, piv = lu_factor(S)
     for (func, args, kwargs) in [
-            (eig,(S,),dict(overwrite_a=True)),  # crash
-            (eigvals,(S,),dict(overwrite_a=True)),  # no crash
-            (lu,(S,),dict(overwrite_a=True)),  # no crash
-            (lu_factor,(S,),dict(overwrite_a=True)),  # no crash
-            (lu_solve,((LU,piv),b),dict(overwrite_b=True)),
-            (solve,(S,b),dict(overwrite_a=True,overwrite_b=True)),
-            (svd,(M,),dict(overwrite_a=True)),  # no crash
-            (svd,(R,),dict(overwrite_a=True)),  # no crash
-            (svd,(S,),dict(overwrite_a=True)),  # crash
-            (svdvals,(S,),dict()),  # no crash
-            (svdvals,(S,),dict(overwrite_a=True)),  # crash
-            (cholesky,(M,),dict(overwrite_a=True)),  # no crash
-            (qr,(S,),dict(overwrite_a=True)),  # crash
-            (rq,(S,),dict(overwrite_a=True)),  # crash
-            (hessenberg,(S,),dict(overwrite_a=True)),  # crash
-            (schur,(S,),dict(overwrite_a=True)),  # crash
+            (eig, (S,), dict(overwrite_a=True)),  # crash
+            (eigvals, (S,), dict(overwrite_a=True)),  # no crash
+            (lu, (S,), dict(overwrite_a=True)),  # no crash
+            (lu_factor, (S,), dict(overwrite_a=True)),  # no crash
+            (lu_solve, ((LU, piv), b), dict(overwrite_b=True)),
+            (solve, (S, b), dict(overwrite_a=True, overwrite_b=True)),
+            (svd, (M,), dict(overwrite_a=True)),  # no crash
+            (svd, (R,), dict(overwrite_a=True)),  # no crash
+            (svd, (S,), dict(overwrite_a=True)),  # crash
+            (svdvals, (S,), dict()),  # no crash
+            (svdvals, (S,), dict(overwrite_a=True)),  # crash
+            (cholesky, (M,), dict(overwrite_a=True)),  # no crash
+            (qr, (S,), dict(overwrite_a=True)),  # crash
+            (rq, (S,), dict(overwrite_a=True)),  # crash
+            (hessenberg, (S,), dict(overwrite_a=True)),  # crash
+            (schur, (S,), dict(overwrite_a=True)),  # crash
             ]:
         check_lapack_misaligned(func, args, kwargs)
 # not properly tested
@@ -2563,58 +2585,58 @@ def test_lapack_misaligned():
 
 class TestOverwrite(object):
     def test_eig(self):
-        assert_no_overwrite(eig, [(3,3)])
-        assert_no_overwrite(eig, [(3,3), (3,3)])
+        assert_no_overwrite(eig, [(3, 3)])
+        assert_no_overwrite(eig, [(3, 3), (3, 3)])
 
     def test_eigh(self):
-        assert_no_overwrite(eigh, [(3,3)])
-        assert_no_overwrite(eigh, [(3,3), (3,3)])
+        assert_no_overwrite(eigh, [(3, 3)])
+        assert_no_overwrite(eigh, [(3, 3), (3, 3)])
 
     def test_eig_banded(self):
-        assert_no_overwrite(eig_banded, [(3,2)])
+        assert_no_overwrite(eig_banded, [(3, 2)])
 
     def test_eigvals(self):
-        assert_no_overwrite(eigvals, [(3,3)])
+        assert_no_overwrite(eigvals, [(3, 3)])
 
     def test_eigvalsh(self):
-        assert_no_overwrite(eigvalsh, [(3,3)])
+        assert_no_overwrite(eigvalsh, [(3, 3)])
 
     def test_eigvals_banded(self):
-        assert_no_overwrite(eigvals_banded, [(3,2)])
+        assert_no_overwrite(eigvals_banded, [(3, 2)])
 
     def test_hessenberg(self):
-        assert_no_overwrite(hessenberg, [(3,3)])
+        assert_no_overwrite(hessenberg, [(3, 3)])
 
     def test_lu_factor(self):
-        assert_no_overwrite(lu_factor, [(3,3)])
+        assert_no_overwrite(lu_factor, [(3, 3)])
 
     def test_lu_solve(self):
-        x = np.array([[1,2,3], [4,5,6], [7,8,8]])
+        x = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 8]])
         xlu = lu_factor(x)
         assert_no_overwrite(lambda b: lu_solve(xlu, b), [(3,)])
 
     def test_lu(self):
-        assert_no_overwrite(lu, [(3,3)])
+        assert_no_overwrite(lu, [(3, 3)])
 
     def test_qr(self):
-        assert_no_overwrite(qr, [(3,3)])
+        assert_no_overwrite(qr, [(3, 3)])
 
     def test_rq(self):
-        assert_no_overwrite(rq, [(3,3)])
+        assert_no_overwrite(rq, [(3, 3)])
 
     def test_schur(self):
-        assert_no_overwrite(schur, [(3,3)])
+        assert_no_overwrite(schur, [(3, 3)])
 
     def test_schur_complex(self):
-        assert_no_overwrite(lambda a: schur(a, 'complex'), [(3,3)],
+        assert_no_overwrite(lambda a: schur(a, 'complex'), [(3, 3)],
                             dtypes=[np.float32, np.float64])
 
     def test_svd(self):
-        assert_no_overwrite(svd, [(3,3)])
-        assert_no_overwrite(lambda a: svd(a, lapack_driver='gesvd'), [(3,3)])
+        assert_no_overwrite(svd, [(3, 3)])
+        assert_no_overwrite(lambda a: svd(a, lapack_driver='gesvd'), [(3, 3)])
 
     def test_svdvals(self):
-        assert_no_overwrite(svdvals, [(3,3)])
+        assert_no_overwrite(svdvals, [(3, 3)])
 
 
 def _check_orth(n, dtype, skip_big=False):
@@ -2633,8 +2655,8 @@ def _check_orth(n, dtype, skip_big=False):
 
     if n > 5 and not skip_big:
         np.random.seed(1)
-        X = np.random.rand(n, 5).dot(np.random.rand(5, n))
-        X = X + 1e-4 * np.random.rand(n, 1).dot(np.random.rand(1, n))
+        X = np.random.rand(n, 5) @ np.random.rand(5, n)
+        X = X + 1e-4 * np.random.rand(n, 1) @ np.random.rand(1, n)
         X = X.astype(dtype)
 
         Y = orth(X, rcond=1e-3)
@@ -2645,7 +2667,8 @@ def _check_orth(n, dtype, skip_big=False):
 
 
 @pytest.mark.slow
-@pytest.mark.skipif(np.dtype(np.intp).itemsize < 8, reason="test only on 64-bit, else too slow")
+@pytest.mark.skipif(np.dtype(np.intp).itemsize < 8,
+                    reason="test only on 64-bit, else too slow")
 def test_orth_memory_efficiency():
     # Pick n so that 16*n bytes is reasonable but 8*n*n bytes is unreasonable.
     # Keep in mind that @pytest.mark.slow tests are likely to be running
@@ -2679,21 +2702,21 @@ def test_null_space():
 
         Y = null_space(X)
         assert_equal(Y.shape, (n, n-1))
-        assert_allclose(X.dot(Y), 0, atol=tol)
+        assert_allclose(X @ Y, 0, atol=tol)
 
         Y = null_space(X.T)
         assert_equal(Y.shape, (2, 1))
-        assert_allclose(X.T.dot(Y), 0, atol=tol)
+        assert_allclose(X.T @ Y, 0, atol=tol)
 
         X = np.random.randn(1 + n//2, n)
         Y = null_space(X)
         assert_equal(Y.shape, (n, n - 1 - n//2))
-        assert_allclose(X.dot(Y), 0, atol=tol)
+        assert_allclose(X @ Y, 0, atol=tol)
 
         if n > 5:
             np.random.seed(1)
-            X = np.random.rand(n, 5).dot(np.random.rand(5, n))
-            X = X + 1e-4 * np.random.rand(n, 1).dot(np.random.rand(1, n))
+            X = np.random.rand(n, 5) @ np.random.rand(5, n)
+            X = X + 1e-4 * np.random.rand(n, 1) @ np.random.rand(1, n)
             X = X.astype(dt)
 
             Y = null_space(X, rcond=1e-3)
@@ -2826,7 +2849,7 @@ class TestCDF2RDF(object):
 
     def test_not_square_error(self):
         # Check that passing a non-square array raises a ValueError.
-        w, v = np.arange(3), np.arange(6).reshape(3,2)
+        w, v = np.arange(3), np.arange(6).reshape(3, 2)
         assert_raises(ValueError, cdf2rdf, w, v)
 
     def test_swapped_v_w_error(self):
@@ -2837,7 +2860,7 @@ class TestCDF2RDF(object):
 
     def test_non_associated_error(self):
         # Check that passing non-associated eigenvectors raises a ValueError.
-        w, v = np.arange(3), np.arange(16).reshape(4,4)
+        w, v = np.arange(3), np.arange(16).reshape(4, 4)
         assert_raises(ValueError, cdf2rdf, w, v)
 
     def test_not_conjugate_pairs(self):

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -830,6 +830,20 @@ class TestEigh:
         assert_raises(ValueError, eigh, a)
         assert_raises(ValueError, eigh, b)
 
+    @pytest.mark.parametrize('driver', ("ev", "evd", "evr", "evx"))
+    def test_various_drivers_standard(self, driver):
+        a = _random_hermitian_matrix(20)
+        w, v = eigh(a, driver=driver)
+        assert_allclose(a @ v - (v * w), 0., atol=1000*np.spacing(1.), rtol=0.)
+
+    @pytest.mark.parametrize('driver', ("gv", "gvd", "gvx"))
+    def test_various_drivers_generalized(self, driver):
+        a = _random_hermitian_matrix(20)
+        b = _random_hermitian_matrix(20, posdef=True)
+        w, v = eigh(a=a, b=b, driver=driver)
+        assert_allclose(a @ v - w*(b @ v), 0.,
+                        atol=1000*np.spacing(1.), rtol=0.)
+
     # Old eigh tests kept for backwards compatibility
     @pytest.mark.parametrize('eigvals', (None, (2, 4)))
     @pytest.mark.parametrize('turbo', (True, False))

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -878,7 +878,7 @@ def test_sygst():
         B = (B + B.T)/2 + 2 * np.eye(n, dtype=dtype)
 
         # Perform eig (sygvd)
-        _, eig_gvd, info = sygvd(A, B)
+        eig_gvd, _, info = sygvd(A, B)
         assert_(info == 0)
 
         # Convert to std problem potrf
@@ -909,7 +909,7 @@ def test_hegst():
         B = (B + B.conj().T)/2 + 2 * np.eye(n, dtype=dtype)
 
         # Perform eig (hegvd)
-        _, eig_gvd, info = hegvd(A, B)
+        eig_gvd, _, info = hegvd(A, B)
         assert_(info == 0)
 
         # Convert to std problem potrf

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -1654,3 +1654,34 @@ def test_getc2_gesc2():
         else:
             assert_array_almost_equal(desired_cplx.astype(dtype),
                                       x/scale, decimal=4)
+
+
+@pytest.mark.parametrize("driver", ['ev', 'evd', 'evr', 'evx'])
+@pytest.mark.parametrize("pfx", ['sy', 'he'])
+def test_standard_eigh_lworks(pfx, driver):
+    n = 1200  # Some sufficiently big arbitrary number
+    dtype = REAL_DTYPES if pfx == 'sy' else COMPLEX_DTYPES
+    sc_dlw = get_lapack_funcs(pfx+driver+'_lwork', dtype=dtype[0])
+    dz_dlw = get_lapack_funcs(pfx+driver+'_lwork', dtype=dtype[1])
+    try:
+        _compute_lwork(sc_dlw, n, lower=1)
+        _compute_lwork(dz_dlw, n, lower=1)
+    except Exception as e:
+        pytest.fail("{}_lwork raised unexpected exception: {}"
+                    "".format(pfx+driver, e))
+
+
+@pytest.mark.parametrize("driver", ['gv', 'gvx'])
+@pytest.mark.parametrize("pfx", ['sy', 'he'])
+def test_generalized_eigh_lworks(pfx, driver):
+    n = 1200  # Some sufficiently big arbitrary number
+    dtype = REAL_DTYPES if pfx == 'sy' else COMPLEX_DTYPES
+    sc_dlw = get_lapack_funcs(pfx+driver+'_lwork', dtype=dtype[0])
+    dz_dlw = get_lapack_funcs(pfx+driver+'_lwork', dtype=dtype[1])
+    # Shouldn't raise any exceptions
+    try:
+        _compute_lwork(sc_dlw, n, uplo="L")
+        _compute_lwork(dz_dlw, n, uplo="L")
+    except Exception as e:
+        pytest.fail("{}_lwork raised unexpected exception: {}"
+                    "".format(pfx+driver, e))


### PR DESCRIPTION
Closes #11279
Closes #11262 
Closes #9212
Closes #8205
Closes #6510 
Closes #6502 

This is a rewrite of the `linalg.eigh()` API and the relevant wrapper additions/modifications. 

There were numerous inconsistencies in the involved wrappers and I am bit surprised that it didn't cause any issues before. On the upside, this means it has lower probability of breaking something downstream. 

Regarding the existing `eigh` tests, all pass without any modification. Hence from outside, nothing should change. Now more functionality of subset selection based on eig values and also selection of all possible drivers are added. Previously unguarded silent incompatible driver/parameter pairs are handled properly

On the low level routines; all routines are now using proper lwork computations that are added. Only backward incompatible changes are 

- The output signature of `<sy/he>evr` changed from `w, v, info` to `w, v, m, isuppz, info`
- The order of `w, v` of `<sy/he>{gv, gvd, gvx}` is swapped

New tests are added for both wrappers and the new API. There is this recurring theme of default values of array bounds generated by f2py is tripping the markdown hence a quick regex is implemented to add guards around them.

If everything goes OK, after the reviews I'd like to go through `test_decomp.py` for PEP8 violations.