### PR TITLE
TST: skip test_aligned_mem linalg test that is crashing on ppcle64

### DIFF
--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -2457,7 +2457,7 @@ class TestDatacopied(object):
 
 
 def test_aligned_mem_float():
-    """Check linalg works with non-aligned memory"""
+    """Check linalg works with non-aligned memory (float32)"""
     # Allocate 402 bytes of memory (allocated on boundary)
     a = arange(402, dtype=np.uint8)
 
@@ -2469,10 +2469,10 @@ def test_aligned_mem_float():
     eig(z.T, overwrite_a=True)
 
 
-@pytest.mark.xfail(platform.machine() == 'ppc64le',
-                   reason="fails on ppc64le")
+@pytest.mark.skip(platform.machine() == 'ppc64le',
+                  reason="crashes on ppc64le")
 def test_aligned_mem():
-    """Check linalg works with non-aligned memory"""
+    """Check linalg works with non-aligned memory (float64)"""
     # Allocate 804 bytes of memory (allocated on boundary)
     a = arange(804, dtype=np.uint8)
 


### PR DESCRIPTION
See gh-11305. This commit only tries to avoid CI crashes.