### PR TITLE
MAINT: clean up object array creation, scalar/1d confusion

### DIFF
--- a/scipy/integrate/tests/test_bvp.py
+++ b/scipy/integrate/tests/test_bvp.py
@@ -326,7 +326,7 @@ def test_compute_global_jac():
 
     J_true = np.zeros((m * n + k, m * n + k))
     for i in range(m - 1):
-        J_true[i * n: (i + 1) * n, i * n: (i + 2) * n] = J_block(h[i], p)
+        J_true[i * n: (i + 1) * n, i * n: (i + 2) * n] = J_block(h[i], p[0])
 
     J_true[:(m - 1) * n:2, -1] = p * h**2/6 * (y[0, :-1] - y[0, 1:])
     J_true[1:(m - 1) * n:2, -1] = p * (h * (y[0, :-1] + y[0, 1:]) +

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -895,9 +895,7 @@ class TestPPolyCommon(object):
             assert_equal(np.shape(p(0.5)), ())
             assert_equal(np.shape(p(np.array(0.5))), ())
 
-            # can't use dtype=object (with any numpy; what fails is
-            # constructing the object array here for old NumPy)
-            assert_raises(ValueError, p, np.array([[0.1, 0.2], [0.4]]))
+            assert_raises(ValueError, p, np.array([[0.1, 0.2], [0.4]], dtype=object))
 
     def test_complex_coef(self):
         np.random.seed(12345)

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -331,7 +331,7 @@ class TestSS2TF:
         assert_allclose(num, [[0, 1, 2, 3], [0, 1, 2, 3]], rtol=1e-13)
         assert_allclose(den, [1, 2, 3, 4], rtol=1e-13)
 
-        tf = ([1, [2, 3]], [1, 6])
+        tf = (np.array([1, [2, 3]], dtype=object), [1, 6])
         A, B, C, D = tf2ss(*tf)
         assert_allclose(A, [[-6]], rtol=1e-31)
         assert_allclose(B, [[1]], rtol=1e-31)
@@ -342,7 +342,7 @@ class TestSS2TF:
         assert_allclose(num, [[0, 1], [2, 3]], rtol=1e-13)
         assert_allclose(den, [1, 6], rtol=1e-13)
 
-        tf = ([[1, -3], [1, 2, 3]], [1, 6, 5])
+        tf = (np.array([[1, -3], [1, 2, 3]], dtype=object), [1, 6, 5])
         A, B, C, D = tf2ss(*tf)
         assert_allclose(A, [[-6, -5], [1, 0]], rtol=1e-13)
         assert_allclose(B, [[1], [0]], rtol=1e-13)

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -1087,7 +1087,7 @@ class TestSTFT(object):
         assert_raises(ValueError, check_NOLA, 'hann', 64, -32)
 
         x = np.zeros(1024)
-        z = stft(x)
+        z = np.array(stft(x), dtype=object)
 
         assert_raises(ValueError, stft, x, window=np.ones((2,2)))
         assert_raises(ValueError, stft, x, window=np.ones(10), nperseg=256)

--- a/scipy/spatial/tests/test_spherical_voronoi.py
+++ b/scipy/spatial/tests/test_spherical_voronoi.py
@@ -76,14 +76,14 @@ class TestSphericalVoronoi(object):
         sv_origin = SphericalVoronoi(self.points)
         center = np.array([1, 1, 1])
         sv_translated = SphericalVoronoi(self.points + center, center=center)
-        assert_array_equal(sv_origin.regions, sv_translated.regions)
+        assert_equal(sv_origin.regions, sv_translated.regions)
         assert_array_almost_equal(sv_origin.vertices + center,
                                   sv_translated.vertices)
 
     def test_vertices_regions_scaling_invariance(self):
         sv_unit = SphericalVoronoi(self.points)
         sv_scaled = SphericalVoronoi(self.points * 2, 2)
-        assert_array_equal(sv_unit.regions, sv_scaled.regions)
+        assert_equal(sv_unit.regions, sv_scaled.regions)
         assert_array_almost_equal(sv_unit.vertices * 2,
                                   sv_scaled.vertices)
 
@@ -102,7 +102,7 @@ class TestSphericalVoronoi(object):
         sv = SphericalVoronoi(self.points)
         unsorted_regions = sv.regions
         sv.sort_vertices_of_regions()
-        assert_array_equal(sorted(sv.regions), sorted(unsorted_regions))
+        assert_equal(sorted(sv.regions), sorted(unsorted_regions))
 
     def test_sort_vertices_of_regions_flattened(self):
         expected = sorted([[0, 6, 5, 2, 3], [2, 3, 10, 11, 8, 7], [0, 6, 4, 1],

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -2258,6 +2258,7 @@ def obrientransform(*args):
 
     # `arrays` will hold the transformed arguments.
     arrays = []
+    sLast = None
 
     for arg in args:
         a = np.asarray(arg)
@@ -2276,7 +2277,12 @@ def obrientransform(*args):
             raise ValueError('Lack of convergence in obrientransform.')
 
         arrays.append(t)
+        sLast = a.shape
 
+    if sLast:
+        for arr in arrays[:-1]:
+            if sLast != arr.shape:
+                return np.array(arrays, dtype=object)
     return np.array(arrays)
 
 

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -158,7 +158,7 @@ class TestShapiro(object):
 
     def test_not_enough_values(self):
         assert_raises(ValueError, stats.shapiro, [1, 2])
-        assert_raises(ValueError, stats.shapiro, [[], [2]])
+        assert_raises(ValueError, stats.shapiro, np.array([[], [2]], dtype=object))
 
     def test_bad_arg(self):
         # Length of x is less than 3.


### PR DESCRIPTION
Continuation of cleanups around array creation and mixing 1d arrays/scalars

xref gh-11147. With this and gh-11308, all tests pass locally with numpy/numpy#14794 (implementation of NEP 34)