### PR TITLE
DOC: Specify custom callable option for metric in cluster.hierarchy.fclusterdata

### DIFF
--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -2630,7 +2630,7 @@ def fclusterdata(X, t, criterion='inconsistent',
         Specifies the criterion for forming flat clusters. Valid
         values are 'inconsistent' (default), 'distance', or 'maxclust'
         cluster formation algorithms. See `fcluster` for descriptions.
-    metric : str, optional
+    metric : str or function, optional
         The distance metric for calculating pairwise distances. See
         ``distance.pdist`` for descriptions and linkage to verify
         compatibility with the linkage method.


### PR DESCRIPTION
The [documentation of `cluster.hierarchy.fclusterdata`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.cluster.hierarchy.fclusterdata.html) suggested that only `str` can be passed as `metric`. However, the implementation [only passes the metric to `spatial.distance.pdist`](https://github.com/scipy/scipy/blob/master/scipy/cluster/hierarchy.py#L2693) which readily accepts custom callables. Another close moving part, [`cluster.hierarchy.linkage`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.cluster.hierarchy.linkage.html#scipy.cluster.hierarchy.linkage), also accepts custom callables for metric. Calling `fclusterdata` with a custom callable seems to work fine, as expected from the implementation.

The bottom line is that this seems like a simple doc bug to me, so I added the option for functions to be passed as the `metric` keyword in the documentation of `fclusterdata`.