### PR TITLE
BUG: fix floating-point literal comparisons under C99

### DIFF
--- a/scipy/optimize/_trlib/trlib/trlib_types.h
+++ b/scipy/optimize/_trlib/trlib/trlib_types.h
@@ -28,9 +28,9 @@
 typedef long trlib_int_t;
 typedef double trlib_flt_t;
 
-#define TRLIB_EPS            (2.2204460492503131e-16)
-#define TRLIB_EPS_POW_4      (5.4774205922939014e-07)
-#define TRLIB_EPS_POW_5      (1.4901161193847656e-08)
-#define TRLIB_EPS_POW_75     (1.8189894035458565e-12)
+#define TRLIB_EPS            ((trlib_flt_t)2.2204460492503131e-16)
+#define TRLIB_EPS_POW_4      ((trlib_flt_t)5.4774205922939014e-07)
+#define TRLIB_EPS_POW_5      ((trlib_flt_t)1.4901161193847656e-08)
+#define TRLIB_EPS_POW_75     ((trlib_flt_t)1.8189894035458565e-12)
 
 #endif

--- a/scipy/special/cephes/ellik.c
+++ b/scipy/special/cephes/ellik.c
@@ -84,7 +84,7 @@ double ellik(double phi,  double m)
 	return (phi);
     a = 1.0 - m;
     if (a == 0.0) {
-	if (fabs(phi) >= NPY_PI_2) {
+	if (fabs(phi) >= (double)NPY_PI_2) {
 	    sf_error("ellik", SF_ERROR_SINGULAR, NULL);
 	    return (NPY_INFINITY);
 	}

--- a/scipy/special/cephes/kolmogorov.c
+++ b/scipy/special/cephes/kolmogorov.c
@@ -169,7 +169,7 @@ _kolmogorov(double x)
         RETURN_3PROBS(1.0, 0.0, 0);
     }
     /* x <= 0.040611972203751713 */
-    if (x <= NPY_PI/sqrt(-MIN_EXPABLE * 8)) {
+    if (x <= (double)NPY_PI/sqrt(-MIN_EXPABLE * 8)) {
         RETURN_3PROBS(1.0, 0.0, 0);
     }
 

--- a/scipy/special/cephes/scipy_iv.c
+++ b/scipy/special/cephes/scipy_iv.c
@@ -576,7 +576,7 @@ static void ikv_temme(double v, double x, double *Iv_p, double *Kv_p)
 	if (reflect && (kind & need_i)) {
 	    double z = (u + n % 2);
 
-	    Iv = sin(NPY_PI * z) == 0 ? Iv : NPY_INFINITY;
+	    Iv = sin((double)NPY_PI * z) == 0 ? Iv : NPY_INFINITY;
 	    if (Iv == NPY_INFINITY || Iv == -NPY_INFINITY) {
 		sf_error("ikv_temme", SF_ERROR_OVERFLOW, NULL);
 	    }

--- a/scipy/special/specfun_wrappers.h
+++ b/scipy/special/specfun_wrappers.h
@@ -20,22 +20,22 @@
 #define ABSQ(z) (z).real*(z).real + (z).imag*(z).imag;
 #define ZCONVINF(func,z)                                                \
     do {                                                                \
-        if (REAL((z)) == 1.0e300) {                                     \
+        if ((double)REAL((z)) == (double)1.0e300) {                     \
             sf_error(func, SF_ERROR_OVERFLOW, NULL);                    \
             REAL((z)) = NPY_INFINITY;                                   \
         }                                                               \
-        if (REAL((z)) == -1.0e300) {                                    \
+        if ((double)REAL((z)) == (double)-1.0e300) {                    \
             sf_error(func, SF_ERROR_OVERFLOW, NULL);                    \
             REAL((z)) = -NPY_INFINITY;                                  \
         }                                                               \
     } while (0)
 #define CONVINF(func, x)                                                \
     do {                                                                \
-        if ((x) == 1.0e300) {                                           \
+        if ((double)(x) == (double)1.0e300) {                           \
             sf_error(func, SF_ERROR_OVERFLOW, NULL);                    \
             (x)=NPY_INFINITY;                                           \
         }                                                               \
-        if ((x)==-1.0e300) {                                            \
+        if ((double)(x) == (double)-1.0e300) {                          \
             sf_error(func, SF_ERROR_OVERFLOW, NULL);                    \
             (x)=-NPY_INFINITY;                                          \
         }                                                               \


### PR DESCRIPTION
Floating point literals under gcc -std=c99 -mfpmode=387 (default on i386
platform) can have 'excess precision' with 80-bit floating point instead
of 64-bit.

Add explicit casts to force some of the literals to the same precision
as the precision of the variables they are compared against.

(The code changes here are no-ops on platforms such as amd64 where gcc defaults to fp math with the precision of the data type, but not e.g. on 386 where the fpu can have wider precision. See FLT_EVAL_METHOD, which also affects constants.)

Fixes: most of the failures in gh-11270 (except the optimize linprog ones)