### PR TITLE
BUG: Include `int64_t` declaration to `rectangular_lsap.cpp`

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -227,6 +227,7 @@ Leo P. Singer for bug fixes in scipy.optimize and scipy.interpolate and
 Domen Gorjup and Janko Slavič for continuous wavelet transform with complex
     wavelets fix.
 Søren Fuglede Jørgensen for improvements to scipy.sparse.csgraph
+Grzegorz Mrukwa for a bug fix in rectangular_lsap.cpp
 
 Institutions
 ------------

--- a/scipy/optimize/rectangular_lsap/rectangular_lsap.cpp
+++ b/scipy/optimize/rectangular_lsap/rectangular_lsap.cpp
@@ -42,7 +42,7 @@ Author: PM Larsen
 
 #include <algorithm>
 #include <cmath>
-#include <cstdint>
+#include "rectangular_lsap.h"
 #include <vector>
 
 static int

--- a/scipy/optimize/rectangular_lsap/rectangular_lsap.cpp
+++ b/scipy/optimize/rectangular_lsap/rectangular_lsap.cpp
@@ -42,6 +42,7 @@ Author: PM Larsen
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <vector>
 
 static int


### PR DESCRIPTION
There was missing declaration of `int64_t` in the file,
causing the extension build failure.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes #11319

#### What does this implement/fix?
Missing declaration of `int64_t` in `rectangular_lsap.cpp`.
