### PR TITLE
BLD: Don't assume -pthread is already set on compiler

### DIFF
--- a/scipy/fft/_pocketfft/setup.py
+++ b/scipy/fft/_pocketfft/setup.py
@@ -21,8 +21,8 @@ def pre_build_hook(build_ext, ext):
                 args.append('-pthread')
                 ext.extra_link_args.append('-pthread')
             else:
-                from numpy.distutils import log
-                log.warn('Unknown compiler pthread flag')
+                raise RuntimeError("Build failed: System has pthreads header "
+                                   "but could not compile with -pthread option")
 
         # Don't export library symbols
         try_add_flag(args, cc, '-fvisibility=hidden')

--- a/scipy/fft/_pocketfft/setup.py
+++ b/scipy/fft/_pocketfft/setup.py
@@ -18,6 +18,12 @@ def pre_build_hook(build_ext, ext):
                                    'int main(int argc, char **argv) {}')
         if has_pthreads:
             ext.define_macros.append(('POCKETFFT_PTHREADS', None))
+            if has_flag(cc, '-pthread'):
+                args.append('-pthread')
+                ext.extra_link_args.append('-pthread')
+            else:
+                from numpy.distutils import log
+                log.warn('Unknown compiler pthread flag')
 
         min_macos_flag = '-mmacosx-version-min=10.9'
         import sys

--- a/scipy/fft/_pocketfft/setup.py
+++ b/scipy/fft/_pocketfft/setup.py
@@ -5,15 +5,14 @@ def pre_build_hook(build_ext, ext):
     cc = build_ext._cxx_compiler
     args = ext.extra_compile_args
 
-    std_flag = get_cxx_std_flag(build_ext._cxx_compiler)
+    std_flag = get_cxx_std_flag(cc)
     if std_flag is not None:
         args.append(std_flag)
 
     if cc.compiler_type == 'msvc':
         args.append('/EHsc')
     else:
-        try_add_flag(args, cc, '-fvisibility=hidden')
-
+        # Use pthreads if available
         has_pthreads = try_compile(cc, code='#include <pthread.h>\n'
                                    'int main(int argc, char **argv) {}')
         if has_pthreads:
@@ -25,6 +24,9 @@ def pre_build_hook(build_ext, ext):
                 from numpy.distutils import log
                 log.warn('Unknown compiler pthread flag')
 
+        # Don't export library symbols
+        try_add_flag(args, cc, '-fvisibility=hidden')
+        # Set min macOS version
         min_macos_flag = '-mmacosx-version-min=10.9'
         import sys
         if sys.platform == 'darwin' and has_flag(cc, min_macos_flag):


### PR DESCRIPTION
#### Reference issue
Fixes gh-11323

#### What does this implement/fix?
This explicitly adds the `-pthread` argument to `pypocketfft` builds. This isn't usually required since `distutils` usually adds this argument already.