### PR TITLE
BUG: directed_hausdorff subset fix

### DIFF
--- a/scipy/spatial/_hausdorff.pyx
+++ b/scipy/spatial/_hausdorff.pyx
@@ -63,7 +63,7 @@ def directed_hausdorff(double[:,::1] ar1, double[:,::1] ar2, seed=0):
 
         # always true on first iteration of for-j loop, after that only
         # if d >= cmax
-        if cmin != np.inf and cmin > cmax and no_break_occurred == True:
+        if cmin != np.inf and cmin >= cmax and no_break_occurred == True:
             cmax = cmin
             i_ret = i_store
             j_ret = j_store

--- a/scipy/spatial/tests/test_hausdorff.py
+++ b/scipy/spatial/tests/test_hausdorff.py
@@ -123,3 +123,30 @@ class TestHausdorff(object):
         B = np.random.rand(4, 5)
         with pytest.raises(ValueError):
             directed_hausdorff(A, B)
+
+    @pytest.mark.parametrize("A, B, seed, expected", [
+        # the two cases from gh-11332
+        ([(0,0)],
+         [(0,1), (0,0)],
+         0,
+         (0.0, 0, 1)),
+        ([(0,0)],
+         [(0,1), (0,0)],
+         1,
+         (0.0, 0, 1)),
+        # slightly more complex case
+        ([(-5, 3), (0,0)],
+         [(0,1), (0,0), (-5, 3)],
+         77098,
+         # the maximum minimum distance will
+         # be the last one found, but a unique
+         # solution is not guaranteed more broadly
+         (0.0, 1, 1)),
+    ])
+    def test_subsets(self, A, B, seed, expected):
+        # verify fix for gh-11332
+        actual = directed_hausdorff(u=A, v=B, seed=seed)
+        # check distance
+        assert_almost_equal(actual[0], expected[0], decimal=9)
+        # check indices
+        assert actual[1:] == expected[1:]


### PR DESCRIPTION
Fixes #11332

* `directed_hausdorff` now correctly handles
cases where one of the vectors is a subset
of the other