### PR TITLE
[ENH] sparse: Loosen check for sparse outer indexing fast path

### DIFF
--- a/scipy/sparse/_index.py
+++ b/scipy/sparse/_index.py
@@ -62,9 +62,9 @@ class IndexMixin(object):
                 return self._get_arrayXint(row, col)
             elif isinstance(col, slice):
                 raise IndexError('index results in >2 dimensions')
-            elif row.shape[1] == 1 and col.ndim == 1:
+            elif row.shape[1] == 1 and (col.ndim == 1 or col.shape[0] == 1):
                 # special case for outer indexing
-                return self._get_columnXarray(row[:,0], col)
+                return self._get_columnXarray(row[:,0], col.ravel())
 
         # The only remaining case is inner (fancy) indexing
         row, col = _broadcast_arrays(row, col)


### PR DESCRIPTION
#### Reference issue
Fixes gh-11255

#### What does this implement/fix?
The fast path now accepts row-vector 2d arrays (that is, with shapes `(1, N)`) in addition to 1d arrays.

This doesn't affect the result of indexing, but does allow more cases to take advantage of the `_get_columnXarray()` fast path.