### PR TITLE
Undefined name 'e' in pavement.py

### DIFF
--- a/pavement.py
+++ b/pavement.py
@@ -74,7 +74,7 @@ try:
     from paver.tasks import VERSION as _PVER
     if not _PVER >= '1.0':
         raise RuntimeError("paver version >= 1.0 required (was %s)" % _PVER)
-except (ImportError, e):
+except ImportError:
     raise RuntimeError("paver version >= 1.0 required")
 
 import paver


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/scipy/scipy on Python 3.8.0

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./pavement.py:77:22: F821 undefined name 'e'
except (ImportError, e):
                     ^
```

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->