### PR TITLE
scipyoptdoc.py: Remove unused variable 'sixu'

### DIFF
--- a/doc/source/scipyoptdoc.py
+++ b/doc/source/scipyoptdoc.py
@@ -39,12 +39,6 @@ from sphinx.domains.python import PythonDomain
 from scipy._lib._util import getargspec_no_self
 
 
-if sys.version_info[0] >= 3:
-    sixu = lambda s: s
-else:
-    sixu = lambda s: unicode(s, 'unicode_escape')
-
-
 def setup(app):
     app.add_domain(ScipyOptimizeInterfaceDomain)
     return {'parallel_read_safe': True}


### PR DESCRIPTION
The [unused __sixu__](https://github.com/scipy/scipy/search?q=sixu&unscoped_q=sixu) is no longer required because Scipy no longer supports Python2 and __unicode()__ is removed in Python 3.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->