### PR TITLE
xrange() was removed in Python 3 in favor of range()

### DIFF
--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -131,7 +131,6 @@ from . import _hierarchy, _optimal_leaf_ordering
 import scipy.spatial.distance as distance
 
 from scipy._lib.six import string_types
-from scipy._lib.six import xrange
 
 _LINKAGE_METHODS = {'single': 0, 'complete': 1, 'average': 2, 'centroid': 3,
                     'median': 4, 'ward': 5, 'weighted': 6}
@@ -1459,12 +1458,12 @@ def to_tree(Z, rd=False):
     d = [None] * (n * 2 - 1)
 
     # Create the nodes corresponding to the n original objects.
-    for i in xrange(0, n):
+    for i in range(0, n):
         d[i] = ClusterNode(i)
 
     nd = None
 
-    for i in xrange(0, n - 1):
+    for i in range(0, n - 1):
         fi = int(Z[i, 0])
         fj = int(Z[i, 1])
         if fi > i + n:
@@ -2292,7 +2291,7 @@ def is_valid_linkage(Z, warning=False, throw=False, name=None):
 
 def _check_hierarchy_uses_cluster_before_formed(Z):
     n = Z.shape[0] + 1
-    for i in xrange(0, n - 1):
+    for i in range(0, n - 1):
         if Z[i, 0] >= n + i or Z[i, 1] >= n + i:
             return True
     return False
@@ -2301,7 +2300,7 @@ def _check_hierarchy_uses_cluster_before_formed(Z):
 def _check_hierarchy_uses_cluster_more_than_once(Z):
     n = Z.shape[0] + 1
     chosen = set([])
-    for i in xrange(0, n - 1):
+    for i in range(0, n - 1):
         if (Z[i, 0] in chosen) or (Z[i, 1] in chosen) or Z[i, 0] == Z[i, 1]:
             return True
         chosen.add(Z[i, 0])
@@ -2312,7 +2311,7 @@ def _check_hierarchy_uses_cluster_more_than_once(Z):
 def _check_hierarchy_not_all_clusters_used(Z):
     n = Z.shape[0] + 1
     chosen = set([])
-    for i in xrange(0, n - 1):
+    for i in range(0, n - 1):
         chosen.add(int(Z[i, 0]))
         chosen.add(int(Z[i, 1]))
     must_chosen = set(range(0, 2 * n - 2))
@@ -3729,7 +3728,7 @@ def is_isomorphic(T1, T2):
     n = T1S[0]
     d1 = {}
     d2 = {}
-    for i in xrange(0, n):
+    for i in range(0, n):
         if T1[i] in d1:
             if not T2[i] in d2:
                 return False

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -38,7 +38,7 @@ from numpy.testing import assert_allclose, assert_equal, assert_, assert_warns
 import pytest
 from pytest import raises as assert_raises
 
-from scipy._lib.six import xrange, u
+from scipy._lib.six import u
 
 import scipy.cluster.hierarchy
 from scipy.cluster.hierarchy import (
@@ -337,7 +337,7 @@ class TestIsIsomorphic(object):
             a = np.int_(np.random.rand(nobs) * nclusters)
             b = np.zeros(a.size, dtype=np.int_)
             P = np.random.permutation(nclusters)
-            for i in xrange(0, a.shape[0]):
+            for i in range(0, a.shape[0]):
                 b[i] = P[a[i]]
             if noniso:
                 Q = np.random.permutation(nobs)
@@ -378,7 +378,7 @@ class TestIsValidLinkage(object):
     def test_is_valid_linkage_4_and_up(self):
         # Tests is_valid_linkage(Z) on linkage on observation sets between
         # sizes 4 and 15 (step size 3).
-        for i in xrange(4, 15, 3):
+        for i in range(4, 15, 3):
             y = np.random.rand(i*(i-1)//2)
             Z = linkage(y)
             assert_(is_valid_linkage(Z) == True)
@@ -386,7 +386,7 @@ class TestIsValidLinkage(object):
     def test_is_valid_linkage_4_and_up_neg_index_left(self):
         # Tests is_valid_linkage(Z) on linkage on observation sets between
         # sizes 4 and 15 (step size 3) with negative indices (left).
-        for i in xrange(4, 15, 3):
+        for i in range(4, 15, 3):
             y = np.random.rand(i*(i-1)//2)
             Z = linkage(y)
             Z[i//2,0] = -2
@@ -396,7 +396,7 @@ class TestIsValidLinkage(object):
     def test_is_valid_linkage_4_and_up_neg_index_right(self):
         # Tests is_valid_linkage(Z) on linkage on observation sets between
         # sizes 4 and 15 (step size 3) with negative indices (right).
-        for i in xrange(4, 15, 3):
+        for i in range(4, 15, 3):
             y = np.random.rand(i*(i-1)//2)
             Z = linkage(y)
             Z[i//2,1] = -2
@@ -406,7 +406,7 @@ class TestIsValidLinkage(object):
     def test_is_valid_linkage_4_and_up_neg_dist(self):
         # Tests is_valid_linkage(Z) on linkage on observation sets between
         # sizes 4 and 15 (step size 3) with negative distances.
-        for i in xrange(4, 15, 3):
+        for i in range(4, 15, 3):
             y = np.random.rand(i*(i-1)//2)
             Z = linkage(y)
             Z[i//2,2] = -0.5
@@ -416,7 +416,7 @@ class TestIsValidLinkage(object):
     def test_is_valid_linkage_4_and_up_neg_counts(self):
         # Tests is_valid_linkage(Z) on linkage on observation sets between
         # sizes 4 and 15 (step size 3) with negative counts.
-        for i in xrange(4, 15, 3):
+        for i in range(4, 15, 3):
             y = np.random.rand(i*(i-1)//2)
             Z = linkage(y)
             Z[i//2,3] = -2
@@ -455,7 +455,7 @@ class TestIsValidInconsistent(object):
     def test_is_valid_im_4_and_up(self):
         # Tests is_valid_im(R) on im on observation sets between sizes 4 and 15
         # (step size 3).
-        for i in xrange(4, 15, 3):
+        for i in range(4, 15, 3):
             y = np.random.rand(i*(i-1)//2)
             Z = linkage(y)
             R = inconsistent(Z)
@@ -464,7 +464,7 @@ class TestIsValidInconsistent(object):
     def test_is_valid_im_4_and_up_neg_index_left(self):
         # Tests is_valid_im(R) on im on observation sets between sizes 4 and 15
         # (step size 3) with negative link height means.
-        for i in xrange(4, 15, 3):
+        for i in range(4, 15, 3):
             y = np.random.rand(i*(i-1)//2)
             Z = linkage(y)
             R = inconsistent(Z)
@@ -475,7 +475,7 @@ class TestIsValidInconsistent(object):
     def test_is_valid_im_4_and_up_neg_index_right(self):
         # Tests is_valid_im(R) on im on observation sets between sizes 4 and 15
         # (step size 3) with negative link height standard deviations.
-        for i in xrange(4, 15, 3):
+        for i in range(4, 15, 3):
             y = np.random.rand(i*(i-1)//2)
             Z = linkage(y)
             R = inconsistent(Z)
@@ -486,7 +486,7 @@ class TestIsValidInconsistent(object):
     def test_is_valid_im_4_and_up_neg_dist(self):
         # Tests is_valid_im(R) on im on observation sets between sizes 4 and 15
         # (step size 3) with negative link counts.
-        for i in xrange(4, 15, 3):
+        for i in range(4, 15, 3):
             y = np.random.rand(i*(i-1)//2)
             Z = linkage(y)
             R = inconsistent(Z)
@@ -515,7 +515,7 @@ class TestNumObsLinkage(object):
     def test_num_obs_linkage_4_and_up(self):
         # Tests num_obs_linkage(Z) on linkage on observation sets between sizes
         # 4 and 15 (step size 3).
-        for i in xrange(4, 15, 3):
+        for i in range(4, 15, 3):
             y = np.random.rand(i*(i-1)//2)
             Z = linkage(y)
             assert_equal(num_obs_linkage(Z), i)
@@ -566,11 +566,11 @@ class TestCorrespond(object):
     def test_correspond_2_and_up(self):
         # Tests correspond(Z, y) on linkage and CDMs over observation sets of
         # different sizes.
-        for i in xrange(2, 4):
+        for i in range(2, 4):
             y = np.random.rand(i*(i-1)//2)
             Z = linkage(y)
             assert_(correspond(Z, y))
-        for i in xrange(4, 15, 3):
+        for i in range(4, 15, 3):
             y = np.random.rand(i*(i-1)//2)
             Z = linkage(y)
             assert_(correspond(Z, y))
@@ -601,7 +601,7 @@ class TestCorrespond(object):
 
     def test_num_obs_linkage_multi_matrix(self):
         # Tests num_obs_linkage with observation matrices of multiple sizes.
-        for n in xrange(2, 10):
+        for n in range(2, 10):
             X = np.random.rand(n, 4)
             Y = pdist(X)
             Z = linkage(Y)
@@ -926,7 +926,7 @@ def calculate_maximum_distances(Z):
     n = Z.shape[0] + 1
     B = np.zeros((n-1,))
     q = np.zeros((3,))
-    for i in xrange(0, n - 1):
+    for i in range(0, n - 1):
         q[:] = 0.0
         left = Z[i, 0]
         right = Z[i, 1]
@@ -944,7 +944,7 @@ def calculate_maximum_inconsistencies(Z, R, k=3):
     n = Z.shape[0] + 1
     B = np.zeros((n-1,))
     q = np.zeros((3,))
-    for i in xrange(0, n - 1):
+    for i in range(0, n - 1):
         q[:] = 0.0
         left = Z[i, 0]
         right = Z[i, 1]

--- a/scipy/cluster/vq.py
+++ b/scipy/cluster/vq.py
@@ -70,7 +70,6 @@ import warnings
 import numpy as np
 from collections import deque
 from scipy._lib._util import _asarray_validated
-from scipy._lib.six import xrange
 from scipy.spatial.distance import cdist
 
 from . import _vq
@@ -451,7 +450,7 @@ def kmeans(obs, k_or_guess, iter=20, thresh=1e-5, check_finite=True):
 
     # initialize best distance value to a large value
     best_dist = np.inf
-    for i in xrange(iter):
+    for i in range(iter):
         # the initial code book is randomly selected from observations
         guess = _kpoints(obs, k)
         book, dist = _kmeans(obs, guess, thresh=thresh)
@@ -747,7 +746,7 @@ def kmeans2(data, k, iter=10, thresh=1e-5, minit='random',
         else:
             code_book = init_meth(data, k)
 
-    for i in xrange(iter):
+    for i in range(iter):
         # Compute the nearest neighbor for each obs using the current code book
         label = vq(data, code_book)[0]
         # Update the code book by computing centroids

--- a/scipy/integrate/quadrature.py
+++ b/scipy/integrate/quadrature.py
@@ -12,7 +12,6 @@ import warnings
 from numpy import trapz
 from scipy.special import roots_legendre
 from scipy.special import gammaln
-from scipy._lib.six import xrange
 
 __all__ = ['fixed_quad', 'quadrature', 'romberg', 'trapz', 'simps', 'romb',
            'cumtrapz', 'newton_cotes']
@@ -162,7 +161,7 @@ def vectorize1(func, args=(), vec_func=False):
             dtype = getattr(y0, 'dtype', type(y0))
             output = np.empty((n,), dtype=dtype)
             output[0] = y0
-            for i in xrange(1, n):
+            for i in range(1, n):
                 output[i] = func(x[i], *args)
             return output
     return vfunc
@@ -238,7 +237,7 @@ def quadrature(func, a, b, args=(), tol=1.49e-8, rtol=1.49e-8, maxiter=50,
     val = np.inf
     err = np.inf
     maxiter = max(miniter+1, maxiter)
-    for n in xrange(miniter, maxiter+1):
+    for n in range(miniter, maxiter+1):
         newval = fixed_quad(vfunc, a, b, (), n)[0]
         err = abs(newval-val)
         val = newval
@@ -586,12 +585,12 @@ def romb(y, dx=1.0, axis=-1, show=False):
     R[(0, 0)] = (y[slice0] + y[slicem1])/2.0*h
     slice_R = slice_all
     start = stop = step = Ninterv
-    for i in xrange(1, k+1):
+    for i in range(1, k+1):
         start >>= 1
         slice_R = tupleset(slice_R, axis, slice(start, stop, step))
         step >>= 1
         R[(i, 0)] = 0.5*(R[(i-1, 0)] + h*y[slice_R].sum(axis=axis))
-        for j in xrange(1, i+1):
+        for j in range(1, i+1):
             prev = R[(i, j-1)]
             R[(i, j)] = prev + (prev-R[(i-1, j-1)]) / ((1 << (2*j))-1)
         h /= 2.0
@@ -613,8 +612,8 @@ def romb(y, dx=1.0, axis=-1, show=False):
 
             title = "Richardson Extrapolation Table for Romberg Integration"
             print("", title.center(68), "=" * 68, sep="\n", end="\n")
-            for i in xrange(k+1):
-                for j in xrange(i+1):
+            for i in range(k+1):
+                for j in range(i+1):
                     print(formstr % R[(i, j)], end=" ")
                 print()
             print("=" * 68)
@@ -676,9 +675,9 @@ def _printresmat(function, interval, resmat):
     print('from', interval)
     print('')
     print('%6s %9s %9s' % ('Steps', 'StepSize', 'Results'))
-    for i in xrange(len(resmat)):
+    for i in range(len(resmat)):
         print('%6d %9f' % (2**i, (interval[1]-interval[0])/(2.**i)), end=' ')
-        for j in xrange(i+1):
+        for j in range(i+1):
             print('%9f' % (resmat[i][j]), end=' ')
         print('')
     print('')
@@ -782,11 +781,11 @@ def romberg(function, a, b, args=(), tol=1.48e-8, rtol=1.48e-8, show=False,
     resmat = [[result]]
     err = np.inf
     last_row = resmat[0]
-    for i in xrange(1, divmax+1):
+    for i in range(1, divmax+1):
         n *= 2
         ordsum += _difftrap(vfunc, interval, n)
         row = [intrange * ordsum / n]
-        for k in xrange(i):
+        for k in range(i):
             row.append(_romberg_diff(last_row[k], row[k], k+1))
         result = row[i]
         lastresult = last_row[i-1]

--- a/scipy/integrate/tests/test_integrate.py
+++ b/scipy/integrate/tests/test_integrate.py
@@ -8,8 +8,6 @@ import numpy as np
 from numpy import (arange, zeros, array, dot, sqrt, cos, sin, eye, pi, exp,
                    allclose)
 
-from scipy._lib.six import xrange
-
 from numpy.testing import (
     assert_, assert_array_almost_equal,
     assert_allclose, assert_array_equal, assert_equal, assert_warns)
@@ -161,7 +159,7 @@ class TestOde(TestODEClass):
     def test_concurrent_ok(self):
         f = lambda t, y: 1.0
 
-        for k in xrange(3):
+        for k in range(3):
             for sol in ('vode', 'zvode', 'lsoda', 'dopri5', 'dop853'):
                 r = ode(f).set_integrator(sol)
                 r.set_initial_value(0, 0)

--- a/scipy/integrate/tests/test_quadpack.py
+++ b/scipy/integrate/tests/test_quadpack.py
@@ -10,7 +10,6 @@ import pytest
 from pytest import raises as assert_raises
 
 from scipy.integrate import quad, dblquad, tplquad, nquad
-from scipy._lib.six import xrange
 from scipy._lib._ccallback import LowLevelCallable
 
 import ctypes

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -15,7 +15,7 @@ from numpy import (array, transpose, searchsorted, atleast_1d, atleast_2d,
 import scipy.special as spec
 from scipy.special import comb
 
-from scipy._lib.six import xrange, integer_types, string_types
+from scipy._lib.six import integer_types, string_types
 
 from . import fitpack
 from . import dfitpack
@@ -83,9 +83,9 @@ def lagrange(x, w):
 
     M = len(x)
     p = poly1d(0.0)
-    for j in xrange(M):
+    for j in range(M):
         pt = poly1d(w[j])
-        for k in xrange(M):
+        for k in range(M):
             if k == j:
                 continue
             fac = x[j]-x[k]
@@ -1289,7 +1289,7 @@ class PPoly(_PPolyBase):
             t, c, k = tck
 
         cvals = np.empty((k + 1, len(t)-1), dtype=c.dtype)
-        for m in xrange(k, -1, -1):
+        for m in range(k, -1, -1):
             y = fitpack.splev(t[:-1], tck, der=m)
             cvals[k - m, :] = y/spec.gamma(m+1)
 
@@ -2716,7 +2716,7 @@ class _ppform(PPoly):
         # Note: this spline representation is incompatible with FITPACK
         N = len(xk)-1
         sivals = np.empty((order+1, N), dtype=float)
-        for m in xrange(order, -1, -1):
+        for m in range(order, -1, -1):
             fact = spec.gamma(m+1)
             res = _fitpack._bspleval(xk[:-1], xk, cvals, order, m)
             res /= fact

--- a/scipy/interpolate/polyint.py
+++ b/scipy/interpolate/polyint.py
@@ -5,7 +5,6 @@ import warnings
 import numpy as np
 from scipy.special import factorial
 
-from scipy._lib.six import xrange
 from scipy._lib._util import _asarray_validated
 
 
@@ -182,7 +181,7 @@ class _Interpolator1DWithDerivatives(_Interpolator1D):
             nx = len(x_shape)
             ny = len(self._y_extra_shape)
             s = ([0] + list(range(nx+1, nx + self._y_axis+1))
-                 + list(range(1,nx+1)) +
+                 + list(range(1, nx+1)) +
                  list(range(nx+1+self._y_axis, nx+ny+1)))
             y = y.transpose(s)
         return y
@@ -299,13 +298,13 @@ class KroghInterpolator(_Interpolator1DWithDerivatives):
         c = np.zeros((self.n+1, self.r), dtype=self.dtype)
         c[0] = self.yi[0]
         Vk = np.zeros((self.n, self.r), dtype=self.dtype)
-        for k in xrange(1,self.n):
+        for k in range(1, self.n):
             s = 0
             while s <= k and xi[k-s] == xi[k]:
                 s += 1
             s -= 1
             Vk[0] = self.yi[k]/float(factorial(s))
-            for i in xrange(k-s):
+            for i in range(k-s):
                 if xi[i] == xi[k]:
                     raise ValueError("Elements if `xi` can't be equal.")
                 if s == 0:
@@ -337,7 +336,7 @@ class KroghInterpolator(_Interpolator1DWithDerivatives):
         p = np.zeros((len(x), self.r), dtype=self.dtype)
         p += self.c[0, np.newaxis, :]
 
-        for k in xrange(1, n):
+        for k in range(1, n):
             w[k-1] = x - self.xi[k-1]
             pi[k] = w[k-1] * pi[k-1]
             p += pi[k, :, np.newaxis] * self.c[k]
@@ -345,8 +344,8 @@ class KroghInterpolator(_Interpolator1DWithDerivatives):
         cn = np.zeros((max(der, n+1), len(x), r), dtype=self.dtype)
         cn[:n+1, :, :] += self.c[:n+1, np.newaxis, :]
         cn[0] = p
-        for k in xrange(1, n):
-            for i in xrange(1, n-k+1):
+        for k in range(1, n):
+            for i in range(1, n-k+1):
                 pi[i] = w[k+i-1]*pi[i-1] + pi[i]
                 cn[k] = cn[k] + pi[i, :, np.newaxis]*cn[k+i]
             cn[k] *= factorial(k)
@@ -507,7 +506,7 @@ class BarycentricInterpolator(_Interpolator1D):
 
         self.wi = np.zeros(self.n)
         self.wi[0] = 1
-        for j in xrange(1,self.n):
+        for j in range(1, self.n):
             self.wi[:j] *= (self.xi[j]-self.xi[:j])
             self.wi[j] = np.multiply.reduce(self.xi[:j]-self.xi[j])
         self.wi **= -1
@@ -571,7 +570,7 @@ class BarycentricInterpolator(_Interpolator1D):
         old_wi = self.wi
         self.wi = np.zeros(self.n)
         self.wi[:old_n] = old_wi
-        for j in xrange(old_n,self.n):
+        for j in range(old_n, self.n):
             self.wi[:j] *= (self.xi[j]-self.xi[:j])
             self.wi[j] = np.multiply.reduce(self.xi[:j]-self.xi[j])
         self.wi **= -1

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -11,8 +11,6 @@ import pytest
 from numpy import mgrid, pi, sin, ogrid, poly1d, linspace
 import numpy as np
 
-from scipy._lib.six import xrange
-
 from scipy.interpolate import (interp1d, interp2d, lagrange, PPoly, BPoly,
          splrep, splev, splantider, splint, sproot, Akima1DInterpolator,
          RegularGridInterpolator, LinearNDInterpolator, NearestNDInterpolator,
@@ -2215,7 +2213,7 @@ def _ppoly_eval_2(coeffs, breaks, xnew, fill=np.nan):
     pp = coeffs
     diff = xx - breaks.take(indxs)
     V = np.vander(diff, N=K)
-    values = np.array([np.dot(V[k, :], pp[:, indxs[k]]) for k in xrange(len(xx))])
+    values = np.array([np.dot(V[k, :], pp[:, indxs[k]]) for k in range(len(xx))])
     res[mask] = values
     res.shape = saveshape
     return res

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -16,8 +16,6 @@ from scipy.interpolate import (
     PchipInterpolator, pchip_interpolate, Akima1DInterpolator, CubicSpline,
     make_interp_spline)
 
-from scipy._lib.six import xrange
-
 
 def check_shape(interpolator_cls, x_shape, y_shape, deriv_shape=None, axis=0,
                 extra_args={}):
@@ -175,14 +173,14 @@ class TestKrogh(object):
     def test_derivatives(self):
         P = KroghInterpolator(self.xs,self.ys)
         D = P.derivatives(self.test_xs)
-        for i in xrange(D.shape[0]):
+        for i in range(D.shape[0]):
             assert_almost_equal(self.true_poly.deriv(i)(self.test_xs),
                                 D[i])
 
     def test_low_derivatives(self):
         P = KroghInterpolator(self.xs,self.ys)
         D = P.derivatives(self.test_xs,len(self.xs)+2)
-        for i in xrange(D.shape[0]):
+        for i in range(D.shape[0]):
             assert_almost_equal(self.true_poly.deriv(i)(self.test_xs),
                                 D[i])
 
@@ -190,12 +188,12 @@ class TestKrogh(object):
         P = KroghInterpolator(self.xs,self.ys)
         m = 10
         r = P.derivatives(self.test_xs,m)
-        for i in xrange(m):
+        for i in range(m):
             assert_almost_equal(P.derivative(self.test_xs,i),r[i])
 
     def test_high_derivative(self):
         P = KroghInterpolator(self.xs,self.ys)
-        for i in xrange(len(self.xs),2*len(self.xs)):
+        for i in range(len(self.xs), 2*len(self.xs)):
             assert_almost_equal(P.derivative(self.test_xs,i),
                                 np.zeros(len(self.test_xs)))
 
@@ -215,7 +213,7 @@ class TestKrogh(object):
         xs = [0, 1, 2]
         ys = np.array([[0,1],[1,0],[2,1]])
         P = KroghInterpolator(xs,ys)
-        Pi = [KroghInterpolator(xs,ys[:,i]) for i in xrange(ys.shape[1])]
+        Pi = [KroghInterpolator(xs,ys[:,i]) for i in range(ys.shape[1])]
         test_xs = np.linspace(-1,3,100)
         assert_almost_equal(P(test_xs),
                 np.rollaxis(np.asarray([p(test_xs) for p in Pi]),-1))
@@ -298,7 +296,7 @@ class TestTaylor(object):
     def test_exponential(self):
         degree = 5
         p = approximate_taylor_polynomial(np.exp, 0, degree, 1, 15)
-        for i in xrange(degree+1):
+        for i in range(degree+1):
             assert_almost_equal(p(0),1)
             p = p.deriv()
         assert_almost_equal(p(0),0)
@@ -335,7 +333,7 @@ class TestBarycentric(object):
         ys = np.array([[0, 1], [1, 0], [2, 1]])
         BI = BarycentricInterpolator
         P = BI(xs, ys)
-        Pi = [BI(xs, ys[:, i]) for i in xrange(ys.shape[1])]
+        Pi = [BI(xs, ys[:, i]) for i in range(ys.shape[1])]
         test_xs = np.linspace(-1, 3, 100)
         assert_almost_equal(P(test_xs),
                 np.rollaxis(np.asarray([p(test_xs) for p in Pi]), -1))

--- a/scipy/io/arff/tests/test_arffread.py
+++ b/scipy/io/arff/tests/test_arffread.py
@@ -4,7 +4,6 @@ import datetime
 import os
 import sys
 from os.path import join as pjoin
-from scipy._lib.six import xrange
 
 if sys.version_info[0] >= 3:
     from io import StringIO
@@ -319,7 +318,7 @@ class TestRelationalAttributeLong(object):
     def test_data(self):
         dtype_instance = [('attr_number', np.float_)]
 
-        expected = np.array([(n,) for n in xrange(30000)],
+        expected = np.array([(n,) for n in range(30000)],
                             dtype=dtype_instance)
 
         assert_array_equal(self.data["attr_relational"][0],

--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -23,7 +23,6 @@ from numpy import (array, isfinite, inexact, nonzero, iscomplexobj, cast,
                    flatnonzero, conj, asarray, argsort, empty, newaxis,
                    argwhere, iscomplex, eye, zeros, einsum)
 # Local imports
-from scipy._lib.six import xrange
 from scipy._lib._util import _asarray_validated
 from scipy._lib.six import string_types
 from .misc import LinAlgError, _datacopied, norm
@@ -100,7 +99,7 @@ def _geneig(a1, b1, left, right, overwrite_a, overwrite_b,
             vr = _make_complex_eigvecs(w, vr, t)
 
     # the eigenvectors returned by the lapack function are NOT normalized
-    for i in xrange(vr.shape[0]):
+    for i in range(vr.shape[0]):
         if right:
             vr[:, i] /= norm(vr[:, i])
         if left:

--- a/scipy/linalg/special_matrices.py
+++ b/scipy/linalg/special_matrices.py
@@ -2,7 +2,6 @@ from __future__ import division, print_function, absolute_import
 
 import math
 import numpy as np
-from scipy._lib.six import xrange
 from scipy._lib.six import string_types
 from numpy.lib.stride_tricks import as_strided
 
@@ -765,8 +764,8 @@ def invhilbert(n, exact=False):
     else:
         dtype = np.float64
     invh = np.empty((n, n), dtype=dtype)
-    for i in xrange(n):
-        for j in xrange(0, i + 1):
+    for i in range(n):
+        for j in range(0, i + 1):
             s = i + j
             invh[i, j] = ((-1) ** s * (s + 1) *
                           comb(n + i, n - j - 1, exact) *

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -20,8 +20,6 @@ from numpy.testing import (assert_equal, assert_almost_equal,
 import pytest
 from pytest import raises as assert_raises
 
-from scipy._lib.six import xrange
-
 from scipy.linalg import (eig, eigvals, lu, svd, svdvals, cholesky, qr,
      schur, rsf2csf, lu_solve, lu_factor, solve, diagsvd, hessenberg, rq,
      eig_banded, eigvals_banded, eigh, eigvalsh, qr_multiply, qz, orth, ordqz,
@@ -250,7 +248,7 @@ class TestEig(object):
                         err_msg=msg)
 
         length = np.empty(len(vr))
-        for i in xrange(len(vr)):
+        for i in range(len(vr)):
             length[i] = norm(vr[:,i])
         assert_allclose(length, np.ones(length.size), err_msg=msg,
                         atol=1e-7, rtol=1e-7)
@@ -277,7 +275,7 @@ class TestEig(object):
                         atol=1e-7, rtol=1e-7, err_msg=msg)
 
         length = np.empty(len(vr))
-        for i in xrange(len(vr)):
+        for i in range(len(vr)):
             length[i] = norm(vr[:,i])
         assert_allclose(length, np.ones(length.size), err_msg=msg)
 
@@ -335,7 +333,7 @@ class TestEig(object):
         # machines -- so we need to test several values
         olderr = np.seterr(all='ignore')
         try:
-            for k in xrange(100):
+            for k in range(100):
                 A, B = matrices(omega=k*5./100)
                 self._check_gen_eig(A, B)
         finally:
@@ -435,7 +433,7 @@ class TestEigBanded(object):
         LDAB = self.KU + 1
         self.bandmat_sym = zeros((LDAB, N), dtype=float)
         self.bandmat_herm = zeros((LDAB, N), dtype=complex)
-        for i in xrange(LDAB):
+        for i in range(LDAB):
             self.bandmat_sym[LDAB-i-1,i:N] = diag(self.sym_mat, i)
             self.bandmat_herm[LDAB-i-1,i:N] = diag(self.herm_mat, i)
 
@@ -444,7 +442,7 @@ class TestEigBanded(object):
         LDAB = 2*self.KL + self.KU + 1
         self.bandmat_real = zeros((LDAB, N), dtype=float)
         self.bandmat_real[2*self.KL,:] = diag(self.real_mat)     # diagonal
-        for i in xrange(self.KL):
+        for i in range(self.KL):
             # superdiagonals
             self.bandmat_real[2*self.KL-1-i,i+1:N] = diag(self.real_mat, i+1)
             # subdiagonals
@@ -452,7 +450,7 @@ class TestEigBanded(object):
 
         self.bandmat_comp = zeros((LDAB, N), dtype=complex)
         self.bandmat_comp[2*self.KL,:] = diag(self.comp_mat)     # diagonal
-        for i in xrange(self.KL):
+        for i in range(self.KL):
             # superdiagonals
             self.bandmat_comp[2*self.KL-1-i,i+1:N] = diag(self.comp_mat, i+1)
             # subdiagonals
@@ -613,7 +611,7 @@ class TestEigBanded(object):
 
         # extract matrix u from lu_symm_band
         u = diag(lu_symm_band[2*self.KL,:])
-        for i in xrange(self.KL + self.KU):
+        for i in range(self.KL + self.KU):
             u += diag(lu_symm_band[2*self.KL-1-i,i+1:N], i+1)
 
         p_lin, l_lin, u_lin = lu(self.real_mat, permute_l=0)
@@ -627,7 +625,7 @@ class TestEigBanded(object):
 
         # extract matrix u from lu_symm_band
         u = diag(lu_symm_band[2*self.KL,:])
-        for i in xrange(self.KL + self.KU):
+        for i in range(self.KL + self.KU):
             u += diag(lu_symm_band[2*self.KL-1-i,i+1:N], i+1)
 
         p_lin, l_lin, u_lin = lu(self.comp_mat, permute_l=0)

--- a/scipy/linalg/tests/test_fblas.py
+++ b/scipy/linalg/tests/test_fblas.py
@@ -13,8 +13,6 @@ from numpy import float32, float64, complex64, complex128, arange, array, \
 
 from scipy.linalg import _fblas as fblas
 
-from scipy._lib.six import xrange
-
 from numpy.testing import assert_array_equal, \
     assert_allclose, assert_array_almost_equal, assert_
 
@@ -35,10 +33,10 @@ def matrixmultiply(a, b):
         b_is_vector = False
     assert_(a.shape[1] == b.shape[0])
     c = zeros((a.shape[0], b.shape[1]), common_type(a, b))
-    for i in xrange(a.shape[0]):
-        for j in xrange(b.shape[1]):
+    for i in range(a.shape[0]):
+        for j in range(b.shape[1]):
             s = 0
-            for k in xrange(a.shape[1]):
+            for k in range(a.shape[1]):
                 s += a[i, k] * b[k, j]
             c[i, j] = s
     if b_is_vector:

--- a/scipy/linalg/tests/test_special_matrices.py
+++ b/scipy/linalg/tests/test_special_matrices.py
@@ -6,8 +6,6 @@ from numpy.testing import (assert_equal, assert_array_equal,
                            assert_array_almost_equal, assert_allclose)
 from pytest import raises as assert_raises
 
-from scipy._lib.six import xrange
-
 from scipy.fft import fft
 from scipy.special import comb
 from scipy.linalg import (toeplitz, hankel, circulant, hadamard, leslie, dft,
@@ -506,7 +504,7 @@ class TestInvHilbert(object):
         assert_allclose(invhilbert(17), invh17.astype(float), rtol=1e-12)
 
     def test_inverse(self):
-        for n in xrange(1, 10):
+        for n in range(1, 10):
             a = hilbert(n)
             b = invhilbert(n)
             # The Hilbert matrix is increasingly badly conditioned,

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -9,7 +9,7 @@ import numpy as np
 from scipy.optimize import OptimizeResult, minimize
 from scipy.optimize.optimize import _status_message
 from scipy._lib._util import check_random_state, MapWrapper
-from scipy._lib.six import xrange, string_types
+from scipy._lib.six import string_types
 
 from scipy.optimize._constraints import (Bounds, new_bounds_to_old,
                                          NonlinearConstraint, LinearConstraint)
@@ -747,7 +747,7 @@ class DifferentialEvolutionSolver(object):
             self._promote_lowest_energy()
 
         # do the optimization.
-        for nit in xrange(1, self.maxiter + 1):
+        for nit in range(1, self.maxiter + 1):
             # evolve the population by a generation
             try:
                 next(self)

--- a/scipy/optimize/linesearch.py
+++ b/scipy/optimize/linesearch.py
@@ -17,7 +17,6 @@ from warnings import warn
 
 from scipy.optimize import minpack2
 import numpy as np
-from scipy._lib.six import xrange
 
 __all__ = ['LineSearchWarning', 'line_search_wolfe1', 'line_search_wolfe2',
            'scalar_search_wolfe1', 'scalar_search_wolfe2',
@@ -166,7 +165,7 @@ def scalar_search_wolfe1(phi, derphi, phi0=None, old_phi0=None, derphi0=None,
     task = b'START'
 
     maxiter = 100
-    for i in xrange(maxiter):
+    for i in range(maxiter):
         stp, phi1, derphi1, task = minpack2.dcsrch(alpha1, phi1, derphi1,
                                                    c1, c2, xtol, task,
                                                    amin, amax, isave, dsave)
@@ -404,7 +403,7 @@ def scalar_search_wolfe2(phi, derphi, phi0=None,
     if extra_condition is None:
         extra_condition = lambda alpha, phi: True
 
-    for i in xrange(maxiter):
+    for i in range(maxiter):
         if alpha1 == 0 or (amax is not None and alpha0 == amax):
             # alpha1 == 0: This shouldn't happen. Perhaps the increment has
             # slipped below machine precision?

--- a/scipy/optimize/nonlin.py
+++ b/scipy/optimize/nonlin.py
@@ -111,7 +111,7 @@ from __future__ import division, print_function, absolute_import
 
 import sys
 import numpy as np
-from scipy._lib.six import callable, exec_, xrange
+from scipy._lib.six import callable, exec_
 from scipy.linalg import norm, solve, inv, qr, svd, LinAlgError
 from numpy import asarray, dot, vdot
 import scipy.sparse.linalg
@@ -302,7 +302,7 @@ def nonlin_solve(F, x0, jacobian='krylov', iter=None, verbose=False,
     eta_treshold = 0.1
     eta = 1e-3
 
-    for n in xrange(maxiter):
+    for n in range(maxiter):
         status = condition.check(Fx, x, dx)
         if status:
             break
@@ -876,7 +876,7 @@ class LowRankMatrix(object):
         C = dot(C, inv(WH))
         D = dot(D, WH.T.conj())
 
-        for k in xrange(q):
+        for k in range(q):
             self.cs[k] = C[:,k].copy()
             self.ds[k] = D[:,k].copy()
 
@@ -1128,7 +1128,7 @@ class Anderson(GenericBroyden):
             return dx
 
         df_f = np.empty(n, dtype=f.dtype)
-        for k in xrange(n):
+        for k in range(n):
             df_f[k] = vdot(self.df[k], f)
 
         try:
@@ -1139,7 +1139,7 @@ class Anderson(GenericBroyden):
             del self.df[:]
             return dx
 
-        for m in xrange(n):
+        for m in range(n):
             dx += gamma[m]*(self.dx[m] + self.alpha*self.df[m])
         return dx
 
@@ -1151,18 +1151,18 @@ class Anderson(GenericBroyden):
             return dx
 
         df_f = np.empty(n, dtype=f.dtype)
-        for k in xrange(n):
+        for k in range(n):
             df_f[k] = vdot(self.df[k], f)
 
         b = np.empty((n, n), dtype=f.dtype)
-        for i in xrange(n):
-            for j in xrange(n):
+        for i in range(n):
+            for j in range(n):
                 b[i,j] = vdot(self.df[i], self.dx[j])
                 if i == j and self.w0 != 0:
                     b[i,j] -= vdot(self.df[i], self.df[i])*self.w0**2*self.alpha
         gamma = solve(b, df_f)
 
-        for m in xrange(n):
+        for m in range(n):
             dx += gamma[m]*(self.df[m] + self.dx[m]/self.alpha)
         return dx
 
@@ -1180,8 +1180,8 @@ class Anderson(GenericBroyden):
         n = len(self.dx)
         a = np.zeros((n, n), dtype=f.dtype)
 
-        for i in xrange(n):
-            for j in xrange(i, n):
+        for i in range(n):
+            for j in range(i, n):
                 if i == j:
                     wd = self.w0**2
                 else:

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -30,7 +30,7 @@ __docformat__ = "restructuredtext en"
 import warnings
 import sys
 import numpy
-from scipy._lib.six import callable, xrange
+from scipy._lib.six import callable
 from numpy import (atleast_1d, eye, mgrid, argmin, zeros, shape, squeeze,
                    asarray, sqrt, Inf, asfarray, isinf)
 import numpy as np
@@ -1610,7 +1610,7 @@ def _minimize_newtoncg(fun, x0, args=(), jac=None, hess=None, hessp=None,
             A = fhess(*(xk,) + args)
             hcalls = hcalls + 1
 
-        for k2 in xrange(cg_maxiter):
+        for k2 in range(cg_maxiter):
             if numpy.add.reduce(numpy.abs(ri)) <= termcond:
                 break
             if fhess is None:
@@ -2289,7 +2289,7 @@ def _minimize_scalar_golden(func, brack=None, args=(),
     f2 = func(*((x2,) + args))
     funcalls += 2
     nit = 0
-    for i in xrange(maxiter):
+    for i in range(maxiter):
         if numpy.abs(x3 - x0) <= tol * (numpy.abs(x1) + numpy.abs(x2)):
             break
         if (f2 < f1):

--- a/scipy/optimize/tests/test_nonlin.py
+++ b/scipy/optimize/tests/test_nonlin.py
@@ -7,7 +7,6 @@ from __future__ import division, print_function, absolute_import
 from numpy.testing import assert_
 import pytest
 
-from scipy._lib.six import xrange
 from scipy.optimize import nonlin, root
 from numpy import diag, dot
 from numpy.linalg import inv
@@ -183,7 +182,7 @@ class TestSecant(object):
         for j, (x, f) in enumerate(zip(self.xs[1:], self.fs[1:])):
             jac.update(x, f)
 
-            for k in xrange(min(npoints, j+1)):
+            for k in range(min(npoints, j+1)):
                 dx = self.xs[j-k+1] - self.xs[j-k]
                 df = self.fs[j-k+1] - self.fs[j-k]
                 assert_(np.allclose(dx, jac.solve(df)))
@@ -309,7 +308,7 @@ class TestJacobianDotSolve(object):
         jac.setup(x0, self._func(x0), self._func)
 
         # check consistency
-        for k in xrange(2*N):
+        for k in range(2*N):
             v = rand(N)
 
             if hasattr(jac, '__array__'):

--- a/scipy/signal/_peak_finding.py
+++ b/scipy/signal/_peak_finding.py
@@ -6,7 +6,6 @@ from __future__ import division, print_function, absolute_import
 import math
 import numpy as np
 
-from scipy._lib.six import xrange
 from scipy.signal.wavelets import cwt, ricker
 from scipy.stats import scoreatpercentile
 
@@ -71,7 +70,7 @@ def _boolrelextrema(data, comparator, axis=0, order=1, mode='clip'):
 
     results = np.ones(data.shape, dtype=bool)
     main = data.take(locs, axis=axis, mode=mode)
-    for shift in xrange(1, order + 1):
+    for shift in range(1, order + 1):
         plus = data.take(locs + shift, axis=axis, mode=mode)
         minus = data.take(locs - shift, axis=axis, mode=mode)
         results &= comparator(main, plus)
@@ -1109,7 +1108,7 @@ def _identify_ridge_lines(matr, max_distances, gap_thresh):
         # XXX Modifying a list while iterating over it.
         # Should be safe, since we iterate backwards, but
         # still tacky.
-        for ind in xrange(len(ridge_lines) - 1, -1, -1):
+        for ind in range(len(ridge_lines) - 1, -1, -1):
             line = ridge_lines[ind]
             if line[2] > gap_thresh:
                 final_lines.append(line)

--- a/scipy/signal/bsplines.py
+++ b/scipy/signal/bsplines.py
@@ -1,6 +1,5 @@
 from __future__ import division, print_function, absolute_import
 
-from scipy._lib.six import xrange
 from numpy import (logical_and, asarray, pi, zeros_like,
                    piecewise, array, arctan2, tan, zeros, arange, floor)
 from numpy.core.umath import (sqrt, exp, greater, less, cos, add, sin,
@@ -79,7 +78,7 @@ def _bspline_piecefunctions(order):
         startbound = -0.5
     condfuncs = [condfuncgen(0, 0, startbound)]
     bound = startbound
-    for num in xrange(1, last - 1):
+    for num in range(1, last - 1):
         condfuncs.append(condfuncgen(1, bound, bound - 1))
         bound = bound - 1
     condfuncs.append(condfuncgen(2, 0, -(order + 1) / 2.0))
@@ -97,8 +96,8 @@ def _bspline_piecefunctions(order):
         if (Mk < 0):
             return 0  # final function is 0
         coeffs = [(1 - 2 * (k % 2)) * float(comb(order + 1, k, exact=1)) / fval
-                  for k in xrange(Mk + 1)]
-        shifts = [-bound - k for k in xrange(Mk + 1)]
+                  for k in range(Mk + 1)]
+        shifts = [-bound - k for k in range(Mk + 1)]
 
         def thefunc(x):
             res = 0.0
@@ -107,7 +106,7 @@ def _bspline_piecefunctions(order):
             return res
         return thefunc
 
-    funclist = [piecefuncgen(k) for k in xrange(last)]
+    funclist = [piecefuncgen(k) for k in range(last)]
 
     _splinefunc_cache[order] = (funclist, condfuncs)
 

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -30,7 +30,6 @@ import scipy._lib.six as six
 from scipy.linalg import qr as s_qr
 from scipy import integrate, interpolate, linalg
 from scipy.interpolate import interp1d
-from scipy._lib.six import xrange
 from .filter_design import (tf2zpk, zpk2tf, normalize, freqs, freqz, freqs_zpk,
                             freqz_zpk)
 from .lti_conversion import (tf2ss, abcd_normalize, ss2tf, zpk2ss, ss2zpk,
@@ -1971,7 +1970,7 @@ def lsim(system, U, T, X0=None, interp=True):
         # Zero input: just use matrix exponential
         # take transpose because state is a row vector
         expAT_dt = linalg.expm(transpose(A) * dt)
-        for i in xrange(1, n_steps):
+        for i in range(1, n_steps):
             xout[i] = dot(xout[i-1], expAT_dt)
         yout = squeeze(dot(xout, transpose(C)))
         return T, squeeze(yout), squeeze(xout)
@@ -2003,7 +2002,7 @@ def lsim(system, U, T, X0=None, interp=True):
         expMT = linalg.expm(transpose(M))
         Ad = expMT[:n_states, :n_states]
         Bd = expMT[n_states:, :n_states]
-        for i in xrange(1, n_steps):
+        for i in range(1, n_steps):
             xout[i] = dot(xout[i-1], Ad) + dot(U[i-1], Bd)
     else:
         # Linear interpolation between steps
@@ -2025,7 +2024,7 @@ def lsim(system, U, T, X0=None, interp=True):
         Ad = expMT[:n_states, :n_states]
         Bd1 = expMT[n_states+n_inputs:, :n_states]
         Bd0 = expMT[n_states:n_states + n_inputs, :n_states] - Bd1
-        for i in xrange(1, n_steps):
+        for i in range(1, n_steps):
             xout[i] = (dot(xout[i-1], Ad) + dot(U[i-1], Bd0) + dot(U[i], Bd1))
 
     yout = (squeeze(dot(xout, transpose(C))) + squeeze(dot(U, transpose(D))))

--- a/scipy/signal/tests/test_peak_finding.py
+++ b/scipy/signal/tests/test_peak_finding.py
@@ -12,7 +12,6 @@ from numpy.testing import (
 import pytest
 from pytest import raises, warns
 
-from scipy._lib.six import xrange
 from scipy.signal._peak_finding import (
     argrelmax,
     argrelmin,
@@ -72,7 +71,7 @@ def _gen_ridge_line(start_locs, max_locs, length, distances, gaps):
         raise ValueError('Cannot generate ridge line according to constraints')
     dist_int = length / len(distances) - 1
     gap_int = length / len(gaps) - 1
-    for ind in xrange(1, length):
+    for ind in range(1, length):
         nextcol = locs[ind - 1, 1]
         nextrow = locs[ind - 1, 0] + 1
         if (ind % dist_int == 0) and (len(distances) > 0):
@@ -313,7 +312,7 @@ class TestArgrel(object):
         test_data_2 = np.vstack([test_data, test_data[rot_range]])
         rel_max_rows, rel_max_cols = argrelmax(test_data_2, axis=1, order=1)
 
-        for rw in xrange(0, test_data_2.shape[0]):
+        for rw in range(0, test_data_2.shape[0]):
             inds = (rel_max_rows == rw)
 
             assert_(len(rel_max_cols[inds]) == len(act_locs))

--- a/scipy/signal/tests/test_wavelets.py
+++ b/scipy/signal/tests/test_wavelets.py
@@ -3,7 +3,6 @@ from __future__ import division, print_function, absolute_import
 import numpy as np
 from numpy.testing import assert_equal, \
     assert_array_equal, assert_array_almost_equal, assert_array_less, assert_
-from scipy._lib.six import xrange
 
 from scipy.signal import wavelets
 
@@ -13,12 +12,12 @@ class TestWavelets(object):
         assert_array_equal(wavelets.qmf([1, 1]), [1, -1])
 
     def test_daub(self):
-        for i in xrange(1, 15):
+        for i in range(1, 15):
             assert_equal(len(wavelets.daub(i)), i * 2)
 
     def test_cascade(self):
-        for J in xrange(1, 7):
-            for i in xrange(1, 5):
+        for J in range(1, 7):
+            for i in range(1, 5):
                 lpcoef = wavelets.daub(i)
                 k = len(lpcoef)
                 x, phi, psi = wavelets.cascade(lpcoef, J)

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -3,7 +3,6 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 
-from scipy._lib.six import xrange
 from .sputils import (isdense, isscalarlike, isintlike,
                       get_sum_dtype, validateaxis, check_reshape_kwargs,
                       check_shape, asmatrix)
@@ -203,7 +202,7 @@ class spmatrix(object):
                             'point format' % self.dtype.name)
 
     def __iter__(self):
-        for r in xrange(self.shape[0]):
+        for r in range(self.shape[0]):
             yield self[r, :]
 
     def getmaxprint(self):
@@ -1153,7 +1152,7 @@ class spmatrix(object):
             if values.ndim == 0:
                 # broadcast
                 max_index = min(M+k, N)
-                for i in xrange(max_index):
+                for i in range(max_index):
                     self[i - k, i] = values
             else:
                 max_index = min(M+k, N, len(values))
@@ -1165,7 +1164,7 @@ class spmatrix(object):
             if values.ndim == 0:
                 # broadcast
                 max_index = min(M, N-k)
-                for i in xrange(max_index):
+                for i in range(max_index):
                     self[i, i + k] = values
             else:
                 max_index = min(M, N-k, len(values))

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -7,7 +7,7 @@ from warnings import warn
 import operator
 
 import numpy as np
-from scipy._lib.six import zip as izip, xrange
+from scipy._lib.six import zip as izip
 from scipy._lib._util import _prune_array
 
 from .base import spmatrix, isspmatrix, SparseEfficiencyWarning
@@ -706,7 +706,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
 
         M, N = self._swap(self.shape)
         start, stop, step = idx.indices(M)
-        M = len(xrange(start, stop, step))
+        M = len(range(start, stop, step))
         new_shape = self._swap((M, N))
         if M == 0:
             return self.__class__(new_shape)
@@ -766,7 +766,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
 
         M, N = self._swap(self.shape)
         start, stop, step = idx.indices(N)
-        N = len(xrange(start, stop, step))
+        N = len(range(start, stop, step))
         if N == 0:
             return self.__class__(self._swap((M, N)))
         if step == 1:

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -10,8 +10,6 @@ __all__ = ['spdiags', 'eye', 'identity', 'kron', 'kronsum',
 
 import numpy as np
 
-from scipy._lib.six import xrange
-
 from .sputils import upcast, get_index_dtype, isscalarlike
 
 from .csr import csr_matrix

--- a/scipy/sparse/csr.py
+++ b/scipy/sparse/csr.py
@@ -7,7 +7,6 @@ __docformat__ = "restructuredtext en"
 __all__ = ['csr_matrix', 'isspmatrix_csr']
 
 import numpy as np
-from scipy._lib.six import xrange
 
 from .base import spmatrix
 from ._sparsetools import (csr_tocsc, csr_tobsr, csr_count_blocks,
@@ -147,7 +146,7 @@ class csr_matrix(_cs_matrix):
         ptr,ind,dat = self.indptr,self.indices,self.data
         rows, data = lil.rows, lil.data
 
-        for n in xrange(self.shape[0]):
+        for n in range(self.shape[0]):
             start = ptr[n]
             end = ptr[n+1]
             rows[n] = ind[start:end].tolist()

--- a/scipy/sparse/dok.py
+++ b/scipy/sparse/dok.py
@@ -9,7 +9,7 @@ __all__ = ['dok_matrix', 'isspmatrix_dok']
 import itertools
 import numpy as np
 
-from scipy._lib.six import zip as izip, xrange, iteritems, iterkeys, itervalues
+from scipy._lib.six import zip as izip, iteritems, iterkeys, itervalues
 
 from .base import spmatrix, isspmatrix
 from ._index import IndexMixin
@@ -169,8 +169,8 @@ class dok_matrix(spmatrix, IndexMixin, dict):
     def _get_sliceXslice(self, row, col):
         row_start, row_stop, row_step = row.indices(self.shape[0])
         col_start, col_stop, col_step = col.indices(self.shape[1])
-        row_range = xrange(row_start, row_stop, row_step)
-        col_range = xrange(col_start, col_stop, col_step)
+        row_range = range(row_start, row_stop, row_step)
+        col_range = range(col_start, col_stop, col_step)
         shape = (len(row_range), len(col_range))
         # Switch paths only when advantageous
         # (count the iterations in the loops, adjust for complexity)
@@ -220,7 +220,7 @@ class dok_matrix(spmatrix, IndexMixin, dict):
         i, j = map(np.atleast_2d, np.broadcast_arrays(row, col))
         newdok = dok_matrix(i.shape, dtype=self.dtype)
 
-        for key in itertools.product(xrange(i.shape[0]), xrange(i.shape[1])):
+        for key in itertools.product(range(i.shape[0]), range(i.shape[1])):
             v = dict.get(self, (i[key], j[key]), 0)
             if v:
                 dict.__setitem__(newdok, key, v)
@@ -251,7 +251,7 @@ class dok_matrix(spmatrix, IndexMixin, dict):
             new = dok_matrix(self.shape, dtype=res_dtype)
             # Add this scalar to every element.
             M, N = self.shape
-            for key in itertools.product(xrange(M), xrange(N)):
+            for key in itertools.product(range(M), range(N)):
                 aij = dict.get(self, (key), 0) + other
                 if aij:
                     new[key] = aij
@@ -280,7 +280,7 @@ class dok_matrix(spmatrix, IndexMixin, dict):
         if isscalarlike(other):
             new = dok_matrix(self.shape, dtype=self.dtype)
             M, N = self.shape
-            for key in itertools.product(xrange(M), xrange(N)):
+            for key in itertools.product(range(M), range(N)):
                 aij = dict.get(self, (key), 0) + other
                 if aij:
                     new[key] = aij

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -11,7 +11,7 @@ from bisect import bisect_left
 
 import numpy as np
 
-from scipy._lib.six import xrange, zip
+from scipy._lib.six import zip
 from .base import spmatrix, isspmatrix
 from ._index import IndexMixin, INT_TYPES, _broadcast_arrays
 from .sputils import (getdtype, isshape, isscalarlike, upcast_scalar,
@@ -231,7 +231,7 @@ class lil_matrix(spmatrix, IndexMixin):
         return self.dtype.type(v)
 
     def _get_sliceXint(self, row, col):
-        row = xrange(*row.indices(self.shape[0]))
+        row = range(*row.indices(self.shape[0]))
         return self._get_row_ranges(row, slice(col, col+1))
 
     def _get_arrayXint(self, row, col):
@@ -241,7 +241,7 @@ class lil_matrix(spmatrix, IndexMixin):
         return self._get_row_ranges((row,), col)
 
     def _get_sliceXslice(self, row, col):
-        row = xrange(*row.indices(self.shape[0]))
+        row = range(*row.indices(self.shape[0]))
         return self._get_row_ranges(row, col)
 
     def _get_arrayXslice(self, row, col):
@@ -280,14 +280,14 @@ class lil_matrix(spmatrix, IndexMixin):
 
         Parameters
         ----------
-        rows : sequence or xrange
-            Rows indexed. If xrange, must be within valid bounds.
+        rows : sequence or range
+            Rows indexed. If range, must be within valid bounds.
         col_slice : slice
             Columns indexed
 
         """
         j_start, j_stop, j_stride = col_slice.indices(self.shape[1])
-        col_range = xrange(j_start, j_stop, j_stride)
+        col_range = range(j_start, j_stop, j_stride)
         nj = len(col_range)
         new = lil_matrix((len(rows), nj), dtype=self.dtype)
 
@@ -364,7 +364,7 @@ class lil_matrix(spmatrix, IndexMixin):
         new = lil_matrix(self.shape, dtype=self.dtype)
         # This is ~14x faster than calling deepcopy() on rows and data.
         _csparsetools.lil_get_row_ranges(M, N, self.rows, self.data,
-                                         new.rows, new.data, xrange(M),
+                                         new.rows, new.data, range(M),
                                          0, N, 1, N)
         return new
 

--- a/scipy/sparse/linalg/isolve/_gcrotmk.py
+++ b/scipy/sparse/linalg/isolve/_gcrotmk.py
@@ -6,7 +6,6 @@ from __future__ import division, print_function, absolute_import
 import warnings
 import numpy as np
 from numpy.linalg import LinAlgError
-from scipy._lib.six import xrange
 from scipy.linalg import (get_blas_funcs, qr, solve, svd, qr_insert, lstsq)
 from scipy.sparse.linalg.isolve.utils import make_system
 
@@ -89,7 +88,7 @@ def _fgmres(matvec, v0, m, atol, lpsolve=None, rpsolve=None, cs=(), outer_v=(),
     breakdown = False
 
     # FGMRES Arnoldi process
-    for j in xrange(m):
+    for j in range(m):
         # L A Z = C B + V H
 
         if prepend_outer_v and j < len(outer_v):
@@ -326,9 +325,9 @@ def gcrotmk(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
 
         # U := U P R^-1,  back-substitution
         new_us = []
-        for j in xrange(len(cs)):
+        for j in range(len(cs)):
             u = us[P[j]]
-            for i in xrange(j):
+            for i in range(j):
                 u = axpy(us[P[i]], u, u.shape[0], -R[i,j])
             if abs(R[j,j]) < 1e-12 * abs(R[0,0]):
                 # discard rest of the vectors
@@ -356,7 +355,7 @@ def gcrotmk(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
             r = axpy(c, r, r.shape[0], -yc)
 
     # GCROT main iteration
-    for j_outer in xrange(maxiter):
+    for j_outer in range(maxiter):
         # -- callback
         if callback is not None:
             callback(x)

--- a/scipy/sparse/linalg/isolve/lgmres.py
+++ b/scipy/sparse/linalg/isolve/lgmres.py
@@ -6,7 +6,6 @@ from __future__ import division, print_function, absolute_import
 import warnings
 import numpy as np
 from numpy.linalg import LinAlgError
-from scipy._lib.six import xrange
 from scipy.linalg import get_blas_funcs, get_lapack_funcs
 from .utils import make_system
 
@@ -149,7 +148,7 @@ def lgmres(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
     b_norm = nrm2(b)
     ptol_max_factor = 1.0
 
-    for k_outer in xrange(maxiter):
+    for k_outer in range(maxiter):
         r_outer = matvec(x) - b
 
         # -- callback

--- a/scipy/sparse/linalg/isolve/tests/test_lsqr.py
+++ b/scipy/sparse/linalg/isolve/tests/test_lsqr.py
@@ -3,7 +3,6 @@ from __future__ import division, print_function, absolute_import
 import numpy as np
 from numpy.testing import (assert_, assert_equal, assert_almost_equal,
                            assert_array_almost_equal)
-from scipy._lib.six import xrange
 
 import scipy.sparse
 import scipy.sparse.linalg
@@ -16,7 +15,7 @@ G = np.eye(n)
 normal = np.random.normal
 norm = np.linalg.norm
 
-for jj in xrange(5):
+for jj in range(5):
     gg = normal(size=n)
     hh = gg * gg.T
     G += (hh + hh.T) * 0.5

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -26,7 +26,7 @@ import platform
 from distutils.version import LooseVersion
 
 import numpy as np
-from scipy._lib.six import xrange, zip as izip
+from scipy._lib.six import zip as izip
 from numpy import (arange, zeros, array, dot, asarray,
                    vstack, ndarray, transpose, diag, kron, inf, conjugate,
                    int8, ComplexWarning)
@@ -1665,8 +1665,8 @@ class _TestCommon(object):
         frac = .3
         random.seed(0)  # make runs repeatable
         A = zeros((L,2))
-        for i in xrange(L):
-            for j in xrange(2):
+        for i in range(L):
+            for j in range(2):
                 r = random.random()
                 if r < frac:
                     A[i,j] = r/frac
@@ -2570,11 +2570,11 @@ class _TestSlicingAssign(object):
                     B[a,b] = 10*i + 1000*(j+1)
                     assert_array_equal(A.todense(), B, repr((a, b)))
 
-            A[0, 1:10:2] = xrange(1,10,2)
-            B[0, 1:10:2] = xrange(1,10,2)
+            A[0, 1:10:2] = range(1, 10, 2)
+            B[0, 1:10:2] = range(1, 10, 2)
             assert_array_equal(A.todense(), B)
-            A[1:5:2,0] = np.array(range(1,5,2))[:,None]
-            B[1:5:2,0] = np.array(range(1,5,2))[:,None]
+            A[1:5:2,0] = np.array(range(1, 5, 2))[:,None]
+            B[1:5:2,0] = np.array(range(1, 5, 2))[:,None]
             assert_array_equal(A.todense(), B)
 
         # The next commands should raise exceptions

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -116,7 +116,6 @@ import numpy as np
 from functools import partial
 from collections import namedtuple
 from scipy._lib.six import callable, string_types
-from scipy._lib.six import xrange
 from scipy._lib._util import _asarray_validated
 
 from . import _distance_wrap
@@ -2042,8 +2041,8 @@ def pdist(X, metric='euclidean', *args, **kwargs):
                                                    metric_name, **kwargs)
 
         k = 0
-        for i in xrange(0, m - 1):
-            for j in xrange(i + 1, m):
+        for i in range(0, m - 1):
+            for j in range(i + 1, m):
                 dm[k] = metric(X[i], X[j], **kwargs)
                 k = k + 1
 
@@ -2077,7 +2076,7 @@ def pdist(X, metric='euclidean', *args, **kwargs):
             # The denom. ||u||*||v||
             de = np.dot(nV, nV.T)
             dm = 1.0 - (nm / de)
-            dm[xrange(0, m), xrange(0, m)] = 0.0
+            dm[range(0, m), range(0, m)] = 0.0
             dm = squareform(dm)
         elif mstr.startswith("test_"):
             if mstr in _TEST_METRICS:
@@ -2267,7 +2266,7 @@ def is_valid_dm(D, tol=0.0, throw=False, name="D", warning=False):
                                      'symmetric.') % name)
                 else:
                     raise ValueError('Distance matrix must be symmetric.')
-            if not (D[xrange(0, s[0]), xrange(0, s[0])] == 0).all():
+            if not (D[range(0, s[0]), range(0, s[0])] == 0).all():
                 if name:
                     raise ValueError(('Distance matrix \'%s\' diagonal must '
                                       'be zero.') % name)
@@ -2282,7 +2281,7 @@ def is_valid_dm(D, tol=0.0, throw=False, name="D", warning=False):
                 else:
                     raise ValueError('Distance matrix must be symmetric within'
                                      ' tolerance %5.5f.' % tol)
-            if not (D[xrange(0, s[0]), xrange(0, s[0])] <= tol).all():
+            if not (D[range(0, s[0]), range(0, s[0])] <= tol).all():
                 if name:
                     raise ValueError(('Distance matrix \'%s\' diagonal must be'
                                       ' close to zero within tolerance %5.5f.')
@@ -2759,8 +2758,8 @@ def cdist(XA, XB, metric='euclidean', *args, **kwargs):
         XA, XB, typ, kwargs = _validate_cdist_input(XA, XB, mA, mB, n,
                                                     metric_name, **kwargs)
 
-        for i in xrange(0, mA):
-            for j in xrange(0, mB):
+        for i in range(0, mA):
+            for j in range(0, mB):
                 dm[i, j] = metric(XA[i], XB[j], **kwargs)
 
     elif isinstance(metric, string_types):

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -37,7 +37,7 @@ from __future__ import division, print_function, absolute_import
 import os.path
 
 from functools import wraps, partial
-from scipy._lib.six import xrange, u
+from scipy._lib.six import u
 
 import numpy as np
 import warnings
@@ -1627,7 +1627,7 @@ class TestSquareForm(object):
         assert_array_equal(rv, np.array([[0, 8.3], [8.3, 0]], dtype=dtype))
 
     def test_squareform_multi_matrix(self):
-        for n in xrange(2, 5):
+        for n in range(2, 5):
             self.check_squareform_multi_matrix(n)
 
     def check_squareform_multi_matrix(self, n):
@@ -1643,8 +1643,8 @@ class TestSquareForm(object):
         assert_equal(len(s), 2)
         assert_equal(len(Yr.shape), 1)
         assert_equal(s[0], s[1])
-        for i in xrange(0, s[0]):
-            for j in xrange(i + 1, s[1]):
+        for i in range(0, s[0]):
+            for j in range(i + 1, s[1]):
                 if i != j:
                     assert_equal(A[i, j], Y[k])
                     k += 1
@@ -1655,7 +1655,7 @@ class TestSquareForm(object):
 class TestNumObsY(object):
 
     def test_num_obs_y_multi_matrix(self):
-        for n in xrange(2, 10):
+        for n in range(2, 10):
             X = np.random.rand(n, 4)
             Y = wpdist_no_const(X)
             assert_equal(num_obs_y(Y), n)
@@ -1677,16 +1677,16 @@ class TestNumObsY(object):
         assert_(self.check_y(4))
 
     def test_num_obs_y_5_10(self):
-        for i in xrange(5, 16):
+        for i in range(5, 16):
             self.minit(i)
 
     def test_num_obs_y_2_100(self):
         # Tests num_obs_y(y) on 100 improper condensed distance matrices.
         # Expecting exception.
         a = set([])
-        for n in xrange(2, 16):
+        for n in range(2, 16):
             a.add(n * (n - 1) / 2)
-        for i in xrange(5, 105):
+        for i in range(5, 105):
             if i not in a:
                 assert_raises(ValueError, self.bad_y, i)
 
@@ -1707,7 +1707,7 @@ class TestNumObsY(object):
 class TestNumObsDM(object):
 
     def test_num_obs_dm_multi_matrix(self):
-        for n in xrange(1, 10):
+        for n in range(1, 10):
             X = np.random.rand(n, 4)
             Y = wpdist_no_const(X)
             A = squareform(Y)
@@ -1764,14 +1764,14 @@ class TestIsValidDM(object):
     def test_is_valid_dm_nonzero_diagonal_E(self):
         y = np.random.rand(10)
         D = squareform(y)
-        for i in xrange(0, 5):
+        for i in range(0, 5):
             D[i, i] = 2.0
         assert_raises(ValueError, is_valid_dm_throw, (D))
 
     def test_is_valid_dm_nonzero_diagonal_F(self):
         y = np.random.rand(10)
         D = squareform(y)
-        for i in xrange(0, 5):
+        for i in range(0, 5):
             D[i, i] = 2.0
         assert_equal(is_valid_dm(D), False)
 
@@ -1855,9 +1855,9 @@ class TestIsValidY(object):
 
     def test_is_valid_y_2_100(self):
         a = set([])
-        for n in xrange(2, 16):
+        for n in range(2, 16):
             a.add(n * (n - 1) / 2)
-        for i in xrange(5, 105):
+        for i in range(5, 105):
             if i not in a:
                 assert_raises(ValueError, self.bad_y, i)
 

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -9,7 +9,6 @@ from numpy.testing import (assert_equal, assert_almost_equal,
                            assert_, assert_allclose, assert_array_equal)
 import pytest
 from pytest import raises as assert_raises
-from scipy._lib.six import xrange
 
 import scipy.spatial.qhull as qhull
 from scipy.spatial import cKDTree as KDTree
@@ -116,7 +115,7 @@ def _add_inc_data(name, chunksize):
         nmin = 12
 
     chunks = [points[:nmin]]
-    for j in xrange(nmin, len(points), chunksize):
+    for j in range(nmin, len(points), chunksize):
         chunks.append(points[j:j+chunksize])
 
     new_name = "%s-chunk-%d" % (name, chunksize)
@@ -362,7 +361,7 @@ class TestUtilities(object):
 
         npoints = {2: 70, 3: 11, 4: 5, 5: 3}
 
-        for ndim in xrange(2, 6):
+        for ndim in range(2, 6):
             # Generate an uniform grid in n-d unit cube
             x = np.linspace(0, 1, npoints[ndim])
             grid = np.c_[list(map(np.ravel, np.broadcast_arrays(*np.ix_(*([x]*ndim)))))].T
@@ -439,9 +438,9 @@ class TestDelaunay(object):
 
     def test_nd_simplex(self):
         # simple smoke test: triangulate a n-dimensional simplex
-        for nd in xrange(2, 8):
+        for nd in range(2, 8):
             points = np.zeros((nd+1, nd))
-            for j in xrange(nd):
+            for j in range(nd):
                 points[j,j] = 1.0
             points[-1,:] = 1.0
 

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -7,7 +7,6 @@ from __future__ import division, print_function, absolute_import
 import operator
 import numpy as np
 import math
-from scipy._lib.six import xrange
 from numpy import (pi, asarray, floor, isscalar, iscomplex, real,
                    imag, sqrt, where, mgrid, sin, place, issubdtype,
                    extract, inexact, nan, zeros, sinc)
@@ -607,7 +606,7 @@ def _bessel_diff_formula(v, z, n, L, phase):
     v = asarray(v)
     p = 1.0
     s = L(v-n, z)
-    for i in xrange(1, n+1):
+    for i in range(1, n+1):
         p = phase * (p * (n-i+1)) / i   # = choose(k, i)
         s += p*L(v-n + i*2, z)
     return s / (2.**n)
@@ -2241,7 +2240,7 @@ def perm(N, k, exact=False):
         if (k > N) or (N < 0) or (k < 0):
             return 0
         val = 1
-        for i in xrange(N - k + 1, N + 1):
+        for i in range(N - k + 1, N + 1):
             val *= i
         return val
     else:
@@ -2348,7 +2347,7 @@ def factorial(n, exact=False):
             if un.size:
                 val = math.factorial(un[0])
                 out[n == un[0]] = val
-                for i in xrange(len(un) - 1):
+                for i in range(len(un) - 1):
                     prev = un[i] + 1
                     current = un[i + 1]
                     val *= _range_prod(prev, current)
@@ -2403,7 +2402,7 @@ def factorial2(n, exact=False):
         if n <= 0:
             return 1
         val = 1
-        for k in xrange(n, 0, -2):
+        for k in range(n, 0, -2):
             val *= k
         return val
     else:
@@ -2468,7 +2467,7 @@ def factorialk(n, k, exact=True):
         if n <= 0:
             return 1
         val = 1
-        for j in xrange(n, 0, -k):
+        for j in range(n, 0, -k):
             val = val*j
         return val
     else:

--- a/scipy/special/tests/test_orthogonal.py
+++ b/scipy/special/tests/test_orthogonal.py
@@ -9,7 +9,6 @@ from numpy.testing import (assert_array_almost_equal, assert_equal,
 import pytest
 from pytest import raises as assert_raises
 
-from scipy._lib.six import xrange
 from scipy import integrate
 import scipy.special as sc
 from scipy.special import gamma
@@ -249,7 +248,7 @@ class _test_sh_jacobi(object):
 class TestCall(object):
     def test_call(self):
         poly = []
-        for n in xrange(5):
+        for n in range(5):
             poly.extend([x.strip() for x in
                 ("""
                 orth.jacobi(%(n)d,0.3,0.9)
@@ -462,7 +461,7 @@ def test_roots_hermite_asy():
         H[0,:] = np.pi**(-0.25) * np.exp(-0.5*nodes**2)
         if n > 1:
             H[1,:] = sqrt(2.0) * nodes * H[0,:]
-            for k in xrange(2, n):
+            for k in range(2, n):
                 H[k,:] = sqrt(2.0/k) * nodes * H[k-1,:] - sqrt((k-1.0)/k) * H[k-2,:]
         return H
 

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -2,7 +2,6 @@ from __future__ import division, print_function, absolute_import
 
 import numpy.testing as npt
 import numpy as np
-from scipy._lib.six import xrange
 import pytest
 
 from scipy import stats
@@ -217,7 +216,7 @@ def check_discrete_chisquare(distfn, arg, rvs, alpha, msg):
     _a, _b = distfn.support(*arg)
     lo = int(max(_a, -1000))
     high = int(min(_b, 1000)) + 1
-    distsupport = xrange(lo, high)
+    distsupport = range(lo, high)
     last = 0
     distsupp = [lo]
     distmass = []

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -27,7 +27,6 @@ import numpy as np
 import scipy.stats as stats
 import scipy.stats.mstats as mstats
 import scipy.stats.mstats_basic as mstats_basic
-from scipy._lib.six import xrange
 from .common_tests import check_named_results
 from scipy.special import kv
 from scipy.sparse.sputils import matrix


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
Remove all instances of __from scipy.\_lib.six import xrange__ and
convert all calls to __xrange()__ into calls to __range()__.

#### Additional information
<!--Any additional information you think is important.-->