### PR TITLE
range() was removed in Py3 in _binned_statistic.py

### DIFF
--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -2,7 +2,7 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 from numpy.testing import suppress_warnings
-from scipy._lib.six import callable, xrange
+from scipy._lib.six import callable
 from collections import namedtuple
 
 __all__ = ['binned_statistic',
@@ -511,6 +511,7 @@ def binned_statistic_dd(sample, values, statistic='mean',
     ...                                  binned_statistic_result=ret,
     ...                                  statistic='mean')
     """
+    import builtins
     known_stats = ['mean', 'median', 'count', 'sum', 'std', 'min', 'max']
     if not callable(statistic) and statistic not in known_stats:
         raise ValueError('invalid statistic %r' % (statistic,))
@@ -554,9 +555,9 @@ def binned_statistic_dd(sample, values, statistic='mean',
         binnumbers = _bin_numbers(sample, nbin, edges, dedges)
     else:
         edges = binned_statistic_result.bin_edges
-        nbin = np.array([len(edges[i]) + 1 for i in xrange(Ndim)])
+        nbin = np.array([len(edges[i]) + 1 for i in builtins.range(Ndim)])
         # +1 for outlier bins
-        dedges = [np.diff(edges[i]) for i in xrange(Ndim)]
+        dedges = [np.diff(edges[i]) for i in builtins.range(Ndim)]
         binnumbers = binned_statistic_result.binnumber
 
     result = np.empty([Vdim, nbin.prod()], float)
@@ -565,7 +566,7 @@ def binned_statistic_dd(sample, values, statistic='mean',
         result.fill(np.nan)
         flatcount = np.bincount(binnumbers, None)
         a = flatcount.nonzero()
-        for vv in xrange(Vdim):
+        for vv in builtins.range(Vdim):
             flatsum = np.bincount(binnumbers, values[vv])
             result[vv, a] = flatsum[a] / flatcount[a]
     elif statistic == 'std':
@@ -573,7 +574,7 @@ def binned_statistic_dd(sample, values, statistic='mean',
         flatcount = np.bincount(binnumbers, None)
         a = flatcount.nonzero()
         for i in np.unique(binnumbers):
-            for vv in xrange(Vdim):
+            for vv in builtins.range(Vdim):
                 # NOTE: take std dev by bin, np.std() is 2-pass and stable
                 result[vv, i] = np.std(values[vv, binnumbers == i])
     elif statistic == 'count':
@@ -583,24 +584,24 @@ def binned_statistic_dd(sample, values, statistic='mean',
         result[:, a] = flatcount[np.newaxis, :]
     elif statistic == 'sum':
         result.fill(0)
-        for vv in xrange(Vdim):
+        for vv in builtins.range(Vdim):
             flatsum = np.bincount(binnumbers, values[vv])
             a = np.arange(len(flatsum))
             result[vv, a] = flatsum
     elif statistic == 'median':
         result.fill(np.nan)
         for i in np.unique(binnumbers):
-            for vv in xrange(Vdim):
+            for vv in builtins.range(Vdim):
                 result[vv, i] = np.median(values[vv, binnumbers == i])
     elif statistic == 'min':
         result.fill(np.nan)
         for i in np.unique(binnumbers):
-            for vv in xrange(Vdim):
+            for vv in builtins.range(Vdim):
                 result[vv, i] = np.min(values[vv, binnumbers == i])
     elif statistic == 'max':
         result.fill(np.nan)
         for i in np.unique(binnumbers):
-            for vv in xrange(Vdim):
+            for vv in builtins.range(Vdim):
                 result[vv, i] = np.max(values[vv, binnumbers == i])
     elif callable(statistic):
         with np.errstate(invalid='ignore'), suppress_warnings() as sup:
@@ -611,7 +612,7 @@ def binned_statistic_dd(sample, values, statistic='mean',
                 null = np.nan
         result.fill(null)
         for i in np.unique(binnumbers):
-            for vv in xrange(Vdim):
+            for vv in builtins.range(Vdim):
                 result[vv, i] = statistic(values[vv, binnumbers == i])
 
     # Shape into a proper matrix
@@ -637,6 +638,7 @@ def binned_statistic_dd(sample, values, statistic='mean',
 def _bin_edges(sample, bins=None, range=None):
     """ Create edge arrays
     """
+    import builtins
     Dlen, Ndim = sample.shape
 
     nbin = np.empty(Ndim, int)    # Number of bins in each dimension
@@ -651,17 +653,17 @@ def _bin_edges(sample, bins=None, range=None):
     else:
         smin = np.zeros(Ndim)
         smax = np.zeros(Ndim)
-        for i in xrange(Ndim):
+        for i in builtins.range(Ndim):
             smin[i], smax[i] = range[i]
 
     # Make sure the bins have a finite width.
-    for i in xrange(len(smin)):
+    for i in builtins.range(len(smin)):
         if smin[i] == smax[i]:
             smin[i] = smin[i] - .5
             smax[i] = smax[i] + .5
 
     # Create edge arrays
-    for i in xrange(Ndim):
+    for i in builtins.range(Ndim):
         if np.isscalar(bins[i]):
             nbin[i] = bins[i] + 2  # +2 for outlier bins
             edges[i] = np.linspace(smin[i], smax[i], nbin[i] - 1)
@@ -682,13 +684,13 @@ def _bin_numbers(sample, nbin, edges, dedges):
 
     sampBin = [
         np.digitize(sample[:, i], edges[i])
-        for i in xrange(Ndim)
+        for i in range(Ndim)
     ]
 
     # Using `digitize`, values that fall on an edge are put in the right bin.
     # For the rightmost bin, we want values equal to the right
     # edge to be counted in the last bin, and not as an outlier.
-    for i in xrange(Ndim):
+    for i in range(Ndim):
         # Find the rounding precision
         dedges_min = dedges[i].min()
         if dedges_min == 0:

--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -1,5 +1,6 @@
 from __future__ import division, print_function, absolute_import
 
+import builtins
 import numpy as np
 from numpy.testing import suppress_warnings
 from scipy._lib.six import callable
@@ -511,7 +512,6 @@ def binned_statistic_dd(sample, values, statistic='mean',
     ...                                  binned_statistic_result=ret,
     ...                                  statistic='mean')
     """
-    import builtins
     known_stats = ['mean', 'median', 'count', 'sum', 'std', 'min', 'max']
     if not callable(statistic) and statistic not in known_stats:
         raise ValueError('invalid statistic %r' % (statistic,))
@@ -638,7 +638,6 @@ def binned_statistic_dd(sample, values, statistic='mean',
 def _bin_edges(sample, bins=None, range=None):
     """ Create edge arrays
     """
-    import builtins
     Dlen, Ndim = sample.shape
 
     nbin = np.empty(Ndim, int)    # Number of bins in each dimension


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Like #11340 but this ___binned_statistic.py__ uses both function parameters named __range__ and the __builtin.range()__ function.

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->