### PR TITLE
BUG: constants: fix 'exact' values table

### DIFF
--- a/scipy/constants/codata.py
+++ b/scipy/constants/codata.py
@@ -1553,6 +1553,10 @@ for k in _physical_constants_2018:
     if 'momentum' in k:
         _aliases[k] = k.replace('momentum', 'mom.um')
 
+# CODATA 2018: renamed and no longer exact; use as aliases
+_aliases['mag. constant'] = 'vacuum mag. permeability'
+_aliases['electric constant'] = 'vacuum electric permittivity'
+
 
 class ConstantWarning(DeprecationWarning):
     """Accessing a constant no longer in current CODATA data set"""
@@ -1701,19 +1705,24 @@ def find(sub=None, disp=False):
     else:
         return result
 
+    
+c = value('speed of light in vacuum')
+mu0 = value('vacuum mag. permeability')
+epsilon0 = value('vacuum electric permittivity')
 
 # Table is lacking some digits for exact values: calculate from definition
-c = value('speed of light in vacuum')
-mu0 = 4e-7 * pi
-epsilon0 = 1 / (mu0 * c * c)
-
 exact_values = {
-    'vacuum mag. permeability': (mu0, 'N A^-2', 0.0),
-    'vacuum electric permittivity': (epsilon0, 'F m^-1', 0.0),
-    'atomic unit of permittivity': (4 * epsilon0 * pi, 'F m^-1', 0.0),
     'joule-kilogram relationship': (1 / (c * c), 'kg', 0.0),
     'kilogram-joule relationship': (c * c, 'J', 0.0),
-    'hertz-inverse meter relationship': (1 / c, 'm^-1', 0.0)
+    'hertz-inverse meter relationship': (1 / c, 'm^-1', 0.0),
+
+    # The following derived quantities are no longer exact (CODATA2018):
+    # specify separately
+    'characteristic impedance of vacuum': (
+        sqrt(mu0 / epsilon0), 'ohm',
+        sqrt(mu0 / epsilon0) * 0.5 * (
+            physical_constants['vacuum mag. permeability'][2] / mu0
+            + physical_constants['vacuum electric permittivity'][2] / epsilon0))
 }
 
 # sanity check

--- a/scipy/constants/codata.py
+++ b/scipy/constants/codata.py
@@ -1718,9 +1718,11 @@ exact_values = {
 
 # sanity check
 for key in exact_values:
-    val = _current_constants[key][0]
+    val = physical_constants[key][0]
     if abs(exact_values[key][0] - val) / val > 1e-9:
         raise ValueError("Constants.codata: exact values too far off.")
+    if exact_values[key][2] == 0 and physical_constants[key][2] != 0:
+        raise ValueError("Constants.codata: value not exact")
 
 physical_constants.update(exact_values)
 

--- a/scipy/constants/constants.py
+++ b/scipy/constants/constants.py
@@ -56,8 +56,8 @@ yobi = 2**80
 
 # physical constants
 c = speed_of_light = _cd('speed of light in vacuum')
-mu_0 = 4e-7*pi
-epsilon_0 = 1 / (mu_0*c*c)
+mu_0 = _cd('vacuum mag. permeability')
+epsilon_0 = _cd('vacuum electric permittivity')
 h = Planck = _cd('Planck constant')
 hbar = h / (2 * pi)
 G = gravitational_constant = _cd('Newtonian constant of gravitation')

--- a/scipy/constants/tests/test_codata.py
+++ b/scipy/constants/tests/test_codata.py
@@ -1,6 +1,6 @@
-from scipy.constants import constants, codata, find, value
-from numpy.testing import (assert_equal, assert_,
-                           assert_almost_equal)
+from scipy.constants import constants, codata, find, value, ConstantWarning
+from numpy.testing import (assert_equal, assert_, assert_almost_equal,
+                           suppress_warnings)
 
 
 def test_find():
@@ -50,6 +50,8 @@ def test_2002_vs_2006():
 
 def test_exact_values():
     # Check that updating stored values with exact ones worked.
-    for key in codata.exact_values:
-        assert_((codata.exact_values[key][0] - value(key)) / value(key) == 0)
+    with suppress_warnings() as sup:
+        sup.filter(ConstantWarning)
+        for key in codata.exact_values:
+            assert_((codata.exact_values[key][0] - value(key)) / value(key) == 0)
 


### PR DESCRIPTION
#### Reference issue
See gh-11341

#### What does this implement/fix?
Restore 'exact' values removed in f166e3a

The vacuum permeabilities and permittivities are no longer exact in
CODATA 2018, so add their old names as aliases (CODATA2018 lists the
atomic unit separately).

The characteristic impedance of vacuum is also not exact, so specify the
old 'exact' value manually.

Also make the 'exact values' override system deal with overriding obsolete values.