### PR TITLE
ENH: diagonal banded form in solve banded

### DIFF
--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -365,7 +365,7 @@ def _diagonal_banded(l_and_u, a):
     if a.shape != (n, n):
         raise ValueError("Matrix must be square (has shape %s)" % (a.shape,))
     (nlower, nupper) = l_and_u
-    if nlower > n or nupper > n:
+    if nlower >= n or nupper >= n:
         raise ValueError("Number of nonzero diagonals must be less than square dimension")
 
     upper = np.empty((nupper, n), dtype=a.dtype)
@@ -391,7 +391,7 @@ def solve_banded(l_and_u, ab, b, overwrite_ab=False, overwrite_b=False,
     """
     Solve the equation a x = b for x, assuming a is banded matrix.
 
-    Until 'diagonal_form' is disabled, the matrix a is stored in `ab` using the matrix diagonal ordered form::
+    Unless 'diagonal_form' is disabled, the matrix a is stored in `ab` using the matrix diagonal ordered form::
 
         ab[u + i - j, j] == a[i,j]
 

--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -368,22 +368,19 @@ def _diagonal_banded(l_and_u, a):
     if nlower >= n or nupper >= n:
         raise ValueError("Number of nonzero diagonals must be less than square dimension")
 
-    upper = np.empty((nupper, n), dtype=a.dtype)
-    mid = np.empty((1, n), dtype=a.dtype)
-    lower = np.empty((nlower, n), dtype=a.dtype)
-
+    diagonal_ordered = np.empty((nlower + nupper + 1, n), dtype=a.dtype)
     for i in range(1, nupper + 1):
         for j in range(n - i):
-            upper[nupper - i, i + j] = a[j, i + j]
+            diagonal_ordered[nupper - i, i + j] = a[j, i + j]
 
     for i in range(n):
-        mid[0, i] = a[i, i]
+        diagonal_ordered[nupper, i] = a[i, i]
 
     for i in range(nlower):
         for j in range(n - i - 1):
-            lower[i, j] = a[i + j + 1, j]
+            diagonal_ordered[nupper + 1 + i, j] = a[i + j + 1, j]
 
-    return np.concatenate((upper, mid, lower))
+    return diagonal_ordered
 
 
 def solve_banded(l_and_u, ab, b, overwrite_ab=False, overwrite_b=False,

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -169,7 +169,6 @@ class TestSolveBanded(object):
         assert_equal(x.dtype, np.dtype('f8'))
         assert_array_equal(b, [[1.0, 2.0, 3.0]])
 
-
     def test_native_list_arguments(self):
         a = [[1.0, 20, 0, 0],
              [-30, 4, 6, 0],

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -61,6 +61,8 @@ class TestSolveBanded(object):
         for b in [b4, b4by1, b4by2, b4by4]:
             x = solve_banded((l, u), ab, b)
             assert_array_almost_equal(dot(a, x), b)
+            x = solve_banded((l, u), a, b, diagonal_form=False)
+            assert_array_almost_equal(dot(a, x), b)
 
     def test_complex(self):
         a = array([[1.0, 20, 0, 0],
@@ -84,6 +86,8 @@ class TestSolveBanded(object):
                        [0, 1, 0, 0]])
         for b in [b4, b4by1, b4by2, b4by4]:
             x = solve_banded((l, u), ab, b)
+            assert_array_almost_equal(dot(a, x), b)
+            x = solve_banded((l, u), a, b, diagonal_form=False)
             assert_array_almost_equal(dot(a, x), b)
 
     def test_tridiag_real(self):
@@ -160,6 +164,12 @@ class TestSolveBanded(object):
         assert_equal(x.dtype, np.dtype('f8'))
         assert_array_equal(b, [[1.0, 2.0, 3.0]])
 
+        x = solve_banded((1, 1), [[2]], b, diagonal_form=False)
+        assert_array_equal(x, [[0.5, 1.0, 1.5]])
+        assert_equal(x.dtype, np.dtype('f8'))
+        assert_array_equal(b, [[1.0, 2.0, 3.0]])
+
+
     def test_native_list_arguments(self):
         a = [[1.0, 20, 0, 0],
              [-30, 4, 6, 0],
@@ -172,6 +182,9 @@ class TestSolveBanded(object):
         l, u = 2, 1
         b = [10.0, 0.0, 2.0, 14.0]
         x = solve_banded((l, u), ab, b)
+        assert_array_almost_equal(dot(a, x), b)
+
+        x = solve_banded((l, u), a, b, diagonal_form=False)
         assert_array_almost_equal(dot(a, x), b)
 
 

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -145,6 +145,10 @@ class TestSolveBanded(object):
         assert_array_almost_equal(dot(a, x), b4)
 
     def test_bad_shape(self):
+        a = array([[1.0, 20, 0, 0],
+                   [-30, 4, 6, 0],
+                   [2, 1, 20, 2],
+                   [0, -1, 7, 14]])
         ab = array([[0.0, 20, 6, 2],
                     [1, 4, 20, 14],
                     [-30, 1, 7, 0],
@@ -153,18 +157,16 @@ class TestSolveBanded(object):
         bad = array([1.0, 2.0, 3.0, 4.0]).reshape(-1, 4)
         assert_raises(ValueError, solve_banded, (l, u), ab, bad)
         assert_raises(ValueError, solve_banded, (l, u), ab, [1.0, 2.0])
+        assert_raises(ValueError, solve_banded, (1, 1), array([[1, 2, 3], [2, 3, 4]]), [1, 2], diagonal_form=False)
 
         # Values of (l,u) are not compatible with ab.
         assert_raises(ValueError, solve_banded, (1, 1), ab, [1.0, 2.0])
+        assert_raises(ValueError, solve_banded, (4, 3), a, [10.0, 0.0, 2.0, 14.0], diagonal_form=False)
+        assert_raises(ValueError, solve_banded, (1, 5), a, [10.0, 0.0, 2.0, 14.0], diagonal_form=False)
 
     def test_1x1(self):
         b = array([[1., 2., 3.]])
         x = solve_banded((1, 1), [[0], [2], [0]], b)
-        assert_array_equal(x, [[0.5, 1.0, 1.5]])
-        assert_equal(x.dtype, np.dtype('f8'))
-        assert_array_equal(b, [[1.0, 2.0, 3.0]])
-
-        x = solve_banded((1, 1), [[2]], b, diagonal_form=False)
         assert_array_equal(x, [[0.5, 1.0, 1.5]])
         assert_equal(x.dtype, np.dtype('f8'))
         assert_array_equal(b, [[1.0, 2.0, 3.0]])


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes #8362

#### What does this implement/fix?
It is helpful to have the possibility of passing a banded matrix in its original form (not only in diagonal ordered form as it is now). 

#### Additional information
I needed this feature and I found the above issue, so I thought that it could be included in Scipy. There is an implementation given in #8362, but I've used my own implementation because it doesn't consume so much memory.

Example (matrix from solve_banded docs):
```python
from scipy.linalg import solve_banded
ab = np.array([[5, 2, -1, 0, 0],
[1, 4, 2, -1, 0],
[0, 1, 3, 2, -1],
[0, 0, 1, 2, 2],
[0, 0, 0, 1, 1]])

b = np.array([0, 1, 2, 2, 3])
solve_banded((1, 2), ab, b, diagonal_form=False)
```