### PR TITLE
MAINT: remove six.string_types usages

### DIFF
--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -130,7 +130,6 @@ import numpy as np
 from . import _hierarchy, _optimal_leaf_ordering
 import scipy.spatial.distance as distance
 
-from scipy._lib.six import string_types
 
 _LINKAGE_METHODS = {'single': 0, 'complete': 1, 'average': 2, 'centroid': 3,
                     'median': 4, 'ward': 5, 'weighted': 6}
@@ -2996,7 +2995,7 @@ def set_link_color_palette(palette):
         palette = ['g', 'r', 'c', 'm', 'y', 'k']
     elif type(palette) not in (list, tuple):
         raise TypeError("palette must be a list or tuple")
-    _ptypes = [isinstance(p, string_types) for p in palette]
+    _ptypes = [isinstance(p, str) for p in palette]
 
     if False in _ptypes:
         raise TypeError("all palette list elements must be color strings")
@@ -3310,7 +3309,7 @@ def dendrogram(Z, p=30, truncate_mode=None, color_threshold=None,
     currently_below_threshold = [False]
     ivl = []  # list of leaves
 
-    if color_threshold is None or (isinstance(color_threshold, string_types) and
+    if color_threshold is None or (isinstance(color_threshold, str) and
                                    color_threshold == 'default'):
         color_threshold = max(Z[:, 2]) * 0.7
 
@@ -3637,7 +3636,7 @@ def _dendrogram_calculate_info(Z, p, truncate_mode,
     dcoord_list.append([uah, h, h, ubh])
     if link_color_func is not None:
         v = link_color_func(int(i))
-        if not isinstance(v, string_types):
+        if not isinstance(v, str):
             raise TypeError("link_color_func must return a matplotlib "
                             "color string!")
         color_list.append(v)

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -4,7 +4,6 @@ import functools
 import operator
 
 import numpy as np
-from scipy._lib.six import string_types
 from scipy.linalg import (get_lapack_funcs, LinAlgError,
                           cholesky_banded, cho_solve_banded)
 from . import _bspl
@@ -594,7 +593,7 @@ def _augknt(x, k):
 
 
 def _convert_string_aliases(deriv, target_shape):
-    if isinstance(deriv, string_types):
+    if isinstance(deriv, str):
         if deriv == "clamped":
             deriv = [(1, np.zeros(target_shape))]
         elif deriv == "natural":
@@ -734,7 +733,7 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
     # convert string aliases for the boundary conditions
     if bc_type is None or bc_type == 'not-a-knot':
         deriv_l, deriv_r = None, None
-    elif isinstance(bc_type, string_types):
+    elif isinstance(bc_type, str):
         deriv_l, deriv_r = bc_type, bc_type
     else:
         try:

--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -4,8 +4,6 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 
-from scipy._lib.six import string_types
-
 from . import BPoly, PPoly
 from .polyint import _isscalar
 from scipy._lib._util import _asarray_validated
@@ -781,7 +779,7 @@ class CubicSpline(CubicHermiteSpline):
             y casted to complex dtype if one of the boundary conditions has
             complex dtype.
         """
-        if isinstance(bc_type, string_types):
+        if isinstance(bc_type, str):
             if bc_type == 'periodic':
                 if not np.allclose(y[0], y[-1], rtol=1e-15, atol=1e-15):
                     raise ValueError(
@@ -803,7 +801,7 @@ class CubicSpline(CubicHermiteSpline):
 
         validated_bc = []
         for bc in bc_type:
-            if isinstance(bc, string_types):
+            if isinstance(bc, str):
                 if bc == 'clamped':
                     validated_bc.append((1, np.zeros(expected_deriv_shape)))
                 elif bc == 'natural':

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -15,8 +15,7 @@ from numpy import (array, transpose, searchsorted, atleast_1d, atleast_2d,
 import scipy.special as spec
 from scipy.special import comb
 
-from scipy._lib.six import integer_types, string_types
-
+from scipy._lib.six import integer_types
 from . import fitpack
 from . import dfitpack
 from . import _fitpack
@@ -332,7 +331,7 @@ def _check_broadcast_up_to(arr_from, shape_to, name):
 
 def _do_extrapolate(fill_value):
     """Helper to check if fill_value == "extrapolate" without warnings"""
-    return (isinstance(fill_value, string_types) and
+    return (isinstance(fill_value, str) and
             fill_value == 'extrapolate')
 
 

--- a/scipy/io/matlab/mio.py
+++ b/scipy/io/matlab/mio.py
@@ -5,7 +5,6 @@ Module for reading and writing matlab (TM) .mat files
 
 from __future__ import division, print_function, absolute_import
 from contextlib import contextmanager
-from scipy._lib.six import string_types
 
 from .miobase import get_matfile_version, docfiller
 from .mio4 import MatFile4Reader, MatFile4Writer
@@ -41,7 +40,7 @@ def _open_file(file_like, appendmat, mode='rb'):
         return open(file_like, mode), True
     except IOError:
         # Probably "not found"
-        if isinstance(file_like, string_types):
+        if isinstance(file_like, str):
             if appendmat and not file_like.endswith('.mat'):
                 file_like += '.mat'
             return open(file_like, mode), True

--- a/scipy/io/matlab/mio4.py
+++ b/scipy/io/matlab/mio4.py
@@ -10,8 +10,6 @@ from numpy.compat import asbytes, asstr
 
 import scipy.sparse
 
-from scipy._lib.six import string_types
-
 from .miobase import (MatFileReader, docfiller, matdims, read_dtype,
                       convert_dtypes, arr_to_chars, arr_dtype_number)
 
@@ -383,7 +381,7 @@ class MatFile4Reader(MatFileReader):
             variable name, or sequence of variable names to get from Mat file /
             file stream. If None, then get all variables in file.
         '''
-        if isinstance(variable_names, string_types):
+        if isinstance(variable_names, str):
             variable_names = [variable_names]
         elif variable_names is not None:
             variable_names = list(variable_names)

--- a/scipy/io/matlab/mio5.py
+++ b/scipy/io/matlab/mio5.py
@@ -86,8 +86,6 @@ from numpy.compat import asbytes, asstr
 
 import scipy.sparse
 
-from scipy._lib.six import string_types
-
 from .byteordercodes import native_code, swapped_code
 
 from .miobase import (MatFileReader, docfiller, matdims, read_dtype,
@@ -258,7 +256,7 @@ class MatFile5Reader(MatFileReader):
 
         If variable_names is None, then get all variables in file
         '''
-        if isinstance(variable_names, string_types):
+        if isinstance(variable_names, str):
             variable_names = [variable_names]
         elif variable_names is not None:
             variable_names = list(variable_names)
@@ -438,7 +436,7 @@ def to_writeable(source):
         dtype = []
         values = []
         for field, value in source.items():
-            if (isinstance(field, string_types) and
+            if (isinstance(field, str) and
                     field[0] not in '_0123456789'):
                 dtype.append((str(field), object))
                 values.append(value)

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -13,7 +13,7 @@ from glob import glob
 from io import BytesIO
 from tempfile import mkdtemp
 
-from scipy._lib.six import u, text_type, string_types
+from scipy._lib.six import u, text_type
 
 import warnings
 import shutil
@@ -1015,7 +1015,7 @@ def test_scalar_squeeze():
     savemat(stream, in_d)
     out_d = loadmat(stream, squeeze_me=True)
     assert_(isinstance(out_d['scalar'], float))
-    assert_(isinstance(out_d['string'], string_types))
+    assert_(isinstance(out_d['string'], str))
     assert_(isinstance(out_d['st'], np.ndarray))
 
 

--- a/scipy/io/mmio.py
+++ b/scipy/io/mmio.py
@@ -19,7 +19,6 @@ from numpy import (asarray, real, imag, conj, zeros, ndarray, concatenate,
                    ones, can_cast)
 from numpy.compat import asbytes, asstr
 
-from scipy._lib.six import string_types
 from scipy.sparse import coo_matrix, isspmatrix
 
 __all__ = ['mminfo', 'mmread', 'mmwrite', 'MMFile']
@@ -292,7 +291,7 @@ class MMFile (object):
             false otherwise.
         """
         close_it = False
-        if isinstance(filespec, string_types):
+        if isinstance(filespec, str):
             close_it = True
 
             # open for reading

--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -24,7 +24,6 @@ from numpy import (array, isfinite, inexact, nonzero, iscomplexobj, cast,
                    argwhere, iscomplex, eye, zeros, einsum)
 # Local imports
 from scipy._lib._util import _asarray_validated
-from scipy._lib.six import string_types
 from .misc import LinAlgError, _datacopied, norm
 from .lapack import get_lapack_funcs, _compute_lwork
 
@@ -499,7 +498,7 @@ _conv_dict = {0: 0, 1: 1, 2: 2,
 
 def _check_select(select, select_range, max_ev, max_len):
     """Check that select is valid, convert to Fortran style."""
-    if isinstance(select, string_types):
+    if isinstance(select, str):
         select = select.lower()
     try:
         select = _conv_dict[select]
@@ -1132,7 +1131,7 @@ def eigh_tridiagonal(d, e, eigvals_only=False, select='a', select_range=None,
                          % (d.size, e.size))
     select, vl, vu, il, iu, _ = _check_select(
         select, select_range, 0, d.size)
-    if not isinstance(lapack_driver, string_types):
+    if not isinstance(lapack_driver, str):
         raise TypeError('lapack_driver must be str')
     drivers = ('auto', 'stemr', 'sterf', 'stebz', 'stev')
     if lapack_driver not in drivers:

--- a/scipy/linalg/decomp_svd.py
+++ b/scipy/linalg/decomp_svd.py
@@ -8,7 +8,6 @@ from numpy import zeros, r_, diag, dot, arccos, arcsin, where, clip
 from .misc import LinAlgError, _datacopied
 from .lapack import get_lapack_funcs, _compute_lwork
 from .decomp import _asarray_validated
-from scipy._lib.six import string_types
 
 __all__ = ['svd', 'svdvals', 'diagsvd', 'orth', 'subspace_angles', 'null_space']
 
@@ -112,7 +111,7 @@ def svd(a, full_matrices=True, compute_uv=True, overwrite_a=False,
     m, n = a1.shape
     overwrite_a = overwrite_a or (_datacopied(a1, a))
 
-    if not isinstance(lapack_driver, string_types):
+    if not isinstance(lapack_driver, str):
         raise TypeError('lapack_driver must be a string')
     if lapack_driver not in ('gesdd', 'gesvd'):
         raise ValueError('lapack_driver must be "gesdd" or "gesvd", not "%s"'

--- a/scipy/linalg/special_matrices.py
+++ b/scipy/linalg/special_matrices.py
@@ -2,7 +2,6 @@ from __future__ import division, print_function, absolute_import
 
 import math
 import numpy as np
-from scipy._lib.six import string_types
 from numpy.lib.stride_tricks import as_strided
 
 __all__ = ['tri', 'tril', 'triu', 'toeplitz', 'circulant', 'hankel',
@@ -60,7 +59,7 @@ def tri(N, M=None, k=0, dtype=None):
     """
     if M is None:
         M = N
-    if isinstance(M, string_types):
+    if isinstance(M, str):
         # pearu: any objections to remove this feature?
         #       As tri(N,'d') is equivalent to tri(N,dtype='d')
         dtype = M

--- a/scipy/ndimage/_ni_support.py
+++ b/scipy/ndimage/_ni_support.py
@@ -32,8 +32,6 @@ from __future__ import division, print_function, absolute_import
 
 import numpy
 
-from scipy._lib.six import string_types
-
 
 def _extend_mode_to_code(mode):
     """Convert an extension mode to the corresponding integer code.
@@ -57,7 +55,7 @@ def _normalize_sequence(input, rank):
     rank by duplicating the input. If input is a sequence,
     check if its length is equal to the length of array.
     """
-    is_str = isinstance(input, string_types)
+    is_str = isinstance(input, str)
     if hasattr(input, '__iter__') and not is_str:
         normalized = list(input)
         if len(normalized) != rank:
@@ -76,7 +74,7 @@ def _get_output(output, input, shape=None):
     elif isinstance(output, (type, numpy.dtype)):
         # Classes (like `np.float32`) and dtypes are interpreted as dtype
         output = numpy.zeros(shape, dtype=output)
-    elif isinstance(output, string_types):
+    elif isinstance(output, str):
         output = numpy.typeDict[output]
         output = numpy.zeros(shape, dtype=output)
     elif output.shape != shape:

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -9,7 +9,6 @@ import numpy as np
 from scipy.optimize import OptimizeResult, minimize
 from scipy.optimize.optimize import _status_message
 from scipy._lib._util import check_random_state, MapWrapper
-from scipy._lib.six import string_types
 
 from scipy.optimize._constraints import (Bounds, new_bounds_to_old,
                                          NonlinearConstraint, LinearConstraint)
@@ -567,7 +566,7 @@ class DifferentialEvolutionSolver(object):
                                  self.parameter_count)
 
         self._nfev = 0
-        if isinstance(init, string_types):
+        if isinstance(init, str):
             if init == 'latinhypercube':
                 self.init_population_lhs()
             elif init == 'random':

--- a/scipy/optimize/_lsq/dogbox.py
+++ b/scipy/optimize/_lsq/dogbox.py
@@ -47,7 +47,6 @@ from numpy.linalg import lstsq, norm
 
 from scipy.sparse.linalg import LinearOperator, aslinearoperator, lsmr
 from scipy.optimize import OptimizeResult
-from scipy._lib.six import string_types
 
 from .common import (
     step_size_to_bound, in_bounds, update_tr_radius, evaluate_quadratic,
@@ -167,7 +166,7 @@ def dogbox(fun, jac, x0, f0, J0, lb, ub, ftol, xtol, gtol, max_nfev, x_scale,
 
     g = compute_grad(J, f)
 
-    jac_scale = isinstance(x_scale, string_types) and x_scale == 'jac'
+    jac_scale = isinstance(x_scale, str) and x_scale == 'jac'
     if jac_scale:
         scale, scale_inv = compute_jac_scale(J)
     else:

--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -10,7 +10,6 @@ from scipy.sparse import issparse, csr_matrix
 from scipy.sparse.linalg import LinearOperator
 from scipy.optimize import _minpack, OptimizeResult
 from scipy.optimize._numdiff import approx_derivative, group_columns
-from scipy._lib.six import string_types
 
 from .trf import trf
 from .dogbox import dogbox
@@ -49,7 +48,7 @@ def call_minpack(fun, x0, jac, ftol, xtol, gtol, max_nfev, x_scale, diff_step):
 
     # Compute MINPACK's `diag`, which is inverse of our `x_scale` and
     # ``x_scale='jac'`` corresponds to ``diag=None``.
-    if isinstance(x_scale, string_types) and x_scale == 'jac':
+    if isinstance(x_scale, str) and x_scale == 'jac':
         diag = None
     else:
         diag = 1 / x_scale
@@ -127,7 +126,7 @@ def check_tolerance(ftol, xtol, gtol):
 
 
 def check_x_scale(x_scale, x0):
-    if isinstance(x_scale, string_types) and x_scale == 'jac':
+    if isinstance(x_scale, str) and x_scale == 'jac':
         return x_scale
 
     try:
@@ -896,7 +895,7 @@ def least_squares(
                     "tr_solver='exact' works only with dense "
                     "Jacobian matrices.")
 
-        jac_scale = isinstance(x_scale, string_types) and x_scale == 'jac'
+        jac_scale = isinstance(x_scale, str) and x_scale == 'jac'
         if isinstance(J0, LinearOperator) and jac_scale:
             raise ValueError("x_scale='jac' can't be used when `jac` "
                              "returns LinearOperator.")

--- a/scipy/optimize/_lsq/trf.py
+++ b/scipy/optimize/_lsq/trf.py
@@ -100,7 +100,6 @@ from numpy.linalg import norm
 from scipy.linalg import svd, qr
 from scipy.sparse.linalg import lsmr
 from scipy.optimize import OptimizeResult
-from scipy._lib.six import string_types
 
 from .common import (
     step_size_to_bound, find_active_constraints, in_bounds,
@@ -226,7 +225,7 @@ def trf_bounds(fun, jac, x0, f0, J0, lb, ub, ftol, xtol, gtol, max_nfev,
 
     g = compute_grad(J, f)
 
-    jac_scale = isinstance(x_scale, string_types) and x_scale == 'jac'
+    jac_scale = isinstance(x_scale, str) and x_scale == 'jac'
     if jac_scale:
         scale, scale_inv = compute_jac_scale(J)
     else:
@@ -426,7 +425,7 @@ def trf_no_bounds(fun, jac, x0, f0, J0, ftol, xtol, gtol, max_nfev,
 
     g = compute_grad(J, f)
 
-    jac_scale = isinstance(x_scale, string_types) and x_scale == 'jac'
+    jac_scale = isinstance(x_scale, str) and x_scale == 'jac'
     if jac_scale:
         scale, scale_inv = compute_jac_scale(J)
     else:

--- a/scipy/signal/fir_filter_design.py
+++ b/scipy/signal/fir_filter_design.py
@@ -11,7 +11,6 @@ from numpy.fft import irfft, fft, ifft
 from scipy.special import sinc
 from scipy.linalg import (toeplitz, hankel, solve, LinAlgError, LinAlgWarning,
                           lstsq)
-from scipy._lib.six import string_types
 
 from . import sigtools
 
@@ -1221,7 +1220,7 @@ def minimum_phase(h, method='homomorphic', n_fft=None):
     if not np.allclose(h[-n_half:][::-1], h[:n_half]):
         warnings.warn('h does not appear to by symmetric, conversion may '
                       'fail', RuntimeWarning)
-    if not isinstance(method, string_types) or method not in \
+    if not isinstance(method, str) or method not in \
             ('homomorphic', 'hilbert',):
         raise ValueError('method must be "homomorphic" or "hilbert", got %r'
                          % (method,))

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -11,7 +11,6 @@ from ._spectral import _lombscargle
 from ._arraytools import const_ext, even_ext, odd_ext, zero_ext
 import warnings
 
-from scipy._lib.six import string_types
 
 __all__ = ['periodogram', 'welch', 'lombscargle', 'csd', 'coherence',
            'spectrogram', 'stft', 'istft', 'check_COLA', 'check_NOLA']
@@ -876,7 +875,7 @@ def check_COLA(window, nperseg, noverlap, tol=1e-10):
         raise ValueError('noverlap must be less than nperseg.')
     noverlap = int(noverlap)
 
-    if isinstance(window, string_types) or type(window) is tuple:
+    if isinstance(window, str) or type(window) is tuple:
         win = get_window(window, nperseg)
     else:
         win = np.asarray(window)
@@ -1004,7 +1003,7 @@ def check_NOLA(window, nperseg, noverlap, tol=1e-10):
         raise ValueError('noverlap must be a nonnegative integer')
     noverlap = int(noverlap)
 
-    if isinstance(window, string_types) or type(window) is tuple:
+    if isinstance(window, str) or type(window) is tuple:
         win = get_window(window, nperseg)
     else:
         win = np.asarray(window)
@@ -1403,7 +1402,7 @@ def istft(Zxx, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
         Zxx = np.transpose(Zxx, zouter+[freq_axis, time_axis])
 
     # Get window as array
-    if isinstance(window, string_types) or type(window) is tuple:
+    if isinstance(window, str) or type(window) is tuple:
         win = get_window(window, nperseg)
     else:
         win = np.asarray(window)
@@ -1956,7 +1955,7 @@ def _triage_segments(window, nperseg, input_length):
     """
 
     # parse window; if array like, then set nperseg = win.shape
-    if isinstance(window, string_types) or isinstance(window, tuple):
+    if isinstance(window, str) or isinstance(window, tuple):
         # if nperseg not specified
         if nperseg is None:
             nperseg = 256  # then change to default

--- a/scipy/signal/waveforms.py
+++ b/scipy/signal/waveforms.py
@@ -10,8 +10,6 @@ import numpy as np
 from numpy import asarray, zeros, place, nan, mod, pi, extract, log, sqrt, \
     exp, cos, sin, polyval, polyint
 
-from scipy._lib.six import string_types
-
 
 __all__ = ['sawtooth', 'square', 'gausspulse', 'chirp', 'sweep_poly',
            'unit_impulse']
@@ -237,7 +235,7 @@ def gausspulse(t, fc=1000, bw=0.5, bwr=-6, tpr=-60, retquad=False,
     # pi^2/a * fc^2 * bw^2 /4=-log(ref)
     a = -(pi * fc * bw) ** 2 / (4.0 * log(ref))
 
-    if isinstance(t, string_types):
+    if isinstance(t, str):
         if t == 'cutoff':  # compute cut_off point
             #  Solve exp(-a tc**2) = tref  for tc
             #   tc = sqrt(-log(tref) / a) where tref = 10^(tpr/20)

--- a/scipy/signal/windows/windows.py
+++ b/scipy/signal/windows/windows.py
@@ -7,7 +7,6 @@ import warnings
 
 import numpy as np
 from scipy import linalg, special, fft as sp_fft
-from scipy._lib.six import string_types
 
 __all__ = ['boxcar', 'triang', 'parzen', 'bohman', 'blackman', 'nuttall',
            'blackmanharris', 'flattop', 'bartlett', 'hanning', 'barthann',
@@ -2101,7 +2100,7 @@ def get_window(window, Nx, fftbins=True):
             winstr = window[0]
             if len(window) > 1:
                 args = window[1:]
-        elif isinstance(window, string_types):
+        elif isinstance(window, str):
             if window in _needs_param:
                 raise ValueError("The '" + window + "' window needs one or "
                                  "more parameters -- pass a tuple.")

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -115,7 +115,7 @@ import numpy as np
 
 from functools import partial
 from collections import namedtuple
-from scipy._lib.six import callable, string_types
+from scipy._lib.six import callable
 from scipy._lib._util import _asarray_validated
 
 from . import _distance_wrap
@@ -2046,7 +2046,7 @@ def pdist(X, metric='euclidean', *args, **kwargs):
                 dm[k] = metric(X[i], X[j], **kwargs)
                 k = k + 1
 
-    elif isinstance(metric, string_types):
+    elif isinstance(metric, str):
         mstr = metric.lower()
 
         mstr, kwargs = _select_weighted_metric(mstr, kwargs, out)
@@ -2762,7 +2762,7 @@ def cdist(XA, XB, metric='euclidean', *args, **kwargs):
             for j in range(0, mB):
                 dm[i, j] = metric(XA[i], XB[j], **kwargs)
 
-    elif isinstance(metric, string_types):
+    elif isinstance(metric, str):
         mstr = metric.lower()
 
         mstr, kwargs = _select_weighted_metric(mstr, kwargs, out)

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -4,7 +4,7 @@
 #
 from __future__ import division, print_function, absolute_import
 
-from scipy._lib.six import string_types, exec_, PY2
+from scipy._lib.six import exec_, PY2
 from scipy._lib._util import getargspec_no_self as _getargspec
 
 import sys
@@ -637,7 +637,7 @@ class rv_generic(object):
 
         if self.shapes:
             # sanitize the user-supplied shapes
-            if not isinstance(self.shapes, string_types):
+            if not isinstance(self.shapes, str):
                 raise TypeError('shapes must be a string.')
 
             shapes = self.shapes.replace(',', ' ').split()
@@ -2293,7 +2293,7 @@ class rv_continuous(rv_generic):
 
         optimizer = kwds.pop('optimizer', optimize.fmin)
         # convert string to function in scipy.optimize
-        if not callable(optimizer) and isinstance(optimizer, string_types):
+        if not callable(optimizer) and isinstance(optimizer, str):
             if not optimizer.startswith('fmin_'):
                 optimizer = "fmin_"+optimizer
             if optimizer == 'fmin_':

--- a/scipy/stats/kde.py
+++ b/scipy/stats/kde.py
@@ -23,7 +23,7 @@ from __future__ import division, print_function, absolute_import
 import warnings
 
 # SciPy imports.
-from scipy._lib.six import callable, string_types
+from scipy._lib.six import callable
 from scipy import linalg, special
 from scipy.special import logsumexp
 from scipy._lib._util import check_random_state
@@ -550,7 +550,7 @@ class gaussian_kde(object):
             self.covariance_factor = self.scotts_factor
         elif bw_method == 'silverman':
             self.covariance_factor = self.silverman_factor
-        elif np.isscalar(bw_method) and not isinstance(bw_method, string_types):
+        elif np.isscalar(bw_method) and not isinstance(bw_method, str):
             self._bw_method = 'use constant'
             self.covariance_factor = lambda: bw_method
         elif callable(bw_method):

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -10,7 +10,6 @@ from numpy import (isscalar, r_, log, around, unique, asarray,
                    sqrt, ceil, floor, array, compress,
                    pi, exp, ravel, count_nonzero, sin, cos, arctan2, hypot)
 
-from scipy._lib.six import string_types
 from scipy import optimize
 from scipy import special
 from . import statlib
@@ -439,7 +438,7 @@ def _parse_dist_kw(dist, enforce_subclass=True):
     """
     if isinstance(dist, rv_generic):
         pass
-    elif isinstance(dist, string_types):
+    elif isinstance(dist, str):
         try:
             dist = getattr(distributions, dist)
         except AttributeError:

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -175,7 +175,7 @@ from collections import namedtuple
 import numpy as np
 from numpy import array, asarray, ma
 
-from scipy._lib.six import callable, string_types
+from scipy._lib.six import callable
 from scipy.spatial.distance import cdist
 from scipy.ndimage import measurements
 from scipy._lib._util import _lazywhere, check_random_state, MapWrapper
@@ -2738,7 +2738,7 @@ def iqr(x, axis=None, rng=(25, 75), scale='raw', nan_policy='propagate',
 
     # An error may be raised here, so fail-fast, before doing lengthy
     # computations, even though `scale` is not used until later
-    if isinstance(scale, string_types):
+    if isinstance(scale, str):
         scale_key = scale.lower()
         if scale_key not in _scale_conversions:
             raise ValueError("{0} not a valid scale for `iqr`".format(scale))
@@ -5412,7 +5412,7 @@ def kstest(rvs, cdf, args=(), N=20, alternative='two-sided', mode='approx'):
     (0.131016895759829, 0.058826222555312224)
 
     """
-    if isinstance(rvs, string_types):
+    if isinstance(rvs, str):
         if (not cdf) or (cdf == rvs):
             cdf = getattr(distributions, rvs).cdf
             rvs = getattr(distributions, rvs).rvs
@@ -5420,7 +5420,7 @@ def kstest(rvs, cdf, args=(), N=20, alternative='two-sided', mode='approx'):
             raise AttributeError("if rvs is string, cdf has to be the "
                                  "same distribution")
 
-    if isinstance(cdf, string_types):
+    if isinstance(cdf, str):
         cdf = getattr(distributions, cdf).cdf
     if callable(rvs):
         kwds = {'size': N}
@@ -5646,7 +5646,7 @@ def power_divergence(f_obs, f_exp=None, ddof=0, axis=0, lambda_=None):
 
     """
     # Convert the input argument `lambda_` to a numerical value.
-    if isinstance(lambda_, string_types):
+    if isinstance(lambda_, str):
         if lambda_ not in _power_div_lambda_names:
             names = repr(list(_power_div_lambda_names.keys()))[1:-1]
             raise ValueError("invalid string for lambda_: {0!r}.  Valid strings "


### PR DESCRIPTION
Py2 --> Py3 all strings are instances of `str`.