### PR TITLE
MAINT: sys.version_info >= 3.5

### DIFF
--- a/scipy/_lib/tests/test_warnings.py
+++ b/scipy/_lib/tests/test_warnings.py
@@ -9,58 +9,57 @@ from __future__ import division, absolute_import, print_function
 
 import os
 import sys
+from pathlib import Path
+import ast
+import tokenize
+
 import scipy
 
 import pytest
 
 
-if sys.version_info >= (3, 4):
-    from pathlib import Path
-    import ast
-    import tokenize
+class ParseCall(ast.NodeVisitor):
+    def __init__(self):
+        self.ls = []
 
-    class ParseCall(ast.NodeVisitor):
-        def __init__(self):
-            self.ls = []
+    def visit_Attribute(self, node):
+        ast.NodeVisitor.generic_visit(self, node)
+        self.ls.append(node.attr)
 
-        def visit_Attribute(self, node):
-            ast.NodeVisitor.generic_visit(self, node)
-            self.ls.append(node.attr)
+    def visit_Name(self, node):
+        self.ls.append(node.id)
 
-        def visit_Name(self, node):
-            self.ls.append(node.id)
+class FindFuncs(ast.NodeVisitor):
+    def __init__(self, filename):
+        super().__init__()
+        self.__filename = filename
+        self.bad_filters = []
+        self.bad_stacklevels = []
 
-    class FindFuncs(ast.NodeVisitor):
-        def __init__(self, filename):
-            super().__init__()
-            self.__filename = filename
-            self.bad_filters = []
-            self.bad_stacklevels = []
+    def visit_Call(self, node):
+        p = ParseCall()
+        p.visit(node.func)
+        ast.NodeVisitor.generic_visit(self, node)
 
-        def visit_Call(self, node):
-            p = ParseCall()
-            p.visit(node.func)
-            ast.NodeVisitor.generic_visit(self, node)
+        if p.ls[-1] == 'simplefilter' or p.ls[-1] == 'filterwarnings':
+            if node.args[0].s == "ignore":
+                self.bad_filters.append(
+                    "{}:{}".format(self.__filename, node.lineno))
 
-            if p.ls[-1] == 'simplefilter' or p.ls[-1] == 'filterwarnings':
-                if node.args[0].s == "ignore":
-                    self.bad_filters.append(
-                        "{}:{}".format(self.__filename, node.lineno))
+        if p.ls[-1] == 'warn' and (
+                len(p.ls) == 1 or p.ls[-2] == 'warnings'):
 
-            if p.ls[-1] == 'warn' and (
-                    len(p.ls) == 1 or p.ls[-2] == 'warnings'):
+            if self.__filename == "_lib/tests/test_warnings.py":
+                # This file
+                return
 
-                if self.__filename == "_lib/tests/test_warnings.py":
-                    # This file
-                    return
-
-                # See if stacklevel exists:
-                if len(node.args) == 3:
-                    return
-                args = {kw.arg for kw in node.keywords}
-                if "stacklevel" not in args:
-                    self.bad_stacklevels.append(
-                        "{}:{}".format(self.__filename, node.lineno))
+            # See if stacklevel exists:
+            if len(node.args) == 3:
+                return
+            args = {kw.arg for kw in node.keywords}
+            if "stacklevel" not in args:
+                self.bad_stacklevels.append(
+                    "{}:{}".format(self.__filename, node.lineno))
 
 
 @pytest.fixture(scope="session")
@@ -85,7 +84,6 @@ def warning_calls():
 
 
 @pytest.mark.slow
-@pytest.mark.skipif(sys.version_info < (3, 4), reason="needs Python >= 3.4")
 def test_warning_calls_filters(warning_calls):
     bad_filters, bad_stacklevels = warning_calls
 
@@ -106,7 +104,6 @@ def test_warning_calls_filters(warning_calls):
 
 
 @pytest.mark.slow
-@pytest.mark.skipif(sys.version_info < (3, 4), reason="needs Python >= 3.4")
 @pytest.mark.xfail(reason="stacklevels currently missing")
 def test_warning_calls_stacklevels(warning_calls):
     bad_filters, bad_stacklevels = warning_calls

--- a/scipy/cluster/setup.py
+++ b/scipy/cluster/setup.py
@@ -2,10 +2,7 @@ from __future__ import division, print_function, absolute_import
 
 import sys
 
-if sys.version_info[0] >= 3:
-    DEFINE_MACROS = [("SCIPY_PY3K", None)]
-else:
-    DEFINE_MACROS = []
+DEFINE_MACROS = [("SCIPY_PY3K", None)]
 
 
 def configuration(parent_package='', top_path=None):

--- a/scipy/fftpack/tests/test_import.py
+++ b/scipy/fftpack/tests/test_import.py
@@ -11,23 +11,22 @@ on one version of Python.
 
 
 import sys
-if sys.version_info >= (3, 4):
-    from pathlib import Path
-    import re
-    import tokenize
-    from numpy.testing import assert_
-    import scipy
+from pathlib import Path
+import re
+import tokenize
+from numpy.testing import assert_
+import scipy
 
-    class TestFFTPackImport(object):
-        def test_fftpack_import(self):
-            base = Path(scipy.__file__).parent
-            regexp = r"\s*from.+\.fftpack import .*\n"
-            for path in base.rglob("*.py"):
-                if base / "fftpack" in path.parents:
-                    continue
-                # use tokenize to auto-detect encoding on systems where no
-                # default encoding is defined (e.g., LANG='C')
-                with tokenize.open(str(path)) as file:
-                    assert_(all(not re.fullmatch(regexp, line)
-                                for line in file),
-                            "{0} contains an import from fftpack".format(path))
+class TestFFTPackImport(object):
+    def test_fftpack_import(self):
+        base = Path(scipy.__file__).parent
+        regexp = r"\s*from.+\.fftpack import .*\n"
+        for path in base.rglob("*.py"):
+            if base / "fftpack" in path.parents:
+                continue
+            # use tokenize to auto-detect encoding on systems where no
+            # default encoding is defined (e.g., LANG='C')
+            with tokenize.open(str(path)) as file:
+                assert_(all(not re.fullmatch(regexp, line)
+                            for line in file),
+                        "{0} contains an import from fftpack".format(path))

--- a/scipy/integrate/tests/test_quadpack.py
+++ b/scipy/integrate/tests/test_quadpack.py
@@ -34,10 +34,7 @@ def get_clib_test_routine(name, restype, *argtypes):
 class TestCtypesQuad(object):
     def setup_method(self):
         if sys.platform == 'win32':
-            if sys.version_info < (3, 5):
-                files = [ctypes.util.find_msvcrt()]
-            else:
-                files = ['api-ms-win-crt-math-l1-1-0.dll']
+            files = ['api-ms-win-crt-math-l1-1-0.dll']
         elif sys.platform == 'darwin':
             files = ['libm.dylib']
         else:

--- a/scipy/io/arff/tests/test_arffread.py
+++ b/scipy/io/arff/tests/test_arffread.py
@@ -5,10 +5,7 @@ import os
 import sys
 from os.path import join as pjoin
 
-if sys.version_info[0] >= 3:
-    from io import StringIO
-else:
-    from cStringIO import StringIO
+from io import StringIO
 
 import numpy as np
 

--- a/scipy/io/harwell_boeing/tests/test_hb.py
+++ b/scipy/io/harwell_boeing/tests/test_hb.py
@@ -1,10 +1,7 @@
 from __future__ import division, print_function, absolute_import
 
 import sys
-if sys.version_info[0] >= 3:
-    from io import StringIO
-else:
-    from StringIO import StringIO
+from io import StringIO
 import tempfile
 
 import numpy as np

--- a/scipy/io/matlab/miobase.py
+++ b/scipy/io/matlab/miobase.py
@@ -13,12 +13,6 @@ import operator
 from scipy._lib.six import reduce
 
 import numpy as np
-
-if sys.version_info[0] >= 3:
-    byteord = int
-else:
-    byteord = ord
-
 from scipy._lib import doccer
 
 from . import byteordercodes as boc
@@ -233,8 +227,8 @@ def get_matfile_version(fileobj):
     tst_str = fileobj.read(4)
     fileobj.seek(0)
     maj_ind = int(tst_str[2] == b'I'[0])
-    maj_val = byteord(tst_str[maj_ind])
-    min_val = byteord(tst_str[1-maj_ind])
+    maj_val = int(tst_str[maj_ind])
+    min_val = int(tst_str[1 - maj_ind])
     ret = (maj_val, min_val)
     if maj_val in (1, 2):
         return ret

--- a/scipy/io/matlab/streams.pyx
+++ b/scipy/io/matlab/streams.pyx
@@ -367,10 +367,7 @@ cpdef GenericStream make_stream(object fobj):
     """ Make stream of correct type for file-like `fobj`
     """
     if npy_PyFile_Check(fobj):
-        if <int>sys.version_info[0] >= 3 or IS_PYPY:
-            return GenericStream(fobj)
-        else:
-            return FileStream(fobj)
+        return GenericStream(fobj)
     elif HAS_PYCCSTRINGIO and (PycStringIO_InputCheck(fobj) or PycStringIO_OutputCheck(fobj)):
         return cStringStream(fobj)
     elif isinstance(fobj, GenericStream):

--- a/scipy/io/matlab/tests/test_streams.py
+++ b/scipy/io/matlab/tests/test_streams.py
@@ -10,10 +10,6 @@ import zlib
 
 from io import BytesIO
 
-if sys.version_info[0] >= 3:
-    cStringIO = BytesIO
-else:
-    from cStringIO import StringIO as cStringIO
 
 from tempfile import mkstemp
 from contextlib import contextmanager
@@ -39,7 +35,7 @@ def setup_test_file():
         fs.write(val)
     with open(fname, 'rb') as fs:
         gs = BytesIO(val)
-        cs = cStringIO(val)
+        cs = BytesIO(val)
         yield fs, gs, cs
     os.unlink(fname)
 
@@ -48,9 +44,6 @@ def test_make_stream():
     with setup_test_file() as (fs, gs, cs):
         # test stream initialization
         assert_(isinstance(make_stream(gs), GenericStream))
-        if sys.version_info[0] < 3 and not IS_PYPY:
-            assert_(isinstance(make_stream(cs), cStringStream))
-            assert_(isinstance(make_stream(fs), FileStream))
 
 
 def test_tell_seek():

--- a/scipy/io/mmio.py
+++ b/scipy/io/mmio.py
@@ -808,8 +808,6 @@ def _is_fromfile_compatible(stream):
     Passing a gzipped file object to ``fromfile/fromstring`` doesn't work with
     Python 3.
     """
-    if sys.version_info[0] < 3:
-        return True
 
     bad_cls = []
     try:

--- a/scipy/io/wavfile.py
+++ b/scipy/io/wavfile.py
@@ -451,10 +451,6 @@ def write(filename, rate, data):
             fid.seek(0)
 
 
-if sys.version_info[0] >= 3:
-    def _array_tofile(fid, data):
-        # ravel gives a c-contiguous buffer
-        fid.write(data.ravel().view('b').data)
-else:
-    def _array_tofile(fid, data):
-        fid.write(data.tostring())
+def _array_tofile(fid, data):
+    # ravel gives a c-contiguous buffer
+    fid.write(data.ravel().view('b').data)

--- a/scipy/spatial/kdtree.py
+++ b/scipy/spatial/kdtree.py
@@ -251,21 +251,20 @@ class KDTree(object):
         self.tree = self.__build(np.arange(self.n), self.maxes, self.mins)
 
     class node(object):
-        if sys.version_info[0] >= 3:
-            def __lt__(self, other):
-                return id(self) < id(other)
+        def __lt__(self, other):
+            return id(self) < id(other)
 
-            def __gt__(self, other):
-                return id(self) > id(other)
+        def __gt__(self, other):
+            return id(self) > id(other)
 
-            def __le__(self, other):
-                return id(self) <= id(other)
+        def __le__(self, other):
+            return id(self) <= id(other)
 
-            def __ge__(self, other):
-                return id(self) >= id(other)
+        def __ge__(self, other):
+            return id(self) >= id(other)
 
-            def __eq__(self, other):
-                return id(self) == id(other)
+        def __eq__(self, other):
+            return id(self) == id(other)
 
     class leafnode(node):
         def __init__(self, idx):

--- a/scipy/special/tests/test_trig.py
+++ b/scipy/special/tests/test_trig.py
@@ -57,10 +57,6 @@ def test_intermediate_overlow():
         assert_allclose(cospi(p), std)
 
 
-@pytest.mark.xfail('win32' in sys.platform
-                   and np.intp(0).itemsize < 8
-                   and sys.version_info < (3, 5),
-                   reason="fails on 32-bit Windows with old MSVC")
 def test_zero_sign():
     y = sinpi(-0.0)
     assert y == 0.0

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -166,10 +166,7 @@ from __future__ import division, print_function, absolute_import
 import warnings
 import sys
 import math
-if sys.version_info >= (3, 5):
-    from math import gcd
-else:
-    from fractions import gcd
+from math import gcd
 from collections import namedtuple
 
 import numpy as np


### PR DESCRIPTION
I searched the codebase for `sys.version_info` and pruned code that was designed for Python < 3.5. Thus I would expect if Python 3.4 (or 2.7) to fail tests if this PR is merged. 3.5 and upwards should still work.