### PR TITLE
ENH: Add wrapper for ?gttrf/?gttrs

### DIFF
--- a/scipy/linalg/flapack_gen_tri.pyf.src
+++ b/scipy/linalg/flapack_gen_tri.pyf.src
@@ -16,7 +16,7 @@ end subroutine <prefix>gtsv
 
 
 subroutine <prefix>gttrf(n, dl, d, du, du2, ipiv, info)
-    ! dl, d, du, du2, ipiv, info  = gttrf(dl, d, du)
+    ! dl, d, du, du2, ipiv, info  = gttrf(dl, d, du, [overwrite_dl=0, overwrite_d=0, overwrite_du=0])
     ! ?GTTRF computes an LU factorization of a tridiagonal matrix A
     ! using elimination with partial pivoting and row interchanges.
     !
@@ -30,14 +30,15 @@ subroutine <prefix>gttrf(n, dl, d, du, du2, ipiv, info)
     callprotoargument int*, <ctype>*, <ctype>*, <ctype>*, <ctype>*, int*, int*
 
     integer intent(hide),   depend(d), check(len(d) > 2) :: n = len(d)
-    <ftype> intent(in,out), depend(n), dimension(n-1)    :: dl
-    <ftype> intent(in,out),            dimension(n)      :: d
-    <ftype> intent(in,out), depend(n), dimension(n-1)    :: du
+    <ftype> intent(in,out,copy), depend(n), dimension(n-1) :: dl
+    <ftype> intent(in,out,copy),            dimension(n)   :: d
+    <ftype> intent(in,out,copy), depend(n), dimension(n-1) :: du
     <ftype> intent(out),    depend(n), dimension(n-2)    :: du2
     integer intent(out),    depend(n), dimension(n)      :: ipiv
     integer intent(out)                                  :: info
 
 end subroutine <prefix>gttrf
+
 
 subroutine <prefix>gttrs(trans, n, nrhs, dl, d, du, du2, ipiv, b, ldb, info)
     ! x, info  = gttrs(dl, d, du, du2, ipiv, b, trans="N")

--- a/scipy/linalg/flapack_gen_tri.pyf.src
+++ b/scipy/linalg/flapack_gen_tri.pyf.src
@@ -29,7 +29,7 @@ subroutine <prefix>gttrf(n, dl, d, du, du2, ipiv, info)
     callstatement (*f2py_func)(&n, dl, d, du, du2, ipiv, &info)
     callprotoargument int*, <ctype>*, <ctype>*, <ctype>*, <ctype>*, int*, int*
 
-    integer intent(hide),   depend(d), check(len(d) > 2) :: n = len(d)
+    integer intent(hide),   depend(d) :: n = max(3, len(d))
     <ftype> intent(in,out,copy), depend(n), dimension(n-1) :: dl
     <ftype> intent(in,out,copy),            dimension(n)   :: d
     <ftype> intent(in,out,copy), depend(n), dimension(n-1) :: du
@@ -52,9 +52,9 @@ subroutine <prefix>gttrs(trans, n, nrhs, dl, d, du, du2, ipiv, b, ldb, info)
     threadsafe
 
     character  optional, intent(in), check(*trans=='N'||*trans=='T'||*trans=='C') :: trans = "N"
-    integer    intent(in, hide), depend(d), check(len(d) > 2) :: n = len(d)
-    integer    intent(in, hide), depend(b), check(nrhs > 0)  :: nrhs = shape(b, 1)
-    integer    intent(in, hide), depend(n) :: ldb = MAX(1, n)
+    integer    intent(in, hide), depend(d) :: n = max(3, len(d))
+    integer    intent(in, hide), depend(b) :: nrhs = max(1, shape(b, 1))
+    integer    intent(in, hide), depend(n) :: ldb = max(1, n)
     <ftype>    intent(in), depend(n), dimension(n - 1) :: dl
     <ftype>    intent(in),            dimension(n)     :: d
     <ftype>    intent(in), depend(n), dimension(n - 1) :: du

--- a/scipy/linalg/flapack_gen_tri.pyf.src
+++ b/scipy/linalg/flapack_gen_tri.pyf.src
@@ -54,7 +54,7 @@ subroutine <prefix>gttrs(trans, n, nrhs, dl, d, du, du2, ipiv, b, ldb, info)
     character  optional, intent(in), check(*trans=='N'||*trans=='T'||*trans=='C') :: trans = "N"
     integer    intent(in, hide), depend(d), check(len(d) > 2) :: n = len(d)
     integer    intent(in, hide), depend(b), check(nrhs > 0)  :: nrhs = shape(b, 1)
-    integer    intent(in, hide), depend(b), check(ldb >= MAX(1, n)):: ldb = shape(b, 0)
+    integer    intent(in, hide), depend(n) :: ldb = MAX(1, n)
     <ftype>    intent(in), depend(n), dimension(n - 1) :: dl
     <ftype>    intent(in),            dimension(n)     :: d
     <ftype>    intent(in), depend(n), dimension(n - 1) :: du

--- a/scipy/linalg/flapack_gen_tri.pyf.src
+++ b/scipy/linalg/flapack_gen_tri.pyf.src
@@ -41,7 +41,7 @@ end subroutine <prefix>gttrf
 
 
 subroutine <prefix>gttrs(trans, n, nrhs, dl, d, du, du2, ipiv, b, ldb, info)
-    ! x, info  = gttrs(dl, d, du, du2, ipiv, b, trans="N")
+    ! x, info  = gttrs(dl, d, du, du2, ipiv, b, trans="N", overwrite_b=0)
     !
     ! ?GTTRS solves one of the systems of equations:
     ! A*X = B  or  A**T*X = B,
@@ -60,7 +60,7 @@ subroutine <prefix>gttrs(trans, n, nrhs, dl, d, du, du2, ipiv, b, ldb, info)
     <ftype>    intent(in), depend(n), dimension(n - 1) :: du
     <ftype>    intent(in), depend(n), dimension(n - 2) :: du2
     integer    intent(in), depend(n), dimension(n)     :: ipiv
-    <ftype>    intent(in, out),       dimension(ldb, nrhs) :: b
+    <ftype>    intent(in, out, copy), dimension(ldb, nrhs) :: b
     integer    intent(out) :: info
 
 end subroutine gttrs

--- a/scipy/linalg/flapack_gen_tri.pyf.src
+++ b/scipy/linalg/flapack_gen_tri.pyf.src
@@ -13,3 +13,28 @@ subroutine <prefix>gtsv(n, nrhs, dl, d, du, b, info)
     integer intent(out) :: info
 
 end subroutine <prefix>gtsv
+
+
+subroutine <prefix>gttrf(n, dl, d, du, du2, ipiv, info)
+    ! dl, d, du, du2, ipiv, info  = gttrf(dl, d, du)
+    ! ?GTTRF computes an LU factorization of a tridiagonal matrix A
+    ! using elimination with partial pivoting and row interchanges.
+    !
+    ! The factorization has the form
+    !    A = L * U
+    !
+    ! where L is a product of permutation and unit lower bidiagonal
+    ! matrices and U is upper triangular with nonzeros in only the main
+    ! diagonal and first two superdiagonals.
+    callstatement (*f2py_func)(&n, dl, d, du, du2, ipiv, &info)
+    callprotoargument int*, <ctype>*, <ctype>*, <ctype>*, <ctype>*, int*, int*
+
+    integer intent(hide),   depend(d), check(len(d) > 2) :: n = len(d)
+    <ftype> intent(in,out), depend(n), dimension(n-1)    :: dl
+    <ftype> intent(in,out),            dimension(n)      :: d
+    <ftype> intent(in,out), depend(n), dimension(n-1)    :: du
+    <ftype> intent(out),    depend(n), dimension(n-2)    :: du2
+    integer intent(out),    depend(n), dimension(n)      :: ipiv
+    integer intent(out)                                  :: info
+
+end subroutine <prefix>gttrf

--- a/scipy/linalg/flapack_gen_tri.pyf.src
+++ b/scipy/linalg/flapack_gen_tri.pyf.src
@@ -60,7 +60,7 @@ subroutine <prefix>gttrs(trans, n, nrhs, dl, d, du, du2, ipiv, b, ldb, info)
     <ftype>    intent(in), depend(n), dimension(n - 1) :: du
     <ftype>    intent(in), depend(n), dimension(n - 2) :: du2
     integer    intent(in), depend(n), dimension(n)     :: ipiv
-    <ftype>    intent(in, out, copy), dimension(ldb, nrhs) :: b
+    <ftype>    intent(in, out, copy, out=x), dimension(ldb, nrhs) :: b
     integer    intent(out) :: info
 
 end subroutine gttrs

--- a/scipy/linalg/flapack_gen_tri.pyf.src
+++ b/scipy/linalg/flapack_gen_tri.pyf.src
@@ -38,3 +38,28 @@ subroutine <prefix>gttrf(n, dl, d, du, du2, ipiv, info)
     integer intent(out)                                  :: info
 
 end subroutine <prefix>gttrf
+
+subroutine <prefix>gttrs(trans, n, nrhs, dl, d, du, du2, ipiv, b, ldb, info)
+    ! x, info  = gttrs(dl, d, du, du2, ipiv, b, trans="N")
+    !
+    ! ?GTTRS solves one of the systems of equations:
+    ! A*X = B  or  A**T*X = B,
+    ! with a tridiagonal matrix A using the LU factorization computed
+    ! by ?GTTRF.
+    callstatement (*f2py_func)(trans, &n, &nrhs, dl, d, du, du2, ipiv, b, &ldb, &info)
+    callprotoargument char*, int*, int*, <ctype>*, <ctype>*, <ctype>*, <ctype>*, int*, <ctype>*, int*, int*
+    threadsafe
+
+    character  optional, intent(in), check(*trans=='N'||*trans=='T'||*trans=='C') :: trans = "N"
+    integer    intent(in, hide), depend(d), check(len(d) > 2) :: n = len(d)
+    integer    intent(in, hide), depend(b), check(nrhs > 0)  :: nrhs = shape(b, 1)
+    integer    intent(in, hide), depend(b), check(ldb >= MAX(1, n)):: ldb = shape(b, 0)
+    <ftype>    intent(in), depend(n), dimension(n - 1) :: dl
+    <ftype>    intent(in),            dimension(n)     :: d
+    <ftype>    intent(in), depend(n), dimension(n - 1) :: du
+    <ftype>    intent(in), depend(n), dimension(n - 2) :: du2
+    integer    intent(in), depend(n), dimension(n)     :: ipiv
+    <ftype>    intent(in, out),       dimension(ldb, nrhs) :: b
+    integer    intent(out) :: info
+
+end subroutine gttrs

--- a/scipy/linalg/flapack_gen_tri.pyf.src
+++ b/scipy/linalg/flapack_gen_tri.pyf.src
@@ -52,9 +52,9 @@ subroutine <prefix>gttrs(trans, n, nrhs, dl, d, du, du2, ipiv, b, ldb, info)
     threadsafe
 
     character  optional, intent(in), check(*trans=='N'||*trans=='T'||*trans=='C') :: trans = "N"
-    integer    intent(in, hide), depend(d) :: n = max(3, len(d))
-    integer    intent(in, hide), depend(b) :: nrhs = max(1, shape(b, 1))
-    integer    intent(in, hide), depend(n) :: ldb = max(1, n)
+    integer    intent(hide), depend(d) :: n = max(3, len(d))
+    integer    intent(hide), depend(b) :: nrhs = max(1, shape(b, 1))
+    integer    intent(hide), depend(n) :: ldb = max(1, n)
     <ftype>    intent(in), depend(n), dimension(n - 1) :: dl
     <ftype>    intent(in),            dimension(n)     :: d
     <ftype>    intent(in), depend(n), dimension(n - 1) :: du

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -650,6 +650,11 @@ All functions
    cgttrf
    zgttrf
 
+   sgttrs
+   dgttrs
+   cgttrs
+   zgttrs
+
    stpqrt
    dtpqrt
    ctpqrt

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -645,6 +645,11 @@ All functions
    cgemqrt
    zgemqrt
 
+   sgttrf
+   dgttrf
+   cgttrf
+   zgttrf
+
    stpqrt
    dtpqrt
    ctpqrt

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -1729,3 +1729,31 @@ def test_gttrf_gttrs():
         __dl, __d, __du, _du2, _ipiv, _info = gttrf(dl, d, du)
         np.testing.assert_(_info != 0,
                            "?gttrf: singular matrix ret info == 0")
+
+    du = np.array([2.1, -1.0, 1.9, 8.0])
+    d = np.array([3.0, 2.3, -5.0, -.9, 7.1])
+    dl = np.array([3.4, 3.6, 7.0, -6.0])
+
+    gttrf, gttrs = get_lapack_funcs(('gttrf', "gttrs"), (du[0], du[0]))
+
+    _dl, _d, _du, du2, ipiv, info = gttrf(dl, d, du)
+    assert_allclose(du2, np.array([-1.0000, 1.90000, 8.0000]))
+    assert_allclose(_du, np.array([2.3, -5, -.9, 7.1]))
+    assert_allclose(_d, np.array([3.4, 3.6, 7, -6, -1.0154]), rtol=.001)
+    assert_allclose(ipiv, np.array([2, 3, 4, 5, 5]))
+
+    b = np.array([[2.7, 6.6],
+                  [-0.5, 10.8],
+                  [2.6, -3.2],
+                  [0.6, -11.2],
+                  [2.7, 19.1]
+                  ])
+
+    x_gttrs, info = gttrs(_dl, _d, _du, du2, ipiv, b)
+    x = np.array([[-4.0000, 5.0000],
+                  [7.0000, -4.0000],
+                  [3.0000, -3.0000],
+                  [-4.0000, -2.0000],
+                  [-3.0000, 1.0000]
+                  ])
+    assert_allclose(x_gttrs, x)

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -1686,6 +1686,7 @@ def test_gttrf_gttrs(dtype):
 
     for i, m in enumerate(_dl):
         # L is given in a factored form.
+        # See http://www.hpcavf.uclan.ac.uk/softwaredoc/sgi_scsl_html/sgi_html/ch03.html
         piv = ipiv[i] - 1
         # right multiply by permutation matrix
         L[:, [i, piv]] = L[:, [piv, i]]

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -40,6 +40,14 @@ COMPLEX_DTYPES = [np.complex64, np.complex128]
 DTYPES = REAL_DTYPES + COMPLEX_DTYPES
 
 
+def generate_random_dtype_array(shape, dtype):
+    # generates a random matrix of desired data type of shape
+    if dtype in COMPLEX_DTYPES:
+        return (np.random.rand(*shape)
+                + np.random.rand(*shape)*1.0j).astype(dtype)
+    return np.random.rand(*shape).astype(dtype)
+
+
 def test_lapack_documented():
     """Test that all entries are in the doc."""
     if lapack.__doc__ is None:  # just in case there is a python -OO
@@ -1800,9 +1808,9 @@ def test_gttrf_gttrs(dtype):
     atol = 100 * np.finfo(dtype).eps
 
     # create the matrix in accordance with the data type
-    du = generate_random_dtype_array(n-1, dtype=dtype)
-    d = generate_random_dtype_array(n, dtype=dtype)
-    dl = generate_random_dtype_array(n-1, dtype=dtype)
+    du = generate_random_dtype_array((n-1,), dtype=dtype)
+    d = generate_random_dtype_array((n,), dtype=dtype)
+    dl = generate_random_dtype_array((n-1,), dtype=dtype)
 
     diag_cpy = [dl.copy(), d.copy(), du.copy()]
 
@@ -1952,14 +1960,6 @@ def test_geqrfp_lwork(dtype, shape):
     m, n = shape
     lwork, info = geqrfp_lwork(m=m, n=n)
     assert_equal(info, 0)
-
-
-def generate_random_dtype_array(shape, dtype):
-    # generates a random matrix of desired data type of shape
-    if dtype in COMPLEX_DTYPES:
-        return (np.random.rand(*shape)
-                + np.random.rand(*shape)*1.0j).astype(dtype)
-    return np.random.rand(*shape).astype(dtype)
 
 
 @pytest.mark.parametrize('dtype', DTYPES)

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -1645,3 +1645,50 @@ def test_getc2_gesc2():
         else:
             assert_array_almost_equal(desired_cplx.astype(dtype),
                                       x/scale, decimal=4)
+
+
+def test_gttrf_gttrs():
+    np.random.seed(42)
+    n = 10
+    for index, dtype in enumerate(DTYPES):
+        atol = 10**-(np.finfo(dtype).precision-1)
+        if index < 2:
+            du = np.random.rand(n-1)
+            d = np.random.rand(n)
+            dl = np.random.rand(n-1)
+        else:
+            du = np.random.rand(n-1) * 1j
+            d = np.random.rand(n) * 1j
+            dl = np.random.rand(n-1) * 1j
+
+        diag_cpy = np.array([dl.copy(), d.copy(), du.copy()])
+
+        A = np.diag(d) + np.diag(dl, -1) + np.diag(du, 1)
+        x = np.random.rand(n)
+        b = A @ x
+
+        dgttrf = get_lapack_funcs('gttrf', dtype=dtype)
+        dgttrs = get_lapack_funcs('gttrs', dtype=dtype)
+
+        _dl, _d, _du, du2, ipiv, info = dgttrf(dl, d, du)
+
+        np.testing.assert_allclose(dl, diag_cpy[0], atol=atol)
+        np.testing.assert_allclose(d, diag_cpy[1], atol=atol)
+        np.testing.assert_allclose(du, diag_cpy[2], atol=atol)
+        
+        b_cpy = b.copy()
+        x_dgttrs, info = dgttrs(_dl, _d, _du, du2, ipiv, b)
+        np.testing.assert_allclose(x, x_dgttrs, atol=atol)
+        np.testing.assert_allclose(b, b_cpy, atol=atol)
+        
+
+        dl_malformatted = np.append(dl, [1])
+        d_malformatted = np.append(d, [1])
+        du_malformatted = np.append(du, [1])
+        with assert_raises(ValueError):
+            dgttrf(dl_malformatted, d, du)
+        with assert_raises(ValueError):
+            dgttrf(dl, d_malformatted, du)
+        with assert_raises(ValueError):
+            dgttrf(dl, d, du_malformatted)
+

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -1945,7 +1945,7 @@ def test_gttrf_gttrs_NAG_f07cdf_f07cef_f07crf_f07csf(du, d, dl, du_exp, d_exp,
     _dl, _d, _du, du2, ipiv, info = gttrf(dl, d, du)
     assert_allclose(du2, du2_exp)
     assert_allclose(_du, du_exp)
-    assert_allclose(_d, d_exp, rtol=1e-4)  # NAG examples provide 4 decimals.
+    assert_allclose(_d, d_exp, atol=1e-4)  # NAG examples provide 4 decimals.
     assert_allclose(ipiv, ipiv_exp)
 
     x_gttrs, info = gttrs(_dl, _d, _du, du2, ipiv, b)

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -1804,7 +1804,6 @@ def test_gttrf_gttrs(dtype):
 
     np.random.seed(42)
     n = 10
-    rtol = 250 * np.finfo(dtype).eps  # set test tolerance appropriate for dtype
     atol = 100 * np.finfo(dtype).eps
 
     # create the matrix in accordance with the data type
@@ -1853,7 +1852,7 @@ def test_gttrf_gttrs(dtype):
     # test that the inputs of ?gttrs are unmodified
     assert_array_equal(b, b_cpy)
     # test that the result of ?gttrs matches the expected input
-    assert_allclose(x, x_gttrs, rtol=rtol)
+    assert_allclose(x, x_gttrs, atol=atol)
 
     # test that ?gttrf and ?gttrs work with transposal options
     if dtype in REAL_DTYPES:
@@ -1864,7 +1863,7 @@ def test_gttrf_gttrs(dtype):
         b_trans = A.conj().T @ x
 
     x_gttrs, info = gttrs(_dl, _d, _du, du2, ipiv, b_trans, trans=trans)
-    assert_allclose(x, x_gttrs, rtol=rtol)
+    assert_allclose(x, x_gttrs, atol=atol)
 
     # test that ValueError is raised with incompatible matrix shapes
     with assert_raises(ValueError):

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -1656,7 +1656,7 @@ def test_gttrf_gttrs(dtype):
     # non zero info.
 
     np.random.seed(42)
-    n = 8
+    n = 10
     rtol = 250*np.finfo(dtype).eps  # set test tolerance appropriate for dtype
     atol = np.finfo(dtype).eps
 
@@ -1735,16 +1735,16 @@ def test_gttrf_gttrs(dtype):
     du[0] = 0
     d[0] = 0
     __dl, __d, __du, _du2, _ipiv, _info = gttrf(dl, d, du)
-    print(_info)
-    np.testing.assert_(_info == n,
-                       "?gttrf: A is singular matrix, _info =/= {}.".format(n))
+    np.testing.assert_(__d[info - 1] == 0,
+                       "?gttrf: _d[info-1] is {}, not the illegal value :0."
+                       .format(__d[info - 1]))
 
 
 def generate_random_dtype_array(shape, dtype):
     # generates a random matrix of desired data type
     if dtype in COMPLEX_DTYPES:
-        return (np.random.rand(shape)
-                + np.random.rand(shape)*1.0j).astype(dtype)
+        return (np.random.rand(shape) +
+                np.random.rand(shape) * 1.0j).astype(dtype)
     return np.random.rand(shape).astype(dtype)
 
 

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -1683,7 +1683,7 @@ def test_gttrf_gttrs():
             perm_fnl[i], perm_fnl[piv-1] = perm_fnl[piv-1], perm_fnl[i]
 
         _A = np.diag(_dl, -1) + np.diag(_d, 0) + np.diag(_du, 1)
-        # assert_allclose(_A, A[perm_fnl], rtol=rtol)
+        #assert_allclose(_A, A[perm_fnl], rtol=rtol)
 
         b_cpy = b.copy()
         x_gttrs, info = gttrs(_dl, _d, _du, du2, ipiv, b)
@@ -1710,9 +1710,22 @@ def test_gttrf_gttrs():
         with assert_raises(Exception):
             gttrf(dl[0], d[:1], du[0])
 
+        transpose_options = ["N", "C", "T"]
+        for trans in transpose_options:
+            if trans == "N":
+                b_trans = A @ x
+            elif trans == "T":
+                b_trans = np.transpose(A) @ x
+            elif trans == "C":
+                b_trans = A.conj().T @ x
+            _dl, _d, _du, du2, ipiv, info = gttrf(dl, d, du)
+            x_gttrs, info = gttrs(_dl, _d, _du, du2, ipiv, b_trans,
+                                  trans=trans)
+            assert_allclose(x, x_gttrs, rtol=rtol)
+
         dl[0] = 0
         du[0] = 0
         d[0] = 0
         __dl, __d, __du, _du2, _ipiv, _info = gttrf(dl, d, du)
         np.testing.assert_(_info != 0,
-                          "?gttrf: singular matrix should return non 0 info")
+                           "?gttrf: singular matrix ret info == 0")

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -1666,8 +1666,8 @@ def test_gttrf_gttrs(dtype):
 
     np.random.seed(42)
     n = 10
-    rtol = 250*np.finfo(dtype).eps  # set test tolerance appropriate for dtype
-    atol = np.finfo(dtype).eps
+    rtol = 250 * np.finfo(dtype).eps  # set test tolerance appropriate for dtype
+    atol = 100 * np.finfo(dtype).eps
 
     # create the matrix in accordance with the data type
     du = generate_random_dtype_array(n-1, dtype=dtype)

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -1678,12 +1678,12 @@ def test_gttrf_gttrs():
         assert_array_equal(d, diag_cpy[1])
         assert_array_equal(du, diag_cpy[2])
 
-        permute_fnl = np.arange(n)
+        perm_fnl = np.arange(n)
         for i, piv in enumerate(ipiv):
-            permute_fnl[i], permute_fnl[piv-1] = permute_fnl[piv-1], permute_fnl[i]
+            perm_fnl[i], perm_fnl[piv-1] = perm_fnl[piv-1], perm_fnl[i]
 
         _A = np.diag(_dl, -1) + np.diag(_d, 0) + np.diag(_du, 1)
-        assert_allclose(_A, A[permute_fnl], rtol=rtol)
+        # assert_allclose(_A, A[perm_fnl], rtol=rtol)
 
         b_cpy = b.copy()
         x_gttrs, info = gttrs(_dl, _d, _du, du2, ipiv, b)
@@ -1692,12 +1692,10 @@ def test_gttrf_gttrs():
         assert_allclose(x, x_gttrs, rtol=rtol)
 
         if index < 2:
-            d_zeros = np.zeros(n)
             dl_misshaped = np.random.rand(n)
             d_misshaped = np.random.rand(n-1)
             du_misshaped = np.random.rand(n)
         else:
-            d_zeros = np.zeros(n) + np.zeros(n) * 1j
             dl_misshaped = np.random.rand(n) + np.random.rand(n) * 1j
             d_misshaped = np.random.rand(n-1) + np.random.rand(n-1) * 1j
             du_misshaped = np.random.rand(n) + np.random.rand(n) * 1j
@@ -1708,14 +1706,13 @@ def test_gttrf_gttrs():
             gttrf(dl, d_misshaped, du)
         with assert_raises(ValueError):
             gttrf(dl, d, du_misshaped)
- 
-        singular_matrix_gttrf = gttrf(dl, d_zeros, du)
-        
+
         with assert_raises(Exception):
             gttrf(dl[0], d[:1], du[0])
-        
-        # np.testing.assert_(singular_matrix_gttrf[5] != 0,
-        #               "?gttrf: singular matrix should return non-zero info.")
-        
 
-
+        dl[0] = 0
+        du[0] = 0
+        d[0] = 0
+        __dl, __d, __du, _du2, _ipiv, _info = gttrf(dl, d, du)
+        np.testing.assert_(_info != 0,
+                          "?gttrf: singular matrix should return non 0 info")

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -1802,7 +1802,7 @@ def test_gttrf_gttrs(dtype):
     # incompatible matrix shapes raise an error, and singular matrices return
     # non zero info.
 
-    np.random.seed(42)
+    seed(42)
     n = 10
     atol = 100 * np.finfo(dtype).eps
 
@@ -1886,7 +1886,7 @@ def test_gttrf_gttrs(dtype):
                        .format(__d[info - 1]))
 
 
-@pytest.mark.parametrize("du,d,dl,du_exp,d_exp,du2_exp,ipiv_exp,b,x",
+@pytest.mark.parametrize("du, d, dl, du_exp, d_exp, du2_exp, ipiv_exp, b, x",
                          [(np.array([2.1, -1.0, 1.9, 8.0]),
                              np.array([3.0, 2.3, -5.0, -.9, 7.1]),
                              np.array([3.4, 3.6, 7.0, -6.0]),
@@ -1931,13 +1931,10 @@ def test_gttrf_gttrs(dtype):
                             )])
 def test_gttrf_gttrs_NAG_f07cdf_f07cef_f07crf_f07csf(du, d, dl, du_exp, d_exp,
                                                      du2_exp, ipiv_exp, b, x):
-    # test to assure that wrapper is consistent with NAG manual
+    # test to assure that wrapper is consistent with NAG Library Manual Mark 26
     # example problems: f07cdf and f07cef (real)
-    # https://www.nag.com/numeric/fl/nagdoc_latest/html/f07/f07cdf.html#example
-    # https://www.nag.com/numeric/fl/nagdoc_latest/html/f07/f07cef.html#example
     # examples: f07crf and f07csf (complex)
-    # https://www.nag.com/numeric/fl/nagdoc_latest/html/f07/f07csf.html
-    # https://www.nag.com/numeric/fl/nagdoc_latest/html/f07/f07crf.html
+    # (Links may expire, so search for "NAG Library Manual Mark 26" online)
 
     gttrf, gttrs = get_lapack_funcs(('gttrf', "gttrs"), (du[0], du[0]))
 


### PR DESCRIPTION
This PR adds Python level wrappers for the LAPACK functions ?gttrf/?gttrs as part of the NumFocus small development grant.  ?gttrf computes the LU factorization of a tridiagonal matrix, and ?gttrs solves a linear system using that factorization.  SciPy has wrappers tailored for the solution of systems of other matrix types, and tridiagonal matrices are important matrix class, so SciPy would benefit from enhanced support for tridiagonal matrices.

This closes #11123  

Finally a special thank you to @swallan and @mdhaber for their contributions and review.