### PR TITLE
ENH (WIP): Python wrapper for ?tbtrs

### DIFF
--- a/scipy/linalg/flapack_other.pyf.src
+++ b/scipy/linalg/flapack_other.pyf.src
@@ -175,6 +175,36 @@ subroutine <prefix>trtrs(lower, trans, unitdiag, n, nrhs, a, lda, b, ldb, info)
 
 end subroutine <prefix>trtrs
 
+subroutine <prefix>tbtrs(uplo,trans,diag,n,kd,nrhs,ab,ldab,b,ldb,info)
+    ! x, info  = tbtrs(ab, b, uplo="U", trans="N", diag="N", overwrite_b=0)
+    ! ?TBTRS solves a triangular system of the form
+    !
+    !     A * X = B  or  A**T * X = B,
+    !
+    ! where:
+    !   * A is a triangular band matrix of order N,
+    !   * B is an N-by NRHS matrix.
+    ! A check is made to verify that A is nonsingular.
+
+    callstatement (*f2py_func)(uplo,trans,diag,&n,&kd,&nrhs,ab,&ldab,b,&ldb,&info)
+    callprotoargument char*,char*,char*,int*,int*,int*,<ctype>*,int*,<ctype>*,int*,int*
+
+    <ftype> intent(in), dimension(ldab, n) :: ab
+    <ftype> intent(in,out,copy,out=x), dimension(ldb, nrhs) :: b
+    integer intent(out) :: info
+
+    character optional intent(in), check(*uplo=='U'||*uplo=='L') :: uplo = 'U'
+    character optional intent(in), check(*trans=='N'||*trans=='T'||*trans=='C') :: trans = 'N'
+    character optional intent(in), check(*diag=='N'||*diag=='U') :: diag = 'N'
+
+    integer intent(hide), depend(ab), check(ldab > 0) :: ldab = shape(ab, 0)
+    integer intent(hide), depend(ab), check(n > 0) :: n = shape(ab, 1)
+    integer intent(hide), depend(ldab) :: kd = ldab - 1
+    integer intent(hide), depend(b), check(ldb > 0) :: ldb = shape(b, 0)
+    integer intent(hide), depend(b), check(nrhs > 0) = shape(b, 1)
+
+end subroutine <prefix>tbtrs
+
 subroutine <prefix2>pbsv(lower,n,kd,nrhs,ab,ldab,b,ldb,info)
     !
     ! Computes the solution to a real system of linear equations

--- a/scipy/linalg/flapack_other.pyf.src
+++ b/scipy/linalg/flapack_other.pyf.src
@@ -198,11 +198,11 @@ subroutine <prefix>tbtrs(uplo,trans,diag,n,kd,nrhs,ab,ldab,b,ldb,info)
     character optional intent(in), check(*trans=='N'||*trans=='T'||*trans=='C') :: trans = 'N'
     character optional intent(in), check(*diag=='N'||*diag=='U') :: diag = 'N'
 
-    integer intent(hide), depend(ab), check(ldab > 0) :: ldab = shape(ab, 0)
-    integer intent(hide), depend(ab), check(n > 0) :: n = shape(ab, 1)
+    integer intent(hide), depend(ab) :: ldab = MAX(1, shape(ab, 0))
+    integer intent(hide), depend(ab) :: n = MAX(1, shape(ab, 1))
     integer intent(hide), depend(ldab) :: kd = ldab - 1
-    integer intent(hide), depend(b, n), check(ldb >= max(1, n)) :: ldb = shape(b, 0)
-    integer intent(hide), depend(b), check(nrhs > 0) :: nrhs = shape(b, 1)
+    integer intent(hide), depend(b, n), check(ldb >= n) :: ldb = MAX(1, shape(b, 0))
+    integer intent(hide), depend(b) :: nrhs = MAX(1, shape(b, 1))
 
 end subroutine <prefix>tbtrs
 

--- a/scipy/linalg/flapack_other.pyf.src
+++ b/scipy/linalg/flapack_other.pyf.src
@@ -201,7 +201,7 @@ subroutine <prefix>tbtrs(uplo,trans,diag,n,kd,nrhs,ab,ldab,b,ldb,info)
     integer intent(hide), depend(ab), check(n > 0) :: n = shape(ab, 1)
     integer intent(hide), depend(ldab) :: kd = ldab - 1
     integer intent(hide), depend(b), check(ldb > 0) :: ldb = shape(b, 0)
-    integer intent(hide), depend(b), check(nrhs > 0) = shape(b, 1)
+    integer intent(hide), depend(b), check(nrhs > 0) :: nrhs = shape(b, 1)
 
 end subroutine <prefix>tbtrs
 

--- a/scipy/linalg/flapack_other.pyf.src
+++ b/scipy/linalg/flapack_other.pyf.src
@@ -175,6 +175,7 @@ subroutine <prefix>trtrs(lower, trans, unitdiag, n, nrhs, a, lda, b, ldb, info)
 
 end subroutine <prefix>trtrs
 
+
 subroutine <prefix>tbtrs(uplo,trans,diag,n,kd,nrhs,ab,ldab,b,ldb,info)
     ! x, info  = tbtrs(ab, b, uplo="U", trans="N", diag="N", overwrite_b=0)
     ! ?TBTRS solves a triangular system of the form
@@ -200,7 +201,7 @@ subroutine <prefix>tbtrs(uplo,trans,diag,n,kd,nrhs,ab,ldab,b,ldb,info)
     integer intent(hide), depend(ab), check(ldab > 0) :: ldab = shape(ab, 0)
     integer intent(hide), depend(ab), check(n > 0) :: n = shape(ab, 1)
     integer intent(hide), depend(ldab) :: kd = ldab - 1
-    integer intent(hide), depend(b), check(ldb > 0) :: ldb = shape(b, 0)
+    integer intent(hide), depend(b, n), check(ldb >= max(1, n)) :: ldb = shape(b, 0)
     integer intent(hide), depend(b), check(nrhs > 0) :: nrhs = shape(b, 1)
 
 end subroutine <prefix>tbtrs

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -560,6 +560,11 @@ All functions
    csytrf_lwork
    zsytrf_lwork
 
+   stbtrs
+   dtbtrs
+   ctbtrs
+   ztbtrs
+
    stfsm
    dtfsm
    ctfsm

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -553,20 +553,22 @@ class TestTbtrs(object):
         band_widths = range(lda, lda - kd - 1, -1)
         band_offsets = np.arange(ldab) if uplo == 'U' else np.arange(ldab) * -1
         if dtype in REAL_DTYPES:
+            b = rand(ldb, nrhs).astype(dtype)
             bands = [rand(width).astype(dtype) for width in band_widths]
         elif dtype in COMPLEX_DTYPES:
+            b = (rand(ldb, nrhs) + rand(ldb, nrhs) * 1j).astype(dtype)
             bands = [(rand(width) + rand(width) * 1j).astype(dtype)
                      for width in band_widths]
 
         # Construct the diagonal banded matrix A from the bands and offsets.
         a = sps.diags(bands, band_offsets, format='dia')
         ab = np.flipud(a.data) if uplo == 'U' else a.data
-        b = rand(ldb, nrhs).astype(dtype)
-
         tbtrs = get_lapack_funcs('tbtrs', dtype=dtype)
+
         x, info = tbtrs(ab=ab, b=b, uplo=uplo)
         assert_equal(info, 0)
         assert_allclose(a @ x, b, rtol=5e-5)
+
 
 def test_lartg():
     for dtype in 'fdFD':

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -597,6 +597,22 @@ class TestTbtrs(object):
         b = rand(2, 4)
         assert_raises(Exception, tbtrs, ab, b, uplo, trans, diag)
 
+    def test_zero_element_in_diagonal(self):
+        """Test if a matrix with a zero diagonal element is singular
+
+        If the i-th diagonal of A is zero, ?tbtrs should return `i` in `info`
+        indicating the provided matrix is singular.
+
+        Note that ?tbtrs requires the matrix A to be stored in banded form.
+        In this form the diagonal corresponds to the last row."""
+        ab = np.ones((3, 4), dtype=float)
+        b = np.ones(4, dtype=float)
+        tbtrs = get_lapack_funcs('tbtrs', dtype=float)
+
+        ab[-1, 3] = 0
+        _, info = tbtrs(ab=ab, b=b, uplo='U')
+        assert_equal(info, 4)
+
 
 def test_lartg():
     for dtype in 'fdFD':

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -613,12 +613,10 @@ class TestTbtrs(object):
         _, info = tbtrs(ab=ab, b=b, uplo='U')
         assert_equal(info, 4)
 
-    @pytest.mark.parametrize('ldab,n,ldb,nrhs',
-                             [(0, 5, 5, 5),
-                              (5, 0, 5, 5),
+    @pytest.mark.parametrize('ldab,n,ldb,nrhs', [
                               (5, 5, 0, 5),
-                              (5, 5, 5, 0),
-                              (5, 5, 3, 5)])
+                              (5, 5, 3, 5)
+    ])
     def test_invalid_matrix_shapes(self, ldab, n, ldb, nrhs):
         """Test ?tbtrs fails correctly if shapes are invalid."""
         ab = np.ones((ldab, n), dtype=float)

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -584,6 +584,19 @@ class TestTbtrs(object):
         else:
             raise ValueError('Invalid trans argument')
 
+    @pytest.mark.parametrize('uplo,trans,diag',
+                             [['U', 'N', 'Invalid'],
+                              ['U', 'Invalid', 'N'],
+                              ['Invalid', 'N', 'N']])
+    def test_invalid_argument_raises_exception(self, uplo, trans, diag):
+        """Test if invalid values of uplo, trans and diag raise exceptions"""
+        # Argument checks occur independently of used datatype.
+        # This mean we must not parameterize all available datatypes.
+        tbtrs = get_lapack_funcs('tbtrs', dtype=np.float)
+        ab = rand(4, 2)
+        b = rand(2, 4)
+        assert_raises(Exception, tbtrs, ab, b, uplo, trans, diag)
+
 
 def test_lartg():
     for dtype in 'fdFD':

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -488,6 +488,55 @@ class TestDlasd4(object):
                         rtol=100*np.finfo(np.float64).eps)
 
 
+class TestTbtrs(object):
+
+    @pytest.mark.parametrize('dtype', DTYPES)
+    def test_nag_example_f07vef_f07vsf(self, dtype):
+        """Test real (f07vef) and complex (f07vsf) examples from NAG
+
+        Examples available from:
+        * https://www.nag.com/numeric/fl/nagdoc_latest/html/f07/f07vef.html
+        * https://www.nag.com/numeric/fl/nagdoc_latest/html/f07/f07vsf.html
+
+        """
+        if dtype in REAL_DTYPES:
+            ab = np.array([[-4.16, 4.78, 6.32, 0.16],
+                           [-2.25, 5.86, -4.82, 0]],
+                          dtype=dtype)
+            b = np.array([[-16.64, -4.16],
+                          [-13.78, -16.59],
+                          [13.10, -4.94],
+                          [-14.14, -9.96]],
+                         dtype=dtype)
+            x_out = np.array([[4, 1],
+                              [-1, -3],
+                              [3, 2],
+                              [2, -2]],
+                             dtype=dtype)
+        elif dtype in COMPLEX_DTYPES:
+            ab = np.array([[-1.94+4.43j, 4.12-4.27j, 0.43-2.66j, 0.44+0.1j],
+                           [-3.39+3.44j, -1.84+5.52j, 1.74 - 0.04j, 0],
+                           [1.62+3.68j, -2.77-1.93j, 0, 0]],
+                          dtype=dtype)
+            b = np.array([[-8.86 - 3.88j, -24.09 - 5.27j],
+                          [-15.57 - 23.41j, -57.97 + 8.14j],
+                          [-7.63 + 22.78j, 19.09 - 29.51j],
+                          [-14.74 - 2.40j, 19.17 + 21.33j]],
+                         dtype=dtype)
+            x_out = np.array([[2j, 1 + 5j],
+                              [1 - 3j, -7 - 2j],
+                              [-4.001887 - 4.988417j, 3.026830 + 4.003182j],
+                              [1.996158 - 1.045105j, -6.103357 - 8.986653j]],
+                             dtype=dtype)
+        else:
+            raise ValueError(f"Datatype {dtype} not understood.")
+
+        tbtrs = get_lapack_funcs(('tbtrs'), dtype=dtype)
+        x, info = tbtrs(ab=ab, b=b, uplo='L')
+        assert_equal(info, 0)
+        assert_allclose(x, x_out, rtol=0, atol=1e-5)
+
+
 def test_lartg():
     for dtype in 'fdFD':
         lartg = get_lapack_funcs('lartg', dtype=dtype)

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -613,6 +613,18 @@ class TestTbtrs(object):
         _, info = tbtrs(ab=ab, b=b, uplo='U')
         assert_equal(info, 4)
 
+    @pytest.mark.parametrize('ldab,n,ldb,nrhs',
+                             [(0, 5, 5, 5),
+                              (5, 0, 5, 5),
+                              (5, 5, 0, 5),
+                              (5, 5, 5, 0)])
+    def test_invalid_matrix_shapes(self, ldab, n, ldb, nrhs):
+        """Test ?tbtrs fails correctly if shapes are invalid."""
+        ab = np.ones((ldab, n), dtype=float)
+        b = np.ones((ldb, nrhs), dtype=float)
+        tbtrs = get_lapack_funcs('tbtrs', dtype=float)
+        assert_raises(Exception, tbtrs, ab, b)
+
 
 def test_lartg():
     for dtype in 'fdFD':

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -617,7 +617,8 @@ class TestTbtrs(object):
                              [(0, 5, 5, 5),
                               (5, 0, 5, 5),
                               (5, 5, 0, 5),
-                              (5, 5, 5, 0)])
+                              (5, 5, 5, 0),
+                              (5, 5, 3, 5)])
     def test_invalid_matrix_shapes(self, ldab, n, ldb, nrhs):
         """Test ?tbtrs fails correctly if shapes are invalid."""
         ab = np.ones((ldab, n), dtype=float)


### PR DESCRIPTION
This PR adds a python wrapper for the LAPACK functions [?tbtrs](http://www.netlib.org/lapack/explore-html/da/dba/group__double_o_t_h_e_rcomputational_gaadacbb4c29e9604acd77ada4963827c5.html#gaadacbb4c29e9604acd77ada4963827c5) as part of the NumFocus small development grant. ?tbtrs solves a linear system with a triangular banded matrix. Triangular band matrices are an important class of matrices, and solving such systems using a tailored routine can yield substantial speed improvements. 

This will close #11190