### PR TITLE
MAINT: Remove six.with_metaclass from benchmarks/cython_special.py

### DIFF
--- a/benchmarks/benchmarks/cython_special.py
+++ b/benchmarks/benchmarks/cython_special.py
@@ -1,7 +1,6 @@
 from __future__ import division, absolute_import, print_function
 
 import re
-import six
 import numpy as np
 from scipy import special
 
@@ -62,7 +61,7 @@ class _CythonSpecialMeta(type):
         return type.__new__(cls, cls_name, bases, dct)
 
 
-class CythonSpecial(six.with_metaclass(_CythonSpecialMeta)):
+class CythonSpecial(metaclass=_CythonSpecialMeta):
     def setup(self, name, args, N, api):
         self.py_func = getattr(cython_special, '_bench_{}_py'.format(name))
         self.cy_func = getattr(cython_special, '_bench_{}_cy'.format(name))


### PR DESCRIPTION
https://realpython.com/python-metaclasses
https://six.readthedocs.io/#six.with_metaclass

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
Remove __six.with_metaclass__ from __benchmarks/cython_special.py__

#### Additional information
<!--Any additional information you think is important.-->