### PR TITLE
BUG: sparse/isolve: bicg and qmr don't treat x0 correctly

### DIFF
--- a/scipy/sparse/linalg/isolve/iterative/BiCGREVCOM.f.src
+++ b/scipy/sparse/linalg/isolve/iterative/BiCGREVCOM.f.src
@@ -226,12 +226,12 @@
 *
       CALL <_c>COPY( N, B, 1, WORK(1,R), 1 )
       IF ( <rc>NRM2( N, X, 1 ).NE.ZERO ) THEN
-*********CALL MATVEC( -ONE, X, ZERO, WORK(1,R) )
+*********CALL MATVEC( -ONE, X, ONE, WORK(1,R) )
 *        using WORK[RTLD] as temp
 *********CALL <_c>COPY( N, X, 1, WORK(1,RTLD), 1 )
          SCLR1 = -ONE
-         SCLR2 = ZERO
-         NDX1 = ((RTLD - 1) * LDW) + 1
+         SCLR2 = ONE
+         NDX1 = -1
          NDX2 = ((R    - 1) * LDW) + 1
          RLBL = 2
          IJOB = 5

--- a/scipy/sparse/linalg/isolve/iterative/QMRREVCOM.f.src
+++ b/scipy/sparse/linalg/isolve/iterative/QMRREVCOM.f.src
@@ -284,12 +284,12 @@
 *
       CALL <_c>COPY( N, B, 1, WORK(1,R), 1 )
       IF ( <rc>NRM2( N, X, 1 ).NE.ZERO ) THEN
-*********CALL MATVEC( -ONE, X, ZERO, WORK(1,R) )
-*        Note: using D as temp
-*********CALL <_c>COPY( N, X, 1, WORK(1,D), 1 )
+*********CALL MATVEC( -ONE, X, ONE, WORK(1,R) )
+*        Note: using VTLD as temp
+*********CALL <_c>COPY( N, X, 1, WORK(1,VTLD), 1 )
          SCLR1 = -ONE
-         SCLR2 = ZERO
-         NDX1 = ((D - 1) * LDW) + 1
+         SCLR2 = ONE
+         NDX1 = -1
          NDX2 = ((R - 1) * LDW) + 1
          RLBL = 2
          IJOB = 7

--- a/scipy/sparse/linalg/isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/isolve/tests/test_iterative.py
@@ -484,6 +484,30 @@ def test_maxiter_worsening(solver):
         assert_(error <= tol*best_error)
 
 
+@pytest.mark.parametrize("solver", [cg, cgs, bicg, bicgstab, gmres, qmr, minres, lgmres, gcrotmk])
+def test_x0_working(solver):
+    # Easy problem
+    np.random.seed(1)
+    n = 10
+    A = np.random.rand(n, n)
+    A = A.dot(A.T)
+    b = np.random.rand(n)
+    x0 = np.random.rand(n)
+
+    if solver is minres:
+        kw = dict(tol=1e-6)
+    else:
+        kw = dict(atol=0, tol=1e-6)
+
+    x, info = solver(A, b, **kw)
+    assert_equal(info, 0)
+    assert_(np.linalg.norm(A.dot(x) - b) <= 1e-6*np.linalg.norm(b))
+
+    x, info = solver(A, b, x0=x0, **kw)
+    assert_equal(info, 0)
+    assert_(np.linalg.norm(A.dot(x) - b) <= 1e-6*np.linalg.norm(b))
+
+
 #------------------------------------------------------------------------------
 
 class TestQMR(object):


### PR DESCRIPTION
#### Reference issue
See https://github.com/scipy/scipy/issues/5022#issuecomment-575218401

#### What does this implement/fix?
Previously, bicg and qmr did the equivalent of `r = b if norm(x0) == 0 else r = -A @ x0` for the initial residual, which is incorrect. Correct the computation to `r = b; if norm(x0) != 0: r -= A @ x0`.

Also add a test (which before this change fails for bicg and qmr).

### Additional information
BiCGSTAB does it correctly:
https://github.com/scipy/scipy/blob/e114f8508528f34d2e758f4de83569fd8c0d213d/scipy/sparse/linalg/isolve/iterative/BiCGSTABREVCOM.f.src#L234-L248

See also the reverse-communication parts for bicg:
https://github.com/scipy/scipy/blob/e114f8508528f34d2e758f4de83569fd8c0d213d/scipy/sparse/linalg/isolve/iterative.py#L168-L186

and qmr:
https://github.com/scipy/scipy/blob/e114f8508528f34d2e758f4de83569fd8c0d213d/scipy/sparse/linalg/isolve/iterative.py#L768-L790