### PR TITLE
MAINT: remove error throw in binned_statistic_dd() on non-finite values or samples

### DIFF
--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -104,7 +104,8 @@ def binned_statistic(x, values, statistic='mean',
 
     >>> values = [1.0, 1.0, 2.0, 1.5, 3.0]
     >>> stats.binned_statistic([1, 1, 2, 5, 7], values, 'sum', bins=2)
-    BinnedStatisticResult(statistic=array([4. , 4.5]), bin_edges=array([1., 4., 7.]), binnumber=array([1, 1, 1, 2, 2]))
+    BinnedStatisticResult(statistic=array([4. , 4.5]),
+            bin_edges=array([1., 4., 7.]), binnumber=array([1, 1, 1, 2, 2]))
 
     Multiple arrays of values can also be passed.  The statistic is calculated
     on each set independently:
@@ -112,11 +113,14 @@ def binned_statistic(x, values, statistic='mean',
     >>> values = [[1.0, 1.0, 2.0, 1.5, 3.0], [2.0, 2.0, 4.0, 3.0, 6.0]]
     >>> stats.binned_statistic([1, 1, 2, 5, 7], values, 'sum', bins=2)
     BinnedStatisticResult(statistic=array([[4. , 4.5],
-           [8. , 9. ]]), bin_edges=array([1., 4., 7.]), binnumber=array([1, 1, 1, 2, 2]))
+           [8. , 9. ]]), bin_edges=array([1., 4., 7.]),
+           binnumber=array([1, 1, 1, 2, 2]))
 
     >>> stats.binned_statistic([1, 2, 1, 2, 4], np.arange(5), statistic='mean',
     ...                        bins=3)
-    BinnedStatisticResult(statistic=array([1., 2., 4.]), bin_edges=array([1., 2., 3., 4.]), binnumber=array([1, 2, 1, 2, 3]))
+    BinnedStatisticResult(statistic=array([1., 2., 4.]),
+            bin_edges=array([1., 2., 3., 4.]),
+            binnumber=array([1, 2, 1, 2, 3]))
 
     As a second example, we now generate some random data of sailing boat speed
     as a function of wind speed, and then determine how fast our boat is for
@@ -305,7 +309,7 @@ def binned_statistic_2d(x, y, values, statistic='mean',
     >>> y = [2.1, 2.6, 2.1, 2.1]
     >>> binx = [0.0, 0.5, 1.0]
     >>> biny = [2.0, 2.5, 3.0]
-    >>> ret = stats.binned_statistic_2d(x, y, x, 'count', bins=[binx,biny])
+    >>> ret = stats.binned_statistic_2d(x, y, None, 'count', bins=[binx, biny])
     >>> ret.statistic
     array([[2., 1.],
            [1., 0.]])
@@ -319,7 +323,7 @@ def binned_statistic_2d(x, y, values, statistic='mean',
     The bin indices can also be expanded into separate entries for each
     dimension using the `expand_binnumbers` parameter:
 
-    >>> ret = stats.binned_statistic_2d(x, y, x, 'count', bins=[binx,biny],
+    >>> ret = stats.binned_statistic_2d(x, y, None, 'count', bins=[binx, biny],
     ...                                 expand_binnumbers=True)
     >>> ret.binnumber
     array([[1, 1, 1, 2],
@@ -513,8 +517,9 @@ def binned_statistic_dd(sample, values, statistic='mean',
     if not callable(statistic) and statistic not in known_stats:
         raise ValueError('invalid statistic %r' % (statistic,))
 
-    if not np.isfinite(values).all() or not np.isfinite(sample).all:
-        raise ValueError('%r or %r contains non-finite values.' % (sample, values,))
+    # NOTE: for _bin_edges(), see e.g. gh-11365
+    if isinstance(bins, int) and not np.isfinite(sample).all():
+        raise ValueError('%r contains non-finite values.' % (sample,))
 
     # `Ndim` is the number of dimensions (e.g. `2` for `binned_statistic_2d`)
     # `Dlen` is the length of elements along each dimension.

--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -1,6 +1,7 @@
 import builtins
 import numpy as np
 from numpy.testing import suppress_warnings
+from operator import index
 from collections import namedtuple
 
 __all__ = ['binned_statistic',
@@ -516,6 +517,13 @@ def binned_statistic_dd(sample, values, statistic='mean',
     known_stats = ['mean', 'median', 'count', 'sum', 'std', 'min', 'max']
     if not callable(statistic) and statistic not in known_stats:
         raise ValueError('invalid statistic %r' % (statistic,))
+
+    try:
+        bins = index(bins)
+    except TypeError:
+        # bins is not an integer
+        pass
+    # If bins was an integer-like object, now it is an actual Python int.
 
     # NOTE: for _bin_edges(), see e.g. gh-11365
     if isinstance(bins, int) and not np.isfinite(sample).all():

--- a/scipy/stats/tests/test_binned_statistic.py
+++ b/scipy/stats/tests/test_binned_statistic.py
@@ -49,18 +49,19 @@ class TestBinnedStatistic(object):
 
         assert_allclose(stat1, stat2)
 
-    def test_non_finite_inputs(self):
+    def test_non_finite_inputs_and_int_bins(self):
         # if either `values` or `sample` contain np.inf or np.nan throw
         # see issue gh-9010 for more
         x = self.x
         u = self.u
         orig = u[0]
         u[0] = np.inf
-        assert_raises(ValueError, binned_statistic, x, u, 'std', bins=10)
+        assert_raises(ValueError, binned_statistic, u, x, 'std', bins=10)
         u[0] = np.nan
         assert_raises(ValueError, binned_statistic, x, u, 'count', bins=10)
         # replace original value, u belongs the class
         u[0] = orig
+        assert_raises(ValueError, binned_statistic, u, x, 'count', bins=10)
 
     def test_1d_result_attributes(self):
         x = self.x

--- a/scipy/stats/tests/test_binned_statistic.py
+++ b/scipy/stats/tests/test_binned_statistic.py
@@ -58,7 +58,8 @@ class TestBinnedStatistic(object):
         u[0] = np.inf
         assert_raises(ValueError, binned_statistic, u, x, 'std', bins=10)
         # need to test for non-python specific ints, e.g. np.int8, np.int64
-        assert_raises(ValueError, binned_statistic, u, x, 'std', bins=np.int64(10))
+        assert_raises(ValueError, binned_statistic, u, x, 'std',
+                      bins=np.int64(10))
         u[0] = np.nan
         assert_raises(ValueError, binned_statistic, u, x, 'count', bins=10)
         # replace original value, u belongs the class

--- a/scipy/stats/tests/test_binned_statistic.py
+++ b/scipy/stats/tests/test_binned_statistic.py
@@ -58,7 +58,6 @@ class TestBinnedStatistic(object):
         u[0] = np.inf
         assert_raises(ValueError, binned_statistic, u, x, 'std', bins=10)
         # need to test for non-python specific ints, e.g. np.int8, np.int64
-        # note np.int will pass the isinstance(bins, int) test but other int no
         assert_raises(ValueError, binned_statistic, u, x, 'std', bins=np.int64(10))
         u[0] = np.nan
         assert_raises(ValueError, binned_statistic, u, x, 'count', bins=10)

--- a/scipy/stats/tests/test_binned_statistic.py
+++ b/scipy/stats/tests/test_binned_statistic.py
@@ -57,11 +57,14 @@ class TestBinnedStatistic(object):
         orig = u[0]
         u[0] = np.inf
         assert_raises(ValueError, binned_statistic, u, x, 'std', bins=10)
+        # need to test for non-python specific ints, e.g. np.int8, np.int64
+        # note np.int will pass the isinstance(bins, int) test but other int no
+        assert_raises(ValueError, binned_statistic, u, x, 'std', bins=np.int64(10))
         u[0] = np.nan
-        assert_raises(ValueError, binned_statistic, x, u, 'count', bins=10)
+        assert_raises(ValueError, binned_statistic, u, x, 'count', bins=10)
+        # needs to raise on non language int types too, e.g np.int
         # replace original value, u belongs the class
         u[0] = orig
-        assert_raises(ValueError, binned_statistic, u, x, 'count', bins=10)
 
     def test_1d_result_attributes(self):
         x = self.x

--- a/scipy/stats/tests/test_binned_statistic.py
+++ b/scipy/stats/tests/test_binned_statistic.py
@@ -61,7 +61,6 @@ class TestBinnedStatistic(object):
         assert_raises(ValueError, binned_statistic, u, x, 'std', bins=np.int64(10))
         u[0] = np.nan
         assert_raises(ValueError, binned_statistic, u, x, 'count', bins=10)
-        # needs to raise on non language int types too, e.g np.int
         # replace original value, u belongs the class
         u[0] = orig
 


### PR DESCRIPTION
#### Reference issue
Closes gh-11365

#### What does this implement/fix?
When I added an error throw in gh-10664 it wasn't the right fix and broke the the `lightkurve` package, see e.g.
https://github.com/KeplerGO/lightkurve/pull/661
and 
https://github.com/KeplerGO/lightkurve/issues/663

The proposal from @barentsen as a fix is confirmed here and the test for non-finite values is repurposed to check and raise a `ValueError` if the `bins` arg is `int` type and there are any non-finite `values`. 

#### Additional information
The error is raised in `binned_statistic_dd()` so it is straightforward to the user but the underlying issue is that `_bin_edges()` is ***not*** robust to a specified number of bins and ***any*** non-finite values. A follow up PR may want to provide a more permanent fix to `_bin_edges()`-if possible.