### PR TITLE
DOC: Fix rendering of rogerstanimoto math formula

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -1416,6 +1416,7 @@ def rogerstanimoto(u, v, w=None):
     `u` and `v`, is defined as
 
     .. math::
+    
        \\frac{R}
             {c_{TT} + c_{FF} + R}
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue

Math formula of `scipy.spatial.distance.rogerstanimoto` [does not render properly](https://scipy.github.io/devdocs/generated/scipy.spatial.distance.rogerstanimoto.html?highlight=tanimoto#scipy.spatial.distance.rogerstanimoto) in Sphinx because of a missing line break. 

#### What does this implement/fix?

Simply add a line break.
