### PR TITLE
ENH: Speed up truncnorm's ppf()and rvs() methods

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -7386,10 +7386,9 @@ class truncnorm_gen(rv_continuous):
             return _truncnorm_pdf_scalar(x, a.item(), b.item())
         it = np.nditer([x, a, b, None], [],
                     [['readonly'], ['readonly'], ['readonly'], ['writeonly','allocate']])
-        with it:
-            for (_x, _a, _b, _ld) in it:
-                _ld[...] = _truncnorm_pdf_scalar(_x, _a, _b)
-            return it.operands[3]
+        for (_x, _a, _b, _ld) in it:
+            _ld[...] = _truncnorm_pdf_scalar(_x, _a, _b)
+        return it.operands[3]
 
     def _logpdf(self, x, a, b):
         if np.isscalar(a) and np.isscalar(b):
@@ -7399,10 +7398,9 @@ class truncnorm_gen(rv_continuous):
             return _truncnorm_logpdf_scalar(x, a.item(), b.item())
         it = np.nditer([x, a, b, None], [],
                     [['readonly'], ['readonly'], ['readonly'], ['writeonly','allocate']])
-        with it:
-            for (_x, _a, _b, _ld) in it:
-                _ld[...] = _truncnorm_logpdf_scalar(_x, _a, _b)
-            return it.operands[3]
+        for (_x, _a, _b, _ld) in it:
+            _ld[...] = _truncnorm_logpdf_scalar(_x, _a, _b)
+        return it.operands[3]
 
     def _cdf(self, x, a, b):
         if np.isscalar(a) and np.isscalar(b):
@@ -7413,10 +7411,9 @@ class truncnorm_gen(rv_continuous):
         out = None
         it = np.nditer([x, a, b, out], [],
                        [['readonly'], ['readonly'], ['readonly'], ['writeonly', 'allocate']])
-        with it:
-            for (_x, _a, _b, _p) in it:
-                _p[...] = _truncnorm_cdf_scalar(_x, _a, _b)
-            return it.operands[3]
+        for (_x, _a, _b, _p) in it:
+            _p[...] = _truncnorm_cdf_scalar(_x, _a, _b)
+        return it.operands[3]
 
     def _logcdf(self, x, a, b):
         if np.isscalar(a) and np.isscalar(b):
@@ -7426,10 +7423,9 @@ class truncnorm_gen(rv_continuous):
             return _truncnorm_logcdf_scalar(x, a.item(), b.item())
         it = np.nditer([x, a, b, None], [],
                        [['readonly'], ['readonly'], ['readonly'], ['writeonly', 'allocate']])
-        with it:
-            for (_x, _a, _b, _p) in it:
-                _p[...] = _truncnorm_logcdf_scalar(_x, _a, _b)
-            return it.operands[3]
+        for (_x, _a, _b, _p) in it:
+            _p[...] = _truncnorm_logcdf_scalar(_x, _a, _b)
+        return it.operands[3]
 
     def _sf(self, x, a, b):
         if np.isscalar(a) and np.isscalar(b):
@@ -7440,10 +7436,9 @@ class truncnorm_gen(rv_continuous):
         out = None
         it = np.nditer([x, a, b, out], [],
                        [['readonly'], ['readonly'], ['readonly'], ['writeonly', 'allocate']])
-        with it:
-            for (_x, _a, _b, _p) in it:
-                _p[...] = _truncnorm_sf_scalar(_x, _a, _b)
-            return it.operands[3]
+        for (_x, _a, _b, _p) in it:
+            _p[...] = _truncnorm_sf_scalar(_x, _a, _b)
+        return it.operands[3]
 
     def _logsf(self, x, a, b):
         if np.isscalar(a) and np.isscalar(b):
@@ -7454,10 +7449,9 @@ class truncnorm_gen(rv_continuous):
         out = None
         it = np.nditer([x, a, b, out], [],
                        [['readonly'], ['readonly'], ['readonly'], ['writeonly', 'allocate']])
-        with it:
-            for (_x, _a, _b, _p) in it:
-                _p[...] = _truncnorm_logsf_scalar(_x, _a, _b)
-            return it.operands[3]
+        for (_x, _a, _b, _p) in it:
+            _p[...] = _truncnorm_logsf_scalar(_x, _a, _b)
+        return it.operands[3]
 
     def _ppf(self, q, a, b):
         if np.isscalar(a) and np.isscalar(b):
@@ -7469,10 +7463,9 @@ class truncnorm_gen(rv_continuous):
         out = None
         it = np.nditer([q, a, b, out], [],
                        [['readonly'], ['readonly'], ['readonly'], ['writeonly', 'allocate']])
-        with it:
-            for (_q, _a, _b, _x) in it:
-                _x[...] = _truncnorm_ppf_scalar(_q, _a, _b)
-            return it.operands[3]
+        for (_q, _a, _b, _x) in it:
+            _x[...] = _truncnorm_ppf_scalar(_q, _a, _b)
+        return it.operands[3]
 
     def _munp(self, n, a, b):
         def n_th_moment(n, a, b):

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -891,11 +891,13 @@ class rv_generic(object):
 
     def _support_mask(self, x, *args):
         a, b = self._get_support(*args)
-        return (a <= x) & (x <= b)
+        with np.errstate(invalid='ignore'):
+            return (a <= x) & (x <= b)
 
     def _open_support_mask(self, x, *args):
         a, b = self._get_support(*args)
-        return (a < x) & (x < b)
+        with np.errstate(invalid='ignore'):
+            return (a < x) & (x < b)
 
     def _rvs(self, *args):
         # This method must handle self._size being a tuple, and it must
@@ -2486,6 +2488,8 @@ class rv_continuous(rv_generic):
         `scipy.integrate.quad` can verify whether the integral exists or is
         finite. For example ``cauchy(0).mean()`` returns ``np.nan`` and
         ``cauchy(0).expect()`` returns ``0.0``.
+
+        The function is not vectorized.
 
         Examples
         --------

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -486,9 +486,7 @@ class TestTruncnorm(object):
     def test_gh_2477_large_values(self):
         # Check a case that used to fail because of extreme tailness.
         low, high = 100, 101
-        with np.errstate(divide='ignore'):
-            x = stats.truncnorm.rvs(low, high, 0, 1, size=10)
-        print(low, x.min(), x.max(), high)
+        x = stats.truncnorm.rvs(low, high, 0, 1, size=10)
         assert_(low <= x.min() <= x.max() <= high), str([low, high, x])
 
         # Check some additional extreme tails
@@ -497,6 +495,10 @@ class TestTruncnorm(object):
         assert_(low < x.min() < x.max() < high)
 
         low, high = 10000, 10001
+        x = stats.truncnorm.rvs(low, high, 0, 1, size=10)
+        assert_(low < x.min() < x.max() < high)
+
+        low, high = -10001, -10000
         x = stats.truncnorm.rvs(low, high, 0, 1, size=10)
         assert_(low < x.min() < x.max() < high)
 
@@ -582,21 +584,25 @@ class TestTruncnorm(object):
         # using both the _norm_XXX() and _norm_logXXX() functions, and by
         # removing the _stats and _munp methods in truncnorm tp force
         # numerical quadrature.
+        # For m,v,s,k expect k to have the largest error as it is
+        # constructed from powers of lower moments
+
         self._test_moments_one_range(-30, 30, [0, 1, 0.0, 0.0])
         self._test_moments_one_range(-10, 10, [0, 1, 0.0, 0.0])
-        self._test_moments_one_range(-3, 3, [0, 0.97333692, 0.0, -0.17111444])
-        self._test_moments_one_range(-2, 2, [0, 0.7737413, 0.0, -0.63446328])
+        self._test_moments_one_range(-3, 3, [0.0000000000000000, 0.9733369246625415, 0.0000000000000000, -0.1711144363977444])
+        self._test_moments_one_range(-2, 2, [0.0000000000000000, 0.7737413035499232, 0.0000000000000000, -0.6344632828703505])
 
-        self._test_moments_one_range(0, np.inf, [0.79788456, 0.36338023, 0.99527175, 0.8691773])
+        self._test_moments_one_range(0, np.inf, [0.7978845608028654, 0.3633802276324186, 0.9952717464311565, 0.8691773036059725])
+        self._test_moments_one_range(-np.inf, 0, [-0.7978845608028654, 0.3633802276324186, -0.9952717464311565, 0.8691773036059725])
 
-        self._test_moments_one_range(-1, 3, [0.2827861, 0.61614174, 0.53930185, -0.20582065])
-        self._test_moments_one_range(-3, 1, [-0.2827861, 0.61614174, -0.53930185, -0.20582065])
+        self._test_moments_one_range(-1, 3, [0.2827861107271540, 0.6161417353578292, 0.5393018494027878, -0.2058206513527461])
+        self._test_moments_one_range(-3, 1, [-0.2827861107271540, 0.6161417353578292, -0.5393018494027878, -0.2058206513527461])
 
-        self._test_moments_one_range(-10, -9, [-9.10845629, 0.01144881, -1.89856073, 5.07334611])
-        self._test_moments_one_range(-20, -19, [-19.05234395, 0.00272507, -1.9838686, 5.87208674])
-        self._test_moments_one_range(-30, -29, [-29.03440124, 0.00118066, -1.99297727, 5.9303358])
-        self._test_moments_one_range(-40, -39, [-39.02560741993262, 0.0006548, -1.99631464, 5.61677584])
-        self._test_moments_one_range(39, 40, [39.02560741993262, 0.0006548, 1.99631464, 5.61677584])
+        self._test_moments_one_range(-10, -9, [-9.1084562880124764, 0.0114488058210104, -1.8985607337519652, 5.0733457094223553])
+        self._test_moments_one_range(-20, -19, [-19.0523439459766628, 0.0027250730180314, -1.9838694022629291, 5.8717850028287586])
+        self._test_moments_one_range(-30, -29, [-29.0344012377394698, 0.0011806603928891, -1.9930304534611458, 5.8854062968996566])
+        self._test_moments_one_range(-40, -39, [-39.0256074199326264, 0.0006548826719649, -1.9963146354109957, 5.6167758371700494])
+        self._test_moments_one_range(39, 40, [39.0256074199326264, 0.0006548826719649, 1.9963146354109957, 5.6167758371700494])
 
     def test_9902_moments(self):
         m, v = stats.truncnorm.stats(0, np.inf, moments='mv')
@@ -609,6 +615,15 @@ class TestTruncnorm(object):
         x = stats.truncnorm.rvs(low, high, 0, 1, size=10)
         assert_(low < x.min() < x.max() < high)
 
+    def test_gh_11299_rvs(self):
+        # Arose from investigating gh-11299
+        # Test multiple shape parameters simultaneously.
+        low = [-10, 10, -np.inf, -5, -np.inf, -np.inf, -45, -45, 40, -10, 40]
+        high = [-5, 11, 5, np.inf, 40, -40, 40, -40, 45, np.inf, np.inf]
+        x = stats.truncnorm.rvs(low, high, size=(5, len(low)))
+        assert np.shape(x) == (5, len(low))
+        assert_(np.all(low <= x.min(axis=0)))
+        assert_(np.all(x.max(axis=0) <= high))
 
 class TestHypergeom(object):
     def setup_method(self):


### PR DESCRIPTION
#### Reference issue
Closes gh-11299

#### What does this implement/fix?
Addresses gh-11299.
Adds an `rvs()` method to `stats.truncnorm` modelled on `geninvgauss_gen.rvs()`.
Replaced `np.vectorize`'d `stats.truncnorm` functions with scalar only versions.
[Scalar refers to the shape parameters only --- the x or q values may be arrays.]
Any broadcasting is handling inside the distributions methods.
This enables generating many `ppf` values for the same`a, b` shape parameters
in a single call, thus making the `truncnorm` delta overhead calculation
just once.

The speed appears to have been restored
```
$ python -m timeit "from scipy.stats import truncnorm; truncnorm.rvs(-2, 2, size=(50, 50, 50))"
1 loop, best of 5: 6.05 msec per loop
```

[My environment: Scipy 1.5, Python 3.8, x86_64-apple-darwin13.4.0]

