### PR TITLE
MAINT: Remove self._size (and self._random_state) from stats distributions.

### DIFF
--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -738,8 +738,8 @@ def random(m, n, density=0.01, format='coo', dtype=None,
     >>> from scipy.sparse import random
     >>> from scipy.stats import rv_continuous
     >>> class CustomDistribution(rv_continuous):
-    ...     def _rvs(self, *args, **kwargs):
-    ...         return self._random_state.randn(*kwargs['size'])
+    ...     def _rvs(self,  size=1, random_state=None):
+    ...         return random_state.randn(size)
     >>> X = CustomDistribution(seed=2906)
     >>> Y = X()  # get a frozen version of the distribution
     >>> S = random(3, 4, density=0.25, random_state=2906, data_rvs=Y.rvs)

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -739,7 +739,7 @@ def random(m, n, density=0.01, format='coo', dtype=None,
     >>> from scipy.stats import rv_continuous
     >>> class CustomDistribution(rv_continuous):
     ...     def _rvs(self, *args, **kwargs):
-    ...         return self._random_state.randn(*self._size)
+    ...         return self._random_state.randn(*kwargs['size'])
     >>> X = CustomDistribution(seed=2906)
     >>> Y = X()  # get a frozen version of the distribution
     >>> S = random(3, 4, density=0.25, random_state=2906, data_rvs=Y.rvs)

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -739,7 +739,7 @@ def random(m, n, density=0.01, format='coo', dtype=None,
     >>> from scipy.stats import rv_continuous
     >>> class CustomDistribution(rv_continuous):
     ...     def _rvs(self,  size=1, random_state=None):
-    ...         return random_state.randn(size)
+    ...         return random_state.randn(*size)
     >>> X = CustomDistribution(seed=2906)
     >>> Y = X()  # get a frozen version of the distribution
     >>> S = random(3, 4, density=0.25, random_state=2906, data_rvs=Y.rvs)

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -738,7 +738,7 @@ def random(m, n, density=0.01, format='coo', dtype=None,
     >>> from scipy.sparse import random
     >>> from scipy.stats import rv_continuous
     >>> class CustomDistribution(rv_continuous):
-    ...     def _rvs(self,  size=1, random_state=None):
+    ...     def _rvs(self,  size=None, random_state=None):
     ...         return random_state.randn(*size)
     >>> X = CustomDistribution(seed=2906)
     >>> Y = X()  # get a frozen version of the distribution

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -293,7 +293,7 @@ class norm_gen(rv_continuous):
     %(example)s
 
     """
-    def _rvs(self, size=1, random_state=None):
+    def _rvs(self, size=None, random_state=None):
         return random_state.standard_normal(size)
 
     def _pdf(self, x):
@@ -583,7 +583,7 @@ class beta_gen(rv_continuous):
     %(example)s
 
     """
-    def _rvs(self, a, b, size=1, random_state=None):
+    def _rvs(self, a, b, size=None, random_state=None):
         return random_state.beta(a, b, size)
 
     def _pdf(self, x, a, b):
@@ -759,7 +759,7 @@ class betaprime_gen(rv_continuous):
     """
     _support_mask = rv_continuous._open_support_mask
 
-    def _rvs(self, a, b, size=1, random_state=None):
+    def _rvs(self, a, b, size=None, random_state=None):
         u1 = gamma.rvs(a, size=size, random_state=random_state)
         u2 = gamma.rvs(b, size=size, random_state=random_state)
         return u1 / u2
@@ -1198,7 +1198,7 @@ class chi_gen(rv_continuous):
 
     """
 
-    def _rvs(self, df, size=1, random_state=None):
+    def _rvs(self, df, size=None, random_state=None):
         return np.sqrt(chi2.rvs(df, size=size, random_state=random_state))
 
     def _pdf(self, x, df):
@@ -1254,7 +1254,7 @@ class chi2_gen(rv_continuous):
     %(example)s
 
     """
-    def _rvs(self, df, size=1, random_state=None):
+    def _rvs(self, df, size=None, random_state=None):
         return random_state.chisquare(df, size)
 
     def _pdf(self, x, df):
@@ -1348,7 +1348,7 @@ class dgamma_gen(rv_continuous):
     %(example)s
 
     """
-    def _rvs(self, a, size=1, random_state=None):
+    def _rvs(self, a, size=None, random_state=None):
         u = random_state.uniform(size=size)
         gm = gamma.rvs(a, size=size, random_state=random_state)
         return gm * np.where(u >= 0.5, 1, -1)
@@ -1404,7 +1404,7 @@ class dweibull_gen(rv_continuous):
     %(example)s
 
     """
-    def _rvs(self, c, size=1, random_state=None):
+    def _rvs(self, c, size=None, random_state=None):
         u = random_state.uniform(size=size)
         w = weibull_min.rvs(c, size=size, random_state=random_state)
         return w * (np.where(u >= 0.5, 1, -1))
@@ -1466,7 +1466,7 @@ class expon_gen(rv_continuous):
     %(example)s
 
     """
-    def _rvs(self, size=1, random_state=None):
+    def _rvs(self, size=None, random_state=None):
         return random_state.standard_exponential(size)
 
     def _pdf(self, x):
@@ -1583,7 +1583,7 @@ class exponnorm_gen(rv_continuous):
     %(example)s
 
     """
-    def _rvs(self, K, size=1, random_state=None):
+    def _rvs(self, K, size=None, random_state=None):
         expval = random_state.standard_exponential(size) * K
         gval = random_state.standard_normal(size)
         return expval + gval
@@ -1770,7 +1770,7 @@ class fatiguelife_gen(rv_continuous):
     """
     _support_mask = rv_continuous._open_support_mask
 
-    def _rvs(self, c, size=1, random_state=None):
+    def _rvs(self, c, size=None, random_state=None):
         z = random_state.standard_normal(size)
         x = 0.5*c*z
         x2 = x*x
@@ -1831,7 +1831,7 @@ class foldcauchy_gen(rv_continuous):
     %(example)s
 
     """
-    def _rvs(self, c, size=1, random_state=None):
+    def _rvs(self, c, size=None, random_state=None):
         return abs(cauchy.rvs(loc=c, size=size,
                               random_state=random_state))
 
@@ -1873,7 +1873,7 @@ class f_gen(rv_continuous):
     %(example)s
 
     """
-    def _rvs(self, dfn, dfd, size=1, random_state=None):
+    def _rvs(self, dfn, dfd, size=None, random_state=None):
         return random_state.f(dfn, dfd, size)
 
     def _pdf(self, x, dfn, dfd):
@@ -1965,7 +1965,7 @@ class foldnorm_gen(rv_continuous):
     def _argcheck(self, c):
         return c >= 0
 
-    def _rvs(self, c, size=1, random_state=None):
+    def _rvs(self, c, size=None, random_state=None):
         return abs(random_state.standard_normal(size) + c)
 
     def _pdf(self, x, c):
@@ -2812,7 +2812,7 @@ class gamma_gen(rv_continuous):
     %(example)s
 
     """
-    def _rvs(self, a, size=1, random_state=None):
+    def _rvs(self, a, size=None, random_state=None):
         return random_state.standard_gamma(a, size)
 
     def _pdf(self, x, a):
@@ -3381,7 +3381,7 @@ class halfnorm_gen(rv_continuous):
     %(example)s
 
     """
-    def _rvs(self, size=1, random_state=None):
+    def _rvs(self, size=None, random_state=None):
         return abs(random_state.standard_normal(size=size))
 
     def _pdf(self, x):
@@ -3594,7 +3594,7 @@ class invgauss_gen(rv_continuous):
     """
     _support_mask = rv_continuous._open_support_mask
 
-    def _rvs(self, mu, size=1, random_state=None):
+    def _rvs(self, mu, size=None, random_state=None):
         return random_state.wald(mu, 1.0, size=size)
 
     def _pdf(self, x, mu):
@@ -3697,7 +3697,7 @@ class geninvgauss_gen(rv_continuous):
                           lambda x, p, b: (p - 1)*np.log(x) - b*(x + 1/x)/2,
                           -np.inf)
 
-    def _rvs(self, p, b, size=1, random_state=None):
+    def _rvs(self, p, b, size=None, random_state=None):
         # if p and b are scalar, use _rvs_scalar, otherwise need to create
         # output by iterating over parameters
         if np.isscalar(p) and np.isscalar(b):
@@ -3978,7 +3978,7 @@ class norminvgauss_gen(rv_continuous):
         sq = np.hypot(1, x)  # reduce overflows
         return fac1 * sc.k1e(a * sq) * np.exp(b*x - a*sq) / sq
 
-    def _rvs(self, a, b, size=1, random_state=None):
+    def _rvs(self, a, b, size=None, random_state=None):
         # note: X = b * V + sqrt(V) * X is norminvgaus(a,b) if X is standard
         # normal and V is invgauss(mu=1/sqrt(a**2 - b**2))
         gamma = np.sqrt(a**2 - b**2)
@@ -4167,7 +4167,7 @@ class laplace_gen(rv_continuous):
     %(example)s
 
     """
-    def _rvs(self, size=1, random_state=None):
+    def _rvs(self, size=None, random_state=None):
         return random_state.laplace(0, 1, size=size)
 
     def _pdf(self, x):
@@ -4370,7 +4370,7 @@ class levy_stable_gen(rv_continuous):
 
     """
 
-    def _rvs(self, alpha, beta, size=1, random_state=None):
+    def _rvs(self, alpha, beta, size=None, random_state=None):
 
         def alpha1func(alpha, beta, TH, aTH, bTH, cosTH, tanTH, W):
             return (2/np.pi*(np.pi/2 + bTH)*tanTH -
@@ -4787,7 +4787,7 @@ class logistic_gen(rv_continuous):
     %(example)s
 
     """
-    def _rvs(self, size=1, random_state=None):
+    def _rvs(self, size=None, random_state=None):
         return random_state.logistic(size=size)
 
     def _pdf(self, x):
@@ -4844,7 +4844,7 @@ class loggamma_gen(rv_continuous):
     %(example)s
 
     """
-    def _rvs(self, c, size=1, random_state=None):
+    def _rvs(self, c, size=None, random_state=None):
         return np.log(random_state.gamma(c, size=size))
 
     def _pdf(self, x, c):
@@ -4959,7 +4959,7 @@ class lognorm_gen(rv_continuous):
     """
     _support_mask = rv_continuous._open_support_mask
 
-    def _rvs(self, s, size=1, random_state=None):
+    def _rvs(self, s, size=None, random_state=None):
         return np.exp(s * random_state.standard_normal(size))
 
     def _pdf(self, x, s):
@@ -5087,7 +5087,7 @@ class gilbrat_gen(rv_continuous):
     """
     _support_mask = rv_continuous._open_support_mask
 
-    def _rvs(self, size=1, random_state=None):
+    def _rvs(self, size=None, random_state=None):
         return np.exp(random_state.standard_normal(size))
 
     def _pdf(self, x):
@@ -5145,7 +5145,7 @@ class maxwell_gen(rv_continuous):
 
     %(example)s
     """
-    def _rvs(self, size=1, random_state=None):
+    def _rvs(self, size=None, random_state=None):
         return chi.rvs(3.0, size=size, random_state=random_state)
 
     def _pdf(self, x):
@@ -5585,7 +5585,7 @@ class moyal_gen(rv_continuous):
     %(example)s
 
     """
-    def _rvs(self, size=1, random_state=None):
+    def _rvs(self, size=None, random_state=None):
         u1 = gamma.rvs(a = 0.5, scale = 2, size=size, random_state=random_state)
         return -np.log(u1)
 
@@ -5708,7 +5708,7 @@ class ncx2_gen(rv_continuous):
     def _argcheck(self, df, nc):
         return (df > 0) & (nc >= 0)
 
-    def _rvs(self, df, nc, size=1, random_state=None):
+    def _rvs(self, df, nc, size=None, random_state=None):
         return random_state.noncentral_chisquare(df, nc, size)
 
     def _logpdf(self, x, df, nc):
@@ -5784,7 +5784,7 @@ class ncf_gen(rv_continuous):
     def _argcheck(self, df1, df2, nc):
         return (df1 > 0) & (df2 > 0) & (nc >= 0)
 
-    def _rvs(self, dfn, dfd, nc, size=1, random_state=None):
+    def _rvs(self, dfn, dfd, nc, size=None, random_state=None):
         return random_state.noncentral_f(dfn, dfd, nc, size)
 
     def _pdf_skip(self, x, dfn, dfd, nc):
@@ -5866,7 +5866,7 @@ class t_gen(rv_continuous):
     def _argcheck(self, df):
         return df > 0
 
-    def _rvs(self, df, size=1, random_state=None):
+    def _rvs(self, df, size=None, random_state=None):
         return random_state.standard_t(df, size=size)
 
     def _pdf(self, x, df):
@@ -5941,7 +5941,7 @@ class nct_gen(rv_continuous):
     def _argcheck(self, df, nc):
         return (df > 0) & (nc == nc)
 
-    def _rvs(self, df, nc, size=1, random_state=None):
+    def _rvs(self, df, nc, size=None, random_state=None):
         n = norm.rvs(loc=nc, size=size, random_state=random_state)
         c2 = chi2.rvs(df, size=size, random_state=random_state)
         return n * np.sqrt(df) / np.sqrt(c2)
@@ -6250,7 +6250,7 @@ class pearson3_gen(rv_continuous):
         ans[invmask] = gamma._cdf(transx, alpha)
         return ans
 
-    def _rvs(self, skew, size=1, random_state=None):
+    def _rvs(self, skew, size=None, random_state=None):
         skew = np.broadcast_to(skew, size)
         ans, _, _, mask, invmask, beta, alpha, zeta = (
             self._preprocess([0], skew))
@@ -6457,7 +6457,7 @@ class rdist_gen(rv_continuous):
     def _ppf(self, q, c):
         return 2*beta._ppf(q, c/2, c/2) - 1
 
-    def _rvs(self, c, size=1, random_state=None):
+    def _rvs(self, c, size=None, random_state=None):
         return 2 * random_state.beta(c/2, c/2, size) - 1
 
     def _munp(self, n, c):
@@ -6492,7 +6492,7 @@ class rayleigh_gen(rv_continuous):
     """
     _support_mask = rv_continuous._open_support_mask
 
-    def _rvs(self, size=1, random_state=None):
+    def _rvs(self, size=None, random_state=None):
         return chi.rvs(2, size=size, random_state=random_state)
 
     def _pdf(self, r):
@@ -6642,7 +6642,7 @@ class rice_gen(rv_continuous):
     def _argcheck(self, b):
         return b >= 0
 
-    def _rvs(self, b, size=1, random_state=None):
+    def _rvs(self, b, size=None, random_state=None):
         # https://en.wikipedia.org/wiki/Rice_distribution
         t = b/np.sqrt(2) + random_state.standard_normal(size=(2,) + size)
         return np.sqrt((t*t).sum(axis=0))
@@ -6712,7 +6712,7 @@ class recipinvgauss_gen(rv_continuous):
         isqx = 1.0/np.sqrt(x)
         return 1.0-_norm_cdf(isqx*trm1)-np.exp(2.0/mu)*_norm_cdf(-isqx*trm2)
 
-    def _rvs(self, mu, size=1, random_state=None):
+    def _rvs(self, mu, size=None, random_state=None):
         return 1.0/random_state.wald(mu, 1.0, size=size)
 
 
@@ -6762,7 +6762,7 @@ class semicircular_gen(rv_continuous):
     def _ppf(self, q):
         return rdist._ppf(q, 3)
 
-    def _rvs(self, size=1, random_state=None):
+    def _rvs(self, size=None, random_state=None):
         # generate values uniformly distributed on the area under the pdf
         # (semi-circle) by randomly generating the radius and angle
         r = np.sqrt(random_state.uniform(size=size))
@@ -6827,7 +6827,7 @@ class skew_norm_gen(rv_continuous):
     def _sf(self, x, a):
         return self._cdf(-x, -a)
 
-    def _rvs(self, a, size=1, random_state=None):
+    def _rvs(self, a, size=None, random_state=None):
         u0 = random_state.normal(size=size)
         v = random_state.normal(size=size)
         d = a/np.sqrt(1 + a**2)
@@ -6979,7 +6979,7 @@ class triang_gen(rv_continuous):
     %(example)s
 
     """
-    def _rvs(self, c, size=1, random_state=None):
+    def _rvs(self, c, size=None, random_state=None):
         return random_state.triangular(0, c, 1, size)
 
     def _argcheck(self, c):
@@ -7582,7 +7582,7 @@ class truncnorm_gen(rv_continuous):
         g2 = mu4 / mu2**2 - 3
         return mu, mu2, g1, g2
 
-    def _rvs(self, a, b, size=1, random_state=None):
+    def _rvs(self, a, b, size=None, random_state=None):
         # if a and b are scalar, use _rvs_scalar, otherwise need to create
         # output by iterating over parameters
         if np.isscalar(a) and np.isscalar(b):
@@ -7726,7 +7726,7 @@ class uniform_gen(rv_continuous):
     %(example)s
 
     """
-    def _rvs(self, size=1, random_state=None):
+    def _rvs(self, size=None, random_state=None):
         return random_state.uniform(0.0, 1.0, size)
 
     def _pdf(self, x):
@@ -7926,7 +7926,7 @@ class vonmises_gen(rv_continuous):
     %(example)s
 
     """
-    def _rvs(self, kappa, size=1, random_state=None):
+    def _rvs(self, kappa, size=None, random_state=None):
         return random_state.vonmises(0.0, kappa, size=size)
 
     def _pdf(self, x, kappa):
@@ -7971,7 +7971,7 @@ class wald_gen(invgauss_gen):
     """
     _support_mask = rv_continuous._open_support_mask
 
-    def _rvs(self, size=1, random_state=None):
+    def _rvs(self, size=None, random_state=None):
         return random_state.wald(1.0, 1.0, size=size)
 
     def _pdf(self, x):
@@ -8390,7 +8390,7 @@ class argus_gen(rv_continuous):
     def _sf(self, x, chi):
         return _argus_phi(chi * np.sqrt(1 - x**2)) / _argus_phi(chi)
 
-    def _rvs(self, chi, size=1, random_state=None):
+    def _rvs(self, chi, size=None, random_state=None):
         chi = np.asarray(chi)
         if chi.size == 1:
             out = self._rvs_scalar(chi, numsamples=size,

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -36,7 +36,6 @@ try:
 except AttributeError:
     float_power = np.power
 
-
 def _remove_optimizer_parameters(kwds):
     """
     Remove the optimizer-related keyword arguments 'loc', 'scale' and
@@ -293,8 +292,8 @@ class norm_gen(rv_continuous):
     %(example)s
 
     """
-    def _rvs(self):
-        return self._random_state.standard_normal(self._size)
+    def _rvs(self, size=1, random_state=None):
+        return random_state.standard_normal(size)
 
     def _pdf(self, x):
         # norm.pdf(x) = exp(-x**2/2)/sqrt(2*pi)
@@ -583,8 +582,8 @@ class beta_gen(rv_continuous):
     %(example)s
 
     """
-    def _rvs(self, a, b):
-        return self._random_state.beta(a, b, self._size)
+    def _rvs(self, a, b, size=1, random_state=None):
+        return random_state.beta(a, b, size)
 
     def _pdf(self, x, a, b):
         #                     gamma(a+b) * x**(a-1) * (1-x)**(b-1)
@@ -759,10 +758,9 @@ class betaprime_gen(rv_continuous):
     """
     _support_mask = rv_continuous._open_support_mask
 
-    def _rvs(self, a, b):
-        sz, rndm = self._size, self._random_state
-        u1 = gamma.rvs(a, size=sz, random_state=rndm)
-        u2 = gamma.rvs(b, size=sz, random_state=rndm)
+    def _rvs(self, a, b, size=1, random_state=None):
+        u1 = gamma.rvs(a, size=size, random_state=random_state)
+        u2 = gamma.rvs(b, size=size, random_state=random_state)
         return u1 / u2
 
     def _pdf(self, x, a, b):
@@ -1199,9 +1197,8 @@ class chi_gen(rv_continuous):
 
     """
 
-    def _rvs(self, df):
-        sz, rndm = self._size, self._random_state
-        return np.sqrt(chi2.rvs(df, size=sz, random_state=rndm))
+    def _rvs(self, df, size=1, random_state=None):
+        return np.sqrt(chi2.rvs(df, size=size, random_state=random_state))
 
     def _pdf(self, x, df):
         #                   x**(df-1) * exp(-x**2/2)
@@ -1256,8 +1253,8 @@ class chi2_gen(rv_continuous):
     %(example)s
 
     """
-    def _rvs(self, df):
-        return self._random_state.chisquare(df, self._size)
+    def _rvs(self, df, size=1, random_state=None):
+        return random_state.chisquare(df, size)
 
     def _pdf(self, x, df):
         # chi2.pdf(x, df) = 1 / (2*gamma(df/2)) * (x/2)**(df/2-1) * exp(-x/2)
@@ -1350,10 +1347,9 @@ class dgamma_gen(rv_continuous):
     %(example)s
 
     """
-    def _rvs(self, a):
-        sz, rndm = self._size, self._random_state
-        u = rndm.uniform(size=sz)
-        gm = gamma.rvs(a, size=sz, random_state=rndm)
+    def _rvs(self, a, size=1, random_state=None):
+        u = random_state.uniform(size=size)
+        gm = gamma.rvs(a, size=size, random_state=random_state)
         return gm * np.where(u >= 0.5, 1, -1)
 
     def _pdf(self, x, a):
@@ -1407,10 +1403,9 @@ class dweibull_gen(rv_continuous):
     %(example)s
 
     """
-    def _rvs(self, c):
-        sz, rndm = self._size, self._random_state
-        u = rndm.uniform(size=sz)
-        w = weibull_min.rvs(c, size=sz, random_state=rndm)
+    def _rvs(self, c, size=1, random_state=None):
+        u = random_state.uniform(size=size)
+        w = weibull_min.rvs(c, size=size, random_state=random_state)
         return w * (np.where(u >= 0.5, 1, -1))
 
     def _pdf(self, x, c):
@@ -1470,8 +1465,8 @@ class expon_gen(rv_continuous):
     %(example)s
 
     """
-    def _rvs(self):
-        return self._random_state.standard_exponential(self._size)
+    def _rvs(self, size=1, random_state=None):
+        return random_state.standard_exponential(size)
 
     def _pdf(self, x):
         # expon.pdf(x) = exp(-x)
@@ -1587,9 +1582,9 @@ class exponnorm_gen(rv_continuous):
     %(example)s
 
     """
-    def _rvs(self, K):
-        expval = self._random_state.standard_exponential(self._size) * K
-        gval = self._random_state.standard_normal(self._size)
+    def _rvs(self, K, size=1, random_state=None):
+        expval = random_state.standard_exponential(size) * K
+        gval = random_state.standard_normal(size)
         return expval + gval
 
     def _pdf(self, x, K):
@@ -1774,8 +1769,8 @@ class fatiguelife_gen(rv_continuous):
     """
     _support_mask = rv_continuous._open_support_mask
 
-    def _rvs(self, c):
-        z = self._random_state.standard_normal(self._size)
+    def _rvs(self, c, size=1, random_state=None):
+        z = random_state.standard_normal(size)
         x = 0.5*c*z
         x2 = x*x
         t = 1.0 + 2*x2 + 2*x*np.sqrt(1 + x2)
@@ -1835,9 +1830,9 @@ class foldcauchy_gen(rv_continuous):
     %(example)s
 
     """
-    def _rvs(self, c):
-        return abs(cauchy.rvs(loc=c, size=self._size,
-                              random_state=self._random_state))
+    def _rvs(self, c, size=1, random_state=None):
+        return abs(cauchy.rvs(loc=c, size=size,
+                              random_state=random_state))
 
     def _pdf(self, x, c):
         # foldcauchy.pdf(x, c) = 1/(pi*(1+(x-c)**2)) + 1/(pi*(1+(x+c)**2))
@@ -1877,8 +1872,8 @@ class f_gen(rv_continuous):
     %(example)s
 
     """
-    def _rvs(self, dfn, dfd):
-        return self._random_state.f(dfn, dfd, self._size)
+    def _rvs(self, dfn, dfd, size=1, random_state=None):
+        return random_state.f(dfn, dfd, size)
 
     def _pdf(self, x, dfn, dfd):
         #                      df2**(df2/2) * df1**(df1/2) * x**(df1/2-1)
@@ -1969,8 +1964,8 @@ class foldnorm_gen(rv_continuous):
     def _argcheck(self, c):
         return c >= 0
 
-    def _rvs(self, c):
-        return abs(self._random_state.standard_normal(self._size) + c)
+    def _rvs(self, c, size=1, random_state=None):
+        return abs(random_state.standard_normal(size) + c)
 
     def _pdf(self, x, c):
         # foldnormal.pdf(x, c) = sqrt(2/pi) * cosh(c*x) * exp(-(x**2+c**2)/2)
@@ -2816,8 +2811,8 @@ class gamma_gen(rv_continuous):
     %(example)s
 
     """
-    def _rvs(self, a):
-        return self._random_state.standard_gamma(a, self._size)
+    def _rvs(self, a, size=1, random_state=None):
+        return random_state.standard_gamma(a, size)
 
     def _pdf(self, x, a):
         # gamma.pdf(x, a) = x**(a-1) * exp(-x) / gamma(a)
@@ -3385,8 +3380,8 @@ class halfnorm_gen(rv_continuous):
     %(example)s
 
     """
-    def _rvs(self):
-        return abs(self._random_state.standard_normal(size=self._size))
+    def _rvs(self, size=1, random_state=None):
+        return abs(random_state.standard_normal(size=size))
 
     def _pdf(self, x):
         # halfnorm.pdf(x) = sqrt(2/pi) * exp(-x**2/2)
@@ -3598,8 +3593,8 @@ class invgauss_gen(rv_continuous):
     """
     _support_mask = rv_continuous._open_support_mask
 
-    def _rvs(self, mu):
-        return self._random_state.wald(mu, 1.0, size=self._size)
+    def _rvs(self, mu, size=1, random_state=None):
+        return random_state.wald(mu, 1.0, size=size)
 
     def _pdf(self, x, mu):
         # invgauss.pdf(x, mu) =
@@ -3701,17 +3696,17 @@ class geninvgauss_gen(rv_continuous):
                           lambda x, p, b: (p - 1)*np.log(x) - b*(x + 1/x)/2,
                           -np.inf)
 
-    def _rvs(self, p, b):
+    def _rvs(self, p, b, size=1, random_state=None):
         # if p and b are scalar, use _rvs_scalar, otherwise need to create
         # output by iterating over parameters
         if np.isscalar(p) and np.isscalar(b):
-            out = self._rvs_scalar(p, b, self._size)
+            out = self._rvs_scalar(p, b, size, random_state)
         elif p.size == 1 and b.size == 1:
-            out = self._rvs_scalar(p.item(), b.item(), self._size)
+            out = self._rvs_scalar(p.item(), b.item(), size, random_state)
         else:
-            # When this method is called, self._size will be a (possibly empty)
+            # When this method is called, size will be a (possibly empty)
             # tuple of integers.  It will not be None; if `size=None` is passed
-            # to `rvs()`, self._size will be the empty tuple ().
+            # to `rvs()`, size will be the empty tuple ().
 
             p, b = np.broadcast_arrays(p, b)
             # p and b now have the same shape.
@@ -3719,11 +3714,11 @@ class geninvgauss_gen(rv_continuous):
             # `shp` is the shape of the blocks of random variates that are
             # generated for each combination of parameters associated with
             # broadcasting p and b.
-            # bc is a tuple the same lenth as self._size.  The values
+            # bc is a tuple the same lenth as size.  The values
             # in bc are bools.  If bc[j] is True, it means that
             # entire axis is filled in for a given combination of the
             # broadcast arguments.
-            shp, bc = _check_shape(p.shape, self._size)
+            shp, bc = _check_shape(p.shape, size)
 
             # `numsamples` is the total number of variates to be generated
             # for each combination of the input arguments.
@@ -3731,7 +3726,7 @@ class geninvgauss_gen(rv_continuous):
 
             # `out` is the array to be returned.  It is filled in in the
             # loop below.
-            out = np.empty(self._size)
+            out = np.empty(size)
 
             it = np.nditer([p, b],
                            flags=['multi_index'],
@@ -3743,20 +3738,19 @@ class geninvgauss_gen(rv_continuous):
                 # index value from it.multi_index.  len(it.multi_index) might
                 # be less than len(bc), and in that case we want to align these
                 # two sequences to the right, so the loop variable j runs from
-                # -len(self._size) to 0.  This doesn't cause an IndexError, as
+                # -len(size) to 0.  This doesn't cause an IndexError, as
                 # bc[j] will be True in those cases where it.multi_index[j]
                 # would cause an IndexError.
                 idx = tuple((it.multi_index[j] if not bc[j] else slice(None))
-                            for j in range(-len(self._size), 0))
-                out[idx] = self._rvs_scalar(it[0], it[1],
-                                            numsamples).reshape(shp)
+                            for j in range(-len(size), 0))
+                out[idx] = self._rvs_scalar(it[0], it[1], numsamples, random_state).reshape(shp)
                 it.iternext()
 
-        if self._size == ():
+        if size == ():
             out = out[()]
         return out
 
-    def _rvs_scalar(self, p, b, numsamples=None):
+    def _rvs_scalar(self, p, b, numsamples, random_state):
         # following [2], the quasi-pdf is used instead of the pdf for the
         # generation of rvs
         invert_res = False
@@ -3835,8 +3829,8 @@ class geninvgauss_gen(rv_continuous):
             while simulated < N:
                 k = N - simulated
                 # simulate uniform rvs on [0, umax] and [vmin, vmax]
-                u = umax * self._random_state.uniform(size=k)
-                v = self._random_state.uniform(size=k)
+                u = umax * random_state.uniform(size=k)
+                v = random_state.uniform(size=k)
                 v = vmin + (vmax - vmin) * v
                 rvs = v / u + c
                 # rewrite acceptance condition u**2 <= pdf(rvs) by taking logs
@@ -3875,8 +3869,8 @@ class geninvgauss_gen(rv_continuous):
                 k = N - simulated
                 h, rvs = np.zeros(k), np.zeros(k)
                 # simulate uniform rvs on [x1, x2] and [0, y2]
-                u = self._random_state.uniform(size=k)
-                v = A * self._random_state.uniform(size=k)
+                u = random_state.uniform(size=k)
+                v = A * random_state.uniform(size=k)
                 cond1 = v <= A1
                 cond2 = np.logical_not(cond1) & (v <= A1 + A2)
                 cond3 = np.logical_not(cond1 | cond2)
@@ -3903,9 +3897,6 @@ class geninvgauss_gen(rv_continuous):
         rvs = np.reshape(x, size1d)
         if invert_res:
             rvs = 1 / rvs
-        if self._size == ():
-            # return scalar in that case; however, return array if size == 1
-            return rvs[0]
         return rvs
 
     def _mode(self, p, b):
@@ -3986,13 +3977,12 @@ class norminvgauss_gen(rv_continuous):
         sq = np.hypot(1, x)  # reduce overflows
         return fac1 * sc.k1e(a * sq) * np.exp(b*x - a*sq) / sq
 
-    def _rvs(self, a, b):
+    def _rvs(self, a, b, size=1, random_state=None):
         # note: X = b * V + sqrt(V) * X is norminvgaus(a,b) if X is standard
         # normal and V is invgauss(mu=1/sqrt(a**2 - b**2))
         gamma = np.sqrt(a**2 - b**2)
-        sz, rndm = self._size, self._random_state
-        ig = invgauss.rvs(mu=1/gamma, size=sz, random_state=rndm)
-        return b * ig + np.sqrt(ig) * norm.rvs(size=sz, random_state=rndm)
+        ig = invgauss.rvs(mu=1/gamma, size=size, random_state=random_state)
+        return b * ig + np.sqrt(ig) * norm.rvs(size=size, random_state=random_state)
 
     def _stats(self, a, b):
         gamma = np.sqrt(a**2 - b**2)
@@ -4176,8 +4166,8 @@ class laplace_gen(rv_continuous):
     %(example)s
 
     """
-    def _rvs(self):
-        return self._random_state.laplace(0, 1, size=self._size)
+    def _rvs(self, size=1, random_state=None):
+        return random_state.laplace(0, 1, size=size)
 
     def _pdf(self, x):
         # laplace.pdf(x) = 1/2 * exp(-abs(x))
@@ -4379,7 +4369,7 @@ class levy_stable_gen(rv_continuous):
 
     """
 
-    def _rvs(self, alpha, beta):
+    def _rvs(self, alpha, beta, size=1, random_state=None):
 
         def alpha1func(alpha, beta, TH, aTH, bTH, cosTH, tanTH, W):
             return (2/np.pi*(np.pi/2 + bTH)*tanTH -
@@ -4404,12 +4394,11 @@ class levy_stable_gen(rv_continuous):
                              beta0func, f2=otherwise)
             return res
 
-        sz = self._size
-        alpha = np.broadcast_to(alpha, sz)
-        beta = np.broadcast_to(beta, sz)
-        TH = uniform.rvs(loc=-np.pi/2.0, scale=np.pi, size=sz,
-                         random_state=self._random_state)
-        W = expon.rvs(size=sz, random_state=self._random_state)
+        alpha = np.broadcast_to(alpha, size)
+        beta = np.broadcast_to(beta, size)
+        TH = uniform.rvs(loc=-np.pi/2.0, scale=np.pi, size=size,
+                         random_state=random_state)
+        W = expon.rvs(size=size, random_state=random_state)
         aTH = alpha*TH
         bTH = beta*TH
         cosTH = np.cos(TH)
@@ -4797,8 +4786,8 @@ class logistic_gen(rv_continuous):
     %(example)s
 
     """
-    def _rvs(self):
-        return self._random_state.logistic(size=self._size)
+    def _rvs(self, size=1, random_state=None):
+        return random_state.logistic(size=size)
 
     def _pdf(self, x):
         # logistic.pdf(x) = exp(-x) / (1+exp(-x))**2
@@ -4854,8 +4843,8 @@ class loggamma_gen(rv_continuous):
     %(example)s
 
     """
-    def _rvs(self, c):
-        return np.log(self._random_state.gamma(c, size=self._size))
+    def _rvs(self, c, size=1, random_state=None):
+        return np.log(random_state.gamma(c, size=size))
 
     def _pdf(self, x, c):
         # loggamma.pdf(x, c) = exp(c*x-exp(x)) / gamma(c)
@@ -4969,8 +4958,8 @@ class lognorm_gen(rv_continuous):
     """
     _support_mask = rv_continuous._open_support_mask
 
-    def _rvs(self, s):
-        return np.exp(s * self._random_state.standard_normal(self._size))
+    def _rvs(self, s, size=1, random_state=None):
+        return np.exp(s * random_state.standard_normal(size))
 
     def _pdf(self, x, s):
         # lognorm.pdf(x, s) = 1 / (s*x*sqrt(2*pi)) * exp(-1/2*(log(x)/s)**2)
@@ -5097,8 +5086,8 @@ class gilbrat_gen(rv_continuous):
     """
     _support_mask = rv_continuous._open_support_mask
 
-    def _rvs(self):
-        return np.exp(self._random_state.standard_normal(self._size))
+    def _rvs(self, size=1, random_state=None):
+        return np.exp(random_state.standard_normal(size))
 
     def _pdf(self, x):
         # gilbrat.pdf(x) = 1/(x*sqrt(2*pi)) * exp(-1/2*(log(x))**2)
@@ -5155,8 +5144,8 @@ class maxwell_gen(rv_continuous):
 
     %(example)s
     """
-    def _rvs(self):
-        return chi.rvs(3.0, size=self._size, random_state=self._random_state)
+    def _rvs(self, size=1, random_state=None):
+        return chi.rvs(3.0, size=size, random_state=random_state)
 
     def _pdf(self, x):
         # maxwell.pdf(x) = sqrt(2/pi)x**2 * exp(-x**2/2)
@@ -5595,9 +5584,8 @@ class moyal_gen(rv_continuous):
     %(example)s
 
     """
-    def _rvs(self):
-        sz, rndm = self._size, self._random_state
-        u1 = gamma.rvs(a = 0.5, scale = 2, size=sz, random_state=rndm)
+    def _rvs(self, size=1, random_state=None):
+        u1 = gamma.rvs(a = 0.5, scale = 2, size=size, random_state=random_state)
         return -np.log(u1)
 
     def _pdf(self, x):
@@ -5719,8 +5707,8 @@ class ncx2_gen(rv_continuous):
     def _argcheck(self, df, nc):
         return (df > 0) & (nc >= 0)
 
-    def _rvs(self, df, nc):
-        return self._random_state.noncentral_chisquare(df, nc, self._size)
+    def _rvs(self, df, nc, size=1, random_state=None):
+        return random_state.noncentral_chisquare(df, nc, size)
 
     def _logpdf(self, x, df, nc):
         cond = np.ones_like(x, dtype=bool) & (nc != 0)
@@ -5795,8 +5783,8 @@ class ncf_gen(rv_continuous):
     def _argcheck(self, df1, df2, nc):
         return (df1 > 0) & (df2 > 0) & (nc >= 0)
 
-    def _rvs(self, dfn, dfd, nc):
-        return self._random_state.noncentral_f(dfn, dfd, nc, self._size)
+    def _rvs(self, dfn, dfd, nc, size=1, random_state=None):
+        return random_state.noncentral_f(dfn, dfd, nc, size)
 
     def _pdf_skip(self, x, dfn, dfd, nc):
         # ncf.pdf(x, df1, df2, nc) = exp(nc/2 + nc*df1*x/(2*(df1*x+df2))) *
@@ -5877,8 +5865,8 @@ class t_gen(rv_continuous):
     def _argcheck(self, df):
         return df > 0
 
-    def _rvs(self, df):
-        return self._random_state.standard_t(df, size=self._size)
+    def _rvs(self, df, size=1, random_state=None):
+        return random_state.standard_t(df, size=size)
 
     def _pdf(self, x, df):
         #                                gamma((df+1)/2)
@@ -5952,10 +5940,9 @@ class nct_gen(rv_continuous):
     def _argcheck(self, df, nc):
         return (df > 0) & (nc == nc)
 
-    def _rvs(self, df, nc):
-        sz, rndm = self._size, self._random_state
-        n = norm.rvs(loc=nc, size=sz, random_state=rndm)
-        c2 = chi2.rvs(df, size=sz, random_state=rndm)
+    def _rvs(self, df, nc, size=1, random_state=None):
+        n = norm.rvs(loc=nc, size=size, random_state=random_state)
+        c2 = chi2.rvs(df, size=size, random_state=random_state)
         return n * np.sqrt(df) / np.sqrt(c2)
 
     def _pdf(self, x, df, nc):
@@ -6262,18 +6249,17 @@ class pearson3_gen(rv_continuous):
         ans[invmask] = gamma._cdf(transx, alpha)
         return ans
 
-    def _rvs(self, skew):
-        skew = np.broadcast_to(skew, self._size)
+    def _rvs(self, skew, size=1, random_state=None):
+        skew = np.broadcast_to(skew, size)
         ans, _, _, mask, invmask, beta, alpha, zeta = (
             self._preprocess([0], skew))
 
         nsmall = mask.sum()
         nbig = mask.size - nsmall
-        ans[mask] = self._random_state.standard_normal(nsmall)
-        ans[invmask] = (self._random_state.standard_gamma(alpha, nbig)/beta +
-                        zeta)
+        ans[mask] = random_state.standard_normal(nsmall)
+        ans[invmask] = random_state.standard_gamma(alpha, nbig)/beta + zeta
 
-        if self._size == ():
+        if size == ():
             ans = ans[0]
         return ans
 
@@ -6470,8 +6456,8 @@ class rdist_gen(rv_continuous):
     def _ppf(self, q, c):
         return 2*beta._ppf(q, c/2, c/2) - 1
 
-    def _rvs(self, c):
-        return 2 * self._random_state.beta(c/2, c/2, self._size) - 1
+    def _rvs(self, c, size=1, random_state=None):
+        return 2 * random_state.beta(c/2, c/2, size) - 1
 
     def _munp(self, n, c):
         numerator = (1 - (n % 2)) * sc.beta((n + 1.0) / 2, c / 2.0)
@@ -6505,8 +6491,8 @@ class rayleigh_gen(rv_continuous):
     """
     _support_mask = rv_continuous._open_support_mask
 
-    def _rvs(self):
-        return chi.rvs(2, size=self._size, random_state=self._random_state)
+    def _rvs(self, size=1, random_state=None):
+        return chi.rvs(2, size=size, random_state=random_state)
 
     def _pdf(self, r):
         # rayleigh.pdf(r) = r * exp(-r**2/2)
@@ -6655,10 +6641,9 @@ class rice_gen(rv_continuous):
     def _argcheck(self, b):
         return b >= 0
 
-    def _rvs(self, b):
+    def _rvs(self, b, size=1, random_state=None):
         # https://en.wikipedia.org/wiki/Rice_distribution
-        t = b/np.sqrt(2) + self._random_state.standard_normal(size=(2,) +
-                                                              self._size)
+        t = b/np.sqrt(2) + random_state.standard_normal(size=(2,) + size)
         return np.sqrt((t*t).sum(axis=0))
 
     def _cdf(self, x, b):
@@ -6726,8 +6711,8 @@ class recipinvgauss_gen(rv_continuous):
         isqx = 1.0/np.sqrt(x)
         return 1.0-_norm_cdf(isqx*trm1)-np.exp(2.0/mu)*_norm_cdf(-isqx*trm2)
 
-    def _rvs(self, mu):
-        return 1.0/self._random_state.wald(mu, 1.0, size=self._size)
+    def _rvs(self, mu, size=1, random_state=None):
+        return 1.0/random_state.wald(mu, 1.0, size=size)
 
 
 recipinvgauss = recipinvgauss_gen(a=0.0, name='recipinvgauss')
@@ -6776,11 +6761,11 @@ class semicircular_gen(rv_continuous):
     def _ppf(self, q):
         return rdist._ppf(q, 3)
 
-    def _rvs(self):
+    def _rvs(self, size=1, random_state=None):
         # generate values uniformly distributed on the area under the pdf
         # (semi-circle) by randomly generating the radius and angle
-        r = np.sqrt(self._random_state.uniform(size=self._size))
-        a = np.cos(np.pi * self._random_state.uniform(size=self._size))
+        r = np.sqrt(random_state.uniform(size=size))
+        a = np.cos(np.pi * random_state.uniform(size=size))
         return r * a
 
     def _stats(self):
@@ -6841,9 +6826,9 @@ class skew_norm_gen(rv_continuous):
     def _sf(self, x, a):
         return self._cdf(-x, -a)
 
-    def _rvs(self, a):
-        u0 = self._random_state.normal(size=self._size)
-        v = self._random_state.normal(size=self._size)
+    def _rvs(self, a, size=1, random_state=None):
+        u0 = random_state.normal(size=size)
+        v = random_state.normal(size=size)
         d = a/np.sqrt(1 + a**2)
         u1 = d*u0 + v*np.sqrt(1 - d**2)
         return np.where(u0 >= 0, u1, -u1)
@@ -6993,8 +6978,8 @@ class triang_gen(rv_continuous):
     %(example)s
 
     """
-    def _rvs(self, c):
-        return self._random_state.triangular(0, c, 1, self._size)
+    def _rvs(self, c, size=1, random_state=None):
+        return random_state.triangular(0, c, 1, size)
 
     def _argcheck(self, c):
         return (c >= 0) & (c <= 1)
@@ -7745,8 +7730,8 @@ class uniform_gen(rv_continuous):
     %(example)s
 
     """
-    def _rvs(self):
-        return self._random_state.uniform(0.0, 1.0, self._size)
+    def _rvs(self, size=1, random_state=None):
+        return random_state.uniform(0.0, 1.0, size)
 
     def _pdf(self, x):
         return 1.0*(x == x)
@@ -7945,8 +7930,8 @@ class vonmises_gen(rv_continuous):
     %(example)s
 
     """
-    def _rvs(self, kappa):
-        return self._random_state.vonmises(0.0, kappa, size=self._size)
+    def _rvs(self, kappa, size=1, random_state=None):
+        return random_state.vonmises(0.0, kappa, size=size)
 
     def _pdf(self, x, kappa):
         # vonmises.pdf(x, \kappa) = exp(\kappa * cos(x)) / (2*pi*I[0](\kappa))
@@ -7990,8 +7975,8 @@ class wald_gen(invgauss_gen):
     """
     _support_mask = rv_continuous._open_support_mask
 
-    def _rvs(self):
-        return self._random_state.wald(1.0, 1.0, size=self._size)
+    def _rvs(self, size=1, random_state=None):
+        return random_state.wald(1.0, 1.0, size=size)
 
     def _pdf(self, x):
         # wald.pdf(x) = 1/sqrt(2*pi*x**3) * exp(-(x-1)**2/(2*x))

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -822,7 +822,7 @@ class randint_gen(rv_discrete):
         """An array of *size* random integers >= ``low`` and < ``high``."""
         if np.asarray(low).size == 1 and np.asarray(high).size == 1:
             # no need to vectorize in that case
-            return rng_integers(self._random_state, low, high, size=size)
+            return rng_integers(random_state, low, high, size=size)
 
         if size is not None:
             # NumPy's RandomState.randint() doesn't broadcast its arguments.

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -37,8 +37,8 @@ class binom_gen(rv_discrete):
     %(example)s
 
     """
-    def _rvs(self, n, p):
-        return self._random_state.binomial(n, p, self._size)
+    def _rvs(self, n, p, size=1, random_state=None):
+        return random_state.binomial(n, p, size)
 
     def _argcheck(self, n, p):
         return (n >= 0) & (p >= 0) & (p <= 1)
@@ -113,8 +113,8 @@ class bernoulli_gen(binom_gen):
     %(example)s
 
     """
-    def _rvs(self, p):
-        return binom_gen._rvs(self, 1, p)
+    def _rvs(self, p, size=1, random_state=None):
+        return binom_gen._rvs(self, 1, p, size=size, random_state=random_state)
 
     def _argcheck(self, p):
         return (p >= 0) & (p <= 1)
@@ -187,9 +187,9 @@ class betabinom_gen(rv_discrete):
 
     """
 
-    def _rvs(self, n, a, b):
-        p = self._random_state.beta(a, b, self._size)
-        return self._random_state.binomial(n, p, self._size)
+    def _rvs(self, n, a, b, size=1, random_state=None):
+        p = random_state.beta(a, b, size)
+        return random_state.binomial(n, p, size)
 
     def _get_support(self, n, a, b):
         return 0, n
@@ -257,8 +257,8 @@ class nbinom_gen(rv_discrete):
     %(example)s
 
     """
-    def _rvs(self, n, p):
-        return self._random_state.negative_binomial(n, p, self._size)
+    def _rvs(self, n, p, size=1, random_state=None):
+        return random_state.negative_binomial(n, p, size)
 
     def _argcheck(self, n, p):
         return (n > 0) & (p >= 0) & (p <= 1)
@@ -325,8 +325,8 @@ class geom_gen(rv_discrete):
     %(example)s
 
     """
-    def _rvs(self, p):
-        return self._random_state.geometric(p, size=self._size)
+    def _rvs(self, p, size=1, random_state=None):
+        return random_state.geometric(p, size=size)
 
     def _argcheck(self, p):
         return (p <= 1) & (p >= 0)
@@ -427,8 +427,8 @@ class hypergeom_gen(rv_discrete):
     >>> R = hypergeom.rvs(M, n, N, size=10)
 
     """
-    def _rvs(self, M, n, N):
-        return self._random_state.hypergeometric(n, M-n, N, size=self._size)
+    def _rvs(self, M, n, N, size=1, random_state=None):
+        return random_state.hypergeometric(n, M-n, N, size=size)
 
     def _get_support(self, M, n, N):
         return np.maximum(N-(M-n), 0), np.minimum(n, N)
@@ -537,10 +537,10 @@ class logser_gen(rv_discrete):
     %(example)s
 
     """
-    def _rvs(self, p):
+    def _rvs(self, p, size=1, random_state=None):
         # looks wrong for p>0.5, too few k=1
         # trying to use generic is worse, no k=1 at all
-        return self._random_state.logseries(p, size=self._size)
+        return random_state.logseries(p, size=size)
 
     def _argcheck(self, p):
         return (p > 0) & (p < 1)
@@ -595,8 +595,8 @@ class poisson_gen(rv_discrete):
     def _argcheck(self, mu):
         return mu >= 0
 
-    def _rvs(self, mu):
-        return self._random_state.poisson(mu, self._size)
+    def _rvs(self, mu, size=1, random_state=None):
+        return random_state.poisson(mu, size)
 
     def _logpmf(self, k, mu):
         Pk = special.xlogy(k, mu) - gamln(k + 1) - mu
@@ -683,10 +683,10 @@ class planck_gen(rv_discrete):
         temp = self._cdf(vals1, lambda_)
         return np.where(temp >= q, vals1, vals)
 
-    def _rvs(self, lambda_):
+    def _rvs(self, lambda_, size=1, random_state=None):
         # use relation to geometric distribution for sampling
         p = -expm1(-lambda_)
-        return self._random_state.geometric(p, size=self._size) - 1.0
+        return random_state.geometric(p, size=size) - 1.0
 
     def _stats(self, lambda_):
         mu = 1/expm1(lambda_)
@@ -818,20 +818,20 @@ class randint_gen(rv_discrete):
         g2 = -6.0/5.0 * (d*d + 1.0) / (d*d - 1.0)
         return mu, var, g1, g2
 
-    def _rvs(self, low, high):
+    def _rvs(self, low, high, size=1, random_state=None):
         """An array of *size* random integers >= ``low`` and < ``high``."""
         if np.asarray(low).size == 1 and np.asarray(high).size == 1:
             # no need to vectorize in that case
-            return rng_integers(self._random_state, low, high, size=self._size)
+            return rng_integers(self._random_state, low, high, size=size)
 
-        if self._size is not None:
+        if size is not None:
             # NumPy's RandomState.randint() doesn't broadcast its arguments.
             # Use `broadcast_to()` to extend the shapes of low and high
-            # up to self._size.  Then we can use the numpy.vectorize'd
+            # up to size.  Then we can use the numpy.vectorize'd
             # randint without needing to pass it a `size` argument.
-            low = np.broadcast_to(low, self._size)
-            high = np.broadcast_to(high, self._size)
-        randint = np.vectorize(partial(rng_integers, self._random_state),
+            low = np.broadcast_to(low, size)
+            high = np.broadcast_to(high, size)
+        randint = np.vectorize(partial(rng_integers, random_state),
                                otypes=[np.int_])
         return randint(low, high)
 
@@ -867,8 +867,8 @@ class zipf_gen(rv_discrete):
     %(example)s
 
     """
-    def _rvs(self, a):
-        return self._random_state.zipf(a, size=self._size)
+    def _rvs(self, a, size=1, random_state=None):
+        return random_state.zipf(a, size=size)
 
     def _argcheck(self, a):
         return a > 1
@@ -937,7 +937,7 @@ class dlaplace_gen(rv_discrete):
     def _entropy(self, a):
         return a / sinh(a) - log(tanh(a/2.0))
 
-    def _rvs(self, a):
+    def _rvs(self, a, size=1, random_state=None):
         # The discrete Laplace is equivalent to the two-sided geometric
         # distribution with PMF:
         #   f(k) = (1 - alpha)/(1 + alpha) * alpha^abs(k)
@@ -954,8 +954,8 @@ class dlaplace_gen(rv_discrete):
         #   1) alpha = e^-a
         #   2) probability_of_success = 1 - alpha (Bernoulli trial)
         probOfSuccess = -np.expm1(-np.asarray(a))
-        x = self._random_state.geometric(probOfSuccess, size=self._size)
-        y = self._random_state.geometric(probOfSuccess, size=self._size)
+        x = random_state.geometric(probOfSuccess, size=size)
+        y = random_state.geometric(probOfSuccess, size=size)
         return x - y
 
 
@@ -993,10 +993,10 @@ class skellam_gen(rv_discrete):
     %(example)s
 
     """
-    def _rvs(self, mu1, mu2):
-        n = self._size
-        return (self._random_state.poisson(mu1, n) -
-                self._random_state.poisson(mu2, n))
+    def _rvs(self, mu1, mu2, size=1, random_state=None):
+        n = size
+        return (random_state.poisson(mu1, n) -
+                random_state.poisson(mu2, n))
 
     def _pmf(self, x, mu1, mu2):
         px = np.where(x < 0,
@@ -1057,9 +1057,9 @@ class yulesimon_gen(rv_discrete):
     %(example)s
 
     """
-    def _rvs(self, alpha):
-        E1 = self._random_state.standard_exponential(self._size)
-        E2 = self._random_state.standard_exponential(self._size)
+    def _rvs(self, alpha, size=1, random_state=None):
+        E1 = random_state.standard_exponential(size)
+        E2 = random_state.standard_exponential(size)
         ans = ceil(-E1 / log1p(-exp(-E2 / alpha)))
         return ans
 

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -37,7 +37,7 @@ class binom_gen(rv_discrete):
     %(example)s
 
     """
-    def _rvs(self, n, p, size=1, random_state=None):
+    def _rvs(self, n, p, size=None, random_state=None):
         return random_state.binomial(n, p, size)
 
     def _argcheck(self, n, p):
@@ -113,7 +113,7 @@ class bernoulli_gen(binom_gen):
     %(example)s
 
     """
-    def _rvs(self, p, size=1, random_state=None):
+    def _rvs(self, p, size=None, random_state=None):
         return binom_gen._rvs(self, 1, p, size=size, random_state=random_state)
 
     def _argcheck(self, p):
@@ -187,7 +187,7 @@ class betabinom_gen(rv_discrete):
 
     """
 
-    def _rvs(self, n, a, b, size=1, random_state=None):
+    def _rvs(self, n, a, b, size=None, random_state=None):
         p = random_state.beta(a, b, size)
         return random_state.binomial(n, p, size)
 
@@ -257,7 +257,7 @@ class nbinom_gen(rv_discrete):
     %(example)s
 
     """
-    def _rvs(self, n, p, size=1, random_state=None):
+    def _rvs(self, n, p, size=None, random_state=None):
         return random_state.negative_binomial(n, p, size)
 
     def _argcheck(self, n, p):
@@ -325,7 +325,7 @@ class geom_gen(rv_discrete):
     %(example)s
 
     """
-    def _rvs(self, p, size=1, random_state=None):
+    def _rvs(self, p, size=None, random_state=None):
         return random_state.geometric(p, size=size)
 
     def _argcheck(self, p):
@@ -427,7 +427,7 @@ class hypergeom_gen(rv_discrete):
     >>> R = hypergeom.rvs(M, n, N, size=10)
 
     """
-    def _rvs(self, M, n, N, size=1, random_state=None):
+    def _rvs(self, M, n, N, size=None, random_state=None):
         return random_state.hypergeometric(n, M-n, N, size=size)
 
     def _get_support(self, M, n, N):
@@ -537,7 +537,7 @@ class logser_gen(rv_discrete):
     %(example)s
 
     """
-    def _rvs(self, p, size=1, random_state=None):
+    def _rvs(self, p, size=None, random_state=None):
         # looks wrong for p>0.5, too few k=1
         # trying to use generic is worse, no k=1 at all
         return random_state.logseries(p, size=size)
@@ -595,7 +595,7 @@ class poisson_gen(rv_discrete):
     def _argcheck(self, mu):
         return mu >= 0
 
-    def _rvs(self, mu, size=1, random_state=None):
+    def _rvs(self, mu, size=None, random_state=None):
         return random_state.poisson(mu, size)
 
     def _logpmf(self, k, mu):
@@ -683,7 +683,7 @@ class planck_gen(rv_discrete):
         temp = self._cdf(vals1, lambda_)
         return np.where(temp >= q, vals1, vals)
 
-    def _rvs(self, lambda_, size=1, random_state=None):
+    def _rvs(self, lambda_, size=None, random_state=None):
         # use relation to geometric distribution for sampling
         p = -expm1(-lambda_)
         return random_state.geometric(p, size=size) - 1.0
@@ -818,7 +818,7 @@ class randint_gen(rv_discrete):
         g2 = -6.0/5.0 * (d*d + 1.0) / (d*d - 1.0)
         return mu, var, g1, g2
 
-    def _rvs(self, low, high, size=1, random_state=None):
+    def _rvs(self, low, high, size=None, random_state=None):
         """An array of *size* random integers >= ``low`` and < ``high``."""
         if np.asarray(low).size == 1 and np.asarray(high).size == 1:
             # no need to vectorize in that case
@@ -867,7 +867,7 @@ class zipf_gen(rv_discrete):
     %(example)s
 
     """
-    def _rvs(self, a, size=1, random_state=None):
+    def _rvs(self, a, size=None, random_state=None):
         return random_state.zipf(a, size=size)
 
     def _argcheck(self, a):
@@ -937,7 +937,7 @@ class dlaplace_gen(rv_discrete):
     def _entropy(self, a):
         return a / sinh(a) - log(tanh(a/2.0))
 
-    def _rvs(self, a, size=1, random_state=None):
+    def _rvs(self, a, size=None, random_state=None):
         # The discrete Laplace is equivalent to the two-sided geometric
         # distribution with PMF:
         #   f(k) = (1 - alpha)/(1 + alpha) * alpha^abs(k)
@@ -993,7 +993,7 @@ class skellam_gen(rv_discrete):
     %(example)s
 
     """
-    def _rvs(self, mu1, mu2, size=1, random_state=None):
+    def _rvs(self, mu1, mu2, size=None, random_state=None):
         n = size
         return (random_state.poisson(mu1, n) -
                 random_state.poisson(mu2, n))
@@ -1057,7 +1057,7 @@ class yulesimon_gen(rv_discrete):
     %(example)s
 
     """
-    def _rvs(self, alpha, size=1, random_state=None):
+    def _rvs(self, alpha, size=None, random_state=None):
         E1 = random_state.standard_exponential(size)
         E2 = random_state.standard_exponential(size)
         ans = ceil(-E1 / log1p(-exp(-E2 / alpha)))

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -913,8 +913,8 @@ class rv_generic(object):
             return (a < x) & (x < b)
 
     def _rvs(self, *args, size=None, random_state=None):
-        # This method must handle self._size being a tuple, and it must
-        # properly broadcast *args and self._size.  self._size might be
+        # This method must handle size being a tuple, and it must
+        # properly broadcast *args and size.  size might be
         # an empty tuple, which means a scalar random variate is to be
         # generated.
 

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -919,7 +919,7 @@ class rv_generic(object):
         # generated.
 
         ## Use basic inverse cdf algorithm for RV generation as default.
-        U = random_state.uniform(size)
+        U = random_state.uniform(size=size)
         Y = self._ppf(U, *args)
         return Y
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -4334,3 +4334,15 @@ class TestArgus(object):
         x = stats.argus.rvs(3.5, size=1500, random_state=1535)
         assert_almost_equal(stats.argus(3.5).mean(), x.mean(), decimal=3)
         assert_almost_equal(stats.argus(3.5).std(), x.std(), decimal=3)
+
+
+def test_rvs_no_size_warning():
+    class rvs_no_size_gen(stats.rv_continuous):
+        def _rvs(self):
+            return 1
+
+    rvs_no_size = rvs_no_size_gen(name='rvs_no_size')
+
+    with assert_warns(np.VisibleDeprecationWarning):
+        rvs_no_size.rvs()
+


### PR DESCRIPTION
Add `size` keyword to `dist._rvs()` rather than relying on `dist._size`.
Moves towards thread safety by passing in values rather than modifying the class.

gh-9900 made many stats usages more thread-safe, but didn't change `distn._size`, which gets set in every call to `distn.rvs()`.  This PR stops the setting the `distn._size` member of the class.
`distns.rvs()` is not yet completely thread-safe as the random_state is stored in `self._random_state`. 

Some questions:
`size` became a keyword argument to `_rvs(self, *shape_args, size=... )`
What should the default size be? `None`? `1`? Something else?
If not set in the parent `rv_generic.rvs()` method, previously it generated one random variate (or perhaps one for each shape args passed in.)
In the actual distribution's `_rvs` method, it appears to always have a value in all the tests.
Is that in fact the case, that by the time a distribution is asked for `_rvs()`, it knows explicitly the size?  Either by `self._size` prior to this PR, or a real `size` passed in for this PR.
Should `size` become a positional argument to each `distn._rvs()`, or would that break backwards compatibility? (Aside: Are _underscore methods part of the API that needs preserving?)
