### PR TITLE
correction in error message (%d->%g format)

### DIFF
--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -1362,7 +1362,7 @@ def toms748(f, a, b, args=(), k=1,
     if not np.isfinite(b):
         raise ValueError("b is not finite %s" % b)
     if a >= b:
-        raise ValueError("a and b are not an interval [%g, %g]" % (a, b))
+        raise ValueError("a and b are not an interval [{}, {}]".format(a, b))
     if not k >= 1:
         raise ValueError("k too small (%s < 1)" % k)
 

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -1362,7 +1362,7 @@ def toms748(f, a, b, args=(), k=1,
     if not np.isfinite(b):
         raise ValueError("b is not finite %s" % b)
     if a >= b:
-        raise ValueError("a and b are not an interval [%d, %d]" % (a, b))
+        raise ValueError("a and b are not an interval [%g, %g]" % (a, b))
     if not k >= 1:
         raise ValueError("k too small (%s < 1)" % k)
 


### PR DESCRIPTION
There seem to be no reason to assume that the root-finding interval boundaries are integer-valued