### PR TITLE
DOC: revert gh10540, removing mtrand

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -325,7 +325,7 @@ latex_elements = {
 # -----------------------------------------------------------------------------
 intersphinx_mapping = {
     'python': ('https://docs.python.org/dev', None),
-    'numpy': ('https://docs.scipy.org/doc/numpy', None),
+    'numpy': ('https://numpy.org/devdocs', None),
     'matplotlib': ('https://matplotlib.org', None),
     'asv': ('https://asv.readthedocs.io/en/stable/', None),
 }

--- a/doc/source/tutorial/stats.rst
+++ b/doc/source/tutorial/stats.rst
@@ -169,7 +169,7 @@ you can explicitly seed a global variable
 
 Relying on a global state is not recommended, though. A better way is to use
 the `random_state` parameter, which accepts an instance of
-`numpy.random.mtrand.RandomState` class, or an integer, which is then used to
+`numpy.random.RandomState` class, or an integer, which is then used to
 seed an internal ``RandomState`` object:
 
     >>> norm.rvs(size=5, random_state=1234)

--- a/scipy/linalg/_sketches.py
+++ b/scipy/linalg/_sketches.py
@@ -28,7 +28,7 @@ def cwt_matrix(n_rows, n_columns, seed=None):
         Number of rows of S
     n_columns: int
         Number of columns of S
-    seed : None or int or `numpy.random.mtrand.RandomState` instance, optional
+    seed : None or int or `numpy.random.RandomState` instance, optional
         This parameter defines the ``RandomState`` object to use for drawing
         random variates.
         If None (or ``np.random``), the global ``np.random`` state is used.
@@ -72,7 +72,7 @@ def clarkson_woodruff_transform(input_matrix, sketch_size, seed=None):
         Input matrix, of shape ``(n, d)``.
     sketch_size: int
         Number of rows for the sketch.
-    seed : None or int or `numpy.random.mtrand.RandomState` instance, optional
+    seed : None or int or `numpy.random.RandomState` instance, optional
         This parameter defines the ``RandomState`` object to use for drawing
         random variates.
         If None (or ``np.random``), the global ``np.random`` state is used.

--- a/scipy/linalg/interpolative.py
+++ b/scipy/linalg/interpolative.py
@@ -417,7 +417,7 @@ def seed(seed=None):
         the generator.
 
         If the value is an integer, the internal state is obtained
-        from `numpy.random.mtrand.RandomState` (MT19937) with the integer
+        from `numpy.random.RandomState` (MT19937) with the integer
         used as the initial seed.
 
         If `seed` is omitted (None), ``numpy.random.rand`` is used to

--- a/scipy/optimize/_dual_annealing.py
+++ b/scipy/optimize/_dual_annealing.py
@@ -40,8 +40,8 @@ class VisitingDistribution(object):
         makes the algorithm jump to a more distant region.
         The value range is (0, 3]. It's value is fixed for the life of the
         object.
-    rand_state : `~numpy.random.mtrand.RandomState` object
-        A `~numpy.random.mtrand.RandomState` object for using the current state
+    rand_state : `~numpy.random.RandomState` object
+        A `~numpy.random.RandomState` object for using the current state
         of the created random generator container.
     """
     TAIL_LIMIT = 1.e8
@@ -228,8 +228,8 @@ class StrategyChain(object):
         Instance of `ObjectiveFunWrapper` class.
     minimizer_wrapper: LocalSearchWrapper
         Instance of `LocalSearchWrapper` class.
-    rand_state : `~numpy.random.mtrand.RandomState` object
-        A `~numpy.random.mtrand.RandomState` object for using the current state
+    rand_state : `~numpy.random.RandomState` object
+        A `~numpy.random.RandomState` object for using the current state
         of the created random generator container.
     energy_state: EnergyState
         Instance of `EnergyState` class.
@@ -476,8 +476,8 @@ def dual_annealing(func, bounds, args=(), maxiter=1000,
         algorithm is in the middle of a local search, this number will be
         exceeded, the algorithm will stop just after the local search is
         done. Default value is 1e7.
-    seed : {int or `~numpy.random.mtrand.RandomState` instance}, optional
-        If `seed` is not specified the `~numpy.random.mtrand.RandomState`
+    seed : {int or `~numpy.random.RandomState` instance}, optional
+        If `seed` is not specified the `~numpy.random.RandomState`
         singleton is used.
         If `seed` is an int, a new ``RandomState`` instance is used,
         seeded with `seed`.

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -366,7 +366,7 @@ def directed_hausdorff(u, v, seed=0):
     v : (O,N) ndarray
         Input array.
     seed : int or None
-        Local `numpy.random.mtrand.RandomState` seed. Default is 0, a random
+        Local `numpy.random.RandomState` seed. Default is 0, a random
         shuffling of u and v that guarantees reproducibility.
 
     Returns

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -1561,7 +1561,7 @@ class exponweib_gen(rv_continuous):
 
     See Also
     --------
-    weibull_min, numpy.random.mtrand.RandomState.weibull
+    weibull_min, numpy.random.RandomState.weibull
 
     Notes
     -----
@@ -1938,7 +1938,7 @@ class weibull_min_gen(rv_continuous):
 
     See Also
     --------
-    weibull_max, numpy.random.mtrand.RandomState.weibull, exponweib
+    weibull_max, numpy.random.RandomState.weibull, exponweib
 
     Notes
     -----


### PR DESCRIPTION
#10540 converted `numpy.random.RandomState` in several docstrings to `numpy.random.mtrand.RandomState`. This was because the intersphinx mappings were incorrect (https://github.com/numpy/numpy/issues/14359). This PR reverts those changes, given that the intersphinx mappings are now correct.