### PR TITLE
ENH: stats can use np.random.Generator

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -1278,7 +1278,7 @@ class dgamma_gen(rv_continuous):
     """
     def _rvs(self, a):
         sz, rndm = self._size, self._random_state
-        u = rndm.random_sample(size=sz)
+        u = rndm.uniform(size=sz)
         gm = gamma.rvs(a, size=sz, random_state=rndm)
         return gm * np.where(u >= 0.5, 1, -1)
 
@@ -1335,7 +1335,7 @@ class dweibull_gen(rv_continuous):
     """
     def _rvs(self, c):
         sz, rndm = self._size, self._random_state
-        u = rndm.random_sample(size=sz)
+        u = rndm.uniform(size=sz)
         w = weibull_min.rvs(c, size=sz, random_state=rndm)
         return w * (np.where(u >= 0.5, 1, -1))
 
@@ -3735,8 +3735,8 @@ class geninvgauss_gen(rv_continuous):
             while simulated < N:
                 k = N - simulated
                 # simulate uniform rvs on [0, umax] and [vmin, vmax]
-                u = umax * self._random_state.random_sample(size=k)
-                v = self._random_state.random_sample(size=k)
+                u = umax * self._random_state.uniform(size=k)
+                v = self._random_state.uniform(size=k)
                 v = vmin + (vmax - vmin) * v
                 rvs = v / u + c
                 # rewrite acceptance condition u**2 <= pdf(rvs) by taking logs
@@ -3775,8 +3775,8 @@ class geninvgauss_gen(rv_continuous):
                 k = N - simulated
                 h, rvs = np.zeros(k), np.zeros(k)
                 # simulate uniform rvs on [x1, x2] and [0, y2]
-                u = self._random_state.random_sample(size=k)
-                v = A * self._random_state.random_sample(size=k)
+                u = self._random_state.uniform(size=k)
+                v = A * self._random_state.uniform(size=k)
                 cond1 = v <= A1
                 cond2 = np.logical_not(cond1) & (v <= A1 + A2)
                 cond3 = np.logical_not(cond1 | cond2)
@@ -6668,8 +6668,8 @@ class semicircular_gen(rv_continuous):
     def _rvs(self):
         # generate values uniformly distributed on the area under the pdf
         # (semi-circle) by randomly generating the radius and angle
-        r = np.sqrt(self._random_state.random_sample(size=self._size))
-        a = np.cos(np.pi * self._random_state.random_sample(size=self._size))
+        r = np.sqrt(self._random_state.uniform(size=self._size))
+        a = np.cos(np.pi * self._random_state.uniform(size=self._size))
         return r * a
 
     def _stats(self):

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -821,9 +821,15 @@ class randint_gen(rv_discrete):
 
     def _rvs(self, low, high):
         """An array of *size* random integers >= ``low`` and < ``high``."""
+        if hasattr(self._random_state, 'integers'):
+            # isinstance(self._random_state, np.random.Generator)
+            int_fun = self._random_state.integers
+        else:
+            int_fun = self._random_state.randint
+
         if np.asarray(low).size == 1 and np.asarray(high).size == 1:
             # no need to vectorize in that case
-            return self._random_state.randint(low, high, size=self._size)
+            return int_fun(low, high, size=self._size)
         if self._size is not None:
             # NumPy's RandomState.randint() doesn't broadcast its arguments.
             # Use `broadcast_to()` to extend the shapes of low and high
@@ -831,7 +837,7 @@ class randint_gen(rv_discrete):
             # randint without needing to pass it a `size` argument.
             low = np.broadcast_to(low, self._size)
             high = np.broadcast_to(high, self._size)
-        randint = np.vectorize(self._random_state.randint, otypes=[np.int_])
+        randint = np.vectorize(int_fun, otypes=[np.int_])
         return randint(low, high)
 
     def _entropy(self, low, high):

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -590,10 +590,11 @@ class rv_generic(object):
     def random_state(self):
         """ Get or set the RandomState object for generating random variates.
 
-        This can be either None or an existing RandomState object.
+        This can be either None, int, a RandomState instance, or a
+        np.random.Generator instance.
 
         If None (or np.random), use the RandomState singleton used by np.random.
-        If already a RandomState instance, use it.
+        If already a RandomState or Generator instance, use it.
         If an int, use a new RandomState instance seeded with seed.
 
         """
@@ -900,7 +901,7 @@ class rv_generic(object):
         # generated.
 
         ## Use basic inverse cdf algorithm for RV generation as default.
-        U = self._random_state.random_sample(self._size)
+        U = self._random_state.uniform(size=self._size)
         Y = self._ppf(U, *args)
         return Y
 
@@ -938,9 +939,12 @@ class rv_generic(object):
             Scale parameter (default=1).
         size : int or tuple of ints, optional
             Defining number of random variates (default is 1).
-        random_state : None or int or ``np.random.RandomState`` instance, optional
-            If int or RandomState, use it for drawing the random variates.
-            If None, rely on ``self.random_state``.
+        random_state : {None, int, `~np.random.RandomState`, `~np.random.Generator`}, optional
+            If `seed` is `None` the `~np.random.RandomState` singleton is used.
+            If `seed` is an int, a new ``RandomState`` instance is used, seeded
+            with seed.
+            If `seed` is already a ``RandomState`` or ``Generator`` instance,
+            then that object is used.
             Default is None.
 
         Returns
@@ -1408,11 +1412,13 @@ class rv_continuous(rv_generic):
         This string is used as the last part of the docstring returned when a
         subclass has no docstring of its own. Note: `extradoc` exists for
         backwards compatibility, do not use for new subclasses.
-    seed : None or int or ``numpy.random.RandomState`` instance, optional
-        This parameter defines the RandomState object to use for drawing
-        random variates.
-        If None (or np.random), the global np.random state is used.
-        If integer, it is used to seed the local RandomState instance.
+    seed : {None, int, `~np.random.RandomState`, `~np.random.Generator`}, optional
+        This parameter defines the object to use for drawing random variates.
+        If `seed` is `None` the `~np.random.RandomState` singleton is used.
+        If `seed` is an int, a new ``RandomState`` instance is used, seeded
+        with seed.
+        If `seed` is already a ``RandomState`` or ``Generator`` instance,
+        then that object is used.
         Default is None.
 
     Methods
@@ -2714,11 +2720,13 @@ class rv_discrete(rv_generic):
         This string is used as the last part of the docstring returned when a
         subclass has no docstring of its own. Note: `extradoc` exists for
         backwards compatibility, do not use for new subclasses.
-    seed : None or int or ``numpy.random.RandomState`` instance, optional
-        This parameter defines the RandomState object to use for drawing
-        random variates.
-        If None, the global np.random state is used.
-        If integer, it is used to seed the local RandomState instance.
+    seed : {None, int, `~np.random.RandomState`, `~np.random.Generator`}, optional
+        This parameter defines the object to use for drawing random variates.
+        If `seed` is `None` the `~np.random.RandomState` singleton is used.
+        If `seed` is an int, a new ``RandomState`` instance is used, seeded
+        with seed.
+        If `seed` is already a ``RandomState`` or ``Generator`` instance,
+        then that object is used.
         Default is None.
 
     Methods
@@ -2943,9 +2951,15 @@ class rv_discrete(rv_generic):
         size : int or tuple of ints, optional
             Defining number of random variates (Default is 1).  Note that `size`
             has to be given as keyword, not as positional argument.
-        random_state : None or int or ``np.random.RandomState`` instance, optional
-            If int or RandomState, use it for drawing the random variates.
-            If None, rely on ``self.random_state``.
+        random_state : {None, int, `~np.random.RandomState`, `~np.random.Generator`}, optional
+            This parameter defines the object to use for drawing random
+            variates.
+            If `random_state` is `None` the `~np.random.RandomState` singleton
+            is used.
+            If `random_state` is an int, a new ``RandomState`` instance is used,
+            seeded with random_state.
+            If `random_state` is already a ``RandomState`` or ``Generator``
+            instance, then that object is used.
             Default is None.
 
         Returns
@@ -3537,7 +3551,7 @@ class rv_sample(rv_discrete):
     def _rvs(self):
         # Need to define it explicitly, otherwise .rvs() with size=None
         # fails due to explicit broadcasting in _ppf
-        U = self._random_state.random_sample(self._size)
+        U = self._random_state.uniform(size=self._size)
         if self._size is None:
             U = np.array(U, ndmin=1)
             Y = self._ppf(U)[0]

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -34,9 +34,13 @@ _LOG_PI = np.log(np.pi)
 
 
 _doc_random_state = """\
-random_state : None or int or np.random.RandomState instance, optional
-    If int or RandomState, use it for drawing the random variates.
-    If None (or np.random), the global np.random state is used.
+random_state : {None, int, np.random.RandomState, np.random.Generator}, optional
+    Used for drawing random variates.
+    If `seed` is `None` the `~np.random.RandomState` singleton is used.
+    If `seed` is an int, a new ``RandomState`` instance is used, seeded
+    with seed.
+    If `seed` is already a ``RandomState`` or ``Generator`` instance,
+    then that object is used.
     Default is None.
 """
 
@@ -193,10 +197,12 @@ class multi_rv_generic(object):
     def random_state(self):
         """ Get or set the RandomState object for generating random variates.
 
-        This can be either None or an existing RandomState object.
+        This can be either None, int, a RandomState instance, or a
+        np.random.Generator instance.
 
-        If None (or np.random), use the RandomState singleton used by np.random.
-        If already a RandomState instance, use it.
+        If None (or np.random), use the RandomState singleton used by
+        np.random.
+        If already a RandomState or Generator instance, use it.
         If an int, use a new RandomState instance seeded with seed.
 
         """
@@ -701,11 +707,14 @@ class multivariate_normal_frozen(multi_rv_frozen):
         allow_singular : bool, optional
             If this flag is True then tolerate a singular
             covariance matrix (default False).
-        seed : None or int or np.random.RandomState instance, optional
-            This parameter defines the RandomState object to use for drawing
-            random variates.
-            If None (or np.random), the global np.random state is used.
-            If integer, it is used to seed the local RandomState instance
+        seed : {None, int, `~np.random.RandomState`, `~np.random.Generator`}, optional
+            This parameter defines the object to use for drawing random
+            variates.
+            If `seed` is `None` the `~np.random.RandomState` singleton is used.
+            If `seed` is an int, a new ``RandomState`` instance is used, seeded
+            with seed.
+            If `seed` is already a ``RandomState`` or ``Generator`` instance,
+            then that object is used.
             Default is None.
         maxpts: integer, optional
             The maximum number of points to use for integration of the
@@ -1153,9 +1162,14 @@ class matrix_normal_frozen(multi_rv_frozen):
         Parameters
         ----------
         %(_matnorm_doc_default_callparams)s
-        seed : None or int or np.random.RandomState instance, optional
-            If int or RandomState, use it for drawing the random variates.
-            If None (or np.random), the global np.random state is used.
+       seed : {None, int, `~np.random.RandomState`, `~np.random.Generator`}, optional
+            This parameter defines the object to use for drawing random
+            variates.
+            If `seed` is `None` the `~np.random.RandomState` singleton is used.
+            If `seed` is an int, a new ``RandomState`` instance is used, seeded
+            with seed.
+            If `seed` is already a ``RandomState`` or ``Generator`` instance,
+            then that object is used.
             Default is None.
 
         Examples
@@ -2038,8 +2052,8 @@ class wishart_gen(multi_rv_generic):
             Dimension of the scale matrix
         df : int
             Degrees of freedom
-        random_state : np.random.RandomState instance
-            RandomState used for drawing the random variates.
+        random_state : {`~np.random.RandomState`, `~np.random.Generator`}
+            Object used for drawing the random variates.
 
         Notes
         -----
@@ -2238,11 +2252,13 @@ class wishart_frozen(multi_rv_frozen):
         Degrees of freedom of the distribution
     scale : array_like
         Scale matrix of the distribution
-    seed : None or int or np.random.RandomState instance, optional
-        This parameter defines the RandomState object to use for drawing
-        random variates.
-        If None (or np.random), the global np.random state is used.
-        If integer, it is used to seed the local RandomState instance
+    seed : {None, int, `~np.random.RandomState`, `~np.random.Generator`}, optional
+        This parameter defines the object to use for drawing random variates.
+        If `seed` is `None` the `~np.random.RandomState` singleton is used.
+        If `seed` is an int, a new ``RandomState`` instance is used, seeded
+        with seed.
+        If `seed` is already a ``RandomState`` or ``Generator`` instance,
+        then that object is used.
         Default is None.
 
     """
@@ -2787,11 +2803,14 @@ class invwishart_frozen(multi_rv_frozen):
             Degrees of freedom of the distribution
         scale : array_like
             Scale matrix of the distribution
-        seed : None or int or np.random.RandomState instance, optional
-            This parameter defines the RandomState object to use for drawing
-            random variates.
-            If None (or np.random), the global np.random state is used.
-            If integer, it is used to seed the local RandomState instance
+        seed : {None, int, `~np.random.RandomState`, `~np.random.Generator`}, optional
+            This parameter defines the object to use for drawing random
+            variates.
+            If `seed` is `None` the `~np.random.RandomState` singleton is used.
+            If `seed` is an int, a new ``RandomState`` instance is used, seeded
+            with seed.
+            If `seed` is already a ``RandomState`` or ``Generator`` instance,
+            then that object is used.
             Default is None.
 
         """
@@ -3233,11 +3252,13 @@ class multinomial_frozen(multi_rv_frozen):
         number of trials
     p: array_like
         probability of a trial falling into each category; should sum to 1
-    seed : None or int or np.random.RandomState instance, optional
-        This parameter defines the RandomState object to use for drawing
-        random variates.
-        If None (or np.random), the global np.random state is used.
-        If integer, it is used to seed the local RandomState instance
+    seed : {None, int, `~np.random.RandomState`, `~np.random.Generator`}, optional
+        This parameter defines the object to use for drawing random variates.
+        If `seed` is `None` the `~np.random.RandomState` singleton is used.
+        If `seed` is an int, a new ``RandomState`` instance is used, seeded
+        with seed.
+        If `seed` is already a ``RandomState`` or ``Generator`` instance,
+        then that object is used.
         Default is None.
     """
     def __init__(self, n, p, seed=None):
@@ -3413,11 +3434,14 @@ class special_ortho_group_frozen(multi_rv_frozen):
         ----------
         dim : scalar
             Dimension of matrices
-        seed : None or int or np.random.RandomState instance, optional
-            This parameter defines the RandomState object to use for drawing
-            random variates.
-            If None (or np.random), the global np.random state is used.
-            If integer, it is used to seed the local RandomState instance
+        seed : {None, int, `~np.random.RandomState`, `~np.random.Generator`}, optional
+            This parameter defines the object to use for drawing random
+            variates.
+            If `seed` is `None` the `~np.random.RandomState` singleton is used.
+            If `seed` is an int, a new ``RandomState`` instance is used, seeded
+            with seed.
+            If `seed` is already a ``RandomState`` or ``Generator`` instance,
+            then that object is used.
             Default is None.
 
         Examples

--- a/scipy/stats/_rvs_sampling.py
+++ b/scipy/stats/_rvs_sampling.py
@@ -25,10 +25,14 @@ def rvs_ratio_uniforms(pdf, umax, vmin, vmax, size=1, c=0, random_state=None):
         Defining number of random variates (default is 1).
     c : float, optional.
         Shift parameter of ratio-of-uniforms method, see Notes. Default is 0.
-    random_state : int or np.random.RandomState instance, optional
-        If already a RandomState instance, use it.
-        If seed is an int, return a new RandomState instance seeded with seed.
-        If None, use np.random.RandomState. Default is None.
+    random_state : {None, int, `~np.random.RandomState`, `~np.random.Generator`}, optional
+        If `random_state` is `None` the `~np.random.RandomState` singleton is
+        used.
+        If `random_state` is an int, a new ``RandomState`` instance is used,
+        seeded with random_state.
+        If `random_state` is already a ``RandomState`` or ``Generator``
+        instance, then that object is used.
+        Default is None.
 
     Returns
     -------
@@ -148,8 +152,8 @@ def rvs_ratio_uniforms(pdf, umax, vmin, vmax, size=1, c=0, random_state=None):
     while simulated < N:
         k = N - simulated
         # simulate uniform rvs on [0, umax] and [vmin, vmax]
-        u1 = umax * rng.random_sample(size=k)
-        v1 = vmin + (vmax - vmin) * rng.random_sample(size=k)
+        u1 = umax * rng.uniform(size=k)
+        v1 = rng.uniform(vmin, vmax, size=k)
         # apply rejection method
         rvs = v1 / u1 + c
         accept = (u1**2 <= pdf(rvs))

--- a/scipy/stats/kde.py
+++ b/scipy/stats/kde.py
@@ -445,13 +445,15 @@ class gaussian_kde(object):
             The number of samples to draw.  If not provided, then the size is
             the same as the effective number of samples in the underlying
             dataset.
-        seed : None or int or `np.random.RandomState`, optional
-            If `seed` is None, random variates are drawn by the RandomState
-            singleton used by np.random.
-            If `seed` is an int, a new `np.random.RandomState` instance is used,
-            seeded with seed.
-            If `seed` is already a `np.random.RandomState instance`, then that
-            `np.random.RandomState` instance is used.
+        seed : {None, int, `~np.random.RandomState`, `~np.random.Generator`}, optional
+            This parameter defines the object to use for drawing random
+            variates.
+            If `seed` is `None` the `~np.random.RandomState` singleton is used.
+            If `seed` is an int, a new ``RandomState`` instance is used, seeded
+            with seed.
+            If `seed` is already a ``RandomState`` or ``Generator`` instance,
+            then that object is used.
+            Default is None.
             Specify `seed` for reproducible drawing of random variates.
 
         Returns

--- a/scipy/stats/tests/common_tests.py
+++ b/scipy/stats/tests/common_tests.py
@@ -199,6 +199,15 @@ def check_random_state_property(distfn, args):
     r2 = distfn.rvs(*args, size=8)
     npt.assert_equal(r0, r2)
 
+    # check that np.random.Generator can be used (numpy >= 1.17)
+    try:
+        # obtain a np.random.Generator object
+        rng = np.random.default_rng(1234)
+        distfn.rvs(*args, size=1, random_state=rng)
+    except AttributeError:
+        # only available in numpy >= 1.17
+        pass
+
     # can override the instance-level random_state for an individual .rvs call
     distfn.random_state = 2
     orig_state = distfn.random_state.get_state()

--- a/scipy/stats/tests/common_tests.py
+++ b/scipy/stats/tests/common_tests.py
@@ -200,13 +200,10 @@ def check_random_state_property(distfn, args):
     npt.assert_equal(r0, r2)
 
     # check that np.random.Generator can be used (numpy >= 1.17)
-    try:
+    if hasattr(np.random, 'default_rng'):
         # obtain a np.random.Generator object
         rng = np.random.default_rng(1234)
         distfn.rvs(*args, size=1, random_state=rng)
-    except AttributeError:
-        # only available in numpy >= 1.17
-        pass
 
     # can override the instance-level random_state for an individual .rvs call
     distfn.random_state = 2

--- a/scipy/stats/tests/test_binned_statistic.py
+++ b/scipy/stats/tests/test_binned_statistic.py
@@ -5,6 +5,7 @@ from numpy.testing import assert_allclose
 from pytest import raises as assert_raises
 from scipy.stats import (binned_statistic, binned_statistic_2d,
                          binned_statistic_dd)
+from scipy._lib._util import check_random_state
 
 from .common_tests import check_named_results
 
@@ -13,13 +14,13 @@ class TestBinnedStatistic(object):
 
     @classmethod
     def setup_class(cls):
-        np.random.seed(9865)
-        cls.x = np.random.random(100)
-        cls.y = np.random.random(100)
-        cls.v = np.random.random(100)
-        cls.X = np.random.random((100, 3))
-        cls.w = np.random.random(100)
-        cls.u = np.random.random(100) + 1e6
+        rng = check_random_state(9865)
+        cls.x = rng.uniform(size=100)
+        cls.y = rng.uniform(size=100)
+        cls.v = rng.uniform(size=100)
+        cls.X = rng.uniform(size=(100, 3))
+        cls.w = rng.uniform(size=100)
+        cls.u = rng.uniform(size=100) + 1e6
 
     def test_1d_count(self):
         x = self.x

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -21,6 +21,7 @@ import numpy as np
 from numpy import typecodes, array
 from numpy.lib.recfunctions import rec_append_fields
 from scipy import special
+from scipy._lib._util import check_random_state
 from scipy.integrate import IntegrationWarning
 import scipy.stats as stats
 from scipy.stats._distn_infrastructure import argsreduce
@@ -1452,7 +1453,7 @@ class TestRvDiscrete(object):
 
 class TestSkewNorm(object):
     def setup_method(self):
-        np.random.seed(1234)
+        self.rng = check_random_state(1234)
 
     def test_normal(self):
         # When the skewness is 0 the distribution is normal
@@ -1462,19 +1463,21 @@ class TestSkewNorm(object):
 
     def test_rvs(self):
         shape = (3, 4, 5)
-        x = stats.skewnorm.rvs(a=0.75, size=shape)
+        x = stats.skewnorm.rvs(a=0.75, size=shape, random_state=self.rng)
         assert_equal(shape, x.shape)
 
-        x = stats.skewnorm.rvs(a=-3, size=shape)
+        x = stats.skewnorm.rvs(a=-3, size=shape, random_state=self.rng)
         assert_equal(shape, x.shape)
 
     def test_moments(self):
-        X = stats.skewnorm.rvs(a=4, size=int(1e6), loc=5, scale=2)
+        X = stats.skewnorm.rvs(a=4, size=int(1e6), loc=5, scale=2,
+                               random_state=self.rng)
         expected = [np.mean(X), np.var(X), stats.skew(X), stats.kurtosis(X)]
         computed = stats.skewnorm.stats(a=4, loc=5, scale=2, moments='mvsk')
         assert_array_almost_equal(computed, expected, decimal=2)
 
-        X = stats.skewnorm.rvs(a=-4, size=int(1e6), loc=5, scale=2)
+        X = stats.skewnorm.rvs(a=-4, size=int(1e6), loc=5, scale=2,
+                               random_state=self.rng)
         expected = [np.mean(X), np.var(X), stats.skew(X), stats.kurtosis(X)]
         computed = stats.skewnorm.stats(a=-4, loc=5, scale=2, moments='mvsk')
         assert_array_almost_equal(computed, expected, decimal=2)

--- a/scipy/stats/tests/test_kdeoth.py
+++ b/scipy/stats/tests/test_kdeoth.py
@@ -413,6 +413,15 @@ def test_seed():
         samp2 = gkde_trail.resample(n_sample, seed=rstate2)
         assert_allclose(samp1, samp2, atol=1e-13)
 
+        # check that np.random.Generator can be used (numpy >= 1.17)
+        try:
+            # obtain a np.random.Generator object
+            rng = np.random.default_rng(1234)
+            gkde_trail.resample(n_sample, seed=rng)
+        except AttributeError:
+            # only available in numpy >= 1.17
+            pass
+
     np.random.seed(8765678)
     n_basesample = 500
     wn = np.random.rand(n_basesample)

--- a/scipy/stats/tests/test_kdeoth.py
+++ b/scipy/stats/tests/test_kdeoth.py
@@ -414,13 +414,10 @@ def test_seed():
         assert_allclose(samp1, samp2, atol=1e-13)
 
         # check that np.random.Generator can be used (numpy >= 1.17)
-        try:
+        if hasattr(np.random, 'default_rng'):
             # obtain a np.random.Generator object
             rng = np.random.default_rng(1234)
             gkde_trail.resample(n_sample, seed=rng)
-        except AttributeError:
-            # only available in numpy >= 1.17
-            pass
 
     np.random.seed(8765678)
     n_basesample = 500


### PR DESCRIPTION
closes #11398. Allows `scipy.stats` to use `np.random.Generator` as well as the older legacy `np.random.RandomState`.