### PR TITLE
ENH: add docstring of butter() for transfer function syntax problem

### DIFF
--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -2842,13 +2842,11 @@ def butter(N, Wn, btype='low', analog=False, output='ba', fs=None):
 
     The ``'sos'`` output parameter was added in 0.16.0.
 
-    If you use the transfer function syntax [b, a], you might encounter
-    numerical problems. Because the conversion between roots and 
-    polynomial coefficients is a numerically sensitive operation.
-    Thus, conversion to a Transfer Function can be unstable
-    even for N = 4 and above. It is recommended to keep the SOS representation.
-    see "Numerical Instability of Transfer Function Syntax" 
-    at https://www.mathworks.com/help/signal/ref/butter.html
+    If the transfer function form ``[b, a]`` is requested, numerical
+    problems can occur since the conversion between roots and
+    the polynomial coefficients is a numerically sensitive operation,
+    even for N >= 4. It is recommended to work with the SOS
+    representation.
 
     Examples
     --------

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -2842,9 +2842,13 @@ def butter(N, Wn, btype='low', analog=False, output='ba', fs=None):
 
     The ``'sos'`` output parameter was added in 0.16.0.
 
-    If you use the transfer function syntax [b, a], you might encounter numerical problems.
-    These problems are due to round-off errors and can occur for N as low as 4. 
-    see "Numerical Instability of Transfer Function Syntax" at https://www.mathworks.com/help/signal/ref/butter.html
+    If you use the transfer function syntax [b, a], you might encounter
+    numerical problems. Because the conversion between roots and 
+    polynomial coefficients is a numerically sensitive operation.
+    Thus, conversion to a Transfer Function can be unstable
+    even for N = 4 and above. It is recommended to keep the SOS representation.
+    see "Numerical Instability of Transfer Function Syntax" 
+    at https://www.mathworks.com/help/signal/ref/butter.html
 
     Examples
     --------

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -2842,6 +2842,10 @@ def butter(N, Wn, btype='low', analog=False, output='ba', fs=None):
 
     The ``'sos'`` output parameter was added in 0.16.0.
 
+    If you use the transfer function syntax [b, a], you might encounter numerical problems.
+    These problems are due to round-off errors and can occur for N as low as 4. 
+    see "Numerical Instability of Transfer Function Syntax" at https://www.mathworks.com/help/signal/ref/butter.html
+
     Examples
     --------
     Design an analog filter and plot its frequency response, showing the


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
To fix #9197

#### What does this implement/fix?
add docstring of butter() for transfer function syntax problem
