### PR TITLE
ENH: Add a `plan` argument to FFT functions in `scipy.fft`

### DIFF
--- a/scipy/fft/_basic.py
+++ b/scipy/fft/_basic.py
@@ -53,6 +53,9 @@ def fft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
         Maximum number of workers to use for parallel computation. If negative,
         the value wraps around from ``os.cpu_count()``. See below for more
         details.
+    plan: object, optional
+        This argument is reserved for passing in a precomputed plan provided
+        by downstream FFT vendors. It is currently not used in SciPy.
 
     Returns
     -------
@@ -201,6 +204,9 @@ def ifft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
         Maximum number of workers to use for parallel computation. If negative,
         the value wraps around from ``os.cpu_count()``.
         See :func:`~scipy.fft.fft` for more details.
+    plan: object, optional
+        This argument is reserved for passing in a precomputed plan provided
+        by downstream FFT vendors. It is currently not used in SciPy.
 
     Returns
     -------
@@ -290,6 +296,9 @@ def rfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
         Maximum number of workers to use for parallel computation. If negative,
         the value wraps around from ``os.cpu_count()``.
         See :func:`~scipy.fft.fft` for more details.
+    plan: object, optional
+        This argument is reserved for passing in a precomputed plan provided
+        by downstream FFT vendors. It is currently not used in SciPy.
 
     Returns
     -------
@@ -390,6 +399,9 @@ def irfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
         Maximum number of workers to use for parallel computation. If negative,
         the value wraps around from ``os.cpu_count()``.
         See :func:`~scipy.fft.fft` for more details.
+    plan: object, optional
+        This argument is reserved for passing in a precomputed plan provided
+        by downstream FFT vendors. It is currently not used in SciPy.
 
     Returns
     -------
@@ -479,6 +491,9 @@ def hfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
         Maximum number of workers to use for parallel computation. If negative,
         the value wraps around from ``os.cpu_count()``.
         See :func:`~scipy.fft.fft` for more details.
+    plan: object, optional
+        This argument is reserved for passing in a precomputed plan provided
+        by downstream FFT vendors. It is currently not used in SciPy.
 
     Returns
     -------
@@ -557,6 +572,9 @@ def ihfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
         Maximum number of workers to use for parallel computation. If negative,
         the value wraps around from ``os.cpu_count()``.
         See :func:`~scipy.fft.fft` for more details.
+    plan: object, optional
+        This argument is reserved for passing in a precomputed plan provided
+        by downstream FFT vendors. It is currently not used in SciPy.
 
     Returns
     -------
@@ -627,6 +645,9 @@ def fftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
         Maximum number of workers to use for parallel computation. If negative,
         the value wraps around from ``os.cpu_count()``.
         See :func:`~scipy.fft.fft` for more details.
+    plan: object, optional
+        This argument is reserved for passing in a precomputed plan provided
+        by downstream FFT vendors. It is currently not used in SciPy.
 
     Returns
     -------
@@ -736,6 +757,9 @@ def ifftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
         Maximum number of workers to use for parallel computation. If negative,
         the value wraps around from ``os.cpu_count()``.
         See :func:`~scipy.fft.fft` for more details.
+    plan: object, optional
+        This argument is reserved for passing in a precomputed plan provided
+        by downstream FFT vendors. It is currently not used in SciPy.
 
     Returns
     -------
@@ -829,6 +853,9 @@ def fft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None, *
         Maximum number of workers to use for parallel computation. If negative,
         the value wraps around from ``os.cpu_count()``.
         See :func:`~scipy.fft.fft` for more details.
+    plan: object, optional
+        This argument is reserved for passing in a precomputed plan provided
+        by downstream FFT vendors. It is currently not used in SciPy.
 
     Returns
     -------
@@ -932,6 +959,9 @@ def ifft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None, 
         Maximum number of workers to use for parallel computation. If negative,
         the value wraps around from ``os.cpu_count()``.
         See :func:`~scipy.fft.fft` for more details.
+    plan: object, optional
+        This argument is reserved for passing in a precomputed plan provided
+        by downstream FFT vendors. It is currently not used in SciPy.
 
     Returns
     -------
@@ -1020,6 +1050,9 @@ def rfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
         Maximum number of workers to use for parallel computation. If negative,
         the value wraps around from ``os.cpu_count()``.
         See :func:`~scipy.fft.fft` for more details.
+    plan: object, optional
+        This argument is reserved for passing in a precomputed plan provided
+        by downstream FFT vendors. It is currently not used in SciPy.
 
     Returns
     -------
@@ -1103,6 +1136,9 @@ def rfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None, 
         Maximum number of workers to use for parallel computation. If negative,
         the value wraps around from ``os.cpu_count()``.
         See :func:`~scipy.fft.fft` for more details.
+    plan: object, optional
+        This argument is reserved for passing in a precomputed plan provided
+        by downstream FFT vendors. It is currently not used in SciPy.
 
     Returns
     -------
@@ -1169,6 +1205,9 @@ def irfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
         Maximum number of workers to use for parallel computation. If negative,
         the value wraps around from ``os.cpu_count()``.
         See :func:`~scipy.fft.fft` for more details.
+    plan: object, optional
+        This argument is reserved for passing in a precomputed plan provided
+        by downstream FFT vendors. It is currently not used in SciPy.
 
     Returns
     -------
@@ -1254,6 +1293,9 @@ def irfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None,
         Maximum number of workers to use for parallel computation. If negative,
         the value wraps around from ``os.cpu_count()``.
         See :func:`~scipy.fft.fft` for more details.
+    plan: object, optional
+        This argument is reserved for passing in a precomputed plan provided
+        by downstream FFT vendors. It is currently not used in SciPy.
 
     Returns
     -------
@@ -1316,6 +1358,9 @@ def hfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
         Maximum number of workers to use for parallel computation. If negative,
         the value wraps around from ``os.cpu_count()``.
         See :func:`~scipy.fft.fft` for more details.
+    plan: object, optional
+        This argument is reserved for passing in a precomputed plan provided
+        by downstream FFT vendors. It is currently not used in SciPy.
 
     Returns
     -------
@@ -1410,6 +1455,9 @@ def hfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None, 
         Maximum number of workers to use for parallel computation. If negative,
         the value wraps around from ``os.cpu_count()``.
         See :func:`~scipy.fft.fft` for more details.
+    plan: object, optional
+        This argument is reserved for passing in a precomputed plan provided
+        by downstream FFT vendors. It is currently not used in SciPy.
 
     Returns
     -------
@@ -1469,6 +1517,9 @@ def ihfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
         Maximum number of workers to use for parallel computation. If negative,
         the value wraps around from ``os.cpu_count()``.
         See :func:`~scipy.fft.fft` for more details.
+    plan: object, optional
+        This argument is reserved for passing in a precomputed plan provided
+        by downstream FFT vendors. It is currently not used in SciPy.
 
     Returns
     -------
@@ -1549,6 +1600,9 @@ def ihfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None,
         Maximum number of workers to use for parallel computation. If negative,
         the value wraps around from ``os.cpu_count()``.
         See :func:`~scipy.fft.fft` for more details.
+    plan: object, optional
+        This argument is reserved for passing in a precomputed plan provided
+        by downstream FFT vendors. It is currently not used in SciPy.
 
     Returns
     -------

--- a/scipy/fft/_basic.py
+++ b/scipy/fft/_basic.py
@@ -21,7 +21,8 @@ def _dispatch(func):
 
 
 @_dispatch
-def fft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
+def fft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
+        plan=None):
     """
     Compute the 1-D discrete Fourier Transform.
 
@@ -150,12 +151,15 @@ def fft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
     >>> plt.show()
 
     """
-
+    if plan is not None:
+        raise NotImplementedError('Passing a precomputed plan is not yet '
+                                  'supported by scipy.fft functions')
     return (Dispatchable(x, np.ndarray),)
 
 
 @_dispatch
-def ifft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
+def ifft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
+         plan=None):
     """
     Compute the 1-D inverse discrete Fourier Transform.
 
@@ -249,11 +253,15 @@ def ifft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
     >>> plt.show()
 
     """
+    if plan is not None:
+        raise NotImplementedError('Passing a precomputed plan is not yet '
+                                  'supported by scipy.fft functions')
     return (Dispatchable(x, np.ndarray),)
 
 
 @_dispatch
-def rfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
+def rfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
+         plan=None):
     """
     Compute the 1-D discrete Fourier Transform for real input.
 
@@ -336,11 +344,15 @@ def rfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
     exploited to compute only the non-negative frequency terms.
 
     """
+    if plan is not None:
+        raise NotImplementedError('Passing a precomputed plan is not yet '
+                                  'supported by scipy.fft functions')
     return (Dispatchable(x, np.ndarray),)
 
 
 @_dispatch
-def irfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
+def irfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
+          plan=None):
     """
     Compute the inverse of the n-point DFT for real input.
 
@@ -431,11 +443,15 @@ def irfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
     specified, and the output array is purely real.
 
     """
+    if plan is not None:
+        raise NotImplementedError('Passing a precomputed plan is not yet '
+                                  'supported by scipy.fft functions')
     return (Dispatchable(x, np.ndarray),)
 
 
 @_dispatch
-def hfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
+def hfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
+         plan=None):
     """
     Compute the FFT of a signal that has Hermitian symmetry, i.e., a real
     spectrum.
@@ -507,11 +523,15 @@ def hfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
     >>> hfft(signal, 10)  # Input entire signal and truncate
     array([  0.,   5.,   0.,  15.,  -0.,   0.,   0., -15.,  -0.,   5.])
     """
+    if plan is not None:
+        raise NotImplementedError('Passing a precomputed plan is not yet '
+                                  'supported by scipy.fft functions')
     return (Dispatchable(x, np.ndarray),)
 
 
 @_dispatch
-def ihfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
+def ihfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
+          plan=None):
     """
     Compute the inverse FFT of a signal that has Hermitian symmetry.
 
@@ -567,11 +587,15 @@ def ihfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
     >>> ihfft(spectrum)
     array([ 1.-0.j,  2.-0.j,  3.-0.j,  4.-0.j]) # may vary
     """
+    if plan is not None:
+        raise NotImplementedError('Passing a precomputed plan is not yet '
+                                  'supported by scipy.fft functions')
     return (Dispatchable(x, np.ndarray),)
 
 
 @_dispatch
-def fftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
+def fftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
+         plan=None):
     """
     Compute the N-D discrete Fourier Transform.
 
@@ -664,12 +688,15 @@ def fftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
     >>> plt.show()
 
     """
-
+    if plan is not None:
+        raise NotImplementedError('Passing a precomputed plan is not yet '
+                                  'supported by scipy.fft functions')
     return (Dispatchable(x, np.ndarray),)
 
 
 @_dispatch
-def ifftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
+def ifftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
+          plan=None):
     """
     Compute the N-D inverse discrete Fourier Transform.
 
@@ -761,11 +788,15 @@ def ifftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
     >>> plt.show()
 
     """
+    if plan is not None:
+        raise NotImplementedError('Passing a precomputed plan is not yet '
+                                  'supported by scipy.fft functions')
     return (Dispatchable(x, np.ndarray),)
 
 
 @_dispatch
-def fft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None):
+def fft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None, *,
+         plan=None):
     """
     Compute the 2-D discrete Fourier Transform
 
@@ -853,12 +884,15 @@ def fft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None):
               0.  +0.j        ,   0.  +0.j        ]])
 
     """
-
+    if plan is not None:
+        raise NotImplementedError('Passing a precomputed plan is not yet '
+                                  'supported by scipy.fft functions')
     return (Dispatchable(x, np.ndarray),)
 
 
 @_dispatch
-def ifft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None):
+def ifft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None, *,
+          plan=None):
     """
     Compute the 2-D inverse discrete Fourier Transform.
 
@@ -943,12 +977,15 @@ def ifft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None):
            [0.+0.j,  1.+0.j,  0.+0.j,  0.+0.j]])
 
     """
-
+    if plan is not None:
+        raise NotImplementedError('Passing a precomputed plan is not yet '
+                                  'supported by scipy.fft functions')
     return (Dispatchable(x, np.ndarray),)
 
 
 @_dispatch
-def rfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
+def rfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
+          plan=None):
     """
     Compute the N-D discrete Fourier Transform for real input.
 
@@ -1037,11 +1074,15 @@ def rfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
             [0.+0.j,  0.+0.j]]])
 
     """
+    if plan is not None:
+        raise NotImplementedError('Passing a precomputed plan is not yet '
+                                  'supported by scipy.fft functions')
     return (Dispatchable(x, np.ndarray),)
 
 
 @_dispatch
-def rfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None):
+def rfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None, *,
+          plan=None):
     """
     Compute the 2-D FFT of a real array.
 
@@ -1079,12 +1120,15 @@ def rfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None):
     For more details see `rfftn`.
 
     """
-
+    if plan is not None:
+        raise NotImplementedError('Passing a precomputed plan is not yet '
+                                  'supported by scipy.fft functions')
     return (Dispatchable(x, np.ndarray),)
 
 
 @_dispatch
-def irfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
+def irfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
+           plan=None):
     """
     Compute the inverse of the N-D FFT of real input.
 
@@ -1180,12 +1224,15 @@ def irfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
             [1.,  1.]]])
 
     """
+    if plan is not None:
+        raise NotImplementedError('Passing a precomputed plan is not yet '
+                                  'supported by scipy.fft functions')
     return (Dispatchable(x, np.ndarray),)
 
 
 @_dispatch
-def irfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False,
-           workers=None):
+def irfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None, *,
+           plan=None):
     """
     Compute the 2-D inverse FFT of a real array.
 
@@ -1223,11 +1270,15 @@ def irfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False,
     For more details see `irfftn`.
 
     """
+    if plan is not None:
+        raise NotImplementedError('Passing a precomputed plan is not yet '
+                                  'supported by scipy.fft functions')
     return (Dispatchable(x, np.ndarray),)
 
 
 @_dispatch
-def hfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
+def hfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
+          plan=None):
     """
     Compute the N-D FFT of Hermitian symmetric complex input, i.e., a
     signal with a real spectrum.
@@ -1330,11 +1381,15 @@ def hfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
             [ 0.,  0.]]])
 
     """
+    if plan is not None:
+        raise NotImplementedError('Passing a precomputed plan is not yet '
+                                  'supported by scipy.fft functions')
     return (Dispatchable(x, np.ndarray),)
 
 
 @_dispatch
-def hfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None):
+def hfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None, *,
+          plan=None):
     """
     Compute the 2-D FFT of a Hermitian complex array.
 
@@ -1372,11 +1427,15 @@ def hfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None):
     For more details see `hfftn`.
 
     """
+    if plan is not None:
+        raise NotImplementedError('Passing a precomputed plan is not yet '
+                                  'supported by scipy.fft functions')
     return (Dispatchable(x, np.ndarray),)
 
 
 @_dispatch
-def ihfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
+def ihfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
+           plan=None):
     """
     Compute the N-D inverse discrete Fourier Transform for a real
     spectrum.
@@ -1460,12 +1519,15 @@ def ihfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
             [0.+0.j,  0.+0.j]]])
 
     """
+    if plan is not None:
+        raise NotImplementedError('Passing a precomputed plan is not yet '
+                                  'supported by scipy.fft functions')
     return (Dispatchable(x, np.ndarray),)
 
 
 @_dispatch
-def ihfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False,
-           workers=None):
+def ihfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None, *,
+           plan=None):
     """
     Compute the 2-D inverse FFT of a real spectrum.
 
@@ -1503,4 +1565,7 @@ def ihfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False,
     For more details see `ihfftn`.
 
     """
+    if plan is not None:
+        raise NotImplementedError('Passing a precomputed plan is not yet '
+                                  'supported by scipy.fft functions')
     return (Dispatchable(x, np.ndarray),)

--- a/scipy/fft/_basic.py
+++ b/scipy/fft/_basic.py
@@ -154,9 +154,6 @@ def fft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
     >>> plt.show()
 
     """
-    if plan is not None:
-        raise NotImplementedError('Passing a precomputed plan is not yet '
-                                  'supported by scipy.fft functions')
     return (Dispatchable(x, np.ndarray),)
 
 
@@ -259,9 +256,6 @@ def ifft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
     >>> plt.show()
 
     """
-    if plan is not None:
-        raise NotImplementedError('Passing a precomputed plan is not yet '
-                                  'supported by scipy.fft functions')
     return (Dispatchable(x, np.ndarray),)
 
 
@@ -353,9 +347,6 @@ def rfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
     exploited to compute only the non-negative frequency terms.
 
     """
-    if plan is not None:
-        raise NotImplementedError('Passing a precomputed plan is not yet '
-                                  'supported by scipy.fft functions')
     return (Dispatchable(x, np.ndarray),)
 
 
@@ -455,9 +446,6 @@ def irfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
     specified, and the output array is purely real.
 
     """
-    if plan is not None:
-        raise NotImplementedError('Passing a precomputed plan is not yet '
-                                  'supported by scipy.fft functions')
     return (Dispatchable(x, np.ndarray),)
 
 
@@ -538,9 +526,6 @@ def hfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
     >>> hfft(signal, 10)  # Input entire signal and truncate
     array([  0.,   5.,   0.,  15.,  -0.,   0.,   0., -15.,  -0.,   5.])
     """
-    if plan is not None:
-        raise NotImplementedError('Passing a precomputed plan is not yet '
-                                  'supported by scipy.fft functions')
     return (Dispatchable(x, np.ndarray),)
 
 
@@ -605,9 +590,6 @@ def ihfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
     >>> ihfft(spectrum)
     array([ 1.-0.j,  2.-0.j,  3.-0.j,  4.-0.j]) # may vary
     """
-    if plan is not None:
-        raise NotImplementedError('Passing a precomputed plan is not yet '
-                                  'supported by scipy.fft functions')
     return (Dispatchable(x, np.ndarray),)
 
 
@@ -709,9 +691,6 @@ def fftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
     >>> plt.show()
 
     """
-    if plan is not None:
-        raise NotImplementedError('Passing a precomputed plan is not yet '
-                                  'supported by scipy.fft functions')
     return (Dispatchable(x, np.ndarray),)
 
 
@@ -812,9 +791,6 @@ def ifftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
     >>> plt.show()
 
     """
-    if plan is not None:
-        raise NotImplementedError('Passing a precomputed plan is not yet '
-                                  'supported by scipy.fft functions')
     return (Dispatchable(x, np.ndarray),)
 
 
@@ -911,9 +887,6 @@ def fft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None, *
               0.  +0.j        ,   0.  +0.j        ]])
 
     """
-    if plan is not None:
-        raise NotImplementedError('Passing a precomputed plan is not yet '
-                                  'supported by scipy.fft functions')
     return (Dispatchable(x, np.ndarray),)
 
 
@@ -1007,9 +980,6 @@ def ifft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None, 
            [0.+0.j,  1.+0.j,  0.+0.j,  0.+0.j]])
 
     """
-    if plan is not None:
-        raise NotImplementedError('Passing a precomputed plan is not yet '
-                                  'supported by scipy.fft functions')
     return (Dispatchable(x, np.ndarray),)
 
 
@@ -1107,9 +1077,6 @@ def rfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
             [0.+0.j,  0.+0.j]]])
 
     """
-    if plan is not None:
-        raise NotImplementedError('Passing a precomputed plan is not yet '
-                                  'supported by scipy.fft functions')
     return (Dispatchable(x, np.ndarray),)
 
 
@@ -1156,9 +1123,6 @@ def rfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None, 
     For more details see `rfftn`.
 
     """
-    if plan is not None:
-        raise NotImplementedError('Passing a precomputed plan is not yet '
-                                  'supported by scipy.fft functions')
     return (Dispatchable(x, np.ndarray),)
 
 
@@ -1263,9 +1227,6 @@ def irfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
             [1.,  1.]]])
 
     """
-    if plan is not None:
-        raise NotImplementedError('Passing a precomputed plan is not yet '
-                                  'supported by scipy.fft functions')
     return (Dispatchable(x, np.ndarray),)
 
 
@@ -1312,9 +1273,6 @@ def irfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None,
     For more details see `irfftn`.
 
     """
-    if plan is not None:
-        raise NotImplementedError('Passing a precomputed plan is not yet '
-                                  'supported by scipy.fft functions')
     return (Dispatchable(x, np.ndarray),)
 
 
@@ -1426,9 +1384,6 @@ def hfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
             [ 0.,  0.]]])
 
     """
-    if plan is not None:
-        raise NotImplementedError('Passing a precomputed plan is not yet '
-                                  'supported by scipy.fft functions')
     return (Dispatchable(x, np.ndarray),)
 
 
@@ -1475,9 +1430,6 @@ def hfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None, 
     For more details see `hfftn`.
 
     """
-    if plan is not None:
-        raise NotImplementedError('Passing a precomputed plan is not yet '
-                                  'supported by scipy.fft functions')
     return (Dispatchable(x, np.ndarray),)
 
 
@@ -1570,9 +1522,6 @@ def ihfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
             [0.+0.j,  0.+0.j]]])
 
     """
-    if plan is not None:
-        raise NotImplementedError('Passing a precomputed plan is not yet '
-                                  'supported by scipy.fft functions')
     return (Dispatchable(x, np.ndarray),)
 
 
@@ -1619,7 +1568,4 @@ def ihfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None,
     For more details see `ihfftn`.
 
     """
-    if plan is not None:
-        raise NotImplementedError('Passing a precomputed plan is not yet '
-                                  'supported by scipy.fft functions')
     return (Dispatchable(x, np.ndarray),)

--- a/scipy/fft/_basic.py
+++ b/scipy/fft/_basic.py
@@ -57,6 +57,8 @@ def fft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
         This argument is reserved for passing in a precomputed plan provided
         by downstream FFT vendors. It is currently not used in SciPy.
 
+        .. versionadded:: 1.5.0
+
     Returns
     -------
     out : complex ndarray
@@ -205,6 +207,8 @@ def ifft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
         This argument is reserved for passing in a precomputed plan provided
         by downstream FFT vendors. It is currently not used in SciPy.
 
+        .. versionadded:: 1.5.0
+
     Returns
     -------
     out : complex ndarray
@@ -293,6 +297,8 @@ def rfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
     plan: object, optional
         This argument is reserved for passing in a precomputed plan provided
         by downstream FFT vendors. It is currently not used in SciPy.
+
+        .. versionadded:: 1.5.0
 
     Returns
     -------
@@ -394,6 +400,8 @@ def irfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
         This argument is reserved for passing in a precomputed plan provided
         by downstream FFT vendors. It is currently not used in SciPy.
 
+        .. versionadded:: 1.5.0
+
     Returns
     -------
     out : ndarray
@@ -483,6 +491,8 @@ def hfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
         This argument is reserved for passing in a precomputed plan provided
         by downstream FFT vendors. It is currently not used in SciPy.
 
+        .. versionadded:: 1.5.0
+
     Returns
     -------
     out : ndarray
@@ -561,6 +571,8 @@ def ihfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
         This argument is reserved for passing in a precomputed plan provided
         by downstream FFT vendors. It is currently not used in SciPy.
 
+        .. versionadded:: 1.5.0
+
     Returns
     -------
     out : complex ndarray
@@ -630,6 +642,8 @@ def fftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
     plan: object, optional
         This argument is reserved for passing in a precomputed plan provided
         by downstream FFT vendors. It is currently not used in SciPy.
+
+        .. versionadded:: 1.5.0
 
     Returns
     -------
@@ -740,6 +754,8 @@ def ifftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
         This argument is reserved for passing in a precomputed plan provided
         by downstream FFT vendors. It is currently not used in SciPy.
 
+        .. versionadded:: 1.5.0
+
     Returns
     -------
     out : complex ndarray
@@ -832,6 +848,8 @@ def fft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None, *
     plan: object, optional
         This argument is reserved for passing in a precomputed plan provided
         by downstream FFT vendors. It is currently not used in SciPy.
+
+        .. versionadded:: 1.5.0
 
     Returns
     -------
@@ -936,6 +954,8 @@ def ifft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None, 
         This argument is reserved for passing in a precomputed plan provided
         by downstream FFT vendors. It is currently not used in SciPy.
 
+        .. versionadded:: 1.5.0
+
     Returns
     -------
     out : complex ndarray
@@ -1024,6 +1044,8 @@ def rfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
         This argument is reserved for passing in a precomputed plan provided
         by downstream FFT vendors. It is currently not used in SciPy.
 
+        .. versionadded:: 1.5.0
+
     Returns
     -------
     out : complex ndarray
@@ -1107,6 +1129,8 @@ def rfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None, 
         This argument is reserved for passing in a precomputed plan provided
         by downstream FFT vendors. It is currently not used in SciPy.
 
+        .. versionadded:: 1.5.0
+
     Returns
     -------
     out : ndarray
@@ -1172,6 +1196,8 @@ def irfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
     plan: object, optional
         This argument is reserved for passing in a precomputed plan provided
         by downstream FFT vendors. It is currently not used in SciPy.
+
+        .. versionadded:: 1.5.0
 
     Returns
     -------
@@ -1258,6 +1284,8 @@ def irfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None,
         This argument is reserved for passing in a precomputed plan provided
         by downstream FFT vendors. It is currently not used in SciPy.
 
+        .. versionadded:: 1.5.0
+
     Returns
     -------
     out : ndarray
@@ -1319,6 +1347,8 @@ def hfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
     plan: object, optional
         This argument is reserved for passing in a precomputed plan provided
         by downstream FFT vendors. It is currently not used in SciPy.
+
+        .. versionadded:: 1.5.0
 
     Returns
     -------
@@ -1414,6 +1444,8 @@ def hfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None, 
         This argument is reserved for passing in a precomputed plan provided
         by downstream FFT vendors. It is currently not used in SciPy.
 
+        .. versionadded:: 1.5.0
+
     Returns
     -------
     out : ndarray
@@ -1472,6 +1504,8 @@ def ihfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
     plan: object, optional
         This argument is reserved for passing in a precomputed plan provided
         by downstream FFT vendors. It is currently not used in SciPy.
+
+        .. versionadded:: 1.5.0
 
     Returns
     -------
@@ -1552,6 +1586,8 @@ def ihfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None,
     plan: object, optional
         This argument is reserved for passing in a precomputed plan provided
         by downstream FFT vendors. It is currently not used in SciPy.
+
+        .. versionadded:: 1.5.0
 
     Returns
     -------

--- a/scipy/fft/_pocketfft/basic.py
+++ b/scipy/fft/_pocketfft/basic.py
@@ -11,8 +11,11 @@ from .helper import (_asfarray, _init_nd_shape_and_axes, _datacopied,
                      _workers)
 
 def c2c(forward, x, n=None, axis=-1, norm=None, overwrite_x=False,
-        workers=None):
+        workers=None, *, plan=None):
     """ Return discrete Fourier transform of real or complex sequence. """
+    if plan is not None:
+        raise NotImplementedError('Passing a precomputed plan is not yet '
+                                  'supported by scipy.fft functions')
     tmp = _asfarray(x)
     overwrite_x = overwrite_x or _datacopied(tmp, x)
     norm = _normalization(norm, forward)
@@ -37,10 +40,13 @@ ifft.__name__ = 'ifft'
 
 
 def r2c(forward, x, n=None, axis=-1, norm=None, overwrite_x=False,
-        workers=None):
+        workers=None, *, plan=None):
     """
     Discrete Fourier transform of a real sequence.
     """
+    if plan is not None:
+        raise NotImplementedError('Passing a precomputed plan is not yet '
+                                  'supported by scipy.fft functions')
     tmp = _asfarray(x)
     norm = _normalization(norm, forward)
     workers = _workers(workers)
@@ -65,10 +71,13 @@ ihfft.__name__ = 'ihfft'
 
 
 def c2r(forward, x, n=None, axis=-1, norm=None, overwrite_x=False,
-        workers=None):
+        workers=None, *, plan=None):
     """
     Return inverse discrete Fourier transform of real sequence x.
     """
+    if plan is not None:
+        raise NotImplementedError('Passing a precomputed plan is not yet '
+                                  'supported by scipy.fft functions')
     tmp = _asfarray(x)
     norm = _normalization(norm, forward)
     workers = _workers(workers)
@@ -96,53 +105,80 @@ irfft = functools.partial(c2r, False)
 irfft.__name__ = 'irfft'
 
 
-def fft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False, workers=None):
+def fft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False, workers=None,
+         *, plan=None):
     """
     2-D discrete Fourier transform.
     """
+    if plan is not None:
+        raise NotImplementedError('Passing a precomputed plan is not yet '
+                                  'supported by scipy.fft functions')
     return fftn(x, s, axes, norm, overwrite_x, workers)
 
 
-def ifft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False, workers=None):
+def ifft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False, workers=None,
+          *, plan=None):
     """
     2-D discrete inverse Fourier transform of real or complex sequence.
     """
+    if plan is not None:
+        raise NotImplementedError('Passing a precomputed plan is not yet '
+                                  'supported by scipy.fft functions')
     return ifftn(x, s, axes, norm, overwrite_x, workers)
 
 
-def rfft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False, workers=None):
+def rfft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False, workers=None,
+          *, plan=None):
     """
     2-D discrete Fourier transform of a real sequence
     """
+    if plan is not None:
+        raise NotImplementedError('Passing a precomputed plan is not yet '
+                                  'supported by scipy.fft functions')
     return rfftn(x, s, axes, norm, overwrite_x, workers)
 
 
-def irfft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False, workers=None):
+def irfft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False, workers=None,
+           *, plan=None):
     """
     2-D discrete inverse Fourier transform of a real sequence
     """
+    if plan is not None:
+        raise NotImplementedError('Passing a precomputed plan is not yet '
+                                  'supported by scipy.fft functions')
     return irfftn(x, s, axes, norm, overwrite_x, workers)
 
 
-def hfft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False, workers=None):
+def hfft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False, workers=None,
+          *, plan=None):
     """
     2-D discrete Fourier transform of a Hermitian sequence
     """
+    if plan is not None:
+        raise NotImplementedError('Passing a precomputed plan is not yet '
+                                  'supported by scipy.fft functions')
     return hfftn(x, s, axes, norm, overwrite_x, workers)
 
 
-def ihfft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False, workers=None):
+def ihfft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False, workers=None,
+           *, plan=None):
     """
     2-D discrete inverse Fourier transform of a Hermitian sequence
     """
+    if plan is not None:
+        raise NotImplementedError('Passing a precomputed plan is not yet '
+                                  'supported by scipy.fft functions')
     return ihfftn(x, s, axes, norm, overwrite_x, workers)
 
 
 def c2cn(forward, x, s=None, axes=None, norm=None, overwrite_x=False,
-         workers=None):
+         workers=None, *, plan=None):
     """
     Return multidimensional discrete Fourier transform.
     """
+    if plan is not None:
+        raise NotImplementedError('Passing a precomputed plan is not yet '
+                                  'supported by scipy.fft functions')
     tmp = _asfarray(x)
 
     shape, axes = _init_nd_shape_and_axes(tmp, s, axes)
@@ -167,8 +203,11 @@ ifftn = functools.partial(c2cn, False)
 ifftn.__name__ = 'ifftn'
 
 def r2cn(forward, x, s=None, axes=None, norm=None, overwrite_x=False,
-         workers=None):
+         workers=None, *, plan=None):
     """Return multidimensional discrete Fourier transform of real input"""
+    if plan is not None:
+        raise NotImplementedError('Passing a precomputed plan is not yet '
+                                  'supported by scipy.fft functions')
     tmp = _asfarray(x)
 
     if not np.isrealobj(tmp):
@@ -193,8 +232,11 @@ ihfftn.__name__ = 'ihfftn'
 
 
 def c2rn(forward, x, s=None, axes=None, norm=None, overwrite_x=False,
-         workers=None):
+         workers=None, *, plan=None):
     """Multidimensional inverse discrete fourier transform with real output"""
+    if plan is not None:
+        raise NotImplementedError('Passing a precomputed plan is not yet '
+                                  'supported by scipy.fft functions')
     tmp = _asfarray(x)
 
     # TODO: Optimize for hermitian and real?

--- a/scipy/fft/tests/test_backend.py
+++ b/scipy/fft/tests/test_backend.py
@@ -57,3 +57,33 @@ def test_backend_call(func, np_func, mock):
         assert_equal(mock.number_calls, 1)
 
     assert_allclose(func(x), answer, atol=1e-10)
+
+
+plan_funcs = (scipy.fft.fft, scipy.fft.fft2, scipy.fft.fftn,
+              scipy.fft.ifft, scipy.fft.ifft2, scipy.fft.ifftn,
+              scipy.fft.rfft, scipy.fft.rfft2, scipy.fft.rfftn,
+              scipy.fft.irfft, scipy.fft.irfft2, scipy.fft.irfftn,
+              scipy.fft.hfft, scipy.fft.hfft2, scipy.fft.hfftn,
+              scipy.fft.ihfft, scipy.fft.ihfft2, scipy.fft.ihfftn)
+
+plan_mocks = (mock_backend.fft, mock_backend.fft2, mock_backend.fftn,
+              mock_backend.ifft, mock_backend.ifft2, mock_backend.ifftn,
+              mock_backend.rfft, mock_backend.rfft2, mock_backend.rfftn,
+              mock_backend.irfft, mock_backend.irfft2, mock_backend.irfftn,
+              mock_backend.hfft, mock_backend.hfft2, mock_backend.hfftn,
+              mock_backend.ihfft, mock_backend.ihfft2, mock_backend.ihfftn)
+
+
+@pytest.mark.parametrize("func, mock", zip(plan_funcs, plan_mocks))
+def test_backend_plan(func, mock):
+    x = np.arange(20).reshape((10, 2))
+
+    with pytest.raises(NotImplementedError, match='precomputed plan'):
+        func(x, plan='foo')
+
+    with set_backend(mock_backend, only=True):
+        mock.number_calls = 0
+        y = func(x, plan='foo')
+        assert_equal(y, mock.return_value)
+        assert_equal(mock.number_calls, 1)
+        assert_equal(mock.last_args[1]['plan'], 'foo')


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #10302.

#### What does this implement/fix?
<!--Please explain your changes.-->
As discussed, a keyword-only argument `plan` is reserved and added to all FFT functions in `scipy.fft` for possible extensions by 3rd party FFT vendors. DST and DCT functions are not touched, as it seems neither FFTW nor cuFFT supports them.

#### Additional information
<!--Any additional information you think is important.-->
I have two questions:
1. Do we want to document this argument given that it's not usable in SciPy itself? If we do, is the following docstring OK?
```python
'''
plan: object, optional
    This argument is reserved for passing in a precomputed plan provided by downstream
    FFT vendors. It is currently not used in SciPy.
'''
```
2. Do we want to test it? If so, where should I add the test?

Thanks!

cc: @peterbell10 @larsoner @grlee77 