### PR TITLE
MAINT: check minimize duplicate evaluations

### DIFF
--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -1111,10 +1111,8 @@ class TestOptimizeSimple(CheckOptimize):
                       'dogleg'):
             hess = self.hess
 
-        x = self.startparams
-        self.trace = []
-
-        optimize.minimize(self.func, x, method=method, jac=jac, hess=hess)
+        optimize.minimize(self.func, self.startparams,
+                          method=method, jac=jac, hess=hess)
         for i in range(1, len(self.trace)):
             if np.array_equal(self.trace[i - 1], self.trace[i]):
                 raise RuntimeError(

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -1096,6 +1096,30 @@ class TestOptimizeSimple(CheckOptimize):
                                         options=dict(maxiter=20))
                 assert_equal(sol.success, False)
 
+    @pytest.mark.parametrize('method', ['nelder-mead', 'cg', 'bfgs',
+                                        'l-bfgs-b', 'tnc',
+                                        'cobyla', 'slsqp', 'trust-constr',
+                                        'dogleg', 'trust-ncg', 'trust-exact',
+                                        'trust-krylov'])
+    def test_duplicate_evaluations(self, method):
+        # check that there are no duplicate evaluations for any methods
+        jac = hess = None
+        if method in ('newton-cg', 'trust-krylov', 'trust-exact',
+                      'trust-ncg', 'dogleg'):
+            jac = self.grad
+        if method in ('trust-krylov', 'trust-exact', 'trust-ncg',
+                      'dogleg'):
+            hess = self.hess
+
+        x = self.startparams
+        self.trace = []
+
+        optimize.minimize(self.func, x, method=method, jac=jac, hess=hess)
+        for i in range(1, len(self.trace)):
+            if np.array_equal(self.trace[i - 1], self.trace[i]):
+                raise RuntimeError(
+                    "Duplicate evaluations made by {}".format(method))
+
 
 class TestLBFGSBBounds(object):
     def setup_method(self):

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -1114,8 +1114,6 @@ class TestOptimizeSimple(CheckOptimize):
         with np.errstate(invalid='ignore'), suppress_warnings() as sup:
             # for trust-constr
             sup.filter(UserWarning, "delta_grad == 0.*")
-            sup.filter(RuntimeWarning, ".*does not use Hessian.*")
-            sup.filter(RuntimeWarning, ".*does not use gradient.*")
             optimize.minimize(self.func, self.startparams,
                               method=method, jac=jac, hess=hess)
 

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -1111,8 +1111,14 @@ class TestOptimizeSimple(CheckOptimize):
                       'dogleg'):
             hess = self.hess
 
-        optimize.minimize(self.func, self.startparams,
-                          method=method, jac=jac, hess=hess)
+        with np.errstate(invalid='ignore'), suppress_warnings() as sup:
+            # for trust-constr
+            sup.filter(UserWarning, "delta_grad == 0.*")
+            sup.filter(RuntimeWarning, ".*does not use Hessian.*")
+            sup.filter(RuntimeWarning, ".*does not use gradient.*")
+            optimize.minimize(self.func, self.startparams,
+                              method=method, jac=jac, hess=hess)
+
         for i in range(1, len(self.trace)):
             if np.array_equal(self.trace[i - 1], self.trace[i]):
                 raise RuntimeError(


### PR DESCRIPTION
closes #11231 

Note methods 'powell' and 'newton-cg' are missing. They appear to have duplicate evaluations. I'll open a separate issue for that.