### PR TITLE
BUG: Fix _lib._util.getargspec_no_self KEYWORD_ONLY support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -143,8 +143,7 @@ before_install:
       export PATH=$TRAVIS_BUILD_DIR/gcc_aliases:$PATH
       popd
       touch config.sh
-      git clone https://github.com/matthew-brett/multibuild.git
-      git -C multibuild checkout 65fd07a180046b4473b21e9084e01f1bf1a8dfac
+      git clone --depth=1 https://github.com/matthew-brett/multibuild.git
       source multibuild/common_utils.sh
       source multibuild/travis_steps.sh
       before_install

--- a/.travis.yml
+++ b/.travis.yml
@@ -171,6 +171,8 @@ before_install:
       echo "library_dirs = $TRAVIS_BUILD_DIR/openblas/usr/local/lib" >> site.cfg
       echo "include_dirs = $TRAVIS_BUILD_DIR/openblas/usr/local/include" >> site.cfg
       echo "runtime_library_dirs = $TRAVIS_BUILD_DIR/openblas/usr/local/lib" >> site.cfg
+      # remove a spurious gcc/gfortran toolchain install
+      rm -rf /usr/local/Cellar/gcc/9.2.0_2
     fi
   - export CCACHE_COMPRESS=1
   - python --version # just to check

--- a/LICENSES_bundled.txt
+++ b/LICENSES_bundled.txt
@@ -168,3 +168,9 @@ Name: uarray
 Files: scipy/_lib/uarray/*
 License: 3-Clause BSD
   For details, see scipy/_lib/uarray/LICENSE
+
+Name: ampgo
+Files: benchmarks/benchmarks/go_benchmark_functions/*.py
+License: MIT
+  Functions for testing global optimizers, forked from the AMPGO project,
+  https://code.google.com/archive/p/ampgo

--- a/benchmarks/benchmarks/optimize.py
+++ b/benchmarks/benchmarks/optimize.py
@@ -197,7 +197,6 @@ class _BenchOptimizers(Benchmark):
         t0 = time.time()
 
         res = dual_annealing(self.fun,
-                             None,
                              self.bounds)
 
         t1 = time.time()

--- a/benchmarks/benchmarks/optimize_linprog.py
+++ b/benchmarks/benchmarks/optimize_linprog.py
@@ -1,21 +1,17 @@
 """
 Benchmarks for Linear Programming
 """
-from __future__ import division, print_function, absolute_import
 
 # Import testing parameters
-try:
-    from scipy.optimize import linprog, OptimizeWarning
-    from scipy.linalg import toeplitz
-    from scipy.optimize.tests.test_linprog import lpgen_2d, magic_square
-    from numpy.testing import suppress_warnings
-    from scipy.optimize._remove_redundancy import _remove_redundancy, _remove_redundancy_dense, _remove_redundancy_sparse
-    from scipy.optimize._linprog_util import _presolve, _clean_inputs, _LPProblem
-    from scipy.sparse import csc_matrix, csr_matrix, issparse
-    import numpy as np
-    import os
-except ImportError:
-    pass
+from scipy.optimize import linprog, OptimizeWarning
+from scipy.linalg import toeplitz
+from scipy.optimize.tests.test_linprog import lpgen_2d, magic_square
+from numpy.testing import suppress_warnings
+from scipy.optimize._remove_redundancy import _remove_redundancy, _remove_redundancy_dense, _remove_redundancy_sparse
+from scipy.optimize._linprog_util import _presolve, _clean_inputs, _LPProblem
+from scipy.sparse import csc_matrix, csr_matrix, issparse
+import numpy as np
+import os
 
 from .common import Benchmark
 

--- a/doc/release/1.2.3-notes.rst
+++ b/doc/release/1.2.3-notes.rst
@@ -1,0 +1,63 @@
+==========================
+SciPy 1.2.3 Release Notes
+==========================
+
+.. contents::
+
+SciPy 1.2.3 is a bug-fix release with no new features compared to 1.2.2. It is
+part of the long-term support (LTS) release series for Python 2.7.
+
+Authors
+=======
+
+* Geordie McBain
+* Matt Haberland
+* David Hagen
+* Tyler Reddy
+* Pauli Virtanen
+* Eric Larson
+* Yu Feng
+* ananyashreyjain
+* Nikolay Mayorov
+* Evgeni Burovski 
+* Warren Weckesser
+
+Issues closed for 1.2.3
+-----------------------
+* `#4915 <https://github.com/scipy/scipy/issues/4915>`__: Bug in unique_roots in scipy.signal.signaltools.py for roots with same magnitude
+* `#5546 <https://github.com/scipy/scipy/issues/5546>`__: ValueError raised if scipy.sparse.linalg.expm recieves array larger than 200x200
+* `#7117 <https://github.com/scipy/scipy/issues/7117>`__: Warn users when using float32 input data to curve_fit and friends
+* `#7906 <https://github.com/scipy/scipy/issues/7906>`__: Wrong result from scipy.interpolate.UnivariateSpline.integral for out-of-bounds 
+* `#9581 <https://github.com/scipy/scipy/issues/9581>`__: Least-squares minimization fails silently when x and y data are different types
+* `#9901 <https://github.com/scipy/scipy/issues/9901>`__: lsoda fails to detect stiff problem when called from solve_ivp
+* `#9988 <https://github.com/scipy/scipy/issues/9988>`__: doc build broken with Sphinx 2.0.0
+* `#10303 <https://github.com/scipy/scipy/issues/10303>`__: BUG: optimize: `linprog` failing TestLinprogSimplexBland::test_unbounded_below_no_presolve_corrected 
+* `#10376 <https://github.com/scipy/scipy/issues/10376>`__: TST: Travis CI fails (with pytest 5.0 ?)
+* `#10384 <https://github.com/scipy/scipy/issues/10384>`__: CircleCI doc build failing on new warnings
+* `#10535 <https://github.com/scipy/scipy/issues/10535>`__: TST: master branch CI failures 
+* `#11121 <https://github.com/scipy/scipy/issues/11121>`__: Calls to `scipy.interpolate.splprep` increase RAM usage.
+* `#11198 <https://github.com/scipy/scipy/issues/11198>`__: BUG: sparse eigs (arpack) shift-invert drops the smallest eigenvalue for some k
+* `#11266 <https://github.com/scipy/scipy/issues/11266>`__: Sparse matrix constructor data type detection changes on Numpy 1.18.0
+
+Pull requests for 1.2.3
+-----------------------
+* `#9992 <https://github.com/scipy/scipy/pull/9992>`__: MAINT: Undo Sphinx pin 
+* `#10071 <https://github.com/scipy/scipy/pull/10071>`__: DOC: reconstruct SuperLU permutation matrices avoiding SparseEfficiencyWarning
+* `#10076 <https://github.com/scipy/scipy/pull/10076>`__: BUG: optimize: fix curve_fit for mixed float32/float64 input
+* `#10138 <https://github.com/scipy/scipy/pull/10138>`__: BUG: special: Invalid arguments to ellip_harm can crash Python.
+* `#10306 <https://github.com/scipy/scipy/pull/10306>`__: BUG: optimize: Fix for 10303
+* `#10309 <https://github.com/scipy/scipy/pull/10309>`__: BUG: Pass jac=None directly to lsoda
+* `#10377 <https://github.com/scipy/scipy/pull/10377>`__: TST, MAINT: adjustments for pytest 5.0
+* `#10379 <https://github.com/scipy/scipy/pull/10379>`__: BUG: sparse: set writeability to be forward-compatible with numpy>=1.17
+* `#10426 <https://github.com/scipy/scipy/pull/10426>`__: MAINT: Fix doc build bugs
+* `#10540 <https://github.com/scipy/scipy/pull/10540>`__: MAINT: Fix Travis and Circle 
+* `#10633 <https://github.com/scipy/scipy/pull/10633>`__: BUG: interpolate: integral(a, b) should be zero when both limits are outside of the interpolation range
+* `#10833 <https://github.com/scipy/scipy/pull/10833>`__: BUG: Fix subspace_angles for complex values
+* `#10882 <https://github.com/scipy/scipy/pull/10882>`__: BUG: sparse/arpack: fix incorrect code for complex hermitian M
+* `#10906 <https://github.com/scipy/scipy/pull/10906>`__: BUG: sparse/linalg: fix expm for np.matrix inputs
+* `#10961 <https://github.com/scipy/scipy/pull/10961>`__: BUG: Fix signal.unique_roots
+* `#11126 <https://github.com/scipy/scipy/pull/11126>`__: BUG: interpolate/fitpack: fix memory leak in splprep
+* `#11199 <https://github.com/scipy/scipy/pull/11199>`__: BUG: sparse.linalg: mistake in unsymm. real shift-invert ARPACK eigenvalue selection
+* `#11269 <https://github.com/scipy/scipy/pull/11269>`__: Fix: Sparse matrix constructor data type detection changes on Numpy 1.18.0
+
+

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -325,7 +325,7 @@ latex_elements = {
 # -----------------------------------------------------------------------------
 intersphinx_mapping = {
     'python': ('https://docs.python.org/dev', None),
-    'numpy': ('https://docs.scipy.org/doc/numpy', None),
+    'numpy': ('https://numpy.org/devdocs', None),
     'matplotlib': ('https://matplotlib.org', None),
     'asv': ('https://asv.readthedocs.io/en/stable/', None),
 }

--- a/doc/source/release.1.2.3.rst
+++ b/doc/source/release.1.2.3.rst
@@ -1,0 +1,1 @@
+.. include:: ../release/1.2.3-notes.rst

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -12,6 +12,7 @@ Release Notes
    release.1.3.2
    release.1.3.1
    release.1.3.0
+   release.1.2.3
    release.1.2.2
    release.1.2.1
    release.1.2.0

--- a/doc/source/scipyoptdoc.py
+++ b/doc/source/scipyoptdoc.py
@@ -36,7 +36,7 @@ from numpydoc.numpydoc import mangle_docstrings
 from docutils.parsers.rst import Directive
 from docutils.statemachine import ViewList
 from sphinx.domains.python import PythonDomain
-from scipy._lib._util import getargspec_no_self
+from scipy._lib._util import getfullargspec_no_self
 
 
 def setup(app):
@@ -79,12 +79,12 @@ def wrap_mangling_directive(base_directive):
             # Interface function
             name = self.arguments[0].strip()
             obj = _import_object(name)
-            args, varargs, keywords, defaults = getargspec_no_self(obj)
+            args, varargs, keywords, defaults = getfullargspec_no_self(obj)[:4]
 
             # Implementation function
             impl_name = self.options['impl']
             impl_obj = _import_object(impl_name)
-            impl_args, impl_varargs, impl_keywords, impl_defaults = getargspec_no_self(impl_obj)
+            impl_args, impl_varargs, impl_keywords, impl_defaults = getfullargspec_no_self(impl_obj)[:4]
 
             # Format signature taking implementation into account
             args = list(args)

--- a/doc/source/tutorial/stats.rst
+++ b/doc/source/tutorial/stats.rst
@@ -169,7 +169,7 @@ you can explicitly seed a global variable
 
 Relying on a global state is not recommended, though. A better way is to use
 the `random_state` parameter, which accepts an instance of
-`numpy.random.mtrand.RandomState` class, or an integer, which is then used to
+`numpy.random.RandomState` class, or an integer, which is then used to
 seed an internal ``RandomState`` object:
 
     >>> norm.rvs(size=5, random_state=1234)

--- a/scipy/_lib/tests/test__util.py
+++ b/scipy/_lib/tests/test__util.py
@@ -10,7 +10,8 @@ import pytest
 from pytest import raises as assert_raises, deprecated_call
 
 import scipy
-from scipy._lib._util import _aligned_zeros, check_random_state, MapWrapper
+from scipy._lib._util import (_aligned_zeros, check_random_state, MapWrapper,
+    getargspec_no_self, getfullargspec_no_self, ArgSpec, FullArgSpec)
 
 
 def test__aligned_zeros():
@@ -66,6 +67,29 @@ def test_check_random_state():
         rsi = check_random_state(rg)
         assert_equal(type(rsi), np.random.Generator)
 
+
+def test_getargspec_no_self():
+    p = MapWrapper(1)
+    argspec = getargspec_no_self(p.__init__)
+    assert_equal(argspec, ArgSpec(['pool'], None, None, [1]))
+    argspec = getargspec_no_self(p.__call__)
+    assert_equal(argspec, ArgSpec(['func', 'iterable'], None, None, None))
+
+
+def test_getfullargspec_no_self():
+    p = MapWrapper(1)
+    argspec = getfullargspec_no_self(p.__init__)
+    assert_equal(argspec, FullArgSpec(['pool'], None, None, (1,), [], None, {}))
+    argspec = getfullargspec_no_self(p.__call__)
+    assert_equal(argspec, FullArgSpec(['func', 'iterable'], None, None, None, [], None, {}))
+
+    class _rv_generic(object):
+        def _rvs(self, a, b=2, c=3, *args, size=None, **kwargs):
+            return None
+
+    rv_obj = _rv_generic()
+    argspec = getfullargspec_no_self(rv_obj._rvs)
+    assert_equal(argspec, FullArgSpec(['a', 'b', 'c'], 'args', 'kwargs', [2, 3], ['size'], {'size': None}, {}))
 
 def test_mapwrapper_serial():
     in_arg = np.arange(10.)

--- a/scipy/_lib/tests/test__util.py
+++ b/scipy/_lib/tests/test__util.py
@@ -11,7 +11,7 @@ from pytest import raises as assert_raises, deprecated_call
 
 import scipy
 from scipy._lib._util import (_aligned_zeros, check_random_state, MapWrapper,
-    getargspec_no_self, getfullargspec_no_self, ArgSpec, FullArgSpec)
+    getfullargspec_no_self, FullArgSpec)
 
 
 def test__aligned_zeros():
@@ -68,17 +68,10 @@ def test_check_random_state():
         assert_equal(type(rsi), np.random.Generator)
 
 
-def test_getargspec_no_self():
-    p = MapWrapper(1)
-    argspec = getargspec_no_self(p.__init__)
-    assert_equal(argspec, ArgSpec(['pool'], None, None, [1]))
-    argspec = getargspec_no_self(p.__call__)
-    assert_equal(argspec, ArgSpec(['func', 'iterable'], None, None, None))
-
-
 def test_getfullargspec_no_self():
     p = MapWrapper(1)
     argspec = getfullargspec_no_self(p.__init__)
+    print(argspec)
     assert_equal(argspec, FullArgSpec(['pool'], None, None, (1,), [], None, {}))
     argspec = getfullargspec_no_self(p.__call__)
     assert_equal(argspec, FullArgSpec(['func', 'iterable'], None, None, None, [], None, {}))
@@ -90,6 +83,7 @@ def test_getfullargspec_no_self():
     rv_obj = _rv_generic()
     argspec = getfullargspec_no_self(rv_obj._rvs)
     assert_equal(argspec, FullArgSpec(['a', 'b', 'c'], 'args', 'kwargs', [2, 3], ['size'], {'size': None}, {}))
+
 
 def test_mapwrapper_serial():
     in_arg = np.arange(10.)

--- a/scipy/fft/_basic.py
+++ b/scipy/fft/_basic.py
@@ -21,7 +21,8 @@ def _dispatch(func):
 
 
 @_dispatch
-def fft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
+def fft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
+        plan=None):
     """
     Compute the 1-D discrete Fourier Transform.
 
@@ -52,6 +53,11 @@ def fft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
         Maximum number of workers to use for parallel computation. If negative,
         the value wraps around from ``os.cpu_count()``. See below for more
         details.
+    plan: object, optional
+        This argument is reserved for passing in a precomputed plan provided
+        by downstream FFT vendors. It is currently not used in SciPy.
+
+        .. versionadded:: 1.5.0
 
     Returns
     -------
@@ -150,12 +156,12 @@ def fft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
     >>> plt.show()
 
     """
-
     return (Dispatchable(x, np.ndarray),)
 
 
 @_dispatch
-def ifft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
+def ifft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
+         plan=None):
     """
     Compute the 1-D inverse discrete Fourier Transform.
 
@@ -197,6 +203,11 @@ def ifft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
         Maximum number of workers to use for parallel computation. If negative,
         the value wraps around from ``os.cpu_count()``.
         See :func:`~scipy.fft.fft` for more details.
+    plan: object, optional
+        This argument is reserved for passing in a precomputed plan provided
+        by downstream FFT vendors. It is currently not used in SciPy.
+
+        .. versionadded:: 1.5.0
 
     Returns
     -------
@@ -253,7 +264,8 @@ def ifft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
 
 
 @_dispatch
-def rfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
+def rfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
+         plan=None):
     """
     Compute the 1-D discrete Fourier Transform for real input.
 
@@ -282,6 +294,11 @@ def rfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
         Maximum number of workers to use for parallel computation. If negative,
         the value wraps around from ``os.cpu_count()``.
         See :func:`~scipy.fft.fft` for more details.
+    plan: object, optional
+        This argument is reserved for passing in a precomputed plan provided
+        by downstream FFT vendors. It is currently not used in SciPy.
+
+        .. versionadded:: 1.5.0
 
     Returns
     -------
@@ -340,7 +357,8 @@ def rfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
 
 
 @_dispatch
-def irfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
+def irfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
+          plan=None):
     """
     Compute the inverse of the n-point DFT for real input.
 
@@ -378,6 +396,11 @@ def irfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
         Maximum number of workers to use for parallel computation. If negative,
         the value wraps around from ``os.cpu_count()``.
         See :func:`~scipy.fft.fft` for more details.
+    plan: object, optional
+        This argument is reserved for passing in a precomputed plan provided
+        by downstream FFT vendors. It is currently not used in SciPy.
+
+        .. versionadded:: 1.5.0
 
     Returns
     -------
@@ -435,7 +458,8 @@ def irfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
 
 
 @_dispatch
-def hfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
+def hfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
+         plan=None):
     """
     Compute the FFT of a signal that has Hermitian symmetry, i.e., a real
     spectrum.
@@ -463,6 +487,11 @@ def hfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
         Maximum number of workers to use for parallel computation. If negative,
         the value wraps around from ``os.cpu_count()``.
         See :func:`~scipy.fft.fft` for more details.
+    plan: object, optional
+        This argument is reserved for passing in a precomputed plan provided
+        by downstream FFT vendors. It is currently not used in SciPy.
+
+        .. versionadded:: 1.5.0
 
     Returns
     -------
@@ -511,7 +540,8 @@ def hfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
 
 
 @_dispatch
-def ihfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
+def ihfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
+          plan=None):
     """
     Compute the inverse FFT of a signal that has Hermitian symmetry.
 
@@ -537,6 +567,11 @@ def ihfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
         Maximum number of workers to use for parallel computation. If negative,
         the value wraps around from ``os.cpu_count()``.
         See :func:`~scipy.fft.fft` for more details.
+    plan: object, optional
+        This argument is reserved for passing in a precomputed plan provided
+        by downstream FFT vendors. It is currently not used in SciPy.
+
+        .. versionadded:: 1.5.0
 
     Returns
     -------
@@ -571,7 +606,8 @@ def ihfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
 
 
 @_dispatch
-def fftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
+def fftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
+         plan=None):
     """
     Compute the N-D discrete Fourier Transform.
 
@@ -603,6 +639,11 @@ def fftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
         Maximum number of workers to use for parallel computation. If negative,
         the value wraps around from ``os.cpu_count()``.
         See :func:`~scipy.fft.fft` for more details.
+    plan: object, optional
+        This argument is reserved for passing in a precomputed plan provided
+        by downstream FFT vendors. It is currently not used in SciPy.
+
+        .. versionadded:: 1.5.0
 
     Returns
     -------
@@ -664,12 +705,12 @@ def fftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
     >>> plt.show()
 
     """
-
     return (Dispatchable(x, np.ndarray),)
 
 
 @_dispatch
-def ifftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
+def ifftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
+          plan=None):
     """
     Compute the N-D inverse discrete Fourier Transform.
 
@@ -709,6 +750,11 @@ def ifftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
         Maximum number of workers to use for parallel computation. If negative,
         the value wraps around from ``os.cpu_count()``.
         See :func:`~scipy.fft.fft` for more details.
+    plan: object, optional
+        This argument is reserved for passing in a precomputed plan provided
+        by downstream FFT vendors. It is currently not used in SciPy.
+
+        .. versionadded:: 1.5.0
 
     Returns
     -------
@@ -765,7 +811,8 @@ def ifftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
 
 
 @_dispatch
-def fft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None):
+def fft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None, *,
+         plan=None):
     """
     Compute the 2-D discrete Fourier Transform
 
@@ -798,6 +845,11 @@ def fft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None):
         Maximum number of workers to use for parallel computation. If negative,
         the value wraps around from ``os.cpu_count()``.
         See :func:`~scipy.fft.fft` for more details.
+    plan: object, optional
+        This argument is reserved for passing in a precomputed plan provided
+        by downstream FFT vendors. It is currently not used in SciPy.
+
+        .. versionadded:: 1.5.0
 
     Returns
     -------
@@ -853,12 +905,12 @@ def fft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None):
               0.  +0.j        ,   0.  +0.j        ]])
 
     """
-
     return (Dispatchable(x, np.ndarray),)
 
 
 @_dispatch
-def ifft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None):
+def ifft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None, *,
+          plan=None):
     """
     Compute the 2-D inverse discrete Fourier Transform.
 
@@ -898,6 +950,11 @@ def ifft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None):
         Maximum number of workers to use for parallel computation. If negative,
         the value wraps around from ``os.cpu_count()``.
         See :func:`~scipy.fft.fft` for more details.
+    plan: object, optional
+        This argument is reserved for passing in a precomputed plan provided
+        by downstream FFT vendors. It is currently not used in SciPy.
+
+        .. versionadded:: 1.5.0
 
     Returns
     -------
@@ -943,12 +1000,12 @@ def ifft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None):
            [0.+0.j,  1.+0.j,  0.+0.j,  0.+0.j]])
 
     """
-
     return (Dispatchable(x, np.ndarray),)
 
 
 @_dispatch
-def rfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
+def rfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
+          plan=None):
     """
     Compute the N-D discrete Fourier Transform for real input.
 
@@ -983,6 +1040,11 @@ def rfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
         Maximum number of workers to use for parallel computation. If negative,
         the value wraps around from ``os.cpu_count()``.
         See :func:`~scipy.fft.fft` for more details.
+    plan: object, optional
+        This argument is reserved for passing in a precomputed plan provided
+        by downstream FFT vendors. It is currently not used in SciPy.
+
+        .. versionadded:: 1.5.0
 
     Returns
     -------
@@ -1041,7 +1103,8 @@ def rfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
 
 
 @_dispatch
-def rfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None):
+def rfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None, *,
+          plan=None):
     """
     Compute the 2-D FFT of a real array.
 
@@ -1062,6 +1125,11 @@ def rfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None):
         Maximum number of workers to use for parallel computation. If negative,
         the value wraps around from ``os.cpu_count()``.
         See :func:`~scipy.fft.fft` for more details.
+    plan: object, optional
+        This argument is reserved for passing in a precomputed plan provided
+        by downstream FFT vendors. It is currently not used in SciPy.
+
+        .. versionadded:: 1.5.0
 
     Returns
     -------
@@ -1079,12 +1147,12 @@ def rfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None):
     For more details see `rfftn`.
 
     """
-
     return (Dispatchable(x, np.ndarray),)
 
 
 @_dispatch
-def irfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
+def irfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
+           plan=None):
     """
     Compute the inverse of the N-D FFT of real input.
 
@@ -1125,6 +1193,11 @@ def irfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
         Maximum number of workers to use for parallel computation. If negative,
         the value wraps around from ``os.cpu_count()``.
         See :func:`~scipy.fft.fft` for more details.
+    plan: object, optional
+        This argument is reserved for passing in a precomputed plan provided
+        by downstream FFT vendors. It is currently not used in SciPy.
+
+        .. versionadded:: 1.5.0
 
     Returns
     -------
@@ -1184,8 +1257,8 @@ def irfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
 
 
 @_dispatch
-def irfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False,
-           workers=None):
+def irfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None, *,
+           plan=None):
     """
     Compute the 2-D inverse FFT of a real array.
 
@@ -1207,6 +1280,11 @@ def irfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False,
         Maximum number of workers to use for parallel computation. If negative,
         the value wraps around from ``os.cpu_count()``.
         See :func:`~scipy.fft.fft` for more details.
+    plan: object, optional
+        This argument is reserved for passing in a precomputed plan provided
+        by downstream FFT vendors. It is currently not used in SciPy.
+
+        .. versionadded:: 1.5.0
 
     Returns
     -------
@@ -1227,7 +1305,8 @@ def irfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False,
 
 
 @_dispatch
-def hfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
+def hfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
+          plan=None):
     """
     Compute the N-D FFT of Hermitian symmetric complex input, i.e., a
     signal with a real spectrum.
@@ -1265,6 +1344,11 @@ def hfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
         Maximum number of workers to use for parallel computation. If negative,
         the value wraps around from ``os.cpu_count()``.
         See :func:`~scipy.fft.fft` for more details.
+    plan: object, optional
+        This argument is reserved for passing in a precomputed plan provided
+        by downstream FFT vendors. It is currently not used in SciPy.
+
+        .. versionadded:: 1.5.0
 
     Returns
     -------
@@ -1334,7 +1418,8 @@ def hfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
 
 
 @_dispatch
-def hfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None):
+def hfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None, *,
+          plan=None):
     """
     Compute the 2-D FFT of a Hermitian complex array.
 
@@ -1355,6 +1440,11 @@ def hfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None):
         Maximum number of workers to use for parallel computation. If negative,
         the value wraps around from ``os.cpu_count()``.
         See :func:`~scipy.fft.fft` for more details.
+    plan: object, optional
+        This argument is reserved for passing in a precomputed plan provided
+        by downstream FFT vendors. It is currently not used in SciPy.
+
+        .. versionadded:: 1.5.0
 
     Returns
     -------
@@ -1376,7 +1466,8 @@ def hfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None):
 
 
 @_dispatch
-def ihfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
+def ihfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
+           plan=None):
     """
     Compute the N-D inverse discrete Fourier Transform for a real
     spectrum.
@@ -1410,6 +1501,11 @@ def ihfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
         Maximum number of workers to use for parallel computation. If negative,
         the value wraps around from ``os.cpu_count()``.
         See :func:`~scipy.fft.fft` for more details.
+    plan: object, optional
+        This argument is reserved for passing in a precomputed plan provided
+        by downstream FFT vendors. It is currently not used in SciPy.
+
+        .. versionadded:: 1.5.0
 
     Returns
     -------
@@ -1464,8 +1560,8 @@ def ihfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None):
 
 
 @_dispatch
-def ihfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False,
-           workers=None):
+def ihfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None, *,
+           plan=None):
     """
     Compute the 2-D inverse FFT of a real spectrum.
 
@@ -1487,6 +1583,11 @@ def ihfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False,
         Maximum number of workers to use for parallel computation. If negative,
         the value wraps around from ``os.cpu_count()``.
         See :func:`~scipy.fft.fft` for more details.
+    plan: object, optional
+        This argument is reserved for passing in a precomputed plan provided
+        by downstream FFT vendors. It is currently not used in SciPy.
+
+        .. versionadded:: 1.5.0
 
     Returns
     -------

--- a/scipy/fft/_pocketfft/basic.py
+++ b/scipy/fft/_pocketfft/basic.py
@@ -11,8 +11,11 @@ from .helper import (_asfarray, _init_nd_shape_and_axes, _datacopied,
                      _workers)
 
 def c2c(forward, x, n=None, axis=-1, norm=None, overwrite_x=False,
-        workers=None):
+        workers=None, *, plan=None):
     """ Return discrete Fourier transform of real or complex sequence. """
+    if plan is not None:
+        raise NotImplementedError('Passing a precomputed plan is not yet '
+                                  'supported by scipy.fft functions')
     tmp = _asfarray(x)
     overwrite_x = overwrite_x or _datacopied(tmp, x)
     norm = _normalization(norm, forward)
@@ -37,10 +40,13 @@ ifft.__name__ = 'ifft'
 
 
 def r2c(forward, x, n=None, axis=-1, norm=None, overwrite_x=False,
-        workers=None):
+        workers=None, *, plan=None):
     """
     Discrete Fourier transform of a real sequence.
     """
+    if plan is not None:
+        raise NotImplementedError('Passing a precomputed plan is not yet '
+                                  'supported by scipy.fft functions')
     tmp = _asfarray(x)
     norm = _normalization(norm, forward)
     workers = _workers(workers)
@@ -65,10 +71,13 @@ ihfft.__name__ = 'ihfft'
 
 
 def c2r(forward, x, n=None, axis=-1, norm=None, overwrite_x=False,
-        workers=None):
+        workers=None, *, plan=None):
     """
     Return inverse discrete Fourier transform of real sequence x.
     """
+    if plan is not None:
+        raise NotImplementedError('Passing a precomputed plan is not yet '
+                                  'supported by scipy.fft functions')
     tmp = _asfarray(x)
     norm = _normalization(norm, forward)
     workers = _workers(workers)
@@ -96,53 +105,80 @@ irfft = functools.partial(c2r, False)
 irfft.__name__ = 'irfft'
 
 
-def fft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False, workers=None):
+def fft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False, workers=None,
+         *, plan=None):
     """
     2-D discrete Fourier transform.
     """
+    if plan is not None:
+        raise NotImplementedError('Passing a precomputed plan is not yet '
+                                  'supported by scipy.fft functions')
     return fftn(x, s, axes, norm, overwrite_x, workers)
 
 
-def ifft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False, workers=None):
+def ifft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False, workers=None,
+          *, plan=None):
     """
     2-D discrete inverse Fourier transform of real or complex sequence.
     """
+    if plan is not None:
+        raise NotImplementedError('Passing a precomputed plan is not yet '
+                                  'supported by scipy.fft functions')
     return ifftn(x, s, axes, norm, overwrite_x, workers)
 
 
-def rfft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False, workers=None):
+def rfft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False, workers=None,
+          *, plan=None):
     """
     2-D discrete Fourier transform of a real sequence
     """
+    if plan is not None:
+        raise NotImplementedError('Passing a precomputed plan is not yet '
+                                  'supported by scipy.fft functions')
     return rfftn(x, s, axes, norm, overwrite_x, workers)
 
 
-def irfft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False, workers=None):
+def irfft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False, workers=None,
+           *, plan=None):
     """
     2-D discrete inverse Fourier transform of a real sequence
     """
+    if plan is not None:
+        raise NotImplementedError('Passing a precomputed plan is not yet '
+                                  'supported by scipy.fft functions')
     return irfftn(x, s, axes, norm, overwrite_x, workers)
 
 
-def hfft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False, workers=None):
+def hfft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False, workers=None,
+          *, plan=None):
     """
     2-D discrete Fourier transform of a Hermitian sequence
     """
+    if plan is not None:
+        raise NotImplementedError('Passing a precomputed plan is not yet '
+                                  'supported by scipy.fft functions')
     return hfftn(x, s, axes, norm, overwrite_x, workers)
 
 
-def ihfft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False, workers=None):
+def ihfft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False, workers=None,
+           *, plan=None):
     """
     2-D discrete inverse Fourier transform of a Hermitian sequence
     """
+    if plan is not None:
+        raise NotImplementedError('Passing a precomputed plan is not yet '
+                                  'supported by scipy.fft functions')
     return ihfftn(x, s, axes, norm, overwrite_x, workers)
 
 
 def c2cn(forward, x, s=None, axes=None, norm=None, overwrite_x=False,
-         workers=None):
+         workers=None, *, plan=None):
     """
     Return multidimensional discrete Fourier transform.
     """
+    if plan is not None:
+        raise NotImplementedError('Passing a precomputed plan is not yet '
+                                  'supported by scipy.fft functions')
     tmp = _asfarray(x)
 
     shape, axes = _init_nd_shape_and_axes(tmp, s, axes)
@@ -167,8 +203,11 @@ ifftn = functools.partial(c2cn, False)
 ifftn.__name__ = 'ifftn'
 
 def r2cn(forward, x, s=None, axes=None, norm=None, overwrite_x=False,
-         workers=None):
+         workers=None, *, plan=None):
     """Return multidimensional discrete Fourier transform of real input"""
+    if plan is not None:
+        raise NotImplementedError('Passing a precomputed plan is not yet '
+                                  'supported by scipy.fft functions')
     tmp = _asfarray(x)
 
     if not np.isrealobj(tmp):
@@ -193,8 +232,11 @@ ihfftn.__name__ = 'ihfftn'
 
 
 def c2rn(forward, x, s=None, axes=None, norm=None, overwrite_x=False,
-         workers=None):
+         workers=None, *, plan=None):
     """Multidimensional inverse discrete fourier transform with real output"""
+    if plan is not None:
+        raise NotImplementedError('Passing a precomputed plan is not yet '
+                                  'supported by scipy.fft functions')
     tmp = _asfarray(x)
 
     # TODO: Optimize for hermitian and real?

--- a/scipy/fft/_pocketfft/pypocketfft.cxx
+++ b/scipy/fft/_pocketfft/pypocketfft.cxx
@@ -20,9 +20,10 @@
 
 namespace {
 
-using namespace std;
 using pocketfft::shape_t;
 using pocketfft::stride_t;
+using std::size_t;
+using std::ptrdiff_t;
 
 namespace py = pybind11;
 
@@ -66,13 +67,13 @@ shape_t makeaxes(const py::array &in, const py::object &axes)
   auto tmp=axes.cast<std::vector<ptrdiff_t>>();
   auto ndim = in.ndim();
   if ((tmp.size()>size_t(ndim)) || (tmp.size()==0))
-    throw runtime_error("bad axes argument");
+    throw std::runtime_error("bad axes argument");
   for (auto& sz: tmp)
     {
     if (sz<0)
       sz += ndim;
     if ((sz>=ndim) || (sz<0))
-      throw invalid_argument("axes exceeds dimensionality of output");
+      throw std::invalid_argument("axes exceeds dimensionality of output");
     }
   return shape_t(tmp.begin(), tmp.end());
   }
@@ -82,7 +83,7 @@ shape_t makeaxes(const py::array &in, const py::object &axes)
   if (py::isinstance<py::array_t<T1>>(arr)) return func<double> args; \
   if (py::isinstance<py::array_t<T2>>(arr)) return func<float> args;  \
   if (py::isinstance<py::array_t<T3>>(arr)) return func<ldbl_t> args; \
-  throw runtime_error("unsupported data type"); \
+  throw std::runtime_error("unsupported data type"); \
   }
 
 template<typename T> T norm_fct(int inorm, size_t N)
@@ -90,7 +91,7 @@ template<typename T> T norm_fct(int inorm, size_t N)
   if (inorm==0) return T(1);
   if (inorm==2) return T(1/ldbl_t(N));
   if (inorm==1) return T(1/sqrt(ldbl_t(N)));
-  throw invalid_argument("invalid value for inorm (must be 0, 1, or 2)");
+  throw std::invalid_argument("invalid value for inorm (must be 0, 1, or 2)");
   }
 
 template<typename T> T norm_fct(int inorm, const shape_t &shape,
@@ -109,7 +110,7 @@ template<typename T> py::array_t<T> prepare_output(py::object &out_,
   if (out_.is_none()) return py::array_t<T>(dims);
   auto tmp = out_.cast<py::array_t<T>>();
   if (!tmp.is(out_)) // a new object was created during casting
-    throw runtime_error("unexpected data type for output array");
+    throw std::runtime_error("unexpected data type for output array");
   return tmp;
   }
 
@@ -119,17 +120,17 @@ template<typename T> py::array c2c_internal(const py::array &in,
   {
   auto axes = makeaxes(in, axes_);
   auto dims(copy_shape(in));
-  auto res = prepare_output<complex<T>>(out_, dims);
+  auto res = prepare_output<std::complex<T>>(out_, dims);
   auto s_in=copy_strides(in);
   auto s_out=copy_strides(res);
-  auto d_in=reinterpret_cast<const complex<T> *>(in.data());
-  auto d_out=reinterpret_cast<complex<T> *>(res.mutable_data());
+  auto d_in=reinterpret_cast<const std::complex<T> *>(in.data());
+  auto d_out=reinterpret_cast<std::complex<T> *>(res.mutable_data());
   {
   py::gil_scoped_release release;
   T fct = norm_fct<T>(inorm, dims, axes);
   pocketfft::c2c(dims, s_in, s_out, axes, forward, d_in, d_out, fct, nthreads);
   }
-  return res;
+  return move(res);
   }
 
 template<typename T> py::array c2c_sym_internal(const py::array &in,
@@ -138,18 +139,18 @@ template<typename T> py::array c2c_sym_internal(const py::array &in,
   {
   auto axes = makeaxes(in, axes_);
   auto dims(copy_shape(in));
-  auto res = prepare_output<complex<T>>(out_, dims);
+  auto res = prepare_output<std::complex<T>>(out_, dims);
   auto s_in=copy_strides(in);
   auto s_out=copy_strides(res);
   auto d_in=reinterpret_cast<const T *>(in.data());
-  auto d_out=reinterpret_cast<complex<T> *>(res.mutable_data());
+  auto d_out=reinterpret_cast<std::complex<T> *>(res.mutable_data());
   {
   py::gil_scoped_release release;
   T fct = norm_fct<T>(inorm, dims, axes);
   pocketfft::r2c(dims, s_in, s_out, axes, forward, d_in, d_out, fct, nthreads);
   // now fill in second half
   using namespace pocketfft::detail;
-  ndarr<complex<T>> ares(res.mutable_data(), dims, s_out);
+  ndarr<std::complex<T>> ares(res.mutable_data(), dims, s_out);
   rev_iter iter(ares, axes);
   while(iter.remaining()>0)
     {
@@ -158,7 +159,7 @@ template<typename T> py::array c2c_sym_internal(const py::array &in,
     iter.advance();
     }
   }
-  return res;
+  return move(res);
   }
 
 py::array c2c(const py::array &a, const py::object &axes_, bool forward,
@@ -179,11 +180,11 @@ template<typename T> py::array r2c_internal(const py::array &in,
   auto axes = makeaxes(in, axes_);
   auto dims_in(copy_shape(in)), dims_out(dims_in);
   dims_out[axes.back()] = (dims_out[axes.back()]>>1)+1;
-  py::array res = prepare_output<complex<T>>(out_, dims_out);
+  py::array res = prepare_output<std::complex<T>>(out_, dims_out);
   auto s_in=copy_strides(in);
   auto s_out=copy_strides(res);
   auto d_in=reinterpret_cast<const T *>(in.data());
-  auto d_out=reinterpret_cast<complex<T> *>(res.mutable_data());
+  auto d_out=reinterpret_cast<std::complex<T> *>(res.mutable_data());
   {
   py::gil_scoped_release release;
   T fct = norm_fct<T>(inorm, dims_in, axes);
@@ -253,7 +254,7 @@ template<typename T> py::array dct_internal(const py::array &in,
 py::array dct(const py::array &in, int type, const py::object &axes_,
   int inorm, py::object &out_, size_t nthreads)
   {
-  if ((type<1) || (type>4)) throw invalid_argument("invalid DCT type");
+  if ((type<1) || (type>4)) throw std::invalid_argument("invalid DCT type");
   DISPATCH(in, f64, f32, flong, dct_internal, (in, axes_, type, inorm, out_,
     nthreads))
   }
@@ -283,7 +284,7 @@ template<typename T> py::array dst_internal(const py::array &in,
 py::array dst(const py::array &in, int type, const py::object &axes_,
   int inorm, py::object &out_, size_t nthreads)
   {
-  if ((type<1) || (type>4)) throw invalid_argument("invalid DST type");
+  if ((type<1) || (type>4)) throw std::invalid_argument("invalid DST type");
   DISPATCH(in, f64, f32, flong, dst_internal, (in, axes_, type, inorm,
     out_, nthreads))
   }
@@ -297,12 +298,12 @@ template<typename T> py::array c2r_internal(const py::array &in,
   shape_t dims_in(copy_shape(in)), dims_out=dims_in;
   if (lastsize==0) lastsize=2*dims_in[axis]-1;
   if ((lastsize/2) + 1 != dims_in[axis])
-    throw invalid_argument("bad lastsize");
+    throw std::invalid_argument("bad lastsize");
   dims_out[axis] = lastsize;
   py::array res = prepare_output<T>(out_, dims_out);
   auto s_in=copy_strides(in);
   auto s_out=copy_strides(res);
-  auto d_in=reinterpret_cast<const complex<T> *>(in.data());
+  auto d_in=reinterpret_cast<const std::complex<T> *>(in.data());
   auto d_out=reinterpret_cast<T *>(res.mutable_data());
   {
   py::gil_scoped_release release;
@@ -346,38 +347,34 @@ py::array separable_hartley(const py::array &in, const py::object &axes_,
     out_, nthreads))
   }
 
-template<typename T>py::array complex2hartley(const py::array &in,
-  const py::array &tmp, const py::object &axes_, py::object &out_)
+template<typename T> py::array genuine_hartley_internal(const py::array &in,
+  const py::object &axes_, int inorm, py::object &out_, size_t nthreads)
   {
-  using namespace pocketfft::detail;
-  auto dims_out(copy_shape(in));
-  py::array out = prepare_output<T>(out_, dims_out);
-  cndarr<cmplx<T>> atmp(tmp.data(), copy_shape(tmp), copy_strides(tmp));
-  ndarr<T> aout(out.mutable_data(), copy_shape(out), copy_strides(out));
+  auto dims(copy_shape(in));
+  py::array res = prepare_output<T>(out_, dims);
   auto axes = makeaxes(in, axes_);
+  auto s_in=copy_strides(in);
+  auto s_out=copy_strides(res);
+  auto d_in=reinterpret_cast<const T *>(in.data());
+  auto d_out=reinterpret_cast<T *>(res.mutable_data());
   {
   py::gil_scoped_release release;
-  simple_iter iin(atmp);
-  rev_iter iout(aout, axes);
-  while(iin.remaining()>0)
-    {
-    auto v = atmp[iin.ofs()];
-    aout[iout.ofs()] = v.r+v.i;
-    aout[iout.rev_ofs()] = v.r-v.i;
-    iin.advance(); iout.advance();
-    }
+  T fct = norm_fct<T>(inorm, dims, axes);
+  pocketfft::r2r_genuine_hartley(dims, s_in, s_out, axes, d_in, d_out, fct,
+    nthreads);
   }
-  return out;
+  return res;
   }
 
 py::array genuine_hartley(const py::array &in, const py::object &axes_,
   int inorm, py::object &out_, size_t nthreads)
   {
-  auto tmp = r2c(in, axes_, true, inorm, None, nthreads);
-  DISPATCH(in, f64, f32, flong, complex2hartley, (in, tmp, axes_, out_))
+  DISPATCH(in, f64, f32, flong, genuine_hartley_internal, (in, axes_, inorm,
+    out_, nthreads))
   }
 
- PyObject * good_size(PyObject * self, PyObject * args)
+// Export good_size in raw C-API to reduce overhead (~4x faster)
+PyObject * good_size(PyObject * /*self*/, PyObject * args)
   {
   Py_ssize_t n_ = -1;
   int real = false;
@@ -406,9 +403,9 @@ const char *pypocketfft_DS = R"""(Fast Fourier and Hartley transforms.
 This module supports
 - single, double, and long double precision
 - complex and real-valued transforms
-- multidimensional transforms
+- multi-dimensional transforms
 
-For two- and higher-dimensional transforms, the code will use SSE2 and AVX
+For two- and higher-dimensional transforms the code will use SSE2 and AVX
 vector instructions for faster execution if these are supported by the CPU and
 were enabled during compilation.
 )""";
@@ -547,7 +544,7 @@ numpy.ndarray (same shape and data type as `a`)
 )""";
 
 const char *separable_hartley_DS = R"""(Performs a separable Hartley transform.
-For every requested axis, a 1-D forward Fourier transform is carried out, and
+For every requested axis, a 1D forward Fourier transform is carried out, and
 the real and imaginary parts of the result are added before the next axis is
 processed.
 

--- a/scipy/fft/_pocketfft/version.md
+++ b/scipy/fft/_pocketfft/version.md
@@ -4,17 +4,15 @@ pypocketfft version
 
 SciPy currently vendors [pypocketfft] at:
 
-    commit c0f74f610adfc60b8b5e3c3bce6477e646329f63
-	Merge: c573384 dce19de
-	Author: Martin Reinecke <martin@mpa-garching.mpg.de>
-	Date:   Wed Aug 14 15:25:48 2019 +0200
+    commit 2147aaf37c6274cc77160f6b355ed9d120cfdc57
+    Merge: 80bb41a 99599e1
+    Author: Martin Reinecke <martin@mpa-garching.mpg.de>
+    Date:   Sat Jan 11 17:09:17 2020 +0100
 
-        Merge branch 'macos-issues' into 'master'
+        Merge branch 'more_clang_fixes' into 'master'
 
-        macOS issues
+        address more problems with clang (and follow its optimization hints)
 
-        See merge request mtr/pypocketfft!27
-
-
+        See merge request mtr/pypocketfft!35
 
 pypocketfft: https://gitlab.mpcdf.mpg.de/mtr/pypocketfft

--- a/scipy/fft/tests/test_backend.py
+++ b/scipy/fft/tests/test_backend.py
@@ -57,3 +57,33 @@ def test_backend_call(func, np_func, mock):
         assert_equal(mock.number_calls, 1)
 
     assert_allclose(func(x), answer, atol=1e-10)
+
+
+plan_funcs = (scipy.fft.fft, scipy.fft.fft2, scipy.fft.fftn,
+              scipy.fft.ifft, scipy.fft.ifft2, scipy.fft.ifftn,
+              scipy.fft.rfft, scipy.fft.rfft2, scipy.fft.rfftn,
+              scipy.fft.irfft, scipy.fft.irfft2, scipy.fft.irfftn,
+              scipy.fft.hfft, scipy.fft.hfft2, scipy.fft.hfftn,
+              scipy.fft.ihfft, scipy.fft.ihfft2, scipy.fft.ihfftn)
+
+plan_mocks = (mock_backend.fft, mock_backend.fft2, mock_backend.fftn,
+              mock_backend.ifft, mock_backend.ifft2, mock_backend.ifftn,
+              mock_backend.rfft, mock_backend.rfft2, mock_backend.rfftn,
+              mock_backend.irfft, mock_backend.irfft2, mock_backend.irfftn,
+              mock_backend.hfft, mock_backend.hfft2, mock_backend.hfftn,
+              mock_backend.ihfft, mock_backend.ihfft2, mock_backend.ihfftn)
+
+
+@pytest.mark.parametrize("func, mock", zip(plan_funcs, plan_mocks))
+def test_backend_plan(func, mock):
+    x = np.arange(20).reshape((10, 2))
+
+    with pytest.raises(NotImplementedError, match='precomputed plan'):
+        func(x, plan='foo')
+
+    with set_backend(mock_backend, only=True):
+        mock.number_calls = 0
+        y = func(x, plan='foo')
+        assert_equal(y, mock.return_value)
+        assert_equal(mock.number_calls, 1)
+        assert_equal(mock.last_args[1]['plan'], 'foo')

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -1035,7 +1035,7 @@ class SmoothBivariateSpline(BivariateSpline):
     bisplrep : an older wrapping of FITPACK
     bisplev : an older wrapping of FITPACK
     UnivariateSpline : a similar class for univariate spline interpolation
-    LSQUnivariateSpline : to create a BivariateSpline using weighted
+    LSQBivariateSpline : to create a BivariateSpline using weighted least-squares fitting
 
     Notes
     -----

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -2606,17 +2606,17 @@ def interpn(points, values, xi, method="linear", bounds_error=True,
 
     ndim = values.ndim
     if ndim > 2 and method == "splinef2d":
-        raise ValueError("The method spline2fd can only be used for "
+        raise ValueError("The method splinef2d can only be used for "
                          "2-dimensional input data")
     if not bounds_error and fill_value is None and method == "splinef2d":
-        raise ValueError("The method spline2fd does not support extrapolation.")
+        raise ValueError("The method splinef2d does not support extrapolation.")
 
     # sanity check consistency of input dimensions
     if len(points) > ndim:
         raise ValueError("There are %d point arrays, but values has %d "
                          "dimensions" % (len(points), ndim))
     if len(points) != ndim and method == 'splinef2d':
-        raise ValueError("The method spline2fd can only be used for "
+        raise ValueError("The method splinef2d can only be used for "
                          "scalar data with one point per coordinate")
 
     # sanity check input grid

--- a/scipy/linalg/_sketches.py
+++ b/scipy/linalg/_sketches.py
@@ -28,7 +28,7 @@ def cwt_matrix(n_rows, n_columns, seed=None):
         Number of rows of S
     n_columns: int
         Number of columns of S
-    seed : None or int or `numpy.random.mtrand.RandomState` instance, optional
+    seed : None or int or `numpy.random.RandomState` instance, optional
         This parameter defines the ``RandomState`` object to use for drawing
         random variates.
         If None (or ``np.random``), the global ``np.random`` state is used.
@@ -72,7 +72,7 @@ def clarkson_woodruff_transform(input_matrix, sketch_size, seed=None):
         Input matrix, of shape ``(n, d)``.
     sketch_size: int
         Number of rows for the sketch.
-    seed : None or int or `numpy.random.mtrand.RandomState` instance, optional
+    seed : None or int or `numpy.random.RandomState` instance, optional
         This parameter defines the ``RandomState`` object to use for drawing
         random variates.
         If None (or ``np.random``), the global ``np.random`` state is used.

--- a/scipy/linalg/interpolative.py
+++ b/scipy/linalg/interpolative.py
@@ -417,7 +417,7 @@ def seed(seed=None):
         the generator.
 
         If the value is an integer, the internal state is obtained
-        from `numpy.random.mtrand.RandomState` (MT19937) with the integer
+        from `numpy.random.RandomState` (MT19937) with the integer
         used as the initial seed.
 
         If `seed` is omitted (None), ``numpy.random.rand`` is used to

--- a/scipy/linalg/special_matrices.py
+++ b/scipy/linalg/special_matrices.py
@@ -751,7 +751,7 @@ def invhilbert(n, exact=False):
     >>> invhilbert(16)[7,7]
     4.2475099528537506e+19
     >>> invhilbert(16, exact=True)[7,7]
-    42475099528537378560L
+    42475099528537378560
 
     """
     from scipy.special import comb
@@ -828,10 +828,10 @@ def pascal(n, kind='symmetric', exact=True):
            [1, 2, 1, 0],
            [1, 3, 3, 1]], dtype=uint64)
     >>> pascal(50)[-1, -1]
-    25477612258980856902730428600L
+    25477612258980856902730428600
     >>> from scipy.special import comb
     >>> comb(98, 49, exact=True)
-    25477612258980856902730428600L
+    25477612258980856902730428600
 
     """
 

--- a/scipy/ndimage/_ni_support.py
+++ b/scipy/ndimage/_ni_support.py
@@ -30,6 +30,7 @@
 
 from __future__ import division, print_function, absolute_import
 
+from collections.abc import Iterable
 import numpy
 
 
@@ -56,7 +57,7 @@ def _normalize_sequence(input, rank):
     check if its length is equal to the length of array.
     """
     is_str = isinstance(input, str)
-    if hasattr(input, '__iter__') and not is_str:
+    if not is_str and isinstance(input, Iterable):
         normalized = list(input)
         if len(normalized) != rank:
             err = "sequence argument must have length equal to input rank"

--- a/scipy/ndimage/filters.py
+++ b/scipy/ndimage/filters.py
@@ -29,6 +29,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from __future__ import division, print_function, absolute_import
+from collections.abc import Iterable
 import warnings
 import numbers
 import numpy
@@ -618,6 +619,8 @@ def _correlate_or_convolve(input, weights, output, mode, cval, origin,
     if not weights.flags.contiguous:
         weights = weights.copy()
     output = _ni_support._get_output(output, input)
+    if not isinstance(mode, str) and isinstance(mode, Iterable):
+        raise RuntimeError("A sequence of modes is not supported")
     mode = _ni_support._extend_mode_to_code(mode)
     _nd_image.correlate(input, weights, output, mode, cval, origins)
     return output
@@ -637,7 +640,7 @@ def correlate(input, weights, output=None, mode='reflect', cval=0.0,
     weights : ndarray
         array of weights, same number of dimensions as input
     %(output)s
-    %(mode_multiple)s
+    %(mode)s
     %(cval)s
     %(origin_multiple)s
 
@@ -663,7 +666,7 @@ def convolve(input, weights, output=None, mode='reflect', cval=0.0,
     weights : array_like
         Array of weights, same number of dimensions as input
     %(output)s
-    %(mode_multiple)s
+    %(mode)s
     cval : scalar, optional
         Value to fill past edges of input if `mode` is 'constant'. Default
         is 0.0
@@ -1027,6 +1030,10 @@ def _min_or_max_filter(input, size, footprint, structure, output, mode,
                 raise RuntimeError('structure array has incorrect shape')
             if not structure.flags.contiguous:
                 structure = structure.copy()
+        if not isinstance(mode, str) and isinstance(mode, Iterable):
+            raise RuntimeError(
+                "A sequence of modes is not supported for non-separable "
+                "footprints")
         mode = _ni_support._extend_mode_to_code(mode)
         _nd_image.min_or_max_filter(input, footprint, structure, output,
                                     mode, cval, origins, minimum)
@@ -1051,6 +1058,11 @@ def minimum_filter(input, size=None, footprint=None, output=None,
     -------
     minimum_filter : ndarray
         Filtered array. Has the same shape as `input`.
+
+    Notes
+    -----
+    A sequence of modes (one per axis) is only supported when the footprint is
+    separable. Otherwise, a single mode string must be provided.
 
     Examples
     --------
@@ -1088,6 +1100,11 @@ def maximum_filter(input, size=None, footprint=None, output=None,
     -------
     maximum_filter : ndarray
         Filtered array. Has the same shape as `input`.
+
+    Notes
+    -----
+    A sequence of modes (one per axis) is only supported when the footprint is
+    separable. Otherwise, a single mode string must be provided.
 
     Examples
     --------
@@ -1156,6 +1173,10 @@ def _rank_filter(input, rank, size=None, footprint=None, output=None,
                               origins)
     else:
         output = _ni_support._get_output(output, input)
+        if not isinstance(mode, str) and isinstance(mode, Iterable):
+            raise RuntimeError(
+                "A sequence of modes is not supported by non-separable rank "
+                "filters")
         mode = _ni_support._extend_mode_to_code(mode)
         _nd_image.rank_filter(input, rank, footprint, output, mode, cval,
                               origins)
@@ -1175,7 +1196,7 @@ def rank_filter(input, rank, size=None, footprint=None, output=None,
         indicates the largest element.
     %(size_foot)s
     %(output)s
-    %(mode_multiple)s
+    %(mode)s
     %(cval)s
     %(origin_multiple)s
 
@@ -1214,7 +1235,7 @@ def median_filter(input, size=None, footprint=None, output=None,
     %(input)s
     %(size_foot)s
     %(output)s
-    %(mode_multiple)s
+    %(mode)s
     %(cval)s
     %(origin_multiple)s
 
@@ -1254,7 +1275,7 @@ def percentile_filter(input, percentile, size=None, footprint=None,
         percentile = -20 equals percentile = 80
     %(size_foot)s
     %(output)s
-    %(mode_multiple)s
+    %(mode)s
     %(cval)s
     %(origin_multiple)s
 
@@ -1381,7 +1402,7 @@ def generic_filter(input, function, size=None, footprint=None,
         Function to apply at each element.
     %(size_foot)s
     %(output)s
-    %(mode_multiple)s
+    %(mode)s
     %(cval)s
     %(origin_multiple)s
     %(extra_arguments)s

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -318,6 +318,14 @@ class TestNdimage:
             assert_array_almost_equal([[2, 3, 5], [5, 6, 8]], output)
             assert_equal(output.dtype.type, numpy.float32)
 
+    def test_correlate_mode_sequence(self):
+        kernel = numpy.ones((2, 2))
+        array = numpy.ones((3, 3), float)
+        with assert_raises(RuntimeError):
+            ndimage.correlate(array, kernel, mode=['nearest', 'reflect'])
+        with assert_raises(RuntimeError):
+            ndimage.convolve(array, kernel, mode=['nearest', 'reflect'])
+
     def test_correlate19(self):
         kernel = numpy.array([[1, 0],
                               [0, 1]])
@@ -747,6 +755,10 @@ class TestNdimage:
         assert_array_almost_equal([[2, 2, 1, 1, 1],
                                    [2, 2, 1, 1, 1],
                                    [5, 3, 3, 1, 1]], output)
+        # separable footprint should allow mode sequence
+        output2 = ndimage.minimum_filter(array, footprint=footprint,
+                                         mode=['reflect', 'reflect'])
+        assert_array_almost_equal(output2, output)
 
     def test_minimum_filter07(self):
         array = numpy.array([[3, 2, 5, 1, 4],
@@ -757,6 +769,9 @@ class TestNdimage:
         assert_array_almost_equal([[2, 2, 1, 1, 1],
                                    [2, 3, 1, 3, 1],
                                    [5, 5, 3, 3, 1]], output)
+        with assert_raises(RuntimeError):
+            ndimage.minimum_filter(array, footprint=footprint,
+                                   mode=['reflect', 'constant'])
 
     def test_minimum_filter08(self):
         array = numpy.array([[3, 2, 5, 1, 4],
@@ -822,6 +837,10 @@ class TestNdimage:
         assert_array_almost_equal([[3, 5, 5, 5, 4],
                                    [7, 9, 9, 9, 5],
                                    [8, 9, 9, 9, 7]], output)
+        # separable footprint should allow mode sequence
+        output2 = ndimage.maximum_filter(array, footprint=footprint,
+                                         mode=['reflect', 'reflect'])
+        assert_array_almost_equal(output2, output)
 
     def test_maximum_filter07(self):
         array = numpy.array([[3, 2, 5, 1, 4],
@@ -832,6 +851,10 @@ class TestNdimage:
         assert_array_almost_equal([[3, 5, 5, 5, 4],
                                    [7, 7, 9, 9, 5],
                                    [7, 9, 8, 9, 7]], output)
+        # non-separable footprint should not allow mode sequence
+        with assert_raises(RuntimeError):
+            ndimage.maximum_filter(array, footprint=footprint,
+                                   mode=['reflect', 'reflect'])
 
     def test_maximum_filter08(self):
         array = numpy.array([[3, 2, 5, 1, 4],
@@ -930,6 +953,15 @@ class TestNdimage:
         assert_array_almost_equal(expected, output)
         output = ndimage.median_filter(array, size=(2, 3))
         assert_array_almost_equal(expected, output)
+
+        # non-separable: does not allow mode sequence
+        with assert_raises(RuntimeError):
+            ndimage.percentile_filter(array, 50.0, size=(2, 3),
+                                      mode=['reflect', 'constant'])
+        with assert_raises(RuntimeError):
+            ndimage.rank_filter(array, 3, size=(2, 3), mode=['reflect']*2)
+        with assert_raises(RuntimeError):
+            ndimage.median_filter(array, size=(2, 3), mode=['reflect']*2)
 
     def test_rank09(self):
         expected = [[3, 3, 2, 4, 4],
@@ -1067,6 +1099,13 @@ class TestNdimage:
                 a, _filter_func, footprint=footprint, extra_arguments=(cf,),
                 extra_keywords={'total': cf.sum()})
             assert_array_almost_equal(r1, r2)
+
+        # generic_filter doesn't allow mode sequence
+        with assert_raises(RuntimeError):
+            r2 = ndimage.generic_filter(
+                a, _filter_func, mode=['reflect', 'reflect'],
+                footprint=footprint, extra_arguments=(cf,),
+                extra_keywords={'total': cf.sum()})
 
     def test_extend01(self):
         array = numpy.array([1, 2, 3])

--- a/scipy/optimize/_dual_annealing.py
+++ b/scipy/optimize/_dual_annealing.py
@@ -40,8 +40,8 @@ class VisitingDistribution(object):
         makes the algorithm jump to a more distant region.
         The value range is (0, 3]. It's value is fixed for the life of the
         object.
-    rand_state : `~numpy.random.mtrand.RandomState` object
-        A `~numpy.random.mtrand.RandomState` object for using the current state
+    rand_state : `~numpy.random.RandomState` object
+        A `~numpy.random.RandomState` object for using the current state
         of the created random generator container.
     """
     TAIL_LIMIT = 1.e8
@@ -228,8 +228,8 @@ class StrategyChain(object):
         Instance of `ObjectiveFunWrapper` class.
     minimizer_wrapper: LocalSearchWrapper
         Instance of `LocalSearchWrapper` class.
-    rand_state : `~numpy.random.mtrand.RandomState` object
-        A `~numpy.random.mtrand.RandomState` object for using the current state
+    rand_state : `~numpy.random.RandomState` object
+        A `~numpy.random.RandomState` object for using the current state
         of the created random generator container.
     energy_state: EnergyState
         Instance of `EnergyState` class.
@@ -476,8 +476,8 @@ def dual_annealing(func, bounds, args=(), maxiter=1000,
         algorithm is in the middle of a local search, this number will be
         exceeded, the algorithm will stop just after the local search is
         done. Default value is 1e7.
-    seed : {int or `~numpy.random.mtrand.RandomState` instance}, optional
-        If `seed` is not specified the `~numpy.random.mtrand.RandomState`
+    seed : {int or `~numpy.random.RandomState` instance}, optional
+        If `seed` is not specified the `~numpy.random.RandomState`
         singleton is used.
         If `seed` is an int, a new ``RandomState`` instance is used,
         seeded with `seed`.

--- a/scipy/optimize/_shgo.py
+++ b/scipy/optimize/_shgo.py
@@ -45,7 +45,7 @@ def shgo(func, bounds, args=(), constraints=None, n=100, iters=1, callback=None,
         Constraints definition.
         Function(s) ``R**n`` in the form::
 
-            g(x) <= 0 applied as g : R^n -> R^m
+            g(x) >= 0 applied as g : R^n -> R^m
             h(x) == 0 applied as h : R^n -> R^p
 
         Each constraint is defined in a dictionary with fields:

--- a/scipy/optimize/lbfgsb_src/lbfgsb.f
+++ b/scipy/optimize/lbfgsb_src/lbfgsb.f
@@ -2559,8 +2559,20 @@ c                               Line search is impossible.
          if (stp .eq. one) then
             call dcopy(n,z,1,x,1)
          else
+c        take step and prevent rounding error beyond bound
             do 41 i = 1, n
-               x(i) = stp*d(i) + t(i)
+               if (nbd(i) .ne. 0) then
+                  if (nbd(i) .eq. 1) then !lower bound only
+                     x(i) = max( l(i) , stp*d(i) + t(i) )
+                  else if ( nbd(i) .eq. 2) then !upper and lower bounds
+                     a1 = max( l(i), stp*d(i) + t(i) )
+                     x(i) = min( u(i), a1)
+                  else if ( nbd(i) .eq. 3) then ! upper bound only
+                     x(i) = min( u(i), stp*d(i) + t(i) )
+                  end if
+               else   ! no bounds
+                  x(i) = stp*d(i) + t(i)
+               end if
   41        continue
          endif
       else

--- a/scipy/optimize/lbfgsb_src/lbfgsb.f
+++ b/scipy/optimize/lbfgsb_src/lbfgsb.f
@@ -2561,18 +2561,9 @@ c                               Line search is impossible.
          else
 c        take step and prevent rounding error beyond bound
             do 41 i = 1, n
-               if (nbd(i) .ne. 0) then
-                  if (nbd(i) .eq. 1) then !lower bound only
-                     x(i) = max( l(i) , stp*d(i) + t(i) )
-                  else if ( nbd(i) .eq. 2) then !upper and lower bounds
-                     a1 = max( l(i), stp*d(i) + t(i) )
-                     x(i) = min( u(i), a1)
-                  else if ( nbd(i) .eq. 3) then ! upper bound only
-                     x(i) = min( u(i), stp*d(i) + t(i) )
-                  end if
-               else   ! no bounds
-                  x(i) = stp*d(i) + t(i)
-               end if
+               x(i) = stp*d(i) + t(i)
+               if (nbd(i).eq.1.or.nbd(i).eq.2) x(i) = max(x(i), l(i))
+               if (nbd(i).eq.2.or.nbd(i).eq.3) x(i) = min(x(i), u(i))
   41        continue
          endif
       else

--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -10,7 +10,7 @@ from numpy import (atleast_1d, dot, take, triu, shape, eye,
                    all, where, isscalar, asarray, inf, abs,
                    finfo, inexact, issubdtype, dtype)
 from scipy.linalg import svd, cholesky, solve_triangular, LinAlgError
-from scipy._lib._util import _asarray_validated, _lazywhere
+from scipy._lib._util import _asarray_validated, _lazywhere, getfullargspec_no_self as _getfullargspec
 from .optimize import OptimizeResult, _check_unknown_options, OptimizeWarning
 from ._lsq import least_squares
 from ._lsq.common import make_strictly_feasible
@@ -682,8 +682,9 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
     """
     if p0 is None:
         # determine number of parameters by inspecting the function
-        from scipy._lib._util import getargspec_no_self as _getargspec
-        args, varargs, varkw, defaults = _getargspec(f)
+        sig = _getfullargspec(f)
+        args = sig.args
+        varargs, varkw, defaults = sig.varargs, sig.varkw, sig.defaults
         if len(args) < 2:
             raise ValueError("Unable to determine number of fit parameters.")
         n = len(args) - 1

--- a/scipy/optimize/nonlin.py
+++ b/scipy/optimize/nonlin.py
@@ -117,7 +117,7 @@ import scipy.sparse.linalg
 import scipy.sparse
 from scipy.linalg import get_blas_funcs
 import inspect
-from scipy._lib._util import getargspec_no_self as _getargspec
+from scipy._lib._util import getfullargspec_no_self as _getfullargspec
 from .linesearch import scalar_search_wolfe1, scalar_search_armijo
 
 
@@ -1536,7 +1536,8 @@ def _nonlin_wrapper(name, jac):
     keyword arguments of `nonlin_solve`
 
     """
-    args, varargs, varkw, defaults = _getargspec(jac.__init__)
+    signature = _getfullargspec(jac.__init__)
+    args, varargs, varkw, defaults, kwonlyargs, kwdefaults, _ = signature
     kwargs = list(zip(args[-len(defaults):], defaults))
     kw_str = ", ".join(["%s=%r" % (k, v) for k, v in kwargs])
     if kw_str:
@@ -1544,6 +1545,8 @@ def _nonlin_wrapper(name, jac):
     kwkw_str = ", ".join(["%s=%s" % (k, k) for k, v in kwargs])
     if kwkw_str:
         kwkw_str = kwkw_str + ", "
+    if kwonlyargs:
+        raise ValueError('Unexpected signature %s' % sig)
 
     # Construct the wrapper function so that its keyword arguments
     # are visible in pydoc.help etc.

--- a/scipy/optimize/nonlin.py
+++ b/scipy/optimize/nonlin.py
@@ -1546,7 +1546,7 @@ def _nonlin_wrapper(name, jac):
     if kwkw_str:
         kwkw_str = kwkw_str + ", "
     if kwonlyargs:
-        raise ValueError('Unexpected signature %s' % sig)
+        raise ValueError('Unexpected signature %s' % signature)
 
     # Construct the wrapper function so that its keyword arguments
     # are visible in pydoc.help etc.

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -37,7 +37,7 @@ from .linesearch import (line_search_wolfe1, line_search_wolfe2,
                          line_search_wolfe2 as line_search,
                          LineSearchWarning)
 from ._numdiff import approx_derivative
-from scipy._lib._util import getargspec_no_self as _getargspec
+from scipy._lib._util import getfullargspec_no_self as _getfullargspec
 from scipy._lib._util import MapWrapper
 from scipy.optimize._differentiable_functions import ScalarFunction, FD_METHODS
 
@@ -3066,7 +3066,7 @@ def brute(func, ranges, args=(), Ns=20, full_output=0, finish=fmin,
 
     if callable(finish):
         # set up kwargs for `finish` function
-        finish_args = _getargspec(finish).args
+        finish_args = _getfullargspec(finish).args
         finish_kwargs = dict()
         if 'full_output' in finish_args:
             finish_kwargs['full_output'] = 1

--- a/scipy/optimize/tests/test_lbfgsb_setulb.py
+++ b/scipy/optimize/tests/test_lbfgsb_setulb.py
@@ -1,0 +1,114 @@
+import numpy as np
+from scipy.optimize import _lbfgsb
+
+
+def objfun(x):
+    """simplified objective func to test lbfgsb bound violation"""
+    x0 = [0.8750000000000278,
+          0.7500000000000153,
+          0.9499999999999722,
+          0.8214285714285992,
+          0.6363636363636085]
+    x1 = [1.0, 0.0, 1.0, 0.0, 0.0]
+    x2 = [1.0,
+          0.0,
+          0.9889733043149325,
+          0.0,
+          0.026353554421041155]
+    x3 = [1.0,
+          0.0,
+          0.9889917442915558,
+          0.0,
+          0.020341986743231205]
+
+    f0 = 5163.647901211178
+    f1 = 5149.8181642072905
+    f2 = 5149.379332309634
+    f3 = 5149.374490771297
+
+    g0 = np.array([-0.5934820547965749,
+                   1.6251549718258351,
+                   -71.99168459202559,
+                   5.346636965797545,
+                   37.10732723092604])
+    g1 = np.array([-0.43295349282641515,
+                   1.008607936794592,
+                   18.223666726602975,
+                   31.927010036981997,
+                   -19.667512518739386])
+    g2 = np.array([-0.4699874455100256,
+                   0.9466285353668347,
+                   -0.016874360242016825,
+                   48.44999161133457,
+                   5.819631620590712])
+    g3 = np.array([-0.46970678696829116,
+                   0.9612719312174818,
+                   0.006129809488833699,
+                   48.43557729419473,
+                   6.005481418498221])
+
+    if np.allclose(x, x0):
+        f = f0
+        g = g0
+    elif np.allclose(x, x1):
+        f = f1
+        g = g1
+    elif np.allclose(x, x2):
+        f = f2
+        g = g2
+    elif np.allclose(x, x3):
+        f = f3
+        g = g3
+    else:
+        raise ValueError(
+            'Simplified objective function not defined '
+            'at requested point')
+    return (np.copy(f), np.copy(g))
+
+
+def test_setulb_floatround():
+    """test if setulb() violates bounds
+
+    checks for violation due to floating point rounding error
+    """
+
+    n = 5
+    m = 10
+    factr = 1e7
+    pgtol = 1e-5
+    maxls = 20
+    iprint = -1
+    nbd = np.full((n,), 2)
+    low_bnd = np.zeros(n, np.float64)
+    upper_bnd = np.ones(n, np.float64)
+
+    x0 = np.array(
+        [0.8750000000000278,
+         0.7500000000000153,
+         0.9499999999999722,
+         0.8214285714285992,
+         0.6363636363636085])
+    x = np.copy(x0)
+
+    f = np.array(0.0, np.float64)
+    g = np.zeros(n, np.float64)
+
+    wa = np.zeros(2*m*n + 5*n + 11*m*m + 8*m, np.float64)
+    iwa = np.zeros(3*n, np.int32)
+    task = np.zeros(1, 'S60')
+    csave = np.zeros(1, 'S60')
+    lsave = np.zeros(4, np.int32)
+    isave = np.zeros(44, np.int32)
+    dsave = np.zeros(29, np.float64)
+
+    task[:] = b'START'
+
+    for n_iter in range(7):  # 7 steps required to reproduce error
+        f, g = objfun(x)
+
+        _lbfgsb.setulb(m, x, low_bnd, upper_bnd, nbd, f, g, factr,
+                       pgtol, wa, iwa, task, iprint, csave, lsave,
+                       isave, dsave, maxls)
+
+        assert (x <= upper_bnd).all() and (x >= low_bnd).all(), (
+            "_lbfgsb.setulb() stepped to a point outside of the bounds")

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -15,7 +15,7 @@ from numpy import finfo, power, nan, isclose
 
 from scipy.optimize import zeros, newton, root_scalar
 
-from scipy._lib._util import getargspec_no_self as _getargspec
+from scipy._lib._util import getfullargspec_no_self as _getfullargspec
 
 # Import testing parameters
 from scipy.optimize._tstutils import get_tests, functions as tstutils_functions, fstrings as tstutils_fstrings
@@ -132,10 +132,11 @@ class TestBasic(object):
         # The methods have one of two base signatures:
         # (f, a, b, **kwargs)  # newton
         # (func, x0, **kwargs)  # bisect/brentq/...
-        sig = _getargspec(method)  # ArgSpec with args, varargs, varkw, defaults
-        nDefaults = len(sig[3])
-        nRequired = len(sig[0]) - nDefaults
-        sig_args_keys = sig[0][:nRequired]
+        sig = _getfullargspec(method)  # FullArgSpec with args, varargs, varkw, defaults, ...
+        assert_(not sig.kwonlyargs)
+        nDefaults = len(sig.defaults)
+        nRequired = len(sig.args) - nDefaults
+        sig_args_keys = sig.args[:nRequired]
         sig_kwargs_keys = []
         if name in ['secant', 'newton', 'halley']:
             if name in ['newton', 'halley']:

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -1362,7 +1362,7 @@ def toms748(f, a, b, args=(), k=1,
     if not np.isfinite(b):
         raise ValueError("b is not finite %s" % b)
     if a >= b:
-        raise ValueError("a and b are not an interval [%g, %g]" % (a, b))
+        raise ValueError("a and b are not an interval [{}, {}]".format(a, b))
     if not k >= 1:
         raise ValueError("k too small (%s < 1)" % k)
 

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -1362,7 +1362,7 @@ def toms748(f, a, b, args=(), k=1,
     if not np.isfinite(b):
         raise ValueError("b is not finite %s" % b)
     if a >= b:
-        raise ValueError("a and b are not an interval [%d, %d]" % (a, b))
+        raise ValueError("a and b are not an interval [%g, %g]" % (a, b))
     if not k >= 1:
         raise ValueError("k too small (%s < 1)" % k)
 

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -272,7 +272,7 @@ def freqs_zpk(z, p, k, worN=200):
     return w, h
 
 
-def freqz(b, a=1, worN=512, whole=False, plot=None, fs=2*pi):
+def freqz(b, a=1, worN=512, whole=False, plot=None, fs=2*pi, include_nyquist=False):
     """
     Compute the frequency response of a digital filter.
 
@@ -301,7 +301,7 @@ def freqz(b, a=1, worN=512, whole=False, plot=None, fs=2*pi):
         If a single integer, then compute at that many frequencies (default is
         N=512). This is a convenient alternative to::
 
-            np.linspace(0, fs if whole else fs/2, N, endpoint=False)
+            np.linspace(0, fs if whole else fs/2, N, endpoint=include_nyquist)
 
         Using a number that is fast for FFT computations can result in
         faster computations (see Notes).
@@ -321,6 +321,11 @@ def freqz(b, a=1, worN=512, whole=False, plot=None, fs=2*pi):
         radians/sample (so w is from 0 to pi).
 
         .. versionadded:: 1.2.0
+    include_nyquist : bool, optional
+        If `whole` is False and `worN` is an integer, setting `include_nyquist` to True
+        will include the last frequency (Nyquist frequency) and is otherwise ignored.
+
+        .. versionadded:: 1.5.0
 
     Returns
     -------
@@ -436,7 +441,8 @@ def freqz(b, a=1, worN=512, whole=False, plot=None, fs=2*pi):
         if N < 0:
             raise ValueError('worN must be nonnegative, got %s' % (N,))
         lastpoint = 2 * pi if whole else pi
-        w = np.linspace(0, lastpoint, N, endpoint=False)
+        # if include_nyquist is true and whole is false, w should include end point
+        w = np.linspace(0, lastpoint, N, endpoint=include_nyquist and not whole)
         if (a.size == 1 and N >= b.shape[0] and
                 sp_fft.next_fast_len(N) == N and
                 (b.ndim == 1 or (b.shape[-1] == 1))):

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -810,6 +810,25 @@ class TestFreqz(object):
             assert_array_almost_equal(w_out, [8])
             assert_array_almost_equal(h, [1])
 
+    def test_nyquist(self):
+        w, h = freqz([1.0], worN=8, include_nyquist=True)
+        assert_array_almost_equal(w, np.pi * np.arange(8) / 7.)
+        assert_array_almost_equal(h, np.ones(8))
+        w, h = freqz([1.0], worN=9, include_nyquist=True)
+        assert_array_almost_equal(w, np.pi * np.arange(9) / 8.)
+        assert_array_almost_equal(h, np.ones(9))
+
+        for a in [1, np.ones(2)]:
+            w, h = freqz(np.ones(2), a, worN=0, include_nyquist=True)
+            assert_equal(w.shape, (0,))
+            assert_equal(h.shape, (0,))
+            assert_equal(h.dtype, np.dtype('complex128'))
+
+        w1, h1 = freqz([1.0], worN=8, whole = True, include_nyquist=True)
+        w2, h2 = freqz([1.0], worN=8, whole = True, include_nyquist=False)
+        assert_array_almost_equal(w1, w2)
+        assert_array_almost_equal(h1, h2)
+
 
 class TestSOSFreqz(object):
 

--- a/scipy/sparse/_index.py
+++ b/scipy/sparse/_index.py
@@ -62,9 +62,9 @@ class IndexMixin(object):
                 return self._get_arrayXint(row, col)
             elif isinstance(col, slice):
                 raise IndexError('index results in >2 dimensions')
-            elif row.shape[1] == 1 and col.ndim == 1:
+            elif row.shape[1] == 1 and (col.ndim == 1 or col.shape[0] == 1):
                 # special case for outer indexing
-                return self._get_columnXarray(row[:,0], col)
+                return self._get_columnXarray(row[:,0], col.ravel())
 
         # The only remaining case is inner (fancy) indexing
         row, col = _broadcast_arrays(row, col)

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -20,7 +20,7 @@ from ._index import IndexMixin
 from .sputils import (upcast, upcast_char, to_native, isdense, isshape,
                       getdtype, isscalarlike, isintlike, get_index_dtype,
                       downcast_intp_index, get_sum_dtype, check_shape,
-                      matrix, asmatrix)
+                      matrix, asmatrix, is_pydata_spmatrix)
 
 
 class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
@@ -231,6 +231,9 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         # Dense other.
         elif isdense(other):
             return self.todense() == other
+        # Pydata sparse other.
+        elif is_pydata_spmatrix(other):
+            return NotImplemented
         # Sparse other.
         elif isspmatrix(other):
             warn("Comparing sparse matrices using == is inefficient, try using"
@@ -266,6 +269,9 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         # Dense other.
         elif isdense(other):
             return self.todense() != other
+        # Pydata sparse other.
+        elif is_pydata_spmatrix(other):
+            return NotImplemented
         # Sparse other.
         elif isspmatrix(other):
             # TODO sparse broadcasting

--- a/scipy/sparse/linalg/tests/test_pydata_sparse.py
+++ b/scipy/sparse/linalg/tests/test_pydata_sparse.py
@@ -21,10 +21,31 @@ msg = "pydata/sparse (0.8) does not implement necessary operations"
 sparse_params = [pytest.param("COO"),
                  pytest.param("DOK", marks=[pytest.mark.xfail(reason=msg)])]
 
+scipy_sparse_classes = [
+    sp.bsr_matrix,
+    sp.csr_matrix,
+    sp.coo_matrix,
+    sp.csc_matrix,
+    sp.dia_matrix,
+    sp.dok_matrix
+]
+
 
 @pytest.fixture(params=sparse_params)
 def sparse_cls(request):
     return getattr(sparse, request.param)
+
+
+@pytest.fixture(params=scipy_sparse_classes)
+def sp_sparse_cls(request):
+    return request.param
+
+
+@pytest.fixture
+def same_matrix(sparse_cls, sp_sparse_cls):
+    np.random.seed(1234)
+    A_dense = np.random.rand(9, 9)
+    return sp_sparse_cls(A_dense), sparse_cls(A_dense)
 
 
 @pytest.fixture
@@ -202,3 +223,13 @@ def test_expm_multiply(matrices):
     x0 = splin.expm_multiply(A_dense, b)
     x = splin.expm_multiply(A_sparse, b)
     assert_allclose(x, x0)
+
+
+def test_eq(same_matrix):
+    sp_sparse, pd_sparse = same_matrix
+    assert (sp_sparse == pd_sparse).all()
+
+
+def test_ne(same_matrix):
+    sp_sparse, pd_sparse = same_matrix
+    assert not (sp_sparse != pd_sparse).any()

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -366,7 +366,7 @@ def directed_hausdorff(u, v, seed=0):
     v : (O,N) ndarray
         Input array.
     seed : int or None
-        Local `numpy.random.mtrand.RandomState` seed. Default is 0, a random
+        Local `numpy.random.RandomState` seed. Default is 0, a random
         shuffling of u and v that guarantees reproducibility.
 
     Returns

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2180,9 +2180,9 @@ def comb(N, k, exact=False, repetition=False):
     >>> comb(n, k, exact=False)
     array([ 120.,  210.])
     >>> comb(10, 3, exact=True)
-    120L
+    120
     >>> comb(10, 3, exact=True, repetition=True)
-    220L
+    220
 
     """
     if repetition:
@@ -2318,7 +2318,7 @@ def factorial(n, exact=False):
     >>> factorial(arr, exact=True)
     array([  6,  24, 120])
     >>> factorial(5, exact=True)
-    120L
+    120
 
     """
     if exact:
@@ -2399,7 +2399,7 @@ def factorial2(n, exact=False):
     >>> factorial2(7, exact=False)
     array(105.00000000000001)
     >>> factorial2(7, exact=True)
-    105L
+    105
 
     """
     if exact:
@@ -2462,9 +2462,9 @@ def factorialk(n, k, exact=True):
     --------
     >>> from scipy.special import factorialk
     >>> factorialk(5, 1, exact=True)
-    120L
+    120
     >>> factorialk(5, 3, exact=True)
-    10L
+    10
 
     """
     if exact:

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -1561,7 +1561,7 @@ class exponweib_gen(rv_continuous):
 
     See Also
     --------
-    weibull_min, numpy.random.mtrand.RandomState.weibull
+    weibull_min, numpy.random.RandomState.weibull
 
     Notes
     -----
@@ -1938,7 +1938,7 @@ class weibull_min_gen(rv_continuous):
 
     See Also
     --------
-    weibull_max, numpy.random.mtrand.RandomState.weibull, exponweib
+    weibull_max, numpy.random.RandomState.weibull, exponweib
 
     Notes
     -----

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -4,7 +4,7 @@
 #
 from __future__ import division, print_function, absolute_import
 
-from scipy._lib._util import getargspec_no_self as _getargspec
+from scipy._lib._util import getfullargspec_no_self as _getfullargspec
 
 import sys
 import keyword
@@ -581,9 +581,9 @@ class rv_generic(object):
         super(rv_generic, self).__init__()
 
         # figure out if _stats signature has 'moments' keyword
-        sign = _getargspec(self._stats)
+        sign = _getfullargspec(self._stats)
         self._stats_has_moments = ((sign[2] is not None) or
-                                   ('moments' in sign[0]))
+                                   ('moments' in sign[0]) or ('moments' in sign[4]))
         self._random_state = check_random_state(seed)
 
     @property
@@ -647,7 +647,7 @@ class rv_generic(object):
             # are shapes.
             shapes_list = []
             for meth in meths_to_inspect:
-                shapes_args = _getargspec(meth)   # NB: does not contain self
+                shapes_args = _getfullargspec(meth)   # NB: does not contain self
                 args = shapes_args.args[1:]       # peel off 'x', too
 
                 if args:
@@ -660,6 +660,9 @@ class rv_generic(object):
                     if shapes_args.keywords is not None:
                         raise TypeError(
                             '**kwds are not allowed w/out explicit shapes')
+                    if shapes_args.kwonlyargs:
+                        raise TypeError(
+                            'kwonly args are not allowed w/out explicit shapes')
                     if shapes_args.defaults is not None:
                         raise TypeError('defaults are not allowed for shapes')
 

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -581,9 +581,10 @@ class rv_generic(object):
         super(rv_generic, self).__init__()
 
         # figure out if _stats signature has 'moments' keyword
-        sign = _getfullargspec(self._stats)
-        self._stats_has_moments = ((sign[2] is not None) or
-                                   ('moments' in sign[0]) or ('moments' in sign[4]))
+        sig = _getfullargspec(self._stats)
+        self._stats_has_moments = ((sig.varkw is not None) or
+                                   ('moments' in sig.args) or
+                                   ('moments' in sig.kwonlyargs))
         self._random_state = check_random_state(seed)
 
     @property
@@ -657,7 +658,7 @@ class rv_generic(object):
                     if shapes_args.varargs is not None:
                         raise TypeError(
                             '*args are not allowed w/out explicit shapes')
-                    if shapes_args.keywords is not None:
+                    if shapes_args.varkw is not None:
                         raise TypeError(
                             '**kwds are not allowed w/out explicit shapes')
                     if shapes_args.kwonlyargs:

--- a/scipy/stats/tests/common_tests.py
+++ b/scipy/stats/tests/common_tests.py
@@ -9,7 +9,7 @@ from pytest import raises as assert_raises
 
 import numpy.ma.testutils as ma_npt
 
-from scipy._lib._util import getargspec_no_self as _getargspec
+from scipy._lib._util import getfullargspec_no_self as _getfullargspec
 from scipy import stats
 
 
@@ -144,9 +144,10 @@ def check_named_args(distfn, x, shape_args, defaults, meths):
     ## Check calling w/ named arguments.
 
     # check consistency of shapes, numargs and _parse signature
-    signature = _getargspec(distfn._parse_args)
+    signature = _getfullargspec(distfn._parse_args)
     npt.assert_(signature.varargs is None)
-    npt.assert_(signature.keywords is None)
+    npt.assert_(signature.varkw is None)
+    npt.assert_(not signature.kwonlyargs)
     npt.assert_(list(signature.defaults) == list(defaults))
 
     shape_argnames = signature.args[:-len(defaults)]  # a, b, loc=0, scale=1


### PR DESCRIPTION
#### Reference issue
Closes gh-11416

#### What does this implement/fix?
* In `_lib._util.get_argspec_no_self()`:
    * return `POSITIONAL_ONLY` arguments in the args element of the ArgSpec tuple.
    * raise ValueError if the method has keyword-only arguments (matches behaviour
   of Python's `inspect.getargspec`).
* Add `_util.getfullargspec_no_self` to match `inspect.getfullargspec`.
* Use `_util.getfullargspec_no_self` in `stats.rv_generic.__init__` when checking
  for the presence of the 'moment' keyword in the distribution's `._stats` method.
* Added tests of `get_argspec_no_self` and `getfullargspec_no_self` to `_lib/tests/test__util.py`

If `get_argspec_no_self` would return incomplete information it will raise an
Exception instead.  This should solve the backwards compatibility issue, in
that older code using it will still work if it can, and break if it would fail.