### PR TITLE
TST: Python 3.7 mac OS gcc multibuild fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -143,8 +143,7 @@ before_install:
       export PATH=$TRAVIS_BUILD_DIR/gcc_aliases:$PATH
       popd
       touch config.sh
-      git clone https://github.com/matthew-brett/multibuild.git
-      git -C multibuild checkout 65fd07a180046b4473b21e9084e01f1bf1a8dfac
+      git clone --depth=1 https://github.com/matthew-brett/multibuild.git
       source multibuild/common_utils.sh
       source multibuild/travis_steps.sh
       before_install

--- a/.travis.yml
+++ b/.travis.yml
@@ -171,6 +171,8 @@ before_install:
       echo "library_dirs = $TRAVIS_BUILD_DIR/openblas/usr/local/lib" >> site.cfg
       echo "include_dirs = $TRAVIS_BUILD_DIR/openblas/usr/local/include" >> site.cfg
       echo "runtime_library_dirs = $TRAVIS_BUILD_DIR/openblas/usr/local/lib" >> site.cfg
+      # remove a spurious gcc/gfortran toolchain install
+      rm -rf /usr/local/Cellar/gcc/9.2.0_2
     fi
   - export CCACHE_COMPRESS=1
   - python --version # just to check


### PR DESCRIPTION
This is part of an effort to address https://github.com/scipy/scipy/issues/10485. Specifically, both master branch of SciPy repo proper & our wheels repo treat Mac OS + Python 3.7 CI builds differently by pinning multibuild to an older version than the latest.

There are compelling reasons to want to use the latest multibuild:
- appropriate naming of MacOS wheels as noted in #10485 
- dealing with pip20 support as noted here: https://github.com/matthew-brett/multibuild/pull/299
- support for upcoming ARM, POWER, s390x wheels ecosystems moving forward

Once this is revised & in (works in my fork anyway..), I would probably feel comfortable unpinning multibuild for the similar MacOS entry in our wheels repo, so that i.e., `1.4.2` can have a full complement of appropriately designated MacOS wheels & use pip20.

@pv I reverted your old multibuild pin from #10917; that original complex issue seems to have been fixed & replaced with the somewhat-simpler issue of an inappropriate/too-recent gcc toolchain install causing trouble, probably because of an automatic `brew update` or something.