### PR TITLE
ENH: Add tool to lint diffs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ matrix:
         # TODO: remove "ignore[import]" filter below when moving to pyflakes==2.1.2 or above
         - PYFLAKES_NODOCTEST=1 pyflakes scipy benchmarks/benchmarks 2>&1 | grep -E -v 'unable to detect undefined names|assigned to but never used|imported but unused|redefinition of unused|may be undefined, or defined from star imports|syntax error in type comment .ignore.import.' > test.out; cat test.out; test \! -s test.out
         - pycodestyle scipy benchmarks/benchmarks
+        - tools/lint_diff.py
         - |
           grep -rlIP '[^\x00-\x7F]' scipy | grep '\.pyx\?' | sort > unicode.out; grep -rlI '# -\*- coding: \(utf-8\|latin-1\) -\*-' scipy | grep '\.pyx\?' | sort > coding.out; comm -23 unicode.out coding.out > test_code.out; cat test_code.out;  test \! -s test_code.out
     - python: 3.7

--- a/runtests.py
+++ b/runtests.py
@@ -137,11 +137,12 @@ def main(argv):
     args = parser.parse_args(argv)
 
     if args.pep8:
-        # os.system("flake8 scipy --ignore=F403,F841,F401,F811,F405,E121,E122,"
-        #           "E123,E125,E126,E127,E128,E226,E231,E251,E265,E266,E302,"
-        #           "E402,E501,E712,E721,E731,E741,W291,W293,W391,W503,W504"
-        #           "--exclude=scipy/_lib/six.py")
+        # Lint the source using the configuration in tox.ini.
         os.system("pycodestyle scipy benchmarks/benchmarks")
+        # Lint just the diff since branching off of master using a
+        # stricter configuration.
+        lint_diff = os.path.join(ROOT_DIR, 'tools', 'lint_diff.py')
+        os.system(lint_diff)
         sys.exit(0)
 
     if args.mypy:

--- a/tools/lint_diff.ini
+++ b/tools/lint_diff.ini
@@ -1,0 +1,5 @@
+[pycodestyle]
+max_line_length = 79
+statistics = True
+ignore = E121,E122,E123,E125,E126,E127,E128,E226,E251,E265,E266,E302,E402,E501,E712,E721,E731,E741,W291,W293,W391,W503,W504
+exclude = scipy/__config__.py

--- a/tools/lint_diff.py
+++ b/tools/lint_diff.py
@@ -1,0 +1,84 @@
+import os
+import sys
+import subprocess
+
+CONFIG = os.path.join(
+    os.path.abspath(os.path.dirname(__file__)),
+    'lint_diff.ini',
+)
+
+
+def rev_list(branch, num_commits):
+    """List commits in reverse chronological order.
+
+    Only the first `num_commits` are shown.
+
+    """
+    res = subprocess.run(
+        [
+            'git',
+            'rev-list',
+            '--max-count',
+            f'{num_commits}',
+            '--first-parent',
+            branch
+        ],
+        capture_output=True,
+        text=True,
+    )
+    res.check_returncode()
+    return res.stdout.rstrip('\n').split('\n')
+
+
+def find_branch_point():
+    """Find when the current branch split off master.
+
+    It is based off of this Stackoverflow post:
+
+    https://stackoverflow.com/questions/1527234/finding-a-branch-point-with-git#4991675
+
+    """
+    branch_commits = rev_list('HEAD', 100)
+    master_commits = set(rev_list('master', 100))
+    for branch_commit in branch_commits:
+        if branch_commit in master_commits:
+            return branch_commit
+
+    # If a branch split off over 100 commits ago we will fail to find
+    # the ancestor.
+    raise RuntimeError('Failed to find a common ancestor')
+
+
+def find_diff(sha):
+    """Find the diff since the given sha."""
+    res = subprocess.run(
+        ['git', 'diff', '--unified=0', sha],
+        capture_output=True,
+        text=True,
+    )
+    res.check_returncode()
+    return res.stdout
+
+
+def run_pycodestyle(diff):
+    """Run pycodestyle on the given diff."""
+    res = subprocess.run(
+        ['pycodestyle', '--diff', '--config', CONFIG],
+        input=diff,
+        capture_output=True,
+        text=True,
+    )
+    return res.returncode, res.stdout
+
+
+def main():
+    branch_point = find_branch_point()
+    diff = find_diff(branch_point)
+    rc, errors = run_pycodestyle(diff)
+    if errors:
+        print(errors)
+    sys.exit(rc)
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/lint_diff.py
+++ b/tools/lint_diff.py
@@ -24,8 +24,8 @@ def rev_list(branch, num_commits):
             '--first-parent',
             branch
         ],
-        capture_output=True,
-        text=True,
+        stdout=subprocess.PIPE,
+        encoding='utf-8',
     )
     res.check_returncode()
     return res.stdout.rstrip('\n').split('\n')
@@ -55,8 +55,8 @@ def find_diff(sha):
     """Find the diff since the given sha."""
     res = subprocess.run(
         ['git', 'diff', '--unified=0', sha, '--', '*.py'],
-        capture_output=True,
-        text=True,
+        stdout=subprocess.PIPE,
+        encoding='utf-8',
     )
     res.check_returncode()
     return res.stdout
@@ -67,8 +67,8 @@ def run_pycodestyle(diff):
     res = subprocess.run(
         ['pycodestyle', '--diff', '--config', CONFIG],
         input=diff,
-        capture_output=True,
-        text=True,
+        stdout=subprocess.PIPE,
+        encoding='utf-8',
     )
     return res.returncode, res.stdout
 

--- a/tools/lint_diff.py
+++ b/tools/lint_diff.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import os
 import sys
 import subprocess
@@ -38,21 +39,22 @@ def find_branch_point():
     https://stackoverflow.com/questions/1527234/finding-a-branch-point-with-git#4991675
 
     """
-    branch_commits = rev_list('HEAD', 100)
-    master_commits = set(rev_list('master', 100))
+    branch_commits = rev_list('HEAD', 1000)
+    master_commits = set(rev_list('master', 1000))
     for branch_commit in branch_commits:
         if branch_commit in master_commits:
             return branch_commit
 
-    # If a branch split off over 100 commits ago we will fail to find
+    # If a branch split off over 1000 commits ago we will fail to find
     # the ancestor.
-    raise RuntimeError('Failed to find a common ancestor')
+    raise RuntimeError(
+        'Failed to find a common ancestor in the last 1000 commits')
 
 
 def find_diff(sha):
     """Find the diff since the given sha."""
     res = subprocess.run(
-        ['git', 'diff', '--unified=0', sha],
+        ['git', 'diff', '--unified=0', sha, '--', '*.py'],
         capture_output=True,
         text=True,
     )


### PR DESCRIPTION
## Reference issue
None

#### What does this implement/fix?
As discussed on the mailing list:

https://mail.python.org/pipermail/scipy-dev/2020-January/023927.html

we can move towards better code style without causing disruption
by adding extra lint checks for diffs. This adds a script that
lints the diff between the tip of the current branch and where it
split off of master.

#### Additional information
Currently only one new check is enabled (whitespace after `,`).
Do we want others?