### PR TITLE
FIX: _array_newton should preserve complex inputs

### DIFF
--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -352,6 +352,14 @@ class TestBasic(object):
         x = zeros.newton(f, t, fprime=fprime)
         assert_allclose(f(x), 0.)
 
+        # should work even if x0 is not complex
+        t = np.ones(4)
+        x = zeros.newton(f, t, fprime=fprime)
+        assert_allclose(f(x), 0.)
+
+        x = zeros.newton(f, t)
+        assert_allclose(f(x), 0.)
+
     def test_array_secant_active_zero_der(self):
         """test secant doesn't continue to iterate zero derivatives"""
         x = zeros.newton(lambda x, *a: x*x - a[0], x0=[4.123, 5],

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -341,6 +341,17 @@ class TestBasic(object):
         x = zeros.newton(f1, x0, args=args)
         assert_allclose(x, x_expected)
 
+    def test_array_newton_complex(self):
+        def f(x):
+            return x + 1+1j
+
+        def fprime(x):
+            return 1.0
+
+        t = np.full(4, 1j)
+        x = zeros.newton(f, t, fprime=fprime)
+        assert_allclose(f(x), 0.)
+
     def test_array_secant_active_zero_der(self):
         """test secant doesn't continue to iterate zero derivatives"""
         x = zeros.newton(lambda x, *a: x*x - a[0], x0=[4.123, 5],

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -372,13 +372,10 @@ def _array_newton(func, x0, fprime, args, tol, maxiter, fprime2, full_output):
     Do not use this method directly. This method is called from `newton`
     when ``np.size(x0) > 1`` is ``True``. For docstring, see `newton`.
     """
+    x0 = np.asarray(x0)
     # Explicitly copy `x0` as `p` will be modified inplace, but the
     # user's array should not be altered.
-    try:
-        p = np.array(x0, copy=True, dtype=float)
-    except TypeError:
-        # can't convert complex to float
-        p = np.array(x0, copy=True)
+    p = np.array(x0, copy=True, dtype=np.promote_types(x0.dtype, np.float64))
 
     failures = np.ones_like(p, dtype=bool)
     nz_der = np.ones_like(failures)


### PR DESCRIPTION
#### Reference issue
Closes gh-11412

#### What does this implement/fix?
Instead of casting the input with `dtype=float`, use `np.promote_types` to promote integer types but leave complex types unchanged. This will also avoid truncating `np.longfloat` input as well.