### PR TITLE
MAINT: licence for global optimization benchmarks

### DIFF
--- a/LICENSES_bundled.txt
+++ b/LICENSES_bundled.txt
@@ -168,3 +168,9 @@ Name: uarray
 Files: scipy/_lib/uarray/*
 License: 3-Clause BSD
   For details, see scipy/_lib/uarray/LICENSE
+
+Name: ampgo
+Files: benchmarks/benchmarks/go_benchmark_functions/*.py
+License: MIT
+  Functions for testing global optimizers, forked from the AMPGO project,
+  https://code.google.com/archive/p/ampgo


### PR DESCRIPTION
The benchmarks for testing global optimizers were developed from a fork of the AMPGO project (https://code.google.com/archive/p/ampgo/), which was MIT licenced. This PR points out where the original code came from, and what its licence was.