### PR TITLE
MAINT: Python3 improvements to refguide_check.py 

### DIFF
--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -35,16 +35,15 @@ import shutil
 import sys
 import tempfile
 import warnings
-import docutils.core
 from argparse import ArgumentParser
 from contextlib import contextmanager, redirect_stderr
 from doctest import NORMALIZE_WHITESPACE, ELLIPSIS, IGNORE_EXCEPTION_DETAIL
 
+import docutils.core
+import numpy as np
+import sphinx
 from docutils.parsers.rst import directives
 from pkg_resources import parse_version
-
-import sphinx
-import numpy as np
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'doc', 'sphinxext'))
 from numpydoc.docscrape_sphinx import get_doc_object


### PR DESCRIPTION
This builds on https://github.com/scipy/scipy/pull/11433 (now submitted) (which has a little personal intro)

This is 3 changes I submitted to numpy (see https://github.com/numpy/numpy/issues/15306#issuecomment-579428830 for numpy commits)

```
MAINT: Use contextmanager in _run_doctests
DOC: Update refguide_check note on how to skip code #15449
MAINT: Cleanup references to python2
```
I've additionally sorted the imports to be, what I believe is, PEP8 compliant.
```
MAINT: reorder tools/refguide_check imports
```

If you would prefer this as 4 git commits instead of the squashed
`DEV: upstream changes to refguide_check from numpy`
I can try to unbundle them