### PR TITLE
MAINT: Remove checks for sys.version < 3.5

### DIFF
--- a/doc/postprocess.py
+++ b/doc/postprocess.py
@@ -7,7 +7,6 @@ MODE is either 'html' or 'tex'.
 
 """
 import sys
-import io
 import re, optparse
 
 def main():
@@ -22,23 +21,16 @@ def main():
     if mode not in ('html', 'tex'):
         p.error('unknown mode %s' % mode)
 
-    def _open(fn, *args, **kwargs):
-        r"""Handle UTF-8 encoding when loading under Py3"""
-        # Issue is that default encoding under Py3 is
-        # locale dependent (might even be ASCII),
-        # so need to specify the encoding.  Py2 doesn't care.
-        if sys.version_info.major < 3:
-            return open(fn, *args, **kwargs)
-        return io.open(fn, *args, encoding='utf-8', **kwargs)
-
     for fn in args:
-        with _open(fn, 'r') as f:
+        # default encoding under Py3 is locale dependent (might even be ASCII),
+        # so need to specify the encoding.
+        with open(fn, 'r', encoding='utf-8') as f:
             if mode == 'html':
                 lines = process_html(fn, f.readlines())
             elif mode == 'tex':
                 lines = process_tex(f.readlines())
 
-        with _open(fn, 'w') as f:
+        with open(fn, 'w', encoding='utf-8') as f:
             f.write("".join(lines))
 
 

--- a/runtests.py
+++ b/runtests.py
@@ -175,7 +175,7 @@ def main(argv):
             sys.modules['__main__'] = new_module('__main__')
             ns = dict(__name__='__main__',
                       __file__=extra_argv[0])
-            exec_(script, ns)
+            exec(script, ns)
             sys.exit(0)
         else:
             import code
@@ -471,26 +471,6 @@ def lcov_generate():
     else:
         print("HTML output generated under build/lcov/")
 
-
-#
-# Python 3 support
-#
-
-if sys.version_info[0] >= 3:
-    import builtins
-    exec_ = getattr(builtins, "exec")
-else:
-    def exec_(code, globs=None, locs=None):
-        """Execute code in a namespace."""
-        if globs is None:
-            frame = sys._getframe(1)
-            globs = frame.f_globals
-            if locs is None:
-                locs = frame.f_locals
-            del frame
-        elif locs is None:
-            locs = globs
-        exec("""exec code in globs, locs""")
 
 if __name__ == "__main__":
     main(argv=sys.argv[1:])

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -4,6 +4,7 @@
 from __future__ import division, print_function, absolute_import
 
 import operator
+import math
 import sys
 import timeit
 from scipy.spatial import cKDTree
@@ -12,18 +13,12 @@ from ._upfirdn import upfirdn, _output_len, _upfirdn_modes
 from scipy import linalg, fft as sp_fft
 from scipy.fft._helper import _init_nd_shape_and_axes
 import numpy as np
-import math
 from scipy.special import factorial, lambertw
 from .windows import get_window
 from ._arraytools import axis_slice, axis_reverse, odd_ext, even_ext, const_ext
 from .filter_design import cheby1, _validate_sos
 from .fir_filter_design import firwin
 from ._sosfilt import _sosfilt
-
-if sys.version_info >= (3, 5):
-    from math import gcd
-else:
-    from fractions import gcd
 
 
 __all__ = ['correlate', 'correlate2d',
@@ -3065,7 +3060,7 @@ def resample_poly(x, up, down, axis=0, window=('kaiser', 5.0),
     # Determine our up and down factors
     # Use a rational approximation to save computation time on really long
     # signals
-    g_ = gcd(up, down)
+    g_ = math.gcd(up, down)
     up //= g_
     down //= g_
     if up == down == 1:

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -5,6 +5,7 @@ import sys
 
 from decimal import Decimal
 from itertools import product
+from math import gcd
 import warnings
 
 import pytest
@@ -31,12 +32,6 @@ from scipy.signal.windows import hann
 from scipy.signal.signaltools import (_filtfilt_gust, _compute_factors,
                                       _group_poles)
 from scipy.signal._upfirdn import _upfirdn_modes
-
-
-if sys.version_info >= (3, 5):
-    from math import gcd
-else:
-    from fractions import gcd
 
 
 class _TestConvolve(object):

--- a/scipy/sparse/_matrix_io.py
+++ b/scipy/sparse/_matrix_io.py
@@ -131,7 +131,7 @@ def load_npz(file):
 
         matrix_format = matrix_format.item()
 
-        if sys.version_info[0] >= 3 and not isinstance(matrix_format, str):
+        if not isinstance(matrix_format, str):
             # Play safe with Python 2 vs 3 backward compatibility;
             # files saved with SciPy < 1.0.0 may contain unicode or bytes.
             matrix_format = matrix_format.decode('ascii')

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -782,12 +782,8 @@ def check_doctests_testfile(fname, verbose, ns=None,
         return results
 
     full_name = fname
-    if sys.version_info.major <= 2:
-        with open(fname) as f:
-            text = f.read()
-    else:
-        with open(fname, encoding='utf-8') as f:
-            text = f.read()
+    with open(fname, encoding='utf-8') as f:
+        text = f.read()
 
     PSEUDOCODE = set(['some_function', 'some_module', 'import example',
                       'ctypes.CDLL',     # likely need compiling, skip it

--- a/tools/suppress_output.py
+++ b/tools/suppress_output.py
@@ -88,10 +88,7 @@ def main():
 
         if ret != 0:
             log.seek(0)
-            if sys.version_info[0] >= 3:
-                shutil.copyfileobj(log, sys.stdout.buffer)
-            else:
-                shutil.copyfileobj(log, sys.stdout)
+            shutil.copyfileobj(log, sys.stdout.buffer)
 
     sys.exit(ret)
 


### PR DESCRIPTION
This removes most uses of sys.version, what's left is all reasonable stuff.