### PR TITLE
Support path objects (PEP 519) in mmio functions

### DIFF
--- a/scipy/io/tests/test_paths.py
+++ b/scipy/io/tests/test_paths.py
@@ -21,7 +21,7 @@ class TestPaths:
         with tempdir() as temp_dir:
             path = Path(temp_dir) / 'data.mat'
             scipy.io.savemat(path, {'data': self.data})
-            assert_(path.is_file())
+            assert path.is_file()
 
     def test_loadmat(self):
         # Save data with string path, load with pathlib.Path
@@ -30,7 +30,7 @@ class TestPaths:
             scipy.io.savemat(str(path), {'data': self.data})
 
             mat_contents = scipy.io.loadmat(path)
-            assert_((mat_contents['data'] == self.data).all())
+            assert (mat_contents['data'] == self.data).all()
 
     def test_whosmat(self):
         # Save data with string path, load with pathlib.Path
@@ -39,7 +39,7 @@ class TestPaths:
             scipy.io.savemat(str(path), {'data': self.data})
 
             contents = scipy.io.whosmat(path)
-            assert_(contents[0] == ('data', (1, 5), 'int64'))
+            assert contents[0] == ('data', (1, 5), 'int64')
 
     def test_readsav(self):
         path = Path(__file__).parent / 'data/scalar_string.sav'
@@ -53,14 +53,14 @@ class TestPaths:
             scipy.io.harwell_boeing.hb_write(str(path), data)
 
             data_new = scipy.io.harwell_boeing.hb_read(path)
-            assert_((data_new != data).nnz == 0)
+            assert (data_new != data).nnz == 0
 
     def test_hb_write(self):
         with tempdir() as temp_dir:
             data = scipy.sparse.csr_matrix(scipy.sparse.eye(3))
             path = Path(temp_dir) / 'data.hb'
             scipy.io.harwell_boeing.hb_write(path, data)
-            assert_(path.is_file())
+            assert path.is_file()
 
     def test_mmio_read(self):
         # Save data with string path, load with pathlib.Path
@@ -70,7 +70,7 @@ class TestPaths:
             scipy.io.mmwrite(str(path), data)
 
             data_new = scipy.io.mmread(path)
-            assert_((data_new != data).nnz == 0)
+            assert (data_new != data).nnz == 0
 
     def test_mmio_write(self):
         with tempdir() as temp_dir:

--- a/scipy/io/tests/test_paths.py
+++ b/scipy/io/tests/test_paths.py
@@ -2,13 +2,7 @@
 Ensure that we can use pathlib.Path objects in all relevant IO functions.
 """
 import sys
-
-try:
-    from pathlib import Path
-except ImportError:
-    # Not available. No fallback import, since we'll skip the entire
-    # test suite for Python < 3.6.
-    pass
+from pathlib import Path
 
 import numpy as np
 from numpy.testing import assert_
@@ -20,9 +14,7 @@ from scipy._lib._tmpdirs import tempdir
 import scipy.sparse
 
 
-@pytest.mark.skipif(sys.version_info < (3, 6),
-                    reason='Passing path-like objects to IO functions requires Python >= 3.6')
-class TestPaths(object):
+class TestPaths:
     data = np.arange(5).astype(np.int64)
 
     def test_savemat(self):

--- a/scipy/io/tests/test_paths.py
+++ b/scipy/io/tests/test_paths.py
@@ -70,6 +70,22 @@ class TestPaths(object):
             scipy.io.harwell_boeing.hb_write(path, data)
             assert_(path.is_file())
 
+    def test_mmio_read(self):
+        # Save data with string path, load with pathlib.Path
+        with tempdir() as temp_dir:
+            data = scipy.sparse.csr_matrix(scipy.sparse.eye(3))
+            path = Path(temp_dir) / 'data.mtx'
+            scipy.io.mmwrite(str(path), data)
+
+            data_new = scipy.io.mmread(path)
+            assert_((data_new != data).nnz == 0)
+
+    def test_mmio_write(self):
+        with tempdir() as temp_dir:
+            data = scipy.sparse.csr_matrix(scipy.sparse.eye(3))
+            path = Path(temp_dir) / 'data.mtx'
+            scipy.io.mmwrite(path, data)
+
     def test_netcdf_file(self):
         path = Path(__file__).parent / 'data/example_1.nc'
         scipy.io.netcdf.netcdf_file(path)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Extends #6855 and #7649 with more I/O functions that I hadn't noticed/used until recently.

#### What does this implement/fix?
Allows using `pathlib.Path` objects (and more) in `scipy.io.mmio` functions. Added test coverage for passing `pathlib.Path` objects to `scipy.io.mmread` and `scipy.io.mmwrite`.

#### Additional information
I noticed in `setup.py` that SciPy now requires Python 3.6 or newer. That simplifies the implementation of this functionality a little bit, since we can now assume the existence of the `os.fspath` function, which converts any path-like object to a `str`. The approach here is "try to convert to `str`, if that fails it must be an open file-like object". (This approach can be used elsewhere, but that seems like it should be a separate PR.)