### PR TITLE
correct bounds pass in run_dualannealing for benchmarks/optimize.py

### DIFF
--- a/benchmarks/benchmarks/optimize.py
+++ b/benchmarks/benchmarks/optimize.py
@@ -197,7 +197,6 @@ class _BenchOptimizers(Benchmark):
         t0 = time.time()
 
         res = dual_annealing(self.fun,
-                             None,
                              self.bounds)
 
         t1 = time.time()


### PR DESCRIPTION
#### Reference issue
closes https://github.com/scipy/scipy/issues/11438

#### What does this implement/fix?
fixes scipy optimize benchmarks for dual_annealing function

#### Additional information
