### PR TITLE
BUG: fix augmentation being broken in maximum_bipartite_matching

### DIFF
--- a/scipy/sparse/csgraph/tests/test_matching.py
+++ b/scipy/sparse/csgraph/tests/test_matching.py
@@ -84,6 +84,28 @@ def test_explicit_zeros_count_as_edges():
     assert_array_equal(expected_matching, y)
 
 
+def test_feasibility_of_result():
+    # This is a regression test for GitHub issue #11458
+    data = np.ones(50, dtype=int)
+    indices = [11, 12, 19, 22, 23, 5, 22, 3, 8, 10, 5, 6, 11, 12, 13, 5, 13,
+               14, 20, 22, 3, 15, 3, 13, 14, 11, 12, 19, 22, 23, 5, 22, 3, 8,
+               10, 5, 6, 11, 12, 13, 5, 13, 14, 20, 22, 3, 15, 3, 13, 14]
+    indptr = [0, 5, 7, 10, 10, 15, 20, 22, 22, 23, 25, 30, 32, 35, 35, 40, 45,
+              47, 47, 48, 50]
+    graph = csr_matrix((data, indices, indptr), shape=(20, 25))
+    x = maximum_bipartite_matching(graph, perm_type='row')
+    y = maximum_bipartite_matching(graph, perm_type='column')
+    assert (x != -1).sum() == 13
+    assert (y != -1).sum() == 13
+    # Ensure that each element of the matching is in fact an edge in the graph.
+    for u, v in zip(range(graph.shape[0]), y):
+        if v != -1:
+            assert graph[u, v]
+    for u, v in zip(x, range(graph.shape[1])):
+        if u != -1:
+            assert graph[u, v]
+
+
 def test_large_random_graph_with_one_edge_incident_to_each_vertex():
     np.random.seed(42)
     A = diags(np.ones(25), offsets=0, format='csr')


### PR DESCRIPTION
This fixes an issue that would worst case cause infeasible solutions to be produced by `scipy.sparse.csgraph.maximum_bipartite_matching` as the matching would end up containing edges that do not belong to the input graph.

The root cause of the issue was a piece of broken logic in the DFS part of the Hopcroft--Karp implementation concerned with keeping track of the augmenting path; looking at it again now, I'm not sure why I thought that would work, so I feel bad for letting that one slip through. We fix the issue by replacing this logic with a more standard approach of marking the parents of each vertex visited on the path (or rather, its grandparent, as we still only deal explicitly with one partition of the graph at a time). As an added benefit, this should make the implementation ever so slightly easier to follow.

A regression test has been added to showcase an example of an input that would previously lead to an infeasible solution.

I'll let someone else determine if backporting is necessary, but let me note that while this showed up in a randomly generated toy example, my best guess would be that this could, unfortunately, just as likely appear in real-life examples. If one uses the resulting matching for anything, one is likely to notice immediately, but if one only uses its cardinality, the issue may go unnoticed.

This closes #11458.

To validate the new implementation, in addition to the added regression test, I've run a number of random cases and ensured that in each of them, the given solution is feasible and its cardinality matches what NetworkX gives:

```
from random import randint, random
import networkx as nx
import scipy
from scipy.sparse.csgraph import maximum_bipartite_matching

for _ in range(1000):
    n = randint(100, 500)
    m = randint(100, 500)
    density = random()
    graph = scipy.sparse.rand(n, m, density=density, format='csr')
    mcol = maximum_bipartite_matching(graph, perm_type='column')
    mrow = maximum_bipartite_matching(graph, perm_type='row')
    G = nx.algorithms.bipartite.from_biadjacency_matrix(graph)
    assert np.sum(mcol >= 0) == np.sum(mrow >= 0)
    assert np.sum(mcol >= 0) == len(nx.algorithms.bipartite.maximum_matching(G, top_nodes=range(n)))//2
    for i in range(n):
        if mcol[i] != -1:
            assert graph[i, mcol[i]]
    for i in range(m):
        if mrow[i] != -1:
            assert graph[mrow[i], i]]
```