### PR TITLE
MAINT: minor spelling corrections in comments in SciPy.sparse.linalg.arpack

### DIFF
--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -772,7 +772,7 @@ class TestHetrd(object):
                     - tau[i] * np.outer(v, np.conj(v))
                 Q = np.dot(H, Q)
 
-            # Make matrix fully Hermetian
+            # Make matrix fully Hermitian
             i_lower = np.tril_indices(n, -1)
             A[i_lower] = np.conj(A.T[i_lower])
 

--- a/scipy/sparse/linalg/eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/arpack.py
@@ -908,7 +908,7 @@ class SpLuInv(LinearOperator):
     """
     SpLuInv:
        helper class to repeatedly solve M*x=b
-       using a sparse LU-decopposition of M
+       using a sparse LU-decomposition of M
     """
     def __init__(self, M):
         self.M_lu = splu(M)

--- a/scipy/sparse/linalg/eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/arpack.py
@@ -14,10 +14,10 @@ Uses ARPACK: http://www.caam.rice.edu/software/ARPACK/
 # - (s,d,c,z)neupd: single,double,complex,double complex general matrix
 # This wrapper puts the *neupd (general matrix) interfaces in eigs()
 # and the *seupd (symmetric matrix) in eigsh().
-# There is no Hermetian complex/double complex interface.
-# To find eigenvalues of a Hermetian matrix you
+# There is no Hermitian complex/double complex interface.
+# To find eigenvalues of a Hermitian matrix you
 # must use eigs() and not eigsh()
-# It might be desirable to handle the Hermetian case differently
+# It might be desirable to handle the Hermitian case differently
 # and, for example, return real eigenvalues.
 
 # Number of eigenvalues returned and complex eigenvalues


### PR DESCRIPTION
* ‘decopposition’ → ‘decomposition’
* ‘Hermetian’ → ‘Hermitian’
