### PR TITLE
BUG: Fixed `_kpp` initialization on `scipy.cluster.vq`

### DIFF
--- a/scipy/cluster/vq.py
+++ b/scipy/cluster/vq.py
@@ -556,7 +556,7 @@ def _kpp(data, k):
 
     for i in range(k):
         if i == 0:
-            init[i, :] = data[np.random.randint(dims)]
+            init[i, :] = data[np.random.randint(data.shape[0])]
 
         else:
             D2 = np.array([min(


### PR DESCRIPTION
The function `_kpp` used the wrong dimension to sample the data.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes #11462 

#### What does this implement/fix?
This corrects the dimension used, the feature dimension was being used in place of the sample dimension. This resulted in a non-uniform sampling over the data and sometimes crash when the feature dimension was larger than the sample size.
