### PR TITLE
[MRG] Make result data type of KDE evaluation like in the input data (Issue #11464)

### DIFF
--- a/scipy/stats/kde.py
+++ b/scipy/stats/kde.py
@@ -196,7 +196,7 @@ class gaussian_kde(object):
         self.d, self.n = self.dataset.shape
 
         if weights is not None:
-            self._weights = atleast_1d(weights).astype(float)
+            self._weights = atleast_1d(weights)
             self._weights /= sum(self._weights)
             if self.weights.ndim != 1:
                 raise ValueError("`weights` input should be one-dimensional.")

--- a/scipy/stats/kde.py
+++ b/scipy/stats/kde.py
@@ -196,7 +196,7 @@ class gaussian_kde(object):
         self.d, self.n = self.dataset.shape
 
         if weights is not None:
-            self._weights = atleast_1d(weights)
+            self._weights = atleast_1d(weights).astype(float)
             self._weights /= sum(self._weights)
             if self.weights.ndim != 1:
                 raise ValueError("`weights` input should be one-dimensional.")

--- a/scipy/stats/kde.py
+++ b/scipy/stats/kde.py
@@ -239,7 +239,11 @@ class gaussian_kde(object):
                     self.d)
                 raise ValueError(msg)
 
-        result = zeros((m,), dtype=float)
+        if np.issubdtype(points.dtype, np.floating):
+            output_dtype = points.dtype
+        else:
+            output_dtype = np.float
+        result = zeros((m,), dtype=output_dtype)
 
         whitening = linalg.cholesky(self.inv_cov)
         scaled_dataset = dot(whitening, self.dataset)

--- a/scipy/stats/kde.py
+++ b/scipy/stats/kde.py
@@ -239,10 +239,7 @@ class gaussian_kde(object):
                     self.d)
                 raise ValueError(msg)
 
-        if np.issubdtype(points.dtype, np.floating):
-            output_dtype = points.dtype
-        else:
-            output_dtype = np.float
+        output_dtype = np.common_type(self.covariance, points)
         result = zeros((m,), dtype=output_dtype)
 
         whitening = linalg.cholesky(self.inv_cov)

--- a/scipy/stats/tests/test_kdeoth.py
+++ b/scipy/stats/tests/test_kdeoth.py
@@ -317,6 +317,24 @@ def test_kde_integer_input():
     y_expected = [0.13480721, 0.18222869, 0.19514935, 0.18222869, 0.13480721]
     assert_array_almost_equal(kde(x1), y_expected, decimal=6)
 
+@pytest.mark.parametrize("test_type", (np.float64, np.float32, np.float128))
+def test_kde_output_dtype(test_type):
+    # test that if input is floating, we maintain the datatype
+    x1 = np.arange(5)
+    k = stats.kde.gaussian_kde(x1)
+    points = np.arange(5, dtype=test_type)
+    result = k(points)
+    assert result.dtype == test_type
+
+def test_kde_output_dtype():
+    # test that kde result is floating if input is not floating
+    test_type = np.int
+    x1 = np.arange(5)
+    k = stats.kde.gaussian_kde(x1)
+    points = np.arange(5, dtype=test_type)
+    result = k(points)
+    assert result.dtype == np.float64
+
 
 def test_pdf_logpdf():
     np.random.seed(1)

--- a/scipy/stats/tests/test_kdeoth.py
+++ b/scipy/stats/tests/test_kdeoth.py
@@ -319,9 +319,12 @@ def test_kde_integer_input():
 
 @pytest.mark.skipif(not hasattr(np, 'float96'), reason='cannot find float96 so skipping')
 @pytest.mark.skipif(not hasattr(np, 'float128'), reason='cannot find float128 so skipping')
-@pytest.mark.parametrize("test_type", (np.float64, np.float32, np.float96, np.float128))
-def test_kde_output_dtype(test_type):
+@pytest.mark.parametrize("test_type", (0,1,2,3))
+def test_kde_output_dtype(test_type_ix):
     # test that if input is floating, we maintain the datatype
+    # need to have the list of types inside, because skipif only applies within the test
+    test_types = [np.float64, np.float32, np.float96, np.float128]
+    test_type = test_types[test_type_ix]
     x1 = np.arange(5)
     k = stats.kde.gaussian_kde(x1)
     points = np.arange(5, dtype=test_type)

--- a/scipy/stats/tests/test_kdeoth.py
+++ b/scipy/stats/tests/test_kdeoth.py
@@ -318,31 +318,20 @@ def test_kde_integer_input():
     assert_array_almost_equal(kde(x1), y_expected, decimal=6)
 
 
-@pytest.mark.parametrize("bw_type", [getattr(np, dtype, None) for dtype in
-                         ['float32', 'float64', 'float96', 'float128']] +
-                         ["scott", "silverman"])
-@pytest.mark.parametrize("weights_type", [getattr(np, dtype, None) for dtype in
-                         ['float32', 'float64', 'float96', 'float128']])
-@pytest.mark.parametrize("dataset_type", [getattr(np, dtype, None) for dtype in
-                         ['float32', 'float64', 'float96', 'float128']])
-@pytest.mark.parametrize("point_type", [getattr(np, dtype, None) for dtype in
-                         ['float32', 'float64', 'float96', 'float128']])
+_ftypes = [getattr(np, dtype) for dtype in ['float32', 'float64', 'float96',
+                                            'float128', 'int32', 'int64']
+           if hasattr(np, dtype)]
+
+@pytest.mark.parametrize("bw_type", _ftypes + ["scott", "silverman"])
+@pytest.mark.parametrize("weights_type", _ftypes)
+@pytest.mark.parametrize("dataset_type", _ftypes)
+@pytest.mark.parametrize("point_type", _ftypes)
 def test_kde_output_dtype(point_type, dataset_type, weights_type, bw_type):
-    # test that for any given combination of input datatypes we get the 
+    # test that for any given combination of input datatypes we get the
     # appropriate result datatype
-    if point_type is None:
-        pytest.skip("Data type not available")
-    if dataset_type is None:
-        pytest.skip("Data type not available")
+    weights = np.arange(5, dtype=weights_type)
 
-    if weights_type is None:
-        pytest.skip("Data type not available")
-    else:
-        weights = np.arange(5, dtype=weights_type)
-
-    if bw_type is None:
-        pytest.skip("Data type not available")
-    elif bw_type in ["scott", "silverman"]:
+    if bw_type in ["scott", "silverman"]:
         bw = bw_type
     else:
         bw = bw_type(3)
@@ -352,15 +341,6 @@ def test_kde_output_dtype(point_type, dataset_type, weights_type, bw_type):
     points = np.arange(5, dtype=point_type)
     result = k(points)
     assert result.dtype == np.result_type(dataset, points, weights, k.factor)
-
-def test_kde_output_dtype():
-    # test that kde result is floating if input is not floating
-    test_type = np.int
-    x1 = np.arange(5)
-    k = stats.kde.gaussian_kde(x1)
-    points = np.arange(5, dtype=test_type)
-    result = k(points)
-    assert result.dtype == np.float64
 
 
 def test_pdf_logpdf():

--- a/scipy/stats/tests/test_kdeoth.py
+++ b/scipy/stats/tests/test_kdeoth.py
@@ -317,14 +317,13 @@ def test_kde_integer_input():
     y_expected = [0.13480721, 0.18222869, 0.19514935, 0.18222869, 0.13480721]
     assert_array_almost_equal(kde(x1), y_expected, decimal=6)
 
-@pytest.mark.skipif(not hasattr(np, 'float96'), reason='cannot find float96 so skipping')
-@pytest.mark.skipif(not hasattr(np, 'float128'), reason='cannot find float128 so skipping')
-@pytest.mark.parametrize("test_type", (0,1,2,3))
-def test_kde_output_dtype(test_type_ix):
+@pytest.mark.parametrize("test_type", [getattr(np, dtype, None) for dtype in
+                         ['float32', 'float64', 'float96', 'float128']])
+def test_kde_output_dtype(test_type):
     # test that if input is floating, we maintain the datatype
     # need to have the list of types inside, because skipif only applies within the test
-    test_types = [np.float64, np.float32, np.float96, np.float128]
-    test_type = test_types[test_type_ix]
+    if test_type is None:
+        pytest.skip("Data type not available")
     x1 = np.arange(5)
     k = stats.kde.gaussian_kde(x1)
     points = np.arange(5, dtype=test_type)

--- a/scipy/stats/tests/test_kdeoth.py
+++ b/scipy/stats/tests/test_kdeoth.py
@@ -340,7 +340,9 @@ def test_kde_output_dtype(point_type, dataset_type, weights_type, bw_type):
     k = stats.kde.gaussian_kde(dataset, bw_method=bw, weights=weights)
     points = np.arange(5, dtype=point_type)
     result = k(points)
-    assert result.dtype == np.result_type(dataset, points, weights, k.factor)
+    # weights are always cast to float64
+    assert result.dtype == np.result_type(dataset, points, np.float64(weights),
+                                          k.factor)
 
 
 def test_pdf_logpdf():

--- a/scipy/stats/tests/test_kdeoth.py
+++ b/scipy/stats/tests/test_kdeoth.py
@@ -317,7 +317,9 @@ def test_kde_integer_input():
     y_expected = [0.13480721, 0.18222869, 0.19514935, 0.18222869, 0.13480721]
     assert_array_almost_equal(kde(x1), y_expected, decimal=6)
 
-@pytest.mark.parametrize("test_type", (np.float64, np.float32, np.float128))
+@pytest.mark.skipif(not hasattr(np, 'float96'), reason='cannot find float96 so skipping')
+@pytest.mark.skipif(not hasattr(np, 'float128'), reason='cannot find float128 so skipping')
+@pytest.mark.parametrize("test_type", (np.float64, np.float32, np.float96, np.float128))
 def test_kde_output_dtype(test_type):
     # test that if input is floating, we maintain the datatype
     x1 = np.arange(5)


### PR DESCRIPTION
As discussed in Issue #11464, currently the KDE evaluation always returns float64 arrays, regardless of the point input data type. This PR makes the data type agree with the input datatype, as long as it is a floating datatype. If it's not a float, I'm not sure this change would make any sense.

#### Reference issue
Closes gh-#11464.

#### What does this implement/fix?
Checks the input data type and instantiate the results array with this dtype if it floats.

#### Additional information
I can't get scipy to build right now, that's why I'm putting it as work in progress.