### PR TITLE
BUG: Make special.hyperu return nan if any argument is nan

### DIFF
--- a/scipy/special/_hypergeometric.pxd
+++ b/scipy/special/_hypergeometric.pxd
@@ -20,6 +20,9 @@ DEF ACCEPTABLE_RTOL = 1e-7
 
 @cython.cdivision(True)
 cdef inline double hyperu(double a, double b, double x) nogil:
+    if npy_isnan(a) or npy_isnan(b) or npy_isnan(x):
+        return NPY_NAN
+
     if x < 0.0:
         sf_error.error("hyperu", sf_error.DOMAIN, NULL)
         return NPY_NAN

--- a/scipy/special/tests/test_hypergeometric.py
+++ b/scipy/special/tests/test_hypergeometric.py
@@ -19,6 +19,11 @@ class TestHyperu(object):
     def test_special_cases(self):
         assert sc.hyperu(0, 1, 1) == 1.0
 
+    @pytest.mark.parametrize('a', [0.5, 1, np.nan])
+    @pytest.mark.parametrize('b', [1, 2, np.nan])
+    @pytest.mark.parametrize('x', [0.25, 3, np.nan])
+    def test_nan_inputs(self, a, b, x):
+        assert np.isnan(sc.hyperu(a, b, x)) == np.any(np.isnan([a, b, x]))
 
 class TestHyp1f1(object):
 


### PR DESCRIPTION
#### Reference issue
Closes #11363.

#### What does this implement/fix?
* Added a check for `np.nan`-valued arguments in `scipy.special.hyperu`. If any input argument is `np.nan`, the output of the function will also be `np.nan`.
* Added a test to test whether `hyperu` correctly returns `np.nan` when passed any combination of `np.nan`-valued arguments .