### PR TITLE
BUG: Fixed `_kpp` initialization on `scipy.cluster.vq`, closing #11463

### DIFF
--- a/scipy/cluster/tests/test_vq.py
+++ b/scipy/cluster/tests/test_vq.py
@@ -297,3 +297,16 @@ class TestKMean(object):
         np.random.seed(42)
         res, _ = kmeans2(TESTDATA_2D, 2, minit='++')
         assert_allclose(res, prev_res)
+
+    def test_kmeans2_kpp_high_dim(self):
+        # Regression test for gh-11462
+        n_dim = 100
+        size = 10
+        centers = np.vstack([ 5 * np.ones(n_dim),
+                             -5 * np.ones(n_dim)])
+        data = np.vstack([np.random.multivariate_normal(centers[0], np.eye(n_dim), size=size),
+                          np.random.multivariate_normal(centers[1], np.eye(n_dim), size=size)])
+        # 20x100 dataset
+        np.random.seed(42)
+        res, _ = kmeans2(data, 2, minit='++')
+        assert_array_almost_equal(res, centers, decimal=0) 

--- a/scipy/cluster/tests/test_vq.py
+++ b/scipy/cluster/tests/test_vq.py
@@ -289,7 +289,7 @@ class TestKMean(object):
         res = kmeans(x, 1, thresh=1e16)
         assert_allclose(res[0], np.array([4.]))
         assert_allclose(res[1], 2.3999999999999999)
-        
+
     def test_kmeans2_kpp_low_dim(self):
         # Regression test for gh-11462
         prev_res = np.array([[-1.95266667, 0.898],
@@ -305,8 +305,9 @@ class TestKMean(object):
         centers = np.vstack([5 * np.ones(n_dim),
                              -5 * np.ones(n_dim)])
         np.random.seed(42)
-        data = np.vstack([np.random.multivariate_normal(centers[0], np.eye(n_dim), size=size),
-                          np.random.multivariate_normal(centers[1], np.eye(n_dim), size=size)])
-        # 20x100 dataset
+        data = np.vstack([
+            np.random.multivariate_normal(centers[0], np.eye(n_dim), size=size),
+            np.random.multivariate_normal(centers[1], np.eye(n_dim), size=size)
+        ])
         res, _ = kmeans2(data, 2, minit='++')
         assert_array_almost_equal(res, centers, decimal=0)

--- a/scipy/cluster/tests/test_vq.py
+++ b/scipy/cluster/tests/test_vq.py
@@ -309,4 +309,5 @@ class TestKMean(object):
         # 20x100 dataset
         np.random.seed(42)
         res, _ = kmeans2(data, 2, minit='++')
-        assert_array_almost_equal(res, centers, decimal=0) 
+        assert_array_almost_equal(res, centers, decimal=0)
+        

--- a/scipy/cluster/tests/test_vq.py
+++ b/scipy/cluster/tests/test_vq.py
@@ -292,8 +292,8 @@ class TestKMean(object):
         
     def test_kmeans2_kpp_low_dim(self):
         # Regression test for gh-11462
-        prev_res = np.array([[-1.95266667,  0.898],
-                             [-3.153375  ,  3.3945]])
+        prev_res = np.array([[-1.95266667, 0.898],
+                             [-3.153375, 3.3945]])
         np.random.seed(42)
         res, _ = kmeans2(TESTDATA_2D, 2, minit='++')
         assert_allclose(res, prev_res)
@@ -302,12 +302,11 @@ class TestKMean(object):
         # Regression test for gh-11462
         n_dim = 100
         size = 10
-        centers = np.vstack([ 5 * np.ones(n_dim),
+        centers = np.vstack([5 * np.ones(n_dim),
                              -5 * np.ones(n_dim)])
+        np.random.seed(42)
         data = np.vstack([np.random.multivariate_normal(centers[0], np.eye(n_dim), size=size),
                           np.random.multivariate_normal(centers[1], np.eye(n_dim), size=size)])
         # 20x100 dataset
-        np.random.seed(42)
         res, _ = kmeans2(data, 2, minit='++')
         assert_array_almost_equal(res, centers, decimal=0)
-        

--- a/scipy/cluster/tests/test_vq.py
+++ b/scipy/cluster/tests/test_vq.py
@@ -289,3 +289,11 @@ class TestKMean(object):
         res = kmeans(x, 1, thresh=1e16)
         assert_allclose(res[0], np.array([4.]))
         assert_allclose(res[1], 2.3999999999999999)
+        
+    def test_kmeans2_kpp_low_dim(self):
+        # Regression test for gh-11462
+        prev_res = np.array([[-1.95266667,  0.898],
+                             [-3.153375  ,  3.3945]])
+        np.random.seed(42)
+        res, _ = kmeans2(TESTDATA_2D, 2, minit='++')
+        assert_allclose(res, prev_res)

--- a/scipy/cluster/vq.py
+++ b/scipy/cluster/vq.py
@@ -556,7 +556,7 @@ def _kpp(data, k):
 
     for i in range(k):
         if i == 0:
-            init[i, :] = data[np.random.randint(dims)]
+            init[i, :] = data[np.random.randint(data.shape[0])]
 
         else:
             D2 = np.array([min(


### PR DESCRIPTION
The function `_kpp` used the wrong dimension to sample the data.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes #11462 

#### What does this implement/fix?
This corrects the dimension used, the feature dimension was being used in place of the sample dimension. This resulted in a non-uniform sampling over the data and sometimes crash when the feature dimension was larger than the sample size.

#### Note
I will be closing the PR #11463 because I accidentally deleted the branch, so I wasn't able to add the requested changes.