### PR TITLE
BUG: make special.eval_hermite return nan if second argument is nan

### DIFF
--- a/scipy/special/orthogonal_eval.pxd
+++ b/scipy/special/orthogonal_eval.pxd
@@ -57,6 +57,9 @@ cdef inline number_t hyp1f1(double a, double b, number_t z) nogil:
         r = chyp1f1_wrap(a, b, npy_cdouble_from_double_complex(z))
         return double_complex_from_npy_cdouble(r)
 
+cdef extern from "numpy/npy_math.h":
+    double npy_isnan(double x) nogil
+
 #-----------------------------------------------------------------------------
 # Binomial coefficient
 #-----------------------------------------------------------------------------
@@ -480,6 +483,9 @@ cdef inline double eval_laguerre_l(long n, double x) nogil:
 cdef inline double eval_hermitenorm(long n, double x) nogil:
     cdef long k
     cdef double y1, y2, y3
+
+    if npy_isnan(x):
+        return x
 
     if n < 0:
         sf_error.error(

--- a/scipy/special/tests/test_orthogonal_eval.py
+++ b/scipy/special/tests/test_orthogonal_eval.py
@@ -2,8 +2,9 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 from numpy.testing import assert_, assert_allclose
-import scipy.special.orthogonal as orth
+import pytest
 
+import scipy.special.orthogonal as orth
 from scipy.special._testutils import FuncData
 
 
@@ -252,3 +253,11 @@ def test_hermite_domain():
     # Regression test for gh-11091.
     assert np.isnan(orth.eval_hermite(-1, 1.0))
     assert np.isnan(orth.eval_hermitenorm(-1, 1.0))
+
+
+@pytest.mark.parametrize("n", [0, 1, 2])
+@pytest.mark.parametrize("x", [0, 1, np.nan])
+def test_hermite_nan(n, x):
+    # Regression test for gh-11369.
+    assert np.isnan(orth.eval_hermite(n, x)) == np.any(np.isnan([n, x]))
+    assert np.isnan(orth.eval_hermitenorm(n, x)) == np.any(np.isnan([n, x]))


### PR DESCRIPTION
#### Reference issue
Closes #11369.

#### What does this implement/fix?
* The `special.eval_hermitenorm` and `special.eval_hermite` (which calls `eval_hermitenorm`) functions save a little computation work for the special case where the first argument is `0`, in which case the return value is always `1`; however, in the case where the second argument is `np.nan`, we'd like the `np.nan` value to propagate through. The modifications made here ensure both functions correctly return `np.nan` when the second argument passed to the function is `np.nan`.
* Tests have been added for both functions to check that `np.nan` is correctly returned when passed as the second argument.