### PR TITLE
BUG: fixes typo introduced in PR #11253 in stats.mstats.kendalltau()

### DIFF
--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -621,7 +621,7 @@ def kendalltau(x, y, use_ties=True, use_missing=False, method='auto'):
         elif c == 1:
             prob = 2.0/np.math.factorial(n-1)
         elif 2*c == (n*(n-1))//2:
-            pvalue = 1.0
+            prob = 1.0
         else:
             old = [0.0]*(c+1)
             new = [0.0]*(c+1)

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -250,6 +250,14 @@ class TestCorr(object):
     @pytest.mark.skipif(platform.machine() == 'ppc64le',
                         reason="fails/crashes on ppc64le")
     def test_kendalltau(self):
+        # check case with with maximum disorder and p=1
+        x = ma.array(np.array([9, 2, 5, 6]))
+        y = ma.array(np.array([4, 7, 9, 11]))
+        # Cross-check with exact result from R:
+        # cor.test(x,y,method="kendall",exact=1)
+        expected = [0.0, 1.0]
+        assert_almost_equal(np.asarray(mstats.kendalltau(x, y)), expected)
+        
         # simple case without ties
         x = ma.array(np.arange(10))
         y = ma.array(np.arange(10))


### PR DESCRIPTION
The bug found by @WarrenWeckesser introduced in PR #11253 is fixed and the example used to show the problem is added as a test.

#### Reference issue
Fixes bug introduced in #11253.

#### What does this implement/fix?
Fixes typo pvalue -> prob and adds corresponding test.
