### PR TITLE
DOC: fix typo in scipy/io/matlab/mio4.py

### DIFF
--- a/scipy/io/matlab/mio4.py
+++ b/scipy/io/matlab/mio4.py
@@ -161,7 +161,7 @@ class VarReader4(object):
         Returns
         -------
         arr : ndarray
-            of dtype givem by `hdr` ``dtype`` and shape givem by `hdr` ``dims``
+            of dtype given by `hdr` ``dtype`` and shape given by `hdr` ``dims``
         '''
         dt = hdr.dtype
         dims = hdr.dims


### PR DESCRIPTION

#### Reference issue
N/A

#### What does this implement/fix?
fix typo in scipy/io/matlab/mio4.py (read_sub_array docstring)

#### Additional information
N/A