### PR TITLE
[WIP] avoid copy for dtype conversion when possible

### DIFF
--- a/scipy/io/matlab/mio4.py
+++ b/scipy/io/matlab/mio4.py
@@ -216,7 +216,7 @@ class VarReader4(object):
         arr : ndarray
             with dtype 'U1', shape given by `hdr` ``dims``
         '''
-        arr = self.read_sub_array(hdr).astype(np.uint8)
+        arr = self.read_sub_array(hdr).astype(np.uint8, copy=False)
         S = arr.tostring().decode('latin-1')
         return np.ndarray(shape=hdr.dims,
                           dtype=np.dtype('U1'),

--- a/scipy/io/matlab/mio5.py
+++ b/scipy/io/matlab/mio5.py
@@ -636,11 +636,11 @@ class VarWriter5(object):
             # No matching matlab type, probably complex256 / float128 / float96
             # Cast data to complex128 / float64.
             if imagf:
-                arr = arr.astype('c128')
+                arr = arr.astype('c128', copy=False)
             elif logif:
-                arr = arr.astype('i1')  # Should only contain 0/1
+                arr = arr.astype('i1', copy=False)  # Should only contain 0/1
             else:
-                arr = arr.astype('f8')
+                arr = arr.astype('f8', copy=False)
             mclass = mxDOUBLE_CLASS
         self.write_header(matdims(arr, self.oned_as),
                           mclass,
@@ -709,8 +709,8 @@ class VarWriter5(object):
                           is_logical=is_logical,
                           # matlab won't load file with 0 nzmax
                           nzmax=1 if nz == 0 else nz)
-        self.write_element(A.indices.astype('i4'))
-        self.write_element(A.indptr.astype('i4'))
+        self.write_element(A.indices.astype('i4', copy=False))
+        self.write_element(A.indptr.astype('i4', copy=False))
         self.write_element(A.data.real)
         if is_complex:
             self.write_element(A.data.imag)

--- a/scipy/io/matlab/mio5_utils.pyx
+++ b/scipy/io/matlab/mio5_utils.pyx
@@ -706,7 +706,7 @@ cdef class VarReader5:
                     mat_dtype = BOOL_DTYPE
                 else:
                     mat_dtype = <object>self.class_dtypes[mc]
-                arr = arr.astype(mat_dtype)
+                arr = arr.astype(mat_dtype, copy=False)
         elif mc == mxSPARSE_CLASS:
             arr = self.read_sparse(header)
             # no current processing makes sense for sparse
@@ -860,7 +860,7 @@ cdef class VarReader5:
                 arr = np.ndarray(shape=(length,),
                                   dtype=dt,
                                   buffer=data)
-                data = arr.astype(np.uint8).tostring()
+                data = arr.astype(np.uint8, copy=False).tostring()
         elif mdtype == miINT8 or mdtype == miUINT8:
             codec = 'ascii'
         elif mdtype in self.codecs: # encoded char data

--- a/scipy/io/mmio.py
+++ b/scipy/io/mmio.py
@@ -672,13 +672,13 @@ class MMFile (object):
                     if not can_cast(a.dtype, 'intp'):
                         raise OverflowError("mmwrite does not support integer "
                                             "dtypes larger than native 'intp'.")
-                    a = a.astype('intp')
+                    a = a.astype('intp', copy=False)
                 elif field == self.FIELD_REAL:
                     if a.dtype.char not in 'fd':
-                        a = a.astype('d')
+                        a = a.astype('d', copy=False)
                 elif field == self.FIELD_COMPLEX:
                     if a.dtype.char not in 'FD':
-                        a = a.astype('D')
+                        a = a.astype('D', copy=False)
 
         else:
             if not isspmatrix(a):

--- a/scipy/io/netcdf.py
+++ b/scipy/io/netcdf.py
@@ -533,7 +533,7 @@ class netcdf_file(object):
                 try:
                     var.data.resize(shape)
                 except ValueError:
-                    var.__dict__['data'] = np.resize(var.data, shape).astype(var.data.dtype)
+                    var.__dict__['data'] = np.resize(var.data, shape).astype(var.data.dtype, copy=False)
 
             pos0 = pos = self.fp.tell()
             for rec in var.data:
@@ -975,7 +975,7 @@ class netcdf_variable(object):
         scale_factor = self._attributes.get('scale_factor')
         add_offset = self._attributes.get('add_offset')
         if add_offset is not None or scale_factor is not None:
-            data = data.astype(np.float64)
+            data = data.astype(np.float64, copy=False)
         if scale_factor is not None:
             data = data * scale_factor
         if add_offset is not None:
@@ -1013,7 +1013,7 @@ class netcdf_variable(object):
                 try:
                     self.data.resize(shape)
                 except ValueError:
-                    self.__dict__['data'] = np.resize(self.data, shape).astype(self.data.dtype)
+                    self.__dict__['data'] = np.resize(self.data, shape).astype(self.data.dtype, copy=False)
         self.data[index] = data
 
     def _default_encoded_fill_value(self):

--- a/scipy/sparse/bsr.py
+++ b/scipy/sparse/bsr.py
@@ -388,10 +388,10 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
         indptr = np.empty(self.indptr.shape, dtype=idx_dtype)
 
         csr_matmat_pass1(M//R, N//C,
-                         self.indptr.astype(idx_dtype),
-                         self.indices.astype(idx_dtype),
-                         other.indptr.astype(idx_dtype),
-                         other.indices.astype(idx_dtype),
+                         self.indptr.astype(idx_dtype, copy=False),
+                         self.indices.astype(idx_dtype, copy=False),
+                         other.indptr.astype(idx_dtype, copy=False),
+                         other.indices.astype(idx_dtype, copy=False),
                          indptr)
 
         bnnz = indptr[-1]
@@ -404,11 +404,11 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
         data = np.empty(R*C*bnnz, dtype=upcast(self.dtype,other.dtype))
 
         bsr_matmat_pass2(M//R, N//C, R, C, n,
-                         self.indptr.astype(idx_dtype),
-                         self.indices.astype(idx_dtype),
+                         self.indptr.astype(idx_dtype, copy=False),
+                         self.indices.astype(idx_dtype, copy=False),
                          np.ravel(self.data),
-                         other.indptr.astype(idx_dtype),
-                         other.indices.astype(idx_dtype),
+                         other.indptr.astype(idx_dtype, copy=False),
+                         other.indices.astype(idx_dtype, copy=False),
                          np.ravel(other.data),
                          indptr,
                          indices,


### PR DESCRIPTION
#### Reference issue
N/A

#### What does this implement/fix?
It seems scipy makes extensive use of [`numpy.ndarray.astype`](https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.astype.html) without setting `copy=False` (~200 instances). Quite often this forces unnecessary copies when the original dtype is the same as the target dtype.

This PR is work in progress to fix this in the `scipy.sparse` package. In some instances the original and target dtype are never the same. In those cases, the change has no effect, but it might be a good idea to use `copy=False` defensively.

#### Additional information

Script to find `astype` usage without explicit `copy` argument. Ignores tests and does not support cython (`*.pyx`) files at the moment.

```python
#!/usr/bin/env python
import ast
from glob import glob


for path in sorted(glob("scipy/**/*.py", recursive=True)):

    if "/tests/" in path:
        continue

    with open(path, "r") as f:
        data = f.read()

    root = ast.parse(source=data, filename=path, mode="exec")
    lines = data.splitlines()

    for node in ast.walk(root):
        if not isinstance(node, ast.Call):
            continue
        func = node.func
        if not isinstance(func, ast.Attribute):
            continue
        if func.attr != "astype":
            continue
        if "copy" in [k.arg for k in node.keywords]:
            continue
        print("%s:%d: %s" % (path, node.lineno, lines[node.lineno - 1]))
```