### PR TITLE
ENH: avoid copy on sparse __init__ when dtype is given

### DIFF
--- a/scipy/sparse/bsr.py
+++ b/scipy/sparse/bsr.py
@@ -209,7 +209,7 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
                 self._shape = check_shape(shape)
 
         if dtype is not None:
-            self.data = self.data.astype(dtype)
+            self.data = self.data.astype(dtype, copy=False)
 
         self.check_format(full_check=False)
 

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -102,7 +102,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                                                           minor_dim)))
 
         if dtype is not None:
-            self.data = np.asarray(self.data, dtype=dtype)
+            self.data = self.data.astype(dtype, copy=False)
 
         self.check_format(full_check=False)
 

--- a/scipy/sparse/dok.py
+++ b/scipy/sparse/dok.py
@@ -88,7 +88,7 @@ class dok_matrix(spmatrix, IndexMixin, dict):
                 arg1 = arg1.todok()
 
             if dtype is not None:
-                arg1 = arg1.astype(dtype)
+                arg1 = arg1.astype(dtype, copy=False)
 
             dict.update(self, arg1)
             self._shape = check_shape(arg1.shape)

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -96,7 +96,7 @@ class lil_matrix(spmatrix, IndexMixin):
                 A = arg1.tolil()
 
             if dtype is not None:
-                A = A.astype(dtype)
+                A = A.astype(dtype, copy=False)
 
             self._shape = check_shape(A.shape)
             self.dtype = A.dtype


### PR DESCRIPTION
#### Reference issue
N/A

#### What does this implement/fix?
Sparse matrix constructors are supposed to avoid copies when copy=False
is given. However, when dtype is given explicitly, a copy is made even
if not needed.

Also when copy=True is given, explicit dtype will force two copies
instead of one.

This commit avoids the extra copy and adds generic tests for these
cases.

#### Additional information
Related: https://github.com/scipy/scipy/pull/11491