### PR TITLE
ENH: avoid unnecessary array copies in matrix product (again)

### DIFF
--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -501,8 +501,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         other = self.__class__(other)  # convert to this format
 
         idx_dtype = get_index_dtype((self.indptr, self.indices,
-                                     other.indptr, other.indices),
-                                    maxval=M*N)
+                                     other.indptr, other.indices))
 
         fn = getattr(_sparsetools, self.format + '_matmat_maxnnz')
         nnz = fn(M, N,


### PR DESCRIPTION

#### Reference issue
N/A

#### What does this implement/fix?
In #11478, M*N was still passed as maxval to get_index_dtype, which
limited the optimization.

#### Additional information
* Amends https://github.com/scipy/scipy/pull/11478