### PR TITLE
[DOC] An ex. for creating arbitrary size tri-diagonal

### DIFF
--- a/scipy/sparse/dia.py
+++ b/scipy/sparse/dia.py
@@ -76,7 +76,7 @@ class dia_matrix(_data_matrix):
     >>> ex = np.ones(n)
     >>> data = np.array([ex, 2 * ex, ex])
     >>> offsets = np.array([-1, 0, 1])
-    >>> sp.sparse.dia_matrix((data, offsets), shape=(n, n)).toarray()
+    >>> dia_matrix((data, offsets), shape=(n, n)).toarray()
 
     array([[2., 1., 0., ..., 0., 0., 0.],
            [1., 2., 1., ..., 0., 0., 0.],

--- a/scipy/sparse/dia.py
+++ b/scipy/sparse/dia.py
@@ -72,6 +72,19 @@ class dia_matrix(_data_matrix):
            [0, 2, 3, 0],
            [0, 0, 3, 4]])
 
+    >>> n= 10000
+    >>> ex = np.ones(n)
+    >>> data = np.array([ex, 2 * ex, ex])
+    >>> offsets = np.array([-1, 0, 1])
+    >>> sp.sparse.dia_matrix((data, offsets), shape=(n, n)).toarray()
+
+    array([[2., 1., 0., ..., 0., 0., 0.],
+           [1., 2., 1., ..., 0., 0., 0.],
+           [0., 1., 2., ..., 0., 0., 0.],
+           ...,
+           [0., 0., 0., ..., 2., 1., 0.],
+           [0., 0., 0., ..., 1., 2., 1.],
+           [0., 0., 0., ..., 0., 1., 2.]])
     """
     format = 'dia'
 

--- a/scipy/sparse/dia.py
+++ b/scipy/sparse/dia.py
@@ -72,7 +72,9 @@ class dia_matrix(_data_matrix):
            [0, 2, 3, 0],
            [0, 0, 3, 4]])
 
-    >>> n= 10000
+    >>> import numpy as np
+    >>> from scipy.sparse import dia_matrix
+    >>> n= 10
     >>> ex = np.ones(n)
     >>> data = np.array([ex, 2 * ex, ex])
     >>> offsets = np.array([-1, 0, 1])

--- a/scipy/sparse/dia.py
+++ b/scipy/sparse/dia.py
@@ -72,14 +72,12 @@ class dia_matrix(_data_matrix):
            [0, 2, 3, 0],
            [0, 0, 3, 4]])
 
-    >>> import numpy as np
     >>> from scipy.sparse import dia_matrix
-    >>> n= 10
+    >>> n = 10
     >>> ex = np.ones(n)
     >>> data = np.array([ex, 2 * ex, ex])
     >>> offsets = np.array([-1, 0, 1])
     >>> dia_matrix((data, offsets), shape=(n, n)).toarray()
-
     array([[2., 1., 0., ..., 0., 0., 0.],
            [1., 2., 1., ..., 0., 0., 0.],
            [0., 1., 2., ..., 0., 0., 0.],


### PR DESCRIPTION
This kind of setting would be used a lot in numerical simulations, like numerical PDE, I was confused a bit on how to get it, so maybe someone else would be confused too. It would be nice to have such an example for them so they can easily plug in and run.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Added an ex. for creating arbitrary size tri-diagonal
#### What does this implement/fix?
<!--Please explain your changes.-->
There was no example on how to create large size matrices that are not possible to write out.
#### Additional information
<!--Any additional information you think is important.-->