### PR TITLE
TST: pin numba for Travis/sparse

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -204,6 +204,7 @@ before_install:
   - travis_retry pip install pybind11
   - |
     if [ -z "${USE_DEBUG}" -a "${TRAVIS_CPU_ARCH}" == "amd64" -a "${TRAVIS_PYTHON_VERSION}" != "3.8" ]; then
+        travis_retry pip install numba==0.47
         travis_retry pip install --only-binary=:all: sparse
     fi
   - |


### PR DESCRIPTION
Should address 1 of the 2 CI failures outlined in #11460

* the `pydata/sparse` `master` branch only
requires `numba>=0.45`, so let's pin
to `numba==0.45` to avoid bleeding
edge numba's NumPy version requirements
that are causing Travis CI failures

cc @hameerabbasi 

Hopefully `pip` doesn't try to upgrade `numba` if the base requirement for `pydata/sparse` is set from a previous install---I believe that is the normal behavior, but CI will tell us soon enough...