### PR TITLE
TST: disable NumPy cache dir ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -115,7 +115,7 @@ matrix:
       env:
         - TESTMODE=fast
         - COVERAGE=
-        - NUMPYSPEC="--upgrade numpy"
+        - NUMPYSPEC="--upgrade numpy --no-cache-dir"
 cache:
   directories:
     - $HOME/.ccache


### PR DESCRIPTION
Addresses ppc64le part of #11460, I think

* Travis CI ppc64le job is failing
because of a cache dir permissions
issue for these workers; disable
the use of the cache dir in the
pip install of NumPy for now