### PR TITLE
BUG: make special.eval_genlaguerre return nan if passed nan

### DIFF
--- a/scipy/special/orthogonal_eval.pxd
+++ b/scipy/special/orthogonal_eval.pxd
@@ -451,6 +451,9 @@ cdef inline double eval_genlaguerre_l(long n, double alpha, double x) nogil:
                        "polynomial defined only for alpha > -1")
         return nan
 
+    if npy_isnan(alpha) or npy_isnan(x):
+        return nan
+
     if n < 0:
         return 0.0
     elif n == 0:

--- a/scipy/special/tests/test_orthogonal_eval.py
+++ b/scipy/special/tests/test_orthogonal_eval.py
@@ -261,3 +261,13 @@ def test_hermite_nan(n, x):
     # Regression test for gh-11369.
     assert np.isnan(orth.eval_hermite(n, x)) == np.any(np.isnan([n, x]))
     assert np.isnan(orth.eval_hermitenorm(n, x)) == np.any(np.isnan([n, x]))
+
+
+@pytest.mark.parametrize('n', [0, 1, 2, 3.2])
+@pytest.mark.parametrize('alpha', [1, np.nan])
+@pytest.mark.parametrize('x', [2, np.nan])
+def test_genlaguerre_nan(n, alpha, x):
+    # Regression test for gh-11361.
+    nan_laguerre = np.isnan(orth.eval_genlaguerre(n, alpha, x))
+    nan_arg = np.any(np.isnan([n, alpha, x]))
+    assert nan_laguerre == nan_arg


### PR DESCRIPTION
#### Reference issue
Closes #11361.

#### What does this implement/fix?
* The second and third arguments of `special.eval_genlaguerre` are now checked if they are `nan` values. If either of them is `nan`, `nan` is returned.
* Implemented a regression test to check that `nan` is returned if either the second or third arguments to `eval_genlaguerre` is `nan`.