### PR TITLE
Fix fresnel documentation

### DIFF
--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -3757,8 +3757,8 @@ add_newdoc("fresnel",
 
     .. math::
 
-       S(z) &= \int_0^z \cos(\pi t^2 /2) dt \\
-       C(z) &= \int_0^z \sin(\pi t^2 /2) dt.
+       S(z) &= \int_0^z \sin(\pi t^2 /2) dt \\
+       C(z) &= \int_0^z \cos(\pi t^2 /2) dt.
 
     See [dlmf]_ for details.
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
The documentation of fresnel function had the definitions of
S and C integrals mixed up. This PR fixes those definitions.

#### Additional information
<!--Any additional information you think is important.-->