### PR TITLE
BUG: make special.eval_gegenbauer return nan if passed nan

### DIFF
--- a/scipy/special/orthogonal_eval.pxd
+++ b/scipy/special/orthogonal_eval.pxd
@@ -197,6 +197,9 @@ cdef inline double eval_gegenbauer_l(long n, double alpha, double x) nogil:
     cdef double p, d
     cdef double k
 
+    if npy_isnan(alpha) or npy_isnan(x):
+        return nan
+
     if n < 0:
         return 0.0
     elif n == 0:

--- a/scipy/special/tests/test_orthogonal_eval.py
+++ b/scipy/special/tests/test_orthogonal_eval.py
@@ -271,3 +271,13 @@ def test_genlaguerre_nan(n, alpha, x):
     nan_laguerre = np.isnan(orth.eval_genlaguerre(n, alpha, x))
     nan_arg = np.any(np.isnan([n, alpha, x]))
     assert nan_laguerre == nan_arg
+
+
+@pytest.mark.parametrize('n', [0, 1, 2, 3.2])
+@pytest.mark.parametrize('alpha', [0.0, 1, np.nan])
+@pytest.mark.parametrize('x', [1e-6, 2, np.nan])
+def test_gegenbauer_nan(n, alpha, x):
+    # Regression test for gh-11370.
+    nan_gegenbauer = np.isnan(orth.eval_gegenbauer(n, alpha, x))
+    nan_arg = np.any(np.isnan([n, alpha, x]))
+    assert nan_gegenbauer == nan_arg


### PR DESCRIPTION
#### Reference issue
Closes #11370.

#### What does this implement/fix?
* The second and third arguments of `special.eval_gegenbauer` are now checked if they are `nan`. If either of the is `nan`, `nan` is returned.
* Implemented a regression test to check for the expected `nan` output when `nan` parameters are passed.