### PR TITLE
MAINT: Removed 3 unused imports, 3 unused assignments from ndimage.

### DIFF
--- a/scipy/ndimage/filters.py
+++ b/scipy/ndimage/filters.py
@@ -31,7 +31,6 @@
 from __future__ import division, print_function, absolute_import
 from collections.abc import Iterable
 import warnings
-import numbers
 import numpy
 import operator
 from . import _ni_support

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -1,7 +1,6 @@
 ''' Some tests for filters '''
 from __future__ import division, print_function, absolute_import
 
-import sys
 import numpy as np
 
 from numpy.testing import (assert_equal, assert_allclose,
@@ -83,7 +82,6 @@ def test_valid_origins():
     data = np.array([1,2,3,4,5], dtype=np.float64)
     assert_raises(ValueError, sndi.generic_filter, data, func, size=3,
                   origin=2)
-    func2 = lambda x, y: np.mean(x + y)
     assert_raises(ValueError, sndi.generic_filter1d, data, func,
                   filter_size=3, origin=2)
     assert_raises(ValueError, sndi.percentile_filter, data, 0.2, size=3,

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -32,7 +32,6 @@ from __future__ import division, print_function, absolute_import
 
 import math
 import sys
-import platform
 
 import numpy
 from numpy import fft
@@ -3627,7 +3626,7 @@ class TestNdimage:
                            [1, 0, 1]], dtype=bool)
         iterations = 2.0
         with assert_raises(TypeError):
-            out = ndimage.binary_erosion(data, iterations=iterations)
+            _ = ndimage.binary_erosion(data, iterations=iterations)
 
     def test_binary_erosion39(self):
         iterations = numpy.int32(3)

--- a/scipy/ndimage/tests/test_regression.py
+++ b/scipy/ndimage/tests/test_regression.py
@@ -27,7 +27,7 @@ def test_ticket_742():
         rank = len(mask.shape)
         la, co = ndimage.label(mask,
                                ndimage.generate_binary_structure(rank, rank))
-        slices = ndimage.find_objects(la)
+        _ = ndimage.find_objects(la)
 
     if np.dtype(np.intp) != np.dtype('i'):
         shape = (3,1240,1240)


### PR DESCRIPTION
Removed explict imports that are unused (and not in `__init__.py`)

There were 5 warnings in test code, 1 in main ndimage code.
E.g. scipy/ndimage/filters.py:34: 'numbers' imported but unused

#### Reference issue
Start on gh-11529

#### What does this implement/fix?
Removes some unused imports, unused assignments to reduce Pyflakes warnings.
