### PR TITLE
DOC: fix typos in bdtr and bdtrc from gh PR 11045

### DIFF
--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -377,7 +377,7 @@ add_newdoc("bdtr",
     Sum of the terms 0 through `floor(k)` of the Binomial probability density.
 
     .. math::
-        \mathrm{bdtr}(k, n, p) = \sum_{j=0}^\lfloor k \rfloor {{n}\choose{j}} p^j (1-p)^{n-j}
+        \mathrm{bdtr}(k, n, p) = \sum_{j=0}^{\lfloor k \rfloor} {{n}\choose{j}} p^j (1-p)^{n-j}
 
     Parameters
     ----------
@@ -421,7 +421,7 @@ add_newdoc("bdtrc",
     density,
 
     .. math::
-        \mathrm{bdtrc}(k, n, p) = \sum_{j=k+1}^n {{n}\choose{j}} p^j (1-p)^{n-j}
+        \mathrm{bdtrc}(k, n, p) = \sum_{j=\lfloor k \rfloor +1}^n {{n}\choose{j}} p^j (1-p)^{n-j}
 
     Parameters
     ----------


### PR DESCRIPTION
#### Reference issue
N/A

#### What does this implement/fix?
In PR: #11045 I updated the docstrings based on the changes to `bdtr` methods. 
I noticed the docs weren't rendering correctly b/c the floor functions need to be either added `bdtrc` case or wrapped in braces in `bdtr` case. 

This small doc PR fixes those. 

#### Additional information
N/A