### PR TITLE
MAINT: Fixed several unused imports and unused assignments from linalg

### DIFF
--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -736,8 +736,6 @@ except ImportError:
     _clapack = None
 
 # Backward compatibility
-# Can this be removed now?
-# from .blas import find_best_blas_type as find_best_lapack_type
 from scipy._lib._util import DeprecatedImport as _DeprecatedImport
 clapack = _DeprecatedImport("scipy.linalg.blas.clapack", "scipy.linalg.lapack")
 flapack = _DeprecatedImport("scipy.linalg.blas.flapack", "scipy.linalg.lapack")

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -736,7 +736,8 @@ except ImportError:
     _clapack = None
 
 # Backward compatibility
-from .blas import find_best_blas_type as find_best_lapack_type
+# Can this be removed now?
+# from .blas import find_best_blas_type as find_best_lapack_type
 from scipy._lib._util import DeprecatedImport as _DeprecatedImport
 clapack = _DeprecatedImport("scipy.linalg.blas.clapack", "scipy.linalg.lapack")
 flapack = _DeprecatedImport("scipy.linalg.blas.flapack", "scipy.linalg.lapack")

--- a/scipy/linalg/setup.py
+++ b/scipy/linalg/setup.py
@@ -1,12 +1,11 @@
 from __future__ import division, print_function, absolute_import
 
-import os
 from os.path import join
 
 
 def configuration(parent_package='', top_path=None):
     from distutils.sysconfig import get_python_inc
-    from scipy._build_utils.system_info import get_info, NotFoundError, numpy_info
+    from scipy._build_utils.system_info import get_info, numpy_info
     from numpy.distutils.misc_util import Configuration, get_numpy_include_dirs
     from scipy._build_utils import get_g77_abi_wrappers
 

--- a/scipy/linalg/tests/test_blas.py
+++ b/scipy/linalg/tests/test_blas.py
@@ -23,8 +23,7 @@ from numpy import float32, float64, complex64, complex128, arange, triu, \
                   nonzero
 
 from numpy.random import rand, seed
-from scipy.linalg import _fblas as fblas, get_blas_funcs, toeplitz, solve, \
-                                          solve_triangular
+from scipy.linalg import _fblas as fblas, get_blas_funcs, toeplitz, solve
 
 try:
     from scipy.linalg import _cblas as cblas

--- a/scipy/linalg/tests/test_build.py
+++ b/scipy/linalg/tests/test_build.py
@@ -19,7 +19,7 @@ class FindDependenciesLdd:
         self.cmd = ['ldd']
 
         try:
-            st = call(self.cmd, stdout=PIPE, stderr=PIPE)
+            _ = call(self.cmd, stdout=PIPE, stderr=PIPE)
         except OSError:
             raise RuntimeError("command %s cannot be run" % self.cmd)
 

--- a/scipy/linalg/tests/test_build.py
+++ b/scipy/linalg/tests/test_build.py
@@ -19,7 +19,7 @@ class FindDependenciesLdd:
         self.cmd = ['ldd']
 
         try:
-            _ = call(self.cmd, stdout=PIPE, stderr=PIPE)
+            call(self.cmd, stdout=PIPE, stderr=PIPE)
         except OSError:
             raise RuntimeError("command %s cannot be run" % self.cmd)
 

--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -65,7 +65,7 @@ class TestSignM(object):
 
     def test_defective1(self):
         a = array([[0.0,1,0,0],[1,0,1,0],[0,0,0,1],[0,0,1,0]])
-        r = signm(a, disp=False)
+        _ = signm(a, disp=False)
         #XXX: what would be the correct result?
 
     def test_defective2(self):
@@ -75,7 +75,7 @@ class TestSignM(object):
             [-10.0,6.0,-20.0,-18.0,-2.0],
             [-9.6,9.6,-25.5,-15.4,-2.0],
             [9.8,-4.8,18.0,18.2,2.0]))
-        r = signm(a, disp=False)
+        _ = signm(a, disp=False)
         #XXX: what would be the correct result?
 
     def test_defective3(self):
@@ -86,7 +86,7 @@ class TestSignM(object):
                    [0., 0., 0., 0., 3., 10., 0.],
                    [0., 0., 0., 0., 0., -2., 25.],
                    [0., 0., 0., 0., 0., 0., -3.]])
-        r = signm(a, disp=False)
+        _ = signm(a, disp=False)
         #XXX: what would be the correct result?
 
 
@@ -378,7 +378,6 @@ class TestSqrtM(object):
             assert_(np.isnan(B_sqrtm).all())
 
     def test_disp(self):
-        from io import StringIO
         np.random.seed(1234)
 
         A = np.random.rand(3, 3)
@@ -729,7 +728,7 @@ class TestExpmFrechet(object):
                 [1.87864034, 2.07055038],
                 [1.34102727, 0.67341123],
                 ], dtype=float)
-        A_norm_1 = scipy.linalg.norm(A, 1)
+        _ = scipy.linalg.norm(A, 1)
         sps_expm, sps_frechet = expm_frechet(
                 A, E, method='SPS')
         blockEnlarge_expm, blockEnlarge_frechet = expm_frechet(

--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -65,7 +65,7 @@ class TestSignM(object):
 
     def test_defective1(self):
         a = array([[0.0,1,0,0],[1,0,1,0],[0,0,0,1],[0,0,1,0]])
-        _ = signm(a, disp=False)
+        signm(a, disp=False)
         #XXX: what would be the correct result?
 
     def test_defective2(self):
@@ -75,7 +75,7 @@ class TestSignM(object):
             [-10.0,6.0,-20.0,-18.0,-2.0],
             [-9.6,9.6,-25.5,-15.4,-2.0],
             [9.8,-4.8,18.0,18.2,2.0]))
-        _ = signm(a, disp=False)
+        signm(a, disp=False)
         #XXX: what would be the correct result?
 
     def test_defective3(self):
@@ -86,7 +86,7 @@ class TestSignM(object):
                    [0., 0., 0., 0., 3., 10., 0.],
                    [0., 0., 0., 0., 0., -2., 25.],
                    [0., 0., 0., 0., 0., 0., -3.]])
-        _ = signm(a, disp=False)
+        signm(a, disp=False)
         #XXX: what would be the correct result?
 
 
@@ -728,7 +728,7 @@ class TestExpmFrechet(object):
                 [1.87864034, 2.07055038],
                 [1.34102727, 0.67341123],
                 ], dtype=float)
-        _ = scipy.linalg.norm(A, 1)
+        scipy.linalg.norm(A, 1)
         sps_expm, sps_frechet = expm_frechet(
                 A, E, method='SPS')
         blockEnlarge_expm, blockEnlarge_frechet = expm_frechet(


### PR DESCRIPTION
Removed explict imports that are unused (and not in __init__.py)
5 unused imports, 5 unused assignments;
7 in test code, 3 in main library.

#### Reference issue
Further work on gh-11529

#### What does this implement/fix?
Removes some unused imports, unused assignments to reduce Pyflakes warnings.
