### PR TITLE
MAINT: Fixed about 100 unused imports, unused assignment warnings from scipy/optimize

### DIFF
--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -25,8 +25,7 @@ from ._linprog_ip import _linprog_ip
 from ._linprog_simplex import _linprog_simplex
 from ._linprog_rs import _linprog_rs
 from ._linprog_util import (
-    _parse_linprog, _presolve, _get_Abc, _postprocess, _LPProblem, _autoscale, _unscale
-    )
+    _parse_linprog, _presolve, _get_Abc, _postprocess, _LPProblem, _autoscale)
 from copy import deepcopy
 
 __all__ = ['linprog', 'linprog_verbose_callback', 'linprog_terse_callback']

--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -22,7 +22,6 @@ from __future__ import print_function, division, absolute_import
 import numpy as np
 import scipy as sp
 import scipy.sparse as sps
-import numbers
 from warnings import warn
 from scipy.linalg import LinAlgError
 from .optimize import OptimizeWarning, OptimizeResult, _check_unknown_options

--- a/scipy/optimize/_linprog_util.py
+++ b/scipy/optimize/_linprog_util.py
@@ -1237,7 +1237,7 @@ def _unscale(x, C, b_scale):
         n = len(C)
         # fails if sparse or scalar; that's OK.
         # this is only needed for original simplex (never sparse)
-    except TypeError as e:
+    except TypeError:
         n = len(x)
 
     return x[:n]*b_scale*C

--- a/scipy/optimize/_lsq/trf.py
+++ b/scipy/optimize/_lsq/trf.py
@@ -352,10 +352,6 @@ def trf_bounds(fun, jac, x0, f0, J0, lb, ub, ftol, xtol, gtol, max_nfev,
             else:
                 cost_new = 0.5 * np.dot(f_new, f_new)
             actual_reduction = cost - cost_new
-            # Correction term is specific to the algorithm,
-            # vanishes in unbounded case.
-            correction = 0.5 * np.dot(step_h * diag_h, step_h)
-
             Delta_new, ratio = update_tr_radius(
                 Delta, actual_reduction, predicted_reduction,
                 step_h_norm, step_h_norm > 0.95 * Delta)

--- a/scipy/optimize/_shgo.py
+++ b/scipy/optimize/_shgo.py
@@ -1332,7 +1332,7 @@ class SHGO(object):
 
         for j in range(1, D):
             F_int = [int(item) for item in next(f).strip().split()]
-            (d, s, a), m = F_int[:3], [0] + F_int[3:]
+            (_, s, a), m = F_int[:3], [0] + F_int[3:]
 
             if L <= s:
                 for i in range(1, L + 1):

--- a/scipy/optimize/_trlib/setup.py
+++ b/scipy/optimize/_trlib/setup.py
@@ -2,7 +2,7 @@ from __future__ import division, print_function, absolute_import
 
 def configuration(parent_package='', top_path=None):
     from numpy import get_include
-    from scipy._build_utils.system_info import get_info, NotFoundError
+    from scipy._build_utils.system_info import get_info
     from numpy.distutils.misc_util import Configuration
     
     from os.path import join, dirname

--- a/scipy/optimize/_trustregion.py
+++ b/scipy/optimize/_trustregion.py
@@ -189,7 +189,7 @@ def _minimize_trust_region(fun, x0, args=(), jac=None, hess=None, hessp=None,
         # has reached the trust region boundary or not.
         try:
             p, hits_boundary = m.solve(trust_radius)
-        except np.linalg.linalg.LinAlgError as e:
+        except np.linalg.linalg.LinAlgError:
             warnflag = 3
             break
 

--- a/scipy/optimize/_trustregion_constr/tests/test_projections.py
+++ b/scipy/optimize/_trustregion_constr/tests/test_projections.py
@@ -58,7 +58,6 @@ class TestProjections(TestCase):
                 # Test if x is in the null_space
                 x = Z.matvec(z)
                 atol = 1e-13 * abs(x).max()
-                _ = abs(A.dot(x)).max()
                 assert_allclose(A.dot(x), 0, atol=atol)
                 # Test orthogonality
                 assert_allclose(orthogonality(A, x), 0, atol=1e-13)

--- a/scipy/optimize/_trustregion_constr/tests/test_projections.py
+++ b/scipy/optimize/_trustregion_constr/tests/test_projections.py
@@ -5,20 +5,13 @@ from scipy.sparse import csc_matrix
 from scipy.optimize._trustregion_constr.projections \
     import projections, orthogonality
 from numpy.testing import (TestCase, assert_array_almost_equal,
-                           assert_array_equal, assert_array_less,
-                           assert_raises, assert_equal, assert_,
-                           run_module_suite, assert_allclose, assert_warns,
-                           dec)
-import pytest
-import sys
-import platform
+                           assert_equal, assert_allclose)
 
 try:
     from sksparse.cholmod import cholesky_AAt
     sksparse_available = True
     available_sparse_methods = ("NormalEquation", "AugmentedSystem")
 except ImportError:
-    import warnings
     sksparse_available = False
     available_sparse_methods = ("AugmentedSystem",)
 available_dense_methods = ('QRFactorization', 'SVDFactorization')
@@ -65,7 +58,7 @@ class TestProjections(TestCase):
                 # Test if x is in the null_space
                 x = Z.matvec(z)
                 atol = 1e-13 * abs(x).max()
-                err = abs(A.dot(x)).max()
+                _ = abs(A.dot(x)).max()
                 assert_allclose(A.dot(x), 0, atol=atol)
                 # Test orthogonality
                 assert_allclose(orthogonality(A, x), 0, atol=1e-13)

--- a/scipy/optimize/_trustregion_constr/tests/test_qp_subproblem.py
+++ b/scipy/optimize/_trustregion_constr/tests/test_qp_subproblem.py
@@ -9,11 +9,7 @@ from scipy.optimize._trustregion_constr.qp_subproblem \
             modified_dogleg)
 from scipy.optimize._trustregion_constr.projections \
     import projections
-from numpy.testing import (TestCase, assert_array_almost_equal,
-                           assert_array_equal, assert_array_less,
-                           assert_equal, assert_,
-                           run_module_suite, assert_allclose, assert_warns,
-                           dec)
+from numpy.testing import (TestCase, assert_array_almost_equal, assert_equal)
 import pytest
 
 

--- a/scipy/optimize/_trustregion_constr/tests/test_report.py
+++ b/scipy/optimize/_trustregion_constr/tests/test_report.py
@@ -1,16 +1,10 @@
-# import numpy as np
-# from numpy.testing import (TestCase, assert_array_almost_equal,
-#                            assert_array_equal, assert_array_less,
-#                            assert_raises, assert_equal, assert_,
-#                            run_module_suite, assert_allclose, assert_warns,
-#                            dec)
 from scipy.optimize import minimize, Bounds
 
 def test_gh10880():
     # checks that verbose reporting works with trust-constr
     bnds = Bounds(1, 2)
     opts = {'maxiter': 1000, 'verbose': 2}
-    _ = minimize(lambda x: x**2, x0=2., method='trust-constr', bounds=bnds, options=opts)
+    minimize(lambda x: x**2, x0=2., method='trust-constr', bounds=bnds, options=opts)
 
     opts = {'maxiter': 1000, 'verbose': 3}
-    _ = minimize(lambda x: x**2, x0=2., method='trust-constr', bounds=bnds, options=opts)
+    minimize(lambda x: x**2, x0=2., method='trust-constr', bounds=bnds, options=opts)

--- a/scipy/optimize/_trustregion_constr/tests/test_report.py
+++ b/scipy/optimize/_trustregion_constr/tests/test_report.py
@@ -1,16 +1,16 @@
-import numpy as np
-from numpy.testing import (TestCase, assert_array_almost_equal,
-                           assert_array_equal, assert_array_less,
-                           assert_raises, assert_equal, assert_,
-                           run_module_suite, assert_allclose, assert_warns,
-                           dec)
+# import numpy as np
+# from numpy.testing import (TestCase, assert_array_almost_equal,
+#                            assert_array_equal, assert_array_less,
+#                            assert_raises, assert_equal, assert_,
+#                            run_module_suite, assert_allclose, assert_warns,
+#                            dec)
 from scipy.optimize import minimize, Bounds
 
 def test_gh10880():
     # checks that verbose reporting works with trust-constr
     bnds = Bounds(1, 2)
     opts = {'maxiter': 1000, 'verbose': 2}
-    res = minimize(lambda x: x**2, x0=2., method='trust-constr', bounds=bnds, options=opts)
+    _ = minimize(lambda x: x**2, x0=2., method='trust-constr', bounds=bnds, options=opts)
 
     opts = {'maxiter': 1000, 'verbose': 3}
-    res = minimize(lambda x: x**2, x0=2., method='trust-constr', bounds=bnds, options=opts)
+    _ = minimize(lambda x: x**2, x0=2., method='trust-constr', bounds=bnds, options=opts)

--- a/scipy/optimize/lbfgsb.py
+++ b/scipy/optimize/lbfgsb.py
@@ -39,10 +39,8 @@ import numpy as np
 from numpy import array, asarray, float64, int32, zeros
 from . import _lbfgsb
 from .optimize import (MemoizeJac, OptimizeResult,
-                       _check_unknown_options, wrap_function, _prepare_scalar_function)
-from ._numdiff import approx_derivative
+                       _check_unknown_options, _prepare_scalar_function)
 from ._constraints import old_bound_to_new
-from ._differentiable_functions import ScalarFunction, FD_METHODS
 
 from scipy.sparse.linalg import LinearOperator
 

--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -1,20 +1,19 @@
 from __future__ import division, print_function, absolute_import
 
-import threading
 import warnings
 from . import _minpack
 
 import numpy as np
 from numpy import (atleast_1d, dot, take, triu, shape, eye,
-                   transpose, zeros, prod, greater, array,
-                   all, where, isscalar, asarray, inf, abs,
+                   transpose, zeros, prod, greater,
+                   asarray, inf,
                    finfo, inexact, issubdtype, dtype)
 from scipy.linalg import svd, cholesky, solve_triangular, LinAlgError
 from scipy._lib._util import _asarray_validated, _lazywhere
 from scipy._lib._util import getfullargspec_no_self as _getfullargspec
 from .optimize import OptimizeResult, _check_unknown_options, OptimizeWarning
 from ._lsq import least_squares
-from ._lsq.common import make_strictly_feasible
+# from ._lsq.common import make_strictly_feasible
 from ._lsq.least_squares import prepare_bounds
 
 error = _minpack.error
@@ -685,7 +684,6 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
         # determine number of parameters by inspecting the function
         sig = _getfullargspec(f)
         args = sig.args
-        varargs, varkw, defaults = sig.varargs, sig.varkw, sig.defaults
         if len(args) < 2:
             raise ValueError("Unable to determine number of fit parameters.")
         n = len(args) - 1

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -30,7 +30,7 @@ __docformat__ = "restructuredtext en"
 import warnings
 import sys
 import numpy
-from numpy import (atleast_1d, eye, mgrid, argmin, zeros, shape, squeeze,
+from numpy import (atleast_1d, eye, argmin, zeros, shape, squeeze,
                    asarray, sqrt, Inf, asfarray, isinf)
 import numpy as np
 from .linesearch import (line_search_wolfe1, line_search_wolfe2,

--- a/scipy/optimize/slsqp.py
+++ b/scipy/optimize/slsqp.py
@@ -21,10 +21,9 @@ import numpy as np
 from scipy.optimize._slsqp import slsqp
 from numpy import (zeros, array, linalg, append, asfarray, concatenate, finfo,
                    sqrt, vstack, exp, inf, isfinite, atleast_1d)
-from .optimize import (wrap_function, OptimizeResult, _check_unknown_options,
+from .optimize import (OptimizeResult, _check_unknown_options,
                        _prepare_scalar_function)
 from ._numdiff import approx_derivative
-from ._differentiable_functions import ScalarFunction, FD_METHODS
 from ._constraints import old_bound_to_new
 
 

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -522,7 +522,7 @@ class TestDifferentialEvolutionSolver(object):
                 return np.inf
             return x[1]
         bounds = [(0, 1), (0, 1)]
-        _ = differential_evolution(sometimes_inf, bounds=bounds, disp=False)
+        differential_evolution(sometimes_inf, bounds=bounds, disp=False)
 
     def test_deferred_updating(self):
         # check setting of deferred updating, with default workers

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -438,11 +438,11 @@ class TestDifferentialEvolutionSolver(object):
 
         # check a proper minimisation can be done by an iterable solver
         solver = DifferentialEvolutionSolver(rosen, self.bounds)
-        x_prev, fun_prev = next(solver)
+        _, fun_prev = next(solver)
         for i, soln in enumerate(solver):
             x_current, fun_current = soln
             assert(fun_prev >= fun_current)
-            x_prev, fun_prev = x_current, fun_current
+            _, fun_prev = x_current, fun_current
             # need to have this otherwise the solver would never stop.
             if i == 50:
                 break
@@ -522,9 +522,7 @@ class TestDifferentialEvolutionSolver(object):
                 return np.inf
             return x[1]
         bounds = [(0, 1), (0, 1)]
-        x_fit = differential_evolution(sometimes_inf,
-                                       bounds=[(0, 1), (0, 1)],
-                                       disp=False)
+        _ = differential_evolution(sometimes_inf, bounds=bounds, disp=False)
 
     def test_deferred_updating(self):
         # check setting of deferred updating, with default workers

--- a/scipy/optimize/tests/test__root.py
+++ b/scipy/optimize/tests/test__root.py
@@ -68,4 +68,4 @@ class TestRoot(object):
 
         F = fun()
         with assert_raises(ValueError):
-            sol = root(F, [0.1, 0.0], method='lm')
+            _ = root(F, [0.1, 0.0], method='lm')

--- a/scipy/optimize/tests/test__root.py
+++ b/scipy/optimize/tests/test__root.py
@@ -68,4 +68,4 @@ class TestRoot(object):
 
         F = fun()
         with assert_raises(ValueError):
-            _ = root(F, [0.1, 0.0], method='lm')
+            root(F, [0.1, 0.0], method='lm')

--- a/scipy/optimize/tests/test__shgo.py
+++ b/scipy/optimize/tests/test__shgo.py
@@ -450,10 +450,10 @@ class TestShgoArguments(object):
             print("Local minimization callback test")
 
         for test in [test1_1, test2_1]:
-            res = shgo(test.f, test.bounds, iters=1,
+            _ = shgo(test.f, test.bounds, iters=1,
                        sampling_method='simplicial',
                        callback=callback_func, options={'disp': True})
-            res = shgo(test.f, test.bounds, n=1, sampling_method='simplicial',
+            _ = shgo(test.f, test.bounds, n=1, sampling_method='simplicial',
                        callback=callback_func, options={'disp': True})
 
     def test_3_2_disp_sobol(self):
@@ -463,10 +463,10 @@ class TestShgoArguments(object):
             print("Local minimization callback test")
 
         for test in [test1_1, test2_1]:
-            res = shgo(test.f, test.bounds, iters=1, sampling_method='sobol',
+            _ = shgo(test.f, test.bounds, iters=1, sampling_method='sobol',
                        callback=callback_func, options={'disp': True})
 
-            res = shgo(test.f, test.bounds, n=1, sampling_method='simplicial',
+            _ = shgo(test.f, test.bounds, n=1, sampling_method='simplicial',
                        callback=callback_func, options={'disp': True})
 
     @pytest.mark.slow
@@ -571,7 +571,7 @@ class TestShgoArguments(object):
         """Test the minimizer_kwargs default inits"""
         minimizer_kwargs = {'ftol': 1e-5}
         options = {'disp': True}  # For coverage purposes
-        SHGOc = SHGO(test3_1.f, test3_1.bounds, constraints=test3_1.cons[0],
+        _ = SHGO(test3_1.f, test3_1.bounds, constraints=test3_1.cons[0],
                      minimizer_kwargs=minimizer_kwargs, options=options)
 
     def test_7_3_minkwargs(self):
@@ -602,26 +602,26 @@ class TestShgoArguments(object):
 
     def test_9_cons_g(self):
         """Test single function constraint passing"""
-        SHGOc = SHGO(test3_1.f, test3_1.bounds, constraints=test3_1.cons[0])
+        _ = SHGO(test3_1.f, test3_1.bounds, constraints=test3_1.cons[0])
 
     def test_10_finite_time(self):
         """Test single function constraint passing"""
         options = {'maxtime': 1e-15}
-        res = shgo(test1_1.f, test1_1.bounds, n=1, iters=None,
+        _ = shgo(test1_1.f, test1_1.bounds, n=1, iters=None,
                    options=options, sampling_method='sobol')
 
     def test_11_f_min_time(self):
         """Test to cover the case where f_lowest == 0"""
         options = {'maxtime': 1e-15,
                    'f_min': 0.0}
-        res = shgo(test1_2.f, test1_2.bounds, n=1, iters=None,
+        _ = shgo(test1_2.f, test1_2.bounds, n=1, iters=None,
                    options=options, sampling_method='sobol')
 
     def test_12_sobol_inf_cons(self):
         """Test to cover the case where f_lowest == 0"""
         options = {'maxtime': 1e-15,
                    'f_min': 0.0}
-        res = shgo(test1_2.f, test1_2.bounds, n=1, iters=None,
+        _ = shgo(test1_2.f, test1_2.bounds, n=1, iters=None,
                    options=options, sampling_method='sobol')
 
     def test_13_high_sobol(self):

--- a/scipy/optimize/tests/test__shgo.py
+++ b/scipy/optimize/tests/test__shgo.py
@@ -450,11 +450,11 @@ class TestShgoArguments(object):
             print("Local minimization callback test")
 
         for test in [test1_1, test2_1]:
-            _ = shgo(test.f, test.bounds, iters=1,
-                       sampling_method='simplicial',
-                       callback=callback_func, options={'disp': True})
-            _ = shgo(test.f, test.bounds, n=1, sampling_method='simplicial',
-                       callback=callback_func, options={'disp': True})
+            shgo(test.f, test.bounds, iters=1,
+                 sampling_method='simplicial',
+                 callback=callback_func, options={'disp': True})
+            shgo(test.f, test.bounds, n=1, sampling_method='simplicial',
+                 callback=callback_func, options={'disp': True})
 
     def test_3_2_disp_sobol(self):
         """Iterative sampling on TestFunction 1 and 2 (multi- and univariate)"""
@@ -463,11 +463,11 @@ class TestShgoArguments(object):
             print("Local minimization callback test")
 
         for test in [test1_1, test2_1]:
-            _ = shgo(test.f, test.bounds, iters=1, sampling_method='sobol',
-                       callback=callback_func, options={'disp': True})
+            shgo(test.f, test.bounds, iters=1, sampling_method='sobol',
+                 callback=callback_func, options={'disp': True})
 
-            _ = shgo(test.f, test.bounds, n=1, sampling_method='simplicial',
-                       callback=callback_func, options={'disp': True})
+            shgo(test.f, test.bounds, n=1, sampling_method='simplicial',
+                 callback=callback_func, options={'disp': True})
 
     @pytest.mark.slow
     def test_4_1_known_f_min(self):
@@ -571,8 +571,8 @@ class TestShgoArguments(object):
         """Test the minimizer_kwargs default inits"""
         minimizer_kwargs = {'ftol': 1e-5}
         options = {'disp': True}  # For coverage purposes
-        _ = SHGO(test3_1.f, test3_1.bounds, constraints=test3_1.cons[0],
-                     minimizer_kwargs=minimizer_kwargs, options=options)
+        SHGO(test3_1.f, test3_1.bounds, constraints=test3_1.cons[0],
+             minimizer_kwargs=minimizer_kwargs, options=options)
 
     def test_7_3_minkwargs(self):
         """Test minimizer_kwargs arguments for solvers without constraints"""
@@ -602,27 +602,27 @@ class TestShgoArguments(object):
 
     def test_9_cons_g(self):
         """Test single function constraint passing"""
-        _ = SHGO(test3_1.f, test3_1.bounds, constraints=test3_1.cons[0])
+        SHGO(test3_1.f, test3_1.bounds, constraints=test3_1.cons[0])
 
     def test_10_finite_time(self):
         """Test single function constraint passing"""
         options = {'maxtime': 1e-15}
-        _ = shgo(test1_1.f, test1_1.bounds, n=1, iters=None,
-                   options=options, sampling_method='sobol')
+        shgo(test1_1.f, test1_1.bounds, n=1, iters=None,
+             options=options, sampling_method='sobol')
 
     def test_11_f_min_time(self):
         """Test to cover the case where f_lowest == 0"""
         options = {'maxtime': 1e-15,
                    'f_min': 0.0}
-        _ = shgo(test1_2.f, test1_2.bounds, n=1, iters=None,
-                   options=options, sampling_method='sobol')
+        shgo(test1_2.f, test1_2.bounds, n=1, iters=None,
+             options=options, sampling_method='sobol')
 
     def test_12_sobol_inf_cons(self):
         """Test to cover the case where f_lowest == 0"""
         options = {'maxtime': 1e-15,
                    'f_min': 0.0}
-        _ = shgo(test1_2.f, test1_2.bounds, n=1, iters=None,
-                   options=options, sampling_method='sobol')
+        shgo(test1_2.f, test1_2.bounds, n=1, iters=None,
+             options=options, sampling_method='sobol')
 
     def test_13_high_sobol(self):
         """Test init of high-dimensional sobol sequences"""

--- a/scipy/optimize/tests/test_constraint_conversion.py
+++ b/scipy/optimize/tests/test_constraint_conversion.py
@@ -4,11 +4,10 @@ Unit test for constraint conversion
 """
 
 import numpy as np
-from numpy.testing import (assert_, assert_array_almost_equal,
-                           assert_allclose, assert_equal, TestCase,
-                           suppress_warnings, assert_warns, suppress_warnings)
+from numpy.testing import (assert_array_almost_equal,
+                           assert_allclose, assert_warns, suppress_warnings)
 import pytest
-from scipy.optimize import (NonlinearConstraint, LinearConstraint, Bounds,
+from scipy.optimize import (NonlinearConstraint, LinearConstraint,
                             OptimizeWarning, minimize, BFGS)
 from .test_minimize_constrained import (Maratos, HyperbolicIneq, Rosenbrock,
                                         IneqRosenbrock, EqIneqRosenbrock,

--- a/scipy/optimize/tests/test_differentiable_functions.py
+++ b/scipy/optimize/tests/test_differentiable_functions.py
@@ -359,7 +359,7 @@ class TestVectorialFunction(TestCase):
         njev = 0
 
         x0 = [1.0, 0.0]
-        v0 = [0.0, 1.0]
+        _ = [0.0, 1.0]
         analit = VectorFunction(ex.fun, x0, ex.jac, ex.hess, None, None,
                                 (-np.inf, np.inf), None)
         nfev += 1

--- a/scipy/optimize/tests/test_differentiable_functions.py
+++ b/scipy/optimize/tests/test_differentiable_functions.py
@@ -359,7 +359,6 @@ class TestVectorialFunction(TestCase):
         njev = 0
 
         x0 = [1.0, 0.0]
-        _ = [0.0, 1.0]
         analit = VectorFunction(ex.fun, x0, ex.jac, ex.hess, None, None,
                                 (-np.inf, np.inf), None)
         nfev += 1

--- a/scipy/optimize/tests/test_hessian_update_strategy.py
+++ b/scipy/optimize/tests/test_hessian_update_strategy.py
@@ -3,14 +3,8 @@ import numpy as np
 from copy import deepcopy
 from numpy.linalg import norm
 from numpy.testing import (TestCase, assert_array_almost_equal,
-                           assert_array_equal, assert_array_less,
-                           assert_raises, assert_equal, assert_,
-                           run_module_suite, assert_allclose, assert_warns,
-                           dec)
-from scipy.optimize import (BFGS,
-                            SR1,
-                            HessianUpdateStrategy,
-                            minimize)
+                           assert_array_equal, assert_array_less)
+from scipy.optimize import (BFGS, SR1)
 
 
 class Rosenbrock:

--- a/scipy/optimize/tests/test_lbfgsb_hessinv.py
+++ b/scipy/optimize/tests/test_lbfgsb_hessinv.py
@@ -1,7 +1,7 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import assert_, assert_allclose
+from numpy.testing import assert_allclose
 import scipy.linalg
 from scipy.optimize import minimize
 

--- a/scipy/optimize/tests/test_lsq_common.py
+++ b/scipy/optimize/tests/test_lsq_common.py
@@ -4,7 +4,6 @@ from numpy.testing import assert_, assert_allclose, assert_equal
 from pytest import raises as assert_raises
 import numpy as np
 
-from scipy.sparse.linalg import LinearOperator
 from scipy.optimize._lsq.common import (
     step_size_to_bound, find_active_constraints, make_strictly_feasible,
     CL_scaling_vector, intersect_trust_region, build_quadratic_1d,

--- a/scipy/optimize/tests/test_lsq_linear.py
+++ b/scipy/optimize/tests/test_lsq_linear.py
@@ -1,7 +1,6 @@
 import numpy as np
 from numpy.linalg import lstsq
 from numpy.testing import assert_allclose, assert_equal, assert_
-from pytest import raises as assert_raises
 
 from scipy.sparse import rand
 from scipy.sparse.linalg import aslinearoperator

--- a/scipy/optimize/tests/test_minimize_constrained.py
+++ b/scipy/optimize/tests/test_minimize_constrained.py
@@ -4,7 +4,7 @@ import pytest
 from scipy.linalg import block_diag
 from scipy.sparse import csc_matrix
 from numpy.testing import (TestCase, assert_array_almost_equal,
-                           assert_array_less, assert_allclose, assert_,
+                           assert_array_less, assert_,
                            suppress_warnings)
 from pytest import raises
 from scipy.optimize import (NonlinearConstraint,

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -771,8 +771,8 @@ class TestOptimizeSimple(CheckOptimize):
             return optimize.OptimizeResult()
 
         x0 = [1, 1]
-        _ = optimize.minimize(optimize.rosen, x0, method=custmin,
-                              bounds=bounds, constraints=constraints)
+        optimize.minimize(optimize.rosen, x0, method=custmin,
+                          bounds=bounds, constraints=constraints)
 
     def test_minimize_tol_parameter(self):
         # Check that the minimize() tol= argument does something
@@ -855,7 +855,7 @@ class TestOptimizeSimple(CheckOptimize):
         def callback(x, *args, **kwargs):
             results.append((x, np.copy(x)))
 
-        _ = routine(func, x0, callback=callback, **kwargs)
+        routine(func, x0, callback=callback, **kwargs)
 
         # Check returned arrays coincide with their copies
         # and have no memory overlap

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -771,8 +771,8 @@ class TestOptimizeSimple(CheckOptimize):
             return optimize.OptimizeResult()
 
         x0 = [1, 1]
-        res = optimize.minimize(optimize.rosen, x0, method=custmin,
-                                bounds=bounds, constraints=constraints)
+        _ = optimize.minimize(optimize.rosen, x0, method=custmin,
+                              bounds=bounds, constraints=constraints)
 
     def test_minimize_tol_parameter(self):
         # Check that the minimize() tol= argument does something
@@ -855,7 +855,7 @@ class TestOptimizeSimple(CheckOptimize):
         def callback(x, *args, **kwargs):
             results.append((x, np.copy(x)))
 
-        sol = routine(func, x0, callback=callback, **kwargs)
+        _ = routine(func, x0, callback=callback, **kwargs)
 
         # Check returned arrays coincide with their copies
         # and have no memory overlap

--- a/scipy/optimize/tests/test_slsqp.py
+++ b/scipy/optimize/tests/test_slsqp.py
@@ -3,13 +3,12 @@ Unit test for SLSQP optimization.
 """
 from __future__ import division, print_function, absolute_import
 
-import pytest
 from numpy.testing import (assert_, assert_array_almost_equal,
                            assert_allclose, assert_equal)
 from pytest import raises as assert_raises
 import numpy as np
 
-from scipy.optimize import fmin_slsqp, minimize, NonlinearConstraint, Bounds
+from scipy.optimize import fmin_slsqp, minimize, Bounds
 
 
 class MyCallBack(object):

--- a/scipy/optimize/tests/test_trustregion_exact.py
+++ b/scipy/optimize/tests/test_trustregion_exact.py
@@ -12,12 +12,9 @@ from scipy.optimize._trustregion_exact import (
     estimate_smallest_singular_value,
     singular_leading_submatrix,
     IterativeSubproblem)
-from scipy.linalg import (svd, get_lapack_funcs, det,
-                          cho_factor, cho_solve, qr,
-                          eigvalsh, eig, norm)
-from numpy.testing import (assert_, assert_array_equal,
-                           assert_equal, assert_array_almost_equal,
-                           assert_array_less)
+from scipy.linalg import (svd, get_lapack_funcs, det, qr, norm)
+from numpy.testing import (assert_array_equal,
+                           assert_equal, assert_array_almost_equal)
 
 
 def random_entry(n, min_eig, max_eig, case):

--- a/scipy/optimize/tests/test_trustregion_krylov.py
+++ b/scipy/optimize/tests/test_trustregion_krylov.py
@@ -9,10 +9,9 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 from scipy.optimize._trlib import (get_trlib_quadratic_subproblem)
-from numpy.testing import (assert_, assert_array_equal,
+from numpy.testing import (assert_,
                            assert_almost_equal,
-                           assert_equal, assert_array_almost_equal,
-                           assert_array_less)
+                           assert_equal, assert_array_almost_equal)
 
 KrylovQP = get_trlib_quadratic_subproblem(tol_rel_i=1e-8, tol_rel_b=1e-6)
 KrylovQP_disp = get_trlib_quadratic_subproblem(tol_rel_i=1e-8, tol_rel_b=1e-6, disp=True)

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -448,7 +448,7 @@ class TestBasic(object):
         dfunc = lambda x: 2*x
         assert_warns(RuntimeWarning, zeros.newton, func, 0.0, dfunc, disp=False)
         with pytest.raises(RuntimeError, match='Derivative was zero'):
-            _ = zeros.newton(func, 0.0, dfunc)
+            zeros.newton(func, 0.0, dfunc)
 
     def test_newton_does_not_modify_x0(self):
         # https://github.com/scipy/scipy/issues/9964
@@ -749,8 +749,8 @@ def test_gh9551_raise_error_if_disp_true():
 
     assert_warns(RuntimeWarning, zeros.newton, f, 1.0, f_p, disp=False)
     with pytest.raises(
-        RuntimeError,
-        match=r'^Derivative was zero\. Failed to converge after \d+ iterations, value is [+-]?\d*\.\d+\.$'):
-        _ = zeros.newton(f, 1.0, f_p)
+            RuntimeError,
+            match=r'^Derivative was zero\. Failed to converge after \d+ iterations, value is [+-]?\d*\.\d+\.$'):
+        zeros.newton(f, 1.0, f_p)
     root = zeros.newton(f, complex(10.0, 10.0), f_p)
     assert_allclose(root, complex(0.0, 1.0))

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -448,7 +448,7 @@ class TestBasic(object):
         dfunc = lambda x: 2*x
         assert_warns(RuntimeWarning, zeros.newton, func, 0.0, dfunc, disp=False)
         with pytest.raises(RuntimeError, match='Derivative was zero'):
-            result = zeros.newton(func, 0.0, dfunc)
+            _ = zeros.newton(func, 0.0, dfunc)
 
     def test_newton_does_not_modify_x0(self):
         # https://github.com/scipy/scipy/issues/9964
@@ -751,6 +751,6 @@ def test_gh9551_raise_error_if_disp_true():
     with pytest.raises(
         RuntimeError,
         match=r'^Derivative was zero\. Failed to converge after \d+ iterations, value is [+-]?\d*\.\d+\.$'):
-        result = zeros.newton(f, 1.0, f_p)
+        _ = zeros.newton(f, 1.0, f_p)
     root = zeros.newton(f, complex(10.0, 10.0), f_p)
     assert_allclose(root, complex(0.0, 1.0))

--- a/scipy/optimize/tnc.py
+++ b/scipy/optimize/tnc.py
@@ -36,9 +36,7 @@ from __future__ import division, print_function, absolute_import
 
 from scipy.optimize import moduleTNC
 from .optimize import (MemoizeJac, OptimizeResult, _check_unknown_options,
-                       wrap_function, _prepare_scalar_function)
-from ._differentiable_functions import ScalarFunction, FD_METHODS
-from ._numdiff import approx_derivative
+                       _prepare_scalar_function)
 from ._constraints import old_bound_to_new
 
 from numpy import inf, array, zeros, asfarray


### PR DESCRIPTION
Unused explicitly named imports have been removed.  Exceptions are:
  - imports in __init__.py;
  - imports used for side-effects.

#### Reference issue
Further work on gh-11529

#### What does this implement/fix?
Removes some unused imports, unused assignments to reduce Pyflakes warnings.
