### PR TITLE
FIX: Allow non-native byte order inputs to scipy.fft

### DIFF
--- a/scipy/fft/_pocketfft/helper.py
+++ b/scipy/fft/_pocketfft/helper.py
@@ -91,8 +91,11 @@ def _asfarray(x):
     elif x.dtype.kind not in 'fc':
         return np.asarray(x, np.float64)
 
+    # Require native byte order
+    dtype = x.dtype.newbyteorder('=')
     # Always align input
-    return np.array(x, copy=not x.flags['ALIGNED'])
+    copy = not x.flags['ALIGNED']
+    return np.array(x, dtype=dtype, copy=copy)
 
 def _datacopied(arr, original):
     """

--- a/scipy/fft/_pocketfft/tests/test_basic.py
+++ b/scipy/fft/_pocketfft/tests/test_basic.py
@@ -1017,7 +1017,7 @@ def test_swapped_byte_order_complex(func):
 
 
 @pytest.mark.parametrize('func', [ihfft, ihfftn, rfft, rfftn])
-def test_swapped_byte_order_complex(func):
+def test_swapped_byte_order_real(func):
     rng = np.random.RandomState(1234)
     x = rng.rand(10)
     assert_allclose(func(swap_byteorder(x)), func(x))

--- a/scipy/fft/_pocketfft/tests/test_basic.py
+++ b/scipy/fft/_pocketfft/tests/test_basic.py
@@ -8,7 +8,8 @@ from numpy.testing import (assert_, assert_equal, assert_array_almost_equal,
 import pytest
 from pytest import raises as assert_raises
 from scipy.fft._pocketfft import (ifft, fft, fftn, ifftn,
-                                  rfft, irfft, rfftn, irfftn, fft2)
+                                  rfft, irfft, rfftn, irfftn, fft2,
+                                  hfft, ihfft, hfftn, ihfftn)
 
 from numpy import (arange, add, array, asarray, zeros, dot, exp, pi,
                    swapaxes, double, cdouble)
@@ -45,6 +46,10 @@ def _assert_close_in_norm(x, y, rtol, size, rdt):
 def random(size):
     return rand(*size)
 
+def swap_byteorder(arr):
+    """Returns the same array with swapped byteorder"""
+    dtype = arr.dtype.newbyteorder('S')
+    return arr.astype(dtype)
 
 def get_mat(n):
     data = arange(n)
@@ -1001,3 +1006,18 @@ def test_invalid_norm(func):
     with assert_raises(ValueError,
                        match='Invalid norm value o, should be None or "ortho"'):
         func(x, norm='o')
+
+
+@pytest.mark.parametrize('func', [fft, ifft, fftn, ifftn,
+                                   irfft, irfftn, hfft, hfftn])
+def test_swapped_byte_order_complex(func):
+    rng = np.random.RandomState(1234)
+    x = rng.rand(10) + 1j * rng.rand(10)
+    assert_allclose(func(swap_byteorder(x)), func(x))
+
+
+@pytest.mark.parametrize('func', [ihfft, ihfftn, rfft, rfftn])
+def test_swapped_byte_order_complex(func):
+    rng = np.random.RandomState(1234)
+    x = rng.rand(10)
+    assert_allclose(func(swap_byteorder(x)), func(x))

--- a/scipy/fft/_pocketfft/tests/test_real_transforms.py
+++ b/scipy/fft/_pocketfft/tests/test_real_transforms.py
@@ -479,3 +479,12 @@ class Test_DCTN_IDCTN(object):
         tmp = fforward(self.data, s=None, axes=axes, norm='ortho')
         tmp = finverse(tmp, s=None, axes=axes, norm='ortho')
         assert_array_almost_equal(self.data, tmp, decimal=self.dec)
+
+
+@pytest.mark.parametrize('func', [dct, dctn, idct, idctn,
+                                  dst, dstn, idst, idstn])
+def test_swapped_byte_order(func):
+    rng = np.random.RandomState(1234)
+    x = rng.rand(10)
+    swapped_dt = x.dtype.newbyteorder('S')
+    assert_allclose(func(x.astype(swapped_dt)), func(x))


### PR DESCRIPTION
#### Reference issue
Fixes https://github.com/scipy/scipy/issues/10422#issuecomment-587040183

#### What does this implement/fix?
`_pocketfft` transforms now accept inputs in non-native byte-order by copying the data to native byte-order first.