### PR TITLE
MAINT: Fixed several unused imports in _lib.

### DIFF
--- a/scipy/_lib/tests/test__gcutils.py
+++ b/scipy/_lib/tests/test__gcutils.py
@@ -73,6 +73,10 @@ def test_assert_deallocated_nodel():
         pass
     with pytest.raises(ReferenceError):
         # Need to delete after using if in with-block context
+        # Note: assert_deallocated(C) needs to be assigned for the test
+        # to function correctly.  It is assigned to c, but c itself is
+        # not referenced in the body of the with, it is only there for
+        # the refcount.
         with assert_deallocated(C) as c:
             pass
 

--- a/scipy/_lib/tests/test__pep440.py
+++ b/scipy/_lib/tests/test__pep440.py
@@ -1,6 +1,5 @@
 from __future__ import division, absolute_import, print_function
 
-from numpy.testing import assert_
 from pytest import raises as assert_raises
 from scipy._lib._pep440 import Version, parse
 

--- a/scipy/_lib/tests/test_warnings.py
+++ b/scipy/_lib/tests/test_warnings.py
@@ -8,7 +8,6 @@ from NumPy.
 from __future__ import division, absolute_import, print_function
 
 import os
-import sys
 from pathlib import Path
 import ast
 import tokenize


### PR DESCRIPTION
Removed two unused imports in _lib.

#### Reference issue
Further work on gh-11529

#### What does this implement/fix?
Removes some unused imports, commented on an unused assignment, to reduce Pyflakes warnings.