### PR TITLE
MAINT: Fixed several unused imports and unused assignments in scipy/interpolate

### DIFF
--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -4,9 +4,8 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 
-from . import BPoly, PPoly
+from . import PPoly
 from .polyint import _isscalar
-from scipy._lib._util import _asarray_validated
 from scipy.linalg import solve_banded, solve
 
 

--- a/scipy/interpolate/fitpack.py
+++ b/scipy/interpolate/fitpack.py
@@ -7,7 +7,7 @@ import warnings
 
 import numpy as np
 
-# These are in the API for fftpack even if not used in fftpacvk.py itself.
+# These are in the API for fitpack even if not used in fitpack.py itself.
 from ._fitpack_impl import bisplrep, bisplev, dblint
 from . import _fitpack_impl as _impl
 from ._bsplines import BSpline

--- a/scipy/interpolate/fitpack.py
+++ b/scipy/interpolate/fitpack.py
@@ -7,6 +7,7 @@ import warnings
 
 import numpy as np
 
+# These are in the API for fftpack even if not used in fftpacvk.py itself.
 from ._fitpack_impl import bisplrep, bisplev, dblint
 from . import _fitpack_impl as _impl
 from ._bsplines import BSpline

--- a/scipy/interpolate/polyint.py
+++ b/scipy/interpolate/polyint.py
@@ -1,7 +1,5 @@
 from __future__ import division, print_function, absolute_import
 
-import warnings
-
 import numpy as np
 from scipy.special import factorial
 

--- a/scipy/interpolate/rbf.py
+++ b/scipy/interpolate/rbf.py
@@ -45,7 +45,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 from __future__ import division, print_function, absolute_import
 
-import sys
 import numpy as np
 
 from scipy import linalg

--- a/scipy/interpolate/tests/test_fitpack.py
+++ b/scipy/interpolate/tests/test_fitpack.py
@@ -79,7 +79,7 @@ class TestSmokeTests(object):
             xe = b
         x = a+(b-a)*arange(N+1,dtype=float)/float(N)    # nodes
         x1 = a+(b-a)*arange(1,N,dtype=float)/float(N-1)  # middle points of the nodes
-        v, _ = f(x),f(x1)
+        v = f(x)
         nk = []
 
         def err_est(k, d):

--- a/scipy/interpolate/tests/test_fitpack.py
+++ b/scipy/interpolate/tests/test_fitpack.py
@@ -79,7 +79,7 @@ class TestSmokeTests(object):
             xe = b
         x = a+(b-a)*arange(N+1,dtype=float)/float(N)    # nodes
         x1 = a+(b-a)*arange(1,N,dtype=float)/float(N-1)  # middle points of the nodes
-        v,v1 = f(x),f(x1)
+        v, _ = f(x),f(x1)
         nk = []
 
         def err_est(k, d):
@@ -192,7 +192,7 @@ class TestSmokeTests(object):
             xe = b
         x = a+(b-a)*arange(N+1,dtype=float)/float(N)    # nodes
         x1 = a + (b-a)*arange(1,N,dtype=float)/float(N-1)  # middle points of the nodes
-        v,v1 = f(x),f(x1)
+        v, _ = f(x),f(x1)
         put(" u = %s   N = %d" % (repr(round(dx,3)),N))
         put("  k  :  [x(u), %s(x(u))]  Error of splprep  Error of splrep " % (f(0,None)))
         for k in range(1,6):

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -200,8 +200,8 @@ class TestUnivariateSpline(object):
         # also test LSQUnivariateSpline [which needs explicit knots]
         spl = UnivariateSpline(xx, yy, check_finite=True)
         t = spl.get_knots()[3:4]  # interior knots w/ default k=3
-        spl2 = UnivariateSpline(x=x, y=y, w=w, s=1, check_finite=True)
-        spl3 = LSQUnivariateSpline(x=x, y=y, t=t, w=w, check_finite=True)
+        UnivariateSpline(x=x, y=y, w=w, s=1, check_finite=True)
+        LSQUnivariateSpline(x=x, y=y, t=t, w=w, check_finite=True)
         assert_raises(ValueError, UnivariateSpline,
                 **dict(x=x, y=y, s=0, check_finite=True))
         assert_raises(ValueError, InterpolatedUnivariateSpline,

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -913,7 +913,7 @@ class TestPPolyCommon(object):
         c_s = c.shape
         xp = np.random.random((1, 2))
         for axis in (0, 1, 2, 3):
-            _, m = c.shape[axis], c.shape[axis+1]
+            m = c.shape[axis+1]
             x = np.sort(np.random.rand(m+1))
             for cls in (PPoly, BPoly):
                 p = cls(c, x, axis=axis)

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -4,7 +4,7 @@ import itertools
 
 from numpy.testing import (assert_, assert_equal, assert_almost_equal,
         assert_array_almost_equal, assert_array_equal,
-        assert_allclose, assert_warns, suppress_warnings)
+        assert_allclose, assert_warns)
 from pytest import raises as assert_raises
 import pytest
 
@@ -658,7 +658,7 @@ class TestInterp1D(object):
         y = np.linspace(0, 1)
         # Confirm interp can be released from memory after use
         with assert_deallocated(interp1d, x, y) as interp:
-            new_y = interp([0.1, 0.2])
+            interp([0.1, 0.2])
             del interp
 
     def test_overflow_nearest(self):
@@ -913,7 +913,7 @@ class TestPPolyCommon(object):
         c_s = c.shape
         xp = np.random.random((1, 2))
         for axis in (0, 1, 2, 3):
-            k, m = c.shape[axis], c.shape[axis+1]
+            _, m = c.shape[axis], c.shape[axis+1]
             x = np.sort(np.random.rand(m+1))
             for cls in (PPoly, BPoly):
                 p = cls(c, x, axis=axis)
@@ -1007,7 +1007,7 @@ class TestPPoly(object):
         c = np.array([[1, 4], [2, 5], [3, 6]])
         x = np.array([0, 0.5, 1])
         xnew = np.array([0, 0.1, 0.2])
-        p = PPoly(c, x, extrapolate='periodic')
+        PPoly(c, x, extrapolate='periodic')
 
         for writeable in (True, False):
             x.flags.writeable = writeable
@@ -1901,7 +1901,7 @@ class TestBPolyFromDerivatives(object):
         m, k = 5, 12
         xi, yi = self._make_random_mk(m, k)
 
-        pp = BPoly.from_derivatives(xi, yi, orders=2*k-1)   # this is still ok
+        BPoly.from_derivatives(xi, yi, orders=2*k-1)   # this is still ok
         assert_raises(ValueError, BPoly.from_derivatives,   # but this is not
                 **dict(xi=xi, yi=yi, orders=2*k))
 
@@ -2572,9 +2572,9 @@ class TestRegularGridInterpolator(object):
         # from #3703; test that interpolator object construction succeeds
         values = np.ones((10, 20, 30), dtype='>f4')
         points = [np.arange(n) for n in values.shape]
-        xi = [(1, 1, 1)]
-        interpolator = RegularGridInterpolator(points, values)
-        interpolator = RegularGridInterpolator(points, values, fill_value=0.)
+        # xi = [(1, 1, 1)]
+        RegularGridInterpolator(points, values)
+        RegularGridInterpolator(points, values, fill_value=0.)
 
 
 class MyValue(object):

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -198,14 +198,14 @@ class TestKrogh(object):
                                 np.zeros(len(self.test_xs)))
 
     def test_hermite(self):
-        xs = [0,0,0,1,1,1,2]
-        ys = [self.true_poly(0),
-              self.true_poly.deriv(1)(0),
-              self.true_poly.deriv(2)(0),
-              self.true_poly(1),
-              self.true_poly.deriv(1)(1),
-              self.true_poly.deriv(2)(1),
-              self.true_poly(2)]
+        # xs = [0,0,0,1,1,1,2]
+        # ys = [self.true_poly(0),
+        #       self.true_poly.deriv(1)(0),
+        #       self.true_poly.deriv(2)(0),
+        #       self.true_poly(1),
+        #       self.true_poly.deriv(1)(1),
+        #       self.true_poly.deriv(2)(1),
+        #       self.true_poly(2)]
         P = KroghInterpolator(self.xs,self.ys)
         assert_almost_equal(self.true_poly(self.test_xs),P(self.test_xs))
 

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -198,14 +198,6 @@ class TestKrogh(object):
                                 np.zeros(len(self.test_xs)))
 
     def test_hermite(self):
-        # xs = [0,0,0,1,1,1,2]
-        # ys = [self.true_poly(0),
-        #       self.true_poly.deriv(1)(0),
-        #       self.true_poly.deriv(2)(0),
-        #       self.true_poly(1),
-        #       self.true_poly.deriv(1)(1),
-        #       self.true_poly.deriv(2)(1),
-        #       self.true_poly(2)]
         P = KroghInterpolator(self.xs,self.ys)
         assert_almost_equal(self.true_poly(self.test_xs),P(self.test_xs))
 

--- a/scipy/interpolate/tests/test_rbf.py
+++ b/scipy/interpolate/tests/test_rbf.py
@@ -216,7 +216,7 @@ def test_two_arg_function_is_callable():
 def test_rbf_epsilon_none():
     x = linspace(0, 10, 9)
     y = sin(x)
-    rbf = Rbf(x, y, epsilon=None)
+    Rbf(x, y, epsilon=None)
 
 
 def test_rbf_epsilon_none_collinear():


### PR DESCRIPTION
#### Reference issue
Further work on gh-11529

#### What does this implement/fix?
To reduce Pyflakes warnings, remove five(5) unused imports; eleven (11) unused variable assignments; commented on why one apparently unused import needs to be kept; 