### PR TITLE
MAINT: stats: remove an _argcheck call

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -428,7 +428,6 @@ class rv_frozen(object):
         self.dist = dist.__class__(**dist._updated_ctor_param())
 
         shapes, _, _ = self.dist._parse_args(*args, **kwds)
-        self.dist._argcheck(*shapes)
         self.a, self.b = self.dist._get_support(*shapes)
 
     @property


### PR DESCRIPTION
This was needed when `_argcheck` could set the `.a` and `.b` attributes. Since it
no longer does (after gh-9900 and gh-10104), the call is not needed. The attributes are set in `self.dist._get_support` which is, literally, the next line.

EDIT: For context, the call was added in gh-3245