### PR TITLE
MAINT: Small change to `optimize.nnls` error messages.

### DIFF
--- a/scipy/optimize/nnls.py
+++ b/scipy/optimize/nnls.py
@@ -60,14 +60,18 @@ def nnls(A, b, maxiter=None):
     A, b = map(asarray_chkfinite, (A, b))
 
     if len(A.shape) != 2:
-        raise ValueError("expected matrix")
+        raise ValueError("Expected a two-dimensional array (matrix)" +
+                         ", but the shape of A is %s" % (A.shape, ))
     if len(b.shape) != 1:
-        raise ValueError("expected vector")
+        raise ValueError("Expected a one-dimensional array (vector" +
+                         ", but the shape of b is %s" % (b.shape, ))
 
     m, n = A.shape
 
     if m != b.shape[0]:
-        raise ValueError("incompatible dimensions")
+        raise ValueError(
+                "Incompatible dimensions. The first dimension of " +
+                "A is %s, while the shape of b is %s" % (m, (b.shape[0], )))
 
     maxiter = -1 if maxiter is None else int(maxiter)
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
I don't think that this was previously flagged.

#### What does this implement/fix?
The term "matrix" is ambiguous and can refer to either a two-dimensional array or a numpy `matrix` object (which is deprecated). The changed error message can confuse users to think they need the latter, when the former will do.

I also added more detail about the inputs provided by the user, as additional feedback when things go wrong.