### PR TITLE
MAINT: Update sytrd/hetrd tests

### DIFF
--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -633,12 +633,19 @@ def test_sgesdd_lwork_bug_workaround():
 
 class TestSytrd(object):
     @pytest.mark.parametrize('dtype', REAL_DTYPES)
-    def test_sytrd(self, dtype):
+    def test_sytrd_with_zero_dim_array(self, dtype):
         # Assert that a 0x0 matrix raises an error
         A = np.zeros((0, 0), dtype=dtype)
+        sytrd = get_lapack_funcs('sytrd', (A,))
+        assert_raises(ValueError, sytrd, A)
+
+    @pytest.mark.parametrize('dtype', REAL_DTYPES)
+    def test_sytrd(self, dtype):
+        n = 3
+        A = np.zeros((n, n), dtype=dtype)
+
         sytrd, sytrd_lwork = \
             get_lapack_funcs(('sytrd', 'sytrd_lwork'), (A,))
-        assert_raises(ValueError, sytrd, A)
 
         # Tests for n = 1 currently fail with
         # ```
@@ -650,8 +657,6 @@ class TestSytrd(object):
         # TODO Once the minimum NumPy version is past 1.14, test for n=1
 
         # some upper triangular array
-        n = 3
-        A = np.zeros((n, n), dtype=dtype)
         A[np.triu_indices_from(A)] = \
             np.arange(1, n*(n+1)//2+1, dtype=dtype)
 

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -709,20 +709,11 @@ class TestHetrd(object):
 
     @pytest.mark.parametrize('real_dtype,complex_dtype',
                              zip(REAL_DTYPES, COMPLEX_DTYPES))
-    def test_hetrd(self, real_dtype, complex_dtype):
-        n = 3
+    @pytest.mark.parametrize('n', (1, 3))
+    def test_hetrd(self, n, real_dtype, complex_dtype):
         A = np.zeros((n, n), dtype=complex_dtype)
         hetrd, hetrd_lwork = \
             get_lapack_funcs(('hetrd', 'hetrd_lwork'), (A,))
-
-        # Tests for n = 1 currently fail with
-        # ```
-        # ValueError: failed to create intent(cache|hide)|optional array--
-        # must have defined dimensions but got (0,)
-        # ```
-        # This is a NumPy issue
-        # <https://github.com/numpy/numpy/issues/9617>.
-        # TODO Once the minimum NumPy version is past 1.14, test for n=1
 
         # some upper triangular array
         A[np.triu_indices_from(A)] = (

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -632,75 +632,75 @@ def test_sgesdd_lwork_bug_workaround():
 
 
 class TestSytrd(object):
-    def test_sytrd(self):
-        for dtype in REAL_DTYPES:
-            # Assert that a 0x0 matrix raises an error
-            A = np.zeros((0, 0), dtype=dtype)
-            sytrd, sytrd_lwork = \
-                get_lapack_funcs(('sytrd', 'sytrd_lwork'), (A,))
-            assert_raises(ValueError, sytrd, A)
+    @pytest.mark.parametrize('dtype', REAL_DTYPES)
+    def test_sytrd(self, dtype):
+        # Assert that a 0x0 matrix raises an error
+        A = np.zeros((0, 0), dtype=dtype)
+        sytrd, sytrd_lwork = \
+            get_lapack_funcs(('sytrd', 'sytrd_lwork'), (A,))
+        assert_raises(ValueError, sytrd, A)
 
-            # Tests for n = 1 currently fail with
-            # ```
-            # ValueError: failed to create intent(cache|hide)|optional array--
-            # must have defined dimensions but got (0,)
-            # ```
-            # This is a NumPy issue
-            # <https://github.com/numpy/numpy/issues/9617>.
-            # TODO Once the minimum NumPy version is past 1.14, test for n=1
+        # Tests for n = 1 currently fail with
+        # ```
+        # ValueError: failed to create intent(cache|hide)|optional array--
+        # must have defined dimensions but got (0,)
+        # ```
+        # This is a NumPy issue
+        # <https://github.com/numpy/numpy/issues/9617>.
+        # TODO Once the minimum NumPy version is past 1.14, test for n=1
 
-            # some upper triangular array
-            n = 3
-            A = np.zeros((n, n), dtype=dtype)
-            A[np.triu_indices_from(A)] = \
-                np.arange(1, n*(n+1)//2+1, dtype=dtype)
+        # some upper triangular array
+        n = 3
+        A = np.zeros((n, n), dtype=dtype)
+        A[np.triu_indices_from(A)] = \
+            np.arange(1, n*(n+1)//2+1, dtype=dtype)
 
-            # query lwork
-            lwork, info = sytrd_lwork(n)
-            assert_equal(info, 0)
+        # query lwork
+        lwork, info = sytrd_lwork(n)
+        assert_equal(info, 0)
 
-            # check lower=1 behavior (shouldn't do much since the matrix is
-            # upper triangular)
-            data, d, e, tau, info = sytrd(A, lower=1, lwork=lwork)
-            assert_equal(info, 0)
+        # check lower=1 behavior (shouldn't do much since the matrix is
+        # upper triangular)
+        data, d, e, tau, info = sytrd(A, lower=1, lwork=lwork)
+        assert_equal(info, 0)
 
-            assert_allclose(data, A, atol=5*np.finfo(dtype).eps, rtol=1.0)
-            assert_allclose(d, np.diag(A))
-            assert_allclose(e, 0.0)
-            assert_allclose(tau, 0.0)
+        assert_allclose(data, A, atol=5*np.finfo(dtype).eps, rtol=1.0)
+        assert_allclose(d, np.diag(A))
+        assert_allclose(e, 0.0)
+        assert_allclose(tau, 0.0)
 
-            # and now for the proper test (lower=0 is the default)
-            data, d, e, tau, info = sytrd(A, lwork=lwork)
-            assert_equal(info, 0)
+        # and now for the proper test (lower=0 is the default)
+        data, d, e, tau, info = sytrd(A, lwork=lwork)
+        assert_equal(info, 0)
 
-            # assert Q^T*A*Q = tridiag(e, d, e)
+        # assert Q^T*A*Q = tridiag(e, d, e)
 
-            # build tridiagonal matrix
-            T = np.zeros_like(A, dtype=dtype)
-            k = np.arange(A.shape[0])
-            T[k, k] = d
-            k2 = np.arange(A.shape[0]-1)
-            T[k2+1, k2] = e
-            T[k2, k2+1] = e
+        # build tridiagonal matrix
+        T = np.zeros_like(A, dtype=dtype)
+        k = np.arange(A.shape[0])
+        T[k, k] = d
+        k2 = np.arange(A.shape[0]-1)
+        T[k2+1, k2] = e
+        T[k2, k2+1] = e
 
-            # build Q
-            Q = np.eye(n, n, dtype=dtype)
-            for i in range(n-1):
-                v = np.zeros(n, dtype=dtype)
-                v[:i] = data[:i, i+1]
-                v[i] = 1.0
-                H = np.eye(n, n, dtype=dtype) - tau[i] * np.outer(v, v)
-                Q = np.dot(H, Q)
+        # build Q
+        Q = np.eye(n, n, dtype=dtype)
+        for i in range(n-1):
+            v = np.zeros(n, dtype=dtype)
+            v[:i] = data[:i, i+1]
+            v[i] = 1.0
+            H = np.eye(n, n, dtype=dtype) - tau[i] * np.outer(v, v)
+            Q = np.dot(H, Q)
 
-            # Make matrix fully symmetric
-            i_lower = np.tril_indices(n, -1)
-            A[i_lower] = A.T[i_lower]
+        # Make matrix fully symmetric
+        i_lower = np.tril_indices(n, -1)
+        A[i_lower] = A.T[i_lower]
 
-            QTAQ = np.dot(Q.T, np.dot(A, Q))
+        QTAQ = np.dot(Q.T, np.dot(A, Q))
 
-            # disable rtol here since some values in QTAQ and T are very close
-            # to 0.
-            assert_allclose(QTAQ, T, atol=5*np.finfo(dtype).eps, rtol=1.0)
+        # disable rtol here since some values in QTAQ and T are very close
+        # to 0.
+        assert_allclose(QTAQ, T, atol=5*np.finfo(dtype).eps, rtol=1.0)
 
 
 class TestHetrd(object):

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -640,21 +640,12 @@ class TestSytrd(object):
         assert_raises(ValueError, sytrd, A)
 
     @pytest.mark.parametrize('dtype', REAL_DTYPES)
-    def test_sytrd(self, dtype):
-        n = 3
+    @pytest.mark.parametrize('n', (1, 3))
+    def test_sytrd(self, dtype, n):
         A = np.zeros((n, n), dtype=dtype)
 
         sytrd, sytrd_lwork = \
             get_lapack_funcs(('sytrd', 'sytrd_lwork'), (A,))
-
-        # Tests for n = 1 currently fail with
-        # ```
-        # ValueError: failed to create intent(cache|hide)|optional array--
-        # must have defined dimensions but got (0,)
-        # ```
-        # This is a NumPy issue
-        # <https://github.com/numpy/numpy/issues/9617>.
-        # TODO Once the minimum NumPy version is past 1.14, test for n=1
 
         # some upper triangular array
         A[np.triu_indices_from(A)] = \

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -700,15 +700,20 @@ class TestSytrd(object):
 
 
 class TestHetrd(object):
+    @pytest.mark.parametrize('complex_dtype', COMPLEX_DTYPES)
+    def test_hetrd_with_zero_dim_array(self, complex_dtype):
+        # Assert that a 0x0 matrix raises an error
+        A = np.zeros((0, 0), dtype=complex_dtype)
+        hetrd = get_lapack_funcs('hetrd', (A,))
+        assert_raises(ValueError, hetrd, A)
 
     @pytest.mark.parametrize('real_dtype,complex_dtype',
                              zip(REAL_DTYPES, COMPLEX_DTYPES))
     def test_hetrd(self, real_dtype, complex_dtype):
-        # Assert that a 0x0 matrix raises an error
-        A = np.zeros((0, 0), dtype=complex_dtype)
+        n = 3
+        A = np.zeros((n, n), dtype=complex_dtype)
         hetrd, hetrd_lwork = \
             get_lapack_funcs(('hetrd', 'hetrd_lwork'), (A,))
-        assert_raises(ValueError, hetrd, A)
 
         # Tests for n = 1 currently fail with
         # ```
@@ -720,8 +725,6 @@ class TestHetrd(object):
         # TODO Once the minimum NumPy version is past 1.14, test for n=1
 
         # some upper triangular array
-        n = 3
-        A = np.zeros((n, n), dtype=complex_dtype)
         A[np.triu_indices_from(A)] = (
             np.arange(1, n*(n+1)//2+1, dtype=real_dtype)
             + 1j * np.arange(1, n*(n+1)//2+1, dtype=real_dtype)

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -700,86 +700,88 @@ class TestSytrd(object):
 
 
 class TestHetrd(object):
-    def test_hetrd(self):
-        for real_dtype, complex_dtype in zip(REAL_DTYPES, COMPLEX_DTYPES):
-            # Assert that a 0x0 matrix raises an error
-            A = np.zeros((0, 0), dtype=complex_dtype)
-            hetrd, hetrd_lwork = \
-                get_lapack_funcs(('hetrd', 'hetrd_lwork'), (A,))
-            assert_raises(ValueError, hetrd, A)
 
-            # Tests for n = 1 currently fail with
-            # ```
-            # ValueError: failed to create intent(cache|hide)|optional array--
-            # must have defined dimensions but got (0,)
-            # ```
-            # This is a NumPy issue
-            # <https://github.com/numpy/numpy/issues/9617>.
-            # TODO Once the minimum NumPy version is past 1.14, test for n=1
+    @pytest.mark.parametrize('real_dtype,complex_dtype',
+                             zip(REAL_DTYPES, COMPLEX_DTYPES))
+    def test_hetrd(self, real_dtype, complex_dtype):
+        # Assert that a 0x0 matrix raises an error
+        A = np.zeros((0, 0), dtype=complex_dtype)
+        hetrd, hetrd_lwork = \
+            get_lapack_funcs(('hetrd', 'hetrd_lwork'), (A,))
+        assert_raises(ValueError, hetrd, A)
 
-            # some upper triangular array
-            n = 3
-            A = np.zeros((n, n), dtype=complex_dtype)
-            A[np.triu_indices_from(A)] = (
-                np.arange(1, n*(n+1)//2+1, dtype=real_dtype)
-                + 1j * np.arange(1, n*(n+1)//2+1, dtype=real_dtype)
-                )
-            np.fill_diagonal(A, np.real(np.diag(A)))
+        # Tests for n = 1 currently fail with
+        # ```
+        # ValueError: failed to create intent(cache|hide)|optional array--
+        # must have defined dimensions but got (0,)
+        # ```
+        # This is a NumPy issue
+        # <https://github.com/numpy/numpy/issues/9617>.
+        # TODO Once the minimum NumPy version is past 1.14, test for n=1
 
-            # test query lwork
-            for x in [0, 1]:
-                _, info = hetrd_lwork(n, lower=x)
-                assert_equal(info, 0)
-            # lwork returns complex which segfaults hetrd call (gh-10388)
-            # use the safe and recommended option
-            lwork = _compute_lwork(hetrd_lwork, n)
+        # some upper triangular array
+        n = 3
+        A = np.zeros((n, n), dtype=complex_dtype)
+        A[np.triu_indices_from(A)] = (
+            np.arange(1, n*(n+1)//2+1, dtype=real_dtype)
+            + 1j * np.arange(1, n*(n+1)//2+1, dtype=real_dtype)
+            )
+        np.fill_diagonal(A, np.real(np.diag(A)))
 
-            # check lower=1 behavior (shouldn't do much since the matrix is
-            # upper triangular)
-            data, d, e, tau, info = hetrd(A, lower=1, lwork=lwork)
+        # test query lwork
+        for x in [0, 1]:
+            _, info = hetrd_lwork(n, lower=x)
             assert_equal(info, 0)
+        # lwork returns complex which segfaults hetrd call (gh-10388)
+        # use the safe and recommended option
+        lwork = _compute_lwork(hetrd_lwork, n)
 
-            assert_allclose(data, A, atol=5*np.finfo(real_dtype).eps, rtol=1.0)
+        # check lower=1 behavior (shouldn't do much since the matrix is
+        # upper triangular)
+        data, d, e, tau, info = hetrd(A, lower=1, lwork=lwork)
+        assert_equal(info, 0)
 
-            assert_allclose(d, np.real(np.diag(A)))
-            assert_allclose(e, 0.0)
-            assert_allclose(tau, 0.0)
+        assert_allclose(data, A, atol=5*np.finfo(real_dtype).eps, rtol=1.0)
 
-            # and now for the proper test (lower=0 is the default)
-            data, d, e, tau, info = hetrd(A, lwork=lwork)
-            assert_equal(info, 0)
+        assert_allclose(d, np.real(np.diag(A)))
+        assert_allclose(e, 0.0)
+        assert_allclose(tau, 0.0)
 
-            # assert Q^T*A*Q = tridiag(e, d, e)
+        # and now for the proper test (lower=0 is the default)
+        data, d, e, tau, info = hetrd(A, lwork=lwork)
+        assert_equal(info, 0)
 
-            # build tridiagonal matrix
-            T = np.zeros_like(A, dtype=real_dtype)
-            k = np.arange(A.shape[0], dtype=int)
-            T[k, k] = d
-            k2 = np.arange(A.shape[0]-1, dtype=int)
-            T[k2+1, k2] = e
-            T[k2, k2+1] = e
+        # assert Q^T*A*Q = tridiag(e, d, e)
 
-            # build Q
-            Q = np.eye(n, n, dtype=complex_dtype)
-            for i in range(n-1):
-                v = np.zeros(n, dtype=complex_dtype)
-                v[:i] = data[:i, i+1]
-                v[i] = 1.0
-                H = np.eye(n, n, dtype=complex_dtype) \
-                    - tau[i] * np.outer(v, np.conj(v))
-                Q = np.dot(H, Q)
+        # build tridiagonal matrix
+        T = np.zeros_like(A, dtype=real_dtype)
+        k = np.arange(A.shape[0], dtype=int)
+        T[k, k] = d
+        k2 = np.arange(A.shape[0]-1, dtype=int)
+        T[k2+1, k2] = e
+        T[k2, k2+1] = e
 
-            # Make matrix fully Hermitian
-            i_lower = np.tril_indices(n, -1)
-            A[i_lower] = np.conj(A.T[i_lower])
+        # build Q
+        Q = np.eye(n, n, dtype=complex_dtype)
+        for i in range(n-1):
+            v = np.zeros(n, dtype=complex_dtype)
+            v[:i] = data[:i, i+1]
+            v[i] = 1.0
+            H = np.eye(n, n, dtype=complex_dtype) \
+                - tau[i] * np.outer(v, np.conj(v))
+            Q = np.dot(H, Q)
 
-            QHAQ = np.dot(np.conj(Q.T), np.dot(A, Q))
+        # Make matrix fully Hermitian
+        i_lower = np.tril_indices(n, -1)
+        A[i_lower] = np.conj(A.T[i_lower])
 
-            # disable rtol here since some values in QTAQ and T are very close
-            # to 0.
-            assert_allclose(
-                QHAQ, T, atol=10*np.finfo(real_dtype).eps, rtol=1.0
-                )
+        QHAQ = np.dot(np.conj(Q.T), np.dot(A, Q))
+
+        # disable rtol here since some values in QTAQ and T are very close
+        # to 0.
+        assert_allclose(
+            QHAQ, T, atol=10*np.finfo(real_dtype).eps, rtol=1.0
+            )
 
 
 def test_gglse():


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR adds tests for matrices with dimensions ``n=1``.

While making the changes I've also refactored the tests in two ways:

* The test ``dtype`` is now parameterized, rather than explicitly looping over through a list of dtype. 
* The tests for zero dimension arrays are now distinct tests.

#### Additional information

The case where ``n=1`` couldn't be tested due to a NumPy bug [gh-9617](https://github.com/numpy/numpy/issues/9617). This was fixed in NumPy version 1.14, however the test hadn't been updated as the minimum version used by SciPy was less than 1.14. As this is now the minimum version the tests should be updated.
<!--Any additional information you think is important.-->