### PR TITLE
BUG: Differential evolution with LinearConstraint with sparse matrix

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -228,6 +228,7 @@ Domen Gorjup and Janko Slavič for continuous wavelet transform with complex
     wavelets fix.
 Søren Fuglede Jørgensen for improvements to scipy.sparse.csgraph
 Grzegorz Mrukwa for a bug fix in rectangular_lsap.cpp
+Santiago Hernandez for a bug fix in scipy.optimize._differentialevolution.py.
 
 Institutions
 ------------

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -1299,10 +1299,10 @@ class _ConstraintWrapper(object):
                 return np.atleast_1d(constraint.fun(x))
         elif isinstance(constraint, LinearConstraint):
             def fun(x):
-                if not issparse(constraint.A):
-                    A = np.atleast_2d(constraint.A)
-                else:
+                if issparse(constraint.A):
                     A = constraint.A
+                else:
+                    A = np.atleast_2d(constraint.A)
                 return A.dot(x)
         elif isinstance(constraint, Bounds):
             def fun(x):

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -12,6 +12,7 @@ from scipy._lib._util import check_random_state, MapWrapper
 
 from scipy.optimize._constraints import (Bounds, new_bounds_to_old,
                                          NonlinearConstraint, LinearConstraint)
+from scipy.sparse import issparse
 
 
 __all__ = ['differential_evolution']
@@ -1298,7 +1299,10 @@ class _ConstraintWrapper(object):
                 return np.atleast_1d(constraint.fun(x))
         elif isinstance(constraint, LinearConstraint):
             def fun(x):
-                A = np.atleast_2d(constraint.A)
+                if not issparse(constraint.A):
+                    A = np.atleast_2d(constraint.A)
+                else:
+                    A = constraint.A
                 return A.dot(x)
         elif isinstance(constraint, Bounds):
             def fun(x):

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -12,6 +12,7 @@ from scipy.optimize import differential_evolution
 from scipy.optimize._constraints import (Bounds, NonlinearConstraint,
                                          LinearConstraint)
 from scipy.optimize import rosen
+from scipy.sparse import dok_matrix
 from scipy._lib._pep440 import Version
 
 import numpy as np
@@ -755,6 +756,11 @@ class TestDifferentialEvolutionSolver(object):
         assert (pc.violation(x0) > 0).any()
         assert (pc.violation([-10, 2, -10, 4]) == 0).all()
 
+        pc = _ConstraintWrapper(LinearConstraint(dok_matrix(A), -np.inf, 0),
+                                x0)
+        assert (pc.violation(x0) > 0).any()
+        assert (pc.violation([-10, 2, -10, 4]) == 0).all()
+
         def fun(x):
             return A.dot(x)
 
@@ -842,6 +848,24 @@ class TestDifferentialEvolutionSolver(object):
                                          seed=1234, constraints=constraints,
                                          popsize=2)
 
+        assert_allclose(res.x, x_opt, atol=5e-4)
+        assert_allclose(res.fun, f_opt, atol=5e-3)
+        assert_(np.all(A@res.x <= b))
+        assert_(np.all(res.x >= np.array(bounds)[:, 0]))
+        assert_(np.all(res.x <= np.array(bounds)[:, 1]))
+
+        # now repeat the same solve, using the same overall constraints,
+        # but using a sparse matrix for the LinearConstraint instead of an
+        # array
+
+        L = LinearConstraint(dok_matrix(A), -np.inf, b)
+
+        # using a lower popsize to speed the test up
+        res = differential_evolution(f, bounds, strategy='best1bin', seed=1234,
+                                     constraints=(L), popsize=2)
+
+        assert_allclose(f(x_opt), f_opt)
+        assert res.success
         assert_allclose(res.x, x_opt, atol=5e-4)
         assert_allclose(res.fun, f_opt, atol=5e-3)
         assert_(np.all(A@res.x <= b))

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -12,7 +12,7 @@ from scipy.optimize import differential_evolution
 from scipy.optimize._constraints import (Bounds, NonlinearConstraint,
                                          LinearConstraint)
 from scipy.optimize import rosen
-from scipy.sparse import dok_matrix
+from scipy.sparse import csr_matrix
 from scipy._lib._pep440 import Version
 
 import numpy as np
@@ -756,7 +756,7 @@ class TestDifferentialEvolutionSolver(object):
         assert (pc.violation(x0) > 0).any()
         assert (pc.violation([-10, 2, -10, 4]) == 0).all()
 
-        pc = _ConstraintWrapper(LinearConstraint(dok_matrix(A), -np.inf, 0),
+        pc = _ConstraintWrapper(LinearConstraint(csr_matrix(A), -np.inf, 0),
                                 x0)
         assert (pc.violation(x0) > 0).any()
         assert (pc.violation([-10, 2, -10, 4]) == 0).all()
@@ -828,7 +828,7 @@ class TestDifferentialEvolutionSolver(object):
         # but using a sparse matrix for the LinearConstraint instead of an
         # array
 
-        L = LinearConstraint(dok_matrix(A), -np.inf, b)
+        L = LinearConstraint(csr_matrix(A), -np.inf, b)
 
         # using a lower popsize to speed the test up
         res = differential_evolution(f, bounds, strategy='best1bin', seed=1234,

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -825,6 +825,24 @@ class TestDifferentialEvolutionSolver(object):
         assert_(np.all(res.x <= np.array(bounds)[:, 1]))
 
         # now repeat the same solve, using the same overall constraints,
+        # but using a sparse matrix for the LinearConstraint instead of an
+        # array
+
+        L = LinearConstraint(dok_matrix(A), -np.inf, b)
+
+        # using a lower popsize to speed the test up
+        res = differential_evolution(f, bounds, strategy='best1bin', seed=1234,
+                                     constraints=(L), popsize=2)
+
+        assert_allclose(f(x_opt), f_opt)
+        assert res.success
+        assert_allclose(res.x, x_opt, atol=5e-4)
+        assert_allclose(res.fun, f_opt, atol=5e-3)
+        assert_(np.all(A@res.x <= b))
+        assert_(np.all(res.x >= np.array(bounds)[:, 0]))
+        assert_(np.all(res.x <= np.array(bounds)[:, 1]))
+
+        # now repeat the same solve, using the same overall constraints,
         # but specify half the constraints in terms of LinearConstraint,
         # and the other half by NonlinearConstraint
         def c1(x):
@@ -848,24 +866,6 @@ class TestDifferentialEvolutionSolver(object):
                                          seed=1234, constraints=constraints,
                                          popsize=2)
 
-        assert_allclose(res.x, x_opt, atol=5e-4)
-        assert_allclose(res.fun, f_opt, atol=5e-3)
-        assert_(np.all(A@res.x <= b))
-        assert_(np.all(res.x >= np.array(bounds)[:, 0]))
-        assert_(np.all(res.x <= np.array(bounds)[:, 1]))
-
-        # now repeat the same solve, using the same overall constraints,
-        # but using a sparse matrix for the LinearConstraint instead of an
-        # array
-
-        L = LinearConstraint(dok_matrix(A), -np.inf, b)
-
-        # using a lower popsize to speed the test up
-        res = differential_evolution(f, bounds, strategy='best1bin', seed=1234,
-                                     constraints=(L), popsize=2)
-
-        assert_allclose(f(x_opt), f_opt)
-        assert res.success
         assert_allclose(res.x, x_opt, atol=5e-4)
         assert_allclose(res.fun, f_opt, atol=5e-3)
         assert_(np.all(A@res.x <= b))


### PR DESCRIPTION
Reference issue #11586.

The constraint matrix was being transformed into a 1x1 array with the
whole matrix in the position (0, 0) instead of keeping it as a matrix
or transforming the sparse matrix into the equivalent dense array.