### PR TITLE
MAINT: Fully display problem size in lsmr/lsqr.

### DIFF
--- a/scipy/sparse/linalg/isolve/lsmr.py
+++ b/scipy/sparse/linalg/isolve/lsmr.py
@@ -229,7 +229,7 @@ def lsmr(A, b, damp=0.0, atol=1e-6, btol=1e-6, conlim=1e8,
     if show:
         print(' ')
         print('LSMR            Least-squares solution of  Ax = b\n')
-        print('The matrix A has %8g rows  and %8g cols' % (m, n))
+        print(f'The matrix A has {m} rows and {n} columns')
         print('damp = %20.14e\n' % (damp))
         print('atol = %8.2e                 conlim = %8.2e\n' % (atol, conlim))
         print('btol = %8.2e             maxiter = %8g\n' % (btol, maxiter))

--- a/scipy/sparse/linalg/isolve/lsqr.py
+++ b/scipy/sparse/linalg/isolve/lsqr.py
@@ -330,7 +330,7 @@ def lsqr(A, b, damp=0.0, atol=1e-8, btol=1e-8, conlim=1e8,
     if show:
         print(' ')
         print('LSQR            Least-squares solution of  Ax = b')
-        str1 = 'The matrix A has %8g rows  and %8g cols' % (m, n)
+        str1 = f'The matrix A has {m} rows and {n} columns'
         str2 = 'damp = %20.14e   calc_var = %8g' % (damp, calc_var)
         str3 = 'atol = %8.2e                 conlim = %8.2e' % (atol, conlim)
         str4 = 'btol = %8.2e               iter_lim = %8g' % (btol, iter_lim)


### PR DESCRIPTION
Using %8g results in scientific notation when there are more than 1e8
rows (or columns), even though the number is still an integer.  Format
the matrix size as integers instead.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->