### PR TITLE
MAINT: Remove Python 2 workarounds

### DIFF
--- a/scipy/_lib/tests/test_import_cycles.py
+++ b/scipy/_lib/tests/test_import_cycles.py
@@ -45,9 +45,8 @@ MODULES = [
 
 
 def test_modules_importable():
-    # Check that all modules are importable in a new Python
-    # process. This is not necessarily true (esp on Python 2) if there
-    # are import cycles present.
+    # Check that all modules are importable in a new Python process.
+    #This is not necessarily true if there are import cycles present.
     for module in MODULES:
         cmd = 'import {}'.format(module)
         subprocess.check_call([sys.executable, '-c', cmd])

--- a/scipy/interpolate/tests/test_fitpack.py
+++ b/scipy/interpolate/tests/test_fitpack.py
@@ -1,5 +1,6 @@
 from __future__ import division, print_function, absolute_import
 
+import itertools
 import os
 
 import numpy as np
@@ -54,8 +55,7 @@ def f2(x,y=0,dx=0,dy=0):
 
 def makepairs(x, y):
     """Helper function to create an array of pairs of x and y."""
-    # Or itertools.product (>= Python 2.6)
-    xy = array([[a, b] for a in asarray(x) for b in asarray(y)])
+    xy = array(list(itertools.product(asarray(x), asarray(y))))
     return xy.T
 
 

--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -67,7 +67,7 @@ cdef extern from "ckdtree_decl.h":
         np.intp_t size
 
     # External build and query methods in C++.
-    
+
     int build_ckdtree(ckdtree *self,
                          np.intp_t start_idx,
                          np.intp_t end_idx,
@@ -286,16 +286,10 @@ cdef class ordered_pairs:
         results = set()
         pair = self.buf.data()
         n = <np.intp_t> self.buf.size()
-        if sizeof(long) < sizeof(np.intp_t):
-            # Needed for Python 2.x on Win64
-            for i in range(n):
-                results.add((int(pair.i), int(pair.j)))
-                pair += 1
-        else:
-            # other platforms
-            for i in range(n):
-                results.add((pair.i, pair.j))
-                pair += 1
+        # other platforms
+        for i in range(n):
+            results.add((pair.i, pair.j))
+            pair += 1
         return results
 
 
@@ -511,8 +505,8 @@ cdef class cKDTree:
 
     def __init__(cKDTree self, data, np.intp_t leafsize=16, compact_nodes=True,
             copy_data=False, balanced_tree=True, boxsize=None):
-        
-        cdef: 
+
+        cdef:
             np.float64_t [::1] tmpmaxes, tmpmins
             np.float64_t *ptmpmaxes
             np.float64_t *ptmpmins
@@ -565,10 +559,10 @@ cdef class cKDTree:
 
         tmpmaxes = np.copy(self.maxes)
         tmpmins = np.copy(self.mins)
-        
+
         ptmpmaxes = &tmpmaxes[0]
         ptmpmins = &tmpmins[0]
-        with nogil: 
+        with nogil:
             build_ckdtree(cself, 0, cself.n, ptmpmaxes, ptmpmins, median, compact)
 
         # set up the tree structure pointers
@@ -770,7 +764,7 @@ cdef class cKDTree:
         # The C++ function touches all dd and ii entries,
         # setting the missing values.
 
-        cdef: 
+        cdef:
             np.float64_t [:, ::1] dd = np.empty((n,len(k)),dtype=np.float64)
             np.intp_t [:, ::1] ii = np.empty((n,len(k)),dtype=np.intp)
             np.intp_t [::1] kk = np.array(k, dtype=np.intp)
@@ -951,7 +945,7 @@ cdef class cKDTree:
 
                 pvxx = &vxx[start, 0]
                 pvrr = &vrr[start + 0]
-                
+
                 with nogil:
                     query_ball_point(self.cself, pvxx,
                         pvrr, p, eps, stop - start, vvres, rlen)
@@ -1124,7 +1118,7 @@ cdef class cKDTree:
         cdef ordered_pairs results
 
         results = ordered_pairs()
-        
+
         with nogil:
             query_pairs(self.cself, r, p, eps, results.buf)
 
@@ -1155,7 +1149,7 @@ cdef class cKDTree:
             total weight for each KD-Tree node.
 
         """
-        cdef: 
+        cdef:
             np.intp_t num_of_nodes
             np.float64_t [::1] node_weights
             np.float64_t [::1] proper_weights
@@ -1366,10 +1360,10 @@ cdef class cKDTree:
             results = np.zeros(n_queries + 1, dtype=np.intp)
 
             iresults = results
-            
+
             prr = &real_r[0]
             pir = &iresults[0]
-            
+
             with nogil:
                 count_neighbors_unweighted(self.cself, other.cself, n_queries,
                             prr, pir, p, cum)
@@ -1391,10 +1385,10 @@ cdef class cKDTree:
 
             results = np.zeros(n_queries + 1, dtype=np.float64)
             fresults = results
-            
+
             prr = &real_r[0]
             pfr = &fresults[0]
-            
+
             with nogil:
                 count_neighbors_weighted(self.cself, other.cself,
                                     w1p, w2p, w1np, w2np,
@@ -1466,7 +1460,7 @@ cdef class cKDTree:
                              "different dimensionality")
         # do the query
         res = coo_entries()
-        
+
         with nogil:
             sparse_distance_matrix(
                 self.cself, other.cself, p, max_distance, res.buf)

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -1160,7 +1160,7 @@ def test_ckdtree_memuse():
     try:
         import resource
     except ImportError:
-        # resource is not available on Windows with Python 2.6
+        # resource is not available on Windows
         return
     # Make some data
     dx, dy = 0.05, 0.05

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1144,9 +1144,7 @@ class TestPpccMax(object):
     def test_ppcc_max_basic(self):
         np.random.seed(1234567)
         x = stats.tukeylambda.rvs(-0.7, loc=2, scale=0.5, size=10000) + 1e4
-        # On Python 2.6 the result is accurate to 5 decimals. On Python >= 2.7
-        # it is accurate up to 16 decimals
-        assert_almost_equal(stats.ppcc_max(x), -0.71215366521264145, decimal=5)
+        assert_almost_equal(stats.ppcc_max(x), -0.71215366521264145, decimal=7)
 
     def test_dist(self):
         np.random.seed(1234567)
@@ -1167,15 +1165,11 @@ class TestPpccMax(object):
         x = stats.tukeylambda.rvs(-0.7, loc=2, scale=0.5, size=10000) + 1e4
         assert_raises(ValueError, stats.ppcc_max, x, brack=(0.0, 1.0, 0.5))
 
-        # On Python 2.6 the result is accurate to 5 decimals. On Python >= 2.7
-        # it is accurate up to 16 decimals
         assert_almost_equal(stats.ppcc_max(x, brack=(0, 1)),
-                            -0.71215366521264145, decimal=5)
+                            -0.71215366521264145, decimal=7)
 
-        # On Python 2.6 the result is accurate to 5 decimals. On Python >= 2.7
-        # it is accurate up to 16 decimals
         assert_almost_equal(stats.ppcc_max(x, brack=(-2, 2)),
-                            -0.71215366521264145, decimal=5)
+                            -0.71215366521264145, decimal=7)
 
 
 class TestBoxcox_llf(object):


### PR DESCRIPTION
Clean up some Python2 specific code as part of #11584 