### PR TITLE
ENH: Optimise _cs_matrix._set_many when new entries are all zero

### DIFF
--- a/benchmarks/benchmarks/sparse.py
+++ b/benchmarks/benchmarks/sparse.py
@@ -219,12 +219,13 @@ class Getset(Benchmark):
     params = [
         [1, 10, 100, 1000, 10000],
         ['different', 'same'],
-        ['csr', 'csc', 'lil', 'dok']
+        ['csr', 'csc', 'lil', 'dok'],
+        ['random', 'zero'],
     ]
-    param_names = ['N', 'sparsity pattern', 'format']
+    param_names = ['N', 'sparsity pattern', 'format', 'values']
     unit = "seconds"
 
-    def setup(self, N, sparsity_pattern, format):
+    def setup(self, N, sparsity_pattern, format, values):
         if format == 'dok' and N > 500:
             raise NotImplementedError()
 
@@ -241,7 +242,12 @@ class Getset(Benchmark):
             jp = numpy.random.randint(0, A.shape[1], size=n)
             i = numpy.r_[i, ip]
             j = numpy.r_[j, jp]
-        v = numpy.random.rand(n)
+
+        if values == 'random':
+            v = numpy.random.rand(n)
+        else:
+            assert values == 'zero'
+            v = 0.0
 
         if N == 1:
             i = int(i)
@@ -277,7 +283,7 @@ class Getset(Benchmark):
             min_time = min(min_time, duration/number)
         return min_time
 
-    def track_fancy_setitem(self, N, sparsity_pattern, format):
+    def track_fancy_setitem(self, N, sparsity_pattern, format, values):
         def kernel(A, i, j, v):
             A[i, j] = v
 
@@ -285,7 +291,7 @@ class Getset(Benchmark):
             warnings.simplefilter('ignore', SparseEfficiencyWarning)
             return self._timeit(kernel, sparsity_pattern == 'different')
 
-    def time_fancy_getitem(self, N, sparsity_pattern, format):
+    def time_fancy_getitem(self, N, sparsity_pattern, format, values):
         self.m[self.i, self.j]
 
 

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -898,19 +898,26 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             return
 
         else:
-            warn("Changing the sparsity structure of a {}_matrix is expensive."
-                 " lil_matrix is more efficient.".format(self.format),
-                 SparseEfficiencyWarning, stacklevel=3)
             # replace where possible
             mask = offsets > -1
             self.data[offsets[mask]] = x[mask]
-            # only insertions remain
+
             mask = ~mask
+            x = x[mask]
+            if np.count_nonzero(x) == 0:
+                # all remaining elements are zero, so no more work is needed
+                return
+
+            # only insertions remain
+            warn("Changing the sparsity structure of a {}_matrix is expensive."
+                 " lil_matrix is more efficient.".format(self.format),
+                 SparseEfficiencyWarning, stacklevel=3)
+
             i = i[mask]
             i[i < 0] += M
             j = j[mask]
             j[j < 0] += N
-            self._insert_many(i, j, x[mask])
+            self._insert_many(i, j, x)
 
     def _zero_many(self, i, j):
         """Sets value at each (i, j) to zero, preserving sparsity structure.

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -475,7 +475,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
 
     diagonal.__doc__ = _data_matrix.diagonal.__doc__
 
-    def _setdiag(self, values, k):
+    def _setdiag(self, values, k, insert_zeros):
         M, N = self.shape
         if values.ndim and not len(values):
             return

--- a/scipy/sparse/dia.py
+++ b/scipy/sparse/dia.py
@@ -256,7 +256,7 @@ class dia_matrix(_data_matrix):
     def _mul_multimatrix(self, other):
         return np.hstack([self._mul_vector(col).reshape(-1,1) for col in other.T])
 
-    def _setdiag(self, values, k=0):
+    def _setdiag(self, values, k=0, insert_zeros=None):
         M, N = self.shape
 
         if values.ndim == 0:

--- a/scipy/sparse/dok.py
+++ b/scipy/sparse/dok.py
@@ -224,24 +224,25 @@ class dok_matrix(spmatrix, IndexMixin, dict):
                 dict.__setitem__(newdok, key, v)
         return newdok
 
-    def _set_intXint(self, row, col, x):
+    def _set_intXint(self, row, col, x, insert_zeros):
         key = (row, col)
-        if x:
+        if x or insert_zeros:
             dict.__setitem__(self, key, x)
         elif dict.__contains__(self, key):
             del self[key]
 
-    def _set_arrayXarray(self, row, col, x):
+    def _set_arrayXarray(self, row, col, x, insert_zeros):
         row = list(map(int, row.ravel()))
         col = list(map(int, col.ravel()))
         x = x.ravel()
         dict.update(self, zip(zip(row, col), x))
 
-        for i in np.nonzero(x == 0)[0]:
-            key = (row[i], col[i])
-            if dict.__getitem__(self, key) == 0:
-                # may have been superseded by later update
-                del self[key]
+        if not insert_zeros:
+            for i in np.nonzero(x == 0)[0]:
+                key = (row[i], col[i])
+                if dict.__getitem__(self, key) == 0:
+                    # may have been superseded by later update
+                    del self[key]
 
     def __add__(self, other):
         if isscalarlike(other):

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -298,17 +298,17 @@ class lil_matrix(spmatrix, IndexMixin):
 
         return new
 
-    def _set_intXint(self, row, col, x):
+    def _set_intXint(self, row, col, x, insert_zeros):
         _csparsetools.lil_insert(self.shape[0], self.shape[1], self.rows,
                                  self.data, row, col, x)
 
-    def _set_arrayXarray(self, row, col, x):
+    def _set_arrayXarray(self, row, col, x, insert_zeros):
         i, j, x = map(np.atleast_2d, _prepare_index_for_memoryview(row, col, x))
         _csparsetools.lil_fancy_set(self.shape[0], self.shape[1],
                                     self.rows, self.data,
                                     i, j, x)
 
-    def _set_arrayXarray_sparse(self, row, col, x):
+    def _set_arrayXarray_sparse(self, row, col, x, insert_zeros):
         # Special case: full matrix assignment
         if (x.shape == self.shape and
                 isinstance(row, slice) and row == slice(None) and
@@ -320,7 +320,7 @@ class lil_matrix(spmatrix, IndexMixin):
         # Fall back to densifying x
         x = np.asarray(x.toarray(), dtype=self.dtype)
         x, _ = _broadcast_arrays(x, row)
-        self._set_arrayXarray(row, col, x)
+        self._set_arrayXarray(row, col, x, insert_zeros)
 
     def __setitem__(self, key, x):
         # Fast path for simple (int, int) indexing.
@@ -330,7 +330,7 @@ class lil_matrix(spmatrix, IndexMixin):
             x = self.dtype.type(x)
             if x.size > 1:
                 raise ValueError("Trying to assign a sequence to an item")
-            return self._set_intXint(key[0], key[1], x)
+            return self._set_intXint(key[0], key[1], x, None)
         # Everything else takes the normal path.
         IndexMixin.__setitem__(self, key, x)
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -857,6 +857,8 @@ class _TestCommon(object):
             m.setdiag((9,), k=-2)
             assert_array_equal(m.A[2,0], 9)
 
+            m.setdiag
+
     def test_nonzero(self):
         A = array([[1, 0, 1],[0, 1, 1],[0, 0, 1]])
         Asp = self.spmatrix(A)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -4521,6 +4521,9 @@ class _NonCanonicalCompressedMixin(_NonCanonicalMixin):
         return data, indices, indptr
 
     def _insert_explicit_zero(self, M, i, j):
+        # setting to zero outside the sparsity structure is a no-op, so first create the element
+        # then zero it
+        M[i,j] = 1
         M[i,j] = 0
         return M
 
@@ -4586,6 +4589,8 @@ class TestCSCNonCanonical(_NonCanonicalCSMixin, TestCSC):
 class TestBSRNonCanonical(_NonCanonicalCompressedMixin, TestBSR):
     def _insert_explicit_zero(self, M, i, j):
         x = M.tocsr()
+        # see _NonCanonicalCompressedMixin:
+        x[i,j] = 1
         x[i,j] = 0
         return x.tobsr(blocksize=M.blocksize)
 


### PR DESCRIPTION
#### Reference issue

Closes: gh-11600

#### What does this implement/fix?

This adds a special case for doing a scatter-set (`arrayXarray`) on a compressed matrices where there's many zeros, and, in particular, where the only new values outside the existing sparsity structure are zero.

Changing the sparsity structure of a csr_matrix or csc_matrix is expensive, and so it's a nice idea to check whether that's actually required, before doing anything. This accelerates functionality like `m.setdiag(0)` and `m[i, j] = 0` significantly, because it never has to change sparsity.

For the latter case, the `Getset.track_fancy_setitem` benchmark is extended to also measure setting some indices to zero, in addition to setting it to random values. On csr and csc matrices, with a different sparsity structure, setting to zero is 3.7-67× faster than random.

The example in #11600 (`setdiag(0)` on a 10000x10000 random CSR matrix) goes from 147ms to ~5ms; essentially the same as the "manual" one described there.