### PR TITLE
MAINT: swap int for long type for bdt{r,ri,rc} functions

### DIFF
--- a/scipy/special/_cephes.pxd
+++ b/scipy/special/_cephes.pxd
@@ -1,8 +1,8 @@
 cdef extern from "cephes.h" nogil:
     int airy(double x, double *ai, double *aip, double *bi, double *bip)
-    double bdtrc(double k, int n, double p)
-    double bdtr(double k, int n, double p)
-    double bdtri(double k, int n, double y)
+    double bdtrc(double k, long n, double p)
+    double bdtr(double k, long n, double p)
+    double bdtri(double k, long n, double y)
     double beta(double a, double b)
     double lbeta(double a, double b)
     double btdtr(double a, double b, double x)

--- a/scipy/special/_legacy.pxd
+++ b/scipy/special/_legacy.pxd
@@ -62,21 +62,21 @@ cdef inline double bdtr_unsafe(double k, double n, double p) nogil:
     if npy_isnan(n) or npy_isinf(n):
         return nan
     else:
-        return bdtr(k, <int>n, p)
+        return bdtr(k, <long>n, p)
 
 cdef inline double bdtrc_unsafe(double k, double n, double p) nogil:
     _legacy_deprecation("bdtrc", k, n)
     if npy_isnan(n) or npy_isinf(n):
         return nan
     else:
-        return bdtrc(k, <int>n, p)
+        return bdtrc(k, <long>n, p)
 
 cdef inline double bdtri_unsafe(double k, double n, double p) nogil:
     _legacy_deprecation("bdtri", k, n)
     if npy_isnan(n) or npy_isinf(n):
         return nan
     else:
-        return bdtri(k, <int>n, p)
+        return bdtri(k, <long>n, p)
 
 cdef inline double expn_unsafe(double n, double x) nogil:
     if npy_isnan(n):

--- a/scipy/special/cephes.h
+++ b/scipy/special/cephes.h
@@ -9,9 +9,9 @@ extern "C" {
 
 extern int airy(double x, double *ai, double *aip, double *bi, double *bip);
 
-extern double bdtrc(double k, int n, double p);
-extern double bdtr(double k, int n, double p);
-extern double bdtri(double k, int n, double y);
+extern double bdtrc(double k, long n, double p);
+extern double bdtr(double k, long n, double p);
+extern double bdtri(double k, long n, double y);
 
 extern double besselpoly(double a, double lambda, double nu);
 

--- a/scipy/special/cephes/bdtr.c
+++ b/scipy/special/cephes/bdtr.c
@@ -149,7 +149,7 @@
 #include "mconf.h"
 #include <numpy/npy_math.h>
 
-double bdtrc(double k, int n, double p)
+double bdtrc(double k, long n, double p)
 {
     double dk, dn;
     double fk = floor(k);
@@ -187,7 +187,7 @@ double bdtrc(double k, int n, double p)
 
 
 
-double bdtr(double k, int n, double p)
+double bdtr(double k, long n, double p)
 {
     double dk, dn;
     double fk = floor(k);
@@ -216,7 +216,7 @@ double bdtr(double k, int n, double p)
 }
 
 
-double bdtri(double k, int n, double y)
+double bdtri(double k, long n, double y)
 {
     double p, dn, dk;
     double fk = floor(k);

--- a/scipy/special/functions.json
+++ b/scipy/special/functions.json
@@ -148,7 +148,7 @@
             "bdtr_unsafe": "ddd->d"
         },
         "cephes.h": {
-            "bdtr": "did->d"
+            "bdtr": "dld->d"
         }
     },
     "bdtrc": {
@@ -156,7 +156,7 @@
             "bdtrc_unsafe": "ddd->d"
         },
         "cephes.h": {
-            "bdtrc": "did->d"
+            "bdtrc": "dld->d"
         }
     },
     "bdtri": {
@@ -164,7 +164,7 @@
             "bdtri_unsafe": "ddd->d"
         },
         "cephes.h": {
-            "bdtri": "did->d"
+            "bdtri": "dld->d"
         }
     },
     "bdtrik": {


### PR DESCRIPTION
  * in PR 11045 we kept the types int. Josh left a comment
    before closing gh-issue 9454 about switching to longs
    which was a suggestion to improve numerics of bdtr in
    some cases deep in the tail of binom cdf. This PR
    makes the int types into long type for these 3 functions.

#### Reference issue
N/A

#### What does this implement/fix?
This PR swaps `int` type for `long` in `bdtr`, `bdtrc`, and `bdtri` functions in special. 

#### Additional information
The major change of switching the types is at values with `n > 2^31`. I did not add a test because I'm not sure if all builds cover 64 bit arch or not. If we adding a test with `n=2^38` wouldn't break the CI then I can include one but not sure what we are covering for platforms. Another option (maybe) is a pytest skipif on a specific platform (e.g. if there is a way to test the word size of the machine) but not sure how to accomplish. If you have a suggestion on this one please let me know. 