### PR TITLE
BUG: fix use of is in DE callback

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -231,6 +231,7 @@ Grzegorz Mrukwa for a bug fix in rectangular_lsap.cpp
 Santiago Hernandez for a bug fix in scipy.optimize._differentialevolution.py.
 Dan Kleeman for implementing nan_policy in stats.zscores and winsorize
 James Wright for simple documentation fixes
+Richard Weiss for a bug fix in scipy.optimize._differentialevolution.py.
 
 Institutions
 ------------

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -766,17 +766,6 @@ class DifferentialEvolutionSolver(object):
                          self.population_energies[0]))
 
             # should the solver terminate?
-            convergence = self.convergence
-
-            if (self.callback and
-                    self.callback(self._scale_parameters(self.population[0]),
-                                  convergence=self.tol / convergence) is True):
-
-                warning_flag = True
-                status_message = ('callback function requested stop early '
-                                  'by returning True')
-                break
-
             if np.any(np.isinf(self.population_energies)):
                 intol = False
             else:
@@ -784,6 +773,12 @@ class DifferentialEvolutionSolver(object):
                          self.atol +
                          self.tol * np.abs(np.mean(self.population_energies)))
             if warning_flag or intol:
+                break
+
+            if self.callback and self.callback(self.x, convergence=self.tol / self.convergence):
+                warning_flag = True
+                status_message = ('callback function requested stop early'
+                                  ' by returning True')
                 break
 
         else:

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -708,6 +708,9 @@ class DifferentialEvolutionSolver(object):
         """
         Return True if the solver has converged.
         """
+        if np.any(np.isinf(self.population_energies)):
+            return False
+
         return (np.std(self.population_energies) <=
                 self.atol +
                 self.tol * np.abs(np.mean(self.population_energies)))
@@ -765,20 +768,15 @@ class DifferentialEvolutionSolver(object):
                       % (nit,
                          self.population_energies[0]))
 
-            # should the solver terminate?
-            if np.any(np.isinf(self.population_energies)):
-                intol = False
-            else:
-                intol = (np.std(self.population_energies) <=
-                         self.atol +
-                         self.tol * np.abs(np.mean(self.population_energies)))
-            if warning_flag or intol:
-                break
+            if self.callback:
+                c = self.tol / (self.convergence + _MACHEPS)
+                warning_flag = bool(self.callback(self.x, convergence=c))
+                if warning_flag:
+                    status_message = ('callback function requested stop early'
+                                      ' by returning True')
 
-            if self.callback and self.callback(self.x, convergence=self.tol / self.convergence):
-                warning_flag = True
-                status_message = ('callback function requested stop early'
-                                  ' by returning True')
+            # should the solver terminate?
+            if warning_flag or self.converged():
                 break
 
         else:

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -241,15 +241,26 @@ class TestDifferentialEvolutionSolver(object):
     def test_callback_terminates(self):
         # test that if the callback returns true, then the minimization halts
         bounds = [(0, 2), (0, 2)]
+        expected_msg = 'callback function requested stop early by returning True'
 
-        def callback(param, convergence=0.):
+        def callback_python_true(param, convergence=0.):
             return True
 
-        result = differential_evolution(rosen, bounds, callback=callback)
+        result = differential_evolution(rosen, bounds, callback=callback_python_true)
+        assert_string_equal(result.message, expected_msg)
 
-        assert_string_equal(result.message,
-                                'callback function requested stop early '
-                                'by returning True')
+        def callback_evaluates_true(param, convergence=0.):
+            # DE should stop if bool(self.callback) is True
+            return [10]
+
+        result = differential_evolution(rosen, bounds, callback=callback_evaluates_true)
+        assert_string_equal(result.message, expected_msg)
+
+        def callback_evaluates_false(param, convergence=0.):
+            return []
+
+        result = differential_evolution(rosen, bounds, callback=callback_evaluates_false)
+        assert result.success
 
     def test_args_tuple_is_passed(self):
         # test that the args tuple is passed to the cost function properly.


### PR DESCRIPTION

#### Reference issue
No referenced issue -- I'm happy to create one if needed

#### What does this implement/fix? 
While using differential evolution I found that the callback function did not work if the result was not identical (in the `is` sense) to True.

Eg:
```
def mycallback(param, convergence=0.):
   return (np.array([1]) == 1)[0]
```
Will *not* halt differential evolution.


This commit changes the condition to be identical in the `==` sense. Critically, this allows the
user to work with numpy arrays in an intuitive way, where previously they could not, because the
numpy True wasn't equivalent in the `is` sense to the python True.

This commit also includes a test to demonstrate the bug.

#### Additional information
I wonder a little why the code was `is True` to begin with. My theory is that it is to make it more difficult to accidentally return True by returning a  floating point value. It seems like it's better to keep optimizing than to stop immediately, just because the user accidentally returned some non-zero float from the callback.

Another reason might be to help programmers avoid a situation where they return an array and get `ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()`. But I think it's better to just fail this way and let them fix the bug. However, this might create bugs in existing code where the callback returns an array.

Another option here is to check for whether this is an instance of `np.bool_`, eg:

```
if ... and isinstance(result, (bool, np.bool_)) and result:
```

Let me know what makes most sense and I'll update the commit.
