### PR TITLE
ENH: add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,124 @@
+# YAML 1.2
+---
+cff-version: 1.1.0
+message: If you use this software, please cite it using these metadata.
+references:
+  -
+    type: article
+    title: "SciPy 1.0: fundamental algorithms for scientific computing in Python"
+    doi: "10.1038/s41592-019-0686-2"
+    journal: Nature Methods
+    year: 2020
+    authors:
+      -
+        given-names: Pauli
+        family-names: Virtanen
+      -
+        given-names: Ralf
+        family-names: Gommers
+      -
+        given-names: Travis E.
+        family-names: Oliphant
+      -
+        given-names: Matt
+        family-names: Haberland
+      -
+        given-names: Tyler
+        family-names: Reddy
+      -
+        given-names: David
+        family-names: Cournapeau
+      -
+        given-names: Evgeni
+        family-names: Burovski
+      -
+        given-names: Pearu
+        family-names: Peterson
+      -
+        given-names: Warren
+        family-names: Weckesser
+      -
+        given-names: Jonathan
+        family-names: Bright
+      -
+        given-names: Stéfan J.
+        name-particle: van der
+        family-names: Walt
+      -
+        given-names: Matthew
+        family-names: Brett
+      -
+        given-names: Joshua
+        family-names: Wilson
+      -
+        given-names: K. Jarrod
+        family-names: Millman
+      -
+        given-names: Nikolay
+        family-names: Mayorov
+      -
+        given-names: Andrew R. J.
+        family-names: Nelson
+      -
+        given-names: Eric
+        family-names: Jones
+      -
+        given-names: Robert
+        family-names: Kern
+      -
+        given-names: Eric
+        family-names: Larson
+      -
+        given-names: CJ
+        family-names: Carey
+      -
+        given-names: İlhan
+        family-names: Polat
+      -
+        given-names: Yu
+        family-names: Feng
+      -
+        given-names: Eric W.
+        family-names: Moore
+      -
+        given-names: Jake
+        family-names: VanderPlas
+      -
+        given-names: Denis
+        family-names: Laxalde
+      -
+        given-names: Josef
+        family-names: Perktold
+      -
+        given-names: Robert
+        family-names: Cimrman
+      -
+        given-names: Ian
+        family-names: Henriksen
+      -
+        given-names: E. A.
+        family-names: Quintero
+      -
+        given-names: Charles R.
+        family-names: Harris
+      -
+        given-names: Anne M.
+        family-names: Archibald
+      -
+        given-names: Antônio H.
+        family-names: Ribeiro
+      -
+        given-names: Fabian
+        family-names: Pedregosa
+      -
+        given-names: Paul
+        name-particle: van
+        family-names: Mulbregt
+      -
+        name: SciPy 1.0 Contributors
+title: "SciPy"
+authors:
+  -
+    name: "SciPy Contributors"
+version: "1.5"
+date-released: "2020-01-01"


### PR DESCRIPTION
It was suggested at the CZI EOSS Kickoff meeting that projects should have a [`CITATION.cff`](https://citation-file-format.github.io/) file:

> `CITATION.cff` files are plain text files with human- and machine-readable citation information for software. Code developers can include them in their repositories to let others know how to correctly cite their software.

The file format is described [here](https://github.com/citation-file-format/citation-file-format/blob/master/README.md).
A validation and conversion tool is [here](https://github.com/citation-file-format/cff-converter-python).

This PR would add a `CITATION.cff` file that meets the requirements of the format (e.g. version number and release date are required fields - how are we going to keep these up to date?) and also includes information about the preferred reference, the Nature Methods paper.

Unfortunately, the CFF format seems to prioritize citation of the software itself rather than a related article. For instance, the conversion tool produces the BIBTEX citation:
```
@misc{YourReferenceHere,
author = {

         },
title  = {SciPy},
month  = {1},
year   = {2020}
}
```
I don't think this is what we want. Perhaps we should not include a CITATION.cff?