### PR TITLE
BUG: fix weights usage in spatial.distance.chebyshev

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -231,6 +231,7 @@ Grzegorz Mrukwa for a bug fix in rectangular_lsap.cpp
 Santiago Hernandez for a bug fix in scipy.optimize._differentialevolution.py.
 Dan Kleeman for implementing nan_policy in stats.zscores and winsorize
 James Wright for simple documentation fixes
+Will Tirone for a bug fix in scipy.spatial.distance.py
 
 Institutions
 ------------

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -1115,13 +1115,11 @@ def chebyshev(u, v, w=None):
     """
     u = _validate_vector(u)
     v = _validate_vector(v)
+    l1_diff = abs(u-v)
     if w is not None:
         w = _validate_weights(w)
-        has_weight = w > 0
-        if has_weight.sum() < w.size:
-            u = u[has_weight]
-            v = v[has_weight]
-    return max(abs(u - v))
+        l1_diff = w * l1_diff
+    return max(l1_diff)
 
 
 def braycurtis(u, v, w=None):

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -1887,6 +1887,11 @@ def test_canberra():
     assert_equal(wcanberra([1, 1, 0, 0], [1, 0, 1, 0]), 2)
 
 
+def test_chebyshev(): 
+    # Regression test for ticket #11442
+    assert_equal(wchebyshev([10, 0, 0], [0, 1, 0], w=np.array([1,20,1])), 20.0)
+
+
 def test_braycurtis():
     # Regression test for ticket #1430.
     assert_almost_equal(wbraycurtis([1, 2, 3], [2, 4, 6]), 1. / 3, decimal=15)


### PR DESCRIPTION

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes issue #11442

#### What does this implement/fix?
Alters the way weights are used in the Chebyshev distance function; they were previously used to "shorten" the list passes as an argument, although base on other distance functions in scipy.spatial.distance.py, I believe it is more consistent to apply it as proposed in this fix.

#### Additional information
This is my first commit to scipy so please review carefully; I've followed the contributor guide very closely and all tests pass / new functionality works.