### PR TITLE
TST, MAINT: TestCtypesQuad skip with pytest

### DIFF
--- a/scipy/integrate/tests/test_quadpack.py
+++ b/scipy/integrate/tests/test_quadpack.py
@@ -4,6 +4,7 @@ import numpy as np
 from numpy import sqrt, cos, sin, arctan, exp, log, pi, Inf
 from numpy.testing import (assert_,
         assert_allclose, assert_array_less, assert_almost_equal)
+import pytest
 from pytest import raises as assert_raises
 
 from scipy.integrate import quad, dblquad, tplquad, nquad
@@ -46,7 +47,7 @@ class TestCtypesQuad(object):
         else:
             # This test doesn't work on some Linux platforms (Fedora for
             # example) that put an ld script in libm.so - see gh-5370
-            self.skipTest("Ctypes can't import libm.so")
+            pytest.skip("Ctypes can't import libm.so")
 
         restype = ctypes.c_double
         argtypes = (ctypes.c_double,)

--- a/scipy/integrate/tests/test_quadpack.py
+++ b/scipy/integrate/tests/test_quadpack.py
@@ -5,7 +5,6 @@ from numpy import sqrt, cos, sin, arctan, exp, log, pi, Inf
 from numpy.testing import (assert_,
         assert_allclose, assert_array_less, assert_almost_equal)
 import pytest
-from pytest import raises as assert_raises
 
 from scipy.integrate import quad, dblquad, tplquad, nquad
 from scipy._lib._ccallback import LowLevelCallable
@@ -89,7 +88,7 @@ class TestCtypesQuad(object):
         for j, func in enumerate(all_sigs):
             callback = LowLevelCallable(func)
             if func in legacy_only_sigs:
-                assert_raises(ValueError, quad, callback, 0, pi)
+                pytest.raises(ValueError, quad, callback, 0, pi)
             else:
                 assert_allclose(quad(callback, 0, pi)[0], 2.0)
 
@@ -98,7 +97,7 @@ class TestCtypesQuad(object):
             if func in legacy_sigs:
                 assert_allclose(quad(func, 0, pi)[0], 2.0)
             else:
-                assert_raises(ValueError, quad, func, 0, pi)
+                pytest.raises(ValueError, quad, func, 0, pi)
 
 
 class TestMultivariateCtypesQuad(object):


### PR DESCRIPTION
Fixes #11613

* replace a usage of `unittest` `skipTest()` in
`TestCtypesQuad` with `pytest.skip()` now that
the test class does not inherit from
`TestCase`