### PR TITLE
BUG: linprog returns 'infeasible' for unbounded case (fix for #11617)

### DIFF
--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -805,7 +805,7 @@ def _ip_hsd(A, b, c, c0, alpha0, beta, maxiter, disp, tol, sparse, lstsq,
             # [4] Lemma 8.4 / Theorem 8.3, but more strict (see issue #11617)
             if b.transpose().dot(y) > x.dot(z) and np.all(A.T.dot(y) <= 0):
                 status = 2
-            else:
+            else:  # elif c.T.dot(x) < tol: ? Probably not necessary.
                 status = 3
             message = _get_message(status)
             break

--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -802,8 +802,8 @@ def _ip_hsd(A, b, c, c0, alpha0, beta, maxiter, disp, tol, sparse, lstsq,
                 max(1, kappa))
         inf2 = rho_mu < tol and tau < tol * min(1, kappa)
         if inf1 or inf2:
-            # [4] Lemma 8.4 / Theorem 8.3
-            if b.transpose().dot(y) > -c.transpose().dot(x):
+            # [4] Lemma 8.4 / Theorem 8.3, but more strict (see issue #11617)
+            if b.transpose().dot(y) > x.dot(z) and np.all(A.T.dot(y) <= 0):
                 status = 2
             else:
                 status = 3

--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -803,9 +803,9 @@ def _ip_hsd(A, b, c, c0, alpha0, beta, maxiter, disp, tol, sparse, lstsq,
         inf2 = rho_mu < tol and tau < tol * min(1, kappa)
         if inf1 or inf2:
             # [4] Lemma 8.4 / Theorem 8.3
-            if b.transpose().dot(y) > tol:
+            if b.transpose().dot(y) > -c.transpose().dot(x):
                 status = 2
-            else:  # elif c.T.dot(x) < tol: ? Probably not necessary.
+            else:
                 status = 3
             message = _get_message(status)
             break

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -1659,7 +1659,8 @@ class TestLinprogIPSpecific(object):
                           method=self.method, options={"presolve": False})
         assert_(not res.success, "Incorrectly reported success")
 
-    def test_bug_11617(self):
+    @pytest.mark.parametrize("s", np.logspace(-7, 8, 16))
+    def test_bug_11617(self, s):
         # interior-point fails to detect unboundedness for the simple LP
         #   min  x1
         #   s.t. x1 <= -1
@@ -1667,16 +1668,13 @@ class TestLinprogIPSpecific(object):
         #   min  x1      - x3
         #   s.t. x1 + x2 - x3 = -1
         #        x1,  x2,  x3 >= 0
-        # and this was true of other specific variants of the above LP.
+        # and also failed for specific variants and scalings of this LP.
         def check(c, A, b):
             res = linprog(c, None, None, A, b, bounds, method=self.method)
-            _assert_unbounded(res)        
-        # all scales from 1e-7...1e14 (1e-8 succeeds; 1e15 doesn't converge)
-        for i in range(-7, 15):
-            s = 10**i
-            check([s, 0, -s], [[s, s, -s]], [-s])  # failed in scipy 1.4.1
-            check([1, 0, -1], [[s, s, -s]], [-s])  # failed in scipy 1.4.1
-            check([1, 0, -1], [[1, 1, -1]], [-s])  # failed in scipy 1.4.1
+            _assert_unbounded(res)
+        check([s, 0, -s], [[s, s, -s]], [-s])  # failed in scipy 1.4.1
+        check([1, 0, -1], [[s, s, -s]], [-s])  # failed in scipy 1.4.1
+        check([1, 0, -1], [[1, 1, -1]], [-s])  # failed in scipy 1.4.1
 
 ########################################
 # Revised Simplex Option-Specific Tests#

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -1676,6 +1676,7 @@ class TestLinprogIPSpecific(object):
             s = 10**i
             check([s, 0, -s], [[s, s, -s]], [-s])  # failed in scipy 1.4.1
             check([1, 0, -1], [[s, s, -s]], [-s])  # failed in scipy 1.4.1
+            check([1, 0, -1], [[1, 1, -1]], [-s])  # failed in scipy 1.4.1
 
 ########################################
 # Revised Simplex Option-Specific Tests#

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -1659,6 +1659,21 @@ class TestLinprogIPSpecific(object):
                           method=self.method, options={"presolve": False})
         assert_(not res.success, "Incorrectly reported success")
 
+    def test_bug_11617(self):
+        # for the simple example:
+        #   min  x1
+        #   s.t. x1 <= -1
+        # when expressed in standard form:
+        #   min  x1      - x3
+        #   s.t. x1 + x2 - x3 = -1
+        #        x1,  x2,  x3 >= 0
+        # interior-point had trouble detecting unboundedness in scipy 1.4.1
+        c = [1., 0., -1.]
+        A_eq = [[1., 1., -1.]]
+        b_eq = [-1.]
+        res = linprog(c, None, None, A_eq, b_eq, bounds, method=self.method)
+        _assert_unbounded(res)
+
 
 ########################################
 # Revised Simplex Option-Specific Tests#


### PR DESCRIPTION
#### Reference issue
Closes #11617.

#### What does this implement/fix?

Tries to fix issue #11617 by evaluating both `b.T @ y` and `-c.T @ x` to determine whether to return 'infeasible' or 'unbounded'. The idea is that the one with largest magnitude is "most responsible" for primal-dual infeasibility (`kappa > tol`).

However, `test_enzo_example_c_with_infeasibility` now fails with this change (only for interior-point) because it is unbounded in some variables and infeasible in others, so the PR needs input from a maintainer on how to best satisfy both tests.

#### Additional information

I'll comment on the behaviour of the new change with respect to the failing test below:
https://github.com/scipy/scipy/blob/0538284d657a9a4538fc50525dc640cc419cd83d/scipy/optimize/tests/test_linprog.py#L922-L935
Running the above test gives with `m = 2` gives
```python
A_eq = [[ 0., -1.5     ],
        [ 0., 0.8660254]]
```
which is unbounded in `x1` and infeasible in `x2`. Linprog returns 'unbounded' both before and after the PR because `b.T @ y <= tol` at termination, specifically:
```python
 b.T @ y = -0.0003964702725403502
-c.T @ x = 1.000446497173729
```
Running the test with the original `m = 50` used to return 'infeasible' but now returns 'unbounded', because at termination `b.T @ y > tol` even though `b.T @ y < -c.T @ x`:
```python
 b.T @ y = 0.9056824687732257
-c.T @ x = 1.3801706687718134
```
The problem instance is unbounded in one variable and infeasible in the others, so I assume the desired behaviour is to return 'infeasible', but (a) I am unsure how to implement that and (b) it would still be inconsistent with old code's behaviour for case `m = 2`. (Before this PR, the interior-point method seemed to report 'infeasible' for `m > 3` and report 'unbounded' for `m <= 3`.)