### PR TITLE
ENH: add nan_policy argument and functionality to stats.mstats.winsorize

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -229,6 +229,7 @@ Domen Gorjup and Janko Slavič for continuous wavelet transform with complex
 Søren Fuglede Jørgensen for improvements to scipy.sparse.csgraph
 Grzegorz Mrukwa for a bug fix in rectangular_lsap.cpp
 Santiago Hernandez for a bug fix in scipy.optimize._differentialevolution.py.
+Dan Kleeman for implementing nan_policy in stats.zscores and windsorize
 
 Institutions
 ------------

--- a/THANKS.txt
+++ b/THANKS.txt
@@ -229,7 +229,7 @@ Domen Gorjup and Janko Slavič for continuous wavelet transform with complex
 Søren Fuglede Jørgensen for improvements to scipy.sparse.csgraph
 Grzegorz Mrukwa for a bug fix in rectangular_lsap.cpp
 Santiago Hernandez for a bug fix in scipy.optimize._differentialevolution.py.
-Dan Kleeman for implementing nan_policy in stats.zscores and windsorize
+Dan Kleeman for implementing nan_policy in stats.zscores and winsorize
 
 Institutions
 ------------

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -14,7 +14,8 @@ from scipy import optimize
 from scipy import special
 from . import statlib
 from . import stats
-from .stats import find_repeats, _contains_nan
+from .stats import find_repeats
+from .mstats_basic import _contains_nan
 from .contingency import chi2_contingency
 from . import distributions
 from ._distn_infrastructure import rv_generic

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -178,6 +178,7 @@ import scipy.special as special
 from scipy import linalg
 from . import distributions
 from . import mstats_basic
+from .mstats_basic import _contains_nan
 from ._stats_mstats_common import (_find_repeats, linregress, theilslopes,
                                    siegelslopes)
 from ._stats import (_kendall_dis, _toint64, _weightedrankedtau,
@@ -237,35 +238,6 @@ def _chk2_asarray(a, b, axis):
         b = np.atleast_1d(b)
 
     return a, b, outaxis
-
-
-def _contains_nan(a, nan_policy='propagate'):
-    policies = ['propagate', 'raise', 'omit']
-    if nan_policy not in policies:
-        raise ValueError("nan_policy must be one of {%s}" %
-                         ', '.join("'%s'" % s for s in policies))
-    try:
-        # Calling np.sum to avoid creating a huge array into memory
-        # e.g. np.isnan(a).any()
-        with np.errstate(invalid='ignore'):
-            contains_nan = np.isnan(np.sum(a))
-    except TypeError:
-        # This can happen when attempting to sum things which are not
-        # numbers (e.g. as in the function `mode`). Try an alternative method:
-        try:
-            contains_nan = np.nan in set(a.ravel())
-        except TypeError:
-            # Don't know what to do. Fall back to omitting nan values and
-            # issue a warning.
-            contains_nan = False
-            nan_policy = 'omit'
-            warnings.warn("The input array could not be properly checked for nan "
-                          "values. nan values will be ignored.", RuntimeWarning)
-
-    if contains_nan and nan_policy == 'raise':
-        raise ValueError("The input contains nan values")
-
-    return (contains_nan, nan_policy)
 
 
 def gmean(a, axis=0, dtype=None):

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -454,6 +454,19 @@ class TestTrimming(object):
         winsorized = mstats.winsorize(data)
         assert_equal(winsorized.mask, data.mask)
 
+    def test_winsorization_nan(self):
+        data = ma.array([np.nan, np.nan, 0, 1, 2])
+        assert_raises(ValueError, mstats.winsorize, data, (0.05, 0.05)
+                      , nan_policy='raise')
+        # Testing propagate (default behavior)
+        assert_equal(mstats.winsorize(data, (0.4, 0.4)),
+                     ma.array([2, 2, 2, 2, 2]))
+        assert_equal(mstats.winsorize(data, (0.8, 0.8)),
+                     ma.array([np.nan, np.nan, np.nan, np.nan, np.nan]))
+        assert_equal(mstats.winsorize(data, (0.4, 0.4), nan_policy='omit'),
+                     ma.array([np.nan, np.nan, 2, 2, 2]))
+        assert_equal(mstats.winsorize(data, (0.8, 0.8), nan_policy='omit'),
+                     ma.array([np.nan, np.nan, 2, 2, 2]))
 
 class TestMoments(object):
     # Comparison numbers are found using R v.1.5.1

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -456,8 +456,8 @@ class TestTrimming(object):
 
     def test_winsorization_nan(self):
         data = ma.array([np.nan, np.nan, 0, 1, 2])
-        assert_raises(ValueError, mstats.winsorize, data, (0.05, 0.05)
-                      , nan_policy='raise')
+        assert_raises(ValueError, mstats.winsorize, data, (0.05, 0.05),
+                      nan_policy='raise')
         # Testing propagate (default behavior)
         assert_equal(mstats.winsorize(data, (0.4, 0.4)),
                      ma.array([2, 2, 2, 2, 2]))


### PR DESCRIPTION
#### Reference issue
Closes issue 8327: https://github.com/scipy/scipy/issues/8327
In summary, this issue explains a problem I recently came across as a user of scipy where the windsorize function will overwrite NaN values or propogate them across the output array in certain cicumstances. This is silent behavior and I believe scipy is improved by giving windsorize a nan_policy argument

#### What does this implement/fix?
This PR implements a nan_policy argument for windsorize. The default behavior will be consistent with the past behavior so as not to break any current uses of the code.

1) Implements a \_contains_nan function identical to stats.stats.py. I cannot import this function because that caused a circular reference and as the function begins with an it seemed fitting to have definied in stats.mstats_basic.py

1) Adds a nan_policy to windsorize that can take on the values ['propagate', 'omit', 'raise']. Propagate has the current behavior and is the default, omit effectively skips the NaNs and leaves them untouched, and raise raises a ValueError. This ensures consistency with other nan_policy parameters in the rest of scipy.

1) Adds a unit test covering example cases for the windsorize function on an array containing NaNs.

#### Additional information
I used my existing scipy fork to make this contribution. If my work to re-sync my fork clutters the commit history too much, I am happy to initiate a new PR from a clean fork.

I appreciate any feedback and am happy to make any changes to this PR. Thank you for taking the time to take a look!