### PR TITLE
MAINT: Cleanup uses of PY_VERSION_HEX, NPY_PY3K in ndimage

### DIFF
--- a/scipy/ndimage/src/_ctest.c
+++ b/scipy/ndimage/src/_ctest.c
@@ -15,22 +15,12 @@
 #endif
 
 
-#if defined(OLDAPI) && PY_VERSION_HEX < 0x03000000
-static void
-_destructor(void *cobject, void *callback_data)
-{
-    PyMem_Free(callback_data);
-}    
-
-
-#else
 static void
 _destructor(PyObject *obj)
 {
     void *callback_data = PyCapsule_GetContext(obj);
     PyMem_Free(callback_data);
 }
-#endif
 
 
 static int
@@ -56,7 +46,7 @@ py_filter1d(PyObject *obj, PyObject *args)
 {
     npy_intp *callback_data = NULL;
     PyObject *capsule = NULL;
-    
+
     callback_data = PyMem_Malloc(sizeof(npy_intp));
     if (!callback_data) {
 	PyErr_NoMemory();
@@ -105,7 +95,7 @@ py_filter2d(PyObject *obj, PyObject *args)
     PyObject *seq = NULL, *item = NULL, *capsule = NULL;
 
     if (!PyArg_ParseTuple(args, "O", &seq)) goto error;
-    
+
     size = PySequence_Length(seq);
     if (size == -1) goto error;
     callback_data = PyMem_Malloc(size*sizeof(double));
@@ -192,8 +182,8 @@ static PyMethodDef _CTestMethods[] = {
     {"filter2d", (PyCFunction)py_filter2d, METH_VARARGS, ""},
     {NULL, NULL, 0, NULL}
 };
-				      
-				      
+
+
 /* Initialize the module */
 static struct PyModuleDef MOD = {
     PyModuleDef_HEAD_INIT,

--- a/scipy/ndimage/src/nd_image.c
+++ b/scipy/ndimage/src/nd_image.c
@@ -450,12 +450,6 @@ static PyObject *Py_GenericFilter1D(PyObject *obj, PyObject *args)
         /* 'Legacy' low-level callable */
         func = PyCapsule_GetPointer(fnc, NULL);
         data = PyCapsule_GetContext(fnc);
-#if PY_VERSION_HEX < 0x03000000
-    } else if (PyCObject_Check(fnc)) {
-        /* 'Legacy' low-level callable on Py2 */
-        func = PyCObject_AsVoidPtr(fnc);
-        data = PyCObject_GetDesc(fnc);
-#endif
     } else {
         int ret;
 
@@ -577,12 +571,6 @@ static PyObject *Py_GenericFilter(PyObject *obj, PyObject *args)
     if (PyCapsule_CheckExact(fnc) && PyCapsule_GetName(fnc) == NULL) {
         func = PyCapsule_GetPointer(fnc, NULL);
         data = PyCapsule_GetContext(fnc);
-#if PY_VERSION_HEX < 0x03000000
-    } else if (PyCObject_Check(fnc)) {
-        /* 'Legacy' low-level callable on Py2 */
-        func = PyCObject_AsVoidPtr(fnc);
-        data = PyCObject_GetDesc(fnc);
-#endif
     } else {
         int ret;
 
@@ -788,12 +776,6 @@ static PyObject *Py_GeometricTransform(PyObject *obj, PyObject *args)
         if (PyCapsule_CheckExact(fnc) && PyCapsule_GetName(fnc) == NULL) {
             func = PyCapsule_GetPointer(fnc, NULL);
             data = PyCapsule_GetContext(fnc);
-#if PY_VERSION_HEX < 0x03000000
-        } else if (PyCObject_Check(fnc)) {
-            /* 'Legacy' low-level callable on Py2 */
-            func = PyCObject_AsVoidPtr(fnc);
-            data = PyCObject_GetDesc(fnc);
-#endif
         } else {
             int ret;
 
@@ -1043,17 +1025,10 @@ exit:
     return PyErr_Occurred() ? NULL : Py_BuildValue("");
 }
 
-#ifdef NPY_PY3K
 static void _FreeCoordinateList(PyObject *obj)
 {
     NI_FreeCoordinateList((NI_CoordinateList*)PyCapsule_GetPointer(obj, NULL));
 }
-#else
-static void _FreeCoordinateList(void* ptr)
-{
-    NI_FreeCoordinateList((NI_CoordinateList*)ptr);
-}
-#endif
 
 static PyObject *Py_BinaryErosion(PyObject *obj, PyObject *args)
 {

--- a/scipy/ndimage/src/ni_support.c
+++ b/scipy/ndimage/src/ni_support.c
@@ -187,13 +187,8 @@ int NI_InitLineBuffer(PyArrayObject *array, int axis, npy_intp size1,
     case NPY_DOUBLE:
         break;
     default:
-#if PY_VERSION_HEX >= 0x03040000
         PyErr_Format(PyExc_RuntimeError, "array type %R not supported",
                      (PyObject *)PyArray_DTYPE(array));
-#else
-        PyErr_Format(PyExc_RuntimeError, "array type %d not supported",
-                     array_type);
-#endif
         return 0;
     }
 


### PR DESCRIPTION
Continued work on Python2 code cleanups #11584

These are the easy cases for these three consts.
The hard cases involve tracking down if functions are used anywhere, updating names...

This is the uses in ndimage, I'll open two other PRs for uses in sparse and elsewhere
