### PR TITLE
MAINT: Cleanup uses of PY_VERSION_HEX, NPY_PY3K in sparse

### DIFF
--- a/scipy/sparse/linalg/dsolve/_superlu_utils.c
+++ b/scipy/sparse/linalg/dsolve/_superlu_utils.c
@@ -181,12 +181,7 @@ static void SuperLUGlobal_dealloc(SuperLUGlobalObject *self)
 
 
 PyTypeObject SuperLUGlobalType = {
-#if defined(NPY_PY3K)
     PyVarObject_HEAD_INIT(NULL, 0)
-#else
-    PyObject_HEAD_INIT(NULL)
-    0,
-#endif
     "_SuperLUGlobal",
     sizeof(SuperLUGlobalObject),
     0,

--- a/scipy/sparse/linalg/dsolve/_superluobject.c
+++ b/scipy/sparse/linalg/dsolve/_superluobject.c
@@ -15,7 +15,7 @@
 #include <ctype.h>
 
 
-/*********************************************************************** 
+/***********************************************************************
  * SuperLUObject methods
  */
 
@@ -24,11 +24,7 @@ static PyObject *SuperLU_solve(SuperLUObject * self, PyObject * args,
 {
     volatile PyArrayObject *b, *x = NULL;
     volatile SuperMatrix B = { 0 };
-#ifndef NPY_PY3K
-    volatile char itrans = 'N';
-#else
     volatile int itrans = 'N';
-#endif
     volatile int info;
     volatile trans_t trans;
     volatile SuperLUStat_t stat = { 0 };
@@ -41,13 +37,8 @@ static PyObject *SuperLU_solve(SuperLUObject * self, PyObject * args,
         return NULL;
     }
 
-#ifndef NPY_PY3K
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!|c", kwlist,
-                                     &PyArray_Type, &b, &itrans))
-#else
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!|C", kwlist,
                                      &PyArray_Type, &b, &itrans))
-#endif
         return NULL;
 
     /* solve transposed system: matrix was passed row-wise instead of
@@ -123,7 +114,7 @@ PyMethodDef SuperLU_methods[] = {
 };
 
 
-/*********************************************************************** 
+/***********************************************************************
  * SuperLUType methods
  */
 
@@ -228,12 +219,7 @@ PyGetSetDef SuperLU_getset[] = {
 
 
 PyTypeObject SuperLUType = {
-#if defined(NPY_PY3K)
     PyVarObject_HEAD_INIT(NULL, 0)
-#else
-    PyObject_HEAD_INIT(NULL)
-    0,
-#endif
     "SuperLU",
     sizeof(SuperLUObject),
     0,
@@ -539,7 +525,7 @@ int LU_to_csc_matrix(SuperMatrix *L, SuperMatrix *U,
     }
 
     result = 0;
-    
+
 fail:
     Py_XDECREF(U_indices);
     Py_XDECREF(U_indptr);
@@ -590,7 +576,7 @@ LU_to_csc(SuperMatrix *L, SuperMatrix *U,
         PyErr_SetString(PyExc_ValueError, "unknown dtype");
         return -1;
     }
-    
+
 #define IS_ZERO(p)                                                      \
     ((dtype == SLU_S) ? (*(float*)(p) == 0) :                           \
      ((dtype == SLU_D) ? (*(double*)(p) == 0) :                         \
@@ -740,7 +726,7 @@ PyObject *newSuperLUObject(SuperMatrix * A, PyObject * option_dict,
     StatInit((SuperLUStat_t *)&stat);
 
     /* calc column permutation */
-    get_perm_c(options.ColPerm, A, self->perm_c);	
+    get_perm_c(options.ColPerm, A, self->perm_c);
 
     /* apply column permutation */
     sp_preorder((superlu_options_t*)&options, A, self->perm_c, (int*)etree,
@@ -1025,11 +1011,9 @@ static int droprule_cvt(PyObject * input, int *value)
     else if (PyString_Check(input) || PyUnicode_Check(input)) {
         /* Comma-separated string */
         char *fmt = "s";
-#if PY_MAJOR_VERSION >= 3
         if (PyBytes_Check(input)) {
             fmt = "y";
         }
-#endif
 	seq = PyObject_CallMethod(input, "split", fmt, ",");
 	if (seq == NULL || !PySequence_Check(seq))
 	    goto fail;

--- a/scipy/sparse/sparsetools/sparsetools.cxx
+++ b/scipy/sparse/sparsetools/sparsetools.cxx
@@ -266,16 +266,7 @@ call_thunk(char ret_spec, const char *spec, thunk_t *thunk, PyObject *args)
             /* Integer scalars */
             PY_LONG_LONG value;
 
-#if PY_VERSION_HEX >= 0x03000000
             value = PyLong_AsLongLong(arg_arrays[j]);
-#else
-            if (PyInt_Check(arg_arrays[j])) {
-                value = PyInt_AsLong(arg_arrays[j]);
-            }
-            else {
-                value = PyLong_AsLongLong(arg_arrays[j]);
-            }
-#endif
             if (PyErr_Occurred()) {
                 goto fail;
             }
@@ -447,7 +438,7 @@ fail:
         }
         #ifdef HAVE_WRITEBACKIFCOPY
             if (is_output[j] && arg_arrays[j] != NULL && PyArray_Check(arg_arrays[j])) {
-                PyArray_ResolveWritebackIfCopy((PyArrayObject *)arg_arrays[j]); 
+                PyArray_ResolveWritebackIfCopy((PyArrayObject *)arg_arrays[j]);
             }
         #endif
         Py_XDECREF(arg_arrays[j]);


### PR DESCRIPTION
Cleans up Python2 constants in scipy/sparse

See: PR #11621 and issue #11584