### PR TITLE
MAINT: Remove unnecessary 'from __future__ import ...' statements

### DIFF
--- a/benchmarks/benchmarks/blas_lapack.py
+++ b/benchmarks/benchmarks/blas_lapack.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import, print_function
-
 import numpy as np
 
 try:

--- a/benchmarks/benchmarks/common.py
+++ b/benchmarks/benchmarks/common.py
@@ -1,8 +1,6 @@
 """
 Airspeed Velocity benchmark utilities
 """
-from __future__ import division, absolute_import, print_function
-
 import sys
 import os
 import re

--- a/benchmarks/benchmarks/cython_special.py
+++ b/benchmarks/benchmarks/cython_special.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import, print_function
-
 import re
 import numpy as np
 from scipy import special

--- a/benchmarks/benchmarks/fft_basic.py
+++ b/benchmarks/benchmarks/fft_basic.py
@@ -1,7 +1,5 @@
 """ Test functions for fftpack.basic module
 """
-from __future__ import division, absolute_import, print_function
-
 from numpy import arange, asarray, zeros, dot, exp, pi, double, cdouble
 from numpy.random import rand
 import numpy as np

--- a/benchmarks/benchmarks/fftpack_pseudo_diffs.py
+++ b/benchmarks/benchmarks/fftpack_pseudo_diffs.py
@@ -1,7 +1,5 @@
 """ Benchmark functions for fftpack.pseudo_diffs module
 """
-from __future__ import division, absolute_import, print_function
-
 from numpy import arange, sin, cos, pi, exp, tanh, sign
 
 try:

--- a/benchmarks/benchmarks/go_benchmark_functions/__init__.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import division, print_function, absolute_import
 """
 ==============================================================================
 `go_benchmark_functions` --  Problems for testing global optimization routines

--- a/benchmarks/benchmarks/go_benchmark_functions/go_benchmark.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_benchmark.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import division, print_function, absolute_import
-
 import numpy as np
 from numpy import abs, asarray
 

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_A.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_A.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import division, print_function, absolute_import
-
 from numpy import abs, cos, exp, pi, prod, sin, sqrt, sum
 from .go_benchmark import Benchmark
 

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_B.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_B.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import division, print_function, absolute_import
-
 from numpy import abs, cos, exp, log, arange, pi, sin, sqrt, sum
 from .go_benchmark import Benchmark
 

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_C.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_C.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import division, print_function, absolute_import
-
 import numpy as np
 from numpy import (abs, asarray, cos, exp, floor, pi, sign, sin, sqrt, sum,
                    size, tril, isnan, atleast_2d, repeat)

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_D.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_D.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import division, print_function, absolute_import
-
 import numpy as np
 from numpy import abs, cos, exp, arange, pi, sin, sqrt, sum, zeros, tanh
 from numpy.testing import assert_almost_equal

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_E.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_E.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import division, print_function, absolute_import
-
 from numpy import abs, asarray, cos, exp, arange, pi, sin, sqrt, sum
 from .go_benchmark import Benchmark
 

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_F.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_F.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import division, print_function, absolute_import
-
 from .go_benchmark import Benchmark
 
 

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_G.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_G.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import division, print_function, absolute_import
-
 import numpy as np
 from numpy import abs, sin, cos, exp, floor, log, arange, prod, sqrt, sum
 

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_H.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_H.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import division, print_function, absolute_import
-
 import numpy as np
 from numpy import abs, arctan2, asarray, cos, exp, arange, pi, sin, sqrt, sum
 from .go_benchmark import Benchmark

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_I.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_I.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import division, print_function, absolute_import
-
 from numpy import sin, sum
 from .go_benchmark import Benchmark
 

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_J.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_J.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import division, print_function, absolute_import
-
 from numpy import sum, asarray, arange, exp
 from .go_benchmark import Benchmark
 

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_K.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_K.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import division, print_function, absolute_import
-
 from numpy import asarray, atleast_2d, arange, sin, sqrt, prod, sum, round
 from .go_benchmark import Benchmark
 

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_L.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_L.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import division, print_function, absolute_import
-
 from numpy import sum, cos, exp, pi, arange, sin
 from .go_benchmark import Benchmark
 

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_M.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_M.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import division, print_function, absolute_import
-
 from numpy import (abs, asarray, cos, exp, log, arange, pi, prod, sin, sqrt,
                    sum, tan)
 try:

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_N.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_N.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import division, print_function, absolute_import
-
 from numpy import cos, sqrt, sin, abs
 from .go_benchmark import Benchmark
 

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_O.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_O.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import division, print_function, absolute_import
-
 from numpy import sum, cos, exp, pi, asarray
 from .go_benchmark import Benchmark
 

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_P.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_P.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import division, print_function, absolute_import
-
 from numpy import (abs, sum, sin, cos, sqrt, log, prod, where, pi, exp, arange,
                    floor, log10, atleast_2d, zeros)
 from .go_benchmark import Benchmark

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_Q.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_Q.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import division, print_function, absolute_import
-
 from numpy import abs, sum, arange, sqrt
 
 from .go_benchmark import Benchmark

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_R.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_R.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import division, print_function, absolute_import
-
 from numpy import abs, sum, sin, cos, asarray, arange, pi, exp, log, sqrt
 from scipy.optimize import rosen
 from .go_benchmark import Benchmark

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_S.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_S.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import division, print_function, absolute_import
-
 from numpy import (abs, asarray, cos, floor, arange, pi, prod, roll, sin,
                    sqrt, sum, repeat, atleast_2d, tril)
 from numpy.random import uniform

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_T.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_T.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import division, print_function, absolute_import
-
 from numpy import abs, asarray, cos, exp, arange, pi, sin, sum, atleast_2d
 from .go_benchmark import Benchmark
 

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_U.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_U.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import division, print_function, absolute_import
-
 from numpy import abs, sin, cos, pi, sqrt
 from .go_benchmark import Benchmark
 

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_V.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_V.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import division, print_function, absolute_import
-
 from numpy import sum, cos, sin, log
 from .go_benchmark import Benchmark
 

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_W.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_W.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import division, print_function, absolute_import
-
 from numpy import atleast_2d, arange, sum, cos, exp, pi
 from .go_benchmark import Benchmark
 

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_X.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_X.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import division, print_function, absolute_import
-
 import numpy as np
 from numpy import abs, sum, sin, cos, pi, exp, arange, prod, sqrt
 from .go_benchmark import Benchmark

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_Y.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_Y.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import division, print_function, absolute_import
-
 from numpy import abs, sum, cos, pi
 from .go_benchmark import Benchmark
 

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_Z.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_Z.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import division, print_function, absolute_import
-
 from numpy import abs, sum, sign, arange
 from .go_benchmark import Benchmark
 

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_univariate.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_univariate.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import division, print_function, absolute_import
 from numpy import cos, exp, log, pi, sin, sqrt
 
 try:

--- a/benchmarks/benchmarks/integrate.py
+++ b/benchmarks/benchmarks/integrate.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import, print_function
-
 import numpy as np
 from .common import Benchmark
 

--- a/benchmarks/benchmarks/interpolate.py
+++ b/benchmarks/benchmarks/interpolate.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import, print_function
-
 import numpy as np
 
 from .common import run_monitored, set_mem_rlimit, Benchmark

--- a/benchmarks/benchmarks/io_matlab.py
+++ b/benchmarks/benchmarks/io_matlab.py
@@ -1,4 +1,3 @@
-from __future__ import division, absolute_import, print_function
 from .common import set_mem_rlimit, run_monitored, get_mem_info
 
 import os

--- a/benchmarks/benchmarks/linalg.py
+++ b/benchmarks/benchmarks/linalg.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import, print_function
-
 import math
 
 import numpy.linalg as nl

--- a/benchmarks/benchmarks/linalg_solve_toeplitz.py
+++ b/benchmarks/benchmarks/linalg_solve_toeplitz.py
@@ -1,7 +1,5 @@
 """Benchmark the solve_toeplitz solver (Levinson recursion)
 """
-from __future__ import division, absolute_import, print_function
-
 import numpy as np
 
 try:

--- a/benchmarks/benchmarks/linalg_sqrtm.py
+++ b/benchmarks/benchmarks/linalg_sqrtm.py
@@ -1,8 +1,6 @@
 """ Benchmark linalg.sqrtm for various blocksizes.
 
 """
-from __future__ import division, absolute_import, print_function
-
 import numpy as np
 
 try:

--- a/benchmarks/benchmarks/linprog_benchmark_files/__init__.py
+++ b/benchmarks/benchmarks/linprog_benchmark_files/__init__.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import division, print_function, absolute_import
-
 """
 ==============================================================================
 `` --  Problems for testing linear programming routines

--- a/benchmarks/benchmarks/lsq_problems.py
+++ b/benchmarks/benchmarks/lsq_problems.py
@@ -1,7 +1,5 @@
 """Benchmark problems for nonlinear least squares."""
 
-from __future__ import division
-
 from collections import OrderedDict
 import inspect
 import sys

--- a/benchmarks/benchmarks/optimize.py
+++ b/benchmarks/benchmarks/optimize.py
@@ -1,5 +1,3 @@
-from __future__ import division, print_function, absolute_import
-
 import os
 import time
 import inspect

--- a/benchmarks/benchmarks/optimize_zeros.py
+++ b/benchmarks/benchmarks/optimize_zeros.py
@@ -1,5 +1,3 @@
-from __future__ import division, print_function, absolute_import
-
 from math import sqrt, exp, cos, sin
 import numpy as np
 

--- a/benchmarks/benchmarks/peak_finding.py
+++ b/benchmarks/benchmarks/peak_finding.py
@@ -1,7 +1,5 @@
 """Benchmarks for peak finding related functions."""
 
-from __future__ import division, print_function, absolute_import
-
 try:
     from scipy.signal import find_peaks, peak_prominences, peak_widths
     from scipy.misc import electrocardiogram

--- a/benchmarks/benchmarks/signal.py
+++ b/benchmarks/benchmarks/signal.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import, print_function
-
 from itertools import product
 
 import numpy as np

--- a/benchmarks/benchmarks/signal_filtering.py
+++ b/benchmarks/benchmarks/signal_filtering.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import, print_function
-
 import numpy as np
 import timeit
 from concurrent.futures import ThreadPoolExecutor, wait

--- a/benchmarks/benchmarks/sparse.py
+++ b/benchmarks/benchmarks/sparse.py
@@ -1,8 +1,6 @@
 """
 Simple benchmarks for the sparse module
 """
-from __future__ import division, print_function, absolute_import
-
 import warnings
 import time
 import timeit

--- a/benchmarks/benchmarks/sparse_csgraph.py
+++ b/benchmarks/benchmarks/sparse_csgraph.py
@@ -1,5 +1,4 @@
 """benchmarks for the scipy.sparse.csgraph module"""
-from __future__ import print_function, absolute_import
 import numpy as np
 import scipy.sparse
 

--- a/benchmarks/benchmarks/sparse_csgraph_djisktra.py
+++ b/benchmarks/benchmarks/sparse_csgraph_djisktra.py
@@ -1,5 +1,4 @@
 """benchmarks for the scipy.sparse.csgraph module"""
-from __future__ import print_function, absolute_import
 import numpy as np
 import scipy.sparse
 

--- a/benchmarks/benchmarks/sparse_linalg_expm.py
+++ b/benchmarks/benchmarks/sparse_linalg_expm.py
@@ -1,6 +1,4 @@
 """benchmarks for the scipy.sparse.linalg._expm_multiply module"""
-from __future__ import division, print_function, absolute_import
-
 import math
 
 import numpy as np

--- a/benchmarks/benchmarks/sparse_linalg_lobpcg.py
+++ b/benchmarks/benchmarks/sparse_linalg_lobpcg.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import, print_function
-
 from functools import partial
 
 import numpy as np

--- a/benchmarks/benchmarks/sparse_linalg_onenormest.py
+++ b/benchmarks/benchmarks/sparse_linalg_onenormest.py
@@ -1,7 +1,5 @@
 """Compare the speed of exact one-norm calculation vs. its estimation.
 """
-from __future__ import division, print_function, absolute_import
-
 import numpy as np
 
 try:

--- a/benchmarks/benchmarks/sparse_linalg_solve.py
+++ b/benchmarks/benchmarks/sparse_linalg_solve.py
@@ -1,8 +1,6 @@
 """
 Check the speed of the conjugate gradient solver.
 """
-from __future__ import division, absolute_import, print_function
-
 import numpy as np
 from numpy.testing import assert_equal
 

--- a/benchmarks/benchmarks/spatial.py
+++ b/benchmarks/benchmarks/spatial.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import, print_function
-
 import numpy as np
 
 try:

--- a/benchmarks/benchmarks/special.py
+++ b/benchmarks/benchmarks/special.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import, print_function
-
 import numpy as np
 
 try:

--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import, print_function
-
 import warnings
 
 import numpy as np

--- a/benchmarks/benchmarks/test_functions.py
+++ b/benchmarks/benchmarks/test_functions.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import time
 
 import numpy as np

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -6,8 +6,6 @@ Convenience wrapper around the ``asv`` command; just sets environment
 variables and chdirs to the correct place etc.
 
 """
-from __future__ import division, absolute_import, print_function
-
 import os
 import sys
 import subprocess


### PR DESCRIPTION
Continued work on Python2 code cleanups #11584

I broke out the changes to `benchmark/` first but I have a seperate PR that does all ~615 files.

---

I double checked this with

To make sure that all files are deletions
```shell
$ git diff upstream/master --stat | grep -v -e '2 --$' -e '1 -$'
 59 files changed, 112 deletions(-)
```

To make sure I'm ovly removing `from __future__` lines
```shell
$ git diff upstream/master | grep '^[-+][^-+]' | sort -u
-from __future__ import division
-from __future__ import division, absolute_import, print_function
-from __future__ import division, print_function, absolute_import
-from __future__ import print_function, absolute_import
```

