### PR TITLE
MAINT: Cleanup uses of PY_VERSION_HEX

### DIFF
--- a/scipy/_lib/messagestream.pyx
+++ b/scipy/_lib/messagestream.pyx
@@ -1,6 +1,6 @@
 cimport cython
 from libc cimport stdio, stdlib
-from cpython cimport PyBytes_FromStringAndSize, PY_VERSION_HEX
+from cpython cimport PyBytes_FromStringAndSize
 
 import os
 import sys
@@ -13,7 +13,7 @@ cdef extern from "messagestream.h":
 @cython.final
 cdef class MessageStream:
     """
-    Capture messages emitted to FILE* streams. Do this by directing them 
+    Capture messages emitted to FILE* streams. Do this by directing them
     to a temporary file, residing in memory (if possible) or on disk.
     """
 
@@ -71,10 +71,7 @@ cdef class MessageStream:
             finally:
                 stdlib.free(buf)
 
-        if PY_VERSION_HEX >= 0x03000000:
-            return obj.decode('latin1')
-        else:
-            return obj
+        return obj.decode('latin1')
 
     def clear(self):
         stdio.rewind(self.handle)

--- a/scipy/_lib/src/ccallback.h
+++ b/scipy/_lib/src/ccallback.h
@@ -217,11 +217,7 @@ static void ccallback__err_invalid_signature(ccallback_signature_t *signatures,
         PyObject *str;
         int ret;
 
-#if PY_VERSION_HEX >= 0x03000000
         str = PyUnicode_FromString(sig->signature);
-#else
-        str = PyString_FromString(sig->signature);
-#endif
         if (str == NULL) {
             goto fail;
         }
@@ -233,32 +229,9 @@ static void ccallback__err_invalid_signature(ccallback_signature_t *signatures,
         }
     }
 
-#if PY_VERSION_HEX >= 0x03000000
     PyErr_Format(PyExc_ValueError,
                  "Invalid scipy.LowLevelCallable signature \"%s\". Expected one of: %R",
                  capsule_signature, sig_list);
-#else
-    {
-        PyObject *sig_list_repr;
-        char *sig_list_repr_str;
-
-        sig_list_repr = PyObject_Repr(sig_list);
-        if (sig_list_repr == NULL) {
-            goto fail;
-        }
-
-        sig_list_repr_str = PyString_AsString(sig_list_repr);
-        if (sig_list_repr_str == NULL) {
-            Py_DECREF(sig_list_repr);
-            goto fail;
-        }
-
-        PyErr_Format(PyExc_ValueError,
-                     "Invalid scipy.LowLevelCallable signature \"%s\". Expected one of: %s",
-                     capsule_signature, sig_list_repr_str);
-        Py_DECREF(sig_list_repr);
-    }
-#endif
 
 fail:
     Py_XDECREF(sig_list);

--- a/scipy/optimize/minpack.h
+++ b/scipy/optimize/minpack.h
@@ -29,12 +29,6 @@ the result tuple when the full_output argument is non-zero.
 */
 
 #include "Python.h"
-#if PY_VERSION_HEX >= 0x03000000
-    #define PyString_FromString PyBytes_FromString
-    #define PyString_Concat PyBytes_Concat
-    #define PyString_AsString PyBytes_AsString
-    #define PyInt_FromLong PyLong_FromLong
-#endif
 #include "numpy/arrayobject.h"
 #include "ccallback.h"
 

--- a/scipy/signal/lfilter.c.src
+++ b/scipy/signal/lfilter.c.src
@@ -196,16 +196,8 @@ scipy_signal_sigtools_linear_filter(PyObject * NPY_UNUSED(dummy), PyObject * arg
         if (str == NULL) {
             goto fail;
         }
-#if PY_VERSION_HEX >= 0x03000000
         msg = PyUnicode_FromFormat(
                         "input type '%U' not supported\n", str);
-#else
-        {
-            char *s = PyString_AsString(str);
-            msg = PyString_FromFormat(
-                        "input type '%s' not supported\n", s);
-        }
-#endif
         Py_DECREF(str);
         if (msg == NULL) {
             goto fail;


### PR DESCRIPTION
Cleans up Python2 constants in three places (the remaining)

Follows PR #11621 and #11622 
Working on issue #11584