### PR TITLE
ENH: add analytic formula for normal moments

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -237,6 +237,7 @@ kstwobign = kstwobign_gen(a=0.0, name='kstwobign')
 # by other distributions.
 _norm_pdf_C = np.sqrt(2*np.pi)
 _norm_pdf_logC = np.log(_norm_pdf_C)
+_norm_munp_C = 1. / np.sqrt(np.pi)
 
 
 def _norm_pdf(x):
@@ -361,6 +362,28 @@ class norm_gen(rv_continuous):
             scale = fscale
 
         return loc, scale
+
+    def _munp(self, n, mu=0., sigma=1.):
+        """
+        @returns Expectation of x^p for integer p >= 0
+
+        See https://arxiv.org/pdf/1209.4340.pdf
+        """
+        if n == 0:
+            return 1.
+        elif n == 1:
+            return mu
+        elif n == 2:
+            return sigma**2 + mu**2
+        elif n % 2 == 0:
+            hyper = sc.gamma(0.5 * n + 0.5) * sc.hyp1f1(-n / 2, 0.5,  -0.5 * (mu / sigma)**2)
+            return _norm_munp_C * sigma**n * 2.**(n / 2) * hyper
+        else:
+            if mu == 0.:
+                return 0.
+            hyper = sc.gamma(0.5 * n + 1.) * sc.hyp1f1((1 - n) / 2, 1.5,  -0.5 * (mu / sigma)**2)
+            return _norm_munp_C * mu * sigma**(n - 1) * 2.**((n + 1) / 2) * hyper
+
 
 
 norm = norm_gen(name='norm')

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -369,6 +369,12 @@ class norm_gen(rv_continuous):
 
         See https://arxiv.org/pdf/1209.4340.pdf
         """
+        if mu == 0.:
+            if  n % 2 == 0:
+                return sigma**n * sf.factorial2(n - 1)
+            else:
+                return 0.
+ 
         if n == 0:
             return 1.
         elif n == 1:
@@ -379,8 +385,6 @@ class norm_gen(rv_continuous):
             hyper = sc.gamma(0.5 * n + 0.5) * sc.hyp1f1(-n / 2, 0.5,  -0.5 * (mu / sigma)**2)
             return _norm_munp_C * sigma**n * 2.**(n / 2) * hyper
         else:
-            if mu == 0.:
-                return 0.
             hyper = sc.gamma(0.5 * n + 1.) * sc.hyp1f1((1 - n) / 2, 1.5,  -0.5 * (mu / sigma)**2)
             return _norm_munp_C * mu * sigma**(n - 1) * 2.**((n + 1) / 2) * hyper
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -237,7 +237,6 @@ kstwobign = kstwobign_gen(a=0.0, name='kstwobign')
 # by other distributions.
 _norm_pdf_C = np.sqrt(2*np.pi)
 _norm_pdf_logC = np.log(_norm_pdf_C)
-_norm_munp_C = 1. / np.sqrt(np.pi)
 
 
 def _norm_pdf(x):
@@ -363,32 +362,17 @@ class norm_gen(rv_continuous):
 
         return loc, scale
 
-    def _munp(self, n, mu=0., sigma=1.):
+    def _munp(self, n):
         """
-        @returns Expectation of x^p for integer p >= 0
+        @returns Moments of standard normal distribution for integer n >= 0
 
         See https://arxiv.org/pdf/1209.4340.pdf
         """
-        if mu == 0.:
-            if  n % 2 == 0:
-                return sigma**n * sf.factorial2(n - 1)
-            else:
-                return 0.
- 
-        if n == 0:
-            return 1.
-        elif n == 1:
-            return mu
-        elif n == 2:
-            return sigma**2 + mu**2
-        elif n % 2 == 0:
-            hyper = sc.gamma(0.5 * n + 0.5) * sc.hyp1f1(-n / 2, 0.5,  -0.5 * (mu / sigma)**2)
-            return _norm_munp_C * sigma**n * 2.**(n / 2) * hyper
+        if  n % 2 == 0:
+            return sf.factorial2(n - 1)
         else:
-            hyper = sc.gamma(0.5 * n + 1.) * sc.hyp1f1((1 - n) / 2, 1.5,  -0.5 * (mu / sigma)**2)
-            return _norm_munp_C * mu * sigma**(n - 1) * 2.**((n + 1) / 2) * hyper
-
-
+            return 0.
+ 
 
 norm = norm_gen(name='norm')
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -366,9 +366,9 @@ class norm_gen(rv_continuous):
         """
         @returns Moments of standard normal distribution for integer n >= 0
 
-        See https://arxiv.org/pdf/1209.4340.pdf
+        See eq. 16 of https://arxiv.org/abs/1209.4340v2
         """
-        if  n % 2 == 0:
+        if n % 2 == 0:
             return sf.factorial2(n - 1)
         else:
             return 0.

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -369,7 +369,7 @@ class norm_gen(rv_continuous):
         See eq. 16 of https://arxiv.org/abs/1209.4340v2
         """
         if n % 2 == 0:
-            return sf.factorial2(n - 1)
+            return sc.factorial2(n - 1)
         else:
             return 0.
  

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -372,7 +372,7 @@ class norm_gen(rv_continuous):
             return sc.factorial2(n - 1)
         else:
             return 0.
- 
+
 
 norm = norm_gen(name='norm')
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -4248,7 +4248,7 @@ class TestHistogram(object):
     def test_munp(self):
         for n in range(4):
             assert_allclose(self.norm_template._munp(n),
-                            stats.norm._munp(n, 1.0, 2.5), rtol=0.05)
+                            stats.norm(1.0, 2.5).moment(n), rtol=0.05)
 
     def test_entropy(self):
         assert_allclose(self.norm_template.entropy(),


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
#11610 

#### What does this implement/fix?
Adds analytic formula for normal moments, which are otherwise calculated by numerical integration. It should be faster and more accurate.

#### Additional information

I'm not completely sure that the shape parameters (mu, sigma) are handled as efficiently as possible. It seems that moments are always found by transforming from the moments of a N(0, 1) distribution to the moments of N(mu, sigma^2), by expanding <(sigma * Y + mu)^n> where Y ~ N(0, 1) and (sigma * Y + mu) ~ N(mu, sigma^2). I have analytic formulas that can take care of mu and sigma already, and it's probably more efficient to do it that way than compute so many moments are multiply them by combinatorial factors etc.