### PR TITLE
MAINT, TST: adjust azure for matplotlib release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -209,7 +209,7 @@ before_install:
     fi
   - |
     if [ "${TESTMODE}" == "full" ]; then
-        travis_retry pip install pytest-cov coverage matplotlib==3.2.0rc1 scikit-umfpack scikit-sparse
+        travis_retry pip install pytest-cov coverage matplotlib scikit-umfpack scikit-sparse
     fi
   - |
     if [ "${REFGUIDE_CHECK}" == "1" ]; then

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ jobs:
            curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
            python3.6 get-pip.py && \
            pip3 --version && \
-           pip3 install setuptools wheel numpy cython==0.29.14 pybind11 pytest pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath matplotlib --user && \
+           pip3 install setuptools wheel numpy cython==0.29.14 pybind11 pytest pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath matplotlib==3.1.3 --user && \
            apt-get -y install gfortran-5 wget && \
            cd .. && \
            mkdir openblas && cd openblas && \
@@ -118,12 +118,7 @@ jobs:
   - script: python -m pip install numpy cython==0.29.14 pybind11 pytest pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath
     displayName: 'Install dependencies'
   - powershell: |
-      If ($(PYTHON_VERSION) -ne '3.6') {
-          python -m pip install matplotlib==3.2.0rc1
-      }
-      else {
-          python -m pip install matplotlib
-      }
+      python -m pip install matplotlib
     displayName: 'Install matplotlib'
   # DLL resolution mechanics were changed in
   # Python 3.8: https://bugs.python.org/issue36085


### PR DESCRIPTION
* matplotlib `3.2.0` stable is out, so we shouldn't
need guards for the release candidate (and Python 3.6
should be ok with it too)

Disruption possibly related to this release: the ascii codec issue in another PR for 32-bit Linux Azure matplotlib install: https://github.com/scipy/scipy/pull/11627

If that persists we might want to squeeze in a fix here or report upstream.

To make matters worse, Azure CI Windows jobs have been more prone to timeouts lately as well.