### PR TITLE
Revert to old behaviour for constant cost matrices in `linear_sum_assignment`

### DIFF
--- a/scipy/optimize/rectangular_lsap/rectangular_lsap.cpp
+++ b/scipy/optimize/rectangular_lsap/rectangular_lsap.cpp
@@ -59,7 +59,9 @@ augmenting_path(int nc, std::vector<double>& cost, std::vector<double>& u,
     int num_remaining = nc;
     std::vector<int> remaining(nc);
     for (int it = 0; it < nc; it++) {
-        remaining[it] = it;
+        // Filling this up in reverse order ensures that the solution of a
+        // constant cost matrix is the identity matrix (c.f. #11602).
+        remaining[it] = nc - it - 1;
     }
 
     std::fill(SR.begin(), SR.end(), false);

--- a/scipy/optimize/tests/test_linear_assignment.py
+++ b/scipy/optimize/tests/test_linear_assignment.py
@@ -91,3 +91,12 @@ def test_linear_sum_assignment_input_validation():
     I = np.identity(3)
     I[:, 0] = np.inf
     assert_raises(ValueError, linear_sum_assignment, I)
+
+
+def test_constant_cost_matrix():
+    # Fixes #11602
+    n = 8
+    C = np.ones((n, n))
+    row_ind, col_ind = linear_sum_assignment(C)
+    assert_array_equal(row_ind, np.arange(n))
+    assert_array_equal(col_ind, np.arange(n))


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #11602

#### What does this implement/fix?
<!--Please explain your changes.-->
This is a cosmetic change which selects the identity matrix as the solution for constant inputs.