### PR TITLE
MAINT: Define ARRAY_ANYORDER with DEF instead of cdef

### DIFF
--- a/scipy/linalg/_decomp_update.pyx.in
+++ b/scipy/linalg/_decomp_update.pyx.in
@@ -61,7 +61,7 @@ from numpy.linalg import LinAlgError
 
 # This is used in place of, e.g., cnp.NPY_C_CONTIGUOUS, to indicate that a C
 # F or non contiguous array is acceptable.
-cdef int ARRAY_ANYORDER = 0
+DEF ARRAY_ANYORDER = 0
 
 cdef int MEMORY_ERROR = libc.limits.INT_MAX
 


### PR DESCRIPTION
This is the only way to tell the compiler that the value is a constant
which may be inlined instead of read from memory.