### PR TITLE
BUG: interpolate/interp1d: fail gracefully on all-nan inputs

### DIFF
--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -522,8 +522,14 @@ class interp1d(_Interpolator1D):
                 # to get the correct shape of the output, which we then fill
                 # with nans.
                 # For slinear or zero order spline, we just pass nans through.
-                if np.isnan(self.x).any():
-                    xx = np.linspace(min(self.x), max(self.x), len(self.x))
+                mask = np.isnan(self.x)
+                if mask.any():
+                    sx = self.x[~mask]
+                    if sx.size == 0:
+                        raise ValueError("`x` array is all-nan")                        
+                    xx = np.linspace(np.nanmin(self.x),
+                                     np.nanmax(self.x),
+                                     len(self.x))
                     rewrite_nan = True
                 if np.isnan(self._y).any():
                     yy = np.ones_like(self._y)

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -700,6 +700,13 @@ class TestInterp1D(object):
                 assert_(np.isnan(outn).all())
                 assert_equal(out.shape, outn.shape)
 
+    def test_all_nans(self):
+        # regression test for gh-11637: interp1d core dumps with all-nan `x`
+        x = np.ones(10) * np.nan
+        y = np.arange(10)
+        with assert_raises(ValueError):
+            interp1d(x, y, kind='cubic')
+
     def test_read_only(self):
         x = np.arange(0, 10)
         y = np.exp(-x / 3.0)


### PR DESCRIPTION

#### Reference issue

fixes gh-11637

#### What does this implement/fix?

interp1d has a bit of fairly weird logic to avoid feeding nans to spline interpolators (which call into LAPACK, and this triggers undefined behavior). However, a corner case of an all-nan input array was not properly handled. So work a bit harder and actually reject all-nan input.
