### PR TITLE
MAINT: Fix BLAS3 trmm wrapper for "side" arg

### DIFF
--- a/scipy/linalg/fblas_l3.pyf.src
+++ b/scipy/linalg/fblas_l3.pyf.src
@@ -163,8 +163,7 @@ subroutine <prefix>trmm(m, n, k, alpha, a, b, lda, ldb, side, lower, trans_a, di
   !
   ! c = trmm(alpha, a, b, side=0, lower=0, trans_a=0, diag=0)
 
-  callstatement (*f2py_func)((side?"R":"L"), (lower?"L":"U"), &
-        (trans_a?(trans_a==2?"C":"T"):"N"), (diag?"U":"N"), &m, &n, &alpha, a, &lda, b, &ldb)
+  callstatement (*f2py_func)((side?"R":"L"), (lower?"L":"U"),(trans_a?(trans_a==2?"C":"T"):"N"), (diag?"U":"N"), &m, &n, &alpha, a, &lda, b, &ldb)
   callprotoargument char*, char*, char*, char*, int*, int*, <ctype>*,<ctype>*,int*,<ctype>*, int*
 
   integer optional, intent(in), check(side==0 || side==1) :: side = 0
@@ -174,16 +173,15 @@ subroutine <prefix>trmm(m, n, k, alpha, a, b, lda, ldb, side, lower, trans_a, di
 
   <ftype> intent(in) :: alpha
 
-  <ftype> dimension(lda, k), intent(in) :: a
-  <ftype> dimension(ldb, n), intent(in, out, copy) :: b
+  <ftype> intent(in), dimension(lda, k) :: a
+  <ftype> intent(in, out, copy), dimension(ldb, n) :: b
 
-  integer depend(a), intent(hide) :: lda = shape(a, 0)
-  integer depend(a), intent(hide) :: k = shape(a, 1)
+  integer intent(hide), depend(a) :: lda = MAX(1,shape(a, 0))
+  integer intent(hide), depend(a, n, m, side), check(k>=(side?n:m) && k<=shape(a, 0)) :: k = shape(a, 1)
 
-  integer depend(b), intent(hide) :: ldb = shape(b, 0)
-  integer depend(b), intent(hide) :: n = shape(b, 1)
-
-  integer depend(side, a, b, n, k), intent(hide) :: m = (side ? n : k)
+  integer intent(hide), depend(b) :: ldb = MAX(1,shape(b, 0))
+  integer intent(hide), depend(b) :: m = shape(b, 0)
+  integer intent(hide), depend(b) :: n = shape(b, 1)
 
 end subroutine <prefix>trmm
 

--- a/scipy/linalg/tests/test_blas.py
+++ b/scipy/linalg/tests/test_blas.py
@@ -12,7 +12,7 @@ Run tests if scipy is installed:
 """
 
 import math
-
+import pytest
 import numpy as np
 from numpy.testing import (assert_equal, assert_almost_equal, assert_,
                            assert_array_almost_equal, assert_allclose)
@@ -945,6 +945,7 @@ class TestBLAS3Syr2k(object):
 
 class TestSyHe(object):
     """Quick and simple tests for (zc)-symm, syrk, syr2k."""
+
     def setup_method(self):
         self.sigma_y = np.array([[0., -1.j],
                                  [1.j, 0.]])
@@ -984,11 +985,30 @@ class TestSyHe(object):
 
 class TestTRMM(object):
     """Quick and simple tests for dtrmm."""
+
     def setup_method(self):
         self.a = np.array([[1., 2., ],
                            [-2., 1.]])
         self.b = np.array([[3., 4., -1.],
                            [5., 6., -2.]])
+
+        self.a2 = np.array([[1, 1, 2, 3],
+                            [0, 1, 4, 5],
+                            [0, 0, 1, 6],
+                            [0, 0, 0, 1]], order="f")
+        self.b2 = np.array([[1, 4], [2, 5], [3, 6], [7, 8], [9, 10]],
+                           order="f")
+
+    @pytest.mark.parametrize("dtype_", DTYPES)
+    def test_side(self, dtype_):
+        trmm = get_blas_funcs("trmm", dtype=dtype_)
+        # Provide large A array that works for side=1 but not 0 (see gh-10841)
+        assert_raises(Exception, trmm, 1.0, self.a2, self.b2)
+        res = trmm(1.0, self.a2.astype(dtype_), self.b2.astype(dtype_),
+                   side=1)
+        k = self.b2.shape[1]
+        assert_allclose(res, self.b2 @ self.a2[:k, :k], rtol=0.,
+                        atol=100*np.finfo(dtype_).eps)
 
     def test_ab(self):
         f = getattr(fblas, 'dtrmm', None)


### PR DESCRIPTION

#### Reference issue
Closes #10841 

#### What does this implement/fix?
The wrapper guard of the A array shape is modified and new tests are added.
