### PR TITLE
TST, MAINT: remove dead code in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -214,10 +214,6 @@ before_install:
   - |
     if [ "${REFGUIDE_CHECK}" == "1" ]; then
         travis_retry pip install matplotlib Sphinx==1.7.2
-        # XXX: Install older numpy as a workaround for float printing changes.
-        # XXX: We'll remove this once numpy 1.14.1 is released to fix its printing
-        # XXX: bugs
-        travis_retry pip install 'numpy!=1.14.0'
     fi
   - |
     if [ "${ASV_CHECK}" == "1" ]; then


### PR DESCRIPTION
* refguide_check matrix entry was avoiding NumPy
1.14.0, but this should no longer be needed as there
are plenty of more recent/stable versions now
