### PR TITLE
MAINT: fix conversion in binom_test

### DIFF
--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -2418,7 +2418,7 @@ def binom_test(x, n=None, p=0.5, alternative='two-sided'):
     because the returned p-value is greater than the critical value of 5%.
 
     """
-    x = atleast_1d(x).astype(np.integer)
+    x = atleast_1d(x).astype(np.int_)
     if len(x) == 2:
         n = x[1] + x[0]
         x = x[0]


### PR DESCRIPTION
* Converting `np.integer` or `np.signedinteger` to a dtype is
deprecated in NumPy master (and causes failures in our Travis
CI NumPy pre-release wheel tests -- #11642)

* repair the single violation of this deprecation in our
source code, in binom_test()
