### PR TITLE
Perform geometric slerp in quaternion space

### DIFF
--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -2131,7 +2131,6 @@ class Slerp(object):
         # Interpolate between rotations using a geometric slerp.
         result = []
         for i, a in zip(ind, alpha):
-            print(i, a)
             start, end = self.basis[i]
             omega = self.omega[i]
             t = np.atleast_1d(a) * omega

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -1126,3 +1126,18 @@ def test_slerp_call_scalar_time():
     delta = r_interpolated * r_interpolated_expected.inv()
 
     assert_allclose(delta.magnitude(), 0, atol=1e-16)
+
+
+def test_slerp_ambiguous():
+    key_quats = np.concatenate((np.eye(4), -np.eye(4)))
+    n = len(key_quats)
+    key_rots = Rotation.from_quat(key_quats)
+    key_times = np.arange(n)
+    interpolator = Slerp(key_times, key_rots)
+
+    k = 4
+    times = np.linspace(0, n - 1, k * n - k + 1, endpoint=True)
+    interp_rots = interpolator(times)
+    interp_quats = interp_rots.as_quat()
+    for i in range(n):
+        assert_allclose(interp_quats[i * k], key_quats[i], atol=1E-12)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #9688 

#### What does this implement/fix?
<!--Please explain your changes.-->
The `Slerp` class performs a geometric slerp in quaternion space rather than using the `rotvec` representation.