### PR TITLE
Fix trust-constr function evaluations outside of bounds

### DIFF
--- a/scipy/optimize/_differentiable_functions.py
+++ b/scipy/optimize/_differentiable_functions.py
@@ -28,6 +28,8 @@ class ScalarFunction(object):
     """
     def __init__(self, fun, x0, args, grad, hess, finite_diff_rel_step,
                  finite_diff_bounds, epsilon=None):
+
+
         if not callable(grad) and grad not in FD_METHODS:
             raise ValueError("`grad` must be either callable or one of {}."
                              .format(FD_METHODS))
@@ -52,6 +54,8 @@ class ScalarFunction(object):
         self.f_updated = False
         self.g_updated = False
         self.H_updated = False
+        self.lb = finite_diff_bounds[0]
+        self.ub = finite_diff_bounds[1]
 
         finite_diff_options = {}
         if grad in FD_METHODS:
@@ -145,6 +149,8 @@ class ScalarFunction(object):
 
         if isinstance(hess, HessianUpdateStrategy):
             def update_x(x):
+                if np.any((x < self.lb) | (x > self.ub)):
+                    raise ValueError("`updated x` violates bound constraints.")
                 self._update_grad()
                 self.x_prev = self.x
                 self.g_prev = self.g
@@ -156,6 +162,8 @@ class ScalarFunction(object):
                 self._update_hess()
         else:
             def update_x(x):
+                if np.any((x < self.lb) | (x > self.ub)):
+                    raise ValueError("`updated x` violates bound constraints.")
                 self.x = np.atleast_1d(x).astype(float)
                 self.f_updated = False
                 self.g_updated = False

--- a/scipy/optimize/_differentiable_functions.py
+++ b/scipy/optimize/_differentiable_functions.py
@@ -52,9 +52,10 @@ class ScalarFunction(object):
         self.f_updated = False
         self.g_updated = False
         self.H_updated = False
+        if finite_diff_bounds is None:
+            finite_diff_bounds = ((np.full(self.n, -np.inf), np.full(self.n, np.inf)))
         self.lb = finite_diff_bounds[0]
         self.ub = finite_diff_bounds[1]
-
         finite_diff_options = {}
         if grad in FD_METHODS:
             finite_diff_options["method"] = grad
@@ -147,22 +148,23 @@ class ScalarFunction(object):
 
         if isinstance(hess, HessianUpdateStrategy):
             def update_x(x):
+                x = np.atleast_1d(x).astype(float)
                 if np.any((x < self.lb) | (x > self.ub)):
                     raise ValueError("`updated x` violates bound constraints.")
                 self._update_grad()
                 self.x_prev = self.x
                 self.g_prev = self.g
-
-                self.x = np.atleast_1d(x).astype(float)
+                self.x = x
                 self.f_updated = False
                 self.g_updated = False
                 self.H_updated = False
                 self._update_hess()
         else:
             def update_x(x):
+                x = np.atleast_1d(x).astype(float)
                 if np.any((x < self.lb) | (x > self.ub)):
                     raise ValueError("`updated x` violates bound constraints.")
-                self.x = np.atleast_1d(x).astype(float)
+                self.x = x
                 self.f_updated = False
                 self.g_updated = False
                 self.H_updated = False

--- a/scipy/optimize/_differentiable_functions.py
+++ b/scipy/optimize/_differentiable_functions.py
@@ -28,8 +28,6 @@ class ScalarFunction(object):
     """
     def __init__(self, fun, x0, args, grad, hess, finite_diff_rel_step,
                  finite_diff_bounds, epsilon=None):
-
-
         if not callable(grad) and grad not in FD_METHODS:
             raise ValueError("`grad` must be either callable or one of {}."
                              .format(FD_METHODS))

--- a/scipy/optimize/_trustregion_constr/minimize_trustregion_constr.py
+++ b/scipy/optimize/_trustregion_constr/minimize_trustregion_constr.py
@@ -339,7 +339,7 @@ def _minimize_trustregion_constr(fun, x0, args, grad,
 
     # Prepare constraints.
     prepared_constraints = [
-        PreparedConstraint(c, x0, sparse_jacobian, finite_diff_bounds)
+        PreparedConstraint(c, x0, sparse_jacobian, (-np.inf, np.inf))
         for c in constraints]
 
     # Check that all constraints are either sparse or dense.

--- a/scipy/optimize/_trustregion_constr/tr_interior_point.py
+++ b/scipy/optimize/_trustregion_constr/tr_interior_point.py
@@ -77,11 +77,17 @@ class BarrierSubproblem:
 
         """
         # Get variables and slack variables
+        # I think this is the spot where we want to check for feasibility with self.enforce_feasibility
+        # need to figure out how to determine if feasibiltiy is violated from the variables and slacks
+        #import ipdb; ipdb.set_trace()
         x = self.get_variables(z)
         s = self.get_slack(z)
-        # Compute function and constraints
-        f = self.fun(x)
         c_eq, c_ineq = self.constr(x)
+        # Compute function and constraints
+        try:
+            f = self.fun(x)
+        except ValueError:
+            return(np.array(np.inf), self._compute_constr(c_ineq, c_eq, s))
         # Return objective function and constraints
         return (self._compute_function(f, c_ineq, s),
                 self._compute_constr(c_ineq, c_eq, s))
@@ -127,6 +133,7 @@ class BarrierSubproblem:
         Both of them scaled by the previously defined scaling factor.
         """
         # Get variables and slack variables
+        #import ipdb; ipdb.set_trace()
         x = self.get_variables(z)
         s = self.get_slack(z)
         # Compute first derivatives
@@ -312,6 +319,7 @@ def tr_interior_point(fun, grad, lagr_hess, n_vars, n_ineq, n_eq,
     fun0_subprob, constr0_subprob = subprob.fun0, subprob.constr0
     grad0_subprob, jac0_subprob = subprob.grad0, subprob.jac0
     # Define trust region bounds
+    #import ipdb; ipdb.set_trace()
     trust_lb = np.hstack((np.full(subprob.n_vars, -np.inf),
                           np.full(subprob.n_ineq, -BOUNDARY_PARAMETER)))
     trust_ub = np.full(subprob.n_vars+subprob.n_ineq, np.inf)
@@ -339,6 +347,7 @@ def tr_interior_point(fun, grad, lagr_hess, n_vars, n_ineq, n_eq,
         # Update Barrier Problem
         subprob.update(barrier_parameter, tolerance)
         # Compute initial values for next iteration
+        #import ipdb; ipdb.set_trace()
         fun0_subprob, constr0_subprob = subprob.function_and_constraints(z)
         grad0_subprob, jac0_subprob = subprob.gradient_and_jacobian(z)
 

--- a/scipy/optimize/_trustregion_constr/tr_interior_point.py
+++ b/scipy/optimize/_trustregion_constr/tr_interior_point.py
@@ -77,9 +77,6 @@ class BarrierSubproblem:
 
         """
         # Get variables and slack variables
-        # I think this is the spot where we want to check for feasibility with self.enforce_feasibility
-        # need to figure out how to determine if feasibiltiy is violated from the variables and slacks
-        #import ipdb; ipdb.set_trace()
         x = self.get_variables(z)
         s = self.get_slack(z)
         c_eq, c_ineq = self.constr(x)
@@ -133,7 +130,6 @@ class BarrierSubproblem:
         Both of them scaled by the previously defined scaling factor.
         """
         # Get variables and slack variables
-        #import ipdb; ipdb.set_trace()
         x = self.get_variables(z)
         s = self.get_slack(z)
         # Compute first derivatives
@@ -319,7 +315,6 @@ def tr_interior_point(fun, grad, lagr_hess, n_vars, n_ineq, n_eq,
     fun0_subprob, constr0_subprob = subprob.fun0, subprob.constr0
     grad0_subprob, jac0_subprob = subprob.grad0, subprob.jac0
     # Define trust region bounds
-    #import ipdb; ipdb.set_trace()
     trust_lb = np.hstack((np.full(subprob.n_vars, -np.inf),
                           np.full(subprob.n_ineq, -BOUNDARY_PARAMETER)))
     trust_ub = np.full(subprob.n_vars+subprob.n_ineq, np.inf)
@@ -347,7 +342,6 @@ def tr_interior_point(fun, grad, lagr_hess, n_vars, n_ineq, n_eq,
         # Update Barrier Problem
         subprob.update(barrier_parameter, tolerance)
         # Compute initial values for next iteration
-        #import ipdb; ipdb.set_trace()
         fun0_subprob, constr0_subprob = subprob.function_and_constraints(z)
         grad0_subprob, jac0_subprob = subprob.gradient_and_jacobian(z)
 


### PR DESCRIPTION
#### Reference issue
Attempts to close #11649.

#### What does this implement/fix?
Adds checks in _differentiable_functions.py to ensure updated x values do not violate bound constraints, stopping potential function evaluations outside of the constrained region and causing an error.

In tr_interior_point.py, returns inf for the function evaluation if we hit the added error in _differentiable_functions.py, consistent with what is described in Nocedal and Wright p. 577.

#### Additional information
Not the most elegant approach, but given how the numerical differentiation routines are set up this seemed to be the quickest solution.