### PR TITLE
DOC: Update paper URL in lambertw documentation

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -230,6 +230,7 @@ Søren Fuglede Jørgensen for improvements to scipy.sparse.csgraph
 Grzegorz Mrukwa for a bug fix in rectangular_lsap.cpp
 Santiago Hernandez for a bug fix in scipy.optimize._differentialevolution.py.
 Dan Kleeman for implementing nan_policy in stats.zscores and winsorize
+James Wright for simple documentation fixes
 
 Institutions
 ------------

--- a/scipy/special/lambertw.py
+++ b/scipy/special/lambertw.py
@@ -67,7 +67,7 @@ def lambertw(z, k=0, tol=1e-8):
     .. [1] https://en.wikipedia.org/wiki/Lambert_W_function
     .. [2] Corless et al, "On the Lambert W function", Adv. Comp. Math. 5
        (1996) 329-359.
-       http://www.apmaths.uwo.ca/~djeffrey/Offprints/W-adv-cm.pdf
+       https://cs.uwaterloo.ca/research/tr/1993/03/W.pdf
 
     Examples
     --------


### PR DESCRIPTION
#### Reference issue
N/A

#### What does this implement/fix?
Previous link to a paper in the `special.lambertw` documentation no longer worked. I found the paper again and have updated the URL.

#### Additional information
I haven't technically checked to see if the documentation will render correctly with Sphinx, but this seems like such a minor change that I figured it shouldn't be that big of an issue.