### PR TITLE
PERF: Switch to C++ STL std::nth_element

### DIFF
--- a/scipy/spatial/ckdtree/src/partial_sort.h
+++ b/scipy/spatial/ckdtree/src/partial_sort.h
@@ -64,8 +64,11 @@ static int partition_node_indices(const double *data,
      *    modified as noted above.
      */
 
-    IndexComparator index_comparator = {.data=data, .split_dim=split_dim, 
-                                        .n_dims = n_dims};
+    IndexComparator index_comparator;
+
+    index_comparator.data = data;
+    index_comparator.split_dim = split_dim;
+    index_comparator.n_dims = n_dims;
 
     std::nth_element(node_indices,
                      node_indices + split_index,

--- a/scipy/spatial/ckdtree/src/partial_sort.h
+++ b/scipy/spatial/ckdtree/src/partial_sort.h
@@ -6,6 +6,7 @@
  *
  */
 
+#include "ckdtree_decl.h"
 #include <algorithm>
 
 struct IndexComparator {
@@ -22,11 +23,13 @@ struct IndexComparator {
                                             n_dims(n_dims) {};
 
     inline bool operator()(ckdtree_intp_t a, ckdtree_intp_t b) {
-        if (data[a * n_dims + split_dim] == data[b * n_dims + split_dim]) {
+        const double point_a = data[a * n_dims + split_dim];
+        const double point_b = data[b * n_dims + split_dim];
+
+        if CKDTREE_UNLIKELY (point_a == point_b) {
             return a < b;
-        }
-        else {
-            return data[a * n_dims + split_dim] < data[b * n_dims + split_dim];
+        } else {
+            return point_a < point_b;
         }
     }
 };


### PR DESCRIPTION
#### Reference issue
Closes #11595

#### What does this implement/fix?
Replaces custom implementation of the partial quicksort algorithm (worst complexity O(n^2)) with 
C++ STL  `std::nth_element` intro-select algorithm (worst complexity (O(n log n)).

#### Additional information
The algorithm used by SciPy for cKD-tree building relies on the partial quicksort algorithm which may be inefficient in some special cases. One of such cases is presented in #11595. 
This is adapted for SciPy solution which is based on [pr-11103](https://github.com/scikit-learn/scikit-learn/pull/11103).