### PR TITLE
WIP, TST, CI: use OpenBLAS for Travis CI Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ language: python
 addons:
   apt:
     packages: &common_packages
-    - libatlas-base-dev
-    - liblapack-dev
     - gfortran
     - libgmp-dev
     - libmpfr-dev
@@ -127,6 +125,9 @@ before_install:
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       free -m
       export PATH=/usr/lib/ccache:$PATH
+      target=$(python tools/openblas_support.py)
+      sudo cp -r $target/lib/* /usr/lib
+      sudo cp $target/include/* /usr/include
     elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       brew cask uninstall oclint
       brew install ccache libmpc gcc@6


### PR DESCRIPTION
Fixes #11652, hopefully/eventually

* Travis CI Linux jobs running the SciPy test
suite are currently exhibiting failures when
built in conjunction with NumPy pre-release wheels

* the failures have not been replicated with
MacOS or native Linux local testing with the
OpenBLAS linear algebra backend (0.3.7)

* since the failing jobs described above are
using APT-installed ATLAS 3.10.2, try switching
to a recent version of OpenBLAS instead, using
our recently-borrowed openblas_support.py infrastructure
