### PR TITLE
BUG: Non-central Fisher distribution (fix nan-values when nc=0)

### DIFF
--- a/doc/source/tutorial/stats/continuous_ncf.rst
+++ b/doc/source/tutorial/stats/continuous_ncf.rst
@@ -8,7 +8,7 @@ The distribution of :math:`\left(X_{1}/X_{2}\right)\left(\nu_{2}/\nu_{1}\right)`
 if :math:`X_{1}` is non-central chi-squared with :math:`\nu_{1}` degrees of freedom
 and parameter :math:`\lambda`, and :math:`X_{2}` is chi-squared with :math:`\nu_{2}` degrees of freedom.
 
-There are 3 shape parameters: the degrees of freedom :math:`\nu_{1}>0` and :math:`\nu_{2}>0`; and :math:`\lambda\geq0`.
+There are 3 shape parameters: the degrees of freedom :math:`\nu_{1}>0` and :math:`\nu_{2}>0`; and :math:`\lambda\geq 0`.
 
 
 .. math::
@@ -19,7 +19,6 @@ There are 3 shape parameters: the degrees of freedom :math:`\nu_{1}>0` and :math
 
 where :math:`L_{\nu_{2}/2}^{\nu_{1}/2-1}(x)` is an associated Laguerre polynomial.
 
-If :math:`\lambda=0`, it becomes equivalent to the Fisher distribution
-with :math:`\nu_{1}` and :math:`\nu_{2}` degrees of freedom.
+If :math:`\lambda=0`, the distribution becomes equivalent to the Fisher distribution with :math:`\nu_{1}` and :math:`\nu_{2}` degrees of freedom.
 
 Implementation: `scipy.stats.ncf`

--- a/doc/source/tutorial/stats/continuous_ncf.rst
+++ b/doc/source/tutorial/stats/continuous_ncf.rst
@@ -5,10 +5,10 @@ Noncentral F Distribution
 =========================
 
 The distribution of :math:`\left(X_{1}/X_{2}\right)\left(\nu_{2}/\nu_{1}\right)`
-if :math:`X_{1}` is non-central chi-squared with :math:`v_{1}` degrees of freedom
-and parameter :math:`\lambda`, and :math:`X_{2}` is chi-squared with :math:`v_{2}` degrees of freedom.
+if :math:`X_{1}` is non-central chi-squared with :math:`\nu_{1}` degrees of freedom
+and parameter :math:`\lambda`, and :math:`X_{2}` is chi-squared with :math:`\nu_{2}` degrees of freedom.
 
-There are 3 shape parameters: the degrees of freedom :math:`\nu_{1}>0` and :math:`\nu_{2}>0`; and :math:`\lambda>0`.
+There are 3 shape parameters: the degrees of freedom :math:`\nu_{1}>0` and :math:`\nu_{2}>0`; and :math:`\lambda\geq0`.
 
 
 .. math::
@@ -18,5 +18,8 @@ There are 3 shape parameters: the degrees of freedom :math:`\nu_{1}>0` and :math
     &  & \times\left(\nu_{2}+\nu_{1}x\right)^{-\left(\nu_{1}+\nu_{2}\right)/2}\frac{\Gamma\left(\frac{\nu_{1}}{2}\right)\Gamma\left(1+\frac{\nu_{2}}{2}\right)L_{\nu_{2}/2}^{\nu_{1}/2-1}\left(-\frac{\lambda\nu_{1}x}{2\left(\nu_{1}x+\nu_{2}\right)}\right)}{B\left(\frac{\nu_{1}}{2},\frac{\nu_{2}}{2}\right)\Gamma\left(\frac{\nu_{1}+\nu_{2}}{2}\right)}\end{eqnarray*}
 
 where :math:`L_{\nu_{2}/2}^{\nu_{1}/2-1}(x)` is an associated Laguerre polynomial.
+
+If :math:`\lambda=0`, it becomes equivalent to the Fisher distribution
+with :math:`\nu_{1}` and :math:`\nu_{2}` degrees of freedom.
 
 Implementation: `scipy.stats.ncf`

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -5748,14 +5748,14 @@ class ncf_gen(rv_continuous):
                                (-\lambda v_1 \frac{x}{2(v_1 x+v_2)})}
                               {B(v_1/2, v_2/2)  \gamma(\frac{v_1+v_2}{2})}
 
-    for :math:`n_1, n_2 > 0`, :math:`\lambda\geq0`.  Here :math:`n_1` is the
+    for :math:`n_1, n_2 > 0`, :math:`\lambda\geq 0`.  Here :math:`n_1` is the
     degrees of freedom in the numerator, :math:`n_2` the degrees of freedom in
     the denominator, :math:`\lambda` the non-centrality parameter,
     :math:`\gamma` is the logarithm of the Gamma function, :math:`L_n^k` is a
     generalized Laguerre polynomial and :math:`B` is the beta function.
 
     `ncf` takes ``df1``, ``df2`` and ``nc`` as shape parameters. If ``nc=0``,
-    it becomes equivalent to the Fisher distribution.
+    the distribution becomes equivalent to the Fisher distribution.
 
     %(after_notes)s
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -5748,15 +5748,20 @@ class ncf_gen(rv_continuous):
                                (-\lambda v_1 \frac{x}{2(v_1 x+v_2)})}
                               {B(v_1/2, v_2/2)  \gamma(\frac{v_1+v_2}{2})}
 
-    for :math:`n_1 > 1`, :math:`n_2, \lambda > 0`.  Here :math:`n_1` is the
+    for :math:`n_1, n_2 > 0`, :math:`\lambda\geq0`.  Here :math:`n_1` is the
     degrees of freedom in the numerator, :math:`n_2` the degrees of freedom in
     the denominator, :math:`\lambda` the non-centrality parameter,
     :math:`\gamma` is the logarithm of the Gamma function, :math:`L_n^k` is a
     generalized Laguerre polynomial and :math:`B` is the beta function.
 
-    `ncf` takes ``df1``, ``df2`` and ``nc`` as shape parameters.
+    `ncf` takes ``df1``, ``df2`` and ``nc`` as shape parameters. If ``nc=0``,
+    it becomes equivalent to the Fisher distribution.
 
     %(after_notes)s
+
+    See Also
+    --------
+    scipy.stats.f : Fisher distribution
 
     %(example)s
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -5761,6 +5761,9 @@ class ncf_gen(rv_continuous):
     %(example)s
 
     """
+    def _argcheck(self, df1, df2, nc):
+        return (df1 > 0) & (df2 > 0) & (nc >= 0)
+
     def _rvs(self, dfn, dfd, nc):
         return self._random_state.noncentral_f(dfn, dfd, nc, self._size)
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -4145,13 +4145,16 @@ def test_crystalball_function_moments():
     assert_allclose(expected_5th_moment, calculated_5th_moment, rtol=0.001)
 
 
-def test_ncf_edge_case():
+@pytest.mark.parametrize(
+    'df1,df2,x',
+    [(2, 2, [-0.5, 0.2, 1.0, 2.3]),
+     (4, 11, [-0.5, 0.2, 1.0, 2.3]),
+     (7, 17, [1, 2, 3, 4, 5])]
+)
+def test_ncf_edge_case(df1, df2, x):
     # Test for edge case described in gh-11660.
     # Non-central Fisher distribution when nc = 0
     # should be the same as Fisher distribution.
-    x = np.array([-0.5, 0.2, 1.0, 2.3])
-    df1 = 4
-    df2 = 11
     nc = 0
     expected_cdf = stats.f.cdf(x, df1, df2)
     calculated_cdf = stats.ncf.cdf(x, df1, df2, nc)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -4145,6 +4145,25 @@ def test_crystalball_function_moments():
     assert_allclose(expected_5th_moment, calculated_5th_moment, rtol=0.001)
 
 
+def test_ncf_edge_case():
+    # Test for edge case described in gh-11660.
+    # Non-central Fisher distribution when nc = 0
+    # should be the same as Fisher distribution.
+    x = np.array([-0.5, 0.2, 1.0, 2.3])
+    df1 = 4
+    df2 = 11
+    nc = 0
+    expected_cdf = stats.f.cdf(x, df1, df2)
+    calculated_cdf = stats.ncf.cdf(x, df1, df2, nc)
+    assert_allclose(expected_cdf, calculated_cdf, rtol=1e-14)
+
+    # when ncf_gen._skip_pdf will be used instead of generic pdf,
+    # this additional test will be useful.
+    expected_pdf = stats.f.pdf(x, df1, df2)
+    calculated_pdf = stats.ncf.pdf(x, df1, df2, nc)
+    assert_allclose(expected_pdf, calculated_pdf, rtol=1e-6)
+
+
 def test_ncf_variance():
     # Regression test for gh-10658 (incorrect variance formula for ncf).
     # The correct value of ncf.var(2, 6, 4), 42.75, can be verified with, for


### PR DESCRIPTION
#### Reference issue
Closes gh-11660

#### What does this implement/fix?
Non-central Fisher distribution (`ncf`) doesn't work for nc=0 and return nan-values.
Adding custom argument checking method to the class `gen_ncf` resolves the problem.

#### Additional information
 No additional information.