### PR TITLE
ENH: Add wrapper for ?gtsvx

### DIFF
--- a/scipy/linalg/flapack_gen_tri.pyf.src
+++ b/scipy/linalg/flapack_gen_tri.pyf.src
@@ -64,3 +64,40 @@ subroutine <prefix>gttrs(trans, n, nrhs, dl, d, du, du2, ipiv, b, ldb, info)
     integer    intent(out) :: info
 
 end subroutine gttrs
+
+
+subroutine <prefix2>gtsvx(fact,trans,n,nrhs,dl,d,du,dlf,df,duf,du2,ipiv,b,ldb,x,ldx,rcond,ferr,berr,work,iwork,info)
+    ! DGTSVX uses the LU factorization to compute the solution to a real
+    ! system of linear equations A * X = B or A**T * X = B,
+    ! where A is a tridiagonal matrix of order N and X and B are N-by-NRHS
+    ! matrices.
+    !
+    ! Error bounds on the solution and a condition estimate are also
+    !provided.
+    callstatement (*f2py_func)(fact,trans,&n,&nrhs,dl,d,du,dlf,df,duf,du2,ipiv,b,&ldb,x,&ldx,&rcond,ferr,berr,work,iwork,&info);
+    callprotoargument char*,char*,int*,int*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,int*,int*
+
+    character optional, intent(in), check(*fact=='F'||*fact=='N') :: fact = 'N'
+    character optional, intent(in), check(*trans=='N'||*trans=='C'||*trans=='T') :: trans = 'N'
+    integer intent(hide), depend(d), check(n > 1) :: n = len(d)
+    integer intent(hide), depend(b) :: nrhs = max(1, shape(b, 1))
+    <ftype2> intent(in), depend(n), dimension(n-1) :: dl
+    <ftype2> intnet(in), dimension(n) :: d
+    <ftype2> intent(in), depend(n), dimension(n-1) :: du
+    <ftype2> optional, intent(in,out), depend(n), dimension(n-1) :: dlf
+    <ftype2> optional, intent(in,out), depend(n), dimension(n) :: df
+    <ftype2> optional, intent(in,out), depend(n), dimension(n-1) :: duf
+    <ftype2> optional, intent(in,out), depend(n), dimension(n-2) :: du2
+    integer optional, intent(in,out), depend(n), dimension(n) :: ipiv
+    <ftype2> intent(in), dimension(ldb, nrhs) :: b
+    integer intent(hide), depend(b), check(ldb >= n) :: ldb = max(1, shape(b, 0))
+    <ftype2> dimension(n,nrhs),depend(n,nrhs),intent(out) :: x
+    integer intent(hide), depend(n) :: ldx = n
+    <ftype2> intent(out) :: rcond
+    <ftype2> intent(out),dimension(nrhs),depend(nrhs) :: ferr
+    <ftype2> intent(out),dimension(nrhs),depend(nrhs) :: berr
+    <ftype2> dimension(3*n),depend(n),intent(hide,cache) :: work
+    integer intent(hide,cache),dimension(n),depend(n) :: iwork
+    integer intent(out) :: info
+
+end subroutine <prefix2>gtsvx

--- a/scipy/linalg/flapack_gen_tri.pyf.src
+++ b/scipy/linalg/flapack_gen_tri.pyf.src
@@ -102,7 +102,7 @@ subroutine <prefix2>gtsvx(fact,trans,n,nrhs,dl,d,du,dlf,df,duf,du2,ipiv,b,ldb,x,
 
 end subroutine <prefix2>gtsvx
 
-subroutine <prefix2c>gtsvx(fact,trans,n,nrhs,dl,d,du,dlf,df,duf,du2,ipiv,b,ldb,x,ldx,rcond,ferr,berr,work,iwork,info)
+subroutine <prefix2c>gtsvx(fact,trans,n,nrhs,dl,d,du,dlf,df,duf,du2,ipiv,b,ldb,x,ldx,rcond,ferr,berr,work,rwork,info)
     ! ?GTSVX uses the LU factorization to compute the solution to a
     ! complex system of linear equations A * X = B or A**T * X = B,
     ! where A is a tridiagonal matrix of order N and X and B are N-by-NRHS
@@ -110,7 +110,7 @@ subroutine <prefix2c>gtsvx(fact,trans,n,nrhs,dl,d,du,dlf,df,duf,du2,ipiv,b,ldb,x
     !
     ! Error bounds on the solution and a condition estimate are also
     !provided.
-    callstatement (*f2py_func)(fact,trans,&n,&nrhs,dl,d,du,dlf,df,duf,du2,ipiv,b,&ldb,x,&ldx,&rcond,ferr,berr,work,iwork,&info);
+    callstatement (*f2py_func)(fact,trans,&n,&nrhs,dl,d,du,dlf,df,duf,du2,ipiv,b,&ldb,x,&ldx,&rcond,ferr,berr,work,rwork,&info);
     callprotoargument char*,char*,int*,int*,<ctype2c>*,<ctype2c>*,<ctype2c>*,<ctype2c>*,<ctype2c>*,<ctype2c>*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2c>*,<ctype2>*,int*
 
     character optional, intent(in), check(*fact=='F'||*fact=='N') :: fact = 'N'
@@ -133,7 +133,7 @@ subroutine <prefix2c>gtsvx(fact,trans,n,nrhs,dl,d,du,dlf,df,duf,du2,ipiv,b,ldb,x
     <ftype2> intent(out),dimension(nrhs),depend(nrhs) :: ferr
     <ftype2> intent(out),dimension(nrhs),depend(nrhs) :: berr
     <ftype2c> dimension(2*n),depend(n),intent(hide,cache) :: work
-    <ftype2> intent(hide,cache),dimension(n),depend(n) :: iwork
+    <ftype2> intent(hide,cache),dimension(n),depend(n) :: rwork
     integer intent(out) :: info
 
 end subroutine <prefix2c>gtsvx

--- a/scipy/linalg/flapack_gen_tri.pyf.src
+++ b/scipy/linalg/flapack_gen_tri.pyf.src
@@ -67,7 +67,7 @@ end subroutine gttrs
 
 
 subroutine <prefix2>gtsvx(fact,trans,n,nrhs,dl,d,du,dlf,df,duf,du2,ipiv,b,ldb,x,ldx,rcond,ferr,berr,work,iwork,info)
-    ! DGTSVX uses the LU factorization to compute the solution to a real
+    ! ?GTSVX uses the LU factorization to compute the solution to a real
     ! system of linear equations A * X = B or A**T * X = B,
     ! where A is a tridiagonal matrix of order N and X and B are N-by-NRHS
     ! matrices.

--- a/scipy/linalg/flapack_gen_tri.pyf.src
+++ b/scipy/linalg/flapack_gen_tri.pyf.src
@@ -101,3 +101,39 @@ subroutine <prefix2>gtsvx(fact,trans,n,nrhs,dl,d,du,dlf,df,duf,du2,ipiv,b,ldb,x,
     integer intent(out) :: info
 
 end subroutine <prefix2>gtsvx
+
+subroutine <prefix2c>gtsvx(fact,trans,n,nrhs,dl,d,du,dlf,df,duf,du2,ipiv,b,ldb,x,ldx,rcond,ferr,berr,work,iwork,info)
+    ! ?GTSVX uses the LU factorization to compute the solution to a
+    ! complex system of linear equations A * X = B or A**T * X = B,
+    ! where A is a tridiagonal matrix of order N and X and B are N-by-NRHS
+    ! matrices.
+    !
+    ! Error bounds on the solution and a condition estimate are also
+    !provided.
+    callstatement (*f2py_func)(fact,trans,&n,&nrhs,dl,d,du,dlf,df,duf,du2,ipiv,b,&ldb,x,&ldx,&rcond,ferr,berr,work,iwork,&info);
+    callprotoargument char*,char*,int*,int*,<ctype2c>*,<ctype2c>*,<ctype2c>*,<ctype2c>*,<ctype2c>*,<ctype2c>*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2c>*,<ctype2>*,int*
+
+    character optional, intent(in), check(*fact=='F'||*fact=='N') :: fact = 'N'
+    character optional, intent(in), check(*trans=='N'||*trans=='C'||*trans=='T') :: trans = 'N'
+    integer intent(hide), depend(d), check(n > 1) :: n = len(d)
+    integer intent(hide), depend(b) :: nrhs = max(1, shape(b, 1))
+    <ftype2c> intent(in), depend(n), dimension(n-1) :: dl
+    <ftype2c> intnet(in), dimension(n) :: d
+    <ftype2c> intent(in), depend(n), dimension(n-1) :: du
+    <ftype2c> optional, intent(in,out), depend(n), dimension(n-1) :: dlf
+    <ftype2c> optional, intent(in,out), depend(n), dimension(n) :: df
+    <ftype2c> optional, intent(in,out), depend(n), dimension(n-1) :: duf
+    <ftype2c> optional, intent(in,out), depend(n), dimension(n-2) :: du2
+    integer optional, intent(in,out), depend(n), dimension(n) :: ipiv
+    <ftype2c> intent(in), dimension(ldb, nrhs) :: b
+    integer intent(hide), depend(b), check(ldb >= n) :: ldb = max(1, shape(b, 0))
+    <ftype2c> dimension(n,nrhs),depend(n,nrhs),intent(out) :: x
+    integer intent(hide), depend(n) :: ldx = n
+    <ftype2> intent(out) :: rcond
+    <ftype2> intent(out),dimension(nrhs),depend(nrhs) :: ferr
+    <ftype2> intent(out),dimension(nrhs),depend(nrhs) :: berr
+    <ftype2c> dimension(2*n),depend(n),intent(hide,cache) :: work
+    <ftype2> intent(hide,cache),dimension(n),depend(n) :: iwork
+    integer intent(out) :: info
+
+end subroutine <prefix2c>gtsvx

--- a/scipy/linalg/flapack_gen_tri.pyf.src
+++ b/scipy/linalg/flapack_gen_tri.pyf.src
@@ -29,13 +29,13 @@ subroutine <prefix>gttrf(n, dl, d, du, du2, ipiv, info)
     callstatement (*f2py_func)(&n, dl, d, du, du2, ipiv, &info)
     callprotoargument int*, <ctype>*, <ctype>*, <ctype>*, <ctype>*, int*, int*
 
-    integer intent(hide),   depend(d) :: n = max(3, len(d))
+    integer intent(hide), depend(d) :: n = max(3, len(d))
     <ftype> intent(in,out,copy), depend(n), dimension(n-1) :: dl
-    <ftype> intent(in,out,copy),            dimension(n)   :: d
+    <ftype> intent(in,out,copy), dimension(n) :: d
     <ftype> intent(in,out,copy), depend(n), dimension(n-1) :: du
-    <ftype> intent(out),    depend(n), dimension(n-2)    :: du2
-    integer intent(out),    depend(n), dimension(n)      :: ipiv
-    integer intent(out)                                  :: info
+    <ftype> intent(out), depend(n), dimension(n-2) :: du2
+    integer intent(out), depend(n), dimension(n) :: ipiv
+    integer intent(out) :: info
 
 end subroutine <prefix>gttrf
 
@@ -51,17 +51,17 @@ subroutine <prefix>gttrs(trans, n, nrhs, dl, d, du, du2, ipiv, b, ldb, info)
     callprotoargument char*, int*, int*, <ctype>*, <ctype>*, <ctype>*, <ctype>*, int*, <ctype>*, int*, int*
     threadsafe
 
-    character  optional, intent(in), check(*trans=='N'||*trans=='T'||*trans=='C') :: trans = "N"
-    integer    intent(hide), depend(d) :: n = max(3, len(d))
-    integer    intent(hide), depend(b) :: nrhs = max(1, shape(b, 1))
-    integer    intent(hide), depend(n) :: ldb = max(1, n)
-    <ftype>    intent(in), depend(n), dimension(n - 1) :: dl
-    <ftype>    intent(in),            dimension(n)     :: d
-    <ftype>    intent(in), depend(n), dimension(n - 1) :: du
-    <ftype>    intent(in), depend(n), dimension(n - 2) :: du2
-    integer    intent(in), depend(n), dimension(n)     :: ipiv
-    <ftype>    intent(in, out, copy, out=x), dimension(ldb, nrhs) :: b
-    integer    intent(out) :: info
+    character optional, intent(in), check(*trans=='N'||*trans=='T'||*trans=='C') :: trans = "N"
+    integer intent(hide), depend(d) :: n = max(3, len(d))
+    integer intent(hide), depend(b) :: nrhs = max(1, shape(b, 1))
+    integer intent(hide), depend(n) :: ldb = max(1, n)
+    <ftype> intent(in), depend(n), dimension(n - 1) :: dl
+    <ftype> intent(in), dimension(n) :: d
+    <ftype> intent(in), depend(n), dimension(n - 1) :: du
+    <ftype> intent(in), depend(n), dimension(n - 2) :: du2
+    integer intent(in), depend(n), dimension(n) :: ipiv
+    <ftype> intent(in, out, copy, out=x), dimension(ldb, nrhs) :: b
+    integer intent(out) :: info
 
 end subroutine gttrs
 
@@ -79,28 +79,29 @@ subroutine <prefix2>gtsvx(fact,trans,n,nrhs,dl,d,du,dlf,df,duf,du2,ipiv,b,ldb,x,
 
     character optional, intent(in), check(*fact=='F'||*fact=='N') :: fact = 'N'
     character optional, intent(in), check(*trans=='N'||*trans=='C'||*trans=='T') :: trans = 'N'
-    integer intent(hide), depend(d), check(n > 1) :: n = len(d)
-    integer intent(hide), depend(b) :: nrhs = max(1, shape(b, 1))
-    <ftype2> intent(in), depend(n), dimension(n-1) :: dl
+    integer intent(hide), depend(d) :: n = len(d)
+    integer intent(hide), depend(b) :: nrhs = shape(b, 1)
+    <ftype2> intent(in), depend(n), dimension(MAX(0, n-1)) :: dl
     <ftype2> intnet(in), dimension(n) :: d
-    <ftype2> intent(in), depend(n), dimension(n-1) :: du
-    <ftype2> optional, intent(in,out), depend(n), dimension(n-1) :: dlf
+    <ftype2> intent(in), depend(n), dimension(MAX(0, n-1)) :: du
+    <ftype2> optional, intent(in,out), depend(n), dimension(MAX(0,n-1)) :: dlf
     <ftype2> optional, intent(in,out), depend(n), dimension(n) :: df
-    <ftype2> optional, intent(in,out), depend(n), dimension(n-1) :: duf
-    <ftype2> optional, intent(in,out), depend(n), dimension(n-2) :: du2
+    <ftype2> optional, intent(in,out), depend(n), dimension(MAX(0,n-1)) :: duf
+    <ftype2> optional, intent(in,out), depend(n), dimension(MAX(0,n-2)) :: du2
     integer optional, intent(in,out), depend(n), dimension(n) :: ipiv
     <ftype2> intent(in), dimension(ldb, nrhs) :: b
-    integer intent(hide), depend(b), check(ldb >= n) :: ldb = max(1, shape(b, 0))
-    <ftype2> dimension(n,nrhs),depend(n,nrhs),intent(out) :: x
-    integer intent(hide), depend(n) :: ldx = n
+    integer intent(hide), check(ldb >= n), depend(b) :: ldb = max(1, shape(b, 0))
+    <ftype2> intent(out), dimension(ldx,nrhs) :: x
+    integer intent(hide) :: ldx = MAX(1, shape(b, 0))
     <ftype2> intent(out) :: rcond
-    <ftype2> intent(out),dimension(nrhs),depend(nrhs) :: ferr
-    <ftype2> intent(out),dimension(nrhs),depend(nrhs) :: berr
-    <ftype2> dimension(3*n),depend(n),intent(hide,cache) :: work
-    integer intent(hide,cache),dimension(n),depend(n) :: iwork
+    <ftype2> intent(out), dimension(nrhs),depend(nrhs) :: ferr
+    <ftype2> intent(out), dimension(nrhs),depend(nrhs) :: berr
+    <ftype2> intent(hide, cache), dimension(3*n),depend(n) :: work
+    integer intent(hide, cache), dimension(n), depend(n) :: iwork
     integer intent(out) :: info
 
 end subroutine <prefix2>gtsvx
+
 
 subroutine <prefix2c>gtsvx(fact,trans,n,nrhs,dl,d,du,dlf,df,duf,du2,ipiv,b,ldb,x,ldx,rcond,ferr,berr,work,rwork,info)
     ! ?GTSVX uses the LU factorization to compute the solution to a
@@ -115,23 +116,23 @@ subroutine <prefix2c>gtsvx(fact,trans,n,nrhs,dl,d,du,dlf,df,duf,du2,ipiv,b,ldb,x
 
     character optional, intent(in), check(*fact=='F'||*fact=='N') :: fact = 'N'
     character optional, intent(in), check(*trans=='N'||*trans=='C'||*trans=='T') :: trans = 'N'
-    integer intent(hide), depend(d), check(n > 1) :: n = len(d)
-    integer intent(hide), depend(b) :: nrhs = max(1, shape(b, 1))
-    <ftype2c> intent(in), depend(n), dimension(n-1) :: dl
+    integer intent(hide), depend(d) :: n = len(d)
+    integer intent(hide), depend(b) :: nrhs = shape(b, 1)
+    <ftype2c> intent(in), depend(n), dimension(MAX(0, n-1)) :: dl
     <ftype2c> intnet(in), dimension(n) :: d
-    <ftype2c> intent(in), depend(n), dimension(n-1) :: du
-    <ftype2c> optional, intent(in,out), depend(n), dimension(n-1) :: dlf
+    <ftype2c> intent(in), depend(n), dimension(MAX(0, n-1)) :: du
+    <ftype2c> optional, intent(in,out), depend(n), dimension(MAX(0,n-1)) :: dlf
     <ftype2c> optional, intent(in,out), depend(n), dimension(n) :: df
-    <ftype2c> optional, intent(in,out), depend(n), dimension(n-1) :: duf
-    <ftype2c> optional, intent(in,out), depend(n), dimension(n-2) :: du2
+    <ftype2c> optional, intent(in,out), depend(n), dimension(MAX(0,n-1)) :: duf
+    <ftype2c> optional, intent(in,out), depend(n), dimension(MAX(0,n-2)) :: du2
     integer optional, intent(in,out), depend(n), dimension(n) :: ipiv
     <ftype2c> intent(in), dimension(ldb, nrhs) :: b
-    integer intent(hide), depend(b), check(ldb >= n) :: ldb = max(1, shape(b, 0))
-    <ftype2c> dimension(n,nrhs),depend(n,nrhs),intent(out) :: x
-    integer intent(hide), depend(n) :: ldx = n
+    integer intent(hide), check(ldb >= n), depend(b) :: ldb = max(1, shape(b, 0))
+    <ftype2c> intent(out), dimension(ldx,nrhs) :: x
+    integer intent(hide) :: ldx = MAX(1, shape(b, 0))
     <ftype2> intent(out) :: rcond
-    <ftype2> intent(out),dimension(nrhs),depend(nrhs) :: ferr
-    <ftype2> intent(out),dimension(nrhs),depend(nrhs) :: berr
+    <ftype2> intent(out), dimension(nrhs),depend(nrhs) :: ferr
+    <ftype2> intent(out), dimension(nrhs),depend(nrhs) :: berr
     <ftype2c> dimension(2*n),depend(n),intent(hide,cache) :: work
     <ftype2> intent(hide,cache),dimension(n),depend(n) :: rwork
     integer intent(out) :: info

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -270,6 +270,8 @@ All functions
 
    sgtsvx
    dgtsvx
+   cgtsvx
+   zgtsvx
 
    chbevd
    zhbevd

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -268,6 +268,9 @@ All functions
    cgtsv
    zgtsv
 
+   sgtsvx
+   dgtsvx
+
    chbevd
    zhbevd
 

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -2503,7 +2503,7 @@ def test_gtsvx_error_incompatible_size(dtype, trans, fact, dl_d_du_lambda):
         assert_raises(ValueError, gtsvx, dl, d, du[:-1], b,
                       fact=fact, trans=trans, dlf=dlf_, df=df_,
                       duf=duf_, du2=du2f_, ipiv=ipiv_)
-        assert_raises(ValueError, gtsvx, dl, d, du, b[:-1],
+        assert_raises(Exception, gtsvx, dl, d, du, b[:-1],
                       fact=fact, trans=trans, dlf=dlf_, df=df_,
                       duf=duf_, du2=du2f_, ipiv=ipiv_)
     else:

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -2115,7 +2115,7 @@ def test_pttrf_pttrs_NAG(d, e, d_expect, e_expect, b, x_expect):
     # examples: f07jrf and f07csf (complex)
     # NAG examples provide 4 decimals.
     # (Links expire, so please search for "NAG Library Manual Mark 26" online)
-    
+
     atol = 1e-4
     pttrf = get_lapack_funcs('pttrf', dtype=e[0])
     _d, _e, info = pttrf(d, e)
@@ -2125,12 +2125,12 @@ def test_pttrf_pttrs_NAG(d, e, d_expect, e_expect, b, x_expect):
     pttrs = get_lapack_funcs('pttrs', dtype=e[0])
     _x, info = pttrs(_d, _e.conj(), b)
     assert_allclose(_x, x_expect, atol=atol)
-    
+
     # also test option `lower`
     if e.dtype in COMPLEX_DTYPES:
         _x, info = pttrs(_d, _e, b, lower=1)
         assert_allclose(_x, x_expect, atol=atol)
-        
+
 
 
 @pytest.mark.parametrize('dtype', DTYPES)
@@ -2296,3 +2296,105 @@ def test_orcsd_uncsd(dtype_):
 
     Xc = U @ S @ VH
     assert_allclose(X, Xc, rtol=0., atol=1e4*np.finfo(dtype_).eps)
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("fact,dl_d_du_lambda",
+                         [("F", lambda dl, d, du: get_lapack_funcs('gttrf',
+                            dtype=d.dtype)),
+                          ("N", lambda dl, d, du: (None, None, None, None,
+                                                   None))])
+def test_gtsvx(dtype, fact, dl_d_du_lambda):
+    dtype = DTYPES[0]
+    np.random.seed(42)
+    # set test tolerance appropriate for dtype
+    rtol = 250 * np.finfo(dtype).eps
+    atol = 100 * np.finfo(dtype).eps
+    # obtain routine
+    gtsvx = get_lapack_funcs('gtsvx', dtype=dtype)
+    # n is the length diagonal of A
+    n = 10
+    # generate facots dl, d, and du.
+    dl = generate_random_dtype_array((n-1,), dtype=dtype)
+    d = generate_random_dtype_array((n,), dtype=dtype)
+    du = generate_random_dtype_array((n-1,), dtype=dtype)
+    # create A from these diagonals
+    A = np.diag(dl, -1) + np.diag(d) + np.diag(du, 1)
+    # generate random solution x
+    x = generate_random_dtype_array((n, 2), dtype=dtype)
+    # create b from x for equation Ax=b
+    b = A @ x
+    inputs_cpy = [dl.copy(), d.copy(), du.copy(), b.copy()]
+
+    # determine dlf, df, duf, du2f, and IPIV from lambda expression
+    dlf_, df_, duf_, du2f_, ipiv_ = dl_d_du_lambda(dl, d, du)
+
+    gtsvx_out = gtsvx(dl, d, du, b, fact=fact, dlf=dlf_, df=df_, duf=duf_,
+                      du2=du2f_, ipiv=ipiv_)
+    # assure that inputs are unmodified
+    assert_array_equal(dl, inputs_cpy[0])
+    assert_array_equal(d, inputs_cpy[1])
+    assert_array_equal(du, inputs_cpy[2])
+    assert_array_equal(b, inputs_cpy[3])
+
+    x_soln, dlf, df, duf, du2f, ipiv, rcond, ferr, berr, info = gtsvx_out
+
+    # note that these are split into multiple lines since it was very long
+
+    U = np.diag(df, 0) + np.diag(duf, 1) + np.diag(du2f, 2)
+    L = np.eye(n, dtype=dtype)
+
+    for i, m in enumerate(dlf):
+        # L is given in a factored form.
+        # See http://www.hpcavf.uclan.ac.uk/softwaredoc/sgi_scsl_html/sgi_html/ch03.html
+        piv = ipiv[i] - 1
+        # right multiply by permutation matrix
+        L[:, [i, piv]] = L[:, [piv, i]]
+        # right multiply by Li, rank-one modification of identity
+        L[:, i] += L[:, i+1]*m
+
+    # one last permutation
+    i, piv = -1, ipiv[-1] - 1
+    # right multiply by final permutation matrix
+    L[:, [i, piv]] = L[:, [piv, i]]
+
+    # check that the outputs define an LU decomposition of A
+    assert_allclose(A, L @ U, atol=atol)
+
+    # assert that the outputs are of correct type or shape
+    # rcond should be a scalar
+    assert_(hasattr(rcond, "__len__") != True,
+            "rcond should be scalar but is {}".format(rcond))
+    # ferr should be length of # of cols in x
+    assert_(ferr.shape[0] == b.shape[1], "ferr.shape is {} but shoud be {},"
+            .format(ferr.shape[0], b.shape[1]))
+    # berr should be length of # of cols in x
+    assert_(berr.shape[0] == b.shape[1], "berr.shape is {} but shoud be {},"
+            .format(berr.shape[0], b.shape[1]))
+
+    # test with singular matrix
+    # no need to test with fact "F" since ?pttrf already tests for these.
+    if fact == "N":
+        d[n-1] = 0
+        dl[n-2] = 0
+
+        # solve using routine
+        gtsvx_out = gtsvx(dl, d, du, b)
+        x_soln, dlf, df, duf, du2f, ipiv, rcond, ferr, berr, info = gtsvx_out
+        # test for the singular matrix.
+        assert_(d[info - 1] == 0,
+                "?gtsvx: d[info-1] is {}, not the illegal value"
+                .format(d[info - 1]))
+
+    else:
+        # assuming that someone is using a singular factorization
+        df[n-1] = 0
+        duf[n-2] = 0
+
+        gtsvx_out = gtsvx(dl, d, du, b, fact=fact, dlf=dlf_, df=df_, duf=duf_,
+                          du2=du2f_, ipiv=ipiv_)
+        x_soln, dlf, df, duf, du2f, ipiv, rcond, ferr, berr, info = gtsvx_out
+        # info should not be zero and should provide index of illegal value
+        assert_(df[info - 1] == 0,
+                "?gtsvx: df[info-1] is {}, not the illegal value"
+                .format(d[info - 1]))

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -924,33 +924,54 @@ class TestHetrd(object):
 
 class TestGtsvx:
 
-    @pytest.mark.parametrize('dtype', REAL_DTYPES)
-    def test_nag_f07cbf(self, dtype):
+    @pytest.mark.parametrize('dtype', DTYPES)
+    def test_nag_example(self, dtype):
         """Find the solution that satisfies the set of equations Ax=b.
 
         For the full reference see:
-        https://www.nag.com/numeric/fl/nagdoc_latest/examples/source/f07cbf.html
-
+        https://www.nag.com/numeric/fl/nagdoc_latest/html/f07/f07cbf.html
+        https://www.nag.com/numeric/fl/nagdoc_latest/html/f07/f07cpf.html
         """
-        du = np.array([2.1, -1.0, 1.9, 8.0], dtype=dtype)
-        d = np.array([3.0, 2.3, -5.0, -0.9, 7.1], dtype=dtype)
-        dl = np.array([3.4, 3.6, 7.0, -6.0], dtype=dtype)
-        b = np.array([[2.7, 6.6],
-                      [-0.5, 10.8],
-                      [2.6, -3.2],
-                      [0.6, -11.2],
-                      [2.7, 19.1]])
 
+        if dtype in REAL_DTYPES:
+            du = (2.1, -1.0, 1.9, 8.0)
+            d = (3.0, 2.3, -5.0, -0.9, 7.1)
+            dl = (3.4, 3.6, 7.0, -6.0)
+            b = ((2.7, 6.6),
+                 (-0.5, 10.8),
+                 (2.6, -3.2),
+                 (0.6, -11.2),
+                 (2.7, 19.1))
+            x_ = ((-4.0000, 5.0000),
+                  (7.0000, -4.0000),
+                  (3.0000, -3.0000),
+                  (-4.0000, -2.0000),
+                  (-3.0000, 1.0000))
+        elif dtype in COMPLEX_DTYPES:
+            du = (2.0 - 1.0j, 2.0 + 1.0j, -1.0 + 1.0j, 1.0 - 1.0j)
+            d = (-1.3 + 1.3j, -1.3 + 1.3j, -1.3 + 3.3j, -0.3 + 4.3j,
+                 -3.3 + 1.3j)
+            dl = (1.0 - 2.0j, 1.0 + 1.0j, 2.0 - 3.0j, 1.0 + 1.0j)
+            b = ((2.4 - 5.0j, 2.7 + 6.9j),
+                 (3.4 - 18.2j, -6.9 - 5.3j),
+                 (-14.7 - 9.7j, -6.0 - 0.6j),
+                 (31.9 - 7.7j, -3.9 + 9.3j),
+                 (-1.0 - 1.6j, -3.0 + 12.2j))
+            x_ = ((1.0 + 1.0j, 2.0 - 1.0j),
+                  (3.0 - 1.0j, 1.0 + 2.0j),
+                  (4.0 + 5.0j, -1.0 + 1.0j),
+                  (-1.0 - 2.0j, 2.0 + 1.0j),
+                  (1.0 - 1.0j, 2.0 - 2.0j))
+        else:
+            raise ValueError(f'{dtype} is neither real nor complex.')
+
+        du, d, dl, b, x_ = [np.asarray(a, dtype=dtype)
+                            for a in (du, d, dl, b, x_)]
         gtsvx = get_lapack_funcs('gtsvx', dtype=dtype)
-        dlf,df,duf,du2,ipiv,x,rcond,ferr,berr,info = gtsvx(dl,d,du,b,fact='N')
-
+        dlf, df, duf, du2, ip, x, rc, f, b, info = gtsvx(dl, d, du, b, fact='N')
         assert_equal(info, 0)
-        assert_allclose(x, [[-4.0000,  5.0000],
-                            [ 7.0000, -4.0000],
-                            [ 3.0000, -3.0000],
-                            [-4.0000, -2.0000],
-                            [-3.0000,  1.0000]],
-                        atol=1e-5)
+        assert_allclose(x, x_, atol=1e-5)
+
 
 def test_gglse():
     # Example data taken from NAG manual

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -2437,8 +2437,8 @@ def test_gtsvx_error_singular(dtype, trans, fact, dl_d_du_lambda):
         L, U = gttrf_to_lu(n, dtype, dlf, df, duf, du2f, ipiv)
         # check that the outputs define an LU decomposition of A
         assert_allclose(A, L @ U, atol=atol, rtol=rtol)
-        d[n-1] = 0
-        dl[n-2] = 0
+        d[-1] = 0
+        dl[-1] = 0
 
         # solve using routine
         gtsvx_out = gtsvx(dl, d, du, b)
@@ -2449,8 +2449,8 @@ def test_gtsvx_error_singular(dtype, trans, fact, dl_d_du_lambda):
     elif fact == 'F':
         # assuming that a singular factorization is input
         df_[-1] = 0
-        duf_[n-2] = 0
-        du2f_[n-3] = 0
+        duf_[-1] = 0
+        du2f_[-1] = 0
 
         gtsvx_out = gtsvx(dl, d, du, b, fact=fact, dlf=dlf_, df=df_, duf=duf_,
                           du2=du2f_, ipiv=ipiv_)

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -922,6 +922,36 @@ class TestHetrd(object):
             )
 
 
+class TestGtsvx:
+
+    @pytest.mark.parametrize('dtype', REAL_DTYPES)
+    def test_nag_f07cbf(self, dtype):
+        """Find the solution that satisfies the set of equations Ax=b.
+
+        For the full reference see:
+        https://www.nag.com/numeric/fl/nagdoc_latest/examples/source/f07cbf.html
+
+        """
+        du = np.array([2.1, -1.0, 1.9, 8.0], dtype=dtype)
+        d = np.array([3.0, 2.3, -5.0, -0.9, 7.1], dtype=dtype)
+        dl = np.array([3.4, 3.6, 7.0, -6.0], dtype=dtype)
+        b = np.array([[2.7, 6.6],
+                      [-0.5, 10.8],
+                      [2.6, -3.2],
+                      [0.6, -11.2],
+                      [2.7, 19.1]])
+
+        gtsvx = get_lapack_funcs('gtsvx', dtype=dtype)
+        dlf,df,duf,du2,ipiv,x,rcond,ferr,berr,info = gtsvx(dl,d,du,b,fact='N')
+
+        assert_equal(info, 0)
+        assert_allclose(x, [[-4.0000,  5.0000],
+                            [ 7.0000, -4.0000],
+                            [ 3.0000, -3.0000],
+                            [-4.0000, -2.0000],
+                            [-3.0000,  1.0000]],
+                        atol=1e-5)
+
 def test_gglse():
     # Example data taken from NAG manual
     for ind, dtype in enumerate(DTYPES):

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -2081,7 +2081,6 @@ def test_pttrf_pttrs_NAG(d, e, d_expect, e_expect, b, x_expect):
         assert_allclose(_x, x_expect, atol=atol)
 
 
-
 @pytest.mark.parametrize('dtype', DTYPES)
 @pytest.mark.parametrize('matrix_size', [(3, 4), (7, 6), (6, 6)])
 def test_geqrfp(dtype, matrix_size):
@@ -2469,7 +2468,7 @@ def test_gtsvx_error_incompatible_size(dtype, trans, fact):
                                      [-14.7 + 9.7j, -6 - .6j],
                                      [31.9 - 7.7j, -3.9 + 9.3j],
                                      [-1 + 1.6j, -3 + 12.2j]]),
-                           np.array([[1 + 1j,  2 - 1j], [3 - 1j, 1 + 2j],
+                           np.array([[1 + 1j, 2 - 1j], [3 - 1j, 1 + 2j],
                                      [4 + 5j, -1 + 1j], [-1 - 2j, 2 + 1j],
                                      [1 - 1j, 2 - 2j]]))])
 def test_gtsvx_NAG(du, d, dl, b, x):


### PR DESCRIPTION
This PR adds Python level wrappers for the LAPACK function ?gtsvx as part of a NumFocus small development grant. ?gtsvx solve a linear system with general tridiagonal matrix. Importantly, it also provide error bounds on the solution and a condition estimate. SciPy already includes wrappers for the equivalent routines for other matrix types; this would help complete the set.

This closes gh-11373

Thanks to @Kai-Striega for writing the wrapper and @swallan for writing the tests. (I'm just creating the PR.) 