### PR TITLE
Add warning to medfilt when array size < kernel_size

### DIFF
--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1379,10 +1379,10 @@ def medfilt(volume, kernel_size=None):
         An array the same size as input containing the median filtered
         result.
 
-    Raises
+    Warns 
     -------
-        UserWarning
-            If array size is lesser than kernel size along any dimension
+    UserWarning
+        If array size is smaller than kernel size along any dimension
 
     See also
     --------

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -19,6 +19,7 @@ from ._arraytools import axis_slice, axis_reverse, odd_ext, even_ext, const_ext
 from .filter_design import cheby1, _validate_sos
 from .fir_filter_design import firwin
 from ._sosfilt import _sosfilt
+import warnings
 
 
 __all__ = ['correlate', 'correlate2d',
@@ -1378,6 +1379,11 @@ def medfilt(volume, kernel_size=None):
         An array the same size as input containing the median filtered
         result.
 
+    Raises
+    -------
+        UserWarning
+            If array size is lesser than kernel size along any dimension
+
     See also
     --------
     scipy.ndimage.median_filter
@@ -1397,6 +1403,11 @@ def medfilt(volume, kernel_size=None):
     for k in range(volume.ndim):
         if (kernel_size[k] % 2) != 1:
             raise ValueError("Each element of kernel_size should be odd.")
+    shape = volume.shape
+    for k in range(volume.ndim):
+        if (kernel_size[k] > shape[k]):
+            warnings.warn(f'Array size is less then kernel size '
+                          f'along axis nr. {k}, input will be zero-padded', UserWarning)
 
     domain = np.ones(kernel_size)
 

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1403,11 +1403,8 @@ def medfilt(volume, kernel_size=None):
     for k in range(volume.ndim):
         if (kernel_size[k] % 2) != 1:
             raise ValueError("Each element of kernel_size should be odd.")
-    shape = volume.shape
-    for k in range(volume.ndim):
-        if (kernel_size[k] > shape[k]):
-            warnings.warn(f'Array size is less then kernel size '
-                          f'along axis nr. {k}, input will be zero-padded', UserWarning)
+    if any(k > s for k, s in zip(kernel_size, volume.shape)):
+        warnings.warn('kernel_size exceeds volume extent: the volume will be zero-padded.')
 
     domain = np.ones(kernel_size)
 

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1034,7 +1034,8 @@ class TestMedFilt(object):
 
     def test_none(self):
         # Ticket #1124. Ensure this does not segfault.
-        signal.medfilt(None)
+        with pytest.warns(UserWarning):
+            signal.medfilt(None)
         # Expand on this test to avoid a regression with possible contiguous
         # numpy arrays that have odd strides. The stride value below gets
         # us into wrong memory if used (but it does not need to be used)
@@ -1052,8 +1053,9 @@ class TestMedFilt(object):
         else:
             n = 10
         # Shouldn't segfault:
-        for j in range(n):
-            signal.medfilt(x)
+        with pytest.warns(UserWarning):
+            for j in range(n):
+                signal.medfilt(x)
         if hasattr(sys, 'getrefcount'):
             assert_(sys.getrefcount(a) < n)
         assert_equal(x, [a, a])


### PR DESCRIPTION
Warn when array size is lesser than kernel size along any axis



<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #11503 

#### What does this implement/fix?
<!--Please explain your changes.-->
After this change user will be notified in case when provided array should be zero-padded

#### Additional information
<!--Any additional information you think is important.-->
As far as I can see, failing tests do not depend on changes which have been made.