### PR TITLE
TST: bump test precision for two np.dot related linalg tests.

### DIFF
--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -726,8 +726,8 @@ class TestCurveFit(object):
                 popt2, pcov2 = curve_fit(funcp, xdata, ydatap, sigma=covarp,
                         jac=jac2, absolute_sigma=absolute_sigma)
 
-                assert_allclose(popt1, popt2, atol=1e-14)
-                assert_allclose(pcov1, pcov2, atol=1e-14)
+                assert_allclose(popt1, popt2, rtol=1.2e-7, atol=1e-14)
+                assert_allclose(pcov1, pcov2, rtol=1.2e-7, atol=1e-14)
 
     def test_dtypes(self):
         # regression test for gh-9581: curve_fit fails if x and y dtypes differ

--- a/scipy/sparse/linalg/tests/test_pydata_sparse.py
+++ b/scipy/sparse/linalg/tests/test_pydata_sparse.py
@@ -72,7 +72,7 @@ def test_lsmr(matrices):
     A_dense, A_sparse, b = matrices
     res0 = splin.lsmr(A_dense, b)
     res = splin.lsmr(A_sparse, b)
-    assert_allclose(res[0], res0[0], atol=1e-5)
+    assert_allclose(res[0], res0[0], atol=1.8e-5)
 
 
 def test_lsqr(matrices):


### PR DESCRIPTION
Only happens for --pre CI runs, it seems related to a new OpenBLAS
build in the NumPy nightly wheels. It's quite hard to reproduce locally
though.

Closes gh-11652