### PR TITLE
ENH: Add wrapper for ?ptsvx

### DIFF
--- a/scipy/linalg/flapack_pos_def_tri.pyf.src
+++ b/scipy/linalg/flapack_pos_def_tri.pyf.src
@@ -133,7 +133,7 @@ subroutine <prefix2>ptsvx(fact, n, nrhs, d, e, df, ef, b, ldb, x, ldx, rcond, fe
     <ftype2> intent(in), dimension(n) :: d
     <ftype2> intent(in), depend(n), dimension(n-1) :: e
     <ftype2> optional, intent(in,out), depend(n), dimension(n) :: df
-    <ftype2> optional, intent(in,out), depend(n), dimension(n) :: ef
+    <ftype2> optional, intent(in,out), depend(n), dimension(n-1) :: ef
     <ftype2> intent(in), dimension(ldb, nrhs) :: b
     integer intent(hide), depend(b) :: ldb = max(1, shape(b, 0))
     <ftype2> intent(out), dimension(ldx, nrhs) :: x
@@ -164,7 +164,7 @@ subroutine <prefix2c>ptsvx(fact, n, nrhs, d, e, df, ef, b, ldb, x, ldx, rcond, f
     <ftype2> intent(in), dimension(n) :: d
     <ftype2c> intent(in), depend(n), dimension(n-1) :: e
     <ftype2> optional, intent(in,out), depend(n), dimension(n) :: df
-    <ftype2c> optional, intent(in,out), depend(n), dimension(n) :: ef
+    <ftype2c> optional, intent(in,out), depend(n), dimension(n-1) :: ef
     <ftype2c> intent(in), dimension(ldb, nrhs) :: b
     integer intent(hide), depend(b) :: ldb = max(1, shape(b, 0))
     <ftype2c> intent(out), dimension(ldx, nrhs) :: x

--- a/scipy/linalg/flapack_pos_def_tri.pyf.src
+++ b/scipy/linalg/flapack_pos_def_tri.pyf.src
@@ -134,7 +134,7 @@ subroutine <prefix2>ptsvx(fact, n, nrhs, d, e, df, ef, b, ldb, x, ldx, rcond, fe
     <ftype2> intent(in), depend(n), dimension(max(0, n-1)) :: e
     <ftype2> optional, intent(in,out), depend(n), dimension(n) :: df
     <ftype2> optional, intent(in,out), depend(n), dimension(max(0, n-1)) :: ef
-    <ftype2> intent(in), dimension(ldb, nrhs) :: b
+    <ftype2> intent(in), depend(n), dimension(ldb, nrhs), check(shape(b, 0) >= n):: b
     integer intent(hide), depend(b) :: ldb = max(1, shape(b, 0))
     <ftype2> intent(out), dimension(ldx, nrhs) :: x
     integer intent(hide), depend(n) :: ldx = n
@@ -165,7 +165,7 @@ subroutine <prefix2c>ptsvx(fact, n, nrhs, d, e, df, ef, b, ldb, x, ldx, rcond, f
     <ftype2c> intent(in), depend(n), dimension(max(0, n-1)) :: e
     <ftype2> optional, intent(in,out), depend(n), dimension(n) :: df
     <ftype2c> optional, intent(in,out), depend(n), dimension(max(0, n-1)) :: ef
-    <ftype2c> intent(in), dimension(ldb, nrhs) :: b
+    <ftype2c> intent(in), depend(n), dimension(ldb, nrhs), check(shape(b,0) >= n) :: b
     integer intent(hide), depend(b) :: ldb = max(1, shape(b, 0))
     <ftype2c> intent(out), dimension(ldx, nrhs) :: x
     integer intent(hide), depend(n) :: ldx = n

--- a/scipy/linalg/flapack_pos_def_tri.pyf.src
+++ b/scipy/linalg/flapack_pos_def_tri.pyf.src
@@ -128,12 +128,12 @@ subroutine <prefix2>ptsvx(fact, n, nrhs, d, e, df, ef, b, ldb, x, ldx, rcond, fe
     callprotoargument char*, int*, int*, <ctype2>*, <ctype2>*, <ctype2>*, <ctype2>*, <ctype2>*, int*, <ctype2>*, int*,  <ctype2>*, <ctype2>*, <ctype2>*, <ctype2>*, int*
 
     character optional, intent(in) :: fact = 'N'
-    integer intent(hide), depend(d) :: n = max(1, len(d))
-    integer intent(hide), depend(b) :: nrhs = max(1, shape(b, 1))
+    integer intent(hide), depend(d) :: n = len(d)
+    integer intent(hide), depend(b) :: nrhs = shape(b, 1)
     <ftype2> intent(in), dimension(n) :: d
-    <ftype2> intent(in), depend(n), dimension(n-1) :: e
+    <ftype2> intent(in), depend(n), dimension(max(0, n-1)) :: e
     <ftype2> optional, intent(in,out), depend(n), dimension(n) :: df
-    <ftype2> optional, intent(in,out), depend(n), dimension(n-1) :: ef
+    <ftype2> optional, intent(in,out), depend(n), dimension(max(0, n-1)) :: ef
     <ftype2> intent(in), dimension(ldb, nrhs) :: b
     integer intent(hide), depend(b) :: ldb = max(1, shape(b, 0))
     <ftype2> intent(out), dimension(ldx, nrhs) :: x
@@ -159,12 +159,12 @@ subroutine <prefix2c>ptsvx(fact, n, nrhs, d, e, df, ef, b, ldb, x, ldx, rcond, f
     callprotoargument char*, int*, int*, <ctype2>*, <ctype2c>*, <ctype2>*, <ctype2c>*, <ctype2c>*, int*, <ctype2c>*, int*,  <ctype2>*, <ctype2>*, <ctype2>*, <ctype2c>*, <ctype2>*, int*
 
     character optional, intent(in) :: fact = 'N'
-    integer intent(hide), depend(d) :: n = max(1, len(d))
-    integer intent(hide), depend(b) :: nrhs = max(1, shape(b, 1))
+    integer intent(hide), depend(d) :: n = len(d)
+    integer intent(hide), depend(b) :: nrhs = shape(b, 1)
     <ftype2> intent(in), dimension(n) :: d
-    <ftype2c> intent(in), depend(n), dimension(n-1) :: e
+    <ftype2c> intent(in), depend(n), dimension(max(0, n-1)) :: e
     <ftype2> optional, intent(in,out), depend(n), dimension(n) :: df
-    <ftype2c> optional, intent(in,out), depend(n), dimension(n-1) :: ef
+    <ftype2c> optional, intent(in,out), depend(n), dimension(max(0, n-1)) :: ef
     <ftype2c> intent(in), dimension(ldb, nrhs) :: b
     integer intent(hide), depend(b) :: ldb = max(1, shape(b, 0))
     <ftype2c> intent(out), dimension(ldx, nrhs) :: x

--- a/scipy/linalg/flapack_pos_def_tri.pyf.src
+++ b/scipy/linalg/flapack_pos_def_tri.pyf.src
@@ -172,8 +172,8 @@ subroutine <prefix2c>ptsvx(fact, n, nrhs, d, e, df, ef, b, ldb, x, ldx, rcond, f
     <ftype2> intent(out) :: rcond
     <ftype2> intent(out), depend(nrhs), dimension(nrhs) :: ferr
     <ftype2> intent(out), depend(nrhs), dimension(nrhs) :: berr
-    <ftype2c> intent(hide,cache), depend(n), dimension(2*n) :: work
-    <ftype2> intent(hide,cache), depend(n), dimension(2*n) :: rwork
+    <ftype2c> intent(hide,cache), depend(n), dimension(n) :: work
+    <ftype2> intent(hide,cache), depend(n), dimension(n) :: rwork
     integer intent(out) :: info
 
 end subroutine <prefix2c>ptsvx

--- a/scipy/linalg/flapack_pos_def_tri.pyf.src
+++ b/scipy/linalg/flapack_pos_def_tri.pyf.src
@@ -114,3 +114,66 @@ subroutine <prefix>pteqr(compute_z, n, d, e, z, ldz, work, info)
     integer intent(out) :: info
 
 end subroutine <prefix>pteqr
+
+
+subroutine <prefix2>ptsvx(fact, n, nrhs, d, e, df, ef, b, ldb, x, ldx, rcond, ferr, berr, work, info)
+    ! DPTSVX uses the factorization A = L*D*L**T to compute the solution
+    ! to a real system of linear equations A*X = B, where A is an N-by-N
+    ! symmetric positive definite tridiagonal matrix and X and B are
+    !N-by-NRHS matrices.
+    !
+    ! Error bounds on the solution and a condition estimate are also
+    ! provided.
+    callstatement (*f2py_func)(fact, &n, &nrhs, d, e, df, ef, b, &ldb, x, &ldx, &rcond, ferr, berr, work, &info)
+    callprotoargument char*, int*, int*, <ctype2>*, <ctype2>*, <ctype2>*, <ctype2>*, <ctype2>*, int*, <ctype2>*, int*,  <ctype2>*, <ctype2>*, <ctype2>*, <ctype2>*, int*
+
+    character optional, intent(in) :: fact = 'N'
+    integer intent(hide), depend(d) :: n = max(1, len(d))
+    integer intent(hide), depend(b) :: nrhs = max(1, shape(b, 1))
+    <ftype2> intent(in), dimension(n) :: d
+    <ftype2> intent(in), depend(n), dimension(n-1) :: e
+    <ftype2> optional, intent(in,out), depend(n), dimension(n) :: df
+    <ftype2> optional, intent(in,out), depend(n), dimension(n) :: ef
+    <ftype2> intent(in), dimension(ldb, nrhs) :: b
+    integer intent(hide), depend(b) :: ldb = max(1, shape(b, 0))
+    <ftype2> intent(out), dimension(ldx, nrhs) :: x
+    integer intent(hide), depend(n) :: ldx = n
+    <ftype2> intent(out) :: rcond
+    <ftype2> intent(out), depend(nrhs), dimension(nrhs) :: ferr
+    <ftype2> intent(out), depend(nrhs), dimension(nrhs) :: berr
+    <ftype2> intent(hide,cache), depend(n), dimension(2*n) :: work
+    integer intent(out) :: info
+
+end subroutine <prefix2>ptsvx
+
+
+subroutine <prefix2c>ptsvx(fact, n, nrhs, d, e, df, ef, b, ldb, x, ldx, rcond, ferr, berr, work, rwork, info)
+    ! DPTSVX uses the factorization A = L*D*L**T to compute the solution
+    ! to a real system of linear equations A*X = B, where A is an N-by-N
+    ! symmetric positive definite tridiagonal matrix and X and B are
+    !N-by-NRHS matrices.
+    !
+    ! Error bounds on the solution and a condition estimate are also
+    ! provided.
+    callstatement (*f2py_func)(fact, &n, &nrhs, d, e, df, ef, b, &ldb, x, &ldx, &rcond, ferr, berr, work, rwork, &info)
+    callprotoargument char*, int*, int*, <ctype2>*, <ctype2c>*, <ctype2>*, <ctype2c>*, <ctype2c>*, int*, <ctype2c>*, int*,  <ctype2>*, <ctype2>*, <ctype2>*, <ctype2c>*, <ctype2>*, int*
+
+    character optional, intent(in) :: fact = 'N'
+    integer intent(hide), depend(d) :: n = max(1, len(d))
+    integer intent(hide), depend(b) :: nrhs = max(1, shape(b, 1))
+    <ftype2> intent(in), dimension(n) :: d
+    <ftype2c> intent(in), depend(n), dimension(n-1) :: e
+    <ftype2> optional, intent(in,out), depend(n), dimension(n) :: df
+    <ftype2c> optional, intent(in,out), depend(n), dimension(n) :: ef
+    <ftype2c> intent(in), dimension(ldb, nrhs) :: b
+    integer intent(hide), depend(b) :: ldb = max(1, shape(b, 0))
+    <ftype2c> intent(out), dimension(ldx, nrhs) :: x
+    integer intent(hide), depend(n) :: ldx = n
+    <ftype2> intent(out) :: rcond
+    <ftype2> intent(out), depend(nrhs), dimension(nrhs) :: ferr
+    <ftype2> intent(out), depend(nrhs), dimension(nrhs) :: berr
+    <ftype2c> intent(hide,cache), depend(n), dimension(2*n) :: work
+    <ftype2> intent(hide,cache), depend(n), dimension(2*n) :: rwork
+    integer intent(out) :: info
+
+end subroutine <prefix2c>ptsvx

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -490,6 +490,11 @@ All functions
    cptsv
    zptsv
 
+   sptsvx
+   dptsvx
+   cptsvx
+   zptsvx
+
    spttrf
    dpttrf
    cpttrf

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -2656,14 +2656,9 @@ def test_ptsvx_error_raise_errors(dtype, realtype, fact, df_de_lambda):
     df, ef, info = df_de_lambda(d, e)
 
     # test with malformatted array sizes
-    with assert_raises(ValueError):
-        ptsvx(d[:-1], e, b, fact=fact, df=df, ef=ef)
-    with assert_raises(ValueError):
-        ptsvx(d, e[:-1], b, fact=fact, df=df, ef=ef)
-    df, ef, x, rcond, ferr, berr, info = ptsvx(d, e, b[:-1], fact=fact,
-                                               df=df, ef=ef)
-    # this info returns -9
-    assert info < 0
+    assert_raises(ValueError, ptsvx, d[:-1], e, b, fact=fact, df=df, ef=ef)
+    assert_raises(ValueError, ptsvx, d, e[:-1], b, fact=fact, df=df, ef=ef)
+    assert_raises(Exception, ptsvx, d, e, b[:-1], fact=fact, df=df, ef=ef)
 
 
 @pytest.mark.parametrize("dtype,realtype", zip(DTYPES, REAL_DTYPES

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -2577,12 +2577,24 @@ def test_gtsvx_NAG(du, d, dl, b, x):
 
 
 @pytest.mark.parametrize("dtype", DTYPES)
-@pytest.mark.parametrize("fact", ("F", "N"))
-def test_ptsvx(dtype,fact):
+@pytest.mark.parametrize("fact,de_df_lambda",
+                         [("F", lambda d, e:get_lapack_funcs('pttrf',
+                                                             dtype=e.dtype)),
+                          ("N", lambda d, e: (None, None, None))])
+def test_ptsvx(dtype, fact, de_df_lambda):
+    '''
+    TODO: let's see what the actual type of rcond is so that we can test for
+    that specifcially
+
+    This tests the ?ptsvx lapack routine wrapper to solve a random system
+    Ax = b for all dtypes and input variations. Tests for: unmodified
+    input parameters, fact options, incompatible matrix shapes raise an error,
+    and singular matrices return info of illegal value.
+    '''
     np.random.seed(42)
     # set test tolerance appropriate for dtype
-    rtol = 250*np.finfo(dtype).eps
-    atol = 100*np.finfo(dtype).eps
+    rtol = 250 * np.finfo(dtype).eps
+    atol = 100 * np.finfo(dtype).eps
     # obtain routine
     ptsvx = get_lapack_funcs('ptsvx', dtype=dtype)
     # n is the length diagonal of A
@@ -2590,7 +2602,7 @@ def test_ptsvx(dtype,fact):
     # create diagonals according to size and dtype
     if dtype in REAL_DTYPES:
         # add 2 so that the matrix will be diagonally dominant
-        d = generate_random_dtype_array((n,), dtype) + 2
+        d = generate_random_dtype_array((n,), dtype=dtype) + 2
     else:
         # diagonal d should always be real.
         # for complex add 4 so it will be dominant
@@ -2600,19 +2612,27 @@ def test_ptsvx(dtype,fact):
     # form matrix A from d and e
     A = np.diag(d) + np.diag(e, -1) + np.diag(e, 1)
     # create random solution x
-    x_soln = generate_random_dtype_array((n,2), dtype)
+    x_soln = generate_random_dtype_array((n, 2), dtype=dtype)
     # now create a b based on these
     b = A @ x_soln
-    # determine if de, df, should be null or based on pttrf
-    if fact == "N":
-        de = None
-        df = None
-    else:
-        pttrf = get_lapack_funcs('pttrf', dtype=dtype)
-        df, fe, info = pttrf(d, e)
+
+    # use lambda to determine what df, ef are
+    # (parametrized to either be null or result of ?pttrf)
+    df, ef, info = de_df_lambda(d, e)
+
+    diag_cpy = [d.copy(), e.copy(), b.copy()]
 
     # solve using routine
-    x, df, ef, rcond, ferr, berr, info  = ptsvx(d, e, b, fact=fact, df=df, de=de)
+    if fact == "F":
+        x, df, ef, rcond, ferr, berr, info = ptsvx(None, None, b, fact=fact,
+                                                   df=df, ef=ef)
+    else:
+        x, df, ef, rcond, ferr, berr, info = ptsvx(d, e, b, fact=fact,
+                                                   df=df, ef=ef)
+    # d, e, and b should be unmodified
+    assert_array_equal(d, diag_cpy[0])
+    assert_array_equal(e, diag_cpy[1])
+    assert_array_equal(b, diag_cpy[2])
     assert_(info == 0, "info should be 0 but is {}.".format(info))
     assert_array_almost_equal(x_soln, x)
 
@@ -2634,16 +2654,92 @@ def test_ptsvx(dtype,fact):
 
     # test with malformatted array sizes
     with assert_raises(Exception):
-        ptsvx(d[:-1], e, b, fact=fact, df=df, de=de)
+        ptsvx(d[:-1], e, b, fact=fact, df=df, ef=ef)
     with assert_raises(Exception):
-        ptsvx(d, e[:-1], b, fact=fact, df=df, de=de)
+        ptsvx(d, e[:-1], b, fact=fact, df=df, ef=ef)
     with assert_raises(Exception):
-        ptsvx(d, e, b[:-1], fact=fact, df=df, de=de)
-
-    # test with singular matrix
+        ptsvx(d, e, b[:-1], fact=fact, df=df, ef=ef)
 
     # test with non spd matrix
-    x, df, ef, rcond, ferr, berr, info = ptsvx(d, e+2, b, fact=fact, df=df, de=de)
+    x, df, ef, rcond, ferr, berr, info = ptsvx(d, e+2, b, fact=fact, df=df,
+                                               ef=ef)
+
+    # test with singular matrix
+    # no need to test with fact "T" since ?pttrf already tests for these.
+    if fact == "N":
+        d[0] = 0
+        # obtain new df, ef
+        df, ef, info = de_df_lambda(d, e)
+        # solve using routine
+        x, df, ef, rcond, ferr, berr, info = ptsvx(d, e, b, fact=fact, df=df,
+                                                   ef=ef)
+        # test for the singular matrix.
+        assert_(d[info - 1] == 0,
+                           "?ptsvx: d[info-1] is {}, not the illegal value"
+                           .format(d[info - 1]))
+
+        # non SPD matrix
+        d = generate_random_dtype_array(n, dtype)
+        x, df, ef, rcond, ferr, berr, info = ptsvx(d, e, b, fact=fact, df=df,
+                                                   ef=ef)
+        assert_(np.linalg.norm(d[info]) < 2 * np.linalg.norm(e[info]),
+                "?ptsvx: idx {} of d should < e but are: {}, {} ".format(
+                   info, np.linalg.norm(d[info]), np.linalg.norm(e[info])))
+    else:
+        # assuming that someone is using a singular factorization
+        df, ef = de_df_lambda(d, e)
+        df[0] = 0
+        ef[0] = 0
+        x, df, ef, rcond, ferr, berr, info = ptsvx(None, None, b, fact=fact,
+                                                   df=df, ef=ef)
+        # info should not be zero and should provide index of illegal value
+        assert_(d[info - 1] == 0,
+                           "?ptsvx: _d[info-1] is {}, not the illegal value"
+                           .format(d[info - 1]))
 
 
-    # It might be cool to create an example for which the matrix is numerically - but not exactly - singular to see if we can get info==N+1
+    # It might be cool to create an example for which the matrix is
+    # numerically - but not exactly - singular to see if we can get info==N+1
+
+
+@pytest.mark.parametrize('d,e,b,x', [(np.array([4, 10, 29, 25, 5]),
+                                      np.array([-2, -6, 15, 8]),
+                                      np.array([[6, 10],
+                                                [9, 4],
+                                                [2, 9],
+                                                [14, 65],
+                                                [7, 23]]),
+                                      np.array([[2.5, 2]],
+                                               [2, -1],
+                                               [1, -3],
+                                               [-1, 6],
+                                               [3, -5])),
+                                     (np.array([16, 41, 46, 21]),
+                                      np.array([16 + 16j, 18 - 9j, 1 - 4j]),
+                                      np.array([[64 - 16j, -16 - 32j],
+                                                [93 - 62j, 61 - 66j],
+                                                [78 - 80j, 71 - 74j],
+                                                [14 - 27j, 35 + 15j]]),
+                                      np.array([[2 + 1j, -3 - 2j]],
+                                               [1 + 1j, 1 + 1j],
+                                               [1 - 2j, 1 - 2j],
+                                               [1 - 1j, 2 - 1j]))])
+def test_ptsvx_NAG(d, e, b, x):
+    '''
+    TODO: On nag manual there are berr vals that are exactly zero.
+        - why would it be zero, shouldn't it not be?
+        - test idea to just see if nearby zero.
+
+    Tests real and complex NAG examples: f07jbf, f07jpf
+    https://www.nag.com/numeric/fl/nagdoc_fl26.2/html/f07/f07jbf.html
+    https://www.nag.com/numeric/fl/nagdoc_fl26.2/html/f07/f07jpf.html
+    '''
+    # test that it is close to zero, ask kai about why it is exactly zero
+    # (not supposed to be exactly zero, or at least shouldnt be)
+
+    # obtain routine with correct type based on e.dtype
+    ptsvx = get_lapack_funcs('ptsvx', dtype=e.dtype)
+    # solve using routine
+    x_ptsvx, df, ef, rcond, ferr, berr, info = ptsvx(d, e, b, fact="N")
+    # determine ptsvx's solution and x are the same.
+    assert_array_almost_equal(x, x_ptsvx)

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -2585,9 +2585,6 @@ def test_gtsvx_NAG(du, d, dl, b, x):
                           ("N", lambda d, e: (None, None, None))])
 def test_ptsvx(dtype, realtype, fact, df_de_lambda):
     '''
-    TODO: let's see what the actual type of rcond is so that we can test for
-    that specifcially
-
     This tests the ?ptsvx lapack routine wrapper to solve a random system
     Ax = b for all dtypes and input variations. Tests for: unmodified
     input parameters, fact options, incompatible matrix shapes raise an error,
@@ -2601,11 +2598,8 @@ def test_ptsvx(dtype, realtype, fact, df_de_lambda):
     n = 5
     # create diagonals according to size and dtype
     d = generate_random_dtype_array((n,), realtype) + 4
-    # diagonal e may be real or complex.
     e = generate_random_dtype_array((n-1,), dtype)
-    # form matrix A from d and e
     A = np.diag(d) + np.diag(e, -1) + np.diag(np.conj(e), 1)
-    # create random solution x
     x_soln = generate_random_dtype_array((n, 2), dtype=dtype)
     b = A @ x_soln
 
@@ -2653,11 +2647,8 @@ def test_ptsvx_error_raise_errors(dtype, realtype, fact, df_de_lambda):
     n = 5
     # create diagonals according to size and dtype
     d = generate_random_dtype_array((n,), realtype) + 4
-    # diagonal e may be real or complex.
     e = generate_random_dtype_array((n-1,), dtype)
-    # form matrix A from d and e
     A = np.diag(d) + np.diag(e, -1) + np.diag(np.conj(e), 1)
-    # create random solution x
     x_soln = generate_random_dtype_array((n, 2), dtype=dtype)
     b = A @ x_soln
 
@@ -2671,6 +2662,7 @@ def test_ptsvx_error_raise_errors(dtype, realtype, fact, df_de_lambda):
         ptsvx(d, e[:-1], b, fact=fact, df=df, ef=ef)
     df, ef, x, rcond, ferr, berr, info = ptsvx(d, e, b[:-1], fact=fact,
                                                df=df, ef=ef)
+    # this info returns -9
     assert info < 0
 
 
@@ -2687,17 +2679,13 @@ def test_ptsvx_non_SPD_singular(dtype, realtype, fact, df_de_lambda):
     n = 5
     # create diagonals according to size and dtype
     d = generate_random_dtype_array((n,), realtype) + 4
-    # diagonal e may be real or complex.
     e = generate_random_dtype_array((n-1,), dtype)
-    # form matrix A from d and e
     A = np.diag(d) + np.diag(e, -1) + np.diag(np.conj(e), 1)
-    # create random solution x
     x_soln = generate_random_dtype_array((n, 2), dtype=dtype)
     b = A @ x_soln
 
     # use lambda to determine what df, ef are
     df, ef, info = df_de_lambda(d, e)
-    # test with non spd matrix
 
     if fact == "N":
         d[3] = 0
@@ -2706,12 +2694,12 @@ def test_ptsvx_non_SPD_singular(dtype, realtype, fact, df_de_lambda):
         # solve using routine
         df, ef, x, rcond, ferr, berr, info = ptsvx(d, e, b)
         # test for the singular matrix.
-        assert info > 0
+        assert info > 0 and info <= n
 
         # non SPD matrix
         d = generate_random_dtype_array((n,), realtype)
         df, ef, x, rcond, ferr, berr, info = ptsvx(d, e, b)
-        assert info > 0
+        assert info > 0 and info <= n
     else:
         # assuming that someone is using a singular factorization
         df, ef, info = df_de_lambda(d, e)
@@ -2719,7 +2707,7 @@ def test_ptsvx_non_SPD_singular(dtype, realtype, fact, df_de_lambda):
         ef[0] = 0
         df, ef, x, rcond, ferr, berr, info = ptsvx(d, e, b, fact=fact,
                                                    df=df, ef=ef)
-        assert info > 0
+        assert info > 0 and info <= n
 
     # It might be cool to create an example for which the matrix is
     # numerically - but not exactly - singular to see if we can get info==N+1

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -2577,11 +2577,11 @@ def test_gtsvx_NAG(du, d, dl, b, x):
 
 
 @pytest.mark.parametrize("dtype", DTYPES)
-@pytest.mark.parametrize("fact,de_df_lambda",
+@pytest.mark.parametrize("fact,df_de_lambda",
                          [("F", lambda d, e:get_lapack_funcs('pttrf',
                                                              dtype=e.dtype)),
                           ("N", lambda d, e: (None, None, None))])
-def test_ptsvx(dtype, fact, de_df_lambda):
+def test_ptsvx(dtype, fact, df_de_lambda):
     '''
     TODO: let's see what the actual type of rcond is so that we can test for
     that specifcially
@@ -2604,11 +2604,11 @@ def test_ptsvx(dtype, fact, de_df_lambda):
         # add 2 so that the matrix will be diagonally dominant
         d = generate_random_dtype_array((n,), dtype=dtype) + 2
     else:
-        # diagonal d should always be real.
+        # Per lapack documentation, diagonal d should always be real.
         # for complex add 4 so it will be dominant
         d = generate_random_dtype_array((n,), DTYPES[1]) + 4
     # diagonal e may be real or complex.
-    e = generate_random_dtype_array(n-1, dtype)
+    e = generate_random_dtype_array((n-1,), dtype)
     # form matrix A from d and e
     A = np.diag(d) + np.diag(e, -1) + np.diag(e, 1)
     # create random solution x
@@ -2618,17 +2618,13 @@ def test_ptsvx(dtype, fact, de_df_lambda):
 
     # use lambda to determine what df, ef are
     # (parametrized to either be null or result of ?pttrf)
-    df, ef, info = de_df_lambda(d, e)
+    df, ef, info = df_de_lambda(d, e)
 
     diag_cpy = [d.copy(), e.copy(), b.copy()]
 
     # solve using routine
-    if fact == "F":
-        x, df, ef, rcond, ferr, berr, info = ptsvx(None, None, b, fact=fact,
-                                                   df=df, ef=ef)
-    else:
-        x, df, ef, rcond, ferr, berr, info = ptsvx(d, e, b, fact=fact,
-                                                   df=df, ef=ef)
+    x, df, ef, rcond, ferr, berr, info = ptsvx(d, e, b, fact=fact,
+                                               df=df, ef=ef)
     # d, e, and b should be unmodified
     assert_array_equal(d, diag_cpy[0])
     assert_array_equal(e, diag_cpy[1])
@@ -2653,13 +2649,13 @@ def test_ptsvx(dtype, fact, de_df_lambda):
             .format(berr.shape, n))
 
     # test with malformatted array sizes
-    with assert_raises(Exception):
+    with assert_raises(ValueError):
         ptsvx(d[:-1], e, b, fact=fact, df=df, ef=ef)
-    with assert_raises(Exception):
+    with assert_raises(ValueError):
         ptsvx(d, e[:-1], b, fact=fact, df=df, ef=ef)
-    with assert_raises(Exception):
+    with assert_raises(ValueError):
         ptsvx(d, e, b[:-1], fact=fact, df=df, ef=ef)
-
+    '''come back to later if doesnt work to check for nonzero info'''
     # test with non spd matrix
     x, df, ef, rcond, ferr, berr, info = ptsvx(d, e+2, b, fact=fact, df=df,
                                                ef=ef)
@@ -2669,14 +2665,14 @@ def test_ptsvx(dtype, fact, de_df_lambda):
     if fact == "N":
         d[0] = 0
         # obtain new df, ef
-        df, ef, info = de_df_lambda(d, e)
+        df, ef, info = df_de_lambda(d, e)
         # solve using routine
         x, df, ef, rcond, ferr, berr, info = ptsvx(d, e, b, fact=fact, df=df,
                                                    ef=ef)
         # test for the singular matrix.
         assert_(d[info - 1] == 0,
-                           "?ptsvx: d[info-1] is {}, not the illegal value"
-                           .format(d[info - 1]))
+                "?ptsvx: d[info-1] is {}, not the illegal value"
+                .format(d[info - 1]))
 
         # non SPD matrix
         d = generate_random_dtype_array(n, dtype)
@@ -2687,16 +2683,15 @@ def test_ptsvx(dtype, fact, de_df_lambda):
                    info, np.linalg.norm(d[info]), np.linalg.norm(e[info])))
     else:
         # assuming that someone is using a singular factorization
-        df, ef = de_df_lambda(d, e)
+        df, ef = df_de_lambda(d, e)
         df[0] = 0
         ef[0] = 0
         x, df, ef, rcond, ferr, berr, info = ptsvx(None, None, b, fact=fact,
                                                    df=df, ef=ef)
         # info should not be zero and should provide index of illegal value
         assert_(d[info - 1] == 0,
-                           "?ptsvx: _d[info-1] is {}, not the illegal value"
-                           .format(d[info - 1]))
-
+                "?ptsvx: _d[info-1] is {}, not the illegal value"
+                .format(d[info - 1]))
 
     # It might be cool to create an example for which the matrix is
     # numerically - but not exactly - singular to see if we can get info==N+1

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -2590,9 +2590,8 @@ def test_ptsvx(dtype, realtype, fact, df_de_lambda):
     input parameters, fact options, incompatible matrix shapes raise an error,
     and singular matrices return info of illegal value.
     '''
-    np.random.seed(42)
+    seed(42)
     # set test tolerance appropriate for dtype
-    rtol = 250 * np.finfo(dtype).eps
     atol = 100 * np.finfo(dtype).eps
     ptsvx = get_lapack_funcs('ptsvx', dtype=dtype)
     n = 5
@@ -2622,7 +2621,7 @@ def test_ptsvx(dtype, realtype, fact, df_de_lambda):
     # test that the factors from ptsvx can be recombined to make A
     L = np.diag(ef, -1) + np.diag(np.ones(n))
     D = np.diag(df)
-    assert_allclose(A, L@D@(np.conj(L).T), rtol=rtol, atol=atol)
+    assert_allclose(A, L@D@(np.conj(L).T), atol=atol)
 
     # assert that the outputs are of correct type or shape
     # rcond should be a scalar
@@ -2643,6 +2642,7 @@ def test_ptsvx(dtype, realtype, fact, df_de_lambda):
                                                         dtype=e.dtype)(d, e)),
                           ("N", lambda d, e: (None, None, None))])
 def test_ptsvx_error_raise_errors(dtype, realtype, fact, df_de_lambda):
+    seed(42)
     ptsvx = get_lapack_funcs('ptsvx', dtype=dtype)
     n = 5
     # create diagonals according to size and dtype
@@ -2674,7 +2674,7 @@ def test_ptsvx_error_raise_errors(dtype, realtype, fact, df_de_lambda):
                                                         dtype=e.dtype)(d, e)),
                           ("N", lambda d, e: (None, None, None))])
 def test_ptsvx_non_SPD_singular(dtype, realtype, fact, df_de_lambda):
-
+    seed(42)
     ptsvx = get_lapack_funcs('ptsvx', dtype=dtype)
     n = 5
     # create diagonals according to size and dtype
@@ -2709,9 +2709,6 @@ def test_ptsvx_non_SPD_singular(dtype, realtype, fact, df_de_lambda):
                                                    df=df, ef=ef)
         assert info > 0
 
-    # It might be cool to create an example for which the matrix is
-    # numerically - but not exactly - singular to see if we can get info==N+1
-
 
 @pytest.mark.parametrize('d,e,b,x',
                          [(np.array([4, 10, 29, 25, 5]),
@@ -2731,17 +2728,9 @@ def test_ptsvx_non_SPD_singular(dtype, realtype, fact, df_de_lambda):
                                      [1 - 2j, 1 - 2j],
                                      [1 - 1j, 2 + 1j]]))])
 def test_ptsvx_NAG(d, e, b, x):
-    '''
-    TODO: On nag manual there are berr vals that are exactly zero.
-        - why would it be zero, shouldn't it not be?
-        - test idea to just see if nearby zero.
-
-    Tests real and complex NAG examples: f07jbf, f07jpf
-    https://www.nag.com/numeric/fl/nagdoc_fl26.2/html/f07/f07jbf.html
-    https://www.nag.com/numeric/fl/nagdoc_fl26.2/html/f07/f07jpf.html
-    '''
-    # test that it is close to zero, ask kai about why it is exactly zero
-    # (not supposed to be exactly zero, or at least shouldnt be)
+    # test to assure that wrapper is consistent with NAG Manual Mark 26
+    # example problemss: f07jbf, f07jpf
+    # (Links expire, so please search for "NAG Library Manual Mark 26" online)
 
     # obtain routine with correct type based on e.dtype
     ptsvx = get_lapack_funcs('ptsvx', dtype=e.dtype)

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -2707,7 +2707,7 @@ def test_ptsvx_non_SPD_singular(dtype, realtype, fact, df_de_lambda):
         ef[0] = 0
         df, ef, x, rcond, ferr, berr, info = ptsvx(d, e, b, fact=fact,
                                                    df=df, ef=ef)
-        assert info > 0 and info <= n
+        assert info > 0
 
     # It might be cool to create an example for which the matrix is
     # numerically - but not exactly - singular to see if we can get info==N+1


### PR DESCRIPTION
This PR adds Python level wrappers for the LAPACK function ?ptsvx as part of a NumFocus small development grant. ?ptsvx solve a linear system with a positive definite tridiagonal matrix. Importantly, it also provide error bounds on the solution and a condition estimate. SciPy already includes wrappers for the equivalent routines for other matrix types; this would help complete the set.

This closes gh-11374

Thanks to @Kai-Striega for writing the wrapper and @swallan for writing the tests.