### PR TITLE
ENH: add mypy ratchet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,10 @@ pip-wheel-metadata
 .cache/*
 .pytest_cache/*
 
+# mypy cache #
+##############
+.mypy_cache/*
+
 # Patches #
 ###########
 *.patch

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,479 @@
+[mypy]
+files = scipy
+warn_redundant_casts = True
+warn_unused_ignores = True
+show_error_codes = True
+# Needed until all dependencies have types.
+ignore_missing_imports = True
+
+#
+# Files with various errors. Likely some false positives, but likely
+# some real bugs too.
+#
+
+[mypy-scipy.__config__]
+ignore_errors = True
+
+[mypy-scipy.signal.tests.test_signaltools]
+ignore_errors = True
+
+[mypy-scipy.stats.tests.test_rank]
+ignore_errors = True
+
+[mypy-scipy.stats._continuous_distns]
+ignore_errors = True
+
+[mypy-scipy.stats.distributions]
+ignore_errors = True
+
+[mypy-scipy.integrate.tests.test_integrate]
+ignore_errors = True
+
+[mypy-scipy.signal.ltisys]
+ignore_errors = True
+
+[mypy-scipy.integrate._ode]
+ignore_errors = True
+
+[mypy-scipy.optimize.tests.test_nonlin]
+ignore_errors = True
+
+[mypy-scipy.integrate._bvp]
+ignore_errors = True
+
+[mypy-scipy.optimize.tests.test_least_squares]
+ignore_errors = True
+
+[mypy-scipy.optimize.tests.test_linprog]
+ignore_errors = True
+
+[mypy-scipy.optimize._tstutils]
+ignore_errors = True
+
+[mypy-scipy.optimize]
+ignore_errors = True
+
+[mypy-scipy.optimize._lsq.least_squares]
+ignore_errors = True
+
+[mypy-scipy.optimize._trustregion_constr.minimize_trustregion_constr]
+ignore_errors = True
+
+[mypy-scipy.optimize._linprog]
+ignore_errors = True
+
+[mypy-scipy.optimize._linprog_util]
+ignore_errors = True
+
+[mypy-scipy.optimize._trustregion]
+ignore_errors = True
+
+[mypy-scipy.optimize._trustregion_dogleg]
+ignore_errors = True
+
+[mypy-scipy.optimize._trustregion_ncg]
+ignore_errors = True
+
+[mypy-scipy.optimize.cobyla]
+ignore_errors = True
+
+[mypy-scipy.optimize._linprog_ip]
+ignore_errors = True
+
+[mypy-scipy.optimize.minpack]
+ignore_errors = True
+
+[mypy-scipy.optimize.nnls]
+ignore_errors = True
+
+[mypy-scipy.optimize.optimize]
+ignore_errors = True
+
+[mypy-scipy.optimize._basinhopping]
+ignore_errors = True
+
+[mypy-scipy.integrate._ivp.radau]
+ignore_errors = True
+
+[mypy-scipy.spatial.distance]
+ignore_errors = True
+
+[mypy-scipy.optimize._trustregion_constr.tests.test_projections]
+ignore_errors = True
+
+[mypy-scipy.integrate.quadrature]
+ignore_errors = True
+
+[mypy-scipy.linalg.tests.test_fblas]
+ignore_errors = True
+
+[mypy-scipy.signal.windows.windows]
+ignore_errors = True
+
+[mypy-scipy.signal.bsplines]
+ignore_errors = True
+
+[mypy-scipy.sparse.linalg.isolve.tests.test_gcrotmk]
+ignore_errors = True
+
+[mypy-scipy.sparse.linalg.isolve.tests.test_lgmres]
+ignore_errors = True
+
+[mypy-scipy.sparse.linalg.isolve.tests.test_utils]
+ignore_errors = True
+
+[mypy-scipy.sparse.tests.test_base]
+ignore_errors = True
+
+[mypy-scipy.special.tests.test_nan_inputs]
+ignore_errors = True
+
+[mypy-scipy.linalg.basic]
+ignore_errors = True
+
+[mypy-scipy.linalg.flinalg]
+ignore_errors = True
+
+[mypy-scipy.linalg.lapack]
+ignore_errors = True
+
+[mypy-scipy.fftpack.pseudo_diffs]
+ignore_errors = True
+
+[mypy-scipy.sparse.linalg.isolve.utils]
+ignore_errors = True
+
+[mypy-scipy.integrate._quad_vec]
+ignore_errors = True
+
+[mypy-scipy.sparse.compressed]
+ignore_errors = True
+
+[mypy-scipy.sparse.data]
+ignore_errors = True
+
+[mypy-scipy.sparse.dok]
+ignore_errors = True
+
+[mypy-scipy.sparse._index]
+ignore_errors = True
+
+[mypy-scipy]
+ignore_errors = True
+
+[mypy-scipy.fft]
+ignore_errors = True
+
+[mypy-scipy.constants]
+ignore_errors = True
+
+[mypy-scipy.fft._helper]
+ignore_errors = True
+
+[mypy-scipy.fft._pocketfft.basic]
+ignore_errors = True
+
+[mypy-scipy.fft._pocketfft.realtransforms]
+ignore_errors = True
+
+[mypy-scipy._lib._pep440]
+ignore_errors = True
+
+[mypy-scipy._lib.decorator]
+ignore_errors = True
+
+[mypy-scipy.io.arff.arffread]
+ignore_errors = True
+
+[mypy-scipy.io.netcdf]
+ignore_errors = True
+
+[mypy-scipy.sparse.sputils]
+ignore_errors = True
+
+[mypy-scipy.linalg._generate_pyx]
+ignore_errors = True
+
+[mypy-scipy.special.add_newdocs]
+ignore_errors = True
+
+#
+# Files referencing compiled code that needs stubs added.
+#
+
+[mypy-scipy.stats.tests.test_distributions]
+ignore_errors = True
+
+[mypy-scipy.stats.tests.test_multivariate]
+ignore_errors = True
+
+[mypy-scipy.signal.tests.test_windows]
+ignore_errors = True
+
+[mypy-scipy.stats.tests.test_continuous_basic]
+ignore_errors = True
+
+[mypy-scipy.linalg.tests.test_decomp]
+ignore_errors = True
+
+[mypy-scipy.linalg.tests.test_lapack]
+ignore_errors = True
+
+[mypy-scipy.signal]
+ignore_errors = True
+
+[mypy-scipy.signal.fir_filter_design]
+ignore_errors = True
+
+[mypy-scipy.signal.signaltools]
+ignore_errors = True
+
+[mypy-scipy.stats.tests.test_contingency]
+ignore_errors = True
+
+[mypy-scipy.stats.tests.test_discrete_distns]
+ignore_errors = True
+
+[mypy-scipy.stats.vonmises]
+ignore_errors = True
+
+[mypy-scipy.stats.mstats_extras]
+ignore_errors = True
+
+[mypy-scipy.stats._multivariate]
+ignore_errors = True
+
+[mypy-scipy.stats.kde]
+ignore_errors = True
+
+[mypy-scipy.stats.morestats]
+ignore_errors = True
+
+[mypy-scipy.stats.stats]
+ignore_errors = True
+
+[mypy-scipy.stats._discrete_distns]
+ignore_errors = True
+
+[mypy-scipy.interpolate.tests.test_interpolate]
+ignore_errors = True
+
+[mypy-scipy.special.tests.test_data]
+ignore_errors = True
+
+[mypy-scipy.stats._distn_infrastructure]
+ignore_errors = True
+
+[mypy-scipy.integrate.odepack]
+ignore_errors = True
+
+[mypy-scipy.integrate.quadpack]
+ignore_errors = True
+
+[mypy-scipy.integrate.tests.test_bvp]
+ignore_errors = True
+
+[mypy-scipy.optimize.tests.test_lbfgsb_setulb]
+ignore_errors = True
+
+[mypy-scipy.spatial.transform.tests.test_rotation_groups]
+ignore_errors = True
+
+[mypy-scipy.cluster.tests.test_vq]
+ignore_errors = True
+
+[mypy-scipy.optimize._lsq.lsq_linear]
+ignore_errors = True
+
+[mypy-scipy.optimize._lsq.trf_linear]
+ignore_errors = True
+
+[mypy-scipy.optimize._lsq.dogbox]
+ignore_errors = True
+
+[mypy-scipy.optimize._lsq.trf]
+ignore_errors = True
+
+[mypy-scipy.optimize._dual_annealing]
+ignore_errors = True
+
+[mypy-scipy.optimize._lsap]
+ignore_errors = True
+
+[mypy-scipy.optimize.lbfgsb]
+ignore_errors = True
+
+[mypy-scipy.optimize.linesearch]
+ignore_errors = True
+
+[mypy-scipy.optimize.tnc]
+ignore_errors = True
+
+[mypy-scipy.optimize.zeros]
+ignore_errors = True
+
+[mypy-scipy.cluster.hierarchy]
+ignore_errors = True
+
+[mypy-scipy.cluster.vq]
+ignore_errors = True
+
+[mypy-scipy.interpolate.tests.test_bsplines]
+ignore_errors = True
+
+[mypy-scipy.spatial.tests.test__plotutils]
+ignore_errors = True
+
+[mypy-scipy.spatial.tests.test_kdtree]
+ignore_errors = True
+
+[mypy-scipy.spatial.tests.test_qhull]
+ignore_errors = True
+
+[mypy-scipy.integrate._ivp.bdf]
+ignore_errors = True
+
+[mypy-scipy.interpolate._bsplines]
+ignore_errors = True
+
+[mypy-scipy.interpolate.interpolate]
+ignore_errors = True
+
+[mypy-scipy.interpolate.ndgriddata]
+ignore_errors = True
+
+[mypy-scipy.interpolate.rbf]
+ignore_errors = True
+
+[mypy-scipy.spatial._spherical_voronoi]
+ignore_errors = True
+
+[mypy-scipy.sparse.linalg.isolve.tests.test_lsmr]
+ignore_errors = True
+
+[mypy-scipy.special.tests.test_basic]
+ignore_errors = True
+
+[mypy-scipy.special.tests.test_kolmogorov]
+ignore_errors = True
+
+[mypy-scipy.special.tests.test_loggamma]
+ignore_errors = True
+
+[mypy-scipy.special.tests.test_spence]
+ignore_errors = True
+
+[mypy-scipy.linalg.tests.test_blas]
+ignore_errors = True
+
+[mypy-scipy.linalg.tests.test_cython_lapack]
+ignore_errors = True
+
+[mypy-scipy.optimize._remove_redundancy]
+ignore_errors = True
+
+[mypy-scipy.sparse.linalg.dsolve.tests.test_linsolve]
+ignore_errors = True
+
+[mypy-scipy.sparse.linalg.eigen.lobpcg.tests.test_lobpcg]
+ignore_errors = True
+
+[mypy-scipy.sparse.linalg.isolve.tests.demo_lgmres]
+ignore_errors = True
+
+[mypy-scipy.sparse.linalg.isolve.tests.test_lsqr]
+ignore_errors = True
+
+[mypy-scipy.sparse.linalg.tests.test_matfuncs]
+ignore_errors = True
+
+[mypy-scipy.special.tests.test_boxcox]
+ignore_errors = True
+
+[mypy-scipy.special.tests.test_cython_special]
+ignore_errors = True
+
+[mypy-scipy.special.tests.test_erfinv]
+ignore_errors = True
+
+[mypy-scipy.special.tests.test_exponential_integrals]
+ignore_errors = True
+
+[mypy-scipy.special.tests.test_logit]
+ignore_errors = True
+
+[mypy-scipy.special.tests.test_round]
+ignore_errors = True
+
+[mypy-scipy.special.tests.test_spfun_stats]
+ignore_errors = True
+
+[mypy-scipy.stats._tukeylambda_stats]
+ignore_errors = True
+
+[mypy-scipy.io.tests.test_fortran]
+ignore_errors = True
+
+[mypy-scipy.sparse.linalg.eigen.arpack.arpack]
+ignore_errors = True
+
+[mypy-scipy.sparse.linalg.matfuncs]
+ignore_errors = True
+
+[mypy-scipy.sparse.linalg.isolve.iterative]
+ignore_errors = True
+
+[mypy-scipy.sparse.linalg.isolve._gcrotmk]
+ignore_errors = True
+
+[mypy-scipy.special._basic]
+ignore_errors = True
+
+[mypy-scipy.special.orthogonal]
+ignore_errors = True
+
+[mypy-scipy.special.spfun_stats]
+ignore_errors = True
+
+[mypy-scipy.linalg._matfuncs_sqrtm]
+ignore_errors = True
+
+[mypy-scipy.linalg.blas]
+ignore_errors = True
+
+[mypy-scipy.sparse.lil]
+ignore_errors = True
+
+[mypy-scipy.ndimage.tests.test_c_api]
+ignore_errors = True
+
+[mypy-scipy._lib.tests.test_ccallback]
+ignore_errors = True
+
+[mypy-scipy.ndimage.filters]
+ignore_errors = True
+
+[mypy-scipy.ndimage.fourier]
+ignore_errors = True
+
+[mypy-scipy.ndimage.interpolation]
+ignore_errors = True
+
+[mypy-scipy.ndimage.measurements]
+ignore_errors = True
+
+[mypy-scipy.ndimage.morphology]
+ignore_errors = True
+
+[mypy-scipy.odr.odrpack]
+ignore_errors = True
+
+[mypy-scipy.optimize.tests.test_cython_optimize]
+ignore_errors = True
+
+#
+# Vendored code
+#
+
+[mypy-scipy._lib._uarray.*]
+ignore_errors = True


### PR DESCRIPTION
#### Reference issue
Related to https://github.com/scipy/scipy/issues/11670.

#### What does this implement/fix?
Add a mypy config file. It includes:

- Some basic configuration; most notably turning off errors for
  imports without types. (Without this there will be many complaints
  about not finding types for NumPy.)
- A ratchet that ignores enough errors to get mypy to pass on the
  current codebase.

The ratchet was broken into three categories:

- Vendored code. Currently `uarray` has some unneeded `# type: ignore`
  comments.
- Files that error because mypy doesn't parse extension modules. To
  fix these we need to add type stubs for those
  modules. (`scipy.special._ufuncs` is a major offender here.)
- Everything else. There are likely some false positives here, but
  from looking through the errors there also appear to be some real
  bugs.

#### Additional information
It would be interesting to see where we can get using mypy. I think it
makes sense to try it out for a bit outside of the CI loop to see what
people think, and maybe if that goes ok we could try using it in CI.
I'd like to experiment with generating (very rough) stubs
for `special._ufuncs`.