### PR TITLE
MAINT: rng_integers allows RandomState.randint or Generator.integers

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -413,7 +413,7 @@ def rng_integers(gen, low, high=None, size=None, dtype='int64',
     `RandomState.randint` (with endpoint=False) and
     `RandomState.random_integers` (with endpoint=True).
 
-    Return random integers from the “discrete uniform” distribution of the
+    Return random integers from the "discrete uniform" distribution of the
     specified dtype. If high is None (the default), then results are from
     0 to low.
 
@@ -436,7 +436,7 @@ def rng_integers(gen, low, high=None, size=None, dtype='int64',
         returned.
     dtype: {str, dtype}, optional
         Desired dtype of the result. All dtypes are determined by their name,
-        i.e., ‘int64’, ‘int’, etc, so byteorder is not available and a specific
+        i.e., 'int64', 'int', etc, so byteorder is not available and a specific
         precision may have different C types depending on the platform.
         The default value is np.int_.
     endpoint: bool, optional

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -418,8 +418,9 @@ def rng_integers(gen, low, high=None, size=None, dtype='int64',
 
     Parameters
     ----------
-    gen: {np.random.RandomState, np.random.Generator}
-        Random number generator
+    gen: {None, np.random.RandomState, np.random.Generator}
+        Random number generator. If None, then the np.random.RandomState
+        singleton is used.
     low: int or array-like of ints
         Lowest (signed) integers to be drawn from the distribution (unless
         high=None, in which case this parameter is 0 and this value is used
@@ -441,6 +442,8 @@ def rng_integers(gen, low, high=None, size=None, dtype='int64',
         If True, sample from the interval [low, high] instead of the default
         [low, high) Defaults to False.
 
+    Returns
+    -------
     out: int or ndarray of ints
         size-shaped array of random integers from the appropriate distribution,
         or a single such random int if size not provided.

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -12,7 +12,8 @@ import numpy as np
 try:
     from numpy.random import Generator as Generator
 except AttributeError:
-    Generator = None
+    class Generator():
+        pass
 
 
 def _valarray(shape, value=np.nan, typecode=None):

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -9,6 +9,11 @@ import inspect
 
 import numpy as np
 
+try:
+    import np.random.Generator as Generator
+except: AttributeError
+    Generator = None
+
 
 def _valarray(shape, value=np.nan, typecode=None):
     """Return an array of all values.
@@ -397,3 +402,56 @@ class MapWrapper(object):
             # wrong number of arguments
             raise TypeError("The map-like callable must be of the"
                             " form f(func, iterable)")
+
+
+def rng_integers(gen, low, high=None, size=None, dtype='int64',
+                 endpoint=False):
+    """
+    Return random integers from low (inclusive) to high (exclusive), or if
+    endpoint=True, low (inclusive) to high (inclusive). Replaces
+    `RandomState.randint` (with endpoint=False) and
+    `RandomState.random_integers` (with endpoint=True).
+
+    Return random integers from the “discrete uniform” distribution of the
+    specified dtype. If high is None (the default), then results are from
+    0 to low.
+
+    Parameters
+    ----------
+    gen: {np.random.RandomState, np.random.Generator}
+        Random number generator
+
+    low: int or array-like of ints
+        Lowest (signed) integers to be drawn from the distribution (unless
+        high=None, in which case this parameter is 0 and this value is used
+        for high).
+    high: int or array-like of ints
+        If provided, one above the largest (signed) integer to be drawn from
+        the distribution (see above for behavior if high=None). If array-like,
+        must contain integer values.
+    size: None
+        Output shape. If the given shape is, e.g., (m, n, k), then m * n * k
+        samples are drawn. Default is None, in which case a single value is
+        returned.
+    dtype: {str, dtype}, optional
+        Desired dtype of the result. All dtypes are determined by their name,
+        i.e., ‘int64’, ‘int’, etc, so byteorder is not available and a specific
+        precision may have different C types depending on the platform.
+        The default value is np.int_.
+    endpoint: bool, optional
+        If True, sample from the interval [low, high] instead of the default
+        [low, high) Defaults to False.
+
+    out: int or ndarray of ints
+        size-shaped array of random integers from the appropriate distribution,
+        or a single such random int if size not provided.
+    """
+    if isinstance(gen, Generator):
+        return gen.integers(low, high=high, size=size, dtype=dtype,
+                            endpoint=endpoint)
+    else:
+        if endpoint:
+            # we want inclusive
+            return gen.random_integers(low, high=high, size=size)
+        else:
+            return gen.randint(low, high=high, size=size, dtype=dtype)

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -11,7 +11,7 @@ import numpy as np
 
 try:
     from numpy.random import Generator as Generator
-except AttributeError:
+except ImportError:
     class Generator():
         pass
 

--- a/scipy/_lib/tests/test__util.py
+++ b/scipy/_lib/tests/test__util.py
@@ -10,7 +10,8 @@ from pytest import raises as assert_raises, deprecated_call
 
 import scipy
 from scipy._lib._util import (_aligned_zeros, check_random_state, MapWrapper,
-                              getfullargspec_no_self, FullArgSpec)
+                              getfullargspec_no_self, FullArgSpec,
+                              rng_integers)
 
 
 def test__aligned_zeros():
@@ -188,3 +189,61 @@ def test_numpy_deprecation_functionality():
 
         assert scipy.float64 == np.float64
         assert issubclass(np.float64, scipy.float64)
+
+
+def test_rng_integers():
+    rng = np.random.RandomState()
+
+    # test that numbers are inclusive of high point
+    arr = rng_integers(rng, low=2, high=5, size=100, endpoint=True)
+    assert np.max(arr) == 5
+    assert np.min(arr) == 2
+    assert arr.shape == (100, )
+
+    # test that numbers are inclusive of high point
+    arr = rng_integers(rng, low=5, size=100, endpoint=True)
+    assert np.max(arr) == 5
+    assert np.min(arr) == 0
+    assert arr.shape == (100, )
+
+    # test that numbers are exclusive of high point
+    arr = rng_integers(rng, low=2, high=5, size=100, endpoint=False)
+    assert np.max(arr) == 4
+    assert np.min(arr) == 2
+    assert arr.shape == (100, )
+
+    # test that numbers are exclusive of high point
+    arr = rng_integers(rng, low=5, size=100, endpoint=False)
+    assert np.max(arr) == 4
+    assert np.min(arr) == 0
+    assert arr.shape == (100, )
+
+    # now try with np.random.Generator
+    try:
+        rng = np.random.default_rng()
+    except AttributeError:
+        return
+
+    # test that numbers are inclusive of high point
+    arr = rng_integers(rng, low=2, high=5, size=100, endpoint=True)
+    assert np.max(arr) == 5
+    assert np.min(arr) == 2
+    assert arr.shape == (100, )
+
+    # test that numbers are inclusive of high point
+    arr = rng_integers(rng, low=5, size=100, endpoint=True)
+    assert np.max(arr) == 5
+    assert np.min(arr) == 0
+    assert arr.shape == (100, )
+
+    # test that numbers are exclusive of high point
+    arr = rng_integers(rng, low=2, high=5, size=100, endpoint=False)
+    assert np.max(arr) == 4
+    assert np.min(arr) == 2
+    assert arr.shape == (100, )
+
+    # test that numbers are exclusive of high point
+    arr = rng_integers(rng, low=5, size=100, endpoint=False)
+    assert np.max(arr) == 4
+    assert np.min(arr) == 0
+    assert arr.shape == (100, )

--- a/scipy/linalg/_sketches.py
+++ b/scipy/linalg/_sketches.py
@@ -5,7 +5,7 @@
 
 import numpy as np
 
-from scipy._lib._util import check_random_state
+from scipy._lib._util import check_random_state, rng_integers
 from scipy.sparse import csc_matrix
 
 __all__ = ['clarkson_woodruff_transform']
@@ -45,7 +45,7 @@ def cwt_matrix(n_rows, n_columns, seed=None):
     Where the error epsilon is related to the size of S.
     """
     rng = check_random_state(seed)
-    rows = rng.randint(0, n_rows, n_columns)
+    rows = rng_integers(rng, 0, n_rows, n_columns)
     cols = np.arange(n_columns+1)
     signs = rng.choice([1, -1], n_columns)
     S = csc_matrix((signs, rows, cols),shape=(n_rows, n_columns))

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -7,8 +7,10 @@ __all__ = ['spdiags', 'eye', 'identity', 'kron', 'kronsum',
            'hstack', 'vstack', 'bmat', 'rand', 'random', 'diags', 'block_diag']
 
 
+from functools import partial
 import numpy as np
 
+from scipy._lib._util import check_random_state, rng_integers
 from .sputils import upcast, get_index_dtype, isscalarlike
 
 from .csr import csr_matrix
@@ -767,23 +769,22 @@ greater than %d - this is not supported on this machine
     # Number of non zero values
     k = int(density * m * n)
 
-    if random_state is None:
-        random_state = np.random
-    elif isinstance(random_state, (int, np.integer)):
-        random_state = np.random.RandomState(random_state)
+    random_state = check_random_state(random_state)
 
     if data_rvs is None:
         if np.issubdtype(dtype, np.integer):
-            randint = random_state.randint
-
             def data_rvs(n):
-                return randint(np.iinfo(dtype).min, np.iinfo(dtype).max,
-                               n, dtype=dtype)
+                return rng_integers(random_state,
+                                    np.iinfo(dtype).min,
+                                    np.iinfo(dtype).max,
+                                    n,
+                                    dtype=dtype)
         elif np.issubdtype(dtype, np.complexfloating):
             def data_rvs(n):
-                return random_state.rand(n) + random_state.rand(n) * 1j
+                return (random_state.uniform(size=n) +
+                        random_state.uniform(size=n) * 1j)
         else:
-            data_rvs = random_state.rand
+            data_rvs = partial(random_state.uniform, 0., 1.)
 
     ind = random_state.choice(mn, size=k, replace=False)
 
@@ -809,7 +810,7 @@ def rand(m, n, density=0.01, format="coo", dtype=None, random_state=None):
         sparse matrix format.
     dtype : dtype, optional
         type of the returned matrix values.
-    random_state : {numpy.random.RandomState, int}, optional
+    random_state : {numpy.random.RandomState, int, np.random.Generator}, optional
         Random number generator or random seed. If not given, the singleton
         numpy.random will be used.
 

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -7,6 +7,7 @@ from numpy.testing import (assert_equal, assert_,
 import pytest
 from pytest import raises as assert_raises
 from scipy._lib._testutils import check_free_memory
+from scipy._lib._util import check_random_state
 
 from scipy.sparse import csr_matrix, coo_matrix, construct
 from scipy.sparse.construct import rand as sprand
@@ -19,11 +20,8 @@ sparse_formats = ['csr','csc','coo','bsr','dia','lil','dok']
 
 def _sprandn(m, n, density=0.01, format="coo", dtype=None, random_state=None):
     # Helper function for testing.
-    if random_state is None:
-        random_state = np.random
-    elif isinstance(random_state, (int, np.integer)):
-        random_state = np.random.RandomState(random_state)
-    data_rvs = random_state.randn
+    random_state = check_random_state(random_state)
+    data_rvs = random_state.standard_normal
     return construct.random(m, n, density, format, dtype,
                             random_state, data_rvs)
 
@@ -458,7 +456,14 @@ class TestConstructUtils(object):
 
     def test_rand(self):
         # Simple distributional checks for sparse.rand.
-        for random_state in None, 4321, np.random.RandomState():
+        random_states = [None, 4321, np.random.RandomState()]
+        try:
+            gen = np.random.default_rng()
+            random_states.append(gen)
+        except AttributeError:
+            pass
+
+        for random_state in random_states:
             x = sprand(10, 20, density=0.5, dtype=np.float64,
                        random_state=random_state)
             assert_(np.all(np.less_equal(0, x.data)))
@@ -468,7 +473,14 @@ class TestConstructUtils(object):
         # Simple distributional checks for sparse.randn.
         # Statistically, some of these should be negative
         # and some should be greater than 1.
-        for random_state in None, 4321, np.random.RandomState():
+        random_states = [None, 4321, np.random.RandomState()]
+        try:
+            gen = np.random.default_rng()
+            random_states.append(gen)
+        except AttributeError:
+            pass
+
+        for random_state in random_states:
             x = _sprandn(10, 20, density=0.5, dtype=np.float64,
                          random_state=random_state)
             assert_(np.any(np.less(x.data, 0)))

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -4,7 +4,7 @@
 #
 from scipy import special
 from scipy.special import entr, logsumexp, betaln, gammaln as gamln
-from scipy._lib._util import _lazywhere
+from scipy._lib._util import _lazywhere, rng_integers
 
 from numpy import floor, ceil, log, exp, sqrt, log1p, expm1, tanh, cosh, sinh
 
@@ -819,15 +819,10 @@ class randint_gen(rv_discrete):
 
     def _rvs(self, low, high):
         """An array of *size* random integers >= ``low`` and < ``high``."""
-        if hasattr(self._random_state, 'integers'):
-            # isinstance(self._random_state, np.random.Generator)
-            int_fun = self._random_state.integers
-        else:
-            int_fun = self._random_state.randint
-
         if np.asarray(low).size == 1 and np.asarray(high).size == 1:
             # no need to vectorize in that case
-            return int_fun(low, high, size=self._size)
+            return rng_integers(self._random_state, low, high, size=self._size)
+
         if self._size is not None:
             # NumPy's RandomState.randint() doesn't broadcast its arguments.
             # Use `broadcast_to()` to extend the shapes of low and high
@@ -835,8 +830,8 @@ class randint_gen(rv_discrete):
             # randint without needing to pass it a `size` argument.
             low = np.broadcast_to(low, self._size)
             high = np.broadcast_to(high, self._size)
-        randint = np.vectorize(int_fun, otypes=[np.int_])
-        return randint(low, high)
+        randint = np.vectorize(rng_integers, otypes=[np.int_])
+        return randint(self._random_state, low, high)
 
     def _entropy(self, low, high):
         return log(high - low)

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -2,6 +2,7 @@
 # Author:  Travis Oliphant  2002-2011 with contributions from
 #          SciPy Developers 2004-2011
 #
+from functools import partial
 from scipy import special
 from scipy.special import entr, logsumexp, betaln, gammaln as gamln
 from scipy._lib._util import _lazywhere, rng_integers
@@ -830,8 +831,9 @@ class randint_gen(rv_discrete):
             # randint without needing to pass it a `size` argument.
             low = np.broadcast_to(low, self._size)
             high = np.broadcast_to(high, self._size)
-        randint = np.vectorize(rng_integers, otypes=[np.int_])
-        return randint(self._random_state, low, high)
+        randint = np.vectorize(partial(rng_integers, self._random_state),
+                               otypes=[np.int_])
+        return randint(low, high)
 
     def _entropy(self, low, high):
         return log(high - low)

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -171,7 +171,8 @@ from numpy import array, asarray, ma
 
 from scipy.spatial.distance import cdist
 from scipy.ndimage import measurements
-from scipy._lib._util import _lazywhere, check_random_state, MapWrapper
+from scipy._lib._util import (_lazywhere, check_random_state, MapWrapper,
+                              rng_integers)
 import scipy.special as special
 from scipy import linalg
 from . import distributions
@@ -4351,7 +4352,7 @@ def _perm_test(x, y, stat, compute_distance, reps=1000, workers=-1,
     # generate seeds for each rep (change to new parallel random number
     # capabilities in numpy >= 1.17+)
     random_state = check_random_state(random_state)
-    random_states = [np.random.RandomState(random_state.randint(1 << 32,
+    random_states = [np.random.RandomState(rng_integers(random_state, 1 << 32,
                      size=4, dtype=np.uint32)) for _ in range(reps)]
 
     # parallelizes with specified workers over number of reps and set seeds

--- a/scipy/stats/tests/test_binned_statistic.py
+++ b/scipy/stats/tests/test_binned_statistic.py
@@ -44,7 +44,7 @@ class TestBinnedStatistic(object):
         # see issue gh-10126 for more
         x = self.x
         u = self.u
-
+        print(u)
         stat1, edges1, bc = binned_statistic(x, u, 'std', bins=10)
         stat2, edges2, bc = binned_statistic(x, u, np.std, bins=10)
 
@@ -55,10 +55,13 @@ class TestBinnedStatistic(object):
         # see issue gh-9010 for more
         x = self.x
         u = self.u
+        orig = u[0]
         u[0] = np.inf
         assert_raises(ValueError, binned_statistic, x, u, 'std', bins=10)
         u[0] = np.nan
         assert_raises(ValueError, binned_statistic, x, u, 'count', bins=10)
+        # replace original value, u belongs the class
+        u[0] = orig
 
     def test_1d_result_attributes(self):
         x = self.x

--- a/scipy/stats/tests/test_binned_statistic.py
+++ b/scipy/stats/tests/test_binned_statistic.py
@@ -44,7 +44,6 @@ class TestBinnedStatistic(object):
         # see issue gh-10126 for more
         x = self.x
         u = self.u
-        print(u)
         stat1, edges1, bc = binned_statistic(x, u, 'std', bins=10)
         stat2, edges2, bc = binned_statistic(x, u, np.std, bins=10)
 


### PR DESCRIPTION
_Copy of relevant message on the mailing list:_

On Tue, Mar 17, 2020 at 9:22 PM Andrew Nelson <andyfaff at gmail.com> wrote:

> Hi all,
> default random number generation is heading towards use of
> np.random.Generator, with RandomState being preserved for legacy usage. It
> would be nice to start using Generator's, but in order to do that in scipy
> we would need to be able to write code that worked with RandomState or
> Generator.
> Unfortunately there are a few methods that have changed their name,
> `randint `--> `integers` and `rand/random_sample` --> `random` spring to
> mind
>

FWIW, `random` exists in RandomState, too, so it's just a matter of using
the existing common name for that one. `randint` --> `integers` is the only
sticky one that I can recall.


> I was wondering if we could add a shim to go in `scipy._lib._util` that
> would permit code to be written as if it were using the Generator front end
> (at least most of it), but could be using either RandomState or Generator
> as a backend.
>

Instead of a wrapper object, which is inevitably going to be passed around
and thus introducing a third API for code to be aware of, I would recommend
having a set of functions for the few methods that have changed names. I.e.

def rng_integers(gen, low, high=None, ...):
    if isinstance(gen, Generator):
        return gen.integers(low, high=high, ...)
    else:
        return gen.randint(low, high=high, ...)

Yes, this also constitutes a third API, but it's one that can't "escape".
It only affects functions that call these functions because it doesn't
introduce a new object with its own lifetime to consider. It's also limited
to a couple of functions.

-- 
Robert Kern