### PR TITLE
BUG: fix mode='mirror' on length 1 axes

### DIFF
--- a/scipy/ndimage/src/ni_support.c
+++ b/scipy/ndimage/src/ni_support.c
@@ -227,6 +227,11 @@ int NI_ExtendLine(double *buffer, npy_intp line_length,
     double *last = first + line_length;
     double *src, *dst, val;
 
+    if ((line_length == 1) && (extend_mode == NI_EXTEND_MIRROR))
+    {
+        extend_mode = NI_EXTEND_NEAREST;
+    }
+
     switch (extend_mode) {
         /* aaaaaaaa|abcd|dddddddd */
         case NI_EXTEND_NEAREST:

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -428,6 +428,14 @@ class TestNdimage:
                                    mode='nearest', output=output, origin=1)
                 assert_array_almost_equal(output, tcov)
 
+    def test_correlate26(self):
+        # test fix for gh-11661 (mirror extension of a length 1 signal)
+        y = ndimage.convolve1d(numpy.ones(1), numpy.ones(5), mode='mirror')
+        assert_array_equal(y, numpy.array(5.))
+
+        y = ndimage.correlate1d(numpy.ones(1), numpy.ones(5), mode='mirror')
+        assert_array_equal(y, numpy.array(5.))
+
     def test_gauss01(self):
         input = numpy.array([[1, 2, 3],
                              [2, 4, 6]], numpy.float32)


### PR DESCRIPTION

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes gh-11661

#### What does this implement/fix?

The `mode='mirror'` boundary condition for `convolve1d` or `correlate1d` needs a special case for lines of length 1 ([a special case used to exist](https://github.com/scipy/scipy/blob/v0.19.1/scipy/ndimage/src/ni_support.c#L232-L241)). Basically, the solution here just falls back to `mode = 'nearest'` when the length is 1. This restores the SciPy 0.19 behavior for this edge case.

#### Additional information
A simplified test case corresponding to the example in #11661 was added.
