### PR TITLE
MAINT: sparse.linalg: avoid importing from `np.core`

### DIFF
--- a/scipy/sparse/linalg/_norm.py
+++ b/scipy/sparse/linalg/_norm.py
@@ -4,7 +4,7 @@
 import numpy as np
 from scipy.sparse import issparse
 
-from numpy.core import Inf, sqrt, abs
+from numpy import Inf, sqrt, abs
 
 __all__ = ['norm']
 
@@ -44,28 +44,28 @@ def norm(x, ord=None, axis=None):
 
     Notes
     -----
-    Some of the ord are not implemented because some associated functions like, 
-    _multi_svd_norm, are not yet available for sparse matrix. 
+    Some of the ord are not implemented because some associated functions like,
+    _multi_svd_norm, are not yet available for sparse matrix.
 
-    This docstring is modified based on numpy.linalg.norm. 
-    https://github.com/numpy/numpy/blob/master/numpy/linalg/linalg.py 
+    This docstring is modified based on numpy.linalg.norm.
+    https://github.com/numpy/numpy/blob/master/numpy/linalg/linalg.py
 
     The following norms can be calculated:
 
-    =====  ============================  
-    ord    norm for sparse matrices             
-    =====  ============================  
-    None   Frobenius norm                
-    'fro'  Frobenius norm                
-    inf    max(sum(abs(x), axis=1))      
-    -inf   min(sum(abs(x), axis=1))      
-    0      abs(x).sum(axis=axis)                           
-    1      max(sum(abs(x), axis=0))      
-    -1     min(sum(abs(x), axis=0))      
-    2      Not implemented  
-    -2     Not implemented      
-    other  Not implemented                               
-    =====  ============================  
+    =====  ============================
+    ord    norm for sparse matrices
+    =====  ============================
+    None   Frobenius norm
+    'fro'  Frobenius norm
+    inf    max(sum(abs(x), axis=1))
+    -inf   min(sum(abs(x), axis=1))
+    0      abs(x).sum(axis=axis)
+    1      max(sum(abs(x), axis=0))
+    -1     min(sum(abs(x), axis=0))
+    2      Not implemented
+    -2     Not implemented
+    other  Not implemented
+    =====  ============================
 
     The Frobenius norm is given by [1]_:
 


### PR DESCRIPTION
#### Reference issue
None

#### What does this implement/fix?
Currently `_norm` has the following import:

```
from numpy.core import Inf, sqrt, abs
```

this replaces it with

```
from numpy import Inf, sqrt, abs
```

since we should prefer importing from the top-level namespace.

#### Additional information
Found this as I was adding the NumPy type stubs-they don't
include those items in `np.core`. While in reality those items do
exist in core, adjusting the import seems most reasonable here. Note
that all the imported items are identical anyway:

```
>>> import numpy as np
>>> np.Inf is np.core.Inf
True
>>> np.sqrt is np.core.sqrt
True
>>> np.abs is np.core.abs
```