### PR TITLE
ENH: mypy: get specific about ignoring missing imports

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -3,7 +3,167 @@ files = scipy
 warn_redundant_casts = True
 warn_unused_ignores = True
 show_error_codes = True
-# Needed until all dependencies have types.
+
+#
+# Standard library modules that don't have types
+#
+
+[mypy-cffi]
+ignore_missing_imports = True
+
+#
+# Third party dependencies that don't have types.
+#
+
+[mypy-mpmath]
+ignore_missing_imports = True
+
+[mypy-matplotlib.*]
+ignore_missing_imports = True
+
+[mypy-pytest]
+ignore_missing_imports = True
+
+[mypy-sympy]
+ignore_missing_imports = True
+
+[mypy-sympy.*]
+ignore_missing_imports = True
+
+[mypy-sksparse]
+ignore_missing_imports = True
+
+[mypy-sksparse.*]
+ignore_missing_imports = True
+
+[mypy-sparse]
+ignore_missing_imports = True
+
+[mypy-scikits]
+ignore_missing_imports = True
+
+[mypy-scikits.*]
+ignore_missing_imports = True
+
+[mypy-uarray]
+ignore_missing_imports = True
+
+[mypy-psutil]
+ignore_missing_imports = True
+
+[mypy-pybind11]
+ignore_missing_imports = True
+
+#
+# Extension modules without stubs.
+#
+
+[mypy-scipy.signal._peak_finding_utils]
+ignore_missing_imports = True
+
+[mypy-scipy.signal._upfirdn_apply]
+ignore_missing_imports = True
+
+[mypy-scipy.signal._spectral]
+ignore_missing_imports = True
+
+[mypy-scipy.integrate._test_odeint_banded]
+ignore_missing_imports = True
+
+[mypy-scipy.integrate._test_multivariate]
+ignore_missing_imports = True
+
+[mypy-scipy._lib._ccallback_c]
+ignore_missing_imports = True
+
+[mypy-scipy.cluster._hierarchy]
+ignore_missing_imports = True
+
+[mypy-scipy.optimize._bglu_dense]
+ignore_missing_imports = True
+
+[mypy-scipy.optimize._slsqp]
+ignore_missing_imports = True
+
+[mypy-scipy.interpolate.dfitpack]
+ignore_missing_imports = True
+
+[mypy-scipy.spatial.qhull]
+ignore_missing_imports = True
+
+[mypy-scipy.interpolate.interpnd]
+ignore_missing_imports = True
+
+[mypy-scipy.special._ufuncs]
+ignore_missing_imports = True
+
+[mypy-scipy.spatial.ckdtree]
+ignore_missing_imports = True
+
+[mypy-scipy.linalg.cython_blas]
+ignore_missing_imports = True
+
+[mypy-scipy.linalg._decomp_update]
+ignore_missing_imports = True
+
+[mypy-scipy.linalg._solve_toeplitz]
+ignore_missing_imports = True
+
+[mypy-scipy.linalg._interpolative]
+ignore_missing_imports = True
+
+[mypy-scipy.optimize._group_columns]
+ignore_missing_imports = True
+
+[mypy-scipy.io.matlab.mio5_utils]
+ignore_missing_imports = True
+
+[mypy-scipy.io.matlab.streams]
+ignore_missing_imports = True
+
+[mypy-scipy.sparse.linalg.dsolve._superlu]
+ignore_missing_imports = True
+
+[mypy-scipy.io.matlab.mio_utils]
+ignore_missing_imports = True
+
+[mypy-scipy.sparse.csgraph._tools]
+ignore_missing_imports = True
+
+[mypy-scipy.sparse._sparsetools]
+ignore_missing_imports = True
+
+[mypy-scipy.sparse.csgraph._reordering]
+ignore_missing_imports = True
+
+[mypy-scipy.sparse.csgraph._matching]
+ignore_missing_imports = True
+
+[mypy-scipy.sparse.csgraph._flow]
+ignore_missing_imports = True
+
+[mypy-scipy.sparse.csgraph._min_spanning_tree]
+ignore_missing_imports = True
+
+[mypy-scipy.sparse.csgraph._traversal]
+ignore_missing_imports = True
+
+[mypy-scipy.sparse.csgraph._shortest_path]
+ignore_missing_imports = True
+
+[mypy-scipy.fft._pocketfft.pypocketfft]
+ignore_missing_imports = True
+
+[mypy-scipy.signal._max_len_seq_inner]
+ignore_missing_imports = True
+
+[mypy-scipy.special._ellip_harm_2]
+ignore_missing_imports = True
+
+[mypy-scipy._lib._fpumode]
+ignore_missing_imports = True
+
+[mypy-scipy.optimize._trlib._trlib]
 ignore_missing_imports = True
 
 #

--- a/mypy_requirements.txt
+++ b/mypy_requirements.txt
@@ -1,0 +1,2 @@
+mypy==0.770
+git+git://github.com/numpy/numpy-stubs.git@master


### PR DESCRIPTION
#### Reference issue
Closes https://github.com/scipy/scipy/issues/11686.

#### What does this implement/fix?
In the first iteration of the ratchet, we just ignored all missing
imports. This:

- Adds a `mypy_requirements.txt` file that will add the latest version
  of the NumPy types and stops ignoring NumPy imports
- Ignores all other third party modules
- Ignores extension modules (for now) since mypy can't find those
  without stubs

#### Additional information
Note that I'm leaving mypy in a dirty state-mostly because it appears
to have found some things worth looking into:

```
scipy/linalg/setup.py:121: error: Cannot find implementation or library stub for module named 'linalg_version'  [import]
scipy/linalg/setup.py:121: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
scipy/sparse/linalg/_norm.py:7: error: Module 'numpy.core' has no attribute 'Inf'  [attr-defined]
scipy/sparse/linalg/_norm.py:7: error: Module 'numpy.core' has no attribute 'sqrt'  [attr-defined]
scipy/sparse/linalg/_norm.py:7: error: Module 'numpy.core' has no attribute 'abs'  [attr-defined]
scipy/fftpack/tests/test_pseudo_diffs.py:325: error: List item 0 has incompatible type "Type[complex64]"; expected "Type[floating]"  [list-item]
scipy/fftpack/tests/test_pseudo_diffs.py:325: error: List item 1 has incompatible type "Type[complex128]"; expected "Type[floating]"  [list-item]
scipy/fftpack/tests/test_basic.py:758: error: List item 0 has incompatible type "Type[complex64]"; expected "Type[floating]"  [list-item]
scipy/fftpack/tests/test_basic.py:758: error: List item 1 has incompatible type "Type[complex128]"; expected "Type[floating]"  [list-item]
scipy/io/matlab/tests/test_mio.py:140: error: Argument 2 to "zeros" has incompatible type "List[Tuple[str, Type[object]]]"; expected "Union[dtype, None, type, str, Tuple[Any, int], Tuple[Any, Union[int, Sequence[int]]], List[Union[Tuple[Union[str, Tuple[str, str]], Any], Tuple[Union[str, Tuple[str, str]], Any, Union[int, Sequence[int]]]]], Dict[str, Union[Sequence[str], Sequence[Any], Sequence[int], Sequence[Union[bytes, str, None]], int]], Dict[str, Tuple[Any, int]], Tuple[Any, Any]]"  [arg-type]
scipy/io/matlab/tests/test_mio.py:140: note: "List" is invariant -- see http://mypy.readthedocs.io/en/latest/common_issues.html#variance
scipy/io/matlab/tests/test_mio.py:140: note: Consider using "Sequence" instead, which is covariant
scipy/linalg/tests/test_decomp_cossin.py:12: error: Unsupported operand types for + ("List[Type[floating]]" and "List[Type[complexfloating]]")  [operator]
Found 10 errors in 6 files (checked 626 source files)
```

One of the things is https://github.com/scipy/scipy/pull/11687, this one

```
scipy/linalg/setup.py:121: error: Cannot find implementation or library stub for module named 'linalg_version'  [import]
```

appears to be because we should be doing a relative import here:

https://github.com/scipy/scipy/blob/master/scipy/linalg/setup.py#L121