### PR TITLE
MAINT: mypy: fix errors about incompatible types in lists

### DIFF
--- a/scipy/fftpack/tests/test_basic.py
+++ b/scipy/fftpack/tests/test_basic.py
@@ -754,8 +754,8 @@ class FakeArray2(object):
 class TestOverwrite(object):
     """Check input overwrite behavior of the FFT functions."""
 
-    real_dtypes = [np.float32, np.float64]
-    dtypes = real_dtypes + [np.complex64, np.complex128]
+    real_dtypes = (np.float32, np.float64)
+    dtypes = real_dtypes + (np.complex64, np.complex128)
     fftsizes = [8, 16, 32]
 
     def _check(self, x, routine, fftsize, axis, overwrite_x):

--- a/scipy/fftpack/tests/test_pseudo_diffs.py
+++ b/scipy/fftpack/tests/test_pseudo_diffs.py
@@ -321,8 +321,8 @@ class TestShift(object):
 class TestOverwrite(object):
     """Check input overwrite behavior """
 
-    real_dtypes = [np.float32, np.float64]
-    dtypes = real_dtypes + [np.complex64, np.complex128]
+    real_dtypes = (np.float32, np.float64)
+    dtypes = real_dtypes + (np.complex64, np.complex128)
 
     def _check(self, x, routine, *args, **kwargs):
         x2 = x.copy()

--- a/scipy/linalg/tests/test_decomp_cossin.py
+++ b/scipy/linalg/tests/test_decomp_cossin.py
@@ -7,8 +7,8 @@ from scipy.linalg.lapack import _compute_lwork
 from scipy.stats import ortho_group, unitary_group
 from scipy.linalg import cossin, get_lapack_funcs, block_diag
 
-REAL_DTYPES = [np.float32, np.float64]
-COMPLEX_DTYPES = [np.complex64, np.complex128]
+REAL_DTYPES = (np.float32, np.float64)
+COMPLEX_DTYPES = (np.complex64, np.complex128)
 DTYPES = REAL_DTYPES + COMPLEX_DTYPES
 
 


### PR DESCRIPTION
#### Reference issue
None

#### What does this implement/fix?
The following construct appears several times in the codebase:

```
real_dtypes = [np.float32, np.float64]
dtypes = real_dtypes + [np.complex64, np.complex128]
```

Mypy doesn't like that because

- it types the first list as `Type[np.floating]`
- the second line then tries to add things of type `Type[np.complex64]`
- lists are invariant:

  https://mypy.readthedocs.io/en/stable/common_issues.html#invariance-vs-covariance

We could fix this by explicitly typing the first list more
broadly, but this instead fixes it by making those lists
tuples. Philosophically tuples make sense here-we are creating a
fixed length, immutable sequence of dtypes to iterate over, not a
mutable possibly growing container of dtypes.

#### Additional information
Mypy started picking this up because we added the NumPy type
stubs-before both of those lists would have been `List[Any]`,
which mypy would have been fine with.