### PR TITLE
MAINT: mypy: fix remaining type errors

### DIFF
--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -137,7 +137,12 @@ case_table5.append(
      })
 st_sub_arr = array([np.sqrt(2),np.exp(1),np.pi]).reshape(1,3)
 dtype = [(n, object) for n in ['stringfield', 'doublefield', 'complexfield']]
-st1 = np.zeros((1,1), dtype)
+# See
+#
+# https://github.com/numpy/numpy-stubs/issues/42
+#
+# for the reasoning behind the ignore.
+st1 = np.zeros((1,1), dtype)  # type: ignore[arg-type]
 st1['stringfield'][0,0] = array(['Rats live on no evil star.'])
 st1['doublefield'][0,0] = st_sub_arr
 st1['complexfield'][0,0] = st_sub_arr * (1 + 1j)

--- a/scipy/linalg/__init__.py
+++ b/scipy/linalg/__init__.py
@@ -95,8 +95,8 @@ Decompositions
    rsf2csf - Real to complex Schur form
    hessenberg - Hessenberg form of a matrix
    cdf2rdf - Complex diagonal form to real diagonal block form
-   cossin - Cosine sine decomposition of a unitary or orthogonal matrix   
-   
+   cossin - Cosine sine decomposition of a unitary or orthogonal matrix
+
 .. seealso::
 
    `scipy.linalg.interpolative` -- Interpolative matrix decompositions
@@ -189,8 +189,6 @@ Low-level routines
    `scipy.linalg.cython_lapack` -- Low-level LAPACK functions for Cython
 
 """  # noqa: E501
-
-from .linalg_version import linalg_version as __version__
 
 from .misc import *
 from .basic import *

--- a/scipy/linalg/linalg_version.py
+++ b/scipy/linalg/linalg_version.py
@@ -1,5 +1,0 @@
-major = 0
-minor = 4
-micro = 9
-
-linalg_version = '%(major)d.%(minor)d.%(micro)d' % (locals())

--- a/scipy/linalg/setup.py
+++ b/scipy/linalg/setup.py
@@ -118,7 +118,5 @@ def configuration(parent_package='', top_path=None):
 
 if __name__ == '__main__':
     from numpy.distutils.core import setup
-    from scipy.linalg.linalg_version import linalg_version
 
-    setup(version=linalg_version,
-          **configuration(top_path='').todict())
+    setup(**configuration(top_path='').todict())

--- a/scipy/linalg/setup.py
+++ b/scipy/linalg/setup.py
@@ -118,7 +118,7 @@ def configuration(parent_package='', top_path=None):
 
 if __name__ == '__main__':
     from numpy.distutils.core import setup
-    from linalg_version import linalg_version
+    from scipy.linalg.linalg_version import linalg_version
 
     setup(version=linalg_version,
           **configuration(top_path='').todict())


### PR DESCRIPTION

#### Reference issue
None

#### What does this implement/fix?
This fixes the remaining mypy errors. One error appears to be an issue in the NumPy stubs:

https://github.com/numpy/numpy-stubs/issues/42

The other is fixed by modifying how we import `linalg_version` inside the linalg setup.

#### Additional information
None