### PR TITLE
TST, MAINT: bump to OpenBLAS 0.3.9 stable, raise tol for Win 32-bit test_L4()

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -159,7 +159,7 @@ jobs:
     displayName: 'Build SciPy'
   - powershell: |
       $env:PATH = "C:\\ProgramData\\chocolatey\\lib\\mingw\\tools\\install\\mingw$(BITS)\\bin;" + $env:PATH
-      python runtests.py -n --mode=$(TEST_MODE) -- -n 2 -rsx --junitxml=junit/test-results.xml --cov=scipy --cov-report=xml --cov-report=html
+      python runtests.py -n --mode=$(TEST_MODE) -- -n 2 -rsx --junitxml=junit/test-results.xml --cov=scipy --cov-report=xml --cov-report=html --durations=10
     displayName: 'Run SciPy Test Suite'
   - task: PublishTestResults@2
     condition: succeededOrFailed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -159,7 +159,7 @@ jobs:
     displayName: 'Build SciPy'
   - powershell: |
       $env:PATH = "C:\\ProgramData\\chocolatey\\lib\\mingw\\tools\\install\\mingw$(BITS)\\bin;" + $env:PATH
-      python runtests.py -n --mode=$(TEST_MODE) -- -n auto -rsx --junitxml=junit/test-results.xml --cov=scipy --cov-report=xml --cov-report=html
+      python runtests.py -n --mode=$(TEST_MODE) -- -n 2 -rsx --junitxml=junit/test-results.xml --cov=scipy --cov-report=xml --cov-report=html
     displayName: 'Run SciPy Test Suite'
   - task: PublishTestResults@2
     condition: succeededOrFailed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,7 @@ pr:
 # the version of OpenBLAS used is currently 0.3.8.dev
 # and should be updated to match scipy-wheels as appropriate
 variables:
-    openblas_version: 0.3.8.dev
+    openblas_version: 0.3.9
 
 jobs:
 - job: Linux_Python_36_32bit_full

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -998,7 +998,14 @@ class TestDifferentialEvolutionSolver(object):
 
         assert_allclose(f(x_opt), f_opt, atol=0.001)
         assert_allclose(res.fun, f_opt, atol=0.001)
-        assert_allclose(res.x, x_opt, atol=0.002)
+
+        # selectively use higher tol here for 32-bit
+        # Windows based on gh-11693
+        if (platform.system() == 'Windows' and np.dtype(np.intp).itemsize < 8):
+            assert_allclose(res.x, x_opt, rtol=2.4e-6, atol=0.0035)
+        else:
+            assert_allclose(res.x, x_opt, atol=0.002)
+
         assert res.success
         assert_(np.all(A @ res.x <= b))
         assert_(np.all(np.array(c1(res.x)) >= 0))

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -11,8 +11,8 @@ from urllib.error import HTTPError
 import zipfile
 import tarfile
 
-OPENBLAS_V = 'v0.3.8'
-OPENBLAS_LONG = 'v0.3.5-605-gc815b8fb'  # the 0.3.5 is misleading
+OPENBLAS_V = 'v0.3.9'
+OPENBLAS_LONG = 'v0.3.9'
 BASE_LOC = ''
 ANACONDA = 'https://anaconda.org/multibuild-wheels-staging/openblas-libs'
 ARCHITECTURES = ['', 'windows', 'darwin', 'aarch64', 'x86', 'ppc64le', 's390x']


### PR DESCRIPTION
Fixes #11693, if I'm lucky with my CI changes & we don't have a timeout, which is another recent issue..

* local testing suggests that failures in
`TestDifferentialEvolutionSolver::test_L4`
observed in Azure CI are related to the version
of OpenBLAS linked to SciPy; bumping from `0.3.7`
to `0.3.9` stable locally causes the test to switch
from 100 % fail to 100 % pass on 5 repeats

* also, the next release of SciPy will likely use
OpenBLAS 0.3.9 stable of higher, so probably good
to bump anyway