### PR TITLE
MAINT: special: add rudimentary types for `_ufuncs` extension module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -248,6 +248,7 @@ scipy/special/_ufuncs_cxx.pxd
 scipy/special/_ufuncs_cxx.pyx
 scipy/special/_ufuncs_cxx_defs.h
 scipy/special/_ufuncs_defs.h
+scipy/special/_ufuncs.pyi
 scipy/special/cython_special.c
 scipy/special/cython_special.h
 scipy/special/cython_special.pxd

--- a/mypy.ini
+++ b/mypy.ini
@@ -94,9 +94,6 @@ ignore_missing_imports = True
 [mypy-scipy.interpolate.interpnd]
 ignore_missing_imports = True
 
-[mypy-scipy.special._ufuncs]
-ignore_missing_imports = True
-
 [mypy-scipy.spatial.ckdtree]
 ignore_missing_imports = True
 
@@ -285,9 +282,6 @@ ignore_errors = True
 [mypy-scipy.sparse.tests.test_base]
 ignore_errors = True
 
-[mypy-scipy.special.tests.test_nan_inputs]
-ignore_errors = True
-
 [mypy-scipy.linalg.basic]
 ignore_errors = True
 
@@ -354,15 +348,9 @@ ignore_errors = True
 [mypy-scipy.linalg._generate_pyx]
 ignore_errors = True
 
-[mypy-scipy.special.add_newdocs]
-ignore_errors = True
-
 #
 # Files referencing compiled code that needs stubs added.
 #
-
-[mypy-scipy.stats.tests.test_distributions]
-ignore_errors = True
 
 [mypy-scipy.stats.tests.test_multivariate]
 ignore_errors = True
@@ -388,13 +376,7 @@ ignore_errors = True
 [mypy-scipy.signal.signaltools]
 ignore_errors = True
 
-[mypy-scipy.stats.tests.test_contingency]
-ignore_errors = True
-
 [mypy-scipy.stats.tests.test_discrete_distns]
-ignore_errors = True
-
-[mypy-scipy.stats.vonmises]
 ignore_errors = True
 
 [mypy-scipy.stats.mstats_extras]
@@ -412,13 +394,7 @@ ignore_errors = True
 [mypy-scipy.stats.stats]
 ignore_errors = True
 
-[mypy-scipy.stats._discrete_distns]
-ignore_errors = True
-
 [mypy-scipy.interpolate.tests.test_interpolate]
-ignore_errors = True
-
-[mypy-scipy.special.tests.test_data]
 ignore_errors = True
 
 [mypy-scipy.stats._distn_infrastructure]
@@ -511,18 +487,6 @@ ignore_errors = True
 [mypy-scipy.sparse.linalg.isolve.tests.test_lsmr]
 ignore_errors = True
 
-[mypy-scipy.special.tests.test_basic]
-ignore_errors = True
-
-[mypy-scipy.special.tests.test_kolmogorov]
-ignore_errors = True
-
-[mypy-scipy.special.tests.test_loggamma]
-ignore_errors = True
-
-[mypy-scipy.special.tests.test_spence]
-ignore_errors = True
-
 [mypy-scipy.linalg.tests.test_blas]
 ignore_errors = True
 
@@ -547,28 +511,10 @@ ignore_errors = True
 [mypy-scipy.sparse.linalg.tests.test_matfuncs]
 ignore_errors = True
 
-[mypy-scipy.special.tests.test_boxcox]
-ignore_errors = True
-
 [mypy-scipy.special.tests.test_cython_special]
 ignore_errors = True
 
-[mypy-scipy.special.tests.test_erfinv]
-ignore_errors = True
-
-[mypy-scipy.special.tests.test_exponential_integrals]
-ignore_errors = True
-
-[mypy-scipy.special.tests.test_logit]
-ignore_errors = True
-
 [mypy-scipy.special.tests.test_round]
-ignore_errors = True
-
-[mypy-scipy.special.tests.test_spfun_stats]
-ignore_errors = True
-
-[mypy-scipy.stats._tukeylambda_stats]
 ignore_errors = True
 
 [mypy-scipy.io.tests.test_fortran]
@@ -590,9 +536,6 @@ ignore_errors = True
 ignore_errors = True
 
 [mypy-scipy.special.orthogonal]
-ignore_errors = True
-
-[mypy-scipy.special.spfun_stats]
 ignore_errors = True
 
 [mypy-scipy.linalg._matfuncs_sqrtm]

--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -6,8 +6,9 @@
 # _generate_pyx.py to generate the docstrings for the ufuncs in
 # scipy.special at the C level when the ufuncs are created at compile
 # time.
+from typing import Dict
 
-docdict = {}
+docdict: Dict[str, str] = {}
 
 
 def get(name):

--- a/scipy/special/tests/test_nan_inputs.py
+++ b/scipy/special/tests/test_nan_inputs.py
@@ -1,15 +1,17 @@
 """Test how the ufuncs in special handle nan inputs.
 
 """
+from typing import Callable, Dict
+
 import numpy as np
 from numpy.testing import assert_array_equal, assert_, suppress_warnings
 import pytest
 import scipy.special as sc
 
 
-KNOWNFAILURES = {}
+KNOWNFAILURES: Dict[str, Callable] = {}
 
-POSTPROCESSING = {}
+POSTPROCESSING: Dict[str, Callable] = {}
 
 
 def _get_ufuncs():


### PR DESCRIPTION
#### Reference issue
None

#### What does this implement/fix?
This adds codegen to generate stubs for `special._ufuncs` that type
everything as `Any`. Obviously that is terrible typing, but:

- There is still some value-mypy will now tell you if you try to
  access a function in special that doesn't exist
- We need to add `np.ufunc` to the NumPy stubs before we can do it
  right
- It lets us remove a bunch of things from the ratchet.

I think the final point is important-if we remove the ratchet then the
door is opened to actually distributing our types per PEP 561, so it
might be reasonable to get terrible types in place and then gradually
improve them.

#### Additional information
None