### PR TITLE
BUG: Fixed a post-merge bug for eigh()

### DIFF
--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -521,7 +521,7 @@ def eigh(a, b=None, lower=True, eigvals_only=False, overwrite_a=False,
                   'syevd': ['lwork', 'liwork'],
                   'syevr': ['lwork', 'liwork'],
                   'heevd': ['lwork', 'liwork', 'lrwork'],
-                  'heevr': ['lwork', 'liwork', 'lrwork'],
+                  'heevr': ['lwork', 'lrwork', 'liwork'],
                   }
 
     if b is None:  # Standard problem
@@ -533,7 +533,7 @@ def eigh(a, b=None, lower=True, eigvals_only=False, overwrite_a=False,
 
         lw = _compute_lwork(drvlw, **clw_args)
         # Multiple lwork vars
-        if isinstance(drvlw, tuple):
+        if isinstance(lw, tuple):
             lwork_args = dict(zip(lwork_spec[pfx+driver], lw))
         else:
             lwork_args = {'lwork': lw}

--- a/scipy/linalg/flapack_sym_herm.pyf.src
+++ b/scipy/linalg/flapack_sym_herm.pyf.src
@@ -127,7 +127,7 @@ subroutine <prefix2>syevd(compute_v,lower,n,w,a,lda,work,lwork,iwork,liwork,info
     check(lwork>=(compute_v?1+6*n+2*n*n:2*n+1)) :: lwork
     <ftype2> dimension(lwork),intent(hide,cache),depend(lwork) :: work
 
-    integer intent(hide),depend(n,compute_v) :: liwork = (compute_v?3+5*n:1)
+    integer optional,intent(in),depend(n,compute_v) :: liwork = (compute_v?3+5*n:1)
     integer dimension(liwork),intent(hide,cache),depend(liwork) :: iwork
 
     integer intent(out) :: info
@@ -183,10 +183,10 @@ subroutine <prefix2c>heevd(compute_v,lower,n,w,a,lda,work,lwork,iwork,liwork,rwo
     check(lwork>=(compute_v?2*n+n*n:n+1)) :: lwork
     <ftype2c> dimension(lwork),intent(hide,cache),depend(lwork) :: work
 
-    integer intent(hide),depend(n,compute_v) :: liwork = (compute_v?3+5*n:1)
+    integer optional,intent(in),depend(n,compute_v) :: liwork = (compute_v?3+5*n:1)
     integer dimension(liwork),intent(hide,cache),depend(liwork) :: iwork
 
-    integer intent(hide),depend(n,compute_v) :: lrwork = (compute_v?1+5*n+2*n*n:n)
+    integer optional,intent(in),depend(n,compute_v) :: lrwork = (compute_v?1+5*n+2*n*n:n)
     <ftype2> dimension(lrwork),intent(hide,cache),depend(n,lrwork) :: rwork
     integer intent(out) :: info
 


### PR DESCRIPTION

#### Reference issue
Fixes #11601 

#### What does this implement/fix?
Due to a typo `lwork` keyword, expecting an integer, was receiving a tuple and in some systems this was a segfault result. In other systems somehow passed through including our CI/CD. This was due to `lwork` variables having default values when not supplied. Hence they only got a performance hit. 

#### Additional information
After fixing the typo a few more items are also fixed.