### PR TITLE
Improves docstring with consistent L2-norm

### DIFF
--- a/scipy/sparse/linalg/isolve/lsqr.py
+++ b/scipy/sparse/linalg/isolve/lsqr.py
@@ -98,7 +98,7 @@ def lsqr(A, b, damp=0.0, atol=1e-8, btol=1e-8, conlim=1e8,
     """Find the least-squares solution to a large, sparse, linear system
     of equations.
 
-    The function solves ``Ax = b``  or  ``min ||b - Ax||^2`` or
+    The function solves ``Ax = b``  or  ``min ||Ax - b||^2`` or
     ``min ||Ax - b||^2 + d^2 ||x||^2``.
 
     The matrix A may be square or rectangular (over-determined or


### PR DESCRIPTION
#### Reference issue
None

#### What does this implement/fix?
Improves docstring with consistent L2-norm contents. The current docstring makes it seem that adding damping is a bigger change than it is by rearranging the L2-norm, but ||b - Ax||_2 = ||Ax - b||_2.