### PR TITLE
DOC: Slerp the SphericalVoronoi docstring

### DIFF
--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -120,24 +120,20 @@ class SphericalVoronoi:
     ...                    c='g')
     >>> # indicate Voronoi regions (as Euclidean polygons)
     >>> for region in sv.regions:
-    ...    region_size = len(region)
-    ...    for i in range(region_size):
-    ...        if i == (region_size - 1):
-    ...            next_index = 0
-    ...        else:
-    ...            next_index = i + 1
+    ...    n = len(region)
+    ...    for i in range(n):
     ...        start = sv.vertices[region][i]
-    ...        end = sv.vertices[region][next_index]
+    ...        end = sv.vertices[region][(i + 1) % n]
     ...        result = geometric_slerp(start, end, t_vals)
-    ...        ax.plot(result[...,0],
-    ...                result[...,1],
-    ...                result[...,2],
+    ...        ax.plot(result[..., 0],
+    ...                result[..., 1],
+    ...                result[..., 2],
     ...                c='k')
     >>> ax.azim = 10
     >>> ax.elev = 40
-    >>> ax.set_xticks([])
-    >>> ax.set_yticks([])
-    >>> ax.set_zticks([])
+    >>> _ = ax.set_xticks([])
+    >>> _ = ax.set_yticks([])
+    >>> _ = ax.set_zticks([])
     >>> fig.set_size_inches(4, 4)
     >>> plt.show()
 

--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -86,10 +86,8 @@ class SphericalVoronoi:
     --------
     Do some imports and take some points on a cube:
 
-    >>> from matplotlib import colors
-    >>> from mpl_toolkits.mplot3d.art3d import Poly3DCollection
     >>> import matplotlib.pyplot as plt
-    >>> from scipy.spatial import SphericalVoronoi
+    >>> from scipy.spatial import SphericalVoronoi, geometric_slerp
     >>> from mpl_toolkits.mplot3d import proj3d
     >>> # set input data
     >>> points = np.array([[0, 0, 1], [0, 0, -1], [1, 0, 0],
@@ -105,6 +103,7 @@ class SphericalVoronoi:
 
     >>> # sort vertices (optional, helpful for plotting)
     >>> sv.sort_vertices_of_regions()
+    >>> t_vals = np.linspace(0, 1, 2000)
     >>> fig = plt.figure()
     >>> ax = fig.add_subplot(111, projection='3d')
     >>> # plot the unit sphere for reference (optional)
@@ -121,10 +120,25 @@ class SphericalVoronoi:
     ...                    c='g')
     >>> # indicate Voronoi regions (as Euclidean polygons)
     >>> for region in sv.regions:
-    ...    random_color = colors.rgb2hex(np.random.rand(3))
-    ...    polygon = Poly3DCollection([sv.vertices[region]], alpha=1.0)
-    ...    polygon.set_color(random_color)
-    ...    ax.add_collection3d(polygon)
+    ...    region_size = len(region)
+    ...    for i in range(region_size):
+    ...        if i == (region_size - 1):
+    ...            next_index = 0
+    ...        else:
+    ...            next_index = i + 1
+    ...        start = sv.vertices[region][i]
+    ...        end = sv.vertices[region][next_index]
+    ...        result = geometric_slerp(start, end, t_vals)
+    ...        ax.plot(result[...,0],
+    ...                result[...,1],
+    ...                result[...,2],
+    ...                c='k')
+    >>> ax.azim = 10
+    >>> ax.elev = 40
+    >>> ax.set_xticks([])
+    >>> ax.set_yticks([])
+    >>> ax.set_zticks([])
+    >>> fig.set_size_inches(4, 4)
     >>> plt.show()
 
     """


### PR DESCRIPTION
* the `Examples` section of the `SphericalVoronoi`
docstring now leverages `geometric_slerp` to produce
a much more realistic/accessible 3D plot of the
Voronoi regions on the sphere

Before: 

![test](https://user-images.githubusercontent.com/7903078/77238186-b6d50600-6b93-11ea-8296-79f0b77f992c.png)

After: 

![test_new](https://user-images.githubusercontent.com/7903078/77238192-c3f1f500-6b93-11ea-9f00-a7471dabac8c.png)

Here's the current devdocs version: https://scipy.github.io/devdocs/generated/scipy.spatial.SphericalVoronoi.html?highlight=sphericalvoronoi#scipy.spatial.SphericalVoronoi

Hopefully this new version looks nice in the docstring render as well (seems better locally at least).