### PR TITLE
ENH: mypy: add `--mypy` option to `runtests.py`

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,4 @@
 [mypy]
-files = scipy
 warn_redundant_casts = True
 warn_unused_ignores = True
 show_error_codes = True

--- a/runtests.py
+++ b/runtests.py
@@ -55,6 +55,7 @@ import os
 sys.path.pop(0)
 
 from argparse import ArgumentParser, REMAINDER
+import contextlib
 import shutil
 import subprocess
 import time
@@ -124,6 +125,8 @@ def main(argv):
                         help="Arguments to pass to Nose, Python or shell")
     parser.add_argument("--pep8", action="store_true", default=False,
                         help="Perform pep8 check with pycodestyle.")
+    parser.add_argument("--mypy", action="store_true", default=False,
+                        help="Run mypy on the codebase")
     parser.add_argument("--doc", action="append", nargs="?",
                         const="html-scipyorg", help="Build documentation")
     args = parser.parse_args(argv)
@@ -135,6 +138,9 @@ def main(argv):
         #           "--exclude=scipy/_lib/six.py")
         os.system("pycodestyle scipy benchmarks/benchmarks")
         sys.exit(0)
+
+    if args.mypy:
+        sys.exit(run_mypy(args))
 
     if args.bench_compare:
         args.bench = True
@@ -470,6 +476,50 @@ def lcov_generate():
         print("genhtml failed!")
     else:
         print("HTML output generated under build/lcov/")
+
+
+@contextlib.contextmanager
+def working_dir(new_dir):
+    current_dir = os.getcwd()
+    try:
+        os.chdir(new_dir)
+        yield
+    finally:
+        os.chdir(current_dir)
+
+
+def run_mypy(args):
+    if args.no_build:
+        raise ValueError('Cannot run mypy with --no-build')
+
+    mypy_check = subprocess.run(
+        [sys.executable, "-m", "mypy", "-V"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    if mypy_check.returncode != 0:
+        raise RuntimeError(
+            "Mypy not found. Please install it by running "
+            "pip install -r mypy_requirements.txt from the repo root"
+        )
+
+    site_dir = build_project(args)
+    config = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        "mypy.ini",
+    )
+    with working_dir(site_dir):
+        # Change to the site directory to make sure mypy doesn't
+        # pick up any type stubs in the source tree.
+        result = subprocess.run([
+            sys.executable,
+            "-m",
+            "mypy",
+            "--config-file",
+            config,
+            PROJECT_MODULE,
+        ])
+    return result.returncode
 
 
 if __name__ == "__main__":

--- a/scipy/special/setup.py
+++ b/scipy/special/setup.py
@@ -159,6 +159,9 @@ def configuration(parent_package='',top_path=None):
 
     config.add_subpackage('_precompute')
 
+    # Type stubs
+    config.add_data_files('_ufuncs.pyi')
+
     return config
 
 


### PR DESCRIPTION
#### Reference issue
None

#### What does this implement/fix?
To ensure that we are all running mypy in a consistent fashion, add a way to run mypy through `runtests.py`.

#### Additional information
You can still run mypy against an in-place build by doing

```
$ python setup.py build_ext -i
$ mypy scipy
```