### PR TITLE
MAINT: io: Remove now-unnecessary `# type: ignore`

### DIFF
--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -137,12 +137,7 @@ case_table5.append(
      })
 st_sub_arr = array([np.sqrt(2),np.exp(1),np.pi]).reshape(1,3)
 dtype = [(n, object) for n in ['stringfield', 'doublefield', 'complexfield']]
-# See
-#
-# https://github.com/numpy/numpy-stubs/issues/42
-#
-# for the reasoning behind the ignore.
-st1 = np.zeros((1,1), dtype)  # type: ignore[arg-type]
+st1 = np.zeros((1,1), dtype)
 st1['stringfield'][0,0] = array(['Rats live on no evil star.'])
 st1['doublefield'][0,0] = st_sub_arr
 st1['complexfield'][0,0] = st_sub_arr * (1 + 1j)


### PR DESCRIPTION
#### Reference issue
None

#### What does this implement/fix?
Now that https://github.com/numpy/numpy-stubs/issues/42 is resolved we can remove an ignore from `test_mio.py`.

#### Additional information
If checking this locally, make sure to install the latest NumPy types.