### PR TITLE
MAINT: mypy: remove mpmath from the ratchet

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -15,9 +15,6 @@ ignore_missing_imports = True
 # Third party dependencies that don't have types.
 #
 
-[mypy-mpmath]
-ignore_missing_imports = True
-
 [mypy-matplotlib.*]
 ignore_missing_imports = True
 

--- a/scipy/signal/tests/mpsig.py
+++ b/scipy/signal/tests/mpsig.py
@@ -3,7 +3,7 @@ Some signal functions implemented using mpmath.
 """
 
 try:
-    import mpmath
+    import mpmath  # type: ignore[import]
 except ImportError:
     mpmath = None
 

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -23,7 +23,7 @@ from scipy.signal.filter_design import (_cplxreal, _cplxpair, _norm_factor,
                                         _bessel_poly, _bessel_zeros)
 
 try:
-    import mpmath
+    import mpmath  # type: ignore[import]
 except ImportError:
     mpmath = None
 

--- a/scipy/special/_mptestutils.py
+++ b/scipy/special/_mptestutils.py
@@ -9,7 +9,7 @@ import pytest
 from scipy.special._testutils import assert_func_equal
 
 try:
-    import mpmath
+    import mpmath  # type: ignore[import]
 except ImportError:
     pass
 

--- a/scipy/special/_precompute/gammainc_asy.py
+++ b/scipy/special/_precompute/gammainc_asy.py
@@ -12,7 +12,7 @@ import os
 from scipy.special._precompute.utils import lagrange_inversion
 
 try:
-    import mpmath as mp
+    import mpmath as mp  # type: ignore[import]
 except ImportError:
     pass
 
@@ -50,7 +50,7 @@ def compute_alpha(n):
     """alpha_n from DLMF 8.12.13"""
     coeffs = mp.taylor(eta, 0, n - 1)
     return lagrange_inversion(coeffs)
-    
+
 
 def compute_d(K, N):
     """d_{k, n} from DLMF 8.12.12"""

--- a/scipy/special/_precompute/gammainc_data.py
+++ b/scipy/special/_precompute/gammainc_data.py
@@ -25,7 +25,7 @@ from numpy import pi
 from scipy.special._mptestutils import mpf2float
 
 try:
-    import mpmath as mp
+    import mpmath as mp  # type: ignore[import]
 except ImportError:
     pass
 
@@ -35,7 +35,7 @@ def gammainc(a, x, dps=50, maxterms=10**8):
     summands in hypercomb. See
 
     mpmath/functions/expintegrals.py#L134
-    
+
     in the mpmath github repository.
 
     """
@@ -63,7 +63,7 @@ def gammaincc(a, x, dps=50, maxterms=10**8):
     """
     with mp.workdps(dps):
         z, a = a, x
-        
+
         if mp.isint(z):
             try:
                 # mpmath has a fast integer path
@@ -98,7 +98,7 @@ def main():
     r = np.logspace(4, 14, 30)
     ltheta = np.logspace(np.log10(pi/4), np.log10(np.arctan(0.6)), 30)
     utheta = np.logspace(np.log10(pi/4), np.log10(np.arctan(1.4)), 30)
-    
+
     regimes = [(gammainc, ltheta), (gammaincc, utheta)]
     for func, theta in regimes:
         rg, thetag = np.meshgrid(r, theta)

--- a/scipy/special/_precompute/lambertw.py
+++ b/scipy/special/_precompute/lambertw.py
@@ -6,7 +6,7 @@ approximations.
 import numpy as np
 
 try:
-    import mpmath
+    import mpmath  # type: ignore[import]
     import matplotlib.pyplot as plt
 except ImportError:
     pass

--- a/scipy/special/_precompute/loggamma.py
+++ b/scipy/special/_precompute/loggamma.py
@@ -1,7 +1,7 @@
 """Precompute series coefficients for log-Gamma."""
 
 try:
-    import mpmath
+    import mpmath  # type: ignore[import]
 except ImportError:
     pass
 
@@ -41,4 +41,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-    

--- a/scipy/special/_precompute/struve_convergence.py
+++ b/scipy/special/_precompute/struve_convergence.py
@@ -34,7 +34,7 @@ Black dashed line
 import numpy as np
 import matplotlib.pyplot as plt
 
-import mpmath
+import mpmath  # type: ignore[import]
 
 
 def err_metric(a, b, atol=1e-290):

--- a/scipy/special/_precompute/utils.py
+++ b/scipy/special/_precompute/utils.py
@@ -1,7 +1,7 @@
 from numpy.testing import suppress_warnings
 
 try:
-    import mpmath as mp
+    import mpmath as mp  # type: ignore[import]
 except ImportError:
     pass
 

--- a/scipy/special/_precompute/wrightomega.py
+++ b/scipy/special/_precompute/wrightomega.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 try:
-    import mpmath
+    import mpmath  # type: ignore[import]
 except ImportError:
     pass
 

--- a/scipy/special/_precompute/zetac.py
+++ b/scipy/special/_precompute/zetac.py
@@ -1,6 +1,6 @@
 """Compute the Taylor series for zeta(x) - 1 around x = 0."""
 try:
-    import mpmath
+    import mpmath  # type: ignore[import]
 except ImportError:
     pass
 

--- a/scipy/special/tests/test_cdflib.py
+++ b/scipy/special/tests/test_cdflib.py
@@ -32,7 +32,7 @@ from scipy.special._mptestutils import (
     Arg, IntArg, get_args, mpf2float, assert_mpmath_equal)
 
 try:
-    import mpmath
+    import mpmath  # type: ignore[import]
 except ImportError:
     mpmath = MissingModule('mpmath')
 

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -23,7 +23,7 @@ from scipy.special._ufuncs import (
     _igam_fac)
 
 try:
-    import mpmath
+    import mpmath  # type: ignore[import]
 except ImportError:
     mpmath = MissingModule('mpmath')
 

--- a/scipy/special/tests/test_precompute_gammainc.py
+++ b/scipy/special/tests/test_precompute_gammainc.py
@@ -14,7 +14,7 @@ except ImportError:
     sympy = MissingModule('sympy')
 
 try:
-    import mpmath as mp
+    import mpmath as mp  # type: ignore[import]
 except ImportError:
     mp = MissingModule('mpmath')
 

--- a/scipy/special/tests/test_precompute_utils.py
+++ b/scipy/special/tests/test_precompute_utils.py
@@ -10,7 +10,7 @@ except ImportError:
     sympy = MissingModule('sympy')
 
 try:
-    import mpmath as mp
+    import mpmath as mp  # type: ignore[import]
 except ImportError:
     mp = MissingModule('mpmath')
 


### PR DESCRIPTION
#### Reference issue
None

#### What does this implement/fix?
Mpmath doesn't have types, is unlikely to get types, and, since it's a
test-only, optional dependency we shouldn't rely on users having its
types installed even if they did exist. For that reason, remove it
from the ratchet and add `type: ignore[import]`s on Mpmath imports so
that the module is typed as `Any`.

#### Additional information
None