### PR TITLE
Fix inaccurate docstring example of HalfspaceIntersection

### DIFF
--- a/scipy/spatial/qhull.pyx
+++ b/scipy/spatial/qhull.pyx
@@ -24,6 +24,26 @@ import os
 import sys
 import tempfile
 
+cimport
+numpy as np
+cimport
+cython
+import numpy as np
+import os
+import sys
+import tempfile
+import threading
+from libc cimport
+
+stdlib
+from numpy.compat import asbytes
+
+from scipy._lib.messagestream cimport
+
+MessageStream
+from .cimport qhull
+from .cimport setlist
+
 cdef extern from "numpy/npy_math.h":
     double nan "NPY_NAN"
 
@@ -2764,7 +2784,7 @@ class HalfspaceIntersection(_QhullUser):
     >>> c[-1] = -1
     >>> A = np.hstack((halfspaces[:, :-1], norm_vector))
     >>> b = - halfspaces[:, -1:]
-    >>> res = linprog(c, A_ub=A, b_ub=b)
+    >>> res = linprog(c, A_ub=A, b_ub=b, bounds=(None, None))
     >>> x = res.x[:-1]
     >>> y = res.x[-1]
     >>> circle = Circle(x, radius=y, alpha=0.3)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
fix #11676

#### What does this implement/fix?
fix inaccurate docstring example of HalfspaceIntersection
