### PR TITLE
Bug: stats: fix wrong shape from median_absolute_deviation for arrays with size 0 and an axis.

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -2829,7 +2829,12 @@ def median_absolute_deviation(x, axis=0, center=np.median, scale=1.4826,
 
     # Consistent with `np.var` and `np.std`.
     if not x.size:
-        return np.nan
+        nan_shape = [item for i, item in enumerate(x.shape) if i != axis]
+        nan_array = np.full(nan_shape, np.nan)
+        if not nan_array.size:
+            return np.nan
+        else:
+            return nan_array
 
     contains_nan, nan_policy = _contains_nan(x, nan_policy)
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1884,6 +1884,26 @@ class TestVariability(object):
         mad = stats.median_absolute_deviation(dat)
         assert_equal(mad, np.nan)
 
+    def test_mad_nan_shape1(self):
+        z = np.ones((3, 0))
+        mad_axis0 = stats.median_absolute_deviation(z, axis=0)
+        assert_equal(mad_axis0, np.nan)
+        mad_axis1 = stats.median_absolute_deviation(z, axis=1)
+        assert_equal(mad_axis1, np.array([np.nan, np.nan, np.nan]))
+        assert_equal(mad_axis1.shape, (3,))
+
+    def test_mad_nan_shape2(self):
+        z = np.ones((3, 0, 2))
+        mad_axis0 = stats.median_absolute_deviation(z, axis=0)
+        assert_equal(mad_axis0, np.nan)
+        mad_axis1 = stats.median_absolute_deviation(z, axis=1)
+        assert_equal(mad_axis1, np.array([[np.nan, np.nan],
+                                          [np.nan, np.nan],
+                                          [np.nan, np.nan]]))
+        assert_equal(mad_axis1.shape, (3, 2))
+        mad_axis2 = stats.median_absolute_deviation(z, axis=2)
+        assert_equal(mad_axis2, np.nan)
+
     def test_mad_nan_propagate(self):
         dat = np.array([2.20, 2.20, 2.4, 2.4, 2.5, 2.7, 2.8, 2.9, 3.03,
                 3.03, 3.10, 3.37, 3.4, 3.4, 3.4, 3.5, 3.6, 3.7, 3.7,


### PR DESCRIPTION
#### Reference issue
fix #11720 

#### What does this implement/fix?
fix wrong shape from median_absolute_deviation for arrays with size 0 and an axis.
