### PR TITLE
BUG: Prevent crashes due to MKL bug in ?heevr

### DIFF
--- a/scipy/linalg/flapack_sym_herm.pyf.src
+++ b/scipy/linalg/flapack_sym_herm.pyf.src
@@ -757,22 +757,22 @@ subroutine <prefix2>syevr(compute_v,range,lower,n,a,lda,vl,vu,il,iu,abstol,w,z,m
     integer optional,intent(in),check(compute_v==1||compute_v==0):: compute_v = 1
     character optional,intent(in),check(*range=='A'||*range=='V' ||*range=='I') :: range='A'
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
-    integer optional,intent(in),check(il>=1) :: il=1
-    integer optional,intent(in),check(iu>=il||iu<=n),depend(il,n) :: iu=n
+    integer optional,intent(in),check(il>=1&&il<=n),depend(n) :: il=1
+    integer optional,intent(in),check(iu>=il&&iu<=n),depend(il,n) :: iu=n
     <ftype2> optional,intent(in) :: vl=0.0
-    <ftype2> optional,intent(in),check(vu>=vl),depend(vl) :: vu=1.0
+    <ftype2> optional,intent(in),check(vu>vl),depend(vl) :: vu=1.0
     <ftype2> intent(in) :: abstol=0.0
-    integer optional,intent(in),depend(n),check(lwork>=1||lwork==-1) :: lwork=max(26*n,1)
-    integer optional,intent(in),depend(n),check(liwork>=1||liwork==-1):: liwork= max(1,10*n)
+    integer optional,intent(in),depend(n),check(lwork>=max(1,26*n)||lwork==-1) :: lwork=max(26*n,1)
+    integer optional,intent(in),depend(n),check(liwork>=max(1,10*n)||liwork==-1):: liwork= max(1,10*n)
 
     integer intent(hide),depend(a) :: n=shape(a,0)
     integer intent(hide),depend(n) :: lda=max(1,n)
-    integer intent(hide),depend(z) :: ldz=max(1,shape(z,0))
+    integer intent(hide),depend(compute_v,n) :: ldz=(compute_v?max(1,n):1)
     <ftype2>  intent(hide),dimension(lwork),depend(lwork) :: work
     integer intent(hide),dimension(liwork),depend(liwork) :: iwork
 
     <ftype2> intent(out),dimension(n),depend(n) :: w
-    <ftype2> intent(out),dimension((compute_v?MAX(0,n):0),(compute_v?(*range=='I'?iu-il+1:MAX(1,n)):0)),depend(n,compute_v,range,iu,il) :: z
+    <ftype2> intent(out),dimension((compute_v?ldz:0),(compute_v?(*range=='I'?iu-il+1:MAX(1,n)):0)),depend(n,compute_v,ldz,range,iu,il) :: z
     integer intent(out) :: m
     ! Only returned if range=='A' or range=='I' and il, iu = 1, n
     integer intent(out),dimension((compute_v?(2*(*range=='A'||(*range=='I' && iu-il+1==n)?n:0)):0)),depend(n,iu,il,compute_v,range) :: isuppz
@@ -827,27 +827,32 @@ subroutine <prefix2c>heevr(compute_v,range,lower,n,a,lda,vl,vu,il,iu,abstol,w,z,
     integer optional,intent(in),check(compute_v==1||compute_v==0):: compute_v = 1
     character optional,intent(in),check(*range=='A'||*range=='V' ||*range=='I') :: range='A'
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
-    integer optional,intent(in) :: il=1
-    integer optional,intent(in),depend(n) :: iu=n
+    integer optional,intent(in),check(il>=1&&il<=n),depend(n) :: il=1
+    integer optional,intent(in),check(iu>=il&&iu<=n),depend(il,n) :: iu=n
     <ftype2> optional,intent(in) :: vl=0.0
     <ftype2> optional,intent(in),check(vu>vl),depend(vl) :: vu=1.0
     <ftype2> intent(in) :: abstol=0.0
-    integer optional,intent(in),depend(n),check(lwork>=1||lwork==-1) :: lwork=max(2*n,1)
-    integer optional,intent(in),depend(n),check(lwork>=1||lwork==-1) :: lrwork=max(24*n,1)
-    integer optional,intent(in),depend(n),check(liwork>=1||liwork==-1):: liwork= max(1,10*n)
+    integer optional,intent(in),depend(n),check(lwork>=max(2*n,1)||lwork==-1) :: lwork=max(2*n,1)
+    integer optional,intent(in),depend(n),check(lrwork>=max(24*n,1)||lrwork==-1) :: lrwork=max(24*n,1)
+    integer optional,intent(in),depend(n),check(liwork>=max(1,10*n)||liwork==-1):: liwork= max(1,10*n)
 
     integer intent(hide),depend(a) :: n=shape(a,0)
     integer intent(hide),depend(n) :: lda=max(1,n)
-    integer intent(hide),depend(z) :: ldz=max(1,shape(z,0))
+    integer intent(hide),depend(compute_v,n) :: ldz=(compute_v?max(1,n):1)
     <ftype2c>  intent(hide),dimension(lwork),depend(lwork) :: work
-    <ftype2> intent(hide),dimension(lrwork) :: rwork
+    <ftype2> intent(hide),dimension(lrwork),depend(lrwork) :: rwork
     integer intent(hide),dimension(liwork),depend(liwork) :: iwork
 
     <ftype2> intent(out),dimension(n),depend(n) :: w
-    <ftype2c> intent(out),dimension((compute_v?MAX(0,n):0),(compute_v?(*range=='I'?iu-il+1:MAX(1,n)):0)),depend(n,compute_v,range,iu,il) :: z
+    <ftype2c> intent(out),dimension((compute_v?ldz:0),(compute_v?(*range=='I'?iu-il+1:MAX(1,n)):0)),depend(n,ldz,compute_v,range,iu,il) :: z
     integer intent(out) :: m
-    ! Only returned if range=='A' or range=='I' and il, iu = 1, n
-    integer intent(out),dimension((compute_v?(2*(*range=='A'||(*range=='I' && iu-il+1==n)?n:0)):0)),depend(n,iu,il,range,compute_v) :: isuppz
+    ! According to the NetLib LAPACK reference-implementation the arrray isuppz
+    ! is only "implemented" if range=='A' or range=='I' and il, iu = 1, n.
+    ! The array is nevertheless allocated with a size that is large enough
+    ! as precaution against out-of-bound access. The underlying LAPACK
+    ! implementation may as well use the buffer in any case, even if the
+    ! eigenvectors are not requested.
+    integer intent(out),dimension(2*max(1,n)),depend(n) :: isuppz
     integer intent(out) :: info
 
 end subroutine <prefix2c>heevr

--- a/scipy/linalg/flapack_sym_herm.pyf.src
+++ b/scipy/linalg/flapack_sym_herm.pyf.src
@@ -757,22 +757,22 @@ subroutine <prefix2>syevr(compute_v,range,lower,n,a,lda,vl,vu,il,iu,abstol,w,z,m
     integer optional,intent(in),check(compute_v==1||compute_v==0):: compute_v = 1
     character optional,intent(in),check(*range=='A'||*range=='V' ||*range=='I') :: range='A'
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
-    integer optional,intent(in),check(il>=1&&il<=n),depend(n) :: il=1
-    integer optional,intent(in),check(iu>=il&&iu<=n),depend(il,n) :: iu=n
+    integer optional,intent(in),check(il>=1) :: il=1
+    integer optional,intent(in),check(iu>=il||iu<=n),depend(il,n) :: iu=n
     <ftype2> optional,intent(in) :: vl=0.0
-    <ftype2> optional,intent(in),check(vu>vl),depend(vl) :: vu=1.0
+    <ftype2> optional,intent(in),check(vu>=vl),depend(vl) :: vu=1.0
     <ftype2> intent(in) :: abstol=0.0
     integer optional,intent(in),depend(n),check(lwork>=max(1,26*n)||lwork==-1) :: lwork=max(26*n,1)
     integer optional,intent(in),depend(n),check(liwork>=max(1,10*n)||liwork==-1):: liwork= max(1,10*n)
 
     integer intent(hide),depend(a) :: n=shape(a,0)
     integer intent(hide),depend(n) :: lda=max(1,n)
-    integer intent(hide),depend(compute_v,n) :: ldz=(compute_v?max(1,n):1)
+    integer intent(hide),depend(z) :: ldz=max(1,shape(z,0))
     <ftype2>  intent(hide),dimension(lwork),depend(lwork) :: work
     integer intent(hide),dimension(liwork),depend(liwork) :: iwork
 
     <ftype2> intent(out),dimension(n),depend(n) :: w
-    <ftype2> intent(out),dimension((compute_v?ldz:0),(compute_v?(*range=='I'?iu-il+1:MAX(1,n)):0)),depend(n,compute_v,ldz,range,iu,il) :: z
+    <ftype2> intent(out),dimension((compute_v?MAX(0,n):0),(compute_v?(*range=='I'?iu-il+1:MAX(1,n)):0)),depend(n,compute_v,range,iu,il) :: z
     integer intent(out) :: m
     ! Only returned if range=='A' or range=='I' and il, iu = 1, n
     integer intent(out),dimension((compute_v?(2*(*range=='A'||(*range=='I' && iu-il+1==n)?n:0)):0)),depend(n,iu,il,compute_v,range) :: isuppz
@@ -827,8 +827,8 @@ subroutine <prefix2c>heevr(compute_v,range,lower,n,a,lda,vl,vu,il,iu,abstol,w,z,
     integer optional,intent(in),check(compute_v==1||compute_v==0):: compute_v = 1
     character optional,intent(in),check(*range=='A'||*range=='V' ||*range=='I') :: range='A'
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
-    integer optional,intent(in),check(il>=1&&il<=n),depend(n) :: il=1
-    integer optional,intent(in),check(iu>=il&&iu<=n),depend(il,n) :: iu=n
+    integer optional,intent(in),check(il>=1) :: il=1
+    integer optional,intent(in),check(iu>=il||iu<=n),depend(il,n) :: iu=n
     <ftype2> optional,intent(in) :: vl=0.0
     <ftype2> optional,intent(in),check(vu>vl),depend(vl) :: vu=1.0
     <ftype2> intent(in) :: abstol=0.0
@@ -838,20 +838,22 @@ subroutine <prefix2c>heevr(compute_v,range,lower,n,a,lda,vl,vu,il,iu,abstol,w,z,
 
     integer intent(hide),depend(a) :: n=shape(a,0)
     integer intent(hide),depend(n) :: lda=max(1,n)
-    integer intent(hide),depend(compute_v,n) :: ldz=(compute_v?max(1,n):1)
+    integer intent(hide),depend(z) :: ldz=max(1,shape(z,0))
     <ftype2c>  intent(hide),dimension(lwork),depend(lwork) :: work
     <ftype2> intent(hide),dimension(lrwork),depend(lrwork) :: rwork
     integer intent(hide),dimension(liwork),depend(liwork) :: iwork
 
     <ftype2> intent(out),dimension(n),depend(n) :: w
-    <ftype2c> intent(out),dimension((compute_v?ldz:0),(compute_v?(*range=='I'?iu-il+1:MAX(1,n)):0)),depend(n,ldz,compute_v,range,iu,il) :: z
+    <ftype2c> intent(out),dimension((compute_v?MAX(0,n):0),(compute_v?(*range=='I'?iu-il+1:MAX(1,n)):0)),depend(n,compute_v,range,iu,il) :: z
     integer intent(out) :: m
-    ! According to the NetLib LAPACK reference-implementation the arrray isuppz
-    ! is only "implemented" if range=='A' or range=='I' and il, iu = 1, n.
-    ! The array is nevertheless allocated with a size that is large enough
-    ! as precaution against out-of-bound access. The underlying LAPACK
-    ! implementation may as well use the buffer in any case, even if the
-    ! eigenvectors are not requested.
+    ! MKL implementation has a bug that still accesses isuppz array even if
+    ! range=='A' or range=='I' and il, iu = 1, n which is not the case for
+    ! the reference implementation. Hence here isuppz is allocated regardless
+    ! of the settings. It is wasteful but necessary. The bug is fixed in
+    ! mkl 2020 update 2 and when time comes change this line with
+    !
+    ! integer intent(out),dimension((compute_v?(2*(*range=='A'||(*range=='I' && iu-il+1==n)?n:0)):0)),depend(n,iu,il,range,compute_v) :: isuppz
+    !
     integer intent(out),dimension(2*max(1,n)),depend(n) :: isuppz
     integer intent(out) :: info
 


### PR DESCRIPTION
In the LAPACK wrapper for ?heevr, enlarge the size of the isuppz array
parameter in order to prevent out-of-bound access by the underlying
library. For both ?heevr and ?syevr, more robust checks and default
values are also put in place.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #11709 

#### What does this implement/fix?
<!--Please explain your changes.-->
Crashes related to `linalg.eigh()`

#### Additional information
<!--Any additional information you think is important.-->
The current status is mostly a workaround for MKL on macos. Further investigation is needed to access the presence or impact of similar issues on other platforms.