### PR TITLE
MAINT: special: remove unused specfun f2py wrappers

### DIFF
--- a/scipy/special/specfun.pyf
+++ b/scipy/special/specfun.pyf
@@ -1,8 +1,6 @@
 !%f90 -*- f90 -*-
 python module specfun ! in
     interface  ! in :specfun
-        ! cpdsa
-        ! cfs
         subroutine clqmn(mm,m,n,z,cqm,cqd) ! in :specfun:specfun.f
             callstatement (*f2py_func)(&mm,&m,&n,&(z.r),&(z.i),cqm,cqd)
             callprotoargument int*,int*,int*,double*,double*,complex_double*,complex_double*
@@ -31,8 +29,6 @@ python module specfun ! in
             complex*16 intent(out),dimension(0:m,0:n),depend(m,n) :: cpm
             complex*16 intent(out),dimension(0:m,0:n),depend(m,n) :: cpd
         end subroutine clpmn
-        ! vvsa
-
         subroutine jdzo(nt,n,m,pcode,zo) ! in :specfun:specfun.f
             integer intent(in), check((nt>0)&&(nt<=1200)) :: nt
             integer depend(nt), intent(out), dimension(1400) :: n
@@ -40,59 +36,10 @@ python module specfun ! in
             integer depend(nt), intent(out), dimension(1400) :: pcode
             double precision intent(out), depend(nt), dimension(0:1400) :: zo
         end subroutine jdzo
-
-        ! cbk
-        ! rmn2sp
         subroutine bernob(n,bn) ! in :specfun:specfun.f
             integer intent(in), check(n>=2) :: n
             double precision intent(out),depend(n),dimension(n+1) :: bn
         end subroutine bernob
-        subroutine bernoa(n,bn) ! in :specfun:specfun.f
-            integer intent(in), check(n>=0) :: n
-            double precision intent(out),depend(n),dimension(n+1) :: bn
-        end subroutine bernoa
-        ! qstar
-        ! cv0
-        ! cvqm
-        ! cvql
-        ! ittjyb
-
-        ! ittjya
-
-        ! msta1
-        ! msta2
-
-        ! cjylv
-        ! rmn2l
-        ! psi (psi_spec)
-        !subroutine cva2(kd,m,q,a) ! in :specfun:specfun.f
-        !    integer :: kd
-        !    integer :: m
-        !    double precision :: q
-        !    double precision :: a
-        !end subroutine cva2
-        subroutine lpmns(m,n,x,pm,pd) ! in :specfun:specfun.f
-            integer intent(in), depend(n), check((m>=0) && (m<=n)):: m
-            integer intent(in), check(n>=1) :: n
-            double precision intent(in) :: x
-            double precision intent(out),depend(n),dimension(n+1) :: pm
-            double precision intent(out),depend(n),dimension(n+1) :: pd
-        end subroutine lpmns
-        ! rswfp
-        ! jyndd
-        ! gam0
-        ! cisib
-        subroutine eulera(n,en) ! in :specfun:specfun.f
-            integer intent(in), check(n>=0) :: n
-            double precision intent(out),depend(n),dimension(n+1) :: en
-        end subroutine eulera
-        ! refine
-        ! cisia
-
-        ! itsl0
-        ! stvl0
-        ! stvl1
-
         subroutine clqn(n,z,cqn,cqd) ! in :specfun:specfun.f
             callstatement (*f2py_func)(&n,&(z.r),&(z.i),cqn,cqd)
             callprotoargument int*,double*,double*,complex_double*,complex_double*
@@ -101,9 +48,6 @@ python module specfun ! in
             complex*16 intent(out),dimension(n+1),depend(n) :: cqn
             complex*16 intent(out),dimension(n+1),depend(n) :: cqd
         end subroutine clqn
-
-        ! stvl0
-
         subroutine airyzo(nt,kf,xa,xb,xc,xd) ! in :specfun:specfun.f
             integer intent(in),check(nt>0) :: nt
             integer optional,intent(in) :: kf=1
@@ -112,30 +56,16 @@ python module specfun ! in
             double precision intent(out),depend(nt),dimension(nt) :: xc
             double precision intent(out),depend(nt),dimension(nt) :: xd
         end subroutine airyzo
-        ! error
-        ! cerror
-
         subroutine eulerb(n,en) ! in :specfun:specfun.
             integer intent(in), check(n>=2) :: n
             double precision intent(out),depend(n),dimension(n+1) :: en
         end subroutine eulerb
-        subroutine cva1(kd,m,q,cv) ! in :specfun:specfun.f
-            integer intent(in) :: kd
-            integer intent(in), check(m<=200) :: m
-            double precision intent(in), check(q>=0) :: q
-            double precision intent(out), depend(m), dimension(m) :: cv
-        end subroutine cva1
-        ! ittikb
         subroutine lqnb(n,x,qn,qd) ! in :specfun:specfun.f
             integer intent(in), check(n>=1) :: n
             double precision intent(in) :: x
             double precision intent(out),depend(n),dimension(n+1) :: qn
             double precision intent(out),depend(n),dimension(n+1) :: qd
         end subroutine lqnb
-        ! cjk
-
-        ! ittika
-
         subroutine lamv(v,x,vm,vl,dl) ! in :specfun:specfun.f
             double precision intent(in), check(v>=1) :: v
             double precision intent(in) :: x
@@ -143,36 +73,6 @@ python module specfun ! in
             double precision intent(out),depend(v),dimension((int)v+1) :: vl
             double precision intent(out),depend(v),dimension((int)v+1) :: dl
         end subroutine lamv
-        ! chguit
-        ! kmn
-        subroutine lagzo(n,x,w) ! in :specfun:specfun.f
-            integer intent(in),check(n>0) :: n
-            double precision intent(out),depend(n),dimension(n) :: x
-            double precision intent(out),dimension(n),depend(n) :: w
-        end subroutine lagzo
-        ! vvla
-
-        ! cjyva
-        ! cjyvb
-
-        ! jy01a
-        ! incog
-
-        ! itika
-        ! itikb
-
-        ! jyv
-        ! jynb
-        ! stvh1
-
-        subroutine legzo(n,x,w) ! in :specfun:specfun.f
-            integer intent(in),check(n>0) :: n
-            double precision intent(out),depend(n),dimension(n) :: x
-            double precision intent(out),dimension(n),depend(n) :: w
-        end subroutine legzo
-        ! aswfa
-        ! jyna
-
         subroutine pbdv(v,x,dv,dp,pdf,pdd) ! in :specfun:specfun.f
             double precision intent(in),check((abs((int)v)+2)>=2) :: v
             double precision intent(in) :: x
@@ -181,17 +81,10 @@ python module specfun ! in
             double precision intent(out) :: pdf
             double precision intent(out) :: pdd
         end subroutine pbdv
-
-        ! itsh0
-
         subroutine cerzo(nt,zo) ! in :specfun:specfun.f
             integer intent(in), check(nt>0) :: nt
             complex*16 intent(out), depend(nt), dimension(nt) :: zo
         end subroutine cerzo
-
-        ! gamma2
-
-        ! chgu
         subroutine lamn(n,x,nm,bl,dl) ! in :specfun:specfun.f
             integer intent(in), check(n>=1) :: n
             double precision intent(in) :: x
@@ -199,16 +92,6 @@ python module specfun ! in
             double precision intent(out),depend(n),dimension(n+1) :: bl
             double precision intent(out),depend(n),dimension(n+1) :: dl
         end subroutine lamn
-        ! comelp
-        ! incob
-        !subroutine cvf(kd,m,q,a,mj,f) ! in :specfun:specfun.f
-        !    integer :: kd
-        !    integer :: m
-        !    double precision :: q
-        !    double precision :: a
-        !    integer :: mj
-        !    double precision :: f
-        !end subroutine cvf
         subroutine clpn(n,z,cpn,cpd) ! in :specfun:specfun.f
             callstatement (*f2py_func)(&n,&(z.r),&(z.i),cpn,cpd)
             callprotoargument int*,double*,double*,complex_double*,complex_double*
@@ -217,40 +100,6 @@ python module specfun ! in
             complex*16 intent(out),depend(n),dimension(n+1) :: cpn
             complex*16 intent(out),depend(n),dimension(n+1) :: cpd
         end subroutine clpn
-
-        subroutine lqmns(m,n,x,qm,qd) ! in :specfun:specfun.f
-            integer intent(in), check(m>=0) :: m
-            integer intent(in), check(n>=1) :: n,
-            double precision intent(in) :: x
-            double precision intent(out),depend(n),dimension(n+1) :: qm
-            double precision intent(out),depend(n),dimension(n+1) :: qd
-        end subroutine lqmns
-        ! ciklv
-        ! elit
-        ! elit3
-
-        ! eix
-        ! e1xb
-
-        subroutine chgm(a,b,x,hg) ! in :specfun:specfun.f
-             double precision intent(in) :: a
-             double precision intent(in) :: b
-             double precision intent(in) :: x
-             double precision intent(out) :: hg
-        end subroutine chgm
-
-        ! stvh0
-
-        ! hygfx
-        ! cchg
-        ! hygfz
-        ! itairy
-        ! airya
-        ! airyb
-
-        ! ikna
-        ! cjynb
-        ! iknb
         subroutine lpmn(mm,m,n,x,pm,pd) ! in :specfun:specfun.f
             integer intent(hide) :: mm=m
             integer intent(in), depend(n), check((m>=0) && (m<=n)) :: m
@@ -259,55 +108,17 @@ python module specfun ! in
             double precision intent(out),depend(m,n),dimension(m+1,n+1) :: pm
             double precision intent(out),dimension(m+1,n+1),depend(m,n) :: pd
         end subroutine lpmn
-        ! mtu0
-        ! cy01
-        ! ffk
-        ! scka
-        ! sckb
-        ! cpdla
         subroutine fcszo(kf,nt,zo) ! in :specfun:specfun.f
             integer intent(in), check((kf==1)||(kf==2)) :: kf
             integer intent(in), check(nt>0) :: nt
             complex*16 intent(out), depend(nt), dimension(nt) :: zo
         end subroutine fcszo
-        ! e1xa
-        ! lpmv
-
-        ! cgama
-
-        subroutine aswfb(m,n,c,x,kd,cv,s1f,s1d) ! in :specfun:specfun.f
-            integer intent(in), check(m>=0) :: m
-            integer intent(in), check(n>=m) :: n
-            double precision intent(in) :: c
-            double precision intent(in), check(fabs(x)<1) :: x
-            integer intent(in), check((kd==-1)||(kd==1)) :: kd
-            double precision intent(in) :: cv
-            double precision intent(out) :: s1f
-            double precision intent(out) :: s1d
-        end subroutine aswfb
-
-        ! chgu
-
-        ! itth0
-
-        ! lgama
-
-        subroutine lqna(n,x,qn,qd) ! in :specfun:specfun.f
-            integer intent(in), check(n>=1) :: n
-            double precision intent(in), check(fabs(x)<1) :: x
-            double precision intent(out),depend(n),dimension(n+1) :: qn
-            double precision intent(out),dimension(n+1),depend(n) :: qd
-        end subroutine lqna
-        ! dvla
-        ! ik01a
         subroutine cpbdn(n,z,cpb,cpd) ! in :specfun:specfun.f
             integer intent(in), check((abs(n)) >= 1) :: n
             complex*16 intent(in) :: z
             complex*16 depend(n), intent(out), dimension(abs(n)+2) :: cpb
             complex*16 depend(n), intent(out), dimension(abs(n)+2) :: cpd
         end subroutine cpbdn
-        ! ik01b
-        ! beta
         subroutine lpn(n,x,pn,pd) ! in :specfun:specfun.f
             integer intent(in), check(n>=1) :: n
             double precision intent(in) :: x
@@ -321,19 +132,6 @@ python module specfun ! in
             double precision intent(in) :: a
             double precision intent(out),dimension(251) :: fc
         end subroutine fcoef
-        ! sphi
-        ! pbwa
-        ! rmn1
-        ! dvsa
-
-        ! e1z
-
-        ! itjyb
-        ! chgul
-        ! gmn
-        ! itjya
-        ! stvlv
-
         subroutine rcty(n,x,nm,ry,dy) ! in :specfun:specfun.f
             integer intent(in), check(n>0) :: n
             double precision intent(in) :: x
@@ -341,17 +139,6 @@ python module specfun ! in
             double precision intent(out),dimension(n+1),depend(n) :: ry
             double precision intent(out),dimension(n+1),depend(n) :: dy
         end subroutine rcty
-        subroutine lpni(n,x,pn,pd,pl) ! in :specfun:specfun.f
-            integer intent(in),check(n>0) :: n
-            double precision intent(in) :: x
-            double precision intent(out), depend(n), dimension(n+1) :: pn
-            double precision intent(out), depend(n), dimension(n+1) :: pd
-            double precision intent(out), depend(n), dimension(n+1) :: pl
-        end subroutine lpni
-
-        ! klvna
-
-        ! chgubi
         subroutine cyzo(nt,kf,kc,zo,zv) ! in :specfun:specfun.f
             integer intent(in), check(nt>0) :: nt
             integer intent(in), check((kf>=0)&&(kf<=2)) :: kf
@@ -359,24 +146,11 @@ python module specfun ! in
             complex*16 intent(out),depend(nt),dimension(nt) :: zo
             complex*16 intent(out),dimension(nt),depend(nt) :: zv
         end subroutine cyzo
-        ! klvnb
-        ! rmn2so
-        ! bjndd
-        ! sphj
-        subroutine othpl(kf,n,x,pl,dpl) ! in :specfun:specfun.f
-            integer intent(in), check((kf>0)&&(kf<5)) :: kf
-            integer intent(in), check(n>0) :: n
-            double precision intent(in) :: x
-            double precision intent(out),dimension(n+1),depend(n) :: pl
-            double precision intent(out),dimension(n+1),depend(n) :: dpl
-        end subroutine othpl
         subroutine klvnzo(nt,kd,zo) ! in :specfun:specfun.f
             integer intent(in), check(nt>0) :: nt
             integer intent(in), check((kd>=1)&&(kd<=8)) :: kd
             double precision intent(out), depend(nt), dimension(nt) :: zo
         end subroutine klvnzo
-        ! rswfo
-        ! ch12n
         subroutine jyzo(n,nt,rj0,rj1,ry0,ry1) ! in :specfun:specfun.f
             integer intent(in), check(n>=0) :: n
             integer intent(in), check(nt>0) :: nt
@@ -385,17 +159,6 @@ python module specfun ! in
             double precision intent(out),dimension(nt),depend(nt) :: ry0
             double precision intent(out),dimension(nt),depend(nt) :: ry1
         end subroutine jyzo
-
-        ! ikv
-
-        ! sdmn
-        ! ajyik
-        ! cikvb
-
-        ! cikva
-        ! cfc
-
-        ! fcs
         subroutine rctj(n,x,nm,rj,dj) ! in :specfun:specfun.f
             integer intent(in), check(n>0) :: n
             double precision intent(in) :: x
@@ -403,24 +166,6 @@ python module specfun ! in
             double precision intent(out),dimension(n+1),depend(n) :: rj
             double precision intent(out),dimension(n+1),depend(n) :: dj
         end subroutine rctj
-        subroutine herzo(n,x,w) ! in :specfun:specfun.f
-            integer intent(in), check(n>0) :: n
-            double precision intent(out),dimension(n),depend(n) :: x
-            double precision intent(out),dimension(n),depend(n) :: w
-        end subroutine herzo
-        ! jy01b
-        ! enxb
-        ! sphk
-        ! enxa
-        ! gaih
-        subroutine pbvv(v,x,vv,vp,pvf,pvd) ! in :specfun:specfun.f
-            double precision intent(in), check((abs((int)v)+2)>=2) :: v
-            double precision intent(in) :: x
-            double precision intent(out),depend(v),dimension(abs((int)v)+2) :: vv
-            double precision intent(out),depend(v),dimension(abs((int)v)+2) :: vp
-            double precision intent(out) :: pvf
-            double precision intent(out) :: pvd
-        end subroutine pbvv
         subroutine segv(m,n,c,kd,cv,eg) ! in :specfun:specfun.f
             integer intent(in) :: m
             integer intent(in),depend(m),check((n>=m) && ((n-m)<199)) :: n
@@ -429,18 +174,5 @@ python module specfun ! in
             double precision intent(out) :: cv
             double precision intent(out),dimension(n-m+2) :: eg
         end subroutine segv
-        ! ciknb
-        ! cikna
-        ! mtu12
-        ! cik01
-        ! cpsi
-        ! sphy
-        ! jelp
-
-        ! stvhv
     end interface
 end python module specfun
-
-! This file was auto-generated with f2py (version:2.13.175-1239).
-!  and then heavily modified.....
-! See http://cens.ioc.ee/projects/f2py2e/


### PR DESCRIPTION
#### Reference issue
None

#### What does this implement/fix?
Various signatures in `specfun.pyf` are currently unused (likely
because many of them are now wrapped manually so that they can be
ufunc kernels); delete them.

#### Additional information
Ran into this while thinking about how to generate type stubs for f2py.