### PR TITLE
DOC: stats: Clean up ncf documentation.

### DIFF
--- a/doc/source/tutorial/stats/continuous_ncf.rst
+++ b/doc/source/tutorial/stats/continuous_ncf.rst
@@ -5,20 +5,40 @@ Noncentral F Distribution
 =========================
 
 The distribution of :math:`\left(X_{1}/X_{2}\right)\left(\nu_{2}/\nu_{1}\right)`
-if :math:`X_{1}` is non-central chi-squared with :math:`\nu_{1}` degrees of freedom
-and parameter :math:`\lambda`, and :math:`X_{2}` is chi-squared with :math:`\nu_{2}` degrees of freedom.
+if :math:`X_{1}` is non-central chi-squared with :math:`\nu_{1}` degrees of
+freedom and parameter :math:`\lambda`, and :math:`X_{2}` is chi-squared with
+:math:`\nu_{2}` degrees of freedom.
 
-There are 3 shape parameters: the degrees of freedom :math:`\nu_{1}>0` and :math:`\nu_{2}>0`; and :math:`\lambda\geq 0`.
+There are 3 shape parameters: the degrees of freedom :math:`\nu_{1}>0` and
+:math:`\nu_{2}>0`; and :math:`\lambda\geq 0`.
 
 
 .. math::
    :nowrap:
 
-    \begin{eqnarray*} f\left(x;\lambda,\nu_{1},\nu_{2}\right) & = & \exp\left[\frac{\lambda}{2}+\frac{\left(\lambda\nu_{1}x\right)}{2\left(\nu_{1}x+\nu_{2}\right)}\right]\nu_{1}^{\nu_{1}/2}\nu_{2}^{\nu_{2}/2}x^{\nu_{1}/2-1}\\
-    &  & \times\left(\nu_{2}+\nu_{1}x\right)^{-\left(\nu_{1}+\nu_{2}\right)/2}\frac{\Gamma\left(\frac{\nu_{1}}{2}\right)\Gamma\left(1+\frac{\nu_{2}}{2}\right)L_{\nu_{2}/2}^{\nu_{1}/2-1}\left(-\frac{\lambda\nu_{1}x}{2\left(\nu_{1}x+\nu_{2}\right)}\right)}{B\left(\frac{\nu_{1}}{2},\frac{\nu_{2}}{2}\right)\Gamma\left(\frac{\nu_{1}+\nu_{2}}{2}\right)}\end{eqnarray*}
+    \begin{eqnarray*}
+        f\left(x;\lambda,\nu_{1},\nu_{2}\right)
+        & = &
+        \exp\left[\frac{\lambda}{2} +
+                  \frac{\left(\lambda\nu_{1}x\right)}
+                  {2\left(\nu_{1}x+\nu_{2}\right)}
+            \right]
+        \nu_{1}^{\nu_{1}/2}\nu_{2}^{\nu_{2}/2}x^{\nu_{1}/2-1} \\
+        &  &
+        \times\left(\nu_{2}+\nu_{1}x\right)^{-\left(\nu_{1}+\nu_{2}\right)/2}
+        \frac{\Gamma\left(\frac{\nu_{1}}{2}\right)
+              \Gamma\left(1+\frac{\nu_{2}}{2}\right)
+              L_{\nu_{2}/2}^{\nu_{1}/2-1}
+                \left(-\frac{\lambda\nu_{1}x}
+                            {2\left(\nu_{1}x+\nu_{2}\right)}\right)}
+             {B\left(\frac{\nu_{1}}{2},\frac{\nu_{2}}{2}\right)
+              \Gamma\left(\frac{\nu_{1}+\nu_{2}}{2}\right)}
+    \end{eqnarray*}
 
-where :math:`L_{\nu_{2}/2}^{\nu_{1}/2-1}(x)` is an associated Laguerre polynomial.
+where :math:`L_{\nu_{2}/2}^{\nu_{1}/2-1}(x)` is an associated Laguerre
+polynomial.
 
-If :math:`\lambda=0`, the distribution becomes equivalent to the Fisher distribution with :math:`\nu_{1}` and :math:`\nu_{2}` degrees of freedom.
+If :math:`\lambda=0`, the distribution becomes equivalent to the Fisher
+distribution with :math:`\nu_{1}` and :math:`\nu_{2}` degrees of freedom.
 
 Implementation: `scipy.stats.ncf`

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -5740,13 +5740,16 @@ class ncf_gen(rv_continuous):
     .. math::
 
         f(x, n_1, n_2, \lambda) =
-                          \exp(\frac{\lambda}{2} + \lambda n_1 \frac{x}{2(n_1 x+n_2)})
-                          n_1^{n_1/2} n_2^{n_2/2} x^{n_1/2 - 1} \\
-                          (n_2+n_1 x)^{-(n_1+n_2)/2}
-                          \gamma(n_1/2) \gamma(1+n_2/2) \\
-                         \frac{L^{\frac{v_1}{2}-1}_{v_2/2}
-                               (-\lambda v_1 \frac{x}{2(v_1 x+v_2)})}
-                              {B(v_1/2, v_2/2)  \gamma(\frac{v_1+v_2}{2})}
+            \exp\left(\frac{\lambda}{2} +
+                      \lambda n_1 \frac{x}{2(n_1 x + n_2)}
+                \right)
+            n_1^{n_1/2} n_2^{n_2/2} x^{n_1/2 - 1} \\
+            (n_2 + n_1 x)^{-(n_1 + n_2)/2}
+            \gamma(n_1/2) \gamma(1 + n_2/2) \\
+            \frac{L^{\frac{n_1}{2}-1}_{n_2/2}
+                \left(-\lambda n_1 \frac{x}{2(n_1 x + n_2)}\right)}
+            {B(n_1/2, n_2/2)
+                \gamma\left(\frac{n_1 + n_2}{2}\right)}
 
     for :math:`n_1, n_2 > 0`, :math:`\lambda\geq 0`.  Here :math:`n_1` is the
     degrees of freedom in the numerator, :math:`n_2` the degrees of freedom in


### PR DESCRIPTION
* Fix error in the ncf docstring: replace occurrences of v_1, v_2
  with n_1, n_2.
* Whitespace clean up in continuous_ncf.rst: break many
  lines for PEP 8 and LaTeX readability.
