### PR TITLE
MAINT: special: type `cython_special` as `Any`

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -507,9 +507,6 @@ ignore_errors = True
 [mypy-scipy.sparse.linalg.tests.test_matfuncs]
 ignore_errors = True
 
-[mypy-scipy.special.tests.test_cython_special]
-ignore_errors = True
-
 [mypy-scipy.io.tests.test_fortran]
 ignore_errors = True
 

--- a/scipy/special/cython_special.pyi
+++ b/scipy/special/cython_special.pyi
@@ -1,0 +1,3 @@
+from typing import Any
+
+def __getattr__(name) -> Any: ...


### PR DESCRIPTION
#### Reference issue
https://github.com/scipy/scipy/issues/11749

#### What does this implement/fix?
The `special.cython_special` exposes some Python functions, but they
are intended only for tests and aren't part of the public API. Because
of that, typing it is very low priority, so just type everything in it
as `Any` and remove it from the ratchet.

#### Additional information
None