### PR TITLE
DOC: fix docstring of scipy.optimize.least_squares

### DIFF
--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -258,10 +258,10 @@ def least_squares(
         ``fun(x, *args, **kwargs)``, i.e., the minimization proceeds with
         respect to its first argument. The argument ``x`` passed to this
         function is an ndarray of shape (n,) (never a scalar, even for n=1).
-        It must always allocate and return a 1-D array_like of shape (m,) or
-        a scalar. If the argument ``x`` is complex or the function ``fun``
-        returns complex residuals, it must be wrapped in a real function of
-        real arguments, as shown at the end of the Examples section.
+        It must allocate and return a 1-D array_like of shape (m,) or a scalar.
+        If the argument ``x`` is complex or the function ``fun`` returns
+        complex residuals, it must be wrapped in a real function of real
+        arguments, as shown at the end of the Examples section.
     x0 : array_like with shape (n,) or float
         Initial guess on independent variables. If float, it will be treated
         as a 1-D array with one element.

--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -796,7 +796,7 @@ def least_squares(
     ftol, xtol, gtol = check_tolerance(ftol, xtol, gtol)
 
     def fun_wrapped(x):
-        return np.array(np.atleast_1d(fun(x, *args, **kwargs)))
+        return np.atleast_1d(fun(x, *args, **kwargs))
 
     if method == 'trf':
         x0 = make_strictly_feasible(x0, lb, ub)

--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -796,7 +796,7 @@ def least_squares(
     ftol, xtol, gtol = check_tolerance(ftol, xtol, gtol)
 
     def fun_wrapped(x):
-        return np.atleast_1d(fun(x, *args, **kwargs))
+        return np.array(np.atleast_1d(fun(x, *args, **kwargs)))
 
     if method == 'trf':
         x0 = make_strictly_feasible(x0, lb, ub)

--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -258,10 +258,10 @@ def least_squares(
         ``fun(x, *args, **kwargs)``, i.e., the minimization proceeds with
         respect to its first argument. The argument ``x`` passed to this
         function is an ndarray of shape (n,) (never a scalar, even for n=1).
-        It must return a 1-D array_like of shape (m,) or a scalar. If the
-        argument ``x`` is complex or the function ``fun`` returns complex
-        residuals, it must be wrapped in a real function of real arguments,
-        as shown at the end of the Examples section.
+        It must always allocate and return a 1-D array_like of shape (m,) or
+        a scalar. If the argument ``x`` is complex or the function ``fun``
+        returns complex residuals, it must be wrapped in a real function of
+        real arguments, as shown at the end of the Examples section.
     x0 : array_like with shape (n,) or float
         Initial guess on independent variables. If float, it will be treated
         as a 1-D array with one element.

--- a/scipy/optimize/tests/test_least_squares.py
+++ b/scipy/optimize/tests/test_least_squares.py
@@ -3,8 +3,7 @@ from itertools import product
 import numpy as np
 from numpy.linalg import norm
 from numpy.testing import (assert_, assert_allclose,
-                           assert_equal, suppress_warnings,
-                           assert_approx_equal)
+                           assert_equal, suppress_warnings)
 from pytest import raises as assert_raises
 from scipy.sparse import issparse, lil_matrix
 from scipy.sparse.linalg import aslinearoperator
@@ -73,21 +72,6 @@ def fun_bvp(x):
     u[1:-1, 1:-1] = x
     y = u[:-2, 1:-1] + u[2:, 1:-1] + u[1:-1, :-2] + u[1:-1, 2:] - 4 * x + x**3
     return y.ravel()
-
-
-buffer = np.empty(2)
-
-
-def fun_buffer_shared_rosenbrock(x):
-    buffer[:] = np.array([10 * (x[1] - x[0] ** 2), (1 - x[0])])
-    return buffer
-
-
-def test_buffer_shared():
-    x0_rosenbrock = np.array([2, 2])
-    res = least_squares(fun_buffer_shared_rosenbrock, x0_rosenbrock)
-    assert_approx_equal(res.x[0], 1.0)
-    assert_approx_equal(res.x[1], 1.0)
 
 
 class BroydenTridiagonal(object):

--- a/scipy/optimize/tests/test_least_squares.py
+++ b/scipy/optimize/tests/test_least_squares.py
@@ -3,7 +3,8 @@ from itertools import product
 import numpy as np
 from numpy.linalg import norm
 from numpy.testing import (assert_, assert_allclose,
-                           assert_equal, suppress_warnings)
+                           assert_equal, suppress_warnings,
+                           assert_approx_equal)
 from pytest import raises as assert_raises
 from scipy.sparse import issparse, lil_matrix
 from scipy.sparse.linalg import aslinearoperator
@@ -72,6 +73,21 @@ def fun_bvp(x):
     u[1:-1, 1:-1] = x
     y = u[:-2, 1:-1] + u[2:, 1:-1] + u[1:-1, :-2] + u[1:-1, 2:] - 4 * x + x**3
     return y.ravel()
+
+
+buffer = np.empty(2)
+
+
+def fun_buffer_shared_rosenbrock(x):
+    buffer[:] = np.array([10 * (x[1] - x[0] ** 2), (1 - x[0])])
+    return buffer
+
+
+def test_buffer_shared():
+    x0_rosenbrock = np.array([2, 2])
+    res = least_squares(fun_buffer_shared_rosenbrock, x0_rosenbrock)
+    assert_approx_equal(res.x[0], 1.0)
+    assert_approx_equal(res.x[1], 1.0)
 
 
 class BroydenTridiagonal(object):


### PR DESCRIPTION
#### Reference issue
fix #11493 

#### What does this implement/fix?
fix buffer shared optimization issue for scipy.optimize.least_squares and add a test.

#### Additional information
This PR can fix the issue, however, it may degrade the performance of the optimization calculations because of the copy of vector of residuals.
Any comments about it?