### PR TITLE
ENH: add input validation for dendrogram and a test.

### DIFF
--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -3093,6 +3093,8 @@ def dendrogram(Z, p=30, truncate_mode=None, color_threshold=None,
         -sized list (or tuple). The ``labels[i]`` value is the text to put
         under the :math:`i` th leaf node only if it corresponds to an original
         observation and not a non-singleton cluster.
+
+        Note, Dimensions of ``Z`` and ``labels`` must be consistent.
     count_sort : str or bool, optional
         For each node n, the order (visually, from left-to-right) n's
         two descendent links are plotted is determined by this
@@ -3270,6 +3272,9 @@ def dendrogram(Z, p=30, truncate_mode=None, color_threshold=None,
     if orientation not in ["top", "left", "bottom", "right"]:
         raise ValueError("orientation must be one of 'top', 'left', "
                          "'bottom', or 'right'")
+
+    if labels and  Z.shape[1] != len(labels):
+        raise ValueError("Dimensions of Z and labels must be consistent.")
 
     is_valid_linkage(Z, throw=True, name='Z')
     Zs = Z.shape

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -3090,9 +3090,9 @@ def dendrogram(Z, p=30, truncate_mode=None, color_threshold=None,
     labels : ndarray, optional
         By default, ``labels`` is None so the index of the original observation
         is used to label the leaf nodes.  Otherwise, this is an :math:`n`-sized
-        sequence, with ``n == Z.shape[1]``. The ``labels[i]`` value is the text
-        to put under the :math:`i` th leaf node only if it corresponds to an
-        original observation and not a non-singleton cluster.
+        sequence, with ``n == Z.shape[0] + 1``. The ``labels[i]`` value is the
+        text to put under the :math:`i` th leaf node only if it corresponds to
+        an original observation and not a non-singleton cluster.
     count_sort : str or bool, optional
         For each node n, the order (visually, from left-to-right) n's
         two descendent links are plotted is determined by this
@@ -3271,7 +3271,7 @@ def dendrogram(Z, p=30, truncate_mode=None, color_threshold=None,
         raise ValueError("orientation must be one of 'top', 'left', "
                          "'bottom', or 'right'")
 
-    if labels and Z.shape[1] != len(labels):
+    if labels and Z.shape[0] + 1 != len(labels):
         raise ValueError("Dimensions of Z and labels must be consistent.")
 
     is_valid_linkage(Z, throw=True, name='Z')

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -3089,12 +3089,10 @@ def dendrogram(Z, p=30, truncate_mode=None, color_threshold=None,
 
     labels : ndarray, optional
         By default, ``labels`` is None so the index of the original observation
-        is used to label the leaf nodes.  Otherwise, this is an :math:`n`
-        -sized list (or tuple). The ``labels[i]`` value is the text to put
-        under the :math:`i` th leaf node only if it corresponds to an original
-        observation and not a non-singleton cluster.
-
-        Note, Dimensions of ``Z`` and ``labels`` must be consistent.
+        is used to label the leaf nodes.  Otherwise, this is an :math:`n`-sized
+        sequence, with ``n == Z.shape[1]``. The ``labels[i]`` value is the text
+        to put under the :math:`i` th leaf node only if it corresponds to an
+        original observation and not a non-singleton cluster.
     count_sort : str or bool, optional
         For each node n, the order (visually, from left-to-right) n's
         two descendent links are plotted is determined by this
@@ -3273,7 +3271,7 @@ def dendrogram(Z, p=30, truncate_mode=None, color_threshold=None,
         raise ValueError("orientation must be one of 'top', 'left', "
                          "'bottom', or 'right'")
 
-    if labels and  Z.shape[1] != len(labels):
+    if labels and Z.shape[1] != len(labels):
         raise ValueError("Dimensions of Z and labels must be consistent.")
 
     is_valid_linkage(Z, throw=True, name='Z')

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -813,6 +813,20 @@ class TestDendrogram(object):
         assert_raises(ValueError, dendrogram, Z, orientation="foo")
 
     @pytest.mark.skipif(not have_matplotlib, reason="no matplotlib")
+    def test_valid_label_size(self):
+        link = np.array([
+            [0, 1, 1.0, 4],
+            [2, 3, 1.0, 5],
+            [4, 5, 2.0, 6],
+        ])
+        plt.figure()
+        with pytest.raises(ValueError) as exc_info:
+            dendrogram(link, labels=list(range(100)))
+        assert "Dimensions of Z and labels must be consistent."\
+               in str(exc_info.value)
+        plt.close()
+
+    @pytest.mark.skipif(not have_matplotlib, reason="no matplotlib")
     def test_dendrogram_plot(self):
         for orientation in ['top', 'bottom', 'left', 'right']:
             self.check_dendrogram_plot(orientation)


### PR DESCRIPTION
#### Reference issue
To fix #11492 

#### What does this implement/fix?
add input validation of Z and labels dimension consistency for dendrogram and a test.