### PR TITLE
MAINT: Replace uses of tostring with tobytes

### DIFF
--- a/scipy/io/matlab/mio4.py
+++ b/scipy/io/matlab/mio4.py
@@ -215,7 +215,7 @@ class VarReader4(object):
             with dtype 'U1', shape given by `hdr` ``dims``
         '''
         arr = self.read_sub_array(hdr).astype(np.uint8)
-        S = arr.tostring().decode('latin-1')
+        S = arr.tobytes().decode('latin-1')
         return np.ndarray(shape=hdr.dims,
                           dtype=np.dtype('U1'),
                           buffer=np.array(S)).copy()
@@ -448,7 +448,7 @@ class VarWriter4(object):
         self.oned_as = file_writer.oned_as
 
     def write_bytes(self, arr):
-        self.file_stream.write(arr.tostring(order='F'))
+        self.file_stream.write(arr.tobytes(order='F'))
 
     def write_string(self, s):
         self.file_stream.write(s)

--- a/scipy/io/matlab/mio5.py
+++ b/scipy/io/matlab/mio5.py
@@ -473,7 +473,7 @@ class VarWriter5(object):
         self._var_is_global = False
 
     def write_bytes(self, arr):
-        self.file_stream.write(arr.tostring(order='F'))
+        self.file_stream.write(arr.tobytes(order='F'))
 
     def write_string(self, s):
         self.file_stream.write(s)
@@ -495,8 +495,8 @@ class VarWriter5(object):
         # write tag with embedded data
         tag = np.zeros((), NDT_TAG_SMALL)
         tag['byte_count_mdtype'] = (byte_count << 16) + mdtype
-        # if arr.tostring is < 4, the element will be zero-padded as needed.
-        tag['data'] = arr.tostring(order='F')
+        # if arr.tobytes is < 4, the element will be zero-padded as needed.
+        tag['data'] = arr.tobytes(order='F')
         self.write_bytes(tag)
 
     def write_regular_element(self, arr, mdtype, byte_count):
@@ -802,7 +802,7 @@ class MatFile5Writer(object):
         hdr['endian_test'] = np.ndarray(shape=(),
                                       dtype='S2',
                                       buffer=np.uint16(0x4d49))
-        self.file_stream.write(hdr.tostring())
+        self.file_stream.write(hdr.tobytes())
 
     def put_variables(self, mdict, write_header=None):
         ''' Write variables in `mdict` to stream
@@ -839,7 +839,7 @@ class MatFile5Writer(object):
                 tag = np.empty((), NDT_TAG_FULL)
                 tag['mdtype'] = miCOMPRESSED
                 tag['byte_count'] = len(out_str)
-                self.file_stream.write(tag.tostring())
+                self.file_stream.write(tag.tobytes())
                 self.file_stream.write(out_str)
             else:  # not compressing
                 self._matrix_writer.write_top(var, asbytes(name), is_global)

--- a/scipy/io/matlab/mio5_utils.pyx
+++ b/scipy/io/matlab/mio5_utils.pyx
@@ -858,7 +858,7 @@ cdef class VarReader5:
                 arr = np.ndarray(shape=(length,),
                                   dtype=dt,
                                   buffer=data)
-                data = arr.astype(np.uint8).tostring()
+                data = arr.astype(np.uint8).tobytes()
         elif mdtype == miINT8 or mdtype == miUINT8:
             codec = 'ascii'
         elif mdtype in self.codecs: # encoded char data

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -1024,7 +1024,7 @@ def test_str_round():
     stream.truncate(0)
     stream.seek(0)
     # Make Fortran ordered version of string
-    in_str = in_arr.tostring(order='F')
+    in_str = in_arr.tobytes(order='F')
     in_from_str = np.ndarray(shape=a.shape,
                              dtype=in_arr.dtype,
                              order='F',

--- a/scipy/io/matlab/tests/test_mio5_utils.py
+++ b/scipy/io/matlab/tests/test_mio5_utils.py
@@ -96,17 +96,17 @@ def test_read_tag():
     # bad SDE
     tag = _make_tag('i4', 1, mio5p.miINT32, sde=True)
     tag['byte_count'] = 5
-    _write_stream(str_io, tag.tostring())
+    _write_stream(str_io, tag.tobytes())
     assert_raises(ValueError, c_reader.read_tag)
 
 
 def test_read_stream():
     tag = _make_tag('i4', 1, mio5p.miINT32, sde=True)
-    tag_str = tag.tostring()
+    tag_str = tag.tobytes()
     str_io = cStringIO(tag_str)
     st = streams.make_stream(str_io)
     s = streams._read_into(st, tag.itemsize)
-    assert_equal(s, tag.tostring())
+    assert_equal(s, tag.tobytes())
 
 
 def test_read_numeric():
@@ -125,7 +125,7 @@ def test_read_numeric():
             for sde_f in (False, True):
                 dt = np.dtype(base_dt).newbyteorder(byte_code)
                 a = _make_tag(dt, val, mdtype, sde_f)
-                a_str = a.tostring()
+                a_str = a.tobytes()
                 _write_stream(str_io, a_str)
                 el = c_reader.read_numeric()
                 assert_equal(el, val)
@@ -144,7 +144,7 @@ def test_read_numeric_writeable():
     c_reader = m5u.VarReader5(r)
     dt = np.dtype('<u2')
     a = _make_tag(dt, 30, mio5p.miUINT16, 0)
-    a_str = a.tostring()
+    a_str = a.tobytes()
     _write_stream(str_io, a_str)
     el = c_reader.read_numeric()
     assert_(el.flags.writeable is True)
@@ -163,13 +163,13 @@ def test_zero_byte_string():
     hdr = m5u.VarHeader5()
     # Try when string is 1 length
     hdr.set_dims([1,])
-    _write_stream(str_io, tag.tostring() + b'        ')
+    _write_stream(str_io, tag.tobytes() + b'        ')
     str_io.seek(0)
     val = c_reader.read_char(hdr)
     assert_equal(val, ' ')
     # Now when string has 0 bytes 1 length
     tag['byte_count'] = 0
-    _write_stream(str_io, tag.tostring())
+    _write_stream(str_io, tag.tobytes())
     str_io.seek(0)
     val = c_reader.read_char(hdr)
     assert_equal(val, ' ')

--- a/scipy/io/matlab/tests/test_mio_funcs.py
+++ b/scipy/io/matlab/tests/test_mio_funcs.py
@@ -35,7 +35,7 @@ def read_workspace_vars(fname):
     rdr = MatFile5Reader(fp, struct_as_record=True)
     vars = rdr.get_variables()
     fws = vars['__function_workspace__']
-    ws_bs = io.BytesIO(fws.tostring())
+    ws_bs = io.BytesIO(fws.tobytes())
     ws_bs.seek(2)
     rdr.mat_stream = ws_bs
     # Guess byte order.

--- a/scipy/io/matlab/tests/test_streams.py
+++ b/scipy/io/matlab/tests/test_streams.py
@@ -90,7 +90,7 @@ def test_read():
 
 class TestZlibInputStream(object):
     def _get_data(self, size):
-        data = np.random.randint(0, 256, size).astype(np.uint8).tostring()
+        data = np.random.randint(0, 256, size).astype(np.uint8).tobytes()
         compressed_data = zlib.compress(data)
         stream = BytesIO(compressed_data)
         return stream, len(compressed_data), data
@@ -122,7 +122,7 @@ class TestZlibInputStream(object):
 
     def test_read_max_length(self):
         size = 1234
-        data = np.random.randint(0, 256, size).astype(np.uint8).tostring()
+        data = np.random.randint(0, 256, size).astype(np.uint8).tobytes()
         compressed_data = zlib.compress(data)
         compressed_stream = BytesIO(compressed_data + b"abbacaca")
         stream = ZlibInputStream(compressed_stream, len(compressed_data))
@@ -133,7 +133,7 @@ class TestZlibInputStream(object):
         assert_raises(IOError, stream.read, 1)
 
     def test_read_bad_checksum(self):
-        data = np.random.randint(0, 256, 10).astype(np.uint8).tostring()
+        data = np.random.randint(0, 256, 10).astype(np.uint8).tobytes()
         compressed_data = zlib.compress(data)
 
         # break checksum
@@ -175,7 +175,7 @@ class TestZlibInputStream(object):
         assert_raises(IOError, stream.read, 12)
 
     def test_seek_bad_checksum(self):
-        data = np.random.randint(0, 256, 10).astype(np.uint8).tostring()
+        data = np.random.randint(0, 256, 10).astype(np.uint8).tobytes()
         compressed_data = zlib.compress(data)
 
         # break checksum
@@ -198,7 +198,7 @@ class TestZlibInputStream(object):
     def test_all_data_read_overlap(self):
         COMPRESSION_LEVEL = 6
 
-        data = np.arange(33707000).astype(np.uint8).tostring()
+        data = np.arange(33707000).astype(np.uint8).tobytes()
         compressed_data = zlib.compress(data, COMPRESSION_LEVEL)
         compressed_data_len = len(compressed_data)
 
@@ -214,7 +214,7 @@ class TestZlibInputStream(object):
     def test_all_data_read_bad_checksum(self):
         COMPRESSION_LEVEL = 6
 
-        data = np.arange(33707000).astype(np.uint8).tostring()
+        data = np.arange(33707000).astype(np.uint8).tobytes()
         compressed_data = zlib.compress(data, COMPRESSION_LEVEL)
         compressed_data_len = len(compressed_data)
 

--- a/scipy/io/netcdf.py
+++ b/scipy/io/netcdf.py
@@ -409,7 +409,7 @@ class netcdf_file(object):
     def _write(self):
         self.fp.seek(0)
         self.fp.write(b'CDF')
-        self.fp.write(array(self.version_byte, '>b').tostring())
+        self.fp.write(array(self.version_byte, '>b').tobytes())
 
         # Write headers and data.
         self._write_numrecs()
@@ -519,7 +519,7 @@ class netcdf_file(object):
 
         # Write data.
         if not var.isrec:
-            self.fp.write(var.data.tostring())
+            self.fp.write(var.data.tobytes())
             count = var.data.size * var.data.itemsize
             self._write_var_padding(var, var._vsize - count)
         else:  # record variable
@@ -541,7 +541,7 @@ class netcdf_file(object):
                 if not rec.shape and (rec.dtype.byteorder == '<' or
                         (rec.dtype.byteorder == '=' and LITTLE_ENDIAN)):
                     rec = rec.byteswap()
-                self.fp.write(rec.tostring())
+                self.fp.write(rec.tobytes())
                 # Padding
                 count = rec.size * rec.itemsize
                 self._write_var_padding(var, var._vsize - count)
@@ -591,7 +591,7 @@ class netcdf_file(object):
         if not values.shape and (values.dtype.byteorder == '<' or
                 (values.dtype.byteorder == '=' and LITTLE_ENDIAN)):
             values = values.byteswap()
-        self.fp.write(values.tostring())
+        self.fp.write(values.tobytes())
         count = values.size * values.itemsize
         self.fp.write(b'\x00' * (-count % 4))  # pad
 
@@ -776,7 +776,7 @@ class netcdf_file(object):
             self._pack_int64(begin)
 
     def _pack_int(self, value):
-        self.fp.write(array(value, '>i').tostring())
+        self.fp.write(array(value, '>i').tobytes())
     _pack_int32 = _pack_int
 
     def _unpack_int(self):
@@ -784,7 +784,7 @@ class netcdf_file(object):
     _unpack_int32 = _unpack_int
 
     def _pack_int64(self, value):
-        self.fp.write(array(value, '>q').tostring())
+        self.fp.write(array(value, '>q').tobytes())
 
     def _unpack_int64(self):
         return frombuffer(self.fp.read(8), '>q')[0]
@@ -1030,7 +1030,7 @@ class netcdf_variable(object):
         """
         if '_FillValue' in self._attributes:
             fill_value = np.array(self._attributes['_FillValue'],
-                                  dtype=self.data.dtype).tostring()
+                                  dtype=self.data.dtype).tobytes()
             if len(fill_value) == self.itemsize():
                 return fill_value
             else:

--- a/scipy/ndimage/utils/generate_label_testvectors.py
+++ b/scipy/ndimage/utils/generate_label_testvectors.py
@@ -32,7 +32,7 @@ def generate_test_vecs(infile, strelfile, resultfile):
     strels = strels + [np.flipud(s) for s in strels]
     strels = strels + [np.rot90(s) for s in strels]
     strels = [np.fromstring(s, dtype=int).reshape((3, 3))
-              for s in set(t.astype(int).tostring() for t in strels)]
+              for s in set(t.astype(int).tobytes() for t in strels)]
     inputs = np.vstack(data)
     results = np.vstack([label(d, s)[0] for d in data for s in strels])
     strels = np.vstack(strels)

--- a/scipy/optimize/lbfgsb.py
+++ b/scipy/optimize/lbfgsb.py
@@ -344,7 +344,7 @@ def _minimize_lbfgsb(fun, x0, args=(), jac=None, bounds=None,
         _lbfgsb.setulb(m, x, low_bnd, upper_bnd, nbd, f, g, factr,
                        pgtol, wa, iwa, task, iprint, csave, lsave,
                        isave, dsave, maxls)
-        task_str = task.tostring()
+        task_str = task.tobytes()
         if task_str.startswith(b'FG'):
             # The minimization routine wants f and g at the current x.
             # Note that interruptions due to maxfun are postponed
@@ -365,7 +365,7 @@ def _minimize_lbfgsb(fun, x0, args=(), jac=None, bounds=None,
         else:
             break
 
-    task_str = task.tostring().strip(b'\x00').strip()
+    task_str = task.tobytes().strip(b'\x00').strip()
     if task_str.startswith(b'CONV'):
         warnflag = 0
     elif sf.nfev > maxfun or n_iterations >= maxiter:


### PR DESCRIPTION
tostring() is the pre-numpy-1.9 name, and is not a good name in python3 where the return type is _not_ `str`.


<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
https://github.com/numpy/numpy/pull/15867

#### What does this implement/fix?
Use of an outdated name.

#### Additional information
<!--Any additional information you think is important.-->