### PR TITLE
MAINT: Replace npy_3kcompat.h shims

### DIFF
--- a/scipy/integrate/_odepackmodule.c
+++ b/scipy/integrate/_odepackmodule.c
@@ -813,7 +813,7 @@ PyInit__odepack(void)
     import_array();
     d = PyModule_GetDict(m);
 
-    s = PyUString_FromString(" 1.9 ");
+    s = PyUnicode_FromString(" 1.9 ");
     PyDict_SetItemString(d, "__version__", s);
     odepack_error = PyErr_NewException ("odepack.error", NULL, NULL);
     Py_DECREF(s);

--- a/scipy/ndimage/src/nd_image.c
+++ b/scipy/ndimage/src/nd_image.c
@@ -1102,7 +1102,7 @@ static PyObject *Py_BinaryErosion2(PyObject *obj, PyObject *args)
     if (!_validate_origin(array, origin)) {
         goto exit;
     }
-    if (NpyCapsule_Check(cobj)) {
+    if (PyCapsule_CheckExact(cobj)) {
         NI_CoordinateList *cobj_data = NpyCapsule_AsVoidPtr(cobj);
         if (!NI_BinaryErosion2(array, strct, mask, niter, origin.ptr, invert,
                                &cobj_data)) {

--- a/scipy/signal/lfilter.c.src
+++ b/scipy/signal/lfilter.c.src
@@ -73,18 +73,18 @@ convert_shape_to_errmsg(npy_intp ndim, npy_intp *Xshape, npy_intp *Vishape,
     PyObject *msg, *tmp, *msg1, *tmp1;
 
     if (ndim == 1) {
-        msg = PyUString_FromFormat("Unexpected shape for zi: expected (%"   \
+        msg = PyUnicode_FromFormat("Unexpected shape for zi: expected (%"   \
                                     NPY_INTP_FMT ",), found (%" NPY_INTP_FMT \
                                     ",).", val, Vishape[0]);
         return msg;
     }
 
-    msg = PyUString_FromString("Unexpected shape for zi:  expected (");
+    msg = PyUnicode_FromString("Unexpected shape for zi:  expected (");
     if (!msg) {
         return 0;
     }
 
-    msg1 = PyUString_FromString("), found (");
+    msg1 = PyUnicode_FromString("), found (");
     if (!msg1) {
         Py_DECREF(msg);
         return 0;
@@ -94,11 +94,11 @@ convert_shape_to_errmsg(npy_intp ndim, npy_intp *Xshape, npy_intp *Vishape,
         expect_size = j != theaxis ? Xshape[j] : val;
 
         if (j == ndim - 1) {
-            tmp = PyUString_FromFormat("%" NPY_INTP_FMT, expect_size);
-            tmp1 = PyUString_FromFormat("%" NPY_INTP_FMT, Vishape[j]);
+            tmp = PyUnicode_FromFormat("%" NPY_INTP_FMT, expect_size);
+            tmp1 = PyUnicode_FromFormat("%" NPY_INTP_FMT, Vishape[j]);
         } else {
-            tmp = PyUString_FromFormat("%" NPY_INTP_FMT ",", expect_size);
-            tmp1 = PyUString_FromFormat("%" NPY_INTP_FMT ",", Vishape[j]);
+            tmp = PyUnicode_FromFormat("%" NPY_INTP_FMT ",", expect_size);
+            tmp1 = PyUnicode_FromFormat("%" NPY_INTP_FMT ",", Vishape[j]);
         }
         if (!tmp) {
             Py_DECREF(msg);
@@ -112,16 +112,21 @@ convert_shape_to_errmsg(npy_intp ndim, npy_intp *Xshape, npy_intp *Vishape,
             Py_DECREF(tmp);
             return 0;
         }
-        PyUString_ConcatAndDel(&msg, tmp);
-        PyUString_ConcatAndDel(&msg1, tmp1);
+        Py_SETREF(msg, PyUnicode_Concat(msg, tmp));
+        Py_SETREF(msg1, PyUnicode_Concat(msg1, tmp1));
+        Py_DECREF(tmp);
+        Py_DECREF(tmp1);
     }
-    tmp = PyUString_FromString(").");
+    tmp = PyUnicode_FromString(").");
     if (!tmp) {
         Py_DECREF(msg);
         Py_DECREF(msg1);
+        return 0;
     }
-    PyUString_ConcatAndDel(&msg1, tmp);
-    PyUString_ConcatAndDel(&msg, msg1);
+    Py_SETREF(msg1, PyUnicode_Concat(msg1, tmp));
+    Py_SETREF(msg, PyUnicode_Concat(msg, msg1));
+    Py_DECREF(tmp);
+    Py_DECREF(msg1);
     return msg;
 }
 

--- a/scipy/sparse/linalg/dsolve/_superluobject.c
+++ b/scipy/sparse/linalg/dsolve/_superluobject.c
@@ -811,13 +811,13 @@ PyObject *newSuperLUObject(SuperMatrix * A, PyObject * option_dict,
     char *s = "";                               \
     PyObject *tmpobj = NULL;                    \
     if (input == Py_None) return 1;             \
-    if (PyString_Check(input)) {                \
-        s = PyString_AS_STRING(input);          \
+    if (PyBytes_Check(input)) {                \
+        s = PyBytes_AS_STRING(input);          \
     }                                           \
     else if (PyUnicode_Check(input)) {          \
         tmpobj = PyUnicode_AsASCIIString(input);\
         if (tmpobj == NULL) return 0;           \
-        s = PyString_AS_STRING(tmpobj);         \
+        s = PyBytes_AS_STRING(tmpobj);         \
     }                                           \
     else if (PyInt_Check(input)) {              \
         i = PyInt_AsLong(input);                \
@@ -1008,7 +1008,7 @@ static int droprule_cvt(PyObject * input, int *value)
 	*value = PyInt_AsLong(input);
 	return 1;
     }
-    else if (PyString_Check(input) || PyUnicode_Check(input)) {
+    else if (PyBytes_Check(input) || PyUnicode_Check(input)) {
         /* Comma-separated string */
         char *fmt = "s";
         if (PyBytes_Check(input)) {


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Continued work to remove all Python2 Code #11584

Follows after #11744

#### What does this implement/fix?
<!--Please explain your changes.-->

Removes about half of SciPy's use of [npy_3kcompat.h](https://github.com/numpy/numpy/blob/master/numpy/core/include/numpy/npy_3kcompat.h). 

What's left is the [npy_capsule shims](https://github.com/numpy/numpy/blob/master/numpy/core/include/numpy/npy_3kcompat.h#L498) which just clear PyErr
```C
static NPY_INLINE PyObject *
NpyCapsule_FromVoidPtr(void *ptr, void (*dtor)(PyObject *))
{
    PyObject *ret = PyCapsule_New(ptr, NULL, dtor);
    if (ret == NULL) {
        PyErr_Clear();
    }
    return ret;
}
```

I'm hoping I can just change these over and we get better error handling and we no longer depend on numpy py3k.h


#### Additional information
<!--Any additional information you think is important.-->