### PR TITLE
TST: Speedup slow test_distributions.py tests

### DIFF
--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -243,28 +243,28 @@ class TestGenInvGauss(object):
     def test_rvs_with_mode_shift(self):
         # ratio_unif w/ mode shift
         gig = stats.geninvgauss(2.3, 1.5)
-        _, p = stats.kstest(gig.rvs(size=1500, random_state=1234), gig.cdf)
+        _, p = stats.kstest(gig.rvs(size=1000, random_state=1234), gig.cdf)
         assert_equal(p > 0.05, True)
 
     @pytest.mark.slow
     def test_rvs_without_mode_shift(self):
         # ratio_unif w/o mode shift
         gig = stats.geninvgauss(0.9, 0.75)
-        _, p = stats.kstest(gig.rvs(size=1500, random_state=1234), gig.cdf)
+        _, p = stats.kstest(gig.rvs(size=1000, random_state=1234), gig.cdf)
         assert_equal(p > 0.05, True)
 
     @pytest.mark.slow
     def test_rvs_new_method(self):
         # new algorithm of Hoermann / Leydold
         gig = stats.geninvgauss(0.1, 0.2)
-        _, p = stats.kstest(gig.rvs(size=1500, random_state=1234), gig.cdf)
+        _, p = stats.kstest(gig.rvs(size=1000, random_state=1234), gig.cdf)
         assert_equal(p > 0.05, True)
 
     @pytest.mark.slow
     def test_rvs_p_zero(self):
         def my_ks_check(p, b):
             gig = stats.geninvgauss(p, b)
-            rvs = gig.rvs(size=1500, random_state=1234)
+            rvs = gig.rvs(size=1000, random_state=1234)
             return stats.kstest(rvs, gig.cdf)[1] > 0.05
         # boundary cases when p = 0
         assert_equal(my_ks_check(0, 0.2), True)  # new algo
@@ -279,7 +279,7 @@ class TestGenInvGauss(object):
 
     def test_invgauss(self):
         # test that invgauss is special case
-        ig = stats.geninvgauss.rvs(size=1500, p=-0.5, b=1, random_state=1234)
+        ig = stats.geninvgauss.rvs(size=1000, p=-0.5, b=1, random_state=1234)
         assert_equal(stats.kstest(ig, 'invgauss', args=[1])[1] > 0.15, True)
         # test pdf and cdf
         mu, x = 100, np.linspace(0.01, 1, 10)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -5183,51 +5183,51 @@ class TestMGCStat(object):
     @dec.slow
     @pytest.mark.parametrize("sim_type, obs_stat, obs_pvalue", [
         ("linear", 0.97, 1/1000),           # test linear simulation
-        ("nonlinear", 0.163, 1/1000),       # test spiral simulation
-        ("independence", -0.0094, 0.78)     # test independence simulation
+        ("nonlinear", 0.18, 1/1000),       # test spiral simulation
+        ("independence", 0.044, 0.043)     # test independence simulation
     ])
     def test_oned(self, sim_type, obs_stat, obs_pvalue):
         np.random.seed(12345678)
 
         # generate x and y
-        x, y = self._simulations(samps=100, dims=1, sim_type=sim_type)
+        x, y = self._simulations(samps=80, dims=1, sim_type=sim_type)
 
         # test stat and pvalue
         stat, pvalue, _ = stats.multiscale_graphcorr(x, y)
-        assert_approx_equal(stat, obs_stat, significant=1)
-        assert_approx_equal(pvalue, obs_pvalue, significant=1)
+        assert_approx_equal(stat, obs_stat, significant=2)
+        assert_approx_equal(pvalue, obs_pvalue, significant=2)
 
     @dec.slow
     @pytest.mark.parametrize("sim_type, obs_stat, obs_pvalue", [
-        ("linear", 0.184, 1/1000),           # test linear simulation
-        ("nonlinear", 0.0190, 0.117),        # test spiral simulation
+        ("linear", 0.21, 1/1000),           # test linear simulation
+        ("nonlinear", -0.0055, 0.55),        # test spiral simulation
     ])
     def test_fived(self, sim_type, obs_stat, obs_pvalue):
         np.random.seed(12345678)
 
         # generate x and y
-        x, y = self._simulations(samps=100, dims=5, sim_type=sim_type)
+        x, y = self._simulations(samps=80, dims=5, sim_type=sim_type)
 
         # test stat and pvalue
         stat, pvalue, _ = stats.multiscale_graphcorr(x, y)
-        assert_approx_equal(stat, obs_stat, significant=1)
-        assert_approx_equal(pvalue, obs_pvalue, significant=1)
+        assert_approx_equal(stat, obs_stat, significant=2)
+        assert_approx_equal(pvalue, obs_pvalue, significant=2)
 
     @dec.slow
     def test_twosamp(self):
         np.random.seed(12345678)
 
-        # generate x and y
-        x = np.random.binomial(100, 0.5, size=(100, 5))
-        y = np.random.normal(0, 1, size=(80, 5))
+        # generate random x and y
+        x = np.random.binomial(100, 0.5, size=(80, 5))
+        y = np.random.normal(0, 1, size=(60, 5))
 
         # test stat and pvalue
         stat, pvalue, _ = stats.multiscale_graphcorr(x, y)
         assert_approx_equal(stat, 1.0, significant=1)
         assert_approx_equal(pvalue, 0.001, significant=1)
 
-        # generate x and y
-        y = np.random.normal(0, 1, size=(100, 5))
+        # generate random new y
+        y = np.random.normal(0, 1, size=(80, 5))
 
         # test stat and pvalue
         stat, pvalue, _ = stats.multiscale_graphcorr(x, y, is_twosamp=True)


### PR DESCRIPTION
(Editted in response to rgommers comment)

I ran the scipy tests on my local machine
`time python runtests.py -m full -- --durations=2000 | tee test.log`
and analysed them in colab ([colab](https://colab.research.google.com/drive/1GLYz5AK6G1PjAJjsRvIsXL5-rDlBfgK_) 

I tried to run the tests in Colab but they fail when I `git clone` or `pip install`.

I also looking at a couple of recent Azure runs and tried to reduce some of the stats sizes.

[Azure also has stats](https://dev.azure.com/scipy-org/SciPy/_test/analytics?definitionId=1&contextType=build)
Which show these test being slow


![Screenshot from 2020-03-30 16-22-45](https://user-images.githubusercontent.com/10172976/77971105-bda1fe00-72a2-11ea-98a3-993af7451566.png)

![Screenshot from 2020-03-30 16-21-06](https://user-images.githubusercontent.com/10172976/77971107-bed32b00-72a2-11ea-86f0-12c2832a20b8.png)


