### PR TITLE
TST: Speedup test_pascal which is VERY slow on Azure

### DIFF
--- a/scipy/sparse/linalg/tests/test_matfuncs.py
+++ b/scipy/sparse/linalg/tests/test_matfuncs.py
@@ -507,13 +507,13 @@ class TestExpM(object):
         # Nilpotent exponential, used to trigger a failure (gh-8029)
 
         for scale in [1.0, 1e-3, 1e-6]:
-            for n in range(120):
+            for n in range(0, 80, 3):
+                sc = scale ** np.arange(n, -1, -1)
+                if np.any(sc < 1e-300):
+                    break
+
                 A = np.diag(np.arange(1, n + 1), -1) * scale
                 B = expm(A)
-
-                sc = scale**np.arange(n, -1, -1)
-                if np.any(sc < 1e-300):
-                    continue
 
                 got = B
                 expected = binom(np.arange(n + 1)[:,None],


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

This test takes an average of *10 minutes!!!!* on azure, yet locally it takes only ~2 seconds!



#### Additional information
<!--Any additional information you think is important.-->