### PR TITLE
TST: speed up differential_evolution L8 test

### DIFF
--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -1150,7 +1150,10 @@ class TestDifferentialEvolutionSolver(object):
 
         with suppress_warnings() as sup:
             sup.filter(UserWarning)
-            res = differential_evolution(f, bounds, strategy='rand1bin',
+            # original Lampinen test was with rand1bin, but that takes a
+            # huge amount of CPU time. Changing strategy to best1bin speeds
+            # things up a lot
+            res = differential_evolution(f, bounds, strategy='best1bin',
                                          seed=1234, constraints=constraints,
                                          maxiter=5000)
 


### PR DESCRIPTION
Some CI entries seem to be running fairly slowly. There are a couple of PR's in to try and fix some of the glaring issues (see #11764). This PR speeds up another of the culprits, a constrained differential evolution solve. The original strategy was `rand1bin`, this PR changes to `best1bin` which speeds up the test on my computer my an order of magnitude.
I don't think that this minor change materially affects the test. The purpose of these tests is to check that constrained solves work.