### PR TITLE
BUG: Fixed calculation of nonzero elements in scipy.sparse.random

### DIFF
--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -761,7 +761,7 @@ greater than %d - this is not supported on this machine
         raise ValueError(msg % np.iinfo(tp).max)
 
     # Number of non zero values
-    k = round(density * m * n)
+    k = int(round(density * m * n))
 
     if random_state is None:
         random_state = np.random

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -761,7 +761,7 @@ greater than %d - this is not supported on this machine
         raise ValueError(msg % np.iinfo(tp).max)
 
     # Number of non zero values
-    k = int(density * m * n)
+    k = round(density * m * n)
 
     if random_state is None:
         random_state = np.random

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -471,3 +471,9 @@ class TestConstructUtils(object):
         # for the dtype
         construct.random(10, 10, dtype='d')
 
+    def test_random_sparse_matrix_returns_correct_number_of_non_zero_elements(self):
+        # A 10 x 10 matrix, with density of 12.65%, should have 13 nonzero elements.
+        # 10 x 10 x 0.1265 = 12.65, which should be rounded up to 13, not 12.
+        sparse_matrix = construct.random(10, 10, density=0.1265)
+        assert_equal(sparse_matrix.count_nonzero(),13)
+


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
None
#### What does this implement/fix?
<!--Please explain your changes.-->
Previously, when calculating the number of non zero values, `int()` was wrapped around the result, meaning the value was always rounded down. Rather the `round()` function should be used so that when number of nonzero elements is something like `10.99`, it gets rounded to `11` non zero values as opposed to `10` (current implementation).
#### Additional information
<!--Any additional information you think is important.-->