### PR TITLE
MAINT: fix domain edge error for betainc a or b ==0 case is 1.

### DIFF
--- a/scipy/special/cephes/incbet.c
+++ b/scipy/special/cephes/incbet.c
@@ -80,7 +80,11 @@ double incbet(double aa, double bb, double xx)
     if (aa < 0.0 || bb < 0.0)
 	goto domerr;
 
-    if (aa == 0.0 || bb == 0.0)
+    if (aa == 0.0 && bb == 0.0)
+	    return (NPY_NAN);
+
+    if ((aa == 0.0 && bb > 0.0 && npy_isfinite(bb)) ||
+		    (aa > 0.0 && bb == 0.0 && npy_isfinite(aa)))
 	return (1.0);
 
     if ((xx <= 0.0) || (xx >= 1.0)) {

--- a/scipy/special/cephes/incbet.c
+++ b/scipy/special/cephes/incbet.c
@@ -72,14 +72,16 @@ static double incbcf(double a, double b, double x);
 static double incbd(double a, double b, double x);
 static double pseries(double a, double b, double x);
 
-double incbet(aa, bb, xx)
-double aa, bb, xx;
+double incbet(double aa, double bb, double xx)
 {
     double a, b, t, x, xc, w, y;
     int flag;
 
-    if (aa <= 0.0 || bb <= 0.0)
+    if (aa < 0.0 || bb < 0.0)
 	goto domerr;
+
+    if (aa == 0.0 || bb == 0.0)
+	return (1.0);
 
     if ((xx <= 0.0) || (xx >= 1.0)) {
 	if (xx == 0.0)

--- a/scipy/special/tests/test_betainc.py
+++ b/scipy/special/tests/test_betainc.py
@@ -1,10 +1,10 @@
 import numpy as np
 import scipy.special as sc
 import pytest
-from numpy.testing import assert_allclose 
+from numpy.testing import assert_allclose
 
 
-class Testbetainc(object):
+class Testbetainc:
     def test(self):
         val = sc.betainc(0.5, 1, 1)
         assert_allclose(val, 1)
@@ -19,11 +19,11 @@ class Testbetainc(object):
         val = sc.betainc(a, b, x)
         assert np.isnan(val)
 
-    @pytest.mark.parametrize('a, b, x', [
-        (0.0, 3, 0.5),
-        (3.0, 0, 0.5),
-        (0.0, 0, 0.5),
+    @pytest.mark.parametrize('a, b, x, result', [
+        (0.0, 3, 0.5, 1.0),
+        (3.0, 0, 0.5, 1.0),
+        (0.0, 0, 0.5, np.nan),
     ])
-    def test_domain_edge(self, a, b, x):
+    def test_domain_edge(self, a, b, x, result):
         val = sc.betainc(a, b, x)
-        assert_allclose(val, 1.0) 
+        assert_allclose(val, result)

--- a/scipy/special/tests/test_betainc.py
+++ b/scipy/special/tests/test_betainc.py
@@ -1,0 +1,29 @@
+import numpy as np
+import scipy.special as sc
+import pytest
+from numpy.testing import assert_allclose 
+
+
+class Testbetainc(object):
+    def test(self):
+        val = sc.betainc(0.5, 1, 1)
+        assert_allclose(val, 1)
+
+    @pytest.mark.parametrize('a, b, x', [
+        (np.inf, 2, 0.5),
+        (1.0, np.inf, 0.5),
+        (1.0, 2, np.inf),
+        (-1.1, 1, 0.5)
+    ])
+    def test_inf(self, a, b, x):
+        val = sc.betainc(a, b, x)
+        assert np.isnan(val)
+
+    @pytest.mark.parametrize('a, b, x', [
+        (0.0, 3, 0.5),
+        (3.0, 0, 0.5),
+        (0.0, 0, 0.5),
+    ])
+    def test_domain_edge(self, a, b, x):
+        val = sc.betainc(a, b, x)
+        assert_allclose(val, 1.0) 


### PR DESCRIPTION
#### Reference issue
Closes gh-8411

#### What does this implement/fix?
the `betainc` function was not providing correct values at boundary values for `a` and `b`, when either are `0.0`. In the described boundary case the values returned should be `1.0`. This PR implements the change. Also adds a test module to confirm the boundary values are as expected. 


#### Additional information
Previously (taken from gh-8411):
```
import numpy as np
from scipy.special import betainc

X = 0.5
Z = np.array(range(0,11))
W = 3

print(betainc(Z,W,X))
[       nan 0.875      0.6875     0.5        0.34375    0.2265625
 0.14453125 0.08984375 0.0546875  0.03271484 0.01928711]
```

Now: 
```
(scipy-dev) Lucass-MacBook:scipy rlucas$ python 
Python 3.6.7 |Anaconda, Inc.| (default, Oct 23 2018, 14:01:38) 
[GCC 4.2.1 Compatible Clang 4.0.1 (tags/RELEASE_401/final)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import numpy as np
>>> from scipy.special import betainc
>>> X = 0.5
>>> Z = np.array(range(0,11))
>>> W = 3
>>> print(betainc(Z,W,X))
[1.         0.875      0.6875     0.5        0.34375    0.2265625
 0.14453125 0.08984375 0.0546875  0.03271484 0.01928711]
>>> 
(scipy-dev) Lucass-MacBook:scipy rlucas$
```
