### PR TITLE
MAINT: add comments explaining a problem in cython_optimize organization

### DIFF
--- a/scipy/optimize/cython_optimize.pxd
+++ b/scipy/optimize/cython_optimize.pxd
@@ -1,2 +1,11 @@
+# Public Cython API declarations
+#
+# See doc/source/dev/contributor/public_cython_api.rst for guidelines
+
+
+# The following cimport statement provides legacy ABI
+# support. Changing it causes an ABI forward-compatibility break
+# (gh-11793), so we currently leave it as is (no further cimport
+# statements should be used in this file).
 from .cython_optimize._zeros cimport (
     brentq, brenth, ridder, bisect, zeros_full_output)

--- a/scipy/optimize/cython_optimize/_zeros.pxd
+++ b/scipy/optimize/cython_optimize/_zeros.pxd
@@ -1,3 +1,9 @@
+# Legacy public Cython API declarations
+#
+# NOTE: due to the way Cython ABI compatibility works, **no changes
+# should be made to this file** --- any API additions/changes should be
+# done in `cython_optimize.pxd` (see gh-11793).
+
 ctypedef double (*callback_type)(double, void*)
 
 ctypedef struct zeros_parameters:


### PR DESCRIPTION
#### Reference issue
See gh-11793

#### What does this implement/fix?

Add comments explaining an ABI compatibility issue in the current `cython_optimize` API, and pointing to the github issue. To my understanding, making changes in `_zeros.pxd` generally results to an ABI break due to the way Cython currently works, so add notices to the source code indicating how to proceed with the issue in future.
