### PR TITLE
DOC: add a note about precision losing in csgraph.minimum_spanning_tree docstring

### DIFF
--- a/scipy/sparse/csgraph/_min_spanning_tree.pyx
+++ b/scipy/sparse/csgraph/_min_spanning_tree.pyx
@@ -44,6 +44,11 @@ def minimum_spanning_tree(csgraph, overwrite=False):
     have an edge connecting them.  If either is nonzero, then the two are
     connected by the minimum nonzero value of the two.
 
+    This routine loses precision when users input a dense matrix.
+    Small elements < 1E-8 of the dense matrix are rounded to zero.
+    All users should input sparse matrices if possible to avoid it.
+
+
     Examples
     --------
     The following example shows the computation of a minimum spanning tree


### PR DESCRIPTION
#### Reference issue
fix #11391

#### What does this implement/fix?
I added a note about precision losing in csgraph.minimum_spanning_tree docstring