### PR TITLE
ENH: Allow negative `axis` in `interpolate.BSpline`.  Also use numpy's `normalize_axis_index` in a few places.

### DIFF
--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -2,6 +2,7 @@ import functools
 import operator
 
 import numpy as np
+from numpy.core.multiarray import normalize_axis_index
 from scipy.linalg import (get_lapack_funcs, LinAlgError,
                           cholesky_banded, cho_solve_banded)
 from . import _bspl
@@ -189,9 +190,9 @@ class BSpline(object):
 
         n = self.t.shape[0] - self.k - 1
 
-        if not (0 <= axis < self.c.ndim):
-            raise ValueError("%s must be between 0 and %s" % (axis, c.ndim))
+        axis = normalize_axis_index(axis, self.c.ndim)
 
+        # Note that the normalized axis is stored in the object.
         self.axis = axis
         if axis != 0:
             # roll the interpolation axis to be the first one in self.c
@@ -741,10 +742,7 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
 
     y = np.asarray(y)
 
-    if not -y.ndim <= axis < y.ndim:
-        raise ValueError("axis {} is out of bounds".format(axis))
-    if axis < 0:
-        axis += y.ndim
+    axis = normalize_axis_index(axis, y.ndim)
 
     # special-case k=0 right away
     if k == 0:
@@ -972,10 +970,7 @@ def make_lsq_spline(x, y, t, k=3, w=None, axis=0, check_finite=True):
         w = np.ones_like(x)
     k = operator.index(k)
 
-    if not -y.ndim <= axis < y.ndim:
-        raise ValueError("axis {} is out of bounds".format(axis))
-    if axis < 0:
-        axis += y.ndim
+    axis = normalize_axis_index(axis, y.ndim)
 
     y = np.rollaxis(y, axis)    # now internally interp axis is zero
 

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -388,32 +388,45 @@ class TestBSpline(object):
         assert_equal(b.derivative().__class__, B)
         assert_equal(b.antiderivative().__class__, B)
 
-    def test_axis(self):
+    @pytest.mark.parametrize('axis', range(-4, 4))
+    def test_axis(self, axis):
         n, k = 22, 3
         t = np.linspace(0, 1, n + k + 1)
-        sh0 = [6, 7, 8]
-        for axis in range(4):
-            sh = sh0[:]
-            sh.insert(axis, n)   # [22, 6, 7, 8] etc
-            c = np.random.random(size=sh)
-            b = BSpline(t, c, k, axis=axis)
-            assert_equal(b.c.shape,
-                         [sh[axis],] + sh[:axis] + sh[axis+1:])
+        sh = [6, 7, 8]
+        # We need the positive axis for some of the indexing and slices used
+        # in this test.
+        pos_axis = axis % 4
+        sh.insert(pos_axis, n)   # [22, 6, 7, 8] etc
+        c = np.random.random(size=sh)
+        b = BSpline(t, c, k, axis=axis)
+        assert_equal(b.c.shape,
+                     [sh[pos_axis],] + sh[:pos_axis] + sh[pos_axis+1:])
 
-            xp = np.random.random((3, 4, 5))
-            assert_equal(b(xp).shape,
-                         sh[:axis] + list(xp.shape) + sh[axis+1:])
+        xp = np.random.random((3, 4, 5))
+        assert_equal(b(xp).shape,
+                     sh[:pos_axis] + list(xp.shape) + sh[pos_axis+1:])
 
-            #0 <= axis < c.ndim
-            for ax in [-1, c.ndim]:
-                assert_raises(ValueError, BSpline, **dict(t=t, c=c, k=k, axis=ax))
+        # -c.ndim <= axis < c.ndim
+        for ax in [-c.ndim - 1, c.ndim]:
+            assert_raises(np.AxisError, BSpline,
+                          **dict(t=t, c=c, k=k, axis=ax))
 
-            # derivative, antiderivative keeps the axis
-            for b1 in [BSpline(t, c, k, axis=axis).derivative(),
-                       BSpline(t, c, k, axis=axis).derivative(2),
-                       BSpline(t, c, k, axis=axis).antiderivative(),
-                       BSpline(t, c, k, axis=axis).antiderivative(2)]:
-                assert_equal(b1.axis, b.axis)
+        # derivative, antiderivative keeps the axis
+        for b1 in [BSpline(t, c, k, axis=axis).derivative(),
+                   BSpline(t, c, k, axis=axis).derivative(2),
+                   BSpline(t, c, k, axis=axis).antiderivative(),
+                   BSpline(t, c, k, axis=axis).antiderivative(2)]:
+            assert_equal(b1.axis, b.axis)
+
+    def test_neg_axis(self):
+        k = 2
+        t = [0, 1, 2, 3, 4, 5, 6]
+        c = np.array([[-1, 2, 0, -1], [2, 0, -3, 1]])
+
+        spl = BSpline(t, c, k, axis=-1)
+        spl0 = BSpline(t, c[0], k)
+        spl1 = BSpline(t, c[1], k)
+        assert_equal(spl(2.5), [spl0(2.5), spl1(2.5)])
 
 
 def test_knots_multiplicity():

--- a/scipy/ndimage/_ni_support.py
+++ b/scipy/ndimage/_ni_support.py
@@ -79,11 +79,3 @@ def _get_output(output, input, shape=None):
     elif output.shape != shape:
         raise RuntimeError("output shape not correct")
     return output
-
-
-def _check_axis(axis, rank):
-    if axis < 0:
-        axis += rank
-    if axis < 0 or axis >= rank:
-        raise ValueError('invalid axis')
-    return axis

--- a/scipy/ndimage/filters.py
+++ b/scipy/ndimage/filters.py
@@ -32,6 +32,7 @@ from collections.abc import Iterable
 import warnings
 import numpy
 import operator
+from numpy.core.multiarray import normalize_axis_index
 from . import _ni_support
 from . import _nd_image
 from . import _ni_docstrings
@@ -84,7 +85,7 @@ def correlate1d(input, weights, axis=-1, output=None, mode="reflect",
         raise RuntimeError('no filter weights given')
     if not weights.flags.contiguous:
         weights = weights.copy()
-    axis = _ni_support._check_axis(axis, input.ndim)
+    axis = normalize_axis_index(axis, input.ndim)
     if _invalid_origin(origin, len(weights)):
         raise ValueError('Invalid origin; origin must satisfy '
                          '-(len(weights) // 2) <= origin <= '
@@ -329,7 +330,7 @@ def prewitt(input, axis=-1, output=None, mode="reflect", cval=0.0):
     >>> plt.show()
     """
     input = numpy.asarray(input)
-    axis = _ni_support._check_axis(axis, input.ndim)
+    axis = normalize_axis_index(axis, input.ndim)
     output = _ni_support._get_output(output, input)
     modes = _ni_support._normalize_sequence(mode, input.ndim)
     correlate1d(input, [-1, 0, 1], axis, output, modes[axis], cval, 0)
@@ -366,7 +367,7 @@ def sobel(input, axis=-1, output=None, mode="reflect", cval=0.0):
     >>> plt.show()
     """
     input = numpy.asarray(input)
-    axis = _ni_support._check_axis(axis, input.ndim)
+    axis = normalize_axis_index(axis, input.ndim)
     output = _ni_support._get_output(output, input)
     modes = _ni_support._normalize_sequence(mode, input.ndim)
     correlate1d(input, [-1, 0, 1], axis, output, modes[axis], cval, 0)
@@ -784,7 +785,7 @@ def uniform_filter1d(input, size, axis=-1, output=None,
     input = numpy.asarray(input)
     if numpy.iscomplexobj(input):
         raise TypeError('Complex type not supported')
-    axis = _ni_support._check_axis(axis, input.ndim)
+    axis = normalize_axis_index(axis, input.ndim)
     if size < 1:
         raise RuntimeError('incorrect filter size')
     output = _ni_support._get_output(output, input)
@@ -898,7 +899,7 @@ def minimum_filter1d(input, size, axis=-1, output=None,
     input = numpy.asarray(input)
     if numpy.iscomplexobj(input):
         raise TypeError('Complex type not supported')
-    axis = _ni_support._check_axis(axis, input.ndim)
+    axis = normalize_axis_index(axis, input.ndim)
     if size < 1:
         raise RuntimeError('incorrect filter size')
     output = _ni_support._get_output(output, input)
@@ -955,7 +956,7 @@ def maximum_filter1d(input, size, axis=-1, output=None,
     input = numpy.asarray(input)
     if numpy.iscomplexobj(input):
         raise TypeError('Complex type not supported')
-    axis = _ni_support._check_axis(axis, input.ndim)
+    axis = normalize_axis_index(axis, input.ndim)
     if size < 1:
         raise RuntimeError('incorrect filter size')
     output = _ni_support._get_output(output, input)
@@ -1372,7 +1373,7 @@ def generic_filter1d(input, function, filter_size, axis=-1,
     output = _ni_support._get_output(output, input)
     if filter_size < 1:
         raise RuntimeError('invalid filter size')
-    axis = _ni_support._check_axis(axis, input.ndim)
+    axis = normalize_axis_index(axis, input.ndim)
     if (filter_size // 2 + origin < 0) or (filter_size // 2 + origin >=
                                            filter_size):
         raise ValueError('invalid origin')

--- a/scipy/ndimage/fourier.py
+++ b/scipy/ndimage/fourier.py
@@ -29,6 +29,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import numpy
+from numpy.core.multiarray import normalize_axis_index
 from . import _ni_support
 from . import _nd_image
 
@@ -117,7 +118,7 @@ def fourier_gaussian(input, sigma, n=-1, axis=-1, output=None):
     """
     input = numpy.asarray(input)
     output = _get_output_fourier(output, input)
-    axis = _ni_support._check_axis(axis, input.ndim)
+    axis = normalize_axis_index(axis, input.ndim)
     sigmas = _ni_support._normalize_sequence(sigma, input.ndim)
     sigmas = numpy.asarray(sigmas, dtype=numpy.float64)
     if not sigmas.flags.contiguous:
@@ -176,7 +177,7 @@ def fourier_uniform(input, size, n=-1, axis=-1, output=None):
     """
     input = numpy.asarray(input)
     output = _get_output_fourier(output, input)
-    axis = _ni_support._check_axis(axis, input.ndim)
+    axis = normalize_axis_index(axis, input.ndim)
     sizes = _ni_support._normalize_sequence(size, input.ndim)
     sizes = numpy.asarray(sizes, dtype=numpy.float64)
     if not sizes.flags.contiguous:
@@ -238,7 +239,7 @@ def fourier_ellipsoid(input, size, n=-1, axis=-1, output=None):
     """
     input = numpy.asarray(input)
     output = _get_output_fourier(output, input)
-    axis = _ni_support._check_axis(axis, input.ndim)
+    axis = normalize_axis_index(axis, input.ndim)
     sizes = _ni_support._normalize_sequence(size, input.ndim)
     sizes = numpy.asarray(sizes, dtype=numpy.float64)
     if not sizes.flags.contiguous:
@@ -295,7 +296,7 @@ def fourier_shift(input, shift, n=-1, axis=-1, output=None):
     """
     input = numpy.asarray(input)
     output = _get_output_fourier_complex(output, input)
-    axis = _ni_support._check_axis(axis, input.ndim)
+    axis = normalize_axis_index(axis, input.ndim)
     shifts = _ni_support._normalize_sequence(shift, input.ndim)
     shifts = numpy.asarray(shifts, dtype=numpy.float64)
     if not shifts.flags.contiguous:

--- a/scipy/ndimage/interpolation.py
+++ b/scipy/ndimage/interpolation.py
@@ -29,8 +29,10 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import itertools
-import numpy
 import warnings
+
+import numpy
+from numpy.core.multiarray import normalize_axis_index
 
 from . import _ni_support
 from . import _nd_image
@@ -98,7 +100,7 @@ def spline_filter1d(input, order=3, axis=-1, output=numpy.float64,
         output[...] = numpy.array(input)
     else:
         mode = _ni_support._extend_mode_to_code(mode)
-        axis = _ni_support._check_axis(axis, input.ndim)
+        axis = normalize_axis_index(axis, input.ndim)
         _nd_image.spline_filter1d(input, order, axis, output, mode)
     return output
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2037,7 +2037,7 @@ class TestIQR(object):
         assert_equal(stats.iqr(d, axis=(1, 3))[2, 2],
                      stats.iqr(d[2, :, 2,:].ravel()))
 
-        assert_raises(IndexError, stats.iqr, d, axis=4)
+        assert_raises(np.AxisError, stats.iqr, d, axis=4)
         assert_raises(ValueError, stats.iqr, d, axis=(0, 0))
 
     def test_rng(self):


### PR DESCRIPTION
We have ad hoc code throughout the library for validating an `axis` argument.  By using the numpy function `normalize_axis_index` where appropriate, we ensure that our code follows a consistent API and matches numpy's behavior.  The main behaviors to ensure are:
* Valid values are `-ndim <= axis < ndim`; return `axis + ndim` if `axis` is negative.
* Raise the exception`numpy.AxisError` if `axis` is outside those bounds.
* Raise a `TypeError` if either `axis` or `ndim` is not an integer.

I updated some code in `interpolate` and `ndimage` to use the `normalize_axis_index` from numpy, and fixed one test in `stats` to check for the more specific exception `np.AxisError` instead of `IndexError`.

There are more places where we can use `normalize_axis_index`, but we don't have to update them all in this PR.
