### PR TITLE
BUG: fix scipy.odr to handle multidimensional independent and dependent variable currently causing segmentation fault

### DIFF
--- a/scipy/odr/__odrpack.c
+++ b/scipy/odr/__odrpack.c
@@ -152,7 +152,7 @@ void fcn_callback(int *n, int *m, int *np, int *nq, int *ldn, int *ldm,
       if ((result_array =
            (PyArrayObject *) PyArray_ContiguousFromObject(result,
                                                           NPY_DOUBLE, 0,
-                                                          2)) == NULL)
+                                                          3)) == NULL)
         {
           PYERR2(odr_error,
                  "Result from function call is not a proper array of floats.");
@@ -211,7 +211,7 @@ void fcn_callback(int *n, int *m, int *np, int *nq, int *ldn, int *ldm,
       if ((result_array =
            (PyArrayObject *) PyArray_ContiguousFromObject(result,
                                                           NPY_DOUBLE, 0,
-                                                          2)) == NULL)
+                                                          3)) == NULL)
         {
           PYERR2(odr_error,
                  "Result from function call is not a proper array of floats.");

--- a/scipy/odr/tests/test_odr.py
+++ b/scipy/odr/tests/test_odr.py
@@ -356,3 +356,71 @@ class TestODR(object):
         odr2 = ODR(data, model, beta0=np.array([1.]), ifixx=fix)
         sol2 = odr2.run()
         assert_equal(sol1.beta, sol2.beta)
+
+    # verify bugfix in #11800
+    def test_ticket_11800(self):
+        # parameters
+        beta_true = np.array([1.0, 2.3, 1.1, -1.0, 1.3, 0.5])
+        nr_measurements = 10;
+
+        std_dev_x = 0.01
+        x_error = np.array([[0.00063445, 0.00515731, 0.00162719, 0.01022866,
+            -0.01624845, 0.00482652, 0.00275988, -0.00714734, -0.00929201, -0.00687301],
+            [-0.00831623, -0.00821211, -0.00203459, 0.00938266, -0.00701829,
+            0.0032169, 0.00259194, -0.00581017, -0.0030283, 0.01014164]])
+
+        std_dev_y = 0.05
+        y_error = np.array([[0.05275304, 0.04519563, -0.07524086, 0.03575642,
+            0.04745194, 0.03806645, 0.07061601, -0.00753604, -0.02592543, -0.02394929],
+            [0.03632366, 0.06642266, 0.08373122, 0.03988822, -0.0092536,
+            -0.03750469, -0.03198903, 0.01642066, 0.01293648, -0.05627085]])
+
+        beta_solution = np.array([-4.43863482, 444.95461327, -440.51978586, 2.36860998,
+            -265.64757342, 266.81217572])
+
+        # model's function and Jacobians
+        def func(beta, x):
+            y0 = beta[0] + beta[1] * x[0, :] + beta[2] * x[1, :]
+            y1 = beta[3] + beta[4] * x[0, :] + beta[5] * x[1, :]
+            return np.vstack((y0, y1))
+
+        def df_dbeta_odr(beta, x):
+            nr_meas = np.shape(x)[1]
+            zeros = np.zeros(nr_meas)
+            ones = np.ones(nr_meas)
+
+            dy0 = np.array([ones, x[0, :], x[1, :], zeros, zeros, zeros])
+            dy1 = np.array([zeros, zeros, zeros, ones, x[0, :], x[1, :]])
+            return np.stack((dy0, dy1))
+
+        def df_dx_odr(beta, x):
+            nr_meas = np.shape(x)[1]
+            ones = np.ones(nr_meas)
+
+            dy0 = np.array([beta[1] * ones, beta[2] * ones])
+            dy1 = np.array([beta[4] * ones, beta[5] * ones])
+            return np.stack((dy0, dy1))
+
+        # do measurements with errors in independent and dependent variables
+        x0_true = np.linspace(1, 10, nr_measurements)
+        x1_true = np.linspace(1, 10, nr_measurements)
+        x_true = np.array([x0_true, x1_true])
+
+        y_true = func(beta_true, x_true)
+
+        x_meas = x_true + x_error
+        y_meas = y_true + y_error
+
+        # estimate model's parameters
+        model_f = Model(func, fjacb=df_dbeta_odr, fjacd=df_dx_odr)
+
+        data = RealData(x_meas, y_meas, sx=std_dev_x, sy=std_dev_y)
+
+        odr_obj = ODR(data, model_f, beta0=0.9 * beta_true)
+        #odr_obj.set_iprint(init=2, iter=0, iter_step=1, final=1)
+        odr_obj.set_job(deriv=2)
+
+        odr_out = odr_obj.run()
+
+        # check results
+        assert_array_almost_equal(odr_out.beta, beta_solution)

--- a/scipy/odr/tests/test_odr.py
+++ b/scipy/odr/tests/test_odr.py
@@ -375,13 +375,15 @@ class TestODR(object):
             [0.03632366, 0.06642266, 0.08373122, 0.03988822, -0.0092536,
             -0.03750469, -0.03198903, 0.01642066, 0.01293648, -0.05627085]])
 
-        beta_solution = np.array([-4.43863482, 444.95461327, -440.51978586, 2.36860998,
-            -265.64757342, 266.81217572])
+        beta_solution = np.array([
+            2.62920235756665876536e+00, -1.26608484996299608838e+02, 1.29703572775403074502e+02,
+            -1.88560985401185465804e+00, 7.83834160771274923718e+01, -7.64124076838087091801e+01])
 
         # model's function and Jacobians
         def func(beta, x):
             y0 = beta[0] + beta[1] * x[0, :] + beta[2] * x[1, :]
             y1 = beta[3] + beta[4] * x[0, :] + beta[5] * x[1, :]
+
             return np.vstack((y0, y1))
 
         def df_dbeta_odr(beta, x):
@@ -391,6 +393,7 @@ class TestODR(object):
 
             dy0 = np.array([ones, x[0, :], x[1, :], zeros, zeros, zeros])
             dy1 = np.array([zeros, zeros, zeros, ones, x[0, :], x[1, :]])
+
             return np.stack((dy0, dy1))
 
         def df_dx_odr(beta, x):
@@ -416,11 +419,12 @@ class TestODR(object):
 
         data = RealData(x_meas, y_meas, sx=std_dev_x, sy=std_dev_y)
 
-        odr_obj = ODR(data, model_f, beta0=0.9 * beta_true)
+        odr_obj = ODR(data, model_f, beta0=0.9 * beta_true, maxit=100)
         #odr_obj.set_iprint(init=2, iter=0, iter_step=1, final=1)
-        odr_obj.set_job(deriv=2)
+        odr_obj.set_job(deriv=3)
 
         odr_out = odr_obj.run()
 
         # check results
+        assert_equal(odr_out.info, 1)
         assert_array_almost_equal(odr_out.beta, beta_solution)

--- a/scipy/odr/tests/test_odr.py
+++ b/scipy/odr/tests/test_odr.py
@@ -357,11 +357,11 @@ class TestODR(object):
         sol2 = odr2.run()
         assert_equal(sol1.beta, sol2.beta)
 
-    # verify bugfix in #11800
+    # verify bugfix for #11800 in #11802
     def test_ticket_11800(self):
         # parameters
         beta_true = np.array([1.0, 2.3, 1.1, -1.0, 1.3, 0.5])
-        nr_measurements = 10;
+        nr_measurements = 10
 
         std_dev_x = 0.01
         x_error = np.array([[0.00063445, 0.00515731, 0.00162719, 0.01022866,


### PR DESCRIPTION
#### Reference issue
Closes #11800.

#### What does this implement/fix?
Fixed scipy.odr to handle multidimensional independent and dependent
variable causing segmentation fault before.