### PR TITLE
MAINT: bump pyflakes to version 2.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
         - NUMPYSPEC="--upgrade numpy"
       before_install:
         - pip install pycodestyle==2.5.0
-        - pip install pyflakes==1.1.0
+        - pip install pyflakes==2.1.1
       script:
         # pyflakes doesn't respect "# noqa" and cannot ignore files, so filter out six.py
         - PYFLAKES_NODOCTEST=1 pyflakes scipy benchmarks/benchmarks | grep -E -v 'unable to detect undefined names|assigned to but never used|imported but unused|redefinition of unused|may be undefined, or defined from star imports' | grep -E -v 'scipy/_lib/six.py' > test.out; cat test.out; test \! -s test.out

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
         - pip install pyflakes==2.1.1
       script:
         # pyflakes doesn't respect "# noqa" and cannot ignore files, so filter out six.py
-        - PYFLAKES_NODOCTEST=1 pyflakes scipy benchmarks/benchmarks | grep -E -v 'unable to detect undefined names|assigned to but never used|imported but unused|redefinition of unused|may be undefined, or defined from star imports' | grep -E -v 'scipy/_lib/six.py' > test.out; cat test.out; test \! -s test.out
+        - PYFLAKES_NODOCTEST=1 pyflakes scipy benchmarks/benchmarks | grep -E -v 'unable to detect undefined names|assigned to but never used|imported but unused|redefinition of unused|may be undefined, or defined from star imports|syntax error in type comment .ignore.import.' | grep -E -v 'scipy/_lib/six.py' > test.out; cat test.out; test \! -s test.out
         - pycodestyle scipy benchmarks/benchmarks
         - |
           grep -rlIP '[^\x00-\x7F]' scipy | grep '\.pyx\?' | sort > unicode.out; grep -rlI '# -\*- coding: \(utf-8\|latin-1\) -\*-' scipy | grep '\.pyx\?' | sort > coding.out; comm -23 unicode.out coding.out > test_code.out; cat test_code.out;  test \! -s test_code.out

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,7 @@ matrix:
         - pip install pycodestyle==2.5.0
         - pip install pyflakes==2.1.1
       script:
-        # pyflakes doesn't respect "# noqa" and cannot ignore files, so filter out six.py
-        - PYFLAKES_NODOCTEST=1 pyflakes scipy benchmarks/benchmarks 2>&1 | grep -E -v 'unable to detect undefined names|assigned to but never used|imported but unused|redefinition of unused|may be undefined, or defined from star imports|syntax error in type comment .ignore.import.' | grep -E -v 'scipy/_lib/six.py' > test.out; cat test.out; test \! -s test.out
+        - PYFLAKES_NODOCTEST=1 pyflakes scipy benchmarks/benchmarks 2>&1 | grep -E -v 'unable to detect undefined names|assigned to but never used|imported but unused|redefinition of unused|may be undefined, or defined from star imports|syntax error in type comment .ignore.import.' > test.out; cat test.out; test \! -s test.out
         - pycodestyle scipy benchmarks/benchmarks
         - |
           grep -rlIP '[^\x00-\x7F]' scipy | grep '\.pyx\?' | sort > unicode.out; grep -rlI '# -\*- coding: \(utf-8\|latin-1\) -\*-' scipy | grep '\.pyx\?' | sort > coding.out; comm -23 unicode.out coding.out > test_code.out; cat test_code.out;  test \! -s test_code.out

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
         - pip install pyflakes==2.1.1
       script:
         # pyflakes doesn't respect "# noqa" and cannot ignore files, so filter out six.py
-        - PYFLAKES_NODOCTEST=1 pyflakes scipy benchmarks/benchmarks | grep -E -v 'unable to detect undefined names|assigned to but never used|imported but unused|redefinition of unused|may be undefined, or defined from star imports|syntax error in type comment .ignore.import.' | grep -E -v 'scipy/_lib/six.py' > test.out; cat test.out; test \! -s test.out
+        - PYFLAKES_NODOCTEST=1 pyflakes scipy benchmarks/benchmarks 2>&1 | grep -E -v 'unable to detect undefined names|assigned to but never used|imported but unused|redefinition of unused|may be undefined, or defined from star imports|syntax error in type comment .ignore.import.' | grep -E -v 'scipy/_lib/six.py' > test.out; cat test.out; test \! -s test.out
         - pycodestyle scipy benchmarks/benchmarks
         - |
           grep -rlIP '[^\x00-\x7F]' scipy | grep '\.pyx\?' | sort > unicode.out; grep -rlI '# -\*- coding: \(utf-8\|latin-1\) -\*-' scipy | grep '\.pyx\?' | sort > coding.out; comm -23 unicode.out coding.out > test_code.out; cat test_code.out;  test \! -s test_code.out

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ matrix:
         - pip install pycodestyle==2.5.0
         - pip install pyflakes==2.1.1
       script:
+        # TODO: remove "ignore[import]" filter below when moving to pyflakes==2.1.2 or above
         - PYFLAKES_NODOCTEST=1 pyflakes scipy benchmarks/benchmarks 2>&1 | grep -E -v 'unable to detect undefined names|assigned to but never used|imported but unused|redefinition of unused|may be undefined, or defined from star imports|syntax error in type comment .ignore.import.' > test.out; cat test.out; test \! -s test.out
         - pycodestyle scipy benchmarks/benchmarks
         - |


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Closes gh-11811.

#### What does this implement/fix?
<!--Please explain your changes.-->

Moves to pyflakes version 2.1.1 on travis-ci.  

#### Additional information
<!--Any additional information you think is important.-->

This fixes the pyflakes failure but does not address fact that pyflakes was failing without signalling a travis build error.  Maybe changing `;` to `&&` in the pyflakes command would do it?
```
... | grep -E -v 'scipy/_lib/six.py' > test.out; cat test.out; test \! -s test.out
```

