### PR TITLE
BUG: scipy.sparse.csr doctest failing with incorrect output value

### DIFF
--- a/scipy/sparse/csr.py
+++ b/scipy/sparse/csr.py
@@ -108,7 +108,7 @@ class csr_matrix(_cs_matrix):
     >>> csr_matrix((data, (row, col)), shape=(3, 3)).toarray()
     array([[9, 0, 0],
            [0, 2, 0],
-           [4, 0, 0]])
+           [0, 4, 0]])
 
     As an example of how to construct a CSR matrix incrementally,
     the following snippet builds a term-document matrix from texts:


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

Recent travis-ci tests are failing across the board because there is a bad doctest example in csr sparse matrix.  The value `4` should be in row 2, column 1, not in row 2, column 0.

#### Additional information
<!--Any additional information you think is important.-->