### PR TITLE
ENH: Raise an error on incorrect bounds format in optimize.fmin_l_bfgs_b

### DIFF
--- a/scipy/optimize/lbfgsb.py
+++ b/scipy/optimize/lbfgsb.py
@@ -169,6 +169,12 @@ def fmin_l_bfgs_b(func, x0, fprime=None, args=(),
       ACM Transactions on Mathematical Software, 38, 1.
 
     """
+    # check bounds
+    if bounds is not None:
+        for lb, ub in bounds:
+            if lb is not None and ub is not None and lb > ub:
+                raise ValueError('bounds should be given as (min, max) pairs.')
+    
     # handle fprime/approx_grad
     if approx_grad:
         fun = func

--- a/scipy/optimize/lbfgsb.py
+++ b/scipy/optimize/lbfgsb.py
@@ -169,12 +169,6 @@ def fmin_l_bfgs_b(func, x0, fprime=None, args=(),
       ACM Transactions on Mathematical Software, 38, 1.
 
     """
-    # check bounds
-    if bounds is not None:
-        for lb, ub in bounds:
-            if lb is not None and ub is not None and lb > ub:
-                raise ValueError('bounds should be given as (min, max) pairs.')
-    
     # handle fprime/approx_grad
     if approx_grad:
         fun = func
@@ -294,6 +288,11 @@ def _minimize_lbfgsb(fun, x0, args=(), jac=None, bounds=None,
     # LBFGSB is sent 'old-style' bounds, 'new-style' bounds are required by
     # approx_derivative and ScalarFunction
     new_bounds = old_bound_to_new(bounds)
+
+    # check bounds
+    if (new_bounds[0] > new_bounds[1]).any():
+        raise ValueError("LBFGSB - one of the lower bounds is greater than an upper bound.")
+
     # initial vector must lie within the bounds. Otherwise ScalarFunction and
     # approx_derivative will cause problems
     x0 = np.clip(x0, new_bounds[0], new_bounds[1])
@@ -422,6 +421,7 @@ class LbfgsInvHessProduct(LinearOperator):
        storage." Mathematics of computation 35.151 (1980): 773-782.
 
     """
+
     def __init__(self, sk, yk):
         """Construct the operator."""
         if sk.shape != yk.shape or sk.ndim != 2:

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -1145,6 +1145,17 @@ class TestLBFGSBBounds(object):
         assert_(d['warnflag'] == 0, d['task'])
         assert_allclose(x, self.solution, atol=1e-6)
 
+    @pytest.mark.parametrize('bounds', [
+        ([(10, 1), (1, 10)]),
+        ([(1, 10), (10, 1)]),
+        ([(10, 1), (10, 1)])
+    ])
+    def test_l_bfgs_b_wrong_bounds(self, bounds):
+        with pytest.raises(ValueError, match='.*bounds.*'):
+            optimize.fmin_l_bfgs_b(self.fun, [0, -1],
+                                         fprime=self.jac,
+                                         bounds=bounds)
+
     def test_l_bfgs_b_funjac(self):
         # L-BFGS-B with fun and jac combined and extra arguments
         x, f, d = optimize.fmin_l_bfgs_b(self.fj, [0, -1], args=(2.0, ),

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -1167,7 +1167,7 @@ class TestLBFGSBBounds(object):
     def test_minimize_l_bfgs_b_incorrect_bounds(self, bounds):
         with pytest.raises(ValueError, match='.*bounds.*'):
             optimize.minimize(self.fun, [0, -1], method='L-BFGS-B',
-                                jac=self.jac, bounds=bounds)
+                              jac=self.jac, bounds=bounds)
 
     def test_minimize_l_bfgs_b_bounds_FD(self):
         # test that initial starting value outside bounds doesn't raise

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -1145,17 +1145,6 @@ class TestLBFGSBBounds(object):
         assert_(d['warnflag'] == 0, d['task'])
         assert_allclose(x, self.solution, atol=1e-6)
 
-    @pytest.mark.parametrize('bounds', [
-        ([(10, 1), (1, 10)]),
-        ([(1, 10), (10, 1)]),
-        ([(10, 1), (10, 1)])
-    ])
-    def test_l_bfgs_b_wrong_bounds(self, bounds):
-        with pytest.raises(ValueError, match='.*bounds.*'):
-            optimize.fmin_l_bfgs_b(self.fun, [0, -1],
-                                         fprime=self.jac,
-                                         bounds=bounds)
-
     def test_l_bfgs_b_funjac(self):
         # L-BFGS-B with fun and jac combined and extra arguments
         x, f, d = optimize.fmin_l_bfgs_b(self.fj, [0, -1], args=(2.0, ),
@@ -1169,6 +1158,16 @@ class TestLBFGSBBounds(object):
                                 jac=self.jac, bounds=self.bounds)
         assert_(res['success'], res['message'])
         assert_allclose(res.x, self.solution, atol=1e-6)
+
+    @pytest.mark.parametrize('bounds', [
+        ([(10, 1), (1, 10)]),
+        ([(1, 10), (10, 1)]),
+        ([(10, 1), (10, 1)])
+    ])
+    def test_minimize_l_bfgs_b_incorrect_bounds(self, bounds):
+        with pytest.raises(ValueError, match='.*bounds.*'):
+            optimize.minimize(self.fun, [0, -1], method='L-BFGS-B',
+                                jac=self.jac, bounds=bounds)
 
     def test_minimize_l_bfgs_b_bounds_FD(self):
         # test that initial starting value outside bounds doesn't raise


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes gh-11659.

#### What does this implement/fix?
<!--Please explain your changes.-->
Added bounds check in fmin_l_bfgs_b to raise an error if one of the bounds is given in incorrect format. Added test to check that this error is raised. 

#### Additional information
<!--Any additional information you think is important.-->
I'd like to hear opinion of SciPy members on some matters:
Should I leave the check in fmin_l_bfgs_b or should I move it to _minimize_lbfgsb?
Is raising an error ok? Or is it better to set d[‘warnflag’] to 2 and to put the message in d[‘task’]?
Also, there is a matter of autocorrecting the bounds. 
There's an option of not correcting the bounds at all. 
Or to use a keyword argument to indicate that user wants to autocorrect them inside fmin_l_bfgs_b(or  _minimize_lbfgsb) and to not raise an error.
Or to introduce a new function that corrects bounds. 
Which one is more in SciPy spirit of doing things?