### PR TITLE
CI: add github actions for macOS

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,0 +1,84 @@
+name: macOS tests
+
+on:
+  - push
+  - pull_request
+
+
+jobs:
+  test_macos:
+
+    runs-on: macos-latest
+    strategy:
+      max-parallel: 3
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+        numpy-version: ['--upgrade numpy']
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Setup openblas
+      run: |
+        # this setup is originally taken from the .travis.yml
+
+        # virtualenv needed for the multibuild steps
+        pip install virtualenv
+        brew install libmpc gcc@6 suitesparse
+        # The openblas binary used here was built using a gfortran older than 7,
+        # so it needs the older abi libgfortran.
+        export FC=gfortran-6
+        export CC=gcc-6
+        export CXX=g++-6
+        mkdir gcc_aliases
+        pushd gcc_aliases
+        ln -s `which gcc-6` gcc
+        ln -s `which g++-6` g++
+        ln -s `which gfortran-6` gfortran
+        # make gcc aliases in current dir
+        export PATH=$PWD/gcc_aliases:$PATH
+        popd
+        touch config.sh
+        git clone --depth=1 https://github.com/matthew-brett/multibuild.git
+
+        # designed for travis, but probably work on github actions
+        source multibuild/common_utils.sh
+        source multibuild/travis_steps.sh
+        before_install
+        export CFLAGS="-arch x86_64"
+        export CXXFLAGS="-arch x86_64"
+        printenv
+
+        # Grab openblas
+        OPENBLAS_PATH=$(python tools/openblas_support.py)
+        # Copy it to the working directory
+        mv $OPENBLAS_PATH ./
+
+        # Modify the openblas dylib so it can be used in its current location
+        # Also make it use the current install location for libgfortran, libquadmath, and libgcc_s.
+        pushd openblas/lib
+        install_name_tool -id $PWD/libopenblasp-r*.dylib libopenblas.dylib
+        install_name_tool -change /usr/local/gfortran/lib/libgfortran.3.dylib `$FC -v 2>&1 | perl -nle 'print $1 if m{--libdir=([^\s]+)}'`/libgfortran.3.dylib libopenblas.dylib
+        install_name_tool -change /usr/local/gfortran/lib/libquadmath.0.dylib `$FC -v 2>&1 | perl -nle 'print $1 if m{--libdir=([^\s]+)}'`/libquadmath.0.dylib libopenblas.dylib
+        install_name_tool -change /usr/local/gfortran/lib/libgcc_s.1.dylib `$FC -v 2>&1 | perl -nle 'print $1 if m{--libdir=([^\s]+)}'`/libgcc_s.1.dylib libopenblas.dylib
+        popd
+        echo "[openblas]" > site.cfg
+        echo "libraries = openblas" >> site.cfg
+        echo "library_dirs = $PWD/openblas/lib" >> site.cfg
+        echo "include_dirs = $PWD/openblas/include" >> site.cfg
+        echo "runtime_library_dirs = $PWD/openblas/lib" >> site.cfg
+        # remove a spurious gcc/gfortran toolchain install
+        rm -rf /usr/local/Cellar/gcc/9.2.0_2
+
+    - name: Install packages
+      run: |
+        pip install ${{ matrix.numpy-version }}
+        pip install setuptools wheel cython gmpy2 pytest pytest-xdist pybind11 pytest-xdist mpmath scikit-umfpack scikit-sparse
+
+    - name: Test SciPy
+      run: |
+        python -u runtests.py


### PR DESCRIPTION
This PR adds some GitHub Actions for CI on macOS. The PR currently does macOS across Python 3.6, 3.7 and 3.8. It could be used as a basis for other targets (Linux + Windows)

The rationale is that it can take some of the load off travisCI (macOS takes a while on there). This would also rationalise the .travis.yml script, which is getting a bit complicated.

The Github Actions work on [my fork of scipy](https://github.com/andyfaff/scipy/actions), but someone with access to the `scipy/scipy` repository settings will need to enable actions (Settings-->Actions) so they start to work on PRs (as well as here).