### PR TITLE
BUG: ndimage: avoid integer overflow in `NI_MinOrMaxFilter`

### DIFF
--- a/scipy/ndimage/src/ni_filters.c
+++ b/scipy/ndimage/src/ni_filters.c
@@ -598,39 +598,41 @@ int NI_MinOrMaxFilter(PyArrayObject* input, PyArrayObject* footprint,
     oo = offsets;
     for(jj = 0; jj < size; jj++) {
         double tmp = 0.0;
+        npy_longlong itmp = 0;
+        npy_ulonglong utmp = 0;
         switch (PyArray_TYPE(input)) {
             CASE_MIN_OR_MAX_POINT(NPY_BOOL, npy_bool,
-                                  pi, oo, filter_size, cvalue, minimum, tmp,
+                                  pi, oo, filter_size, cvalue, minimum, utmp,
                                   border_flag_value, ss);
             CASE_MIN_OR_MAX_POINT(NPY_UBYTE, npy_ubyte,
-                                  pi, oo, filter_size, cvalue, minimum, tmp,
+                                  pi, oo, filter_size, cvalue, minimum, utmp,
                                   border_flag_value, ss);
             CASE_MIN_OR_MAX_POINT(NPY_USHORT, npy_ushort,
-                                  pi, oo, filter_size, cvalue, minimum, tmp,
+                                  pi, oo, filter_size, cvalue, minimum, utmp,
                                   border_flag_value, ss);
             CASE_MIN_OR_MAX_POINT(NPY_UINT, npy_uint,
-                                  pi, oo, filter_size, cvalue, minimum, tmp,
+                                  pi, oo, filter_size, cvalue, minimum, utmp,
                                   border_flag_value, ss);
             CASE_MIN_OR_MAX_POINT(NPY_ULONG, npy_ulong,
-                                  pi, oo, filter_size, cvalue, minimum, tmp,
+                                  pi, oo, filter_size, cvalue, minimum, utmp,
                                   border_flag_value, ss);
             CASE_MIN_OR_MAX_POINT(NPY_ULONGLONG, npy_ulonglong,
-                                  pi, oo, filter_size, cvalue, minimum, tmp,
+                                  pi, oo, filter_size, cvalue, minimum, utmp,
                                   border_flag_value, ss);
             CASE_MIN_OR_MAX_POINT(NPY_BYTE, npy_byte,
-                                  pi, oo, filter_size, cvalue, minimum, tmp,
+                                  pi, oo, filter_size, cvalue, minimum, itmp,
                                   border_flag_value, ss);
             CASE_MIN_OR_MAX_POINT(NPY_SHORT, npy_short,
-                                  pi, oo, filter_size, cvalue, minimum, tmp,
+                                  pi, oo, filter_size, cvalue, minimum, itmp,
                                   border_flag_value, ss);
             CASE_MIN_OR_MAX_POINT(NPY_INT, npy_int,
-                                  pi, oo, filter_size, cvalue, minimum, tmp,
+                                  pi, oo, filter_size, cvalue, minimum, itmp,
                                   border_flag_value, ss);
             CASE_MIN_OR_MAX_POINT(NPY_LONG, npy_long,
-                                  pi, oo, filter_size, cvalue, minimum, tmp,
+                                  pi, oo, filter_size, cvalue, minimum, itmp,
                                   border_flag_value, ss);
             CASE_MIN_OR_MAX_POINT(NPY_LONGLONG, npy_longlong,
-                                  pi, oo, filter_size, cvalue, minimum, tmp,
+                                  pi, oo, filter_size, cvalue, minimum, itmp,
                                   border_flag_value, ss);
             CASE_MIN_OR_MAX_POINT(NPY_FLOAT, npy_float,
                                   pi, oo, filter_size, cvalue, minimum, tmp,
@@ -643,17 +645,17 @@ int NI_MinOrMaxFilter(PyArrayObject* input, PyArrayObject* footprint,
                 goto exit;
         }
         switch (PyArray_TYPE(output)) {
-            CASE_FILTER_OUT_SAFE(NPY_BOOL, npy_bool, po, tmp);
-            CASE_FILTER_OUT_SAFE(NPY_UBYTE, npy_ubyte, po, tmp);
-            CASE_FILTER_OUT_SAFE(NPY_USHORT, npy_ushort, po, tmp);
-            CASE_FILTER_OUT_SAFE(NPY_UINT, npy_uint, po, tmp);
-            CASE_FILTER_OUT_SAFE(NPY_ULONG, npy_ulong, po, tmp);
-            CASE_FILTER_OUT_SAFE(NPY_ULONGLONG, npy_ulonglong, po, tmp);
-            CASE_FILTER_OUT(NPY_BYTE, npy_byte, po, tmp);
-            CASE_FILTER_OUT(NPY_SHORT, npy_short, po, tmp);
-            CASE_FILTER_OUT(NPY_INT, npy_int, po, tmp);
-            CASE_FILTER_OUT(NPY_LONG, npy_long, po, tmp);
-            CASE_FILTER_OUT(NPY_LONGLONG, npy_longlong, po, tmp);
+            CASE_FILTER_OUT_SAFE(NPY_BOOL, npy_bool, po, utmp);
+            CASE_FILTER_OUT_SAFE(NPY_UBYTE, npy_ubyte, po, utmp);
+            CASE_FILTER_OUT_SAFE(NPY_USHORT, npy_ushort, po, utmp);
+            CASE_FILTER_OUT_SAFE(NPY_UINT, npy_uint, po, utmp);
+            CASE_FILTER_OUT_SAFE(NPY_ULONG, npy_ulong, po, utmp);
+            CASE_FILTER_OUT_SAFE(NPY_ULONGLONG, npy_ulonglong, po, utmp);
+            CASE_FILTER_OUT(NPY_BYTE, npy_byte, po, itmp);
+            CASE_FILTER_OUT(NPY_SHORT, npy_short, po, itmp);
+            CASE_FILTER_OUT(NPY_INT, npy_int, po, itmp);
+            CASE_FILTER_OUT(NPY_LONG, npy_long, po, itmp);
+            CASE_FILTER_OUT(NPY_LONGLONG, npy_longlong, po, itmp);
             CASE_FILTER_OUT(NPY_FLOAT, npy_float, po, tmp);
             CASE_FILTER_OUT(NPY_DOUBLE, npy_double, po, tmp);
             default:

--- a/scipy/ndimage/src/ni_filters.c
+++ b/scipy/ndimage/src/ni_filters.c
@@ -598,7 +598,7 @@ int NI_MinOrMaxFilter(PyArrayObject* input, PyArrayObject* footprint,
     oo = offsets;
     for(jj = 0; jj < size; jj++) {
         double tmp = 0.0;
-        npy_longlong itmp = 0;
+        int64_t itmp = 0;
         switch (PyArray_TYPE(input)) {
             CASE_MIN_OR_MAX_POINT(NPY_BOOL, npy_bool,
                                   pi, oo, filter_size, cvalue, minimum, itmp,

--- a/scipy/ndimage/src/ni_filters.c
+++ b/scipy/ndimage/src/ni_filters.c
@@ -599,25 +599,24 @@ int NI_MinOrMaxFilter(PyArrayObject* input, PyArrayObject* footprint,
     for(jj = 0; jj < size; jj++) {
         double tmp = 0.0;
         npy_longlong itmp = 0;
-        npy_ulonglong utmp = 0;
         switch (PyArray_TYPE(input)) {
             CASE_MIN_OR_MAX_POINT(NPY_BOOL, npy_bool,
-                                  pi, oo, filter_size, cvalue, minimum, utmp,
+                                  pi, oo, filter_size, cvalue, minimum, itmp,
                                   border_flag_value, ss);
             CASE_MIN_OR_MAX_POINT(NPY_UBYTE, npy_ubyte,
-                                  pi, oo, filter_size, cvalue, minimum, utmp,
+                                  pi, oo, filter_size, cvalue, minimum, itmp,
                                   border_flag_value, ss);
             CASE_MIN_OR_MAX_POINT(NPY_USHORT, npy_ushort,
-                                  pi, oo, filter_size, cvalue, minimum, utmp,
+                                  pi, oo, filter_size, cvalue, minimum, itmp,
                                   border_flag_value, ss);
             CASE_MIN_OR_MAX_POINT(NPY_UINT, npy_uint,
-                                  pi, oo, filter_size, cvalue, minimum, utmp,
+                                  pi, oo, filter_size, cvalue, minimum, itmp,
                                   border_flag_value, ss);
             CASE_MIN_OR_MAX_POINT(NPY_ULONG, npy_ulong,
-                                  pi, oo, filter_size, cvalue, minimum, utmp,
+                                  pi, oo, filter_size, cvalue, minimum, tmp,
                                   border_flag_value, ss);
             CASE_MIN_OR_MAX_POINT(NPY_ULONGLONG, npy_ulonglong,
-                                  pi, oo, filter_size, cvalue, minimum, utmp,
+                                  pi, oo, filter_size, cvalue, minimum, tmp,
                                   border_flag_value, ss);
             CASE_MIN_OR_MAX_POINT(NPY_BYTE, npy_byte,
                                   pi, oo, filter_size, cvalue, minimum, itmp,
@@ -645,12 +644,12 @@ int NI_MinOrMaxFilter(PyArrayObject* input, PyArrayObject* footprint,
                 goto exit;
         }
         switch (PyArray_TYPE(output)) {
-            CASE_FILTER_OUT_SAFE(NPY_BOOL, npy_bool, po, utmp);
-            CASE_FILTER_OUT_SAFE(NPY_UBYTE, npy_ubyte, po, utmp);
-            CASE_FILTER_OUT_SAFE(NPY_USHORT, npy_ushort, po, utmp);
-            CASE_FILTER_OUT_SAFE(NPY_UINT, npy_uint, po, utmp);
-            CASE_FILTER_OUT_SAFE(NPY_ULONG, npy_ulong, po, utmp);
-            CASE_FILTER_OUT_SAFE(NPY_ULONGLONG, npy_ulonglong, po, utmp);
+            CASE_FILTER_OUT(NPY_BOOL, npy_bool, po, itmp);
+            CASE_FILTER_OUT(NPY_UBYTE, npy_ubyte, po, itmp);
+            CASE_FILTER_OUT(NPY_USHORT, npy_ushort, po, itmp);
+            CASE_FILTER_OUT(NPY_UINT, npy_uint, po, itmp);
+            CASE_FILTER_OUT_SAFE(NPY_ULONG, npy_ulong, po, tmp);
+            CASE_FILTER_OUT_SAFE(NPY_ULONGLONG, npy_ulonglong, po, tmp);
             CASE_FILTER_OUT(NPY_BYTE, npy_byte, po, itmp);
             CASE_FILTER_OUT(NPY_SHORT, npy_short, po, itmp);
             CASE_FILTER_OUT(NPY_INT, npy_int, po, itmp);

--- a/scipy/ndimage/tests/test_morphology.py
+++ b/scipy/ndimage/tests/test_morphology.py
@@ -2055,6 +2055,30 @@ class TestNdimageMorphology:
         output = ndimage.white_tophat(array, structure=structure)
         assert_array_equal(expected, output)
 
+    def test_white_tophat03_uint(self):
+        # Backwards compatibility test case
+        # The expected array was determined in SciPy 1.4.1.
+        for dtype in [numpy.uint8, numpy.uint16, numpy.uint32, numpy.uint64]:
+            array = numpy.array([[1, 0, 0, 0, 0, 0, 0],
+                                 [0, 1, 1, 1, 1, 1, 0],
+                                 [0, 1, 1, 1, 1, 1, 0],
+                                 [0, 1, 1, 1, 1, 1, 0],
+                                 [0, 1, 1, 1, 0, 1, 0],
+                                 [0, 1, 1, 1, 1, 1, 0],
+                                 [0, 0, 0, 0, 0, 0, 1]], dtype=dtype)
+            structure = numpy.ones((3, 3), dtype=dtype)
+            m = numpy.iinfo(dtype).max
+            expected = numpy.array([[0, m, m, 0, 0, 0, 0],
+                                    [m, 0, 0, 1, 1, 1, 0],
+                                    [m, 0, 0, 1, 1, 1, 0],
+                                    [0, 1, 1, 0, 0, 0, m],
+                                    [0, 1, 1, 0, m, 0, m],
+                                    [0, 1, 1, 0, 0, 0, m],
+                                    [0, 0, 0, m, m, m, 1]], dtype=dtype)
+
+            output = ndimage.white_tophat(array, structure=structure)
+            assert_array_equal(expected, output)
+
     def test_white_tophat04(self):
         array = numpy.eye(5, dtype=numpy.bool_)
         structure = numpy.ones((3, 3), dtype=numpy.bool_)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
This is a partial fix for #11816. 

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR avoids potential integer overflow in `NI_MinOrMaxFilter`, which fixes the reported issue in `grey_erosion`, but only when the footprint is non-separable. Thus, this fixes the following example which has the same overflow as seen in #11816 on current master:

```Python
import numpy as np                                                        
a = np.ones((3, 3), dtype=np.int64)                                       
a[1, 1] = 0                                                               
a *= np.iinfo(a.dtype).max                                                
from scipy import ndimage                                                 
out = ndimage.grey_erosion(a, footprint=ndimage.generate_binary_structure(2, 1))
print(out)
```
gives on master
```
[[-9223372036854775808                    0 -9223372036854775808]
 [                   0                    0                    0]
 [-9223372036854775808                    0 -9223372036854775808]]
```

and with this PR:
```
[[9223372036854775807                    0 9223372036854775807]
 [                   0                    0                    0]
 [9223372036854775807                    0 9223372036854775807]]
```

The solution used here is to only use the existing double `tmp` for float types and to instead use a 64-bit integer (`itmp`) or 64-bit unsigned integer (`utmp`) for the various integer types.


#### Additional information
<!--Any additional information you think is important.-->

If a separable footprint such as `ndimage.generate_binary_structure(2, 2)` were used, the issue will still occur because a different function,  `NI_MinOrMaxFilter1D`, is used in that case. Unfortunately, a similar fix for `NI_MinOrMaxFilter1D` on the C side looks like it would be much more involved. `NI_MinOrMaxFilter1D` uses various helper functions for line buffers that assume double-precision data. If any C gurus have an idea of how to fix this without large amounts of code duplication, please let me know.

It would probably be fairly easy to always just call `NI_MinOrMaxFilter` instead of `NI_MinOrMaxFilter1D` for integer arrays with large values, but this would likely have a substantial performance impact, so I have not done it at the moment. That could be done purely on the Python side with minimal code, though.
