### PR TITLE
TST: Always use fork for multiprocessing in fft tests

### DIFF
--- a/scipy/fft/tests/test_multithreading.py
+++ b/scipy/fft/tests/test_multithreading.py
@@ -31,7 +31,6 @@ def _mt_fft(x):
 
 def test_mixed_threads_processes(x):
     # Test that the fft threadpool is safe to use before & after fork
-    expect = fft.fft(x, workers=2)
 
     # Must use fork to work around python 3.8 bug
     # https://bugs.python.org/issue38501
@@ -39,6 +38,8 @@ def test_mixed_threads_processes(x):
         mp = multiprocessing.get_context('fork')
     except ValueError:
         pytest.skip('fork method not available')
+
+    expect = fft.fft(x, workers=2)
 
     with mp.Pool(2) as p:
         res = p.map(_mt_fft, [x for _ in range(4)])

--- a/scipy/fft/tests/test_multithreading.py
+++ b/scipy/fft/tests/test_multithreading.py
@@ -29,14 +29,18 @@ def _mt_fft(x):
     return fft.fft(x, workers=2)
 
 
-@pytest.mark.skipif(multiprocessing.get_start_method() != 'fork',
-                    reason=('multiprocessing with spawn method is not'
-                            ' compatible with pytest.'))
 def test_mixed_threads_processes(x):
     # Test that the fft threadpool is safe to use before & after fork
     expect = fft.fft(x, workers=2)
 
-    with multiprocessing.Pool(2) as p:
+    # Must use fork to work around python 3.8 bug
+    # https://bugs.python.org/issue38501
+    try:
+        mp = multiprocessing.get_context('fork')
+    except ValueError:
+        pytest.skip('fork method not available')
+
+    with mp.Pool(2) as p:
         res = p.map(_mt_fft, [x for _ in range(4)])
 
     for r in res:

--- a/scipy/fft/tests/test_numpy.py
+++ b/scipy/fft/tests/test_numpy.py
@@ -304,7 +304,12 @@ class TestFFTThreadSafe(object):
 @pytest.mark.parametrize("func", [fft.fft, fft.ifft, fft.rfft, fft.irfft])
 def test_multiprocess(func):
     # Test that fft still works after fork (gh-10422)
-    with multiprocessing.Pool(2) as p:
+    try:
+        mp = multiprocessing.get_context('fork')
+    except ValueError:
+        pytest.skip('fork method not available')
+
+    with mp.Pool(2) as p:
         res = p.map(func, [np.ones(100) for _ in range(4)])
 
     expect = func(np.ones(100))


### PR DESCRIPTION
#### Reference issue
Closes gh-11827

#### What does this implement/fix?
FFT tests now always use fork to create processes and skips if not available. The tests were mainly for the fork handler anyway so this is okay.

#### Additional information
I guess at some point the multiprocessing issue was recongnised for `test_multithreading.py` but not `test_numpy.py`.