### PR TITLE
DOC: add Examples and Returns in scipy.misc.central_diff_weights docstring.

### DIFF
--- a/scipy/misc/common.py
+++ b/scipy/misc/common.py
@@ -52,6 +52,10 @@ def central_diff_weights(Np, ndiv=1):
     This value is close to the analytical solution:
     f'(x) = 4x, so f'(3) = 12
 
+    References
+    ----------
+    .. [1] https://en.wikipedia.org/wiki/Finite_difference
+
     """
     if Np < ndiv + 1:
         raise ValueError("Number of points must be at least the derivative order + 1.")

--- a/scipy/misc/common.py
+++ b/scipy/misc/common.py
@@ -40,13 +40,13 @@ def central_diff_weights(Np, ndiv=1):
 
     >>> from scipy.misc import central_diff_weights
     >>> def f(x):
-    ...     return 2*x**2+3
+    ...     return 2 * x**2 + 3
     >>> x = 3.0 # derivative point
     >>> h = 0.1 # differential step
     >>> Np = 3 # point number for central derivative
     >>> weights = central_diff_weights(Np) # weights for first derivative
-    >>> vals = [f(x+(i-Np/2)*h) for i in range(Np)]
-    >>> sum(w*v for (w, v) in zip(weights, vals))/h
+    >>> vals = [f(x + (i - Np/2) * h) for i in range(Np)]
+    >>> sum(w * v for (w, v) in zip(weights, vals))/h
     11.79999999999998
 
     This value is close to the analytical solution:

--- a/scipy/misc/common.py
+++ b/scipy/misc/common.py
@@ -25,9 +25,32 @@ def central_diff_weights(Np, ndiv=1):
     ndiv : int, optional
         Number of divisions. Default is 1.
 
+    Returns
+    -------
+    w : ndarray
+        Weights for an Np-point central derivative. Its size is `Np`.
+
     Notes
     -----
     Can be inaccurate for a large number of points.
+
+    Examples
+    --------
+    We can calculate a derivative value of a function.
+
+    >>> from scipy.misc import central_diff_weights
+    >>> def f(x):
+    ...     return 2*x**2+3
+    >>> x = 3.0 # derivative point
+    >>> h = 0.1 # differential step
+    >>> Np = 3 # point number for central derivative
+    >>> weights = central_diff_weights(Np) # weights for first derivative
+    >>> vals = [f(x+(i-Np/2)*h) for i in range(Np)]
+    >>> sum(w*v for (w, v) in zip(weights, vals))/h
+    11.79999999999998
+
+    This value is close to the analytical solution:
+    f'(x) = 4x, so f'(3) = 12
 
     """
     if Np < ndiv + 1:


### PR DESCRIPTION
#### Reference issue
fix a part of #7168

#### What does this implement/fix?
DOC: add Examples and Returns in scipy.misc.central_diff_weights.