### PR TITLE
BUG: Fix compiler_name when there are paths used in flags

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -264,7 +264,7 @@ def get_build_ext_override():
                     cc = sysconfig.get_config_var("CC")
                     if not cc:
                         cc = ""
-                    compiler_name = os.path.basename(cc)
+                    compiler_name = os.path.basename(cc.split(" ")[0])
                     is_gcc = "gcc" in compiler_name or "g++" in compiler_name
             return is_gcc and sysconfig.get_config_var('GNULD') == 'yes'
 


### PR DESCRIPTION
On conda, the compiler CC is,

    gcc -pthread -B /home/isuru/miniforge3/compiler_compat -Wl,--sysroot=/

Basename of above is empty. Fix this by splitting using a space.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->