### PR TITLE
Bug: ttest_rel now always returns Ttest_relResult

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5291,7 +5291,7 @@ def ttest_rel(a, b, axis=0, nan_policy='propagate'):
         raise ValueError('unequal length arrays')
 
     if a.size == 0 or b.size == 0:
-        return np.nan, np.nan
+        return Ttest_relResult(np.nan, np.nan)
 
     n = a.shape[axis]
     df = n - 1


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
None

#### What does this implement/fix?
*Old behaviour*
```
In [1]: sp.stats.ttest_rel([], [])
Out[1]: (nan, nan)

In [2]: sp.stats.ttest_rel([2, 3, 3, 4], [12, 12, 14, 14])
Out[2]: Ttest_relResult(statistic=-24.49489742783178, pvalue=0.0001491572012849361)
```

*New Behaviour*
Old behaviour
In [16]: sp.stats.ttest_rel([], [])
Out[16]: Ttest_relResult(statistic=-nan, pvalue=nan)

In [2]: sp.stats.ttest_rel([2, 3, 3, 4], [12, 12, 14, 14])
Out[2]: Ttest_relResult(statistic=-24.49489742783178, pvalue=0.0001491572012849361)
**

<!--Please explain your changes.-->
sp.stats.ttest_rel returns a named tuple in all cases except when the input is an empty list, ttest_ind returns a named tuple in all cases, I changed ttest_rel, such that is also alway wraps it's output in a named tuple

#### Additional information
<!--Any additional information you think is important.-->
I had code that crashed in production because I assumed that functuion would always return a named tuple. I think most people who play with the function will assume the same