### PR TITLE
MAINT: re-introduce multiprocessing tests on Python3.8

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -29,7 +29,6 @@ Generate C code coverage listing under build/lcov/:
 # This is a generic test runner script for projects using NumPy's test
 # framework. Change the following values to adapt to your project:
 #
-import multiprocessing
 
 PROJECT_MODULE = "scipy"
 PROJECT_ROOT_FILES = ['scipy', 'LICENSE.txt', 'setup.py']
@@ -50,6 +49,11 @@ else:
 
 import sys
 import os
+# the following multiprocessing import is necessary to prevent tests that use
+# multiprocessing from hanging on >= Python3.8 (macOS) using pytest. Just the
+# import is enough...
+import multiprocessing
+
 
 # In case we are run from the source directory, we don't want to import the
 # project from there:
@@ -523,5 +527,4 @@ def run_mypy(args):
 
 
 if __name__ == "__main__":
-    multiprocessing.freeze_support()
     main(argv=sys.argv[1:])

--- a/runtests.py
+++ b/runtests.py
@@ -29,6 +29,7 @@ Generate C code coverage listing under build/lcov/:
 # This is a generic test runner script for projects using NumPy's test
 # framework. Change the following values to adapt to your project:
 #
+import multiprocessing
 
 PROJECT_MODULE = "scipy"
 PROJECT_ROOT_FILES = ['scipy', 'LICENSE.txt', 'setup.py']
@@ -522,4 +523,5 @@ def run_mypy(args):
 
 
 if __name__ == "__main__":
+    multiprocessing.freeze_support()
     main(argv=sys.argv[1:])

--- a/scipy/_lib/tests/test__util.py
+++ b/scipy/_lib/tests/test__util.py
@@ -1,6 +1,7 @@
 from multiprocessing import Pool, get_start_method
 from multiprocessing.pool import Pool as PWL
 import os
+import math
 
 import numpy as np
 from numpy.testing import assert_equal, assert_
@@ -97,9 +98,11 @@ def test_mapwrapper_serial():
         p = MapWrapper(0)
 
 
-@pytest.mark.skipif(get_start_method() != 'fork',
-                    reason=('multiprocessing with spawn method is not'
-                            ' compatible with pytest.'))
+def test_pool():
+    with Pool(2) as p:
+        p.map(math.sin, [1,2,3, 4])
+
+
 def test_mapwrapper_parallel():
     in_arg = np.arange(10.)
     out_arg = np.sin(in_arg)

--- a/scipy/fft/tests/test_multithreading.py
+++ b/scipy/fft/tests/test_multithreading.py
@@ -32,16 +32,9 @@ def _mt_fft(x):
 def test_mixed_threads_processes(x):
     # Test that the fft threadpool is safe to use before & after fork
 
-    # Must use fork to work around python 3.8 bug
-    # https://bugs.python.org/issue38501
-    try:
-        mp = multiprocessing.get_context('fork')
-    except ValueError:
-        pytest.skip('fork method not available')
-
     expect = fft.fft(x, workers=2)
 
-    with mp.Pool(2) as p:
+    with multiprocessing.Pool(2) as p:
         res = p.map(_mt_fft, [x for _ in range(4)])
 
     for r in res:

--- a/scipy/fft/tests/test_numpy.py
+++ b/scipy/fft/tests/test_numpy.py
@@ -304,10 +304,6 @@ class TestFFTThreadSafe(object):
 @pytest.mark.parametrize("func", [fft.fft, fft.ifft, fft.rfft, fft.irfft])
 def test_multiprocess(func):
     # Test that fft still works after fork (gh-10422)
-    try:
-        mp = multiprocessing.get_context('fork')
-    except ValueError:
-        pytest.skip('fork method not available')
 
     with mp.Pool(2) as p:
         res = p.map(func, [np.ones(100) for _ in range(4)])

--- a/scipy/fft/tests/test_numpy.py
+++ b/scipy/fft/tests/test_numpy.py
@@ -305,7 +305,7 @@ class TestFFTThreadSafe(object):
 def test_multiprocess(func):
     # Test that fft still works after fork (gh-10422)
 
-    with mp.Pool(2) as p:
+    with multiprocessing.Pool(2) as p:
         res = p.map(func, [np.ones(100) for _ in range(4)])
 
     expect = func(np.ones(100))

--- a/scipy/integrate/tests/test__quad_vec.py
+++ b/scipy/integrate/tests/test__quad_vec.py
@@ -1,3 +1,4 @@
+import sys
 import pytest
 
 import numpy as np

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -1,7 +1,6 @@
 """
 Unit tests for the differential global minimization algorithm.
 """
-import gc
 import multiprocessing
 import sys
 import platform
@@ -21,11 +20,6 @@ from numpy.testing import (assert_equal, assert_allclose,
                            assert_string_equal, assert_, suppress_warnings)
 from pytest import raises as assert_raises, warns
 import pytest
-
-
-knownfail_on_py38 = pytest.mark.xfail(
-    sys.version_info >= (3, 8), run=False,
-    reason='Python 3.8 hangs when cleaning up MapWrapper')
 
 
 class TestDifferentialEvolutionSolver(object):
@@ -561,7 +555,6 @@ class TestDifferentialEvolutionSolver(object):
         assert_(solver._mapwrapper._mapfunc is map)
         solver.solve()
 
-    @knownfail_on_py38
     def test_immediate_updating(self):
         # check setting of immediate updating, with default workers
         bounds = [(0., 2.), (0., 2.)]
@@ -571,12 +564,10 @@ class TestDifferentialEvolutionSolver(object):
         # should raise a UserWarning because the updating='immediate'
         # is being overridden by the workers keyword
         with warns(UserWarning):
-            solver = DifferentialEvolutionSolver(rosen, bounds, workers=2)
+            with DifferentialEvolutionSolver(rosen, bounds, workers=2) as solver:
+                pass
         assert_(solver._updating == 'deferred')
-        del solver
-        gc.collect()  # ensure MapWrapper cleans up properly
 
-    @knownfail_on_py38
     def test_parallel(self):
         # smoke test for parallelization with deferred updating
         bounds = [(0., 2.), (0., 2.)]
@@ -591,8 +582,6 @@ class TestDifferentialEvolutionSolver(object):
             assert_(solver._mapwrapper.pool is not None)
             assert_(solver._updating == 'deferred')
             solver.solve()
-        del solver
-        gc.collect()  # ensure MapWrapper cleans up properly
 
     def test_converged(self):
         solver = DifferentialEvolutionSolver(rosen, [(0, 2), (0, 2)])

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -1565,9 +1565,6 @@ class TestBrute:
 
         optimize.brute(f, [(-1, 1)], Ns=3, finish=None)
 
-    @pytest.mark.skipif(multiprocessing.get_start_method() != 'fork',
-                        reason=('multiprocessing with spawn method is not'
-                                ' compatible with pytest.'))
     def test_workers(self):
         # check that parallel evaluation works
         resbrute = optimize.brute(brute_func, self.rranges, args=self.params,

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -5244,9 +5244,6 @@ class TestMGCStat(object):
         assert_approx_equal(stat, 1.0, significant=1)
         assert_approx_equal(pvalue, 0.001, significant=1)
 
-    @pytest.mark.skipif(multiprocessing.get_start_method() != 'fork',
-                        reason=('multiprocessing with spawn method is not'
-                                ' compatible with pytest.'))
     def test_workers(self):
         np.random.seed(12345678)
 


### PR DESCRIPTION
closes #11835