### PR TITLE
BUG: sparse.linalg: fix overflow in expm intermediate computation

### DIFF
--- a/scipy/sparse/linalg/matfuncs.py
+++ b/scipy/sparse/linalg/matfuncs.py
@@ -714,9 +714,9 @@ def _solve_P_Q(U, V, structure=None):
         raise ValueError('unsupported matrix structure: ' + str(structure))
 
 
-def _sinch(x):
+def _exp_sinch(a, x):
     """
-    Stably evaluate sinch.
+    Stably evaluate exp(a)*sinh(x)/x
 
     Notes
     -----
@@ -738,11 +738,11 @@ def _sinch(x):
     # How small is small? I am using the point where the relative error
     # of the approximation is less than 1e-14.
     # If x is large then directly evaluate sinh(x) / x.
-    x2 = x*x
     if abs(x) < 0.0135:
-        return 1 + (x2/6.)*(1 + (x2/20.)*(1 + (x2/42.)))
+        x2 = x*x
+        return np.exp(a) * (1 + (x2/6.)*(1 + (x2/20.)*(1 + (x2/42.))))
     else:
-        return np.sinh(x) / x
+        return (np.exp(a + x) - np.exp(a - x)) / (2*x)
 
 
 def _eq_10_42(lam_1, lam_2, t_12):
@@ -766,7 +766,7 @@ def _eq_10_42(lam_1, lam_2, t_12):
     # will apparently work around the cancellation.
     a = 0.5 * (lam_1 + lam_2)
     b = 0.5 * (lam_1 - lam_2)
-    return t_12 * np.exp(a) * _sinch(b)
+    return t_12 * _exp_sinch(a, b)
 
 
 def _fragment_2_1(X, T, s):

--- a/scipy/sparse/linalg/tests/test_matfuncs.py
+++ b/scipy/sparse/linalg/tests/test_matfuncs.py
@@ -532,6 +532,24 @@ class TestExpM(object):
             B = expm(np.matrix(A))
         assert_allclose(B, B0)
 
+    def test_exp_sinch_overflow(self):
+        # Check overflow in intermediate steps is fixed (gh-11839)
+        L = np.array([[1.0, -0.5, -0.5, 0.0, 0.0, 0.0, 0.0],
+                      [0.0, 1.0, 0.0, -0.5, -0.5, 0.0, 0.0],
+                      [0.0, 0.0, 1.0, 0.0, 0.0, -0.5, -0.5],
+                      [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                      [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                      [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                      [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]])
+
+        E0 = expm(-L)
+        E1 = expm(-2**11 * L)
+        E2 = E0
+        for j in range(11):
+            E2 = E2 @ E2
+
+        assert_allclose(E1, E2)
+
 
 class TestOperators(object):
 


### PR DESCRIPTION
#### Reference issue
Closes: gh-11839

#### What does this implement/fix?
Avoid unnecessary overflow in exp(a)*sinch(b) computation of expm.