### PR TITLE
BLD: fix build with gfortran 10

### DIFF
--- a/scipy/_build_utils/_fortran.py
+++ b/scipy/_build_utils/_fortran.py
@@ -4,7 +4,8 @@ import glob
 from distutils.dep_util import newer
 
 
-__all__ = ['needs_g77_abi_wrapper', 'get_g77_abi_wrappers']
+__all__ = ['needs_g77_abi_wrapper', 'get_g77_abi_wrappers',
+           'gfortran_legacy_flag_hook']
 
 
 def uses_mkl(info):
@@ -43,3 +44,27 @@ def get_g77_abi_wrappers(info):
             os.path.join(path, 'src', 'wrap_dummy_g77_abi.f'),
         ]
     return wrapper_sources
+
+
+def gfortran_legacy_flag_hook(cmd, ext):
+    """
+    Pre-build hook to add dd gfortran legacy flag -fallow-argument-mismatch
+    """
+    from .compiler_helper import try_add_flag
+    from distutils.version import LooseVersion
+
+    if isinstance(ext, dict):
+        # build_clib
+        compilers = ((cmd._f_compiler, ext.setdefault('extra_f77_compile_args', [])),
+                      (cmd._f_compiler, ext.setdefault('extra_f90_compile_args', [])))
+    else:
+        # build_ext
+        compilers = ((cmd._f77_compiler, ext.extra_f77_compile_args),
+                     (cmd._f90_compiler, ext.extra_f90_compile_args))
+
+    for compiler, args in compilers:
+        if compiler is None:
+            continue
+
+        if compiler.compiler_type == "gnu95" and compiler.version >= LooseVersion("10"):
+            try_add_flag(args, compiler, "-fallow-argument-mismatch")

--- a/scipy/_build_utils/compiler_helper.py
+++ b/scipy/_build_utils/compiler_helper.py
@@ -7,8 +7,14 @@ import os
 def try_compile(compiler, code=None, flags=[], ext=None):
     """Returns True if the compiler is able to compile the given code"""
     from distutils.errors import CompileError
+    from numpy.distutils.fcompiler import FCompiler
 
-    code = code or 'int main (int argc, char **argv) { return 0; }'
+    if code is None:
+        if isinstance(compiler, FCompiler):
+            code = "      program main\n      return\n      end"
+        else:
+            code = 'int main (int argc, char **argv) { return 0; }'
+
     ext = ext or compiler.src_extensions[0]
 
     with tempfile.TemporaryDirectory() as temp_dir:

--- a/scipy/linalg/setup.py
+++ b/scipy/linalg/setup.py
@@ -5,7 +5,7 @@ def configuration(parent_package='', top_path=None):
     from distutils.sysconfig import get_python_inc
     from scipy._build_utils.system_info import get_info, numpy_info
     from numpy.distutils.misc_util import Configuration, get_numpy_include_dirs
-    from scipy._build_utils import get_g77_abi_wrappers
+    from scipy._build_utils import get_g77_abi_wrappers, gfortran_legacy_flag_hook
 
     config = Configuration('linalg', parent_package, top_path)
 
@@ -68,11 +68,12 @@ def configuration(parent_package='', top_path=None):
                          )
 
     # _interpolative:
-    config.add_extension('_interpolative',
-                         sources=[join('src', 'id_dist', 'src', '*.f'),
-                                  "interpolative.pyf"],
-                         extra_info=lapack_opt
-                         )
+    ext = config.add_extension('_interpolative',
+                               sources=[join('src', 'id_dist', 'src', '*.f'),
+                                        "interpolative.pyf"],
+                               extra_info=lapack_opt
+                               )
+    ext._pre_build_hook = gfortran_legacy_flag_hook
 
     # _solve_toeplitz:
     config.add_extension('_solve_toeplitz',

--- a/scipy/optimize/setup.py
+++ b/scipy/optimize/setup.py
@@ -6,6 +6,8 @@ from scipy._build_utils import numpy_nodepr_api
 def configuration(parent_package='',top_path=None):
     from numpy.distutils.misc_util import Configuration
     from scipy._build_utils.system_info import get_info
+    from scipy._build_utils import gfortran_legacy_flag_hook
+
     config = Configuration('optimize',parent_package, top_path)
 
     include_dirs = [join(os.path.dirname(__file__), '..', '_lib', 'src')]
@@ -74,12 +76,14 @@ def configuration(parent_package='',top_path=None):
                          **numpy_nodepr_api)
 
     sources = ['slsqp.pyf', 'slsqp_optmz.f']
-    config.add_extension('_slsqp', sources=[join('slsqp', x) for x in sources],
-                         **numpy_nodepr_api)
+    ext = config.add_extension('_slsqp', sources=[join('slsqp', x) for x in sources],
+                               **numpy_nodepr_api)
+    ext._pre_build_hook = gfortran_legacy_flag_hook
 
-    config.add_extension('_nnls', sources=[join('nnls', x)
-                                          for x in ["nnls.f","nnls.pyf"]],
-                         **numpy_nodepr_api)
+    ext = config.add_extension('_nnls', sources=[join('nnls', x)
+                                                 for x in ["nnls.f","nnls.pyf"]],
+                               **numpy_nodepr_api)
+    ext._pre_build_hook = gfortran_legacy_flag_hook
 
     config.add_extension('_group_columns', sources=['_group_columns.c'],)
 

--- a/scipy/sparse/linalg/eigen/arpack/setup.py
+++ b/scipy/sparse/linalg/eigen/arpack/setup.py
@@ -4,7 +4,8 @@ from os.path import join
 def configuration(parent_package='',top_path=None):
     from scipy._build_utils.system_info import get_info
     from numpy.distutils.misc_util import Configuration
-    from scipy._build_utils import get_g77_abi_wrappers
+    from scipy._build_utils import (get_g77_abi_wrappers,
+                                    gfortran_legacy_flag_hook)
 
     lapack_opt = get_info('lapack_opt')
 
@@ -16,15 +17,17 @@ def configuration(parent_package='',top_path=None):
     arpack_sources += get_g77_abi_wrappers(lapack_opt)
 
     config.add_library('arpack_scipy', sources=arpack_sources,
-                       include_dirs=[join('ARPACK', 'SRC')])
+                       include_dirs=[join('ARPACK', 'SRC')],
+                       _pre_build_hook=gfortran_legacy_flag_hook)
 
     ext_sources = ['arpack.pyf.src']
-    config.add_extension('_arpack',
-                         sources=ext_sources,
-                         libraries=['arpack_scipy'],
-                         extra_info=lapack_opt,
-                         depends=arpack_sources,
-                         )
+    ext = config.add_extension('_arpack',
+                               sources=ext_sources,
+                               libraries=['arpack_scipy'],
+                               extra_info=lapack_opt,
+                               depends=arpack_sources,
+                               )
+    ext._pre_build_hook = gfortran_legacy_flag_hook
 
     config.add_data_dir('tests')
 

--- a/setup.py
+++ b/setup.py
@@ -241,8 +241,8 @@ def get_build_ext_override():
                     ext.extra_link_args.append('-Wl,--version-script=' + script_fn)
 
             # Allow late configuration
-            if hasattr(ext, '_pre_build_hook'):
-                ext._pre_build_hook(self, ext)
+            hooks = getattr(ext, '_pre_build_hook', ())
+            _run_pre_build_hooks(hooks, (self, ext))
 
             old_build_ext.build_extension(self, ext)
 
@@ -269,6 +269,32 @@ def get_build_ext_override():
             return is_gcc and sysconfig.get_config_var('GNULD') == 'yes'
 
     return build_ext
+
+
+def get_build_clib_override():
+    """
+    Custom build_clib command to tweak library building.
+    """
+    from numpy.distutils.command.build_clib import build_clib as old_build_clib
+
+    class build_clib(old_build_clib):
+        def build_a_library(self, build_info, lib_name, libraries):
+            # Allow late configuration
+            hooks = build_info.get('_pre_build_hook', ())
+            _run_pre_build_hooks(hooks, (self, build_info))
+            old_build_clib.build_a_library(self, build_info, lib_name, libraries)
+
+    return build_clib
+
+
+def _run_pre_build_hooks(hooks, args):
+    """Call a sequence of pre-build hooks, if any"""
+    if hooks is None:
+        hooks = ()
+    elif not hasattr(hooks, '__iter__'):
+        hooks = (hooks,)
+    for hook in hooks:
+        hook(*args)
 
 
 def generate_cython():
@@ -517,6 +543,7 @@ def setup_package():
 
         # Customize extension building
         cmdclass['build_ext'] = get_build_ext_override()
+        cmdclass['build_clib'] = get_build_clib_override()
 
         cwd = os.path.abspath(os.path.dirname(__file__))
         if not os.path.exists(os.path.join(cwd, 'PKG-INFO')):

--- a/setup.py
+++ b/setup.py
@@ -226,6 +226,16 @@ def get_build_ext_override():
     from numpy.distutils.command.build_ext import build_ext as old_build_ext
 
     class build_ext(old_build_ext):
+        def finalize_options(self):
+            super().finalize_options()
+
+            # Disable distutils parallel build, due to race conditions
+            # in numpy.distutils (Numpy issue gh-15957)
+            if self.parallel:
+                print("NOTE: -j build option not supportd. Set NPY_NUM_BUILD_JOBS=4 "
+                      "for parallel build.")
+            self.parallel = None
+
         def build_extension(self, ext):
             # When compiling with GNU compilers, use a version script to
             # hide symbols during linking.
@@ -278,6 +288,12 @@ def get_build_clib_override():
     from numpy.distutils.command.build_clib import build_clib as old_build_clib
 
     class build_clib(old_build_clib):
+        def finalize_options(self):
+            super().finalize_options()
+
+            # Disable parallelization (see build_ext above)
+            self.parallel = None
+
         def build_a_library(self, build_info, lib_name, libraries):
             # Allow late configuration
             hooks = build_info.get('_pre_build_hook', ())


### PR DESCRIPTION
#### Reference issue
Closes: gh-11611

#### What does this implement/fix?

Gfortran 10 forbids by default certain nonstandard constructs, which breaks Scipy build in a few places (see https://gcc.gnu.org/gcc-10/porting_to.html). The feature must be explicitly enabled by adding compiler flag `-fallow-argument-mismatch` where necessary.

Implement pre-build hooks that add the flag when necessary, and use it in the four places we need it (arpack, id_dist, slsqp, nnls).

Also, extend the pre-build hook machinery to support hooks in `build_clib` (needed for arpack) and multiple hooks.