### PR TITLE
Add ignore_nan flag to scipy.optimize.curve_fit

### DIFF
--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -517,7 +517,7 @@ def _initialize_feasible(lb, ub):
 
 def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
               check_finite=True, bounds=(-np.inf, np.inf), method=None,
-              jac=None, **kwargs):
+              jac=None, ignore_nan=False, **kwargs):
     """
     Use non-linear least squares to fit a function, f, to data.
 
@@ -714,6 +714,15 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
                          "Use 'trf' or 'dogbox' instead.")
 
     # optimization may produce garbage for float32 inputs, cast them to float64
+
+    # ignore NaNs in an array being fit
+    if ignore_nan:
+        xy = np.vstack((xdata, ydata))
+        if np.isnan(xy).all():
+            return np.nan
+        xy = xy[:, ~np.isnan(xy).any(axis=0)]
+        xdata = xy[0]
+        ydata = xy[1]
 
     # NaNs cannot be handled
     if check_finite:

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -553,6 +553,7 @@ class TestCurveFit(object):
 
         assert result == expected
 
+        # Test all NaNs data
         xdata = np.array([np.nan, np.nan, np.nan])
         ydata = np.array([np.nan, np.nan, np.nan])
         result = curve_fit(f, xdata, ydata, ignore_nan=True)

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -546,7 +546,8 @@ class TestCurveFit(object):
         xdata = np.array([1, 2, np.nan, 3, 4, np.nan])
         ydata = np.array([1, 2, 5, 3, np.nan, 7])
 
-        result = curve_fit(f, xdata, ydata, ignore_nan=True)
+        result, _ = curve_fit(f, xdata, ydata, ignore_nan=True)
+
         expected = np.array([1, 0])
 
         assert_allclose(result, expected)

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -539,6 +539,26 @@ class TestCurveFit(object):
         assert_raises(ValueError, curve_fit, lambda x, a, b: a*x + b,
                       xdata, ydata, **{"check_finite": True})
 
+    def test_ignore_nan(self):
+        # Test for handling of NaNs in input data when ignore_nan flag is set: gh-11841
+        f = lambda x, a, b: a*x + b
+
+        xdata = np.array([1, 2, 3])
+        ydata = np.array([3, 4, 6])
+        expected = curve_fit(f, xdata, ydata)
+
+        xdata = np.array([1, 2, np.nan, 3, 4 ,np.nan])
+        ydata = np.array([3, 4, 5, 6, np.nan, 7])
+        result = curve_fit(f, xdata, ydata, ignore_nan=True)
+
+        assert result == expected
+
+        xdata = np.array([np.nan, np.nan, np.nan])
+        ydata = np.array([np.nan, np.nan, np.nan])
+        result = curve_fit(f, xdata, ydata, ignore_nan=True)
+
+        assert result == np.nan
+
     def test_empty_inputs(self):
         # Test both with and without bounds (regression test for gh-9864)
         assert_raises(ValueError, curve_fit, lambda x, a: a*x, [], [])

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -7,6 +7,7 @@ from numpy.testing import (assert_, assert_almost_equal, assert_array_equal,
                            assert_array_almost_equal, assert_allclose,
                            assert_warns, suppress_warnings)
 from pytest import raises as assert_raises
+from pytest import fail
 import numpy as np
 from numpy import array, float64
 from multiprocessing.pool import ThreadPool
@@ -543,15 +544,12 @@ class TestCurveFit(object):
         # Test for handling of NaNs in input data when ignore_nan flag is set: gh-11841
         f = lambda x, a, b: a*x + b
 
-        xdata = np.array([1, 2, 3])
-        ydata = np.array([3, 4, 6])
-        expected = curve_fit(f, xdata, ydata)
-
         xdata = np.array([1, 2, np.nan, 3, 4 ,np.nan])
         ydata = np.array([3, 4, 5, 6, np.nan, 7])
-        result = curve_fit(f, xdata, ydata, ignore_nan=True)
-
-        assert result == expected
+        try:
+            curve_fit(f, xdata, ydata, ignore_nan=True)
+        except ValueError:
+            fail("Did raise ValueError when it should not!")
 
         # Test all NaNs data
         xdata = np.array([np.nan, np.nan, np.nan])

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -544,7 +544,7 @@ class TestCurveFit(object):
         # Test for handling of NaNs in input data when ignore_nan flag is set: gh-11841
         f = lambda x, a, b: a*x + b
 
-        xdata = np.array([1, 2, np.nan, 3, 4 ,np.nan])
+        xdata = np.array([1, 2, np.nan, 3, 4, np.nan])
         ydata = np.array([3, 4, 5, 6, np.nan, 7])
         try:
             curve_fit(f, xdata, ydata, ignore_nan=True)

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -556,7 +556,7 @@ class TestCurveFit(object):
         ydata = np.array([np.nan, np.nan, np.nan])
         result = curve_fit(f, xdata, ydata, ignore_nan=True)
 
-        assert result == np.nan
+        assert np.isnan(result)
 
     def test_empty_inputs(self):
         # Test both with and without bounds (regression test for gh-9864)

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -7,7 +7,7 @@ from numpy.testing import (assert_, assert_almost_equal, assert_array_equal,
                            assert_array_almost_equal, assert_allclose,
                            assert_warns, suppress_warnings)
 from pytest import raises as assert_raises
-from pytest import fail
+from pytest import approx
 import numpy as np
 from numpy import array, float64
 from multiprocessing.pool import ThreadPool
@@ -545,11 +545,12 @@ class TestCurveFit(object):
         f = lambda x, a, b: a*x + b
 
         xdata = np.array([1, 2, np.nan, 3, 4, np.nan])
-        ydata = np.array([3, 4, 5, 6, np.nan, 7])
-        try:
-            curve_fit(f, xdata, ydata, ignore_nan=True)
-        except ValueError:
-            fail("Did raise ValueError when it should not!")
+        ydata = np.array([1, 2, 5, 3, np.nan, 7])
+
+        result = curve_fit(f, xdata, ydata, ignore_nan=True)
+        expected = np.array([1, 0])
+
+        assert result == approx(expected)
 
         # Test all NaNs data
         xdata = np.array([np.nan, np.nan, np.nan])

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -7,7 +7,6 @@ from numpy.testing import (assert_, assert_almost_equal, assert_array_equal,
                            assert_array_almost_equal, assert_allclose,
                            assert_warns, suppress_warnings)
 from pytest import raises as assert_raises
-from pytest import approx
 import numpy as np
 from numpy import array, float64
 from multiprocessing.pool import ThreadPool
@@ -550,14 +549,14 @@ class TestCurveFit(object):
         result = curve_fit(f, xdata, ydata, ignore_nan=True)
         expected = np.array([1, 0])
 
-        assert result == approx(expected)
+        assert_allclose(result, expected)
 
         # Test all NaNs data
         xdata = np.array([np.nan, np.nan, np.nan])
         ydata = np.array([np.nan, np.nan, np.nan])
         result = curve_fit(f, xdata, ydata, ignore_nan=True)
 
-        assert np.isnan(result)
+        assert_(np.isnan(result))
 
     def test_empty_inputs(self):
         # Test both with and without bounds (regression test for gh-9864)

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -543,12 +543,12 @@ class TestCurveFit(object):
         # Test for handling of NaNs in input data when ignore_nan flag is set: gh-11841
         f = lambda x, a, b: a*x + b
 
-        xdata = np.array([1, 2, np.nan, 3, 4, np.nan])
+        xdata = np.array([2, 3, np.nan, 4, 4, np.nan])
         ydata = np.array([1, 2, 5, 3, np.nan, 7])
 
         result, _ = curve_fit(f, xdata, ydata, ignore_nan=True)
 
-        expected = np.array([1, 0])
+        expected = np.array([1, -1])
 
         assert_allclose(result, expected)
 


### PR DESCRIPTION
fix #11841

When xdata or ydata includes np.nan value, scipy.optimize.curve_fit returns ValueError.
This behavior is sometimes inappropriate, so I added a flag to ignore np.nan values in xdata and ydata.
