### PR TITLE
ENH: speed up geninvgauss by using cython

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -3659,19 +3659,12 @@ class geninvgauss_gen(rv_continuous):
         def logpdf_single(x, p, b):
             return _stats.geninvgauss_gen_logpdf(x, p, b)
 
-        return logpdf_single(x, p, b)
-        # z = sc.kve(p, b)
-        # z_inf = np.isinf(z)
-        # if z_inf.any():
-        #     msg = ("Infinite values encountered in scipy.special.kve(p, b). "
-        #            "Values replaced by NaN to avoid incorrect results.")
-        #     warnings.warn(msg, RuntimeWarning)
-        #     z[z_inf] = np.nan
-        # c = -np.log(2) - np.log(z) + b
-        # return _lazywhere(x > 0, (x, p, b, c),
-        #                   lambda x, p, b, c:
-        #                       c + (p - 1)*np.log(x) - b*(x + 1/x)/2,
-        #                   -np.inf)
+        z = logpdf_single(x, p, b)
+        if np.isnan(z).any():
+            msg = ("Infinite values encountered in scipy.special.kve(p, b). "
+                   "Values replaced by NaN to avoid incorrect results.")
+            warnings.warn(msg, RuntimeWarning)
+        return z
 
     def _pdf(self, x, p, b):
         # relying on logpdf avoids overflow of x**(p-1) for large x and p

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -3655,18 +3655,23 @@ class geninvgauss_gen(rv_continuous):
         # kve instead of kv works better for large values of b
         # warn if kve produces infinite values and replace by nan
         # otherwise c = -inf and the results are often incorrect
-        z = sc.kve(p, b)
-        z_inf = np.isinf(z)
-        if z_inf.any():
-            msg = ("Infinite values encountered in scipy.special.kve(p, b). "
-                   "Values replaced by NaN to avoid incorrect results.")
-            warnings.warn(msg, RuntimeWarning)
-            z[z_inf] = np.nan
-        c = -np.log(2) - np.log(z) + b
-        return _lazywhere(x > 0, (x, p, b, c),
-                          lambda x, p, b, c:
-                              c + (p - 1)*np.log(x) - b*(x + 1/x)/2,
-                          -np.inf)
+        @np.vectorize
+        def logpdf_single(x, p, b):
+            return _stats.geninvgauss_gen_logpdf(x, p, b)
+
+        return logpdf_single(x, p, b)
+        # z = sc.kve(p, b)
+        # z_inf = np.isinf(z)
+        # if z_inf.any():
+        #     msg = ("Infinite values encountered in scipy.special.kve(p, b). "
+        #            "Values replaced by NaN to avoid incorrect results.")
+        #     warnings.warn(msg, RuntimeWarning)
+        #     z[z_inf] = np.nan
+        # c = -np.log(2) - np.log(z) + b
+        # return _lazywhere(x > 0, (x, p, b, c),
+        #                   lambda x, p, b, c:
+        #                       c + (p - 1)*np.log(x) - b*(x + 1/x)/2,
+        #                   -np.inf)
 
     def _pdf(self, x, p, b):
         # relying on logpdf avoids overflow of x**(p-1) for large x and p

--- a/scipy/stats/_stats.pxd
+++ b/scipy/stats/_stats.pxd
@@ -1,0 +1,2 @@
+# destined to be used in a LowLevelCallable
+cdef double _geninvgauss_pdf(double x, void *user_data) except *

--- a/scipy/stats/_stats.pxd
+++ b/scipy/stats/_stats.pxd
@@ -1,2 +1,2 @@
 # destined to be used in a LowLevelCallable
-cdef double _geninvgauss_pdf(double x, void *user_data) except *
+cdef double _geninvgauss_pdf(double x, void *user_data) nogil except *

--- a/scipy/stats/_stats.pyx
+++ b/scipy/stats/_stats.pyx
@@ -3,13 +3,14 @@ from libc cimport math
 cimport cython
 cimport numpy as np
 from numpy.math cimport PI
+from numpy.math cimport INFINITY
+from numpy.math cimport NAN
 from numpy cimport ndarray, int64_t, float64_t, intp_t
 
 import warnings
 import numpy as np
 import scipy.stats, scipy.special
 import scipy.special.cython_special as cs
-import math
 
 
 cdef double von_mises_cdf_series(double k, double x, unsigned int p):
@@ -481,15 +482,39 @@ def _local_correlations(distx, disty, global_corr='mgc'):
     return corr_mat
 
 
-cpdef geninvgauss_gen_logpdf(double x, double p, double b):
+cpdef double geninvgauss_logpdf(double x, double p, double b):
+    return _geninvgauss_logpdf_kernel(x, p, b)
+
+
+cdef _geninvgauss_logpdf_kernel(double x, double p, double b):
     cdef double z, c
 
     z = cs.kve(p, b)
     if math.isinf(z):
-        return math.nan
+        return NAN
 
     if x <= 0:
-        return -math.inf
+        return -INFINITY
 
     c = -math.log(2) - math.log(z) + b
     return c + (p - 1)*math.log(x) - b*(x + 1/x)/2
+
+
+cdef double _geninvgauss_pdf(double x, void *user_data) except *:
+    # destined to be used in a LowLevelCallable
+    # can't use nogil because cs.kve isn't marked nogil
+    cdef double p, b
+
+    p = (<double *>user_data)[0]
+    b = (<double *>user_data)[1]
+
+    if x <= 0:
+        return 0.
+
+    return math.exp(_geninvgauss_logpdf_kernel(x, p, b))
+
+
+# Ctypes declarations of the callables above
+import ctypes
+_geninvgauss_pdf_t = ctypes.CFUNCTYPE(ctypes.c_double, ctypes.c_double, ctypes.c_void_p)
+_geninvgauss_pdf_ctypes = ctypes.cast(<size_t>&_geninvgauss_pdf, _geninvgauss_pdf_t)

--- a/scipy/stats/_stats.pyx
+++ b/scipy/stats/_stats.pyx
@@ -489,12 +489,12 @@ cpdef double geninvgauss_logpdf(double x, double p, double b):
 cdef _geninvgauss_logpdf_kernel(double x, double p, double b):
     cdef double z, c
 
+    if x <= 0:
+        return -INFINITY
+
     z = cs.kve(p, b)
     if math.isinf(z):
         return NAN
-
-    if x <= 0:
-        return -INFINITY
 
     c = -math.log(2) - math.log(z) + b
     return c + (p - 1)*math.log(x) - b*(x + 1/x)/2
@@ -505,16 +505,10 @@ cdef double _geninvgauss_pdf(double x, void *user_data) except *:
     # can't use nogil because cs.kve isn't marked nogil
     cdef double p, b
 
-    p = (<double *>user_data)[0]
-    b = (<double *>user_data)[1]
-
     if x <= 0:
         return 0.
 
+    p = (<double *>user_data)[0]
+    b = (<double *>user_data)[1]
+
     return math.exp(_geninvgauss_logpdf_kernel(x, p, b))
-
-
-# Ctypes declarations of the callables above
-import ctypes
-_geninvgauss_pdf_t = ctypes.CFUNCTYPE(ctypes.c_double, ctypes.c_double, ctypes.c_void_p)
-_geninvgauss_pdf_ctypes = ctypes.cast(<size_t>&_geninvgauss_pdf, _geninvgauss_pdf_t)

--- a/scipy/stats/_stats.pyx
+++ b/scipy/stats/_stats.pyx
@@ -486,9 +486,6 @@ cpdef geninvgauss_gen_logpdf(double x, double p, double b):
 
     z = cs.kve(p, b)
     if math.isinf(z):
-        msg = ("Infinite values encountered in scipy.special.kve(p, b). "
-               "Values replaced by NaN to avoid incorrect results.")
-        warnings.warn(msg, RuntimeWarning)
         return math.nan
 
     if x <= 0:

--- a/scipy/stats/_stats.pyx
+++ b/scipy/stats/_stats.pyx
@@ -486,7 +486,7 @@ cpdef double geninvgauss_logpdf(double x, double p, double b):
     return _geninvgauss_logpdf_kernel(x, p, b)
 
 
-cdef _geninvgauss_logpdf_kernel(double x, double p, double b):
+cdef double _geninvgauss_logpdf_kernel(double x, double p, double b):
     cdef double z, c
 
     if x <= 0:

--- a/scipy/stats/_stats.pyx
+++ b/scipy/stats/_stats.pyx
@@ -10,7 +10,7 @@ from numpy cimport ndarray, int64_t, float64_t, intp_t
 import warnings
 import numpy as np
 import scipy.stats, scipy.special
-import scipy.special.cython_special as cs
+cimport scipy.special.cython_special as cs
 
 
 cdef double von_mises_cdf_series(double k, double x, unsigned int p):
@@ -486,7 +486,7 @@ cpdef double geninvgauss_logpdf(double x, double p, double b):
     return _geninvgauss_logpdf_kernel(x, p, b)
 
 
-cdef double _geninvgauss_logpdf_kernel(double x, double p, double b):
+cdef double _geninvgauss_logpdf_kernel(double x, double p, double b) nogil:
     cdef double z, c
 
     if x <= 0:
@@ -500,7 +500,7 @@ cdef double _geninvgauss_logpdf_kernel(double x, double p, double b):
     return c + (p - 1)*math.log(x) - b*(x + 1/x)/2
 
 
-cdef double _geninvgauss_pdf(double x, void *user_data) except *:
+cdef double _geninvgauss_pdf(double x, void *user_data) nogil except *:
     # destined to be used in a LowLevelCallable
     # can't use nogil because cs.kve isn't marked nogil
     cdef double p, b

--- a/scipy/stats/_stats.pyx
+++ b/scipy/stats/_stats.pyx
@@ -8,6 +8,8 @@ from numpy cimport ndarray, int64_t, float64_t, intp_t
 import warnings
 import numpy as np
 import scipy.stats, scipy.special
+import scipy.special.cython_special as cs
+import math
 
 
 cdef double von_mises_cdf_series(double k, double x, unsigned int p):
@@ -477,3 +479,20 @@ def _local_correlations(distx, disty, global_corr='mgc'):
     corr_mat[:, local_vary <= 0] = 0
 
     return corr_mat
+
+
+cpdef geninvgauss_gen_logpdf(double x, double p, double b):
+    cdef double z, c
+
+    z = cs.kve(p, b)
+    if math.isinf(z):
+        msg = ("Infinite values encountered in scipy.special.kve(p, b). "
+               "Values replaced by NaN to avoid incorrect results.")
+        warnings.warn(msg, RuntimeWarning)
+        return math.nan
+
+    if x <= 0:
+        return -math.inf
+
+    c = -math.log(2) - math.log(z) + b
+    return c + (p - 1)*math.log(x) - b*(x + 1/x)/2

--- a/scipy/stats/_stats.pyx
+++ b/scipy/stats/_stats.pyx
@@ -482,7 +482,7 @@ def _local_correlations(distx, disty, global_corr='mgc'):
     return corr_mat
 
 
-cpdef double geninvgauss_logpdf(double x, double p, double b):
+cpdef double geninvgauss_logpdf(double x, double p, double b) nogil:
     return _geninvgauss_logpdf_kernel(x, p, b)
 
 
@@ -502,7 +502,6 @@ cdef double _geninvgauss_logpdf_kernel(double x, double p, double b) nogil:
 
 cdef double _geninvgauss_pdf(double x, void *user_data) nogil except *:
     # destined to be used in a LowLevelCallable
-    # can't use nogil because cs.kve isn't marked nogil
     cdef double p, b
 
     if x <= 0:


### PR DESCRIPTION
The full test suite for `stats` can take a long time, and `geninvgauss` is a key culprit. This is because there's no analytic CDF, so it's done via numeric integration of the PDF.
This PR makes a cython function for `_logpdf`, which greatly speeds up calculation.

Before PR:
```
(dev3) 192-168-1-103:scipy andrew$ python runtests.py -t scipy.stats.tests.test_distributions -m full
Building, see build.log...
Build OK (0:00:08.035044 elapsed)
=========================================================== test session starts ============================================================
platform darwin -- Python 3.8.2, pytest-5.4.1, py-1.8.1, pluggy-0.13.1
rootdir: /Users/andrew/Documents/Andy/programming/scipy, inifile: pytest.ini
plugins: xdist-1.31.0, forked-1.1.3
collected 443 items                                                                                                                        

scipy/stats/tests/test_distributions.py ............................................................................................ [ 20%]
.................................................................................................................................s.. [ 50%]
......ss..................................................s....................s.................................................... [ 80%]
.......................................................................................                                              [100%]

================================================ 438 passed, 5 skipped in 171.10s (0:02:51) ================================================
```

After PR:
```
(dev3) 192-168-1-103:scipy andrew$ python runtests.py -t scipy.stats.tests.test_distributions -m full
Building, see build.log...
Build OK (0:00:17.091902 elapsed)
=========================================================== test session starts ============================================================
platform darwin -- Python 3.8.2, pytest-5.4.1, py-1.8.1, pluggy-0.13.1
rootdir: /Users/andrew/Documents/Andy/programming/scipy, inifile: pytest.ini
plugins: xdist-1.31.0, forked-1.1.3
collected 443 items                                                                                                                        

scipy/stats/tests/test_distributions.py ............................................................................................ [ 20%]
.................................................................................................................................s.. [ 50%]
......ss..................................................s....................s.................................................... [ 80%]
.......................................................................................                                              [100%]

================================================ 438 passed, 5 skipped in 85.33s (0:01:25) =================================================
```

It may be possible for further gains by using a `LowLevelCallable` for the numeric integration, but this is a good start.