### PR TITLE
CI: remove osx from travisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,14 +100,6 @@ matrix:
         # pytest-xdist plugin for load scheduling its workers don't pick up the
         # flag. This environment variable starts all Py instances in -OO mode.
         - PYTHONOPTIMIZE=2
-    - os: osx
-      if: type = pull_request
-      language: generic
-      env:
-        - TESTMODE=fast
-        - COVERAGE=
-        - NUMPYSPEC="--upgrade numpy"
-        - MB_PYTHON_VERSION=3.7
     - python: 3.6
       if: type = pull_request
       os: linux
@@ -127,52 +119,6 @@ before_install:
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       free -m
       export PATH=/usr/lib/ccache:$PATH
-    elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      brew cask uninstall oclint
-      brew install ccache libmpc gcc@6
-      # The openblas binary used here was built using a gfortran older than 7,
-      # so it needs the older abi libgfortran.
-      export FC=gfortran-6
-      export CC=gcc-6
-      export CXX=g++-6
-      mkdir gcc_aliases
-      pushd gcc_aliases
-      ln -s `which gcc-6` gcc
-      ln -s `which g++-6` g++
-      ln -s `which gfortran-6` gfortran
-      export PATH=$TRAVIS_BUILD_DIR/gcc_aliases:$PATH
-      popd
-      touch config.sh
-      git clone --depth=1 https://github.com/matthew-brett/multibuild.git
-      source multibuild/common_utils.sh
-      source multibuild/travis_steps.sh
-      before_install
-      which ccache
-      export PATH=/usr/local/opt/ccache/libexec:$PATH
-      export USE_CCACHE=1
-      export CCACHE_MAXSIZE=200M
-      export CCACHE_CPP2=1
-      export CFLAGS="-arch x86_64"
-      export CXXFLAGS="-arch x86_64"
-      printenv
-      wget https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.7-macosx_10_9_x86_64-gf_1becaaa.tar.gz -O openblas.tar.gz
-      mkdir openblas
-      tar -xzf openblas.tar.gz -C openblas
-      # Modify the openblas dylib so it can be used in its current location
-      # Also make it use the current install location for libgfortran, libquadmath, and libgcc_s.
-      pushd openblas/usr/local/lib
-      install_name_tool -id $TRAVIS_BUILD_DIR/openblas/usr/local/lib/libopenblasp-r0.3.7.dylib libopenblas.dylib
-      install_name_tool -change /usr/local/gfortran/lib/libgfortran.3.dylib `$FC -v 2>&1 | perl -nle 'print $1 if m{--libdir=([^\s]+)}'`/libgfortran.3.dylib libopenblas.dylib
-      install_name_tool -change /usr/local/gfortran/lib/libquadmath.0.dylib `$FC -v 2>&1 | perl -nle 'print $1 if m{--libdir=([^\s]+)}'`/libquadmath.0.dylib libopenblas.dylib
-      install_name_tool -change /usr/local/gfortran/lib/libgcc_s.1.dylib `$FC -v 2>&1 | perl -nle 'print $1 if m{--libdir=([^\s]+)}'`/libgcc_s.1.dylib libopenblas.dylib
-      popd
-      echo "[openblas]" > site.cfg
-      echo "libraries = openblas" >> site.cfg
-      echo "library_dirs = $TRAVIS_BUILD_DIR/openblas/usr/local/lib" >> site.cfg
-      echo "include_dirs = $TRAVIS_BUILD_DIR/openblas/usr/local/include" >> site.cfg
-      echo "runtime_library_dirs = $TRAVIS_BUILD_DIR/openblas/usr/local/lib" >> site.cfg
-      # remove a spurious gcc/gfortran toolchain install
-      rm -rf /usr/local/Cellar/gcc/9.2.0_2
     fi
   - export CCACHE_COMPRESS=1
   - python --version # just to check


### PR DESCRIPTION
If/when #11822 is merged then a more comprehensive CI examination will be done for macOS via github actions. This means we don't need to run any macOS entries on travisCI. Since this is one of the matrix entries that takes a long time this should relieve some of scipy's load on travisCI.
Only merge once #11822 has been shown to work on the main repo (it's working on my fork).