### PR TITLE
WIP, MAINT: Test cython

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ matrix:
         - TESTMODE=fast
         - COVERAGE=
         - NUMPYSPEC="--pre --upgrade --timeout=60 -f $PRE_WHEELS numpy"
+        - CYTHONSPEC="--pre"
         # Need a test with most recent Python version where we build from an
         # sdist (uses pip build isolation), to check that the version we
         # specify in pyproject.toml (will be older than --pre --upgrade) works
@@ -73,6 +74,7 @@ matrix:
       env:
         - TESTMODE=full
         - NUMPYSPEC="--pre --upgrade --timeout=60 -f $PRE_WHEELS numpy"
+        - CYTHONSPEC="--pre"
     - python: 3.6
       if: type = pull_request
       env:
@@ -137,7 +139,7 @@ before_install:
   - python -V -V
   - python -c 'import sys; print("Python debug build:", hasattr(sys, "gettotalrefcount"))'
   - travis_retry pip install --upgrade pip setuptools wheel
-  - travis_retry pip install cython
+  - travis_retry pip install $CYTHONSPEC cython
   - if [ -n "$NUMPYSPEC" ]; then travis_retry pip install $NUMPYSPEC; fi
   - travis_retry pip install --upgrade pytest pytest-xdist mpmath argparse Pillow codecov
   - |

--- a/scipy/signal/windows/setup.py
+++ b/scipy/signal/windows/setup.py
@@ -4,6 +4,4 @@ def configuration(parent_package='', top_path=None):
 
     config = Configuration('windows', parent_package, top_path)
 
-    config.add_data_dir('tests')
-
     return config


### PR DESCRIPTION
[Cython 3.0 alpha is out](https://groups.google.com/forum/#!topic/cython-users/oPAowytvbCo), might be a good idea to test it on our `--pre` run like we do for NumPy.

Also removes a `tests` data package dir `scipy/signal/windows/tests` from `setup.py` that does not actually exist.