### PR TITLE
BUG: Change parameter fc of gausspulse to float.

### DIFF
--- a/scipy/signal/waveforms.py
+++ b/scipy/signal/waveforms.py
@@ -174,7 +174,7 @@ def gausspulse(t, fc=1000, bw=0.5, bwr=-6, tpr=-60, retquad=False,
     ----------
     t : ndarray or the string 'cutoff'
         Input array.
-    fc : int, optional
+    fc : float, optional
         Center frequency (e.g. Hz).  Default is 1000.
     bw : float, optional
         Fractional bandwidth in frequency domain of pulse (e.g. Hz).


### PR DESCRIPTION
#### What does this implement/fix?
The parameter fc of gausspulse denotes the center frequency of the gaussian modulated sinusoid. There is no reason why it should be limited to whole numbers. 
As frequencies may be somewhat high in many use cases, users might for example prefer entering the center frequency using an exponent notation (e.g. 1e7). As of now, code inspection tools will warn against this, because the parameter is documented as an integer.