### PR TITLE
order = degree + 1 for splines

### DIFF
--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -264,7 +264,7 @@ class BSpline(object):
 
         Notes
         -----
-        The order of the B-spline, `k`, is inferred from the length of `t` as
+        The degree of the B-spline, `k`, is inferred from the length of `t` as
         ``len(t)-2``. The knot vector is constructed by appending and prepending
         ``k+1`` elements to internal knots `t`.
 
@@ -281,7 +281,7 @@ class BSpline(object):
         >>> k
         3
 
-        Construct a second order B-spline on ``[0, 1, 1, 2]``, and compare
+        Construct a quadratic B-spline on ``[0, 1, 1, 2]``, and compare
         to its explicit form:
 
         >>> t = [-1, 0, 1, 1, 2]


### PR DESCRIPTION
The order of splines equals to the degree plus 1, we will usually call cubic/quadratic splines (splines of degree 3/degree 2) or splines of order 4/order 3. Refer to https://en.wikipedia.org/wiki/Spline_(mathematics)

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->