### PR TITLE
Make g77 ABI wrapper work with gfortran ABI lapack

### DIFF
--- a/scipy/_build_utils/src/wrap_g77_abi_f.f
+++ b/scipy/_build_utils/src/wrap_g77_abi_f.f
@@ -37,15 +37,21 @@
       COMPLEX FUNCTION WCLADIV( X, Y )
       COMPLEX            X, Y
       COMPLEX            Z
-      EXTERNAL CLADIV
-      CALL CLADIV(Z, X, Y)
-      WCLADIV = Z
+      EXTERNAL SLADIV
+      INTRINSIC          AIMAG, CMPLX, REAL
+      REAL               ZI, ZR
+      CALL SLADIV( REAL( X ), AIMAG( X ), REAL( Y ), AIMAG( Y ), ZR,
+     $             ZI )
+      WCLADIV = CMPLX( ZR, ZI )
       END FUNCTION
 
       DOUBLE COMPLEX FUNCTION WZLADIV( X, Y )
       DOUBLE COMPLEX     X, Y
       DOUBLE COMPLEX     Z
-      EXTERNAL ZLADIV
-      CALL ZLADIV(Z, X, Y)
-      WZLADIV = Z
+      EXTERNAL DLADIV
+      INTRINSIC          DBLE, DCMPLX, DIMAG
+      DOUBLE PRECISION   ZI, ZR
+      CALL DLADIV( DBLE( X ), DIMAG( X ), DBLE( Y ), DIMAG( Y ), ZR,
+     $             ZI )
+      WZLADIV = DCMPLX( ZR, ZI )
       END FUNCTION


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Ref: https://github.com/scipy/scipy/issues/11812

#### What does this implement/fix?
<!--Please explain your changes.-->

Using the g77 ABI wrapper with a gfortran ABI lapack doesn't
work for cladiv and zladiv as mentioned in https://github.com/scipy/scipy/issues/11812
This PR fixes that by calling sladiv and dladiv.

#### Additional information
<!--Any additional information you think is important.-->