### PR TITLE
MAINT: add type ignores to sympy and matplotlib imports

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -14,16 +14,7 @@ ignore_missing_imports = True
 # Third party dependencies that don't have types.
 #
 
-[mypy-matplotlib.*]
-ignore_missing_imports = True
-
 [mypy-pytest]
-ignore_missing_imports = True
-
-[mypy-sympy]
-ignore_missing_imports = True
-
-[mypy-sympy.*]
 ignore_missing_imports = True
 
 [mypy-sksparse]

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -54,11 +54,11 @@ from . import hierarchy_test_data
 # Matplotlib is not a scipy dependency but is optionally used in dendrogram, so
 # check if it's available
 try:
-    import matplotlib
+    import matplotlib  # type: ignore[import]
     # and set the backend to be Agg (no gui)
     matplotlib.use('Agg')
     # before importing pyplot
-    import matplotlib.pyplot as plt
+    import matplotlib.pyplot as plt  # type: ignore[import]
     have_matplotlib = True
 except Exception:
     have_matplotlib = False
@@ -1055,4 +1055,3 @@ def test_Heap():
     pair = heap.get_min()
     assert_equal(pair['key'], 1)
     assert_equal(pair['value'], 10)
-

--- a/scipy/interpolate/interpnd_info.py
+++ b/scipy/interpolate/interpnd_info.py
@@ -3,7 +3,7 @@ Here we perform some symbolic computations required for the N-D
 interpolation routines in `interpnd.pyx`.
 
 """
-from sympy import symbols, binomial, Matrix
+from sympy import symbols, binomial, Matrix  # type: ignore[import]
 
 
 def _estimate_gradients_2d_global():

--- a/scipy/optimize/_shgo_lib/triangulation.py
+++ b/scipy/optimize/_shgo_lib/triangulation.py
@@ -369,7 +369,7 @@ class Complex:
 
              To plot a single simplex S in a set C, use e.g., [C[0]]
         """
-        from matplotlib import pyplot
+        from matplotlib import pyplot  # type: ignore[import]
         if self.dim == 2:
             pyplot.figure()
             for C in self.H:

--- a/scipy/spatial/_plotutils.py
+++ b/scipy/spatial/_plotutils.py
@@ -6,7 +6,7 @@ __all__ = ['delaunay_plot_2d', 'convex_hull_plot_2d', 'voronoi_plot_2d']
 
 @_decorator
 def _held_figure(func, obj, ax=None, **kw):
-    import matplotlib.pyplot as plt
+    import matplotlib.pyplot as plt  # type: ignore[import]
 
     if ax is None:
         fig = plt.figure()
@@ -131,7 +131,7 @@ def convex_hull_plot_2d(hull, ax=None):
     >>> plt.show()
 
     """
-    from matplotlib.collections import LineCollection
+    from matplotlib.collections import LineCollection  # type: ignore[import]
 
     if hull.points.shape[1] != 2:
         raise ValueError("Convex hull is not 2-D")

--- a/scipy/special/_precompute/expn_asy.py
+++ b/scipy/special/_precompute/expn_asy.py
@@ -15,7 +15,7 @@ try:
     # https://github.com/sympy/sympy/issues/11255
     with suppress_warnings() as sup:
         sup.filter(DeprecationWarning, "inspect.getargspec.. is deprecated")
-        import sympy
+        import sympy  # type: ignore[import]
         from sympy import Poly
         x = sympy.symbols('x')
 except ImportError:

--- a/scipy/special/_precompute/lambertw.py
+++ b/scipy/special/_precompute/lambertw.py
@@ -7,7 +7,7 @@ import numpy as np
 
 try:
     import mpmath  # type: ignore[import]
-    import matplotlib.pyplot as plt
+    import matplotlib.pyplot as plt  # type: ignore[import]
 except ImportError:
     pass
 

--- a/scipy/special/_precompute/struve_convergence.py
+++ b/scipy/special/_precompute/struve_convergence.py
@@ -32,7 +32,7 @@ Black dashed line
 
 """
 import numpy as np
-import matplotlib.pyplot as plt
+import matplotlib.pyplot as plt  # type: ignore[import]
 
 import mpmath  # type: ignore[import]
 

--- a/scipy/special/_precompute/utils.py
+++ b/scipy/special/_precompute/utils.py
@@ -10,7 +10,7 @@ try:
     # https://github.com/sympy/sympy/issues/11255
     with suppress_warnings() as sup:
         sup.filter(DeprecationWarning, "inspect.getargspec.. is deprecated")
-        from sympy.abc import x
+        from sympy.abc import x  # type: ignore[import]
 except ImportError:
     pass
 

--- a/scipy/special/tests/test_precompute_expn_asy.py
+++ b/scipy/special/tests/test_precompute_expn_asy.py
@@ -4,7 +4,7 @@ from scipy.special._testutils import check_version, MissingModule
 from scipy.special._precompute.expn_asy import generate_A
 
 try:
-    import sympy
+    import sympy  # type: ignore[import]
     from sympy import Poly
 except ImportError:
     sympy = MissingModule("sympy")

--- a/scipy/special/tests/test_precompute_gammainc.py
+++ b/scipy/special/tests/test_precompute_gammainc.py
@@ -9,7 +9,7 @@ from scipy.special._precompute.gammainc_asy import (
 from scipy.special._precompute.gammainc_data import gammainc, gammaincc
 
 try:
-    import sympy
+    import sympy  # type: ignore[import]
 except ImportError:
     sympy = MissingModule('sympy')
 

--- a/scipy/special/tests/test_precompute_utils.py
+++ b/scipy/special/tests/test_precompute_utils.py
@@ -5,7 +5,7 @@ from scipy.special._mptestutils import mp_assert_allclose
 from scipy.special._precompute.utils import lagrange_inversion
 
 try:
-    import sympy
+    import sympy  # type: ignore[import]
 except ImportError:
     sympy = MissingModule('sympy')
 

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -18,9 +18,9 @@ from .common_tests import check_named_results
 # Matplotlib is not a scipy dependency but is optionally used in probplot, so
 # check if it's available
 try:
-    import matplotlib
+    import matplotlib  # type: ignore[import]
     matplotlib.rcParams['backend'] = 'Agg'
-    import matplotlib.pyplot as plt
+    import matplotlib.pyplot as plt  # type: ignore[import]
     have_matplotlib = True
 except Exception:
     have_matplotlib = False


### PR DESCRIPTION
#### Reference issue
https://github.com/scipy/scipy/issues/11749

#### What does this implement/fix?
Similar to what we did with mpmath; sympy and matplotlib don't have stubs and aren't actual runtime dependencies, so we should just ignore them.

#### Additional information
None