### PR TITLE
ENH: type ufuncs in special as ufuncs instead of Any

### DIFF
--- a/scipy/special/_generate_pyx.py
+++ b/scipy/special/_generate_pyx.py
@@ -137,6 +137,8 @@ include "_cython_special.pxi"
 STUBS = """\
 from typing import Any, Type
 
+import numpy as np
+
 __all__ = [
     {ALL}
 ]
@@ -1330,15 +1332,14 @@ def generate_fused_funcs(modname, ufunc_fn_prefix, fused_funcs):
 def generate_ufuncs_type_stubs(module_name: str, ufuncs: List[Ufunc]):
     stubs, module_all = [], []
     for ufunc in ufuncs:
-        stubs.append(f'{ufunc.name}: Any')
+        stubs.append(f'{ufunc.name}: np.ufunc')
         if not ufunc.name.startswith('_'):
             module_all.append(f"'{ufunc.name}'")
     # jn is an alias for jv.
     module_all.append("'jn'")
+    stubs.append('jn: np.ufunc')
     module_all.sort()
     stubs.sort()
-    # Make sure jn goes last so that jv has been declared.
-    stubs.append('jn: Type[jv]')
 
     contents = STUBS.format(
         ALL=',\n    '.join(module_all),


### PR DESCRIPTION
#### Reference issue
https://github.com/scipy/scipy/issues/11749

#### What does this implement/fix?
The NumPy stubs have basic support for ufuncs now, so improve the typing of things in `special._ufuncs`.

#### Additional information
Ok actually if you run this against the master of NumPy as of the time of me writing this you will get one error, but that's going to be fixed by https://github.com/numpy/numpy-stubs/pull/55.