### PR TITLE
DOC: add Examples of docstring for scipy.interpolate.approximate_taylor_polynomial

### DIFF
--- a/scipy/interpolate/polyint.py
+++ b/scipy/interpolate/polyint.py
@@ -445,14 +445,16 @@ def approximate_taylor_polynomial(f,x,degree,scale,order=None):
     various degrees:
 
     >>> import matplotlib.pyplot as plt
-    >>> from scipy import interpolate
+    >>> from scipy.interpolate import approximate_taylor_polynomial
     >>> x = np.linspace(-10.0, 10.0, num=100)
     >>> plt.plot(x, np.sin(x), label="sin curve")
     >>> for degree in np.arange(1, 15, step=2):
-    >>>     sin_taylor = interpolate.approximate_taylor_polynomial(np.sin, 0,
-    ...                                                             degree, 1)
-    >>>     plt.plot(x, sin_taylor(x), label=f"degree={degree}")
-    >>> plt.legend()
+    ...     sin_taylor = approximate_taylor_polynomial(np.sin, 0, degree, 1,
+    ...                                                 order=degree + 2)
+    ...     plt.plot(x, sin_taylor(x), label=f"degree={degree}")
+    >>> plt.legend(bbox_to_anchor=(1.05, 1), loc='upper left',
+    ...             borderaxespad=0.0, shadow=True)
+    >>> plt.tight_layout()
     >>> plt.axis([-10, 10, -10, 10])
     >>> plt.show()
 

--- a/scipy/interpolate/polyint.py
+++ b/scipy/interpolate/polyint.py
@@ -453,7 +453,7 @@ def approximate_taylor_polynomial(f,x,degree,scale,order=None):
     ...                                                order=degree + 2)
     ...     plt.plot(x, sin_taylor(x), label=f"degree={degree}")
     >>> plt.legend(bbox_to_anchor=(1.05, 1), loc='upper left',
-    ...             borderaxespad=0.0, shadow=True)
+    ...            borderaxespad=0.0, shadow=True)
     >>> plt.tight_layout()
     >>> plt.axis([-10, 10, -10, 10])
     >>> plt.show()

--- a/scipy/interpolate/polyint.py
+++ b/scipy/interpolate/polyint.py
@@ -450,7 +450,7 @@ def approximate_taylor_polynomial(f,x,degree,scale,order=None):
     >>> plt.plot(x, np.sin(x), label="sin curve")
     >>> for degree in np.arange(1, 15, step=2):
     ...     sin_taylor = approximate_taylor_polynomial(np.sin, 0, degree, 1,
-    ...                                                 order=degree + 2)
+    ...                                                order=degree + 2)
     ...     plt.plot(x, sin_taylor(x), label=f"degree={degree}")
     >>> plt.legend(bbox_to_anchor=(1.05, 1), loc='upper left',
     ...             borderaxespad=0.0, shadow=True)

--- a/scipy/interpolate/polyint.py
+++ b/scipy/interpolate/polyint.py
@@ -439,6 +439,23 @@ def approximate_taylor_polynomial(f,x,degree,scale,order=None):
     Choosing order somewhat larger than degree may improve the higher-order
     terms.
 
+    Examples
+    --------
+    We can calculate Taylor approximation polynomials of sin function with
+    various degrees:
+
+    >>> import matplotlib.pyplot as plt
+    >>> from scipy import interpolate
+    >>> x = np.linspace(-10.0, 10.0, num=100)
+    >>> plt.plot(x, np.sin(x), label="sin curve")
+    >>> for degree in np.arange(1, 15, step=2):
+    >>>     sin_taylor = interpolate.approximate_taylor_polynomial(np.sin, 0,
+    ...                                                             degree, 1)
+    >>>     plt.plot(x, sin_taylor(x), label=f"degree={degree}")
+    >>> plt.legend()
+    >>> plt.axis([-10, 10, -10, 10])
+    >>> plt.show()
+
     """
     if order is None:
         order = degree


### PR DESCRIPTION
#### Reference issue
To fix a part of #7168 

#### What does this implement/fix?
Add Examples of docstring for scipy.interpolate.approximate_taylor_polynomial

