### PR TITLE
BUG: Fix ndim support for f_oneway

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3229,11 +3229,12 @@ def f_oneway(*args):
     # Based on https://github.com/scipy/scipy/issues/11669
     const_groups = True
     for group in args:
-        if not (group == group.ravel()[0]).all():
+        if not (group == group[:1]).all():  # look along the first dim
             const_groups = False
             break
     if const_groups:
         warnings.warn(F_onewayConstantInputWarning())
+        # XXX this is not correct, needs to be first-axis-wise somehow
         if len(set(group.ravel()[0] for group in args)) > 1:
             return F_onewayResult(np.inf, 0)
         else:

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3229,12 +3229,12 @@ def f_oneway(*args):
     # Based on https://github.com/scipy/scipy/issues/11669
     const_groups = True
     for group in args:
-        if not all(x == group[0] for x in group):
+        if not (group == group.ravel()[0]).all():
             const_groups = False
             break
     if const_groups:
         warnings.warn(F_onewayConstantInputWarning())
-        if len(set(group[0] for group in args)) > 1:
+        if len(set(group.ravel()[0] for group in args)) > 1:
             return F_onewayResult(np.inf, 0)
         else:
             return F_onewayResult(np.nan, np.nan)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -9,7 +9,6 @@
 import os
 import warnings
 from collections import namedtuple
-import multiprocessing
 
 from numpy.testing import (dec, assert_, assert_equal,
                            assert_almost_equal, assert_array_almost_equal,
@@ -4425,6 +4424,15 @@ class TestFOneWay(object):
         F, p = stats.f_oneway([0,2], [2,4])
         assert_equal(F, 2.0)
 
+    @pytest.mark.parametrize('ndim', (1, 2, 3))
+    def test_ndim(self, ndim):
+        a, b = np.arange(0, 3, 2), np.arange(2, 5, 2)
+        for _ in range(ndim - 1):
+            a, b = a[:, np.newaxis], b[:, np.newaxis]
+        F, p = stats.f_oneway([0,2], [2,4])
+        assert F.ndim == 0
+        assert F == 2.0
+
     def test_large_integer_array(self):
         a = np.array([655, 788], dtype=np.uint16)
         b = np.array([789, 772], dtype=np.uint16)
@@ -4470,12 +4478,15 @@ class TestFOneWay(object):
             assert_allclose(res[0], f, rtol=rtol,
                             err_msg='Failing testcase: %s' % test_case)
 
+    @pytest.mark.parametrize('ndim', (1, 2, 3))
     @pytest.mark.parametrize("a, b, expected",[
         (np.array([42, 42, 42]), np.array([7, 7, 7]), (np.inf, 0)),
         (np.array([42, 42, 42]), np.array([42, 42, 42]), (np.nan, np.nan))
         ])
-    def test_constant_input(self, a, b, expected):
+    def test_constant_input(self, a, b, expected, ndim):
         # For more details, look on https://github.com/scipy/scipy/issues/11669
+        for _ in range(ndim - 1):
+            a, b = a[:, np.newaxis], b[:, np.newaxis]
         with assert_warns(stats.F_onewayConstantInputWarning):
             f, p = stats.f_oneway(a, b)
             assert f, p == expected

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4429,9 +4429,9 @@ class TestFOneWay(object):
         a, b = np.arange(0, 3, 2), np.arange(2, 5, 2)
         for _ in range(ndim - 1):
             a, b = a[:, np.newaxis], b[:, np.newaxis]
-        F, p = stats.f_oneway([0,2], [2,4])
-        assert F.ndim == 0
-        assert F == 2.0
+        F, p = stats.f_oneway(a, b)
+        assert F.ndim == a.ndim - 1
+        assert_array_equal(F, 2.0)
 
     def test_large_integer_array(self):
         a = np.array([655, 788], dtype=np.uint16)


### PR DESCRIPTION
#11726 broke support for `ndim > 1` in `f_oneway`. Based on the docs I don't know whether or not this is a supported use case, but it used to work (on the `ravel()`'ed array), so this restores that behavior (I think). If it seems preferred or safer to force the input to 1D, this PR should be scrapped and this condition should be checked after the `asarray` calls.

cc @erheron @rlucas7 since you worked on #11726