### PR TITLE
BUG: Fix index arrays overflow in sparse.kron

### DIFF
--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -331,9 +331,15 @@ def kron(A, B, format=None):
             return coo_matrix(output_shape)
 
         # expand entries of a into blocks
-        row = A.row.repeat(B.nnz).astype(np.int64)
-        col = A.col.repeat(B.nnz).astype(np.int64)
+        row = A.row.repeat(B.nnz)
+        col = A.col.repeat(B.nnz)
         data = A.data.repeat(B.nnz)
+
+        if A.shape[0]*B.shape[0] > np.iinfo('int32').max:
+            row = row.astype(np.int64)
+
+        if A.shape[1]*B.shape[1] > np.iinfo('int32').max:
+            col = col.astype(np.int64)
 
         row *= B.shape[0]
         col *= B.shape[1]

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -331,8 +331,8 @@ def kron(A, B, format=None):
             return coo_matrix(output_shape)
 
         # expand entries of a into blocks
-        row = A.row.repeat(B.nnz)
-        col = A.col.repeat(B.nnz)
+        row = A.row.repeat(B.nnz).astype(np.int64)
+        col = A.col.repeat(B.nnz).astype(np.int64)
         data = A.data.repeat(B.nnz)
 
         row *= B.shape[0]

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -335,10 +335,8 @@ def kron(A, B, format=None):
         col = A.col.repeat(B.nnz)
         data = A.data.repeat(B.nnz)
 
-        if A.shape[0]*B.shape[0] > np.iinfo('int32').max:
+        if max(A.shape[0]*B.shape[0], A.shape[1]*B.shape[1]) > np.iinfo('int32').max:
             row = row.astype(np.int64)
-
-        if A.shape[1]*B.shape[1] > np.iinfo('int32').max:
             col = col.astype(np.int64)
 
         row *= B.shape[0]

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -280,6 +280,14 @@ class TestConstructUtils(object):
                 expected = np.kron(a,b)
                 assert_array_equal(result,expected)
 
+    def test_kron_large(self):
+        n = 2**16
+        a = construct.eye(1, n, n-1)
+        b = construct.eye(n, 1, 1-n)
+
+        construct.kron(a, a)
+        construct.kron(b, b)
+
     def test_kronsum(self):
         cases = []
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes gh-11494
#### What does this implement/fix?
<!--Please explain your changes.-->
Fixes index arrays overflow when performing kronecker product of two large sparse matrices.
#### Additional information
<!--Any additional information you think is important.-->