### PR TITLE
WIP: ENH: linalg: Python wrapper for `?gbsvx`

### DIFF
--- a/scipy/linalg/flapack_gen_banded.pyf.src
+++ b/scipy/linalg/flapack_gen_banded.pyf.src
@@ -34,11 +34,12 @@ subroutine <prefix2>gbsvx(fact,trans,n,kl,ku,nrhs,ab,ldab,afb,ldafb,ipiv,equed,r
      ! Error bounds on the solution and a condition estimate are also
      ! provided.
 
-    callstatement (*f2py_func)(fact,trans,&n,&kl,&ku,&nrhs,ab,&ldab,afb,&ldafb,ipiv,equed,r,c,b,&ldb,x,&ldx,&rcond,ferr,berr,work,iwork,&info)
+    callstatement (*f2py_func)(&"NEF"[fact],&"NTC"[trans],&n,&kl,&ku,&nrhs,ab,&ldab,afb,&ldafb,ipiv,equed,r,c,b,&ldb,x,&ldx,&rcond,ferr,berr,work,iwork,&info)
     callprotoargument char*,char*,int*,int*,int*,int*,<ctype2>*,int*,<ctype2>*,int*,int*,char*,<ctype2>*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,int*,int*
 
-    character intent(in), check((*fact=='F')||(*fact=='N')||(*fact=='E')) :: fact = 'N'
-    character intent(in), check((*trans=='N')||(*trans=='T')||(*trans=='C')) :: trans = 'N'
+    integer intent(in), check((0<=fact) && (fact<3)) :: fact = 0
+    integer intent(in), check((0<=trans) && (trans<3)) :: trans = 0
+
     integer depend(ab),intent(hide):: n = shape(ab,1)
     integer intent(in), check(0<=kl) :: kl
     integer intent(in), check(0<=ku) :: ku
@@ -73,11 +74,11 @@ subroutine <prefix2c>gbsvx(fact,trans,n,kl,ku,nrhs,ab,ldab,afb,ldafb,ipiv,equed,
      ! Error bounds on the solution and a condition estimate are also
      ! provided.
 
-    callstatement (*f2py_func)(fact,trans,&n,&kl,&ku,&nrhs,ab,&ldab,afb,&ldafb,ipiv,equed,r,c,b,&ldb,x,&ldx,&rcond,ferr,berr,work,rwork,&info)
+    callstatement (*f2py_func)(&"NEF"[fact],&"NTC"[trans],&n,&kl,&ku,&nrhs,ab,&ldab,afb,&ldafb,ipiv,equed,r,c,b,&ldb,x,&ldx,&rcond,ferr,berr,work,rwork,&info)
     callprotoargument char*,char*,int*,int*,int*,int*,<ctype2c>*,int*,<ctype2c>*,int*,int*,char*,<ctype2>*,<ctype2>*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2c>*,<ctype2>*,int*
 
-    character intent(in), check((*fact=='F')||(*fact=='N')||(*fact=='E')) :: fact = 'N'
-    character intent(in), check((*trans=='N')||(*trans=='T')||(*trans=='C')) :: trans = 'N'
+    integer intent(in), check((0<=fact) && (fact<3)) :: fact = 0
+    integer intent(in), check((0<=trans) && (trans<3)) :: trans = 0
 
     integer depend(ab),intent(hide):: n = shape(ab,1)
     integer intent(in), check(0<=kl) :: kl

--- a/scipy/linalg/flapack_gen_banded.pyf.src
+++ b/scipy/linalg/flapack_gen_banded.pyf.src
@@ -25,7 +25,7 @@ subroutine <prefix>gbsv(n,kl,ku,nrhs,ab,piv,b,info)
 end subroutine <prefix>gbsv
 
 
-subroutine <prefix2>gbsvx(fact,trans,n,kl,ku,nrhs,ab,ldab,afb,ldafb,ipiv,equed,r,c,b,ldb,x,ldx,rcond,ferr,berr,work,iwork,info)
+subroutine <prefix2>gbsvx(fact,trans,n,kl,ku,nrhs,ab,ldab,afb,ldafb,piv,equed,r,c,b,ldb,x,ldx,rcond,ferr,berr,work,iwork,info)
      ! ?GBSVX uses the LU factorization to compute the solution to a real
      ! system of linear equations A * X = B, A**T * X = B, or A**H * X = B,
      ! where A is a band matrix of order N with KL subdiagonals and KU
@@ -34,7 +34,7 @@ subroutine <prefix2>gbsvx(fact,trans,n,kl,ku,nrhs,ab,ldab,afb,ldafb,ipiv,equed,r
      ! Error bounds on the solution and a condition estimate are also
      ! provided.
 
-    callstatement (*f2py_func)(&"NEF"[fact],&"NTC"[trans],&n,&kl,&ku,&nrhs,ab,&ldab,afb,&ldafb,ipiv,equed,r,c,b,&ldb,x,&ldx,&rcond,ferr,berr,work,iwork,&info)
+    callstatement {int i;for(i=0;i\<n;++piv[i++]);(*f2py_func)(&"NEF"[fact],&"NTC"[trans],&n,&kl,&ku,&nrhs,ab,&ldab,afb,&ldafb,piv,equed,r,c,b,&ldb,x,&ldx,&rcond,ferr,berr,work,iwork,&info);for(i=0;i\<n;--piv[i++]);}
     callprotoargument char*,char*,int*,int*,int*,int*,<ctype2>*,int*,<ctype2>*,int*,int*,char*,<ctype2>*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,int*,int*
 
     integer intent(in), check((0<=fact) && (fact<3)) :: fact = 0
@@ -48,7 +48,7 @@ subroutine <prefix2>gbsvx(fact,trans,n,kl,ku,nrhs,ab,ldab,afb,ldafb,ipiv,equed,r
     integer intent(hide), depend(ab) :: ldab = max(1, shape(ab,0))
     <ftype2> optional, intent(in,out,copy,out=lu), depend(kl, ku), dimension(2*kl+ku+1,n), check(2*kl+ku+1==shape(afb,0)) :: afb
     integer intent(hide), depend(afb)  :: ldafb = max(1, shape(afb, 0))
-    integer optional, intent(in,out,copy,out=piv), depend(n), dimension(n) :: ipiv
+    integer optional, intent(in,out,copy,out=ipiv), depend(n), dimension(n) :: piv
     character optional, intent(in,out), check((*equed=='N')||(*equed=='R')||(*equed=='C')||(*equed=='B')) :: equed = 'N'
     <ftype2> optional, intent(in,out), depend(n), dimension(n) :: r
     <ftype2> optional, intent(in,out), depend(n), dimension(n) :: c
@@ -65,7 +65,7 @@ subroutine <prefix2>gbsvx(fact,trans,n,kl,ku,nrhs,ab,ldab,afb,ldafb,ipiv,equed,r
 end subroutine <prefix2>gbsvx
 
 
-subroutine <prefix2c>gbsvx(fact,trans,n,kl,ku,nrhs,ab,ldab,afb,ldafb,ipiv,equed,r,c,b,ldb,x,ldx,rcond,ferr,berr,work,rwork,info)
+subroutine <prefix2c>gbsvx(fact,trans,n,kl,ku,nrhs,ab,ldab,afb,ldafb,piv,equed,r,c,b,ldb,x,ldx,rcond,ferr,berr,work,rwork,info)
      ! ?GBSVX uses the LU factorization to compute the solution to a real
      ! system of linear equations A * X = B, A**T * X = B, or A**H * X = B,
      ! where A is a band matrix of order N with KL subdiagonals and KU
@@ -74,7 +74,7 @@ subroutine <prefix2c>gbsvx(fact,trans,n,kl,ku,nrhs,ab,ldab,afb,ldafb,ipiv,equed,
      ! Error bounds on the solution and a condition estimate are also
      ! provided.
 
-    callstatement (*f2py_func)(&"NEF"[fact],&"NTC"[trans],&n,&kl,&ku,&nrhs,ab,&ldab,afb,&ldafb,ipiv,equed,r,c,b,&ldb,x,&ldx,&rcond,ferr,berr,work,rwork,&info)
+    callstatement {int i;for(i=0;i\<n;++piv[i++]);(*f2py_func)(&"NEF"[fact],&"NTC"[trans],&n,&kl,&ku,&nrhs,ab,&ldab,afb,&ldafb,piv,equed,r,c,b,&ldb,x,&ldx,&rcond,ferr,berr,work,rwork,&info);for(i=0;i\<n;--piv[i++]);}
     callprotoargument char*,char*,int*,int*,int*,int*,<ctype2c>*,int*,<ctype2c>*,int*,int*,char*,<ctype2>*,<ctype2>*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2c>*,<ctype2>*,int*
 
     integer intent(in), check((0<=fact) && (fact<3)) :: fact = 0
@@ -88,7 +88,7 @@ subroutine <prefix2c>gbsvx(fact,trans,n,kl,ku,nrhs,ab,ldab,afb,ldafb,ipiv,equed,
     integer intent(hide), depend(ab) :: ldab = max(1, shape(ab,0))
     <ftype2c> optional, intent(in,out,copy,out=lu), depend(kl, ku), dimension(2*kl+ku+1,n), check(2*kl+ku+1==shape(afb,0)) :: afb
     integer intent(hide), depend(afb)  :: ldafb = max(1, shape(afb, 0))
-    integer optional, intent(in,out,copy,out=piv), depend(n), dimension(n) :: ipiv
+    integer optional, intent(in,out,copy,out=piv), depend(n), dimension(n) :: piv
     character optional, intent(in,out), check((*equed=='N')||(*equed=='R')||(*equed=='C')||(*equed=='B')) :: equed = 'N'
     <ftype2> optional, intent(in,out), depend(n), dimension(n) :: r
     <ftype2> optional, intent(in,out), depend(n), dimension(n) :: c

--- a/scipy/linalg/flapack_gen_banded.pyf.src
+++ b/scipy/linalg/flapack_gen_banded.pyf.src
@@ -40,13 +40,13 @@ subroutine <prefix2>gbsvx(fact,trans,n,kl,ku,nrhs,ab,ldab,afb,ldafb,piv,equed,r,
     integer intent(in), check((0<=fact) && (fact<3)) :: fact = 0
     integer intent(in), check((0<=trans) && (trans<3)) :: trans = 0
 
-    integer depend(ab),intent(hide):: n = shape(ab,1)
+    integer depend(ab), intent(hide) :: n = shape(ab, 1)
     integer intent(in), check(0<=kl) :: kl
     integer intent(in), check(0<=ku) :: ku
-    integer intent(hide), depend(b) :: nrhs = shape(b,1)
-    <ftype2> intent(in,out,copy,out=a), dimension(ldab,n), check(kl+ku+1==shape(ab,0)) :: ab
-    integer intent(hide), depend(ab) :: ldab = max(1, shape(ab,0))
-    <ftype2> optional, intent(in,out,copy,out=lu), depend(kl, ku), dimension(2*kl+ku+1,n), check(2*kl+ku+1==shape(afb,0)) :: afb
+    integer intent(hide), depend(b) :: nrhs = shape(b, 1)
+    <ftype2> intent(in,out,copy,out=sab), dimension(ldab, n), check(kl+ku+1 == shape(ab, 0)) :: ab
+    integer intent(hide), depend(ab) :: ldab = max(1, shape(ab, 0))
+    <ftype2> optional, intent(in,out,copy,out=lu), depend(kl, ku), dimension(2*kl+ku+1, n), check(2*kl+ku+1 == shape(afb, 0)) :: afb
     integer intent(hide), depend(afb)  :: ldafb = max(1, shape(afb, 0))
     integer optional, intent(in,out,copy,out=ipiv), depend(n), dimension(n) :: piv
     character optional, intent(in,out), check((*equed=='N')||(*equed=='R')||(*equed=='C')||(*equed=='B')) :: equed = 'N'
@@ -59,7 +59,7 @@ subroutine <prefix2>gbsvx(fact,trans,n,kl,ku,nrhs,ab,ldab,afb,ldafb,piv,equed,r,
     <ftype2> intent(out) :: rcond
     <ftype2> intent(out), depend(nrhs), dimension(nrhs) :: ferr
     <ftype2> intent(out), depend(nrhs), dimension(nrhs) :: berr
-    <ftype2> intent(out), depend(n), dimension(3 * n) :: work
+    <ftype2> intent(out), depend(n), dimension(3*n) :: work
     integer intent(hide), depend(n), dimension(n) :: iwork
     integer intent(out) :: info
 end subroutine <prefix2>gbsvx
@@ -80,15 +80,15 @@ subroutine <prefix2c>gbsvx(fact,trans,n,kl,ku,nrhs,ab,ldab,afb,ldafb,piv,equed,r
     integer intent(in), check((0<=fact) && (fact<3)) :: fact = 0
     integer intent(in), check((0<=trans) && (trans<3)) :: trans = 0
 
-    integer depend(ab),intent(hide):: n = shape(ab,1)
+    integer depend(ab), intent(hide) :: n = shape(ab, 1)
     integer intent(in), check(0<=kl) :: kl
     integer intent(in), check(0<=ku) :: ku
-    integer intent(hide), depend(b) :: nrhs = shape(b,1)
-    <ftype2c> intent(in,out,copy,out=a), dimension(ldab,n), check(kl+ku+1==shape(ab,0)) :: ab
-    integer intent(hide), depend(ab) :: ldab = max(1, shape(ab,0))
+    integer intent(hide), depend(b) :: nrhs = shape(b, 1)
+    <ftype2c> intent(in,out,copy,out=sab), dimension(ldab,n), check(kl+ku+1==shape(ab,0)) :: ab
+    integer intent(hide), depend(ab) :: ldab = max(1, shape(ab, 0))
     <ftype2c> optional, intent(in,out,copy,out=lu), depend(kl, ku), dimension(2*kl+ku+1,n), check(2*kl+ku+1==shape(afb,0)) :: afb
     integer intent(hide), depend(afb)  :: ldafb = max(1, shape(afb, 0))
-    integer optional, intent(in,out,copy,out=piv), depend(n), dimension(n) :: piv
+    integer optional, intent(in,out,copy,out=ipiv), depend(n), dimension(n) :: piv
     character optional, intent(in,out), check((*equed=='N')||(*equed=='R')||(*equed=='C')||(*equed=='B')) :: equed = 'N'
     <ftype2> optional, intent(in,out), depend(n), dimension(n) :: r
     <ftype2> optional, intent(in,out), depend(n), dimension(n) :: c
@@ -99,7 +99,7 @@ subroutine <prefix2c>gbsvx(fact,trans,n,kl,ku,nrhs,ab,ldab,afb,ldafb,piv,equed,r
     <ftype2> intent(out) :: rcond
     <ftype2> intent(out), depend(nrhs), dimension(nrhs) :: ferr
     <ftype2> intent(out), depend(nrhs), dimension(nrhs) :: berr
-    <ftype2c> intent(out), depend(n), dimension(2 * n) :: work
+    <ftype2c> intent(out), depend(n), dimension(2*n) :: work
     <ftype2> intent(hide), depend(n), dimension(n) :: rwork
     integer intent(out) :: info
 end subroutine <prefix2c>gbsvx

--- a/scipy/linalg/flapack_gen_banded.pyf.src
+++ b/scipy/linalg/flapack_gen_banded.pyf.src
@@ -23,7 +23,87 @@ subroutine <prefix>gbsv(n,kl,ku,nrhs,ab,piv,b,info)
     intent(in,out,copy,out=lub) ab
 
 end subroutine <prefix>gbsv
-   
+
+
+subroutine <prefix2>gbsvx(fact,trans,n,kl,ku,nrhs,ab,ldab,afb,ldafb,ipiv,equed,r,c,b,ldb,x,ldx,rcond,ferr,berr,work,iwork,info)
+     ! ?GBSVX uses the LU factorization to compute the solution to a real
+     ! system of linear equations A * X = B, A**T * X = B, or A**H * X = B,
+     ! where A is a band matrix of order N with KL subdiagonals and KU
+     ! superdiagonals, and X and B are N-by-NRHS matrices.
+
+     ! Error bounds on the solution and a condition estimate are also
+     ! provided.
+
+    callstatement (*f2py_func)(fact,trans,&n,&kl,&ku,&nrhs,ab,&ldab,afb,&ldafb,ipiv,equed,r,c,b,&ldb,x,&ldx,&rcond,ferr,berr,work,iwork,&info)
+    callprotoargument char*,char*,int*,int*,int*,int*,<ctype2>*,int*,<ctype2>*,int*,int*,char*,<ctype2>*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,int*,int*
+
+    character intent(in), check((*fact=='F')||(*fact=='N')||(*fact=='E')) :: fact = 'N'
+    character intent(in), check((*trans=='N')||(*trans=='T')||(*trans=='C')) :: trans = 'N'
+    integer depend(ab),intent(hide):: n = shape(ab,1)
+    integer intent(in), check(0 <= kl) :: kl = 0
+    integer intent(in), check(0 <= ku) :: ku = 0
+    integer intent(hide), depend(b) :: nrhs = shape(b,1)
+    <ftype2> intent(in,out,copy, out=a), dimension(ldab,n) :: ab
+    integer intent(hide), depend(a) :: ldab = kl + ku + 1
+    <ftype2> optional, intent(in,out,copy,out=lu), dimension(2*kl + ku + 1, n) :: afb
+    integer intent(hide) depend(kl, ku) :: ldafb = 2*kl + ku + 1
+    integer optional, intent(in,out,copy,out=piv), depend(n), dimension(n) :: ipiv
+    character optional, intent(in,out), check((*equed=='N')||(*equed=='R')||(*equed=='C')||(*equed=='B')) :: equed = 'N'
+    <ftype2> optional, intent(in,out), depend(n), dimension(n) :: r
+    <ftype2> optional, intent(in,out), depend(n), dimension(n) :: c
+    <ftype2>  intent(in, out), depend(n), dimension(ldb, nrhs) :: b
+    integer intent(hide) :: ldb = max(1, n)
+    <ftype2> depend(n, nrhs), intent(out), dimension(ldx, nrhs) :: x
+    integer intent(hide) :: ldx = max(1, n)
+    <ftype2> intent(out) :: rcond
+    <ftype2> intent(out), depend(nrhs), dimension(nrhs) :: ferr
+    <ftype2> intent(out), depend(nrhs), dimension(nrhs) :: berr
+    <ftype2> intent(out), depend(n), dimension(3 * n) :: work
+    integer intent(hide), depend(n), dimension(n) :: iwork
+    integer intent(out) :: info
+end subroutine <prefix2>gbsvx
+
+
+subroutine <prefix2c>gbsvx(fact,trans,n,kl,ku,nrhs,ab,ldab,afb,ldafb,ipiv,equed,r,c,b,ldb,x,ldx,rcond,ferr,berr,work,rwork,info)
+     ! ?GBSVX uses the LU factorization to compute the solution to a real
+     ! system of linear equations A * X = B, A**T * X = B, or A**H * X = B,
+     ! where A is a band matrix of order N with KL subdiagonals and KU
+     ! superdiagonals, and X and B are N-by-NRHS matrices.
+
+     ! Error bounds on the solution and a condition estimate are also
+     ! provided.
+
+    callstatement (*f2py_func)(fact,trans,&n,&kl,&ku,&nrhs,ab,&ldab,afb,&ldafb,ipiv,equed,r,c,b,&ldb,x,&ldx,&rcond,ferr,berr,work,rwork,&info)
+    callprotoargument char*,char*,int*,int*,int*,int*,<ctype2c>*,int*,<ctype2c>*,int*,int*,char*,<ctype2>*,<ctype2>*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2c>*,<ctype2>*,int*
+
+    character intent(in), check((*fact=='F')||(*fact=='N')||(*fact=='E')) :: fact = 'N'
+    character intent(in), check((*trans=='N')||(*trans=='T')||(*trans=='C')) :: trans = 'N'
+
+    integer depend(ab),intent(hide):: n = shape(ab,1)
+    integer intent(in), check(0 <= kl) :: kl = 0
+    integer intent(in), check(0 <= ku) :: ku = 0
+    integer intent(hide), depend(b) :: nrhs = shape(b,1)
+    <ftype2c> intent(in,out,copy), depend(kl,ku), dimension(kl+ku+1,n) :: ab
+    integer intent(hide), depend(a) :: ldab = kl + ku + 1
+    <ftype2c> optional, depend(kl, ku, n), intent(in,out,copy,out=lua), dimension(2*kl + ku + 1, n) :: afb
+    integer intent(hide) depend(kl, ku) :: ldafb = 2*kl + ku + 1
+    integer optional, intent(in,out,copy,out=piv), depend(n), dimension(n) :: ipiv
+    character optional, intent(in,out), check((*equed=='N')||(*equed=='R')||(*equed=='C')||(*equed=='B')) :: equed = 'N'
+    <ftype2> optional, intent(in,out), depend(n), dimension(n) :: r
+    <ftype2> optional, intent(in,out), depend(n), dimension(n) :: c
+    <ftype2c>  intent(in,out), depend(n), dimension(ldb, nrhs) :: b
+    integer intent(hide) :: ldb = max(1, n)
+    <ftype2c> depend(n, nrhs), intent(out), dimension(ldx, nrhs) :: x
+    integer intent(hide) :: ldx = max(1, n)
+    <ftype2> intent(out) :: rcond
+    <ftype2> intent(out), depend(nrhs), dimension(nrhs) :: ferr
+    <ftype2> intent(out), depend(nrhs), dimension(nrhs) :: berr
+    <ftype2c> intent(out), depend(n), dimension(2 * n) :: work
+    <ftype2> intent(hide), depend(n), dimension(n) :: rwork
+    integer intent(out) :: info
+end subroutine <prefix2c>gbsvx
+
+
 subroutine <prefix>gbtrf(m,n,ab,kl,ku,ldab,ipiv,info)
     ! in :Band:dgbtrf.f
     ! lu,ipiv,info = dgbtrf(ab,kl,ku,[m,n,ldab,overwrite_ab])

--- a/scipy/linalg/flapack_gen_banded.pyf.src
+++ b/scipy/linalg/flapack_gen_banded.pyf.src
@@ -40,19 +40,19 @@ subroutine <prefix2>gbsvx(fact,trans,n,kl,ku,nrhs,ab,ldab,afb,ldafb,ipiv,equed,r
     character intent(in), check((*fact=='F')||(*fact=='N')||(*fact=='E')) :: fact = 'N'
     character intent(in), check((*trans=='N')||(*trans=='T')||(*trans=='C')) :: trans = 'N'
     integer depend(ab),intent(hide):: n = shape(ab,1)
-    integer intent(in), check(0 <= kl) :: kl = 0
-    integer intent(in), check(0 <= ku) :: ku = 0
+    integer intent(in), check(0<=kl) :: kl
+    integer intent(in), check(0<=ku) :: ku
     integer intent(hide), depend(b) :: nrhs = shape(b,1)
-    <ftype2> intent(in,out,copy, out=a), dimension(ldab,n) :: ab
-    integer intent(hide), depend(a) :: ldab = kl + ku + 1
-    <ftype2> optional, intent(in,out,copy,out=lu), dimension(2*kl + ku + 1, n) :: afb
-    integer intent(hide) depend(kl, ku) :: ldafb = 2*kl + ku + 1
+    <ftype2> intent(in,out,copy,out=a), dimension(ldab,n), check(kl+ku+1==shape(ab,0)) :: ab
+    integer intent(hide), depend(ab) :: ldab = max(1, shape(ab,0))
+    <ftype2> optional, intent(in,out,copy,out=lu), depend(kl, ku), dimension(2*kl+ku+1,n), check(2*kl+ku+1==shape(afb,0)) :: afb
+    integer intent(hide), depend(afb)  :: ldafb = max(1, shape(afb, 0))
     integer optional, intent(in,out,copy,out=piv), depend(n), dimension(n) :: ipiv
     character optional, intent(in,out), check((*equed=='N')||(*equed=='R')||(*equed=='C')||(*equed=='B')) :: equed = 'N'
     <ftype2> optional, intent(in,out), depend(n), dimension(n) :: r
     <ftype2> optional, intent(in,out), depend(n), dimension(n) :: c
-    <ftype2>  intent(in, out), depend(n), dimension(ldb, nrhs) :: b
-    integer intent(hide) :: ldb = max(1, n)
+    <ftype2>  intent(in,out), depend(n), dimension(ldb, nrhs), check(n==shape(b, 0)) :: b
+    integer intent(hide) :: ldb = max(1, shape(b, 0))
     <ftype2> depend(n, nrhs), intent(out), dimension(ldx, nrhs) :: x
     integer intent(hide) :: ldx = max(1, n)
     <ftype2> intent(out) :: rcond
@@ -80,19 +80,19 @@ subroutine <prefix2c>gbsvx(fact,trans,n,kl,ku,nrhs,ab,ldab,afb,ldafb,ipiv,equed,
     character intent(in), check((*trans=='N')||(*trans=='T')||(*trans=='C')) :: trans = 'N'
 
     integer depend(ab),intent(hide):: n = shape(ab,1)
-    integer intent(in), check(0 <= kl) :: kl = 0
-    integer intent(in), check(0 <= ku) :: ku = 0
+    integer intent(in), check(0<=kl) :: kl
+    integer intent(in), check(0<=ku) :: ku
     integer intent(hide), depend(b) :: nrhs = shape(b,1)
-    <ftype2c> intent(in,out,copy), depend(kl,ku), dimension(kl+ku+1,n) :: ab
-    integer intent(hide), depend(a) :: ldab = kl + ku + 1
-    <ftype2c> optional, depend(kl, ku, n), intent(in,out,copy,out=lua), dimension(2*kl + ku + 1, n) :: afb
-    integer intent(hide) depend(kl, ku) :: ldafb = 2*kl + ku + 1
+    <ftype2c> intent(in,out,copy,out=a), dimension(ldab,n), check(kl+ku+1==shape(ab,0)) :: ab
+    integer intent(hide), depend(ab) :: ldab = max(1, shape(ab,0))
+    <ftype2c> optional, intent(in,out,copy,out=lu), depend(kl, ku), dimension(2*kl+ku+1,n), check(2*kl+ku+1==shape(afb,0)) :: afb
+    integer intent(hide), depend(afb)  :: ldafb = max(1, shape(afb, 0))
     integer optional, intent(in,out,copy,out=piv), depend(n), dimension(n) :: ipiv
     character optional, intent(in,out), check((*equed=='N')||(*equed=='R')||(*equed=='C')||(*equed=='B')) :: equed = 'N'
     <ftype2> optional, intent(in,out), depend(n), dimension(n) :: r
     <ftype2> optional, intent(in,out), depend(n), dimension(n) :: c
-    <ftype2c>  intent(in,out), depend(n), dimension(ldb, nrhs) :: b
-    integer intent(hide) :: ldb = max(1, n)
+    <ftype2c>  intent(in,out), depend(n), dimension(ldb, nrhs), check(n==shape(b, 0)) :: b
+    integer intent(hide) :: ldb = max(1, shape(b, 0))
     <ftype2c> depend(n, nrhs), intent(out), dimension(ldx, nrhs) :: x
     integer intent(hide) :: ldx = max(1, n)
     <ftype2> intent(out) :: rcond

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -53,6 +53,11 @@ All functions
    cgbsv
    zgbsv
 
+   sgbsvx
+   dgbsvx
+   cgbsvx
+   zgbsvx
+
    sgbtrf
    dgbtrf
    cgbtrf

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -732,6 +732,11 @@ class TestGbsvx:
         else:
             assert_allclose(b, A.conj().T @ actual.x, atol=atol)
 
+        # Now that we know the calls work correctly check if invalid shapes
+        # fail by raising an exception rather than seg faulting.
+        assert_raises(Exception, gbsvx, kl, ku, ab[:-1], b, fact, trans)
+        assert_raises(Exception, gbsvx, kl, ku, ab, b[:-1], fact, trans)
+
     @pytest.mark.parametrize('dtype', DTYPES)
     @pytest.mark.parametrize('equed', ('R', 'C', 'B'))
     @pytest.mark.parametrize('trans', ('N', 'T', 'C'))
@@ -798,7 +803,20 @@ class TestGbsvx:
         else:
             assert_allclose(b, A.conj().T @ actual.x, atol=atol)
 
-
+        # Now that we know the calls work correctly check if invalid shapes
+        # fail by raising an exception rather than seg faulting.
+        assert_raises(Exception, gbsvx, kl, ku, ab[:-1], b, 'F',
+                      trans, afb, ipiv, equed, r, c)
+        assert_raises(Exception, gbsvx, kl, ku, ab, b[:-1], 'F',
+                      trans, afb, ipiv, equed, r, c)
+        assert_raises(Exception, gbsvx, kl, ku, ab, b, 'F',
+                      trans, afb[:-1], ipiv, equed, r, c)
+        assert_raises(Exception, gbsvx, kl, ku, ab, b, 'F',
+                      trans, afb, ipiv[:-1], equed, r, c)
+        assert_raises(Exception, gbsvx, kl, ku, ab, b, 'F',
+                      trans, afb, ipiv, equed, r[:-1], c)
+        assert_raises(Exception, gbsvx, kl, ku, ab, b, 'F',
+                      trans, afb, ipiv, equed, r, c[:-1])
 
 
 def test_lartg():

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -689,14 +689,13 @@ class TestGbsvx:
         gbsvx = get_lapack_funcs('gbsvx', dtype=ab.dtype)
         assert_raises(Exception, gbsvx, ab=ab, b=b, **kwargs)
 
-
     @pytest.mark.parametrize('dtype', DTYPES)
     @pytest.mark.parametrize('fact', ('N', 'E'))
     @pytest.mark.parametrize('trans', ('N', 'T', 'C'))
     def test_random_non_equilibrated (self, dtype, fact, trans):
         seed(1724)
         atol = 100 * np.finfo(dtype).eps
-        m, n = 6, 6
+        m, n, nrhs = 6, 6, 6
         kl, ku = 2, 1
         gbsvx = get_lapack_funcs('gbsvx', dtype=dtype)
 
@@ -707,7 +706,7 @@ class TestGbsvx:
         A = sps.dia_matrix(A)
 
         ab = np.flipud(A.data)
-        x = generate_random_dtype_array((n, n), dtype)
+        x = generate_random_dtype_array((n, nrhs), dtype)
         b = A@x
 
         actual = self.Actual(*gbsvx(ab=ab,

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -734,7 +734,8 @@ class TestGbsvx:
 
     @pytest.mark.parametrize('dtype', DTYPES)
     @pytest.mark.parametrize('equed', ('R', 'C', 'B'))
-    def test_random_equilibrated(self, dtype, equed):
+    @pytest.mark.parametrize('trans', ('N', 'T', 'C'))
+    def test_random_equilibrated(self, dtype, equed, trans):
         seed(1724)
         atol = 100 * np.finfo(dtype).eps
         m, n, nrhs = 6, 6, 4
@@ -790,7 +791,12 @@ class TestGbsvx:
 
         # Compare the solution using the calculated solution `x`
         # to the pre-calculated solution
-        assert_allclose(b, A @ actual.x, atol=atol)
+        if trans == 'N':
+            assert_allclose(b, A @ actual.x, atol=atol)
+        elif trans == 'T':
+            assert_allclose(b, A.T @ actual.x, atol=atol)
+        else:
+            assert_allclose(b, A.conj().T @ actual.x, atol=atol)
 
 
 

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -770,10 +770,6 @@ class TestGbsvx:
         afb[kl:] = np.flipud(A.data)
         afb, ipiv, info = gbtrf(afb, kl, ku)
 
-        # FIXME: Increment needs to be implemented at the wrapper level
-        for i in range(len(ipiv)):
-            ipiv[i] += 1
-
         result = gbsvx(kl, ku, ab, b, 2, trans, afb, ipiv, equed, r, c)
         actual = self.Actual(*result)
 

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -6,6 +6,7 @@ import sys
 import subprocess
 import time
 from functools import reduce
+from collections import namedtuple
 
 from numpy.testing import (assert_equal, assert_array_almost_equal, assert_,
                            assert_allclose, assert_almost_equal,
@@ -636,6 +637,9 @@ class TestTbtrs(object):
 
 class TestGbsvx:
 
+    fields = 'ab afb ipiv equed r c b x rcond ferr berr work info'.split()
+    Actual = namedtuple('Actual', fields)
+
     def test_nag_f07bbf(self):
         ab = np.array(((0, 0, -3.66, -2.13),
                        (0, 2.54, -2.73, 4.07),
@@ -651,14 +655,15 @@ class TestGbsvx:
                             (-4.0, -2.0)))
         kl, ku = 1, 2
         gbsvx = get_lapack_funcs('gbsvx', dtype=ab.dtype)
-        ab, afb, ipiv, equed, r, c, b, x, rcond, ferr, berr, work, info = gbsvx(ab=ab, kl=kl, ku=ku, b=b)
-        assert_equal(info, 0)
-        assert_allclose(x, desired)
+        actual = self.Actual(*gbsvx(ab=ab, kl=kl, ku=ku, b=b))
+        assert_equal(actual.info, 0)
+        assert_allclose(actual.x, desired)
 
     def test_nag_f07bpfe(self):
         ab =  np.array(((0, 0, 0.97 - 2.84j, 0.59 - 0.48j),
                         (0, -2.05 - 0.85j, -3.99 + 4.01j, 3.33 - 1.04j),
-                        (-1.65 + 2.26j, -1.48 - 1.75j, -1.06 + 1.94j, -0.46 + -1.72j),
+                        (-1.65 + 2.26j, -1.48 - 1.75j,
+                         -1.06 + 1.94j, -0.46 -1.72j),
                         (6.30j, -0.77 + 2.83j, 4.48 - 1.09j, 0)))
         b =  np.array(((-1.06 + 21.50j, 12.85 + 2.84j),
                        (-22.72 - 53.90j, -70.22 + 21.57j),
@@ -670,9 +675,9 @@ class TestGbsvx:
                             (6.0 - 8.0j, -8.0 + 2.0j)))
         kl, ku = 1, 2
         gbsvx = get_lapack_funcs('gbsvx', dtype=ab.dtype)
-        ab, afb, ipiv, equed, r, c, b, x, rcond, ferr, berr, work, info = gbsvx(ab=ab, kl=kl, ku=ku, b=b)
-        assert_equal(info, 0)
-        assert_allclose(x, desired)
+        actual = self.Actual(*gbsvx(ab=ab, kl=kl, ku=ku, b=b))
+        assert_equal(actual.info, 0)
+        assert_allclose(actual.x, desired)
 
     @pytest.mark.parametrize('dtype', DTYPES)
     @pytest.mark.parametrize('kwargs', ({'fact': 'A'}, {'trans': 'A'},

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -645,9 +645,9 @@ class TestGbsvx:
                        (0, 2.54, -2.73, 4.07),
                        (-0.23, 2.46, 2.46, -3.82),
                        (-6.98, 2.56, -4.78, 0)))
-        b = np.array((( 4.42, -36.01),
+        b = np.array(((4.42, -36.01),
                       (27.13, -31.67),
-                      (-6.14,  -1.16),
+                      (-6.14, -1.16),
                       (10.50, -25.82)))
         desired = np.array(((-2.0, 1),
                             (3.0, -4.0),
@@ -660,15 +660,15 @@ class TestGbsvx:
         assert_allclose(actual.x, desired)
 
     def test_nag_f07bpfe(self):
-        ab =  np.array(((0, 0, 0.97 - 2.84j, 0.59 - 0.48j),
-                        (0, -2.05 - 0.85j, -3.99 + 4.01j, 3.33 - 1.04j),
-                        (-1.65 + 2.26j, -1.48 - 1.75j,
-                         -1.06 + 1.94j, -0.46 -1.72j),
-                        (6.30j, -0.77 + 2.83j, 4.48 - 1.09j, 0)))
-        b =  np.array(((-1.06 + 21.50j, 12.85 + 2.84j),
-                       (-22.72 - 53.90j, -70.22 + 21.57j),
-                       ( 28.24 - 38.60j, -20.73 - 1.23j),
-                       (-34.56 + 16.73j, 26.01 + 31.97j)))
+        ab = np.array(((0, 0, 0.97 - 2.84j, 0.59 - 0.48j),
+                       (0, -2.05 - 0.85j, -3.99 + 4.01j, 3.33 - 1.04j),
+                       (-1.65 + 2.26j, -1.48 - 1.75j,
+                        -1.06 + 1.94j, -0.46 - 1.72j),
+                       (6.30j, -0.77 + 2.83j, 4.48 - 1.09j, 0)))
+        b = np.array(((-1.06 + 21.50j, 12.85 + 2.84j),
+                      (-22.72 - 53.90j, -70.22 + 21.57j),
+                      (28.24 - 38.60j, -20.73 - 1.23j),
+                      (-34.56 + 16.73j, 26.01 + 31.97j)))
         desired = np.array(((-3.0 + 2.0j, 1.0 + 6.0j),
                             (1.0 - 7.0j, -7.0 - 4.0j),
                             (-5.0 + 4.0j, 3.0 + 5.0j),
@@ -692,7 +692,7 @@ class TestGbsvx:
     @pytest.mark.parametrize('dtype', DTYPES)
     @pytest.mark.parametrize('fact', ('N', 'E'))
     @pytest.mark.parametrize('trans', ('N', 'T', 'C'))
-    def test_random_non_equilibrated (self, dtype, fact, trans):
+    def test_random_non_equilibrated(self, dtype, fact, trans):
         seed(1724)
         atol = 100 * np.finfo(dtype).eps
         m, n, nrhs = 6, 6, 4

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -634,6 +634,57 @@ class TestTbtrs(object):
         assert_raises(Exception, tbtrs, ab, b)
 
 
+class TestGbsvx:
+
+    def test_nag_f07bbf(self):
+        ab = np.array(((0, 0, -3.66, -2.13),
+                       (0, 2.54, -2.73, 4.07),
+                       (-0.23, 2.46, 2.46, -3.82),
+                       (-6.98, 2.56, -4.78, 0)))
+        b = np.array((( 4.42, -36.01),
+                      (27.13, -31.67),
+                      (-6.14,  -1.16),
+                      (10.50, -25.82)))
+        desired = np.array(((-2.0, 1),
+                            (3.0, -4.0),
+                            (1.0, 7.0),
+                            (-4.0, -2.0)))
+        kl, ku = 1, 2
+        gbsvx = get_lapack_funcs('gbsvx', dtype=ab.dtype)
+        ab, afb, ipiv, equed, r, c, b, x, rcond, ferr, berr, work, info = gbsvx(ab=ab, kl=kl, ku=ku, b=b)
+        assert_equal(info, 0)
+        assert_allclose(x, desired)
+
+    def test_nag_f07bpfe(self):
+        ab =  np.array(((0, 0, 0.97 - 2.84j, 0.59 - 0.48j),
+                        (0, -2.05 - 0.85j, -3.99 + 4.01j, 3.33 - 1.04j),
+                        (-1.65 + 2.26j, -1.48 - 1.75j, -1.06 + 1.94j, -0.46 + -1.72j),
+                        (6.30j, -0.77 + 2.83j, 4.48 - 1.09j, 0)))
+        b =  np.array(((-1.06 + 21.50j, 12.85 + 2.84j),
+                       (-22.72 - 53.90j, -70.22 + 21.57j),
+                       ( 28.24 - 38.60j, -20.73 - 1.23j),
+                       (-34.56 + 16.73j, 26.01 + 31.97j)))
+        desired = np.array(((-3.0 + 2.0j, 1.0 + 6.0j),
+                            (1.0 - 7.0j, -7.0 - 4.0j),
+                            (-5.0 + 4.0j, 3.0 + 5.0j),
+                            (6.0 - 8.0j, -8.0 + 2.0j)))
+        kl, ku = 1, 2
+        gbsvx = get_lapack_funcs('gbsvx', dtype=ab.dtype)
+        ab, afb, ipiv, equed, r, c, b, x, rcond, ferr, berr, work, info = gbsvx(ab=ab, kl=kl, ku=ku, b=b)
+        assert_equal(info, 0)
+        assert_allclose(x, desired)
+
+    @pytest.mark.parametrize('dtype', DTYPES)
+    @pytest.mark.parametrize('kwargs', ({'fact': 'A'}, {'trans': 'A'},
+                                        {'equed': 'A'},
+                                        {'kl': -1}, {'ku': -1}))
+    def test_invalid_variables(self, dtype, kwargs):
+        ab = np.ones((1, 1))
+        b = np.ones((1, 1))
+        gbsvx = get_lapack_funcs('gbsvx', dtype=ab.dtype)
+        assert_raises(Exception, gbsvx, ab=ab, b=b, **kwargs)
+
+
 def test_lartg():
     for dtype in 'fdFD':
         lartg = get_lapack_funcs('lartg', dtype=dtype)

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -699,15 +699,15 @@ class TestGbsvx:
         kl, ku = 2, 1
         gbsvx = get_lapack_funcs('gbsvx', dtype=dtype)
 
-        # Generate the random m x n banded matrix `A` and convert it
-        # to band storage
+        # Generate ``A``, ``x`` s.t. Ax = b is a linear system of equations
         A = generate_random_dtype_array((m, n), dtype)
+        x = generate_random_dtype_array((n, nrhs), dtype)
+        b = A @ x
+
+        # Convert the matrix A into banded storage
         A = np.triu(np.tril(A, k=ku), k=-kl)
         A = sps.dia_matrix(A)
-
         ab = np.flipud(A.data)
-        x = generate_random_dtype_array((n, nrhs), dtype)
-        b = A@x
 
         actual = self.Actual(*gbsvx(ab=ab,
                                     kl=kl,
@@ -723,7 +723,7 @@ class TestGbsvx:
         assert_equal(actual.berr.shape, (nrhs,))
         assert_equal(actual.afb.shape, (2 * kl + ku + 1, n))
 
-        # Compare the solution using the calculated solution `x_`
+        # Compare the solution using the calculated solution `x`
         # to the pre-calculated solution
         if trans == 'N':
             assert_allclose(b, A@actual.x, atol=atol)

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -709,12 +709,7 @@ class TestGbsvx:
         A = sps.dia_matrix(A)
         ab = np.flipud(A.data)
 
-        actual = self.Actual(*gbsvx(ab=ab,
-                                    kl=kl,
-                                    ku=ku,
-                                    b=b,
-                                    fact=fact,
-                                    trans=trans))
+        actual = self.Actual(*gbsvx(kl, ku, ab, b, fact, trans))
 
         assert_equal(actual.info, 0)
         assert np.count_nonzero(actual.afb)
@@ -777,17 +772,8 @@ class TestGbsvx:
         for i in range(len(ipiv)):
             ipiv[i] += 1
 
-        actual = self.Actual(*gbsvx(ab=ab,
-                                    afb=afb,
-                                    kl=kl,
-                                    ku=ku,
-                                    b=b,
-                                    r=r,
-                                    c=c,
-                                    ipiv=ipiv,
-                                    fact='F',
-                                    equed=equed,
-                                    trans=trans))
+        result = gbsvx(kl, ku, ab, b, 'F', trans, afb, ipiv, equed, r, c)
+        actual = self.Actual(*result)
 
         assert_equal(actual.info, 0)
         assert np.isscalar(actual.rcond)

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -680,9 +680,11 @@ class TestGbsvx:
         assert_allclose(actual.x, desired)
 
     @pytest.mark.parametrize('dtype', DTYPES)
-    @pytest.mark.parametrize('kwargs', ({'fact': 'A'}, {'trans': 'A'},
+    @pytest.mark.parametrize('kwargs', ({'fact': 999},
+                                        {'trans': 999},
                                         {'equed': 'A'},
-                                        {'kl': -1}, {'ku': -1}))
+                                        {'kl': -1},
+                                        {'ku': -1}))
     def test_invalid_variables(self, dtype, kwargs):
         ab = np.ones((1, 1))
         b = np.ones((1, 1))
@@ -690,8 +692,8 @@ class TestGbsvx:
         assert_raises(Exception, gbsvx, ab=ab, b=b, **kwargs)
 
     @pytest.mark.parametrize('dtype', DTYPES)
-    @pytest.mark.parametrize('fact', ('N', 'E'))
-    @pytest.mark.parametrize('trans', ('N', 'T', 'C'))
+    @pytest.mark.parametrize('fact', (0, 1))
+    @pytest.mark.parametrize('trans', (0, 1, 2))
     def test_random_non_equilibrated(self, dtype, fact, trans):
         seed(1724)
         atol = 100 * np.finfo(dtype).eps
@@ -720,9 +722,9 @@ class TestGbsvx:
 
         # Compare the solution using the calculated solution `x`
         # to the pre-calculated solution
-        if trans == 'N':
+        if trans == 0:
             assert_allclose(b, A@actual.x, atol=atol)
-        elif trans == 'T':
+        elif trans == 1:
             assert_allclose(b, A.T @ actual.x, atol=atol)
         else:
             assert_allclose(b, A.conj().T @ actual.x, atol=atol)
@@ -734,7 +736,7 @@ class TestGbsvx:
 
     @pytest.mark.parametrize('dtype', DTYPES)
     @pytest.mark.parametrize('equed', ('R', 'C', 'B'))
-    @pytest.mark.parametrize('trans', ('N', 'T', 'C'))
+    @pytest.mark.parametrize('trans', (0, 1, 2))
     def test_random_equilibrated(self, dtype, equed, trans):
         seed(1724)
         atol = 100 * np.finfo(dtype).eps
@@ -772,7 +774,7 @@ class TestGbsvx:
         for i in range(len(ipiv)):
             ipiv[i] += 1
 
-        result = gbsvx(kl, ku, ab, b, 'F', trans, afb, ipiv, equed, r, c)
+        result = gbsvx(kl, ku, ab, b, 2, trans, afb, ipiv, equed, r, c)
         actual = self.Actual(*result)
 
         assert_equal(actual.info, 0)
@@ -782,26 +784,26 @@ class TestGbsvx:
 
         # Compare the solution using the calculated solution `x`
         # to the pre-calculated solution
-        if trans == 'N':
+        if trans == 0:
             assert_allclose(b, A @ actual.x, atol=atol)
-        elif trans == 'T':
+        elif trans == 1:
             assert_allclose(b, A.T @ actual.x, atol=atol)
         else:
             assert_allclose(b, A.conj().T @ actual.x, atol=atol)
 
         # Now that we know the calls work correctly check if invalid shapes
         # fail by raising an exception rather than seg faulting.
-        assert_raises(Exception, gbsvx, kl, ku, ab[:-1], b, 'F',
+        assert_raises(Exception, gbsvx, kl, ku, ab[:-1], b, 2,
                       trans, afb, ipiv, equed, r, c)
-        assert_raises(Exception, gbsvx, kl, ku, ab, b[:-1], 'F',
+        assert_raises(Exception, gbsvx, kl, ku, ab, b[:-1], 2,
                       trans, afb, ipiv, equed, r, c)
-        assert_raises(Exception, gbsvx, kl, ku, ab, b, 'F',
+        assert_raises(Exception, gbsvx, kl, ku, ab, b, 2,
                       trans, afb[:-1], ipiv, equed, r, c)
-        assert_raises(Exception, gbsvx, kl, ku, ab, b, 'F',
+        assert_raises(Exception, gbsvx, kl, ku, ab, b, 2,
                       trans, afb, ipiv[:-1], equed, r, c)
-        assert_raises(Exception, gbsvx, kl, ku, ab, b, 'F',
+        assert_raises(Exception, gbsvx, kl, ku, ab, b, 2,
                       trans, afb, ipiv, equed, r[:-1], c)
-        assert_raises(Exception, gbsvx, kl, ku, ab, b, 'F',
+        assert_raises(Exception, gbsvx, kl, ku, ab, b, 2,
                       trans, afb, ipiv, equed, r, c[:-1])
 
 

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -695,7 +695,7 @@ class TestGbsvx:
     def test_random_non_equilibrated (self, dtype, fact, trans):
         seed(1724)
         atol = 100 * np.finfo(dtype).eps
-        m, n, nrhs = 6, 6, 6
+        m, n, nrhs = 6, 6, 4
         kl, ku = 2, 1
         gbsvx = get_lapack_funcs('gbsvx', dtype=dtype)
 
@@ -718,6 +718,10 @@ class TestGbsvx:
 
         assert_equal(actual.info, 0)
         assert np.count_nonzero(actual.afb)
+        assert np.isscalar(actual.rcond)
+        assert_equal(actual.ferr.shape, (nrhs,))
+        assert_equal(actual.berr.shape, (nrhs,))
+        assert_equal(actual.afb.shape, (2 * kl + ku + 1, n))
 
         # Compare the solution using the calculated solution `x_`
         # to the pre-calculated solution


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
This closes #11615

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR creates Python level wrappers for the LAPACK functions ?gbsvx and adds appropriate unit tests as discussed in #11615.  There are still minor adjustments required but it should be ready for a broad review, these include:

- [x] change option arguments from characters to integers
- [x] pre/post increment ``ipiv`` in the wrapper
- [x] test with incompatible and incorrect array sizes 

#### Additional information
<!--Any additional information you think is important.-->
These wrappers are from Lapack versions greater than the minimum version so some unit tests will fail and  this PR should not be merged until the LAPACK version is bumped up.