### PR TITLE
DOC: Remove misleading default values from fit method

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -102,6 +102,8 @@ entropy(%(shapes)s, loc=0, scale=1)
 _doc_fit = """\
 fit(data)
     Parameter estimates for generic data.
+    See [`scipy.stats.rv_continuous.fit`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.rv_continuous.fit.html#scipy.stats.rv_continuous.fit) for detailed documentation of the
+    keyword arguments.
 """
 _doc_expect = """\
 expect(func, args=(%(shapes_)s), loc=0, scale=1, lb=None, ub=None, conditional=False, **kwds)

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -2187,22 +2187,20 @@ class rv_continuous(rv_generic):
         ----------
         data : array_like
             Data to use in calculating the MLEs.
-        args : floats, optional
+        arg1, arg2, arg3,... : floats, optional
             Starting value(s) for any shape-characterizing arguments (those not
             provided will be determined by a call to ``_fitstart(data)``).
             No default value.
         kwds : floats, optional
-            - shape: Estimated from ``self._fitstart(data)`` by default.
-            - `loc`: initial guess of the distribution's location parameter. 
-            based on the `shape` parameter, by default.
-            - scale: Estimated from ``self._fit_loc_scale_support(data)``
-            based on the `shape` parameter, by default.
+            - `loc`: initial guess of the distribution's location parameter.
+            - `scale`: initial guess of the distribution's scale parameter.
+
             Special keyword arguments are recognized as holding certain
             parameters fixed:
 
             - f0...fn : hold respective shape parameters fixed.
               Alternatively, shape parameters to fix can be specified by name.
-              For example, if ``self.shapes == "a, b"``, ``fa``and ``fix_a``
+              For example, if ``self.shapes == "a, b"``, ``fa`` and ``fix_a``
               are equivalent to ``f0``, and ``fb`` and ``fix_b`` are
               equivalent to ``f1``.
 

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -2192,7 +2192,11 @@ class rv_continuous(rv_generic):
             provided will be determined by a call to ``_fitstart(data)``).
             No default value.
         kwds : floats, optional
-            Starting values for the location and scale parameters; no default.
+            - shape: Estimated from ``self._fitstart(data)`` by default.
+            - loc: Estimated from ``self._fit_loc_scale_support(data)``
+            based on the `shape` parameter, by default.
+            - scale: Estimated from ``self._fit_loc_scale_support(data)``
+            based on the `shape` parameter, by default.
             Special keyword arguments are recognized as holding certain
             parameters fixed:
 

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -100,7 +100,7 @@ entropy(%(shapes)s, loc=0, scale=1)
     (Differential) entropy of the RV.
 """
 _doc_fit = """\
-fit(data, %(shapes)s, loc=0, scale=1)
+fit(data, %(shapes)s, loc, scale)
     Parameter estimates for generic data.
 """
 _doc_expect = """\

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -100,7 +100,7 @@ entropy(%(shapes)s, loc=0, scale=1)
     (Differential) entropy of the RV.
 """
 _doc_fit = """\
-fit(data, %(shapes)s)
+fit(data)
     Parameter estimates for generic data.
 """
 _doc_expect = """\
@@ -2193,7 +2193,7 @@ class rv_continuous(rv_generic):
             No default value.
         kwds : floats, optional
             - shape: Estimated from ``self._fitstart(data)`` by default.
-            - loc: Estimated from ``self._fit_loc_scale_support(data)``
+            - `loc`: initial guess of the distribution's location parameter. 
             based on the `shape` parameter, by default.
             - scale: Estimated from ``self._fit_loc_scale_support(data)``
             based on the `shape` parameter, by default.

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -100,7 +100,7 @@ entropy(%(shapes)s, loc=0, scale=1)
     (Differential) entropy of the RV.
 """
 _doc_fit = """\
-fit(data, %(shapes)s, loc, scale)
+fit(data, %(shapes)s)
     Parameter estimates for generic data.
 """
 _doc_expect = """\

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -102,7 +102,7 @@ entropy(%(shapes)s, loc=0, scale=1)
 _doc_fit = """\
 fit(data)
     Parameter estimates for generic data.
-    See [`scipy.stats.rv_continuous.fit`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.rv_continuous.fit.html#scipy.stats.rv_continuous.fit) for detailed documentation of the
+    See `scipy.stats.rv_continuous.fit <https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.rv_continuous.fit.html#scipy.stats.rv_continuous.fit>`__ for detailed documentation of the
     keyword arguments.
 """
 _doc_expect = """\


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #11856 

#### What does this implement/fix?
<!--Please explain your changes.-->
Fixes misleading default value in documentation of `fit` method

#### Additional information
<!--Any additional information you think is important.-->
The `fit` method parameters are estimated by default but not mentioned even in the detailed docs, where should that be mentioned?
It is mentioned as no defaults in https://github.com/scipy/scipy/blob/4774d47f38fa2a3d708132c92f55df761f11f90e/scipy/stats/_distn_infrastructure.py#L2194-L2195
But no mention of estimation in
https://github.com/scipy/scipy/blob/4774d47f38fa2a3d708132c92f55df761f11f90e/scipy/stats/_distn_infrastructure.py#L2172-L2268