### PR TITLE
MAINT: LinearVectorFunction.J is ndarray closes #11886

### DIFF
--- a/scipy/optimize/_differentiable_functions.py
+++ b/scipy/optimize/_differentiable_functions.py
@@ -478,7 +478,8 @@ class LinearVectorFunction(object):
             self.J = A.toarray()
             self.sparse_jacobian = False
         else:
-            self.J = np.atleast_2d(A)
+            # np.asarray makes sure A is ndarray and not matrix
+            self.J = np.atleast_2d(np.asarray(A))
             self.sparse_jacobian = False
 
         self.m, self.n = self.J.shape

--- a/scipy/optimize/tests/test_minimize_constrained.py
+++ b/scipy/optimize/tests/test_minimize_constrained.py
@@ -672,8 +672,8 @@ def test_bug_11886():
     def opt(x):
         return x[0]**2+x[1]**2
 
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
+    with np.testing.suppress_warnings() as sup:
+        sup.filter(PendingDeprecationWarning)
         A = np.matrix(np.diag([1, 1]))
     lin_cons = LinearConstraint(A, -1, np.inf)
     minimize(opt, 2*[1], constraints = lin_cons)

--- a/scipy/optimize/tests/test_minimize_constrained.py
+++ b/scipy/optimize/tests/test_minimize_constrained.py
@@ -1,3 +1,4 @@
+import warnings
 import numpy as np
 import pytest
 from scipy.linalg import block_diag
@@ -665,3 +666,14 @@ class TestEmptyConstraint(TestCase):
         )
 
         assert_array_almost_equal(abs(result.x), np.array([1, 0]), decimal=4)
+
+
+def test_bug_11886():
+    def opt(x):
+        return x[0]**2+x[1]**2
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        A = np.matrix(np.diag([1, 1]))
+    lin_cons = LinearConstraint(A, -1, np.inf)
+    minimize(opt, 2*[1], constraints = lin_cons)

--- a/scipy/optimize/tests/test_minimize_constrained.py
+++ b/scipy/optimize/tests/test_minimize_constrained.py
@@ -676,4 +676,4 @@ def test_bug_11886():
         sup.filter(PendingDeprecationWarning)
         A = np.matrix(np.diag([1, 1]))
     lin_cons = LinearConstraint(A, -1, np.inf)
-    minimize(opt, 2*[1], constraints = lin_cons)
+    minimize(opt, 2*[1], constraints = lin_cons)  # just checking that there are no errors


### PR DESCRIPTION
@mdhaber.

Makes sure `LinearVectorFunction.J` is an `np.ndarray`. Full explanation is in #11886.