### PR TITLE
Added sparse nonzero functionality to min, max, argmin, argmax

### DIFF
--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -3356,6 +3356,121 @@ class _TestMinMax(object):
             assert_raises(ValueError, mat.argmax, axis=axis)
             assert_raises(ValueError, mat.argmin, axis=axis)
 
+    def test_minmax_explicit_axis(self):
+        axes_even = [0, -2]
+        axes_odd = [1, -1]
+
+        # Partial matrix
+        D = matrix(np.arange(50).reshape(5, 10))
+        # completely empty rows, leaving some completely full:
+        D[1, :] = 0
+        # empty at end for reduceat:
+        D[:, 9] = 0
+        # partial rows/cols:
+        D[3, 3] = 0
+        # entries on either side of 0:
+        D[2, 2] = -1
+        # Create the matrix
+        X = self.spmatrix(D)
+
+        for axis in axes_even:
+            assert_array_equal(X.max(axis=axis, explicit=True).A.flatten(),
+                               np.array([40, 41, 42, 43, 44, 45, 46, 47, 48, 0]))
+
+            if np.any(X.data == 0):
+                # Noncanonical case
+                assert_array_equal(X.min(axis=axis, explicit=True).A.flatten(),
+                                   np.array([20, 1, -1, 3, 4, 5, 0, 7, 8, 0]))
+            else:
+                # Canonical case.
+                assert_array_equal(X.min(axis=axis, explicit=True).A.flatten(),
+                                   np.array([20, 1, -1, 3, 4, 5, 6, 7, 8, 0]))
+
+        for axis in axes_odd:
+            assert_array_equal(X.max(axis=axis, explicit=True).A.flatten(),
+                               np.array([8, 0, 28, 38, 48]))
+            assert_array_equal(X.min(axis=axis, explicit=True).A.flatten(),
+                               np.array([1, 0, -1, 30, 40]))
+
+        # full matrix
+        D = matrix(np.arange(1, 51).reshape(10, 5))
+        X = self.spmatrix(D)
+
+        for axis in axes_even:
+            assert_array_equal(X.max(axis=axis, explicit=True).A.flatten(),
+                               np.array([46, 47, 48, 49, 50]))
+            assert_array_equal(X.min(axis=axis, explicit=True).A.flatten(),
+                               np.array([1, 2, 3, 4, 5]))
+
+        for axis in axes_odd:
+            assert_array_equal(X.max(axis=axis, explicit=True).A.flatten(),
+                               np.array([5, 10, 15, 20, 25, 30, 35, 40, 45, 50]))
+            assert_array_equal(X.min(axis=axis, explicit=True).A.flatten(),
+                               np.array([1, 6, 11, 16, 21, 26, 31, 36, 41, 46]))
+
+        # empty matrix
+        D = matrix(np.zeros((10, 5)))
+        X = self.spmatrix(D)
+
+        for axis in axes_even:
+            assert_array_equal(X.max(axis=axis, explicit=True).A.flatten(), np.zeros(5))
+            assert_array_equal(X.min(axis=axis, explicit=True).A.flatten(), np.zeros(5))
+
+        for axis in axes_odd:
+            assert_array_equal(X.max(axis=axis, explicit=True).A.flatten(), np.zeros(10))
+            assert_array_equal(X.min(axis=axis, explicit=True).A.flatten(), np.zeros(10))
+
+        # zero-size matrices
+        D = np.zeros((0, 10))
+        X = self.spmatrix(D)
+        for axis in axes_even:
+            assert_raises(ValueError, X.min, axis=axis, explicit=True)
+            assert_raises(ValueError, X.max, axis=axis, explicit=True)
+        for axis in axes_odd:
+            assert_array_equal(np.zeros((0, 1)), X.min(axis=axis, explicit=True).A)
+            assert_array_equal(np.zeros((0, 1)), X.max(axis=axis, explicit=True).A)
+
+        D = np.zeros((10, 0))
+        X = self.spmatrix(D)
+        for axis in axes_odd:
+            assert_raises(ValueError, X.min, axis=axis, explicit=True)
+            assert_raises(ValueError, X.max, axis=axis, explicit=True)
+        for axis in axes_even:
+            assert_array_equal(np.zeros((1, 0)), X.min(axis=axis, explicit=True).A)
+            assert_array_equal(np.zeros((1, 0)), X.max(axis=axis, explicit=True).A)
+
+    def test_argmax_explicit(self):
+        D1 = np.array([[-1, 5, 2, 3],
+                       [0, 0, -1, -2],
+                       [-1, -2, -3, -4],
+                       [1, 2, 3, 4],
+                       [1, 2, 0, 0]])
+
+        mat = csr_matrix(D1)
+
+        assert_equal(mat.argmax(axis=0, explicit=True).A.flatten(),
+                     np.array([3, 0, 3, 3]))
+        assert_equal(mat.argmin(axis=0, explicit=True).A.flatten(),
+                     np.array([0, 2, 2, 2]))
+
+        assert_equal(mat.argmax(axis=1, explicit=True).A.flatten(),
+                     np.array([1, 2, 0, 3, 1]))
+        assert_equal(mat.argmin(axis=1, explicit=True).A.flatten(),
+                     np.array([0, 3, 3, 0, 0]))
+
+        D1 = np.empty((0, 5))
+        D2 = np.empty((5, 0))
+
+        for axis in [None, 0]:
+            mat = self.spmatrix(D1)
+            assert_raises(ValueError, mat.argmax, axis=axis, explicit=True)
+            assert_raises(ValueError, mat.argmin, axis=axis, explicit=True)
+
+        for axis in [None, 1]:
+            mat = self.spmatrix(D2)
+            assert_raises(ValueError, mat.argmax, axis=axis, explicit=True)
+            assert_raises(ValueError, mat.argmin, axis=axis, explicit=True)
+
 
 class _TestGetNnzAxis(object):
     def test_getnnz_axis(self):


### PR DESCRIPTION
Added nonzero parsing functionality into sparse matrix min, max, argmin, and argmax functions.

#### What does this implement/fix?
This allows a user to selectively consider only the nonzero values in the sparse min, max, argmin, and argmax functions. A programmer will often use a sparse matrix when zeros do not matter. Previous to this change, the programmer will have needed to mathematically manipulate the sparse matrix so that these functions gave the correct result when considering nonzero values. By passing in the nonzero keyword, these functions are now able to consider only nonzero values within the matrix. The change defaults to the existing functionality and only activates these changes if the user activates the input keyword.

This issue exists in several of my existing programs. As a benchmark, this implementation improves performance between 1.15x and 1.35x compared to manipulating the sparse matrix to identify nonzero values. 

#### Additional information
This broadly mirrors the same functionality as implemented in cupy, which should help the compatibility of the packages.