### PR TITLE
fix real-to-real transforms for complex inputs and overwrite_x=True

### DIFF
--- a/scipy/fft/_pocketfft/realtransforms.py
+++ b/scipy/fft/_pocketfft/realtransforms.py
@@ -36,9 +36,9 @@ def _r2r(forward, transform, x, type=2, n=None, axis=-1, norm=None,
 
     out = (tmp if overwrite_x else None)
 
-    # For complex input, transform real and imaginary components seperably
+    # For complex input, transform real and imaginary components separably
     if np.iscomplexobj(x):
-        out = out or np.empty_like(tmp)
+        out = np.empty_like(tmp) if out is None else out
         transform(tmp.real, type, (axis,), norm, out.real, workers)
         transform(tmp.imag, type, (axis,), norm, out.imag, workers)
         return out
@@ -89,9 +89,9 @@ def _r2rn(forward, transform, x, type=2, s=None, axes=None, norm=None,
     workers = _workers(workers)
     out = (tmp if overwrite_x else None)
 
-    # For complex input, transform real and imaginary components seperably
+    # For complex input, transform real and imaginary components separably
     if np.iscomplexobj(x):
-        out = out or np.empty_like(tmp)
+        out = np.empty_like(tmp) if out is None else out
         transform(tmp.real, type, axes, norm, out.real, workers)
         transform(tmp.imag, type, axes, norm, out.imag, workers)
         return out

--- a/scipy/fft/tests/test_real_transforms.py
+++ b/scipy/fft/tests/test_real_transforms.py
@@ -1,6 +1,6 @@
 
 import numpy as np
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_array_equal
 import pytest
 
 from scipy.fft import dct, idct, dctn, idctn, dst, idst, dstn, idstn
@@ -31,6 +31,30 @@ def test_identity_1d(forward, backward, type, n, axis, norm):
     y2 = np.pad(y, pad, mode='edge')
     z2 = backward(y2, type, n, axis, norm)
     assert_allclose(z2, x)
+
+
+@pytest.mark.parametrize("forward, backward", [(dct, idct), (dst, idst)])
+@pytest.mark.parametrize("type", [1, 2, 3, 4])
+@pytest.mark.parametrize("dtype", [np.float16, np.float32, np.float64,
+                                   np.complex64, np.complex128])
+@pytest.mark.parametrize("axis", [0, 1])
+@pytest.mark.parametrize("norm", [None, 'ortho'])
+@pytest.mark.parametrize("overwrite_x", [True, False])
+def test_identity_1d_overwrite(forward, backward, type, dtype, axis, norm,
+                               overwrite_x):
+    # Test the identity f^-1(f(x)) == x
+    x = np.random.rand(7, 8)
+    x_orig = x.copy()
+
+    y = forward(x, type, axis=axis, norm=norm, overwrite_x=overwrite_x)
+    y_orig = y.copy()
+    z = backward(y, type, axis=axis, norm=norm, overwrite_x=overwrite_x)
+    if not overwrite_x:
+        assert_allclose(z, x, rtol=1e-6, atol=1e-6)
+        assert_array_equal(x, x_orig)
+        assert_array_equal(y, y_orig)
+    else:
+        assert_allclose(z, x_orig, rtol=1e-6, atol=1e-6)
 
 
 @pytest.mark.parametrize("forward, backward", [(dctn, idctn), (dstn, idstn)])
@@ -74,6 +98,39 @@ def test_identity_nd(forward, backward, type, shape, axes, norm):
     y2 = np.pad(y, pad, mode='edge')
     z2 = backward(y2, type, shape, axes, norm)
     assert_allclose(z2, x)
+
+
+@pytest.mark.parametrize("forward, backward", [(dctn, idctn), (dstn, idstn)])
+@pytest.mark.parametrize("type", [1, 2, 3, 4])
+@pytest.mark.parametrize("shape, axes",
+                         [
+                             ((4, 5), 0),
+                             ((4, 5), 1),
+                             ((4, 5), None),
+                         ])
+@pytest.mark.parametrize("dtype", [np.float16, np.float32, np.float64,
+                                   np.complex64, np.complex128])
+@pytest.mark.parametrize("norm", [None, 'ortho'])
+@pytest.mark.parametrize("overwrite_x", [False, True])
+def test_identity_nd_overwrite(forward, backward, type, shape, axes, dtype,
+                               norm, overwrite_x):
+    # Test the identity f^-1(f(x)) == x
+
+    x = np.random.random(shape).astype(dtype)
+    x_orig = x.copy()
+
+    if axes is not None:
+        shape = np.take(shape, axes)
+
+    y = forward(x, type, axes=axes, norm=norm)
+    y_orig = y.copy()
+    z = backward(y, type, axes=axes, norm=norm)
+    if overwrite_x:
+        assert_allclose(z, x_orig, rtol=1e-6, atol=1e-6)
+    else:
+        assert_allclose(z, x, rtol=1e-6, atol=1e-6)
+        assert_array_equal(x, x_orig)
+        assert_array_equal(y, y_orig)
 
 
 @pytest.mark.parametrize("func", ['dct', 'dst', 'dctn', 'dstn'])


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
None

#### What does this implement/fix?
This PR fixes a corner case where real-to-real transforms fail if the input is complex-valued and `overwrite_x=True` (The expected behavior is to transform the real and imaginary components, separably). A minimal example of the issue:

```Python
import numpy as np
import scipy.fft
scipy.fft.dctn(np.ones(8, dtype=np.complex64), overwrite_x=True)
```

```Python
Traceback (most recent call last):

  File "<ipython-input-222-ae6e0c6f2821>", line 1, in <module>
    scipy.fft.dctn(np.ones(8, dtype=np.complex64), overwrite_x=True)

  File "/home/lee8rx/miniconda3/envs/pyir/lib/python3.7/site-packages/scipy/fft/_backend.py", line 23, in __ua_function__
    return fn(*args, **kwargs)

  File "/home/lee8rx/miniconda3/envs/pyir/lib/python3.7/site-packages/scipy/fft/_pocketfft/realtransforms.py", line 99, in _r2rn
    out = out or np.empty_like(tmp)

ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

#### Additional information
<!--Any additional information you think is important.-->

Test cases with and without `overwrite_x` for various floating point dtypes were added. The complex-valued cases here would fail with the above error prior to this PR.

This PR also indirectly fixes the same issue for the `scipy.fftpack` real-to-real transforms since those just end up calling the `scipy.fft` ones.