### PR TITLE
DOC: stats: fix error caused by trapz docstring

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -6880,8 +6880,8 @@ class trapz_gen(rv_continuous):
     defines the trapezoid base from ``loc`` to ``(loc+scale)`` and the flat
     top from ``c`` to ``d`` proportional to the position along the base
     with ``0 <= c <= d <= 1``.  When ``c=d``, this is equivalent to `triang`
-    with the same values for `loc`, `scale` and `c`.  `stats` implements
-    the method of [1]_ for computing moments.
+    with the same values for `loc`, `scale` and `c`.
+    The method of [1]_ is used for computing moments.
 
     `trapz` takes :math:`c` and :math:`d` as shape parameters.
 


### PR DESCRIPTION
Doc builds are failing:
```
/home/circleci/repo/build/testenv/lib/python3.7/site-packages/scipy/stats/__init__.py:docstring of scipy.stats.trapz:19: WARNING: py:obj reference target not found: stats
```
![image](https://user-images.githubusercontent.com/6570539/79838508-f98f2700-8367-11ea-8d60-01b28ea84c5d.png)

Attempting to fix...