### PR TITLE
BUG: stats: fixed SEGFAULT from Issue #9710

### DIFF
--- a/scipy/stats/_stats.pyx
+++ b/scipy/stats/_stats.pyx
@@ -159,6 +159,7 @@ def _toint64(x):
         j = 1
         l = i + 1
 
+    i = -1
     for i in range(l - 1):
         result[perm[i]] = j
         if x[perm[i]] != x[perm[i + 1]]:

--- a/scipy/stats/_stats.pyx
+++ b/scipy/stats/_stats.pyx
@@ -159,13 +159,12 @@ def _toint64(x):
         j = 1
         l = i + 1
 
-    i = -1
     for i in range(l - 1):
         result[perm[i]] = j
         if x[perm[i]] != x[perm[i + 1]]:
             j += 1
 
-    result[perm[i + 1]] = j
+    result[perm[l - 1]] = j
     return np.array(result, dtype=np.int64)
 
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1181,9 +1181,11 @@ def test_weightedtau():
 
 def test_segfault_issue_9710():
     # https://github.com/scipy/scipy/issues/9710
-    # This test was created to check  segfault
+    # This test was created to check segfault
+    # In issue SEGFAULT only repros in optimized builds after calling the function twice
     stats.weightedtau([1], [1.0])
     stats.weightedtau([1], [1.0])
+    # The code below also caused SEGFAULT
     stats.weightedtau([np.nan], [52])
 
 def test_kendall_tau_large():

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1179,6 +1179,12 @@ def test_weightedtau():
     tau, p_value = stats.weightedtau(x, y)
     assert_approx_equal(tau, -0.56694968153682723)
 
+def test_segfault_issue_9710():
+    # https://github.com/scipy/scipy/issues/9710
+    # This test was created to check  segfault
+    stats.weightedtau([1], [1.0])
+    stats.weightedtau([1], [1.0])
+    stats.weightedtau([np.nan], [52])
 
 def test_kendall_tau_large():
     n = 172.


### PR DESCRIPTION
_toint64 caused SEGFAULT when stats.weightedtau were used with arrays of different types with len == 1.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes #9710

#### What does this implement/fix?
Fixed by assigning value -1 to variable i before last for as evgenyzhurko suggested.
Added test with examples from issue to catch issue in the future.

#### Additional information
<!--Any additional information you think is important.-->