### PR TITLE
ENH: Respect matplotlib color palette with hierarchy/dendrogram.

### DIFF
--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -2798,7 +2798,7 @@ def _get_tick_rotation(p):
 def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
                      no_labels, color_list, leaf_font_size=None,
                      leaf_rotation=None, contraction_marks=None,
-                     ax=None, above_threshold_color='b'):
+                     ax=None, above_threshold_color='C0'):
     # Import matplotlib here so that it's not imported unless dendrograms
     # are plotted. Raise an informative error if importing fails.
     try:
@@ -2929,7 +2929,9 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
         matplotlib.pylab.draw_if_interactive()
 
 
-_link_line_colors = ['g', 'r', 'c', 'm', 'y', 'k']
+# C0  is used for above threshhold color
+_link_line_colors_default = ('C1', 'C2', 'C3', 'C4', 'C5', 'C6', 'C7', 'C8', 'C9')
+_link_line_colors = list(_link_line_colors_default)
 
 
 def set_link_color_palette(palette):
@@ -2950,8 +2952,8 @@ def set_link_color_palette(palette):
         order in which the colors are cycled through when color thresholding in
         the dendrogram.
 
-        If ``None``, resets the palette to its default (which is
-        ``['g', 'r', 'c', 'm', 'y', 'k']``).
+        If ``None``, resets the palette to its default (which are matplotlib
+        default colors C1 to C9).
 
     Returns
     -------
@@ -2973,9 +2975,9 @@ def set_link_color_palette(palette):
     >>> Z = hierarchy.linkage(ytdist, 'single')
     >>> dn = hierarchy.dendrogram(Z, no_plot=True)
     >>> dn['color_list']
-    ['g', 'b', 'b', 'b', 'b']
+    ['C1', 'C0', 'C0', 'C0', 'C0']
     >>> hierarchy.set_link_color_palette(['c', 'm', 'y', 'k'])
-    >>> dn = hierarchy.dendrogram(Z, no_plot=True)
+    >>> dn = hierarchy.dendrogram(Z, no_plot=True, above_threshold_color='b')
     >>> dn['color_list']
     ['c', 'b', 'b', 'b', 'b']
     >>> dn = hierarchy.dendrogram(Z, no_plot=True, color_threshold=267,
@@ -2990,7 +2992,7 @@ def set_link_color_palette(palette):
     """
     if palette is None:
         # reset to its default
-        palette = ['g', 'r', 'c', 'm', 'y', 'k']
+        palette = _link_line_colors_default
     elif type(palette) not in (list, tuple):
         raise TypeError("palette must be a list or tuple")
     _ptypes = [isinstance(p, str) for p in palette]
@@ -2998,9 +3000,8 @@ def set_link_color_palette(palette):
     if False in _ptypes:
         raise TypeError("all palette list elements must be color strings")
 
-    for i in list(_link_line_colors):
-        _link_line_colors.remove(i)
-    _link_line_colors.extend(list(palette))
+    global _link_line_colors
+    _link_line_colors = palette
 
 
 def dendrogram(Z, p=30, truncate_mode=None, color_threshold=None,
@@ -3009,7 +3010,7 @@ def dendrogram(Z, p=30, truncate_mode=None, color_threshold=None,
                no_plot=False, no_labels=False, leaf_font_size=None,
                leaf_rotation=None, leaf_label_func=None,
                show_contracted=False, link_color_func=None, ax=None,
-               above_threshold_color='b'):
+               above_threshold_color='C0'):
     """
     Plot the hierarchical clustering as a dendrogram.
 
@@ -3060,10 +3061,12 @@ def dendrogram(Z, p=30, truncate_mode=None, color_threshold=None,
         :math:`k` the same color if :math:`k` is the first node below
         the cut threshold :math:`t`. All links connecting nodes with
         distances greater than or equal to the threshold are colored
-        blue. If :math:`t` is less than or equal to zero, all nodes
-        are colored blue. If ``color_threshold`` is None or
-        'default', corresponding with MATLAB(TM) behavior, the
-        threshold is set to ``0.7*max(Z[:,2])``.
+        with de default matplotlib color ``'C0'``. If :math:`t` is less
+        than or equal to zero, all nodes are colored ``'C0'``.
+        If ``color_threshold`` is None or 'default',
+        corresponding with MATLAB(TM) behavior, the threshold is set to
+        ``0.7*max(Z[:,2])``.
+
     get_leaves : bool, optional
         Includes a list ``R['leaves']=H`` in the result
         dictionary. For each :math:`i`, ``H[i] == j``, cluster node
@@ -3192,7 +3195,7 @@ def dendrogram(Z, p=30, truncate_mode=None, color_threshold=None,
         useful if the dendrogram is part of a more complex figure.
     above_threshold_color : str, optional
         This matplotlib color string sets the color of the links above the
-        color_threshold. The default is 'b'.
+        color_threshold. The default is ``'C0'``.
 
     Returns
     -------
@@ -3426,7 +3429,7 @@ def _dendrogram_calculate_info(Z, p, truncate_mode,
                                leaf_label_func=None, level=0,
                                contraction_marks=None,
                                link_color_func=None,
-                               above_threshold_color='b'):
+                               above_threshold_color='C0'):
     """
     Calculate the endpoints of the links as well as the labels for the
     the dendrogram rooted at the node with index i. iv is the independent

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -834,7 +834,7 @@ class TestDendrogram(object):
     def check_dendrogram_plot(self, orientation):
         # Tests dendrogram plotting.
         Z = linkage(hierarchy_test_data.ytdist, 'single')
-        expected = {'color_list': ['g', 'b', 'b', 'b', 'b'],
+        expected = {'color_list': ['C1', 'C0', 'C0', 'C0', 'C0'],
                     'dcoord': [[0.0, 138.0, 138.0, 0.0],
                                [0.0, 219.0, 219.0, 0.0],
                                [0.0, 255.0, 255.0, 219.0],
@@ -895,7 +895,7 @@ class TestDendrogram(object):
 
         R = dendrogram(Z, 2, 'lastp', show_contracted=True)
         plt.close()
-        assert_equal(R, {'color_list': ['b'],
+        assert_equal(R, {'color_list': ['C0'],
                          'dcoord': [[0.0, 295.0, 295.0, 0.0]],
                          'icoord': [[5.0, 5.0, 15.0, 15.0]],
                          'ivl': ['(2)', '(4)'],
@@ -903,7 +903,7 @@ class TestDendrogram(object):
 
         R = dendrogram(Z, 2, 'mtica', show_contracted=True)
         plt.close()
-        assert_equal(R, {'color_list': ['g', 'b', 'b', 'b'],
+        assert_equal(R, {'color_list': ['C1', 'C0', 'C0', 'C0'],
                          'dcoord': [[0.0, 138.0, 138.0, 0.0],
                                     [0.0, 255.0, 255.0, 0.0],
                                     [0.0, 268.0, 268.0, 255.0],


### PR DESCRIPTION
Dendrogram appear to be using its own color palette, which does not play
well with the new matplotlib theming abilities.

Instead of hardcoding the values, use reference to matplotlib colors
using `'C0'` to `'C9'`. We use `'C0'` as the default color (where `'blue'`)
was the default, and cycle through `'C1'` to `'C9'`. It also appear the
global colors were stored in a list, and the original author was using
the mutability of the list to emulate a global variable. This is more
explicit and uses use a global variable.

Docstrings are updated to reflect this change of default.

As this changes default values, this can of course be considered as a
API breaking change.

#### Reference issue

No reference issue.