### PR TITLE
DOC: refine doc for spatial.distance.squareform

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -2116,23 +2116,24 @@ def squareform(X, force="no", checks=True):
 
     Notes
     -----
-    1. v = squareform(X)
+    1. ``v = squareform(X)``
 
-       Given a square d-by-d symmetric distance matrix X,
-       ``v = squareform(X)`` returns a ``d * (d-1) / 2`` (or
-       :math:`{n \\choose 2}`) sized vector v.
+       Given a square :math:`n`-by-:math:`n` symmetric distance matrix :math:`X`,
+       ``v = squareform(X)`` returns a
+       :math:`{n \\choose 2} = \\frac{n(n-1)}{2}` sized vector :math:`v`
+       where :math:`v[{n \\choose 2}-{n-i \\choose 2} + (j-i-1)]`
+       is the distance between points ``i`` and ``j``, :math:`i \\not= j`.
+       If :math:`X` is non-square or asymmetric, an error is raised.
 
-      :math:`v[{n \\choose 2}-{n-i \\choose 2} + (j-i-1)]` is the distance
-      between points i and j. If X is non-square or asymmetric, an error
-      is returned.
+    2. ``X = squareform(v)``
 
-    2. X = squareform(v)
-
-      Given a ``d*(d-1)/2`` sized v for some integer ``d >= 2`` encoding
-      distances as described, ``X = squareform(v)`` returns a d by d distance
-      matrix X.  The ``X[i, j]`` and ``X[j, i]`` values are set to
-      :math:`v[{n \\choose 2}-{n-i \\choose 2} + (j-i-1)]` and all
-      diagonal elements are zero.
+       Given a :math:`\\frac{n(n-1)}{2}` sized vector :math:`v`
+       for some integer :math:`n \\geq 1` encoding distances as described,
+       ``X = squareform(v)`` returns a
+       :math:`n`-by-:math:`n` distance matrix :math:`X`.
+       The ``X[i, j]`` and ``X[j, i]`` values are set to
+       :math:`v[{n \\choose 2}-{n-i \\choose 2} + (j-i-1)]`
+       and all diagonal elements are zero.
 
     In SciPy 0.19.0, ``squareform`` stopped casting all input types to
     float64, and started returning arrays of the same dtype as the input.

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -2118,18 +2118,18 @@ def squareform(X, force="no", checks=True):
     -----
     1. ``v = squareform(X)``
 
-       Given a square n-by-n symmetric distance matrix `X`,
-       ``v = squareform(X)`` returns a `n * (n-1) / 2`
+       Given a square n-by-n symmetric distance matrix ``X``,
+       ``v = squareform(X)`` returns a ``n * (n-1) / 2``
        (i.e. binomial coefficient n choose 2) sized vector `v`
        where :math:`v[{n \\choose 2} - {n-i \\choose 2} + (j-i-1)]`
-       is the distance between distinct points `i` and `j`.
-       If `X` is non-square or asymmetric, an error is raised.
+       is the distance between distinct points ``i`` and ``j``.
+       If ``X`` is non-square or asymmetric, an error is raised.
 
     2. ``X = squareform(v)``
 
-       Given a `n * (n-1) / 2` sized vector `v`
-       for some integer `n >= 1` encoding distances as described,
-       ``X = squareform(v)`` returns a n-by-n distance matrix `X`.
+       Given a ``n * (n-1) / 2`` sized vector ``v``
+       for some integer ``n >= 1`` encoding distances as described,
+       ``X = squareform(v)`` returns a n-by-n distance matrix ``X``.
        The ``X[i, j]`` and ``X[j, i]`` values are set to
        :math:`v[{n \\choose 2} - {n-i \\choose 2} + (j-i-1)]`
        and all diagonal elements are zero.

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -2118,21 +2118,20 @@ def squareform(X, force="no", checks=True):
     -----
     1. ``v = squareform(X)``
 
-       Given a square :math:`n`-by-:math:`n` symmetric distance matrix :math:`X`,
-       ``v = squareform(X)`` returns a
-       :math:`{n \\choose 2} = \\frac{n(n-1)}{2}` sized vector :math:`v`
-       where :math:`v[{n \\choose 2}-{n-i \\choose 2} + (j-i-1)]`
-       is the distance between points ``i`` and ``j``, :math:`i \\not= j`.
-       If :math:`X` is non-square or asymmetric, an error is raised.
+       Given a square n-by-n symmetric distance matrix `X`,
+       ``v = squareform(X)`` returns a `n * (n-1) / 2`
+       (i.e. binomial coefficient n choose 2) sized vector `v`
+       where :math:`v[{n \\choose 2} - {n-i \\choose 2} + (j-i-1)]`
+       is the distance between distinct points `i` and `j`.
+       If `X` is non-square or asymmetric, an error is raised.
 
     2. ``X = squareform(v)``
 
-       Given a :math:`\\frac{n(n-1)}{2}` sized vector :math:`v`
-       for some integer :math:`n \\geq 1` encoding distances as described,
-       ``X = squareform(v)`` returns a
-       :math:`n`-by-:math:`n` distance matrix :math:`X`.
+       Given a `n * (n-1) / 2` sized vector `v`
+       for some integer `n >= 1` encoding distances as described,
+       ``X = squareform(v)`` returns a n-by-n distance matrix `X`.
        The ``X[i, j]`` and ``X[j, i]`` values are set to
-       :math:`v[{n \\choose 2}-{n-i \\choose 2} + (j-i-1)]`
+       :math:`v[{n \\choose 2} - {n-i \\choose 2} + (j-i-1)]`
        and all diagonal elements are zero.
 
     In SciPy 0.19.0, ``squareform`` stopped casting all input types to


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### What does this implement/fix?

Improve documentation for `squareform()` function:
* remove misleading variable `d`, keep only `n`
* ~use more math-rendered blocks~
* loosen vector size restriction (as code actually allows input vectors of zero length)