### PR TITLE
ENH: expose "window_size" parameter in find_peaks_cwt()

### DIFF
--- a/scipy/signal/_peak_finding.py
+++ b/scipy/signal/_peak_finding.py
@@ -1188,7 +1188,8 @@ def _filter_ridge_lines(cwt, ridge_lines, window_size=None, min_length=None,
 
 
 def find_peaks_cwt(vector, widths, wavelet=None, max_distances=None,
-                   gap_thresh=None, min_length=None, min_snr=1, noise_perc=10):
+                   gap_thresh=None, min_length=None, window_size=None,
+                   min_snr=1, noise_perc=10):
     """
     Find peaks in a 1-D array with wavelet transformation.
 
@@ -1222,6 +1223,9 @@ def find_peaks_cwt(vector, widths, wavelet=None, max_distances=None,
     min_length : int, optional
         Minimum length a ridge line needs to be acceptable.
         Default is ``cwt.shape[0] / 4``, ie 1/4-th the number of widths.
+    window_size : int, optional
+        Size of window to use to calculate noise floor.
+        Default is ``cwt.shape[1] / 20``.
     min_snr : float, optional
         Minimum SNR ratio. Default 1. The signal is the value of
         the cwt matrix at the shortest length scale (``cwt[0, loc]``), the
@@ -1289,7 +1293,8 @@ def find_peaks_cwt(vector, widths, wavelet=None, max_distances=None,
     cwt_dat = cwt(vector, wavelet, widths)
     ridge_lines = _identify_ridge_lines(cwt_dat, max_distances, gap_thresh)
     filtered = _filter_ridge_lines(cwt_dat, ridge_lines, min_length=min_length,
-                                   min_snr=min_snr, noise_perc=noise_perc)
+                                   window_size=window_size, min_snr=min_snr,
+                                   noise_perc=noise_perc)
     max_locs = np.asarray([x[1][0] for x in filtered])
     max_locs.sort()
 

--- a/scipy/signal/_peak_finding.py
+++ b/scipy/signal/_peak_finding.py
@@ -1188,8 +1188,8 @@ def _filter_ridge_lines(cwt, ridge_lines, window_size=None, min_length=None,
 
 
 def find_peaks_cwt(vector, widths, wavelet=None, max_distances=None,
-                   gap_thresh=None, min_length=None, window_size=None,
-                   min_snr=1, noise_perc=10):
+                   gap_thresh=None, min_length=None,
+                   min_snr=1, noise_perc=10, window_size=None):
     """
     Find peaks in a 1-D array with wavelet transformation.
 
@@ -1223,9 +1223,6 @@ def find_peaks_cwt(vector, widths, wavelet=None, max_distances=None,
     min_length : int, optional
         Minimum length a ridge line needs to be acceptable.
         Default is ``cwt.shape[0] / 4``, ie 1/4-th the number of widths.
-    window_size : int, optional
-        Size of window to use to calculate noise floor.
-        Default is ``cwt.shape[1] / 20``.
     min_snr : float, optional
         Minimum SNR ratio. Default 1. The signal is the value of
         the cwt matrix at the shortest length scale (``cwt[0, loc]``), the
@@ -1235,6 +1232,9 @@ def find_peaks_cwt(vector, widths, wavelet=None, max_distances=None,
         When calculating the noise floor, percentile of data points
         examined below which to consider noise. Calculated using
         `stats.scoreatpercentile`.  Default is 10.
+    window_size : int, optional
+        Size of window to use to calculate noise floor.
+        Default is ``cwt.shape[1] / 20``.
 
     Returns
     -------

--- a/scipy/signal/tests/test_peak_finding.py
+++ b/scipy/signal/tests/test_peak_finding.py
@@ -838,10 +838,10 @@ class TestFindPeaksCwt(object):
         test_data[250:320] -= 1
 
         found_locs = find_peaks_cwt(test_data, widths, gap_thresh=2, min_snr=3,
-                                         min_length=None, window_size=None)
+                                    min_length=None, window_size=None)
         with pytest.raises(AssertionError):
-            assert_array_equal(len(found_locs), len(act_locs))
+            assert found_locs.size == act_locs.size
+
         found_locs = find_peaks_cwt(test_data, widths, gap_thresh=2, min_snr=3,
-                                         min_length=None, window_size=20)
-        assert_array_equal(len(found_locs), len(act_locs),
-                           "Found maximum locations did not equal those expected")
+                                    min_length=None, window_size=20)
+        assert found_locs.size == act_locs.size

--- a/scipy/signal/tests/test_peak_finding.py
+++ b/scipy/signal/tests/test_peak_finding.py
@@ -819,3 +819,30 @@ class TestFindPeaksCwt(object):
         widths = np.arange(10, 50)
         found_locs = find_peaks_cwt(test_data, widths, min_snr=5, noise_perc=30)
         np.testing.assert_equal(len(found_locs), 0)
+
+    def test_find_peaks_window_size(self):
+        """
+        Verify that window_size is passed correctly to private function and
+        affects the result.
+        """
+        sigmas = [2.0, 2.0]
+        num_points = 1000
+        test_data, act_locs = _gen_gaussians_even(sigmas, num_points)
+        widths = np.arange(0.1, max(sigmas), 0.2)
+        noise_amp = 0.05
+        np.random.seed(18181911)
+        test_data += (np.random.rand(num_points) - 0.5)*(2*noise_amp)
+
+        # Possibly contrived negative region to throw off peak finding
+        # when window_size is too large
+        test_data[250:320] -= 1
+
+        found_locs = find_peaks_cwt(test_data, widths, gap_thresh=2, min_snr=3,
+                                         min_length=None, window_size=None)
+        np.testing.assert_raises(AssertionError, np.testing.assert_array_equal,
+                                 len(found_locs), len(act_locs),
+                                 "Unexpectedly found all maximum locations")
+        found_locs = find_peaks_cwt(test_data, widths, gap_thresh=2, min_snr=3,
+                                         min_length=None, window_size=20)
+        np.testing.assert_array_equal(len(found_locs), len(act_locs),
+                        "Found maximum locations did not equal those expected")

--- a/scipy/signal/tests/test_peak_finding.py
+++ b/scipy/signal/tests/test_peak_finding.py
@@ -839,10 +839,9 @@ class TestFindPeaksCwt(object):
 
         found_locs = find_peaks_cwt(test_data, widths, gap_thresh=2, min_snr=3,
                                          min_length=None, window_size=None)
-        np.testing.assert_raises(AssertionError, np.testing.assert_array_equal,
-                                 len(found_locs), len(act_locs),
-                                 "Unexpectedly found all maximum locations")
+        with pytest.raises(AssertionError):
+            assert_array_equal(len(found_locs), len(act_locs))
         found_locs = find_peaks_cwt(test_data, widths, gap_thresh=2, min_snr=3,
                                          min_length=None, window_size=20)
-        np.testing.assert_array_equal(len(found_locs), len(act_locs),
-                        "Found maximum locations did not equal those expected")
+        assert_array_equal(len(found_locs), len(act_locs),
+                           "Found maximum locations did not equal those expected")


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

This is not related to any existing issues.

#### What does this implement/fix?
<!--Please explain your changes.-->

In scipy.signal's peak_finding, window_size is a useful parameter in _filter_ridge_lines() but is not exposed by the calling function, find_peaks_cwt(). This minor change corrects that, without affecting existing behavior (it defaults to None and is passed through without being touched), and removes the need to call any private functions.

#### Additional information
<!--Any additional information you think is important.-->