### PR TITLE
DOC, MAINT: mailmap update

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -49,6 +49,7 @@ Aman Pratik <amanpratik10@gmail.com> amanp10 <amanpratik10@gmail.com>
 Aman Singh <bewithaman@outlook.com> bewithaman <bewithaman@outlook.com>
 Aman Thakral <aman.thakral@gmail.com> aman-thakral <aman.thakral@gmail.com>
 Amato Kasahara <thisisdummy@example.com> kshramt <thisisdummy@example.com>
+Anany Shrey Jain <31594632+ananyashreyjain@users.noreply.github.com> ananyashreyjain <31594632+ananyashreyjain@users.noreply.github.com>
 Anders Bech Borchersen <anb@es.aau.dk> andbo <anb@es.aau.dk>
 Andreas Hilboll <andreas@hilboll.de> Andreas H <andreas@hilboll.de>
 Andreas Hilboll <andreas@hilboll.de> Andreas Hilboll <andreas-h@users.noreply.github.com>
@@ -68,6 +69,7 @@ Ashwin Pathak <ashwinpathak20nov1996@gmail.com> ashwinpathak20 <ashwinpathak20no
 Balint Pato <balintp@google.com> balopat <balintp@google.com>
 Behzad Nouri <behzadnouri@gmail.com> behzad nouri <behzadnouri@gmail.com>
 Benjamin Root <> weathergod <>
+Benjamin Santos <caos21@users.noreply.github.com> Benjamin <caos21@users.noreply.github.com>
 Benny Malengier <benny.malengier@gmail.com> Benny <benny.malengier@gmail.com>
 Berkay Antmen <berkay.antmen@shopify.com> bantmen <berkay.antmen@shopify.com>
 Bharat Raghunathan <bharatraghunthan9767@gmail.com> Bharat123rox <bharatraghunthan9767@gmail.com>
@@ -244,6 +246,7 @@ Luke Zoltan Kelley <lkelley@cfa.harvard.edu> lzkelley <lkelley@cfa.harvard.edu>
 Maja Gwozdz <maja.k.gwozdz@gmail.com> mkg33 <maja.k.gwozdz@gmail.com>
 Mak Sze Chun <makszechun@gmail.com> makbigc <makszechun@gmail.com>
 Malayaja Chutani <42006125+malch2@users.noreply.github.com> malch2 <42006125+malch2@users.noreply.github.com>
+Malte Esders <git@maltimore.info> Maltimore <git@maltimore.info>
 M.J. Nichol <mjnichol@alumni.uwaterloo.ca> voyager6868 <mjnichol@alumni.uwaterloo.ca>
 Maniteja Nandana <manitejanmt@gmail.com> maniteja123 <manitejanmt@gmail.com>
 Marc Honnorat <marc.honnorat@gmail.com> honnorat <marc.honnorat@gmail.com>
@@ -270,13 +273,14 @@ Michael Hirsch <scienceopen@noreply.github.com> Michael Hirsch <scienceopen@user
 Michael James Bedford <SunsetOrange@users.noreply.github.com> Michael <SunsetOrange@users.noreply.github.com>
 Michael Marien <marien.mich@gmail.com> michaelmarien <marien.mich@gmail.com>
 Mikhail Pak <mikhail.pak@tum.de> mp4096 <mikhail.pak@tum.de>
-Milad Sadeghi <EverLookNeverSee@Protonmail.ch> ELNS <57490926+EverLookNeverSee@users.noreply.github.com>
+Milad Sadeghi DM <EverLookNeverSee@Protonmail.ch> ELNS <57490926+EverLookNeverSee@users.noreply.github.com>
 Muhammad Firmansyah Kasim <firman.kasim@gmail.com> mfkasim91 <firman.kasim@gmail.com>
 Nathan Bell <wnbell@localhost> wnbell <wnbell@localhost>
 Nathan Woods <woodscn@lanl.gov> Charles Nathan Woods <woodscn@pn1504346.lanl.gov>
 Nathan Woods <woodscn@lanl.gov> Nathan Woods <charlesnwoods@gmail.com>
 Nathan Woods <woodscn@lanl.gov> Nathan Woods <woodscn@pn1504346.lanl.gov>
 Neil Girdhar <mistersheik@gmail.com> Neil <mistersheik@gmail.com>
+Nicholas McKibben <nicholas.bgp@gmail.com> mckib2 <nicholas.bgp@gmail.com>
 Nicola Montecchio <nicola.montecchio@gmail.com> nicola montecchio <nicola.montecchio@gmail.com>
 Nikolai Nowaczyk <mail@nikno.de> Nikolai <mail@nikno.de>
 Nikolas Moya <nikolasmoya@gmail.com> nmoya <nikolasmoya@gmail.com>
@@ -308,6 +312,7 @@ Ralf Gommers <ralf.gommers@gmail.com> rgommers <ralf.gommers@googlemail.com>
 Ralf Gommers <ralf.gommers@gmail.com> Ralf Gommers <ralf.gommers@googlemail.com>
 Raphael Wettinger <ra@phael.org> raphael <ra@phael.org>
 Raphael Wettinger <ra@phael.org> raphaelw <raphael.wettinger@googlemail.com>
+Reidar Kind <53039431+reidarkind@users.noreply.github.com> reidarkind <53039431+reidarkind@users.noreply.github.com>
 Renee Otten <reneeotten@users.noreply.github.com> reneeotten <reneeotten@users.noreply.github.com>
 Rick Paris <rick.paris@mlb.com> rparis <rick.paris@mlb.com>
 Rob Falck <robfalck@gmail.com> rob.falck <rob.falck@localhost>

--- a/.mailmap
+++ b/.mailmap
@@ -65,10 +65,13 @@ Anne Archibald <peridot.faceted@gmail.com> Anne Archibald <archibald@astron.nl>
 Antonio Horta Ribeiro <antonior92@gmail.com> antonio <antonior92@gmail.com>
 Ariel Rokem <arokem@gmail.com> ariel.rokem <ariel.rokem@localhost>
 Ashwin Pathak <ashwinpathak20nov1996@gmail.com> ashwinpathak20 <ashwinpathak20nov1996@gmail.com>
+Balint Pato <balintp@google.com> balopat <balintp@google.com>
 Behzad Nouri <behzadnouri@gmail.com> behzad nouri <behzadnouri@gmail.com>
 Benjamin Root <> weathergod <>
 Benny Malengier <benny.malengier@gmail.com> Benny <benny.malengier@gmail.com>
+Berkay Antmen <berkay.antmen@shopify.com> bantmen <berkay.antmen@shopify.com>
 Bharat Raghunathan <bharatraghunthan9767@gmail.com> Bharat123rox <bharatraghunthan9767@gmail.com>
+Bharat Raghunathan <bharatraghunthan9767@gmail.com> Bharat123Rox <bharatraghunthan9767@gmail.com>
 Bhavika Tekwani <bhavicka.7992@gmail.com> bhavikat <bhavicka.7992@gmail.com>
 Blair Azzopardi <blairuk@gmail.com> bsdz <blairuk@gmail.com>
 Brandon David <brandon.david@zoho.com> brandondavid <brandon.david@zoho.com>
@@ -77,11 +80,13 @@ Brian Hawthorne <brian.hawthorne@localhost> brian.hawthorne <brian.hawthorne@loc
 Brian Newsom <brian.newsom@colorado.edu> Brian Newsom <Brian.Newsom@Colorado.edu>
 Callum Jacob Hays <callumjhays@gmail.com> callumJHays <callumjhays@gmail.com>
 Carlos Ramos Carreño <vnmabus@gmail.com> vnmabus <vnmabus@gmail.com>
+Charles Jekel <cjekel@gmail.com> cjekel <cjekel@gmail.com>
 Charles Masson <charles.masson@datadoghq.com> charlesmasson <charles.masson@datadoghq.com>
 Chelsea Liu <chelsea.liu@datadoghq.com> Chelsea <chelsea.liu@datadoghq.com>
 Chelsea Liu <chelsea.liu@datadoghq.com> chelsea.l <chelsea.liu@datadoghq.com>
 Chris Burns <chris.burns@localhost> chris.burns <chris.burns@localhost>
 Chris Lasher <> gotgenes <>
+Christian Clauss <cclauss@me.com> cclauss <cclauss@me.com>
 Christoph Baumgarten <christoph.baumgarten@gmail.com> chrisb83 <33071866+chrisb83@users.noreply.github.com>
 Christoph Baumgarten <christoph.baumgarten@gmail.com> chrisb83 <christoph.baumgarten@gmail.com>
 Christoph Gohlke <cgohlke@uci.edu> cgohlke <cgohlke@uci.edu>
@@ -118,6 +123,7 @@ Denis Laxalde <denis@laxalde.org> Denis Laxalde <denis.laxalde@mcgill.ca>
 Denis Laxalde <denis@laxalde.org> Denis Laxalde <denis@mail.laxalde.org>
 Derek Homeier <> Derek Homeir <>
 Derek Homeier <> Derek Homier <>
+Derrick Chambers <d-chambers@users.noreply.github.com> Derrick <d-chambers@users.noreply.github.com>
 Dezmond Goff <goff.dezmond@gmail.com> Dezmond <goff.dezmond@gmail.com>
 Dieter Werthmüller <dieter@werthmuller.org> Dieter Werthmüller <mail@werthmuller.org>
 Dieter Werthmüller <dieter@werthmuller.org> Dieter Werthmüller <prisae@users.noreply.github.com>
@@ -154,6 +160,7 @@ Guillaume Horel <thrasibule@users.noreply.github.com> Thrasibule <thrasibule@use
 Guo Fei <<guofei9987@foxmail.com> Guofei <<guofei9987@foxmail.com>
 Han Genuit <> 87 <>
 Han Genuit <> Han <>
+Harshal Prakash Patankar <pharshalp@gmail.com> pharshalp <pharshalp@gmail.com>
 Hervé Audren <h.audren@gmail.com> Herve Audren <h.audren@gmail.com>
 Heshy Roskes <heshyr@gmail.com> <hroskes@jhu.edu>
 Heshy Roskes <heshyr@gmail.com> <jroskes1@jhu.edu>
@@ -168,6 +175,7 @@ Ion Elberdin <ionelberdin@gmail.com> Ion <ionelberdin@gmail.com>
 Ilhan Polat <ilhanpolat@gmail.com> ilayn <ilhanpolat@gmail.com>
 Irvin Probst <irvin.probst@ensta-bretagne.fr> I--P <irvin.probst@ensta-bretagne.fr>
 Jacob Carey <jacobcvt12@gmail.com> Jacob Carey <Jacobcvt12@users.noreply.github.com>
+Jakob Jakobson <43045863+jakobjakobson13@users.noreply.github.com> jakobjakobson13 <43045863+jakobjakobson13@users.noreply.github.com>
 Jacob Vanderplas <jakevdp@gmail.com> Jake VanderPlas <jakevdp@gmail.com>
 Jacob Vanderplas <jakevdp@gmail.com> Jake Vanderplas <jakevdp@gmail.com>
 Jacob Vanderplas <jakevdp@gmail.com> Jake Vanderplas <jakevdp@yahoo.com>
@@ -178,6 +186,7 @@ Jaime Fernandez del Rio <jaime.frio@gmail.com> Jaime <jaime.frio@gmail.com>
 Jaime Fernandez del Rio <jaimefrio@google.com> Jaime Fernandez <jaimefrio@google.com>
 Jakub Dyczek <34447984+JDkuba@users.noreply.github.com> JDkuba <34447984+JDkuba@users.noreply.github.com>
 James T. Webber <jamestwebber@gmail.com> jamestwebber <jamestwebber@gmail.com>
+Jan Vleeshouwers <j.m.vleeshouwers@tue.nl> janvle <j.m.vleeshouwers@tue.nl>
 Janani Padmanabhan <jenny.stone125@gmail.com> janani <janani@janani-Vostro-3446.(none)>
 Janani Padmanabhan <jenny.stone125@gmail.com> Janani <jenny.stone125@gmail.com>
 Jean-François B. <jfbu@free.fr> jfbu <jfbu@free.fr>
@@ -229,6 +238,7 @@ Liam Damewood <damewood@physics.ucdavis.edu> ldamewood <damewood@physics.ucdavis
 Liming Wang <lmwang@gmail.com> lmwang <lmwang@gmail.com>
 Lindsey Hiltner <lindsey.hiltner@gmail.com> L. Hiltner <lhilt@users.noreply.github.com>
 Lindsey Hiltner <lindsey.hiltner@gmail.com> L Hiltner <lhilt@users.noreply.github.com>
+Lijun Wang <szcfweiya@gmail.com> szcf-weiya <szcfweiya@gmail.com>
 Lorenzo Luengo <> loluengo <>
 Luke Zoltan Kelley <lkelley@cfa.harvard.edu> lzkelley <lkelley@cfa.harvard.edu>
 Maja Gwozdz <maja.k.gwozdz@gmail.com> mkg33 <maja.k.gwozdz@gmail.com>
@@ -260,6 +270,7 @@ Michael Hirsch <scienceopen@noreply.github.com> Michael Hirsch <scienceopen@user
 Michael James Bedford <SunsetOrange@users.noreply.github.com> Michael <SunsetOrange@users.noreply.github.com>
 Michael Marien <marien.mich@gmail.com> michaelmarien <marien.mich@gmail.com>
 Mikhail Pak <mikhail.pak@tum.de> mp4096 <mikhail.pak@tum.de>
+Milad Sadeghi <EverLookNeverSee@Protonmail.ch> ELNS <57490926+EverLookNeverSee@users.noreply.github.com>
 Muhammad Firmansyah Kasim <firman.kasim@gmail.com> mfkasim91 <firman.kasim@gmail.com>
 Nathan Bell <wnbell@localhost> wnbell <wnbell@localhost>
 Nathan Woods <woodscn@lanl.gov> Charles Nathan Woods <woodscn@pn1504346.lanl.gov>
@@ -288,6 +299,7 @@ Peter Bell <peterbell10@live.co.uk> peterbell10 <peterbell10@live.co.uk>
 Peter Lysakovski <30794408+Lskvk@users.noreply.github.com> Lskvk <30794408+Lskvk@users.noreply.github.com>
 Peter Mahler Larsen <pete.mahler.larsen@gmail.com> pmla <pete.mahler.larsen@gmail.com>
 Peter Mahler Larsen <pete.mahler.larsen@gmail.com> Peter <peter.mahler.larsen@gmail.com>
+Peyton Murray <peynmurray@gmail.com> pdmurray <peynmurray@gmail.com>
 Phillip Weinberg <weinbe58@bu.edu> weinbe58 <weinbe58@bu.edu>
 Pierre GM <pierregm@localhost> pierregm <pierregm@localhost>
 Radoslaw Guzinski <radoslaw.guzinski@esa.int> radosuav <rmgu@dhi-gras.com>
@@ -297,6 +309,7 @@ Ralf Gommers <ralf.gommers@gmail.com> Ralf Gommers <ralf.gommers@googlemail.com>
 Raphael Wettinger <ra@phael.org> raphael <ra@phael.org>
 Raphael Wettinger <ra@phael.org> raphaelw <raphael.wettinger@googlemail.com>
 Renee Otten <reneeotten@users.noreply.github.com> reneeotten <reneeotten@users.noreply.github.com>
+Rick Paris <rick.paris@mlb.com> rparis <rick.paris@mlb.com>
 Rob Falck <robfalck@gmail.com> rob.falck <rob.falck@localhost>
 Robert David Grant <rgrant@enthought.com> Robert David Grant <robert.david.grant@gmail.com>
 Robert Kern <rkern@enthought.com> Robert Kern <robert.kern@gmail.com>
@@ -304,6 +317,7 @@ Roman Mirochnik <roman.mirochnik@hpe.com> mirochni <roman.mirochnik@hpe.com>
 Rupak Das <dr10ru@yahoo.co.in> Rupak <dr10ru@yahoo.co.in>
 Sam Lewis <sam.vr.lewis@gmail.com> Sam Lewis <samvrlewis@users.noreply.github.com>
 Sam Mason <sam@samason.uk> Sam Mason <sam.mason@warwick.ac.uk>
+Santi Hernandez <santi-hernandez@hotmail.com> santiher <santi-hernandez@hotmail.com>
 Santi Villalba <sdvillal@gmail.com> santi <sdvillal@gmail.com>
 Saurabh Agarwal <shourabh.agarwal@gmail.com> saurabhkgpee <shourabh.agarwal@gmail.com>
 Scott Sievert <me@scottsievert.com> scottsievert <sieve121@umn.edu>


### PR DESCRIPTION
* update mailmap early to reduce last-minute
burden for `1.5.0` release

I made an effort to click through GitHub profiles and webpages linked therein to find full names, but in some cases I couldn't quite track the info down; pinging for those I couldn't find full names for in case they'd prefer their full name in release notes vs. username:

- [x] @reidarkind
- [x] @mckib2
- [ ] @Mazay0
- [x] @Maltimore
- [ ] @Konrad0
- [ ] @janvle
- [ ] @hakeemo
- [ ] @dankleeman
- [x] @caos21
- [x] @ananyashreyjain