### PR TITLE
DOC: Add docstring examples to fft2, ifft2, io.savemat

### DIFF
--- a/scipy/fftpack/basic.py
+++ b/scipy/fftpack/basic.py
@@ -387,7 +387,7 @@ def fft2(x, shape=None, axes=(-2,-1), overwrite_x=False):
     array([[0, 0, 0, 0, 0],
            [1, 1, 1, 1, 1],
            [2, 2, 2, 2, 2],
-           [3, 3, 3, 3, 3]
+           [3, 3, 3, 3, 3],
            [4, 4, 4, 4, 4]])
     >>> np.allclose(y, ifft2(fft2(y)))
     True
@@ -417,7 +417,7 @@ def ifft2(x, shape=None, axes=(-2,-1), overwrite_x=False):
     array([[0, 0, 0, 0, 0],
            [1, 1, 1, 1, 1],
            [2, 2, 2, 2, 2],
-           [3, 3, 3, 3, 3]
+           [3, 3, 3, 3, 3],
            [4, 4, 4, 4, 4]])
     >>> np.allclose(y, fft2(ifft2(y)))
     True

--- a/scipy/fftpack/basic.py
+++ b/scipy/fftpack/basic.py
@@ -408,5 +408,19 @@ def ifft2(x, shape=None, axes=(-2,-1), overwrite_x=False):
     --------
     fft2, ifft
 
+    Examples
+    --------
+    >>> from scipy.fftpack import fft2, ifft2
+    >>> import numpy as np
+    >>> y = np.mgrid[:5, :5][0]
+    >>> y
+    array([[0, 0, 0, 0, 0],
+           [1, 1, 1, 1, 1],
+           [2, 2, 2, 2, 2],
+           [3, 3, 3, 3, 3]
+           [4, 4, 4, 4, 4]])
+    >>> np.allclose(y, fft2(ifft2(y)))
+    True
+
     """
     return ifftn(x,shape,axes,overwrite_x)

--- a/scipy/fftpack/basic.py
+++ b/scipy/fftpack/basic.py
@@ -378,6 +378,19 @@ def fft2(x, shape=None, axes=(-2,-1), overwrite_x=False):
     --------
     fftn : for detailed information.
 
+    Examples
+    --------
+    >>> from scipy.fftpack import fft2, ifft2
+    >>> import numpy as np
+    >>> y = np.mgrid[:5, :5][0]
+    >>> y
+    array([[0, 0, 0, 0, 0],
+           [1, 1, 1, 1, 1],
+           [2, 2, 2, 2, 2],
+           [3, 3, 3, 3, 3]
+           [4, 4, 4, 4, 4]])
+    >>> np.allclose(y, ifft2(fft2(y)))
+    True
     """
     return fftn(x,shape,axes,overwrite_x)
 

--- a/scipy/fftpack/basic.py
+++ b/scipy/fftpack/basic.py
@@ -381,7 +381,6 @@ def fft2(x, shape=None, axes=(-2,-1), overwrite_x=False):
     Examples
     --------
     >>> from scipy.fftpack import fft2, ifft2
-    >>> import numpy as np
     >>> y = np.mgrid[:5, :5][0]
     >>> y
     array([[0, 0, 0, 0, 0],
@@ -411,7 +410,6 @@ def ifft2(x, shape=None, axes=(-2,-1), overwrite_x=False):
     Examples
     --------
     >>> from scipy.fftpack import fft2, ifft2
-    >>> import numpy as np
     >>> y = np.mgrid[:5, :5][0]
     >>> y
     array([[0, 0, 0, 0, 0],

--- a/scipy/io/matlab/mio.py
+++ b/scipy/io/matlab/mio.py
@@ -266,7 +266,6 @@ def savemat(file_name, mdict,
     Examples
     --------
     >>> from scipy.io import savemat
-    >>> import numpy as np
     >>> a = np.arange(20)
     >>> mdic = {"a": a, "label": "experiment"}
     >>> mdic

--- a/scipy/io/matlab/mio.py
+++ b/scipy/io/matlab/mio.py
@@ -269,6 +269,7 @@ def savemat(file_name, mdict,
     >>> import numpy as np
     >>> a = np.arange(20)
     >>> mdic = {"a": a, "label": "experiment"}
+    >>> mdic
     {'a': array([ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16,
         17, 18, 19]),
     'label': 'experiment'}

--- a/scipy/io/matlab/mio.py
+++ b/scipy/io/matlab/mio.py
@@ -262,6 +262,17 @@ def savemat(file_name, mdict,
     oned_as : {'row', 'column'}, optional
         If 'column', write 1-D NumPy arrays as column vectors.
         If 'row', write 1-D NumPy arrays as row vectors.
+
+    Examples
+    --------
+    >>> from scipy.io import savemat
+    >>> import numpy as np
+    >>> a = np.arange(20)
+    >>> mdic = {"a": a, "label": "experiment"}
+    {'a': array([ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16,
+        17, 18, 19]),
+    'label': 'experiment'}
+    >>> savemat("matlab_matrix.mat", mdic)
     """
     with _open_file_context(file_name, appendmat, 'wb') as file_stream:
         if format == '4':


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Relates to #7168

#### What does this implement/fix?
Add docstring examples for:
 - `fftpack.fft2`
 - `fftpack.ifft2`
 - `io.savemat`