### PR TITLE
MAINT: add helper function for deprecating Cython API functions

### DIFF
--- a/doc/source/dev/contributor/public_cython_api.rst
+++ b/doc/source/dev/contributor/public_cython_api.rst
@@ -74,7 +74,8 @@ compile binaries without having to pay attention to ABI, i.e.,
     ABI compatibility = API compatibility
 
 Cython API backward/forward compatibility will be handled with a
-similar deprecation/removal policy as for the Python API.
+similar deprecation/removal policy as for the Python API, see
+:ref:`deprecations`.
 
 
 Implementing ABI stability in SciPy
@@ -120,3 +121,42 @@ necessary to maintain the ABI stability aim above:
   public API.  The interface declarations should not contain any
   declarations of struct members.  Allocation, freeing, and attribute
   access of data structures should be done with functions.
+
+
+.. _deprecating-public-cython-api:
+
+Deprecating public Cython APIs
+------------------------------
+
+To deprecate a public Cython API function, for example::
+
+    # scipy/something/foo.pxd
+    cdef public int somefunc()
+
+    # scipy/something/foo.pyx
+    cdef public int somefunc():
+        return 42
+
+you can add use the ``scipy._lib.deprecation.deprecate_cython_api``
+function to do the deprecations at the end of the corresponding
+``.pyx`` file::
+
+    # scipy/something/foo.pyx
+    cdef public int somefunc():
+        return 42
+
+    from scipy._lib.deprecation import deprecate_cython_api
+    import scipy.something.foo as mod
+    deprecate_cython_api(mod, "somefunc", new_name="scipy.something.newfunc",
+                         message="Deprecated in Scipy 1.5.0")
+    del deprecate_cython_api, mod
+
+After this, Cython modules that ``cimport somefunc``, will emit a
+`DeprecationWarning` at import time.
+
+There is no way to deprecate Cython data structures and types.  They
+can be however removed after all functions using them in the API are
+removed, having gone through the deprecation cycle.
+
+Whole Cython modules can be deprecated similarly as Python modules, by
+emitting a `DeprecationWarning` on the top-level.

--- a/doc/source/dev/core-dev/deprecations.rst.inc
+++ b/doc/source/dev/core-dev/deprecations.rst.inc
@@ -14,7 +14,8 @@ something from the public API:
 #. Propose to deprecate the functionality on the scipy-dev mailing list and get
    agreement that that's OK.
 #. Add a ``DeprecationWarning`` for it, which states that the functionality was
-   deprecated, and in which release.
+   deprecated, and in which release. For Cython APIs, see
+   :ref:`deprecating-public-cython-api` for the practical steps.
 #. Mention the deprecation in the release notes for that release.
 #. Wait till at least 6 months after the release date of the release that
    introduced the ``DeprecationWarning`` before removing the functionality.

--- a/scipy/_lib/_test_deprecation_call.pyx
+++ b/scipy/_lib/_test_deprecation_call.pyx
@@ -1,0 +1,4 @@
+from ._test_deprecation_def cimport foo, foo_deprecated
+
+def call():
+    return foo(), foo_deprecated()

--- a/scipy/_lib/_test_deprecation_def.pxd
+++ b/scipy/_lib/_test_deprecation_def.pxd
@@ -1,0 +1,3 @@
+cdef public int foo_deprecated()
+
+cdef public int foo()

--- a/scipy/_lib/_test_deprecation_def.pyx
+++ b/scipy/_lib/_test_deprecation_def.pyx
@@ -1,0 +1,11 @@
+cdef public int foo():
+    return 1
+
+cdef public int foo_deprecated():
+    return 1
+
+from scipy._lib.deprecation import deprecate_cython_api
+import scipy._lib._test_deprecation_def as mod
+deprecate_cython_api(mod, "foo_deprecated", new_name="foo",
+                     message="Deprecated in Scipy 42.0.0")
+del deprecate_cython_api, mod

--- a/scipy/_lib/deprecation.py
+++ b/scipy/_lib/deprecation.py
@@ -22,3 +22,86 @@ def _deprecated(msg, stacklevel=2):
         return call
 
     return wrap
+
+
+class _DeprecationHelperStr(object):
+    """
+    Helper class used by deprecate_cython_api
+    """
+    def __init__(self, content, message):
+        self._content = content
+        self._message = message
+
+    def __hash__(self):
+        return hash(self._content)
+
+    def __eq__(self, other):
+        res = (self._content == other)
+        if res:
+            warnings.warn(self._message, category=DeprecationWarning,
+                          stacklevel=2)
+        return res
+
+
+def deprecate_cython_api(module, routine_name, new_name=None, message=None):
+    """
+    Deprecate an exported cdef function in a public Cython API module.
+
+    Only functions can be deprecated; typedefs etc. cannot.
+
+    Parameters
+    ----------
+    module : module
+        Public Cython API module (e.g. scipy.linalg.cython_blas).
+    routine_name : str
+        Name of the routine to deprecate. May also be a fused-type
+        routine (in which case its all specializations are deprecated).
+    new_name : str
+        New name to include in the deprecation warning message
+    message : str
+        Additional text in the deprecation warning message
+
+    Examples
+    --------
+    Usually, this function would be used in the top-level of the
+    module ``.pyx`` file:
+
+    >>> from scipy._lib.deprecation import deprecate_cython_api
+    >>> import scipy.linalg.cython_blas as mod
+    >>> deprecate_cython_api(mod, "dgemm", "dgemm_new",
+    ...                      message="Deprecated in Scipy 1.5.0")
+    >>> del deprecate_cython_api, mod
+
+    After this, Cython modules that use the deprecated function emit a
+    deprecation warning when they are imported.
+
+    """
+    old_name = "{}.{}".format(module.__name__, routine_name)
+
+    if new_name is None:
+        depdoc = "`%s` is deprecated!" % old_name
+    else:
+        depdoc = "`%s` is deprecated, use `%s` instead!" % \
+                 (old_name, new_name)
+
+    if message is not None:
+        depdoc += "\n" + message
+
+    d = module.__pyx_capi__
+
+    # Check if the function is a fused-type function with a mangled name
+    j = 0
+    has_fused = False
+    while True:
+        fused_name = "__pyx_fuse_{}{}".format(j, routine_name)
+        if fused_name in d:
+            has_fused = True
+            d[_DeprecationHelperStr(fused_name, depdoc)] = d.pop(fused_name)
+            j += 1
+        else:
+            break
+
+    # If not, apply deprecation to the named routine
+    if not has_fused:
+        d[_DeprecationHelperStr(routine_name, depdoc)] = d.pop(routine_name)
+

--- a/scipy/_lib/setup.py
+++ b/scipy/_lib/setup.py
@@ -41,6 +41,14 @@ def configuration(parent_package='',top_path=None):
                          depends=depends,
                          include_dirs=[include_dir])
 
+    config.add_extension("_test_deprecation_call",
+                         sources=["_test_deprecation_call.c"],
+                         include_dirs=[include_dir])
+
+    config.add_extension("_test_deprecation_def",
+                         sources=["_test_deprecation_def.c"],
+                         include_dirs=[include_dir])
+
     config.add_subpackage('_uarray')
 
     return config

--- a/scipy/_lib/tests/test_deprecation.py
+++ b/scipy/_lib/tests/test_deprecation.py
@@ -1,0 +1,10 @@
+import pytest
+
+
+def test_cython_api_deprecation():
+    match = ("`scipy._lib._test_deprecation_def.foo_deprecated` "
+             "is deprecated, use `foo` instead!\n"
+             "Deprecated in Scipy 42.0.0")
+    with pytest.warns(DeprecationWarning, match=match):
+        from .. import _test_deprecation_call
+    assert _test_deprecation_call.call() == (1, 1)


### PR DESCRIPTION
#### Reference issue
See gh-6440, https://github.com/scipy/scipy/pull/11792#pullrequestreview-387841332

#### What does this implement/fix?
Add a mechanism for marking public `cdef` Cython API functions as deprecated, and the corresponding documentation.
