### PR TITLE
MAINT: special: add types for geterr/seterr/errstate

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -12,6 +12,9 @@ show_error_codes = True
 [mypy-scipy.special.tests.test_orthogonal]
 check_untyped_defs = True
 
+[mypy-scipy.special.tests.test_sf_error]
+check_untyped_defs = True
+
 #
 # The ratchet
 #

--- a/scipy/special/_generate_pyx.py
+++ b/scipy/special/_generate_pyx.py
@@ -135,13 +135,29 @@ include "_cython_special.pxi"
 """
 
 STUBS = """\
-from typing import Any, Type
+from typing import Any, Dict
 
 import numpy as np
 
 __all__ = [
+    'geterr',
+    'seterr',
+    'errstate',
     {ALL}
 ]
+
+def geterr() -> Dict[str, str]: ...
+def seterr(**kwargs: str) -> Dict[str, str]: ...
+
+class errstate:
+    def __init__(self, **kargs: str) -> None: ...
+    def __enter__(self) -> None: ...
+    def __exit__(
+        self,
+        exc_type: Any,  # Unused
+        exc_value: Any,  # Unused
+        traceback: Any,  # Unused
+    ) -> None: ...
 
 {STUBS}
 


### PR DESCRIPTION
#### Reference issue
https://github.com/scipy/scipy/issues/11749

#### What does this implement/fix?
They are included in the _ufuncs extension module, so add stubs for
them to `_ufuncs.pyi`. Test the new types by enabling type checking
for `test_sf_error.py`.

#### Additional information
Hit this while experimenting with doing

```
[mypy-scipy.special.tests.*]
check_untyped_defs = True
```

which is proving to be a good way to find problems that need addressing.