### PR TITLE
MAINT: add py.typed marker

### DIFF
--- a/scipy/setup.py
+++ b/scipy/setup.py
@@ -25,6 +25,7 @@ def configuration(parent_package='',top_path=None):
     config.add_subpackage('_build_utils')
     config.add_subpackage('_lib')
     config.make_config_py()
+    config.add_data_files('py.typed')
     return config
 
 


### PR DESCRIPTION
#### Reference issue
Closes https://github.com/scipy/scipy/issues/11945

#### What does this implement/fix?
Allow third parties to try out our types. Tested this by

- installing from this branch
- running mypy on the following script:

  ```python
  import scipy.special as sc

  sc.chebyt('foo')
  sc.chebyt(1)
  ```

  which gave the following results:

  ```
  test_mypy.py:3: error: Argument 1 to "chebyt" has incompatible type "str"; expected "Union[int, integer]"
  Found 1 error in 1 file (checked 1 source file)
  ```

#### Additional information
None