### PR TITLE
MAINT: type sph vor function signatures

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -113,6 +113,7 @@ pygments_style = 'sphinx'
 
 # Ensure all our internal links work
 nitpicky = True
+nitpick_ignore = [('py:class', 'Union[numpy.ndarray, List, None]')]
 exclude_patterns = [  # glob-style
 
 ]

--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -11,6 +11,7 @@ Spherical Voronoi Code
 # Distributed under the same BSD license as SciPy.
 #
 
+from typing import Optional, List, Union
 import warnings
 import numpy as np
 import scipy
@@ -20,7 +21,7 @@ from scipy.spatial import cKDTree
 __all__ = ['SphericalVoronoi']
 
 
-def calculate_solid_angles(R):
+def calculate_solid_angles(R: np.ndarray):
     """Calculates the solid angles of plane triangles. Implements the method of
     Van Oosterom and Strackee [VanOosterom]_ with some modifications. Assumes
     that input points have unit norm."""
@@ -163,7 +164,11 @@ class SphericalVoronoi:
     >>> plt.show()
 
     """
-    def __init__(self, points, radius=1, center=None, threshold=1e-06):
+    def __init__(self,
+                 points: np.ndarray,
+                 radius: Optional[float] = 1,
+                 center: Optional[Union[np.ndarray, List]] = None,
+                 threshold: float = 1e-06):
 
         if radius is None:
             radius = 1.

--- a/scipy/spatial/ckdtree.pyi
+++ b/scipy/spatial/ckdtree.pyi
@@ -4,14 +4,14 @@ import numpy as np
 class cKDTree:
     def __init__(self,
                  data: np.ndarray,
-                 leafsize: int = 16,
-                 compact_nodes: bool = True,
-                 copy_data: bool = False,
-                 balanced_tree: bool = True,
-                 boxsize: Optional[Union[np.ndarray, float]] = None) -> None: ...
+                 leafsize: int = ...,
+                 compact_nodes: bool = ...,
+                 copy_data: bool = ...,
+                 balanced_tree: bool = ...,
+                 boxsize: Optional[Union[np.ndarray, float]] = ...) -> None: ...
 
     def query_pairs(self,
                     r: float,
-                    p: float = 2.,
-                    eps: float = 0,
-                    output_type: str = 'set') -> Union[set, np.ndarray]: ...
+                    p: float = ...,
+                    eps: float = ...,
+                    output_type: str = ...) -> Union[set, np.ndarray]: ...

--- a/scipy/spatial/ckdtree.pyi
+++ b/scipy/spatial/ckdtree.pyi
@@ -1,1 +1,17 @@
-class cKDTree: ...
+from typing import Union, Optional
+import numpy as np
+
+class cKDTree:
+    def __init__(self,
+                 data: np.ndarray,
+                 leafsize: int = 16,
+                 compact_nodes: bool = True,
+                 copy_data: bool = False,
+                 balanced_tree: bool = True,
+                 boxsize: Optional[Union[np.ndarray, float]] = None) -> None: ...
+
+    def query_pairs(self,
+                    r: float,
+                    p: float = 2.,
+                    eps: float = 0,
+                    output_type: str = 'set') -> Union[set, np.ndarray]: ...


### PR DESCRIPTION
* add type hints to `_spherical_voronoi.py` module
function signatures

* expansion of the `ckdtree.pyi` stub module with a few
more call signatures was needed to allow type checking of
the Cython calls without errors