### PR TITLE
MAINT: Use np.errstate context manager instead of np.seterr.

### DIFF
--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -294,11 +294,8 @@ class TestEig(object):
                    [16, 25, 27, 14, 23],
                    [24, 35, 18, 21, 22]])
 
-        olderr = np.seterr(all='ignore')
-        try:
+        with np.errstate(all='ignore'):
             self._check_gen_eig(A, B)
-        finally:
-            np.seterr(**olderr)
 
     def test_falker(self):
         # Test matrices giving some Nan generalized eigenvalues.
@@ -310,11 +307,8 @@ class TestEig(object):
         A = bmat([[I3, Z], [Z, -K]])
         B = bmat([[Z, I3], [M, D]])
 
-        olderr = np.seterr(all='ignore')
-        try:
+        with np.errstate(all='ignore'):
             self._check_gen_eig(A, B)
-        finally:
-            np.seterr(**olderr)
 
     def test_bad_geneig(self):
         # Ticket #709 (strange return values from DGGEV)
@@ -334,13 +328,10 @@ class TestEig(object):
 
         # With a buggy LAPACK, this can fail for different omega on different
         # machines -- so we need to test several values
-        olderr = np.seterr(all='ignore')
-        try:
+        with np.errstate(all='ignore'):
             for k in range(100):
                 A, B = matrices(omega=k*5./100)
                 self._check_gen_eig(A, B)
-        finally:
-            np.seterr(**olderr)
 
     def test_make_eigvals(self):
         # Step through all paths in _make_eigvals
@@ -2276,12 +2267,8 @@ class TestOrdQZ(object):
         cls.B = [B1, B2, B3, B4, A5]
 
     def qz_decomp(self, sort):
-        try:
-            olderr = np.seterr('raise')
+        with np.errstate(all='raise'):
             ret = [ordqz(Ai, Bi, sort=sort) for Ai, Bi in zip(self.A, self.B)]
-        finally:
-            np.seterr(**olderr)
-
         return tuple(ret)
 
     def check(self, A, B, sort, AA, BB, alpha, beta, Q, Z):

--- a/scipy/ndimage/tests/test_measurements.py
+++ b/scipy/ndimage/tests/test_measurements.py
@@ -540,16 +540,13 @@ def test_mean03():
 
 def test_mean04():
     labels = np.array([[1, 2], [2, 4]], np.int8)
-    olderr = np.seterr(all='ignore')
-    try:
+    with np.errstate(all='ignore'):
         for type in types:
             input = np.array([[1, 2], [3, 4]], type)
             output = ndimage.mean(input, labels=labels,
                                             index=[4, 8, 2])
             assert_array_almost_equal(output[[0,2]], [4.0, 2.5])
             assert_(np.isnan(output[1]))
-    finally:
-        np.seterr(**olderr)
 
 
 def test_minimum01():
@@ -660,16 +657,13 @@ def test_median03():
 
 
 def test_variance01():
-    olderr = np.seterr(all='ignore')
-    try:
+    with np.errstate(all='ignore'):
         for type in types:
             input = np.array([], type)
             with suppress_warnings() as sup:
                 sup.filter(RuntimeWarning, "Mean of empty slice")
                 output = ndimage.variance(input)
             assert_(np.isnan(output))
-    finally:
-        np.seterr(**olderr)
 
 
 def test_variance02():
@@ -702,27 +696,21 @@ def test_variance05():
 
 def test_variance06():
     labels = [2, 2, 3, 3, 4]
-    olderr = np.seterr(all='ignore')
-    try:
+    with np.errstate(all='ignore'):
         for type in types:
             input = np.array([1, 3, 8, 10, 8], type)
             output = ndimage.variance(input, labels, [2, 3, 4])
             assert_array_almost_equal(output, [1.0, 1.0, 0.0])
-    finally:
-        np.seterr(**olderr)
 
 
 def test_standard_deviation01():
-    olderr = np.seterr(all='ignore')
-    try:
+    with np.errstate(all='ignore'):
         for type in types:
             input = np.array([], type)
             with suppress_warnings() as sup:
                 sup.filter(RuntimeWarning, "Mean of empty slice")
                 output = ndimage.standard_deviation(input)
             assert_(np.isnan(output))
-    finally:
-        np.seterr(**olderr)
 
 
 def test_standard_deviation02():
@@ -755,26 +743,20 @@ def test_standard_deviation05():
 
 def test_standard_deviation06():
     labels = [2, 2, 3, 3, 4]
-    olderr = np.seterr(all='ignore')
-    try:
+    with np.errstate(all='ignore'):
         for type in types:
             input = np.array([1, 3, 8, 10, 8], type)
             output = ndimage.standard_deviation(input, labels, [2, 3, 4])
             assert_array_almost_equal(output, [1.0, 1.0, 0.0])
-    finally:
-        np.seterr(**olderr)
 
 
 def test_standard_deviation07():
     labels = [1]
-    olderr = np.seterr(all='ignore')
-    try:
+    with np.errstate(all='ignore'):
         for type in types:
             input = np.array([-0.00619519], type)
             output = ndimage.standard_deviation(input, labels, [1])
             assert_array_almost_equal(output, [0])
-    finally:
-        np.seterr(**olderr)
 
 
 def test_minimum_position01():

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -837,11 +837,8 @@ class TestFixedPoint(object):
         def func(x):
             return 2.0*x
         x0 = [0.3, 0.15]
-        olderr = np.seterr(all='ignore')
-        try:
+        with np.errstate(all='ignore'):
             x = fixed_point(func, x0)
-        finally:
-            np.seterr(**olderr)
         assert_almost_equal(x, [0.0, 0.0])
 
     def test_array_basic1(self):
@@ -850,11 +847,8 @@ class TestFixedPoint(object):
             return c * x**2
         c = array([0.75, 1.0, 1.25])
         x0 = [1.1, 1.15, 0.9]
-        olderr = np.seterr(all='ignore')
-        try:
+        with np.errstate(all='ignore'):
             x = fixed_point(func, x0, args=(c,))
-        finally:
-            np.seterr(**olderr)
         assert_almost_equal(x, 1.0/c)
 
     def test_array_basic2(self):

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -179,8 +179,7 @@ class CheckOptimizeParameterized(CheckOptimize):
         func = lambda x: -np.e**-x
         fprime = lambda x: -func(x)
         x0 = [0]
-        olderr = np.seterr(over='ignore')
-        try:
+        with np.errstate(over='ignore'):
             if self.use_wrapper:
                 opts = {'disp': self.disp}
                 x = optimize.minimize(func, x0, jac=fprime, method='BFGS',
@@ -188,8 +187,6 @@ class CheckOptimizeParameterized(CheckOptimize):
             else:
                 x = optimize.fmin_bfgs(func, x0, fprime, disp=self.disp)
             assert_(not np.isfinite(func(x)))
-        finally:
-            np.seterr(**olderr)
 
     def test_powell(self):
         # Powell (direction set) optimization routine

--- a/scipy/sparse/csgraph/tests/test_conversions.py
+++ b/scipy/sparse/csgraph/tests/test_conversions.py
@@ -12,11 +12,8 @@ def test_csgraph_from_dense():
 
     for null_value in [0, np.nan, np.inf]:
         G[all_nulls] = null_value
-        olderr = np.seterr(invalid="ignore")
-        try:
+        with np.errstate(invalid="ignore"):
             G_csr = csgraph_from_dense(G, null_value=0)
-        finally:
-            np.seterr(**olderr)
 
         G[all_nulls] = 0
         assert_array_almost_equal(G, G_csr.toarray())
@@ -24,11 +21,8 @@ def test_csgraph_from_dense():
     for null_value in [np.nan, np.inf]:
         G[all_nulls] = 0
         G[some_nulls] = null_value
-        olderr = np.seterr(invalid="ignore")
-        try:
+        with np.errstate(invalid="ignore"):
             G_csr = csgraph_from_dense(G, null_value=0)
-        finally:
-            np.seterr(**olderr)
 
         G[all_nulls] = 0
         assert_array_almost_equal(G, G_csr.toarray())

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -1215,8 +1215,7 @@ def canberra(u, v, w=None):
     v = _validate_vector(v, dtype=np.float64)
     if w is not None:
         w = _validate_weights(w)
-    olderr = np.seterr(invalid='ignore')
-    try:
+    with np.errstate(invalid='ignore'):
         abs_uv = abs(u - v)
         abs_u = abs(u)
         abs_v = abs(v)
@@ -1224,8 +1223,6 @@ def canberra(u, v, w=None):
         if w is not None:
             d = w * d
         d = np.nansum(d)
-    finally:
-        np.seterr(**olderr)
     return d
 
 

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -303,11 +303,8 @@ class TestUtilities(object):
         eps = np.finfo(float).eps
 
         c = barycentric_transform(tri.transform, centroids)
-        olderr = np.seterr(invalid="ignore")
-        try:
+        with np.errstate(invalid="ignore"):
             ok = np.isnan(c).all(axis=1) | (abs(c - sc)/sc < 0.1).all(axis=1)
-        finally:
-            np.seterr(**olderr)
 
         assert_(ok.all(), "%s %s" % (err_msg, np.nonzero(~ok)))
 

--- a/scipy/special/_testutils.py
+++ b/scipy/special/_testutils.py
@@ -255,8 +255,7 @@ class FuncData(object):
             nan_x = np.isnan(x)
             nan_y = np.isnan(y)
 
-            olderr = np.seterr(all='ignore')
-            try:
+            with np.errstate(all='ignore'):
                 abs_y = np.absolute(y)
                 abs_y[~np.isfinite(abs_y)] = 0
                 diff = np.absolute(x - y)
@@ -264,8 +263,6 @@ class FuncData(object):
 
                 rdiff = diff / np.absolute(y)
                 rdiff[~np.isfinite(rdiff)] = 0
-            finally:
-                np.seterr(**olderr)
 
             tol_mask = (diff <= atol + rtol*abs_y)
             pinf_mask = (pinf_x == pinf_y)

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1602,8 +1602,7 @@ class TestErf(object):
         y = np.random.pareto(0.02, n) * (2*np.random.randint(0, 2, n) - 1)
         z = x + 1j*y
 
-        old_errors = np.seterr(all='ignore')
-        try:
+        with np.errstate(all='ignore'):
             w = other_func(z)
             w_real = other_func(x).real
 
@@ -1618,8 +1617,6 @@ class TestErf(object):
             # test both real and complex variants
             assert_func_equal(func, w, z, rtol=rtol, atol=atol)
             assert_func_equal(func, w_real, x, rtol=rtol, atol=atol)
-        finally:
-            np.seterr(**old_errors)
 
     def test_erfc_consistent(self):
         self._check_variant_func(
@@ -1700,12 +1697,9 @@ class TestEuler(object):
                 correct[2*k] = -float(mathworld[k])
             else:
                 correct[2*k] = float(mathworld[k])
-        olderr = np.seterr(all='ignore')
-        try:
+        with np.errstate(all='ignore'):
             err = nan_to_num((eu24-correct)/correct)
             errmax = max(err)
-        finally:
-            np.seterr(**olderr)
         assert_almost_equal(errmax, 0.0, 14)
 
 
@@ -2541,11 +2535,8 @@ class TestBessel(object):
         self.check_cephes_vs_amos(special.yv, special.yn, rtol=1e-11, atol=1e-305, skip=skipper)
 
     def test_iv_cephes_vs_amos(self):
-        olderr = np.seterr(all='ignore')
-        try:
+        with np.errstate(all='ignore'):
             self.check_cephes_vs_amos(special.iv, special.iv, rtol=5e-9, atol=1e-305)
-        finally:
-            np.seterr(**olderr)
 
     @pytest.mark.slow
     def test_iv_cephes_vs_amos_mass_test(self):
@@ -2557,8 +2548,7 @@ class TestBessel(object):
         imsk = (np.random.randint(8, size=N) == 0)
         v[imsk] = v[imsk].astype(int)
 
-        old_err = np.seterr(all='ignore')
-        try:
+        with np.errstate(all='ignore'):
             c1 = special.iv(v, x)
             c2 = special.iv(v, x+0j)
 
@@ -2570,8 +2560,6 @@ class TestBessel(object):
 
             dc = abs(c1/c2 - 1)
             dc[np.isnan(dc)] = 0
-        finally:
-            np.seterr(**old_err)
 
         k = np.argmax(dc)
 
@@ -2911,11 +2899,8 @@ class TestLegendreFunctions(object):
 
         # XXX: this is outside the domain of the current implementation,
         #      so ensure it returns a NaN rather than a wrong answer.
-        olderr = np.seterr(all='ignore')
-        try:
+        with np.errstate(all='ignore'):
             lp = special.lpmv(-1,-1,.001)
-        finally:
-            np.seterr(**olderr)
         assert_(lp != 0 or np.isnan(lp))
 
     def test_lqmn(self):

--- a/scipy/special/tests/test_data.py
+++ b/scipy/special/tests/test_data.py
@@ -491,8 +491,5 @@ def _test_factory(test, dtype=np.double):
     """Boost test"""
     with suppress_warnings() as sup:
         sup.filter(IntegrationWarning, "The occurrence of roundoff error is detected")
-        olderr = np.seterr(all='ignore')
-        try:
+        with np.errstate(all='ignore'):
             test.check(dtype=dtype)
-        finally:
-            np.seterr(**olderr)

--- a/scipy/special/tests/test_lambertw.py
+++ b/scipy/special/tests/test_lambertw.py
@@ -79,11 +79,8 @@ def test_values():
 
     def w(x, y):
         return lambertw(x, y.real.astype(int))
-    olderr = np.seterr(all='ignore')
-    try:
+    with np.errstate(all='ignore'):
         FuncData(w, data, (0,1), 2, rtol=1e-10, atol=1e-13).check()
-    finally:
-        np.seterr(**olderr)
 
 
 def test_ufunc():

--- a/scipy/special/tests/test_logit.py
+++ b/scipy/special/tests/test_logit.py
@@ -8,11 +8,8 @@ class TestLogit(object):
     def check_logit_out(self, dtype, expected):
         a = np.linspace(0,1,10)
         a = np.array(a, dtype=dtype)
-        olderr = np.seterr(divide='ignore')
-        try:
+        with np.errstate(divide='ignore'):
             actual = logit(a)
-        finally:
-            np.seterr(**olderr)
 
         assert_almost_equal(actual, expected)
 
@@ -36,11 +33,8 @@ class TestLogit(object):
 
     def test_nan(self):
         expected = np.array([np.nan]*4)
-        olderr = np.seterr(invalid='ignore')
-        try:
+        with np.errstate(invalid='ignore'):
             actual = logit(np.array([-3., -2., 2., 3.]))
-        finally:
-            np.seterr(**olderr)
 
         assert_equal(expected, actual)
 

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -167,11 +167,8 @@ def test_hyp2f1_real_some_points():
     dataset = [p + (float(mpmath.hyp2f1(*p)),) for p in pts]
     dataset = np.array(dataset, dtype=np.float_)
 
-    olderr = np.seterr(invalid='ignore')
-    try:
+    with np.errstate(invalid='ignore'):
         FuncData(sc.hyp2f1, dataset, (0,1,2,3), 4, rtol=1e-10).check()
-    finally:
-        np.seterr(**olderr)
 
 
 @check_version(mpmath, '0.14')
@@ -210,12 +207,9 @@ def test_hyp2f1_real_some():
                     dataset.append((a, b, c, z, v))
     dataset = np.array(dataset, dtype=np.float_)
 
-    olderr = np.seterr(invalid='ignore')
-    try:
+    with np.errstate(invalid='ignore'):
         FuncData(sc.hyp2f1, dataset, (0,1,2,3), 4, rtol=1e-9,
                  ignore_inf_sign=True).check()
-    finally:
-        np.seterr(**olderr)
 
 
 @check_version(mpmath, '0.12')
@@ -317,11 +311,8 @@ def test_lpmv():
     def evf(mu, nu, x):
         return sc.lpmv(mu.astype(int), nu, x)
 
-    olderr = np.seterr(invalid='ignore')
-    try:
+    with np.errstate(invalid='ignore'):
         FuncData(evf, dataset, (0,1,2), 3, rtol=1e-10, atol=1e-14).check()
-    finally:
-        np.seterr(**olderr)
 
 
 # ------------------------------------------------------------------------------
@@ -827,11 +818,8 @@ class TestSystematic(object):
             r = complex(mpmath.bessely(v, x, **HYPERKW))
             if abs(r) > 1e305:
                 # overflowing to inf a bit earlier is OK
-                olderr = np.seterr(invalid='ignore')
-                try:
+                with np.errstate(invalid='ignore'):
                     r = np.inf * np.sign(r)
-                finally:
-                    np.seterr(**olderr)
             return r
         assert_mpmath_equal(lambda v, z: sc.yv(v.real, z),
                             exception_to_nan(mpbessely),

--- a/scipy/special/tests/test_orthogonal.py
+++ b/scipy/special/tests/test_orthogonal.py
@@ -14,14 +14,11 @@ class TestCheby(object):
     def test_chebyc(self):
         C0 = orth.chebyc(0)
         C1 = orth.chebyc(1)
-        olderr = np.seterr(all='ignore')
-        try:
+        with np.errstate(all='ignore'):
             C2 = orth.chebyc(2)
             C3 = orth.chebyc(3)
             C4 = orth.chebyc(4)
             C5 = orth.chebyc(5)
-        finally:
-            np.seterr(**olderr)
 
         assert_array_almost_equal(C0.c,[2],13)
         assert_array_almost_equal(C1.c,[1,0],13)
@@ -263,14 +260,11 @@ class TestCall(object):
                 orth.sh_legendre(%(n)d)
                 """ % dict(n=n)).split()
             ])
-        olderr = np.seterr(all='ignore')
-        try:
+        with np.errstate(all='ignore'):
             for pstr in poly:
                 p = eval(pstr)
                 assert_almost_equal(p(0.315), np.poly1d(p.coef)(0.315),
                                     err_msg=pstr)
-        finally:
-            np.seterr(**olderr)
 
 
 class TestGenlaguerre(object):

--- a/scipy/special/tests/test_orthogonal_eval.py
+++ b/scipy/special/tests/test_orthogonal_eval.py
@@ -22,14 +22,11 @@ def test_eval_genlaguerre_restriction():
 
 def test_warnings():
     # ticket 1334
-    olderr = np.seterr(all='raise')
-    try:
+    with np.errstate(all='raise'):
         # these should raise no fp warnings
         orth.eval_legendre(1, 0)
         orth.eval_laguerre(1, 1)
         orth.eval_gegenbauer(1, 1, 0)
-    finally:
-        np.seterr(**olderr)
 
 
 class TestPolys(object):
@@ -66,13 +63,10 @@ class TestPolys(object):
             p = (p[0].astype(int),) + p[1:]
             return func(*p)
 
-        olderr = np.seterr(all='raise')
-        try:
+        with np.errstate(all='raise'):
             ds = FuncData(polyfunc, dataset, list(range(len(param_ranges)+2)), -1,
                           rtol=rtol)
             ds.check()
-        finally:
-            np.seterr(**olderr)
 
     def test_jacobi(self):
         self.check_poly(orth.eval_jacobi, orth.jacobi,
@@ -106,12 +100,9 @@ class TestPolys(object):
                    param_ranges=[], x_range=[-2, 2])
 
     def test_sh_chebyt(self):
-        olderr = np.seterr(all='ignore')
-        try:
+        with np.errstate(all='ignore'):
             self.check_poly(orth.eval_sh_chebyt, orth.sh_chebyt,
                             param_ranges=[], x_range=[0, 1])
-        finally:
-            np.seterr(**olderr)
 
     def test_sh_chebyu(self):
         self.check_poly(orth.eval_sh_chebyu, orth.sh_chebyu,
@@ -122,12 +113,9 @@ class TestPolys(object):
                    param_ranges=[], x_range=[-1, 1])
 
     def test_sh_legendre(self):
-        olderr = np.seterr(all='ignore')
-        try:
+        with np.errstate(all='ignore'):
             self.check_poly(orth.eval_sh_legendre, orth.sh_legendre,
                             param_ranges=[], x_range=[0, 1])
-        finally:
-            np.seterr(**olderr)
 
     def test_genlaguerre(self):
         self.check_poly(orth.eval_genlaguerre, orth.genlaguerre,
@@ -181,13 +169,10 @@ class TestRecurrence(object):
             kw = dict(sig='l'+(len(p)-1)*'d'+'->d')
             return func(*p, **kw)
 
-        olderr = np.seterr(all='raise')
-        try:
+        with np.errstate(all='raise'):
             ds = FuncData(polyfunc, dataset, list(range(len(param_ranges)+2)), -1,
                           rtol=rtol)
             ds.check()
-        finally:
-            np.seterr(**olderr)
 
     def test_jacobi(self):
         self.check_poly(orth.eval_jacobi,

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -775,9 +775,8 @@ class rv_generic(object):
     # The primed mu is a widely used notation for the noncentral moment.
     def _munp(self, n, *args):
         # Silence floating point warnings from integration.
-        olderr = np.seterr(all='ignore')
-        vals = self.generic_moment(n, *args)
-        np.seterr(**olderr)
+        with np.errstate(all='ignore'):
+            vals = self.generic_moment(n, *args)
         return vals
 
     def _argcheck_rvs(self, *args, **kwargs):
@@ -2412,9 +2411,8 @@ class rv_continuous(rv_generic):
 
         # upper limit is often inf, so suppress warnings when integrating
         _a, _b = self._get_support(*args)
-        olderr = np.seterr(over='ignore')
-        h = integrate.quad(integ, _a, _b)[0]
-        np.seterr(**olderr)
+        with np.errstate(over='ignore'):
+            h = integrate.quad(integ, _a, _b)[0]
 
         if not np.isnan(h):
             return h
@@ -2530,9 +2528,8 @@ class rv_continuous(rv_generic):
             invfac = 1.0
         kwds['args'] = args
         # Silence floating point warnings from integration.
-        olderr = np.seterr(all='ignore')
-        vals = integrate.quad(fun, lb, ub, **kwds)[0] / invfac
-        np.seterr(**olderr)
+        with np.errstate(all='ignore'):
+            vals = integrate.quad(fun, lb, ub, **kwds)[0] / invfac
         return vals
 
 

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -518,13 +518,10 @@ def spearmanr(x, y=None, use_ties=True, axis=None, nan_policy='propagate'):
         rs = ma.corrcoef(x_ranked, rowvar=False).data
 
         # rs can have elements equal to 1, so avoid zero division warnings
-        olderr = np.seterr(divide='ignore')
-        try:
+        with np.errstate(divide='ignore'):
             # clip the small negative values possibly caused by rounding
             # errors before taking the square root
             t = rs * np.sqrt((dof / ((rs+1.0) * (1.0-rs))).clip(0))
-        finally:
-            np.seterr(**olderr)
 
         prob = 2 * distributions.t.sf(np.abs(t), dof)
 
@@ -2250,11 +2247,8 @@ def skew(a, axis=0, bias=True):
     n = a.count(axis)
     m2 = moment(a, 2, axis)
     m3 = moment(a, 3, axis)
-    olderr = np.seterr(all='ignore')
-    try:
+    with np.errstate(all='ignore'):
         vals = ma.where(m2 == 0, 0, m3 / m2**1.5)
-    finally:
-        np.seterr(**olderr)
 
     if not bias:
         can_correct = (n > 2) & (m2 > 0)
@@ -2306,11 +2300,8 @@ def kurtosis(a, axis=0, fisher=True, bias=True):
     a, axis = _chk_asarray(a, axis)
     m2 = moment(a, 2, axis)
     m4 = moment(a, 4, axis)
-    olderr = np.seterr(all='ignore')
-    try:
+    with np.errstate(all='ignore'):
         vals = ma.where(m2 == 0, 0, m4 / m2**2.0)
-    finally:
-        np.seterr(**olderr)
 
     if not bias:
         n = a.count(axis)

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1234,11 +1234,8 @@ def kurtosis(a, axis=0, fisher=True, bias=True, nan_policy='propagate'):
     m2 = moment(a, 2, axis)
     m4 = moment(a, 4, axis)
     zero = (m2 == 0)
-    olderr = np.seterr(all='ignore')
-    try:
+    with np.errstate(all='ignore'):
         vals = np.where(zero, 0, m4 / m2**2.0)
-    finally:
-        np.seterr(**olderr)
 
     if not bias:
         can_correct = (n > 3) & (m2 > 0)
@@ -3797,13 +3794,10 @@ def spearmanr(a, b=None, axis=0, nan_policy='propagate'):
     dof = n_obs - 2  # degrees of freedom
 
     # rs can have elements equal to 1, so avoid zero division warnings
-    olderr = np.seterr(divide='ignore')
-    try:
+    with np.errstate(divide='ignore'):
         # clip the small negative values possibly caused by rounding
         # errors before taking the square root
         t = rs * np.sqrt((dof/((rs+1.0)*(1.0-rs))).clip(0))
-    finally:
-        np.seterr(**olderr)
 
     prob = 2 * distributions.t.sf(np.abs(t), dof)
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3340,8 +3340,7 @@ def test_regression_tukey_lambda():
     # non-positive lambdas.
     x = np.linspace(-5.0, 5.0, 101)
 
-    olderr = np.seterr(divide='ignore')
-    try:
+    with np.errstate(divide='ignore'):
         for lam in [0.0, -1.0, -2.0, np.array([[-1.0], [0.0], [-2.0]])]:
             p = stats.tukeylambda.pdf(x, lam)
             assert_((p != 0.0).all())
@@ -3349,8 +3348,6 @@ def test_regression_tukey_lambda():
 
         lam = np.array([[-1.0], [0.0], [2.0]])
         p = stats.tukeylambda.pdf(x, lam)
-    finally:
-        np.seterr(**olderr)
 
     assert_(~np.isnan(p).all())
     assert_((p[0] != 0.0).all())
@@ -3391,11 +3388,8 @@ def test_frozen_fit_ticket_1536():
     true = np.array([0.25, 0., 0.5])
     x = stats.lognorm.rvs(true[0], true[1], true[2], size=100)
 
-    olderr = np.seterr(divide='ignore')
-    try:
+    with np.errstate(divide='ignore'):
         params = np.array(stats.lognorm.fit(x, floc=0.))
-    finally:
-        np.seterr(**olderr)
 
     assert_almost_equal(params, true, decimal=2)
 
@@ -3543,8 +3537,7 @@ def test_ksone_fit_freeze():
          -0.10943985, -0.35243174, 0.06897665, -0.03553363, -0.0701746,
          -0.06037974, 0.37670779, -0.21684405])
 
-    try:
-        olderr = np.seterr(invalid='ignore')
+    with np.errstate(invalid='ignore'):
         with suppress_warnings() as sup:
             sup.filter(IntegrationWarning,
                        "The maximum number of subdivisions .50. has been "
@@ -3552,8 +3545,6 @@ def test_ksone_fit_freeze():
             sup.filter(RuntimeWarning,
                        "floating point number truncated to an integer")
             stats.ksone.fit(d)
-    finally:
-        np.seterr(**olderr)
 
 
 def test_norm_logcdf():

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -202,11 +202,8 @@ class TestAnderson(object):
         x2 = rs.standard_normal(size=50)
         A, crit, sig = stats.anderson(x1, 'expon')
         assert_array_less(A, crit[-2:])
-        olderr = np.seterr(all='ignore')
-        try:
+        with np.errstate(all='ignore'):
             A, crit, sig = stats.anderson(x2, 'expon')
-        finally:
-            np.seterr(**olderr)
         assert_(A > crit[-1])
 
     def test_gumbel(self):

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -79,21 +79,15 @@ class TestGeoMean(object):
         #  Test a 1d masked array with zero element
         a = np.ma.array([10, 20, 30, 40, 50, 60, 70, 80, 90, 0])
         desired = 41.4716627439
-        olderr = np.seterr(all='ignore')
-        try:
+        with np.errstate(all='ignore'):
             check_equal_gmean(a, desired)
-        finally:
-            np.seterr(**olderr)
 
     def test_1d_ma_inf(self):
         #  Test a 1d masked array with negative element
         a = np.ma.array([10, 20, 30, 40, 50, 60, 70, 80, 90, -1])
         desired = 41.4716627439
-        olderr = np.seterr(all='ignore')
-        try:
+        with np.errstate(all='ignore'):
             check_equal_gmean(a, desired)
-        finally:
-            np.seterr(**olderr)
 
     @pytest.mark.skipif(not hasattr(np, 'float96'), reason='cannot find float96 so skipping')
     def test_1d_float96(self):
@@ -1392,8 +1386,7 @@ class TestCompareWithStats(object):
                 assert_equal(r[0][1], rm[0][1])
 
     def test_normaltest(self):
-        np.seterr(over='raise')
-        with suppress_warnings() as sup:
+        with np.errstate(over='raise'), suppress_warnings() as sup:
             sup.filter(UserWarning, "kurtosistest only valid for n>=20")
             for n in self.get_n():
                 if n > 8:

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4072,21 +4072,15 @@ class TestGeoMean(object):
         #  Test a 1d list with zero element
         a = [10, 20, 30, 40, 50, 60, 70, 80, 90, 0]
         desired = 0.0  # due to exp(-inf)=0
-        olderr = np.seterr(all='ignore')
-        try:
+        with np.errstate(all='ignore'):
             check_equal_gmean(a, desired)
-        finally:
-            np.seterr(**olderr)
 
     def test_1d_array0(self):
         #  Test a 1d array with zero element
         a = np.array([10, 20, 30, 40, 50, 60, 70, 80, 90, 0])
         desired = 0.0  # due to exp(-inf)=0
-        olderr = np.seterr(all='ignore')
-        try:
+        with np.errstate(all='ignore'):
             check_equal_gmean(a, desired)
-        finally:
-            np.seterr(**olderr)
 
 
 class TestGeometricStandardDeviation(object):


### PR DESCRIPTION
Replace the old-style pattern of
    
    olderr = np.seterr(<...new error settings...>)
    try:
        <do stuff>
    finally:
        np.seterr(**olderr)
    
with
    
    with np.errstate(<...new error settings...>):
        <do stuff>