### PR TITLE
TST: Remove ncf hack for cases_test_moments

### DIFF
--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -197,7 +197,7 @@ def test_levy_stable_random_state_property():
 
 def cases_test_moments():
     fail_normalization = set(['vonmises'])
-    fail_higher = set(['vonmises', 'ncf'])
+    fail_higher = set(['vonmises'])
 
     for distname, arg in distcont[:] + [(histogram_test_instance, tuple())]:
         if distname == 'levy_stable':


### PR DESCRIPTION
This passes locally, testing on CI

This was probably fixed by https://github.com/scipy/scipy/pull/11849
Other patch that was closed: https://github.com/scipy/scipy/pull/11768