### PR TITLE
MAINT: fix mypy errors after adding py.typed marker

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -61,115 +61,6 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 
 #
-# Extension modules without stubs.
-#
-
-[mypy-scipy.signal._peak_finding_utils]
-ignore_missing_imports = True
-
-[mypy-scipy.signal._upfirdn_apply]
-ignore_missing_imports = True
-
-[mypy-scipy.signal._spectral]
-ignore_missing_imports = True
-
-[mypy-scipy.integrate._test_odeint_banded]
-ignore_missing_imports = True
-
-[mypy-scipy.integrate._test_multivariate]
-ignore_missing_imports = True
-
-[mypy-scipy._lib._ccallback_c]
-ignore_missing_imports = True
-
-[mypy-scipy.cluster._hierarchy]
-ignore_missing_imports = True
-
-[mypy-scipy.optimize._bglu_dense]
-ignore_missing_imports = True
-
-[mypy-scipy.optimize._slsqp]
-ignore_missing_imports = True
-
-[mypy-scipy.interpolate.dfitpack]
-ignore_missing_imports = True
-
-[mypy-scipy.spatial.qhull]
-ignore_missing_imports = True
-
-[mypy-scipy.interpolate.interpnd]
-ignore_missing_imports = True
-
-[mypy-scipy.spatial.ckdtree]
-ignore_missing_imports = True
-
-[mypy-scipy.linalg.cython_blas]
-ignore_missing_imports = True
-
-[mypy-scipy.linalg._decomp_update]
-ignore_missing_imports = True
-
-[mypy-scipy.linalg._solve_toeplitz]
-ignore_missing_imports = True
-
-[mypy-scipy.linalg._interpolative]
-ignore_missing_imports = True
-
-[mypy-scipy.optimize._group_columns]
-ignore_missing_imports = True
-
-[mypy-scipy.io.matlab.mio5_utils]
-ignore_missing_imports = True
-
-[mypy-scipy.io.matlab.streams]
-ignore_missing_imports = True
-
-[mypy-scipy.sparse.linalg.dsolve._superlu]
-ignore_missing_imports = True
-
-[mypy-scipy.io.matlab.mio_utils]
-ignore_missing_imports = True
-
-[mypy-scipy.sparse.csgraph._tools]
-ignore_missing_imports = True
-
-[mypy-scipy.sparse._sparsetools]
-ignore_missing_imports = True
-
-[mypy-scipy.sparse.csgraph._reordering]
-ignore_missing_imports = True
-
-[mypy-scipy.sparse.csgraph._matching]
-ignore_missing_imports = True
-
-[mypy-scipy.sparse.csgraph._flow]
-ignore_missing_imports = True
-
-[mypy-scipy.sparse.csgraph._min_spanning_tree]
-ignore_missing_imports = True
-
-[mypy-scipy.sparse.csgraph._traversal]
-ignore_missing_imports = True
-
-[mypy-scipy.sparse.csgraph._shortest_path]
-ignore_missing_imports = True
-
-[mypy-scipy.fft._pocketfft.pypocketfft]
-ignore_missing_imports = True
-
-[mypy-scipy.signal._max_len_seq_inner]
-ignore_missing_imports = True
-
-[mypy-scipy.special._ellip_harm_2]
-ignore_missing_imports = True
-
-[mypy-scipy._lib._fpumode]
-ignore_missing_imports = True
-
-[mypy-scipy.optimize._trlib._trlib]
-ignore_missing_imports = True
-
-#
 # Files with various errors. Likely some false positives, but likely
 # some real bugs too.
 #
@@ -566,6 +457,102 @@ ignore_errors = True
 ignore_errors = True
 
 [mypy-scipy.optimize.tests.test_cython_optimize]
+ignore_errors = True
+
+[mypy-scipy.conftest]
+ignore_errors = True
+
+[mypy-scipy.special._ellip_harm]
+ignore_errors = True
+
+[mypy-scipy.signal._upfirdn]
+ignore_errors = True
+
+[mypy-scipy.signal._max_len_seq]
+ignore_errors = True
+
+[mypy-scipy.optimize._trlib]
+ignore_errors = True
+
+[mypy-scipy.io.matlab.tests.test_streams]
+ignore_errors = True
+
+[mypy-scipy.io.matlab.tests.test_mio_utils]
+ignore_errors = True
+
+[mypy-scipy.fft._pocketfft.helper]
+ignore_errors = True
+
+[mypy-scipy.sparse.dia]
+ignore_errors = True
+
+[mypy-scipy.sparse.coo]
+ignore_errors = True
+
+[mypy-scipy.sparse.csr]
+ignore_errors = True
+
+[mypy-scipy.sparse.csc]
+ignore_errors = True
+
+[mypy-scipy.sparse.bsr]
+ignore_errors = True
+
+[mypy-scipy.sparse.spfuncs]
+ignore_errors = True
+
+[mypy-scipy.sparse.csgraph]
+ignore_errors = True
+
+[mypy-scipy.sparse.tests.test_spfuncs]
+ignore_errors = True
+
+[mypy-scipy.sparse.csgraph._validation]
+ignore_errors = True
+
+[mypy-scipy.io.matlab.mio4]
+ignore_errors = True
+
+[mypy-scipy.sparse.linalg.dsolve]
+ignore_errors = True
+
+[mypy-scipy.optimize._numdiff]
+ignore_errors = True
+
+[mypy-scipy.linalg.tests.test_solve_toeplitz]
+ignore_errors = True
+
+[mypy-scipy.linalg.tests.test_decomp_update]
+ignore_errors = True
+
+[mypy-scipy.interpolate.tests.test_fitpack]
+ignore_errors = True
+
+[mypy-scipy.optimize.slsqp]
+ignore_errors = True
+
+[mypy-scipy.optimize._linprog_rs]
+ignore_errors = True
+
+[mypy-scipy.cluster.tests.test_hierarchy]
+ignore_errors = True
+
+[mypy-scipy.integrate.tests.test_quadpack]
+ignore_errors = True
+
+[mypy-scipy.signal.spectral]
+ignore_errors = True
+
+[mypy-scipy.signal._peak_finding]
+ignore_errors = True
+
+[mypy-scipy.signal.tests.test_upfirdn]
+ignore_errors = True
+
+[mypy-scipy.signal.tests.test_peak_finding]
+ignore_errors = True
+
+[mypy-scipy.io.matlab.mio5]
 ignore_errors = True
 
 #


### PR DESCRIPTION
#### Reference issue
None

#### What does this implement/fix?
Adding the py.typed marker caused mypy to realize that all of our
extension modules exist, which changed the errors we were getting from
"missing import" to "x attribute in the module does not exist"
(because it has no stubs). Shuffle the ignores in the ratchet to
account for that.

Also update `runtests.py` to support the `--no-build` flag, since you
can now run mypy against an installed SciPy.

#### Additional information
None