### PR TITLE
BUG: sparse: 'diagonal' of sparse matrices fixed to match numpy's diagonal behaviour

### DIFF
--- a/scipy/sparse/bsr.py
+++ b/scipy/sparse/bsr.py
@@ -295,10 +295,8 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
 
     def diagonal(self, k=0):
         rows, cols = self.shape
-        if rows == 0 or cols == 0:
-            return np.empty(0)
         if k <= -rows or k >= cols:
-            raise ValueError("k exceeds matrix dimensions")
+            return np.empty(0, dtype=self.data.dtype)
         R, C = self.blocksize
         y = np.zeros(min(rows + min(k, 0), cols - max(k, 0)),
                      dtype=upcast(self.dtype))

--- a/scipy/sparse/bsr.py
+++ b/scipy/sparse/bsr.py
@@ -295,6 +295,8 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
 
     def diagonal(self, k=0):
         rows, cols = self.shape
+        if rows == 0 or cols == 0:
+            return np.empty(0)
         if k <= -rows or k >= cols:
             raise ValueError("k exceeds matrix dimensions")
         R, C = self.blocksize

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -529,6 +529,8 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
 
     def diagonal(self, k=0):
         rows, cols = self.shape
+        if rows == 0 or cols == 0:
+            return np.empty(0)
         if k <= -rows or k >= cols:
             raise ValueError("k exceeds matrix dimensions")
         fn = getattr(_sparsetools, self.format + "_diagonal")

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -529,10 +529,8 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
 
     def diagonal(self, k=0):
         rows, cols = self.shape
-        if rows == 0 or cols == 0:
-            return np.empty(0)
         if k <= -rows or k >= cols:
-            raise ValueError("k exceeds matrix dimensions")
+            return np.empty(0, dtype=self.data.dtype)
         fn = getattr(_sparsetools, self.format + "_diagonal")
         y = np.empty(min(rows + min(k, 0), cols - max(k, 0)),
                      dtype=upcast(self.dtype))

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -455,6 +455,8 @@ class coo_matrix(_data_matrix, _minmax_mixin):
 
     def diagonal(self, k=0):
         rows, cols = self.shape
+        if rows == 0 or cols == 0:
+            return np.empty(0)
         if k <= -rows or k >= cols:
             raise ValueError("k exceeds matrix dimensions")
         diag = np.zeros(min(rows + min(k, 0), cols - max(k, 0)),

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -455,10 +455,8 @@ class coo_matrix(_data_matrix, _minmax_mixin):
 
     def diagonal(self, k=0):
         rows, cols = self.shape
-        if rows == 0 or cols == 0:
-            return np.empty(0)
         if k <= -rows or k >= cols:
-            raise ValueError("k exceeds matrix dimensions")
+            return np.empty(0, dtype=self.data.dtype)
         diag = np.zeros(min(rows + min(k, 0), cols - max(k, 0)),
                         dtype=self.dtype)
         diag_mask = (self.row + k) == self.col

--- a/scipy/sparse/dia.py
+++ b/scipy/sparse/dia.py
@@ -320,10 +320,8 @@ class dia_matrix(_data_matrix):
 
     def diagonal(self, k=0):
         rows, cols = self.shape
-        if rows == 0 or cols == 0:
-            return np.empty(0)
         if k <= -rows or k >= cols:
-            raise ValueError("k exceeds matrix dimensions")
+            return np.empty(0, dtype=self.data.dtype)
         idx, = np.nonzero(self.offsets == k)
         first_col, last_col = max(0, k), min(rows + k, cols)
         if idx.size == 0:

--- a/scipy/sparse/dia.py
+++ b/scipy/sparse/dia.py
@@ -320,6 +320,8 @@ class dia_matrix(_data_matrix):
 
     def diagonal(self, k=0):
         rows, cols = self.shape
+        if rows == 0 or cols == 0:
+            return np.empty(0)
         if k <= -rows or k >= cols:
             raise ValueError("k exceeds matrix dimensions")
         idx, = np.nonzero(self.offsets == k)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -731,6 +731,9 @@ class _TestCommon(object):
 
         # Test all-zero matrix.
         assert_equal(self.spmatrix((40, 16130)).diagonal(), np.zeros(40))
+        # Test empty matrix
+        # https://github.com/scipy/scipy/issues/11949
+        assert_equal(self.spmatrix((0, 0)).diagonal(), np.empty(0))
 
     def test_reshape(self):
         # This first example is taken from the lil_matrix reshaping test.

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -726,7 +726,7 @@ class _TestCommon(object):
             sparse_mat = self.spmatrix(m)
             for k in range(-rows-1, cols+2):
                 assert_equal(sparse_mat.diagonal(k=k), diag(m, k=k))
-            # Test for k beyound boundaries(issue #11949)
+            # Test for k beyond boundaries(issue #11949)
             assert_equal(sparse_mat.diagonal(k=10), diag(m, k=10))
             assert_equal(sparse_mat.diagonal(k=-99), diag(m, k=-99))
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -724,15 +724,19 @@ class _TestCommon(object):
         for m in mats:
             rows, cols = array(m).shape
             sparse_mat = self.spmatrix(m)
-            # Test all possible values ok k
             for k in range(-rows-1, cols+2):
                 assert_equal(sparse_mat.diagonal(k=k), diag(m, k=k))
+            # Test for k beyound boundaries(issue #11949)
+            assert_equal(sparse_mat.diagonal(k=10), diag(m, k=10))
+            assert_equal(sparse_mat.diagonal(k=-99), diag(m, k=-99))
 
         # Test all-zero matrix.
         assert_equal(self.spmatrix((40, 16130)).diagonal(), np.zeros(40))
         # Test empty matrix
         # https://github.com/scipy/scipy/issues/11949
         assert_equal(self.spmatrix((0, 0)).diagonal(), np.empty(0))
+        assert_equal(self.spmatrix((15, 0)).diagonal(), np.empty(0))
+        assert_equal(self.spmatrix((0, 5)).diagonal(10), np.empty(0))
 
     def test_reshape(self):
         # This first example is taken from the lil_matrix reshaping test.

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -724,10 +724,9 @@ class _TestCommon(object):
         for m in mats:
             rows, cols = array(m).shape
             sparse_mat = self.spmatrix(m)
-            for k in range(-rows + 1, cols):
+            # Test all possible values ok k
+            for k in range(-rows-1, cols+2):
                 assert_equal(sparse_mat.diagonal(k=k), diag(m, k=k))
-            assert_raises(ValueError, sparse_mat.diagonal, -rows)
-            assert_raises(ValueError, sparse_mat.diagonal, cols)
 
         # Test all-zero matrix.
         assert_equal(self.spmatrix((40, 16130)).diagonal(), np.zeros(40))


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes #11949

#### What does this implement/fix?
'diagonal' raises 'ValueError' if called from a sparse matrix with size 0. That differs from 'numpy.diagonal', which returns an empty array.
Added check if of size om matrix is 0, and return of empty array to match the behaviour of numpy function.
Added case of an empty matrix in tests.