### PR TITLE
BUG: Reshape oaconvolve output even when no axes are convolved

### DIFF
--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -743,11 +743,12 @@ def oaconvolve(in1, in2, mode="full", axes=None):
     in1, in2, axes = _init_freq_conv_axes(in1, in2, mode, axes,
                                           sorted_axes=True)
 
-    if not axes:
-        return in1*in2
-
     s1 = in1.shape
     s2 = in2.shape
+
+    if not axes:
+        ret = in1 * in2
+        return _apply_conv_mode(ret, s1, s2, mode, axes)
 
     # Calculate this now since in1 is changed later
     shape_final = [None if i not in axes else

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -803,7 +803,7 @@ class TestOAConvolve(object):
         assert_array_almost_equal(out, expected)
 
     @pytest.mark.parametrize('shape_a_0, shape_b_0',
-                             gen_oa_shapes([50, 47, 6, 4]))
+                             gen_oa_shapes([50, 47, 6, 4, 1]))
     @pytest.mark.parametrize('is_complex', [True, False])
     @pytest.mark.parametrize('mode', ['full', 'valid', 'same'])
     def test_1d_noaxes(self, shape_a_0, shape_b_0,


### PR DESCRIPTION


#### Reference issue
Fixes gh-11973

#### What does this implement/fix?
When one array is of length 1, we can have no axes convolved. The fast path here didn't apply the convolve mode correctly and so did not output the correct shape.