### PR TITLE
MAINT: add logo for github actions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,9 @@ SciPy
 .. image:: https://dev.azure.com/scipy-org/SciPy/_apis/build/status/scipy.scipy?branchName=master
   :target: https://dev.azure.com/scipy-org/SciPy/_build/latest?definitionId=1?branchName=master
 
+.. image:: https://github.com/scipy/scipy/workflows/macOS%20tests/badge.svg?branch=master
+  :target: https://github.com/scipy/scipy/actions?query=workflow%3A%22macOS+tests%22
+
 SciPy (pronounced "Sigh Pie") is open-source software for mathematics,
 science, and engineering. It includes modules for statistics, optimization,
 integration, linear algebra, Fourier transforms, signal and image processing,


### PR DESCRIPTION
This adds a status badge to README.rst for the tests using Github Actions.

At the moment the badge says 'macOS tests', because that's the name of the Github action. If we rename the action and the logo if desired.