### PR TITLE
MAINT: math.factorial will only accept int

### DIFF
--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2323,7 +2323,7 @@ def factorial(n, exact=False):
         if np.ndim(n) == 0:
             if np.isnan(n):
                 return n
-            return 0 if n < 0 else math.factorial(n)
+            return 0 if n < 0 else math.factorial(operator.index(n))
         else:
             n = asarray(n)
             un = np.unique(n).astype(object)
@@ -2349,7 +2349,7 @@ def factorial(n, exact=False):
 
             # Calculate products of each range of numbers
             if un.size:
-                val = math.factorial(un[0])
+                val = math.factorial(operator.index(un[0]))
                 out[n == un[0]] = val
                 for i in range(len(un) - 1):
                     prev = un[i] + 1


### PR DESCRIPTION
In Python 3.9 (https://github.com/scipy/scipy/runs/635036752?check_suite_focus=true) there is a `DeprecationWarning: Using factorial() with floats is deprecated`.
This PR changes the code in special._basic.factorial` to account for that.