### PR TITLE
WIP: ENH: linalg: add wrapper for `?pbsvx`

### DIFF
--- a/scipy/linalg/flapack_other.pyf.src
+++ b/scipy/linalg/flapack_other.pyf.src
@@ -347,6 +347,44 @@ subroutine <prefix2>pbsvx(fact,lower,n,kd,nrhs,ab,ldab,afb,ldafb,equed,s,b,ldb,x
 end subroutine <prefix2>pbsvx
 
 
+subroutine <prefix2c>pbsvx(fact,lower,n,kd,nrhs,ab,ldab,afb,ldafb,equed,s,b,ldb,x,ldx,rcond,ferr,berr,work,rwork,info)
+    ! PBSVX uses the Cholesky factorization A = U**T*U or A = L*L**T to
+    ! compute the solution to a real system of linear equations
+    !    A * X = B,
+    ! where A is an N-by-N symmetric positive definite band matrix and X
+    ! and B are N-by-NRHS matrices.
+
+    ! Error bounds on the solution and a condition estimate are also
+    ! provided.
+    ! end subroutine <prefix2>pbsvx
+    callstatement (*f2py_func)(&"NEF"[fact],(lower?"L":"U"),&n,&kd,&nrhs,ab,&ldab,afb,&ldafb,equed,s,b,&ldb,x,&ldx,&rcond,ferr,berr,work,rwork,&info);
+    callprotoargument char*,char*,int*,int*,int*,<ctype2c>*,int*,<ctype2c>*,int*,char*,<ctype2>*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2c>*,<ctype2>*,int*
+
+    integer optional, intent(in) :: fact = 0
+    integer optional, intent(in) :: lower = 0
+    integer intent(hide), depend(ab) :: n = shape(ab, 1)
+    integer optional, intent(in), check(0<=kd) :: kd = 0
+    integer intent(hide), depend(b) :: nrhs = shape(b, 1)
+    <ftype2c> intent(in,out), depend(kd), dimension(ldab, n), check(kd+1==shape(ab,0)) :: ab
+    integer intent(hide), depend(ab) :: ldab = max(1,shape(ab,0))
+    <ftype2c> optional, intent(in,out), depend(kd, n), dimension(kd+1, n), check((kd+1==shape(afb,0)) && (n==shape(afb,1))) :: afb
+    integer intent(hide), depend(afb) :: ldafb = max(1,shape(afb,0))
+    character optional, intent(in,out) :: equed = 'N'
+    <ftype2> optional, intent(in,out), depend(n), dimension(n) :: s
+    <ftype2c> intent(in), dimension(ldb,nrhs), depend(n), check(n==shape(b,0)) :: b
+    integer intent(hide), depend(b) :: ldb = max(1,shape(b,0))
+    <ftype2c> intent(out), depend(n,nrhs), dimension(n,nrhs) :: x
+    integer intent(hide), depend(n) :: ldx = max(1,n)
+    <ftype2> intent(out) :: rcond
+    <ftype2> intent(out), depend(nrhs), dimension(nrhs) :: ferr
+    <ftype2> intent(out), depend(nrhs), dimension(nrhs) :: berr
+    <ftype2c> intent(hide), depend(n), dimension(2*n) :: work
+    <ftype2> intent(hide), depend(n), dimension(n) :: rwork
+    integer intent(out) :: info
+
+end subroutine <prefix2c>pbsvx
+
+
 subroutine <prefix2>orcsd(compute_u1,compute_u2,compute_v1t,compute_v2t,trans,signs,m,p,q,x11,ldx11,x12,ldx12,x21,ldx21,x22,ldx22,theta,u1,ldu1,u2,ldu2,v1t,ldv1t,v2t,ldv2t,work,lwork,iwork,info,mmp,mmq)
     ! DORCSD computes the CS decomposition of an M-by-M partitioned
     ! unitary matrix X:

--- a/scipy/linalg/flapack_other.pyf.src
+++ b/scipy/linalg/flapack_other.pyf.src
@@ -308,6 +308,45 @@ subroutine <prefix2c>pbsv(lower,n,kd,nrhs,ab,ldab,b,ldb,info)
 
 end subroutine <prefix2c>pbsv
 
+
+subroutine <prefix2>pbsvx(fact,lower,n,kd,nrhs,ab,ldab,afb,ldafb,equed,s,b,ldb,x,ldx,rcond,ferr,berr,work,iwork,info)
+    ! PBSVX uses the Cholesky factorization A = U**T*U or A = L*L**T to
+    ! compute the solution to a real system of linear equations
+    !    A * X = B,
+    ! where A is an N-by-N symmetric positive definite band matrix and X
+    ! and B are N-by-NRHS matrices.
+
+    ! Error bounds on the solution and a condition estimate are also
+    ! provided.
+    ! end subroutine <prefix2>pbsvx
+    callstatement (*f2py_func)(&"NEF"[fact],(lower?"L":"U"),&n,&kd,&nrhs,ab,&ldab,afb,&ldafb,equed,s,b,&ldb,x,&ldx,&rcond,ferr,berr,work,iwork,&info);
+    callprotoargument char*,char*,int*,int*,int*,<ctype2>*,int*,<ctype2>*,int*,char*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,int*,int*
+
+    integer optional, intent(in) :: fact = 0
+    integer optional, intent(in) :: lower = 0
+    integer intent(hide), depend(ab) :: n = shape(ab, 1)
+    integer optional, intent(in), check(0<=kd) :: kd = 0
+    integer intent(hide), depend(b) :: nrhs = shape(b, 1)
+    <ftype2> intent(in,out), depend(kd), dimension(ldab, n), check(kd+1==shape(ab,0)) :: ab
+    integer intent(hide), depend(ab) :: ldab = max(1,shape(ab,0))
+    <ftype2> optional, intent(in,out), depend(kd, n), dimension(kd+1, n), check((kd+1==shape(afb,0)) && (n==shape(afb,1))) :: afb
+    integer intent(hide), depend(afb) :: ldafb = max(1,shape(afb,0))
+    character optional, intent(in,out) :: equed = 'N'
+    <ftype2> optional, intent(in,out), depend(n), dimension(n) :: s
+    <ftype2> intent(in), dimension(ldb,nrhs), depend(n), check(n==shape(b,0)) :: b
+    integer intent(hide), depend(b) :: ldb = max(1,shape(b,0))
+    <ftype2> intent(out), depend(n,nrhs), dimension(n,nrhs) :: x
+    integer intent(hide), depend(n) :: ldx = max(1,n)
+    <ftype2> intent(out) :: rcond
+    <ftype2> intent(out), depend(nrhs), dimension(nrhs) :: ferr
+    <ftype2> intent(out), depend(nrhs), dimension(nrhs) :: berr
+    <ftype2> intent(hide), depend(n), dimension(3*n) :: work
+    integer intent(hide), depend(n), dimension(n) :: iwork
+    integer intent(out) :: info
+
+end subroutine <prefix2>pbsvx
+
+
 subroutine <prefix2>orcsd(compute_u1,compute_u2,compute_v1t,compute_v2t,trans,signs,m,p,q,x11,ldx11,x12,ldx12,x21,ldx21,x22,ldx22,theta,u1,ldu1,u2,ldu2,v1t,ldv1t,v2t,ldv2t,work,lwork,iwork,info,mmp,mmq)
     ! DORCSD computes the CS decomposition of an M-by-M partitioned
     ! unitary matrix X:

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -425,6 +425,8 @@ All functions
 
    spbsvx
    dpbsvx
+   cpbsvx
+   zpbsvx
 
    spbtrf
    dpbtrf

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -423,6 +423,9 @@ All functions
    cpbsv
    zpbsv
 
+   spbsvx
+   dpbsvx
+
    spbtrf
    dpbtrf
    cpbtrf

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -499,6 +499,34 @@ class TestDlasd4(object):
                         rtol=100*np.finfo(np.float64).eps)
 
 
+class TestPbsvx:
+
+    def test_nag_f07hbf(self):
+        ab_ = np.array([(0, 2.68, -2.39, -2.22),
+                       (5.49, 5.63, 2.60, 5.17)])
+        b_ = np.array([(22.09, 5.10),
+                       (9.31, 30.81),
+                       (-5.24, -25.82),
+                       (11.83, 22.90)])
+        x_ = np.array([(5.0000, -2.0000),
+                       (-2.0000, 6.0000),
+                       (-3.0000, -1.0000),
+                       (1.0000, 4.0000)])
+        atol = 100 * np.finfo(ab_.dtype).eps
+        pbsvx = get_lapack_funcs('pbsvx', dtype=ab_.dtype)
+        ab, afb, e, s, x, rcond, ferr, berr, info = pbsvx(ab=ab_, b=b_,kd=1)
+
+        assert_equal(ab, ab_)
+        assert_equal(afb.shape, ab_.shape)
+        assert_equal(e, b'N')
+        assert_equal(s.shape, (4,))
+        assert_allclose(x, x_, atol=atol)
+        assert np.isscalar(rcond)
+        assert_equal(ferr.shape, (2,))
+        assert_equal(berr.shape, (2,))
+        assert_equal(info, 0)
+
+
 class TestTbtrs(object):
 
     @pytest.mark.parametrize('dtype', DTYPES)

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -563,6 +563,12 @@ class TestPbsvx:
         assert_equal(ferr.shape, (nrhs,))
         assert_equal(berr.shape, (nrhs,))
 
+        # Now that we know the tests pass as expected try test with
+        # invalid shapes for some arguments.
+        assert_raises(Exception, pbsvx, ab[:-1], b, 2, lower, kd, afb, 'N')
+        assert_raises(Exception, pbsvx, ab[:,:-1], b, 2, lower, kd, afb, 'N')
+        assert_raises(Exception, pbsvx, ab, b[:-1], 2, lower, kd, afb, 'N')
+
     @pytest.mark.parametrize('dtype', REAL_DTYPES)
     @pytest.mark.parametrize('lower', (0, 1))
     def test_random_example_factored(self, dtype, lower):
@@ -602,7 +608,16 @@ class TestPbsvx:
         assert_equal(ferr.shape, (nrhs,))
         assert_equal(berr.shape, (nrhs,))
 
-    def _pb_array(self, dtype, kd, lda, ldab, lower):
+        # Now that we know the tests pass as expected try test with
+        # invalid shapes for some arguments.
+        assert_raises(Exception, pbsvx, ab[:-1], b, 2, lower, kd, afb, 'N')
+        assert_raises(Exception, pbsvx, ab[:,:-1], b, 2, lower, kd, afb, 'N')
+        assert_raises(Exception, pbsvx, ab, b[:-1], 2, lower, kd, afb, 'N')
+        assert_raises(Exception, pbsvx, ab, b, 2, lower, kd, afb[:-1], 'N')
+        assert_raises(Exception, pbsvx, ab, b, 2, lower, kd, afb[:,:-1], 'N')
+
+    @staticmethod
+    def _pb_array(dtype, kd, lda, ldab, lower):
         """Construct a random symmetric positive banded array A"""
         # Construct the diagonal and kd super/sub diagonals of A with
         # the corresponding offsets.


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes issue #11616 

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR adds a python wrapper for the LAPACK functions {d,s,c,z}pbsvx. These functions solve the linear system of equations Ax = b where A is a Symmetric/Hermitian matrix.

#### Additional information
<!--Any additional information you think is important.-->
?pbsvx comes from a more recent version of lapack than our current minimum. It should therefore not yet be merged.

This PR is missing tests with ``equed='Y'``. This test requires `A` to be multiplied by some scaling factor `s` i.e. ``A = diag(s) @ A @ diag(s)``. The problem I'm having is how do I best generate s? If I were to use a random s, the resultant matrix is (almost certainly) no longer hermitian alternatively I could use [?geequb](https://docs.scipy.org/doc/scipy/reference/generated/scipy.linalg.lapack.dgeequb.html#scipy.linalg.lapack.dgeequb) this returns row, column factors, in that case, how should I convert the row, col factors to `s`?