### PR TITLE
Avoid bugs in ndimage when the output and input arrays overlap in memory

### DIFF
--- a/scipy/ndimage/filters.py
+++ b/scipy/ndimage/filters.py
@@ -80,11 +80,6 @@ def correlate1d(input, weights, axis=-1, output=None, mode="reflect",
     if numpy.iscomplexobj(input):
         raise TypeError('Complex type not supported')
     output = _ni_support._get_output(output, input)
-    temp_needed = numpy.shares_memory(input, output)
-    if temp_needed:
-        # input and output arrays cannot share memory
-        temp = output
-        output = _ni_support._get_output(output.dtype, input)
     weights = numpy.asarray(weights, dtype=numpy.float64)
     if weights.ndim != 1 or weights.shape[0] < 1:
         raise RuntimeError('no filter weights given')
@@ -98,9 +93,6 @@ def correlate1d(input, weights, axis=-1, output=None, mode="reflect",
     mode = _ni_support._extend_mode_to_code(mode)
     _nd_image.correlate1d(input, weights, axis, output, mode, cval,
                           origin)
-    if temp_needed:
-        temp[...] = output
-        output = temp
     return output
 
 

--- a/scipy/ndimage/filters.py
+++ b/scipy/ndimage/filters.py
@@ -80,6 +80,11 @@ def correlate1d(input, weights, axis=-1, output=None, mode="reflect",
     if numpy.iscomplexobj(input):
         raise TypeError('Complex type not supported')
     output = _ni_support._get_output(output, input)
+    temp_needed = numpy.shares_memory(input, output)
+    if temp_needed:
+        # input and output arrays cannot share memory
+        temp = output
+        output = _ni_support._get_output(output.dtype, input)
     weights = numpy.asarray(weights, dtype=numpy.float64)
     if weights.ndim != 1 or weights.shape[0] < 1:
         raise RuntimeError('no filter weights given')
@@ -93,6 +98,9 @@ def correlate1d(input, weights, axis=-1, output=None, mode="reflect",
     mode = _ni_support._extend_mode_to_code(mode)
     _nd_image.correlate1d(input, weights, axis, output, mode, cval,
                           origin)
+    if temp_needed:
+        temp[...] = output
+        output = temp
     return output
 
 
@@ -618,10 +626,18 @@ def _correlate_or_convolve(input, weights, output, mode, cval, origin,
     if not weights.flags.contiguous:
         weights = weights.copy()
     output = _ni_support._get_output(output, input)
+    temp_needed = numpy.shares_memory(input, output)
+    if temp_needed:
+        # input and output arrays cannot share memory
+        temp = output
+        output = _ni_support._get_output(output.dtype, input)
     if not isinstance(mode, str) and isinstance(mode, Iterable):
         raise RuntimeError("A sequence of modes is not supported")
     mode = _ni_support._extend_mode_to_code(mode)
     _nd_image.correlate(input, weights, output, mode, cval, origins)
+    if temp_needed:
+        temp[...] = output
+        output = temp
     return output
 
 
@@ -1035,6 +1051,11 @@ def _min_or_max_filter(input, size, footprint, structure, output, mode,
     if numpy.iscomplexobj(input):
         raise TypeError('Complex type not supported')
     output = _ni_support._get_output(output, input)
+    temp_needed = numpy.shares_memory(input, output)
+    if temp_needed:
+        # input and output arrays cannot share memory
+        temp = output
+        output = _ni_support._get_output(output.dtype, input)
     origins = _ni_support._normalize_sequence(origin, input.ndim)
     if separable:
         sizes = _ni_support._normalize_sequence(size, input.ndim)
@@ -1073,6 +1094,9 @@ def _min_or_max_filter(input, size, footprint, structure, output, mode,
         mode = _ni_support._extend_mode_to_code(mode)
         _nd_image.min_or_max_filter(input, footprint, structure, output,
                                     mode, cval, origins, minimum)
+    if temp_needed:
+        temp[...] = output
+        output = temp
     return output
 
 
@@ -1209,6 +1233,11 @@ def _rank_filter(input, rank, size=None, footprint=None, output=None,
                               origins)
     else:
         output = _ni_support._get_output(output, input)
+        temp_needed = numpy.shares_memory(input, output)
+        if temp_needed:
+            # input and output arrays cannot share memory
+            temp = output
+            output = _ni_support._get_output(output.dtype, input)
         if not isinstance(mode, str) and isinstance(mode, Iterable):
             raise RuntimeError(
                 "A sequence of modes is not supported by non-separable rank "
@@ -1216,6 +1245,9 @@ def _rank_filter(input, rank, size=None, footprint=None, output=None,
         mode = _ni_support._extend_mode_to_code(mode)
         _nd_image.rank_filter(input, rank, footprint, output, mode, cval,
                               origins)
+        if temp_needed:
+            temp[...] = output
+            output = temp
         return output
 
 

--- a/scipy/ndimage/morphology.py
+++ b/scipy/ndimage/morphology.py
@@ -244,7 +244,11 @@ def _binary_erosion(input, structure, iterations, mask, output,
     else:
         output = bool
     output = _ni_support._get_output(output, input)
-
+    temp_needed = numpy.shares_memory(input, output)
+    if temp_needed:
+        # input and output arrays cannot share memory
+        temp = output
+        output = _ni_support._get_output(output.dtype, input)
     if iterations == 1:
         _nd_image.binary_erosion(input, structure, mask, output,
                                  border_value, origin, invert, cit, 0)
@@ -265,7 +269,6 @@ def _binary_erosion(input, structure, iterations, mask, output,
             structure = structure.copy()
         _nd_image.binary_erosion2(output, structure, mask, iterations - 1,
                                   origin, invert, coordinate_list)
-        return output
     else:
         tmp_in = numpy.empty_like(input, dtype=bool)
         tmp_out = output
@@ -281,7 +284,10 @@ def _binary_erosion(input, structure, iterations, mask, output,
                 tmp_in, structure, mask, tmp_out,
                 border_value, origin, invert, cit, 0)
             ii += 1
-        return output
+    if temp_needed:
+        temp[...] = output
+        output = temp
+    return output
 
 
 def binary_erosion(input, structure=None, iterations=1, mask=None, output=None,

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -79,6 +79,14 @@ class TestNdimage:
         output = ndimage.convolve1d(array, weights)
         assert_array_almost_equal(output, expected)
 
+    def test_correlate01_overlap(self):
+        array = numpy.arange(256).reshape(16, 16)
+        weights = numpy.array([2])
+        expected = 2 * array
+
+        ndimage.correlate1d(array, weights, output=array)
+        assert_array_almost_equal(array, expected)
+
     def test_correlate02(self):
         array = numpy.array([1, 2, 3])
         kernel = numpy.array([1])
@@ -491,6 +499,14 @@ class TestNdimage:
         output2 = ndimage.gaussian_filter(input, 1.0, output=otype)
         assert_array_almost_equal(output1, output2)
 
+    def test_gauss_memory_overlap(self):
+        input = numpy.arange(100 * 100).astype(numpy.float32)
+        input.shape = (100, 100)
+        otype = numpy.float64
+        output1 = ndimage.gaussian_filter(input, 1.0)
+        ndimage.gaussian_filter(input, 1.0, output=input)
+        assert_array_almost_equal(output1, input)
+
     def test_prewitt01(self):
         for type_ in self.types:
             array = numpy.array([[3, 2, 5, 1, 4],
@@ -751,6 +767,16 @@ class TestNdimage:
                                    [2, 2, 1, 1, 1],
                                    [5, 3, 3, 1, 1]], output)
 
+    def test_minimum_filter05_overlap(self):
+        array = numpy.array([[3, 2, 5, 1, 4],
+                             [7, 6, 9, 3, 5],
+                             [5, 8, 3, 7, 1]])
+        filter_shape = numpy.array([2, 3])
+        ndimage.minimum_filter(array, filter_shape, output=array)
+        assert_array_almost_equal([[2, 2, 1, 1, 1],
+                                   [2, 2, 1, 1, 1],
+                                   [5, 3, 3, 1, 1]], array)
+
     def test_minimum_filter06(self):
         array = numpy.array([[3, 2, 5, 1, 4],
                              [7, 6, 9, 3, 5],
@@ -934,6 +960,21 @@ class TestNdimage:
         assert_array_almost_equal(expected, output)
         output = ndimage.percentile_filter(array, 17, size=(2, 3))
         assert_array_almost_equal(expected, output)
+
+    def test_rank06_overlap(self):
+        array = numpy.array([[3, 2, 5, 1, 4],
+                             [5, 8, 3, 7, 1],
+                             [5, 6, 9, 3, 5]])
+        array_copy = array.copy()
+        expected = [[2, 2, 1, 1, 1],
+                    [3, 3, 2, 1, 1],
+                    [5, 5, 3, 3, 1]]
+        ndimage.rank_filter(array, 1, size=[2, 3], output=array)
+        assert_array_almost_equal(expected, array)
+
+        ndimage.percentile_filter(array_copy, 17, size=(2, 3),
+                                  output=array_copy)
+        assert_array_almost_equal(expected, array_copy)
 
     def test_rank07(self):
         array = numpy.array([[3, 2, 5, 1, 4],
@@ -3441,6 +3482,11 @@ class TestNdimage:
                                iterations=3, output=out)
         assert_array_almost_equal(out, expected)
 
+        # test with output memory overlap
+        ndimage.binary_erosion(data, struct, border_value=1,
+                               iterations=3, output=data)
+        assert_array_almost_equal(data, expected)
+
     def test_binary_erosion31(self):
         struct = [[0, 1, 0],
                   [1, 1, 1],
@@ -4357,6 +4403,16 @@ class TestNdimage:
         assert_array_almost_equal([[2, 2, 1, 1, 1],
                                    [2, 3, 1, 3, 1],
                                    [5, 5, 3, 3, 1]], output)
+
+    def test_grey_erosion01_overlap(self):
+        array = numpy.array([[3, 2, 5, 1, 4],
+                             [7, 6, 9, 3, 5],
+                             [5, 8, 3, 7, 1]])
+        footprint = [[1, 0, 1], [1, 1, 0]]
+        ndimage.grey_erosion(array, footprint=footprint, output=array)
+        assert_array_almost_equal([[2, 2, 1, 1, 1],
+                                   [2, 3, 1, 3, 1],
+                                   [5, 5, 3, 3, 1]], array)
 
     def test_grey_erosion02(self):
         array = numpy.array([[3, 2, 5, 1, 4],


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
closes gh-9553

#### What does this implement/fix?
<!--Please explain your changes.-->

If the preallocated output array overlaps in memory with the input array, computation is performed using a newly allocated temporary array and the result is copied back to the output afterwards. Thus the operation is not truly in-place when `output=input`, but incorrect results are avoided.

This fixes bugs in the morphology functions, non-separable convolutions and rank filters. Filters based on separable 1D convolutions do not suffer from the bug and thus no temporary is created in `correlate1d`.

The solution used here is adapted from Jeffrey Bush's convolve PR at CuPy cupy/cupy#3184

Test cases were added checking the expected behavior when `output=input`. The newly added `gaussian_filter` and `correlate1d` test cases pass even on current master, but the others fail without the changes made in this PR.

#### Additional information
<!--Any additional information you think is important.-->
A simple script illustrating the issue on current master:

```Python
import numpy as np
import scipy.ndimage as ndi
import matplotlib.pyplot as plt

x = np.random.randn(64, 64);
x_copy = x.copy()
y = ndi.median_filter(x, (5, 5))
ndi.median_filter(x, (5, 5), output=x)

fig, axes = plt.subplots(1, 3)
axes[0].imshow(x_copy)
axes[0].set_title('original')
axes[1].imshow(y)
axes[1].set_title('filtered')
axes[2].imshow(x)
axes[2].set_title('in-place filtered')
```

![median_bug](https://user-images.githubusercontent.com/6528957/80785727-3c62b300-8b4f-11ea-8c00-69986ca3cbfc.png)
