### PR TITLE
DOC: add TOC for all tutorials

### DIFF
--- a/doc/source/tutorial/arpack.rst
+++ b/doc/source/tutorial/arpack.rst
@@ -7,6 +7,7 @@ Sparse eigenvalue problems with ARPACK
 
 .. currentmodule:: scipy.sparse.linalg
 
+.. contents::
 
 Introduction
 ------------

--- a/doc/source/tutorial/csgraph.rst
+++ b/doc/source/tutorial/csgraph.rst
@@ -5,6 +5,7 @@ Compressed Sparse Graph Routines (`scipy.sparse.csgraph`)
 
 .. currentmodule: scipy.sparse.csgraph
 
+.. contents::
 
 Example: Word Ladders
 ---------------------

--- a/doc/source/tutorial/integrate.rst
+++ b/doc/source/tutorial/integrate.rst
@@ -5,6 +5,8 @@ Integration (:mod:`scipy.integrate`)
 
 .. currentmodule:: scipy.integrate
 
+.. contents::
+
 The :mod:`scipy.integrate` sub-package provides several integration
 techniques including an ordinary differential equation integrator. An
 overview of the module is provided by the help command:

--- a/doc/source/tutorial/io.rst
+++ b/doc/source/tutorial/io.rst
@@ -7,6 +7,8 @@ File IO (:mod:`scipy.io`)
 
 .. seealso:: `NumPy IO routines <https://www.numpy.org/devdocs/reference/routines.io.html>`__
 
+.. contents::
+
 MATLAB files
 ------------
 

--- a/doc/source/tutorial/linalg.rst
+++ b/doc/source/tutorial/linalg.rst
@@ -5,6 +5,8 @@ Linear Algebra (`scipy.linalg`)
 
 .. currentmodule:: scipy
 
+.. contents::
+
 When SciPy is built using the optimized ATLAS LAPACK and BLAS
 libraries, it has very fast linear algebra capabilities. If you dig
 deep enough, all of the raw LAPACK and BLAS libraries are available

--- a/doc/source/tutorial/ndimage.rst
+++ b/doc/source/tutorial/ndimage.rst
@@ -5,6 +5,8 @@ Multidimensional image processing (`scipy.ndimage`)
 
 .. currentmodule:: scipy.ndimage
 
+.. contents::
+
 .. _ndimage-introduction:
 
 Introduction

--- a/doc/source/tutorial/signal.rst
+++ b/doc/source/tutorial/signal.rst
@@ -7,6 +7,8 @@ Signal Processing (`scipy.signal`)
 
 .. currentmodule:: scipy.signal
 
+.. contents::
+
 The signal processing toolbox currently contains some filtering
 functions, a limited set of filter design tools, and a few B-spline
 interpolation algorithms for 1- and 2-D data. While the

--- a/doc/source/tutorial/spatial.rst
+++ b/doc/source/tutorial/spatial.rst
@@ -5,6 +5,8 @@ Spatial data structures and algorithms (`scipy.spatial`)
 
 .. currentmodule:: scipy.spatial
 
+.. contents::
+
 `scipy.spatial` can compute triangulations, Voronoi diagrams, and
 convex hulls of a set of points, by leveraging the `Qhull
 <http://qhull.org/>`__ library.

--- a/doc/source/tutorial/stats.rst
+++ b/doc/source/tutorial/stats.rst
@@ -8,6 +8,8 @@ Statistics (`scipy.stats`)
 
 .. currentmodule:: scipy
 
+.. contents::
+
 Introduction
 ------------
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### What does this implement/fix?
I added table of contents for all tutorials.
Some tutorials already have TOC, but other tutorials don't.
I thind all tutorials should have TOC for consistency and improving accessibility for users
