### PR TITLE
MAINT, CI: remove custom mingw Azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -140,10 +140,6 @@ jobs:
       choco install -y mingw --forcex86 --force --version=6.4.0
     displayName: 'Install 32-bit mingw for 32-bit builds'
     condition: and(succeeded(), eq(variables['BITS'], 32))
-  - powershell: |
-      choco install -y mingw --force --version=6.4.0
-    displayName: 'Install 64-bit mingw for 64-bit builds'
-    condition: and(succeeded(), eq(variables['BITS'], 64))
   - script: python -m pip install numpy cython==0.29.14 pybind11 pytest pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath
     displayName: 'Install dependencies'
   - powershell: |


### PR DESCRIPTION
* we no longer need the custom install of
mingw **64-bit** in Azure CI for Windows builds
because of upstream toolchain updates

* this download task consumes valuable time (~2-5 minutes)
and is a source of errors for failed connections
sometimes, so remove it and use the [pre-installed
mingw](https://github.com/actions/virtual-environments/blob/master/images/win/Windows2016-Readme.md#mingw), which is automatically on PATH

* the remaining mingw PATH adjustments should
only have en effect for 32-bit builds and shouldn't
be harmful for 64-bit builds where they'd presumably
start pointing to an empty path or simply the
default installed path for mingw (can probably
be cleaned up later)