### PR TITLE
MAINT, CI: Azure OpenBLAS simplify

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,6 +64,10 @@ jobs:
   condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))  # skip for PR merges
   pool:
     vmImage: 'VS2017-Win2016'
+  variables:
+    # OPENBLAS64_ variable has same value
+    # but only needed for ILP64 build below
+    OPENBLAS: '$(Agent.BuildDirectory)\openblaslib'
   strategy:
     maxParallel: 4
     matrix:
@@ -88,6 +92,7 @@ jobs:
           TEST_MODE: full
           NPY_USE_BLAS_ILP64: 1
           BITS: 64
+          OPENBLAS64_: $(OPENBLAS)
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -101,7 +106,7 @@ jobs:
       Write-Host "Python Version: $pyversion"
       function Download-OpenBLAS($ilp64) {
           if ($ilp64 -eq '1') { $target_name = "openblas64_.a" } else { $target_name = "openblas.a" }
-          $target = "$pwd\openblaslib\$target_name"
+          $target = "$(OPENBLAS)\$target_name"
           Write-Host "target path: $target"
           $old_value = $env:NPY_USE_BLAS_ILP64
           $env:NPY_USE_BLAS_ILP64 = $ilp64
@@ -109,31 +114,12 @@ jobs:
           $env:NPY_USE_BLAS_ILP64 = $old_value
           cp $openblas $target
       }
-      mkdir openblaslib
+      mkdir $(OPENBLAS)
       Download-OpenBLAS('0')
       If ($env:NPY_USE_BLAS_ILP64 -eq '1') {
           Download-OpenBLAS('1')
       }
     displayName: 'Download / Install OpenBLAS'
-  - bash: |
-      echo "[openblas]" >> site.cfg
-      echo "libraries = openblas" >> site.cfg
-      echo "library_dirs = d:\a\1\s\openblaslib" >> site.cfg
-      echo "include_dirs = d:\a\1\s\openblaslib" >> site.cfg
-      echo "runtime_library_dirs = d:\a\1\s\openblaslib" >> site.cfg
-    displayName: 'Set basic site.cfg for openblas'
-  - bash: |
-      # 64-bit integer OpenBLAS SciPy builds need both 32-bit
-      # integer OpenBLAS from above, and 64-bit suffix static
-      # lib specified here as well
-      echo "    " >> site.cfg
-      echo "[openblas64_]" >> site.cfg
-      echo "libraries = openblas64_" >> site.cfg
-      echo "library_dirs = d:\a\1\s\openblaslib" >> site.cfg
-      echo "include_dirs = d:\a\1\s\openblaslib" >> site.cfg
-      echo "runtime_library_dirs = d:\a\1\s\openblaslib" >> site.cfg
-    displayName: 'Adjust site.cfg for ilp64 case'
-    condition: eq(variables['NPY_USE_BLAS_ILP64'], 1)
   - powershell: |
       # wheels appear to use mingw64 version 6.3.0, but 6.4.0
       # is the closest match available from choco package manager


### PR DESCRIPTION
* use the `OPENBLAS` style ENV variables
to specify the paths to the `openblas.a` and
related static library files in Azure CI for
Windows

* two advantages: concision and, more importantly,
we now avoid hard-coded drive references here,
which are subject to change without warning:
https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops#avoid-hard-coded-references