### PR TITLE
BENCH: Run against current HEAD instead of master

### DIFF
--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -13,7 +13,7 @@
     // benchmarked
     "repo": "..",
     "dvcs": "git",
-    "branches": ["master"],
+    "branches": ["HEAD"],
 
     // The base URL to "how a commit for the project.
     "show_commit_url": "https://github.com/scipy/scipy/commit/",


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Stems from discussion in https://github.com/scipy/scipy/pull/11759 about running linprog benchmarks in a branch.

Relevant discussion:
> > `asv` executes the benchmarks of the active branch but builds head of the master branch. -- @mdhaber
> 
> Oh. I didn't realise it does that. Looking at it now that's what we're telling it to do. Changing `"branches": ["master"]` ⇾ `"branches": ["HEAD"]` in [asv.conf.json](https://github.com/scipy/scipy/blob/master/benchmarks/asv.conf.json) builds the head of the current branch.
> 
> Perhaps that should be changed - but that can be another PR. -- @Kai-Striega

#### What does this implement/fix?
<!--Please explain your changes.-->

- `"branches": ["master"]` ⇾ `"branches": ["HEAD"]` in [asv.conf.json](https://github.com/scipy/scipy/blob/master/benchmarks/asv.conf.json)

#### Additional information
<!--Any additional information you think is important.-->

I'm not incredibly familiar with scipy benchmarking, just moving the discussion into its own PR.