### PR TITLE
DOC: add examples for integrate.quad_vec() and integrate.quad_explain()

### DIFF
--- a/scipy/integrate/_quad_vec.py
+++ b/scipy/integrate/_quad_vec.py
@@ -200,6 +200,10 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6, li
     --------
     We can compute integrations of a vector-valued functions:
 
+    .. math::
+
+           y = \int_{0}^{2} x^n \mathrm{d}x
+
     >>> from scipy.integrate import quad_vec
     >>> import matplotlib.pyplot as plt
     >>> n = np.linspace(0.0, 10.0)
@@ -208,7 +212,7 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6, li
     >>> y, err = quad_vec(f, x0, x1)
     >>> plt.plot(n, y)
     >>> plt.xlabel("n")
-    >>> plt.ylabel(r"$\int_{0}^{2} x^n \mathrm{d}x$")
+    >>> plt.ylabel("y")
     >>> plt.show()
 
     """

--- a/scipy/integrate/_quad_vec.py
+++ b/scipy/integrate/_quad_vec.py
@@ -202,12 +202,12 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6, li
 
     >>> from scipy.integrate import quad_vec
     >>> import matplotlib.pyplot as plt
-    >>> alpha = np.linspace(0.0, 10.0, num=30)
+    >>> alpha = np.linspace(0.0, 2.0, num=30)
     >>> f = lambda x: x**alpha
     >>> x0, x1 = 0, 2
     >>> y, err = quad_vec(f, x0, x1)
     >>> plt.plot(alpha, y)
-    >>> plt.xlabel(r"\alpha")
+    >>> plt.xlabel(r"$\alpha$")
     >>> plt.ylabel(r"$\int_{0}^{2} x^\alpha dx$")
     >>> plt.show()
 

--- a/scipy/integrate/_quad_vec.py
+++ b/scipy/integrate/_quad_vec.py
@@ -196,6 +196,21 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6, li
     ----------
     [1] R. Piessens, E. de Doncker, QUADPACK (1983).
 
+    Examples
+    --------
+    We can compute integrations of a vector-valued functions:
+
+    >>> from scipy.integrate import quad_vec
+    >>> import matplotlib.pyplot as plt
+    >>> n = np.linspace(0.0, 10.0)
+    >>> f = lambda x: x**n
+    >>> x0, x1 = 0, 2
+    >>> y, err = quad_vec(f, x0, x1)
+    >>> plt.plot(n, y)
+    >>> plt.xlabel("n")
+    >>> plt.ylabel(r"$\int_{0}^{2} x^n \mathrm{d}x$")
+    >>> plt.show()
+
     """
     a = float(a)
     b = float(b)

--- a/scipy/integrate/_quad_vec.py
+++ b/scipy/integrate/_quad_vec.py
@@ -103,7 +103,7 @@ class _Bunch(object):
 
 def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6, limit=10000,
              workers=1, points=None, quadrature=None, full_output=False):
-    """Adaptive integration of a vector-valued function.
+    r"""Adaptive integration of a vector-valued function.
 
     Parameters
     ----------
@@ -208,7 +208,7 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6, li
     >>> y, err = quad_vec(f, x0, x1)
     >>> plt.plot(n, y)
     >>> plt.xlabel("n")
-    >>> plt.ylabel(r"$\int_{0}^{2} x^n \mathrm{d}x$")
+    >>> plt.ylabel(r"$\int_{0}^{2} x^n dx$")
     >>> plt.show()
 
     """

--- a/scipy/integrate/_quad_vec.py
+++ b/scipy/integrate/_quad_vec.py
@@ -198,7 +198,7 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6, li
 
     Examples
     --------
-    We can compute integrations of a vector-valued functions:
+    We can compute integrations of a vector-valued function:
 
     >>> from scipy.integrate import quad_vec
     >>> import matplotlib.pyplot as plt

--- a/scipy/integrate/_quad_vec.py
+++ b/scipy/integrate/_quad_vec.py
@@ -202,13 +202,13 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6, li
 
     >>> from scipy.integrate import quad_vec
     >>> import matplotlib.pyplot as plt
-    >>> n = np.linspace(0.0, 10.0)
-    >>> f = lambda x: x**n
+    >>> alpha = np.linspace(0.0, 10.0, num=30)
+    >>> f = lambda x: x**alpha
     >>> x0, x1 = 0, 2
     >>> y, err = quad_vec(f, x0, x1)
-    >>> plt.plot(n, y)
-    >>> plt.xlabel("n")
-    >>> plt.ylabel(r"$\int_{0}^{2} x^n dx$")
+    >>> plt.plot(alpha, y)
+    >>> plt.xlabel(r"\alpha")
+    >>> plt.ylabel(r"$\int_{0}^{2} x^\alpha dx$")
     >>> plt.show()
 
     """

--- a/scipy/integrate/quadpack.py
+++ b/scipy/integrate/quadpack.py
@@ -37,12 +37,10 @@ def quad_explain(output=sys.stdout):
 
     Examples
     --------
-    We can show detailed information of the `integrate.quad` function:
+    We can show detailed information of the `integrate.quad` function in stdout:
 
     >>> from scipy.integrate import quad_explain
     >>> quad_explain()
-    Compute a definite integral.
-        ...
 
     """
     output.write(quad.__doc__)

--- a/scipy/integrate/quadpack.py
+++ b/scipy/integrate/quadpack.py
@@ -37,7 +37,7 @@ def quad_explain(output=sys.stdout):
 
     Examples
     --------
-    We can show `integrate.quad` detailed information:
+    We can show detailed information of the `integrate.quad` function:
 
     >>> from scipy.integrate import quad_explain
     >>> quad_explain()

--- a/scipy/integrate/quadpack.py
+++ b/scipy/integrate/quadpack.py
@@ -35,6 +35,15 @@ def quad_explain(output=sys.stdout):
     -------
     None
 
+    Examples
+    --------
+    We can show `integrate.quad` detailed information:
+
+    >>> from scipy.integrate import quad_explain
+    >>> quad_explain()
+    Compute a definite integral.
+        ...
+
     """
     output.write(quad.__doc__)
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
fix a part of #7168 

#### What does this implement/fix?
add examples for integrate.quad_vec() and integrate.quad_explain()
