### PR TITLE
MAINT: Use helper functions in ?tbtrs tests

### DIFF
--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -587,29 +587,29 @@ class TestTbtrs(object):
     @pytest.mark.parametrize('diag', ['N', 'U'])
     def test_random_matrices(self, dtype, trans, uplo, diag):
         seed(1724)
-        # lda, ldb, nrhs, kd are used to specify A and b.
-        # A is of shape lda x ldb with kd super/sub-diagonals
-        # b is of shape ldb x nrhs matrix
-        lda, ldb, nrhs, kd = 4, 4, 3, 2
+        # n, nrhs, kd are used to specify A and b.
+        # A is of shape n x n with kd super/sub-diagonals
+        # b is of shape n x nrhs matrix
+        n, nrhs, kd = 4, 3, 2
         ldab = kd + 1
         tbtrs = get_lapack_funcs('tbtrs', dtype=dtype)
 
         # Construct the diagonal and kd super/sub diagonals of A with
         # the corresponding offsets.
-        band_widths = range(lda, lda - kd - 1, -1)
+        band_widths = range(n, n - kd - 1, -1)
         band_offsets = np.arange(ldab) if uplo == 'U' else np.arange(ldab) * -1
         bands = [generate_random_dtype_array((width,), dtype)
                  for width in band_widths]
 
         if diag == 'U':  # A must be unit triangular
-            bands[0] = np.ones(lda, dtype=dtype)
+            bands[0] = np.ones(n, dtype=dtype)
 
         # Construct the diagonal banded matrix A from the bands and offsets.
         a = sps.diags(bands, band_offsets, format='dia')
         ab = _to_symmetric_banded(a.toarray(), uplo, kd)
 
         # The RHS values.
-        b = generate_random_dtype_array((ldb, nrhs), dtype)
+        b = generate_random_dtype_array((n, nrhs), dtype)
 
         x, info = tbtrs(ab=ab, b=b, uplo=uplo, trans=trans, diag=diag)
         assert_equal(info, 0)

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -565,13 +565,8 @@ class TestTbtrs(object):
         # the corresponding offsets.
         band_widths = range(lda, lda - kd - 1, -1)
         band_offsets = np.arange(ldab) if uplo == 'U' else np.arange(ldab) * -1
-        if dtype in REAL_DTYPES:
-            b = rand(ldb, nrhs).astype(dtype)
-            bands = [rand(width).astype(dtype) for width in band_widths]
-        elif dtype in COMPLEX_DTYPES:
-            b = (rand(ldb, nrhs) + rand(ldb, nrhs) * 1j).astype(dtype)
-            bands = [(rand(width) + rand(width) * 1j).astype(dtype)
-                     for width in band_widths]
+        bands = [generate_random_dtype_array((width,), dtype)
+                 for width in band_widths]
 
         if diag == 'U':  # A must be unit triangular
             bands[0] = np.ones(lda, dtype=dtype)
@@ -579,6 +574,9 @@ class TestTbtrs(object):
         # Construct the diagonal banded matrix A from the bands and offsets.
         a = sps.diags(bands, band_offsets, format='dia')
         ab = np.flipud(a.data) if uplo == 'U' else a.data
+
+        # The RHS values.
+        b = generate_random_dtype_array((ldb, nrhs), dtype)
 
         tbtrs = get_lapack_funcs('tbtrs', dtype=dtype)
         x, info = tbtrs(ab=ab, b=b, uplo=uplo, trans=trans, diag=diag)


### PR DESCRIPTION
#### What does this implement/fix?
<!--Please explain your changes.-->
This PR tidies `TestTbtrs.test_random_matrices` by allowing it to use helper functions where possible. 

* ``generate_random_dtype_array`` is used to generate the bands rather than explicitly constructing random vectors
* ``_to_symmetric_banded`` is used to convert the full matrix ``A`` to banded storage ``ab``, further, this adds ``_to_banded``  a more generic version of ``_to_symmetric_banded``

The test constructs the banded matrix as a [dia_matrix](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.dia_matrix.html#scipy-sparse-dia-matrix) then massages the underlying data into `ab`. While this works, it is messy and could lead to some obscure bugs if the way the data is stored changes. Now the test is no longer dependent on the data's structure as it indexes the data directly.

#### Additional information
<!--Any additional information you think is important.-->
While ``_to_banded``  is not used here I've used a similar "trick" in #11890 / #11985. Adding it here will allow me to rebase those branches and have these functions without messing up my commit history too much.

Banded storage stores the diagonal bands of ``A`` in ``ab`` such that: ``ab[u + i - j, j] == a[i,j]`` for example, a (6, 6) matrix with 2 lower bands and 1 upper band is stored as:

```
*    a01  a12  a23  a34  a45
a00  a11  a22  a33  a44  a55
a10  a21  a32  a43  a54   *
a20  a31  a42  a53   *    *
```

where `*` elements are not referenced. sy/he banded storage uses a similar pattern except only the lower or upper bands are stored. Therefore, to store a sy/he banded matrix, only the number of unique diagonals and whether it is to be in lower or upper storage is required.