### PR TITLE
DOC: roadmap update

### DIFF
--- a/doc/source/roadmap-detailed.rst
+++ b/doc/source/roadmap-detailed.rst
@@ -82,8 +82,7 @@ There are currently only two options: using Intel Fortran, or using MSVC +
 gfortran.  The former is expensive, while the latter works (it's what we use
 for releases) but is quite hard to do correctly.  For allowing contributors and
 end users to reliably build SciPy on Windows, using the Flang compiler looks
-like the best way forward long-term.  Until Flang support materializes, we need
-to streamline and better document the MSVC + gfortran build.
+like the best way forward long-term.
 
 
 Continuous integration

--- a/doc/source/roadmap-detailed.rst
+++ b/doc/source/roadmap-detailed.rst
@@ -168,19 +168,19 @@ of the most important things that SciPy provides. In general ``scipy.linalg``
 is in good shape, however we can make a number of improvements:
 
 1. Library support. Our released wheels now ship with OpenBLAS, which is
-currently the only feasible performant option (ATLAS is too slow, MKL cannot be
-the default due to licensing issues, Accelerate support is dropped because
-Apple doesn't update Accelerate anymore). OpenBLAS isn't very stable though,
-sometimes its releases break things and it has issues with threading (currently
-the only issue for using SciPy with PyPy3).  We need at the very least better
-support for debugging OpenBLAS issues, and better documentation on how to build
-SciPy with it.  An option is to use BLIS for a BLAS interface (see `numpy
-gh-7372 <https://github.com/numpy/numpy/issues/7372>`__).
+   currently the only feasible performant option (ATLAS is too slow, MKL cannot
+   be the default due to licensing issues, Accelerate support is dropped
+   because Apple doesn't update Accelerate anymore). OpenBLAS isn't very stable
+   though, sometimes its releases break things and it has issues with threading
+   (currently the only issue for using SciPy with PyPy3).  We need at the very
+   least better support for debugging OpenBLAS issues, and better documentation
+   on how to build SciPy with it.  An option is to use BLIS for a BLAS
+   interface (see `numpy gh-7372 <https://github.com/numpy/numpy/issues/7372>`__).
 
 2. Support for newer LAPACK features.  In SciPy 1.2.0 we increased the minimum
-supported version of LAPACK to 3.4.0.  Now that we dropped Python 2.7, we can
-increase that version further (MKL + Python 2.7 was the blocker for >3.4.0
-previously) and start adding support for new features in LAPACK.
+   supported version of LAPACK to 3.4.0.  Now that we dropped Python 2.7, we
+   can increase that version further (MKL + Python 2.7 was the blocker for
+   >3.4.0 previously) and start adding support for new features in LAPACK.
 
 
 misc

--- a/doc/source/roadmap-detailed.rst
+++ b/doc/source/roadmap-detailed.rst
@@ -92,6 +92,16 @@ and Linux, ARM64 and ppc64le platforms, as well as a range of versions of our
 dependencies and building release quality wheels.
 
 
+Size of binaries
+````````````````
+SciPy binaries are quite large (e.g. an unzipped manylinux wheel for 1.4.1 is
+91 MB), and this can be problematic - for example for use in AWS Lambda, which
+has a 250 MB size limit. We aim to keep binary size as low as possible; when
+adding new compiled extensions, this needs checking. Stripping of debug symbols
+in ``multibuild`` can likely be improved (see `this issue
+<https://github.com/matthew-brett/multibuild/issues/162>`__).
+
+
 Modules
 -------
 

--- a/doc/source/roadmap-detailed.rst
+++ b/doc/source/roadmap-detailed.rst
@@ -108,12 +108,8 @@ This module is basically done, low-maintenance and without open issues.
 
 fft
 ````
+This module is in good shape.
 
-Ideas for new features:
-
-- Add a backend/plugin system.  At the moment pyFFTW is monkeypatching SciPy,
-  and ``mkl_fft`` provides ``fftpack``-compatible functions as well.  We should
-  provide a method to support such packages.
 
 integrate
 `````````
@@ -414,12 +410,12 @@ The following improvements will help SciPy better serve this role.
   - multivariate t distribution
   - mixture distributions
 
-- Improve the core calculations provided by SciPy's probability distributions 
+- Improve the core calculations provided by SciPy's probability distributions
   so they can robustly handle wide ranges of parameter values.  Specifically,
   replace many of the PDF and CDF methods from the Fortran library CDFLIB
   used in scipy.special with better code, perhaps ported from the Boost C++
   library.
-  
+
 In addition, we should:
 
 - Continue work on making the function signatures of ``stats`` and
@@ -432,5 +428,5 @@ In addition, we should:
   example implement an exact two-sided KS test (see
   `gh-8341 <https://github.com/scipy/scipy/issues/8341>`__) or a one-sided
   Wilcoxon test (see `gh-9046 <https://github.com/scipy/scipy/issues/9046>`__).
-- Address the various issues regarding ``stats.mannwhitneyu``, and pick up the 
+- Address the various issues regarding ``stats.mannwhitneyu``, and pick up the
   stalled PR in `gh-4933 <https://github.com/scipy/scipy/pull/4933>`__.

--- a/doc/source/roadmap.rst
+++ b/doc/source/roadmap.rst
@@ -8,29 +8,10 @@ going forward.  For a more detailed roadmap, including per-subpackage status,
 many more ideas, API stability and more, see :ref:`scipy-roadmap-detailed`.
 
 
-Implement sparse arrays in addition to sparse matrices
-------------------------------------------------------
-
-The sparse matrix formats are mostly feature-complete, however the main issue
-is that they act like ``numpy.matrix`` (which will be deprecated in NumPy at
-some point).  What we want is sparse *arrays* that act like ``numpy.ndarray``.
-This is being worked on in https://github.com/pydata/sparse, which is quite far
-along.  The tentative plan is:
-
-- Start depending on ``pydata/sparse`` once it's feature-complete enough (it
-  still needs a CSC/CSR equivalent) and okay performance-wise.
-- Add support for ``pydata/sparse`` to ``scipy.sparse.linalg`` (and perhaps to
-  ``scipy.sparse.csgraph`` after that).
-- Indicate in the documentation that for new code users should prefer
-  ``pydata/sparse`` over sparse matrices.
-- When NumPy deprecates ``numpy.matrix``, vendor that or maintain it as a
-  stand-alone package.
-
-
 Support for distributed arrays and GPU arrays
 ---------------------------------------------
 
-NumPy is splitting its API from its execution engine with
+NumPy has split its API from its execution engine with
 ``__array_function__`` and ``__array_ufunc__``.  This will enable parts of SciPy
 to accept distributed arrays (e.g. ``dask.array.Array``) and GPU arrays (e.g.
 ``cupy.ndarray``) that implement the ``ndarray`` interface.  At the moment it is
@@ -42,7 +23,9 @@ In addition to making use of NumPy protocols like ``__array_function__``, we can
 make use of these protocols in SciPy as well.  That will make it possible to
 (re)implement SciPy functions like, e.g., those in ``scipy.signal`` for Dask
 or GPU arrays (see
-`NEP 18 - use outside of NumPy <http://www.numpy.org/neps/nep-0018-array-function-protocol.html#use-outside-of-numpy>`__).
+`NEP 18 - use outside of NumPy <http://www.numpy.org/neps/nep-0018-array-function-protocol.html#use-outside-of-numpy>`__).  NumPy's features in this areas are still evolving,
+see e.g. `NEP 37 - A dispatch protocol for NumPy-like modules <https://numpy.org/neps/nep-0037-array-module.html>`__,
+and SciPy is an important "client" for those features.
 
 
 Statistics enhancements
@@ -55,3 +38,34 @@ particularly high importance to the project.
 - Expand the set of hypothesis tests.  In particular, include all the basic
   variations of analysis of variance.
 - Add confidence intervals for all statistical tests.
+
+
+Support for more hardware platforms
+-----------------------------------
+
+SciPy now has continuous integration for ARM64 (or ``aarch64``) and POWER8/9
+(or ``ppc64le``), and binaries are available via
+`Miniforge <https://github.com/conda-forge/miniforge>`__.  Wheels on PyPI for
+these platforms are now also possible (with the ``manylinux2014`` standard),
+and requests for those are becoming more frequent.
+
+Additionally, having IBM Z (or ``s390x``) in CI is now possible with TravisCI
+but not yet done - and ``manylinux2014`` wheels for that platform are also
+possible then.  Finally, resolving open AIX build issues would help users.
+
+
+Implement sparse arrays in addition to sparse matrices
+------------------------------------------------------
+
+The sparse matrix formats are mostly feature-complete, however the main issue
+is that they act like ``numpy.matrix`` (which will be deprecated in NumPy at
+some point).  What we want is sparse *arrays* that act like ``numpy.ndarray``.
+This is being worked on in https://github.com/pydata/sparse, which is quite far
+along.  The tentative plan is:
+
+- Start depending on ``pydata/sparse`` once it's feature-complete enough (it
+  still needs a CSC/CSR equivalent) and okay performance-wise.
+- Indicate in the documentation that for new code users should prefer
+  ``pydata/sparse`` over sparse matrices.
+- When NumPy deprecates ``numpy.matrix``, vendor that or maintain it as a
+  stand-alone package.

--- a/doc/source/roadmap.rst
+++ b/doc/source/roadmap.rst
@@ -50,13 +50,6 @@ along.  The tentative plan is:
   stand-alone package.
 
 
-Fourier transform enhancements
-------------------------------
-
-The new ``scipy.fft`` subpackage should be extended to add a backend system with
-support for PyFFTW and mkl-fft.
-
-
 Support for distributed arrays and GPU arrays
 ---------------------------------------------
 

--- a/doc/source/roadmap.rst
+++ b/doc/source/roadmap.rst
@@ -28,6 +28,25 @@ see e.g. `NEP 37 - A dispatch protocol for NumPy-like modules <https://numpy.org
 and SciPy is an important "client" for those features.
 
 
+Performance improvements
+------------------------
+
+Speed improvements, lower memory usage and the ability to parallelize
+algorithms are beneficial to most science domains and use cases.  We have
+established an API design pattern for multiprocessing - using the ``workers``
+keyword - that can be adopted in many more functions.
+
+Enabling the use of an accelerator like Pythran, possibly via Transonic, and
+making it easier for users to use Numba's ``@njit`` in their code that relies
+on SciPy functionality would unlock a lot of performance gain.  That needs a
+strategy though, all solutions are still maturing (see for example
+`this overview <https://fluiddyn.bitbucket.io/transonic-vision.html>`__).
+
+Finally, many individual functions can be optimized for performance.
+``scipy.optimize`` and ``scipy.interpolate`` functions are particularly often
+requested in this respect.
+
+
 Statistics enhancements
 -----------------------
 

--- a/doc/source/roadmap.rst
+++ b/doc/source/roadmap.rst
@@ -8,29 +8,6 @@ going forward.  For a more detailed roadmap, including per-subpackage status,
 many more ideas, API stability and more, see :ref:`scipy-roadmap-detailed`.
 
 
-Evolve BLAS and LAPACK support
-------------------------------
-
-The Python and Cython interfaces to BLAS and LAPACK in ``scipy.linalg`` are one
-of the most important things that SciPy provides. In general ``scipy.linalg``
-is in good shape, however we can make a number of improvements:
-
-1. Library support. Our released wheels now ship with OpenBLAS, which is
-currently the only feasible performant option (ATLAS is too slow, MKL cannot be
-the default due to licensing issues, Accelerate support is dropped because
-Apple doesn't update Accelerate anymore). OpenBLAS isn't very stable though,
-sometimes its releases break things and it has issues with threading (currently
-the only issue for using SciPy with PyPy3).  We need at the very least better
-support for debugging OpenBLAS issues, and better documentation on how to build
-SciPy with it.  An option is to use BLIS for a BLAS interface (see `numpy
-gh-7372 <https://github.com/numpy/numpy/issues/7372>`__).
-
-2. Support for newer LAPACK features.  In SciPy 1.2.0 we increased the minimum
-supported version of LAPACK to 3.4.0.  Now that we dropped Python 2.7, we can
-increase that version further (MKL + Python 2.7 was the blocker for >3.4.0
-previously) and start adding support for new features in LAPACK.
-
-
 Implement sparse arrays in addition to sparse matrices
 ------------------------------------------------------
 
@@ -66,18 +43,6 @@ make use of these protocols in SciPy as well.  That will make it possible to
 (re)implement SciPy functions like, e.g., those in ``scipy.signal`` for Dask
 or GPU arrays (see
 `NEP 18 - use outside of NumPy <http://www.numpy.org/neps/nep-0018-array-function-protocol.html#use-outside-of-numpy>`__).
-
-
-Improve source builds on Windows
---------------------------------
-
-SciPy critically relies on Fortran code. This is still problematic on Windows.
-There are currently only two options: using Intel Fortran, or using
-MSVC + gfortran.  The former is expensive, while the latter works (it's what we
-use for releases) but is quite hard to do correctly.  For allowing contributors
-and end users to reliably build SciPy on Windows, using the Flang compiler
-looks like the best way forward long-term.  Until Flang support materializes,
-we need to streamline and better document the MSVC + gfortran build.
 
 
 Statistics enhancements


### PR DESCRIPTION
Changes to the main roadmap:

- removed `fft` changes, those were done
- moved "Windows builds" and "evolve LAPACK support" to the detailed roadmap
- added "support for more hardware platforms", interest keeps growing is my impression
- added "performance" as a main item on the roadmap
- reordered items for importance, mainly sparse ndarrays from top to bottom, that's evolving slowly