### PR TITLE
CI: print 10 slowest tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,15 +72,15 @@ matrix:
       if: type = pull_request
       dist: bionic
       env:
-        - USE_DEBUG=python3.6-dbg
+        - USE_DEBUG=python3.7-dbg
         - TESTMODE=fast
         - NUMPYSPEC="--upgrade numpy"
       addons:
         apt:
           packages:
             - *common_packages
-            - python3.6-dbg
-            - python3.6-dev
+            - python3.7-dbg
+            - python3.7-dev
     - python: 3.8
       if: type = pull_request
       env:
@@ -171,7 +171,7 @@ before_install:
     if [ -n "${USE_DEBUG}" ]; then
         # see gh-10676; need to pin pytest version with debug
         # Python 3.6
-        travis_retry pip install pytest==5.0.1
+        travis_retry pip install pytest
     fi
   - |
     if [ -z "${USE_DEBUG}" -a "${TRAVIS_CPU_ARCH}" == "amd64" -a "${TRAVIS_PYTHON_VERSION}" != "3.8" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -241,7 +241,7 @@ script:
         USE_WHEEL_BUILD="--no-build"
     fi
   - export SCIPY_AVAILABLE_MEM=3G
-  - python -u runtests.py -g -m $TESTMODE $COVERAGE $USE_WHEEL_BUILD -- -rfEX -n 3 2>&1 | tee runtests.log
+  - python -u runtests.py -g -m $TESTMODE $COVERAGE $USE_WHEEL_BUILD -- -rfEX --durations=10 -n 3 2>&1 | tee runtests.log
 
   - tools/validate_runtests_log.py $TESTMODE < runtests.log
   - if [ "${REFGUIDE_CHECK}" == "1" ]; then python runtests.py -g --refguide-check; fi


### PR DESCRIPTION
on travisCI print out the 10 slowest tests, so we can follow if/when tests are introduced that take too long.