### PR TITLE
DOC : added default value of absolute_sigma to False in scipy.optimize.curve_fit docs

### DIFF
--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -575,12 +575,12 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
         If True, `sigma` is used in an absolute sense and the estimated parameter
         covariance `pcov` reflects these absolute values.
 
-        If False, only the relative magnitudes of the `sigma` values matter.
+        If False (default), only the relative magnitudes of the `sigma` values matter.
         The returned parameter covariance matrix `pcov` is based on scaling
         `sigma` by a constant factor. This constant is set by demanding that the
         reduced `chisq` for the optimal parameters `popt` when using the
         *scaled* `sigma` equals unity. In other words, `sigma` is scaled to
-        match the sample variance of the residuals after the fit.
+        match the sample variance of the residuals after the fit. Default is False
         Mathematically,
         ``pcov(absolute_sigma=False) = pcov(absolute_sigma=True) * chisq(popt)/(M-N)``
     check_finite : bool, optional

--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -580,7 +580,7 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
         `sigma` by a constant factor. This constant is set by demanding that the
         reduced `chisq` for the optimal parameters `popt` when using the
         *scaled* `sigma` equals unity. In other words, `sigma` is scaled to
-        match the sample variance of the residuals after the fit. Default is False
+        match the sample variance of the residuals after the fit. Default is False.
         Mathematically,
         ``pcov(absolute_sigma=False) = pcov(absolute_sigma=True) * chisq(popt)/(M-N)``
     check_finite : bool, optional


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #11944
#### What does this implement/fix?
<!--Please explain your changes.-->
added default value of absolute_sigma to False in scipy.optimize.curve_fit docs
#### Additional information
<!--Any additional information you think is important.-->