### PR TITLE
MAINT: Remove numpy/npy_3kcompat.h from nd_image

### DIFF
--- a/scipy/ndimage/src/nd_image.c
+++ b/scipy/ndimage/src/nd_image.c
@@ -43,7 +43,6 @@
 #include "ni_measure.h"
 
 #include "ccallback.h"
-#include "numpy/npy_3kcompat.h"
 
 #if NPY_API_VERSION >= 0x0000000c
     #define HAVE_WRITEBACKIFCOPY
@@ -1059,7 +1058,7 @@ static PyObject *Py_BinaryErosion(PyObject *obj, PyObject *args)
         goto exit;
     }
     if (return_coordinates) {
-        cobj = NpyCapsule_FromVoidPtr(coordinate_list, _FreeCoordinateList);
+        cobj = PyCapsule_New(coordinate_list, NULL, _FreeCoordinateList);
     }
     #ifdef HAVE_WRITEBACKIFCOPY
         PyArray_ResolveWritebackIfCopy(output);
@@ -1103,7 +1102,7 @@ static PyObject *Py_BinaryErosion2(PyObject *obj, PyObject *args)
         goto exit;
     }
     if (PyCapsule_CheckExact(cobj)) {
-        NI_CoordinateList *cobj_data = NpyCapsule_AsVoidPtr(cobj);
+        NI_CoordinateList *cobj_data = PyCapsule_GetPointer(cobj, NULL);
         if (!NI_BinaryErosion2(array, strct, mask, niter, origin.ptr, invert,
                                &cobj_data)) {
             goto exit;

--- a/scipy/ndimage/src/nd_image.h
+++ b/scipy/ndimage/src/nd_image.h
@@ -37,6 +37,4 @@
 #define PY_ARRAY_UNIQUE_SYMBOL _scipy_ndimage_ARRAY_API
 #include <numpy/arrayobject.h>
 
-#include "numpy/npy_3kcompat.h"
-
 #endif /* ND_IMAGE_H */


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Continued work to remove all Python2 Code #11584

#### What does this implement/fix?
<!--Please explain your changes.-->
The delta here is that `PyErr` caused by `PyCapsule_New/Get` are no longer cleared. [shim impl](https://github.com/numpy/numpy/blob/master/numpy/core/include/numpy/npy_3kcompat.h#L496)

#### Additional information
<!--Any additional information you think is important.-->

I'm trying to understand `OLDAPI` from the [_ctest.c](https://github.com/scipy/scipy/blob/master/scipy/ndimage/src/_ctest.c#L5), is this used anymore? can it be removed? Potential diff: https://github.com/scipy/scipy/compare/master...sethtroisi:remove_oldapi?expand=1
