### PR TITLE
BUG FIX: pearson3.stats returning moments as arrays rather than scalars. 

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -234,6 +234,7 @@ James Wright for simple documentation fixes
 Sam Wallan for scipy.linalg.lapack enhancements
 Richard Weiss for a bug fix in scipy.optimize._differentialevolution.py.
 Luigi F. Cruz for adding time/frequency domain option to scipy.signal.resample.
+Will Tirone for a bug fix in scipy.stats._continuous_distns.py. 
 
 Institutions
 ------------

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -6219,16 +6219,19 @@ class pearson3_gen(rv_continuous):
         # for all skew args.
         return np.ones(np.shape(skew), dtype=bool)
 
+    def _norm_stats(self):
+        return 0.0, 1.0, 0.0, 0.0
+    
     def _stats(self, skew):
-        _, _, _, _, _, beta, alpha, zeta = (
+        _, _, _, _, invmask, beta, alpha, zeta = (
             self._preprocess([1], skew))
         m = zeta + alpha / beta
         v = alpha / (beta**2)
         s = 2.0 / (alpha**0.5) * np.sign(beta)
         k = 6.0 / alpha
-        for i in [m, v, s, k]: 
-            if np.any(i.size) == 0: 
-                return (0, 0, 0, 0)
+        if invmask == False:
+            m,v,s,k = self._norm_stats() 
+            return m,v,s,k
         else: 
             return np.float(m), np.float(v), np.float(s), np.float(k)
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -6226,7 +6226,11 @@ class pearson3_gen(rv_continuous):
         v = alpha / (beta**2)
         s = 2.0 / (alpha**0.5) * np.sign(beta)
         k = 6.0 / alpha
-        return m, v, s, k
+        for i in [m, v, s, k]: 
+            if np.any(i.size) == 0: 
+                return (0, 0, 0, 0)
+        else: 
+            return np.float(m), np.float(v), np.float(s), np.float(k)
 
     def _pdf(self, x, skew):
         # pearson3.pdf(x, skew) = abs(beta) / gamma(alpha) *

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -340,8 +340,6 @@ def test_nomodify_gh9900_regression():
 def test_gh11746_regression():
     # Regression test for gh-11746
     prsn3 = stats.pearson3
-    # Use the right-half truncated normal
-    # Check that the cdf and _cdf return the same result.
     npt.assert_equal(prsn3.moment(1, skew=0), 0.0)
     npt.assert_almost_equal(prsn3.moment(2, skew=1), 1.0)
 

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -337,6 +337,14 @@ def test_nomodify_gh9900_regression():
     npt.assert_almost_equal(tn.cdf(1, -np.inf, 0), 1)                     # Not 1.6826894921370859
     npt.assert_almost_equal(tn.cdf(-1, -np.inf, 0), 0.31731050786291415)  # Not -0.6826894921370859
 
+def test_gh11746_regression():
+    # Regression test for gh-11746
+    prsn3 = stats.pearson3
+    # Use the right-half truncated normal
+    # Check that the cdf and _cdf return the same result.
+    npt.assert_equal(prsn3.moment(1, skew=0), 0.0)
+    npt.assert_almost_equal(prsn3.moment(2, skew=1), 1.0)
+
 
 def test_broadcast_gh9990_regression():
     # Regression test for gh-9990


### PR DESCRIPTION


#### Reference issue
Closes gh-11746

#### What does this implement/fix?
pearson3.moment was returning an array and now returns a scalar. Fixed by converting pearson._stats output variables to scalars.

#### Additional information
This is my first contribution so please review carefully. I followed the contribution guide fairly carefully. Changes pass testing and I added a regression test in _continous_distns.py. 

There is a comment that I would like reviewed from the distribution: 

        # The _argcheck function in rv_continuous only allows positive
        # arguments.  The skew argument for pearson3 can be zero (which I want
        # to handle inside pearson3._pdf) or negative.  So just return True
        # for all skew args.

I'm honestly not sure what the original intent here was as far as handling a skew of zero, so I just  defaulted to returning zeros in _stats, but please let me know if this is incorrect. I think that portion may be outside of my understanding of statistics / the standard approach for scipy devs in cases like this.
