### PR TITLE
MAINT, CI: Travis rackcdn->conda.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
    - PRE_WHEELS="https://pypi.anaconda.org/scipy-wheels-nightly/simple"
    # Using a single thread can actually speed up some computations on Travis
    - OPENBLAS_NUM_THREADS=1
+   - OTHERSPEC=""
 
 matrix:
   include:
@@ -56,6 +57,7 @@ matrix:
         - TESTMODE=fast
         - COVERAGE=
         - NUMPYSPEC="--pre --upgrade --timeout=60 -i $PRE_WHEELS numpy"
+        - OTHERSPEC="--pre --upgrade --timeout=60"
         # Need a test with most recent Python version where we build from an
         # sdist (uses pip build isolation), to check that the version we
         # specify in pyproject.toml (will be older than --pre --upgrade) works
@@ -87,6 +89,7 @@ matrix:
       env:
         - TESTMODE=full
         - NUMPYSPEC="--pre --upgrade --timeout=60 -i $PRE_WHEELS numpy"
+        - OTHERSPEC="--pre --upgrade --timeout=60"
         - NPY_USE_BLAS_ILP64=1
     - python: 3.6
       if: type = pull_request
@@ -166,7 +169,8 @@ before_install:
   # Miniforge / conda-forge), so skip arm64 here
   - |
     if [[ "$TRAVIS_CPU_ARCH" != "arm64" ]]; then
-         travis_retry pip install --upgrade pip setuptools wheel $NUMPYSPEC cython pytest pytest-xdist mpmath argparse Pillow codecov gmpy2 pybind11
+         travis_retry pip install --upgrade pip setuptools wheel $OTHERSPEC cython pytest pytest-xdist mpmath argparse Pillow codecov gmpy2 pybind11
+         travis_retry pip install --upgrade $NUMPYSPEC
     fi
   - |
     if [ -n "${USE_DEBUG}" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ addons:
 env:
   global:
    # Wheelhouse for pre-release wheels
-   - PRE_WHEELS="https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com"
+   - PRE_WHEELS="https://pypi.anaconda.org/scipy-wheels-nightly/simple"
    # Using a single thread can actually speed up some computations on Travis
    - OPENBLAS_NUM_THREADS=1
 
@@ -55,7 +55,7 @@ matrix:
       env:
         - TESTMODE=fast
         - COVERAGE=
-        - NUMPYSPEC="--pre --upgrade --timeout=60 -f $PRE_WHEELS numpy"
+        - NUMPYSPEC="--pre --upgrade --timeout=60 -i $PRE_WHEELS numpy"
         # Need a test with most recent Python version where we build from an
         # sdist (uses pip build isolation), to check that the version we
         # specify in pyproject.toml (will be older than --pre --upgrade) works
@@ -86,7 +86,7 @@ matrix:
       if: type = pull_request
       env:
         - TESTMODE=full
-        - NUMPYSPEC="--pre --upgrade --timeout=60 -f $PRE_WHEELS numpy"
+        - NUMPYSPEC="--pre --upgrade --timeout=60 -i $PRE_WHEELS numpy"
         - NPY_USE_BLAS_ILP64=1
     - python: 3.6
       if: type = pull_request


### PR DESCRIPTION
* transition to usage of anaconda.org for retrieving
NumPy pre-release ("nightly") wheels in Travis CI, because
continued dependence on rackcdn will eventually lead to charges
for the OSS community

* the `NUMPYSPEC` lines for pre-release matrix entries were modified
based on the instructions (https://anaconda.org/scipy-wheels-nightly/numpy)
and local testing:

* 1) Use the new URL

* 2) Switch from `-f` (finding archives/tarballs at a URL) to `-i`
(use a PEP 503 compliant index like anaconda.org `simple` API format)

I'll mark with WIP until we check the logs for the pre-wheels and because the pre-wheels matrix entries are likely to fail until #12037 is resolved (bleeding-edge Cython issue).