### PR TITLE
MAINT: signal: Lower the resolution of the plots in the chirp examples.

### DIFF
--- a/scipy/signal/waveforms.py
+++ b/scipy/signal/waveforms.py
@@ -351,7 +351,7 @@ def chirp(t, f0, t1, f1, method='linear', phi=0, vertex_zero=True):
     For the first example, we'll plot the waveform for a linear chirp
     from 6 Hz to 1 Hz over 10 seconds:
 
-    >>> t = np.linspace(0, 10, 5001)
+    >>> t = np.linspace(0, 10, 1500)
     >>> w = chirp(t, f0=6, f1=1, t1=10, method='linear')
     >>> plt.plot(t, w)
     >>> plt.title("Linear Chirp, f(0)=6, f(10)=1")
@@ -360,62 +360,49 @@ def chirp(t, f0, t1, f1, method='linear', phi=0, vertex_zero=True):
 
     For the remaining examples, we'll use higher frequency ranges,
     and demonstrate the result using `scipy.signal.spectrogram`.
-    We'll use a 10 second interval sampled at 8000 Hz.
+    We'll use a 4 second interval sampled at 7200 Hz.
 
-    >>> fs = 8000
-    >>> T = 10
-    >>> t = np.linspace(0, T, T*fs, endpoint=False)
+    >>> fs = 7200
+    >>> T = 4
+    >>> t = np.arange(0, int(T*fs)) / fs
 
-    Quadratic chirp from 1500 Hz to 250 Hz over 10 seconds
+    We'll use this function to plot the spectrogram in each example.
+
+    >>> def plot_spectrogram(title, w, fs):
+    ...     ff, tt, Sxx = spectrogram(w, fs=fs, nperseg=256, nfft=576)
+    ...     plt.pcolormesh(tt, ff[:145], Sxx[:145], cmap='gray_r')
+    ...     plt.title(title)
+    ...     plt.xlabel('t (sec)')
+    ...     plt.ylabel('Frequency (Hz)')
+    ...     plt.grid()
+    ...
+
+    Quadratic chirp from 1500 Hz to 250 Hz
     (vertex of the parabolic curve of the frequency is at t=0):
 
-    >>> w = chirp(t, f0=1500, f1=250, t1=10, method='quadratic')
-    >>> ff, tt, Sxx = spectrogram(w, fs=fs, noverlap=256, nperseg=512,
-    ...                           nfft=2048)
-    >>> plt.pcolormesh(tt, ff[:513], Sxx[:513], cmap='gray_r')
-    >>> plt.title('Quadratic Chirp, f(0)=1500, f(10)=250')
-    >>> plt.xlabel('t (sec)')
-    >>> plt.ylabel('Frequency (Hz)')
-    >>> plt.grid()
+    >>> w = chirp(t, f0=1500, f1=250, t1=T, method='quadratic')
+    >>> plot_spectrogram(f'Quadratic Chirp, f(0)=1500, f({T})=250', w, fs)
     >>> plt.show()
 
-    Quadratic chirp from 1500 Hz to 250 Hz over 10 seconds
-    (vertex of the parabolic curve of the frequency is at t=10):
+    Quadratic chirp from 1500 Hz to 250 Hz
+    (vertex of the parabolic curve of the frequency is at t=T):
 
-    >>> w = chirp(t, f0=1500, f1=250, t1=10, method='quadratic',
+    >>> w = chirp(t, f0=1500, f1=250, t1=T, method='quadratic',
     ...           vertex_zero=False)
-    >>> ff, tt, Sxx = spectrogram(w, fs=fs, noverlap=256, nperseg=512,
-    ...                           nfft=2048)
-    >>> plt.pcolormesh(tt, ff[:513], Sxx[:513], cmap='gray_r')
-    >>> plt.title('Quadratic Chirp, f(0)=1500, f(10)=250\\n' +
-    ...           '(vertex_zero=False)')
-    >>> plt.xlabel('t (sec)')
-    >>> plt.ylabel('Frequency (Hz)')
-    >>> plt.grid()
+    >>> plot_spectrogram(f'Quadratic Chirp, f(0)=1500, f({T})=250\\n' +
+    ...                  '(vertex_zero=False)', w, fs)
     >>> plt.show()
 
-    Logarithmic chirp from 1500 Hz to 250 Hz over 10 seconds:
+    Logarithmic chirp from 1500 Hz to 250 Hz:
 
-    >>> w = chirp(t, f0=1500, f1=250, t1=10, method='logarithmic')
-    >>> ff, tt, Sxx = spectrogram(w, fs=fs, noverlap=256, nperseg=512,
-    ...                           nfft=2048)
-    >>> plt.pcolormesh(tt, ff[:513], Sxx[:513], cmap='gray_r')
-    >>> plt.title('Logarithmic Chirp, f(0)=1500, f(10)=250')
-    >>> plt.xlabel('t (sec)')
-    >>> plt.ylabel('Frequency (Hz)')
-    >>> plt.grid()
+    >>> w = chirp(t, f0=1500, f1=250, t1=T, method='logarithmic')
+    >>> plot_spectrogram(f'Logarithmic Chirp, f(0)=1500, f({T})=250', w, fs)
     >>> plt.show()
 
-    Hyperbolic chirp from 1500 Hz to 250 Hz over 10 seconds:
+    Hyperbolic chirp from 1500 Hz to 250 Hz:
 
-    >>> w = chirp(t, f0=1500, f1=250, t1=10, method='hyperbolic')
-    >>> ff, tt, Sxx = spectrogram(w, fs=fs, noverlap=256, nperseg=512,
-    ...                           nfft=2048)
-    >>> plt.pcolormesh(tt, ff[:513], Sxx[:513], cmap='gray_r')
-    >>> plt.title('Hyperbolic Chirp, f(0)=1500, f(10)=250')
-    >>> plt.xlabel('t (sec)')
-    >>> plt.ylabel('Frequency (Hz)')
-    >>> plt.grid()
+    >>> w = chirp(t, f0=1500, f1=250, t1=T, method='hyperbolic')
+    >>> plot_spectrogram(f'Hyperbolic Chirp, f(0)=1500, f({T})=250', w, fs)
     >>> plt.show()
 
     """


### PR DESCRIPTION
On my computer, this reduces the time required to generate the
HTML documentation for `chirp` from over a minute to less than
10 seconds.  The plots still have resolution high enough to
demonstrate the properties of the signal.
