### PR TITLE
TST: Reduce size of test_diagonal_types to speed up tests

### DIFF
--- a/scipy/sparse/linalg/eigen/lobpcg/tests/test_lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/tests/test_lobpcg.py
@@ -323,7 +323,7 @@ def test_diagonal_data_types():
     """Check lobpcg for diagonal matrices for all matrix types.
     """
     np.random.seed(1234)
-    n = 50
+    n = 40
     m = 4
     # Define the generalized eigenvalue problem Av = cBv
     # where (c, v) is a generalized eigenpair,


### PR DESCRIPTION
This is the slowest test taking ~135s

![Screenshot from 2020-05-05 11-21-39](https://user-images.githubusercontent.com/10172976/81238687-89afac00-8fb7-11ea-86aa-ce1d694e9334.png)

It performs `lobpcd` (eigenvector finding) over a 4x50 matrix for 7x spare formats, 4x float formats (for A) x 2x float formats (for B) x 5x preconditioners (for M) x 2x float formats (for X) x 2x float formats (for Y).

This is 7\*4\*2\*5\*2\*2 = 1,120 configurations.

In the short term reducing n=50 to n=40 reduces runtime ~25% or ~35 seconds. This is ~1% of total test execution time.

---

It's also possible not all of these configurations need to be tested which would also help reduce runtime.

I wrote a different change which tests each config for only two of the 7 sparse formats so we still get coverage but the test runs 71% faster (saving over 100 seconds = 4% of total test time)
See: https://github.com/scipy/scipy/compare/master...sethtroisi:fast_tests_diagonal_types_2

If that sounds like a reasonable idea I'm happy to improve and propose that change in addition or as a replacement for this one.
