### PR TITLE
MAINT: Remove unused npy_3kcompat.h

### DIFF
--- a/scipy/integrate/_odepackmodule.c
+++ b/scipy/integrate/_odepackmodule.c
@@ -29,7 +29,6 @@ the result tuple when the full_output argument is non-zero.
 */
 
 #include "Python.h"
-#include "numpy/npy_3kcompat.h"
 
 #include "numpy/arrayobject.h"
 

--- a/scipy/sparse/linalg/dsolve/_superlu_utils.c
+++ b/scipy/sparse/linalg/dsolve/_superlu_utils.c
@@ -6,7 +6,6 @@
 #define PY_ARRAY_UNIQUE_SYMBOL _scipy_sparse_superlu_ARRAY_API
 
 #include "_superluobject.h"
-#include "numpy/npy_3kcompat.h"
 #include <setjmp.h>
 
 


### PR DESCRIPTION
There are only 6 instances of `npy_3kcompat.h` left.
* 2 are deleted here
* 2 are deleted in https://github.com/scipy/scipy/pull/12025
* 1 is cleaned up after #12025
* the final use depends on finding a solution in https://github.com/scipy/scipy/pull/11636

---

part of continued work on #11584