### PR TITLE
MAINT: Cython 3.0 compat

### DIFF
--- a/scipy/ndimage/src/_ni_label.pyx
+++ b/scipy/ndimage/src/_ni_label.pyx
@@ -250,7 +250,6 @@ cpdef _label(np.ndarray input,
         np.intp_t si, so, ss
         np.intp_t total_offset
         np.intp_t output_ndim, structure_ndim, strides
-        np.npy_intp * output_shape
         bint needs_self_labeling, valid, center, use_previous, overflowed
         np.ndarray _line_buffer, _neighbor_buffer
         np.uintp_t *line_buffer
@@ -303,7 +302,6 @@ cpdef _label(np.ndarray input,
         # 2... = working labels, will be compacted on output
         next_region = 2
 
-        # Used for labeling single lines
         structure_ndim = structure.ndim
         temp = [1] * structure_ndim
         temp[axis] = 0
@@ -324,6 +322,7 @@ cpdef _label(np.ndarray input,
                 # copy nonzero values in input to line_buffer as FOREGROUND
                 nonzero_line(PyArray_ITER_DATA(iti), si, line_buffer, L)
 
+                # Used for labeling single lines
                 needs_self_labeling = True
 
                 # Take neighbor labels

--- a/scipy/spatial/qhull.pyx
+++ b/scipy/spatial/qhull.pyx
@@ -555,7 +555,6 @@ cdef class _Qhull:
         cdef np.ndarray[np.npy_int, ndim=1] id_map
         cdef double dist
         cdef int facet_ndim
-        cdef np.npy_intp * coplanar_shape
         cdef unsigned int lower_bound
         cdef unsigned int swapped_index
 
@@ -2069,7 +2068,6 @@ class Delaunay(_QhullUser):
         cdef int k
         cdef np.ndarray[np.double_t, ndim=2] x
         cdef np.ndarray[np.npy_int, ndim=1] out_
-        cdef np.npy_intp * x_shape
 
         xi = np.asanyarray(xi)
 
@@ -2123,7 +2121,6 @@ class Delaunay(_QhullUser):
         cdef DelaunayInfo_t info
         cdef double z[NPY_MAXDIMS+1]
         cdef int i, j, k
-        cdef np.npy_intp * x_shape
 
         if xi.shape[-1] != self.ndim:
             raise ValueError("xi has different dimensionality than "


### PR DESCRIPTION
Fixes #12037

* hoist a few function/method calls out of
`nogil` contexts to satisfy the stricter
handling in new Cython versions (`3.0` pre-release
series)

* type the variables assigned from the hoisted
operations for good measure