### PR TITLE
DOC: add download number badges of PyPI and conda-forge in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,12 @@ SciPy
 .. image:: https://github.com/scipy/scipy/workflows/macOS%20tests/badge.svg?branch=master
   :target: https://github.com/scipy/scipy/actions?query=workflow%3A%22macOS+tests%22
 
+.. image:: https://img.shields.io/pypi/dm/scipy.svg?label=Pypi%20downloads
+  :target: https://pypi.org/project/scipy/
+
+.. image:: https://img.shields.io/conda/dn/conda-forge/scipy.svg?label=Conda%20downloads
+  :target: https://anaconda.org/conda-forge/scipy
+
 SciPy (pronounced "Sigh Pie") is open-source software for mathematics,
 science, and engineering. It includes modules for statistics, optimization,
 integration, linear algebra, Fourier transforms, signal and image processing,


### PR DESCRIPTION
#### What does this implement/fix?
I added download number badges of PyPI and conda-forge in README.rst.

Almost scipy users download scipy from PyPI or conda-forge.
If some scipy developers are motivated by the number, this PR might be useful.
