### PR TITLE
TST: Reduce number of test_diagonal_types configs

### DIFF
--- a/scipy/sparse/linalg/eigen/lobpcg/tests/test_lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/tests/test_lobpcg.py
@@ -331,7 +331,8 @@ def test_diagonal_data_types():
     vals = np.arange(1, n + 1)
 
     list_sparse_format = ['bsr', 'coo', 'csc', 'csr', 'dia', 'dok', 'lil']
-    for s_f in list_sparse_format:
+    sparse_formats = len(list_sparse_format)
+    for s_f_i, s_f in enumerate(list_sparse_format):
 
         As64 = diags([vals * vals], [0], (n, n), format=s_f)
         As32 = As64.astype(np.float32)
@@ -388,8 +389,16 @@ def test_diagonal_data_types():
         Yf32 = np.eye(n, m_excluded, dtype=np.float32)
         listY = [Yf64, Yf32]
 
-        for A, B, M, X, Y in itertools.product(listA, listB, listM, listX,
-                                               listY):
+        tests = list(itertools.product(listA, listB, listM, listX, listY))
+        # This is one of the slower tests because there are >1,000 configs
+        # to test here, instead of checking product of all input, output types
+        # test each configuration for the first sparse format, and then
+        # for one additional sparse format. this takes 2/7=30% as long as
+        # testing all configurations for all sparse formats.
+        if s_f_i > 0:
+            tests = tests[s_f_i - 1::sparse_formats-1]
+
+        for A, B, M, X, Y in tests:
             eigvals, _ = lobpcg(A, X, B=B, M=M, Y=Y, tol=1e-4,
                                 maxiter=100, largest=False)
             assert_allclose(eigvals,


### PR DESCRIPTION
Follow up after https://github.com/scipy/scipy/pull/12045

This is one of the slowest tests (locally and on azure).

This improves the test from 83 (81+86+81) seconds to 28 (28+28+27) seconds for me locally when running with -j1.
I believe this should reduces the **overall** scipy test runtime **~3.5%** (83-28)/(1568) locally and should be a larger percent improvement on azure which has fewer cores.