### PR TITLE
Check parameter consistensy in signal.iirdesign

### DIFF
--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -2071,7 +2071,7 @@ def iirdesign(wp, ws, gpass, gstop, analog=False, ftype='ellip', output='ba',
 
     Parameters
     ----------
-    wp, ws : float or array like
+    wp, ws : float or array like, shape (2,)
         Passband and stopband edge frequencies. Possible values are scalars
         (for lowpass and highpass filters) or ranges (for bandpass and bandstop
         filters).
@@ -2183,9 +2183,10 @@ def iirdesign(wp, ws, gpass, gstop, analog=False, ftype='ellip', output='ba',
     wp = atleast_1d(wp)
     ws = atleast_1d(ws)
 
-    if wp.shape[0] != ws.shape[0]:
-        raise ValueError("Passband and stopband frequencies must"
-                         " have the same dimension.")
+    if wp.shape[0] != ws.shape[0] or wp.shape not in [(1,), (2,)]:
+        raise ValueError("wp and ws must have one or two elements each, and"
+                         "the same shape, got %s and %s"
+                         % (wp.shape, ws.shape))
     if wp.shape[0] == 2:
         if wp[0] < 0 or ws[0] < 0:
             raise ValueError("Values for wp, ws can't be negative")

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -2072,7 +2072,9 @@ def iirdesign(wp, ws, gpass, gstop, analog=False, ftype='ellip', output='ba',
     Parameters
     ----------
     wp, ws : float
-        Passband and stopband edge frequencies.
+        Passband and stopband edge frequencies. Possible values are scalars
+        (for lowpass and highpass filters) or ranges (for bandpass and bandstop
+        filters).
         For digital filters, these are in the same units as `fs`. By default,
         `fs` is 2 half-cycles/sample, so these are normalized from 0 to 1,
         where 1 is the Nyquist frequency. For example:
@@ -2083,8 +2085,8 @@ def iirdesign(wp, ws, gpass, gstop, analog=False, ftype='ellip', output='ba',
             - Bandstop:  wp = [0.1, 0.6],   ws = [0.2, 0.5]
 
         For analog filters, `wp` and `ws` are angular frequencies (e.g., rad/s).
-        Note, that for bandpass and bandstop filters passband must lie strictly inside 
-        stopband or vice versa.
+        Note, that for bandpass and bandstop filters passband must lie strictly
+        inside stopband or vice versa.
     gpass : float
         The maximum loss in the passband (dB).
     gstop : float
@@ -2185,7 +2187,7 @@ def iirdesign(wp, ws, gpass, gstop, analog=False, ftype='ellip', output='ba',
         raise ValueError("Passband and stopband frequencies must"
                          " have the same dimension.")
     if wp.shape == 2 and not((ws[0] < wp[0] and wp[1] < ws[1]) or
-            (wp[0] < ws[0] and ws[1] < wp[1]))
+            (wp[0] < ws[0] and ws[1] < wp[1])):
         raise ValueError("Passband must lie strictly inside stopband"
                          " or vice versa")
 

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -2083,6 +2083,8 @@ def iirdesign(wp, ws, gpass, gstop, analog=False, ftype='ellip', output='ba',
             - Bandstop:  wp = [0.1, 0.6],   ws = [0.2, 0.5]
 
         For analog filters, `wp` and `ws` are angular frequencies (e.g., rad/s).
+        Note, that for bandpass and bandstop filters passband must lie strictly inside 
+        stopband or vice versa.
     gpass : float
         The maximum loss in the passband (dB).
     gstop : float
@@ -2178,6 +2180,14 @@ def iirdesign(wp, ws, gpass, gstop, analog=False, ftype='ellip', output='ba',
 
     wp = atleast_1d(wp)
     ws = atleast_1d(ws)
+
+    if wp.shape[0] != ws.shape[0]:
+        raise ValueError("Passband and stopband frequencies must"
+                         " have the same dimension.")
+    if wp.shape == 2 and not((ws[0] < wp[0] and wp[1] < ws[1]) or
+            (wp[0] < ws[0] and ws[1] < wp[1]))
+        raise ValueError("Passband must lie strictly inside stopband"
+                         " or vice versa")
 
     band_type = 2 * (len(wp) - 1)
     band_type += 1

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -2071,7 +2071,7 @@ def iirdesign(wp, ws, gpass, gstop, analog=False, ftype='ellip', output='ba',
 
     Parameters
     ----------
-    wp, ws : float
+    wp, ws : float or array like
         Passband and stopband edge frequencies. Possible values are scalars
         (for lowpass and highpass filters) or ranges (for bandpass and bandstop
         filters).
@@ -2186,9 +2186,12 @@ def iirdesign(wp, ws, gpass, gstop, analog=False, ftype='ellip', output='ba',
     if wp.shape[0] != ws.shape[0]:
         raise ValueError("Passband and stopband frequencies must"
                          " have the same dimension.")
-    if wp.shape == 2 and not((ws[0] < wp[0] and wp[1] < ws[1]) or
+    if wp.shape[0] == 2:
+        if wp[0] < 0 or ws[0] < 0:
+            raise ValueError("Values for wp, ws can't be negative")
+        if not((ws[0] < wp[0] and wp[1] < ws[1]) or
             (wp[0] < ws[0] and ws[1] < wp[1])):
-        raise ValueError("Passband must lie strictly inside stopband"
+            raise ValueError("Passband must lie strictly inside stopband"
                          " or vice versa")
 
     band_type = 2 * (len(wp) - 1)

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -3614,8 +3614,11 @@ class TestIIRPeak(object):
 class TestIIRDesign(object):
 
     def test_exceptions(self):
-        with pytest.raises(ValueError, match="have the same dimension"):
+        with pytest.raises(ValueError, match="the same shape"):
             iirdesign(0.2, [0.1, 0.3], 1, 40)
+        with pytest.raises(ValueError, match="the same shape"):
+            iirdesign(np.array([[0.3, 0.6], [0.3, 0.6]]),
+                      np.array([[0.4, 0.5], [0.4, 0.5]]), 1, 40)
         with pytest.raises(ValueError, match="can't be negative"):
             iirdesign([0.1, 0.3], [-0.1, 0.5], 1, 40)
         with pytest.raises(ValueError, match="strictly inside stopband"):

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -14,9 +14,9 @@ from scipy.signal import (BadCoefficients, bessel, besselap, bilinear, buttap,
                           butter, buttord, cheb1ap, cheb1ord, cheb2ap,
                           cheb2ord, cheby1, cheby2, ellip, ellipap, ellipord,
                           firwin, freqs_zpk, freqs, freqz, freqz_zpk,
-                          group_delay, iirfilter, iirnotch, iirpeak, lp2bp,
-                          lp2bs, lp2hp, lp2lp, normalize, sos2tf, sos2zpk,
-                          sosfreqz, tf2sos, tf2zpk, zpk2sos, zpk2tf,
+                          group_delay, iirdesign, iirfilter, iirnotch, iirpeak,
+                          lp2bp, lp2bs, lp2hp, lp2lp, normalize, sos2tf,
+                          sos2zpk, sosfreqz, tf2sos, tf2zpk, zpk2sos, zpk2tf,
                           bilinear_zpk, lp2lp_zpk, lp2hp_zpk, lp2bp_zpk,
                           lp2bs_zpk)
 from scipy.signal.filter_design import (_cplxreal, _cplxpair, _norm_factor,
@@ -3611,6 +3611,21 @@ class TestIIRPeak(object):
         assert_allclose(abs(hp[2]), 1, rtol=1e-10)
 
 
+class TestIIRDesign(object):
+    def test_exceptions(self):
+        with pytest.raises(ValueError, match="have the same dimension"):
+            iirdesign(0.2, [0.1, 0.3], 1, 40)
+        with pytest.raises(ValueError, match="can't be negative"):
+            iirdesign([0.1, 0.3], [-0.1, 0.5], 1, 40)
+        with pytest.raises(ValueError, match="strictly inside stopband"):
+            iirdesign([0.1, 0.4], [0.5, 0.6], 1, 40)
+        with pytest.raises(ValueError, match="strictly inside stopband"):
+            iirdesign([0.5, 0.6], [0.1, 0.4], 1, 40)
+        with pytest.raises(ValueError, match="strictly inside stopband"):
+            iirdesign([0.3, 0.6], [0.4, 0.7], 1, 40)
+        with pytest.raises(ValueError, match="strictly inside stopband"):
+            iirdesign([0.4, 0.7], [0.3, 0.6], 1, 40)
+
 class TestIIRFilter(object):
 
     def test_symmetry(self):
@@ -3654,6 +3669,7 @@ class TestIIRFilter(object):
         assert_raises(ValueError, iirfilter, 1, -1, btype='high')
         assert_raises(ValueError, iirfilter, 1, [1, 2], btype='band')
         assert_raises(ValueError, iirfilter, 1, [10, 20], btype='stop')
+
 
 
 class TestGroupDelay(object):

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -3612,6 +3612,7 @@ class TestIIRPeak(object):
 
 
 class TestIIRDesign(object):
+
     def test_exceptions(self):
         with pytest.raises(ValueError, match="have the same dimension"):
             iirdesign(0.2, [0.1, 0.3], 1, 40)
@@ -3625,6 +3626,7 @@ class TestIIRDesign(object):
             iirdesign([0.3, 0.6], [0.4, 0.7], 1, 40)
         with pytest.raises(ValueError, match="strictly inside stopband"):
             iirdesign([0.4, 0.7], [0.3, 0.6], 1, 40)
+
 
 class TestIIRFilter(object):
 
@@ -3669,7 +3671,6 @@ class TestIIRFilter(object):
         assert_raises(ValueError, iirfilter, 1, -1, btype='high')
         assert_raises(ValueError, iirfilter, 1, [1, 2], btype='band')
         assert_raises(ValueError, iirfilter, 1, [10, 20], btype='stop')
-
 
 
 class TestGroupDelay(object):


### PR DESCRIPTION
Ref. https://github.com/scipy/scipy/issues/11567

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Ref. #11567 

#### What does this implement/fix?
<!--Please explain your changes.-->
This aims at raising ValueError from the `scipy.signal.iirdesign` function rather than from anywhere else (as it is now, in some cases) to provide uniform behaviour and clear explanation of an error. Docs are also updated by a single sentence

#### Additional information
<!--Any additional information you think is important.-->