### PR TITLE
ENH: Exposes factor and logs WRITE in nnls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 *.tmp
 *.vim
 tags
+*.vscode
 
 # Compiled source #
 ###################

--- a/scipy/optimize/nnls.py
+++ b/scipy/optimize/nnls.py
@@ -1,10 +1,11 @@
 from . import _nnls
 from numpy import asarray_chkfinite, zeros, double
+import logging
 
 __all__ = ['nnls']
 
 
-def nnls(A, b, maxiter=None):
+def nnls(A, b, maxiter=None, factor=0.01):
     """
     Solve ``argmin_x || Ax - b ||_2`` for ``x>=0``. This is a wrapper
     for a FORTRAN non-negative least squares solver.
@@ -18,6 +19,10 @@ def nnls(A, b, maxiter=None):
     maxiter: int, optional
         Maximum number of iterations, optional.
         Default is ``3 * A.shape[1]``.
+    factor: float, optional
+        A scalar which determines when to end the search due to lack
+        of linear independence.
+        Default is ``0.01``.
 
     Returns
     -------
@@ -77,8 +82,11 @@ def nnls(A, b, maxiter=None):
     zz = zeros((m,), dtype=double)
     index = zeros((n,), dtype=int)
 
-    x, rnorm, mode = _nnls.nnls(A, m, n, b, w, zz, index, maxiter)
+    x, rnorm, mode, iterationquit = _nnls.nnls(A, m, n, b, w, zz, index, maxiter, factor)
     if mode != 1:
         raise RuntimeError("too many iterations")
+    
+    if iterationquit == 1:
+        logging.info("NNLS quitting on iteration count.")
 
     return x, rnorm

--- a/scipy/optimize/nnls/nnls.f
+++ b/scipy/optimize/nnls/nnls.f
@@ -49,7 +49,8 @@ C     MAXITER THE MAXIMUM ALLOWED NUMBER OF ITERATIONS.
 C             IF NEGATIVE, THE LIMIT IS TAKEN AS THE DEFAULT, 3*N.              
 C   
 C     ------------------------------------------------------------------
-      SUBROUTINE NNLS (A,MDA,M,N,B,X,RNORM,W,ZZ,INDEX,MODE,MAXITER) 
+      SUBROUTINE NNLS (A,MDA,M,N,B,X,RNORM,W,ZZ,INDEX,MODE,MAXITER,
+     $      FACTOR, ITERATIONQUIT)  
 C     ------------------------------------------------------------------
       integer I, II, IP, ITER, ITMAX, IZ, IZ1, IZ2, IZMAX, J, JJ, JZ, L
       integer M, MDA, MODE,N, NPP1, NSETP, RTNKEY
@@ -61,9 +62,10 @@ c     double precision A(MDA,N), B(M), W(N), X(N), ZZ(M)
       double precision ALPHA, ASAVE, CC, DIFF, DUMMY, FACTOR, RNORM
       double precision SM, SS, T, TEMP, TWO, UNORM, UP, WMAX
       double precision ZERO, ZTEST
-      parameter(FACTOR = 0.01d0)
+      integer ITERATIONQUIT
       parameter(TWO = 2.0d0, ZERO = 0.0d0)
 C     ------------------------------------------------------------------
+      ITERATIONQUIT=0
       MODE=1
       IF (M .le. 0 .or. N .le. 0) then
          MODE=2
@@ -197,7 +199,7 @@ C
       ITER=ITER+1   
       IF (ITER .gt. ITMAX) then
          MODE=3
-         write (*,'(/a)') ' NNLS quitting on iteration count.'
+         ITERATIONQUIT=1
          GO TO 350 
       endif
 C   

--- a/scipy/optimize/nnls/nnls.pyf
+++ b/scipy/optimize/nnls/nnls.pyf
@@ -3,7 +3,7 @@
 
 python module _nnls ! in 
     interface  ! in :_nnls
-        subroutine nnls(a,mda,m,n,b,x,rnorm,w,zz,index_bn,mode,maxiter) ! in :nnls:NNLS.F
+        subroutine nnls(a,mda,m,n,b,x,rnorm,w,zz,index_bn,mode,maxiter,factor,iterationquit) ! in :nnls:NNLS.F
             double precision dimension(mda,*), intent(copy) :: a
             integer optional,check(shape(a,0)==mda),depend(a) :: mda=shape(a,0)
             integer :: m
@@ -16,6 +16,8 @@ python module _nnls ! in
             integer dimension(*) :: index_bn
             integer , intent(out):: mode
             integer :: maxiter
+            double precision :: factor
+            integer, intent(out) :: iterationquit
         end subroutine nnls
     end interface
 end python module _nnls

--- a/scipy/optimize/tests/test_nnls.py
+++ b/scipy/optimize/tests/test_nnls.py
@@ -33,7 +33,7 @@ class TestNNLS(object):
             nnls(a, b, maxiter=1)
 
     def test_nnls_with_factor(self):
-        a = arange(25.0).reshape(-1,5)
+        a = arange(25.0).reshape(-1, 5)
         x = arange(5.0)
         y = dot(a, x)
         factor = 0.001

--- a/scipy/optimize/tests/test_nnls.py
+++ b/scipy/optimize/tests/test_nnls.py
@@ -32,3 +32,11 @@ class TestNNLS(object):
         with assert_raises(RuntimeError):
             nnls(a, b, maxiter=1)
 
+    def test_nnls_with_factor(self):
+        a = arange(25.0).reshape(-1,5)
+        x = arange(5.0)
+        y = dot(a, x)
+        factor = 0.001
+        x, res = nnls(a, y, factor=factor)
+        assert_(res < 1e-7)
+        assert_(norm(dot(a, x)-y) < 1e-7)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes #12017

#### What does this implement/fix?
* Adds `factor` as an optional argument for `optimize.nnls`.
* Removes `WRITE` from `nnls.f` and instead logs it under `logging.info` by instead passing out a logical parameter, `iterationquit`, that is read by `nnls.py`
* Added new input parameter, `factor`, and new output parameter, `iterationquit` to nnls.pyf
* Adds `.vscode` to `.gitignore`
