### PR TITLE
MAINT: Cleanup OLDAPI in ndimage/src/_ctest.c

### DIFF
--- a/scipy/ndimage/setup.py
+++ b/scipy/ndimage/setup.py
@@ -36,15 +36,6 @@ def configuration(parent_package='', top_path=None):
                          include_dirs=[get_include()],
                          **numpy_nodepr_api)
 
-    _define_macros = [("OLDAPI", 1)]
-    if 'define_macros' in numpy_nodepr_api:
-        _define_macros.extend(numpy_nodepr_api['define_macros'])
-
-    config.add_extension("_ctest_oldapi",
-                         sources=["src/_ctest.c"],
-                         include_dirs=[get_include()],
-                         define_macros=_define_macros)
-
     config.add_extension("_cytest",
                          sources=["src/_cytest.c"])
 

--- a/scipy/ndimage/src/_ctest.c
+++ b/scipy/ndimage/src/_ctest.c
@@ -1,16 +1,5 @@
 #include <Python.h>
 #include <numpy/npy_common.h>
-#include <numpy/npy_3kcompat.h>
-
-#ifdef OLDAPI
-#define MOD _ctest_oldapi
-#define MODSTR "_ctest_oldapi"
-#define PYINIT PyInit__ctest_oldapi
-#else
-#define MOD _ctest
-#define MODSTR "_ctest"
-#define PYINIT PyInit__ctest
-#endif
 
 
 static void
@@ -52,17 +41,12 @@ py_filter1d(PyObject *obj, PyObject *args)
     }
     if (!PyArg_ParseTuple(args, "n", callback_data)) goto error;
 
-#ifdef OLDAPI
-    capsule = NpyCapsule_FromVoidPtrAndDesc(_filter1d, callback_data, _destructor);
-    if (!capsule) goto error;
-#else
     capsule = PyCapsule_New(_filter1d, NULL, _destructor);
     if (!capsule) goto error;
     if (PyCapsule_SetContext(capsule, callback_data) != 0) {
 	Py_DECREF(capsule);
 	goto error;
     }
-#endif
     return capsule;
  error:
     PyMem_Free(callback_data);
@@ -112,17 +96,12 @@ py_filter2d(PyObject *obj, PyObject *args)
 	if (PyErr_Occurred()) goto error;
     }
 
-#ifdef OLDAPI
-    capsule = NpyCapsule_FromVoidPtrAndDesc(_filter2d, callback_data, _destructor);
-    if (!capsule) goto error;
-#else
     capsule = PyCapsule_New(_filter2d, NULL, _destructor);
     if (!capsule) goto error;
     if (PyCapsule_SetContext(capsule, callback_data) != 0) {
 	Py_DECREF(capsule);
 	goto error;
     }
-#endif
     return capsule;
  error:
     PyMem_Free(callback_data);
@@ -156,17 +135,12 @@ py_transform(PyObject *obj, PyObject *args)
     }
     if (!PyArg_ParseTuple(args, "d", callback_data)) goto error;
 
-#ifdef OLDAPI
-    capsule = NpyCapsule_FromVoidPtrAndDesc(_transform, callback_data, _destructor);
-    if (!capsule) goto error;
-#else
     capsule = PyCapsule_New(_transform, NULL, _destructor);
     if (!capsule) goto error;
     if (PyCapsule_SetContext(capsule, callback_data) != 0) {
 	Py_DECREF(capsule);
 	goto error;
     }
-#endif
     return capsule;
  error:
     PyMem_Free(callback_data);
@@ -183,9 +157,9 @@ static PyMethodDef _CTestMethods[] = {
 
 
 /* Initialize the module */
-static struct PyModuleDef MOD = {
+static struct PyModuleDef _ctest = {
     PyModuleDef_HEAD_INIT,
-    MODSTR,
+    "_ctest",
     NULL,
     -1,
     _CTestMethods,
@@ -196,7 +170,7 @@ static struct PyModuleDef MOD = {
 };
 
 
-PyObject *PYINIT(void)
+PyObject *PyInit__ctest(void)
 {
-    return PyModule_Create(&MOD);
+    return PyModule_Create(&_ctest);
 }

--- a/scipy/ndimage/tests/test_c_api.py
+++ b/scipy/ndimage/tests/test_c_api.py
@@ -3,13 +3,11 @@ from numpy.testing import assert_allclose
 
 from scipy import ndimage
 from scipy.ndimage import _ctest
-from scipy.ndimage import _ctest_oldapi
 from scipy.ndimage import _cytest
 from scipy._lib._ccallback import LowLevelCallable
 
 FILTER1D_FUNCTIONS = [
     lambda filter_size: _ctest.filter1d(filter_size),
-    lambda filter_size: _ctest_oldapi.filter1d(filter_size),
     lambda filter_size: _cytest.filter1d(filter_size, with_signature=False),
     lambda filter_size: LowLevelCallable(_cytest.filter1d(filter_size, with_signature=True)),
     lambda filter_size: LowLevelCallable.from_cython(_cytest, "_filter1d",
@@ -18,7 +16,6 @@ FILTER1D_FUNCTIONS = [
 
 FILTER2D_FUNCTIONS = [
     lambda weights: _ctest.filter2d(weights),
-    lambda weights: _ctest_oldapi.filter2d(weights),
     lambda weights: _cytest.filter2d(weights, with_signature=False),
     lambda weights: LowLevelCallable(_cytest.filter2d(weights, with_signature=True)),
     lambda weights: LowLevelCallable.from_cython(_cytest, "_filter2d", _cytest.filter2d_capsule(weights)),
@@ -26,7 +23,6 @@ FILTER2D_FUNCTIONS = [
 
 TRANSFORM_FUNCTIONS = [
     lambda shift: _ctest.transform(shift),
-    lambda shift: _ctest_oldapi.transform(shift),
     lambda shift: _cytest.transform(shift, with_signature=False),
     lambda shift: LowLevelCallable(_cytest.transform(shift, with_signature=True)),
     lambda shift: LowLevelCallable.from_cython(_cytest, "_transform", _cytest.transform_capsule(shift)),


### PR DESCRIPTION
Cleanup identified in https://github.com/scipy/scipy/pull/12025

https://github.com/scipy/scipy/pull/12025#issuecomment-625639464

> Looks like that's only there to support `PyCObject` (see commit [8d28b0b](https://github.com/scipy/scipy/commit/8d28b0be03974e7393faed610a4821ae461452b6)) which no longer exists, so yes it can be removed as far as I can tell.

