### PR TITLE
ENH: Modifies jarque_bera to return a named tuple

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -235,6 +235,7 @@ James Wright for simple documentation fixes
 Sam Wallan for scipy.linalg.lapack enhancements
 Richard Weiss for a bug fix in scipy.optimize._differentialevolution.py.
 Luigi F. Cruz for adding time/frequency domain option to scipy.signal.resample.
+Wesley Alves for improvements to scipy.stats.jarque_bera and scipy.stats.shapiro
 
 Institutions
 ------------

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1637,11 +1637,11 @@ def jarque_bera(x):
     >>> x = np.random.normal(0, 1, 100000)
     >>> jarque_bera_test = stats.jarque_bera(x)
     >>> jarque_bera_test
-    Jarque_beraResult(4.7165707989581342, 0.09458225503041906)
+    Jarque_beraResult(statistic=4.716570798957913, pvalue=0.0945822550304295)
     >>> jarque_bera_test.statistic
-    4.7165707989581342
+    4.716570798957913
     >>> jarque_bera_test.pvalue
-    0.09458225503041906
+    0.0945822550304295
 
     """
     x = np.asarray(x)

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1599,6 +1599,7 @@ def normaltest(a, axis=0, nan_policy='propagate'):
 
     return NormaltestResult(k2, distributions.chi2.sf(k2, 2))
 
+Jarque_beratestResult = namedtuple('Jarque_beratestResult', ('statistic', 'pvalue'))
 
 def jarque_bera(x):
     """
@@ -1634,11 +1635,13 @@ def jarque_bera(x):
     >>> from scipy import stats
     >>> np.random.seed(987654321)
     >>> x = np.random.normal(0, 1, 100000)
-    >>> y = np.random.rayleigh(1, 100000)
-    >>> stats.jarque_bera(x)
-    (4.7165707989581342, 0.09458225503041906)
-    >>> stats.jarque_bera(y)
-    (6713.7098548143422, 0.0)
+    >>> jarque_bera_test = stats.jarque_bera(x)
+    >>> jarque_bera_test
+    Jarque_beratestResult(4.7165707989581342, 0.09458225503041906)
+    >>> jarque_bera_test.statistic
+    4.7165707989581342
+    >>> jarque_bera_test.pvalue
+    0.09458225503041906
 
     """
     x = np.asarray(x)
@@ -1653,7 +1656,7 @@ def jarque_bera(x):
     jb_value = n / 6 * (skewness**2 + (kurtosis - 3)**2 / 4)
     p = 1 - distributions.chi2.cdf(jb_value, 2)
 
-    return jb_value, p
+    return Jarque_beratestResult(jb_value, p)
 
 
 #####################################

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1599,7 +1599,9 @@ def normaltest(a, axis=0, nan_policy='propagate'):
 
     return NormaltestResult(k2, distributions.chi2.sf(k2, 2))
 
+
 Jarque_beraResult = namedtuple('Jarque_beraResult', ('statistic', 'pvalue'))
+
 
 def jarque_bera(x):
     """

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1599,7 +1599,7 @@ def normaltest(a, axis=0, nan_policy='propagate'):
 
     return NormaltestResult(k2, distributions.chi2.sf(k2, 2))
 
-Jarque_beratestResult = namedtuple('Jarque_beratestResult', ('statistic', 'pvalue'))
+Jarque_beraResult = namedtuple('Jarque_beraResult', ('statistic', 'pvalue'))
 
 def jarque_bera(x):
     """
@@ -1637,7 +1637,7 @@ def jarque_bera(x):
     >>> x = np.random.normal(0, 1, 100000)
     >>> jarque_bera_test = stats.jarque_bera(x)
     >>> jarque_bera_test
-    Jarque_beratestResult(4.7165707989581342, 0.09458225503041906)
+    Jarque_beraResult(4.7165707989581342, 0.09458225503041906)
     >>> jarque_bera_test.statistic
     4.7165707989581342
     >>> jarque_bera_test.pvalue
@@ -1656,7 +1656,7 @@ def jarque_bera(x):
     jb_value = n / 6 * (skewness**2 + (kurtosis - 3)**2 / 4)
     p = 1 - distributions.chi2.cdf(jb_value, 2)
 
-    return Jarque_beratestResult(jb_value, p)
+    return Jarque_beraResult(jb_value, p)
 
 
 #####################################

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3648,20 +3648,34 @@ class TestJarqueBera(object):
         y = np.random.chisquare(10000, 100000)
         z = np.random.rayleigh(1, 100000)
 
+        assert_equal(stats.jarque_bera(x)[0], stats.jarque_bera(x).statistic)
+        assert_equal(stats.jarque_bera(x)[1], stats.jarque_bera(x).pvalue)
+
+        assert_equal(stats.jarque_bera(y)[0], stats.jarque_bera(y).statistic)
+        assert_equal(stats.jarque_bera(y)[1], stats.jarque_bera(y).pvalue)
+
+        assert_equal(stats.jarque_bera(z)[0], stats.jarque_bera(z).statistic)
+        assert_equal(stats.jarque_bera(z)[1], stats.jarque_bera(z).pvalue)
+
         assert_(stats.jarque_bera(x)[1] > stats.jarque_bera(y)[1])
+        assert_(stats.jarque_bera(x).pvalue > stats.jarque_bera(y).pvalue)
+
         assert_(stats.jarque_bera(x)[1] > stats.jarque_bera(z)[1])
+        assert_(stats.jarque_bera(x).pvalue > stats.jarque_bera(z).pvalue)
+
         assert_(stats.jarque_bera(y)[1] > stats.jarque_bera(z)[1])
+        assert_(stats.jarque_bera(y).pvalue > stats.jarque_bera(z).pvalue)
 
     def test_jarque_bera_array_like(self):
         np.random.seed(987654321)
         x = np.random.normal(0, 1, 100000)
 
-        JB1, p1 = stats.jarque_bera(list(x))
-        JB2, p2 = stats.jarque_bera(tuple(x))
-        JB3, p3 = stats.jarque_bera(x.reshape(2, 50000))
+        jb_test1 = JB1, p1 = stats.jarque_bera(list(x))
+        jb_test2 = JB2, p2 = stats.jarque_bera(tuple(x))
+        jb_test3 = JB3, p3 = stats.jarque_bera(x.reshape(2, 50000))
 
-        assert_(JB1 == JB2 == JB3)
-        assert_(p1 == p2 == p3)
+        assert_(JB1 == JB2 == JB3 == jb_test1.statistic == jb_test2.statistic == jb_test3.statistic)
+        assert_(p1 == p2 == p3 == jb_test1.pvalue == jb_test2.pvalue == jb_test3.pvalue)
 
     def test_jarque_bera_size(self):
         assert_raises(ValueError, stats.jarque_bera, [])


### PR DESCRIPTION
Performs a change in the return of jarque_bera function, returning now a
named tuple Jarque_beratestResult, which has "statistic" and "pvalue" as
indexes. This modify was made to turn the function return similar to
other functions like scipy,stats.normaltest and scipy.stats.ttest_ind.

Previously we had to create two objects, something like stats, p = scipy.stats.jarque_bera(x). Otherwise, we would have to access these values by index(using [0] or [1]), which makes understanding more difficult to someone who does not know exactly the behavior of the function.
With this implementation, we were able to make jb_test = scipy.stats.jarque_bera(x) and, for example, get the p-value with jb_test.pvalue.

The function description has also been updated.