### PR TITLE
TST: filter out factorial(float) deprecation warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,6 +191,7 @@ scipy/ndimage/src/_cytest.c
 scipy/optimize/_bglu_dense.c
 scipy/optimize/cobyla/_cobylamodule.c
 scipy/optimize/lbfgsb_src/_lbfgsbmodule.c
+scipy/optimize/lbfgsb_src/_lbfgsb-f2pywrappers.f
 scipy/optimize/minpack2/minpack2module.c
 scipy/optimize/nnls/_nnlsmodule.c
 scipy/optimize/slsqp/_slsqpmodule.c

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1824,10 +1824,12 @@ class TestFactorialFunctions(object):
 
     def test_mixed_nan_inputs(self):
         x = np.array([np.nan, 1, 2, 3, np.nan])
-        result = special.factorial(x, exact=True)
-        assert_equal(np.array([np.nan, 1, 2, 6, np.nan]), result)
-        result = special.factorial(x, exact=False)
-        assert_equal(np.array([np.nan, 1, 2, 6, np.nan]), result)
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning, "Using factorial\\(\\) with floats is deprecated")
+            result = special.factorial(x, exact=True)
+            assert_equal(np.array([np.nan, 1, 2, 6, np.nan]), result)
+            result = special.factorial(x, exact=False)
+            assert_equal(np.array([np.nan, 1, 2, 6, np.nan]), result)
 
 
 class TestFresnel(object):


### PR DESCRIPTION
This was causing the python3.9-dev CI to fail.

Also add a missing file to `.gitignore`.