### PR TITLE
TST: Skip test on colab with large memory alloc

### DIFF
--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -17,10 +17,11 @@ Run tests if sparse is not installed:
   python tests/test_base.py
 """
 
-import operator
 import contextlib
 import functools
+import operator
 import platform
+import sys
 from distutils.version import LooseVersion
 
 import numpy as np
@@ -47,6 +48,9 @@ from scipy.sparse.linalg import splu, expm, inv
 from scipy._lib.decorator import decorator
 
 import pytest
+
+
+IS_COLAB = ('google.colab' in sys.modules)
 
 
 def assert_in(member, collection, msg=None):
@@ -4389,6 +4393,7 @@ class TestBSR(sparse_test_class(getset=False,
     def test_setdiag_comprehensive(self):
         pass
 
+    @pytest.mark.skipif(IS_COLAB, reason="exceeds memory limit")
     def test_scalar_idx_dtype(self):
         # Check that index dtype takes into account all parameters
         # passed to sparsetools, including the scalar ones


### PR DESCRIPTION
This test consistently crashes colab from allocating too much memory.

![Screenshot from 2020-05-09 19-11-03](https://user-images.githubusercontent.com/10172976/81489323-d8b04800-9228-11ea-9721-bb316d5ce1d1.png)

---

It's not clear to me how much memory this should use from a theoretical standpoint (0? 1gig?)
There's a warning already that
```
        except (MemoryError, ValueError):
            # May fail on 32-bit Python
```

but when I test locally I see it only use a small amount of memory

```
$/usr/bin/time -v python runtests.py -vv -t scipy/sparse/tests/test_base.py::TestBSR::test_scalar_idx_dtype
Maximum resident set size (kbytes): 59444
```
but I'm not sure this is counting correctly as the test might be a subprocess.

---

It's difficult to test this in Colab so it's possible other tests will need to also be disabled, I'm trying to do due diligence but I have to run setup.py build_ext fresh every time it crashes which is a pain.