### PR TITLE
BUG: interpolate: fix BarycentricInterpolator with integer input arrays

### DIFF
--- a/scipy/interpolate/polyint.py
+++ b/scipy/interpolate/polyint.py
@@ -515,7 +515,7 @@ class BarycentricInterpolator(_Interpolator1D):
     def __init__(self, xi, yi=None, axis=0):
         _Interpolator1D.__init__(self, xi, yi, axis)
 
-        self.xi = np.asarray(xi)
+        self.xi = np.asfarray(xi)
         self.set_yi(yi)
         self.n = len(self.xi)
 

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -352,6 +352,12 @@ class TestBarycentric(object):
         values = barycentric_interpolate(self.xs, self.ys, self.test_xs)
         assert_almost_equal(P(self.test_xs), values)
 
+    def test_int_input(self):
+        x = 1000 * np.arange(1, 11)  # np.prod(x[-1] - x[:-1]) overflows
+        y = np.arange(1, 11)
+        value = barycentric_interpolate(x, y, 1000 * 9.5)
+        assert_almost_equal(value, 9.5)
+
 
 class TestPCHIP(object):
     def _make_random(self, npts=20):


### PR DESCRIPTION
#### What does this implement/fix?
Fix wrong results from BarycentricInterpolator if input `x` array is of integer type.

With integer arrays, computation of self.wi can overflow, resulting to
wrong results. Fix by casting to floats on input.
