### PR TITLE
ENH: special: support ILP64 Lapack

### DIFF
--- a/scipy/special/lapack_defs.h
+++ b/scipy/special/lapack_defs.h
@@ -2,29 +2,19 @@
  * Handle different Fortran conventions.
  */
 
-#if defined(NO_APPEND_FORTRAN)
-#if defined(UPPERCASE_FORTRAN)
-#define F_FUNC(f,F) F
-#else
-#define F_FUNC(f,F) f
-#endif
-#else
-#if defined(UPPERCASE_FORTRAN)
-#define F_FUNC(f,F) F##_
-#else
-#define F_FUNC(f,F) f##_
-#endif
-#endif
+#include "npy_cblas.h"
 
-extern void F_FUNC(dstevr,DSTEVR)(char *jobz, char *range, int *n, double *d, double *e,
-				  double *vl, double *vu, int *il, int *iu, double *abstol,
-				  int *m, double *w, double *z, int *ldz, int *isuppz,
-				  double *work, int *lwork, int *iwork, int *liwork, int *info);
+extern void BLAS_FUNC(dstevr)(char *jobz, char *range, CBLAS_INT *n, double *d, double *e,
+                              double *vl, double *vu, CBLAS_INT *il, CBLAS_INT *iu, double *abstol,
+                              CBLAS_INT *m, double *w, double *z, CBLAS_INT *ldz, CBLAS_INT *isuppz,
+                              double *work, CBLAS_INT *lwork, CBLAS_INT *iwork, CBLAS_INT *liwork,
+                              CBLAS_INT *info, size_t jobz_len, size_t range_len);
 
-static void c_dstevr(char *jobz, char *range, int *n, double *d, double *e,
-                     double *vl, double *vu, int *il, int *iu, double *abstol,
-                     int *m, double *w, double *z, int *ldz, int *isuppz,
-                     double *work, int *lwork, int *iwork, int *liwork, int *info) {
-    F_FUNC(dstevr,DSTEVR)(jobz, range, n, d, e, vl, vu, il, iu, abstol, m,
-			  w, z, ldz, isuppz, work, lwork, iwork, liwork, info);
+static void c_dstevr(char *jobz, char *range, CBLAS_INT *n, double *d, double *e,
+                     double *vl, double *vu, CBLAS_INT *il, CBLAS_INT *iu, double *abstol,
+                     CBLAS_INT *m, double *w, double *z, CBLAS_INT *ldz, CBLAS_INT *isuppz,
+                     double *work, CBLAS_INT *lwork, CBLAS_INT *iwork, CBLAS_INT *liwork, CBLAS_INT *info) {
+    BLAS_FUNC(dstevr)(jobz, range, n, d, e, vl, vu, il, iu, abstol, m,
+                      w, z, ldz, isuppz, work, lwork, iwork, liwork, info,
+                      1, 1);
 }

--- a/scipy/special/setup.py
+++ b/scipy/special/setup.py
@@ -16,8 +16,14 @@ except ImportError:
 def configuration(parent_package='',top_path=None):
     from numpy.distutils.misc_util import Configuration
     from scipy._build_utils.system_info import get_info as get_system_info
+    from scipy._build_utils import combine_dict, uses_blas64
 
     config = Configuration('special', parent_package, top_path)
+
+    if uses_blas64():
+        lapack_opt = get_system_info('lapack_ilp64_opt')
+    else:
+        lapack_opt = get_system_info('lapack_opt')
 
     define_macros = []
     if sys.platform == 'win32':
@@ -32,6 +38,7 @@ def configuration(parent_package='',top_path=None):
     if python_inc_dirs != plat_specific_python_inc_dirs:
         inc_dirs.append(plat_specific_python_inc_dirs)
     inc_dirs.append(join(dirname(dirname(__file__)), '_lib'))
+    inc_dirs.append(join(dirname(dirname(__file__)), '_build_utils', 'src'))
 
     # C libraries
     cephes_src = [join('cephes','*.c')]
@@ -73,12 +80,11 @@ def configuration(parent_package='',top_path=None):
         + cdf_src
         + specfun_src
     )
-    cfg = dict(get_system_info('lapack_opt'))
-    cfg.setdefault('include_dirs', []).extend([curdir] + inc_dirs + [numpy.get_include()])
-    cfg.setdefault('libraries', []).extend(
-        ['sc_amos', 'sc_cephes', 'sc_mach', 'sc_cdf', 'sc_specfun']
-    )
-    cfg.setdefault('define_macros', []).extend(define_macros)
+    cfg = combine_dict(lapack_opt,
+                       include_dirs=[curdir] + inc_dirs + [numpy.get_include()],
+                       libraries=['sc_amos', 'sc_cephes', 'sc_mach',
+                                  'sc_cdf', 'sc_specfun'],
+                       define_macros=define_macros)
     config.add_extension('_ufuncs',
                          depends=ufuncs_dep,
                          sources=ufuncs_src,
@@ -98,11 +104,10 @@ def configuration(parent_package='',top_path=None):
                          define_macros=define_macros,
                          extra_info=get_info("npymath"))
 
-    cfg = dict(get_system_info('lapack_opt'))
+    cfg = combine_dict(lapack_opt, include_dirs=inc_dirs)
     config.add_extension('_ellip_harm_2',
                          sources=['_ellip_harm_2.c', 'sf_error.c',],
-                         **cfg
-                         )
+                         **cfg)
 
     # Cython API
     config.add_data_files('cython_special.pxd')
@@ -119,12 +124,11 @@ def configuration(parent_package='',top_path=None):
         + cdf_src
         + specfun_src
     )
-    cfg = dict(get_system_info('lapack_opt'))
-    cfg.setdefault('include_dirs', []).extend([curdir] + inc_dirs + [numpy.get_include()])
-    cfg.setdefault('libraries', []).extend(
-        ['sc_amos', 'sc_cephes', 'sc_mach', 'sc_cdf', 'sc_specfun']
-    )
-    cfg.setdefault('define_macros', []).extend(define_macros)
+    cfg = combine_dict(lapack_opt,
+                       include_dirs=[curdir] + inc_dirs + [numpy.get_include()],
+                       libraries=['sc_amos', 'sc_cephes', 'sc_mach',
+                                  'sc_cdf', 'sc_specfun'],
+                       define_macros=define_macros)
     config.add_extension('cython_special',
                          depends=cython_special_dep,
                          sources=cython_special_src,


### PR DESCRIPTION
#### Reference issue
Part of gh-11193

#### What does this implement/fix?
Add support for ilp64 Lapack in scipy.special.
It's not used there in many places, only in the C code of ellip_harm*