### PR TITLE
MAINT: Cleanup PyMODINIT_FUNC used during 2to3

### DIFF
--- a/scipy/_lib/src/_test_ccallback.c
+++ b/scipy/_lib/src/_test_ccallback.c
@@ -400,8 +400,7 @@ static struct PyModuleDef test_ccallback_module = {
 };
 
 
-PyMODINIT_FUNC
-PyInit__test_ccallback(void)
+PyObject *PyInit__test_ccallback(void)
 {
     return PyModule_Create(&test_ccallback_module);
 }

--- a/scipy/integrate/tests/_test_multivariate.c
+++ b/scipy/integrate/tests/_test_multivariate.c
@@ -109,8 +109,7 @@ static struct PyModuleDef moduledef = {
     NULL
 };
 
-PyMODINIT_FUNC
-PyInit__test_multivariate(void)
+PyObject *PyInit__test_multivariate(void)
 {
     PyObject *m;
     m = PyModule_Create(&moduledef);

--- a/scipy/ndimage/src/_ctest.c
+++ b/scipy/ndimage/src/_ctest.c
@@ -196,8 +196,7 @@ static struct PyModuleDef MOD = {
 };
 
 
-PyMODINIT_FUNC
-PYINIT(void)
+PyObject *PYINIT(void)
 {
     return PyModule_Create(&MOD);
 }


### PR DESCRIPTION
from https://docs.python.org/3/extending/extending.html
> Note that PyMODINIT_FUNC declares the function as PyObject * return type, declares any special linkage declarations required by the platform, and for C++ declares the function as extern "C".

from http://python3porting.com/cextensions.html
> It’s not just the name that has changed; it’s also the value of PyMODINIT_FUNC. In Python 2 it’s typically void while in Python 3 it now returns a PyObject*

These are the only three usages/mentions of `PyMODINIT_FUNC` in the code base.
There are ~20 usages of return `PyObject *` see `grep -ri -B4 PyModule_Cre scipy/`