### PR TITLE
Revert "MAINT: Rollback python2.6 workaround"

### DIFF
--- a/scipy/odr/__odrpack.c
+++ b/scipy/odr/__odrpack.c
@@ -1,7 +1,7 @@
 /* Anti-Copyright
  *
  * I hereby release this code into the PUBLIC DOMAIN AS IS. There is no
- * support, warranty, or guarantee. I will gladly accept comments, bug
+ * support, warranty, or guarantee. I will gladly accept comments, bug 
  * reports, and patches, however.
  *
  * Robert Kern
@@ -536,10 +536,21 @@ PyObject *odr(PyObject * self, PyObject * args, PyObject * kwds)
     {
       PYERR(PyExc_TypeError, "initbeta must be a sequence");
     }
-  if (!PySequence_Check(py) && !PyLong_Check(py))
+  if (!PySequence_Check(py))
     {
-      PYERR(PyExc_TypeError,
-            "y must be a sequence or integer (if model is implicit)");
+      /* Checking whether py is an int
+       *
+       * XXX: PyInt_Check for np.int32 instances does not work on python 2.6 -
+       * we should fix this in numpy, workaround by trying to cast to an int
+       * for now */
+      long val;
+
+      PyErr_Clear();
+      val = PyInt_AsLong(py);
+      if (val == -1 && PyErr_Occurred()) {
+        PYERR(PyExc_TypeError,
+              "y must be a sequence or integer (if model is implicit)");
+      }
     }
   if (!PySequence_Check(px))
     {
@@ -640,7 +651,7 @@ PyObject *odr(PyObject * self, PyObject * args, PyObject * kwds)
   else
     {                           /* we *do* have an implicit model */
       ldy = 1;
-      nq = (int)PyLong_AsLong(py);
+      nq = (int)PyInt_AsLong(py);
       dim1[0] = 1;
 
       /* initialize y to a dummy array; never referenced */

--- a/scipy/odr/odrpack.h
+++ b/scipy/odr/odrpack.h
@@ -2,6 +2,8 @@
 #include "Python.h"
 #include "numpy/arrayobject.h"
 
+#include "numpy/npy_3kcompat.h"
+
 #if defined(NO_APPEND_FORTRAN)
 #if defined(UPPERCASE_FORTRAN)
 #define F_FUNC(f,F) F


### PR DESCRIPTION
Reverts scipy/scipy#11636

CI was broken, shouldn't have merged.