### PR TITLE
ENH: spatial/qhull: support ILP64 Lapack

### DIFF
--- a/scipy/spatial/qhull.pyx
+++ b/scipy/spatial/qhull.pyx
@@ -208,13 +208,14 @@ from libc.stdlib cimport qsort
 #------------------------------------------------------------------------------
 
 cdef extern from "qhull_misc.h":
+    ctypedef int CBLAS_INT   # actual type defined in the header file
     void qhull_misc_lib_check()
-    void qh_dgetrf(int *m, int *n, double *a, int *lda, int *ipiv,
-                   int *info) nogil
-    void qh_dgetrs(char *trans, int *n, int *nrhs, double *a, int *lda,
-                   int *ipiv, double *b, int *ldb, int *info) nogil
-    void qh_dgecon(char *norm, int *n, double *a, int *lda, double *anorm,
-                   double *rcond, double *work, int *iwork, int *info) nogil
+    void qh_dgetrf(CBLAS_INT *m, CBLAS_INT *n, double *a, CBLAS_INT *lda, CBLAS_INT *ipiv,
+                   CBLAS_INT *info) nogil
+    void qh_dgetrs(char *trans, CBLAS_INT *n, CBLAS_INT *nrhs, double *a, CBLAS_INT *lda,
+                   CBLAS_INT *ipiv, double *b, CBLAS_INT *ldb, CBLAS_INT *info) nogil
+    void qh_dgecon(char *norm, CBLAS_INT *n, double *a, CBLAS_INT *lda, double *anorm,
+                   double *rcond, double *work, CBLAS_INT *iwork, CBLAS_INT *info) nogil
 
 
 #------------------------------------------------------------------------------
@@ -1077,9 +1078,10 @@ def _get_barycentric_transforms(np.ndarray[np.double_t, ndim=2] points,
     cdef np.ndarray[np.double_t, ndim=2] T
     cdef np.ndarray[np.double_t, ndim=3] Tinvs
     cdef int isimplex
-    cdef int i, j, n, nrhs, lda, ldb
-    cdef int info = 0
-    cdef int ipiv[NPY_MAXDIMS+1]
+    cdef int i, j
+    cdef CBLAS_INT n, nrhs, lda, ldb
+    cdef CBLAS_INT info = 0
+    cdef CBLAS_INT ipiv[NPY_MAXDIMS+1]
     cdef int ndim, nsimplex
     cdef double centroid[NPY_MAXDIMS]
     cdef double c[NPY_MAXDIMS+1]
@@ -1089,7 +1091,7 @@ def _get_barycentric_transforms(np.ndarray[np.double_t, ndim=2] points,
     cdef double rcond_limit
 
     cdef double work[4*NPY_MAXDIMS]
-    cdef int iwork[NPY_MAXDIMS]
+    cdef CBLAS_INT iwork[NPY_MAXDIMS]
 
     cdef double x1, x2, x3
     cdef double y1, y2, y3

--- a/scipy/spatial/qhull_misc.h
+++ b/scipy/spatial/qhull_misc.h
@@ -4,23 +4,15 @@
 #ifndef QHULL_MISC_H_
 #define QHULL_MISC_H_
 
-#if defined(NO_APPEND_FORTRAN)
-#if defined(UPPERCASE_FORTRAN)
-#define F_FUNC(f,F) F
-#else
-#define F_FUNC(f,F) f
-#endif
-#else
-#if defined(UPPERCASE_FORTRAN)
-#define F_FUNC(f,F) F##_
-#else
-#define F_FUNC(f,F) f##_
-#endif
-#endif
+#include "npy_cblas.h"
 
-#define qh_dgetrf F_FUNC(dgetrf,DGETRF)
-#define qh_dgecon F_FUNC(dgecon,DGECON)
-#define qh_dgetrs F_FUNC(dgetrs,DGETRS)
+void BLAS_FUNC(dgetrf)(CBLAS_INT*, CBLAS_INT*, double*, CBLAS_INT*, CBLAS_INT*, CBLAS_INT*);
+void BLAS_FUNC(dgecon)(char*, CBLAS_INT*, double*, CBLAS_INT*, double*, double*, double*, CBLAS_INT*, CBLAS_INT*, size_t);
+void BLAS_FUNC(dgetrs)(char*, CBLAS_INT*, CBLAS_INT*, double*, CBLAS_INT*, CBLAS_INT*, double*, CBLAS_INT*, CBLAS_INT*, size_t);
+
+#define qh_dgetrf(m,n,a,lda,ipiv,info) BLAS_FUNC(dgetrf)(m,n,a,lda,ipiv,info)
+#define qh_dgecon(norm,n,a,lda,anorm,rcond,work,iwork,info) BLAS_FUNC(dgecon)(norm,n,a,lda,anorm,rcond,work,iwork,info,1)
+#define qh_dgetrs(trans,n,nrhs,a,lda,ipiv,b,ldb,info) BLAS_FUNC(dgetrs)(trans,n,nrhs,a,lda,ipiv,b,ldb,info,1)
 
 #define qhull_misc_lib_check() QHULL_LIB_CHECK
 

--- a/scipy/spatial/setup.py
+++ b/scipy/spatial/setup.py
@@ -12,7 +12,8 @@ def pre_build_hook(build_ext, ext):
 def configuration(parent_package='', top_path=None):
     from numpy.distutils.misc_util import Configuration, get_numpy_include_dirs
     from numpy.distutils.misc_util import get_info as get_misc_info
-    from scipy._build_utils.system_info import get_info as get_sys_info
+    from scipy._build_utils.system_info import get_info
+    from scipy._build_utils import combine_dict, uses_blas64
     from distutils.sysconfig import get_python_inc
 
     config = Configuration('spatial', parent_package, top_path)
@@ -31,9 +32,14 @@ def configuration(parent_package='', top_path=None):
         inc_dirs.append(get_python_inc(plat_specific=1))
     inc_dirs.append(get_numpy_include_dirs())
     inc_dirs.append(join(dirname(dirname(__file__)), '_lib'))
+    inc_dirs.append(join(dirname(dirname(__file__)), '_build_utils', 'src'))
 
-    cfg = dict(get_sys_info('lapack_opt'))
-    cfg.setdefault('include_dirs', []).extend(inc_dirs)
+    if uses_blas64():
+        lapack_opt = get_info('lapack_ilp64_opt')
+    else:
+        lapack_opt = get_info('lapack_opt')
+
+    cfg = combine_dict(lapack_opt, include_dirs=inc_dirs)
     config.add_extension('qhull',
                          sources=['qhull.c', 'qhull_misc.c'] + qhull_src,
                          **cfg)


### PR DESCRIPTION
#### Reference issue
Part of gh-11193

#### What does this implement/fix?
Support 64-bit lapack in scipy.spatial, where it's used only in qhull.