### PR TITLE
ENH: integrate: support ILP64 BLAS in odeint/vode/lsoda

### DIFF
--- a/scipy/integrate/_ode.py
+++ b/scipy/integrate/_ode.py
@@ -85,11 +85,16 @@ __docformat__ = "restructuredtext en"
 import re
 import warnings
 
-from numpy import asarray, array, zeros, int32, isscalar, real, imag, vstack
+from numpy import asarray, array, zeros, isscalar, real, imag, vstack
 
 from . import vode as _vode
 from . import _dop
 from . import lsoda as _lsoda
+
+
+_dop_int_dtype = _dop.types.intvar.dtype
+_vode_int_dtype = _vode.types.intvar.dtype
+_lsoda_int_dtype = _lsoda.types.intvar.dtype
 
 
 # ------------------------------------------------------------------------------
@@ -969,7 +974,7 @@ class vode(IntegratorBase):
         rwork[6] = self.min_step
         self.rwork = rwork
 
-        iwork = zeros((liw,), int32)
+        iwork = zeros((liw,), _vode_int_dtype)
         if self.ml is not None:
             iwork[0] = self.ml
         if self.mu is not None:
@@ -1082,7 +1087,7 @@ class zvode(vode):
         rwork[6] = self.min_step
         self.rwork = rwork
 
-        iwork = zeros((liw,), int32)
+        iwork = zeros((liw,), _vode_int_dtype)
         if self.ml is not None:
             iwork[0] = self.ml
         if self.mu is not None:
@@ -1157,7 +1162,7 @@ class dopri5(IntegratorBase):
         work[5] = self.max_step
         work[6] = self.first_step
         self.work = work
-        iwork = zeros((21,), int32)
+        iwork = zeros((21,), _dop_int_dtype)
         iwork[0] = self.nsteps
         iwork[2] = self.verbosity
         self.iwork = iwork
@@ -1219,7 +1224,7 @@ class dop853(dopri5):
         work[5] = self.max_step
         work[6] = self.first_step
         self.work = work
-        iwork = zeros((21,), int32)
+        iwork = zeros((21,), _dop_int_dtype)
         iwork[0] = self.nsteps
         iwork[2] = self.verbosity
         self.iwork = iwork
@@ -1314,7 +1319,7 @@ class lsoda(IntegratorBase):
         rwork[5] = self.max_step
         rwork[6] = self.min_step
         self.rwork = rwork
-        iwork = zeros((liw,), int32)
+        iwork = zeros((liw,), _lsoda_int_dtype)
         if self.ml is not None:
             iwork[0] = self.ml
         if self.mu is not None:

--- a/scipy/integrate/_odepackmodule.c
+++ b/scipy/integrate/_odepackmodule.c
@@ -32,6 +32,15 @@ the result tuple when the full_output argument is non-zero.
 
 #include "numpy/arrayobject.h"
 
+#ifdef HAVE_BLAS_ILP64
+#define F_INT npy_int64
+#define F_INT_NPY NPY_INT64
+#else
+#define F_INT int
+#define F_INT_NPY NPY_INT
+#endif
+
+
 #define PYERR(errobj,message) {\
     PyErr_SetString(errobj,message); \
     goto fail; \
@@ -145,7 +154,14 @@ static PyObject *odepack_error;
     #endif
 #endif
 
-void LSODA();
+typedef void lsoda_f_t(F_INT *n, double *t, double *y, double *ydot);
+typedef int lsoda_jac_t(F_INT *n, double *t, double *y, F_INT *ml, F_INT *mu,
+                        double *pd, F_INT *nrowpd);
+
+void LSODA(lsoda_f_t *f, F_INT *neq, double *y, double *t, double *tout, F_INT *itol,
+           double *rtol, double *atol, F_INT *itask, F_INT *istate, F_INT *iopt,
+           double *rwork, F_INT *lrw, F_INT *iwork, F_INT *liw, lsoda_jac_t *jac,
+           F_INT *jt);
 
 /*
 void ode_function(int *n, double *t, double *y, double *ydot)
@@ -158,7 +174,7 @@ void ode_function(int *n, double *t, double *y, double *ydot)
 */
 
 void
-ode_function(int *n, double *t, double *y, double *ydot)
+ode_function(F_INT *n, double *t, double *y, double *ydot)
 {
     /*
     This is the function called from the Fortran code. It should
@@ -214,11 +230,11 @@ ode_function(int *n, double *t, double *y, double *ydot)
  */
 
 static void
-copy_array_to_fortran(double *f, int ldf, int nrows, int ncols,
-                      double *c, int transposed)
+copy_array_to_fortran(double *f, F_INT ldf, F_INT nrows, F_INT ncols,
+                      double *c, F_INT transposed)
 {
-    int i, j;
-    int row_stride, col_stride;
+    F_INT i, j;
+    F_INT row_stride, col_stride;
 
     /* The strides count multiples of sizeof(double), not bytes. */
     if (transposed) {
@@ -242,8 +258,8 @@ copy_array_to_fortran(double *f, int ldf, int nrows, int ncols,
 
 
 int
-ode_jacobian_function(int *n, double *t, double *y, int *ml, int *mu,
-                      double *pd, int *nrowpd)
+ode_jacobian_function(F_INT *n, double *t, double *y, F_INT *ml, F_INT *mu,
+                      double *pd, F_INT *nrowpd)
 {
     /*
         This is the function called from the Fortran code. It should
@@ -254,7 +270,7 @@ ode_jacobian_function(int *n, double *t, double *y, int *ml, int *mu,
     */
 
     PyArrayObject *result_array;
-    int ndim, nrows, ncols, dim_error;
+    npy_intp ndim, nrows, ncols, dim_error;
     npy_intp *dims;
 
     result_array = (PyArrayObject *)
@@ -276,7 +292,7 @@ ode_jacobian_function(int *n, double *t, double *y, int *ml, int *mu,
     }
 
     if (!global_params.jac_transpose) {
-        int tmp;
+        npy_intp tmp;
         tmp = nrows;
         nrows = ncols;
         ncols = tmp;
@@ -342,7 +358,7 @@ ode_jacobian_function(int *n, double *t, double *y, int *ml, int *mu,
          *  dimension of pd doesn't necessarily equal the number of rows of the
          *  matrix.
          */
-        int m;  /* Number of rows in the (full or packed banded) Jacobian. */
+        npy_intp m;  /* Number of rows in the (full or packed banded) Jacobian. */
         if (global_params.jac_type == 4) {
             m = *ml + *mu + 1;
         }
@@ -363,7 +379,7 @@ int
 setup_extra_inputs(PyArrayObject **ap_rtol, PyObject *o_rtol,
                    PyArrayObject **ap_atol, PyObject *o_atol,
                    PyArrayObject **ap_tcrit, PyObject *o_tcrit,
-                   int *numcrit, int neq)
+                   long *numcrit, int neq)
 {
     int itol = 0;
     double tol = 1.49012e-8;
@@ -432,10 +448,10 @@ fail:       /* Needed for use of PYERR */
 
 
 int
-compute_lrw_liw(int *lrw, int *liw, int neq, int jt, int ml, int mu,
-                int mxordn, int mxords)
+compute_lrw_liw(F_INT *lrw, F_INT *liw, F_INT neq, F_INT jt, F_INT ml, F_INT mu,
+                F_INT mxordn, F_INT mxords)
 {
-    int lrn, lrs, nyh, lmat;
+    F_INT lrn, lrs, nyh, lmat;
 
     if (jt == 1 || jt == 2) {
         lmat = neq*neq + 2;
@@ -482,21 +498,21 @@ odepack_odeint(PyObject *dummy, PyObject *args, PyObject *kwdict)
     PyArrayObject *ap_tout = NULL;
     PyObject *extra_args = NULL;
     PyObject *Dfun = Py_None;
-    int neq, itol = 1, itask = 1, istate = 1, iopt = 0, lrw, *iwork, liw, jt = 4;
+    F_INT neq, itol = 1, itask = 1, istate = 1, iopt = 0, lrw, *iwork, liw, jt = 4;
     double *y, t, *tout, *rtol, *atol, *rwork;
     double h0 = 0.0, hmax = 0.0, hmin = 0.0;
-    int ixpr = 0, mxstep = 0, mxhnil = 0, mxordn = 12, mxords = 5, ml = -1, mu = -1;
-    int tfirst;
+    long ixpr = 0, mxstep = 0, mxhnil = 0, mxordn = 12, mxords = 5, ml = -1, mu = -1;
+    long tfirst;
     PyObject *o_tcrit = NULL;
     PyArrayObject *ap_tcrit = NULL;
     PyArrayObject *ap_hu = NULL, *ap_tcur = NULL, *ap_tolsf = NULL, *ap_tsw = NULL;
     PyArrayObject *ap_nst = NULL, *ap_nfe = NULL, *ap_nje = NULL, *ap_nqu = NULL;
     PyArrayObject *ap_mused = NULL;
-    int imxer = 0, lenrw = 0, leniw = 0, col_deriv = 0;
+    long imxer = 0, lenrw = 0, leniw = 0, col_deriv = 0;
     npy_intp out_sz = 0, dims[2];
-    int k, ntimes, crit_ind = 0;
-    int allocated = 0, full_output = 0, numcrit = 0;
-    int t0count;
+    long k, ntimes, crit_ind = 0;
+    long allocated = 0, full_output = 0, numcrit = 0;
+    long t0count;
     double *yout, *yout_ptr, *tout_ptr, *tcrit;
     double *wa;
     static char *kwlist[] = {"fun", "y0", "t", "args", "Dfun", "col_deriv",
@@ -505,7 +521,7 @@ odepack_odeint(PyObject *dummy, PyObject *args, PyObject *kwdict)
                              "mxordn", "mxords", "tfirst", NULL};
     odepack_params save_params;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwdict, "OOO|OOiiiiOOOdddiiiiii", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwdict, "OOO|OOllllOOOdddllllll", kwlist,
                                      &fcn, &y0, &p_tout, &extra_args, &Dfun,
                                      &col_deriv, &ml, &mu, &full_output, &o_rtol, &o_atol,
                                      &o_tcrit, &h0, &hmax, &hmin, &ixpr, &mxstep, &mxhnil,
@@ -632,13 +648,13 @@ odepack_odeint(PyObject *dummy, PyObject *args, PyObject *kwdict)
         goto fail;
     }
 
-    if ((wa = (double *)malloc(lrw*sizeof(double) + liw*sizeof(int)))==NULL) {
+    if ((wa = (double *)malloc(lrw*sizeof(double) + liw*sizeof(F_INT)))==NULL) {
         PyErr_NoMemory();
         goto fail;
     }
     allocated = 1;
     rwork = wa;
-    iwork = (int *)(wa + lrw);
+    iwork = (F_INT *)(wa + lrw);
 
     iwork[0] = ml;
     iwork[1] = mu;
@@ -665,11 +681,11 @@ odepack_odeint(PyObject *dummy, PyObject *args, PyObject *kwdict)
         ap_tcur = (PyArrayObject *) PyArray_SimpleNew(1, &out_sz, NPY_DOUBLE);
         ap_tolsf = (PyArrayObject *) PyArray_SimpleNew(1, &out_sz, NPY_DOUBLE);
         ap_tsw = (PyArrayObject *) PyArray_SimpleNew(1, &out_sz, NPY_DOUBLE);
-        ap_nst = (PyArrayObject *) PyArray_SimpleNew(1, &out_sz, NPY_INT);
-        ap_nfe = (PyArrayObject *) PyArray_SimpleNew(1, &out_sz, NPY_INT);
-        ap_nje = (PyArrayObject *) PyArray_SimpleNew(1, &out_sz, NPY_INT);
-        ap_nqu = (PyArrayObject *) PyArray_SimpleNew(1, &out_sz, NPY_INT);
-        ap_mused = (PyArrayObject *) PyArray_SimpleNew(1, &out_sz, NPY_INT);
+        ap_nst = (PyArrayObject *) PyArray_SimpleNew(1, &out_sz, F_INT_NPY);
+        ap_nfe = (PyArrayObject *) PyArray_SimpleNew(1, &out_sz, F_INT_NPY);
+        ap_nje = (PyArrayObject *) PyArray_SimpleNew(1, &out_sz, F_INT_NPY);
+        ap_nqu = (PyArrayObject *) PyArray_SimpleNew(1, &out_sz, F_INT_NPY);
+        ap_mused = (PyArrayObject *) PyArray_SimpleNew(1, &out_sz, F_INT_NPY);
         if (ap_hu == NULL || ap_tcur == NULL || ap_tolsf == NULL ||
                 ap_tsw == NULL || ap_nst == NULL || ap_nfe == NULL ||
                 ap_nje == NULL || ap_nqu == NULL || ap_mused == NULL) {
@@ -702,10 +718,10 @@ odepack_odeint(PyObject *dummy, PyObject *args, PyObject *kwdict)
             *((double *)PyArray_DATA(ap_tcur) + (k-1)) = rwork[12];
             *((double *)PyArray_DATA(ap_tolsf) + (k-1)) = rwork[13];
             *((double *)PyArray_DATA(ap_tsw) + (k-1)) = rwork[14];
-            *((int *)PyArray_DATA(ap_nst) + (k-1)) = iwork[10];
-            *((int *)PyArray_DATA(ap_nfe) + (k-1)) = iwork[11];
-            *((int *)PyArray_DATA(ap_nje) + (k-1)) = iwork[12];
-            *((int *)PyArray_DATA(ap_nqu) + (k-1)) = iwork[13];
+            *((F_INT *)PyArray_DATA(ap_nst) + (k-1)) = iwork[10];
+            *((F_INT *)PyArray_DATA(ap_nfe) + (k-1)) = iwork[11];
+            *((F_INT *)PyArray_DATA(ap_nje) + (k-1)) = iwork[12];
+            *((F_INT *)PyArray_DATA(ap_nqu) + (k-1)) = iwork[13];
             if (istate == -5 || istate == -4) {
                 imxer = iwork[15];
             }
@@ -714,7 +730,7 @@ odepack_odeint(PyObject *dummy, PyObject *args, PyObject *kwdict)
             }
             lenrw = iwork[16];
             leniw = iwork[17];
-            *((int *)PyArray_DATA(ap_mused) + (k-1)) = iwork[18];
+            *((F_INT *)PyArray_DATA(ap_mused) + (k-1)) = iwork[18];
         }
         if (PyErr_Occurred()) {
             goto fail;
@@ -737,7 +753,7 @@ odepack_odeint(PyObject *dummy, PyObject *args, PyObject *kwdict)
 
     /* Do Full output */
     if (full_output) {
-        return Py_BuildValue("N{s:N,s:N,s:N,s:N,s:N,s:N,s:N,s:N,s:i,s:i,s:i,s:N}i",
+        return Py_BuildValue("N{s:N,s:N,s:N,s:N,s:N,s:N,s:N,s:N,s:l,s:l,s:l,s:N}l",
                     PyArray_Return(ap_yout),
                     "hu", PyArray_Return(ap_hu),
                     "tcur", PyArray_Return(ap_tcur),
@@ -751,10 +767,10 @@ odepack_odeint(PyObject *dummy, PyObject *args, PyObject *kwdict)
                     "lenrw", lenrw,
                     "leniw", leniw,
                     "mused", PyArray_Return(ap_mused),
-                    istate);
+                    (long)istate);
     }
     else {
-        return Py_BuildValue("Ni", PyArray_Return(ap_yout), istate);
+        return Py_BuildValue("Nl", PyArray_Return(ap_yout), (long)istate);
     }
 
 fail:

--- a/scipy/integrate/dop.pyf
+++ b/scipy/integrate/dop.pyf
@@ -75,6 +75,10 @@ python module _dop
          double precision intent(hide) :: rpar = 0.0
          integer intent(hide) :: ipar = 0
        end subroutine dop853
+
+       ! Fake common block for indicating the integer size
+       integer :: intvar
+       common /types/ intvar
     end interface
 end python module dop
 

--- a/scipy/integrate/lsoda.pyf
+++ b/scipy/integrate/lsoda.pyf
@@ -49,5 +49,9 @@ python module lsoda
          integer intent(hide),check(len(iwork)>=liw),depend(iwork) :: liw=len(iwork)
          integer intent(in) :: jt
        end subroutine lsoda
+
+       ! Fake common block for indicating the integer size
+       integer :: intvar
+       common /types/ intvar
     end interface
 end python module lsoda

--- a/scipy/integrate/setup.py
+++ b/scipy/integrate/setup.py
@@ -7,13 +7,19 @@ from scipy._build_utils import numpy_nodepr_api
 def configuration(parent_package='',top_path=None):
     from numpy.distutils.misc_util import Configuration
     from scipy._build_utils.system_info import get_info
+    from scipy._build_utils import (uses_blas64, blas_ilp64_pre_build_hook,
+                                    combine_dict, get_f2py_int64_options)
+
     config = Configuration('integrate', parent_package, top_path)
 
-    # Get a local copy of lapack_opt_info
-    lapack_opt = dict(get_info('lapack_opt',notfound_action=2))
-    # Pop off the libraries list so it can be combined with
-    # additional required libraries
-    lapack_libs = lapack_opt.pop('libraries', [])
+    if uses_blas64():
+        lapack_maybe64_opt = get_info('lapack_ilp64_opt', 2)
+        pre_build_hook = blas_ilp64_pre_build_hook(lapack_maybe64_opt)
+        f2py_options = get_f2py_int64_options()
+    else:
+        lapack_maybe64_opt = get_info('lapack_opt')
+        pre_build_hook = None
+        f2py_options = None
 
     mach_src = [join('mach','*.f')]
     quadpack_src = [join('quadpack', '*.f')]
@@ -28,15 +34,25 @@ def configuration(parent_package='',top_path=None):
     quadpack_test_src = [join('tests','_test_multivariate.c')]
     odeint_banded_test_src = [join('tests', 'banded5x5.f')]
 
+    if uses_blas64():
+        mach64_name = 'mach64'
+        config.add_library('mach64', sources=mach_src,
+                           config_fc={'noopt': (__file__, 1)})
+    else:
+        # quadpack still needs the 32-bit integer lib
+        mach64_name = 'mach'
+
     config.add_library('mach', sources=mach_src,
                        config_fc={'noopt':(__file__,1)})
     config.add_library('quadpack', sources=quadpack_src)
-    config.add_library('lsoda', sources=lsoda_src)
-    config.add_library('vode', sources=vode_src)
-    config.add_library('dop', sources=dop_src)
+    config.add_library('lsoda', sources=lsoda_src, _pre_build_hook=pre_build_hook)
+    config.add_library('vode', sources=vode_src, _pre_build_hook=pre_build_hook)
+    config.add_library('dop', sources=dop_src, _pre_build_hook=pre_build_hook)
 
     # Extensions
     # quadpack:
+    lapack_opt = dict(get_info('lapack_opt', notfound_action=2))
+    lapack_libs = lapack_opt.pop('libraries', [])
     include_dirs = [join(os.path.dirname(__file__), '..', '_lib', 'src')]
     if 'include_dirs' in lapack_opt:
         lapack_opt = dict(lapack_opt)
@@ -51,43 +67,53 @@ def configuration(parent_package='',top_path=None):
                          **lapack_opt)
 
     # odepack/lsoda-odeint
-    odepack_opts = lapack_opt.copy()
-    odepack_opts.update(numpy_nodepr_api)
+    cfg = combine_dict(lapack_maybe64_opt, numpy_nodepr_api,
+                       libraries=['lsoda', 'mach'])
     config.add_extension('_odepack',
                          sources=['_odepackmodule.c'],
-                         libraries=['lsoda', 'mach'] + lapack_libs,
                          depends=(lsoda_src + mach_src),
-                         **odepack_opts)
+                         **cfg)
 
     # vode
-    config.add_extension('vode',
-                         sources=['vode.pyf'],
-                         libraries=['vode'] + lapack_libs,
-                         depends=vode_src,
-                         **lapack_opt)
+    cfg = combine_dict(lapack_maybe64_opt,
+                       libraries=['vode'])
+    ext = config.add_extension('vode',
+                               sources=['vode.pyf'],
+                               depends=vode_src,
+                               f2py_options=f2py_options,
+                               **cfg)
+    ext._pre_build_hook = pre_build_hook
 
     # lsoda
-    config.add_extension('lsoda',
-                         sources=['lsoda.pyf'],
-                         libraries=['lsoda', 'mach'] + lapack_libs,
-                         depends=(lsoda_src + mach_src),
-                         **lapack_opt)
+    cfg = combine_dict(lapack_maybe64_opt,
+                       libraries=['lsoda', mach64_name])
+    ext = config.add_extension('lsoda',
+                               sources=['lsoda.pyf'],
+                               depends=(lsoda_src + mach_src),
+                               f2py_options=f2py_options,
+                               **cfg)
+    ext._pre_build_hook = pre_build_hook
 
     # dop
-    config.add_extension('_dop',
-                         sources=['dop.pyf'],
-                         libraries=['dop'],
-                         depends=dop_src)
+    ext = config.add_extension('_dop',
+                               sources=['dop.pyf'],
+                               libraries=['dop'],
+                               depends=dop_src,
+                               f2py_options=f2py_options)
+    ext._pre_build_hook = pre_build_hook
 
     config.add_extension('_test_multivariate',
                          sources=quadpack_test_src)
 
     # Fortran+f2py extension module for testing odeint.
-    config.add_extension('_test_odeint_banded',
-                         sources=odeint_banded_test_src,
-                         libraries=['lsoda', 'mach'] + lapack_libs,
-                         depends=(lsoda_src + mach_src),
-                         **lapack_opt)
+    cfg = combine_dict(lapack_maybe64_opt,
+                       libraries=['lsoda', mach64_name])
+    ext = config.add_extension('_test_odeint_banded',
+                               sources=odeint_banded_test_src,
+                               depends=(lsoda_src + mach_src),
+                               f2py_options=f2py_options,
+                               **cfg)
+    ext._pre_build_hook = pre_build_hook
 
     config.add_subpackage('_ivp')
 

--- a/scipy/integrate/vode.pyf
+++ b/scipy/integrate/vode.pyf
@@ -110,5 +110,9 @@ python module vode
          double precision intent(hide) :: rpar = 0.0
          integer intent(hide) :: ipar = 0
        end subroutine zvode
+
+       ! Fake common block for indicating the integer size
+       integer :: intvar
+       common /types/ intvar
     end interface
 end python module vode


### PR DESCRIPTION
#### Reference issue
Part of gh-11193

#### What does this implement/fix?
Support ILP64 BLAS in odeint/vode/lsoda.
Also convert dop to 64-bit Fortran ints, even though it doesn't use blas.