### PR TITLE
BUG: Fix dropping dt in signal.StateSpace

### DIFF
--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -1400,7 +1400,8 @@ class StateSpace(LinearTimeInvariant):
         return StateSpace(np.asarray(a, dtype=common_dtype),
                           np.asarray(b, dtype=common_dtype),
                           np.asarray(c, dtype=common_dtype),
-                          np.asarray(d, dtype=common_dtype))
+                          np.asarray(d, dtype=common_dtype),
+                          **self._dt_dict)
 
     def __rmul__(self, other):
         """Pre-multiply a scalar or matrix (but not StateSpace)"""
@@ -1417,11 +1418,12 @@ class StateSpace(LinearTimeInvariant):
         return StateSpace(np.asarray(a, dtype=common_dtype),
                           np.asarray(b, dtype=common_dtype),
                           np.asarray(c, dtype=common_dtype),
-                          np.asarray(d, dtype=common_dtype))
+                          np.asarray(d, dtype=common_dtype),
+                          **self._dt_dict)
 
     def __neg__(self):
         """Negate the system (equivalent to pre-multiplying by -1)."""
-        return StateSpace(self.A, self.B, -self.C, -self.D)
+        return StateSpace(self.A, self.B, -self.C, -self.D, **self._dt_dict)
 
     def __add__(self, other):
         """
@@ -1469,7 +1471,8 @@ class StateSpace(LinearTimeInvariant):
         return StateSpace(np.asarray(a, dtype=common_dtype),
                           np.asarray(b, dtype=common_dtype),
                           np.asarray(c, dtype=common_dtype),
-                          np.asarray(d, dtype=common_dtype))
+                          np.asarray(d, dtype=common_dtype),
+                          **self._dt_dict)
 
     def __sub__(self, other):
         if not self._check_binop_other(other):

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -803,6 +803,7 @@ class TestStateSpace(object):
 
         s_discrete = s1.to_discrete(0.1)
         s2_discrete = s2.to_discrete(0.2)
+        s3_discrete = s2.to_discrete(0.1)
 
         # Impulse response
         t = np.linspace(0, 1, 100)
@@ -898,6 +899,17 @@ class TestStateSpace(object):
         with assert_raises(TypeError):
             BadType() - s1
 
+        s = s_discrete + s3_discrete
+        assert_(s.dt == 0.1)
+
+        s = s_discrete * s3_discrete
+        assert_(s.dt == 0.1)
+
+        s = 3 * s_discrete
+        assert_(s.dt == 0.1)
+
+        s = -s_discrete
+        assert_(s.dt == 0.1)
 
 class TestTransferFunction(object):
     def test_initialization(self):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes gh-9913.
#### What does this implement/fix?
<!--Please explain your changes.-->
The "dt" parameter is getting dropped when performing adding/multiplying on discrete StateSpace systems. This PR fixes it and adds tests.
#### Additional information
<!--Any additional information you think is important.-->