### PR TITLE
ENH: Area calculation for 2D inputs in SphericalVoronoi

### DIFF
--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -70,9 +70,10 @@ class SphericalVoronoi:
     Methods
     ----------
     calculate_areas
-        Calculates the areas of the Voronoi regions. The regions are
-        spherical polygons (not planar). The sum of the areas is
-        `4 * pi * radius**2`.
+        Calculates the areas of the Voronoi regions. For 2D point sets, the
+        regions are circular arcs. The sum of the areas is `2 * pi * radius`.
+        For 3D point sets, the regions are spherical polygons. The sum of the
+        areas is `4 * pi * radius**2`.
 
     Raises
     ------
@@ -262,18 +263,7 @@ class SphericalVoronoi:
             raise TypeError("Only supported for three-dimensional point sets")
         _voronoi.sort_vertices_of_regions(self._simplices, self.regions)
 
-    def calculate_areas(self):
-        """Calculates the areas of the Voronoi regions. The regions are
-        spherical polygons (not planar). The sum of the areas is
-        `4 * pi * radius**2`.
-
-        .. versionadded:: 1.5.0
-
-        Returns
-        -------
-        areas : double array of shape (npoints,)
-            The areas of the Voronoi regions.
-        """
+    def _calculate_areas_3d(self):
         self.sort_vertices_of_regions()
         sizes = [len(region) for region in self.regions]
         csizes = np.cumsum(sizes)
@@ -311,3 +301,45 @@ class SphericalVoronoi:
 
         # Get polygon areas using A = omega * r**2
         return solid_angles * self.radius**2
+
+    def _calculate_areas_2d(self):
+        # Find start and end points of arcs
+        arcs = self.points[self._simplices] - self.center
+
+        # Calculate the angle subtended by arcs
+        cosine = np.einsum('ij,ij->i', arcs[:, 0], arcs[:, 1])
+        sine = np.abs(np.linalg.det(arcs))
+        theta = np.arctan2(sine, cosine)
+
+        # Get areas using A = r * theta
+        areas = self.radius * theta
+
+        # Correct arcs which go the wrong way (single-hemisphere inputs)
+        signs = np.sign(np.einsum('ij,ij->i', arcs[:, 0],
+                                              self.vertices - self.center))
+        indices = np.where(signs < 0)
+        areas[indices] = 2 * np.pi * self.radius - areas[indices]
+        return areas
+
+    def calculate_areas(self):
+        """Calculates the areas of the Voronoi regions.
+
+        For 2D point sets, the regions are circular arcs. The sum of the areas
+        is `2 * pi * radius`.
+
+        For 3D point sets, the regions are spherical polygons. The sum of the
+        areas is `4 * pi * radius**2`.
+
+        .. versionadded:: 1.5.0
+
+        Returns
+        -------
+        areas : double array of shape (npoints,)
+            The areas of the Voronoi regions.
+        """
+        if self._dim == 2:
+            return self._calculate_areas_2d()
+        elif self._dim == 3:
+            return self._calculate_areas_3d()
+        else:
+            raise TypeError("Only supported for 2D and 3D point sets")


### PR DESCRIPTION
#### What does this implement/fix?
This extends the calculation of areas of Voronoi regions to 2D inputs. This is a simpler case than 3D input - the area of a segment is `theta * radius`.

@tylerjereddy 