### PR TITLE
MAINT: ensure attributes have correct data type in `SphericalVoronoi`

### DIFF
--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -166,19 +166,16 @@ class SphericalVoronoi:
     def __init__(self, points, radius=1, center=None, threshold=1e-06):
 
         if radius is None:
-            radius = 1
+            radius = 1.
             warnings.warn('`radius` is `None`. '
                           'This will raise an error in a future version. '
                           'Please provide a floating point number '
                           '(i.e. `radius=1`).',
                           DeprecationWarning)
 
-        self.points = np.array(points, dtype=float)
-        if points.ndim != 2:
-            raise TypeError("`points` must be a 2D array.")
-
         self.radius = float(radius)
-        self._dim = points.shape[1]
+        self.points = np.array(points).astype(np.double)
+        self._dim = len(points[0])
         if center is None:
             self.center = np.zeros(self._dim)
         else:

--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -166,20 +166,23 @@ class SphericalVoronoi:
     def __init__(self, points, radius=1, center=None, threshold=1e-06):
 
         if radius is None:
-            radius = 1.
+            radius = 1
             warnings.warn('`radius` is `None`. '
                           'This will raise an error in a future version. '
                           'Please provide a floating point number '
                           '(i.e. `radius=1`).',
                           DeprecationWarning)
 
-        self.points = np.array(points).astype(np.double)
-        self.radius = radius
-        self._dim = len(points[0])
+        self.points = np.array(points, dtype=float)
+        if points.ndim != 2:
+            raise TypeError("`points` must be a 2D array.")
+
+        self.radius = float(radius)
+        self._dim = points.shape[1]
         if center is None:
             self.center = np.zeros(self._dim)
         else:
-            self.center = np.array(center)
+            self.center = np.array(center, dtype=float)
 
         # test degenerate input
         self._rank = np.linalg.matrix_rank(self.points - self.points[0],

--- a/scipy/spatial/tests/test_spherical_voronoi.py
+++ b/scipy/spatial/tests/test_spherical_voronoi.py
@@ -327,3 +327,20 @@ class TestSphericalVoronoi(object):
         sv = SphericalVoronoi(points)
         areas = sv.calculate_areas()
         assert_almost_equal(areas, 4 * np.pi / len(points))
+
+    @pytest.mark.parametrize("radius", [1, 1.])
+    @pytest.mark.parametrize("center", [None, (1, 2, 3), (1., 2., 3.)])
+    def test_attribute_types(self, radius, center):
+        points = radius * self.points
+        if center is not None:
+            points += center
+
+        sv = SphericalVoronoi(points, radius=radius, center=center)
+        assert sv.points.dtype is np.dtype(np.float64)
+        assert sv.center.dtype is np.dtype(np.float64)
+        assert isinstance(sv.radius, float)
+
+    def test_incorrect_array_dimensions(self):
+        points = np.zeros((4, 3, 2))
+        with pytest.raises(TypeError, match="must be a 2D array."):
+            spherical_voronoi.SphericalVoronoi(points)

--- a/scipy/spatial/tests/test_spherical_voronoi.py
+++ b/scipy/spatial/tests/test_spherical_voronoi.py
@@ -339,8 +339,3 @@ class TestSphericalVoronoi(object):
         assert sv.points.dtype is np.dtype(np.float64)
         assert sv.center.dtype is np.dtype(np.float64)
         assert isinstance(sv.radius, float)
-
-    def test_incorrect_array_dimensions(self):
-        points = np.zeros((4, 3, 2))
-        with pytest.raises(TypeError, match="must be a 2D array."):
-            spherical_voronoi.SphericalVoronoi(points)


### PR DESCRIPTION
#### What does this implement/fix?
The changes in this PR ensure that the attributes of the `SphericalVoronoi` class have the correct data type, regardless of the input data type. This also means that the data types are the same as those advertised in the docstring.

@tylerjereddy 