### PR TITLE
degree is not order in splines

### DIFF
--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -48,7 +48,7 @@ class BSpline(object):
 
         S(x) = \sum_{j=0}^{n-1} c_j  B_{j, k; t}(x)
 
-    where :math:`B_{j, k; t}` are B-spline basis functions of degree `k`
+    where :math:`B_{j, k; t}` are B-spline basis functions of order `k`
     and knots `t`.
 
     Parameters

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -48,7 +48,7 @@ class BSpline(object):
 
         S(x) = \sum_{j=0}^{n-1} c_j  B_{j, k; t}(x)
 
-    where :math:`B_{j, k; t}` are B-spline basis functions of order `k`
+    where :math:`B_{j, k; t}` are B-spline basis functions of degree `k`
     and knots `t`.
 
     Parameters
@@ -58,7 +58,7 @@ class BSpline(object):
     c : ndarray, shape (>=n, ...)
         spline coefficients
     k : int
-        B-spline order
+        B-spline degree
     extrapolate : bool or 'periodic', optional
         whether to extrapolate beyond the base interval, ``t[k] .. t[n]``,
         or to return nans.


### PR DESCRIPTION
The following explanation of parameters said `k` is the B-spline order, while here it uses `degree`, but `degree` is different from `order`, and they satisfy `order = degree + 1`. The same issue https://github.com/scipy/scipy/pull/11861 has been corrected.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->