### PR TITLE
[MAINT] Fix error on PyData/Sparse import.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -180,7 +180,7 @@ before_install:
     fi
   - |
     if [ -z "${USE_DEBUG}" -a "${TRAVIS_CPU_ARCH}" == "amd64" -a "${TRAVIS_PYTHON_VERSION}" != "3.8" ]; then
-        travis_retry pip install numba==0.47
+        travis_retry pip install numba==0.49.1
         travis_retry pip install --only-binary=:all: sparse
     fi
   - |

--- a/scipy/sparse/linalg/tests/test_pydata_sparse.py
+++ b/scipy/sparse/linalg/tests/test_pydata_sparse.py
@@ -8,7 +8,7 @@ from numpy.testing import assert_allclose
 
 try:
     import sparse
-except ImportError:
+except Exception:
     sparse = None
 
 pytestmark = pytest.mark.skipif(sparse is None,


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

The release of PyData/Sparse 0.10.0 requires Numba 0.49.0 which in turn requires NumPy 1.15. Due to this, an `AttributeError` is raised in CI: https://travis-ci.org/github/scipy/scipy/jobs/687254774#L2962 when importing Numba.