### PR TITLE
TST: Always test matmul now that Python3.5+ is required

### DIFF
--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -549,9 +549,9 @@ class spmatrix(object):
                 tr = np.asarray(other).transpose()
             return (self.transpose() * tr).transpose()
 
-    #####################################
-    # matmul (@) operator (Python 3.5+) #
-    #####################################
+    #######################
+    # matmul (@) operator #
+    #######################
 
     def __matmul__(self, other):
         if isscalarlike(other):

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -15,10 +15,6 @@ from scipy.sparse.linalg import interface
 from scipy.sparse.sputils import matrix
 
 
-# Only test matmul operator (A @ B) when available (Python 3.5+)
-TEST_MATMUL = hasattr(operator, 'matmul')
-
-
 class TestLinearOperator(object):
     def setup_method(self):
         self.A = np.array([[1,2,3],
@@ -172,9 +168,6 @@ class TestLinearOperator(object):
             assert_(isinstance(C**2, interface._PowerLinearOperator))
 
     def test_matmul(self):
-        if not TEST_MATMUL:
-            pytest.skip("matmul is only tested in Python 3.5+")
-
         D = {'shape': self.A.shape,
              'matvec': lambda x: np.dot(self.A, x).reshape(self.A.shape[0]),
              'rmatvec': lambda x: np.dot(self.A.T.conj(),

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -80,9 +80,6 @@ def sparse_may_share_memory(A, B):
     return False
 
 
-# Only test matmul operator (A @ B) when available (Python 3.5+)
-TEST_MATMUL = hasattr(operator, 'matmul')
-
 sup_complex = suppress_warnings()
 sup_complex.filter(ComplexWarning)
 
@@ -1569,9 +1566,8 @@ class _TestCommon(object):
         assert_equal(B - A, "matrix on the right")
         assert_equal(B * A, "matrix on the right")
 
-        if TEST_MATMUL:
-            assert_equal(eval('A @ B'), "matrix on the left")
-            assert_equal(eval('B @ A'), "matrix on the right")
+        assert_equal(eval('A @ B'), "matrix on the left")
+        assert_equal(eval('B @ A'), "matrix on the right")
 
     def test_binop_custom_type_with_shape(self):
         A = self.spmatrix([[1], [2], [3]])
@@ -1583,14 +1579,10 @@ class _TestCommon(object):
         assert_equal(B - A, "matrix on the right")
         assert_equal(B * A, "matrix on the right")
 
-        if TEST_MATMUL:
-            assert_equal(eval('A @ B'), "matrix on the left")
-            assert_equal(eval('B @ A'), "matrix on the right")
+        assert_equal(eval('A @ B'), "matrix on the left")
+        assert_equal(eval('B @ A'), "matrix on the right")
 
     def test_matmul(self):
-        if not TEST_MATMUL:
-            pytest.skip("matmul is only tested in Python 3.5+")
-
         M = self.spmatrix(array([[3,0,0],[0,1,0],[2,0,3.0],[2,3,0]]))
         B = self.spmatrix(array([[0,1],[1,0],[0,2]],'d'))
         col = array([[1,2,3]]).T


### PR DESCRIPTION
Small cleanup. TEST_MATMUL should always been true now that Python 3.5+ is required