### PR TITLE
TST: Add a test for stats.gmean with negative input

### DIFF
--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -79,14 +79,14 @@ class TestGeoMean(object):
         #  Test a 1d masked array with zero element
         a = np.ma.array([10, 20, 30, 40, 50, 60, 70, 80, 90, 0])
         desired = 41.4716627439
-        with np.errstate(all='ignore'):
+        with np.errstate(divide='ignore'):
             check_equal_gmean(a, desired)
 
     def test_1d_ma_inf(self):
         #  Test a 1d masked array with negative element
         a = np.ma.array([10, 20, 30, 40, 50, 60, 70, 80, 90, -1])
         desired = 41.4716627439
-        with np.errstate(all='ignore'):
+        with np.errstate(invalid='ignore'):
             check_equal_gmean(a, desired)
 
     @pytest.mark.skipif(not hasattr(np, 'float96'), reason='cannot find float96 so skipping')
@@ -249,7 +249,7 @@ class TestCorr(object):
         # cor.test(x,y,method="kendall",exact=1)
         expected = [0.0, 1.0]
         assert_almost_equal(np.asarray(mstats.kendalltau(x, y)), expected)
-        
+
         # simple case without ties
         x = ma.array(np.arange(10))
         y = ma.array(np.arange(10))

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4092,7 +4092,14 @@ class TestGeoMean(object):
         #  Test a 1d array with zero element
         a = np.array([10, 20, 30, 40, 50, 60, 70, 80, 90, 0])
         desired = 0.0  # due to exp(-inf)=0
-        with np.errstate(all='ignore'):
+        with np.errstate(divide='ignore'):
+            check_equal_gmean(a, desired)
+
+    def test_1d_list_neg(self):
+        #  Test a 1d list with negative element
+        a = [10, 20, 30, 40, 50, 60, 70, 80, 90, -1]
+        desired = np.nan  # due to log(-1) = nan
+        with np.errstate(invalid='ignore'):
             check_equal_gmean(a, desired)
 
 


### PR DESCRIPTION
I'm looking at https://github.com/scipy/scipy/issues/6551

As part of that I wanted to document what should happen with negative input which is not documented in https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.mstats.gmean.html

Technically by the definition given in the docs
> Return the geometric average of the array elements. That is: n-th root of (x1 * x2 * … * xn)

So gmean([-2, -2, 2, 2]) = (-2*-2*2*2)^(1/4) = 16^(1/4) = 2 but nan is probably more appropriate?