### PR TITLE
TST, CI: reproduce wheels 32-bit setup

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,7 +37,7 @@ jobs:
            curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
            python3.6 get-pip.py && \
            pip3 --version && \
-           pip3 install setuptools wheel numpy cython==0.29.14 pybind11 pytest pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath matplotlib==3.1.3 --user && \
+           pip3 install setuptools wheel numpy==1.14.5 cython==0.29.14 pybind11 pytest pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath matplotlib==3.1.3 --user && \
            apt-get -y install gfortran-5 wget && \
            cd .. && \
            mkdir openblas && cd openblas && \

--- a/scipy/signal/_peak_finding.py
+++ b/scipy/signal/_peak_finding.py
@@ -1288,7 +1288,7 @@ def find_peaks_cwt(vector, widths, wavelet=None, max_distances=None,
     if wavelet is None:
         wavelet = ricker
 
-    cwt_dat = cwt(vector, wavelet, widths)
+    cwt_dat = cwt(vector, wavelet, widths, window_size=window_size)
     ridge_lines = _identify_ridge_lines(cwt_dat, max_distances, gap_thresh)
     filtered = _filter_ridge_lines(cwt_dat, ridge_lines, min_length=min_length,
                                    window_size=window_size, min_snr=min_snr,

--- a/scipy/signal/wavelets.py
+++ b/scipy/signal/wavelets.py
@@ -456,6 +456,8 @@ def cwt(data, wavelet, widths, dtype=None, **kwargs):
     ...            vmax=abs(cwtmatr).max(), vmin=-abs(cwtmatr).max())
     >>> plt.show()
     """
+    if wavelet == ricker:
+        window_size = kwargs.pop('window_size', None)
     # Determine output type
     if dtype is None:
         if np.asarray(wavelet(1, widths[0], **kwargs)).dtype.char in 'FDG':
@@ -466,6 +468,14 @@ def cwt(data, wavelet, widths, dtype=None, **kwargs):
     output = np.zeros((len(widths), len(data)), dtype=dtype)
     for ind, width in enumerate(widths):
         N = np.min([10 * width, len(data)])
+        # the conditional block below and the window_size
+        # kwarg pop above may be removed eventually; these
+        # are shims for 32-bit arch + NumPy <= 1.14.5 to
+        # address gh-11095
+        if wavelet == ricker and window_size is None:
+            ceil = np.ceil(N)
+            if ceil != N:
+                N = int(N)
         wavelet_data = np.conj(wavelet(N, width, **kwargs)[::-1])
         output[ind] = convolve(data, wavelet_data, mode='same')
     return output


### PR DESCRIPTION
* pin 32-bit Linux azure CI NumPy version
to minimum supported to produce better
match to wheels repo (should reveal two
`signal` test failures)

* failures are reported in https://github.com/scipy/scipy/issues/11095 ; I'm working on the fix for them, but probably good to have main repo with less dissonance with wheels repo

* example wheels fail: https://travis-ci.org/github/MacPython/scipy-wheels/builds/687683011

Fixes #11095