### PR TITLE
TST: Reduce flakiness in lsmr test

### DIFF
--- a/scipy/sparse/linalg/isolve/tests/test_lsmr.py
+++ b/scipy/sparse/linalg/isolve/tests/test_lsmr.py
@@ -18,7 +18,7 @@ Dept of MS&E, Stanford University.
 
 from numpy import array, arange, eye, zeros, ones, sqrt, transpose, hstack
 from numpy.linalg import norm
-from numpy.testing import (assert_almost_equal,
+from numpy.testing import (assert_allclose, assert_almost_equal,
                            assert_array_almost_equal)
 
 from scipy.sparse import coo_matrix
@@ -97,15 +97,34 @@ class TestLSMR:
 
     def testInitialization(self):
         # Test that the default setting is not modified
-        x_ref = lsmr(G, b)[0]
+        x_ref, _, itn_ref, normr_ref, *_ = lsmr(G, b)
+        assert_allclose(norm(b - G@x_ref), normr_ref, atol=1e-6)
+
+        # Test passing zeros yields similiar result
         x0 = zeros(b.shape)
         x = lsmr(G, b, x0=x0)[0]
-        assert_array_almost_equal(x_ref, x)
+        assert_array_almost_equal(x, x_ref)
 
         # Test warm-start with single iteration
         x0 = lsmr(G, b, maxiter=1)[0]
-        x = lsmr(G, b, x0=x0)[0]
-        assert_array_almost_equal(x_ref, x)
+
+        x, _, itn, normr, *_ = lsmr(G, b, x0=x0)
+        assert_allclose(norm(b - G@x), normr, atol=1e-6)
+
+        # NOTE(gh-12139): This doesn't always converge to the same value as
+        # ref because error estimates will be slightly different when calculated
+        # from zeros vs x0 as a result only compare norm and itn (not x).
+
+        # x generally converges 1 iteration faster because it started at x0.
+        # itn == itn_ref means that lsmr(x0) took an extra iteration see above.
+        # -1 is technically possible but is rare (1 in 100000) so it's more
+        # likely to be an error elsewhere.
+        assert itn - itn_ref in (0, 1)
+
+        # If an extra iteration is performed normr may be 0, while normr_ref
+        # may be much larger.
+        assert normr < normr_ref * (1 + 1e-6)
+
 
 class TestLSMRReturns:
     def setup_method(self):


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Fixes https://github.com/scipy/scipy/issues/8163

#### What does this implement/fix?
<!--Please explain your changes.-->

I believe that the comparison of `x` to a subsequent iteration of x is not valid, I can find instances where pointwise `x` and `x_ref` vary by as much as 0.5 while the `norm(b - A*x)` for both is very small. This happens because setting x0=x0 doesn't results in exact the same estimates which leads the 2nd call to `lsmr` to run one iteration longer about 1 in 3000 tests and one iteration less 1 in 100,000 times.

#### Additional information
<!--Any additional information you think is important.-->
