### PR TITLE
TST: stats: add kstwo, ksone to slow tests.

### DIFF
--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -44,8 +44,8 @@ distcont_extra = [
 ]
 
 
-distslow = ['kappa4', 'gausshyper', 'recipinvgauss', 'genexpon',
-            'vonmises', 'vonmises_line', 'cosine', 'invweibull',
+distslow = ['kstwo', 'ksone', 'kappa4', 'gausshyper', 'recipinvgauss',
+            'genexpon', 'vonmises', 'vonmises_line', 'cosine', 'invweibull',
             'powerlognorm', 'johnsonsu', 'kstwobign']
 # distslow are sorted by speed (very slow to slow)
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3003,6 +3003,7 @@ class TestKSTwoSamples(object):
         self._testOne(data2, data2-0.5, 'greater', 0.0/3, 1.0)
         self._testOne(data2, data2-0.5, 'less', 1.0/3, 0.75)
 
+    @pytest.mark.slow
     def testMiddlingBoth(self):
         # 500, 600
         n1, n2 = 500, 600
@@ -3022,6 +3023,7 @@ class TestKSTwoSamples(object):
             self._testOne(x, y, 'less', 500.0 / n1 / n2, 0.9968735843165021, mode='exact')
             _check_warnings(w, RuntimeWarning, 1)
 
+    @pytest.mark.slow
     def testMediumBoth(self):
         # 1000, 1100
         n1, n2 = 1000, 1100
@@ -3097,6 +3099,7 @@ class TestKSTwoSamples(object):
         res = stats.ks_2samp([1, 2], [3])
         check_named_results(res, attributes)
 
+    @pytest.mark.slow
     def test_some_code_paths(self):
         # Check that some code paths are executed
         from scipy.stats.stats import _count_paths_outside_method, _compute_prob_inside_method
@@ -5270,6 +5273,7 @@ class TestMGCStat(object):
         assert_approx_equal(stat, 0.97, significant=1)
         assert_approx_equal(pvalue, 0.001, significant=1)
 
+    @pytest.mark.slow
     def test_random_state(self):
         # generate x and y
         x, y = self._simulations(samps=100, dims=1, sim_type="linear")


### PR DESCRIPTION
This speeds up ``stats.test()`` by almost 50% (60 sec to 31 sec)
when running locally. The `kstwo` test is also the single slowest test
on CI, see gh-12132.

Output before this commit:
```
========================================================= slowest 40 test durations =========================================================
17.48s call     tests/test_continuous_basic.py::test_cont_basic[kstwo-arg59]
5.02s call     tests/test_stats.py::TestMGCStat::test_random_state
3.46s call     tests/test_stats.py::TestMGCStat::test_workers
3.17s call     tests/test_continuous_basic.py::test_cont_basic[ksone-arg58]
1.84s call     tests/test_stats.py::TestKSTwoSamples::testMediumBoth
1.71s call     tests/test_stats.py::TestKSTwoSamples::testMiddlingBoth
1.34s call     tests/test_continuous_basic.py::test_cont_basic[norminvgauss-arg78]
1.23s call     tests/test_mstats_basic.py::TestCorr::test_kendalltau
1.03s call     tests/test_stats.py::TestKSTwoSamples::test_some_code_paths
0.79s call     tests/test_continuous_basic.py::test_cont_basic[ncx2-arg76]
0.72s call     tests/test_continuous_basic.py::test_cont_basic[geninvgauss-arg35]
0.59s call     tests/test_continuous_basic.py::test_cont_basic[skewnorm-arg90]
0.50s call     tests/test_continuous_basic.py::test_cont_basic[burr-arg7]
0.47s call     tests/test_continuous_basic.py::test_cont_basic[exponweib-arg20]
0.42s call     tests/test_continuous_basic.py::test_cont_basic[tukeylambda-arg97]
0.36s call     tests/test_continuous_basic.py::test_cont_basic[pearson3-arg80]
0.33s call     tests/test_mstats_basic.py::TestCompareWithStats::test_kendalltau
0.33s call     tests/test_continuous_basic.py::test_cont_basic[johnsonsb-arg51]
0.31s call     tests/test_continuous_basic.py::test_cont_basic[powernorm-arg83]
0.29s call     tests/test_continuous_basic.py::test_cont_basic[exponpow-arg19]
0.29s call     tests/test_continuous_basic.py::test_cont_basic[crystalball-arg13]
0.27s call     tests/test_continuous_basic.py::test_cont_basic[beta-arg4]
0.27s call     tests/test_continuous_basic.py::test_cont_basic[triang-arg93]
0.26s call     tests/test_continuous_basic.py::test_cont_basic[exponnorm-arg18]
0.26s call     tests/test_continuous_basic.py::test_cont_basic[fatiguelife-arg22]
0.25s call     tests/test_continuous_basic.py::test_cont_basic[burr12-arg8]
0.25s call     tests/test_continuous_basic.py::test_cont_basic[gengamma-arg33]
0.25s call     tests/test_continuous_basic.py::test_cont_basic[betaprime-arg5]
0.23s call     tests/test_continuous_basic.py::test_cont_basic[halfgennorm-arg38]
0.22s call     tests/test_continuous_basic.py::test_cont_basic[genhalflogistic-arg34]
0.22s call     tests/test_continuous_basic.py::test_cont_basic[f-arg21]
0.19s call     tests/test_stats.py::TestFOneWay::test_nist
0.19s call     tests/test_continuous_basic.py::test_cont_basic[chi-arg10]
0.19s call     tests/test_continuous_basic.py::test_cont_basic[invgauss-arg49]
0.19s call     tests/test_continuous_basic.py::test_cont_basic[nct-arg75]
0.18s call     tests/test_continuous_basic.py::test_cont_basic[genpareto-arg39]
0.18s call     tests/test_multivariate.py::TestMultivariateNormal::test_broadcasting
0.18s call     tests/test_distributions.py::TestLevyStable::test_pdf_alpha_equals_one_beta_non_zero
0.16s call     tests/test_distributions.py::TestSkewNorm::test_moments
0.16s call     tests/test_continuous_basic.py::test_cont_basic[gompertz-arg41]
```

I'm leaving `TestMGCStat::test_workers` as the only test that takes >1.5 sec, to not make test coverage for `MGC` too low.