### PR TITLE
Support 64-bit integer size in Fitpack

### DIFF
--- a/scipy/_build_utils/_fortran.py
+++ b/scipy/_build_utils/_fortran.py
@@ -9,7 +9,7 @@ import numpy as np
 __all__ = ['needs_g77_abi_wrapper', 'get_g77_abi_wrappers',
            'gfortran_legacy_flag_hook', 'blas_ilp64_pre_build_hook',
            'get_f2py_int64_options', 'generic_pre_build_hook',
-           'write_file_content']
+           'write_file_content', 'ilp64_pre_build_hook']
 
 
 def uses_mkl(info):
@@ -97,6 +97,18 @@ def get_f2py_int64_options():
     write_file_content(f2cmap_fn, text)
 
     return ['--f2cmap', f2cmap_fn]
+
+
+def ilp64_pre_build_hook(cmd, ext):
+    """
+    Pre-build hook for adding Fortran compiler flags that change
+    default integer size to 64-bit.
+    """
+    fcompiler_flags = {
+        'gnu95': ['-fdefault-integer-8'],
+    }
+    return generic_pre_build_hook(cmd, ext, fcompiler_flags=fcompiler_flags,
+                                  source_fnpart="_ilp64")
 
 
 def blas_ilp64_pre_build_hook(blas_info):

--- a/scipy/interpolate/_fitpack_impl.py
+++ b/scipy/interpolate/_fitpack_impl.py
@@ -28,7 +28,7 @@ import warnings
 import numpy as np
 from . import _fitpack
 from numpy import (atleast_1d, array, ones, zeros, sqrt, ravel, transpose,
-                   empty, iinfo, intc, asarray)
+                   empty, iinfo, asarray)
 
 # Try to replace _fitpack interface with
 #  f2py-generated version
@@ -38,15 +38,15 @@ from . import dfitpack
 dfitpack_int = dfitpack.types.intvar.dtype
 
 
-def _intc_overflow(x, msg=None):
-    """Cast the value to an intc and raise an OverflowError if the value
+def _int_overflow(x, msg=None):
+    """Cast the value to an dfitpack_int and raise an OverflowError if the value
     cannot fit.
     """
-    if x > iinfo(intc).max:
+    if x > iinfo(dfitpack_int).max:
         if msg is None:
-            msg = '%r cannot fit into an intc' % x
+            msg = '%r cannot fit into an %r' % (x, dfitpack_int)
         raise OverflowError(msg)
-    return intc(x)
+    return dfitpack_int.type(x)
 
 
 _iermess = {
@@ -100,7 +100,7 @@ _iermess2 = {
 }
 
 _parcur_cache = {'t': array([], float), 'wrk': array([], float),
-                 'iwrk': array([], intc), 'u': array([], float),
+                 'iwrk': array([], dfitpack_int), 'u': array([], float),
                  'ub': 0, 'ue': 1}
 
 
@@ -215,7 +215,7 @@ def splprep(x, w=None, u=None, ub=None, ue=None, k=3, task=0, s=None, t=None,
     """
     if task <= 0:
         _parcur_cache = {'t': array([], float), 'wrk': array([], float),
-                         'iwrk': array([], intc), 'u': array([], float),
+                         'iwrk': array([], dfitpack_int), 'u': array([], float),
                          'ub': 0, 'ue': 1}
     x = atleast_1d(x)
     idim, m = x.shape
@@ -796,7 +796,7 @@ def spalde(x, tck):
 
 
 _surfit_cache = {'tx': array([], float), 'ty': array([], float),
-                 'wrk': array([], float), 'iwrk': array([], intc)}
+                 'wrk': array([], float), 'iwrk': array([], dfitpack_int)}
 
 
 def bisplrep(x, y, z, w=None, xb=None, xe=None, yb=None, ye=None,
@@ -951,10 +951,10 @@ def bisplrep(x, y, z, w=None, xb=None, xe=None, yb=None, ye=None,
     if bx > by:
         b1, b2 = by, by + u - kx
     msg = "Too many data points to interpolate"
-    lwrk1 = _intc_overflow(u*v*(2 + b1 + b2) +
-                           2*(u + v + km*(m + ne) + ne - kx - ky) + b2 + 1,
-                           msg=msg)
-    lwrk2 = _intc_overflow(u*v*(b2 + 1) + b2, msg=msg)
+    lwrk1 = _int_overflow(u*v*(2 + b1 + b2) +
+                          2*(u + v + km*(m + ne) + ne - kx - ky) + b2 + 1,
+                          msg=msg)
+    lwrk2 = _int_overflow(u*v*(b2 + 1) + b2, msg=msg)
     tx, ty, c, o = _fitpack._surfit(x, y, z, w, xb, xe, yb, ye, kx, ky,
                                     task, s, eps, tx, ty, nxest, nyest,
                                     wrk, lwrk1, lwrk2)

--- a/scipy/interpolate/_fitpack_impl.py
+++ b/scipy/interpolate/_fitpack_impl.py
@@ -35,6 +35,9 @@ from numpy import (atleast_1d, array, ones, zeros, sqrt, ravel, transpose,
 from . import dfitpack
 
 
+dfitpack_int = dfitpack.types.intvar.dtype
+
+
 def _intc_overflow(x, msg=None):
     """Cast the value to an intc and raise an OverflowError if the value
     cannot fit.
@@ -310,7 +313,7 @@ def splprep(x, w=None, u=None, ub=None, ue=None, k=3, task=0, s=None, t=None,
 
 
 _curfit_cache = {'t': array([], float), 'wrk': array([], float),
-                 'iwrk': array([], intc)}
+                 'iwrk': array([], dfitpack_int)}
 
 
 def splrep(x, y, w=None, xb=None, xe=None, k=3, task=0, s=None, t=None,
@@ -487,7 +490,7 @@ def splrep(x, y, w=None, xb=None, xe=None, k=3, task=0, s=None, t=None,
             _curfit_cache['wrk'] = empty((m*(k + 1) + nest*(8 + 5*k),), float)
         else:
             _curfit_cache['wrk'] = empty((m*(k + 1) + nest*(7 + 3*k),), float)
-        _curfit_cache['iwrk'] = empty((nest,), intc)
+        _curfit_cache['iwrk'] = empty((nest,), dfitpack_int)
     try:
         t = _curfit_cache['t']
         wrk = _curfit_cache['wrk']

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -28,6 +28,9 @@ from . import fitpack
 from . import dfitpack
 
 
+dfitpack_int = dfitpack.types.intvar.dtype
+
+
 # ############### Univariate spline ####################
 
 _curfit_messages = {1: """
@@ -1732,8 +1735,8 @@ class RectSphereBivariateSpline(SphereBivariateSpline):
 
     def __init__(self, u, v, r, s=0., pole_continuity=False, pole_values=None,
                  pole_exact=False, pole_flat=False):
-        iopt = np.array([0, 0, 0], dtype=int)
-        ider = np.array([-1, 0, -1, 0], dtype=int)
+        iopt = np.array([0, 0, 0], dtype=dfitpack_int)
+        ider = np.array([-1, 0, -1, 0], dtype=dfitpack_int)
         if pole_values is None:
             pole_values = (None, None)
         elif isinstance(pole_values, (float, np.float32, np.float64)):

--- a/scipy/interpolate/setup.py
+++ b/scipy/interpolate/setup.py
@@ -16,20 +16,16 @@ def configuration(parent_package='',top_path=None):
         pre_build_hook = ilp64_pre_build_hook
         f2py_options = get_f2py_int64_options()
         define_macros = [("HAVE_ILP64", None)]
-        fitpack64_name = "fitpack64"
     else:
         pre_build_hook = None
         f2py_options = None
         define_macros = []
-        fitpack64_name = "fitpack"
 
     config = Configuration('interpolate', parent_package, top_path)
 
     fitpack_src = [join('fitpack', '*.f')]
-    config.add_library('fitpack', sources=fitpack_src)
-    if fitpack64_name != "fitpack":
-        config.add_library('fitpack64', sources=fitpack_src,
-                           _pre_build_hook=pre_build_hook)
+    config.add_library('fitpack', sources=fitpack_src,
+                       _pre_build_hook=pre_build_hook)
 
     config.add_extension('interpnd',
                          sources=['interpnd.c'])
@@ -44,13 +40,14 @@ def configuration(parent_package='',top_path=None):
     config.add_extension('_fitpack',
                          sources=['src/_fitpackmodule.c'],
                          libraries=['fitpack'],
+                         define_macros=define_macros,
                          depends=(['src/__fitpack.h']
                                   + fitpack_src)
                          )
 
     config.add_extension('dfitpack',
                          sources=['src/fitpack.pyf'],
-                         libraries=[fitpack64_name],
+                         libraries=['fitpack'],
                          define_macros=define_macros,
                          depends=fitpack_src,
                          f2py_options=f2py_options

--- a/scipy/interpolate/setup.py
+++ b/scipy/interpolate/setup.py
@@ -3,11 +3,33 @@ from os.path import join
 
 def configuration(parent_package='',top_path=None):
     from numpy.distutils.misc_util import Configuration
+    from scipy._build_utils import (get_f2py_int64_options,
+                                    ilp64_pre_build_hook,
+                                    uses_blas64)
+
+    if uses_blas64():
+        # TODO: Note that fitpack does not use BLAS/LAPACK.
+        # The reason why we use 64-bit ints only in this case
+        # is because scipy._build_utils knows the 64-bit int
+        # flags for too few Fortran compilers, so we cannot turn
+        # this on by default.
+        pre_build_hook = ilp64_pre_build_hook
+        f2py_options = get_f2py_int64_options()
+        define_macros = [("HAVE_ILP64", None)]
+        fitpack64_name = "fitpack64"
+    else:
+        pre_build_hook = None
+        f2py_options = None
+        define_macros = []
+        fitpack64_name = "fitpack"
 
     config = Configuration('interpolate', parent_package, top_path)
 
     fitpack_src = [join('fitpack', '*.f')]
     config.add_library('fitpack', sources=fitpack_src)
+    if fitpack64_name != "fitpack":
+        config.add_library('fitpack64', sources=fitpack_src,
+                           _pre_build_hook=pre_build_hook)
 
     config.add_extension('interpnd',
                          sources=['interpnd.c'])
@@ -17,20 +39,21 @@ def configuration(parent_package='',top_path=None):
 
     config.add_extension('_bspl',
                          sources=['_bspl.c'],
-                         libraries=['fitpack'],
-                         depends=['src/__fitpack.h'] + fitpack_src)
+                         depends=['src/__fitpack.h'])
 
     config.add_extension('_fitpack',
                          sources=['src/_fitpackmodule.c'],
                          libraries=['fitpack'],
-                         depends=(['src/__fitpack.h','src/multipack.h']
+                         depends=(['src/__fitpack.h']
                                   + fitpack_src)
                          )
 
     config.add_extension('dfitpack',
                          sources=['src/fitpack.pyf'],
-                         libraries=['fitpack'],
+                         libraries=[fitpack64_name],
+                         define_macros=define_macros,
                          depends=fitpack_src,
+                         f2py_options=f2py_options
                          )
 
     config.add_data_dir('tests')

--- a/scipy/interpolate/src/_fitpackmodule.c
+++ b/scipy/interpolate/src/_fitpackmodule.c
@@ -11,6 +11,34 @@
 static PyObject *fitpack_error;
 #include "__fitpack.h"
 
+#ifdef HAVE_ILP64
+
+#define F_INT npy_int64
+#define F_INT_NPY NPY_INT64
+
+#if NPY_BITSOF_SHORT == 64
+#define F_INT_PYFMT   "h"
+#elif NPY_BITSOF_INT == 64
+#define F_INT_PYFMT   "i"
+#elif NPY_BITSOF_LONG == 64
+#define F_INT_PYFMT   "l"
+#elif NPY_BITSOF_LONGLONG == 64
+#define F_INT_PYFMT   "L"
+#else
+#error No compatible 64-bit integer size. \
+       Please contact NumPy maintainers and give detailed information about your \
+       compiler and platform, or set NPY_USE_BLAS64_=0
+#endif
+
+#else
+
+#define F_INT int
+#define F_INT_NPY NPY_INT
+#define F_INT_PYFMT   "i"
+
+#endif
+
+
 /*
  * Functions moved verbatim from __fitpack.h
  */
@@ -94,36 +122,36 @@ static PyObject *fitpack_error;
 	#endif
 #endif
 
-void CURFIT(int*,int*,double*,double*,double*,double*,
-        double*,int*,double*,int*,int*,double*,double*,
-        double*,double*,int*,int*,int*);
-void PERCUR(int*,int*,double*,double*,double*,int*,
-        double*,int*,int*,double*,double*,double*,
-        double*,int*,int*,int*);
-void SPALDE(double*,int*,double*,int*,double*,double*,int*);
-void SPLDER(double*,int*,double*,int*,int*,double*,
-        double*,int*,int*,double*,int*);
-void SPLEV(double*,int*,double*,int*,double*,double*,int*,int*,int*);
-double SPLINT(double*,int*,double*,int*,double*,double*,double*);
-void SPROOT(double*,int*,double*,double*,int*,int*,int*);
-void PARCUR(int*,int*,int*,int*,double*,int*,double*,
-        double*,double*,double*,int*,double*,int*,int*,
-        double*,int*,double*,double*,double*,int*,int*,int*);
-void CLOCUR(int*,int*,int*,int*,double*,int*,double*,
-        double*,int*,double*,int*,int*,double*,int*,
-        double*,double*,double*,int*,int*,int*);
-void SURFIT(int*,int*,double*,double*,double*,double*,
-        double*,double*,double*,double*,int*,int*,double*,
-        int*,int*,int*,double*,int*,double*,int*,double*,
-        double*,double*,double*,int*,double*,int*,int*,int*,int*);
-void BISPEV(double*,int*,double*,int*,double*,int*,int*,
-        double*,int*,double*,int*,double*,double*,int*,
-        int*,int*,int*);
-void PARDER(double*,int*,double*,int*,double*,int*,int*,
-        int*,int*,double*,int*,double*,int*,double*,
-        double*,int*,int*,int*,int*);
-void INSERT(int*,double*,int*,double*,int*,double*,double*,
-        int*,double*,int*,int*);
+void CURFIT(F_INT*,F_INT*,double*,double*,double*,double*,
+        double*,F_INT*,double*,F_INT*,F_INT*,double*,double*,
+        double*,double*,F_INT*,F_INT*,F_INT*);
+void PERCUR(F_INT*,F_INT*,double*,double*,double*,F_INT*,
+        double*,F_INT*,F_INT*,double*,double*,double*,
+        double*,F_INT*,F_INT*,F_INT*);
+void SPALDE(double*,F_INT*,double*,F_INT*,double*,double*,F_INT*);
+void SPLDER(double*,F_INT*,double*,F_INT*,F_INT*,double*,
+        double*,F_INT*,F_INT*,double*,F_INT*);
+void SPLEV(double*,F_INT*,double*,F_INT*,double*,double*,F_INT*,F_INT*,F_INT*);
+double SPLINT(double*,F_INT*,double*,F_INT*,double*,double*,double*);
+void SPROOT(double*,F_INT*,double*,double*,F_INT*,F_INT*,F_INT*);
+void PARCUR(F_INT*,F_INT*,F_INT*,F_INT*,double*,F_INT*,double*,
+        double*,double*,double*,F_INT*,double*,F_INT*,F_INT*,
+        double*,F_INT*,double*,double*,double*,F_INT*,F_INT*,F_INT*);
+void CLOCUR(F_INT*,F_INT*,F_INT*,F_INT*,double*,F_INT*,double*,
+        double*,F_INT*,double*,F_INT*,F_INT*,double*,F_INT*,
+        double*,double*,double*,F_INT*,F_INT*,F_INT*);
+void SURFIT(F_INT*,F_INT*,double*,double*,double*,double*,
+        double*,double*,double*,double*,F_INT*,F_INT*,double*,
+        F_INT*,F_INT*,F_INT*,double*,F_INT*,double*,F_INT*,double*,
+        double*,double*,double*,F_INT*,double*,F_INT*,F_INT*,F_INT*,F_INT*);
+void BISPEV(double*,F_INT*,double*,F_INT*,double*,F_INT*,F_INT*,
+        double*,F_INT*,double*,F_INT*,double*,double*,F_INT*,
+        F_INT*,F_INT*,F_INT*);
+void PARDER(double*,F_INT*,double*,F_INT*,double*,F_INT*,F_INT*,
+        F_INT*,F_INT*,double*,F_INT*,double*,F_INT*,double*,
+        double*,F_INT*,F_INT*,F_INT*,F_INT*);
+void INSERT(F_INT*,double*,F_INT*,double*,F_INT*,double*,double*,
+        F_INT*,double*,F_INT*,F_INT*);
 
 /* Note that curev, cualde need no interface. */
 
@@ -131,15 +159,15 @@ static char doc_bispev[] = " [z,ier] = _bispev(tx,ty,c,kx,ky,x,y,nux,nuy)";
 static PyObject *
 fitpack_bispev(PyObject *dummy, PyObject *args)
 {
-    int nx, ny, kx, ky, mx, my, lwrk, *iwrk, kwrk, ier, lwa, nux, nuy;
+    F_INT nx, ny, kx, ky, mx, my, lwrk, *iwrk, kwrk, ier, lwa, nux, nuy;
     npy_intp mxy;
     double *tx, *ty, *c, *x, *y, *z, *wrk, *wa = NULL;
     PyArrayObject *ap_x = NULL, *ap_y = NULL, *ap_z = NULL, *ap_tx = NULL;
     PyArrayObject *ap_ty = NULL, *ap_c = NULL;
     PyObject *x_py = NULL, *y_py = NULL, *c_py = NULL, *tx_py = NULL, *ty_py = NULL;
 
-    if (!PyArg_ParseTuple(args, "OOOiiOOii",&tx_py,&ty_py,&c_py,&kx,&ky,
-                &x_py,&y_py,&nux,&nuy)) {
+    if (!PyArg_ParseTuple(args, ("OOO" F_INT_PYFMT F_INT_PYFMT "OO" F_INT_PYFMT F_INT_PYFMT),
+                          &tx_py,&ty_py,&c_py,&kx,&ky,&x_py,&y_py,&nux,&nuy)) {
         return NULL;
     }
     ap_x = (PyArrayObject *)PyArray_ContiguousFromObject(x_py, NPY_DOUBLE, 0, 1);
@@ -223,8 +251,8 @@ static char doc_surfit[] = " [tx,ty,c,o] = _surfit(x, y, z, w, xb, xe, yb, ye,"\
 static PyObject *
 fitpack_surfit(PyObject *dummy, PyObject *args)
 {
-    int iopt, m, kx, ky, nxest, nyest, lwrk1, lwrk2, *iwrk, kwrk, ier;
-    int lwa, nxo, nyo, i, lcest, nmax, nx, ny, lc;
+    F_INT iopt, m, kx, ky, nxest, nyest, lwrk1, lwrk2, *iwrk, kwrk, ier;
+    F_INT lwa, nxo, nyo, i, lcest, nmax, nx, ny, lc;
     npy_intp dims[1];
     double *x, *y, *z, *w, xb, xe, yb, ye, s, *tx, *ty, *c, fp;
     double *wrk1, *wrk2, *wa = NULL, eps;
@@ -234,7 +262,9 @@ fitpack_surfit(PyObject *dummy, PyObject *args)
     PyObject *tx_py = NULL, *ty_py = NULL, *wrk_py = NULL;
 
     nx = ny = ier = nxo = nyo = 0;
-    if (!PyArg_ParseTuple(args, "OOOOddddiiiddOOiiOii",
+    if (!PyArg_ParseTuple(args, ("OOOOdddd" F_INT_PYFMT F_INT_PYFMT F_INT_PYFMT
+                                 "ddOO" F_INT_PYFMT F_INT_PYFMT "O"
+                                 F_INT_PYFMT F_INT_PYFMT),
                 &x_py, &y_py, &z_py, &w_py, &xb, &xe, &yb, &ye,
                 &kx, &ky, &iopt, &s, &eps, &tx_py, &ty_py, &nxest,
                 &nyest, &wrk_py, &lwrk1, &lwrk2)) {
@@ -245,7 +275,7 @@ fitpack_surfit(PyObject *dummy, PyObject *args)
     ap_z = (PyArrayObject *)PyArray_ContiguousFromObject(z_py, NPY_DOUBLE, 0, 1);
     ap_w = (PyArrayObject *)PyArray_ContiguousFromObject(w_py, NPY_DOUBLE, 0, 1);
     ap_wrk=(PyArrayObject *)PyArray_ContiguousFromObject(wrk_py, NPY_DOUBLE, 0, 1);
-    /*ap_iwrk=(PyArrayObject *)PyArray_ContiguousFromObject(iwrk_py, NPY_INT, 0, 1);*/
+    /*ap_iwrk=(PyArrayObject *)PyArray_ContiguousFromObject(iwrk_py, F_INT_NPY, 0, 1);*/
     if (ap_x == NULL
             || ap_y == NULL
             || ap_z == NULL
@@ -278,7 +308,7 @@ fitpack_surfit(PyObject *dummy, PyObject *args)
     ty = tx + nmax;
     c = ty + nmax;
     wrk1 = c + lcest;
-    iwrk = (int *)(wrk1 + lwrk1);
+    iwrk = (F_INT *)(wrk1 + lwrk1);
     wrk2 = ((double *)iwrk) + kwrk;
     if (iopt) {
         ap_tx = (PyArrayObject *)PyArray_ContiguousFromObject(tx_py, NPY_DOUBLE, 0, 1);
@@ -336,7 +366,7 @@ fitpack_surfit(PyObject *dummy, PyObject *args)
         if (ap_wrk == NULL) {
             goto fail;
         }
-        /*ap_iwrk = (PyArrayObject *)PyArray_SimpleNew(1,&n,NPY_INT);*/
+        /*ap_iwrk = (PyArrayObject *)PyArray_SimpleNew(1,&n,F_INT_NPY);*/
     }
     if (ap_wrk->dimensions[0] < lc) {
         Py_XDECREF(ap_wrk);
@@ -383,8 +413,8 @@ static char doc_parcur[] = " [t,c,o] = _parcur(x,w,u,ub,ue,k,iopt,ipar,s,t,nest,
 static PyObject *
 fitpack_parcur(PyObject *dummy, PyObject *args)
 {
-    int k, iopt, ipar, nest, *iwrk, idim, m, mx, no=0, nc, ier, lwa, lwrk, i, per;
-    int n=0,  lc;
+    F_INT k, iopt, ipar, nest, *iwrk, idim, m, mx, no=0, nc, ier, lwa, lwrk, i, per;
+    F_INT n=0,  lc;
     npy_intp dims[1];
     double *x, *w, *u, *c, *t, *wrk, *wa=NULL, ub, ue, fp, s;
     PyObject *x_py = NULL, *u_py = NULL, *w_py = NULL, *t_py = NULL;
@@ -392,15 +422,17 @@ fitpack_parcur(PyObject *dummy, PyObject *args)
     PyArrayObject *ap_x = NULL, *ap_u = NULL, *ap_w = NULL, *ap_t = NULL, *ap_c = NULL;
     PyArrayObject *ap_wrk = NULL, *ap_iwrk = NULL;
 
-    if (!PyArg_ParseTuple(args,  "OOOddiiidOiOOi", &x_py, &w_py, &u_py, &ub, &ue,
-                &k, &iopt, &ipar, &s, &t_py, &nest, &wrk_py, &iwrk_py, &per)) {
+    if (!PyArg_ParseTuple(args, ("OOOdd" F_INT_PYFMT F_INT_PYFMT F_INT_PYFMT
+                                 "dO" F_INT_PYFMT "OO" F_INT_PYFMT),
+                          &x_py, &w_py, &u_py, &ub, &ue, &k, &iopt, &ipar,
+                          &s, &t_py, &nest, &wrk_py, &iwrk_py, &per)) {
         return NULL;
     }
     ap_x = (PyArrayObject *)PyArray_ContiguousFromObject(x_py, NPY_DOUBLE, 0, 1);
     ap_u = (PyArrayObject *)PyArray_ContiguousFromObject(u_py, NPY_DOUBLE, 0, 1);
     ap_w = (PyArrayObject *)PyArray_ContiguousFromObject(w_py, NPY_DOUBLE, 0, 1);
     ap_wrk=(PyArrayObject *)PyArray_ContiguousFromObject(wrk_py, NPY_DOUBLE, 0, 1);
-    ap_iwrk=(PyArrayObject *)PyArray_ContiguousFromObject(iwrk_py, NPY_INT, 0, 1);
+    ap_iwrk=(PyArrayObject *)PyArray_ContiguousFromObject(iwrk_py, F_INT_NPY, 0, 1);
     if (ap_x == NULL
             || ap_u == NULL
             || ap_w == NULL
@@ -429,7 +461,7 @@ fitpack_parcur(PyObject *dummy, PyObject *args)
     t = wa;
     c = t + nest;
     wrk = c + nc;
-    iwrk = (int *)(wrk + lwrk);
+    iwrk = (F_INT *)(wrk + lwrk);
     if (iopt) {
         ap_t=(PyArrayObject *)PyArray_ContiguousFromObject(t_py, NPY_DOUBLE, 0, 1);
         if (ap_t == NULL) {
@@ -442,7 +474,7 @@ fitpack_parcur(PyObject *dummy, PyObject *args)
     }
     if (iopt == 1) {
         memcpy(wrk, ap_wrk->data, n*sizeof(double));
-        memcpy(iwrk, ap_iwrk->data, n*sizeof(int));
+        memcpy(iwrk, ap_iwrk->data, n*sizeof(F_INT));
     }
     if (per) {
         CLOCUR(&iopt, &ipar, &idim, &m, u, &mx, x, w, &k, &s, &nest,
@@ -478,7 +510,7 @@ fitpack_parcur(PyObject *dummy, PyObject *args)
         if (ap_wrk == NULL) {
             goto fail;
         }
-        ap_iwrk = (PyArrayObject *)PyArray_SimpleNew(1, dims, NPY_INT);
+        ap_iwrk = (PyArrayObject *)PyArray_SimpleNew(1, dims, F_INT_NPY);
         if (ap_iwrk == NULL) {
             goto fail;
         }
@@ -487,11 +519,11 @@ fitpack_parcur(PyObject *dummy, PyObject *args)
     for (i = 0; i < idim; i++)
         memcpy((double *)ap_c->data + i*(n - k - 1), c + i*n, (n - k - 1)*sizeof(double));
     memcpy(ap_wrk->data, wrk, n*sizeof(double));
-    memcpy(ap_iwrk->data, iwrk, n*sizeof(int));
+    memcpy(ap_iwrk->data, iwrk, n*sizeof(F_INT));
     free(wa);
     Py_DECREF(ap_x);
     Py_DECREF(ap_w);
-    return Py_BuildValue("NN{s:N,s:d,s:d,s:N,s:N,s:i,s:d}", PyArray_Return(ap_t),
+    return Py_BuildValue(("NN{s:N,s:d,s:d,s:N,s:N,s:" F_INT_PYFMT ",s:d}"), PyArray_Return(ap_t),
             PyArray_Return(ap_c), "u", PyArray_Return(ap_u), "ub", ub, "ue", ue,
             "wrk", PyArray_Return(ap_wrk), "iwrk", PyArray_Return(ap_iwrk),
             "ier", ier, "fp",fp);
@@ -510,8 +542,8 @@ static char doc_curfit[] = " [t,c,o] = _curfit(x,y,w,xb,xe,k,iopt,s,t,nest,wrk,i
 static PyObject *
 fitpack_curfit(PyObject *dummy, PyObject *args)
 {
-    int iopt, m, k, nest, lwrk, *iwrk, ier, lwa, no=0, per;
-    int n, lc;
+    F_INT iopt, m, k, nest, lwrk, *iwrk, ier, lwa, no=0, per;
+    F_INT n, lc;
     npy_intp dims[1];
     double *x, *y, *w, xb, xe, s, *t, *c, fp, *wrk, *wa = NULL;
     PyArrayObject *ap_x = NULL, *ap_y = NULL, *ap_w = NULL, *ap_t = NULL, *ap_c = NULL;
@@ -519,15 +551,17 @@ fitpack_curfit(PyObject *dummy, PyObject *args)
     PyObject *x_py = NULL, *y_py = NULL, *w_py = NULL, *t_py = NULL;
     PyObject *wrk_py=NULL, *iwrk_py=NULL;
 
-    if (!PyArg_ParseTuple(args, "OOOddiidOiOOi", &x_py, &y_py, &w_py, &xb, &xe,
-                &k, &iopt, &s, &t_py, &nest, &wrk_py, &iwrk_py, &per)) {
+    if (!PyArg_ParseTuple(args, ("OOOdd" F_INT_PYFMT F_INT_PYFMT
+                                 "dO" F_INT_PYFMT "OO" F_INT_PYFMT),
+                          &x_py, &y_py, &w_py, &xb, &xe, &k, &iopt,
+                          &s, &t_py, &nest, &wrk_py, &iwrk_py, &per)) {
         return NULL;
     }
     ap_x = (PyArrayObject *)PyArray_ContiguousFromObject(x_py, NPY_DOUBLE, 0, 1);
     ap_y = (PyArrayObject *)PyArray_ContiguousFromObject(y_py, NPY_DOUBLE, 0, 1);
     ap_w = (PyArrayObject *)PyArray_ContiguousFromObject(w_py, NPY_DOUBLE, 0, 1);
     ap_wrk = (PyArrayObject *)PyArray_ContiguousFromObject(wrk_py, NPY_DOUBLE, 0, 1);
-    ap_iwrk = (PyArrayObject *)PyArray_ContiguousFromObject(iwrk_py, NPY_INT, 0, 1);
+    ap_iwrk = (PyArrayObject *)PyArray_ContiguousFromObject(iwrk_py, F_INT_NPY, 0, 1);
     if (ap_x == NULL
             || ap_y == NULL
             || ap_w == NULL
@@ -553,7 +587,7 @@ fitpack_curfit(PyObject *dummy, PyObject *args)
     t = wa;
     c = t + nest;
     wrk = c + nest;
-    iwrk = (int *)(wrk + lwrk);
+    iwrk = (F_INT *)(wrk + lwrk);
     if (iopt) {
         ap_t = (PyArrayObject *)PyArray_ContiguousFromObject(t_py, NPY_DOUBLE, 0, 1);
         if (ap_t == NULL) {
@@ -564,7 +598,7 @@ fitpack_curfit(PyObject *dummy, PyObject *args)
     }
     if (iopt == 1) {
         memcpy(wrk, ap_wrk->data, n*sizeof(double));
-        memcpy(iwrk, ap_iwrk->data, n*sizeof(int));
+        memcpy(iwrk, ap_iwrk->data, n*sizeof(F_INT));
     }
     if (per)
         PERCUR(&iopt, &m, x, y, w, &k, &s, &nest, &n, t, c, &fp, wrk,
@@ -595,7 +629,7 @@ fitpack_curfit(PyObject *dummy, PyObject *args)
         Py_XDECREF(ap_iwrk);
         dims[0] = n;
         ap_wrk = (PyArrayObject *)PyArray_SimpleNew(1, dims, NPY_DOUBLE);
-        ap_iwrk = (PyArrayObject *)PyArray_SimpleNew(1, dims, NPY_INT);
+        ap_iwrk = (PyArrayObject *)PyArray_SimpleNew(1, dims, F_INT_NPY);
         if (ap_wrk == NULL || ap_iwrk == NULL) {
             goto fail;
         }
@@ -603,12 +637,12 @@ fitpack_curfit(PyObject *dummy, PyObject *args)
     memcpy(ap_t->data, t, n*sizeof(double));
     memcpy(ap_c->data, c, lc*sizeof(double));
     memcpy(ap_wrk->data, wrk, n*sizeof(double));
-    memcpy(ap_iwrk->data, iwrk, n*sizeof(int));
+    memcpy(ap_iwrk->data, iwrk, n*sizeof(F_INT));
     free(wa);
     Py_DECREF(ap_x);
     Py_DECREF(ap_y);
     Py_DECREF(ap_w);
-    return Py_BuildValue("NN{s:N,s:N,s:i,s:d}", PyArray_Return(ap_t),
+    return Py_BuildValue(("NN{s:N,s:N,s:" F_INT_PYFMT ",s:d}"), PyArray_Return(ap_t),
             PyArray_Return(ap_c), "wrk", PyArray_Return(ap_wrk),
             "iwrk", PyArray_Return(ap_iwrk), "ier", ier, "fp", fp);
 
@@ -627,13 +661,14 @@ static char doc_spl_[] = " [y,ier] = _spl_(x,nu,t,c,k,e)";
 static PyObject *
 fitpack_spl_(PyObject *dummy, PyObject *args)
 {
-    int n, nu, ier, k, m, e=0;
+    F_INT n, nu, ier, k, m, e=0;
     npy_intp dims[1];
     double *x, *y, *t, *c, *wrk = NULL;
     PyArrayObject *ap_x = NULL, *ap_y = NULL, *ap_t = NULL, *ap_c = NULL;
     PyObject *x_py = NULL, *t_py = NULL, *c_py = NULL;
 
-    if (!PyArg_ParseTuple(args, "OiOOii", &x_py, &nu, &t_py, &c_py, &k, &e)) {
+    if (!PyArg_ParseTuple(args, ("O" F_INT_PYFMT "OO" F_INT_PYFMT F_INT_PYFMT),
+                          &x_py, &nu, &t_py, &c_py, &k, &e)) {
         return NULL;
     }
     ap_x = (PyArrayObject *)PyArray_ContiguousFromObject(x_py, NPY_DOUBLE, 0, 1);
@@ -667,7 +702,7 @@ fitpack_spl_(PyObject *dummy, PyObject *args)
     Py_DECREF(ap_x);
     Py_DECREF(ap_c);
     Py_DECREF(ap_t);
-    return Py_BuildValue("Ni", PyArray_Return(ap_y), ier);
+    return Py_BuildValue(("N" F_INT_PYFMT), PyArray_Return(ap_y), ier);
 
 fail:
     free(wrk);
@@ -681,14 +716,14 @@ static char doc_splint[] = " [aint,wrk] = _splint(t,c,k,a,b)";
 static PyObject *
 fitpack_splint(PyObject *dummy, PyObject *args)
 {
-    int k, n;
+    F_INT k, n;
     npy_intp dims[1];
     double *t, *c, *wrk = NULL, a, b, aint;
     PyArrayObject *ap_t = NULL, *ap_c = NULL;
     PyArrayObject *ap_wrk = NULL;
     PyObject *t_py = NULL, *c_py = NULL;
 
-    if (!PyArg_ParseTuple(args, "OOidd",&t_py,&c_py,&k,&a,&b)) {
+    if (!PyArg_ParseTuple(args, ("OO" F_INT_PYFMT "dd"),&t_py,&c_py,&k,&a,&b)) {
         return NULL;
     }
     ap_t = (PyArrayObject *)PyArray_ContiguousFromObject(t_py, NPY_DOUBLE, 0, 1);
@@ -720,14 +755,15 @@ static char doc_sproot[] = " [z,ier] = _sproot(t,c,k,mest)";
 static PyObject *
 fitpack_sproot(PyObject *dummy, PyObject *args)
 {
-    int n, k, m, mest, ier;
+    F_INT n, k, m, mest, ier;
     npy_intp dims[1];
     double *t, *c, *z = NULL;
     PyArrayObject *ap_t = NULL, *ap_c = NULL;
     PyArrayObject *ap_z = NULL;
     PyObject *t_py = NULL, *c_py = NULL;
 
-    if (!PyArg_ParseTuple(args, "OOii",&t_py,&c_py,&k,&mest)) {
+    if (!PyArg_ParseTuple(args, ("OO" F_INT_PYFMT F_INT_PYFMT),
+                          &t_py,&c_py,&k,&mest)) {
         return NULL;
     }
     ap_t = (PyArrayObject *)PyArray_ContiguousFromObject(t_py, NPY_DOUBLE, 0, 1);
@@ -756,7 +792,7 @@ fitpack_sproot(PyObject *dummy, PyObject *args)
     free(z);
     Py_DECREF(ap_c);
     Py_DECREF(ap_t);
-    return Py_BuildValue("Ni", PyArray_Return(ap_z), ier);
+    return Py_BuildValue(("N" F_INT_PYFMT), PyArray_Return(ap_z), ier);
 
 fail:
     free(z);
@@ -769,13 +805,14 @@ static char doc_spalde[] = " [d,ier] = _spalde(t,c,k,x)";
 static PyObject *
 fitpack_spalde(PyObject *dummy, PyObject *args)
 {
-    int n, k, ier, k1;
+    F_INT n, k, ier, k1;
     npy_intp dims[1];
     double *t, *c, *d = NULL, x;
     PyArrayObject *ap_t = NULL, *ap_c = NULL, *ap_d = NULL;
     PyObject *t_py = NULL, *c_py = NULL;
 
-    if (!PyArg_ParseTuple(args, "OOid",&t_py,&c_py,&k,&x)) {
+    if (!PyArg_ParseTuple(args, ("OO" F_INT_PYFMT "d"),
+                          &t_py,&c_py,&k,&x)) {
         return NULL;
     }
     ap_t = (PyArrayObject *)PyArray_ContiguousFromObject(t_py, NPY_DOUBLE, 0, 1);
@@ -796,7 +833,7 @@ fitpack_spalde(PyObject *dummy, PyObject *args)
     SPALDE(t, &n, c, &k1, &x, d, &ier);
     Py_DECREF(ap_c);
     Py_DECREF(ap_t);
-    return Py_BuildValue("Ni", PyArray_Return(ap_d), ier);
+    return Py_BuildValue(("N" F_INT_PYFMT), PyArray_Return(ap_d), ier);
 
 fail:
     Py_XDECREF(ap_c);
@@ -808,7 +845,7 @@ static char doc_insert[] = " [tt,cc,ier] = _insert(iopt,t,c,k,x,m)";
 static PyObject *
 fitpack_insert(PyObject *dummy, PyObject*args)
 {
-    int iopt, n, nn, k, ier, m, nest;
+    F_INT iopt, n, nn, k, ier, m, nest;
     npy_intp dims[1];
     double x;
     double *t_in, *c_in, *t_out, *c_out, *t_buf = NULL, *c_buf = NULL, *p;
@@ -817,7 +854,8 @@ fitpack_insert(PyObject *dummy, PyObject*args)
     PyObject *t_py = NULL, *c_py = NULL;
     PyObject *ret = NULL;
 
-    if (!PyArg_ParseTuple(args, "iOOidi",&iopt,&t_py,&c_py,&k, &x, &m)) {
+    if (!PyArg_ParseTuple(args,(F_INT_PYFMT "OO" F_INT_PYFMT "d" F_INT_PYFMT),
+                          &iopt,&t_py,&c_py,&k, &x, &m)) {
         return NULL;
     }
     ap_t_in = (PyArrayObject *)PyArray_ContiguousFromObject(t_py, NPY_DOUBLE, 0, 1);
@@ -890,7 +928,7 @@ fitpack_insert(PyObject *dummy, PyObject*args)
     Py_DECREF(ap_t_in);
     free(t_buf);
     free(c_buf);
-    ret = Py_BuildValue("NNi", PyArray_Return(ap_t_out), PyArray_Return(ap_c_out), ier);
+    ret = Py_BuildValue(("NN" F_INT_PYFMT), PyArray_Return(ap_t_out), PyArray_Return(ap_c_out), ier);
     return ret;
 
 fail:

--- a/scipy/interpolate/src/fitpack.pyf
+++ b/scipy/interpolate/src/fitpack.pyf
@@ -13,9 +13,15 @@ python module dfitpack ! in
 
   usercode '''
 
-static double dmax(double* seq,int len) {
+#ifdef HAVE_ILP64
+typedef npy_int64 F_INT;
+#else
+typedef npy_int32 F_INT;
+#endif
+
+static double dmax(double* seq, F_INT len) {
   double val;
-  int i;
+  F_INT i;
   if (len<1)
     return -1e308;
   val = seq[0];
@@ -23,9 +29,9 @@ static double dmax(double* seq,int len) {
     if (seq[i]>val) val = seq[i];
   return val;
 }
-static double dmin(double* seq,int len) {
+static double dmin(double* seq,F_INT len) {
   double val;
-  int i;
+  F_INT i;
   if (len<1)
     return 1e308;
   val = seq[0];
@@ -33,59 +39,59 @@ static double dmin(double* seq,int len) {
     if (seq[i]<val) val = seq[i];
   return val;
 }
-static double calc_b(double* x,int m,double* tx,int nx) {
+static double calc_b(double* x,F_INT m,double* tx,F_INT nx) {
   double val1 = dmin(x,m);
   double val2 = dmin(tx,nx);
   if (val2>val1) return val1;
   val1 = dmax(tx,nx);
   return val2 - (val1-val2)/nx;
 }
-static double calc_e(double* x,int m,double* tx,int nx) {
+static double calc_e(double* x,F_INT m,double* tx,F_INT nx) {
   double val1 = dmax(x,m);
   double val2 = dmax(tx,nx);
   if (val2<val1) return val1;
   val1 = dmin(tx,nx);
   return val2 + (val2-val1)/nx;
 }
-static int imax(int i1,int i2) {
+static F_INT imax(F_INT i1,F_INT i2) {
   return MAX(i1,i2);
 }
 
-static int calc_surfit_lwrk1(int m, int kx, int ky, int nxest, int nyest) {
- int u = nxest-kx-1;
- int v = nyest-ky-1;
- int km = MAX(kx,ky)+1;
- int ne = MAX(nxest,nyest);
- int bx = kx*v+ky+1;
- int by = ky*u+kx+1;
- int b1,b2;
+static F_INT calc_surfit_lwrk1(F_INT m, F_INT kx, F_INT ky, F_INT nxest, F_INT nyest) {
+ F_INT u = nxest-kx-1;
+ F_INT v = nyest-ky-1;
+ F_INT km = MAX(kx,ky)+1;
+ F_INT ne = MAX(nxest,nyest);
+ F_INT bx = kx*v+ky+1;
+ F_INT by = ky*u+kx+1;
+ F_INT b1,b2;
  if (bx<=by) {b1=bx;b2=bx+v-ky;}
  else {b1=by;b2=by+u-kx;}
  return u*v*(2+b1+b2)+2*(u+v+km*(m+ne)+ne-kx-ky)+b2+1;
 }
-static int calc_surfit_lwrk2(int m, int kx, int ky, int nxest, int nyest) {
- int u = nxest-kx-1;
- int v = nyest-ky-1;
- int bx = kx*v+ky+1;
- int by = ky*u+kx+1;
- int b2 = (bx<=by?bx+v-ky:by+u-kx);
+static F_INT calc_surfit_lwrk2(F_INT m, F_INT kx, F_INT ky, F_INT nxest, F_INT nyest) {
+ F_INT u = nxest-kx-1;
+ F_INT v = nyest-ky-1;
+ F_INT bx = kx*v+ky+1;
+ F_INT by = ky*u+kx+1;
+ F_INT b2 = (bx<=by?bx+v-ky:by+u-kx);
  return u*v*(b2+1)+b2;
 }
 
-static int calc_spherfit_lwrk1(int m, int ntest, int npest) {
- int u = ntest-7;
- int v = npest-7;
+static F_INT calc_spherfit_lwrk1(F_INT m, F_INT ntest, F_INT npest) {
+ F_INT u = ntest-7;
+ F_INT v = npest-7;
  return 185+52*v+10*u+14*u*v+8*(u-1)*v*v+8*m;
 }
-static int calc_spherfit_lwrk2(int ntest, int npest) {
- int u = ntest-7;
- int v = npest-7;
+static F_INT calc_spherfit_lwrk2(F_INT ntest, F_INT npest) {
+ F_INT u = ntest-7;
+ F_INT v = npest-7;
  return 48+21*v+7*u*v+4*(u-1)*v*v;
 }
 
-static int calc_regrid_lwrk(int mx, int my, int kx, int ky,
-                            int nxest, int nyest) {
- int u = MAX(my, nxest);
+static F_INT calc_regrid_lwrk(F_INT mx, F_INT my, F_INT kx, F_INT ky,
+                            F_INT nxest, F_INT nyest) {
+ F_INT u = MAX(my, nxest);
  return 4+nxest*(my+2*kx+5)+nyest*(2*ky+5)+mx*(kx+1)+my*(ky+1)+u;
 }
 '''
@@ -163,7 +169,7 @@ static int calc_regrid_lwrk(int mx, int my, int kx, int ky,
        ! d,ier = spalde(t,c,k,x)
 
        threadsafe
-       callprotoargument double*,int*,double*,int*,double*,double*,int*
+       callprotoargument double*,F_INT*,double*,F_INT*,double*,double*,F_INT*
        callstatement {int k1=k+1; (*f2py_func)(t,&n,c,&k1,&x,d,&ier); }
 
        real*8 dimension(n) :: t
@@ -254,7 +260,7 @@ static int calc_regrid_lwrk(int mx, int my, int kx, int ky,
 
        fortranname fpcurf
        threadsafe
-       callprotoargument int*,double*,double*,double*,int*,double*,double*,int*,double*,int*,double*,int*,int*,int*,int*,double*,double*,double*,double*,double*,double*,double*,double*,double*,int*,int*
+       callprotoargument F_INT*,double*,double*,double*,F_INT*,double*,double*,F_INT*,double*,F_INT*,double*,F_INT*,F_INT*,F_INT*,F_INT*,double*,double*,double*,double*,double*,double*,double*,double*,double*,F_INT*,F_INT*
        callstatement (*f2py_func)(&iopt,x,y,w,&m,&xb,&xe,&k,&s,&nest,&tol,&maxit,&k1,&k2,&n,t,c,&fp,fpint,wrk,wrk+nest,wrk+nest*k2,wrk+nest*2*k2,wrk+nest*3*k2,nrdata,&ier)
 
        integer intent(hide) :: iopt = 0
@@ -287,7 +293,7 @@ static int calc_regrid_lwrk(int mx, int my, int kx, int ky,
 
        fortranname fpcurf
        threadsafe
-       callprotoargument int*,double*,double*,double*,int*,double*,double*,int*,double*,int*,double*,int*,int*,int*,int*,double*,double*,double*,double*,double*,double*,double*,double*,double*,int*,int*
+       callprotoargument F_INT*,double*,double*,double*,F_INT*,double*,double*,F_INT*,double*,F_INT*,double*,F_INT*,F_INT*,F_INT*,F_INT*,double*,double*,double*,double*,double*,double*,double*,double*,double*,F_INT*,F_INT*
        callstatement (*f2py_func)(&iopt,x,y,w,&m,&xb,&xe,&k,&s,&nest,&tol,&maxit,&k1,&k2,&n,t,c,&fp,fpint,wrk,wrk+nest,wrk+nest*k2,wrk+nest*2*k2,wrk+nest*3*k2,nrdata,&ier)
 
        integer intent(hide) :: iopt = 1
@@ -320,7 +326,7 @@ static int calc_regrid_lwrk(int mx, int my, int kx, int ky,
 
        fortranname fpcurf
        threadsafe
-       callprotoargument int*,double*,double*,double*,int*,double*,double*,int*,double*,int*,double*,int*,int*,int*,int*,double*,double*,double*,double*,double*,double*,double*,double*,double*,int*,int*
+       callprotoargument F_INT*,double*,double*,double*,F_INT*,double*,double*,F_INT*,double*,F_INT*,double*,F_INT*,F_INT*,F_INT*,F_INT*,double*,double*,double*,double*,double*,double*,double*,double*,double*,F_INT*,F_INT*
        callstatement (*f2py_func)(&iopt,x,y,w,&m,&xb,&xe,&k,&s,&nest,&tol,&maxit,&k1,&k2,&n,t,c,&fp,fpint,wrk,wrk+nest,wrk+nest*k2,wrk+nest*2*k2,wrk+nest*3*k2,nrdata,&ier)
 
        integer intent(hide) :: iopt = -1
@@ -698,6 +704,10 @@ static int calc_regrid_lwrk(int mx, int my, int kx, int ky,
        real*8 dimension(nx+ny-kx-ky-2),depend(nx,ny,kx,ky),intent(cache,hide) :: wrk
        real*8 :: dblint
      end function dblint
+
+     ! Fake common block for indicating the integer size
+     integer :: intvar
+     common /types/ intvar
   end interface
 end python module dfitpack
 

--- a/scipy/interpolate/tests/test_fitpack.py
+++ b/scipy/interpolate/tests/test_fitpack.py
@@ -5,12 +5,14 @@ import numpy as np
 from numpy.testing import (assert_equal, assert_allclose, assert_,
                            assert_almost_equal, assert_array_almost_equal)
 from pytest import raises as assert_raises
+import pytest
 
 from numpy import array, asarray, pi, sin, cos, arange, dot, ravel, sqrt, round
 from scipy import interpolate
 from scipy.interpolate.fitpack import (splrep, splev, bisplrep, bisplev,
      sproot, splprep, splint, spalde, splder, splantider, insert, dblint)
 from scipy.interpolate.dfitpack import regrid_smth
+from scipy.interpolate.fitpack2 import dfitpack_int
 
 
 def data_file(basename):
@@ -381,11 +383,16 @@ class TestSplder(object):
 
 class TestBisplrep(object):
     def test_overflow(self):
-        a = np.linspace(0, 1, 620)
-        b = np.linspace(0, 1, 620)
-        x, y = np.meshgrid(a, b)
-        z = np.random.rand(*x.shape)
-        assert_raises(OverflowError, bisplrep, x.ravel(), y.ravel(), z.ravel(), s=0)
+        from numpy.lib.stride_tricks import as_strided
+        if dfitpack_int.itemsize == 8:
+            size = 1500000**2
+        else:
+            size = 400**2
+        # Don't allocate a real array, as it's very big, but rely
+        # on that it's not referenced
+        x = as_strided(np.zeros(()), shape=(size,))
+        assert_raises(OverflowError, bisplrep, x, x, x, w=x,
+                      xb=0, xe=1, yb=0, ye=1, s=0)
 
     def test_regression_1310(self):
         # Regression test for gh-1310

--- a/scipy/interpolate/tests/test_fitpack.py
+++ b/scipy/interpolate/tests/test_fitpack.py
@@ -6,6 +6,7 @@ from numpy.testing import (assert_equal, assert_allclose, assert_,
                            assert_almost_equal, assert_array_almost_equal)
 from pytest import raises as assert_raises
 import pytest
+from scipy._lib._testutils import check_free_memory
 
 from numpy import array, asarray, pi, sin, cos, arange, dot, ravel, sqrt, round
 from scipy import interpolate
@@ -404,6 +405,16 @@ class TestBisplrep(object):
         # code to crash when compiled with -O3
         bisplrep(data[:,0], data[:,1], data[:,2], kx=3, ky=3, s=0,
                  full_output=True)
+
+    @pytest.mark.skipif(dfitpack_int != np.int64, reason="needs ilp64 fitpack")
+    def test_ilp64_bisplrep(self):
+        check_free_memory(28000)  # VM size, doesn't actually use the pages
+        x = np.linspace(0, 1, 400)
+        y = np.linspace(0, 1, 400)
+        x, y = np.meshgrid(x, y)
+        z = np.zeros_like(x)
+        tck = bisplrep(x, y, z, kx=3, ky=3, s=0)
+        assert_allclose(bisplev(0.5, 0.5, tck), 0.0)
 
 
 def test_dblint():


### PR DESCRIPTION
#### Reference issue
See gh-7663

#### What does this implement/fix?
Support 64-bit integer size in fitpack.

Fitpack does not use blas/lapack, but we use the same 64-bitness flag to turn the feature on because `scipy._build_utils` supports 64-bit ints only for gfortran so we can't turn that on by default.

#### Additional information
Whether it makes any sense to run fitpack for this large inputs is then a different question --- it's going to be very slow and the work arrays use large amounts of memory. E.g. in gh-7663 the submitter was looking for just bilinear interp, not the automatic knot selection + smoothing that fitpack does.