### PR TITLE
ENH: scipy.signal: allow lists in gauss_spline

### DIFF
--- a/scipy/signal/bsplines.py
+++ b/scipy/signal/bsplines.py
@@ -239,6 +239,7 @@ def gauss_spline(x, n):
     array([0.16666667, 0.66666667, 0.16666667])  # may vary
 
     """
+    x = asarray(x)
     signsq = (n + 1) / 12.0
     return 1 / sqrt(2 * pi * signsq) * exp(-x ** 2 / 2 / signsq)
 

--- a/scipy/signal/tests/test_bsplines.py
+++ b/scipy/signal/tests/test_bsplines.py
@@ -123,6 +123,12 @@ class TestBSplines(object):
         assert_almost_equal(bsp.gauss_spline(0, 0), 1.381976597885342)
         assert_allclose(bsp.gauss_spline(array([1.]), 1), array([0.04865217]))
 
+    def test_gauss_spline_list(self):
+        # fix for gh-12152
+        knots = [-1.0, 0.0, -1.0]
+        assert_almost_equal(bsp.gauss_spline(knots, 3),
+                            array([0.15418033, 0.6909883 , 0.15418033]))
+
     def test_cubic(self):
         np.random.seed(12460)
         assert_array_equal(bsp.cubic([0]), array([0]))

--- a/scipy/signal/tests/test_bsplines.py
+++ b/scipy/signal/tests/test_bsplines.py
@@ -124,10 +124,10 @@ class TestBSplines(object):
         assert_allclose(bsp.gauss_spline(array([1.]), 1), array([0.04865217]))
 
     def test_gauss_spline_list(self):
-        # fix for gh-12152
+        # regression test for gh-12152 (accept array_like)
         knots = [-1.0, 0.0, -1.0]
         assert_almost_equal(bsp.gauss_spline(knots, 3),
-                            array([0.15418033, 0.6909883 , 0.15418033]))
+                            array([0.15418033, 0.6909883, 0.15418033]))
 
     def test_cubic(self):
         np.random.seed(12460)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Fixes #12152 

#### What does this implement/fix?
<!--Please explain your changes.-->
I have added support for lists in gauss_splines function in ``scipy.signal`` module and added test for it.

#### Additional information
<!--Any additional information you think is important.-->
I also noticed that there is no argument validation. If the team thinks it is important enough to validate the arguments, I will happily add it!