### PR TITLE
BUG: Fix length calculation in upfirdn

### DIFF
--- a/scipy/signal/_upfirdn.py
+++ b/scipy/signal/_upfirdn.py
@@ -70,8 +70,9 @@ def _check_mode(mode):
 
 
 class _UpFIRDn(object):
+    """Helper for resampling."""
+
     def __init__(self, h, x_dtype, up, down):
-        """Helper for resampling"""
         h = np.asarray(h)
         if h.ndim != 1 or h.size == 0:
             raise ValueError('h must be 1-D with non-zero length')
@@ -84,10 +85,11 @@ class _UpFIRDn(object):
         # This both transposes, and "flips" each phase for filtering
         self._h_trans_flip = _pad_h(h, self._up)
         self._h_trans_flip = np.ascontiguousarray(self._h_trans_flip)
+        self._h_len_orig = len(h)
 
     def apply_filter(self, x, axis=-1, mode='constant', cval=0):
-        """Apply the prepared filter to the specified axis of a N-D signal x"""
-        output_len = _output_len(len(self._h_trans_flip), x.shape[axis],
+        """Apply the prepared filter to the specified axis of N-D signal x."""
+        output_len = _output_len(self._h_len_orig, x.shape[axis],
                                  self._up, self._down)
         # Explicit use of np.int64 for output_shape dtype avoids OverflowError
         # when allocating large array on platforms where np.int_ is 32 bits
@@ -103,7 +105,7 @@ class _UpFIRDn(object):
 
 
 def upfirdn(h, x, up=1, down=1, axis=-1, mode='constant', cval=0):
-    """Upsample, FIR filter, and downsample
+    """Upsample, FIR filter, and downsample.
 
     Parameters
     ----------
@@ -147,15 +149,17 @@ def upfirdn(h, x, up=1, down=1, axis=-1, mode='constant', cval=0):
     The algorithm is an implementation of the block diagram shown on page 129
     of the Vaidyanathan text [1]_ (Figure 4.3-8d).
 
-    .. [1] P. P. Vaidyanathan, Multirate Systems and Filter Banks,
-       Prentice Hall, 1993.
-
     The direct approach of upsampling by factor of P with zero insertion,
     FIR filtering of length ``N``, and downsampling by factor of Q is
     O(N*Q) per output sample. The polyphase implementation used here is
     O(N/P).
 
     .. versionadded:: 0.18
+
+    References
+    ----------
+    .. [1] P. P. Vaidyanathan, Multirate Systems and Filter Banks,
+           Prentice Hall, 1993.
 
     Examples
     --------
@@ -204,7 +208,6 @@ def upfirdn(h, x, up=1, down=1, axis=-1, mode='constant', cval=0):
            [ 4.,  5.],
            [ 6.,  7.],
            [ 6.,  7.]])
-
     """
     x = np.asarray(x)
     ufd = _UpFIRDn(h, x.dtype, up, down)

--- a/scipy/signal/_upfirdn_apply.pyx
+++ b/scipy/signal/_upfirdn_apply.pyx
@@ -63,13 +63,6 @@ def _output_len(np.intp_t len_h,
                 np.intp_t up,
                 np.intp_t down):
     """The output length that results from a given input"""
-    return _c_output_len(len_h, in_len, up, down)
-
-
-cdef np.intp_t _c_output_len(np.intp_t len_h,
-                             np.intp_t in_len,
-                             np.intp_t up,
-                             np.intp_t down) nogil:
     # ceil(((in_len - 1) * up + len_h) / down), but using integer arithmetic
     return (((in_len - 1) * up + len_h) - 1) // down + 1
 
@@ -483,5 +476,5 @@ cdef void _apply_impl(DTYPE_t *x, np.intp_t len_x, DTYPE_t *h_trans_flip,
         if y_idx >= len_out:
             return
         t += down
-        x_idx += t / up  # integer div
+        x_idx += t // up
         t = t % up

--- a/scipy/signal/_upfirdn_apply.pyx
+++ b/scipy/signal/_upfirdn_apply.pyx
@@ -439,6 +439,8 @@ cdef void _apply_impl(DTYPE_t *x, np.intp_t len_x, DTYPE_t *h_trans_flip,
     cdef bint zpad
 
     zpad = (mode == MODE_CONSTANT and cval == 0)
+    if len_out == 0:
+        return
 
     while x_idx < len_x:
         h_idx = t * h_per_phase
@@ -457,6 +459,8 @@ cdef void _apply_impl(DTYPE_t *x, np.intp_t len_x, DTYPE_t *h_trans_flip,
             h_idx += 1
         # store and increment
         y_idx += 1
+        if y_idx >= len_out:
+            return
         t += down
         x_idx += t // up
         # which phase of the filter to use
@@ -473,10 +477,11 @@ cdef void _apply_impl(DTYPE_t *x, np.intp_t len_x, DTYPE_t *h_trans_flip,
                 xval = _extend_left(x, x_conv_idx, len_x, mode, cval)
             else:
                 xval = x[x_conv_idx]
-            if y_idx < len_out:
-                out[y_idx] += xval * h_trans_flip[h_idx]
+            out[y_idx] += xval * h_trans_flip[h_idx]
             h_idx += 1
         y_idx += 1
+        if y_idx >= len_out:
+            return
         t += down
         x_idx += t / up  # integer div
         t = t % up

--- a/scipy/signal/_upfirdn_apply.pyx
+++ b/scipy/signal/_upfirdn_apply.pyx
@@ -63,14 +63,15 @@ def _output_len(np.intp_t len_h,
                 np.intp_t up,
                 np.intp_t down):
     """The output length that results from a given input"""
-    cdef np.intp_t nt
-    cdef np.intp_t in_len_copy
-    in_len_copy = in_len + (len_h + (-len_h % up)) // up - 1
-    nt = in_len_copy * up
-    cdef np.intp_t need = nt // down
-    if nt % down > 0:
-        need += 1
-    return need
+    return _c_output_len(len_h, in_len, up, down)
+
+
+cdef np.intp_t _c_output_len(np.intp_t len_h,
+                             np.intp_t in_len,
+                             np.intp_t up,
+                             np.intp_t down) nogil:
+    # ceil(((in_len - 1) * up + len_h) / down), but using integer arithmetic
+    return (((in_len - 1) * up + len_h) - 1) // down + 1
 
 
 # Signal extension modes
@@ -288,6 +289,7 @@ def _apply(np.ndarray data, DTYPE_t [::1] h_trans_flip, np.ndarray out,
     cdef DTYPE_t *filter_ptr
     cdef DTYPE_t *out_ptr
     cdef int retval
+    cdef np.intp_t len_out = out.shape[axis]
 
     data_info.ndim = data.ndim
     data_info.strides = <np.intp_t *> data.strides
@@ -305,7 +307,7 @@ def _apply(np.ndarray data, DTYPE_t [::1] h_trans_flip, np.ndarray out,
         retval = _apply_axis_inner(data_ptr, data_info,
                                    filter_ptr, len_h,
                                    out_ptr, output_info,
-                                   up, down, axis, <MODE>mode, cval)
+                                   up, down, axis, <MODE>mode, cval, len_out)
     if retval == 1:
         raise ValueError("failure in _apply_axis_inner: data and output arrays"
                          " must have the same number of dimensions.")
@@ -325,7 +327,8 @@ cdef int _apply_axis_inner(DTYPE_t* data, ArrayInfo data_info,
                            DTYPE_t* h_trans_flip, np.intp_t len_h,
                            DTYPE_t* output, ArrayInfo output_info,
                            np.intp_t up, np.intp_t down,
-                           np.intp_t axis, MODE mode, DTYPE_t cval) nogil:
+                           np.intp_t axis, MODE mode, DTYPE_t cval,
+                           np.intp_t len_out) nogil:
     cdef np.intp_t i
     cdef np.intp_t num_loops = 1
     cdef bint make_temp_data, make_temp_output
@@ -403,7 +406,8 @@ cdef int _apply_axis_inner(DTYPE_t* data, ArrayInfo data_info,
 
         # call 1D upfirdn
         _apply_impl(data_row, data_info.shape[axis],
-                    h_trans_flip, len_h, output_row, up, down, mode, cval)
+                    h_trans_flip, len_h, output_row, up, down, mode, cval,
+                    len_out)
 
         # Copy from temporary output if necessary
         if make_temp_output:
@@ -423,8 +427,8 @@ cdef int _apply_axis_inner(DTYPE_t* data, ArrayInfo data_info,
 cdef void _apply_impl(DTYPE_t *x, np.intp_t len_x, DTYPE_t *h_trans_flip,
                       np.intp_t len_h, DTYPE_t *out,
                       np.intp_t up, np.intp_t down, MODE mode,
-                      DTYPE_t cval) nogil:
-    cdef np.intp_t h_per_phase = len_h / up
+                      DTYPE_t cval, np.intp_t len_out) nogil:
+    cdef np.intp_t h_per_phase = len_h // up
     cdef np.intp_t padded_len = len_x + h_per_phase - 1
     cdef np.intp_t x_idx = 0
     cdef np.intp_t y_idx = 0
@@ -454,7 +458,7 @@ cdef void _apply_impl(DTYPE_t *x, np.intp_t len_x, DTYPE_t *h_trans_flip,
         # store and increment
         y_idx += 1
         t += down
-        x_idx += t / up  # integer div
+        x_idx += t // up
         # which phase of the filter to use
         t = t % up
 
@@ -469,7 +473,8 @@ cdef void _apply_impl(DTYPE_t *x, np.intp_t len_x, DTYPE_t *h_trans_flip,
                 xval = _extend_left(x, x_conv_idx, len_x, mode, cval)
             else:
                 xval = x[x_conv_idx]
-            out[y_idx] += xval * h_trans_flip[h_idx]
+            if y_idx < len_out:
+                out[y_idx] += xval * h_trans_flip[h_idx]
             h_idx += 1
         y_idx += 1
         t += down

--- a/scipy/signal/tests/test_upfirdn.py
+++ b/scipy/signal/tests/test_upfirdn.py
@@ -39,13 +39,13 @@ from numpy.testing import assert_equal, assert_allclose
 from pytest import raises as assert_raises
 import pytest
 
-from scipy.signal import upfirdn, firwin, lfilter
+from scipy.signal import upfirdn, firwin
 from scipy.signal._upfirdn import _output_len, _upfirdn_modes
 from scipy.signal._upfirdn_apply import _pad_test
 
 
 def upfirdn_naive(x, h, up=1, down=1):
-    """Naive upfirdn processing in Python
+    """Naive upfirdn processing in Python.
 
     Note: arg order (x, h) differs to facilitate apply_along_axis use.
     """
@@ -91,7 +91,11 @@ class UpFIRDnCase(object):
     def scrub(self, x, axis=-1):
         yr = np.apply_along_axis(upfirdn_naive, axis, x,
                                  self.h, self.up, self.down)
+        want_len = _output_len(len(self.h), x.shape[axis], self.up, self.down)
+        assert yr.shape[axis] == want_len
         y = upfirdn(self.h, x, self.up, self.down, axis=axis)
+        assert y.shape[axis] == want_len
+        assert y.shape == yr.shape
         dtypes = (self.h.dtype, x.dtype)
         if all(d == np.complex64 for d in dtypes):
             assert_equal(y.dtype, np.complex64)
@@ -106,6 +110,9 @@ class UpFIRDnCase(object):
         assert_allclose(yr, y)
 
 
+_UPFIRDN_TYPES = (int, np.float32, np.complex64, float, complex)
+
+
 class TestUpfirdn(object):
 
     def test_valid_input(self):
@@ -113,42 +120,77 @@ class TestUpfirdn(object):
         assert_raises(ValueError, upfirdn, [], [1], 1, 1)  # h.ndim != 1
         assert_raises(ValueError, upfirdn, [[1]], [1], 1, 1)
 
-    def test_vs_lfilter(self):
-        # Check that up=1.0 gives same answer as lfilter + slicing
+    @pytest.mark.parametrize('len_h', [1, 2, 3, 4, 5])
+    @pytest.mark.parametrize('len_x', [1, 2, 3, 4, 5])
+    def test_singleton(self, len_h, len_x):
+        # gh-9844: lengths producing expected outputs
+        h = np.zeros(len_h)
+        h[len_h // 2] = 1.  # make h a delta
+        x = np.ones(len_x)
+        y = upfirdn(h, x, 1, 1)
+        want = np.pad(x, (len_h // 2, (len_h - 1) // 2), 'constant')
+        assert_allclose(y, want)
+
+    def test_shift_x(self):
+        # gh-9844: shifted x can change values?
+        y = upfirdn([1, 1], [1.], 1, 1)
+        assert_allclose(y, [1, 1])  # was [0, 1] in the issue
+        y = upfirdn([1, 1], [0., 1.], 1, 1)
+        assert_allclose(y, [0, 1, 1])
+
+    # A bunch of lengths/factors chosen because they exposed differences
+    # between the "old way" and new way of computing length, and then
+    # got `expected` from MATLAB
+    @pytest.mark.parametrize('len_h, len_x, up, down, expected', [
+        (2, 2, 5, 2, [1, 0, 0, 0]),
+        (2, 3, 6, 3, [1, 0, 1, 0, 1]),
+        (2, 4, 4, 3, [1, 0, 0, 0, 1]),
+        (3, 2, 6, 2, [1, 0, 0, 1, 0]),
+        (4, 11, 3, 5, [1, 0, 0, 1, 0, 0, 1]),
+    ])
+    def test_length_factors(self, len_h, len_x, up, down, expected):
+        # gh-9844: weird factors
+        h = np.zeros(len_h)
+        h[0] = 1.
+        x = np.ones(len_x)
+        y = upfirdn(h, x, up, down)
+        assert_allclose(y, expected)
+
+    @pytest.mark.parametrize('down, want_len', [  # lengths from MATLAB
+        (2, 5015),
+        (11, 912),
+        (79, 127),
+    ])
+    def test_vs_convolve(self, down, want_len):
+        # Check that up=1.0 gives same answer as convolve + slicing
         random_state = np.random.RandomState(17)
         try_types = (int, np.float32, np.complex64, float, complex)
         size = 10000
-        down_factors = [2, 11, 79]
 
         for dtype in try_types:
             x = random_state.randn(size).astype(dtype)
             if dtype in (np.complex64, np.complex128):
                 x += 1j * random_state.randn(size)
 
-            for down in down_factors:
-                h = firwin(31, 1. / down, window='hamming')
-                yl = lfilter(h, 1.0, x)[::down]
-                y = upfirdn(h, x, up=1, down=down)
-                assert_allclose(yl, y[:yl.size], atol=1e-7, rtol=1e-7)
+            h = firwin(31, 1. / down, window='hamming')
+            yl = upfirdn_naive(x, h, 1, down)
+            y = upfirdn(h, x, up=1, down=down)
+            assert y.shape == (want_len,)
+            assert yl.shape[0] == y.shape[0]
+            assert_allclose(yl, y, atol=1e-7, rtol=1e-7)
 
-    def test_vs_naive(self):
-        tests = []
-        try_types = (int, np.float32, np.complex64, float, complex)
+    @pytest.mark.parametrize('x_dtype', _UPFIRDN_TYPES)
+    @pytest.mark.parametrize('h', (1., 1j))
+    @pytest.mark.parametrize('up, down', [(1, 1), (2, 2), (3, 2), (2, 3)])
+    def test_vs_naive_delta(self, x_dtype, h, up, down):
+        UpFIRDnCase(up, down, h, x_dtype)()
 
-        # Simple combinations of factors
-        for x_dtype, h in product(try_types, (1., 1j)):
-            tests.append(UpFIRDnCase(1, 1, h, x_dtype))
-            tests.append(UpFIRDnCase(2, 2, h, x_dtype))
-            tests.append(UpFIRDnCase(3, 2, h, x_dtype))
-            tests.append(UpFIRDnCase(2, 3, h, x_dtype))
-
-        # mixture of big, small, and both directions (net up and net down)
-        # use all combinations of data and filter dtypes
-        factors = (100, 10)  # up/down factors
-        cases = product(factors, factors, try_types, try_types)
-        for case in cases:
-            tests += self._random_factors(*case)
-
+    @pytest.mark.parametrize('x_dtype', _UPFIRDN_TYPES)
+    @pytest.mark.parametrize('h_dtype', _UPFIRDN_TYPES)
+    @pytest.mark.parametrize('p_max, q_max',
+                             list(product((10, 100), (10, 100))))
+    def test_vs_naive(self, x_dtype, h_dtype, p_max, q_max):
+        tests = self._random_factors(p_max, q_max, h_dtype, x_dtype)
         for test in tests:
             test()
 


### PR DESCRIPTION
Closes #9844.

Implements the suggestion implemented in that issue by @grlee77 and @sirtom67, except I kept `ceil` instead of floor as now the length matches both the naive `upfirdn` calculation with `np.convolve` and slicing, as well as MATLAB outputs (calculated and put in the test).

Also refactors a few tests to use `pytest.mark.parametrize` instead of `for` in the tests (was useful for figuring out what was actually wrong) and fixes a few flake8 errors.

Would be good to get this into 1.5.0 if possible. @grlee77 @sirtom67 would either of you have time to look in the next few days? Sorry for the short notice...