### PR TITLE
BUG: Fix M_PI

### DIFF
--- a/scipy/stats/_stats.pyx
+++ b/scipy/stats/_stats.pyx
@@ -1,6 +1,5 @@
 from cpython cimport bool
 from libc cimport math
-from libc.math cimport M_PI
 cimport cython
 cimport numpy as np
 from numpy.math cimport PI
@@ -567,7 +566,7 @@ def gaussian_kernel_estimate(points, values, xi, precision, dtype, real _=0):
     values_ = values.astype(dtype, copy=False)
 
     # Evaluate the normalisation
-    norm = (2 * M_PI) ** (- d / 2)
+    norm = (2 * PI) ** (- d / 2)
     for i in range(d):
         norm *= whitening[i, i]
 

--- a/scipy/stats/_stats.pyx
+++ b/scipy/stats/_stats.pyx
@@ -1,5 +1,6 @@
 from cpython cimport bool
 from libc cimport math
+from libc.math import M_PI
 cimport cython
 cimport numpy as np
 from numpy.math cimport PI
@@ -548,7 +549,7 @@ def gaussian_kernel_estimate(points, values, xi, precision, dtype, real _=0):
         int i, j, k
         int n, d, m, p
         real arg, residual, norm
-    
+
     n = points.shape[0]
     d = points.shape[1]
     m = xi.shape[0]
@@ -566,7 +567,7 @@ def gaussian_kernel_estimate(points, values, xi, precision, dtype, real _=0):
     values_ = values.astype(dtype, copy=False)
 
     # Evaluate the normalisation
-    norm = (2 * math.M_PI) ** (- d / 2)
+    norm = (2 * M_PI) ** (- d / 2)
     for i in range(d):
         norm *= whitening[i, i]
 

--- a/scipy/stats/_stats.pyx
+++ b/scipy/stats/_stats.pyx
@@ -1,6 +1,6 @@
 from cpython cimport bool
 from libc cimport math
-from libc.math import M_PI
+from libc.math cimport M_PI
 cimport cython
 cimport numpy as np
 from numpy.math cimport PI


### PR DESCRIPTION
Might fix https://ci.appveyor.com/project/scipy/scipy/builds/32959985 and related failures:
```
  scipy\stats\_stats.c(19781): error C2065: 'M_PI': undeclared identifier
```
Seems like this must be an underlying Cython issue (?), but maybe this will allow us to work around it.