### PR TITLE
DOC: add an obsolete version checking javascript to doc release builds

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -81,7 +81,9 @@ dist:
 	$(CURDIR)/build/env/bin/python -mpip install ..
 	make PYTHON="$(CURDIR)/build/env/bin/python" doc-dist
 
-doc-dist: html html-scipyorg
+doc-dist: VERSIONWARNING=-t versionwarning
+
+doc-dist: html-scipyorg html
 	test -d build/latex || make latex
 	make -C build/latex all-pdf LATEXOPTS="-halt-on-error"
 	-test -d build/htmlhelp || make htmlhelp-build
@@ -123,7 +125,7 @@ html-build:
 
 html-scipyorg:
 	mkdir -p build/html build/doctrees
-	$(SPHINXBUILD) -WT --keep-going -t scipyorg -b html $(ALLSPHINXOPTS) build/html-scipyorg $(FILES)
+	$(SPHINXBUILD) -WT --keep-going -t scipyorg $(VERSIONWARNING) -b html $(ALLSPHINXOPTS) build/html-scipyorg $(FILES)
 	@echo
 	@echo "Build finished. The HTML pages are in build/html-scipyorg."
 

--- a/doc/source/_static/versioncheck.js_t
+++ b/doc/source/_static/versioncheck.js_t
@@ -1,0 +1,1 @@
+{{ VERSIONCHECK_JS }}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -191,6 +191,15 @@ else:
         html_logo = '_static/scipyshiny_small.png'
         html_sidebars = {'index': ['indexsidebar.html', 'searchbox.html']}
 
+if 'versionwarning' in tags:
+    # Specific to docs.scipy.org deployment.
+    # See https://github.com/scipy/docs.scipy.org/blob/master/_static/versionwarning.js_t
+    src = '$.getScript("/doc/_static/versionwarning.js");'
+    html_context = {
+        'VERSIONCHECK_JS': src
+    }
+    html_js_files = ['versioncheck.js']
+
 html_title = "%s v%s Reference Guide" % (project, version)
 html_static_path = ['_static']
 html_last_updated_fmt = '%b %d, %Y'


### PR DESCRIPTION
#### Reference issue
See gh-12166

#### What does this implement/fix?
Add an obsolete version checking javascript to doc release builds.

How this will work:
- There is a script `/doc/_static/versionwarning.js` hosted on `docs.scipy.org`, which adds a warning box if the current URL points to a documentation version that's not the latest. See https://github.com/scipy/docs.scipy.org/pull/38
- The `_static/versioncheck.js` of documentation release builds load that script.
- All pages of documentation release builds load their `_static/versioncheck.js`.

The loader script is in a separate file, so that it is easier to replace in historical doc builds if necessary after building.

The doc makefile targets 'doc-dist' and 'dist' add additional javascript to the built docs, which checks whether they are out of date, assuming they are uploaded to the docs.scipy.org site.  It's not included by default.