### PR TITLE
CI, MAINT: Azure OpenBLAS drive flip

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,7 +67,7 @@ jobs:
   variables:
     # OPENBLAS64_ variable has same value
     # but only needed for ILP64 build below
-    OPENBLAS: '$(Agent.BuildDirectory)\openblaslib'
+    OPENBLAS: '$(Agent.HomeDirectory)\openblaslib'
   strategy:
     maxParallel: 4
     matrix:


### PR DESCRIPTION
* Azure CI is misbehaving again with ` ValueError: path is on mount
'D:', start on mount 'C:'`

* fix by moving the OpenBLAS static library install location to the other
drive (containing the Agent software and NumPy/distutils pip
installs); reference to Agent variables:
https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#agent-variables

Example fails in unrelated PRs:
https://github.com/scipy/scipy/pull/12168
https://github.com/scipy/scipy/pull/12170