### PR TITLE
ENH: Bounds for the Powell minimization method

### DIFF
--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -804,14 +804,10 @@ def minimize_scalar(fun, bracket=None, bounds=None, args=(),
 
 def standardize_bounds(bounds, x0, meth):
     """Converts bounds to the form required by the solver."""
-    if meth == 'trust-constr':
+    if meth in {'trust-constr', 'powell'}:
         if not isinstance(bounds, Bounds):
             lb, ub = old_bound_to_new(bounds)
             bounds = Bounds(lb, ub)
-    elif meth == 'powell':
-        if isinstance(bounds, Bounds):
-            bounds = new_bounds_to_old(bounds.lb, bounds.ub, x0.shape[0])
-        bounds = old_bound_to_new(bounds)
     elif meth in ('l-bfgs-b', 'tnc', 'slsqp'):
         if isinstance(bounds, Bounds):
             bounds = new_bounds_to_old(bounds.lb, bounds.ub, x0.shape[0])

--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -143,7 +143,7 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
         dimension (n,) and `args` is a tuple with the fixed
         parameters.
     bounds : sequence or `Bounds`, optional
-        Bounds on variables for L-BFGS-B, TNC, SLSQP and
+        Bounds on variables for L-BFGS-B, TNC, SLSQP, Powell, and
         trust-constr methods. There are two ways to specify the bounds:
 
             1. Instance of `Bounds` class.
@@ -233,14 +233,6 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
     information might be preferred for their better performance in
     general.
 
-    Method :ref:`Powell <optimize.minimize-powell>` is a modification
-    of Powell's method [3]_, [4]_ which is a conjugate direction
-    method. It performs sequential one-dimensional minimizations along
-    each vector of the directions set (`direc` field in `options` and
-    `info`), which is updated at each iteration of the main
-    minimization loop. The function need not be differentiable, and no
-    derivatives are taken.
-
     Method :ref:`CG <optimize.minimize-cg>` uses a nonlinear conjugate
     gradient algorithm by Polak and Ribiere, a variant of the
     Fletcher-Reeves method described in [5]_ pp.120-122. Only the
@@ -291,6 +283,24 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
 
     Method :ref:`L-BFGS-B <optimize.minimize-lbfgsb>` uses the L-BFGS-B
     algorithm [6]_, [7]_ for bound constrained minimization.
+
+    Method :ref:`Powell <optimize.minimize-powell>` is a modification
+    of Powell's method [3]_, [4]_ which is a conjugate direction
+    method. It performs sequential one-dimensional minimizations along
+    each vector of the directions set (`direc` field in `options` and
+    `info`), which is updated at each iteration of the main
+    minimization loop. The function need not be differentiable, and no
+    derivatives are taken. If bounds are not provided, then an
+    unbounded line search will be used. If bounds are provided and
+    the initial guess is within the bounds, then every function
+    evaluation throughout the minimization procedure will be within
+    the bounds. If bounds are provided, the initial guess is outside
+    the bounds, and `direc` is full rank (default has full rank), then
+    some function evaluations during the first iteration may be
+    outside the bounds, but every function evaluation after the first
+    iteration will be within the bounds. If `direc` is not full rank,
+    then some parameters may not be optimized and the solution is not
+    guaranteed to be within the bounds.
 
     Method :ref:`TNC <optimize.minimize-tnc>` uses a truncated Newton
     algorithm [5]_, [8]_ to minimize a function with variables subject
@@ -518,11 +528,11 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
         warn('Method %s does not use Hessian-vector product '
              'information (hessp).' % method, RuntimeWarning)
     # - constraints or bounds
-    if (meth in ('nelder-mead', 'powell', 'cg', 'bfgs', 'newton-cg', 'dogleg',
+    if (meth in ('nelder-mead', 'cg', 'bfgs', 'newton-cg', 'dogleg',
                  'trust-ncg') and (bounds is not None or np.any(constraints))):
         warn('Method %s cannot handle constraints nor bounds.' % method,
              RuntimeWarning)
-    if meth in ('l-bfgs-b', 'tnc') and np.any(constraints):
+    if meth in ('l-bfgs-b', 'tnc', 'powell') and np.any(constraints):
         warn('Method %s cannot handle constraints.' % method,
              RuntimeWarning)
     if meth == 'cobyla' and bounds is not None:
@@ -595,7 +605,7 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
     if meth == 'nelder-mead':
         return _minimize_neldermead(fun, x0, args, callback, **options)
     elif meth == 'powell':
-        return _minimize_powell(fun, x0, args, callback, **options)
+        return _minimize_powell(fun, x0, args, callback, bounds, **options)
     elif meth == 'cg':
         return _minimize_cg(fun, x0, args, jac, callback, **options)
     elif meth == 'bfgs':
@@ -798,6 +808,10 @@ def standardize_bounds(bounds, x0, meth):
         if not isinstance(bounds, Bounds):
             lb, ub = old_bound_to_new(bounds)
             bounds = Bounds(lb, ub)
+    elif meth == 'powell':
+        if isinstance(bounds, Bounds):
+            bounds = new_bounds_to_old(bounds.lb, bounds.ub, x0.shape[0])
+        bounds = old_bound_to_new(bounds)
     elif meth in ('l-bfgs-b', 'tnc', 'slsqp'):
         if isinstance(bounds, Bounds):
             bounds = new_bounds_to_old(bounds.lb, bounds.ub, x0.shape[0])

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -47,7 +47,7 @@ _status_message = {'success': 'Optimization terminated successfully.',
                               'exceeded.',
                    'pr_loss': 'Desired error not necessarily achieved due '
                               'to precision loss.',
-                   'nan': 'NaN result encountered.'}
+                   'nan': 'NaN result encountered.',
                    'out_of_bounds': 'The result is outside of the provided '
                                     'bounds.'}
 
@@ -2854,19 +2854,20 @@ def _minimize_powell(func, x0, args=(), callback=None, bounds=None,
     return_all : bool, optional
         Set to True to return a list of the best solution at each of the
         iterations.
-    bounds : sequence
-        Sequence of ``(min, max)`` pairs for each element in ``x0``. None
-        is used to specify no bound. If bounds are not provided, then an
-        unbounded line search will be used. If bounds are provided and
-        the initial guess is within the bounds, then every function
-        evaluation throughout the minimization procedure will be within
-        the bounds. If bounds are provided, the initial guess is outside
-        the bounds, and `direc` is full rank (or left to default), then
-        some function evaluations during the first iteration may be
-        outside the bounds, but every function evaluation after the first
-        iteration will be within the bounds. If `direc` is not full rank,
-        then some parameters may not be optimized and the solution is not
-        guarenteed to be within the bounds.
+    bounds : `Bounds`
+        If bounds are not provided, then an unbounded line search will be used.
+        If bounds are provided and the initial guess is within the bounds, then
+        every function evaluation throughout the minimization procedure will be
+        within the bounds. If bounds are provided, the initial guess is outside
+        the bounds, and `direc` is full rank (or left to default), then some
+        function evaluations during the first iteration may be outside the
+        bounds, but every function evaluation after the first iteration will be
+        within the bounds. If `direc` is not full rank, then some parameters may
+        not be optimized and the solution is not guaranteed to be within the
+        bounds.
+    return_all : bool, optional
+        Set to True to return a list of the best solution at each of the
+        iterations.
     """
     _check_unknown_options(unknown_options)
     maxfun = maxfev
@@ -2907,12 +2908,12 @@ def _minimize_powell(func, x0, args=(), callback=None, bounds=None,
     if bounds is None:
         # don't make these arrays of all +/- inf. because
         # _linesearch_powell will do an unnecessary check of all the elements.
-        # just keep them None, an _linesearch_powell will not have to check
+        # just keep them None, _linesearch_powell will not have to check
         # all the elements.
         lower_bound, upper_bound = None, None
     else:
         # bounds is standardized in _minimize.py.
-        lower_bound, upper_bound = bounds
+        lower_bound, upper_bound = bounds.lb, bounds.ub
         if np.any(lower_bound > x0) or np.any(x0 > upper_bound):
             warnings.warn("Initial guess is not within the specified bounds",
                           OptimizeWarning, 3)
@@ -2980,7 +2981,7 @@ def _minimize_powell(func, x0, args=(), callback=None, bounds=None,
     # established warning flags for maxfev and maxiter, so the out of bounds
     # warning flag becomes 3, but is checked for first.
     if bounds and (np.any(lower_bound > x) or np.any(x > upper_bound)):
-        warnflag = 3
+        warnflag = 4
         msg = _status_message['out_of_bounds']
     elif fcalls[0] >= maxfun:
         warnflag = 1

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -48,6 +48,8 @@ _status_message = {'success': 'Optimization terminated successfully.',
                    'pr_loss': 'Desired error not necessarily achieved due '
                               'to precision loss.',
                    'nan': 'NaN result encountered.'}
+                   'out_of_bounds': 'The result is outside of the provided '
+                                    'bounds.'}
 
 
 class MemoizeJac(object):
@@ -2566,17 +2568,122 @@ def bracket(func, xa=0.0, xb=1.0, args=(), grow_limit=110.0, maxiter=1000):
     return xa, xb, xc, fa, fb, fc, funcalls
 
 
-def _linesearch_powell(func, p, xi, tol=1e-3):
+def _line_for_search(x0, alpha, lower_bound, upper_bound):
+    """
+    Given a parameter vector ``x0`` with length ``n`` and a direction
+    vector ``alpha`` with length ``n``, and lower and upper bounds on
+    each of the ``n`` parameters, what are the bounds on a scalar
+    ``l`` such that ``lower_bound <= x0 + alpha * l <= upper_bound``.
+
+
+    Parameters
+    ----------
+    x0 : np.array. 
+        The vector representing the current location.
+        Note ``np.shape(x0) == (n,)``.
+    alpha : np.array.
+        The vector representing the direction.
+        Note ``np.shape(alpha) == (n,)``.
+    lower_bound : np.array.
+        The lower bounds for each parameter in ``x0``. If the ``i``th
+        parameter in ``x0`` is unbounded below, then ``lower_bound[i]``
+        should be ``-np.inf``.
+        Note ``np.shape(lower_bound) == (n,)``.
+    upper_bound : np.array.
+        The upper bounds for each parameter in ``x0``. If the ``i``th
+        parameter in ``x0`` is unbounded above, then ``upper_bound[i]``
+        should be ``np.inf``.
+        Note ``np.shape(upper_bound) == (n,)``.
+
+    Returns
+    -------
+    res : tuple ``(lmin, lmax)``
+        The bounds for ``l`` such that
+            ``lower_bound[i] <= x0[i] + alpha[i] * l <= upper_bound[i]``
+        for all ``i``.
+
+    """
+    # get nonzero indices of alpha so we don't get any zero division errors.
+    # alpha will not be all zero, since it is called from _linesearch_powell
+    # where we have a check for this.
+    nonzero, = alpha.nonzero()
+    lower_bound, upper_bound = lower_bound[nonzero], upper_bound[nonzero]
+    x0, alpha = x0[nonzero], alpha[nonzero]
+    low = (lower_bound - x0) / alpha
+    high = (upper_bound - x0) / alpha
+
+    # positive and negative indices
+    pos = alpha > 0
+
+    lmin_pos = np.where(pos, low, 0)
+    lmin_neg = np.where(pos, 0, high)
+    lmax_pos = np.where(pos, high, 0)
+    lmax_neg = np.where(pos, 0, low)
+
+    lmin = np.max(lmin_pos + lmin_neg)
+    lmax = np.min(lmax_pos + lmax_neg)
+
+    # if x0 is outside the bounds, then it is possible that there is 
+    # no way to get back in the bounds for the parameters being updated
+    # with the current direction alpha.
+    # when this happens, lmax < lmin.
+    # If this is the case, then we can just return (0, 0)
+    return (lmin, lmax) if lmax >= lmin else (0, 0)
+
+
+def _linesearch_powell(func, p, xi, tol=1e-3,
+                       lower_bound=None, upper_bound=None, fval=None):
     """Line-search algorithm using fminbound.
 
-    Find the minimium of the function ``func(x0+ alpha*direc)``.
+    Find the minimium of the function ``func(x0 + alpha*direc)``.
+
+    lower_bound : np.array.
+        The lower bounds for each parameter in ``x0``. If the ``i``th
+        parameter in ``x0`` is unbounded below, then ``lower_bound[i]``
+        should be ``-np.inf``.
+        Note ``np.shape(lower_bound) == (n,)``.
+    upper_bound : np.array.
+        The upper bounds for each parameter in ``x0``. If the ``i``th
+        parameter in ``x0`` is unbounded above, then ``upper_bound[i]``
+        should be ``np.inf``.
+        Note ``np.shape(upper_bound) == (n,)``.
+    fval : number.
+        ``fval`` is equal to ``func(p)``, the idea is just to avoid
+        recomputing it so we can limit the ``fevals``.
 
     """
     def myfunc(alpha):
         return func(p + alpha*xi)
-    alpha_min, fret, iter, num = brent(myfunc, full_output=1, tol=tol)
-    xi = alpha_min*xi
-    return squeeze(fret), p + xi, xi
+
+    # if xi is zero, then don't optimize
+    if not np.any(xi):
+        return ((fval, p, xi) if fval is not None else (func(p), p, xi))
+    elif lower_bound is None and upper_bound is None:
+        # non-bounded minimization
+        alpha_min, fret, _, _ = brent(myfunc, full_output=1, tol=tol)
+        xi = alpha_min * xi
+        return squeeze(fret), p + xi, xi
+    else:
+        bound = _line_for_search(p, xi, lower_bound, upper_bound)
+        if np.isneginf(bound[0]) and np.isposinf(bound[1]):
+            # equivalent to unbounded
+            return _linesearch_powell(func, p, xi, fval=fval, tol=tol)
+        elif not np.isneginf(bound[0]) and not np.isposinf(bound[1]):
+            # we can use a bounded scalar minimization
+            res = _minimize_scalar_bounded(myfunc, bound, xatol=tol / 100)
+            xi = res.x * xi
+            return squeeze(res.fun), p + xi, xi
+        else:
+            # only bounded on one side. use the tangent function to convert
+            # the infinity bound to a finite bound. The new bounded region
+            # is a subregion of the region bounded by -np.pi/2 and np.pi/2.
+            bound = np.arctan(bound[0]), np.arctan(bound[1])
+            res = _minimize_scalar_bounded(
+                lambda x: myfunc(np.tan(x)),
+                bound,
+                xatol=tol / 100)
+            xi = np.tan(res.x) * xi
+            return squeeze(res.fun), p + xi, xi
 
 
 def fmin_powell(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None,
@@ -2641,6 +2748,7 @@ def fmin_powell(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None,
             1 : Maximum number of function evaluations.
             2 : Maximum number of iterations.
             3 : NaN result encountered.
+            4 : The result is out of the provided bounds.
     allvecs : list
         List of solutions at each iteration.
 
@@ -2705,7 +2813,6 @@ def fmin_powell(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None,
             'return_all': retall}
 
     res = _minimize_powell(func, x0, args, callback=callback, **opts)
-    res['x'] = squeeze(res['x'])
 
     if full_output:
         retlist = (res['x'], res['fun'], res['direc'], res['nit'],
@@ -2720,7 +2827,7 @@ def fmin_powell(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None,
             return res['x']
 
 
-def _minimize_powell(func, x0, args=(), callback=None,
+def _minimize_powell(func, x0, args=(), callback=None, bounds=None,
                      xtol=1e-4, ftol=1e-4, maxiter=None, maxfev=None,
                      disp=False, direc=None, return_all=False,
                      **unknown_options):
@@ -2747,7 +2854,19 @@ def _minimize_powell(func, x0, args=(), callback=None,
     return_all : bool, optional
         Set to True to return a list of the best solution at each of the
         iterations.
-
+    bounds : sequence
+        Sequence of ``(min, max)`` pairs for each element in ``x0``. None
+        is used to specify no bound. If bounds are not provided, then an
+        unbounded line search will be used. If bounds are provided and
+        the initial guess is within the bounds, then every function
+        evaluation throughout the minimization procedure will be within
+        the bounds. If bounds are provided, the initial guess is outside
+        the bounds, and `direc` is full rank (or left to default), then
+        some function evaluations during the first iteration may be
+        outside the bounds, but every function evaluation after the first
+        iteration will be within the bounds. If `direc` is not full rank,
+        then some parameters may not be optimized and the solution is not
+        guarenteed to be within the bounds.
     """
     _check_unknown_options(unknown_options)
     maxfun = maxfev
@@ -2780,6 +2899,23 @@ def _minimize_powell(func, x0, args=(), callback=None,
         direc = eye(N, dtype=float)
     else:
         direc = asarray(direc, dtype=float)
+        if np.linalg.matrix_rank(direc) != direc.shape[0]:
+            warnings.warn("direc input is not full rank, some parameters may "
+                          "not be optimized",
+                          OptimizeWarning, 3)
+
+    if bounds is None:
+        # don't make these arrays of all +/- inf. because
+        # _linesearch_powell will do an unnecessary check of all the elements.
+        # just keep them None, an _linesearch_powell will not have to check
+        # all the elements.
+        lower_bound, upper_bound = None, None
+    else:
+        # bounds is standardized in _minimize.py.
+        lower_bound, upper_bound = bounds
+        if np.any(lower_bound > x0) or np.any(x0 > upper_bound):
+            warnings.warn("Initial guess is not within the specified bounds",
+                          OptimizeWarning, 3)
 
     fval = squeeze(func(x))
     x1 = x.copy()
@@ -2793,7 +2929,10 @@ def _minimize_powell(func, x0, args=(), callback=None,
             direc1 = direc[i]
             fx2 = fval
             fval, x, direc1 = _linesearch_powell(func, x, direc1,
-                                                 tol=xtol * 100)
+                                                 tol=xtol * 100,
+                                                 lower_bound=lower_bound,
+                                                 upper_bound=upper_bound,
+                                                 fval=fval)
             if (fx2 - fval) > delta:
                 delta = fx2 - fval
                 bigind = i
@@ -2827,12 +2966,23 @@ def _minimize_powell(func, x0, args=(), callback=None,
             t -= delta*temp*temp
             if t < 0.0:
                 fval, x, direc1 = _linesearch_powell(func, x, direc1,
-                                                     tol=xtol*100)
-                direc[bigind] = direc[-1]
-                direc[-1] = direc1
+                                                     tol=xtol * 100,
+                                                     lower_bound=lower_bound,
+                                                     upper_bound=upper_bound,
+                                                     fval=fval)
+                if np.any(direc1):
+                    direc[bigind] = direc[-1]
+                    direc[-1] = direc1
 
     warnflag = 0
-    if fcalls[0] >= maxfun:
+    # out of bounds is more urgent than exceeding function evals or iters,
+    # but I don't want to cause inconsistencies by changing the
+    # established warning flags for maxfev and maxiter, so the out of bounds
+    # warning flag becomes 3, but is checked for first.
+    if bounds and (np.any(lower_bound > x) or np.any(x > upper_bound)):
+        warnflag = 3
+        msg = _status_message['out_of_bounds']
+    elif fcalls[0] >= maxfun:
         warnflag = 1
         msg = _status_message['maxfev']
         if disp:

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -228,6 +228,55 @@ class CheckOptimizeParameterized(CheckOptimize):
                          [1.72949016, -0.44156936, 0.47576729]],
                         atol=1e-14, rtol=1e-7)
 
+    def test_powell_bounded(self):
+        # Powell (direction set) optimization routine
+        # same as test_powell above, but with bounds
+        bounds = [(-np.pi, np.pi) for _ in self.startparams]
+        if self.use_wrapper:
+            opts = {'maxiter': self.maxiter, 'disp': self.disp,
+                    'return_all': False}
+            res = optimize.minimize(self.func, self.startparams, args=(),
+                                    bounds=bounds, 
+                                    method='Powell', options=opts)
+            params, fopt, direc, numiter, func_calls, warnflag = (
+                    res['x'], res['fun'], res['direc'], res['nit'],
+                    res['nfev'], res['status'])
+        else:
+            # since fmin_powell is legacy, we do not add the bounds option
+            # thus the bounds option is only accesible through the wrapper.
+            retval = optimize.fmin_powell(self.func, self.startparams,
+                                          args=(),
+                                          maxiter=self.maxiter,
+                                          full_output=True, disp=self.disp,
+                                          retall=False)
+            (params, fopt, direc, numiter, func_calls, warnflag) = retval
+
+        assert_(func_calls == self.funccalls, (func_calls, self.funccalls))
+        assert_allclose(self.func(params), self.func(self.solution),
+                        atol=1e-6)
+
+        # Ensure that function call counts are 'known good'.
+        #
+        # However, some leeway must be added: the exact evaluation
+        # count is sensitive to numerical error, and floating-point
+        # computations are not bit-for-bit reproducible across
+        # machines, and when using e.g. MKL, data alignment
+        # etc. affect the rounding error.
+        #
+        # Generally, this takes 131 function calls. However, without
+        # the +20 leeway, one of Travis-CI checks
+        # (TESTMODE=fast COVERAGE=NUMPYSPEC="--upgrade numpy"
+        # MB_PYTHON_VERSION=3.7)
+        # fails, it finds 138 funccalls. All the rest of the Travis-CI
+        # checks find 131 funccalls. I am not sure why this is, but this
+        # leeway was also included in the test_powell function
+        # (right above where I put my test_bounded_powell function).
+        # Whoever included that test also included a 20 funccall leeway.
+        # I just did as they did.
+        #
+        assert_(self.funccalls <= 131 + 20, self.funccalls)
+        assert_(self.gradcalls == 0, self.gradcalls)
+
     def test_neldermead(self):
         # Nelder-Mead simplex algorithm
         if self.use_wrapper:
@@ -471,6 +520,157 @@ def test_neldermead_adaptive():
     res = optimize.minimize(func, p0, method='Nelder-Mead',
                             options={'adaptive': True})
     assert_equal(res.success, True)
+
+
+def test_bounded_powell_outsidebounds():
+    # One cool feature of the bounded Powell method is that if you
+    # start outside the bounds, the final answer will still be
+    # within the bounds (provided that the user doesn't make a bad
+    # choice for the `direc` argument). 
+    func = lambda x: np.sum(x**2)
+    bounds = (-1, 1), (-1, 1), (-1, 1)
+    x0 = [-4, .5, -.8]
+
+    # we're starting outside the bounds, so we should get a warning
+    with assert_warns(optimize.OptimizeWarning):
+        res = optimize.minimize(func, x0, bounds=bounds, method="Powell")
+    assert_allclose(res.x, np.array([0.] * len(x0)), atol=1e-6)
+    assert_equal(res.success, True)
+    assert_equal(res.status, 0)
+
+    # However, now if we change the `direc` argument such that the
+    # set of vectors does not span the parameter space, then we may
+    # not end up back within the bounds. Here we see that the first
+    # parameter cannot be updated!
+    direc = [[0, 0, 0], [0, 1, 0], [0, 0, 1]]
+    # we're starting outside the bounds, so we should get a warning
+    with assert_warns(optimize.OptimizeWarning):
+        res = optimize.minimize(func, x0, 
+                                bounds=bounds, method="Powell",
+                                options=dict(direc=direc))
+    assert_allclose(res.x, np.array([-4., 0, 0]), atol=1e-6)
+    assert_equal(res.success, False)
+    assert_equal(res.status, 4)
+
+
+def test_bounded_powell_vs_powell():
+    # here we test an example where the bounded Powell method
+    # will return a different result than the standard Powell
+    # method.
+
+    # first we test a simple example where the minimum is at
+    # the origin and the minimum that is within the bounds is
+    # larger than the minimum at the origin.
+    func = lambda x: np.sum(x**2)
+    bounds = (-5, -1), (-10, -.1), (1, 9.2), (-4, 7.6), (-15.9, -2)
+    x0 = [-2.1, -5.2, 1.9, 0, -2]
+
+    options = dict(ftol=1e-10, xtol=1e-10)
+
+    res_powell = optimize.minimize(func, x0, method="Powell", options=options)
+    assert_allclose(np.array([0.]*len(x0)), res_powell.x, atol=1e-6)
+    assert_allclose(0., res_powell.fun, atol=1e-6)
+
+    res_bounded_powell = optimize.minimize(func, x0, options=options,
+                                           bounds=bounds,
+                                           method="Powell")
+    p = np.array([-1, -.1, 1, 0, -2])
+    assert_allclose(p, res_bounded_powell.x, atol=1e-6)
+    assert_allclose(func(p), res_bounded_powell.fun, atol=1e-6)
+
+    # now we test bounded Powell but with a mix of inf bounds.
+    bounds = (None, -1), (-np.inf, -.1), (1, np.inf), (-4, None), (-15.9, -2)
+    res_bounded_powell = optimize.minimize(func, x0, options=options,
+                                           bounds=bounds,
+                                           method="Powell")
+    p = np.array([-1, -.1, 1, 0, -2])
+    assert_allclose(p, res_bounded_powell.x, atol=1e-6)
+    assert_allclose(func(p), res_bounded_powell.fun, atol=1e-6)
+
+    # next we test an example where the global minimum is within
+    # the bounds, but the bounded Powell method performs better
+    # than the standard Powell method.
+    func = lambda x: (
+        np.sin(-x[0])*np.cos(x[1])*np.sin(-x[0]*x[1])*np.cos(x[1]) -
+        np.cos(np.sin(x[1]*x[2]) * np.cos(x[2]))
+    )**2
+    bounds = tuple((-2, 5) for _ in range(3))
+    x0 = [-.5]*len(bounds)
+
+    res_powell = optimize.minimize(func, x0, method="Powell")
+    res_bounded_powell = optimize.minimize(func, x0,
+                                           bounds=bounds,
+                                           method="Powell")
+    assert_allclose(res_powell.fun, 0.007136253919761627, atol=1e-6)
+    assert_allclose(res_bounded_powell.fun, 0, atol=1e-6)
+
+    # next we test the previous example where the we provide Powell
+    # with (-inf, inf) bounds, and compare it to providing Powell
+    # with no bounds. They should end up the same.
+    bounds = tuple((-np.inf, np.inf) for _ in range(3))
+
+    res_bounded_powell = optimize.minimize(func, x0,
+                                           bounds=bounds,
+                                           method="Powell")
+    assert_allclose(res_powell.fun, res_bounded_powell.fun, atol=1e-6)
+    assert_allclose(res_powell.nfev, res_bounded_powell.nfev, atol=1e-6)
+    assert_allclose(res_powell.x, res_bounded_powell.x, atol=1e-6)
+
+    # now test when x0 starts outside of the bounds.
+    x0 = [45.46254415, -26.52351498, 31.74830248]
+    bounds = tuple((-2, 5) for _ in range(3))
+    # we're starting outside the bounds, so we should get a warning
+    with assert_warns(optimize.OptimizeWarning):
+        res_bounded_powell = optimize.minimize(func, x0,
+                                               bounds=bounds,
+                                               method="Powell")
+    assert_allclose(res_bounded_powell.fun, 0, atol=1e-6)
+
+
+def test_onesided_bounded_powell_stability():
+    # When the Powell method is bounded on only one side, a
+    # np.tan transform is done in order to convert it into a
+    # completely bounded problem. Here we do some simple tests
+    # of one-sided bounded Powell where the optimal solutions
+    # are large to test the stability of the transformation.
+
+    kwargs = dict(
+        method="Powell",
+        bounds=((-np.inf, 1e6), (-np.inf, 1e6), (-np.inf, 1e6)),
+        options=dict(
+            ftol=1e-8,
+            xtol=1e-8
+        )
+    )
+    x0 = [1, 1, 1]
+
+    # start out with an example where df/dx is constant.
+    f = lambda x: -np.sum(x)
+    res = optimize.minimize(f, x0, **kwargs)
+    assert_allclose(res.fun, -3e6, atol=1)
+
+    # now we do example where df/dx gets smaller and smaller.
+    f = lambda x: (
+        -np.abs(np.sum(x)) ** (1 / 10) * (1 if np.all(x > 0) else -1)
+    )
+    res = optimize.minimize(f, x0, **kwargs)
+    assert_allclose(res.fun, -(3e6) ** (1 / 10), atol=1)
+
+    # now we do example where df/dx gets larger and larger.
+    f = lambda x: (
+        -np.abs(np.sum(x)) ** 10 * (1 if np.all(x > 0) else -1)
+    )
+    res = optimize.minimize(f, x0, **kwargs)
+    assert_allclose(res.fun, -(3e6) ** 10, atol=1)
+
+    # now we do an example where df/dx gets larger for some
+    # of the varables and smaller for others.
+    f = lambda x: (
+        (1 if np.all(x > 0) else -1) *
+        (-np.abs(np.sum(x[:2])) ** 10 - np.abs(np.sum(x[3:])) ** (1 / 10))
+    )
+    res = optimize.minimize(f, x0, **kwargs)
+    assert_allclose(res.fun, -(2e6) ** 10 - (1e6) ** (1 / 10), atol=1)
 
 
 class TestOptimizeWrapperDisp(CheckOptimizeParameterized):
@@ -1403,6 +1603,231 @@ class TestNewtonCg(object):
         assert_(sol.success, sol.message)
         assert_allclose(sol.x, himmelblau_xopt, rtol=1e-4)
         assert_allclose(sol.fun, himmelblau_min, atol=1e-4)
+
+
+def test_line_for_search():
+    # helper function in optimize.py, not a public function.
+    line_for_search = optimize.optimize._line_for_search
+    # args are x0, alpha, lower_bound, upper_bound
+    # returns lmin, lmax
+
+    lower_bound = np.array([-5.3, -1, -1.5, -3])
+    upper_bound = np.array([1.9, 1, 2.8, 3])
+
+    # test when starting in the bounds
+    x0 = np.array([0., 0, 0, 0])
+    # and when starting outside of the bounds
+    x1 = np.array([0., 2, -3, 0])
+
+    all_tests = (
+        (x0, np.array([1., 0, 0, 0]), -5.3, 1.9),
+        (x0, np.array([0., 1, 0, 0]), -1, 1),
+        (x0, np.array([0., 0, 1, 0]), -1.5, 2.8),
+        (x0, np.array([0., 0, 0, 1]), -3, 3),
+        (x0, np.array([1., 1, 0, 0]), -1, 1),
+        (x0, np.array([1., 0, -1, 2]), -1.5, 1.5),
+        (x0, np.array([2., 0, -1, 2]), -1.5, 0.95),
+        (x1, np.array([1., 0, 0, 0]), -5.3, 1.9),
+        (x1, np.array([0., 1, 0, 0]), -3, -1),
+        (x1, np.array([0., 0, 1, 0]), 1.5, 5.8),
+        (x1, np.array([0., 0, 0, 1]), -3, 3),
+        (x1, np.array([1., 1, 0, 0]), -3, -1),
+        (x1, np.array([1., 0, -1, 0]), -5.3, -1.5),
+    )
+
+    for x, alpha, lmin, lmax in all_tests:
+        mi, ma = line_for_search(x, alpha, lower_bound, upper_bound)
+        assert_allclose(mi, lmin, atol=1e-6)
+        assert_allclose(ma, lmax, atol=1e-6)
+
+    # now with infinite bounds
+    lower_bound = np.array([-np.inf, -1, -np.inf, -3])
+    upper_bound = np.array([np.inf, 1, 2.8, np.inf])
+
+    all_tests = (
+        (x0, np.array([1., 0, 0, 0]), -np.inf, np.inf),
+        (x0, np.array([0., 1, 0, 0]), -1, 1),
+        (x0, np.array([0., 0, 1, 0]), -np.inf, 2.8),
+        (x0, np.array([0., 0, 0, 1]), -3, np.inf),
+        (x0, np.array([1., 1, 0, 0]), -1, 1),
+        (x0, np.array([1., 0, -1, 2]), -1.5, np.inf),
+        (x1, np.array([1., 0, 0, 0]), -np.inf, np.inf),
+        (x1, np.array([0., 1, 0, 0]), -3, -1),
+        (x1, np.array([0., 0, 1, 0]), -np.inf, 5.8),
+        (x1, np.array([0., 0, 0, 1]), -3, np.inf),
+        (x1, np.array([1., 1, 0, 0]), -3, -1),
+        (x1, np.array([1., 0, -1, 0]), -5.8, np.inf),
+    )
+
+    for x, alpha, lmin, lmax in all_tests:
+        mi, ma = line_for_search(x, alpha, lower_bound, upper_bound)
+        assert_allclose(mi, lmin, atol=1e-6)
+        assert_allclose(ma, lmax, atol=1e-6)
+
+    # _line_for_search is only used in _linesearch_powell, which is also
+    # tested below. Thus there are more tests of _line_for_search in the
+    # test_linesearch_powell_bounded function.
+
+
+def test_linesearch_powell():
+    # helper function in optimize.py, not a public function.
+    linesearch_powell = optimize.optimize._linesearch_powell
+    # args are func, p, xi, fval, lower_bound=None, upper_bound=None, tol=1e-3
+    # returns new_fval, p+direction, direction
+    func = lambda x: np.sum((x-np.array([-1., 2., 1.5, -.4]))**2)
+    p0 = np.array([0., 0, 0, 0])
+    fval = func(p0)
+    lower_bound = np.array([-np.inf] * 4)
+    upper_bound = np.array([np.inf] * 4)
+
+    all_tests = (
+        (np.array([1., 0, 0, 0]), -1),
+        (np.array([0., 1, 0, 0]), 2),
+        (np.array([0., 0, 1, 0]), 1.5),
+        (np.array([0., 0, 0, 1]), -.4),
+        (np.array([-1., 0, 1, 0]), 1.25),
+        (np.array([0., 0, 1, 1]), .55),
+        (np.array([2., 0, -1, 1]), -.65),
+    )
+
+    for xi, l in all_tests:
+        f, p, direction = linesearch_powell(func, p0, xi,
+                                            fval=fval, tol=1e-5)
+        assert_allclose(f, func(l * xi), atol=1e-6)
+        assert_allclose(p, l * xi, atol=1e-6)
+        assert_allclose(direction, l * xi, atol=1e-6)
+
+        f, p, direction = linesearch_powell(func, p0, xi, tol=1e-5,
+                                            lower_bound=lower_bound,
+                                            upper_bound=upper_bound,
+                                            fval=fval)
+        assert_allclose(f, func(l * xi), atol=1e-6)
+        assert_allclose(p, l * xi, atol=1e-6)
+        assert_allclose(direction, l * xi, atol=1e-6)
+
+
+def test_linesearch_powell_bounded():
+    # helper function in optimize.py, not a public function.
+    linesearch_powell = optimize.optimize._linesearch_powell
+    # args are func, p, xi, fval, lower_bound=None, upper_bound=None, tol=1e-3
+    # returns new_fval, p+direction, direction
+    func = lambda x: np.sum((x-np.array([-1., 2., 1.5, -.4]))**2)
+    p0 = np.array([0., 0, 0, 0])
+    fval = func(p0)
+
+    # first choose bounds such that the same tests from
+    # test_linesearch_powell should pass.
+    lower_bound = np.array([-2.]*4)
+    upper_bound = np.array([2.]*4)
+
+    all_tests = (
+        (np.array([1., 0, 0, 0]), -1),
+        (np.array([0., 1, 0, 0]), 2),
+        (np.array([0., 0, 1, 0]), 1.5),
+        (np.array([0., 0, 0, 1]), -.4),
+        (np.array([-1., 0, 1, 0]), 1.25),
+        (np.array([0., 0, 1, 1]), .55),
+        (np.array([2., 0, -1, 1]), -.65),
+    )
+
+    for xi, l in all_tests:
+        f, p, direction = linesearch_powell(func, p0, xi, tol=1e-5,
+                                            lower_bound=lower_bound,
+                                            upper_bound=upper_bound,
+                                            fval=fval)
+        assert_allclose(f, func(l * xi), atol=1e-6)
+        assert_allclose(p, l * xi, atol=1e-6)
+        assert_allclose(direction, l * xi, atol=1e-6)
+
+    # now choose bounds such that unbounded vs bounded gives different results
+    lower_bound = np.array([-.3]*3 + [-1])
+    upper_bound = np.array([.45]*3 + [.9])
+
+    all_tests = (
+        (np.array([1., 0, 0, 0]), -.3),
+        (np.array([0., 1, 0, 0]), .45),
+        (np.array([0., 0, 1, 0]), .45),
+        (np.array([0., 0, 0, 1]), -.4),
+        (np.array([-1., 0, 1, 0]), .3),
+        (np.array([0., 0, 1, 1]), .45),
+        (np.array([2., 0, -1, 1]), -.15),
+    )
+
+    for xi, l in all_tests:
+        f, p, direction = linesearch_powell(func, p0, xi, tol=1e-5,
+                                            lower_bound=lower_bound,
+                                            upper_bound=upper_bound,
+                                            fval=fval)
+        assert_allclose(f, func(l * xi), atol=1e-6)
+        assert_allclose(p, l * xi, atol=1e-6)
+        assert_allclose(direction, l * xi, atol=1e-6)
+
+    # now choose as above but start outside the bounds
+    p0 = np.array([-1., 0, 0, 2])
+    fval = func(p0)
+
+    all_tests = (
+        (np.array([1., 0, 0, 0]), .7),
+        (np.array([0., 1, 0, 0]), .45),
+        (np.array([0., 0, 1, 0]), .45),
+        (np.array([0., 0, 0, 1]), -2.4),
+    )
+
+    for xi, l in all_tests:
+        f, p, direction = linesearch_powell(func, p0, xi, tol=1e-5,
+                                            lower_bound=lower_bound,
+                                            upper_bound=upper_bound,
+                                            fval=fval)
+        assert_allclose(f, func(p0 + l * xi), atol=1e-6)
+        assert_allclose(p, p0 + l * xi, atol=1e-6)
+        assert_allclose(direction, l * xi, atol=1e-6)
+
+    # now mix in inf
+    p0 = np.array([0., 0, 0, 0])
+    fval = func(p0)
+
+    # now choose bounds that mix inf
+    lower_bound = np.array([-.3, -np.inf, -np.inf, -1])
+    upper_bound = np.array([np.inf, .45, np.inf, .9])
+
+    all_tests = (
+        (np.array([1., 0, 0, 0]), -.3),
+        (np.array([0., 1, 0, 0]), .45),
+        (np.array([0., 0, 1, 0]), 1.5),
+        (np.array([0., 0, 0, 1]), -.4),
+        (np.array([-1., 0, 1, 0]), .3),
+        (np.array([0., 0, 1, 1]), .55),
+        (np.array([2., 0, -1, 1]), -.15),
+    )
+
+    for xi, l in all_tests:
+        f, p, direction = linesearch_powell(func, p0, xi, tol=1e-5,
+                                            lower_bound=lower_bound,
+                                            upper_bound=upper_bound,
+                                            fval=fval)
+        assert_allclose(f, func(l * xi), atol=1e-6)
+        assert_allclose(p, l * xi, atol=1e-6)
+        assert_allclose(direction, l * xi, atol=1e-6)
+
+    # now choose as above but start outside the bounds
+    p0 = np.array([-1., 0, 0, 2])
+    fval = func(p0)
+
+    all_tests = (
+        (np.array([1., 0, 0, 0]), .7),
+        (np.array([0., 1, 0, 0]), .45),
+        (np.array([0., 0, 1, 0]), 1.5),
+        (np.array([0., 0, 0, 1]), -2.4),
+    )
+
+    for xi, l in all_tests:
+        f, p, direction = linesearch_powell(func, p0, xi, tol=1e-5,
+                                            lower_bound=lower_bound,
+                                            upper_bound=upper_bound,
+                                            fval=fval)
+        assert_allclose(f, func(p0 + l * xi), atol=1e-6)
+        assert_allclose(p, p0 + l * xi, atol=1e-6)
+        assert_allclose(direction, l * xi, atol=1e-6)
 
 
 class TestRosen(object):

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -615,7 +615,7 @@ def test_onesided_bounded_powell_stability():
     # are large to test the stability of the transformation.
     kwargs = {'method': 'Powell',
               'bounds': [(-np.inf, 1e6)] * 3,
-              'options': {'ftol': 1e-8, 'xtol':1e-8}}
+              'options': {'ftol': 1e-8, 'xtol': 1e-8}}
     x0 = [1, 1, 1]
 
     # df/dx is constant.


### PR DESCRIPTION
This PR replaces #10648. The original PR wasn't done on a feature branch it was done on the master branch of @jtiosue fork, and had tens of commits. The original PR needed changes, in order to get the PR into 1.5.0 (@tylerjereddy) I decided to make them myself.
I therefore checked out the original fork, rebased it onto the current tip of scipy/master (which took a lot of interactive work), squashed the original PR commits down, and made it into a feature branch. I don't know how to push those changes back into the original PR without difficult rebasing efforts, so it just seemed easier to create a new PR.
The work done by @jtiosue is still acknowledged in the git commit history.

I've gone over the PR and I'm happy for it to be merged.