### PR TITLE
BUG: stats: A few distributions didn't accept lists as arguments.

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -1837,9 +1837,9 @@ class rv_continuous(rv_generic):
 
         """
         args, loc, scale = self._parse_args(*args, **kwds)
-        _a, _b = self._get_support(*args)
         x, loc, scale = map(asarray, (x, loc, scale))
         args = tuple(map(asarray, args))
+        _a, _b = self._get_support(*args)
         dtyp = np.find_common_type([x.dtype, np.float64], [])
         x = np.asarray((x - loc)/scale, dtype=dtyp)
         cond0 = self._argcheck(*args) & (scale > 0)
@@ -1879,9 +1879,9 @@ class rv_continuous(rv_generic):
 
         """
         args, loc, scale = self._parse_args(*args, **kwds)
-        _a, _b = self._get_support(*args)
         x, loc, scale = map(asarray, (x, loc, scale))
         args = tuple(map(asarray, args))
+        _a, _b = self._get_support(*args)
         dtyp = np.find_common_type([x.dtype, np.float64], [])
         x = np.asarray((x - loc)/scale, dtype=dtyp)
         cond0 = self._argcheck(*args) & (scale > 0)
@@ -1922,9 +1922,9 @@ class rv_continuous(rv_generic):
 
         """
         args, loc, scale = self._parse_args(*args, **kwds)
-        _a, _b = self._get_support(*args)
         x, loc, scale = map(asarray, (x, loc, scale))
         args = tuple(map(asarray, args))
+        _a, _b = self._get_support(*args)
         dtyp = np.find_common_type([x.dtype, np.float64], [])
         x = np.asarray((x - loc)/scale, dtype=dtyp)
         cond0 = self._argcheck(*args) & (scale > 0)
@@ -1967,9 +1967,9 @@ class rv_continuous(rv_generic):
 
         """
         args, loc, scale = self._parse_args(*args, **kwds)
-        _a, _b = self._get_support(*args)
         x, loc, scale = map(asarray, (x, loc, scale))
         args = tuple(map(asarray, args))
+        _a, _b = self._get_support(*args)
         dtyp = np.find_common_type([x.dtype, np.float64], [])
         x = np.asarray((x - loc)/scale, dtype=dtyp)
         cond0 = self._argcheck(*args) & (scale > 0)
@@ -2010,9 +2010,9 @@ class rv_continuous(rv_generic):
 
         """
         args, loc, scale = self._parse_args(*args, **kwds)
-        _a, _b = self._get_support(*args)
         q, loc, scale = map(asarray, (q, loc, scale))
         args = tuple(map(asarray, args))
+        _a, _b = self._get_support(*args)
         cond0 = self._argcheck(*args) & (scale > 0) & (loc == loc)
         cond1 = (0 < q) & (q < 1)
         cond2 = cond0 & (q == 0)
@@ -2056,9 +2056,9 @@ class rv_continuous(rv_generic):
 
         """
         args, loc, scale = self._parse_args(*args, **kwds)
-        _a, _b = self._get_support(*args)
         q, loc, scale = map(asarray, (q, loc, scale))
         args = tuple(map(asarray, args))
+        _a, _b = self._get_support(*args)
         cond0 = self._argcheck(*args) & (scale > 0) & (loc == loc)
         cond1 = (0 < q) & (q < 1)
         cond2 = cond0 & (q == 1)
@@ -3017,9 +3017,9 @@ class rv_discrete(rv_generic):
 
         """
         args, loc, _ = self._parse_args(*args, **kwds)
-        _a, _b = self._get_support(*args)
         k, loc = map(asarray, (k, loc))
         args = tuple(map(asarray, args))
+        _a, _b = self._get_support(*args)
         k = asarray((k-loc))
         cond0 = self._argcheck(*args)
         cond1 = (k >= _a) & (k <= _b) & self._nonzero(k, *args)
@@ -3054,9 +3054,9 @@ class rv_discrete(rv_generic):
 
         """
         args, loc, _ = self._parse_args(*args, **kwds)
-        _a, _b = self._get_support(*args)
         k, loc = map(asarray, (k, loc))
         args = tuple(map(asarray, args))
+        _a, _b = self._get_support(*args)
         k = asarray((k-loc))
         cond0 = self._argcheck(*args)
         cond1 = (k >= _a) & (k <= _b) & self._nonzero(k, *args)
@@ -3092,9 +3092,9 @@ class rv_discrete(rv_generic):
 
         """
         args, loc, _ = self._parse_args(*args, **kwds)
-        _a, _b = self._get_support(*args)
         k, loc = map(asarray, (k, loc))
         args = tuple(map(asarray, args))
+        _a, _b = self._get_support(*args)
         k = asarray((k-loc))
         cond0 = self._argcheck(*args)
         cond1 = (k >= _a) & (k < _b)
@@ -3132,9 +3132,9 @@ class rv_discrete(rv_generic):
 
         """
         args, loc, _ = self._parse_args(*args, **kwds)
-        _a, _b = self._get_support(*args)
         k, loc = map(asarray, (k, loc))
         args = tuple(map(asarray, args))
+        _a, _b = self._get_support(*args)
         k = asarray((k-loc))
         cond0 = self._argcheck(*args)
         cond1 = (k >= _a) & (k < _b)
@@ -3173,9 +3173,9 @@ class rv_discrete(rv_generic):
 
         """
         args, loc, _ = self._parse_args(*args, **kwds)
-        _a, _b = self._get_support(*args)
         k, loc = map(asarray, (k, loc))
         args = tuple(map(asarray, args))
+        _a, _b = self._get_support(*args)
         k = asarray(k-loc)
         cond0 = self._argcheck(*args)
         cond1 = (k >= _a) & (k < _b)
@@ -3215,9 +3215,9 @@ class rv_discrete(rv_generic):
 
         """
         args, loc, _ = self._parse_args(*args, **kwds)
-        _a, _b = self._get_support(*args)
         k, loc = map(asarray, (k, loc))
         args = tuple(map(asarray, args))
+        _a, _b = self._get_support(*args)
         k = asarray(k-loc)
         cond0 = self._argcheck(*args)
         cond1 = (k >= _a) & (k < _b)
@@ -3255,9 +3255,9 @@ class rv_discrete(rv_generic):
 
         """
         args, loc, _ = self._parse_args(*args, **kwds)
-        _a, _b = self._get_support(*args)
         q, loc = map(asarray, (q, loc))
         args = tuple(map(asarray, args))
+        _a, _b = self._get_support(*args)
         cond0 = self._argcheck(*args) & (loc == loc)
         cond1 = (q > 0) & (q < 1)
         cond2 = (q == 1) & cond0
@@ -3296,9 +3296,9 @@ class rv_discrete(rv_generic):
 
         """
         args, loc, _ = self._parse_args(*args, **kwds)
-        _a, _b = self._get_support(*args)
         q, loc = map(asarray, (q, loc))
         args = tuple(map(asarray, args))
+        _a, _b = self._get_support(*args)
         cond0 = self._argcheck(*args) & (loc == loc)
         cond1 = (q > 0) & (q < 1)
         cond2 = (q == 1) & cond0

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -612,3 +612,26 @@ def check_fit_args_fix(distfn, arg, rvs):
             vals5 = distfn.fit(rvs, f2=arg[2])
             npt.assert_(len(vals5) == 2+len(arg))
             npt.assert_(vals5[2] == arg[2])
+
+
+@pytest.mark.parametrize('method', ['pdf', 'logpdf', 'cdf', 'logcdf',
+                                    'sf', 'logsf', 'ppf', 'isf'])
+@pytest.mark.parametrize('distname, args', distcont)
+def test_methods_with_lists(method, distname, args):
+    # Test that the continuous distributions can accept Python lists
+    # as arguments.
+    with npt.suppress_warnings() as sup:
+        sup.filter(category=DeprecationWarning, message=".*frechet_")
+        dist = getattr(stats, distname)
+        f = getattr(dist, method)
+        if distname == 'invweibull' and method.startswith('log'):
+            x = [1.5, 2]
+        else:
+            x = [0.1, 0.2]
+        shape2 = [[a]*2 for a in args]
+        loc = [0, 0.1]
+        scale = [1, 1.01]
+        result = f(x, *shape2, loc=loc, scale=scale)
+        npt.assert_allclose(result,
+                            [f(*v) for v in zip(x, *shape2, loc, scale)],
+                            rtol=1e-15, atol=1e-15)

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -250,3 +250,24 @@ def check_scale_docstring(distfn):
         # Docstrings can be stripped if interpreter is run with -OO
         npt.assert_('scale' not in distfn.__doc__)
 
+
+@pytest.mark.parametrize('method', ['pmf', 'logpmf', 'cdf', 'logcdf',
+                                    'sf', 'logsf', 'ppf', 'isf'])
+@pytest.mark.parametrize('distname, args', distdiscrete)
+def test_methods_with_lists(method, distname, args):
+    # Test that the discrete distributions can accept Python lists
+    # as arguments.
+    try:
+        dist = getattr(stats, distname)
+    except TypeError:
+        return
+    if method in ['ppf', 'isf']:
+        z = [0.1, 0.2]
+    else:
+        z = [0, 1]
+    p2 = [[p]*2 for p in args]
+    loc = [0, 1]
+    result = dist.pmf(z, *p2, loc=loc)
+    npt.assert_allclose(result,
+                        [dist.pmf(*v) for v in zip(z, *p2, loc)],
+                        rtol=1e-15, atol=1e-15)


### PR DESCRIPTION
Expressions such as

    >>> boltzmann.pmf(0, 2, [10, 11])
    >>> hypergeom.pmf(0, [10, 11], 5, 9)
    >>> randint.pmf(0, 0, [10, 11])

would raise

    TypeError: unsupported operand type(s) for -: 'list' and 'int'

Some of the continuous distributions also raise a TypeError when given a list, such as

    >>> genextreme.cdf(0.1, [1, 2])

which raises

    TypeError: '>' not supported between instances of 'list' and 'int'

The problem is the calculations in `_get_support(*args)` generally assume that the arguments are numpy arrays, so it should be called after the arguments have been passed through `asarray`. 

Closes gh-12178.
