### PR TITLE
DOC: for versionwarning don't use $.getScript

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -194,7 +194,10 @@ else:
 if 'versionwarning' in tags:
     # Specific to docs.scipy.org deployment.
     # See https://github.com/scipy/docs.scipy.org/blob/master/_static/versionwarning.js_t
-    src = '$.getScript("/doc/_static/versionwarning.js");'
+    src = ('var script = document.createElement("script");\n'
+           'script.type = "text/javascript";\n'
+           'script.src = "/doc/_static/versionwarning.js";\n'
+           'document.head.appendChild(script);');
     html_context = {
         'VERSIONCHECK_JS': src
     }


### PR DESCRIPTION
Jquery $.getScript by default turns browser caching off, which we don't
want here, so fetch the script with plain javascript.