### PR TITLE
ENH: Avoid re-factorizing covariance matrix in multivariate_normal_frozen

### DIFF
--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -95,6 +95,29 @@ class Distribution(Benchmark):
     time_distribution.version = "fb22ae5386501008d945783921fe44aef3f82c1dafc40cddfaccaeec38b792b0"
 
 
+class FrozenDistribution(Benchmark):
+    params = [
+            ['multivariate_normal'],
+            ['rvs'],
+            [1000]
+    ]
+    param_names = ['distribution', 'method', 'dimension']
+
+    def setup(self, distribution, method, dim):
+        np.random.seed(4321)
+        if distribution == 'multivariate_normal':
+            mean = np.random.rand(dim)
+            eigvals = np.random.rand(dim)
+            eigvals *= dim / np.sum(eigvals)
+            cov = stats.random_correlation.rvs(eigvals)
+            self.dist = stats.multivariate_normal(mean, cov)
+
+    def time_frozen_distribution(self, distribution, method, dim):
+        if distribution == 'multivariate_normal':
+            if method == 'rvs':
+                self.dist.rvs(100)
+
+
 class DescriptiveStats(Benchmark):
     param_names = ['n_levels']
     params = [

--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -107,10 +107,14 @@ class FrozenDistribution(Benchmark):
         np.random.seed(4321)
         if distribution == 'multivariate_normal':
             mean = np.random.rand(dim)
-            eigvals = np.random.rand(dim)
-            eigvals *= dim / np.sum(eigvals)
-            cov = stats.random_correlation.rvs(eigvals)
+            scale = np.diag(np.random.rand(dim))
+            cov = stats.wishart(df=dim + 1, scale=scale).rvs()
             self.dist = stats.multivariate_normal(mean, cov)
+            if method == 'rvs':
+                # Call the `rvs` method once to compute the necessary matrix
+                # factor. Subsequent calls to `rvs` don't have to compute this
+                # factor and get accelerated.
+                self.dist.rvs()
 
     def time_frozen_distribution(self, distribution, method, dim):
         if distribution == 'multivariate_normal':

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -859,8 +859,8 @@ class multivariate_normal_frozen(multi_rv_frozen):
         return _squeeze_output(out)
 
     def rvs(self, size=1, random_state=None):
-        # Compute a matrix `_cov_A` such that `_cov_A @ _cov_A.T == cov` using the
-        # singular value decomposition. Although other methods (such as an
+        # Compute a matrix `_cov_A` such that `_cov_A @ _cov_A.T == cov` using
+        # the singular value decomposition. Although other methods (such as an
         # eigenvalue or Cholesky decomposition) could be used to compute such a
         # matrix, we use SVD to maintain backward compatibility.
         if self._cov_A is None:

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -260,17 +260,22 @@ class TestMultivariateNormal(object):
 
     def test_frozen(self):
         # The frozen distribution should agree with the regular one
+        rvs_seed = 4567
         np.random.seed(1234)
         x = np.random.randn(5)
         mean = np.random.randn(5)
         cov = np.abs(np.random.randn(5))
-        norm_frozen = multivariate_normal(mean, cov)
+        norm_frozen = multivariate_normal(mean, cov, seed=rvs_seed)
         assert_allclose(norm_frozen.pdf(x), multivariate_normal.pdf(x, mean, cov))
         assert_allclose(norm_frozen.logpdf(x),
                         multivariate_normal.logpdf(x, mean, cov))
         assert_allclose(norm_frozen.cdf(x), multivariate_normal.cdf(x, mean, cov))
         assert_allclose(norm_frozen.logcdf(x),
                         multivariate_normal.logcdf(x, mean, cov))
+        n = 2
+        assert_array_almost_equal(
+            norm_frozen.rvs(n), multivariate_normal.rvs(mean, cov, size=n,
+                                                        random_state=rvs_seed))
 
     def test_pseudodet_pinv(self):
         # Make sure that pseudo-inverse and pseudo-det agree on cutoff


### PR DESCRIPTION
Closes #11772 

This PR introduces changes so that repeated calls to `rvs` don't re-factorize the covariance matrix of a frozen multivariate normal distribution. 

Benchmarks (added upon @rlucas7 's suggestion) look promising:

This branch:
```
[100.00%] ··· ....FrozenDistribution.time_frozen_distribution                 ok
[100.00%] ··· ===================== ============
              --                    method / dimension
              --------------------- ------------
                   distribution      rvs / 1000
              ===================== ============
               multivariate_normal   4.15±0.2ms
              ===================== ============
```

whereas master:
```
[100.00%] ··· ===================== ============
              --                    method / dimension
              --------------------- ------------
                   distribution      rvs / 1000
              ===================== ============
               multivariate_normal    235±3ms
              ===================== ============
```

P.S. 
Something similar can be done for the frozen matrix normal distribution as well. 

P.P.S 
#11413 (adding a multivariate t-distribution) can benefit from this too.
