### PR TITLE
MAINT: generalize tests in SphericalVoronoi

### DIFF
--- a/scipy/spatial/tests/test_spherical_voronoi.py
+++ b/scipy/spatial/tests/test_spherical_voronoi.py
@@ -109,27 +109,6 @@ class TestSphericalVoronoi(object):
             [0.79979205, 0.54555747, 0.25039913]]
         )
 
-        # Issue #9386
-        self.hemisphere_points = np.array([
-            [0.88610999, -0.42383021, 0.18755541],
-            [0.51980039, -0.72622668, 0.4498915],
-            [0.56540011, -0.81629197, -0.11827989],
-            [0.69659682, -0.69972598, 0.15854467]])
-
-        # Issue #8859
-        phi = np.linspace(0, 2 * np.pi, 10, endpoint=False)    # azimuth angle
-        theta = np.linspace(0.001, np.pi * 0.4, 5)    # polar angle
-        theta = theta[np.newaxis, :].T
-
-        phiv, thetav = np.meshgrid(phi, theta)
-        phiv = np.reshape(phiv, (50, 1))
-        thetav = np.reshape(thetav, (50, 1))
-
-        x = np.cos(phiv) * np.sin(thetav)
-        y = np.sin(phiv) * np.sin(thetav)
-        z = np.cos(thetav)
-        self.hemisphere_points2 = np.concatenate([x, y, z], axis=1)
-
     def test_constructor(self):
         center = np.array([1, 2, 3])
         radius = 2
@@ -239,25 +218,30 @@ class TestSphericalVoronoi(object):
         with assert_raises(ValueError):
             SphericalVoronoi(self.points, center=[0.1, 0, 0])
 
-    def test_single_hemisphere_handling(self):
-        # Test solution of Issues #9386, #8859
-
-        for points in [self.hemisphere_points, self.hemisphere_points2]:
-            sv = SphericalVoronoi(points)
-            triangles = sv.points[sv._simplices]
-            dots = np.einsum('ij,ij->i', sv.vertices, triangles[:, 0])
-            circumradii = np.arccos(np.clip(dots, -1, 1))
-            assert np.max(circumradii) > np.pi / 2
+    @pytest.mark.parametrize("dim", range(2, 6))
+    @pytest.mark.parametrize("shift", [False, True])
+    def test_single_hemisphere_handling(self, dim, shift):
+        n = 10
+        points = _sample_sphere(n, dim, seed=0)
+        points[:, 0] = np.abs(points[:, 0])
+        center = (np.arange(dim) + 1) * shift
+        sv = SphericalVoronoi(points + center, center=center)
+        dots = np.einsum('ij,ij->i', sv.vertices - center,
+                                     sv.points[sv._simplices[:, 0]] - center)
+        circumradii = np.arccos(np.clip(dots, -1, 1))
+        assert np.max(circumradii) > np.pi / 2
 
     @pytest.mark.parametrize("n", [1, 2, 10])
-    @pytest.mark.parametrize("center", [(0, 0, 0), (1, 2, 3)])
-    def test_rank_deficient(self, n, center):
-        thetas = np.linspace(0, 2 * np.pi, n, endpoint=False)
-        points = np.vstack([np.sin(thetas), np.cos(thetas), np.zeros(n)]).T
+    @pytest.mark.parametrize("dim", range(2, 6))
+    @pytest.mark.parametrize("shift", [False, True])
+    def test_rank_deficient(self, n, dim, shift):
+        center = (np.arange(dim) + 1) * shift
+        points = _sample_sphere(n, dim - 1, seed=0)
+        points = np.hstack([points, np.zeros((n, 1))])
         with pytest.raises(ValueError, match="Rank of input points"):
             SphericalVoronoi(points + center, center=center)
 
-    @pytest.mark.parametrize("dim", range(2, 7))
+    @pytest.mark.parametrize("dim", range(2, 6))
     def test_higher_dimensions(self, dim):
         n = 100
         points = _sample_sphere(n, dim, seed=0)
@@ -278,7 +262,7 @@ class TestSphericalVoronoi(object):
         actual_euler = sum([(-1)**i * e for i, e in enumerate(cell_counts)])
         assert expected_euler == actual_euler
 
-    @pytest.mark.parametrize("dim", range(2, 7))
+    @pytest.mark.parametrize("dim", range(2, 6))
     def test_cross_polytope_regions(self, dim):
         # The hypercube is the dual of the cross-polytope, so the voronoi
         # vertices of the cross-polytope lie on the points of the hypercube.
@@ -297,7 +281,7 @@ class TestSphericalVoronoi(object):
         res = linear_sum_assignment(dist)
         assert dist[res].sum() < TOL
 
-    @pytest.mark.parametrize("dim", range(2, 4))
+    @pytest.mark.parametrize("dim", range(2, 6))
     def test_hypercube_regions(self, dim):
         # The cross-polytope is the dual of the hypercube, so the voronoi
         # vertices of the hypercube lie on the points of the cross-polytope.


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->
#### What does this implement/fix?
The current single-hemisphere and rank-deficient tests are for 3D inputs only. Here I have generalized these tests to higher and lower dimensions.

I have also changed the maximum tested dimension to 5, since the tests get slower above this.

@tylerjereddy 