### PR TITLE
BUG: fix splprep seg fault for task=-1

### DIFF
--- a/scipy/interpolate/src/_fitpackmodule.c
+++ b/scipy/interpolate/src/_fitpackmodule.c
@@ -499,7 +499,7 @@ fitpack_parcur(PyObject *dummy, PyObject *args)
     if (ap_t == NULL || ap_c == NULL) {
         goto fail;
     }
-    if (iopt == 0|| n > no) {
+    if (iopt != 1|| n > no) {
         Py_XDECREF(ap_wrk);
         ap_wrk = NULL;
         Py_XDECREF(ap_iwrk);


### PR DESCRIPTION
Fixes random seg faults of the splprep routing caused by copying data into a zero sized array. 

#### Reference issue
This fixes #7395 for me.

#### What does this implement/fix?
The fix creates a correctly sized output array before copying data into it.
The parcur_cache in _fitpack_impl.py gets cleared when task <= 0, which leads to wrk and iwrk being initialized to a zero sized array. We therefore need to allocate a correctly sized array, before copying data into it.