### PR TITLE
TST: Fix str + bytes error

### DIFF
--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -778,7 +778,7 @@ def test_sgesdd_lwork_bug_workaround():
         p.terminate()
 
     assert_equal(returncode, 0,
-                 "Code apparently failed: " + p.stdout.read())
+                 "Code apparently failed: " + p.stdout.read().decode())
 
 
 class TestSytrd(object):


### PR DESCRIPTION
Quick low pri fix for https://github.com/scipy/scipy/issues/10179

Tested before and after with

```
SCIPY_XSLOW=1 python3 -c "import scipy, sys; scipy.test(extra_argv=['-v', '-k test_sgesdd'])"
```

as mentioned in issues