### PR TITLE
ENH: match np.result_type behaviour in some scipy.signal functions

### DIFF
--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -1195,8 +1195,12 @@ def sos2tf(sos):
     .. versionadded:: 0.16.0
     """
     sos = np.asarray(sos)
-    b = [1.]
-    a = [1.]
+    result_type = sos.dtype
+    if result_type.kind in 'bui':
+        result_type = np.float64
+
+    b = np.array([1], dtype=result_type)
+    a = np.array([1], dtype=result_type)
     n_sections = sos.shape[0]
     for section in range(n_sections):
         b = np.polymul(b, sos[section, :3])

--- a/scipy/signal/tests/test_result_type.py
+++ b/scipy/signal/tests/test_result_type.py
@@ -1,0 +1,54 @@
+# Regressions tests on result types of some signal functions
+
+import numpy as np
+from numpy.testing import assert_
+
+import pytest
+
+from scipy.signal import (decimate,
+                          lfilter_zi,
+                          lfiltic,
+                          sos2tf,
+                          sosfilt_zi)
+
+
+def test_decimate():
+    ones_f32 = np.ones(32, dtype=np.float32)
+    assert_(decimate(ones_f32, 2).dtype == np.float32)
+
+    ones_i64 = np.ones(32, dtype=np.int64)
+    assert_(decimate(ones_i64, 2).dtype == np.float64)
+    
+
+def test_lfilter_zi():
+    b_f32 = np.array([1, 2, 3], dtype=np.float32)
+    a_f32 = np.array([4, 5, 6], dtype=np.float32)
+    assert_(lfilter_zi(b_f32, a_f32).dtype == np.float32)
+
+
+def test_lfiltic():
+    # this would return f32 when given a mix of f32 / f64 args
+    b_f32 = np.array([1, 2, 3], dtype=np.float32)
+    a_f32 = np.array([4, 5, 6], dtype=np.float32)
+    x_f32 = np.ones(32, dtype=np.float32)
+    
+    b_f64 = b_f32.astype(np.float64)
+    a_f64 = a_f32.astype(np.float64)
+    x_f64 = x_f32.astype(np.float64)
+
+    assert_(lfiltic(b_f64, a_f32, x_f32).dtype == np.float64)
+    assert_(lfiltic(b_f32, a_f64, x_f32).dtype == np.float64)
+    assert_(lfiltic(b_f32, a_f32, x_f64).dtype == np.float64)
+    assert_(lfiltic(b_f32, a_f32, x_f32, x_f64).dtype == np.float64)
+
+
+def test_sos2tf():
+    sos_f32 = np.array([[4, 5, 6, 1, 2, 3]], dtype=np.float32)
+    b, a = sos2tf(sos_f32)
+    assert_(b.dtype == np.float32)
+    assert_(a.dtype == np.float32)
+
+
+def test_sosfilt_zi():
+    sos_f32 = np.array([[4, 5, 6, 1, 2, 3]], dtype=np.float32)
+    assert_(sosfilt_zi(sos_f32).dtype == np.float32)


### PR DESCRIPTION
Changes the following to have return type np.float32 when all
arguments have type np.float32, and to have return type np.complex64
when all arguments are have type float32 and complex64.
  - decimate
  - lfilter_zi
  - lfiltic
  - sos2tf
  - sosfilt_zi

decimate was also changed to return np.float64 when all arguments are
neither float32, nor float64.  sos2tf and lfiltic already had this
behaviour, which has been maintained.

Adds tests for this behaviour for the above functions and also:
  - filtfilt (no complex type support with method='gust')
  - lfilter
  - savgol_filter (no complex type support)
  - sosfilt
  - sosfiltfilt

Fixes #3158.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->