### PR TITLE
ENH: tool to DL release wheels from Anaconda

### DIFF
--- a/tools/download-wheels.py
+++ b/tools/download-wheels.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+"""
+Download SciPy wheels from Anaconda staging area.
+
+"""
+import sys
+import os
+import re
+import shutil
+import argparse
+
+import urllib3
+from bs4 import BeautifulSoup
+
+__version__ = '0.1'
+
+# Edit these for other projects.
+STAGING_URL = 'https://anaconda.org/multibuild-wheels-staging/scipy'
+PREFIX = '^.*scipy-'
+
+def get_wheel_names(version):
+    """ Get wheel names from Anaconda HTML directory.
+
+    This looks in the Anaconda multibuild-wheels-staging page and
+    parses the HTML to get all the wheel names for a release version.
+
+    Parameters
+    ----------
+    version : str
+        The release version. For instance, "1.5.0".
+
+    """
+    http = urllib3.PoolManager(cert_reqs='CERT_REQUIRED')
+    tmpl = re.compile(rf"{PREFIX}{version}.*\.whl$")
+    index_url =  f"{STAGING_URL}/files"
+    index_html = http.request('GET', index_url)
+    soup = BeautifulSoup(index_html.data, 'html.parser')
+    return soup.findAll(text=tmpl)
+
+
+def download_wheels(version, wheelhouse):
+    """Download release wheels.
+
+    The release wheels for the given SciPy version are downloaded
+    into the given directory.
+
+    Parameters
+    ----------
+    version : str
+        The release version. For instance, "1.5.0".
+    wheelhouse : str
+        Directory in which to download the wheels.
+
+    """
+    http = urllib3.PoolManager(cert_reqs='CERT_REQUIRED')
+    wheel_names = get_wheel_names(version)
+
+    for i, wheel_name in enumerate(wheel_names):
+        wheel_url = f"{STAGING_URL}/{version}/download/{wheel_name}"
+        wheel_path = os.path.join(wheelhouse, wheel_name)
+        with open(wheel_path, 'wb') as f:
+            with http.request('GET', wheel_url, preload_content=False,) as r:
+                print(f"Downloading wheel {i + 1}, name: {wheel_name}")
+                shutil.copyfileobj(r, f)
+    print(f"\nTotal files downloaded: {len(wheel_names)}")
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "version",
+         help="SciPy version to download.")
+    parser.add_argument(
+        "-w", "--wheelhouse",
+        default=os.path.join(os.getcwd(), "release", "installers"),
+        help="Directory in which to store downloaded wheels\n"
+             "[defaults to <cwd>/release/installers]")
+
+    args = parser.parse_args()
+
+    wheelhouse = os.path.expanduser(args.wheelhouse)
+    if not os.path.isdir(wheelhouse):
+        raise RuntimeError(
+            f"{wheelhouse} wheelhouse directory is not present."
+            " Perhaps you need to use the '-w' flag to specify one.")
+
+    download_wheels(args.version, wheelhouse)

--- a/tools/download-wheels.py
+++ b/tools/download-wheels.py
@@ -16,7 +16,7 @@ __version__ = '0.1'
 
 # Edit these for other projects.
 STAGING_URL = 'https://anaconda.org/multibuild-wheels-staging/scipy'
-PREFIX = '^.*scipy-'
+PREFIX = 'scipy'
 
 def get_wheel_names(version):
     """ Get wheel names from Anaconda HTML directory.
@@ -31,8 +31,8 @@ def get_wheel_names(version):
 
     """
     http = urllib3.PoolManager(cert_reqs='CERT_REQUIRED')
-    tmpl = re.compile(rf"{PREFIX}{version}.*\.whl$")
-    index_url =  f"{STAGING_URL}/files"
+    tmpl = re.compile(rf"^.*{PREFIX}-{version}-.*\.whl$")
+    index_url = f"{STAGING_URL}/files"
     index_html = http.request('GET', index_url)
     soup = BeautifulSoup(index_html.data, 'html.parser')
     return soup.findAll(text=tmpl)
@@ -60,7 +60,7 @@ def download_wheels(version, wheelhouse):
         wheel_path = os.path.join(wheelhouse, wheel_name)
         with open(wheel_path, 'wb') as f:
             with http.request('GET', wheel_url, preload_content=False,) as r:
-                print(f"Downloading wheel {i + 1}, name: {wheel_name}")
+                print(f"{i + 1:<4}{wheel_name}")
                 shutil.copyfileobj(r, f)
     print(f"\nTotal files downloaded: {len(wheel_names)}")
 
@@ -69,7 +69,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "version",
-         help="SciPy version to download.")
+        help="SciPy version to download.")
     parser.add_argument(
         "-w", "--wheelhouse",
         default=os.path.join(os.getcwd(), "release", "installers"),


### PR DESCRIPTION
* because of the rackspace -> `anaconda.org` migration
for binary assets during the release process, we should
probably "borrow" the approach NumPy is using to retrieve
wheels from the new site--see:
https://github.com/numpy/numpy/pull/16265

* I modified the NumPy script only to account for the
name change to SciPy in a few places

* testing locally, it seems to work ok--I may need to
first purge the staging area of all the merged/uploaded
"junk" binaries before the release though, since there's
a bit of promiscuity otherwise:

```
mkdir wheelhouse
python tools/download-wheels.py 1.5.0 -w ./wheelhouse/
...
Downloading wheel 1, name:
scipy-1.5.0.dev0+01c65a7-cp37-cp37m-manylinux1_i686.whl
Downloading wheel 2, name:
scipy-1.5.0.dev0+01c65a7-cp36-cp36m-manylinux1_i686.whl
Downloading wheel 3, name:
scipy-1.5.0.dev0+01c65a7-cp38-cp38-manylinux1_i686.whl
Downloading wheel 4, name:
scipy-1.5.0.dev0+01c65a7-cp37-cp37m-manylinux1_x86_64.whl
```

cc @charris @mattip @rgommers 