### PR TITLE
BUG: wavfile bugfixes and maintenance

### DIFF
--- a/scipy/io/wavfile.py
+++ b/scipy/io/wavfile.py
@@ -567,9 +567,6 @@ def read(filename, mmap=False):
         file_size, is_big_endian = _read_riff_chunk(fid)
         fmt_chunk_received = False
         data_chunk_received = False
-        channels = 1
-        bit_depth = 8
-        format_tag = WAVE_FORMAT.PCM
         while fid.tell() < file_size:
             # read the next chunk
             chunk_id = fid.read(4)

--- a/scipy/io/wavfile.py
+++ b/scipy/io/wavfile.py
@@ -305,9 +305,6 @@ class WAVE_FORMAT(IntEnum):
 
 KNOWN_WAVE_FORMATS = {WAVE_FORMAT.PCM, WAVE_FORMAT.IEEE_FLOAT}
 
-# assumes file pointer is immediately
-#  after the 'fmt ' id
-
 
 def _read_fmt_chunk(fid, is_big_endian):
     """
@@ -327,6 +324,10 @@ def _read_fmt_chunk(fid, is_big_endian):
         bytes per sample, including all channels
     bit_depth : int
         bits per sample
+
+    Notes
+    -----
+    Assumes file pointer is immediately after the 'fmt ' id
     """
     if is_big_endian:
         fmt = '>'
@@ -380,9 +381,13 @@ def _read_fmt_chunk(fid, is_big_endian):
             bit_depth)
 
 
-# assumes file pointer is immediately after the 'data' id
 def _read_data_chunk(fid, format_tag, channels, bit_depth, is_big_endian,
                      mmap=False):
+    """
+    Notes
+    -----
+    Assumes file pointer is immediately after the 'data' id
+    """
     if is_big_endian:
         fmt = '>I'
     else:

--- a/scipy/io/wavfile.py
+++ b/scipy/io/wavfile.py
@@ -511,7 +511,8 @@ def read(filename, mmap=False):
         Sample rate of wav file.
     data : numpy array
         Data read from wav file. Data-type is determined from the file;
-        see Notes.
+        see Notes.  Data is 1-D for 1-channel WAV, or 2-D of shape
+        (Nsamples, Nchannels) otherwise.
 
     Notes
     -----

--- a/scipy/io/wavfile.py
+++ b/scipy/io/wavfile.py
@@ -408,26 +408,23 @@ def _read_data_chunk(fid, format_tag, channels, bit_depth, is_big_endian,
         nChannels = 2, nBlockAlign = 8, wBitsPerSample = 20
     """
     if is_big_endian:
-        fmt = '>I'
+        fmt = '>'
     else:
-        fmt = '<I'
+        fmt = '<'
 
     # Size of the data subchunk in bytes
-    size = struct.unpack(fmt, fid.read(4))[0]
+    size = struct.unpack(fmt+'I', fid.read(4))[0]
 
     # Number of bytes per sample (sample container size)
     bytes_per_sample = block_align // channels
     if bit_depth == 8:
         dtype = 'u1'
     else:
-        if is_big_endian:
-            dtype = '>'
-        else:
-            dtype = '<'
         if format_tag == WAVE_FORMAT.PCM:
-            dtype += 'i%d' % bytes_per_sample
+            dtype = f'{fmt}i{bytes_per_sample}'
         else:
-            dtype += 'f%d' % bytes_per_sample
+            dtype = f'{fmt}f{bytes_per_sample}'
+
     if not mmap:
         data = numpy.frombuffer(fid.read(size), dtype=dtype)
     else:

--- a/scipy/io/wavfile.py
+++ b/scipy/io/wavfile.py
@@ -334,14 +334,13 @@ def _read_fmt_chunk(fid, is_big_endian):
     else:
         fmt = '<'
 
-    size = res = struct.unpack(fmt+'I', fid.read(4))[0]
-    bytes_read = 0
+    size = struct.unpack(fmt+'I', fid.read(4))[0]
 
     if size < 16:
         raise ValueError("Binary structure of wave file is not compliant")
 
     res = struct.unpack(fmt+'HHIIHH', fid.read(16))
-    bytes_read += 16
+    bytes_read = 16
 
     format_tag, channels, fs, bytes_per_second, block_align, bit_depth = res
 
@@ -374,7 +373,7 @@ def _read_fmt_chunk(fid, is_big_endian):
                          ', '.join(x.name for x in KNOWN_WAVE_FORMATS))
 
     # move file pointer to next chunk
-    if size > (bytes_read):
+    if size > bytes_read:
         fid.read(size - bytes_read)
 
     return (size, format_tag, channels, fs, bytes_per_second, block_align,


### PR DESCRIPTION
#### What does this implement/fix?
Working my way through the changes in https://github.com/scipy/scipy/pull/6852 and https://github.com/X-Raym/wavfile.py

These are small bug fixes and changes that should be easy to get through.

Bug 1: bytes_per_sample was being calculated from bits_per_sample instead of the actual container size reported by the format chunk
Bug 2: Odd-length chunks have a padding byte which is not included in their length, and SciPy was not including this when seeking through the chunk, which is the actual cause of #10332.

Neither bug affects current functionality, but will be necessary for future enhancements.
