### PR TITLE
Remove py.typed marker (at least for the release)

### DIFF
--- a/scipy/setup.py
+++ b/scipy/setup.py
@@ -25,7 +25,6 @@ def configuration(parent_package='',top_path=None):
     config.add_subpackage('_build_utils')
     config.add_subpackage('_lib')
     config.make_config_py()
-    config.add_data_files('py.typed')
     return config
 
 


### PR DESCRIPTION
#### Reference issue
None

#### What does this implement/fix?
As of now I don't think the types are quite ready for prime-time, so
remove the `py.typed` marker so that type checkers ignore them. I
think we will be in a better situation come next release:

- We will have had more time to work on them
- There will probably be a released version of NumPy with types

#### Additional information
None