### PR TITLE
DOC: fix docstring of "sd_beta" of odr.Output.

### DIFF
--- a/scipy/odr/odrpack.py
+++ b/scipy/odr/odrpack.py
@@ -549,7 +549,7 @@ class Output(object):
     beta : ndarray
         Estimated parameter values, of shape (q,).
     sd_beta : ndarray
-        Standard errors of the estimated parameters, of shape (p,).
+        Standard deviations of the estimated parameters, of shape (p,).
     cov_beta : ndarray
         Covariance matrix of the estimated parameters, of shape (p,p).
     delta : ndarray, optional


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
fix #9857

#### What does this implement/fix?
<!--Please explain your changes.-->
fix docstring of "sd_beta" of odr.Output, because "sd" means Standard deviations.
