### PR TITLE
BUG: stats: Fix handling of edge cases in median_abs_deviation.

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -2853,6 +2853,25 @@ def iqr(x, axis=None, rng=(25, 75), scale=1.0, nan_policy='propagate',
     return out
 
 
+def _mad_1d(x, center, nan_policy):
+    # Median absolute deviation for 1-d array x.  No warning is generated
+    # if x is empty or all nan.
+    # x must be a 1-d numpy array.
+    # If nan_policy is not 'propagate', it is assumed to be 'omit'.
+    isnan = np.isnan(x)
+    if isnan.any():
+        if nan_policy == 'propagate':
+            return np.nan
+        x = x[~isnan]
+    if x.size == 0:
+        # MAD of an empty array is nan.
+        return np.nan
+    # Edge cases have been handled, so do the basic MAD calculation.
+    med = center(x)
+    mad = np.median(np.abs(x - med))
+    return mad
+
+
 def median_abs_deviation(x, axis=0, center=np.median, scale=1.0,
                          nan_policy='propagate'):
     r"""
@@ -2914,6 +2933,13 @@ def median_abs_deviation(x, axis=0, center=np.median, scale=1.0,
     will calculate the MAD around the mean - it will not calculate the *mean*
     absolute deviation.
 
+    The default `center` function is `numpy.median`, but it is wrapped in
+    code that will prevent it from generating a warning if it is given an
+    empty input.
+
+    The input array may contain `inf`, but if `center` returns `inf`, the
+    corresponding MAD for that data will be `nan`.
+
     References
     ----------
     .. [1] "Median absolute deviation",
@@ -2971,30 +2997,30 @@ def median_abs_deviation(x, axis=0, center=np.median, scale=1.0,
 
     # Consistent with `np.var` and `np.std`.
     if not x.size:
-        nan_shape = [item for i, item in enumerate(x.shape) if i != axis]
-        nan_array = np.full(nan_shape, np.nan)
-        if not nan_array.size:
+        if axis is None:
             return np.nan
-        else:
-            return nan_array
+        nan_shape = tuple(item for i, item in enumerate(x.shape) if i != axis)
+        if nan_shape == ():
+            # Return nan, not array(nan)
+            return np.nan
+        return np.full(nan_shape, np.nan)
 
     contains_nan, nan_policy = _contains_nan(x, nan_policy)
 
-    if contains_nan and nan_policy == 'propagate':
-        return np.nan
-
-    if contains_nan and nan_policy == 'omit':
-        # Way faster than carrying the masks around
-        arr = ma.masked_invalid(x).compressed()
+    if contains_nan:
+        if axis is None:
+            mad = _mad_1d(x.ravel(), center, nan_policy)
+        else:
+            mad = np.apply_along_axis(_mad_1d, axis, x, center, nan_policy)
     else:
-        arr = x
-
-    if axis is None:
-        med = center(arr)
-        mad = np.median(np.abs(arr - med))
-    else:
-        med = np.apply_over_axes(center, arr, axis)
-        mad = np.median(np.abs(arr - med), axis=axis)
+        if axis is None:
+            med = center(x, axis=None)
+            mad = np.median(np.abs(x - med))
+        else:
+            # Wrap the call to center() in expand_dims() so it acts like
+            # keepdims=True was used.
+            med = np.expand_dims(center(x, axis=axis), axis)
+            mad = np.median(np.abs(x - med), axis=axis)
 
     return mad / scale
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1937,6 +1937,10 @@ class TestMedianAbsDeviation(object):
                                          axis=axis)
         assert_allclose(mad, expected, rtol=1e-15, atol=1e-15)
 
+    def test_center_not_callable(self):
+        with pytest.raises(TypeError, match='callable'):
+            stats.median_abs_deviation([1, 2, 3, 5], center=99)
+
 
 class TestMedianAbsoluteDeviation(object):
     def setup_class(self):

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1882,11 +1882,11 @@ class TestVariability(object):
 class TestMedianAbsDeviation(object):
     def setup_class(self):
         self.dat_nan = np.array([2.20, 2.20, 2.4, 2.4, 2.5, 2.7, 2.8, 2.9,
-                3.03, 3.03, 3.10, 3.37, 3.4, 3.4, 3.4, 3.5, 3.6, 3.7, 3.7,
-                3.7, 3.7, 3.77, 5.28, np.nan])
+                                 3.03, 3.03, 3.10, 3.37, 3.4, 3.4, 3.4, 3.5,
+                                 3.6, 3.7, 3.7, 3.7, 3.7, 3.77, 5.28, np.nan])
         self.dat = np.array([2.20, 2.20, 2.4, 2.4, 2.5, 2.7, 2.8, 2.9, 3.03,
-                3.03, 3.10, 3.37, 3.4, 3.4, 3.4, 3.5, 3.6, 3.7, 3.7,
-                3.7, 3.7, 3.77, 5.28, 28.95])
+                             3.03, 3.10, 3.37, 3.4, 3.4, 3.4, 3.5, 3.6, 3.7,
+                             3.7, 3.7, 3.7, 3.77, 5.28, 28.95])
 
     def test_median_abs_deviation(self):
         assert_almost_equal(stats.median_abs_deviation(self.dat, axis=None),

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1900,6 +1900,43 @@ class TestMedianAbsDeviation(object):
         mad = stats.median_abs_deviation(self.dat_nan, nan_policy='omit')
         assert_almost_equal(mad, 0.34)
 
+    def test_axis_and_nan(self):
+        x = np.array([[1.0, 2.0, 3.0, 4.0, np.nan],
+                      [1.0, 4.0, 5.0, 8.0, 9.0]])
+        mad = stats.median_abs_deviation(x, axis=1)
+        assert_equal(mad, np.array([np.nan, 3.0]))
+
+    def test_nan_policy_omit_with_inf(sef):
+        z = np.array([1, 3, 4, 6, 99, np.nan, np.inf])
+        mad = stats.median_abs_deviation(z, nan_policy='omit')
+        assert_equal(mad, 3.0)
+
+    @pytest.mark.parametrize('axis', [0, 1, 2, None])
+    def test_size_zero_with_axis(self, axis):
+        x = np.zeros((3, 0, 4))
+        mad = stats.median_abs_deviation(x, axis=axis)
+        assert_equal(mad, np.full_like(x.sum(axis=axis), fill_value=np.nan))
+
+    @pytest.mark.parametrize('nan_policy, expected',
+                             [('omit', np.array([np.nan, 1.5, 1.5])),
+                              ('propagate', np.array([np.nan, np.nan, 1.5]))])
+    def test_nan_policy_with_axis(self, nan_policy, expected):
+        x = np.array([[np.nan, np.nan, np.nan, np.nan, np.nan, np.nan],
+                      [1, 5, 3, 6, np.nan, np.nan],
+                      [5, 6, 7, 9, 9, 10]])
+        mad = stats.median_abs_deviation(x, nan_policy=nan_policy, axis=1)
+        assert_equal(mad, expected)
+
+    @pytest.mark.parametrize('axis, expected',
+                             [(1, [2.5, 2.0, 12.0]), (None, 4.5)])
+    def test_center_mean_with_nan(self, axis, expected):
+        x = np.array([[1, 2, 4, 9, np.nan],
+                      [0, 1, 1, 1, 12],
+                      [-10, -10, -10, 20, 20]])
+        mad = stats.median_abs_deviation(x, center=np.mean, nan_policy='omit',
+                                         axis=axis)
+        assert_allclose(mad, expected, rtol=1e-15, atol=1e-15)
+
 
 class TestMedianAbsoluteDeviation(object):
     def setup_class(self):


### PR DESCRIPTION
The edge cases that are fixed:
* Size 0 arrays with an axis argument are now handled correctly;
  the return value is an appropriately shaped array of nan.
* The return value when the input contains nan, axis is used
  and nan_policy is 'propagate' is fixed.  It used to return a
  scalar nan, now it returns the array with the result of the
  MAD calculation applied along the axis.
* inf is not ignored when nan_policy='omit'.