### PR TITLE
BUG: stats: wilcoxon returned p > 1 for certain inputs.

### DIFF
--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -3035,9 +3035,13 @@ def wilcoxon(x, y=None, zero_method="wilcox", correction=False,
         # note: r_plus is int (ties not allowed), need int for slices below
         r_plus = int(r_plus)
         if alternative == "two-sided":
-            p_less = np.sum(cnt[:r_plus + 1]) / 2**count
-            p_greater = np.sum(cnt[r_plus:]) / 2**count
-            prob = 2*min(p_greater, p_less)
+            if r_plus == (len(cnt) - 1) // 2:
+                # r_plus is the center of the distribution.
+                prob = 1.0
+            else:
+                p_less = np.sum(cnt[:r_plus + 1]) / 2**count
+                p_greater = np.sum(cnt[r_plus:]) / 2**count
+                prob = 2*min(p_greater, p_less)
         elif alternative == "greater":
             prob = np.sum(cnt[r_plus:]) / 2**count
         else:

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1087,6 +1087,21 @@ class TestWilcoxon(object):
         d = np.arange(26) + 1
         assert_raises(ValueError, stats.wilcoxon, d, mode="exact")
 
+    # These inputs were chosen to give a W statistic that is either the
+    # center of the distribution (when the length of the support is odd), or
+    # the value to the left of the center (when the length of the support is
+    # even).  Also, the numbers are chosen so that the W statistic is the
+    # sum of the positive values.
+    @pytest.mark.parametrize('x', [[-1, -2, 3],
+                                   [-1, 2, -3, -4, 5],
+                                   [-1, -2, 3, -4, -5, -6, 7, 8]])
+    def test_exact_p_1(self, x):
+        w, p = stats.wilcoxon(x)
+        x = np.array(x)
+        wtrue = x[x > 0].sum()
+        assert_equal(w, wtrue)
+        assert_equal(p, 1)
+
     def test_auto(self):
         # auto default to exact if there are no ties and n<= 25
         x = np.arange(0, 25) + 0.5


### PR DESCRIPTION
When the W statistic associated with an input array occurred
at the center of the distribution and the length of the support
of the distribution was odd, the two-sided calculation of the
p-value counted the middle value of the distribution twice,
resulting in a p-value greater than 1.

The code now handles this case explicitly.

