### PR TITLE
BLD: Set macos min version when building rectangular_lsap

### DIFF
--- a/scipy/_build_utils/compiler_helper.py
+++ b/scipy/_build_utils/compiler_helper.py
@@ -3,6 +3,8 @@ Helpers for detection of compiler features
 """
 import tempfile
 import os
+import sys
+from numpy.distutils.system_info import dict_append
 
 def try_compile(compiler, code=None, flags=[], ext=None):
     """Returns True if the compiler is able to compile the given code"""
@@ -64,3 +66,40 @@ def try_add_flag(args, compiler, flag, ext=None):
     """Appends flag to the list of arguments if supported by the compiler"""
     if try_compile(compiler, flags=args+[flag], ext=ext):
         args.append(flag)
+
+def set_cxx_flags_hook(build_ext, ext):
+    """Sets basic compiler flags for compiling C++11 code"""
+    cc = build_ext._cxx_compiler
+    args = ext.extra_compile_args
+
+    std_flag = get_cxx_std_flag(cc)
+    if std_flag is not None:
+        args.append(std_flag)
+
+    if sys.platform == 'darwin':
+        # Set min macOS version
+        min_macos_flag = '-mmacosx-version-min=10.9'
+        if has_flag(cc, min_macos_flag):
+            args.append(min_macos_flag)
+            ext.extra_link_args.append(min_macos_flag)
+
+
+def set_cxx_flags_clib_hook(build_clib, build_info):
+    cc = build_clib.compiler
+    new_args = []
+    new_link_args = []
+
+    std_flag = get_cxx_std_flag(cc)
+    if std_flag is not None:
+        new_args.append(std_flag)
+
+    if sys.platform == 'darwin':
+        # Set min macOS version
+        min_macos_flag = '-mmacosx-version-min=10.9'
+        if has_flag(cc, min_macos_flag):
+            new_args.append(min_macos_flag)
+            new_link_args.append(min_macos_flag)
+
+    dict_append(build_info, extra_compile_args=new_args,
+                extra_link_args=new_link_args)
+

--- a/scipy/_lib/_uarray/setup.py
+++ b/scipy/_lib/_uarray/setup.py
@@ -1,24 +1,16 @@
 
 def pre_build_hook(build_ext, ext):
     from scipy._build_utils.compiler_helper import (
-        get_cxx_std_flag, has_flag, try_add_flag)
+        set_cxx_flags_hook, try_add_flag)
     cc = build_ext._cxx_compiler
     args = ext.extra_compile_args
 
-    std_flag = get_cxx_std_flag(cc)
-    if std_flag is not None:
-        args.append(std_flag)
+    set_cxx_flags_hook(build_ext, ext)
 
     if cc.compiler_type == 'msvc':
         args.append('/EHsc')
     else:
         try_add_flag(args, cc, '-fvisibility=hidden')
-
-        min_macos_flag = '-mmacosx-version-min=10.9'
-        import sys
-        if sys.platform == 'darwin' and has_flag(cc, min_macos_flag):
-            args.append(min_macos_flag)
-            ext.extra_link_args.append(min_macos_flag)
 
 
 def configuration(parent_package='', top_path=None):

--- a/scipy/fft/_pocketfft/setup.py
+++ b/scipy/fft/_pocketfft/setup.py
@@ -1,13 +1,11 @@
 
 def pre_build_hook(build_ext, ext):
     from scipy._build_utils.compiler_helper import (
-        get_cxx_std_flag, try_add_flag, try_compile, has_flag)
+        set_cxx_flags_hook, try_add_flag, try_compile, has_flag)
     cc = build_ext._cxx_compiler
     args = ext.extra_compile_args
 
-    std_flag = get_cxx_std_flag(cc)
-    if std_flag is not None:
-        args.append(std_flag)
+    set_cxx_flags_hook(build_ext, ext)
 
     if cc.compiler_type == 'msvc':
         args.append('/EHsc')
@@ -26,12 +24,6 @@ def pre_build_hook(build_ext, ext):
 
         # Don't export library symbols
         try_add_flag(args, cc, '-fvisibility=hidden')
-        # Set min macOS version
-        min_macos_flag = '-mmacosx-version-min=10.9'
-        import sys
-        if sys.platform == 'darwin' and has_flag(cc, min_macos_flag):
-            args.append(min_macos_flag)
-            ext.extra_link_args.append(min_macos_flag)
 
 
 def configuration(parent_package='', top_path=None):

--- a/scipy/optimize/setup.py
+++ b/scipy/optimize/setup.py
@@ -9,6 +9,8 @@ def configuration(parent_package='',top_path=None):
     from scipy._build_utils import (gfortran_legacy_flag_hook,
                                     blas_ilp64_pre_build_hook, combine_dict,
                                     uses_blas64, get_f2py_int64_options)
+    from scipy._build_utils.compiler_helper import (
+        set_cxx_flags_hook, set_cxx_flags_clib_hook)
 
     config = Configuration('optimize',parent_package, top_path)
 
@@ -26,14 +28,16 @@ def configuration(parent_package='',top_path=None):
 
     config.add_library('rectangular_lsap',
                        sources='rectangular_lsap/rectangular_lsap.cpp',
-                       headers='rectangular_lsap/rectangular_lsap.h')
-    config.add_extension('_lsap_module',
-                         sources=['_lsap_module.c'],
-                         libraries=['rectangular_lsap'],
-                         depends=(['rectangular_lsap/rectangular_lsap.cpp',
-                                   'rectangular_lsap/rectangular_lsap.h']),
-                         include_dirs=include_dirs,
-                         **numpy_nodepr_api)
+                       headers='rectangular_lsap/rectangular_lsap.h',
+                       _pre_build_hook=set_cxx_flags_clib_hook)
+    config.add_extension(
+        '_lsap_module',
+        sources=['_lsap_module.c'],
+        libraries=['rectangular_lsap'],
+        depends=(['rectangular_lsap/rectangular_lsap.cpp',
+                  'rectangular_lsap/rectangular_lsap.h']),
+        include_dirs=include_dirs,
+        **numpy_nodepr_api)
 
     rootfind_src = [join('Zeros','*.c')]
     rootfind_hdr = [join('Zeros','zeros.h')]

--- a/scipy/spatial/setup.py
+++ b/scipy/spatial/setup.py
@@ -2,18 +2,12 @@ from os.path import join, dirname
 import glob
 
 
-def pre_build_hook(build_ext, ext):
-    from scipy._build_utils.compiler_helper import get_cxx_std_flag
-    std_flag = get_cxx_std_flag(build_ext._cxx_compiler)
-    if std_flag is not None:
-        ext.extra_compile_args.append(std_flag)
-
-
 def configuration(parent_package='', top_path=None):
     from numpy.distutils.misc_util import Configuration, get_numpy_include_dirs
     from numpy.distutils.misc_util import get_info as get_misc_info
     from scipy._build_utils.system_info import get_info
     from scipy._build_utils import combine_dict, uses_blas64
+    from scipy._build_utils.compiler_helper import set_cxx_flags_hook
     from distutils.sysconfig import get_python_inc
 
     config = Configuration('spatial', parent_package, top_path)
@@ -70,7 +64,7 @@ def configuration(parent_package='', top_path=None):
                          sources=['ckdtree.cxx'] + ckdtree_src,
                          depends=ckdtree_dep,
                          include_dirs=inc_dirs + [join('ckdtree', 'src')])
-    ext._pre_build_hook = pre_build_hook
+    ext._pre_build_hook = set_cxx_flags_hook
 
     # _distance_wrap
     config.add_extension('_distance_wrap',


### PR DESCRIPTION
Fixes gh-12203

The build error in the issue indicates clang trying to build `rectangular_lsap` with `libstdc++` instead of `libc++` but not finding the includes:
```
    clang: warning: include path for libstdc++ headers not found; pass '-stdlib=libc++' on the command line to use the libc++ standard library instead [-Wstdlibcxx-not-found]
    scipy/optimize/rectangular_lsap/rectangular_lsap.cpp:43:10: fatal error: 'algorithm' file not found
    #include <algorithm>
```

From what I've read, `libstdc++` is the default on older versions of macos but setting `-macos-min-version=10.9` will make `-stdlib=libc++` the default.

These flags should be the same for all C++ code using the standard library, so I've factored out a build hook that can be shared with other C++ extensions.