### PR TITLE
BUG: Fix exit condition for QUICK_SELECT pivot

### DIFF
--- a/scipy/signal/medianfilter.c
+++ b/scipy/signal/medianfilter.c
@@ -14,8 +14,8 @@ extern char *check_malloc (int);
 
 
 /* The QUICK_SELECT routine is based on Hoare's Quickselect algorithm,
- * with unrolled recursion. 
- * Author: Thouis R. Jones, 2008 
+ * with unrolled recursion.
+ * Author: Thouis R. Jones, 2008
  */
 
 #define ELEM_SWAP(t, a, x, y) {register t temp = (a)[x]; (a)[x] = (a)[y]; (a)[y] = temp;}
@@ -54,7 +54,7 @@ TYPE NAME(TYPE arr[], int n)                                            \
         for (ll = lo+1, hh = hi;; ll++, hh--) {                         \
 	    while (arr[ll] < piv) ll++;					\
 	    while (arr[hh] > piv) hh--;					\
-	    if (hh < ll) break;						\
+	    if (hh <= ll) break;					\
 	    ELEM_SWAP(TYPE, arr, ll, hh);				\
         }                                                               \
         /* move pivot to top of lower partition */                      \


### PR DESCRIPTION
Fixes: https://github.com/scipy/scipy/issues/9476

```
import numpy as np, scipy.signal
scipy.signal.medfilt2d(np.array([[100, 5, 10], [15, 20, 25], [30, 35, 100]], np.uint8))
```

before
```
lo: 0 mid: 4, hi: 8
arr before median swap 100 5 10 15 20 25 30 35 100
arr after median swap 100 5 10 15 20 25 30 35 100
lo=0, hi=8
test swap: piv:100 ll:8 hh:8
test swap: piv:100 ll:9 hh:7
```

after
```
lo: 0 mid: 4, hi: 8
arr before median swap: 100 5 10 15 20 25 30 35 100
arr after median swap: 100 5 10 15 20 25 30 35 100
lo=0, hi=8
test swap: piv:100 ll:8 hh:8
```