### PR TITLE
ENH: Rename ndimage.sum to ndimage.sum_labels (keep sum as alias)

### DIFF
--- a/scipy/ndimage/__init__.py
+++ b/scipy/ndimage/__init__.py
@@ -85,7 +85,7 @@ Measurements
    minimum
    minimum_position
    standard_deviation - Standard deviation of an N-D image array
-   sum - Sum of the values of the array
+   sum_labels - Sum of the values of the array
    variance - Variance of the values of an N-D image array
    watershed_ift
 

--- a/scipy/ndimage/measurements.py
+++ b/scipy/ndimage/measurements.py
@@ -38,7 +38,7 @@ from . import morphology
 __all__ = ['label', 'find_objects', 'labeled_comprehension', 'sum', 'mean',
            'variance', 'standard_deviation', 'minimum', 'maximum', 'median',
            'minimum_position', 'maximum_position', 'extrema', 'center_of_mass',
-           'histogram', 'watershed_ift']
+           'histogram', 'watershed_ift', 'sum_labels']
 
 
 def label(input, structure=None, output=None):
@@ -572,6 +572,20 @@ def _stats(input, labels=None, index=None, centered=False):
 
 
 def sum(input, labels=None, index=None):
+    """
+    Calculate the sum of the values of the array.
+
+    Notes
+    -----
+    This is an alias for `ndimage.sum_labels` kept for backwards compatibility
+    reasons, for new code please prefer `sum_labels`.  See the `sum_labels`
+    docstring for more details.
+
+    """
+    return sum_labels(input, labels, index)
+
+
+def sum_labels(input, labels=None, index=None):
     """
     Calculate the sum of the values of the array.
 
@@ -1203,7 +1217,7 @@ def maximum_position(input, labels=None, index=None):
     --------
     label, minimum, median, maximum_position, extrema, sum, mean, variance,
     standard_deviation
-    
+
     Examples
     --------
     >>> from scipy import ndimage
@@ -1222,14 +1236,14 @@ def maximum_position(input, labels=None, index=None):
     ...                 [0, 1, 2, 3]])
     >>> ndimage.maximum_position(a, lbl, 1)
     (1, 1)
-    
+
     If no index is given, non-zero `labels` are processed:
 
     >>> ndimage.maximum_position(a, lbl)
     (2, 3)
-    
+
     If there are no maxima, the position of the first element is returned:
-    
+
     >>> ndimage.maximum_position(a, lbl, 2)
     (0, 2)
 

--- a/scipy/ndimage/tests/test_measurements.py
+++ b/scipy/ndimage/tests/test_measurements.py
@@ -509,9 +509,19 @@ def test_sum12():
     labels = np.array([[1, 2], [2, 4]], np.int8)
     for type in types:
         input = np.array([[1, 2], [3, 4]], type)
-        output = ndimage.sum(input, labels=labels,
-                                        index=[4, 8, 2])
+        output = ndimage.sum(input, labels=labels, index=[4, 8, 2])
         assert_array_almost_equal(output, [4.0, 0.0, 5.0])
+
+
+def test_sum_labels():
+    labels = np.array([[1, 2], [2, 4]], np.int8)
+    for type in types:
+        input = np.array([[1, 2], [3, 4]], type)
+        output_sum = ndimage.sum(input, labels=labels, index=[4, 8, 2])
+        output_labels = ndimage.sum_labels(input, labels=labels, index=[4, 8, 2])
+
+        assert (output_sum == output_labels).all()
+        assert_array_almost_equal(output_labels, [4.0, 0.0, 5.0])
 
 
 def test_mean01():

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -132,6 +132,7 @@ REFGUIDE_ALL_SKIPLIST = [
 REFGUIDE_AUTOSUMMARY_SKIPLIST = [
     r'scipy\.special\..*_roots',  # old aliases for scipy.special.*_roots
     r'scipy\.special\.jn',  # alias for jv
+    r'scipy\.ndimage\.sum',   # alias for sum_labels
     r'scipy\.linalg\.solve_lyapunov',  # deprecated name
     r'scipy\.stats\.contingency\.chi2_contingency',
     r'scipy\.stats\.contingency\.expected_freq',


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Fixes https://github.com/scipy/scipy/issues/10593

#### What does this implement/fix?
<!--Please explain your changes.-->
Helps scientists who want to use `from scipy.ndimage import *` without having ambiguity about builtin `sum`

#### Additional information
<!--Any additional information you think is important.-->
I didn't find an official mechanism to alias so I just guessed at what it should look like. Happy to copy a template if one exists.

I ran `make html` and verified that the generate results have the correct text (I ended up without theme like in https://github.com/scipy/scipy/issues/8351)