### PR TITLE
EHN: Update SuperLU

### DIFF
--- a/scipy/sparse/linalg/dsolve/SuperLU/README
+++ b/scipy/sparse/linalg/dsolve/SuperLU/README
@@ -128,10 +128,14 @@ are described below.
 
      or with more options, e.g.,
         cmake .. \
-	      -DCMAKE_INSTALL_INCLUDEDIR=/my/custom/path 	 
+	      -DCMAKE_INSTALL_PREFIX=../build
+	      -DCMAKE_INSTALL_INCLUDEDIR=/my/custom/path
 
    To actually build, type:
    	make
+
+   To install the library, type:
+        make install
 
    To run the installation test, type:
    	make test (or: ctest)
@@ -141,9 +145,6 @@ are described below.
        	    build/TESTING/d_test.out   # double precision, real
        	    build/TESTING/c_test.out   # single precision, complex
        	    build/TESTING/z_test.out   # double precision, complex
-
-   To install the library, type:
-        make install
 
 
 --------------------

--- a/scipy/sparse/linalg/dsolve/SuperLU/SRC/cdiagonal.c
+++ b/scipy/sparse/linalg/dsolve/SuperLU/SRC/cdiagonal.c
@@ -31,7 +31,7 @@ int cfill_diag(int n, NCformat *Astore)
     int nnz = colptr[n];
     int fill = 0;
     complex *nzval_new;
-    complex zero = {1.0, 0.0};
+    complex zero = {0.0, 0.0};
     int *rowind_new;
     int i, j, diag;
 

--- a/scipy/sparse/linalg/dsolve/SuperLU/SRC/cgsisx.c
+++ b/scipy/sparse/linalg/dsolve/SuperLU/SRC/cgsisx.c
@@ -34,7 +34,7 @@ at the top-level directory.
  *
  *   1. If A is stored column-wise (A->Stype = SLU_NC):
  *  
- *	1.1. If options->Equil = YES or options->RowPerm = LargeDiag, scaling
+ *	1.1. If options->Equil = YES or options->RowPerm = LargeDiag_MC64, scaling
  *	     factors are computed to equilibrate the system:
  *	     options->Trans = NOTRANS:
  *		 diag(R)*A*diag(C) *inv(diag(C))*X = diag(R)*B
@@ -78,12 +78,12 @@ at the top-level directory.
  *	     original system before equilibration.
  *
  *	1.9. options for ILU only
- *	     1) If options->RowPerm = LargeDiag, MC64 is used to scale and
+ *	     1) If options->RowPerm = LargeDiag_MC64, MC64 is used to scale and
  *		permute the matrix to an I-matrix, that is Pr*Dr*A*Dc has
  *		entries of modulus 1 on the diagonal and off-diagonal entries
  *		of modulus at most 1. If MC64 fails, dgsequ() is used to
  *		equilibrate the system.
- *              ( Default: LargeDiag )
+ *              ( Default: LargeDiag_MC64 )
  *	     2) options->ILU_DropTol = tau is the threshold for dropping.
  *		For L, it is used directly (for the whole row in a supernode);
  *		For U, ||A(:,i)||_oo * tau is used as the threshold
@@ -145,7 +145,7 @@ at the top-level directory.
  *   2. If A is stored row-wise (A->Stype = SLU_NR), apply the above algorithm
  *	to the transpose of A:
  *
- *	2.1. If options->Equil = YES or options->RowPerm = LargeDiag, scaling
+ *	2.1. If options->Equil = YES or options->RowPerm = LargeDiag_MC64, scaling
  *	     factors are computed to equilibrate the system:
  *	     options->Trans = NOTRANS:
  *		 diag(R)*A*diag(C) *inv(diag(C))*X = diag(R)*B
@@ -224,7 +224,7 @@ at the top-level directory.
  *	     equed = 'C':  transpose(A) := transpose(A) * diag(C)
  *	     equed = 'B':  transpose(A) := diag(R) * transpose(A) * diag(C).
  *
- *         If options->RowPerm = LargeDiag, MC64 is used to scale and permute
+ *         If options->RowPerm = LargeDiag_MC64, MC64 is used to scale and permute
  *            the matrix to an I-matrix, that is A is modified as follows:
  *            P*Dr*A*Dc has entries of modulus 1 on the diagonal and 
  *            off-diagonal entries of modulus at most 1. P is a permutation
@@ -442,7 +442,7 @@ cgsisx(superlu_options_t *options, SuperMatrix *A, int *perm_c, int *perm_r,
     nofact = (options->Fact != FACTORED);
     equil = (options->Equil == YES);
     notran = (options->Trans == NOTRANS);
-    mc64 = (options->RowPerm == LargeDiag);
+    mc64 = (options->RowPerm == LargeDiag_MC64);
     if ( nofact ) {
 	*(unsigned char *)equed = 'N';
 	rowequ = FALSE;

--- a/scipy/sparse/linalg/dsolve/SuperLU/SRC/cgsitrf.c
+++ b/scipy/sparse/linalg/dsolve/SuperLU/SRC/cgsitrf.c
@@ -290,9 +290,9 @@ cgsitrf(superlu_options_t *options, SuperMatrix *A, int relax, int panel_size,
     for (k = 0; k < n; k++) swap[k] = iperm_c[k];
     iswap = (int *)intMalloc(n);
     for (k = 0; k < n; k++) iswap[k] = perm_c[k];
-    amax = (float *) floatMalloc(panel_size);
+    amax = (float *) SUPERLU_MALLOC(panel_size * sizeof(float));
     if (drop_rule & DROP_SECONDARY)
-	swork2 = (float *)floatMalloc(n);
+	swork2 = SUPERLU_MALLOC(n * sizeof(float));
     else
 	swork2 = NULL;
 

--- a/scipy/sparse/linalg/dsolve/SuperLU/SRC/clacon2.c
+++ b/scipy/sparse/linalg/dsolve/SuperLU/SRC/clacon2.c
@@ -106,6 +106,11 @@ clacon2_(int *n, complex *v, complex *x, float *est, int *kase, int isave[3])
     extern float smach(char *);
     extern int icmax1_slu(int *, complex *, int *);
     extern double scsum1_slu(int *, complex *, int *);
+#ifdef _CRAY
+    extern int CCOPY(int *, complex *, int *, complex [], int *);
+#else
+    extern int ccopy_(int *, complex *, int *, complex [], int *);
+#endif
 
     safmin = smach("Safe minimum");  /* lamch_("Safe minimum"); */
     if ( *kase == 0 ) {

--- a/scipy/sparse/linalg/dsolve/SuperLU/SRC/colamd.c
+++ b/scipy/sparse/linalg/dsolve/SuperLU/SRC/colamd.c
@@ -81,7 +81,7 @@ at the top-level directory.
 
 	    https://web.archive.org/web/20141010162709/http://www.cise.ufl.edu/research/sparse/colamd/
 
-	This is the https://web.archive.org/web/20040113022019/http://www.cise.ufl.edu:80/research/sparse/colamd/colamd.c
+	This is the https://web.archive.org/web/20040113022019/http://www.cise.ufl.edu/research/sparse/colamd/colamd.c
 	file.  It requires the colamd.h file.  It is required by the colamdmex.c
 	and symamdmex.c files, for the MATLAB interface to colamd and symamd.
 
@@ -349,7 +349,7 @@ at the top-level directory.
 
 	Example:
 	
-	    See http://www.cise.ufl.edu/research/sparse/colamd/example.c (dead link)
+	    See http://www.cise.ufl.edu/research/sparse/colamd/example.c
 	    for a complete example.
 
 	    To order the columns of a 5-by-4 matrix with 11 nonzero entries in

--- a/scipy/sparse/linalg/dsolve/SuperLU/SRC/cutil.c
+++ b/scipy/sparse/linalg/dsolve/SuperLU/SRC/cutil.c
@@ -474,7 +474,7 @@ cPrintPerf(SuperMatrix *L, SuperMatrix *U, mem_usage_t *mem_usage,
 
 
 
-
+int
 print_complex_vec(char *what, int n, complex *vec)
 {
     int i;
@@ -482,4 +482,3 @@ print_complex_vec(char *what, int n, complex *vec)
     for (i = 0; i < n; ++i) printf("%d\t%f%f\n", i, vec[i].r, vec[i].i);
     return 0;
 }
-

--- a/scipy/sparse/linalg/dsolve/SuperLU/SRC/dGetDiagU.c
+++ b/scipy/sparse/linalg/dsolve/SuperLU/SRC/dGetDiagU.c
@@ -1,0 +1,58 @@
+/*! @file dGetDiagU.c
+ * \brief Extracts main diagonal of matrix
+ *
+ * <pre> 
+ * -- Auxiliary routine in SuperLU (version 2.0) --
+ * Lawrence Berkeley National Lab, Univ. of California Berkeley.
+ * Xiaoye S. Li
+ * September 11, 2003
+ *
+ *  Purpose
+ * =======
+ *
+ * GetDiagU extracts the main diagonal of matrix U of the LU factorization.
+ *  
+ * Arguments
+ * =========
+ *
+ * L      (input) SuperMatrix*
+ *        The factor L from the factorization Pr*A*Pc=L*U as computed by
+ *        dgstrf(). Use compressed row subscripts storage for supernodes,
+ *        i.e., L has types: Stype = SLU_SC, Dtype = SLU_D, Mtype = SLU_TRLU.
+ *
+ * diagU  (output) double*, dimension (n)
+ *        The main diagonal of matrix U.
+ *
+ * Note
+ * ====
+ * The diagonal blocks of the L and U matrices are stored in the L
+ * data structures.
+ * </pre> 
+*/
+#include <slu_ddefs.h>
+
+void dGetDiagU(SuperMatrix *L, double *diagU)
+{
+    int_t i, k, nsupers;
+    int_t fsupc, nsupr, nsupc, luptr;
+    double *dblock, *Lval;
+    SCformat *Lstore;
+
+    Lstore = L->Store;
+    Lval = Lstore->nzval;
+    nsupers = Lstore->nsuper + 1;
+
+    for (k = 0; k < nsupers; ++k) {
+      fsupc = L_FST_SUPC(k);
+      nsupc = L_FST_SUPC(k+1) - fsupc;
+      nsupr = L_SUB_START(fsupc+1) - L_SUB_START(fsupc);
+      luptr = L_NZ_START(fsupc);
+
+      dblock = &diagU[fsupc];
+      for (i = 0; i < nsupc; ++i) {
+	dblock[i] = Lval[luptr];
+	luptr += nsupr + 1;
+      }
+    }
+}
+

--- a/scipy/sparse/linalg/dsolve/SuperLU/SRC/dgsisx.c
+++ b/scipy/sparse/linalg/dsolve/SuperLU/SRC/dgsisx.c
@@ -34,7 +34,7 @@ at the top-level directory.
  *
  *   1. If A is stored column-wise (A->Stype = SLU_NC):
  *  
- *	1.1. If options->Equil = YES or options->RowPerm = LargeDiag, scaling
+ *	1.1. If options->Equil = YES or options->RowPerm = LargeDiag_MC64, scaling
  *	     factors are computed to equilibrate the system:
  *	     options->Trans = NOTRANS:
  *		 diag(R)*A*diag(C) *inv(diag(C))*X = diag(R)*B
@@ -78,12 +78,12 @@ at the top-level directory.
  *	     original system before equilibration.
  *
  *	1.9. options for ILU only
- *	     1) If options->RowPerm = LargeDiag, MC64 is used to scale and
+ *	     1) If options->RowPerm = LargeDiag_MC64, MC64 is used to scale and
  *		permute the matrix to an I-matrix, that is Pr*Dr*A*Dc has
  *		entries of modulus 1 on the diagonal and off-diagonal entries
  *		of modulus at most 1. If MC64 fails, dgsequ() is used to
  *		equilibrate the system.
- *              ( Default: LargeDiag )
+ *              ( Default: LargeDiag_MC64 )
  *	     2) options->ILU_DropTol = tau is the threshold for dropping.
  *		For L, it is used directly (for the whole row in a supernode);
  *		For U, ||A(:,i)||_oo * tau is used as the threshold
@@ -145,7 +145,7 @@ at the top-level directory.
  *   2. If A is stored row-wise (A->Stype = SLU_NR), apply the above algorithm
  *	to the transpose of A:
  *
- *	2.1. If options->Equil = YES or options->RowPerm = LargeDiag, scaling
+ *	2.1. If options->Equil = YES or options->RowPerm = LargeDiag_MC64, scaling
  *	     factors are computed to equilibrate the system:
  *	     options->Trans = NOTRANS:
  *		 diag(R)*A*diag(C) *inv(diag(C))*X = diag(R)*B
@@ -224,7 +224,7 @@ at the top-level directory.
  *	     equed = 'C':  transpose(A) := transpose(A) * diag(C)
  *	     equed = 'B':  transpose(A) := diag(R) * transpose(A) * diag(C).
  *
- *         If options->RowPerm = LargeDiag, MC64 is used to scale and permute
+ *         If options->RowPerm = LargeDiag_MC64, MC64 is used to scale and permute
  *            the matrix to an I-matrix, that is A is modified as follows:
  *            P*Dr*A*Dc has entries of modulus 1 on the diagonal and 
  *            off-diagonal entries of modulus at most 1. P is a permutation
@@ -442,7 +442,7 @@ dgsisx(superlu_options_t *options, SuperMatrix *A, int *perm_c, int *perm_r,
     nofact = (options->Fact != FACTORED);
     equil = (options->Equil == YES);
     notran = (options->Trans == NOTRANS);
-    mc64 = (options->RowPerm == LargeDiag);
+    mc64 = (options->RowPerm == LargeDiag_MC64);
     if ( nofact ) {
 	*(unsigned char *)equed = 'N';
 	rowequ = FALSE;

--- a/scipy/sparse/linalg/dsolve/SuperLU/SRC/dgsitrf.c
+++ b/scipy/sparse/linalg/dsolve/SuperLU/SRC/dgsitrf.c
@@ -289,9 +289,9 @@ dgsitrf(superlu_options_t *options, SuperMatrix *A, int relax, int panel_size,
     for (k = 0; k < n; k++) swap[k] = iperm_c[k];
     iswap = (int *)intMalloc(n);
     for (k = 0; k < n; k++) iswap[k] = perm_c[k];
-    amax = (double *) doubleMalloc(panel_size);
+    amax = (double *) SUPERLU_MALLOC(panel_size * sizeof(double));
     if (drop_rule & DROP_SECONDARY)
-	dwork2 = (double *)doubleMalloc(n);
+	dwork2 = SUPERLU_MALLOC(n * sizeof(double));
     else
 	dwork2 = NULL;
 

--- a/scipy/sparse/linalg/dsolve/SuperLU/SRC/dmach.c
+++ b/scipy/sparse/linalg/dsolve/SuperLU/SRC/dmach.c
@@ -11,6 +11,7 @@ at the top-level directory.
 #include <float.h>
 #include <math.h>
 #include <stdio.h>
+#include <string.h>
 
 double dmach(char *cmach)
 {

--- a/scipy/sparse/linalg/dsolve/SuperLU/SRC/dutil.c
+++ b/scipy/sparse/linalg/dsolve/SuperLU/SRC/dutil.c
@@ -470,7 +470,7 @@ dPrintPerf(SuperMatrix *L, SuperMatrix *U, mem_usage_t *mem_usage,
 
 
 
-
+int
 print_double_vec(char *what, int n, double *vec)
 {
     int i;
@@ -478,4 +478,3 @@ print_double_vec(char *what, int n, double *vec)
     for (i = 0; i < n; ++i) printf("%d\t%f\n", i, vec[i]);
     return 0;
 }
-

--- a/scipy/sparse/linalg/dsolve/SuperLU/SRC/icmax1.c
+++ b/scipy/sparse/linalg/dsolve/SuperLU/SRC/icmax1.c
@@ -63,8 +63,8 @@ int icmax1_slu(int *n, complex *cx, int *incx)
     int ret_val, i__1, i__2;
     float r__1;
     /* Local variables */
-    static float smax;
-    static int i, ix;
+    float smax;
+    int i, ix;
 
 
 #define CX(I) cx[(I)-1]

--- a/scipy/sparse/linalg/dsolve/SuperLU/SRC/ilu_cdrop_row.c
+++ b/scipy/sparse/linalg/dsolve/SuperLU/SRC/ilu_cdrop_row.c
@@ -28,6 +28,7 @@ extern void caxpy_(int *, complex *, complex [], int *, complex [], int *);
 extern void ccopy_(int *, complex [], int *, complex [], int *);
 extern float scasum_(int *, complex *, int *);
 extern float scnrm2_(int *, complex *, int *);
+extern void scopy_(int *, float [], int *, float [], int *);
 extern double dnrm2_(int *, double [], int *);
 extern int icamax_(int *, complex [], int *);
 

--- a/scipy/sparse/linalg/dsolve/SuperLU/SRC/ilu_zdrop_row.c
+++ b/scipy/sparse/linalg/dsolve/SuperLU/SRC/ilu_zdrop_row.c
@@ -29,6 +29,7 @@ extern void zcopy_(int *, doublecomplex [], int *, doublecomplex [], int *);
 extern double dzasum_(int *, doublecomplex *, int *);
 extern double dznrm2_(int *, doublecomplex *, int *);
 extern double dnrm2_(int *, double [], int *);
+extern void dcopy_(int *, double [], int *, double [], int *);
 extern int izamax_(int *, doublecomplex [], int *);
 
 static double *A;  /* used in _compare_ only */

--- a/scipy/sparse/linalg/dsolve/SuperLU/SRC/input_error.c
+++ b/scipy/sparse/linalg/dsolve/SuperLU/SRC/input_error.c
@@ -1,0 +1,50 @@
+/*! \file
+Copyright (c) 2003, The Regents of the University of California, through
+Lawrence Berkeley National Laboratory (subject to receipt of any required 
+approvals from U.S. Dept. of Energy) 
+
+All rights reserved. 
+
+The source code is distributed under BSD license, see the file License.txt
+at the top-level directory.
+*/
+#include <stdio.h>
+#include "slu_Cnames.h"
+
+/*! @file input_error.c
+ * \brief Error handler for input parameters.
+ *
+ * <pre>
+ * -- SuperLU routine (version 4.4) --
+ * Lawrence Berkeley National Lab, Univ. of California Berkeley.
+ * November 20, 2012
+ * </pre>
+ */
+
+/*! \brief
+ *
+ * <pre>
+ * Purpose   
+ * =======   
+ *
+ * INPUT_ERROR is called if an input parameter has an   
+ * invalid value.  A message is printed and execution stops.   
+ *
+ * Arguments   
+ * =========   
+ *
+ * srname  (input) character*6
+ *         The name of the routine which called INPUT_ERROR.
+ *
+ * info    (input) int
+ *         The position of the invalid parameter in the parameter list   
+ *         of the calling routine.
+ *
+ * </pre>
+ */
+int input_error(char *srname, int *info)
+{
+    printf("** On entry to %6s, parameter number %2d had an illegal value\n",
+		srname, *info);
+    return 0;
+}

--- a/scipy/sparse/linalg/dsolve/SuperLU/SRC/scsum1.c
+++ b/scipy/sparse/linalg/dsolve/SuperLU/SRC/scsum1.c
@@ -58,8 +58,8 @@ double scsum1_slu(int *n, complex *cx, int *incx)
     /* Builtin functions */
     double c_abs(complex *);
     /* Local variables */
-    static int i, nincx;
-    static float stemp;
+    int i, nincx;
+    float stemp;
 
 
 #define CX(I) cx[(I)-1]

--- a/scipy/sparse/linalg/dsolve/SuperLU/SRC/sgsisx.c
+++ b/scipy/sparse/linalg/dsolve/SuperLU/SRC/sgsisx.c
@@ -34,7 +34,7 @@ at the top-level directory.
  *
  *   1. If A is stored column-wise (A->Stype = SLU_NC):
  *  
- *	1.1. If options->Equil = YES or options->RowPerm = LargeDiag, scaling
+ *	1.1. If options->Equil = YES or options->RowPerm = LargeDiag_MC64, scaling
  *	     factors are computed to equilibrate the system:
  *	     options->Trans = NOTRANS:
  *		 diag(R)*A*diag(C) *inv(diag(C))*X = diag(R)*B
@@ -78,12 +78,12 @@ at the top-level directory.
  *	     original system before equilibration.
  *
  *	1.9. options for ILU only
- *	     1) If options->RowPerm = LargeDiag, MC64 is used to scale and
+ *	     1) If options->RowPerm = LargeDiag_MC64, MC64 is used to scale and
  *		permute the matrix to an I-matrix, that is Pr*Dr*A*Dc has
  *		entries of modulus 1 on the diagonal and off-diagonal entries
  *		of modulus at most 1. If MC64 fails, dgsequ() is used to
  *		equilibrate the system.
- *              ( Default: LargeDiag )
+ *              ( Default: LargeDiag_MC64 )
  *	     2) options->ILU_DropTol = tau is the threshold for dropping.
  *		For L, it is used directly (for the whole row in a supernode);
  *		For U, ||A(:,i)||_oo * tau is used as the threshold
@@ -145,7 +145,7 @@ at the top-level directory.
  *   2. If A is stored row-wise (A->Stype = SLU_NR), apply the above algorithm
  *	to the transpose of A:
  *
- *	2.1. If options->Equil = YES or options->RowPerm = LargeDiag, scaling
+ *	2.1. If options->Equil = YES or options->RowPerm = LargeDiag_MC64, scaling
  *	     factors are computed to equilibrate the system:
  *	     options->Trans = NOTRANS:
  *		 diag(R)*A*diag(C) *inv(diag(C))*X = diag(R)*B
@@ -224,7 +224,7 @@ at the top-level directory.
  *	     equed = 'C':  transpose(A) := transpose(A) * diag(C)
  *	     equed = 'B':  transpose(A) := diag(R) * transpose(A) * diag(C).
  *
- *         If options->RowPerm = LargeDiag, MC64 is used to scale and permute
+ *         If options->RowPerm = LargeDiag_MC64, MC64 is used to scale and permute
  *            the matrix to an I-matrix, that is A is modified as follows:
  *            P*Dr*A*Dc has entries of modulus 1 on the diagonal and 
  *            off-diagonal entries of modulus at most 1. P is a permutation
@@ -442,7 +442,7 @@ sgsisx(superlu_options_t *options, SuperMatrix *A, int *perm_c, int *perm_r,
     nofact = (options->Fact != FACTORED);
     equil = (options->Equil == YES);
     notran = (options->Trans == NOTRANS);
-    mc64 = (options->RowPerm == LargeDiag);
+    mc64 = (options->RowPerm == LargeDiag_MC64);
     if ( nofact ) {
 	*(unsigned char *)equed = 'N';
 	rowequ = FALSE;

--- a/scipy/sparse/linalg/dsolve/SuperLU/SRC/sgsitrf.c
+++ b/scipy/sparse/linalg/dsolve/SuperLU/SRC/sgsitrf.c
@@ -289,9 +289,9 @@ sgsitrf(superlu_options_t *options, SuperMatrix *A, int relax, int panel_size,
     for (k = 0; k < n; k++) swap[k] = iperm_c[k];
     iswap = (int *)intMalloc(n);
     for (k = 0; k < n; k++) iswap[k] = perm_c[k];
-    amax = (float *) floatMalloc(panel_size);
+    amax = (float *) SUPERLU_MALLOC(panel_size * sizeof(float));
     if (drop_rule & DROP_SECONDARY)
-	swork2 = (float *)floatMalloc(n);
+	swork2 = SUPERLU_MALLOC(n * sizeof(float));
     else
 	swork2 = NULL;
 

--- a/scipy/sparse/linalg/dsolve/SuperLU/SRC/slacon2.c
+++ b/scipy/sparse/linalg/dsolve/SuperLU/SRC/slacon2.c
@@ -157,7 +157,7 @@ L40:
 #ifdef _CRAY
     isave[1] = ISAMAX(n, &x[0], &c__1);   /* j */
 #else
-    isave[1] = idamax_(n, &x[0], &c__1);  /* j */
+    isave[1] = isamax_(n, &x[0], &c__1);  /* j */
 #endif
     --isave[1];  /* --j; */
     isave[2] = 2;  /* iter = 2; */

--- a/scipy/sparse/linalg/dsolve/SuperLU/SRC/slu_cdefs.h
+++ b/scipy/sparse/linalg/dsolve/SuperLU/SRC/slu_cdefs.h
@@ -254,6 +254,7 @@ extern int     ilu_cQuerySpace (SuperMatrix *, SuperMatrix *, mem_usage_t *);
 extern void    creadhb(FILE *, int *, int *, int *, complex **, int **, int **);
 extern void    creadrb(int *, int *, int *, complex **, int **, int **);
 extern void    creadtriple(int *, int *, int *, complex **, int **, int **);
+extern void    creadMM(FILE *, int *, int *, int *, complex **, int **, int **);
 extern void    cCompRow_to_CompCol(int, int, int, complex*, int*, int*,
 		                   complex **, int **, int **);
 extern void    cfill (complex *, int, complex);

--- a/scipy/sparse/linalg/dsolve/SuperLU/SRC/slu_ddefs.h
+++ b/scipy/sparse/linalg/dsolve/SuperLU/SRC/slu_ddefs.h
@@ -251,6 +251,7 @@ extern int     ilu_dQuerySpace (SuperMatrix *, SuperMatrix *, mem_usage_t *);
 extern void    dreadhb(FILE *, int *, int *, int *, double **, int **, int **);
 extern void    dreadrb(int *, int *, int *, double **, int **, int **);
 extern void    dreadtriple(int *, int *, int *, double **, int **, int **);
+extern void    dreadMM(FILE *, int *, int *, int *, double **, int **, int **);
 extern void    dCompRow_to_CompCol(int, int, int, double*, int*, int*,
 		                   double **, int **, int **);
 extern void    dfill (double *, int, double);

--- a/scipy/sparse/linalg/dsolve/SuperLU/SRC/slu_sdefs.h
+++ b/scipy/sparse/linalg/dsolve/SuperLU/SRC/slu_sdefs.h
@@ -251,6 +251,7 @@ extern int     ilu_sQuerySpace (SuperMatrix *, SuperMatrix *, mem_usage_t *);
 extern void    sreadhb(FILE *, int *, int *, int *, float **, int **, int **);
 extern void    sreadrb(int *, int *, int *, float **, int **, int **);
 extern void    sreadtriple(int *, int *, int *, float **, int **, int **);
+extern void    sreadMM(FILE *, int *, int *, int *, float **, int **, int **);
 extern void    sCompRow_to_CompCol(int, int, int, float*, int*, int*,
 		                   float **, int **, int **);
 extern void    sfill (float *, int, float);

--- a/scipy/sparse/linalg/dsolve/SuperLU/SRC/slu_zdefs.h
+++ b/scipy/sparse/linalg/dsolve/SuperLU/SRC/slu_zdefs.h
@@ -254,6 +254,7 @@ extern int     ilu_zQuerySpace (SuperMatrix *, SuperMatrix *, mem_usage_t *);
 extern void    zreadhb(FILE *, int *, int *, int *, doublecomplex **, int **, int **);
 extern void    zreadrb(int *, int *, int *, doublecomplex **, int **, int **);
 extern void    zreadtriple(int *, int *, int *, doublecomplex **, int **, int **);
+extern void    zreadMM(FILE *, int *, int *, int *, doublecomplex **, int **, int **);
 extern void    zCompRow_to_CompCol(int, int, int, doublecomplex*, int*, int*,
 		                   doublecomplex **, int **, int **);
 extern void    zfill (doublecomplex *, int, doublecomplex);

--- a/scipy/sparse/linalg/dsolve/SuperLU/SRC/smach.c
+++ b/scipy/sparse/linalg/dsolve/SuperLU/SRC/smach.c
@@ -11,6 +11,7 @@ at the top-level directory.
 #include <float.h>
 #include <math.h>
 #include <stdio.h>
+#include <string.h>
 
 float smach(char *cmach)
 {

--- a/scipy/sparse/linalg/dsolve/SuperLU/SRC/sp_ienv.c
+++ b/scipy/sparse/linalg/dsolve/SuperLU/SRC/sp_ienv.c
@@ -24,6 +24,7 @@ at the top-level directory.
  * History:             Modified from lapack routine ILAENV
  */
 #include "slu_Cnames.h"
+extern int input_error(char *, int *);
 
 /*! \brief
 

--- a/scipy/sparse/linalg/dsolve/SuperLU/SRC/superlu_enum_consts.h
+++ b/scipy/sparse/linalg/dsolve/SuperLU/SRC/superlu_enum_consts.h
@@ -14,6 +14,7 @@ at the top-level directory.
  * -- SuperLU routine (version 4.1) --
  * Lawrence Berkeley National Lab, Univ. of California Berkeley, 
  * October 1, 2010
+ * January 28, 2018
  *
  */
 
@@ -25,13 +26,14 @@ at the top-level directory.
  ***********************************************************************/
 typedef enum {NO, YES}                                          yes_no_t;
 typedef enum {DOFACT, SamePattern, SamePattern_SameRowPerm, FACTORED} fact_t;
-typedef enum {NOROWPERM, LargeDiag, MY_PERMR}                   rowperm_t;
+typedef enum {NOROWPERM, LargeDiag_MC64, LargeDiag_AWPM, MY_PERMR} rowperm_t;
 typedef enum {NATURAL, MMD_ATA, MMD_AT_PLUS_A, COLAMD,
 	      METIS_AT_PLUS_A, PARMETIS, ZOLTAN, MY_PERMC}      colperm_t;
 typedef enum {NOTRANS, TRANS, CONJ}                             trans_t;
 typedef enum {NOEQUIL, ROW, COL, BOTH}                          DiagScale_t;
 typedef enum {NOREFINE, SLU_SINGLE=1, SLU_DOUBLE, SLU_EXTRA}    IterRefine_t;
-typedef enum {LUSUP, UCOL, LSUB, USUB, LLVL, ULVL}              MemType;
+//typedef enum {LUSUP, UCOL, LSUB, USUB, LLVL, ULVL, NO_MEMTYPE}  MemType;
+typedef enum {USUB, LSUB, UCOL, LUSUP, LLVL, ULVL, NO_MEMTYPE}  MemType;
 typedef enum {HEAD, TAIL}                                       stack_end_t;
 typedef enum {SYSTEM, USER}                                     LU_space_t;
 typedef enum {ONE_NORM, TWO_NORM, INF_NORM}			norm_t;
@@ -67,7 +69,13 @@ typedef enum {
     DIST,    /* distribute matrix. */
     FACT,    /* perform LU factorization */
     COMM,    /* communication for factorization */
+    COMM_DIAG, /* Bcast diagonal block to process column */
+    COMM_RIGHT, /* communicate L panel */
+    COMM_DOWN, /* communicate U panel */
     SOL_COMM,/* communication for solve */
+    SOL_GEMM,/* gemm for solve */
+    SOL_TRSM,/* trsm for solve */
+    SOL_TOT,	/* LU-solve time*/
     RCOND,   /* estimate reciprocal condition number */
     SOLVE,   /* forward and back solves */
     REFINE,  /* perform iterative refinement */
@@ -76,6 +84,5 @@ typedef enum {
     FERR,    /* estimate error bounds after iterative refinement */
     NPHASES  /* total number of phases */
 } PhaseType;
-
 
 #endif /* __SUPERLU_ENUM_CONSTS */

--- a/scipy/sparse/linalg/dsolve/SuperLU/SRC/superlu_timer.c
+++ b/scipy/sparse/linalg/dsolve/SuperLU/SRC/superlu_timer.c
@@ -8,6 +8,7 @@ All rights reserved.
 The source code is distributed under BSD license, see the file License.txt
 at the top-level directory.
 */
+
 /*! @file superlu_timer.c
  * \brief Returns the time used
  *
@@ -22,6 +23,7 @@ at the top-level directory.
  * </pre>
  */
 
+#undef USE_TIMES
 
 #ifdef SUN 
 /*
@@ -46,7 +48,7 @@ double SuperLU_timer_()
     return ((double)t)/CLOCKS_PER_SEC;
 }
 
-#else
+#elif defined( USE_TIMES )
 
 #ifndef NO_TIMER
 #include <sys/types.h>
@@ -55,17 +57,17 @@ double SuperLU_timer_()
 #include <unistd.h>
 #endif
 
+#ifndef CLK_TCK
+#define CLK_TCK 60
+#endif
 /*! \brief Timer function
  */ 
-
 double SuperLU_timer_()
 {
 #ifdef NO_TIMER
     /* no sys/times.h on WIN32 */
     double tmp;
     tmp = 0.0;
-    /* return (double)(tmp) / CLK_TCK;*/
-    return 0.0;
 #else
     struct tms use;
     double tmp;
@@ -74,8 +76,25 @@ double SuperLU_timer_()
     times ( &use );
     tmp = use.tms_utime;
     tmp += use.tms_stime;
-    return (double)(tmp) / clocks_per_sec;
 #endif
+    /*return (double)(tmp) / CLK_TCK;*/
+    return (double)(tmp) / clocks_per_sec;
+}
+
+#else
+
+#include <sys/time.h>
+#include <stdlib.h>
+
+/*! \brief Timer function
+ */ 
+double SuperLU_timer_()
+{
+    struct timeval tp;
+    double tmp;
+    gettimeofday(&tp, NULL);
+    tmp = tp.tv_sec + tp.tv_usec/1000000.0;
+    return (tmp);
 }
 
 #endif

--- a/scipy/sparse/linalg/dsolve/SuperLU/SRC/sutil.c
+++ b/scipy/sparse/linalg/dsolve/SuperLU/SRC/sutil.c
@@ -470,7 +470,7 @@ sPrintPerf(SuperMatrix *L, SuperMatrix *U, mem_usage_t *mem_usage,
 
 
 
-
+int
 print_float_vec(char *what, int n, float *vec)
 {
     int i;
@@ -478,4 +478,3 @@ print_float_vec(char *what, int n, float *vec)
     for (i = 0; i < n; ++i) printf("%d\t%f\n", i, vec[i]);
     return 0;
 }
-

--- a/scipy/sparse/linalg/dsolve/SuperLU/SRC/util.c
+++ b/scipy/sparse/linalg/dsolve/SuperLU/SRC/util.c
@@ -67,7 +67,7 @@ void ilu_set_default_options(superlu_options_t *options)
 
     /* further options for incomplete factorization */
     options->DiagPivotThresh = 0.1;
-    options->RowPerm = LargeDiag;
+    options->RowPerm = LargeDiag_MC64;
     options->ILU_DropRule = DROP_BASIC | DROP_AREA;
     options->ILU_DropTol = 1e-4;
     options->ILU_FillFactor = 10.0;
@@ -344,12 +344,12 @@ StatPrint(SuperLUStat_t *stat)
 
     utime = stat->utime;
     ops   = stat->ops;
-    printf("Factor time  = %8.2f\n", utime[FACT]);
+    printf("Factor time  = %8.5f\n", utime[FACT]);
     if ( utime[FACT] != 0.0 )
       printf("Factor flops = %e\tMflops = %8.2f\n", ops[FACT],
 	     ops[FACT]*1e-6/utime[FACT]);
 
-    printf("Solve time   = %8.2f\n", utime[SOLVE]);
+    printf("Solve time   = %8.4f\n", utime[SOLVE]);
     if ( utime[SOLVE] != 0.0 )
       printf("Solve flops = %e\tMflops = %8.2f\n", ops[SOLVE],
 	     ops[SOLVE]*1e-6/utime[SOLVE]);

--- a/scipy/sparse/linalg/dsolve/SuperLU/SRC/zdiagonal.c
+++ b/scipy/sparse/linalg/dsolve/SuperLU/SRC/zdiagonal.c
@@ -31,7 +31,7 @@ int zfill_diag(int n, NCformat *Astore)
     int nnz = colptr[n];
     int fill = 0;
     doublecomplex *nzval_new;
-    doublecomplex zero = {1.0, 0.0};
+    doublecomplex zero = {0.0, 0.0};
     int *rowind_new;
     int i, j, diag;
 

--- a/scipy/sparse/linalg/dsolve/SuperLU/SRC/zgsisx.c
+++ b/scipy/sparse/linalg/dsolve/SuperLU/SRC/zgsisx.c
@@ -34,7 +34,7 @@ at the top-level directory.
  *
  *   1. If A is stored column-wise (A->Stype = SLU_NC):
  *  
- *	1.1. If options->Equil = YES or options->RowPerm = LargeDiag, scaling
+ *	1.1. If options->Equil = YES or options->RowPerm = LargeDiag_MC64, scaling
  *	     factors are computed to equilibrate the system:
  *	     options->Trans = NOTRANS:
  *		 diag(R)*A*diag(C) *inv(diag(C))*X = diag(R)*B
@@ -78,12 +78,12 @@ at the top-level directory.
  *	     original system before equilibration.
  *
  *	1.9. options for ILU only
- *	     1) If options->RowPerm = LargeDiag, MC64 is used to scale and
+ *	     1) If options->RowPerm = LargeDiag_MC64, MC64 is used to scale and
  *		permute the matrix to an I-matrix, that is Pr*Dr*A*Dc has
  *		entries of modulus 1 on the diagonal and off-diagonal entries
  *		of modulus at most 1. If MC64 fails, dgsequ() is used to
  *		equilibrate the system.
- *              ( Default: LargeDiag )
+ *              ( Default: LargeDiag_MC64 )
  *	     2) options->ILU_DropTol = tau is the threshold for dropping.
  *		For L, it is used directly (for the whole row in a supernode);
  *		For U, ||A(:,i)||_oo * tau is used as the threshold
@@ -145,7 +145,7 @@ at the top-level directory.
  *   2. If A is stored row-wise (A->Stype = SLU_NR), apply the above algorithm
  *	to the transpose of A:
  *
- *	2.1. If options->Equil = YES or options->RowPerm = LargeDiag, scaling
+ *	2.1. If options->Equil = YES or options->RowPerm = LargeDiag_MC64, scaling
  *	     factors are computed to equilibrate the system:
  *	     options->Trans = NOTRANS:
  *		 diag(R)*A*diag(C) *inv(diag(C))*X = diag(R)*B
@@ -224,7 +224,7 @@ at the top-level directory.
  *	     equed = 'C':  transpose(A) := transpose(A) * diag(C)
  *	     equed = 'B':  transpose(A) := diag(R) * transpose(A) * diag(C).
  *
- *         If options->RowPerm = LargeDiag, MC64 is used to scale and permute
+ *         If options->RowPerm = LargeDiag_MC64, MC64 is used to scale and permute
  *            the matrix to an I-matrix, that is A is modified as follows:
  *            P*Dr*A*Dc has entries of modulus 1 on the diagonal and 
  *            off-diagonal entries of modulus at most 1. P is a permutation
@@ -442,7 +442,7 @@ zgsisx(superlu_options_t *options, SuperMatrix *A, int *perm_c, int *perm_r,
     nofact = (options->Fact != FACTORED);
     equil = (options->Equil == YES);
     notran = (options->Trans == NOTRANS);
-    mc64 = (options->RowPerm == LargeDiag);
+    mc64 = (options->RowPerm == LargeDiag_MC64);
     if ( nofact ) {
 	*(unsigned char *)equed = 'N';
 	rowequ = FALSE;

--- a/scipy/sparse/linalg/dsolve/SuperLU/SRC/zgsitrf.c
+++ b/scipy/sparse/linalg/dsolve/SuperLU/SRC/zgsitrf.c
@@ -290,9 +290,9 @@ zgsitrf(superlu_options_t *options, SuperMatrix *A, int relax, int panel_size,
     for (k = 0; k < n; k++) swap[k] = iperm_c[k];
     iswap = (int *)intMalloc(n);
     for (k = 0; k < n; k++) iswap[k] = perm_c[k];
-    amax = (double *) doubleMalloc(panel_size);
+    amax = (double *) SUPERLU_MALLOC(panel_size * sizeof(double));
     if (drop_rule & DROP_SECONDARY)
-	dwork2 = (double *)doubleMalloc(n);
+	dwork2 = SUPERLU_MALLOC(n * sizeof(double));
     else
 	dwork2 = NULL;
 

--- a/scipy/sparse/linalg/dsolve/SuperLU/SRC/zlacon2.c
+++ b/scipy/sparse/linalg/dsolve/SuperLU/SRC/zlacon2.c
@@ -106,6 +106,11 @@ zlacon2_(int *n, doublecomplex *v, doublecomplex *x, double *est, int *kase, int
     extern double dmach(char *);
     extern int izmax1_slu(int *, doublecomplex *, int *);
     extern double dzsum1_slu(int *, doublecomplex *, int *);
+#ifdef _CRAY
+    extern int CCOPY(int *, doublecomplex *, int *, doublecomplex *, int *);
+#else
+    extern int zcopy_(int *, doublecomplex *, int *, doublecomplex *, int *);
+#endif
 
     safmin = dmach("Safe minimum");  /* lamch_("Safe minimum"); */
     if ( *kase == 0 ) {

--- a/scipy/sparse/linalg/dsolve/SuperLU/SRC/zutil.c
+++ b/scipy/sparse/linalg/dsolve/SuperLU/SRC/zutil.c
@@ -474,7 +474,7 @@ zPrintPerf(SuperMatrix *L, SuperMatrix *U, mem_usage_t *mem_usage,
 
 
 
-
+int
 print_doublecomplex_vec(char *what, int n, doublecomplex *vec)
 {
     int i;
@@ -482,4 +482,3 @@ print_doublecomplex_vec(char *what, int n, doublecomplex *vec)
     for (i = 0; i < n; ++i) printf("%d\t%f%f\n", i, vec[i].r, vec[i].i);
     return 0;
 }
-

--- a/scipy/sparse/linalg/dsolve/_superluobject.c
+++ b/scipy/sparse/linalg/dsolve/_superluobject.c
@@ -890,7 +890,6 @@ static int rowperm_cvt(PyObject * input, rowperm_t * value)
 {
     ENUM_CHECK_INIT;
     ENUM_CHECK(NOROWPERM);
-    ENUM_CHECK(LargeDiag);
     ENUM_CHECK(MY_PERMR);
     ENUM_CHECK_FINISH("invalid value for 'RowPerm' parameter");
 }


### PR DESCRIPTION
I'm doing a pass to fix compiler warnings and several of them were fixed upstream already so I created this.

My steps (constructed after the fact) were
```
cd scipy/sparse/linalg/dsolve/SuperLU
rm SRC/*
cp -r ~/test/superlu/SRC/* SRC/
cp ~/test/superlu/{README,License.txt} .
git add SRC/ README License.txt
git commit -am 'EHN sparse/dsolve: add unmodified SuperLU 5.2.X sources'
rm SRC/CMakeLists.txt SRC/Makefile SRC/superluConfig.cmake.in
rm SRC/mc64ad.c
rm SRC/{c,d,s,z}readMM.c
git commit -am 'ENH: sparse/dsolve: revert unneeded files\n mc64ad.c CmakeList.txt Makefile'
git apply --ignore-whitespace scipychanges.patch
vim ../_superluobject.c
# change LargeDiag to LargeDiag_MC64
git commit -am 'ENH: sparse/dsolve: re-apply scipy patches on SuperLU'
```

Note: I have delete a couple of source files:
* `SRC/CMakeLists.txt SRC/Makefile SRC/superluConfig.cmake.in` not needed by us.
* `[cdsz]readMM.c` which is used to "read a matrix stored in Harwell-Boeing format"
* `mc64ad.c` previously removed

The change is small enough that it can be hand verified: There are a couple of weird changes:
* `cdiagonal.c`: complex zero changed from `{1.0, 0.0}` to `{0.0, 0.0}` from ([this change](https://github.com/xiaoyeli/superlu/commit/ea9c349ce158bb496afe9b3a9d7f2ff21269bc53#diff-da2c5e7e901c206dce89a05c63d46d36))
* `slacon2.c`: `idamax_` changed to `isamax_`  ([this change](https://github.com/xiaoyeli/superlu/pull/19))

