### PR TITLE
DOC: Fixed incorrect default for mode in scipy.ndimage.spline_filter1d

### DIFF
--- a/scipy/ndimage/_ni_docstrings.py
+++ b/scipy/ndimage/_ni_docstrings.py
@@ -29,7 +29,7 @@ footprint : array, optional
     of dimensions of the input array, so that, if the input array is
     shape (10,10,10), and `size` is 2, then the actual size used is
     (2,2,2). When `footprint` is given, `size` is ignored.""")
-_mode_doc = (
+_mode_reflect_doc = (
 """mode : {'reflect', 'constant', 'nearest', 'mirror', 'wrap'}, optional
     The `mode` parameter determines how the input array is extended
     beyond its boundaries. Default is 'reflect'. Behavior for each valid
@@ -52,6 +52,12 @@ _mode_doc = (
 
     'wrap' (`a b c d | a b c d | a b c d`)
         The input is extended by wrapping around to the opposite edge.""")
+_mode_constant_doc = (
+    _mode_reflect_doc.replace("Default is 'reflect'", "Default is 'constant'"))
+_mode_mirror_doc = (
+    _mode_reflect_doc.replace("Default is 'reflect'", "Default is 'mirror'"))
+assert _mode_reflect_doc != _mode_constant_doc, 'Default not replaced'
+
 _mode_multiple_doc = (
 """mode : str or sequence, optional
     The `mode` parameter determines how the input array is extended
@@ -115,7 +121,9 @@ docdict = {
     'axis': _axis_doc,
     'output': _output_doc,
     'size_foot': _size_foot_doc,
-    'mode': _mode_doc,
+    'mode_constant': _mode_constant_doc,
+    'mode_mirror': _mode_mirror_doc,
+    'mode_reflect': _mode_reflect_doc,
     'mode_multiple': _mode_multiple_doc,
     'cval': _cval_doc,
     'origin': _origin_doc,

--- a/scipy/ndimage/filters.py
+++ b/scipy/ndimage/filters.py
@@ -66,7 +66,7 @@ def correlate1d(input, weights, axis=-1, output=None, mode="reflect",
         1-D sequence of numbers.
     %(axis)s
     %(output)s
-    %(mode)s
+    %(mode_reflect)s
     %(cval)s
     %(origin)s
 
@@ -111,7 +111,7 @@ def convolve1d(input, weights, axis=-1, output=None, mode="reflect",
         1-D sequence of numbers.
     %(axis)s
     %(output)s
-    %(mode)s
+    %(mode_reflect)s
     %(cval)s
     %(origin)s
 
@@ -180,7 +180,7 @@ def gaussian_filter1d(input, sigma, axis=-1, order=0, output=None,
         kernel. A positive order corresponds to convolution with
         that derivative of a Gaussian.
     %(output)s
-    %(mode)s
+    %(mode_reflect)s
     %(cval)s
     truncate : float, optional
         Truncate the filter at this many standard deviations.
@@ -647,7 +647,7 @@ def correlate(input, weights, output=None, mode='reflect', cval=0.0,
     weights : ndarray
         array of weights, same number of dimensions as input
     %(output)s
-    %(mode)s
+    %(mode_reflect)s
     %(cval)s
     %(origin_multiple)s
 
@@ -710,7 +710,7 @@ def convolve(input, weights, output=None, mode='reflect', cval=0.0,
     weights : array_like
         Array of weights, same number of dimensions as input
     %(output)s
-    %(mode)s
+    %(mode_reflect)s
     cval : scalar, optional
         Value to fill past edges of input if `mode` is 'constant'. Default
         is 0.0
@@ -817,7 +817,7 @@ def uniform_filter1d(input, size, axis=-1, output=None,
         length of uniform filter
     %(axis)s
     %(output)s
-    %(mode)s
+    %(mode_reflect)s
     %(cval)s
     %(origin)s
 
@@ -919,7 +919,7 @@ def minimum_filter1d(input, size, axis=-1, output=None,
         length along which to calculate 1D minimum
     %(axis)s
     %(output)s
-    %(mode)s
+    %(mode_reflect)s
     %(cval)s
     %(origin)s
 
@@ -971,7 +971,7 @@ def maximum_filter1d(input, size, axis=-1, output=None,
         Length along which to calculate the 1-D maximum.
     %(axis)s
     %(output)s
-    %(mode)s
+    %(mode_reflect)s
     %(cval)s
     %(origin)s
 
@@ -1256,7 +1256,7 @@ def rank_filter(input, rank, size=None, footprint=None, output=None,
         indicates the largest element.
     %(size_foot)s
     %(output)s
-    %(mode)s
+    %(mode_reflect)s
     %(cval)s
     %(origin_multiple)s
 
@@ -1295,7 +1295,7 @@ def median_filter(input, size=None, footprint=None, output=None,
     %(input)s
     %(size_foot)s
     %(output)s
-    %(mode)s
+    %(mode_reflect)s
     %(cval)s
     %(origin_multiple)s
 
@@ -1335,7 +1335,7 @@ def percentile_filter(input, percentile, size=None, footprint=None,
         percentile = -20 equals percentile = 80
     %(size_foot)s
     %(output)s
-    %(mode)s
+    %(mode_reflect)s
     %(cval)s
     %(origin_multiple)s
 
@@ -1384,7 +1384,7 @@ def generic_filter1d(input, function, filter_size, axis=-1,
         Length of the filter.
     %(axis)s
     %(output)s
-    %(mode)s
+    %(mode_reflect)s
     %(cval)s
     %(origin)s
     %(extra_arguments)s
@@ -1462,7 +1462,7 @@ def generic_filter(input, function, size=None, footprint=None,
         Function to apply at each element.
     %(size_foot)s
     %(output)s
-    %(mode)s
+    %(mode_reflect)s
     %(cval)s
     %(origin_multiple)s
     %(extra_arguments)s

--- a/scipy/ndimage/interpolation.py
+++ b/scipy/ndimage/interpolation.py
@@ -36,16 +36,9 @@ from numpy.core.multiarray import normalize_axis_index
 
 from . import _ni_support
 from . import _nd_image
-from ._ni_docstrings import docdict
+from ._ni_docstrings import docfiller
 from scipy._lib import doccer
 
-# Change the default 'reflect' to 'constant' via modifying a copy of docdict
-docdict_copy = docdict.copy()
-del docdict
-docdict_copy['mode'] = docdict_copy['mode'].replace("Default is 'reflect'",
-                                                    "Default is 'constant'")
-
-docfiller = doccer.filldoc(docdict_copy)
 
 __all__ = ['spline_filter1d', 'spline_filter', 'geometric_transform',
            'map_coordinates', 'affine_transform', 'shift', 'zoom', 'rotate']
@@ -71,7 +64,7 @@ def spline_filter1d(input, order=3, axis=-1, output=numpy.float64,
     output : ndarray or dtype, optional
         The array in which to place the output, or the dtype of the returned
         array. Default is ``numpy.float64``.
-    %(mode)s
+    %(mode_mirror)s
 
     Returns
     -------
@@ -206,7 +199,7 @@ def geometric_transform(input, mapping, output_shape=None,
     order : int, optional
         The order of the spline interpolation, default is 3.
         The order has to be in the range 0-5.
-    %(mode)s
+    %(mode_constant)s
     %(cval)s
     %(prefilter)s
     extra_arguments : tuple, optional
@@ -329,7 +322,7 @@ def map_coordinates(input, coordinates, output=None, order=3,
     order : int, optional
         The order of the spline interpolation, default is 3.
         The order has to be in the range 0-5.
-    %(mode)s
+    %(mode_constant)s
     %(cval)s
     %(prefilter)s
 
@@ -441,7 +434,7 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None,
     order : int, optional
         The order of the spline interpolation, default is 3.
         The order has to be in the range 0-5.
-    %(mode)s
+    %(mode_constant)s
     %(cval)s
     %(prefilter)s
 
@@ -548,7 +541,7 @@ def shift(input, shift, output=None, order=3, mode='constant', cval=0.0,
     order : int, optional
         The order of the spline interpolation, default is 3.
         The order has to be in the range 0-5.
-    %(mode)s
+    %(mode_constant)s
     %(cval)s
     %(prefilter)s
 
@@ -598,7 +591,7 @@ def zoom(input, zoom, output=None, order=3, mode='constant', cval=0.0,
     order : int, optional
         The order of the spline interpolation, default is 3.
         The order has to be in the range 0-5.
-    %(mode)s
+    %(mode_constant)s
     %(cval)s
     %(prefilter)s
 
@@ -681,7 +674,7 @@ def rotate(input, angle, axes=(1, 0), reshape=True, output=None, order=3,
     order : int, optional
         The order of the spline interpolation, default is 3.
         The order has to be in the range 0-5.
-    %(mode)s
+    %(mode_constant)s
     %(cval)s
     %(prefilter)s
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Fixes https://github.com/scipy/scipy/issues/10610

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->

I tested by running `doc$ make html-scipyorg` and tried to verify inspecting `scipy/doc/build/html-scipyorg/generated/scipy.ndimage.spline_filter1d.html` **but they don't show my changes** I spent 20 minutes and 3 builds but was unable to figure out how to get `make html` to reflect changes I made to docstrings. (maybe something is cached in some weird way)