### PR TITLE
ENH: Replaced csr_matrix() by tocsr() and complemented docstring

### DIFF
--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -280,7 +280,8 @@ def least_squares(
         always uses the '2-point' scheme. If callable, it is used as
         ``jac(x, *args, **kwargs)`` and should return a good approximation
         (or the exact value) for the Jacobian as an array_like (np.atleast_2d
-        is applied), a sparse matrix or a `scipy.sparse.linalg.LinearOperator`.
+        is applied), a sparse matrix (csr_matrix prefered for performance) or
+        a `scipy.sparse.linalg.LinearOperator`.
     bounds : 2-tuple of array_like, optional
         Lower and upper bounds on independent variables. Defaults to no bounds.
         Each array must match the size of `x0` or be a scalar, in the latter
@@ -836,10 +837,10 @@ def least_squares(
         J0 = jac(x0, *args, **kwargs)
 
         if issparse(J0):
-            J0 = csr_matrix(J0)
+            J0 = J0.tocsr()
 
             def jac_wrapped(x, _=None):
-                return csr_matrix(jac(x, *args, **kwargs))
+                return jac(x, *args, **kwargs).tocsr()
 
         elif isinstance(J0, LinearOperator):
             def jac_wrapped(x, _=None):

--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -280,7 +280,7 @@ def least_squares(
         always uses the '2-point' scheme. If callable, it is used as
         ``jac(x, *args, **kwargs)`` and should return a good approximation
         (or the exact value) for the Jacobian as an array_like (np.atleast_2d
-        is applied), a sparse matrix (csr_matrix prefered for performance) or
+        is applied), a sparse matrix (csr_matrix preferred for performance) or
         a `scipy.sparse.linalg.LinearOperator`.
     bounds : 2-tuple of array_like, optional
         Lower and upper bounds on independent variables. Defaults to no bounds.


### PR DESCRIPTION
#### Reference issue
Issue #12249 
Reminder: small performance gain for `least_squares()` at every iteration when the user provides the jacobian as a sparse jacobian already in csr_matrix format

#### What does this implement/fix?
This PR:
* adds a parenthesis in least_squares docstr to mention that csr_matrix is preferred when jac is provided as a callable sparse.
* Replaces csr_matrix() instanciation by tocsr() method in the wrapper. As explained in issue #12249 , it should results in a x100 speed gain for that specific step in jacobian evaluation, for every evaluation

#### Additional information
Another option would have been to test J0 format and provide the wrapper only if it is not already in csr_matrix format, I leave it to the PR reviewer to judge which option is best.