### PR TITLE
RFC: ENH: make scipy.spatial.ConvexHull interruptible

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ requires = [
     "wheel",
     "setuptools",
     "Cython>=0.29.18",
+    "cysignals",
     "numpy==1.14.5; python_version=='3.6' and platform_system!='AIX'",
     "numpy==1.14.5; python_version=='3.7' and platform_system!='AIX'",
     "numpy==1.17.3; python_version>='3.8' and platform_system!='AIX'",

--- a/scipy/spatial/qhull.pyx
+++ b/scipy/spatial/qhull.pyx
@@ -17,6 +17,7 @@ cimport cython
 from . cimport qhull
 from . cimport setlist
 from libc cimport stdlib
+from cysignals.signals cimport sig_on, sig_off
 from scipy._lib.messagestream cimport MessageStream
 
 from numpy.compat import asbytes
@@ -346,9 +347,12 @@ cdef class _Qhull:
                 coord = <coordT*>interior_point.data
             else:
                 coord = NULL
+
+            sig_on()
             exitcode = qh_new_qhull_scipy(self._qh, self.ndim, self.numpoints,
                                           <realT*>points.data, 0,
                                           options_c, NULL, self._messages.handle, coord)
+            sig_off()
 
         if exitcode != 0:
             msg = self._messages.get()

--- a/scipy/spatial/setup.py
+++ b/scipy/spatial/setup.py
@@ -8,7 +8,7 @@ def configuration(parent_package='', top_path=None):
     from scipy._build_utils.system_info import get_info
     from scipy._build_utils import combine_dict, uses_blas64
     from scipy._build_utils.compiler_helper import set_cxx_flags_hook
-    from distutils.sysconfig import get_python_inc
+    from distutils.sysconfig import get_python_inc, get_python_lib
 
     config = Configuration('spatial', parent_package, top_path)
 
@@ -27,6 +27,7 @@ def configuration(parent_package='', top_path=None):
     inc_dirs.append(get_numpy_include_dirs())
     inc_dirs.append(join(dirname(dirname(__file__)), '_lib'))
     inc_dirs.append(join(dirname(dirname(__file__)), '_build_utils', 'src'))
+    inc_dirs.append(join(get_python_lib(), 'cysignals'))
 
     if uses_blas64():
         lapack_opt = get_info('lapack_ilp64_opt')


### PR DESCRIPTION
#### Reference issue
Closes gh-12219.

#### What does this implement/fix?
Use `cysignals` module to allow interrupting C routines in `spatial.ConvexHull`.

#### Additional information
Not sure if a new dependency is what we want, but it works well in this case.