### PR TITLE
TST, CI: turn on codecov patch diffs

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,5 @@
 codecov:
+  require_ci_to_pass: false
   ci:
     - !appveyor
   notify:
@@ -10,6 +11,11 @@ coverage:
       default:
         # Require 1% coverage, i.e., always succeed
         target: 1
-    patch: false
+    patch:
+      default:
+        target: 90
+        if_no_uploads: error
+        if_not_found: success
+        if_ci_failed: failure
     changes: false
 comment: off

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,5 @@
 codecov:
   require_ci_to_pass: false
-  ci:
-    - !appveyor
   notify:
     require_ci_to_pass: no
     after_n_builds: 1


### PR DESCRIPTION
* now that we have an open channel of communication
with the codecov team and GitHub app has been activated
(gh-12240), try turning on pull request patch diffs again,
similar to https://github.com/numpy/numpy/pull/16409

