### PR TITLE
BLD: Build lsap as a single extension instead of extension + lib

### DIFF
--- a/scipy/_build_utils/compiler_helper.py
+++ b/scipy/_build_utils/compiler_helper.py
@@ -83,3 +83,23 @@ def set_cxx_flags_hook(build_ext, ext):
             args.append(min_macos_flag)
             ext.extra_link_args.append(min_macos_flag)
 
+
+def set_cxx_flags_clib_hook(build_clib, build_info):
+    cc = build_clib.compiler
+    new_args = []
+    new_link_args = []
+
+    std_flag = get_cxx_std_flag(cc)
+    if std_flag is not None:
+        new_args.append(std_flag)
+
+    if sys.platform == 'darwin':
+        # Set min macOS version
+        min_macos_flag = '-mmacosx-version-min=10.9'
+        if has_flag(cc, min_macos_flag):
+            new_args.append(min_macos_flag)
+            new_link_args.append(min_macos_flag)
+
+    dict_append(build_info, extra_compiler_args=new_args,
+                extra_link_args=new_link_args)
+

--- a/scipy/_build_utils/compiler_helper.py
+++ b/scipy/_build_utils/compiler_helper.py
@@ -83,23 +83,3 @@ def set_cxx_flags_hook(build_ext, ext):
             args.append(min_macos_flag)
             ext.extra_link_args.append(min_macos_flag)
 
-
-def set_cxx_flags_clib_hook(build_clib, build_info):
-    cc = build_clib.compiler
-    new_args = []
-    new_link_args = []
-
-    std_flag = get_cxx_std_flag(cc)
-    if std_flag is not None:
-        new_args.append(std_flag)
-
-    if sys.platform == 'darwin':
-        # Set min macOS version
-        min_macos_flag = '-mmacosx-version-min=10.9'
-        if has_flag(cc, min_macos_flag):
-            new_args.append(min_macos_flag)
-            new_link_args.append(min_macos_flag)
-
-    dict_append(build_info, extra_compile_args=new_args,
-                extra_link_args=new_link_args)
-

--- a/scipy/optimize/setup.py
+++ b/scipy/optimize/setup.py
@@ -10,8 +10,7 @@ def configuration(parent_package='', top_path=None):
     from scipy._build_utils import (gfortran_legacy_flag_hook,
                                     blas_ilp64_pre_build_hook, combine_dict,
                                     uses_blas64, get_f2py_int64_options)
-    from scipy._build_utils.compiler_helper import (
-        set_cxx_flags_hook, set_cxx_flags_clib_hook)
+    from scipy._build_utils.compiler_helper import set_cxx_flags_hook
 
     config = Configuration('optimize', parent_package, top_path)
 
@@ -26,18 +25,13 @@ def configuration(parent_package='', top_path=None):
                          include_dirs=include_dirs,
                          **numpy_nodepr_api)
 
-    config.add_library('rectangular_lsap',
-                       sources='rectangular_lsap/rectangular_lsap.cpp',
-                       headers='rectangular_lsap/rectangular_lsap.h',
-                       _pre_build_hook=set_cxx_flags_clib_hook)
-    config.add_extension(
+    lsap_module = config.add_extension(
         '_lsap_module',
-        sources=['_lsap_module.c'],
-        libraries=['rectangular_lsap'],
-        depends=(['rectangular_lsap/rectangular_lsap.cpp',
-                  'rectangular_lsap/rectangular_lsap.h']),
+        sources=['_lsap_module.c', 'rectangular_lsap/rectangular_lsap.cpp'],
+        depends=(['rectangular_lsap/rectangular_lsap.h']),
         include_dirs=include_dirs,
         **numpy_nodepr_api)
+    lsap_module._pre_build_hook = set_cxx_flags_hook
 
     rootfind_src = [join('Zeros', '*.c')]
     rootfind_hdr = [join('Zeros', 'zeros.h')]

--- a/scipy/optimize/setup.py
+++ b/scipy/optimize/setup.py
@@ -10,7 +10,8 @@ def configuration(parent_package='', top_path=None):
     from scipy._build_utils import (gfortran_legacy_flag_hook,
                                     blas_ilp64_pre_build_hook, combine_dict,
                                     uses_blas64, get_f2py_int64_options)
-    from scipy._build_utils.compiler_helper import set_cxx_flags_hook
+    from scipy._build_utils.compiler_helper import (
+        set_cxx_flags_hook, set_cxx_flags_clib_hook)
 
     config = Configuration('optimize', parent_package, top_path)
 
@@ -25,13 +26,18 @@ def configuration(parent_package='', top_path=None):
                          include_dirs=include_dirs,
                          **numpy_nodepr_api)
 
-    lsap_module = config.add_extension(
+    config.add_library('rectangular_lsap',
+                       sources='rectangular_lsap/rectangular_lsap.cpp',
+                       headers='rectangular_lsap/rectangular_lsap.h',
+                       _pre_build_hook=set_cxx_flags_clib_hook)
+    config.add_extension(
         '_lsap_module',
-        sources=['_lsap_module.c', 'rectangular_lsap/rectangular_lsap.cpp'],
-        depends=(['rectangular_lsap/rectangular_lsap.h']),
+        sources=['_lsap_module.c'],
+        libraries=['rectangular_lsap'],
+        depends=(['rectangular_lsap/rectangular_lsap.cpp',
+                  'rectangular_lsap/rectangular_lsap.h']),
         include_dirs=include_dirs,
         **numpy_nodepr_api)
-    lsap_module._pre_build_hook = set_cxx_flags_hook
 
     rootfind_src = [join('Zeros', '*.c')]
     rootfind_hdr = [join('Zeros', 'zeros.h')]


### PR DESCRIPTION
#### Reference issue
Closes gh-12203

#### What does this implement/fix?
We can't add the required arguments when building the library, so just compile `rectangular_lsap` sources in the extension.

@Sanjoth would you mind testing?