### PR TITLE
DOC: Allow for parallel sphinx doc build

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -116,16 +116,22 @@ upload:
 # Basic Sphinx generation rules for different formats
 #------------------------------------------------------------------------------
 
+.NOTPARALLEL: html-build html-scipyorg
+
+# It's hard to find the value of the -j parameter: https://news.ycombinator.com/item?id=9282218
+PID := $(shell cat /proc/$$$$/status | grep PPid | awk '{print $$2}')
+JJOBS := $(shell grep -aoP "\-j\x00\d+" /proc/$(PID)/cmdline | tr -d '\0')
+
 html: version-check html-build
 html-build:
 	mkdir -p build/html build/doctrees
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) build/html $(FILES)
+	$(SPHINXBUILD) $(JJOBS) -b html $(ALLSPHINXOPTS) build/html $(FILES)
 	@echo
 	@echo "Build finished. The HTML pages are in build/html."
 
 html-scipyorg:
 	mkdir -p build/html build/doctrees
-	$(SPHINXBUILD) -WT --keep-going -t scipyorg $(VERSIONWARNING) -b html $(ALLSPHINXOPTS) build/html-scipyorg $(FILES)
+	$(SPHINXBUILD) $(JJOBS) -WT --keep-going -t scipyorg $(VERSIONWARNING) -b html $(ALLSPHINXOPTS) build/html-scipyorg $(FILES)
 	@echo
 	@echo "Build finished. The HTML pages are in build/html-scipyorg."
 


### PR DESCRIPTION
## What does this implement/fix?
<!--Please explain your changes.-->
The Sphinx docs take ~9 minutes to build on my system.

It only takes ~3 minutes if you know the magic incantation

**PR is slightly aspiration as it's likely unix specific.**
---
#### Additional information
Currently the ways to build in parallel are
```
python runtests.py --no-build --doc -j8
# ^ undocumented (and I don't like having to pass --no-build)
make html SPHINXOPTS=-j6 
# ^ undocumented magic incantation
```

`make -j4 html` seems more natural but sadly doesn't pass `-j4` to SPHINX, in fact getting access to the `-j` parameter is quite hard (see [discussion of difficulty](https://news.ycombinator.com/item?id=9282218))

Maybe I should just overhaul the [build docs guide](https://scipy.github.io/devdocs/dev/contributor/rendering_documentation.html) and say "use `runtest.py --doc --no-build`) and mention `SPHINXOPTS`

Refenece: https://github.com/scipy/scipy/issues/10646