### PR TITLE
BUG: Fix paren error in dual annealing accept_reject calculation

### DIFF
--- a/scipy/optimize/_dual_annealing.py
+++ b/scipy/optimize/_dual_annealing.py
@@ -256,14 +256,14 @@ class StrategyChain(object):
 
     def accept_reject(self, j, e, x_visit):
         r = self._rand_gen.uniform()
-        pqv_temp = (self.acceptance_param - 1.0) * (
-            e - self.energy_state.current_energy) / (
-                self.temperature_step + 1.)
+        pqv_temp = 1.0 - ((1.0 - self.acceptance_param) *
+            (e - self.energy_state.current_energy) / self.temperature_step)
         if pqv_temp <= 0.:
             pqv = 0.
         else:
             pqv = np.exp(np.log(pqv_temp) / (
                 1. - self.acceptance_param))
+
         if r <= pqv:
             # We accept the new location and update state
             self.energy_state.update_current(e, x_visit)

--- a/scipy/optimize/tests/test__dual_annealing.py
+++ b/scipy/optimize/tests/test__dual_annealing.py
@@ -6,10 +6,11 @@
 Unit tests for the dual annealing global optimizer
 """
 from scipy.optimize import dual_annealing
-from scipy.optimize._dual_annealing import VisitingDistribution
-from scipy.optimize._dual_annealing import ObjectiveFunWrapper
 from scipy.optimize._dual_annealing import EnergyState
 from scipy.optimize._dual_annealing import LocalSearchWrapper
+from scipy.optimize._dual_annealing import ObjectiveFunWrapper
+from scipy.optimize._dual_annealing import StrategyChain
+from scipy.optimize._dual_annealing import VisitingDistribution
 from scipy.optimize import rosen, rosen_der
 import pytest
 import numpy as np
@@ -258,3 +259,45 @@ class TestDualAnnealing:
                          -3.93616815e-09, -6.55623025e-09, -6.05775280e-09,
                          -5.00668935e-09], atol=4e-8)
         assert_allclose(ret.fun, 0.000000, atol=5e-13)
+
+    # TODO gh-10892 Fix incorrect accepted counts.
+    @pytest.mark.parametrize('new_e, temp_step, accepted, accept_rate', [
+        (0, 100, 633, 1.0097587941791923),
+        (10, 100, 0, 0.8786035869128718),
+        (10, 60, 0, 0.6812920690579612),
+        (2, 100, 0, 0.9897404249173424),
+    ])
+    def test_accept_reject_probabilistic(
+            self, new_e, temp_step, accepted, accept_rate):
+        # Test accepts unconditionally with e < current_energy and
+        # probabilistically with e > current_energy
+
+        rs = check_random_state(123)
+
+        count_accepted = 0
+        iterations = 1000
+
+        accept_param = -5
+        current_energy = 1
+        for _ in range(iterations):
+            energy_state = EnergyState(lower=None, upper=None)
+            # Set energy state with current_energy, any location.
+            energy_state.update_current(current_energy, [0])
+
+            chain = StrategyChain(
+                accept_param, None, None, None, rs, energy_state)
+            # Normally this is set in run()
+            chain.temperature_step = temp_step
+
+            # Check if update is accepted.
+            chain.accept_reject(j=1, e=new_e, x_visit=[2])
+            if energy_state.current_energy == new_e:
+                count_accepted += 1
+
+        assert count_accepted == accepted
+
+        # Check accept rate
+        pqv = 1 - (1 - accept_param) * (new_e - current_energy) / temp_step
+        rate = 0 if pqv <= 0 else np.exp(np.log(pqv) / (1 - accept_param))
+
+        assert_allclose(rate, accept_rate)

--- a/scipy/optimize/tests/test__dual_annealing.py
+++ b/scipy/optimize/tests/test__dual_annealing.py
@@ -260,12 +260,12 @@ class TestDualAnnealing:
                          -5.00668935e-09], atol=4e-8)
         assert_allclose(ret.fun, 0.000000, atol=5e-13)
 
-    # TODO gh-10892 Fix incorrect accepted counts.
     @pytest.mark.parametrize('new_e, temp_step, accepted, accept_rate', [
-        (0, 100, 633, 1.0097587941791923),
-        (10, 100, 0, 0.8786035869128718),
-        (10, 60, 0, 0.6812920690579612),
-        (2, 100, 0, 0.9897404249173424),
+        (0, 100, 1000, 1.0097587941791923),
+        (0, 2, 1000, 1.2599210498948732),
+        (10, 100, 878, 0.8786035869128718),
+        (10, 60, 695, 0.6812920690579612),
+        (2, 100, 990, 0.9897404249173424),
     ])
     def test_accept_reject_probabilistic(
             self, new_e, temp_step, accepted, accept_rate):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Fixes: https://github.com/scipy/scipy/issues/10892


#### What does this implement/fix?
<!--Please explain your changes.-->
**Change dual_annealing accept_reject calculation.**
@deng-cy noticed that we probably have +1 inside a parenthesis where it probably doesn't belong and I'm inclined to agree (because in several tests pqv_temp_old is never positive (e.g. we never accept))

#### Additional information
<!--Any additional information you think is important.-->
I tested with the Rastrigin example from [the docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.dual_annealing.html)
```
import numpy as np
from scipy.optimize import dual_annealing, minimize

#func = lambda x: np.sum(x*x - 10*np.cos(x)) + 10*np.size(x)
#lower = [-0.5, -0.4, -0.3, -0.2, 0.5]
#upper = [   1,    2,    3,    4,   5]

func = lambda x: np.sum(x*x - 10*np.cos(2*np.pi*(x))) + 10*np.size(x)
lower = [-5.12] * 10
upper = [5.12] * 10

bounds = list(zip(lower, upper))

ret = dual_annealing(func,bounds=bounds,local_search_options={"method":"SLSQP"})
print (ret)
```
Both new and old code find the all zero solution in roughly the same number of iterations so I'm unsure what better test I could be performing.

