### PR TITLE
MAINT: Included mismatched shapes in error messages.

### DIFF
--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -799,7 +799,8 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
     if t.ndim != 1 or np.any(t[1:] < t[:-1]):
         raise ValueError("Expect t to be a 1-D sorted array_like.")
     if x.size != y.shape[0]:
-        raise ValueError('x and y are incompatible.')
+        raise ValueError('Shapes of x {} and y {} are incompatible'
+                         .format(x.shape, y.shape))
     if t.size < x.size + k + 1:
         raise ValueError('Got %d knots, need at least %d.' %
                          (t.size, x.size + k + 1))
@@ -985,11 +986,13 @@ def make_lsq_spline(x, y, t, k=3, w=None, axis=0, check_finite=True):
     if t.ndim != 1 or np.any(t[1:] - t[:-1] < 0):
         raise ValueError("Expect t to be a 1-D sorted array_like.")
     if x.size != y.shape[0]:
-        raise ValueError('x & y are incompatible.')
+        raise ValueError('Shapes of x {} and y {} are incompatible'
+                         .format(x.shape, y.shape))
     if k > 0 and np.any((x < t[k]) | (x > t[-k])):
         raise ValueError('Out of bounds w/ x = %s.' % x)
     if x.size != w.size:
-        raise ValueError('Incompatible weights.')
+        raise ValueError('Shapes of x {} and w {} are incompatible'
+                         .format(x.shape, w.shape))
 
     # number of coefficients
     n = t.size - k - 1

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -818,9 +818,11 @@ class _PPolyBase(object):
         if x.ndim != 1:
             raise ValueError("invalid dimensions for x")
         if x.shape[0] != c.shape[1]:
-            raise ValueError("x and c have incompatible sizes")
+            raise ValueError("Shapes of x {} and c {} are incompatible"
+                             .format(x.shape, c.shape))
         if c.shape[2:] != self.c.shape[2:] or c.ndim != self.c.ndim:
-            raise ValueError("c and self.c have incompatible shapes")
+            raise ValueError("Shapes of c {} and self.c {} are incompatible"
+                             .format(c.shape, self.c.shape))
 
         if c.size == 0:
             return
@@ -1815,7 +1817,8 @@ class BPoly(_PPolyBase):
         """
         ya, yb = np.asarray(ya), np.asarray(yb)
         if ya.shape[1:] != yb.shape[1:]:
-            raise ValueError('ya and yb have incompatible dimensions.')
+            raise ValueError('Shapes of ya {} and yb {} are incompatible'
+                             .format(ya.shape, yb.shape))
 
         dta, dtb = ya.dtype, yb.dtype
         if (np.issubdtype(dta, np.complexfloating) or

--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -335,7 +335,8 @@ def solve_triangular(a, b, trans=0, lower=False, unit_diagonal=False,
     if len(a1.shape) != 2 or a1.shape[0] != a1.shape[1]:
         raise ValueError('expected square matrix')
     if a1.shape[0] != b1.shape[0]:
-        raise ValueError('incompatible dimensions')
+        raise ValueError('shapes of a {} and b {} are incompatible'
+                         .format(a1.shape, b1.shape))
     overwrite_b = overwrite_b or _datacopied(b1, b)
     if debug:
         print('solve:overwrite_b=', overwrite_b)
@@ -862,7 +863,8 @@ def solve_circulant(c, b, singular='raise', tol=None,
     b = np.atleast_1d(b)
     nb = _get_axis_len("b", b, baxis)
     if nc != nb:
-        raise ValueError('Incompatible c and b axis lengths')
+        raise ValueError('Shapes of c {} and b {} are incompatible'
+                         .format(c.shape, b.shape))
 
     fc = np.fft.fft(np.rollaxis(c, caxis, c.ndim), axis=-1)
     abs_fc = np.abs(fc)

--- a/scipy/linalg/decomp_cholesky.py
+++ b/scipy/linalg/decomp_cholesky.py
@@ -199,7 +199,8 @@ def cho_solve(c_and_lower, b, overwrite_b=False, check_finite=True):
     if c.ndim != 2 or c.shape[0] != c.shape[1]:
         raise ValueError("The factored matrix c is not square.")
     if c.shape[1] != b1.shape[0]:
-        raise ValueError("incompatible dimensions.")
+        raise ValueError("incompatible dimensions ({} and {})"
+                         .format(c.shape, b1.shape))
 
     overwrite_b = overwrite_b or _datacopied(b1, b)
 

--- a/scipy/linalg/decomp_lu.py
+++ b/scipy/linalg/decomp_lu.py
@@ -137,7 +137,8 @@ def lu_solve(lu_and_piv, b, trans=0, overwrite_b=False, check_finite=True):
         b1 = asarray(b)
     overwrite_b = overwrite_b or _datacopied(b1, b)
     if lu.shape[0] != b1.shape[0]:
-        raise ValueError("incompatible dimensions.")
+        raise ValueError("Shapes of lu {} and b {} are incompatible"
+                         .format(lu.shape, b1.shape))
 
     getrs, = get_lapack_funcs(('getrs',), (lu, b1))
     x, info = getrs(lu, piv, b1, trans=trans, overwrite_b=overwrite_b)

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -1465,7 +1465,9 @@ class StateSpace(LinearTimeInvariant):
                 c = self.C
                 d = self.D + other
             else:
-                raise ValueError("Cannot add systems with incompatible dimensions")
+                raise ValueError("Cannot add systems with incompatible "
+                                 "dimensions ({} and {})"
+                                 .format(self.D.shape, other.shape))
 
         common_dtype = np.find_common_type((a.dtype, b.dtype, c.dtype, d.dtype), ())
         return StateSpace(np.asarray(a, dtype=common_dtype),

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -345,7 +345,8 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
 
     def _add_dense(self, other):
         if other.shape != self.shape:
-            raise ValueError('Incompatible shapes.')
+            raise ValueError('Incompatible shapes ({} and {})'
+                             .format(self.shape, other.shape))
         dtype = upcast_char(self.dtype.char, other.dtype.char)
         order = self._swap('CF')[0]
         result = np.array(other, dtype=dtype, order=order, copy=True)

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -567,7 +567,8 @@ class coo_matrix(_data_matrix, _minmax_mixin):
 
     def _add_dense(self, other):
         if other.shape != self.shape:
-            raise ValueError('Incompatible shapes.')
+            raise ValueError('Incompatible shapes ({} and {})'
+                             .format(self.shape, other.shape))
         dtype = upcast_char(self.dtype.char, other.dtype.char)
         result = np.array(other, dtype=dtype, copy=True)
         fortran = int(result.flags.f_contiguous)

--- a/scipy/sparse/linalg/_expm_multiply.py
+++ b/scipy/sparse/linalg/_expm_multiply.py
@@ -172,7 +172,8 @@ def _expm_multiply_simple(A, B, t=1.0, balance=False):
     if len(A.shape) != 2 or A.shape[0] != A.shape[1]:
         raise ValueError('expected A to be like a square matrix')
     if A.shape[1] != B.shape[0]:
-        raise ValueError('the matrices A and B have incompatible shapes')
+        raise ValueError('shapes of matrices A {} and B {} are incompatible'
+                         .format(A.shape, B.shape))
     ident = _ident_like(A)
     n = A.shape[0]
     if len(B.shape) == 1:
@@ -556,7 +557,8 @@ def _expm_multiply_interval(A, B, start=None, stop=None,
     if len(A.shape) != 2 or A.shape[0] != A.shape[1]:
         raise ValueError('expected A to be like a square matrix')
     if A.shape[1] != B.shape[0]:
-        raise ValueError('the matrices A and B have incompatible shapes')
+        raise ValueError('shapes of matrices A {} and B {} are incompatible'
+                         .format(A.shape, B.shape))
     ident = _ident_like(A)
     n = A.shape[0]
     if len(B.shape) == 1:

--- a/scipy/sparse/linalg/isolve/utils.py
+++ b/scipy/sparse/linalg/isolve/utils.py
@@ -71,7 +71,8 @@ def make_system(A, M, x0, b):
     b = asanyarray(b)
 
     if not (b.shape == (N,1) or b.shape == (N,)):
-        raise ValueError('A and b have incompatible dimensions')
+        raise ValueError('shapes of A {} and b {} are incompatible'
+                         .format(A.shape, b.shape))
 
     if b.dtype.char not in 'fdFD':
         b = b.astype('d')  # upcast non-FP types to double
@@ -95,7 +96,8 @@ def make_system(A, M, x0, b):
     else:
         x = array(x0, dtype=xtype)
         if not (x.shape == (N,1) or x.shape == (N,)):
-            raise ValueError('A and x have incompatible dimensions')
+            raise ValueError('shapes of A {} and x0 {} are incompatible'
+                            .format(A.shape, x.shape))
         x = x.ravel()
 
     # process preconditioner


### PR DESCRIPTION
... just to help with debugging.

Note that there are no parentheses in the formulation "Shapes of foo {}
and bar {}..." because tuple formatting already provides them.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
N/A

#### What does this implement/fix?
Improve error messages when matrices with mismatched shapes are passed to various functions.

#### Additional information
N/A