### PR TITLE
ENH: linalg: support for ILP64 BLAS/LAPACK in f2py wrappers

### DIFF
--- a/scipy/linalg/blas.py
+++ b/scipy/linalg/blas.py
@@ -216,6 +216,13 @@ try:
 except ImportError:
     _cblas = None
 
+try:
+    from scipy.linalg import _fblas_64
+    HAS_ILP64 = True
+except ImportError:
+    HAS_ILP64 = False
+    _fblas_64 = None
+
 # Expose all functions (only fblas --- cblas is an implementation detail)
 empty_module = None
 from scipy.linalg._fblas import *
@@ -316,7 +323,8 @@ def find_best_blas_type(arrays=(), dtype=None):
 
 def _get_funcs(names, arrays, dtype,
                lib_name, fmodule, cmodule,
-               fmodule_name, cmodule_name, alias):
+               fmodule_name, cmodule_name, alias,
+               ilp64=False):
     """
     Return available BLAS/LAPACK functions.
 
@@ -351,6 +359,10 @@ def _get_funcs(names, arrays, dtype,
                 '%s function %s could not be found' % (lib_name, func_name))
         func.module_name, func.typecode = module_name, prefix
         func.dtype = dtype
+        if not ilp64:
+            func.int_dtype = _np.dtype(_np.intc)
+        else:
+            func.int_dtype = _np.dtype(_np.int64)
         func.prefix = prefix  # Backward compatibility
         funcs.append(func)
 
@@ -368,8 +380,8 @@ def _memoize_get_funcs(func):
     func.memo = memo
 
     @functools.wraps(func)
-    def getter(names, arrays=(), dtype=None):
-        key = (names, dtype)
+    def getter(names, arrays=(), dtype=None, ilp64=False):
+        key = (names, dtype, ilp64)
         for array in arrays:
             # cf. find_blas_funcs
             key += (array.dtype.char, array.flags.fortran)
@@ -384,7 +396,7 @@ def _memoize_get_funcs(func):
         if value is not None:
             return value
 
-        value = func(names, arrays, dtype)
+        value = func(names, arrays, dtype, ilp64)
 
         if key is not None:
             memo[key] = value
@@ -395,7 +407,7 @@ def _memoize_get_funcs(func):
 
 
 @_memoize_get_funcs
-def get_blas_funcs(names, arrays=(), dtype=None):
+def get_blas_funcs(names, arrays=(), dtype=None, ilp64=False):
     """Return available BLAS function objects from names.
 
     Arrays are used to determine the optimal prefix of BLAS routines.
@@ -413,6 +425,10 @@ def get_blas_funcs(names, arrays=(), dtype=None):
     dtype : str or dtype, optional
         Data-type specifier. Not used if `arrays` is non-empty.
 
+    ilp64 : {True, False, 'preferred'}, optional
+        Whether to return ILP64 routine variant.
+        Choosing 'preferred' returns ILP64 routine if available,
+        and otherwise the 32-bit routine. Default: False
 
     Returns
     -------
@@ -445,6 +461,20 @@ def get_blas_funcs(names, arrays=(), dtype=None):
     'z'
 
     """
-    return _get_funcs(names, arrays, dtype,
-                      "BLAS", _fblas, _cblas, "fblas", "cblas",
-                      _blas_alias)
+    if isinstance(ilp64, str):
+        if ilp64 == 'preferred':
+            ilp64 = HAS_ILP64
+        else:
+            raise ValueError("Invalid value for 'ilp64'")
+
+    if not ilp64:
+        return _get_funcs(names, arrays, dtype,
+                          "BLAS", _fblas, _cblas, "fblas", "cblas",
+                          _blas_alias, ilp64=False)
+    else:
+        if not HAS_ILP64:
+            raise RuntimeError("BLAS ILP64 routine requested, but Scipy "
+                               "compiled only with 32-bit BLAS")
+        return _get_funcs(names, arrays, dtype,
+                          "BLAS", _fblas_64, None, "fblas_64", None,
+                          _blas_alias, ilp64=True)

--- a/scipy/linalg/decomp_svd.py
+++ b/scipy/linalg/decomp_svd.py
@@ -115,7 +115,7 @@ def svd(a, full_matrices=True, compute_uv=True, overwrite_a=False,
         raise ValueError('lapack_driver must be "gesdd" or "gesvd", not "%s"'
                          % (lapack_driver,))
     funcs = (lapack_driver, lapack_driver + '_lwork')
-    gesXd, gesXd_lwork = get_lapack_funcs(funcs, (a1,))
+    gesXd, gesXd_lwork = get_lapack_funcs(funcs, (a1,), ilp64='preferred')
 
     # compute optimal lwork
     lwork = _compute_lwork(gesXd_lwork, a1.shape[0], a1.shape[1],

--- a/scipy/linalg/fblas.pyf.src
+++ b/scipy/linalg/fblas.pyf.src
@@ -8,6 +8,10 @@
 
 
 python module _fblas
+    usercode '''
+#define F_INT int
+'''
+
     interface
 
        include 'fblas_l1.pyf.src'

--- a/scipy/linalg/fblas_64.pyf.src
+++ b/scipy/linalg/fblas_64.pyf.src
@@ -1,0 +1,14 @@
+python module _fblas_64
+    usercode '''
+#if defined(BLAS_SYMBOL_PREFIX) || defined(BLAS_SYMBOL_SUFFIX)
+#include "blas64-prefix-defines.h"
+#endif
+#define F_INT npy_int64
+'''
+
+    interface
+       include 'fblas_l1.pyf.src'
+       include 'fblas_l2.pyf.src'
+       include 'fblas_l3.pyf.src'
+    end interface
+end python module _fblas_64

--- a/scipy/linalg/fblas_l1.pyf.src
+++ b/scipy/linalg/fblas_l1.pyf.src
@@ -125,7 +125,7 @@ subroutine <tchar>rot(n,x,offx,incx,y,offy,incy,c,s)
   !
 
   callstatement (*f2py_func)(&n,x+offx,&incx,y+offy,&incy,&c,&s)
-  callprotoargument int*,<ctype>*,int*,<ctype>*,int*,<ctypereal>*,<ctypereal>*
+  callprotoargument F_INT*,<ctype>*,F_INT*,<ctype>*,F_INT*,<ctypereal>*,<ctypereal>*
 
   <ftype> dimension(*),intent(in,out,copy) :: x,y
   <ftypereal> intent(in) :: c, s
@@ -156,7 +156,7 @@ subroutine <prefix2>rotm(n,x,offx,incx,y,offy,incy,param)
   ! in the param(2) through param(5) array.
 
   callstatement (*f2py_func)(&n,x+offx,&incx,y+offy,&incy,param)
-  callprotoargument int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*
+  callprotoargument F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*
 
   <ftype2> dimension(*), intent(in,out,copy) :: x, y
   <ftype2> dimension(5), intent(in) :: param
@@ -178,7 +178,7 @@ subroutine <prefix>swap(n,x,offx,incx,y,offy,incy)
   ! Swap two arrays: x <-> y
 
   callstatement (*f2py_func)(&n,x+offx,&incx,y+offy,&incy)
-  callprotoargument int*,<ctype>*,int*,<ctype>*,int*
+  callprotoargument F_INT*,<ctype>*,F_INT*,<ctype>*,F_INT*
 
   <ftype> dimension(*), intent(in,out) :: x, y
   integer optional, intent(in),check(incx>0||incx<0) :: incx = 1
@@ -199,7 +199,7 @@ subroutine <prefix>scal(n,a,x,offx,incx)
   ! Computes the product of a vector by a scalar: y = a*x
 
   callstatement (*f2py_func)(&n,&a,x+offx,&incx)
-  callprotoargument int*,<ctype>*,<ctype>*,int*
+  callprotoargument F_INT*,<ctype>*,<ctype>*,F_INT*
 
   <ftype> intent(in):: a
   <ftype> dimension(*), intent(in,out) :: x
@@ -218,7 +218,7 @@ subroutine <tchar2c>scal(n,a,x,offx,incx)
   ! y = a*x
 
   callstatement (*f2py_func)(&n,&a,x+offx,&incx)
-  callprotoargument int*,<float,double>*,<complex_float, complex_double>*,int*
+  callprotoargument F_INT*,<float,double>*,<complex_float, complex_double>*,F_INT*
 
   <real,double precision> intent(in) :: a
   <complex, double complex> dimension(*), intent(in,out,copy) :: x
@@ -235,7 +235,7 @@ subroutine <prefix>copy(n,x,offx,incx,y,offy,incy)
   ! Copy y <- x
 
   callstatement (*f2py_func)(&n,x+offx,&incx,y+offy,&incy)
-  callprotoargument int*,<ctype>*,int*,<ctype>*,int*
+  callprotoargument F_INT*,<ctype>*,F_INT*,<ctype>*,F_INT*
 
   <ftype> dimension(*), intent(in) :: x
   <ftype> dimension(*), intent(in,out) :: y
@@ -257,7 +257,7 @@ subroutine <prefix>axpy(n,a,x,offx,incx,y,offy,incy)
   ! Calculate z = a*x+y, where a is scalar.
 
   callstatement (*f2py_func)(&n,&a,x+offx,&incx,y+offy,&incy)
-  callprotoargument int*,<ctype>*,<ctype>*,int*,<ctype>*,int*
+  callprotoargument F_INT*,<ctype>*,<ctype>*,F_INT*,<ctype>*,F_INT*
 
   <ftype> dimension(*), intent(in) :: x
   <ftype> dimension(*), intent(in,out,out=z) :: y
@@ -282,7 +282,7 @@ function sdot(n,x,offx,incx,y,offy,incy) result (xy)
   fortranname sdot
 
   callstatement (*f2py_func)(&sdot,&n,x+offx,&incx,y+offy,&incy)
-  callprotoargument float*,int*,float*,int*,float*,int*
+  callprotoargument float*,F_INT*,float*,F_INT*,float*,F_INT*
 
   real dimension(*), intent(in) :: x
   real dimension(*), intent(in) :: y
@@ -305,7 +305,7 @@ function ddot(n,x,offx,incx,y,offy,incy) result (xy)
   ! Computes a vector-vector dot product.
 
   callstatement (*f2py_func)(&ddot,&n,x+offx,&incx,y+offy,&incy)
-  callprotoargument double*,int*,double*,int*,double*,int*
+  callprotoargument double*,F_INT*,double*,F_INT*,double*,F_INT*
 
   double precision dimension(*), intent(in) :: x
   double precision dimension(*), intent(in) :: y
@@ -330,7 +330,7 @@ function <prefix2c>dotu(n,x,offx,incx,y,offy,incy) result(xy)
   fortranname w<prefix2c>dotu
 
   callstatement (*f2py_func)(&<prefix2c>dotu,&n,x+offx,&incx,y+offy,&incy)
-  callprotoargument <ctype2c>*,int*,<ctype2c>*,int*,<ctype2c>*,int*
+  callprotoargument <ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*
 
   <ftype2c> dimension(*),intent(in) :: x
   <ftype2c> dimension(*),intent(in) :: y
@@ -357,7 +357,7 @@ function <prefix2c>dotc(n,x,offx,incx,y,offy,incy) result(xy)
   fortranname w<prefix2c>dotc
 
   callstatement (*f2py_func)(&<prefix2c>dotc,&n,x+offx,&incx,y+offy,&incy)
-  callprotoargument <ctype2c>*,int*,<ctype2c>*,int*,<ctype2c>*,int*
+  callprotoargument <ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*
 
   <ftype2c> dimension(*),intent(in) :: x
   <ftype2c> dimension(*),intent(in) :: y
@@ -382,7 +382,7 @@ function <prefix3>nrm2(n,x,offx,incx) result(n2)
   <ftypereal3> <prefix3>nrm2, n2
 
   callstatement (*f2py_func)(&<prefix3>nrm2, &n,x+offx,&incx)
-  callprotoargument <ctypereal3>*,int*,<ctype3>*,int*
+  callprotoargument <ctypereal3>*,F_INT*,<ctype3>*,F_INT*
 
   <ftype3> dimension(*),intent(in) :: x
 
@@ -402,7 +402,7 @@ function <prefix4>nrm2(n,x,offx,incx) result(n2)
   <ftypereal4> <prefix4>nrm2, n2
 
   callstatement (*f2py_func)(&<prefix4>nrm2, &n,x+offx,&incx)
-  callprotoargument <ctypereal4>*,int*,<ctype4>*,int*
+  callprotoargument <ctypereal4>*,F_INT*,<ctype4>*,F_INT*
 
   <ftype4> dimension(*),intent(in) :: x
 
@@ -421,7 +421,7 @@ function <prefix3>asum(n,x,offx,incx) result (s)
   ! Computes the sum of magnitudes of the vector elements
 
   callstatement (*f2py_func)(&<prefix3>asum,&n,x+offx,&incx)
-  callprotoargument <ctypereal3>*,int*,<ctype3>*,int*
+  callprotoargument <ctypereal3>*,F_INT*,<ctype3>*,F_INT*
 
   <ftype3> dimension(*), intent(in) :: x
   <ftypereal3> <prefix3>asum,s
@@ -438,7 +438,7 @@ function <prefix4>asum(n,x,offx,incx) result (s)
   ! Computes the sum of magnitudes of the vector elements
 
   callstatement (*f2py_func)(&<prefix4>asum,&n,x+offx,&incx)
-  callprotoargument <ctypereal4>*,int*,<ctype4>*,int*
+  callprotoargument <ctypereal4>*,F_INT*,<ctype4>*,F_INT*
 
   <ftype4> dimension(*), intent(in) :: x
   <ftypereal4> <prefix4>asum,s
@@ -455,7 +455,7 @@ function i<prefix>amax(n,x,offx,incx) result(k)
   ! Finds the index of the element with maximum absolute value.
 
   callstatement i<prefix>amax_return_value = (*f2py_func)(&n,x+offx,&incx) - 1
-  callprotoargument int*,<ctype>*,int*
+  callprotoargument F_INT*,<ctype>*,F_INT*
 
   ! This is to avoid Fortran wrappers.
   integer i<prefix>amax,k

--- a/scipy/linalg/fblas_l2.pyf.src
+++ b/scipy/linalg/fblas_l2.pyf.src
@@ -22,8 +22,8 @@ subroutine <prefix>gemv(m,n,alpha,a,x,beta,y,offx,incx,offy,incy,trans,rows,cols
 
   callstatement (*f2py_func)((trans?(trans==2?"C":"T"):"N"),&m,&n,&alpha,a,&m, &
        x+offx,&incx,&beta,y+offy,&incy)
-  callprotoargument char*,int*,int*,<ctype>*,<ctype>*,int*,<ctype>*,int*,<ctype>*, &
-       <ctype>*,int*
+  callprotoargument char*,F_INT*,F_INT*,<ctype>*,<ctype>*,F_INT*,<ctype>*,F_INT*,<ctype>*, &
+       <ctype>*,F_INT*
 
   integer optional, intent(in), check(trans>=0 && trans <=2) :: trans = 0
   integer optional, intent(in), check(incx>0||incx<0) :: incx = 1
@@ -65,7 +65,7 @@ subroutine <prefix>gbmv(m,n,kl,ku,alpha,a,lda,x,incx,offx,beta,y,incy,offy,trans
   ! m by n band matrix, with kl sub-diagonals and ku super-diagonals.
 
   callstatement (*f2py_func)((trans?(trans==2?"C":"T"):"N"),&m,&n,&kl,&ku,&alpha,a,&lda,x+offx,&incx,&beta,y+offy,&incy)
-  callprotoargument char*,int*,int*,int*,int*,<ctype>*,<ctype>*,int*,<ctype>*,int*,<ctype>*,<ctype>*,int*
+  callprotoargument char*,F_INT*,F_INT*,F_INT*,F_INT*,<ctype>*,<ctype>*,F_INT*,<ctype>*,F_INT*,<ctype>*,<ctype>*,F_INT*
 
   integer optional,intent(in),check(trans>=0 && trans <=2) :: trans = 0
   integer intent(in), depend(ku,kl),check(m>=ku+kl+1) :: m
@@ -107,7 +107,7 @@ subroutine <prefix><s,s,h,h>bmv(n,k,alpha,a,lda,x,incx,offx,beta,y,incy,offy,low
   ! A is an n by n symmetric band matrix, with k super-diagonals.
 
   callstatement (*f2py_func)((lower?"L":"U"),&n,&k,&alpha,a,&lda,x+offx,&incx,&beta,y+offy,&incy)
-  callprotoargument char*,int*,int*,<ctype>*,<ctype>*,int*,<ctype>*,int*,<ctype>*,<ctype>*,int*
+  callprotoargument char*,F_INT*,F_INT*,<ctype>*,<ctype>*,F_INT*,<ctype>*,F_INT*,<ctype>*,<ctype>*,F_INT*
 
   integer optional, intent(in),check(lower==0||lower==1) :: lower = 0
   integer intent(hide),depend(a),check(n>=0) :: n = shape(a,1)
@@ -143,7 +143,7 @@ subroutine <prefix6><s,s,s,s,h,h>pmv(n,alpha,ap,x,incx,offx,beta,y,incy,offy,low
   ! Calculate y <- alpha * A * x + beta * y, A is symmmetric in packed form.
 
   callstatement (*f2py_func)((lower?"L":"U"),&n,&alpha,ap,x+offx,&incx,&beta,y+offy,&incy)
-  callprotoargument char*,int*,<ctype6>*,<ctype6>*,<ctype6>*,int*,<ctype6>*,<ctype6>*,int*
+  callprotoargument char*,F_INT*,<ctype6>*,<ctype6>*,<ctype6>*,F_INT*,<ctype6>*,<ctype6>*,F_INT*
 
   integer optional, intent(in),check(lower==0||lower==1) :: lower = 0
   integer intent(in),check(n>=0) :: n
@@ -178,8 +178,8 @@ subroutine <prefix><symv,\0,hemv,\2>(n,alpha,a,x,beta,y,offx,incx,offy,incy,lowe
 
   callstatement (*f2py_func)((lower?"L":"U"),&n,&alpha,a,&n,x+offx,&incx,&beta, &
        y+offy,&incy)
-  callprotoargument char*,int*,<ctype>*,<ctype>*,int*,<ctype>*,int*,<ctype>*, &
-       <ctype>*,int*
+  callprotoargument char*,F_INT*,<ctype>*,<ctype>*,F_INT*,<ctype>*,F_INT*,<ctype>*, &
+       <ctype>*,F_INT*
 
   integer optional, intent(in),check(lower==0||lower==1) :: lower = 0
   integer optional, intent(in),check(incx>0||incx<0) :: incx = 1
@@ -236,7 +236,7 @@ subroutine <prefix6><sy,\0,\0,\0, he,\4>r(alpha,x,lower,incx,offx,n,a)
   ! Calculate a <- alpha*x*x^H + a
   !
     callstatement (*f2py_func)((lower?"L":"U"),&n,&alpha,x+offx,&incx,a,&n)
-    callprotoargument char*, int*, <ctype6>*, <ctype6>*, int*, <ctype6>*, int*
+    callprotoargument char*, F_INT*, <ctype6>*, <ctype6>*, F_INT*, <ctype6>*, F_INT*
 
     integer, optional, intent(in), check(lower == 0 || lower == 1) :: lower = 0
     <ftype6> intent(in) :: alpha
@@ -264,7 +264,7 @@ subroutine <prefix><sy, \0, he, \2>r2(alpha,x,y,lower,incx,offx,incy,offy,n,a)
   ! Calculate a <- alpha*x*y^H + alpha*y*x^H + a
   !
     callstatement (*f2py_func)((lower?"L":"U"),&n,&alpha,x+offx,&incx,y+offy,&incy,a,&n)
-    callprotoargument char*, int*, <ctype>*, <ctype>*, int*, <ctype>*, int*, <ctype>*, int*
+    callprotoargument char*, F_INT*, <ctype>*, <ctype>*, F_INT*, <ctype>*, F_INT*, <ctype>*, F_INT*
 
     integer intent(in), optional, check(lower == 0 || lower == 1) :: lower = 0
     <ftype> intent(in) :: alpha
@@ -295,7 +295,7 @@ subroutine <prefix6><s,s,s,s,h,h>pr(n,alpha,x,incx,offx,ap,lower)
   ! symmetric/hermitian matrix, supplied in packed form.
 
     callstatement (*f2py_func)((lower?"L":"U"),&n,&alpha,x+offx,&incx,ap)
-    callprotoargument char*,int*,<ctype6creal>*,<ctype6>*,int*,<ctype6>*
+    callprotoargument char*,F_INT*,<ctype6creal>*,<ctype6>*,F_INT*,<ctype6>*
 
     integer intent(in),check(n>=0) :: n
     integer intent(in), optional, check(lower == 0 || lower == 1) :: lower = 0
@@ -322,7 +322,7 @@ subroutine <prefix><s,s,h,h>pr2(n,alpha,x,incx,offx,y,incy,offy,ap,lower)
   ! where alpha is a scalar, x and y are n element vectors and A is an
   ! n by n symmetric/hermitian matrix, supplied in packed form.
     callstatement (*f2py_func)((lower?"L":"U"),&n,&alpha,x+offx,&incx,y+offy,&incy,ap)
-    callprotoargument char*,int*,<ctype>*,<ctype>*,int*,<ctype>*,int*,<ctype>*
+    callprotoargument char*,F_INT*,<ctype>*,<ctype>*,F_INT*,<ctype>*,F_INT*,<ctype>*
 
     integer intent(in),check(n>=0) :: n
     integer intent(in), optional, check(lower == 0 || lower == 1) :: lower = 0
@@ -359,7 +359,7 @@ subroutine <prefix>tbsv(n,k,a,lda,x,incx,offx,lower,trans,diag)
   ! routine. Such tests must be performed before calling this routine.
 
   callstatement (*f2py_func)((lower?"L":"U"),(trans?(trans==2?"C":"T"):"N"),(diag?"U":"N"),&n,&k,a,&lda,x+offx,&incx)
-  callprotoargument char*,char*,char*,int*,int*,<ctype>*,int*,<ctype>*,int*
+  callprotoargument char*,char*,char*,F_INT*,F_INT*,<ctype>*,F_INT*,<ctype>*,F_INT*
 
   integer intent(hide),check(n>=0),depend(a) :: n = shape(a,1)
   integer intent(in), optional, check(lower == 0 || lower == 1) :: lower = 0
@@ -392,7 +392,7 @@ subroutine <prefix>tpsv(n,ap,x,incx,offx,lower,trans,diag)
   ! routine. Such tests must be performed before calling this routine.
 
   callstatement (*f2py_func)((lower?"L":"U"),(trans?(trans==2?"C":"T"):"N"),(diag?"U":"N"),&n,ap,x+offx,&incx)
-  callprotoargument char*,char*,char*,int*,<ctype>*,<ctype>*,int*
+  callprotoargument char*,char*,char*,F_INT*,<ctype>*,<ctype>*,F_INT*
 
   integer intent(in),check(n>=0) :: n
   integer intent(in), optional, check(lower == 0 || lower == 1) :: lower = 0
@@ -419,7 +419,7 @@ subroutine <prefix>trmv(n,a,x,offx,incx,lower,trans,diag)
 
   callstatement (*f2py_func)((lower?"L":"U"), (trans?(trans==2?"C":"T"):"N"), &
        (diag?"U":"N"),&n,a,&n,x+offx,&incx)
-  callprotoargument char*,char*,char*,int*,<ctype>*,int*,<ctype>*,int*
+  callprotoargument char*,char*,char*,F_INT*,<ctype>*,F_INT*,<ctype>*,F_INT*
 
   integer optional, intent(in), check(trans>=0 && trans <=2) :: trans = 0
   integer optional, intent(in), check(lower==0||lower==1) :: lower = 0
@@ -451,7 +451,7 @@ subroutine <prefix>trsv(n,a,lda,x,incx,offx,lower,trans,diag)
   ! routine. Such tests must be performed before calling this routine.
 
   callstatement (*f2py_func)((lower?"L":"U"),(trans?(trans==2?"C":"T"):"N"),(diag?"U":"N"),&n,a,&lda,x+offx,&incx)
-  callprotoargument char*,char*,char*,int*,<ctype>*,int*,<ctype>*,int*
+  callprotoargument char*,char*,char*,F_INT*,<ctype>*,F_INT*,<ctype>*,F_INT*
 
   integer intent(hide),check(n>=0),depend(a) :: n = shape(a,0)
   integer intent(in), optional, check(lower == 0 || lower == 1) :: lower = 0
@@ -480,7 +480,7 @@ subroutine <prefix>tbmv(n,k,a,lda,x,incx,offx,lower,trans,diag)
   ! upper or lower triangular band matrix, with ( k + 1 ) diagonals.
 
   callstatement (*f2py_func)((lower?"L":"U"),(trans?(trans==2?"C":"T"):"N"),(diag?"U":"N"),&n,&k,a,&lda,x+offx,&incx)
-  callprotoargument char*,char*,char*,int*,int*,<ctype>*,int*,<ctype>*,int*
+  callprotoargument char*,char*,char*,F_INT*,F_INT*,<ctype>*,F_INT*,<ctype>*,F_INT*
 
   integer intent(hide),check(n>=0),depend(a) :: n = shape(a,1)
   integer intent(in), optional, check(lower == 0 || lower == 1) :: lower = 0
@@ -510,7 +510,7 @@ subroutine <prefix>tpmv(n,ap,x,incx,offx,lower,trans,diag)
   ! non-unit, upper or lower triangular matrix, supplied in packed form.
 
   callstatement (*f2py_func)((lower?"L":"U"),(trans?(trans==2?"C":"T"):"N"),(diag?"U":"N"),&n,ap,x+offx,&incx)
-  callprotoargument char*,char*,char*,int*,<ctype>*,<ctype>*,int*
+  callprotoargument char*,char*,char*,F_INT*,<ctype>*,<ctype>*,F_INT*
 
   integer intent(in),check(n>=0) :: n
   integer intent(in), optional, check(lower == 0 || lower == 1) :: lower = 0

--- a/scipy/linalg/fblas_l3.pyf.src
+++ b/scipy/linalg/fblas_l3.pyf.src
@@ -22,8 +22,8 @@ subroutine <prefix>gemm(m,n,k,alpha,a,b,beta,c,trans_a,trans_b,lda,ka,ldb,kb)
 
   callstatement (*f2py_func)((trans_a?(trans_a==2?"C":"T"):"N"), &
        (trans_b?(trans_b==2?"C":"T"):"N"),&m,&n,&k,&alpha,a,&lda,b,&ldb,&beta,c,&m)
-  callprotoargument char*,char*,int*,int*,int*,<ctype>*,<ctype>*,int*,<ctype>*, &
-       int*,<ctype>*,<ctype>*,int*
+  callprotoargument char*,char*,F_INT*,F_INT*,F_INT*,<ctype>*,<ctype>*,F_INT*,<ctype>*, &
+       F_INT*,<ctype>*,<ctype>*,F_INT*
 
   integer optional,intent(in),check(trans_a>=0 && trans_a <=2) :: trans_a = 0
   integer optional,intent(in),check(trans_b>=0 && trans_b <=2) :: trans_b = 0
@@ -58,8 +58,8 @@ subroutine <prefix6><sy,\0,\0,\0,he,he>mm(m, n, alpha, a, b, beta, c, side, lowe
 
   callstatement (*f2py_func)((side?"R":"L"), &
        (lower?"L":"U"),&m,&n,&alpha,a,&lda,b,&ldb,&beta,c,&m)
-  callprotoargument char*,char*,int*,int*,<ctype6>*,<ctype6>*,int*,<ctype6>*, &
-       int*,<ctype6>*,<ctype6>*,int*
+  callprotoargument char*,char*,F_INT*,F_INT*,<ctype6>*,<ctype6>*,F_INT*,<ctype6>*, &
+       F_INT*,<ctype6>*,<ctype6>*,F_INT*
 
   integer optional, intent(in),check(side==0||side==1) :: side = 0
   integer optional, intent(in),check(lower==0||lower==1) :: lower = 0
@@ -93,8 +93,8 @@ subroutine <prefix6><sy,\0,\0,\0,he,he>rk(n,k,alpha,a,beta,c,trans,lower,lda,ka)
   !
   callstatement (*f2py_func)((lower?"L":"U"), &
         (trans?(trans==2?"C":"T"):"N"), &n,&k,&alpha,a,&lda,&beta,c,&n)
-  callprotoargument char*,char*,int*,int*,<ctype6>*,<ctype6>*,int*,<ctype6>*, &
-        <ctype6>*,int*
+  callprotoargument char*,char*,F_INT*,F_INT*,<ctype6>*,<ctype6>*,F_INT*,<ctype6>*, &
+        <ctype6>*,F_INT*
 
   integer optional, intent(in),check(lower==0||lower==1) :: lower = 0
   integer optional,intent(in),check(trans>=0 && trans <=2) :: trans = 0
@@ -124,8 +124,8 @@ subroutine <prefix6><sy,\0,\0,\0,he,he>r2k(n,k,alpha,a,b,beta,c,trans,lower,lda,
   !
   callstatement (*f2py_func)((lower?"L":"U"), &
         (trans?(trans==2?"C":"T"):"N"), &n,&k,&alpha,a,&lda,b,&ldb,&beta,c,&n)
-  callprotoargument char*,char*,int*,int*,<ctype6>*,<ctype6>*,int*,<ctype6>*,int*, &
-        <ctype6>*, <ctype6>*,int*
+  callprotoargument char*,char*,F_INT*,F_INT*,<ctype6>*,<ctype6>*,F_INT*,<ctype6>*,F_INT*, &
+        <ctype6>*, <ctype6>*,F_INT*
 
   integer optional, intent(in),check(lower==0||lower==1) :: lower = 0
   integer optional,intent(in),check(trans>=0 && trans <=2) :: trans = 0
@@ -164,7 +164,7 @@ subroutine <prefix>trmm(m, n, k, alpha, a, b, lda, ldb, side, lower, trans_a, di
   ! c = trmm(alpha, a, b, side=0, lower=0, trans_a=0, diag=0)
 
   callstatement (*f2py_func)((side?"R":"L"), (lower?"L":"U"),(trans_a?(trans_a==2?"C":"T"):"N"), (diag?"U":"N"), &m, &n, &alpha, a, &lda, b, &ldb)
-  callprotoargument char*, char*, char*, char*, int*, int*, <ctype>*,<ctype>*,int*,<ctype>*, int*
+  callprotoargument char*, char*, char*, char*, F_INT*, F_INT*, <ctype>*,<ctype>*,F_INT*,<ctype>*, F_INT*
 
   integer optional, intent(in), check(side==0 || side==1) :: side = 0
   integer optional, intent(in), check(lower==0 || lower==1) :: lower = 0
@@ -200,7 +200,7 @@ subroutine <prefix>trsm(m, n, alpha, a, b, lda, ldb, side, lower, trans_a, diag)
 
   callstatement (*f2py_func)((side?"R":"L"), (lower?"L":"U"), &
         (trans_a?(trans_a==2?"C":"T"):"N"), (diag?"U":"N"), &m, &n, &alpha, a, &lda, b, &ldb)
-  callprotoargument char*, char*, char*, char*, int*, int*, <ctype>*,<ctype>*,int*,<ctype>*, int*
+  callprotoargument char*, char*, char*, char*, F_INT*, F_INT*, <ctype>*,<ctype>*,F_INT*,<ctype>*, F_INT*
 
   integer optional, intent(in), check(side==0 || side==1) :: side = 0
   integer optional, intent(in), check(lower==0 || lower==1) :: lower = 0

--- a/scipy/linalg/flapack.pyf.src
+++ b/scipy/linalg/flapack.pyf.src
@@ -25,6 +25,10 @@
 !
 
 python module _flapack
+    usercode '''
+#define F_INT int
+'''
+
 interface
 
     ! Following classification is due to

--- a/scipy/linalg/flapack_64.pyf.src
+++ b/scipy/linalg/flapack_64.pyf.src
@@ -1,0 +1,36 @@
+! Shorthand Notations:
+! --------------------
+! <prefix=s,d,c,z>
+! <prefix2=s,d>
+! <prefix2c=c,z>
+! <ftype=real,double precision,complex,double complex>
+! <ftype2=real,double precision>
+! <ftype2c=complex,double complex>
+! <ftypereal=real,double precision,real,double precision>
+! <ftypecomplex=complex,double complex,\0,\1>
+! <ctype=float,double,complex_float,complex_double>
+! <ctype2=float,double>
+! <ctype2c=complex_float,complex_double>
+! <ctypereal=float,double,float,double>
+! <ctypecomplex=complex_float,complex_double,\0,\1>
+
+python module _flapack_64
+    usercode '''
+#if defined(BLAS_SYMBOL_PREFIX) || defined(BLAS_SYMBOL_SUFFIX)
+#include "blas64-prefix-defines.h"
+#endif
+#define F_INT npy_int64
+'''
+
+interface
+    include 'flapack_user.pyf.src'
+    include 'flapack_gen.pyf.src'
+    include 'flapack_gen_banded.pyf.src'
+    include 'flapack_gen_tri.pyf.src'
+    include 'flapack_sym_herm.pyf.src'
+    include 'flapack_pos_def.pyf.src'
+    include 'flapack_pos_def_tri.pyf.src'
+    include 'flapack_other.pyf.src'
+end interface
+
+end python module _flapack_64

--- a/scipy/linalg/flapack_gen.pyf.src
+++ b/scipy/linalg/flapack_gen.pyf.src
@@ -17,7 +17,7 @@ subroutine <prefix>gebal(scale,permute,n,a,m,lo,hi,pivscale,info)
     ! lo,hi mark the starting and ending columns of submatrix B.
 
     callstatement { (*f2py_func)((permute?(scale?"B":"P"):(scale?"S":"N")),&n,a,&m,&lo,&hi,pivscale,&info); hi--; lo--; }
-    callprotoargument char*,int*,<ctype>*,int*,int*,int*,<ctypereal>*,int*
+    callprotoargument char*,F_INT*,<ctype>*,F_INT*,F_INT*,F_INT*,<ctypereal>*,F_INT*
     integer intent(in),optional :: permute = 0
     integer intent(in),optional :: scale = 0
     integer intent(hide),depend(a,n) :: m = shape(a,0)
@@ -52,7 +52,7 @@ subroutine <prefix>gehrd(n,lo,hi,a,tau,work,lwork,info)
     !              a]
     !
     callstatement { hi++; lo++; (*f2py_func)(&n,&lo,&hi,a,&n,tau,work,&lwork,&info); }
-    callprotoargument int*,int*,int*,<ctype>*,int*,<ctype>*,<ctype>*,int*,int*
+    callprotoargument F_INT*,F_INT*,F_INT*,<ctype>*,F_INT*,<ctype>*,<ctype>*,F_INT*,F_INT*
     integer intent(hide),depend(a) :: n = shape(a,0)
     <ftype> dimension(n,n),intent(in,out,copy,out=ht,aligned8),check(shape(a,0)==shape(a,1)) :: a
     integer intent(in),optional :: lo = 0
@@ -68,7 +68,7 @@ subroutine <prefix>gehrd_lwork(n,lo,hi,a,tau,work,lwork,info)
     ! LWORK computation for GEHRD
     fortranname <prefix>gehrd
     callstatement { hi++; lo++; (*f2py_func)(&n,&lo,&hi,&a,&n,&tau,&work,&lwork,&info); }
-    callprotoargument int*,int*,int*,<ctype>*,int*,<ctype>*,<ctype>*,int*,int*
+    callprotoargument F_INT*,F_INT*,F_INT*,<ctype>*,F_INT*,<ctype>*,<ctype>*,F_INT*,F_INT*
     integer intent(in) :: n
     <ftype> intent(hide) :: a
     integer intent(in),optional :: lo = 0
@@ -86,8 +86,8 @@ subroutine <prefix>gesv(n,nrhs,a,piv,b,info)
     ! U is upper diagonal triangular, L is unit lower triangular,
     ! piv pivots columns.
 
-    callstatement {int i;(*f2py_func)(&n,&nrhs,a,&n,piv,b,&n,&info);for(i=0;i\<n;--piv[i++]);}
-    callprotoargument int*,int*,<ctype>*,int*,int*,<ctype>*,int*,int*
+    callstatement {F_INT i;(*f2py_func)(&n,&nrhs,a,&n,piv,b,&n,&info);for(i=0;i\<n;--piv[i++]);}
+    callprotoargument F_INT*,F_INT*,<ctype>*,F_INT*,F_INT*,<ctype>*,F_INT*,F_INT*
 
     integer depend(a),intent(hide):: n = shape(a,0)
     integer depend(b),intent(hide):: nrhs = shape(b,1)
@@ -104,8 +104,8 @@ subroutine <prefix2>gesvx(fact,trans,n,nrhs,a,lda,af,ldaf,ipiv,equed,r,c,b,ldb,x
     ! The expert driver of ?GESV with condition number, backward/forward error estimates, and iterative refinement
     ! This part takes care of the data types, single and double reals (sgesvx and dgesvx)
     threadsafe
-    callstatement {int i;(*f2py_func)(fact,trans,&n,&nrhs,a,&lda,af,&ldaf,ipiv,equed,r,c,b,&ldb,x,&ldx,&rcond,ferr,berr,work,iwork,&info);for(i=0;i\<n;--ipiv[i++]);}
-    callprotoargument char*,char*,int*,int*,<ctype2>*,int*,<ctype2>*,int*,int*,char*,<ctype2>*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,int*,int*
+    callstatement {F_INT i;(*f2py_func)(fact,trans,&n,&nrhs,a,&lda,af,&ldaf,ipiv,equed,r,c,b,&ldb,x,&ldx,&rcond,ferr,berr,work,iwork,&info);for(i=0;i\<n;--ipiv[i++]);}
+    callprotoargument char*,char*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*,char*,<ctype2>*,<ctype2>*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,F_INT*,F_INT*
 
     character optional,intent(in):: trans = "N"
     character optional,intent(in):: fact = "E"
@@ -137,8 +137,8 @@ subroutine <prefix2c>gesvx(fact,trans,n,nrhs,a,lda,af,ldaf,ipiv,equed,r,c,b,ldb,
     ! The expert driver of ?GESV with condition number, backward/forward error estimates, and iterative refinement
     ! This part takes care of the data types, complex and double complex (cgesvx and zgesvx)
     threadsafe
-    callstatement {int i;(*f2py_func)(fact,trans,&n,&nrhs,a,&lda,af,&ldaf,ipiv,equed,r,c,b,&ldb,x,&ldx,&rcond,ferr,berr,work,rwork,&info);for(i=0;i\<n;--ipiv[i++]);}
-    callprotoargument char*,char*,int*,int*,<ctype2c>*,int*,<ctype2c>*,int*,int*,char*,<ctype2>*,<ctype2>*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2c>*,<ctype2>*,int*
+    callstatement {F_INT i;(*f2py_func)(fact,trans,&n,&nrhs,a,&lda,af,&ldaf,ipiv,equed,r,c,b,&ldb,x,&ldx,&rcond,ferr,berr,work,rwork,&info);for(i=0;i\<n;--ipiv[i++]);}
+    callprotoargument char*,char*,F_INT*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,F_INT*,char*,<ctype2>*,<ctype2>*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2c>*,<ctype2>*,F_INT*
 
     character optional,intent(in):: trans = "N"
     character optional,intent(in):: fact = "E"
@@ -169,7 +169,7 @@ subroutine <prefix>gecon(norm,n,a,lda,anorm,rcond,work,irwork,info)
    ! Computes the 1- or inf- norm reciprocal condition number estimate.
     threadsafe
     callstatement (*f2py_func)(norm,&n,a,&lda,&anorm,&rcond,work,irwork,&info)
-    callprotoargument char*,int*,<ctype>*,int*,<ctypereal>*,<ctypereal>*,<ctype>*,<int,int,float,double>*,int*
+    callprotoargument char*,F_INT*,<ctype>*,F_INT*,<ctypereal>*,<ctypereal>*,<ctype>*,<F_INT,F_INT,float,double>*,F_INT*
 
     character optional,intent(in):: norm = '1'
     integer depend(a),intent(hide):: n = shape(a,0)
@@ -188,8 +188,8 @@ subroutine <prefix>getrf(m,n,a,piv,info)
     ! Compute an LU factorization of a  general  M-by-N  matrix  A.
     ! A = P * L * U
     threadsafe
-    callstatement {int i;(*f2py_func)(&m,&n,a,&m,piv,&info);for(i=0,n=MIN(m,n);i\<n;--piv[i++]);}
-    callprotoargument int*,int*,<ctype>*,int*,int*,int*
+    callstatement {F_INT i;(*f2py_func)(&m,&n,a,&m,piv,&info);for(i=0,n=MIN(m,n);i\<n;--piv[i++]);}
+    callprotoargument F_INT*,F_INT*,<ctype>*,F_INT*,F_INT*,F_INT*
 
     integer depend(a),intent(hide):: m = shape(a,0)
     integer depend(a),intent(hide):: n = shape(a,1)
@@ -206,8 +206,8 @@ subroutine <prefix>getrs(n,nrhs,lu,piv,b,info,trans)
     ! Solve A^H * X = B if trans=2
     ! A = P * L * U
     threadsafe
-    callstatement {int i;for(i=0;i\<n;++piv[i++]);(*f2py_func)((trans?(trans==2?"C":"T"):"N"),&n,&nrhs,lu,&n,piv,b,&n,&info);for(i=0;i\<n;--piv[i++]);}
-    callprotoargument char*,int*,int*,<ctype>*,int*,int*,<ctype>*,int*,int*
+    callstatement {F_INT i;for(i=0;i\<n;++piv[i++]);(*f2py_func)((trans?(trans==2?"C":"T"):"N"),&n,&nrhs,lu,&n,piv,b,&n,&info);for(i=0;i\<n;--piv[i++]);}
+    callprotoargument char*,F_INT*,F_INT*,<ctype>*,F_INT*,F_INT*,<ctype>*,F_INT*,F_INT*
 
     integer optional,intent(in),check(trans>=0 && trans <=2) :: trans = 0
 
@@ -226,8 +226,8 @@ subroutine <prefix>getc2(n,a,lda,ipiv,jpiv,info)
     ! Compute an LU factorization of with complete pivoting of a general n-by-n matrix.
     ! A = P * L * U * Q
     threadsafe
-    callstatement {int i;(*f2py_func)(&n,a,&lda,ipiv,jpiv,&info);for(i=0;i\<n;--ipiv[i],--jpiv[i++]);}
-    callprotoargument int*,<ctype>*,int*,int*,int*,int*
+    callstatement {F_INT i;(*f2py_func)(&n,a,&lda,ipiv,jpiv,&info);for(i=0;i\<n;--ipiv[i],--jpiv[i++]);}
+    callprotoargument F_INT*,<ctype>*,F_INT*,F_INT*,F_INT*,F_INT*
 
     integer depend(a),intent(hide):: n = shape(a,0)
     <ftype> dimension(n,n),intent(in,out,copy,out=lu) :: a
@@ -244,8 +244,8 @@ subroutine <prefix>gesc2(n,lu,lda,rhs,ipiv,jpiv,scale)
     ! Solve  A * X = scale * RHS
     ! A = P * L * U * Q
     threadsafe
-    callstatement {int i;for(i=0;i\<n;++ipiv[i],++jpiv[i++]);(*f2py_func)(&n,lu,&lda,rhs,ipiv,jpiv,&scale);for(i=0;i\<n;--ipiv[i],--jpiv[i++]);}
-    callprotoargument int*,<ctype>*,int*,<ctype>*,int*,int*,<ctypereal>*
+    callstatement {F_INT i;for(i=0;i\<n;++ipiv[i],++jpiv[i++]);(*f2py_func)(&n,lu,&lda,rhs,ipiv,jpiv,&scale);for(i=0;i\<n;--ipiv[i],--jpiv[i++]);}
+    callprotoargument F_INT*,<ctype>*,F_INT*,<ctype>*,F_INT*,F_INT*,<ctypereal>*
 
     integer depend(lu),intent(hide):: n = shape(lu,0)
     <ftype> dimension(n,n),intent(in) :: lu
@@ -263,8 +263,8 @@ subroutine <prefix>getri(n,lu,piv,work,lwork,info)
     ! Find A inverse A^-1.
     ! A = P * L * U
 
-    callstatement {int i;for(i=0;i\<n;++piv[i++]);(*f2py_func)(&n,lu,&n,piv,work,&lwork,&info);for(i=0;i\<n;--piv[i++]);}
-    callprotoargument int*,<ctype>*,int*,int*,<ctype>*,int*,int*
+    callstatement {F_INT i;for(i=0;i\<n;++piv[i++]);(*f2py_func)(&n,lu,&n,piv,work,&lwork,&info);for(i=0;i\<n;--piv[i++]);}
+    callprotoargument F_INT*,<ctype>*,F_INT*,F_INT*,<ctype>*,F_INT*,F_INT*
 
     integer depend(lu),intent(hide):: n = shape(lu,0)
     <ftype> dimension(n,n),intent(in,out,copy,out=inv_a) :: lu
@@ -280,7 +280,7 @@ subroutine <prefix>getri_lwork(n,lu,piv,work,lwork,info)
     ! *GETRI LWORK query
     fortranname <prefix>getri
     callstatement (*f2py_func)(&n,&lu,&n,&piv,&work,&lwork,&info)
-    callprotoargument int*,<ctype>*,int*,int*,<ctype>*,int*,int*
+    callprotoargument F_INT*,<ctype>*,F_INT*,F_INT*,<ctype>*,F_INT*,F_INT*
 
     integer intent(in):: n
     <ftype> intent(hide) :: lu
@@ -301,7 +301,7 @@ subroutine <prefix2>gesdd(m,n,minmn,u0,u1,vt0,vt1,a,compute_uv,full_matrices,u,s
     ! transpose(V) - N x N matrix or N x min(M,N) if full_matrices=False
 
     callstatement (*f2py_func)((compute_uv?(full_matrices?"A":"S"):"N"),&m,&n,a,&m,s,u,&u0,vt,&vt0,work,&lwork,iwork,&info)
-    callprotoargument char*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,int*,int*,int*
+    callprotoargument char*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*
 
     integer intent(in),optional,check(compute_uv==0||compute_uv==1):: compute_uv = 1
     integer intent(in),optional,check(full_matrices==0||full_matrices==1):: full_matrices = 1
@@ -329,7 +329,7 @@ subroutine <prefix2>gesdd_lwork(m,n,minmn,u0,vt0,a,compute_uv,full_matrices,u,s,
 
     fortranname <prefix2>gesdd
     callstatement (*f2py_func)((compute_uv?(full_matrices?"A":"S"):"N"),&m,&n,&a,&m,&s,&u,&u0,&vt,&vt0,&work,&lwork,&iwork,&info)
-    callprotoargument char*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,int*,int*,int*
+    callprotoargument char*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*
 
     integer intent(in),optional,check(compute_uv==0||compute_uv==1):: compute_uv = 1
     integer intent(in),optional,check(full_matrices==0||full_matrices==1):: full_matrices = 1
@@ -360,7 +360,7 @@ subroutine <prefix2c>gesdd(m,n,minmn,u0,u1,vt0,vt1,a,compute_uv,full_matrices,u,
     ! transpose(V) - N x N matrix or N x min(M,N) if full_matrices=False
 
     callstatement (*f2py_func)((compute_uv?(full_matrices?"A":"S"):"N"),&m,&n,a,&m,s,u,&u0,vt,&vt0,work,&lwork,rwork,iwork,&info)
-    callprotoargument char*,int*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,int*,int*
+    callprotoargument char*,F_INT*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,F_INT*,F_INT*
 
     integer intent(in),optional,check(compute_uv==0||compute_uv==1):: compute_uv = 1
     integer intent(in),optional,check(full_matrices==0||full_matrices==1):: full_matrices = 1
@@ -389,7 +389,7 @@ subroutine <prefix2c>gesdd_lwork(m,n,minmn,u0,vt0,a,compute_uv,full_matrices,u,s
 
     fortranname <prefix2c>gesdd
     callstatement (*f2py_func)((compute_uv?(full_matrices?"A":"S"):"N"),&m,&n,&a,&m,&s,&u,&u0,&vt,&vt0,&work,&lwork,&rwork,&iwork,&info)
-    callprotoargument char*,int*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,int*,int*
+    callprotoargument char*,F_INT*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,F_INT*,F_INT*
 
     integer intent(in),optional,check(compute_uv==0||compute_uv==1):: compute_uv = 1
     integer intent(in),optional,check(full_matrices==0||full_matrices==1):: full_matrices = 1
@@ -421,7 +421,7 @@ subroutine <prefix2>gesvd(m,n,minmn,u0,u1,vt0,vt1,a,compute_uv,full_matrices,u,s
     ! transpose(V) - N x N matrix or N x min(M,N) if full_matrices=False
 
     callstatement (*f2py_func)((compute_uv?(full_matrices?"A":"S"):"N"),(compute_uv?(full_matrices?"A":"S"):"N"),&m,&n,a,&m,s,u,&u0,vt,&vt0,work,&lwork,&info)
-    callprotoargument char*,char*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,int*,int*
+    callprotoargument char*,char*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*
 
     integer intent(in),optional,check(compute_uv==0||compute_uv==1):: compute_uv = 1
     integer intent(in),optional,check(full_matrices==0||full_matrices==1):: full_matrices = 1
@@ -447,7 +447,7 @@ subroutine <prefix2>gesvd_lwork(m,n,minmn,u0,vt0,a,compute_uv,full_matrices,u,s,
 
     fortranname <prefix2>gesvd
     callstatement (*f2py_func)((compute_uv?(full_matrices?"A":"S"):"N"),(compute_uv?(full_matrices?"A":"S"):"N"),&m,&n,&a,&m,&s,&u,&u0,&vt,&vt0,&work,&lwork,&info)
-    callprotoargument char*,char*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,int*,int*
+    callprotoargument char*,char*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*
 
     integer intent(in),optional,check(compute_uv==0||compute_uv==1):: compute_uv = 1
     integer intent(in),optional,check(full_matrices==0||full_matrices==1):: full_matrices = 1
@@ -477,7 +477,7 @@ subroutine <prefix2c>gesvd(m,n,minmn,u0,u1,vt0,vt1,a,compute_uv,full_matrices,u,
     ! transpose(V) - N x N matrix or N x min(M,N) if full_matrices=False
 
     callstatement (*f2py_func)((compute_uv?(full_matrices?"A":"S"):"N"),(compute_uv?(full_matrices?"A":"S"):"N"),&m,&n,a,&m,s,u,&u0,vt,&vt0,work,&lwork,rwork,&info)
-    callprotoargument char*,char*,int*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,int*
+    callprotoargument char*,char*,F_INT*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,F_INT*
 
     integer intent(in),optional,check(compute_uv==0||compute_uv==1):: compute_uv = 1
     integer intent(in),optional,check(full_matrices==0||full_matrices==1):: full_matrices = 1
@@ -504,7 +504,7 @@ subroutine <prefix2c>gesvd_lwork(m,n,minmn,u0,vt0,a,compute_uv,full_matrices,u,s
 
     fortranname <prefix2c>gesvd
     callstatement (*f2py_func)((compute_uv?(full_matrices?"A":"S"):"N"),(compute_uv?(full_matrices?"A":"S"):"N"),&m,&n,&a,&m,&s,&u,&u0,&vt,&vt0,&work,&lwork,&rwork,&info)
-    callprotoargument char*,char*,int*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,int*
+    callprotoargument char*,char*,F_INT*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,F_INT*
 
     integer intent(in),optional,check(compute_uv==0||compute_uv==1):: compute_uv = 1
     integer intent(in),optional,check(full_matrices==0||full_matrices==1):: full_matrices = 1
@@ -529,7 +529,7 @@ subroutine <prefix>gels(trans,m,n,nrhs,a,lda,b,ldb,work,lwork,info)
     ! Solve Minimize 2-norm(A * X - B).
 
     callstatement (*f2py_func)(trans,&m,&n,&nrhs,a,&lda,b,&ldb,work,&lwork,&info)
-    callprotoargument char*,int*,int*,int*,<ctype>*,int*,<ctype>*,int*,<ctype>*,int*,int*
+    callprotoargument char*,F_INT*,F_INT*,F_INT*,<ctype>*,F_INT*,<ctype>*,F_INT*,<ctype>*,F_INT*,F_INT*
 
     character optional,intent(in),check(*trans=='N'||*trans==<'T',\0,'C',\2>):: trans = 'N'
     integer intent(hide),depend(a):: m = shape(a,0)
@@ -550,7 +550,7 @@ subroutine <prefix>gels_lwork(trans,m,n,nrhs,a,lda,b,ldb,work,lwork,info)
 
     fortranname <prefix>gels
     callstatement (*f2py_func)(trans,&m,&n,&nrhs,&a,&lda,&b,&ldb,&work,&lwork,&info)
-    callprotoargument char*,int*,int*,int*,<ctype>*,int*,<ctype>*,int*,<ctype>*,int*,int*
+    callprotoargument char*,F_INT*,F_INT*,F_INT*,<ctype>*,F_INT*,<ctype>*,F_INT*,<ctype>*,F_INT*,F_INT*
 
     character optional,intent(in),check(*trans=='N'||*trans==<'T',\0,'C',\2>):: trans = 'N'
     integer intent(in),check(m>=0) :: m
@@ -573,7 +573,7 @@ subroutine <prefix2>gelss(m,n,minmn,maxmn,nrhs,a,b,s,cond,r,work,lwork,info)
     ! Solve Minimize 2-norm(A * X - B).
 
     callstatement (*f2py_func)(&m,&n,&nrhs,a,&m,b,&maxmn,s,&cond,&r,work,&lwork,&info)
-    callprotoargument int*,int*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,int*
+    callprotoargument F_INT*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*
 
     integer intent(hide),depend(a):: m = shape(a,0)
     integer intent(hide),depend(a):: n = shape(a,1)
@@ -603,7 +603,7 @@ subroutine <prefix2>gelss_lwork(m,n,maxmn,nrhs,a,b,s,cond,r,work,lwork,info)
    ! Query for optimal lwork size
     fortranname <prefix2>gelss
     callstatement (*f2py_func)(&m,&n,&nrhs,&a,&m,&b,&maxmn,&s,&cond,&r,&work,&lwork,&info)
-    callprotoargument int*,int*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,int*
+    callprotoargument F_INT*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*
 
     integer intent(in):: m
     integer intent(in):: n
@@ -628,7 +628,7 @@ subroutine <prefix2c>gelss(m,n,minmn,maxmn,nrhs,a,b,s,cond,r,work,rwork,lwork,in
     ! Solve Minimize 2-norm(A * X - B).
 
     callstatement (*f2py_func)(&m,&n,&nrhs,a,&m,b,&maxmn,s,&cond,&r,work,&lwork,rwork,&info)
-    callprotoargument int*,int*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2c>*,int*,<ctype2>*,int*
+    callprotoargument F_INT*,F_INT*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,F_INT*
 
     integer intent(hide),depend(a):: m = shape(a,0)
     integer intent(hide),depend(a):: n = shape(a,1)
@@ -660,7 +660,7 @@ subroutine <prefix2c>gelss_lwork(m,n,maxmn,nrhs,a,b,s,cond,r,work,rwork,lwork,in
 
     fortranname <prefix2c>gelss
     callstatement (*f2py_func)(&m,&n,&nrhs,&a,&m,&b,&maxmn,&s,&cond,&r,&work,&lwork,&rwork,&info)
-    callprotoargument int*,int*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2c>*,int*,<ctype2>*,int*
+    callprotoargument F_INT*,F_INT*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,F_INT*
 
     integer intent(in):: m
     integer intent(in):: n
@@ -686,7 +686,7 @@ subroutine <prefix2>gelsy(m,n,maxmn,minmn,nrhs,a,b,jptv,cond,r,work,lwork,info)
     ! Solve Minimize 2-norm(A * X - B).
 
     callstatement (*f2py_func)(&m,&n,&nrhs,a,&m,b,&maxmn,jptv,&cond,&r,work,&lwork,&info)
-    callprotoargument int*,int*,int*,<ctype2>*,int*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,int*,int*
+    callprotoargument F_INT*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*
 
     integer intent(hide),depend(a):: m = shape(a,0)
     integer intent(hide),depend(a):: n = shape(a,1)
@@ -716,7 +716,7 @@ subroutine <prefix2>gelsy_lwork(m,n,maxmn,nrhs,a,b,jptv,cond,r,work,lwork,info)
 
     fortranname <prefix2>gelsy
     callstatement (*f2py_func)(&m,&n,&nrhs,&a,&m,&b,&maxmn,&jptv,&cond,&r,&work,&lwork,&info)
-    callprotoargument int*,int*,int*,<ctype2>*,int*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,int*,int*
+    callprotoargument F_INT*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*
 
     integer intent(in) :: m
     integer intent(in) :: n
@@ -741,7 +741,7 @@ subroutine <prefix2c>gelsy(m,n,maxmn,minmn,nrhs,a,b,jptv,cond,r,work,lwork,rwork
     ! Solve Minimize 2-norm(A * X - B).
 
     callstatement (*f2py_func)(&m,&n,&nrhs,a,&m,b,&maxmn,jptv,&cond,&r,work,&lwork,rwork,&info)
-    callprotoargument int*,int*,int*,<ctype2c>*,int*,<ctype2c>*,int*,int*,<ctype2>*,int*,<ctype2c>*,int*,<ctype2>*,int*
+    callprotoargument F_INT*,F_INT*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,F_INT*
 
     integer intent(hide),depend(a):: m = shape(a,0)
     integer intent(hide),depend(a):: n = shape(a,1)
@@ -772,7 +772,7 @@ subroutine <prefix2c>gelsy_lwork(m,n,maxmn,nrhs,a,b,jptv,cond,r,work,lwork,rwork
 
     fortranname <prefix2c>gelsy
     callstatement (*f2py_func)(&m,&n,&nrhs,&a,&m,&b,&maxmn,&jptv,&cond,&r,&work,&lwork,&rwork,&info)
-    callprotoargument int*,int*,int*,<ctype2c>*,int*,<ctype2c>*,int*,int*,<ctype2>*,int*,<ctype2c>*,int*,<ctype2>*,int*
+    callprotoargument F_INT*,F_INT*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,F_INT*
 
     integer intent(in) :: m
     integer intent(in) :: n
@@ -798,7 +798,7 @@ subroutine <prefix2>gelsd(m,n,minmn,maxmn,nrhs,a,b,s,cond,r,work,lwork,size_iwor
     ! Solve Minimize 2-norm(A * X - B).
 
     callstatement (*f2py_func)(&m,&n,&nrhs,a,&m,b,&maxmn,s,&cond,&r,work,&lwork,iwork,&info)
-    callprotoargument int*,int*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,int*,int*
+    callprotoargument F_INT*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*
 
     integer intent(hide),depend(a):: m = shape(a,0)
     integer intent(hide),depend(a):: n = shape(a,1)
@@ -831,7 +831,7 @@ subroutine <prefix2>gelsd_lwork(m,n,maxmn,nrhs,a,b,s,cond,r,work,lwork,iwork,inf
 
     fortranname <prefix2>gelsd
     callstatement (*f2py_func)(&m,&n,&nrhs,&a,&m,&b,&maxmn,&s,&cond,&r,&work,&lwork,&iwork,&info)
-    callprotoargument int*,int*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,int*,int*
+    callprotoargument F_INT*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*
 
     integer intent(in) :: m
     integer intent(in) :: n
@@ -858,7 +858,7 @@ subroutine <prefix2c>gelsd(m,n,minmn,maxmn,nrhs,a,b,s,cond,r,work,lwork,size_rwo
     ! Solve Minimize 2-norm(A * X - B).
 
     callstatement (*f2py_func)(&m,&n,&nrhs,a,&m,b,&maxmn,s,&cond,&r,work,&lwork, rwork, iwork,&info)
-    callprotoargument int*,int*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,int*, <ctype2c>*,int*,<ctype2>*,int*,int*
+    callprotoargument F_INT*,F_INT*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*, <ctype2c>*,F_INT*,<ctype2>*,F_INT*,F_INT*
 
     integer intent(hide),depend(a):: m = shape(a,0)
     integer intent(hide),depend(a):: n = shape(a,1)
@@ -894,7 +894,7 @@ subroutine <prefix2c>gelsd_lwork(m,n,maxmn,nrhs,a,b,s,cond,r,work,lwork,rwork,iw
 
     fortranname <prefix2c>gelsd
     callstatement (*f2py_func)(&m,&n,&nrhs,&a,&m,&b,&maxmn,&s,&cond,&r,&work,&lwork, &rwork, &iwork,&info)
-    callprotoargument int*,int*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,int*, <ctype2c>*,int*,<ctype2>*,int*,int*
+    callprotoargument F_INT*,F_INT*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*, <ctype2c>*,F_INT*,<ctype2>*,F_INT*,F_INT*
 
     integer intent(in) :: m
     integer intent(in) :: n
@@ -924,7 +924,7 @@ subroutine <prefix2>geqp3(m,n,a,jpvt,tau,work,lwork,info)
 
     threadsafe
     callstatement (*f2py_func)(&m,&n,a,&m,jpvt,tau,work,&lwork,&info)
-    callprotoargument int*,int*,<ctype2>*,int*,int*,<ctype2>*,<ctype2>*,int*,int*
+    callprotoargument F_INT*,F_INT*,<ctype2>*,F_INT*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,F_INT*
     integer intent(hide),depend(a):: m = shape(a,0)
     integer intent(hide),depend(a):: n = shape(a,1)
     <ftype2> dimension(m,n),intent(in,out,copy,out=qr,aligned8) :: a
@@ -943,7 +943,7 @@ subroutine <prefix2c>geqp3(m,n,a,jpvt,tau,work,lwork,rwork,info)
 
     threadsafe
     callstatement (*f2py_func)(&m,&n,a,&m,jpvt,tau,work,&lwork,rwork,&info)
-    callprotoargument int*,int*,<ctype2c>*,int*,int*,<ctype2c>*,<ctype2c>*,int*,<ctype2>*,int*
+    callprotoargument F_INT*,F_INT*,<ctype2c>*,F_INT*,F_INT*,<ctype2c>*,<ctype2c>*,F_INT*,<ctype2>*,F_INT*
 
     integer intent(hide),depend(a):: m = shape(a,0)
     integer intent(hide),depend(a):: n = shape(a,1)
@@ -965,7 +965,7 @@ subroutine <prefix>geqrf(m,n,a,tau,work,lwork,info)
 
     threadsafe
     callstatement (*f2py_func)(&m,&n,a,&m,tau,work,&lwork,&info)
-    callprotoargument int*,int*,<ctype>*,int*,<ctype>*,<ctype>*,int*,int*
+    callprotoargument F_INT*,F_INT*,<ctype>*,F_INT*,<ctype>*,<ctype>*,F_INT*,F_INT*
 
     integer intent(hide),depend(a):: m = shape(a,0)
     integer intent(hide),depend(a):: n = shape(a,1)
@@ -984,7 +984,7 @@ subroutine <prefix>geqrf_lwork(m,n,a,tau,work,lwork,info)
 
     fortranname <prefix>geqrf
     callstatement (*f2py_func)(&m,&n,&a,&m,&tau,&work,&lwork,&info)
-    callprotoargument int*,int*,<ctype>*,int*,<ctype>*,<ctype>*,int*,int*
+    callprotoargument F_INT*,F_INT*,<ctype>*,F_INT*,<ctype>*,<ctype>*,F_INT*,F_INT*
 
     integer intent(in), check(m > 0) :: m
     integer intent(in), check(n > 0) :: n
@@ -1011,7 +1011,7 @@ subroutine <prefix>geqrfp(m,n,a,lda,tau,work,lwork,info)
     !    0 is a (M-N)-by-N zero matrix, if M > N.
 
     callstatement (*f2py_func)(&m,&n,a,&lda,tau,work,&lwork,&info)
-    callprotoargument int*,int*,<ctype>*,int*,<ctype>*,<ctype>*,int*,int*
+    callprotoargument F_INT*,F_INT*,<ctype>*,F_INT*,<ctype>*,<ctype>*,F_INT*,F_INT*
 
     integer intent(hide), check(m > 0), depend(a) :: m = shape(a, 0)
     integer intent(hide), check(n > 0), depend(a) :: n = shape(a, 1)
@@ -1029,7 +1029,7 @@ subroutine <prefix>geqrfp_lwork(m,n,a,lda,tau,work,lwork,info)
 
     fortranname <prefix>geqrfp
     callstatement (*f2py_func)(&m,&n,&a,&lda,&tau,&work,&lwork,&info)
-    callprotoargument int*,int*,<ctype>*,int*,<ctype>*,<ctype>*,int*,int*
+    callprotoargument F_INT*,F_INT*,<ctype>*,F_INT*,<ctype>*,<ctype>*,F_INT*,F_INT*
 
     integer intent(in), check(m > 0) :: m
     integer intent(in), check(n > 0) :: n
@@ -1049,7 +1049,7 @@ subroutine <prefix>gerqf(m,n,a,tau,work,lwork,info)
 
     threadsafe
     callstatement (*f2py_func)(&m,&n,a,&m,tau,work,&lwork,&info)
-    callprotoargument int*,int*,<ctype>*,int*,<ctype>*,<ctype>*,int*,int*
+    callprotoargument F_INT*,F_INT*,<ctype>*,F_INT*,<ctype>*,<ctype>*,F_INT*,F_INT*
 
     integer intent(hide),depend(a):: m = shape(a,0)
     integer intent(hide),depend(a):: n = shape(a,1)
@@ -1066,7 +1066,7 @@ subroutine <prefix2>geev(compute_vl,compute_vr,n,a,wr,wi,vl,ldvl,vr,ldvr,work,lw
     ! wr,wi,vl,vr,info = geev(a,compute_vl=1,compute_vr=1,lwork=4*n,overwrite_a=0)
 
     callstatement {(*f2py_func)((compute_vl?"V":"N"),(compute_vr?"V":"N"),&n,a,&n,wr,wi,vl,&ldvl,vr,&ldvr,work,&lwork,&info);}
-    callprotoargument char*,char*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,int*,int*
+    callprotoargument char*,char*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*
 
     integer optional,intent(in):: compute_vl = 1
     check(compute_vl==1||compute_vl==0) compute_vl
@@ -1099,7 +1099,7 @@ subroutine <prefix2>geev_lwork(compute_vl,compute_vr,n,a,wr,wi,vl,ldvl,vr,ldvr,w
 
     fortranname <prefix2>geev
     callstatement {(*f2py_func)((compute_vl?"V":"N"),(compute_vr?"V":"N"),&n,&a,&n,&wr,&wi,&vl,&ldvl,&vr,&ldvr,&work,&lwork,&info);}
-    callprotoargument char*,char*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,int*,int*
+    callprotoargument char*,char*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*
 
     integer optional,intent(in):: compute_vl = 1
     check(compute_vl==1||compute_vl==0) compute_vl
@@ -1129,7 +1129,7 @@ subroutine <prefix2c>geev(compute_vl,compute_vr,n,a,w,vl,ldvl,vr,ldvr,work,lwork
     ! w,vl,vr,info = geev(a,compute_vl=1,compute_vr=1,lwork=2*n,overwrite_a=0)
 
     callstatement (*f2py_func)((compute_vl?"V":"N"),(compute_vr?"V":"N"),&n,a,&n,w,vl,&ldvl,vr,&ldvr,work,&lwork,rwork,&info)
-    callprotoargument char*,char*,int*,<ctype2c>*,int*,<ctype2c>*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,int*
+    callprotoargument char*,char*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,F_INT*
 
     integer optional,intent(in):: compute_vl = 1
     check(compute_vl==1||compute_vl==0) compute_vl
@@ -1162,7 +1162,7 @@ subroutine <prefix2c>geev_lwork(compute_vl,compute_vr,n,a,w,vl,ldvl,vr,ldvr,work
 
     fortranname <prefix2c>geev
     callstatement (*f2py_func)((compute_vl?"V":"N"),(compute_vr?"V":"N"),&n,&a,&n,&w,&vl,&ldvl,&vr,&ldvr,&work,&lwork,&rwork,&info)
-    callprotoargument char*,char*,int*,<ctype2c>*,int*,<ctype2c>*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,int*
+    callprotoargument char*,char*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,F_INT*
 
     integer optional,intent(in):: compute_vl = 1
     check(compute_vl==1||compute_vl==0) compute_vl
@@ -1197,7 +1197,7 @@ subroutine <prefix2>gegv(compute_vl,compute_vr,n,a,b,alphar,alphai,beta,vl,ldvl,
     ! alphar,alphai,beta,vl,vr,info = gegv(a,b,compute_vl=1,compute_vr=1,lwork=8*n,overwrite_a=0,overwrite_b=0)
 
     callstatement (*f2py_func)((compute_vl?"V":"N"),(compute_vr?"V":"N"),&n,a,&n,b,&n,alphar,alphai,beta,vl,&ldvl,vr,&ldvr,work,&lwork,&info)
-    callprotoargument char*,char*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,int*,int*
+    callprotoargument char*,char*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*
 
     integer optional,intent(in):: compute_vl = 1
     check(compute_vl==1||compute_vl==0) compute_vl
@@ -1238,7 +1238,7 @@ subroutine <prefix2c>gegv(compute_vl,compute_vr,n,a,b,alpha,beta,vl,ldvl,vr,ldvr
     ! alpha,beta,vl,vr,info = gegv(a,b,compute_vl=1,compute_vr=1,lwork=2*n,overwrite_a=0,overwrite_b=0)
 
     callstatement (*f2py_func)((compute_vl?"V":"N"),(compute_vr?"V":"N"),&n,a,&n,b,&n,alpha,beta,vl,&ldvl,vr,&ldvr,work,&lwork,rwork,&info)
-    callprotoargument char*,char*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2c>*,<ctype2c>*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,int*
+    callprotoargument char*,char*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,<ctype2c>*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,F_INT*
 
     integer optional,intent(in):: compute_vl = 1
     check(compute_vl==1||compute_vl==0) compute_vl
@@ -1278,7 +1278,7 @@ subroutine <prefix2c>gees(compute_v,sort_t,<prefix2c>select,n,a,nrows,sdim,w,vs,
     !  triangular
 
     callstatement (*f2py_func)((compute_v?"V":"N"),(sort_t?"S":"N"),cb_<prefix2c>select_in_gees__user__routines,&n,a,&nrows,&sdim,w,vs,&ldvs,work,&lwork,rwork,bwork,&info,1,1)
-    callprotoargument char*,char*,int(*)(<ctype2c>*),int*,<ctype2c>*,int*,int*,<ctype2c>*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,int*,int*,int,int
+    callprotoargument char*,char*,F_INT(*)(<ctype2c>*),F_INT*,<ctype2c>*,F_INT*,F_INT*,<ctype2c>*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT,F_INT
 
     use gees__user__routines
 
@@ -1308,7 +1308,7 @@ subroutine <prefix2>gees(compute_v,sort_t,<prefix2>select,n,a,nrows,sdim,wr,wi,v
     !  triangular with 1x1 and 2x2 blocks.
 
     callstatement (*f2py_func)((compute_v?"V":"N"),(sort_t?"S":"N"),cb_<prefix2>select_in_gees__user__routines,&n,a,&nrows,&sdim,wr,wi,vs,&ldvs,work,&lwork,bwork,&info,1,1)
-    callprotoargument char*,char*,int(*)(<ctype2>*,<ctype2>*),int*,<ctype2>*,int*,int*,<ctype2>*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,int*,int*,int,int
+    callprotoargument char*,char*,F_INT(*)(<ctype2>*,<ctype2>*),F_INT*,<ctype2>*,F_INT*,F_INT*,<ctype2>*,<ctype2>*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*,F_INT,F_INT
 
     use gees__user__routines
 
@@ -1339,7 +1339,7 @@ subroutine <prefix2>gges(jobvsl,jobvsr,sort_t,<prefix2>select,n,a,lda,b,ldb,sdim
     ! (A,B) = ( (VSL)*S*(VSR)**T, (VSL)*T*(VSR)**T )
 
     callstatement (*f2py_func)((jobvsl?"V":"N"),(jobvsr?"V":"N"),(sort_t?"S":"N"),cb_<prefix2>select_in_gges__user__routines,&n,a,&lda,b,&ldb,&sdim,alphar,alphai,beta,vsl,&ldvsl,vsr,&ldvsr,work,&lwork,bwork,&info)
-    callprotoargument char*,char*,char*,int(*)(<ctype2>*,<ctype2>*,<ctype2>*),int*,<ctype2>*,int*,<ctype2>*,int*,int*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,int*,int*,int*
+    callprotoargument char*,char*,char*,F_INT(*)(<ctype2>*,<ctype2>*,<ctype2>*),F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*
 
     use gges__user__routines
 
@@ -1375,7 +1375,7 @@ subroutine <prefix2c>gges(jobvsl,jobvsr,sort_t,<prefix2c>select,n,a,lda,b,ldb,sd
     ! (A,B) = ( (VSL)*S*(VSR)**T, (VSL)*T*(VSR)**H )
 
     callstatement (*f2py_func)((jobvsl?"V":"N"),(jobvsr?"V":"N"),(sort_t?"S":"N"),cb_<prefix2c>select_in_gges__user__routines,&n,a,&lda,b,&ldb,&sdim,alpha,beta,vsl,&ldvsl,vsr,&ldvsr,work,&lwork,rwork,bwork,&info)
-    callprotoargument char*,char*,char*,int(*)(<ctype2c>*,<ctype2c>*),int*,<ctype2c>*,int*,<ctype2c>*,int*,int*,<ctype2c>*,<ctype2c>*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,int*,int*
+    callprotoargument char*,char*,char*,F_INT(*)(<ctype2c>*,<ctype2c>*),F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,F_INT*,<ctype2c>*,<ctype2c>*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,F_INT*,F_INT*
 
     use gges__user__routines
 
@@ -1406,7 +1406,7 @@ end subroutine <prefix2c>gges
 subroutine <prefix2>ggev(compute_vl,compute_vr,n,a,b,alphar,alphai,beta,vl,ldvl,vr,ldvr,work,lwork,info)
 
     callstatement {(*f2py_func)((compute_vl?"V":"N"),(compute_vr?"V":"N"),&n,a,&n,b,&n,alphar,alphai,beta,vl,&ldvl,vr,&ldvr,work,&lwork,&info);}
-    callprotoargument char*,char*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,int*,int*
+    callprotoargument char*,char*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*
 
     integer optional,intent(in):: compute_vl = 1
     check(compute_vl==1||compute_vl==0) compute_vl
@@ -1441,7 +1441,7 @@ end subroutine <prefix2>ggev
 subroutine <prefix2c>ggev(compute_vl,compute_vr,n,a,b,alpha,beta,vl,ldvl,vr,ldvr,work,lwork,rwork,info)
 
     callstatement {(*f2py_func)((compute_vl?"V":"N"),(compute_vr?"V":"N"),&n,a,&n,b,&n,alpha,beta,vl,&ldvl,vr,&ldvr,work,&lwork,rwork,&info);}
-    callprotoargument char*,char*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2c>*,<ctype2c>*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,int*
+    callprotoargument char*,char*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,<ctype2c>*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,F_INT*
 
     integer optional,intent(in):: compute_vl = 1
     check(compute_vl==1||compute_vl==0) compute_vl
@@ -1476,7 +1476,7 @@ end subroutine <prefix2>ggev
 subroutine <prefix>geequ(m,n,a,lda,r,c,rowcnd,colcnd,amax,info)
 
     callstatement (*f2py_func)(&m,&n,a,&lda,r,c,&rowcnd,&colcnd,&amax,&info)
-    callprotoargument int*,int*,<ctype>*,int*,<ctypereal>*,<ctypereal>*,<ctypereal>*,<ctypereal>*,<ctypereal>*,int*
+    callprotoargument F_INT*,F_INT*,<ctype>*,F_INT*,<ctypereal>*,<ctypereal>*,<ctypereal>*,<ctypereal>*,<ctypereal>*,F_INT*
 
     integer intent(hide),depend(a) :: m = shape(a,0)
     integer intent(hide),depend(a) :: n = shape(a,1)
@@ -1495,7 +1495,7 @@ end subroutine <prefix>geequ
 subroutine <prefix>geequb(m,n,a,lda,r,c,rowcnd,colcnd,amax,info)
 
     callstatement (*f2py_func)(&m,&n,a,&lda,r,c,&rowcnd,&colcnd,&amax,&info)
-    callprotoargument int*,int*,<ctype>*,int*,<ctypereal>*,<ctypereal>*,<ctypereal>*,<ctypereal>*,<ctypereal>*,int*
+    callprotoargument F_INT*,F_INT*,<ctype>*,F_INT*,<ctypereal>*,<ctypereal>*,<ctypereal>*,<ctypereal>*,<ctypereal>*,F_INT*
 
     integer intent(hide),depend(a) :: m = shape(a,0)
     integer intent(hide),depend(a) :: n = shape(a,1)

--- a/scipy/linalg/flapack_gen_banded.pyf.src
+++ b/scipy/linalg/flapack_gen_banded.pyf.src
@@ -9,8 +9,8 @@ subroutine <prefix>gbsv(n,kl,ku,nrhs,ab,piv,b,info)
     ! starting at kl-th row.
     ! X, B are n-by-nrhs matrices
  
-    callstatement {int i=2*kl+ku+1;(*f2py_func)(&n,&kl,&ku,&nrhs,ab,&i,piv,b,&n,&info);for(i=0;i\<n;--piv[i++]);}
-    callprotoargument int*,int*,int*,int*,<ctype>*,int*,int*,<ctype>*,int*,int*
+    callstatement {F_INT i=2*kl+ku+1;(*f2py_func)(&n,&kl,&ku,&nrhs,ab,&i,piv,b,&n,&info);for(i=0;i\<n;--piv[i++]);}
+    callprotoargument F_INT*,F_INT*,F_INT*,F_INT*,<ctype>*,F_INT*,F_INT*,<ctype>*,F_INT*,F_INT*
     integer depend(ab),intent(hide):: n = shape(ab,1)
     integer intent(in) :: kl
     integer intent(in) :: ku
@@ -31,8 +31,8 @@ subroutine <prefix>gbtrf(m,n,ab,kl,ku,ldab,ipiv,info)
 
     ! threadsafe  ! FIXME: should this be added ?
 
-    callstatement {int i;(*f2py_func)(&m,&n,&kl,&ku,ab,&ldab,ipiv,&info); for(i=0,n=MIN(m,n);i\<n;--ipiv[i++]);}
-    callprotoargument int*,int*,int*,int*,<ctype>*,int*,int*,int*
+    callstatement {F_INT i;(*f2py_func)(&m,&n,&kl,&ku,ab,&ldab,ipiv,&info); for(i=0,n=MIN(m,n);i\<n;--ipiv[i++]);}
+    callprotoargument F_INT*,F_INT*,F_INT*,F_INT*,<ctype>*,F_INT*,F_INT*,F_INT*
 
     ! let the default be a square matrix:
     integer optional,depend(ab) :: m=shape(ab,1)
@@ -58,8 +58,8 @@ subroutine <prefix>gbtrs(ab,kl,ku,b,ipiv,trans,n,nrhs,ldab,ldb,info) ! in :Band:
     !  1  = 'T':  A'* X = B  (Transpose)
     !  2  = 'C':  A'* X = B  (Conjugate transpose = Transpose)
     
-    callstatement {int i;for(i=0;i\<n;++ipiv[i++]);(*f2py_func)((trans>0?(trans==1?"T":"C"):"N"),&n,&kl,&ku,&nrhs,ab,&ldab,ipiv,b,&ldb,&info);for(i=0;i\<n;--ipiv[i++]);}
-    callprotoargument char*,int*,int *,int*,int*,<ctype>*,int*,int*,<ctype>*,int*,int*
+    callstatement {F_INT i;for(i=0;i\<n;++ipiv[i++]);(*f2py_func)((trans>0?(trans==1?"T":"C"):"N"),&n,&kl,&ku,&nrhs,ab,&ldab,ipiv,b,&ldb,&info);for(i=0;i\<n;--ipiv[i++]);}
+    callprotoargument char*,F_INT*,F_INT *,F_INT*,F_INT*,<ctype>*,F_INT*,F_INT*,<ctype>*,F_INT*,F_INT*
     !character optional:: trans='N'
     integer optional:: trans=0
     integer optional,depend(ab) :: n=shape(ab,1)

--- a/scipy/linalg/flapack_gen_tri.pyf.src
+++ b/scipy/linalg/flapack_gen_tri.pyf.src
@@ -3,7 +3,7 @@
 
 subroutine <prefix>gtsv(n, nrhs, dl, d, du, b, info)
     callstatement (*f2py_func)(&n, &nrhs, dl, d, du, b, &n, &info);
-    callprotoargument int*, int*, <ctype>*, <ctype>*, <ctype>*, <ctype>*, int*, int*
+    callprotoargument F_INT*, F_INT*, <ctype>*, <ctype>*, <ctype>*, <ctype>*, F_INT*, F_INT*
     integer intent(hide), depend(d) :: n = len(d)
     integer intent(hide), depend(b) :: nrhs = shape(b, 1)
     <ftype> dimension(n-1), intent(in,out,copy,out=du2), depend(d,n) :: dl
@@ -27,7 +27,7 @@ subroutine <prefix>gttrf(n, dl, d, du, du2, ipiv, info)
     ! matrices and U is upper triangular with nonzeros in only the main
     ! diagonal and first two superdiagonals.
     callstatement (*f2py_func)(&n, dl, d, du, du2, ipiv, &info)
-    callprotoargument int*, <ctype>*, <ctype>*, <ctype>*, <ctype>*, int*, int*
+    callprotoargument F_INT*, <ctype>*, <ctype>*, <ctype>*, <ctype>*, F_INT*, F_INT*
 
     integer intent(hide), depend(d) :: n = max(3, len(d))
     <ftype> intent(in,out,copy), depend(n), dimension(n-1) :: dl
@@ -48,7 +48,7 @@ subroutine <prefix>gttrs(trans, n, nrhs, dl, d, du, du2, ipiv, b, ldb, info)
     ! with a tridiagonal matrix A using the LU factorization computed
     ! by ?GTTRF.
     callstatement (*f2py_func)(trans, &n, &nrhs, dl, d, du, du2, ipiv, b, &ldb, &info)
-    callprotoargument char*, int*, int*, <ctype>*, <ctype>*, <ctype>*, <ctype>*, int*, <ctype>*, int*, int*
+    callprotoargument char*, F_INT*, F_INT*, <ctype>*, <ctype>*, <ctype>*, <ctype>*, F_INT*, <ctype>*, F_INT*, F_INT*
     threadsafe
 
     character optional, intent(in), check(*trans=='N'||*trans=='T'||*trans=='C') :: trans = "N"
@@ -75,7 +75,7 @@ subroutine <prefix2>gtsvx(fact,trans,n,nrhs,dl,d,du,dlf,df,duf,du2,ipiv,b,ldb,x,
     ! Error bounds on the solution and a condition estimate are also
     !provided.
     callstatement (*f2py_func)(fact,trans,&n,&nrhs,dl,d,du,dlf,df,duf,du2,ipiv,b,&ldb,x,&ldx,&rcond,ferr,berr,work,iwork,&info);
-    callprotoargument char*,char*,int*,int*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,int*,int*
+    callprotoargument char*,char*,F_INT*,F_INT*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,F_INT*,F_INT*
 
     character optional, intent(in), check(*fact=='F'||*fact=='N') :: fact = 'N'
     character optional, intent(in), check(*trans=='N'||*trans=='C'||*trans=='T') :: trans = 'N'
@@ -112,7 +112,7 @@ subroutine <prefix2c>gtsvx(fact,trans,n,nrhs,dl,d,du,dlf,df,duf,du2,ipiv,b,ldb,x
     ! Error bounds on the solution and a condition estimate are also
     !provided.
     callstatement (*f2py_func)(fact,trans,&n,&nrhs,dl,d,du,dlf,df,duf,du2,ipiv,b,&ldb,x,&ldx,&rcond,ferr,berr,work,rwork,&info);
-    callprotoargument char*,char*,int*,int*,<ctype2c>*,<ctype2c>*,<ctype2c>*,<ctype2c>*,<ctype2c>*,<ctype2c>*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2c>*,<ctype2>*,int*
+    callprotoargument char*,char*,F_INT*,F_INT*,<ctype2c>*,<ctype2c>*,<ctype2c>*,<ctype2c>*,<ctype2c>*,<ctype2c>*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2c>*,<ctype2>*,F_INT*
 
     character optional, intent(in), check(*fact=='F'||*fact=='N') :: fact = 'N'
     character optional, intent(in), check(*trans=='N'||*trans=='C'||*trans=='T') :: trans = 'N'

--- a/scipy/linalg/flapack_other.pyf.src
+++ b/scipy/linalg/flapack_other.pyf.src
@@ -14,8 +14,8 @@ subroutine <prefix2>gejsv(joba,jobu,jobv,jobr,jobt,jobp,m,n,a,lda,sva,u,ldu,v,ld
     ! the right singular vectors of [A], respectively. The matrices [U] and [V]
     ! are computed and stored in the arrays U and V, respectively. The diagonal
     ! of [SIGMA] is computed and stored in the array SVA.
-    callstatement {int i;(*f2py_func)(&"CEFGAR"[joba],&"UFWN"[jobu],&"VJWN"[jobv],(jobr?"R":"N"),(jobt?"T":"N"),(jobp?"P":"N"),&m,&n,a,&lda,sva,u,&ldu,v,&ldv,work,&lwork,iwork,&info);for(i=0;i\<7;i++){workout[i] = work[i];}for(i=0;i\<3;i++){iworkout[i] = iwork[i];}}
-    callprotoargument char*,char*,char*,char*,char*,char*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,int*,int*,int*
+    callstatement {F_INT i;(*f2py_func)(&"CEFGAR"[joba],&"UFWN"[jobu],&"VJWN"[jobv],(jobr?"R":"N"),(jobt?"T":"N"),(jobp?"P":"N"),&m,&n,a,&lda,sva,u,&ldu,v,&ldv,work,&lwork,iwork,&info);for(i=0;i\<7;i++){workout[i] = work[i];}for(i=0;i\<3;i++){iworkout[i] = iwork[i];}}
+    callprotoargument char*,char*,char*,char*,char*,char*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*
 
     integer intent(in, optional), check((0 <= joba) && (joba < 6)) :: joba = 4
     integer intent(in, optional), check((0 <= jobu) && (jobu < 4)) :: jobu = 0
@@ -45,7 +45,7 @@ end subroutine <prefix2>gejsv
 subroutine <prefix2>tgsen(ijob,wantq,wantz,select,n,a,lda,b,ldb,alphar,alphai,beta,q,ldq,z,ldz,m,pl,pr,dif,work,lwork,iwork,liwork,info)
 
     callstatement (*f2py_func)(&ijob,&wantq,&wantz,select,&n,a,&lda,b,&ldb,alphar,alphai,beta,q,&ldq,z,&ldz,&m,&pl,&pr,dif,work,&lwork,iwork,&liwork,&info)
-    callprotoargument int*,int*,int*,int*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,int*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,int*,int*,int*,int*
+    callprotoargument F_INT*,F_INT*,F_INT*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,F_INT*,F_INT*
 
     integer intent(hide) :: ijob=4
     integer intent(hide),check(wantq==0||wantq==1) :: wantq=1
@@ -77,7 +77,7 @@ end subroutine <prefix2>tgsen
 
 subroutine <prefix2c>tgsen(ijob,wantq,wantz,select,n,a,lda,b,ldb,alpha,beta,q,ldq,z,ldz,m,pl,pr,dif,work,lwork,iwork,liwork,info)
     callstatement (*f2py_func)(&ijob,&wantq,&wantz,select,&n,a,&lda,b,&ldb,alpha,beta,q,&ldq,z,&ldz,&m,&pl,&pr,dif,work,&lwork,iwork,&liwork,&info)
-    callprotoargument int*,int*,int*,int*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2c>*,<ctype2c>*,<ctype2c>*,int*,<ctype2c>*,int*,int*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2c>*,int*,int*,int*,int*
+    callprotoargument F_INT*,F_INT*,F_INT*,F_INT*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,<ctype2c>*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,F_INT*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2c>*,F_INT*,F_INT*,F_INT*,F_INT*
 
     integer intent(hide) :: ijob=4
     integer intent(hide),check(wantq==0||wantq==1) :: wantq=1
@@ -113,7 +113,7 @@ subroutine <prefix2>pbtrf(lower,n,kd,ab,ldab,info)
     ! C is triangular matrix of the corresponding Cholesky decomposition.
 
     callstatement (*f2py_func)((lower?"L":"U"),&n,&kd,ab,&ldab,&info);
-    callprotoargument char*,int*,int*,<ctype2>*,int*,int*
+    callprotoargument char*,F_INT*,F_INT*,<ctype2>*,F_INT*,F_INT*
 
     integer optional,check(shape(ab,0)==ldab),depend(ab) :: ldab=shape(ab,0)
     integer intent(hide),depend(ab) :: n=shape(ab,1)
@@ -133,7 +133,7 @@ subroutine <prefix2c>pbtrf(lower,n,kd,ab,ldab,info)
     ! C is triangular matrix of the corresponding Cholesky decomposition.
 
     callstatement (*f2py_func)((lower?"L":"U"),&n,&kd,ab,&ldab,&info);
-    callprotoargument char*,int*,int*,<ctype2c>*,int*,int*
+    callprotoargument char*,F_INT*,F_INT*,<ctype2c>*,F_INT*,F_INT*
 
     integer optional,check(shape(ab,0)==ldab),depend(ab) :: ldab=shape(ab,0)
     integer intent(hide),depend(ab) :: n=shape(ab,1)
@@ -155,7 +155,7 @@ subroutine <prefix2>pbtrs(lower, n, kd, nrhs, ab, ldab, b, ldb, info)
     ! A = L * L^T, AB = L if lower = 1
 
     callstatement (*f2py_func)((lower?"L":"U"),&n,&kd,&nrhs,ab,&ldab,b,&ldb,&info);
-    callprotoargument char*,int*,int*,int*,<ctype2>*,int*,<ctype2>*,int*,int*
+    callprotoargument char*,F_INT*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*
 
     integer optional,check(shape(ab,0)==ldab),depend(ab) :: ldab=shape(ab,0)
     integer intent(hide),depend(ab) :: n=shape(ab,1)
@@ -179,7 +179,7 @@ subroutine <prefix2c>pbtrs(lower, n, kd, nrhs, ab, ldab, b, ldb, info)
     ! A = L * L^T, AB = L if lower = 1
 
     callstatement (*f2py_func)((lower?"L":"U"),&n,&kd,&nrhs,ab,&ldab,b,&ldb,&info);
-    callprotoargument char*,int*,int*,int*,<ctype2c>*,int*,<ctype2c>*,int*,int*
+    callprotoargument char*,F_INT*,F_INT*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,F_INT*
 
     integer optional,check(shape(ab,0)==ldab),depend(ab) :: ldab=shape(ab,0)
     integer intent(hide),depend(ab) :: n=shape(ab,1)
@@ -200,7 +200,7 @@ subroutine <prefix>trtrs(lower, trans, unitdiag, n, nrhs, a, lda, b, ldb, info)
     ! matrix A.
 
     callstatement (*f2py_func)((lower?"L":"U"),(trans?(trans==2?"C":"T"):"N"),(unitdiag?"U":"N"),&n,&nrhs,a,&lda,b,&ldb,&info);
-    callprotoargument char*,char*,char*,int*,int*,<ctype>*,int*,<ctype>*,int*,int*
+    callprotoargument char*,char*,char*,F_INT*,F_INT*,<ctype>*,F_INT*,<ctype>*,F_INT*,F_INT*
 
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
     integer optional,intent(in),check(trans>=0 && trans <=2) :: trans = 0
@@ -229,7 +229,7 @@ subroutine <prefix>tbtrs(uplo,trans,diag,n,kd,nrhs,ab,ldab,b,ldb,info)
     ! A check is made to verify that A is nonsingular.
 
     callstatement (*f2py_func)(uplo,trans,diag,&n,&kd,&nrhs,ab,&ldab,b,&ldb,&info)
-    callprotoargument char*,char*,char*,int*,int*,int*,<ctype>*,int*,<ctype>*,int*,int*
+    callprotoargument char*,char*,char*,F_INT*,F_INT*,F_INT*,<ctype>*,F_INT*,<ctype>*,F_INT*,F_INT*
 
     <ftype> intent(in), dimension(ldab, n) :: ab
     <ftype> intent(in,out,copy,out=x), dimension(ldb, nrhs) :: b
@@ -263,7 +263,7 @@ subroutine <prefix2>pbsv(lower,n,kd,nrhs,ab,ldab,b,ldb,info)
     !  system of equations A * X = B.
 
     callstatement (*f2py_func)((lower?"L":"U"),&n,&kd,&nrhs,ab,&ldab,b,&ldb,&info);
-    callprotoargument char*,int*,int*,int*,<ctype2>*,int*,<ctype2>*,int*,int*
+    callprotoargument char*,F_INT*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*
 
     integer optional,check(shape(ab,0)==ldab),depend(ab) :: ldab=shape(ab,0)
     integer intent(hide),depend(ab) :: n=shape(ab,1)
@@ -293,7 +293,7 @@ subroutine <prefix2c>pbsv(lower,n,kd,nrhs,ab,ldab,b,ldb,info)
     !  system of equations A * X = B.
 
     callstatement (*f2py_func)((lower?"L":"U"),&n,&kd,&nrhs,ab,&ldab,b,&ldb,&info);
-    callprotoargument char*,int*,int*,int*,<ctype2c>*,int*,<ctype2c>*,int*,int*
+    callprotoargument char*,F_INT*,F_INT*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,F_INT*
 
     integer optional,check(shape(ab,0)==ldab),depend(ab) :: ldab=shape(ab,0)
     integer intent(hide),depend(ab) :: n=shape(ab,1)
@@ -330,7 +330,7 @@ subroutine <prefix2>orcsd(compute_u1,compute_u2,compute_v1t,compute_v2t,trans,si
     !  respectively.
 
     callstatement (*f2py_func)((compute_u1?"Y":"N"),(compute_u2?"Y":"N"),(compute_v1t?"Y":"N"),(compute_v2t?"Y":"N"),(trans?"T":"N"),(signs?"O":"D"),&m,&p,&q,x11,&ldx11,x12,&ldx12,x21,&ldx21,x22,&ldx22,theta,u1,&ldu1,u2,&ldu2,v1t,&ldv1t,v2t,&ldv2t,work,&lwork,iwork,&info)
-    callprotoargument char*,char*,char*,char*,char*,char*,int*,int*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,int*,int*,int*
+    callprotoargument char*,char*,char*,char*,char*,char*,F_INT*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*
 
     integer optional,intent(in),check(compute_u1==0||compute_u1==1) :: compute_u1 = 1
     integer optional,intent(in),check(compute_u2==0||compute_u2==1) :: compute_u2 = 1
@@ -380,7 +380,7 @@ subroutine <prefix2>orcsd_lwork(m,p,q,x11,ldx11,x12,ldx12,x21,ldx21,x22,ldx22,th
 
     fortranname <prefix2>orcsd
     callstatement (*f2py_func)("Y","Y","Y","Y","N","D",&m,&p,&q,&x11,&ldx11,&x12,&ldx12,&x21,&ldx21,&x22,&ldx22,&theta,&u1,&ldu1,&u2,&ldu2,&v1t,&ldv1t,&v2t,&ldv2t,&work,&lwork,&iwork,&info)
-    callprotoargument char*,char*,char*,char*,char*,char*,int*,int*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,int*,int*,int*
+    callprotoargument char*,char*,char*,char*,char*,char*,F_INT*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*
 
     integer intent(in) :: m
     integer intent(in) :: p
@@ -436,7 +436,7 @@ subroutine <prefix2c>uncsd(compute_u1,compute_u2,compute_v1t,compute_v2t,trans,s
     
 
     callstatement (*f2py_func)((compute_u1?"Y":"N"),(compute_u2?"Y":"N"),(compute_v1t?"Y":"N"),(compute_v2t?"Y":"N"),(trans?"T":"N"),(signs?"O":"D"),&m,&p,&q,x11,&ldx11,x12,&ldx12,x21,&ldx21,x22,&ldx22,theta,u1,&ldu1,u2,&ldu2,v1t,&ldv1t,v2t,&ldv2t,work,&lwork,rwork,&lrwork,iwork,&info)
-    callprotoargument char*,char*,char*,char*,char*,char*,int*,int*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,int*,int*,int*
+    callprotoargument char*,char*,char*,char*,char*,char*,F_INT*,F_INT*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*
 
     integer optional,intent(in),check(compute_u1==0||compute_u1==1) :: compute_u1 = 1
     integer optional,intent(in),check(compute_u2==0||compute_u2==1) :: compute_u2 = 1
@@ -488,7 +488,7 @@ subroutine <prefix2c>uncsd_lwork(m,p,q,x11,ldx11,x12,ldx12,x21,ldx21,x22,ldx22,t
 
     fortranname <prefix2c>uncsd
     callstatement (*f2py_func)("Y","Y","Y","Y","N","D",&m,&p,&q,&x11,&ldx11,&x12,&ldx12,&x21,&ldx21,&x22,&ldx22,&theta,&u1,&ldu1,&u2,&ldu2,&v1t,&ldv1t,&v2t,&ldv2t,&work,&lwork,&rwork,&lrwork,&iwork,&info)
-    callprotoargument char*,char*,char*,char*,char*,char*,int*,int*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,int*,int*,int*
+    callprotoargument char*,char*,char*,char*,char*,char*,F_INT*,F_INT*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*
 
     integer intent(in) :: m
     integer intent(in) :: p
@@ -530,7 +530,7 @@ subroutine <prefix2>orghr(n,lo,hi,a,tau,work,lwork,info)
     ! that was computed by gehrd
     !
     callstatement { hi++; lo++; (*f2py_func)(&n,&lo,&hi,a,&n,tau,work,&lwork,&info); }
-    callprotoargument int*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*
+    callprotoargument F_INT*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,F_INT*
     integer intent(hide),depend(a) :: n = shape(a,0)
     <ftype2> dimension(n,n),intent(in,out,copy,out=ht,aligned8),check(shape(a,0)==shape(a,1)) :: a
     integer intent(in),optional :: lo = 0
@@ -546,7 +546,7 @@ subroutine <prefix2>orghr_lwork(n,lo,hi,a,tau,work,lwork,info)
     ! LWORK computation ofr orghr
     fortranname <prefix2>orghr
     callstatement { hi++; lo++; (*f2py_func)(&n,&lo,&hi,&a,&n,&tau,&work,&lwork,&info); }
-    callprotoargument int*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*
+    callprotoargument F_INT*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,F_INT*
     integer intent(in) :: n
     <ftype2> intent(hide) :: a
     integer intent(in), optional :: lo = 0
@@ -564,7 +564,7 @@ subroutine <prefix2c>unghr(n,lo,hi,a,tau,work,lwork,info)
     ! that was computed by gehrd
     !
     callstatement { hi++; lo++; (*f2py_func)(&n,&lo,&hi,a,&n,tau,work,&lwork,&info); }
-    callprotoargument int*,int*,int*,<ctype2c>*,int*,<ctype2c>*,<ctype2c>*,int*,int*
+    callprotoargument F_INT*,F_INT*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,<ctype2c>*,F_INT*,F_INT*
     integer intent(hide),depend(a) :: n = shape(a,0)
     <ftype2c> dimension(n,n),intent(in,out,copy,out=ht,aligned8),check(shape(a,0)==shape(a,1)) :: a
     integer intent(in),optional :: lo = 0
@@ -580,7 +580,7 @@ subroutine <prefix2c>unghr_lwork(n,lo,hi,a,tau,work,lwork,info)
     ! LWORK computation for orghr
     fortranname <prefix2c>unghr
     callstatement { hi++; lo++; (*f2py_func)(&n,&lo,&hi,&a,&n,&tau,&work,&lwork,&info); }
-    callprotoargument int*,int*,int*,<ctype2c>*,int*,<ctype2c>*,<ctype2c>*,int*,int*
+    callprotoargument F_INT*,F_INT*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,<ctype2c>*,F_INT*,F_INT*
     integer intent(in) :: n
     <ftype2c> intent(hide) :: a
     integer intent(in), optional :: lo = 0
@@ -600,7 +600,7 @@ subroutine <prefix2>orgqr(m,n,k,a,tau,work,lwork,info)
 
     threadsafe
     callstatement (*f2py_func)(&m,&n,&k,a,&m,tau,work,&lwork,&info)
-    callprotoargument int*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*
+    callprotoargument F_INT*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,F_INT*
 
     integer intent(hide),depend(a):: m = shape(a,0)
     integer intent(hide),depend(a):: n = shape(a,1)
@@ -622,7 +622,7 @@ subroutine <prefix2c>ungqr(m,n,k,a,tau,work,lwork,info)
 
     threadsafe
     callstatement (*f2py_func)(&m,&n,&k,a,&m,tau,work,&lwork,&info)
-    callprotoargument int*,int*,int*,<ctype2c>*,int*,<ctype2c>*,<ctype2c>*,int*,int*
+    callprotoargument F_INT*,F_INT*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,<ctype2c>*,F_INT*,F_INT*
 
     integer intent(hide),depend(a):: m = shape(a,0)
     integer intent(hide),depend(a):: n = shape(a,1)
@@ -644,7 +644,7 @@ subroutine <prefix2>ormqr(side,trans,m,n,k,a,lda,tau,c,ldc,work,lwork,info)
 
     threadsafe
     callstatement (*f2py_func)(side,trans,&m,&n,&k,a,&lda,tau,c,&ldc,work,&lwork,&info)
-    callprotoargument char*,char*,int*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,int*
+    callprotoargument char*,char*,F_INT*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*
 
     character intent(in),check(*side=='L'||*side=='R'):: side
     character intent(in),check(*trans=='N'||*trans=='T'):: trans
@@ -670,7 +670,7 @@ subroutine <prefix2c>unmqr(side,trans,m,n,k,a,lda,tau,c,ldc,work,lwork,info)
 
     threadsafe
     callstatement (*f2py_func)(side,trans,&m,&n,&k,a,&lda,tau,c,&ldc,work,&lwork,&info)
-    callprotoargument char*,char*,int*,int*,int*,<ctype2c>*,int*,<ctype2c>*,<ctype2c>*,int*,<ctype2c>*,int*,int*
+    callprotoargument char*,char*,F_INT*,F_INT*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,F_INT*
 
     character intent(in),check(*side=='L'||*side=='R'):: side
     character intent(in),check(*trans=='N'||*trans=='C'):: trans
@@ -696,7 +696,7 @@ subroutine <prefix>geqrt(m,n,nb,a,lda,t,ldt,work,info)
     ! block reflectors.
 
     callstatement (*f2py_func)(&m,&n,&nb,a,&lda,t,&ldt,work,&info)
-    callprotoargument int*,int*,int*,<ctype>*,int*,<ctype>*,int*,<ctype>*,int*
+    callprotoargument F_INT*,F_INT*,F_INT*,<ctype>*,F_INT*,<ctype>*,F_INT*,<ctype>*,F_INT*
 
     integer intent(hide),depend(a):: m = shape(a,0)
     integer intent(hide),depend(a):: n = shape(a,1)
@@ -719,7 +719,7 @@ subroutine <prefix>gemqrt(side,trans,m,n,k,nb,v,ldv,t,ldt,c,ldc,work,info)
     ! matrices), or its adjoint (for complex matrices) from the left or right.
 
     callstatement (*f2py_func)(side,trans,&m,&n,&k,&nb,v,&ldv,t,&ldt,c,&ldc,work,&info)
-    callprotoargument char*,char*,int*,int*,int*,int*,<ctype>*,int*,<ctype>*,int*,<ctype>*,int*,<ctype>*,int*
+    callprotoargument char*,char*,F_INT*,F_INT*,F_INT*,F_INT*,<ctype>*,F_INT*,<ctype>*,F_INT*,<ctype>*,F_INT*,<ctype>*,F_INT*
 
     character optional,intent(in),check(*side=='L'||*side=='R'):: side = 'L'
     character optional,intent(in),check(*trans=='N'||*trans==<'T','T','C','C'>):: trans = 'N'
@@ -748,7 +748,7 @@ subroutine <prefix>tpqrt(m,n,l,nb,a,lda,b,ldb,t,ldt,work,info)
     ! reflectors.
 
     callstatement (*f2py_func)(&m,&n,&l,&nb,a,&lda,b,&ldb,t,&ldt,work,&info)
-    callprotoargument int*,int*,int*,int*,<ctype>*,int*,<ctype>*,int*,<ctype>*,int*,<ctype>*,int*
+    callprotoargument F_INT*,F_INT*,F_INT*,F_INT*,<ctype>*,F_INT*,<ctype>*,F_INT*,<ctype>*,F_INT*,<ctype>*,F_INT*
 
     integer intent(hide),depend(b):: m = shape(b,0)
     integer intent(hide),depend(b):: n = shape(b,1)
@@ -776,7 +776,7 @@ subroutine <prefix>tpmqrt(side,trans,m,n,k,l,nb,v,ldv,t,ldt,a,lda,b,ldb,work,inf
     ! complex matrices) from the left or right.
 
     callstatement (*f2py_func)(side,trans,&m,&n,&k,&l,&nb,v,&ldv,t,&ldt,a,&lda,b,&ldb,work,&info)
-    callprotoargument char*,char*,int*,int*,int*,int*,int*,<ctype>*,int*,<ctype>*,int*,<ctype>*,int*,<ctype>*,int*,<ctype>*,int*
+    callprotoargument char*,char*,F_INT*,F_INT*,F_INT*,F_INT*,F_INT*,<ctype>*,F_INT*,<ctype>*,F_INT*,<ctype>*,F_INT*,<ctype>*,F_INT*,<ctype>*,F_INT*
 
     character optional,intent(in),check(*side=='L'||*side=='R'):: side = 'L'
     character optional,intent(in),check(*trans=='N'||*trans==<'T','T','C','C'>):: trans = 'N'
@@ -815,7 +815,7 @@ subroutine <prefix><or,or,un,un>mrz(side,trans,m,n,k,l,a,lda,nt,tau,c,ldc,work,l
     ! if SIDE = 'R'.
     !
     callstatement (*f2py_func)(side,trans,&m,&n,&k,&l,a,&lda,tau,c,&ldc,work,&lwork,&info)
-    callprotoargument char*,char*,int*,int*,int*,int*,<ctype>*,int*,<ctype>*,<ctype>*,int*,<ctype>*,int*,int*
+    callprotoargument char*,char*,F_INT*,F_INT*,F_INT*,F_INT*,<ctype>*,F_INT*,<ctype>*,<ctype>*,F_INT*,<ctype>*,F_INT*,F_INT*
 
     character optional,intent(in),check(*side=='L'||*side=='R'):: side = 'L'
     character optional,intent(in),check(*trans=='N'||*trans==<'T','T','C','C'>):: trans = 'N'
@@ -853,7 +853,7 @@ subroutine <prefix><or,or,un,un>mrz_lwork(side,trans,m,n,k,l,a,lda,tau,c,ldc,wor
     !
     fortranname <prefix><or,or,un,un>mrz
     callstatement (*f2py_func)(side,trans,&m,&n,&k,&l,&a,&lda,&tau,&c,&ldc,&work,&lwork,&info)
-    callprotoargument char*,char*,int*,int*,int*,int*,<ctype>*,int*,<ctype>*,<ctype>*,int*,<ctype>*,int*,int*
+    callprotoargument char*,char*,F_INT*,F_INT*,F_INT*,F_INT*,<ctype>*,F_INT*,<ctype>*,<ctype>*,F_INT*,<ctype>*,F_INT*,F_INT*
 
     character optional,intent(in),check(*side=='L'||*side=='R'):: side = 'L'
     character optional,intent(in),check(*trans=='N'||*trans==<'T','T','C','C'>):: trans = 'N'
@@ -880,7 +880,7 @@ subroutine <prefix2>orgrq(m,n,k,a,tau,work,lwork,info)
 
     threadsafe
     callstatement (*f2py_func)(&m,&n,&k,a,&m,tau,work,&lwork,&info)
-    callprotoargument int*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*
+    callprotoargument F_INT*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,F_INT*
 
     integer intent(hide),depend(a):: m = shape(a,0)
     integer intent(hide),depend(a):: n = shape(a,1)
@@ -902,7 +902,7 @@ subroutine <prefix2c>ungrq(m,n,k,a,tau,work,lwork,info)
 
     threadsafe
     callstatement (*f2py_func)(&m,&n,&k,a,&m,tau,work,&lwork,&info)
-    callprotoargument int*,int*,int*,<ctype2c>*,int*,<ctype2c>*,<ctype2c>*,int*,int*
+    callprotoargument F_INT*,F_INT*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,<ctype2c>*,F_INT*,F_INT*
 
     integer intent(hide),depend(a):: m = shape(a,0)
     integer intent(hide),depend(a):: n = shape(a,1)
@@ -926,7 +926,7 @@ subroutine <prefix>trtri(n,c,info,lower,unitdiag)
     ! C is unit triangular matrix if unitdiag = 1
 
     callstatement (*f2py_func)((lower?"L":"U"),(unitdiag?"U":"N"),&n,c,&n,&info)
-    callprotoargument char*,char*,int*,<ctype>*,int*,int*
+    callprotoargument char*,char*,F_INT*,<ctype>*,F_INT*,F_INT*
 
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
     integer optional,intent(in),check(unitdiag==0||unitdiag==1) :: unitdiag = 0
@@ -962,7 +962,7 @@ subroutine <prefix>trsyl(trana, tranb, isgn, m, n, a, lda, b, ldb, c, ldc, scale
     !         were used to solve the equation
 
     callstatement (*f2py_func)(trana,tranb,&isgn,&m,&n,a,&lda,b,&ldb,c,&ldc,&scale,&info)
-    callprotoargument char*,char*,int*,int*,int*,<ctype>*,int*,<ctype>*,int*,<ctype>*,int*,<ctypereal>*,int*
+    callprotoargument char*,char*,F_INT*,F_INT*,F_INT*,<ctype>*,F_INT*,<ctype>*,F_INT*,<ctype>*,F_INT*,<ctypereal>*,F_INT*
 
     character optional,intent(in),check(*trana=='N'||*trana=='T'||*trana=='C'):: trana='N'
     character optional,intent(in),check(*tranb=='N'||*tranb=='T'||*tranb=='C'):: tranb='N'
@@ -993,7 +993,7 @@ subroutine <prefix2c>hbevd(ab,compute_v,lower,n,ldab,kd,w,z,ldz,work,lwork,rwork
     ! in :Band:zubevd.f
 
     callstatement (*f2py_func)((compute_v?"V":"N"),(lower?"L":"U"),&n,&kd,ab,&ldab,w,z,&ldz,work,&lwork,rwork,&lrwork,iwork,&liwork,&info)
-    callprotoargument char*,char*,int*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,int*,int*,int*,int*
+    callprotoargument char*,char*,F_INT*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*,F_INT*
 
     ! Remark: if ab is fortran contigous on input
     !         and overwrite_ab=1  ab will be overwritten.
@@ -1033,7 +1033,7 @@ end subroutine <prefix2c>hbevd
 subroutine <prefix2c>hbevx(ab,ldab,compute_v,range,lower,n,kd,q,ldq,vl,vu,il,iu,abstol,w,z,m,mmax,ldz,work,rwork,iwork,ifail,info) ! in :Band:dsbevx.f
 
     callstatement (*f2py_func)((compute_v?"V":"N"),(range>0?(range==1?"V":"I"):"A"),(lower?"L":"U"),&n,&kd,ab,&ldab,q,&ldq,&vl,&vu,&il,&iu,&abstol,&m,w,z,&ldz,work,rwork,iwork,ifail,&info)
-    callprotoargument char*,char*,char*,int*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2c>*,int*,<ctype2c>*,<ctype2>*,int*,int*,int*
+    callprotoargument char*,char*,char*,F_INT*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2c>*,F_INT*,<ctype2c>*,<ctype2>*,F_INT*,F_INT*,F_INT*
 
     integer optional,intent(in):: compute_v = 1
     check(compute_v==1||compute_v==0) compute_v
@@ -1123,7 +1123,7 @@ subroutine <prefix>gglse(m,n,p,a,lda,b,ldb,c,d,x,work,lwork,info)
     !    B = (0 R)*Q,   A = Z*T*Q.
 
     callstatement (*f2py_func)(&m,&n,&p,a,&lda,b,&ldb,c,d,x,work,&lwork,&info)
-    callprotoargument int*,int*,int*,<ctype>*,int*,<ctype>*,int*,<ctype>*,<ctype>*,<ctype>*,<ctype>*,int*,int*
+    callprotoargument F_INT*,F_INT*,F_INT*,<ctype>*,F_INT*,<ctype>*,F_INT*,<ctype>*,<ctype>*,<ctype>*,<ctype>*,F_INT*,F_INT*
 
     integer intent(hide),depend(a),check(m>=0) :: m = shape(a,0)
     integer intent(hide),depend(a),check(n>=0) :: n = shape(a,1)
@@ -1151,7 +1151,7 @@ subroutine <prefix>gglse_lwork(m,n,p,a,lda,b,ldb,c,d,x,work,lwork,info)
     !
     fortranname <prefix>gglse
     callstatement (*f2py_func)(&m,&n,&p,&a,&lda,&b,&ldb,&c,&d,&x,&work,&lwork,&info)
-    callprotoargument int*,int*,int*,<ctype>*,int*,<ctype>*,int*,<ctype>*,<ctype>*,<ctype>*,<ctype>*,int*,int*
+    callprotoargument F_INT*,F_INT*,F_INT*,<ctype>*,F_INT*,<ctype>*,F_INT*,<ctype>*,<ctype>*,<ctype>*,<ctype>*,F_INT*,F_INT*
 
     integer intent(in),check(m>=0) :: m
     integer intent(in),check(n>=0) :: n
@@ -1177,7 +1177,7 @@ subroutine <prefix2>sbev(ab,compute_v,lower,n,ldab,kd,w,z,ldz,work,info)
 
     callstatement (*f2py_func)((compute_v?"V":"N"),(lower?"L":"U"),&n,&kd,ab,&ldab,w,z,&ldz,work,&info)
 
-    callprotoargument char*,char*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*
+    callprotoargument char*,char*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,<ctype2>*,F_INT*
 
     ! Remark: if ab is fortran contigous on input
     !         and overwrite_ab=1  ab will be overwritten.
@@ -1205,7 +1205,7 @@ end subroutine <prefix2>sbev
 subroutine <prefix2>sbevd(ab,compute_v,lower,n,ldab,kd,w,z,ldz,work,lwork,iwork,liwork,info)
     ! in :Band:dsbevd.f
     callstatement (*f2py_func)((compute_v?"V":"N"),(lower?"L":"U"),&n,&kd,ab,&ldab,w,z,&ldz,work,&lwork,iwork,&liwork,&info)
-    callprotoargument char*,char*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,int*,int*,int*
+    callprotoargument char*,char*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*,F_INT*
 
     ! Remark: if ab is fortran contigous on input
     !         and overwrite_ab=1  ab will be overwritten.
@@ -1238,7 +1238,7 @@ end subroutine <prefix2>sbevd
 subroutine <prefix2>sbevx(ab,ldab,compute_v,range,lower,n,kd,q,ldq,vl,vu,il,iu,abstol,w,z,m,mmax,ldz,work,iwork,ifail,info) ! in :Band:dsbevx.f
 
     callstatement (*f2py_func)((compute_v?"V":"N"),(range>0?(range==1?"V":"I"):"A"),(lower?"L":"U"),&n,&kd,ab,&ldab,q,&ldq,&vl,&vu,&il,&iu,&abstol,&m,w,z,&ldz,work,iwork,ifail,&info)
-    callprotoargument char*,char*,char*,int*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2>*, int*,int*,int*
+    callprotoargument char*,char*,char*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,<ctype2>*, F_INT*,F_INT*,F_INT*
 
     integer optional,intent(in):: compute_v = 1
     check(compute_v==1||compute_v==0) compute_v
@@ -1315,7 +1315,7 @@ subroutine <prefix2>stebz(d,e,range,vl,vu,il,iu,tol,order,n,work,iwork,m,nsplit,
     ! matrix.
 
     callstatement (*f2py_func)((range>0?(range==1?"V":"I"):"A"),order,&n,&vl,&vu,&il,&iu,&tol,d,e,&m,&nsplit,w,iblock,isplit,work,iwork,&info)
-    callprotoargument char*,char*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,int*,<ctype2>*,int*,int*
+    callprotoargument char*,char*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,<ctype2>*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,<ctype2>*,F_INT*,F_INT*,<ctype2>*,F_INT*,F_INT*
 
     <ftype2> dimension(n),intent(in) :: d
     <ftype2> dimension(n-1),depend(n),intent(in) :: e
@@ -1342,7 +1342,7 @@ subroutine <prefix2>sterf(d,e,n,info)
     ! computes all eigenvalues of a real, symmetric tridiagonal matrix.
 
     callstatement (*f2py_func)(&n,d,e,&info)
-    callprotoargument int*,<ctype2>*,<ctype2>*,int*
+    callprotoargument F_INT*,<ctype2>*,<ctype2>*,F_INT*
 
     <ftype2> dimension(n),intent(in,out,copy,out=vals) :: d
     <ftype2> dimension(n-1),depend(n),intent(in,copy) :: e
@@ -1356,7 +1356,7 @@ subroutine <prefix2>stein(d,e,w,iblock,isplit,m,n,z,ldz,work,iwork,ifail,info)
     ! tridiagonal matrix.
 
     callstatement (*f2py_func)(&n,d,e,&m,w,iblock,isplit,z,&ldz,work,iwork,ifail,&info)
-    callprotoargument int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,int*,int*,int*
+    callprotoargument F_INT*,<ctype2>*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*
 
     <ftype2> dimension(n),intent(in) :: d
     <ftype2> dimension(n-1),depend(n),intent(in) :: e
@@ -1378,7 +1378,7 @@ subroutine <prefix2>stemr(d,e,range,vl,vu,il,iu,compute_v,n,m,w,z,ldz,nzc,isuppz
     ! computes all eigenvalues of a real, symmetric tridiagonal matrix.
 
     callstatement (*f2py_func)((compute_v?"V":"N"),(range>0?(range==1?"V":"I"):"A"),&n,d,e,&vl,&vu,&il,&iu,&m,w,z,&ldz,&nzc,isuppz,&tryrac,work,&lwork,iwork,&liwork,&info)
-    callprotoargument char*,char*,int*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,int*,int*,int*,<ctype2>*,<ctype2>*,int*,int*,int*,int*,<ctype2>*,int*,int*,int*,int*
+    callprotoargument char*,char*,F_INT*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,F_INT*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*,F_INT*
 
     <ftype2> dimension(n),intent(in,copy) :: d
     <ftype2> dimension(n),intent(in) :: e
@@ -1409,7 +1409,7 @@ subroutine <prefix2>stemr_lwork(d,e,range,vl,vu,il,iu,compute_v,n,m,w,z,ldz,nzc,
 
     fortranname <prefix2c>stemr
     callstatement (*f2py_func)((compute_v?"V":"N"),(range>0?(range==1?"V":"I"):"A"),&n,d,e,&vl,&vu,&il,&iu,&m,w,z,&ldz,&nzc,isuppz,&tryrac,&work,&lwork,&iwork,&liwork,&info)
-    callprotoargument char*,char*,int*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,int*,int*,int*,<ctype2>*,<ctype2>*,int*,int*,int*,int*,<ctype2>*,int*,int*,int*,int*
+    callprotoargument char*,char*,F_INT*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,F_INT*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*,F_INT*
 
     <ftype2> dimension(n),intent(in,copy) :: d
     <ftype2> dimension(n),intent(in,copy) :: e
@@ -1439,7 +1439,7 @@ subroutine <prefix2>stev(d,e,compute_v,n,z,ldz,work,info)
     ! symmetric tridiagonal matrix.
 
     callstatement (*f2py_func)((compute_v?"V":"N"),&n,d,e,z,&ldz,work,&info)
-    callprotoargument char*,int*,<ctype2>*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*
+    callprotoargument char*,F_INT*,<ctype2>*,<ctype2>*,<ctype2>*,F_INT*,<ctype2>*,F_INT*
 
     integer optional,intent(in):: compute_v = 1
     <ftype2> dimension(n),intent(in,out,copy,out=vals) :: d
@@ -1463,7 +1463,7 @@ subroutine <prefix><s,s,h,h>frk(transr,uplo,trans,n,k,nt,ka,alpha,a,lda,beta,c)
     ! matrix in the second case.
 
     callstatement (*f2py_func)(transr,uplo,trans,&n,&k,&alpha,a,&lda,&beta,c)
-    callprotoargument char*,char*,char*,int*,int*,<ctypereal>*,<ctype>*,int*,<ctypereal>*,<ctype>*
+    callprotoargument char*,char*,char*,F_INT*,F_INT*,<ctypereal>*,<ctype>*,F_INT*,<ctypereal>*,<ctype>*
 
     character optional,intent(in),check(*transr=='N'||*transr==<'T','T','C','C'>):: transr = 'N'
     character optional,intent(in),check(*uplo=='U'||*uplo=='L'):: uplo = 'U'
@@ -1487,7 +1487,7 @@ subroutine <prefix>tpttf(transr,uplo,n,nt,ap,arf,info)
     !
 
     callstatement (*f2py_func)(transr,uplo,&n,ap,arf,&info)
-    callprotoargument char*,char*,int*,<ctype>*,<ctype>*,int*
+    callprotoargument char*,char*,F_INT*,<ctype>*,<ctype>*,F_INT*
 
     character optional,intent(in),check(*transr=='N'||*transr==<'T','T','C','C'>):: transr = 'N'
     character optional,intent(in),check(*uplo=='U'||*uplo=='L'):: uplo = 'U'
@@ -1506,7 +1506,7 @@ subroutine <prefix>tpttr(uplo,n,nt,ap,a,lda,info)
     !
 
     callstatement (*f2py_func)(uplo,&n,ap,a,&lda,&info)
-    callprotoargument char*,int*,<ctype>*,<ctype>*,int*,int*
+    callprotoargument char*,F_INT*,<ctype>*,<ctype>*,F_INT*,F_INT*
 
     character optional,intent(in),check(*uplo=='U'||*uplo=='L'):: uplo = 'U'
     integer intent(in), check(n>=0):: n
@@ -1525,7 +1525,7 @@ subroutine <prefix>tfttp(transr,uplo,n,nt,ap,arf,info)
     !
 
     callstatement (*f2py_func)(transr,uplo,&n,arf,ap,&info)
-    callprotoargument char*,char*,int*,<ctype>*,<ctype>*,int*
+    callprotoargument char*,char*,F_INT*,<ctype>*,<ctype>*,F_INT*
 
     character optional,intent(in),check(*transr=='N'||*transr==<'T','T','C','C'>):: transr = 'N'
     character optional,intent(in),check(*uplo=='U'||*uplo=='L'):: uplo = 'U'
@@ -1543,7 +1543,7 @@ subroutine <prefix>tfttr(transr,uplo,n,nt,arf,a,lda,info)
     ! format (TF) to the standard full format (TR).
     !
     callstatement (*f2py_func)(transr,uplo,&n,arf,a,&lda,&info)
-    callprotoargument char*,char*,int*,<ctype>*,<ctype>*,int*,int*
+    callprotoargument char*,char*,F_INT*,<ctype>*,<ctype>*,F_INT*,F_INT*
 
     character optional,intent(in),check(*transr=='N'||*transr==<'T','T','C','C'>):: transr = 'N'
     character optional,intent(in),check(*uplo=='U'||*uplo=='L'):: uplo = 'U'
@@ -1562,7 +1562,7 @@ subroutine <prefix>trttf(transr,uplo,n,a,lda,arf,info)
     ! to rectangular full packed format (TF).
     !
     callstatement (*f2py_func)(transr,uplo,&n,a,&lda,arf,&info)
-    callprotoargument char*,char*,int*,<ctype>*,int*,<ctype>*,int*
+    callprotoargument char*,char*,F_INT*,<ctype>*,F_INT*,<ctype>*,F_INT*
 
     character optional,intent(in),check(*transr=='N'||*transr==<'T','T','C','C'>):: transr = 'N'
     character optional,intent(in),check(*uplo=='U'||*uplo=='L'):: uplo = 'U'
@@ -1580,9 +1580,9 @@ subroutine <prefix>trttp(uplo,n,a,lda,ap,info)
     ! the standard packed format (TP).
     !
     callstatement (*f2py_func)(uplo,&n,a,&lda,ap,&info)
-    callprotoargument char*,int*,<ctype>*,int*,<ctype>*,int*
+    callprotoargument char*,F_INT*,<ctype>*,F_INT*,<ctype>*,F_INT*
 
-    character optional, intent(int),check(*uplo=='U'||*uplo=='L'):: uplo = 'U'
+    character optional, intent(F_INT),check(*uplo=='U'||*uplo=='L'):: uplo = 'U'
     integer intent(hide),depend(a):: n = shape(a,1)
     integer intent(hide),depend(a):: lda = MAX(shape(a,0),1)
     <ftype> dimension(lda,n),intent(in),check(shape(a,0)==shape(a,1)):: a
@@ -1608,7 +1608,7 @@ subroutine <prefix>tfsm(transr,side,uplo,trans,diag,m,n,nt,alpha,a,b,ldb)
     !
 
     callstatement (*f2py_func)(transr,side,uplo,trans,diag,&m,&n,&alpha,a,b,&ldb)
-    callprotoargument char*,char*,char*,char*,char*,int*,int*,<ctype>*,<ctype>*,<ctype>*,int*
+    callprotoargument char*,char*,char*,char*,char*,F_INT*,F_INT*,<ctype>*,<ctype>*,<ctype>*,F_INT*
 
     character optional,intent(in),check(*transr=='N'||*transr==<'T','T','C','C'>):: transr = 'N'
     character optional,intent(in),check(*side=='L'||*side=='R'):: side = 'L'
@@ -1636,7 +1636,7 @@ subroutine <prefix>pftrf(transr,uplo,n,nt,a,info)
     ! This is the block version of the algorithm, calling Level 3 BLAS.
     !
     callstatement (*f2py_func)(transr,uplo,&n,a,&info)
-    callprotoargument char*,char*,int*,<ctype>*,int*
+    callprotoargument char*,char*,F_INT*,<ctype>*,F_INT*
 
     character optional,intent(in),check(*transr=='N'||*transr==<'T','T','C','C'>):: transr = 'N'
     character optional,intent(in),check(*uplo=='U'||*uplo=='L'):: uplo = 'U'
@@ -1655,7 +1655,7 @@ subroutine <prefix>pftri(transr,uplo,n,nt,a,info)
     !
 
     callstatement (*f2py_func)(transr,uplo,&n,a,&info)
-    callprotoargument char*,char*,int*,<ctype>*,int*
+    callprotoargument char*,char*,F_INT*,<ctype>*,F_INT*
 
     character optional,intent(in),check(*transr=='N'||*transr==<'T','T','C','C'>):: transr = 'N'
     character optional,intent(in),check(*uplo=='U'||*uplo=='L'):: uplo = 'U'
@@ -1673,7 +1673,7 @@ subroutine <prefix>pftrs(transr,uplo,n,nhrs,nt,a,b,ldb,info)
     ! A = U**H*U or A = L*L**H computed by ?PFTRF.
     !
     callstatement (*f2py_func)(transr,uplo,&n,&nhrs,a,b,&ldb,&info)
-    callprotoargument char*,char*,int*,int*,<ctype>*,<ctype>*,int*,int*
+    callprotoargument char*,char*,F_INT*,F_INT*,<ctype>*,<ctype>*,F_INT*,F_INT*
 
     character optional,intent(in),check(*transr=='N'||*transr==<'T','T','C','C'>):: transr = 'N'
     character optional,intent(in),check(*uplo=='U'||*uplo=='L'):: uplo = 'U'
@@ -1699,7 +1699,7 @@ subroutine <prefix>tzrzf(m,n,a,lda,tau,work,lwork,info)
     ! triangular matrix.
     !
     callstatement (*f2py_func)(&m,&n,a,&lda,tau,work,&lwork,&info)
-    callprotoargument int*,int*,<ctype>*,int*,<ctype>*,<ctype>*,int*,int*
+    callprotoargument F_INT*,F_INT*,<ctype>*,F_INT*,<ctype>*,<ctype>*,F_INT*,F_INT*
 
     integer intent(hide),depend(a):: m=shape(a,0)
     integer intent(hide),depend(a):: n=shape(a,1)
@@ -1716,7 +1716,7 @@ subroutine <prefix>tzrzf_lwork(m,n,a,lda,tau,work,lwork,info)
     ! lwork computation for tzrzf
     fortranname <prefix>tzrzf
     callstatement (*f2py_func)(&m,&n,&a,&lda,&tau,&work,&lwork,&info)
-    callprotoargument int*,int*,<ctype>*,int*,<ctype>*,<ctype>*,int*,int*
+    callprotoargument F_INT*,F_INT*,<ctype>*,F_INT*,<ctype>*,<ctype>*,F_INT*,F_INT*
 
     integer intent(in):: m
     integer intent(in):: n
@@ -1734,7 +1734,7 @@ subroutine <prefix2>lasd4( n, i, d, z, delta, rho, sigma, work, info )
    	! Computes i-th square root of eigenvalue of rank one augmented diagonal matrix. Needed by SVD update procedure
 
 	callstatement { i++; (*f2py_func)( &n, &i, d, z, delta, &rho, &sigma, work, &info); }
-    callprotoargument int*, int*, <ctype2>*, <ctype2>*, <ctype2>*, <ctype2>*, <ctype2>*, <ctype2>*, int*
+    callprotoargument F_INT*, F_INT*, <ctype2>*, <ctype2>*, <ctype2>*, <ctype2>*, <ctype2>*, <ctype2>*, F_INT*
 
 	integer intent(hide),depend(d):: n = shape(d,0)
 	integer intent(in),depend(d),check(i>=0 && i<=(shape(d,0)-1)):: i
@@ -1759,7 +1759,7 @@ subroutine <prefix>lauum(n,c,info,lower)
     ! C is triangular matrix of the corresponding Cholesky decomposition.
 
     callstatement (*f2py_func)((lower?"L":"U"),&n,c,&n,&info)
-    callprotoargument char*,int*,<ctype>*,int*,int*
+    callprotoargument char*,F_INT*,<ctype>*,F_INT*,F_INT*
 
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
 
@@ -1776,8 +1776,8 @@ subroutine <prefix>laswp(n,a,nrows,k1,k2,piv,off,inc,m,npiv)
     !
     ! piv pivots rows.
 
-    callstatement {int i;m=len(piv);for(i=0;i<m;++piv[i++]);++k1;++k2; (*f2py_func)(&n,a,&nrows,&k1,&k2,piv+off,&inc); for(i=0;i<m;--piv[i++]);}
-    callprotoargument int*,<ctype>*,int*,int*,int*,int*,int*
+    callstatement {F_INT i;m=len(piv);for(i=0;i<m;++piv[i++]);++k1;++k2; (*f2py_func)(&n,a,&nrows,&k1,&k2,piv+off,&inc); for(i=0;i<m;--piv[i++]);}
+    callprotoargument F_INT*,<ctype>*,F_INT*,F_INT*,F_INT*,F_INT*,F_INT*
 
     integer depend(a),intent(hide):: nrows = shape(a,0)
     integer depend(a),intent(hide):: n = shape(a,1)
@@ -1838,7 +1838,7 @@ function <prefix2>lange(norm,m,n,a,lda,work) result(n2)
     ! element of largest absolute value of a real matrix A.
     <ftype2> <prefix2>lange, n2
     callstatement (*f2py_func)(&<prefix2>lange,norm,&m,&n,a,&lda,work)
-    callprotoargument <ctype2>*,char*,int*,int*,<ctype2>*,int*,<ctype2>*
+    callprotoargument <ctype2>*,char*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*
 
     character intent(in),check(*norm=='M'||*norm=='m'||*norm=='1'||*norm=='O'||*norm=='o'||*norm=='I'||*norm=='i'||*norm=='F'||*norm=='f'||*norm=='E'||*norm=='e'):: norm
     integer intent(hide),depend(a,n) :: m = shape(a,0)
@@ -1853,7 +1853,7 @@ function <prefix2c>lange(norm,m,n,a,lda,work) result(n2)
     ! element of largest absolute value of a complex matrix A.
     <ftype2> <prefix2c>lange, n2
     callstatement (*f2py_func)(&<prefix2c>lange,norm,&m,&n,a,&lda,work)
-    callprotoargument <ctype2>*,char*,int*,int*,<ctype2c>*,int*,<ctype2>*
+    callprotoargument <ctype2>*,char*,F_INT*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*
 
     character intent(in),check(*norm=='M'||*norm=='m'||*norm=='1'||*norm=='O'||*norm=='o'||*norm=='I'||*norm=='i'||*norm=='F'||*norm=='f'||*norm=='E'||*norm=='e'):: norm
     integer intent(hide),depend(a,n) :: m = shape(a,0)
@@ -1896,7 +1896,7 @@ end subroutine <prefix>lartg
 
 subroutine <prefix2c>rot(n,x,offx,incx,y,offy,incy,c,s,lx,ly)
     callstatement (*f2py_func)(&n,x+offx,&incx,y+offy,&incy,&c,&s)
-    callprotoargument int*,<ctype2c>*,int*,<ctype2c>*,int*,<float,double>*,<ctype2c>*
+    callprotoargument F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<float,double>*,<ctype2c>*
     <ftype2c> dimension(lx),intent(in,out,copy) :: x
     <ftype2c> dimension(ly),intent(in,out,copy) :: y
     integer intent(hide),depend(x) :: lx = len(x)

--- a/scipy/linalg/flapack_pos_def.pyf.src
+++ b/scipy/linalg/flapack_pos_def.pyf.src
@@ -11,7 +11,7 @@ subroutine <prefix>pstrf(n,a,lda,piv,rank_c,tol,work,info,lower)
     ! P is stored as vector PIV.
 
     callstatement (*f2py_func)((lower?"L":"U"),&n,a,&lda,piv,&rank_c,&tol,work,&info)
-    callprotoargument char*,int*,<ctype>*,int*,int*,int*,<ctypereal>*,<ctypereal>*,int*
+    callprotoargument char*,F_INT*,<ctype>*,F_INT*,F_INT*,F_INT*,<ctypereal>*,<ctypereal>*,F_INT*
     
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
     integer depend(a),intent(hide):: n = shape(a,0)
@@ -35,7 +35,7 @@ subroutine <prefix>pstf2(n,a,lda,piv,rank_c,tol,work,info,lower)
     ! P is stored as vector PIV.
 
     callstatement (*f2py_func)((lower?"L":"U"),&n,a,&lda,piv,&rank_c,&tol,work,&info)
-    callprotoargument char*,int*,<ctype>*,int*,int*,int*,<ctypereal>*,<ctypereal>*,int*
+    callprotoargument char*,F_INT*,<ctype>*,F_INT*,F_INT*,F_INT*,<ctypereal>*,<ctypereal>*,F_INT*
 
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
     integer depend(a),intent(hide):: n = shape(a,0)
@@ -58,7 +58,7 @@ subroutine <prefix>posv(n,nrhs,a,b,info,lower)
     ! C is triangular matrix of the corresponding Cholesky decomposition.
 
     callstatement (*f2py_func)((lower?"L":"U"),&n,&nrhs,a,&n,b,&n,&info)
-    callprotoargument char*,int*,int*,<ctype>*,int*,<ctype>*,int*,int*
+    callprotoargument char*,F_INT*,F_INT*,<ctype>*,F_INT*,<ctype>*,F_INT*,F_INT*
 
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
 
@@ -77,7 +77,7 @@ subroutine <prefix>posvx(fact,n,nrhs,a,lda,af,ldaf,equed,s,b,ldb,x,ldx,rcond,fer
     ! "expert" version of the ?POSV routines
     threadsafe
     callstatement (*f2py_func)(fact,(lower?"L":"U"),&n,&nrhs,a,&lda,af,&ldaf,equed,s,b,&ldb,x,&ldx,&rcond,ferr,berr,work,irwork,&info)
-    callprotoargument char*,char*,int*,int*,<ctype>*,int*,<ctype>*,int*,char*,<ctypereal>*,<ctype>*,int*,<ctype>*,int*,<ctypereal>*,<ctypereal>*,<ctypereal>*,<ctype>*,<int,int,float,double>*,int*
+    callprotoargument char*,char*,F_INT*,F_INT*,<ctype>*,F_INT*,<ctype>*,F_INT*,char*,<ctypereal>*,<ctype>*,F_INT*,<ctype>*,F_INT*,<ctypereal>*,<ctypereal>*,<ctypereal>*,<ctype>*,<F_INT,F_INT,float,double>*,F_INT*
  
     character optional,intent(in):: fact = "E"
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
@@ -107,7 +107,7 @@ subroutine <prefix>pocon(uplo,n,a,lda,anorm,rcond,work,irwork,info)
     ! for a positive definite symmetric/hermitian matrix.
     threadsafe
     callstatement (*f2py_func)(uplo,&n,a,&lda,&anorm,&rcond,work,irwork,&info)
-    callprotoargument char*,int*,<ctype>*,int*,<ctypereal>*,<ctypereal>*,<ctype>*,<int,int,float,double>*,int*
+    callprotoargument char*,F_INT*,<ctype>*,F_INT*,<ctypereal>*,<ctypereal>*,<ctype>*,<F_INT,F_INT,float,double>*,F_INT*
  
     character optional,intent(in):: uplo = 'U'
     integer depend(a),intent(hide):: n = shape(a,0)
@@ -129,8 +129,8 @@ subroutine <prefix2>potrf(n,a,lda,info,lower,clean)
     ! C is triangular matrix of the corresponding Cholesky decomposition.
     ! clean==1 zeros strictly lower or upper parts of U or L, respectively
  
-    callstatement (*f2py_func)((lower?"L":"U"),&n,a,&lda,&info); if(clean){int i,j;if(lower){for(i=0;i\<n;++i) for(j=i+1;j\<n;++j) *(a+j*n+i)=0.0;} else {for(i=0;i\<n;++i) for(j=i+1;j<n;++j) *(a+i*n+j)=0.0;}}
-    callprotoargument char*,int*,<ctype2>*,int*,int*
+    callstatement (*f2py_func)((lower?"L":"U"),&n,a,&lda,&info); if(clean){F_INT i,j;if(lower){for(i=0;i\<n;++i) for(j=i+1;j\<n;++j) *(a+j*n+i)=0.0;} else {for(i=0;i\<n;++i) for(j=i+1;j<n;++j) *(a+i*n+j)=0.0;}}
+    callprotoargument char*,F_INT*,<ctype2>*,F_INT*,F_INT*
  
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
     integer optional,intent(in),check(clean==0||clean==1) :: clean = 1
@@ -149,8 +149,8 @@ subroutine <prefix2c>potrf(n,a,lda,info,lower,clean)
     ! C is triangular matrix of the corresponding Cholesky decomposition.
     ! clean==1 zeros strictly lower or upper parts of U or L, respectively
  
-    callstatement (*f2py_func)((lower?"L":"U"),&n,a,&lda,&info); if(clean){int i,j,k;if(lower){for(i=0;i\<n;++i) for(j=i+1;j\<n;++j) {k=j*n+i;(a+k)->r=(a+k)->i=0.0;}} else {for(i=0;i\<n;++i) for(j=i+1;j\<n;++j) {k=i*n+j;(a+k)->r=(a+k)->i=0.0;}}}
-    callprotoargument char*,int*,<ctype2c>*,int*,int*
+    callstatement (*f2py_func)((lower?"L":"U"),&n,a,&lda,&info); if(clean){F_INT i,j,k;if(lower){for(i=0;i\<n;++i) for(j=i+1;j\<n;++j) {k=j*n+i;(a+k)->r=(a+k)->i=0.0;}} else {for(i=0;i\<n;++i) for(j=i+1;j\<n;++j) {k=i*n+j;(a+k)->r=(a+k)->i=0.0;}}}
+    callprotoargument char*,F_INT*,<ctype2c>*,F_INT*,F_INT*
  
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
     integer optional,intent(in),check(clean==0||clean==1) :: clean = 1
@@ -170,7 +170,7 @@ subroutine <prefix>potrs(n,nrhs,c,b,info,lower)
     ! C is triangular matrix of the corresponding Cholesky decomposition.
  
     callstatement (*f2py_func)((lower?"L":"U"),&n,&nrhs,c,&n,b,&n,&info)
-    callprotoargument char*,int*,int*,<ctype>*,int*,<ctype>*,int*,int*
+    callprotoargument char*,F_INT*,F_INT*,<ctype>*,F_INT*,<ctype>*,F_INT*,F_INT*
  
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
  
@@ -192,7 +192,7 @@ subroutine <prefix>potri(n,c,info,lower)
     ! C is triangular matrix of the corresponding Cholesky decomposition.
  
     callstatement (*f2py_func)((lower?"L":"U"),&n,c,&n,&info)
-    callprotoargument char*,int*,<ctype>*,int*,int*
+    callprotoargument char*,F_INT*,<ctype>*,F_INT*,F_INT*
  
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
  

--- a/scipy/linalg/flapack_pos_def_tri.pyf.src
+++ b/scipy/linalg/flapack_pos_def_tri.pyf.src
@@ -3,7 +3,7 @@
 
 subroutine <prefix>ptsv(n, nrhs, d, e, b, info)
     callstatement (*f2py_func)(&n, &nrhs, d, e, b, &n, &info);
-    callprotoargument int*, int*, <ctypereal>*, <ctype>*, <ctype>*, int*, int*
+    callprotoargument F_INT*, F_INT*, <ctypereal>*, <ctype>*, <ctype>*, F_INT*, F_INT*
     integer intent(hide), depend(d) :: n = len(d)
     integer intent(hide), depend(b) :: nrhs = shape(b, 1)
     <ftypereal> dimension(n), intent(in,out,copy) :: d
@@ -22,7 +22,7 @@ subroutine <prefix>pttrf(n, d, e, info)
     ! as ! having the form A = U**T*D*U.
 
     callstatement (*f2py_func)(&n, d, e, &info)
-    callprotoargument int*, <ctypereal>*, <ctype>*, int*
+    callprotoargument F_INT*, <ctypereal>*, <ctype>*, F_INT*
 
     integer intent(hide), depend(d) :: n = len(d)
     <ftypereal> intent(in, out, copy), dimension(n) :: d
@@ -45,7 +45,7 @@ subroutine <prefix2>pttrs(n, nrhs, d, e, b, ldb, info)
     ! are N by NRHS matrices.
 
     callstatement (*f2py_func)(&n, &nrhs, d, e, b, &ldb, &info)
-    callprotoargument int*, int*, <ctype2>*, <ctype2>*, <ctype2>*, int*, int*
+    callprotoargument F_INT*, F_INT*, <ctype2>*, <ctype2>*, <ctype2>*, F_INT*, F_INT*
 
     integer intent(hide), depend(d) :: n = len(d)
     <ftype2> intent(in), dimension(n) :: d
@@ -71,7 +71,7 @@ subroutine <prefix2c>pttrs(lower, n, nrhs, d, e, b, ldb, info)
     ! are N by NRHS matrices.
 
     callstatement (*f2py_func)((lower?"L":"U"), &n, &nrhs, d, e, b, &ldb, &info)
-    callprotoargument char*, int*, int*, <ctype2>*, <ctype2c>*, <ctype2c>*, int*, int*
+    callprotoargument char*, F_INT*, F_INT*, <ctype2>*, <ctype2c>*, <ctype2c>*, F_INT*, F_INT*
 
     integer optional, intent(in), check(lower==0||lower==1) :: lower = 0
     integer intent(hide), depend(d) :: n = len(d)
@@ -103,7 +103,7 @@ subroutine <prefix>pteqr(compute_z, n, d, e, z, ldz, work, info)
     ! high relative accuracy in the small eigenvalues of the original
     ! matrix, if these eigenvalues range over many orders of magnitude.)
     callstatement (*f2py_func)((compute_z?(compute_z==2?"I":"V"):"N"), &n, d, e, z, &ldz, work, &info)
-    callprotoargument char*, int*, <ctypereal>*, <ctypereal>*, <ctype>*, int*, <ctypereal>*, int*
+    callprotoargument char*, F_INT*, <ctypereal>*, <ctypereal>*, <ctype>*, F_INT*, <ctypereal>*, F_INT*
     integer intent(in, optional), check((compute_z>=0) && (compute_z<=2)) :: compute_z = 0
     integer intent(hide), depend(d) :: n = len(d)
     <ftypereal> intent(in,out,copy), dimension(n) :: d
@@ -125,7 +125,7 @@ subroutine <prefix2>ptsvx(fact, n, nrhs, d, e, df, ef, b, ldb, x, ldx, rcond, fe
     ! Error bounds on the solution and a condition estimate are also
     ! provided.
     callstatement (*f2py_func)(fact, &n, &nrhs, d, e, df, ef, b, &ldb, x, &ldx, &rcond, ferr, berr, work, &info)
-    callprotoargument char*, int*, int*, <ctype2>*, <ctype2>*, <ctype2>*, <ctype2>*, <ctype2>*, int*, <ctype2>*, int*,  <ctype2>*, <ctype2>*, <ctype2>*, <ctype2>*, int*
+    callprotoargument char*, F_INT*, F_INT*, <ctype2>*, <ctype2>*, <ctype2>*, <ctype2>*, <ctype2>*, F_INT*, <ctype2>*, F_INT*,  <ctype2>*, <ctype2>*, <ctype2>*, <ctype2>*, F_INT*
 
     character optional, intent(in) :: fact = 'N'
     integer intent(hide), depend(d) :: n = len(d)
@@ -156,7 +156,7 @@ subroutine <prefix2c>ptsvx(fact, n, nrhs, d, e, df, ef, b, ldb, x, ldx, rcond, f
     ! Error bounds on the solution and a condition estimate are also
     ! provided.
     callstatement (*f2py_func)(fact, &n, &nrhs, d, e, df, ef, b, &ldb, x, &ldx, &rcond, ferr, berr, work, rwork, &info)
-    callprotoargument char*, int*, int*, <ctype2>*, <ctype2c>*, <ctype2>*, <ctype2c>*, <ctype2c>*, int*, <ctype2c>*, int*,  <ctype2>*, <ctype2>*, <ctype2>*, <ctype2c>*, <ctype2>*, int*
+    callprotoargument char*, F_INT*, F_INT*, <ctype2>*, <ctype2c>*, <ctype2>*, <ctype2c>*, <ctype2c>*, F_INT*, <ctype2c>*, F_INT*,  <ctype2>*, <ctype2>*, <ctype2>*, <ctype2c>*, <ctype2>*, F_INT*
 
     character optional, intent(in) :: fact = 'N'
     integer intent(hide), depend(d) :: n = len(d)

--- a/scipy/linalg/flapack_sym_herm.pyf.src
+++ b/scipy/linalg/flapack_sym_herm.pyf.src
@@ -10,7 +10,7 @@ subroutine <prefix2>syev(compute_v,lower,n,w,a,lda,work,lwork,info)
     !   If compute_v=0 then set also overwrite_a=1.
 
     callstatement (*f2py_func)((compute_v?"V":"N"),(lower?"L":"U"),&n,a,&lda,w,work,&lwork,&info)
-    callprotoargument char*,char*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*
+    callprotoargument char*,char*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,F_INT*
 
     integer optional,intent(in):: compute_v = 1
     check(compute_v==1||compute_v==0) compute_v
@@ -37,7 +37,7 @@ subroutine <prefix2>syev_lwork(lower,n,w,a,lda,work,lwork,info)
     fortranname <prefix2>syev
 
     callstatement (*f2py_func)("N",(lower?"L":"U"),&n,&a,&lda,&w,&work,&lwork,&info)
-    callprotoargument char*,char*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*
+    callprotoargument char*,char*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,F_INT*
     
      integer intent(in):: n
      integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
@@ -61,7 +61,7 @@ subroutine <prefix2c>heev(compute_v,lower,n,w,a,lda,work,lwork,rwork,info)
     !   If compute_v=0 and overwrite_a=1, the contents of a is destroyed.
 
     callstatement (*f2py_func)((compute_v?"V":"N"),(lower?"L":"U"),&n,a,&lda,w,work,&lwork,rwork,&info)
-    callprotoargument char*,char*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2c>*,int*,<ctype2>*,int*
+    callprotoargument char*,char*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,<ctype2c>*,F_INT*,<ctype2>*,F_INT*
 
     integer optional,intent(in),check(compute_v==1||compute_v==0) :: compute_v = 1
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
@@ -87,7 +87,7 @@ subroutine <prefix2c>heev_lwork(lower,n,w,a,lda,work,lwork,rwork,info)
 
     fortranname <prefix2c>heev
     callstatement (*f2py_func)("N",(lower?"L":"U"),&n,&a,&lda,&w,&work,&lwork,&rwork,&info)
-    callprotoargument char*,char*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2c>*,int*,<ctype2>*,int*
+    callprotoargument char*,char*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,<ctype2c>*,F_INT*,<ctype2>*,F_INT*
 
      integer intent(in):: n
      integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
@@ -112,7 +112,7 @@ subroutine <prefix2>syevd(compute_v,lower,n,w,a,lda,work,lwork,iwork,liwork,info
     !   If compute_v=0 then set also overwrite_a=1.
 
     callstatement (*f2py_func)((compute_v?"V":"N"),(lower?"L":"U"),&n,a,&lda,w,work,&lwork,iwork,&liwork,&info)
-    callprotoargument char*,char*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,int*,int*
+    callprotoargument char*,char*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,F_INT*,F_INT*
 
     integer optional,intent(in),check(compute_v==1||compute_v==0) :: compute_v = 1
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
@@ -140,7 +140,7 @@ subroutine <prefix2>syevd_lwork(compute_v,lower,n,w,a,lda,work,lwork,iwork,liwor
     fortranname <prefix2>syevd
 
     callstatement (*f2py_func)((compute_v?"V":"N"),(lower?"L":"U"),&n,&a,&lda,&w,&work,&lwork,&iwork,&liwork,&info)
-    callprotoargument char*,char*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,int*,int*
+    callprotoargument char*,char*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,F_INT*,F_INT*
 
     integer intent(in):: n
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
@@ -167,7 +167,7 @@ subroutine <prefix2c>heevd(compute_v,lower,n,w,a,lda,work,lwork,iwork,liwork,rwo
     !   If compute_v=0 and overwrite_a=1, the contents of a is destroyed.
 
     callstatement (*f2py_func)((compute_v?"V":"N"),(lower?"L":"U"),&n,a,&lda,w,work,&lwork,rwork,&lrwork,iwork,&liwork,&info)
-    callprotoargument char*,char*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2c>*,int*,<ctype2>*,int*,int*,int*,int*
+    callprotoargument char*,char*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,<ctype2c>*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*,F_INT*
 
     integer optional,intent(in):: compute_v = 1
     check(compute_v==1||compute_v==0) compute_v
@@ -198,7 +198,7 @@ subroutine <prefix2c>heevd_lwork(compute_v,lower,n,w,a,lda,work,lwork,iwork,liwo
     fortranname <prefix2c>heevd
     
     callstatement (*f2py_func)((compute_v?"V":"N"),(lower?"L":"U"),&n,&a,&lda,&w,&work,&lwork,&rwork,&lrwork,&iwork,&liwork,&info)
-    callprotoargument char*,char*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2c>*,int*,<ctype2>*,int*,int*,int*,int*
+    callprotoargument char*,char*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,<ctype2c>*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*,F_INT*
 
     integer intent(in):: n
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
@@ -225,7 +225,7 @@ end subroutine <prefix2c>heevd_lwork
      ! A = U * D * U^T if lower = 0
 
      callstatement (*f2py_func)((lower?"L":"U"),&n,a,&lda,ipiv,&info)
-     callprotoargument char*,int*,<ctype>*,int*,int*,int*
+     callprotoargument char*,F_INT*,<ctype>*,F_INT*,F_INT*,F_INT*
 
      integer optional,intent(in),check(lower==0||lower==1):: lower = 0
      integer depend(a),intent(hide):: n = shape(a,0)
@@ -245,7 +245,7 @@ end subroutine <prefix2c>heevd_lwork
     ! B must contain the factorized U and L from potrf
 
      callstatement (*f2py_func)(&itype,(lower?"L":"U"),&n,a,&lda,b,&ldb,&info)
-     callprotoargument int*,char*,int*,<ctype2>*,int*,<ctype2>*,int*,int*
+     callprotoargument F_INT*,char*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*
 
      integer optional,intent(in),check(itype==1||itype==2||itype==3):: itype = 1
      integer optional,intent(in),check(lower==0||lower==1):: lower = 0
@@ -266,7 +266,7 @@ end subroutine <prefix2c>heevd_lwork
      ! This is similar to ?SYTF2 but uses BLAS3 blocked calls
 
      callstatement (*f2py_func)((lower?"L":"U"),&n,a,&lda,ipiv,work,&lwork,&info)
-     callprotoargument char*,int*,<ctype>*,int*,int*,<ctype>*,int*,int*
+     callprotoargument char*,F_INT*,<ctype>*,F_INT*,F_INT*,<ctype>*,F_INT*,F_INT*
 
      integer optional,intent(in),check(lower==0||lower==1):: lower = 0
      integer depend(a),intent(hide):: n = shape(a,0)
@@ -286,7 +286,7 @@ end subroutine <prefix2c>heevd_lwork
      fortranname <prefix>sytrf
 
      callstatement (*f2py_func)((lower?"L":"U"),&n,&a,&lda,&ipiv,&work,&lwork,&info)
-     callprotoargument char*,int*,<ctype>*,int*,int*,<ctype>*,int*,int*
+     callprotoargument char*,F_INT*,<ctype>*,F_INT*,F_INT*,<ctype>*,F_INT*,F_INT*
 
      integer intent(in):: n
      integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
@@ -307,7 +307,7 @@ end subroutine <prefix2c>heevd_lwork
    ! Solve A * X = B for symmetric A matrix
 
      callstatement (*f2py_func)((lower?"L":"U"),&n,&nrhs,a,&lda,ipiv,b,&ldb,work,&lwork,&info)
-     callprotoargument char*,int*,int*,<ctype>*,int*,int*,<ctype>*,int*,<ctype>*,int*,int*
+     callprotoargument char*,F_INT*,F_INT*,<ctype>*,F_INT*,F_INT*,<ctype>*,F_INT*,<ctype>*,F_INT*,F_INT*
 
      integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
      integer depend(a),intent(hide):: n = shape(a,0)
@@ -329,7 +329,7 @@ end subroutine <prefix2c>heevd_lwork
 
      fortranname <prefix>sysv
      callstatement (*f2py_func)((lower?"L":"U"),&n,&nrhs,&a,&lda,&ipiv,&b,&ldb,&work,&lwork,&info)
-     callprotoargument char*,int*,int*,<ctype>*,int*,int*,<ctype>*,int*,<ctype>*,int*,int*
+     callprotoargument char*,F_INT*,F_INT*,<ctype>*,F_INT*,F_INT*,<ctype>*,F_INT*,<ctype>*,F_INT*,F_INT*
 
      integer intent(in):: n
      integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
@@ -354,7 +354,7 @@ end subroutine <prefix2c>heevd_lwork
    ! The (c,z) versions assume only symmetric complex matrices. For Hermitian matrices, routine (c,z)HESVX is used
      threadsafe
      callstatement (*f2py_func)((factored?"F":"N"),(lower?"L":"U"),&n,&nrhs,a,&lda,af,&ldaf,ipiv,b,&ldb,x,&ldx,&rcond,ferr,berr,work,&lwork,irwork,&info)
-     callprotoargument char*,char*,int*,int*,<ctype>*,int*,<ctype>*,int*,int*,<ctype>*,int*,<ctype>*,int*,<ctypereal>*,<ctypereal>*,<ctypereal>*,<ctype>*,int*,<int,int,float,double>*,int*
+     callprotoargument char*,char*,F_INT*,F_INT*,<ctype>*,F_INT*,<ctype>*,F_INT*,F_INT*,<ctype>*,F_INT*,<ctype>*,F_INT*,<ctypereal>*,<ctypereal>*,<ctypereal>*,<ctype>*,F_INT*,<F_INT,F_INT,float,double>*,F_INT*
 
      integer optional,intent(in),check(factored==0||factored==1) :: factored = 0
      integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
@@ -385,7 +385,7 @@ end subroutine <prefix2c>heevd_lwork
 
      fortranname <prefix>sysvx
      callstatement (*f2py_func)((factored?"F":"N"),(lower?"L":"U"),&n,&nrhs,&a,&lda,&af,&ldaf,&ipiv,&b,&ldb,&x,&ldx,&rcond,&ferr,&berr,&work,&lwork,&irwork,&info)
-     callprotoargument char*,char*,int*,int*,<ctype>*,int*,<ctype>*,int*,int*,<ctype>*,int*,<ctype>*,int*,<ctypereal>*,<ctypereal>*,<ctypereal>*,<ctype>*,int*,<int,int,float,double>*,int*
+     callprotoargument char*,char*,F_INT*,F_INT*,<ctype>*,F_INT*,<ctype>*,F_INT*,F_INT*,<ctype>*,F_INT*,<ctype>*,F_INT*,<ctypereal>*,<ctypereal>*,<ctypereal>*,<ctype>*,F_INT*,<F_INT,F_INT,float,double>*,F_INT*
 
      integer intent(in):: n
      integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
@@ -422,7 +422,7 @@ end subroutine <prefix2c>heevd_lwork
   !   condition number is computed as RCOND = 1 / (ANORM * norm(inv(A)))
 
     callstatement (*f2py_func)((lower?"L":"U"),&n,a,&lda,ipiv,&anorm,&rcond,work,iwork,&info)
-    callprotoargument char*,int*,<ctype2>*,int*,int*,<ctype2>*,<ctype2>*,<ctype2>*,int*,int*
+    callprotoargument char*,F_INT*,<ctype2>*,F_INT*,F_INT*,<ctype2>*,<ctype2>*,<ctype2>*,F_INT*,F_INT*
 
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
     integer depend(a),intent(hide):: n = shape(a,0)
@@ -447,7 +447,7 @@ end subroutine <prefix2c>heevd_lwork
   !   condition number is computed as RCOND = 1 / (ANORM * norm(inv(A)))
 
     callstatement (*f2py_func)((lower?"L":"U"),&n,a,&lda,ipiv,&anorm,&rcond,work,&info)
-    callprotoargument char*,int*,<ctypecomplex>*,int*,int*,<ctypereal>*,<ctypereal>*,<ctypecomplex>*,int*
+    callprotoargument char*,F_INT*,<ctypecomplex>*,F_INT*,F_INT*,<ctypereal>*,<ctypereal>*,<ctypecomplex>*,F_INT*
 
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
     integer depend(a),intent(hide):: n = shape(a,0)
@@ -466,7 +466,7 @@ end subroutine <prefix2c>heevd_lwork
   ! Get Non-diag elements of D (returned in workspace) and apply or reverse permutation done in TRF.
 
     callstatement (*f2py_func)((lower?"L":"U"),(way?"R":"C"),&n,a,&lda,ipiv,e,&info)
-    callprotoargument char*,char*,int*,<ctype>*,int*,int*,<ctype>*,int*
+    callprotoargument char*,char*,F_INT*,<ctype>*,F_INT*,F_INT*,<ctype>*,F_INT*
 
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
     integer optional,intent(in),check(way==0||way==1) :: way = 0
@@ -488,7 +488,7 @@ end subroutine <prefix2c>heevd_lwork
     ! B must contain the factorized U and L from potrf
 
      callstatement (*f2py_func)(&itype,(lower?"L":"U"),&n,a,&lda,b,&ldb,&info)
-     callprotoargument int*,char*,int*,<ctype2c>*,int*,<ctype2c>*,int*,int*
+     callprotoargument F_INT*,char*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,F_INT*
 
      integer optional,intent(in),check(itype==1||itype==2||itype==3):: itype = 1
      integer optional,intent(in),check(lower==0||lower==1):: lower = 0
@@ -509,7 +509,7 @@ end subroutine <prefix2c>heevd_lwork
      ! This is similar to ?HETF2 but uses BLAS3 blocked calls
 
      callstatement (*f2py_func)((lower?"L":"U"),&n,a,&lda,ipiv,work,&lwork,&info)
-     callprotoargument char*,int*,<ctype2c>*,int*,int*,<ctype2c>*,int*,int*
+     callprotoargument char*,F_INT*,<ctype2c>*,F_INT*,F_INT*,<ctype2c>*,F_INT*,F_INT*
 
      integer optional,intent(in),check(lower==0||lower==1):: lower = 0
      integer depend(a),intent(hide):: n = shape(a,0)
@@ -529,7 +529,7 @@ end subroutine <prefix2c>heevd_lwork
      fortranname <prefix2c>hetrf
 
      callstatement (*f2py_func)((lower?"L":"U"),&n,&a,&lda,&ipiv,&work,&lwork,&info)
-     callprotoargument char*,int*,<ctype2c>*,int*,int*,<ctype2c>*,int*,int*
+     callprotoargument char*,F_INT*,<ctype2c>*,F_INT*,F_INT*,<ctype2c>*,F_INT*,F_INT*
 
      integer intent(in):: n
      integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
@@ -553,7 +553,7 @@ end subroutine <prefix2c>heevd_lwork
    ! A = L * D * L**H if lower = 1
      threadsafe
      callstatement (*f2py_func)((lower?"L":"U"),&n,&nrhs,a,&lda,ipiv,b,&ldb,work,&lwork,&info)
-     callprotoargument char*,int*,int*,<ctype2c>*,int*,int*,<ctype2c>*,int*,<ctype2c>*,int*,int*
+     callprotoargument char*,F_INT*,F_INT*,<ctype2c>*,F_INT*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,F_INT*
 
      integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
      integer depend(a),intent(hide):: n = shape(a,0)
@@ -575,7 +575,7 @@ end subroutine <prefix2c>heevd_lwork
 
      fortranname <prefix2c>hesv
      callstatement (*f2py_func)((lower?"L":"U"),&n,&nrhs,&a,&lda,&ipiv,&b,&ldb,&work,&lwork,&info)
-     callprotoargument char*,int*,int*,<ctype2c>*,int*,int*,<ctype2c>*,int*,<ctype2c>*,int*,int*
+     callprotoargument char*,F_INT*,F_INT*,<ctype2c>*,F_INT*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,F_INT*
 
      integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
      integer intent(in):: n
@@ -601,7 +601,7 @@ subroutine <prefix2c>hesvx(n,nrhs,a,lda,af,ldaf,ipiv,b,ldb,x,ldx,rcond,ferr,berr
    ! A = L * D * L**H if lower = 1
     threadsafe
     callstatement (*f2py_func)((factored?"F":"N"),(lower?"L":"U"),&n,&nrhs,a,&lda,af,&ldaf,ipiv,b,&ldb,x,&ldx,&rcond,ferr,berr,work,&lwork,rwork,&info)
-    callprotoargument char*,char*,int*,int*,<ctype2c>*,int*,<ctype2c>*,int*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2c>*,int*,<ctype2>*,int*
+    callprotoargument char*,char*,F_INT*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2c>*,F_INT*,<ctype2>*,F_INT*
 
     integer optional,intent(in),check(factored==0||factored==1) :: factored = 0
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
@@ -630,7 +630,7 @@ subroutine <prefix2c>hesvx_lwork(n,nrhs,a,lda,af,ldaf,ipiv,b,ldb,x,ldx,rcond,fer
     ! lwork computation for ?HESVX
     fortranname <prefix2c>hesvx
     callstatement (*f2py_func)((factored?"F":"N"),(lower?"L":"U"),&n,&nrhs,&a,&lda,&af,&ldaf,&ipiv,&b,&ldb,&x,&ldx,&rcond,&ferr,&berr,&work,&lwork,&rwork,&info)
-    callprotoargument char*,char*,int*,int*,<ctype2c>*,int*,<ctype2c>*,int*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2c>*,int*,<ctype2>*,int*
+    callprotoargument char*,char*,F_INT*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2c>*,F_INT*,<ctype2>*,F_INT*
 
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
     integer intent(in):: n
@@ -663,7 +663,7 @@ subroutine <prefix2>sytrd(lower,n,a,lda,d,e,tau,work,lwork,info)
     ! Q**T * A * Q = T.
 
     callstatement (*f2py_func)((lower?"L":"U"),&n,a,&lda,d,e,tau,work,&lwork,&info);
-    callprotoargument char*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,int*,int*
+    callprotoargument char*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,F_INT*,F_INT*
 
     integer intent(hide),depend(a) :: lda=MAX(shape(a,0),1)
     integer intent(hide),depend(a) :: n=shape(a,1)
@@ -683,7 +683,7 @@ subroutine <prefix2>sytrd_lwork(lower,n,a,lda,d,e,tau,work,lwork,info)
     ! lwork computation for sytrd
     fortranname <prefix2>sytrd
     callstatement (*f2py_func)((lower?"L":"U"),&n,&a,&lda,&d,&e,&tau,&work,&lwork,&info);
-    callprotoargument char*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,int*,int*
+    callprotoargument char*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,F_INT*,F_INT*
 
     integer intent(in) :: n
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
@@ -705,7 +705,7 @@ subroutine <prefix2c>hetrd(lower,n,a,lda,d,e,tau,work,lwork,info)
     ! Q**H * A * Q = T.
 
     callstatement (*f2py_func)((lower?"L":"U"),&n,a,&lda,d,e,tau,work,&lwork,&info);
-    callprotoargument char*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,<ctype2c>*,<ctype2c>*,int*,int*
+    callprotoargument char*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,<ctype2>*,<ctype2c>*,<ctype2c>*,F_INT*,F_INT*
 
     integer intent(hide),depend(a) :: lda=MAX(shape(a,0),1)
     integer intent(hide),depend(a) :: n=shape(a,1)
@@ -725,7 +725,7 @@ subroutine <prefix2c>hetrd_lwork(lower,n,a,lda,d,e,tau,work,lwork,info)
     ! lwork computation for hetrd
     fortranname <prefix2c>hetrd
     callstatement (*f2py_func)((lower?"L":"U"),&n,&a,&lda,&d,&e,&tau,&work,&lwork,&info);
-    callprotoargument char*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,<ctype2c>*,<ctype2c>*,int*,int*
+    callprotoargument char*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,<ctype2>*,<ctype2c>*,<ctype2c>*,F_INT*,F_INT*
 
     integer intent(in) :: n
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
@@ -751,7 +751,7 @@ subroutine <prefix2>syevr(compute_v,range,lower,n,a,lda,vl,vu,il,iu,abstol,w,z,m
     ! if jobz = 'V' and range = 'I', z is (nx(iu-il+1))
 
     callstatement (*f2py_func)((compute_v?"V":"N"),range,(lower?"L":"U"),&n,a,&lda,&vl,&vu,&il,&iu,&abstol,&m,w,z,&ldz,isuppz,work,&lwork,iwork,&liwork,&info)
-    callprotoargument char*,char*,char*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,int*,int*,int*
+    callprotoargument char*,char*,char*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*,F_INT*
 
     <ftype2> intent(in,copy,aligned8),check(shape(a,0)==shape(a,1)),dimension(n,n) :: a
     integer optional,intent(in),check(compute_v==1||compute_v==0):: compute_v = 1
@@ -784,7 +784,7 @@ subroutine <prefix2>syevr_lwork(lower,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,isupp
     ! LWORK routines for (s/d)syevr
     fortranname <prefix2>syevr
     callstatement (*f2py_func)("N","A",(lower?"L":"U"),&n,&a,&lda,&vl,&vu,&il,&iu,&abstol,&m,&w,&z,&ldz,&isuppz,&work,&lwork,&iwork,&liwork,&info)
-    callprotoargument char*,char*,char*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,int*,int*,int*
+    callprotoargument char*,char*,char*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*,F_INT*
 
     ! Inputs
     integer intent(in):: n
@@ -821,7 +821,7 @@ subroutine <prefix2c>heevr(compute_v,range,lower,n,a,lda,vl,vu,il,iu,abstol,w,z,
     ! if jobz = 'V' and range = 'I', z is (nx(iu-il+1))
 
     callstatement (*f2py_func)((compute_v?"V":"N"),range,(lower?"L":"U"),&n,a,&lda,&vl,&vu,&il,&iu,&abstol,&m,w,z,&ldz,isuppz,work,&lwork,rwork,&lrwork,iwork,&liwork,&info)
-    callprotoargument char*,char*,char*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2c>*,int*,int*,<ctype2c>*,int*,<ctype2>*,int*,int*,int*,int*
+    callprotoargument char*,char*,char*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2c>*,F_INT*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*,F_INT*
 
     <ftype2c> intent(in,copy,aligned8),check(shape(a,0)==shape(a,1)),dimension(n,n) :: a
     integer optional,intent(in),check(compute_v==1||compute_v==0):: compute_v = 1
@@ -863,7 +863,7 @@ subroutine <prefix2c>heevr_lwork(n,lower,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,isup
     ! LWORK routines for (c/z)heevr
     fortranname <prefix2c>heevr
     callstatement (*f2py_func)("N","A",(lower?"L":"U"),&n,&a,&lda,&vl,&vu,&il,&iu,&abstol,&m,&w,&z,&ldz,&isuppz,&work,&lwork,&rwork,&lrwork,&iwork,&liwork,&info)
-    callprotoargument char*,char*,char*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2c>*,int*,int*,<ctype2c>*,int*,<ctype2>*,int*,int*,int*,int*
+    callprotoargument char*,char*,char*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2c>*,F_INT*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*,F_INT*
 
     ! Inputs
     integer intent(in):: n
@@ -899,7 +899,7 @@ subroutine <prefix2>syevx(compute_v,range,lower,n,a,lda,vl,vu,il,iu,abstol,w,z,m
     ! for the desired eigenvalues.
 
     callstatement (*f2py_func)((compute_v?"V":"N"),range,(lower?"L":"U"),&n,a,&lda,&vl,&vu,&il,&iu,&abstol,&m,w,z,&ldz,work,&lwork,iwork,ifail,&info)
-    callprotoargument char*,char*,char*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,int*,int*,int*
+    callprotoargument char*,char*,char*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*,F_INT*
     
     integer optional,intent(in),check(compute_v==1||compute_v==0):: compute_v = 1
     character optional,intent(in),check(*range=='A'||*range=='V' ||*range=='I') :: range='A'
@@ -931,7 +931,7 @@ subroutine <prefix2>syevx_lwork(lower,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,work,
 
     fortranname <prefix2>syevx
     callstatement (*f2py_func)("N","A",(lower?"L":"U"),&n,&a,&lda,&vl,&vu,&il,&iu,&abstol,&m,&w,&z,&ldz,&work,&lwork,&iwork,&ifail,&info)
-    callprotoargument char*,char*,char*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,int*,int*,int*
+    callprotoargument char*,char*,char*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*,F_INT*
     
     integer intent(in):: n
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
@@ -963,7 +963,7 @@ subroutine <prefix2c>heevx(compute_v,range,lower,n,a,lda,vl,vu,il,iu,abstol,m,w,
     ! indices for the desired eigenvalues.
 
     callstatement (*f2py_func)((compute_v?"V":"N"),range,(lower?"L":"U"),&n,a,&lda,&vl,&vu,&il,&iu,&abstol,&m,w,z,&ldz,work,&lwork,&rwork,iwork,ifail,&info)
-    callprotoargument char*,char*,char*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,int*,int*,int*
+    callprotoargument char*,char*,char*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*
     
     integer optional,intent(in),check(compute_v==1||compute_v==0):: compute_v = 1
     character optional,intent(in),check(*range=='A'||*range=='V' ||*range=='I') :: range='A'
@@ -996,7 +996,7 @@ subroutine <prefix2c>heevx_lwork(lower,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,work
 
     fortranname <prefix2c>heevx
     callstatement (*f2py_func)("N","A",(lower?"L":"U"),&n,&a,&lda,&vl,&vu,&il,&iu,&abstol,&m,&w,&z,&ldz,&work,&lwork,&rwork,&iwork,&ifail,&info)
-    callprotoargument char*,char*,char*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,int*,int*,int*
+    callprotoargument char*,char*,char*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*
     
     integer intent(in):: n
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
@@ -1030,7 +1030,7 @@ subroutine <prefix2>sygv(itype,jobz,uplo,n,lda,ldb,w,a,b,work,lwork,info)
     ! if jobz = 'V' 'a' contains eigvecs
 
     callstatement (*f2py_func)(&itype,jobz,uplo,&n,a,&lda,b,&ldb,w,work,&lwork,&info)
-    callprotoargument int*,char*,char*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*
+    callprotoargument F_INT*,char*,char*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,F_INT*
     !                itype,jobz ,uplo , n  ,    a    ,lda ,    b    , ldb,   w     , work   ,lwork, info
 
     <ftype2> intent(in,copy,aligned8,out,out=v),check(shape(a,0)==shape(a,1)),dimension(n,n) :: a
@@ -1055,7 +1055,7 @@ subroutine <prefix2>sygv_lwork(itype,jobz,uplo,n,a,lda,b,ldb,w,work,lwork,info)
 
     fortranname <prefix2>sygv
     callstatement (*f2py_func)(&itype,jobz,uplo,&n,&a,&lda,&b,&ldb,&w,&work,&lwork,&info)
-    callprotoargument int*,char*,char*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*
+    callprotoargument F_INT*,char*,char*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,F_INT*
 
     ! Inputs
     integer intent(in):: n
@@ -1083,7 +1083,7 @@ subroutine <prefix2c>hegv(itype,jobz,uplo,n,lda,ldb,w,a,b,work,lwork,rwork,info)
     ! if jobz = 'V' 'a' contains eigvecs
 
     callstatement (*f2py_func)(&itype,jobz,uplo,&n,a,&lda,b,&ldb,w,work,&lwork,rwork,&info)
-    callprotoargument int*,char*,char*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2c>*,int*,<ctype2>*,int*
+    callprotoargument F_INT*,char*,char*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,<ctype2c>*,F_INT*,<ctype2>*,F_INT*
     !                itype,jobz ,uplo , n  ,    a     ,lda ,    b     , ldb,   w     , work     ,lwork,rwork   ,info
 
     <ftype2c> intent(in,copy,aligned8,out,out=v),check(shape(a,0)==shape(a,1)),dimension(n,n) :: a
@@ -1109,7 +1109,7 @@ subroutine <prefix2c>hegv_lwork(itype,jobz,uplo,n,a,lda,b,ldb,w,work,lwork,rwork
 
     fortranname <prefix2c>hegv
     callstatement (*f2py_func)(&itype,jobz,uplo,&n,&a,&lda,&b,&ldb,&w,&work,&lwork,&rwork,&info)
-    callprotoargument int*,char*,char*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2c>*,int*,<ctype2>*,int*
+    callprotoargument F_INT*,char*,char*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,<ctype2c>*,F_INT*,<ctype2>*,F_INT*
 
     ! Inputs
     integer intent(in):: n
@@ -1138,7 +1138,7 @@ subroutine <prefix2>sygvd(itype,jobz,uplo,n,lda,ldb,w,a,b,work,lwork,iwork,liwor
     ! No call to ILAENV is performed. Hence no need for (d/s)sygvd_lwork. Default sizes are optimal.
 
     callstatement (*f2py_func)(&itype,jobz,uplo,&n,a,&lda,b,&ldb,w,work,&lwork,iwork,&liwork,&info)
-    callprotoargument int*,char*,char*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,int*,int*
+    callprotoargument F_INT*,char*,char*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,F_INT*,F_INT*
 
     <ftype2> intent(in,copy,aligned8,out,out=v),check(shape(a,0)==shape(a,1)),dimension(n,n) :: a
     <ftype2> intent(in,copy,aligned8),check(shape(b,0)==shape(b,1)),check(shape(b,0)==n),dimension(n,n),depend(n) :: b
@@ -1164,7 +1164,7 @@ subroutine <prefix2c>hegvd(itype,jobz,uplo,n,lda,ldb,w,a,b,work,lwork,rwork,lrwo
     ! No call to ILAENV is performed. Hence no need for (c/z)hegvd_lwork. Default sizes are optimal.
 
     callstatement (*f2py_func)(&itype,jobz,uplo,&n,a,&lda,b,&ldb,w,work,&lwork,rwork,&lrwork,iwork,&liwork,&info)
-    callprotoargument int*,char*,char*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2c>*,int*,<ctype2>*,int*,int*,int*,int*
+    callprotoargument F_INT*,char*,char*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,<ctype2c>*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*,F_INT*
 
     <ftype2c> intent(in,copy,aligned8,out,out=v),check(shape(a,0)==shape(a,1)),dimension(n,n) :: a
     <ftype2c> intent(in,copy,aligned8),check(shape(b,0)==shape(b,1)),check(shape(b,0)==n),dimension(n,n),depend(n) :: b
@@ -1199,7 +1199,7 @@ subroutine <prefix2>sygvx(itype,jobz,range,uplo,n,a,lda,b,ldb,vl,vu,il,iu,abstol
     ! range of values or a range of indices for the desired eigenvalues.
 
     callstatement (*f2py_func)(&itype,jobz,range,uplo,&n,a,&lda,b,&ldb,&vl,&vu,&il,&iu,&abstol,&m,w,z,&ldz,work,&lwork,iwork,ifail,&info)
-    callprotoargument int*,char*,char*,char*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,int*,int*,int*
+    callprotoargument F_INT*,char*,char*,char*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*,F_INT*
     
     integer optional,intent(in),check(itype>0||itype<4) :: itype=1
     character optional,intent(in),check(*jobz=='N'||*jobz=='V') :: jobz="V"
@@ -1233,7 +1233,7 @@ subroutine <prefix2>sygvx_lwork(itype,uplo,n,a,lda,b,ldb,vl,vu,il,iu,abstol,m,w,
     ! LWORK Query routine for (s/d)sygvx
     fortranname <prefix2>sygvx
     callstatement (*f2py_func)(&itype,"N","A",uplo,&n,&a,&lda,&b,&ldb,&vl,&vu,&il,&iu,&abstol,&m,&w,&z,&ldz,&work,&lwork,&iwork,&ifail,&info)
-    callprotoargument int*,char*,char*,char*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,int*,int*,int*
+    callprotoargument F_INT*,char*,char*,char*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*,F_INT*
 
     integer intent(in):: n
     character optional,intent(in),check(*uplo=='U'||*uplo=='L') :: uplo='L'
@@ -1269,7 +1269,7 @@ subroutine <prefix2c>hegvx(itype,jobz,range,uplo,n,a,lda,b,ldb,vl,vu,il,iu,absto
     ! Eigenvalues and eigenvectors can be selected by specifying either a
     ! range of values or a range of indices for the desired eigenvalues.
     callstatement (*f2py_func)(&itype,jobz,range,uplo,&n,a,&lda,b,&ldb,&vl,&vu,&il,&iu,&abstol,&m,w,z,&ldz,work,&lwork,rwork,iwork,ifail,&info)
-    callprotoargument int*,char*,char*,char*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,int*,int*,int*
+    callprotoargument F_INT*,char*,char*,char*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*
     
     integer optional,intent(in),check(itype>0||itype<4) :: itype=1
     character optional,intent(in),check(*jobz=='N'||*jobz=='V') :: jobz='V'
@@ -1304,7 +1304,7 @@ subroutine <prefix2c>hegvx_lwork(itype,uplo,n,a,lda,b,ldb,vl,vu,il,iu,abstol,m,w
     ! LWORK Query routine for (c/z)hegvx
     fortranname <prefix2c>hegvx
     callstatement (*f2py_func)(&itype,"N","A",uplo,&n,&a,&lda,&b,&ldb,&vl,&vu,&il,&iu,&abstol,&m,&w,&z,&ldz,&work,&lwork,&rwork,&iwork,&ifail,&info)
-    callprotoargument int*,char*,char*,char*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,int*,int*,int*
+    callprotoargument F_INT*,char*,char*,char*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*
 
     integer intent(in):: n
     character optional,intent(in),check(*uplo=='U'||*uplo=='L') :: uplo='L'
@@ -1336,7 +1336,7 @@ end subroutine <prefix2c>hegvx_lwork
 subroutine <prefix>syequb(lower,n,a,lda,s,scond,amax,work,info)
 
     callstatement (*f2py_func)((lower?"L":"U"),&n,a,&lda,s,&scond,&amax,work,&info)
-    callprotoargument char*,int*,<ctype>*,int*,<ctypereal>*,<ctypereal>*,<ctypereal>*,<ctype>*,int*
+    callprotoargument char*,F_INT*,<ctype>*,F_INT*,<ctypereal>*,<ctypereal>*,<ctypereal>*,<ctype>*,F_INT*
 
     integer intent(hide),depend(a) :: n = shape(a,1)
     integer intent(hide),depend(a) :: lda = MAX(1,shape(a,0))
@@ -1355,7 +1355,7 @@ end subroutine <prefix>syequb
 subroutine <prefix2c>heequb(lower,n,a,lda,s,scond,amax,work,info)
 
     callstatement (*f2py_func)((lower?"L":"U"),&n,a,&lda,s,&scond,&amax,work,&info)
-    callprotoargument char*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2c>*,int*
+    callprotoargument char*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2c>*,F_INT*
 
     integer intent(hide),depend(a) :: n = shape(a,1)
     integer intent(hide),depend(a) :: lda = MAX(1,shape(a,0))

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -787,6 +787,13 @@ try:
 except ImportError:
     _clapack = None
 
+try:
+    from scipy.linalg import _flapack_64
+    HAS_ILP64 = True
+except ImportError:
+    HAS_ILP64 = False
+    _flapack_64 = None
+
 # Backward compatibility
 from scipy._lib._util import DeprecatedImport as _DeprecatedImport
 clapack = _DeprecatedImport("scipy.linalg.blas.clapack", "scipy.linalg.lapack")
@@ -852,7 +859,7 @@ del regex_compile, p1, p2, backtickrepl
 
 
 @_memoize_get_funcs
-def get_lapack_funcs(names, arrays=(), dtype=None):
+def get_lapack_funcs(names, arrays=(), dtype=None, ilp64=False):
     """Return available LAPACK function objects from names.
 
     Arrays are used to determine the optimal prefix of LAPACK routines.
@@ -869,6 +876,11 @@ def get_lapack_funcs(names, arrays=(), dtype=None):
 
     dtype : str or dtype, optional
         Data-type specifier. Not used if `arrays` is non-empty.
+
+    ilp64 : {True, False, 'preferred'}, optional
+        Whether to return ILP64 routine variant.
+        Choosing 'preferred' returns ILP64 routine if available, and
+        otherwise the 32-bit routine. Default: False
 
     Returns
     -------
@@ -917,12 +929,29 @@ def get_lapack_funcs(names, arrays=(), dtype=None):
     >>> udut, ipiv, x, info = xsysv(a, b, lwork=int(opt_lwork.real))
 
     """
-    return _get_funcs(names, arrays, dtype,
-                      "LAPACK", _flapack, _clapack,
-                      "flapack", "clapack", _lapack_alias)
+    if isinstance(ilp64, str):
+        if ilp64 == 'preferred':
+            ilp64 = HAS_ILP64
+        else:
+            raise ValueError("Invalid value for 'ilp64'")
+
+    if not ilp64:
+        return _get_funcs(names, arrays, dtype,
+                          "LAPACK", _flapack, _clapack,
+                          "flapack", "clapack", _lapack_alias,
+                          ilp64=False)
+    else:
+        if not HAS_ILP64:
+            raise RuntimeError("LAPACK ILP64 routine requested, but Scipy "
+                               "compiled only with 32-bit BLAS")
+        return _get_funcs(names, arrays, dtype,
+                          "LAPACK", _flapack_64, None,
+                          "flapack_64", None, _lapack_alias,
+                          ilp64=True)
 
 
 _int32_max = _np.iinfo(_np.int32).max
+_int64_max = _np.iinfo(_np.int64).max
 
 
 def _compute_lwork(routine, *args, **kwargs):
@@ -947,18 +976,19 @@ def _compute_lwork(routine, *args, **kwargs):
 
     """
     dtype = getattr(routine, 'dtype', None)
+    int_dtype = getattr(routine, 'int_dtype', None)
     ret = routine(*args, **kwargs)
     if ret[-1] != 0:
         raise ValueError("Internal work array size computation failed: "
                          "%d" % (ret[-1],))
 
     if len(ret) == 2:
-        return _check_work_float(ret[0].real, dtype)
+        return _check_work_float(ret[0].real, dtype, int_dtype)
     else:
-        return tuple(_check_work_float(x.real, dtype) for x in ret[:-1])
+        return tuple(_check_work_float(x.real, dtype, int_dtype) for x in ret[:-1])
 
 
-def _check_work_float(value, dtype):
+def _check_work_float(value, dtype, int_dtype):
     """
     Convert LAPACK-returned work array size float to integer,
     carefully for single-precision types.
@@ -970,7 +1000,12 @@ def _check_work_float(value, dtype):
         value = _np.nextafter(value, _np.inf, dtype=_np.float32)
 
     value = int(value)
-    if value < 0 or value > _int32_max:
-        raise ValueError("Too large work array required -- computation cannot "
-                         "be performed with standard 32-bit LAPACK.")
+    if int_dtype.itemsize == 4:
+        if value < 0 or value > _int32_max:
+            raise ValueError("Too large work array required -- computation cannot "
+                             "be performed with standard 32-bit LAPACK.")
+    elif int_dtype.itemsize == 8:
+        if value < 0 or value > _int64_max:
+            raise ValueError("Too large work array required -- computation cannot "
+                             "be performed with standard 64-bit LAPACK.")
     return value

--- a/scipy/linalg/misc.py
+++ b/scipy/linalg/misc.py
@@ -146,7 +146,7 @@ def norm(a, ord=None, axis=None, keepdims=False, check_finite=True):
 
         if ord in (None, 2) and (a.ndim == 1):
             # use blas for fast and stable euclidean norm
-            nrm2 = get_blas_funcs('nrm2', dtype=a.dtype)
+            nrm2 = get_blas_funcs('nrm2', dtype=a.dtype, ilp64='preferred')
             return nrm2(a)
 
         if a.ndim == 2 and axis is None and not keepdims:
@@ -166,7 +166,7 @@ def norm(a, ord=None, axis=None, keepdims=False, check_finite=True):
                 elif np.isfortran(a.T):
                     lange_args = '1', a.T
             if lange_args:
-                lange = get_lapack_funcs('lange', dtype=a.dtype)
+                lange = get_lapack_funcs('lange', dtype=a.dtype, ilp64='preferred')
                 return lange(*lange_args)
 
     # Filter out the axis and keepdims arguments if they aren't used so they

--- a/scipy/linalg/setup.py
+++ b/scipy/linalg/setup.py
@@ -5,7 +5,9 @@ def configuration(parent_package='', top_path=None):
     from distutils.sysconfig import get_python_inc
     from scipy._build_utils.system_info import get_info, numpy_info
     from numpy.distutils.misc_util import Configuration, get_numpy_include_dirs
-    from scipy._build_utils import get_g77_abi_wrappers, gfortran_legacy_flag_hook
+    from scipy._build_utils import (get_g77_abi_wrappers, gfortran_legacy_flag_hook,
+                                    blas_ilp64_pre_build_hook, get_f2py_int64_options,
+                                    uses_blas64)
 
     config = Configuration('linalg', parent_package, top_path)
 
@@ -16,15 +18,28 @@ def configuration(parent_package='', top_path=None):
     if atlas_version:
         print(('ATLAS version: %s' % atlas_version))
 
+    if uses_blas64():
+        lapack_ilp64_opt = get_info('lapack_ilp64_opt', 2)
+
     # fblas:
     sources = ['fblas.pyf.src']
     sources += get_g77_abi_wrappers(lapack_opt)
+    depends = ['fblas_l?.pyf.src']
 
     config.add_extension('_fblas',
                          sources=sources,
-                         depends=['fblas_l?.pyf.src'],
+                         depends=depends,
                          extra_info=lapack_opt
                          )
+
+    if uses_blas64():
+        sources = ['fblas_64.pyf.src'] + sources[1:]
+        ext = config.add_extension('_fblas_64',
+                                   sources=sources,
+                                   depends=depends,
+                                   f2py_options=get_f2py_int64_options(),
+                                   extra_info=lapack_ilp64_opt)
+        ext._pre_build_hook = blas_ilp64_pre_build_hook(lapack_ilp64_opt)
 
     # flapack:
     sources = ['flapack.pyf.src']
@@ -32,19 +47,29 @@ def configuration(parent_package='', top_path=None):
     dep_pfx = join('src', 'lapack_deprecations')
     deprecated_lapack_routines = [join(dep_pfx, c + 'gegv.f') for c in 'cdsz']
     sources += deprecated_lapack_routines
+    depends = ['flapack_gen.pyf.src',
+               'flapack_gen_banded.pyf.src',
+               'flapack_gen_tri.pyf.src',
+               'flapack_pos_def.pyf.src',
+               'flapack_pos_def_tri.pyf.src',
+               'flapack_sym_herm.pyf.src',
+               'flapack_other.pyf.src',
+               'flapack_user.pyf.src']
 
     config.add_extension('_flapack',
                          sources=sources,
-                         depends=['flapack_gen.pyf.src',
-                                  'flapack_gen_banded.pyf.src',
-                                  'flapack_gen_tri.pyf.src',
-                                  'flapack_pos_def.pyf.src',
-                                  'flapack_pos_def_tri.pyf.src',
-                                  'flapack_sym_herm.pyf.src',
-                                  'flapack_other.pyf.src',
-                                  'flapack_user.pyf.src'],
+                         depends=depends,
                          extra_info=lapack_opt
                          )
+
+    if uses_blas64():
+        sources = ['flapack_64.pyf.src'] + sources[1:]
+        ext = config.add_extension('_flapack_64',
+                                   sources=sources,
+                                   depends=depends,
+                                   f2py_options=get_f2py_int64_options(),
+                                   extra_info=lapack_ilp64_opt)
+        ext._pre_build_hook = blas_ilp64_pre_build_hook(lapack_ilp64_opt)
 
     if atlas_version is not None:
         # cblas:

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -18,6 +18,8 @@ from scipy.linalg import (solve, inv, det, lstsq, pinv, pinv2, pinvh, norm,
                           matrix_balance, LinAlgWarning)
 
 from scipy.linalg._testutils import assert_no_overwrite
+from scipy._lib._testutils import check_free_memory
+from scipy.linalg.blas import HAS_ILP64
 
 REAL_DTYPES = [np.float32, np.float64, np.longdouble]
 COMPLEX_DTYPES = [np.complex64, np.complex128, np.clongdouble]
@@ -1365,6 +1367,15 @@ class TestVectorNorms(object):
         assert_allclose(b, [[[3.60555128, 4.12310563]]] * 2)
         assert_(b.shape == (2, 1, 2))
         assert_allclose(norm(a, 1, axis=2, keepdims=True), [[[3.], [7.]]] * 2)
+
+    @pytest.mark.skipif(not HAS_ILP64, reason="64-bit BLAS required")
+    def test_large_vector(self):
+        check_free_memory(free_mb=17000)
+        x = np.zeros([2**31], dtype=np.float64)
+        x[-1] = 1
+        res = norm(x)
+        del x
+        assert_allclose(res, 1.0)
 
 
 class TestMatrixNorms(object):

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -55,7 +55,7 @@ def test_lapack_documented():
     names = set(lapack.__doc__.split())
     ignore_list = set([
         'absolute_import', 'clapack', 'division', 'find_best_lapack_type',
-        'flapack', 'print_function',
+        'flapack', 'print_function', 'HAS_ILP64',
     ])
     missing = list()
     for name in dir(lapack):


### PR DESCRIPTION
#### Reference issue
Part of gh-11193
Fixes gh-5489

#### What does this implement/fix?
Add support for ILP64 blas/lapack in the f2py wrappers.

This adds two new modules `scipy.linalg._fblas_64` and `scipy.linalg._flapack_64` that are present only when building with ILP64 blas. The `get_blas/lapack_funcs` helpers acquire an `ilp64=` kwarg that indicates which version of the routines is wanted. For backward compatibility, we retain the 32-bit wrappers, and they remain the default.

This PR makes `scipy.linalg.norm` and `scipy.linalg.svd*` to use ilp64 when available. Other `scipy.linalg` routines should be changed in separate PRs. Here and in many cases, the change is not visible to the user, except in that the routine starts to work also for vectors/matrixes too large for 32-bit.

The changes in the *.pyf.src files are only replacing `int` with `F_INT`, in callprotoargument/callstatement blocks that contain manually written C code. Moreover, the matching define is added to the the top-level files, and new top-level files are added for the 64-bit versions.

The approach here differs from that in gh-11193, in that there's no need to autogenerate/patch the *.pyf* files, which makes things simpler.