### PR TITLE
CI: split travis arm64 run into two

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -206,8 +206,11 @@ before_install:
     fi
   - |
     if [ -z "${USE_DEBUG}" -a "${TRAVIS_CPU_ARCH}" == "amd64" -a "${TRAVIS_PYTHON_VERSION}" != "3.8" ]; then
-        travis_retry pip install numba==0.49.1
-        travis_retry pip install --only-binary=:all: sparse
+        if ! expr "$NUMPYSPEC" : ".*--pre.*" > /dev/null; then
+            # Install these only when not using Numpy prerelease
+            travis_retry pip install numba==0.49.1
+            travis_retry pip install --only-binary=:all: sparse
+        fi
     fi
   - |
     if [ -n "${TEST_GROUP_COUNT}" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,20 @@ matrix:
         - USE_WHEEL=1
         - PIP_NO_CACHE_DIR=off
         - NUMPYSPEC="numpy"
+        - TEST_GROUP_COUNT=2
+        - TEST_GROUP=1
+    - python: 3.7
+      if: type = pull_request
+      arch: arm64
+      dist: bionic
+      env:
+        - TESTMODE=fast
+        - COVERAGE=
+        - USE_WHEEL=1
+        - PIP_NO_CACHE_DIR=off
+        - NUMPYSPEC="numpy"
+        - TEST_GROUP_COUNT=2
+        - TEST_GROUP=2
     - python: 3.7
       if: type = pull_request
       env:
@@ -155,6 +169,18 @@ before_install:
   - uname -a
   - df -h
   - ulimit -a
+  - set -o pipefail
+  - if [[ "${TRAVIS_CPU_ARCH}" == "arm64" ]]; then
+      wget -q "https://github.com/conda-forge/miniforge/releases/download/4.8.2-1/Miniforge3-4.8.2-1-Linux-aarch64.sh"  -O miniconda.sh;
+      chmod +x miniconda.sh;
+      ./miniconda.sh -b -p $HOME/miniconda3;
+      export PATH=$HOME/miniconda3/bin:$PATH;
+      conda config --set always_yes yes --set auto_update_conda false;
+      conda install pip conda;
+      conda update -n base conda;
+      conda info -a;
+      conda install pytest pytest-xdist $NUMPYSPEC mpmath gmpy2 Cython pybind11;
+    fi
   - mkdir builds
   - cd builds
   - |
@@ -184,6 +210,11 @@ before_install:
         travis_retry pip install --only-binary=:all: sparse
     fi
   - |
+    if [ -n "${TEST_GROUP_COUNT}" ]; then
+        travis_retry pip install pytest-test-groups
+        export TEST_GROUP_ARGS="--test-group-count=${TEST_GROUP_COUNT} --test-group=${TEST_GROUP} --test-group-random-seed=1234"
+    fi
+  - |
     if [ "${TESTMODE}" == "full" ]; then
         travis_retry pip install pytest-cov coverage matplotlib scikit-umfpack scikit-sparse
     fi
@@ -201,18 +232,6 @@ before_install:
     fi
   - ccache -s
   - cd ..
-  - set -o pipefail
-  - if [[ "${TRAVIS_CPU_ARCH}" == "arm64" ]]; then
-      wget -q "https://github.com/conda-forge/miniforge/releases/download/4.8.2-1/Miniforge3-4.8.2-1-Linux-aarch64.sh"  -O miniconda.sh;
-      chmod +x miniconda.sh;
-      ./miniconda.sh -b -p $HOME/miniconda3;
-      export PATH=$HOME/miniconda3/bin:$PATH;
-      conda config --set always_yes yes --set auto_update_conda false;
-      conda install pip conda;
-      conda update -n base conda;
-      conda info -a;
-      conda install pytest pytest-xdist $NUMPYSPEC mpmath gmpy2 Cython pybind11;
-    fi
 
 
 script:
@@ -246,7 +265,7 @@ script:
         USE_WHEEL_BUILD="--no-build"
     fi
   - export SCIPY_AVAILABLE_MEM=3G
-  - python -u runtests.py -g -m $TESTMODE $COVERAGE $USE_WHEEL_BUILD -- -rfEX --durations=10 -n 3 2>&1 | tee runtests.log
+  - python -u runtests.py -g -m $TESTMODE $COVERAGE $USE_WHEEL_BUILD -- -rfEX --durations=10 -n 3 $TEST_GROUP_ARGS 2>&1 | tee runtests.log
 
   - tools/validate_runtests_log.py $TESTMODE < runtests.log
   - if [ "${REFGUIDE_CHECK}" == "1" ]; then python runtests.py -g --refguide-check; fi


### PR DESCRIPTION
The arm64 run is too slow for the test suite to complete, so split it into two batches.